### PR TITLE
Remove overlapping resource folders

### DIFF
--- a/jet/hadoop/pom.xml
+++ b/jet/hadoop/pom.xml
@@ -29,14 +29,6 @@
     </parent>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <directory>../wordcount/src/main/resources</directory>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.avro</groupId>

--- a/jet/hadoop/src/main/resources/books/a-tale-of-two-cities.txt
+++ b/jet/hadoop/src/main/resources/books/a-tale-of-two-cities.txt
@@ -1,0 +1,16272 @@
+﻿The Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: A Tale of Two Cities
+       A Story of the French Revolution
+
+Author: Charles Dickens
+
+Release Date: January, 1994 [EBook #98]
+Posting Date: November 28, 2009
+Last Updated: September 25, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+
+
+
+Produced by Judith Boss
+
+
+
+
+
+
+
+
+A TALE OF TWO CITIES
+
+A STORY OF THE FRENCH REVOLUTION
+
+By Charles Dickens
+
+
+CONTENTS
+
+
+     Book the First--Recalled to Life
+
+     Chapter I      The Period
+     Chapter II     The Mail
+     Chapter III    The Night Shadows
+     Chapter IV     The Preparation
+     Chapter V      The Wine-shop
+     Chapter VI     The Shoemaker
+
+
+     Book the Second--the Golden Thread
+
+     Chapter I      Five Years Later
+     Chapter II     A Sight
+     Chapter III    A Disappointment
+     Chapter IV     Congratulatory
+     Chapter V      The Jackal
+     Chapter VI     Hundreds of People
+     Chapter VII    Monseigneur in Town
+     Chapter VIII   Monseigneur in the Country
+     Chapter IX     The Gorgon’s Head
+     Chapter X      Two Promises
+     Chapter XI     A Companion Picture
+     Chapter XII    The Fellow of Delicacy
+     Chapter XIII   The Fellow of no Delicacy
+     Chapter XIV    The Honest Tradesman
+     Chapter XV     Knitting
+     Chapter XVI    Still Knitting
+     Chapter XVII   One Night
+     Chapter XVIII  Nine Days
+     Chapter XIX    An Opinion
+     Chapter XX     A Plea
+     Chapter XXI    Echoing Footsteps
+     Chapter XXII   The Sea Still Rises
+     Chapter XXIII  Fire Rises
+     Chapter XXIV   Drawn to the Loadstone Rock
+
+
+     Book the Third--the Track of a Storm
+
+     Chapter I      In Secret
+     Chapter II     The Grindstone
+     Chapter III    The Shadow
+     Chapter IV     Calm in Storm
+     Chapter V      The Wood-sawyer
+     Chapter VI     Triumph
+     Chapter VII    A Knock at the Door
+     Chapter VIII   A Hand at Cards
+     Chapter IX     The Game Made
+     Chapter X      The Substance of the Shadow
+     Chapter XI     Dusk
+     Chapter XII    Darkness
+     Chapter XIII   Fifty-two
+     Chapter XIV    The Knitting Done
+     Chapter XV     The Footsteps Die Out For Ever
+
+
+
+
+
+Book the First--Recalled to Life
+
+
+
+
+I. The Period
+
+
+It was the best of times,
+it was the worst of times,
+it was the age of wisdom,
+it was the age of foolishness,
+it was the epoch of belief,
+it was the epoch of incredulity,
+it was the season of Light,
+it was the season of Darkness,
+it was the spring of hope,
+it was the winter of despair,
+we had everything before us,
+we had nothing before us,
+we were all going direct to Heaven,
+we were all going direct the other way--
+in short, the period was so far like the present period, that some of
+its noisiest authorities insisted on its being received, for good or for
+evil, in the superlative degree of comparison only.
+
+There were a king with a large jaw and a queen with a plain face, on the
+throne of England; there were a king with a large jaw and a queen with
+a fair face, on the throne of France. In both countries it was clearer
+than crystal to the lords of the State preserves of loaves and fishes,
+that things in general were settled for ever.
+
+It was the year of Our Lord one thousand seven hundred and seventy-five.
+Spiritual revelations were conceded to England at that favoured period,
+as at this. Mrs. Southcott had recently attained her five-and-twentieth
+blessed birthday, of whom a prophetic private in the Life Guards had
+heralded the sublime appearance by announcing that arrangements were
+made for the swallowing up of London and Westminster. Even the Cock-lane
+ghost had been laid only a round dozen of years, after rapping out its
+messages, as the spirits of this very year last past (supernaturally
+deficient in originality) rapped out theirs. Mere messages in the
+earthly order of events had lately come to the English Crown and People,
+from a congress of British subjects in America: which, strange
+to relate, have proved more important to the human race than any
+communications yet received through any of the chickens of the Cock-lane
+brood.
+
+France, less favoured on the whole as to matters spiritual than her
+sister of the shield and trident, rolled with exceeding smoothness down
+hill, making paper money and spending it. Under the guidance of her
+Christian pastors, she entertained herself, besides, with such humane
+achievements as sentencing a youth to have his hands cut off, his tongue
+torn out with pincers, and his body burned alive, because he had not
+kneeled down in the rain to do honour to a dirty procession of monks
+which passed within his view, at a distance of some fifty or sixty
+yards. It is likely enough that, rooted in the woods of France and
+Norway, there were growing trees, when that sufferer was put to death,
+already marked by the Woodman, Fate, to come down and be sawn into
+boards, to make a certain movable framework with a sack and a knife in
+it, terrible in history. It is likely enough that in the rough outhouses
+of some tillers of the heavy lands adjacent to Paris, there were
+sheltered from the weather that very day, rude carts, bespattered with
+rustic mire, snuffed about by pigs, and roosted in by poultry, which
+the Farmer, Death, had already set apart to be his tumbrils of
+the Revolution. But that Woodman and that Farmer, though they work
+unceasingly, work silently, and no one heard them as they went about
+with muffled tread: the rather, forasmuch as to entertain any suspicion
+that they were awake, was to be atheistical and traitorous.
+
+In England, there was scarcely an amount of order and protection to
+justify much national boasting. Daring burglaries by armed men, and
+highway robberies, took place in the capital itself every night;
+families were publicly cautioned not to go out of town without removing
+their furniture to upholsterers’ warehouses for security; the highwayman
+in the dark was a City tradesman in the light, and, being recognised and
+challenged by his fellow-tradesman whom he stopped in his character of
+“the Captain,” gallantly shot him through the head and rode away; the
+mail was waylaid by seven robbers, and the guard shot three dead, and
+then got shot dead himself by the other four, “in consequence of the
+failure of his ammunition:” after which the mail was robbed in peace;
+that magnificent potentate, the Lord Mayor of London, was made to stand
+and deliver on Turnham Green, by one highwayman, who despoiled the
+illustrious creature in sight of all his retinue; prisoners in London
+gaols fought battles with their turnkeys, and the majesty of the law
+fired blunderbusses in among them, loaded with rounds of shot and ball;
+thieves snipped off diamond crosses from the necks of noble lords at
+Court drawing-rooms; musketeers went into St. Giles’s, to search
+for contraband goods, and the mob fired on the musketeers, and the
+musketeers fired on the mob, and nobody thought any of these occurrences
+much out of the common way. In the midst of them, the hangman, ever busy
+and ever worse than useless, was in constant requisition; now, stringing
+up long rows of miscellaneous criminals; now, hanging a housebreaker on
+Saturday who had been taken on Tuesday; now, burning people in the
+hand at Newgate by the dozen, and now burning pamphlets at the door of
+Westminster Hall; to-day, taking the life of an atrocious murderer,
+and to-morrow of a wretched pilferer who had robbed a farmer’s boy of
+sixpence.
+
+All these things, and a thousand like them, came to pass in and close
+upon the dear old year one thousand seven hundred and seventy-five.
+Environed by them, while the Woodman and the Farmer worked unheeded,
+those two of the large jaws, and those other two of the plain and the
+fair faces, trod with stir enough, and carried their divine rights
+with a high hand. Thus did the year one thousand seven hundred
+and seventy-five conduct their Greatnesses, and myriads of small
+creatures--the creatures of this chronicle among the rest--along the
+roads that lay before them.
+
+
+
+
+II. The Mail
+
+
+It was the Dover road that lay, on a Friday night late in November,
+before the first of the persons with whom this history has business.
+The Dover road lay, as to him, beyond the Dover mail, as it lumbered up
+Shooter’s Hill. He walked up hill in the mire by the side of the mail,
+as the rest of the passengers did; not because they had the least relish
+for walking exercise, under the circumstances, but because the hill,
+and the harness, and the mud, and the mail, were all so heavy, that the
+horses had three times already come to a stop, besides once drawing the
+coach across the road, with the mutinous intent of taking it back
+to Blackheath. Reins and whip and coachman and guard, however, in
+combination, had read that article of war which forbade a purpose
+otherwise strongly in favour of the argument, that some brute animals
+are endued with Reason; and the team had capitulated and returned to
+their duty.
+
+With drooping heads and tremulous tails, they mashed their way through
+the thick mud, floundering and stumbling between whiles, as if they were
+falling to pieces at the larger joints. As often as the driver rested
+them and brought them to a stand, with a wary “Wo-ho! so-ho-then!” the
+near leader violently shook his head and everything upon it--like an
+unusually emphatic horse, denying that the coach could be got up the
+hill. Whenever the leader made this rattle, the passenger started, as a
+nervous passenger might, and was disturbed in mind.
+
+There was a steaming mist in all the hollows, and it had roamed in its
+forlornness up the hill, like an evil spirit, seeking rest and finding
+none. A clammy and intensely cold mist, it made its slow way through the
+air in ripples that visibly followed and overspread one another, as the
+waves of an unwholesome sea might do. It was dense enough to shut out
+everything from the light of the coach-lamps but these its own workings,
+and a few yards of road; and the reek of the labouring horses steamed
+into it, as if they had made it all.
+
+Two other passengers, besides the one, were plodding up the hill by the
+side of the mail. All three were wrapped to the cheekbones and over the
+ears, and wore jack-boots. Not one of the three could have said, from
+anything he saw, what either of the other two was like; and each was
+hidden under almost as many wrappers from the eyes of the mind, as from
+the eyes of the body, of his two companions. In those days, travellers
+were very shy of being confidential on a short notice, for anybody on
+the road might be a robber or in league with robbers. As to the latter,
+when every posting-house and ale-house could produce somebody in
+“the Captain’s” pay, ranging from the landlord to the lowest stable
+non-descript, it was the likeliest thing upon the cards. So the guard
+of the Dover mail thought to himself, that Friday night in November, one
+thousand seven hundred and seventy-five, lumbering up Shooter’s Hill, as
+he stood on his own particular perch behind the mail, beating his feet,
+and keeping an eye and a hand on the arm-chest before him, where a
+loaded blunderbuss lay at the top of six or eight loaded horse-pistols,
+deposited on a substratum of cutlass.
+
+The Dover mail was in its usual genial position that the guard suspected
+the passengers, the passengers suspected one another and the guard, they
+all suspected everybody else, and the coachman was sure of nothing but
+the horses; as to which cattle he could with a clear conscience have
+taken his oath on the two Testaments that they were not fit for the
+journey.
+
+“Wo-ho!” said the coachman. “So, then! One more pull and you’re at the
+top and be damned to you, for I have had trouble enough to get you to
+it!--Joe!”
+
+“Halloa!” the guard replied.
+
+“What o’clock do you make it, Joe?”
+
+“Ten minutes, good, past eleven.”
+
+“My blood!” ejaculated the vexed coachman, “and not atop of Shooter’s
+yet! Tst! Yah! Get on with you!”
+
+The emphatic horse, cut short by the whip in a most decided negative,
+made a decided scramble for it, and the three other horses followed
+suit. Once more, the Dover mail struggled on, with the jack-boots of its
+passengers squashing along by its side. They had stopped when the coach
+stopped, and they kept close company with it. If any one of the three
+had had the hardihood to propose to another to walk on a little ahead
+into the mist and darkness, he would have put himself in a fair way of
+getting shot instantly as a highwayman.
+
+The last burst carried the mail to the summit of the hill. The horses
+stopped to breathe again, and the guard got down to skid the wheel for
+the descent, and open the coach-door to let the passengers in.
+
+“Tst! Joe!” cried the coachman in a warning voice, looking down from his
+box.
+
+“What do you say, Tom?”
+
+They both listened.
+
+“I say a horse at a canter coming up, Joe.”
+
+“_I_ say a horse at a gallop, Tom,” returned the guard, leaving his hold
+of the door, and mounting nimbly to his place. “Gentlemen! In the king’s
+name, all of you!”
+
+With this hurried adjuration, he cocked his blunderbuss, and stood on
+the offensive.
+
+The passenger booked by this history, was on the coach-step, getting in;
+the two other passengers were close behind him, and about to follow. He
+remained on the step, half in the coach and half out of; they remained
+in the road below him. They all looked from the coachman to the guard,
+and from the guard to the coachman, and listened. The coachman looked
+back and the guard looked back, and even the emphatic leader pricked up
+his ears and looked back, without contradicting.
+
+The stillness consequent on the cessation of the rumbling and labouring
+of the coach, added to the stillness of the night, made it very quiet
+indeed. The panting of the horses communicated a tremulous motion to
+the coach, as if it were in a state of agitation. The hearts of the
+passengers beat loud enough perhaps to be heard; but at any rate, the
+quiet pause was audibly expressive of people out of breath, and holding
+the breath, and having the pulses quickened by expectation.
+
+The sound of a horse at a gallop came fast and furiously up the hill.
+
+“So-ho!” the guard sang out, as loud as he could roar. “Yo there! Stand!
+I shall fire!”
+
+The pace was suddenly checked, and, with much splashing and floundering,
+a man’s voice called from the mist, “Is that the Dover mail?”
+
+“Never you mind what it is!” the guard retorted. “What are you?”
+
+“_Is_ that the Dover mail?”
+
+“Why do you want to know?”
+
+“I want a passenger, if it is.”
+
+“What passenger?”
+
+“Mr. Jarvis Lorry.”
+
+Our booked passenger showed in a moment that it was his name. The guard,
+the coachman, and the two other passengers eyed him distrustfully.
+
+“Keep where you are,” the guard called to the voice in the mist,
+“because, if I should make a mistake, it could never be set right in
+your lifetime. Gentleman of the name of Lorry answer straight.”
+
+“What is the matter?” asked the passenger, then, with mildly quavering
+speech. “Who wants me? Is it Jerry?”
+
+(“I don’t like Jerry’s voice, if it is Jerry,” growled the guard to
+himself. “He’s hoarser than suits me, is Jerry.”)
+
+“Yes, Mr. Lorry.”
+
+“What is the matter?”
+
+“A despatch sent after you from over yonder. T. and Co.”
+
+“I know this messenger, guard,” said Mr. Lorry, getting down into the
+road--assisted from behind more swiftly than politely by the other two
+passengers, who immediately scrambled into the coach, shut the door, and
+pulled up the window. “He may come close; there’s nothing wrong.”
+
+“I hope there ain’t, but I can’t make so ‘Nation sure of that,” said the
+guard, in gruff soliloquy. “Hallo you!”
+
+“Well! And hallo you!” said Jerry, more hoarsely than before.
+
+“Come on at a footpace! d’ye mind me? And if you’ve got holsters to that
+saddle o’ yourn, don’t let me see your hand go nigh ‘em. For I’m a devil
+at a quick mistake, and when I make one it takes the form of Lead. So
+now let’s look at you.”
+
+The figures of a horse and rider came slowly through the eddying mist,
+and came to the side of the mail, where the passenger stood. The rider
+stooped, and, casting up his eyes at the guard, handed the passenger
+a small folded paper. The rider’s horse was blown, and both horse and
+rider were covered with mud, from the hoofs of the horse to the hat of
+the man.
+
+“Guard!” said the passenger, in a tone of quiet business confidence.
+
+The watchful guard, with his right hand at the stock of his raised
+blunderbuss, his left at the barrel, and his eye on the horseman,
+answered curtly, “Sir.”
+
+“There is nothing to apprehend. I belong to Tellson’s Bank. You must
+know Tellson’s Bank in London. I am going to Paris on business. A crown
+to drink. I may read this?”
+
+“If so be as you’re quick, sir.”
+
+He opened it in the light of the coach-lamp on that side, and
+read--first to himself and then aloud: “‘Wait at Dover for Mam’selle.’
+It’s not long, you see, guard. Jerry, say that my answer was, RECALLED
+TO LIFE.”
+
+Jerry started in his saddle. “That’s a Blazing strange answer, too,”
+ said he, at his hoarsest.
+
+“Take that message back, and they will know that I received this, as
+well as if I wrote. Make the best of your way. Good night.”
+
+With those words the passenger opened the coach-door and got in; not at
+all assisted by his fellow-passengers, who had expeditiously secreted
+their watches and purses in their boots, and were now making a general
+pretence of being asleep. With no more definite purpose than to escape
+the hazard of originating any other kind of action.
+
+The coach lumbered on again, with heavier wreaths of mist closing round
+it as it began the descent. The guard soon replaced his blunderbuss
+in his arm-chest, and, having looked to the rest of its contents, and
+having looked to the supplementary pistols that he wore in his belt,
+looked to a smaller chest beneath his seat, in which there were a
+few smith’s tools, a couple of torches, and a tinder-box. For he was
+furnished with that completeness that if the coach-lamps had been blown
+and stormed out, which did occasionally happen, he had only to shut
+himself up inside, keep the flint and steel sparks well off the straw,
+and get a light with tolerable safety and ease (if he were lucky) in
+five minutes.
+
+“Tom!” softly over the coach roof.
+
+“Hallo, Joe.”
+
+“Did you hear the message?”
+
+“I did, Joe.”
+
+“What did you make of it, Tom?”
+
+“Nothing at all, Joe.”
+
+“That’s a coincidence, too,” the guard mused, “for I made the same of it
+myself.”
+
+Jerry, left alone in the mist and darkness, dismounted meanwhile, not
+only to ease his spent horse, but to wipe the mud from his face, and
+shake the wet out of his hat-brim, which might be capable of
+holding about half a gallon. After standing with the bridle over his
+heavily-splashed arm, until the wheels of the mail were no longer within
+hearing and the night was quite still again, he turned to walk down the
+hill.
+
+“After that there gallop from Temple Bar, old lady, I won’t trust your
+fore-legs till I get you on the level,” said this hoarse messenger,
+glancing at his mare. “‘Recalled to life.’ That’s a Blazing strange
+message. Much of that wouldn’t do for you, Jerry! I say, Jerry! You’d
+be in a Blazing bad way, if recalling to life was to come into fashion,
+Jerry!”
+
+
+
+
+III. The Night Shadows
+
+
+A wonderful fact to reflect upon, that every human creature is
+constituted to be that profound secret and mystery to every other. A
+solemn consideration, when I enter a great city by night, that every
+one of those darkly clustered houses encloses its own secret; that every
+room in every one of them encloses its own secret; that every beating
+heart in the hundreds of thousands of breasts there, is, in some of
+its imaginings, a secret to the heart nearest it! Something of the
+awfulness, even of Death itself, is referable to this. No more can I
+turn the leaves of this dear book that I loved, and vainly hope in time
+to read it all. No more can I look into the depths of this unfathomable
+water, wherein, as momentary lights glanced into it, I have had glimpses
+of buried treasure and other things submerged. It was appointed that the
+book should shut with a spring, for ever and for ever, when I had read
+but a page. It was appointed that the water should be locked in an
+eternal frost, when the light was playing on its surface, and I stood
+in ignorance on the shore. My friend is dead, my neighbour is dead,
+my love, the darling of my soul, is dead; it is the inexorable
+consolidation and perpetuation of the secret that was always in that
+individuality, and which I shall carry in mine to my life’s end. In
+any of the burial-places of this city through which I pass, is there
+a sleeper more inscrutable than its busy inhabitants are, in their
+innermost personality, to me, or than I am to them?
+
+As to this, his natural and not to be alienated inheritance, the
+messenger on horseback had exactly the same possessions as the King, the
+first Minister of State, or the richest merchant in London. So with the
+three passengers shut up in the narrow compass of one lumbering old mail
+coach; they were mysteries to one another, as complete as if each had
+been in his own coach and six, or his own coach and sixty, with the
+breadth of a county between him and the next.
+
+The messenger rode back at an easy trot, stopping pretty often at
+ale-houses by the way to drink, but evincing a tendency to keep his
+own counsel, and to keep his hat cocked over his eyes. He had eyes that
+assorted very well with that decoration, being of a surface black, with
+no depth in the colour or form, and much too near together--as if they
+were afraid of being found out in something, singly, if they kept too
+far apart. They had a sinister expression, under an old cocked-hat like
+a three-cornered spittoon, and over a great muffler for the chin and
+throat, which descended nearly to the wearer’s knees. When he stopped
+for drink, he moved this muffler with his left hand, only while he
+poured his liquor in with his right; as soon as that was done, he
+muffled again.
+
+“No, Jerry, no!” said the messenger, harping on one theme as he rode.
+“It wouldn’t do for you, Jerry. Jerry, you honest tradesman, it wouldn’t
+suit _your_ line of business! Recalled--! Bust me if I don’t think he’d
+been a drinking!”
+
+His message perplexed his mind to that degree that he was fain, several
+times, to take off his hat to scratch his head. Except on the crown,
+which was raggedly bald, he had stiff, black hair, standing jaggedly all
+over it, and growing down hill almost to his broad, blunt nose. It was
+so like Smith’s work, so much more like the top of a strongly spiked
+wall than a head of hair, that the best of players at leap-frog might
+have declined him, as the most dangerous man in the world to go over.
+
+While he trotted back with the message he was to deliver to the night
+watchman in his box at the door of Tellson’s Bank, by Temple Bar, who
+was to deliver it to greater authorities within, the shadows of the
+night took such shapes to him as arose out of the message, and took such
+shapes to the mare as arose out of _her_ private topics of uneasiness.
+They seemed to be numerous, for she shied at every shadow on the road.
+
+What time, the mail-coach lumbered, jolted, rattled, and bumped upon
+its tedious way, with its three fellow-inscrutables inside. To whom,
+likewise, the shadows of the night revealed themselves, in the forms
+their dozing eyes and wandering thoughts suggested.
+
+Tellson’s Bank had a run upon it in the mail. As the bank
+passenger--with an arm drawn through the leathern strap, which did what
+lay in it to keep him from pounding against the next passenger,
+and driving him into his corner, whenever the coach got a special
+jolt--nodded in his place, with half-shut eyes, the little
+coach-windows, and the coach-lamp dimly gleaming through them, and the
+bulky bundle of opposite passenger, became the bank, and did a great
+stroke of business. The rattle of the harness was the chink of money,
+and more drafts were honoured in five minutes than even Tellson’s, with
+all its foreign and home connection, ever paid in thrice the time. Then
+the strong-rooms underground, at Tellson’s, with such of their valuable
+stores and secrets as were known to the passenger (and it was not a
+little that he knew about them), opened before him, and he went in among
+them with the great keys and the feebly-burning candle, and found them
+safe, and strong, and sound, and still, just as he had last seen them.
+
+But, though the bank was almost always with him, and though the coach
+(in a confused way, like the presence of pain under an opiate) was
+always with him, there was another current of impression that never
+ceased to run, all through the night. He was on his way to dig some one
+out of a grave.
+
+Now, which of the multitude of faces that showed themselves before him
+was the true face of the buried person, the shadows of the night did
+not indicate; but they were all the faces of a man of five-and-forty by
+years, and they differed principally in the passions they expressed,
+and in the ghastliness of their worn and wasted state. Pride, contempt,
+defiance, stubbornness, submission, lamentation, succeeded one another;
+so did varieties of sunken cheek, cadaverous colour, emaciated hands
+and figures. But the face was in the main one face, and every head was
+prematurely white. A hundred times the dozing passenger inquired of this
+spectre:
+
+“Buried how long?”
+
+The answer was always the same: “Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+“You know that you are recalled to life?”
+
+“They tell me so.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+“Shall I show her to you? Will you come and see her?”
+
+The answers to this question were various and contradictory. Sometimes
+the broken reply was, “Wait! It would kill me if I saw her too soon.”
+ Sometimes, it was given in a tender rain of tears, and then it was,
+“Take me to her.” Sometimes it was staring and bewildered, and then it
+was, “I don’t know her. I don’t understand.”
+
+After such imaginary discourse, the passenger in his fancy would dig,
+and dig, dig--now with a spade, now with a great key, now with his
+hands--to dig this wretched creature out. Got out at last, with earth
+hanging about his face and hair, he would suddenly fan away to dust. The
+passenger would then start to himself, and lower the window, to get the
+reality of mist and rain on his cheek.
+
+Yet even when his eyes were opened on the mist and rain, on the moving
+patch of light from the lamps, and the hedge at the roadside retreating
+by jerks, the night shadows outside the coach would fall into the train
+of the night shadows within. The real Banking-house by Temple Bar, the
+real business of the past day, the real strong rooms, the real express
+sent after him, and the real message returned, would all be there. Out
+of the midst of them, the ghostly face would rise, and he would accost
+it again.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+Dig--dig--dig--until an impatient movement from one of the two
+passengers would admonish him to pull up the window, draw his arm
+securely through the leathern strap, and speculate upon the two
+slumbering forms, until his mind lost its hold of them, and they again
+slid away into the bank and the grave.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+The words were still in his hearing as just spoken--distinctly in
+his hearing as ever spoken words had been in his life--when the weary
+passenger started to the consciousness of daylight, and found that the
+shadows of the night were gone.
+
+He lowered the window, and looked out at the rising sun. There was a
+ridge of ploughed land, with a plough upon it where it had been left
+last night when the horses were unyoked; beyond, a quiet coppice-wood,
+in which many leaves of burning red and golden yellow still remained
+upon the trees. Though the earth was cold and wet, the sky was clear,
+and the sun rose bright, placid, and beautiful.
+
+“Eighteen years!” said the passenger, looking at the sun. “Gracious
+Creator of day! To be buried alive for eighteen years!”
+
+
+
+
+IV. The Preparation
+
+
+When the mail got successfully to Dover, in the course of the forenoon,
+the head drawer at the Royal George Hotel opened the coach-door as his
+custom was. He did it with some flourish of ceremony, for a mail journey
+from London in winter was an achievement to congratulate an adventurous
+traveller upon.
+
+By that time, there was only one adventurous traveller left be
+congratulated: for the two others had been set down at their respective
+roadside destinations. The mildewy inside of the coach, with its damp
+and dirty straw, its disagreeable smell, and its obscurity, was rather
+like a larger dog-kennel. Mr. Lorry, the passenger, shaking himself out
+of it in chains of straw, a tangle of shaggy wrapper, flapping hat, and
+muddy legs, was rather like a larger sort of dog.
+
+“There will be a packet to Calais, tomorrow, drawer?”
+
+“Yes, sir, if the weather holds and the wind sets tolerable fair. The
+tide will serve pretty nicely at about two in the afternoon, sir. Bed,
+sir?”
+
+“I shall not go to bed till night; but I want a bedroom, and a barber.”
+
+“And then breakfast, sir? Yes, sir. That way, sir, if you please.
+Show Concord! Gentleman’s valise and hot water to Concord. Pull off
+gentleman’s boots in Concord. (You will find a fine sea-coal fire, sir.)
+Fetch barber to Concord. Stir about there, now, for Concord!”
+
+The Concord bed-chamber being always assigned to a passenger by the
+mail, and passengers by the mail being always heavily wrapped up from
+head to foot, the room had the odd interest for the establishment of the
+Royal George, that although but one kind of man was seen to go into it,
+all kinds and varieties of men came out of it. Consequently, another
+drawer, and two porters, and several maids and the landlady, were all
+loitering by accident at various points of the road between the Concord
+and the coffee-room, when a gentleman of sixty, formally dressed in a
+brown suit of clothes, pretty well worn, but very well kept, with large
+square cuffs and large flaps to the pockets, passed along on his way to
+his breakfast.
+
+The coffee-room had no other occupant, that forenoon, than the gentleman
+in brown. His breakfast-table was drawn before the fire, and as he sat,
+with its light shining on him, waiting for the meal, he sat so still,
+that he might have been sitting for his portrait.
+
+Very orderly and methodical he looked, with a hand on each knee, and a
+loud watch ticking a sonorous sermon under his flapped waist-coat,
+as though it pitted its gravity and longevity against the levity and
+evanescence of the brisk fire. He had a good leg, and was a little vain
+of it, for his brown stockings fitted sleek and close, and were of a
+fine texture; his shoes and buckles, too, though plain, were trim. He
+wore an odd little sleek crisp flaxen wig, setting very close to his
+head: which wig, it is to be presumed, was made of hair, but which
+looked far more as though it were spun from filaments of silk or glass.
+His linen, though not of a fineness in accordance with his stockings,
+was as white as the tops of the waves that broke upon the neighbouring
+beach, or the specks of sail that glinted in the sunlight far at sea. A
+face habitually suppressed and quieted, was still lighted up under the
+quaint wig by a pair of moist bright eyes that it must have cost
+their owner, in years gone by, some pains to drill to the composed and
+reserved expression of Tellson’s Bank. He had a healthy colour in his
+cheeks, and his face, though lined, bore few traces of anxiety.
+But, perhaps the confidential bachelor clerks in Tellson’s Bank were
+principally occupied with the cares of other people; and perhaps
+second-hand cares, like second-hand clothes, come easily off and on.
+
+Completing his resemblance to a man who was sitting for his portrait,
+Mr. Lorry dropped off to sleep. The arrival of his breakfast roused him,
+and he said to the drawer, as he moved his chair to it:
+
+“I wish accommodation prepared for a young lady who may come here at any
+time to-day. She may ask for Mr. Jarvis Lorry, or she may only ask for a
+gentleman from Tellson’s Bank. Please to let me know.”
+
+“Yes, sir. Tellson’s Bank in London, sir?”
+
+“Yes.”
+
+“Yes, sir. We have oftentimes the honour to entertain your gentlemen in
+their travelling backwards and forwards betwixt London and Paris, sir. A
+vast deal of travelling, sir, in Tellson and Company’s House.”
+
+“Yes. We are quite a French House, as well as an English one.”
+
+“Yes, sir. Not much in the habit of such travelling yourself, I think,
+sir?”
+
+“Not of late years. It is fifteen years since we--since I--came last
+from France.”
+
+“Indeed, sir? That was before my time here, sir. Before our people’s
+time here, sir. The George was in other hands at that time, sir.”
+
+“I believe so.”
+
+“But I would hold a pretty wager, sir, that a House like Tellson and
+Company was flourishing, a matter of fifty, not to speak of fifteen
+years ago?”
+
+“You might treble that, and say a hundred and fifty, yet not be far from
+the truth.”
+
+“Indeed, sir!”
+
+Rounding his mouth and both his eyes, as he stepped backward from the
+table, the waiter shifted his napkin from his right arm to his left,
+dropped into a comfortable attitude, and stood surveying the guest while
+he ate and drank, as from an observatory or watchtower. According to the
+immemorial usage of waiters in all ages.
+
+When Mr. Lorry had finished his breakfast, he went out for a stroll on
+the beach. The little narrow, crooked town of Dover hid itself away
+from the beach, and ran its head into the chalk cliffs, like a marine
+ostrich. The beach was a desert of heaps of sea and stones tumbling
+wildly about, and the sea did what it liked, and what it liked was
+destruction. It thundered at the town, and thundered at the cliffs, and
+brought the coast down, madly. The air among the houses was of so strong
+a piscatory flavour that one might have supposed sick fish went up to be
+dipped in it, as sick people went down to be dipped in the sea. A little
+fishing was done in the port, and a quantity of strolling about by
+night, and looking seaward: particularly at those times when the tide
+made, and was near flood. Small tradesmen, who did no business whatever,
+sometimes unaccountably realised large fortunes, and it was remarkable
+that nobody in the neighbourhood could endure a lamplighter.
+
+As the day declined into the afternoon, and the air, which had been
+at intervals clear enough to allow the French coast to be seen, became
+again charged with mist and vapour, Mr. Lorry’s thoughts seemed to cloud
+too. When it was dark, and he sat before the coffee-room fire, awaiting
+his dinner as he had awaited his breakfast, his mind was busily digging,
+digging, digging, in the live red coals.
+
+A bottle of good claret after dinner does a digger in the red coals no
+harm, otherwise than as it has a tendency to throw him out of work.
+Mr. Lorry had been idle a long time, and had just poured out his last
+glassful of wine with as complete an appearance of satisfaction as is
+ever to be found in an elderly gentleman of a fresh complexion who has
+got to the end of a bottle, when a rattling of wheels came up the narrow
+street, and rumbled into the inn-yard.
+
+He set down his glass untouched. “This is Mam’selle!” said he.
+
+In a very few minutes the waiter came in to announce that Miss Manette
+had arrived from London, and would be happy to see the gentleman from
+Tellson’s.
+
+“So soon?”
+
+Miss Manette had taken some refreshment on the road, and required none
+then, and was extremely anxious to see the gentleman from Tellson’s
+immediately, if it suited his pleasure and convenience.
+
+The gentleman from Tellson’s had nothing left for it but to empty his
+glass with an air of stolid desperation, settle his odd little flaxen
+wig at the ears, and follow the waiter to Miss Manette’s apartment.
+It was a large, dark room, furnished in a funereal manner with black
+horsehair, and loaded with heavy dark tables. These had been oiled and
+oiled, until the two tall candles on the table in the middle of the room
+were gloomily reflected on every leaf; as if _they_ were buried, in deep
+graves of black mahogany, and no light to speak of could be expected
+from them until they were dug out.
+
+The obscurity was so difficult to penetrate that Mr. Lorry, picking his
+way over the well-worn Turkey carpet, supposed Miss Manette to be, for
+the moment, in some adjacent room, until, having got past the two tall
+candles, he saw standing to receive him by the table between them and
+the fire, a young lady of not more than seventeen, in a riding-cloak,
+and still holding her straw travelling-hat by its ribbon in her hand. As
+his eyes rested on a short, slight, pretty figure, a quantity of golden
+hair, a pair of blue eyes that met his own with an inquiring look, and
+a forehead with a singular capacity (remembering how young and smooth
+it was), of rifting and knitting itself into an expression that was
+not quite one of perplexity, or wonder, or alarm, or merely of a bright
+fixed attention, though it included all the four expressions--as his
+eyes rested on these things, a sudden vivid likeness passed before him,
+of a child whom he had held in his arms on the passage across that very
+Channel, one cold time, when the hail drifted heavily and the sea ran
+high. The likeness passed away, like a breath along the surface of
+the gaunt pier-glass behind her, on the frame of which, a hospital
+procession of negro cupids, several headless and all cripples, were
+offering black baskets of Dead Sea fruit to black divinities of the
+feminine gender--and he made his formal bow to Miss Manette.
+
+“Pray take a seat, sir.” In a very clear and pleasant young voice; a
+little foreign in its accent, but a very little indeed.
+
+“I kiss your hand, miss,” said Mr. Lorry, with the manners of an earlier
+date, as he made his formal bow again, and took his seat.
+
+“I received a letter from the Bank, sir, yesterday, informing me that
+some intelligence--or discovery--”
+
+“The word is not material, miss; either word will do.”
+
+“--respecting the small property of my poor father, whom I never saw--so
+long dead--”
+
+Mr. Lorry moved in his chair, and cast a troubled look towards the
+hospital procession of negro cupids. As if _they_ had any help for
+anybody in their absurd baskets!
+
+“--rendered it necessary that I should go to Paris, there to communicate
+with a gentleman of the Bank, so good as to be despatched to Paris for
+the purpose.”
+
+“Myself.”
+
+“As I was prepared to hear, sir.”
+
+She curtseyed to him (young ladies made curtseys in those days), with a
+pretty desire to convey to him that she felt how much older and wiser he
+was than she. He made her another bow.
+
+“I replied to the Bank, sir, that as it was considered necessary, by
+those who know, and who are so kind as to advise me, that I should go to
+France, and that as I am an orphan and have no friend who could go with
+me, I should esteem it highly if I might be permitted to place myself,
+during the journey, under that worthy gentleman’s protection. The
+gentleman had left London, but I think a messenger was sent after him to
+beg the favour of his waiting for me here.”
+
+“I was happy,” said Mr. Lorry, “to be entrusted with the charge. I shall
+be more happy to execute it.”
+
+“Sir, I thank you indeed. I thank you very gratefully. It was told me
+by the Bank that the gentleman would explain to me the details of the
+business, and that I must prepare myself to find them of a surprising
+nature. I have done my best to prepare myself, and I naturally have a
+strong and eager interest to know what they are.”
+
+“Naturally,” said Mr. Lorry. “Yes--I--”
+
+After a pause, he added, again settling the crisp flaxen wig at the
+ears, “It is very difficult to begin.”
+
+He did not begin, but, in his indecision, met her glance. The young
+forehead lifted itself into that singular expression--but it was pretty
+and characteristic, besides being singular--and she raised her hand,
+as if with an involuntary action she caught at, or stayed some passing
+shadow.
+
+“Are you quite a stranger to me, sir?”
+
+“Am I not?” Mr. Lorry opened his hands, and extended them outwards with
+an argumentative smile.
+
+Between the eyebrows and just over the little feminine nose, the line of
+which was as delicate and fine as it was possible to be, the expression
+deepened itself as she took her seat thoughtfully in the chair by which
+she had hitherto remained standing. He watched her as she mused, and the
+moment she raised her eyes again, went on:
+
+“In your adopted country, I presume, I cannot do better than address you
+as a young English lady, Miss Manette?”
+
+“If you please, sir.”
+
+“Miss Manette, I am a man of business. I have a business charge to
+acquit myself of. In your reception of it, don’t heed me any more than
+if I was a speaking machine--truly, I am not much else. I will, with
+your leave, relate to you, miss, the story of one of our customers.”
+
+“Story!”
+
+He seemed wilfully to mistake the word she had repeated, when he added,
+in a hurry, “Yes, customers; in the banking business we usually call
+our connection our customers. He was a French gentleman; a scientific
+gentleman; a man of great acquirements--a Doctor.”
+
+“Not of Beauvais?”
+
+“Why, yes, of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of repute in Paris. I had the honour of knowing him there.
+Our relations were business relations, but confidential. I was at that
+time in our French House, and had been--oh! twenty years.”
+
+“At that time--I may ask, at what time, sir?”
+
+“I speak, miss, of twenty years ago. He married--an English lady--and
+I was one of the trustees. His affairs, like the affairs of many other
+French gentlemen and French families, were entirely in Tellson’s hands.
+In a similar way I am, or I have been, trustee of one kind or other for
+scores of our customers. These are mere business relations, miss;
+there is no friendship in them, no particular interest, nothing like
+sentiment. I have passed from one to another, in the course of my
+business life, just as I pass from one of our customers to another in
+the course of my business day; in short, I have no feelings; I am a mere
+machine. To go on--”
+
+“But this is my father’s story, sir; and I begin to think”--the
+curiously roughened forehead was very intent upon him--“that when I was
+left an orphan through my mother’s surviving my father only two years,
+it was you who brought me to England. I am almost sure it was you.”
+
+Mr. Lorry took the hesitating little hand that confidingly advanced
+to take his, and he put it with some ceremony to his lips. He then
+conducted the young lady straightway to her chair again, and, holding
+the chair-back with his left hand, and using his right by turns to rub
+his chin, pull his wig at the ears, or point what he said, stood looking
+down into her face while she sat looking up into his.
+
+“Miss Manette, it _was_ I. And you will see how truly I spoke of myself
+just now, in saying I had no feelings, and that all the relations I hold
+with my fellow-creatures are mere business relations, when you reflect
+that I have never seen you since. No; you have been the ward of
+Tellson’s House since, and I have been busy with the other business of
+Tellson’s House since. Feelings! I have no time for them, no chance
+of them. I pass my whole life, miss, in turning an immense pecuniary
+Mangle.”
+
+After this odd description of his daily routine of employment, Mr. Lorry
+flattened his flaxen wig upon his head with both hands (which was most
+unnecessary, for nothing could be flatter than its shining surface was
+before), and resumed his former attitude.
+
+“So far, miss (as you have remarked), this is the story of your
+regretted father. Now comes the difference. If your father had not died
+when he did--Don’t be frightened! How you start!”
+
+She did, indeed, start. And she caught his wrist with both her hands.
+
+“Pray,” said Mr. Lorry, in a soothing tone, bringing his left hand from
+the back of the chair to lay it on the supplicatory fingers that clasped
+him in so violent a tremble: “pray control your agitation--a matter of
+business. As I was saying--”
+
+Her look so discomposed him that he stopped, wandered, and began anew:
+
+“As I was saying; if Monsieur Manette had not died; if he had suddenly
+and silently disappeared; if he had been spirited away; if it had not
+been difficult to guess to what dreadful place, though no art could
+trace him; if he had an enemy in some compatriot who could exercise a
+privilege that I in my own time have known the boldest people afraid
+to speak of in a whisper, across the water there; for instance, the
+privilege of filling up blank forms for the consignment of any one
+to the oblivion of a prison for any length of time; if his wife had
+implored the king, the queen, the court, the clergy, for any tidings of
+him, and all quite in vain;--then the history of your father would have
+been the history of this unfortunate gentleman, the Doctor of Beauvais.”
+
+“I entreat you to tell me more, sir.”
+
+“I will. I am going to. You can bear it?”
+
+“I can bear anything but the uncertainty you leave me in at this
+moment.”
+
+“You speak collectedly, and you--_are_ collected. That’s good!” (Though
+his manner was less satisfied than his words.) “A matter of business.
+Regard it as a matter of business--business that must be done. Now
+if this doctor’s wife, though a lady of great courage and spirit,
+had suffered so intensely from this cause before her little child was
+born--”
+
+“The little child was a daughter, sir.”
+
+“A daughter. A-a-matter of business--don’t be distressed. Miss, if the
+poor lady had suffered so intensely before her little child was born,
+that she came to the determination of sparing the poor child the
+inheritance of any part of the agony she had known the pains of, by
+rearing her in the belief that her father was dead--No, don’t kneel! In
+Heaven’s name why should you kneel to me!”
+
+“For the truth. O dear, good, compassionate sir, for the truth!”
+
+“A--a matter of business. You confuse me, and how can I transact
+business if I am confused? Let us be clear-headed. If you could kindly
+mention now, for instance, what nine times ninepence are, or how many
+shillings in twenty guineas, it would be so encouraging. I should be so
+much more at my ease about your state of mind.”
+
+Without directly answering to this appeal, she sat so still when he had
+very gently raised her, and the hands that had not ceased to clasp
+his wrists were so much more steady than they had been, that she
+communicated some reassurance to Mr. Jarvis Lorry.
+
+“That’s right, that’s right. Courage! Business! You have business before
+you; useful business. Miss Manette, your mother took this course with
+you. And when she died--I believe broken-hearted--having never slackened
+her unavailing search for your father, she left you, at two years old,
+to grow to be blooming, beautiful, and happy, without the dark cloud
+upon you of living in uncertainty whether your father soon wore his
+heart out in prison, or wasted there through many lingering years.”
+
+As he said the words he looked down, with an admiring pity, on the
+flowing golden hair; as if he pictured to himself that it might have
+been already tinged with grey.
+
+“You know that your parents had no great possession, and that what
+they had was secured to your mother and to you. There has been no new
+discovery, of money, or of any other property; but--”
+
+He felt his wrist held closer, and he stopped. The expression in the
+forehead, which had so particularly attracted his notice, and which was
+now immovable, had deepened into one of pain and horror.
+
+“But he has been--been found. He is alive. Greatly changed, it is too
+probable; almost a wreck, it is possible; though we will hope the best.
+Still, alive. Your father has been taken to the house of an old servant
+in Paris, and we are going there: I, to identify him if I can: you, to
+restore him to life, love, duty, rest, comfort.”
+
+A shiver ran through her frame, and from it through his. She said, in a
+low, distinct, awe-stricken voice, as if she were saying it in a dream,
+
+“I am going to see his Ghost! It will be his Ghost--not him!”
+
+Mr. Lorry quietly chafed the hands that held his arm. “There, there,
+there! See now, see now! The best and the worst are known to you, now.
+You are well on your way to the poor wronged gentleman, and, with a fair
+sea voyage, and a fair land journey, you will be soon at his dear side.”
+
+She repeated in the same tone, sunk to a whisper, “I have been free, I
+have been happy, yet his Ghost has never haunted me!”
+
+“Only one thing more,” said Mr. Lorry, laying stress upon it as a
+wholesome means of enforcing her attention: “he has been found under
+another name; his own, long forgotten or long concealed. It would be
+worse than useless now to inquire which; worse than useless to seek to
+know whether he has been for years overlooked, or always designedly
+held prisoner. It would be worse than useless now to make any inquiries,
+because it would be dangerous. Better not to mention the subject,
+anywhere or in any way, and to remove him--for a while at all
+events--out of France. Even I, safe as an Englishman, and even
+Tellson’s, important as they are to French credit, avoid all naming of
+the matter. I carry about me, not a scrap of writing openly referring
+to it. This is a secret service altogether. My credentials, entries,
+and memoranda, are all comprehended in the one line, ‘Recalled to Life;’
+which may mean anything. But what is the matter! She doesn’t notice a
+word! Miss Manette!”
+
+Perfectly still and silent, and not even fallen back in her chair, she
+sat under his hand, utterly insensible; with her eyes open and fixed
+upon him, and with that last expression looking as if it were carved or
+branded into her forehead. So close was her hold upon his arm, that he
+feared to detach himself lest he should hurt her; therefore he called
+out loudly for assistance without moving.
+
+A wild-looking woman, whom even in his agitation, Mr. Lorry observed to
+be all of a red colour, and to have red hair, and to be dressed in some
+extraordinary tight-fitting fashion, and to have on her head a most
+wonderful bonnet like a Grenadier wooden measure, and good measure too,
+or a great Stilton cheese, came running into the room in advance of the
+inn servants, and soon settled the question of his detachment from the
+poor young lady, by laying a brawny hand upon his chest, and sending him
+flying back against the nearest wall.
+
+(“I really think this must be a man!” was Mr. Lorry’s breathless
+reflection, simultaneously with his coming against the wall.)
+
+“Why, look at you all!” bawled this figure, addressing the inn servants.
+“Why don’t you go and fetch things, instead of standing there staring
+at me? I am not so much to look at, am I? Why don’t you go and fetch
+things? I’ll let you know, if you don’t bring smelling-salts, cold
+water, and vinegar, quick, I will.”
+
+There was an immediate dispersal for these restoratives, and she
+softly laid the patient on a sofa, and tended her with great skill and
+gentleness: calling her “my precious!” and “my bird!” and spreading her
+golden hair aside over her shoulders with great pride and care.
+
+“And you in brown!” she said, indignantly turning to Mr. Lorry;
+“couldn’t you tell her what you had to tell her, without frightening her
+to death? Look at her, with her pretty pale face and her cold hands. Do
+you call _that_ being a Banker?”
+
+Mr. Lorry was so exceedingly disconcerted by a question so hard to
+answer, that he could only look on, at a distance, with much feebler
+sympathy and humility, while the strong woman, having banished the inn
+servants under the mysterious penalty of “letting them know” something
+not mentioned if they stayed there, staring, recovered her charge by a
+regular series of gradations, and coaxed her to lay her drooping head
+upon her shoulder.
+
+“I hope she will do well now,” said Mr. Lorry.
+
+“No thanks to you in brown, if she does. My darling pretty!”
+
+“I hope,” said Mr. Lorry, after another pause of feeble sympathy and
+humility, “that you accompany Miss Manette to France?”
+
+“A likely thing, too!” replied the strong woman. “If it was ever
+intended that I should go across salt water, do you suppose Providence
+would have cast my lot in an island?”
+
+This being another question hard to answer, Mr. Jarvis Lorry withdrew to
+consider it.
+
+
+
+
+V. The Wine-shop
+
+
+A large cask of wine had been dropped and broken, in the street. The
+accident had happened in getting it out of a cart; the cask had tumbled
+out with a run, the hoops had burst, and it lay on the stones just
+outside the door of the wine-shop, shattered like a walnut-shell.
+
+All the people within reach had suspended their business, or their
+idleness, to run to the spot and drink the wine. The rough, irregular
+stones of the street, pointing every way, and designed, one might have
+thought, expressly to lame all living creatures that approached them,
+had dammed it into little pools; these were surrounded, each by its own
+jostling group or crowd, according to its size. Some men kneeled down,
+made scoops of their two hands joined, and sipped, or tried to help
+women, who bent over their shoulders, to sip, before the wine had all
+run out between their fingers. Others, men and women, dipped in
+the puddles with little mugs of mutilated earthenware, or even with
+handkerchiefs from women’s heads, which were squeezed dry into infants’
+mouths; others made small mud-embankments, to stem the wine as it ran;
+others, directed by lookers-on up at high windows, darted here and
+there, to cut off little streams of wine that started away in new
+directions; others devoted themselves to the sodden and lee-dyed
+pieces of the cask, licking, and even champing the moister wine-rotted
+fragments with eager relish. There was no drainage to carry off the
+wine, and not only did it all get taken up, but so much mud got taken up
+along with it, that there might have been a scavenger in the street,
+if anybody acquainted with it could have believed in such a miraculous
+presence.
+
+A shrill sound of laughter and of amused voices--voices of men, women,
+and children--resounded in the street while this wine game lasted. There
+was little roughness in the sport, and much playfulness. There was a
+special companionship in it, an observable inclination on the part
+of every one to join some other one, which led, especially among the
+luckier or lighter-hearted, to frolicsome embraces, drinking of healths,
+shaking of hands, and even joining of hands and dancing, a dozen
+together. When the wine was gone, and the places where it had been
+most abundant were raked into a gridiron-pattern by fingers, these
+demonstrations ceased, as suddenly as they had broken out. The man who
+had left his saw sticking in the firewood he was cutting, set it in
+motion again; the women who had left on a door-step the little pot of
+hot ashes, at which she had been trying to soften the pain in her own
+starved fingers and toes, or in those of her child, returned to it; men
+with bare arms, matted locks, and cadaverous faces, who had emerged into
+the winter light from cellars, moved away, to descend again; and a gloom
+gathered on the scene that appeared more natural to it than sunshine.
+
+The wine was red wine, and had stained the ground of the narrow street
+in the suburb of Saint Antoine, in Paris, where it was spilled. It had
+stained many hands, too, and many faces, and many naked feet, and many
+wooden shoes. The hands of the man who sawed the wood, left red marks
+on the billets; and the forehead of the woman who nursed her baby, was
+stained with the stain of the old rag she wound about her head again.
+Those who had been greedy with the staves of the cask, had acquired a
+tigerish smear about the mouth; and one tall joker so besmirched, his
+head more out of a long squalid bag of a nightcap than in it, scrawled
+upon a wall with his finger dipped in muddy wine-lees--BLOOD.
+
+The time was to come, when that wine too would be spilled on the
+street-stones, and when the stain of it would be red upon many there.
+
+And now that the cloud settled on Saint Antoine, which a momentary
+gleam had driven from his sacred countenance, the darkness of it was
+heavy--cold, dirt, sickness, ignorance, and want, were the lords in
+waiting on the saintly presence--nobles of great power all of them;
+but, most especially the last. Samples of a people that had undergone a
+terrible grinding and regrinding in the mill, and certainly not in the
+fabulous mill which ground old people young, shivered at every corner,
+passed in and out at every doorway, looked from every window, fluttered
+in every vestige of a garment that the wind shook. The mill which
+had worked them down, was the mill that grinds young people old; the
+children had ancient faces and grave voices; and upon them, and upon the
+grown faces, and ploughed into every furrow of age and coming up afresh,
+was the sigh, Hunger. It was prevalent everywhere. Hunger was pushed out
+of the tall houses, in the wretched clothing that hung upon poles and
+lines; Hunger was patched into them with straw and rag and wood and
+paper; Hunger was repeated in every fragment of the small modicum of
+firewood that the man sawed off; Hunger stared down from the smokeless
+chimneys, and started up from the filthy street that had no offal,
+among its refuse, of anything to eat. Hunger was the inscription on the
+baker’s shelves, written in every small loaf of his scanty stock of
+bad bread; at the sausage-shop, in every dead-dog preparation that
+was offered for sale. Hunger rattled its dry bones among the roasting
+chestnuts in the turned cylinder; Hunger was shred into atomics in every
+farthing porringer of husky chips of potato, fried with some reluctant
+drops of oil.
+
+Its abiding place was in all things fitted to it. A narrow winding
+street, full of offence and stench, with other narrow winding streets
+diverging, all peopled by rags and nightcaps, and all smelling of rags
+and nightcaps, and all visible things with a brooding look upon them
+that looked ill. In the hunted air of the people there was yet some
+wild-beast thought of the possibility of turning at bay. Depressed and
+slinking though they were, eyes of fire were not wanting among them; nor
+compressed lips, white with what they suppressed; nor foreheads knitted
+into the likeness of the gallows-rope they mused about enduring, or
+inflicting. The trade signs (and they were almost as many as the shops)
+were, all, grim illustrations of Want. The butcher and the porkman
+painted up, only the leanest scrags of meat; the baker, the coarsest of
+meagre loaves. The people rudely pictured as drinking in the wine-shops,
+croaked over their scanty measures of thin wine and beer, and were
+gloweringly confidential together. Nothing was represented in a
+flourishing condition, save tools and weapons; but, the cutler’s knives
+and axes were sharp and bright, the smith’s hammers were heavy, and the
+gunmaker’s stock was murderous. The crippling stones of the pavement,
+with their many little reservoirs of mud and water, had no footways, but
+broke off abruptly at the doors. The kennel, to make amends, ran down
+the middle of the street--when it ran at all: which was only after heavy
+rains, and then it ran, by many eccentric fits, into the houses. Across
+the streets, at wide intervals, one clumsy lamp was slung by a rope and
+pulley; at night, when the lamplighter had let these down, and lighted,
+and hoisted them again, a feeble grove of dim wicks swung in a sickly
+manner overhead, as if they were at sea. Indeed they were at sea, and
+the ship and crew were in peril of tempest.
+
+For, the time was to come, when the gaunt scarecrows of that region
+should have watched the lamplighter, in their idleness and hunger, so
+long, as to conceive the idea of improving on his method, and hauling
+up men by those ropes and pulleys, to flare upon the darkness of their
+condition. But, the time was not come yet; and every wind that blew over
+France shook the rags of the scarecrows in vain, for the birds, fine of
+song and feather, took no warning.
+
+The wine-shop was a corner shop, better than most others in its
+appearance and degree, and the master of the wine-shop had stood outside
+it, in a yellow waistcoat and green breeches, looking on at the struggle
+for the lost wine. “It’s not my affair,” said he, with a final shrug
+of the shoulders. “The people from the market did it. Let them bring
+another.”
+
+There, his eyes happening to catch the tall joker writing up his joke,
+he called to him across the way:
+
+“Say, then, my Gaspard, what do you do there?”
+
+The fellow pointed to his joke with immense significance, as is often
+the way with his tribe. It missed its mark, and completely failed, as is
+often the way with his tribe too.
+
+“What now? Are you a subject for the mad hospital?” said the wine-shop
+keeper, crossing the road, and obliterating the jest with a handful of
+mud, picked up for the purpose, and smeared over it. “Why do you write
+in the public streets? Is there--tell me thou--is there no other place
+to write such words in?”
+
+In his expostulation he dropped his cleaner hand (perhaps accidentally,
+perhaps not) upon the joker’s heart. The joker rapped it with his
+own, took a nimble spring upward, and came down in a fantastic dancing
+attitude, with one of his stained shoes jerked off his foot into his
+hand, and held out. A joker of an extremely, not to say wolfishly
+practical character, he looked, under those circumstances.
+
+“Put it on, put it on,” said the other. “Call wine, wine; and finish
+there.” With that advice, he wiped his soiled hand upon the joker’s
+dress, such as it was--quite deliberately, as having dirtied the hand on
+his account; and then recrossed the road and entered the wine-shop.
+
+This wine-shop keeper was a bull-necked, martial-looking man of thirty,
+and he should have been of a hot temperament, for, although it was a
+bitter day, he wore no coat, but carried one slung over his shoulder.
+His shirt-sleeves were rolled up, too, and his brown arms were bare to
+the elbows. Neither did he wear anything more on his head than his own
+crisply-curling short dark hair. He was a dark man altogether, with good
+eyes and a good bold breadth between them. Good-humoured looking on
+the whole, but implacable-looking, too; evidently a man of a strong
+resolution and a set purpose; a man not desirable to be met, rushing
+down a narrow pass with a gulf on either side, for nothing would turn
+the man.
+
+Madame Defarge, his wife, sat in the shop behind the counter as he
+came in. Madame Defarge was a stout woman of about his own age, with
+a watchful eye that seldom seemed to look at anything, a large hand
+heavily ringed, a steady face, strong features, and great composure of
+manner. There was a character about Madame Defarge, from which one might
+have predicated that she did not often make mistakes against herself
+in any of the reckonings over which she presided. Madame Defarge being
+sensitive to cold, was wrapped in fur, and had a quantity of bright
+shawl twined about her head, though not to the concealment of her large
+earrings. Her knitting was before her, but she had laid it down to pick
+her teeth with a toothpick. Thus engaged, with her right elbow supported
+by her left hand, Madame Defarge said nothing when her lord came in, but
+coughed just one grain of cough. This, in combination with the lifting
+of her darkly defined eyebrows over her toothpick by the breadth of a
+line, suggested to her husband that he would do well to look round the
+shop among the customers, for any new customer who had dropped in while
+he stepped over the way.
+
+The wine-shop keeper accordingly rolled his eyes about, until they
+rested upon an elderly gentleman and a young lady, who were seated in
+a corner. Other company were there: two playing cards, two playing
+dominoes, three standing by the counter lengthening out a short supply
+of wine. As he passed behind the counter, he took notice that the
+elderly gentleman said in a look to the young lady, “This is our man.”
+
+“What the devil do _you_ do in that galley there?” said Monsieur Defarge
+to himself; “I don’t know you.”
+
+But, he feigned not to notice the two strangers, and fell into discourse
+with the triumvirate of customers who were drinking at the counter.
+
+“How goes it, Jacques?” said one of these three to Monsieur Defarge. “Is
+all the spilt wine swallowed?”
+
+“Every drop, Jacques,” answered Monsieur Defarge.
+
+When this interchange of Christian name was effected, Madame Defarge,
+picking her teeth with her toothpick, coughed another grain of cough,
+and raised her eyebrows by the breadth of another line.
+
+“It is not often,” said the second of the three, addressing Monsieur
+Defarge, “that many of these miserable beasts know the taste of wine, or
+of anything but black bread and death. Is it not so, Jacques?”
+
+“It is so, Jacques,” Monsieur Defarge returned.
+
+At this second interchange of the Christian name, Madame Defarge, still
+using her toothpick with profound composure, coughed another grain of
+cough, and raised her eyebrows by the breadth of another line.
+
+The last of the three now said his say, as he put down his empty
+drinking vessel and smacked his lips.
+
+“Ah! So much the worse! A bitter taste it is that such poor cattle
+always have in their mouths, and hard lives they live, Jacques. Am I
+right, Jacques?”
+
+“You are right, Jacques,” was the response of Monsieur Defarge.
+
+This third interchange of the Christian name was completed at the moment
+when Madame Defarge put her toothpick by, kept her eyebrows up, and
+slightly rustled in her seat.
+
+“Hold then! True!” muttered her husband. “Gentlemen--my wife!”
+
+The three customers pulled off their hats to Madame Defarge, with three
+flourishes. She acknowledged their homage by bending her head, and
+giving them a quick look. Then she glanced in a casual manner round the
+wine-shop, took up her knitting with great apparent calmness and repose
+of spirit, and became absorbed in it.
+
+“Gentlemen,” said her husband, who had kept his bright eye observantly
+upon her, “good day. The chamber, furnished bachelor-fashion, that you
+wished to see, and were inquiring for when I stepped out, is on the
+fifth floor. The doorway of the staircase gives on the little courtyard
+close to the left here,” pointing with his hand, “near to the window of
+my establishment. But, now that I remember, one of you has already been
+there, and can show the way. Gentlemen, adieu!”
+
+They paid for their wine, and left the place. The eyes of Monsieur
+Defarge were studying his wife at her knitting when the elderly
+gentleman advanced from his corner, and begged the favour of a word.
+
+“Willingly, sir,” said Monsieur Defarge, and quietly stepped with him to
+the door.
+
+Their conference was very short, but very decided. Almost at the first
+word, Monsieur Defarge started and became deeply attentive. It had
+not lasted a minute, when he nodded and went out. The gentleman then
+beckoned to the young lady, and they, too, went out. Madame Defarge
+knitted with nimble fingers and steady eyebrows, and saw nothing.
+
+Mr. Jarvis Lorry and Miss Manette, emerging from the wine-shop thus,
+joined Monsieur Defarge in the doorway to which he had directed his own
+company just before. It opened from a stinking little black courtyard,
+and was the general public entrance to a great pile of houses, inhabited
+by a great number of people. In the gloomy tile-paved entry to the
+gloomy tile-paved staircase, Monsieur Defarge bent down on one knee
+to the child of his old master, and put her hand to his lips. It was
+a gentle action, but not at all gently done; a very remarkable
+transformation had come over him in a few seconds. He had no good-humour
+in his face, nor any openness of aspect left, but had become a secret,
+angry, dangerous man.
+
+“It is very high; it is a little difficult. Better to begin slowly.”
+ Thus, Monsieur Defarge, in a stern voice, to Mr. Lorry, as they began
+ascending the stairs.
+
+“Is he alone?” the latter whispered.
+
+“Alone! God help him, who should be with him!” said the other, in the
+same low voice.
+
+“Is he always alone, then?”
+
+“Yes.”
+
+“Of his own desire?”
+
+“Of his own necessity. As he was, when I first saw him after they
+found me and demanded to know if I would take him, and, at my peril be
+discreet--as he was then, so he is now.”
+
+“He is greatly changed?”
+
+“Changed!”
+
+The keeper of the wine-shop stopped to strike the wall with his hand,
+and mutter a tremendous curse. No direct answer could have been half so
+forcible. Mr. Lorry’s spirits grew heavier and heavier, as he and his
+two companions ascended higher and higher.
+
+Such a staircase, with its accessories, in the older and more crowded
+parts of Paris, would be bad enough now; but, at that time, it was vile
+indeed to unaccustomed and unhardened senses. Every little habitation
+within the great foul nest of one high building--that is to say,
+the room or rooms within every door that opened on the general
+staircase--left its own heap of refuse on its own landing, besides
+flinging other refuse from its own windows. The uncontrollable and
+hopeless mass of decomposition so engendered, would have polluted
+the air, even if poverty and deprivation had not loaded it with their
+intangible impurities; the two bad sources combined made it almost
+insupportable. Through such an atmosphere, by a steep dark shaft of dirt
+and poison, the way lay. Yielding to his own disturbance of mind, and to
+his young companion’s agitation, which became greater every instant, Mr.
+Jarvis Lorry twice stopped to rest. Each of these stoppages was made
+at a doleful grating, by which any languishing good airs that were left
+uncorrupted, seemed to escape, and all spoilt and sickly vapours seemed
+to crawl in. Through the rusted bars, tastes, rather than glimpses, were
+caught of the jumbled neighbourhood; and nothing within range, nearer
+or lower than the summits of the two great towers of Notre-Dame, had any
+promise on it of healthy life or wholesome aspirations.
+
+At last, the top of the staircase was gained, and they stopped for the
+third time. There was yet an upper staircase, of a steeper inclination
+and of contracted dimensions, to be ascended, before the garret story
+was reached. The keeper of the wine-shop, always going a little in
+advance, and always going on the side which Mr. Lorry took, as though he
+dreaded to be asked any question by the young lady, turned himself about
+here, and, carefully feeling in the pockets of the coat he carried over
+his shoulder, took out a key.
+
+“The door is locked then, my friend?” said Mr. Lorry, surprised.
+
+“Ay. Yes,” was the grim reply of Monsieur Defarge.
+
+“You think it necessary to keep the unfortunate gentleman so retired?”
+
+“I think it necessary to turn the key.” Monsieur Defarge whispered it
+closer in his ear, and frowned heavily.
+
+“Why?”
+
+“Why! Because he has lived so long, locked up, that he would be
+frightened--rave--tear himself to pieces--die--come to I know not what
+harm--if his door was left open.”
+
+“Is it possible!” exclaimed Mr. Lorry.
+
+“Is it possible!” repeated Defarge, bitterly. “Yes. And a beautiful
+world we live in, when it _is_ possible, and when many other such things
+are possible, and not only possible, but done--done, see you!--under
+that sky there, every day. Long live the Devil. Let us go on.”
+
+This dialogue had been held in so very low a whisper, that not a word
+of it had reached the young lady’s ears. But, by this time she trembled
+under such strong emotion, and her face expressed such deep anxiety,
+and, above all, such dread and terror, that Mr. Lorry felt it incumbent
+on him to speak a word or two of reassurance.
+
+“Courage, dear miss! Courage! Business! The worst will be over in a
+moment; it is but passing the room-door, and the worst is over. Then,
+all the good you bring to him, all the relief, all the happiness you
+bring to him, begin. Let our good friend here, assist you on that side.
+That’s well, friend Defarge. Come, now. Business, business!”
+
+They went up slowly and softly. The staircase was short, and they were
+soon at the top. There, as it had an abrupt turn in it, they came all at
+once in sight of three men, whose heads were bent down close together at
+the side of a door, and who were intently looking into the room to which
+the door belonged, through some chinks or holes in the wall. On hearing
+footsteps close at hand, these three turned, and rose, and showed
+themselves to be the three of one name who had been drinking in the
+wine-shop.
+
+“I forgot them in the surprise of your visit,” explained Monsieur
+Defarge. “Leave us, good boys; we have business here.”
+
+The three glided by, and went silently down.
+
+There appearing to be no other door on that floor, and the keeper of
+the wine-shop going straight to this one when they were left alone, Mr.
+Lorry asked him in a whisper, with a little anger:
+
+“Do you make a show of Monsieur Manette?”
+
+“I show him, in the way you have seen, to a chosen few.”
+
+“Is that well?”
+
+“_I_ think it is well.”
+
+“Who are the few? How do you choose them?”
+
+“I choose them as real men, of my name--Jacques is my name--to whom the
+sight is likely to do good. Enough; you are English; that is another
+thing. Stay there, if you please, a little moment.”
+
+With an admonitory gesture to keep them back, he stooped, and looked in
+through the crevice in the wall. Soon raising his head again, he struck
+twice or thrice upon the door--evidently with no other object than to
+make a noise there. With the same intention, he drew the key across it,
+three or four times, before he put it clumsily into the lock, and turned
+it as heavily as he could.
+
+The door slowly opened inward under his hand, and he looked into the
+room and said something. A faint voice answered something. Little more
+than a single syllable could have been spoken on either side.
+
+He looked back over his shoulder, and beckoned them to enter. Mr. Lorry
+got his arm securely round the daughter’s waist, and held her; for he
+felt that she was sinking.
+
+“A-a-a-business, business!” he urged, with a moisture that was not of
+business shining on his cheek. “Come in, come in!”
+
+“I am afraid of it,” she answered, shuddering.
+
+“Of it? What?”
+
+“I mean of him. Of my father.”
+
+Rendered in a manner desperate, by her state and by the beckoning of
+their conductor, he drew over his neck the arm that shook upon his
+shoulder, lifted her a little, and hurried her into the room. He sat her
+down just within the door, and held her, clinging to him.
+
+Defarge drew out the key, closed the door, locked it on the inside,
+took out the key again, and held it in his hand. All this he did,
+methodically, and with as loud and harsh an accompaniment of noise as he
+could make. Finally, he walked across the room with a measured tread to
+where the window was. He stopped there, and faced round.
+
+The garret, built to be a depository for firewood and the like, was dim
+and dark: for, the window of dormer shape, was in truth a door in the
+roof, with a little crane over it for the hoisting up of stores from
+the street: unglazed, and closing up the middle in two pieces, like any
+other door of French construction. To exclude the cold, one half of this
+door was fast closed, and the other was opened but a very little way.
+Such a scanty portion of light was admitted through these means, that it
+was difficult, on first coming in, to see anything; and long habit
+alone could have slowly formed in any one, the ability to do any work
+requiring nicety in such obscurity. Yet, work of that kind was being
+done in the garret; for, with his back towards the door, and his face
+towards the window where the keeper of the wine-shop stood looking at
+him, a white-haired man sat on a low bench, stooping forward and very
+busy, making shoes.
+
+
+
+
+VI. The Shoemaker
+
+
+“Good day!” said Monsieur Defarge, looking down at the white head that
+bent low over the shoemaking.
+
+It was raised for a moment, and a very faint voice responded to the
+salutation, as if it were at a distance:
+
+“Good day!”
+
+“You are still hard at work, I see?”
+
+After a long silence, the head was lifted for another moment, and the
+voice replied, “Yes--I am working.” This time, a pair of haggard eyes
+had looked at the questioner, before the face had dropped again.
+
+The faintness of the voice was pitiable and dreadful. It was not the
+faintness of physical weakness, though confinement and hard fare no
+doubt had their part in it. Its deplorable peculiarity was, that it was
+the faintness of solitude and disuse. It was like the last feeble echo
+of a sound made long and long ago. So entirely had it lost the life and
+resonance of the human voice, that it affected the senses like a once
+beautiful colour faded away into a poor weak stain. So sunken and
+suppressed it was, that it was like a voice underground. So expressive
+it was, of a hopeless and lost creature, that a famished traveller,
+wearied out by lonely wandering in a wilderness, would have remembered
+home and friends in such a tone before lying down to die.
+
+Some minutes of silent work had passed: and the haggard eyes had looked
+up again: not with any interest or curiosity, but with a dull mechanical
+perception, beforehand, that the spot where the only visitor they were
+aware of had stood, was not yet empty.
+
+“I want,” said Defarge, who had not removed his gaze from the shoemaker,
+“to let in a little more light here. You can bear a little more?”
+
+The shoemaker stopped his work; looked with a vacant air of listening,
+at the floor on one side of him; then similarly, at the floor on the
+other side of him; then, upward at the speaker.
+
+“What did you say?”
+
+“You can bear a little more light?”
+
+“I must bear it, if you let it in.” (Laying the palest shadow of a
+stress upon the second word.)
+
+The opened half-door was opened a little further, and secured at that
+angle for the time. A broad ray of light fell into the garret, and
+showed the workman with an unfinished shoe upon his lap, pausing in his
+labour. His few common tools and various scraps of leather were at his
+feet and on his bench. He had a white beard, raggedly cut, but not very
+long, a hollow face, and exceedingly bright eyes. The hollowness and
+thinness of his face would have caused them to look large, under his yet
+dark eyebrows and his confused white hair, though they had been really
+otherwise; but, they were naturally large, and looked unnaturally so.
+His yellow rags of shirt lay open at the throat, and showed his body
+to be withered and worn. He, and his old canvas frock, and his loose
+stockings, and all his poor tatters of clothes, had, in a long seclusion
+from direct light and air, faded down to such a dull uniformity of
+parchment-yellow, that it would have been hard to say which was which.
+
+He had put up a hand between his eyes and the light, and the very bones
+of it seemed transparent. So he sat, with a steadfastly vacant gaze,
+pausing in his work. He never looked at the figure before him, without
+first looking down on this side of himself, then on that, as if he had
+lost the habit of associating place with sound; he never spoke, without
+first wandering in this manner, and forgetting to speak.
+
+“Are you going to finish that pair of shoes to-day?” asked Defarge,
+motioning to Mr. Lorry to come forward.
+
+“What did you say?”
+
+“Do you mean to finish that pair of shoes to-day?”
+
+“I can’t say that I mean to. I suppose so. I don’t know.”
+
+But, the question reminded him of his work, and he bent over it again.
+
+Mr. Lorry came silently forward, leaving the daughter by the door. When
+he had stood, for a minute or two, by the side of Defarge, the shoemaker
+looked up. He showed no surprise at seeing another figure, but the
+unsteady fingers of one of his hands strayed to his lips as he looked at
+it (his lips and his nails were of the same pale lead-colour), and then
+the hand dropped to his work, and he once more bent over the shoe. The
+look and the action had occupied but an instant.
+
+“You have a visitor, you see,” said Monsieur Defarge.
+
+“What did you say?”
+
+“Here is a visitor.”
+
+The shoemaker looked up as before, but without removing a hand from his
+work.
+
+“Come!” said Defarge. “Here is monsieur, who knows a well-made shoe when
+he sees one. Show him that shoe you are working at. Take it, monsieur.”
+
+Mr. Lorry took it in his hand.
+
+“Tell monsieur what kind of shoe it is, and the maker’s name.”
+
+There was a longer pause than usual, before the shoemaker replied:
+
+“I forget what it was you asked me. What did you say?”
+
+“I said, couldn’t you describe the kind of shoe, for monsieur’s
+information?”
+
+“It is a lady’s shoe. It is a young lady’s walking-shoe. It is in the
+present mode. I never saw the mode. I have had a pattern in my hand.” He
+glanced at the shoe with some little passing touch of pride.
+
+“And the maker’s name?” said Defarge.
+
+Now that he had no work to hold, he laid the knuckles of the right hand
+in the hollow of the left, and then the knuckles of the left hand in the
+hollow of the right, and then passed a hand across his bearded chin, and
+so on in regular changes, without a moment’s intermission. The task of
+recalling him from the vagrancy into which he always sank when he
+had spoken, was like recalling some very weak person from a swoon, or
+endeavouring, in the hope of some disclosure, to stay the spirit of a
+fast-dying man.
+
+“Did you ask me for my name?”
+
+“Assuredly I did.”
+
+“One Hundred and Five, North Tower.”
+
+“Is that all?”
+
+“One Hundred and Five, North Tower.”
+
+With a weary sound that was not a sigh, nor a groan, he bent to work
+again, until the silence was again broken.
+
+“You are not a shoemaker by trade?” said Mr. Lorry, looking steadfastly
+at him.
+
+His haggard eyes turned to Defarge as if he would have transferred the
+question to him: but as no help came from that quarter, they turned back
+on the questioner when they had sought the ground.
+
+“I am not a shoemaker by trade? No, I was not a shoemaker by trade. I-I
+learnt it here. I taught myself. I asked leave to--”
+
+He lapsed away, even for minutes, ringing those measured changes on his
+hands the whole time. His eyes came slowly back, at last, to the face
+from which they had wandered; when they rested on it, he started, and
+resumed, in the manner of a sleeper that moment awake, reverting to a
+subject of last night.
+
+“I asked leave to teach myself, and I got it with much difficulty after
+a long while, and I have made shoes ever since.”
+
+As he held out his hand for the shoe that had been taken from him, Mr.
+Lorry said, still looking steadfastly in his face:
+
+“Monsieur Manette, do you remember nothing of me?”
+
+The shoe dropped to the ground, and he sat looking fixedly at the
+questioner.
+
+“Monsieur Manette”; Mr. Lorry laid his hand upon Defarge’s arm; “do you
+remember nothing of this man? Look at him. Look at me. Is there no old
+banker, no old business, no old servant, no old time, rising in your
+mind, Monsieur Manette?”
+
+As the captive of many years sat looking fixedly, by turns, at Mr.
+Lorry and at Defarge, some long obliterated marks of an actively intent
+intelligence in the middle of the forehead, gradually forced themselves
+through the black mist that had fallen on him. They were overclouded
+again, they were fainter, they were gone; but they had been there. And
+so exactly was the expression repeated on the fair young face of her who
+had crept along the wall to a point where she could see him, and where
+she now stood looking at him, with hands which at first had been only
+raised in frightened compassion, if not even to keep him off and
+shut out the sight of him, but which were now extending towards him,
+trembling with eagerness to lay the spectral face upon her warm young
+breast, and love it back to life and hope--so exactly was the expression
+repeated (though in stronger characters) on her fair young face, that it
+looked as though it had passed like a moving light, from him to her.
+
+Darkness had fallen on him in its place. He looked at the two, less and
+less attentively, and his eyes in gloomy abstraction sought the ground
+and looked about him in the old way. Finally, with a deep long sigh, he
+took the shoe up, and resumed his work.
+
+“Have you recognised him, monsieur?” asked Defarge in a whisper.
+
+“Yes; for a moment. At first I thought it quite hopeless, but I have
+unquestionably seen, for a single moment, the face that I once knew so
+well. Hush! Let us draw further back. Hush!”
+
+She had moved from the wall of the garret, very near to the bench on
+which he sat. There was something awful in his unconsciousness of the
+figure that could have put out its hand and touched him as he stooped
+over his labour.
+
+Not a word was spoken, not a sound was made. She stood, like a spirit,
+beside him, and he bent over his work.
+
+It happened, at length, that he had occasion to change the instrument
+in his hand, for his shoemaker’s knife. It lay on that side of him
+which was not the side on which she stood. He had taken it up, and was
+stooping to work again, when his eyes caught the skirt of her dress. He
+raised them, and saw her face. The two spectators started forward,
+but she stayed them with a motion of her hand. She had no fear of his
+striking at her with the knife, though they had.
+
+He stared at her with a fearful look, and after a while his lips began
+to form some words, though no sound proceeded from them. By degrees, in
+the pauses of his quick and laboured breathing, he was heard to say:
+
+“What is this?”
+
+With the tears streaming down her face, she put her two hands to her
+lips, and kissed them to him; then clasped them on her breast, as if she
+laid his ruined head there.
+
+“You are not the gaoler’s daughter?”
+
+She sighed “No.”
+
+“Who are you?”
+
+Not yet trusting the tones of her voice, she sat down on the bench
+beside him. He recoiled, but she laid her hand upon his arm. A strange
+thrill struck him when she did so, and visibly passed over his frame; he
+laid the knife down softly, as he sat staring at her.
+
+Her golden hair, which she wore in long curls, had been hurriedly pushed
+aside, and fell down over her neck. Advancing his hand by little and
+little, he took it up and looked at it. In the midst of the action
+he went astray, and, with another deep sigh, fell to work at his
+shoemaking.
+
+But not for long. Releasing his arm, she laid her hand upon his
+shoulder. After looking doubtfully at it, two or three times, as if to
+be sure that it was really there, he laid down his work, put his hand
+to his neck, and took off a blackened string with a scrap of folded rag
+attached to it. He opened this, carefully, on his knee, and it contained
+a very little quantity of hair: not more than one or two long golden
+hairs, which he had, in some old day, wound off upon his finger.
+
+He took her hair into his hand again, and looked closely at it. “It is
+the same. How can it be! When was it! How was it!”
+
+As the concentrated expression returned to his forehead, he seemed to
+become conscious that it was in hers too. He turned her full to the
+light, and looked at her.
+
+“She had laid her head upon my shoulder, that night when I was summoned
+out--she had a fear of my going, though I had none--and when I was
+brought to the North Tower they found these upon my sleeve. ‘You will
+leave me them? They can never help me to escape in the body, though they
+may in the spirit.’ Those were the words I said. I remember them very
+well.”
+
+He formed this speech with his lips many times before he could utter it.
+But when he did find spoken words for it, they came to him coherently,
+though slowly.
+
+“How was this?--_Was it you_?”
+
+Once more, the two spectators started, as he turned upon her with a
+frightful suddenness. But she sat perfectly still in his grasp, and only
+said, in a low voice, “I entreat you, good gentlemen, do not come near
+us, do not speak, do not move!”
+
+“Hark!” he exclaimed. “Whose voice was that?”
+
+His hands released her as he uttered this cry, and went up to his white
+hair, which they tore in a frenzy. It died out, as everything but his
+shoemaking did die out of him, and he refolded his little packet and
+tried to secure it in his breast; but he still looked at her, and
+gloomily shook his head.
+
+“No, no, no; you are too young, too blooming. It can’t be. See what the
+prisoner is. These are not the hands she knew, this is not the face
+she knew, this is not a voice she ever heard. No, no. She was--and He
+was--before the slow years of the North Tower--ages ago. What is your
+name, my gentle angel?”
+
+Hailing his softened tone and manner, his daughter fell upon her knees
+before him, with her appealing hands upon his breast.
+
+“O, sir, at another time you shall know my name, and who my mother was,
+and who my father, and how I never knew their hard, hard history. But I
+cannot tell you at this time, and I cannot tell you here. All that I may
+tell you, here and now, is, that I pray to you to touch me and to bless
+me. Kiss me, kiss me! O my dear, my dear!”
+
+His cold white head mingled with her radiant hair, which warmed and
+lighted it as though it were the light of Freedom shining on him.
+
+“If you hear in my voice--I don’t know that it is so, but I hope it
+is--if you hear in my voice any resemblance to a voice that once was
+sweet music in your ears, weep for it, weep for it! If you touch, in
+touching my hair, anything that recalls a beloved head that lay on your
+breast when you were young and free, weep for it, weep for it! If, when
+I hint to you of a Home that is before us, where I will be true to you
+with all my duty and with all my faithful service, I bring back the
+remembrance of a Home long desolate, while your poor heart pined away,
+weep for it, weep for it!”
+
+She held him closer round the neck, and rocked him on her breast like a
+child.
+
+“If, when I tell you, dearest dear, that your agony is over, and that I
+have come here to take you from it, and that we go to England to be at
+peace and at rest, I cause you to think of your useful life laid waste,
+and of our native France so wicked to you, weep for it, weep for it! And
+if, when I shall tell you of my name, and of my father who is living,
+and of my mother who is dead, you learn that I have to kneel to my
+honoured father, and implore his pardon for having never for his sake
+striven all day and lain awake and wept all night, because the love of
+my poor mother hid his torture from me, weep for it, weep for it! Weep
+for her, then, and for me! Good gentlemen, thank God! I feel his sacred
+tears upon my face, and his sobs strike against my heart. O, see! Thank
+God for us, thank God!”
+
+He had sunk in her arms, and his face dropped on her breast: a sight so
+touching, yet so terrible in the tremendous wrong and suffering which
+had gone before it, that the two beholders covered their faces.
+
+When the quiet of the garret had been long undisturbed, and his heaving
+breast and shaken form had long yielded to the calm that must follow all
+storms--emblem to humanity, of the rest and silence into which the storm
+called Life must hush at last--they came forward to raise the father and
+daughter from the ground. He had gradually dropped to the floor, and lay
+there in a lethargy, worn out. She had nestled down with him, that his
+head might lie upon her arm; and her hair drooping over him curtained
+him from the light.
+
+“If, without disturbing him,” she said, raising her hand to Mr. Lorry as
+he stooped over them, after repeated blowings of his nose, “all could be
+arranged for our leaving Paris at once, so that, from the very door, he
+could be taken away--”
+
+“But, consider. Is he fit for the journey?” asked Mr. Lorry.
+
+“More fit for that, I think, than to remain in this city, so dreadful to
+him.”
+
+“It is true,” said Defarge, who was kneeling to look on and hear. “More
+than that; Monsieur Manette is, for all reasons, best out of France.
+Say, shall I hire a carriage and post-horses?”
+
+“That’s business,” said Mr. Lorry, resuming on the shortest notice his
+methodical manners; “and if business is to be done, I had better do it.”
+
+“Then be so kind,” urged Miss Manette, “as to leave us here. You see how
+composed he has become, and you cannot be afraid to leave him with me
+now. Why should you be? If you will lock the door to secure us from
+interruption, I do not doubt that you will find him, when you come back,
+as quiet as you leave him. In any case, I will take care of him until
+you return, and then we will remove him straight.”
+
+Both Mr. Lorry and Defarge were rather disinclined to this course, and
+in favour of one of them remaining. But, as there were not only carriage
+and horses to be seen to, but travelling papers; and as time pressed,
+for the day was drawing to an end, it came at last to their hastily
+dividing the business that was necessary to be done, and hurrying away
+to do it.
+
+Then, as the darkness closed in, the daughter laid her head down on the
+hard ground close at the father’s side, and watched him. The darkness
+deepened and deepened, and they both lay quiet, until a light gleamed
+through the chinks in the wall.
+
+Mr. Lorry and Monsieur Defarge had made all ready for the journey, and
+had brought with them, besides travelling cloaks and wrappers, bread and
+meat, wine, and hot coffee. Monsieur Defarge put this provender, and the
+lamp he carried, on the shoemaker’s bench (there was nothing else in the
+garret but a pallet bed), and he and Mr. Lorry roused the captive, and
+assisted him to his feet.
+
+No human intelligence could have read the mysteries of his mind, in
+the scared blank wonder of his face. Whether he knew what had happened,
+whether he recollected what they had said to him, whether he knew that
+he was free, were questions which no sagacity could have solved. They
+tried speaking to him; but, he was so confused, and so very slow to
+answer, that they took fright at his bewilderment, and agreed for
+the time to tamper with him no more. He had a wild, lost manner of
+occasionally clasping his head in his hands, that had not been seen
+in him before; yet, he had some pleasure in the mere sound of his
+daughter’s voice, and invariably turned to it when she spoke.
+
+In the submissive way of one long accustomed to obey under coercion, he
+ate and drank what they gave him to eat and drink, and put on the cloak
+and other wrappings, that they gave him to wear. He readily responded to
+his daughter’s drawing her arm through his, and took--and kept--her hand
+in both his own.
+
+They began to descend; Monsieur Defarge going first with the lamp, Mr.
+Lorry closing the little procession. They had not traversed many steps
+of the long main staircase when he stopped, and stared at the roof and
+round at the walls.
+
+“You remember the place, my father? You remember coming up here?”
+
+“What did you say?”
+
+But, before she could repeat the question, he murmured an answer as if
+she had repeated it.
+
+“Remember? No, I don’t remember. It was so very long ago.”
+
+That he had no recollection whatever of his having been brought from his
+prison to that house, was apparent to them. They heard him mutter,
+“One Hundred and Five, North Tower;” and when he looked about him, it
+evidently was for the strong fortress-walls which had long encompassed
+him. On their reaching the courtyard he instinctively altered his
+tread, as being in expectation of a drawbridge; and when there was
+no drawbridge, and he saw the carriage waiting in the open street, he
+dropped his daughter’s hand and clasped his head again.
+
+No crowd was about the door; no people were discernible at any of the
+many windows; not even a chance passerby was in the street. An unnatural
+silence and desertion reigned there. Only one soul was to be seen, and
+that was Madame Defarge--who leaned against the door-post, knitting, and
+saw nothing.
+
+The prisoner had got into a coach, and his daughter had followed
+him, when Mr. Lorry’s feet were arrested on the step by his asking,
+miserably, for his shoemaking tools and the unfinished shoes. Madame
+Defarge immediately called to her husband that she would get them, and
+went, knitting, out of the lamplight, through the courtyard. She quickly
+brought them down and handed them in;--and immediately afterwards leaned
+against the door-post, knitting, and saw nothing.
+
+Defarge got upon the box, and gave the word “To the Barrier!” The
+postilion cracked his whip, and they clattered away under the feeble
+over-swinging lamps.
+
+Under the over-swinging lamps--swinging ever brighter in the better
+streets, and ever dimmer in the worse--and by lighted shops, gay crowds,
+illuminated coffee-houses, and theatre-doors, to one of the city
+gates. Soldiers with lanterns, at the guard-house there. “Your papers,
+travellers!” “See here then, Monsieur the Officer,” said Defarge,
+getting down, and taking him gravely apart, “these are the papers of
+monsieur inside, with the white head. They were consigned to me, with
+him, at the--” He dropped his voice, there was a flutter among the
+military lanterns, and one of them being handed into the coach by an arm
+in uniform, the eyes connected with the arm looked, not an every day
+or an every night look, at monsieur with the white head. “It is well.
+Forward!” from the uniform. “Adieu!” from Defarge. And so, under a short
+grove of feebler and feebler over-swinging lamps, out under the great
+grove of stars.
+
+Beneath that arch of unmoved and eternal lights; some, so remote from
+this little earth that the learned tell us it is doubtful whether their
+rays have even yet discovered it, as a point in space where anything
+is suffered or done: the shadows of the night were broad and black.
+All through the cold and restless interval, until dawn, they once more
+whispered in the ears of Mr. Jarvis Lorry--sitting opposite the buried
+man who had been dug out, and wondering what subtle powers were for ever
+lost to him, and what were capable of restoration--the old inquiry:
+
+“I hope you care to be recalled to life?”
+
+And the old answer:
+
+“I can’t say.”
+
+
+The end of the first book.
+
+
+
+
+
+Book the Second--the Golden Thread
+
+
+
+
+I. Five Years Later
+
+
+Tellson’s Bank by Temple Bar was an old-fashioned place, even in the
+year one thousand seven hundred and eighty. It was very small, very
+dark, very ugly, very incommodious. It was an old-fashioned place,
+moreover, in the moral attribute that the partners in the House were
+proud of its smallness, proud of its darkness, proud of its ugliness,
+proud of its incommodiousness. They were even boastful of its eminence
+in those particulars, and were fired by an express conviction that, if
+it were less objectionable, it would be less respectable. This was
+no passive belief, but an active weapon which they flashed at more
+convenient places of business. Tellson’s (they said) wanted
+no elbow-room, Tellson’s wanted no light, Tellson’s wanted no
+embellishment. Noakes and Co.’s might, or Snooks Brothers’ might; but
+Tellson’s, thank Heaven--!
+
+Any one of these partners would have disinherited his son on the
+question of rebuilding Tellson’s. In this respect the House was much
+on a par with the Country; which did very often disinherit its sons for
+suggesting improvements in laws and customs that had long been highly
+objectionable, but were only the more respectable.
+
+Thus it had come to pass, that Tellson’s was the triumphant perfection
+of inconvenience. After bursting open a door of idiotic obstinacy with
+a weak rattle in its throat, you fell into Tellson’s down two steps,
+and came to your senses in a miserable little shop, with two little
+counters, where the oldest of men made your cheque shake as if the
+wind rustled it, while they examined the signature by the dingiest of
+windows, which were always under a shower-bath of mud from Fleet-street,
+and which were made the dingier by their own iron bars proper, and the
+heavy shadow of Temple Bar. If your business necessitated your seeing
+“the House,” you were put into a species of Condemned Hold at the back,
+where you meditated on a misspent life, until the House came with its
+hands in its pockets, and you could hardly blink at it in the dismal
+twilight. Your money came out of, or went into, wormy old wooden
+drawers, particles of which flew up your nose and down your throat when
+they were opened and shut. Your bank-notes had a musty odour, as if they
+were fast decomposing into rags again. Your plate was stowed away among
+the neighbouring cesspools, and evil communications corrupted its good
+polish in a day or two. Your deeds got into extemporised strong-rooms
+made of kitchens and sculleries, and fretted all the fat out of their
+parchments into the banking-house air. Your lighter boxes of family
+papers went up-stairs into a Barmecide room, that always had a great
+dining-table in it and never had a dinner, and where, even in the year
+one thousand seven hundred and eighty, the first letters written to you
+by your old love, or by your little children, were but newly released
+from the horror of being ogled through the windows, by the heads
+exposed on Temple Bar with an insensate brutality and ferocity worthy of
+Abyssinia or Ashantee.
+
+But indeed, at that time, putting to death was a recipe much in vogue
+with all trades and professions, and not least of all with Tellson’s.
+Death is Nature’s remedy for all things, and why not Legislation’s?
+Accordingly, the forger was put to Death; the utterer of a bad note
+was put to Death; the unlawful opener of a letter was put to Death; the
+purloiner of forty shillings and sixpence was put to Death; the holder
+of a horse at Tellson’s door, who made off with it, was put to
+Death; the coiner of a bad shilling was put to Death; the sounders of
+three-fourths of the notes in the whole gamut of Crime, were put to
+Death. Not that it did the least good in the way of prevention--it
+might almost have been worth remarking that the fact was exactly the
+reverse--but, it cleared off (as to this world) the trouble of each
+particular case, and left nothing else connected with it to be looked
+after. Thus, Tellson’s, in its day, like greater places of business,
+its contemporaries, had taken so many lives, that, if the heads laid
+low before it had been ranged on Temple Bar instead of being privately
+disposed of, they would probably have excluded what little light the
+ground floor had, in a rather significant manner.
+
+Cramped in all kinds of dim cupboards and hutches at Tellson’s, the
+oldest of men carried on the business gravely. When they took a young
+man into Tellson’s London house, they hid him somewhere till he was
+old. They kept him in a dark place, like a cheese, until he had the full
+Tellson flavour and blue-mould upon him. Then only was he permitted to
+be seen, spectacularly poring over large books, and casting his breeches
+and gaiters into the general weight of the establishment.
+
+Outside Tellson’s--never by any means in it, unless called in--was an
+odd-job-man, an occasional porter and messenger, who served as the live
+sign of the house. He was never absent during business hours, unless
+upon an errand, and then he was represented by his son: a grisly urchin
+of twelve, who was his express image. People understood that Tellson’s,
+in a stately way, tolerated the odd-job-man. The house had always
+tolerated some person in that capacity, and time and tide had drifted
+this person to the post. His surname was Cruncher, and on the youthful
+occasion of his renouncing by proxy the works of darkness, in the
+easterly parish church of Hounsditch, he had received the added
+appellation of Jerry.
+
+The scene was Mr. Cruncher’s private lodging in Hanging-sword-alley,
+Whitefriars: the time, half-past seven of the clock on a windy March
+morning, Anno Domini seventeen hundred and eighty. (Mr. Cruncher himself
+always spoke of the year of our Lord as Anna Dominoes: apparently under
+the impression that the Christian era dated from the invention of a
+popular game, by a lady who had bestowed her name upon it.)
+
+Mr. Cruncher’s apartments were not in a savoury neighbourhood, and were
+but two in number, even if a closet with a single pane of glass in it
+might be counted as one. But they were very decently kept. Early as
+it was, on the windy March morning, the room in which he lay abed was
+already scrubbed throughout; and between the cups and saucers arranged
+for breakfast, and the lumbering deal table, a very clean white cloth
+was spread.
+
+Mr. Cruncher reposed under a patchwork counterpane, like a Harlequin
+at home. At first, he slept heavily, but, by degrees, began to roll
+and surge in bed, until he rose above the surface, with his spiky hair
+looking as if it must tear the sheets to ribbons. At which juncture, he
+exclaimed, in a voice of dire exasperation:
+
+“Bust me, if she ain’t at it agin!”
+
+A woman of orderly and industrious appearance rose from her knees in a
+corner, with sufficient haste and trepidation to show that she was the
+person referred to.
+
+“What!” said Mr. Cruncher, looking out of bed for a boot. “You’re at it
+agin, are you?”
+
+After hailing the morn with this second salutation, he threw a boot at
+the woman as a third. It was a very muddy boot, and may introduce the
+odd circumstance connected with Mr. Cruncher’s domestic economy, that,
+whereas he often came home after banking hours with clean boots, he
+often got up next morning to find the same boots covered with clay.
+
+“What,” said Mr. Cruncher, varying his apostrophe after missing his
+mark--“what are you up to, Aggerawayter?”
+
+“I was only saying my prayers.”
+
+“Saying your prayers! You’re a nice woman! What do you mean by flopping
+yourself down and praying agin me?”
+
+“I was not praying against you; I was praying for you.”
+
+“You weren’t. And if you were, I won’t be took the liberty with. Here!
+your mother’s a nice woman, young Jerry, going a praying agin your
+father’s prosperity. You’ve got a dutiful mother, you have, my son.
+You’ve got a religious mother, you have, my boy: going and flopping
+herself down, and praying that the bread-and-butter may be snatched out
+of the mouth of her only child.”
+
+Master Cruncher (who was in his shirt) took this very ill, and, turning
+to his mother, strongly deprecated any praying away of his personal
+board.
+
+“And what do you suppose, you conceited female,” said Mr. Cruncher, with
+unconscious inconsistency, “that the worth of _your_ prayers may be?
+Name the price that you put _your_ prayers at!”
+
+“They only come from the heart, Jerry. They are worth no more than
+that.”
+
+“Worth no more than that,” repeated Mr. Cruncher. “They ain’t worth
+much, then. Whether or no, I won’t be prayed agin, I tell you. I can’t
+afford it. I’m not a going to be made unlucky by _your_ sneaking. If
+you must go flopping yourself down, flop in favour of your husband and
+child, and not in opposition to ‘em. If I had had any but a unnat’ral
+wife, and this poor boy had had any but a unnat’ral mother, I might
+have made some money last week instead of being counter-prayed and
+countermined and religiously circumwented into the worst of luck.
+B-u-u-ust me!” said Mr. Cruncher, who all this time had been putting
+on his clothes, “if I ain’t, what with piety and one blowed thing and
+another, been choused this last week into as bad luck as ever a poor
+devil of a honest tradesman met with! Young Jerry, dress yourself, my
+boy, and while I clean my boots keep a eye upon your mother now and
+then, and if you see any signs of more flopping, give me a call. For, I
+tell you,” here he addressed his wife once more, “I won’t be gone agin,
+in this manner. I am as rickety as a hackney-coach, I’m as sleepy as
+laudanum, my lines is strained to that degree that I shouldn’t know, if
+it wasn’t for the pain in ‘em, which was me and which somebody else, yet
+I’m none the better for it in pocket; and it’s my suspicion that you’ve
+been at it from morning to night to prevent me from being the better for
+it in pocket, and I won’t put up with it, Aggerawayter, and what do you
+say now!”
+
+Growling, in addition, such phrases as “Ah! yes! You’re religious, too.
+You wouldn’t put yourself in opposition to the interests of your husband
+and child, would you? Not you!” and throwing off other sarcastic sparks
+from the whirling grindstone of his indignation, Mr. Cruncher betook
+himself to his boot-cleaning and his general preparation for business.
+In the meantime, his son, whose head was garnished with tenderer spikes,
+and whose young eyes stood close by one another, as his father’s did,
+kept the required watch upon his mother. He greatly disturbed that poor
+woman at intervals, by darting out of his sleeping closet, where he made
+his toilet, with a suppressed cry of “You are going to flop, mother.
+--Halloa, father!” and, after raising this fictitious alarm, darting in
+again with an undutiful grin.
+
+Mr. Cruncher’s temper was not at all improved when he came to his
+breakfast. He resented Mrs. Cruncher’s saying grace with particular
+animosity.
+
+“Now, Aggerawayter! What are you up to? At it again?”
+
+His wife explained that she had merely “asked a blessing.”
+
+“Don’t do it!” said Mr. Crunches looking about, as if he rather expected
+to see the loaf disappear under the efficacy of his wife’s petitions. “I
+ain’t a going to be blest out of house and home. I won’t have my wittles
+blest off my table. Keep still!”
+
+Exceedingly red-eyed and grim, as if he had been up all night at a party
+which had taken anything but a convivial turn, Jerry Cruncher worried
+his breakfast rather than ate it, growling over it like any four-footed
+inmate of a menagerie. Towards nine o’clock he smoothed his ruffled
+aspect, and, presenting as respectable and business-like an exterior as
+he could overlay his natural self with, issued forth to the occupation
+of the day.
+
+It could scarcely be called a trade, in spite of his favourite
+description of himself as “a honest tradesman.” His stock consisted of
+a wooden stool, made out of a broken-backed chair cut down, which stool,
+young Jerry, walking at his father’s side, carried every morning to
+beneath the banking-house window that was nearest Temple Bar: where,
+with the addition of the first handful of straw that could be gleaned
+from any passing vehicle to keep the cold and wet from the odd-job-man’s
+feet, it formed the encampment for the day. On this post of his, Mr.
+Cruncher was as well known to Fleet-street and the Temple, as the Bar
+itself,--and was almost as in-looking.
+
+Encamped at a quarter before nine, in good time to touch his
+three-cornered hat to the oldest of men as they passed in to Tellson’s,
+Jerry took up his station on this windy March morning, with young Jerry
+standing by him, when not engaged in making forays through the Bar, to
+inflict bodily and mental injuries of an acute description on passing
+boys who were small enough for his amiable purpose. Father and son,
+extremely like each other, looking silently on at the morning traffic
+in Fleet-street, with their two heads as near to one another as the two
+eyes of each were, bore a considerable resemblance to a pair of monkeys.
+The resemblance was not lessened by the accidental circumstance, that
+the mature Jerry bit and spat out straw, while the twinkling eyes of the
+youthful Jerry were as restlessly watchful of him as of everything else
+in Fleet-street.
+
+The head of one of the regular indoor messengers attached to Tellson’s
+establishment was put through the door, and the word was given:
+
+“Porter wanted!”
+
+“Hooray, father! Here’s an early job to begin with!”
+
+Having thus given his parent God speed, young Jerry seated himself on
+the stool, entered on his reversionary interest in the straw his father
+had been chewing, and cogitated.
+
+“Al-ways rusty! His fingers is al-ways rusty!” muttered young Jerry.
+“Where does my father get all that iron rust from? He don’t get no iron
+rust here!”
+
+
+
+
+II. A Sight
+
+
+“You know the Old Bailey well, no doubt?” said one of the oldest of
+clerks to Jerry the messenger.
+
+“Ye-es, sir,” returned Jerry, in something of a dogged manner. “I _do_
+know the Bailey.”
+
+“Just so. And you know Mr. Lorry.”
+
+“I know Mr. Lorry, sir, much better than I know the Bailey. Much
+better,” said Jerry, not unlike a reluctant witness at the establishment
+in question, “than I, as a honest tradesman, wish to know the Bailey.”
+
+“Very well. Find the door where the witnesses go in, and show the
+door-keeper this note for Mr. Lorry. He will then let you in.”
+
+“Into the court, sir?”
+
+“Into the court.”
+
+Mr. Cruncher’s eyes seemed to get a little closer to one another, and to
+interchange the inquiry, “What do you think of this?”
+
+“Am I to wait in the court, sir?” he asked, as the result of that
+conference.
+
+“I am going to tell you. The door-keeper will pass the note to Mr.
+Lorry, and do you make any gesture that will attract Mr. Lorry’s
+attention, and show him where you stand. Then what you have to do, is,
+to remain there until he wants you.”
+
+“Is that all, sir?”
+
+“That’s all. He wishes to have a messenger at hand. This is to tell him
+you are there.”
+
+As the ancient clerk deliberately folded and superscribed the note,
+Mr. Cruncher, after surveying him in silence until he came to the
+blotting-paper stage, remarked:
+
+“I suppose they’ll be trying Forgeries this morning?”
+
+“Treason!”
+
+“That’s quartering,” said Jerry. “Barbarous!”
+
+“It is the law,” remarked the ancient clerk, turning his surprised
+spectacles upon him. “It is the law.”
+
+“It’s hard in the law to spile a man, I think. It’s hard enough to kill
+him, but it’s wery hard to spile him, sir.”
+
+“Not at all,” retained the ancient clerk. “Speak well of the law. Take
+care of your chest and voice, my good friend, and leave the law to take
+care of itself. I give you that advice.”
+
+“It’s the damp, sir, what settles on my chest and voice,” said Jerry. “I
+leave you to judge what a damp way of earning a living mine is.”
+
+“Well, well,” said the old clerk; “we all have our various ways of
+gaining a livelihood. Some of us have damp ways, and some of us have dry
+ways. Here is the letter. Go along.”
+
+Jerry took the letter, and, remarking to himself with less internal
+deference than he made an outward show of, “You are a lean old one,
+too,” made his bow, informed his son, in passing, of his destination,
+and went his way.
+
+They hanged at Tyburn, in those days, so the street outside Newgate had
+not obtained one infamous notoriety that has since attached to it.
+But, the gaol was a vile place, in which most kinds of debauchery and
+villainy were practised, and where dire diseases were bred, that came
+into court with the prisoners, and sometimes rushed straight from the
+dock at my Lord Chief Justice himself, and pulled him off the bench. It
+had more than once happened, that the Judge in the black cap pronounced
+his own doom as certainly as the prisoner’s, and even died before him.
+For the rest, the Old Bailey was famous as a kind of deadly inn-yard,
+from which pale travellers set out continually, in carts and coaches, on
+a violent passage into the other world: traversing some two miles and a
+half of public street and road, and shaming few good citizens, if any.
+So powerful is use, and so desirable to be good use in the beginning. It
+was famous, too, for the pillory, a wise old institution, that inflicted
+a punishment of which no one could foresee the extent; also, for
+the whipping-post, another dear old institution, very humanising and
+softening to behold in action; also, for extensive transactions in
+blood-money, another fragment of ancestral wisdom, systematically
+leading to the most frightful mercenary crimes that could be committed
+under Heaven. Altogether, the Old Bailey, at that date, was a choice
+illustration of the precept, that “Whatever is is right;” an aphorism
+that would be as final as it is lazy, did it not include the troublesome
+consequence, that nothing that ever was, was wrong.
+
+Making his way through the tainted crowd, dispersed up and down this
+hideous scene of action, with the skill of a man accustomed to make his
+way quietly, the messenger found out the door he sought, and handed in
+his letter through a trap in it. For, people then paid to see the play
+at the Old Bailey, just as they paid to see the play in Bedlam--only the
+former entertainment was much the dearer. Therefore, all the Old Bailey
+doors were well guarded--except, indeed, the social doors by which the
+criminals got there, and those were always left wide open.
+
+After some delay and demur, the door grudgingly turned on its hinges a
+very little way, and allowed Mr. Jerry Cruncher to squeeze himself into
+court.
+
+“What’s on?” he asked, in a whisper, of the man he found himself next
+to.
+
+“Nothing yet.”
+
+“What’s coming on?”
+
+“The Treason case.”
+
+“The quartering one, eh?”
+
+“Ah!” returned the man, with a relish; “he’ll be drawn on a hurdle to
+be half hanged, and then he’ll be taken down and sliced before his own
+face, and then his inside will be taken out and burnt while he looks on,
+and then his head will be chopped off, and he’ll be cut into quarters.
+That’s the sentence.”
+
+“If he’s found Guilty, you mean to say?” Jerry added, by way of proviso.
+
+“Oh! they’ll find him guilty,” said the other. “Don’t you be afraid of
+that.”
+
+Mr. Cruncher’s attention was here diverted to the door-keeper, whom he
+saw making his way to Mr. Lorry, with the note in his hand. Mr. Lorry
+sat at a table, among the gentlemen in wigs: not far from a wigged
+gentleman, the prisoner’s counsel, who had a great bundle of papers
+before him: and nearly opposite another wigged gentleman with his hands
+in his pockets, whose whole attention, when Mr. Cruncher looked at him
+then or afterwards, seemed to be concentrated on the ceiling of the
+court. After some gruff coughing and rubbing of his chin and signing
+with his hand, Jerry attracted the notice of Mr. Lorry, who had stood up
+to look for him, and who quietly nodded and sat down again.
+
+“What’s _he_ got to do with the case?” asked the man he had spoken with.
+
+“Blest if I know,” said Jerry.
+
+“What have _you_ got to do with it, then, if a person may inquire?”
+
+“Blest if I know that either,” said Jerry.
+
+The entrance of the Judge, and a consequent great stir and settling
+down in the court, stopped the dialogue. Presently, the dock became the
+central point of interest. Two gaolers, who had been standing there,
+went out, and the prisoner was brought in, and put to the bar.
+
+Everybody present, except the one wigged gentleman who looked at the
+ceiling, stared at him. All the human breath in the place, rolled
+at him, like a sea, or a wind, or a fire. Eager faces strained round
+pillars and corners, to get a sight of him; spectators in back rows
+stood up, not to miss a hair of him; people on the floor of the court,
+laid their hands on the shoulders of the people before them, to help
+themselves, at anybody’s cost, to a view of him--stood a-tiptoe, got
+upon ledges, stood upon next to nothing, to see every inch of him.
+Conspicuous among these latter, like an animated bit of the spiked wall
+of Newgate, Jerry stood: aiming at the prisoner the beery breath of a
+whet he had taken as he came along, and discharging it to mingle with
+the waves of other beer, and gin, and tea, and coffee, and what not,
+that flowed at him, and already broke upon the great windows behind him
+in an impure mist and rain.
+
+The object of all this staring and blaring, was a young man of about
+five-and-twenty, well-grown and well-looking, with a sunburnt cheek and
+a dark eye. His condition was that of a young gentleman. He was plainly
+dressed in black, or very dark grey, and his hair, which was long and
+dark, was gathered in a ribbon at the back of his neck; more to be out
+of his way than for ornament. As an emotion of the mind will express
+itself through any covering of the body, so the paleness which his
+situation engendered came through the brown upon his cheek, showing the
+soul to be stronger than the sun. He was otherwise quite self-possessed,
+bowed to the Judge, and stood quiet.
+
+The sort of interest with which this man was stared and breathed at,
+was not a sort that elevated humanity. Had he stood in peril of a less
+horrible sentence--had there been a chance of any one of its savage
+details being spared--by just so much would he have lost in his
+fascination. The form that was to be doomed to be so shamefully mangled,
+was the sight; the immortal creature that was to be so butchered
+and torn asunder, yielded the sensation. Whatever gloss the various
+spectators put upon the interest, according to their several arts and
+powers of self-deceit, the interest was, at the root of it, Ogreish.
+
+Silence in the court! Charles Darnay had yesterday pleaded Not Guilty to
+an indictment denouncing him (with infinite jingle and jangle) for that
+he was a false traitor to our serene, illustrious, excellent, and so
+forth, prince, our Lord the King, by reason of his having, on divers
+occasions, and by divers means and ways, assisted Lewis, the French
+King, in his wars against our said serene, illustrious, excellent, and
+so forth; that was to say, by coming and going, between the dominions of
+our said serene, illustrious, excellent, and so forth, and those of the
+said French Lewis, and wickedly, falsely, traitorously, and otherwise
+evil-adverbiously, revealing to the said French Lewis what forces our
+said serene, illustrious, excellent, and so forth, had in preparation
+to send to Canada and North America. This much, Jerry, with his head
+becoming more and more spiky as the law terms bristled it, made out with
+huge satisfaction, and so arrived circuitously at the understanding that
+the aforesaid, and over and over again aforesaid, Charles Darnay, stood
+there before him upon his trial; that the jury were swearing in; and
+that Mr. Attorney-General was making ready to speak.
+
+The accused, who was (and who knew he was) being mentally hanged,
+beheaded, and quartered, by everybody there, neither flinched from
+the situation, nor assumed any theatrical air in it. He was quiet and
+attentive; watched the opening proceedings with a grave interest;
+and stood with his hands resting on the slab of wood before him, so
+composedly, that they had not displaced a leaf of the herbs with which
+it was strewn. The court was all bestrewn with herbs and sprinkled with
+vinegar, as a precaution against gaol air and gaol fever.
+
+Over the prisoner’s head there was a mirror, to throw the light down
+upon him. Crowds of the wicked and the wretched had been reflected in
+it, and had passed from its surface and this earth’s together. Haunted
+in a most ghastly manner that abominable place would have been, if the
+glass could ever have rendered back its reflections, as the ocean is one
+day to give up its dead. Some passing thought of the infamy and disgrace
+for which it had been reserved, may have struck the prisoner’s mind. Be
+that as it may, a change in his position making him conscious of a bar
+of light across his face, he looked up; and when he saw the glass his
+face flushed, and his right hand pushed the herbs away.
+
+It happened, that the action turned his face to that side of the court
+which was on his left. About on a level with his eyes, there sat,
+in that corner of the Judge’s bench, two persons upon whom his look
+immediately rested; so immediately, and so much to the changing of his
+aspect, that all the eyes that were turned upon him, turned to them.
+
+The spectators saw in the two figures, a young lady of little more than
+twenty, and a gentleman who was evidently her father; a man of a very
+remarkable appearance in respect of the absolute whiteness of his hair,
+and a certain indescribable intensity of face: not of an active kind,
+but pondering and self-communing. When this expression was upon him, he
+looked as if he were old; but when it was stirred and broken up--as
+it was now, in a moment, on his speaking to his daughter--he became a
+handsome man, not past the prime of life.
+
+His daughter had one of her hands drawn through his arm, as she sat by
+him, and the other pressed upon it. She had drawn close to him, in her
+dread of the scene, and in her pity for the prisoner. Her forehead had
+been strikingly expressive of an engrossing terror and compassion
+that saw nothing but the peril of the accused. This had been so very
+noticeable, so very powerfully and naturally shown, that starers who
+had had no pity for him were touched by her; and the whisper went about,
+“Who are they?”
+
+Jerry, the messenger, who had made his own observations, in his own
+manner, and who had been sucking the rust off his fingers in his
+absorption, stretched his neck to hear who they were. The crowd about
+him had pressed and passed the inquiry on to the nearest attendant, and
+from him it had been more slowly pressed and passed back; at last it got
+to Jerry:
+
+“Witnesses.”
+
+“For which side?”
+
+“Against.”
+
+“Against what side?”
+
+“The prisoner’s.”
+
+The Judge, whose eyes had gone in the general direction, recalled them,
+leaned back in his seat, and looked steadily at the man whose life was
+in his hand, as Mr. Attorney-General rose to spin the rope, grind the
+axe, and hammer the nails into the scaffold.
+
+
+
+
+III. A Disappointment
+
+
+Mr. Attorney-General had to inform the jury, that the prisoner before
+them, though young in years, was old in the treasonable practices which
+claimed the forfeit of his life. That this correspondence with the
+public enemy was not a correspondence of to-day, or of yesterday, or
+even of last year, or of the year before. That, it was certain the
+prisoner had, for longer than that, been in the habit of passing and
+repassing between France and England, on secret business of which
+he could give no honest account. That, if it were in the nature of
+traitorous ways to thrive (which happily it never was), the real
+wickedness and guilt of his business might have remained undiscovered.
+That Providence, however, had put it into the heart of a person who
+was beyond fear and beyond reproach, to ferret out the nature of the
+prisoner’s schemes, and, struck with horror, to disclose them to his
+Majesty’s Chief Secretary of State and most honourable Privy Council.
+That, this patriot would be produced before them. That, his position and
+attitude were, on the whole, sublime. That, he had been the prisoner’s
+friend, but, at once in an auspicious and an evil hour detecting his
+infamy, had resolved to immolate the traitor he could no longer cherish
+in his bosom, on the sacred altar of his country. That, if statues
+were decreed in Britain, as in ancient Greece and Rome, to public
+benefactors, this shining citizen would assuredly have had one. That, as
+they were not so decreed, he probably would not have one. That, Virtue,
+as had been observed by the poets (in many passages which he well
+knew the jury would have, word for word, at the tips of their tongues;
+whereat the jury’s countenances displayed a guilty consciousness that
+they knew nothing about the passages), was in a manner contagious; more
+especially the bright virtue known as patriotism, or love of country.
+That, the lofty example of this immaculate and unimpeachable witness
+for the Crown, to refer to whom however unworthily was an honour, had
+communicated itself to the prisoner’s servant, and had engendered in him
+a holy determination to examine his master’s table-drawers and pockets,
+and secrete his papers. That, he (Mr. Attorney-General) was prepared to
+hear some disparagement attempted of this admirable servant; but that,
+in a general way, he preferred him to his (Mr. Attorney-General’s)
+brothers and sisters, and honoured him more than his (Mr.
+Attorney-General’s) father and mother. That, he called with confidence
+on the jury to come and do likewise. That, the evidence of these two
+witnesses, coupled with the documents of their discovering that would be
+produced, would show the prisoner to have been furnished with lists of
+his Majesty’s forces, and of their disposition and preparation, both by
+sea and land, and would leave no doubt that he had habitually conveyed
+such information to a hostile power. That, these lists could not be
+proved to be in the prisoner’s handwriting; but that it was all the
+same; that, indeed, it was rather the better for the prosecution, as
+showing the prisoner to be artful in his precautions. That, the proof
+would go back five years, and would show the prisoner already engaged
+in these pernicious missions, within a few weeks before the date of the
+very first action fought between the British troops and the Americans.
+That, for these reasons, the jury, being a loyal jury (as he knew they
+were), and being a responsible jury (as _they_ knew they were), must
+positively find the prisoner Guilty, and make an end of him, whether
+they liked it or not. That, they never could lay their heads upon their
+pillows; that, they never could tolerate the idea of their wives laying
+their heads upon their pillows; that, they never could endure the notion
+of their children laying their heads upon their pillows; in short, that
+there never more could be, for them or theirs, any laying of heads upon
+pillows at all, unless the prisoner’s head was taken off. That head
+Mr. Attorney-General concluded by demanding of them, in the name of
+everything he could think of with a round turn in it, and on the faith
+of his solemn asseveration that he already considered the prisoner as
+good as dead and gone.
+
+When the Attorney-General ceased, a buzz arose in the court as if
+a cloud of great blue-flies were swarming about the prisoner, in
+anticipation of what he was soon to become. When toned down again, the
+unimpeachable patriot appeared in the witness-box.
+
+Mr. Solicitor-General then, following his leader’s lead, examined the
+patriot: John Barsad, gentleman, by name. The story of his pure soul was
+exactly what Mr. Attorney-General had described it to be--perhaps, if
+it had a fault, a little too exactly. Having released his noble bosom
+of its burden, he would have modestly withdrawn himself, but that the
+wigged gentleman with the papers before him, sitting not far from Mr.
+Lorry, begged to ask him a few questions. The wigged gentleman sitting
+opposite, still looking at the ceiling of the court.
+
+Had he ever been a spy himself? No, he scorned the base insinuation.
+What did he live upon? His property. Where was his property? He didn’t
+precisely remember where it was. What was it? No business of anybody’s.
+Had he inherited it? Yes, he had. From whom? Distant relation. Very
+distant? Rather. Ever been in prison? Certainly not. Never in a debtors’
+prison? Didn’t see what that had to do with it. Never in a debtors’
+prison?--Come, once again. Never? Yes. How many times? Two or three
+times. Not five or six? Perhaps. Of what profession? Gentleman. Ever
+been kicked? Might have been. Frequently? No. Ever kicked downstairs?
+Decidedly not; once received a kick on the top of a staircase, and fell
+downstairs of his own accord. Kicked on that occasion for cheating at
+dice? Something to that effect was said by the intoxicated liar who
+committed the assault, but it was not true. Swear it was not true?
+Positively. Ever live by cheating at play? Never. Ever live by play? Not
+more than other gentlemen do. Ever borrow money of the prisoner? Yes.
+Ever pay him? No. Was not this intimacy with the prisoner, in reality a
+very slight one, forced upon the prisoner in coaches, inns, and packets?
+No. Sure he saw the prisoner with these lists? Certain. Knew no more
+about the lists? No. Had not procured them himself, for instance? No.
+Expect to get anything by this evidence? No. Not in regular government
+pay and employment, to lay traps? Oh dear no. Or to do anything? Oh dear
+no. Swear that? Over and over again. No motives but motives of sheer
+patriotism? None whatever.
+
+The virtuous servant, Roger Cly, swore his way through the case at a
+great rate. He had taken service with the prisoner, in good faith and
+simplicity, four years ago. He had asked the prisoner, aboard the Calais
+packet, if he wanted a handy fellow, and the prisoner had engaged him.
+He had not asked the prisoner to take the handy fellow as an act of
+charity--never thought of such a thing. He began to have suspicions of
+the prisoner, and to keep an eye upon him, soon afterwards. In arranging
+his clothes, while travelling, he had seen similar lists to these in the
+prisoner’s pockets, over and over again. He had taken these lists from
+the drawer of the prisoner’s desk. He had not put them there first. He
+had seen the prisoner show these identical lists to French gentlemen
+at Calais, and similar lists to French gentlemen, both at Calais and
+Boulogne. He loved his country, and couldn’t bear it, and had given
+information. He had never been suspected of stealing a silver tea-pot;
+he had been maligned respecting a mustard-pot, but it turned out to be
+only a plated one. He had known the last witness seven or eight years;
+that was merely a coincidence. He didn’t call it a particularly curious
+coincidence; most coincidences were curious. Neither did he call it a
+curious coincidence that true patriotism was _his_ only motive too. He
+was a true Briton, and hoped there were many like him.
+
+The blue-flies buzzed again, and Mr. Attorney-General called Mr. Jarvis
+Lorry.
+
+“Mr. Jarvis Lorry, are you a clerk in Tellson’s bank?”
+
+“I am.”
+
+“On a certain Friday night in November one thousand seven hundred and
+seventy-five, did business occasion you to travel between London and
+Dover by the mail?”
+
+“It did.”
+
+“Were there any other passengers in the mail?”
+
+“Two.”
+
+“Did they alight on the road in the course of the night?”
+
+“They did.”
+
+“Mr. Lorry, look upon the prisoner. Was he one of those two passengers?”
+
+“I cannot undertake to say that he was.”
+
+“Does he resemble either of these two passengers?”
+
+“Both were so wrapped up, and the night was so dark, and we were all so
+reserved, that I cannot undertake to say even that.”
+
+“Mr. Lorry, look again upon the prisoner. Supposing him wrapped up as
+those two passengers were, is there anything in his bulk and stature to
+render it unlikely that he was one of them?”
+
+“No.”
+
+“You will not swear, Mr. Lorry, that he was not one of them?”
+
+“No.”
+
+“So at least you say he may have been one of them?”
+
+“Yes. Except that I remember them both to have been--like
+myself--timorous of highwaymen, and the prisoner has not a timorous
+air.”
+
+“Did you ever see a counterfeit of timidity, Mr. Lorry?”
+
+“I certainly have seen that.”
+
+“Mr. Lorry, look once more upon the prisoner. Have you seen him, to your
+certain knowledge, before?”
+
+“I have.”
+
+“When?”
+
+“I was returning from France a few days afterwards, and, at Calais, the
+prisoner came on board the packet-ship in which I returned, and made the
+voyage with me.”
+
+“At what hour did he come on board?”
+
+“At a little after midnight.”
+
+“In the dead of the night. Was he the only passenger who came on board
+at that untimely hour?”
+
+“He happened to be the only one.”
+
+“Never mind about ‘happening,’ Mr. Lorry. He was the only passenger who
+came on board in the dead of the night?”
+
+“He was.”
+
+“Were you travelling alone, Mr. Lorry, or with any companion?”
+
+“With two companions. A gentleman and lady. They are here.”
+
+“They are here. Had you any conversation with the prisoner?”
+
+“Hardly any. The weather was stormy, and the passage long and rough, and
+I lay on a sofa, almost from shore to shore.”
+
+“Miss Manette!”
+
+The young lady, to whom all eyes had been turned before, and were now
+turned again, stood up where she had sat. Her father rose with her, and
+kept her hand drawn through his arm.
+
+“Miss Manette, look upon the prisoner.”
+
+To be confronted with such pity, and such earnest youth and beauty, was
+far more trying to the accused than to be confronted with all the crowd.
+Standing, as it were, apart with her on the edge of his grave, not all
+the staring curiosity that looked on, could, for the moment, nerve him
+to remain quite still. His hurried right hand parcelled out the herbs
+before him into imaginary beds of flowers in a garden; and his efforts
+to control and steady his breathing shook the lips from which the colour
+rushed to his heart. The buzz of the great flies was loud again.
+
+“Miss Manette, have you seen the prisoner before?”
+
+“Yes, sir.”
+
+“Where?”
+
+“On board of the packet-ship just now referred to, sir, and on the same
+occasion.”
+
+“You are the young lady just now referred to?”
+
+“O! most unhappily, I am!”
+
+The plaintive tone of her compassion merged into the less musical voice
+of the Judge, as he said something fiercely: “Answer the questions put
+to you, and make no remark upon them.”
+
+“Miss Manette, had you any conversation with the prisoner on that
+passage across the Channel?”
+
+“Yes, sir.”
+
+“Recall it.”
+
+In the midst of a profound stillness, she faintly began: “When the
+gentleman came on board--”
+
+“Do you mean the prisoner?” inquired the Judge, knitting his brows.
+
+“Yes, my Lord.”
+
+“Then say the prisoner.”
+
+“When the prisoner came on board, he noticed that my father,” turning
+her eyes lovingly to him as he stood beside her, “was much fatigued
+and in a very weak state of health. My father was so reduced that I was
+afraid to take him out of the air, and I had made a bed for him on the
+deck near the cabin steps, and I sat on the deck at his side to take
+care of him. There were no other passengers that night, but we four.
+The prisoner was so good as to beg permission to advise me how I could
+shelter my father from the wind and weather, better than I had done. I
+had not known how to do it well, not understanding how the wind would
+set when we were out of the harbour. He did it for me. He expressed
+great gentleness and kindness for my father’s state, and I am sure he
+felt it. That was the manner of our beginning to speak together.”
+
+“Let me interrupt you for a moment. Had he come on board alone?”
+
+“No.”
+
+“How many were with him?”
+
+“Two French gentlemen.”
+
+“Had they conferred together?”
+
+“They had conferred together until the last moment, when it was
+necessary for the French gentlemen to be landed in their boat.”
+
+“Had any papers been handed about among them, similar to these lists?”
+
+“Some papers had been handed about among them, but I don’t know what
+papers.”
+
+“Like these in shape and size?”
+
+“Possibly, but indeed I don’t know, although they stood whispering very
+near to me: because they stood at the top of the cabin steps to have the
+light of the lamp that was hanging there; it was a dull lamp, and they
+spoke very low, and I did not hear what they said, and saw only that
+they looked at papers.”
+
+“Now, to the prisoner’s conversation, Miss Manette.”
+
+“The prisoner was as open in his confidence with me--which arose out
+of my helpless situation--as he was kind, and good, and useful to my
+father. I hope,” bursting into tears, “I may not repay him by doing him
+harm to-day.”
+
+Buzzing from the blue-flies.
+
+“Miss Manette, if the prisoner does not perfectly understand that
+you give the evidence which it is your duty to give--which you must
+give--and which you cannot escape from giving--with great unwillingness,
+he is the only person present in that condition. Please to go on.”
+
+“He told me that he was travelling on business of a delicate and
+difficult nature, which might get people into trouble, and that he was
+therefore travelling under an assumed name. He said that this business
+had, within a few days, taken him to France, and might, at intervals,
+take him backwards and forwards between France and England for a long
+time to come.”
+
+“Did he say anything about America, Miss Manette? Be particular.”
+
+“He tried to explain to me how that quarrel had arisen, and he said
+that, so far as he could judge, it was a wrong and foolish one on
+England’s part. He added, in a jesting way, that perhaps George
+Washington might gain almost as great a name in history as George the
+Third. But there was no harm in his way of saying this: it was said
+laughingly, and to beguile the time.”
+
+Any strongly marked expression of face on the part of a chief actor in
+a scene of great interest to whom many eyes are directed, will be
+unconsciously imitated by the spectators. Her forehead was painfully
+anxious and intent as she gave this evidence, and, in the pauses when
+she stopped for the Judge to write it down, watched its effect upon
+the counsel for and against. Among the lookers-on there was the same
+expression in all quarters of the court; insomuch, that a great majority
+of the foreheads there, might have been mirrors reflecting the witness,
+when the Judge looked up from his notes to glare at that tremendous
+heresy about George Washington.
+
+Mr. Attorney-General now signified to my Lord, that he deemed it
+necessary, as a matter of precaution and form, to call the young lady’s
+father, Doctor Manette. Who was called accordingly.
+
+“Doctor Manette, look upon the prisoner. Have you ever seen him before?”
+
+“Once. When he called at my lodgings in London. Some three years, or
+three years and a half ago.”
+
+“Can you identify him as your fellow-passenger on board the packet, or
+speak to his conversation with your daughter?”
+
+“Sir, I can do neither.”
+
+“Is there any particular and special reason for your being unable to do
+either?”
+
+He answered, in a low voice, “There is.”
+
+“Has it been your misfortune to undergo a long imprisonment, without
+trial, or even accusation, in your native country, Doctor Manette?”
+
+He answered, in a tone that went to every heart, “A long imprisonment.”
+
+“Were you newly released on the occasion in question?”
+
+“They tell me so.”
+
+“Have you no remembrance of the occasion?”
+
+“None. My mind is a blank, from some time--I cannot even say what
+time--when I employed myself, in my captivity, in making shoes, to the
+time when I found myself living in London with my dear daughter
+here. She had become familiar to me, when a gracious God restored
+my faculties; but, I am quite unable even to say how she had become
+familiar. I have no remembrance of the process.”
+
+Mr. Attorney-General sat down, and the father and daughter sat down
+together.
+
+A singular circumstance then arose in the case. The object in hand being
+to show that the prisoner went down, with some fellow-plotter untracked,
+in the Dover mail on that Friday night in November five years ago, and
+got out of the mail in the night, as a blind, at a place where he did
+not remain, but from which he travelled back some dozen miles or more,
+to a garrison and dockyard, and there collected information; a witness
+was called to identify him as having been at the precise time required,
+in the coffee-room of an hotel in that garrison-and-dockyard town,
+waiting for another person. The prisoner’s counsel was cross-examining
+this witness with no result, except that he had never seen the prisoner
+on any other occasion, when the wigged gentleman who had all this time
+been looking at the ceiling of the court, wrote a word or two on a
+little piece of paper, screwed it up, and tossed it to him. Opening
+this piece of paper in the next pause, the counsel looked with great
+attention and curiosity at the prisoner.
+
+“You say again you are quite sure that it was the prisoner?”
+
+The witness was quite sure.
+
+“Did you ever see anybody very like the prisoner?”
+
+Not so like (the witness said) as that he could be mistaken.
+
+“Look well upon that gentleman, my learned friend there,” pointing
+to him who had tossed the paper over, “and then look well upon the
+prisoner. How say you? Are they very like each other?”
+
+Allowing for my learned friend’s appearance being careless and slovenly
+if not debauched, they were sufficiently like each other to surprise,
+not only the witness, but everybody present, when they were thus brought
+into comparison. My Lord being prayed to bid my learned friend lay aside
+his wig, and giving no very gracious consent, the likeness became
+much more remarkable. My Lord inquired of Mr. Stryver (the prisoner’s
+counsel), whether they were next to try Mr. Carton (name of my learned
+friend) for treason? But, Mr. Stryver replied to my Lord, no; but he
+would ask the witness to tell him whether what happened once, might
+happen twice; whether he would have been so confident if he had seen
+this illustration of his rashness sooner, whether he would be so
+confident, having seen it; and more. The upshot of which, was, to smash
+this witness like a crockery vessel, and shiver his part of the case to
+useless lumber.
+
+Mr. Cruncher had by this time taken quite a lunch of rust off his
+fingers in his following of the evidence. He had now to attend while Mr.
+Stryver fitted the prisoner’s case on the jury, like a compact suit
+of clothes; showing them how the patriot, Barsad, was a hired spy and
+traitor, an unblushing trafficker in blood, and one of the greatest
+scoundrels upon earth since accursed Judas--which he certainly did look
+rather like. How the virtuous servant, Cly, was his friend and partner,
+and was worthy to be; how the watchful eyes of those forgers and false
+swearers had rested on the prisoner as a victim, because some family
+affairs in France, he being of French extraction, did require his making
+those passages across the Channel--though what those affairs were, a
+consideration for others who were near and dear to him, forbade him,
+even for his life, to disclose. How the evidence that had been warped
+and wrested from the young lady, whose anguish in giving it they
+had witnessed, came to nothing, involving the mere little innocent
+gallantries and politenesses likely to pass between any young gentleman
+and young lady so thrown together;--with the exception of that
+reference to George Washington, which was altogether too extravagant and
+impossible to be regarded in any other light than as a monstrous joke.
+How it would be a weakness in the government to break down in this
+attempt to practise for popularity on the lowest national antipathies
+and fears, and therefore Mr. Attorney-General had made the most of it;
+how, nevertheless, it rested upon nothing, save that vile and infamous
+character of evidence too often disfiguring such cases, and of which the
+State Trials of this country were full. But, there my Lord interposed
+(with as grave a face as if it had not been true), saying that he could
+not sit upon that Bench and suffer those allusions.
+
+Mr. Stryver then called his few witnesses, and Mr. Cruncher had next to
+attend while Mr. Attorney-General turned the whole suit of clothes Mr.
+Stryver had fitted on the jury, inside out; showing how Barsad and
+Cly were even a hundred times better than he had thought them, and the
+prisoner a hundred times worse. Lastly, came my Lord himself, turning
+the suit of clothes, now inside out, now outside in, but on the whole
+decidedly trimming and shaping them into grave-clothes for the prisoner.
+
+And now, the jury turned to consider, and the great flies swarmed again.
+
+Mr. Carton, who had so long sat looking at the ceiling of the court,
+changed neither his place nor his attitude, even in this excitement.
+While his learned friend, Mr. Stryver, massing his papers before him,
+whispered with those who sat near, and from time to time glanced
+anxiously at the jury; while all the spectators moved more or less, and
+grouped themselves anew; while even my Lord himself arose from his seat,
+and slowly paced up and down his platform, not unattended by a suspicion
+in the minds of the audience that his state was feverish; this one man
+sat leaning back, with his torn gown half off him, his untidy wig put
+on just as it had happened to light on his head after its removal, his
+hands in his pockets, and his eyes on the ceiling as they had been all
+day. Something especially reckless in his demeanour, not only gave him
+a disreputable look, but so diminished the strong resemblance he
+undoubtedly bore to the prisoner (which his momentary earnestness,
+when they were compared together, had strengthened), that many of the
+lookers-on, taking note of him now, said to one another they would
+hardly have thought the two were so alike. Mr. Cruncher made the
+observation to his next neighbour, and added, “I’d hold half a guinea
+that _he_ don’t get no law-work to do. Don’t look like the sort of one
+to get any, do he?”
+
+Yet, this Mr. Carton took in more of the details of the scene than he
+appeared to take in; for now, when Miss Manette’s head dropped upon
+her father’s breast, he was the first to see it, and to say audibly:
+“Officer! look to that young lady. Help the gentleman to take her out.
+Don’t you see she will fall!”
+
+There was much commiseration for her as she was removed, and much
+sympathy with her father. It had evidently been a great distress to
+him, to have the days of his imprisonment recalled. He had shown
+strong internal agitation when he was questioned, and that pondering or
+brooding look which made him old, had been upon him, like a heavy cloud,
+ever since. As he passed out, the jury, who had turned back and paused a
+moment, spoke, through their foreman.
+
+They were not agreed, and wished to retire. My Lord (perhaps with George
+Washington on his mind) showed some surprise that they were not agreed,
+but signified his pleasure that they should retire under watch and ward,
+and retired himself. The trial had lasted all day, and the lamps in
+the court were now being lighted. It began to be rumoured that the
+jury would be out a long while. The spectators dropped off to get
+refreshment, and the prisoner withdrew to the back of the dock, and sat
+down.
+
+Mr. Lorry, who had gone out when the young lady and her father went out,
+now reappeared, and beckoned to Jerry: who, in the slackened interest,
+could easily get near him.
+
+“Jerry, if you wish to take something to eat, you can. But, keep in the
+way. You will be sure to hear when the jury come in. Don’t be a moment
+behind them, for I want you to take the verdict back to the bank. You
+are the quickest messenger I know, and will get to Temple Bar long
+before I can.”
+
+Jerry had just enough forehead to knuckle, and he knuckled it in
+acknowledgment of this communication and a shilling. Mr. Carton came up
+at the moment, and touched Mr. Lorry on the arm.
+
+“How is the young lady?”
+
+“She is greatly distressed; but her father is comforting her, and she
+feels the better for being out of court.”
+
+“I’ll tell the prisoner so. It won’t do for a respectable bank gentleman
+like you, to be seen speaking to him publicly, you know.”
+
+Mr. Lorry reddened as if he were conscious of having debated the point
+in his mind, and Mr. Carton made his way to the outside of the bar.
+The way out of court lay in that direction, and Jerry followed him, all
+eyes, ears, and spikes.
+
+“Mr. Darnay!”
+
+The prisoner came forward directly.
+
+“You will naturally be anxious to hear of the witness, Miss Manette. She
+will do very well. You have seen the worst of her agitation.”
+
+“I am deeply sorry to have been the cause of it. Could you tell her so
+for me, with my fervent acknowledgments?”
+
+“Yes, I could. I will, if you ask it.”
+
+Mr. Carton’s manner was so careless as to be almost insolent. He stood,
+half turned from the prisoner, lounging with his elbow against the bar.
+
+“I do ask it. Accept my cordial thanks.”
+
+“What,” said Carton, still only half turned towards him, “do you expect,
+Mr. Darnay?”
+
+“The worst.”
+
+“It’s the wisest thing to expect, and the likeliest. But I think their
+withdrawing is in your favour.”
+
+Loitering on the way out of court not being allowed, Jerry heard no
+more: but left them--so like each other in feature, so unlike each other
+in manner--standing side by side, both reflected in the glass above
+them.
+
+An hour and a half limped heavily away in the thief-and-rascal crowded
+passages below, even though assisted off with mutton pies and ale.
+The hoarse messenger, uncomfortably seated on a form after taking that
+refection, had dropped into a doze, when a loud murmur and a rapid tide
+of people setting up the stairs that led to the court, carried him along
+with them.
+
+“Jerry! Jerry!” Mr. Lorry was already calling at the door when he got
+there.
+
+“Here, sir! It’s a fight to get back again. Here I am, sir!”
+
+Mr. Lorry handed him a paper through the throng. “Quick! Have you got
+it?”
+
+“Yes, sir.”
+
+Hastily written on the paper was the word “ACQUITTED.”
+
+“If you had sent the message, ‘Recalled to Life,’ again,” muttered
+Jerry, as he turned, “I should have known what you meant, this time.”
+
+He had no opportunity of saying, or so much as thinking, anything else,
+until he was clear of the Old Bailey; for, the crowd came pouring out
+with a vehemence that nearly took him off his legs, and a loud buzz
+swept into the street as if the baffled blue-flies were dispersing in
+search of other carrion.
+
+
+
+
+IV. Congratulatory
+
+
+From the dimly-lighted passages of the court, the last sediment of the
+human stew that had been boiling there all day, was straining off, when
+Doctor Manette, Lucie Manette, his daughter, Mr. Lorry, the solicitor
+for the defence, and its counsel, Mr. Stryver, stood gathered round Mr.
+Charles Darnay--just released--congratulating him on his escape from
+death.
+
+It would have been difficult by a far brighter light, to recognise
+in Doctor Manette, intellectual of face and upright of bearing, the
+shoemaker of the garret in Paris. Yet, no one could have looked at him
+twice, without looking again: even though the opportunity of observation
+had not extended to the mournful cadence of his low grave voice, and
+to the abstraction that overclouded him fitfully, without any apparent
+reason. While one external cause, and that a reference to his long
+lingering agony, would always--as on the trial--evoke this condition
+from the depths of his soul, it was also in its nature to arise of
+itself, and to draw a gloom over him, as incomprehensible to those
+unacquainted with his story as if they had seen the shadow of the actual
+Bastille thrown upon him by a summer sun, when the substance was three
+hundred miles away.
+
+Only his daughter had the power of charming this black brooding from
+his mind. She was the golden thread that united him to a Past beyond his
+misery, and to a Present beyond his misery: and the sound of her voice,
+the light of her face, the touch of her hand, had a strong beneficial
+influence with him almost always. Not absolutely always, for she could
+recall some occasions on which her power had failed; but they were few
+and slight, and she believed them over.
+
+Mr. Darnay had kissed her hand fervently and gratefully, and had turned
+to Mr. Stryver, whom he warmly thanked. Mr. Stryver, a man of little
+more than thirty, but looking twenty years older than he was, stout,
+loud, red, bluff, and free from any drawback of delicacy, had a pushing
+way of shouldering himself (morally and physically) into companies and
+conversations, that argued well for his shouldering his way up in life.
+
+He still had his wig and gown on, and he said, squaring himself at his
+late client to that degree that he squeezed the innocent Mr. Lorry clean
+out of the group: “I am glad to have brought you off with honour, Mr.
+Darnay. It was an infamous prosecution, grossly infamous; but not the
+less likely to succeed on that account.”
+
+“You have laid me under an obligation to you for life--in two senses,”
+ said his late client, taking his hand.
+
+“I have done my best for you, Mr. Darnay; and my best is as good as
+another man’s, I believe.”
+
+It clearly being incumbent on some one to say, “Much better,” Mr. Lorry
+said it; perhaps not quite disinterestedly, but with the interested
+object of squeezing himself back again.
+
+“You think so?” said Mr. Stryver. “Well! you have been present all day,
+and you ought to know. You are a man of business, too.”
+
+“And as such,” quoth Mr. Lorry, whom the counsel learned in the law had
+now shouldered back into the group, just as he had previously shouldered
+him out of it--“as such I will appeal to Doctor Manette, to break up
+this conference and order us all to our homes. Miss Lucie looks ill, Mr.
+Darnay has had a terrible day, we are worn out.”
+
+“Speak for yourself, Mr. Lorry,” said Stryver; “I have a night’s work to
+do yet. Speak for yourself.”
+
+“I speak for myself,” answered Mr. Lorry, “and for Mr. Darnay, and for
+Miss Lucie, and--Miss Lucie, do you not think I may speak for us all?”
+ He asked her the question pointedly, and with a glance at her father.
+
+His face had become frozen, as it were, in a very curious look at
+Darnay: an intent look, deepening into a frown of dislike and distrust,
+not even unmixed with fear. With this strange expression on him his
+thoughts had wandered away.
+
+“My father,” said Lucie, softly laying her hand on his.
+
+He slowly shook the shadow off, and turned to her.
+
+“Shall we go home, my father?”
+
+With a long breath, he answered “Yes.”
+
+The friends of the acquitted prisoner had dispersed, under the
+impression--which he himself had originated--that he would not be
+released that night. The lights were nearly all extinguished in the
+passages, the iron gates were being closed with a jar and a rattle,
+and the dismal place was deserted until to-morrow morning’s interest of
+gallows, pillory, whipping-post, and branding-iron, should repeople it.
+Walking between her father and Mr. Darnay, Lucie Manette passed into
+the open air. A hackney-coach was called, and the father and daughter
+departed in it.
+
+Mr. Stryver had left them in the passages, to shoulder his way back
+to the robing-room. Another person, who had not joined the group, or
+interchanged a word with any one of them, but who had been leaning
+against the wall where its shadow was darkest, had silently strolled
+out after the rest, and had looked on until the coach drove away. He now
+stepped up to where Mr. Lorry and Mr. Darnay stood upon the pavement.
+
+“So, Mr. Lorry! Men of business may speak to Mr. Darnay now?”
+
+Nobody had made any acknowledgment of Mr. Carton’s part in the day’s
+proceedings; nobody had known of it. He was unrobed, and was none the
+better for it in appearance.
+
+“If you knew what a conflict goes on in the business mind, when the
+business mind is divided between good-natured impulse and business
+appearances, you would be amused, Mr. Darnay.”
+
+Mr. Lorry reddened, and said, warmly, “You have mentioned that before,
+sir. We men of business, who serve a House, are not our own masters. We
+have to think of the House more than ourselves.”
+
+“_I_ know, _I_ know,” rejoined Mr. Carton, carelessly. “Don’t be
+nettled, Mr. Lorry. You are as good as another, I have no doubt: better,
+I dare say.”
+
+“And indeed, sir,” pursued Mr. Lorry, not minding him, “I really don’t
+know what you have to do with the matter. If you’ll excuse me, as very
+much your elder, for saying so, I really don’t know that it is your
+business.”
+
+“Business! Bless you, _I_ have no business,” said Mr. Carton.
+
+“It is a pity you have not, sir.”
+
+“I think so, too.”
+
+“If you had,” pursued Mr. Lorry, “perhaps you would attend to it.”
+
+“Lord love you, no!--I shouldn’t,” said Mr. Carton.
+
+“Well, sir!” cried Mr. Lorry, thoroughly heated by his indifference,
+“business is a very good thing, and a very respectable thing. And, sir,
+if business imposes its restraints and its silences and impediments, Mr.
+Darnay as a young gentleman of generosity knows how to make allowance
+for that circumstance. Mr. Darnay, good night, God bless you, sir!
+I hope you have been this day preserved for a prosperous and happy
+life.--Chair there!”
+
+Perhaps a little angry with himself, as well as with the barrister, Mr.
+Lorry bustled into the chair, and was carried off to Tellson’s. Carton,
+who smelt of port wine, and did not appear to be quite sober, laughed
+then, and turned to Darnay:
+
+“This is a strange chance that throws you and me together. This must
+be a strange night to you, standing alone here with your counterpart on
+these street stones?”
+
+“I hardly seem yet,” returned Charles Darnay, “to belong to this world
+again.”
+
+“I don’t wonder at it; it’s not so long since you were pretty far
+advanced on your way to another. You speak faintly.”
+
+“I begin to think I _am_ faint.”
+
+“Then why the devil don’t you dine? I dined, myself, while those
+numskulls were deliberating which world you should belong to--this, or
+some other. Let me show you the nearest tavern to dine well at.”
+
+Drawing his arm through his own, he took him down Ludgate-hill to
+Fleet-street, and so, up a covered way, into a tavern. Here, they were
+shown into a little room, where Charles Darnay was soon recruiting
+his strength with a good plain dinner and good wine: while Carton sat
+opposite to him at the same table, with his separate bottle of port
+before him, and his fully half-insolent manner upon him.
+
+“Do you feel, yet, that you belong to this terrestrial scheme again, Mr.
+Darnay?”
+
+“I am frightfully confused regarding time and place; but I am so far
+mended as to feel that.”
+
+“It must be an immense satisfaction!”
+
+He said it bitterly, and filled up his glass again: which was a large
+one.
+
+“As to me, the greatest desire I have, is to forget that I belong to it.
+It has no good in it for me--except wine like this--nor I for it. So we
+are not much alike in that particular. Indeed, I begin to think we are
+not much alike in any particular, you and I.”
+
+Confused by the emotion of the day, and feeling his being there with
+this Double of coarse deportment, to be like a dream, Charles Darnay was
+at a loss how to answer; finally, answered not at all.
+
+“Now your dinner is done,” Carton presently said, “why don’t you call a
+health, Mr. Darnay; why don’t you give your toast?”
+
+“What health? What toast?”
+
+“Why, it’s on the tip of your tongue. It ought to be, it must be, I’ll
+swear it’s there.”
+
+“Miss Manette, then!”
+
+“Miss Manette, then!”
+
+Looking his companion full in the face while he drank the toast, Carton
+flung his glass over his shoulder against the wall, where it shivered to
+pieces; then, rang the bell, and ordered in another.
+
+“That’s a fair young lady to hand to a coach in the dark, Mr. Darnay!”
+ he said, filling his new goblet.
+
+A slight frown and a laconic “Yes,” were the answer.
+
+“That’s a fair young lady to be pitied by and wept for by! How does it
+feel? Is it worth being tried for one’s life, to be the object of such
+sympathy and compassion, Mr. Darnay?”
+
+Again Darnay answered not a word.
+
+“She was mightily pleased to have your message, when I gave it her. Not
+that she showed she was pleased, but I suppose she was.”
+
+The allusion served as a timely reminder to Darnay that this
+disagreeable companion had, of his own free will, assisted him in the
+strait of the day. He turned the dialogue to that point, and thanked him
+for it.
+
+“I neither want any thanks, nor merit any,” was the careless rejoinder.
+“It was nothing to do, in the first place; and I don’t know why I did
+it, in the second. Mr. Darnay, let me ask you a question.”
+
+“Willingly, and a small return for your good offices.”
+
+“Do you think I particularly like you?”
+
+“Really, Mr. Carton,” returned the other, oddly disconcerted, “I have
+not asked myself the question.”
+
+“But ask yourself the question now.”
+
+“You have acted as if you do; but I don’t think you do.”
+
+“_I_ don’t think I do,” said Carton. “I begin to have a very good
+opinion of your understanding.”
+
+“Nevertheless,” pursued Darnay, rising to ring the bell, “there is
+nothing in that, I hope, to prevent my calling the reckoning, and our
+parting without ill-blood on either side.”
+
+Carton rejoining, “Nothing in life!” Darnay rang. “Do you call the whole
+reckoning?” said Carton. On his answering in the affirmative, “Then
+bring me another pint of this same wine, drawer, and come and wake me at
+ten.”
+
+The bill being paid, Charles Darnay rose and wished him good night.
+Without returning the wish, Carton rose too, with something of a threat
+of defiance in his manner, and said, “A last word, Mr. Darnay: you think
+I am drunk?”
+
+“I think you have been drinking, Mr. Carton.”
+
+“Think? You know I have been drinking.”
+
+“Since I must say so, I know it.”
+
+“Then you shall likewise know why. I am a disappointed drudge, sir. I
+care for no man on earth, and no man on earth cares for me.”
+
+“Much to be regretted. You might have used your talents better.”
+
+“May be so, Mr. Darnay; may be not. Don’t let your sober face elate you,
+however; you don’t know what it may come to. Good night!”
+
+When he was left alone, this strange being took up a candle, went to a
+glass that hung against the wall, and surveyed himself minutely in it.
+
+“Do you particularly like the man?” he muttered, at his own image; “why
+should you particularly like a man who resembles you? There is nothing
+in you to like; you know that. Ah, confound you! What a change you have
+made in yourself! A good reason for taking to a man, that he shows you
+what you have fallen away from, and what you might have been! Change
+places with him, and would you have been looked at by those blue eyes as
+he was, and commiserated by that agitated face as he was? Come on, and
+have it out in plain words! You hate the fellow.”
+
+He resorted to his pint of wine for consolation, drank it all in a few
+minutes, and fell asleep on his arms, with his hair straggling over the
+table, and a long winding-sheet in the candle dripping down upon him.
+
+
+
+
+V. The Jackal
+
+
+Those were drinking days, and most men drank hard. So very great is
+the improvement Time has brought about in such habits, that a moderate
+statement of the quantity of wine and punch which one man would swallow
+in the course of a night, without any detriment to his reputation as a
+perfect gentleman, would seem, in these days, a ridiculous exaggeration.
+The learned profession of the law was certainly not behind any other
+learned profession in its Bacchanalian propensities; neither was Mr.
+Stryver, already fast shouldering his way to a large and lucrative
+practice, behind his compeers in this particular, any more than in the
+drier parts of the legal race.
+
+A favourite at the Old Bailey, and eke at the Sessions, Mr. Stryver had
+begun cautiously to hew away the lower staves of the ladder on which
+he mounted. Sessions and Old Bailey had now to summon their favourite,
+specially, to their longing arms; and shouldering itself towards the
+visage of the Lord Chief Justice in the Court of King’s Bench, the
+florid countenance of Mr. Stryver might be daily seen, bursting out of
+the bed of wigs, like a great sunflower pushing its way at the sun from
+among a rank garden-full of flaring companions.
+
+It had once been noted at the Bar, that while Mr. Stryver was a glib
+man, and an unscrupulous, and a ready, and a bold, he had not that
+faculty of extracting the essence from a heap of statements, which is
+among the most striking and necessary of the advocate’s accomplishments.
+But, a remarkable improvement came upon him as to this. The more
+business he got, the greater his power seemed to grow of getting at its
+pith and marrow; and however late at night he sat carousing with Sydney
+Carton, he always had his points at his fingers’ ends in the morning.
+
+Sydney Carton, idlest and most unpromising of men, was Stryver’s great
+ally. What the two drank together, between Hilary Term and Michaelmas,
+might have floated a king’s ship. Stryver never had a case in hand,
+anywhere, but Carton was there, with his hands in his pockets, staring
+at the ceiling of the court; they went the same Circuit, and even there
+they prolonged their usual orgies late into the night, and Carton was
+rumoured to be seen at broad day, going home stealthily and unsteadily
+to his lodgings, like a dissipated cat. At last, it began to get about,
+among such as were interested in the matter, that although Sydney Carton
+would never be a lion, he was an amazingly good jackal, and that he
+rendered suit and service to Stryver in that humble capacity.
+
+“Ten o’clock, sir,” said the man at the tavern, whom he had charged to
+wake him--“ten o’clock, sir.”
+
+“_What’s_ the matter?”
+
+“Ten o’clock, sir.”
+
+“What do you mean? Ten o’clock at night?”
+
+“Yes, sir. Your honour told me to call you.”
+
+“Oh! I remember. Very well, very well.”
+
+After a few dull efforts to get to sleep again, which the man
+dexterously combated by stirring the fire continuously for five minutes,
+he got up, tossed his hat on, and walked out. He turned into the Temple,
+and, having revived himself by twice pacing the pavements of King’s
+Bench-walk and Paper-buildings, turned into the Stryver chambers.
+
+The Stryver clerk, who never assisted at these conferences, had gone
+home, and the Stryver principal opened the door. He had his slippers on,
+and a loose bed-gown, and his throat was bare for his greater ease. He
+had that rather wild, strained, seared marking about the eyes, which
+may be observed in all free livers of his class, from the portrait of
+Jeffries downward, and which can be traced, under various disguises of
+Art, through the portraits of every Drinking Age.
+
+“You are a little late, Memory,” said Stryver.
+
+“About the usual time; it may be a quarter of an hour later.”
+
+They went into a dingy room lined with books and littered with papers,
+where there was a blazing fire. A kettle steamed upon the hob, and in
+the midst of the wreck of papers a table shone, with plenty of wine upon
+it, and brandy, and rum, and sugar, and lemons.
+
+“You have had your bottle, I perceive, Sydney.”
+
+“Two to-night, I think. I have been dining with the day’s client; or
+seeing him dine--it’s all one!”
+
+“That was a rare point, Sydney, that you brought to bear upon the
+identification. How did you come by it? When did it strike you?”
+
+“I thought he was rather a handsome fellow, and I thought I should have
+been much the same sort of fellow, if I had had any luck.”
+
+Mr. Stryver laughed till he shook his precocious paunch.
+
+“You and your luck, Sydney! Get to work, get to work.”
+
+Sullenly enough, the jackal loosened his dress, went into an adjoining
+room, and came back with a large jug of cold water, a basin, and a towel
+or two. Steeping the towels in the water, and partially wringing them
+out, he folded them on his head in a manner hideous to behold, sat down
+at the table, and said, “Now I am ready!”
+
+“Not much boiling down to be done to-night, Memory,” said Mr. Stryver,
+gaily, as he looked among his papers.
+
+“How much?”
+
+“Only two sets of them.”
+
+“Give me the worst first.”
+
+“There they are, Sydney. Fire away!”
+
+The lion then composed himself on his back on a sofa on one side of the
+drinking-table, while the jackal sat at his own paper-bestrewn table
+proper, on the other side of it, with the bottles and glasses ready to
+his hand. Both resorted to the drinking-table without stint, but each in
+a different way; the lion for the most part reclining with his hands in
+his waistband, looking at the fire, or occasionally flirting with some
+lighter document; the jackal, with knitted brows and intent face,
+so deep in his task, that his eyes did not even follow the hand he
+stretched out for his glass--which often groped about, for a minute or
+more, before it found the glass for his lips. Two or three times, the
+matter in hand became so knotty, that the jackal found it imperative on
+him to get up, and steep his towels anew. From these pilgrimages to the
+jug and basin, he returned with such eccentricities of damp headgear as
+no words can describe; which were made the more ludicrous by his anxious
+gravity.
+
+At length the jackal had got together a compact repast for the lion, and
+proceeded to offer it to him. The lion took it with care and caution,
+made his selections from it, and his remarks upon it, and the jackal
+assisted both. When the repast was fully discussed, the lion put his
+hands in his waistband again, and lay down to meditate. The jackal then
+invigorated himself with a bumper for his throttle, and a fresh application
+to his head, and applied himself to the collection of a second meal;
+this was administered to the lion in the same manner, and was not
+disposed of until the clocks struck three in the morning.
+
+“And now we have done, Sydney, fill a bumper of punch,” said Mr.
+Stryver.
+
+The jackal removed the towels from his head, which had been steaming
+again, shook himself, yawned, shivered, and complied.
+
+“You were very sound, Sydney, in the matter of those crown witnesses
+to-day. Every question told.”
+
+“I always am sound; am I not?”
+
+“I don’t gainsay it. What has roughened your temper? Put some punch to
+it and smooth it again.”
+
+With a deprecatory grunt, the jackal again complied.
+
+“The old Sydney Carton of old Shrewsbury School,” said Stryver, nodding
+his head over him as he reviewed him in the present and the past, “the
+old seesaw Sydney. Up one minute and down the next; now in spirits and
+now in despondency!”
+
+“Ah!” returned the other, sighing: “yes! The same Sydney, with the same
+luck. Even then, I did exercises for other boys, and seldom did my own.”
+
+“And why not?”
+
+“God knows. It was my way, I suppose.”
+
+He sat, with his hands in his pockets and his legs stretched out before
+him, looking at the fire.
+
+“Carton,” said his friend, squaring himself at him with a bullying air,
+as if the fire-grate had been the furnace in which sustained endeavour
+was forged, and the one delicate thing to be done for the old Sydney
+Carton of old Shrewsbury School was to shoulder him into it, “your way
+is, and always was, a lame way. You summon no energy and purpose. Look
+at me.”
+
+“Oh, botheration!” returned Sydney, with a lighter and more
+good-humoured laugh, “don’t _you_ be moral!”
+
+“How have I done what I have done?” said Stryver; “how do I do what I
+do?”
+
+“Partly through paying me to help you, I suppose. But it’s not worth
+your while to apostrophise me, or the air, about it; what you want to
+do, you do. You were always in the front rank, and I was always behind.”
+
+“I had to get into the front rank; I was not born there, was I?”
+
+“I was not present at the ceremony; but my opinion is you were,” said
+Carton. At this, he laughed again, and they both laughed.
+
+“Before Shrewsbury, and at Shrewsbury, and ever since Shrewsbury,”
+ pursued Carton, “you have fallen into your rank, and I have fallen into
+mine. Even when we were fellow-students in the Student-Quarter of Paris,
+picking up French, and French law, and other French crumbs that we
+didn’t get much good of, you were always somewhere, and I was always
+nowhere.”
+
+“And whose fault was that?”
+
+“Upon my soul, I am not sure that it was not yours. You were always
+driving and riving and shouldering and passing, to that restless degree
+that I had no chance for my life but in rust and repose. It’s a gloomy
+thing, however, to talk about one’s own past, with the day breaking.
+Turn me in some other direction before I go.”
+
+“Well then! Pledge me to the pretty witness,” said Stryver, holding up
+his glass. “Are you turned in a pleasant direction?”
+
+Apparently not, for he became gloomy again.
+
+“Pretty witness,” he muttered, looking down into his glass. “I have had
+enough of witnesses to-day and to-night; who’s your pretty witness?”
+
+“The picturesque doctor’s daughter, Miss Manette.”
+
+“_She_ pretty?”
+
+“Is she not?”
+
+“No.”
+
+“Why, man alive, she was the admiration of the whole Court!”
+
+“Rot the admiration of the whole Court! Who made the Old Bailey a judge
+of beauty? She was a golden-haired doll!”
+
+“Do you know, Sydney,” said Mr. Stryver, looking at him with sharp eyes,
+and slowly drawing a hand across his florid face: “do you know, I rather
+thought, at the time, that you sympathised with the golden-haired doll,
+and were quick to see what happened to the golden-haired doll?”
+
+“Quick to see what happened! If a girl, doll or no doll, swoons within a
+yard or two of a man’s nose, he can see it without a perspective-glass.
+I pledge you, but I deny the beauty. And now I’ll have no more drink;
+I’ll get to bed.”
+
+When his host followed him out on the staircase with a candle, to light
+him down the stairs, the day was coldly looking in through its grimy
+windows. When he got out of the house, the air was cold and sad, the
+dull sky overcast, the river dark and dim, the whole scene like a
+lifeless desert. And wreaths of dust were spinning round and round
+before the morning blast, as if the desert-sand had risen far away, and
+the first spray of it in its advance had begun to overwhelm the city.
+
+Waste forces within him, and a desert all around, this man stood still
+on his way across a silent terrace, and saw for a moment, lying in the
+wilderness before him, a mirage of honourable ambition, self-denial, and
+perseverance. In the fair city of this vision, there were airy galleries
+from which the loves and graces looked upon him, gardens in which the
+fruits of life hung ripening, waters of Hope that sparkled in his sight.
+A moment, and it was gone. Climbing to a high chamber in a well of
+houses, he threw himself down in his clothes on a neglected bed, and its
+pillow was wet with wasted tears.
+
+Sadly, sadly, the sun rose; it rose upon no sadder sight than the man of
+good abilities and good emotions, incapable of their directed exercise,
+incapable of his own help and his own happiness, sensible of the blight
+on him, and resigning himself to let it eat him away.
+
+
+
+
+VI. Hundreds of People
+
+
+The quiet lodgings of Doctor Manette were in a quiet street-corner not
+far from Soho-square. On the afternoon of a certain fine Sunday when the
+waves of four months had rolled over the trial for treason, and carried
+it, as to the public interest and memory, far out to sea, Mr. Jarvis
+Lorry walked along the sunny streets from Clerkenwell where he lived,
+on his way to dine with the Doctor. After several relapses into
+business-absorption, Mr. Lorry had become the Doctor’s friend, and the
+quiet street-corner was the sunny part of his life.
+
+On this certain fine Sunday, Mr. Lorry walked towards Soho, early in
+the afternoon, for three reasons of habit. Firstly, because, on fine
+Sundays, he often walked out, before dinner, with the Doctor and Lucie;
+secondly, because, on unfavourable Sundays, he was accustomed to be with
+them as the family friend, talking, reading, looking out of window, and
+generally getting through the day; thirdly, because he happened to have
+his own little shrewd doubts to solve, and knew how the ways of the
+Doctor’s household pointed to that time as a likely time for solving
+them.
+
+A quainter corner than the corner where the Doctor lived, was not to be
+found in London. There was no way through it, and the front windows of
+the Doctor’s lodgings commanded a pleasant little vista of street that
+had a congenial air of retirement on it. There were few buildings then,
+north of the Oxford-road, and forest-trees flourished, and wild flowers
+grew, and the hawthorn blossomed, in the now vanished fields. As a
+consequence, country airs circulated in Soho with vigorous freedom,
+instead of languishing into the parish like stray paupers without a
+settlement; and there was many a good south wall, not far off, on which
+the peaches ripened in their season.
+
+The summer light struck into the corner brilliantly in the earlier part
+of the day; but, when the streets grew hot, the corner was in shadow,
+though not in shadow so remote but that you could see beyond it into a
+glare of brightness. It was a cool spot, staid but cheerful, a wonderful
+place for echoes, and a very harbour from the raging streets.
+
+There ought to have been a tranquil bark in such an anchorage, and
+there was. The Doctor occupied two floors of a large stiff house, where
+several callings purported to be pursued by day, but whereof little was
+audible any day, and which was shunned by all of them at night. In
+a building at the back, attainable by a courtyard where a plane-tree
+rustled its green leaves, church-organs claimed to be made, and silver
+to be chased, and likewise gold to be beaten by some mysterious giant
+who had a golden arm starting out of the wall of the front hall--as if
+he had beaten himself precious, and menaced a similar conversion of all
+visitors. Very little of these trades, or of a lonely lodger rumoured
+to live up-stairs, or of a dim coach-trimming maker asserted to have
+a counting-house below, was ever heard or seen. Occasionally, a stray
+workman putting his coat on, traversed the hall, or a stranger peered
+about there, or a distant clink was heard across the courtyard, or a
+thump from the golden giant. These, however, were only the exceptions
+required to prove the rule that the sparrows in the plane-tree behind
+the house, and the echoes in the corner before it, had their own way
+from Sunday morning unto Saturday night.
+
+Doctor Manette received such patients here as his old reputation, and
+its revival in the floating whispers of his story, brought him.
+His scientific knowledge, and his vigilance and skill in conducting
+ingenious experiments, brought him otherwise into moderate request, and
+he earned as much as he wanted.
+
+These things were within Mr. Jarvis Lorry’s knowledge, thoughts, and
+notice, when he rang the door-bell of the tranquil house in the corner,
+on the fine Sunday afternoon.
+
+“Doctor Manette at home?”
+
+Expected home.
+
+“Miss Lucie at home?”
+
+Expected home.
+
+“Miss Pross at home?”
+
+Possibly at home, but of a certainty impossible for handmaid to
+anticipate intentions of Miss Pross, as to admission or denial of the
+fact.
+
+“As I am at home myself,” said Mr. Lorry, “I’ll go upstairs.”
+
+Although the Doctor’s daughter had known nothing of the country of her
+birth, she appeared to have innately derived from it that ability to
+make much of little means, which is one of its most useful and most
+agreeable characteristics. Simple as the furniture was, it was set off
+by so many little adornments, of no value but for their taste and fancy,
+that its effect was delightful. The disposition of everything in the
+rooms, from the largest object to the least; the arrangement of colours,
+the elegant variety and contrast obtained by thrift in trifles, by
+delicate hands, clear eyes, and good sense; were at once so pleasant in
+themselves, and so expressive of their originator, that, as Mr. Lorry
+stood looking about him, the very chairs and tables seemed to ask him,
+with something of that peculiar expression which he knew so well by this
+time, whether he approved?
+
+There were three rooms on a floor, and, the doors by which they
+communicated being put open that the air might pass freely through them
+all, Mr. Lorry, smilingly observant of that fanciful resemblance which
+he detected all around him, walked from one to another. The first was
+the best room, and in it were Lucie’s birds, and flowers, and books,
+and desk, and work-table, and box of water-colours; the second was
+the Doctor’s consulting-room, used also as the dining-room; the third,
+changingly speckled by the rustle of the plane-tree in the yard, was the
+Doctor’s bedroom, and there, in a corner, stood the disused shoemaker’s
+bench and tray of tools, much as it had stood on the fifth floor of the
+dismal house by the wine-shop, in the suburb of Saint Antoine in Paris.
+
+“I wonder,” said Mr. Lorry, pausing in his looking about, “that he keeps
+that reminder of his sufferings about him!”
+
+“And why wonder at that?” was the abrupt inquiry that made him start.
+
+It proceeded from Miss Pross, the wild red woman, strong of hand, whose
+acquaintance he had first made at the Royal George Hotel at Dover, and
+had since improved.
+
+“I should have thought--” Mr. Lorry began.
+
+“Pooh! You’d have thought!” said Miss Pross; and Mr. Lorry left off.
+
+“How do you do?” inquired that lady then--sharply, and yet as if to
+express that she bore him no malice.
+
+“I am pretty well, I thank you,” answered Mr. Lorry, with meekness; “how
+are you?”
+
+“Nothing to boast of,” said Miss Pross.
+
+“Indeed?”
+
+“Ah! indeed!” said Miss Pross. “I am very much put out about my
+Ladybird.”
+
+“Indeed?”
+
+“For gracious sake say something else besides ‘indeed,’ or you’ll
+fidget me to death,” said Miss Pross: whose character (dissociated from
+stature) was shortness.
+
+“Really, then?” said Mr. Lorry, as an amendment.
+
+“Really, is bad enough,” returned Miss Pross, “but better. Yes, I am
+very much put out.”
+
+“May I ask the cause?”
+
+“I don’t want dozens of people who are not at all worthy of Ladybird, to
+come here looking after her,” said Miss Pross.
+
+“_Do_ dozens come for that purpose?”
+
+“Hundreds,” said Miss Pross.
+
+It was characteristic of this lady (as of some other people before her
+time and since) that whenever her original proposition was questioned,
+she exaggerated it.
+
+“Dear me!” said Mr. Lorry, as the safest remark he could think of.
+
+“I have lived with the darling--or the darling has lived with me, and
+paid me for it; which she certainly should never have done, you may take
+your affidavit, if I could have afforded to keep either myself or her
+for nothing--since she was ten years old. And it’s really very hard,”
+ said Miss Pross.
+
+Not seeing with precision what was very hard, Mr. Lorry shook his head;
+using that important part of himself as a sort of fairy cloak that would
+fit anything.
+
+“All sorts of people who are not in the least degree worthy of the pet,
+are always turning up,” said Miss Pross. “When you began it--”
+
+“_I_ began it, Miss Pross?”
+
+“Didn’t you? Who brought her father to life?”
+
+“Oh! If _that_ was beginning it--” said Mr. Lorry.
+
+“It wasn’t ending it, I suppose? I say, when you began it, it was hard
+enough; not that I have any fault to find with Doctor Manette, except
+that he is not worthy of such a daughter, which is no imputation on
+him, for it was not to be expected that anybody should be, under any
+circumstances. But it really is doubly and trebly hard to have crowds
+and multitudes of people turning up after him (I could have forgiven
+him), to take Ladybird’s affections away from me.”
+
+Mr. Lorry knew Miss Pross to be very jealous, but he also knew her by
+this time to be, beneath the service of her eccentricity, one of those
+unselfish creatures--found only among women--who will, for pure love and
+admiration, bind themselves willing slaves, to youth when they have lost
+it, to beauty that they never had, to accomplishments that they were
+never fortunate enough to gain, to bright hopes that never shone upon
+their own sombre lives. He knew enough of the world to know that there
+is nothing in it better than the faithful service of the heart; so
+rendered and so free from any mercenary taint, he had such an exalted
+respect for it, that in the retributive arrangements made by his own
+mind--we all make such arrangements, more or less--he stationed Miss
+Pross much nearer to the lower Angels than many ladies immeasurably
+better got up both by Nature and Art, who had balances at Tellson’s.
+
+“There never was, nor will be, but one man worthy of Ladybird,” said
+Miss Pross; “and that was my brother Solomon, if he hadn’t made a
+mistake in life.”
+
+Here again: Mr. Lorry’s inquiries into Miss Pross’s personal history had
+established the fact that her brother Solomon was a heartless scoundrel
+who had stripped her of everything she possessed, as a stake to
+speculate with, and had abandoned her in her poverty for evermore, with
+no touch of compunction. Miss Pross’s fidelity of belief in Solomon
+(deducting a mere trifle for this slight mistake) was quite a serious
+matter with Mr. Lorry, and had its weight in his good opinion of her.
+
+“As we happen to be alone for the moment, and are both people of
+business,” he said, when they had got back to the drawing-room and had
+sat down there in friendly relations, “let me ask you--does the Doctor,
+in talking with Lucie, never refer to the shoemaking time, yet?”
+
+“Never.”
+
+“And yet keeps that bench and those tools beside him?”
+
+“Ah!” returned Miss Pross, shaking her head. “But I don’t say he don’t
+refer to it within himself.”
+
+“Do you believe that he thinks of it much?”
+
+“I do,” said Miss Pross.
+
+“Do you imagine--” Mr. Lorry had begun, when Miss Pross took him up
+short with:
+
+“Never imagine anything. Have no imagination at all.”
+
+“I stand corrected; do you suppose--you go so far as to suppose,
+sometimes?”
+
+“Now and then,” said Miss Pross.
+
+“Do you suppose,” Mr. Lorry went on, with a laughing twinkle in his
+bright eye, as it looked kindly at her, “that Doctor Manette has any
+theory of his own, preserved through all those years, relative to
+the cause of his being so oppressed; perhaps, even to the name of his
+oppressor?”
+
+“I don’t suppose anything about it but what Ladybird tells me.”
+
+“And that is--?”
+
+“That she thinks he has.”
+
+“Now don’t be angry at my asking all these questions; because I am a
+mere dull man of business, and you are a woman of business.”
+
+“Dull?” Miss Pross inquired, with placidity.
+
+Rather wishing his modest adjective away, Mr. Lorry replied, “No, no,
+no. Surely not. To return to business:--Is it not remarkable that Doctor
+Manette, unquestionably innocent of any crime as we are all well assured
+he is, should never touch upon that question? I will not say with me,
+though he had business relations with me many years ago, and we are now
+intimate; I will say with the fair daughter to whom he is so devotedly
+attached, and who is so devotedly attached to him? Believe me, Miss
+Pross, I don’t approach the topic with you, out of curiosity, but out of
+zealous interest.”
+
+“Well! To the best of my understanding, and bad’s the best, you’ll tell
+me,” said Miss Pross, softened by the tone of the apology, “he is afraid
+of the whole subject.”
+
+“Afraid?”
+
+“It’s plain enough, I should think, why he may be. It’s a dreadful
+remembrance. Besides that, his loss of himself grew out of it. Not
+knowing how he lost himself, or how he recovered himself, he may never
+feel certain of not losing himself again. That alone wouldn’t make the
+subject pleasant, I should think.”
+
+It was a profounder remark than Mr. Lorry had looked for. “True,” said
+he, “and fearful to reflect upon. Yet, a doubt lurks in my mind, Miss
+Pross, whether it is good for Doctor Manette to have that suppression
+always shut up within him. Indeed, it is this doubt and the uneasiness
+it sometimes causes me that has led me to our present confidence.”
+
+“Can’t be helped,” said Miss Pross, shaking her head. “Touch that
+string, and he instantly changes for the worse. Better leave it alone.
+In short, must leave it alone, like or no like. Sometimes, he gets up in
+the dead of the night, and will be heard, by us overhead there, walking
+up and down, walking up and down, in his room. Ladybird has learnt to
+know then that his mind is walking up and down, walking up and down, in
+his old prison. She hurries to him, and they go on together, walking up
+and down, walking up and down, until he is composed. But he never says
+a word of the true reason of his restlessness, to her, and she finds it
+best not to hint at it to him. In silence they go walking up and down
+together, walking up and down together, till her love and company have
+brought him to himself.”
+
+Notwithstanding Miss Pross’s denial of her own imagination, there was a
+perception of the pain of being monotonously haunted by one sad idea,
+in her repetition of the phrase, walking up and down, which testified to
+her possessing such a thing.
+
+The corner has been mentioned as a wonderful corner for echoes; it
+had begun to echo so resoundingly to the tread of coming feet, that it
+seemed as though the very mention of that weary pacing to and fro had
+set it going.
+
+“Here they are!” said Miss Pross, rising to break up the conference;
+“and now we shall have hundreds of people pretty soon!”
+
+It was such a curious corner in its acoustical properties, such a
+peculiar Ear of a place, that as Mr. Lorry stood at the open window,
+looking for the father and daughter whose steps he heard, he fancied
+they would never approach. Not only would the echoes die away, as though
+the steps had gone; but, echoes of other steps that never came would be
+heard in their stead, and would die away for good when they seemed close
+at hand. However, father and daughter did at last appear, and Miss Pross
+was ready at the street door to receive them.
+
+Miss Pross was a pleasant sight, albeit wild, and red, and grim, taking
+off her darling’s bonnet when she came up-stairs, and touching it up
+with the ends of her handkerchief, and blowing the dust off it, and
+folding her mantle ready for laying by, and smoothing her rich hair with
+as much pride as she could possibly have taken in her own hair if she
+had been the vainest and handsomest of women. Her darling was a pleasant
+sight too, embracing her and thanking her, and protesting against
+her taking so much trouble for her--which last she only dared to do
+playfully, or Miss Pross, sorely hurt, would have retired to her own
+chamber and cried. The Doctor was a pleasant sight too, looking on at
+them, and telling Miss Pross how she spoilt Lucie, in accents and with
+eyes that had as much spoiling in them as Miss Pross had, and would
+have had more if it were possible. Mr. Lorry was a pleasant sight too,
+beaming at all this in his little wig, and thanking his bachelor
+stars for having lighted him in his declining years to a Home. But, no
+Hundreds of people came to see the sights, and Mr. Lorry looked in vain
+for the fulfilment of Miss Pross’s prediction.
+
+Dinner-time, and still no Hundreds of people. In the arrangements of
+the little household, Miss Pross took charge of the lower regions, and
+always acquitted herself marvellously. Her dinners, of a very modest
+quality, were so well cooked and so well served, and so neat in their
+contrivances, half English and half French, that nothing could be
+better. Miss Pross’s friendship being of the thoroughly practical
+kind, she had ravaged Soho and the adjacent provinces, in search of
+impoverished French, who, tempted by shillings and half-crowns, would
+impart culinary mysteries to her. From these decayed sons and daughters
+of Gaul, she had acquired such wonderful arts, that the woman and girl
+who formed the staff of domestics regarded her as quite a Sorceress,
+or Cinderella’s Godmother: who would send out for a fowl, a rabbit,
+a vegetable or two from the garden, and change them into anything she
+pleased.
+
+On Sundays, Miss Pross dined at the Doctor’s table, but on other days
+persisted in taking her meals at unknown periods, either in the lower
+regions, or in her own room on the second floor--a blue chamber, to
+which no one but her Ladybird ever gained admittance. On this occasion,
+Miss Pross, responding to Ladybird’s pleasant face and pleasant efforts
+to please her, unbent exceedingly; so the dinner was very pleasant, too.
+
+It was an oppressive day, and, after dinner, Lucie proposed that the
+wine should be carried out under the plane-tree, and they should sit
+there in the air. As everything turned upon her, and revolved about her,
+they went out under the plane-tree, and she carried the wine down for
+the special benefit of Mr. Lorry. She had installed herself, some
+time before, as Mr. Lorry’s cup-bearer; and while they sat under the
+plane-tree, talking, she kept his glass replenished. Mysterious backs
+and ends of houses peeped at them as they talked, and the plane-tree
+whispered to them in its own way above their heads.
+
+Still, the Hundreds of people did not present themselves. Mr. Darnay
+presented himself while they were sitting under the plane-tree, but he
+was only One.
+
+Doctor Manette received him kindly, and so did Lucie. But, Miss Pross
+suddenly became afflicted with a twitching in the head and body, and
+retired into the house. She was not unfrequently the victim of this
+disorder, and she called it, in familiar conversation, “a fit of the
+jerks.”
+
+The Doctor was in his best condition, and looked specially young. The
+resemblance between him and Lucie was very strong at such times, and as
+they sat side by side, she leaning on his shoulder, and he resting
+his arm on the back of her chair, it was very agreeable to trace the
+likeness.
+
+He had been talking all day, on many subjects, and with unusual
+vivacity. “Pray, Doctor Manette,” said Mr. Darnay, as they sat under the
+plane-tree--and he said it in the natural pursuit of the topic in hand,
+which happened to be the old buildings of London--“have you seen much of
+the Tower?”
+
+“Lucie and I have been there; but only casually. We have seen enough of
+it, to know that it teems with interest; little more.”
+
+“_I_ have been there, as you remember,” said Darnay, with a smile,
+though reddening a little angrily, “in another character, and not in a
+character that gives facilities for seeing much of it. They told me a
+curious thing when I was there.”
+
+“What was that?” Lucie asked.
+
+“In making some alterations, the workmen came upon an old dungeon, which
+had been, for many years, built up and forgotten. Every stone of
+its inner wall was covered by inscriptions which had been carved by
+prisoners--dates, names, complaints, and prayers. Upon a corner stone
+in an angle of the wall, one prisoner, who seemed to have gone to
+execution, had cut as his last work, three letters. They were done with
+some very poor instrument, and hurriedly, with an unsteady hand.
+At first, they were read as D. I. C.; but, on being more carefully
+examined, the last letter was found to be G. There was no record or
+legend of any prisoner with those initials, and many fruitless guesses
+were made what the name could have been. At length, it was suggested
+that the letters were not initials, but the complete word, DIG. The
+floor was examined very carefully under the inscription, and, in the
+earth beneath a stone, or tile, or some fragment of paving, were found
+the ashes of a paper, mingled with the ashes of a small leathern case
+or bag. What the unknown prisoner had written will never be read, but he
+had written something, and hidden it away to keep it from the gaoler.”
+
+“My father,” exclaimed Lucie, “you are ill!”
+
+He had suddenly started up, with his hand to his head. His manner and
+his look quite terrified them all.
+
+“No, my dear, not ill. There are large drops of rain falling, and they
+made me start. We had better go in.”
+
+He recovered himself almost instantly. Rain was really falling in large
+drops, and he showed the back of his hand with rain-drops on it. But, he
+said not a single word in reference to the discovery that had been told
+of, and, as they went into the house, the business eye of Mr. Lorry
+either detected, or fancied it detected, on his face, as it turned
+towards Charles Darnay, the same singular look that had been upon it
+when it turned towards him in the passages of the Court House.
+
+He recovered himself so quickly, however, that Mr. Lorry had doubts of
+his business eye. The arm of the golden giant in the hall was not more
+steady than he was, when he stopped under it to remark to them that he
+was not yet proof against slight surprises (if he ever would be), and
+that the rain had startled him.
+
+Tea-time, and Miss Pross making tea, with another fit of the jerks upon
+her, and yet no Hundreds of people. Mr. Carton had lounged in, but he
+made only Two.
+
+The night was so very sultry, that although they sat with doors and
+windows open, they were overpowered by heat. When the tea-table was
+done with, they all moved to one of the windows, and looked out into the
+heavy twilight. Lucie sat by her father; Darnay sat beside her; Carton
+leaned against a window. The curtains were long and white, and some of
+the thunder-gusts that whirled into the corner, caught them up to the
+ceiling, and waved them like spectral wings.
+
+“The rain-drops are still falling, large, heavy, and few,” said Doctor
+Manette. “It comes slowly.”
+
+“It comes surely,” said Carton.
+
+They spoke low, as people watching and waiting mostly do; as people in a
+dark room, watching and waiting for Lightning, always do.
+
+There was a great hurry in the streets of people speeding away to
+get shelter before the storm broke; the wonderful corner for echoes
+resounded with the echoes of footsteps coming and going, yet not a
+footstep was there.
+
+“A multitude of people, and yet a solitude!” said Darnay, when they had
+listened for a while.
+
+“Is it not impressive, Mr. Darnay?” asked Lucie. “Sometimes, I have
+sat here of an evening, until I have fancied--but even the shade of
+a foolish fancy makes me shudder to-night, when all is so black and
+solemn--”
+
+“Let us shudder too. We may know what it is.”
+
+“It will seem nothing to you. Such whims are only impressive as we
+originate them, I think; they are not to be communicated. I have
+sometimes sat alone here of an evening, listening, until I have made
+the echoes out to be the echoes of all the footsteps that are coming
+by-and-bye into our lives.”
+
+“There is a great crowd coming one day into our lives, if that be so,”
+ Sydney Carton struck in, in his moody way.
+
+The footsteps were incessant, and the hurry of them became more and more
+rapid. The corner echoed and re-echoed with the tread of feet; some,
+as it seemed, under the windows; some, as it seemed, in the room; some
+coming, some going, some breaking off, some stopping altogether; all in
+the distant streets, and not one within sight.
+
+“Are all these footsteps destined to come to all of us, Miss Manette, or
+are we to divide them among us?”
+
+“I don’t know, Mr. Darnay; I told you it was a foolish fancy, but you
+asked for it. When I have yielded myself to it, I have been alone, and
+then I have imagined them the footsteps of the people who are to come
+into my life, and my father’s.”
+
+“I take them into mine!” said Carton. “_I_ ask no questions and make no
+stipulations. There is a great crowd bearing down upon us, Miss Manette,
+and I see them--by the Lightning.” He added the last words, after there
+had been a vivid flash which had shown him lounging in the window.
+
+“And I hear them!” he added again, after a peal of thunder. “Here they
+come, fast, fierce, and furious!”
+
+It was the rush and roar of rain that he typified, and it stopped him,
+for no voice could be heard in it. A memorable storm of thunder and
+lightning broke with that sweep of water, and there was not a moment’s
+interval in crash, and fire, and rain, until after the moon rose at
+midnight.
+
+The great bell of Saint Paul’s was striking one in the cleared air, when
+Mr. Lorry, escorted by Jerry, high-booted and bearing a lantern, set
+forth on his return-passage to Clerkenwell. There were solitary patches
+of road on the way between Soho and Clerkenwell, and Mr. Lorry, mindful
+of foot-pads, always retained Jerry for this service: though it was
+usually performed a good two hours earlier.
+
+“What a night it has been! Almost a night, Jerry,” said Mr. Lorry, “to
+bring the dead out of their graves.”
+
+“I never see the night myself, master--nor yet I don’t expect to--what
+would do that,” answered Jerry.
+
+“Good night, Mr. Carton,” said the man of business. “Good night, Mr.
+Darnay. Shall we ever see such a night again, together!”
+
+Perhaps. Perhaps, see the great crowd of people with its rush and roar,
+bearing down upon them, too.
+
+
+
+
+VII. Monseigneur in Town
+
+
+Monseigneur, one of the great lords in power at the Court, held his
+fortnightly reception in his grand hotel in Paris. Monseigneur was in
+his inner room, his sanctuary of sanctuaries, the Holiest of Holiests to
+the crowd of worshippers in the suite of rooms without. Monseigneur
+was about to take his chocolate. Monseigneur could swallow a great many
+things with ease, and was by some few sullen minds supposed to be rather
+rapidly swallowing France; but, his morning’s chocolate could not so
+much as get into the throat of Monseigneur, without the aid of four
+strong men besides the Cook.
+
+Yes. It took four men, all four ablaze with gorgeous decoration, and the
+Chief of them unable to exist with fewer than two gold watches in his
+pocket, emulative of the noble and chaste fashion set by Monseigneur, to
+conduct the happy chocolate to Monseigneur’s lips. One lacquey carried
+the chocolate-pot into the sacred presence; a second, milled and frothed
+the chocolate with the little instrument he bore for that function;
+a third, presented the favoured napkin; a fourth (he of the two gold
+watches), poured the chocolate out. It was impossible for Monseigneur to
+dispense with one of these attendants on the chocolate and hold his high
+place under the admiring Heavens. Deep would have been the blot upon
+his escutcheon if his chocolate had been ignobly waited on by only three
+men; he must have died of two.
+
+Monseigneur had been out at a little supper last night, where the Comedy
+and the Grand Opera were charmingly represented. Monseigneur was out at
+a little supper most nights, with fascinating company. So polite and so
+impressible was Monseigneur, that the Comedy and the Grand Opera had far
+more influence with him in the tiresome articles of state affairs and
+state secrets, than the needs of all France. A happy circumstance
+for France, as the like always is for all countries similarly
+favoured!--always was for England (by way of example), in the regretted
+days of the merry Stuart who sold it.
+
+Monseigneur had one truly noble idea of general public business, which
+was, to let everything go on in its own way; of particular public
+business, Monseigneur had the other truly noble idea that it must all go
+his way--tend to his own power and pocket. Of his pleasures, general and
+particular, Monseigneur had the other truly noble idea, that the world
+was made for them. The text of his order (altered from the original
+by only a pronoun, which is not much) ran: “The earth and the fulness
+thereof are mine, saith Monseigneur.”
+
+Yet, Monseigneur had slowly found that vulgar embarrassments crept into
+his affairs, both private and public; and he had, as to both classes of
+affairs, allied himself perforce with a Farmer-General. As to finances
+public, because Monseigneur could not make anything at all of them, and
+must consequently let them out to somebody who could; as to finances
+private, because Farmer-Generals were rich, and Monseigneur, after
+generations of great luxury and expense, was growing poor. Hence
+Monseigneur had taken his sister from a convent, while there was yet
+time to ward off the impending veil, the cheapest garment she could
+wear, and had bestowed her as a prize upon a very rich Farmer-General,
+poor in family. Which Farmer-General, carrying an appropriate cane with
+a golden apple on the top of it, was now among the company in the outer
+rooms, much prostrated before by mankind--always excepting superior
+mankind of the blood of Monseigneur, who, his own wife included, looked
+down upon him with the loftiest contempt.
+
+A sumptuous man was the Farmer-General. Thirty horses stood in his
+stables, twenty-four male domestics sat in his halls, six body-women
+waited on his wife. As one who pretended to do nothing but plunder and
+forage where he could, the Farmer-General--howsoever his matrimonial
+relations conduced to social morality--was at least the greatest reality
+among the personages who attended at the hotel of Monseigneur that day.
+
+For, the rooms, though a beautiful scene to look at, and adorned with
+every device of decoration that the taste and skill of the time could
+achieve, were, in truth, not a sound business; considered with any
+reference to the scarecrows in the rags and nightcaps elsewhere (and not
+so far off, either, but that the watching towers of Notre Dame, almost
+equidistant from the two extremes, could see them both), they would
+have been an exceedingly uncomfortable business--if that could have
+been anybody’s business, at the house of Monseigneur. Military officers
+destitute of military knowledge; naval officers with no idea of a ship;
+civil officers without a notion of affairs; brazen ecclesiastics, of the
+worst world worldly, with sensual eyes, loose tongues, and looser lives;
+all totally unfit for their several callings, all lying horribly in
+pretending to belong to them, but all nearly or remotely of the order of
+Monseigneur, and therefore foisted on all public employments from which
+anything was to be got; these were to be told off by the score and the
+score. People not immediately connected with Monseigneur or the State,
+yet equally unconnected with anything that was real, or with lives
+passed in travelling by any straight road to any true earthly end, were
+no less abundant. Doctors who made great fortunes out of dainty remedies
+for imaginary disorders that never existed, smiled upon their courtly
+patients in the ante-chambers of Monseigneur. Projectors who had
+discovered every kind of remedy for the little evils with which the
+State was touched, except the remedy of setting to work in earnest to
+root out a single sin, poured their distracting babble into any ears
+they could lay hold of, at the reception of Monseigneur. Unbelieving
+Philosophers who were remodelling the world with words, and making
+card-towers of Babel to scale the skies with, talked with Unbelieving
+Chemists who had an eye on the transmutation of metals, at this
+wonderful gathering accumulated by Monseigneur. Exquisite gentlemen of
+the finest breeding, which was at that remarkable time--and has been
+since--to be known by its fruits of indifference to every natural
+subject of human interest, were in the most exemplary state of
+exhaustion, at the hotel of Monseigneur. Such homes had these various
+notabilities left behind them in the fine world of Paris, that the spies
+among the assembled devotees of Monseigneur--forming a goodly half
+of the polite company--would have found it hard to discover among
+the angels of that sphere one solitary wife, who, in her manners and
+appearance, owned to being a Mother. Indeed, except for the mere act of
+bringing a troublesome creature into this world--which does not go far
+towards the realisation of the name of mother--there was no such thing
+known to the fashion. Peasant women kept the unfashionable babies close,
+and brought them up, and charming grandmammas of sixty dressed and
+supped as at twenty.
+
+The leprosy of unreality disfigured every human creature in attendance
+upon Monseigneur. In the outermost room were half a dozen exceptional
+people who had had, for a few years, some vague misgiving in them that
+things in general were going rather wrong. As a promising way of setting
+them right, half of the half-dozen had become members of a fantastic
+sect of Convulsionists, and were even then considering within themselves
+whether they should foam, rage, roar, and turn cataleptic on the
+spot--thereby setting up a highly intelligible finger-post to the
+Future, for Monseigneur’s guidance. Besides these Dervishes, were other
+three who had rushed into another sect, which mended matters with a
+jargon about “the Centre of Truth:” holding that Man had got out of the
+Centre of Truth--which did not need much demonstration--but had not got
+out of the Circumference, and that he was to be kept from flying out of
+the Circumference, and was even to be shoved back into the Centre,
+by fasting and seeing of spirits. Among these, accordingly, much
+discoursing with spirits went on--and it did a world of good which never
+became manifest.
+
+But, the comfort was, that all the company at the grand hotel of
+Monseigneur were perfectly dressed. If the Day of Judgment had only been
+ascertained to be a dress day, everybody there would have been eternally
+correct. Such frizzling and powdering and sticking up of hair, such
+delicate complexions artificially preserved and mended, such gallant
+swords to look at, and such delicate honour to the sense of smell, would
+surely keep anything going, for ever and ever. The exquisite gentlemen
+of the finest breeding wore little pendent trinkets that chinked as they
+languidly moved; these golden fetters rang like precious little bells;
+and what with that ringing, and with the rustle of silk and brocade and
+fine linen, there was a flutter in the air that fanned Saint Antoine and
+his devouring hunger far away.
+
+Dress was the one unfailing talisman and charm used for keeping all
+things in their places. Everybody was dressed for a Fancy Ball that
+was never to leave off. From the Palace of the Tuileries, through
+Monseigneur and the whole Court, through the Chambers, the Tribunals
+of Justice, and all society (except the scarecrows), the Fancy Ball
+descended to the Common Executioner: who, in pursuance of the charm, was
+required to officiate “frizzled, powdered, in a gold-laced coat, pumps,
+and white silk stockings.” At the gallows and the wheel--the axe was a
+rarity--Monsieur Paris, as it was the episcopal mode among his brother
+Professors of the provinces, Monsieur Orleans, and the rest, to call
+him, presided in this dainty dress. And who among the company at
+Monseigneur’s reception in that seventeen hundred and eightieth year
+of our Lord, could possibly doubt, that a system rooted in a frizzled
+hangman, powdered, gold-laced, pumped, and white-silk stockinged, would
+see the very stars out!
+
+Monseigneur having eased his four men of their burdens and taken his
+chocolate, caused the doors of the Holiest of Holiests to be thrown
+open, and issued forth. Then, what submission, what cringing and
+fawning, what servility, what abject humiliation! As to bowing down in
+body and spirit, nothing in that way was left for Heaven--which may have
+been one among other reasons why the worshippers of Monseigneur never
+troubled it.
+
+Bestowing a word of promise here and a smile there, a whisper on one
+happy slave and a wave of the hand on another, Monseigneur affably
+passed through his rooms to the remote region of the Circumference of
+Truth. There, Monseigneur turned, and came back again, and so in due
+course of time got himself shut up in his sanctuary by the chocolate
+sprites, and was seen no more.
+
+The show being over, the flutter in the air became quite a little storm,
+and the precious little bells went ringing downstairs. There was soon
+but one person left of all the crowd, and he, with his hat under his arm
+and his snuff-box in his hand, slowly passed among the mirrors on his
+way out.
+
+“I devote you,” said this person, stopping at the last door on his way,
+and turning in the direction of the sanctuary, “to the Devil!”
+
+With that, he shook the snuff from his fingers as if he had shaken the
+dust from his feet, and quietly walked downstairs.
+
+He was a man of about sixty, handsomely dressed, haughty in manner, and
+with a face like a fine mask. A face of a transparent paleness; every
+feature in it clearly defined; one set expression on it. The nose,
+beautifully formed otherwise, was very slightly pinched at the top
+of each nostril. In those two compressions, or dints, the only little
+change that the face ever showed, resided. They persisted in changing
+colour sometimes, and they would be occasionally dilated and contracted
+by something like a faint pulsation; then, they gave a look of
+treachery, and cruelty, to the whole countenance. Examined with
+attention, its capacity of helping such a look was to be found in the
+line of the mouth, and the lines of the orbits of the eyes, being much
+too horizontal and thin; still, in the effect of the face made, it was a
+handsome face, and a remarkable one.
+
+Its owner went downstairs into the courtyard, got into his carriage, and
+drove away. Not many people had talked with him at the reception; he had
+stood in a little space apart, and Monseigneur might have been warmer
+in his manner. It appeared, under the circumstances, rather agreeable
+to him to see the common people dispersed before his horses, and
+often barely escaping from being run down. His man drove as if he were
+charging an enemy, and the furious recklessness of the man brought no
+check into the face, or to the lips, of the master. The complaint had
+sometimes made itself audible, even in that deaf city and dumb age,
+that, in the narrow streets without footways, the fierce patrician
+custom of hard driving endangered and maimed the mere vulgar in a
+barbarous manner. But, few cared enough for that to think of it a second
+time, and, in this matter, as in all others, the common wretches were
+left to get out of their difficulties as they could.
+
+With a wild rattle and clatter, and an inhuman abandonment of
+consideration not easy to be understood in these days, the carriage
+dashed through streets and swept round corners, with women screaming
+before it, and men clutching each other and clutching children out of
+its way. At last, swooping at a street corner by a fountain, one of its
+wheels came to a sickening little jolt, and there was a loud cry from a
+number of voices, and the horses reared and plunged.
+
+But for the latter inconvenience, the carriage probably would not have
+stopped; carriages were often known to drive on, and leave their wounded
+behind, and why not? But the frightened valet had got down in a hurry,
+and there were twenty hands at the horses’ bridles.
+
+“What has gone wrong?” said Monsieur, calmly looking out.
+
+A tall man in a nightcap had caught up a bundle from among the feet of
+the horses, and had laid it on the basement of the fountain, and was
+down in the mud and wet, howling over it like a wild animal.
+
+“Pardon, Monsieur the Marquis!” said a ragged and submissive man, “it is
+a child.”
+
+“Why does he make that abominable noise? Is it his child?”
+
+“Excuse me, Monsieur the Marquis--it is a pity--yes.”
+
+The fountain was a little removed; for the street opened, where it was,
+into a space some ten or twelve yards square. As the tall man suddenly
+got up from the ground, and came running at the carriage, Monsieur the
+Marquis clapped his hand for an instant on his sword-hilt.
+
+“Killed!” shrieked the man, in wild desperation, extending both arms at
+their length above his head, and staring at him. “Dead!”
+
+The people closed round, and looked at Monsieur the Marquis. There was
+nothing revealed by the many eyes that looked at him but watchfulness
+and eagerness; there was no visible menacing or anger. Neither did the
+people say anything; after the first cry, they had been silent, and they
+remained so. The voice of the submissive man who had spoken, was flat
+and tame in its extreme submission. Monsieur the Marquis ran his eyes
+over them all, as if they had been mere rats come out of their holes.
+
+He took out his purse.
+
+“It is extraordinary to me,” said he, “that you people cannot take care
+of yourselves and your children. One or the other of you is for ever in
+the way. How do I know what injury you have done my horses. See! Give
+him that.”
+
+He threw out a gold coin for the valet to pick up, and all the heads
+craned forward that all the eyes might look down at it as it fell. The
+tall man called out again with a most unearthly cry, “Dead!”
+
+He was arrested by the quick arrival of another man, for whom the rest
+made way. On seeing him, the miserable creature fell upon his shoulder,
+sobbing and crying, and pointing to the fountain, where some women were
+stooping over the motionless bundle, and moving gently about it. They
+were as silent, however, as the men.
+
+“I know all, I know all,” said the last comer. “Be a brave man, my
+Gaspard! It is better for the poor little plaything to die so, than to
+live. It has died in a moment without pain. Could it have lived an hour
+as happily?”
+
+“You are a philosopher, you there,” said the Marquis, smiling. “How do
+they call you?”
+
+“They call me Defarge.”
+
+“Of what trade?”
+
+“Monsieur the Marquis, vendor of wine.”
+
+“Pick up that, philosopher and vendor of wine,” said the Marquis,
+throwing him another gold coin, “and spend it as you will. The horses
+there; are they right?”
+
+Without deigning to look at the assemblage a second time, Monsieur the
+Marquis leaned back in his seat, and was just being driven away with the
+air of a gentleman who had accidentally broke some common thing, and had
+paid for it, and could afford to pay for it; when his ease was suddenly
+disturbed by a coin flying into his carriage, and ringing on its floor.
+
+“Hold!” said Monsieur the Marquis. “Hold the horses! Who threw that?”
+
+He looked to the spot where Defarge the vendor of wine had stood, a
+moment before; but the wretched father was grovelling on his face on
+the pavement in that spot, and the figure that stood beside him was the
+figure of a dark stout woman, knitting.
+
+“You dogs!” said the Marquis, but smoothly, and with an unchanged front,
+except as to the spots on his nose: “I would ride over any of you very
+willingly, and exterminate you from the earth. If I knew which rascal
+threw at the carriage, and if that brigand were sufficiently near it, he
+should be crushed under the wheels.”
+
+So cowed was their condition, and so long and hard their experience of
+what such a man could do to them, within the law and beyond it, that not
+a voice, or a hand, or even an eye was raised. Among the men, not one.
+But the woman who stood knitting looked up steadily, and looked the
+Marquis in the face. It was not for his dignity to notice it; his
+contemptuous eyes passed over her, and over all the other rats; and he
+leaned back in his seat again, and gave the word “Go on!”
+
+He was driven on, and other carriages came whirling by in quick
+succession; the Minister, the State-Projector, the Farmer-General, the
+Doctor, the Lawyer, the Ecclesiastic, the Grand Opera, the Comedy, the
+whole Fancy Ball in a bright continuous flow, came whirling by. The rats
+had crept out of their holes to look on, and they remained looking
+on for hours; soldiers and police often passing between them and the
+spectacle, and making a barrier behind which they slunk, and through
+which they peeped. The father had long ago taken up his bundle and
+bidden himself away with it, when the women who had tended the bundle
+while it lay on the base of the fountain, sat there watching the running
+of the water and the rolling of the Fancy Ball--when the one woman who
+had stood conspicuous, knitting, still knitted on with the steadfastness
+of Fate. The water of the fountain ran, the swift river ran, the day ran
+into evening, so much life in the city ran into death according to rule,
+time and tide waited for no man, the rats were sleeping close together
+in their dark holes again, the Fancy Ball was lighted up at supper, all
+things ran their course.
+
+
+
+
+VIII. Monseigneur in the Country
+
+
+A beautiful landscape, with the corn bright in it, but not abundant.
+Patches of poor rye where corn should have been, patches of poor peas
+and beans, patches of most coarse vegetable substitutes for wheat. On
+inanimate nature, as on the men and women who cultivated it, a prevalent
+tendency towards an appearance of vegetating unwillingly--a dejected
+disposition to give up, and wither away.
+
+Monsieur the Marquis in his travelling carriage (which might have been
+lighter), conducted by four post-horses and two postilions, fagged up
+a steep hill. A blush on the countenance of Monsieur the Marquis was
+no impeachment of his high breeding; it was not from within; it was
+occasioned by an external circumstance beyond his control--the setting
+sun.
+
+The sunset struck so brilliantly into the travelling carriage when it
+gained the hill-top, that its occupant was steeped in crimson. “It will
+die out,” said Monsieur the Marquis, glancing at his hands, “directly.”
+
+In effect, the sun was so low that it dipped at the moment. When the
+heavy drag had been adjusted to the wheel, and the carriage slid down
+hill, with a cinderous smell, in a cloud of dust, the red glow departed
+quickly; the sun and the Marquis going down together, there was no glow
+left when the drag was taken off.
+
+But, there remained a broken country, bold and open, a little village
+at the bottom of the hill, a broad sweep and rise beyond it, a
+church-tower, a windmill, a forest for the chase, and a crag with a
+fortress on it used as a prison. Round upon all these darkening objects
+as the night drew on, the Marquis looked, with the air of one who was
+coming near home.
+
+The village had its one poor street, with its poor brewery, poor
+tannery, poor tavern, poor stable-yard for relays of post-horses, poor
+fountain, all usual poor appointments. It had its poor people too. All
+its people were poor, and many of them were sitting at their doors,
+shredding spare onions and the like for supper, while many were at the
+fountain, washing leaves, and grasses, and any such small yieldings of
+the earth that could be eaten. Expressive signs of what made them poor,
+were not wanting; the tax for the state, the tax for the church, the tax
+for the lord, tax local and tax general, were to be paid here and to be
+paid there, according to solemn inscription in the little village, until
+the wonder was, that there was any village left unswallowed.
+
+Few children were to be seen, and no dogs. As to the men and women,
+their choice on earth was stated in the prospect--Life on the lowest
+terms that could sustain it, down in the little village under the mill;
+or captivity and Death in the dominant prison on the crag.
+
+Heralded by a courier in advance, and by the cracking of his postilions’
+whips, which twined snake-like about their heads in the evening air, as
+if he came attended by the Furies, Monsieur the Marquis drew up in
+his travelling carriage at the posting-house gate. It was hard by the
+fountain, and the peasants suspended their operations to look at him.
+He looked at them, and saw in them, without knowing it, the slow
+sure filing down of misery-worn face and figure, that was to make the
+meagreness of Frenchmen an English superstition which should survive the
+truth through the best part of a hundred years.
+
+Monsieur the Marquis cast his eyes over the submissive faces that
+drooped before him, as the like of himself had drooped before
+Monseigneur of the Court--only the difference was, that these faces
+drooped merely to suffer and not to propitiate--when a grizzled mender
+of the roads joined the group.
+
+“Bring me hither that fellow!” said the Marquis to the courier.
+
+The fellow was brought, cap in hand, and the other fellows closed round
+to look and listen, in the manner of the people at the Paris fountain.
+
+“I passed you on the road?”
+
+“Monseigneur, it is true. I had the honour of being passed on the road.”
+
+“Coming up the hill, and at the top of the hill, both?”
+
+“Monseigneur, it is true.”
+
+“What did you look at, so fixedly?”
+
+“Monseigneur, I looked at the man.”
+
+He stooped a little, and with his tattered blue cap pointed under the
+carriage. All his fellows stooped to look under the carriage.
+
+“What man, pig? And why look there?”
+
+“Pardon, Monseigneur; he swung by the chain of the shoe--the drag.”
+
+“Who?” demanded the traveller.
+
+“Monseigneur, the man.”
+
+“May the Devil carry away these idiots! How do you call the man? You
+know all the men of this part of the country. Who was he?”
+
+“Your clemency, Monseigneur! He was not of this part of the country. Of
+all the days of my life, I never saw him.”
+
+“Swinging by the chain? To be suffocated?”
+
+“With your gracious permission, that was the wonder of it, Monseigneur.
+His head hanging over--like this!”
+
+He turned himself sideways to the carriage, and leaned back, with his
+face thrown up to the sky, and his head hanging down; then recovered
+himself, fumbled with his cap, and made a bow.
+
+“What was he like?”
+
+“Monseigneur, he was whiter than the miller. All covered with dust,
+white as a spectre, tall as a spectre!”
+
+The picture produced an immense sensation in the little crowd; but all
+eyes, without comparing notes with other eyes, looked at Monsieur
+the Marquis. Perhaps, to observe whether he had any spectre on his
+conscience.
+
+“Truly, you did well,” said the Marquis, felicitously sensible that such
+vermin were not to ruffle him, “to see a thief accompanying my carriage,
+and not open that great mouth of yours. Bah! Put him aside, Monsieur
+Gabelle!”
+
+Monsieur Gabelle was the Postmaster, and some other taxing functionary
+united; he had come out with great obsequiousness to assist at this
+examination, and had held the examined by the drapery of his arm in an
+official manner.
+
+“Bah! Go aside!” said Monsieur Gabelle.
+
+“Lay hands on this stranger if he seeks to lodge in your village
+to-night, and be sure that his business is honest, Gabelle.”
+
+“Monseigneur, I am flattered to devote myself to your orders.”
+
+“Did he run away, fellow?--where is that Accursed?”
+
+The accursed was already under the carriage with some half-dozen
+particular friends, pointing out the chain with his blue cap. Some
+half-dozen other particular friends promptly hauled him out, and
+presented him breathless to Monsieur the Marquis.
+
+“Did the man run away, Dolt, when we stopped for the drag?”
+
+“Monseigneur, he precipitated himself over the hill-side, head first, as
+a person plunges into the river.”
+
+“See to it, Gabelle. Go on!”
+
+The half-dozen who were peering at the chain were still among the
+wheels, like sheep; the wheels turned so suddenly that they were lucky
+to save their skins and bones; they had very little else to save, or
+they might not have been so fortunate.
+
+The burst with which the carriage started out of the village and up the
+rise beyond, was soon checked by the steepness of the hill. Gradually,
+it subsided to a foot pace, swinging and lumbering upward among the many
+sweet scents of a summer night. The postilions, with a thousand gossamer
+gnats circling about them in lieu of the Furies, quietly mended the
+points to the lashes of their whips; the valet walked by the horses; the
+courier was audible, trotting on ahead into the dull distance.
+
+At the steepest point of the hill there was a little burial-ground,
+with a Cross and a new large figure of Our Saviour on it; it was a poor
+figure in wood, done by some inexperienced rustic carver, but he had
+studied the figure from the life--his own life, maybe--for it was
+dreadfully spare and thin.
+
+To this distressful emblem of a great distress that had long been
+growing worse, and was not at its worst, a woman was kneeling. She
+turned her head as the carriage came up to her, rose quickly, and
+presented herself at the carriage-door.
+
+“It is you, Monseigneur! Monseigneur, a petition.”
+
+With an exclamation of impatience, but with his unchangeable face,
+Monseigneur looked out.
+
+“How, then! What is it? Always petitions!”
+
+“Monseigneur. For the love of the great God! My husband, the forester.”
+
+“What of your husband, the forester? Always the same with you people. He
+cannot pay something?”
+
+“He has paid all, Monseigneur. He is dead.”
+
+“Well! He is quiet. Can I restore him to you?”
+
+“Alas, no, Monseigneur! But he lies yonder, under a little heap of poor
+grass.”
+
+“Well?”
+
+“Monseigneur, there are so many little heaps of poor grass?”
+
+“Again, well?”
+
+She looked an old woman, but was young. Her manner was one of passionate
+grief; by turns she clasped her veinous and knotted hands together
+with wild energy, and laid one of them on the carriage-door--tenderly,
+caressingly, as if it had been a human breast, and could be expected to
+feel the appealing touch.
+
+“Monseigneur, hear me! Monseigneur, hear my petition! My husband died of
+want; so many die of want; so many more will die of want.”
+
+“Again, well? Can I feed them?”
+
+“Monseigneur, the good God knows; but I don’t ask it. My petition is,
+that a morsel of stone or wood, with my husband’s name, may be placed
+over him to show where he lies. Otherwise, the place will be quickly
+forgotten, it will never be found when I am dead of the same malady, I
+shall be laid under some other heap of poor grass. Monseigneur, they
+are so many, they increase so fast, there is so much want. Monseigneur!
+Monseigneur!”
+
+The valet had put her away from the door, the carriage had broken into
+a brisk trot, the postilions had quickened the pace, she was left far
+behind, and Monseigneur, again escorted by the Furies, was rapidly
+diminishing the league or two of distance that remained between him and
+his chateau.
+
+The sweet scents of the summer night rose all around him, and rose, as
+the rain falls, impartially, on the dusty, ragged, and toil-worn group
+at the fountain not far away; to whom the mender of roads, with the aid
+of the blue cap without which he was nothing, still enlarged upon his
+man like a spectre, as long as they could bear it. By degrees, as they
+could bear no more, they dropped off one by one, and lights twinkled
+in little casements; which lights, as the casements darkened, and more
+stars came out, seemed to have shot up into the sky instead of having
+been extinguished.
+
+The shadow of a large high-roofed house, and of many over-hanging trees,
+was upon Monsieur the Marquis by that time; and the shadow was exchanged
+for the light of a flambeau, as his carriage stopped, and the great door
+of his chateau was opened to him.
+
+“Monsieur Charles, whom I expect; is he arrived from England?”
+
+“Monseigneur, not yet.”
+
+
+
+
+IX. The Gorgon’s Head
+
+
+It was a heavy mass of building, that chateau of Monsieur the Marquis,
+with a large stone courtyard before it, and two stone sweeps of
+staircase meeting in a stone terrace before the principal door. A stony
+business altogether, with heavy stone balustrades, and stone urns, and
+stone flowers, and stone faces of men, and stone heads of lions, in
+all directions. As if the Gorgon’s head had surveyed it, when it was
+finished, two centuries ago.
+
+Up the broad flight of shallow steps, Monsieur the Marquis, flambeau
+preceded, went from his carriage, sufficiently disturbing the darkness
+to elicit loud remonstrance from an owl in the roof of the great pile
+of stable building away among the trees. All else was so quiet, that the
+flambeau carried up the steps, and the other flambeau held at the great
+door, burnt as if they were in a close room of state, instead of being
+in the open night-air. Other sound than the owl’s voice there was none,
+save the falling of a fountain into its stone basin; for, it was one of
+those dark nights that hold their breath by the hour together, and then
+heave a long low sigh, and hold their breath again.
+
+The great door clanged behind him, and Monsieur the Marquis crossed a
+hall grim with certain old boar-spears, swords, and knives of the chase;
+grimmer with certain heavy riding-rods and riding-whips, of which many a
+peasant, gone to his benefactor Death, had felt the weight when his lord
+was angry.
+
+Avoiding the larger rooms, which were dark and made fast for the night,
+Monsieur the Marquis, with his flambeau-bearer going on before, went up
+the staircase to a door in a corridor. This thrown open, admitted him
+to his own private apartment of three rooms: his bed-chamber and two
+others. High vaulted rooms with cool uncarpeted floors, great dogs upon
+the hearths for the burning of wood in winter time, and all luxuries
+befitting the state of a marquis in a luxurious age and country.
+The fashion of the last Louis but one, of the line that was never to
+break--the fourteenth Louis--was conspicuous in their rich furniture;
+but, it was diversified by many objects that were illustrations of old
+pages in the history of France.
+
+A supper-table was laid for two, in the third of the rooms; a round
+room, in one of the chateau’s four extinguisher-topped towers. A small
+lofty room, with its window wide open, and the wooden jalousie-blinds
+closed, so that the dark night only showed in slight horizontal lines of
+black, alternating with their broad lines of stone colour.
+
+“My nephew,” said the Marquis, glancing at the supper preparation; “they
+said he was not arrived.”
+
+Nor was he; but, he had been expected with Monseigneur.
+
+“Ah! It is not probable he will arrive to-night; nevertheless, leave the
+table as it is. I shall be ready in a quarter of an hour.”
+
+In a quarter of an hour Monseigneur was ready, and sat down alone to his
+sumptuous and choice supper. His chair was opposite to the window, and
+he had taken his soup, and was raising his glass of Bordeaux to his
+lips, when he put it down.
+
+“What is that?” he calmly asked, looking with attention at the
+horizontal lines of black and stone colour.
+
+“Monseigneur? That?”
+
+“Outside the blinds. Open the blinds.”
+
+It was done.
+
+“Well?”
+
+“Monseigneur, it is nothing. The trees and the night are all that are
+here.”
+
+The servant who spoke, had thrown the blinds wide, had looked out into
+the vacant darkness, and stood with that blank behind him, looking round
+for instructions.
+
+“Good,” said the imperturbable master. “Close them again.”
+
+That was done too, and the Marquis went on with his supper. He was
+half way through it, when he again stopped with his glass in his hand,
+hearing the sound of wheels. It came on briskly, and came up to the
+front of the chateau.
+
+“Ask who is arrived.”
+
+It was the nephew of Monseigneur. He had been some few leagues behind
+Monseigneur, early in the afternoon. He had diminished the distance
+rapidly, but not so rapidly as to come up with Monseigneur on the road.
+He had heard of Monseigneur, at the posting-houses, as being before him.
+
+He was to be told (said Monseigneur) that supper awaited him then and
+there, and that he was prayed to come to it. In a little while he came.
+He had been known in England as Charles Darnay.
+
+Monseigneur received him in a courtly manner, but they did not shake
+hands.
+
+“You left Paris yesterday, sir?” he said to Monseigneur, as he took his
+seat at table.
+
+“Yesterday. And you?”
+
+“I come direct.”
+
+“From London?”
+
+“Yes.”
+
+“You have been a long time coming,” said the Marquis, with a smile.
+
+“On the contrary; I come direct.”
+
+“Pardon me! I mean, not a long time on the journey; a long time
+intending the journey.”
+
+“I have been detained by”--the nephew stopped a moment in his
+answer--“various business.”
+
+“Without doubt,” said the polished uncle.
+
+So long as a servant was present, no other words passed between them.
+When coffee had been served and they were alone together, the nephew,
+looking at the uncle and meeting the eyes of the face that was like a
+fine mask, opened a conversation.
+
+“I have come back, sir, as you anticipate, pursuing the object that
+took me away. It carried me into great and unexpected peril; but it is
+a sacred object, and if it had carried me to death I hope it would have
+sustained me.”
+
+“Not to death,” said the uncle; “it is not necessary to say, to death.”
+
+“I doubt, sir,” returned the nephew, “whether, if it had carried me to
+the utmost brink of death, you would have cared to stop me there.”
+
+The deepened marks in the nose, and the lengthening of the fine straight
+lines in the cruel face, looked ominous as to that; the uncle made a
+graceful gesture of protest, which was so clearly a slight form of good
+breeding that it was not reassuring.
+
+“Indeed, sir,” pursued the nephew, “for anything I know, you may have
+expressly worked to give a more suspicious appearance to the suspicious
+circumstances that surrounded me.”
+
+“No, no, no,” said the uncle, pleasantly.
+
+“But, however that may be,” resumed the nephew, glancing at him with
+deep distrust, “I know that your diplomacy would stop me by any means,
+and would know no scruple as to means.”
+
+“My friend, I told you so,” said the uncle, with a fine pulsation in the
+two marks. “Do me the favour to recall that I told you so, long ago.”
+
+“I recall it.”
+
+“Thank you,” said the Marquis--very sweetly indeed.
+
+His tone lingered in the air, almost like the tone of a musical
+instrument.
+
+“In effect, sir,” pursued the nephew, “I believe it to be at once your
+bad fortune, and my good fortune, that has kept me out of a prison in
+France here.”
+
+“I do not quite understand,” returned the uncle, sipping his coffee.
+“Dare I ask you to explain?”
+
+“I believe that if you were not in disgrace with the Court, and had not
+been overshadowed by that cloud for years past, a letter de cachet would
+have sent me to some fortress indefinitely.”
+
+“It is possible,” said the uncle, with great calmness. “For the honour
+of the family, I could even resolve to incommode you to that extent.
+Pray excuse me!”
+
+“I perceive that, happily for me, the Reception of the day before
+yesterday was, as usual, a cold one,” observed the nephew.
+
+“I would not say happily, my friend,” returned the uncle, with refined
+politeness; “I would not be sure of that. A good opportunity for
+consideration, surrounded by the advantages of solitude, might influence
+your destiny to far greater advantage than you influence it for
+yourself. But it is useless to discuss the question. I am, as you say,
+at a disadvantage. These little instruments of correction, these gentle
+aids to the power and honour of families, these slight favours that
+might so incommode you, are only to be obtained now by interest
+and importunity. They are sought by so many, and they are granted
+(comparatively) to so few! It used not to be so, but France in all such
+things is changed for the worse. Our not remote ancestors held the right
+of life and death over the surrounding vulgar. From this room, many such
+dogs have been taken out to be hanged; in the next room (my bedroom),
+one fellow, to our knowledge, was poniarded on the spot for professing
+some insolent delicacy respecting his daughter--_his_ daughter? We have
+lost many privileges; a new philosophy has become the mode; and the
+assertion of our station, in these days, might (I do not go so far as
+to say would, but might) cause us real inconvenience. All very bad, very
+bad!”
+
+The Marquis took a gentle little pinch of snuff, and shook his head;
+as elegantly despondent as he could becomingly be of a country still
+containing himself, that great means of regeneration.
+
+“We have so asserted our station, both in the old time and in the modern
+time also,” said the nephew, gloomily, “that I believe our name to be
+more detested than any name in France.”
+
+“Let us hope so,” said the uncle. “Detestation of the high is the
+involuntary homage of the low.”
+
+“There is not,” pursued the nephew, in his former tone, “a face I can
+look at, in all this country round about us, which looks at me with any
+deference on it but the dark deference of fear and slavery.”
+
+“A compliment,” said the Marquis, “to the grandeur of the family,
+merited by the manner in which the family has sustained its grandeur.
+Hah!” And he took another gentle little pinch of snuff, and lightly
+crossed his legs.
+
+But, when his nephew, leaning an elbow on the table, covered his eyes
+thoughtfully and dejectedly with his hand, the fine mask looked at
+him sideways with a stronger concentration of keenness, closeness,
+and dislike, than was comportable with its wearer’s assumption of
+indifference.
+
+“Repression is the only lasting philosophy. The dark deference of fear
+and slavery, my friend,” observed the Marquis, “will keep the dogs
+obedient to the whip, as long as this roof,” looking up to it, “shuts
+out the sky.”
+
+That might not be so long as the Marquis supposed. If a picture of the
+chateau as it was to be a very few years hence, and of fifty like it as
+they too were to be a very few years hence, could have been shown to
+him that night, he might have been at a loss to claim his own from
+the ghastly, fire-charred, plunder-wrecked rains. As for the roof
+he vaunted, he might have found _that_ shutting out the sky in a new
+way--to wit, for ever, from the eyes of the bodies into which its lead
+was fired, out of the barrels of a hundred thousand muskets.
+
+“Meanwhile,” said the Marquis, “I will preserve the honour and repose
+of the family, if you will not. But you must be fatigued. Shall we
+terminate our conference for the night?”
+
+“A moment more.”
+
+“An hour, if you please.”
+
+“Sir,” said the nephew, “we have done wrong, and are reaping the fruits
+of wrong.”
+
+“_We_ have done wrong?” repeated the Marquis, with an inquiring smile,
+and delicately pointing, first to his nephew, then to himself.
+
+“Our family; our honourable family, whose honour is of so much account
+to both of us, in such different ways. Even in my father’s time, we did
+a world of wrong, injuring every human creature who came between us and
+our pleasure, whatever it was. Why need I speak of my father’s time,
+when it is equally yours? Can I separate my father’s twin-brother, joint
+inheritor, and next successor, from himself?”
+
+“Death has done that!” said the Marquis.
+
+“And has left me,” answered the nephew, “bound to a system that is
+frightful to me, responsible for it, but powerless in it; seeking to
+execute the last request of my dear mother’s lips, and obey the last
+look of my dear mother’s eyes, which implored me to have mercy and to
+redress; and tortured by seeking assistance and power in vain.”
+
+“Seeking them from me, my nephew,” said the Marquis, touching him on the
+breast with his forefinger--they were now standing by the hearth--“you
+will for ever seek them in vain, be assured.”
+
+Every fine straight line in the clear whiteness of his face, was
+cruelly, craftily, and closely compressed, while he stood looking
+quietly at his nephew, with his snuff-box in his hand. Once again he
+touched him on the breast, as though his finger were the fine point of
+a small sword, with which, in delicate finesse, he ran him through the
+body, and said,
+
+“My friend, I will die, perpetuating the system under which I have
+lived.”
+
+When he had said it, he took a culminating pinch of snuff, and put his
+box in his pocket.
+
+“Better to be a rational creature,” he added then, after ringing a small
+bell on the table, “and accept your natural destiny. But you are lost,
+Monsieur Charles, I see.”
+
+“This property and France are lost to me,” said the nephew, sadly; “I
+renounce them.”
+
+“Are they both yours to renounce? France may be, but is the property? It
+is scarcely worth mentioning; but, is it yet?”
+
+“I had no intention, in the words I used, to claim it yet. If it passed
+to me from you, to-morrow--”
+
+“Which I have the vanity to hope is not probable.”
+
+“--or twenty years hence--”
+
+“You do me too much honour,” said the Marquis; “still, I prefer that
+supposition.”
+
+“--I would abandon it, and live otherwise and elsewhere. It is little to
+relinquish. What is it but a wilderness of misery and ruin!”
+
+“Hah!” said the Marquis, glancing round the luxurious room.
+
+“To the eye it is fair enough, here; but seen in its integrity,
+under the sky, and by the daylight, it is a crumbling tower of waste,
+mismanagement, extortion, debt, mortgage, oppression, hunger, nakedness,
+and suffering.”
+
+“Hah!” said the Marquis again, in a well-satisfied manner.
+
+“If it ever becomes mine, it shall be put into some hands better
+qualified to free it slowly (if such a thing is possible) from the
+weight that drags it down, so that the miserable people who cannot leave
+it and who have been long wrung to the last point of endurance, may, in
+another generation, suffer less; but it is not for me. There is a curse
+on it, and on all this land.”
+
+“And you?” said the uncle. “Forgive my curiosity; do you, under your new
+philosophy, graciously intend to live?”
+
+“I must do, to live, what others of my countrymen, even with nobility at
+their backs, may have to do some day--work.”
+
+“In England, for example?”
+
+“Yes. The family honour, sir, is safe from me in this country. The
+family name can suffer from me in no other, for I bear it in no other.”
+
+The ringing of the bell had caused the adjoining bed-chamber to be
+lighted. It now shone brightly, through the door of communication. The
+Marquis looked that way, and listened for the retreating step of his
+valet.
+
+“England is very attractive to you, seeing how indifferently you have
+prospered there,” he observed then, turning his calm face to his nephew
+with a smile.
+
+“I have already said, that for my prospering there, I am sensible I may
+be indebted to you, sir. For the rest, it is my Refuge.”
+
+“They say, those boastful English, that it is the Refuge of many. You
+know a compatriot who has found a Refuge there? A Doctor?”
+
+“Yes.”
+
+“With a daughter?”
+
+“Yes.”
+
+“Yes,” said the Marquis. “You are fatigued. Good night!”
+
+As he bent his head in his most courtly manner, there was a secrecy
+in his smiling face, and he conveyed an air of mystery to those words,
+which struck the eyes and ears of his nephew forcibly. At the same
+time, the thin straight lines of the setting of the eyes, and the thin
+straight lips, and the markings in the nose, curved with a sarcasm that
+looked handsomely diabolic.
+
+“Yes,” repeated the Marquis. “A Doctor with a daughter. Yes. So
+commences the new philosophy! You are fatigued. Good night!”
+
+It would have been of as much avail to interrogate any stone face
+outside the chateau as to interrogate that face of his. The nephew
+looked at him, in vain, in passing on to the door.
+
+“Good night!” said the uncle. “I look to the pleasure of seeing you
+again in the morning. Good repose! Light Monsieur my nephew to his
+chamber there!--And burn Monsieur my nephew in his bed, if you will,” he
+added to himself, before he rang his little bell again, and summoned his
+valet to his own bedroom.
+
+The valet come and gone, Monsieur the Marquis walked to and fro in his
+loose chamber-robe, to prepare himself gently for sleep, that hot still
+night. Rustling about the room, his softly-slippered feet making no
+noise on the floor, he moved like a refined tiger:--looked like some
+enchanted marquis of the impenitently wicked sort, in story, whose
+periodical change into tiger form was either just going off, or just
+coming on.
+
+He moved from end to end of his voluptuous bedroom, looking again at the
+scraps of the day’s journey that came unbidden into his mind; the slow
+toil up the hill at sunset, the setting sun, the descent, the mill, the
+prison on the crag, the little village in the hollow, the peasants at
+the fountain, and the mender of roads with his blue cap pointing out the
+chain under the carriage. That fountain suggested the Paris fountain,
+the little bundle lying on the step, the women bending over it, and the
+tall man with his arms up, crying, “Dead!”
+
+“I am cool now,” said Monsieur the Marquis, “and may go to bed.”
+
+So, leaving only one light burning on the large hearth, he let his thin
+gauze curtains fall around him, and heard the night break its silence
+with a long sigh as he composed himself to sleep.
+
+The stone faces on the outer walls stared blindly at the black night
+for three heavy hours; for three heavy hours, the horses in the stables
+rattled at their racks, the dogs barked, and the owl made a noise with
+very little resemblance in it to the noise conventionally assigned to
+the owl by men-poets. But it is the obstinate custom of such creatures
+hardly ever to say what is set down for them.
+
+For three heavy hours, the stone faces of the chateau, lion and human,
+stared blindly at the night. Dead darkness lay on all the landscape,
+dead darkness added its own hush to the hushing dust on all the roads.
+The burial-place had got to the pass that its little heaps of poor grass
+were undistinguishable from one another; the figure on the Cross might
+have come down, for anything that could be seen of it. In the village,
+taxers and taxed were fast asleep. Dreaming, perhaps, of banquets, as
+the starved usually do, and of ease and rest, as the driven slave and
+the yoked ox may, its lean inhabitants slept soundly, and were fed and
+freed.
+
+The fountain in the village flowed unseen and unheard, and the fountain
+at the chateau dropped unseen and unheard--both melting away, like the
+minutes that were falling from the spring of Time--through three dark
+hours. Then, the grey water of both began to be ghostly in the light,
+and the eyes of the stone faces of the chateau were opened.
+
+Lighter and lighter, until at last the sun touched the tops of the still
+trees, and poured its radiance over the hill. In the glow, the water
+of the chateau fountain seemed to turn to blood, and the stone faces
+crimsoned. The carol of the birds was loud and high, and, on the
+weather-beaten sill of the great window of the bed-chamber of Monsieur
+the Marquis, one little bird sang its sweetest song with all its might.
+At this, the nearest stone face seemed to stare amazed, and, with open
+mouth and dropped under-jaw, looked awe-stricken.
+
+Now, the sun was full up, and movement began in the village. Casement
+windows opened, crazy doors were unbarred, and people came forth
+shivering--chilled, as yet, by the new sweet air. Then began the rarely
+lightened toil of the day among the village population. Some, to the
+fountain; some, to the fields; men and women here, to dig and delve; men
+and women there, to see to the poor live stock, and lead the bony cows
+out, to such pasture as could be found by the roadside. In the church
+and at the Cross, a kneeling figure or two; attendant on the latter
+prayers, the led cow, trying for a breakfast among the weeds at its
+foot.
+
+The chateau awoke later, as became its quality, but awoke gradually and
+surely. First, the lonely boar-spears and knives of the chase had been
+reddened as of old; then, had gleamed trenchant in the morning sunshine;
+now, doors and windows were thrown open, horses in their stables looked
+round over their shoulders at the light and freshness pouring in at
+doorways, leaves sparkled and rustled at iron-grated windows, dogs
+pulled hard at their chains, and reared impatient to be loosed.
+
+All these trivial incidents belonged to the routine of life, and the
+return of morning. Surely, not so the ringing of the great bell of the
+chateau, nor the running up and down the stairs; nor the hurried
+figures on the terrace; nor the booting and tramping here and there and
+everywhere, nor the quick saddling of horses and riding away?
+
+What winds conveyed this hurry to the grizzled mender of roads, already
+at work on the hill-top beyond the village, with his day’s dinner (not
+much to carry) lying in a bundle that it was worth no crow’s while to
+peck at, on a heap of stones? Had the birds, carrying some grains of it
+to a distance, dropped one over him as they sow chance seeds? Whether or
+no, the mender of roads ran, on the sultry morning, as if for his life,
+down the hill, knee-high in dust, and never stopped till he got to the
+fountain.
+
+All the people of the village were at the fountain, standing about
+in their depressed manner, and whispering low, but showing no other
+emotions than grim curiosity and surprise. The led cows, hastily brought
+in and tethered to anything that would hold them, were looking stupidly
+on, or lying down chewing the cud of nothing particularly repaying their
+trouble, which they had picked up in their interrupted saunter. Some of
+the people of the chateau, and some of those of the posting-house, and
+all the taxing authorities, were armed more or less, and were crowded
+on the other side of the little street in a purposeless way, that was
+highly fraught with nothing. Already, the mender of roads had penetrated
+into the midst of a group of fifty particular friends, and was smiting
+himself in the breast with his blue cap. What did all this portend,
+and what portended the swift hoisting-up of Monsieur Gabelle behind
+a servant on horseback, and the conveying away of the said Gabelle
+(double-laden though the horse was), at a gallop, like a new version of
+the German ballad of Leonora?
+
+It portended that there was one stone face too many, up at the chateau.
+
+The Gorgon had surveyed the building again in the night, and had added
+the one stone face wanting; the stone face for which it had waited
+through about two hundred years.
+
+It lay back on the pillow of Monsieur the Marquis. It was like a fine
+mask, suddenly startled, made angry, and petrified. Driven home into the
+heart of the stone figure attached to it, was a knife. Round its hilt
+was a frill of paper, on which was scrawled:
+
+“Drive him fast to his tomb. This, from Jacques.”
+
+
+
+
+X. Two Promises
+
+
+More months, to the number of twelve, had come and gone, and Mr. Charles
+Darnay was established in England as a higher teacher of the French
+language who was conversant with French literature. In this age, he
+would have been a Professor; in that age, he was a Tutor. He read with
+young men who could find any leisure and interest for the study of a
+living tongue spoken all over the world, and he cultivated a taste for
+its stores of knowledge and fancy. He could write of them, besides, in
+sound English, and render them into sound English. Such masters were not
+at that time easily found; Princes that had been, and Kings that were
+to be, were not yet of the Teacher class, and no ruined nobility had
+dropped out of Tellson’s ledgers, to turn cooks and carpenters. As a
+tutor, whose attainments made the student’s way unusually pleasant and
+profitable, and as an elegant translator who brought something to his
+work besides mere dictionary knowledge, young Mr. Darnay soon became
+known and encouraged. He was well acquainted, more-over, with the
+circumstances of his country, and those were of ever-growing interest.
+So, with great perseverance and untiring industry, he prospered.
+
+In London, he had expected neither to walk on pavements of gold, nor
+to lie on beds of roses; if he had had any such exalted expectation, he
+would not have prospered. He had expected labour, and he found it, and
+did it and made the best of it. In this, his prosperity consisted.
+
+A certain portion of his time was passed at Cambridge, where he
+read with undergraduates as a sort of tolerated smuggler who drove a
+contraband trade in European languages, instead of conveying Greek
+and Latin through the Custom-house. The rest of his time he passed in
+London.
+
+Now, from the days when it was always summer in Eden, to these days
+when it is mostly winter in fallen latitudes, the world of a man has
+invariably gone one way--Charles Darnay’s way--the way of the love of a
+woman.
+
+He had loved Lucie Manette from the hour of his danger. He had never
+heard a sound so sweet and dear as the sound of her compassionate voice;
+he had never seen a face so tenderly beautiful, as hers when it was
+confronted with his own on the edge of the grave that had been dug for
+him. But, he had not yet spoken to her on the subject; the assassination
+at the deserted chateau far away beyond the heaving water and the long,
+long, dusty roads--the solid stone chateau which had itself become the
+mere mist of a dream--had been done a year, and he had never yet, by so
+much as a single spoken word, disclosed to her the state of his heart.
+
+That he had his reasons for this, he knew full well. It was again a
+summer day when, lately arrived in London from his college occupation,
+he turned into the quiet corner in Soho, bent on seeking an opportunity
+of opening his mind to Doctor Manette. It was the close of the summer
+day, and he knew Lucie to be out with Miss Pross.
+
+He found the Doctor reading in his arm-chair at a window. The energy
+which had at once supported him under his old sufferings and aggravated
+their sharpness, had been gradually restored to him. He was now a
+very energetic man indeed, with great firmness of purpose, strength
+of resolution, and vigour of action. In his recovered energy he was
+sometimes a little fitful and sudden, as he had at first been in the
+exercise of his other recovered faculties; but, this had never been
+frequently observable, and had grown more and more rare.
+
+He studied much, slept little, sustained a great deal of fatigue with
+ease, and was equably cheerful. To him, now entered Charles Darnay, at
+sight of whom he laid aside his book and held out his hand.
+
+“Charles Darnay! I rejoice to see you. We have been counting on your
+return these three or four days past. Mr. Stryver and Sydney Carton were
+both here yesterday, and both made you out to be more than due.”
+
+“I am obliged to them for their interest in the matter,” he answered,
+a little coldly as to them, though very warmly as to the Doctor. “Miss
+Manette--”
+
+“Is well,” said the Doctor, as he stopped short, “and your return will
+delight us all. She has gone out on some household matters, but will
+soon be home.”
+
+“Doctor Manette, I knew she was from home. I took the opportunity of her
+being from home, to beg to speak to you.”
+
+There was a blank silence.
+
+“Yes?” said the Doctor, with evident constraint. “Bring your chair here,
+and speak on.”
+
+He complied as to the chair, but appeared to find the speaking on less
+easy.
+
+“I have had the happiness, Doctor Manette, of being so intimate here,”
+ so he at length began, “for some year and a half, that I hope the topic
+on which I am about to touch may not--”
+
+He was stayed by the Doctor’s putting out his hand to stop him. When he
+had kept it so a little while, he said, drawing it back:
+
+“Is Lucie the topic?”
+
+“She is.”
+
+“It is hard for me to speak of her at any time. It is very hard for me
+to hear her spoken of in that tone of yours, Charles Darnay.”
+
+“It is a tone of fervent admiration, true homage, and deep love, Doctor
+Manette!” he said deferentially.
+
+There was another blank silence before her father rejoined:
+
+“I believe it. I do you justice; I believe it.”
+
+His constraint was so manifest, and it was so manifest, too, that it
+originated in an unwillingness to approach the subject, that Charles
+Darnay hesitated.
+
+“Shall I go on, sir?”
+
+Another blank.
+
+“Yes, go on.”
+
+“You anticipate what I would say, though you cannot know how earnestly
+I say it, how earnestly I feel it, without knowing my secret heart, and
+the hopes and fears and anxieties with which it has long been
+laden. Dear Doctor Manette, I love your daughter fondly, dearly,
+disinterestedly, devotedly. If ever there were love in the world, I love
+her. You have loved yourself; let your old love speak for me!”
+
+The Doctor sat with his face turned away, and his eyes bent on the
+ground. At the last words, he stretched out his hand again, hurriedly,
+and cried:
+
+“Not that, sir! Let that be! I adjure you, do not recall that!”
+
+His cry was so like a cry of actual pain, that it rang in Charles
+Darnay’s ears long after he had ceased. He motioned with the hand he had
+extended, and it seemed to be an appeal to Darnay to pause. The latter
+so received it, and remained silent.
+
+“I ask your pardon,” said the Doctor, in a subdued tone, after some
+moments. “I do not doubt your loving Lucie; you may be satisfied of it.”
+
+He turned towards him in his chair, but did not look at him, or
+raise his eyes. His chin dropped upon his hand, and his white hair
+overshadowed his face:
+
+“Have you spoken to Lucie?”
+
+“No.”
+
+“Nor written?”
+
+“Never.”
+
+“It would be ungenerous to affect not to know that your self-denial is
+to be referred to your consideration for her father. Her father thanks
+you.”
+
+He offered his hand; but his eyes did not go with it.
+
+“I know,” said Darnay, respectfully, “how can I fail to know, Doctor
+Manette, I who have seen you together from day to day, that between
+you and Miss Manette there is an affection so unusual, so touching, so
+belonging to the circumstances in which it has been nurtured, that it
+can have few parallels, even in the tenderness between a father and
+child. I know, Doctor Manette--how can I fail to know--that, mingled
+with the affection and duty of a daughter who has become a woman, there
+is, in her heart, towards you, all the love and reliance of infancy
+itself. I know that, as in her childhood she had no parent, so she is
+now devoted to you with all the constancy and fervour of her present
+years and character, united to the trustfulness and attachment of the
+early days in which you were lost to her. I know perfectly well that if
+you had been restored to her from the world beyond this life, you could
+hardly be invested, in her sight, with a more sacred character than that
+in which you are always with her. I know that when she is clinging to
+you, the hands of baby, girl, and woman, all in one, are round your
+neck. I know that in loving you she sees and loves her mother at her
+own age, sees and loves you at my age, loves her mother broken-hearted,
+loves you through your dreadful trial and in your blessed restoration. I
+have known this, night and day, since I have known you in your home.”
+
+Her father sat silent, with his face bent down. His breathing was a
+little quickened; but he repressed all other signs of agitation.
+
+“Dear Doctor Manette, always knowing this, always seeing her and you
+with this hallowed light about you, I have forborne, and forborne, as
+long as it was in the nature of man to do it. I have felt, and do even
+now feel, that to bring my love--even mine--between you, is to touch
+your history with something not quite so good as itself. But I love her.
+Heaven is my witness that I love her!”
+
+“I believe it,” answered her father, mournfully. “I have thought so
+before now. I believe it.”
+
+“But, do not believe,” said Darnay, upon whose ear the mournful voice
+struck with a reproachful sound, “that if my fortune were so cast as
+that, being one day so happy as to make her my wife, I must at any time
+put any separation between her and you, I could or would breathe a
+word of what I now say. Besides that I should know it to be hopeless, I
+should know it to be a baseness. If I had any such possibility, even at
+a remote distance of years, harboured in my thoughts, and hidden in my
+heart--if it ever had been there--if it ever could be there--I could not
+now touch this honoured hand.”
+
+He laid his own upon it as he spoke.
+
+“No, dear Doctor Manette. Like you, a voluntary exile from France; like
+you, driven from it by its distractions, oppressions, and miseries; like
+you, striving to live away from it by my own exertions, and trusting
+in a happier future; I look only to sharing your fortunes, sharing your
+life and home, and being faithful to you to the death. Not to divide
+with Lucie her privilege as your child, companion, and friend; but to
+come in aid of it, and bind her closer to you, if such a thing can be.”
+
+His touch still lingered on her father’s hand. Answering the touch for a
+moment, but not coldly, her father rested his hands upon the arms of
+his chair, and looked up for the first time since the beginning of the
+conference. A struggle was evidently in his face; a struggle with that
+occasional look which had a tendency in it to dark doubt and dread.
+
+“You speak so feelingly and so manfully, Charles Darnay, that I thank
+you with all my heart, and will open all my heart--or nearly so. Have
+you any reason to believe that Lucie loves you?”
+
+“None. As yet, none.”
+
+“Is it the immediate object of this confidence, that you may at once
+ascertain that, with my knowledge?”
+
+“Not even so. I might not have the hopefulness to do it for weeks; I
+might (mistaken or not mistaken) have that hopefulness to-morrow.”
+
+“Do you seek any guidance from me?”
+
+“I ask none, sir. But I have thought it possible that you might have it
+in your power, if you should deem it right, to give me some.”
+
+“Do you seek any promise from me?”
+
+“I do seek that.”
+
+“What is it?”
+
+“I well understand that, without you, I could have no hope. I well
+understand that, even if Miss Manette held me at this moment in her
+innocent heart--do not think I have the presumption to assume so much--I
+could retain no place in it against her love for her father.”
+
+“If that be so, do you see what, on the other hand, is involved in it?”
+
+“I understand equally well, that a word from her father in any suitor’s
+favour, would outweigh herself and all the world. For which reason,
+Doctor Manette,” said Darnay, modestly but firmly, “I would not ask that
+word, to save my life.”
+
+“I am sure of it. Charles Darnay, mysteries arise out of close love, as
+well as out of wide division; in the former case, they are subtle and
+delicate, and difficult to penetrate. My daughter Lucie is, in this one
+respect, such a mystery to me; I can make no guess at the state of her
+heart.”
+
+“May I ask, sir, if you think she is--” As he hesitated, her father
+supplied the rest.
+
+“Is sought by any other suitor?”
+
+“It is what I meant to say.”
+
+Her father considered a little before he answered:
+
+“You have seen Mr. Carton here, yourself. Mr. Stryver is here too,
+occasionally. If it be at all, it can only be by one of these.”
+
+“Or both,” said Darnay.
+
+“I had not thought of both; I should not think either, likely. You want
+a promise from me. Tell me what it is.”
+
+“It is, that if Miss Manette should bring to you at any time, on her own
+part, such a confidence as I have ventured to lay before you, you will
+bear testimony to what I have said, and to your belief in it. I hope you
+may be able to think so well of me, as to urge no influence against
+me. I say nothing more of my stake in this; this is what I ask. The
+condition on which I ask it, and which you have an undoubted right to
+require, I will observe immediately.”
+
+“I give the promise,” said the Doctor, “without any condition. I believe
+your object to be, purely and truthfully, as you have stated it. I
+believe your intention is to perpetuate, and not to weaken, the ties
+between me and my other and far dearer self. If she should ever tell me
+that you are essential to her perfect happiness, I will give her to you.
+If there were--Charles Darnay, if there were--”
+
+The young man had taken his hand gratefully; their hands were joined as
+the Doctor spoke:
+
+“--any fancies, any reasons, any apprehensions, anything whatsoever,
+new or old, against the man she really loved--the direct responsibility
+thereof not lying on his head--they should all be obliterated for her
+sake. She is everything to me; more to me than suffering, more to me
+than wrong, more to me--Well! This is idle talk.”
+
+So strange was the way in which he faded into silence, and so strange
+his fixed look when he had ceased to speak, that Darnay felt his own
+hand turn cold in the hand that slowly released and dropped it.
+
+“You said something to me,” said Doctor Manette, breaking into a smile.
+“What was it you said to me?”
+
+He was at a loss how to answer, until he remembered having spoken of a
+condition. Relieved as his mind reverted to that, he answered:
+
+“Your confidence in me ought to be returned with full confidence on my
+part. My present name, though but slightly changed from my mother’s, is
+not, as you will remember, my own. I wish to tell you what that is, and
+why I am in England.”
+
+“Stop!” said the Doctor of Beauvais.
+
+“I wish it, that I may the better deserve your confidence, and have no
+secret from you.”
+
+“Stop!”
+
+For an instant, the Doctor even had his two hands at his ears; for
+another instant, even had his two hands laid on Darnay’s lips.
+
+“Tell me when I ask you, not now. If your suit should prosper, if Lucie
+should love you, you shall tell me on your marriage morning. Do you
+promise?”
+
+“Willingly.
+
+“Give me your hand. She will be home directly, and it is better she
+should not see us together to-night. Go! God bless you!”
+
+It was dark when Charles Darnay left him, and it was an hour later and
+darker when Lucie came home; she hurried into the room alone--for
+Miss Pross had gone straight up-stairs--and was surprised to find his
+reading-chair empty.
+
+“My father!” she called to him. “Father dear!”
+
+Nothing was said in answer, but she heard a low hammering sound in his
+bedroom. Passing lightly across the intermediate room, she looked in at
+his door and came running back frightened, crying to herself, with her
+blood all chilled, “What shall I do! What shall I do!”
+
+Her uncertainty lasted but a moment; she hurried back, and tapped at
+his door, and softly called to him. The noise ceased at the sound of
+her voice, and he presently came out to her, and they walked up and down
+together for a long time.
+
+She came down from her bed, to look at him in his sleep that night. He
+slept heavily, and his tray of shoemaking tools, and his old unfinished
+work, were all as usual.
+
+
+
+
+XI. A Companion Picture
+
+
+“Sydney,” said Mr. Stryver, on that self-same night, or morning, to his
+jackal; “mix another bowl of punch; I have something to say to you.”
+
+Sydney had been working double tides that night, and the night before,
+and the night before that, and a good many nights in succession, making
+a grand clearance among Mr. Stryver’s papers before the setting in
+of the long vacation. The clearance was effected at last; the Stryver
+arrears were handsomely fetched up; everything was got rid of until
+November should come with its fogs atmospheric, and fogs legal, and
+bring grist to the mill again.
+
+Sydney was none the livelier and none the soberer for so much
+application. It had taken a deal of extra wet-towelling to pull him
+through the night; a correspondingly extra quantity of wine had preceded
+the towelling; and he was in a very damaged condition, as he now pulled
+his turban off and threw it into the basin in which he had steeped it at
+intervals for the last six hours.
+
+“Are you mixing that other bowl of punch?” said Stryver the portly, with
+his hands in his waistband, glancing round from the sofa where he lay on
+his back.
+
+“I am.”
+
+“Now, look here! I am going to tell you something that will rather
+surprise you, and that perhaps will make you think me not quite as
+shrewd as you usually do think me. I intend to marry.”
+
+“_Do_ you?”
+
+“Yes. And not for money. What do you say now?”
+
+“I don’t feel disposed to say much. Who is she?”
+
+“Guess.”
+
+“Do I know her?”
+
+“Guess.”
+
+“I am not going to guess, at five o’clock in the morning, with my brains
+frying and sputtering in my head. If you want me to guess, you must ask
+me to dinner.”
+
+“Well then, I’ll tell you,” said Stryver, coming slowly into a sitting
+posture. “Sydney, I rather despair of making myself intelligible to you,
+because you are such an insensible dog.”
+
+“And you,” returned Sydney, busy concocting the punch, “are such a
+sensitive and poetical spirit--”
+
+“Come!” rejoined Stryver, laughing boastfully, “though I don’t prefer
+any claim to being the soul of Romance (for I hope I know better), still
+I am a tenderer sort of fellow than _you_.”
+
+“You are a luckier, if you mean that.”
+
+“I don’t mean that. I mean I am a man of more--more--”
+
+“Say gallantry, while you are about it,” suggested Carton.
+
+“Well! I’ll say gallantry. My meaning is that I am a man,” said Stryver,
+inflating himself at his friend as he made the punch, “who cares more to
+be agreeable, who takes more pains to be agreeable, who knows better how
+to be agreeable, in a woman’s society, than you do.”
+
+“Go on,” said Sydney Carton.
+
+“No; but before I go on,” said Stryver, shaking his head in his bullying
+way, “I’ll have this out with you. You’ve been at Doctor Manette’s house
+as much as I have, or more than I have. Why, I have been ashamed of your
+moroseness there! Your manners have been of that silent and sullen and
+hangdog kind, that, upon my life and soul, I have been ashamed of you,
+Sydney!”
+
+“It should be very beneficial to a man in your practice at the bar, to
+be ashamed of anything,” returned Sydney; “you ought to be much obliged
+to me.”
+
+“You shall not get off in that way,” rejoined Stryver, shouldering the
+rejoinder at him; “no, Sydney, it’s my duty to tell you--and I tell you
+to your face to do you good--that you are a devilish ill-conditioned
+fellow in that sort of society. You are a disagreeable fellow.”
+
+Sydney drank a bumper of the punch he had made, and laughed.
+
+“Look at me!” said Stryver, squaring himself; “I have less need to make
+myself agreeable than you have, being more independent in circumstances.
+Why do I do it?”
+
+“I never saw you do it yet,” muttered Carton.
+
+“I do it because it’s politic; I do it on principle. And look at me! I
+get on.”
+
+“You don’t get on with your account of your matrimonial intentions,”
+ answered Carton, with a careless air; “I wish you would keep to that. As
+to me--will you never understand that I am incorrigible?”
+
+He asked the question with some appearance of scorn.
+
+“You have no business to be incorrigible,” was his friend’s answer,
+delivered in no very soothing tone.
+
+“I have no business to be, at all, that I know of,” said Sydney Carton.
+“Who is the lady?”
+
+“Now, don’t let my announcement of the name make you uncomfortable,
+Sydney,” said Mr. Stryver, preparing him with ostentatious friendliness
+for the disclosure he was about to make, “because I know you don’t mean
+half you say; and if you meant it all, it would be of no importance. I
+make this little preface, because you once mentioned the young lady to
+me in slighting terms.”
+
+“I did?”
+
+“Certainly; and in these chambers.”
+
+Sydney Carton looked at his punch and looked at his complacent friend;
+drank his punch and looked at his complacent friend.
+
+“You made mention of the young lady as a golden-haired doll. The young
+lady is Miss Manette. If you had been a fellow of any sensitiveness or
+delicacy of feeling in that kind of way, Sydney, I might have been a
+little resentful of your employing such a designation; but you are not.
+You want that sense altogether; therefore I am no more annoyed when I
+think of the expression, than I should be annoyed by a man’s opinion of
+a picture of mine, who had no eye for pictures: or of a piece of music
+of mine, who had no ear for music.”
+
+Sydney Carton drank the punch at a great rate; drank it by bumpers,
+looking at his friend.
+
+“Now you know all about it, Syd,” said Mr. Stryver. “I don’t care about
+fortune: she is a charming creature, and I have made up my mind to
+please myself: on the whole, I think I can afford to please myself. She
+will have in me a man already pretty well off, and a rapidly rising man,
+and a man of some distinction: it is a piece of good fortune for her,
+but she is worthy of good fortune. Are you astonished?”
+
+Carton, still drinking the punch, rejoined, “Why should I be
+astonished?”
+
+“You approve?”
+
+Carton, still drinking the punch, rejoined, “Why should I not approve?”
+
+“Well!” said his friend Stryver, “you take it more easily than I fancied
+you would, and are less mercenary on my behalf than I thought you would
+be; though, to be sure, you know well enough by this time that your
+ancient chum is a man of a pretty strong will. Yes, Sydney, I have had
+enough of this style of life, with no other as a change from it; I
+feel that it is a pleasant thing for a man to have a home when he feels
+inclined to go to it (when he doesn’t, he can stay away), and I feel
+that Miss Manette will tell well in any station, and will always do me
+credit. So I have made up my mind. And now, Sydney, old boy, I want to
+say a word to _you_ about _your_ prospects. You are in a bad way, you
+know; you really are in a bad way. You don’t know the value of money,
+you live hard, you’ll knock up one of these days, and be ill and poor;
+you really ought to think about a nurse.”
+
+The prosperous patronage with which he said it, made him look twice as
+big as he was, and four times as offensive.
+
+“Now, let me recommend you,” pursued Stryver, “to look it in the face.
+I have looked it in the face, in my different way; look it in the face,
+you, in your different way. Marry. Provide somebody to take care of
+you. Never mind your having no enjoyment of women’s society, nor
+understanding of it, nor tact for it. Find out somebody. Find out some
+respectable woman with a little property--somebody in the landlady way,
+or lodging-letting way--and marry her, against a rainy day. That’s the
+kind of thing for _you_. Now think of it, Sydney.”
+
+“I’ll think of it,” said Sydney.
+
+
+
+
+XII. The Fellow of Delicacy
+
+
+Mr. Stryver having made up his mind to that magnanimous bestowal of good
+fortune on the Doctor’s daughter, resolved to make her happiness known
+to her before he left town for the Long Vacation. After some mental
+debating of the point, he came to the conclusion that it would be as
+well to get all the preliminaries done with, and they could then arrange
+at their leisure whether he should give her his hand a week or two
+before Michaelmas Term, or in the little Christmas vacation between it
+and Hilary.
+
+As to the strength of his case, he had not a doubt about it, but clearly
+saw his way to the verdict. Argued with the jury on substantial worldly
+grounds--the only grounds ever worth taking into account--it was a
+plain case, and had not a weak spot in it. He called himself for the
+plaintiff, there was no getting over his evidence, the counsel for
+the defendant threw up his brief, and the jury did not even turn to
+consider. After trying it, Stryver, C. J., was satisfied that no plainer
+case could be.
+
+Accordingly, Mr. Stryver inaugurated the Long Vacation with a formal
+proposal to take Miss Manette to Vauxhall Gardens; that failing, to
+Ranelagh; that unaccountably failing too, it behoved him to present
+himself in Soho, and there declare his noble mind.
+
+Towards Soho, therefore, Mr. Stryver shouldered his way from the Temple,
+while the bloom of the Long Vacation’s infancy was still upon it.
+Anybody who had seen him projecting himself into Soho while he was yet
+on Saint Dunstan’s side of Temple Bar, bursting in his full-blown way
+along the pavement, to the jostlement of all weaker people, might have
+seen how safe and strong he was.
+
+His way taking him past Tellson’s, and he both banking at Tellson’s and
+knowing Mr. Lorry as the intimate friend of the Manettes, it entered Mr.
+Stryver’s mind to enter the bank, and reveal to Mr. Lorry the brightness
+of the Soho horizon. So, he pushed open the door with the weak rattle
+in its throat, stumbled down the two steps, got past the two ancient
+cashiers, and shouldered himself into the musty back closet where Mr.
+Lorry sat at great books ruled for figures, with perpendicular iron
+bars to his window as if that were ruled for figures too, and everything
+under the clouds were a sum.
+
+“Halloa!” said Mr. Stryver. “How do you do? I hope you are well!”
+
+It was Stryver’s grand peculiarity that he always seemed too big for any
+place, or space. He was so much too big for Tellson’s, that old clerks
+in distant corners looked up with looks of remonstrance, as though he
+squeezed them against the wall. The House itself, magnificently reading
+the paper quite in the far-off perspective, lowered displeased, as if
+the Stryver head had been butted into its responsible waistcoat.
+
+The discreet Mr. Lorry said, in a sample tone of the voice he would
+recommend under the circumstances, “How do you do, Mr. Stryver? How do
+you do, sir?” and shook hands. There was a peculiarity in his manner
+of shaking hands, always to be seen in any clerk at Tellson’s who shook
+hands with a customer when the House pervaded the air. He shook in a
+self-abnegating way, as one who shook for Tellson and Co.
+
+“Can I do anything for you, Mr. Stryver?” asked Mr. Lorry, in his
+business character.
+
+“Why, no, thank you; this is a private visit to yourself, Mr. Lorry; I
+have come for a private word.”
+
+“Oh indeed!” said Mr. Lorry, bending down his ear, while his eye strayed
+to the House afar off.
+
+“I am going,” said Mr. Stryver, leaning his arms confidentially on the
+desk: whereupon, although it was a large double one, there appeared to
+be not half desk enough for him: “I am going to make an offer of myself
+in marriage to your agreeable little friend, Miss Manette, Mr. Lorry.”
+
+“Oh dear me!” cried Mr. Lorry, rubbing his chin, and looking at his
+visitor dubiously.
+
+“Oh dear me, sir?” repeated Stryver, drawing back. “Oh dear you, sir?
+What may your meaning be, Mr. Lorry?”
+
+“My meaning,” answered the man of business, “is, of course, friendly and
+appreciative, and that it does you the greatest credit, and--in short,
+my meaning is everything you could desire. But--really, you know, Mr.
+Stryver--” Mr. Lorry paused, and shook his head at him in the oddest
+manner, as if he were compelled against his will to add, internally,
+“you know there really is so much too much of you!”
+
+“Well!” said Stryver, slapping the desk with his contentious hand,
+opening his eyes wider, and taking a long breath, “if I understand you,
+Mr. Lorry, I’ll be hanged!”
+
+Mr. Lorry adjusted his little wig at both ears as a means towards that
+end, and bit the feather of a pen.
+
+“D--n it all, sir!” said Stryver, staring at him, “am I not eligible?”
+
+“Oh dear yes! Yes. Oh yes, you’re eligible!” said Mr. Lorry. “If you say
+eligible, you are eligible.”
+
+“Am I not prosperous?” asked Stryver.
+
+“Oh! if you come to prosperous, you are prosperous,” said Mr. Lorry.
+
+“And advancing?”
+
+“If you come to advancing you know,” said Mr. Lorry, delighted to be
+able to make another admission, “nobody can doubt that.”
+
+“Then what on earth is your meaning, Mr. Lorry?” demanded Stryver,
+perceptibly crestfallen.
+
+“Well! I--Were you going there now?” asked Mr. Lorry.
+
+“Straight!” said Stryver, with a plump of his fist on the desk.
+
+“Then I think I wouldn’t, if I was you.”
+
+“Why?” said Stryver. “Now, I’ll put you in a corner,” forensically
+shaking a forefinger at him. “You are a man of business and bound to
+have a reason. State your reason. Why wouldn’t you go?”
+
+“Because,” said Mr. Lorry, “I wouldn’t go on such an object without
+having some cause to believe that I should succeed.”
+
+“D--n _me_!” cried Stryver, “but this beats everything.”
+
+Mr. Lorry glanced at the distant House, and glanced at the angry
+Stryver.
+
+“Here’s a man of business--a man of years--a man of experience--_in_
+a Bank,” said Stryver; “and having summed up three leading reasons for
+complete success, he says there’s no reason at all! Says it with his
+head on!” Mr. Stryver remarked upon the peculiarity as if it would have
+been infinitely less remarkable if he had said it with his head off.
+
+“When I speak of success, I speak of success with the young lady; and
+when I speak of causes and reasons to make success probable, I speak of
+causes and reasons that will tell as such with the young lady. The young
+lady, my good sir,” said Mr. Lorry, mildly tapping the Stryver arm, “the
+young lady. The young lady goes before all.”
+
+“Then you mean to tell me, Mr. Lorry,” said Stryver, squaring his
+elbows, “that it is your deliberate opinion that the young lady at
+present in question is a mincing Fool?”
+
+“Not exactly so. I mean to tell you, Mr. Stryver,” said Mr. Lorry,
+reddening, “that I will hear no disrespectful word of that young lady
+from any lips; and that if I knew any man--which I hope I do not--whose
+taste was so coarse, and whose temper was so overbearing, that he could
+not restrain himself from speaking disrespectfully of that young lady at
+this desk, not even Tellson’s should prevent my giving him a piece of my
+mind.”
+
+The necessity of being angry in a suppressed tone had put Mr. Stryver’s
+blood-vessels into a dangerous state when it was his turn to be angry;
+Mr. Lorry’s veins, methodical as their courses could usually be, were in
+no better state now it was his turn.
+
+“That is what I mean to tell you, sir,” said Mr. Lorry. “Pray let there
+be no mistake about it.”
+
+Mr. Stryver sucked the end of a ruler for a little while, and then stood
+hitting a tune out of his teeth with it, which probably gave him the
+toothache. He broke the awkward silence by saying:
+
+“This is something new to me, Mr. Lorry. You deliberately advise me not
+to go up to Soho and offer myself--_my_self, Stryver of the King’s Bench
+bar?”
+
+“Do you ask me for my advice, Mr. Stryver?”
+
+“Yes, I do.”
+
+“Very good. Then I give it, and you have repeated it correctly.”
+
+“And all I can say of it is,” laughed Stryver with a vexed laugh, “that
+this--ha, ha!--beats everything past, present, and to come.”
+
+“Now understand me,” pursued Mr. Lorry. “As a man of business, I am
+not justified in saying anything about this matter, for, as a man of
+business, I know nothing of it. But, as an old fellow, who has carried
+Miss Manette in his arms, who is the trusted friend of Miss Manette and
+of her father too, and who has a great affection for them both, I have
+spoken. The confidence is not of my seeking, recollect. Now, you think I
+may not be right?”
+
+“Not I!” said Stryver, whistling. “I can’t undertake to find third
+parties in common sense; I can only find it for myself. I suppose sense
+in certain quarters; you suppose mincing bread-and-butter nonsense. It’s
+new to me, but you are right, I dare say.”
+
+“What I suppose, Mr. Stryver, I claim to characterise for myself--And
+understand me, sir,” said Mr. Lorry, quickly flushing again, “I
+will not--not even at Tellson’s--have it characterised for me by any
+gentleman breathing.”
+
+“There! I beg your pardon!” said Stryver.
+
+“Granted. Thank you. Well, Mr. Stryver, I was about to say:--it might be
+painful to you to find yourself mistaken, it might be painful to Doctor
+Manette to have the task of being explicit with you, it might be very
+painful to Miss Manette to have the task of being explicit with you. You
+know the terms upon which I have the honour and happiness to stand with
+the family. If you please, committing you in no way, representing you
+in no way, I will undertake to correct my advice by the exercise of a
+little new observation and judgment expressly brought to bear upon
+it. If you should then be dissatisfied with it, you can but test its
+soundness for yourself; if, on the other hand, you should be satisfied
+with it, and it should be what it now is, it may spare all sides what is
+best spared. What do you say?”
+
+“How long would you keep me in town?”
+
+“Oh! It is only a question of a few hours. I could go to Soho in the
+evening, and come to your chambers afterwards.”
+
+“Then I say yes,” said Stryver: “I won’t go up there now, I am not so
+hot upon it as that comes to; I say yes, and I shall expect you to look
+in to-night. Good morning.”
+
+Then Mr. Stryver turned and burst out of the Bank, causing such a
+concussion of air on his passage through, that to stand up against it
+bowing behind the two counters, required the utmost remaining strength
+of the two ancient clerks. Those venerable and feeble persons were
+always seen by the public in the act of bowing, and were popularly
+believed, when they had bowed a customer out, still to keep on bowing in
+the empty office until they bowed another customer in.
+
+The barrister was keen enough to divine that the banker would not have
+gone so far in his expression of opinion on any less solid ground than
+moral certainty. Unprepared as he was for the large pill he had to
+swallow, he got it down. “And now,” said Mr. Stryver, shaking his
+forensic forefinger at the Temple in general, when it was down, “my way
+out of this, is, to put you all in the wrong.”
+
+It was a bit of the art of an Old Bailey tactician, in which he found
+great relief. “You shall not put me in the wrong, young lady,” said Mr.
+Stryver; “I’ll do that for you.”
+
+Accordingly, when Mr. Lorry called that night as late as ten o’clock,
+Mr. Stryver, among a quantity of books and papers littered out for the
+purpose, seemed to have nothing less on his mind than the subject of
+the morning. He even showed surprise when he saw Mr. Lorry, and was
+altogether in an absent and preoccupied state.
+
+“Well!” said that good-natured emissary, after a full half-hour of
+bootless attempts to bring him round to the question. “I have been to
+Soho.”
+
+“To Soho?” repeated Mr. Stryver, coldly. “Oh, to be sure! What am I
+thinking of!”
+
+“And I have no doubt,” said Mr. Lorry, “that I was right in the
+conversation we had. My opinion is confirmed, and I reiterate my
+advice.”
+
+“I assure you,” returned Mr. Stryver, in the friendliest way, “that I
+am sorry for it on your account, and sorry for it on the poor father’s
+account. I know this must always be a sore subject with the family; let
+us say no more about it.”
+
+“I don’t understand you,” said Mr. Lorry.
+
+“I dare say not,” rejoined Stryver, nodding his head in a smoothing and
+final way; “no matter, no matter.”
+
+“But it does matter,” Mr. Lorry urged.
+
+“No it doesn’t; I assure you it doesn’t. Having supposed that there was
+sense where there is no sense, and a laudable ambition where there is
+not a laudable ambition, I am well out of my mistake, and no harm is
+done. Young women have committed similar follies often before, and have
+repented them in poverty and obscurity often before. In an unselfish
+aspect, I am sorry that the thing is dropped, because it would have been
+a bad thing for me in a worldly point of view; in a selfish aspect, I am
+glad that the thing has dropped, because it would have been a bad thing
+for me in a worldly point of view--it is hardly necessary to say I could
+have gained nothing by it. There is no harm at all done. I have not
+proposed to the young lady, and, between ourselves, I am by no means
+certain, on reflection, that I ever should have committed myself to
+that extent. Mr. Lorry, you cannot control the mincing vanities and
+giddinesses of empty-headed girls; you must not expect to do it, or you
+will always be disappointed. Now, pray say no more about it. I tell you,
+I regret it on account of others, but I am satisfied on my own account.
+And I am really very much obliged to you for allowing me to sound you,
+and for giving me your advice; you know the young lady better than I do;
+you were right, it never would have done.”
+
+Mr. Lorry was so taken aback, that he looked quite stupidly at Mr.
+Stryver shouldering him towards the door, with an appearance of
+showering generosity, forbearance, and goodwill, on his erring head.
+“Make the best of it, my dear sir,” said Stryver; “say no more about it;
+thank you again for allowing me to sound you; good night!”
+
+Mr. Lorry was out in the night, before he knew where he was. Mr. Stryver
+was lying back on his sofa, winking at his ceiling.
+
+
+
+
+XIII. The Fellow of No Delicacy
+
+
+If Sydney Carton ever shone anywhere, he certainly never shone in the
+house of Doctor Manette. He had been there often, during a whole year,
+and had always been the same moody and morose lounger there. When he
+cared to talk, he talked well; but, the cloud of caring for nothing,
+which overshadowed him with such a fatal darkness, was very rarely
+pierced by the light within him.
+
+And yet he did care something for the streets that environed that house,
+and for the senseless stones that made their pavements. Many a night
+he vaguely and unhappily wandered there, when wine had brought no
+transitory gladness to him; many a dreary daybreak revealed his solitary
+figure lingering there, and still lingering there when the first beams
+of the sun brought into strong relief, removed beauties of architecture
+in spires of churches and lofty buildings, as perhaps the quiet time
+brought some sense of better things, else forgotten and unattainable,
+into his mind. Of late, the neglected bed in the Temple Court had known
+him more scantily than ever; and often when he had thrown himself upon
+it no longer than a few minutes, he had got up again, and haunted that
+neighbourhood.
+
+On a day in August, when Mr. Stryver (after notifying to his jackal
+that “he had thought better of that marrying matter”) had carried his
+delicacy into Devonshire, and when the sight and scent of flowers in the
+City streets had some waifs of goodness in them for the worst, of health
+for the sickliest, and of youth for the oldest, Sydney’s feet still trod
+those stones. From being irresolute and purposeless, his feet became
+animated by an intention, and, in the working out of that intention,
+they took him to the Doctor’s door.
+
+He was shown up-stairs, and found Lucie at her work, alone. She had
+never been quite at her ease with him, and received him with some little
+embarrassment as he seated himself near her table. But, looking up at
+his face in the interchange of the first few common-places, she observed
+a change in it.
+
+“I fear you are not well, Mr. Carton!”
+
+“No. But the life I lead, Miss Manette, is not conducive to health. What
+is to be expected of, or by, such profligates?”
+
+“Is it not--forgive me; I have begun the question on my lips--a pity to
+live no better life?”
+
+“God knows it is a shame!”
+
+“Then why not change it?”
+
+Looking gently at him again, she was surprised and saddened to see that
+there were tears in his eyes. There were tears in his voice too, as he
+answered:
+
+“It is too late for that. I shall never be better than I am. I shall
+sink lower, and be worse.”
+
+He leaned an elbow on her table, and covered his eyes with his hand. The
+table trembled in the silence that followed.
+
+She had never seen him softened, and was much distressed. He knew her to
+be so, without looking at her, and said:
+
+“Pray forgive me, Miss Manette. I break down before the knowledge of
+what I want to say to you. Will you hear me?”
+
+“If it will do you any good, Mr. Carton, if it would make you happier,
+it would make me very glad!”
+
+“God bless you for your sweet compassion!”
+
+He unshaded his face after a little while, and spoke steadily.
+
+“Don’t be afraid to hear me. Don’t shrink from anything I say. I am like
+one who died young. All my life might have been.”
+
+“No, Mr. Carton. I am sure that the best part of it might still be; I am
+sure that you might be much, much worthier of yourself.”
+
+“Say of you, Miss Manette, and although I know better--although in the
+mystery of my own wretched heart I know better--I shall never forget
+it!”
+
+She was pale and trembling. He came to her relief with a fixed despair
+of himself which made the interview unlike any other that could have
+been holden.
+
+“If it had been possible, Miss Manette, that you could have returned the
+love of the man you see before yourself--flung away, wasted, drunken,
+poor creature of misuse as you know him to be--he would have been
+conscious this day and hour, in spite of his happiness, that he would
+bring you to misery, bring you to sorrow and repentance, blight you,
+disgrace you, pull you down with him. I know very well that you can have
+no tenderness for me; I ask for none; I am even thankful that it cannot
+be.”
+
+“Without it, can I not save you, Mr. Carton? Can I not recall
+you--forgive me again!--to a better course? Can I in no way repay your
+confidence? I know this is a confidence,” she modestly said, after a
+little hesitation, and in earnest tears, “I know you would say this to
+no one else. Can I turn it to no good account for yourself, Mr. Carton?”
+
+He shook his head.
+
+“To none. No, Miss Manette, to none. If you will hear me through a very
+little more, all you can ever do for me is done. I wish you to know that
+you have been the last dream of my soul. In my degradation I have not
+been so degraded but that the sight of you with your father, and of this
+home made such a home by you, has stirred old shadows that I thought had
+died out of me. Since I knew you, I have been troubled by a remorse that
+I thought would never reproach me again, and have heard whispers from
+old voices impelling me upward, that I thought were silent for ever. I
+have had unformed ideas of striving afresh, beginning anew, shaking off
+sloth and sensuality, and fighting out the abandoned fight. A dream, all
+a dream, that ends in nothing, and leaves the sleeper where he lay down,
+but I wish you to know that you inspired it.”
+
+“Will nothing of it remain? O Mr. Carton, think again! Try again!”
+
+“No, Miss Manette; all through it, I have known myself to be quite
+undeserving. And yet I have had the weakness, and have still the
+weakness, to wish you to know with what a sudden mastery you kindled me,
+heap of ashes that I am, into fire--a fire, however, inseparable in
+its nature from myself, quickening nothing, lighting nothing, doing no
+service, idly burning away.”
+
+“Since it is my misfortune, Mr. Carton, to have made you more unhappy
+than you were before you knew me--”
+
+“Don’t say that, Miss Manette, for you would have reclaimed me, if
+anything could. You will not be the cause of my becoming worse.”
+
+“Since the state of your mind that you describe, is, at all events,
+attributable to some influence of mine--this is what I mean, if I can
+make it plain--can I use no influence to serve you? Have I no power for
+good, with you, at all?”
+
+“The utmost good that I am capable of now, Miss Manette, I have come
+here to realise. Let me carry through the rest of my misdirected life,
+the remembrance that I opened my heart to you, last of all the world;
+and that there was something left in me at this time which you could
+deplore and pity.”
+
+“Which I entreated you to believe, again and again, most fervently, with
+all my heart, was capable of better things, Mr. Carton!”
+
+“Entreat me to believe it no more, Miss Manette. I have proved myself,
+and I know better. I distress you; I draw fast to an end. Will you let
+me believe, when I recall this day, that the last confidence of my life
+was reposed in your pure and innocent breast, and that it lies there
+alone, and will be shared by no one?”
+
+“If that will be a consolation to you, yes.”
+
+“Not even by the dearest one ever to be known to you?”
+
+“Mr. Carton,” she answered, after an agitated pause, “the secret is
+yours, not mine; and I promise to respect it.”
+
+“Thank you. And again, God bless you.”
+
+He put her hand to his lips, and moved towards the door.
+
+“Be under no apprehension, Miss Manette, of my ever resuming this
+conversation by so much as a passing word. I will never refer to it
+again. If I were dead, that could not be surer than it is henceforth. In
+the hour of my death, I shall hold sacred the one good remembrance--and
+shall thank and bless you for it--that my last avowal of myself was made
+to you, and that my name, and faults, and miseries were gently carried
+in your heart. May it otherwise be light and happy!”
+
+He was so unlike what he had ever shown himself to be, and it was so
+sad to think how much he had thrown away, and how much he every day kept
+down and perverted, that Lucie Manette wept mournfully for him as he
+stood looking back at her.
+
+“Be comforted!” he said, “I am not worth such feeling, Miss Manette. An
+hour or two hence, and the low companions and low habits that I scorn
+but yield to, will render me less worth such tears as those, than any
+wretch who creeps along the streets. Be comforted! But, within myself, I
+shall always be, towards you, what I am now, though outwardly I shall be
+what you have heretofore seen me. The last supplication but one I make
+to you, is, that you will believe this of me.”
+
+“I will, Mr. Carton.”
+
+“My last supplication of all, is this; and with it, I will relieve
+you of a visitor with whom I well know you have nothing in unison, and
+between whom and you there is an impassable space. It is useless to say
+it, I know, but it rises out of my soul. For you, and for any dear to
+you, I would do anything. If my career were of that better kind that
+there was any opportunity or capacity of sacrifice in it, I would
+embrace any sacrifice for you and for those dear to you. Try to hold
+me in your mind, at some quiet times, as ardent and sincere in this one
+thing. The time will come, the time will not be long in coming, when new
+ties will be formed about you--ties that will bind you yet more tenderly
+and strongly to the home you so adorn--the dearest ties that will ever
+grace and gladden you. O Miss Manette, when the little picture of a
+happy father’s face looks up in yours, when you see your own bright
+beauty springing up anew at your feet, think now and then that there is
+a man who would give his life, to keep a life you love beside you!”
+
+He said, “Farewell!” said a last “God bless you!” and left her.
+
+
+
+
+XIV. The Honest Tradesman
+
+
+To the eyes of Mr. Jeremiah Cruncher, sitting on his stool in
+Fleet-street with his grisly urchin beside him, a vast number and
+variety of objects in movement were every day presented. Who could sit
+upon anything in Fleet-street during the busy hours of the day, and
+not be dazed and deafened by two immense processions, one ever tending
+westward with the sun, the other ever tending eastward from the sun,
+both ever tending to the plains beyond the range of red and purple where
+the sun goes down!
+
+With his straw in his mouth, Mr. Cruncher sat watching the two streams,
+like the heathen rustic who has for several centuries been on duty
+watching one stream--saving that Jerry had no expectation of their ever
+running dry. Nor would it have been an expectation of a hopeful kind,
+since a small part of his income was derived from the pilotage of timid
+women (mostly of a full habit and past the middle term of life) from
+Tellson’s side of the tides to the opposite shore. Brief as such
+companionship was in every separate instance, Mr. Cruncher never failed
+to become so interested in the lady as to express a strong desire to
+have the honour of drinking her very good health. And it was from
+the gifts bestowed upon him towards the execution of this benevolent
+purpose, that he recruited his finances, as just now observed.
+
+Time was, when a poet sat upon a stool in a public place, and mused in
+the sight of men. Mr. Cruncher, sitting on a stool in a public place,
+but not being a poet, mused as little as possible, and looked about him.
+
+It fell out that he was thus engaged in a season when crowds were
+few, and belated women few, and when his affairs in general were so
+unprosperous as to awaken a strong suspicion in his breast that Mrs.
+Cruncher must have been “flopping” in some pointed manner, when an
+unusual concourse pouring down Fleet-street westward, attracted his
+attention. Looking that way, Mr. Cruncher made out that some kind of
+funeral was coming along, and that there was popular objection to this
+funeral, which engendered uproar.
+
+“Young Jerry,” said Mr. Cruncher, turning to his offspring, “it’s a
+buryin’.”
+
+“Hooroar, father!” cried Young Jerry.
+
+The young gentleman uttered this exultant sound with mysterious
+significance. The elder gentleman took the cry so ill, that he watched
+his opportunity, and smote the young gentleman on the ear.
+
+“What d’ye mean? What are you hooroaring at? What do you want to conwey
+to your own father, you young Rip? This boy is a getting too many for
+_me_!” said Mr. Cruncher, surveying him. “Him and his hooroars! Don’t
+let me hear no more of you, or you shall feel some more of me. D’ye
+hear?”
+
+“I warn’t doing no harm,” Young Jerry protested, rubbing his cheek.
+
+“Drop it then,” said Mr. Cruncher; “I won’t have none of _your_ no
+harms. Get a top of that there seat, and look at the crowd.”
+
+His son obeyed, and the crowd approached; they were bawling and hissing
+round a dingy hearse and dingy mourning coach, in which mourning coach
+there was only one mourner, dressed in the dingy trappings that were
+considered essential to the dignity of the position. The position
+appeared by no means to please him, however, with an increasing rabble
+surrounding the coach, deriding him, making grimaces at him, and
+incessantly groaning and calling out: “Yah! Spies! Tst! Yaha! Spies!”
+ with many compliments too numerous and forcible to repeat.
+
+Funerals had at all times a remarkable attraction for Mr. Cruncher; he
+always pricked up his senses, and became excited, when a funeral passed
+Tellson’s. Naturally, therefore, a funeral with this uncommon attendance
+excited him greatly, and he asked of the first man who ran against him:
+
+“What is it, brother? What’s it about?”
+
+“_I_ don’t know,” said the man. “Spies! Yaha! Tst! Spies!”
+
+He asked another man. “Who is it?”
+
+“_I_ don’t know,” returned the man, clapping his hands to his mouth
+nevertheless, and vociferating in a surprising heat and with the
+greatest ardour, “Spies! Yaha! Tst, tst! Spi--ies!”
+
+At length, a person better informed on the merits of the case, tumbled
+against him, and from this person he learned that the funeral was the
+funeral of one Roger Cly.
+
+“Was He a spy?” asked Mr. Cruncher.
+
+“Old Bailey spy,” returned his informant. “Yaha! Tst! Yah! Old Bailey
+Spi--i--ies!”
+
+“Why, to be sure!” exclaimed Jerry, recalling the Trial at which he had
+assisted. “I’ve seen him. Dead, is he?”
+
+“Dead as mutton,” returned the other, “and can’t be too dead. Have ‘em
+out, there! Spies! Pull ‘em out, there! Spies!”
+
+The idea was so acceptable in the prevalent absence of any idea,
+that the crowd caught it up with eagerness, and loudly repeating the
+suggestion to have ‘em out, and to pull ‘em out, mobbed the two vehicles
+so closely that they came to a stop. On the crowd’s opening the coach
+doors, the one mourner scuffled out of himself and was in their hands
+for a moment; but he was so alert, and made such good use of his time,
+that in another moment he was scouring away up a bye-street, after
+shedding his cloak, hat, long hatband, white pocket-handkerchief, and
+other symbolical tears.
+
+These, the people tore to pieces and scattered far and wide with great
+enjoyment, while the tradesmen hurriedly shut up their shops; for a
+crowd in those times stopped at nothing, and was a monster much dreaded.
+They had already got the length of opening the hearse to take the coffin
+out, when some brighter genius proposed instead, its being escorted to
+its destination amidst general rejoicing. Practical suggestions being
+much needed, this suggestion, too, was received with acclamation, and
+the coach was immediately filled with eight inside and a dozen out,
+while as many people got on the roof of the hearse as could by any
+exercise of ingenuity stick upon it. Among the first of these volunteers
+was Jerry Cruncher himself, who modestly concealed his spiky head from
+the observation of Tellson’s, in the further corner of the mourning
+coach.
+
+The officiating undertakers made some protest against these changes in
+the ceremonies; but, the river being alarmingly near, and several voices
+remarking on the efficacy of cold immersion in bringing refractory
+members of the profession to reason, the protest was faint and brief.
+The remodelled procession started, with a chimney-sweep driving the
+hearse--advised by the regular driver, who was perched beside him, under
+close inspection, for the purpose--and with a pieman, also attended
+by his cabinet minister, driving the mourning coach. A bear-leader, a
+popular street character of the time, was impressed as an additional
+ornament, before the cavalcade had gone far down the Strand; and his
+bear, who was black and very mangy, gave quite an Undertaking air to
+that part of the procession in which he walked.
+
+Thus, with beer-drinking, pipe-smoking, song-roaring, and infinite
+caricaturing of woe, the disorderly procession went its way, recruiting
+at every step, and all the shops shutting up before it. Its destination
+was the old church of Saint Pancras, far off in the fields. It got there
+in course of time; insisted on pouring into the burial-ground; finally,
+accomplished the interment of the deceased Roger Cly in its own way, and
+highly to its own satisfaction.
+
+The dead man disposed of, and the crowd being under the necessity of
+providing some other entertainment for itself, another brighter
+genius (or perhaps the same) conceived the humour of impeaching casual
+passers-by, as Old Bailey spies, and wreaking vengeance on them. Chase
+was given to some scores of inoffensive persons who had never been near
+the Old Bailey in their lives, in the realisation of this fancy, and
+they were roughly hustled and maltreated. The transition to the sport of
+window-breaking, and thence to the plundering of public-houses, was easy
+and natural. At last, after several hours, when sundry summer-houses had
+been pulled down, and some area-railings had been torn up, to arm
+the more belligerent spirits, a rumour got about that the Guards were
+coming. Before this rumour, the crowd gradually melted away, and perhaps
+the Guards came, and perhaps they never came, and this was the usual
+progress of a mob.
+
+Mr. Cruncher did not assist at the closing sports, but had remained
+behind in the churchyard, to confer and condole with the undertakers.
+The place had a soothing influence on him. He procured a pipe from a
+neighbouring public-house, and smoked it, looking in at the railings and
+maturely considering the spot.
+
+“Jerry,” said Mr. Cruncher, apostrophising himself in his usual way,
+“you see that there Cly that day, and you see with your own eyes that he
+was a young ‘un and a straight made ‘un.”
+
+Having smoked his pipe out, and ruminated a little longer, he turned
+himself about, that he might appear, before the hour of closing, on his
+station at Tellson’s. Whether his meditations on mortality had touched
+his liver, or whether his general health had been previously at all
+amiss, or whether he desired to show a little attention to an eminent
+man, is not so much to the purpose, as that he made a short call upon
+his medical adviser--a distinguished surgeon--on his way back.
+
+Young Jerry relieved his father with dutiful interest, and reported No
+job in his absence. The bank closed, the ancient clerks came out, the
+usual watch was set, and Mr. Cruncher and his son went home to tea.
+
+“Now, I tell you where it is!” said Mr. Cruncher to his wife, on
+entering. “If, as a honest tradesman, my wenturs goes wrong to-night, I
+shall make sure that you’ve been praying again me, and I shall work you
+for it just the same as if I seen you do it.”
+
+The dejected Mrs. Cruncher shook her head.
+
+“Why, you’re at it afore my face!” said Mr. Cruncher, with signs of
+angry apprehension.
+
+“I am saying nothing.”
+
+“Well, then; don’t meditate nothing. You might as well flop as meditate.
+You may as well go again me one way as another. Drop it altogether.”
+
+“Yes, Jerry.”
+
+“Yes, Jerry,” repeated Mr. Cruncher sitting down to tea. “Ah! It _is_
+yes, Jerry. That’s about it. You may say yes, Jerry.”
+
+Mr. Cruncher had no particular meaning in these sulky corroborations,
+but made use of them, as people not unfrequently do, to express general
+ironical dissatisfaction.
+
+“You and your yes, Jerry,” said Mr. Cruncher, taking a bite out of his
+bread-and-butter, and seeming to help it down with a large invisible
+oyster out of his saucer. “Ah! I think so. I believe you.”
+
+“You are going out to-night?” asked his decent wife, when he took
+another bite.
+
+“Yes, I am.”
+
+“May I go with you, father?” asked his son, briskly.
+
+“No, you mayn’t. I’m a going--as your mother knows--a fishing. That’s
+where I’m going to. Going a fishing.”
+
+“Your fishing-rod gets rayther rusty; don’t it, father?”
+
+“Never you mind.”
+
+“Shall you bring any fish home, father?”
+
+“If I don’t, you’ll have short commons, to-morrow,” returned that
+gentleman, shaking his head; “that’s questions enough for you; I ain’t a
+going out, till you’ve been long abed.”
+
+He devoted himself during the remainder of the evening to keeping a
+most vigilant watch on Mrs. Cruncher, and sullenly holding her in
+conversation that she might be prevented from meditating any petitions
+to his disadvantage. With this view, he urged his son to hold her in
+conversation also, and led the unfortunate woman a hard life by dwelling
+on any causes of complaint he could bring against her, rather than
+he would leave her for a moment to her own reflections. The devoutest
+person could have rendered no greater homage to the efficacy of an
+honest prayer than he did in this distrust of his wife. It was as if a
+professed unbeliever in ghosts should be frightened by a ghost story.
+
+“And mind you!” said Mr. Cruncher. “No games to-morrow! If I, as a
+honest tradesman, succeed in providing a jinte of meat or two, none
+of your not touching of it, and sticking to bread. If I, as a honest
+tradesman, am able to provide a little beer, none of your declaring
+on water. When you go to Rome, do as Rome does. Rome will be a ugly
+customer to you, if you don’t. _I_‘m your Rome, you know.”
+
+Then he began grumbling again:
+
+“With your flying into the face of your own wittles and drink! I don’t
+know how scarce you mayn’t make the wittles and drink here, by your
+flopping tricks and your unfeeling conduct. Look at your boy: he _is_
+your’n, ain’t he? He’s as thin as a lath. Do you call yourself a mother,
+and not know that a mother’s first duty is to blow her boy out?”
+
+This touched Young Jerry on a tender place; who adjured his mother to
+perform her first duty, and, whatever else she did or neglected, above
+all things to lay especial stress on the discharge of that maternal
+function so affectingly and delicately indicated by his other parent.
+
+Thus the evening wore away with the Cruncher family, until Young Jerry
+was ordered to bed, and his mother, laid under similar injunctions,
+obeyed them. Mr. Cruncher beguiled the earlier watches of the night with
+solitary pipes, and did not start upon his excursion until nearly one
+o’clock. Towards that small and ghostly hour, he rose up from his chair,
+took a key out of his pocket, opened a locked cupboard, and brought
+forth a sack, a crowbar of convenient size, a rope and chain, and other
+fishing tackle of that nature. Disposing these articles about him
+in skilful manner, he bestowed a parting defiance on Mrs. Cruncher,
+extinguished the light, and went out.
+
+Young Jerry, who had only made a feint of undressing when he went to
+bed, was not long after his father. Under cover of the darkness he
+followed out of the room, followed down the stairs, followed down the
+court, followed out into the streets. He was in no uneasiness concerning
+his getting into the house again, for it was full of lodgers, and the
+door stood ajar all night.
+
+Impelled by a laudable ambition to study the art and mystery of his
+father’s honest calling, Young Jerry, keeping as close to house fronts,
+walls, and doorways, as his eyes were close to one another, held his
+honoured parent in view. The honoured parent steering Northward, had not
+gone far, when he was joined by another disciple of Izaak Walton, and
+the two trudged on together.
+
+Within half an hour from the first starting, they were beyond the
+winking lamps, and the more than winking watchmen, and were out upon a
+lonely road. Another fisherman was picked up here--and that so silently,
+that if Young Jerry had been superstitious, he might have supposed the
+second follower of the gentle craft to have, all of a sudden, split
+himself into two.
+
+The three went on, and Young Jerry went on, until the three stopped
+under a bank overhanging the road. Upon the top of the bank was a low
+brick wall, surmounted by an iron railing. In the shadow of bank and
+wall the three turned out of the road, and up a blind lane, of which
+the wall--there, risen to some eight or ten feet high--formed one side.
+Crouching down in a corner, peeping up the lane, the next object that
+Young Jerry saw, was the form of his honoured parent, pretty well
+defined against a watery and clouded moon, nimbly scaling an iron gate.
+He was soon over, and then the second fisherman got over, and then the
+third. They all dropped softly on the ground within the gate, and lay
+there a little--listening perhaps. Then, they moved away on their hands
+and knees.
+
+It was now Young Jerry’s turn to approach the gate: which he did,
+holding his breath. Crouching down again in a corner there, and looking
+in, he made out the three fishermen creeping through some rank grass!
+and all the gravestones in the churchyard--it was a large churchyard
+that they were in--looking on like ghosts in white, while the church
+tower itself looked on like the ghost of a monstrous giant. They did not
+creep far, before they stopped and stood upright. And then they began to
+fish.
+
+They fished with a spade, at first. Presently the honoured parent
+appeared to be adjusting some instrument like a great corkscrew.
+Whatever tools they worked with, they worked hard, until the awful
+striking of the church clock so terrified Young Jerry, that he made off,
+with his hair as stiff as his father’s.
+
+But, his long-cherished desire to know more about these matters, not
+only stopped him in his running away, but lured him back again. They
+were still fishing perseveringly, when he peeped in at the gate for
+the second time; but, now they seemed to have got a bite. There was a
+screwing and complaining sound down below, and their bent figures were
+strained, as if by a weight. By slow degrees the weight broke away the
+earth upon it, and came to the surface. Young Jerry very well knew what
+it would be; but, when he saw it, and saw his honoured parent about to
+wrench it open, he was so frightened, being new to the sight, that he
+made off again, and never stopped until he had run a mile or more.
+
+He would not have stopped then, for anything less necessary than breath,
+it being a spectral sort of race that he ran, and one highly desirable
+to get to the end of. He had a strong idea that the coffin he had seen
+was running after him; and, pictured as hopping on behind him, bolt
+upright, upon its narrow end, always on the point of overtaking him
+and hopping on at his side--perhaps taking his arm--it was a pursuer to
+shun. It was an inconsistent and ubiquitous fiend too, for, while it
+was making the whole night behind him dreadful, he darted out into the
+roadway to avoid dark alleys, fearful of its coming hopping out of them
+like a dropsical boy’s Kite without tail and wings. It hid in doorways
+too, rubbing its horrible shoulders against doors, and drawing them up
+to its ears, as if it were laughing. It got into shadows on the road,
+and lay cunningly on its back to trip him up. All this time it was
+incessantly hopping on behind and gaining on him, so that when the boy
+got to his own door he had reason for being half dead. And even then
+it would not leave him, but followed him upstairs with a bump on every
+stair, scrambled into bed with him, and bumped down, dead and heavy, on
+his breast when he fell asleep.
+
+From his oppressed slumber, Young Jerry in his closet was awakened after
+daybreak and before sunrise, by the presence of his father in the
+family room. Something had gone wrong with him; at least, so Young Jerry
+inferred, from the circumstance of his holding Mrs. Cruncher by the
+ears, and knocking the back of her head against the head-board of the
+bed.
+
+“I told you I would,” said Mr. Cruncher, “and I did.”
+
+“Jerry, Jerry, Jerry!” his wife implored.
+
+“You oppose yourself to the profit of the business,” said Jerry, “and me
+and my partners suffer. You was to honour and obey; why the devil don’t
+you?”
+
+“I try to be a good wife, Jerry,” the poor woman protested, with tears.
+
+“Is it being a good wife to oppose your husband’s business? Is it
+honouring your husband to dishonour his business? Is it obeying your
+husband to disobey him on the wital subject of his business?”
+
+“You hadn’t taken to the dreadful business then, Jerry.”
+
+“It’s enough for you,” retorted Mr. Cruncher, “to be the wife of a
+honest tradesman, and not to occupy your female mind with calculations
+when he took to his trade or when he didn’t. A honouring and obeying
+wife would let his trade alone altogether. Call yourself a religious
+woman? If you’re a religious woman, give me a irreligious one! You have
+no more nat’ral sense of duty than the bed of this here Thames river has
+of a pile, and similarly it must be knocked into you.”
+
+The altercation was conducted in a low tone of voice, and terminated in
+the honest tradesman’s kicking off his clay-soiled boots, and lying down
+at his length on the floor. After taking a timid peep at him lying on
+his back, with his rusty hands under his head for a pillow, his son lay
+down too, and fell asleep again.
+
+There was no fish for breakfast, and not much of anything else. Mr.
+Cruncher was out of spirits, and out of temper, and kept an iron pot-lid
+by him as a projectile for the correction of Mrs. Cruncher, in case
+he should observe any symptoms of her saying Grace. He was brushed
+and washed at the usual hour, and set off with his son to pursue his
+ostensible calling.
+
+Young Jerry, walking with the stool under his arm at his father’s side
+along sunny and crowded Fleet-street, was a very different Young Jerry
+from him of the previous night, running home through darkness and
+solitude from his grim pursuer. His cunning was fresh with the day,
+and his qualms were gone with the night--in which particulars it is not
+improbable that he had compeers in Fleet-street and the City of London,
+that fine morning.
+
+“Father,” said Young Jerry, as they walked along: taking care to keep
+at arm’s length and to have the stool well between them: “what’s a
+Resurrection-Man?”
+
+Mr. Cruncher came to a stop on the pavement before he answered, “How
+should I know?”
+
+“I thought you knowed everything, father,” said the artless boy.
+
+“Hem! Well,” returned Mr. Cruncher, going on again, and lifting off his
+hat to give his spikes free play, “he’s a tradesman.”
+
+“What’s his goods, father?” asked the brisk Young Jerry.
+
+“His goods,” said Mr. Cruncher, after turning it over in his mind, “is a
+branch of Scientific goods.”
+
+“Persons’ bodies, ain’t it, father?” asked the lively boy.
+
+“I believe it is something of that sort,” said Mr. Cruncher.
+
+“Oh, father, I should so like to be a Resurrection-Man when I’m quite
+growed up!”
+
+Mr. Cruncher was soothed, but shook his head in a dubious and moral way.
+“It depends upon how you dewelop your talents. Be careful to dewelop
+your talents, and never to say no more than you can help to nobody, and
+there’s no telling at the present time what you may not come to be fit
+for.” As Young Jerry, thus encouraged, went on a few yards in advance,
+to plant the stool in the shadow of the Bar, Mr. Cruncher added to
+himself: “Jerry, you honest tradesman, there’s hopes wot that boy will
+yet be a blessing to you, and a recompense to you for his mother!”
+
+
+
+
+XV. Knitting
+
+
+There had been earlier drinking than usual in the wine-shop of Monsieur
+Defarge. As early as six o’clock in the morning, sallow faces peeping
+through its barred windows had descried other faces within, bending over
+measures of wine. Monsieur Defarge sold a very thin wine at the best
+of times, but it would seem to have been an unusually thin wine that
+he sold at this time. A sour wine, moreover, or a souring, for its
+influence on the mood of those who drank it was to make them gloomy. No
+vivacious Bacchanalian flame leaped out of the pressed grape of Monsieur
+Defarge: but, a smouldering fire that burnt in the dark, lay hidden in
+the dregs of it.
+
+This had been the third morning in succession, on which there had been
+early drinking at the wine-shop of Monsieur Defarge. It had begun
+on Monday, and here was Wednesday come. There had been more of early
+brooding than drinking; for, many men had listened and whispered and
+slunk about there from the time of the opening of the door, who could
+not have laid a piece of money on the counter to save their souls. These
+were to the full as interested in the place, however, as if they could
+have commanded whole barrels of wine; and they glided from seat to seat,
+and from corner to corner, swallowing talk in lieu of drink, with greedy
+looks.
+
+Notwithstanding an unusual flow of company, the master of the wine-shop
+was not visible. He was not missed; for, nobody who crossed the
+threshold looked for him, nobody asked for him, nobody wondered to see
+only Madame Defarge in her seat, presiding over the distribution of
+wine, with a bowl of battered small coins before her, as much defaced
+and beaten out of their original impress as the small coinage of
+humanity from whose ragged pockets they had come.
+
+A suspended interest and a prevalent absence of mind, were perhaps
+observed by the spies who looked in at the wine-shop, as they looked in
+at every place, high and low, from the king’s palace to the criminal’s
+gaol. Games at cards languished, players at dominoes musingly built
+towers with them, drinkers drew figures on the tables with spilt drops
+of wine, Madame Defarge herself picked out the pattern on her sleeve
+with her toothpick, and saw and heard something inaudible and invisible
+a long way off.
+
+Thus, Saint Antoine in this vinous feature of his, until midday. It was
+high noontide, when two dusty men passed through his streets and under
+his swinging lamps: of whom, one was Monsieur Defarge: the other a
+mender of roads in a blue cap. All adust and athirst, the two entered
+the wine-shop. Their arrival had lighted a kind of fire in the breast
+of Saint Antoine, fast spreading as they came along, which stirred and
+flickered in flames of faces at most doors and windows. Yet, no one had
+followed them, and no man spoke when they entered the wine-shop, though
+the eyes of every man there were turned upon them.
+
+“Good day, gentlemen!” said Monsieur Defarge.
+
+It may have been a signal for loosening the general tongue. It elicited
+an answering chorus of “Good day!”
+
+“It is bad weather, gentlemen,” said Defarge, shaking his head.
+
+Upon which, every man looked at his neighbour, and then all cast down
+their eyes and sat silent. Except one man, who got up and went out.
+
+“My wife,” said Defarge aloud, addressing Madame Defarge: “I have
+travelled certain leagues with this good mender of roads, called
+Jacques. I met him--by accident--a day and half’s journey out of Paris.
+He is a good child, this mender of roads, called Jacques. Give him to
+drink, my wife!”
+
+A second man got up and went out. Madame Defarge set wine before the
+mender of roads called Jacques, who doffed his blue cap to the company,
+and drank. In the breast of his blouse he carried some coarse dark
+bread; he ate of this between whiles, and sat munching and drinking near
+Madame Defarge’s counter. A third man got up and went out.
+
+Defarge refreshed himself with a draught of wine--but, he took less
+than was given to the stranger, as being himself a man to whom it was no
+rarity--and stood waiting until the countryman had made his breakfast.
+He looked at no one present, and no one now looked at him; not even
+Madame Defarge, who had taken up her knitting, and was at work.
+
+“Have you finished your repast, friend?” he asked, in due season.
+
+“Yes, thank you.”
+
+“Come, then! You shall see the apartment that I told you you could
+occupy. It will suit you to a marvel.”
+
+Out of the wine-shop into the street, out of the street into a
+courtyard, out of the courtyard up a steep staircase, out of the
+staircase into a garret--formerly the garret where a white-haired man
+sat on a low bench, stooping forward and very busy, making shoes.
+
+No white-haired man was there now; but, the three men were there who had
+gone out of the wine-shop singly. And between them and the white-haired
+man afar off, was the one small link, that they had once looked in at
+him through the chinks in the wall.
+
+Defarge closed the door carefully, and spoke in a subdued voice:
+
+“Jacques One, Jacques Two, Jacques Three! This is the witness
+encountered by appointment, by me, Jacques Four. He will tell you all.
+Speak, Jacques Five!”
+
+The mender of roads, blue cap in hand, wiped his swarthy forehead with
+it, and said, “Where shall I commence, monsieur?”
+
+“Commence,” was Monsieur Defarge’s not unreasonable reply, “at the
+commencement.”
+
+“I saw him then, messieurs,” began the mender of roads, “a year ago this
+running summer, underneath the carriage of the Marquis, hanging by the
+chain. Behold the manner of it. I leaving my work on the road, the sun
+going to bed, the carriage of the Marquis slowly ascending the hill, he
+hanging by the chain--like this.”
+
+Again the mender of roads went through the whole performance; in which
+he ought to have been perfect by that time, seeing that it had been
+the infallible resource and indispensable entertainment of his village
+during a whole year.
+
+Jacques One struck in, and asked if he had ever seen the man before?
+
+“Never,” answered the mender of roads, recovering his perpendicular.
+
+Jacques Three demanded how he afterwards recognised him then?
+
+“By his tall figure,” said the mender of roads, softly, and with his
+finger at his nose. “When Monsieur the Marquis demands that evening,
+‘Say, what is he like?’ I make response, ‘Tall as a spectre.’”
+
+“You should have said, short as a dwarf,” returned Jacques Two.
+
+“But what did I know? The deed was not then accomplished, neither did he
+confide in me. Observe! Under those circumstances even, I do not
+offer my testimony. Monsieur the Marquis indicates me with his finger,
+standing near our little fountain, and says, ‘To me! Bring that rascal!’
+My faith, messieurs, I offer nothing.”
+
+“He is right there, Jacques,” murmured Defarge, to him who had
+interrupted. “Go on!”
+
+“Good!” said the mender of roads, with an air of mystery. “The tall man
+is lost, and he is sought--how many months? Nine, ten, eleven?”
+
+“No matter, the number,” said Defarge. “He is well hidden, but at last
+he is unluckily found. Go on!”
+
+“I am again at work upon the hill-side, and the sun is again about to
+go to bed. I am collecting my tools to descend to my cottage down in the
+village below, where it is already dark, when I raise my eyes, and see
+coming over the hill six soldiers. In the midst of them is a tall man
+with his arms bound--tied to his sides--like this!”
+
+With the aid of his indispensable cap, he represented a man with his
+elbows bound fast at his hips, with cords that were knotted behind him.
+
+“I stand aside, messieurs, by my heap of stones, to see the soldiers
+and their prisoner pass (for it is a solitary road, that, where any
+spectacle is well worth looking at), and at first, as they approach, I
+see no more than that they are six soldiers with a tall man bound, and
+that they are almost black to my sight--except on the side of the sun
+going to bed, where they have a red edge, messieurs. Also, I see that
+their long shadows are on the hollow ridge on the opposite side of the
+road, and are on the hill above it, and are like the shadows of giants.
+Also, I see that they are covered with dust, and that the dust moves
+with them as they come, tramp, tramp! But when they advance quite near
+to me, I recognise the tall man, and he recognises me. Ah, but he would
+be well content to precipitate himself over the hill-side once again, as
+on the evening when he and I first encountered, close to the same spot!”
+
+He described it as if he were there, and it was evident that he saw it
+vividly; perhaps he had not seen much in his life.
+
+“I do not show the soldiers that I recognise the tall man; he does not
+show the soldiers that he recognises me; we do it, and we know it, with
+our eyes. ‘Come on!’ says the chief of that company, pointing to the
+village, ‘bring him fast to his tomb!’ and they bring him faster. I
+follow. His arms are swelled because of being bound so tight, his wooden
+shoes are large and clumsy, and he is lame. Because he is lame, and
+consequently slow, they drive him with their guns--like this!”
+
+He imitated the action of a man’s being impelled forward by the
+butt-ends of muskets.
+
+“As they descend the hill like madmen running a race, he falls. They
+laugh and pick him up again. His face is bleeding and covered with dust,
+but he cannot touch it; thereupon they laugh again. They bring him into
+the village; all the village runs to look; they take him past the mill,
+and up to the prison; all the village sees the prison gate open in the
+darkness of the night, and swallow him--like this!”
+
+He opened his mouth as wide as he could, and shut it with a sounding
+snap of his teeth. Observant of his unwillingness to mar the effect by
+opening it again, Defarge said, “Go on, Jacques.”
+
+“All the village,” pursued the mender of roads, on tiptoe and in a low
+voice, “withdraws; all the village whispers by the fountain; all the
+village sleeps; all the village dreams of that unhappy one, within the
+locks and bars of the prison on the crag, and never to come out of it,
+except to perish. In the morning, with my tools upon my shoulder, eating
+my morsel of black bread as I go, I make a circuit by the prison, on
+my way to my work. There I see him, high up, behind the bars of a lofty
+iron cage, bloody and dusty as last night, looking through. He has no
+hand free, to wave to me; I dare not call to him; he regards me like a
+dead man.”
+
+Defarge and the three glanced darkly at one another. The looks of all
+of them were dark, repressed, and revengeful, as they listened to the
+countryman’s story; the manner of all of them, while it was secret, was
+authoritative too. They had the air of a rough tribunal; Jacques One
+and Two sitting on the old pallet-bed, each with his chin resting on
+his hand, and his eyes intent on the road-mender; Jacques Three, equally
+intent, on one knee behind them, with his agitated hand always gliding
+over the network of fine nerves about his mouth and nose; Defarge
+standing between them and the narrator, whom he had stationed in the
+light of the window, by turns looking from him to them, and from them to
+him.
+
+“Go on, Jacques,” said Defarge.
+
+“He remains up there in his iron cage some days. The village looks
+at him by stealth, for it is afraid. But it always looks up, from a
+distance, at the prison on the crag; and in the evening, when the work
+of the day is achieved and it assembles to gossip at the fountain, all
+faces are turned towards the prison. Formerly, they were turned towards
+the posting-house; now, they are turned towards the prison. They
+whisper at the fountain, that although condemned to death he will not be
+executed; they say that petitions have been presented in Paris, showing
+that he was enraged and made mad by the death of his child; they say
+that a petition has been presented to the King himself. What do I know?
+It is possible. Perhaps yes, perhaps no.”
+
+“Listen then, Jacques,” Number One of that name sternly interposed.
+“Know that a petition was presented to the King and Queen. All here,
+yourself excepted, saw the King take it, in his carriage in the street,
+sitting beside the Queen. It is Defarge whom you see here, who, at the
+hazard of his life, darted out before the horses, with the petition in
+his hand.”
+
+“And once again listen, Jacques!” said the kneeling Number Three:
+his fingers ever wandering over and over those fine nerves, with a
+strikingly greedy air, as if he hungered for something--that was neither
+food nor drink; “the guard, horse and foot, surrounded the petitioner,
+and struck him blows. You hear?”
+
+“I hear, messieurs.”
+
+“Go on then,” said Defarge.
+
+“Again; on the other hand, they whisper at the fountain,” resumed the
+countryman, “that he is brought down into our country to be executed on
+the spot, and that he will very certainly be executed. They even whisper
+that because he has slain Monseigneur, and because Monseigneur was the
+father of his tenants--serfs--what you will--he will be executed as a
+parricide. One old man says at the fountain, that his right hand, armed
+with the knife, will be burnt off before his face; that, into wounds
+which will be made in his arms, his breast, and his legs, there will be
+poured boiling oil, melted lead, hot resin, wax, and sulphur; finally,
+that he will be torn limb from limb by four strong horses. That old man
+says, all this was actually done to a prisoner who made an attempt on
+the life of the late King, Louis Fifteen. But how do I know if he lies?
+I am not a scholar.”
+
+“Listen once again then, Jacques!” said the man with the restless hand
+and the craving air. “The name of that prisoner was Damiens, and it was
+all done in open day, in the open streets of this city of Paris; and
+nothing was more noticed in the vast concourse that saw it done, than
+the crowd of ladies of quality and fashion, who were full of eager
+attention to the last--to the last, Jacques, prolonged until nightfall,
+when he had lost two legs and an arm, and still breathed! And it was
+done--why, how old are you?”
+
+“Thirty-five,” said the mender of roads, who looked sixty.
+
+“It was done when you were more than ten years old; you might have seen
+it.”
+
+“Enough!” said Defarge, with grim impatience. “Long live the Devil! Go
+on.”
+
+“Well! Some whisper this, some whisper that; they speak of nothing else;
+even the fountain appears to fall to that tune. At length, on Sunday
+night when all the village is asleep, come soldiers, winding down from
+the prison, and their guns ring on the stones of the little street.
+Workmen dig, workmen hammer, soldiers laugh and sing; in the morning, by
+the fountain, there is raised a gallows forty feet high, poisoning the
+water.”
+
+The mender of roads looked _through_ rather than _at_ the low ceiling,
+and pointed as if he saw the gallows somewhere in the sky.
+
+“All work is stopped, all assemble there, nobody leads the cows out,
+the cows are there with the rest. At midday, the roll of drums. Soldiers
+have marched into the prison in the night, and he is in the midst
+of many soldiers. He is bound as before, and in his mouth there is
+a gag--tied so, with a tight string, making him look almost as if he
+laughed.” He suggested it, by creasing his face with his two thumbs,
+from the corners of his mouth to his ears. “On the top of the gallows is
+fixed the knife, blade upwards, with its point in the air. He is hanged
+there forty feet high--and is left hanging, poisoning the water.”
+
+They looked at one another, as he used his blue cap to wipe his face,
+on which the perspiration had started afresh while he recalled the
+spectacle.
+
+“It is frightful, messieurs. How can the women and the children draw
+water! Who can gossip of an evening, under that shadow! Under it, have
+I said? When I left the village, Monday evening as the sun was going to
+bed, and looked back from the hill, the shadow struck across the church,
+across the mill, across the prison--seemed to strike across the earth,
+messieurs, to where the sky rests upon it!”
+
+The hungry man gnawed one of his fingers as he looked at the other
+three, and his finger quivered with the craving that was on him.
+
+“That’s all, messieurs. I left at sunset (as I had been warned to do),
+and I walked on, that night and half next day, until I met (as I was
+warned I should) this comrade. With him, I came on, now riding and now
+walking, through the rest of yesterday and through last night. And here
+you see me!”
+
+After a gloomy silence, the first Jacques said, “Good! You have acted
+and recounted faithfully. Will you wait for us a little, outside the
+door?”
+
+“Very willingly,” said the mender of roads. Whom Defarge escorted to the
+top of the stairs, and, leaving seated there, returned.
+
+The three had risen, and their heads were together when he came back to
+the garret.
+
+“How say you, Jacques?” demanded Number One. “To be registered?”
+
+“To be registered, as doomed to destruction,” returned Defarge.
+
+“Magnificent!” croaked the man with the craving.
+
+“The chateau, and all the race?” inquired the first.
+
+“The chateau and all the race,” returned Defarge. “Extermination.”
+
+The hungry man repeated, in a rapturous croak, “Magnificent!” and began
+gnawing another finger.
+
+“Are you sure,” asked Jacques Two, of Defarge, “that no embarrassment
+can arise from our manner of keeping the register? Without doubt it is
+safe, for no one beyond ourselves can decipher it; but shall we always
+be able to decipher it--or, I ought to say, will she?”
+
+“Jacques,” returned Defarge, drawing himself up, “if madame my wife
+undertook to keep the register in her memory alone, she would not lose
+a word of it--not a syllable of it. Knitted, in her own stitches and her
+own symbols, it will always be as plain to her as the sun. Confide in
+Madame Defarge. It would be easier for the weakest poltroon that lives,
+to erase himself from existence, than to erase one letter of his name or
+crimes from the knitted register of Madame Defarge.”
+
+There was a murmur of confidence and approval, and then the man who
+hungered, asked: “Is this rustic to be sent back soon? I hope so. He is
+very simple; is he not a little dangerous?”
+
+“He knows nothing,” said Defarge; “at least nothing more than would
+easily elevate himself to a gallows of the same height. I charge myself
+with him; let him remain with me; I will take care of him, and set him
+on his road. He wishes to see the fine world--the King, the Queen, and
+Court; let him see them on Sunday.”
+
+“What?” exclaimed the hungry man, staring. “Is it a good sign, that he
+wishes to see Royalty and Nobility?”
+
+“Jacques,” said Defarge; “judiciously show a cat milk, if you wish her
+to thirst for it. Judiciously show a dog his natural prey, if you wish
+him to bring it down one day.”
+
+Nothing more was said, and the mender of roads, being found already
+dozing on the topmost stair, was advised to lay himself down on the
+pallet-bed and take some rest. He needed no persuasion, and was soon
+asleep.
+
+Worse quarters than Defarge’s wine-shop, could easily have been found
+in Paris for a provincial slave of that degree. Saving for a mysterious
+dread of madame by which he was constantly haunted, his life was very
+new and agreeable. But, madame sat all day at her counter, so expressly
+unconscious of him, and so particularly determined not to perceive that
+his being there had any connection with anything below the surface, that
+he shook in his wooden shoes whenever his eye lighted on her. For, he
+contended with himself that it was impossible to foresee what that lady
+might pretend next; and he felt assured that if she should take it
+into her brightly ornamented head to pretend that she had seen him do a
+murder and afterwards flay the victim, she would infallibly go through
+with it until the play was played out.
+
+Therefore, when Sunday came, the mender of roads was not enchanted
+(though he said he was) to find that madame was to accompany monsieur
+and himself to Versailles. It was additionally disconcerting to have
+madame knitting all the way there, in a public conveyance; it was
+additionally disconcerting yet, to have madame in the crowd in the
+afternoon, still with her knitting in her hands as the crowd waited to
+see the carriage of the King and Queen.
+
+“You work hard, madame,” said a man near her.
+
+“Yes,” answered Madame Defarge; “I have a good deal to do.”
+
+“What do you make, madame?”
+
+“Many things.”
+
+“For instance--”
+
+“For instance,” returned Madame Defarge, composedly, “shrouds.”
+
+The man moved a little further away, as soon as he could, and the mender
+of roads fanned himself with his blue cap: feeling it mightily close
+and oppressive. If he needed a King and Queen to restore him, he was
+fortunate in having his remedy at hand; for, soon the large-faced King
+and the fair-faced Queen came in their golden coach, attended by the
+shining Bull’s Eye of their Court, a glittering multitude of laughing
+ladies and fine lords; and in jewels and silks and powder and splendour
+and elegantly spurning figures and handsomely disdainful faces of both
+sexes, the mender of roads bathed himself, so much to his temporary
+intoxication, that he cried Long live the King, Long live the Queen,
+Long live everybody and everything! as if he had never heard of
+ubiquitous Jacques in his time. Then, there were gardens, courtyards,
+terraces, fountains, green banks, more King and Queen, more Bull’s Eye,
+more lords and ladies, more Long live they all! until he absolutely wept
+with sentiment. During the whole of this scene, which lasted some three
+hours, he had plenty of shouting and weeping and sentimental company,
+and throughout Defarge held him by the collar, as if to restrain him
+from flying at the objects of his brief devotion and tearing them to
+pieces.
+
+“Bravo!” said Defarge, clapping him on the back when it was over, like a
+patron; “you are a good boy!”
+
+The mender of roads was now coming to himself, and was mistrustful of
+having made a mistake in his late demonstrations; but no.
+
+“You are the fellow we want,” said Defarge, in his ear; “you make
+these fools believe that it will last for ever. Then, they are the more
+insolent, and it is the nearer ended.”
+
+“Hey!” cried the mender of roads, reflectively; “that’s true.”
+
+“These fools know nothing. While they despise your breath, and would
+stop it for ever and ever, in you or in a hundred like you rather than
+in one of their own horses or dogs, they only know what your breath
+tells them. Let it deceive them, then, a little longer; it cannot
+deceive them too much.”
+
+Madame Defarge looked superciliously at the client, and nodded in
+confirmation.
+
+“As to you,” said she, “you would shout and shed tears for anything, if
+it made a show and a noise. Say! Would you not?”
+
+“Truly, madame, I think so. For the moment.”
+
+“If you were shown a great heap of dolls, and were set upon them to
+pluck them to pieces and despoil them for your own advantage, you would
+pick out the richest and gayest. Say! Would you not?”
+
+“Truly yes, madame.”
+
+“Yes. And if you were shown a flock of birds, unable to fly, and were
+set upon them to strip them of their feathers for your own advantage,
+you would set upon the birds of the finest feathers; would you not?”
+
+“It is true, madame.”
+
+“You have seen both dolls and birds to-day,” said Madame Defarge, with
+a wave of her hand towards the place where they had last been apparent;
+“now, go home!”
+
+
+
+
+XVI. Still Knitting
+
+
+Madame Defarge and monsieur her husband returned amicably to the
+bosom of Saint Antoine, while a speck in a blue cap toiled through the
+darkness, and through the dust, and down the weary miles of avenue by
+the wayside, slowly tending towards that point of the compass where
+the chateau of Monsieur the Marquis, now in his grave, listened to
+the whispering trees. Such ample leisure had the stone faces, now,
+for listening to the trees and to the fountain, that the few village
+scarecrows who, in their quest for herbs to eat and fragments of dead
+stick to burn, strayed within sight of the great stone courtyard and
+terrace staircase, had it borne in upon their starved fancy that
+the expression of the faces was altered. A rumour just lived in the
+village--had a faint and bare existence there, as its people had--that
+when the knife struck home, the faces changed, from faces of pride to
+faces of anger and pain; also, that when that dangling figure was hauled
+up forty feet above the fountain, they changed again, and bore a cruel
+look of being avenged, which they would henceforth bear for ever. In the
+stone face over the great window of the bed-chamber where the murder
+was done, two fine dints were pointed out in the sculptured nose, which
+everybody recognised, and which nobody had seen of old; and on the
+scarce occasions when two or three ragged peasants emerged from the
+crowd to take a hurried peep at Monsieur the Marquis petrified, a
+skinny finger would not have pointed to it for a minute, before they all
+started away among the moss and leaves, like the more fortunate hares
+who could find a living there.
+
+Chateau and hut, stone face and dangling figure, the red stain on the
+stone floor, and the pure water in the village well--thousands of acres
+of land--a whole province of France--all France itself--lay under the
+night sky, concentrated into a faint hair-breadth line. So does a whole
+world, with all its greatnesses and littlenesses, lie in a twinkling
+star. And as mere human knowledge can split a ray of light and analyse
+the manner of its composition, so, sublimer intelligences may read in
+the feeble shining of this earth of ours, every thought and act, every
+vice and virtue, of every responsible creature on it.
+
+The Defarges, husband and wife, came lumbering under the starlight,
+in their public vehicle, to that gate of Paris whereunto their
+journey naturally tended. There was the usual stoppage at the barrier
+guardhouse, and the usual lanterns came glancing forth for the usual
+examination and inquiry. Monsieur Defarge alighted; knowing one or two
+of the soldiery there, and one of the police. The latter he was intimate
+with, and affectionately embraced.
+
+When Saint Antoine had again enfolded the Defarges in his dusky wings,
+and they, having finally alighted near the Saint’s boundaries, were
+picking their way on foot through the black mud and offal of his
+streets, Madame Defarge spoke to her husband:
+
+“Say then, my friend; what did Jacques of the police tell thee?”
+
+“Very little to-night, but all he knows. There is another spy
+commissioned for our quarter. There may be many more, for all that he
+can say, but he knows of one.”
+
+“Eh well!” said Madame Defarge, raising her eyebrows with a cool
+business air. “It is necessary to register him. How do they call that
+man?”
+
+“He is English.”
+
+“So much the better. His name?”
+
+“Barsad,” said Defarge, making it French by pronunciation. But, he had
+been so careful to get it accurately, that he then spelt it with perfect
+correctness.
+
+“Barsad,” repeated madame. “Good. Christian name?”
+
+“John.”
+
+“John Barsad,” repeated madame, after murmuring it once to herself.
+“Good. His appearance; is it known?”
+
+“Age, about forty years; height, about five feet nine; black hair;
+complexion dark; generally, rather handsome visage; eyes dark, face
+thin, long, and sallow; nose aquiline, but not straight, having a
+peculiar inclination towards the left cheek; expression, therefore,
+sinister.”
+
+“Eh my faith. It is a portrait!” said madame, laughing. “He shall be
+registered to-morrow.”
+
+They turned into the wine-shop, which was closed (for it was midnight),
+and where Madame Defarge immediately took her post at her desk, counted
+the small moneys that had been taken during her absence, examined the
+stock, went through the entries in the book, made other entries of
+her own, checked the serving man in every possible way, and finally
+dismissed him to bed. Then she turned out the contents of the bowl
+of money for the second time, and began knotting them up in her
+handkerchief, in a chain of separate knots, for safe keeping through the
+night. All this while, Defarge, with his pipe in his mouth, walked
+up and down, complacently admiring, but never interfering; in which
+condition, indeed, as to the business and his domestic affairs, he
+walked up and down through life.
+
+The night was hot, and the shop, close shut and surrounded by so foul a
+neighbourhood, was ill-smelling. Monsieur Defarge’s olfactory sense was
+by no means delicate, but the stock of wine smelt much stronger than
+it ever tasted, and so did the stock of rum and brandy and aniseed. He
+whiffed the compound of scents away, as he put down his smoked-out pipe.
+
+“You are fatigued,” said madame, raising her glance as she knotted the
+money. “There are only the usual odours.”
+
+“I am a little tired,” her husband acknowledged.
+
+“You are a little depressed, too,” said madame, whose quick eyes had
+never been so intent on the accounts, but they had had a ray or two for
+him. “Oh, the men, the men!”
+
+“But my dear!” began Defarge.
+
+“But my dear!” repeated madame, nodding firmly; “but my dear! You are
+faint of heart to-night, my dear!”
+
+“Well, then,” said Defarge, as if a thought were wrung out of his
+breast, “it _is_ a long time.”
+
+“It is a long time,” repeated his wife; “and when is it not a long time?
+Vengeance and retribution require a long time; it is the rule.”
+
+“It does not take a long time to strike a man with Lightning,” said
+Defarge.
+
+“How long,” demanded madame, composedly, “does it take to make and store
+the lightning? Tell me.”
+
+Defarge raised his head thoughtfully, as if there were something in that
+too.
+
+“It does not take a long time,” said madame, “for an earthquake to
+swallow a town. Eh well! Tell me how long it takes to prepare the
+earthquake?”
+
+“A long time, I suppose,” said Defarge.
+
+“But when it is ready, it takes place, and grinds to pieces everything
+before it. In the meantime, it is always preparing, though it is not
+seen or heard. That is your consolation. Keep it.”
+
+She tied a knot with flashing eyes, as if it throttled a foe.
+
+“I tell thee,” said madame, extending her right hand, for emphasis,
+“that although it is a long time on the road, it is on the road and
+coming. I tell thee it never retreats, and never stops. I tell thee it
+is always advancing. Look around and consider the lives of all the world
+that we know, consider the faces of all the world that we know, consider
+the rage and discontent to which the Jacquerie addresses itself with
+more and more of certainty every hour. Can such things last? Bah! I mock
+you.”
+
+“My brave wife,” returned Defarge, standing before her with his head
+a little bent, and his hands clasped at his back, like a docile and
+attentive pupil before his catechist, “I do not question all this. But
+it has lasted a long time, and it is possible--you know well, my wife,
+it is possible--that it may not come, during our lives.”
+
+“Eh well! How then?” demanded madame, tying another knot, as if there
+were another enemy strangled.
+
+“Well!” said Defarge, with a half complaining and half apologetic shrug.
+“We shall not see the triumph.”
+
+“We shall have helped it,” returned madame, with her extended hand in
+strong action. “Nothing that we do, is done in vain. I believe, with all
+my soul, that we shall see the triumph. But even if not, even if I knew
+certainly not, show me the neck of an aristocrat and tyrant, and still I
+would--”
+
+Then madame, with her teeth set, tied a very terrible knot indeed.
+
+“Hold!” cried Defarge, reddening a little as if he felt charged with
+cowardice; “I too, my dear, will stop at nothing.”
+
+“Yes! But it is your weakness that you sometimes need to see your victim
+and your opportunity, to sustain you. Sustain yourself without that.
+When the time comes, let loose a tiger and a devil; but wait for the
+time with the tiger and the devil chained--not shown--yet always ready.”
+
+Madame enforced the conclusion of this piece of advice by striking her
+little counter with her chain of money as if she knocked its brains
+out, and then gathering the heavy handkerchief under her arm in a serene
+manner, and observing that it was time to go to bed.
+
+Next noontide saw the admirable woman in her usual place in the
+wine-shop, knitting away assiduously. A rose lay beside her, and if she
+now and then glanced at the flower, it was with no infraction of her
+usual preoccupied air. There were a few customers, drinking or not
+drinking, standing or seated, sprinkled about. The day was very hot,
+and heaps of flies, who were extending their inquisitive and adventurous
+perquisitions into all the glutinous little glasses near madame, fell
+dead at the bottom. Their decease made no impression on the other flies
+out promenading, who looked at them in the coolest manner (as if they
+themselves were elephants, or something as far removed), until they met
+the same fate. Curious to consider how heedless flies are!--perhaps they
+thought as much at Court that sunny summer day.
+
+A figure entering at the door threw a shadow on Madame Defarge which she
+felt to be a new one. She laid down her knitting, and began to pin her
+rose in her head-dress, before she looked at the figure.
+
+It was curious. The moment Madame Defarge took up the rose, the
+customers ceased talking, and began gradually to drop out of the
+wine-shop.
+
+“Good day, madame,” said the new-comer.
+
+“Good day, monsieur.”
+
+She said it aloud, but added to herself, as she resumed her knitting:
+“Hah! Good day, age about forty, height about five feet nine, black
+hair, generally rather handsome visage, complexion dark, eyes dark,
+thin, long and sallow face, aquiline nose but not straight, having a
+peculiar inclination towards the left cheek which imparts a sinister
+expression! Good day, one and all!”
+
+“Have the goodness to give me a little glass of old cognac, and a
+mouthful of cool fresh water, madame.”
+
+Madame complied with a polite air.
+
+“Marvellous cognac this, madame!”
+
+It was the first time it had ever been so complimented, and Madame
+Defarge knew enough of its antecedents to know better. She said,
+however, that the cognac was flattered, and took up her knitting. The
+visitor watched her fingers for a few moments, and took the opportunity
+of observing the place in general.
+
+“You knit with great skill, madame.”
+
+“I am accustomed to it.”
+
+“A pretty pattern too!”
+
+“_You_ think so?” said madame, looking at him with a smile.
+
+“Decidedly. May one ask what it is for?”
+
+“Pastime,” said madame, still looking at him with a smile while her
+fingers moved nimbly.
+
+“Not for use?”
+
+“That depends. I may find a use for it one day. If I do--Well,” said
+madame, drawing a breath and nodding her head with a stern kind of
+coquetry, “I’ll use it!”
+
+It was remarkable; but, the taste of Saint Antoine seemed to be
+decidedly opposed to a rose on the head-dress of Madame Defarge. Two
+men had entered separately, and had been about to order drink, when,
+catching sight of that novelty, they faltered, made a pretence of
+looking about as if for some friend who was not there, and went away.
+Nor, of those who had been there when this visitor entered, was there
+one left. They had all dropped off. The spy had kept his eyes open,
+but had been able to detect no sign. They had lounged away in a
+poverty-stricken, purposeless, accidental manner, quite natural and
+unimpeachable.
+
+“_John_,” thought madame, checking off her work as her fingers knitted,
+and her eyes looked at the stranger. “Stay long enough, and I shall knit
+‘BARSAD’ before you go.”
+
+“You have a husband, madame?”
+
+“I have.”
+
+“Children?”
+
+“No children.”
+
+“Business seems bad?”
+
+“Business is very bad; the people are so poor.”
+
+“Ah, the unfortunate, miserable people! So oppressed, too--as you say.”
+
+“As _you_ say,” madame retorted, correcting him, and deftly knitting an
+extra something into his name that boded him no good.
+
+“Pardon me; certainly it was I who said so, but you naturally think so.
+Of course.”
+
+“_I_ think?” returned madame, in a high voice. “I and my husband have
+enough to do to keep this wine-shop open, without thinking. All we
+think, here, is how to live. That is the subject _we_ think of, and
+it gives us, from morning to night, enough to think about, without
+embarrassing our heads concerning others. _I_ think for others? No, no.”
+
+The spy, who was there to pick up any crumbs he could find or make, did
+not allow his baffled state to express itself in his sinister face; but,
+stood with an air of gossiping gallantry, leaning his elbow on Madame
+Defarge’s little counter, and occasionally sipping his cognac.
+
+“A bad business this, madame, of Gaspard’s execution. Ah! the poor
+Gaspard!” With a sigh of great compassion.
+
+“My faith!” returned madame, coolly and lightly, “if people use knives
+for such purposes, they have to pay for it. He knew beforehand what the
+price of his luxury was; he has paid the price.”
+
+“I believe,” said the spy, dropping his soft voice to a tone
+that invited confidence, and expressing an injured revolutionary
+susceptibility in every muscle of his wicked face: “I believe there
+is much compassion and anger in this neighbourhood, touching the poor
+fellow? Between ourselves.”
+
+“Is there?” asked madame, vacantly.
+
+“Is there not?”
+
+“--Here is my husband!” said Madame Defarge.
+
+As the keeper of the wine-shop entered at the door, the spy saluted
+him by touching his hat, and saying, with an engaging smile, “Good day,
+Jacques!” Defarge stopped short, and stared at him.
+
+“Good day, Jacques!” the spy repeated; with not quite so much
+confidence, or quite so easy a smile under the stare.
+
+“You deceive yourself, monsieur,” returned the keeper of the wine-shop.
+“You mistake me for another. That is not my name. I am Ernest Defarge.”
+
+“It is all the same,” said the spy, airily, but discomfited too: “good
+day!”
+
+“Good day!” answered Defarge, drily.
+
+“I was saying to madame, with whom I had the pleasure of chatting when
+you entered, that they tell me there is--and no wonder!--much sympathy
+and anger in Saint Antoine, touching the unhappy fate of poor Gaspard.”
+
+“No one has told me so,” said Defarge, shaking his head. “I know nothing
+of it.”
+
+Having said it, he passed behind the little counter, and stood with his
+hand on the back of his wife’s chair, looking over that barrier at the
+person to whom they were both opposed, and whom either of them would
+have shot with the greatest satisfaction.
+
+The spy, well used to his business, did not change his unconscious
+attitude, but drained his little glass of cognac, took a sip of fresh
+water, and asked for another glass of cognac. Madame Defarge poured it
+out for him, took to her knitting again, and hummed a little song over
+it.
+
+“You seem to know this quarter well; that is to say, better than I do?”
+ observed Defarge.
+
+“Not at all, but I hope to know it better. I am so profoundly interested
+in its miserable inhabitants.”
+
+“Hah!” muttered Defarge.
+
+“The pleasure of conversing with you, Monsieur Defarge, recalls to me,”
+ pursued the spy, “that I have the honour of cherishing some interesting
+associations with your name.”
+
+“Indeed!” said Defarge, with much indifference.
+
+“Yes, indeed. When Doctor Manette was released, you, his old domestic,
+had the charge of him, I know. He was delivered to you. You see I am
+informed of the circumstances?”
+
+“Such is the fact, certainly,” said Defarge. He had had it conveyed
+to him, in an accidental touch of his wife’s elbow as she knitted and
+warbled, that he would do best to answer, but always with brevity.
+
+“It was to you,” said the spy, “that his daughter came; and it was
+from your care that his daughter took him, accompanied by a neat brown
+monsieur; how is he called?--in a little wig--Lorry--of the bank of
+Tellson and Company--over to England.”
+
+“Such is the fact,” repeated Defarge.
+
+“Very interesting remembrances!” said the spy. “I have known Doctor
+Manette and his daughter, in England.”
+
+“Yes?” said Defarge.
+
+“You don’t hear much about them now?” said the spy.
+
+“No,” said Defarge.
+
+“In effect,” madame struck in, looking up from her work and her little
+song, “we never hear about them. We received the news of their safe
+arrival, and perhaps another letter, or perhaps two; but, since then,
+they have gradually taken their road in life--we, ours--and we have held
+no correspondence.”
+
+“Perfectly so, madame,” replied the spy. “She is going to be married.”
+
+“Going?” echoed madame. “She was pretty enough to have been married long
+ago. You English are cold, it seems to me.”
+
+“Oh! You know I am English.”
+
+“I perceive your tongue is,” returned madame; “and what the tongue is, I
+suppose the man is.”
+
+He did not take the identification as a compliment; but he made the best
+of it, and turned it off with a laugh. After sipping his cognac to the
+end, he added:
+
+“Yes, Miss Manette is going to be married. But not to an Englishman; to
+one who, like herself, is French by birth. And speaking of Gaspard (ah,
+poor Gaspard! It was cruel, cruel!), it is a curious thing that she is
+going to marry the nephew of Monsieur the Marquis, for whom Gaspard
+was exalted to that height of so many feet; in other words, the present
+Marquis. But he lives unknown in England, he is no Marquis there; he is
+Mr. Charles Darnay. D’Aulnais is the name of his mother’s family.”
+
+Madame Defarge knitted steadily, but the intelligence had a palpable
+effect upon her husband. Do what he would, behind the little counter,
+as to the striking of a light and the lighting of his pipe, he was
+troubled, and his hand was not trustworthy. The spy would have been no
+spy if he had failed to see it, or to record it in his mind.
+
+Having made, at least, this one hit, whatever it might prove to be
+worth, and no customers coming in to help him to any other, Mr. Barsad
+paid for what he had drunk, and took his leave: taking occasion to say,
+in a genteel manner, before he departed, that he looked forward to the
+pleasure of seeing Monsieur and Madame Defarge again. For some minutes
+after he had emerged into the outer presence of Saint Antoine, the
+husband and wife remained exactly as he had left them, lest he should
+come back.
+
+“Can it be true,” said Defarge, in a low voice, looking down at his wife
+as he stood smoking with his hand on the back of her chair: “what he has
+said of Ma’amselle Manette?”
+
+“As he has said it,” returned madame, lifting her eyebrows a little, “it
+is probably false. But it may be true.”
+
+“If it is--” Defarge began, and stopped.
+
+“If it is?” repeated his wife.
+
+“--And if it does come, while we live to see it triumph--I hope, for her
+sake, Destiny will keep her husband out of France.”
+
+“Her husband’s destiny,” said Madame Defarge, with her usual composure,
+“will take him where he is to go, and will lead him to the end that is
+to end him. That is all I know.”
+
+“But it is very strange--now, at least, is it not very strange”--said
+Defarge, rather pleading with his wife to induce her to admit it,
+“that, after all our sympathy for Monsieur her father, and herself, her
+husband’s name should be proscribed under your hand at this moment, by
+the side of that infernal dog’s who has just left us?”
+
+“Stranger things than that will happen when it does come,” answered
+madame. “I have them both here, of a certainty; and they are both here
+for their merits; that is enough.”
+
+She rolled up her knitting when she had said those words, and presently
+took the rose out of the handkerchief that was wound about her head.
+Either Saint Antoine had an instinctive sense that the objectionable
+decoration was gone, or Saint Antoine was on the watch for its
+disappearance; howbeit, the Saint took courage to lounge in, very
+shortly afterwards, and the wine-shop recovered its habitual aspect.
+
+In the evening, at which season of all others Saint Antoine turned
+himself inside out, and sat on door-steps and window-ledges, and came
+to the corners of vile streets and courts, for a breath of air, Madame
+Defarge with her work in her hand was accustomed to pass from place
+to place and from group to group: a Missionary--there were many like
+her--such as the world will do well never to breed again. All the women
+knitted. They knitted worthless things; but, the mechanical work was a
+mechanical substitute for eating and drinking; the hands moved for the
+jaws and the digestive apparatus: if the bony fingers had been still,
+the stomachs would have been more famine-pinched.
+
+But, as the fingers went, the eyes went, and the thoughts. And as Madame
+Defarge moved on from group to group, all three went quicker and fiercer
+among every little knot of women that she had spoken with, and left
+behind.
+
+Her husband smoked at his door, looking after her with admiration. “A
+great woman,” said he, “a strong woman, a grand woman, a frightfully
+grand woman!”
+
+Darkness closed around, and then came the ringing of church bells and
+the distant beating of the military drums in the Palace Courtyard, as
+the women sat knitting, knitting. Darkness encompassed them. Another
+darkness was closing in as surely, when the church bells, then ringing
+pleasantly in many an airy steeple over France, should be melted into
+thundering cannon; when the military drums should be beating to drown a
+wretched voice, that night all potent as the voice of Power and Plenty,
+Freedom and Life. So much was closing in about the women who sat
+knitting, knitting, that they their very selves were closing in around
+a structure yet unbuilt, where they were to sit knitting, knitting,
+counting dropping heads.
+
+
+
+
+XVII. One Night
+
+
+Never did the sun go down with a brighter glory on the quiet corner in
+Soho, than one memorable evening when the Doctor and his daughter sat
+under the plane-tree together. Never did the moon rise with a milder
+radiance over great London, than on that night when it found them still
+seated under the tree, and shone upon their faces through its leaves.
+
+Lucie was to be married to-morrow. She had reserved this last evening
+for her father, and they sat alone under the plane-tree.
+
+“You are happy, my dear father?”
+
+“Quite, my child.”
+
+They had said little, though they had been there a long time. When it
+was yet light enough to work and read, she had neither engaged herself
+in her usual work, nor had she read to him. She had employed herself in
+both ways, at his side under the tree, many and many a time; but, this
+time was not quite like any other, and nothing could make it so.
+
+“And I am very happy to-night, dear father. I am deeply happy in the
+love that Heaven has so blessed--my love for Charles, and Charles’s love
+for me. But, if my life were not to be still consecrated to you, or
+if my marriage were so arranged as that it would part us, even by
+the length of a few of these streets, I should be more unhappy and
+self-reproachful now than I can tell you. Even as it is--”
+
+Even as it was, she could not command her voice.
+
+In the sad moonlight, she clasped him by the neck, and laid her face
+upon his breast. In the moonlight which is always sad, as the light of
+the sun itself is--as the light called human life is--at its coming and
+its going.
+
+“Dearest dear! Can you tell me, this last time, that you feel quite,
+quite sure, no new affections of mine, and no new duties of mine, will
+ever interpose between us? _I_ know it well, but do you know it? In your
+own heart, do you feel quite certain?”
+
+Her father answered, with a cheerful firmness of conviction he could
+scarcely have assumed, “Quite sure, my darling! More than that,” he
+added, as he tenderly kissed her: “my future is far brighter, Lucie,
+seen through your marriage, than it could have been--nay, than it ever
+was--without it.”
+
+“If I could hope _that_, my father!--”
+
+“Believe it, love! Indeed it is so. Consider how natural and how plain
+it is, my dear, that it should be so. You, devoted and young, cannot
+fully appreciate the anxiety I have felt that your life should not be
+wasted--”
+
+She moved her hand towards his lips, but he took it in his, and repeated
+the word.
+
+“--wasted, my child--should not be wasted, struck aside from the
+natural order of things--for my sake. Your unselfishness cannot entirely
+comprehend how much my mind has gone on this; but, only ask yourself,
+how could my happiness be perfect, while yours was incomplete?”
+
+“If I had never seen Charles, my father, I should have been quite happy
+with you.”
+
+He smiled at her unconscious admission that she would have been unhappy
+without Charles, having seen him; and replied:
+
+“My child, you did see him, and it is Charles. If it had not been
+Charles, it would have been another. Or, if it had been no other, I
+should have been the cause, and then the dark part of my life would have
+cast its shadow beyond myself, and would have fallen on you.”
+
+It was the first time, except at the trial, of her ever hearing him
+refer to the period of his suffering. It gave her a strange and new
+sensation while his words were in her ears; and she remembered it long
+afterwards.
+
+“See!” said the Doctor of Beauvais, raising his hand towards the moon.
+“I have looked at her from my prison-window, when I could not bear her
+light. I have looked at her when it has been such torture to me to think
+of her shining upon what I had lost, that I have beaten my head against
+my prison-walls. I have looked at her, in a state so dull and lethargic,
+that I have thought of nothing but the number of horizontal lines I
+could draw across her at the full, and the number of perpendicular lines
+with which I could intersect them.” He added in his inward and pondering
+manner, as he looked at the moon, “It was twenty either way, I remember,
+and the twentieth was difficult to squeeze in.”
+
+The strange thrill with which she heard him go back to that time,
+deepened as he dwelt upon it; but, there was nothing to shock her in
+the manner of his reference. He only seemed to contrast his present
+cheerfulness and felicity with the dire endurance that was over.
+
+“I have looked at her, speculating thousands of times upon the unborn
+child from whom I had been rent. Whether it was alive. Whether it had
+been born alive, or the poor mother’s shock had killed it. Whether it
+was a son who would some day avenge his father. (There was a time in my
+imprisonment, when my desire for vengeance was unbearable.) Whether it
+was a son who would never know his father’s story; who might even live
+to weigh the possibility of his father’s having disappeared of his own
+will and act. Whether it was a daughter who would grow to be a woman.”
+
+She drew closer to him, and kissed his cheek and his hand.
+
+“I have pictured my daughter, to myself, as perfectly forgetful of
+me--rather, altogether ignorant of me, and unconscious of me. I have
+cast up the years of her age, year after year. I have seen her married
+to a man who knew nothing of my fate. I have altogether perished from
+the remembrance of the living, and in the next generation my place was a
+blank.”
+
+“My father! Even to hear that you had such thoughts of a daughter who
+never existed, strikes to my heart as if I had been that child.”
+
+“You, Lucie? It is out of the Consolation and restoration you have
+brought to me, that these remembrances arise, and pass between us and
+the moon on this last night.--What did I say just now?”
+
+“She knew nothing of you. She cared nothing for you.”
+
+“So! But on other moonlight nights, when the sadness and the silence
+have touched me in a different way--have affected me with something as
+like a sorrowful sense of peace, as any emotion that had pain for its
+foundations could--I have imagined her as coming to me in my cell, and
+leading me out into the freedom beyond the fortress. I have seen her
+image in the moonlight often, as I now see you; except that I never held
+her in my arms; it stood between the little grated window and the door.
+But, you understand that that was not the child I am speaking of?”
+
+“The figure was not; the--the--image; the fancy?”
+
+“No. That was another thing. It stood before my disturbed sense of
+sight, but it never moved. The phantom that my mind pursued, was another
+and more real child. Of her outward appearance I know no more than
+that she was like her mother. The other had that likeness too--as you
+have--but was not the same. Can you follow me, Lucie? Hardly, I think?
+I doubt you must have been a solitary prisoner to understand these
+perplexed distinctions.”
+
+His collected and calm manner could not prevent her blood from running
+cold, as he thus tried to anatomise his old condition.
+
+“In that more peaceful state, I have imagined her, in the moonlight,
+coming to me and taking me out to show me that the home of her married
+life was full of her loving remembrance of her lost father. My picture
+was in her room, and I was in her prayers. Her life was active,
+cheerful, useful; but my poor history pervaded it all.”
+
+“I was that child, my father, I was not half so good, but in my love
+that was I.”
+
+“And she showed me her children,” said the Doctor of Beauvais, “and
+they had heard of me, and had been taught to pity me. When they passed
+a prison of the State, they kept far from its frowning walls, and looked
+up at its bars, and spoke in whispers. She could never deliver me; I
+imagined that she always brought me back after showing me such things.
+But then, blessed with the relief of tears, I fell upon my knees, and
+blessed her.”
+
+“I am that child, I hope, my father. O my dear, my dear, will you bless
+me as fervently to-morrow?”
+
+“Lucie, I recall these old troubles in the reason that I have to-night
+for loving you better than words can tell, and thanking God for my great
+happiness. My thoughts, when they were wildest, never rose near the
+happiness that I have known with you, and that we have before us.”
+
+He embraced her, solemnly commended her to Heaven, and humbly thanked
+Heaven for having bestowed her on him. By-and-bye, they went into the
+house.
+
+There was no one bidden to the marriage but Mr. Lorry; there was even to
+be no bridesmaid but the gaunt Miss Pross. The marriage was to make no
+change in their place of residence; they had been able to extend it,
+by taking to themselves the upper rooms formerly belonging to the
+apocryphal invisible lodger, and they desired nothing more.
+
+Doctor Manette was very cheerful at the little supper. They were only
+three at table, and Miss Pross made the third. He regretted that Charles
+was not there; was more than half disposed to object to the loving
+little plot that kept him away; and drank to him affectionately.
+
+So, the time came for him to bid Lucie good night, and they separated.
+But, in the stillness of the third hour of the morning, Lucie came
+downstairs again, and stole into his room; not free from unshaped fears,
+beforehand.
+
+All things, however, were in their places; all was quiet; and he lay
+asleep, his white hair picturesque on the untroubled pillow, and his
+hands lying quiet on the coverlet. She put her needless candle in the
+shadow at a distance, crept up to his bed, and put her lips to his;
+then, leaned over him, and looked at him.
+
+Into his handsome face, the bitter waters of captivity had worn; but, he
+covered up their tracks with a determination so strong, that he held the
+mastery of them even in his sleep. A more remarkable face in its quiet,
+resolute, and guarded struggle with an unseen assailant, was not to be
+beheld in all the wide dominions of sleep, that night.
+
+She timidly laid her hand on his dear breast, and put up a prayer that
+she might ever be as true to him as her love aspired to be, and as his
+sorrows deserved. Then, she withdrew her hand, and kissed his lips once
+more, and went away. So, the sunrise came, and the shadows of the leaves
+of the plane-tree moved upon his face, as softly as her lips had moved
+in praying for him.
+
+
+
+
+XVIII. Nine Days
+
+
+The marriage-day was shining brightly, and they were ready outside the
+closed door of the Doctor’s room, where he was speaking with Charles
+Darnay. They were ready to go to church; the beautiful bride, Mr.
+Lorry, and Miss Pross--to whom the event, through a gradual process of
+reconcilement to the inevitable, would have been one of absolute bliss,
+but for the yet lingering consideration that her brother Solomon should
+have been the bridegroom.
+
+“And so,” said Mr. Lorry, who could not sufficiently admire the bride,
+and who had been moving round her to take in every point of her quiet,
+pretty dress; “and so it was for this, my sweet Lucie, that I brought
+you across the Channel, such a baby! Lord bless me! How little I thought
+what I was doing! How lightly I valued the obligation I was conferring
+on my friend Mr. Charles!”
+
+“You didn’t mean it,” remarked the matter-of-fact Miss Pross, “and
+therefore how could you know it? Nonsense!”
+
+“Really? Well; but don’t cry,” said the gentle Mr. Lorry.
+
+“I am not crying,” said Miss Pross; “_you_ are.”
+
+“I, my Pross?” (By this time, Mr. Lorry dared to be pleasant with her,
+on occasion.)
+
+“You were, just now; I saw you do it, and I don’t wonder at it. Such
+a present of plate as you have made ‘em, is enough to bring tears into
+anybody’s eyes. There’s not a fork or a spoon in the collection,” said
+Miss Pross, “that I didn’t cry over, last night after the box came, till
+I couldn’t see it.”
+
+“I am highly gratified,” said Mr. Lorry, “though, upon my honour, I
+had no intention of rendering those trifling articles of remembrance
+invisible to any one. Dear me! This is an occasion that makes a man
+speculate on all he has lost. Dear, dear, dear! To think that there
+might have been a Mrs. Lorry, any time these fifty years almost!”
+
+“Not at all!” From Miss Pross.
+
+“You think there never might have been a Mrs. Lorry?” asked the
+gentleman of that name.
+
+“Pooh!” rejoined Miss Pross; “you were a bachelor in your cradle.”
+
+“Well!” observed Mr. Lorry, beamingly adjusting his little wig, “that
+seems probable, too.”
+
+“And you were cut out for a bachelor,” pursued Miss Pross, “before you
+were put in your cradle.”
+
+“Then, I think,” said Mr. Lorry, “that I was very unhandsomely dealt
+with, and that I ought to have had a voice in the selection of my
+pattern. Enough! Now, my dear Lucie,” drawing his arm soothingly round
+her waist, “I hear them moving in the next room, and Miss Pross and
+I, as two formal folks of business, are anxious not to lose the final
+opportunity of saying something to you that you wish to hear. You leave
+your good father, my dear, in hands as earnest and as loving as your
+own; he shall be taken every conceivable care of; during the next
+fortnight, while you are in Warwickshire and thereabouts, even Tellson’s
+shall go to the wall (comparatively speaking) before him. And when, at
+the fortnight’s end, he comes to join you and your beloved husband, on
+your other fortnight’s trip in Wales, you shall say that we have sent
+him to you in the best health and in the happiest frame. Now, I hear
+Somebody’s step coming to the door. Let me kiss my dear girl with an
+old-fashioned bachelor blessing, before Somebody comes to claim his
+own.”
+
+For a moment, he held the fair face from him to look at the
+well-remembered expression on the forehead, and then laid the bright
+golden hair against his little brown wig, with a genuine tenderness and
+delicacy which, if such things be old-fashioned, were as old as Adam.
+
+The door of the Doctor’s room opened, and he came out with Charles
+Darnay. He was so deadly pale--which had not been the case when they
+went in together--that no vestige of colour was to be seen in his face.
+But, in the composure of his manner he was unaltered, except that to the
+shrewd glance of Mr. Lorry it disclosed some shadowy indication that the
+old air of avoidance and dread had lately passed over him, like a cold
+wind.
+
+He gave his arm to his daughter, and took her down-stairs to the chariot
+which Mr. Lorry had hired in honour of the day. The rest followed in
+another carriage, and soon, in a neighbouring church, where no strange
+eyes looked on, Charles Darnay and Lucie Manette were happily married.
+
+Besides the glancing tears that shone among the smiles of the little
+group when it was done, some diamonds, very bright and sparkling,
+glanced on the bride’s hand, which were newly released from the
+dark obscurity of one of Mr. Lorry’s pockets. They returned home to
+breakfast, and all went well, and in due course the golden hair that had
+mingled with the poor shoemaker’s white locks in the Paris garret, were
+mingled with them again in the morning sunlight, on the threshold of the
+door at parting.
+
+It was a hard parting, though it was not for long. But her father
+cheered her, and said at last, gently disengaging himself from her
+enfolding arms, “Take her, Charles! She is yours!”
+
+And her agitated hand waved to them from a chaise window, and she was
+gone.
+
+The corner being out of the way of the idle and curious, and the
+preparations having been very simple and few, the Doctor, Mr. Lorry,
+and Miss Pross, were left quite alone. It was when they turned into
+the welcome shade of the cool old hall, that Mr. Lorry observed a great
+change to have come over the Doctor; as if the golden arm uplifted
+there, had struck him a poisoned blow.
+
+He had naturally repressed much, and some revulsion might have been
+expected in him when the occasion for repression was gone. But, it was
+the old scared lost look that troubled Mr. Lorry; and through his absent
+manner of clasping his head and drearily wandering away into his own
+room when they got up-stairs, Mr. Lorry was reminded of Defarge the
+wine-shop keeper, and the starlight ride.
+
+“I think,” he whispered to Miss Pross, after anxious consideration, “I
+think we had best not speak to him just now, or at all disturb him.
+I must look in at Tellson’s; so I will go there at once and come back
+presently. Then, we will take him a ride into the country, and dine
+there, and all will be well.”
+
+It was easier for Mr. Lorry to look in at Tellson’s, than to look out of
+Tellson’s. He was detained two hours. When he came back, he ascended the
+old staircase alone, having asked no question of the servant; going thus
+into the Doctor’s rooms, he was stopped by a low sound of knocking.
+
+“Good God!” he said, with a start. “What’s that?”
+
+Miss Pross, with a terrified face, was at his ear. “O me, O me! All is
+lost!” cried she, wringing her hands. “What is to be told to Ladybird?
+He doesn’t know me, and is making shoes!”
+
+Mr. Lorry said what he could to calm her, and went himself into the
+Doctor’s room. The bench was turned towards the light, as it had been
+when he had seen the shoemaker at his work before, and his head was bent
+down, and he was very busy.
+
+“Doctor Manette. My dear friend, Doctor Manette!”
+
+The Doctor looked at him for a moment--half inquiringly, half as if he
+were angry at being spoken to--and bent over his work again.
+
+He had laid aside his coat and waistcoat; his shirt was open at the
+throat, as it used to be when he did that work; and even the old
+haggard, faded surface of face had come back to him. He worked
+hard--impatiently--as if in some sense of having been interrupted.
+
+Mr. Lorry glanced at the work in his hand, and observed that it was a
+shoe of the old size and shape. He took up another that was lying by
+him, and asked what it was.
+
+“A young lady’s walking shoe,” he muttered, without looking up. “It
+ought to have been finished long ago. Let it be.”
+
+“But, Doctor Manette. Look at me!”
+
+He obeyed, in the old mechanically submissive manner, without pausing in
+his work.
+
+“You know me, my dear friend? Think again. This is not your proper
+occupation. Think, dear friend!”
+
+Nothing would induce him to speak more. He looked up, for an instant at
+a time, when he was requested to do so; but, no persuasion would extract
+a word from him. He worked, and worked, and worked, in silence, and
+words fell on him as they would have fallen on an echoless wall, or on
+the air. The only ray of hope that Mr. Lorry could discover, was, that
+he sometimes furtively looked up without being asked. In that, there
+seemed a faint expression of curiosity or perplexity--as though he were
+trying to reconcile some doubts in his mind.
+
+Two things at once impressed themselves on Mr. Lorry, as important above
+all others; the first, that this must be kept secret from Lucie;
+the second, that it must be kept secret from all who knew him. In
+conjunction with Miss Pross, he took immediate steps towards the latter
+precaution, by giving out that the Doctor was not well, and required a
+few days of complete rest. In aid of the kind deception to be practised
+on his daughter, Miss Pross was to write, describing his having been
+called away professionally, and referring to an imaginary letter of
+two or three hurried lines in his own hand, represented to have been
+addressed to her by the same post.
+
+These measures, advisable to be taken in any case, Mr. Lorry took in
+the hope of his coming to himself. If that should happen soon, he kept
+another course in reserve; which was, to have a certain opinion that he
+thought the best, on the Doctor’s case.
+
+In the hope of his recovery, and of resort to this third course
+being thereby rendered practicable, Mr. Lorry resolved to watch him
+attentively, with as little appearance as possible of doing so. He
+therefore made arrangements to absent himself from Tellson’s for the
+first time in his life, and took his post by the window in the same
+room.
+
+He was not long in discovering that it was worse than useless to speak
+to him, since, on being pressed, he became worried. He abandoned that
+attempt on the first day, and resolved merely to keep himself always
+before him, as a silent protest against the delusion into which he had
+fallen, or was falling. He remained, therefore, in his seat near the
+window, reading and writing, and expressing in as many pleasant and
+natural ways as he could think of, that it was a free place.
+
+Doctor Manette took what was given him to eat and drink, and worked on,
+that first day, until it was too dark to see--worked on, half an hour
+after Mr. Lorry could not have seen, for his life, to read or write.
+When he put his tools aside as useless, until morning, Mr. Lorry rose
+and said to him:
+
+“Will you go out?”
+
+He looked down at the floor on either side of him in the old manner,
+looked up in the old manner, and repeated in the old low voice:
+
+“Out?”
+
+“Yes; for a walk with me. Why not?”
+
+He made no effort to say why not, and said not a word more. But, Mr.
+Lorry thought he saw, as he leaned forward on his bench in the dusk,
+with his elbows on his knees and his head in his hands, that he was in
+some misty way asking himself, “Why not?” The sagacity of the man of
+business perceived an advantage here, and determined to hold it.
+
+Miss Pross and he divided the night into two watches, and observed him
+at intervals from the adjoining room. He paced up and down for a long
+time before he lay down; but, when he did finally lay himself down, he
+fell asleep. In the morning, he was up betimes, and went straight to his
+bench and to work.
+
+On this second day, Mr. Lorry saluted him cheerfully by his name,
+and spoke to him on topics that had been of late familiar to them. He
+returned no reply, but it was evident that he heard what was said, and
+that he thought about it, however confusedly. This encouraged Mr. Lorry
+to have Miss Pross in with her work, several times during the day;
+at those times, they quietly spoke of Lucie, and of her father then
+present, precisely in the usual manner, and as if there were nothing
+amiss. This was done without any demonstrative accompaniment, not long
+enough, or often enough to harass him; and it lightened Mr. Lorry’s
+friendly heart to believe that he looked up oftener, and that he
+appeared to be stirred by some perception of inconsistencies surrounding
+him.
+
+When it fell dark again, Mr. Lorry asked him as before:
+
+“Dear Doctor, will you go out?”
+
+As before, he repeated, “Out?”
+
+“Yes; for a walk with me. Why not?”
+
+This time, Mr. Lorry feigned to go out when he could extract no answer
+from him, and, after remaining absent for an hour, returned. In the
+meanwhile, the Doctor had removed to the seat in the window, and had
+sat there looking down at the plane-tree; but, on Mr. Lorry’s return, he
+slipped away to his bench.
+
+The time went very slowly on, and Mr. Lorry’s hope darkened, and his
+heart grew heavier again, and grew yet heavier and heavier every day.
+The third day came and went, the fourth, the fifth. Five days, six days,
+seven days, eight days, nine days.
+
+With a hope ever darkening, and with a heart always growing heavier and
+heavier, Mr. Lorry passed through this anxious time. The secret was
+well kept, and Lucie was unconscious and happy; but he could not fail to
+observe that the shoemaker, whose hand had been a little out at first,
+was growing dreadfully skilful, and that he had never been so intent on
+his work, and that his hands had never been so nimble and expert, as in
+the dusk of the ninth evening.
+
+
+
+
+XIX. An Opinion
+
+
+Worn out by anxious watching, Mr. Lorry fell asleep at his post. On the
+tenth morning of his suspense, he was startled by the shining of the sun
+into the room where a heavy slumber had overtaken him when it was dark
+night.
+
+He rubbed his eyes and roused himself; but he doubted, when he had
+done so, whether he was not still asleep. For, going to the door of the
+Doctor’s room and looking in, he perceived that the shoemaker’s bench
+and tools were put aside again, and that the Doctor himself sat reading
+at the window. He was in his usual morning dress, and his face (which
+Mr. Lorry could distinctly see), though still very pale, was calmly
+studious and attentive.
+
+Even when he had satisfied himself that he was awake, Mr. Lorry felt
+giddily uncertain for some few moments whether the late shoemaking might
+not be a disturbed dream of his own; for, did not his eyes show him his
+friend before him in his accustomed clothing and aspect, and employed
+as usual; and was there any sign within their range, that the change of
+which he had so strong an impression had actually happened?
+
+It was but the inquiry of his first confusion and astonishment, the
+answer being obvious. If the impression were not produced by a real
+corresponding and sufficient cause, how came he, Jarvis Lorry, there?
+How came he to have fallen asleep, in his clothes, on the sofa in Doctor
+Manette’s consulting-room, and to be debating these points outside the
+Doctor’s bedroom door in the early morning?
+
+Within a few minutes, Miss Pross stood whispering at his side. If he
+had had any particle of doubt left, her talk would of necessity have
+resolved it; but he was by that time clear-headed, and had none.
+He advised that they should let the time go by until the regular
+breakfast-hour, and should then meet the Doctor as if nothing unusual
+had occurred. If he appeared to be in his customary state of mind, Mr.
+Lorry would then cautiously proceed to seek direction and guidance from
+the opinion he had been, in his anxiety, so anxious to obtain.
+
+Miss Pross, submitting herself to his judgment, the scheme was worked
+out with care. Having abundance of time for his usual methodical
+toilette, Mr. Lorry presented himself at the breakfast-hour in his usual
+white linen, and with his usual neat leg. The Doctor was summoned in the
+usual way, and came to breakfast.
+
+So far as it was possible to comprehend him without overstepping those
+delicate and gradual approaches which Mr. Lorry felt to be the only safe
+advance, he at first supposed that his daughter’s marriage had taken
+place yesterday. An incidental allusion, purposely thrown out, to
+the day of the week, and the day of the month, set him thinking and
+counting, and evidently made him uneasy. In all other respects, however,
+he was so composedly himself, that Mr. Lorry determined to have the aid
+he sought. And that aid was his own.
+
+Therefore, when the breakfast was done and cleared away, and he and the
+Doctor were left together, Mr. Lorry said, feelingly:
+
+“My dear Manette, I am anxious to have your opinion, in confidence, on a
+very curious case in which I am deeply interested; that is to say, it is
+very curious to me; perhaps, to your better information it may be less
+so.”
+
+Glancing at his hands, which were discoloured by his late work, the
+Doctor looked troubled, and listened attentively. He had already glanced
+at his hands more than once.
+
+“Doctor Manette,” said Mr. Lorry, touching him affectionately on the
+arm, “the case is the case of a particularly dear friend of mine. Pray
+give your mind to it, and advise me well for his sake--and above all,
+for his daughter’s--his daughter’s, my dear Manette.”
+
+“If I understand,” said the Doctor, in a subdued tone, “some mental
+shock--?”
+
+“Yes!”
+
+“Be explicit,” said the Doctor. “Spare no detail.”
+
+Mr. Lorry saw that they understood one another, and proceeded.
+
+“My dear Manette, it is the case of an old and a prolonged shock,
+of great acuteness and severity to the affections, the feelings,
+the--the--as you express it--the mind. The mind. It is the case of a
+shock under which the sufferer was borne down, one cannot say for how
+long, because I believe he cannot calculate the time himself, and there
+are no other means of getting at it. It is the case of a shock from
+which the sufferer recovered, by a process that he cannot trace
+himself--as I once heard him publicly relate in a striking manner. It is
+the case of a shock from which he has recovered, so completely, as to
+be a highly intelligent man, capable of close application of mind, and
+great exertion of body, and of constantly making fresh additions to his
+stock of knowledge, which was already very large. But, unfortunately,
+there has been,” he paused and took a deep breath--“a slight relapse.”
+
+The Doctor, in a low voice, asked, “Of how long duration?”
+
+“Nine days and nights.”
+
+“How did it show itself? I infer,” glancing at his hands again, “in the
+resumption of some old pursuit connected with the shock?”
+
+“That is the fact.”
+
+“Now, did you ever see him,” asked the Doctor, distinctly and
+collectedly, though in the same low voice, “engaged in that pursuit
+originally?”
+
+“Once.”
+
+“And when the relapse fell on him, was he in most respects--or in all
+respects--as he was then?”
+
+“I think in all respects.”
+
+“You spoke of his daughter. Does his daughter know of the relapse?”
+
+“No. It has been kept from her, and I hope will always be kept from her.
+It is known only to myself, and to one other who may be trusted.”
+
+The Doctor grasped his hand, and murmured, “That was very kind. That was
+very thoughtful!” Mr. Lorry grasped his hand in return, and neither of
+the two spoke for a little while.
+
+“Now, my dear Manette,” said Mr. Lorry, at length, in his most
+considerate and most affectionate way, “I am a mere man of business,
+and unfit to cope with such intricate and difficult matters. I do not
+possess the kind of information necessary; I do not possess the kind of
+intelligence; I want guiding. There is no man in this world on whom
+I could so rely for right guidance, as on you. Tell me, how does this
+relapse come about? Is there danger of another? Could a repetition of it
+be prevented? How should a repetition of it be treated? How does it come
+about at all? What can I do for my friend? No man ever can have been
+more desirous in his heart to serve a friend, than I am to serve mine,
+if I knew how.
+
+“But I don’t know how to originate, in such a case. If your sagacity,
+knowledge, and experience, could put me on the right track, I might be
+able to do so much; unenlightened and undirected, I can do so little.
+Pray discuss it with me; pray enable me to see it a little more clearly,
+and teach me how to be a little more useful.”
+
+Doctor Manette sat meditating after these earnest words were spoken, and
+Mr. Lorry did not press him.
+
+“I think it probable,” said the Doctor, breaking silence with an effort,
+“that the relapse you have described, my dear friend, was not quite
+unforeseen by its subject.”
+
+“Was it dreaded by him?” Mr. Lorry ventured to ask.
+
+“Very much.” He said it with an involuntary shudder.
+
+“You have no idea how such an apprehension weighs on the sufferer’s
+mind, and how difficult--how almost impossible--it is, for him to force
+himself to utter a word upon the topic that oppresses him.”
+
+“Would he,” asked Mr. Lorry, “be sensibly relieved if he could prevail
+upon himself to impart that secret brooding to any one, when it is on
+him?”
+
+“I think so. But it is, as I have told you, next to impossible. I even
+believe it--in some cases--to be quite impossible.”
+
+“Now,” said Mr. Lorry, gently laying his hand on the Doctor’s arm again,
+after a short silence on both sides, “to what would you refer this
+attack?”
+
+“I believe,” returned Doctor Manette, “that there had been a strong and
+extraordinary revival of the train of thought and remembrance that
+was the first cause of the malady. Some intense associations of a most
+distressing nature were vividly recalled, I think. It is probable that
+there had long been a dread lurking in his mind, that those associations
+would be recalled--say, under certain circumstances--say, on a
+particular occasion. He tried to prepare himself in vain; perhaps the
+effort to prepare himself made him less able to bear it.”
+
+“Would he remember what took place in the relapse?” asked Mr. Lorry,
+with natural hesitation.
+
+The Doctor looked desolately round the room, shook his head, and
+answered, in a low voice, “Not at all.”
+
+“Now, as to the future,” hinted Mr. Lorry.
+
+“As to the future,” said the Doctor, recovering firmness, “I should have
+great hope. As it pleased Heaven in its mercy to restore him so soon, I
+should have great hope. He, yielding under the pressure of a complicated
+something, long dreaded and long vaguely foreseen and contended against,
+and recovering after the cloud had burst and passed, I should hope that
+the worst was over.”
+
+“Well, well! That’s good comfort. I am thankful!” said Mr. Lorry.
+
+“I am thankful!” repeated the Doctor, bending his head with reverence.
+
+“There are two other points,” said Mr. Lorry, “on which I am anxious to
+be instructed. I may go on?”
+
+“You cannot do your friend a better service.” The Doctor gave him his
+hand.
+
+“To the first, then. He is of a studious habit, and unusually energetic;
+he applies himself with great ardour to the acquisition of professional
+knowledge, to the conducting of experiments, to many things. Now, does
+he do too much?”
+
+“I think not. It may be the character of his mind, to be always in
+singular need of occupation. That may be, in part, natural to it; in
+part, the result of affliction. The less it was occupied with healthy
+things, the more it would be in danger of turning in the unhealthy
+direction. He may have observed himself, and made the discovery.”
+
+“You are sure that he is not under too great a strain?”
+
+“I think I am quite sure of it.”
+
+“My dear Manette, if he were overworked now--”
+
+“My dear Lorry, I doubt if that could easily be. There has been a
+violent stress in one direction, and it needs a counterweight.”
+
+“Excuse me, as a persistent man of business. Assuming for a moment,
+that he _was_ overworked; it would show itself in some renewal of this
+disorder?”
+
+“I do not think so. I do not think,” said Doctor Manette with the
+firmness of self-conviction, “that anything but the one train of
+association would renew it. I think that, henceforth, nothing but some
+extraordinary jarring of that chord could renew it. After what has
+happened, and after his recovery, I find it difficult to imagine any
+such violent sounding of that string again. I trust, and I almost
+believe, that the circumstances likely to renew it are exhausted.”
+
+He spoke with the diffidence of a man who knew how slight a thing
+would overset the delicate organisation of the mind, and yet with the
+confidence of a man who had slowly won his assurance out of personal
+endurance and distress. It was not for his friend to abate that
+confidence. He professed himself more relieved and encouraged than he
+really was, and approached his second and last point. He felt it to
+be the most difficult of all; but, remembering his old Sunday morning
+conversation with Miss Pross, and remembering what he had seen in the
+last nine days, he knew that he must face it.
+
+“The occupation resumed under the influence of this passing affliction
+so happily recovered from,” said Mr. Lorry, clearing his throat, “we
+will call--Blacksmith’s work, Blacksmith’s work. We will say, to put a
+case and for the sake of illustration, that he had been used, in his bad
+time, to work at a little forge. We will say that he was unexpectedly
+found at his forge again. Is it not a pity that he should keep it by
+him?”
+
+The Doctor shaded his forehead with his hand, and beat his foot
+nervously on the ground.
+
+“He has always kept it by him,” said Mr. Lorry, with an anxious look at
+his friend. “Now, would it not be better that he should let it go?”
+
+Still, the Doctor, with shaded forehead, beat his foot nervously on the
+ground.
+
+“You do not find it easy to advise me?” said Mr. Lorry. “I quite
+understand it to be a nice question. And yet I think--” And there he
+shook his head, and stopped.
+
+“You see,” said Doctor Manette, turning to him after an uneasy pause,
+“it is very hard to explain, consistently, the innermost workings
+of this poor man’s mind. He once yearned so frightfully for that
+occupation, and it was so welcome when it came; no doubt it relieved
+his pain so much, by substituting the perplexity of the fingers for
+the perplexity of the brain, and by substituting, as he became more
+practised, the ingenuity of the hands, for the ingenuity of the mental
+torture; that he has never been able to bear the thought of putting it
+quite out of his reach. Even now, when I believe he is more hopeful of
+himself than he has ever been, and even speaks of himself with a kind
+of confidence, the idea that he might need that old employment, and not
+find it, gives him a sudden sense of terror, like that which one may
+fancy strikes to the heart of a lost child.”
+
+He looked like his illustration, as he raised his eyes to Mr. Lorry’s
+face.
+
+“But may not--mind! I ask for information, as a plodding man of business
+who only deals with such material objects as guineas, shillings, and
+bank-notes--may not the retention of the thing involve the retention of
+the idea? If the thing were gone, my dear Manette, might not the fear go
+with it? In short, is it not a concession to the misgiving, to keep the
+forge?”
+
+There was another silence.
+
+“You see, too,” said the Doctor, tremulously, “it is such an old
+companion.”
+
+“I would not keep it,” said Mr. Lorry, shaking his head; for he gained
+in firmness as he saw the Doctor disquieted. “I would recommend him to
+sacrifice it. I only want your authority. I am sure it does no good.
+Come! Give me your authority, like a dear good man. For his daughter’s
+sake, my dear Manette!”
+
+Very strange to see what a struggle there was within him!
+
+“In her name, then, let it be done; I sanction it. But, I would not take
+it away while he was present. Let it be removed when he is not there;
+let him miss his old companion after an absence.”
+
+Mr. Lorry readily engaged for that, and the conference was ended. They
+passed the day in the country, and the Doctor was quite restored. On the
+three following days he remained perfectly well, and on the fourteenth
+day he went away to join Lucie and her husband. The precaution that
+had been taken to account for his silence, Mr. Lorry had previously
+explained to him, and he had written to Lucie in accordance with it, and
+she had no suspicions.
+
+On the night of the day on which he left the house, Mr. Lorry went into
+his room with a chopper, saw, chisel, and hammer, attended by Miss Pross
+carrying a light. There, with closed doors, and in a mysterious and
+guilty manner, Mr. Lorry hacked the shoemaker’s bench to pieces, while
+Miss Pross held the candle as if she were assisting at a murder--for
+which, indeed, in her grimness, she was no unsuitable figure. The
+burning of the body (previously reduced to pieces convenient for the
+purpose) was commenced without delay in the kitchen fire; and the tools,
+shoes, and leather, were buried in the garden. So wicked do destruction
+and secrecy appear to honest minds, that Mr. Lorry and Miss Pross,
+while engaged in the commission of their deed and in the removal of its
+traces, almost felt, and almost looked, like accomplices in a horrible
+crime.
+
+
+
+
+XX. A Plea
+
+
+When the newly-married pair came home, the first person who appeared, to
+offer his congratulations, was Sydney Carton. They had not been at home
+many hours, when he presented himself. He was not improved in habits, or
+in looks, or in manner; but there was a certain rugged air of fidelity
+about him, which was new to the observation of Charles Darnay.
+
+He watched his opportunity of taking Darnay aside into a window, and of
+speaking to him when no one overheard.
+
+“Mr. Darnay,” said Carton, “I wish we might be friends.”
+
+“We are already friends, I hope.”
+
+“You are good enough to say so, as a fashion of speech; but, I don’t
+mean any fashion of speech. Indeed, when I say I wish we might be
+friends, I scarcely mean quite that, either.”
+
+Charles Darnay--as was natural--asked him, in all good-humour and
+good-fellowship, what he did mean?
+
+“Upon my life,” said Carton, smiling, “I find that easier to comprehend
+in my own mind, than to convey to yours. However, let me try. You
+remember a certain famous occasion when I was more drunk than--than
+usual?”
+
+“I remember a certain famous occasion when you forced me to confess that
+you had been drinking.”
+
+“I remember it too. The curse of those occasions is heavy upon me, for I
+always remember them. I hope it may be taken into account one day,
+when all days are at an end for me! Don’t be alarmed; I am not going to
+preach.”
+
+“I am not at all alarmed. Earnestness in you, is anything but alarming
+to me.”
+
+“Ah!” said Carton, with a careless wave of his hand, as if he waved that
+away. “On the drunken occasion in question (one of a large number, as
+you know), I was insufferable about liking you, and not liking you. I
+wish you would forget it.”
+
+“I forgot it long ago.”
+
+“Fashion of speech again! But, Mr. Darnay, oblivion is not so easy to
+me, as you represent it to be to you. I have by no means forgotten it,
+and a light answer does not help me to forget it.”
+
+“If it was a light answer,” returned Darnay, “I beg your forgiveness
+for it. I had no other object than to turn a slight thing, which, to my
+surprise, seems to trouble you too much, aside. I declare to you, on the
+faith of a gentleman, that I have long dismissed it from my mind. Good
+Heaven, what was there to dismiss! Have I had nothing more important to
+remember, in the great service you rendered me that day?”
+
+“As to the great service,” said Carton, “I am bound to avow to you, when
+you speak of it in that way, that it was mere professional claptrap, I
+don’t know that I cared what became of you, when I rendered it.--Mind! I
+say when I rendered it; I am speaking of the past.”
+
+“You make light of the obligation,” returned Darnay, “but I will not
+quarrel with _your_ light answer.”
+
+“Genuine truth, Mr. Darnay, trust me! I have gone aside from my purpose;
+I was speaking about our being friends. Now, you know me; you know I am
+incapable of all the higher and better flights of men. If you doubt it,
+ask Stryver, and he’ll tell you so.”
+
+“I prefer to form my own opinion, without the aid of his.”
+
+“Well! At any rate you know me as a dissolute dog, who has never done
+any good, and never will.”
+
+“I don’t know that you ‘never will.’”
+
+“But I do, and you must take my word for it. Well! If you could endure
+to have such a worthless fellow, and a fellow of such indifferent
+reputation, coming and going at odd times, I should ask that I might be
+permitted to come and go as a privileged person here; that I might
+be regarded as an useless (and I would add, if it were not for the
+resemblance I detected between you and me, an unornamental) piece of
+furniture, tolerated for its old service, and taken no notice of. I
+doubt if I should abuse the permission. It is a hundred to one if I
+should avail myself of it four times in a year. It would satisfy me, I
+dare say, to know that I had it.”
+
+“Will you try?”
+
+“That is another way of saying that I am placed on the footing I have
+indicated. I thank you, Darnay. I may use that freedom with your name?”
+
+“I think so, Carton, by this time.”
+
+They shook hands upon it, and Sydney turned away. Within a minute
+afterwards, he was, to all outward appearance, as unsubstantial as ever.
+
+When he was gone, and in the course of an evening passed with Miss
+Pross, the Doctor, and Mr. Lorry, Charles Darnay made some mention of
+this conversation in general terms, and spoke of Sydney Carton as a
+problem of carelessness and recklessness. He spoke of him, in short, not
+bitterly or meaning to bear hard upon him, but as anybody might who saw
+him as he showed himself.
+
+He had no idea that this could dwell in the thoughts of his fair young
+wife; but, when he afterwards joined her in their own rooms, he found
+her waiting for him with the old pretty lifting of the forehead strongly
+marked.
+
+“We are thoughtful to-night!” said Darnay, drawing his arm about her.
+
+“Yes, dearest Charles,” with her hands on his breast, and the inquiring
+and attentive expression fixed upon him; “we are rather thoughtful
+to-night, for we have something on our mind to-night.”
+
+“What is it, my Lucie?”
+
+“Will you promise not to press one question on me, if I beg you not to
+ask it?”
+
+“Will I promise? What will I not promise to my Love?”
+
+What, indeed, with his hand putting aside the golden hair from the
+cheek, and his other hand against the heart that beat for him!
+
+“I think, Charles, poor Mr. Carton deserves more consideration and
+respect than you expressed for him to-night.”
+
+“Indeed, my own? Why so?”
+
+“That is what you are not to ask me. But I think--I know--he does.”
+
+“If you know it, it is enough. What would you have me do, my Life?”
+
+“I would ask you, dearest, to be very generous with him always, and very
+lenient on his faults when he is not by. I would ask you to believe that
+he has a heart he very, very seldom reveals, and that there are deep
+wounds in it. My dear, I have seen it bleeding.”
+
+“It is a painful reflection to me,” said Charles Darnay, quite
+astounded, “that I should have done him any wrong. I never thought this
+of him.”
+
+“My husband, it is so. I fear he is not to be reclaimed; there is
+scarcely a hope that anything in his character or fortunes is reparable
+now. But, I am sure that he is capable of good things, gentle things,
+even magnanimous things.”
+
+She looked so beautiful in the purity of her faith in this lost man,
+that her husband could have looked at her as she was for hours.
+
+“And, O my dearest Love!” she urged, clinging nearer to him, laying her
+head upon his breast, and raising her eyes to his, “remember how strong
+we are in our happiness, and how weak he is in his misery!”
+
+The supplication touched him home. “I will always remember it, dear
+Heart! I will remember it as long as I live.”
+
+He bent over the golden head, and put the rosy lips to his, and folded
+her in his arms. If one forlorn wanderer then pacing the dark streets,
+could have heard her innocent disclosure, and could have seen the drops
+of pity kissed away by her husband from the soft blue eyes so loving of
+that husband, he might have cried to the night--and the words would not
+have parted from his lips for the first time--
+
+“God bless her for her sweet compassion!”
+
+
+
+
+XXI. Echoing Footsteps
+
+
+A wonderful corner for echoes, it has been remarked, that corner where
+the Doctor lived. Ever busily winding the golden thread which bound
+her husband, and her father, and herself, and her old directress and
+companion, in a life of quiet bliss, Lucie sat in the still house in
+the tranquilly resounding corner, listening to the echoing footsteps of
+years.
+
+At first, there were times, though she was a perfectly happy young wife,
+when her work would slowly fall from her hands, and her eyes would be
+dimmed. For, there was something coming in the echoes, something light,
+afar off, and scarcely audible yet, that stirred her heart too much.
+Fluttering hopes and doubts--hopes, of a love as yet unknown to her:
+doubts, of her remaining upon earth, to enjoy that new delight--divided
+her breast. Among the echoes then, there would arise the sound of
+footsteps at her own early grave; and thoughts of the husband who would
+be left so desolate, and who would mourn for her so much, swelled to her
+eyes, and broke like waves.
+
+That time passed, and her little Lucie lay on her bosom. Then, among the
+advancing echoes, there was the tread of her tiny feet and the sound of
+her prattling words. Let greater echoes resound as they would, the young
+mother at the cradle side could always hear those coming. They came, and
+the shady house was sunny with a child’s laugh, and the Divine friend of
+children, to whom in her trouble she had confided hers, seemed to take
+her child in his arms, as He took the child of old, and made it a sacred
+joy to her.
+
+Ever busily winding the golden thread that bound them all together,
+weaving the service of her happy influence through the tissue of all
+their lives, and making it predominate nowhere, Lucie heard in the
+echoes of years none but friendly and soothing sounds. Her husband’s
+step was strong and prosperous among them; her father’s firm and equal.
+Lo, Miss Pross, in harness of string, awakening the echoes, as an
+unruly charger, whip-corrected, snorting and pawing the earth under the
+plane-tree in the garden!
+
+Even when there were sounds of sorrow among the rest, they were not
+harsh nor cruel. Even when golden hair, like her own, lay in a halo on a
+pillow round the worn face of a little boy, and he said, with a radiant
+smile, “Dear papa and mamma, I am very sorry to leave you both, and to
+leave my pretty sister; but I am called, and I must go!” those were not
+tears all of agony that wetted his young mother’s cheek, as the spirit
+departed from her embrace that had been entrusted to it. Suffer them and
+forbid them not. They see my Father’s face. O Father, blessed words!
+
+Thus, the rustling of an Angel’s wings got blended with the other
+echoes, and they were not wholly of earth, but had in them that breath
+of Heaven. Sighs of the winds that blew over a little garden-tomb were
+mingled with them also, and both were audible to Lucie, in a hushed
+murmur--like the breathing of a summer sea asleep upon a sandy shore--as
+the little Lucie, comically studious at the task of the morning, or
+dressing a doll at her mother’s footstool, chattered in the tongues of
+the Two Cities that were blended in her life.
+
+The Echoes rarely answered to the actual tread of Sydney Carton. Some
+half-dozen times a year, at most, he claimed his privilege of coming in
+uninvited, and would sit among them through the evening, as he had once
+done often. He never came there heated with wine. And one other thing
+regarding him was whispered in the echoes, which has been whispered by
+all true echoes for ages and ages.
+
+No man ever really loved a woman, lost her, and knew her with a
+blameless though an unchanged mind, when she was a wife and a mother,
+but her children had a strange sympathy with him--an instinctive
+delicacy of pity for him. What fine hidden sensibilities are touched in
+such a case, no echoes tell; but it is so, and it was so here. Carton
+was the first stranger to whom little Lucie held out her chubby arms,
+and he kept his place with her as she grew. The little boy had spoken of
+him, almost at the last. “Poor Carton! Kiss him for me!”
+
+Mr. Stryver shouldered his way through the law, like some great engine
+forcing itself through turbid water, and dragged his useful friend in
+his wake, like a boat towed astern. As the boat so favoured is usually
+in a rough plight, and mostly under water, so, Sydney had a swamped
+life of it. But, easy and strong custom, unhappily so much easier and
+stronger in him than any stimulating sense of desert or disgrace, made
+it the life he was to lead; and he no more thought of emerging from his
+state of lion’s jackal, than any real jackal may be supposed to think of
+rising to be a lion. Stryver was rich; had married a florid widow with
+property and three boys, who had nothing particularly shining about them
+but the straight hair of their dumpling heads.
+
+These three young gentlemen, Mr. Stryver, exuding patronage of the most
+offensive quality from every pore, had walked before him like three
+sheep to the quiet corner in Soho, and had offered as pupils to
+Lucie’s husband: delicately saying “Halloa! here are three lumps of
+bread-and-cheese towards your matrimonial picnic, Darnay!” The polite
+rejection of the three lumps of bread-and-cheese had quite bloated Mr.
+Stryver with indignation, which he afterwards turned to account in the
+training of the young gentlemen, by directing them to beware of the
+pride of Beggars, like that tutor-fellow. He was also in the habit of
+declaiming to Mrs. Stryver, over his full-bodied wine, on the arts
+Mrs. Darnay had once put in practice to “catch” him, and on the
+diamond-cut-diamond arts in himself, madam, which had rendered him “not
+to be caught.” Some of his King’s Bench familiars, who were occasionally
+parties to the full-bodied wine and the lie, excused him for the
+latter by saying that he had told it so often, that he believed
+it himself--which is surely such an incorrigible aggravation of an
+originally bad offence, as to justify any such offender’s being carried
+off to some suitably retired spot, and there hanged out of the way.
+
+These were among the echoes to which Lucie, sometimes pensive, sometimes
+amused and laughing, listened in the echoing corner, until her little
+daughter was six years old. How near to her heart the echoes of her
+child’s tread came, and those of her own dear father’s, always active
+and self-possessed, and those of her dear husband’s, need not be told.
+Nor, how the lightest echo of their united home, directed by herself
+with such a wise and elegant thrift that it was more abundant than any
+waste, was music to her. Nor, how there were echoes all about her, sweet
+in her ears, of the many times her father had told her that he found her
+more devoted to him married (if that could be) than single, and of the
+many times her husband had said to her that no cares and duties seemed
+to divide her love for him or her help to him, and asked her “What is
+the magic secret, my darling, of your being everything to all of us,
+as if there were only one of us, yet never seeming to be hurried, or to
+have too much to do?”
+
+But, there were other echoes, from a distance, that rumbled menacingly
+in the corner all through this space of time. And it was now, about
+little Lucie’s sixth birthday, that they began to have an awful sound,
+as of a great storm in France with a dreadful sea rising.
+
+On a night in mid-July, one thousand seven hundred and eighty-nine, Mr.
+Lorry came in late, from Tellson’s, and sat himself down by Lucie and
+her husband in the dark window. It was a hot, wild night, and they were
+all three reminded of the old Sunday night when they had looked at the
+lightning from the same place.
+
+“I began to think,” said Mr. Lorry, pushing his brown wig back, “that
+I should have to pass the night at Tellson’s. We have been so full of
+business all day, that we have not known what to do first, or which way
+to turn. There is such an uneasiness in Paris, that we have actually a
+run of confidence upon us! Our customers over there, seem not to be able
+to confide their property to us fast enough. There is positively a mania
+among some of them for sending it to England.”
+
+“That has a bad look,” said Darnay--
+
+“A bad look, you say, my dear Darnay? Yes, but we don’t know what reason
+there is in it. People are so unreasonable! Some of us at Tellson’s are
+getting old, and we really can’t be troubled out of the ordinary course
+without due occasion.”
+
+“Still,” said Darnay, “you know how gloomy and threatening the sky is.”
+
+“I know that, to be sure,” assented Mr. Lorry, trying to persuade
+himself that his sweet temper was soured, and that he grumbled, “but I
+am determined to be peevish after my long day’s botheration. Where is
+Manette?”
+
+“Here he is,” said the Doctor, entering the dark room at the moment.
+
+“I am quite glad you are at home; for these hurries and forebodings by
+which I have been surrounded all day long, have made me nervous without
+reason. You are not going out, I hope?”
+
+“No; I am going to play backgammon with you, if you like,” said the
+Doctor.
+
+“I don’t think I do like, if I may speak my mind. I am not fit to be
+pitted against you to-night. Is the teaboard still there, Lucie? I can’t
+see.”
+
+“Of course, it has been kept for you.”
+
+“Thank ye, my dear. The precious child is safe in bed?”
+
+“And sleeping soundly.”
+
+“That’s right; all safe and well! I don’t know why anything should be
+otherwise than safe and well here, thank God; but I have been so put out
+all day, and I am not as young as I was! My tea, my dear! Thank ye. Now,
+come and take your place in the circle, and let us sit quiet, and hear
+the echoes about which you have your theory.”
+
+“Not a theory; it was a fancy.”
+
+“A fancy, then, my wise pet,” said Mr. Lorry, patting her hand. “They
+are very numerous and very loud, though, are they not? Only hear them!”
+
+Headlong, mad, and dangerous footsteps to force their way into anybody’s
+life, footsteps not easily made clean again if once stained red, the
+footsteps raging in Saint Antoine afar off, as the little circle sat in
+the dark London window.
+
+Saint Antoine had been, that morning, a vast dusky mass of scarecrows
+heaving to and fro, with frequent gleams of light above the billowy
+heads, where steel blades and bayonets shone in the sun. A tremendous
+roar arose from the throat of Saint Antoine, and a forest of naked arms
+struggled in the air like shrivelled branches of trees in a winter wind:
+all the fingers convulsively clutching at every weapon or semblance of a
+weapon that was thrown up from the depths below, no matter how far off.
+
+Who gave them out, whence they last came, where they began, through what
+agency they crookedly quivered and jerked, scores at a time, over the
+heads of the crowd, like a kind of lightning, no eye in the throng could
+have told; but, muskets were being distributed--so were cartridges,
+powder, and ball, bars of iron and wood, knives, axes, pikes, every
+weapon that distracted ingenuity could discover or devise. People who
+could lay hold of nothing else, set themselves with bleeding hands to
+force stones and bricks out of their places in walls. Every pulse and
+heart in Saint Antoine was on high-fever strain and at high-fever heat.
+Every living creature there held life as of no account, and was demented
+with a passionate readiness to sacrifice it.
+
+As a whirlpool of boiling waters has a centre point, so, all this raging
+circled round Defarge’s wine-shop, and every human drop in the caldron
+had a tendency to be sucked towards the vortex where Defarge himself,
+already begrimed with gunpowder and sweat, issued orders, issued arms,
+thrust this man back, dragged this man forward, disarmed one to arm
+another, laboured and strove in the thickest of the uproar.
+
+“Keep near to me, Jacques Three,” cried Defarge; “and do you, Jacques
+One and Two, separate and put yourselves at the head of as many of these
+patriots as you can. Where is my wife?”
+
+“Eh, well! Here you see me!” said madame, composed as ever, but not
+knitting to-day. Madame’s resolute right hand was occupied with an axe,
+in place of the usual softer implements, and in her girdle were a pistol
+and a cruel knife.
+
+“Where do you go, my wife?”
+
+“I go,” said madame, “with you at present. You shall see me at the head
+of women, by-and-bye.”
+
+“Come, then!” cried Defarge, in a resounding voice. “Patriots and
+friends, we are ready! The Bastille!”
+
+With a roar that sounded as if all the breath in France had been shaped
+into the detested word, the living sea rose, wave on wave, depth on
+depth, and overflowed the city to that point. Alarm-bells ringing, drums
+beating, the sea raging and thundering on its new beach, the attack
+began.
+
+Deep ditches, double drawbridge, massive stone walls, eight great
+towers, cannon, muskets, fire and smoke. Through the fire and through
+the smoke--in the fire and in the smoke, for the sea cast him up against
+a cannon, and on the instant he became a cannonier--Defarge of the
+wine-shop worked like a manful soldier, Two fierce hours.
+
+Deep ditch, single drawbridge, massive stone walls, eight great towers,
+cannon, muskets, fire and smoke. One drawbridge down! “Work, comrades
+all, work! Work, Jacques One, Jacques Two, Jacques One Thousand, Jacques
+Two Thousand, Jacques Five-and-Twenty Thousand; in the name of all
+the Angels or the Devils--which you prefer--work!” Thus Defarge of the
+wine-shop, still at his gun, which had long grown hot.
+
+“To me, women!” cried madame his wife. “What! We can kill as well as
+the men when the place is taken!” And to her, with a shrill thirsty
+cry, trooping women variously armed, but all armed alike in hunger and
+revenge.
+
+Cannon, muskets, fire and smoke; but, still the deep ditch, the single
+drawbridge, the massive stone walls, and the eight great towers. Slight
+displacements of the raging sea, made by the falling wounded. Flashing
+weapons, blazing torches, smoking waggonloads of wet straw, hard work
+at neighbouring barricades in all directions, shrieks, volleys,
+execrations, bravery without stint, boom smash and rattle, and the
+furious sounding of the living sea; but, still the deep ditch, and the
+single drawbridge, and the massive stone walls, and the eight great
+towers, and still Defarge of the wine-shop at his gun, grown doubly hot
+by the service of Four fierce hours.
+
+A white flag from within the fortress, and a parley--this dimly
+perceptible through the raging storm, nothing audible in it--suddenly
+the sea rose immeasurably wider and higher, and swept Defarge of the
+wine-shop over the lowered drawbridge, past the massive stone outer
+walls, in among the eight great towers surrendered!
+
+So resistless was the force of the ocean bearing him on, that even to
+draw his breath or turn his head was as impracticable as if he had been
+struggling in the surf at the South Sea, until he was landed in the
+outer courtyard of the Bastille. There, against an angle of a wall, he
+made a struggle to look about him. Jacques Three was nearly at his side;
+Madame Defarge, still heading some of her women, was visible in the
+inner distance, and her knife was in her hand. Everywhere was tumult,
+exultation, deafening and maniacal bewilderment, astounding noise, yet
+furious dumb-show.
+
+“The Prisoners!”
+
+“The Records!”
+
+“The secret cells!”
+
+“The instruments of torture!”
+
+“The Prisoners!”
+
+Of all these cries, and ten thousand incoherences, “The Prisoners!” was
+the cry most taken up by the sea that rushed in, as if there were an
+eternity of people, as well as of time and space. When the foremost
+billows rolled past, bearing the prison officers with them, and
+threatening them all with instant death if any secret nook remained
+undisclosed, Defarge laid his strong hand on the breast of one of
+these men--a man with a grey head, who had a lighted torch in his
+hand--separated him from the rest, and got him between himself and the
+wall.
+
+“Show me the North Tower!” said Defarge. “Quick!”
+
+“I will faithfully,” replied the man, “if you will come with me. But
+there is no one there.”
+
+“What is the meaning of One Hundred and Five, North Tower?” asked
+Defarge. “Quick!”
+
+“The meaning, monsieur?”
+
+“Does it mean a captive, or a place of captivity? Or do you mean that I
+shall strike you dead?”
+
+“Kill him!” croaked Jacques Three, who had come close up.
+
+“Monsieur, it is a cell.”
+
+“Show it me!”
+
+“Pass this way, then.”
+
+Jacques Three, with his usual craving on him, and evidently disappointed
+by the dialogue taking a turn that did not seem to promise bloodshed,
+held by Defarge’s arm as he held by the turnkey’s. Their three heads had
+been close together during this brief discourse, and it had been as much
+as they could do to hear one another, even then: so tremendous was the
+noise of the living ocean, in its irruption into the Fortress, and
+its inundation of the courts and passages and staircases. All around
+outside, too, it beat the walls with a deep, hoarse roar, from which,
+occasionally, some partial shouts of tumult broke and leaped into the
+air like spray.
+
+Through gloomy vaults where the light of day had never shone, past
+hideous doors of dark dens and cages, down cavernous flights of steps,
+and again up steep rugged ascents of stone and brick, more like dry
+waterfalls than staircases, Defarge, the turnkey, and Jacques Three,
+linked hand and arm, went with all the speed they could make. Here and
+there, especially at first, the inundation started on them and swept by;
+but when they had done descending, and were winding and climbing up a
+tower, they were alone. Hemmed in here by the massive thickness of walls
+and arches, the storm within the fortress and without was only audible
+to them in a dull, subdued way, as if the noise out of which they had
+come had almost destroyed their sense of hearing.
+
+The turnkey stopped at a low door, put a key in a clashing lock, swung
+the door slowly open, and said, as they all bent their heads and passed
+in:
+
+“One hundred and five, North Tower!”
+
+There was a small, heavily-grated, unglazed window high in the wall,
+with a stone screen before it, so that the sky could be only seen by
+stooping low and looking up. There was a small chimney, heavily barred
+across, a few feet within. There was a heap of old feathery wood-ashes
+on the hearth. There was a stool, and table, and a straw bed. There were
+the four blackened walls, and a rusted iron ring in one of them.
+
+“Pass that torch slowly along these walls, that I may see them,” said
+Defarge to the turnkey.
+
+The man obeyed, and Defarge followed the light closely with his eyes.
+
+“Stop!--Look here, Jacques!”
+
+“A. M.!” croaked Jacques Three, as he read greedily.
+
+“Alexandre Manette,” said Defarge in his ear, following the letters
+with his swart forefinger, deeply engrained with gunpowder. “And here he
+wrote ‘a poor physician.’ And it was he, without doubt, who scratched
+a calendar on this stone. What is that in your hand? A crowbar? Give it
+me!”
+
+He had still the linstock of his gun in his own hand. He made a sudden
+exchange of the two instruments, and turning on the worm-eaten stool and
+table, beat them to pieces in a few blows.
+
+“Hold the light higher!” he said, wrathfully, to the turnkey. “Look
+among those fragments with care, Jacques. And see! Here is my knife,”
+ throwing it to him; “rip open that bed, and search the straw. Hold the
+light higher, you!”
+
+With a menacing look at the turnkey he crawled upon the hearth, and,
+peering up the chimney, struck and prised at its sides with the crowbar,
+and worked at the iron grating across it. In a few minutes, some mortar
+and dust came dropping down, which he averted his face to avoid; and
+in it, and in the old wood-ashes, and in a crevice in the chimney
+into which his weapon had slipped or wrought itself, he groped with a
+cautious touch.
+
+“Nothing in the wood, and nothing in the straw, Jacques?”
+
+“Nothing.”
+
+“Let us collect them together, in the middle of the cell. So! Light
+them, you!”
+
+The turnkey fired the little pile, which blazed high and hot. Stooping
+again to come out at the low-arched door, they left it burning, and
+retraced their way to the courtyard; seeming to recover their sense
+of hearing as they came down, until they were in the raging flood once
+more.
+
+They found it surging and tossing, in quest of Defarge himself. Saint
+Antoine was clamorous to have its wine-shop keeper foremost in the guard
+upon the governor who had defended the Bastille and shot the people.
+Otherwise, the governor would not be marched to the Hotel de Ville for
+judgment. Otherwise, the governor would escape, and the people’s
+blood (suddenly of some value, after many years of worthlessness) be
+unavenged.
+
+In the howling universe of passion and contention that seemed to
+encompass this grim old officer conspicuous in his grey coat and red
+decoration, there was but one quite steady figure, and that was a
+woman’s. “See, there is my husband!” she cried, pointing him out.
+“See Defarge!” She stood immovable close to the grim old officer, and
+remained immovable close to him; remained immovable close to him through
+the streets, as Defarge and the rest bore him along; remained immovable
+close to him when he was got near his destination, and began to
+be struck at from behind; remained immovable close to him when the
+long-gathering rain of stabs and blows fell heavy; was so close to him
+when he dropped dead under it, that, suddenly animated, she put her foot
+upon his neck, and with her cruel knife--long ready--hewed off his head.
+
+The hour was come, when Saint Antoine was to execute his horrible idea
+of hoisting up men for lamps to show what he could be and do. Saint
+Antoine’s blood was up, and the blood of tyranny and domination by the
+iron hand was down--down on the steps of the Hotel de Ville where the
+governor’s body lay--down on the sole of the shoe of Madame Defarge
+where she had trodden on the body to steady it for mutilation. “Lower
+the lamp yonder!” cried Saint Antoine, after glaring round for a new
+means of death; “here is one of his soldiers to be left on guard!” The
+swinging sentinel was posted, and the sea rushed on.
+
+The sea of black and threatening waters, and of destructive upheaving
+of wave against wave, whose depths were yet unfathomed and whose forces
+were yet unknown. The remorseless sea of turbulently swaying shapes,
+voices of vengeance, and faces hardened in the furnaces of suffering
+until the touch of pity could make no mark on them.
+
+But, in the ocean of faces where every fierce and furious expression was
+in vivid life, there were two groups of faces--each seven in number--so
+fixedly contrasting with the rest, that never did sea roll which bore
+more memorable wrecks with it. Seven faces of prisoners, suddenly
+released by the storm that had burst their tomb, were carried high
+overhead: all scared, all lost, all wondering and amazed, as if the Last
+Day were come, and those who rejoiced around them were lost spirits.
+Other seven faces there were, carried higher, seven dead faces, whose
+drooping eyelids and half-seen eyes awaited the Last Day. Impassive
+faces, yet with a suspended--not an abolished--expression on them;
+faces, rather, in a fearful pause, as having yet to raise the dropped
+lids of the eyes, and bear witness with the bloodless lips, “THOU DIDST
+IT!”
+
+Seven prisoners released, seven gory heads on pikes, the keys of the
+accursed fortress of the eight strong towers, some discovered letters
+and other memorials of prisoners of old time, long dead of broken
+hearts,--such, and such--like, the loudly echoing footsteps of Saint
+Antoine escort through the Paris streets in mid-July, one thousand seven
+hundred and eighty-nine. Now, Heaven defeat the fancy of Lucie Darnay,
+and keep these feet far out of her life! For, they are headlong, mad,
+and dangerous; and in the years so long after the breaking of the cask
+at Defarge’s wine-shop door, they are not easily purified when once
+stained red.
+
+
+
+
+XXII. The Sea Still Rises
+
+
+Haggard Saint Antoine had had only one exultant week, in which to soften
+his modicum of hard and bitter bread to such extent as he could, with
+the relish of fraternal embraces and congratulations, when Madame
+Defarge sat at her counter, as usual, presiding over the customers.
+Madame Defarge wore no rose in her head, for the great brotherhood of
+Spies had become, even in one short week, extremely chary of trusting
+themselves to the saint’s mercies. The lamps across his streets had a
+portentously elastic swing with them.
+
+Madame Defarge, with her arms folded, sat in the morning light and heat,
+contemplating the wine-shop and the street. In both, there were several
+knots of loungers, squalid and miserable, but now with a manifest sense
+of power enthroned on their distress. The raggedest nightcap, awry on
+the wretchedest head, had this crooked significance in it: “I know how
+hard it has grown for me, the wearer of this, to support life in myself;
+but do you know how easy it has grown for me, the wearer of this, to
+destroy life in you?” Every lean bare arm, that had been without work
+before, had this work always ready for it now, that it could strike.
+The fingers of the knitting women were vicious, with the experience that
+they could tear. There was a change in the appearance of Saint Antoine;
+the image had been hammering into this for hundreds of years, and the
+last finishing blows had told mightily on the expression.
+
+Madame Defarge sat observing it, with such suppressed approval as was
+to be desired in the leader of the Saint Antoine women. One of her
+sisterhood knitted beside her. The short, rather plump wife of a starved
+grocer, and the mother of two children withal, this lieutenant had
+already earned the complimentary name of The Vengeance.
+
+“Hark!” said The Vengeance. “Listen, then! Who comes?”
+
+As if a train of powder laid from the outermost bound of Saint Antoine
+Quarter to the wine-shop door, had been suddenly fired, a fast-spreading
+murmur came rushing along.
+
+“It is Defarge,” said madame. “Silence, patriots!”
+
+Defarge came in breathless, pulled off a red cap he wore, and looked
+around him! “Listen, everywhere!” said madame again. “Listen to him!”
+ Defarge stood, panting, against a background of eager eyes and open
+mouths, formed outside the door; all those within the wine-shop had
+sprung to their feet.
+
+“Say then, my husband. What is it?”
+
+“News from the other world!”
+
+“How, then?” cried madame, contemptuously. “The other world?”
+
+“Does everybody here recall old Foulon, who told the famished people
+that they might eat grass, and who died, and went to Hell?”
+
+“Everybody!” from all throats.
+
+“The news is of him. He is among us!”
+
+“Among us!” from the universal throat again. “And dead?”
+
+“Not dead! He feared us so much--and with reason--that he caused himself
+to be represented as dead, and had a grand mock-funeral. But they have
+found him alive, hiding in the country, and have brought him in. I have
+seen him but now, on his way to the Hotel de Ville, a prisoner. I have
+said that he had reason to fear us. Say all! _Had_ he reason?”
+
+Wretched old sinner of more than threescore years and ten, if he had
+never known it yet, he would have known it in his heart of hearts if he
+could have heard the answering cry.
+
+A moment of profound silence followed. Defarge and his wife looked
+steadfastly at one another. The Vengeance stooped, and the jar of a drum
+was heard as she moved it at her feet behind the counter.
+
+“Patriots!” said Defarge, in a determined voice, “are we ready?”
+
+Instantly Madame Defarge’s knife was in her girdle; the drum was beating
+in the streets, as if it and a drummer had flown together by magic; and
+The Vengeance, uttering terrific shrieks, and flinging her arms about
+her head like all the forty Furies at once, was tearing from house to
+house, rousing the women.
+
+The men were terrible, in the bloody-minded anger with which they looked
+from windows, caught up what arms they had, and came pouring down into
+the streets; but, the women were a sight to chill the boldest. From
+such household occupations as their bare poverty yielded, from their
+children, from their aged and their sick crouching on the bare ground
+famished and naked, they ran out with streaming hair, urging one
+another, and themselves, to madness with the wildest cries and actions.
+Villain Foulon taken, my sister! Old Foulon taken, my mother! Miscreant
+Foulon taken, my daughter! Then, a score of others ran into the midst of
+these, beating their breasts, tearing their hair, and screaming, Foulon
+alive! Foulon who told the starving people they might eat grass! Foulon
+who told my old father that he might eat grass, when I had no bread
+to give him! Foulon who told my baby it might suck grass, when these
+breasts were dry with want! O mother of God, this Foulon! O Heaven our
+suffering! Hear me, my dead baby and my withered father: I swear on my
+knees, on these stones, to avenge you on Foulon! Husbands, and brothers,
+and young men, Give us the blood of Foulon, Give us the head of Foulon,
+Give us the heart of Foulon, Give us the body and soul of Foulon, Rend
+Foulon to pieces, and dig him into the ground, that grass may grow from
+him! With these cries, numbers of the women, lashed into blind frenzy,
+whirled about, striking and tearing at their own friends until they
+dropped into a passionate swoon, and were only saved by the men
+belonging to them from being trampled under foot.
+
+Nevertheless, not a moment was lost; not a moment! This Foulon was at
+the Hotel de Ville, and might be loosed. Never, if Saint Antoine knew
+his own sufferings, insults, and wrongs! Armed men and women flocked out
+of the Quarter so fast, and drew even these last dregs after them with
+such a force of suction, that within a quarter of an hour there was not
+a human creature in Saint Antoine’s bosom but a few old crones and the
+wailing children.
+
+No. They were all by that time choking the Hall of Examination where
+this old man, ugly and wicked, was, and overflowing into the adjacent
+open space and streets. The Defarges, husband and wife, The Vengeance,
+and Jacques Three, were in the first press, and at no great distance
+from him in the Hall.
+
+“See!” cried madame, pointing with her knife. “See the old villain bound
+with ropes. That was well done to tie a bunch of grass upon his back.
+Ha, ha! That was well done. Let him eat it now!” Madame put her knife
+under her arm, and clapped her hands as at a play.
+
+The people immediately behind Madame Defarge, explaining the cause of
+her satisfaction to those behind them, and those again explaining to
+others, and those to others, the neighbouring streets resounded with the
+clapping of hands. Similarly, during two or three hours of drawl,
+and the winnowing of many bushels of words, Madame Defarge’s frequent
+expressions of impatience were taken up, with marvellous quickness, at
+a distance: the more readily, because certain men who had by some
+wonderful exercise of agility climbed up the external architecture
+to look in from the windows, knew Madame Defarge well, and acted as a
+telegraph between her and the crowd outside the building.
+
+At length the sun rose so high that it struck a kindly ray as of hope or
+protection, directly down upon the old prisoner’s head. The favour was
+too much to bear; in an instant the barrier of dust and chaff that had
+stood surprisingly long, went to the winds, and Saint Antoine had got
+him!
+
+It was known directly, to the furthest confines of the crowd. Defarge
+had but sprung over a railing and a table, and folded the miserable
+wretch in a deadly embrace--Madame Defarge had but followed and turned
+her hand in one of the ropes with which he was tied--The Vengeance and
+Jacques Three were not yet up with them, and the men at the windows
+had not yet swooped into the Hall, like birds of prey from their high
+perches--when the cry seemed to go up, all over the city, “Bring him
+out! Bring him to the lamp!”
+
+Down, and up, and head foremost on the steps of the building; now, on
+his knees; now, on his feet; now, on his back; dragged, and struck at,
+and stifled by the bunches of grass and straw that were thrust into his
+face by hundreds of hands; torn, bruised, panting, bleeding, yet always
+entreating and beseeching for mercy; now full of vehement agony of
+action, with a small clear space about him as the people drew one
+another back that they might see; now, a log of dead wood drawn through
+a forest of legs; he was hauled to the nearest street corner where one
+of the fatal lamps swung, and there Madame Defarge let him go--as a cat
+might have done to a mouse--and silently and composedly looked at him
+while they made ready, and while he besought her: the women passionately
+screeching at him all the time, and the men sternly calling out to have
+him killed with grass in his mouth. Once, he went aloft, and the rope
+broke, and they caught him shrieking; twice, he went aloft, and the rope
+broke, and they caught him shrieking; then, the rope was merciful, and
+held him, and his head was soon upon a pike, with grass enough in the
+mouth for all Saint Antoine to dance at the sight of.
+
+Nor was this the end of the day’s bad work, for Saint Antoine so shouted
+and danced his angry blood up, that it boiled again, on hearing when
+the day closed in that the son-in-law of the despatched, another of the
+people’s enemies and insulters, was coming into Paris under a guard
+five hundred strong, in cavalry alone. Saint Antoine wrote his crimes
+on flaring sheets of paper, seized him--would have torn him out of the
+breast of an army to bear Foulon company--set his head and heart on
+pikes, and carried the three spoils of the day, in Wolf-procession
+through the streets.
+
+Not before dark night did the men and women come back to the children,
+wailing and breadless. Then, the miserable bakers’ shops were beset by
+long files of them, patiently waiting to buy bad bread; and while
+they waited with stomachs faint and empty, they beguiled the time by
+embracing one another on the triumphs of the day, and achieving them
+again in gossip. Gradually, these strings of ragged people shortened and
+frayed away; and then poor lights began to shine in high windows, and
+slender fires were made in the streets, at which neighbours cooked in
+common, afterwards supping at their doors.
+
+Scanty and insufficient suppers those, and innocent of meat, as of
+most other sauce to wretched bread. Yet, human fellowship infused
+some nourishment into the flinty viands, and struck some sparks of
+cheerfulness out of them. Fathers and mothers who had had their full
+share in the worst of the day, played gently with their meagre children;
+and lovers, with such a world around them and before them, loved and
+hoped.
+
+It was almost morning, when Defarge’s wine-shop parted with its last
+knot of customers, and Monsieur Defarge said to madame his wife, in
+husky tones, while fastening the door:
+
+“At last it is come, my dear!”
+
+“Eh well!” returned madame. “Almost.”
+
+Saint Antoine slept, the Defarges slept: even The Vengeance slept with
+her starved grocer, and the drum was at rest. The drum’s was the
+only voice in Saint Antoine that blood and hurry had not changed. The
+Vengeance, as custodian of the drum, could have wakened him up and had
+the same speech out of him as before the Bastille fell, or old Foulon
+was seized; not so with the hoarse tones of the men and women in Saint
+Antoine’s bosom.
+
+
+
+
+XXIII. Fire Rises
+
+
+There was a change on the village where the fountain fell, and where
+the mender of roads went forth daily to hammer out of the stones on the
+highway such morsels of bread as might serve for patches to hold his
+poor ignorant soul and his poor reduced body together. The prison on the
+crag was not so dominant as of yore; there were soldiers to guard it,
+but not many; there were officers to guard the soldiers, but not one of
+them knew what his men would do--beyond this: that it would probably not
+be what he was ordered.
+
+Far and wide lay a ruined country, yielding nothing but desolation.
+Every green leaf, every blade of grass and blade of grain, was as
+shrivelled and poor as the miserable people. Everything was bowed down,
+dejected, oppressed, and broken. Habitations, fences, domesticated
+animals, men, women, children, and the soil that bore them--all worn
+out.
+
+Monseigneur (often a most worthy individual gentleman) was a national
+blessing, gave a chivalrous tone to things, was a polite example of
+luxurious and shining life, and a great deal more to equal purpose;
+nevertheless, Monseigneur as a class had, somehow or other, brought
+things to this. Strange that Creation, designed expressly for
+Monseigneur, should be so soon wrung dry and squeezed out! There must
+be something short-sighted in the eternal arrangements, surely! Thus it
+was, however; and the last drop of blood having been extracted from the
+flints, and the last screw of the rack having been turned so often that
+its purchase crumbled, and it now turned and turned with nothing
+to bite, Monseigneur began to run away from a phenomenon so low and
+unaccountable.
+
+But, this was not the change on the village, and on many a village like
+it. For scores of years gone by, Monseigneur had squeezed it and wrung
+it, and had seldom graced it with his presence except for the pleasures
+of the chase--now, found in hunting the people; now, found in hunting
+the beasts, for whose preservation Monseigneur made edifying spaces
+of barbarous and barren wilderness. No. The change consisted in
+the appearance of strange faces of low caste, rather than in the
+disappearance of the high caste, chiselled, and otherwise beautified and
+beautifying features of Monseigneur.
+
+For, in these times, as the mender of roads worked, solitary, in the
+dust, not often troubling himself to reflect that dust he was and
+to dust he must return, being for the most part too much occupied in
+thinking how little he had for supper and how much more he would eat if
+he had it--in these times, as he raised his eyes from his lonely labour,
+and viewed the prospect, he would see some rough figure approaching on
+foot, the like of which was once a rarity in those parts, but was now
+a frequent presence. As it advanced, the mender of roads would discern
+without surprise, that it was a shaggy-haired man, of almost barbarian
+aspect, tall, in wooden shoes that were clumsy even to the eyes of a
+mender of roads, grim, rough, swart, steeped in the mud and dust of many
+highways, dank with the marshy moisture of many low grounds, sprinkled
+with the thorns and leaves and moss of many byways through woods.
+
+Such a man came upon him, like a ghost, at noon in the July weather,
+as he sat on his heap of stones under a bank, taking such shelter as he
+could get from a shower of hail.
+
+The man looked at him, looked at the village in the hollow, at the mill,
+and at the prison on the crag. When he had identified these objects
+in what benighted mind he had, he said, in a dialect that was just
+intelligible:
+
+“How goes it, Jacques?”
+
+“All well, Jacques.”
+
+“Touch then!”
+
+They joined hands, and the man sat down on the heap of stones.
+
+“No dinner?”
+
+“Nothing but supper now,” said the mender of roads, with a hungry face.
+
+“It is the fashion,” growled the man. “I meet no dinner anywhere.”
+
+He took out a blackened pipe, filled it, lighted it with flint and
+steel, pulled at it until it was in a bright glow: then, suddenly held
+it from him and dropped something into it from between his finger and
+thumb, that blazed and went out in a puff of smoke.
+
+“Touch then.” It was the turn of the mender of roads to say it this
+time, after observing these operations. They again joined hands.
+
+“To-night?” said the mender of roads.
+
+“To-night,” said the man, putting the pipe in his mouth.
+
+“Where?”
+
+“Here.”
+
+He and the mender of roads sat on the heap of stones looking silently at
+one another, with the hail driving in between them like a pigmy charge
+of bayonets, until the sky began to clear over the village.
+
+“Show me!” said the traveller then, moving to the brow of the hill.
+
+“See!” returned the mender of roads, with extended finger. “You go down
+here, and straight through the street, and past the fountain--”
+
+“To the Devil with all that!” interrupted the other, rolling his eye
+over the landscape. “_I_ go through no streets and past no fountains.
+Well?”
+
+“Well! About two leagues beyond the summit of that hill above the
+village.”
+
+“Good. When do you cease to work?”
+
+“At sunset.”
+
+“Will you wake me, before departing? I have walked two nights without
+resting. Let me finish my pipe, and I shall sleep like a child. Will you
+wake me?”
+
+“Surely.”
+
+The wayfarer smoked his pipe out, put it in his breast, slipped off his
+great wooden shoes, and lay down on his back on the heap of stones. He
+was fast asleep directly.
+
+As the road-mender plied his dusty labour, and the hail-clouds, rolling
+away, revealed bright bars and streaks of sky which were responded to
+by silver gleams upon the landscape, the little man (who wore a red cap
+now, in place of his blue one) seemed fascinated by the figure on the
+heap of stones. His eyes were so often turned towards it, that he used
+his tools mechanically, and, one would have said, to very poor account.
+The bronze face, the shaggy black hair and beard, the coarse woollen
+red cap, the rough medley dress of home-spun stuff and hairy skins of
+beasts, the powerful frame attenuated by spare living, and the sullen
+and desperate compression of the lips in sleep, inspired the mender
+of roads with awe. The traveller had travelled far, and his feet were
+footsore, and his ankles chafed and bleeding; his great shoes, stuffed
+with leaves and grass, had been heavy to drag over the many long
+leagues, and his clothes were chafed into holes, as he himself was into
+sores. Stooping down beside him, the road-mender tried to get a peep at
+secret weapons in his breast or where not; but, in vain, for he slept
+with his arms crossed upon him, and set as resolutely as his lips.
+Fortified towns with their stockades, guard-houses, gates, trenches, and
+drawbridges, seemed to the mender of roads, to be so much air as against
+this figure. And when he lifted his eyes from it to the horizon and
+looked around, he saw in his small fancy similar figures, stopped by no
+obstacle, tending to centres all over France.
+
+The man slept on, indifferent to showers of hail and intervals of
+brightness, to sunshine on his face and shadow, to the paltering lumps
+of dull ice on his body and the diamonds into which the sun changed
+them, until the sun was low in the west, and the sky was glowing. Then,
+the mender of roads having got his tools together and all things ready
+to go down into the village, roused him.
+
+“Good!” said the sleeper, rising on his elbow. “Two leagues beyond the
+summit of the hill?”
+
+“About.”
+
+“About. Good!”
+
+The mender of roads went home, with the dust going on before him
+according to the set of the wind, and was soon at the fountain,
+squeezing himself in among the lean kine brought there to drink, and
+appearing even to whisper to them in his whispering to all the village.
+When the village had taken its poor supper, it did not creep to bed,
+as it usually did, but came out of doors again, and remained there. A
+curious contagion of whispering was upon it, and also, when it gathered
+together at the fountain in the dark, another curious contagion of
+looking expectantly at the sky in one direction only. Monsieur Gabelle,
+chief functionary of the place, became uneasy; went out on his house-top
+alone, and looked in that direction too; glanced down from behind his
+chimneys at the darkening faces by the fountain below, and sent word to
+the sacristan who kept the keys of the church, that there might be need
+to ring the tocsin by-and-bye.
+
+The night deepened. The trees environing the old chateau, keeping its
+solitary state apart, moved in a rising wind, as though they threatened
+the pile of building massive and dark in the gloom. Up the two terrace
+flights of steps the rain ran wildly, and beat at the great door, like a
+swift messenger rousing those within; uneasy rushes of wind went through
+the hall, among the old spears and knives, and passed lamenting up the
+stairs, and shook the curtains of the bed where the last Marquis
+had slept. East, West, North, and South, through the woods, four
+heavy-treading, unkempt figures crushed the high grass and cracked the
+branches, striding on cautiously to come together in the courtyard. Four
+lights broke out there, and moved away in different directions, and all
+was black again.
+
+But, not for long. Presently, the chateau began to make itself strangely
+visible by some light of its own, as though it were growing luminous.
+Then, a flickering streak played behind the architecture of the front,
+picking out transparent places, and showing where balustrades, arches,
+and windows were. Then it soared higher, and grew broader and brighter.
+Soon, from a score of the great windows, flames burst forth, and the
+stone faces awakened, stared out of fire.
+
+A faint murmur arose about the house from the few people who were left
+there, and there was a saddling of a horse and riding away. There was
+spurring and splashing through the darkness, and bridle was drawn in the
+space by the village fountain, and the horse in a foam stood at Monsieur
+Gabelle’s door. “Help, Gabelle! Help, every one!” The tocsin rang
+impatiently, but other help (if that were any) there was none. The
+mender of roads, and two hundred and fifty particular friends, stood
+with folded arms at the fountain, looking at the pillar of fire in the
+sky. “It must be forty feet high,” said they, grimly; and never moved.
+
+The rider from the chateau, and the horse in a foam, clattered away
+through the village, and galloped up the stony steep, to the prison on
+the crag. At the gate, a group of officers were looking at the fire;
+removed from them, a group of soldiers. “Help, gentlemen--officers! The
+chateau is on fire; valuable objects may be saved from the flames by
+timely aid! Help, help!” The officers looked towards the soldiers who
+looked at the fire; gave no orders; and answered, with shrugs and biting
+of lips, “It must burn.”
+
+As the rider rattled down the hill again and through the street, the
+village was illuminating. The mender of roads, and the two hundred and
+fifty particular friends, inspired as one man and woman by the idea of
+lighting up, had darted into their houses, and were putting candles in
+every dull little pane of glass. The general scarcity of everything,
+occasioned candles to be borrowed in a rather peremptory manner of
+Monsieur Gabelle; and in a moment of reluctance and hesitation on
+that functionary’s part, the mender of roads, once so submissive to
+authority, had remarked that carriages were good to make bonfires with,
+and that post-horses would roast.
+
+The chateau was left to itself to flame and burn. In the roaring and
+raging of the conflagration, a red-hot wind, driving straight from the
+infernal regions, seemed to be blowing the edifice away. With the rising
+and falling of the blaze, the stone faces showed as if they were in
+torment. When great masses of stone and timber fell, the face with the
+two dints in the nose became obscured: anon struggled out of the smoke
+again, as if it were the face of the cruel Marquis, burning at the stake
+and contending with the fire.
+
+The chateau burned; the nearest trees, laid hold of by the fire,
+scorched and shrivelled; trees at a distance, fired by the four fierce
+figures, begirt the blazing edifice with a new forest of smoke. Molten
+lead and iron boiled in the marble basin of the fountain; the water ran
+dry; the extinguisher tops of the towers vanished like ice before the
+heat, and trickled down into four rugged wells of flame. Great rents and
+splits branched out in the solid walls, like crystallisation; stupefied
+birds wheeled about and dropped into the furnace; four fierce figures
+trudged away, East, West, North, and South, along the night-enshrouded
+roads, guided by the beacon they had lighted, towards their next
+destination. The illuminated village had seized hold of the tocsin, and,
+abolishing the lawful ringer, rang for joy.
+
+Not only that; but the village, light-headed with famine, fire, and
+bell-ringing, and bethinking itself that Monsieur Gabelle had to do with
+the collection of rent and taxes--though it was but a small instalment
+of taxes, and no rent at all, that Gabelle had got in those latter
+days--became impatient for an interview with him, and, surrounding his
+house, summoned him to come forth for personal conference. Whereupon,
+Monsieur Gabelle did heavily bar his door, and retire to hold counsel
+with himself. The result of that conference was, that Gabelle again
+withdrew himself to his housetop behind his stack of chimneys; this time
+resolved, if his door were broken in (he was a small Southern man
+of retaliative temperament), to pitch himself head foremost over the
+parapet, and crush a man or two below.
+
+Probably, Monsieur Gabelle passed a long night up there, with the
+distant chateau for fire and candle, and the beating at his door,
+combined with the joy-ringing, for music; not to mention his having an
+ill-omened lamp slung across the road before his posting-house gate,
+which the village showed a lively inclination to displace in his favour.
+A trying suspense, to be passing a whole summer night on the brink of
+the black ocean, ready to take that plunge into it upon which Monsieur
+Gabelle had resolved! But, the friendly dawn appearing at last, and the
+rush-candles of the village guttering out, the people happily dispersed,
+and Monsieur Gabelle came down bringing his life with him for that
+while.
+
+Within a hundred miles, and in the light of other fires, there were
+other functionaries less fortunate, that night and other nights, whom
+the rising sun found hanging across once-peaceful streets, where they
+had been born and bred; also, there were other villagers and townspeople
+less fortunate than the mender of roads and his fellows, upon whom the
+functionaries and soldiery turned with success, and whom they strung up
+in their turn. But, the fierce figures were steadily wending East, West,
+North, and South, be that as it would; and whosoever hung, fire burned.
+The altitude of the gallows that would turn to water and quench it,
+no functionary, by any stretch of mathematics, was able to calculate
+successfully.
+
+
+
+
+XXIV. Drawn to the Loadstone Rock
+
+
+In such risings of fire and risings of sea--the firm earth shaken by
+the rushes of an angry ocean which had now no ebb, but was always on the
+flow, higher and higher, to the terror and wonder of the beholders on
+the shore--three years of tempest were consumed. Three more birthdays
+of little Lucie had been woven by the golden thread into the peaceful
+tissue of the life of her home.
+
+Many a night and many a day had its inmates listened to the echoes in
+the corner, with hearts that failed them when they heard the thronging
+feet. For, the footsteps had become to their minds as the footsteps of
+a people, tumultuous under a red flag and with their country declared in
+danger, changed into wild beasts, by terrible enchantment long persisted
+in.
+
+Monseigneur, as a class, had dissociated himself from the phenomenon of
+his not being appreciated: of his being so little wanted in France, as
+to incur considerable danger of receiving his dismissal from it, and
+this life together. Like the fabled rustic who raised the Devil with
+infinite pains, and was so terrified at the sight of him that he could
+ask the Enemy no question, but immediately fled; so, Monseigneur, after
+boldly reading the Lord’s Prayer backwards for a great number of years,
+and performing many other potent spells for compelling the Evil One, no
+sooner beheld him in his terrors than he took to his noble heels.
+
+The shining Bull’s Eye of the Court was gone, or it would have been the
+mark for a hurricane of national bullets. It had never been a good
+eye to see with--had long had the mote in it of Lucifer’s pride,
+Sardanapalus’s luxury, and a mole’s blindness--but it had dropped
+out and was gone. The Court, from that exclusive inner circle to its
+outermost rotten ring of intrigue, corruption, and dissimulation, was
+all gone together. Royalty was gone; had been besieged in its Palace and
+“suspended,” when the last tidings came over.
+
+The August of the year one thousand seven hundred and ninety-two was
+come, and Monseigneur was by this time scattered far and wide.
+
+As was natural, the head-quarters and great gathering-place of
+Monseigneur, in London, was Tellson’s Bank. Spirits are supposed to
+haunt the places where their bodies most resorted, and Monseigneur
+without a guinea haunted the spot where his guineas used to be.
+Moreover, it was the spot to which such French intelligence as was most
+to be relied upon, came quickest. Again: Tellson’s was a munificent
+house, and extended great liberality to old customers who had fallen
+from their high estate. Again: those nobles who had seen the coming
+storm in time, and anticipating plunder or confiscation, had made
+provident remittances to Tellson’s, were always to be heard of there
+by their needy brethren. To which it must be added that every new-comer
+from France reported himself and his tidings at Tellson’s, almost as
+a matter of course. For such variety of reasons, Tellson’s was at that
+time, as to French intelligence, a kind of High Exchange; and this
+was so well known to the public, and the inquiries made there were in
+consequence so numerous, that Tellson’s sometimes wrote the latest news
+out in a line or so and posted it in the Bank windows, for all who ran
+through Temple Bar to read.
+
+On a steaming, misty afternoon, Mr. Lorry sat at his desk, and Charles
+Darnay stood leaning on it, talking with him in a low voice. The
+penitential den once set apart for interviews with the House, was now
+the news-Exchange, and was filled to overflowing. It was within half an
+hour or so of the time of closing.
+
+“But, although you are the youngest man that ever lived,” said Charles
+Darnay, rather hesitating, “I must still suggest to you--”
+
+“I understand. That I am too old?” said Mr. Lorry.
+
+“Unsettled weather, a long journey, uncertain means of travelling, a
+disorganised country, a city that may not be even safe for you.”
+
+“My dear Charles,” said Mr. Lorry, with cheerful confidence, “you touch
+some of the reasons for my going: not for my staying away. It is safe
+enough for me; nobody will care to interfere with an old fellow of hard
+upon fourscore when there are so many people there much better worth
+interfering with. As to its being a disorganised city, if it were not a
+disorganised city there would be no occasion to send somebody from our
+House here to our House there, who knows the city and the business, of
+old, and is in Tellson’s confidence. As to the uncertain travelling, the
+long journey, and the winter weather, if I were not prepared to submit
+myself to a few inconveniences for the sake of Tellson’s, after all
+these years, who ought to be?”
+
+“I wish I were going myself,” said Charles Darnay, somewhat restlessly,
+and like one thinking aloud.
+
+“Indeed! You are a pretty fellow to object and advise!” exclaimed Mr.
+Lorry. “You wish you were going yourself? And you a Frenchman born? You
+are a wise counsellor.”
+
+“My dear Mr. Lorry, it is because I am a Frenchman born, that the
+thought (which I did not mean to utter here, however) has passed through
+my mind often. One cannot help thinking, having had some sympathy for
+the miserable people, and having abandoned something to them,” he spoke
+here in his former thoughtful manner, “that one might be listened to,
+and might have the power to persuade to some restraint. Only last night,
+after you had left us, when I was talking to Lucie--”
+
+“When you were talking to Lucie,” Mr. Lorry repeated. “Yes. I wonder you
+are not ashamed to mention the name of Lucie! Wishing you were going to
+France at this time of day!”
+
+“However, I am not going,” said Charles Darnay, with a smile. “It is
+more to the purpose that you say you are.”
+
+“And I am, in plain reality. The truth is, my dear Charles,” Mr. Lorry
+glanced at the distant House, and lowered his voice, “you can have no
+conception of the difficulty with which our business is transacted, and
+of the peril in which our books and papers over yonder are involved. The
+Lord above knows what the compromising consequences would be to numbers
+of people, if some of our documents were seized or destroyed; and they
+might be, at any time, you know, for who can say that Paris is not set
+afire to-day, or sacked to-morrow! Now, a judicious selection from these
+with the least possible delay, and the burying of them, or otherwise
+getting of them out of harm’s way, is within the power (without loss of
+precious time) of scarcely any one but myself, if any one. And shall
+I hang back, when Tellson’s knows this and says this--Tellson’s, whose
+bread I have eaten these sixty years--because I am a little stiff about
+the joints? Why, I am a boy, sir, to half a dozen old codgers here!”
+
+“How I admire the gallantry of your youthful spirit, Mr. Lorry.”
+
+“Tut! Nonsense, sir!--And, my dear Charles,” said Mr. Lorry, glancing at
+the House again, “you are to remember, that getting things out of
+Paris at this present time, no matter what things, is next to an
+impossibility. Papers and precious matters were this very day brought
+to us here (I speak in strict confidence; it is not business-like to
+whisper it, even to you), by the strangest bearers you can imagine,
+every one of whom had his head hanging on by a single hair as he passed
+the Barriers. At another time, our parcels would come and go, as easily
+as in business-like Old England; but now, everything is stopped.”
+
+“And do you really go to-night?”
+
+“I really go to-night, for the case has become too pressing to admit of
+delay.”
+
+“And do you take no one with you?”
+
+“All sorts of people have been proposed to me, but I will have nothing
+to say to any of them. I intend to take Jerry. Jerry has been my
+bodyguard on Sunday nights for a long time past and I am used to him.
+Nobody will suspect Jerry of being anything but an English bull-dog, or
+of having any design in his head but to fly at anybody who touches his
+master.”
+
+“I must say again that I heartily admire your gallantry and
+youthfulness.”
+
+“I must say again, nonsense, nonsense! When I have executed this little
+commission, I shall, perhaps, accept Tellson’s proposal to retire and
+live at my ease. Time enough, then, to think about growing old.”
+
+This dialogue had taken place at Mr. Lorry’s usual desk, with
+Monseigneur swarming within a yard or two of it, boastful of what he
+would do to avenge himself on the rascal-people before long. It was too
+much the way of Monseigneur under his reverses as a refugee, and it
+was much too much the way of native British orthodoxy, to talk of this
+terrible Revolution as if it were the only harvest ever known under
+the skies that had not been sown--as if nothing had ever been done, or
+omitted to be done, that had led to it--as if observers of the wretched
+millions in France, and of the misused and perverted resources that
+should have made them prosperous, had not seen it inevitably coming,
+years before, and had not in plain words recorded what they saw. Such
+vapouring, combined with the extravagant plots of Monseigneur for the
+restoration of a state of things that had utterly exhausted itself,
+and worn out Heaven and earth as well as itself, was hard to be endured
+without some remonstrance by any sane man who knew the truth. And it was
+such vapouring all about his ears, like a troublesome confusion of blood
+in his own head, added to a latent uneasiness in his mind, which had
+already made Charles Darnay restless, and which still kept him so.
+
+Among the talkers, was Stryver, of the King’s Bench Bar, far on his
+way to state promotion, and, therefore, loud on the theme: broaching
+to Monseigneur, his devices for blowing the people up and exterminating
+them from the face of the earth, and doing without them: and for
+accomplishing many similar objects akin in their nature to the abolition
+of eagles by sprinkling salt on the tails of the race. Him, Darnay heard
+with a particular feeling of objection; and Darnay stood divided between
+going away that he might hear no more, and remaining to interpose his
+word, when the thing that was to be, went on to shape itself out.
+
+The House approached Mr. Lorry, and laying a soiled and unopened letter
+before him, asked if he had yet discovered any traces of the person to
+whom it was addressed? The House laid the letter down so close to Darnay
+that he saw the direction--the more quickly because it was his own right
+name. The address, turned into English, ran:
+
+“Very pressing. To Monsieur heretofore the Marquis St. Evremonde, of
+France. Confided to the cares of Messrs. Tellson and Co., Bankers,
+London, England.”
+
+On the marriage morning, Doctor Manette had made it his one urgent and
+express request to Charles Darnay, that the secret of this name should
+be--unless he, the Doctor, dissolved the obligation--kept inviolate
+between them. Nobody else knew it to be his name; his own wife had no
+suspicion of the fact; Mr. Lorry could have none.
+
+“No,” said Mr. Lorry, in reply to the House; “I have referred it,
+I think, to everybody now here, and no one can tell me where this
+gentleman is to be found.”
+
+The hands of the clock verging upon the hour of closing the Bank, there
+was a general set of the current of talkers past Mr. Lorry’s desk. He
+held the letter out inquiringly; and Monseigneur looked at it, in the
+person of this plotting and indignant refugee; and Monseigneur looked at
+it in the person of that plotting and indignant refugee; and This, That,
+and The Other, all had something disparaging to say, in French or in
+English, concerning the Marquis who was not to be found.
+
+“Nephew, I believe--but in any case degenerate successor--of the
+polished Marquis who was murdered,” said one. “Happy to say, I never
+knew him.”
+
+“A craven who abandoned his post,” said another--this Monseigneur had
+been got out of Paris, legs uppermost and half suffocated, in a load of
+hay--“some years ago.”
+
+“Infected with the new doctrines,” said a third, eyeing the direction
+through his glass in passing; “set himself in opposition to the last
+Marquis, abandoned the estates when he inherited them, and left them to
+the ruffian herd. They will recompense him now, I hope, as he deserves.”
+
+“Hey?” cried the blatant Stryver. “Did he though? Is that the sort of
+fellow? Let us look at his infamous name. D--n the fellow!”
+
+Darnay, unable to restrain himself any longer, touched Mr. Stryver on
+the shoulder, and said:
+
+“I know the fellow.”
+
+“Do you, by Jupiter?” said Stryver. “I am sorry for it.”
+
+“Why?”
+
+“Why, Mr. Darnay? D’ye hear what he did? Don’t ask, why, in these
+times.”
+
+“But I do ask why?”
+
+“Then I tell you again, Mr. Darnay, I am sorry for it. I am sorry to
+hear you putting any such extraordinary questions. Here is a fellow,
+who, infected by the most pestilent and blasphemous code of devilry that
+ever was known, abandoned his property to the vilest scum of the earth
+that ever did murder by wholesale, and you ask me why I am sorry that a
+man who instructs youth knows him? Well, but I’ll answer you. I am sorry
+because I believe there is contamination in such a scoundrel. That’s
+why.”
+
+Mindful of the secret, Darnay with great difficulty checked himself, and
+said: “You may not understand the gentleman.”
+
+“I understand how to put _you_ in a corner, Mr. Darnay,” said Bully
+Stryver, “and I’ll do it. If this fellow is a gentleman, I _don’t_
+understand him. You may tell him so, with my compliments. You may also
+tell him, from me, that after abandoning his worldly goods and position
+to this butcherly mob, I wonder he is not at the head of them. But, no,
+gentlemen,” said Stryver, looking all round, and snapping his fingers,
+“I know something of human nature, and I tell you that you’ll never
+find a fellow like this fellow, trusting himself to the mercies of such
+precious _protégés_. No, gentlemen; he’ll always show ‘em a clean pair
+of heels very early in the scuffle, and sneak away.”
+
+With those words, and a final snap of his fingers, Mr. Stryver
+shouldered himself into Fleet-street, amidst the general approbation of
+his hearers. Mr. Lorry and Charles Darnay were left alone at the desk,
+in the general departure from the Bank.
+
+“Will you take charge of the letter?” said Mr. Lorry. “You know where to
+deliver it?”
+
+“I do.”
+
+“Will you undertake to explain, that we suppose it to have been
+addressed here, on the chance of our knowing where to forward it, and
+that it has been here some time?”
+
+“I will do so. Do you start for Paris from here?”
+
+“From here, at eight.”
+
+“I will come back, to see you off.”
+
+Very ill at ease with himself, and with Stryver and most other men,
+Darnay made the best of his way into the quiet of the Temple, opened the
+letter, and read it. These were its contents:
+
+
+“Prison of the Abbaye, Paris.
+
+“June 21, 1792. “MONSIEUR HERETOFORE THE MARQUIS.
+
+“After having long been in danger of my life at the hands of the
+village, I have been seized, with great violence and indignity, and
+brought a long journey on foot to Paris. On the road I have suffered a
+great deal. Nor is that all; my house has been destroyed--razed to the
+ground.
+
+“The crime for which I am imprisoned, Monsieur heretofore the Marquis,
+and for which I shall be summoned before the tribunal, and shall lose my
+life (without your so generous help), is, they tell me, treason against
+the majesty of the people, in that I have acted against them for an
+emigrant. It is in vain I represent that I have acted for them, and not
+against, according to your commands. It is in vain I represent that,
+before the sequestration of emigrant property, I had remitted the
+imposts they had ceased to pay; that I had collected no rent; that I had
+had recourse to no process. The only response is, that I have acted for
+an emigrant, and where is that emigrant?
+
+“Ah! most gracious Monsieur heretofore the Marquis, where is that
+emigrant? I cry in my sleep where is he? I demand of Heaven, will he
+not come to deliver me? No answer. Ah Monsieur heretofore the Marquis,
+I send my desolate cry across the sea, hoping it may perhaps reach your
+ears through the great bank of Tilson known at Paris!
+
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name, I supplicate you, Monsieur heretofore the Marquis, to
+succour and release me. My fault is, that I have been true to you. Oh
+Monsieur heretofore the Marquis, I pray you be you true to me!
+
+“From this prison here of horror, whence I every hour tend nearer and
+nearer to destruction, I send you, Monsieur heretofore the Marquis, the
+assurance of my dolorous and unhappy service.
+
+“Your afflicted,
+
+“Gabelle.”
+
+
+The latent uneasiness in Darnay’s mind was roused to vigourous life
+by this letter. The peril of an old servant and a good one, whose
+only crime was fidelity to himself and his family, stared him so
+reproachfully in the face, that, as he walked to and fro in the Temple
+considering what to do, he almost hid his face from the passersby.
+
+He knew very well, that in his horror of the deed which had culminated
+the bad deeds and bad reputation of the old family house, in his
+resentful suspicions of his uncle, and in the aversion with which his
+conscience regarded the crumbling fabric that he was supposed to uphold,
+he had acted imperfectly. He knew very well, that in his love for Lucie,
+his renunciation of his social place, though by no means new to his own
+mind, had been hurried and incomplete. He knew that he ought to have
+systematically worked it out and supervised it, and that he had meant to
+do it, and that it had never been done.
+
+The happiness of his own chosen English home, the necessity of being
+always actively employed, the swift changes and troubles of the time
+which had followed on one another so fast, that the events of this week
+annihilated the immature plans of last week, and the events of the week
+following made all new again; he knew very well, that to the force of
+these circumstances he had yielded:--not without disquiet, but still
+without continuous and accumulating resistance. That he had watched
+the times for a time of action, and that they had shifted and struggled
+until the time had gone by, and the nobility were trooping from
+France by every highway and byway, and their property was in course of
+confiscation and destruction, and their very names were blotting out,
+was as well known to himself as it could be to any new authority in
+France that might impeach him for it.
+
+But, he had oppressed no man, he had imprisoned no man; he was so
+far from having harshly exacted payment of his dues, that he had
+relinquished them of his own will, thrown himself on a world with no
+favour in it, won his own private place there, and earned his own
+bread. Monsieur Gabelle had held the impoverished and involved estate
+on written instructions, to spare the people, to give them what little
+there was to give--such fuel as the heavy creditors would let them have
+in the winter, and such produce as could be saved from the same grip in
+the summer--and no doubt he had put the fact in plea and proof, for his
+own safety, so that it could not but appear now.
+
+This favoured the desperate resolution Charles Darnay had begun to make,
+that he would go to Paris.
+
+Yes. Like the mariner in the old story, the winds and streams had driven
+him within the influence of the Loadstone Rock, and it was drawing him
+to itself, and he must go. Everything that arose before his mind drifted
+him on, faster and faster, more and more steadily, to the terrible
+attraction. His latent uneasiness had been, that bad aims were being
+worked out in his own unhappy land by bad instruments, and that he who
+could not fail to know that he was better than they, was not there,
+trying to do something to stay bloodshed, and assert the claims of mercy
+and humanity. With this uneasiness half stifled, and half reproaching
+him, he had been brought to the pointed comparison of himself with the
+brave old gentleman in whom duty was so strong; upon that comparison
+(injurious to himself) had instantly followed the sneers of Monseigneur,
+which had stung him bitterly, and those of Stryver, which above all were
+coarse and galling, for old reasons. Upon those, had followed Gabelle’s
+letter: the appeal of an innocent prisoner, in danger of death, to his
+justice, honour, and good name.
+
+His resolution was made. He must go to Paris.
+
+Yes. The Loadstone Rock was drawing him, and he must sail on, until he
+struck. He knew of no rock; he saw hardly any danger. The intention
+with which he had done what he had done, even although he had left
+it incomplete, presented it before him in an aspect that would be
+gratefully acknowledged in France on his presenting himself to assert
+it. Then, that glorious vision of doing good, which is so often the
+sanguine mirage of so many good minds, arose before him, and he even
+saw himself in the illusion with some influence to guide this raging
+Revolution that was running so fearfully wild.
+
+As he walked to and fro with his resolution made, he considered that
+neither Lucie nor her father must know of it until he was gone.
+Lucie should be spared the pain of separation; and her father, always
+reluctant to turn his thoughts towards the dangerous ground of old,
+should come to the knowledge of the step, as a step taken, and not in
+the balance of suspense and doubt. How much of the incompleteness of his
+situation was referable to her father, through the painful anxiety
+to avoid reviving old associations of France in his mind, he did not
+discuss with himself. But, that circumstance too, had had its influence
+in his course.
+
+He walked to and fro, with thoughts very busy, until it was time to
+return to Tellson’s and take leave of Mr. Lorry. As soon as he arrived
+in Paris he would present himself to this old friend, but he must say
+nothing of his intention now.
+
+A carriage with post-horses was ready at the Bank door, and Jerry was
+booted and equipped.
+
+“I have delivered that letter,” said Charles Darnay to Mr. Lorry. “I
+would not consent to your being charged with any written answer, but
+perhaps you will take a verbal one?”
+
+“That I will, and readily,” said Mr. Lorry, “if it is not dangerous.”
+
+“Not at all. Though it is to a prisoner in the Abbaye.”
+
+“What is his name?” said Mr. Lorry, with his open pocket-book in his
+hand.
+
+“Gabelle.”
+
+“Gabelle. And what is the message to the unfortunate Gabelle in prison?”
+
+“Simply, ‘that he has received the letter, and will come.’”
+
+“Any time mentioned?”
+
+“He will start upon his journey to-morrow night.”
+
+“Any person mentioned?”
+
+“No.”
+
+He helped Mr. Lorry to wrap himself in a number of coats and cloaks,
+and went out with him from the warm atmosphere of the old Bank, into the
+misty air of Fleet-street. “My love to Lucie, and to little Lucie,” said
+Mr. Lorry at parting, “and take precious care of them till I come back.”
+ Charles Darnay shook his head and doubtfully smiled, as the carriage
+rolled away.
+
+That night--it was the fourteenth of August--he sat up late, and wrote
+two fervent letters; one was to Lucie, explaining the strong obligation
+he was under to go to Paris, and showing her, at length, the reasons
+that he had, for feeling confident that he could become involved in no
+personal danger there; the other was to the Doctor, confiding Lucie and
+their dear child to his care, and dwelling on the same topics with the
+strongest assurances. To both, he wrote that he would despatch letters
+in proof of his safety, immediately after his arrival.
+
+It was a hard day, that day of being among them, with the first
+reservation of their joint lives on his mind. It was a hard matter to
+preserve the innocent deceit of which they were profoundly unsuspicious.
+But, an affectionate glance at his wife, so happy and busy, made him
+resolute not to tell her what impended (he had been half moved to do it,
+so strange it was to him to act in anything without her quiet aid), and
+the day passed quickly. Early in the evening he embraced her, and her
+scarcely less dear namesake, pretending that he would return by-and-bye
+(an imaginary engagement took him out, and he had secreted a valise
+of clothes ready), and so he emerged into the heavy mist of the heavy
+streets, with a heavier heart.
+
+The unseen force was drawing him fast to itself, now, and all the tides
+and winds were setting straight and strong towards it. He left his
+two letters with a trusty porter, to be delivered half an hour before
+midnight, and no sooner; took horse for Dover; and began his journey.
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name!” was the poor prisoner’s cry with which he strengthened
+his sinking heart, as he left all that was dear on earth behind him, and
+floated away for the Loadstone Rock.
+
+
+The end of the second book.
+
+
+
+
+
+Book the Third--the Track of a Storm
+
+
+
+
+I. In Secret
+
+
+The traveller fared slowly on his way, who fared towards Paris from
+England in the autumn of the year one thousand seven hundred and
+ninety-two. More than enough of bad roads, bad equipages, and bad
+horses, he would have encountered to delay him, though the fallen and
+unfortunate King of France had been upon his throne in all his glory;
+but, the changed times were fraught with other obstacles than
+these. Every town-gate and village taxing-house had its band of
+citizen-patriots, with their national muskets in a most explosive state
+of readiness, who stopped all comers and goers, cross-questioned them,
+inspected their papers, looked for their names in lists of their own,
+turned them back, or sent them on, or stopped them and laid them in
+hold, as their capricious judgment or fancy deemed best for the dawning
+Republic One and Indivisible, of Liberty, Equality, Fraternity, or
+Death.
+
+A very few French leagues of his journey were accomplished, when Charles
+Darnay began to perceive that for him along these country roads there
+was no hope of return until he should have been declared a good citizen
+at Paris. Whatever might befall now, he must on to his journey’s end.
+Not a mean village closed upon him, not a common barrier dropped across
+the road behind him, but he knew it to be another iron door in
+the series that was barred between him and England. The universal
+watchfulness so encompassed him, that if he had been taken in a net,
+or were being forwarded to his destination in a cage, he could not have
+felt his freedom more completely gone.
+
+This universal watchfulness not only stopped him on the highway twenty
+times in a stage, but retarded his progress twenty times in a day, by
+riding after him and taking him back, riding before him and stopping him
+by anticipation, riding with him and keeping him in charge. He had been
+days upon his journey in France alone, when he went to bed tired out, in
+a little town on the high road, still a long way from Paris.
+
+Nothing but the production of the afflicted Gabelle’s letter from his
+prison of the Abbaye would have got him on so far. His difficulty at the
+guard-house in this small place had been such, that he felt his journey
+to have come to a crisis. And he was, therefore, as little surprised as
+a man could be, to find himself awakened at the small inn to which he
+had been remitted until morning, in the middle of the night.
+
+Awakened by a timid local functionary and three armed patriots in rough
+red caps and with pipes in their mouths, who sat down on the bed.
+
+“Emigrant,” said the functionary, “I am going to send you on to Paris,
+under an escort.”
+
+“Citizen, I desire nothing more than to get to Paris, though I could
+dispense with the escort.”
+
+“Silence!” growled a red-cap, striking at the coverlet with the butt-end
+of his musket. “Peace, aristocrat!”
+
+“It is as the good patriot says,” observed the timid functionary. “You
+are an aristocrat, and must have an escort--and must pay for it.”
+
+“I have no choice,” said Charles Darnay.
+
+“Choice! Listen to him!” cried the same scowling red-cap. “As if it was
+not a favour to be protected from the lamp-iron!”
+
+“It is always as the good patriot says,” observed the functionary. “Rise
+and dress yourself, emigrant.”
+
+Darnay complied, and was taken back to the guard-house, where other
+patriots in rough red caps were smoking, drinking, and sleeping, by
+a watch-fire. Here he paid a heavy price for his escort, and hence he
+started with it on the wet, wet roads at three o’clock in the morning.
+
+The escort were two mounted patriots in red caps and tri-coloured
+cockades, armed with national muskets and sabres, who rode one on either
+side of him.
+
+The escorted governed his own horse, but a loose line was attached to
+his bridle, the end of which one of the patriots kept girded round his
+wrist. In this state they set forth with the sharp rain driving in their
+faces: clattering at a heavy dragoon trot over the uneven town pavement,
+and out upon the mire-deep roads. In this state they traversed without
+change, except of horses and pace, all the mire-deep leagues that lay
+between them and the capital.
+
+They travelled in the night, halting an hour or two after daybreak, and
+lying by until the twilight fell. The escort were so wretchedly clothed,
+that they twisted straw round their bare legs, and thatched their ragged
+shoulders to keep the wet off. Apart from the personal discomfort of
+being so attended, and apart from such considerations of present danger
+as arose from one of the patriots being chronically drunk, and carrying
+his musket very recklessly, Charles Darnay did not allow the restraint
+that was laid upon him to awaken any serious fears in his breast; for,
+he reasoned with himself that it could have no reference to the merits
+of an individual case that was not yet stated, and of representations,
+confirmable by the prisoner in the Abbaye, that were not yet made.
+
+But when they came to the town of Beauvais--which they did at eventide,
+when the streets were filled with people--he could not conceal from
+himself that the aspect of affairs was very alarming. An ominous crowd
+gathered to see him dismount of the posting-yard, and many voices called
+out loudly, “Down with the emigrant!”
+
+He stopped in the act of swinging himself out of his saddle, and,
+resuming it as his safest place, said:
+
+“Emigrant, my friends! Do you not see me here, in France, of my own
+will?”
+
+“You are a cursed emigrant,” cried a farrier, making at him in a
+furious manner through the press, hammer in hand; “and you are a cursed
+aristocrat!”
+
+The postmaster interposed himself between this man and the rider’s
+bridle (at which he was evidently making), and soothingly said, “Let him
+be; let him be! He will be judged at Paris.”
+
+“Judged!” repeated the farrier, swinging his hammer. “Ay! and condemned
+as a traitor.” At this the crowd roared approval.
+
+Checking the postmaster, who was for turning his horse’s head to the
+yard (the drunken patriot sat composedly in his saddle looking on, with
+the line round his wrist), Darnay said, as soon as he could make his
+voice heard:
+
+“Friends, you deceive yourselves, or you are deceived. I am not a
+traitor.”
+
+“He lies!” cried the smith. “He is a traitor since the decree. His life
+is forfeit to the people. His cursed life is not his own!”
+
+At the instant when Darnay saw a rush in the eyes of the crowd, which
+another instant would have brought upon him, the postmaster turned his
+horse into the yard, the escort rode in close upon his horse’s flanks,
+and the postmaster shut and barred the crazy double gates. The farrier
+struck a blow upon them with his hammer, and the crowd groaned; but, no
+more was done.
+
+“What is this decree that the smith spoke of?” Darnay asked the
+postmaster, when he had thanked him, and stood beside him in the yard.
+
+“Truly, a decree for selling the property of emigrants.”
+
+“When passed?”
+
+“On the fourteenth.”
+
+“The day I left England!”
+
+“Everybody says it is but one of several, and that there will be
+others--if there are not already--banishing all emigrants, and
+condemning all to death who return. That is what he meant when he said
+your life was not your own.”
+
+“But there are no such decrees yet?”
+
+“What do I know!” said the postmaster, shrugging his shoulders; “there
+may be, or there will be. It is all the same. What would you have?”
+
+They rested on some straw in a loft until the middle of the night, and
+then rode forward again when all the town was asleep. Among the many
+wild changes observable on familiar things which made this wild ride
+unreal, not the least was the seeming rarity of sleep. After long and
+lonely spurring over dreary roads, they would come to a cluster of poor
+cottages, not steeped in darkness, but all glittering with lights, and
+would find the people, in a ghostly manner in the dead of the night,
+circling hand in hand round a shrivelled tree of Liberty, or all drawn
+up together singing a Liberty song. Happily, however, there was sleep in
+Beauvais that night to help them out of it and they passed on once more
+into solitude and loneliness: jingling through the untimely cold and
+wet, among impoverished fields that had yielded no fruits of the earth
+that year, diversified by the blackened remains of burnt houses, and by
+the sudden emergence from ambuscade, and sharp reining up across their
+way, of patriot patrols on the watch on all the roads.
+
+Daylight at last found them before the wall of Paris. The barrier was
+closed and strongly guarded when they rode up to it.
+
+“Where are the papers of this prisoner?” demanded a resolute-looking man
+in authority, who was summoned out by the guard.
+
+Naturally struck by the disagreeable word, Charles Darnay requested the
+speaker to take notice that he was a free traveller and French citizen,
+in charge of an escort which the disturbed state of the country had
+imposed upon him, and which he had paid for.
+
+“Where,” repeated the same personage, without taking any heed of him
+whatever, “are the papers of this prisoner?”
+
+The drunken patriot had them in his cap, and produced them. Casting his
+eyes over Gabelle’s letter, the same personage in authority showed some
+disorder and surprise, and looked at Darnay with a close attention.
+
+He left escort and escorted without saying a word, however, and went
+into the guard-room; meanwhile, they sat upon their horses outside the
+gate. Looking about him while in this state of suspense, Charles
+Darnay observed that the gate was held by a mixed guard of soldiers and
+patriots, the latter far outnumbering the former; and that while ingress
+into the city for peasants’ carts bringing in supplies, and for similar
+traffic and traffickers, was easy enough, egress, even for the homeliest
+people, was very difficult. A numerous medley of men and women, not
+to mention beasts and vehicles of various sorts, was waiting to issue
+forth; but, the previous identification was so strict, that they
+filtered through the barrier very slowly. Some of these people knew
+their turn for examination to be so far off, that they lay down on the
+ground to sleep or smoke, while others talked together, or loitered
+about. The red cap and tri-colour cockade were universal, both among men
+and women.
+
+When he had sat in his saddle some half-hour, taking note of these
+things, Darnay found himself confronted by the same man in authority,
+who directed the guard to open the barrier. Then he delivered to the
+escort, drunk and sober, a receipt for the escorted, and requested him
+to dismount. He did so, and the two patriots, leading his tired horse,
+turned and rode away without entering the city.
+
+He accompanied his conductor into a guard-room, smelling of common wine
+and tobacco, where certain soldiers and patriots, asleep and awake,
+drunk and sober, and in various neutral states between sleeping and
+waking, drunkenness and sobriety, were standing and lying about. The
+light in the guard-house, half derived from the waning oil-lamps of
+the night, and half from the overcast day, was in a correspondingly
+uncertain condition. Some registers were lying open on a desk, and an
+officer of a coarse, dark aspect, presided over these.
+
+“Citizen Defarge,” said he to Darnay’s conductor, as he took a slip of
+paper to write on. “Is this the emigrant Evremonde?”
+
+“This is the man.”
+
+“Your age, Evremonde?”
+
+“Thirty-seven.”
+
+“Married, Evremonde?”
+
+“Yes.”
+
+“Where married?”
+
+“In England.”
+
+“Without doubt. Where is your wife, Evremonde?”
+
+“In England.”
+
+“Without doubt. You are consigned, Evremonde, to the prison of La
+Force.”
+
+“Just Heaven!” exclaimed Darnay. “Under what law, and for what offence?”
+
+The officer looked up from his slip of paper for a moment.
+
+“We have new laws, Evremonde, and new offences, since you were here.” He
+said it with a hard smile, and went on writing.
+
+“I entreat you to observe that I have come here voluntarily, in response
+to that written appeal of a fellow-countryman which lies before you. I
+demand no more than the opportunity to do so without delay. Is not that
+my right?”
+
+“Emigrants have no rights, Evremonde,” was the stolid reply. The officer
+wrote until he had finished, read over to himself what he had written,
+sanded it, and handed it to Defarge, with the words “In secret.”
+
+Defarge motioned with the paper to the prisoner that he must accompany
+him. The prisoner obeyed, and a guard of two armed patriots attended
+them.
+
+“Is it you,” said Defarge, in a low voice, as they went down the
+guardhouse steps and turned into Paris, “who married the daughter of
+Doctor Manette, once a prisoner in the Bastille that is no more?”
+
+“Yes,” replied Darnay, looking at him with surprise.
+
+“My name is Defarge, and I keep a wine-shop in the Quarter Saint
+Antoine. Possibly you have heard of me.”
+
+“My wife came to your house to reclaim her father? Yes!”
+
+The word “wife” seemed to serve as a gloomy reminder to Defarge, to say
+with sudden impatience, “In the name of that sharp female newly-born,
+and called La Guillotine, why did you come to France?”
+
+“You heard me say why, a minute ago. Do you not believe it is the
+truth?”
+
+“A bad truth for you,” said Defarge, speaking with knitted brows, and
+looking straight before him.
+
+“Indeed I am lost here. All here is so unprecedented, so changed, so
+sudden and unfair, that I am absolutely lost. Will you render me a
+little help?”
+
+“None.” Defarge spoke, always looking straight before him.
+
+“Will you answer me a single question?”
+
+“Perhaps. According to its nature. You can say what it is.”
+
+“In this prison that I am going to so unjustly, shall I have some free
+communication with the world outside?”
+
+“You will see.”
+
+“I am not to be buried there, prejudged, and without any means of
+presenting my case?”
+
+“You will see. But, what then? Other people have been similarly buried
+in worse prisons, before now.”
+
+“But never by me, Citizen Defarge.”
+
+Defarge glanced darkly at him for answer, and walked on in a steady
+and set silence. The deeper he sank into this silence, the fainter hope
+there was--or so Darnay thought--of his softening in any slight degree.
+He, therefore, made haste to say:
+
+“It is of the utmost importance to me (you know, Citizen, even better
+than I, of how much importance), that I should be able to communicate to
+Mr. Lorry of Tellson’s Bank, an English gentleman who is now in Paris,
+the simple fact, without comment, that I have been thrown into the
+prison of La Force. Will you cause that to be done for me?”
+
+“I will do,” Defarge doggedly rejoined, “nothing for you. My duty is to
+my country and the People. I am the sworn servant of both, against you.
+I will do nothing for you.”
+
+Charles Darnay felt it hopeless to entreat him further, and his pride
+was touched besides. As they walked on in silence, he could not but see
+how used the people were to the spectacle of prisoners passing along the
+streets. The very children scarcely noticed him. A few passers turned
+their heads, and a few shook their fingers at him as an aristocrat;
+otherwise, that a man in good clothes should be going to prison, was no
+more remarkable than that a labourer in working clothes should be
+going to work. In one narrow, dark, and dirty street through which they
+passed, an excited orator, mounted on a stool, was addressing an excited
+audience on the crimes against the people, of the king and the royal
+family. The few words that he caught from this man’s lips, first made
+it known to Charles Darnay that the king was in prison, and that the
+foreign ambassadors had one and all left Paris. On the road (except at
+Beauvais) he had heard absolutely nothing. The escort and the universal
+watchfulness had completely isolated him.
+
+That he had fallen among far greater dangers than those which had
+developed themselves when he left England, he of course knew now. That
+perils had thickened about him fast, and might thicken faster and faster
+yet, he of course knew now. He could not but admit to himself that he
+might not have made this journey, if he could have foreseen the events
+of a few days. And yet his misgivings were not so dark as, imagined by
+the light of this later time, they would appear. Troubled as the future
+was, it was the unknown future, and in its obscurity there was ignorant
+hope. The horrible massacre, days and nights long, which, within a few
+rounds of the clock, was to set a great mark of blood upon the blessed
+garnering time of harvest, was as far out of his knowledge as if it had
+been a hundred thousand years away. The “sharp female newly-born, and
+called La Guillotine,” was hardly known to him, or to the generality
+of people, by name. The frightful deeds that were to be soon done, were
+probably unimagined at that time in the brains of the doers. How could
+they have a place in the shadowy conceptions of a gentle mind?
+
+Of unjust treatment in detention and hardship, and in cruel separation
+from his wife and child, he foreshadowed the likelihood, or the
+certainty; but, beyond this, he dreaded nothing distinctly. With this on
+his mind, which was enough to carry into a dreary prison courtyard, he
+arrived at the prison of La Force.
+
+A man with a bloated face opened the strong wicket, to whom Defarge
+presented “The Emigrant Evremonde.”
+
+“What the Devil! How many more of them!” exclaimed the man with the
+bloated face.
+
+Defarge took his receipt without noticing the exclamation, and withdrew,
+with his two fellow-patriots.
+
+“What the Devil, I say again!” exclaimed the gaoler, left with his wife.
+“How many more!”
+
+The gaoler’s wife, being provided with no answer to the question, merely
+replied, “One must have patience, my dear!” Three turnkeys who entered
+responsive to a bell she rang, echoed the sentiment, and one added, “For
+the love of Liberty;” which sounded in that place like an inappropriate
+conclusion.
+
+The prison of La Force was a gloomy prison, dark and filthy, and with a
+horrible smell of foul sleep in it. Extraordinary how soon the noisome
+flavour of imprisoned sleep, becomes manifest in all such places that
+are ill cared for!
+
+“In secret, too,” grumbled the gaoler, looking at the written paper. “As
+if I was not already full to bursting!”
+
+He stuck the paper on a file, in an ill-humour, and Charles Darnay
+awaited his further pleasure for half an hour: sometimes, pacing to and
+fro in the strong arched room: sometimes, resting on a stone seat: in
+either case detained to be imprinted on the memory of the chief and his
+subordinates.
+
+“Come!” said the chief, at length taking up his keys, “come with me,
+emigrant.”
+
+Through the dismal prison twilight, his new charge accompanied him by
+corridor and staircase, many doors clanging and locking behind them,
+until they came into a large, low, vaulted chamber, crowded with
+prisoners of both sexes. The women were seated at a long table, reading
+and writing, knitting, sewing, and embroidering; the men were for the
+most part standing behind their chairs, or lingering up and down the
+room.
+
+In the instinctive association of prisoners with shameful crime and
+disgrace, the new-comer recoiled from this company. But the crowning
+unreality of his long unreal ride, was, their all at once rising to
+receive him, with every refinement of manner known to the time, and with
+all the engaging graces and courtesies of life.
+
+So strangely clouded were these refinements by the prison manners and
+gloom, so spectral did they become in the inappropriate squalor and
+misery through which they were seen, that Charles Darnay seemed to stand
+in a company of the dead. Ghosts all! The ghost of beauty, the ghost
+of stateliness, the ghost of elegance, the ghost of pride, the ghost of
+frivolity, the ghost of wit, the ghost of youth, the ghost of age, all
+waiting their dismissal from the desolate shore, all turning on him eyes
+that were changed by the death they had died in coming there.
+
+It struck him motionless. The gaoler standing at his side, and the other
+gaolers moving about, who would have been well enough as to appearance
+in the ordinary exercise of their functions, looked so extravagantly
+coarse contrasted with sorrowing mothers and blooming daughters who were
+there--with the apparitions of the coquette, the young beauty, and the
+mature woman delicately bred--that the inversion of all experience and
+likelihood which the scene of shadows presented, was heightened to its
+utmost. Surely, ghosts all. Surely, the long unreal ride some progress
+of disease that had brought him to these gloomy shades!
+
+“In the name of the assembled companions in misfortune,” said a
+gentleman of courtly appearance and address, coming forward, “I have the
+honour of giving you welcome to La Force, and of condoling with you
+on the calamity that has brought you among us. May it soon terminate
+happily! It would be an impertinence elsewhere, but it is not so here,
+to ask your name and condition?”
+
+Charles Darnay roused himself, and gave the required information, in
+words as suitable as he could find.
+
+“But I hope,” said the gentleman, following the chief gaoler with his
+eyes, who moved across the room, “that you are not in secret?”
+
+“I do not understand the meaning of the term, but I have heard them say
+so.”
+
+“Ah, what a pity! We so much regret it! But take courage; several
+members of our society have been in secret, at first, and it has lasted
+but a short time.” Then he added, raising his voice, “I grieve to inform
+the society--in secret.”
+
+There was a murmur of commiseration as Charles Darnay crossed the room
+to a grated door where the gaoler awaited him, and many voices--among
+which, the soft and compassionate voices of women were conspicuous--gave
+him good wishes and encouragement. He turned at the grated door, to
+render the thanks of his heart; it closed under the gaoler’s hand; and
+the apparitions vanished from his sight forever.
+
+The wicket opened on a stone staircase, leading upward. When they had
+ascended forty steps (the prisoner of half an hour already counted
+them), the gaoler opened a low black door, and they passed into a
+solitary cell. It struck cold and damp, but was not dark.
+
+“Yours,” said the gaoler.
+
+“Why am I confined alone?”
+
+“How do I know!”
+
+“I can buy pen, ink, and paper?”
+
+“Such are not my orders. You will be visited, and can ask then. At
+present, you may buy your food, and nothing more.”
+
+There were in the cell, a chair, a table, and a straw mattress. As
+the gaoler made a general inspection of these objects, and of the four
+walls, before going out, a wandering fancy wandered through the mind of
+the prisoner leaning against the wall opposite to him, that this gaoler
+was so unwholesomely bloated, both in face and person, as to look like
+a man who had been drowned and filled with water. When the gaoler was
+gone, he thought in the same wandering way, “Now am I left, as if I were
+dead.” Stopping then, to look down at the mattress, he turned from it
+with a sick feeling, and thought, “And here in these crawling creatures
+is the first condition of the body after death.”
+
+“Five paces by four and a half, five paces by four and a half, five
+paces by four and a half.” The prisoner walked to and fro in his cell,
+counting its measurement, and the roar of the city arose like muffled
+drums with a wild swell of voices added to them. “He made shoes, he made
+shoes, he made shoes.” The prisoner counted the measurement again, and
+paced faster, to draw his mind with him from that latter repetition.
+“The ghosts that vanished when the wicket closed. There was one among
+them, the appearance of a lady dressed in black, who was leaning in the
+embrasure of a window, and she had a light shining upon her golden
+hair, and she looked like * * * * Let us ride on again, for God’s sake,
+through the illuminated villages with the people all awake! * * * * He
+made shoes, he made shoes, he made shoes. * * * * Five paces by four and
+a half.” With such scraps tossing and rolling upward from the depths of
+his mind, the prisoner walked faster and faster, obstinately counting
+and counting; and the roar of the city changed to this extent--that it
+still rolled in like muffled drums, but with the wail of voices that he
+knew, in the swell that rose above them.
+
+
+
+
+II. The Grindstone
+
+
+Tellson’s Bank, established in the Saint Germain Quarter of Paris, was
+in a wing of a large house, approached by a courtyard and shut off from
+the street by a high wall and a strong gate. The house belonged to
+a great nobleman who had lived in it until he made a flight from the
+troubles, in his own cook’s dress, and got across the borders. A
+mere beast of the chase flying from hunters, he was still in his
+metempsychosis no other than the same Monseigneur, the preparation
+of whose chocolate for whose lips had once occupied three strong men
+besides the cook in question.
+
+Monseigneur gone, and the three strong men absolving themselves from the
+sin of having drawn his high wages, by being more than ready and
+willing to cut his throat on the altar of the dawning Republic one and
+indivisible of Liberty, Equality, Fraternity, or Death, Monseigneur’s
+house had been first sequestrated, and then confiscated. For, all
+things moved so fast, and decree followed decree with that fierce
+precipitation, that now upon the third night of the autumn month
+of September, patriot emissaries of the law were in possession of
+Monseigneur’s house, and had marked it with the tri-colour, and were
+drinking brandy in its state apartments.
+
+A place of business in London like Tellson’s place of business in Paris,
+would soon have driven the House out of its mind and into the Gazette.
+For, what would staid British responsibility and respectability have
+said to orange-trees in boxes in a Bank courtyard, and even to a Cupid
+over the counter? Yet such things were. Tellson’s had whitewashed the
+Cupid, but he was still to be seen on the ceiling, in the coolest
+linen, aiming (as he very often does) at money from morning to
+night. Bankruptcy must inevitably have come of this young Pagan, in
+Lombard-street, London, and also of a curtained alcove in the rear of
+the immortal boy, and also of a looking-glass let into the wall, and
+also of clerks not at all old, who danced in public on the slightest
+provocation. Yet, a French Tellson’s could get on with these things
+exceedingly well, and, as long as the times held together, no man had
+taken fright at them, and drawn out his money.
+
+What money would be drawn out of Tellson’s henceforth, and what would
+lie there, lost and forgotten; what plate and jewels would tarnish in
+Tellson’s hiding-places, while the depositors rusted in prisons,
+and when they should have violently perished; how many accounts with
+Tellson’s never to be balanced in this world, must be carried over into
+the next; no man could have said, that night, any more than Mr. Jarvis
+Lorry could, though he thought heavily of these questions. He sat by
+a newly-lighted wood fire (the blighted and unfruitful year was
+prematurely cold), and on his honest and courageous face there was a
+deeper shade than the pendent lamp could throw, or any object in the
+room distortedly reflect--a shade of horror.
+
+He occupied rooms in the Bank, in his fidelity to the House of which
+he had grown to be a part, like strong root-ivy. It chanced that they
+derived a kind of security from the patriotic occupation of the main
+building, but the true-hearted old gentleman never calculated about
+that. All such circumstances were indifferent to him, so that he did
+his duty. On the opposite side of the courtyard, under a colonnade,
+was extensive standing--for carriages--where, indeed, some carriages
+of Monseigneur yet stood. Against two of the pillars were fastened two
+great flaring flambeaux, and in the light of these, standing out in the
+open air, was a large grindstone: a roughly mounted thing which appeared
+to have hurriedly been brought there from some neighbouring smithy,
+or other workshop. Rising and looking out of window at these harmless
+objects, Mr. Lorry shivered, and retired to his seat by the fire. He had
+opened, not only the glass window, but the lattice blind outside it, and
+he had closed both again, and he shivered through his frame.
+
+From the streets beyond the high wall and the strong gate, there came
+the usual night hum of the city, with now and then an indescribable ring
+in it, weird and unearthly, as if some unwonted sounds of a terrible
+nature were going up to Heaven.
+
+“Thank God,” said Mr. Lorry, clasping his hands, “that no one near and
+dear to me is in this dreadful town to-night. May He have mercy on all
+who are in danger!”
+
+Soon afterwards, the bell at the great gate sounded, and he thought,
+“They have come back!” and sat listening. But, there was no loud
+irruption into the courtyard, as he had expected, and he heard the gate
+clash again, and all was quiet.
+
+The nervousness and dread that were upon him inspired that vague
+uneasiness respecting the Bank, which a great change would naturally
+awaken, with such feelings roused. It was well guarded, and he got up to
+go among the trusty people who were watching it, when his door suddenly
+opened, and two figures rushed in, at sight of which he fell back in
+amazement.
+
+Lucie and her father! Lucie with her arms stretched out to him, and with
+that old look of earnestness so concentrated and intensified, that it
+seemed as though it had been stamped upon her face expressly to give
+force and power to it in this one passage of her life.
+
+“What is this?” cried Mr. Lorry, breathless and confused. “What is the
+matter? Lucie! Manette! What has happened? What has brought you here?
+What is it?”
+
+With the look fixed upon him, in her paleness and wildness, she panted
+out in his arms, imploringly, “O my dear friend! My husband!”
+
+“Your husband, Lucie?”
+
+“Charles.”
+
+“What of Charles?”
+
+“Here.
+
+“Here, in Paris?”
+
+“Has been here some days--three or four--I don’t know how many--I can’t
+collect my thoughts. An errand of generosity brought him here unknown to
+us; he was stopped at the barrier, and sent to prison.”
+
+The old man uttered an irrepressible cry. Almost at the same moment, the
+bell of the great gate rang again, and a loud noise of feet and voices
+came pouring into the courtyard.
+
+“What is that noise?” said the Doctor, turning towards the window.
+
+“Don’t look!” cried Mr. Lorry. “Don’t look out! Manette, for your life,
+don’t touch the blind!”
+
+The Doctor turned, with his hand upon the fastening of the window, and
+said, with a cool, bold smile:
+
+“My dear friend, I have a charmed life in this city. I have been
+a Bastille prisoner. There is no patriot in Paris--in Paris? In
+France--who, knowing me to have been a prisoner in the Bastille, would
+touch me, except to overwhelm me with embraces, or carry me in triumph.
+My old pain has given me a power that has brought us through the
+barrier, and gained us news of Charles there, and brought us here. I
+knew it would be so; I knew I could help Charles out of all danger; I
+told Lucie so.--What is that noise?” His hand was again upon the window.
+
+“Don’t look!” cried Mr. Lorry, absolutely desperate. “No, Lucie, my
+dear, nor you!” He got his arm round her, and held her. “Don’t be so
+terrified, my love. I solemnly swear to you that I know of no harm
+having happened to Charles; that I had no suspicion even of his being in
+this fatal place. What prison is he in?”
+
+“La Force!”
+
+“La Force! Lucie, my child, if ever you were brave and serviceable in
+your life--and you were always both--you will compose yourself now, to
+do exactly as I bid you; for more depends upon it than you can think, or
+I can say. There is no help for you in any action on your part to-night;
+you cannot possibly stir out. I say this, because what I must bid you
+to do for Charles’s sake, is the hardest thing to do of all. You must
+instantly be obedient, still, and quiet. You must let me put you in a
+room at the back here. You must leave your father and me alone for
+two minutes, and as there are Life and Death in the world you must not
+delay.”
+
+“I will be submissive to you. I see in your face that you know I can do
+nothing else than this. I know you are true.”
+
+The old man kissed her, and hurried her into his room, and turned the
+key; then, came hurrying back to the Doctor, and opened the window and
+partly opened the blind, and put his hand upon the Doctor’s arm, and
+looked out with him into the courtyard.
+
+Looked out upon a throng of men and women: not enough in number, or near
+enough, to fill the courtyard: not more than forty or fifty in all. The
+people in possession of the house had let them in at the gate, and they
+had rushed in to work at the grindstone; it had evidently been set up
+there for their purpose, as in a convenient and retired spot.
+
+But, such awful workers, and such awful work!
+
+The grindstone had a double handle, and, turning at it madly were two
+men, whose faces, as their long hair flapped back when the whirlings of
+the grindstone brought their faces up, were more horrible and cruel than
+the visages of the wildest savages in their most barbarous disguise.
+False eyebrows and false moustaches were stuck upon them, and their
+hideous countenances were all bloody and sweaty, and all awry with
+howling, and all staring and glaring with beastly excitement and want of
+sleep. As these ruffians turned and turned, their matted locks now flung
+forward over their eyes, now flung backward over their necks, some women
+held wine to their mouths that they might drink; and what with dropping
+blood, and what with dropping wine, and what with the stream of sparks
+struck out of the stone, all their wicked atmosphere seemed gore and
+fire. The eye could not detect one creature in the group free from
+the smear of blood. Shouldering one another to get next at the
+sharpening-stone, were men stripped to the waist, with the stain all
+over their limbs and bodies; men in all sorts of rags, with the stain
+upon those rags; men devilishly set off with spoils of women’s lace
+and silk and ribbon, with the stain dyeing those trifles through
+and through. Hatchets, knives, bayonets, swords, all brought to be
+sharpened, were all red with it. Some of the hacked swords were tied to
+the wrists of those who carried them, with strips of linen and fragments
+of dress: ligatures various in kind, but all deep of the one colour. And
+as the frantic wielders of these weapons snatched them from the stream
+of sparks and tore away into the streets, the same red hue was red in
+their frenzied eyes;--eyes which any unbrutalised beholder would have
+given twenty years of life, to petrify with a well-directed gun.
+
+All this was seen in a moment, as the vision of a drowning man, or of
+any human creature at any very great pass, could see a world if it
+were there. They drew back from the window, and the Doctor looked for
+explanation in his friend’s ashy face.
+
+“They are,” Mr. Lorry whispered the words, glancing fearfully round at
+the locked room, “murdering the prisoners. If you are sure of what you
+say; if you really have the power you think you have--as I believe you
+have--make yourself known to these devils, and get taken to La Force. It
+may be too late, I don’t know, but let it not be a minute later!”
+
+Doctor Manette pressed his hand, hastened bareheaded out of the room,
+and was in the courtyard when Mr. Lorry regained the blind.
+
+His streaming white hair, his remarkable face, and the impetuous
+confidence of his manner, as he put the weapons aside like water,
+carried him in an instant to the heart of the concourse at the stone.
+For a few moments there was a pause, and a hurry, and a murmur, and
+the unintelligible sound of his voice; and then Mr. Lorry saw him,
+surrounded by all, and in the midst of a line of twenty men long, all
+linked shoulder to shoulder, and hand to shoulder, hurried out with
+cries of--“Live the Bastille prisoner! Help for the Bastille prisoner’s
+kindred in La Force! Room for the Bastille prisoner in front there! Save
+the prisoner Evremonde at La Force!” and a thousand answering shouts.
+
+He closed the lattice again with a fluttering heart, closed the window
+and the curtain, hastened to Lucie, and told her that her father was
+assisted by the people, and gone in search of her husband. He found
+her child and Miss Pross with her; but, it never occurred to him to be
+surprised by their appearance until a long time afterwards, when he sat
+watching them in such quiet as the night knew.
+
+Lucie had, by that time, fallen into a stupor on the floor at his feet,
+clinging to his hand. Miss Pross had laid the child down on his own
+bed, and her head had gradually fallen on the pillow beside her pretty
+charge. O the long, long night, with the moans of the poor wife! And O
+the long, long night, with no return of her father and no tidings!
+
+Twice more in the darkness the bell at the great gate sounded, and the
+irruption was repeated, and the grindstone whirled and spluttered.
+“What is it?” cried Lucie, affrighted. “Hush! The soldiers’ swords are
+sharpened there,” said Mr. Lorry. “The place is national property now,
+and used as a kind of armoury, my love.”
+
+Twice more in all; but, the last spell of work was feeble and fitful.
+Soon afterwards the day began to dawn, and he softly detached himself
+from the clasping hand, and cautiously looked out again. A man, so
+besmeared that he might have been a sorely wounded soldier creeping back
+to consciousness on a field of slain, was rising from the pavement by
+the side of the grindstone, and looking about him with a vacant air.
+Shortly, this worn-out murderer descried in the imperfect light one of
+the carriages of Monseigneur, and, staggering to that gorgeous vehicle,
+climbed in at the door, and shut himself up to take his rest on its
+dainty cushions.
+
+The great grindstone, Earth, had turned when Mr. Lorry looked out again,
+and the sun was red on the courtyard. But, the lesser grindstone stood
+alone there in the calm morning air, with a red upon it that the sun had
+never given, and would never take away.
+
+
+
+
+III. The Shadow
+
+
+One of the first considerations which arose in the business mind of Mr.
+Lorry when business hours came round, was this:--that he had no right to
+imperil Tellson’s by sheltering the wife of an emigrant prisoner under
+the Bank roof. His own possessions, safety, life, he would have hazarded
+for Lucie and her child, without a moment’s demur; but the great trust
+he held was not his own, and as to that business charge he was a strict
+man of business.
+
+At first, his mind reverted to Defarge, and he thought of finding out
+the wine-shop again and taking counsel with its master in reference to
+the safest dwelling-place in the distracted state of the city. But, the
+same consideration that suggested him, repudiated him; he lived in the
+most violent Quarter, and doubtless was influential there, and deep in
+its dangerous workings.
+
+Noon coming, and the Doctor not returning, and every minute’s delay
+tending to compromise Tellson’s, Mr. Lorry advised with Lucie. She said
+that her father had spoken of hiring a lodging for a short term, in that
+Quarter, near the Banking-house. As there was no business objection to
+this, and as he foresaw that even if it were all well with Charles, and
+he were to be released, he could not hope to leave the city, Mr. Lorry
+went out in quest of such a lodging, and found a suitable one, high up
+in a removed by-street where the closed blinds in all the other windows
+of a high melancholy square of buildings marked deserted homes.
+
+To this lodging he at once removed Lucie and her child, and Miss Pross:
+giving them what comfort he could, and much more than he had himself.
+He left Jerry with them, as a figure to fill a doorway that would bear
+considerable knocking on the head, and returned to his own occupations.
+A disturbed and doleful mind he brought to bear upon them, and slowly
+and heavily the day lagged on with him.
+
+It wore itself out, and wore him out with it, until the Bank closed. He
+was again alone in his room of the previous night, considering what to
+do next, when he heard a foot upon the stair. In a few moments, a
+man stood in his presence, who, with a keenly observant look at him,
+addressed him by his name.
+
+“Your servant,” said Mr. Lorry. “Do you know me?”
+
+He was a strongly made man with dark curling hair, from forty-five
+to fifty years of age. For answer he repeated, without any change of
+emphasis, the words:
+
+“Do you know me?”
+
+“I have seen you somewhere.”
+
+“Perhaps at my wine-shop?”
+
+Much interested and agitated, Mr. Lorry said: “You come from Doctor
+Manette?”
+
+“Yes. I come from Doctor Manette.”
+
+“And what says he? What does he send me?”
+
+Defarge gave into his anxious hand, an open scrap of paper. It bore the
+words in the Doctor’s writing:
+
+    “Charles is safe, but I cannot safely leave this place yet.
+     I have obtained the favour that the bearer has a short note
+     from Charles to his wife.  Let the bearer see his wife.”
+
+It was dated from La Force, within an hour.
+
+“Will you accompany me,” said Mr. Lorry, joyfully relieved after reading
+this note aloud, “to where his wife resides?”
+
+“Yes,” returned Defarge.
+
+Scarcely noticing as yet, in what a curiously reserved and mechanical
+way Defarge spoke, Mr. Lorry put on his hat and they went down into the
+courtyard. There, they found two women; one, knitting.
+
+“Madame Defarge, surely!” said Mr. Lorry, who had left her in exactly
+the same attitude some seventeen years ago.
+
+“It is she,” observed her husband.
+
+“Does Madame go with us?” inquired Mr. Lorry, seeing that she moved as
+they moved.
+
+“Yes. That she may be able to recognise the faces and know the persons.
+It is for their safety.”
+
+Beginning to be struck by Defarge’s manner, Mr. Lorry looked dubiously
+at him, and led the way. Both the women followed; the second woman being
+The Vengeance.
+
+They passed through the intervening streets as quickly as they might,
+ascended the staircase of the new domicile, were admitted by Jerry,
+and found Lucie weeping, alone. She was thrown into a transport by the
+tidings Mr. Lorry gave her of her husband, and clasped the hand that
+delivered his note--little thinking what it had been doing near him in
+the night, and might, but for a chance, have done to him.
+
+     “DEAREST,--Take courage.  I am well, and your father has
+      influence around me.  You cannot answer this.
+      Kiss our child for me.”
+
+That was all the writing. It was so much, however, to her who received
+it, that she turned from Defarge to his wife, and kissed one of the
+hands that knitted. It was a passionate, loving, thankful, womanly
+action, but the hand made no response--dropped cold and heavy, and took
+to its knitting again.
+
+There was something in its touch that gave Lucie a check. She stopped in
+the act of putting the note in her bosom, and, with her hands yet at her
+neck, looked terrified at Madame Defarge. Madame Defarge met the lifted
+eyebrows and forehead with a cold, impassive stare.
+
+“My dear,” said Mr. Lorry, striking in to explain; “there are frequent
+risings in the streets; and, although it is not likely they will ever
+trouble you, Madame Defarge wishes to see those whom she has the power
+to protect at such times, to the end that she may know them--that she
+may identify them. I believe,” said Mr. Lorry, rather halting in his
+reassuring words, as the stony manner of all the three impressed itself
+upon him more and more, “I state the case, Citizen Defarge?”
+
+Defarge looked gloomily at his wife, and gave no other answer than a
+gruff sound of acquiescence.
+
+“You had better, Lucie,” said Mr. Lorry, doing all he could to
+propitiate, by tone and manner, “have the dear child here, and our
+good Pross. Our good Pross, Defarge, is an English lady, and knows no
+French.”
+
+The lady in question, whose rooted conviction that she was more than a
+match for any foreigner, was not to be shaken by distress and, danger,
+appeared with folded arms, and observed in English to The Vengeance,
+whom her eyes first encountered, “Well, I am sure, Boldface! I hope
+_you_ are pretty well!” She also bestowed a British cough on Madame
+Defarge; but, neither of the two took much heed of her.
+
+“Is that his child?” said Madame Defarge, stopping in her work for the
+first time, and pointing her knitting-needle at little Lucie as if it
+were the finger of Fate.
+
+“Yes, madame,” answered Mr. Lorry; “this is our poor prisoner’s darling
+daughter, and only child.”
+
+The shadow attendant on Madame Defarge and her party seemed to fall so
+threatening and dark on the child, that her mother instinctively
+kneeled on the ground beside her, and held her to her breast. The
+shadow attendant on Madame Defarge and her party seemed then to fall,
+threatening and dark, on both the mother and the child.
+
+“It is enough, my husband,” said Madame Defarge. “I have seen them. We
+may go.”
+
+But, the suppressed manner had enough of menace in it--not visible and
+presented, but indistinct and withheld--to alarm Lucie into saying, as
+she laid her appealing hand on Madame Defarge’s dress:
+
+“You will be good to my poor husband. You will do him no harm. You will
+help me to see him if you can?”
+
+“Your husband is not my business here,” returned Madame Defarge, looking
+down at her with perfect composure. “It is the daughter of your father
+who is my business here.”
+
+“For my sake, then, be merciful to my husband. For my child’s sake! She
+will put her hands together and pray you to be merciful. We are more
+afraid of you than of these others.”
+
+Madame Defarge received it as a compliment, and looked at her husband.
+Defarge, who had been uneasily biting his thumb-nail and looking at her,
+collected his face into a sterner expression.
+
+“What is it that your husband says in that little letter?” asked Madame
+Defarge, with a lowering smile. “Influence; he says something touching
+influence?”
+
+“That my father,” said Lucie, hurriedly taking the paper from her
+breast, but with her alarmed eyes on her questioner and not on it, “has
+much influence around him.”
+
+“Surely it will release him!” said Madame Defarge. “Let it do so.”
+
+“As a wife and mother,” cried Lucie, most earnestly, “I implore you to
+have pity on me and not to exercise any power that you possess, against
+my innocent husband, but to use it in his behalf. O sister-woman, think
+of me. As a wife and mother!”
+
+Madame Defarge looked, coldly as ever, at the suppliant, and said,
+turning to her friend The Vengeance:
+
+“The wives and mothers we have been used to see, since we were as little
+as this child, and much less, have not been greatly considered? We have
+known _their_ husbands and fathers laid in prison and kept from them,
+often enough? All our lives, we have seen our sister-women suffer, in
+themselves and in their children, poverty, nakedness, hunger, thirst,
+sickness, misery, oppression and neglect of all kinds?”
+
+“We have seen nothing else,” returned The Vengeance.
+
+“We have borne this a long time,” said Madame Defarge, turning her eyes
+again upon Lucie. “Judge you! Is it likely that the trouble of one wife
+and mother would be much to us now?”
+
+She resumed her knitting and went out. The Vengeance followed. Defarge
+went last, and closed the door.
+
+“Courage, my dear Lucie,” said Mr. Lorry, as he raised her. “Courage,
+courage! So far all goes well with us--much, much better than it has of
+late gone with many poor souls. Cheer up, and have a thankful heart.”
+
+“I am not thankless, I hope, but that dreadful woman seems to throw a
+shadow on me and on all my hopes.”
+
+“Tut, tut!” said Mr. Lorry; “what is this despondency in the brave
+little breast? A shadow indeed! No substance in it, Lucie.”
+
+But the shadow of the manner of these Defarges was dark upon himself,
+for all that, and in his secret mind it troubled him greatly.
+
+
+
+
+IV. Calm in Storm
+
+
+Doctor Manette did not return until the morning of the fourth day of his
+absence. So much of what had happened in that dreadful time as could be
+kept from the knowledge of Lucie was so well concealed from her, that
+not until long afterwards, when France and she were far apart, did she
+know that eleven hundred defenceless prisoners of both sexes and all
+ages had been killed by the populace; that four days and nights had been
+darkened by this deed of horror; and that the air around her had been
+tainted by the slain. She only knew that there had been an attack upon
+the prisons, that all political prisoners had been in danger, and that
+some had been dragged out by the crowd and murdered.
+
+To Mr. Lorry, the Doctor communicated under an injunction of secrecy on
+which he had no need to dwell, that the crowd had taken him through a
+scene of carnage to the prison of La Force. That, in the prison he had
+found a self-appointed Tribunal sitting, before which the prisoners were
+brought singly, and by which they were rapidly ordered to be put forth
+to be massacred, or to be released, or (in a few cases) to be sent back
+to their cells. That, presented by his conductors to this Tribunal, he
+had announced himself by name and profession as having been for eighteen
+years a secret and unaccused prisoner in the Bastille; that, one of the
+body so sitting in judgment had risen and identified him, and that this
+man was Defarge.
+
+That, hereupon he had ascertained, through the registers on the table,
+that his son-in-law was among the living prisoners, and had pleaded hard
+to the Tribunal--of whom some members were asleep and some awake, some
+dirty with murder and some clean, some sober and some not--for his life
+and liberty. That, in the first frantic greetings lavished on himself as
+a notable sufferer under the overthrown system, it had been accorded
+to him to have Charles Darnay brought before the lawless Court, and
+examined. That, he seemed on the point of being at once released, when
+the tide in his favour met with some unexplained check (not intelligible
+to the Doctor), which led to a few words of secret conference. That,
+the man sitting as President had then informed Doctor Manette that
+the prisoner must remain in custody, but should, for his sake, be held
+inviolate in safe custody. That, immediately, on a signal, the prisoner
+was removed to the interior of the prison again; but, that he, the
+Doctor, had then so strongly pleaded for permission to remain and
+assure himself that his son-in-law was, through no malice or mischance,
+delivered to the concourse whose murderous yells outside the gate had
+often drowned the proceedings, that he had obtained the permission, and
+had remained in that Hall of Blood until the danger was over.
+
+The sights he had seen there, with brief snatches of food and sleep by
+intervals, shall remain untold. The mad joy over the prisoners who were
+saved, had astounded him scarcely less than the mad ferocity against
+those who were cut to pieces. One prisoner there was, he said, who had
+been discharged into the street free, but at whom a mistaken savage had
+thrust a pike as he passed out. Being besought to go to him and dress
+the wound, the Doctor had passed out at the same gate, and had found him
+in the arms of a company of Samaritans, who were seated on the bodies
+of their victims. With an inconsistency as monstrous as anything in this
+awful nightmare, they had helped the healer, and tended the wounded man
+with the gentlest solicitude--had made a litter for him and escorted him
+carefully from the spot--had then caught up their weapons and plunged
+anew into a butchery so dreadful, that the Doctor had covered his eyes
+with his hands, and swooned away in the midst of it.
+
+As Mr. Lorry received these confidences, and as he watched the face of
+his friend now sixty-two years of age, a misgiving arose within him that
+such dread experiences would revive the old danger.
+
+But, he had never seen his friend in his present aspect: he had never
+at all known him in his present character. For the first time the Doctor
+felt, now, that his suffering was strength and power. For the first time
+he felt that in that sharp fire, he had slowly forged the iron which
+could break the prison door of his daughter’s husband, and deliver him.
+“It all tended to a good end, my friend; it was not mere waste and ruin.
+As my beloved child was helpful in restoring me to myself, I will be
+helpful now in restoring the dearest part of herself to her; by the aid
+of Heaven I will do it!” Thus, Doctor Manette. And when Jarvis Lorry saw
+the kindled eyes, the resolute face, the calm strong look and bearing
+of the man whose life always seemed to him to have been stopped, like a
+clock, for so many years, and then set going again with an energy which
+had lain dormant during the cessation of its usefulness, he believed.
+
+Greater things than the Doctor had at that time to contend with, would
+have yielded before his persevering purpose. While he kept himself
+in his place, as a physician, whose business was with all degrees
+of mankind, bond and free, rich and poor, bad and good, he used his
+personal influence so wisely, that he was soon the inspecting physician
+of three prisons, and among them of La Force. He could now assure Lucie
+that her husband was no longer confined alone, but was mixed with the
+general body of prisoners; he saw her husband weekly, and brought sweet
+messages to her, straight from his lips; sometimes her husband himself
+sent a letter to her (though never by the Doctor’s hand), but she was
+not permitted to write to him: for, among the many wild suspicions of
+plots in the prisons, the wildest of all pointed at emigrants who were
+known to have made friends or permanent connections abroad.
+
+This new life of the Doctor’s was an anxious life, no doubt; still, the
+sagacious Mr. Lorry saw that there was a new sustaining pride in it.
+Nothing unbecoming tinged the pride; it was a natural and worthy one;
+but he observed it as a curiosity. The Doctor knew, that up to that
+time, his imprisonment had been associated in the minds of his daughter
+and his friend, with his personal affliction, deprivation, and weakness.
+Now that this was changed, and he knew himself to be invested through
+that old trial with forces to which they both looked for Charles’s
+ultimate safety and deliverance, he became so far exalted by the change,
+that he took the lead and direction, and required them as the weak, to
+trust to him as the strong. The preceding relative positions of himself
+and Lucie were reversed, yet only as the liveliest gratitude and
+affection could reverse them, for he could have had no pride but in
+rendering some service to her who had rendered so much to him. “All
+curious to see,” thought Mr. Lorry, in his amiably shrewd way, “but all
+natural and right; so, take the lead, my dear friend, and keep it; it
+couldn’t be in better hands.”
+
+But, though the Doctor tried hard, and never ceased trying, to get
+Charles Darnay set at liberty, or at least to get him brought to trial,
+the public current of the time set too strong and fast for him. The new
+era began; the king was tried, doomed, and beheaded; the Republic of
+Liberty, Equality, Fraternity, or Death, declared for victory or death
+against the world in arms; the black flag waved night and day from the
+great towers of Notre Dame; three hundred thousand men, summoned to rise
+against the tyrants of the earth, rose from all the varying soils
+of France, as if the dragon’s teeth had been sown broadcast, and
+had yielded fruit equally on hill and plain, on rock, in gravel, and
+alluvial mud, under the bright sky of the South and under the clouds of
+the North, in fell and forest, in the vineyards and the olive-grounds
+and among the cropped grass and the stubble of the corn, along the
+fruitful banks of the broad rivers, and in the sand of the sea-shore.
+What private solicitude could rear itself against the deluge of the Year
+One of Liberty--the deluge rising from below, not falling from above,
+and with the windows of Heaven shut, not opened!
+
+There was no pause, no pity, no peace, no interval of relenting rest, no
+measurement of time. Though days and nights circled as regularly as when
+time was young, and the evening and morning were the first day, other
+count of time there was none. Hold of it was lost in the raging fever
+of a nation, as it is in the fever of one patient. Now, breaking the
+unnatural silence of a whole city, the executioner showed the people the
+head of the king--and now, it seemed almost in the same breath, the
+head of his fair wife which had had eight weary months of imprisoned
+widowhood and misery, to turn it grey.
+
+And yet, observing the strange law of contradiction which obtains in
+all such cases, the time was long, while it flamed by so fast. A
+revolutionary tribunal in the capital, and forty or fifty thousand
+revolutionary committees all over the land; a law of the Suspected,
+which struck away all security for liberty or life, and delivered over
+any good and innocent person to any bad and guilty one; prisons gorged
+with people who had committed no offence, and could obtain no hearing;
+these things became the established order and nature of appointed
+things, and seemed to be ancient usage before they were many weeks old.
+Above all, one hideous figure grew as familiar as if it had been before
+the general gaze from the foundations of the world--the figure of the
+sharp female called La Guillotine.
+
+It was the popular theme for jests; it was the best cure for headache,
+it infallibly prevented the hair from turning grey, it imparted a
+peculiar delicacy to the complexion, it was the National Razor which
+shaved close: who kissed La Guillotine, looked through the little window
+and sneezed into the sack. It was the sign of the regeneration of the
+human race. It superseded the Cross. Models of it were worn on breasts
+from which the Cross was discarded, and it was bowed down to and
+believed in where the Cross was denied.
+
+It sheared off heads so many, that it, and the ground it most polluted,
+were a rotten red. It was taken to pieces, like a toy-puzzle for a young
+Devil, and was put together again when the occasion wanted it. It hushed
+the eloquent, struck down the powerful, abolished the beautiful and
+good. Twenty-two friends of high public mark, twenty-one living and one
+dead, it had lopped the heads off, in one morning, in as many minutes.
+The name of the strong man of Old Scripture had descended to the chief
+functionary who worked it; but, so armed, he was stronger than his
+namesake, and blinder, and tore away the gates of God’s own Temple every
+day.
+
+Among these terrors, and the brood belonging to them, the Doctor walked
+with a steady head: confident in his power, cautiously persistent in his
+end, never doubting that he would save Lucie’s husband at last. Yet the
+current of the time swept by, so strong and deep, and carried the time
+away so fiercely, that Charles had lain in prison one year and three
+months when the Doctor was thus steady and confident. So much more
+wicked and distracted had the Revolution grown in that December month,
+that the rivers of the South were encumbered with the bodies of the
+violently drowned by night, and prisoners were shot in lines and squares
+under the southern wintry sun. Still, the Doctor walked among the
+terrors with a steady head. No man better known than he, in Paris at
+that day; no man in a stranger situation. Silent, humane, indispensable
+in hospital and prison, using his art equally among assassins and
+victims, he was a man apart. In the exercise of his skill, the
+appearance and the story of the Bastille Captive removed him from all
+other men. He was not suspected or brought in question, any more than if
+he had indeed been recalled to life some eighteen years before, or were
+a Spirit moving among mortals.
+
+
+
+
+V. The Wood-Sawyer
+
+
+One year and three months. During all that time Lucie was never
+sure, from hour to hour, but that the Guillotine would strike off her
+husband’s head next day. Every day, through the stony streets, the
+tumbrils now jolted heavily, filled with Condemned. Lovely girls; bright
+women, brown-haired, black-haired, and grey; youths; stalwart men and
+old; gentle born and peasant born; all red wine for La Guillotine, all
+daily brought into light from the dark cellars of the loathsome prisons,
+and carried to her through the streets to slake her devouring thirst.
+Liberty, equality, fraternity, or death;--the last, much the easiest to
+bestow, O Guillotine!
+
+If the suddenness of her calamity, and the whirling wheels of the time,
+had stunned the Doctor’s daughter into awaiting the result in idle
+despair, it would but have been with her as it was with many. But, from
+the hour when she had taken the white head to her fresh young bosom in
+the garret of Saint Antoine, she had been true to her duties. She was
+truest to them in the season of trial, as all the quietly loyal and good
+will always be.
+
+As soon as they were established in their new residence, and her father
+had entered on the routine of his avocations, she arranged the little
+household as exactly as if her husband had been there. Everything had
+its appointed place and its appointed time. Little Lucie she taught,
+as regularly, as if they had all been united in their English home. The
+slight devices with which she cheated herself into the show of a belief
+that they would soon be reunited--the little preparations for his speedy
+return, the setting aside of his chair and his books--these, and the
+solemn prayer at night for one dear prisoner especially, among the many
+unhappy souls in prison and the shadow of death--were almost the only
+outspoken reliefs of her heavy mind.
+
+She did not greatly alter in appearance. The plain dark dresses, akin to
+mourning dresses, which she and her child wore, were as neat and as well
+attended to as the brighter clothes of happy days. She lost her colour,
+and the old and intent expression was a constant, not an occasional,
+thing; otherwise, she remained very pretty and comely. Sometimes, at
+night on kissing her father, she would burst into the grief she had
+repressed all day, and would say that her sole reliance, under Heaven,
+was on him. He always resolutely answered: “Nothing can happen to him
+without my knowledge, and I know that I can save him, Lucie.”
+
+They had not made the round of their changed life many weeks, when her
+father said to her, on coming home one evening:
+
+“My dear, there is an upper window in the prison, to which Charles can
+sometimes gain access at three in the afternoon. When he can get to
+it--which depends on many uncertainties and incidents--he might see you
+in the street, he thinks, if you stood in a certain place that I can
+show you. But you will not be able to see him, my poor child, and even
+if you could, it would be unsafe for you to make a sign of recognition.”
+
+“O show me the place, my father, and I will go there every day.”
+
+From that time, in all weathers, she waited there two hours. As the
+clock struck two, she was there, and at four she turned resignedly away.
+When it was not too wet or inclement for her child to be with her, they
+went together; at other times she was alone; but, she never missed a
+single day.
+
+It was the dark and dirty corner of a small winding street. The hovel
+of a cutter of wood into lengths for burning, was the only house at that
+end; all else was wall. On the third day of her being there, he noticed
+her.
+
+“Good day, citizeness.”
+
+“Good day, citizen.”
+
+This mode of address was now prescribed by decree. It had been
+established voluntarily some time ago, among the more thorough patriots;
+but, was now law for everybody.
+
+“Walking here again, citizeness?”
+
+“You see me, citizen!”
+
+The wood-sawyer, who was a little man with a redundancy of gesture (he
+had once been a mender of roads), cast a glance at the prison, pointed
+at the prison, and putting his ten fingers before his face to represent
+bars, peeped through them jocosely.
+
+“But it’s not my business,” said he. And went on sawing his wood.
+
+Next day he was looking out for her, and accosted her the moment she
+appeared.
+
+“What? Walking here again, citizeness?”
+
+“Yes, citizen.”
+
+“Ah! A child too! Your mother, is it not, my little citizeness?”
+
+“Do I say yes, mamma?” whispered little Lucie, drawing close to her.
+
+“Yes, dearest.”
+
+“Yes, citizen.”
+
+“Ah! But it’s not my business. My work is my business. See my saw! I
+call it my Little Guillotine. La, la, la; La, la, la! And off his head
+comes!”
+
+The billet fell as he spoke, and he threw it into a basket.
+
+“I call myself the Samson of the firewood guillotine. See here again!
+Loo, loo, loo; Loo, loo, loo! And off _her_ head comes! Now, a child.
+Tickle, tickle; Pickle, pickle! And off _its_ head comes. All the
+family!”
+
+Lucie shuddered as he threw two more billets into his basket, but it was
+impossible to be there while the wood-sawyer was at work, and not be in
+his sight. Thenceforth, to secure his good will, she always spoke to him
+first, and often gave him drink-money, which he readily received.
+
+He was an inquisitive fellow, and sometimes when she had quite forgotten
+him in gazing at the prison roof and grates, and in lifting her heart
+up to her husband, she would come to herself to find him looking at her,
+with his knee on his bench and his saw stopped in its work. “But it’s
+not my business!” he would generally say at those times, and would
+briskly fall to his sawing again.
+
+In all weathers, in the snow and frost of winter, in the bitter winds of
+spring, in the hot sunshine of summer, in the rains of autumn, and again
+in the snow and frost of winter, Lucie passed two hours of every day at
+this place; and every day on leaving it, she kissed the prison wall.
+Her husband saw her (so she learned from her father) it might be once in
+five or six times: it might be twice or thrice running: it might be, not
+for a week or a fortnight together. It was enough that he could and did
+see her when the chances served, and on that possibility she would have
+waited out the day, seven days a week.
+
+These occupations brought her round to the December month, wherein her
+father walked among the terrors with a steady head. On a lightly-snowing
+afternoon she arrived at the usual corner. It was a day of some wild
+rejoicing, and a festival. She had seen the houses, as she came along,
+decorated with little pikes, and with little red caps stuck upon them;
+also, with tricoloured ribbons; also, with the standard inscription
+(tricoloured letters were the favourite), Republic One and Indivisible.
+Liberty, Equality, Fraternity, or Death!
+
+The miserable shop of the wood-sawyer was so small, that its whole
+surface furnished very indifferent space for this legend. He had got
+somebody to scrawl it up for him, however, who had squeezed Death in
+with most inappropriate difficulty. On his house-top, he displayed pike
+and cap, as a good citizen must, and in a window he had stationed his
+saw inscribed as his “Little Sainte Guillotine”--for the great sharp
+female was by that time popularly canonised. His shop was shut and he
+was not there, which was a relief to Lucie, and left her quite alone.
+
+But, he was not far off, for presently she heard a troubled movement
+and a shouting coming along, which filled her with fear. A moment
+afterwards, and a throng of people came pouring round the corner by the
+prison wall, in the midst of whom was the wood-sawyer hand in hand with
+The Vengeance. There could not be fewer than five hundred people, and
+they were dancing like five thousand demons. There was no other music
+than their own singing. They danced to the popular Revolution song,
+keeping a ferocious time that was like a gnashing of teeth in unison.
+Men and women danced together, women danced together, men danced
+together, as hazard had brought them together. At first, they were a
+mere storm of coarse red caps and coarse woollen rags; but, as they
+filled the place, and stopped to dance about Lucie, some ghastly
+apparition of a dance-figure gone raving mad arose among them. They
+advanced, retreated, struck at one another’s hands, clutched at one
+another’s heads, spun round alone, caught one another and spun round
+in pairs, until many of them dropped. While those were down, the rest
+linked hand in hand, and all spun round together: then the ring broke,
+and in separate rings of two and four they turned and turned until they
+all stopped at once, began again, struck, clutched, and tore, and then
+reversed the spin, and all spun round another way. Suddenly they stopped
+again, paused, struck out the time afresh, formed into lines the width
+of the public way, and, with their heads low down and their hands high
+up, swooped screaming off. No fight could have been half so terrible
+as this dance. It was so emphatically a fallen sport--a something, once
+innocent, delivered over to all devilry--a healthy pastime changed into
+a means of angering the blood, bewildering the senses, and steeling the
+heart. Such grace as was visible in it, made it the uglier, showing how
+warped and perverted all things good by nature were become. The maidenly
+bosom bared to this, the pretty almost-child’s head thus distracted, the
+delicate foot mincing in this slough of blood and dirt, were types of
+the disjointed time.
+
+This was the Carmagnole. As it passed, leaving Lucie frightened and
+bewildered in the doorway of the wood-sawyer’s house, the feathery snow
+fell as quietly and lay as white and soft, as if it had never been.
+
+“O my father!” for he stood before her when she lifted up the eyes she
+had momentarily darkened with her hand; “such a cruel, bad sight.”
+
+“I know, my dear, I know. I have seen it many times. Don’t be
+frightened! Not one of them would harm you.”
+
+“I am not frightened for myself, my father. But when I think of my
+husband, and the mercies of these people--”
+
+“We will set him above their mercies very soon. I left him climbing to
+the window, and I came to tell you. There is no one here to see. You may
+kiss your hand towards that highest shelving roof.”
+
+“I do so, father, and I send him my Soul with it!”
+
+“You cannot see him, my poor dear?”
+
+“No, father,” said Lucie, yearning and weeping as she kissed her hand,
+“no.”
+
+A footstep in the snow. Madame Defarge. “I salute you, citizeness,”
+ from the Doctor. “I salute you, citizen.” This in passing. Nothing more.
+Madame Defarge gone, like a shadow over the white road.
+
+“Give me your arm, my love. Pass from here with an air of cheerfulness
+and courage, for his sake. That was well done;” they had left the spot;
+“it shall not be in vain. Charles is summoned for to-morrow.”
+
+“For to-morrow!”
+
+“There is no time to lose. I am well prepared, but there are precautions
+to be taken, that could not be taken until he was actually summoned
+before the Tribunal. He has not received the notice yet, but I know
+that he will presently be summoned for to-morrow, and removed to the
+Conciergerie; I have timely information. You are not afraid?”
+
+She could scarcely answer, “I trust in you.”
+
+“Do so, implicitly. Your suspense is nearly ended, my darling; he shall
+be restored to you within a few hours; I have encompassed him with every
+protection. I must see Lorry.”
+
+He stopped. There was a heavy lumbering of wheels within hearing. They
+both knew too well what it meant. One. Two. Three. Three tumbrils faring
+away with their dread loads over the hushing snow.
+
+“I must see Lorry,” the Doctor repeated, turning her another way.
+
+The staunch old gentleman was still in his trust; had never left it. He
+and his books were in frequent requisition as to property confiscated
+and made national. What he could save for the owners, he saved. No
+better man living to hold fast by what Tellson’s had in keeping, and to
+hold his peace.
+
+A murky red and yellow sky, and a rising mist from the Seine, denoted
+the approach of darkness. It was almost dark when they arrived at the
+Bank. The stately residence of Monseigneur was altogether blighted and
+deserted. Above a heap of dust and ashes in the court, ran the letters:
+National Property. Republic One and Indivisible. Liberty, Equality,
+Fraternity, or Death!
+
+Who could that be with Mr. Lorry--the owner of the riding-coat upon the
+chair--who must not be seen? From whom newly arrived, did he come out,
+agitated and surprised, to take his favourite in his arms? To whom did
+he appear to repeat her faltering words, when, raising his voice and
+turning his head towards the door of the room from which he had issued,
+he said: “Removed to the Conciergerie, and summoned for to-morrow?”
+
+
+
+
+VI. Triumph
+
+
+The dread tribunal of five Judges, Public Prosecutor, and determined
+Jury, sat every day. Their lists went forth every evening, and were
+read out by the gaolers of the various prisons to their prisoners. The
+standard gaoler-joke was, “Come out and listen to the Evening Paper, you
+inside there!”
+
+“Charles Evremonde, called Darnay!”
+
+So at last began the Evening Paper at La Force.
+
+When a name was called, its owner stepped apart into a spot reserved
+for those who were announced as being thus fatally recorded. Charles
+Evremonde, called Darnay, had reason to know the usage; he had seen
+hundreds pass away so.
+
+His bloated gaoler, who wore spectacles to read with, glanced over them
+to assure himself that he had taken his place, and went through the
+list, making a similar short pause at each name. There were twenty-three
+names, but only twenty were responded to; for one of the prisoners so
+summoned had died in gaol and been forgotten, and two had already been
+guillotined and forgotten. The list was read, in the vaulted chamber
+where Darnay had seen the associated prisoners on the night of his
+arrival. Every one of those had perished in the massacre; every human
+creature he had since cared for and parted with, had died on the
+scaffold.
+
+There were hurried words of farewell and kindness, but the parting was
+soon over. It was the incident of every day, and the society of La Force
+were engaged in the preparation of some games of forfeits and a little
+concert, for that evening. They crowded to the grates and shed tears
+there; but, twenty places in the projected entertainments had to be
+refilled, and the time was, at best, short to the lock-up hour, when the
+common rooms and corridors would be delivered over to the great dogs
+who kept watch there through the night. The prisoners were far from
+insensible or unfeeling; their ways arose out of the condition of the
+time. Similarly, though with a subtle difference, a species of fervour
+or intoxication, known, without doubt, to have led some persons to
+brave the guillotine unnecessarily, and to die by it, was not mere
+boastfulness, but a wild infection of the wildly shaken public mind. In
+seasons of pestilence, some of us will have a secret attraction to the
+disease--a terrible passing inclination to die of it. And all of us have
+like wonders hidden in our breasts, only needing circumstances to evoke
+them.
+
+The passage to the Conciergerie was short and dark; the night in its
+vermin-haunted cells was long and cold. Next day, fifteen prisoners were
+put to the bar before Charles Darnay’s name was called. All the fifteen
+were condemned, and the trials of the whole occupied an hour and a half.
+
+“Charles Evremonde, called Darnay,” was at length arraigned.
+
+His judges sat upon the Bench in feathered hats; but the rough red cap
+and tricoloured cockade was the head-dress otherwise prevailing. Looking
+at the Jury and the turbulent audience, he might have thought that the
+usual order of things was reversed, and that the felons were trying the
+honest men. The lowest, cruelest, and worst populace of a city, never
+without its quantity of low, cruel, and bad, were the directing
+spirits of the scene: noisily commenting, applauding, disapproving,
+anticipating, and precipitating the result, without a check. Of the men,
+the greater part were armed in various ways; of the women, some wore
+knives, some daggers, some ate and drank as they looked on, many
+knitted. Among these last, was one, with a spare piece of knitting under
+her arm as she worked. She was in a front row, by the side of a man whom
+he had never seen since his arrival at the Barrier, but whom he directly
+remembered as Defarge. He noticed that she once or twice whispered in
+his ear, and that she seemed to be his wife; but, what he most noticed
+in the two figures was, that although they were posted as close to
+himself as they could be, they never looked towards him. They seemed to
+be waiting for something with a dogged determination, and they looked at
+the Jury, but at nothing else. Under the President sat Doctor Manette,
+in his usual quiet dress. As well as the prisoner could see, he and Mr.
+Lorry were the only men there, unconnected with the Tribunal, who
+wore their usual clothes, and had not assumed the coarse garb of the
+Carmagnole.
+
+Charles Evremonde, called Darnay, was accused by the public prosecutor
+as an emigrant, whose life was forfeit to the Republic, under the decree
+which banished all emigrants on pain of Death. It was nothing that the
+decree bore date since his return to France. There he was, and there was
+the decree; he had been taken in France, and his head was demanded.
+
+“Take off his head!” cried the audience. “An enemy to the Republic!”
+
+The President rang his bell to silence those cries, and asked the
+prisoner whether it was not true that he had lived many years in
+England?
+
+Undoubtedly it was.
+
+Was he not an emigrant then? What did he call himself?
+
+Not an emigrant, he hoped, within the sense and spirit of the law.
+
+Why not? the President desired to know.
+
+Because he had voluntarily relinquished a title that was distasteful
+to him, and a station that was distasteful to him, and had left
+his country--he submitted before the word emigrant in the present
+acceptation by the Tribunal was in use--to live by his own industry in
+England, rather than on the industry of the overladen people of France.
+
+What proof had he of this?
+
+He handed in the names of two witnesses; Theophile Gabelle, and
+Alexandre Manette.
+
+But he had married in England? the President reminded him.
+
+True, but not an English woman.
+
+A citizeness of France?
+
+Yes. By birth.
+
+Her name and family?
+
+“Lucie Manette, only daughter of Doctor Manette, the good physician who
+sits there.”
+
+This answer had a happy effect upon the audience. Cries in exaltation
+of the well-known good physician rent the hall. So capriciously were
+the people moved, that tears immediately rolled down several ferocious
+countenances which had been glaring at the prisoner a moment before, as
+if with impatience to pluck him out into the streets and kill him.
+
+On these few steps of his dangerous way, Charles Darnay had set his foot
+according to Doctor Manette’s reiterated instructions. The same cautious
+counsel directed every step that lay before him, and had prepared every
+inch of his road.
+
+The President asked, why had he returned to France when he did, and not
+sooner?
+
+He had not returned sooner, he replied, simply because he had no means
+of living in France, save those he had resigned; whereas, in England,
+he lived by giving instruction in the French language and literature.
+He had returned when he did, on the pressing and written entreaty of
+a French citizen, who represented that his life was endangered by his
+absence. He had come back, to save a citizen’s life, and to bear his
+testimony, at whatever personal hazard, to the truth. Was that criminal
+in the eyes of the Republic?
+
+The populace cried enthusiastically, “No!” and the President rang his
+bell to quiet them. Which it did not, for they continued to cry “No!”
+ until they left off, of their own will.
+
+The President required the name of that citizen. The accused explained
+that the citizen was his first witness. He also referred with confidence
+to the citizen’s letter, which had been taken from him at the Barrier,
+but which he did not doubt would be found among the papers then before
+the President.
+
+The Doctor had taken care that it should be there--had assured him that
+it would be there--and at this stage of the proceedings it was produced
+and read. Citizen Gabelle was called to confirm it, and did so. Citizen
+Gabelle hinted, with infinite delicacy and politeness, that in the
+pressure of business imposed on the Tribunal by the multitude of
+enemies of the Republic with which it had to deal, he had been slightly
+overlooked in his prison of the Abbaye--in fact, had rather passed out
+of the Tribunal’s patriotic remembrance--until three days ago; when he
+had been summoned before it, and had been set at liberty on the Jury’s
+declaring themselves satisfied that the accusation against him was
+answered, as to himself, by the surrender of the citizen Evremonde,
+called Darnay.
+
+Doctor Manette was next questioned. His high personal popularity,
+and the clearness of his answers, made a great impression; but, as he
+proceeded, as he showed that the Accused was his first friend on his
+release from his long imprisonment; that, the accused had remained in
+England, always faithful and devoted to his daughter and himself in
+their exile; that, so far from being in favour with the Aristocrat
+government there, he had actually been tried for his life by it, as
+the foe of England and friend of the United States--as he brought these
+circumstances into view, with the greatest discretion and with the
+straightforward force of truth and earnestness, the Jury and the
+populace became one. At last, when he appealed by name to Monsieur
+Lorry, an English gentleman then and there present, who, like himself,
+had been a witness on that English trial and could corroborate his
+account of it, the Jury declared that they had heard enough, and that
+they were ready with their votes if the President were content to
+receive them.
+
+At every vote (the Jurymen voted aloud and individually), the populace
+set up a shout of applause. All the voices were in the prisoner’s
+favour, and the President declared him free.
+
+Then, began one of those extraordinary scenes with which the populace
+sometimes gratified their fickleness, or their better impulses towards
+generosity and mercy, or which they regarded as some set-off against
+their swollen account of cruel rage. No man can decide now to which of
+these motives such extraordinary scenes were referable; it is probable,
+to a blending of all the three, with the second predominating. No sooner
+was the acquittal pronounced, than tears were shed as freely as blood
+at another time, and such fraternal embraces were bestowed upon the
+prisoner by as many of both sexes as could rush at him, that after
+his long and unwholesome confinement he was in danger of fainting from
+exhaustion; none the less because he knew very well, that the very same
+people, carried by another current, would have rushed at him with
+the very same intensity, to rend him to pieces and strew him over the
+streets.
+
+His removal, to make way for other accused persons who were to be tried,
+rescued him from these caresses for the moment. Five were to be tried
+together, next, as enemies of the Republic, forasmuch as they had not
+assisted it by word or deed. So quick was the Tribunal to compensate
+itself and the nation for a chance lost, that these five came down to
+him before he left the place, condemned to die within twenty-four
+hours. The first of them told him so, with the customary prison sign
+of Death--a raised finger--and they all added in words, “Long live the
+Republic!”
+
+The five had had, it is true, no audience to lengthen their proceedings,
+for when he and Doctor Manette emerged from the gate, there was a great
+crowd about it, in which there seemed to be every face he had seen in
+Court--except two, for which he looked in vain. On his coming out, the
+concourse made at him anew, weeping, embracing, and shouting, all by
+turns and all together, until the very tide of the river on the bank of
+which the mad scene was acted, seemed to run mad, like the people on the
+shore.
+
+They put him into a great chair they had among them, and which they had
+taken either out of the Court itself, or one of its rooms or passages.
+Over the chair they had thrown a red flag, and to the back of it they
+had bound a pike with a red cap on its top. In this car of triumph, not
+even the Doctor’s entreaties could prevent his being carried to his home
+on men’s shoulders, with a confused sea of red caps heaving about him,
+and casting up to sight from the stormy deep such wrecks of faces, that
+he more than once misdoubted his mind being in confusion, and that he
+was in the tumbril on his way to the Guillotine.
+
+In wild dreamlike procession, embracing whom they met and pointing
+him out, they carried him on. Reddening the snowy streets with the
+prevailing Republican colour, in winding and tramping through them, as
+they had reddened them below the snow with a deeper dye, they carried
+him thus into the courtyard of the building where he lived. Her father
+had gone on before, to prepare her, and when her husband stood upon his
+feet, she dropped insensible in his arms.
+
+As he held her to his heart and turned her beautiful head between his
+face and the brawling crowd, so that his tears and her lips might come
+together unseen, a few of the people fell to dancing. Instantly, all the
+rest fell to dancing, and the courtyard overflowed with the Carmagnole.
+Then, they elevated into the vacant chair a young woman from the
+crowd to be carried as the Goddess of Liberty, and then swelling and
+overflowing out into the adjacent streets, and along the river’s bank,
+and over the bridge, the Carmagnole absorbed them every one and whirled
+them away.
+
+After grasping the Doctor’s hand, as he stood victorious and proud
+before him; after grasping the hand of Mr. Lorry, who came panting in
+breathless from his struggle against the waterspout of the Carmagnole;
+after kissing little Lucie, who was lifted up to clasp her arms round
+his neck; and after embracing the ever zealous and faithful Pross who
+lifted her; he took his wife in his arms, and carried her up to their
+rooms.
+
+“Lucie! My own! I am safe.”
+
+“O dearest Charles, let me thank God for this on my knees as I have
+prayed to Him.”
+
+They all reverently bowed their heads and hearts. When she was again in
+his arms, he said to her:
+
+“And now speak to your father, dearest. No other man in all this France
+could have done what he has done for me.”
+
+She laid her head upon her father’s breast, as she had laid his poor
+head on her own breast, long, long ago. He was happy in the return he
+had made her, he was recompensed for his suffering, he was proud of his
+strength. “You must not be weak, my darling,” he remonstrated; “don’t
+tremble so. I have saved him.”
+
+
+
+
+VII. A Knock at the Door
+
+
+“I have saved him.” It was not another of the dreams in which he had
+often come back; he was really here. And yet his wife trembled, and a
+vague but heavy fear was upon her.
+
+All the air round was so thick and dark, the people were so passionately
+revengeful and fitful, the innocent were so constantly put to death on
+vague suspicion and black malice, it was so impossible to forget that
+many as blameless as her husband and as dear to others as he was to
+her, every day shared the fate from which he had been clutched, that her
+heart could not be as lightened of its load as she felt it ought to be.
+The shadows of the wintry afternoon were beginning to fall, and even now
+the dreadful carts were rolling through the streets. Her mind pursued
+them, looking for him among the Condemned; and then she clung closer to
+his real presence and trembled more.
+
+Her father, cheering her, showed a compassionate superiority to this
+woman’s weakness, which was wonderful to see. No garret, no shoemaking,
+no One Hundred and Five, North Tower, now! He had accomplished the task
+he had set himself, his promise was redeemed, he had saved Charles. Let
+them all lean upon him.
+
+Their housekeeping was of a very frugal kind: not only because that was
+the safest way of life, involving the least offence to the people, but
+because they were not rich, and Charles, throughout his imprisonment,
+had had to pay heavily for his bad food, and for his guard, and towards
+the living of the poorer prisoners. Partly on this account, and
+partly to avoid a domestic spy, they kept no servant; the citizen and
+citizeness who acted as porters at the courtyard gate, rendered them
+occasional service; and Jerry (almost wholly transferred to them by
+Mr. Lorry) had become their daily retainer, and had his bed there every
+night.
+
+It was an ordinance of the Republic One and Indivisible of Liberty,
+Equality, Fraternity, or Death, that on the door or doorpost of every
+house, the name of every inmate must be legibly inscribed in letters
+of a certain size, at a certain convenient height from the ground. Mr.
+Jerry Cruncher’s name, therefore, duly embellished the doorpost down
+below; and, as the afternoon shadows deepened, the owner of that name
+himself appeared, from overlooking a painter whom Doctor Manette had
+employed to add to the list the name of Charles Evremonde, called
+Darnay.
+
+In the universal fear and distrust that darkened the time, all the usual
+harmless ways of life were changed. In the Doctor’s little household, as
+in very many others, the articles of daily consumption that were wanted
+were purchased every evening, in small quantities and at various small
+shops. To avoid attracting notice, and to give as little occasion as
+possible for talk and envy, was the general desire.
+
+For some months past, Miss Pross and Mr. Cruncher had discharged the
+office of purveyors; the former carrying the money; the latter, the
+basket. Every afternoon at about the time when the public lamps were
+lighted, they fared forth on this duty, and made and brought home
+such purchases as were needful. Although Miss Pross, through her long
+association with a French family, might have known as much of their
+language as of her own, if she had had a mind, she had no mind in that
+direction; consequently she knew no more of that “nonsense” (as she was
+pleased to call it) than Mr. Cruncher did. So her manner of marketing
+was to plump a noun-substantive at the head of a shopkeeper without any
+introduction in the nature of an article, and, if it happened not to be
+the name of the thing she wanted, to look round for that thing, lay hold
+of it, and hold on by it until the bargain was concluded. She always
+made a bargain for it, by holding up, as a statement of its just price,
+one finger less than the merchant held up, whatever his number might be.
+
+“Now, Mr. Cruncher,” said Miss Pross, whose eyes were red with felicity;
+“if you are ready, I am.”
+
+Jerry hoarsely professed himself at Miss Pross’s service. He had worn
+all his rust off long ago, but nothing would file his spiky head down.
+
+“There’s all manner of things wanted,” said Miss Pross, “and we shall
+have a precious time of it. We want wine, among the rest. Nice toasts
+these Redheads will be drinking, wherever we buy it.”
+
+“It will be much the same to your knowledge, miss, I should think,”
+ retorted Jerry, “whether they drink your health or the Old Un’s.”
+
+“Who’s he?” said Miss Pross.
+
+Mr. Cruncher, with some diffidence, explained himself as meaning “Old
+Nick’s.”
+
+“Ha!” said Miss Pross, “it doesn’t need an interpreter to explain the
+meaning of these creatures. They have but one, and it’s Midnight Murder,
+and Mischief.”
+
+“Hush, dear! Pray, pray, be cautious!” cried Lucie.
+
+“Yes, yes, yes, I’ll be cautious,” said Miss Pross; “but I may say
+among ourselves, that I do hope there will be no oniony and tobaccoey
+smotherings in the form of embracings all round, going on in the
+streets. Now, Ladybird, never you stir from that fire till I come back!
+Take care of the dear husband you have recovered, and don’t move your
+pretty head from his shoulder as you have it now, till you see me again!
+May I ask a question, Doctor Manette, before I go?”
+
+“I think you may take that liberty,” the Doctor answered, smiling.
+
+“For gracious sake, don’t talk about Liberty; we have quite enough of
+that,” said Miss Pross.
+
+“Hush, dear! Again?” Lucie remonstrated.
+
+“Well, my sweet,” said Miss Pross, nodding her head emphatically, “the
+short and the long of it is, that I am a subject of His Most Gracious
+Majesty King George the Third;” Miss Pross curtseyed at the name; “and
+as such, my maxim is, Confound their politics, Frustrate their knavish
+tricks, On him our hopes we fix, God save the King!”
+
+Mr. Cruncher, in an access of loyalty, growlingly repeated the words
+after Miss Pross, like somebody at church.
+
+“I am glad you have so much of the Englishman in you, though I wish you
+had never taken that cold in your voice,” said Miss Pross, approvingly.
+“But the question, Doctor Manette. Is there”--it was the good creature’s
+way to affect to make light of anything that was a great anxiety
+with them all, and to come at it in this chance manner--“is there any
+prospect yet, of our getting out of this place?”
+
+“I fear not yet. It would be dangerous for Charles yet.”
+
+“Heigh-ho-hum!” said Miss Pross, cheerfully repressing a sigh as she
+glanced at her darling’s golden hair in the light of the fire, “then we
+must have patience and wait: that’s all. We must hold up our heads and
+fight low, as my brother Solomon used to say. Now, Mr. Cruncher!--Don’t
+you move, Ladybird!”
+
+They went out, leaving Lucie, and her husband, her father, and the
+child, by a bright fire. Mr. Lorry was expected back presently from the
+Banking House. Miss Pross had lighted the lamp, but had put it aside in
+a corner, that they might enjoy the fire-light undisturbed. Little Lucie
+sat by her grandfather with her hands clasped through his arm: and he,
+in a tone not rising much above a whisper, began to tell her a story of
+a great and powerful Fairy who had opened a prison-wall and let out
+a captive who had once done the Fairy a service. All was subdued and
+quiet, and Lucie was more at ease than she had been.
+
+“What is that?” she cried, all at once.
+
+“My dear!” said her father, stopping in his story, and laying his hand
+on hers, “command yourself. What a disordered state you are in! The
+least thing--nothing--startles you! _You_, your father’s daughter!”
+
+“I thought, my father,” said Lucie, excusing herself, with a pale face
+and in a faltering voice, “that I heard strange feet upon the stairs.”
+
+“My love, the staircase is as still as Death.”
+
+As he said the word, a blow was struck upon the door.
+
+“Oh father, father. What can this be! Hide Charles. Save him!”
+
+“My child,” said the Doctor, rising, and laying his hand upon her
+shoulder, “I _have_ saved him. What weakness is this, my dear! Let me go
+to the door.”
+
+He took the lamp in his hand, crossed the two intervening outer rooms,
+and opened it. A rude clattering of feet over the floor, and four rough
+men in red caps, armed with sabres and pistols, entered the room.
+
+“The Citizen Evremonde, called Darnay,” said the first.
+
+“Who seeks him?” answered Darnay.
+
+“I seek him. We seek him. I know you, Evremonde; I saw you before the
+Tribunal to-day. You are again the prisoner of the Republic.”
+
+The four surrounded him, where he stood with his wife and child clinging
+to him.
+
+“Tell me how and why am I again a prisoner?”
+
+“It is enough that you return straight to the Conciergerie, and will
+know to-morrow. You are summoned for to-morrow.”
+
+Doctor Manette, whom this visitation had so turned into stone, that he
+stood with the lamp in his hand, as if he were a statue made to hold it,
+moved after these words were spoken, put the lamp down, and confronting
+the speaker, and taking him, not ungently, by the loose front of his red
+woollen shirt, said:
+
+“You know him, you have said. Do you know me?”
+
+“Yes, I know you, Citizen Doctor.”
+
+“We all know you, Citizen Doctor,” said the other three.
+
+He looked abstractedly from one to another, and said, in a lower voice,
+after a pause:
+
+“Will you answer his question to me then? How does this happen?”
+
+“Citizen Doctor,” said the first, reluctantly, “he has been denounced to
+the Section of Saint Antoine. This citizen,” pointing out the second who
+had entered, “is from Saint Antoine.”
+
+The citizen here indicated nodded his head, and added:
+
+“He is accused by Saint Antoine.”
+
+“Of what?” asked the Doctor.
+
+“Citizen Doctor,” said the first, with his former reluctance, “ask no
+more. If the Republic demands sacrifices from you, without doubt you as
+a good patriot will be happy to make them. The Republic goes before all.
+The People is supreme. Evremonde, we are pressed.”
+
+“One word,” the Doctor entreated. “Will you tell me who denounced him?”
+
+“It is against rule,” answered the first; “but you can ask Him of Saint
+Antoine here.”
+
+The Doctor turned his eyes upon that man. Who moved uneasily on his
+feet, rubbed his beard a little, and at length said:
+
+“Well! Truly it is against rule. But he is denounced--and gravely--by
+the Citizen and Citizeness Defarge. And by one other.”
+
+“What other?”
+
+“Do _you_ ask, Citizen Doctor?”
+
+“Yes.”
+
+“Then,” said he of Saint Antoine, with a strange look, “you will be
+answered to-morrow. Now, I am dumb!”
+
+
+
+
+VIII. A Hand at Cards
+
+
+Happily unconscious of the new calamity at home, Miss Pross threaded her
+way along the narrow streets and crossed the river by the bridge of the
+Pont-Neuf, reckoning in her mind the number of indispensable purchases
+she had to make. Mr. Cruncher, with the basket, walked at her side. They
+both looked to the right and to the left into most of the shops they
+passed, had a wary eye for all gregarious assemblages of people, and
+turned out of their road to avoid any very excited group of talkers. It
+was a raw evening, and the misty river, blurred to the eye with blazing
+lights and to the ear with harsh noises, showed where the barges were
+stationed in which the smiths worked, making guns for the Army of the
+Republic. Woe to the man who played tricks with _that_ Army, or got
+undeserved promotion in it! Better for him that his beard had never
+grown, for the National Razor shaved him close.
+
+Having purchased a few small articles of grocery, and a measure of oil
+for the lamp, Miss Pross bethought herself of the wine they wanted.
+After peeping into several wine-shops, she stopped at the sign of the
+Good Republican Brutus of Antiquity, not far from the National Palace,
+once (and twice) the Tuileries, where the aspect of things rather
+took her fancy. It had a quieter look than any other place of the same
+description they had passed, and, though red with patriotic caps, was
+not so red as the rest. Sounding Mr. Cruncher, and finding him of her
+opinion, Miss Pross resorted to the Good Republican Brutus of Antiquity,
+attended by her cavalier.
+
+Slightly observant of the smoky lights; of the people, pipe in mouth,
+playing with limp cards and yellow dominoes; of the one bare-breasted,
+bare-armed, soot-begrimed workman reading a journal aloud, and of
+the others listening to him; of the weapons worn, or laid aside to be
+resumed; of the two or three customers fallen forward asleep, who in the
+popular high-shouldered shaggy black spencer looked, in that attitude,
+like slumbering bears or dogs; the two outlandish customers approached
+the counter, and showed what they wanted.
+
+As their wine was measuring out, a man parted from another man in a
+corner, and rose to depart. In going, he had to face Miss Pross. No
+sooner did he face her, than Miss Pross uttered a scream, and clapped
+her hands.
+
+In a moment, the whole company were on their feet. That somebody was
+assassinated by somebody vindicating a difference of opinion was the
+likeliest occurrence. Everybody looked to see somebody fall, but only
+saw a man and a woman standing staring at each other; the man with all
+the outward aspect of a Frenchman and a thorough Republican; the woman,
+evidently English.
+
+What was said in this disappointing anti-climax, by the disciples of the
+Good Republican Brutus of Antiquity, except that it was something very
+voluble and loud, would have been as so much Hebrew or Chaldean to Miss
+Pross and her protector, though they had been all ears. But, they had no
+ears for anything in their surprise. For, it must be recorded, that
+not only was Miss Pross lost in amazement and agitation, but,
+Mr. Cruncher--though it seemed on his own separate and individual
+account--was in a state of the greatest wonder.
+
+“What is the matter?” said the man who had caused Miss Pross to scream;
+speaking in a vexed, abrupt voice (though in a low tone), and in
+English.
+
+“Oh, Solomon, dear Solomon!” cried Miss Pross, clapping her hands again.
+“After not setting eyes upon you or hearing of you for so long a time,
+do I find you here!”
+
+“Don’t call me Solomon. Do you want to be the death of me?” asked the
+man, in a furtive, frightened way.
+
+“Brother, brother!” cried Miss Pross, bursting into tears. “Have I ever
+been so hard with you that you ask me such a cruel question?”
+
+“Then hold your meddlesome tongue,” said Solomon, “and come out, if you
+want to speak to me. Pay for your wine, and come out. Who’s this man?”
+
+Miss Pross, shaking her loving and dejected head at her by no means
+affectionate brother, said through her tears, “Mr. Cruncher.”
+
+“Let him come out too,” said Solomon. “Does he think me a ghost?”
+
+Apparently, Mr. Cruncher did, to judge from his looks. He said not a
+word, however, and Miss Pross, exploring the depths of her reticule
+through her tears with great difficulty paid for her wine. As she did
+so, Solomon turned to the followers of the Good Republican Brutus
+of Antiquity, and offered a few words of explanation in the French
+language, which caused them all to relapse into their former places and
+pursuits.
+
+“Now,” said Solomon, stopping at the dark street corner, “what do you
+want?”
+
+“How dreadfully unkind in a brother nothing has ever turned my love away
+from!” cried Miss Pross, “to give me such a greeting, and show me no
+affection.”
+
+“There. Confound it! There,” said Solomon, making a dab at Miss Pross’s
+lips with his own. “Now are you content?”
+
+Miss Pross only shook her head and wept in silence.
+
+“If you expect me to be surprised,” said her brother Solomon, “I am not
+surprised; I knew you were here; I know of most people who are here. If
+you really don’t want to endanger my existence--which I half believe you
+do--go your ways as soon as possible, and let me go mine. I am busy. I
+am an official.”
+
+“My English brother Solomon,” mourned Miss Pross, casting up her
+tear-fraught eyes, “that had the makings in him of one of the best and
+greatest of men in his native country, an official among foreigners, and
+such foreigners! I would almost sooner have seen the dear boy lying in
+his--”
+
+“I said so!” cried her brother, interrupting. “I knew it. You want to be
+the death of me. I shall be rendered Suspected, by my own sister. Just
+as I am getting on!”
+
+“The gracious and merciful Heavens forbid!” cried Miss Pross. “Far
+rather would I never see you again, dear Solomon, though I have ever
+loved you truly, and ever shall. Say but one affectionate word to me,
+and tell me there is nothing angry or estranged between us, and I will
+detain you no longer.”
+
+Good Miss Pross! As if the estrangement between them had come of any
+culpability of hers. As if Mr. Lorry had not known it for a fact, years
+ago, in the quiet corner in Soho, that this precious brother had spent
+her money and left her!
+
+He was saying the affectionate word, however, with a far more grudging
+condescension and patronage than he could have shown if their relative
+merits and positions had been reversed (which is invariably the case,
+all the world over), when Mr. Cruncher, touching him on the shoulder,
+hoarsely and unexpectedly interposed with the following singular
+question:
+
+“I say! Might I ask the favour? As to whether your name is John Solomon,
+or Solomon John?”
+
+The official turned towards him with sudden distrust. He had not
+previously uttered a word.
+
+“Come!” said Mr. Cruncher. “Speak out, you know.” (Which, by the way,
+was more than he could do himself.) “John Solomon, or Solomon John? She
+calls you Solomon, and she must know, being your sister. And _I_ know
+you’re John, you know. Which of the two goes first? And regarding that
+name of Pross, likewise. That warn’t your name over the water.”
+
+“What do you mean?”
+
+“Well, I don’t know all I mean, for I can’t call to mind what your name
+was, over the water.”
+
+“No?”
+
+“No. But I’ll swear it was a name of two syllables.”
+
+“Indeed?”
+
+“Yes. T’other one’s was one syllable. I know you. You was a spy--witness
+at the Bailey. What, in the name of the Father of Lies, own father to
+yourself, was you called at that time?”
+
+“Barsad,” said another voice, striking in.
+
+“That’s the name for a thousand pound!” cried Jerry.
+
+The speaker who struck in, was Sydney Carton. He had his hands behind
+him under the skirts of his riding-coat, and he stood at Mr. Cruncher’s
+elbow as negligently as he might have stood at the Old Bailey itself.
+
+“Don’t be alarmed, my dear Miss Pross. I arrived at Mr. Lorry’s, to his
+surprise, yesterday evening; we agreed that I would not present myself
+elsewhere until all was well, or unless I could be useful; I present
+myself here, to beg a little talk with your brother. I wish you had a
+better employed brother than Mr. Barsad. I wish for your sake Mr. Barsad
+was not a Sheep of the Prisons.”
+
+Sheep was a cant word of the time for a spy, under the gaolers. The spy,
+who was pale, turned paler, and asked him how he dared--
+
+“I’ll tell you,” said Sydney. “I lighted on you, Mr. Barsad, coming out
+of the prison of the Conciergerie while I was contemplating the walls,
+an hour or more ago. You have a face to be remembered, and I remember
+faces well. Made curious by seeing you in that connection, and having
+a reason, to which you are no stranger, for associating you with
+the misfortunes of a friend now very unfortunate, I walked in your
+direction. I walked into the wine-shop here, close after you, and
+sat near you. I had no difficulty in deducing from your unreserved
+conversation, and the rumour openly going about among your admirers, the
+nature of your calling. And gradually, what I had done at random, seemed
+to shape itself into a purpose, Mr. Barsad.”
+
+“What purpose?” the spy asked.
+
+“It would be troublesome, and might be dangerous, to explain in the
+street. Could you favour me, in confidence, with some minutes of your
+company--at the office of Tellson’s Bank, for instance?”
+
+“Under a threat?”
+
+“Oh! Did I say that?”
+
+“Then, why should I go there?”
+
+“Really, Mr. Barsad, I can’t say, if you can’t.”
+
+“Do you mean that you won’t say, sir?” the spy irresolutely asked.
+
+“You apprehend me very clearly, Mr. Barsad. I won’t.”
+
+Carton’s negligent recklessness of manner came powerfully in aid of his
+quickness and skill, in such a business as he had in his secret mind,
+and with such a man as he had to do with. His practised eye saw it, and
+made the most of it.
+
+“Now, I told you so,” said the spy, casting a reproachful look at his
+sister; “if any trouble comes of this, it’s your doing.”
+
+“Come, come, Mr. Barsad!” exclaimed Sydney. “Don’t be ungrateful.
+But for my great respect for your sister, I might not have led up so
+pleasantly to a little proposal that I wish to make for our mutual
+satisfaction. Do you go with me to the Bank?”
+
+“I’ll hear what you have got to say. Yes, I’ll go with you.”
+
+“I propose that we first conduct your sister safely to the corner of her
+own street. Let me take your arm, Miss Pross. This is not a good city,
+at this time, for you to be out in, unprotected; and as your escort
+knows Mr. Barsad, I will invite him to Mr. Lorry’s with us. Are we
+ready? Come then!”
+
+Miss Pross recalled soon afterwards, and to the end of her life
+remembered, that as she pressed her hands on Sydney’s arm and looked up
+in his face, imploring him to do no hurt to Solomon, there was a braced
+purpose in the arm and a kind of inspiration in the eyes, which not only
+contradicted his light manner, but changed and raised the man. She was
+too much occupied then with fears for the brother who so little deserved
+her affection, and with Sydney’s friendly reassurances, adequately to
+heed what she observed.
+
+They left her at the corner of the street, and Carton led the way to Mr.
+Lorry’s, which was within a few minutes’ walk. John Barsad, or Solomon
+Pross, walked at his side.
+
+Mr. Lorry had just finished his dinner, and was sitting before a cheery
+little log or two of fire--perhaps looking into their blaze for the
+picture of that younger elderly gentleman from Tellson’s, who had looked
+into the red coals at the Royal George at Dover, now a good many years
+ago. He turned his head as they entered, and showed the surprise with
+which he saw a stranger.
+
+“Miss Pross’s brother, sir,” said Sydney. “Mr. Barsad.”
+
+“Barsad?” repeated the old gentleman, “Barsad? I have an association
+with the name--and with the face.”
+
+“I told you you had a remarkable face, Mr. Barsad,” observed Carton,
+coolly. “Pray sit down.”
+
+As he took a chair himself, he supplied the link that Mr. Lorry wanted,
+by saying to him with a frown, “Witness at that trial.” Mr. Lorry
+immediately remembered, and regarded his new visitor with an undisguised
+look of abhorrence.
+
+“Mr. Barsad has been recognised by Miss Pross as the affectionate
+brother you have heard of,” said Sydney, “and has acknowledged the
+relationship. I pass to worse news. Darnay has been arrested again.”
+
+Struck with consternation, the old gentleman exclaimed, “What do you
+tell me! I left him safe and free within these two hours, and am about
+to return to him!”
+
+“Arrested for all that. When was it done, Mr. Barsad?”
+
+“Just now, if at all.”
+
+“Mr. Barsad is the best authority possible, sir,” said Sydney, “and I
+have it from Mr. Barsad’s communication to a friend and brother Sheep
+over a bottle of wine, that the arrest has taken place. He left the
+messengers at the gate, and saw them admitted by the porter. There is no
+earthly doubt that he is retaken.”
+
+Mr. Lorry’s business eye read in the speaker’s face that it was loss
+of time to dwell upon the point. Confused, but sensible that something
+might depend on his presence of mind, he commanded himself, and was
+silently attentive.
+
+“Now, I trust,” said Sydney to him, “that the name and influence of
+Doctor Manette may stand him in as good stead to-morrow--you said he
+would be before the Tribunal again to-morrow, Mr. Barsad?--”
+
+“Yes; I believe so.”
+
+“--In as good stead to-morrow as to-day. But it may not be so. I own
+to you, I am shaken, Mr. Lorry, by Doctor Manette’s not having had the
+power to prevent this arrest.”
+
+“He may not have known of it beforehand,” said Mr. Lorry.
+
+“But that very circumstance would be alarming, when we remember how
+identified he is with his son-in-law.”
+
+“That’s true,” Mr. Lorry acknowledged, with his troubled hand at his
+chin, and his troubled eyes on Carton.
+
+“In short,” said Sydney, “this is a desperate time, when desperate games
+are played for desperate stakes. Let the Doctor play the winning game; I
+will play the losing one. No man’s life here is worth purchase. Any one
+carried home by the people to-day, may be condemned tomorrow. Now, the
+stake I have resolved to play for, in case of the worst, is a friend
+in the Conciergerie. And the friend I purpose to myself to win, is Mr.
+Barsad.”
+
+“You need have good cards, sir,” said the spy.
+
+“I’ll run them over. I’ll see what I hold,--Mr. Lorry, you know what a
+brute I am; I wish you’d give me a little brandy.”
+
+It was put before him, and he drank off a glassful--drank off another
+glassful--pushed the bottle thoughtfully away.
+
+“Mr. Barsad,” he went on, in the tone of one who really was looking
+over a hand at cards: “Sheep of the prisons, emissary of Republican
+committees, now turnkey, now prisoner, always spy and secret informer,
+so much the more valuable here for being English that an Englishman
+is less open to suspicion of subornation in those characters than a
+Frenchman, represents himself to his employers under a false name.
+That’s a very good card. Mr. Barsad, now in the employ of the republican
+French government, was formerly in the employ of the aristocratic
+English government, the enemy of France and freedom. That’s an excellent
+card. Inference clear as day in this region of suspicion, that Mr.
+Barsad, still in the pay of the aristocratic English government, is the
+spy of Pitt, the treacherous foe of the Republic crouching in its bosom,
+the English traitor and agent of all mischief so much spoken of and so
+difficult to find. That’s a card not to be beaten. Have you followed my
+hand, Mr. Barsad?”
+
+“Not to understand your play,” returned the spy, somewhat uneasily.
+
+“I play my Ace, Denunciation of Mr. Barsad to the nearest Section
+Committee. Look over your hand, Mr. Barsad, and see what you have. Don’t
+hurry.”
+
+He drew the bottle near, poured out another glassful of brandy, and
+drank it off. He saw that the spy was fearful of his drinking himself
+into a fit state for the immediate denunciation of him. Seeing it, he
+poured out and drank another glassful.
+
+“Look over your hand carefully, Mr. Barsad. Take time.”
+
+It was a poorer hand than he suspected. Mr. Barsad saw losing cards
+in it that Sydney Carton knew nothing of. Thrown out of his honourable
+employment in England, through too much unsuccessful hard swearing
+there--not because he was not wanted there; our English reasons for
+vaunting our superiority to secrecy and spies are of very modern
+date--he knew that he had crossed the Channel, and accepted service in
+France: first, as a tempter and an eavesdropper among his own countrymen
+there: gradually, as a tempter and an eavesdropper among the natives. He
+knew that under the overthrown government he had been a spy upon Saint
+Antoine and Defarge’s wine-shop; had received from the watchful police
+such heads of information concerning Doctor Manette’s imprisonment,
+release, and history, as should serve him for an introduction to
+familiar conversation with the Defarges; and tried them on Madame
+Defarge, and had broken down with them signally. He always remembered
+with fear and trembling, that that terrible woman had knitted when he
+talked with her, and had looked ominously at him as her fingers moved.
+He had since seen her, in the Section of Saint Antoine, over and over
+again produce her knitted registers, and denounce people whose lives the
+guillotine then surely swallowed up. He knew, as every one employed as
+he was did, that he was never safe; that flight was impossible; that
+he was tied fast under the shadow of the axe; and that in spite of
+his utmost tergiversation and treachery in furtherance of the reigning
+terror, a word might bring it down upon him. Once denounced, and on such
+grave grounds as had just now been suggested to his mind, he foresaw
+that the dreadful woman of whose unrelenting character he had seen many
+proofs, would produce against him that fatal register, and would quash
+his last chance of life. Besides that all secret men are men soon
+terrified, here were surely cards enough of one black suit, to justify
+the holder in growing rather livid as he turned them over.
+
+“You scarcely seem to like your hand,” said Sydney, with the greatest
+composure. “Do you play?”
+
+“I think, sir,” said the spy, in the meanest manner, as he turned to Mr.
+Lorry, “I may appeal to a gentleman of your years and benevolence, to
+put it to this other gentleman, so much your junior, whether he can
+under any circumstances reconcile it to his station to play that Ace
+of which he has spoken. I admit that _I_ am a spy, and that it is
+considered a discreditable station--though it must be filled by
+somebody; but this gentleman is no spy, and why should he so demean
+himself as to make himself one?”
+
+“I play my Ace, Mr. Barsad,” said Carton, taking the answer on himself,
+and looking at his watch, “without any scruple, in a very few minutes.”
+
+“I should have hoped, gentlemen both,” said the spy, always striving to
+hook Mr. Lorry into the discussion, “that your respect for my sister--”
+
+“I could not better testify my respect for your sister than by finally
+relieving her of her brother,” said Sydney Carton.
+
+“You think not, sir?”
+
+“I have thoroughly made up my mind about it.”
+
+The smooth manner of the spy, curiously in dissonance with his
+ostentatiously rough dress, and probably with his usual demeanour,
+received such a check from the inscrutability of Carton,--who was a
+mystery to wiser and honester men than he,--that it faltered here and
+failed him. While he was at a loss, Carton said, resuming his former air
+of contemplating cards:
+
+“And indeed, now I think again, I have a strong impression that I
+have another good card here, not yet enumerated. That friend and
+fellow-Sheep, who spoke of himself as pasturing in the country prisons;
+who was he?”
+
+“French. You don’t know him,” said the spy, quickly.
+
+“French, eh?” repeated Carton, musing, and not appearing to notice him
+at all, though he echoed his word. “Well; he may be.”
+
+“Is, I assure you,” said the spy; “though it’s not important.”
+
+“Though it’s not important,” repeated Carton, in the same mechanical
+way--“though it’s not important--No, it’s not important. No. Yet I know
+the face.”
+
+“I think not. I am sure not. It can’t be,” said the spy.
+
+“It-can’t-be,” muttered Sydney Carton, retrospectively, and idling his
+glass (which fortunately was a small one) again. “Can’t-be. Spoke good
+French. Yet like a foreigner, I thought?”
+
+“Provincial,” said the spy.
+
+“No. Foreign!” cried Carton, striking his open hand on the table, as a
+light broke clearly on his mind. “Cly! Disguised, but the same man. We
+had that man before us at the Old Bailey.”
+
+“Now, there you are hasty, sir,” said Barsad, with a smile that gave his
+aquiline nose an extra inclination to one side; “there you really give
+me an advantage over you. Cly (who I will unreservedly admit, at this
+distance of time, was a partner of mine) has been dead several years. I
+attended him in his last illness. He was buried in London, at the church
+of Saint Pancras-in-the-Fields. His unpopularity with the blackguard
+multitude at the moment prevented my following his remains, but I helped
+to lay him in his coffin.”
+
+Here, Mr. Lorry became aware, from where he sat, of a most remarkable
+goblin shadow on the wall. Tracing it to its source, he discovered it
+to be caused by a sudden extraordinary rising and stiffening of all the
+risen and stiff hair on Mr. Cruncher’s head.
+
+“Let us be reasonable,” said the spy, “and let us be fair. To show you
+how mistaken you are, and what an unfounded assumption yours is, I will
+lay before you a certificate of Cly’s burial, which I happened to have
+carried in my pocket-book,” with a hurried hand he produced and opened
+it, “ever since. There it is. Oh, look at it, look at it! You may take
+it in your hand; it’s no forgery.”
+
+Here, Mr. Lorry perceived the reflection on the wall to elongate, and
+Mr. Cruncher rose and stepped forward. His hair could not have been more
+violently on end, if it had been that moment dressed by the Cow with the
+crumpled horn in the house that Jack built.
+
+Unseen by the spy, Mr. Cruncher stood at his side, and touched him on
+the shoulder like a ghostly bailiff.
+
+“That there Roger Cly, master,” said Mr. Cruncher, with a taciturn and
+iron-bound visage. “So _you_ put him in his coffin?”
+
+“I did.”
+
+“Who took him out of it?”
+
+Barsad leaned back in his chair, and stammered, “What do you mean?”
+
+“I mean,” said Mr. Cruncher, “that he warn’t never in it. No! Not he!
+I’ll have my head took off, if he was ever in it.”
+
+The spy looked round at the two gentlemen; they both looked in
+unspeakable astonishment at Jerry.
+
+“I tell you,” said Jerry, “that you buried paving-stones and earth in
+that there coffin. Don’t go and tell me that you buried Cly. It was a
+take in. Me and two more knows it.”
+
+“How do you know it?”
+
+“What’s that to you? Ecod!” growled Mr. Cruncher, “it’s you I have got a
+old grudge again, is it, with your shameful impositions upon tradesmen!
+I’d catch hold of your throat and choke you for half a guinea.”
+
+Sydney Carton, who, with Mr. Lorry, had been lost in amazement at
+this turn of the business, here requested Mr. Cruncher to moderate and
+explain himself.
+
+“At another time, sir,” he returned, evasively, “the present time is
+ill-conwenient for explainin’. What I stand to, is, that he knows well
+wot that there Cly was never in that there coffin. Let him say he was,
+in so much as a word of one syllable, and I’ll either catch hold of his
+throat and choke him for half a guinea;” Mr. Cruncher dwelt upon this as
+quite a liberal offer; “or I’ll out and announce him.”
+
+“Humph! I see one thing,” said Carton. “I hold another card, Mr. Barsad.
+Impossible, here in raging Paris, with Suspicion filling the air, for
+you to outlive denunciation, when you are in communication with another
+aristocratic spy of the same antecedents as yourself, who, moreover, has
+the mystery about him of having feigned death and come to life again!
+A plot in the prisons, of the foreigner against the Republic. A strong
+card--a certain Guillotine card! Do you play?”
+
+“No!” returned the spy. “I throw up. I confess that we were so unpopular
+with the outrageous mob, that I only got away from England at the risk
+of being ducked to death, and that Cly was so ferreted up and down, that
+he never would have got away at all but for that sham. Though how this
+man knows it was a sham, is a wonder of wonders to me.”
+
+“Never you trouble your head about this man,” retorted the contentious
+Mr. Cruncher; “you’ll have trouble enough with giving your attention to
+that gentleman. And look here! Once more!”--Mr. Cruncher could not
+be restrained from making rather an ostentatious parade of his
+liberality--“I’d catch hold of your throat and choke you for half a
+guinea.”
+
+The Sheep of the prisons turned from him to Sydney Carton, and said,
+with more decision, “It has come to a point. I go on duty soon, and
+can’t overstay my time. You told me you had a proposal; what is it?
+Now, it is of no use asking too much of me. Ask me to do anything in my
+office, putting my head in great extra danger, and I had better trust my
+life to the chances of a refusal than the chances of consent. In short,
+I should make that choice. You talk of desperation. We are all desperate
+here. Remember! I may denounce you if I think proper, and I can swear my
+way through stone walls, and so can others. Now, what do you want with
+me?”
+
+“Not very much. You are a turnkey at the Conciergerie?”
+
+“I tell you once for all, there is no such thing as an escape possible,”
+ said the spy, firmly.
+
+“Why need you tell me what I have not asked? You are a turnkey at the
+Conciergerie?”
+
+“I am sometimes.”
+
+“You can be when you choose?”
+
+“I can pass in and out when I choose.”
+
+Sydney Carton filled another glass with brandy, poured it slowly out
+upon the hearth, and watched it as it dropped. It being all spent, he
+said, rising:
+
+“So far, we have spoken before these two, because it was as well that
+the merits of the cards should not rest solely between you and me. Come
+into the dark room here, and let us have one final word alone.”
+
+
+
+
+IX. The Game Made
+
+
+While Sydney Carton and the Sheep of the prisons were in the adjoining
+dark room, speaking so low that not a sound was heard, Mr. Lorry looked
+at Jerry in considerable doubt and mistrust. That honest tradesman’s
+manner of receiving the look, did not inspire confidence; he changed the
+leg on which he rested, as often as if he had fifty of those limbs,
+and were trying them all; he examined his finger-nails with a very
+questionable closeness of attention; and whenever Mr. Lorry’s eye caught
+his, he was taken with that peculiar kind of short cough requiring the
+hollow of a hand before it, which is seldom, if ever, known to be an
+infirmity attendant on perfect openness of character.
+
+“Jerry,” said Mr. Lorry. “Come here.”
+
+Mr. Cruncher came forward sideways, with one of his shoulders in advance
+of him.
+
+“What have you been, besides a messenger?”
+
+After some cogitation, accompanied with an intent look at his patron,
+Mr. Cruncher conceived the luminous idea of replying, “Agicultooral
+character.”
+
+“My mind misgives me much,” said Mr. Lorry, angrily shaking a forefinger
+at him, “that you have used the respectable and great house of Tellson’s
+as a blind, and that you have had an unlawful occupation of an infamous
+description. If you have, don’t expect me to befriend you when you
+get back to England. If you have, don’t expect me to keep your secret.
+Tellson’s shall not be imposed upon.”
+
+“I hope, sir,” pleaded the abashed Mr. Cruncher, “that a gentleman like
+yourself wot I’ve had the honour of odd jobbing till I’m grey at it,
+would think twice about harming of me, even if it wos so--I don’t say it
+is, but even if it wos. And which it is to be took into account that if
+it wos, it wouldn’t, even then, be all o’ one side. There’d be two sides
+to it. There might be medical doctors at the present hour, a picking
+up their guineas where a honest tradesman don’t pick up his
+fardens--fardens! no, nor yet his half fardens--half fardens! no, nor
+yet his quarter--a banking away like smoke at Tellson’s, and a cocking
+their medical eyes at that tradesman on the sly, a going in and going
+out to their own carriages--ah! equally like smoke, if not more so.
+Well, that ‘ud be imposing, too, on Tellson’s. For you cannot sarse the
+goose and not the gander. And here’s Mrs. Cruncher, or leastways wos
+in the Old England times, and would be to-morrow, if cause given,
+a floppin’ again the business to that degree as is ruinating--stark
+ruinating! Whereas them medical doctors’ wives don’t flop--catch ‘em at
+it! Or, if they flop, their floppings goes in favour of more patients,
+and how can you rightly have one without t’other? Then, wot with
+undertakers, and wot with parish clerks, and wot with sextons, and wot
+with private watchmen (all awaricious and all in it), a man wouldn’t get
+much by it, even if it wos so. And wot little a man did get, would never
+prosper with him, Mr. Lorry. He’d never have no good of it; he’d want
+all along to be out of the line, if he, could see his way out, being
+once in--even if it wos so.”
+
+“Ugh!” cried Mr. Lorry, rather relenting, nevertheless, “I am shocked at
+the sight of you.”
+
+“Now, what I would humbly offer to you, sir,” pursued Mr. Cruncher,
+“even if it wos so, which I don’t say it is--”
+
+“Don’t prevaricate,” said Mr. Lorry.
+
+“No, I will _not_, sir,” returned Mr. Crunches as if nothing were
+further from his thoughts or practice--“which I don’t say it is--wot I
+would humbly offer to you, sir, would be this. Upon that there stool, at
+that there Bar, sets that there boy of mine, brought up and growed up to
+be a man, wot will errand you, message you, general-light-job you, till
+your heels is where your head is, if such should be your wishes. If it
+wos so, which I still don’t say it is (for I will not prewaricate to
+you, sir), let that there boy keep his father’s place, and take care of
+his mother; don’t blow upon that boy’s father--do not do it, sir--and
+let that father go into the line of the reg’lar diggin’, and make amends
+for what he would have undug--if it wos so--by diggin’ of ‘em in with
+a will, and with conwictions respectin’ the futur’ keepin’ of ‘em safe.
+That, Mr. Lorry,” said Mr. Cruncher, wiping his forehead with his
+arm, as an announcement that he had arrived at the peroration of his
+discourse, “is wot I would respectfully offer to you, sir. A man don’t
+see all this here a goin’ on dreadful round him, in the way of Subjects
+without heads, dear me, plentiful enough fur to bring the price down
+to porterage and hardly that, without havin’ his serious thoughts of
+things. And these here would be mine, if it wos so, entreatin’ of you
+fur to bear in mind that wot I said just now, I up and said in the good
+cause when I might have kep’ it back.”
+
+“That at least is true,” said Mr. Lorry. “Say no more now. It may be
+that I shall yet stand your friend, if you deserve it, and repent in
+action--not in words. I want no more words.”
+
+Mr. Cruncher knuckled his forehead, as Sydney Carton and the spy
+returned from the dark room. “Adieu, Mr. Barsad,” said the former; “our
+arrangement thus made, you have nothing to fear from me.”
+
+He sat down in a chair on the hearth, over against Mr. Lorry. When they
+were alone, Mr. Lorry asked him what he had done?
+
+“Not much. If it should go ill with the prisoner, I have ensured access
+to him, once.”
+
+Mr. Lorry’s countenance fell.
+
+“It is all I could do,” said Carton. “To propose too much, would be
+to put this man’s head under the axe, and, as he himself said, nothing
+worse could happen to him if he were denounced. It was obviously the
+weakness of the position. There is no help for it.”
+
+“But access to him,” said Mr. Lorry, “if it should go ill before the
+Tribunal, will not save him.”
+
+“I never said it would.”
+
+Mr. Lorry’s eyes gradually sought the fire; his sympathy with his
+darling, and the heavy disappointment of his second arrest, gradually
+weakened them; he was an old man now, overborne with anxiety of late,
+and his tears fell.
+
+“You are a good man and a true friend,” said Carton, in an altered
+voice. “Forgive me if I notice that you are affected. I could not see my
+father weep, and sit by, careless. And I could not respect your
+sorrow more, if you were my father. You are free from that misfortune,
+however.”
+
+Though he said the last words, with a slip into his usual manner, there
+was a true feeling and respect both in his tone and in his touch,
+that Mr. Lorry, who had never seen the better side of him, was wholly
+unprepared for. He gave him his hand, and Carton gently pressed it.
+
+“To return to poor Darnay,” said Carton. “Don’t tell Her of this
+interview, or this arrangement. It would not enable Her to go to see
+him. She might think it was contrived, in case of the worse, to convey
+to him the means of anticipating the sentence.”
+
+Mr. Lorry had not thought of that, and he looked quickly at Carton to
+see if it were in his mind. It seemed to be; he returned the look, and
+evidently understood it.
+
+“She might think a thousand things,” Carton said, “and any of them would
+only add to her trouble. Don’t speak of me to her. As I said to you when
+I first came, I had better not see her. I can put my hand out, to do any
+little helpful work for her that my hand can find to do, without that.
+You are going to her, I hope? She must be very desolate to-night.”
+
+“I am going now, directly.”
+
+“I am glad of that. She has such a strong attachment to you and reliance
+on you. How does she look?”
+
+“Anxious and unhappy, but very beautiful.”
+
+“Ah!”
+
+It was a long, grieving sound, like a sigh--almost like a sob. It
+attracted Mr. Lorry’s eyes to Carton’s face, which was turned to the
+fire. A light, or a shade (the old gentleman could not have said which),
+passed from it as swiftly as a change will sweep over a hill-side on a
+wild bright day, and he lifted his foot to put back one of the little
+flaming logs, which was tumbling forward. He wore the white riding-coat
+and top-boots, then in vogue, and the light of the fire touching their
+light surfaces made him look very pale, with his long brown hair,
+all untrimmed, hanging loose about him. His indifference to fire was
+sufficiently remarkable to elicit a word of remonstrance from Mr. Lorry;
+his boot was still upon the hot embers of the flaming log, when it had
+broken under the weight of his foot.
+
+“I forgot it,” he said.
+
+Mr. Lorry’s eyes were again attracted to his face. Taking note of the
+wasted air which clouded the naturally handsome features, and having
+the expression of prisoners’ faces fresh in his mind, he was strongly
+reminded of that expression.
+
+“And your duties here have drawn to an end, sir?” said Carton, turning
+to him.
+
+“Yes. As I was telling you last night when Lucie came in so
+unexpectedly, I have at length done all that I can do here. I hoped to
+have left them in perfect safety, and then to have quitted Paris. I have
+my Leave to Pass. I was ready to go.”
+
+They were both silent.
+
+“Yours is a long life to look back upon, sir?” said Carton, wistfully.
+
+“I am in my seventy-eighth year.”
+
+“You have been useful all your life; steadily and constantly occupied;
+trusted, respected, and looked up to?”
+
+“I have been a man of business, ever since I have been a man. Indeed, I
+may say that I was a man of business when a boy.”
+
+“See what a place you fill at seventy-eight. How many people will miss
+you when you leave it empty!”
+
+“A solitary old bachelor,” answered Mr. Lorry, shaking his head. “There
+is nobody to weep for me.”
+
+“How can you say that? Wouldn’t She weep for you? Wouldn’t her child?”
+
+“Yes, yes, thank God. I didn’t quite mean what I said.”
+
+“It _is_ a thing to thank God for; is it not?”
+
+“Surely, surely.”
+
+“If you could say, with truth, to your own solitary heart, to-night,
+‘I have secured to myself the love and attachment, the gratitude or
+respect, of no human creature; I have won myself a tender place in no
+regard; I have done nothing good or serviceable to be remembered by!’
+your seventy-eight years would be seventy-eight heavy curses; would they
+not?”
+
+“You say truly, Mr. Carton; I think they would be.”
+
+Sydney turned his eyes again upon the fire, and, after a silence of a
+few moments, said:
+
+“I should like to ask you:--Does your childhood seem far off? Do the
+days when you sat at your mother’s knee, seem days of very long ago?”
+
+Responding to his softened manner, Mr. Lorry answered:
+
+“Twenty years back, yes; at this time of my life, no. For, as I draw
+closer and closer to the end, I travel in the circle, nearer and
+nearer to the beginning. It seems to be one of the kind smoothings and
+preparings of the way. My heart is touched now, by many remembrances
+that had long fallen asleep, of my pretty young mother (and I so old!),
+and by many associations of the days when what we call the World was not
+so real with me, and my faults were not confirmed in me.”
+
+“I understand the feeling!” exclaimed Carton, with a bright flush. “And
+you are the better for it?”
+
+“I hope so.”
+
+Carton terminated the conversation here, by rising to help him on with
+his outer coat; “But you,” said Mr. Lorry, reverting to the theme, “you
+are young.”
+
+“Yes,” said Carton. “I am not old, but my young way was never the way to
+age. Enough of me.”
+
+“And of me, I am sure,” said Mr. Lorry. “Are you going out?”
+
+“I’ll walk with you to her gate. You know my vagabond and restless
+habits. If I should prowl about the streets a long time, don’t be
+uneasy; I shall reappear in the morning. You go to the Court to-morrow?”
+
+“Yes, unhappily.”
+
+“I shall be there, but only as one of the crowd. My Spy will find a
+place for me. Take my arm, sir.”
+
+Mr. Lorry did so, and they went down-stairs and out in the streets. A
+few minutes brought them to Mr. Lorry’s destination. Carton left him
+there; but lingered at a little distance, and turned back to the gate
+again when it was shut, and touched it. He had heard of her going to
+the prison every day. “She came out here,” he said, looking about him,
+“turned this way, must have trod on these stones often. Let me follow in
+her steps.”
+
+It was ten o’clock at night when he stood before the prison of La Force,
+where she had stood hundreds of times. A little wood-sawyer, having
+closed his shop, was smoking his pipe at his shop-door.
+
+“Good night, citizen,” said Sydney Carton, pausing in going by; for, the
+man eyed him inquisitively.
+
+“Good night, citizen.”
+
+“How goes the Republic?”
+
+“You mean the Guillotine. Not ill. Sixty-three to-day. We shall mount
+to a hundred soon. Samson and his men complain sometimes, of being
+exhausted. Ha, ha, ha! He is so droll, that Samson. Such a Barber!”
+
+“Do you often go to see him--”
+
+“Shave? Always. Every day. What a barber! You have seen him at work?”
+
+“Never.”
+
+“Go and see him when he has a good batch. Figure this to yourself,
+citizen; he shaved the sixty-three to-day, in less than two pipes! Less
+than two pipes. Word of honour!”
+
+As the grinning little man held out the pipe he was smoking, to explain
+how he timed the executioner, Carton was so sensible of a rising desire
+to strike the life out of him, that he turned away.
+
+“But you are not English,” said the wood-sawyer, “though you wear
+English dress?”
+
+“Yes,” said Carton, pausing again, and answering over his shoulder.
+
+“You speak like a Frenchman.”
+
+“I am an old student here.”
+
+“Aha, a perfect Frenchman! Good night, Englishman.”
+
+“Good night, citizen.”
+
+“But go and see that droll dog,” the little man persisted, calling after
+him. “And take a pipe with you!”
+
+Sydney had not gone far out of sight, when he stopped in the middle of
+the street under a glimmering lamp, and wrote with his pencil on a scrap
+of paper. Then, traversing with the decided step of one who remembered
+the way well, several dark and dirty streets--much dirtier than usual,
+for the best public thoroughfares remained uncleansed in those times of
+terror--he stopped at a chemist’s shop, which the owner was closing with
+his own hands. A small, dim, crooked shop, kept in a tortuous, up-hill
+thoroughfare, by a small, dim, crooked man.
+
+Giving this citizen, too, good night, as he confronted him at his
+counter, he laid the scrap of paper before him. “Whew!” the chemist
+whistled softly, as he read it. “Hi! hi! hi!”
+
+Sydney Carton took no heed, and the chemist said:
+
+“For you, citizen?”
+
+“For me.”
+
+“You will be careful to keep them separate, citizen? You know the
+consequences of mixing them?”
+
+“Perfectly.”
+
+Certain small packets were made and given to him. He put them, one by
+one, in the breast of his inner coat, counted out the money for them,
+and deliberately left the shop. “There is nothing more to do,” said he,
+glancing upward at the moon, “until to-morrow. I can’t sleep.”
+
+It was not a reckless manner, the manner in which he said these words
+aloud under the fast-sailing clouds, nor was it more expressive of
+negligence than defiance. It was the settled manner of a tired man, who
+had wandered and struggled and got lost, but who at length struck into
+his road and saw its end.
+
+Long ago, when he had been famous among his earliest competitors as a
+youth of great promise, he had followed his father to the grave. His
+mother had died, years before. These solemn words, which had been
+read at his father’s grave, arose in his mind as he went down the dark
+streets, among the heavy shadows, with the moon and the clouds sailing
+on high above him. “I am the resurrection and the life, saith the Lord:
+he that believeth in me, though he were dead, yet shall he live: and
+whosoever liveth and believeth in me, shall never die.”
+
+In a city dominated by the axe, alone at night, with natural sorrow
+rising in him for the sixty-three who had been that day put to death,
+and for to-morrow’s victims then awaiting their doom in the prisons,
+and still of to-morrow’s and to-morrow’s, the chain of association that
+brought the words home, like a rusty old ship’s anchor from the deep,
+might have been easily found. He did not seek it, but repeated them and
+went on.
+
+With a solemn interest in the lighted windows where the people were
+going to rest, forgetful through a few calm hours of the horrors
+surrounding them; in the towers of the churches, where no prayers
+were said, for the popular revulsion had even travelled that length
+of self-destruction from years of priestly impostors, plunderers, and
+profligates; in the distant burial-places, reserved, as they wrote upon
+the gates, for Eternal Sleep; in the abounding gaols; and in the streets
+along which the sixties rolled to a death which had become so common and
+material, that no sorrowful story of a haunting Spirit ever arose among
+the people out of all the working of the Guillotine; with a solemn
+interest in the whole life and death of the city settling down to its
+short nightly pause in fury; Sydney Carton crossed the Seine again for
+the lighter streets.
+
+Few coaches were abroad, for riders in coaches were liable to be
+suspected, and gentility hid its head in red nightcaps, and put on heavy
+shoes, and trudged. But, the theatres were all well filled, and the
+people poured cheerfully out as he passed, and went chatting home. At
+one of the theatre doors, there was a little girl with a mother, looking
+for a way across the street through the mud. He carried the child over,
+and before the timid arm was loosed from his neck asked her for a kiss.
+
+“I am the resurrection and the life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me, shall never die.”
+
+Now, that the streets were quiet, and the night wore on, the words
+were in the echoes of his feet, and were in the air. Perfectly calm
+and steady, he sometimes repeated them to himself as he walked; but, he
+heard them always.
+
+The night wore out, and, as he stood upon the bridge listening to the
+water as it splashed the river-walls of the Island of Paris, where the
+picturesque confusion of houses and cathedral shone bright in the light
+of the moon, the day came coldly, looking like a dead face out of the
+sky. Then, the night, with the moon and the stars, turned pale and died,
+and for a little while it seemed as if Creation were delivered over to
+Death’s dominion.
+
+But, the glorious sun, rising, seemed to strike those words, that burden
+of the night, straight and warm to his heart in its long bright rays.
+And looking along them, with reverently shaded eyes, a bridge of light
+appeared to span the air between him and the sun, while the river
+sparkled under it.
+
+The strong tide, so swift, so deep, and certain, was like a congenial
+friend, in the morning stillness. He walked by the stream, far from the
+houses, and in the light and warmth of the sun fell asleep on the
+bank. When he awoke and was afoot again, he lingered there yet a little
+longer, watching an eddy that turned and turned purposeless, until the
+stream absorbed it, and carried it on to the sea.--“Like me.”
+
+A trading-boat, with a sail of the softened colour of a dead leaf, then
+glided into his view, floated by him, and died away. As its silent track
+in the water disappeared, the prayer that had broken up out of his heart
+for a merciful consideration of all his poor blindnesses and errors,
+ended in the words, “I am the resurrection and the life.”
+
+Mr. Lorry was already out when he got back, and it was easy to surmise
+where the good old man was gone. Sydney Carton drank nothing but a
+little coffee, ate some bread, and, having washed and changed to refresh
+himself, went out to the place of trial.
+
+The court was all astir and a-buzz, when the black sheep--whom many fell
+away from in dread--pressed him into an obscure corner among the crowd.
+Mr. Lorry was there, and Doctor Manette was there. She was there,
+sitting beside her father.
+
+When her husband was brought in, she turned a look upon him, so
+sustaining, so encouraging, so full of admiring love and pitying
+tenderness, yet so courageous for his sake, that it called the healthy
+blood into his face, brightened his glance, and animated his heart. If
+there had been any eyes to notice the influence of her look, on Sydney
+Carton, it would have been seen to be the same influence exactly.
+
+Before that unjust Tribunal, there was little or no order of procedure,
+ensuring to any accused person any reasonable hearing. There could have
+been no such Revolution, if all laws, forms, and ceremonies, had not
+first been so monstrously abused, that the suicidal vengeance of the
+Revolution was to scatter them all to the winds.
+
+Every eye was turned to the jury. The same determined patriots and good
+republicans as yesterday and the day before, and to-morrow and the day
+after. Eager and prominent among them, one man with a craving face, and
+his fingers perpetually hovering about his lips, whose appearance
+gave great satisfaction to the spectators. A life-thirsting,
+cannibal-looking, bloody-minded juryman, the Jacques Three of St.
+Antoine. The whole jury, as a jury of dogs empannelled to try the deer.
+
+Every eye then turned to the five judges and the public prosecutor.
+No favourable leaning in that quarter to-day. A fell, uncompromising,
+murderous business-meaning there. Every eye then sought some other eye
+in the crowd, and gleamed at it approvingly; and heads nodded at one
+another, before bending forward with a strained attention.
+
+Charles Evremonde, called Darnay. Released yesterday. Reaccused and
+retaken yesterday. Indictment delivered to him last night. Suspected and
+Denounced enemy of the Republic, Aristocrat, one of a family of tyrants,
+one of a race proscribed, for that they had used their abolished
+privileges to the infamous oppression of the people. Charles Evremonde,
+called Darnay, in right of such proscription, absolutely Dead in Law.
+
+To this effect, in as few or fewer words, the Public Prosecutor.
+
+The President asked, was the Accused openly denounced or secretly?
+
+“Openly, President.”
+
+“By whom?”
+
+“Three voices. Ernest Defarge, wine-vendor of St. Antoine.”
+
+“Good.”
+
+“Therese Defarge, his wife.”
+
+“Good.”
+
+“Alexandre Manette, physician.”
+
+A great uproar took place in the court, and in the midst of it, Doctor
+Manette was seen, pale and trembling, standing where he had been seated.
+
+“President, I indignantly protest to you that this is a forgery and
+a fraud. You know the accused to be the husband of my daughter. My
+daughter, and those dear to her, are far dearer to me than my life. Who
+and where is the false conspirator who says that I denounce the husband
+of my child!”
+
+“Citizen Manette, be tranquil. To fail in submission to the authority of
+the Tribunal would be to put yourself out of Law. As to what is dearer
+to you than life, nothing can be so dear to a good citizen as the
+Republic.”
+
+Loud acclamations hailed this rebuke. The President rang his bell, and
+with warmth resumed.
+
+“If the Republic should demand of you the sacrifice of your child
+herself, you would have no duty but to sacrifice her. Listen to what is
+to follow. In the meanwhile, be silent!”
+
+Frantic acclamations were again raised. Doctor Manette sat down, with
+his eyes looking around, and his lips trembling; his daughter drew
+closer to him. The craving man on the jury rubbed his hands together,
+and restored the usual hand to his mouth.
+
+Defarge was produced, when the court was quiet enough to admit of his
+being heard, and rapidly expounded the story of the imprisonment, and of
+his having been a mere boy in the Doctor’s service, and of the release,
+and of the state of the prisoner when released and delivered to him.
+This short examination followed, for the court was quick with its work.
+
+“You did good service at the taking of the Bastille, citizen?”
+
+“I believe so.”
+
+Here, an excited woman screeched from the crowd: “You were one of the
+best patriots there. Why not say so? You were a cannonier that day
+there, and you were among the first to enter the accursed fortress when
+it fell. Patriots, I speak the truth!”
+
+It was The Vengeance who, amidst the warm commendations of the audience,
+thus assisted the proceedings. The President rang his bell; but, The
+Vengeance, warming with encouragement, shrieked, “I defy that bell!”
+ wherein she was likewise much commended.
+
+“Inform the Tribunal of what you did that day within the Bastille,
+citizen.”
+
+“I knew,” said Defarge, looking down at his wife, who stood at the
+bottom of the steps on which he was raised, looking steadily up at him;
+“I knew that this prisoner, of whom I speak, had been confined in a cell
+known as One Hundred and Five, North Tower. I knew it from himself. He
+knew himself by no other name than One Hundred and Five, North Tower,
+when he made shoes under my care. As I serve my gun that day, I resolve,
+when the place shall fall, to examine that cell. It falls. I mount to
+the cell, with a fellow-citizen who is one of the Jury, directed by a
+gaoler. I examine it, very closely. In a hole in the chimney, where a
+stone has been worked out and replaced, I find a written paper. This is
+that written paper. I have made it my business to examine some specimens
+of the writing of Doctor Manette. This is the writing of Doctor Manette.
+I confide this paper, in the writing of Doctor Manette, to the hands of
+the President.”
+
+“Let it be read.”
+
+In a dead silence and stillness--the prisoner under trial looking
+lovingly at his wife, his wife only looking from him to look with
+solicitude at her father, Doctor Manette keeping his eyes fixed on the
+reader, Madame Defarge never taking hers from the prisoner, Defarge
+never taking his from his feasting wife, and all the other eyes there
+intent upon the Doctor, who saw none of them--the paper was read, as
+follows.
+
+
+
+
+X. The Substance of the Shadow
+
+
+“I, Alexandre Manette, unfortunate physician, native of Beauvais, and
+afterwards resident in Paris, write this melancholy paper in my doleful
+cell in the Bastille, during the last month of the year, 1767. I write
+it at stolen intervals, under every difficulty. I design to secrete it
+in the wall of the chimney, where I have slowly and laboriously made a
+place of concealment for it. Some pitying hand may find it there, when I
+and my sorrows are dust.
+
+“These words are formed by the rusty iron point with which I write with
+difficulty in scrapings of soot and charcoal from the chimney, mixed
+with blood, in the last month of the tenth year of my captivity. Hope
+has quite departed from my breast. I know from terrible warnings I have
+noted in myself that my reason will not long remain unimpaired, but I
+solemnly declare that I am at this time in the possession of my right
+mind--that my memory is exact and circumstantial--and that I write the
+truth as I shall answer for these my last recorded words, whether they
+be ever read by men or not, at the Eternal Judgment-seat.
+
+“One cloudy moonlight night, in the third week of December (I think the
+twenty-second of the month) in the year 1757, I was walking on a retired
+part of the quay by the Seine for the refreshment of the frosty air,
+at an hour’s distance from my place of residence in the Street of the
+School of Medicine, when a carriage came along behind me, driven very
+fast. As I stood aside to let that carriage pass, apprehensive that it
+might otherwise run me down, a head was put out at the window, and a
+voice called to the driver to stop.
+
+“The carriage stopped as soon as the driver could rein in his horses,
+and the same voice called to me by my name. I answered. The carriage
+was then so far in advance of me that two gentlemen had time to open the
+door and alight before I came up with it.
+
+“I observed that they were both wrapped in cloaks, and appeared to
+conceal themselves. As they stood side by side near the carriage door,
+I also observed that they both looked of about my own age, or rather
+younger, and that they were greatly alike, in stature, manner, voice,
+and (as far as I could see) face too.
+
+“‘You are Doctor Manette?’ said one.
+
+“I am.”
+
+“‘Doctor Manette, formerly of Beauvais,’ said the other; ‘the young
+physician, originally an expert surgeon, who within the last year or two
+has made a rising reputation in Paris?’
+
+“‘Gentlemen,’ I returned, ‘I am that Doctor Manette of whom you speak so
+graciously.’
+
+“‘We have been to your residence,’ said the first, ‘and not being
+so fortunate as to find you there, and being informed that you were
+probably walking in this direction, we followed, in the hope of
+overtaking you. Will you please to enter the carriage?’
+
+“The manner of both was imperious, and they both moved, as these words
+were spoken, so as to place me between themselves and the carriage door.
+They were armed. I was not.
+
+“‘Gentlemen,’ said I, ‘pardon me; but I usually inquire who does me
+the honour to seek my assistance, and what is the nature of the case to
+which I am summoned.’
+
+“The reply to this was made by him who had spoken second. ‘Doctor,
+your clients are people of condition. As to the nature of the case,
+our confidence in your skill assures us that you will ascertain it for
+yourself better than we can describe it. Enough. Will you please to
+enter the carriage?’
+
+“I could do nothing but comply, and I entered it in silence. They both
+entered after me--the last springing in, after putting up the steps. The
+carriage turned about, and drove on at its former speed.
+
+“I repeat this conversation exactly as it occurred. I have no doubt that
+it is, word for word, the same. I describe everything exactly as it took
+place, constraining my mind not to wander from the task. Where I make
+the broken marks that follow here, I leave off for the time, and put my
+paper in its hiding-place.
+
+        *****
+
+“The carriage left the streets behind, passed the North Barrier, and
+emerged upon the country road. At two-thirds of a league from the
+Barrier--I did not estimate the distance at that time, but afterwards
+when I traversed it--it struck out of the main avenue, and presently
+stopped at a solitary house, We all three alighted, and walked, by
+a damp soft footpath in a garden where a neglected fountain had
+overflowed, to the door of the house. It was not opened immediately, in
+answer to the ringing of the bell, and one of my two conductors struck
+the man who opened it, with his heavy riding glove, across the face.
+
+“There was nothing in this action to attract my particular attention,
+for I had seen common people struck more commonly than dogs. But, the
+other of the two, being angry likewise, struck the man in like manner
+with his arm; the look and bearing of the brothers were then so exactly
+alike, that I then first perceived them to be twin brothers.
+
+“From the time of our alighting at the outer gate (which we found
+locked, and which one of the brothers had opened to admit us, and had
+relocked), I had heard cries proceeding from an upper chamber. I was
+conducted to this chamber straight, the cries growing louder as we
+ascended the stairs, and I found a patient in a high fever of the brain,
+lying on a bed.
+
+“The patient was a woman of great beauty, and young; assuredly not much
+past twenty. Her hair was torn and ragged, and her arms were bound to
+her sides with sashes and handkerchiefs. I noticed that these bonds were
+all portions of a gentleman’s dress. On one of them, which was a fringed
+scarf for a dress of ceremony, I saw the armorial bearings of a Noble,
+and the letter E.
+
+“I saw this, within the first minute of my contemplation of the patient;
+for, in her restless strivings she had turned over on her face on the
+edge of the bed, had drawn the end of the scarf into her mouth, and was
+in danger of suffocation. My first act was to put out my hand to relieve
+her breathing; and in moving the scarf aside, the embroidery in the
+corner caught my sight.
+
+“I turned her gently over, placed my hands upon her breast to calm her
+and keep her down, and looked into her face. Her eyes were dilated and
+wild, and she constantly uttered piercing shrieks, and repeated the
+words, ‘My husband, my father, and my brother!’ and then counted up to
+twelve, and said, ‘Hush!’ For an instant, and no more, she would pause
+to listen, and then the piercing shrieks would begin again, and she
+would repeat the cry, ‘My husband, my father, and my brother!’ and
+would count up to twelve, and say, ‘Hush!’ There was no variation in the
+order, or the manner. There was no cessation, but the regular moment’s
+pause, in the utterance of these sounds.
+
+“‘How long,’ I asked, ‘has this lasted?’
+
+“To distinguish the brothers, I will call them the elder and the
+younger; by the elder, I mean him who exercised the most authority. It
+was the elder who replied, ‘Since about this hour last night.’
+
+“‘She has a husband, a father, and a brother?’
+
+“‘A brother.’
+
+“‘I do not address her brother?’
+
+“He answered with great contempt, ‘No.’
+
+“‘She has some recent association with the number twelve?’
+
+“The younger brother impatiently rejoined, ‘With twelve o’clock?’
+
+“‘See, gentlemen,’ said I, still keeping my hands upon her breast, ‘how
+useless I am, as you have brought me! If I had known what I was coming
+to see, I could have come provided. As it is, time must be lost. There
+are no medicines to be obtained in this lonely place.’
+
+“The elder brother looked to the younger, who said haughtily, ‘There is
+a case of medicines here;’ and brought it from a closet, and put it on
+the table.
+
+        *****
+
+“I opened some of the bottles, smelt them, and put the stoppers to my
+lips. If I had wanted to use anything save narcotic medicines that were
+poisons in themselves, I would not have administered any of those.
+
+“‘Do you doubt them?’ asked the younger brother.
+
+“‘You see, monsieur, I am going to use them,’ I replied, and said no
+more.
+
+“I made the patient swallow, with great difficulty, and after many
+efforts, the dose that I desired to give. As I intended to repeat it
+after a while, and as it was necessary to watch its influence, I then
+sat down by the side of the bed. There was a timid and suppressed woman
+in attendance (wife of the man down-stairs), who had retreated into
+a corner. The house was damp and decayed, indifferently
+furnished--evidently, recently occupied and temporarily used. Some thick
+old hangings had been nailed up before the windows, to deaden the
+sound of the shrieks. They continued to be uttered in their regular
+succession, with the cry, ‘My husband, my father, and my brother!’ the
+counting up to twelve, and ‘Hush!’ The frenzy was so violent, that I had
+not unfastened the bandages restraining the arms; but, I had looked to
+them, to see that they were not painful. The only spark of encouragement
+in the case, was, that my hand upon the sufferer’s breast had this much
+soothing influence, that for minutes at a time it tranquillised the
+figure. It had no effect upon the cries; no pendulum could be more
+regular.
+
+“For the reason that my hand had this effect (I assume), I had sat by
+the side of the bed for half an hour, with the two brothers looking on,
+before the elder said:
+
+“‘There is another patient.’
+
+“I was startled, and asked, ‘Is it a pressing case?’
+
+“‘You had better see,’ he carelessly answered; and took up a light.
+
+        *****
+
+“The other patient lay in a back room across a second staircase, which
+was a species of loft over a stable. There was a low plastered ceiling
+to a part of it; the rest was open, to the ridge of the tiled roof, and
+there were beams across. Hay and straw were stored in that portion of
+the place, fagots for firing, and a heap of apples in sand. I had to
+pass through that part, to get at the other. My memory is circumstantial
+and unshaken. I try it with these details, and I see them all, in
+this my cell in the Bastille, near the close of the tenth year of my
+captivity, as I saw them all that night.
+
+“On some hay on the ground, with a cushion thrown under his head, lay a
+handsome peasant boy--a boy of not more than seventeen at the most.
+He lay on his back, with his teeth set, his right hand clenched on his
+breast, and his glaring eyes looking straight upward. I could not see
+where his wound was, as I kneeled on one knee over him; but, I could see
+that he was dying of a wound from a sharp point.
+
+“‘I am a doctor, my poor fellow,’ said I. ‘Let me examine it.’
+
+“‘I do not want it examined,’ he answered; ‘let it be.’
+
+“It was under his hand, and I soothed him to let me move his hand away.
+The wound was a sword-thrust, received from twenty to twenty-four hours
+before, but no skill could have saved him if it had been looked to
+without delay. He was then dying fast. As I turned my eyes to the elder
+brother, I saw him looking down at this handsome boy whose life was
+ebbing out, as if he were a wounded bird, or hare, or rabbit; not at all
+as if he were a fellow-creature.
+
+“‘How has this been done, monsieur?’ said I.
+
+“‘A crazed young common dog! A serf! Forced my brother to draw upon him,
+and has fallen by my brother’s sword--like a gentleman.’
+
+“There was no touch of pity, sorrow, or kindred humanity, in this
+answer. The speaker seemed to acknowledge that it was inconvenient to
+have that different order of creature dying there, and that it would
+have been better if he had died in the usual obscure routine of his
+vermin kind. He was quite incapable of any compassionate feeling about
+the boy, or about his fate.
+
+“The boy’s eyes had slowly moved to him as he had spoken, and they now
+slowly moved to me.
+
+“‘Doctor, they are very proud, these Nobles; but we common dogs are
+proud too, sometimes. They plunder us, outrage us, beat us, kill us; but
+we have a little pride left, sometimes. She--have you seen her, Doctor?’
+
+“The shrieks and the cries were audible there, though subdued by the
+distance. He referred to them, as if she were lying in our presence.
+
+“I said, ‘I have seen her.’
+
+“‘She is my sister, Doctor. They have had their shameful rights, these
+Nobles, in the modesty and virtue of our sisters, many years, but we
+have had good girls among us. I know it, and have heard my father say
+so. She was a good girl. She was betrothed to a good young man, too: a
+tenant of his. We were all tenants of his--that man’s who stands there.
+The other is his brother, the worst of a bad race.’
+
+“It was with the greatest difficulty that the boy gathered bodily force
+to speak; but, his spirit spoke with a dreadful emphasis.
+
+“‘We were so robbed by that man who stands there, as all we common dogs
+are by those superior Beings--taxed by him without mercy, obliged to
+work for him without pay, obliged to grind our corn at his mill, obliged
+to feed scores of his tame birds on our wretched crops, and forbidden
+for our lives to keep a single tame bird of our own, pillaged and
+plundered to that degree that when we chanced to have a bit of meat, we
+ate it in fear, with the door barred and the shutters closed, that his
+people should not see it and take it from us--I say, we were so robbed,
+and hunted, and were made so poor, that our father told us it was a
+dreadful thing to bring a child into the world, and that what we should
+most pray for, was, that our women might be barren and our miserable
+race die out!’
+
+“I had never before seen the sense of being oppressed, bursting forth
+like a fire. I had supposed that it must be latent in the people
+somewhere; but, I had never seen it break out, until I saw it in the
+dying boy.
+
+“‘Nevertheless, Doctor, my sister married. He was ailing at that time,
+poor fellow, and she married her lover, that she might tend and comfort
+him in our cottage--our dog-hut, as that man would call it. She had not
+been married many weeks, when that man’s brother saw her and admired
+her, and asked that man to lend her to him--for what are husbands among
+us! He was willing enough, but my sister was good and virtuous, and
+hated his brother with a hatred as strong as mine. What did the two
+then, to persuade her husband to use his influence with her, to make her
+willing?’
+
+“The boy’s eyes, which had been fixed on mine, slowly turned to the
+looker-on, and I saw in the two faces that all he said was true. The two
+opposing kinds of pride confronting one another, I can see, even in this
+Bastille; the gentleman’s, all negligent indifference; the peasant’s, all
+trodden-down sentiment, and passionate revenge.
+
+“‘You know, Doctor, that it is among the Rights of these Nobles to
+harness us common dogs to carts, and drive us. They so harnessed him and
+drove him. You know that it is among their Rights to keep us in their
+grounds all night, quieting the frogs, in order that their noble sleep
+may not be disturbed. They kept him out in the unwholesome mists at
+night, and ordered him back into his harness in the day. But he was
+not persuaded. No! Taken out of harness one day at noon, to feed--if he
+could find food--he sobbed twelve times, once for every stroke of the
+bell, and died on her bosom.’
+
+“Nothing human could have held life in the boy but his determination to
+tell all his wrong. He forced back the gathering shadows of death, as
+he forced his clenched right hand to remain clenched, and to cover his
+wound.
+
+“‘Then, with that man’s permission and even with his aid, his
+brother took her away; in spite of what I know she must have told his
+brother--and what that is, will not be long unknown to you, Doctor, if
+it is now--his brother took her away--for his pleasure and diversion,
+for a little while. I saw her pass me on the road. When I took the
+tidings home, our father’s heart burst; he never spoke one of the words
+that filled it. I took my young sister (for I have another) to a place
+beyond the reach of this man, and where, at least, she will never be
+_his_ vassal. Then, I tracked the brother here, and last night climbed
+in--a common dog, but sword in hand.--Where is the loft window? It was
+somewhere here?’
+
+“The room was darkening to his sight; the world was narrowing around
+him. I glanced about me, and saw that the hay and straw were trampled
+over the floor, as if there had been a struggle.
+
+“‘She heard me, and ran in. I told her not to come near us till he was
+dead. He came in and first tossed me some pieces of money; then struck
+at me with a whip. But I, though a common dog, so struck at him as to
+make him draw. Let him break into as many pieces as he will, the sword
+that he stained with my common blood; he drew to defend himself--thrust
+at me with all his skill for his life.’
+
+“My glance had fallen, but a few moments before, on the fragments of
+a broken sword, lying among the hay. That weapon was a gentleman’s. In
+another place, lay an old sword that seemed to have been a soldier’s.
+
+“‘Now, lift me up, Doctor; lift me up. Where is he?’
+
+“‘He is not here,’ I said, supporting the boy, and thinking that he
+referred to the brother.
+
+“‘He! Proud as these nobles are, he is afraid to see me. Where is the
+man who was here? Turn my face to him.’
+
+“I did so, raising the boy’s head against my knee. But, invested for the
+moment with extraordinary power, he raised himself completely: obliging
+me to rise too, or I could not have still supported him.
+
+“‘Marquis,’ said the boy, turned to him with his eyes opened wide, and
+his right hand raised, ‘in the days when all these things are to be
+answered for, I summon you and yours, to the last of your bad race, to
+answer for them. I mark this cross of blood upon you, as a sign that
+I do it. In the days when all these things are to be answered for,
+I summon your brother, the worst of the bad race, to answer for them
+separately. I mark this cross of blood upon him, as a sign that I do
+it.’
+
+“Twice, he put his hand to the wound in his breast, and with his
+forefinger drew a cross in the air. He stood for an instant with the
+finger yet raised, and as it dropped, he dropped with it, and I laid him
+down dead.
+
+        *****
+
+“When I returned to the bedside of the young woman, I found her raving
+in precisely the same order of continuity. I knew that this might last
+for many hours, and that it would probably end in the silence of the
+grave.
+
+“I repeated the medicines I had given her, and I sat at the side of
+the bed until the night was far advanced. She never abated the piercing
+quality of her shrieks, never stumbled in the distinctness or the order
+of her words. They were always ‘My husband, my father, and my brother!
+One, two, three, four, five, six, seven, eight, nine, ten, eleven,
+twelve. Hush!’
+
+“This lasted twenty-six hours from the time when I first saw her. I had
+come and gone twice, and was again sitting by her, when she began to
+falter. I did what little could be done to assist that opportunity, and
+by-and-bye she sank into a lethargy, and lay like the dead.
+
+“It was as if the wind and rain had lulled at last, after a long and
+fearful storm. I released her arms, and called the woman to assist me to
+compose her figure and the dress she had torn. It was then that I knew
+her condition to be that of one in whom the first expectations of being
+a mother have arisen; and it was then that I lost the little hope I had
+had of her.
+
+“‘Is she dead?’ asked the Marquis, whom I will still describe as the
+elder brother, coming booted into the room from his horse.
+
+“‘Not dead,’ said I; ‘but like to die.’
+
+“‘What strength there is in these common bodies!’ he said, looking down
+at her with some curiosity.
+
+“‘There is prodigious strength,’ I answered him, ‘in sorrow and
+despair.’
+
+“He first laughed at my words, and then frowned at them. He moved a
+chair with his foot near to mine, ordered the woman away, and said in a
+subdued voice,
+
+“‘Doctor, finding my brother in this difficulty with these hinds, I
+recommended that your aid should be invited. Your reputation is high,
+and, as a young man with your fortune to make, you are probably mindful
+of your interest. The things that you see here, are things to be seen,
+and not spoken of.’
+
+“I listened to the patient’s breathing, and avoided answering.
+
+“‘Do you honour me with your attention, Doctor?’
+
+“‘Monsieur,’ said I, ‘in my profession, the communications of patients
+are always received in confidence.’ I was guarded in my answer, for I
+was troubled in my mind with what I had heard and seen.
+
+“Her breathing was so difficult to trace, that I carefully tried the
+pulse and the heart. There was life, and no more. Looking round as I
+resumed my seat, I found both the brothers intent upon me.
+
+        *****
+
+“I write with so much difficulty, the cold is so severe, I am so
+fearful of being detected and consigned to an underground cell and total
+darkness, that I must abridge this narrative. There is no confusion or
+failure in my memory; it can recall, and could detail, every word that
+was ever spoken between me and those brothers.
+
+“She lingered for a week. Towards the last, I could understand some few
+syllables that she said to me, by placing my ear close to her lips. She
+asked me where she was, and I told her; who I was, and I told her. It
+was in vain that I asked her for her family name. She faintly shook her
+head upon the pillow, and kept her secret, as the boy had done.
+
+“I had no opportunity of asking her any question, until I had told the
+brothers she was sinking fast, and could not live another day. Until
+then, though no one was ever presented to her consciousness save the
+woman and myself, one or other of them had always jealously sat behind
+the curtain at the head of the bed when I was there. But when it came to
+that, they seemed careless what communication I might hold with her; as
+if--the thought passed through my mind--I were dying too.
+
+“I always observed that their pride bitterly resented the younger
+brother’s (as I call him) having crossed swords with a peasant, and that
+peasant a boy. The only consideration that appeared to affect the mind
+of either of them was the consideration that this was highly degrading
+to the family, and was ridiculous. As often as I caught the younger
+brother’s eyes, their expression reminded me that he disliked me deeply,
+for knowing what I knew from the boy. He was smoother and more polite to
+me than the elder; but I saw this. I also saw that I was an incumbrance
+in the mind of the elder, too.
+
+“My patient died, two hours before midnight--at a time, by my watch,
+answering almost to the minute when I had first seen her. I was alone
+with her, when her forlorn young head drooped gently on one side, and
+all her earthly wrongs and sorrows ended.
+
+“The brothers were waiting in a room down-stairs, impatient to ride
+away. I had heard them, alone at the bedside, striking their boots with
+their riding-whips, and loitering up and down.
+
+“‘At last she is dead?’ said the elder, when I went in.
+
+“‘She is dead,’ said I.
+
+“‘I congratulate you, my brother,’ were his words as he turned round.
+
+“He had before offered me money, which I had postponed taking. He now
+gave me a rouleau of gold. I took it from his hand, but laid it on
+the table. I had considered the question, and had resolved to accept
+nothing.
+
+“‘Pray excuse me,’ said I. ‘Under the circumstances, no.’
+
+“They exchanged looks, but bent their heads to me as I bent mine to
+them, and we parted without another word on either side.
+
+        *****
+
+“I am weary, weary, weary--worn down by misery. I cannot read what I
+have written with this gaunt hand.
+
+“Early in the morning, the rouleau of gold was left at my door in a
+little box, with my name on the outside. From the first, I had anxiously
+considered what I ought to do. I decided, that day, to write privately
+to the Minister, stating the nature of the two cases to which I had been
+summoned, and the place to which I had gone: in effect, stating all the
+circumstances. I knew what Court influence was, and what the immunities
+of the Nobles were, and I expected that the matter would never be
+heard of; but, I wished to relieve my own mind. I had kept the matter a
+profound secret, even from my wife; and this, too, I resolved to state
+in my letter. I had no apprehension whatever of my real danger; but
+I was conscious that there might be danger for others, if others were
+compromised by possessing the knowledge that I possessed.
+
+“I was much engaged that day, and could not complete my letter that
+night. I rose long before my usual time next morning to finish it.
+It was the last day of the year. The letter was lying before me just
+completed, when I was told that a lady waited, who wished to see me.
+
+        *****
+
+“I am growing more and more unequal to the task I have set myself. It is
+so cold, so dark, my senses are so benumbed, and the gloom upon me is so
+dreadful.
+
+“The lady was young, engaging, and handsome, but not marked for long
+life. She was in great agitation. She presented herself to me as the
+wife of the Marquis St. Evremonde. I connected the title by which the
+boy had addressed the elder brother, with the initial letter embroidered
+on the scarf, and had no difficulty in arriving at the conclusion that I
+had seen that nobleman very lately.
+
+“My memory is still accurate, but I cannot write the words of our
+conversation. I suspect that I am watched more closely than I was, and I
+know not at what times I may be watched. She had in part suspected, and
+in part discovered, the main facts of the cruel story, of her husband’s
+share in it, and my being resorted to. She did not know that the girl
+was dead. Her hope had been, she said in great distress, to show her,
+in secret, a woman’s sympathy. Her hope had been to avert the wrath of
+Heaven from a House that had long been hateful to the suffering many.
+
+“She had reasons for believing that there was a young sister living, and
+her greatest desire was, to help that sister. I could tell her nothing
+but that there was such a sister; beyond that, I knew nothing. Her
+inducement to come to me, relying on my confidence, had been the hope
+that I could tell her the name and place of abode. Whereas, to this
+wretched hour I am ignorant of both.
+
+        *****
+
+“These scraps of paper fail me. One was taken from me, with a warning,
+yesterday. I must finish my record to-day.
+
+“She was a good, compassionate lady, and not happy in her marriage. How
+could she be! The brother distrusted and disliked her, and his influence
+was all opposed to her; she stood in dread of him, and in dread of her
+husband too. When I handed her down to the door, there was a child, a
+pretty boy from two to three years old, in her carriage.
+
+“‘For his sake, Doctor,’ she said, pointing to him in tears, ‘I would do
+all I can to make what poor amends I can. He will never prosper in his
+inheritance otherwise. I have a presentiment that if no other innocent
+atonement is made for this, it will one day be required of him. What
+I have left to call my own--it is little beyond the worth of a few
+jewels--I will make it the first charge of his life to bestow, with the
+compassion and lamenting of his dead mother, on this injured family, if
+the sister can be discovered.’
+
+“She kissed the boy, and said, caressing him, ‘It is for thine own dear
+sake. Thou wilt be faithful, little Charles?’ The child answered her
+bravely, ‘Yes!’ I kissed her hand, and she took him in her arms, and
+went away caressing him. I never saw her more.
+
+“As she had mentioned her husband’s name in the faith that I knew it,
+I added no mention of it to my letter. I sealed my letter, and, not
+trusting it out of my own hands, delivered it myself that day.
+
+“That night, the last night of the year, towards nine o’clock, a man in
+a black dress rang at my gate, demanded to see me, and softly followed
+my servant, Ernest Defarge, a youth, up-stairs. When my servant came
+into the room where I sat with my wife--O my wife, beloved of my heart!
+My fair young English wife!--we saw the man, who was supposed to be at
+the gate, standing silent behind him.
+
+“An urgent case in the Rue St. Honore, he said. It would not detain me,
+he had a coach in waiting.
+
+“It brought me here, it brought me to my grave. When I was clear of the
+house, a black muffler was drawn tightly over my mouth from behind, and
+my arms were pinioned. The two brothers crossed the road from a dark
+corner, and identified me with a single gesture. The Marquis took from
+his pocket the letter I had written, showed it me, burnt it in the light
+of a lantern that was held, and extinguished the ashes with his foot.
+Not a word was spoken. I was brought here, I was brought to my living
+grave.
+
+“If it had pleased _God_ to put it in the hard heart of either of the
+brothers, in all these frightful years, to grant me any tidings of
+my dearest wife--so much as to let me know by a word whether alive or
+dead--I might have thought that He had not quite abandoned them. But,
+now I believe that the mark of the red cross is fatal to them, and that
+they have no part in His mercies. And them and their descendants, to the
+last of their race, I, Alexandre Manette, unhappy prisoner, do this last
+night of the year 1767, in my unbearable agony, denounce to the times
+when all these things shall be answered for. I denounce them to Heaven
+and to earth.”
+
+A terrible sound arose when the reading of this document was done. A
+sound of craving and eagerness that had nothing articulate in it but
+blood. The narrative called up the most revengeful passions of the time,
+and there was not a head in the nation but must have dropped before it.
+
+Little need, in presence of that tribunal and that auditory, to show
+how the Defarges had not made the paper public, with the other captured
+Bastille memorials borne in procession, and had kept it, biding their
+time. Little need to show that this detested family name had long been
+anathematised by Saint Antoine, and was wrought into the fatal register.
+The man never trod ground whose virtues and services would have
+sustained him in that place that day, against such denunciation.
+
+And all the worse for the doomed man, that the denouncer was a
+well-known citizen, his own attached friend, the father of his wife. One
+of the frenzied aspirations of the populace was, for imitations of
+the questionable public virtues of antiquity, and for sacrifices and
+self-immolations on the people’s altar. Therefore when the President
+said (else had his own head quivered on his shoulders), that the good
+physician of the Republic would deserve better still of the Republic by
+rooting out an obnoxious family of Aristocrats, and would doubtless feel
+a sacred glow and joy in making his daughter a widow and her child an
+orphan, there was wild excitement, patriotic fervour, not a touch of
+human sympathy.
+
+“Much influence around him, has that Doctor?” murmured Madame Defarge,
+smiling to The Vengeance. “Save him now, my Doctor, save him!”
+
+At every juryman’s vote, there was a roar. Another and another. Roar and
+roar.
+
+Unanimously voted. At heart and by descent an Aristocrat, an enemy
+of the Republic, a notorious oppressor of the People. Back to the
+Conciergerie, and Death within four-and-twenty hours!
+
+
+
+
+XI. Dusk
+
+
+The wretched wife of the innocent man thus doomed to die, fell under
+the sentence, as if she had been mortally stricken. But, she uttered no
+sound; and so strong was the voice within her, representing that it was
+she of all the world who must uphold him in his misery and not augment
+it, that it quickly raised her, even from that shock.
+
+The Judges having to take part in a public demonstration out of doors,
+the Tribunal adjourned. The quick noise and movement of the court’s
+emptying itself by many passages had not ceased, when Lucie stood
+stretching out her arms towards her husband, with nothing in her face
+but love and consolation.
+
+“If I might touch him! If I might embrace him once! O, good citizens, if
+you would have so much compassion for us!”
+
+There was but a gaoler left, along with two of the four men who had
+taken him last night, and Barsad. The people had all poured out to the
+show in the streets. Barsad proposed to the rest, “Let her embrace
+him then; it is but a moment.” It was silently acquiesced in, and they
+passed her over the seats in the hall to a raised place, where he, by
+leaning over the dock, could fold her in his arms.
+
+“Farewell, dear darling of my soul. My parting blessing on my love. We
+shall meet again, where the weary are at rest!”
+
+They were her husband’s words, as he held her to his bosom.
+
+“I can bear it, dear Charles. I am supported from above: don’t suffer
+for me. A parting blessing for our child.”
+
+“I send it to her by you. I kiss her by you. I say farewell to her by
+you.”
+
+“My husband. No! A moment!” He was tearing himself apart from her.
+“We shall not be separated long. I feel that this will break my heart
+by-and-bye; but I will do my duty while I can, and when I leave her, God
+will raise up friends for her, as He did for me.”
+
+Her father had followed her, and would have fallen on his knees to both
+of them, but that Darnay put out a hand and seized him, crying:
+
+“No, no! What have you done, what have you done, that you should kneel
+to us! We know now, what a struggle you made of old. We know, now what
+you underwent when you suspected my descent, and when you knew it. We
+know now, the natural antipathy you strove against, and conquered, for
+her dear sake. We thank you with all our hearts, and all our love and
+duty. Heaven be with you!”
+
+Her father’s only answer was to draw his hands through his white hair,
+and wring them with a shriek of anguish.
+
+“It could not be otherwise,” said the prisoner. “All things have worked
+together as they have fallen out. It was the always-vain endeavour to
+discharge my poor mother’s trust that first brought my fatal presence
+near you. Good could never come of such evil, a happier end was not in
+nature to so unhappy a beginning. Be comforted, and forgive me. Heaven
+bless you!”
+
+As he was drawn away, his wife released him, and stood looking after him
+with her hands touching one another in the attitude of prayer, and
+with a radiant look upon her face, in which there was even a comforting
+smile. As he went out at the prisoners’ door, she turned, laid her head
+lovingly on her father’s breast, tried to speak to him, and fell at his
+feet.
+
+Then, issuing from the obscure corner from which he had never moved,
+Sydney Carton came and took her up. Only her father and Mr. Lorry were
+with her. His arm trembled as it raised her, and supported her head.
+Yet, there was an air about him that was not all of pity--that had a
+flush of pride in it.
+
+“Shall I take her to a coach? I shall never feel her weight.”
+
+He carried her lightly to the door, and laid her tenderly down in a
+coach. Her father and their old friend got into it, and he took his seat
+beside the driver.
+
+When they arrived at the gateway where he had paused in the dark not
+many hours before, to picture to himself on which of the rough stones of
+the street her feet had trodden, he lifted her again, and carried her up
+the staircase to their rooms. There, he laid her down on a couch, where
+her child and Miss Pross wept over her.
+
+“Don’t recall her to herself,” he said, softly, to the latter, “she is
+better so. Don’t revive her to consciousness, while she only faints.”
+
+“Oh, Carton, Carton, dear Carton!” cried little Lucie, springing up and
+throwing her arms passionately round him, in a burst of grief. “Now that
+you have come, I think you will do something to help mamma, something to
+save papa! O, look at her, dear Carton! Can you, of all the people who
+love her, bear to see her so?”
+
+He bent over the child, and laid her blooming cheek against his face. He
+put her gently from him, and looked at her unconscious mother.
+
+“Before I go,” he said, and paused--“I may kiss her?”
+
+It was remembered afterwards that when he bent down and touched her face
+with his lips, he murmured some words. The child, who was nearest to
+him, told them afterwards, and told her grandchildren when she was a
+handsome old lady, that she heard him say, “A life you love.”
+
+When he had gone out into the next room, he turned suddenly on Mr. Lorry
+and her father, who were following, and said to the latter:
+
+“You had great influence but yesterday, Doctor Manette; let it at least
+be tried. These judges, and all the men in power, are very friendly to
+you, and very recognisant of your services; are they not?”
+
+“Nothing connected with Charles was concealed from me. I had the
+strongest assurances that I should save him; and I did.” He returned the
+answer in great trouble, and very slowly.
+
+“Try them again. The hours between this and to-morrow afternoon are few
+and short, but try.”
+
+“I intend to try. I will not rest a moment.”
+
+“That’s well. I have known such energy as yours do great things before
+now--though never,” he added, with a smile and a sigh together, “such
+great things as this. But try! Of little worth as life is when we misuse
+it, it is worth that effort. It would cost nothing to lay down if it
+were not.”
+
+“I will go,” said Doctor Manette, “to the Prosecutor and the President
+straight, and I will go to others whom it is better not to name. I will
+write too, and--But stay! There is a Celebration in the streets, and no
+one will be accessible until dark.”
+
+“That’s true. Well! It is a forlorn hope at the best, and not much the
+forlorner for being delayed till dark. I should like to know how you
+speed; though, mind! I expect nothing! When are you likely to have seen
+these dread powers, Doctor Manette?”
+
+“Immediately after dark, I should hope. Within an hour or two from
+this.”
+
+“It will be dark soon after four. Let us stretch the hour or two. If I
+go to Mr. Lorry’s at nine, shall I hear what you have done, either from
+our friend or from yourself?”
+
+“Yes.”
+
+“May you prosper!”
+
+Mr. Lorry followed Sydney to the outer door, and, touching him on the
+shoulder as he was going away, caused him to turn.
+
+“I have no hope,” said Mr. Lorry, in a low and sorrowful whisper.
+
+“Nor have I.”
+
+“If any one of these men, or all of these men, were disposed to spare
+him--which is a large supposition; for what is his life, or any man’s
+to them!--I doubt if they durst spare him after the demonstration in the
+court.”
+
+“And so do I. I heard the fall of the axe in that sound.”
+
+Mr. Lorry leaned his arm upon the door-post, and bowed his face upon it.
+
+“Don’t despond,” said Carton, very gently; “don’t grieve. I encouraged
+Doctor Manette in this idea, because I felt that it might one day be
+consolatory to her. Otherwise, she might think ‘his life was wantonly
+thrown away or wasted,’ and that might trouble her.”
+
+“Yes, yes, yes,” returned Mr. Lorry, drying his eyes, “you are right.
+But he will perish; there is no real hope.”
+
+“Yes. He will perish: there is no real hope,” echoed Carton.
+
+And walked with a settled step, down-stairs.
+
+
+
+
+XII. Darkness
+
+
+Sydney Carton paused in the street, not quite decided where to go. “At
+Tellson’s banking-house at nine,” he said, with a musing face. “Shall I
+do well, in the mean time, to show myself? I think so. It is best that
+these people should know there is such a man as I here; it is a sound
+precaution, and may be a necessary preparation. But care, care, care!
+Let me think it out!”
+
+Checking his steps which had begun to tend towards an object, he took a
+turn or two in the already darkening street, and traced the thought
+in his mind to its possible consequences. His first impression was
+confirmed. “It is best,” he said, finally resolved, “that these people
+should know there is such a man as I here.” And he turned his face
+towards Saint Antoine.
+
+Defarge had described himself, that day, as the keeper of a wine-shop in
+the Saint Antoine suburb. It was not difficult for one who knew the city
+well, to find his house without asking any question. Having ascertained
+its situation, Carton came out of those closer streets again, and dined
+at a place of refreshment and fell sound asleep after dinner. For the
+first time in many years, he had no strong drink. Since last night he
+had taken nothing but a little light thin wine, and last night he had
+dropped the brandy slowly down on Mr. Lorry’s hearth like a man who had
+done with it.
+
+It was as late as seven o’clock when he awoke refreshed, and went out
+into the streets again. As he passed along towards Saint Antoine, he
+stopped at a shop-window where there was a mirror, and slightly altered
+the disordered arrangement of his loose cravat, and his coat-collar, and
+his wild hair. This done, he went on direct to Defarge’s, and went in.
+
+There happened to be no customer in the shop but Jacques Three, of the
+restless fingers and the croaking voice. This man, whom he had seen upon
+the Jury, stood drinking at the little counter, in conversation with the
+Defarges, man and wife. The Vengeance assisted in the conversation, like
+a regular member of the establishment.
+
+As Carton walked in, took his seat and asked (in very indifferent
+French) for a small measure of wine, Madame Defarge cast a careless
+glance at him, and then a keener, and then a keener, and then advanced
+to him herself, and asked him what it was he had ordered.
+
+He repeated what he had already said.
+
+“English?” asked Madame Defarge, inquisitively raising her dark
+eyebrows.
+
+After looking at her, as if the sound of even a single French word were
+slow to express itself to him, he answered, in his former strong foreign
+accent. “Yes, madame, yes. I am English!”
+
+Madame Defarge returned to her counter to get the wine, and, as he
+took up a Jacobin journal and feigned to pore over it puzzling out its
+meaning, he heard her say, “I swear to you, like Evremonde!”
+
+Defarge brought him the wine, and gave him Good Evening.
+
+“How?”
+
+“Good evening.”
+
+“Oh! Good evening, citizen,” filling his glass. “Ah! and good wine. I
+drink to the Republic.”
+
+Defarge went back to the counter, and said, “Certainly, a little like.”
+ Madame sternly retorted, “I tell you a good deal like.” Jacques Three
+pacifically remarked, “He is so much in your mind, see you, madame.”
+ The amiable Vengeance added, with a laugh, “Yes, my faith! And you
+are looking forward with so much pleasure to seeing him once more
+to-morrow!”
+
+Carton followed the lines and words of his paper, with a slow
+forefinger, and with a studious and absorbed face. They were all leaning
+their arms on the counter close together, speaking low. After a silence
+of a few moments, during which they all looked towards him without
+disturbing his outward attention from the Jacobin editor, they resumed
+their conversation.
+
+“It is true what madame says,” observed Jacques Three. “Why stop? There
+is great force in that. Why stop?”
+
+“Well, well,” reasoned Defarge, “but one must stop somewhere. After all,
+the question is still where?”
+
+“At extermination,” said madame.
+
+“Magnificent!” croaked Jacques Three. The Vengeance, also, highly
+approved.
+
+“Extermination is good doctrine, my wife,” said Defarge, rather
+troubled; “in general, I say nothing against it. But this Doctor has
+suffered much; you have seen him to-day; you have observed his face when
+the paper was read.”
+
+“I have observed his face!” repeated madame, contemptuously and angrily.
+“Yes. I have observed his face. I have observed his face to be not the
+face of a true friend of the Republic. Let him take care of his face!”
+
+“And you have observed, my wife,” said Defarge, in a deprecatory manner,
+“the anguish of his daughter, which must be a dreadful anguish to him!”
+
+“I have observed his daughter,” repeated madame; “yes, I have observed
+his daughter, more times than one. I have observed her to-day, and I
+have observed her other days. I have observed her in the court, and
+I have observed her in the street by the prison. Let me but lift my
+finger--!” She seemed to raise it (the listener’s eyes were always on
+his paper), and to let it fall with a rattle on the ledge before her, as
+if the axe had dropped.
+
+“The citizeness is superb!” croaked the Juryman.
+
+“She is an Angel!” said The Vengeance, and embraced her.
+
+“As to thee,” pursued madame, implacably, addressing her husband, “if it
+depended on thee--which, happily, it does not--thou wouldst rescue this
+man even now.”
+
+“No!” protested Defarge. “Not if to lift this glass would do it! But I
+would leave the matter there. I say, stop there.”
+
+“See you then, Jacques,” said Madame Defarge, wrathfully; “and see you,
+too, my little Vengeance; see you both! Listen! For other crimes as
+tyrants and oppressors, I have this race a long time on my register,
+doomed to destruction and extermination. Ask my husband, is that so.”
+
+“It is so,” assented Defarge, without being asked.
+
+“In the beginning of the great days, when the Bastille falls, he finds
+this paper of to-day, and he brings it home, and in the middle of the
+night when this place is clear and shut, we read it, here on this spot,
+by the light of this lamp. Ask him, is that so.”
+
+“It is so,” assented Defarge.
+
+“That night, I tell him, when the paper is read through, and the lamp is
+burnt out, and the day is gleaming in above those shutters and between
+those iron bars, that I have now a secret to communicate. Ask him, is
+that so.”
+
+“It is so,” assented Defarge again.
+
+“I communicate to him that secret. I smite this bosom with these two
+hands as I smite it now, and I tell him, ‘Defarge, I was brought up
+among the fishermen of the sea-shore, and that peasant family so injured
+by the two Evremonde brothers, as that Bastille paper describes, is my
+family. Defarge, that sister of the mortally wounded boy upon the ground
+was my sister, that husband was my sister’s husband, that unborn child
+was their child, that brother was my brother, that father was my father,
+those dead are my dead, and that summons to answer for those things
+descends to me!’ Ask him, is that so.”
+
+“It is so,” assented Defarge once more.
+
+“Then tell Wind and Fire where to stop,” returned madame; “but don’t
+tell me.”
+
+Both her hearers derived a horrible enjoyment from the deadly nature
+of her wrath--the listener could feel how white she was, without seeing
+her--and both highly commended it. Defarge, a weak minority, interposed
+a few words for the memory of the compassionate wife of the Marquis; but
+only elicited from his own wife a repetition of her last reply. “Tell
+the Wind and the Fire where to stop; not me!”
+
+Customers entered, and the group was broken up. The English customer
+paid for what he had had, perplexedly counted his change, and asked, as
+a stranger, to be directed towards the National Palace. Madame Defarge
+took him to the door, and put her arm on his, in pointing out the road.
+The English customer was not without his reflections then, that it might
+be a good deed to seize that arm, lift it, and strike under it sharp and
+deep.
+
+But, he went his way, and was soon swallowed up in the shadow of the
+prison wall. At the appointed hour, he emerged from it to present
+himself in Mr. Lorry’s room again, where he found the old gentleman
+walking to and fro in restless anxiety. He said he had been with Lucie
+until just now, and had only left her for a few minutes, to come and
+keep his appointment. Her father had not been seen, since he quitted the
+banking-house towards four o’clock. She had some faint hopes that his
+mediation might save Charles, but they were very slight. He had been
+more than five hours gone: where could he be?
+
+Mr. Lorry waited until ten; but, Doctor Manette not returning, and
+he being unwilling to leave Lucie any longer, it was arranged that he
+should go back to her, and come to the banking-house again at midnight.
+In the meanwhile, Carton would wait alone by the fire for the Doctor.
+
+He waited and waited, and the clock struck twelve; but Doctor Manette
+did not come back. Mr. Lorry returned, and found no tidings of him, and
+brought none. Where could he be?
+
+They were discussing this question, and were almost building up some
+weak structure of hope on his prolonged absence, when they heard him on
+the stairs. The instant he entered the room, it was plain that all was
+lost.
+
+Whether he had really been to any one, or whether he had been all that
+time traversing the streets, was never known. As he stood staring at
+them, they asked him no question, for his face told them everything.
+
+“I cannot find it,” said he, “and I must have it. Where is it?”
+
+His head and throat were bare, and, as he spoke with a helpless look
+straying all around, he took his coat off, and let it drop on the floor.
+
+“Where is my bench? I have been looking everywhere for my bench, and I
+can’t find it. What have they done with my work? Time presses: I must
+finish those shoes.”
+
+They looked at one another, and their hearts died within them.
+
+“Come, come!” said he, in a whimpering miserable way; “let me get to
+work. Give me my work.”
+
+Receiving no answer, he tore his hair, and beat his feet upon the
+ground, like a distracted child.
+
+“Don’t torture a poor forlorn wretch,” he implored them, with a dreadful
+cry; “but give me my work! What is to become of us, if those shoes are
+not done to-night?”
+
+Lost, utterly lost!
+
+It was so clearly beyond hope to reason with him, or try to restore him,
+that--as if by agreement--they each put a hand upon his shoulder, and
+soothed him to sit down before the fire, with a promise that he should
+have his work presently. He sank into the chair, and brooded over the
+embers, and shed tears. As if all that had happened since the garret
+time were a momentary fancy, or a dream, Mr. Lorry saw him shrink into
+the exact figure that Defarge had had in keeping.
+
+Affected, and impressed with terror as they both were, by this spectacle
+of ruin, it was not a time to yield to such emotions. His lonely
+daughter, bereft of her final hope and reliance, appealed to them both
+too strongly. Again, as if by agreement, they looked at one another with
+one meaning in their faces. Carton was the first to speak:
+
+“The last chance is gone: it was not much. Yes; he had better be taken
+to her. But, before you go, will you, for a moment, steadily attend to
+me? Don’t ask me why I make the stipulations I am going to make, and
+exact the promise I am going to exact; I have a reason--a good one.”
+
+“I do not doubt it,” answered Mr. Lorry. “Say on.”
+
+The figure in the chair between them, was all the time monotonously
+rocking itself to and fro, and moaning. They spoke in such a tone as
+they would have used if they had been watching by a sick-bed in the
+night.
+
+Carton stooped to pick up the coat, which lay almost entangling his
+feet. As he did so, a small case in which the Doctor was accustomed to
+carry the lists of his day’s duties, fell lightly on the floor. Carton
+took it up, and there was a folded paper in it. “We should look
+at this!” he said. Mr. Lorry nodded his consent. He opened it, and
+exclaimed, “Thank _God!_”
+
+“What is it?” asked Mr. Lorry, eagerly.
+
+“A moment! Let me speak of it in its place. First,” he put his hand in
+his coat, and took another paper from it, “that is the certificate which
+enables me to pass out of this city. Look at it. You see--Sydney Carton,
+an Englishman?”
+
+Mr. Lorry held it open in his hand, gazing in his earnest face.
+
+“Keep it for me until to-morrow. I shall see him to-morrow, you
+remember, and I had better not take it into the prison.”
+
+“Why not?”
+
+“I don’t know; I prefer not to do so. Now, take this paper that Doctor
+Manette has carried about him. It is a similar certificate, enabling him
+and his daughter and her child, at any time, to pass the barrier and the
+frontier! You see?”
+
+“Yes!”
+
+“Perhaps he obtained it as his last and utmost precaution against evil,
+yesterday. When is it dated? But no matter; don’t stay to look; put it
+up carefully with mine and your own. Now, observe! I never doubted until
+within this hour or two, that he had, or could have such a paper. It is
+good, until recalled. But it may be soon recalled, and, I have reason to
+think, will be.”
+
+“They are not in danger?”
+
+“They are in great danger. They are in danger of denunciation by Madame
+Defarge. I know it from her own lips. I have overheard words of that
+woman’s, to-night, which have presented their danger to me in strong
+colours. I have lost no time, and since then, I have seen the spy. He
+confirms me. He knows that a wood-sawyer, living by the prison wall,
+is under the control of the Defarges, and has been rehearsed by
+Madame Defarge as to his having seen Her”--he never mentioned Lucie’s
+name--“making signs and signals to prisoners. It is easy to foresee that
+the pretence will be the common one, a prison plot, and that it will
+involve her life--and perhaps her child’s--and perhaps her father’s--for
+both have been seen with her at that place. Don’t look so horrified. You
+will save them all.”
+
+“Heaven grant I may, Carton! But how?”
+
+“I am going to tell you how. It will depend on you, and it could depend
+on no better man. This new denunciation will certainly not take place
+until after to-morrow; probably not until two or three days afterwards;
+more probably a week afterwards. You know it is a capital crime, to
+mourn for, or sympathise with, a victim of the Guillotine. She and her
+father would unquestionably be guilty of this crime, and this woman (the
+inveteracy of whose pursuit cannot be described) would wait to add that
+strength to her case, and make herself doubly sure. You follow me?”
+
+“So attentively, and with so much confidence in what you say, that for
+the moment I lose sight,” touching the back of the Doctor’s chair, “even
+of this distress.”
+
+“You have money, and can buy the means of travelling to the seacoast
+as quickly as the journey can be made. Your preparations have been
+completed for some days, to return to England. Early to-morrow have your
+horses ready, so that they may be in starting trim at two o’clock in the
+afternoon.”
+
+“It shall be done!”
+
+His manner was so fervent and inspiring, that Mr. Lorry caught the
+flame, and was as quick as youth.
+
+“You are a noble heart. Did I say we could depend upon no better man?
+Tell her, to-night, what you know of her danger as involving her child
+and her father. Dwell upon that, for she would lay her own fair head
+beside her husband’s cheerfully.” He faltered for an instant; then went
+on as before. “For the sake of her child and her father, press upon her
+the necessity of leaving Paris, with them and you, at that hour. Tell
+her that it was her husband’s last arrangement. Tell her that more
+depends upon it than she dare believe, or hope. You think that her
+father, even in this sad state, will submit himself to her; do you not?”
+
+“I am sure of it.”
+
+“I thought so. Quietly and steadily have all these arrangements made in
+the courtyard here, even to the taking of your own seat in the carriage.
+The moment I come to you, take me in, and drive away.”
+
+“I understand that I wait for you under all circumstances?”
+
+“You have my certificate in your hand with the rest, you know, and will
+reserve my place. Wait for nothing but to have my place occupied, and
+then for England!”
+
+“Why, then,” said Mr. Lorry, grasping his eager but so firm and steady
+hand, “it does not all depend on one old man, but I shall have a young
+and ardent man at my side.”
+
+“By the help of Heaven you shall! Promise me solemnly that nothing will
+influence you to alter the course on which we now stand pledged to one
+another.”
+
+“Nothing, Carton.”
+
+“Remember these words to-morrow: change the course, or delay in it--for
+any reason--and no life can possibly be saved, and many lives must
+inevitably be sacrificed.”
+
+“I will remember them. I hope to do my part faithfully.”
+
+“And I hope to do mine. Now, good bye!”
+
+Though he said it with a grave smile of earnestness, and though he even
+put the old man’s hand to his lips, he did not part from him then. He
+helped him so far to arouse the rocking figure before the dying embers,
+as to get a cloak and hat put upon it, and to tempt it forth to find
+where the bench and work were hidden that it still moaningly besought
+to have. He walked on the other side of it and protected it to the
+courtyard of the house where the afflicted heart--so happy in
+the memorable time when he had revealed his own desolate heart to
+it--outwatched the awful night. He entered the courtyard and remained
+there for a few moments alone, looking up at the light in the window of
+her room. Before he went away, he breathed a blessing towards it, and a
+Farewell.
+
+
+
+
+XIII. Fifty-two
+
+
+In the black prison of the Conciergerie, the doomed of the day awaited
+their fate. They were in number as the weeks of the year. Fifty-two were
+to roll that afternoon on the life-tide of the city to the boundless
+everlasting sea. Before their cells were quit of them, new occupants
+were appointed; before their blood ran into the blood spilled yesterday,
+the blood that was to mingle with theirs to-morrow was already set
+apart.
+
+Two score and twelve were told off. From the farmer-general of seventy,
+whose riches could not buy his life, to the seamstress of twenty, whose
+poverty and obscurity could not save her. Physical diseases, engendered
+in the vices and neglects of men, will seize on victims of all degrees;
+and the frightful moral disorder, born of unspeakable suffering,
+intolerable oppression, and heartless indifference, smote equally
+without distinction.
+
+Charles Darnay, alone in a cell, had sustained himself with no
+flattering delusion since he came to it from the Tribunal. In every line
+of the narrative he had heard, he had heard his condemnation. He had
+fully comprehended that no personal influence could possibly save him,
+that he was virtually sentenced by the millions, and that units could
+avail him nothing.
+
+Nevertheless, it was not easy, with the face of his beloved wife fresh
+before him, to compose his mind to what it must bear. His hold on life
+was strong, and it was very, very hard, to loosen; by gradual efforts
+and degrees unclosed a little here, it clenched the tighter there; and
+when he brought his strength to bear on that hand and it yielded,
+this was closed again. There was a hurry, too, in all his thoughts,
+a turbulent and heated working of his heart, that contended against
+resignation. If, for a moment, he did feel resigned, then his wife and
+child who had to live after him, seemed to protest and to make it a
+selfish thing.
+
+But, all this was at first. Before long, the consideration that there
+was no disgrace in the fate he must meet, and that numbers went the same
+road wrongfully, and trod it firmly every day, sprang up to stimulate
+him. Next followed the thought that much of the future peace of mind
+enjoyable by the dear ones, depended on his quiet fortitude. So,
+by degrees he calmed into the better state, when he could raise his
+thoughts much higher, and draw comfort down.
+
+Before it had set in dark on the night of his condemnation, he had
+travelled thus far on his last way. Being allowed to purchase the means
+of writing, and a light, he sat down to write until such time as the
+prison lamps should be extinguished.
+
+He wrote a long letter to Lucie, showing her that he had known nothing
+of her father’s imprisonment, until he had heard of it from herself,
+and that he had been as ignorant as she of his father’s and uncle’s
+responsibility for that misery, until the paper had been read. He had
+already explained to her that his concealment from herself of the name
+he had relinquished, was the one condition--fully intelligible now--that
+her father had attached to their betrothal, and was the one promise he
+had still exacted on the morning of their marriage. He entreated her,
+for her father’s sake, never to seek to know whether her father had
+become oblivious of the existence of the paper, or had had it recalled
+to him (for the moment, or for good), by the story of the Tower, on
+that old Sunday under the dear old plane-tree in the garden. If he had
+preserved any definite remembrance of it, there could be no doubt that
+he had supposed it destroyed with the Bastille, when he had found no
+mention of it among the relics of prisoners which the populace had
+discovered there, and which had been described to all the world. He
+besought her--though he added that he knew it was needless--to console
+her father, by impressing him through every tender means she could think
+of, with the truth that he had done nothing for which he could justly
+reproach himself, but had uniformly forgotten himself for their joint
+sakes. Next to her preservation of his own last grateful love and
+blessing, and her overcoming of her sorrow, to devote herself to their
+dear child, he adjured her, as they would meet in Heaven, to comfort her
+father.
+
+To her father himself, he wrote in the same strain; but, he told her
+father that he expressly confided his wife and child to his care. And
+he told him this, very strongly, with the hope of rousing him from any
+despondency or dangerous retrospect towards which he foresaw he might be
+tending.
+
+To Mr. Lorry, he commended them all, and explained his worldly affairs.
+That done, with many added sentences of grateful friendship and warm
+attachment, all was done. He never thought of Carton. His mind was so
+full of the others, that he never once thought of him.
+
+He had time to finish these letters before the lights were put out. When
+he lay down on his straw bed, he thought he had done with this world.
+
+But, it beckoned him back in his sleep, and showed itself in shining
+forms. Free and happy, back in the old house in Soho (though it had
+nothing in it like the real house), unaccountably released and light of
+heart, he was with Lucie again, and she told him it was all a dream, and
+he had never gone away. A pause of forgetfulness, and then he had even
+suffered, and had come back to her, dead and at peace, and yet there
+was no difference in him. Another pause of oblivion, and he awoke in the
+sombre morning, unconscious where he was or what had happened, until it
+flashed upon his mind, “this is the day of my death!”
+
+Thus, had he come through the hours, to the day when the fifty-two heads
+were to fall. And now, while he was composed, and hoped that he could
+meet the end with quiet heroism, a new action began in his waking
+thoughts, which was very difficult to master.
+
+He had never seen the instrument that was to terminate his life. How
+high it was from the ground, how many steps it had, where he would be
+stood, how he would be touched, whether the touching hands would be dyed
+red, which way his face would be turned, whether he would be the first,
+or might be the last: these and many similar questions, in nowise
+directed by his will, obtruded themselves over and over again, countless
+times. Neither were they connected with fear: he was conscious of no
+fear. Rather, they originated in a strange besetting desire to know what
+to do when the time came; a desire gigantically disproportionate to the
+few swift moments to which it referred; a wondering that was more like
+the wondering of some other spirit within his, than his own.
+
+The hours went on as he walked to and fro, and the clocks struck the
+numbers he would never hear again. Nine gone for ever, ten gone for
+ever, eleven gone for ever, twelve coming on to pass away. After a hard
+contest with that eccentric action of thought which had last perplexed
+him, he had got the better of it. He walked up and down, softly
+repeating their names to himself. The worst of the strife was over.
+He could walk up and down, free from distracting fancies, praying for
+himself and for them.
+
+Twelve gone for ever.
+
+He had been apprised that the final hour was Three, and he knew he would
+be summoned some time earlier, inasmuch as the tumbrils jolted heavily
+and slowly through the streets. Therefore, he resolved to keep Two
+before his mind, as the hour, and so to strengthen himself in the
+interval that he might be able, after that time, to strengthen others.
+
+Walking regularly to and fro with his arms folded on his breast, a very
+different man from the prisoner, who had walked to and fro at La Force,
+he heard One struck away from him, without surprise. The hour had
+measured like most other hours. Devoutly thankful to Heaven for his
+recovered self-possession, he thought, “There is but another now,” and
+turned to walk again.
+
+Footsteps in the stone passage outside the door. He stopped.
+
+The key was put in the lock, and turned. Before the door was opened, or
+as it opened, a man said in a low voice, in English: “He has never seen
+me here; I have kept out of his way. Go you in alone; I wait near. Lose
+no time!”
+
+The door was quickly opened and closed, and there stood before him
+face to face, quiet, intent upon him, with the light of a smile on his
+features, and a cautionary finger on his lip, Sydney Carton.
+
+There was something so bright and remarkable in his look, that, for the
+first moment, the prisoner misdoubted him to be an apparition of his own
+imagining. But, he spoke, and it was his voice; he took the prisoner’s
+hand, and it was his real grasp.
+
+“Of all the people upon earth, you least expected to see me?” he said.
+
+“I could not believe it to be you. I can scarcely believe it now. You
+are not”--the apprehension came suddenly into his mind--“a prisoner?”
+
+“No. I am accidentally possessed of a power over one of the keepers
+here, and in virtue of it I stand before you. I come from her--your
+wife, dear Darnay.”
+
+The prisoner wrung his hand.
+
+“I bring you a request from her.”
+
+“What is it?”
+
+“A most earnest, pressing, and emphatic entreaty, addressed to you
+in the most pathetic tones of the voice so dear to you, that you well
+remember.”
+
+The prisoner turned his face partly aside.
+
+“You have no time to ask me why I bring it, or what it means; I have
+no time to tell you. You must comply with it--take off those boots you
+wear, and draw on these of mine.”
+
+There was a chair against the wall of the cell, behind the prisoner.
+Carton, pressing forward, had already, with the speed of lightning, got
+him down into it, and stood over him, barefoot.
+
+“Draw on these boots of mine. Put your hands to them; put your will to
+them. Quick!”
+
+“Carton, there is no escaping from this place; it never can be done. You
+will only die with me. It is madness.”
+
+“It would be madness if I asked you to escape; but do I? When I ask you
+to pass out at that door, tell me it is madness and remain here. Change
+that cravat for this of mine, that coat for this of mine. While you do
+it, let me take this ribbon from your hair, and shake out your hair like
+this of mine!”
+
+With wonderful quickness, and with a strength both of will and action,
+that appeared quite supernatural, he forced all these changes upon him.
+The prisoner was like a young child in his hands.
+
+“Carton! Dear Carton! It is madness. It cannot be accomplished, it never
+can be done, it has been attempted, and has always failed. I implore you
+not to add your death to the bitterness of mine.”
+
+“Do I ask you, my dear Darnay, to pass the door? When I ask that,
+refuse. There are pen and ink and paper on this table. Is your hand
+steady enough to write?”
+
+“It was when you came in.”
+
+“Steady it again, and write what I shall dictate. Quick, friend, quick!”
+
+Pressing his hand to his bewildered head, Darnay sat down at the table.
+Carton, with his right hand in his breast, stood close beside him.
+
+“Write exactly as I speak.”
+
+“To whom do I address it?”
+
+“To no one.” Carton still had his hand in his breast.
+
+“Do I date it?”
+
+“No.”
+
+The prisoner looked up, at each question. Carton, standing over him with
+his hand in his breast, looked down.
+
+“‘If you remember,’” said Carton, dictating, “‘the words that passed
+between us, long ago, you will readily comprehend this when you see it.
+You do remember them, I know. It is not in your nature to forget them.’”
+
+He was drawing his hand from his breast; the prisoner chancing to look
+up in his hurried wonder as he wrote, the hand stopped, closing upon
+something.
+
+“Have you written ‘forget them’?” Carton asked.
+
+“I have. Is that a weapon in your hand?”
+
+“No; I am not armed.”
+
+“What is it in your hand?”
+
+“You shall know directly. Write on; there are but a few words more.” He
+dictated again. “‘I am thankful that the time has come, when I can prove
+them. That I do so is no subject for regret or grief.’” As he said these
+words with his eyes fixed on the writer, his hand slowly and softly
+moved down close to the writer’s face.
+
+The pen dropped from Darnay’s fingers on the table, and he looked about
+him vacantly.
+
+“What vapour is that?” he asked.
+
+“Vapour?”
+
+“Something that crossed me?”
+
+“I am conscious of nothing; there can be nothing here. Take up the pen
+and finish. Hurry, hurry!”
+
+As if his memory were impaired, or his faculties disordered, the
+prisoner made an effort to rally his attention. As he looked at Carton
+with clouded eyes and with an altered manner of breathing, Carton--his
+hand again in his breast--looked steadily at him.
+
+“Hurry, hurry!”
+
+The prisoner bent over the paper, once more.
+
+“‘If it had been otherwise;’” Carton’s hand was again watchfully and
+softly stealing down; “‘I never should have used the longer opportunity.
+If it had been otherwise;’” the hand was at the prisoner’s face; “‘I
+should but have had so much the more to answer for. If it had been
+otherwise--’” Carton looked at the pen and saw it was trailing off into
+unintelligible signs.
+
+Carton’s hand moved back to his breast no more. The prisoner sprang up
+with a reproachful look, but Carton’s hand was close and firm at his
+nostrils, and Carton’s left arm caught him round the waist. For a few
+seconds he faintly struggled with the man who had come to lay down his
+life for him; but, within a minute or so, he was stretched insensible on
+the ground.
+
+Quickly, but with hands as true to the purpose as his heart was, Carton
+dressed himself in the clothes the prisoner had laid aside, combed back
+his hair, and tied it with the ribbon the prisoner had worn. Then, he
+softly called, “Enter there! Come in!” and the Spy presented himself.
+
+“You see?” said Carton, looking up, as he kneeled on one knee beside the
+insensible figure, putting the paper in the breast: “is your hazard very
+great?”
+
+“Mr. Carton,” the Spy answered, with a timid snap of his fingers, “my
+hazard is not _that_, in the thick of business here, if you are true to
+the whole of your bargain.”
+
+“Don’t fear me. I will be true to the death.”
+
+“You must be, Mr. Carton, if the tale of fifty-two is to be right. Being
+made right by you in that dress, I shall have no fear.”
+
+“Have no fear! I shall soon be out of the way of harming you, and the
+rest will soon be far from here, please God! Now, get assistance and
+take me to the coach.”
+
+“You?” said the Spy nervously.
+
+“Him, man, with whom I have exchanged. You go out at the gate by which
+you brought me in?”
+
+“Of course.”
+
+“I was weak and faint when you brought me in, and I am fainter now you
+take me out. The parting interview has overpowered me. Such a thing has
+happened here, often, and too often. Your life is in your own hands.
+Quick! Call assistance!”
+
+“You swear not to betray me?” said the trembling Spy, as he paused for a
+last moment.
+
+“Man, man!” returned Carton, stamping his foot; “have I sworn by no
+solemn vow already, to go through with this, that you waste the precious
+moments now? Take him yourself to the courtyard you know of, place
+him yourself in the carriage, show him yourself to Mr. Lorry, tell him
+yourself to give him no restorative but air, and to remember my words of
+last night, and his promise of last night, and drive away!”
+
+The Spy withdrew, and Carton seated himself at the table, resting his
+forehead on his hands. The Spy returned immediately, with two men.
+
+“How, then?” said one of them, contemplating the fallen figure. “So
+afflicted to find that his friend has drawn a prize in the lottery of
+Sainte Guillotine?”
+
+“A good patriot,” said the other, “could hardly have been more afflicted
+if the Aristocrat had drawn a blank.”
+
+They raised the unconscious figure, placed it on a litter they had
+brought to the door, and bent to carry it away.
+
+“The time is short, Evremonde,” said the Spy, in a warning voice.
+
+“I know it well,” answered Carton. “Be careful of my friend, I entreat
+you, and leave me.”
+
+“Come, then, my children,” said Barsad. “Lift him, and come away!”
+
+The door closed, and Carton was left alone. Straining his powers of
+listening to the utmost, he listened for any sound that might denote
+suspicion or alarm. There was none. Keys turned, doors clashed,
+footsteps passed along distant passages: no cry was raised, or hurry
+made, that seemed unusual. Breathing more freely in a little while, he
+sat down at the table, and listened again until the clock struck Two.
+
+Sounds that he was not afraid of, for he divined their meaning, then
+began to be audible. Several doors were opened in succession, and
+finally his own. A gaoler, with a list in his hand, looked in, merely
+saying, “Follow me, Evremonde!” and he followed into a large dark room,
+at a distance. It was a dark winter day, and what with the shadows
+within, and what with the shadows without, he could but dimly discern
+the others who were brought there to have their arms bound. Some were
+standing; some seated. Some were lamenting, and in restless motion;
+but, these were few. The great majority were silent and still, looking
+fixedly at the ground.
+
+As he stood by the wall in a dim corner, while some of the fifty-two
+were brought in after him, one man stopped in passing, to embrace him,
+as having a knowledge of him. It thrilled him with a great dread of
+discovery; but the man went on. A very few moments after that, a young
+woman, with a slight girlish form, a sweet spare face in which there was
+no vestige of colour, and large widely opened patient eyes, rose from
+the seat where he had observed her sitting, and came to speak to him.
+
+“Citizen Evremonde,” she said, touching him with her cold hand. “I am a
+poor little seamstress, who was with you in La Force.”
+
+He murmured for answer: “True. I forget what you were accused of?”
+
+“Plots. Though the just Heaven knows that I am innocent of any. Is it
+likely? Who would think of plotting with a poor little weak creature
+like me?”
+
+The forlorn smile with which she said it, so touched him, that tears
+started from his eyes.
+
+“I am not afraid to die, Citizen Evremonde, but I have done nothing. I
+am not unwilling to die, if the Republic which is to do so much good
+to us poor, will profit by my death; but I do not know how that can be,
+Citizen Evremonde. Such a poor weak little creature!”
+
+As the last thing on earth that his heart was to warm and soften to, it
+warmed and softened to this pitiable girl.
+
+“I heard you were released, Citizen Evremonde. I hoped it was true?”
+
+“It was. But, I was again taken and condemned.”
+
+“If I may ride with you, Citizen Evremonde, will you let me hold your
+hand? I am not afraid, but I am little and weak, and it will give me
+more courage.”
+
+As the patient eyes were lifted to his face, he saw a sudden doubt in
+them, and then astonishment. He pressed the work-worn, hunger-worn young
+fingers, and touched his lips.
+
+“Are you dying for him?” she whispered.
+
+“And his wife and child. Hush! Yes.”
+
+“O you will let me hold your brave hand, stranger?”
+
+“Hush! Yes, my poor sister; to the last.”
+
+        *****
+
+The same shadows that are falling on the prison, are falling, in that
+same hour of the early afternoon, on the Barrier with the crowd about
+it, when a coach going out of Paris drives up to be examined.
+
+“Who goes here? Whom have we within? Papers!”
+
+The papers are handed out, and read.
+
+“Alexandre Manette. Physician. French. Which is he?”
+
+This is he; this helpless, inarticulately murmuring, wandering old man
+pointed out.
+
+“Apparently the Citizen-Doctor is not in his right mind? The
+Revolution-fever will have been too much for him?”
+
+Greatly too much for him.
+
+“Hah! Many suffer with it. Lucie. His daughter. French. Which is she?”
+
+This is she.
+
+“Apparently it must be. Lucie, the wife of Evremonde; is it not?”
+
+It is.
+
+“Hah! Evremonde has an assignation elsewhere. Lucie, her child. English.
+This is she?”
+
+She and no other.
+
+“Kiss me, child of Evremonde. Now, thou hast kissed a good Republican;
+something new in thy family; remember it! Sydney Carton. Advocate.
+English. Which is he?”
+
+He lies here, in this corner of the carriage. He, too, is pointed out.
+
+“Apparently the English advocate is in a swoon?”
+
+It is hoped he will recover in the fresher air. It is represented that
+he is not in strong health, and has separated sadly from a friend who is
+under the displeasure of the Republic.
+
+“Is that all? It is not a great deal, that! Many are under the
+displeasure of the Republic, and must look out at the little window.
+Jarvis Lorry. Banker. English. Which is he?”
+
+“I am he. Necessarily, being the last.”
+
+It is Jarvis Lorry who has replied to all the previous questions. It
+is Jarvis Lorry who has alighted and stands with his hand on the coach
+door, replying to a group of officials. They leisurely walk round the
+carriage and leisurely mount the box, to look at what little luggage it
+carries on the roof; the country-people hanging about, press nearer to
+the coach doors and greedily stare in; a little child, carried by its
+mother, has its short arm held out for it, that it may touch the wife of
+an aristocrat who has gone to the Guillotine.
+
+“Behold your papers, Jarvis Lorry, countersigned.”
+
+“One can depart, citizen?”
+
+“One can depart. Forward, my postilions! A good journey!”
+
+“I salute you, citizens.--And the first danger passed!”
+
+These are again the words of Jarvis Lorry, as he clasps his hands, and
+looks upward. There is terror in the carriage, there is weeping, there
+is the heavy breathing of the insensible traveller.
+
+“Are we not going too slowly? Can they not be induced to go faster?”
+ asks Lucie, clinging to the old man.
+
+“It would seem like flight, my darling. I must not urge them too much;
+it would rouse suspicion.”
+
+“Look back, look back, and see if we are pursued!”
+
+“The road is clear, my dearest. So far, we are not pursued.”
+
+Houses in twos and threes pass by us, solitary farms, ruinous buildings,
+dye-works, tanneries, and the like, open country, avenues of leafless
+trees. The hard uneven pavement is under us, the soft deep mud is on
+either side. Sometimes, we strike into the skirting mud, to avoid the
+stones that clatter us and shake us; sometimes, we stick in ruts and
+sloughs there. The agony of our impatience is then so great, that in our
+wild alarm and hurry we are for getting out and running--hiding--doing
+anything but stopping.
+
+Out of the open country, in again among ruinous buildings, solitary
+farms, dye-works, tanneries, and the like, cottages in twos and threes,
+avenues of leafless trees. Have these men deceived us, and taken us back
+by another road? Is not this the same place twice over? Thank Heaven,
+no. A village. Look back, look back, and see if we are pursued! Hush!
+the posting-house.
+
+Leisurely, our four horses are taken out; leisurely, the coach stands in
+the little street, bereft of horses, and with no likelihood upon it
+of ever moving again; leisurely, the new horses come into visible
+existence, one by one; leisurely, the new postilions follow, sucking and
+plaiting the lashes of their whips; leisurely, the old postilions count
+their money, make wrong additions, and arrive at dissatisfied results.
+All the time, our overfraught hearts are beating at a rate that would
+far outstrip the fastest gallop of the fastest horses ever foaled.
+
+At length the new postilions are in their saddles, and the old are left
+behind. We are through the village, up the hill, and down the hill, and
+on the low watery grounds. Suddenly, the postilions exchange speech with
+animated gesticulation, and the horses are pulled up, almost on their
+haunches. We are pursued?
+
+“Ho! Within the carriage there. Speak then!”
+
+“What is it?” asks Mr. Lorry, looking out at window.
+
+“How many did they say?”
+
+“I do not understand you.”
+
+“--At the last post. How many to the Guillotine to-day?”
+
+“Fifty-two.”
+
+“I said so! A brave number! My fellow-citizen here would have it
+forty-two; ten more heads are worth having. The Guillotine goes
+handsomely. I love it. Hi forward. Whoop!”
+
+The night comes on dark. He moves more; he is beginning to revive, and
+to speak intelligibly; he thinks they are still together; he asks him,
+by his name, what he has in his hand. O pity us, kind Heaven, and help
+us! Look out, look out, and see if we are pursued.
+
+The wind is rushing after us, and the clouds are flying after us, and
+the moon is plunging after us, and the whole wild night is in pursuit of
+us; but, so far, we are pursued by nothing else.
+
+
+
+
+XIV. The Knitting Done
+
+
+In that same juncture of time when the Fifty-Two awaited their fate
+Madame Defarge held darkly ominous council with The Vengeance and
+Jacques Three of the Revolutionary Jury. Not in the wine-shop did Madame
+Defarge confer with these ministers, but in the shed of the wood-sawyer,
+erst a mender of roads. The sawyer himself did not participate in the
+conference, but abided at a little distance, like an outer satellite who
+was not to speak until required, or to offer an opinion until invited.
+
+“But our Defarge,” said Jacques Three, “is undoubtedly a good
+Republican? Eh?”
+
+“There is no better,” the voluble Vengeance protested in her shrill
+notes, “in France.”
+
+“Peace, little Vengeance,” said Madame Defarge, laying her hand with
+a slight frown on her lieutenant’s lips, “hear me speak. My husband,
+fellow-citizen, is a good Republican and a bold man; he has deserved
+well of the Republic, and possesses its confidence. But my husband has
+his weaknesses, and he is so weak as to relent towards this Doctor.”
+
+“It is a great pity,” croaked Jacques Three, dubiously shaking his head,
+with his cruel fingers at his hungry mouth; “it is not quite like a good
+citizen; it is a thing to regret.”
+
+“See you,” said madame, “I care nothing for this Doctor, I. He may wear
+his head or lose it, for any interest I have in him; it is all one to
+me. But, the Evremonde people are to be exterminated, and the wife and
+child must follow the husband and father.”
+
+“She has a fine head for it,” croaked Jacques Three. “I have seen blue
+eyes and golden hair there, and they looked charming when Samson held
+them up.” Ogre that he was, he spoke like an epicure.
+
+Madame Defarge cast down her eyes, and reflected a little.
+
+“The child also,” observed Jacques Three, with a meditative enjoyment
+of his words, “has golden hair and blue eyes. And we seldom have a child
+there. It is a pretty sight!”
+
+“In a word,” said Madame Defarge, coming out of her short abstraction,
+“I cannot trust my husband in this matter. Not only do I feel, since
+last night, that I dare not confide to him the details of my projects;
+but also I feel that if I delay, there is danger of his giving warning,
+and then they might escape.”
+
+“That must never be,” croaked Jacques Three; “no one must escape. We
+have not half enough as it is. We ought to have six score a day.”
+
+“In a word,” Madame Defarge went on, “my husband has not my reason for
+pursuing this family to annihilation, and I have not his reason for
+regarding this Doctor with any sensibility. I must act for myself,
+therefore. Come hither, little citizen.”
+
+The wood-sawyer, who held her in the respect, and himself in the
+submission, of mortal fear, advanced with his hand to his red cap.
+
+“Touching those signals, little citizen,” said Madame Defarge, sternly,
+“that she made to the prisoners; you are ready to bear witness to them
+this very day?”
+
+“Ay, ay, why not!” cried the sawyer. “Every day, in all weathers, from
+two to four, always signalling, sometimes with the little one, sometimes
+without. I know what I know. I have seen with my eyes.”
+
+He made all manner of gestures while he spoke, as if in incidental
+imitation of some few of the great diversity of signals that he had
+never seen.
+
+“Clearly plots,” said Jacques Three. “Transparently!”
+
+“There is no doubt of the Jury?” inquired Madame Defarge, letting her
+eyes turn to him with a gloomy smile.
+
+“Rely upon the patriotic Jury, dear citizeness. I answer for my
+fellow-Jurymen.”
+
+“Now, let me see,” said Madame Defarge, pondering again. “Yet once more!
+Can I spare this Doctor to my husband? I have no feeling either way. Can
+I spare him?”
+
+“He would count as one head,” observed Jacques Three, in a low voice.
+“We really have not heads enough; it would be a pity, I think.”
+
+“He was signalling with her when I saw her,” argued Madame Defarge; “I
+cannot speak of one without the other; and I must not be silent, and
+trust the case wholly to him, this little citizen here. For, I am not a
+bad witness.”
+
+The Vengeance and Jacques Three vied with each other in their fervent
+protestations that she was the most admirable and marvellous of
+witnesses. The little citizen, not to be outdone, declared her to be a
+celestial witness.
+
+“He must take his chance,” said Madame Defarge. “No, I cannot spare
+him! You are engaged at three o’clock; you are going to see the batch of
+to-day executed.--You?”
+
+The question was addressed to the wood-sawyer, who hurriedly replied in
+the affirmative: seizing the occasion to add that he was the most ardent
+of Republicans, and that he would be in effect the most desolate of
+Republicans, if anything prevented him from enjoying the pleasure of
+smoking his afternoon pipe in the contemplation of the droll national
+barber. He was so very demonstrative herein, that he might have been
+suspected (perhaps was, by the dark eyes that looked contemptuously at
+him out of Madame Defarge’s head) of having his small individual fears
+for his own personal safety, every hour in the day.
+
+“I,” said madame, “am equally engaged at the same place. After it is
+over--say at eight to-night--come you to me, in Saint Antoine, and we
+will give information against these people at my Section.”
+
+The wood-sawyer said he would be proud and flattered to attend the
+citizeness. The citizeness looking at him, he became embarrassed, evaded
+her glance as a small dog would have done, retreated among his wood, and
+hid his confusion over the handle of his saw.
+
+Madame Defarge beckoned the Juryman and The Vengeance a little nearer to
+the door, and there expounded her further views to them thus:
+
+“She will now be at home, awaiting the moment of his death. She will
+be mourning and grieving. She will be in a state of mind to impeach the
+justice of the Republic. She will be full of sympathy with its enemies.
+I will go to her.”
+
+“What an admirable woman; what an adorable woman!” exclaimed Jacques
+Three, rapturously. “Ah, my cherished!” cried The Vengeance; and
+embraced her.
+
+“Take you my knitting,” said Madame Defarge, placing it in her
+lieutenant’s hands, “and have it ready for me in my usual seat. Keep
+me my usual chair. Go you there, straight, for there will probably be a
+greater concourse than usual, to-day.”
+
+“I willingly obey the orders of my Chief,” said The Vengeance with
+alacrity, and kissing her cheek. “You will not be late?”
+
+“I shall be there before the commencement.”
+
+“And before the tumbrils arrive. Be sure you are there, my soul,” said
+The Vengeance, calling after her, for she had already turned into the
+street, “before the tumbrils arrive!”
+
+Madame Defarge slightly waved her hand, to imply that she heard, and
+might be relied upon to arrive in good time, and so went through the
+mud, and round the corner of the prison wall. The Vengeance and the
+Juryman, looking after her as she walked away, were highly appreciative
+of her fine figure, and her superb moral endowments.
+
+There were many women at that time, upon whom the time laid a dreadfully
+disfiguring hand; but, there was not one among them more to be dreaded
+than this ruthless woman, now taking her way along the streets. Of a
+strong and fearless character, of shrewd sense and readiness, of great
+determination, of that kind of beauty which not only seems to impart
+to its possessor firmness and animosity, but to strike into others an
+instinctive recognition of those qualities; the troubled time would have
+heaved her up, under any circumstances. But, imbued from her childhood
+with a brooding sense of wrong, and an inveterate hatred of a class,
+opportunity had developed her into a tigress. She was absolutely without
+pity. If she had ever had the virtue in her, it had quite gone out of
+her.
+
+It was nothing to her, that an innocent man was to die for the sins of
+his forefathers; she saw, not him, but them. It was nothing to her, that
+his wife was to be made a widow and his daughter an orphan; that was
+insufficient punishment, because they were her natural enemies and
+her prey, and as such had no right to live. To appeal to her, was made
+hopeless by her having no sense of pity, even for herself. If she had
+been laid low in the streets, in any of the many encounters in which
+she had been engaged, she would not have pitied herself; nor, if she had
+been ordered to the axe to-morrow, would she have gone to it with any
+softer feeling than a fierce desire to change places with the man who
+sent her there.
+
+Such a heart Madame Defarge carried under her rough robe. Carelessly
+worn, it was a becoming robe enough, in a certain weird way, and her
+dark hair looked rich under her coarse red cap. Lying hidden in her
+bosom, was a loaded pistol. Lying hidden at her waist, was a sharpened
+dagger. Thus accoutred, and walking with the confident tread of such
+a character, and with the supple freedom of a woman who had habitually
+walked in her girlhood, bare-foot and bare-legged, on the brown
+sea-sand, Madame Defarge took her way along the streets.
+
+Now, when the journey of the travelling coach, at that very moment
+waiting for the completion of its load, had been planned out last night,
+the difficulty of taking Miss Pross in it had much engaged Mr. Lorry’s
+attention. It was not merely desirable to avoid overloading the coach,
+but it was of the highest importance that the time occupied in examining
+it and its passengers, should be reduced to the utmost; since their
+escape might depend on the saving of only a few seconds here and there.
+Finally, he had proposed, after anxious consideration, that Miss Pross
+and Jerry, who were at liberty to leave the city, should leave it at
+three o’clock in the lightest-wheeled conveyance known to that period.
+Unencumbered with luggage, they would soon overtake the coach, and,
+passing it and preceding it on the road, would order its horses in
+advance, and greatly facilitate its progress during the precious hours
+of the night, when delay was the most to be dreaded.
+
+Seeing in this arrangement the hope of rendering real service in that
+pressing emergency, Miss Pross hailed it with joy. She and Jerry had
+beheld the coach start, had known who it was that Solomon brought, had
+passed some ten minutes in tortures of suspense, and were now concluding
+their arrangements to follow the coach, even as Madame Defarge,
+taking her way through the streets, now drew nearer and nearer to the
+else-deserted lodging in which they held their consultation.
+
+“Now what do you think, Mr. Cruncher,” said Miss Pross, whose agitation
+was so great that she could hardly speak, or stand, or move, or live:
+“what do you think of our not starting from this courtyard? Another
+carriage having already gone from here to-day, it might awaken
+suspicion.”
+
+“My opinion, miss,” returned Mr. Cruncher, “is as you’re right. Likewise
+wot I’ll stand by you, right or wrong.”
+
+“I am so distracted with fear and hope for our precious creatures,” said
+Miss Pross, wildly crying, “that I am incapable of forming any plan. Are
+_you_ capable of forming any plan, my dear good Mr. Cruncher?”
+
+“Respectin’ a future spear o’ life, miss,” returned Mr. Cruncher, “I
+hope so. Respectin’ any present use o’ this here blessed old head o’
+mine, I think not. Would you do me the favour, miss, to take notice o’
+two promises and wows wot it is my wishes fur to record in this here
+crisis?”
+
+“Oh, for gracious sake!” cried Miss Pross, still wildly crying, “record
+them at once, and get them out of the way, like an excellent man.”
+
+“First,” said Mr. Cruncher, who was all in a tremble, and who spoke with
+an ashy and solemn visage, “them poor things well out o’ this, never no
+more will I do it, never no more!”
+
+“I am quite sure, Mr. Cruncher,” returned Miss Pross, “that you
+never will do it again, whatever it is, and I beg you not to think it
+necessary to mention more particularly what it is.”
+
+“No, miss,” returned Jerry, “it shall not be named to you. Second: them
+poor things well out o’ this, and never no more will I interfere with
+Mrs. Cruncher’s flopping, never no more!”
+
+“Whatever housekeeping arrangement that may be,” said Miss Pross,
+striving to dry her eyes and compose herself, “I have no doubt it
+is best that Mrs. Cruncher should have it entirely under her own
+superintendence.--O my poor darlings!”
+
+“I go so far as to say, miss, moreover,” proceeded Mr. Cruncher, with a
+most alarming tendency to hold forth as from a pulpit--“and let my words
+be took down and took to Mrs. Cruncher through yourself--that wot my
+opinions respectin’ flopping has undergone a change, and that wot I only
+hope with all my heart as Mrs. Cruncher may be a flopping at the present
+time.”
+
+“There, there, there! I hope she is, my dear man,” cried the distracted
+Miss Pross, “and I hope she finds it answering her expectations.”
+
+“Forbid it,” proceeded Mr. Cruncher, with additional solemnity,
+additional slowness, and additional tendency to hold forth and hold
+out, “as anything wot I have ever said or done should be wisited on my
+earnest wishes for them poor creeturs now! Forbid it as we shouldn’t all
+flop (if it was anyways conwenient) to get ‘em out o’ this here dismal
+risk! Forbid it, miss! Wot I say, for-_bid_ it!” This was Mr. Cruncher’s
+conclusion after a protracted but vain endeavour to find a better one.
+
+And still Madame Defarge, pursuing her way along the streets, came
+nearer and nearer.
+
+“If we ever get back to our native land,” said Miss Pross, “you may rely
+upon my telling Mrs. Cruncher as much as I may be able to remember and
+understand of what you have so impressively said; and at all events
+you may be sure that I shall bear witness to your being thoroughly in
+earnest at this dreadful time. Now, pray let us think! My esteemed Mr.
+Cruncher, let us think!”
+
+Still, Madame Defarge, pursuing her way along the streets, came nearer
+and nearer.
+
+“If you were to go before,” said Miss Pross, “and stop the vehicle and
+horses from coming here, and were to wait somewhere for me; wouldn’t
+that be best?”
+
+Mr. Cruncher thought it might be best.
+
+“Where could you wait for me?” asked Miss Pross.
+
+Mr. Cruncher was so bewildered that he could think of no locality but
+Temple Bar. Alas! Temple Bar was hundreds of miles away, and Madame
+Defarge was drawing very near indeed.
+
+“By the cathedral door,” said Miss Pross. “Would it be much out of
+the way, to take me in, near the great cathedral door between the two
+towers?”
+
+“No, miss,” answered Mr. Cruncher.
+
+“Then, like the best of men,” said Miss Pross, “go to the posting-house
+straight, and make that change.”
+
+“I am doubtful,” said Mr. Cruncher, hesitating and shaking his head,
+“about leaving of you, you see. We don’t know what may happen.”
+
+“Heaven knows we don’t,” returned Miss Pross, “but have no fear for me.
+Take me in at the cathedral, at Three o’Clock, or as near it as you can,
+and I am sure it will be better than our going from here. I feel certain
+of it. There! Bless you, Mr. Cruncher! Think-not of me, but of the lives
+that may depend on both of us!”
+
+This exordium, and Miss Pross’s two hands in quite agonised entreaty
+clasping his, decided Mr. Cruncher. With an encouraging nod or two, he
+immediately went out to alter the arrangements, and left her by herself
+to follow as she had proposed.
+
+The having originated a precaution which was already in course of
+execution, was a great relief to Miss Pross. The necessity of composing
+her appearance so that it should attract no special notice in the
+streets, was another relief. She looked at her watch, and it was twenty
+minutes past two. She had no time to lose, but must get ready at once.
+
+Afraid, in her extreme perturbation, of the loneliness of the deserted
+rooms, and of half-imagined faces peeping from behind every open door
+in them, Miss Pross got a basin of cold water and began laving her eyes,
+which were swollen and red. Haunted by her feverish apprehensions, she
+could not bear to have her sight obscured for a minute at a time by the
+dripping water, but constantly paused and looked round to see that there
+was no one watching her. In one of those pauses she recoiled and cried
+out, for she saw a figure standing in the room.
+
+The basin fell to the ground broken, and the water flowed to the feet of
+Madame Defarge. By strange stern ways, and through much staining blood,
+those feet had come to meet that water.
+
+Madame Defarge looked coldly at her, and said, “The wife of Evremonde;
+where is she?”
+
+It flashed upon Miss Pross’s mind that the doors were all standing open,
+and would suggest the flight. Her first act was to shut them. There were
+four in the room, and she shut them all. She then placed herself before
+the door of the chamber which Lucie had occupied.
+
+Madame Defarge’s dark eyes followed her through this rapid movement,
+and rested on her when it was finished. Miss Pross had nothing beautiful
+about her; years had not tamed the wildness, or softened the grimness,
+of her appearance; but, she too was a determined woman in her different
+way, and she measured Madame Defarge with her eyes, every inch.
+
+“You might, from your appearance, be the wife of Lucifer,” said Miss
+Pross, in her breathing. “Nevertheless, you shall not get the better of
+me. I am an Englishwoman.”
+
+Madame Defarge looked at her scornfully, but still with something of
+Miss Pross’s own perception that they two were at bay. She saw a tight,
+hard, wiry woman before her, as Mr. Lorry had seen in the same figure a
+woman with a strong hand, in the years gone by. She knew full well that
+Miss Pross was the family’s devoted friend; Miss Pross knew full well
+that Madame Defarge was the family’s malevolent enemy.
+
+“On my way yonder,” said Madame Defarge, with a slight movement of
+her hand towards the fatal spot, “where they reserve my chair and my
+knitting for me, I am come to make my compliments to her in passing. I
+wish to see her.”
+
+“I know that your intentions are evil,” said Miss Pross, “and you may
+depend upon it, I’ll hold my own against them.”
+
+Each spoke in her own language; neither understood the other’s words;
+both were very watchful, and intent to deduce from look and manner, what
+the unintelligible words meant.
+
+“It will do her no good to keep herself concealed from me at this
+moment,” said Madame Defarge. “Good patriots will know what that means.
+Let me see her. Go tell her that I wish to see her. Do you hear?”
+
+“If those eyes of yours were bed-winches,” returned Miss Pross, “and I
+was an English four-poster, they shouldn’t loose a splinter of me. No,
+you wicked foreign woman; I am your match.”
+
+Madame Defarge was not likely to follow these idiomatic remarks in
+detail; but, she so far understood them as to perceive that she was set
+at naught.
+
+“Woman imbecile and pig-like!” said Madame Defarge, frowning. “I take no
+answer from you. I demand to see her. Either tell her that I demand
+to see her, or stand out of the way of the door and let me go to her!”
+ This, with an angry explanatory wave of her right arm.
+
+“I little thought,” said Miss Pross, “that I should ever want to
+understand your nonsensical language; but I would give all I have,
+except the clothes I wear, to know whether you suspect the truth, or any
+part of it.”
+
+Neither of them for a single moment released the other’s eyes. Madame
+Defarge had not moved from the spot where she stood when Miss Pross
+first became aware of her; but, she now advanced one step.
+
+“I am a Briton,” said Miss Pross, “I am desperate. I don’t care an
+English Twopence for myself. I know that the longer I keep you here, the
+greater hope there is for my Ladybird. I’ll not leave a handful of that
+dark hair upon your head, if you lay a finger on me!”
+
+Thus Miss Pross, with a shake of her head and a flash of her eyes
+between every rapid sentence, and every rapid sentence a whole breath.
+Thus Miss Pross, who had never struck a blow in her life.
+
+But, her courage was of that emotional nature that it brought the
+irrepressible tears into her eyes. This was a courage that Madame
+Defarge so little comprehended as to mistake for weakness. “Ha, ha!” she
+laughed, “you poor wretch! What are you worth! I address myself to that
+Doctor.” Then she raised her voice and called out, “Citizen Doctor! Wife
+of Evremonde! Child of Evremonde! Any person but this miserable fool,
+answer the Citizeness Defarge!”
+
+Perhaps the following silence, perhaps some latent disclosure in the
+expression of Miss Pross’s face, perhaps a sudden misgiving apart from
+either suggestion, whispered to Madame Defarge that they were gone.
+Three of the doors she opened swiftly, and looked in.
+
+“Those rooms are all in disorder, there has been hurried packing, there
+are odds and ends upon the ground. There is no one in that room behind
+you! Let me look.”
+
+“Never!” said Miss Pross, who understood the request as perfectly as
+Madame Defarge understood the answer.
+
+“If they are not in that room, they are gone, and can be pursued and
+brought back,” said Madame Defarge to herself.
+
+“As long as you don’t know whether they are in that room or not, you are
+uncertain what to do,” said Miss Pross to herself; “and you shall not
+know that, if I can prevent your knowing it; and know that, or not know
+that, you shall not leave here while I can hold you.”
+
+“I have been in the streets from the first, nothing has stopped me,
+I will tear you to pieces, but I will have you from that door,” said
+Madame Defarge.
+
+“We are alone at the top of a high house in a solitary courtyard, we are
+not likely to be heard, and I pray for bodily strength to keep you here,
+while every minute you are here is worth a hundred thousand guineas to
+my darling,” said Miss Pross.
+
+Madame Defarge made at the door. Miss Pross, on the instinct of the
+moment, seized her round the waist in both her arms, and held her tight.
+It was in vain for Madame Defarge to struggle and to strike; Miss Pross,
+with the vigorous tenacity of love, always so much stronger than hate,
+clasped her tight, and even lifted her from the floor in the struggle
+that they had. The two hands of Madame Defarge buffeted and tore her
+face; but, Miss Pross, with her head down, held her round the waist, and
+clung to her with more than the hold of a drowning woman.
+
+Soon, Madame Defarge’s hands ceased to strike, and felt at her encircled
+waist. “It is under my arm,” said Miss Pross, in smothered tones, “you
+shall not draw it. I am stronger than you, I bless Heaven for it. I hold
+you till one or other of us faints or dies!”
+
+Madame Defarge’s hands were at her bosom. Miss Pross looked up, saw
+what it was, struck at it, struck out a flash and a crash, and stood
+alone--blinded with smoke.
+
+All this was in a second. As the smoke cleared, leaving an awful
+stillness, it passed out on the air, like the soul of the furious woman
+whose body lay lifeless on the ground.
+
+In the first fright and horror of her situation, Miss Pross passed the
+body as far from it as she could, and ran down the stairs to call for
+fruitless help. Happily, she bethought herself of the consequences of
+what she did, in time to check herself and go back. It was dreadful to
+go in at the door again; but, she did go in, and even went near it, to
+get the bonnet and other things that she must wear. These she put on,
+out on the staircase, first shutting and locking the door and taking
+away the key. She then sat down on the stairs a few moments to breathe
+and to cry, and then got up and hurried away.
+
+By good fortune she had a veil on her bonnet, or she could hardly have
+gone along the streets without being stopped. By good fortune, too, she
+was naturally so peculiar in appearance as not to show disfigurement
+like any other woman. She needed both advantages, for the marks of
+gripping fingers were deep in her face, and her hair was torn, and her
+dress (hastily composed with unsteady hands) was clutched and dragged a
+hundred ways.
+
+In crossing the bridge, she dropped the door key in the river. Arriving
+at the cathedral some few minutes before her escort, and waiting there,
+she thought, what if the key were already taken in a net, what if
+it were identified, what if the door were opened and the remains
+discovered, what if she were stopped at the gate, sent to prison, and
+charged with murder! In the midst of these fluttering thoughts, the
+escort appeared, took her in, and took her away.
+
+“Is there any noise in the streets?” she asked him.
+
+“The usual noises,” Mr. Cruncher replied; and looked surprised by the
+question and by her aspect.
+
+“I don’t hear you,” said Miss Pross. “What do you say?”
+
+It was in vain for Mr. Cruncher to repeat what he said; Miss Pross could
+not hear him. “So I’ll nod my head,” thought Mr. Cruncher, amazed, “at
+all events she’ll see that.” And she did.
+
+“Is there any noise in the streets now?” asked Miss Pross again,
+presently.
+
+Again Mr. Cruncher nodded his head.
+
+“I don’t hear it.”
+
+“Gone deaf in an hour?” said Mr. Cruncher, ruminating, with his mind
+much disturbed; “wot’s come to her?”
+
+“I feel,” said Miss Pross, “as if there had been a flash and a crash,
+and that crash was the last thing I should ever hear in this life.”
+
+“Blest if she ain’t in a queer condition!” said Mr. Cruncher, more and
+more disturbed. “Wot can she have been a takin’, to keep her courage up?
+Hark! There’s the roll of them dreadful carts! You can hear that, miss?”
+
+“I can hear,” said Miss Pross, seeing that he spoke to her, “nothing. O,
+my good man, there was first a great crash, and then a great stillness,
+and that stillness seems to be fixed and unchangeable, never to be
+broken any more as long as my life lasts.”
+
+“If she don’t hear the roll of those dreadful carts, now very nigh their
+journey’s end,” said Mr. Cruncher, glancing over his shoulder, “it’s my
+opinion that indeed she never will hear anything else in this world.”
+
+And indeed she never did.
+
+
+
+
+XV. The Footsteps Die Out For Ever
+
+
+Along the Paris streets, the death-carts rumble, hollow and harsh. Six
+tumbrils carry the day’s wine to La Guillotine. All the devouring and
+insatiate Monsters imagined since imagination could record itself,
+are fused in the one realisation, Guillotine. And yet there is not in
+France, with its rich variety of soil and climate, a blade, a leaf,
+a root, a sprig, a peppercorn, which will grow to maturity under
+conditions more certain than those that have produced this horror. Crush
+humanity out of shape once more, under similar hammers, and it will
+twist itself into the same tortured forms. Sow the same seed of
+rapacious license and oppression over again, and it will surely yield
+the same fruit according to its kind.
+
+Six tumbrils roll along the streets. Change these back again to what
+they were, thou powerful enchanter, Time, and they shall be seen to be
+the carriages of absolute monarchs, the equipages of feudal nobles, the
+toilettes of flaring Jezebels, the churches that are not my father’s
+house but dens of thieves, the huts of millions of starving peasants!
+No; the great magician who majestically works out the appointed order
+of the Creator, never reverses his transformations. “If thou be changed
+into this shape by the will of God,” say the seers to the enchanted, in
+the wise Arabian stories, “then remain so! But, if thou wear this
+form through mere passing conjuration, then resume thy former aspect!”
+ Changeless and hopeless, the tumbrils roll along.
+
+As the sombre wheels of the six carts go round, they seem to plough up
+a long crooked furrow among the populace in the streets. Ridges of faces
+are thrown to this side and to that, and the ploughs go steadily onward.
+So used are the regular inhabitants of the houses to the spectacle, that
+in many windows there are no people, and in some the occupation of the
+hands is not so much as suspended, while the eyes survey the faces in
+the tumbrils. Here and there, the inmate has visitors to see the sight;
+then he points his finger, with something of the complacency of a
+curator or authorised exponent, to this cart and to this, and seems to
+tell who sat here yesterday, and who there the day before.
+
+Of the riders in the tumbrils, some observe these things, and all
+things on their last roadside, with an impassive stare; others, with
+a lingering interest in the ways of life and men. Some, seated with
+drooping heads, are sunk in silent despair; again, there are some so
+heedful of their looks that they cast upon the multitude such glances as
+they have seen in theatres, and in pictures. Several close their eyes,
+and think, or try to get their straying thoughts together. Only one, and
+he a miserable creature, of a crazed aspect, is so shattered and made
+drunk by horror, that he sings, and tries to dance. Not one of the whole
+number appeals by look or gesture, to the pity of the people.
+
+There is a guard of sundry horsemen riding abreast of the tumbrils,
+and faces are often turned up to some of them, and they are asked some
+question. It would seem to be always the same question, for, it is
+always followed by a press of people towards the third cart. The
+horsemen abreast of that cart, frequently point out one man in it with
+their swords. The leading curiosity is, to know which is he; he stands
+at the back of the tumbril with his head bent down, to converse with a
+mere girl who sits on the side of the cart, and holds his hand. He has
+no curiosity or care for the scene about him, and always speaks to the
+girl. Here and there in the long street of St. Honore, cries are raised
+against him. If they move him at all, it is only to a quiet smile, as he
+shakes his hair a little more loosely about his face. He cannot easily
+touch his face, his arms being bound.
+
+On the steps of a church, awaiting the coming-up of the tumbrils, stands
+the Spy and prison-sheep. He looks into the first of them: not there.
+He looks into the second: not there. He already asks himself, “Has he
+sacrificed me?” when his face clears, as he looks into the third.
+
+“Which is Evremonde?” says a man behind him.
+
+“That. At the back there.”
+
+“With his hand in the girl’s?”
+
+“Yes.”
+
+The man cries, “Down, Evremonde! To the Guillotine all aristocrats!
+Down, Evremonde!”
+
+“Hush, hush!” the Spy entreats him, timidly.
+
+“And why not, citizen?”
+
+“He is going to pay the forfeit: it will be paid in five minutes more.
+Let him be at peace.”
+
+But the man continuing to exclaim, “Down, Evremonde!” the face of
+Evremonde is for a moment turned towards him. Evremonde then sees the
+Spy, and looks attentively at him, and goes his way.
+
+The clocks are on the stroke of three, and the furrow ploughed among the
+populace is turning round, to come on into the place of execution, and
+end. The ridges thrown to this side and to that, now crumble in and
+close behind the last plough as it passes on, for all are following
+to the Guillotine. In front of it, seated in chairs, as in a garden of
+public diversion, are a number of women, busily knitting. On one of the
+fore-most chairs, stands The Vengeance, looking about for her friend.
+
+“Therese!” she cries, in her shrill tones. “Who has seen her? Therese
+Defarge!”
+
+“She never missed before,” says a knitting-woman of the sisterhood.
+
+“No; nor will she miss now,” cries The Vengeance, petulantly. “Therese.”
+
+“Louder,” the woman recommends.
+
+Ay! Louder, Vengeance, much louder, and still she will scarcely hear
+thee. Louder yet, Vengeance, with a little oath or so added, and yet
+it will hardly bring her. Send other women up and down to seek her,
+lingering somewhere; and yet, although the messengers have done dread
+deeds, it is questionable whether of their own wills they will go far
+enough to find her!
+
+“Bad Fortune!” cries The Vengeance, stamping her foot in the chair, “and
+here are the tumbrils! And Evremonde will be despatched in a wink, and
+she not here! See her knitting in my hand, and her empty chair ready for
+her. I cry with vexation and disappointment!”
+
+As The Vengeance descends from her elevation to do it, the tumbrils
+begin to discharge their loads. The ministers of Sainte Guillotine are
+robed and ready. Crash!--A head is held up, and the knitting-women who
+scarcely lifted their eyes to look at it a moment ago when it could
+think and speak, count One.
+
+The second tumbril empties and moves on; the third comes up. Crash!--And
+the knitting-women, never faltering or pausing in their Work, count Two.
+
+The supposed Evremonde descends, and the seamstress is lifted out next
+after him. He has not relinquished her patient hand in getting out, but
+still holds it as he promised. He gently places her with her back to the
+crashing engine that constantly whirrs up and falls, and she looks into
+his face and thanks him.
+
+“But for you, dear stranger, I should not be so composed, for I am
+naturally a poor little thing, faint of heart; nor should I have been
+able to raise my thoughts to Him who was put to death, that we might
+have hope and comfort here to-day. I think you were sent to me by
+Heaven.”
+
+“Or you to me,” says Sydney Carton. “Keep your eyes upon me, dear child,
+and mind no other object.”
+
+“I mind nothing while I hold your hand. I shall mind nothing when I let
+it go, if they are rapid.”
+
+“They will be rapid. Fear not!”
+
+The two stand in the fast-thinning throng of victims, but they speak as
+if they were alone. Eye to eye, voice to voice, hand to hand, heart to
+heart, these two children of the Universal Mother, else so wide apart
+and differing, have come together on the dark highway, to repair home
+together, and to rest in her bosom.
+
+“Brave and generous friend, will you let me ask you one last question? I
+am very ignorant, and it troubles me--just a little.”
+
+“Tell me what it is.”
+
+“I have a cousin, an only relative and an orphan, like myself, whom I
+love very dearly. She is five years younger than I, and she lives in a
+farmer’s house in the south country. Poverty parted us, and she knows
+nothing of my fate--for I cannot write--and if I could, how should I
+tell her! It is better as it is.”
+
+“Yes, yes: better as it is.”
+
+“What I have been thinking as we came along, and what I am still
+thinking now, as I look into your kind strong face which gives me so
+much support, is this:--If the Republic really does good to the poor,
+and they come to be less hungry, and in all ways to suffer less, she may
+live a long time: she may even live to be old.”
+
+“What then, my gentle sister?”
+
+“Do you think:” the uncomplaining eyes in which there is so much
+endurance, fill with tears, and the lips part a little more and tremble:
+“that it will seem long to me, while I wait for her in the better land
+where I trust both you and I will be mercifully sheltered?”
+
+“It cannot be, my child; there is no Time there, and no trouble there.”
+
+“You comfort me so much! I am so ignorant. Am I to kiss you now? Is the
+moment come?”
+
+“Yes.”
+
+She kisses his lips; he kisses hers; they solemnly bless each other.
+The spare hand does not tremble as he releases it; nothing worse than
+a sweet, bright constancy is in the patient face. She goes next before
+him--is gone; the knitting-women count Twenty-Two.
+
+“I am the Resurrection and the Life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me shall never die.”
+
+The murmuring of many voices, the upturning of many faces, the pressing
+on of many footsteps in the outskirts of the crowd, so that it swells
+forward in a mass, like one great heave of water, all flashes away.
+Twenty-Three.
+
+        *****
+
+They said of him, about the city that night, that it was the
+peacefullest man’s face ever beheld there. Many added that he looked
+sublime and prophetic.
+
+One of the most remarkable sufferers by the same axe--a woman--had asked
+at the foot of the same scaffold, not long before, to be allowed to
+write down the thoughts that were inspiring her. If he had given any
+utterance to his, and they were prophetic, they would have been these:
+
+“I see Barsad, and Cly, Defarge, The Vengeance, the Juryman, the Judge,
+long ranks of the new oppressors who have risen on the destruction of
+the old, perishing by this retributive instrument, before it shall cease
+out of its present use. I see a beautiful city and a brilliant people
+rising from this abyss, and, in their struggles to be truly free, in
+their triumphs and defeats, through long years to come, I see the evil
+of this time and of the previous time of which this is the natural
+birth, gradually making expiation for itself and wearing out.
+
+“I see the lives for which I lay down my life, peaceful, useful,
+prosperous and happy, in that England which I shall see no more. I see
+Her with a child upon her bosom, who bears my name. I see her father,
+aged and bent, but otherwise restored, and faithful to all men in his
+healing office, and at peace. I see the good old man, so long their
+friend, in ten years’ time enriching them with all he has, and passing
+tranquilly to his reward.
+
+“I see that I hold a sanctuary in their hearts, and in the hearts of
+their descendants, generations hence. I see her, an old woman, weeping
+for me on the anniversary of this day. I see her and her husband, their
+course done, lying side by side in their last earthly bed, and I know
+that each was not more honoured and held sacred in the other’s soul,
+than I was in the souls of both.
+
+“I see that child who lay upon her bosom and who bore my name, a man
+winning his way up in that path of life which once was mine. I see him
+winning it so well, that my name is made illustrious there by the
+light of his. I see the blots I threw upon it, faded away. I see him,
+fore-most of just judges and honoured men, bringing a boy of my name,
+with a forehead that I know and golden hair, to this place--then fair to
+look upon, with not a trace of this day’s disfigurement--and I hear him
+tell the child my story, with a tender and a faltering voice.
+
+“It is a far, far better thing that I do, than I have ever done; it is a
+far, far better rest that I go to than I have ever known.”
+
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+*** END OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+***** This file should be named 98-0.txt or 98-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/9/98/
+
+Produced by Judith Boss
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/adventures-of-sherlock-holmes.txt
+++ b/jet/hadoop/src/main/resources/books/adventures-of-sherlock-holmes.txt
@@ -1,0 +1,12759 @@
+﻿Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+
+Title: Adventures of Sherlock Holmes
+       Illustrated
+
+Author: A. Conan Doyle
+
+Release Date: February 20, 2015 [EBook #48320]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+
+
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+
+
+
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+
+
+
+[Illustration:
+
+  “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”
+                                           [Page 238
+]
+
+
+
+
+  ADVENTURES
+  OF
+  SHERLOCK HOLMES
+
+  BY
+  A. CONAN DOYLE
+
+  AUTHOR OF “MICAH CLARKE” ETC.
+
+  ILLUSTRATED
+
+  NEW YORK
+  HARPER & BROTHERS, FRANKLIN SQUARE
+
+
+
+
+  Copyright, 1892, by HARPER & BROTHERS.
+  _All rights reserved._
+
+
+
+
+CONTENTS
+
+
+                                                 PAGE
+
+     I.—A SCANDAL IN BOHEMIA                        3
+
+    II.—THE RED-HEADED LEAGUE                      29
+
+   III.—A CASE OF IDENTITY                         56
+
+    IV.—THE BOSCOMBE VALLEY MYSTERY                76
+
+     V.—THE FIVE ORANGE PIPS                      104
+
+    VI.—THE MAN WITH THE TWISTED LIP              126
+
+   VII.—THE ADVENTURE OF THE BLUE CARBUNCLE       153
+
+  VIII.—THE ADVENTURE OF THE SPECKLED BAND        176
+
+    IX.—THE ADVENTURE OF THE ENGINEER’S THUMB     205
+
+     X.—THE ADVENTURE OF THE NOBLE BACHELOR       229
+
+    XI.—THE ADVENTURE OF THE BERYL CORONET        253
+
+   XII.—THE ADVENTURE OF THE COPPER BEECHES       280
+
+
+
+
+ILLUSTRATIONS
+
+
+    “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”  _Frontispiece_
+
+    “A MAN ENTERED”                                 _Facing p._  8
+
+    “THE DOOR WAS SHUT AND LOCKED”                         ″     40
+
+    “ALL AFTERNOON HE SAT IN THE STALLS”                   ″     46
+
+    “SHERLOCK HOLMES WELCOMED HER”                         ″     60
+
+    “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”              ″     72
+
+    “THEY FOUND THE BODY”                                  ″     80
+
+    “THE MAID SHOWED US THE BOOTS”                         ″     92
+
+    “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”                ″    122
+
+    “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+        SCOUNDREL”                                         ″    134
+
+    “‘HAVE MERCY!’ HE SHRIEKED”                            ″    172
+
+    “‘GOOD-BYE, AND BE BRAVE’”                             ″    196
+
+    “‘NOT A WORD TO A SOUL’”                               ″    214
+
+    “‘I WILL WISH YOU ALL A VERY GOOD NIGHT’”              ″    250
+
+    “I CLAPPED A PISTOL TO HIS HEAD”                       ″    278
+
+    “‘I AM SO DELIGHTED THAT YOU HAVE COME’”               ″    292
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+Adventure I
+
+A SCANDAL IN BOHEMIA
+
+
+I
+
+To Sherlock Holmes she is always _the_ woman. I have seldom heard
+him mention her under any other name. In his eyes she eclipses and
+predominates the whole of her sex. It was not that he felt any emotion
+akin to love for Irene Adler. All emotions, and that one particularly,
+were abhorrent to his cold, precise, but admirably balanced mind. He
+was, I take it, the most perfect reasoning and observing machine that
+the world has seen; but, as a lover, he would have placed himself in a
+false position. He never spoke of the softer passions, save with a gibe
+and a sneer. They were admirable things for the observer—excellent
+for drawing the veil from men’s motives and actions. But for the
+trained reasoner to admit such intrusions into his own delicate and
+finely adjusted temperament was to introduce a distracting factor which
+might throw a doubt upon all his mental results. Grit in a sensitive
+instrument, or a crack in one of his own high-power lenses, would not
+be more disturbing than a strong emotion in a nature such as his. And
+yet there was but one woman to him, and that woman was the late Irene
+Adler, of dubious and questionable memory.
+
+I had seen little of Holmes lately. My marriage had drifted us away
+from each other. My own complete happiness, and the home-centred
+interests which rise up around the man who first finds himself master
+of his own establishment, were sufficient to absorb all my attention;
+while Holmes, who loathed every form of society with his whole
+Bohemian soul, remained in our lodgings in Baker Street, buried among
+his old books, and alternating from week to week between cocaine and
+ambition, the drowsiness of the drug, and the fierce energy of his
+own keen nature. He was still, as ever, deeply attracted by the study
+of crime, and occupied his immense faculties and extraordinary powers
+of observation in following out those clues, and clearing up those
+mysteries, which had been abandoned as hopeless by the official police.
+From time to time I heard some vague account of his doings: of his
+summons to Odessa in the case of the Trepoff murder, of his clearing
+up of the singular tragedy of the Atkinson brothers at Trincomalee,
+and finally of the mission which he had accomplished so delicately and
+successfully for the reigning family of Holland. Beyond these signs of
+his activity, however, which I merely shared with all the readers of
+the daily press, I knew little of my former friend and companion.
+
+One night—it was on the 20th of March, 1888—I was returning from a
+journey to a patient (for I had now returned to civil practice), when
+my way led me through Baker Street. As I passed the well-remembered
+door, which must always be associated in my mind with my wooing, and
+with the dark incidents of the Study in Scarlet, I was seized with a
+keen desire to see Holmes again, and to know how he was employing his
+extraordinary powers. His rooms were brilliantly lit, and, even as I
+looked up, I saw his tall, spare figure pass twice in a dark silhouette
+against the blind. He was pacing the room swiftly, eagerly, with his
+head sunk upon his chest and his hands clasped behind him. To me, who
+knew his every mood and habit, his attitude and manner told their own
+story. He was at work again. He had arisen out of his drug-created
+dreams, and was hot upon the scent of some new problem. I rang the
+bell, and was shown up to the chamber which had formerly been in part
+my own.
+
+His manner was not effusive. It seldom was; but he was glad, I think,
+to see me. With hardly a word spoken, but with a kindly eye, he waved
+me to an arm-chair, threw across his case of cigars, and indicated a
+spirit case and a gasogene in the corner. Then he stood before the
+fire, and looked me over in his singular introspective fashion.
+
+“Wedlock suits you,” he remarked. “I think, Watson, that you have put
+on seven and a half pounds since I saw you.”
+
+“Seven!” I answered.
+
+“Indeed, I should have thought a little more. Just a trifle more, I
+fancy, Watson. And in practice again, I observe. You did not tell me
+that you intended to go into harness.”
+
+“Then, how do you know?”
+
+“I see it, I deduce it. How do I know that you have been getting
+yourself very wet lately, and that you have a most clumsy and careless
+servant girl?”
+
+“My dear Holmes,” said I, “this is too much. You would certainly have
+been burned, had you lived a few centuries ago. It is true that I had
+a country walk on Thursday and came home in a dreadful mess; but, as I
+have changed my clothes, I can’t imagine how you deduce it. As to Mary
+Jane, she is incorrigible, and my wife has given her notice; but there,
+again, I fail to see how you work it out.”
+
+He chuckled to himself and rubbed his long, nervous hands together.
+
+“It is simplicity itself,” said he; “my eyes tell me that on the
+inside of your left shoe, just where the firelight strikes it, the
+leather is scored by six almost parallel cuts. Obviously they have
+been caused by some one who has very carelessly scraped round the
+edges of the sole in order to remove crusted mud from it. Hence, you
+see, my double deduction that you had been out in vile weather, and
+that you had a particularly malignant boot-slitting specimen of the
+London slavey. As to your practice, if a gentleman walks into my rooms
+smelling of iodoform, with a black mark of nitrate of silver upon his
+right forefinger, and a bulge on the side of his top-hat to show where
+he has secreted his stethoscope, I must be dull, indeed, if I do not
+pronounce him to be an active member of the medical profession.”
+
+I could not help laughing at the ease with which he explained his
+process of deduction. “When I hear you give your reasons,” I remarked,
+“the thing always appears to me to be so ridiculously simple that I
+could easily do it myself, though at each successive instance of your
+reasoning I am baffled, until you explain your process. And yet I
+believe that my eyes are as good as yours.”
+
+“Quite so,” he answered, lighting a cigarette, and throwing himself
+down into an arm-chair. “You see, but you do not observe. The
+distinction is clear. For example, you have frequently seen the steps
+which lead up from the hall to this room.”
+
+“Frequently.”
+
+“How often?”
+
+“Well, some hundreds of times.”
+
+“Then how many are there?”
+
+“How many? I don’t know.”
+
+“Quite so! You have not observed. And yet you have seen. That is just
+my point. Now, I know that there are seventeen steps, because I have
+both seen and observed. By-the-way, since you are interested in these
+little problems, and since you are good enough to chronicle one or two
+of my trifling experiences, you may be interested in this.” He threw
+over a sheet of thick, pink-tinted note-paper which had been lying open
+upon the table. “It came by the last post,” said he. “Read it aloud.”
+
+The note was undated, and without either signature or address.
+
+“There will call upon you to-night, at a quarter to eight o’clock,”
+it said, “a gentleman who desires to consult you upon a matter of the
+very deepest moment. Your recent services to one of the royal houses
+of Europe have shown that you are one who may safely be trusted with
+matters which are of an importance which can hardly be exaggerated.
+This account of you we have from all quarters received. Be in your
+chamber then at that hour, and do not take it amiss if your visitor
+wear a mask.”
+
+“This is indeed a mystery,” I remarked. “What do you imagine that it
+means?”
+
+“I have no data yet. It is a capital mistake to theorize before one has
+data. Insensibly one begins to twist facts to suit theories, instead of
+theories to suit facts. But the note itself. What do you deduce from
+it?”
+
+I carefully examined the writing, and the paper upon which it was
+written.
+
+“The man who wrote it was presumably well to do,” I remarked,
+endeavoring to imitate my companion’s processes. “Such paper could not
+be bought under half a crown a packet. It is peculiarly strong and
+stiff.”
+
+“Peculiar—that is the very word,” said Holmes. “It is not an English
+paper at all. Hold it up to the light.”
+
+I did so, and saw a large _E_ with a small _g_, a _P_, and a large _G_
+with a small _t_ woven into the texture of the paper.
+
+“What do you make of that?” asked Holmes.
+
+“The name of the maker, no doubt; or his monogram, rather.”
+
+“Not at all. The _G_ with the small _t_ stands for ‘Gesellschaft,’
+which is the German for ‘Company.’ It is a customary contraction like
+our ‘Co.’ _P_, of course, stands for ‘Papier.’ Now for the _Eg_. Let us
+glance at our Continental Gazetteer.” He took down a heavy brown volume
+from his shelves. “Eglow, Eglonitz—here we are, Egria. It is in a
+German-speaking country—in Bohemia, not far from Carlsbad. ‘Remarkable
+as being the scene of the death of Wallenstein, and for its numerous
+glass-factories and paper-mills.’ Ha, ha, my boy, what do you make of
+that?” His eyes sparkled, and he sent up a great blue triumphant cloud
+from his cigarette.
+
+“The paper was made in Bohemia,” I said.
+
+“Precisely. And the man who wrote the note is a German. Do you note the
+peculiar construction of the sentence—‘This account of you we have
+from all quarters received.’ A Frenchman or Russian could not have
+written that. It is the German who is so uncourteous to his verbs. It
+only remains, therefore, to discover what is wanted by this German
+who writes upon Bohemian paper, and prefers wearing a mask to showing
+his face. And here he comes, if I am not mistaken, to resolve all our
+doubts.”
+
+As he spoke there was the sharp sound of horses’ hoofs and grating
+wheels against the curb, followed by a sharp pull at the bell. Holmes
+whistled.
+
+“A pair, by the sound,” said he. “Yes,” he continued, glancing out of
+the window. “A nice little brougham and a pair of beauties. A hundred
+and fifty guineas apiece. There’s money in this case, Watson, if there
+is nothing else.”
+
+“I think that I had better go, Holmes.”
+
+“Not a bit, doctor. Stay where you are. I am lost without my Boswell.
+And this promises to be interesting. It would be a pity to miss it.”
+
+“But your client—”
+
+“Never mind him. I may want your help, and so may he. Here he comes.
+Sit down in that arm-chair, doctor, and give us your best attention.”
+
+A slow and heavy step, which had been heard upon the stairs and in the
+passage, paused immediately outside the door. Then there was a loud and
+authoritative tap.
+
+“Come in!” said Holmes.
+
+[Illustration: “A MAN ENTERED”]
+
+A man entered who could hardly have been less than six feet six inches
+in height, with the chest and limbs of a Hercules. His dress was rich
+with a richness which would, in England, be looked upon as akin to bad
+taste. Heavy bands of Astrakhan were slashed across the sleeves and
+fronts of his double-breasted coat, while the deep blue cloak which
+was thrown over his shoulders was lined with flame-colored silk, and
+secured at the neck with a brooch which consisted of a single flaming
+beryl. Boots which extended half-way up his calves, and which were
+trimmed at the tops with rich brown fur, completed the impression of
+barbaric opulence which was suggested by his whole appearance. He
+carried a broad-brimmed hat in his hand, while he wore across the upper
+part of his face, extending down past the cheekbones, a black vizard
+mask, which he had apparently adjusted that very moment, for his hand
+was still raised to it as he entered. From the lower part of the face
+he appeared to be a man of strong character, with a thick, hanging
+lip, and a long, straight chin, suggestive of resolution pushed to the
+length of obstinacy.
+
+“You had my note?” he asked, with a deep harsh voice and a strongly
+marked German accent. “I told you that I would call.” He looked from
+one to the other of us, as if uncertain which to address.
+
+“Pray take a seat,” said Holmes. “This is my friend and colleague, Dr.
+Watson, who is occasionally good enough to help me in my cases. Whom
+have I the honor to address?”
+
+“You may address me as the Count Von Kramm, a Bohemian nobleman.
+I understand that this gentleman, your friend, is a man of honor
+and discretion, whom I may trust with a matter of the most extreme
+importance. If not, I should much prefer to communicate with you alone.”
+
+I rose to go, but Holmes caught me by the wrist and pushed me back into
+my chair. “It is both, or none,” said he. “You may say before this
+gentleman anything which you may say to me.”
+
+The count shrugged his broad shoulders. “Then I must begin,” said he,
+“by binding you both to absolute secrecy for two years, at the end of
+that time the matter will be of no importance. At present it is not too
+much to say that it is of such weight it may have an influence upon
+European history.”
+
+“I promise,” said Holmes.
+
+“And I.”
+
+“You will excuse this mask,” continued our strange visitor. “The august
+person who employs me wishes his agent to be unknown to you, and I may
+confess at once that the title by which I have just called myself is
+not exactly my own.”
+
+“I was aware of it,” said Holmes, dryly.
+
+“The circumstances are of great delicacy, and every precaution has
+to be taken to quench what might grow to be an immense scandal and
+seriously compromise one of the reigning families of Europe. To speak
+plainly, the matter implicates the great House of Ormstein, hereditary
+kings of Bohemia.”
+
+“I was also aware of that,” murmured Holmes, settling himself down in
+his arm-chair and closing his eyes.
+
+Our visitor glanced with some apparent surprise at the languid,
+lounging figure of the man who had been no doubt depicted to him as
+the most incisive reasoner and most energetic agent in Europe. Holmes
+slowly reopened his eyes and looked impatiently at his gigantic client.
+
+“If your Majesty would condescend to state your case,” he remarked, “I
+should be better able to advise you.”
+
+The man sprang from his chair and paced up and down the room in
+uncontrollable agitation. Then, with a gesture of desperation, he tore
+the mask from his face and hurled it upon the ground. “You are right,”
+he cried; “I am the King. Why should I attempt to conceal it?”
+
+“Why, indeed?” murmured Holmes. “Your Majesty had not spoken before
+I was aware that I was addressing Wilhelm Gottsreich Sigismond von
+Ormstein, Grand Duke of Cassel-Felstein, and hereditary King of
+Bohemia.”
+
+“But you can understand,” said our strange visitor, sitting down once
+more and passing his hand over his high, white forehead, “you can
+understand that I am not accustomed to doing such business in my own
+person. Yet the matter was so delicate that I could not confide it to
+an agent without putting myself in his power. I have come _incognito_
+from Prague for the purpose of consulting you.”
+
+“Then, pray consult,” said Holmes, shutting his eyes once more.
+
+“The facts are briefly these: Some five years ago, during a lengthy
+visit to Warsaw, I made the acquaintance of the well-known
+adventuress, Irene Adler. The name is no doubt familiar to you.”
+
+“Kindly look her up in my index, doctor,” murmured Holmes, without
+opening his eyes. For many years he had adopted a system of docketing
+all paragraphs concerning men and things, so that it was difficult
+to name a subject or a person on which he could not at once furnish
+information. In this case I found her biography sandwiched in between
+that of a Hebrew Rabbi and that of a staff-commander who had written a
+monograph upon the deep-sea fishes.
+
+“Let me see!” said Holmes. “Hum! Born in New Jersey in the year
+1858. Contralto—hum! La Scala, hum! Prima donna Imperial Opera of
+Warsaw—Yes! Retired from operatic stage—ha! Living in London—quite
+so! Your Majesty, as I understand, became entangled with this young
+person, wrote her some compromising letters, and is now desirous of
+getting those letters back.”
+
+“Precisely so. But how—”
+
+“Was there a secret marriage?”
+
+“None.”
+
+“No legal papers or certificates?”
+
+“None.”
+
+“Then I fail to follow your Majesty. If this young person should
+produce her letters for blackmailing or other purposes, how is she to
+prove their authenticity?”
+
+“There is the writing.”
+
+“Pooh, pooh! Forgery.”
+
+“My private note-paper.”
+
+“Stolen.”
+
+“My own seal.”
+
+“Imitated.”
+
+“My photograph.”
+
+“Bought.”
+
+“We were both in the photograph.”
+
+“Oh dear! That is very bad! Your Majesty has indeed committed an
+indiscretion.”
+
+“I was mad—insane.”
+
+“You have compromised yourself seriously.”
+
+“I was only Crown Prince then. I was young. I am but thirty now.”
+
+“It must be recovered.”
+
+“We have tried and failed.”
+
+“Your Majesty must pay. It must be bought.”
+
+“She will not sell.”
+
+“Stolen, then.”
+
+“Five attempts have been made. Twice burglars in my pay ransacked her
+house. Once we diverted her luggage when she travelled. Twice she has
+been waylaid. There has been no result.”
+
+“No sign of it?”
+
+“Absolutely none.”
+
+Holmes laughed. “It is quite a pretty little problem,” said he.
+
+“But a very serious one to me,” returned the King, reproachfully.
+
+“Very, indeed. And what does she propose to do with the photograph?”
+
+“To ruin me.”
+
+“But how?”
+
+“I am about to be married.”
+
+“So I have heard.”
+
+“To Clotilde Lothman von Saxe-Meningen, second daughter of the King of
+Scandinavia. You may know the strict principles of her family. She is
+herself the very soul of delicacy. A shadow of a doubt as to my conduct
+would bring the matter to an end.”
+
+“And Irene Adler?”
+
+“Threatens to send them the photograph. And she will do it. I know that
+she will do it. You do not know her, but she has a soul of steel. She
+has the face of the most beautiful of women, and the mind of the most
+resolute of men. Rather than I should marry another woman, there are
+no lengths to which she would not go—none.”
+
+“You are sure that she has not sent it yet?”
+
+“I am sure.”
+
+“And why?”
+
+“Because she has said that she would send it on the day when the
+betrothal was publicly proclaimed. That will be next Monday.”
+
+“Oh, then, we have three days yet,” said Holmes, with a yawn. “That is
+very fortunate, as I have one or two matters of importance to look into
+just at present. Your Majesty will, of course, stay in London for the
+present?”
+
+“Certainly. You will find me at the Langham, under the name of the
+Count Von Kramm.”
+
+“Then I shall drop you a line to let you know how we progress.”
+
+“Pray do so. I shall be all anxiety.”
+
+“Then, as to money?”
+
+“You have _carte blanche_.”
+
+“Absolutely?”
+
+“I tell you that I would give one of the provinces of my kingdom to
+have that photograph.”
+
+“And for present expenses?”
+
+The king took a heavy chamois leather bag from under his cloak and laid
+it on the table.
+
+“There are three hundred pounds in gold and seven hundred in notes,” he
+said.
+
+Holmes scribbled a receipt upon a sheet of his note-book and handed it
+to him.
+
+“And mademoiselle’s address?” he asked.
+
+“Is Briony Lodge, Serpentine Avenue, St. John’s Wood.”
+
+Holmes took a note of it. “One other question,” said he. “Was the
+photograph a cabinet?”
+
+“It was.”
+
+“Then, good-night, your Majesty, and I trust that we shall soon have
+some good news for you. And good-night, Watson,” he added, as the
+wheels of the royal brougham rolled down the street. “If you will be
+good enough to call to-morrow afternoon, at three o’clock, I should
+like to chat this little matter over with you.”
+
+
+II
+
+At three o’clock precisely I was at Baker Street, but Holmes had not
+yet returned. The landlady informed me that he had left the house
+shortly after eight o’clock in the morning. I sat down beside the
+fire, however, with the intention of awaiting him, however long he
+might be. I was already deeply interested in his inquiry, for, though
+it was surrounded by none of the grim and strange features which
+were associated with the two crimes which I have already recorded,
+still, the nature of the case and the exalted station of his client
+gave it a character of its own. Indeed, apart from the nature of the
+investigation which my friend had on hand, there was something in his
+masterly grasp of a situation, and his keen, incisive reasoning, which
+made it a pleasure to me to study his system of work, and to follow the
+quick, subtle methods by which he disentangled the most inextricable
+mysteries. So accustomed was I to his invariable success that the very
+possibility of his failing had ceased to enter into my head.
+
+It was close upon four before the door opened, and a drunken-looking
+groom, ill-kempt and side-whiskered, with an inflamed face and
+disreputable clothes, walked into the room. Accustomed as I was to
+my friend’s amazing powers in the use of disguises, I had to look
+three times before I was certain that it was indeed he. With a nod
+he vanished into the bedroom, whence he emerged in five minutes
+tweed-suited and respectable, as of old. Putting his hands into his
+pockets, he stretched out his legs in front of the fire, and laughed
+heartily for some minutes.
+
+“Well, really!” he cried, and then he choked; and laughed again until
+he was obliged to lie back, limp and helpless, in the chair.
+
+“What is it?”
+
+“It’s quite too funny. I am sure you could never guess how I employed
+my morning, or what I ended by doing.”
+
+“I can’t imagine. I suppose that you have been watching the habits, and
+perhaps the house, of Miss Irene Adler.”
+
+“Quite so; but the sequel was rather unusual. I will tell you, however.
+I left the house a little after eight o’clock this morning, in the
+character of a groom out of work. There is a wonderful sympathy and
+freemasonry among horsey men. Be one of them, and you will know all
+that there is to know. I soon found Briony Lodge. It is a _bijou_
+villa, with a garden at the back, but built out in front right up to
+the road, two stories. Chubb lock to the door. Large sitting-room on
+the right side, well furnished, with long windows almost to the floor,
+and those preposterous English window fasteners which a child could
+open. Behind there was nothing remarkable, save that the passage window
+could be reached from the top of the coach-house. I walked round it
+and examined it closely from every point of view, but without noting
+anything else of interest.
+
+“I then lounged down the street, and found, as I expected, that there
+was a mews in a lane which runs down by one wall of the garden. I lent
+the ostlers a hand in rubbing down their horses, and I received in
+exchange twopence, a glass of half-and-half, two fills of shag tobacco,
+and as much information as I could desire about Miss Adler, to say
+nothing of half a dozen other people in the neighborhood in whom I was
+not in the least interested, but whose biographies I was compelled to
+listen to.”
+
+“And what of Irene Adler?” I asked.
+
+“Oh, she has turned all the men’s heads down in that part. She
+is the daintiest thing under a bonnet on this planet. So say the
+Serpentine-mews, to a man. She lives quietly, sings at concerts, drives
+out at five every day, and returns at seven sharp for dinner. Seldom
+goes out at other times, except when she sings. Has only one male
+visitor, but a good deal of him. He is dark, handsome, and dashing,
+never calls less than once a day, and often twice. He is a Mr. Godfrey
+Norton, of the Inner Temple. See the advantages of a cabman as a
+confidant. They had driven him home a dozen times from Serpentine-mews,
+and knew all about him. When I had listened to all that they had to
+tell, I began to walk up and down near Briony Lodge once more, and to
+think over my plan of campaign.
+
+“This Godfrey Norton was evidently an important factor in the
+matter. He was a lawyer. That sounded ominous. What was the relation
+between them, and what the object of his repeated visits? Was she
+his client, his friend, or his mistress? If the former, she had
+probably transferred the photograph to his keeping. If the latter,
+it was less likely. On the issue of this question depended whether I
+should continue my work at Briony Lodge, or turn my attention to the
+gentleman’s chambers in the Temple. It was a delicate point, and it
+widened the field of my inquiry. I fear that I bore you with these
+details, but I have to let you see my little difficulties, if you are
+to understand the situation.”
+
+“I am following you closely,” I answered.
+
+“I was still balancing the matter in my mind, when a hansom cab drove
+up to Briony Lodge, and a gentleman sprang out. He was a remarkably
+handsome man, dark, aquiline, and mustached—evidently the man of whom
+I had heard. He appeared to be in a great hurry, shouted to the cabman
+to wait, and brushed past the maid who opened the door with the air of
+a man who was thoroughly at home.
+
+“He was in the house about half an hour, and I could catch glimpses of
+him in the windows of the sitting-room, pacing up and down, talking
+excitedly, and waving his arms. Of her I could see nothing. Presently
+he emerged, looking even more flurried than before. As he stepped up
+to the cab, he pulled a gold watch from his pocket and looked at it
+earnestly. ‘Drive like the devil,’ he shouted, ‘first to Gross &
+Hankey’s in Regent Street, and then to the church of St. Monica in the
+Edgware Road. Half a guinea if you do it in twenty minutes!’
+
+“Away they went, and I was just wondering whether I should not do
+well to follow them, when up the lane came a neat little landau, the
+coachman with his coat only half-buttoned, and his tie under his ear,
+while all the tags of his harness were sticking out of the buckles. It
+hadn’t pulled up before she shot out of the hall door and into it. I
+only caught a glimpse of her at the moment, but she was a lovely woman,
+with a face that a man might die for.
+
+“‘The Church of St. Monica, John,’ she cried, ‘and half a sovereign if
+you reach it in twenty minutes.’
+
+“This was quite too good to lose, Watson. I was just balancing whether
+I should run for it, or whether I should perch behind her landau,
+when a cab came through the street. The driver looked twice at such a
+shabby fare; but I jumped in before he could object. ‘The Church of
+St. Monica,’ said I, ‘and half a sovereign if you reach it in twenty
+minutes.’ It was twenty-five minutes to twelve, and of course it was
+clear enough what was in the wind.
+
+“My cabby drove fast. I don’t think I ever drove faster, but the others
+were there before us. The cab and the landau with their steaming horses
+were in front of the door when I arrived. I paid the man and hurried
+into the church. There was not a soul there save the two whom I had
+followed and a surpliced clergyman, who seemed to be expostulating with
+them. They were all three standing in a knot in front of the altar. I
+lounged up the side aisle like any other idler who has dropped into a
+church. Suddenly, to my surprise, the three at the altar faced round to
+me, and Godfrey Norton came running as hard as he could towards me.”
+
+“Thank God!” he cried. “You’ll do. Come! Come!”
+
+“What then?” I asked.
+
+“Come, man, come, only three minutes, or it won’t be legal.”
+
+“I was half-dragged up to the altar, and, before I knew where I was, I
+found myself mumbling responses which were whispered in my ear, and
+vouching for things of which I knew nothing, and generally assisting
+in the secure tying up of Irene Adler, spinster, to Godfrey Norton,
+bachelor. It was all done in an instant, and there was the gentleman
+thanking me on the one side and the lady on the other, while the
+clergyman beamed on me in front. It was the most preposterous position
+in which I ever found myself in my life, and it was the thought of
+it that started me laughing just now. It seems that there had been
+some informality about their license, that the clergyman absolutely
+refused to marry them without a witness of some sort, and that my lucky
+appearance saved the bridegroom from having to sally out into the
+streets in search of a best man. The bride gave me a sovereign, and I
+mean to wear it on my watch-chain in memory of the occasion.”
+
+“This is a very unexpected turn of affairs,” said I; “and what then?”
+
+“Well, I found my plans very seriously menaced. It looked as if the
+pair might take an immediate departure, and so necessitate very prompt
+and energetic measures on my part. At the church door, however, they
+separated, he driving back to the Temple, and she to her own house. ‘I
+shall drive out in the park at five as usual,’ she said, as she left
+him. I heard no more. They drove away in different directions, and I
+went off to make my own arrangements.”
+
+“Which are?”
+
+“Some cold beef and a glass of beer,” he answered, ringing the bell. “I
+have been too busy to think of food, and I am likely to be busier still
+this evening. By the way, doctor, I shall want your co-operation.”
+
+“I shall be delighted.”
+
+“You don’t mind breaking the law?”
+
+“Not in the least.”
+
+“Nor running a chance of arrest?”
+
+“Not in a good cause.”
+
+“Oh, the cause is excellent!”
+
+“Then I am your man.”
+
+“I was sure that I might rely on you.”
+
+“But what is it you wish?”
+
+“When Mrs. Turner has brought in the tray I will make it clear to
+you. Now,” he said, as he turned hungrily on the simple fare that our
+landlady had provided, “I must discuss it while I eat, for I have not
+much time. It is nearly five now. In two hours we must be on the scene
+of action. Miss Irene, or Madame, rather, returns from her drive at
+seven. We must be at Briony Lodge to meet her.”
+
+“And what then?”
+
+“You must leave that to me. I have already arranged what is to occur.
+There is only one point on which I must insist. You must not interfere,
+come what may. You understand?”
+
+“I am to be neutral?”
+
+“To do nothing whatever. There will probably be some small
+unpleasantness. Do not join in it. It will end in my being conveyed
+into the house. Four or five minutes afterwards the sitting-room window
+will open. You are to station yourself close to that open window.”
+
+“Yes.”
+
+“You are to watch me, for I will be visible to you.”
+
+“Yes.”
+
+“And when I raise my hand—so—you will throw into the room what I give
+you to throw, and will, at the same time, raise the cry of fire. You
+quite follow me?”
+
+“Entirely.”
+
+“It is nothing very formidable,” he said, taking a long cigar-shaped
+roll from his pocket. “It is an ordinary plumber’s smoke-rocket,
+fitted with a cap at either end to make it self-lighting. Your task is
+confined to that. When you raise your cry of fire, it will be taken
+up by quite a number of people. You may then walk to the end of the
+street, and I will rejoin you in ten minutes. I hope that I have made
+myself clear?”
+
+“I am to remain neutral, to get near the window, to watch you, and, at
+the signal, to throw in this object, then to raise the cry of fire, and
+to wait you at the corner of the street.”
+
+“Precisely.”
+
+“Then you may entirely rely on me.”
+
+“That is excellent. I think, perhaps, it is almost time that I prepare
+for the new role I have to play.”
+
+He disappeared into his bedroom, and returned in a few minutes in the
+character of an amiable and simple-minded Nonconformist clergyman. His
+broad black hat, his baggy trousers, his white tie, his sympathetic
+smile, and general look of peering and benevolent curiosity were such
+as Mr. John Hare alone could have equalled. It was not merely that
+Holmes changed his costume. His expression, his manner, his very soul
+seemed to vary with every fresh part that he assumed. The stage lost a
+fine actor, even as science lost an acute reasoner, when he became a
+specialist in crime.
+
+It was a quarter past six when we left Baker Street, and it still
+wanted ten minutes to the hour when we found ourselves in Serpentine
+Avenue. It was already dusk, and the lamps were just being lighted as
+we paced up and down in front of Briony Lodge, waiting for the coming
+of its occupant. The house was just such as I had pictured it from
+Sherlock Holmes’s succinct description, but the locality appeared to
+be less private that I expected. On the contrary, for a small street
+in a quiet neighborhood, it was remarkably animated. There was a
+group of shabbily-dressed men smoking and laughing in a corner, a
+scissors-grinder with his wheel, two guardsmen who were flirting with a
+nurse-girl, and several well-dressed young men who were lounging up and
+down with cigars in their mouths.
+
+“You see,” remarked Holmes, as we paced to and fro in front of the
+house, “this marriage rather simplifies matters. The photograph becomes
+a double-edged weapon now. The chances are that she would be as averse
+to its being seen by Mr. Godfrey Norton, as our client is to its coming
+to the eyes of his princess. Now the question is, Where are we to find
+the photograph?”
+
+“Where, indeed?”
+
+“It is most unlikely that she carries it about with her. It is cabinet
+size. Too large for easy concealment about a woman’s dress. She knows
+that the King is capable of having her waylaid and searched. Two
+attempts of the sort have already been made. We may take it, then, that
+she does not carry it about with her.”
+
+“Where, then?”
+
+“Her banker or her lawyer. There is that double possibility. But I am
+inclined to think neither. Women are naturally secretive, and they
+like to do their own secreting. Why should she hand it over to any one
+else? She could trust her own guardianship, but she could not tell
+what indirect or political influence might be brought to bear upon a
+business man. Besides, remember that she had resolved to use it within
+a few days. It must be where she can lay her hands upon it. It must be
+in her own house.”
+
+“But it has twice been burgled.”
+
+“Pshaw! They did not know how to look.”
+
+“But how will you look?”
+
+“I will not look.”
+
+“What then?”
+
+“I will get her to show me.”
+
+“But she will refuse.”
+
+“She will not be able to. But I hear the rumble of wheels. It is her
+carriage. Now carry out my orders to the letter.”
+
+As he spoke the gleam of the side-lights of a carriage came round the
+curve of the avenue. It was a smart little landau which rattled up to
+the door of Briony Lodge. As it pulled up, one of the loafing men at
+the corner dashed forward to open the door in the hope of earning a
+copper, but was elbowed away by another loafer, who had rushed up with
+the same intention. A fierce quarrel broke out, which was increased by
+the two guardsmen, who took sides with one of the loungers, and by the
+scissors-grinder, who was equally hot upon the other side. A blow was
+struck, and in an instant the lady, who had stepped from her carriage,
+was the centre of a little knot of flushed and struggling men, who
+struck savagely at each other with their fists and sticks. Holmes
+dashed into the crowd to protect the lady; but just as he reached her
+he gave a cry and dropped to the ground, with the blood running freely
+down his face. At his fall the guardsmen took to their heels in one
+direction and the loungers in the other, while a number of better
+dressed people, who had watched the scuffle without taking part in it,
+crowded in to help the lady and to attend to the injured man. Irene
+Adler, as I will still call her, had hurried up the steps; but she
+stood at the top with her superb figure outlined against the lights of
+the hall, looking back into the street.
+
+“Is the poor gentleman much hurt?” she asked.
+
+“He is dead,” cried several voices.
+
+“No, no, there’s life in him!” shouted another. “But he’ll be gone
+before you can get him to hospital.”
+
+“He’s a brave fellow,” said a woman. “They would have had the lady’s
+purse and watch if it hadn’t been for him. They were a gang, and a
+rough one, too. Ah, he’s breathing now.”
+
+“He can’t lie in the street. May we bring him in, marm?”
+
+“Surely. Bring him into the sitting-room. There is a comfortable sofa.
+This way, please!”
+
+Slowly and solemnly he was borne into Briony Lodge and laid out in the
+principal room, while I still observed the proceedings from my post
+by the window. The lamps had been lit, but the blinds had not been
+drawn, so that I could see Holmes as he lay upon the couch. I do not
+know whether he was seized with compunction at that moment for the part
+he was playing, but I know that I never felt more heartily ashamed of
+myself in my life than when I saw the beautiful creature against whom
+I was conspiring, or the grace and kindliness with which she waited
+upon the injured man. And yet it would be the blackest treachery to
+Holmes to draw back now from the part which he had intrusted to me.
+I hardened my heart, and took the smoke-rocket from under my ulster.
+After all, I thought, we are not injuring her. We are but preventing
+her from injuring another.
+
+Holmes had sat up upon the couch, and I saw him motion like a man who
+is in need of air. A maid rushed across and threw open the window. At
+the same instant I saw him raise his hand, and at the signal I tossed
+my rocket into the room with a cry of “Fire!” The word was no sooner
+out of my mouth than the whole crowd of spectators, well dressed and
+ill—gentlemen, ostlers, and servant-maids—joined in a general shriek
+of “Fire!” Thick clouds of smoke curled through the room and out at
+the open window. I caught a glimpse of rushing figures, and a moment
+later the voice of Holmes from within assuring them that it was a false
+alarm. Slipping through the shouting crowd I made my way to the corner
+of the street, and in ten minutes was rejoiced to find my friend’s arm
+in mine, and to get away from the scene of uproar. He walked swiftly
+and in silence for some few minutes, until we had turned down one of
+the quiet streets which lead towards the Edgware Road.
+
+“You did it very nicely, doctor,” he remarked. “Nothing could have been
+better. It is all right.”
+
+“You have the photograph?”
+
+“I know where it is.”
+
+“And how did you find out?”
+
+“She showed me, as I told you that she would.”
+
+“I am still in the dark.”
+
+“I do not wish to make a mystery,” said he, laughing. “The matter was
+perfectly simple. You, of course, saw that every one in the street was
+an accomplice. They were all engaged for the evening.”
+
+“I guessed as much.”
+
+“Then, when the row broke out, I had a little moist red paint in the
+palm of my hand. I rushed forward, fell down, clapped my hand to my
+face, and became a piteous spectacle. It is an old trick.”
+
+“That also I could fathom.”
+
+“Then they carried me in. She was bound to have me in. What else could
+she do? And into her sitting-room, which was the very room which I
+suspected. It lay between that and her bedroom, and I was determined
+to see which. They laid me on a couch, I motioned for air, they were
+compelled to open the window, and you had your chance.”
+
+“How did that help you?”
+
+“It was all-important. When a woman thinks that her house is on fire,
+her instinct is at once to rush to the thing which she values most. It
+is a perfectly overpowering impulse, and I have more than once taken
+advantage of it. In the case of the Darlington Substitution Scandal it
+was of use to me, and also in the Arnsworth Castle business. A married
+woman grabs at her baby; an unmarried one reaches for her jewel-box.
+Now it was clear to me that our lady of to-day had nothing in the house
+more precious to her than what we are in quest of. She would rush to
+secure it. The alarm of fire was admirably done. The smoke and shouting
+were enough to shake nerves of steel. She responded beautifully. The
+photograph is in a recess behind a sliding panel just above the right
+bell-pull. She was there in an instant, and I caught a glimpse of it as
+she half-drew it out. When I cried out that it was a false alarm, she
+replaced it, glanced at the rocket, rushed from the room, and I have
+not seen her since. I rose, and, making my excuses, escaped from the
+house. I hesitated whether to attempt to secure the photograph at once;
+but the coachman had come in, and as he was watching me narrowly, it
+seemed safer to wait. A little over-precipitance may ruin all.”
+
+“And now?” I asked.
+
+“Our quest is practically finished. I shall call with the King
+to-morrow, and with you, if you care to come with us. We will be shown
+into the sitting-room to wait for the lady, but it is probable that
+when she comes she may find neither us nor the photograph. It might be
+a satisfaction to His Majesty to regain it with his own hands.”
+
+“And when will you call?”
+
+“At eight in the morning. She will not be up, so that we shall have a
+clear field. Besides, we must be prompt, for this marriage may mean a
+complete change in her life and habits. I must wire to the King without
+delay.”
+
+We had reached Baker Street, and had stopped at the door. He was
+searching his pockets for the key, when some one passing said:
+
+“Good-night, Mister Sherlock Holmes.”
+
+There were several people on the pavement at the time, but the greeting
+appeared to come from a slim youth in an ulster who had hurried by.
+
+“I’ve heard that voice before,” said Holmes, staring down the dimly-lit
+street. “Now, I wonder who the deuce that could have been.”
+
+
+III
+
+I slept at Baker Street that night, and we were engaged upon our toast
+and coffee in the morning when the King of Bohemia rushed into the room.
+
+“You have really got it!” he cried, grasping Sherlock Holmes by either
+shoulder, and looking eagerly into his face.
+
+“Not yet.”
+
+“But you have hopes?”
+
+“I have hopes.”
+
+“Then, come. I am all impatience to be gone.”
+
+“We must have a cab.”
+
+“No, my brougham is waiting.”
+
+“Then that will simplify matters.” We descended, and started off once
+more for Briony Lodge.
+
+“Irene Adler is married,” remarked Holmes.
+
+“Married! When?”
+
+“Yesterday.”
+
+“But to whom?”
+
+“To an English lawyer named Norton.”
+
+“But she could not love him?”
+
+“I am in hopes that she does.”
+
+“And why in hopes?”
+
+“Because it would spare your Majesty all fear of future annoyance. If
+the lady loves her husband, she does not love your Majesty. If she does
+not love your Majesty, there is no reason why she should interfere with
+your Majesty’s plan.”
+
+“It is true. And yet—Well! I wish she had been of my own station! What
+a queen she would have made!” He relapsed into a moody silence, which
+was not broken until we drew up in Serpentine Avenue.
+
+The door of Briony Lodge was open, and an elderly woman stood upon
+the steps. She watched us with a sardonic eye as we stepped from the
+brougham.
+
+“Mr. Sherlock Holmes, I believe?” said she.
+
+“I am Mr. Holmes,” answered my companion, looking at her with a
+questioning and rather startled gaze.
+
+“Indeed! My mistress told me that you were likely to call. She left
+this morning with her husband by the 5.15 train from Charing Cross for
+the Continent.”
+
+“What!” Sherlock Holmes staggered back, white with chagrin and
+surprise. “Do you mean that she has left England?”
+
+“Never to return.”
+
+“And the papers?” asked the King, hoarsely. “All is lost.”
+
+“We shall see.” He pushed past the servant and rushed into the
+drawing-room, followed by the King and myself. The furniture was
+scattered about in every direction, with dismantled shelves and open
+drawers, as if the lady had hurriedly ransacked them before her flight.
+Holmes rushed at the bell-pull, tore back a small sliding shutter,
+and, plunging in his hand, pulled out a photograph and a letter. The
+photograph was of Irene Adler herself in evening dress, the letter was
+superscribed to “Sherlock Holmes, Esq. To be left till called for.” My
+friend tore it open, and we all three read it together. It was dated at
+midnight of the preceding night, and ran in this way:
+
+  “MY DEAR MR. SHERLOCK HOLMES,—You really did it very
+  well. You took me in completely. Until after the alarm of
+  fire, I had not a suspicion. But then, when I found how I had
+  betrayed myself, I began to think. I had been warned against
+  you months ago. I had been told that, if the King employed an
+  agent, it would certainly be you. And your address had been
+  given me. Yet, with all this, you made me reveal what you
+  wanted to know. Even after I became suspicious, I found it hard
+  to think evil of such a dear, kind old clergyman. But, you
+  know, I have been trained as an actress myself. Male costume
+  is nothing new to me. I often take advantage of the freedom
+  which it gives. I sent John, the coachman, to watch you, ran
+  up-stairs, got into my walking-clothes, as I call them, and
+  came down just as you departed.
+
+  “Well, I followed you to your door, and so made sure that I was
+  really an object of interest to the celebrated Mr. Sherlock
+  Holmes. Then I, rather imprudently, wished you good-night, and
+  started for the Temple to see my husband.
+
+  “We both thought the best resource was flight, when pursued by
+  so formidable an antagonist; so you will find the nest empty
+  when you call to-morrow. As to the photograph, your client may
+  rest in peace. I love and am loved by a better man than he.
+  The King may do what he will without hinderance from one whom
+  he has cruelly wronged. I keep it only to safeguard myself,
+  and to preserve a weapon which will always secure me from any
+  steps which he might take in the future. I leave a photograph
+  which he might care to possess; and I remain, dear Mr. Sherlock
+  Holmes, very truly yours,      IRENE NORTON, _née_ ADLER.”
+
+“What a woman—oh, what a woman!” cried the King of Bohemia, when we
+had all three read this epistle. “Did I not tell you how quick and
+resolute she was? Would she not have made an admirable queen? Is it not
+a pity that she was not on my level?”
+
+“From what I have seen of the lady she seems indeed to be on a very
+different level to your Majesty,” said Holmes, coldly. “I am sorry
+that I have not been able to bring your Majesty’s business to a more
+successful conclusion.”
+
+“On the contrary, my dear sir,” cried the King; “nothing could be more
+successful. I know that her word is inviolate. The photograph is now as
+safe as if it were in the fire.”
+
+“I am glad to hear your Majesty say so.”
+
+“I am immensely indebted to you. Pray tell me in what way I can reward
+you. This ring—” He slipped an emerald snake ring from his finger and
+held it out upon the palm of his hand.
+
+“Your Majesty has something which I should value even more highly,”
+said Holmes.
+
+“You have but to name it.”
+
+“This photograph!”
+
+The King stared at him in amazement.
+
+“Irene’s photograph!” he cried. “Certainly, if you wish it.”
+
+“I thank your Majesty. Then there is no more to be done in the matter.
+I have the honor to wish you a very good-morning.” He bowed, and,
+turning away without observing the hand which the King had stretched
+out to him, he set off in my company for his chambers.
+
+       *       *       *       *       *
+
+And that was how a great scandal threatened to affect the kingdom of
+Bohemia, and how the best plans of Mr. Sherlock Holmes were beaten by
+a woman’s wit. He used to make merry over the cleverness of women, but
+I have not heard him do it of late. And when he speaks of Irene Adler,
+or when he refers to her photograph, it is always under the honorable
+title of _the_ woman.
+
+
+
+
+Adventure II
+
+THE RED-HEADED LEAGUE
+
+
+I had called upon my friend, Mr. Sherlock Holmes, one day in the autumn
+of last year, and found him in deep conversation with a very stout,
+florid-faced, elderly gentleman, with fiery red hair. With an apology
+for my intrusion, I was about to withdraw, when Holmes pulled me
+abruptly into the room and closed the door behind me.
+
+“You could not possibly have come at a better time, my dear Watson,” he
+said, cordially.
+
+“I was afraid that you were engaged.”
+
+“So I am. Very much so.”
+
+“Then I can wait in the next room.”
+
+“Not at all. This gentleman, Mr. Wilson, has been my partner and helper
+in many of my most successful cases, and I have no doubt that he will
+be of the utmost use to me in yours also.”
+
+The stout gentleman half-rose from his chair and gave a bob of
+greeting, with a quick, little, questioning glance from his small,
+fat-encircled eyes.
+
+“Try the settee,” said Holmes, relapsing into his arm-chair and putting
+his finger-tips together, as was his custom when in judicial moods. “I
+know, my dear Watson, that you share my love of all that is bizarre and
+outside the conventions and humdrum routine of every-day life. You have
+shown your relish for it by the enthusiasm which has prompted you to
+chronicle, and, if you will excuse my saying so, somewhat to embellish
+so many of my own little adventures.”
+
+“Your cases have indeed been of the greatest interest to me,” I
+observed.
+
+“You will remember that I remarked the other day, just before we went
+into the very simple problem presented by Miss Mary Sutherland, that
+for strange effects and extraordinary combinations we must go to
+life itself, which is always far more daring than any effort of the
+imagination.”
+
+“A proposition which I took the liberty of doubting.”
+
+“You did, doctor, but none the less you must come round to my view,
+for otherwise I shall keep on piling fact upon fact on you, until your
+reason breaks down under them and acknowledges me to be right. Now, Mr.
+Jabez Wilson here has been good enough to call upon me this morning,
+and to begin a narrative which promises to be one of the most singular
+which I have listened to for some time. You have heard me remark that
+the strangest and most unique things are very often connected not with
+the larger but with the smaller crimes, and occasionally, indeed, where
+there is room for doubt whether any positive crime has been committed.
+As far as I have heard it is impossible for me to say whether the
+present case is an instance of crime or not, but the course of events
+is certainly among the most singular that I have ever listened to.
+Perhaps, Mr. Wilson, you would have the great kindness to recommence
+your narrative. I ask you, not merely because my friend Dr. Watson has
+not heard the opening part, but also because the peculiar nature of the
+story makes me anxious to have every possible detail from your lips.
+As a rule, when I have heard some slight indication of the course of
+events, I am able to guide myself by the thousands of other similar
+cases which occur to my memory. In the present instance I am forced to
+admit that the facts are, to the best of my belief, unique.”
+
+The portly client puffed out his chest with an appearance of some
+little pride, and pulled a dirty and wrinkled newspaper from the inside
+pocket of his great-coat. As he glanced down the advertisement column,
+with his head thrust forward, and the paper flattened out upon his
+knee, I took a good look at the man, and endeavored, after the fashion
+of my companion, to read the indications which might be presented by
+his dress or appearance.
+
+I did not gain very much, however, by my inspection. Our visitor bore
+every mark of being an average commonplace British tradesman, obese,
+pompous, and slow. He wore rather baggy gray shepherd’s check trousers,
+a not over-clean black frock-coat, unbuttoned in the front, and a drab
+waistcoat with a heavy brassy Albert chain, and a square pierced bit of
+metal dangling down as an ornament. A frayed top-hat and a faded brown
+overcoat with a wrinkled velvet collar lay upon a chair beside him.
+Altogether, look as I would, there was nothing remarkable about the man
+save his blazing red head, and the expression of extreme chagrin and
+discontent upon his features.
+
+Sherlock Holmes’s quick eye took in my occupation, and he shook his
+head with a smile as he noticed my questioning glances. “Beyond the
+obvious facts that he has at some time done manual labor, that he takes
+snuff, that he is a Freemason, that he has been in China, and that he
+has done a considerable amount of writing lately, I can deduce nothing
+else.”
+
+Mr. Jabez Wilson started up in his chair, with his forefinger upon the
+paper, but his eyes upon my companion.
+
+“How, in the name of good-fortune, did you know all that, Mr. Holmes?”
+he asked. “How did you know, for example, that I did manual labor. It’s
+as true as gospel, for I began as a ship’s carpenter.”
+
+“Your hands, my dear sir. Your right hand is quite a size larger than
+your left. You have worked with it, and the muscles are more developed.”
+
+“Well, the snuff, then, and the Freemasonry?”
+
+“I won’t insult your intelligence by telling you how I read that,
+especially as, rather against the strict rules of your order, you use
+an arc-and-compass breastpin.”
+
+“Ah, of course, I forgot that. But the writing?”
+
+“What else can be indicated by that right cuff so very shiny for five
+inches, and the left one with the smooth patch near the elbow where you
+rest it upon the desk.”
+
+“Well, but China?”
+
+“The fish that you have tattooed immediately above your right wrist
+could only have been done in China. I have made a small study of tattoo
+marks, and have even contributed to the literature of the subject.
+That trick of staining the fishes’ scales of a delicate pink is quite
+peculiar to China. When, in addition, I see a Chinese coin hanging from
+your watch-chain, the matter becomes even more simple.”
+
+Mr. Jabez Wilson laughed heavily. “Well, I never!” said he. “I thought
+at first that you had done something clever, but I see that there was
+nothing in it, after all.”
+
+“I begin to think, Watson,” said Holmes, “that I make a mistake in
+explaining. ‘Omne ignotum pro magnifico,’ you know, and my poor little
+reputation, such as it is, will suffer shipwreck if I am so candid. Can
+you not find the advertisement, Mr. Wilson?”
+
+“Yes, I have got it now,” he answered, with his thick, red finger
+planted half-way down the column. “Here it is. This is what began it
+all. You just read it for yourself, sir.”
+
+I took the paper from him, and read as follows:
+
+  “TO THE RED-HEADED LEAGUE: On account of the bequest of the
+  late Ezekiah Hopkins, of Lebanon, Pa., U.S.A., there is now
+  another vacancy open which entitles a member of the League
+  to a salary of £4 a week for purely nominal services. All
+  red-headed men who are sound in body and mind, and above
+  the age of twenty-one years, are eligible. Apply in person on
+  Monday, at eleven o’clock, to Duncan Ross, at the offices of
+  the League, 7 Pope’s Court, Fleet Street.”
+
+“What on earth does this mean?” I ejaculated, after I had twice read
+over the extraordinary announcement.
+
+Holmes chuckled, and wriggled in his chair, as was his habit when in
+high spirits. “It is a little off the beaten track, isn’t it?” said
+he. “And now, Mr. Wilson, off you go at scratch, and tell us all about
+yourself, your household, and the effect which this advertisement had
+upon your fortunes. You will first make a note, doctor, of the paper
+and the date.”
+
+“It is _The Morning Chronicle_, of April 27, 1890. Just two months ago.”
+
+“Very good. Now, Mr. Wilson?”
+
+“Well, it is just as I have been telling you, Mr. Sherlock Holmes,”
+said Jabez Wilson, mopping his forehead; “I have a small pawnbroker’s
+business at Coburg Square, near the city. It’s not a very large affair,
+and of late years it has not done more than just give me a living. I
+used to be able to keep two assistants, but now I only keep one; and I
+would have a job to pay him, but that he is willing to come for half
+wages, so as to learn the business.”
+
+“What is the name of this obliging youth?” asked Sherlock Holmes.
+
+“His name is Vincent Spaulding, and he’s not such a youth, either. It’s
+hard to say his age. I should not wish a smarter assistant, Mr. Holmes;
+and I know very well that he could better himself, and earn twice what
+I am able to give him. But, after all, if he is satisfied, why should I
+put ideas in his head?”
+
+“Why, indeed? You seem most fortunate in having an _employé_ who
+comes under the full market price. It is not a common experience among
+employers in this age. I don’t know that your assistant is not as
+remarkable as your advertisement.”
+
+“Oh, he has his faults, too,” said Mr. Wilson. “Never was such a fellow
+for photography. Snapping away with a camera when he ought to be
+improving his mind, and then diving down into the cellar like a rabbit
+into its hole to develope his pictures. That is his main fault; but, on
+the whole, he’s a good worker. There’s no vice in him.”
+
+“He is still with you, I presume?”
+
+“Yes, sir. He and a girl of fourteen, who does a bit of simple cooking,
+and keeps the place clean—that’s all I have in the house, for I am a
+widower, and never had any family. We live very quietly, sir, the three
+of us; and we keep a roof over our heads, and pay our debts, if we do
+nothing more.
+
+“The first thing that put us out was that advertisement. Spaulding, he
+came down into the office just this day eight weeks, with this very
+paper in his hand, and he says:
+
+“‘I wish to the Lord, Mr. Wilson, that I was a red-headed man.’
+
+“‘Why that?’ I asks.
+
+“‘Why,’ says he, ‘here’s another vacancy on the League of the
+Red-headed Men. It’s worth quite a little fortune to any man who gets
+it, and I understand that there are more vacancies than there are men,
+so that the trustees are at their wits’ end what to do with the money.
+If my hair would only change color, here’s a nice little crib all ready
+for me to step into.’
+
+“‘Why, what is it, then?’ I asked. You see, Mr. Holmes, I am a very
+stay-at-home man, and as my business came to me instead of my having
+to go to it, I was often weeks on end without putting my foot over the
+door-mat. In that way I didn’t know much of what was going on outside,
+and I was always glad of a bit of news.
+
+“‘Have you never heard of the League of the Red-headed Men?’ he asked,
+with his eyes open.
+
+“‘Never.’
+
+“‘Why, I wonder at that, for you are eligible yourself for one of the
+vacancies.’
+
+“‘And what are they worth?’ I asked.
+
+“‘Oh, merely a couple of hundred a year, but the work is slight, and it
+need not interfere very much with one’s other occupations.’
+
+“Well, you can easily think that that made me prick up my ears, for the
+business has not been over-good for some years, and an extra couple of
+hundred would have been very handy.
+
+“‘Tell me all about it,’ said I.
+
+“‘Well,’ said he, showing me the advertisement, ‘you can see for
+yourself that the League has a vacancy, and there is the address
+where you should apply for particulars. As far as I can make out, the
+League was founded by an American millionaire, Ezekiah Hopkins, who
+was very peculiar in his ways. He was himself red-headed, and he had a
+great sympathy for all red-headed men; so, when he died, it was found
+that he had left his enormous fortune in the hands of trustees, with
+instructions to apply the interest to the providing of easy berths to
+men whose hair is of that color. From all I hear it is splendid pay,
+and very little to do.’
+
+“‘But,’ said I, ‘there would be millions of red-headed men who would
+apply.’
+
+“‘Not so many as you might think,’ he answered. ‘You see it is really
+confined to Londoners, and to grown men. This American had started from
+London when he was young, and he wanted to do the old town a good turn.
+Then, again, I have heard it is no use your applying if your hair is
+light red, or dark red, or anything but real bright, blazing, fiery
+red. Now, if you cared to apply, Mr. Wilson, you would just walk in;
+but perhaps it would hardly be worth your while to put yourself out of
+the way for the sake of a few hundred pounds.’
+
+“Now, it is a fact, gentlemen, as you may see for yourselves, that my
+hair is of a very full and rich tint, so that it seemed to me that, if
+there was to be any competition in the matter, I stood as good a chance
+as any man that I had ever met. Vincent Spaulding seemed to know so
+much about it that I thought he might prove useful, so I just ordered
+him to put up the shutters for the day, and to come right away with me.
+He was very willing to have a holiday, so we shut the business up, and
+started off for the address that was given us in the advertisement.
+
+“I never hope to see such a sight as that again, Mr. Holmes. From
+north, south, east, and west every man who had a shade of red in his
+hair had tramped into the city to answer the advertisement. Fleet
+Street was choked with red-headed folk, and Pope’s Court looked
+like a coster’s orange barrow. I should not have thought there were
+so many in the whole country as were brought together by that single
+advertisement. Every shade of color they were—straw, lemon, orange,
+brick, Irish-setter, liver, clay; but, as Spaulding said, there were
+not many who had the real vivid flame-colored tint. When I saw how many
+were waiting, I would have given it up in despair; but Spaulding would
+not hear of it. How he did it I could not imagine, but he pushed and
+pulled and butted until he got me through the crowd, and right up to
+the steps which led to the office. There was a double stream upon the
+stair, some going up in hope, and some coming back dejected; but we
+wedged in as well as we could, and soon found ourselves in the office.”
+
+“Your experience has been a most entertaining one,” remarked Holmes, as
+his client paused and refreshed his memory with a huge pinch of snuff.
+“Pray continue your very interesting statement.”
+
+“There was nothing in the office but a couple of wooden chairs and a
+deal table, behind which sat a small man, with a head that was even
+redder than mine. He said a few words to each candidate as he came
+up, and then he always managed to find some fault in them which would
+disqualify them. Getting a vacancy did not seem to be such a very easy
+matter, after all. However, when our turn came, the little man was much
+more favorable to me than to any of the others, and he closed the door
+as we entered, so that he might have a private word with us.
+
+“‘This is Mr. Jabez Wilson,’ said my assistant, ‘and he is willing to
+fill a vacancy in the League.’
+
+“‘And he is admirably suited for it,’ the other answered. ‘He has every
+requirement. I cannot recall when I have seen anything so fine.’ He
+took a step backward, cocked his head on one side, and gazed at my hair
+until I felt quite bashful. Then suddenly he plunged forward, wrung my
+hand, and congratulated me warmly on my success.
+
+“‘It would be injustice to hesitate,’ said he. ‘You will, however, I am
+sure, excuse me for taking an obvious precaution.’ With that he seized
+my hair in both his hands, and tugged until I yelled with the pain.
+‘There is water in your eyes,’ said he, as he released me. ‘I perceive
+that all is as it should be. But we have to be careful, for we have
+twice been deceived by wigs and once by paint. I could tell you tales
+of cobbler’s wax which would disgust you with human nature.’ He stepped
+over to the window, and shouted through it at the top of his voice that
+the vacancy was filled. A groan of disappointment came up from below,
+and the folk all trooped away in different directions, until there was
+not a red head to be seen except my own and that of the manager.
+
+“‘My name,’ said he, ‘is Mr. Duncan Ross, and I am myself one of the
+pensioners upon the fund left by our noble benefactor. Are you a
+married man, Mr. Wilson? Have you a family?’
+
+“I answered that I had not.
+
+“His face fell immediately.
+
+“‘Dear me!’ he said, gravely, ‘that is very serious indeed! I am sorry
+to hear you say that. The fund was, of course, for the propagation
+and spread of the red-heads as well as for their maintenance. It is
+exceedingly unfortunate that you should be a bachelor.’
+
+“My face lengthened at this, Mr. Holmes, for I thought that I was not
+to have the vacancy after all; but, after thinking it over for a few
+minutes, he said that it would be all right.
+
+“‘In the case of another,’ said he, ‘the objection might be fatal, but
+we must stretch a point in favor of a man with such a head of hair as
+yours. When shall you be able to enter upon your new duties?’
+
+“‘Well, it is a little awkward, for I have a business already,’ said I.
+
+“‘Oh, never mind about that, Mr. Wilson!’ said Vincent Spaulding. ‘I
+shall be able to look after that for you.’
+
+“‘What would be the hours?’ I asked.
+
+“‘Ten to two.’
+
+“Now a pawnbroker’s business is mostly done of an evening, Mr. Holmes,
+especially Thursday and Friday evening, which is just before pay-day;
+so it would suit me very well to earn a little in the mornings.
+Besides, I knew that my assistant was a good man, and that he would see
+to anything that turned up.
+
+“‘That would suit me very well,’ said I. ‘And the pay?’
+
+“‘Is £4 a week.’
+
+“‘And the work?’
+
+“‘Is purely nominal.’
+
+“‘What do you call purely nominal?’
+
+“‘Well, you have to be in the office, or at least in the building, the
+whole time. If you leave, you forfeit your whole position forever.
+The will is very clear upon that point. You don’t comply with the
+conditions if you budge from the office during that time.’
+
+“‘It’s only four hours a day, and I should not think of leaving,’ said
+I.
+
+“‘No excuse will avail,’ said Mr. Duncan Ross, ‘neither sickness nor
+business nor anything else. There you must stay, or you lose your
+billet.’
+
+“‘And the work?’
+
+“‘Is to copy out the “Encyclopædia Britannica.” There is the first
+volume of it in that press. You must find your own ink, pens, and
+blotting-paper, but we provide this table and chair. Will you be ready
+to-morrow?’
+
+“‘Certainly,’ I answered.
+
+“‘Then, good-bye, Mr. Jabez Wilson, and let me congratulate you once
+more on the important position which you have been fortunate enough to
+gain.’ He bowed me out of the room, and I went home with my assistant,
+hardly knowing what to say or do, I was so pleased at my own good
+fortune.
+
+“Well, I thought over the matter all day, and by evening I was in
+low spirits again; for I had quite persuaded myself that the whole
+affair must be some great hoax or fraud, though what its object might
+be I could not imagine. It seemed altogether past belief that any one
+could make such a will, or that they would pay such a sum for doing
+anything so simple as copying out the ‘Encyclopædia Britannica.’
+Vincent Spaulding did what he could to cheer me up, but by bedtime I
+had reasoned myself out of the whole thing. However, in the morning
+I determined to have a look at it anyhow, so I bought a penny bottle
+of ink, and with a quill-pen, and seven sheets of foolscap paper, I
+started off for Pope’s Court.
+
+“Well, to my surprise and delight, everything was as right as possible.
+The table was set out ready for me, and Mr. Duncan Ross was there to
+see that I got fairly to work. He started me off upon the letter A, and
+then he left me; but he would drop in from time to time to see that all
+was right with me. At two o’clock he bade me good-day, complimented me
+upon the amount that I had written, and locked the door of the office
+after me.
+
+“This went on day after day, Mr. Holmes, and on Saturday the manager
+came in and planked down four golden sovereigns for my week’s work.
+It was the same next week, and the same the week after. Every morning
+I was there at ten, and every afternoon I left at two. By degrees Mr.
+Duncan Ross took to coming in only once of a morning, and then, after
+a time, he did not come in at all. Still, of course, I never dared to
+leave the room for an instant, for I was not sure when he might come,
+and the billet was such a good one, and suited me so well, that I would
+not risk the loss of it.
+
+“Eight weeks passed away like this, and I had written about Abbots and
+Archery and Armor and Architecture and Attica, and hoped with diligence
+that I might get on to the B’s before very long. It cost me something
+in foolscap, and I had pretty nearly filled a shelf with my writings.
+And then suddenly the whole business came to an end.”
+
+“To an end?”
+
+“Yes, sir. And no later than this morning. I went to my work as usual
+at ten o’clock, but the door was shut and locked, with a little square
+of card-board hammered on to the middle of the panel with a tack. Here
+it is, and you can read for yourself.”
+
+He held up a piece of white card-board about the size of a sheet of
+note-paper. It read in this fashion:
+
+  “THE RED-HEADED LEAGUE
+   IS
+   DISSOLVED.
+   _October 9, 1890._”
+
+Sherlock Holmes and I surveyed this curt announcement and the rueful
+face behind it, until the comical side of the affair so completely
+overtopped every other consideration that we both burst out into a roar
+of laughter.
+
+“I cannot see that there is anything very funny,” cried our client,
+flushing up to the roots of his flaming head. “If you can do nothing
+better than laugh at me, I can go elsewhere.”
+
+“No, no,” cried Holmes, shoving him back into the chair from which he
+had half risen. “I really wouldn’t miss your case for the world. It is
+most refreshingly unusual. But there is, if you will excuse my saying
+so, something just a little funny about it. Pray what steps did you
+take when you found the card upon the door?”
+
+“I was staggered, sir. I did not know what to do. Then I called at
+the offices round, but none of them seemed to know anything about it.
+Finally, I went to the landlord, who is an accountant living on the
+ground-floor, and I asked him if he could tell me what had become of
+the Red-headed League. He said that he had never heard of any such
+body. Then I asked him who Mr. Duncan Ross was. He answered that the
+name was new to him.
+
+[Illustration: “THE DOOR WAS SHUT AND LOCKED”]
+
+“‘Well,’ said I, ‘the gentleman at No. 4.’
+
+“‘What, the red-headed man?’
+
+“‘Yes.’
+
+“‘Oh,’ said he, ‘his name was William Morris. He was a solicitor, and
+was using my room as a temporary convenience until his new premises
+were ready. He moved out yesterday.’
+
+“‘Where could I find him?’
+
+“‘Oh, at his new offices. He did tell me the address. Yes, 17 King
+Edward Street, near St. Paul’s.’
+
+“I started off, Mr. Holmes, but when I got to that address it was a
+manufactory of artificial knee-caps, and no one in it had ever heard of
+either Mr. William Morris or Mr. Duncan Ross.”
+
+“And what did you do then?” asked Holmes.
+
+“I went home to Saxe-Coburg Square, and I took the advice of my
+assistant. But he could not help me in any way. He could only say that
+if I waited I should hear by post. But that was not quite good enough,
+Mr. Holmes. I did not wish to lose such a place without a struggle, so,
+as I had heard that you were good enough to give advice to poor folk
+who were in need of it, I came right away to you.”
+
+“And you did very wisely,” said Holmes. “Your case is an exceedingly
+remarkable one, and I shall be happy to look into it. From what you
+have told me I think that it is possible that graver issues hang from
+it than might at first sight appear.”
+
+“Grave enough!” said Mr. Jabez Wilson. “Why, I have lost four pound a
+week.”
+
+“As far as you are personally concerned,” remarked Holmes, “I do not
+see that you have any grievance against this extraordinary league. On
+the contrary, you are, as I understand, richer by some £30, to say
+nothing of the minute knowledge which you have gained on every subject
+which comes under the letter A. You have lost nothing by them.”
+
+“No, sir. But I want to find out about them, and who they are, and what
+their object was in playing this prank—if it was a prank—upon me. It
+was a pretty expensive joke for them, for it cost them two and thirty
+pounds.”
+
+“We shall endeavor to clear up these points for you. And, first, one
+or two questions, Mr. Wilson. This assistant of yours who first called
+your attention to the advertisement—how long had he been with you?”
+
+“About a month then.”
+
+“How did he come?”
+
+“In answer to an advertisement.”
+
+“Was he the only applicant?”
+
+“No, I had a dozen.”
+
+“Why did you pick him?”
+
+“Because he was handy, and would come cheap.”
+
+“At half-wages, in fact.”
+
+“Yes.”
+
+“What is he like, this Vincent Spaulding?”
+
+“Small, stout-built, very quick in his ways, no hair on his face,
+though he’s not short of thirty. Has a white splash of acid upon his
+forehead.”
+
+Holmes sat up in his chair in considerable excitement. “I thought as
+much,” said he. “Have you ever observed that his ears are pierced for
+earrings?”
+
+“Yes, sir. He told me that a gypsy had done it for him when he was a
+lad.”
+
+“Hum!” said Holmes, sinking back in deep thought. “He is still with
+you?”
+
+“Oh yes, sir; I have only just left him.”
+
+“And has your business been attended to in your absence?”
+
+“Nothing to complain of, sir. There’s never very much to do of a
+morning.”
+
+“That will do, Mr. Wilson. I shall be happy to give you an opinion upon
+the subject in the course of a day or two. To-day is Saturday, and I
+hope that by Monday we may come to a conclusion.”
+
+“Well, Watson,” said Holmes, when our visitor had left us, “what do you
+make of it all?”
+
+“I make nothing of it,” I answered, frankly. “It is a most mysterious
+business.”
+
+“As a rule,” said Holmes, “the more bizarre a thing is the less
+mysterious it proves to be. It is your commonplace, featureless crimes
+which are really puzzling, just as a commonplace face is the most
+difficult to identify. But I must be prompt over this matter.”
+
+“What are you going to do, then?” I asked.
+
+“To smoke,” he answered. “It is quite a three-pipe problem, and I beg
+that you won’t speak to me for fifty minutes.” He curled himself up
+in his chair, with his thin knees drawn up to his hawk-like nose, and
+there he sat with his eyes closed and his black clay pipe thrusting out
+like the bill of some strange bird. I had come to the conclusion that
+he had dropped asleep, and indeed was nodding myself, when he suddenly
+sprang out of his chair with the gesture of a man who has made up his
+mind, and put his pipe down upon the mantel-piece.
+
+“Sarasate plays at the St. James’s Hall this afternoon,” he remarked.
+“What do you think, Watson? Could your patients spare you for a few
+hours?”
+
+“I have nothing to do to-day. My practice is never very absorbing.”
+
+“Then put on your hat and come. I am going through the city first, and
+we can have some lunch on the way. I observe that there is a good deal
+of German music on the programme, which is rather more to my taste than
+Italian or French. It is introspective, and I want to introspect. Come
+along!”
+
+We travelled by the Underground as far as Aldersgate; and a short walk
+took us to Saxe-Coburg Square, the scene of the singular story which we
+had listened to in the morning. It was a pokey, little, shabby-genteel
+place, where four lines of dingy two-storied brick houses looked out
+into a small railed-in enclosure, where a lawn of weedy grass and
+a few clumps of faded laurel-bushes made a hard fight against a
+smoke-laden and uncongenial atmosphere. Three gilt balls and a brown
+board with “JABEZ WILSON” in white letters, upon a corner
+house, announced the place where our red-headed client carried on his
+business. Sherlock Holmes stopped in front of it with his head on one
+side, and looked it all over, with his eyes shining brightly between
+puckered lids. Then he walked slowly up the street, and then down again
+to the corner, still looking keenly at the houses. Finally he returned
+to the pawnbroker’s, and, having thumped vigorously upon the pavement
+with his stick two or three times, he went up to the door and knocked.
+It was instantly opened by a bright-looking, clean-shaven young fellow,
+who asked him to step in.
+
+“Thank you,” said Holmes, “I only wished to ask you how you would go
+from here to the Strand.”
+
+“Third right, fourth left,” answered the assistant, promptly, closing
+the door.
+
+“Smart fellow, that,” observed Holmes, as we walked away. “He is, in my
+judgment, the fourth smartest man in London, and for daring I am not
+sure that he has not a claim to be third. I have known something of him
+before.”
+
+“Evidently,” said I, “Mr. Wilson’s assistant counts for a good deal in
+this mystery of the Red-headed League. I am sure that you inquired your
+way merely in order that you might see him.”
+
+“Not him.”
+
+“What then?”
+
+“The knees of his trousers.”
+
+“And what did you see?”
+
+“What I expected to see.”
+
+“Why did you beat the pavement?”
+
+“My dear doctor, this is a time for observation, not for talk. We are
+spies in an enemy’s country. We know something of Saxe-Coburg Square.
+Let us now explore the parts which lie behind it.”
+
+The road in which we found ourselves as we turned round the corner
+from the retired Saxe-Coburg Square presented as great a contrast to
+it as the front of a picture does to the back. It was one of the main
+arteries which convey the traffic of the city to the north and west.
+The roadway was blocked with the immense stream of commerce flowing
+in a double tide inward and outward, while the foot-paths were black
+with the hurrying swarm of pedestrians. It was difficult to realize
+as we looked at the line of fine shops and stately business premises
+that they really abutted on the other side upon the faded and stagnant
+square which we had just quitted.
+
+“Let me see,” said Holmes, standing at the corner, and glancing along
+the line, “I should like just to remember the order of the houses here.
+It is a hobby of mine to have an exact knowledge of London. There is
+Mortimer’s, the tobacconist, the little newspaper shop, the Coburg
+branch of the City and Suburban Bank, the Vegetarian Restaurant, and
+McFarlane’s carriage-building depot. That carries us right on to the
+other block. And now, doctor, we’ve done our work, so it’s time we had
+some play. A sandwich and a cup of coffee, and then off to violin-land,
+where all is sweetness and delicacy and harmony, and there are no
+red-headed clients to vex us with their conundrums.”
+
+My friend was an enthusiastic musician, being himself not only a
+very capable performer, but a composer of no ordinary merit. All the
+afternoon he sat in the stalls wrapped in the most perfect happiness,
+gently waving his long, thin fingers in time to the music, while his
+gently smiling face and his languid, dreamy eyes were as unlike those
+of Holmes, the sleuth-hound, Holmes the relentless, keen-witted,
+ready-handed criminal agent, as it was possible to conceive. In his
+singular character the dual nature alternately asserted itself, and
+his extreme exactness and astuteness represented, as I have often
+thought, the reaction against the poetic and contemplative mood which
+occasionally predominated in him. The swing of his nature took him from
+extreme languor to devouring energy; and, as I knew well, he was never
+so truly formidable as when, for days on end, he had been lounging in
+his arm-chair amid his improvisations and his black-letter editions.
+Then it was that the lust of the chase would suddenly come upon him,
+and that his brilliant reasoning power would rise to the level of
+intuition, until those who were unacquainted with his methods would
+look askance at him as on a man whose knowledge was not that of other
+mortals. When I saw him that afternoon so enrapt in the music at St.
+James’s Hall I felt that an evil time might be coming upon those whom
+he had set himself to hunt down.
+
+“You want to go home, no doubt, doctor,” he remarked, as we emerged.
+
+“Yes, it would be as well.”
+
+“And I have some business to do which will take some hours. This
+business at Coburg Square is serious.”
+
+“Why serious?”
+
+“A considerable crime is in contemplation. I have every reason to
+believe that we shall be in time to stop it. But to-day being Saturday
+rather complicates matters. I shall want your help to-night.”
+
+“At what time?”
+
+“Ten will be early enough.”
+
+“I shall be at Baker Street at ten.”
+
+“Very well. And, I say, doctor, there may be some little danger, so
+kindly put your army revolver in your pocket.” He waved his hand,
+turned on his heel, and disappeared in an instant among the crowd.
+
+[Illustration: “ALL AFTERNOON HE SAT IN THE STALLS”]
+
+I trust that I am not more dense than my neighbors, but I was always
+oppressed with a sense of my own stupidity in my dealings with Sherlock
+Holmes. Here I had heard what he had heard, I had seen what he had
+seen, and yet from his words it was evident that he saw clearly not
+only what had happened, but what was about to happen, while to me the
+whole business was still confused and grotesque. As I drove home to
+my house in Kensington I thought over it all, from the extraordinary
+story of the red-headed copier of the “Encyclopædia” down to the visit
+to Saxe-Coburg Square, and the ominous words with which he had parted
+from me. What was this nocturnal expedition, and why should I go armed?
+Where were we going, and what were we to do? I had the hint from Holmes
+that this smooth-faced pawnbroker’s assistant was a formidable man—a
+man who might play a deep game. I tried to puzzle it out, but gave it
+up in despair, and set the matter aside until night should bring an
+explanation.
+
+It was a quarter past nine when I started from home and made my way
+across the Park, and so through Oxford Street to Baker Street. Two
+hansoms were standing at the door, and, as I entered the passage, I
+heard the sound of voices from above. On entering his room I found
+Holmes in animated conversation with two men, one of whom I recognized
+as Peter Jones, the official police agent, while the other was a long,
+thin, sad-faced man, with a very shiny hat and oppressively respectable
+frock-coat.
+
+“Ha! our party is complete,” said Holmes, buttoning up his pea-jacket,
+and taking his heavy hunting crop from the rack. “Watson, I think
+you know Mr. Jones, of Scotland Yard? Let me introduce you to Mr.
+Merryweather, who is to be our companion in to-night’s adventure.”
+
+“We’re hunting in couples again, doctor, you see,” said Jones, in his
+consequential way. “Our friend here is a wonderful man for starting a
+chase. All he wants is an old dog to help him to do the running down.”
+
+“I hope a wild goose may not prove to be the end of our chase,”
+observed Mr. Merryweather, gloomily.
+
+“You may place considerable confidence in Mr. Holmes, sir,” said the
+police agent, loftily. “He has his own little methods, which are, if he
+won’t mind my saying so, just a little too theoretical and fantastic,
+but he has the makings of a detective in him. It is not too much to
+say that once or twice, as in that business of the Sholto murder and
+the Agra treasure, he has been more nearly correct than the official
+force.”
+
+“Oh, if you say so, Mr. Jones, it is all right,” said the stranger,
+with deference. “Still, I confess that I miss my rubber. It is the
+first Saturday night for seven-and-twenty years that I have not had my
+rubber.”
+
+“I think you will find,” said Sherlock Holmes, “that you will play for
+a higher stake to-night than you have ever done yet, and that the play
+will be more exciting. For you, Mr. Merryweather, the stake will be
+some £30,000; and for you, Jones, it will be the man upon whom you wish
+to lay your hands.”
+
+“John Clay, the murderer, thief, smasher, and forger. He’s a young man,
+Mr. Merryweather, but he is at the head of his profession, and I would
+rather have my bracelets on him than on any criminal in London. He’s a
+remarkable man, is young John Clay. His grandfather was a royal duke,
+and he himself has been to Eton and Oxford. His brain is as cunning as
+his fingers, and though we meet signs of him at every turn, we never
+know where to find the man himself. He’ll crack a crib in Scotland one
+week, and be raising money to build an orphanage in Cornwall the next.
+I’ve been on his track for years, and have never set eyes on him yet.”
+
+“I hope that I may have the pleasure of introducing you to-night. I’ve
+had one or two little turns also with Mr. John Clay, and I agree with
+you that he is at the head of his profession. It is past ten, however,
+and quite time that we started. If you two will take the first hansom,
+Watson and I will follow in the second.”
+
+Sherlock Holmes was not very communicative during the long drive,
+and lay back in the cab humming the tunes which he had heard in the
+afternoon. We rattled through an endless labyrinth of gas-lit streets
+until we emerged into Farringdon Street.
+
+“We are close there now,” my friend remarked. “This fellow Merryweather
+is a bank director, and personally interested in the matter. I thought
+it as well to have Jones with us also. He is not a bad fellow, though
+an absolute imbecile in his profession. He has one positive virtue. He
+is as brave as a bull-dog, and as tenacious as a lobster if he gets his
+claws upon any one. Here we are, and they are waiting for us.”
+
+We had reached the same crowded thoroughfare in which we had found
+ourselves in the morning. Our cabs were dismissed, and, following
+the guidance of Mr. Merryweather, we passed down a narrow passage
+and through a side door, which he opened for us. Within there was a
+small corridor, which ended in a very massive iron gate. This also was
+opened, and led down a flight of winding stone steps, which terminated
+at another formidable gate. Mr. Merryweather stopped to light a
+lantern, and then conducted us down a dark, earth-smelling passage, and
+so, after opening a third door, into a huge vault or cellar, which was
+piled all round with crates and massive boxes.
+
+“You are not very vulnerable from above,” Holmes remarked, as he held
+up the lantern and gazed about him.
+
+“Nor from below,” said Mr. Merryweather, striking his stick upon the
+flags which lined the floor. “Why, dear me, it sounds quite hollow!” he
+remarked, looking up in surprise.
+
+“I must really ask you to be a little more quiet,” said Holmes,
+severely. “You have already imperilled the whole success of our
+expedition. Might I beg that you would have the goodness to sit down
+upon one of those boxes, and not to interfere?”
+
+The solemn Mr. Merryweather perched himself upon a crate, with a very
+injured expression upon his face, while Holmes fell upon his knees
+upon the floor, and, with the lantern and a magnifying lens, began to
+examine minutely the cracks between the stones. A few seconds sufficed
+to satisfy him, for he sprang to his feet again, and put his glass in
+his pocket.
+
+“We have at least an hour before us,” he remarked; “for they can
+hardly take any steps until the good pawnbroker is safely in bed.
+Then they will not lose a minute, for the sooner they do their work
+the longer time they will have for their escape. We are at present,
+doctor—as no doubt you have divined—in the cellar of the city branch
+of one of the principal London banks. Mr. Merryweather is the chairman
+of directors, and he will explain to you that there are reasons why the
+more daring criminals of London should take a considerable interest in
+this cellar at present.”
+
+“It is our French gold,” whispered the director. “We have had several
+warnings that an attempt might be made upon it.”
+
+“Your French gold?”
+
+“Yes. We had occasion some months ago to strengthen our resources, and
+borrowed, for that purpose, 30,000 napoleons from the Bank of France.
+It has become known that we have never had occasion to unpack the
+money, and that it is still lying in our cellar. The crate upon which
+I sit contains 2000 napoleons packed between layers of lead foil. Our
+reserve of bullion is much larger at present than is usually kept in a
+single branch office, and the directors have had misgivings upon the
+subject.”
+
+“Which were very well justified,” observed Holmes. “And now it is time
+that we arranged our little plans. I expect that within an hour matters
+will come to a head. In the mean time, Mr. Merryweather, we must put
+the screen over that dark lantern.”
+
+“And sit in the dark?”
+
+“I am afraid so. I had brought a pack of cards in my pocket, and I
+thought that, as we were a _partie carrée_, you might have your rubber
+after all. But I see that the enemy’s preparations have gone so far
+that we cannot risk the presence of a light. And, first of all, we must
+choose our positions. These are daring men, and though we shall take
+them at a disadvantage, they may do us some harm unless we are careful.
+I shall stand behind this crate, and do you conceal yourselves behind
+those. Then, when I flash a light upon them, close in swiftly. If they
+fire, Watson, have no compunction about shooting them down.”
+
+I placed my revolver, cocked, upon the top of the wooden case behind
+which I crouched. Holmes shot the slide across the front of his
+lantern, and left us in pitch darkness—such an absolute darkness
+as I have never before experienced. The smell of hot metal remained
+to assure us that the light was still there, ready to flash out at
+a moment’s notice. To me, with my nerves worked up to a pitch of
+expectancy, there was something depressing and subduing in the sudden
+gloom, and in the cold, dank air of the vault.
+
+“They have but one retreat,” whispered Holmes. “That is back through
+the house into Saxe-Coburg Square. I hope that you have done what I
+asked you, Jones?”
+
+“I have an inspector and two officers waiting at the front door.”
+
+“Then we have stopped all the holes. And now we must be silent and
+wait.”
+
+What a time it seemed! From comparing notes afterwards it was but an
+hour and a quarter, yet it appeared to me that the night must have
+almost gone, and the dawn be breaking above us. My limbs were weary and
+stiff, for I feared to change my position; yet my nerves were worked
+up to the highest pitch of tension, and my hearing was so acute that I
+could not only hear the gentle breathing of my companions, but I could
+distinguish the deeper, heavier in-breath of the bulky Jones from the
+thin, sighing note of the bank director. From my position I could look
+over the case in the direction of the floor. Suddenly my eyes caught
+the glint of a light.
+
+At first it was but a lurid spark upon the stone pavement. Then it
+lengthened out until it became a yellow line, and then, without any
+warning or sound, a gash seemed to open and a hand appeared; a white,
+almost womanly hand, which felt about in the centre of the little area
+of light. For a minute or more the hand, with its writhing fingers,
+protruded out of the floor. Then it was withdrawn as suddenly as it
+appeared, and all was dark again save the single lurid spark which
+marked a chink between the stones.
+
+Its disappearance, however, was but momentary. With a rending, tearing
+sound, one of the broad, white stones turned over upon its side, and
+left a square, gaping hole, through which streamed the light of a
+lantern. Over the edge there peeped a clean-cut, boyish face, which
+looked keenly about it, and then, with a hand on either side of the
+aperture, drew itself shoulder-high and waist-high, until one knee
+rested upon the edge. In another instant he stood at the side of the
+hole, and was hauling after him a companion, lithe and small like
+himself, with a pale face and a shock of very red hair.
+
+“It’s all clear,” he whispered. “Have you the chisel and the bags.
+Great Scott! Jump, Archie, jump, and I’ll swing for it!”
+
+Sherlock Holmes had sprung out and seized the intruder by the collar.
+The other dived down the hole, and I heard the sound of rending cloth
+as Jones clutched at his skirts. The light flashed upon the barrel of a
+revolver, but Holmes’s hunting crop came down on the man’s wrist, and
+the pistol clinked upon the stone floor.
+
+“It’s no use, John Clay,” said Holmes, blandly. “You have no chance at
+all.”
+
+“So I see,” the other answered, with the utmost coolness. “I fancy that
+my pal is all right, though I see you have got his coat-tails.”
+
+“There are three men waiting for him at the door,” said Holmes.
+
+“Oh, indeed! You seem to have done the thing very completely. I must
+compliment you.”
+
+“And I you,” Holmes answered. “Your red-headed idea was very new and
+effective.”
+
+“You’ll see your pal again presently,” said Jones. “He’s quicker at
+climbing down holes than I am. Just hold out while I fix the derbies.”
+
+“I beg that you will not touch me with your filthy hands,” remarked
+our prisoner, as the handcuffs clattered upon his wrists. “You may not
+be aware that I have royal blood in my veins. Have the goodness, also,
+when you address me always to say ‘sir’ and ‘please.’”
+
+“All right,” said Jones, with a stare and a snigger. “Well, would you
+please, sir, march up-stairs, where we can get a cab to carry your
+highness to the police-station?”
+
+“That is better,” said John Clay, serenely. He made a sweeping bow to
+the three of us, and walked quietly off in the custody of the detective.
+
+“Really Mr. Holmes,” said Mr. Merryweather, as we followed them from
+the cellar, “I do not know how the bank can thank you or repay you.
+There is no doubt that you have detected and defeated in the most
+complete manner one of the most determined attempts at bank robbery
+that have ever come within my experience.”
+
+“I have had one or two little scores of my own to settle with Mr.
+John Clay,” said Holmes. “I have been at some small expense over this
+matter, which I shall expect the bank to refund, but beyond that I am
+amply repaid by having had an experience which is in many ways unique,
+and by hearing the very remarkable narrative of the Red-headed League.”
+
+       *       *       *       *       *
+
+“You see, Watson,” he explained, in the early hours of the morning,
+as we sat over a glass of whiskey-and-soda in Baker Street, “it was
+perfectly obvious from the first that the only possible object of this
+rather fantastic business of the advertisement of the League, and the
+copying of the ‘Encyclopædia,’ must be to get this not over-bright
+pawnbroker out of the way for a number of hours every day. It was a
+curious way of managing it, but, really, it would be difficult to
+suggest a better. The method was no doubt suggested to Clay’s ingenious
+mind by the color of his accomplice’s hair. The £4 a week was a lure
+which must draw him, and what was it to them, who were playing for
+thousands? They put in the advertisement, one rogue has the temporary
+office, the other rogue incites the man to apply for it, and together
+they manage to secure his absence every morning in the week. From
+the time that I heard of the assistant having come for half wages,
+it was obvious to me that he had some strong motive for securing the
+situation.”
+
+“But how could you guess what the motive was?”
+
+“Had there been women in the house, I should have suspected a mere
+vulgar intrigue. That, however, was out of the question. The man’s
+business was a small one, and there was nothing in his house which
+could account for such elaborate preparations, and such an expenditure
+as they were at. It must, then, be something out of the house. What
+could it be? I thought of the assistant’s fondness for photography,
+and his trick of vanishing into the cellar. The cellar! There was the
+end of this tangled clue. Then I made inquiries as to this mysterious
+assistant, and found that I had to deal with one of the coolest
+and most daring criminals in London. He was doing something in the
+cellar—something which took many hours a day for months on end. What
+could it be, once more? I could think of nothing save that he was
+running a tunnel to some other building.
+
+“So far I had got when we went to visit the scene of action. I
+surprised you by beating upon the pavement with my stick. I was
+ascertaining whether the cellar stretched out in front or behind.
+It was not in front. Then I rang the bell, and, as I hoped, the
+assistant answered it. We have had some skirmishes, but we had never
+set eyes upon each other before. I hardly looked at his face. His
+knees were what I wished to see. You must yourself have remarked how
+worn, wrinkled, and stained they were. They spoke of those hours of
+burrowing. The only remaining point was what they were burrowing for. I
+walked round the corner, saw that the City and Suburban Bank abutted on
+our friend’s premises, and felt that I had solved my problem. When you
+drove home after the concert I called upon Scotland Yard, and upon the
+chairman of the bank directors, with the result that you have seen.”
+
+“And how could you tell that they would make their attempt to-night?” I
+asked.
+
+“Well, when they closed their League offices that was a sign that they
+cared no longer about Mr. Jabez Wilson’s presence—in other words,
+that they had completed their tunnel. But it was essential that they
+should use it soon, as it might be discovered, or the bullion might
+be removed. Saturday would suit them better than any other day, as it
+would give them two days for their escape. For all these reasons I
+expected them to come to-night.”
+
+“You reasoned it out beautifully,” I exclaimed, in unfeigned
+admiration. “It is so long a chain, and yet every link rings true.”
+
+“It saved me from ennui,” he answered, yawning. “Alas! I already feel
+it closing in upon me. My life is spent in one long effort to escape
+from the commonplaces of existence. These little problems help me to do
+so.”
+
+“And you are a benefactor of the race,” said I.
+
+He shrugged his shoulders. “Well, perhaps, after all, it is of some
+little use,” he remarked. “‘L’homme c’est rien—l’oeuvre c’est
+tout,’ as Gustave Flaubert wrote to Georges Sand.”
+
+
+
+
+Adventure III
+
+A CASE OF IDENTITY
+
+
+“My dear fellow,” said Sherlock Holmes, as we sat on either side
+of the fire in his lodgings at Baker Street, “life is infinitely
+stranger than anything which the mind of man could invent. We would
+not dare to conceive the things which are really mere commonplaces of
+existence. If we could fly out of that window hand in hand, hover over
+this great city, gently remove the roofs, and peep in at the queer
+things which are going on, the strange coincidences, the plannings,
+the cross-purposes, the wonderful chains of events, working through
+generations, and leading to the most _outré_ results, it would make all
+fiction with its conventionalities and foreseen conclusions most stale
+and unprofitable.”
+
+“And yet I am not convinced of it,” I answered. “The cases which come
+to light in the papers are, as a rule, bald enough, and vulgar enough.
+We have in our police reports realism pushed to its extreme limits,
+and yet the result is, it must be confessed, neither fascinating nor
+artistic.”
+
+“A certain selection and discretion must be used in producing a
+realistic effect,” remarked Holmes. “This is wanting in the police
+report, where more stress is laid, perhaps, upon the platitudes of the
+magistrate than upon the details, which to an observer contain the
+vital essence of the whole matter. Depend upon it there is nothing so
+unnatural as the commonplace.”
+
+I smiled and shook my head. “I can quite understand you thinking so,”
+I said. “Of course, in your position of unofficial adviser and helper
+to everybody who is absolutely puzzled, throughout three continents,
+you are brought in contact with all that is strange and bizarre. But
+here”—I picked up the morning paper from the ground—“let us put it
+to a practical test. Here is the first heading upon which I come. ‘A
+husband’s cruelty to his wife.’ There is half a column of print, but
+I know without reading it that it is all perfectly familiar to me.
+There is, of course, the other woman, the drink, the push, the blow,
+the bruise, the sympathetic sister or landlady. The crudest of writers
+could invent nothing more crude.”
+
+“Indeed, your example is an unfortunate one for your argument,”
+said Holmes, taking the paper and glancing his eye down it. “This
+is the Dundas separation case, and, as it happens, I was engaged in
+clearing up some small points in connection with it. The husband was
+a teetotaler, there was no other woman, and the conduct complained of
+was that he had drifted into the habit of winding up every meal by
+taking out his false teeth and hurling them at his wife, which, you
+will allow, is not an action likely to occur to the imagination of the
+average story-teller. Take a pinch of snuff, doctor, and acknowledge
+that I have scored over you in your example.”
+
+He held out his snuffbox of old gold, with a great amethyst in the
+centre of the lid. Its splendor was in such contrast to his homely ways
+and simple life that I could not help commenting upon it.
+
+“Ah,” said he, “I forgot that I had not seen you for some weeks. It is
+a little souvenir from the King of Bohemia in return for my assistance
+in the case of the Irene Adler papers.”
+
+“And the ring?” I asked, glancing at a remarkable brilliant which
+sparkled upon his finger.
+
+“It was from the reigning family of Holland, though the matter in which
+I served them was of such delicacy that I cannot confide it even to
+you, who have been good enough to chronicle one or two of my little
+problems.”
+
+“And have you any on hand just now?” I asked, with interest.
+
+“Some ten or twelve, but none which present any feature of interest.
+They are important, you understand, without being interesting. Indeed,
+I have found that it is usually in unimportant matters that there is
+a field for the observation, and for the quick analysis of cause and
+effect which gives the charm to an investigation. The larger crimes are
+apt to be the simpler, for the bigger the crime, the more obvious, as
+a rule, is the motive. In these cases, save for one rather intricate
+matter which has been referred to me from Marseilles, there is nothing
+which presents any features of interest. It is possible, however, that
+I may have something better before very many minutes are over, for this
+is one of my clients, or I am much mistaken.”
+
+He had risen from his chair, and was standing between the parted
+blinds, gazing down into the dull, neutral-tinted London street.
+Looking over his shoulder, I saw that on the pavement opposite there
+stood a large woman with a heavy fur boa round her neck, and a large
+curling red feather in a broad-brimmed hat which was tilted in a
+coquettish Duchess-of-Devonshire fashion over her ear. From under
+this great panoply she peeped up in a nervous, hesitating fashion at
+our windows, while her body oscillated backward and forward, and her
+fingers fidgetted with her glove buttons. Suddenly, with a plunge, as
+of the swimmer who leaves the bank, she hurried across the road, and we
+heard the sharp clang of the bell.
+
+“I have seen those symptoms before,” said Holmes, throwing his
+cigarette into the fire. “Oscillation upon the pavement always means an
+_affaire de cœur_. She would like advice, but is not sure that the
+matter is not too delicate for communication. And yet even here we may
+discriminate. When a woman has been seriously wronged by a man she no
+longer oscillates, and the usual symptom is a broken bell wire. Here we
+may take it that there is a love matter, but that the maiden is not so
+much angry as perplexed, or grieved. But here she comes in person to
+resolve our doubts.”
+
+As he spoke there was a tap at the door, and the boy in buttons entered
+to announce Miss Mary Sutherland, while the lady herself loomed behind
+his small black figure like a full-sailed merchant-man behind a tiny
+pilot boat. Sherlock Holmes welcomed her with the easy courtesy for
+which he was remarkable, and having closed the door, and bowed her into
+an arm-chair, he looked her over in the minute, and yet abstracted
+fashion which was peculiar to him.
+
+“Do you not find,” he said, “that with your short sight it is a little
+trying to do so much type-writing?”
+
+“I did at first,” she answered, “but now I know where the letters
+are without looking.” Then, suddenly realizing the full purport of
+his words, she gave a violent start and looked up, with fear and
+astonishment upon her broad, good-humored face. “You’ve heard about me,
+Mr. Holmes,” she cried, “else how could you know all that?”
+
+“Never mind,” said Holmes, laughing; “it is my business to know things.
+Perhaps I have trained myself to see what others overlook. If not, why
+should you come to consult me?”
+
+“I came to you, sir, because I heard of you from Mrs. Etherege, whose
+husband you found so easy when the police and every one had given him
+up for dead. Oh, Mr. Holmes, I wish you would do as much for me. I’m
+not rich, but still I have a hundred a year in my own right, besides
+the little that I make by the machine, and I would give it all to know
+what has become of Mr. Hosmer Angel.”
+
+“Why did you come away to consult me in such a hurry?” asked Sherlock
+Holmes, with his finger-tips together, and his eyes to the ceiling.
+
+Again a startled look came over the somewhat vacuous face of Miss Mary
+Sutherland. “Yes, I did bang out of the house,” she said, “for it
+made me angry to see the easy way in which Mr. Windibank—that is, my
+father—took it all. He would not go to the police, and he would not
+go to you, and so at last, as he would do nothing, and kept on saying
+that there was no harm done, it made me mad, and I just on with my
+things and came right away to you.”
+
+“Your father,” said Holmes, “your step-father, surely, since the name
+is different.”
+
+“Yes, my step-father. I call him father, though it sounds funny, too,
+for he is only five years and two months older than myself.”
+
+“And your mother is alive?”
+
+“Oh yes, mother is alive and well. I wasn’t best pleased, Mr. Holmes,
+when she married again so soon after father’s death, and a man who was
+nearly fifteen years younger than herself. Father was a plumber in the
+Tottenham Court Road, and he left a tidy business behind him, which
+mother carried on with Mr. Hardy, the foreman; but when Mr. Windibank
+came he made her sell the business, for he was very superior, being a
+traveller in wines. They got £4700 for the goodwill and interest, which
+wasn’t near as much as father could have got if he had been alive.”
+
+I had expected to see Sherlock Holmes impatient under this rambling and
+inconsequential narrative, but, on the contrary, he had listened with
+the greatest concentration of attention.
+
+“Your own little income,” he asked, “does it come out of the business?”
+
+“Oh no, sir. It is quite separate, and was left me by my Uncle Ned
+in Auckland. It is in New Zealand stock, paying 4-1/2 per cent. Two
+thousand five hundred pounds was the amount, but I can only touch the
+interest.”
+
+“You interest me extremely,” said Holmes. “And since you draw so large
+a sum as a hundred a year, with what you earn into the bargain, you no
+doubt travel a little, and indulge yourself in every way. I believe
+that a single lady can get on very nicely upon an income of about £60.”
+
+[Illustration: “SHERLOCK HOLMES WELCOMED HER”]
+
+“I could do with much less than that, Mr. Holmes, but you understand
+that as long as I live at home I don’t wish to be a burden to them, and
+so they have the use of the money just while I am staying with them. Of
+course, that is only just for the time. Mr. Windibank draws my interest
+every quarter, and pays it over to mother, and I find that I can do
+pretty well with what I earn at type-writing. It brings me twopence a
+sheet, and I can often do from fifteen to twenty sheets in a day.”
+
+“You have made your position very clear to me,” said Holmes. “This is
+my friend, Dr. Watson, before whom you can speak as freely as before
+myself. Kindly tell us now all about your connection with Mr. Hosmer
+Angel.”
+
+A flush stole over Miss Sutherland’s face, and she picked nervously at
+the fringe of her jacket. “I met him first at the gasfitters’ ball,”
+she said. “They used to send father tickets when he was alive, and then
+afterwards they remembered us, and sent them to mother. Mr. Windibank
+did not wish us to go. He never did wish us to go anywhere. He would
+get quite mad if I wanted so much as to join a Sunday-school treat.
+But this time I was set on going, and I would go; for what right had
+he to prevent? He said the folk were not fit for us to know, when all
+father’s friends were to be there. And he said that I had nothing fit
+to wear, when I had my purple plush that I had never so much as taken
+out of the drawer. At last, when nothing else would do, he went off
+to France upon the business of the firm, but we went, mother and I,
+with Mr. Hardy, who used to be our foreman, and it was there I met Mr.
+Hosmer Angel.”
+
+“I suppose,” said Holmes, “that when Mr. Windibank came back from
+France he was very annoyed at your having gone to the ball.”
+
+“Oh, well, he was very good about it. He laughed, I remember, and
+shrugged his shoulders, and said there was no use denying anything to a
+woman, for she would have her way.”
+
+“I see. Then at the gasfitters’ ball you met, as I understand, a
+gentleman called Mr. Hosmer Angel.”
+
+“Yes, sir. I met him that night, and he called next day to ask if we
+had got home all safe, and after that we met him—that is to say, Mr.
+Holmes, I met him twice for walks, but after that father came back
+again, and Mr. Hosmer Angel could not come to the house any more.”
+
+“No?”
+
+“Well, you know, father didn’t like anything of the sort. He wouldn’t
+have any visitors if he could help it, and he used to say that a woman
+should be happy in her own family circle. But then, as I used to say to
+mother, a woman wants her own circle to begin with, and I had not got
+mine yet.”
+
+“But how about Mr. Hosmer Angel? Did he make no attempt to see you?”
+
+“Well, father was going off to France again in a week, and Hosmer wrote
+and said that it would be safer and better not to see each other until
+he had gone. We could write in the mean time, and he used to write
+every day. I took the letters in in the morning, so there was no need
+for father to know.”
+
+“Were you engaged to the gentleman at this time?”
+
+“Oh yes, Mr. Holmes. We were engaged after the first walk that we
+took. Hosmer—Mr. Angel—was a cashier in an office in Leadenhall
+Street—and—”
+
+“What office?”
+
+“That’s the worst of it, Mr. Holmes, I don’t know.”
+
+“Where did he live, then?”
+
+“He slept on the premises.”
+
+“And you don’t know his address?”
+
+“No—except that it was Leadenhall Street.”
+
+“Where did you address your letters, then?”
+
+“To the Leadenhall Street Post-office, to be left till called for. He
+said that if they were sent to the office he would be chaffed by all
+the other clerks about having letters from a lady, so I offered to
+type-write them, like he did his, but he wouldn’t have that, for he
+said that when I wrote them they seemed to come from me, but when they
+were type-written he always felt that the machine had come between us.
+That will just show you how fond he was of me, Mr. Holmes, and the
+little things that he would think of.”
+
+“It was most suggestive,” said Holmes. “It has long been an axiom of
+mine that the little things are infinitely the most important. Can you
+remember any other little things about Mr. Hosmer Angel?”
+
+“He was a very shy man, Mr. Holmes. He would rather walk with me in
+the evening than in the daylight, for he said that he hated to be
+conspicuous. Very retiring and gentlemanly he was. Even his voice was
+gentle. He’d had the quinsy and swollen glands when he was young, he
+told me, and it had left him with a weak throat, and a hesitating,
+whispering fashion of speech. He was always well dressed, very neat and
+plain, but his eyes were weak, just as mine are, and he wore tinted
+glasses against the glare.”
+
+“Well, and what happened when Mr. Windibank, your step-father, returned
+to France?”
+
+“Mr. Hosmer Angel came to the house again, and proposed that we should
+marry before father came back. He was in dreadful earnest, and made
+me swear, with my hands on the Testament, that whatever happened I
+would always be true to him. Mother said he was quite right to make me
+swear, and that it was a sign of his passion. Mother was all in his
+favor from the first, and was even fonder of him than I was. Then, when
+they talked of marrying within the week, I began to ask about father;
+but they both said never to mind about father, but just to tell him
+afterwards, and mother said she would make it all right with him. I
+didn’t quite like that, Mr. Holmes. It seemed funny that I should ask
+his leave, as he was only a few years older than me; but I didn’t want
+to do anything on the sly, so I wrote to father at Bordeaux, where the
+company has its French offices, but the letter came back to me on the
+very morning of the wedding.”
+
+“It missed him, then?”
+
+“Yes, sir; for he had started to England just before it arrived.”
+
+“Ha! that was unfortunate. Your wedding was arranged, then, for the
+Friday. Was it to be in church?”
+
+“Yes, sir, but very quietly. It was to be at St. Saviour’s, near King’s
+Cross, and we were to have breakfast afterwards at the St. Pancras
+Hotel. Hosmer came for us in a hansom, but as there were two of us, he
+put us both into it, and stepped himself into a four-wheeler, which
+happened to be the only other cab in the street. We got to the church
+first, and when the four-wheeler drove up we waited for him to step
+out, but he never did, and when the cabman got down from the box and
+looked, there was no one there! The cabman said that he could not
+imagine what had become of him, for he had seen him get in with his own
+eyes. That was last Friday, Mr. Holmes, and I have never seen or heard
+anything since then to throw any light upon what became of him.”
+
+“It seems to me that you have been very shamefully treated,” said
+Holmes.
+
+“Oh no, sir! He was too good and kind to leave me so. Why, all the
+morning he was saying to me that, whatever happened, I was to be true;
+and that even if something quite unforeseen occurred to separate
+us, I was always to remember that I was pledged to him, and that he
+would claim his pledge sooner or later. It seemed strange talk for a
+wedding-morning, but what has happened since gives a meaning to it.”
+
+“Most certainly it does. Your own opinion is, then, that some
+unforeseen catastrophe has occurred to him?”
+
+“Yes, sir. I believe that he foresaw some danger, or else he would not
+have talked so. And then I think that what he foresaw happened.”
+
+“But you have no notion as to what it could have been?”
+
+“None.”
+
+“One more question. How did your mother take the matter?”
+
+“She was angry, and said that I was never to speak of the matter again.”
+
+“And your father? Did you tell him?”
+
+“Yes; and he seemed to think, with me, that something had happened, and
+that I should hear of Hosmer again. As he said, what interest could any
+one have in bringing me to the doors of the church, and then leaving
+me? Now, if he had borrowed my money, or if he had married me and got
+my money settled on him, there might be some reason; but Hosmer was
+very independent about money, and never would look at a shilling of
+mine. And yet, what could have happened? And why could he not write?
+Oh, it drives me half-mad to think of! and I can’t sleep a wink at
+night.” She pulled a little handkerchief out of her muff, and began to
+sob heavily into it.
+
+“I shall glance into the case for you,” said Holmes, rising; “and I
+have no doubt that we shall reach some definite result. Let the weight
+of the matter rest upon me now, and do not let your mind dwell upon
+it further. Above all, try to let Mr. Hosmer Angel vanish from your
+memory, as he has done from your life.”
+
+“Then you don’t think I’ll see him again?”
+
+“I fear not.”
+
+“Then what has happened to him?”
+
+“You will leave that question in my hands. I should like an accurate
+description of him, and any letters of his which you can spare.”
+
+“I advertised for him in last Saturday’s _Chronicle_,” said she. “Here
+is the slip, and here are four letters from him.”
+
+“Thank you. And your address?”
+
+“No. 31 Lyon Place, Camberwell.”
+
+“Mr. Angel’s address you never had, I understand. Where is your
+father’s place of business?”
+
+“He travels for Westhouse & Marbank, the great claret importers of
+Fenchurch Street.”
+
+“Thank you. You have made your statement very clearly. You will leave
+the papers here, and remember the advice which I have given you. Let
+the whole incident be a sealed book, and do not allow it to affect your
+life.”
+
+“You are very kind, Mr. Holmes, but I cannot do that. I shall be true
+to Hosmer. He shall find me ready when he comes back.”
+
+For all the preposterous hat and the vacuous face, there was something
+noble in the simple faith of our visitor which compelled our respect.
+She laid her little bundle of papers upon the table, and went her way,
+with a promise to come again whenever she might be summoned.
+
+Sherlock Holmes sat silent for a few minutes with his finger-tips still
+pressed together, his legs stretched out in front of him, and his gaze
+directed upward to the ceiling. Then he took down from the rack the
+old and oily clay pipe, which was to him as a counsellor, and, having
+lit it, he leaned back in his chair, with the thick blue cloud-wreaths
+spinning up from him, and a look of infinite languor in his face.
+
+“Quite an interesting study, that maiden,” he observed. “I found her
+more interesting than her little problem, which, by the way, is rather
+a trite one. You will find parallel cases, if you consult my index, in
+Andover in ’77, and there was something of the sort at The Hague last
+year. Old as is the idea, however, there were one or two details which
+were new to me. But the maiden herself was most instructive.”
+
+“You appeared to read a good deal upon her which was quite invisible to
+me,” I remarked.
+
+“Not invisible, but unnoticed, Watson. You did not know where to look,
+and so you missed all that was important. I can never bring you to
+realize the importance of sleeves, the suggestiveness of thumb-nails,
+or the great issues that may hang from a boot-lace. Now, what did you
+gather from that woman’s appearance? Describe it.”
+
+“Well, she had a slate-colored, broad-brimmed straw hat, with a feather
+of a brickish red. Her jacket was black, with black beads sewn upon it,
+and a fringe of little black jet ornaments. Her dress was brown, rather
+darker than coffee color, with a little purple plush at the neck and
+sleeves. Her gloves were grayish, and were worn through at the right
+forefinger. Her boots I didn’t observe. She had small, round, hanging
+gold ear-rings, and a general air of being fairly well-to-do, in a
+vulgar, comfortable, easy-going way.”
+
+Sherlock Holmes clapped his hands softly together and chuckled.
+
+“’Pon my word, Watson, you are coming along wonderfully. You have
+really done very well indeed. It is true that you have missed
+everything of importance, but you have hit upon the method, and you
+have a quick eye for color. Never trust to general impressions, my boy,
+but concentrate yourself upon details. My first glance is always at a
+woman’s sleeve. In a man it is perhaps better first to take the knee
+of the trouser. As you observe, this woman had plush upon her sleeves,
+which is a most useful material for showing traces. The double line
+a little above the wrist, where the type-writist presses against the
+table, was beautifully defined. The sewing-machine, of the hand type,
+leaves a similar mark, but only on the left arm, and on the side of it
+farthest from the thumb, instead of being right across the broadest
+part, as this was. I then glanced at her face, and observing the dint
+of a pince-nez at either side of her nose, I ventured a remark upon
+short sight and type-writing, which seemed to surprise her.”
+
+“It surprised me.”
+
+“But, surely, it was very obvious. I was then much surprised and
+interested on glancing down to observe that, though the boots which she
+was wearing were not unlike each other, they were really odd ones; the
+one having a slightly decorated toe-cap, and the other a plain one.
+One was buttoned only in the two lower buttons out of five, and the
+other at the first, third, and fifth. Now, when you see that a young
+lady, otherwise neatly dressed, has come away from home with odd boots,
+half-buttoned, it is no great deduction to say that she came away in a
+hurry.”
+
+“And what else?” I asked, keenly interested, as I always was, by my
+friend’s incisive reasoning.
+
+“I noted, in passing, that she had written a note before leaving home,
+but after being fully dressed. You observed that her right glove was
+torn at the forefinger, but you did not apparently see that both glove
+and finger were stained with violet ink. She had written in a hurry,
+and dipped her pen too deep. It must have been this morning, or the
+mark would not remain clear upon the finger. All this is amusing,
+though rather elementary, but I must go back to business, Watson. Would
+you mind reading me the advertised description of Mr. Hosmer Angel?”
+
+I held the little printed slip to the light. “Missing,” it said, “on
+the morning of the 14th, a gentleman named Hosmer Angel. About 5 ft. 7
+in. in height; strongly built, sallow complexion, black hair, a little
+bald in the centre, bushy, black side-whiskers and mustache; tinted
+glasses, slight infirmity of speech. Was dressed, when last seen, in
+black frock-coat faced with silk, black waistcoat, gold Albert chain,
+and gray Harris tweed trousers, with brown gaiters over elastic-sided
+boots. Known to have been employed in an office in Leadenhall Street.
+Anybody bringing,” etc., etc.
+
+“That will do,” said Holmes. “As to the letters,” he continued,
+glancing over them, “they are very commonplace. Absolutely no clew
+in them to Mr. Angel, save that he quotes Balzac once. There is one
+remarkable point, however, which will no doubt strike you.”
+
+“They are type-written,” I remarked.
+
+“Not only that, but the signature is type-written. Look at the neat
+little ‘Hosmer Angel’ at the bottom. There is a date, you see, but no
+superscription except Leadenhall Street, which is rather vague. The
+point about the signature is very suggestive—in fact, we may call it
+conclusive.”
+
+“Of what?”
+
+“My dear fellow, is it possible you do not see how strongly it bears
+upon the case?”
+
+“I cannot say that I do, unless it were that he wished to be able to
+deny his signature if an action for breach of promise were instituted.”
+
+“No, that was not the point. However, I shall write two letters, which
+should settle the matter. One is to a firm in the city, the other is
+to the young lady’s step-father, Mr. Windibank, asking him whether he
+could meet us here at six o’clock to-morrow evening. It is just as well
+that we should do business with the male relatives. And now, doctor, we
+can do nothing until the answers to those letters come, so we may put
+our little problem upon the shelf for the interim.”
+
+I had had so many reasons to believe in my friend’s subtle powers of
+reasoning, and extraordinary energy in action, that I felt that he must
+have some solid grounds for the assured and easy demeanor with which he
+treated the singular mystery which he had been called upon to fathom.
+Once only had I known him to fail, in the case of the King of Bohemia
+and of the Irene Adler photograph; but when I looked back to the weird
+business of the Sign of Four, and the extraordinary circumstances
+connected with the Study in Scarlet, I felt that it would be a strange
+tangle indeed which he could not unravel.
+
+I left him then, still puffing at his black clay pipe, with the
+conviction that when I came again on the next evening I would find that
+he held in his hands all the clews which would lead up to the identity
+of the disappearing bridegroom of Miss Mary Sutherland.
+
+A professional case of great gravity was engaging my own attention at
+the time, and the whole of next day I was busy at the bedside of the
+sufferer. It was not until close upon six o’clock that I found myself
+free, and was able to spring into a hansom and drive to Baker Street,
+half afraid that I might be too late to assist at the _dénouement_
+of the little mystery. I found Sherlock Holmes alone, however, half
+asleep, with his long, thin form curled up in the recesses of his
+arm-chair. A formidable array of bottles and test-tubes, with the
+pungent cleanly smell of hydrochloric acid, told me that he had spent
+his day in the chemical work which was so dear to him.
+
+“Well, have you solved it?” I asked, as I entered.
+
+“Yes. It was the bisulphate of baryta.”
+
+“No, no, the mystery!” I cried.
+
+“Oh, that! I thought of the salt that I have been working upon. There
+was never any mystery in the matter, though, as I said yesterday, some
+of the details are of interest. The only drawback is that there is no
+law, I fear, that can touch the scoundrel.”
+
+“Who was he, then, and what was his object in deserting Miss
+Sutherland?”
+
+The question was hardly out of my mouth, and Holmes had not yet opened
+his lips to reply, when we heard a heavy footfall in the passage, and a
+tap at the door.
+
+“This is the girl’s step-father, Mr. James Windibank,” said Holmes. “He
+has written to me to say that he would be here at six. Come in!”
+
+The man who entered was a sturdy, middle-sized fellow, some thirty
+years of age, clean shaven, and sallow skinned, with a bland,
+insinuating manner, and a pair of wonderfully sharp and penetrating
+gray eyes. He shot a questioning glance at each of us, placed his shiny
+top hat upon the sideboard, and with a slight bow sidled down into the
+nearest chair.
+
+“Good-evening, Mr. James Windibank,” said Holmes. “I think that this
+type-written letter is from you, in which you made an appointment with
+me for six o’clock?”
+
+“Yes, sir. I am afraid that I am a little late, but I am not quite my
+own master, you know. I am sorry that Miss Sutherland has troubled you
+about this little matter, for I think it is far better not to wash
+linen of the sort in public. It was quite against my wishes that she
+came, but she is a very excitable, impulsive girl, as you may have
+noticed, and she is not easily controlled when she has made up her
+mind on a point. Of course, I did not mind you so much, as you are not
+connected with the official police, but it is not pleasant to have a
+family misfortune like this noised abroad. Besides, it is a useless
+expense, for how could you possibly find this Hosmer Angel?”
+
+“On the contrary,” said Holmes, quietly; “I have every reason to
+believe that I will succeed in discovering Mr. Hosmer Angel.”
+
+Mr. Windibank gave a violent start, and dropped his gloves. “I am
+delighted to hear it,” he said.
+
+“It is a curious thing,” remarked Holmes, “that a type-writer has
+really quite as much individuality as a man’s handwriting. Unless they
+are quite new, no two of them write exactly alike. Some letters get
+more worn than others, and some wear only on one side. Now, you remark
+in this note of yours, Mr. Windibank, that in every case there is some
+little slurring over of the ‘e,’ and a slight defect in the tail of the
+‘r.’ There are fourteen other characteristics, but those are the more
+obvious.”
+
+“We do all our correspondence with this machine at the office, and no
+doubt it is a little worn,” our visitor answered, glancing keenly at
+Holmes with his bright little eyes.
+
+“And now I will show you what is really a very interesting study,
+Mr. Windibank,” Holmes continued. “I think of writing another little
+monograph some of these days on the type-writer and its relation to
+crime. It is a subject to which I have devoted some little attention.
+I have here four letters which purport to come from the missing man.
+They are all type-written. In each case, not only are the ‘e’s’ slurred
+and the ‘r’s’ tailless, but you will observe, if you care to use my
+magnifying lens, that the fourteen other characteristics to which I
+have alluded are there as well.”
+
+Mr. Windibank sprang out of his chair, and picked up his hat. “I cannot
+waste time over this sort of fantastic talk, Mr. Holmes,” he said. “If
+you can catch the man, catch him, and let me know when you have done
+it.”
+
+“Certainly,” said Holmes, stepping over and turning the key in the
+door. “I let you know, then, that I have caught him!”
+
+“What! where?” shouted Mr. Windibank, turning white to his lips, and
+glancing about him like a rat in a trap.
+
+“Oh, it won’t do—really it won’t,” said Holmes, suavely. “There is no
+possible getting out of it, Mr. Windibank. It is quite too transparent,
+and it was a very bad compliment when you said that it was impossible
+for me to solve so simple a question. That’s right! Sit down, and let
+us talk it over.”
+
+Our visitor collapsed into a chair, with a ghastly face, and a glitter
+of moisture on his brow. “It—it’s not actionable,” he stammered.
+
+“I am very much afraid that it is not. But between ourselves,
+Windibank, it was as cruel and selfish and heartless a trick in a petty
+way as ever came before me. Now, let me just run over the course of
+events, and you will contradict me if I go wrong.”
+
+The man sat huddled up in his chair, with his head sunk upon his
+breast, like one who is utterly crushed. Holmes stuck his feet up on
+the corner of the mantel-piece, and, leaning back with his hands in his
+pockets, began talking, rather to himself, as it seemed, than to us.
+
+“The man married a woman very much older than himself for her money,”
+said he, “and he enjoyed the use of the money of the daughter as long
+as she lived with them. It was a considerable sum, for people in their
+position, and the loss of it would have made a serious difference.
+It was worth an effort to preserve it. The daughter was of a good,
+amiable disposition, but affectionate and warm-hearted in her ways, so
+that it was evident that with her fair personal advantages, and her
+little income, she would not be allowed to remain single long. Now her
+marriage would mean, of course, the loss of a hundred a year, so what
+does her step-father do to prevent it? He takes the obvious course of
+keeping her at home, and forbidding her to seek the company of people
+of her own age. But soon he found that that would not answer forever.
+She became restive, insisted upon her rights, and finally announced her
+positive intention of going to a certain ball. What does her clever
+step-father do then? He conceives an idea more creditable to his head
+than to his heart. With the connivance and assistance of his wife he
+disguised himself, covered those keen eyes with tinted glasses, masked
+the face with a mustache and a pair of bushy whiskers, sunk that clear
+voice into an insinuating whisper, and doubly secure on account of the
+girl’s short sight, he appears as Mr. Hosmer Angel, and keeps off other
+lovers by making love himself.”
+
+[Illustration: “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”]
+
+“It was only a joke at first,” groaned our visitor. “We never thought
+that she would have been so carried away.”
+
+“Very likely not. However that may be, the young lady was very
+decidedly carried away, and having quite made up her mind that her
+step-father was in France, the suspicion of treachery never for
+an instant entered her mind. She was flattered by the gentleman’s
+attentions, and the effect was increased by the loudly expressed
+admiration of her mother. Then Mr. Angel began to call, for it was
+obvious that the matter should be pushed as far as it would go,
+if a real effect were to be produced. There were meetings, and an
+engagement, which would finally secure the girl’s affections from
+turning towards any one else. But the deception could not be kept up
+forever. These pretended journeys to France were rather cumbrous. The
+thing to do was clearly to bring the business to an end in such a
+dramatic manner that it would leave a permanent impression upon the
+young lady’s mind, and prevent her from looking upon any other suitor
+for some time to come. Hence those vows of fidelity exacted upon a
+Testament, and hence also the allusions to a possibility of something
+happening on the very morning of the wedding. James Windibank wished
+Miss Sutherland to be so bound to Hosmer Angel, and so uncertain as to
+his fate, that for ten years to come, at any rate, she would not listen
+to another man. As far as the church door he brought her, and then, as
+he could go no farther, he conveniently vanished away by the old trick
+of stepping in at one door of a four-wheeler, and out at the other. I
+think that that was the chain of events, Mr. Windibank!”
+
+Our visitor had recovered something of his assurance while Holmes had
+been talking, and he rose from his chair now with a cold sneer upon his
+pale face.
+
+“It may be so, or it may not, Mr. Holmes,” said he, “but if you are so
+very sharp you ought to be sharp enough to know that it is you who are
+breaking the law now, and not me. I have done nothing actionable from
+the first, but as long as you keep that door locked you lay yourself
+open to an action for assault and illegal constraint.”
+
+“The law cannot, as you say, touch you,” said Holmes, unlocking and
+throwing open the door, “yet there never was a man who deserved
+punishment more. If the young lady has a brother or a friend, he ought
+to lay a whip across your shoulders. By Jove!” he continued, flushing
+up at the sight of the bitter sneer upon the man’s face, “it is not
+part of my duties to my client, but here’s a hunting crop handy, and I
+think I shall just treat myself to—” He took two swift steps to the
+whip, but before he could grasp it there was a wild clatter of steps
+upon the stairs, the heavy hall door banged, and from the window we
+could see Mr. James Windibank running at the top of his speed down the
+road.
+
+“There’s a cold-blooded scoundrel!” said Holmes, laughing, as he threw
+himself down into his chair once more. “That fellow will rise from
+crime to crime until he does something very bad, and ends on a gallows.
+The case has, in some respects, been not entirely devoid of interest.”
+
+“I cannot now entirely see all the steps of your reasoning,” I remarked.
+
+“Well, of course it was obvious from the first that this Mr. Hosmer
+Angel must have some strong object for his curious conduct, and it was
+equally clear that the only man who really profited by the incident,
+as far as we could see, was the step-father. Then the fact that the
+two men were never together, but that the one always appeared when
+the other was away, was suggestive. So were the tinted spectacles and
+the curious voice, which both hinted at a disguise, as did the bushy
+whiskers. My suspicions were all confirmed by his peculiar action
+in type-writing his signature, which, of course, inferred that his
+handwriting was so familiar to her that she would recognize even the
+smallest sample of it. You see all these isolated facts, together with
+many minor ones, all pointed in the same direction.”
+
+“And how did you verify them?”
+
+“Having once spotted my man, it was easy to get corroboration. I
+knew the firm for which this man worked. Having taken the printed
+description, I eliminated everything from it which could be the result
+of a disguise—the whiskers, the glasses, the voice, and I sent it
+to the firm, with a request that they would inform me whether it
+answered to the description of any of their travellers. I had already
+noticed the peculiarities of the type-writer, and I wrote to the man
+himself at his business address, asking him if he would come here. As
+I expected, his reply was type-written, and revealed the same trivial
+but characteristic defects. The same post brought me a letter from
+Westhouse & Marbank, of Fenchurch Street, to say that the description
+tallied in every respect with that of their employé, James Windibank.
+_Voila tout!_”
+
+“And Miss Sutherland?”
+
+“If I tell her she will not believe me. You may remember the old
+Persian saying, ‘There is danger for him who taketh the tiger cub, and
+danger also for whoso snatches a delusion from a woman.’ There is as
+much sense in Hafiz as in Horace, and as much knowledge of the world.”
+
+
+
+
+Adventure IV
+
+THE BOSCOMBE VALLEY MYSTERY
+
+
+We were seated at breakfast one morning, my wife and I, when the maid
+brought in a telegram. It was from Sherlock Holmes, and ran in this way:
+
+“Have you a couple of days to spare? Have just been wired for from
+the West of England in connection with Boscombe Valley tragedy. Shall
+be glad if you will come with me. Air and scenery perfect. Leave
+Paddington by the 11.15.”
+
+“What do you say, dear?” said my wife, looking across at me. “Will you
+go?”
+
+“I really don’t know what to say. I have a fairly long list at present.”
+
+“Oh, Anstruther would do your work for you. You have been looking a
+little pale lately. I think that the change would do you good, and you
+are always so interested in Mr. Sherlock Holmes’s cases.”
+
+“I should be ungrateful if I were not, seeing what I gained through one
+of them,” I answered. “But if I am to go, I must pack at once, for I
+have only half an hour.”
+
+My experience of camp life in Afghanistan had at least had the effect
+of making me a prompt and ready traveller. My wants were few and
+simple, so that in less than the time stated I was in a cab with my
+valise, rattling away to Paddington Station. Sherlock Holmes was pacing
+up and down the platform, his tall, gaunt figure made even gaunter and
+taller by his long gray travelling-cloak and close-fitting cloth cap.
+
+“It is really very good of you to come, Watson,” said he. “It makes a
+considerable difference to me, having some one with me on whom I can
+thoroughly rely. Local aid is always either worthless or else biassed.
+If you will keep the two corner seats I shall get the tickets.”
+
+We had the carriage to ourselves save for an immense litter of papers
+which Holmes had brought with him. Among these he rummaged and read,
+with intervals of note-taking and of meditation, until we were past
+Reading. Then he suddenly rolled them all into a gigantic ball, and
+tossed them up onto the rack.
+
+“Have you heard anything of the case?” he asked.
+
+“Not a word. I have not seen a paper for some days.”
+
+“The London press has not had very full accounts. I have just
+been looking through all the recent papers in order to master the
+particulars. It seems, from what I gather, to be one of those simple
+cases which are so extremely difficult.”
+
+“That sounds a little paradoxical.”
+
+“But it is profoundly true. Singularity is almost invariably a clew.
+The more featureless and commonplace a crime is, the more difficult is
+it to bring it home. In this case, however, they have established a
+very serious case against the son of the murdered man.”
+
+“It is a murder, then?”
+
+“Well, it is conjectured to be so. I shall take nothing for granted
+until I have the opportunity of looking personally into it. I will
+explain the state of things to you, as far as I have been able to
+understand it, in a very few words.
+
+“Boscombe Valley is a country district not very far from Ross, in
+Herefordshire. The largest landed proprietor in that part is a Mr. John
+Turner, who made his money in Australia, and returned some years ago to
+the old country. One of the farms which he held, that of Hatherley, was
+let to Mr. Charles McCarthy, who was also an ex-Australian. The men had
+known each other in the colonies, so that it was not unnatural that
+when they came to settle down they should do so as near each other as
+possible. Turner was apparently the richer man, so McCarthy became his
+tenant, but still remained, it seems, upon terms of perfect equality,
+as they were frequently together. McCarthy had one son, a lad of
+eighteen, and Turner had an only daughter of the same age, but neither
+of them had wives living. They appear to have avoided the society of
+the neighboring English families, and to have led retired lives, though
+both the McCarthys were fond of sport, and were frequently seen at
+the race-meetings of the neighborhood. McCarthy kept two servants—a
+man and a girl. Turner had a considerable household, some half-dozen
+at the least. That is as much as I have been able to gather about the
+families. Now for the facts.
+
+“On June 3, that is, on Monday last, McCarthy left his house at
+Hatherley about three in the afternoon, and walked down to the Boscombe
+Pool, which is a small lake formed by the spreading out of the
+stream which runs down the Boscombe Valley. He had been out with his
+serving-man in the morning at Ross, and he had told the man that he
+must hurry, as he had an appointment of importance to keep at three.
+From that appointment he never came back alive.
+
+“From Hatherley Farm-house to the Boscombe Pool is a quarter of a mile,
+and two people saw him as he passed over this ground. One was an old
+woman, whose name is not mentioned, and the other was William Crowder,
+a game-keeper in the employ of Mr. Turner. Both these witnesses depose
+that Mr. McCarthy was walking alone. The game-keeper adds that within
+a few minutes of his seeing Mr. McCarthy pass he had seen his son, Mr.
+James McCarthy, going the same way with a gun under his arm. To the
+best of his belief, the father was actually in sight at the time, and
+the son was following him. He thought no more of the matter until he
+heard in the evening of the tragedy that had occurred.
+
+“The two McCarthys were seen after the time when William Crowder, the
+game-keeper, lost sight of them. The Boscombe Pool is thickly-wooded
+round, with just a fringe of grass and of reeds round the edge. A girl
+of fourteen, Patience Moran, who is the daughter of the lodge-keeper of
+the Boscombe Valley estate, was in one of the woods picking flowers.
+She states that while she was there she saw, at the border of the wood
+and close by the lake, Mr. McCarthy and his son, and that they appeared
+to be having a violent quarrel. She heard Mr. McCarthy the elder using
+very strong language to his son, and she saw the latter raise up
+his hand as if to strike his father. She was so frightened by their
+violence that she ran away, and told her mother when she reached home
+that she had left the two McCarthys quarrelling near Boscombe Pool, and
+that she was afraid that they were going to fight. She had hardly said
+the words when young Mr. McCarthy came running up to the lodge to say
+that he had found his father dead in the wood, and to ask for the help
+of the lodge-keeper. He was much excited, without either his gun or his
+hat, and his right hand and sleeve were observed to be stained with
+fresh blood. On following him they found the dead body stretched out
+upon the grass beside the Pool. The head had been beaten in by repeated
+blows of some heavy and blunt weapon. The injuries were such as might
+very well have been inflicted by the butt-end of his son’s gun, which
+was found lying on the grass within a few paces of the body. Under
+these circumstances the young man was instantly arrested, and a verdict
+of ‘Wilful Murder’ having been returned at the inquest on Tuesday,
+he was on Wednesday brought before the magistrates at Ross, who have
+referred the case to the next assizes. Those are the main facts of the
+case as they came out before the coroner and at the police-court.”
+
+“I could hardly imagine a more damning case,” I remarked. “If ever
+circumstantial evidence pointed to a criminal it does so here.”
+
+“Circumstantial evidence is a very tricky thing,” answered Holmes,
+thoughtfully. “It may seem to point very straight to one thing, but if
+you shift your own point of view a little, you may find it pointing
+in an equally uncompromising manner to something entirely different.
+It must be confessed, however, that the case looks exceedingly grave
+against the young man, and it is very possible that he is indeed the
+culprit. There are several people in the neighborhood, however, and
+among them Miss Turner, the daughter of the neighboring land-owner,
+who believe in his innocence, and who have retained Lestrade, whom you
+may recollect in connection with the Study in Scarlet, to work out the
+case in his interest. Lestrade, being rather puzzled, has referred the
+case to me, and hence it is that two middle-aged gentlemen are flying
+westward at fifty miles an hour, instead of quietly digesting their
+breakfasts at home.”
+
+“I am afraid,” said I, “that the facts are so obvious that you will
+find little credit to be gained out of this case.”
+
+“There is nothing more deceptive than an obvious fact,” he answered,
+laughing. “Besides, we may chance to hit upon some other obvious facts
+which may have been by no means obvious to Mr. Lestrade. You know me
+too well to think that I am boasting when I say that I shall either
+confirm or destroy his theory by means which he is quite incapable of
+employing, or even of understanding. To take the first example to hand,
+I very clearly perceive that in your bedroom the window is upon the
+right-hand side, and yet I question whether Mr. Lestrade would have
+noted even so self-evident a thing as that.”
+
+“How on earth—”
+
+“My dear fellow, I know you well. I know the military neatness which
+characterizes you. You shave every morning, and in this season you
+shave by the sunlight; but since your shaving is less and less complete
+as we get farther back on the left side, until it becomes positively
+slovenly as we get round the angle of the jaw, it is surely very clear
+that that side is less well illuminated than the other. I could not
+imagine a man of your habits looking at himself in an equal light, and
+being satisfied with such a result. I only quote this as a trivial
+example of observation and inference. Therein lies my _métier_, and it
+is just possible that it may be of some service in the investigation
+which lies before us. There are one or two minor points which were
+brought out in the inquest, and which are worth considering.”
+
+[Illustration: “THEY FOUND THE BODY”]
+
+“What are they?”
+
+“It appears that his arrest did not take place at once, but after the
+return to Hatherley Farm. On the inspector of constabulary informing
+him that he was a prisoner, he remarked that he was not surprised to
+hear it, and that it was no more than his deserts. This observation of
+his had the natural effect of removing any traces of doubt which might
+have remained in the minds of the coroner’s jury.”
+
+“It was a confession,” I ejaculated.
+
+“No, for it was followed by a protestation of innocence.”
+
+“Coming on the top of such a damning series of events, it was at least
+a most suspicious remark.”
+
+“On the contrary,” said Holmes, “it is the brightest rift which I can
+at present see in the clouds. However innocent he might be, he could
+not be such an absolute imbecile as not to see that the circumstances
+were very black against him. Had he appeared surprised at his own
+arrest, or feigned indignation at it, I should have looked upon it as
+highly suspicious, because such surprise or anger would not be natural
+under the circumstances, and yet might appear to be the best policy
+to a scheming man. His frank acceptance of the situation marks him as
+either an innocent man, or else as a man of considerable self-restraint
+and firmness. As to his remark about his deserts, it was also not
+unnatural if you consider that he stood beside the dead body of his
+father, and that there is no doubt that he had that very day so far
+forgotten his filial duty as to bandy words with him, and even,
+according to the little girl whose evidence is so important, to raise
+his hand as if to strike him. The self-reproach and contrition which
+are displayed in his remark appear to me to be the signs of a healthy
+mind, rather than of a guilty one.”
+
+I shook my head. “Many men have been hanged on far slighter evidence,”
+I remarked.
+
+“So they have. And many men have been wrongfully hanged.”
+
+“What is the young man’s own account of the matter?”
+
+“It is, I am afraid, not very encouraging to his supporters, though
+there are one or two points in it which are suggestive. You will find
+it here, and may read it for yourself.”
+
+He picked out from his bundle a copy of the local Herefordshire paper,
+and having turned down the sheet, he pointed out the paragraph in which
+the unfortunate young man had given his own statement of what had
+occurred. I settled myself down in the corner of the carriage, and read
+it very carefully. It ran in this way:
+
+“Mr. James McCarthy, the only son of the deceased, was then called, and
+gave evidence as follows: ‘I had been away from home for three days at
+Bristol, and had only just returned upon the morning of last Monday,
+the 3rd. My father was absent from home at the time of my arrival, and
+I was informed by the maid that he had driven over to Ross with John
+Cobb, the groom. Shortly after my return I heard the wheels of his trap
+in the yard, and, looking out of my window, I saw him get out and walk
+rapidly out of the yard, though I was not aware in which direction he
+was going. I then took my gun, and strolled out in the direction of
+the Boscombe Pool, with the intention of visiting the rabbit-warren
+which is upon the other side. On my way I saw William Crowder, the
+game-keeper, as he had stated in his evidence; but he is mistaken in
+thinking that I was following my father. I had no idea that he was in
+front of me. When about a hundred yards from the Pool I heard a cry of
+“Cooee!” which was a usual signal between my father and myself. I then
+hurried forward, and found him standing by the Pool. He appeared to be
+much surprised at seeing me, and asked me rather roughly what I was
+doing there. A conversation ensued which led to high words, and almost
+to blows, for my father was a man of a very violent temper. Seeing
+that his passion was becoming ungovernable, I left him, and returned
+towards Hatherley Farm. I had not gone more than 150 yards, however,
+when I heard a hideous outcry behind me, which caused me to run back
+again. I found my father expiring upon the ground, with his head
+terribly injured. I dropped my gun, and held him in my arms, but he
+almost instantly expired. I knelt beside him for some minutes, and then
+made my way to Mr. Turner’s lodge-keeper, his house being the nearest,
+to ask for assistance. I saw no one near my father when I returned, and
+I have no idea how he came by his injuries. He was not a popular man,
+being somewhat cold and forbidding in his manners; but he had, as far
+as I know, no active enemies. I know nothing further of the matter.’
+
+“The Coroner: Did your father make any statement to you before he died?
+
+“Witness: He mumbled a few words, but I could only catch some allusion
+to a rat.
+
+“The Coroner: What did you understand by that?
+
+“Witness: It conveyed no meaning to me. I thought that he was delirious.
+
+“The Coroner: What was the point upon which you and your father had
+this final quarrel?
+
+“Witness: I should prefer not to answer.
+
+“The Coroner: I am afraid that I must press it.
+
+“Witness: It is really impossible for me to tell you. I can assure you
+that it has nothing to do with the sad tragedy which followed.
+
+“The Coroner: That is for the court to decide. I need not point out to
+you that your refusal to answer will prejudice your case considerably
+in any future proceedings which may arise.
+
+“Witness: I must still refuse.
+
+“The Coroner: I understand that the cry of ‘Cooee’ was a common signal
+between you and your father?
+
+“Witness: It was.
+
+“The Coroner: How was it, then, that he uttered it before he saw you,
+and before he even knew that you had returned from Bristol?
+
+“Witness (with considerable confusion): I do not know.
+
+“A Juryman: Did you see nothing which aroused your suspicions when you
+returned on hearing the cry, and found your father fatally injured?
+
+“Witness: Nothing definite.
+
+“The Coroner: What do you mean?
+
+“Witness: I was so disturbed and excited as I rushed out into the open,
+that I could think of nothing except of my father. Yet I have a vague
+impression that as I ran forward something lay upon the ground to the
+left of me. It seemed to me to be something gray in color, a coat of
+some sort, or a plaid perhaps. When I rose from my father I looked
+round for it, but it was gone.
+
+“‘Do you mean that it disappeared before you went for help?’
+
+“‘Yes, it was gone.’
+
+“‘You cannot say what it was?’
+
+“‘No, I had a feeling something was there.’
+
+“‘How far from the body?’
+
+“‘A dozen yards or so.’
+
+“‘And how far from the edge of the wood?’
+
+“‘About the same.’
+
+“‘Then if it was removed it was while you were within a dozen yards of
+it?’
+
+“‘Yes, but with my back towards it.’
+
+“This concluded the examination of the witness.”
+
+“I see,” said I, as I glanced down the column, “that the coroner in
+his concluding remarks was rather severe upon young McCarthy. He calls
+attention, and with reason, to the discrepancy about his father having
+signalled to him before seeing him, also to his refusal to give details
+of his conversation with his father, and his singular account of his
+father’s dying words. They are all, as he remarks, very much against
+the son.”
+
+Holmes laughed softly to himself, and stretched himself out upon the
+cushioned seat. “Both you and the coroner have been at some pains,”
+said he, “to single out the very strongest points in the young man’s
+favor. Don’t you see that you alternately give him credit for having
+too much imagination and too little. Too little, if he could not invent
+a cause of quarrel which would give him the sympathy of the jury;
+too much, if he evolved from his own inner consciousness anything
+so _outré_ as a dying reference to a rat, and the incident of the
+vanishing cloth. No, sir, I shall approach this case from the point of
+view that what this young man says is true, and we shall see whither
+that hypothesis will lead us. And now here is my pocket Petrarch, and
+not another word shall I say of this case until we are on the scene of
+action. We lunch at Swindon, and I see that we shall be there in twenty
+minutes.”
+
+It was nearly four o’clock when we at last, after passing through
+the beautiful Stroud Valley, and over the broad gleaming Severn,
+found ourselves at the pretty little country-town of Ross. A lean,
+ferret-like man, furtive and sly-looking, was waiting for us upon the
+platform. In spite of the light brown dustcoat and leather-leggings
+which he wore in deference to his rustic surroundings, I had no
+difficulty in recognizing Lestrade, of Scotland Yard. With him we drove
+to the Hereford Arms, where a room had already been engaged for us.
+
+“I have ordered a carriage,” said Lestrade, as we sat over a cup of
+tea. “I knew your energetic nature, and that you would not be happy
+until you had been on the scene of the crime.”
+
+“It was very nice and complimentary of you,” Holmes answered. “It is
+entirely a question of barometric pressure.”
+
+Lestrade looked startled. “I do not quite follow,” he said.
+
+“How is the glass? Twenty-nine, I see. No wind, and not a cloud in the
+sky. I have a caseful of cigarettes here which need smoking, and the
+sofa is very much superior to the usual country hotel abomination. I do
+not think that it is probable that I shall use the carriage to-night.”
+
+Lestrade laughed indulgently. “You have, no doubt, already formed your
+conclusions from the newspapers,” he said. “The case is as plain as a
+pikestaff, and the more one goes into it the plainer it becomes. Still,
+of course, one can’t refuse a lady, and such a very positive one, too.
+She had heard of you, and would have your opinion, though I repeatedly
+told her that there was nothing which you could do which I had not
+already done. Why, bless my soul! here is her carriage at the door.”
+
+He had hardly spoken before there rushed into the room one of the most
+lovely young women that I have ever seen in my life. Her violet eyes
+shining, her lips parted, a pink flush upon her cheeks, all thought of
+her natural reserve lost in her overpowering excitement and concern.
+
+“Oh, Mr. Sherlock Holmes!” she cried, glancing from one to the other
+of us, and finally, with a woman’s quick intuition, fastening upon my
+companion, “I am so glad that you have come. I have driven down to tell
+you so. I know that James didn’t do it. I know it, and I want you to
+start upon your work knowing it, too. Never let yourself doubt upon
+that point. We have known each other since we were little children, and
+I know his faults as no one else does; but he is too tender-hearted to
+hurt a fly. Such a charge is absurd to any one who really knows him.”
+
+“I hope we may clear him, Miss Turner,” said Sherlock Holmes. “You may
+rely upon my doing all that I can.”
+
+“But you have read the evidence. You have formed some conclusion? Do
+you not see some loophole, some flaw? Do you not yourself think that he
+is innocent?”
+
+“I think that it is very probable.”
+
+“There, now!” she cried, throwing back her head, and looking defiantly
+at Lestrade. “You hear! He gives me hopes.”
+
+Lestrade shrugged his shoulders. “I am afraid that my colleague has
+been a little quick in forming his conclusions,” he said.
+
+“But he is right. Oh! I know that he is right. James never did it. And
+about his quarrel with his father, I am sure that the reason why he
+would not speak about it to the coroner was because I was concerned in
+it.”
+
+“In what way?” asked Holmes.
+
+“It is no time for me to hide anything. James and his father had many
+disagreements about me. Mr. McCarthy was very anxious that there should
+be a marriage between us. James and I have always loved each other as
+brother and sister; but of course he is young, and has seen very little
+of life yet, and—and—well, he naturally did not wish to do anything
+like that yet. So there were quarrels, and this, I am sure, was one of
+them.”
+
+“And your father?” asked Holmes. “Was he in favor of such a union?”
+
+“No, he was averse to it also. No one but Mr. McCarthy was in favor of
+it.” A quick blush passed over her fresh young face as Holmes shot one
+of his keen, questioning glances at her.
+
+“Thank you for this information,” said he. “May I see your father if I
+call to-morrow?”
+
+“I am afraid the doctor won’t allow it.”
+
+“The doctor?”
+
+“Yes, have you not heard? Poor father has never been strong for years
+back, but this has broken him down completely. He has taken to his bed,
+and Dr. Willows says that he is a wreck, and that his nervous system is
+shattered. Mr. McCarthy was the only man alive who had known dad in the
+old days in Victoria.”
+
+“Ha! In Victoria! That is important.”
+
+“Yes, at the mines.”
+
+“Quite so; at the gold-mines, where, as I understand, Mr. Turner made
+his money.”
+
+“Yes, certainly.”
+
+“Thank you, Miss Turner. You have been of material assistance to me.”
+
+“You will tell me if you have any news to-morrow. No doubt you will go
+to the prison to see James. Oh, if you do, Mr. Holmes, do tell him that
+I know him to be innocent.”
+
+“I will, Miss Turner.”
+
+“I must go home now, for dad is very ill, and he misses me so if I
+leave him. Good-bye, and God help you in your undertaking.” She hurried
+from the room as impulsively as she had entered, and we heard the
+wheels of her carriage rattle off down the street.
+
+“I am ashamed of you, Holmes,” said Lestrade, with dignity, after a few
+minutes’ silence. “Why should you raise up hopes which you are bound to
+disappoint? I am not over-tender of heart, but I call it cruel.”
+
+“I think that I see my way to clearing James McCarthy,” said Holmes.
+“Have you an order to see him in prison?”
+
+“Yes, but only for you and me.”
+
+“Then I shall reconsider my resolution about going out. We have still
+time to take a train to Hereford and see him to-night?”
+
+“Ample.”
+
+“Then let us do so. Watson, I fear that you will find it very slow, but
+I shall only be away a couple of hours.”
+
+I walked down to the station with them, and then wandered through the
+streets of the little town, finally returning to the hotel, where I
+lay upon the sofa and tried to interest myself in a yellow-backed
+novel. The puny plot of the story was so thin, however, when compared
+to the deep mystery through which we were groping, and I found my
+attention wander so continually from the fiction to the fact, that I
+at last flung it across the room, and gave myself up entirely to a
+consideration of the events of the day. Supposing that this unhappy
+young man’s story was absolutely true, then what hellish thing, what
+absolutely unforeseen and extraordinary calamity could have occurred
+between the time when he parted from his father, and the moment when,
+drawn back by his screams, he rushed into the glade? It was something
+terrible and deadly. What could it be? Might not the nature of the
+injuries reveal something to my medical instincts? I rang the bell,
+and called for the weekly county paper, which contained a verbatim
+account of the inquest. In the surgeon’s deposition it was stated that
+the posterior third of the left parietal bone and the left half of the
+occipital bone had been shattered by a heavy blow from a blunt weapon.
+I marked the spot upon my own head. Clearly such a blow must have been
+struck from behind. That was to some extent in favor of the accused,
+as when seen quarrelling he was face to face with his father. Still,
+it did not go for very much, for the older man might have turned his
+back before the blow fell. Still, it might be worth while to call
+Holmes’s attention to it. Then there was the peculiar dying reference
+to a rat. What could that mean? It could not be delirium. A man dying
+from a sudden blow does not commonly become delirious. No, it was more
+likely to be an attempt to explain how he met his fate. But what could
+it indicate? I cudgelled my brains to find some possible explanation.
+And then the incident of the gray cloth, seen by young McCarthy. If
+that were true, the murderer must have dropped some part of his dress,
+presumably his overcoat, in his flight, and must have had the hardihood
+to return and to carry it away at the instant when the son was kneeling
+with his back turned not a dozen paces off. What a tissue of mysteries
+and improbabilities the whole thing was! I did not wonder at Lestrade’s
+opinion, and yet I had so much faith in Sherlock Holmes’s insight that
+I could not lose hope as long as every fresh fact seemed to strengthen
+his conviction of young McCarthy’s innocence.
+
+It was late before Sherlock Holmes returned. He came back alone, for
+Lestrade was staying in lodgings in the town.
+
+“The glass still keeps very high,” he remarked, as he sat down. “It is
+of importance that it should not rain before we are able to go over the
+ground. On the other hand, a man should be at his very best and keenest
+for such nice work as that, and I did not wish to do it when fagged by
+a long journey. I have seen young McCarthy.”
+
+“And what did you learn from him?”
+
+“Nothing.”
+
+“Could he throw no light?”
+
+“None at all. I was inclined to think at one time that he knew who had
+done it, and was screening him or her, but I am convinced now that he
+is as puzzled as every one else. He is not a very quick-witted youth,
+though comely to look at, and, I should think, sound at heart.”
+
+“I cannot admire his taste,” I remarked, “if it is indeed a fact that
+he was averse to a marriage with so charming a young lady as this Miss
+Turner.”
+
+“Ah, thereby hangs a rather painful tale. This fellow is madly,
+insanely in love with her, but some two years ago, when he was only a
+lad, and before he really knew her, for she had been away five years at
+a boarding-school, what does the idiot do but get into the clutches of
+a barmaid in Bristol, and marry her at a registry office? No one knows
+a word of the matter, but you can imagine how maddening it must be to
+him to be upbraided for not doing what he would give his very eyes to
+do, but what he knows to be absolutely impossible. It was sheer frenzy
+of this sort which made him throw his hands up into the air when his
+father, at their last interview, was goading him on to propose to Miss
+Turner. On the other hand, he had no means of supporting himself, and
+his father, who was by all accounts a very hard man, would have thrown
+him over utterly had he known the truth. It was with his barmaid wife
+that he had spent the last three days in Bristol, and his father did
+not know where he was. Mark that point. It is of importance. Good has
+come out of evil, however, for the barmaid, finding from the papers
+that he is in serious trouble, and likely to be hanged, has thrown
+him over utterly, and has written to him to say that she has a husband
+already in the Bermuda Dockyard, so that there is really no tie between
+them. I think that that bit of news has consoled young McCarthy for all
+that he has suffered.”
+
+“But if he is innocent, who has done it?”
+
+“Ah! who? I would call your attention very particularly to two points.
+One is that the murdered man had an appointment with some one at the
+Pool, and that the some one could not have been his son, for his son
+was away, and he did not know when he would return. The second is that
+the murdered man was heard to cry ‘Cooee!’ before he knew that his son
+had returned. Those are the crucial points upon which the case depends.
+And now let us talk about George Meredith, if you please, and we shall
+leave all minor matters until to-morrow.”
+
+There was no rain, as Holmes had foretold, and the morning broke
+bright and cloudless. At nine o’clock Lestrade called for us with the
+carriage, and we set off for Hatherley Farm and the Boscombe Pool.
+
+“There is serious news this morning,” Lestrade observed. “It is said
+that Mr. Turner, of the Hall, is so ill that his life is despaired of.”
+
+“An elderly man, I presume?” said Holmes.
+
+“About sixty; but his constitution has been shattered by his life
+abroad, and he has been in failing health for some time. This business
+has had a very bad effect upon him. He was an old friend of McCarthy’s,
+and, I may add, a great benefactor to him, for I have learned that he
+gave him Hatherley Farm rent free.”
+
+“Indeed! That is interesting,” said Holmes.
+
+“Oh yes! In a hundred other ways he has helped him. Everybody about
+here speaks of his kindness to him.”
+
+“Really! Does it not strike you as a little singular that this
+McCarthy, who appears to have had little of his own, and to have been
+under such obligations to Turner, should still talk of marrying his
+son to Turner’s daughter, who is, presumably, heiress to the estate,
+and that in such a very cocksure manner, as if it were merely a case of
+a proposal and all else would follow? It is the more strange, since we
+know that Turner himself was averse to the idea. The daughter told us
+as much. Do you not deduce something from that?”
+
+“We have got to the deductions and the inferences,” said Lestrade,
+winking at me. “I find it hard enough to tackle facts, Holmes, without
+flying away after theories and fancies.”
+
+“You are right,” said Holmes, demurely; “you do find it very hard to
+tackle the facts.”
+
+“Anyhow, I have grasped one fact which you seem to find it difficult to
+get hold of,” replied Lestrade, with some warmth.
+
+“And that is—”
+
+“That McCarthy, senior, met his death from McCarthy, junior, and that
+all theories to the contrary are the merest moonshine.”
+
+“Well, moonshine is a brighter thing than fog,” said Holmes, laughing.
+“But I am very much mistaken if this is not Hatherley Farm upon the
+left.”
+
+“Yes, that is it.” It was a wide-spread, comfortable-looking building,
+two-storied, slate roofed, with great yellow blotches of lichen upon
+the gray walls. The drawn blinds and the smokeless chimneys, however,
+gave it a stricken look, as though the weight of this horror still
+lay heavy upon it. We called at the door, when the maid, at Holmes’s
+request, showed us the boots which her master wore at the time of his
+death, and also a pair of the son’s, though not the pair which he had
+then had. Having measured these very carefully from seven or eight
+different points, Holmes desired to be led to the court-yard, from
+which we all followed the winding track which led to Boscombe Pool.
+
+[Illustration: “THE MAID SHOWED US THE BOOTS.”]
+
+Sherlock Holmes was transformed when he was hot upon such a scent
+as this. Men who had only known the quiet thinker and logician of
+Baker Street would have failed to recognize him. His face flushed and
+darkened. His brows were drawn into two hard, black lines, while his
+eyes shone out from beneath them with a steely glitter. His face was
+bent downward, his shoulders bowed, his lips compressed, and the veins
+stood out like whip-cord in his long, sinewy neck. His nostrils seemed
+to dilate with a purely animal lust for the chase, and his mind was so
+absolutely concentrated upon the matter before him, that a question
+or remark fell unheeded upon his ears, or, at the most, only provoked
+a quick, impatient snarl in reply. Swiftly and silently he made his
+way along the track which ran through the meadows, and so by way of
+the woods to the Boscombe Pool. It was damp, marshy ground, as is all
+that district, and there were marks of many feet, both upon the path
+and amid the short grass which bounded it on either side. Sometimes
+Holmes would hurry on, sometimes stop dead, and once he made quite a
+little _détour_ into the meadow. Lestrade and I walked behind him, the
+detective indifferent and contemptuous, while I watched my friend with
+the interest which sprang from the conviction that every one of his
+actions was directed towards a definite end.
+
+The Boscombe Pool, which is a little reed-girt sheet of water some
+fifty yards across, is situated at the boundary between the Hatherley
+Farm and the private park of the wealthy Mr. Turner. Above the woods
+which lined it upon the farther side we could see the red, jutting
+pinnacles which marked the site of the rich land-owner’s dwelling. On
+the Hatherley side of the Pool the woods grew very thick, and there was
+a narrow belt of sodden grass twenty paces across between the edge of
+the trees and the reeds which lined the lake. Lestrade showed us the
+exact spot at which the body had been found, and, indeed, so moist was
+the ground, that I could plainly see the traces which had been left by
+the fall of the stricken man. To Holmes, as I could see by his eager
+face and peering eyes, very many other things were to be read upon the
+trampled grass. He ran round, like a dog who is picking up a scent, and
+then turned upon my companion.
+
+“What did you go into the Pool for?” he asked.
+
+“I fished about with a rake. I thought there might be some weapon or
+other trace. But how on earth—”
+
+“Oh, tut, tut! I have no time! That left foot of yours with its inward
+twist is all over the place. A mole could trace it, and there it
+vanishes among the reeds. Oh, how simple it would all have been had I
+been here before they came like a herd of buffalo, and wallowed all
+over it. Here is where the party with the lodge-keeper came, and they
+have covered all tracks for six or eight feet round the body. But
+here are three separate tracks of the same feet.” He drew out a lens,
+and lay down upon his waterproof to have a better view, talking all
+the time rather to himself than to us. “These are young McCarthy’s
+feet. Twice he was walking, and once he ran swiftly so that the soles
+are deeply marked, and the heels hardly visible. That bears out his
+story. He ran when he saw his father on the ground. Then here are the
+father’s feet as he paced up and down. What is this, then? It is the
+butt-end of the gun as the son stood listening. And this? Ha, ha! What
+have we here? Tiptoes! tiptoes! Square, too, quite unusual boots! They
+come, they go, they come again—of course that was for the cloak.
+Now where did they come from?” He ran up and down, sometimes losing,
+sometimes finding the track until we were well within the edge of the
+wood, and under the shadow of a great beech, the largest tree in the
+neighborhood. Holmes traced his way to the farther side of this, and
+lay down once more upon his face with a little cry of satisfaction.
+For a long time he remained there, turning over the leaves and dried
+sticks, gathering up what seemed to me to be dust into an envelope, and
+examining with his lens not only the ground, but even the bark of the
+tree as far as he could reach. A jagged stone was lying among the moss,
+and this also he carefully examined and retained. Then he followed a
+pathway through the wood until he came to the high-road, where all
+traces were lost.
+
+“It has been a case of considerable interest,” he remarked, returning
+to his natural manner. “I fancy that this gray house on the right must
+be the lodge. I think that I will go in and have a word with Moran, and
+perhaps write a little note. Having done that, we may drive back to our
+luncheon. You may walk to the cab, and I shall be with you presently.”
+
+It was about ten minutes before we regained our cab, and drove back
+into Ross, Holmes still carrying with him the stone which he had picked
+up in the wood.
+
+“This may interest you, Lestrade,” he remarked, holding it out. “The
+murder was done with it.”
+
+“I see no marks.”
+
+“There are none.”
+
+“How do you know, then?”
+
+“The grass was growing under it. It had only lain there a few days.
+There was no sign of a place whence it had been taken. It corresponds
+with the injuries. There is no sign of any other weapon.”
+
+“And the murderer?”
+
+“Is a tall man, left-handed, limps with the right leg, wears
+thick-soled shooting-boots and a gray cloak, smokes Indian cigars, uses
+a cigar-holder, and carries a blunt penknife in his pocket. There are
+several other indications, but these may be enough to aid us in our
+search.”
+
+Lestrade laughed. “I am afraid that I am still a sceptic,” he said.
+“Theories are all very well, but we have to deal with a hard-headed
+British jury.”
+
+“_Nous verrons_,” answered Holmes, calmly. “You work your own method,
+and I shall work mine. I shall be busy this afternoon, and shall
+probably return to London by the evening train.”
+
+“And leave your case unfinished?”
+
+“No, finished.”
+
+“But the mystery?”
+
+“It is solved.”
+
+“Who was the criminal, then?”
+
+“The gentleman I describe.”
+
+“But who is he?”
+
+“Surely it would not be difficult to find out. This is not such a
+populous neighborhood.”
+
+Lestrade shrugged his shoulders. “I am a practical man,” he said,
+“and I really cannot undertake to go about the country looking
+for a left-handed gentleman with a game-leg. I should become the
+laughing-stock of Scotland Yard.”
+
+“All right,” said Holmes, quietly. “I have given you the chance. Here
+are your lodgings. Good-bye. I shall drop you a line before I leave.”
+
+Having left Lestrade at his rooms, we drove to our hotel, where we
+found lunch upon the table. Holmes was silent and buried in thought
+with a pained expression upon his face, as one who finds himself in a
+perplexing position.
+
+“Look here, Watson,” he said, when the cloth was cleared; “just sit
+down in this chair and let me preach to you for a little. I don’t quite
+know what to do, and I should value your advice. Light a cigar, and let
+me expound.”
+
+“Pray do so.”
+
+“Well, now, in considering this case there are two points about young
+McCarthy’s narrative which struck us both instantly, although they
+impressed me in his favor and you against him. One was the fact that
+his father should, according to his account, cry ‘Cooee!’ before seeing
+him. The other was his singular dying reference to a rat. He mumbled
+several words, you understand, but that was all that caught the son’s
+ear. Now from this double point our research must commence, and we will
+begin it by presuming that what the lad says is absolutely true.”
+
+“What of this ‘Cooee!’ then?”
+
+“Well, obviously it could not have been meant for the son. The son, as
+far as he knew, was in Bristol. It was mere chance that he was within
+ear-shot. The ‘Cooee!’ was meant to attract the attention of whoever
+it was that he had the appointment with. But ‘Cooee’ is a distinctly
+Australian cry, and one which is used between Australians. There is a
+strong presumption that the person whom McCarthy expected to meet him
+at Boscombe Pool was some one who had been in Australia.”
+
+“What of the rat, then?”
+
+Sherlock Holmes took a folded paper from his pocket and flattened it
+out on the table. “This is a map of the Colony of Victoria,” he said.
+“I wired to Bristol for it last night.” He put his hand over part of
+the map. “What do you read?” he asked.
+
+“ARAT,” I read.
+
+“And now?” He raised his hand.
+
+“BALLARAT.”
+
+“Quite so. That was the word the man uttered, and of which his son only
+caught the last two syllables. He was trying to utter the name of his
+murderer. So-and-so, of Ballarat.”
+
+“It is wonderful!” I exclaimed.
+
+“It is obvious. And now, you see, I had narrowed the field down
+considerably. The possession of a gray garment was a third point
+which, granting the son’s statement to be correct, was a certainty. We
+have come now out of mere vagueness to the definite conception of an
+Australian from Ballarat with a gray cloak.”
+
+“Certainly.”
+
+“And one who was at home in the district, for the Pool can only be
+approached by the farm or by the estate, where strangers could hardly
+wander.”
+
+“Quite so.”
+
+“Then comes our expedition of to-day. By an examination of the ground I
+gained the trifling details which I gave to that imbecile Lestrade, as
+to the personality of the criminal.”
+
+“But how did you gain them?”
+
+“You know my method. It is founded upon the observance of trifles.”
+
+“His height I know that you might roughly judge from the length of his
+stride. His boots, too, might be told from their traces.”
+
+“Yes, they were peculiar boots.”
+
+“But his lameness?”
+
+“The impression of his right foot was always less distinct than his
+left. He put less weight upon it. Why? Because he limped—he was lame.”
+
+“But his left-handedness.”
+
+“You were yourself struck by the nature of the injury as recorded
+by the surgeon at the inquest. The blow was struck from immediately
+behind, and yet was upon the left side. Now, how can that be unless it
+were by a left-handed man? He had stood behind that tree during the
+interview between the father and son. He had even smoked there. I found
+the ash of a cigar, which my special knowledge of tobacco ashes enabled
+me to pronounce as an Indian cigar. I have, as you know, devoted some
+attention to this, and written a little monograph on the ashes of 140
+different varieties of pipe, cigar, and cigarette tobacco. Having found
+the ash, I then looked round and discovered the stump among the moss
+where he had tossed it. It was an Indian cigar, of the variety which
+are rolled in Rotterdam.”
+
+“And the cigar-holder?”
+
+“I could see that the end had not been in his mouth. Therefore he used
+a holder. The tip had been cut off, not bitten off, but the cut was not
+a clean one, so I deduced a blunt pen-knife.”
+
+“Holmes,” I said, “you have drawn a net round this man from which he
+cannot escape, and you have saved an innocent human life as truly as
+if you had cut the cord which was hanging him. I see the direction in
+which all this points. The culprit is—”
+
+“Mr. John Turner,” cried the hotel waiter, opening the door of our
+sitting-room, and ushering in a visitor.
+
+The man who entered was a strange and impressive figure. His slow,
+limping step and bowed shoulders gave the appearance of decrepitude,
+and yet his hard, deep-lined, craggy features, and his enormous
+limbs showed that he was possessed of unusual strength of body and
+of character. His tangled beard, grizzled hair, and outstanding,
+drooping eyebrows combined to give an air of dignity and power to his
+appearance, but his face was of an ashen white, while his lips and the
+corners of his nostrils were tinged with a shade of blue. It was clear
+to me at a glance that he was in the grip of some deadly and chronic
+disease.
+
+“Pray sit down on the sofa,” said Holmes, gently. “You had my note?”
+
+“Yes, the lodge-keeper brought it up. You said that you wished to see
+me here to avoid scandal.”
+
+“I thought people would talk if I went to the Hall.”
+
+“And why did you wish to see me?” He looked across at my companion with
+despair in his weary eyes, as though his question was already answered.
+
+“Yes,” said Holmes, answering the look rather than the words. “It is
+so. I know all about McCarthy.”
+
+The old man sank his face in his hands. “God help me!” he cried. “But I
+would not have let the young man come to harm. I give you my word that
+I would have spoken out if it went against him at the Assizes.”
+
+“I am glad to hear you say so,” said Holmes, gravely.
+
+“I would have spoken now had it not been for my dear girl. It would
+break her heart—it will break her heart when she hears that I am
+arrested.”
+
+“It may not come to that,” said Holmes.
+
+“What!”
+
+“I am no official agent. I understand that it was your daughter who
+required my presence here, and I am acting in her interests. Young
+McCarthy must be got off, however.”
+
+“I am a dying man,” said old Turner. “I have had diabetes for years. My
+doctor says it is a question whether I shall live a month. Yet I would
+rather die under my own roof than in a jail.”
+
+Holmes rose and sat down at the table with his pen in his hand and a
+bundle of paper before him. “Just tell us the truth,” he said. “I
+shall jot down the facts. You will sign it, and Watson here can witness
+it. Then I could produce your confession at the last extremity to save
+young McCarthy. I promise you that I shall not use it unless it is
+absolutely needed.”
+
+“It’s as well,” said the old man; “it’s a question whether I shall live
+to the Assizes, so it matters little to me, but I should wish to spare
+Alice the shock. And now I will make the thing clear to you; it has
+been a long time in the acting, but will not take me long to tell.
+
+“You didn’t know this dead man, McCarthy. He was a devil incarnate. I
+tell you that. God keep you out of the clutches of such a man as he.
+His grip has been upon me these twenty years, and he has blasted my
+life. I’ll tell you first how I came to be in his power.
+
+“It was in the early sixties at the diggings. I was a young chap then,
+hot-blooded and reckless, ready to turn my hand at anything; I got
+among bad companions, took to drink, had no luck with my claim, took to
+the bush, and in a word became what you would call over here a highway
+robber. There were six of us, and we had a wild, free life of it,
+sticking up a station from time to time, or stopping the wagons on the
+road to the diggings. Black Jack of Ballarat was the name I went under,
+and our party is still remembered in the colony as the Ballarat Gang.
+
+“One day a gold convoy came down from Ballarat to Melbourne, and we
+lay in wait for it and attacked it. There were six troopers and six of
+us, so it was a close thing, but we emptied four of their saddles at
+the first volley. Three of our boys were killed, however, before we
+got the swag. I put my pistol to the head of the wagon-driver, who was
+this very man McCarthy. I wish to the Lord that I had shot him then,
+but I spared him, though I saw his wicked little eyes fixed on my face,
+as though to remember every feature. We got away with the gold, became
+wealthy men, and made our way over to England without being suspected.
+There I parted from my old pals, and determined to settle down to a
+quiet and respectable life. I bought this estate, which chanced to be
+in the market, and I set myself to do a little good with my money,
+to make up for the way in which I had earned it. I married, too, and
+though my wife died young, she left me my dear little Alice. Even when
+she was just a baby her wee hand seemed to lead me down the right path
+as nothing else had ever done. In a word, I turned over a new leaf, and
+did my best to make up for the past. All was going well when McCarthy
+laid his grip upon me.
+
+“I had gone up to town about an investment, and I met him in Regent
+Street with hardly a coat to his back or a boot to his foot.
+
+“‘Here we are, Jack,’ says he, touching me on the arm; ‘we’ll be as
+good as a family to you. There’s two of us, me and my son, and you can
+have the keeping of us. If you don’t—it’s a fine, law-abiding country
+is England, and there’s always a policeman within hail.’
+
+“Well, down they came to the West country, there was no shaking them
+off, and there they have lived rent free on my best land ever since.
+There was no rest for me, no peace, no forgetfulness; turn where I
+would, there was his cunning, grinning face at my elbow. It grew worse
+as Alice grew up, for he soon saw I was more afraid of her knowing my
+past than of the police. Whatever he wanted he must have, and whatever
+it was I gave him without question, land, money, houses, until at last
+he asked a thing which I could not give. He asked for Alice.
+
+“His son, you see, had grown up, and so had my girl, and as I was known
+to be in weak health, it seemed a fine stroke to him that his lad
+should step into the whole property. But there I was firm. I would not
+have his cursed stock mixed with mine; not that I had any dislike to
+the lad, but his blood was in him, and that was enough. I stood firm.
+McCarthy threatened. I braved him to do his worst. We were to meet at
+the Pool midway between our houses to talk it over.
+
+“When I went down there I found him talking with his son, so I smoked
+a cigar, and waited behind a tree until he should be alone. But as I
+listened to his talk all that was black and bitter in me seemed to
+come uppermost. He was urging his son to marry my daughter with as
+little regard for what she might think as if she were a slut from off
+the streets. It drove me mad to think that I and all that I held most
+dear should be in the power of such a man as this. Could I not snap the
+bond? I was already a dying and a desperate man. Though clear of mind
+and fairly strong of limb, I knew that my own fate was sealed. But my
+memory and my girl! Both could be saved, if I could but silence that
+foul tongue. I did it, Mr. Holmes. I would do it again. Deeply as I
+have sinned, I have led a life of martyrdom to atone for it. But that
+my girl should be entangled in the same meshes which held me was more
+than I could suffer. I struck him down with no more compunction than if
+he had been some foul and venomous beast. His cry brought back his son;
+but I had gained the cover of the wood, though I was forced to go back
+to fetch the cloak which I had dropped in my flight. That is the true
+story, gentlemen, of all that occurred.”
+
+“Well, it is not for me to judge you,” said Holmes, as the old man
+signed the statement which had been drawn out. “I pray that we may
+never be exposed to such a temptation.”
+
+“I pray not, sir. And what do you intend to do?”
+
+“In view of your health, nothing. You are yourself aware that you will
+soon have to answer for your deed at a higher court than the Assizes.
+I will keep your confession, and, if McCarthy is condemned, I shall be
+forced to use it. If not, it shall never be seen by mortal eye; and
+your secret, whether you be alive or dead, shall be safe with us.”
+
+“Farewell, then,” said the old man, solemnly. “Your own death-beds,
+when they come, will be the easier for the thought of the peace which
+you have given to mine.” Tottering and shaking in all his giant frame,
+he stumbled slowly from the room.
+
+“God help us!” said Holmes, after a long silence. “Why does fate play
+such tricks with poor, helpless worms? I never hear of such a case as
+this that I do not think of Baxter’s words, and say, ‘There, but for
+the grace of God, goes Sherlock Holmes.’”
+
+James McCarthy was acquitted at the Assizes, on the strength of a
+number of objections which had been drawn out by Holmes, and submitted
+to the defending counsel. Old Turner lived for seven months after our
+interview, but he is now dead; and there is every prospect that the son
+and daughter may come to live happily together, in ignorance of the
+black cloud which rests upon their past.
+
+
+
+
+Adventure V
+
+THE FIVE ORANGE PIPS
+
+
+When I glance over my notes and records of the Sherlock Holmes cases
+between the years ’82 and ’90, I am faced by so many which present
+strange and interesting features that it is no easy matter to know
+which to choose and which to leave. Some, however, have already gained
+publicity through the papers, and others have not offered a field
+for those peculiar qualities which my friend possessed in so high a
+degree, and which it is the object of these papers to illustrate. Some,
+too, have baffled his analytical skill, and would be, as narratives,
+beginnings without an ending, while others have been but partially
+cleared up, and have their explanations founded rather upon conjecture
+and surmise than on that absolute logical proof which was so dear to
+him. There is, however, one of these last which was so remarkable in
+its details and so startling in its results that I am tempted to give
+some account of it, in spite of the fact that there are points in
+connection with it which never have been, and probably never will be,
+entirely cleared up.
+
+The year ’87 furnished us with a long series of cases of greater
+or less interest, of which I retain the records. Among my headings
+under this one twelve months I find an account of the adventure of
+the Paradol Chamber, of the Amateur Mendicant Society, who held a
+luxurious club in the lower vault of a furniture warehouse, of the
+facts connected with the loss of the British bark _Sophy Anderson_, of
+the singular adventures of the Grice Patersons in the island of Uffa,
+and finally of the Camberwell poisoning case. In the latter, as may
+be remembered, Sherlock Holmes was able, by winding up the dead man’s
+watch, to prove that it had been wound up two hours before, and that
+therefore the deceased had gone to bed within that time—a deduction
+which was of the greatest importance in clearing up the case. All these
+I may sketch out at some future date, but none of them present such
+singular features as the strange train of circumstances which I have
+now taken up my pen to describe.
+
+It was in the latter days of September, and the equinoctial gales had
+set in with exceptional violence. All day the wind had screamed and the
+rain had beaten against the windows, so that even here in the heart
+of great, hand-made London we were forced to raise our minds for the
+instant from the routine of life, and to recognize the presence of
+those great elemental forces which shriek at mankind through the bars
+of his civilization, like untamed beasts in a cage. As evening drew in,
+the storm grew higher and louder, and the wind cried and sobbed like a
+child in the chimney. Sherlock Holmes sat moodily at one side of the
+fireplace cross-indexing his records of crime, while I at the other was
+deep in one of Clark Russell’s fine sea-stories, until the howl of the
+gale from without seemed to blend with the text, and the splash of the
+rain to lengthen out into the long swash of the sea waves. My wife was
+on a visit to her mother’s, and for a few days I was a dweller once
+more in my old quarters at Baker Street.
+
+“Why,” said I, glancing up at my companion, “that was surely the bell.
+Who could come to-night? Some friend of yours, perhaps?”
+
+“Except yourself I have none,” he answered. “I do not encourage
+visitors.”
+
+“A client, then?”
+
+“If so, it is a serious case. Nothing less would bring a man out on
+such a day and at such an hour. But I take it that it is more likely to
+be some crony of the landlady’s.”
+
+Sherlock Holmes was wrong in his conjecture, however, for there came
+a step in the passage and a tapping at the door. He stretched out his
+long arm to turn the lamp away from himself and towards the vacant
+chair upon which a new-comer must sit. “Come in!” said he.
+
+The man who entered was young, some two-and-twenty at the outside,
+well-groomed and trimly clad, with something of refinement and delicacy
+in his bearing. The steaming umbrella which he held in his hand, and
+his long shining waterproof told of the fierce weather through which he
+had come. He looked about him anxiously in the glare of the lamp, and
+I could see that his face was pale and his eyes heavy, like those of a
+man who is weighed down with some great anxiety.
+
+“I owe you an apology,” he said, raising his golden _pince-nez_ to his
+eyes. “I trust that I am not intruding. I fear that I have brought some
+traces of the storm and rain into your snug chamber.”
+
+“Give me your coat and umbrella,” said Holmes. “They may rest here
+on the hook, and will be dry presently. You have come up from the
+south-west, I see.”
+
+“Yes, from Horsham.”
+
+“That clay and chalk mixture which I see upon your toe-caps is quite
+distinctive.”
+
+“I have come for advice.”
+
+“That is easily got.”
+
+“And help.”
+
+“That is not always so easy.”
+
+“I have heard of you, Mr. Holmes. I heard from Major Prendergast how
+you saved him in the Tankerville Club Scandal.”
+
+“Ah, of course. He was wrongfully accused of cheating at cards.”
+
+“He said that you could solve anything.”
+
+“He said too much.”
+
+“That you are never beaten.”
+
+“I have been beaten four times—three times by men, and once by a
+woman.”
+
+“But what is that compared with the number of your successes?”
+
+“It is true that I have been generally successful.”
+
+“Then you may be so with me.”
+
+“I beg that you will draw your chair up to the fire, and favor me with
+some details as to your case.”
+
+“It is no ordinary one.”
+
+“None of those which come to me are. I am the last court of appeal.”
+
+“And yet I question, sir, whether, in all your experience, you have
+ever listened to a more mysterious and inexplicable chain of events
+than those which have happened in my own family.”
+
+“You fill me with interest,” said Holmes. “Pray give us the essential
+facts from the commencement, and I can afterwards question you as to
+those details which seem to me to be most important.”
+
+The young man pulled his chair up, and pushed his wet feet out towards
+the blaze.
+
+“My name,” said he, “is John Openshaw, but my own affairs have, as far
+as I can understand it, little to do with this awful business. It is an
+hereditary matter; so in order to give you an idea of the facts, I must
+go back to the commencement of the affair.
+
+“You must know that my grandfather had two sons—my uncle Elias and
+my father Joseph. My father had a small factory at Coventry, which
+he enlarged at the time of the invention of bicycling. He was the
+patentee of the Openshaw unbreakable tire, and his business met with
+such success that he was able to sell it, and to retire upon a handsome
+competence.
+
+“My uncle Elias emigrated to America when he was a young man, and
+became a planter in Florida, where he was reported to have done
+very well. At the time of the war he fought in Jackson’s army, and
+afterwards under Hood, where he rose to be a colonel. When Lee laid
+down his arms my uncle returned to his plantation, where he remained
+for three or four years. About 1869 or 1870 he came back to Europe,
+and took a small estate in Sussex, near Horsham. He had made a very
+considerable fortune in the States, and his reason for leaving them was
+his aversion to the negroes, and his dislike of the Republican policy
+in extending the franchise to them. He was a singular man, fierce and
+quick-tempered, very foul-mouthed when he was angry, and of a most
+retiring disposition. During all the years that he lived at Horsham I
+doubt if ever he set foot in the town. He had a garden and two or three
+fields round his house, and there he would take his exercise, though
+very often for weeks on end he would never leave his room. He drank
+a great deal of brandy, and smoked very heavily, but he would see no
+society, and did not want any friends, not even his own brother.
+
+“He didn’t mind me, in fact, he took a fancy to me, for at the time
+when he saw me first I was a youngster of twelve or so. This would be
+in the year 1878, after he had been eight or nine years in England. He
+begged my father to let me live with him, and he was very kind to me
+in his way. When he was sober he used to be fond of playing backgammon
+and draughts with me, and he would make me his representative both with
+the servants and with the tradespeople, so that by the time that I was
+sixteen I was quite master of the house. I kept all the keys, and could
+go where I liked and do what I liked, so long as I did not disturb him
+in his privacy. There was one singular exception, however, for he had
+a single room, a lumber-room up among the attics, which was invariably
+locked, and which he would never permit either me or anyone else to
+enter. With a boy’s curiosity I have peeped through the key-hole, but
+I was never able to see more than such a collection of old trunks and
+bundles as would be expected in such a room.
+
+“One day—it was in March, 1883—a letter with a foreign stamp lay
+upon the table in front of the Colonel’s plate. It was not a common
+thing for him to receive letters, for his bills were all paid in
+ready money, and he had no friends of any sort. ‘From India!’ said he,
+as he took it up, ‘Pondicherry postmark! What can this be?’ Opening
+it hurriedly, out there jumped five little dried orange pips, which
+pattered down upon his plate. I began to laugh at this, but the laugh
+was struck from my lips at the sight of his face. His lip had fallen,
+his eyes were protruding, his skin the color of putty, and he glared at
+the envelope which he still held in his trembling hand. ‘K. K. K.!’ he
+shrieked, and then, ‘My God, my God, my sins have overtaken me!’
+
+“‘What is it, uncle?’ I cried.
+
+“‘Death,’ said he, and rising from the table he retired to his room,
+leaving me palpitating with horror. I took up the envelope, and saw
+scrawled in red ink upon the inner flap, just above the gum, the letter
+K three times repeated. There was nothing else save the five dried
+pips. What could be the reason of his overpowering terror? I left the
+breakfast-table, and as I ascended the stair I met him coming down with
+an old rusty key, which must have belonged to the attic, in one hand,
+and a small brass box, like a cash-box, in the other.
+
+“‘They may do what they like, but I’ll checkmate them still,’ said he,
+with an oath. ‘Tell Mary that I shall want a fire in my room to-day,
+and send down to Fordham, the Horsham lawyer.’
+
+“I did as he ordered, and when the lawyer arrived I was asked to step
+up to the room. The fire was burning brightly, and in the grate there
+was a mass of black, fluffy ashes, as of burned paper, while the brass
+box stood open and empty beside it. As I glanced at the box I noticed,
+with a start, that upon the lid were printed the treble K which I had
+read in the morning upon the envelope.
+
+“‘I wish you, John,’ said my uncle, ‘to witness my will. I leave
+my estate, with all its advantages and all its disadvantages to my
+brother, your father, whence it will, no doubt, descend to you. If you
+can enjoy it in peace, well and good! If you find you cannot, take my
+advice, my boy, and leave it to your deadliest enemy. I am sorry to
+give you such a two-edged thing, but I can’t say what turn things are
+going to take. Kindly sign the paper where Mr. Fordham shows you.’
+
+“I signed the paper as directed, and the lawyer took it away with him.
+The singular incident made, as you may think, the deepest impression
+upon me, and I pondered over it, and turned it every way in my mind
+without being able to make anything of it. Yet I could not shake off
+the vague feeling of dread which it left behind though the sensation
+grew less keen as the weeks passed, and nothing happened to disturb
+the usual routine of our lives. I could see a change in my uncle,
+however. He drank more than ever, and he was less inclined for any
+sort of society. Most of his time he would spend in his room, with the
+door locked upon the inside, but sometimes he would emerge in a sort
+of drunken frenzy, and would burst out of the house and tear about the
+garden with a revolver in his hand, screaming out that he was afraid
+of no man, and that he was not to be cooped up, like a sheep in a pen,
+by man or devil. When these hot fits were over, however, he would rush
+tumultuously in at the door, and lock and bar it behind him, like a man
+who can brazen it out no longer against the terror which lies at the
+roots of his soul. At such times I have seen his face, even on a cold
+day, glisten with moisture, as though it were new raised from a basin.
+
+“Well, to come to an end of the matter, Mr. Holmes, and not to abuse
+your patience, there came a night when he made one of those drunken
+sallies from which he never came back. We found him, when we went to
+search for him, face downward in a little green-scummed pool, which lay
+at the foot of the garden. There was no sign of any violence, and the
+water was but two feet deep, so that the jury, having regard to his
+known eccentricity, brought in a verdict of suicide. But I, who knew
+how he winced from the very thought of death, had much ado to persuade
+myself that he had gone out of his way to meet it. The matter passed,
+however, and my father entered into possession of the estate, and of
+some £14,000, which lay to his credit at the bank.”
+
+“One moment,” Holmes interposed. “Your statement is, I foresee, one
+of the most remarkable to which I have ever listened. Let me have the
+date of the reception by your uncle of the letter, and the date of his
+supposed suicide.”
+
+“The latter arrived on March 10, 1883. His death was seven weeks later,
+upon the night of May 2d.”
+
+“Thank you. Pray proceed.”
+
+“When my father took over the Horsham property, he, at my request, made
+a careful examination of the attic, which had been always locked up. We
+found the brass box there, although its contents had been destroyed. On
+the inside of the cover was a paper label, with the initials of K. K.
+K. repeated upon it, and ‘Letters, memoranda, receipts, and a register’
+written beneath. These, we presume, indicated the nature of the papers
+which had been destroyed by Colonel Openshaw. For the rest, there was
+nothing of much importance in the attic, save a great many scattered
+papers and note-books bearing upon my uncle’s life in America. Some
+of them were of the war time, and showed that he had done his duty
+well, and had borne the repute of a brave soldier. Others were of a
+date during the reconstruction of the Southern States, and were mostly
+concerned with politics, for he had evidently taken a strong part in
+opposing the carpet-bag politicians who had been sent down from the
+North.
+
+“Well, it was the beginning of ’84 when my father came to live at
+Horsham, and all went as well as possible with us until the January
+of ’85. On the fourth day after the new year I heard my father give a
+sharp cry of surprise as we sat together at the breakfast-table. There
+he was, sitting with a newly-opened envelope in one hand and five dried
+orange pips in the outstretched palm of the other one. He had always
+laughed at what he called my cock-and-a-bull story about the Colonel,
+but he looked very scared and puzzled now that the same thing had come
+upon himself.
+
+“‘Why, what on earth does this mean, John?’ he stammered.
+
+“My heart had turned to lead. ‘It is K. K. K.,’ said I.
+
+“He looked inside the envelope. ‘So it is,’ he cried. ‘Here are the
+very letters. But what is this written above them?’
+
+“‘Put the papers on the sundial,’ I read, peeping over his shoulder.
+
+“‘What papers? What sundial?’ he asked.
+
+“‘The sundial in the garden. There is no other,’ said I; ‘but the
+papers must be those that are destroyed.’
+
+“‘Pooh!’ said he, gripping hard at his courage. ‘We are in a civilized
+land here, and we can’t have tomfoolery of this kind. Where does the
+thing come from?’
+
+“‘From Dundee,’ I answered, glancing at the post-mark.
+
+“‘Some preposterous practical joke,’ said he. ‘What have I to do with
+sundials and papers? I shall take no notice of such nonsense.’
+
+“‘I should certainly speak to the police,’ I said.
+
+“‘And be laughed at for my pains. Nothing of the sort.’
+
+“‘Then let me do so?’
+
+“‘No, I forbid you. I won’t have a fuss made about such nonsense.’
+
+“It was in vain to argue with him, for he was a very obstinate man. I
+went about, however, with a heart which was full of forebodings.
+
+“On the third day after the coming of the letter my father went from
+home to visit an old friend of his, Major Freebody, who is in command
+of one of the forts upon Portsdown Hill. I was glad that he should go,
+for it seemed to me that he was farther from danger when he was away
+from home. In that, however, I was in error. Upon the second day of his
+absence I received a telegram from the Major, imploring me to come at
+once. My father had fallen over one of the deep chalk-pits which abound
+in the neighborhood, and was lying senseless, with a shattered skull. I
+hurried to him, but he passed away without having ever recovered his
+consciousness. He had, as it appears, been returning from Fareham in
+the twilight, and as the country was unknown to him, and the chalk-pit
+unfenced, the jury had no hesitation in bringing in a verdict of ‘Death
+from accidental causes.’ Carefully as I examined every fact connected
+with his death, I was unable to find anything which could suggest the
+idea of murder. There were no signs of violence, no footmarks, no
+robbery, no record of strangers having been seen upon the roads. And
+yet I need not tell you that my mind was far from at ease, and that I
+was wellnigh certain that some foul plot had been woven round him.
+
+“In this sinister way I came into my inheritance. You will ask me why
+I did not dispose of it? I answer, because I was well convinced that
+our troubles were in some way dependent upon an incident in my uncle’s
+life, and that the danger would be as pressing in one house as in
+another.
+
+“It was in January, ’85, that my poor father met his end, and two years
+and eight months have elapsed since then. During that time I have lived
+happily at Horsham, and I had begun to hope that this curse had passed
+away from the family, and that it had ended with the last generation. I
+had begun to take comfort too soon, however; yesterday morning the blow
+fell in the very shape in which it had come upon my father.”
+
+The young man took from his waistcoat a crumpled envelope, and, turning
+to the table, he shook out upon it five little dried orange pips.
+
+“This is the envelope,” he continued. “The post-mark is London—eastern
+division. Within are the very words which were upon my father’s last
+message: ‘K. K. K.’; and then ‘Put the papers on the sundial.’”
+
+“What have you done?” asked Holmes.
+
+“Nothing.”
+
+“Nothing?”
+
+“To tell the truth”—he sank his face into his thin, white hands—“I
+have felt helpless. I have felt like one of those poor rabbits when
+the snake is writhing towards it. I seem to be in the grasp of some
+resistless, inexorable evil, which no foresight and no precautions can
+guard against.”
+
+“Tut! tut!” cried Sherlock Holmes. “You must act, man, or you are lost.
+Nothing but energy can save you. This is no time for despair.”
+
+“I have seen the police.”
+
+“Ah!”
+
+“But they listened to my story with a smile. I am convinced that the
+inspector has formed the opinion that the letters are all practical
+jokes, and that the deaths of my relations were really accidents, as
+the jury stated, and were not to be connected with the warnings.”
+
+Holmes shook his clenched hands in the air. “Incredible imbecility!” he
+cried.
+
+“They have, however, allowed me a policeman, who may remain in the
+house with me.”
+
+“Has he come with you to-night?”
+
+“No. His orders were to stay in the house.”
+
+Again Holmes raved in the air.
+
+“Why did you come to me?” he said; “and, above all, why did you not
+come at once?”
+
+“I did not know. It was only to-day that I spoke to Major Prendergast
+about my troubles, and was advised by him to come to you.”
+
+“It is really two days since you had the letter. We should have acted
+before this. You have no further evidence, I suppose, than that which
+you have placed before us—no suggestive detail which might help us?”
+
+“There is one thing,” said John Openshaw. He rummaged in his coat
+pocket, and drawing out a piece of discolored, blue-tinted paper, he
+laid it out upon the table. “I have some remembrance,” said he, “that
+on the day when my uncle burned the papers I observed that the small,
+unburned margins which lay amid the ashes were of this particular
+color. I found this single sheet upon the floor of his room, and I am
+inclined to think that it may be one of the papers which has, perhaps,
+fluttered out from among the others, and in that way have escaped
+destruction. Beyond the mention of pips, I do not see that it helps us
+much. I think myself that it is a page from some private diary. The
+writing is undoubtedly my uncle’s.”
+
+Holmes moved the lamp, and we both bent over the sheet of paper, which
+showed by its ragged edge that it had indeed been torn from a book. It
+was headed, “March, 1869,” and beneath were the following enigmatical
+notices:
+
+“4th. Hudson came. Same old platform.
+
+“7th. Set the pips on McCauley, Paramore, and John Swain, of St.
+Augustine.
+
+“9th. McCauley cleared.
+
+“10th. John Swain cleared.
+
+“12th. Visited Paramore. All well.”
+
+“Thank you!” said Holmes, folding up the paper, and returning it to
+our visitor. “And now you must on no account lose another instant. We
+cannot spare time even to discuss what you have told me. You must get
+home instantly and act.”
+
+“What shall I do?”
+
+“There is but one thing to do. It must be done at once. You must put
+this piece of paper which you have shown us into the brass box which
+you have described. You must also put in a note to say that all the
+other papers were burned by your uncle, and that this is the only
+one which remains. You must assert that in such words as will carry
+conviction with them. Having done this, you must at once put the box
+out upon the sundial, as directed. Do you understand?”
+
+“Entirely.”
+
+“Do not think of revenge, or anything of the sort, at present. I think
+that we may gain that by means of the law; but we have our web to
+weave, while theirs is already woven. The first consideration is to
+remove the pressing danger which threatens you. The second is to clear
+up the mystery and to punish the guilty parties.”
+
+“I thank you,” said the young man, rising, and pulling on his overcoat.
+“You have given me fresh life and hope. I shall certainly do as you
+advise.”
+
+“Do not lose an instant. And, above all, take care of yourself in the
+meanwhile, for I do not think that there can be a doubt that you are
+threatened by a very real and imminent danger. How do you go back?”
+
+“By train from Waterloo.”
+
+“It is not yet nine. The streets will be crowded, so I trust that you
+may be in safety. And yet you cannot guard yourself too closely.”
+
+“I am armed.”
+
+“That is well. To-morrow I shall set to work upon your case.”
+
+“I shall see you at Horsham, then?”
+
+“No, your secret lies in London. It is there that I shall seek it.”
+
+“Then I shall call upon you in a day, or in two days, with news as to
+the box and the papers. I shall take your advice in every particular.”
+He shook hands with us, and took his leave. Outside the wind still
+screamed, and the rain splashed and pattered against the windows.
+This strange, wild story seemed to have come to us from amid the mad
+elements—blown in upon us like a sheet of sea-weed in a gale—and now
+to have been reabsorbed by them once more.
+
+Sherlock Holmes sat for some time in silence, with his head sunk
+forward and his eyes bent upon the red glow of the fire. Then he lit
+his pipe, and leaning back in his chair he watched the blue smoke-rings
+as they chased each other up to the ceiling.
+
+“I think, Watson,” he remarked at last, “that of all our cases we have
+had none more fantastic than this.”
+
+“Save, perhaps, the Sign of Four.”
+
+“Well, yes. Save, perhaps, that. And yet this John Openshaw seems to
+me to be walking amid even greater perils than did the Sholtos.”
+
+“But have you,” I asked, “formed any definite conception as to what
+these perils are?”
+
+“There can be no question as to their nature,” he answered.
+
+“Then what are they? Who is this K. K. K., and why does he pursue this
+unhappy family?”
+
+Sherlock Holmes closed his eyes and placed his elbows upon the arms
+of his chair, with his finger-tips together. “The ideal reasoner,” he
+remarked, “would, when he had once been shown a single fact in all
+its bearings, deduce from it not only all the chain of events which
+led up to it, but also all the results which would follow from it. As
+Cuvier could correctly describe a whole animal by the contemplation of
+a single bone, so the observer who has thoroughly understood one link
+in a series of incidents, should be able to accurately state all the
+other ones, both before and after. We have not yet grasped the results
+which the reason alone can attain to. Problems may be solved in the
+study which have baffled all those who have sought a solution by the
+aid of their senses. To carry the art, however, to its highest pitch,
+it is necessary that the reasoner should be able to utilize all the
+facts which have come to his knowledge; and this in itself implies,
+as you will readily see, a possession of all knowledge, which, even
+in these days of free education and encyclopædias, is a somewhat rare
+accomplishment. It is not so impossible, however, that a man should
+possess all knowledge which is likely to be useful to him in his work,
+and this I have endeavored in my case to do. If I remember rightly, you
+on one occasion, in the early days of our friendship, defined my limits
+in a very precise fashion.”
+
+“Yes,” I answered, laughing. “It was a singular document. Philosophy,
+astronomy, and politics were marked at zero, I remember. Botany
+variable, geology profound as regards the mud-stains from any region
+within fifty miles of town, chemistry eccentric, anatomy unsystematic,
+sensational literature and crime records unique, violin-player, boxer,
+swordsman, lawyer, and self-poisoner by cocaine and tobacco. Those, I
+think, were the main points of my analysis.”
+
+Holmes grinned at the last item. “Well,” he said, “I say now, as I said
+then, that a man should keep his little brain-attic stocked with all
+the furniture that he is likely to use, and the rest he can put away
+in the lumber-room of his library, where he can get it if he wants
+it. Now, for such a case as the one which has been submitted to us
+to-night, we need certainly to muster all our resources. Kindly hand
+me down the letter K of the American Encyclopædia which stands upon
+the shelf beside you. Thank you. Now let us consider the situation,
+and see what may be deduced from it. In the first place, we may start
+with a strong presumption that Colonel Openshaw had some very strong
+reason for leaving America. Men at his time of life do not change all
+their habits, and exchange willingly the charming climate of Florida
+for the lonely life of an English provincial town. His extreme love of
+solitude in England suggests the idea that he was in fear of some one
+or something, so we may assume as a working hypothesis that it was fear
+of some one or something which drove him from America. As to what it
+was he feared, we can only deduce that by considering the formidable
+letters which were received by himself and his successors. Did you
+remark the post-marks of those letters?”
+
+“The first was from Pondicherry, the second from Dundee, and the third
+from London.”
+
+“From East London. What do you deduce from that?”
+
+“They are all seaports. That the writer was on board of a ship.”
+
+“Excellent. We have already a clew. There can be no doubt that the
+probability—the strong probability—is that the writer was on board
+of a ship. And now let us consider another point. In the case of
+Pondicherry, seven weeks elapsed between the threat and its fulfilment,
+in Dundee it was only some three or four days. Does that suggest
+anything?”
+
+“A greater distance to travel.”
+
+“But the letter had also a greater distance to come.”
+
+“Then I do not see the point.”
+
+“There is at least a presumption that the vessel in which the man
+or men are is a sailing-ship. It looks as if they always sent their
+singular warning or token before them when starting upon their mission.
+You see how quickly the deed followed the sign when it came from
+Dundee. If they had come from Pondicherry in a steamer they would
+have arrived almost as soon as their letter. But as a matter of fact
+seven weeks elapsed. I think that those seven weeks represented the
+difference between the mail-boat which brought the letter, and the
+sailing-vessel which brought the writer.”
+
+“It is possible.”
+
+“More than that. It is probable. And now you see the deadly urgency of
+this new case, and why I urged young Openshaw to caution. The blow has
+always fallen at the end of the time which it would take the senders to
+travel the distance. But this one comes from London, and therefore we
+cannot count upon delay.”
+
+“Good God!” I cried; “what can it mean, this relentless persecution?”
+
+“The papers which Openshaw carried are obviously of vital importance
+to the person or persons in the sailing-ship. I think that it is quite
+clear that there must be more than one of them. A single man could not
+have carried out two deaths in such a way as to deceive a coroner’s
+jury. There must have been several in it, and they must have been men
+of resource and determination. Their papers they mean to have, be the
+holder of them who it may. In this way you see K. K. K. ceases to be
+the initials of an individual, and becomes the badge of a society.”
+
+“But of what society?”
+
+“Have you never—” said Sherlock Holmes, bending forward and sinking
+his voice—“have you never heard of the Ku Klux Klan?”
+
+“I never have.”
+
+Holmes turned over the leaves of the book upon his knee. “Here it
+is,” said he, presently, “‘Ku Klux Klan. A name derived from the
+fanciful resemblance to the sound produced by cocking a rifle. This
+terrible secret society was formed by some ex-Confederate soldiers in
+the Southern States after the Civil War, and it rapidly formed local
+branches in different parts of the country, notably in Tennessee,
+Louisiana, the Carolinas, Georgia, and Florida. Its power was used
+for political purposes, principally for the terrorizing of the negro
+voters, and the murdering and driving from the country of those who
+were opposed to its views. Its outrages were usually preceded by
+a warning sent to the marked man in some fantastic but generally
+recognized shape—a sprig of oak-leaves in some parts, melon seeds or
+orange pips in others. On receiving this the victim might either openly
+abjure his former ways, or might fly from the country. If he braved the
+matter out, death would unfailingly come upon him, and usually in some
+strange and unforeseen manner. So perfect was the organization of the
+society, and so systematic its methods, that there is hardly a case
+upon record where any man succeeded in braving it with impunity, or in
+which any of its outrages were traced home to the perpetrators. For
+some years the organization flourished, in spite of the efforts of the
+United States Government and of the better classes of the community in
+the South. Eventually, in the year 1869, the movement rather suddenly
+collapsed, although there have been sporadic outbreaks of the same sort
+since that date.’
+
+“You will observe,” said Holmes, laying down the volume, “that the
+sudden breaking up of the society was coincident with the disappearance
+of Openshaw from America with their papers. It may well have been cause
+and effect. It is no wonder that he and his family have some of the
+more implacable spirits upon their track. You can understand that this
+register and diary may implicate some of the first men in the South,
+and that there may be many who will not sleep easy at night until it is
+recovered.”
+
+“Then the page we have seen—”
+
+“Is such as we might expect. It ran, if I remember right, ‘sent the
+pips to A, B, and C,’—that is, sent the society’s warning to them.
+Then there are successive entries that A and B cleared, or left the
+country, and finally that C was visited, with, I fear, a sinister
+result for C. Well, I think, Doctor, that we may let some light into
+this dark place, and I believe that the only chance young Openshaw has
+in the mean time is to do what I have told him. There is nothing more
+to be said or to be done to-night, so hand me over my violin, and let
+us try to forget for half an hour the miserable weather and the still
+more miserable ways of our fellow-men.”
+
+       *       *       *       *       *
+
+It had cleared in the morning, and the sun was shining with a subdued
+brightness through the dim veil which hangs over the great city.
+Sherlock Holmes was already at breakfast when I came down.
+
+“You will excuse me for not waiting for you,” said he; “I have, I
+foresee, a very busy day before me in looking into this case of young
+Openshaw’s.”
+
+“What steps will you take?” I asked.
+
+“It will very much depend upon the results of my first inquiries. I may
+have to go down to Horsham, after all.”
+
+“You will not go there first?”
+
+“No, I shall commence with the city. Just ring the bell, and the maid
+will bring up your coffee.”
+
+As I waited, I lifted the unopened newspaper from the table and glanced
+my eye over it. It rested upon a heading which sent a chill to my heart.
+
+“Holmes,” I cried, “you are too late.”
+
+“Ah!” said he, laying down his cup, “I feared as much. How was it
+done?” He spoke calmly, but I could see that he was deeply moved.
+
+“My eye caught the name of Openshaw, and the heading, ‘Tragedy near
+Waterloo Bridge.’ Here is the account: ‘Between nine and ten last
+night Police-constable Cook, of the H Division, on duty near Waterloo
+Bridge, heard a cry for help and a splash in the water. The night,
+however, was extremely dark and stormy, so that, in spite of the help
+of several passers-by, it was quite impossible to effect a rescue.
+The alarm, however, was given, and, by the aid of the water-police,
+the body was eventually recovered. It proved to be that of a young
+gentleman whose name, as it appears from an envelope which was found in
+his pocket, was John Openshaw, and whose residence is near Horsham. It
+is conjectured that he may have been hurrying down to catch the last
+train from Waterloo Station, and that in his haste and the extreme
+darkness he missed his path and walked over the edge of one of the
+small landing-places for river steamboats. The body exhibited no traces
+of violence, and there can be no doubt that the deceased had been
+the victim of an unfortunate accident, which should have the effect
+of calling the attention of the authorities to the condition of the
+river-side landing-stages.’”
+
+We sat in silence for some minutes, Holmes more depressed and shaken
+than I had ever seen him.
+
+“That hurts my pride, Watson,” he said, at last. “It is a petty
+feeling, no doubt, but it hurts my pride. It becomes a personal matter
+with me now, and, if God sends me health, I shall set my hand upon this
+gang. That he should come to me for help, and that I should send him
+away to his death—!” He sprang from his chair and paced about the room
+in uncontrollable agitation, with a flush upon his sallow cheeks, and a
+nervous clasping and unclasping of his long, thin hands.
+
+“They must be cunning devils,” he exclaimed, at last. “How could they
+have decoyed him down there? The Embankment is not on the direct line
+to the station. The bridge, no doubt, was too crowded, even on such a
+night, for their purpose. Well, Watson, we shall see who will win in
+the long run. I am going out now!”
+
+[Illustration: “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”]
+
+“To the police?”
+
+“No; I shall be my own police. When I have spun the web they may take
+the flies, but not before.”
+
+All day I was engaged in my professional work, and it was late in the
+evening before I returned to Baker Street. Sherlock Holmes had not come
+back yet. It was nearly ten o’clock before he entered, looking pale
+and worn. He walked up to the sideboard, and, tearing a piece from the
+loaf, he devoured it voraciously, washing it down with a long draught
+of water.
+
+“You are hungry,” I remarked.
+
+“Starving. It had escaped my memory. I have had nothing since
+breakfast.”
+
+“Nothing?”
+
+“Not a bite. I had no time to think of it.”
+
+“And how have you succeeded?”
+
+“Well.”
+
+“You have a clew?”
+
+“I have them in the hollow of my hand. Young Openshaw shall not long
+remain unavenged. Why, Watson, let us put their own devilish trade-mark
+upon them. It is well thought of!”
+
+“What do you mean?”
+
+He took an orange from the cupboard, and, tearing it to pieces, he
+squeezed out the pips upon the table. Of these he took five, and thrust
+them into an envelope. On the inside of the flap he wrote “S. H. for J.
+O.” Then he sealed it and addressed it to “Captain James Calhoun, Bark
+_Lone Star_, Savannah, Georgia.”
+
+“That will await him when he enters port,” said he, chuckling. “It may
+give him a sleepless night. He will find it as sure a precursor of his
+fate as Openshaw did before him.”
+
+“And who is this Captain Calhoun?”
+
+“The leader of the gang. I shall have the others, but he first.”
+
+“How did you trace it, then?”
+
+He took a large sheet of paper from his pocket, all covered with dates
+and names.
+
+“I have spent the whole day,” said he, “over Lloyd’s registers and the
+files of the old papers, following the future career of every vessel
+which touched at Pondicherry in January and February in ’83. There
+were thirty-six ships of fair tonnage which were reported there during
+those months. Of these, one, the _Lone Star_, instantly attracted my
+attention, since, although it was reported as having cleared from
+London, the name is that which is given to one of the States of the
+Union.”
+
+“Texas, I think.”
+
+“I was not and am not sure which; but I knew that the ship must have an
+American origin.”
+
+“What then?”
+
+“I searched the Dundee records, and when I found that the bark _Lone
+Star_ was there in January, ’85, my suspicion became a certainty. I
+then inquired as to the vessels which lay at present in the port of
+London.”
+
+“Yes?”
+
+“The _Lone Star_ had arrived here last week. I went down to the Albert
+Dock, and found that she had been taken down the river by the early
+tide this morning, homeward bound to Savannah. I wired to Gravesend,
+and learned that she had passed some time ago; and as the wind is
+easterly, I have no doubt that she is now past the Goodwins, and not
+very far from the Isle of Wight.”
+
+“What will you do, then?”
+
+“Oh, I have my hand upon him. He and the two mates, are, as I learn,
+the only native-born Americans in the ship. The others are Finns and
+Germans. I know, also, that they were all three away from the ship last
+night. I had it from the stevedore who has been loading their cargo. By
+the time that their sailing-ship reaches Savannah the mail-boat will
+have carried this letter, and the cable will have informed the police
+of Savannah that these three gentlemen are badly wanted here upon a
+charge of murder.”
+
+There is ever a flaw, however, in the best laid of human plans, and
+the murderers of John Openshaw were never to receive the orange pips
+which would show them that another, as cunning and as resolute as
+themselves, was upon their track. Very long and very severe were the
+equinoctial gales that year. We waited long for news of the _Lone
+Star_ of Savannah, but none ever reached us. We did at last hear that
+somewhere far out in the Atlantic a shattered stern-post of a boat was
+seen swinging in the trough of a wave, with the letters “L. S.” carved
+upon it, and that is all which we shall ever know of the fate of the
+_Lone Star_.
+
+
+
+
+Adventure VI
+
+THE MAN WITH THE TWISTED LIP
+
+
+Isa Whitney, brother of the late Elias Whitney, D.D., Principal of the
+Theological College of St. George’s, was much addicted to opium. The
+habit grew upon him, as I understand, from some foolish freak when he
+was at college; for having read De Quincey’s description of his dreams
+and sensations, he had drenched his tobacco with laudanum in an attempt
+to produce the same effects. He found, as so many more have done, that
+the practice is easier to attain than to get rid of, and for many years
+he continued to be a slave to the drug, an object of mingled horror
+and pity to his friends and relatives. I can see him now, with yellow,
+pasty face, drooping lids, and pin-point pupils, all huddled in a
+chair, the wreck and ruin of a noble man.
+
+One night—it was in June, ’89—there came a ring to my bell, about the
+hour when a man gives his first yawn and glances at the clock. I sat up
+in my chair, and my wife laid her needle-work down in her lap and made
+a little face of disappointment.
+
+“A patient!” said she. “You’ll have to go out.”
+
+I groaned, for I was newly come back from a weary day.
+
+We heard the door open, a few hurried words, and then quick steps
+upon the linoleum. Our own door flew open, and a lady, clad in some
+dark-colored stuff, with a black veil, entered the room.
+
+“You will excuse my calling so late,” she began, and then, suddenly
+losing her self-control, she ran forward, threw her arms about my
+wife’s neck, and sobbed upon her shoulder. “Oh, I’m in such trouble!”
+she cried; “I do so want a little help.”
+
+“Why,” said my wife, pulling up her veil, “it is Kate Whitney. How you
+startled me, Kate! I had not an idea who you were when you came in.”
+
+“I didn’t know what to do, so I came straight to you.” That was always
+the way. Folk who were in grief came to my wife like birds to a
+light-house.
+
+“It was very sweet of you to come. Now, you must have some wine and
+water, and sit here comfortably and tell us all about it. Or should you
+rather that I sent James off to bed?”
+
+“Oh, no, no! I want the Doctor’s advice and help, too. It’s about Isa.
+He has not been home for two days. I am so frightened about him!”
+
+It was not the first time that she had spoken to us of her husband’s
+trouble, to me as a doctor, to my wife as an old friend and school
+companion. We soothed and comforted her by such words as we could find.
+Did she know where her husband was? Was it possible that we could bring
+him back to her?
+
+It seemed that it was. She had the surest information that of late he
+had, when the fit was on him, made use of an opium den in the farthest
+east of the city. Hitherto his orgies had always been confined to one
+day, and he had come back, twitching and shattered, in the evening.
+But now the spell had been upon him eight-and-forty hours, and he lay
+there, doubtless among the dregs of the docks, breathing in the poison
+or sleeping off the effects. There he was to be found, she was sure of
+it, at the “Bar of Gold,” in Upper Swandam Lane. But what was she to
+do? How could she, a young and timid woman, make her way into such a
+place, and pluck her husband out from among the ruffians who surrounded
+him?
+
+There was the case, and of course there was but one way out of it.
+Might I not escort her to this place? And then, as a second thought,
+why should she come at all? I was Isa Whitney’s medical adviser, and
+as such I had influence over him. I could manage it better if I were
+alone. I promised her on my word that I would send him home in a
+cab within two hours if he were indeed at the address which she had
+given me. And so in ten minutes I had left my arm-chair and cheery
+sitting-room behind me, and was speeding eastward in a hansom on a
+strange errand, as it seemed to me at the time, though the future only
+could show how strange it was to be.
+
+But there was no great difficulty in the first stage of my adventure.
+Upper Swandam Lane is a vile alley lurking behind the high wharves
+which line the north side of the river to the east of London Bridge.
+Between a slop-shop and a gin-shop, approached by a steep flight of
+steps leading down to a black gap like the mouth of a cave, I found the
+den of which I was in search. Ordering my cab to wait, I passed down
+the steps, worn hollow in the centre by the ceaseless tread of drunken
+feet, and by the light of a flickering oil-lamp above the door I found
+the latch, and made my way into a long, low room, thick and heavy
+with the brown opium smoke, and terraced with wooden berths, like the
+forecastle of an emigrant ship.
+
+Through the gloom one could dimly catch a glimpse of bodies lying in
+strange fantastic poses, bowed shoulders, bent knees, heads thrown back
+and chins pointing upward, with here and there a dark, lack-lustre eye
+turned upon the new-comer. Out of the black shadows there glimmered
+little red circles of light, now bright, now faint, as the burning
+poison waxed or waned in the bowls of the metal pipes. The most lay
+silent, but some muttered to themselves, and others talked together in
+a strange, low, monotonous voice, their conversation coming in gushes,
+and then suddenly tailing off into silence, each mumbling out his own
+thoughts, and paying little heed to the words of his neighbor. At the
+farther end was a small brazier of burning charcoal, beside which on a
+three-legged wooden stool there sat a tall, thin old man, with his jaw
+resting upon his two fists, and his elbows upon his knees, staring into
+the fire.
+
+As I entered, a sallow Malay attendant had hurried up with a pipe for
+me and a supply of the drug, beckoning me to an empty berth.
+
+“Thank you. I have not come to stay,” said I. “There is a friend of
+mine here, Mr. Isa Whitney, and I wish to speak with him.”
+
+There was a movement and an exclamation from my right, and, peering
+through the gloom, I saw Whitney, pale, haggard, and unkempt, staring
+out at me.
+
+“My God! It’s Watson,” said he. He was in a pitiable state of reaction,
+with every nerve in a twitter. “I say, Watson, what o’clock is it?”
+
+“Nearly eleven.”
+
+“Of what day?”
+
+“Of Friday, June 19th.”
+
+“Good heavens! I thought it was Wednesday. It is Wednesday. What d’you
+want to frighten a chap for?” He sank his face onto his arms, and began
+to sob in a high treble key.
+
+“I tell you that it is Friday, man. Your wife has been waiting this two
+days for you. You should be ashamed of yourself!”
+
+“So I am. But you’ve got mixed, Watson, for I have only been here a few
+hours, three pipes, four pipes—I forget how many. But I’ll go home
+with you. I wouldn’t frighten Kate—poor little Kate. Give me your
+hand! Have you a cab?”
+
+“Yes, I have one waiting.”
+
+“Then I shall go in it. But I must owe something. Find what I owe,
+Watson. I am all off color. I can do nothing for myself.”
+
+I walked down the narrow passage between the double row of sleepers,
+holding my breath to keep out the vile, stupefying fumes of the drug,
+and looking about for the manager. As I passed the tall man who sat
+by the brazier I felt a sudden pluck at my skirt, and a low voice
+whispered, “Walk past me, and then look back at me.” The words fell
+quite distinctly upon my ear. I glanced down. They could only have come
+from the old man at my side, and yet he sat now as absorbed as ever,
+very thin, very wrinkled, bent with age, an opium pipe dangling down
+from between his knees, as though it had dropped in sheer lassitude
+from his fingers. I took two steps forward and looked back. It took
+all my self-control to prevent me from breaking out into a cry of
+astonishment. He had turned his back so that none could see him but
+I. His form had filled out, his wrinkles were gone, the dull eyes had
+regained their fire, and there, sitting by the fire, and grinning at
+my surprise, was none other than Sherlock Holmes. He made a slight
+motion to me to approach him, and instantly, as he turned his face half
+round to the company once more, subsided into a doddering, loose-lipped
+senility.
+
+“Holmes!” I whispered, “what on earth are you doing in this den?”
+
+“As low as you can,” he answered; “I have excellent ears. If you would
+have the great kindness to get rid of that sottish friend of yours I
+should be exceedingly glad to have a little talk with you.”
+
+“I have a cab outside.”
+
+“Then pray send him home in it. You may safely trust him, for he
+appears to be too limp to get into any mischief. I should recommend you
+also to send a note by the cabman to your wife to say that you have
+thrown in your lot with me. If you will wait outside, I shall be with
+you in five minutes.”
+
+It was difficult to refuse any of Sherlock Holmes’s requests, for they
+were always so exceedingly definite, and put forward with such a quiet
+air of mastery. I felt, however, that when Whitney was once confined
+in the cab my mission was practically accomplished, and for the rest,
+I could not wish anything better than to be associated with my friend
+in one of those singular adventures which were the normal condition of
+his existence. In a few minutes I had written my note, paid Whitney’s
+bill, led him out to the cab, and seen him driven through the darkness.
+In a very short time a decrepit figure had emerged from the opium
+den, and I was walking down the street with Sherlock Holmes. For two
+streets he shuffled along with a bent back and an uncertain foot. Then,
+glancing quickly round, he straightened himself out and burst into a
+hearty fit of laughter.
+
+“I suppose, Watson,” said he, “that you imagine that I have added
+opium-smoking to cocaine injections, and all the other little
+weaknesses on which you have favored me with your medical views.”
+
+“I was certainly surprised to find you there.”
+
+“But not more so than I to find you.”
+
+“I came to find a friend.”
+
+“And I to find an enemy.”
+
+“An enemy?”
+
+“Yes; one of my natural enemies, or, shall I say, my natural prey.
+Briefly, Watson, I am in the midst of a very remarkable inquiry, and
+I have hoped to find a clew in the incoherent ramblings of these
+sots, as I have done before now. Had I been recognized in that den my
+life would not have been worth an hour’s purchase; for I have used it
+before now for my own purposes, and the rascally Lascar who runs it has
+sworn to have vengeance upon me. There is a trap-door at the back of
+that building, near the corner of Paul’s Wharf, which could tell some
+strange tales of what has passed through it upon the moonless nights.”
+
+“What! You do not mean bodies?”
+
+“Aye, bodies, Watson. We should be rich men if we had £1000 for every
+poor devil who has been done to death in that den. It is the vilest
+murder-trap on the whole river-side, and I fear that Neville St. Clair
+has entered it never to leave it more. But our trap should be here.”
+He put his two forefingers between his teeth and whistled shrilly—a
+signal which was answered by a similar whistle from the distance,
+followed shortly by the rattle of wheels and the clink of horses’
+hoofs.
+
+“Now, Watson,” said Holmes, as a tall dog-cart dashed up through the
+gloom, throwing out two golden tunnels of yellow light from its side
+lanterns. “You’ll come with me, won’t you?”
+
+“If I can be of use.”
+
+“Oh, a trusty comrade is always of use; and a chronicler still more so.
+My room at ‘The Cedars’ is a double-bedded one.”
+
+“‘The Cedars?’”
+
+“Yes; that is Mr. St. Clair’s house. I am staying there while I conduct
+the inquiry.”
+
+“Where is it, then?”
+
+“Near Lee, in Kent. We have a seven-mile drive before us.”
+
+“But I am all in the dark.”
+
+“Of course you are. You’ll know all about it presently. Jump up here.
+All right, John; we shall not need you. Here’s half a crown. Look out
+for me to-morrow, about eleven. Give her her head. So long, then!”
+
+He flicked the horse with his whip, and we dashed away through the
+endless succession of sombre and deserted streets, which widened
+gradually, until we were flying across a broad balustraded bridge, with
+the murky river flowing sluggishly beneath us. Beyond lay another dull
+wilderness of bricks and mortar, its silence broken only by the heavy,
+regular footfall of the policeman, or the songs and shouts of some
+belated party of revellers. A dull wrack was drifting slowly across the
+sky, and a star or two twinkled dimly here and there through the rifts
+of the clouds. Holmes drove in silence, with his head sunk upon his
+breast, and the air of a man who is lost in thought, while I sat beside
+him, curious to learn what this new quest might be which seemed to tax
+his powers so sorely, and yet afraid to break in upon the current of
+his thoughts. We had driven several miles, and were beginning to get
+to the fringe of the belt of suburban villas, when he shook himself,
+shrugged his shoulders, and lit up his pipe with the air of a man who
+has satisfied himself that he is acting for the best.
+
+“You have a grand gift of silence, Watson,” said he. “It makes you
+quite invaluable as a companion. ’Pon my word, it is a great thing
+for me to have some one to talk to, for my own thoughts are not over
+pleasant. I was wondering what I should say to this dear little woman
+to-night when she meets me at the door.”
+
+“You forget that I know nothing about it.”
+
+“I shall just have time to tell you the facts of the case before we get
+to Lee. It seems absurdly simple, and yet, somehow, I can get nothing
+to go upon. There’s plenty of thread, no doubt, but I can’t get the end
+of it into my hand. Now, I’ll state the case clearly and concisely to
+you, Watson, and maybe you can see a spark where all is dark to me.”
+
+“Proceed, then.”
+
+“Some years ago—to be definite, in May, 1884—there came to Lee a
+gentleman, Neville St. Clair by name, who appeared to have plenty
+of money. He took a large villa, laid out the grounds very nicely,
+and lived generally in good style. By degrees he made friends in the
+neighborhood, and in 1887 he married the daughter of a local brewer, by
+whom he now has two children. He had no occupation, but was interested
+in several companies, and went into town as a rule in the morning,
+returning by the 5.14 from Cannon Street every night. Mr. St. Clair is
+now thirty-seven years of age, is a man of temperate habits, a good
+husband, a very affectionate father, and a man who is popular with all
+who know him. I may add that his whole debts at the present moment,
+as far as we have been able to ascertain, amount to £88 10_s._, while
+he has £220 standing to his credit in the Capital and Counties Bank.
+There is no reason, therefore, to think that money troubles have been
+weighing upon his mind.
+
+“Last Monday Mr. Neville St. Clair went into town rather earlier
+than usual, remarking before he started that he had two important
+commissions to perform, and that he would bring his little boy home a
+box of bricks. Now, by the merest chance, his wife received a telegram
+upon this same Monday, very shortly after his departure, to the effect
+that a small parcel of considerable value which she had been expecting
+was waiting for her at the offices of the Aberdeen Shipping Company.
+Now, if you are well up in your London, you will know that the offices
+of the company is in Fresno Street, which branches out of Upper Swandam
+Lane, where you found me to-night. Mrs. St. Clair had her lunch,
+started for the city, did some shopping, proceeded to the company’s
+office, got her packet, and found herself at exactly 4.35 walking
+through Swandam Lane on her way back to the station. Have you followed
+me so far?”
+
+“It is very clear.”
+
+“If you remember, Monday was an exceedingly hot day, and Mrs. St.
+Clair walked slowly, glancing about in the hope of seeing a cab, as
+she did not like the neighborhood in which she found herself. While
+she was walking in this way down Swandam Lane, she suddenly heard an
+ejaculation or cry, and was struck cold to see her husband looking down
+at her, and, as it seemed to her, beckoning to her from a second-floor
+window. The window was open, and she distinctly saw his face, which she
+describes as being terribly agitated. He waved his hands frantically
+to her, and then vanished from the window so suddenly that it seemed
+to her that he had been plucked back by some irresistible force from
+behind. One singular point which struck her quick feminine eye was
+that, although he wore some dark coat, such as he had started to town
+in, he had on neither collar nor necktie.
+
+[Illustration: “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+SCOUNDREL.”]
+
+“Convinced that something was amiss with him, she rushed down the
+steps—for the house was none other than the opium den in which you
+found me to-night—and, running through the front room, she attempted
+to ascend the stairs which led to the first floor. At the foot of the
+stairs, however, she met this Lascar scoundrel of whom I have spoken,
+who thrust her back, and, aided by a Dane, who acts as assistant there,
+pushed her out into the street. Filled with the most maddening doubts
+and fears, she rushed down the lane, and, by rare good-fortune, met, in
+Fresno Street, a number of constables with an inspector, all on their
+way to their beat. The inspector and two men accompanied her back, and,
+in spite of the continued resistance of the proprietor, they made their
+way to the room in which Mr. St. Clair had last been seen. There was no
+sign of him there. In fact, in the whole of that floor there was no one
+to be found, save a crippled wretch of hideous aspect, who, it seems,
+made his home there. Both he and the Lascar stoutly swore that no one
+else had been in the front room during the afternoon. So determined
+was their denial that the inspector was staggered, and had almost come
+to believe that Mrs. St. Clair had been deluded, when, with a cry, she
+sprang at a small deal box which lay upon the table, and tore the lid
+from it. Out there fell a cascade of children’s bricks. It was the toy
+which he had promised to bring home.
+
+“This discovery, and the evident confusion which the cripple showed,
+made the inspector realize that the matter was serious. The rooms were
+carefully examined, and results all pointed to an abominable crime.
+The front room was plainly furnished as a sitting-room, and led into a
+small bedroom, which looked out upon the back of one of the wharves.
+Between the wharf and the bedroom window is a narrow strip, which is
+dry at low tide, but is covered at high tide with at least four and
+a half feet of water. The bedroom window was a broad one, and opened
+from below. On examination traces of blood were to be seen upon the
+window-sill, and several scattered drops were visible upon the wooden
+floor of the bedroom. Thrust away behind a curtain in the front room
+were all the clothes of Mr. Neville St. Clair, with the exception of
+his coat. His boots, his socks, his hat, and his watch—all were there.
+There were no signs of violence upon any of these garments, and there
+were no other traces of Mr. Neville St. Clair. Out of the window he
+must apparently have gone, for no other exit could be discovered, and
+the ominous blood-stains upon the sill gave little promise that he
+could save himself by swimming, for the tide was at its very highest at
+the moment of the tragedy.
+
+“And now as to the villains who seemed to be immediately implicated in
+the matter. The Lascar was known to be a man of the vilest antecedents,
+but as, by Mrs. St. Clair’s story, he was known to have been at the
+foot of the stair within a very few seconds of her husband’s appearance
+at the window, he could hardly have been more than an accessory to the
+crime. His defense was one of absolute ignorance, and he protested that
+he had no knowledge as to the doings of Hugh Boone, his lodger, and
+that he could not account in any way for the presence of the missing
+gentleman’s clothes.
+
+“So much for the Lascar manager. Now for the sinister cripple who lives
+upon the second floor of the opium den, and who was certainly the
+last human being whose eyes rested upon Neville St. Clair. His name
+is Hugh Boone, and his hideous face is one which is familiar to every
+man who goes much to the city. He is a professional beggar, though,
+in order to avoid the police regulations, he pretends to a small
+trade in wax vestas. Some little distance down Threadneedle Street,
+upon the left-hand side, there is, as you may have remarked, a small
+angle in the wall. Here it is that this creature takes his daily seat,
+cross-legged, with his tiny stock of matches on his lap, and, as he is
+a piteous spectacle, a small rain of charity descends into the greasy
+leather cap which lies upon the pavement beside him. I have watched the
+fellow more than once, before ever I thought of making his professional
+acquaintance, and I have been surprised at the harvest which he has
+reaped in a short time. His appearance, you see, is so remarkable that
+no one can pass him without observing him. A shock of orange hair, a
+pale face disfigured by a horrible scar, which, by its contraction,
+has turned up the outer edge of his upper lip, a bull-dog chin, and a
+pair of very penetrating dark eyes, which present a singular contrast
+to the color of his hair, all mark him out from amid the common
+crowd of mendicants, and so, too, does his wit, for he is ever ready
+with a reply to any piece of chaff which may be thrown at him by the
+passers-by. This is the man whom we now learn to have been the lodger
+at the opium den, and to have been the last man to see the gentleman of
+whom we are in quest.”
+
+“But a cripple!” said I. “What could he have done single-handed against
+a man in the prime of life?”
+
+“He is a cripple in the sense that he walks with a limp; but in other
+respects he appears to be a powerful and well-nurtured man. Surely your
+medical experience would tell you, Watson, that weakness in one limb is
+often compensated for by exceptional strength in the others.”
+
+“Pray continue your narrative.”
+
+“Mrs. St. Clair had fainted at the sight of the blood upon the window,
+and she was escorted home in a cab by the police, as her presence
+could be of no help to them in their investigations. Inspector Barton,
+who had charge of the case, made a very careful examination of the
+premises, but without finding anything which threw any light upon the
+matter. One mistake had been made in not arresting Boone instantly, as
+he was allowed some few minutes during which he might have communicated
+with his friend the Lascar, but this fault was soon remedied, and he
+was seized and searched, without anything being found which could
+incriminate him. There were, it is true, some blood-stains upon his
+right shirt-sleeve, but he pointed to his ring-finger, which had been
+cut near the nail, and explained that the bleeding came from there,
+adding that he had been to the window not long before, and that the
+stains which had been observed there came doubtless from the same
+source. He denied strenuously having ever seen Mr. Neville St. Clair,
+and swore that the presence of the clothes in his room was as much
+a mystery to him as to the police. As to Mrs. St. Clair’s assertion
+that she had actually seen her husband at the window, he declared that
+she must have been either mad or dreaming. He was removed, loudly
+protesting, to the police-station, while the inspector remained upon
+the premises in the hope that the ebbing tide might afford some fresh
+clew.
+
+“And it did, though they hardly found upon the mud-bank what they had
+feared to find. It was Neville St. Clair’s coat, and not Neville St.
+Clair, which lay uncovered as the tide receded. And what do you think
+they found in the pockets?”
+
+“I cannot imagine.”
+
+“No, I don’t think you would guess. Every pocket stuffed with pennies
+and half-pennies—421 pennies and 270 half-pennies. It was no wonder
+that it had not been swept away by the tide. But a human body is a
+different matter. There is a fierce eddy between the wharf and the
+house. It seemed likely enough that the weighted coat had remained when
+the stripped body had been sucked away into the river.”
+
+“But I understand that all the other clothes were found in the room.
+Would the body be dressed in a coat alone?”
+
+“No, sir, but the facts might be met speciously enough. Suppose that
+this man Boone had thrust Neville St. Clair through the window, there
+is no human eye which could have seen the deed. What would he do then?
+It would of course instantly strike him that he must get rid of the
+tell-tale garments. He would seize the coat, then, and be in the act of
+throwing it out, when it would occur to him that it would swim and not
+sink. He has little time, for he has heard the scuffle down-stairs when
+the wife tried to force her way up, and perhaps he has already heard
+from his Lascar confederate that the police are hurrying up the street.
+There is not an instant to be lost. He rushes to some secret horde,
+where he has accumulated the fruits of his beggary, and he stuffs all
+the coins upon which he can lay his hands into the pockets to make sure
+of the coat’s sinking. He throws it out, and would have done the same
+with the other garments had not he heard the rush of steps below, and
+only just had time to close the window when the police appeared.”
+
+“It certainly sounds feasible.”
+
+“Well, we will take it as a working hypothesis for want of a better.
+Boone, as I have told you, was arrested and taken to the station, but
+it could not be shown that there had ever before been anything against
+him. He had for years been known as a professional beggar, but his life
+appeared to have been a very quiet and innocent one. There the matter
+stands at present, and the questions which have to be solved—what
+Neville St. Clair was doing in the opium den, what happened to him
+when there, where is he now, and what Hugh Boone had to do with his
+disappearance—are all as far from a solution as ever. I confess that I
+cannot recall any case within my experience which looked at the first
+glance so simple, and yet which presented such difficulties.”
+
+While Sherlock Holmes had been detailing this singular series of
+events, we had been whirling through the outskirts of the great town
+until the last straggling houses had been left behind, and we rattled
+along with a country hedge upon either side of us. Just as he finished,
+however, we drove through two scattered villages, where a few lights
+still glimmered in the windows.
+
+“We are on the outskirts of Lee,” said my companion. “We have touched
+on three English counties in our short drive, starting in Middlesex,
+passing over an angle of Surrey, and ending in Kent. See that light
+among the trees? That is ‘The Cedars,’ and beside that lamp sits a
+woman whose anxious ears have already, I have little doubt, caught the
+clink of our horse’s feet.”
+
+“But why are you not conducting the case from Baker Street?” I asked.
+
+“Because there are many inquiries which must be made out here. Mrs.
+St. Clair has most kindly put two rooms at my disposal, and you may
+rest assured that she will have nothing but a welcome for my friend
+and colleague. I hate to meet her, Watson, when I have no news of her
+husband. Here we are. Whoa, there, whoa!”
+
+We had pulled up in front of a large villa which stood within its own
+grounds. A stable-boy had run out to the horse’s head, and, springing
+down, I followed Holmes up the small, winding gravel-drive which led to
+the house. As we approached, the door flew open, and a little blonde
+woman stood in the opening, clad in some sort of light mousseline de
+soie, with a touch of fluffy pink chiffon at her neck and wrists. She
+stood with her figure outlined against the flood of light, one hand
+upon the door, one half-raised in her eagerness, her body slightly
+bent, her head and face protruded, with eager eyes and parted lips, a
+standing question.
+
+“Well?” she cried, “well?” And then, seeing that there were two of
+us, she gave a cry of hope which sank into a groan as she saw that my
+companion shook his head and shrugged his shoulders.
+
+“No good news?”
+
+“None.”
+
+“No bad?”
+
+“No.”
+
+“Thank God for that. But come in. You must be weary, for you have had a
+long day.”
+
+“This is my friend, Dr. Watson. He has been of most vital use to me in
+several of my cases, and a lucky chance has made it possible for me to
+bring him out and associate him with this investigation.”
+
+“I am delighted to see you,” said she, pressing my hand warmly.
+“You will, I am sure, forgive anything that may be wanting in our
+arrangements, when you consider the blow which has come so suddenly
+upon us.”
+
+“My dear madam,” said I, “I am an old campaigner, and if I were not,
+I can very well see that no apology is needed. If I can be of any
+assistance, either to you or to my friend here, I shall be indeed
+happy.”
+
+“Now, Mr. Sherlock Holmes,” said the lady, as we entered a well-lit
+dining-room, upon the table of which a cold supper had been laid out,
+“I should very much like to ask you one or two plain questions, to
+which I beg that you will give a plain answer.”
+
+“Certainly, madam.”
+
+“Do not trouble about my feelings. I am not hysterical, nor given to
+fainting. I simply wish to hear your real, real opinion.”
+
+“Upon what point?”
+
+“In your heart of hearts do you think that Neville is alive?”
+
+Sherlock Holmes seemed to be embarrassed by the question. “Frankly,
+now!” she repeated, standing upon the rug and looking keenly down at
+him as he leaned back in a basket-chair.
+
+“Frankly, then, madam, I do not.”
+
+“You think that he is dead?”
+
+“I do.”
+
+“Murdered?”
+
+“I don’t say that. Perhaps.”
+
+“And on what day did he meet his death?”
+
+“On Monday.”
+
+“Then perhaps, Mr. Holmes, you will be good enough to explain how it is
+that I have received a letter from him to-day.”
+
+Sherlock Holmes sprang out of his chair as if he had been galvanized.
+
+“What!” he roared.
+
+“Yes, to-day.” She stood smiling, holding up a little slip of paper in
+the air.
+
+“May I see it?”
+
+“Certainly.”
+
+He snatched it from her in his eagerness, and smoothing it out upon
+the table, he drew over the lamp, and examined it intently. I had left
+my chair, and was gazing at it over his shoulder. The envelope was a
+very coarse one, and was stamped with the Gravesend post-mark, and with
+the date of that very day, or rather of the day before, for it was
+considerably after midnight.
+
+“Coarse writing,” murmured Holmes. “Surely this is not your husband’s
+writing, madam.”
+
+“No, but the enclosure is.”
+
+“I perceive also that whoever addressed the envelope had to go and
+inquire as to the address.”
+
+“How can you tell that?”
+
+“The name, you see, is in perfectly black ink, which has dried itself.
+The rest is of the grayish color, which shows that blotting-paper has
+been used. If it had been written straight off, and then blotted, none
+would be of a deep black shade. This man has written the name, and
+there has then been a pause before he wrote the address, which can only
+mean that he was not familiar with it. It is, of course, a trifle, but
+there is nothing so important as trifles. Let us now see the letter.
+Ha! there has been an enclosure here!”
+
+“Yes, there was a ring. His signet-ring.”
+
+“And you are sure that this is your husband’s hand?”
+
+“One of his hands.”
+
+“One?”
+
+“His hand when he wrote hurriedly. It is very unlike his usual writing,
+and yet I know it well.”
+
+“‘Dearest do not be frightened. All will come well. There is a
+huge error which it may take some little time to rectify. Wait in
+patience.—Neville.’ Written in pencil upon the fly-leaf of a book,
+octavo size, no water-mark. Hum! Posted to-day in Gravesend by a man
+with a dirty thumb. Ha! And the flap has been gummed, if I am not very
+much in error, by a person who had been chewing tobacco. And you have
+no doubt that it is your husband’s hand, madam?”
+
+“None. Neville wrote those words.”
+
+“And they were posted to-day at Gravesend. Well, Mrs. St. Clair, the
+clouds lighten, though I should not venture to say that the danger is
+over.”
+
+“But he must be alive, Mr. Holmes.”
+
+“Unless this is a clever forgery to put us on the wrong scent. The
+ring, after all, proves nothing. It may have been taken from him.”
+
+“No, no; it is, it is, it is his very own writing!”
+
+“Very well. It may, however, have been written on Monday, and only
+posted to-day.”
+
+“That is possible.”
+
+“If so, much may have happened between.”
+
+“Oh, you must not discourage me, Mr. Holmes. I know that all is well
+with him. There is so keen a sympathy between us that I should know if
+evil came upon him. On the very day that I saw him last he cut himself
+in the bedroom, and yet I in the dining-room rushed up-stairs instantly
+with the utmost certainty that something had happened. Do you think
+that I would respond to such a trifle, and yet be ignorant of his
+death?”
+
+“I have seen too much not to know that the impression of a woman may
+be more valuable than the conclusion of an analytical reasoner. And
+in this letter you certainly have a very strong piece of evidence to
+corroborate your view. But if your husband is alive, and able to write
+letters, why should he remain away from you?”
+
+“I cannot imagine. It is unthinkable.”
+
+“And on Monday he made no remarks before leaving you?”
+
+“No.”
+
+“And you were surprised to see him in Swandam Lane?”
+
+“Very much so.”
+
+“Was the window open?”
+
+“Yes.”
+
+“Then he might have called to you?”
+
+“He might.”
+
+“He only, as I understand, gave an inarticulate cry?”
+
+“Yes.”
+
+“A call for help, you thought?”
+
+“Yes. He waved his hands.”
+
+“But it might have been a cry of surprise. Astonishment at the
+unexpected sight of you might cause him to throw up his hands?”
+
+“It is possible.”
+
+“And you thought he was pulled back?”
+
+“He disappeared so suddenly.”
+
+“He might have leaped back. You did not see any one else in the room?”
+
+“No, but this horrible man confessed to having been there, and the
+Lascar was at the foot of the stairs.”
+
+“Quite so. Your husband, as far as you could see, had his ordinary
+clothes on?”
+
+“But without his collar or tie. I distinctly saw his bare throat.”
+
+“Had he ever spoken of Swandam Lane?”
+
+“Never.”
+
+“Had he ever showed any signs of having taken opium?”
+
+“Never.”
+
+“Thank you, Mrs. St. Clair. Those are the principal points about which
+I wished to be absolutely clear. We shall now have a little supper and
+then retire, for we may have a very busy day to-morrow.”
+
+A large and comfortable double-bedded room had been placed at our
+disposal, and I was quickly between the sheets, for I was weary after
+my night of adventure. Sherlock Holmes was a man, however, who, when
+he had an unsolved problem upon his mind, would go for days, and even
+for a week, without rest, turning it over, rearranging his facts,
+looking at it from every point of view, until he had either fathomed
+it, or convinced himself that his data were insufficient. It was soon
+evident to me that he was now preparing for an all-night sitting. He
+took off his coat and waistcoat, put on a large blue dressing-gown,
+and then wandered about the room collecting pillows from his bed and
+cushions from the sofa and arm-chairs. With these he constructed a sort
+of Eastern divan, upon which he perched himself cross-legged, with an
+ounce of shag tobacco and a box of matches laid out in front of him.
+In the dim light of the lamp I saw him sitting there, an old briar
+pipe between his lips, his eyes fixed vacantly upon the corner of the
+ceiling, the blue smoke curling up from him, silent, motionless, with
+the light shining upon his strong-set aquiline features. So he sat as I
+dropped off to sleep, and so he sat when a sudden ejaculation caused me
+to wake up, and I found the summer sun shining into the apartment. The
+pipe was still between his lips, the smoke still curled upward, and the
+room was full of a dense tobacco haze, but nothing remained of the heap
+of shag which I had seen upon the previous night.
+
+“Awake, Watson?” he asked.
+
+“Yes.”
+
+“Game for a morning drive?”
+
+“Certainly.”
+
+“Then dress. No one is stirring yet, but I know where the stable-boy
+sleeps, and we shall soon have the trap out.” He chuckled to himself
+as he spoke, his eyes twinkled, and he seemed a different man to the
+sombre thinker of the previous night.
+
+As I dressed I glanced at my watch. It was no wonder that no one was
+stirring. It was twenty-five minutes past four. I had hardly finished
+when Holmes returned with the news that the boy was putting in the
+horse.
+
+“I want to test a little theory of mine,” said he, pulling on his
+boots. “I think, Watson, that you are now standing in the presence of
+one of the most absolute fools in Europe. I deserve to be kicked from
+here to Charing Cross. But I think I have the key of the affair now.”
+
+“And where is it?” I asked, smiling.
+
+“In the bath-room,” he answered. “Oh yes, I am not joking,” he
+continued, seeing my look of incredulity. “I have just been there, and
+I have taken it out, and I have got it in this Gladstone bag. Come on,
+my boy, and we shall see whether it will not fit the lock.”
+
+We made our way down-stairs as quietly as possible, and out into the
+bright morning sunshine. In the road stood our horse and trap, with
+the half-clad stable-boy waiting at the head. We both sprang in, and
+away we dashed down the London Road. A few country carts were stirring,
+bearing in vegetables to the metropolis, but the lines of villas on
+either side were as silent and lifeless as some city in a dream.
+
+“It has been in some points a singular case,” said Holmes, flicking the
+horse on into a gallop. “I confess that I have been as blind as a mole,
+but it is better to learn wisdom late than never to learn it at all.”
+
+In town the earliest risers were just beginning to look sleepily from
+their windows as we drove through the streets of the Surrey side.
+Passing down the Waterloo Bridge Road we crossed over the river, and
+dashing up Wellington Street wheeled sharply to the right, and found
+ourselves in Bow Street. Sherlock Holmes was well known to the Force,
+and the two constables at the door saluted him. One of them held the
+horse’s head while the other led us in.
+
+“Who is on duty?” asked Holmes.
+
+“Inspector Bradstreet, sir.”
+
+“Ah, Bradstreet, how are you?” A tall, stout official had come down the
+stone-flagged passage, in a peaked cap and frogged jacket. “I wish to
+have a quiet word with you, Bradstreet.”
+
+“Certainly, Mr. Holmes. Step into my room here.”
+
+It was a small, office-like room, with a huge ledger upon the table,
+and a telephone projecting from the wall. The inspector sat down at his
+desk.
+
+“What can I do for you, Mr. Holmes?”
+
+“I called about that beggarman, Boone—the one who was charged with
+being concerned in the disappearance of Mr. Neville St. Clair, of Lee.”
+
+“Yes. He was brought up and remanded for further inquiries.”
+
+“So I heard. You have him here?”
+
+“In the cells.”
+
+“Is he quiet?”
+
+“Oh, he gives no trouble. But he is a dirty scoundrel.”
+
+“Dirty?”
+
+“Yes, it is all we can do to make him wash his hands, and his face is
+as black as a tinker’s. Well, when once his case has been settled, he
+will have a regular prison bath; and I think, if you saw him, you would
+agree with me that he needed it.”
+
+“I should like to see him very much.”
+
+“Would you? That is easily done. Come this way. You can leave your bag.”
+
+“No, I think that I’ll take it.”
+
+“Very good. Come this way, if you please.” He led us down a passage,
+opened a barred door, passed down a winding stair, and brought us to a
+whitewashed corridor with a line of doors on each side.
+
+“The third on the right is his,” said the inspector. “Here it is!” He
+quietly shot back a panel in the upper part of the door and glanced
+through.
+
+“He is asleep,” said he. “You can see him very well.”
+
+We both put our eyes to the grating. The prisoner lay with his face
+towards us, in a very deep sleep, breathing slowly and heavily. He was
+a middle-sized man, coarsely clad as became his calling, with a colored
+shirt protruding through the rent in his tattered coat. He was, as the
+inspector had said, extremely dirty, but the grime which covered his
+face could not conceal its repulsive ugliness. A broad wheal from an
+old scar ran right across it from eye to chin, and by its contraction
+had turned up one side of the upper lip, so that three teeth were
+exposed in a perpetual snarl. A shock of very bright red hair grew low
+over his eyes and forehead.
+
+“He’s a beauty, isn’t he?” said the inspector.
+
+“He certainly needs a wash,” remarked Holmes. “I had an idea that he
+might, and I took the liberty of bringing the tools with me.” He opened
+the Gladstone bag as he spoke, and took out, to my astonishment, a very
+large bath-sponge.
+
+“He! he! You are a funny one,” chuckled the inspector.
+
+“Now, if you will have the great goodness to open that door very
+quietly, we will soon make him cut a much more respectable figure.”
+
+“Well, I don’t know why not,” said the inspector. “He doesn’t look
+a credit to the Bow Street cells, does he?” He slipped his key into
+the lock, and we all very quietly entered the cell. The sleeper half
+turned, and then settled down once more into a deep slumber. Holmes
+stooped to the water-jug, moistened his sponge, and then rubbed it
+twice vigorously across and down the prisoner’s face.
+
+“Let me introduce you,” he shouted, “to Mr. Neville St. Clair, of Lee,
+in the county of Kent.”
+
+Never in my life have I seen such a sight. The man’s face peeled off
+under the sponge like the bark from a tree. Gone was the coarse brown
+tint! Gone, too, was the horrid scar which had seamed it across, and
+the twisted lip which had given the repulsive sneer to the face! A
+twitch brought away the tangled red hair, and there, sitting up in
+his bed, was a pale, sad-faced, refined-looking man, black-haired and
+smooth-skinned, rubbing his eyes, and staring about him with sleepy
+bewilderment. Then suddenly realizing the exposure, he broke into a
+scream, and threw himself down with his face to the pillow.
+
+“Great heavens!” cried the inspector, “it is, indeed, the missing man.
+I know him from the photograph.”
+
+The prisoner turned with the reckless air of a man who abandons himself
+to his destiny. “Be it so,” said he. “And pray, what am I charged with?”
+
+“With making away with Mr. Neville St.—— Oh, come, you can’t be
+charged with that, unless they make a case of attempted suicide of it,”
+said the inspector, with a grin. “Well, I have been twenty-seven years
+in the force, but this really takes the cake.”
+
+“If I am Mr. Neville St. Clair, then it is obvious that no crime has
+been committed, and that, therefore, I am illegally detained.”
+
+“No crime, but a very great error has been committed,” said Holmes.
+“You would have done better to have trusted your wife.”
+
+“It was not the wife, it was the children,” groaned the prisoner. “God
+help me, I would not have them ashamed of their father. My God! What an
+exposure! What can I do?”
+
+Sherlock Holmes sat down beside him on the couch and patted him kindly
+on the shoulder.
+
+“If you leave it to a court of law to clear the matter up,” said he,
+“of course you can hardly avoid publicity. On the other hand, if you
+convince the police authorities that there is no possible case against
+you, I do not know that there is any reason that the details should
+find their way into the papers. Inspector Bradstreet would, I am sure,
+make notes upon anything which you might tell us, and submit it to the
+proper authorities. The case would then never go into court at all.”
+
+“God bless you!” cried the prisoner, passionately. “I would have
+endured imprisonment, aye, even execution, rather than have left my
+miserable secret as a family blot to my children.
+
+“You are the first who have ever heard my story. My father was
+a school-master in Chesterfield, where I received an excellent
+education. I travelled in my youth, took to the stage, and finally
+became a reporter on an evening paper in London. One day my editor
+wished to have a series of articles upon begging in the metropolis,
+and I volunteered to supply them. There was the point from which all
+my adventures started. It was only by trying begging as an amateur
+that I could get the facts upon which to base my articles. When an
+actor I had, of course, learned all the secrets of making up, and had
+been famous in the greenroom for my skill. I took advantage now of
+my attainments. I painted my face, and to make myself as pitiable as
+possible I made a good scar and fixed one side of my lip in a twist
+by the aid of a small slip of flesh-colored plaster. Then with a red
+head of hair, and an appropriate dress, I took my station in the
+busiest part of the city, ostensibly as a match-seller, but really as a
+beggar. For seven hours I plied my trade, and when I returned home in
+the evening I found, to my surprise, that I had received no less than
+26_s._ 4_d._
+
+“I wrote my articles, and thought little more of the matter until, some
+time later, I backed a bill for a friend, and had a writ served upon
+me for £25. I was at my wits’ end where to get the money, but a sudden
+idea came to me. I begged a fortnight’s grace from the creditor, asked
+for a holiday from my employers, and spent the time in begging in the
+city under my disguise. In ten days I had the money, and had paid the
+debt.
+
+“Well, you can imagine how hard it was to settle down to arduous
+work at £2 a week, when I knew that I could earn as much in a day by
+smearing my face with a little paint, laying my cap on the ground, and
+sitting still. It was a long fight between my pride and the money,
+but the dollars won at last, and I threw up reporting, and sat day
+after day in the corner which I had first chosen, inspiring pity by my
+ghastly face, and filling my pockets with coppers. Only one man knew
+my secret. He was the keeper of a low den in which I used to lodge in
+Swandam Lane, where I could every morning emerge as a squalid beggar,
+and in the evenings transform myself into a well-dressed man about
+town. This fellow, a Lascar, was well paid by me for his rooms, so that
+I knew that my secret was safe in his possession.
+
+“Well, very soon I found that I was saving considerable sums of money.
+I do not mean that any beggar in the streets of London could earn £700
+a year—which is less than my average takings—but I had exceptional
+advantages in my power of making up, and also in a facility of
+repartee, which improved by practice, and made me quite a recognized
+character in the city. All day a stream of pennies, varied by silver,
+poured in upon me, and it was a very bad day in which I failed to take
+£2.
+
+“As I grew richer I grew more ambitious, took a house in the country,
+and eventually married, without any one having a suspicion as to my
+real occupation. My dear wife knew that I had business in the city. She
+little knew what.
+
+“Last Monday I had finished for the day, and was dressing in my room
+above the opium den, when I looked out of my window, and saw, to my
+horror and astonishment, that my wife was standing in the street, with
+her eyes fixed full upon me. I gave a cry of surprise, threw up my arms
+to cover my face, and, rushing to my confidant, the Lascar, entreated
+him to prevent any one from coming up to me. I heard her voice
+down-stairs, but I knew that she could not ascend. Swiftly I threw off
+my clothes, pulled on those of a beggar, and put on my pigments and
+wig. Even a wife’s eyes could not pierce so complete a disguise. But
+then it occurred to me that there might be a search in the room, and
+that the clothes might betray me. I threw open the window, reopening
+by my violence a small cut which I had inflicted upon myself in the
+bedroom that morning. Then I seized my coat, which was weighted by
+the coppers which I had just transferred to it from the leather bag
+in which I carried my takings. I hurled it out of the window, and it
+disappeared into the Thames. The other clothes would have followed, but
+at that moment there was a rush of constables up the stair, and a few
+minutes after I found, rather, I confess, to my relief, that instead
+of being identified as Mr. Neville St. Clair, I was arrested as his
+murderer.
+
+“I do not know that there is anything else for me to explain. I was
+determined to preserve my disguise as long as possible, and hence my
+preference for a dirty face. Knowing that my wife would be terribly
+anxious, I slipped off my ring, and confided it to the Lascar at a
+moment when no constable was watching me, together with a hurried
+scrawl, telling her that she had no cause to fear.”
+
+“That note only reached her yesterday,” said Holmes.
+
+“Good God! What a week she must have spent!”
+
+“The police have watched this Lascar,” said Inspector Bradstreet, “and
+I can quite understand that he might find it difficult to post a letter
+unobserved. Probably he handed it to some sailor customer of his, who
+forgot all about it for some days.”
+
+“That was it,” said Holmes, nodding approvingly; “I have no doubt of
+it. But have you never been prosecuted for begging?”
+
+“Many times; but what was a fine to me?”
+
+“It must stop here, however,” said Bradstreet. “If the police are to
+hush this thing up, there must be no more of Hugh Boone.”
+
+“I have sworn it by the most solemn oaths which a man can take.”
+
+“In that case I think that it is probable that no further steps may be
+taken. But if you are found again, then all must come out. I am sure,
+Mr. Holmes, that we are very much indebted to you for having cleared
+the matter up. I wish I knew how you reach your results.”
+
+“I reached this one,” said my friend, “by sitting upon five pillows and
+consuming an ounce of shag. I think, Watson, that if we drive to Baker
+Street we shall just be in time for breakfast.”
+
+
+
+
+Adventure VII
+
+THE ADVENTURE OF THE BLUE CARBUNCLE
+
+
+I had called upon my friend Sherlock Holmes upon the second morning
+after Christmas, with the intention of wishing him the compliments of
+the season. He was lounging upon the sofa in a purple dressing-gown,
+a pipe-rack within his reach upon the right, and a pile of crumpled
+morning papers, evidently newly studied, near at hand. Beside the couch
+was a wooden chair, and on the angle of the back hung a very seedy
+and disreputable hard-felt hat, much the worse for wear, and cracked
+in several places. A lens and a forceps lying upon the seat of the
+chair suggested that the hat had been suspended in this manner for the
+purpose of examination.
+
+“You are engaged,” said I; “perhaps I interrupt you.”
+
+“Not at all. I am glad to have a friend with whom I can discuss my
+results. The matter is a perfectly trivial one” (he jerked his thumb in
+the direction of the old hat), “but there are points in connection with
+it which are not entirely devoid of interest and even of instruction.”
+
+I seated myself in his arm-chair and warmed my hands before his
+crackling fire, for a sharp frost had set in, and the windows were
+thick with the ice crystals. “I suppose,” I remarked, “that, homely as
+it looks, this thing has some deadly story linked on to it—that it is
+the clew which will guide you in the solution of some mystery and the
+punishment of some crime.”
+
+“No, no. No crime,” said Sherlock Holmes, laughing. “Only one of
+those whimsical little incidents which will happen when you have
+four million human beings all jostling each other within the space of
+a few square miles. Amid the action and reaction of so dense a swarm
+of humanity, every possible combination of events may be expected to
+take place, and many a little problem will be presented which may
+be striking and bizarre without being criminal. We have already had
+experience of such.”
+
+“So much so,” I remarked, “that of the last six cases which I have
+added to my notes, three have been entirely free of any legal crime.”
+
+“Precisely. You allude to my attempt to recover the Irene Adler papers,
+to the singular case of Miss Mary Sutherland, and to the adventure of
+the man with the twisted lip. Well, I have no doubt that this small
+matter will fall into the same innocent category. You know Peterson,
+the commissionaire?”
+
+“Yes.”
+
+“It is to him that this trophy belongs.”
+
+“It is his hat.”
+
+“No, no; he found it. Its owner is unknown. I beg that you will look
+upon it, not as a battered billycock, but as an intellectual problem.
+And, first, as to how it came here. It arrived upon Christmas morning,
+in company with a good fat goose, which is, I have no doubt, roasting
+at this moment in front of Peterson’s fire. The facts are these: about
+four o’clock on Christmas morning, Peterson, who, as you know, is a
+very honest fellow, was returning from some small jollification, and
+was making his way homeward down Tottenham Court Road. In front of him
+he saw, in the gaslight, a tallish man, walking with a slight stagger,
+and carrying a white goose slung over his shoulder. As he reached the
+corner of Goodge Street, a row broke out between this stranger and a
+little knot of roughs. One of the latter knocked off the man’s hat, on
+which he raised his stick to defend himself, and, swinging it over his
+head, smashed the shop window behind him. Peterson had rushed forward
+to protect the stranger from his assailants; but the man, shocked at
+having broken the window, and seeing an official-looking person in
+uniform rushing towards him, dropped his goose, took to his heels, and
+vanished amid the labyrinth of small streets which lie at the back of
+Tottenham Court Road. The roughs had also fled at the appearance of
+Peterson, so that he was left in possession of the field of battle, and
+also of the spoils of victory in the shape of this battered hat and a
+most unimpeachable Christmas goose.”
+
+“Which surely he restored to their owner?”
+
+“My dear fellow, there lies the problem. It is true that ‘For Mrs.
+Henry Baker’ was printed upon a small card which was tied to the bird’s
+left leg, and it is also true that the initials ‘H. B.’ are legible
+upon the lining of this hat; but as there are some thousands of Bakers,
+and some hundreds of Henry Bakers in this city of ours, it is not easy
+to restore lost property to any one of them.”
+
+“What, then, did Peterson do?”
+
+“He brought round both hat and goose to me on Christmas morning,
+knowing that even the smallest problems are of interest to me. The
+goose we retained until this morning, when there were signs that, in
+spite of the slight frost, it would be well that it should be eaten
+without unnecessary delay. Its finder has carried it off, therefore, to
+fulfil the ultimate destiny of a goose, while I continue to retain the
+hat of the unknown gentleman who lost his Christmas dinner.”
+
+“Did he not advertise?”
+
+“No.”
+
+“Then, what clue could you have as to his identity?”
+
+“Only as much as we can deduce.”
+
+“From his hat?”
+
+“Precisely.”
+
+“But you are joking. What can you gather from this old battered felt?”
+
+“Here is my lens. You know my methods. What can you gather yourself as
+to the individuality of the man who has worn this article?”
+
+I took the tattered object in my hands and turned it over rather
+ruefully. It was a very ordinary black hat of the usual round shape,
+hard, and much the worse for wear. The lining had been of red silk, but
+was a good deal discolored. There was no maker’s name; but, as Holmes
+had remarked, the initials “H. B.” were scrawled upon one side. It was
+pierced in the brim for a hat-securer, but the elastic was missing. For
+the rest, it was cracked, exceedingly dusty, and spotted in several
+places, although there seemed to have been some attempt to hide the
+discolored patches by smearing them with ink.
+
+“I can see nothing,” said I, handing it back to my friend.
+
+“On the contrary, Watson, you can see everything. You fail, however, to
+reason from what you see. You are too timid in drawing your inferences.”
+
+“Then, pray tell me what it is that you can infer from this hat?”
+
+He picked it up and gazed at it in the peculiar introspective fashion
+which was characteristic of him. “It is perhaps less suggestive than
+it might have been,” he remarked, “and yet there are a few inferences
+which are very distinct, and a few others which represent at least a
+strong balance of probability. That the man was highly intellectual
+is of course obvious upon the face of it, and also that he was fairly
+well-to-do within the last three years, although he has now fallen upon
+evil days. He had foresight, but has less now than formerly, pointing
+to a moral retrogression, which, when taken with the decline of his
+fortunes, seems to indicate some evil influence, probably drink, at
+work upon him. This may account also for the obvious fact that his wife
+has ceased to love him.”
+
+“My dear Holmes!”
+
+“He has, however, retained some degree of self-respect,” he continued,
+disregarding my remonstrance. “He is a man who leads a sedentary
+life, goes out little, is out of training entirely, is middle-aged,
+has grizzled hair which he has had cut within the last few days, and
+which he anoints with lime-cream. These are the more patent facts which
+are to be deduced from his hat. Also, by-the-way, that it is extremely
+improbable that he has gas laid on in his house.”
+
+“You are certainly joking, Holmes.”
+
+“Not in the least. Is it possible that even now, when I give you these
+results, you are unable to see how they are attained?”
+
+“I have no doubt that I am very stupid; but I must confess that I am
+unable to follow you. For example, how did you deduce that this man was
+intellectual?”
+
+For answer Holmes clapped the hat upon his head. It came right over the
+forehead and settled upon the bridge of his nose. “It is a question
+of cubic capacity,” said he; “a man with so large a brain must have
+something in it.”
+
+“The decline of his fortunes, then?”
+
+“This hat is three years old. These flat brims curled at the edge came
+in then. It is a hat of the very best quality. Look at the band of
+ribbed silk and the excellent lining. If this man could afford to buy
+so expensive a hat three years ago, and has had no hat since, then he
+has assuredly gone down in the world.”
+
+“Well, that is clear enough, certainly. But how about the foresight and
+the moral retrogression?”
+
+Sherlock Holmes laughed. “Here is the foresight,” said he, putting
+his finger upon the little disk and loop of the hat-securer. “They
+are never sold upon hats. If this man ordered one, it is a sign of a
+certain amount of foresight, since he went out of his way to take this
+precaution against the wind. But since we see that he has broken the
+elastic, and has not troubled to replace it, it is obvious that he
+has less foresight now than formerly, which is a distinct proof of a
+weakening nature. On the other hand, he has endeavored to conceal some
+of these stains upon the felt by daubing them with ink, which is a
+sign that he has not entirely lost his self-respect.”
+
+“Your reasoning is certainly plausible.”
+
+“The further points, that he is middle-aged, that his hair is grizzled,
+that it has been recently cut, and that he uses lime-cream, are all
+to be gathered from a close examination of the lower part of the
+lining. The lens discloses a large number of hair-ends, clean cut by
+the scissors of the barber. They all appear to be adhesive, and there
+is a distinct odor of lime-cream. This dust, you will observe, is not
+the gritty, gray dust of the street, but the fluffy brown dust of the
+house, showing that it has been hung up in-doors most of the time;
+while the marks of moisture upon the inside are proof positive that the
+wearer perspired very freely, and could, therefore, hardly be in the
+best of training.”
+
+“But his wife—you said that she had ceased to love him.”
+
+“This hat has not been brushed for weeks. When I see you, my dear
+Watson, with a week’s accumulation of dust upon your hat, and when your
+wife allows you to go out in such a state, I shall fear that you also
+have been unfortunate enough to lose your wife’s affection.”
+
+“But he might be a bachelor.”
+
+“Nay, he was bringing home the goose as a peace-offering to his wife.
+Remember the card upon the bird’s leg.”
+
+“You have an answer to everything. But how on earth do you deduce that
+the gas is not laid on in his house?”
+
+“One tallow stain, or even two, might come by chance; but when I
+see no less than five, I think that there can be little doubt that
+the individual must be brought into frequent contact with burning
+tallow—walks up-stairs at night probably with his hat in one hand and
+a guttering candle in the other. Anyhow, he never got tallow-stains
+from a gas-jet. Are you satisfied?”
+
+“Well, it is very ingenious,” said I, laughing; “but since, as you said
+just now, there has been no crime committed, and no harm done, save
+the loss of a goose, all this seems to be rather a waste of energy.”
+
+Sherlock Holmes had opened his mouth to reply, when the door flew
+open, and Peterson, the commissionaire, rushed into the apartment with
+flushed cheeks and the face of a man who is dazed with astonishment.
+
+“The goose, Mr. Holmes! The goose, sir!” he gasped.
+
+“Eh? What of it, then? Has it returned to life and flapped off through
+the kitchen window?” Holmes twisted himself round upon the sofa to get
+a fairer view of the man’s excited face.
+
+“See here, sir! See what my wife found in its crop!” He held out
+his hand and displayed upon the centre of the palm a brilliantly
+scintillating blue stone, rather smaller than a bean in size, but of
+such purity and radiance that it twinkled like an electric point in the
+dark hollow of his hand.
+
+Sherlock Holmes sat up with a whistle. “By Jove, Peterson!” said he,
+“this is treasure trove indeed. I suppose you know what you have got?”
+
+“A diamond, sir? A precious stone. It cuts into glass as though it were
+putty.”
+
+“It’s more than a precious stone. It is _the_ precious stone.”
+
+“Not the Countess of Morcar’s blue carbuncle!” I ejaculated.
+
+“Precisely so. I ought to know its size and shape, seeing that I have
+read the advertisement about it in _The Times_ every day lately. It
+is absolutely unique, and its value can only be conjectured, but the
+reward offered of £1000 is certainly not within a twentieth part of the
+market price.”
+
+“A thousand pounds! Great Lord of mercy!” The commissionaire plumped
+down into a chair, and stared from one to the other of us.
+
+“That is the reward, and I have reason to know that there are
+sentimental considerations in the background which would induce the
+countess to part with half her fortune if she could but recover the
+gem.”
+
+“It was lost, if I remember aright, at the ‘Hotel Cosmopolitan,’” I
+remarked.
+
+“Precisely so, on December 22d, just five days ago. John Horner,
+a plumber, was accused of having abstracted it from the lady’s
+jewel-case. The evidence against him was so strong that the case has
+been referred to the Assizes. I have some account of the matter here,
+I believe.” He rummaged amid his newspapers, glancing over the dates,
+until at last he smoothed one out, doubled it over, and read the
+following paragraph:
+
+“‘Hotel Cosmopolitan Jewel Robbery. John Horner, 26, plumber, was
+brought up upon the charge of having upon the 22d inst. abstracted from
+the jewel-case of the Countess of Morcar the valuable gem known as the
+blue carbuncle. James Ryder, upper-attendant at the hotel, gave his
+evidence to the effect that he had shown Horner up to the dressing-room
+of the Countess of Morcar upon the day of the robbery, in order that
+he might solder the second bar of the grate, which was loose. He had
+remained with Horner some little time, but had finally been called
+away. On returning, he found that Horner had disappeared, that the
+bureau had been forced open, and that the small morocco casket in
+which, as it afterwards transpired, the countess was accustomed to keep
+her jewel, was lying empty upon the dressing-table. Ryder instantly
+gave the alarm, and Horner was arrested the same evening; but the stone
+could not be found either upon his person or in his rooms. Catherine
+Cusack, maid to the countess, deposed to having heard Ryder’s cry of
+dismay on discovering the robbery, and to having rushed into the room,
+where she found matters as described by the last witness. Inspector
+Bradstreet, B division, gave evidence as to the arrest of Horner, who
+struggled frantically, and protested his innocence in the strongest
+terms. Evidence of a previous conviction for robbery having been given
+against the prisoner, the magistrate refused to deal summarily with
+the offence, but referred it to the Assizes. Horner, who had shown
+signs of intense emotion during the proceedings, fainted away at the
+conclusion, and was carried out of court.’
+
+“Hum! So much for the police-court,” said Holmes, thoughtfully, tossing
+aside the paper. “The question for us now to solve is the sequence
+of events leading from a rifled jewel-case at one end to the crop of
+a goose in Tottenham Court Road at the other. You see, Watson, our
+little deductions have suddenly assumed a much more important and less
+innocent aspect. Here is the stone; the stone came from the goose, and
+the goose came from Mr. Henry Baker, the gentleman with the bad hat
+and all the other characteristics with which I have bored you. So now
+we must set ourselves very seriously to finding this gentleman, and
+ascertaining what part he has played in this little mystery. To do
+this, we must try the simplest means first, and these lie undoubtedly
+in an advertisement in all the evening papers. If this fails, I shall
+have recourse to other methods.”
+
+“What will you say?”
+
+“Give me a pencil and that slip of paper. Now, then: ‘Found at the
+corner of Goodge Street, a goose and a black felt hat. Mr. Henry Baker
+can have the same by applying at 6.30 this evening at 221B,
+Baker Street.’ That is clear and concise.”
+
+“Very. But will he see it?”
+
+“Well, he is sure to keep an eye on the papers, since, to a poor man,
+the loss was a heavy one. He was clearly so scared by his mischance
+in breaking the window and by the approach of Peterson, that he
+thought of nothing but flight; but since then he must have bitterly
+regretted the impulse which caused him to drop his bird. Then, again,
+the introduction of his name will cause him to see it, for every one
+who knows him will direct his attention to it. Here you are, Peterson,
+run down to the advertising agency, and have this put in the evening
+papers.”
+
+“In which, sir?”
+
+“Oh, in the _Globe_, _Star_, _Pall Mall_, _St. James’s_, _Evening
+News_, _Standard_, _Echo_, and any others that occur to you.”
+
+“Very well, sir. And this stone?”
+
+“Ah, yes, I shall keep the stone. Thank you. And, I say, Peterson,
+just buy a goose on your way back, and leave it here with me, for we
+must have one to give to this gentleman in place of the one which your
+family is now devouring.”
+
+When the commissionaire had gone, Holmes took up the stone and held
+it against the light. “It’s a bonny thing,” said he. “Just see how it
+glints and sparkles. Of course it is a nucleus and focus of crime.
+Every good stone is. They are the devil’s pet baits. In the larger and
+older jewels every facet may stand for a bloody deed. This stone is not
+yet twenty years old. It was found in the banks of the Amoy River in
+Southern China, and is remarkable in having every characteristic of the
+carbuncle, save that it is blue in shade, instead of ruby red. In spite
+of its youth, it has already a sinister history. There have been two
+murders, a vitriol-throwing, a suicide, and several robberies brought
+about for the sake of this forty-grain weight of crystallized charcoal.
+Who would think that so pretty a toy would be a purveyor to the gallows
+and the prison? I’ll lock it up in my strong box now, and drop a line
+to the countess to say that we have it.”
+
+“Do you think that this man Horner is innocent?”
+
+“I cannot tell.”
+
+“Well, then, do you imagine that this other one, Henry Baker, had
+anything to do with the matter?”
+
+“It is, I think, much more likely that Henry Baker is an absolutely
+innocent man, who had no idea that the bird which he was carrying was
+of considerably more value than if it were made of solid gold. That,
+however, I shall determine by a very simple test, if we have an answer
+to our advertisement.”
+
+“And you can do nothing until then?”
+
+“Nothing.”
+
+“In that case I shall continue my professional round. But I shall come
+back in the evening at the hour you have mentioned, for I should like
+to see the solution of so tangled a business.”
+
+“Very glad to see you. I dine at seven. There is a woodcock, I believe.
+By-the-way, in view of recent occurrences, perhaps I ought to ask Mrs.
+Hudson to examine its crop.”
+
+I had been delayed at a case, and it was a little after half-past
+six when I found myself in Baker Street once more. As I approached
+the house I saw a tall man in a Scotch bonnet with a coat which was
+buttoned up to his chin, waiting outside in the bright semicircle which
+was thrown from the fanlight. Just as I arrived, the door was opened,
+and we were shown up together to Holmes’s room.
+
+“Mr. Henry Baker, I believe,” said he, rising from his arm-chair, and
+greeting his visitor with the easy air of geniality which he could so
+readily assume. “Pray take this chair by the fire, Mr. Baker. It is a
+cold night, and I observe that your circulation is more adapted for
+summer than for winter. Ah, Watson, you have just come at the right
+time. Is that your hat, Mr. Baker?”
+
+“Yes, sir, that is undoubtedly my hat.”
+
+He was a large man, with rounded shoulders, a massive head, and a
+broad, intelligent face, sloping down to a pointed beard of grizzled
+brown. A touch of red in nose and cheeks, with a slight tremor of his
+extended hand, recalled Holmes’s surmise as to his habits. His rusty
+black frock-coat was buttoned right up in front, with the collar turned
+up, and his lank wrists protruded from his sleeves without a sign of
+cuff or shirt. He spoke in a slow staccato fashion, choosing his words
+with care, and gave the impression generally of a man of learning and
+letters who had had ill-usage at the hands of fortune.
+
+“We have retained these things for some days,” said Holmes, “because we
+expected to see an advertisement from you giving your address. I am at
+a loss to know now why you did not advertise.”
+
+Our visitor gave a rather shamefaced laugh. “Shillings have not been
+so plentiful with me as they once were,” he remarked. “I had no doubt
+that the gang of roughs who assaulted me had carried off both my hat
+and the bird. I did not care to spend more money in a hopeless attempt
+at recovering them.”
+
+“Very naturally. By-the-way, about the bird, we were compelled to eat
+it.”
+
+“To eat it!” Our visitor half rose from his chair in his excitement.
+
+“Yes, it would have been of no use to any one had we not done so. But
+I presume that this other goose upon the sideboard, which is about the
+same weight and perfectly fresh, will answer your purpose equally well?”
+
+“Oh, certainly, certainly;” answered Mr. Baker, with a sigh of relief.
+
+“Of course, we still have the feathers, legs, crop, and so on of your
+own bird, so if you wish—”
+
+The man burst into a hearty laugh. “They might be useful to me as
+relics of my adventure,” said he, “but beyond that I can hardly see
+what use the _disjecta membra_ of my late acquaintance are going to be
+to me. No, sir, I think that, with your permission, I will confine my
+attentions to the excellent bird which I perceive upon the sideboard.”
+
+Sherlock Holmes glanced sharply across at me with a slight shrug of his
+shoulders.
+
+“There is your hat, then, and there your bird,” said he. “By-the-way,
+would it bore you to tell me where you got the other one from? I am
+somewhat of a fowl fancier, and I have seldom seen a better grown
+goose.”
+
+“Certainly, sir,” said Baker, who had risen and tucked his newly-gained
+property under his arm. “There are a few of us who frequent the ‘Alpha
+Inn,’ near the Museum—we are to be found in the Museum itself during
+the day, you understand. This year our good host, Windigate by name,
+instituted a goose club, by which, on consideration of some few pence
+every week, we were each to receive a bird at Christmas. My pence were
+duly paid, and the rest is familiar to you. I am much indebted to you,
+sir, for a Scotch bonnet is fitted neither to my years nor my gravity.”
+With a comical pomposity of manner he bowed solemnly to both of us and
+strode off upon his way.
+
+“So much for Mr. Henry Baker,” said Holmes, when he had closed the door
+behind him. “It is quite certain that he knows nothing whatever about
+the matter. Are you hungry, Watson?”
+
+“Not particularly.”
+
+“Then I suggest that we turn our dinner into a supper, and follow up
+this clew while it is still hot.”
+
+“By all means.”
+
+It was a bitter night, so we drew on our ulsters and wrapped cravats
+about our throats. Outside, the stars were shining coldly in a
+cloudless sky, and the breath of the passers-by blew out into smoke
+like so many pistol shots. Our footfalls rang out crisply and loudly
+as we swung through the Doctors’ quarter, Wimpole Street, Harley
+Street, and so through Wigmore Street into Oxford Street. In a quarter
+of an hour we were in Bloomsbury at the “Alpha Inn,” which is a small
+public-house at the corner of one of the streets which runs down into
+Holborn. Holmes pushed open the door of the private bar, and ordered
+two glasses of beer from the ruddy-faced, white-aproned landlord.
+
+“Your beer should be excellent if it is as good as your geese,” said he.
+
+“My geese!” The man seemed surprised.
+
+“Yes. I was speaking only half an hour ago to Mr. Henry Baker, who was
+a member of your goose club.”
+
+“Ah! yes, I see. But you see, sir, them’s not _our_ geese.”
+
+“Indeed! Whose, then?”
+
+“Well, I got the two dozen from a salesman in Covent Garden.”
+
+“Indeed? I know some of them. Which was it?”
+
+“Breckinridge is his name.”
+
+“Ah! I don’t know him. Well, here’s your good health, landlord, and
+prosperity to your house. Good-night?”
+
+“Now for Mr. Breckinridge,” he continued, buttoning up his coat, as we
+came out into the frosty air. “Remember, Watson, that though we have
+so homely a thing as a goose at one end of this chain, we have at the
+other a man who will certainly get seven years’ penal servitude unless
+we can establish his innocence. It is possible that our inquiry may but
+confirm his guilt; but, in any case, we have a line of investigation
+which has been missed by the police, and which a singular chance has
+placed in our hands. Let us follow it out to the bitter end. Faces to
+the south, then, and quick march!”
+
+We passed across Holborn, down Endell Street, and so through a zigzag
+of slums to Covent Garden Market. One of the largest stalls bore the
+name of Breckinridge upon it, and the proprietor, a horsey-looking man,
+with a sharp face and trim side-whiskers, was helping a boy to put up
+the shutters.
+
+“Good-evening. It’s a cold night,” said Holmes.
+
+The salesman nodded, and shot a questioning glance at my companion.
+
+“Sold out of geese, I see,” continued Holmes, pointing at the bare
+slabs of marble.
+
+“Let you have 500 to-morrow morning.”
+
+“That’s no good.”
+
+“Well, there are some on the stall with the gas-flare.”
+
+“Ah, but I was recommended to you.”
+
+“Who by?”
+
+“The landlord of the ‘Alpha.’”
+
+“Oh, yes; I sent him a couple of dozen.”
+
+“Fine birds they were, too. Now where did you get them from?”
+
+To my surprise the question provoked a burst of anger from the salesman.
+
+“Now, then, mister,” said he, with his head cocked and his arms
+akimbo, “what are you driving at? Let’s have it straight, now.”
+
+“It is straight enough. I should like to know who sold you the geese
+which you supplied to the ‘Alpha.’”
+
+“Well, then, I sha’n’t tell you. So now!”
+
+“Oh, it is a matter of no importance; but I don’t know why you should
+be so warm over such a trifle.”
+
+“Warm! You’d be as warm, maybe, if you were as pestered as I am. When
+I pay good money for a good article there should be an end of the
+business; but it’s ‘Where are the geese?’ and ‘Who did you sell the
+geese to?’ and ‘What will you take for the geese?’ One would think they
+were the only geese in the world, to hear the fuss that is made over
+them.”
+
+“Well, I have no connection with any other people who have been making
+inquiries,” said Holmes, carelessly. “If you won’t tell us the bet is
+off, that is all. But I’m always ready to back my opinion on a matter
+of fowls, and I have a fiver on it that the bird I ate is country bred.”
+
+“Well, then, you’ve lost your fiver, for it’s town bred,” snapped the
+salesman.
+
+“It’s nothing of the kind.”
+
+“I say it is.”
+
+“I don’t believe it.”
+
+“D’you think you know more about fowls than I, who have handled them
+ever since I was a nipper? I tell you, all those birds that went to the
+‘Alpha’ were town bred.”
+
+“You’ll never persuade me to believe that.”
+
+“Will you bet, then?”
+
+“It’s merely taking your money, for I know that I am right. But I’ll
+have a sovereign on with you, just to teach you not to be obstinate.”
+
+The salesman chuckled grimly. “Bring me the books, Bill,” said he.
+
+The small boy brought round a small thin volume and a great
+greasy-backed one, laying them out together beneath the hanging lamp.
+
+“Now then, Mr. Cocksure,” said the salesman, “I thought that I was out
+of geese, but before I finish you’ll find that there is still one left
+in my shop. You see this little book?”
+
+“Well?”
+
+“That’s the list of the folk from whom I buy. D’you see? Well, then,
+here on this page are the country folk, and the numbers after their
+names are where their accounts are in the big ledger. Now, then!
+You see this other page in red ink? Well, that is a list of my town
+suppliers. Now, look at that third name. Just read it out to me.”
+
+“Mrs. Oakshott, 117, Brixton Road—249,” read Holmes.
+
+“Quite so. Now turn that up in the ledger.”
+
+Holmes turned to the page indicated. “Here you are, ‘Mrs. Oakshott,
+117, Brixton Road, egg and poultry supplier.’”
+
+“Now, then, what’s the last entry?”
+
+“‘December 22. Twenty-four geese at 7_s._ 6_d._’”
+
+“Quite so. There you are. And underneath?”
+
+“‘Sold to Mr. Windigate of the ‘Alpha,’ at 12_s._’”
+
+“What have you to say now?”
+
+Sherlock Holmes looked deeply chagrined. He drew a sovereign from his
+pocket and threw it down upon the slab, turning away with the air of
+a man whose disgust is too deep for words. A few yards off he stopped
+under a lamp-post, and laughed in the hearty, noiseless fashion which
+was peculiar to him.
+
+“When you see a man with whiskers of that cut and the ‘pink ‘un’
+protruding out of his pocket, you can always draw him by a bet,” said
+he. “I dare say that if I had put £100 down in front of him, that man
+would not have given me such complete information as was drawn from
+him by the idea that he was doing me on a wager. Well, Watson, we
+are, I fancy, nearing the end of our quest, and the only point which
+remains to be determined is whether we should go on to this Mrs.
+Oakshott to-night, or whether we should reserve it for to-morrow. It is
+clear from what that surly fellow said that there are others besides
+ourselves who are anxious about the matter, and I should—”
+
+His remarks were suddenly cut short by a loud hubbub which broke out
+from the stall which we had just left. Turning round we saw a little
+rat-faced fellow standing in the centre of the circle of yellow light
+which was thrown by the swinging lamp, while Breckinridge the salesman,
+framed in the door of his stall, was shaking his fists fiercely at the
+cringing figure.
+
+“I’ve had enough of you and your geese,” he shouted. “I wish you were
+all at the devil together. If you come pestering me any more with your
+silly talk I’ll set the dog at you. You bring Mrs. Oakshott here and
+I’ll answer her, but what have you to do with it? Did I buy the geese
+off you?”
+
+“No; but one of them was mine all the same,” whined the little man.
+
+“Well, then, ask Mrs. Oakshott for it.”
+
+“She told me to ask you.”
+
+“Well, you can ask the King of Proosia, for all I care. I’ve had enough
+of it. Get out of this!” He rushed fiercely forward, and the inquirer
+flitted away into the darkness.
+
+“Ha! this may save us a visit to Brixton Road,” whispered Holmes. “Come
+with me, and we will see what is to be made of this fellow.” Striding
+through the scattered knots of people who lounged round the flaring
+stalls, my companion speedily overtook the little man and touched him
+upon the shoulder. He sprang round, and I could see in the gaslight
+that every vestige of color had been driven from his face.
+
+“Who are you, then? What do you want?” he asked, in a quavering voice.
+
+“You will excuse me,” said Holmes, blandly, “but I could not help
+overhearing the questions which you put to the salesman just now. I
+think that I could be of assistance to you.”
+
+“You? Who are you? How could you know anything of the matter?”
+
+“My name is Sherlock Holmes. It is my business to know what other
+people don’t know.”
+
+“But you can know nothing of this?”
+
+“Excuse me, I know everything of it. You are endeavoring to trace some
+geese which were sold by Mrs. Oakshott, of Brixton Road, to a salesman
+named Breckinridge, by him in turn to Mr. Windigate, of the ‘Alpha,’
+and by him to his club, of which Mr. Henry Baker is a member.”
+
+“Oh, sir, you are the very man whom I have longed to meet,” cried the
+little fellow, with outstretched hands and quivering fingers. “I can
+hardly explain to you how interested I am in this matter.”
+
+Sherlock Holmes hailed a four-wheeler which was passing. “In that case
+we had better discuss it in a cosey room rather than in this windswept
+market-place,” said he. “But pray tell me, before we go farther, who it
+is that I have the pleasure of assisting.”
+
+The man hesitated for an instant. “My name is John Robinson,” he
+answered, with a sidelong glance.
+
+“No, no; the real name,” said Holmes, sweetly. “It is always awkward
+doing business with an _alias_.”
+
+A flush sprang to the white cheeks of the stranger. “Well, then,” said
+he, “my real name is James Ryder.”
+
+“Precisely so. Head attendant at the ‘Hotel Cosmopolitan.’ Pray step
+into the cab, and I shall soon be able to tell you everything which you
+would wish to know.”
+
+The little man stood glancing from one to the other of us with
+half-frightened, half-hopeful eyes, as one who is not sure whether he
+is on the verge of a windfall or of a catastrophe. Then he stepped into
+the cab, and in half an hour we were back in the sitting-room at Baker
+Street. Nothing had been said during our drive, but the high, thin
+breathing of our new companion, and the claspings and unclaspings of
+his hands, spoke of the nervous tension within him.
+
+“Here we are!” said Holmes, cheerily, as we filed into the room. “The
+fire looks very seasonable in this weather. You look cold, Mr. Ryder.
+Pray take the basket-chair. I will just put on my slippers before we
+settle this little matter of yours. Now, then! You want to know what
+became of those geese?”
+
+“Yes, sir.”
+
+“Or rather, I fancy, of that goose. It was one bird, I imagine, in
+which you were interested—white, with a black bar across the tail.”
+
+Ryder quivered with emotion. “Oh, sir,” he cried, “can you tell me
+where it went to?”
+
+“It came here.”
+
+“Here?”
+
+“Yes, and a most remarkable bird it proved. I don’t wonder that you
+should take an interest in it. It laid an egg after it was dead—the
+bonniest, brightest little blue egg that ever was seen. I have it here
+in my museum.”
+
+Our visitor staggered to his feet and clutched the mantel-piece with
+his right hand. Holmes unlocked his strong-box, and held up the blue
+carbuncle, which shone out like a star, with a cold, brilliant,
+many-pointed radiance. Ryder stood glaring with a drawn face, uncertain
+whether to claim or to disown it.
+
+“The game’s up, Ryder,” said Holmes, quietly. “Hold up, man, or you’ll
+be into the fire! Give him an arm back into his chair, Watson. He’s not
+got blood enough to go in for felony with impunity. Give him a dash of
+brandy. So! Now he looks a little more human. What a shrimp it is, to
+be sure!”
+
+For a moment he had staggered and nearly fallen, but the brandy brought
+a tinge of color into his cheeks, and he sat staring with frightened
+eyes at his accuser.
+
+“I have almost every link in my hands, and all the proofs which I could
+possibly need, so there is little which you need tell me. Still, that
+little may as well be cleared up to make the case complete. You had
+heard, Ryder, of this blue stone of the Countess of Morcar’s?”
+
+“It was Catherine Cusack who told me of it,” said he, in a crackling
+voice.
+
+“I see—her ladyship’s waiting-maid. Well, the temptation of sudden
+wealth so easily acquired was too much for you, as it has been for
+better men before you; but you were not very scrupulous in the means
+you used. It seems to me, Ryder, that there is the making of a very
+pretty villain in you. You knew that this man Horner, the plumber, had
+been concerned in some such matter before, and that suspicion would
+rest the more readily upon him. What did you do, then? You made some
+small job in my lady’s room—you and your confederate Cusack—and you
+managed that he should be the man sent for. Then, when he had left, you
+rifled the jewel-case, raised the alarm, and had this unfortunate man
+arrested. You then—”
+
+Ryder threw himself down suddenly upon the rug and clutched at my
+companion’s knees. “For God’s sake, have mercy!” he shrieked. “Think
+of my father! of my mother! It would break their hearts. I never went
+wrong before! I never will again. I swear it. I’ll swear it on a Bible.
+Oh, don’t bring it into court! For Christ’s sake, don’t!”
+
+“Get back into your chair!” said Holmes, sternly. “It is very well to
+cringe and crawl now, but you thought little enough of this poor Horner
+in the dock for a crime of which he knew nothing.”
+
+“I will fly, Mr. Holmes. I will leave the country, sir. Then the charge
+against him will break down.”
+
+“Hum! We will talk about that. And now let us hear a true account of
+the next act. How came the stone into the goose, and how came the goose
+into the open market? Tell us the truth, for there lies your only hope
+of safety.”
+
+[Illustration: “‘HAVE MERCY!’ HE SHRIEKED”]
+
+Ryder passed his tongue over his parched lips. “I will tell you it
+just as it happened, sir,” said he. “When Horner had been arrested, it
+seemed to me that it would be best for me to get away with the stone
+at once, for I did not know at what moment the police might not take
+it into their heads to search me and my room. There was no place about
+the hotel where it would be safe. I went out, as if on some commission,
+and I made for my sister’s house. She had married a man named Oakshott,
+and lived in Brixton Road, where she fattened fowls for the market.
+All the way there every man I met seemed to me to be a policeman or a
+detective; and, for all that it was a cold night, the sweat was pouring
+down my face before I came to the Brixton Road. My sister asked me what
+was the matter, and why I was so pale; but I told her that I had been
+upset by the jewel robbery at the hotel. Then I went into the back yard
+and smoked a pipe, and wondered what it would be best to do.
+
+“I had a friend once called Maudsley, who went to the bad, and has just
+been serving his time in Pentonville. One day he had met me, and fell
+into talk about the ways of thieves, and how they could get rid of what
+they stole. I knew that he would be true to me, for I knew one or two
+things about him; so I made up my mind to go right on to Kilburn, where
+he lived, and take him into my confidence. He would show me how to
+turn the stone into money. But how to get to him in safety? I thought
+of the agonies I had gone through in coming from the hotel. I might
+at any moment be seized and searched, and there would be the stone
+in my waistcoat pocket. I was leaning against the wall at the time,
+and looking at the geese which were waddling about round my feet, and
+suddenly an idea came into my head which showed me how I could beat the
+best detective that ever lived.
+
+“My sister had told me some weeks before that I might have the pick of
+her geese for a Christmas present, and I knew that she was always as
+good as her word. I would take my goose now, and in it I would carry
+my stone to Kilburn. There was a little shed in the yard, and behind
+this I drove one of the birds—a fine big one, white, with a barred
+tail. I caught it, and, prying its bill open, I thrust the stone down
+its throat as far as my finger could reach. The bird gave a gulp, and I
+felt the stone pass along its gullet and down into its crop. But the
+creature flapped and struggled, and out came my sister to know what
+was the matter. As I turned to speak to her the brute broke loose and
+fluttered off among the others.
+
+“‘Whatever were you doing with that bird, Jem?’ says she.
+
+“‘Well,’ said I, ‘you said you’d give me one for Christmas, and I was
+feeling which was the fattest.’
+
+“‘Oh,’ says she, ‘we’ve set yours aside for you—Jem’s bird, we call
+it. It’s the big white one over yonder. There’s twenty-six of them,
+which makes one for you, and one for us, and two dozen for the market.’
+
+“‘Thank you, Maggie,’ says I; ‘but if it is all the same to you, I’d
+rather have that one I was handling just now.’
+
+“‘The other is a good three pound heavier,’ said she, ‘and we fattened
+it expressly for you.’
+
+“‘Never mind. I’ll have the other, and I’ll take it now,’ said I.
+
+“‘Oh, just as you like,’ said she, a little huffed. ‘Which is it you
+want, then?’
+
+“‘That white one with the barred tail, right in the middle of the
+flock.’
+
+“‘Oh, very well. Kill it and take it with you.’
+
+“Well, I did what she said, Mr. Holmes, and I carried the bird all the
+way to Kilburn. I told my pal what I had done, for he was a man that
+it was easy to tell a thing like that to. He laughed until he choked,
+and we got a knife and opened the goose. My heart turned to water, for
+there was no sign of the stone, and I knew that some terrible mistake
+had occurred. I left the bird, rushed back to my sister’s, and hurried
+into the back yard. There was not a bird to be seen there.
+
+“‘Where are they all, Maggie?’ I cried.
+
+“‘Gone to the dealer’s, Jem.’
+
+“‘Which dealer’s?’
+
+“‘Breckinridge, of Covent Garden.’
+
+“‘But was there another with a barred tail?’ I asked, ‘the same as the
+one I chose?’
+
+“‘Yes, Jem; there were two barred-tailed ones, and I could never tell
+them apart.’
+
+“Well, then, of course I saw it all, and I ran off as hard as my feet
+would carry me to this man Breckinridge; but he had sold the lot at
+once, and not one word would he tell me as to where they had gone. You
+heard him yourselves to-night. Well, he has always answered me like
+that. My sister thinks that I am going mad. Sometimes I think that I
+am myself. And now—and now I am myself a branded thief, without ever
+having touched the wealth for which I sold my character. God help me!
+God help me!” He burst into convulsive sobbing, with his face buried in
+his hands.
+
+There was a long silence, broken only by his heavy breathing, and by
+the measured tapping of Sherlock Holmes’s finger-tips upon the edge of
+the table. Then my friend rose and threw open the door.
+
+“Get out!” said he.
+
+“What, sir! Oh, heaven bless you!”
+
+“No more words. Get out!”
+
+And no more words were needed. There was a rush, a clatter upon the
+stairs, the bang of a door, and the crisp rattle of running footfalls
+from the street.
+
+“After all, Watson,” said Holmes, reaching up his hand for his clay
+pipe, “I am not retained by the police to supply their deficiencies. If
+Horner were in danger it would be another thing; but this fellow will
+not appear against him, and the case must collapse. I suppose that I am
+commuting a felony, but it is just possible that I am saving a soul.
+This fellow will not go wrong again; he is too terribly frightened.
+Send him to jail now, and you make him a jail-bird for life. Besides,
+it is the season of forgiveness. Chance has put in our way a most
+singular and whimsical problem, and its solution is its own reward.
+If you will have the goodness to touch the bell, doctor, we will
+begin another investigation, in which, also, a bird will be the chief
+feature.”
+
+
+
+
+Adventure VIII
+
+THE ADVENTURE OF THE SPECKLED BAND
+
+
+On glancing over my notes of the seventy odd cases in which I have
+during the last eight years studied the methods of my friend Sherlock
+Holmes, I find many tragic, some comic, a large number merely strange,
+but none commonplace; for, working as he did rather for the love of his
+art than for the acquirement of wealth, he refused to associate himself
+with any investigation which did not tend towards the unusual, and even
+the fantastic. Of all these varied cases, however, I cannot recall any
+which presented more singular features than that which was associated
+with the well-known Surrey family of the Roylotts of Stoke Moran. The
+events in question occurred in the early days of my association with
+Holmes, when we were sharing rooms as bachelors in Baker Street. It
+is possible that I might have placed them upon record before, but a
+promise of secrecy was made at the time, from which I have only been
+freed during the last month by the untimely death of the lady to whom
+the pledge was given. It is perhaps as well that the facts should now
+come to light, for I have reasons to know that there are wide-spread
+rumors as to the death of Dr. Grimesby Roylott which tend to make the
+matter even more terrible than the truth.
+
+It was early in April in the year ’83 that I woke one morning to find
+Sherlock Holmes standing, fully dressed, by the side of my bed. He was
+a late riser as a rule, and as the clock on the mantel-piece showed
+me that it was only a quarter past seven, I blinked up at him in some
+surprise, and perhaps just a little resentment, for I was myself
+regular in my habits.
+
+“Very sorry to knock you up, Watson,” said he, “but it’s the common lot
+this morning. Mrs. Hudson has been knocked up, she retorted upon me,
+and I on you.”
+
+“What is it, then—a fire?”
+
+“No; a client. It seems that a young lady has arrived in a considerable
+state of excitement, who insists upon seeing me. She is waiting now in
+the sitting-room. Now, when young ladies wander about the metropolis
+at this hour of the morning, and knock sleepy people up out of their
+beds, I presume that it is something very pressing which they have to
+communicate. Should it prove to be an interesting case, you would, I am
+sure, wish to follow it from the outset. I thought, at any rate, that I
+should call you and give you the chance.”
+
+“My dear fellow, I would not miss it for anything.”
+
+I had no keener pleasure than in following Holmes in his professional
+investigations, and in admiring the rapid deductions, as swift as
+intuitions, and yet always founded on a logical basis, with which he
+unravelled the problems which were submitted to him. I rapidly threw on
+my clothes, and was ready in a few minutes to accompany my friend down
+to the sitting-room. A lady dressed in black and heavily veiled, who
+had been sitting in the window, rose as we entered.
+
+“Good-morning, madam,” said Holmes, cheerily. “My name is Sherlock
+Holmes. This is my intimate friend and associate, Dr. Watson, before
+whom you can speak as freely as before myself. Ha! I am glad to see
+that Mrs. Hudson has had the good sense to light the fire. Pray draw up
+to it, and I shall order you a cup of hot coffee, for I observe that
+you are shivering.”
+
+“It is not cold which makes me shiver,” said the woman, in a low voice,
+changing her seat as requested.
+
+“What, then?”
+
+“It is fear, Mr. Holmes. It is terror.” She raised her veil as she
+spoke, and we could see that she was indeed in a pitiable state of
+agitation, her face all drawn and gray, with restless, frightened eyes,
+like those of some hunted animal. Her features and figure were those of
+a woman of thirty, but her hair was shot with premature gray, and her
+expression was weary and haggard. Sherlock Holmes ran her over with one
+of his quick, all-comprehensive glances.
+
+“You must not fear,” said he, soothingly, bending forward and patting
+her forearm. “We shall soon set matters right, I have no doubt. You
+have come in by train this morning, I see.”
+
+“You know me, then?”
+
+“No, but I observe the second half of a return ticket in the palm of
+your left glove. You must have started early, and yet you had a good
+drive in a dog-cart, along heavy roads, before you reached the station.”
+
+The lady gave a violent start, and stared in bewilderment at my
+companion.
+
+“There is no mystery, my dear madam,” said he, smiling. “The left arm
+of your jacket is spattered with mud in no less than seven places. The
+marks are perfectly fresh. There is no vehicle save a dog-cart which
+throws up mud in that way, and then only when you sit on the left-hand
+side of the driver.”
+
+“Whatever your reasons may be, you are perfectly correct,” said she. “I
+started from home before six, reached Leatherhead at twenty past, and
+came in by the first train to Waterloo. Sir, I can stand this strain no
+longer; I shall go mad if it continues. I have no one to turn to—none,
+save only one, who cares for me, and he, poor fellow, can be of little
+aid. I have heard of you, Mr. Holmes; I have heard of you from Mrs.
+Farintosh, whom you helped in the hour of her sore need. It was from
+her that I had your address. Oh, sir, do you not think that you could
+help me, too, and at least throw a little light through the dense
+darkness which surrounds me? At present it is out of my power to reward
+you for your services, but in a month or six weeks I shall be married,
+with the control of my own income, and then at least you shall not
+find me ungrateful.”
+
+Holmes turned to his desk, and unlocking it, drew out a small
+case-book, which he consulted.
+
+“Farintosh,” said he. “Ah yes, I recall the case; it was concerned with
+an opal tiara. I think it was before your time, Watson. I can only say,
+madam, that I shall be happy to devote the same care to your case as
+I did to that of your friend. As to reward, my profession is its own
+reward; but you are at liberty to defray whatever expenses I may be put
+to, at the time which suits you best. And now I beg that you will lay
+before us everything that may help us in forming an opinion upon the
+matter.”
+
+“Alas!” replied our visitor, “the very horror of my situation lies
+in the fact that my fears are so vague, and my suspicions depend so
+entirely upon small points, which might seem trivial to another, that
+even he to whom of all others I have a right to look for help and
+advice looks upon all that I tell him about it as the fancies of a
+nervous woman. He does not say so, but I can read it from his soothing
+answers and averted eyes. But I have heard, Mr. Holmes, that you can
+see deeply into the manifold wickedness of the human heart. You may
+advise me how to walk amid the dangers which encompass me.”
+
+“I am all attention, madam.”
+
+“My name is Helen Stoner, and I am living with my step-father, who is
+the last survivor of one of the oldest Saxon families in England, the
+Roylotts of Stoke Moran, on the western border of Surrey.”
+
+Holmes nodded his head. “The name is familiar to me,” said he.
+
+“The family was at one time among the richest in England, and the
+estates extended over the borders into Berkshire in the north, and
+Hampshire in the west. In the last century, however, four successive
+heirs were of a dissolute and wasteful disposition, and the family
+ruin was eventually completed by a gambler in the days of the
+Regency. Nothing was left save a few acres of ground, and the
+two-hundred-year-old house, which is itself crushed under a heavy
+mortgage. The last squire dragged out his existence there, living
+the horrible life of an aristocratic pauper; but his only son, my
+step-father, seeing that he must adapt himself to the new conditions,
+obtained an advance from a relative, which enabled him to take a
+medical degree, and went out to Calcutta, where, by his professional
+skill and his force of character, he established a large practice.
+In a fit of anger, however, caused by some robberies which had been
+perpetrated in the house, he beat his native butler to death, and
+narrowly escaped a capital sentence. As it was, he suffered a long
+term of imprisonment, and afterwards returned to England a morose and
+disappointed man.
+
+“When Dr. Roylott was in India he married my mother, Mrs. Stoner, the
+young widow of Major-general Stoner, of the Bengal Artillery. My sister
+Julia and I were twins, and we were only two years old at the time of
+my mother’s re-marriage. She had a considerable sum of money—not less
+than £1000 a year—and this she bequeathed to Dr. Roylott entirely
+while we resided with him, with a provision that a certain annual sum
+should be allowed to each of us in the event of our marriage. Shortly
+after our return to England my mother died—she was killed eight years
+ago in a railway accident near Crewe. Dr. Roylott then abandoned his
+attempts to establish himself in practice in London, and took us to
+live with him in the old ancestral house at Stoke Moran. The money
+which my mother had left was enough for all our wants, and there seemed
+to be no obstacle to our happiness.
+
+“But a terrible change came over our step-father about this time.
+Instead of making friends and exchanging visits with our neighbors, who
+had at first been overjoyed to see a Roylott of Stoke Moran back in
+the old family seat, he shut himself up in his house, and seldom came
+out save to indulge in ferocious quarrels with whoever might cross his
+path. Violence of temper approaching to mania has been hereditary in
+the men of the family, and in my step-father’s case it had, I believe,
+been intensified by his long residence in the tropics. A series of
+disgraceful brawls took place, two of which ended in the police-court,
+until at last he became the terror of the village, and the folks
+would fly at his approach, for he is a man of immense strength, and
+absolutely uncontrollable in his anger.
+
+“Last week he hurled the local blacksmith over a parapet into a stream,
+and it was only by paying over all the money which I could gather
+together that I was able to avert another public exposure. He had no
+friends at all save the wandering gypsies, and he would give these
+vagabonds leave to encamp upon the few acres of bramble-covered land
+which represent the family estate, and would accept in return the
+hospitality of their tents, wandering away with them sometimes for
+weeks on end. He has a passion also for Indian animals, which are sent
+over to him by a correspondent, and he has at this moment a cheetah and
+a baboon, which wander freely over his grounds, and are feared by the
+villagers almost as much as their master.
+
+“You can imagine from what I say that my poor sister Julia and I had no
+great pleasure in our lives. No servant would stay with us, and for a
+long time we did all the work of the house. She was but thirty at the
+time of her death, and yet her hair had already begun to whiten, even
+as mine has.”
+
+“Your sister is dead, then?”
+
+“She died just two years ago, and it is of her death that I wish to
+speak to you. You can understand that, living the life which I have
+described, we were little likely to see anyone of our own age and
+position. We had, however, an aunt, my mother’s maiden sister, Miss
+Honoria Westphail, who lives near Harrow, and we were occasionally
+allowed to pay short visits at this lady’s house. Julia went there at
+Christmas two years ago, and met there a half-pay major of marines,
+to whom she became engaged. My step-father learned of the engagement
+when my sister returned, and offered no objection to the marriage; but
+within a fortnight of the day which had been fixed for the wedding, the
+terrible event occurred which has deprived me of my only companion.”
+
+Sherlock Holmes had been leaning back in his chair with his eyes closed
+and his head sunk in a cushion, but he half opened his lids now and
+glanced across at his visitor.
+
+“Pray be precise as to details,” said he.
+
+“It is easy for me to be so, for every event of that dreadful time is
+seared into my memory. The manor-house is, as I have already said, very
+old, and only one wing is now inhabited. The bedrooms in this wing are
+on the ground floor, the sitting-rooms being in the central block of
+the buildings. Of these bedrooms the first is Dr. Roylott’s, the second
+my sister’s, and the third my own. There is no communication between
+them, but they all open out into the same corridor. Do I make myself
+plain?”
+
+“Perfectly so.”
+
+“The windows of the three rooms open out upon the lawn. That fatal
+night Dr. Roylott had gone to his room early, though we knew that he
+had not retired to rest, for my sister was troubled by the smell of
+the strong Indian cigars which it was his custom to smoke. She left
+her room, therefore, and came into mine, where she sat for some time,
+chatting about her approaching wedding. At eleven o’clock she rose to
+leave me but she paused at the door and looked back.
+
+“‘Tell me, Helen,’ said she, ‘have you ever heard any one whistle in
+the dead of the night?’
+
+“‘Never,’ said I.
+
+“‘I suppose that you could not possibly whistle, yourself, in your
+sleep?’
+
+“‘Certainly not. But why?’
+
+“‘Because during the last few nights I have always, about three in
+the morning, heard a low, clear whistle. I am a light sleeper, and it
+has awakened me. I cannot tell where it came from—perhaps from the
+next room, perhaps from the lawn. I thought that I would just ask you
+whether you had heard it.’
+
+“‘No, I have not. It must be those wretched gypsies in the plantation.’
+
+“‘Very likely. And yet if it were on the lawn, I wonder that you did
+not hear it also.’
+
+“‘Ah, but I sleep more heavily than you.’
+
+“‘Well, it is of no great consequence, at any rate.’ She smiled back at
+me, closed my door, and a few moments later I heard her key turn in the
+lock.”
+
+“Indeed,” said Holmes. “Was it your custom always to lock yourselves in
+at night?”
+
+“Always.”
+
+“And why?”
+
+“I think that I mentioned to you that the doctor kept a cheetah and a
+baboon. We had no feeling of security unless our doors were locked.”
+
+“Quite so. Pray proceed with your statement.”
+
+“I could not sleep that night. A vague feeling of impending misfortune
+impressed me. My sister and I, you will recollect, were twins, and you
+know how subtle are the links which bind two souls which are so closely
+allied. It was a wild night. The wind was howling outside, and the rain
+was beating and splashing against the windows. Suddenly, amid all the
+hubbub of the gale, there burst forth the wild scream of a terrified
+woman. I knew that it was my sister’s voice. I sprang from my bed,
+wrapped a shawl round me, and rushed into the corridor. As I opened my
+door I seemed to hear a low whistle, such as my sister described, and a
+few moments later a clanging sound, as if a mass of metal had fallen.
+As I ran down the passage, my sister’s door was unlocked, and revolved
+slowly upon its hinges. I stared at it horror-stricken, not knowing
+what was about to issue from it. By the light of the corridor-lamp I
+saw my sister appear at the opening, her face blanched with terror, her
+hands groping for help, her whole figure swaying to and fro like that
+of a drunkard. I ran to her and threw my arms round her, but at that
+moment her knees seemed to give way and she fell to the ground. She
+writhed as one who is in terrible pain, and her limbs were dreadfully
+convulsed. At first I thought that she had not recognized me, but as I
+bent over her she suddenly shrieked out in a voice which I shall never
+forget, ‘Oh, my God! Helen! It was the band! The speckled band!’ There
+was something else which she would fain have said, and she stabbed with
+her finger into the air in the direction of the doctor’s room, but a
+fresh convulsion seized her and choked her words. I rushed out, calling
+loudly for my step-father, and I met him hastening from his room in his
+dressing-gown. When he reached my sister’s side she was unconscious,
+and though he poured brandy down her throat and sent for medical aid
+from the village, all efforts were in vain, for she slowly sank and
+died without having recovered her consciousness. Such was the dreadful
+end of my beloved sister.”
+
+“One moment,” said Holmes; “are you sure about this whistle and
+metallic sound? Could you swear to it?”
+
+“That was what the county coroner asked me at the inquiry. It is my
+strong impression that I heard it, and yet, among the crash of the gale
+and the creaking of an old house, I may possibly have been deceived.”
+
+“Was your sister dressed?”
+
+“No, she was in her night-dress. In her right hand was found the
+charred stump of a match, and in her left a matchbox.”
+
+“Showing that she had struck a light and looked about her when the
+alarm took place. That is important. And what conclusions did the
+coroner come to?”
+
+“He investigated the case with great care, for Dr. Roylott’s conduct
+had long been notorious in the county, but he was unable to find any
+satisfactory cause of death. My evidence showed that the door had
+been fastened upon the inner side, and the windows were blocked by
+old-fashioned shutters with broad iron bars, which were secured every
+night. The walls were carefully sounded, and were shown to be quite
+solid all round, and the flooring was also thoroughly examined, with
+the same result. The chimney is wide, but is barred up by four large
+staples. It is certain, therefore, that my sister was quite alone when
+she met her end. Besides, there were no marks of any violence upon her.”
+
+“How about poison?”
+
+“The doctors examined her for it, but without success.”
+
+“What do you think that this unfortunate lady died of, then?”
+
+“It is my belief that she died of pure fear and nervous shock, though
+what it was that frightened her I cannot imagine.”
+
+“Were there gypsies in the plantation at the time?”
+
+“Yes, there are nearly always some there.”
+
+“Ah, and what did you gather from this allusion to a band—a speckled
+band?”
+
+“Sometimes I have thought that it was merely the wild talk of delirium,
+sometimes that it may have referred to some band of people, perhaps to
+these very gypsies in the plantation. I do not know whether the spotted
+handkerchiefs which so many of them wear over their heads might have
+suggested the strange adjective which she used.”
+
+Holmes shook his head like a man who is far from being satisfied.
+
+“These are very deep waters,” said he; “pray go on with your narrative.”
+
+“Two years have passed since then, and my life has been until lately
+lonelier than ever. A month ago, however, a dear friend, whom I have
+known for many years, has done me the honor to ask my hand in marriage.
+His name is Armitage—Percy Armitage—the second son of Mr. Armitage,
+of Crane Water, near Reading. My step-father has offered no opposition
+to the match, and we are to be married in the course of the spring. Two
+days ago some repairs were started in the west wing of the building,
+and my bedroom wall has been pierced, so that I have had to move into
+the chamber in which my sister died, and to sleep in the very bed in
+which she slept. Imagine, then, my thrill of terror when last night,
+as I lay awake, thinking over her terrible fate, I suddenly heard in
+the silence of the night the low whistle which had been the herald of
+her own death. I sprang up and lit the lamp, but nothing was to be
+seen in the room. I was too shaken to go to bed again, however, so I
+dressed, and as soon as it was daylight I slipped down, got a dog-cart
+at the ‘Crown Inn,’ which is opposite, and drove to Leatherhead, from
+whence I have come on this morning with the one object of seeing you
+and asking your advice.”
+
+“You have done wisely,” said my friend. “But have you told me all?”
+
+“Yes, all.”
+
+“Miss Roylott, you have not. You are screening your step-father.”
+
+“Why, what do you mean?”
+
+For answer Holmes pushed back the frill of black lace which fringed the
+hand that lay upon our visitor’s knee. Five little livid spots, the
+marks of four fingers and a thumb, were printed upon the white wrist.
+
+“You have been cruelly used,” said Holmes.
+
+The lady colored deeply and covered over her injured wrist. “He is a
+hard man,” she said, “and perhaps he hardly knows his own strength.”
+
+There was a long silence, during which Holmes leaned his chin upon his
+hands and stared into the crackling fire.
+
+“This is a very deep business,” he said, at last. “There are a thousand
+details which I should desire to know before I decide upon our course
+of action. Yet we have not a moment to lose. If we were to come to
+Stoke Moran to-day, would it be possible for us to see over these rooms
+without the knowledge of your step-father?”
+
+“As it happens, he spoke of coming into town to-day upon some most
+important business. It is probable that he will be away all day, and
+that there would be nothing to disturb you. We have a house-keeper
+now, but she is old and foolish, and I could easily get her out of the
+way.”
+
+“Excellent. You are not averse to this trip, Watson?”
+
+“By no means.”
+
+“Then we shall both come. What are you going to do yourself?”
+
+“I have one or two things which I would wish to do now that I am in
+town. But I shall return by the twelve o’clock train, so as to be there
+in time for your coming.”
+
+“And you may expect us early in the afternoon. I have myself some small
+business matters to attend to. Will you not wait and breakfast?”
+
+“No, I must go. My heart is lightened already since I have confided
+my trouble to you. I shall look forward to seeing you again this
+afternoon.” She dropped her thick black veil over her face and glided
+from the room.
+
+“And what do you think of it all, Watson?” asked Sherlock Holmes,
+leaning back in his chair.
+
+“It seems to me to be a most dark and sinister business.”
+
+“Dark enough and sinister enough.”
+
+“Yet if the lady is correct in saying that the flooring and walls are
+sound, and that the door, window, and chimney are impassable, then her
+sister must have been undoubtedly alone when she met her mysterious
+end.”
+
+“What becomes, then, of these nocturnal whistles, and what of the very
+peculiar words of the dying woman?”
+
+“I cannot think.”
+
+“When you combine the ideas of whistles at night, the presence of a
+band of gypsies who are on intimate terms with this old doctor, the
+fact that we have every reason to believe that the doctor has an
+interest in preventing his step-daughter’s marriage, the dying allusion
+to a band, and, finally, the fact that Miss Helen Stoner heard a
+metallic clang, which might have been caused by one of those metal bars
+which secured the shutters falling back into their place, I think that
+there is good ground to think that the mystery may be cleared along
+those lines.”
+
+“But what, then, did the gypsies do?”
+
+“I cannot imagine.”
+
+“I see many objections to any such theory.”
+
+“And so do I. It is precisely for that reason that we are going to
+Stoke Moran this day. I want to see whether the objections are fatal,
+or if they may be explained away. But what in the name of the devil!”
+
+The ejaculation had been drawn from my companion by the fact that our
+door had been suddenly dashed open, and that a huge man had framed
+himself in the aperture. His costume was a peculiar mixture of the
+professional and of the agricultural, having a black top-hat, a long
+frock-coat, and a pair of high gaiters, with a hunting-crop swinging in
+his hand. So tall was he that his hat actually brushed the cross bar
+of the doorway, and his breadth seemed to span it across from side to
+side. A large face, seared with a thousand wrinkles, burned yellow with
+the sun, and marked with every evil passion, was turned from one to the
+other of us, while his deep-set, bile-shot eyes, and his high, thin,
+fleshless nose, gave him somewhat the resemblance to a fierce old bird
+of prey.
+
+“Which of you is Holmes?” asked this apparition.
+
+“My name, sir; but you have the advantage of me,” said my companion,
+quietly.
+
+“I am Dr. Grimesby Roylott, of Stoke Moran.”
+
+“Indeed, doctor,” said Holmes, blandly. “Pray take a seat.”
+
+“I will do nothing of the kind. My step-daughter has been here. I have
+traced her. What has she been saying to you?”
+
+“It is a little cold for the time of the year,” said Holmes.
+
+“What has she been saying to you?” screamed the old man, furiously.
+
+“But I have heard that the crocuses promise well,” continued my
+companion, imperturbably.
+
+“Ha! You put me off, do you?” said our new visitor, taking a step
+forward and shaking his hunting-crop. “I know you, you scoundrel! I
+have heard of you before. You are Holmes, the meddler.”
+
+My friend smiled.
+
+“Holmes, the busybody!”
+
+His smile broadened.
+
+“Holmes, the Scotland-yard Jack-in-office!”
+
+Holmes chuckled heartily. “Your conversation is most entertaining,”
+said he. “When you go out close the door, for there is a decided
+draught.”
+
+“I will go when I have said my say. Don’t you dare to meddle with my
+affairs. I know that Miss Stoner has been here. I traced her! I am a
+dangerous man to fall foul of! See here.” He stepped swiftly forward,
+seized the poker, and bent it into a curve with his huge brown hands.
+
+“See that you keep yourself out of my grip,” he snarled, and hurling
+the twisted poker into the fireplace, he strode out of the room.
+
+“He seems a very amiable person,” said Holmes, laughing. “I am not
+quite so bulky, but if he had remained I might have shown him that my
+grip was not much more feeble than his own.” As he spoke he picked up
+the steel poker, and with a sudden effort straightened it out again.
+
+“Fancy his having the insolence to confound me with the official
+detective force! This incident gives zest to our investigation,
+however, and I only trust that our little friend will not suffer from
+her imprudence in allowing this brute to trace her. And now, Watson,
+we shall order breakfast, and afterwards I shall walk down to Doctors’
+Commons, where I hope to get some data which may help us in this
+matter.”
+
+       *       *       *       *       *
+
+It was nearly one o’clock when Sherlock Holmes returned from his
+excursion. He held in his hand a sheet of blue paper, scrawled over
+with notes and figures.
+
+“I have seen the will of the deceased wife,” said he. “To determine
+its exact meaning I have been obliged to work out the present prices
+of the investments with which it is concerned. The total income, which
+at the time of the wife’s death was little short of £1100, is now,
+through the fall in agricultural prices, not more than £750. Each
+daughter can claim an income of £250, in case of marriage. It is
+evident, therefore, that if both girls had married, this beauty would
+have had a mere pittance, while even one of them would cripple him to
+a very serious extent. My morning’s work has not been wasted, since it
+has proved that he has the very strongest motives for standing in the
+way of anything of the sort. And now, Watson, this is too serious for
+dawdling, especially as the old man is aware that we are interesting
+ourselves in his affairs; so if you are ready, we shall call a cab and
+drive to Waterloo. I should be very much obliged if you would slip your
+revolver into your pocket. An Eley’s No. 2 is an excellent argument
+with gentlemen who can twist steel pokers into knots. That and a
+tooth-brush are, I think, all that we need.”
+
+At Waterloo we were fortunate in catching a train for Leatherhead,
+where we hired a trap at the station inn, and drove for four or five
+miles through the lovely Surrey lanes. It was a perfect day, with
+a bright sun and a few fleecy clouds in the heavens. The trees and
+way-side hedges were just throwing out their first green shoots, and
+the air was full of the pleasant smell of the moist earth. To me at
+least there was a strange contrast between the sweet promise of the
+spring and this sinister quest upon which we were engaged. My companion
+sat in the front of the trap, his arms folded, his hat pulled down over
+his eyes, and his chin sunk upon his breast, buried in the deepest
+thought. Suddenly, however, he started, tapped me on the shoulder, and
+pointed over the meadows.
+
+“Look there!” said he.
+
+A heavily-timbered park stretched up in a gentle slope, thickening into
+a grove at the highest point. From amid the branches there jutted out
+the gray gables and high roof-tree of a very old mansion.
+
+“Stoke Moran?” said he.
+
+“Yes, sir, that be the house of Dr. Grimesby Roylott,” remarked the
+driver.
+
+“There is some building going on there,” said Holmes; “that is where we
+are going.”
+
+“There’s the village,” said the driver, pointing to a cluster of roofs
+some distance to the left; “but if you want to get to the house, you’ll
+find it shorter to get over this stile, and so by the foot-path over
+the fields. There it is, where the lady is walking.”
+
+“And the lady, I fancy, is Miss Stoner,” observed Holmes, shading his
+eyes. “Yes, I think we had better do as you suggest.”
+
+We got off, paid our fare, and the trap rattled back on its way to
+Leatherhead.
+
+“I thought it as well,” said Holmes, as we climbed the stile, “that
+this fellow should think we had come here as architects, or on some
+definite business. It may stop his gossip. Good-afternoon, Miss Stoner.
+You see that we have been as good as our word.”
+
+Our client of the morning had hurried forward to meet us with a face
+which spoke her joy. “I have been waiting so eagerly for you,” she
+cried, shaking hands with us warmly. “All has turned out splendidly.
+Dr. Roylott has gone to town, and it is unlikely that he will be back
+before evening.”
+
+“We have had the pleasure of making the doctor’s acquaintance,” said
+Holmes, and in a few words he sketched out what had occurred. Miss
+Stoner turned white to the lips as she listened.
+
+“Good heavens!” she cried, “he has followed me, then.”
+
+“So it appears.”
+
+“He is so cunning that I never know when I am safe from him. What will
+he say when he returns?”
+
+“He must guard himself, for he may find that there is some one more
+cunning than himself upon his track. You must lock yourself up from him
+to-night. If he is violent, we shall take you away to your aunt’s at
+Harrow. Now, we must make the best use of our time, so kindly take us
+at once to the rooms which we are to examine.”
+
+The building was of gray, lichen-blotched stone, with a high central
+portion, and two curving wings, like the claws of a crab, thrown out
+on each side. In one of these wings the windows were broken, and
+blocked with wooden boards, while the roof was partly caved in, a
+picture of ruin. The central portion was in little better repair, but
+the right-hand block was comparatively modern, and the blinds in the
+windows, with the blue smoke curling up from the chimneys, showed that
+this was where the family resided. Some scaffolding had been erected
+against the end wall, and the stone-work had been broken into, but
+there were no signs of any workmen at the moment of our visit. Holmes
+walked slowly up and down the ill-trimmed lawn, and examined with deep
+attention the outsides of the windows.
+
+“This, I take it, belongs to the room in which you used to sleep, the
+centre one to your sister’s, and the one next to the main building to
+Dr. Roylott’s chamber?”
+
+“Exactly so. But I am now sleeping in the middle one.”
+
+“Pending the alterations, as I understand. By-the-way, there does not
+seem to be any very pressing need for repairs at that end wall.”
+
+“There were none. I believe that it was an excuse to move me from my
+room.”
+
+“Ah! that is suggestive. Now, on the other side of this narrow wing
+runs the corridor from which these three rooms open. There are windows
+in it, of course?”
+
+“Yes, but very small ones. Too narrow for any one to pass through.”
+
+“As you both locked your doors at night, your rooms were unapproachable
+from that side. Now, would you have the kindness to go into your room
+and bar your shutters.”
+
+Miss Stoner did so, and Holmes, after a careful examination through
+the open window, endeavored in every way to force the shutter open,
+but without success. There was no slit through which a knife could be
+passed to raise the bar. Then with his lens he tested the hinges, but
+they were of solid iron, built firmly into the massive masonry. “Hum!”
+said he, scratching his chin in some perplexity; “my theory certainly
+presents some difficulties. No one could pass these shutters if they
+were bolted. Well, we shall see if the inside throws any light upon the
+matter.”
+
+A small side door led into the whitewashed corridor from which the
+three bedrooms opened. Holmes refused to examine the third chamber,
+so we passed at once to the second, that in which Miss Stoner was now
+sleeping, and in which her sister had met with her fate. It was a
+homely little room, with a low ceiling and a gaping fireplace, after
+the fashion of old country-houses. A brown chest of drawers stood
+in one corner, a narrow white-counterpaned bed in another, and a
+dressing-table on the left-hand side of the window. These articles,
+with two small wicker-work chairs, made up all the furniture in the
+room, save for a square of Wilton carpet in the centre. The boards
+round and the panelling of the walls were of brown, worm-eaten oak, so
+old and discolored that it may have dated from the original building of
+the house. Holmes drew one of the chairs into a corner and sat silent,
+while his eyes travelled round and round and up and down, taking in
+every detail of the apartment.
+
+“Where does that bell communicate with?” he asked, at last, pointing to
+a thick bell-rope which hung down beside the bed, the tassel actually
+lying upon the pillow.
+
+“It goes to the house-keeper’s room.”
+
+“It looks newer than the other things?”
+
+“Yes, it was only put there a couple of years ago.”
+
+“Your sister asked for it, I suppose?”
+
+“No, I never heard of her using it. We used always to get what we
+wanted for ourselves.”
+
+“Indeed, it seemed unnecessary to put so nice a bell-pull there. You
+will excuse me for a few minutes while I satisfy myself as to this
+floor.” He threw himself down upon his face with his lens in his hand,
+and crawled swiftly backward and forward, examining minutely the cracks
+between the boards. Then he did the same with the wood-work with which
+the chamber was panelled. Finally he walked over to the bed, and spent
+some time in staring at it, and in running his eye up and down the
+wall. Finally he took the bell-rope in his hand and gave it a brisk tug.
+
+“Why, it’s a dummy,” said he.
+
+“Won’t it ring?”
+
+“No, it is not even attached to a wire. This is very interesting. You
+can see now that it is fastened to a hook just above where the little
+opening for the ventilator is.”
+
+“How very absurd! I never noticed that before.”
+
+“Very strange!” muttered Holmes, pulling at the rope. “There are one or
+two very singular points about this room. For example, what a fool a
+builder must be to open a ventilator into another room, when, with the
+same trouble, he might have communicated with the outside air!”
+
+“That is also quite modern,” said the lady.
+
+“Done about the same time as the bell-rope?” remarked Holmes.
+
+“Yes, there were several little changes carried out about that time.”
+
+“They seem to have been of a most interesting character—dummy
+bell-ropes, and ventilators which do not ventilate. With your
+permission, Miss Stoner, we shall now carry our researches into the
+inner apartment.”
+
+Dr. Grimesby Roylott’s chamber was larger than that of his
+step-daughter, but was as plainly furnished. A camp-bed, a small wooden
+shelf full of books, mostly of a technical character, an arm-chair
+beside the bed, a plain wooden chair against the wall, a round table,
+and a large iron safe were the principal things which met the eye.
+Holmes walked slowly round and examined each and all of them with the
+keenest interest.
+
+“What’s in here?” he asked, tapping the safe.
+
+“My step-father’s business papers.”
+
+“Oh! you have seen inside, then?”
+
+“Only once, some years ago. I remember that it was full of papers.”
+
+“There isn’t a cat in it, for example?”
+
+“No. What a strange idea!”
+
+“Well, look at this!” He took up a small saucer of milk which stood on
+the top of it.
+
+“No; we don’t keep a cat. But there is a cheetah and a baboon.”
+
+“Ah, yes, of course! Well, a cheetah is just a big cat, and yet a
+saucer of milk does not go very far in satisfying its wants, I dare
+say. There is one point which I should wish to determine.” He squatted
+down in front of the wooden chair, and examined the seat of it with the
+greatest attention.
+
+“Thank you. That is quite settled,” said he, rising and putting his
+lens in his pocket. “Hello! Here is something interesting!”
+
+The object which had caught his eye was a small dog-lash hung on one
+corner of the bed. The lash, however, was curled upon itself, and tied
+so as to make a loop of whip-cord.
+
+“What do you make of that, Watson?”
+
+“It’s a common enough lash. But I don’t know why it should be tied.”
+
+“That is not quite so common, is it? Ah, me! it’s a wicked world,
+and when a clever man turns his brains to crime it is the worst of
+all. I think that I have seen enough now, Miss Stoner, and with your
+permission we shall walk out upon the lawn.”
+
+I had never seen my friend’s face so grim or his brow so dark as it
+was when we turned from the scene of this investigation. We had walked
+several times up and down the lawn, neither Miss Stoner nor myself
+liking to break in upon his thoughts before he roused himself from his
+reverie.
+
+“It is very essential, Miss Stoner,” said he, “that you should
+absolutely follow my advice in every respect.”
+
+“I shall most certainly do so.”
+
+“The matter is too serious for any hesitation. Your life may depend
+upon your compliance.”
+
+“I assure you that I am in your hands.”
+
+“In the first place, both my friend and I must spend the night in your
+room.”
+
+Both Miss Stoner and I gazed at him in astonishment.
+
+“Yes, it must be so. Let me explain. I believe that that is the village
+inn over there?”
+
+“Yes, that is the ‘Crown.’”
+
+“Very good. Your windows would be visible from there?”
+
+“Certainly.”
+
+“You must confine yourself to your room, on pretence of a headache,
+when your step-father comes back. Then when you hear him retire for
+the night, you must open the shutters of your window, undo the hasp,
+put your lamp there as a signal to us, and then withdraw quietly with
+everything which you are likely to want into the room which you used to
+occupy. I have no doubt that, in spite of the repairs, you could manage
+there for one night.”
+
+“Oh yes, easily.”
+
+“The rest you will leave in our hands.”
+
+“But what will you do?”
+
+“We shall spend the night in your room, and we shall investigate the
+cause of this noise which has disturbed you.”
+
+“I believe, Mr. Holmes, that you have already made up your mind,” said
+Miss Stoner, laying her hand upon my companion’s sleeve.
+
+“Perhaps I have.”
+
+“Then for pity’s sake tell me what was the cause of my sister’s death.”
+
+“I should prefer to have clearer proofs before I speak.”
+
+“You can at least tell me whether my own thought is correct, and if she
+died from some sudden fright.”
+
+[Illustration: “‘GOOD-BYE, AND BE BRAVE’”]
+
+“No, I do not think so. I think that there was probably some more
+tangible cause. And now, Miss Stoner, we must leave you, for if Dr.
+Roylott returned and saw us, our journey would be in vain. Good-bye,
+and be brave, for if you will do what I have told you, you may rest
+assured that we shall soon drive away the dangers that threaten you.”
+
+Sherlock Holmes and I had no difficulty in engaging a bedroom and
+sitting-room at the “Crown Inn.” They were on the upper floor, and
+from our window we could command a view of the avenue gate, and of the
+inhabited wing of Stoke Moran Manor House. At dusk we saw Dr. Grimesby
+Roylott drive past, his huge form looming up beside the little figure
+of the lad who drove him. The boy had some slight difficulty in undoing
+the heavy iron gates, and we heard the hoarse roar of the doctor’s
+voice, and saw the fury with which he shook his clinched fists at him.
+The trap drove on, and a few minutes later we saw a sudden light spring
+up among the trees as the lamp was lit in one of the sitting-rooms.
+
+“Do you know, Watson,” said Holmes, as we sat together in the gathering
+darkness, “I have really some scruples as to taking you to-night. There
+is a distinct element of danger.”
+
+“Can I be of assistance?”
+
+“Your presence might be invaluable.”
+
+“Then I shall certainly come.”
+
+“It is very kind of you.”
+
+“You speak of danger. You have evidently seen more in these rooms than
+was visible to me.”
+
+“No, but I fancy that I may have deduced a little more. I imagine that
+you saw all that I did.”
+
+“I saw nothing remarkable save the bell-rope, and what purpose that
+could answer I confess is more than I can imagine.”
+
+“You saw the ventilator, too?”
+
+“Yes, but I do not think that it is such a very unusual thing to have
+a small opening between two rooms. It was so small that a rat could
+hardly pass through.”
+
+“I knew that we should find a ventilator before ever we came to Stoke
+Moran.”
+
+“My dear Holmes!”
+
+“Oh yes, I did. You remember in her statement she said that her sister
+could smell Dr. Roylott’s cigar. Now, of course that suggested at once
+that there must be a communication between the two rooms. It could only
+be a small one, or it would have been remarked upon at the coroner’s
+inquiry. I deduced a ventilator.”
+
+“But what harm can there be in that?”
+
+“Well, there is at least a curious coincidence of dates. A ventilator
+is made, a cord is hung, and a lady who sleeps in the bed dies. Does
+not that strike you?”
+
+“I cannot as yet see any connection.”
+
+“Did you observe anything very peculiar about that bed?”
+
+“No.”
+
+“It was clamped to the floor. Did you ever see a bed fastened like that
+before?”
+
+“I cannot say that I have.”
+
+“The lady could not move her bed. It must always be in the same
+relative position to the ventilator and to the rope—for so we may call
+it, since it was clearly never meant for a bell-pull.”
+
+“Holmes,” I cried, “I seem to see dimly what you are hinting at. We are
+only just in time to prevent some subtle and horrible crime.”
+
+“Subtle enough and horrible enough. When a doctor does go wrong, he is
+the first of criminals. He has nerve and he has knowledge. Palmer and
+Pritchard were among the heads of their profession. This man strikes
+even deeper, but I think, Watson, that we shall be able to strike
+deeper still. But we shall have horrors enough before the night is
+over; for goodness’ sake let us have a quiet pipe, and turn our minds
+for a few hours to something more cheerful.”
+
+       *       *       *       *       *
+
+About nine o’clock the light among the trees was extinguished, and all
+was dark in the direction of the Manor House. Two hours passed slowly
+away, and then, suddenly, just at the stroke of eleven, a single
+bright light shone out right in front of us.
+
+“That is our signal,” said Holmes, springing to his feet; “it comes
+from the middle window.”
+
+As we passed out he exchanged a few words with the landlord, explaining
+that we were going on a late visit to an acquaintance, and that it was
+possible that we might spend the night there. A moment later we were
+out on the dark road, a chill wind blowing in our faces, and one yellow
+light twinkling in front of us through the gloom to guide us on our
+sombre errand.
+
+There was little difficulty in entering the grounds, for unrepaired
+breaches gaped in the old park wall. Making our way among the trees,
+we reached the lawn, crossed it, and were about to enter through the
+window, when out from a clump of laurel bushes there darted what seemed
+to be a hideous and distorted child, who threw itself upon the grass
+with writhing limbs, and then ran swiftly across the lawn into the
+darkness.
+
+“My God!” I whispered; “did you see it?”
+
+Holmes was for the moment as startled as I. His hand closed like a vice
+upon my wrist in his agitation. Then he broke into a low laugh, and put
+his lips to my ear.
+
+“It is a nice household,” he murmured. “That is the baboon.”
+
+I had forgotten the strange pets which the doctor affected. There was
+a cheetah, too; perhaps we might find it upon our shoulders at any
+moment. I confess that I felt easier in my mind when, after following
+Holmes’s example and slipping off my shoes, I found myself inside the
+bedroom. My companion noiselessly closed the shutters, moved the lamp
+onto the table, and cast his eyes round the room. All was as we had
+seen it in the daytime. Then creeping up to me and making a trumpet of
+his hand, he whispered into my ear again so gently that it was all that
+I could do to distinguish the words:
+
+“The least sound would be fatal to our plans.”
+
+I nodded to show that I had heard.
+
+“We must sit without light. He would see it through the ventilator.”
+
+I nodded again.
+
+“Do not go asleep; your very life may depend upon it. Have your pistol
+ready in case we should need it. I will sit on the side of the bed, and
+you in that chair.”
+
+I took out my revolver and laid it on the corner of the table.
+
+Holmes had brought up a long thin cane, and this he placed upon the bed
+beside him. By it he laid the box of matches and the stump of a candle.
+Then he turned down the lamp, and we were left in darkness.
+
+How shall I ever forget that dreadful vigil? I could not hear a sound,
+not even the drawing of a breath, and yet I knew that my companion
+sat open-eyed, within a few feet of me, in the same state of nervous
+tension in which I was myself. The shutters cut off the least ray
+of light, and we waited in absolute darkness. From outside came the
+occasional cry of a night-bird, and once at our very window a long
+drawn cat-like whine, which told us that the cheetah was indeed at
+liberty. Far away we could hear the deep tones of the parish clock,
+which boomed out every quarter of an hour. How long they seemed, those
+quarters! Twelve struck, and one and two and three, and still we sat
+waiting silently for whatever might befall.
+
+Suddenly there was the momentary gleam of a light up in the direction
+of the ventilator, which vanished immediately, but was succeeded by
+a strong smell of burning oil and heated metal. Some one in the next
+room had lit a dark-lantern. I heard a gentle sound of movement, and
+then all was silent once more, though the smell grew stronger. For half
+an hour I sat with straining ears. Then suddenly another sound became
+audible—a very gentle, soothing sound, like that of a small jet of
+steam escaping continually from a kettle. The instant that we heard it,
+Holmes sprang from the bed, struck a match, and lashed furiously with
+his cane at the bell-pull.
+
+“You see it, Watson?” he yelled. “You see it?”
+
+But I saw nothing. At the moment when Holmes struck the light I heard
+a low, clear whistle, but the sudden glare flashing into my weary eyes
+made it impossible for me to tell what it was at which my friend lashed
+so savagely. I could, however, see that his face was deadly pale, and
+filled with horror and loathing.
+
+He had ceased to strike, and was gazing up at the ventilator, when
+suddenly there broke from the silence of the night the most horrible
+cry to which I have ever listened. It swelled up louder and louder, a
+hoarse yell of pain and fear and anger all mingled in the one dreadful
+shriek. They say that away down in the village, and even in the distant
+parsonage, that cry raised the sleepers from their beds. It struck cold
+to our hearts, and I stood gazing at Holmes, and he at me, until the
+last echoes of it had died away into the silence from which it rose.
+
+“What can it mean?” I gasped.
+
+“It means that it is all over,” Holmes answered. “And perhaps, after
+all, it is for the best. Take your pistol, and we will enter Dr.
+Roylott’s room.”
+
+With a grave face he lit the lamp and led the way down the corridor.
+Twice he struck at the chamber door without any reply from within.
+Then he turned the handle and entered, I at his heels, with the cocked
+pistol in my hand.
+
+It was a singular sight which met our eyes. On the table stood a
+dark-lantern with the shutter half open, throwing a brilliant beam
+of light upon the iron safe, the door of which was ajar. Beside this
+table, on the wooden chair, sat Dr. Grimesby Roylott, clad in a long
+gray dressing-gown, his bare ankles protruding beneath, and his feet
+thrust into red heelless Turkish slippers. Across his lap lay the short
+stock with the long lash which we had noticed during the day. His chin
+was cocked upward and his eyes were fixed in a dreadful, rigid stare
+at the corner of the ceiling. Round his brow he had a peculiar yellow
+band, with brownish speckles, which seemed to be bound tightly round
+his head. As we entered he made neither sound nor motion.
+
+“The band! the speckled band!” whispered Holmes.
+
+I took a step forward. In an instant his strange head-gear began
+to move, and there reared itself from among his hair the squat
+diamond-shaped head and puffed neck of a loathsome serpent.
+
+“It is a swamp adder!” cried Holmes; “the deadliest snake in India. He
+has died within ten seconds of being bitten. Violence does, in truth,
+recoil upon the violent, and the schemer falls into the pit which he
+digs for another. Let us thrust this creature back into its den, and
+we can then remove Miss Stoner to some place of shelter, and let the
+county police know what has happened.”
+
+As he spoke he drew the dog-whip swiftly from the dead man’s lap, and
+throwing the noose round the reptile’s neck, he drew it from its horrid
+perch, and carrying it at arm’s length, threw it into the iron safe,
+which he closed upon it.
+
+       *       *       *       *       *
+
+Such are the true facts of the death of Dr. Grimesby Roylott, of Stoke
+Moran. It is not necessary that I should prolong a narrative which has
+already run to too great a length, by telling how we broke the sad news
+to the terrified girl, how we conveyed her by the morning train to the
+care of her good aunt at Harrow, of how the slow process of official
+inquiry came to the conclusion that the doctor met his fate while
+indiscreetly playing with a dangerous pet. The little which I had yet
+to learn of the case was told me by Sherlock Holmes as we travelled
+back next day.
+
+“I had,” said he, “come to an entirely erroneous conclusion, which
+shows, my dear Watson, how dangerous it always is to reason from
+insufficient data. The presence of the gypsies, and the use of the
+word ‘band,’ which was used by the poor girl, no doubt to explain the
+appearance which she had caught a hurried glimpse of by the light of
+her match, were sufficient to put me upon an entirely wrong scent. I
+can only claim the merit that I instantly reconsidered my position
+when, however, it became clear to me that whatever danger threatened
+an occupant of the room could not come either from the window or the
+door. My attention was speedily drawn, as I have already remarked to
+you, to this ventilator, and to the bell-rope which hung down to the
+bed. The discovery that this was a dummy, and that the bed was clamped
+to the floor, instantly gave rise to the suspicion that the rope was
+there as bridge for something passing through the hole, and coming
+to the bed. The idea of a snake instantly occurred to me, and when
+I coupled it with my knowledge that the doctor was furnished with a
+supply of creatures from India, I felt that I was probably on the right
+track. The idea of using a form of poison which could not possibly be
+discovered by any chemical test was just such a one as would occur to a
+clever and ruthless man who had had an Eastern training. The rapidity
+with which such a poison would take effect would also, from his point
+of view, be an advantage. It would be a sharp-eyed coroner, indeed, who
+could distinguish the two little dark punctures which would show where
+the poison fangs had done their work. Then I thought of the whistle. Of
+course he must recall the snake before the morning light revealed it to
+the victim. He had trained it, probably by the use of the milk which
+we saw, to return to him when summoned. He would put it through this
+ventilator at the hour that he thought best, with the certainty that it
+would crawl down the rope and land on the bed. It might or might not
+bite the occupant, perhaps she might escape every night for a week, but
+sooner or later she must fall a victim.
+
+“I had come to these conclusions before ever I had entered his room.
+An inspection of his chair showed me that he had been in the habit of
+standing on it, which of course would be necessary in order that he
+should reach the ventilator. The sight of the safe, the saucer of milk,
+and the loop of whip-cord were enough to finally dispel any doubts
+which may have remained. The metallic clang heard by Miss Stoner was
+obviously caused by her step-father hastily closing the door of his
+safe upon its terrible occupant. Having once made up my mind, you know
+the steps which I took in order to put the matter to the proof. I
+heard the creature hiss, as I have no doubt that you did also, and I
+instantly lit the light and attacked it.”
+
+“With the result of driving it through the ventilator.”
+
+“And also with the result of causing it to turn upon its master at the
+other side. Some of the blows of my cane came home, and roused its
+snakish temper, so that it flew upon the first person it saw. In this
+way I am no doubt indirectly responsible for Dr. Grimesby Roylott’s
+death, and I cannot say that it is likely to weigh very heavily upon my
+conscience.”
+
+
+
+
+Adventure IX
+
+THE ADVENTURE OF THE ENGINEER’S THUMB
+
+
+Of all the problems which have been submitted to my friend Mr. Sherlock
+Holmes for solution during the years of our intimacy, there were only
+two which I was the means of introducing to his notice—that of Mr.
+Hatherley’s thumb, and that of Colonel Warburton’s madness. Of these
+the latter may have afforded a finer field for an acute and original
+observer, but the other was so strange in its inception and so dramatic
+in its details, that it may be the more worthy of being placed upon
+record, even if it gave my friend fewer openings for those deductive
+methods of reasoning by which he achieved such remarkable results. The
+story has, I believe, been told more than once in the newspapers, but,
+like all such narratives, its effect is much less striking when set
+forth _en bloc_ in a single half-column of print than when the facts
+slowly evolve before your own eyes, and the mystery clears gradually
+away as each new discovery furnishes a step which leads on to the
+complete truth. At the time the circumstances made a deep impression
+upon me, and the lapse of two years has hardly served to weaken the
+effect.
+
+It was in the summer of ’89, not long after my marriage, that the
+events occurred which I am now about to summarize. I had returned to
+civil practice, and had finally abandoned Holmes in his Baker Street
+rooms, although I continually visited him, and occasionally even
+persuaded him to forego his Bohemian habits so far as to come and visit
+us. My practice had steadily increased, and as I happened to live at
+no very great distance from Paddington Station, I got a few patients
+from among the officials. One of these, whom I had cured of a painful
+and lingering disease, was never weary of advertising my virtues, and
+of endeavoring to send me on every sufferer over whom he might have any
+influence.
+
+One morning, at a little before seven o’clock, I was awakened by
+the maid tapping at the door, to announce that two men had come
+from Paddington, and were waiting in the consulting-room. I dressed
+hurriedly, for I knew by experience that railway cases were seldom
+trivial, and hastened down-stairs. As I descended, my old ally, the
+guard, came out of the room and closed the door tightly behind him.
+
+“I’ve got him here,” he whispered, jerking his thumb over his shoulder;
+“he’s all right.”
+
+“What is it, then?” I asked, for his manner suggested that it was some
+strange creature which he had caged up in my room.
+
+“It’s a new patient,” he whispered. “I thought I’d bring him round
+myself; then he couldn’t slip away. There he is, all safe and sound. I
+must go now, doctor; I have my dooties, just the same as you.” And off
+he went, this trusty tout, without even giving me time to thank him.
+
+I entered my consulting-room and found a gentleman seated by the
+table. He was quietly dressed in a suit of heather tweed, with a soft
+cloth cap, which he had laid down upon my books. Round one of his
+hands he had a handkerchief wrapped, which was mottled all over with
+blood-stains. He was young, not more than five-and-twenty, I should
+say, with a strong, masculine face; but he was exceedingly pale, and
+gave me the impression of a man who was suffering from some strong
+agitation, which it took all his strength of mind to control.
+
+“I am sorry to knock you up so early, doctor,” said he, “but I have
+had a very serious accident during the night. I came in by train this
+morning, and on inquiring at Paddington as to where I might find a
+doctor, a worthy fellow very kindly escorted me here. I gave the maid a
+card, but I see that she has left it upon the side-table.”
+
+I took it up and glanced at it. “Mr. Victor Hatherley, hydraulic
+engineer, 16A, Victoria Street (3d floor).” That was the name,
+style, and abode of my morning visitor. “I regret that I have kept you
+waiting,” said I, sitting down in my library-chair. “You are fresh
+from a night journey, I understand, which is in itself a monotonous
+occupation.”
+
+“Oh, my night could not be called monotonous,” said he, and laughed. He
+laughed very heartily, with a high, ringing note, leaning back in his
+chair and shaking his sides. All my medical instincts rose up against
+that laugh.
+
+“Stop it!” I cried; “pull yourself together!” and I poured out some
+water from a caraffe.
+
+It was useless, however. He was off in one of those hysterical
+outbursts which come upon a strong nature when some great crisis is
+over and gone. Presently he came to himself once more, very weary and
+blushing hotly.
+
+“I have been making a fool of myself,” he gasped.
+
+“Not at all. Drink this.” I dashed some brandy into the water, and the
+color began to come back to his bloodless cheeks.
+
+“That’s better!” said he. “And now, doctor, perhaps you would kindly
+attend to my thumb, or rather to the place where my thumb used to be.”
+
+He unwound the handkerchief and held out his hand. It gave even my
+hardened nerves a shudder to look at it. There were four protruding
+fingers and a horrid red, spongy surface where the thumb should have
+been. It had been hacked or torn right out from the roots.
+
+“Good heavens!” I cried, “this is a terrible injury. It must have bled
+considerably.”
+
+“Yes, it did. I fainted when it was done, and I think that I must have
+been senseless for a long time. When I came to I found that it was
+still bleeding, so I tied one end of my handkerchief very tightly
+round the wrist, and braced it up with a twig.”
+
+“Excellent! You should have been a surgeon.”
+
+“It is a question of hydraulics, you see, and came within my own
+province.”
+
+“This has been done,” said I, examining the wound, “by a very heavy and
+sharp instrument.”
+
+“A thing like a cleaver,” said he.
+
+“An accident, I presume?”
+
+“By no means.”
+
+“What! a murderous attack?”
+
+“Very murderous indeed.”
+
+“You horrify me.”
+
+I sponged the wound, cleaned it, dressed it, and finally covered it
+over with cotton wadding and carbolized bandages. He lay back without
+wincing, though he bit his lip from time to time.
+
+“How is that?” I asked, when I had finished.
+
+“Capital! Between your brandy and your bandage, I feel a new man. I was
+very weak, but I have had a good deal to go through.”
+
+“Perhaps you had better not speak of the matter. It is evidently trying
+to your nerves.”
+
+“Oh no, not now. I shall have to tell my tale to the police; but,
+between ourselves, if it were not for the convincing evidence of this
+wound of mine, I should be surprised if they believed my statement; for
+it is a very extraordinary one, and I have not much in the way of proof
+with which to back it up; and, even if they believe me, the clews which
+I can give them are so vague that it is a question whether justice will
+be done.”
+
+“Ha!” cried I, “if it is anything in the nature of a problem which you
+desire to see solved, I should strongly recommend you to come to my
+friend Mr. Sherlock Holmes before you go to the official police.”
+
+“Oh, I have heard of that fellow,” answered my visitor, “and I should
+be very glad if he would take the matter up, though of course I must
+use the official police as well. Would you give me an introduction to
+him?”
+
+“I’ll do better. I’ll take you round to him myself.”
+
+“I should be immensely obliged to you.”
+
+“We’ll call a cab and go together. We shall just be in time to have a
+little breakfast with him. Do you feel equal to it?”
+
+“Yes; I shall not feel easy until I have told my story.”
+
+“Then my servant will call a cab, and I shall be with you in an
+instant.” I rushed up-stairs, explained the matter shortly to my
+wife, and in five minutes was inside a hansom, driving with my new
+acquaintance to Baker Street.
+
+Sherlock Holmes was, as I expected, lounging about his sitting-room in
+his dressing-gown, reading the agony column of _The Times_, and smoking
+his before-breakfast pipe, which was composed of all the plugs and
+dottels left from his smokes of the day before, all carefully dried
+and collected on the corner of the mantel-piece. He received us in his
+quietly genial fashion, ordered fresh rashers and eggs, and joined us
+in a hearty meal. When it was concluded he settled our new acquaintance
+upon the sofa, placed a pillow beneath his head, and laid a glass of
+brandy-and-water within his reach.
+
+“It is easy to see that your experience has been no common one, Mr.
+Hatherley,” said he. “Pray, lie down there and make yourself absolutely
+at home. Tell us what you can, but stop when you are tired, and keep up
+your strength with a little stimulant.”
+
+“Thank you,” said my patient, “but I have felt another man since the
+doctor bandaged me, and I think that your breakfast has completed the
+cure. I shall take up as little of your valuable time as possible, so I
+shall start at once upon my peculiar experiences.”
+
+Holmes sat in his big arm-chair with the weary, heavy-lidded expression
+which veiled his keen and eager nature, while I sat opposite to him,
+and we listened in silence to the strange story which our visitor
+detailed to us.
+
+“You must know,” said he, “that I am an orphan and a bachelor, residing
+alone in lodgings in London. By profession I am an hydraulic engineer,
+and I have had considerable experience of my work during the seven
+years that I was apprenticed to Venner & Matheson, the well-known
+firm, of Greenwich. Two years ago, having served my time, and having
+also come into a fair sum of money through my poor father’s death,
+I determined to start in business for myself, and took professional
+chambers in Victoria Street.
+
+“I suppose that every one finds his first independent start in business
+a dreary experience. To me it has been exceptionally so. During two
+years I have had three consultations and one small job, and that is
+absolutely all that my profession has brought me. My gross takings
+amount to £27 10_s._ Every day, from nine in the morning until four in
+the afternoon, I waited in my little den, until at last my heart began
+to sink, and I came to believe that I should never have any practice at
+all.
+
+“Yesterday, however, just as I was thinking of leaving the office,
+my clerk entered to say there was a gentleman waiting who wished to
+see me upon business. He brought up a card, too, with the name of
+‘Colonel Lysander Stark’ engraved upon it. Close at his heels came the
+colonel himself, a man rather over the middle size, but of an exceeding
+thinness. I do not think that I have ever seen so thin a man. His whole
+face sharpened away into nose and chin, and the skin of his cheeks
+was drawn quite tense over his outstanding bones. Yet this emaciation
+seemed to be his natural habit, and due to no disease, for his eye was
+bright, his step brisk, and his bearing assured. He was plainly but
+neatly dressed, and his age, I should judge, would be nearer forty than
+thirty.
+
+“‘Mr. Hatherley?’ said he, with something of a German accent. ‘You
+have been recommended to me, Mr. Hatherley, as being a man who is not
+only proficient in his profession, but is also discreet and capable of
+preserving a secret.’
+
+“I bowed, feeling as flattered as any young man would at such an
+address. ‘May I ask who it was who gave me so good a character?’
+
+“‘Well, perhaps it is better that I should not tell you that just at
+this moment. I have it from the same source that you are both an orphan
+and a bachelor, and are residing alone in London.’
+
+“‘That is quite correct,’ I answered, ‘but you will excuse me if
+I say that I cannot see how all this bears upon my professional
+qualifications. I understood that it was on a professional matter that
+you wished to speak to me?’
+
+“‘Undoubtedly so. But you will find that all I say is really to the
+point. I have a professional commission for you, but absolute secrecy
+is quite essential—_absolute_ secrecy, you understand, and of course
+we may expect that more from a man who is alone than from one who lives
+in the bosom of his family.’
+
+“‘If I promise to keep a secret,’ said I, ‘you may absolutely depend
+upon my doing so.’
+
+“He looked very hard at me as I spoke, and it seemed to me that I had
+never seen so suspicious and questioning an eye.
+
+“‘Do you promise, then?’ said he, at last.
+
+“‘Yes, I promise.’
+
+“‘Absolute and complete silence before, during, and after? No reference
+to the matter at all, either in word or writing?’
+
+“‘I have already given you my word.’
+
+“‘Very good.’ He suddenly sprang up, and darting like lightning across
+the room, he flung open the door. The passage outside was empty.
+
+“‘That’s all right,’ said he, coming back. ‘I know that clerks are
+sometimes curious as to their master’s affairs. Now we can talk in
+safety.’ He drew up his chair very close to mine, and began to stare at
+me again with the same questioning and thoughtful look.
+
+“A feeling of repulsion, and of something akin to fear had begun to
+rise within me at the strange antics of this fleshless man. Even
+my dread of losing a client could not restrain me from showing my
+impatience.
+
+“‘I beg that you will state your business, sir,’ said I; ‘my time is of
+value.’ Heaven forgive me for that last sentence, but the words came to
+my lips.
+
+“‘How would fifty guineas for a night’s work suit you?’ he asked.
+
+“‘Most admirably.’
+
+“‘I say a night’s work, but an hour’s would be nearer the mark. I
+simply want your opinion about a hydraulic stamping machine which has
+got out of gear. If you show us what is wrong we shall soon set it
+right ourselves. What do you think of such a commission as that?’
+
+“‘The work appears to be light and the pay munificent.’
+
+“‘Precisely so. We shall want you to come to-night by the last train.’
+
+“‘Where to?’
+
+“‘To Eyford, in Berkshire. It is a little place near the borders of
+Oxfordshire, and within seven miles of Reading. There is a train from
+Paddington which would bring you there at about 11.15.’
+
+“‘Very good.’
+
+“‘I shall come down in a carriage to meet you.’
+
+“‘There is a drive, then?’
+
+“‘Yes, our little place is quite out in the country. It is a good seven
+miles from Eyford Station.’
+
+“‘Then we can hardly get there before midnight. I suppose there would
+be no chance of a train back. I should be compelled to stop the night.’
+
+“‘Yes, we could easily give you a shake-down.’
+
+“‘That is very awkward. Could I not come at some more convenient hour?’
+
+“‘We have judged it best that you should come late. It is to recompense
+you for any inconvenience that we are paying to you, a young and
+unknown man, a fee which would buy an opinion from the very heads of
+your profession. Still, of course, if you would like to draw out of
+the business, there is plenty of time to do so.’
+
+“I thought of the fifty guineas, and of how very useful they would be
+to me. ‘Not at all,’ said I, ‘I shall be very happy to accommodate
+myself to your wishes. I should like, however, to understand a little
+more clearly what it is that you wish me to do.’
+
+“‘Quite so. It is very natural that the pledge of secrecy which we have
+exacted from you should have aroused your curiosity. I have no wish to
+commit you to anything without your having it all laid before you. I
+suppose that we are absolutely safe from eavesdroppers?’
+
+“‘Entirely.’
+
+“‘Then the matter stands thus. You are probably aware that
+fuller’s-earth is a valuable product, and that it is only found in one
+or two places in England?’
+
+“‘I have heard so.’
+
+“‘Some little time ago I bought a small place—a very small
+place—within ten miles of Reading. I was fortunate enough to discover
+that there was a deposit of fuller’s-earth in one of my fields. On
+examining it, however, I found that this deposit was a comparatively
+small one, and that it formed a link between two very much larger ones
+upon the right and left—both of them, however, in the grounds of my
+neighbors. These good people were absolutely ignorant that their land
+contained that which was quite as valuable as a gold-mine. Naturally,
+it was to my interest to buy their land before they discovered its true
+value; but, unfortunately, I had no capital by which I could do this. I
+took a few of my friends into the secret, however, and they suggested
+that we should quietly and secretly work our own little deposit, and
+that in this way we should earn the money which would enable us to buy
+the neighboring fields. This we have now been doing for some time, and
+in order to help us in our operations we erected an hydraulic press.
+This press, as I have already explained, has got out of order, and we
+wish your advice upon the subject. We guard our secret very jealously,
+however, and if it once became known that we had hydraulic engineers
+coming to our little house, it would soon rouse inquiry, and then, if
+the facts came out, it would be good-bye to any chance of getting these
+fields and carrying out our plans. That is why I have made you promise
+me that you will not tell a human being that you are going to Eyford
+to-night. I hope that I make it all plain?’
+
+“‘I quite follow you,’ said I. ‘The only point which I could not
+quite understand, was what use you could make of an hydraulic press
+in excavating fuller’s-earth, which, as I understand, is dug out like
+gravel from a pit.’
+
+“‘Ah!’ said he, carelessly, ‘we have our own process. We compress
+the earth into bricks, so as to remove them without revealing what
+they are. But that is a mere detail. I have taken you fully into my
+confidence now, Mr. Hatherley, and I have shown you how I trust you.’
+He rose as he spoke. ‘I shall expect you, then, at Eyford at 11.15.’
+
+“‘I shall certainly be there.’
+
+“‘And not a word to a soul.’ He looked at me with a last, long,
+questioning gaze, and then, pressing my hand in a cold, dank grasp, he
+hurried from the room.
+
+“Well, when I came to think it all over in cool blood I was very much
+astonished, as you may both think, at this sudden commission which had
+been intrusted to me. On the one hand, of course, I was glad, for the
+fee was at least tenfold what I should have asked had I set a price
+upon my own services, and it was possible that this order might lead
+to other ones. On the other hand, the face and manner of my patron
+had made an unpleasant impression upon me, and I could not think that
+his explanation of the fuller’s-earth was sufficient to explain the
+necessity for my coming at midnight, and his extreme anxiety lest I
+should tell any one of my errand. However, I threw all fears to the
+winds, ate a hearty supper, drove to Paddington, and started off,
+having obeyed to the letter the injunction as to holding my tongue.
+
+[Illustration: “‘NOT A WORD TO A SOUL’”]
+
+“At Reading I had to change not only my carriage, but my station.
+However, I was in time for the last train to Eyford, and I reached the
+little dim-lit station after eleven o’clock. I was the only passenger
+who got out there, and there was no one upon the platform save a single
+sleepy porter with a lantern. As I passed out through the wicket gate,
+however, I found my acquaintance of the morning waiting in the shadow
+upon the other side. Without a word he grasped my arm and hurried me
+into a carriage, the door of which was standing open. He drew up the
+windows on either side, tapped on the wood-work, and away we went as
+fast as the horse could go.”
+
+“One horse?” interjected Holmes.
+
+“Yes, only one.”
+
+“Did you observe the color?”
+
+“Yes, I saw it by the side-lights when I was stepping into the
+carriage. It was a chestnut.”
+
+“Tired-looking or fresh?”
+
+“Oh, fresh and glossy.”
+
+“Thank you. I am sorry to have interrupted you. Pray continue your most
+interesting statement.”
+
+“Away we went then, and we drove for at least an hour. Colonel Lysander
+Stark had said that it was only seven miles, but I should think, from
+the rate that we seemed to go, and from the time that we took, that
+it must have been nearer twelve. He sat at my side in silence all the
+time, and I was aware, more than once when I glanced in his direction,
+that he was looking at me with great intensity. The country roads seem
+to be not very good in that part of the world, for we lurched and
+jolted terribly. I tried to look out of the windows to see something of
+where we were, but they were made of frosted glass, and I could make
+out nothing save the occasional bright blur of a passing light. Now
+and then I hazarded some remark to break the monotony of the journey,
+but the colonel answered only in monosyllables, and the conversation
+soon flagged. At last, however, the bumping of the road was exchanged
+for the crisp smoothness of a gravel-drive, and the carriage came to
+a stand. Colonel Lysander Stark sprang out, and, as I followed after
+him, pulled me swiftly into a porch which gaped in front of us. We
+stepped, as it were, right out of the carriage and into the hall, so
+that I failed to catch the most fleeting glance of the front of the
+house. The instant that I had crossed the threshold the door slammed
+heavily behind us, and I heard faintly the rattle of the wheels as the
+carriage drove away.
+
+“It was pitch dark inside the house, and the colonel fumbled about
+looking for matches, and muttering under his breath. Suddenly a door
+opened at the other end of the passage, and a long, golden bar of light
+shot out in our direction. It grew broader, and a woman appeared with
+a lamp in her hand, which she held above her head, pushing her face
+forward and peering at us. I could see that she was pretty, and from
+the gloss with which the light shone upon her dark dress I knew that
+it was a rich material. She spoke a few words in a foreign tongue in a
+tone as though asking a question, and when my companion answered in a
+gruff monosyllable she gave such a start that the lamp nearly fell from
+her hand. Colonel Stark went up to her, whispered something in her ear,
+and then, pushing her back into the room from whence she had come, he
+walked towards me again with the lamp in his hand.
+
+“‘Perhaps you will have the kindness to wait in this room for a few
+minutes,’ said he, throwing open another door. It was a quiet, little,
+plainly-furnished room, with a round table in the centre, on which
+several German books were scattered. Colonel Stark laid down the lamp
+on the top of a harmonium beside the door. ‘I shall not keep you
+waiting an instant,’ said he, and vanished into the darkness.
+
+“I glanced at the books upon the table, and in spite of my ignorance
+of German I could see that two of them were treatises on science, the
+others being volumes of poetry. Then I walked across to the window,
+hoping that I might catch some glimpse of the country-side, but an oak
+shutter, heavily barred, was folded across it. It was a wonderfully
+silent house. There was an old clock ticking loudly somewhere in the
+passage, but otherwise everything was deadly still. A vague feeling of
+uneasiness began to steal over me. Who were these German people, and
+what were they doing, living in this strange, out-of-the-way place?
+And where was the place? I was ten miles or so from Eyford, that was
+all I knew, but whether north, south, east, or west I had no idea.
+For that matter, Reading, and possibly other large towns, were within
+that radius, so the place might not be so secluded, after all. Yet it
+was quite certain, from the absolute stillness, that we were in the
+country. I paced up and down the room, humming a tune under my breath
+to keep up my spirits, and feeling that I was thoroughly earning my
+fifty-guinea fee.
+
+“Suddenly, without any preliminary sound in the midst of the utter
+stillness, the door of my room swung slowly open. The woman was
+standing in the aperture, the darkness of the hall behind her, the
+yellow light from my lamp beating upon her eager and beautiful face. I
+could see at a glance that she was sick with fear, and the sight sent a
+chill to my own heart. She held up one shaking finger to warn me to be
+silent, and she shot a few whispered words of broken English at me, her
+eyes glancing back, like those of a frightened horse, into the gloom
+behind her.
+
+“‘I would go,’ said she, trying hard, as it seemed to me, to speak
+calmly; ‘I would go. I should not stay here. There is no good for you
+to do.’
+
+“‘But, madam,’ said I, ‘I have not yet done what I came for. I cannot
+possibly leave until I have seen the machine.’
+
+“‘It is not worth your while to wait,’ she went on. ‘You can pass
+through the door; no one hinders.’ And then, seeing that I smiled and
+shook my head, she suddenly threw aside her constraint and made a step
+forward, with her hands wrung together. ‘For the love of Heaven!’ she
+whispered, ‘get away from here before it is too late!’
+
+“But I am somewhat headstrong by nature, and the more ready to engage
+in an affair when there is some obstacle in the way. I thought of my
+fifty-guinea fee, of my wearisome journey, and of the unpleasant night
+which seemed to be before me. Was it all to go for nothing? Why should
+I slink away without having carried out my commission, and without
+the payment which was my due? This woman might, for all I knew, be a
+monomaniac. With a stout bearing, therefore, though her manner had
+shaken me more than I cared to confess, I still shook my head, and
+declared my intention of remaining where I was. She was about to renew
+her entreaties, when a door slammed overhead, and the sound of several
+footsteps were heard upon the stairs. She listened for an instant,
+threw up her hands with a despairing gesture, and vanished as suddenly
+and as noiselessly as she had come.
+
+“The new-comers were Colonel Lysander Stark and a short, thick man with
+a chinchilla beard growing out of the creases of his double chin, who
+was introduced to me as Mr. Ferguson.
+
+“‘This is my secretary and manager,’ said the colonel. ‘By-the-way, I
+was under the impression that I left this door shut just now. I fear
+that you have felt the draught.’
+
+“‘On the contrary,’ said I, ‘I opened the door myself, because I felt
+the room to be a little close.’
+
+“He shot one of his suspicious looks at me. ‘Perhaps we had better
+proceed to business, then,’ said he. ‘Mr. Ferguson and I will take you
+up to see the machine.’
+
+“‘I had better put my hat on, I suppose.’
+
+“‘Oh no, it is in the house.’
+
+“‘What, you dig fuller’s-earth in the house?’
+
+“‘No, no. This is only where we compress it. But never mind that. All
+we wish you to do is to examine the machine, and to let us know what is
+wrong with it.’
+
+“We went up-stairs together, the colonel first with the lamp, the fat
+manager, and I behind him. It was a labyrinth of an old house, with
+corridors, passages, narrow winding staircases, and little low doors,
+the thresholds of which were hollowed out by the generations who had
+crossed them. There were no carpets and no signs of any furniture
+above the ground floor, while the plaster was peeling off the walls,
+and the damp was breaking through in green, unhealthy blotches. I tried
+to put on as unconcerned an air as possible, but I had not forgotten
+the warnings of the lady, even though I disregarded them, and I kept a
+keen eye upon my two companions. Ferguson appeared to be a morose and
+silent man, but I could see from the little that he said that he was at
+least a fellow-countryman.
+
+“Colonel Lysander Stark stopped at last before a low door, which he
+unlocked. Within was a small, square room, in which the three of us
+could hardly get at one time. Ferguson remained outside, and the
+colonel ushered me in.
+
+“‘We are now,’ said he, ‘actually within the hydraulic press, and it
+would be a particularly unpleasant thing for us if any one were to
+turn it on. The ceiling of this small chamber is really the end of the
+descending piston, and it comes down with the force of many tons upon
+this metal floor. There are small lateral columns of water outside
+which receive the force, and which transmit and multiply it in the
+manner which is familiar to you. The machine goes readily enough, but
+there is some stiffness in the working of it, and it has lost a little
+of its force. Perhaps you will have the goodness to look it over and to
+show us how we can set it right.’
+
+“I took the lamp from him, and I examined the machine very thoroughly.
+It was indeed a gigantic one, and capable of exercising enormous
+pressure. When I passed outside, however, and pressed down the levers
+which controlled it, I knew at once by the whishing sound that there
+was a slight leakage, which allowed a regurgitation of water through
+one of the side cylinders. An examination showed that one of the
+india-rubber bands which was round the head of a driving-rod had shrunk
+so as not quite to fill the socket along which it worked. This was
+clearly the cause of the loss of power, and I pointed it out to my
+companions, who followed my remarks very carefully, and asked several
+practical questions as to how they should proceed to set it right. When
+I had made it clear to them, I returned to the main chamber of the
+machine and took a good look at it to satisfy my own curiosity. It was
+obvious at a glance that the story of the fuller’s-earth was the merest
+fabrication, for it would be absurd to suppose that so powerful an
+engine could be designed for so inadequate a purpose. The walls were of
+wood, but the floor consisted of a large iron trough, and when I came
+to examine it I could see a crust of metallic deposit all over it. I
+had stooped and was scraping at this to see exactly what it was, when I
+heard a muttered exclamation in German, and saw the cadaverous face of
+the colonel looking down at me.
+
+“‘What are you doing there?’ he asked.
+
+“I felt angry at having been tricked by so elaborate a story as that
+which he had told me. ‘I was admiring your fuller’s-earth,’ said I; ‘I
+think that I should be better able to advise you as to your machine if
+I knew what the exact purpose was for which it was used.’
+
+“The instant that I uttered the words I regretted the rashness of my
+speech. His face set hard, and a baleful light sprang up in his gray
+eyes.
+
+“‘Very well,’ said he, ‘you shall know all about the machine.’ He took
+a step backward, slammed the little door, and turned the key in the
+lock. I rushed towards it and pulled at the handle, but it was quite
+secure, and did not give in the least to my kicks and shoves. ‘Hello!’
+I yelled. ‘Hello! Colonel! Let me out!’
+
+“And then suddenly in the silence I heard a sound which sent my heart
+into my mouth. It was the clank of the levers and the swish of the
+leaking cylinder. He had set the engine at work. The lamp still stood
+upon the floor where I had placed it when examining the trough. By its
+light I saw that the black ceiling was coming down upon me, slowly,
+jerkily, but, as none knew better than myself, with a force which
+must within a minute grind me to a shapeless pulp. I threw myself,
+screaming, against the door, and dragged with my nails at the lock. I
+implored the colonel to let me out, but the remorseless clanking of the
+levers drowned my cries. The ceiling was only a foot or two above my
+head, and with my hand upraised I could feel its hard, rough surface.
+Then it flashed through my mind that the pain of my death would depend
+very much upon the position in which I met it. If I lay on my face
+the weight would come upon my spine, and I shuddered to think of that
+dreadful snap. Easier the other way, perhaps; and yet, had I the nerve
+to lie and look up at that deadly black shadow wavering down upon me?
+Already I was unable to stand erect, when my eye caught something which
+brought a gush of hope back to my heart.
+
+“I have said that though the floor and ceiling were of iron, the walls
+were of wood. As I gave a last hurried glance around, I saw a thin
+line of yellow light between two of the boards, which broadened and
+broadened as a small panel was pushed backward. For an instant I could
+hardly believe that here was indeed a door which led away from death.
+The next instant I threw myself through, and lay half-fainting upon the
+other side. The panel had closed again behind me, but the crash of the
+lamp, and a few moments afterwards the clang of the two slabs of metal,
+told me how narrow had been my escape.
+
+“I was recalled to myself by a frantic plucking at my wrist, and I
+found myself lying upon the stone floor of a narrow corridor, while a
+woman bent over me and tugged at me with her left hand, while she held
+a candle in her right. It was the same good friend whose warning I had
+so foolishly rejected.
+
+“‘Come! come!’ she cried, breathlessly. ‘They will be here in a moment.
+They will see that you are not there. Oh, do not waste the so-precious
+time, but come!’
+
+“This time, at least, I did not scorn her advice. I staggered to my
+feet and ran with her along the corridor and down a winding stair. The
+latter led to another broad passage, and, just as we reached it, we
+heard the sound of running feet and the shouting of two voices, one
+answering the other, from the floor on which we were and from the one
+beneath. My guide stopped and looked about her like one who is at her
+wits’ end. Then she threw open a door which led into a bedroom, through
+the window of which the moon was shining brightly.
+
+“‘It is your only chance,’ said she. ‘It is high, but it may be that
+you can jump it.’
+
+“As she spoke a light sprang into view at the further end of the
+passage, and I saw the lean figure of Colonel Lysander Stark rushing
+forward with a lantern in one hand and a weapon like a butcher’s
+cleaver in the other. I rushed across the bedroom, flung open the
+window, and looked out. How quiet and sweet and wholesome the garden
+looked in the moonlight, and it could not be more than thirty feet
+down. I clambered out upon the sill, but I hesitated to jump until I
+should have heard what passed between my savior and the ruffian who
+pursued me. If she were ill-used, then at any risks I was determined to
+go back to her assistance. The thought had hardly flashed through my
+mind before he was at the door, pushing his way past her; but she threw
+her arms round him and tried to hold him back.
+
+“‘Fritz! Fritz!’ she cried, in English, ‘remember your promise after
+the last time. You said it should not be again. He will be silent! Oh,
+he will be silent!’
+
+“‘You are mad, Elise!’ he shouted, struggling to break away from her.
+‘You will be the ruin of us. He has seen too much. Let me pass, I say!’
+He dashed her to one side, and, rushing to the window, cut at me with
+his heavy weapon. I had let myself go, and was hanging by the hands to
+the sill, when his blow fell. I was conscious of a dull pain, my grip
+loosened, and I fell into the garden below.
+
+“I was shaken but not hurt by the fall; so I picked myself up and
+rushed off among the bushes as hard as I could run, for I understood
+that I was far from being out of danger yet. Suddenly, however, as I
+ran, a deadly dizziness and sickness came over me. I glanced down at
+my hand, which was throbbing painfully, and then, for the first time,
+saw that my thumb had been cut off and that the blood was pouring from
+my wound. I endeavored to tie my handkerchief round it, but there came
+a sudden buzzing in my ears, and next moment I fell in a dead faint
+among the rose-bushes.
+
+“How long I remained unconscious I cannot tell. It must have been
+a very long time, for the moon had sunk, and a bright morning was
+breaking when I came to myself. My clothes were all sodden with dew,
+and my coat-sleeve was drenched with blood from my wounded thumb.
+The smarting of it recalled in an instant all the particulars of my
+night’s adventure, and I sprang to my feet with the feeling that I
+might hardly yet be safe from my pursuers. But, to my astonishment,
+when I came to look round me, neither house nor garden were to be seen.
+I had been lying in an angle of the hedge close by the high-road, and
+just a little lower down was a long building, which proved, upon my
+approaching it, to be the very station at which I had arrived upon the
+previous night. Were it not for the ugly wound upon my hand, all that
+had passed during those dreadful hours might have been an evil dream.
+
+“Half dazed, I went into the station and asked about the morning train.
+There would be one to Reading in less than an hour. The same porter
+was on duty, I found, as had been there when I arrived. I inquired of
+him whether he had ever heard of Colonel Lysander Stark. The name was
+strange to him. Had he observed a carriage the night before waiting for
+me? No, he had not. Was there a police-station anywhere near? There was
+one about three miles off.
+
+“It was too far for me to go, weak and ill as I was. I determined to
+wait until I got back to town before telling my story to the police. It
+was a little past six when I arrived, so I went first to have my wound
+dressed, and then the doctor was kind enough to bring me along here. I
+put the case into your hands, and shall do exactly what you advise.”
+
+We both sat in silence for some little time after, listening to this
+extraordinary narrative. Then Sherlock Holmes pulled down from the
+shelf one of the ponderous commonplace books in which he placed his
+cuttings.
+
+“Here is an advertisement which will interest you,” said he. “It
+appeared in all the papers about a year ago. Listen to this: ‘Lost,
+on the 9th inst., Mr. Jeremiah Hayling, aged twenty-six, an hydraulic
+engineer. Left his lodgings at ten o’clock at night, and has not been
+heard of since. Was dressed in,’ etc., etc. Ha! That represents the
+last time that the colonel needed to have his machine overhauled, I
+fancy.”
+
+“Good heavens!” cried my patient. “Then that explains what the girl
+said.”
+
+“Undoubtedly. It is quite clear that the colonel was a cool and
+desperate man, who was absolutely determined that nothing should stand
+in the way of his little game, like those out-and-out pirates who will
+leave no survivor from a captured ship. Well, every moment now is
+precious, so if you feel equal to it, we shall go down to Scotland Yard
+at once as a preliminary to starting for Eyford.”
+
+Some three hours or so afterwards we were all in the train together,
+bound from Reading to the little Berkshire village. There were Sherlock
+Holmes, the hydraulic engineer, Inspector Bradstreet, of Scotland Yard,
+a plain-clothes man, and myself. Bradstreet had spread an ordnance
+map of the county out upon the seat, and was busy with his compasses
+drawing a circle with Eyford for its centre.
+
+“There you are,” said he. “That circle is drawn at a radius of ten
+miles from the village. The place we want must be somewhere near that
+line. You said ten miles, I think, sir.”
+
+“It was an hour’s good drive.”
+
+“And you think that they brought you back all that way when you were
+unconscious?”
+
+“They must have done so. I have a confused memory, too, of having been
+lifted and conveyed somewhere.”
+
+“What I cannot understand,” said I, “is why they should have spared you
+when they found you lying fainting in the garden. Perhaps the villain
+was softened by the woman’s entreaties.”
+
+“I hardly think that likely. I never saw a more inexorable face in my
+life.”
+
+“Oh, we shall soon clear up all that,” said Bradstreet. “Well, I have
+drawn my circle, and I only wish I knew at what point upon it the folk
+that we are in search of are to be found.”
+
+“I think I could lay my finger on it,” said Holmes, quietly.
+
+“Really, now!” cried the inspector, “you have formed your opinion!
+Come, now, we shall see who agrees with you. I say it is south, for the
+country is more deserted there.”
+
+“And I say east,” said my patient.
+
+“I am for west,” remarked the plain-clothes man. “There are several
+quiet little villages up there.”
+
+“And I am for north,” said I, “because there are no hills there, and
+our friend says that he did not notice the carriage go up any.”
+
+“Come,” cried the inspector, laughing; “it’s a very pretty diversity
+of opinion. We have boxed the compass among us. Who do you give your
+casting vote to?”
+
+“You are all wrong.”
+
+“But we can’t _all_ be.”
+
+“Oh yes, you can. This is my point;” he placed his finger in the centre
+of the circle. “This is where we shall find them.”
+
+“But the twelve-mile drive?” gasped Hatherley.
+
+“Six out and six back. Nothing simpler. You say yourself that the horse
+was fresh and glossy when you got in. How could it be that if it had
+gone twelve miles over heavy roads?”
+
+“Indeed, it is a likely ruse enough,” observed Bradstreet,
+thoughtfully. “Of course there can be no doubt as to the nature of this
+gang.”
+
+“None at all,” said Holmes. “They are coiners on a large scale, and
+have used the machine to form the amalgam which has taken the place of
+silver.”
+
+“We have known for some time that a clever gang was at work,” said the
+inspector. “They have been turning out half-crowns by the thousand. We
+even traced them as far as Reading, but could get no farther, for they
+had covered their traces in a way that showed that they were very old
+hands. But now, thanks to this lucky chance, I think that we have got
+them right enough.”
+
+But the inspector was mistaken, for those criminals were not destined
+to fall into the hands of justice. As we rolled into Eyford Station we
+saw a gigantic column of smoke which streamed up from behind a small
+clump of trees in the neighborhood, and hung like an immense ostrich
+feather over the landscape.
+
+“A house on fire?” asked Bradstreet, as the train steamed off again on
+its way.
+
+“Yes, sir!” said the station-master.
+
+“When did it break out?”
+
+“I hear that it was during the night, sir, but it has got worse, and
+the whole place is in a blaze.”
+
+“Whose house is it?”
+
+“Dr. Becher’s.”
+
+“Tell me,” broke in the engineer, “is Dr. Becher a German, very thin,
+with a long, sharp nose?”
+
+The station-master laughed heartily. “No, sir, Dr. Becher is an
+Englishman, and there isn’t a man in the parish who has a better-lined
+waistcoat. But he has a gentleman staying with him, a patient, as
+I understand, who is a foreigner, and he looks as if a little good
+Berkshire beef would do him no harm.”
+
+The station-master had not finished his speech before we were all
+hastening in the direction of the fire. The road topped a low hill,
+and there was a great wide-spread whitewashed building in front of us,
+spouting fire at every chink and window, while in the garden in front
+three fire-engines were vainly striving to keep the flames under.
+
+“That’s it!” cried Hatherley, in intense excitement. “There is the
+gravel-drive, and there are the rose-bushes where I lay. That second
+window is the one that I jumped from.”
+
+“Well, at least,” said Holmes, “you have had your revenge upon them.
+There can be no question that it was your oil-lamp which, when it was
+crushed in the press, set fire to the wooden walls, though no doubt
+they were too excited in the chase after you to observe it at the time.
+Now keep your eyes open in this crowd for your friends of last night,
+though I very much fear that they are a good hundred miles off by now.”
+
+And Holmes’s fears came to be realized, for from that day to this no
+word has ever been heard either of the beautiful woman, the sinister
+German, or the morose Englishman. Early that morning a peasant had met
+a cart containing several people and some very bulky boxes driving
+rapidly in the direction of Reading, but there all traces of the
+fugitives disappeared, and even Holmes’s ingenuity failed ever to
+discover the least clew as to their whereabouts.
+
+The firemen had been much perturbed at the strange arrangements which
+they had found within, and still more so by discovering a newly severed
+human thumb upon a window-sill of the second floor. About sunset,
+however, their efforts were at last successful, and they subdued the
+flames, but not before the roof had fallen in, and the whole place been
+reduced to such absolute ruin that, save some twisted cylinders and
+iron piping, not a trace remained of the machinery which had cost our
+unfortunate acquaintance so dearly. Large masses of nickel and of tin
+were discovered stored in an out-house, but no coins were to be found,
+which may have explained the presence of those bulky boxes which have
+been already referred to.
+
+How our hydraulic engineer had been conveyed from the garden to the
+spot where he recovered his senses might have remained forever a
+mystery were it not for the soft mould, which told us a very plain
+tale. He had evidently been carried down by two persons, one of whom
+had remarkably small feet and the other unusually large ones. On the
+whole, it was most probable that the silent Englishman, being less bold
+or less murderous than his companion, had assisted the woman to bear
+the unconscious man out of the way of danger.
+
+“Well,” said our engineer ruefully, as we took our seats to return once
+more to London, “it has been a pretty business for me! I have lost my
+thumb and I have lost a fifty-guinea fee, and what have I gained?”
+
+“Experience,” said Holmes, laughing. “Indirectly it may be of value,
+you know; you have only to put it into words to gain the reputation of
+being excellent company for the remainder of your existence.”
+
+
+
+
+Adventure X
+
+THE ADVENTURE OF THE NOBLE BACHELOR
+
+
+The Lord St. Simon marriage, and its curious termination, have long
+ceased to be a subject of interest in those exalted circles in which
+the unfortunate bridegroom moves. Fresh scandals have eclipsed it,
+and their more piquant details have drawn the gossips away from this
+four-year-old drama. As I have reason to believe, however, that the
+full facts have never been revealed to the general public, and as my
+friend Sherlock Holmes had a considerable share in clearing the matter
+up, I feel that no memoir of him would be complete without some little
+sketch of this remarkable episode.
+
+It was a few weeks before my own marriage, during the days when I was
+still sharing rooms with Holmes in Baker Street, that he came home from
+an afternoon stroll to find a letter on the table waiting for him.
+I had remained in-doors all day, for the weather had taken a sudden
+turn to rain, with high autumnal winds, and the jezail bullet which I
+had brought back in one of my limbs as a relic of my Afghan campaign,
+throbbed with dull persistency. With my body in one easy-chair and my
+legs upon another, I had surrounded myself with a cloud of newspapers,
+until at last, saturated with the news of the day, I tossed them all
+aside and lay listless, watching the huge crest and monogram upon the
+envelope upon the table, and wondering lazily who my friend’s noble
+correspondent could be.
+
+“Here is a very fashionable epistle,” I remarked, as he entered. “Your
+morning letters, if I remember right, were from a fish-monger and a
+tide-waiter.”
+
+“Yes, my correspondence has certainly the charm of variety,” he
+answered, smiling, “and the humbler are usually the more interesting.
+This looks like one of those unwelcome social summonses which call upon
+a man either to be bored or to lie.”
+
+He broke the seal and glanced over the contents.
+
+“Oh, come, it may prove to be something of interest after all.”
+
+“Not social, then?”
+
+“No, distinctly professional.”
+
+“And from a noble client?”
+
+“One of the highest in England.”
+
+“My dear fellow, I congratulate you.”
+
+“I assure you, Watson, without affectation, that the status of my
+client is a matter of less moment to me than the interest of his case.
+It is just possible, however, that that also may not be wanting in this
+new investigation. You have been reading the papers diligently of late,
+have you not?”
+
+“It looks like it,” said I, ruefully, pointing to a huge bundle in the
+corner. “I have had nothing else to do.”
+
+“It is fortunate, for you will perhaps be able to post me up. I read
+nothing except the criminal news and the agony column. The latter is
+always instructive. But if you have followed recent events so closely
+you must have read about Lord St. Simon and his wedding?”
+
+“Oh yes, with the deepest interest.”
+
+“That is well. The letter which I hold in my hand is from Lord St.
+Simon. I will read it to you, and in return you must turn over these
+papers and let me have whatever bears upon the matter. This is what he
+says:
+
+  “‘MY DEAR MR. SHERLOCK HOLMES,—Lord Backwater tells me that I
+  may place implicit reliance upon your judgment and discretion.
+  I have determined, therefore, to call upon you, and to consult
+  you in reference to the very painful event which has occurred
+  in connection with my wedding. Mr. Lestrade, of Scotland Yard,
+  is acting already in the matter, but he assures me that he sees
+  no objection to your co-operation, and that he even thinks that
+  it might be of some assistance. I will call at four o’clock in
+  the afternoon, and, should you have any other engagement at
+  that time, I hope that you will postpone it, as this matter is
+  of paramount importance.    Yours faithfully,   ST. SIMON.’
+
+“It is dated from Grosvenor Mansions, written with a quill pen, and the
+noble lord has had the misfortune to get a smear of ink upon the outer
+side of his right little finger,” remarked Holmes, as he folded up the
+epistle.
+
+“He says four o’clock. It is three now. He will be here in an hour.”
+
+“Then I have just time, with your assistance, to get clear upon the
+subject. Turn over those papers, and arrange the extracts in their
+order of time, while I take a glance as to who our client is.” He
+picked a red-covered volume from a line of books of reference beside
+the mantel-piece. “Here he is,” said he, sitting down and flattening it
+out upon his knee. “Lord Robert Walsingham de Vere St. Simon, second
+son of the Duke of Balmoral—Hum! Arms: Azure, three caltrops in chief
+over a fess sable. Born in 1846. He’s forty-one years of age, which
+is mature for marriage. Was Undersecretary for the Colonies in a late
+Administration. The Duke, his father, was at one time Secretary for
+Foreign Affairs. They inherit Plantagenet blood by direct descent, and
+Tudor on the distaff side. Ha! Well, there is nothing very instructive
+in all this. I think that I must turn to you, Watson, for something
+more solid.”
+
+“I have very little difficulty in finding what I want,” said I, “for
+the facts are quite recent, and the matter struck me as remarkable. I
+feared to refer them to you, however, as I knew that you had an inquiry
+on hand, and that you disliked the intrusion of other matters.”
+
+“Oh, you mean the little problem of the Grosvenor Square furniture
+van. That is quite cleared up now—though, indeed, it was obvious from
+the first. Pray give me the results of your newspaper selections.”
+
+“Here is the first notice which I can find. It is in the personal
+column of _The Morning Post_, and dates, as you see, some weeks back.
+‘A marriage has been arranged,’ it says, ‘and will, if rumor is
+correct, very shortly take place, between Lord Robert St. Simon, second
+son of the Duke of Balmoral, and Miss Hatty Doran, the only daughter of
+Aloysius Doran, Esq., of San Francisco, Cal., U.S.A.’ That is all.”
+
+“Terse and to the point,” remarked Holmes, stretching his long, thin
+legs towards the fire.
+
+“There was a paragraph amplifying this in one of the society papers
+of the same week. Ah, here it is. ‘There will soon be a call for
+protection in the marriage market, for the present free-trade principle
+appears to tell heavily against our home product. One by one the
+management of the noble houses of Great Britain is passing into the
+hands of our fair cousins from across the Atlantic. An important
+addition has been made during the last week to the list of the prizes
+which have been borne away by these charming invaders. Lord St. Simon,
+who has shown himself for over twenty years proof against the little
+god’s arrows, has now definitely announced his approaching marriage
+with Miss Hatty Doran, the fascinating daughter of a California
+millionaire. Miss Doran, whose graceful figure and striking face
+attracted much attention at the Westbury House festivities, is an
+only child, and it is currently reported that her dowry will run to
+considerably over the six figures, with expectancies for the future.
+As it is an open secret that the Duke of Balmoral has been compelled
+to sell his pictures within the last few years, and as Lord St. Simon
+has no property of his own, save the small estate of Birchmoor, it
+is obvious that the Californian heiress is not the only gainer by an
+alliance which will enable her to make the easy and common transition
+from a Republican lady to a British peeress.’”
+
+“Anything else?” asked Holmes, yawning.
+
+“Oh yes; plenty. Then there is another note in _The Morning Post_ to
+say that the marriage would be an absolutely quiet one, that it would
+be at St. George’s, Hanover Square, that only half a dozen intimate
+friends would be invited, and that the party would return to the
+furnished house at Lancaster Gate which has been taken by Mr. Aloysius
+Doran. Two days later—that is, on Wednesday last—there is a curt
+announcement that the wedding had taken place, and that the honey-moon
+would be passed at Lord Backwater’s place, near Petersfield. Those are
+all the notices which appeared before the disappearance of the bride.”
+
+“Before the what?” asked Holmes, with a start.
+
+“The vanishing of the lady.”
+
+“When did she vanish, then?”
+
+“At the wedding breakfast.”
+
+“Indeed. This is more interesting than it promised to be; quite
+dramatic, in fact.”
+
+“Yes; it struck me as being a little out of the common.”
+
+“They often vanish before the ceremony, and occasionally during the
+honey-moon; but I cannot call to mind anything quite so prompt as this.
+Pray let me have the details.”
+
+“I warn you that they are very incomplete.”
+
+“Perhaps we may make them less so.”
+
+“Such as they are, they are set forth in a single article of a morning
+paper of yesterday, which I will read to you. It is headed, ‘Singular
+Occurrence at a Fashionable Wedding’:
+
+“‘The family of Lord Robert St. Simon has been thrown into the
+greatest consternation by the strange and painful episodes which have
+taken place in connection with his wedding. The ceremony, as shortly
+announced in the papers of yesterday, occurred on the previous morning;
+but it is only now that it has been possible to confirm the strange
+rumors which have been so persistently floating about. In spite of
+the attempts of the friends to hush the matter up, so much public
+attention has now been drawn to it that no good purpose can be served
+by affecting to disregard what is a common subject for conversation.
+
+“‘The ceremony, which was performed at St. George’s, Hanover Square,
+was a very quiet one, no one being present save the father of the
+bride, Mr. Aloysius Doran, the Duchess of Balmoral, Lord Backwater,
+Lord Eustace, and Lady Clara St. Simon (the younger brother and sister
+of the bridegroom), and Lady Alicia Whittington. The whole party
+proceeded afterwards to the house of Mr. Aloysius Doran, at Lancaster
+Gate, where breakfast had been prepared. It appears that some little
+trouble was caused by a woman, whose name has not been ascertained,
+who endeavored to force her way into the house after the bridal party,
+alleging that she had some claim upon Lord St. Simon. It was only after
+a painful and prolonged scene that she was ejected by the butler and
+the footman. The bride, who had fortunately entered the house before
+this unpleasant interruption, had sat down to breakfast with the rest,
+when she complained of a sudden indisposition, and retired to her room.
+Her prolonged absence having caused some comment, her father followed
+her, but learned from her maid that she had only come up to her chamber
+for an instant, caught up an ulster and bonnet, and hurried down to
+the passage. One of the footmen declared that he had seen a lady leave
+the house thus apparelled, but had refused to credit that it was his
+mistress, believing her to be with the company. On ascertaining that
+his daughter had disappeared, Mr. Aloysius Doran, in conjunction with
+the bridegroom, instantly put themselves into communication with
+the police, and very energetic inquiries are being made, which will
+probably result in a speedy clearing up of this very singular business.
+Up to a late hour last night, however, nothing had transpired as to
+the whereabouts of the missing lady. There are rumors of foul play in
+the matter, and it is said that the police have caused the arrest of
+the woman who had caused the original disturbance, in the belief that,
+from jealousy or some other motive, she may have been concerned in the
+strange disappearance of the bride.’”
+
+“And is that all?”
+
+“Only one little item in another of the morning papers, but it is a
+suggestive one.”
+
+“And it is—”
+
+“That Miss Flora Millar, the lady who had caused the disturbance, has
+actually been arrested. It appears that she was formerly a _danseuse_
+at the ‘Allegro,’ and that she has known the bridegroom for some years.
+There are no further particulars, and the whole case is in your hands
+now—so far as it has been set forth in the public press.”
+
+“And an exceedingly interesting case it appears to be. I would not have
+missed it for worlds. But there is a ring at the bell, Watson, and as
+the clock makes it a few minutes after four, I have no doubt that this
+will prove to be our noble client. Do not dream of going, Watson, for I
+very much prefer having a witness, if only as a check to my own memory.”
+
+“Lord Robert St. Simon,” announced our page-boy, throwing open the
+door. A gentleman entered, with a pleasant, cultured face, high-nosed
+and pale, with something perhaps of petulance about the mouth, and
+with the steady, well-opened eye of a man whose pleasant lot it had
+ever been to command and to be obeyed. His manner was brisk, and yet
+his general appearance gave an undue impression of age, for he had a
+slight forward stoop and a little bend of the knees as he walked. His
+hair, too, as he swept off his very curly-brimmed hat, was grizzled
+round the edges and thin upon the top. As to his dress, it was careful
+to the verge of foppishness, with high collar, black frock-coat, white
+waistcoat, yellow gloves, patent-leather shoes, and light-colored
+gaiters. He advanced slowly into the room, turning his head from left
+to right, and swinging in his right hand the cord which held his golden
+eye-glasses.
+
+“Good-day, Lord St. Simon,” said Holmes, rising and bowing. “Pray take
+the basket-chair. This is my friend and colleague, Dr. Watson. Draw up
+a little to the fire, and we will talk this matter over.”
+
+“A most painful matter to me, as you can most readily imagine, Mr.
+Holmes. I have been cut to the quick. I understand that you have
+already managed several delicate cases of this sort, sir, though I
+presume that they were hardly from the same class of society.”
+
+“No, I am descending.”
+
+“I beg pardon.”
+
+“My last client of the sort was a king.”
+
+“Oh, really! I had no idea. And which king?”
+
+“The King of Scandinavia.”
+
+“What! Had he lost his wife?”
+
+“You can understand,” said Holmes, suavely, “that I extend to the
+affairs of my other clients the same secrecy which I promise to you in
+yours.”
+
+“Of course! Very right! very right! I’m sure I beg pardon. As to my own
+case, I am ready to give you any information which may assist you in
+forming an opinion.”
+
+“Thank you. I have already learned all that is in the public prints,
+nothing more. I presume that I may take it as correct—this article,
+for example, as to the disappearance of the bride.”
+
+Lord St. Simon glanced over it. “Yes, it is correct, as far as it goes.”
+
+“But it needs a great deal of supplementing before any one could offer
+an opinion. I think that I may arrive at my facts most directly by
+questioning you.”
+
+“Pray do so.”
+
+“When did you first meet Miss Hatty Doran?”
+
+“In San Francisco, a year ago.”
+
+“You were travelling in the States?”
+
+“Yes.”
+
+“Did you become engaged then?”
+
+“No.”
+
+“But you were on a friendly footing?”
+
+“I was amused by her society, and she could see that I was amused.”
+
+“Her father is very rich?”
+
+“He is said to be the richest man on the Pacific slope.”
+
+“And how did he make his money?”
+
+“In mining. He had nothing a few years ago. Then he struck gold,
+invested it, and came up by leaps and bounds.”
+
+“Now, what is your own impression as to the young lady’s—your wife’s
+character?”
+
+The nobleman swung his glasses a little faster and stared down into the
+fire. “You see, Mr. Holmes,” said he, “my wife was twenty before her
+father became a rich man. During that time she ran free in a mining
+camp, and wandered through woods or mountains, so that her education
+has come from Nature rather than from the school-master. She is what
+we call in England a tomboy, with a strong nature, wild and free,
+unfettered by any sort of traditions. She is impetuous—volcanic, I
+was about to say. She is swift in making up her mind, and fearless
+in carrying out her resolutions. On the other hand, I would not have
+given her the name which I have the honor to bear”—he gave a little
+stately cough—“had not I thought her to be at bottom a noble woman. I
+believe that she is capable of heroic self-sacrifice, and that anything
+dishonorable would be repugnant to her.”
+
+“Have you her photograph?”
+
+“I brought this with me.” He opened a locket, and showed us the full
+face of a very lovely woman. It was not a photograph, but an ivory
+miniature, and the artist had brought out the full effect of the
+lustrous black hair, the large dark eyes, and the exquisite mouth.
+Holmes gazed long and earnestly at it. Then he closed the locket and
+handed it back to Lord St. Simon.
+
+“The young lady came to London, then, and you renewed your
+acquaintance?”
+
+“Yes, her father brought her over for this last London season. I met
+her several times, became engaged to her, and have now married her.”
+
+“She brought, I understand, a considerable dowry?”
+
+“A fair dowry. Not more than is usual in my family.”
+
+“And this, of course, remains to you, since the marriage is a _fait
+accompli_?”
+
+“I really have made no inquiries on the subject.”
+
+“Very naturally not. Did you see Miss Doran on the day before the
+wedding?”
+
+“Yes.”
+
+“Was she in good spirits?”
+
+“Never better. She kept talking of what we should do in our future
+lives.”
+
+“Indeed! That is very interesting. And on the morning of the wedding?”
+
+“She was as bright as possible—at least, until after the ceremony.”
+
+“And did you observe any change in her then?”
+
+“Well, to tell the truth, I saw then the first signs that I had ever
+seen that her temper was just a little sharp. The incident, however,
+was too trivial to relate, and can have no possible bearing upon the
+case.”
+
+“Pray let us have it, for all that.”
+
+“Oh, it is childish. She dropped her bouquet as we went towards the
+vestry. She was passing the front pew at the time, and it fell over
+into the pew. There was a moment’s delay, but the gentleman in the
+pew handed it up to her again, and it did not appear to be the worse
+for the fall. Yet, when I spoke to her of the matter, she answered me
+abruptly; and in the carriage, on our way home, she seemed absurdly
+agitated over this trifling cause.”
+
+“Indeed! You say that there was a gentleman in the pew. Some of the
+general public were present, then?”
+
+“Oh yes. It is impossible to exclude them when the church is open.”
+
+“This gentleman was not one of your wife’s friends?”
+
+“No, no; I call him a gentleman by courtesy, but he was quite a
+common-looking person. I hardly noticed his appearance. But really I
+think that we are wandering rather far from the point.”
+
+“Lady St. Simon, then, returned from the wedding in a less cheerful
+frame of mind than she had gone to it. What did she do on re-entering
+her father’s house?”
+
+“I saw her in conversation with her maid.”
+
+“And who is her maid?”
+
+“Alice is her name. She is an American, and came from California with
+her.”
+
+“A confidential servant?”
+
+“A little too much so. It seemed to me that her mistress allowed her to
+take great liberties. Still, of course, in America they look upon these
+things in a different way.”
+
+“How long did she speak to this Alice?”
+
+“Oh, a few minutes. I had something else to think of.”
+
+“You did not overhear what they said?”
+
+“Lady St. Simon said something about ‘jumping a claim.’ She was
+accustomed to use slang of the kind. I have no idea what she meant.”
+
+“American slang is very expressive sometimes. And what did your wife do
+when she finished speaking to her maid?”
+
+“She walked into the breakfast-room.”
+
+“On your arm?”
+
+“No, alone. She was very independent in little matters like that.
+Then, after we had sat down for ten minutes or so, she rose hurriedly,
+muttered some words of apology, and left the room. She never came back.”
+
+“But this maid, Alice, as I understand, deposes that she went to her
+room, covered her bride’s dress with a long ulster, put on a bonnet,
+and went out.”
+
+“Quite so. And she was afterwards seen walking into Hyde Park in
+company with Flora Millar, a woman who is now in custody, and who had
+already made a disturbance at Mr. Doran’s house that morning.”
+
+“Ah, yes. I should like a few particulars as to this young lady, and
+your relations to her.”
+
+Lord St. Simon shrugged his shoulders and raised his eyebrows. “We
+have been on a friendly footing for some years—I may say on a _very_
+friendly footing. She used to be at the ‘Allegro.’ I have not treated
+her ungenerously, and she has no just cause of complaint against me;
+but you know what women are, Mr. Holmes. Flora was a dear little thing,
+but exceedingly hot-headed, and devotedly attached to me. She wrote me
+dreadful letters when she heard that I was about to be married; and, to
+tell the truth, the reason why I had the marriage celebrated so quietly
+was that I feared lest there might be a scandal in the church. She came
+to Mr. Doran’s door just after we returned, and she endeavored to push
+her way in, uttering very abusive expressions towards my wife, and even
+threatening her, but I had foreseen the possibility of something of the
+sort, and I had two police fellows there in private clothes, who soon
+pushed her out again. She was quiet when she saw that there was no good
+in making a row.”
+
+“Did your wife hear all this?”
+
+“No, thank goodness, she did not.”
+
+“And she was seen walking with this very woman afterwards?”
+
+“Yes. That is what Mr. Lestrade, of Scotland Yard, looks upon as so
+serious. It is thought that Flora decoyed my wife out, and laid some
+terrible trap for her.”
+
+“Well, it is a possible supposition.”
+
+“You think so, too?”
+
+“I did not say a probable one. But you do not yourself look upon this
+as likely?”
+
+“I do not think Flora would hurt a fly.”
+
+“Still, jealousy is a strange transformer of characters. Pray what is
+your own theory as to what took place?”
+
+“Well, really, I came to seek a theory, not to propound one. I have
+given you all the facts. Since you ask me, however, I may say that it
+has occurred to me as possible that the excitement of this affair, the
+consciousness that she had made so immense a social stride, had the
+effect of causing some little nervous disturbance in my wife.”
+
+“In short, that she had become suddenly deranged?”
+
+“Well, really, when I consider that she has turned her back—I will
+not say upon me, but upon so much that many have aspired to without
+success—I can hardly explain it in any other fashion.”
+
+“Well, certainly that is also a conceivable hypothesis,” said Holmes,
+smiling. “And now, Lord St. Simon, I think that I have nearly all my
+data. May I ask whether you were seated at the breakfast-table so that
+you could see out of the window?”
+
+“We could see the other side of the road and the Park.”
+
+“Quite so. Then I do not think that I need to detain you longer. I
+shall communicate with you.”
+
+“Should you be fortunate enough to solve this problem,” said our
+client, rising.
+
+“I have solved it.”
+
+“Eh? What was that?”
+
+“I say that I have solved it.”
+
+“Where, then, is my wife?”
+
+“That is a detail which I shall speedily supply.”
+
+Lord St. Simon shook his head. “I am afraid that it will take wiser
+heads than yours or mine,” he remarked, and bowing in a stately,
+old-fashioned manner, he departed.
+
+“It is very good of Lord St. Simon to honor my head by putting it
+on a level with his own,” said Sherlock Holmes, laughing. “I think
+that I shall have a whiskey-and-soda and a cigar after all this
+cross-questioning. I had formed my conclusions as to the case before
+our client came into the room.”
+
+“My dear Holmes!”
+
+“I have notes of several similar cases, though none, as I remarked
+before, which were quite as prompt. My whole examination served to
+turn my conjecture into a certainty. Circumstantial evidence is
+occasionally very convincing, as when you find a trout in the milk, to
+quote Thoreau’s example.”
+
+“But I have heard all that you have heard.”
+
+“Without, however, the knowledge of pre-existing cases which serves me
+so well. There was a parallel instance in Aberdeen some years back,
+and something on very much the same lines at Munich the year after the
+Franco-Prussian war. It is one of these cases—but, hello, here is
+Lestrade! Good-afternoon, Lestrade! You will find an extra tumbler upon
+the sideboard, and there are cigars in the box.”
+
+The official detective was attired in a pea-jacket and cravat, which
+gave him a decidedly nautical appearance, and he carried a black canvas
+bag in his hand. With a short greeting he seated himself and lit the
+cigar which had been offered to him.
+
+“What’s up, then?” asked Holmes, with a twinkle in his eye. “You look
+dissatisfied.”
+
+“And I feel dissatisfied. It is this infernal St. Simon marriage case.
+I can make neither head nor tail of the business.”
+
+“Really! You surprise me.”
+
+“Who ever heard of such a mixed affair? Every clew seems to slip
+through my fingers. I have been at work upon it all day.”
+
+“And very wet it seems to have made you,” said Holmes, laying his hand
+upon the arm of the pea-jacket.
+
+“Yes, I have been dragging the Serpentine.”
+
+“In Heaven’s name, what for?”
+
+“In search of the body of Lady St. Simon.”
+
+Sherlock Holmes leaned back in his chair and laughed heartily.
+
+“Have you dragged the basin of Trafalgar Square fountain?” he asked.
+
+“Why? What do you mean?”
+
+“Because you have just as good a chance of finding this lady in the one
+as in the other.”
+
+Lestrade shot an angry glance at my companion. “I suppose you know all
+about it,” he snarled.
+
+“Well, I have only just heard the facts, but my mind is made up.”
+
+“Oh, indeed! Then you think that the Serpentine plays no part in the
+matter?”
+
+“I think it very unlikely.”
+
+“Then perhaps you will kindly explain how it is that we found this
+in it?” He opened his bag as he spoke, and tumbled onto the floor a
+wedding-dress of watered silk, a pair of white satin shoes, and a
+bride’s wreath and veil, all discolored and soaked in water. “There,”
+said he, putting a new wedding-ring upon the top of the pile. “There is
+a little nut for you to crack, Master Holmes.”
+
+“Oh, indeed!” said my friend, blowing blue rings into the air. “You
+dragged them from the Serpentine?”
+
+“No. They were found floating near the margin by a park-keeper. They
+have been identified as her clothes, and it seemed to me that if the
+clothes were there the body would not be far off.”
+
+“By the same brilliant reasoning, every man’s body is to be found in
+the neighborhood of his wardrobe. And pray what did you hope to arrive
+at through this?”
+
+“At some evidence implicating Flora Millar in the disappearance.”
+
+“I am afraid that you will find it difficult.”
+
+“Are you, indeed, now?” cried Lestrade, with some bitterness. “I am
+afraid, Holmes, that you are not very practical with your deductions
+and your inferences. You have made two blunders in as many minutes.
+This dress does implicate Miss Flora Millar.”
+
+“And how?”
+
+“In the dress is a pocket. In the pocket is a card-case. In the
+card-case is a note. And here is the very note.” He slapped it down
+upon the table in front of him. “Listen to this: ‘You will see me when
+all is ready. Come at once. F. H. M.’ Now my theory all along has been
+that Lady St. Simon was decoyed away by Flora Millar, and that she,
+with confederates, no doubt, was responsible for her disappearance.
+Here, signed with her initials, is the very note which was no doubt
+quietly slipped into her hand at the door, and which lured her within
+their reach.”
+
+“Very good, Lestrade,” said Holmes, laughing. “You really are very fine
+indeed. Let me see it.” He took up the paper in a listless way, but
+his attention instantly became riveted, and he gave a little cry of
+satisfaction. “This is indeed important,” said he.
+
+“Ha! you find it so?”
+
+“Extremely so. I congratulate you warmly.”
+
+Lestrade rose in his triumph and bent his head to look. “Why,” he
+shrieked, “you’re looking at the wrong side!”
+
+“On the contrary, this is the right side.”
+
+“The right side? You’re mad! Here is the note written in pencil over
+here.”
+
+“And over here is what appears to be the fragment of a hotel bill,
+which interests me deeply.”
+
+“There’s nothing in it. I looked at it before,” said Lestrade. “‘Oct.
+4th, rooms 8_s._, breakfast 2_s._ 6_d._, cocktail 1_s._, lunch 2_s._
+6_d._, glass sherry, 8_d._’ I see nothing in that.”
+
+“Very likely not. It is most important, all the same. As to the note,
+it is important also, or at least the initials are, so I congratulate
+you again.”
+
+“I’ve wasted time enough,” said Lestrade, rising. “I believe in hard
+work, and not in sitting by the fire spinning fine theories. Good-day,
+Mr. Holmes, and we shall see which gets to the bottom of the matter
+first.” He gathered up the garments, thrust them into the bag, and made
+for the door.
+
+“Just one hint to you, Lestrade,” drawled Holmes, before his rival
+vanished; “I will tell you the true solution of the matter. Lady St.
+Simon is a myth. There is not, and there never has been, any such
+person.”
+
+Lestrade looked sadly at my companion. Then he turned to me, tapped
+his forehead three times, shook his head solemnly, and hurried away.
+
+He had hardly shut the door behind him when Holmes rose and put on his
+overcoat. “There is something in what the fellow says about out-door
+work,” he remarked, “so I think, Watson, that I must leave you to your
+papers for a little.”
+
+It was after five o’clock when Sherlock Holmes left me, but I had no
+time to be lonely, for within an hour there arrived a confectioner’s
+man with a very large flat box. This he unpacked with the help of a
+youth whom he had brought with him, and presently, to my very great
+astonishment, a quite epicurean little cold supper began to be laid out
+upon our humble lodging-house mahogany. There were a couple of brace of
+cold woodcock, a pheasant, a _pâté de foie gras_ pie, with a group of
+ancient and cobwebby bottles. Having laid out all these luxuries, my
+two visitors vanished away, like the genii of the Arabian Nights, with
+no explanation save that the things had been paid for and were ordered
+to this address.
+
+Just before nine o’clock Sherlock Holmes stepped briskly into the room.
+His features were gravely set, but there was a light in his eye which
+made me think that he had not been disappointed in his conclusions.
+
+“They have laid the supper, then,” he said, rubbing his hands.
+
+“You seem to expect company. They have laid for five.”
+
+“Yes, I fancy we may have some company dropping in,” said he. “I am
+surprised that Lord St. Simon has not already arrived. Ha! I fancy that
+I hear his step now upon the stairs.”
+
+It was indeed our visitor of the morning who came bustling in, dangling
+his glasses more vigorously than ever, and with a very perturbed
+expression upon his aristocratic features.
+
+“My messenger reached you, then?” asked Holmes.
+
+“Yes, and I confess that the contents startled me beyond measure. Have
+you good authority for what you say?”
+
+“The best possible.”
+
+Lord St. Simon sank into a chair and passed his hand over his forehead.
+
+“What will the duke say,” he murmured, “when he hears that one of the
+family has been subjected to such humiliation?”
+
+“It is the purest accident. I cannot allow that there is any
+humiliation.”
+
+“Ah, you look on these things from another stand-point.”
+
+“I fail to see that any one is to blame. I can hardly see how the lady
+could have acted otherwise, though her abrupt method of doing it was
+undoubtedly to be regretted. Having no mother, she had no one to advise
+her at such a crisis.”
+
+“It was a slight, sir, a public slight,” said Lord St. Simon, tapping
+his fingers upon the table.
+
+“You must make allowance for this poor girl, placed in so unprecedented
+a position.”
+
+“I will make no allowance. I am very angry indeed, and I have been
+shamefully used.”
+
+“I think that I heard a ring,” said Holmes. “Yes, there are steps on
+the landing. If I cannot persuade you to take a lenient view of the
+matter, Lord St. Simon, I have brought an advocate here who may be more
+successful.” He opened the door and ushered in a lady and gentleman.
+“Lord St. Simon,” said he, “allow me to introduce you to Mr. and Mrs.
+Francis Hay Moulton. The lady, I think, you have already met.”
+
+At the sight of these new-comers our client had sprung from his seat
+and stood very erect, with his eyes cast down and his hand thrust into
+the breast of his frock-coat, a picture of offended dignity. The lady
+had taken a quick step forward and had held out her hand to him, but
+he still refused to raise his eyes. It was as well for his resolution,
+perhaps, for her pleading face was one which it was hard to resist.
+
+“You’re angry, Robert,” said she. “Well, I guess you have every cause
+to be.”
+
+“Pray make no apology to me,” said Lord St. Simon, bitterly.
+
+“Oh yes, I know that I have treated you real bad, and that I should
+have spoken to you before I went; but I was kind of rattled, and from
+the time when I saw Frank here again I just didn’t know what I was
+doing or saying. I only wonder I didn’t fall down and do a faint right
+there before the altar.”
+
+“Perhaps, Mrs. Moulton, you would like my friend and me to leave the
+room while you explain this matter?”
+
+“If I may give an opinion,” remarked the strange gentleman, “we’ve had
+just a little too much secrecy over this business already. For my part,
+I should like all Europe and America to hear the rights of it.” He was
+a small, wiry, sunburnt man, clean shaven, with a sharp face and alert
+manner.
+
+“Then I’ll tell our story right away,” said the lady. “Frank here and I
+met in ’84, in McQuire’s camp, near the Rockies, where pa was working
+a claim. We were engaged to each other, Frank and I; but then one day
+father struck a rich pocket and made a pile, while poor Frank here had
+a claim that petered out and came to nothing. The richer pa grew, the
+poorer was Frank; so at last pa wouldn’t hear of our engagement lasting
+any longer, and he took me away to ’Frisco. Frank wouldn’t throw up
+his hand, though; so he followed me there, and he saw me without pa
+knowing anything about it. It would only have made him mad to know, so
+we just fixed it all up for ourselves. Frank said that he would go and
+make his pile, too, and never come back to claim me until he had as
+much as pa. So then I promised to wait for him to the end of time, and
+pledged myself not to marry any one else while he lived. ‘Why shouldn’t
+we be married right away, then,’ said he, ‘and then I will feel sure of
+you; and I won’t claim to be your husband until I come back?’ Well, we
+talked it over, and he had fixed it all up so nicely, with a clergyman
+all ready in waiting, that we just did it right there; and then Frank
+went off to seek his fortune, and I went back to pa.
+
+“The next I heard of Frank was that he was in Montana, and then he went
+prospecting in Arizona, and then I heard of him from New Mexico. After
+that came a long newspaper story about how a miners’ camp had been
+attacked by Apache Indians, and there was my Frank’s name among the
+killed. I fainted dead away, and I was very sick for months after. Pa
+thought I had a decline, and took me to half the doctors in ’Frisco.
+Not a word of news came for a year and more, so that I never doubted
+that Frank was really dead. Then Lord St. Simon came to ’Frisco, and we
+came to London, and a marriage was arranged, and pa was very pleased,
+but I felt all the time that no man on this earth would ever take the
+place in my heart that had been given to my poor Frank.
+
+“Still, if I had married Lord St. Simon, of course I’d have done my
+duty by him. We can’t command our love, but we can our actions. I went
+to the altar with him with the intention to make him just as good a
+wife as it was in me to be. But you may imagine what I felt when, just
+as I came to the altar rails, I glanced back and saw Frank standing
+and looking at me out of the first pew. I thought it was his ghost at
+first; but when I looked again, there he was still, with a kind of
+question in his eyes as if to ask me whether I were glad or sorry to
+see him. I wonder I didn’t drop. I know that everything was turning
+round, and the words of the clergyman were just like the buzz of a bee
+in my ear. I didn’t know what to do. Should I stop the service and make
+a scene in the church? I glanced at him again, and he seemed to know
+what I was thinking, for he raised his finger to his lips to tell me to
+be still. Then I saw him scribble on a piece of paper, and I knew that
+he was writing me a note. As I passed his pew on the way out I dropped
+my bouquet over to him, and he slipped the note into my hand when he
+returned me the flowers. It was only a line asking me to join him when
+he made the sign to me to do so. Of course I never doubted for a moment
+that my first duty was now to him, and I determined to do just whatever
+he might direct.
+
+“When I got back I told my maid, who had known him in California, and
+had always been his friend. I ordered her to say nothing, but to get a
+few things packed and my ulster ready. I know I ought to have spoken
+to Lord St. Simon, but it was dreadful hard before his mother and all
+those great people. I just made up my mind to run away and explain
+afterwards. I hadn’t been at the table ten minutes before I saw Frank
+out of the window at the other side of the road. He beckoned to me, and
+then began walking into the Park. I slipped out, put on my things, and
+followed him. Some woman came talking something or other about Lord
+St. Simon to me—seemed to me from the little I heard as if he had a
+little secret of his own before marriage also—but I managed to get
+away from her, and soon overtook Frank. We got into a cab together, and
+away we drove to some lodgings he had taken in Gordon Square, and that
+was my true wedding after all those years of waiting. Frank had been a
+prisoner among the Apaches, had escaped, came on to ’Frisco, found that
+I had given him up for dead and had gone to England, followed me there,
+and had come upon me at last on the very morning of my second wedding.”
+
+“I saw it in a paper,” explained the American. “It gave the name and
+the church, but not where the lady lived.”
+
+“Then we had a talk as to what we should do, and Frank was all for
+openness, but I was so ashamed of it all that I felt as if I should
+like to vanish away and never see any of them again—just sending
+a line to pa, perhaps, to show him that I was alive. It was awful
+to me to think of all those lords and ladies sitting round that
+breakfast-table and waiting for me to come back. So Frank took my
+wedding-clothes and things and made a bundle of them, so that I should
+not be traced, and dropped them away somewhere where no one could find
+them. It is likely that we should have gone on to Paris to-morrow, only
+that this good gentleman, Mr. Holmes, came round to us this evening,
+though how he found us is more than I can think, and he showed us very
+clearly and kindly that I was wrong and that Frank was right, and that
+we should be putting ourselves in the wrong if we were so secret. Then
+he offered to give us a chance of talking to Lord St. Simon alone, and
+so we came right away round to his rooms at once. Now, Robert, you have
+heard it all, and I am very sorry if I have given you pain, and I hope
+that you do not think very meanly of me.”
+
+Lord St. Simon had by no means relaxed his rigid attitude, but had
+listened with a frowning brow and a compressed lip to this long
+narrative.
+
+“Excuse me,” he said, “but it is not my custom to discuss my most
+intimate personal affairs in this public manner.”
+
+“Then you won’t forgive me? You won’t shake hands before I go?”
+
+“Oh, certainly, if it would give you any pleasure.” He put out his hand
+and coldly grasped that which she extended to him.
+
+“I had hoped,” suggested Holmes, “that you would have joined us in a
+friendly supper.”
+
+“I think that there you ask a little too much,” responded his lordship.
+“I may be forced to acquiesce in these recent developments, but I can
+hardly be expected to make merry over them. I think that, with your
+permission, I will now wish you all a very good-night.” He included us
+all in a sweeping bow and stalked out of the room.
+
+“Then I trust that you at least will honor me with your company,” said
+Sherlock Holmes. “It is always a joy to meet an American, Mr. Moulton,
+for I am one of those who believe that the folly of a monarch and
+the blundering of a minister in far-gone years will not prevent our
+children from being some day citizens of the same world-wide country
+under a flag which shall be a quartering of the Union Jack with the
+Stars and Stripes.”
+
+       *       *       *       *       *
+
+“The case has been an interesting one,” remarked Holmes, when our
+visitors had left us, “because it serves to show very clearly how
+simple the explanation may be of an affair which at first sight seems
+to be almost inexplicable. Nothing could be more natural than the
+sequence of events as narrated by this lady, and nothing stranger than
+the result when viewed, for instance, by Mr. Lestrade, of Scotland
+Yard.”
+
+[Illustration: “‘I WILL WISH YOU ALL A VERY GOOD NIGHT.’”]
+
+“You were not yourself at fault at all, then?”
+
+“From the first, two facts were very obvious to me, the one that the
+lady had been quite willing to undergo the wedding ceremony, the other
+that she had repented of it within a few minutes of returning home.
+Obviously something had occurred during the morning, then, to cause her
+to change her mind. What could that something be? She could not have
+spoken to any one when she was out, for she had been in the company
+of the bridegroom. Had she seen some one, then? If she had, it must
+be some one from America, because she had spent so short a time in
+this country that she could hardly have allowed any one to acquire so
+deep an influence over her that the mere sight of him would induce her
+to change her plans so completely. You see we have already arrived,
+by a process of exclusion, at the idea that she might have seen an
+American. Then who could this American be, and why should he possess so
+much influence over her? It might be a lover; it might be a husband.
+Her young womanhood had, I knew, been spent in rough scenes and under
+strange conditions. So far I had got before I ever heard Lord St.
+Simon’s narrative. When he told us of a man in a pew, of the change in
+the bride’s manner, of so transparent a device for obtaining a note as
+the dropping of a bouquet, of her resort to her confidential maid, and
+of her very significant allusion to claim-jumping—which in miners’
+parlance means taking possession of that which another person has a
+prior claim to—the whole situation became absolutely clear. She had
+gone off with a man, and the man was either a lover or was a previous
+husband—the chances being in favor of the latter.”
+
+“And how in the world did you find them?”
+
+“It might have been difficult, but friend Lestrade held information in
+his hands the value of which he did not himself know. The initials were
+of course of the highest importance, but more valuable still was it
+to know that within a week he had settled his bill at one of the most
+select London hotels.”
+
+“How did you deduce the select?”
+
+“By the select prices. Eight shillings for a bed and eight-pence for a
+glass of sherry pointed to one of the most expensive hotels. There are
+not many in London which charge at that rate. In the second one which
+I visited in Northumberland Avenue, I learned by an inspection of the
+book that Francis H. Moulton, an American gentleman, had left only the
+day before, and on looking over the entries against him, I came upon
+the very items which I had seen in the duplicate bill. His letters
+were to be forwarded to 226 Gordon Square; so thither I travelled, and
+being fortunate enough to find the loving couple at home, I ventured to
+give them some paternal advice, and to point out to them that it would
+be better in every way that they should make their position a little
+clearer both to the general public and to Lord St. Simon in particular.
+I invited them to meet him here, and, as you see, I made him keep the
+appointment.”
+
+“But with no very good result,” I remarked. “His conduct was certainly
+not very gracious.”
+
+“Ah, Watson,” said Holmes, smiling, “perhaps you would not be very
+gracious either, if, after all the trouble of wooing and wedding, you
+found yourself deprived in an instant of wife and of fortune. I think
+that we may judge Lord St. Simon very mercifully, and thank our stars
+that we are never likely to find ourselves in the same position. Draw
+your chair up, and hand me my violin, for the only problem we have
+still to solve is how to while away these bleak autumnal evenings.”
+
+
+
+
+Adventure XI
+
+THE ADVENTURE OF THE BERYL CORONET
+
+
+“Holmes,” said I, as I stood one morning in our bow-window looking down
+the street, “here is a madman coming along. It seems rather sad that
+his relatives should allow him to come out alone.”
+
+My friend rose lazily from his arm-chair and stood with his hands in
+the pockets of his dressing-gown, looking over my shoulder. It was a
+bright, crisp February morning, and the snow of the day before still
+lay deep upon the ground, shimmering brightly in the wintry sun. Down
+the centre of Baker Street it had been ploughed into a brown crumbly
+band by the traffic, but at either side and on the heaped-up edges of
+the foot-paths it still lay as white as when it fell. The gray pavement
+had been cleaned and scraped, but was still dangerously slippery, so
+that there were fewer passengers than usual. Indeed, from the direction
+of the Metropolitan Station no one was coming save the single gentleman
+whose eccentric conduct had drawn my attention.
+
+He was a man of about fifty, tall, portly, and imposing, with a
+massive, strongly marked face and a commanding figure. He was dressed
+in a sombre yet rich style, in black frock-coat, shining hat, neat
+brown gaiters, and well-cut pearl-gray trousers. Yet his actions were
+in absurd contrast to the dignity of his dress and features, for he
+was running hard, with occasional little springs, such as a weary man
+gives who is little accustomed to set any tax upon his legs. As he ran
+he jerked his hands up and down, waggled his head, and writhed his face
+into the most extraordinary contortions.
+
+“What on earth can be the matter with him?” I asked. “He is looking up
+at the numbers of the houses.”
+
+“I believe that he is coming here,” said Holmes, rubbing his hands.
+
+“Here?”
+
+“Yes; I rather think he is coming to consult me professionally. I think
+that I recognize the symptoms. Ha! did I not tell you?” As he spoke,
+the man, puffing and blowing, rushed at our door and pulled at our bell
+until the whole house resounded with the clanging.
+
+A few moments later he was in our room, still puffing, still
+gesticulating, but with so fixed a look of grief and despair in his
+eyes that our smiles were turned in an instant to horror and pity. For
+a while he could not get his words out, but swayed his body and plucked
+at his hair like one who has been driven to the extreme limits of his
+reason. Then, suddenly springing to his feet, he beat his head against
+the wall with such force that we both rushed upon him and tore him away
+to the centre of the room. Sherlock Holmes pushed him down into the
+easy-chair, and, sitting beside him, patted his hand, and chatted with
+him in the easy, soothing tones which he knew so well how to employ.
+
+“You have come to me to tell your story, have you not?” said he. “You
+are fatigued with your haste. Pray wait until you have recovered
+yourself, and then I shall be most happy to look into any little
+problem which you may submit to me.”
+
+The man sat for a minute or more with a heaving chest, fighting against
+his emotion. Then he passed his handkerchief over his brow, set his
+lips tight, and turned his face towards us.
+
+“No doubt you think me mad?” said he.
+
+“I see that you have had some great trouble,” responded Holmes.
+
+“God knows I have!—a trouble which is enough to unseat my reason,
+so sudden and so terrible is it. Public disgrace I might have faced,
+although I am a man whose character has never yet borne a stain.
+Private affliction also is the lot of every man; but the two coming
+together, and in so frightful a form, have been enough to shake my very
+soul. Besides, it is not I alone. The very noblest in the land may
+suffer, unless some way be found out of this horrible affair.”
+
+“Pray compose yourself, sir,” said Holmes, “and let me have a clear
+account of who you are, and what it is that has befallen you.”
+
+“My name,” answered our visitor, “is probably familiar to your ears.
+I am Alexander Holder, of the banking firm of Holder & Stevenson, of
+Threadneedle Street.”
+
+The name was indeed well known to us as belonging to the senior partner
+in the second largest private banking concern in the City of London.
+What could have happened, then, to bring one of the foremost citizens
+of London to this most pitiable pass? We waited, all curiosity, until
+with another effort he braced himself to tell his story.
+
+“I feel that time is of value,” said he; “that is why I hastened
+here when the police inspector suggested that I should secure your
+co-operation. I came to Baker Street by the Underground, and hurried
+from there on foot, for the cabs go slowly through this snow. That
+is why I was so out of breath, for I am a man who takes very little
+exercise. I feel better now, and I will put the facts before you as
+shortly and yet as clearly as I can.
+
+“It is, of course, well known to you that in a successful banking
+business as much depends upon our being able to find remunerative
+investments for our funds as upon our increasing our connection and the
+number of our depositors. One of our most lucrative means of laying out
+money is in the shape of loans, where the security is unimpeachable. We
+have done a good deal in this direction during the last few years, and
+there are many noble families to whom we have advanced large sums upon
+the security of their pictures, libraries, or plate.
+
+“Yesterday morning I was seated in my office at the bank when a card
+was brought in to me by one of the clerks. I started when I saw the
+name, for it was that of none other than—well, perhaps even to you I
+had better say no more than that it was a name which is a household
+word all over the earth—one of the highest, noblest, most exalted
+names in England. I was overwhelmed by the honor, and attempted, when
+he entered, to say so, but he plunged at once into business with the
+air of a man who wishes to hurry quickly through a disagreeable task.
+
+“‘Mr. Holder,’ said he, ‘I have been informed that you are in the habit
+of advancing money.’
+
+“‘The firm do so when the security is good,’ I answered.
+
+“‘It is absolutely essential to me,’ said he, ‘that I should have
+£50,000 at once. I could of course borrow so trifling a sum ten
+times over from my friends, but I much prefer to make it a matter of
+business, and to carry out that business myself. In my position you
+can readily understand that it is unwise to place one’s self under
+obligations.’
+
+“‘For how long, may I ask, do you want this sum?’ I asked.
+
+“‘Next Monday I have a large sum due to me, and I shall then most
+certainly repay what you advance, with whatever interest you think it
+right to charge. But it is very essential to me that the money should
+be paid at once.’
+
+“‘I should be happy to advance it without further parley from my own
+private purse,’ said I, ‘were it not that the strain would be rather
+more than it could bear. If, on the other hand, I am to do it in the
+name of the firm, then in justice to my partner I must insist that,
+even in your case, every business-like precaution should be taken.’
+
+“‘I should much prefer to have it so,’ said he, raising up a square,
+black morocco case which he had laid beside his chair. ‘You have
+doubtless heard of the Beryl Coronet?’
+
+“‘One of the most precious public possessions of the empire,’ said I.
+
+“‘Precisely.’ He opened the case, and there, imbedded in soft,
+flesh-colored velvet, lay the magnificent piece of jewelry which he
+had named. ‘There are thirty-nine enormous beryls,’ said he, ‘and the
+price of the gold chasing is incalculable. The lowest estimate would
+put the worth of the coronet at double the sum which I have asked. I am
+prepared to leave it with you as my security.’
+
+“I took the precious case into my hands and looked in some perplexity
+from it to my illustrious client.
+
+“‘You doubt its value?’ he asked.
+
+“‘Not at all. I only doubt—’
+
+“‘The propriety of my leaving it. You may set your mind at rest about
+that. I should not dream of doing so were it not absolutely certain
+that I should be able in four days to reclaim it. It is a pure matter
+of form. Is the security sufficient?’
+
+“‘Ample.’
+
+“‘You understand, Mr. Holder, that I am giving you a strong proof of
+the confidence which I have in you, founded upon all that I have heard
+of you. I rely upon you not only to be discreet and to refrain from all
+gossip upon the matter, but, above all, to preserve this coronet with
+every possible precaution, because I need not say that a great public
+scandal would be caused if any harm were to befall it. Any injury to
+it would be almost as serious as its complete loss, for there are no
+beryls in the world to match these, and it would be impossible to
+replace them. I leave it with you, however, with every confidence, and
+I shall call for it in person on Monday morning.’
+
+“Seeing that my client was anxious to leave, I said no more; but,
+calling for my cashier, I ordered him to pay over fifty £1000 notes.
+When I was alone once more, however, with the precious case lying upon
+the table in front of me, I could not but think with some misgivings of
+the immense responsibility which it entailed upon me. There could be no
+doubt that, as it was a national possession, a horrible scandal would
+ensue if any misfortune should occur to it. I already regretted having
+ever consented to take charge of it. However, it was too late to alter
+the matter now, so I locked it up in my private safe, and turned once
+more to my work.
+
+“When evening came I felt that it would be an imprudence to leave so
+precious a thing in the office behind me. Bankers’ safes had been
+forced before now, and why should not mine be? If so, how terrible
+would be the position in which I should find myself! I determined,
+therefore, that for the next few days I would always carry the case
+backward and forward with me, so that it might never be really out
+of my reach. With this intention, I called a cab, and drove out to
+my house at Streatham, carrying the jewel with me. I did not breathe
+freely until I had taken it up-stairs and locked it in the bureau of my
+dressing-room.
+
+“And now a word as to my household, Mr. Holmes, for I wish you to
+thoroughly understand the situation. My groom and my page sleep out of
+the house, and may be set aside altogether. I have three maid-servants
+who have been with me a number of years, and whose absolute reliability
+is quite above suspicion. Another, Lucy Parr, the second waiting-maid,
+has only been in my service a few months. She came with an excellent
+character, however, and has always given me satisfaction. She is a very
+pretty girl, and has attracted admirers who have occasionally hung
+about the place. That is the only drawback which we have found to her,
+but we believe her to be a thoroughly good girl in every way.
+
+“So much for the servants. My family itself is so small that it will
+not take me long to describe it. I am a widower, and have an only son,
+Arthur. He has been a disappointment to me, Mr. Holmes—a grievous
+disappointment. I have no doubt that I am myself to blame. People tell
+me that I have spoiled him. Very likely I have. When my dear wife died
+I felt that he was all I had to love. I could not bear to see the smile
+fade even for a moment from his face. I have never denied him a wish.
+Perhaps it would have been better for both of us had I been sterner,
+but I meant it for the best.
+
+“It was naturally my intention that he should succeed me in my
+business, but he was not of a business turn. He was wild, wayward, and,
+to speak the truth, I could not trust him in the handling of large
+sums of money. When he was young he became a member of an aristocratic
+club, and there, having charming manners, he was soon the intimate of a
+number of men with long purses and expensive habits. He learned to play
+heavily at cards and to squander money on the turf, until he had again
+and again to come to me and implore me to give him an advance upon his
+allowance, that he might settle his debts of honor. He tried more than
+once to break away from the dangerous company which he was keeping, but
+each time the influence of his friend Sir George Burnwell was enough to
+draw him back again.
+
+“And, indeed, I could not wonder that such a man as Sir George Burnwell
+should gain an influence over him, for he has frequently brought him
+to my house, and I have found myself that I could hardly resist the
+fascination of his manner. He is older than Arthur, a man of the world
+to his finger-tips, one who had been everywhere, seen everything, a
+brilliant talker, and a man of great personal beauty. Yet when I think
+of him in cold blood, far away from the glamour of his presence, I am
+convinced from his cynical speech, and the look which I have caught in
+his eyes, that he is one who should be deeply distrusted. So I think,
+and so, too, thinks my little Mary, who has a woman’s quick insight
+into character.
+
+“And now there is only she to be described. She is my niece; but when
+my brother died five years ago and left her alone in the world I
+adopted her, and have looked upon her ever since as my daughter. She is
+a sunbeam in my house—sweet, loving, beautiful, a wonderful manager
+and house-keeper, yet as tender and quiet and gentle as a woman could
+be. She is my right hand. I do not know what I could do without her. In
+only one matter has she ever gone against my wishes. Twice my boy has
+asked her to marry him, for he loves her devotedly, but each time she
+has refused him. I think that if any one could have drawn him into the
+right path it would have been she, and that his marriage might have
+changed his whole life; but now, alas! it is too late—for ever too
+late!
+
+“Now, Mr. Holmes, you know the people who live under my roof, and I
+shall continue with my miserable story.
+
+“When we were taking coffee in the drawing-room that night, after
+dinner, I told Arthur and Mary my experience, and of the precious
+treasure which we had under our roof, suppressing only the name of my
+client. Lucy Parr, who had brought in the coffee, had, I am sure, left
+the room; but I cannot swear that the door was closed. Mary and Arthur
+were much interested, and wished to see the famous coronet, but I
+thought it better not to disturb it.
+
+“‘Where have you put it?’ asked Arthur.
+
+“‘In my own bureau.’
+
+“‘Well, I hope to goodness the house won’t be burgled during the
+night,’ said he.
+
+“‘It is locked up,’ I answered.
+
+“‘Oh, any old key will fit that bureau. When I was a youngster I have
+opened it myself with the key of the box-room cupboard.’
+
+“He often had a wild way of talking, so that I thought little of what
+he said. He followed me to my room, however, that night with a very
+grave face.
+
+“‘Look here, dad,’ said he, with his eyes cast down, ‘can you let me
+have £200?’
+
+“‘No, I cannot!’ I answered, sharply. ‘I have been far too generous
+with you in money matters.’
+
+“‘You have been very kind,’ said he: ‘but I must have this money, or
+else I can never show my face inside the club again.’
+
+“‘And a very good thing, too!’ I cried.
+
+“‘Yes, but you would not have me leave it a dishonored man,’ said he.
+‘I could not bear the disgrace. I must raise the money in some way, and
+if you will not let me have it, then I must try other means.’
+
+“I was very angry, for this was the third demand during the month. ‘You
+shall not have a farthing from me,’ I cried; on which he bowed and left
+the room without another word.
+
+“When he was gone I unlocked my bureau, made sure that my treasure was
+safe, and locked it again. Then I started to go round the house to see
+that all was secure—a duty which I usually leave to Mary, but which I
+thought it well to perform myself that night. As I came down the stairs
+I saw Mary herself at the side window of the hall, which she closed and
+fastened as I approached.
+
+“‘Tell me, dad,’ said she, looking, I thought, a little disturbed, ‘did
+you give Lucy, the maid, leave to go out to-night?’
+
+“‘Certainly not.’
+
+“‘She came in just now by the back door. I have no doubt that she has
+only been to the side gate to see some one; but I think that it is
+hardly safe, and should be stopped.”
+
+“‘You must speak to her in the morning, or I will, if you prefer it.
+Are you sure that everything is fastened?’
+
+“‘Quite sure, dad.’
+
+“‘Then, good-night.’ I kissed her, and went up to my bedroom again,
+where I was soon asleep.
+
+“I am endeavoring to tell you everything, Mr. Holmes, which may have
+any bearing upon the case, but I beg that you will question me upon any
+point which I do not make clear.”
+
+“On the contrary, your statement is singularly lucid.”
+
+“I come to a part of my story now in which I should wish to be
+particularly so. I am not a very heavy sleeper, and the anxiety in my
+mind tended, no doubt, to make me even less so than usual. About two
+in the morning, then, I was awakened by some sound in the house. It
+had ceased ere I was wide awake, but it had left an impression behind
+it as though a window had gently closed somewhere. I lay listening
+with all my ears. Suddenly, to my horror, there was a distinct sound
+of footsteps moving softly in the next room. I slipped out of bed, all
+palpitating with fear, and peeped round the corner of my dressing-room
+door.
+
+“‘Arthur!’ I screamed, ‘you villain! you thief! How dare you touch that
+coronet?’
+
+“The gas was half up, as I had left it, and my unhappy boy, dressed
+only in his shirt and trousers, was standing beside the light, holding
+the coronet in his hands. He appeared to be wrenching at it, or bending
+it with all his strength. At my cry he dropped it from his grasp, and
+turned as pale as death. I snatched it up and examined it. One of the
+gold corners, with three of the beryls in it, was missing.
+
+“‘You blackguard!’ I shouted, beside myself with rage. ‘You have
+destroyed it! You have dishonored me for ever! Where are the jewels
+which you have stolen?’
+
+“‘Stolen!’ he cried.
+
+“‘Yes, you thief!’ I roared, shaking him by the shoulder.
+
+“‘There are none missing. There cannot be any missing,’ said he.
+
+“‘There are three missing. And you know where they are. Must I call you
+a liar as well as a thief? Did I not see you trying to tear off another
+piece?’
+
+“‘You have called me names enough,’ said he; ‘I will not stand it any
+longer. I shall not say another word about this business since you have
+chosen to insult me. I will leave your house in the morning and make my
+own way in the world.’
+
+“‘You shall leave it in the hands of the police!’ I cried, half-mad
+with grief and rage. ‘I shall have this matter probed to the bottom.’
+
+“‘You shall learn nothing from me,’ said he, with a passion such as I
+should not have thought was in his nature. ‘If you choose to call the
+police, let the police find what they can.’
+
+“By this time the whole house was astir, for I had raised my voice in
+my anger. Mary was the first to rush into my room, and, at the sight of
+the coronet and of Arthur’s face, she read the whole story, and, with
+a scream, fell down senseless on the ground. I sent the house-maid for
+the police, and put the investigation into their hands at once. When
+the inspector and a constable entered the house, Arthur, who had stood
+sullenly with his arms folded, asked me whether it was my intention to
+charge him with theft. I answered that it had ceased to be a private
+matter, but had become a public one, since the ruined coronet was
+national property. I was determined that the law should have its way in
+everything.
+
+“‘At least,’ said he, ‘you will not have me arrested at once. It would
+be to your advantage as well as mine if I might leave the house for
+five minutes.’
+
+“‘That you may get away, or perhaps that you may conceal what you have
+stolen,’ said I. And then realizing the dreadful position in which I
+was placed, I implored him to remember that not only my honor, but that
+of one who was far greater than I was at stake; and that he threatened
+to raise a scandal which would convulse the nation. He might avert it
+all if he would but tell me what he had done with the three missing
+stones.
+
+“‘You may as well face the matter,’ said I; ‘you have been caught in
+the act, and no confession could make your guilt more heinous. If you
+but make such reparation as is in your power, by telling us where the
+beryls are, all shall be forgiven and forgotten.’
+
+“‘Keep your forgiveness for those who ask for it,’ he answered, turning
+away from me, with a sneer. I saw that he was too hardened for any
+words of mine to influence him. There was but one way for it. I called
+in the inspector, and gave him into custody. A search was made at once,
+not only of his person, but of his room, and of every portion of the
+house where he could possibly have concealed the gems; but no trace of
+them could be found, nor would the wretched boy open his mouth for all
+our persuasions and our threats. This morning he was removed to a cell,
+and I, after going through all the police formalities, have hurried
+round to you, to implore you to use your skill in unravelling the
+matter. The police have openly confessed that they can at present make
+nothing of it. You may go to any expense which you think necessary. I
+have already offered a reward of £1000. My God, what shall I do! I have
+lost my honor, my gems, and my son in one night. Oh, what shall I do!”
+
+He put a hand on either side of his head, and rocked himself to and
+fro, droning to himself like a child whose grief has got beyond words.
+
+Sherlock Holmes sat silent for some few minutes, with his brows knitted
+and his eyes fixed upon the fire.
+
+“Do you receive much company?” he asked.
+
+“None, save my partner with his family, and an occasional friend of
+Arthur’s. Sir George Burnwell has been several times lately. No one
+else, I think.”
+
+“Do you go out much in society?”
+
+“Arthur does. Mary and I stay at home. We neither of us care for it.”
+
+“That is unusual in a young girl.”
+
+“She is of a quiet nature. Besides, she is not so very young. She is
+four-and-twenty.”
+
+“This matter, from what you say, seems to have been a shock to her
+also.”
+
+“Terrible! She is even more affected than I.”
+
+“You have neither of you any doubt as to your son’s guilt?”
+
+“How can we have, when I saw him with my own eyes with the coronet in
+his hands.”
+
+“I hardly consider that a conclusive proof. Was the remainder of the
+coronet at all injured?”
+
+“Yes, it was twisted.”
+
+“Do you not think, then, that he might have been trying to straighten
+it?”
+
+“God bless you! You are doing what you can for him and for me. But it
+is too heavy a task. What was he doing there at all? If his purpose
+were innocent, why did he not say so?”
+
+“Precisely. And if it were guilty, why did he not invent a lie? His
+silence appears to me to cut both ways. There are several singular
+points about the case. What did the police think of the noise which
+awoke you from your sleep?”
+
+“They considered that it might be caused by Arthur’s closing his
+bedroom door.”
+
+“A likely story! As if a man bent on felony would slam his door so as
+to wake a household. What did they say, then, of the disappearance of
+these gems?”
+
+“They are still sounding the planking and probing the furniture in the
+hope of finding them.”
+
+“Have they thought of looking outside the house?”
+
+“Yes, they have shown extraordinary energy. The whole garden has
+already been minutely examined.”
+
+“Now, my dear sir,” said Holmes, “is it not obvious to you now that
+this matter really strikes very much deeper than either you or the
+police were at first inclined to think? It appeared to you to be a
+simple case; to me it seems exceedingly complex. Consider what is
+involved by your theory. You suppose that your son came down from his
+bed, went, at great risk, to your dressing-room, opened your bureau,
+took out your coronet, broke off by main force a small portion of
+it, went off to some other place, concealed three gems out of the
+thirty-nine, with such skill that nobody can find them, and then
+returned with the other thirty-six into the room in which he exposed
+himself to the greatest danger of being discovered. I ask you now, is
+such a theory tenable?”
+
+“But what other is there?” cried the banker, with a gesture of despair.
+“If his motives were innocent, why does he not explain them?”
+
+“It is our task to find that out,” replied Holmes; “so now, if you
+please, Mr. Holder, we will set off for Streatham together, and devote
+an hour to glancing a little more closely into details.”
+
+My friend insisted upon my accompanying them in their expedition,
+which I was eager enough to do, for my curiosity and sympathy were
+deeply stirred by the story to which we had listened. I confess that
+the guilt of the banker’s son appeared to me to be as obvious as it
+did to his unhappy father, but still I had such faith in Holmes’s
+judgment that I felt that there must be some grounds for hope as long
+as he was dissatisfied with the accepted explanation. He hardly spoke
+a word the whole way out to the southern suburb, but sat with his chin
+upon his breast and his hat drawn over his eyes, sunk in the deepest
+thought. Our client appeared to have taken fresh heart at the little
+glimpse of hope which had been presented to him, and he even broke into
+a desultory chat with me over his business affairs. A short railway
+journey and a shorter walk brought us to Fairbank, the modest residence
+of the great financier.
+
+Fairbank was a good-sized square house of white stone, standing back
+a little from the road. A double carriage-sweep, with a snow-clad
+lawn, stretched down in front to two large iron gates which closed the
+entrance. On the right side was a small wooden thicket, which led into
+a narrow path between two neat hedges stretching from the road to the
+kitchen door, and forming the tradesmen’s entrance. On the left ran a
+lane which led to the stables, and was not itself within the grounds
+at all, being a public, though little used, thoroughfare. Holmes left
+us standing at the door, and walked slowly all round the house, across
+the front, down the tradesmen’s path, and so round by the garden behind
+into the stable lane. So long was he that Mr. Holder and I went into
+the dining-room and waited by the fire until he should return. We were
+sitting there in silence when the door opened and a young lady came in.
+She was rather above the middle height, slim, with dark hair and eyes,
+which seemed the darker against the absolute pallor of her skin. I do
+not think that I have ever seen such deadly paleness in a woman’s face.
+Her lips, too, were bloodless, but her eyes were flushed with crying.
+As she swept silently into the room she impressed me with a greater
+sense of grief than the banker had done in the morning, and it was the
+more striking in her as she was evidently a woman of strong character,
+with immense capacity for self-restraint. Disregarding my presence,
+she went straight to her uncle, and passed her hand over his head with
+a sweet womanly caress.
+
+“You have given orders that Arthur should be liberated, have you not,
+dad?” she asked.
+
+“No, no, my girl, the matter must be probed to the bottom.”
+
+“But I am so sure that he is innocent. You know what women’s instincts
+are. I know that he has done no harm and that you will be sorry for
+having acted so harshly.”
+
+“Why is he silent, then, if he is innocent?”
+
+“Who knows? Perhaps because he was so angry that you should suspect
+him.”
+
+“How could I help suspecting him, when I actually saw him with the
+coronet in his hand?”
+
+“Oh, but he had only picked it up to look at it. Oh do, do take my word
+for it that he is innocent. Let the matter drop and say no more. It is
+so dreadful to think of our dear Arthur in prison!”
+
+“I shall never let it drop until the gems are found—never, Mary! Your
+affection for Arthur blinds you as to the awful consequences to me. Far
+from hushing the thing up, I have brought a gentleman down from London
+to inquire more deeply into it.”
+
+“This gentleman?” she asked, facing round to me.
+
+“No, his friend. He wished us to leave him alone. He is round in the
+stable lane now.”
+
+“The stable lane?” She raised her dark eyebrows. “What can he hope to
+find there? Ah! this, I suppose, is he. I trust, sir, that you will
+succeed in proving, what I feel sure is the truth, that my cousin
+Arthur is innocent of this crime.”
+
+“I fully share your opinion, and I trust, with you, that we may prove
+it,” returned Holmes, going back to the mat to knock the snow from his
+shoes. “I believe I have the honor of addressing Miss Mary Holder.
+Might I ask you a question or two?”
+
+“Pray do, sir, if it may help to clear this horrible affair up.”
+
+“You heard nothing yourself last night?”
+
+“Nothing, until my uncle here began to speak loudly. I heard that, and
+I came down.”
+
+“You shut up the windows and doors the night before. Did you fasten all
+the windows?”
+
+“Yes.”
+
+“Were they all fastened this morning?”
+
+“Yes.”
+
+“You have a maid who has a sweetheart? I think that you remarked to
+your uncle last night that she had been out to see him?”
+
+“Yes, and she was the girl who waited in the drawing-room, and who may
+have heard uncle’s remarks about the coronet.”
+
+“I see. You infer that she may have gone out to tell her sweetheart,
+and that the two may have planned the robbery.”
+
+“But what is the good of all these vague theories,” cried the banker,
+impatiently, “when I have told you that I saw Arthur with the coronet
+in his hands?”
+
+“Wait a little, Mr. Holder. We must come back to that. About this girl,
+Miss Holder. You saw her return by the kitchen door, I presume?”
+
+“Yes; when I went to see if the door was fastened for the night I met
+her slipping in. I saw the man, too, in the gloom.”
+
+“Do you know him?”
+
+“Oh yes; he is the green-grocer who brings our vegetables round. His
+name is Francis Prosper.”
+
+“He stood,” said Holmes, “to the left of the door—that is to say,
+farther up the path than is necessary to reach the door?”
+
+“Yes, he did.”
+
+“And he is a man with a wooden leg?”
+
+Something like fear sprang up in the young lady’s expressive black
+eyes. “Why, you are like a magician,” said she. “How do you know that?”
+She smiled, but there was no answering smile in Holmes’s thin, eager
+face.
+
+“I should be very glad now to go up-stairs,” said he. “I shall probably
+wish to go over the outside of the house again. Perhaps I had better
+take a look at the lower windows before I go up.”
+
+He walked swiftly round from one to the other, pausing only at the
+large one which looked from the hall onto the stable lane. This he
+opened, and made a very careful examination of the sill with his
+powerful magnifying lens. “Now we shall go up-stairs,” said he, at last.
+
+The banker’s dressing-room was a plainly furnished little chamber, with
+a gray carpet, a large bureau, and a long mirror. Holmes went to the
+bureau first and looked hard at the lock.
+
+“Which key was used to open it?” he asked.
+
+“That which my son himself indicated—that of the cupboard of the
+lumber-room.”
+
+“Have you it here?”
+
+“That is it on the dressing-table.”
+
+Sherlock Holmes took it up and opened the bureau.
+
+“It is a noiseless lock,” said he. “It is no wonder that it did not
+wake you. This case, I presume, contains the coronet. We must have a
+look at it.” He opened the case, and, taking out the diadem, he laid it
+upon the table. It was a magnificent specimen of the jeweller’s art,
+and the thirty-six stones were the finest that I have ever seen. At one
+side of the coronet was a cracked edge, where a corner holding three
+gems had been torn away.
+
+“Now, Mr. Holder,” said Holmes, “here is the corner which corresponds
+to that which has been so unfortunately lost. Might I beg that you will
+break it off.”
+
+The banker recoiled in horror. “I should not dream of trying,” said he.
+
+“Then I will.” Holmes suddenly bent his strength upon it, but without
+result. “I feel it give a little,” said he; “but, though I am
+exceptionally strong in the fingers, it would take me all my time to
+break it. An ordinary man could not do it. Now, what do you think would
+happen if I did break it, Mr. Holder? There would be a noise like a
+pistol shot. Do you tell me that all this happened within a few yards
+of your bed, and that you heard nothing of it?”
+
+“I do not know what to think. It is all dark to me.”
+
+“But perhaps it may grow lighter as we go. What do you think, Miss
+Holder?”
+
+“I confess that I still share my uncle’s perplexity.”
+
+“Your son had no shoes or slippers on when you saw him?”
+
+“He had nothing on save only his trousers and shirt.”
+
+“Thank you. We have certainly been favored with extraordinary luck
+during this inquiry, and it will be entirely our own fault if we do not
+succeed in clearing the matter up. With your permission, Mr. Holder, I
+shall now continue my investigations outside.”
+
+He went alone, at his own request, for he explained that any
+unnecessary footmarks might make his task more difficult. For an hour
+or more he was at work, returning at last with his feet heavy with snow
+and his features as inscrutable as ever.
+
+“I think that I have seen now all that there is to see, Mr. Holder,”
+said he; “I can serve you best by returning to my rooms.”
+
+“But the gems, Mr. Holmes. Where are they?”
+
+“I cannot tell.”
+
+The banker wrung his hands. “I shall never see them again!” he cried.
+“And my son? You give me hopes?”
+
+“My opinion is in no way altered.”
+
+“Then, for God’s sake, what was this dark business which was acted in
+my house last night?”
+
+“If you can call upon me at my Baker Street rooms to-morrow morning
+between nine and ten I shall be happy to do what I can to make it
+clearer. I understand that you give me _carte blanche_ to act for you,
+provided only that I get back the gems, and that you place no limit on
+the sum I may draw.”
+
+“I would give my fortune to have them back.”
+
+“Very good. I shall look into the matter between this and then.
+Good-bye; it is just possible that I may have to come over here again
+before evening.”
+
+It was obvious to me that my companion’s mind was now made up about
+the case, although what his conclusions were was more than I could
+even dimly imagine. Several times during our homeward journey I
+endeavored to sound him upon the point, but he always glided away to
+some other topic, until at last I gave it over in despair. It was not
+yet three when we found ourselves in our room once more. He hurried to
+his chamber, and was down again in a few minutes dressed as a common
+loafer. With his collar turned up, his shiny, seedy coat, his red
+cravat, and his worn boots, he was a perfect sample of the class.
+
+“I think that this should do,” said he, glancing into the glass above
+the fireplace. “I only wish that you could come with me, Watson, but
+I fear that it won’t do. I may be on the trail in this matter, or I
+may be following a will-of-the-wisp, but I shall soon know which it
+is. I hope that I may be back in a few hours.” He cut a slice of beef
+from the joint upon the sideboard, sandwiched it between two rounds of
+bread, and, thrusting this rude meal into his pocket, he started off
+upon his expedition.
+
+I had just finished my tea when he returned, evidently in excellent
+spirits, swinging an old elastic-sided boot in his hand. He chucked it
+down into a corner and helped himself to a cup of tea.
+
+“I only looked in as I passed,” said he. “I am going right on.”
+
+“Where to?”
+
+“Oh, to the other side of the West End. It may be some time before I
+get back. Don’t wait up for me in case I should be late.”
+
+“How are you getting on?”
+
+“Oh, so so. Nothing to complain of. I have been out to Streatham since
+I saw you last, but I did not call at the house. It is a very sweet
+little problem, and I would not have missed it for a good deal.
+However, I must not sit gossiping here, but must get these disreputable
+clothes off and return to my highly respectable self.”
+
+I could see by his manner that he had stronger reasons for satisfaction
+than his words alone would imply. His eyes twinkled, and there was even
+a touch of color upon his sallow cheeks. He hastened up-stairs, and a
+few minutes later I heard the slam of the hall door, which told me that
+he was off once more upon his congenial hunt.
+
+I waited until midnight, but there was no sign of his return, so I
+retired to my room. It was no uncommon thing for him to be away for
+days and nights on end when he was hot upon a scent, so that his
+lateness caused me no surprise. I do not know at what hour he came in,
+but when I came down to breakfast in the morning, there he was with a
+cup of coffee in one hand and the paper in the other, as fresh and trim
+as possible.
+
+“You will excuse my beginning without you, Watson,” said he; “but you
+remember that our client has rather an early appointment this morning.”
+
+“Why, it is after nine now,” I answered. “I should not be surprised if
+that were he. I thought I heard a ring.”
+
+It was, indeed, our friend the financier. I was shocked by the change
+which had come over him, for his face, which was naturally of a broad
+and massive mould, was now pinched and fallen in, while his hair seemed
+to me at least a shade whiter. He entered with a weariness and lethargy
+which was even more painful than his violence of the morning before,
+and he dropped heavily into the arm-chair which I pushed forward for
+him.
+
+“I do not know what I have done to be so severely tried,” said he.
+“Only two days ago I was a happy and prosperous man, without a care in
+the world. Now I am left to a lonely and dishonored age. One sorrow
+comes close upon the heels of another. My niece, Mary, has deserted me.”
+
+“Deserted you?”
+
+“Yes. Her bed this morning had not been slept in, her room was empty,
+and a note for me lay upon the hall table. I had said to her last
+night, in sorrow and not in anger, that if she had married my boy all
+might have been well with him. Perhaps it was thoughtless of me to say
+so. It is to that remark that she refers in this note:
+
+  “‘MY DEAREST UNCLE,—I feel that I have brought trouble
+  upon you, and that if I had acted differently this terrible
+  misfortune might never have occurred. I cannot, with this
+  thought in my mind, ever again be happy under your roof, and
+  I feel that I must leave you for ever. Do not worry about my
+  future, for that is provided for; and, above all, do not search
+  for me, for it will be fruitless labor and an ill-service to
+  me. In life or in death, I am ever your loving       MARY.’
+
+“What could she mean by that note, Mr. Holmes? Do you think it points
+to suicide?”
+
+“No, no, nothing of the kind. It is perhaps the best possible solution.
+I trust, Mr. Holder, that you are nearing the end of your troubles.”
+
+“Ha! You say so! You have heard something, Mr. Holmes; you have learned
+something! Where are the gems?”
+
+“You would not think £1000 apiece an excessive sum for them?”
+
+“I would pay ten.”
+
+“That would be unnecessary. Three thousand will cover the matter. And
+there is a little reward, I fancy. Have you your check-book? Here is a
+pen. Better make it out for £4000 pounds.”
+
+With a dazed face the banker made out the required check. Holmes walked
+over to his desk, took out a little triangular piece of gold with three
+gems in it, and threw it down upon the table.
+
+With a shriek of joy our client clutched it up.
+
+“You have it!” he gasped. “I am saved! I am saved!”
+
+The reaction of joy was as passionate as his grief had been, and he
+hugged his recovered gems to his bosom.
+
+“There is one other thing you owe, Mr. Holder,” said Sherlock Holmes,
+rather sternly.
+
+“Owe!” He caught up a pen. “Name the sum, and I will pay it.”
+
+“No, the debt is not to me. You owe a very humble apology to that noble
+lad, your son, who has carried himself in this matter as I should be
+proud to see my own son do, should I ever chance to have one.”
+
+“Then it was not Arthur who took them?”
+
+“I told you yesterday, and I repeat to-day, that it was not.”
+
+“You are sure of it! Then let us hurry to him at once, to let him know
+that the truth is known.”
+
+“He knows it already. When I had cleared it all up I had an interview
+with him, and, finding that he would not tell me the story, I told it
+to him, on which he had to confess that I was right, and to add the
+very few details which were not yet quite clear to me. Your news of
+this morning, however, may open his lips.”
+
+“For Heaven’s sake, tell me, then, what is this extraordinary mystery!”
+
+“I will do so, and I will show you the steps by which I reached it. And
+let me say to you, first, that which it is hardest for me to say and
+for you to hear: there has been an understanding between Sir George
+Burnwell and your niece Mary. They have now fled together.”
+
+“My Mary? Impossible!”
+
+“It is, unfortunately, more than possible; it is certain. Neither you
+nor your son knew the true character of this man when you admitted
+him into your family circle. He is one of the most dangerous men in
+England—a ruined gambler, an absolutely desperate villain, a man
+without heart or conscience. Your niece knew nothing of such men. When
+he breathed his vows to her, as he had done to a hundred before her,
+she flattered herself that she alone had touched his heart. The devil
+knows best what he said, but at least she became his tool, and was in
+the habit of seeing him nearly every evening.”
+
+“I cannot, and I will not, believe it!” cried the banker, with an ashen
+face.
+
+“I will tell you, then, what occurred in your house last night. Your
+niece, when you had, as she thought, gone to your room, slipped down
+and talked to her lover through the window which leads into the stable
+lane. His footmarks had pressed right through the snow, so long had
+he stood there. She told him of the coronet. His wicked lust for gold
+kindled at the news, and he bent her to his will. I have no doubt
+that she loved you, but there are women in whom the love of a lover
+extinguishes all other loves, and I think that she must have been one.
+She had hardly listened to his instructions when she saw you coming
+down-stairs, on which she closed the window rapidly, and told you about
+one of the servants’ escapade with her wooden-legged lover, which was
+all perfectly true.
+
+“Your boy, Arthur, went to bed after his interview with you, but
+he slept badly on account of his uneasiness about his club debts.
+In the middle of the night he heard a soft tread pass his door, so
+he rose, and looking out, was surprised to see his cousin walking
+very stealthily along the passage, until she disappeared into your
+dressing-room. Petrified with astonishment, the lad slipped on some
+clothes, and waited there in the dark to see what would come of this
+strange affair. Presently she emerged from the room again, and in the
+light of the passage-lamp your son saw that she carried the precious
+coronet in her hands. She passed down the stairs, and he, thrilling
+with horror, ran along and slipped behind the curtain near your door,
+whence he could see what passed in the hall beneath. He saw her
+stealthily open the window, hand out the coronet to some one in the
+gloom, and then closing it once more hurry back to her room, passing
+quite close to where he stood hid behind the curtain.
+
+“As long as she was on the scene he could not take any action without
+a horrible exposure of the woman whom he loved. But the instant that
+she was gone he realized how crushing a misfortune this would be for
+you, and how all-important it was to set it right. He rushed down, just
+as he was, in his bare feet, opened the window, sprang out into the
+snow, and ran down the lane, where he could see a dark figure in the
+moonlight. Sir George Burnwell tried to get away, but Arthur caught
+him, and there was a struggle between them, your lad tugging at one
+side of the coronet, and his opponent at the other. In the scuffle,
+your son struck Sir George, and cut him over the eye. Then something
+suddenly snapped, and your son, finding that he had the coronet in his
+hands, rushed back, closed the window, ascended to your room, and had
+just observed that the coronet had been twisted in the struggle, and
+was endeavoring to straighten it when you appeared upon the scene.”
+
+“Is it possible?” gasped the banker.
+
+“You then roused his anger by calling him names at a moment when he
+felt that he had deserved your warmest thanks. He could not explain
+the true state of affairs without betraying one who certainly deserved
+little enough consideration at his hands. He took the more chivalrous
+view, however, and preserved her secret.”
+
+“And that was why she shrieked and fainted when she saw the coronet,”
+cried Mr. Holder. “Oh, my God! what a blind fool I have been! And his
+asking to be allowed to go out for five minutes! The dear fellow wanted
+to see if the missing piece were at the scene of the struggle. How
+cruelly I have misjudged him!”
+
+“When I arrived at the house,” continued Holmes, “I at once went very
+carefully round it to observe if there were any traces in the snow
+which might help me. I knew that none had fallen since the evening
+before, and also that there had been a strong frost to preserve
+impressions. I passed along the tradesmen’s path, but found it all
+trampled down and indistinguishable. Just beyond it, however, at the
+far side of the kitchen door, a woman had stood and talked with a man,
+whose round impressions on one side showed that he had a wooden leg.
+I could even tell that they had been disturbed, for the woman had run
+back swiftly to the door, as was shown by the deep toe and light heel
+marks, while Wooden-leg had waited a little, and then had gone away.
+I thought at the time that this might be the maid and her sweetheart,
+of whom you had already spoken to me, and inquiry showed it was so.
+I passed round the garden without seeing anything more than random
+tracks, which I took to be the police; but when I got into the stable
+lane a very long and complex story was written in the snow in front of
+me.
+
+“There was a double line of tracks of a booted man, and a second double
+line which I saw with delight belonged to a man with naked feet. I was
+at once convinced from what you had told me that the latter was your
+son. The first had walked both ways, but the other had run swiftly,
+and, as his tread was marked in places over the depression of the boot,
+it was obvious that he had passed after the other. I followed them up,
+and found that they led to the hall window, where Boots had worn all
+the snow away while waiting. Then I walked to the other end, which was
+a hundred yards or more down the lane. I saw where Boots had faced
+round, where the snow was cut up as though there had been a struggle,
+and, finally, where a few drops of blood had fallen, to show me that I
+was not mistaken. Boots had then run down the lane, and another little
+smudge of blood showed that it was he who had been hurt. When he came
+to the high-road at the other end, I found that the pavement had been
+cleared, so there was an end to that clew.
+
+“On entering the house, however, I examined, as you remember, the sill
+and framework of the hall window with my lens, and I could at once
+see that some one had passed out. I could distinguish the outline of
+an instep where the wet foot had been placed in coming in. I was then
+beginning to be able to form an opinion as to what had occurred. A man
+had waited outside the window, some one had brought the gems; the deed
+had been overseen by your son, he had pursued the thief, had struggled
+with him, they had each tugged at the coronet, their united strength
+causing injuries which neither alone could have effected. He had
+returned with the prize, but had left a fragment in the grasp of his
+opponent. So far I was clear. The question now was, who was the man,
+and who was it brought him the coronet?
+
+“It is an old maxim of mine that when you have excluded the impossible,
+whatever remains, however improbable, must be the truth. Now, I knew
+that it was not you who had brought it down, so there only remained
+your niece and the maids. But if it were the maids, why should your son
+allow himself to be accused in their place? There could be no possible
+reason. As he loved his cousin, however, there was an excellent
+explanation why he should retain her secret—the more so as the secret
+was a disgraceful one. When I remembered that you had seen her at
+that window, and how she had fainted on seeing the coronet again, my
+conjecture became a certainty.
+
+“And who could it be who was her confederate? A lover evidently, for
+who else could outweigh the love and gratitude which she must feel to
+you? I knew that you went out little, and that your circle of friends
+was a very limited one. But among them was Sir George Burnwell. I had
+heard of him before as being a man of evil reputation among women. It
+must have been he who wore those boots and retained the missing gems.
+Even though he knew that Arthur had discovered him, he might still
+flatter himself that he was safe, for the lad could not say a word
+without compromising his own family.
+
+“Well, your own good sense will suggest what measures I took next. I
+went in the shape of a loafer to Sir George’s house, managed to pick
+up an acquaintance with his valet, learned that his master had cut his
+head the night before, and, finally, at the expense of six shillings,
+made all sure by buying a pair of his cast-off shoes. With these I
+journeyed down to Streatham, and saw that they exactly fitted the
+tracks.”
+
+[Illustration: “I CLAPPED A PISTOL TO HIS HEAD”]
+
+“I saw an ill-dressed vagabond in the lane yesterday evening,” said Mr.
+Holder.
+
+“Precisely. It was I. I found that I had my man, so I came home and
+changed my clothes. It was a delicate part which I had to play then,
+for I saw that a prosecution must be avoided to avert scandal, and I
+knew that so astute a villain would see that our hands were tied in the
+matter. I went and saw him. At first, of course, he denied everything.
+But when I gave him every particular that had occurred, he tried to
+bluster, and took down a life-preserver from the wall. I knew my man,
+however, and I clapped a pistol to his head before he could strike.
+Then he became a little more reasonable. I told him that we would give
+him a price for the stones he held—£1000 apiece. That brought out the
+first signs of grief that he had shown. ‘Why, dash it all!’ said he,
+‘I’ve let them go at six hundred for the three!’ I soon managed to get
+the address of the receiver who had them, on promising him that there
+would be no prosecution. Off I set to him, and after much chaffering I
+got our stones at £1000 apiece. Then I looked in upon your son, told
+him that all was right, and eventually got to my bed about two o’clock,
+after what I may call a really hard day’s work.”
+
+“A day which has saved England from a great public scandal,” said the
+banker, rising. “Sir, I cannot find words to thank you, but you shall
+not find me ungrateful for what you have done. Your skill has indeed
+exceeded all that I have heard of it. And now I must fly to my dear boy
+to apologize to him for the wrong which I have done him. As to what you
+tell me of poor Mary, it goes to my very heart. Not even your skill can
+inform me where she is now.”
+
+“I think that we may safely say,” returned Holmes, “that she is
+wherever Sir George Burnwell is. It is equally certain, too, that
+whatever her sins are, they will soon receive a more than sufficient
+punishment.”
+
+
+
+
+Adventure XII
+
+THE ADVENTURE OF THE COPPER BEECHES
+
+
+“To the man who loves art for its own sake,” remarked Sherlock Holmes,
+tossing aside the advertisement sheet of _The Daily Telegraph_, “it is
+frequently in its least important and lowliest manifestations that the
+keenest pleasure is to be derived. It is pleasant to me to observe,
+Watson, that you have so far grasped this truth that in these little
+records of our cases which you have been good enough to draw up, and, I
+am bound to say, occasionally to embellish, you have given prominence
+not so much to the many _causes célèbres_ and sensational trials in
+which I have figured, but rather to those incidents which may have been
+trivial in themselves, but which have given room for those faculties
+of deduction and of logical synthesis which I have made my special
+province.”
+
+“And yet,” said I, smiling, “I cannot quite hold myself absolved from
+the charge of sensationalism which has been urged against my records.”
+
+“You have erred, perhaps,” he observed, taking up a glowing cinder with
+the tongs, and lighting with it the long cherry-wood pipe which was
+wont to replace his clay when he was in a disputatious, rather than a
+meditative mood—“you have erred perhaps in attempting to put color and
+life into each of your statements, instead of confining yourself to the
+task of placing upon record that severe reasoning from cause to effect
+which is really the only notable feature about the thing.”
+
+“It seems to me that I have done you full justice in the matter,” I
+remarked, with some coldness, for I was repelled by the egotism which
+I had more than once observed to be a strong factor in my friend’s
+singular character.
+
+“No, it is not selfishness or conceit,” said he, answering, as was his
+wont, my thoughts rather than my words. “If I claim full justice for my
+art, it is because it is an impersonal thing—a thing beyond myself.
+Crime is common. Logic is rare. Therefore it is upon the logic rather
+than upon the crime that you should dwell. You have degraded what
+should have been a course of lectures into a series of tales.”
+
+It was a cold morning of the early spring, and we sat after breakfast
+on either side of a cheery fire in the old room at Baker Street. A
+thick fog rolled down between the lines of dun-colored houses, and the
+opposing windows loomed like dark, shapeless blurs through the heavy
+yellow wreaths. Our gas was lit, and shone on the white cloth and
+glimmer of china and metal, for the table had not been cleared yet.
+Sherlock Holmes had been silent all the morning, dipping continuously
+into the advertisement columns of a succession of papers, until at
+last, having apparently given up his search, he had emerged in no very
+sweet temper to lecture me upon my literary shortcomings.
+
+“At the same time,” he remarked, after a pause, during which he had sat
+puffing at his long pipe and gazing down into the fire, “you can hardly
+be open to a charge of sensationalism, for out of these cases which you
+have been so kind as to interest yourself in, a fair proportion do not
+treat of crime, in its legal sense, at all. The small matter in which I
+endeavored to help the King of Bohemia, the singular experience of Miss
+Mary Sutherland, the problem connected with the man with the twisted
+lip, and the incident of the noble bachelor, were all matters which are
+outside the pale of the law. But in avoiding the sensational, I fear
+that you may have bordered on the trivial.”
+
+“The end may have been so,” I answered, “but the methods I hold to have
+been novel and of interest.”
+
+“Pshaw, my dear fellow, what do the public, the great unobservant
+public, who could hardly tell a weaver by his tooth or a compositor by
+his left thumb, care about the finer shades of analysis and deduction!
+But, indeed, if you are trivial, I cannot blame you, for the days of
+the great cases are past. Man, or at least criminal man, has lost all
+enterprise and originality. As to my own little practice, it seems to
+be degenerating into an agency for recovering lost lead pencils and
+giving advice to young ladies from boarding-schools. I think that I
+have touched bottom at last, however. This note I had this morning
+marks my zero-point, I fancy. Read it!” He tossed a crumpled letter
+across to me.
+
+It was dated from Montague Place upon the preceding evening, and ran
+thus:
+
+  “DEAR MR. HOLMES,—I am very anxious to consult you as
+  to whether I should or should not accept a situation which has
+  been offered to me as governess. I shall call at half-past ten
+  to-morrow, if I do not inconvenience you.
+
+  “Yours faithfully,     VIOLET HUNTER.”
+
+“Do you know the young lady?” I asked.
+
+“Not I.”
+
+“It is half-past ten now.”
+
+“Yes, and I have no doubt that is her ring.”
+
+“It may turn out to be of more interest than you think. You remember
+that the affair of the blue carbuncle, which appeared to be a mere whim
+at first, developed into a serious investigation. It may be so in this
+case, also.”
+
+“Well, let us hope so. But our doubts will very soon be solved, for
+here, unless I am much mistaken, is the person in question.”
+
+As he spoke the door opened and a young lady entered the room. She was
+plainly but neatly dressed, with a bright, quick face, freckled like a
+plover’s egg, and with the brisk manner of a woman who has had her own
+way to make in the world.
+
+“You will excuse my troubling you, I am sure,” said she, as my
+companion rose to greet her; “but I have had a very strange experience,
+and as I have no parents or relations of any sort from whom I could ask
+advice, I thought that perhaps you would be kind enough to tell me what
+I should do.”
+
+“Pray take a seat, Miss Hunter. I shall be happy to do anything that I
+can to serve you.”
+
+I could see that Holmes was favorably impressed by the manner and
+speech of his new client. He looked her over in his searching fashion,
+and then composed himself, with his lids drooping and his finger tips
+together, to listen to her story.
+
+“I have been a governess for five years,” said she, “in the family
+of Colonel Spence Munro, but two months ago the colonel received an
+appointment at Halifax, in Nova Scotia, and took his children over
+to America with him, so that I found myself without a situation. I
+advertised, and I answered advertisements, but without success. At last
+the little money which I had saved began to run short, and I was at my
+wits’ end as to what I should do.
+
+“There is a well-known agency for governesses in the West End called
+Westaway’s, and there I used to call about once a week in order to
+see whether anything had turned up which might suit me. Westaway was
+the name of the founder of the business, but it is really managed by
+Miss Stoper. She sits in her own little office, and the ladies who are
+seeking employment wait in an ante-room, and are then shown in one by
+one, when she consults her ledgers, and sees whether she has anything
+which would suit them.
+
+“Well, when I called last week I was shown into the little office as
+usual, but I found that Miss Stoper was not alone. A prodigiously stout
+man with a very smiling face, and a great heavy chin which rolled down
+in fold upon fold over his throat, sat at her elbow with a pair of
+glasses on his nose, looking very earnestly at the ladies who entered.
+As I came in he gave quite a jump in his chair, and turned quickly to
+Miss Stoper:
+
+“‘That will do,’ said he; ‘I could not ask for anything better. Capital!
+capital!’ He seemed quite enthusiastic, and rubbed his hands together
+in the most genial fashion. He was such a comfortable-looking man that
+it was quite a pleasure to look at him.
+
+“‘You are looking for a situation, miss?’ he asked.
+
+“‘Yes, sir.’
+
+“‘As governess?’
+
+“‘Yes, sir.’
+
+“‘And what salary do you ask?’
+
+“‘I had £4 a month in my last place with Colonel Spence Munro.’
+
+“‘Oh, tut, tut! sweating—rank sweating!’ he cried, throwing his fat
+hands out into the air like a man who is in a boiling passion. ‘How
+could any one offer so pitiful a sum to a lady with such attractions
+and accomplishments?’
+
+“‘My accomplishments, sir, may be less than you imagine,’ said I. ‘A
+little French, a little German, music, and drawing—’
+
+“‘Tut, tut!’ he cried. ‘This is all quite beside the question. The
+point is, have you or have you not the bearing and deportment of a
+lady? There it is in a nutshell. If you have not, you are not fitted
+for the rearing of a child who may some day play a considerable part
+in the history of the country. But if you have, why, then, how could
+any gentleman ask you to condescend to accept anything under the three
+figures? Your salary with me, madam, would commence at £100 a year.’
+
+“You may imagine, Mr. Holmes, that to me, destitute as I was, such an
+offer seemed almost too good to be true. The gentleman, however, seeing
+perhaps the look of incredulity upon my face, opened a pocket-book and
+took out a note.
+
+“‘It is also my custom,’ said he, smiling in the most pleasant fashion
+until his eyes were just two little shining slits amid the white
+creases of his face, ‘to advance to my young ladies half their salary
+beforehand, so that they may meet any little expenses of their journey
+and their wardrobe.’
+
+“It seemed to me that I had never met so fascinating and so thoughtful
+a man. As I was already in debt to my tradesmen, the advance was a
+great convenience, and yet there was something unnatural about the
+whole transaction which made me wish to know a little more before I
+quite committed myself.
+
+“‘May I ask where you live, sir?’ said I.
+
+“‘Hampshire. Charming rural place. The Copper Beeches, five miles on the
+far side of Winchester. It is the most lovely country, my dear young
+lady, and the dearest old country-house.’
+
+“‘And my duties, sir? I should be glad to know what they would be.’
+
+“‘One child—one dear little romper just six years old. Oh, if you could
+see him killing cockroaches with a slipper! Smack! smack! smack! Three
+gone before you could wink!’ He leaned back in his chair and laughed
+his eyes into his head again.
+
+“I was a little startled at the nature of the child’s amusement, but
+the father’s laughter made me think that perhaps he was joking.
+
+“‘My sole duties, then,’ I asked, ‘are to take charge of a single child?’
+
+“‘No, no, not the sole, not the sole, my dear young lady,’ he cried.
+‘Your duty would be, as I am sure your good sense would suggest, to
+obey any little commands my wife might give, provided always that they
+were such commands as a lady might with propriety obey. You see no
+difficulty, heh?’
+
+“‘I should be happy to make myself useful.’
+
+“‘Quite so. In dress now, for example. We are faddy people, you
+know—faddy but kind-hearted. If you were asked to wear any dress which
+we might give you, you would not object to our little whim. Heh?’
+
+“‘No,’ said I, considerably astonished at his words.
+
+“‘Or to sit here, or sit there, that would not be offensive to you?’
+
+“‘Oh, no.’
+
+“‘Or to cut your hair quite short before you come to us?’
+
+“I could hardly believe my ears. As you may observe, Mr. Holmes, my
+hair is somewhat luxuriant, and of a rather peculiar tint of chestnut.
+It has been considered artistic. I could not dream of sacrificing it in
+this off-hand fashion.
+
+“‘I am afraid that that is quite impossible,’ said I. He had been
+watching me eagerly out of his small eyes, and I could see a shadow
+pass over his face as I spoke.
+
+“‘I am afraid that it is quite essential,’ said he. ‘It is a little
+fancy of my wife’s, and ladies’ fancies, you know, madam, ladies’
+fancies must be consulted. And so you won’t cut your hair?’
+
+“‘No, sir, I really could not,’ I answered, firmly.
+
+“‘Ah, very well; then that quite settles the matter. It is a pity,
+because in other respects you would really have done very nicely. In
+that case, Miss Stoper, I had best inspect a few more of your young
+ladies.’
+
+“The manageress had sat all this while busy with her papers without a
+word to either of us, but she glanced at me now with so much annoyance
+upon her face that I could not help suspecting that she had lost a
+handsome commission through my refusal.
+
+“‘Do you desire your name to be kept upon the books?’ she asked.
+
+“‘If you please, Miss Stoper.’
+
+“‘Well, really, it seems rather useless, since you refuse the most
+excellent offers in this fashion,’ said she, sharply. ‘You can hardly
+expect us to exert ourselves to find another such opening for you.
+Good-day to you, Miss Hunter.’ She struck a gong upon the table, and I
+was shown out by the page.
+
+“Well, Mr. Holmes, when I got back to my lodgings and found little
+enough in the cupboard, and two or three bills upon the table, I began
+to ask myself whether I had not done a very foolish thing. After all,
+if these people had strange fads, and expected obedience on the most
+extraordinary matters, they were at least ready to pay for their
+eccentricity. Very few governesses in England are getting £100 a
+year. Besides, what use was my hair to me? Many people are improved by
+wearing it short, and perhaps I should be among the number. Next day I
+was inclined to think that I had made a mistake, and by the day after
+I was sure of it. I had almost overcome my pride, so far as to go back
+to the agency and inquire whether the place was still open, when I
+received this letter from the gentleman himself. I have it here, and I
+will read it to you:
+
+    “‘The Copper Beeches, near Winchester.
+
+    “‘DEAR MISS HUNTER,—Miss Stoper has very kindly given me your
+    address, and I write from here to ask you whether you have
+    reconsidered your decision. My wife is very anxious that you
+    should come, for she has been much attracted by my description
+    of you. We are willing to give £30 a quarter, or £120 a year, so
+    as to recompense you for any little inconvenience which our fads
+    may cause you. They are not very exacting, after all. My wife
+    is fond of a particular shade of electric blue, and would like
+    you to wear such a dress in-doors in the morning. You need not,
+    however, go to the expense of purchasing one, as we have one
+    belonging to my dear daughter Alice (now in Philadelphia), which
+    would, I should think, fit you very well. Then, as to sitting
+    here or there, or amusing yourself in any manner indicated, that
+    need cause you no inconvenience. As regards your hair, it is
+    no doubt a pity, especially as I could not help remarking its
+    beauty during our short interview, but I am afraid that I must
+    remain firm upon this point, and I only hope that the increased
+    salary may recompense you for the loss. Your duties, as far as
+    the child is concerned, are very light. Now do try to come, and
+    I shall meet you with the dog-cart at Winchester. Let me know
+    your train.         Yours faithfully,      JEPHRO RUCASTLE.’
+
+“That is the letter which I have just received, Mr. Holmes, and my mind
+is made up that I will accept it. I thought, however, that before
+taking the final step I should like to submit the whole matter to your
+consideration.”
+
+“Well, Miss Hunter, if your mind is made up, that settles the
+question,” said Holmes, smiling.
+
+“But you would not advise me to refuse?”
+
+“I confess that it is not the situation which I should like to see a
+sister of mine apply for.”
+
+“What is the meaning of it all, Mr. Holmes?”
+
+“Ah, I have no data. I cannot tell. Perhaps you have yourself formed
+some opinion?”
+
+“Well, there seems to me to be only one possible solution. Mr. Rucastle
+seemed to be a very kind, good-natured man. Is it not possible that his
+wife is a lunatic, that he desires to keep the matter quiet for fear
+she should be taken to an asylum, and that he humors her fancies in
+every way in order to prevent an outbreak.”
+
+“That is a possible solution—in fact, as matters stand, it is the most
+probable one. But in any case it does not seem to be a nice household
+for a young lady.”
+
+“But the money, Mr. Holmes, the money!”
+
+“Well, yes, of course the pay is good—too good. That is what makes
+me uneasy. Why should they give you £120 a year, when they could have
+their pick for £40? There must be some strong reason behind.”
+
+“I thought that if I told you the circumstances you would understand
+afterwards if I wanted your help. I should feel so much stronger if I
+felt that you were at the back of me.”
+
+“Oh, you may carry that feeling away with you. I assure you that your
+little problem promises to be the most interesting which has come my
+way for some months. There is something distinctly novel about some of
+the features. If you should find yourself in doubt or in danger—”
+
+“Danger! What danger do you foresee?”
+
+Holmes shook his head gravely. “It would cease to be a danger if we
+could define it,” said he. “But at any time, day or night, a telegram
+would bring me down to your help.”
+
+“That is enough.” She rose briskly from her chair with the anxiety
+all swept from her face. “I shall go down to Hampshire quite easy in
+my mind now. I shall write to Mr. Rucastle at once, sacrifice my poor
+hair to-night, and start for Winchester to-morrow.” With a few grateful
+words to Holmes she bade us both good-night and bustled off upon her
+way.
+
+“At least,” said I, as we heard her quick, firm step descending the
+stairs, “she seems to be a young lady who is very well able to take
+care of herself.”
+
+“And she would need to be,” said Holmes, gravely; “I am much mistaken
+if we do not hear from her before many days are past.”
+
+It was not very long before my friend’s prediction was fulfilled. A
+fortnight went by, during which I frequently found my thoughts turning
+in her direction, and wondering what strange side-alley of human
+experience this lonely woman had strayed into. The unusual salary,
+the curious conditions, the light duties, all pointed to something
+abnormal, though whether a fad or a plot, or whether the man were
+a philanthropist or a villain, it was quite beyond my powers to
+determine. As to Holmes, I observed that he sat frequently for half an
+hour on end, with knitted brows and an abstracted air, but he swept the
+matter away with a wave of his hand when I mentioned it. “Data! data!
+data!” he cried, impatiently. “I can’t make bricks without clay.” And
+yet he would always wind up by muttering that no sister of his should
+ever have accepted such a situation.
+
+The telegram which we eventually received came late one night, just as
+I was thinking of turning in, and Holmes was settling down to one of
+those all-night chemical researches which he frequently indulged in,
+when I would leave him stooping over a retort and a test-tube at night,
+and find him in the same position when I came down to breakfast in
+the morning. He opened the yellow envelope, and then, glancing at the
+message, threw it across to me.
+
+“Just look up the trains in Bradshaw,” said he, and turned back to his
+chemical studies.
+
+The summons was a brief and urgent one.
+
+  “Please be at the ‘Black Swan’ Hotel at Winchester at
+  mid-day to-morrow,” it said. “Do come! I am at my wits’
+  end.                                       HUNTER.”
+
+“Will you come with me?” asked Holmes, glancing up.
+
+“I should wish to.”
+
+“Just look it up, then.”
+
+“There is a train at half-past nine,” said I, glancing over my
+Bradshaw. “It is due at Winchester at 11.30.”
+
+“That will do very nicely. Then perhaps I had better postpone my
+analysis of the acetones, as we may need to be at our best in the
+morning.”
+
+       *       *       *       *       *
+
+By eleven o’clock the next day we were well upon our way to the old
+English capital. Holmes had been buried in the morning papers all the
+way down, but after we had passed the Hampshire border he threw them
+down, and began to admire the scenery. It was an ideal spring day, a
+light blue sky, flecked with little fleecy white clouds drifting across
+from west to east. The sun was shining very brightly, and yet there was
+an exhilarating nip in the air, which set an edge to a man’s energy.
+All over the country-side, away to the rolling hills around Aldershot,
+the little red and gray roofs of the farm-steadings peeped out from
+amid the light green of the new foliage.
+
+“Are they not fresh and beautiful?” I cried, with all the enthusiasm of
+a man fresh from the fogs of Baker Street.
+
+But Holmes shook his head gravely.
+
+“Do you know, Watson,” said he, “that it is one of the curses of a mind
+with a turn like mine that I must look at everything with reference to
+my own special subject. You look at these scattered houses, and you are
+impressed by their beauty. I look at them, and the only thought which
+comes to me is a feeling of their isolation and of the impunity with
+which crime may be committed there.”
+
+“Good heavens!” I cried. “Who would associate crime with these dear old
+homesteads?”
+
+“They always fill me with a certain horror. It is my belief, Watson,
+founded upon my experience, that the lowest and vilest alleys in London
+do not present a more dreadful record of sin than does the smiling and
+beautiful country-side.”
+
+“You horrify me!”
+
+“But the reason is very obvious. The pressure of public opinion can
+do in the town what the law cannot accomplish. There is no lane so
+vile that the scream of a tortured child, or the thud of a drunkard’s
+blow, does not beget sympathy and indignation among the neighbors, and
+then the whole machinery of justice is ever so close that a word of
+complaint can set it going, and there is but a step between the crime
+and the dock. But look at these lonely houses, each in its own fields,
+filled for the most part with poor ignorant folk who know little of
+the law. Think of the deeds of hellish cruelty, the hidden wickedness
+which may go on, year in, year out, in such places, and none the wiser.
+Had this lady who appeals to us for help gone to live in Winchester, I
+should never have had a fear for her. It is the five miles of country
+which makes the danger. Still, it is clear that she is not personally
+threatened.”
+
+“No. If she can come to Winchester to meet us she can get away.”
+
+“Quite so. She has her freedom.”
+
+“What _can_ be the matter, then? Can you suggest no explanation?”
+
+“I have devised seven separate explanations, each of which would cover
+the facts as far as we know them. But which of these is correct can
+only be determined by the fresh information which we shall no doubt
+find waiting for us. Well, there is the tower of the cathedral, and we
+shall soon learn all that Miss Hunter has to tell.”
+
+The “Black Swan” is an inn of repute in the High Street, at no
+distance from the station, and there we found the young lady waiting
+for us. She had engaged a sitting-room, and our lunch awaited us upon
+the table.
+
+“I am so delighted that you have come,” she said, earnestly. “It is so
+very kind of you both; but indeed I do not know what I should do. Your
+advice will be altogether invaluable to me.”
+
+“Pray tell us what has happened to you.”
+
+“I will do so, and I must be quick, for I have promised Mr. Rucastle to
+be back before three. I got his leave to come into town this morning,
+though he little knew for what purpose.”
+
+“Let us have everything in its due order.” Holmes thrust his long thin
+legs out towards the fire and composed himself to listen.
+
+“In the first place, I may say that I have met, on the whole, with no
+actual ill-treatment from Mr. and Mrs. Rucastle. It is only fair to
+them to say that. But I cannot understand them, and I am not easy in my
+mind about them.”
+
+“What can you not understand?”
+
+“Their reasons for their conduct. But you shall have it all just as
+it occurred. When I came down, Mr. Rucastle met me here, and drove me
+in his dog-cart to the Copper Beeches. It is, as he said, beautifully
+situated, but it is not beautiful in itself, for it is a large square
+block of a house, whitewashed, but all stained and streaked with damp
+and bad weather. There are grounds round it, woods on three sides, and
+on the fourth a field which slopes down to the Southampton high-road,
+which curves past about a hundred yards from the front door. This
+ground in front belongs to the house, but the woods all round are part
+of Lord Southerton’s preserves. A clump of copper beeches immediately
+in front of the hall door has given its name to the place.
+
+[Illustration: “‘I AM SO DELIGHTED THAT YOU HAVE COME’”]
+
+“I was driven over by my employer, who was as amiable as ever, and was
+introduced by him that evening to his wife and the child. There was no
+truth, Mr. Holmes, in the conjecture which seemed to us to be probable
+in your rooms at Baker Street. Mrs. Rucastle is not mad. I found her
+to be a silent, pale-faced woman, much younger than her husband, not
+more than thirty, I should think, while he can hardly be less than
+forty-five. From their conversation I have gathered that they have been
+married about seven years, that he was a widower, and that his only
+child by the first wife was the daughter who has gone to Philadelphia.
+Mr. Rucastle told me in private that the reason why she had left them
+was that she had an unreasoning aversion to her step-mother. As the
+daughter could not have been less than twenty, I can quite imagine that
+her position must have been uncomfortable with her father’s young wife.
+
+“Mrs. Rucastle seemed to me to be colorless in mind as well as in
+feature. She impressed me neither favorably nor the reverse. She was a
+nonentity. It was easy to see that she was passionately devoted both
+to her husband and to her little son. Her light gray eyes wandered
+continually from one to the other, noting every little want and
+forestalling it if possible. He was kind to her also in his bluff,
+boisterous fashion, and on the whole they seemed to be a happy couple.
+And yet she had some secret sorrow, this woman. She would often be lost
+in deep thought, with the saddest look upon her face. More than once I
+have surprised her in tears. I have thought sometimes that it was the
+disposition of her child which weighed upon her mind, for I have never
+met so utterly spoilt and so ill-natured a little creature. He is small
+for his age, with a head which is quite disproportionately large. His
+whole life appears to be spent in an alternation between savage fits of
+passion and gloomy intervals of sulking. Giving pain to any creature
+weaker than himself seems to be his one idea of amusement, and he
+shows quite remarkable talent in planning the capture of mice, little
+birds, and insects. But I would rather not talk about the creature, Mr.
+Holmes, and, indeed, he has little to do with my story.”
+
+“I am glad of all details,” remarked my friend, “whether they seem to
+you to be relevant or not.”
+
+“I shall try not to miss anything of importance. The one unpleasant
+thing about the house, which struck me at once, was the appearance
+and conduct of the servants. There are only two, a man and his wife.
+Toller, for that is his name, is a rough, uncouth man, with grizzled
+hair and whiskers, and a perpetual smell of drink. Twice since I have
+been with them he has been quite drunk, and yet Mr. Rucastle seemed to
+take no notice of it. His wife is a very tall and strong woman with a
+sour face, as silent as Mrs. Rucastle, and much less amiable. They are
+a most unpleasant couple, but fortunately I spend most of my time in
+the nursery and my own room, which are next to each other in one corner
+of the building.
+
+“For two days after my arrival at the Copper Beeches my life was very
+quiet; on the third, Mrs. Rucastle came down just after breakfast and
+whispered something to her husband.
+
+“‘Oh yes,’ said he, turning to me; ‘we are very much obliged to you,
+Miss Hunter, for falling in with our whims so far as to cut your hair.
+I assure you that it has not detracted in the tiniest iota from your
+appearance. We shall now see how the electric-blue dress will become
+you. You will find it laid out upon the bed in your room, and if you
+would be so good as to put it on we should both be extremely obliged.’
+
+“The dress which I found waiting for me was of a peculiar shade of
+blue. It was of excellent material, a sort of beige, but it bore
+unmistakable signs of having been worn before. It could not have been
+a better fit if I had been measured for it. Both Mr. and Mrs. Rucastle
+expressed a delight at the look of it, which seemed quite exaggerated
+in its vehemence. They were waiting for me in the drawing-room, which
+is a very large room, stretching along the entire front of the house,
+with three long windows reaching down to the floor. A chair had been
+placed close to the central window, with its back turned towards it. In
+this I was asked to sit, and then Mr. Rucastle, walking up and down on
+the other side of the room, began to tell me a series of the funniest
+stories that I have ever listened to. You cannot imagine how comical he
+was, and I laughed until I was quite weary. Mrs. Rucastle, however, who
+has evidently no sense of humor, never so much as smiled, but sat with
+her hands in her lap, and a sad, anxious look upon her face. After an
+hour or so, Mr. Rucastle suddenly remarked that it was time to commence
+the duties of the day, and that I might change my dress and go to
+little Edward in the nursery.
+
+“Two days later this same performance was gone through under exactly
+similar circumstances. Again I changed my dress, again I sat in the
+window, and again I laughed very heartily at the funny stories of which
+my employer had an immense _répertoire_, and which he told inimitably.
+Then he handed me a yellow-backed novel, and, moving my chair a little
+sideways, that my own shadow might not fall upon the page, he begged me
+to read aloud to him. I read for about ten minutes, beginning in the
+heart of a chapter, and then suddenly, in the middle of a sentence, he
+ordered me to cease and to change my dress.
+
+“You can easily imagine, Mr. Holmes, how curious I became as to what
+the meaning of this extraordinary performance could possibly be. They
+were always very careful, I observed, to turn my face away from the
+window, so that I became consumed with the desire to see what was going
+on behind my back. At first it seemed to be impossible, but I soon
+devised a means. My hand-mirror had been broken, so a happy thought
+seized me, and I concealed a piece of the glass in my handkerchief. On
+the next occasion, in the midst of my laughter, I put my handkerchief
+up to my eyes, and was able with a little management to see all that
+there was behind me. I confess that I was disappointed. There was
+nothing. At least that was my first impression. At the second glance,
+however, I perceived that there was a man standing in the Southampton
+Road, a small bearded man in a gray suit, who seemed to be looking in
+my direction. The road is an important highway, and there are usually
+people there. This man, however, was leaning against the railings
+which bordered our field, and was looking earnestly up. I lowered my
+handkerchief and glanced at Mrs. Rucastle, to find her eyes fixed upon
+me with a most searching gaze. She said nothing, but I am convinced
+that she had divined that I had a mirror in my hand, and had seen what
+was behind me. She rose at once.
+
+“‘Jephro,’ said she, ‘there is an impertinent fellow upon the road
+there who stares up at Miss Hunter.’
+
+“‘No friend of yours, Miss Hunter?’ he asked.
+
+“‘No; I know no one in these parts.’
+
+“‘Dear me! How very impertinent! Kindly turn round and motion to him to
+go away.’
+
+“‘Surely it would be better to take no notice.’
+
+“‘No, no, we should have him loitering here always. Kindly turn round
+and wave him away like that.’
+
+“I did as I was told, and at the same instant Mrs. Rucastle drew down
+the blind. That was a week ago, and from that time I have not sat again
+in the window, nor have I worn the blue dress, nor seen the man in the
+road.”
+
+“Pray continue,” said Holmes. “Your narrative promises to be a most
+interesting one.”
+
+“You will find it rather disconnected, I fear, and there may prove to
+be little relation between the different incidents of which I speak.
+On the very first day that I was at the Copper Beeches, Mr. Rucastle
+took me to a small out-house which stands near the kitchen door. As we
+approached it I heard the sharp rattling of a chain, and the sound as
+of a large animal moving about.
+
+“‘Look in here!’ said Mr. Rucastle, showing me a slit between two
+planks. ‘Is he not a beauty?’
+
+“I looked through, and was conscious of two glowing eyes, and of a
+vague figure huddled up in the darkness.
+
+“‘Don’t be frightened,’ said my employer, laughing at the start which I
+had given. ‘It’s only Carlo, my mastiff. I call him mine, but really
+old Toller, my groom, is the only man who can do anything with him. We
+feed him once a day, and not too much then, so that he is always as
+keen as mustard. Toller lets him loose every night, and God help the
+trespasser whom he lays his fangs upon. For goodness’ sake don’t you
+ever on any pretext set your foot over the threshold at night, for it
+is as much as your life is worth.’
+
+“The warning was no idle one, for two nights later I happened to look
+out of my bedroom window about two o’clock in the morning. It was a
+beautiful moonlight night, and the lawn in front of the house was
+silvered over and almost as bright as day. I was standing, rapt in
+the peaceful beauty of the scene, when I was aware that something was
+moving under the shadow of the copper beeches. As it emerged into the
+moonshine I saw what it was. It was a giant dog, as large as a calf,
+tawny tinted, with hanging jowl, black muzzle, and huge projecting
+bones. It walked slowly across the lawn and vanished into the shadow
+upon the other side. That dreadful silent sentinel sent a chill to my
+heart which I do not think that any burglar could have done.
+
+“And now I have a very strange experience to tell you. I had, as you
+know, cut off my hair in London, and I had placed it in a great coil
+at the bottom of my trunk. One evening, after the child was in bed,
+I began to amuse myself by examining the furniture of my room and by
+rearranging my own little things. There was an old chest of drawers
+in the room, the two upper ones empty and open, the lower one locked.
+I had filled the first two with my linen, and, as I had still much
+to pack away, I was naturally annoyed at not having the use of the
+third drawer. It struck me that it might have been fastened by a mere
+oversight, so I took out my bunch of keys and tried to open it. The
+very first key fitted to perfection, and I drew the drawer open. There
+was only one thing in it, but I am sure that you would never guess what
+it was. It was my coil of hair.
+
+“I took it up and examined it. It was of the same peculiar tint, and
+the same thickness. But then the impossibility of the thing obtruded
+itself upon me. How _could_ my hair have been locked in the drawer?
+With trembling hands I undid my trunk, turned out the contents, and
+drew from the bottom my own hair. I laid the two tresses together, and
+I assure you that they were identical. Was it not extraordinary? Puzzle
+as I would, I could make nothing at all of what it meant. I returned
+the strange hair to the drawer, and I said nothing of the matter to the
+Rucastles, as I felt that I had put myself in the wrong by opening a
+drawer which they had locked.
+
+“I am naturally observant, as you may have remarked, Mr. Holmes, and I
+soon had a pretty good plan of the whole house in my head. There was
+one wing, however, which appeared not to be inhabited at all. A door
+which faced that which led into the quarters of the Tollers opened
+into this suite, but it was invariably locked. One day, however, as I
+ascended the stair, I met Mr. Rucastle coming out through this door,
+his keys in his hand, and a look on his face which made him a very
+different person to the round, jovial man to whom I was accustomed. His
+cheeks were red, his brow was all crinkled with anger, and the veins
+stood out at his temples with passion. He locked the door and hurried
+past me without a word or a look.
+
+“This aroused my curiosity; so when I went out for a walk in the
+grounds with my charge, I strolled round to the side from which I could
+see the windows of this part of the house. There were four of them in a
+row, three of which were simply dirty, while the fourth was shuttered
+up. They were evidently all deserted. As I strolled up and down,
+glancing at them occasionally, Mr. Rucastle came out to me, looking as
+merry and jovial as ever.
+
+“‘Ah!’ said he, ‘you must not think me rude if I passed you without a
+word, my dear young lady. I was preoccupied with business matters.’
+
+“I assured him that I was not offended. ‘By-the-way,’ said I, ‘you
+seem to have quite a suite of spare rooms up there, and one of them has
+the shutters up.’
+
+“He looked surprised, and, as it seemed to me, a little startled at my
+remark.
+
+“‘Photography is one of my hobbies,’ said he. ‘I have made my dark room
+up there. But, dear me! what an observant young lady we have come upon.
+Who would have believed it? Who would have ever believed it?’ He spoke
+in a jesting tone, but there was no jest in his eyes as he looked at
+me. I read suspicion there and annoyance, but no jest.
+
+“Well, Mr. Holmes, from the moment that I understood that there was
+something about that suite of rooms which I was not to know, I was all
+on fire to go over them. It was not mere curiosity, though I have my
+share of that. It was more a feeling of duty—a feeling that some good
+might come from my penetrating to this place. They talk of woman’s
+instinct; perhaps it was woman’s instinct which gave me that feeling.
+At any rate, it was there, and I was keenly on the lookout for any
+chance to pass the forbidden door.
+
+“It was only yesterday that the chance came. I may tell you that,
+besides Mr. Rucastle, both Toller and his wife find something to do in
+these deserted rooms, and I once saw him carrying a large black linen
+bag with him through the door. Recently he has been drinking hard, and
+yesterday evening he was very drunk; and, when I came up-stairs, there
+was the key in the door. I have no doubt at all that he had left it
+there. Mr. and Mrs. Rucastle were both down-stairs, and the child was
+with them, so that I had an admirable opportunity. I turned the key
+gently in the lock, opened the door, and slipped through.
+
+“There was a little passage in front of me, unpapered and uncarpeted,
+which turned at a right angle at the farther end. Round this corner
+were three doors in a line, the first and third of which were open.
+They each led into an empty room, dusty and cheerless, with two windows
+in the one and one in the other, so thick with dirt that the evening
+light glimmered dimly through them. The centre door was closed, and
+across the outside of it had been fastened one of the broad bars of
+an iron bed, padlocked at one end to a ring in the wall, and fastened
+at the other with stout cord. The door itself was locked as well, and
+the key was not there. This barricaded door corresponded clearly with
+the shuttered window outside, and yet I could see by the glimmer from
+beneath it that the room was not in darkness. Evidently there was a
+skylight which let in light from above. As I stood in the passage
+gazing at the sinister door, and wondering what secret it might veil,
+I suddenly heard the sound of steps within the room, and saw a shadow
+pass backward and forward against the little slit of dim light which
+shone out from under the door. A mad, unreasoning terror rose up in
+me at the sight, Mr. Holmes. My overstrung nerves failed me suddenly,
+and I turned and ran—ran as though some dreadful hand were behind me
+clutching at the skirt of my dress. I rushed down the passage, through
+the door, and straight into the arms of Mr. Rucastle, who was waiting
+outside.
+
+“‘So,’ said he, smiling, ‘it was you, then. I thought that it must be
+when I saw the door open.’
+
+“‘Oh, I am so frightened!’ I panted.
+
+“‘My dear young lady! my dear young lady!’—you cannot think how
+caressing and soothing his manner was—‘and what has frightened you, my
+dear young lady?’
+
+“But his voice was just a little too coaxing. He overdid it. I was
+keenly on my guard against him.
+
+“‘I was foolish enough to go into the empty wing,’ I answered. ‘But it
+is so lonely and eerie in this dim light that I was frightened and ran
+out again. Oh, it is so dreadfully still in there!’
+
+“‘Only that?’ said he, looking at me keenly.
+
+“‘Why, what did you think?’ I asked.
+
+“‘Why do you think that I lock this door?’
+
+“‘I am sure that I do not know.’
+
+“‘It is to keep people out who have no business there. Do you see?’ He
+was still smiling in the most amiable manner.
+
+“‘I am sure if I had known—’
+
+“‘Well, then, you know now. And if you ever put your foot over that
+threshold again—’ here in an instant the smile hardened into a grin of
+rage, and he glared down at me with the face of a demon—‘I’ll throw
+you to the mastiff.’
+
+“I was so terrified that I do not know what I did. I suppose that I
+must have rushed past him into my room. I remember nothing until I
+found myself lying on my bed trembling all over. Then I thought of you,
+Mr. Holmes. I could not live there longer without some advice. I was
+frightened of the house, of the man, of the woman, of the servants,
+even of the child. They were all horrible to me. If I could only bring
+you down all would be well. Of course I might have fled from the house,
+but my curiosity was almost as strong as my fears. My mind was soon
+made up. I would send you a wire. I put on my hat and cloak, went down
+to the office, which is about half a mile from the house, and then
+returned, feeling very much easier. A horrible doubt came into my mind
+as I approached the door lest the dog might be loose, but I remembered
+that Toller had drunk himself into a state of insensibility that
+evening, and I knew that he was the only one in the household who had
+any influence with the savage creature, or who would venture to set him
+free. I slipped in in safety, and lay awake half the night in my joy at
+the thought of seeing you. I had no difficulty in getting leave to come
+into Winchester this morning, but I must be back before three o’clock,
+for Mr. and Mrs. Rucastle are going on a visit, and will be away all
+the evening, so that I must look after the child. Now I have told you
+all my adventures, Mr. Holmes, and I should be very glad if you could
+tell me what it all means, and, above all, what I should do.”
+
+Holmes and I had listened spellbound to this extraordinary story. My
+friend rose now and paced up and down the room, his hands in his
+pockets, and an expression of the most profound gravity upon his face.
+
+“Is Toller still drunk?” he asked.
+
+“Yes. I heard his wife tell Mrs. Rucastle that she could do nothing
+with him.”
+
+“That is well. And the Rucastles go out to-night?”
+
+“Yes.”
+
+“Is there a cellar with a good strong lock?”
+
+“Yes, the wine-cellar.”
+
+“You seem to me to have acted all through this matter like a very brave
+and sensible girl, Miss Hunter. Do you think that you could perform one
+more feat? I should not ask it of you if I did not think you a quite
+exceptional woman.”
+
+“I will try. What is it?”
+
+“We shall be at the Copper Beeches by seven o’clock, my friend and I.
+The Rucastles will be gone by that time, and Toller will, we hope, be
+incapable. There only remains Mrs. Toller, who might give the alarm. If
+you could send her into the cellar on some errand, and then turn the
+key upon her, you would facilitate matters immensely.”
+
+“I will do it.”
+
+“Excellent! We shall then look thoroughly into the affair. Of course
+there is only one feasible explanation. You have been brought there to
+personate some one, and the real person is imprisoned in this chamber.
+That is obvious. As to who this prisoner is, I have no doubt that it is
+the daughter, Miss Alice Rucastle, if I remember right, who was said
+to have gone to America. You were chosen, doubtless, as resembling her
+in height, figure, and the color of your hair. Hers had been cut off,
+very possibly in some illness through which she has passed, and so, of
+course, yours had to be sacrificed also. By a curious chance you came
+upon her tresses. The man in the road was, undoubtedly, some friend of
+hers—possibly her _fiancé_—and no doubt, as you wore the girl’s dress
+and were so like her, he was convinced from your laughter, whenever
+he saw you, and afterwards from your gesture, that Miss Rucastle was
+perfectly happy, and that she no longer desired his attentions. The dog
+is let loose at night to prevent him from endeavoring to communicate
+with her. So much is fairly clear. The most serious point in the case
+is the disposition of the child.”
+
+“What on earth has that to do with it?” I ejaculated.
+
+“My dear Watson, you as a medical man are continually gaining light as
+to the tendencies of a child by the study of the parents. Don’t you see
+that the converse is equally valid. I have frequently gained my first
+real insight into the character of parents by studying their children.
+This child’s disposition is abnormally cruel, merely for cruelty’s
+sake, and whether he derives this from his smiling father, as I should
+suspect, or from his mother, it bodes evil for the poor girl who is in
+their power.”
+
+“I am sure that you are right, Mr. Holmes,” cried our client. “A
+thousand things come back to me which make me certain that you have
+hit it. Oh, let us lose not an instant in bringing help to this poor
+creature.”
+
+“We must be circumspect, for we are dealing with a very cunning man. We
+can do nothing until seven o’clock. At that hour we shall be with you,
+and it will not be long before we solve the mystery.”
+
+We were as good as our word, for it was just seven when we reached the
+Copper Beeches, having put up our trap at a way-side public-house. The
+group of trees, with their dark leaves shining like burnished metal in
+the light of the setting sun, were sufficient to mark the house even
+had Miss Hunter not been standing smiling on the door-step.
+
+“Have you managed it?” asked Holmes.
+
+A loud thudding noise came from somewhere down-stairs. “That is
+Mrs. Toller in the cellar,” said she. “Her husband lies snoring on
+the kitchen rug. Here are his keys, which are the duplicates of Mr.
+Rucastle’s.”
+
+“You have done well indeed!” cried Holmes, with enthusiasm. “Now lead
+the way, and we shall soon see the end of this black business.”
+
+We passed up the stair, unlocked the door, followed on down a passage,
+and found ourselves in front of the barricade which Miss Hunter had
+described. Holmes cut the cord and removed the transverse bar. Then he
+tried the various keys in the lock, but without success. No sound came
+from within, and at the silence Holmes’s face clouded over.
+
+“I trust that we are not too late,” said he. “I think, Miss Hunter,
+that we had better go in without you. Now, Watson, put your shoulder to
+it, and we shall see whether we cannot make our way in.”
+
+It was an old rickety door, and gave at once before our united
+strength. Together we rushed into the room. It was empty. There was no
+furniture save a little pallet bed, a small table, and a basketful of
+linen. The skylight above was open, and the prisoner gone.
+
+“There has been some villainy here,” said Holmes; “this beauty has
+guessed Miss Hunter’s intentions, and has carried his victim off.”
+
+“But how?”
+
+“Through the skylight. We shall soon see how he managed it.” He swung
+himself up onto the roof. “Ah, yes,” he cried; “here’s the end of a
+long light ladder against the eaves. That is how he did it.”
+
+“But it is impossible,” said Miss Hunter; “the ladder was not there
+when the Rucastles went away.”
+
+“He has come back and done it. I tell you that he is a clever and
+dangerous man. I should not be very much surprised if this were he
+whose step I hear now upon the stair. I think, Watson, that it would be
+as well for you to have your pistol ready.”
+
+The words were hardly out of his mouth before a man appeared at the
+door of the room, a very fat and burly man, with a heavy stick in his
+hand. Miss Hunter screamed and shrunk against the wall at the sight of
+him, but Sherlock Holmes sprang forward and confronted him.
+
+“You villain!” said he, “where’s your daughter?”
+
+The fat man cast his eyes round, and then up at the open skylight.
+
+“It is for me to ask you that,” he shrieked, “you thieves! Spies and
+thieves! I have caught you, have I? You are in my power. I’ll serve
+you!” He turned and clattered down the stairs as hard as he could go.
+
+“He’s gone for the dog!” cried Miss Hunter.
+
+“I have my revolver,” said I.
+
+“Better close the front door,” cried Holmes, and we all rushed down
+the stairs together. We had hardly reached the hall when we heard the
+baying of a hound, and then a scream of agony, with a horrible worrying
+sound which it was dreadful to listen to. An elderly man with a red
+face and shaking limbs came staggering out at a side door.
+
+“My God!” he cried. “Some one has loosed the dog. It’s not been fed for
+two days. Quick, quick, or it’ll be too late!”
+
+Holmes and I rushed out and round the angle of the house, with Toller
+hurrying behind us. There was the huge famished brute, its black muzzle
+buried in Rucastle’s throat, while he writhed and screamed upon the
+ground. Running up, I blew its brains out, and it fell over with its
+keen white teeth still meeting in the great creases of his neck. With
+much labor we separated them, and carried him, living but horribly
+mangled, into the house. We laid him upon the drawing-room sofa, and,
+having despatched the sobered Toller to bear the news to his wife, I
+did what I could to relieve his pain. We were all assembled round him
+when the door opened, and a tall, gaunt woman entered the room.
+
+“Mrs. Toller!” cried Miss Hunter.
+
+“Yes, miss. Mr. Rucastle let me out when he came back before he went
+up to you. Ah, miss, it is a pity you didn’t let me know what you were
+planning, for I would have told you that your pains were wasted.”
+
+“Ha!” said Holmes, looking keenly at her. “It is clear that Mrs. Toller
+knows more about this matter than any one else.”
+
+“Yes, sir, I do, and I am ready enough to tell what I know.”
+
+“Then, pray, sit down, and let us hear it, for there are several points
+on which I must confess that I am still in the dark.”
+
+“I will soon make it clear to you,” said she; “and I’d have done
+so before now if I could ha’ got out from the cellar. If there’s
+police-court business over this, you’ll remember that I was the one
+that stood your friend, and that I was Miss Alice’s friend too.
+
+“She was never happy at home, Miss Alice wasn’t, from the time that
+her father married again. She was slighted like, and had no say in
+anything; but it never really became bad for her until after she met
+Mr. Fowler at a friend’s house. As well as I could learn, Miss Alice
+had rights of her own by will, but she was so quiet and patient, she
+was, that she never said a word about them, but just left everything in
+Mr. Rucastle’s hands. He knew he was safe with her; but when there was
+a chance of a husband coming forward, who would ask for all that the
+law would give him, then her father thought it time to put a stop on
+it. He wanted her to sign a paper, so that whether she married or not,
+he could use her money. When she wouldn’t do it, he kept on worrying
+her until she got brain-fever, and for six weeks was at death’s door.
+Then she got better at last, all worn to a shadow, and with her
+beautiful hair cut off; but that didn’t make no change in her young
+man, and he stuck to her as true as man could be.”
+
+“Ah,” said Holmes, “I think that what you have been good enough to
+tell us makes the matter fairly clear, and that I can deduce all
+that remains. Mr. Rucastle then, I presume, took to this system of
+imprisonment?”
+
+“Yes, sir.”
+
+“And brought Miss Hunter down from London in order to get rid of the
+disagreeable persistence of Mr. Fowler.”
+
+“That was it, sir.”
+
+“But Mr. Fowler being a persevering man, as a good seaman should
+be, blockaded the house, and, having met you, succeeded by certain
+arguments, metallic or otherwise, in convincing you that your interests
+were the same as his.”
+
+“Mr. Fowler was a very kind-spoken, free-handed gentleman,” said Mrs.
+Toller, serenely.
+
+“And in this way he managed that your good man should have no want of
+drink, and that a ladder should be ready at the moment when your master
+had gone out.”
+
+“You have it, sir, just as it happened.”
+
+“I am sure we owe you an apology, Mrs. Toller,” said Holmes, “for you
+have certainly cleared up everything which puzzled us. And here comes
+the country surgeon and Mrs. Rucastle, so I think, Watson, that we had
+best escort Miss Hunter back to Winchester, as it seems to me that our
+_locus standi_ now is rather a questionable one.”
+
+And thus was solved the mystery of the sinister house with the copper
+beeches in front of the door. Mr. Rucastle survived, but was always a
+broken man, kept alive solely through the care of his devoted wife.
+They still live with their old servants, who probably know so much of
+Rucastle’s past life that he finds it difficult to part from them.
+Mr. Fowler and Miss Rucastle were married, by special license, in
+Southampton the day after their flight, and he is now the holder of a
+Government appointment in the Island of Mauritius. As to Miss Violet
+Hunter, my friend Holmes, rather to my disappointment, manifested no
+further interest in her when once she had ceased to be the centre of
+one of his problems, and she is now the head of a private school at
+Walsall, where I believe that she has met with considerable success.
+
+
+THE END
+
+
+
+
+BY W. D. HOWELLS.
+
+
+  THE QUALITY OF MERCY. A Novel. 12mo, Cloth, $1 50; Paper,
+    75 cents.
+
+  AN IMPERATIVE DUTY. A Novel. 12mo, Cloth, $1 00.
+
+  A HAZARD OF NEW FORTUNES. A Novel. 2 Volumes. 12mo, Cloth,
+    $2 00; Illustrated. 12mo, Paper, $1 00.
+
+  THE SHADOW OF A DREAM. A Story. 12mo, Cloth, $1 00; Paper,
+    50 cents.
+
+  ANNIE KILBURN. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  APRIL HOPES. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  CHRISTMAS EVERY DAY, AND OTHER STORIES. Illustrated. Post 8vo,
+    Cloth, $1 25.
+
+  A BOY’S TOWN. Illustrated. Post 8vo, Cloth, $1 25.
+
+  CRITICISM AND FICTION. With Portrait. 16mo, Cloth, $1 00.
+
+  MODERN ITALIAN POETS. With Portraits. 12mo, Half Cloth, $2 00.
+
+  THE MOUSE-TRAP, AND OTHER FARCES. Illustrated. 12mo, Cloth,
+    $1 00.
+
+  A LETTER OF INTRODUCTION. A Farce. Illustrated. 32mo, Cloth,
+    50 cents.
+
+  A LITTLE SWISS SOJOURN. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE ALBANY DEPOT. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE GARROTERS. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above works are for sale by all booksellers, or will be sent
+by the publishers, postage prepaid, to any part of the United States,
+Canada, or Mexico, on receipt of the price._
+
+
+
+
+R. D. BLACKMORE’S NOVELS.
+
+
+His descriptions are wonderfully vivid and natural. His pages are
+brightened everywhere with great humor; the quaint, dry turns of
+thought remind you occasionally of Fielding.—_London Times._
+
+Mr. Blackmore always writes like a scholar and a
+gentleman—_Athenæum_, London.
+
+His tales, all of them, are pre-eminently meritorious. They are
+remarkable for their careful elaboration, the conscientious finish of
+their workmanship, their affluence of striking dramatic and narrative
+incident, their close observation and general interpretation of nature,
+their profusion of picturesque description, and their quiet and
+sustained humor. Besides, they are pervaded by a bright and elastic
+atmosphere which diffuses a cheery feeling of healthful and robust
+vigor. While they charm us by their sprightly vivacity and their
+naturalness, they never in the slightest degree transcend the limits
+of delicacy or good taste. While radiating warmth and brightness, they
+are as pure as the new-fallen snow.... Their literary execution is
+admirable, and their dramatic power is as exceptional as their moral
+purity.—_Christian Intelligencer_, N. Y.
+
+  LORNA DOONE. Illustrated. 12mo, Cloth, $1 00; 8vo, Paper,
+    40 cents.
+
+  KIT AND KITTY. 12mo, Cloth, $1 25; Paper, 35 cents.
+
+  SPRINGHAVEN. Illustrated. 12mo, Cloth, $1 50; 4to, Paper,
+    25 cents.
+
+  CHRISTOWELL. 4to, Paper, 20 cents.
+
+  CRADOCK NOWELL. 8vo, Paper, 60 cents.
+
+  EREMA; OR, MY FATHER’S SIN. 8vo, Paper, 50 cents.
+
+  MARY ANERLEY. 16mo, Cloth, $1 00; 4to, Paper, 15 cents.
+
+  TOMMY UPMORE. 16mo, Cloth, 50 cents; Paper, 35 cents; 4to,
+    Paper, 20 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works will be sent by mail, postage prepaid,
+to any part of the United States, Canada, or Mexico, on receipt of
+the price._
+
+
+
+
+By CAPT. CHARLES KING.
+
+
+  CAMPAIGNING WITH CROOK, AND STORIES OF ARMY LIFE. Post 8vo,
+      Cloth, $1 25.
+
+  A WAR-TIME WOOING. Illustrated by R. F. ZOGBAUM. pp. iv.,
+      196. Post 8vo, Cloth, $1 00.
+
+  BETWEEN THE LINES. A Story of the War. Illustrated by GILBERT
+      GAUL. pp. iv., 312. Post 8vo, Cloth, $1 25.
+
+In all of Captain King’s stories the author holds to lofty ideals of
+manhood and womanhood, and inculcates the lessons of honor, generosity,
+courage, and self-control.—_Literary World_, Boston.
+
+The vivacity and charm which signally distinguish Captain King’s
+pen.... He occupies a position in American literature entirely
+his own.... His is the literature of honest sentiment, pure and
+tender.—_N. Y. Press._
+
+A romance by Captain King is always a pleasure, because he has so
+complete a mastery of the subjects with which he deals.... Captain
+King has few rivals in his domain.... The general tone of Captain
+King’s stories is highly commendable. The heroes are simple, frank,
+and soldierly; the heroines are dignified and maidenly in the most
+unconventional situations.—_Epoch_, N. Y.
+
+All Captain King’s stories are full of spirit and with the true ring
+about them.—_Philadelphia Item._
+
+Captain King’s stories of army life are so brilliant and intense, they
+have such a ring of true experience, and his characters are so lifelike
+and vivid that the announcement of a new one is always received with
+pleasure.—_New Haven Palladium._
+
+Captain King is a delightful story-teller.—_Washington Post._
+
+In the delineation of war scenes Captain King’s style is crisp and
+vigorous, inspiring in the breast of the reader a thrill of genuine
+patriotic fervor.—_Boston Commonwealth._
+
+Captain King is almost without a rival in the field he has chosen....
+His style is at once vigorous and sentimental in the best sense of that
+word, so that his novels are pleasing to young men as well as young
+women.—_Pittsburgh Bulletin._
+
+It is good to think that there is at least one man who believes that
+all the spirit of romance and chivalry has not yet died out of the
+world, and that there are as brave and honest hearts to-day as there
+were in the days of knights and paladins.—_Philadelphia Record._
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+BEN-HUR: A TALE OF THE CHRIST.
+
+
+  By LEW. WALLACE. 16mo, Cloth, $1 50. _Garfield Edition._
+    Two Volumes. Twenty Full-page Photogravures. Over 1000
+    Illustrations as Marginal Drawings by WILLIAM MARTIN JOHNSON.
+    Crown 8vo, Printed on Fine Super-calendered Plate-paper, Uncut
+    Edges and Gilt Tops, Bound in Silk and Gold, $7 00. (_In a
+    Gladstone Box._)
+
+Anything so startling, new, and distinctive as the leading feature of
+this romance does not often appear in works of fiction.... Some of Mr.
+Wallace’s writing is remarkable for its pathetic eloquence. The scenes
+described in the New Testament are rewritten with the power and skill
+of an accomplished master of style.—_N. Y. Times._
+
+Its real basis is a description of the life of the Jews and Romans
+at the beginning of the Christian era, and this is both forcible and
+brilliant.... We are carried through a surprising variety of scenes;
+we witness a sea-fight, a chariot-race, the internal economy of a
+Roman galley, domestic interiors at Antioch, at Jerusalem, and among
+the tribes of the desert; palaces, prisons, the haunts of dissipated
+Roman youth, the houses of pious families of Israel. There is plenty of
+exciting incident; everything is animated, vivid and glowing.—_N. Y.
+Tribune._
+
+From the opening of the volume to the very close the reader’s interest
+will be kept at the highest pitch, and the novel will be pronounced by
+all one of the greatest novels of the day.—_Boston Post._
+
+“Ben Hur” is interesting, and its characterization is fine and strong.
+Meanwhile it evinces careful study of the period in which the scene
+is laid, and will help those who read it with reasonable attention to
+realize the nature and conditions of Hebrew life in Jerusalem and Roman
+life at Antioch at the time of our Saviour’s advent.—_Examiner_, N. Y.
+
+The book is one of unquestionable power, and will be read with unwonted
+interest by many readers who are weary of the conventional novel and
+romance.—_Boston Journal._
+
+One of the most remarkable and delightful books. It is as real and
+warm as life itself, and as attractive as the grandest and most heroic
+chapters of history.—_Indianapolis Journal._
+
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above work will be sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+Transcriber’s Note:
+
+The text published in the original publication has been
+preserved except as follows:
+
+  Punctuation has been standardised.
+
+  Page 5
+  scored by six almost paralled _changed to_
+  scored by six almost parallel
+
+  Page 20
+  Sherlock Holmes’ succinct description _changed to_
+  Sherlock Holmes’s succinct description
+
+  Page 37
+  injustice to hestitate _changed to_
+  injustice to hesitate
+
+  Page 46
+  I saw him that afternoon so enwrapped _changed to_
+  I saw him that afternoon so enrapt
+
+  Page 81
+  his had the natural ef-effect _changed to_
+  his had the natural effect
+
+  Page 87
+  brother and siser; but of course _changed to_
+  brother and sister; but of course
+
+  Page 93
+  at this. Men who had only know _changed to_
+  as this. Men who had only know
+
+  Page 148
+  and we very all quietly entered _changed to_
+  and we all very quietly entered
+
+  Page 156
+  had remarked, the initals “H. B.” _changed to_
+  had remarked, the initials “H. B.”
+
+  Page 161
+  If this fail _changed to_
+  If this fails
+
+  Page 174
+  Gone to the dealer’s, Jim _changed to_
+  Gone to the dealer’s, Jem
+
+  Page 185
+  delirum, sometimes that it _changed to_
+  delirium, sometimes that it
+
+  Page 192
+  The centra portion was in _changed to_
+  The central portion was in
+
+  Page 200
+  waiting silently for for whatever _changed to_
+  waiting silently for whatever
+
+  Page 215
+  save the occasional bright blurr _changed to_
+  save the occasional bright blur
+
+  Page 245
+  a _pâtè de foie gras_ pie _changed to_
+  a _pâté de foie gras_ pie
+
+  Page 250
+  permision, I will now wish _changed to_
+  permission, I will now wish
+
+  Page 293
+  boisterious fashion, and on the whole _changed to_
+  boisterous fashion, and on the whole
+
+  Page 297
+  wrapt in the peaceful beauty _changed to_
+  rapt in the peaceful beauty
+
+
+
+
+
+
+
+End of Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+***** This file should be named 48320-0.txt or 48320-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/4/8/3/2/48320/
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/anderson-fairy-tales.txt
+++ b/jet/hadoop/src/main/resources/books/anderson-fairy-tales.txt
@@ -1,0 +1,6206 @@
+﻿Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Andersen’s Fairy Tales
+
+Author: Hans Christian Andersen
+
+Posting Date: October 10, 2008 [EBook #1597]
+Release Date: January, 1999
+Last Updated: October 8, 2016
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+
+
+
+Produced by Dianne Bean
+
+
+
+
+
+ANDERSEN’S FAIRY TALES
+
+By Hans Christian Andersen
+
+
+
+CONTENTS
+
+
+     The Emperor’s New Clothes
+     The Swineherd
+     The Real Princess
+     The Shoes of Fortune
+     The Fir Tree
+     The Snow Queen
+     The Leap-Frog
+     The Elderbush
+     The Bell
+     The Old House
+     The Happy Family
+     The Story of a Mother
+     The False Collar
+     The Shadow
+     The Little Match Girl
+     The Dream of Little Tuk
+     The Naughty Boy
+     The Red Shoes
+
+
+
+
+THE EMPEROR’S NEW CLOTHES
+
+Many years ago, there was an Emperor, who was so excessively fond of
+new clothes, that he spent all his money in dress. He did not trouble
+himself in the least about his soldiers; nor did he care to go either to
+the theatre or the chase, except for the opportunities then afforded him
+for displaying his new clothes. He had a different suit for each hour of
+the day; and as of any other king or emperor, one is accustomed to say,
+“he is sitting in council,” it was always said of him, “The Emperor is
+sitting in his wardrobe.”
+
+Time passed merrily in the large town which was his capital; strangers
+arrived every day at the court. One day, two rogues, calling themselves
+weavers, made their appearance. They gave out that they knew how to
+weave stuffs of the most beautiful colors and elaborate patterns, the
+clothes manufactured from which should have the wonderful property of
+remaining invisible to everyone who was unfit for the office he held, or
+who was extraordinarily simple in character.
+
+“These must, indeed, be splendid clothes!” thought the Emperor. “Had I
+such a suit, I might at once find out what men in my realms are unfit
+for their office, and also be able to distinguish the wise from the
+foolish! This stuff must be woven for me immediately.” And he caused
+large sums of money to be given to both the weavers in order that they
+might begin their work directly.
+
+So the two pretended weavers set up two looms, and affected to work very
+busily, though in reality they did nothing at all. They asked for the
+most delicate silk and the purest gold thread; put both into their own
+knapsacks; and then continued their pretended work at the empty looms
+until late at night.
+
+“I should like to know how the weavers are getting on with my cloth,”
+ said the Emperor to himself, after some little time had elapsed; he was,
+however, rather embarrassed, when he remembered that a simpleton, or
+one unfit for his office, would be unable to see the manufacture. To be
+sure, he thought he had nothing to risk in his own person; but yet, he
+would prefer sending somebody else, to bring him intelligence about the
+weavers, and their work, before he troubled himself in the affair. All
+the people throughout the city had heard of the wonderful property the
+cloth was to possess; and all were anxious to learn how wise, or how
+ignorant, their neighbors might prove to be.
+
+“I will send my faithful old minister to the weavers,” said the Emperor
+at last, after some deliberation, “he will be best able to see how the
+cloth looks; for he is a man of sense, and no one can be more suitable
+for his office than he is.”
+
+So the faithful old minister went into the hall, where the knaves were
+working with all their might, at their empty looms. “What can be the
+meaning of this?” thought the old man, opening his eyes very wide. “I
+cannot discover the least bit of thread on the looms.” However, he did
+not express his thoughts aloud.
+
+The impostors requested him very courteously to be so good as to come
+nearer their looms; and then asked him whether the design pleased
+him, and whether the colors were not very beautiful; at the same time
+pointing to the empty frames. The poor old minister looked and looked,
+he could not discover anything on the looms, for a very good reason,
+viz: there was nothing there. “What!” thought he again. “Is it possible
+that I am a simpleton? I have never thought so myself; and no one must
+know it now if I am so. Can it be, that I am unfit for my office? No,
+that must not be said either. I will never confess that I could not see
+the stuff.”
+
+“Well, Sir Minister!” said one of the knaves, still pretending to work.
+“You do not say whether the stuff pleases you.”
+
+“Oh, it is excellent!” replied the old minister, looking at the loom
+through his spectacles. “This pattern, and the colors, yes, I will tell
+the Emperor without delay, how very beautiful I think them.”
+
+“We shall be much obliged to you,” said the impostors, and then they
+named the different colors and described the pattern of the pretended
+stuff. The old minister listened attentively to their words, in order
+that he might repeat them to the Emperor; and then the knaves asked for
+more silk and gold, saying that it was necessary to complete what
+they had begun. However, they put all that was given them into their
+knapsacks; and continued to work with as much apparent diligence as
+before at their empty looms.
+
+The Emperor now sent another officer of his court to see how the men
+were getting on, and to ascertain whether the cloth would soon be
+ready. It was just the same with this gentleman as with the minister;
+he surveyed the looms on all sides, but could see nothing at all but the
+empty frames.
+
+“Does not the stuff appear as beautiful to you, as it did to my lord the
+minister?” asked the impostors of the Emperor’s second ambassador; at
+the same time making the same gestures as before, and talking of the
+design and colors which were not there.
+
+“I certainly am not stupid!” thought the messenger. “It must be, that I
+am not fit for my good, profitable office! That is very odd; however, no
+one shall know anything about it.” And accordingly he praised the stuff
+he could not see, and declared that he was delighted with both colors
+and patterns. “Indeed, please your Imperial Majesty,” said he to his
+sovereign when he returned, “the cloth which the weavers are preparing
+is extraordinarily magnificent.”
+
+The whole city was talking of the splendid cloth which the Emperor had
+ordered to be woven at his own expense.
+
+And now the Emperor himself wished to see the costly manufacture, while
+it was still in the loom. Accompanied by a select number of officers of
+the court, among whom were the two honest men who had already admired
+the cloth, he went to the crafty impostors, who, as soon as they were
+aware of the Emperor’s approach, went on working more diligently than
+ever; although they still did not pass a single thread through the
+looms.
+
+“Is not the work absolutely magnificent?” said the two officers of the
+crown, already mentioned. “If your Majesty will only be pleased to look
+at it! What a splendid design! What glorious colors!” and at the same
+time they pointed to the empty frames; for they imagined that everyone
+else could see this exquisite piece of workmanship.
+
+“How is this?” said the Emperor to himself. “I can see nothing! This
+is indeed a terrible affair! Am I a simpleton, or am I unfit to be an
+Emperor? That would be the worst thing that could happen--Oh! the cloth
+is charming,” said he, aloud. “It has my complete approbation.” And he
+smiled most graciously, and looked closely at the empty looms; for on no
+account would he say that he could not see what two of the officers of
+his court had praised so much. All his retinue now strained their eyes,
+hoping to discover something on the looms, but they could see no more
+than the others; nevertheless, they all exclaimed, “Oh, how beautiful!”
+ and advised his majesty to have some new clothes made from this splendid
+material, for the approaching procession. “Magnificent! Charming!
+Excellent!” resounded on all sides; and everyone was uncommonly gay. The
+Emperor shared in the general satisfaction; and presented the impostors
+with the riband of an order of knighthood, to be worn in their
+button-holes, and the title of “Gentlemen Weavers.”
+
+The rogues sat up the whole of the night before the day on which the
+procession was to take place, and had sixteen lights burning, so that
+everyone might see how anxious they were to finish the Emperor’s new
+suit. They pretended to roll the cloth off the looms; cut the air with
+their scissors; and sewed with needles without any thread in them.
+“See!” cried they, at last. “The Emperor’s new clothes are ready!”
+
+And now the Emperor, with all the grandees of his court, came to the
+weavers; and the rogues raised their arms, as if in the act of holding
+something up, saying, “Here are your Majesty’s trousers! Here is the
+scarf! Here is the mantle! The whole suit is as light as a cobweb;
+one might fancy one has nothing at all on, when dressed in it; that,
+however, is the great virtue of this delicate cloth.”
+
+“Yes indeed!” said all the courtiers, although not one of them could see
+anything of this exquisite manufacture.
+
+“If your Imperial Majesty will be graciously pleased to take off your
+clothes, we will fit on the new suit, in front of the looking glass.”
+
+The Emperor was accordingly undressed, and the rogues pretended to
+array him in his new suit; the Emperor turning round, from side to side,
+before the looking glass.
+
+“How splendid his Majesty looks in his new clothes, and how well they
+fit!” everyone cried out. “What a design! What colors! These are indeed
+royal robes!”
+
+“The canopy which is to be borne over your Majesty, in the procession,
+is waiting,” announced the chief master of the ceremonies.
+
+“I am quite ready,” answered the Emperor. “Do my new clothes fit well?”
+ asked he, turning himself round again before the looking glass, in order
+that he might appear to be examining his handsome suit.
+
+The lords of the bedchamber, who were to carry his Majesty’s train felt
+about on the ground, as if they were lifting up the ends of the mantle;
+and pretended to be carrying something; for they would by no means
+betray anything like simplicity, or unfitness for their office.
+
+So now the Emperor walked under his high canopy in the midst of the
+procession, through the streets of his capital; and all the people
+standing by, and those at the windows, cried out, “Oh! How beautiful
+are our Emperor’s new clothes! What a magnificent train there is to
+the mantle; and how gracefully the scarf hangs!” in short, no one would
+allow that he could not see these much-admired clothes; because, in
+doing so, he would have declared himself either a simpleton or unfit
+for his office. Certainly, none of the Emperor’s various suits, had ever
+made so great an impression, as these invisible ones.
+
+“But the Emperor has nothing at all on!” said a little child.
+
+“Listen to the voice of innocence!” exclaimed his father; and what the
+child had said was whispered from one to another.
+
+“But he has nothing at all on!” at last cried out all the people.
+The Emperor was vexed, for he knew that the people were right; but he
+thought the procession must go on now! And the lords of the bedchamber
+took greater pains than ever, to appear holding up a train, although, in
+reality, there was no train to hold.
+
+
+
+
+THE SWINEHERD
+
+There was once a poor Prince, who had a kingdom. His kingdom was very
+small, but still quite large enough to marry upon; and he wished to
+marry.
+
+It was certainly rather cool of him to say to the Emperor’s daughter,
+“Will you have me?” But so he did; for his name was renowned far and
+wide; and there were a hundred princesses who would have answered,
+“Yes!” and “Thank you kindly.” We shall see what this princess said.
+
+Listen!
+
+It happened that where the Prince’s father lay buried, there grew a rose
+tree--a most beautiful rose tree, which blossomed only once in every
+five years, and even then bore only one flower, but that was a rose!
+It smelt so sweet that all cares and sorrows were forgotten by him who
+inhaled its fragrance.
+
+And furthermore, the Prince had a nightingale, who could sing in such a
+manner that it seemed as though all sweet melodies dwelt in her little
+throat. So the Princess was to have the rose, and the nightingale; and
+they were accordingly put into large silver caskets, and sent to her.
+
+The Emperor had them brought into a large hall, where the Princess was
+playing at “Visiting,” with the ladies of the court; and when she saw
+the caskets with the presents, she clapped her hands for joy.
+
+“Ah, if it were but a little pussy-cat!” said she; but the rose tree,
+with its beautiful rose came to view.
+
+“Oh, how prettily it is made!” said all the court ladies.
+
+“It is more than pretty,” said the Emperor, “it is charming!”
+
+But the Princess touched it, and was almost ready to cry.
+
+“Fie, papa!” said she. “It is not made at all, it is natural!”
+
+“Let us see what is in the other casket, before we get into a bad
+humor,” said the Emperor. So the nightingale came forth and sang so
+delightfully that at first no one could say anything ill-humored of her.
+
+“Superbe! Charmant!” exclaimed the ladies; for they all used to chatter
+French, each one worse than her neighbor.
+
+“How much the bird reminds me of the musical box that belonged to our
+blessed Empress,” said an old knight. “Oh yes! These are the same tones,
+the same execution.”
+
+“Yes! yes!” said the Emperor, and he wept like a child at the
+remembrance.
+
+“I will still hope that it is not a real bird,” said the Princess.
+
+“Yes, it is a real bird,” said those who had brought it. “Well then let
+the bird fly,” said the Princess; and she positively refused to see the
+Prince.
+
+However, he was not to be discouraged; he daubed his face over brown and
+black; pulled his cap over his ears, and knocked at the door.
+
+“Good day to my lord, the Emperor!” said he. “Can I have employment at
+the palace?”
+
+“Why, yes,” said the Emperor. “I want some one to take care of the pigs,
+for we have a great many of them.”
+
+So the Prince was appointed “Imperial Swineherd.” He had a dirty little
+room close by the pigsty; and there he sat the whole day, and worked. By
+the evening he had made a pretty little kitchen-pot. Little bells were
+hung all round it; and when the pot was boiling, these bells tinkled in
+the most charming manner, and played the old melody,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”*
+
+    * “Ah! dear Augustine!
+    All is gone, gone, gone!”
+
+
+But what was still more curious, whoever held his finger in the smoke of
+the kitchen-pot, immediately smelt all the dishes that were cooking on
+every hearth in the city--this, you see, was something quite different
+from the rose.
+
+Now the Princess happened to walk that way; and when she heard the tune,
+she stood quite still, and seemed pleased; for she could play “Lieber
+Augustine”; it was the only piece she knew; and she played it with one
+finger.
+
+“Why there is my piece,” said the Princess. “That swineherd must
+certainly have been well educated! Go in and ask him the price of the
+instrument.”
+
+So one of the court-ladies must run in; however, she drew on wooden
+slippers first.
+
+“What will you take for the kitchen-pot?” said the lady.
+
+“I will have ten kisses from the Princess,” said the swineherd.
+
+“Yes, indeed!” said the lady.
+
+“I cannot sell it for less,” rejoined the swineherd.
+
+“He is an impudent fellow!” said the Princess, and she walked on; but
+when she had gone a little way, the bells tinkled so prettily
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+“Stay,” said the Princess. “Ask him if he will have ten kisses from the
+ladies of my court.”
+
+“No, thank you!” said the swineherd. “Ten kisses from the Princess, or I
+keep the kitchen-pot myself.”
+
+“That must not be, either!” said the Princess. “But do you all stand
+before me that no one may see us.”
+
+And the court-ladies placed themselves in front of her, and spread
+out their dresses--the swineherd got ten kisses, and the Princess--the
+kitchen-pot.
+
+That was delightful! The pot was boiling the whole evening, and the
+whole of the following day. They knew perfectly well what was cooking at
+every fire throughout the city, from the chamberlain’s to the cobbler’s;
+the court-ladies danced and clapped their hands.
+
+“We know who has soup, and who has pancakes for dinner to-day, who has
+cutlets, and who has eggs. How interesting!”
+
+“Yes, but keep my secret, for I am an Emperor’s daughter.”
+
+The swineherd--that is to say--the Prince, for no one knew that he was
+other than an ill-favored swineherd, let not a day pass without working
+at something; he at last constructed a rattle, which, when it was swung
+round, played all the waltzes and jig tunes, which have ever been heard
+since the creation of the world.
+
+“Ah, that is superbe!” said the Princess when she passed by. “I have
+never heard prettier compositions! Go in and ask him the price of the
+instrument; but mind, he shall have no more kisses!”
+
+“He will have a hundred kisses from the Princess!” said the lady who had
+been to ask.
+
+“I think he is not in his right senses!” said the Princess, and walked
+on, but when she had gone a little way, she stopped again. “One must
+encourage art,” said she, “I am the Emperor’s daughter. Tell him he
+shall, as on yesterday, have ten kisses from me, and may take the rest
+from the ladies of the court.”
+
+“Oh--but we should not like that at all!” said they. “What are you
+muttering?” asked the Princess. “If I can kiss him, surely you can.
+Remember that you owe everything to me.” So the ladies were obliged to
+go to him again.
+
+“A hundred kisses from the Princess,” said he, “or else let everyone
+keep his own!”
+
+“Stand round!” said she; and all the ladies stood round her whilst the
+kissing was going on.
+
+“What can be the reason for such a crowd close by the pigsty?” said the
+Emperor, who happened just then to step out on the balcony; he rubbed
+his eyes, and put on his spectacles. “They are the ladies of the
+court; I must go down and see what they are about!” So he pulled up his
+slippers at the heel, for he had trodden them down.
+
+As soon as he had got into the court-yard, he moved very softly, and the
+ladies were so much engrossed with counting the kisses, that all might
+go on fairly, that they did not perceive the Emperor. He rose on his
+tiptoes.
+
+“What is all this?” said he, when he saw what was going on, and he boxed
+the Princess’s ears with his slipper, just as the swineherd was taking
+the eighty-sixth kiss.
+
+“March out!” said the Emperor, for he was very angry; and both Princess
+and swineherd were thrust out of the city.
+
+The Princess now stood and wept, the swineherd scolded, and the rain
+poured down.
+
+“Alas! Unhappy creature that I am!” said the Princess. “If I had but
+married the handsome young Prince! Ah! how unfortunate I am!”
+
+And the swineherd went behind a tree, washed the black and brown color
+from his face, threw off his dirty clothes, and stepped forth in his
+princely robes; he looked so noble that the Princess could not help
+bowing before him.
+
+“I am come to despise thee,” said he. “Thou would’st not have an
+honorable Prince! Thou could’st not prize the rose and the nightingale,
+but thou wast ready to kiss the swineherd for the sake of a trumpery
+plaything. Thou art rightly served.”
+
+He then went back to his own little kingdom, and shut the door of his
+palace in her face. Now she might well sing,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+
+
+
+THE REAL PRINCESS
+
+There was once a Prince who wished to marry a Princess; but then she
+must be a real Princess. He travelled all over the world in hopes of
+finding such a lady; but there was always something wrong. Princesses he
+found in plenty; but whether they were real Princesses it was impossible
+for him to decide, for now one thing, now another, seemed to him not
+quite right about the ladies. At last he returned to his palace quite
+cast down, because he wished so much to have a real Princess for his
+wife.
+
+One evening a fearful tempest arose, it thundered and lightened, and the
+rain poured down from the sky in torrents: besides, it was as dark as
+pitch. All at once there was heard a violent knocking at the door, and
+the old King, the Prince’s father, went out himself to open it.
+
+It was a Princess who was standing outside the door. What with the rain
+and the wind, she was in a sad condition; the water trickled down from
+her hair, and her clothes clung to her body. She said she was a real
+Princess.
+
+“Ah! we shall soon see that!” thought the old Queen-mother; however, she
+said not a word of what she was going to do; but went quietly into the
+bedroom, took all the bed-clothes off the bed, and put three little peas
+on the bedstead. She then laid twenty mattresses one upon another over
+the three peas, and put twenty feather beds over the mattresses.
+
+Upon this bed the Princess was to pass the night.
+
+The next morning she was asked how she had slept. “Oh, very badly
+indeed!” she replied. “I have scarcely closed my eyes the whole night
+through. I do not know what was in my bed, but I had something hard
+under me, and am all over black and blue. It has hurt me so much!”
+
+Now it was plain that the lady must be a real Princess, since she had
+been able to feel the three little peas through the twenty mattresses
+and twenty feather beds. None but a real Princess could have had such a
+delicate sense of feeling.
+
+The Prince accordingly made her his wife; being now convinced that he
+had found a real Princess. The three peas were however put into the
+cabinet of curiosities, where they are still to be seen, provided they
+are not lost.
+
+Wasn’t this a lady of real delicacy?
+
+
+
+
+THE SHOES OF FORTUNE
+
+I. A Beginning
+
+Every author has some peculiarity in his descriptions or in his style
+of writing. Those who do not like him, magnify it, shrug up their
+shoulders, and exclaim--there he is again! I, for my part, know very
+well how I can bring about this movement and this exclamation. It would
+happen immediately if I were to begin here, as I intended to do, with:
+“Rome has its Corso, Naples its Toledo”--“Ah! that Andersen; there he is
+again!” they would cry; yet I must, to please my fancy, continue quite
+quietly, and add: “But Copenhagen has its East Street.”
+
+Here, then, we will stay for the present. In one of the houses not far
+from the new market a party was invited--a very large party, in order,
+as is often the case, to get a return invitation from the others. One
+half of the company was already seated at the card-table, the other half
+awaited the result of the stereotype preliminary observation of the lady
+of the house:
+
+“Now let us see what we can do to amuse ourselves.”
+
+They had got just so far, and the conversation began to crystallise,
+as it could but do with the scanty stream which the commonplace world
+supplied. Amongst other things they spoke of the middle ages: some
+praised that period as far more interesting, far more poetical than our
+own too sober present; indeed Councillor Knap defended this opinion
+so warmly, that the hostess declared immediately on his side, and both
+exerted themselves with unwearied eloquence. The Councillor boldly
+declared the time of King Hans to be the noblest and the most happy
+period.*
+
+* A.D. 1482-1513
+
+
+While the conversation turned on this subject, and was only for a moment
+interrupted by the arrival of a journal that contained nothing worth
+reading, we will just step out into the antechamber, where cloaks,
+mackintoshes, sticks, umbrellas, and shoes, were deposited. Here sat two
+female figures, a young and an old one. One might have thought at first
+they were servants come to accompany their mistresses home; but on
+looking nearer, one soon saw they could scarcely be mere servants; their
+forms were too noble for that, their skin too fine, the cut of their
+dress too striking. Two fairies were they; the younger, it is true,
+was not Dame Fortune herself, but one of the waiting-maids of her
+handmaidens who carry about the lesser good things that she distributes;
+the other looked extremely gloomy--it was Care. She always attends to
+her own serious business herself, as then she is sure of having it done
+properly.
+
+They were telling each other, with a confidential interchange of ideas,
+where they had been during the day. The messenger of Fortune had only
+executed a few unimportant commissions, such as saving a new bonnet from
+a shower of rain, etc.; but what she had yet to perform was something
+quite unusual.
+
+“I must tell you,” said she, “that to-day is my birthday; and in honor
+of it, a pair of walking-shoes or galoshes has been entrusted to me,
+which I am to carry to mankind. These shoes possess the property of
+instantly transporting him who has them on to the place or the period
+in which he most wishes to be; every wish, as regards time or place, or
+state of being, will be immediately fulfilled, and so at last man will
+be happy, here below.”
+
+“Do you seriously believe it?” replied Care, in a severe tone of
+reproach. “No; he will be very unhappy, and will assuredly bless the
+moment when he feels that he has freed himself from the fatal shoes.”
+
+“Stupid nonsense!” said the other angrily. “I will put them here by
+the door. Some one will make a mistake for certain and take the wrong
+ones--he will be a happy man.”
+
+Such was their conversation.
+
+
+II. What Happened to the Councillor
+
+It was late; Councillor Knap, deeply occupied with the times of King
+Hans, intended to go home, and malicious Fate managed matters so that
+his feet, instead of finding their way to his own galoshes, slipped
+into those of Fortune. Thus caparisoned the good man walked out of the
+well-lighted rooms into East Street. By the magic power of the shoes he
+was carried back to the times of King Hans; on which account his foot
+very naturally sank in the mud and puddles of the street, there having
+been in those days no pavement in Copenhagen.
+
+“Well! This is too bad! How dirty it is here!” sighed the Councillor.
+“As to a pavement, I can find no traces of one, and all the lamps, it
+seems, have gone to sleep.”
+
+The moon was not yet very high; it was besides rather foggy, so that
+in the darkness all objects seemed mingled in chaotic confusion. At the
+next corner hung a votive lamp before a Madonna, but the light it gave
+was little better than none at all; indeed, he did not observe it before
+he was exactly under it, and his eyes fell upon the bright colors of the
+pictures which represented the well-known group of the Virgin and the
+infant Jesus.
+
+“That is probably a wax-work show,” thought he; “and the people delay
+taking down their sign in hopes of a late visitor or two.”
+
+A few persons in the costume of the time of King Hans passed quickly by
+him.
+
+“How strange they look! The good folks come probably from a masquerade!”
+
+Suddenly was heard the sound of drums and fifes; the bright blaze of a
+fire shot up from time to time, and its ruddy gleams seemed to contend
+with the bluish light of the torches. The Councillor stood still, and
+watched a most strange procession pass by. First came a dozen drummers,
+who understood pretty well how to handle their instruments; then came
+halberdiers, and some armed with cross-bows. The principal person in the
+procession was a priest. Astonished at what he saw, the Councillor asked
+what was the meaning of all this mummery, and who that man was.
+
+“That’s the Bishop of Zealand,” was the answer.
+
+“Good Heavens! What has taken possession of the Bishop?” sighed the
+Councillor, shaking his head. It certainly could not be the Bishop; even
+though he was considered the most absent man in the whole kingdom, and
+people told the drollest anecdotes about him. Reflecting on the matter,
+and without looking right or left, the Councillor went through East
+Street and across the Habro-Platz. The bridge leading to Palace Square
+was not to be found; scarcely trusting his senses, the nocturnal
+wanderer discovered a shallow piece of water, and here fell in with two
+men who very comfortably were rocking to and fro in a boat.
+
+“Does your honor want to cross the ferry to the Holme?” asked they.
+
+“Across to the Holme!” said the Councillor, who knew nothing of the age
+in which he at that moment was. “No, I am going to Christianshafen, to
+Little Market Street.”
+
+Both men stared at him in astonishment.
+
+“Only just tell me where the bridge is,” said he. “It is really
+unpardonable that there are no lamps here; and it is as dirty as if one
+had to wade through a morass.”
+
+The longer he spoke with the boatmen, the more unintelligible did their
+language become to him.
+
+“I don’t understand your Bornholmish dialect,” said he at last, angrily,
+and turning his back upon them. He was unable to find the bridge: there
+was no railway either. “It is really disgraceful what a state this place
+is in,” muttered he to himself. Never had his age, with which, however,
+he was always grumbling, seemed so miserable as on this evening. “I’ll
+take a hackney-coach!” thought he. But where were the hackney-coaches?
+Not one was to be seen.
+
+“I must go back to the New Market; there, it is to be hoped, I
+shall find some coaches; for if I don’t, I shall never get safe to
+Christianshafen.”
+
+So off he went in the direction of East Street, and had nearly got to
+the end of it when the moon shone forth.
+
+“God bless me! What wooden scaffolding is that which they have set up
+there?” cried he involuntarily, as he looked at East Gate, which, in
+those days, was at the end of East Street.
+
+He found, however, a little side-door open, and through this he went,
+and stepped into our New Market of the present time. It was a huge
+desolate plain; some wild bushes stood up here and there, while across
+the field flowed a broad canal or river. Some wretched hovels for the
+Dutch sailors, resembling great boxes, and after which the place was
+named, lay about in confused disorder on the opposite bank.
+
+“I either behold a fata morgana, or I am regularly tipsy,” whimpered out
+the Councillor. “But what’s this?”
+
+He turned round anew, firmly convinced that he was seriously ill. He
+gazed at the street formerly so well known to him, and now so strange in
+appearance, and looked at the houses more attentively: most of them were
+of wood, slightly put together; and many had a thatched roof.
+
+“No--I am far from well,” sighed he; “and yet I drank only one glass of
+punch; but I cannot suppose it--it was, too, really very wrong to give
+us punch and hot salmon for supper. I shall speak about it at the first
+opportunity. I have half a mind to go back again, and say what I suffer.
+But no, that would be too silly; and Heaven only knows if they are up
+still.”
+
+He looked for the house, but it had vanished.
+
+“It is really dreadful,” groaned he with increasing anxiety; “I cannot
+recognise East Street again; there is not a single decent shop from one
+end to the other! Nothing but wretched huts can I see anywhere; just
+as if I were at Ringstead. Oh! I am ill! I can scarcely bear myself any
+longer. Where the deuce can the house be? It must be here on this very
+spot; yet there is not the slightest idea of resemblance, to such a
+degree has everything changed this night! At all events here are some
+people up and stirring. Oh! oh! I am certainly very ill.”
+
+He now hit upon a half-open door, through a chink of which a faint light
+shone. It was a sort of hostelry of those times; a kind of public-house.
+The room had some resemblance to the clay-floored halls in Holstein; a
+pretty numerous company, consisting of seamen, Copenhagen burghers, and
+a few scholars, sat here in deep converse over their pewter cans, and
+gave little heed to the person who entered.
+
+“By your leave!” said the Councillor to the Hostess, who came bustling
+towards him. “I’ve felt so queer all of a sudden; would you have the
+goodness to send for a hackney-coach to take me to Christianshafen?”
+
+The woman examined him with eyes of astonishment, and shook her head;
+she then addressed him in German. The Councillor thought she did not
+understand Danish, and therefore repeated his wish in German. This, in
+connection with his costume, strengthened the good woman in the belief
+that he was a foreigner. That he was ill, she comprehended directly; so
+she brought him a pitcher of water, which tasted certainly pretty strong
+of the sea, although it had been fetched from the well.
+
+The Councillor supported his head on his hand, drew a long breath, and
+thought over all the wondrous things he saw around him.
+
+“Is this the Daily News of this evening?” he asked mechanically, as he
+saw the Hostess push aside a large sheet of paper.
+
+The meaning of this councillorship query remained, of course, a riddle
+to her, yet she handed him the paper without replying. It was a coarse
+wood-cut, representing a splendid meteor “as seen in the town of
+Cologne,” which was to be read below in bright letters.
+
+“That is very old!” said the Councillor, whom this piece of antiquity
+began to make considerably more cheerful. “Pray how did you come into
+possession of this rare print? It is extremely interesting, although the
+whole is a mere fable. Such meteorous appearances are to be explained in
+this way--that they are the reflections of the Aurora Borealis, and it
+is highly probable they are caused principally by electricity.”
+
+Those persons who were sitting nearest him and heard his speech,
+stared at him in wonderment; and one of them rose, took off his hat
+respectfully, and said with a serious countenance, “You are no doubt a
+very learned man, Monsieur.”
+
+“Oh no,” answered the Councillor, “I can only join in conversation on
+this topic and on that, as indeed one must do according to the demands
+of the world at present.”
+
+“Modestia is a fine virtue,” continued the gentleman; “however, as to
+your speech, I must say mihi secus videtur: yet I am willing to suspend
+my judicium.”
+
+“May I ask with whom I have the pleasure of speaking?” asked the
+Councillor.
+
+“I am a Bachelor in Theologia,” answered the gentleman with a stiff
+reverence.
+
+This reply fully satisfied the Councillor; the title suited the dress.
+“He is certainly,” thought he, “some village schoolmaster--some queer
+old fellow, such as one still often meets with in Jutland.”
+
+“This is no locus docendi, it is true,” began the clerical gentleman;
+“yet I beg you earnestly to let us profit by your learning. Your reading
+in the ancients is, sine dubio, of vast extent?”
+
+“Oh yes, I’ve read something, to be sure,” replied the Councillor. “I
+like reading all useful works; but I do not on that account despise the
+modern ones; ‘tis only the unfortunate ‘Tales of Every-day Life’ that I
+cannot bear--we have enough and more than enough such in reality.”
+
+“‘Tales of Every-day Life?’” said our Bachelor inquiringly.
+
+“I mean those new fangled novels, twisting and writhing themselves in
+the dust of commonplace, which also expect to find a reading public.”
+
+“Oh,” exclaimed the clerical gentleman smiling, “there is much wit in
+them; besides they are read at court. The King likes the history of Sir
+Iffven and Sir Gaudian particularly, which treats of King Arthur, and
+his Knights of the Round Table; he has more than once joked about it
+with his high vassals.”
+
+“I have not read that novel,” said the Councillor; “it must be quite a
+new one, that Heiberg has published lately.”
+
+“No,” answered the theologian of the time of King Hans: “that book is
+not written by a Heiberg, but was imprinted by Godfrey von Gehmen.”
+
+“Oh, is that the author’s name?” said the Councillor. “It is a very
+old name, and, as well as I recollect, he was the first printer that
+appeared in Denmark.”
+
+“Yes, he is our first printer,” replied the clerical gentleman hastily.
+
+So far all went on well. Some one of the worthy burghers now spoke of
+the dreadful pestilence that had raged in the country a few years back,
+meaning that of 1484. The Councillor imagined it was the cholera that
+was meant, which people made so much fuss about; and the discourse
+passed off satisfactorily enough. The war of the buccaneers of 1490 was
+so recent that it could not fail being alluded to; the English
+pirates had, they said, most shamefully taken their ships while in the
+roadstead; and the Councillor, before whose eyes the Herostratic [*]
+event of 1801 still floated vividly, agreed entirely with the others in
+abusing the rascally English. With other topics he was not so fortunate;
+every moment brought about some new confusion, and threatened to become
+a perfect Babel; for the worthy Bachelor was really too ignorant, and
+the simplest observations of the Councillor sounded to him too daring
+and phantastical. They looked at one another from the crown of the head
+to the soles of the feet; and when matters grew to too high a
+pitch, then the Bachelor talked Latin, in the hope of being better
+understood--but it was of no use after all.
+
+     * Herostratus, or Eratostratus--an Ephesian, who wantonly
+     set fire to the famous temple of Diana, in order to
+     commemorate his name by so uncommon an action.
+
+“What’s the matter?” asked the Hostess, plucking the Councillor by the
+sleeve; and now his recollection returned, for in the course of the
+conversation he had entirely forgotten all that had preceded it.
+
+“Merciful God, where am I!” exclaimed he in agony; and while he so
+thought, all his ideas and feelings of overpowering dizziness, against
+which he struggled with the utmost power of desperation, encompassed
+him with renewed force. “Let us drink claret and mead, and Bremen beer,”
+ shouted one of the guests--“and you shall drink with us!”
+
+Two maidens approached. One wore a cap of two staring colors, denoting
+the class of persons to which she belonged. They poured out the liquor,
+and made the most friendly gesticulations; while a cold perspiration
+trickled down the back of the poor Councillor.
+
+“What’s to be the end of this! What’s to become of me!” groaned he; but
+he was forced, in spite of his opposition, to drink with the rest. They
+took hold of the worthy man; who, hearing on every side that he was
+intoxicated, did not in the least doubt the truth of this certainly
+not very polite assertion; but on the contrary, implored the ladies
+and gentlemen present to procure him a hackney-coach: they, however,
+imagined he was talking Russian.
+
+Never before, he thought, had he been in such a coarse and ignorant
+company; one might almost fancy the people had turned heathens again.
+“It is the most dreadful moment of my life: the whole world is leagued
+against me!” But suddenly it occurred to him that he might stoop down
+under the table, and then creep unobserved out of the door. He did so;
+but just as he was going, the others remarked what he was about; they
+laid hold of him by the legs; and now, happily for him, off fell his
+fatal shoes--and with them the charm was at an end.
+
+The Councillor saw quite distinctly before him a lantern burning, and
+behind this a large handsome house. All seemed to him in proper order as
+usual; it was East Street, splendid and elegant as we now see it. He lay
+with his feet towards a doorway, and exactly opposite sat the watchman
+asleep.
+
+“Gracious Heaven!” said he. “Have I lain here in the street and dreamed?
+Yes; ‘tis East Street! How splendid and light it is! But really it is
+terrible what an effect that one glass of punch must have had on me!”
+
+Two minutes later, he was sitting in a hackney-coach and driving to
+Frederickshafen. He thought of the distress and agony he had endured,
+and praised from the very bottom of his heart the happy reality--our own
+time--which, with all its deficiencies, is yet much better than that in
+which, so much against his inclination, he had lately been.
+
+
+III. The Watchman’s Adventure
+
+“Why, there is a pair of galoshes, as sure as I’m alive!” said the
+watchman, awaking from a gentle slumber. “They belong no doubt to the
+lieutenant who lives over the way. They lie close to the door.”
+
+The worthy man was inclined to ring and deliver them at the house, for
+there was still a light in the window; but he did not like disturbing
+the other people in their beds, and so very considerately he left the
+matter alone.
+
+“Such a pair of shoes must be very warm and comfortable,” said he; “the
+leather is so soft and supple.” They fitted his feet as though they
+had been made for him. “‘Tis a curious world we live in,” continued he,
+soliloquizing. “There is the lieutenant, now, who might go quietly to
+bed if he chose, where no doubt he could stretch himself at his ease;
+but does he do it? No; he saunters up and down his room, because,
+probably, he has enjoyed too many of the good things of this world at
+his dinner. That’s a happy fellow! He has neither an infirm mother, nor
+a whole troop of everlastingly hungry children to torment him. Every
+evening he goes to a party, where his nice supper costs him nothing:
+would to Heaven I could but change with him! How happy should I be!”
+
+While expressing his wish, the charm of the shoes, which he had put on,
+began to work; the watchman entered into the being and nature of the
+lieutenant. He stood in the handsomely furnished apartment, and held
+between his fingers a small sheet of rose-colored paper, on which some
+verses were written--written indeed by the officer himself; for who has
+not, at least once in his life, had a lyrical moment? And if one then
+marks down one’s thoughts, poetry is produced. But here was written:
+
+                  OH, WERE I RICH!
+
+     “Oh, were I rich! Such was my wish, yea such
+      When hardly three feet high, I longed for much.
+       Oh, were I rich! an officer were I,
+       With sword, and uniform, and plume so high.
+       And the time came, and officer was I!
+     But yet I grew not rich. Alas, poor me!
+     Have pity, Thou, who all man’s wants dost see.
+
+        “I sat one evening sunk in dreams of bliss,
+      A maid of seven years old gave me a kiss,
+       I at that time was rich in poesy
+       And tales of old, though poor as poor could be;
+       But all she asked for was this poesy.
+     Then was I rich, but not in gold, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich! Oft asked I for this boon.
+      The child grew up to womanhood full soon.
+       She is so pretty, clever, and so kind
+     Oh, did she know what’s hidden in my mind--
+       A tale of old. Would she to me were kind!
+     But I’m condemned to silence! oh, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich in calm and peace of mind,
+      My grief you then would not here written find!
+       O thou, to whom I do my heart devote,
+       Oh read this page of glad days now remote,
+       A dark, dark tale, which I tonight devote!
+     Dark is the future now. Alas, poor me!
+     Have pity Thou, who all men’s pains dost see.”
+
+Such verses as these people write when they are in love! But no man
+in his senses ever thinks of printing them. Here one of the sorrows of
+life, in which there is real poetry, gave itself vent; not that
+barren grief which the poet may only hint at, but never depict in its
+detail--misery and want: that animal necessity, in short, to snatch
+at least at a fallen leaf of the bread-fruit tree, if not at the fruit
+itself. The higher the position in which one finds oneself transplanted,
+the greater is the suffering. Everyday necessity is the stagnant pool of
+life--no lovely picture reflects itself therein. Lieutenant, love, and
+lack of money--that is a symbolic triangle, or much the same as the
+half of the shattered die of Fortune. This the lieutenant felt most
+poignantly, and this was the reason he leant his head against the
+window, and sighed so deeply.
+
+“The poor watchman out there in the street is far happier than I. He
+knows not what I term privation. He has a home, a wife, and children,
+who weep with him over his sorrows, who rejoice with him when he is
+glad. Oh, far happier were I, could I exchange with him my being--with
+his desires and with his hopes perform the weary pilgrimage of life! Oh,
+he is a hundred times happier than I!”
+
+In the same moment the watchman was again watchman. It was the shoes
+that caused the metamorphosis by means of which, unknown to himself, he
+took upon him the thoughts and feelings of the officer; but, as we have
+just seen, he felt himself in his new situation much less contented,
+and now preferred the very thing which but some minutes before he had
+rejected. So then the watchman was again watchman.
+
+“That was an unpleasant dream,” said he; “but ‘twas droll enough
+altogether. I fancied that I was the lieutenant over there: and yet
+the thing was not very much to my taste after all. I missed my good old
+mother and the dear little ones; who almost tear me to pieces for sheer
+love.”
+
+He seated himself once more and nodded: the dream continued to haunt
+him, for he still had the shoes on his feet. A falling star shone in the
+dark firmament.
+
+“There falls another star,” said he: “but what does it matter; there
+are always enough left. I should not much mind examining the little
+glimmering things somewhat nearer, especially the moon; for that would
+not slip so easily through a man’s fingers. When we die--so at least
+says the student, for whom my wife does the washing--we shall fly about
+as light as a feather from one such a star to the other. That’s, of
+course, not true: but ‘twould be pretty enough if it were so. If I could
+but once take a leap up there, my body might stay here on the steps for
+what I care.”
+
+Behold--there are certain things in the world to which one ought never
+to give utterance except with the greatest caution; but doubly careful
+must one be when we have the Shoes of Fortune on our feet. Now just
+listen to what happened to the watchman.
+
+As to ourselves, we all know the speed produced by the employment of
+steam; we have experienced it either on railroads, or in boats when
+crossing the sea; but such a flight is like the travelling of a sloth in
+comparison with the velocity with which light moves. It flies nineteen
+million times faster than the best race-horse; and yet electricity is
+quicker still. Death is an electric shock which our heart receives; the
+freed soul soars upwards on the wings of electricity. The sun’s light
+wants eight minutes and some seconds to perform a journey of more than
+twenty million of our Danish [*] miles; borne by electricity, the soul
+wants even some minutes less to accomplish the same flight. To it the
+space between the heavenly bodies is not greater than the distance
+between the homes of our friends in town is for us, even if they live a
+short way from each other; such an electric shock in the heart, however,
+costs us the use of the body here below; unless, like the watchman of
+East Street, we happen to have on the Shoes of Fortune.
+
+     * A Danish mile is nearly 4 3/4 English.
+
+
+In a few seconds the watchman had done the fifty-two thousand of our
+miles up to the moon, which, as everyone knows, was formed out of
+matter much lighter than our earth; and is, so we should say, as soft
+as newly-fallen snow. He found himself on one of the many circumjacent
+mountain-ridges with which we are acquainted by means of Dr. Madler’s
+“Map of the Moon.” Within, down it sunk perpendicularly into a caldron,
+about a Danish mile in depth; while below lay a town, whose appearance
+we can, in some measure, realize to ourselves by beating the white of
+an egg in a glass of water. The matter of which it was built was just as
+soft, and formed similar towers, and domes, and pillars, transparent and
+rocking in the thin air; while above his head our earth was rolling like
+a large fiery ball.
+
+He perceived immediately a quantity of beings who were certainly what
+we call “men”; yet they looked different to us. A far more correct
+imagination than that of the pseudo-Herschel* had created them; and
+if they had been placed in rank and file, and copied by some skilful
+painter’s hand, one would, without doubt, have exclaimed involuntarily,
+“What a beautiful arabesque!”
+
+*This relates to a book published some years ago in Germany, and said
+to be by Herschel, which contained a description of the moon and its
+inhabitants, written with such a semblance of truth that many were
+deceived by the imposture.
+
+Probably a translation of the celebrated Moon hoax, written by Richard
+A. Locke, and originally published in New York.
+
+
+They had a language too; but surely nobody can expect that the soul of
+the watchman should understand it. Be that as it may, it did comprehend
+it; for in our souls there germinate far greater powers than we poor
+mortals, despite all our cleverness, have any notion of. Does she
+not show us--she the queen in the land of enchantment--her astounding
+dramatic talent in all our dreams? There every acquaintance appears and
+speaks upon the stage, so entirely in character, and with the same tone
+of voice, that none of us, when awake, were able to imitate it. How
+well can she recall persons to our mind, of whom we have not thought for
+years; when suddenly they step forth “every inch a man,” resembling the
+real personages, even to the finest features, and become the heroes
+or heroines of our world of dreams. In reality, such remembrances are
+rather unpleasant: every sin, every evil thought, may, like a clock with
+alarm or chimes, be repeated at pleasure; then the question is if we can
+trust ourselves to give an account of every unbecoming word in our heart
+and on our lips.
+
+The watchman’s spirit understood the language of the inhabitants of the
+moon pretty well. The Selenites* disputed variously about our earth,
+and expressed their doubts if it could be inhabited: the air, they said,
+must certainly be too dense to allow any rational dweller in the moon
+the necessary free respiration. They considered the moon alone to
+be inhabited: they imagined it was the real heart of the universe or
+planetary system, on which the genuine Cosmopolites, or citizens of the
+world, dwelt. What strange things men--no, what strange things Selenites
+sometimes take into their heads!
+
+* Dwellers in the moon.
+
+
+About politics they had a good deal to say. But little Denmark must
+take care what it is about, and not run counter to the moon; that
+great realm, that might in an ill-humor bestir itself, and dash down a
+hail-storm in our faces, or force the Baltic to overflow the sides of
+its gigantic basin.
+
+We will, therefore, not listen to what was spoken, and on no condition
+run in the possibility of telling tales out of school; but we will
+rather proceed, like good quiet citizens, to East Street, and observe
+what happened meanwhile to the body of the watchman.
+
+He sat lifeless on the steps: the morning-star,* that is to say, the
+heavy wooden staff, headed with iron spikes, and which had nothing else
+in common with its sparkling brother in the sky, had glided from his
+hand; while his eyes were fixed with glassy stare on the moon, looking
+for the good old fellow of a spirit which still haunted it.
+
+*The watchmen in Germany, had formerly, and in some places they still
+carry with them, on their rounds at night, a sort of mace or club, known
+in ancient times by the above denomination.
+
+
+“What’s the hour, watchman?” asked a passer-by. But when the watchman
+gave no reply, the merry roysterer, who was now returning home from a
+noisy drinking bout, took it into his head to try what a tweak of the
+nose would do, on which the supposed sleeper lost his balance, the body
+lay motionless, stretched out on the pavement: the man was dead. When
+the patrol came up, all his comrades, who comprehended nothing of the
+whole affair, were seized with a dreadful fright, for dead he was,
+and he remained so. The proper authorities were informed of the
+circumstance, people talked a good deal about it, and in the morning the
+body was carried to the hospital.
+
+Now that would be a very pretty joke, if the spirit when it came back
+and looked for the body in East Street, were not to find one. No doubt
+it would, in its anxiety, run off to the police, and then to the
+“Hue and Cry” office, to announce that “the finder will be handsomely
+rewarded,” and at last away to the hospital; yet we may boldly assert
+that the soul is shrewdest when it shakes off every fetter, and every
+sort of leading-string--the body only makes it stupid.
+
+The seemingly dead body of the watchman wandered, as we have said, to
+the hospital, where it was brought into the general viewing-room:
+and the first thing that was done here was naturally to pull off the
+galoshes--when the spirit, that was merely gone out on adventures, must
+have returned with the quickness of lightning to its earthly tenement.
+It took its direction towards the body in a straight line; and a few
+seconds after, life began to show itself in the man. He asserted that
+the preceding night had been the worst that ever the malice of fate had
+allotted him; he would not for two silver marks again go through what he
+had endured while moon-stricken; but now, however, it was over.
+
+The same day he was discharged from the hospital as perfectly cured; but
+the Shoes meanwhile remained behind.
+
+
+IV. A Moment of Head Importance--An Evening’s “Dramatic Readings”--A
+Most Strange Journey
+
+Every inhabitant of Copenhagen knows, from personal inspection, how
+the entrance to Frederick’s Hospital looks; but as it is possible that
+others, who are not Copenhagen people, may also read this little work,
+we will beforehand give a short description of it.
+
+The extensive building is separated from the street by a pretty high
+railing, the thick iron bars of which are so far apart, that in
+all seriousness, it is said, some very thin fellow had of a night
+occasionally squeezed himself through to go and pay his little visits
+in the town. The part of the body most difficult to manage on such
+occasions was, no doubt, the head; here, as is so often the case in
+the world, long-headed people get through best. So much, then, for the
+introduction.
+
+One of the young men, whose head, in a physical sense only, might be
+said to be of the thickest, had the watch that evening. The rain poured
+down in torrents; yet despite these two obstacles, the young man was
+obliged to go out, if it were but for a quarter of an hour; and as
+to telling the door-keeper about it, that, he thought, was quite
+unnecessary, if, with a whole skin, he were able to slip through the
+railings. There, on the floor lay the galoshes, which the watchman
+had forgotten; he never dreamed for a moment that they were those of
+Fortune; and they promised to do him good service in the wet; so he put
+them on. The question now was, if he could squeeze himself through the
+grating, for he had never tried before. Well, there he stood.
+
+“Would to Heaven I had got my head through!” said he, involuntarily; and
+instantly through it slipped, easily and without pain, notwithstanding
+it was pretty large and thick. But now the rest of the body was to be
+got through!
+
+“Ah! I am much too stout,” groaned he aloud, while fixed as in a vice.
+“I had thought the head was the most difficult part of the matter--oh!
+oh! I really cannot squeeze myself through!”
+
+He now wanted to pull his over-hasty head back again, but he could not.
+For his neck there was room enough, but for nothing more. His first
+feeling was of anger; his next that his temper fell to zero. The
+Shoes of Fortune had placed him in the most dreadful situation; and,
+unfortunately, it never occurred to him to wish himself free. The
+pitch-black clouds poured down their contents in still heavier torrents;
+not a creature was to be seen in the streets. To reach up to the bell
+was what he did not like; to cry aloud for help would have availed him
+little; besides, how ashamed would he have been to be found caught in a
+trap, like an outwitted fox! How was he to twist himself through! He saw
+clearly that it was his irrevocable destiny to remain a prisoner till
+dawn, or, perhaps, even late in the morning; then the smith must be
+fetched to file away the bars; but all that would not be done so quickly
+as he could think about it. The whole Charity School, just opposite,
+would be in motion; all the new booths, with their not very
+courtier-like swarm of seamen, would join them out of curiosity, and
+would greet him with a wild “hurrah!” while he was standing in his
+pillory: there would be a mob, a hissing, and rejoicing, and jeering,
+ten times worse than in the rows about the Jews some years ago--“Oh, my
+blood is mounting to my brain; ‘tis enough to drive one mad! I shall go
+wild! I know not what to do. Oh! were I but loose; my dizziness would
+then cease; oh, were my head but loose!”
+
+You see he ought to have said that sooner; for the moment he expressed
+the wish his head was free; and cured of all his paroxysms of love, he
+hastened off to his room, where the pains consequent on the fright the
+Shoes had prepared for him, did not so soon take their leave.
+
+But you must not think that the affair is over now; it grows much worse.
+
+The night passed, the next day also; but nobody came to fetch the Shoes.
+
+In the evening “Dramatic Readings” were to be given at the little
+theatre in King Street. The house was filled to suffocation; and among
+other pieces to be recited was a new poem by H. C. Andersen, called, My
+Aunt’s Spectacles; the contents of which were pretty nearly as follows:
+
+“A certain person had an aunt, who boasted of particular skill in
+fortune-telling with cards, and who was constantly being stormed by
+persons that wanted to have a peep into futurity. But she was full of
+mystery about her art, in which a certain pair of magic spectacles
+did her essential service. Her nephew, a merry boy, who was his aunt’s
+darling, begged so long for these spectacles, that, at last, she lent
+him the treasure, after having informed him, with many exhortations,
+that in order to execute the interesting trick, he need only repair to
+some place where a great many persons were assembled; and then, from a
+higher position, whence he could overlook the crowd, pass the company in
+review before him through his spectacles. Immediately ‘the inner man’ of
+each individual would be displayed before him, like a game of cards, in
+which he unerringly might read what the future of every person presented
+was to be. Well pleased the little magician hastened away to prove the
+powers of the spectacles in the theatre; no place seeming to him more
+fitted for such a trial. He begged permission of the worthy audience,
+and set his spectacles on his nose. A motley phantasmagoria presents
+itself before him, which he describes in a few satirical touches, yet
+without expressing his opinion openly: he tells the people enough to set
+them all thinking and guessing; but in order to hurt nobody, he wraps
+his witty oracular judgments in a transparent veil, or rather in a lurid
+thundercloud, shooting forth bright sparks of wit, that they may fall in
+the powder-magazine of the expectant audience.”
+
+The humorous poem was admirably recited, and the speaker much applauded.
+Among the audience was the young man of the hospital, who seemed to have
+forgotten his adventure of the preceding night. He had on the Shoes; for
+as yet no lawful owner had appeared to claim them; and besides it was so
+very dirty out-of-doors, they were just the thing for him, he thought.
+
+The beginning of the poem he praised with great generosity: he even
+found the idea original and effective. But that the end of it, like the
+Rhine, was very insignificant, proved, in his opinion, the author’s
+want of invention; he was without genius, etc. This was an excellent
+opportunity to have said something clever.
+
+Meanwhile he was haunted by the idea--he should like to possess such a
+pair of spectacles himself; then, perhaps, by using them circumspectly,
+one would be able to look into people’s hearts, which, he thought, would
+be far more interesting than merely to see what was to happen next year;
+for that we should all know in proper time, but the other never.
+
+“I can now,” said he to himself, “fancy the whole row of ladies and
+gentlemen sitting there in the front row; if one could but see into
+their hearts--yes, that would be a revelation--a sort of bazar. In that
+lady yonder, so strangely dressed, I should find for certain a large
+milliner’s shop; in that one the shop is empty, but it wants cleaning
+plain enough. But there would also be some good stately shops among
+them. Alas!” sighed he, “I know one in which all is stately; but there
+sits already a spruce young shopman, which is the only thing that’s
+amiss in the whole shop. All would be splendidly decked out, and we
+should hear, ‘Walk in, gentlemen, pray walk in; here you will find all
+you please to want.’ Ah! I wish to Heaven I could walk in and take a
+trip right through the hearts of those present!”
+
+And behold! to the Shoes of Fortune this was the cue; the whole man
+shrunk together and a most uncommon journey through the hearts of the
+front row of spectators, now began. The first heart through which he
+came, was that of a middle-aged lady, but he instantly fancied himself
+in the room of the “Institution for the cure of the crooked and
+deformed,” where casts of mis-shapen limbs are displayed in naked
+reality on the wall. Yet there was this difference, in the institution
+the casts were taken at the entry of the patient; but here they were
+retained and guarded in the heart while the sound persons went away.
+They were, namely, casts of female friends, whose bodily or mental
+deformities were here most faithfully preserved.
+
+With the snake-like writhings of an idea he glided into another female
+heart; but this seemed to him like a large holy fane. [*] The white dove of
+innocence fluttered over the altar. How gladly would he have sunk upon
+his knees; but he must away to the next heart; yet he still heard the
+pealing tones of the organ, and he himself seemed to have become a newer
+and a better man; he felt unworthy to tread the neighboring sanctuary
+which a poor garret, with a sick bed-rid mother, revealed. But God’s
+warm sun streamed through the open window; lovely roses nodded from
+the wooden flower-boxes on the roof, and two sky-blue birds sang
+rejoicingly, while the sick mother implored God’s richest blessings on
+her pious daughter.
+
+     * temple
+
+
+He now crept on hands and feet through a butcher’s shop; at least on
+every side, and above and below, there was nought but flesh. It was the
+heart of a most respectable rich man, whose name is certain to be found
+in the Directory.
+
+He was now in the heart of the wife of this worthy gentleman. It was an
+old, dilapidated, mouldering dovecot. The husband’s portrait was used as
+a weather-cock, which was connected in some way or other with the doors,
+and so they opened and shut of their own accord, whenever the stern old
+husband turned round.
+
+Hereupon he wandered into a boudoir formed entirely of mirrors, like
+the one in Castle Rosenburg; but here the glasses magnified to an
+astonishing degree. On the floor, in the middle of the room, sat, like a
+Dalai-Lama, the insignificant “Self” of the person, quite confounded at
+his own greatness. He then imagined he had got into a needle-case full
+of pointed needles of every size.
+
+“This is certainly the heart of an old maid,” thought he. But he was
+mistaken. It was the heart of a young military man; a man, as people
+said, of talent and feeling.
+
+In the greatest perplexity, he now came out of the last heart in the
+row; he was unable to put his thoughts in order, and fancied that his
+too lively imagination had run away with him.
+
+“Good Heavens!” sighed he. “I have surely a disposition to madness--‘tis
+dreadfully hot here; my blood boils in my veins and my head is burning
+like a coal.” And he now remembered the important event of the evening
+before, how his head had got jammed in between the iron railings of the
+hospital. “That’s what it is, no doubt,” said he. “I must do something
+in time: under such circumstances a Russian bath might do me good. I
+only wish I were already on the upper bank.” [*]
+
+     *In these Russian (vapor) baths the person extends himself
+     on a bank or form, and as he gets accustomed to the heat,
+     moves to another higher up towards the ceiling, where, of
+     course, the vapor is warmest. In this manner he ascends
+     gradually to the highest.
+
+And so there he lay on the uppermost bank in the vapor-bath; but with
+all his clothes on, in his boots and galoshes, while the hot drops fell
+scalding from the ceiling on his face.
+
+“Holloa!” cried he, leaping down. The bathing attendant, on his side,
+uttered a loud cry of astonishment when he beheld in the bath, a man
+completely dressed.
+
+The other, however, retained sufficient presence of mind to whisper to
+him, “‘Tis a bet, and I have won it!” But the first thing he did as soon
+as he got home, was to have a large blister put on his chest and back to
+draw out his madness.
+
+The next morning he had a sore chest and a bleeding back; and, excepting
+the fright, that was all that he had gained by the Shoes of Fortune.
+
+
+V. Metamorphosis of the Copying-Clerk
+
+The watchman, whom we have certainly not forgotten, thought meanwhile
+of the galoshes he had found and taken with him to the hospital; he now
+went to fetch them; and as neither the lieutenant, nor anybody else in
+the street, claimed them as his property, they were delivered over to
+the police-office.*
+
+*As on the continent, in all law and police practices nothing is verbal,
+but any circumstance, however trifling, is reduced to writing, the
+labor, as well as the number of papers that thus accumulate, is
+enormous. In a police-office, consequently, we find copying-clerks among
+many other scribes of various denominations, of which, it seems, our
+hero was one.
+
+
+“Why, I declare the Shoes look just like my own,” said one of the
+clerks, eying the newly-found treasure, whose hidden powers, even he,
+sharp as he was, was not able to discover. “One must have more than
+the eye of a shoemaker to know one pair from the other,” said he,
+soliloquizing; and putting, at the same time, the galoshes in search of
+an owner, beside his own in the corner.
+
+“Here, sir!” said one of the men, who panting brought him a tremendous
+pile of papers.
+
+The copying-clerk turned round and spoke awhile with the man about the
+reports and legal documents in question; but when he had finished, and
+his eye fell again on the Shoes, he was unable to say whether those to
+the left or those to the right belonged to him. “At all events it must
+be those which are wet,” thought he; but this time, in spite of his
+cleverness, he guessed quite wrong, for it was just those of Fortune
+which played as it were into his hands, or rather on his feet. And why,
+I should like to know, are the police never to be wrong? So he put them
+on quickly, stuck his papers in his pocket, and took besides a few under
+his arm, intending to look them through at home to make the necessary
+notes. It was noon; and the weather, that had threatened rain, began
+to clear up, while gaily dressed holiday folks filled the streets. “A
+little trip to Fredericksburg would do me no great harm,” thought he;
+“for I, poor beast of burden that I am, have so much to annoy me, that I
+don’t know what a good appetite is. ‘Tis a bitter crust, alas! at which
+I am condemned to gnaw!”
+
+Nobody could be more steady or quiet than this young man; we therefore
+wish him joy of the excursion with all our heart; and it will certainly
+be beneficial for a person who leads so sedentary a life. In the park
+he met a friend, one of our young poets, who told him that the following
+day he should set out on his long-intended tour.
+
+“So you are going away again!” said the clerk. “You are a very free
+and happy being; we others are chained by the leg and held fast to our
+desk.”
+
+“Yes; but it is a chain, friend, which ensures you the blessed bread
+of existence,” answered the poet. “You need feel no care for the coming
+morrow: when you are old, you receive a pension.”
+
+“True,” said the clerk, shrugging his shoulders; “and yet you are
+the better off. To sit at one’s ease and poetise--that is a pleasure;
+everybody has something agreeable to say to you, and you are always your
+own master. No, friend, you should but try what it is to sit from one
+year’s end to the other occupied with and judging the most trivial
+matters.”
+
+The poet shook his head, the copying-clerk did the same. Each one kept
+to his own opinion, and so they separated.
+
+“It’s a strange race, those poets!” said the clerk, who was very fond of
+soliloquizing. “I should like some day, just for a trial, to take such
+nature upon me, and be a poet myself; I am very sure I should make
+no such miserable verses as the others. Today, methinks, is a most
+delicious day for a poet. Nature seems anew to celebrate her awakening
+into life. The air is so unusually clear, the clouds sail on so
+buoyantly, and from the green herbage a fragrance is exhaled that fills
+me with delight. For many a year have I not felt as at this moment.”
+
+We see already, by the foregoing effusion, that he is become a poet; to
+give further proof of it, however, would in most cases be insipid, for
+it is a most foolish notion to fancy a poet different from other men.
+Among the latter there may be far more poetical natures than many an
+acknowledged poet, when examined more closely, could boast of; the
+difference only is, that the poet possesses a better mental memory, on
+which account he is able to retain the feeling and the thought till they
+can be embodied by means of words; a faculty which the others do not
+possess. But the transition from a commonplace nature to one that is
+richly endowed, demands always a more or less breakneck leap over a
+certain abyss which yawns threateningly below; and thus must the sudden
+change with the clerk strike the reader.
+
+“The sweet air!” continued he of the police-office, in his dreamy
+imaginings; “how it reminds me of the violets in the garden of my aunt
+Magdalena! Yes, then I was a little wild boy, who did not go to school
+very regularly. O heavens! ‘tis a long time since I have thought on
+those times. The good old soul! She lived behind the Exchange. She
+always had a few twigs or green shoots in water--let the winter rage
+without as it might. The violets exhaled their sweet breath, whilst I
+pressed against the windowpanes covered with fantastic frost-work the
+copper coin I had heated on the stove, and so made peep-holes.
+What splendid vistas were then opened to my view! What change--what
+magnificence! Yonder in the canal lay the ships frozen up, and deserted
+by their whole crews, with a screaming crow for the sole occupant. But
+when the spring, with a gentle stirring motion, announced her arrival,
+a new and busy life arose; with songs and hurrahs the ice was sawn
+asunder, the ships were fresh tarred and rigged, that they might sail
+away to distant lands. But I have remained here--must always remain
+here, sitting at my desk in the office, and patiently see other people
+fetch their passports to go abroad. Such is my fate! Alas!”--sighed he,
+and was again silent. “Great Heaven! What is come to me! Never have I
+thought or felt like this before! It must be the summer air that affects
+me with feelings almost as disquieting as they are refreshing.”
+
+He felt in his pocket for the papers. “These police-reports will soon
+stem the torrent of my ideas, and effectually hinder any rebellious
+overflowing of the time-worn banks of official duties”; he said to
+himself consolingly, while his eye ran over the first page. “DAME
+TIGBRITH, tragedy in five acts.” “What is that? And yet it is undeniably
+my own handwriting. Have I written the tragedy? Wonderful, very
+wonderful!--And this--what have I here? ‘INTRIGUE ON THE RAMPARTS; or
+THE DAY OF REPENTANCE: vaudeville with new songs to the most favorite
+airs.’ The deuce! Where did I get all this rubbish? Some one must have
+slipped it slyly into my pocket for a joke. There is too a letter to me;
+a crumpled letter and the seal broken.”
+
+Yes; it was not a very polite epistle from the manager of a theatre, in
+which both pieces were flatly refused.
+
+“Hem! hem!” said the clerk breathlessly, and quite exhausted he seated
+himself on a bank. His thoughts were so elastic, his heart so tender;
+and involuntarily he picked one of the nearest flowers. It is a simple
+daisy, just bursting out of the bud. What the botanist tells us after
+a number of imperfect lectures, the flower proclaimed in a minute. It
+related the mythus of its birth, told of the power of the sun-light that
+spread out its delicate leaves, and forced them to impregnate the air
+with their incense--and then he thought of the manifold struggles of
+life, which in like manner awaken the budding flowers of feeling in our
+bosom. Light and air contend with chivalric emulation for the love of
+the fair flower that bestowed her chief favors on the latter; full of
+longing she turned towards the light, and as soon as it vanished, rolled
+her tender leaves together and slept in the embraces of the air. “It is
+the light which adorns me,” said the flower.
+
+“But ‘tis the air which enables thee to breathe,” said the poet’s voice.
+
+Close by stood a boy who dashed his stick into a wet ditch. The drops of
+water splashed up to the green leafy roof, and the clerk thought of the
+million of ephemera which in a single drop were thrown up to a height,
+that was as great doubtless for their size, as for us if we were to
+be hurled above the clouds. While he thought of this and of the whole
+metamorphosis he had undergone, he smiled and said, “I sleep and dream;
+but it is wonderful how one can dream so naturally, and know besides so
+exactly that it is but a dream. If only to-morrow on awaking, I could
+again call all to mind so vividly! I seem in unusually good spirits; my
+perception of things is clear, I feel as light and cheerful as though
+I were in heaven; but I know for a certainty, that if to-morrow a dim
+remembrance of it should swim before my mind, it will then seem nothing
+but stupid nonsense, as I have often experienced already--especially
+before I enlisted under the banner of the police, for that dispels like
+a whirlwind all the visions of an unfettered imagination. All we hear
+or say in a dream that is fair and beautiful is like the gold of the
+subterranean spirits; it is rich and splendid when it is given us, but
+viewed by daylight we find only withered leaves. Alas!” he sighed quite
+sorrowful, and gazed at the chirping birds that hopped contentedly from
+branch to branch, “they are much better off than I! To fly must be a
+heavenly art; and happy do I prize that creature in which it is innate.
+Yes! Could I exchange my nature with any other creature, I fain would be
+such a happy little lark!”
+
+He had hardly uttered these hasty words when the skirts and sleeves
+of his coat folded themselves together into wings; the clothes became
+feathers, and the galoshes claws. He observed it perfectly, and laughed
+in his heart. “Now then, there is no doubt that I am dreaming; but I
+never before was aware of such mad freaks as these.” And up he flew into
+the green roof and sang; but in the song there was no poetry, for the
+spirit of the poet was gone. The Shoes, as is the case with anybody who
+does what he has to do properly, could only attend to one thing at a
+time. He wanted to be a poet, and he was one; he now wished to be a
+merry chirping bird: but when he was metamorphosed into one, the former
+peculiarities ceased immediately. “It is really pleasant enough,” said
+he: “the whole day long I sit in the office amid the driest
+law-papers, and at night I fly in my dream as a lark in the gardens of
+Fredericksburg; one might really write a very pretty comedy upon it.” He
+now fluttered down into the grass, turned his head gracefully on every
+side, and with his bill pecked the pliant blades of grass, which, in
+comparison to his present size, seemed as majestic as the palm-branches
+of northern Africa.
+
+Unfortunately the pleasure lasted but a moment. Presently black night
+overshadowed our enthusiast, who had so entirely missed his part of
+copying-clerk at a police-office; some vast object seemed to be thrown
+over him. It was a large oil-skin cap, which a sailor-boy of the quay
+had thrown over the struggling bird; a coarse hand sought its way
+carefully in under the broad rim, and seized the clerk over the back
+and wings. In the first moment of fear, he called, indeed, as loud as
+he could--“You impudent little blackguard! I am a copying-clerk at
+the police-office; and you know you cannot insult any belonging to the
+constabulary force without a chastisement. Besides, you good-for-nothing
+rascal, it is strictly forbidden to catch birds in the royal gardens of
+Fredericksburg; but your blue uniform betrays where you come from.”
+ This fine tirade sounded, however, to the ungodly sailor-boy like a mere
+“Pippi-pi.” He gave the noisy bird a knock on his beak, and walked on.
+
+He was soon met by two schoolboys of the upper class--that is to say as
+individuals, for with regard to learning they were in the lowest class
+in the school; and they bought the stupid bird. So the copying-clerk
+came to Copenhagen as guest, or rather as prisoner in a family living in
+Gother Street.
+
+“‘Tis well that I’m dreaming,” said the clerk, “or I really should get
+angry. First I was a poet; now sold for a few pence as a lark; no doubt
+it was that accursed poetical nature which has metamorphosed me
+into such a poor harmless little creature. It is really pitiable,
+particularly when one gets into the hands of a little blackguard,
+perfect in all sorts of cruelty to animals: all I should like to know
+is, how the story will end.”
+
+The two schoolboys, the proprietors now of the transformed clerk,
+carried him into an elegant room. A stout stately dame received them
+with a smile; but she expressed much dissatisfaction that a common
+field-bird, as she called the lark, should appear in such high society.
+For to-day, however, she would allow it; and they must shut him in the
+empty cage that was standing in the window. “Perhaps he will amuse my
+good Polly,” added the lady, looking with a benignant smile at a large
+green parrot that swung himself backwards and forwards most comfortably
+in his ring, inside a magnificent brass-wired cage. “To-day is Polly’s
+birthday,” said she with stupid simplicity: “and the little brown
+field-bird must wish him joy.”
+
+Mr. Polly uttered not a syllable in reply, but swung to and fro with
+dignified condescension; while a pretty canary, as yellow as gold, that
+had lately been brought from his sunny fragrant home, began to sing
+aloud.
+
+“Noisy creature! Will you be quiet!” screamed the lady of the house,
+covering the cage with an embroidered white pocket handkerchief.
+
+“Chirp, chirp!” sighed he. “That was a dreadful snowstorm”; and he
+sighed again, and was silent.
+
+The copying-clerk, or, as the lady said, the brown field-bird, was
+put into a small cage, close to the Canary, and not far from “my good
+Polly.” The only human sounds that the Parrot could bawl out
+were, “Come, let us be men!” Everything else that he said was as
+unintelligible to everybody as the chirping of the Canary, except to the
+clerk, who was now a bird too: he understood his companion perfectly.
+
+“I flew about beneath the green palms and the blossoming almond-trees,”
+ sang the Canary; “I flew around, with my brothers and sisters, over
+the beautiful flowers, and over the glassy lakes, where the bright
+water-plants nodded to me from below. There, too, I saw many
+splendidly-dressed paroquets, that told the drollest stories, and the
+wildest fairy tales without end.”
+
+“Oh! those were uncouth birds,” answered the Parrot. “They had no
+education, and talked of whatever came into their head.
+
+“If my mistress and all her friends can laugh at what I say, so may you
+too, I should think. It is a great fault to have no taste for what is
+witty or amusing--come, let us be men.”
+
+“Ah, you have no remembrance of love for the charming maidens that
+danced beneath the outspread tents beside the bright fragrant flowers?
+Do you no longer remember the sweet fruits, and the cooling juice in
+the wild plants of our never-to-be-forgotten home?” said the former
+inhabitant of the Canary Isles, continuing his dithyrambic.
+
+“Oh, yes,” said the Parrot; “but I am far better off here. I am well
+fed, and get friendly treatment. I know I am a clever fellow; and that
+is all I care about. Come, let us be men. You are of a poetical nature,
+as it is called--I, on the contrary, possess profound knowledge and
+inexhaustible wit. You have genius; but clear-sighted, calm discretion
+does not take such lofty flights, and utter such high natural tones.
+For this they have covered you over--they never do the like to me; for
+I cost more. Besides, they are afraid of my beak; and I have always a
+witty answer at hand. Come, let us be men!”
+
+“O warm spicy land of my birth,” sang the Canary bird; “I will sing of
+thy dark-green bowers, of the calm bays where the pendent boughs
+kiss the surface of the water; I will sing of the rejoicing of all my
+brothers and sisters where the cactus grows in wanton luxuriance.”
+
+“Spare us your elegiac tones,” said the Parrot giggling. “Rather speak
+of something at which one may laugh heartily. Laughing is an infallible
+sign of the highest degree of mental development. Can a dog, or a horse
+laugh? No, but they can cry. The gift of laughing was given to man
+alone. Ha! ha! ha!” screamed Polly, and added his stereotype witticism.
+“Come, let us be men!”
+
+“Poor little Danish grey-bird,” said the Canary; “you have been caught
+too. It is, no doubt, cold enough in your woods, but there at least
+is the breath of liberty; therefore fly away. In the hurry they have
+forgotten to shut your cage, and the upper window is open. Fly, my
+friend; fly away. Farewell!”
+
+Instinctively the Clerk obeyed; with a few strokes of his wings he was
+out of the cage; but at the same moment the door, which was only ajar,
+and which led to the next room, began to creak, and supple and creeping
+came the large tomcat into the room, and began to pursue him. The
+frightened Canary fluttered about in his cage; the Parrot flapped his
+wings, and cried, “Come, let us be men!” The Clerk felt a mortal fright,
+and flew through the window, far away over the houses and streets. At
+last he was forced to rest a little.
+
+The neighboring house had a something familiar about it; a window stood
+open; he flew in; it was his own room. He perched upon the table.
+
+“Come, let us be men!” said he, involuntarily imitating the chatter of
+the Parrot, and at the same moment he was again a copying-clerk; but he
+was sitting in the middle of the table.
+
+“Heaven help me!” cried he. “How did I get up here--and so buried in
+sleep, too? After all, that was a very unpleasant, disagreeable dream
+that haunted me! The whole story is nothing but silly, stupid nonsense!”
+
+
+VI. The Best That the Galoshes Gave
+
+The following day, early in the morning, while the Clerk was still in
+bed, someone knocked at his door. It was his neighbor, a young Divine,
+who lived on the same floor. He walked in.
+
+“Lend me your Galoshes,” said he; “it is so wet in the garden, though
+the sun is shining most invitingly. I should like to go out a little.”
+
+He got the Galoshes, and he was soon below in a little duodecimo garden,
+where between two immense walls a plumtree and an apple-tree were
+standing. Even such a little garden as this was considered in the
+metropolis of Copenhagen as a great luxury.
+
+The young man wandered up and down the narrow paths, as well as the
+prescribed limits would allow; the clock struck six; without was heard
+the horn of a post-boy.
+
+“To travel! to travel!” exclaimed he, overcome by most painful and
+passionate remembrances. “That is the happiest thing in the world! That
+is the highest aim of all my wishes! Then at last would the agonizing
+restlessness be allayed, which destroys my existence! But it must be
+far, far away! I would behold magnificent Switzerland; I would travel to
+Italy, and--”
+
+It was a good thing that the power of the Galoshes worked as
+instantaneously as lightning in a powder-magazine would do, otherwise
+the poor man with his overstrained wishes would have travelled about
+the world too much for himself as well as for us. In short, he was
+travelling. He was in the middle of Switzerland, but packed up with
+eight other passengers in the inside of an eternally-creaking diligence;
+his head ached till it almost split, his weary neck could hardly bear
+the heavy load, and his feet, pinched by his torturing boots, were
+terribly swollen. He was in an intermediate state between sleeping and
+waking; at variance with himself, with his company, with the country,
+and with the government. In his right pocket he had his letter of
+credit, in the left, his passport, and in a small leathern purse some
+double louis d’or, carefully sewn up in the bosom of his waistcoat.
+Every dream proclaimed that one or the other of these valuables was
+lost; wherefore he started up as in a fever; and the first movement
+which his hand made, described a magic triangle from the right pocket to
+the left, and then up towards the bosom, to feel if he had them all safe
+or not. From the roof inside the carriage, umbrellas, walking-sticks,
+hats, and sundry other articles were depending, and hindered the view,
+which was particularly imposing. He now endeavored as well as he
+was able to dispel his gloom, which was caused by outward chance
+circumstances merely, and on the bosom of nature imbibe the milk of
+purest human enjoyment.
+
+Grand, solemn, and dark was the whole landscape around. The gigantic
+pine-forests, on the pointed crags, seemed almost like little tufts of
+heather, colored by the surrounding clouds. It began to snow, a cold
+wind blew and roared as though it were seeking a bride.
+
+“Augh!” sighed he, “were we only on the other side the Alps, then we
+should have summer, and I could get my letters of credit cashed. The
+anxiety I feel about them prevents me enjoying Switzerland. Were I but
+on the other side!”
+
+And so saying he was on the other side in Italy, between Florence and
+Rome. Lake Thracymene, illumined by the evening sun, lay like flaming
+gold between the dark-blue mountain-ridges; here, where Hannibal
+defeated Flaminius, the rivers now held each other in their green
+embraces; lovely, half-naked children tended a herd of black swine,
+beneath a group of fragrant laurel-trees, hard by the road-side.
+Could we render this inimitable picture properly, then would everybody
+exclaim, “Beautiful, unparalleled Italy!” But neither the young Divine
+said so, nor anyone of his grumbling companions in the coach of the
+vetturino.
+
+The poisonous flies and gnats swarmed around by thousands; in vain one
+waved myrtle-branches about like mad; the audacious insect population
+did not cease to sting; nor was there a single person in the
+well-crammed carriage whose face was not swollen and sore from their
+ravenous bites. The poor horses, tortured almost to death, suffered most
+from this truly Egyptian plague; the flies alighted upon them in large
+disgusting swarms; and if the coachman got down and scraped them off,
+hardly a minute elapsed before they were there again. The sun now set: a
+freezing cold, though of short duration pervaded the whole creation;
+it was like a horrid gust coming from a burial-vault on a warm summer’s
+day--but all around the mountains retained that wonderful green tone
+which we see in some old pictures, and which, should we not have seen a
+similar play of color in the South, we declare at once to be unnatural.
+It was a glorious prospect; but the stomach was empty, the body tired;
+all that the heart cared and longed for was good night-quarters; yet
+how would they be? For these one looked much more anxiously than for the
+charms of nature, which every where were so profusely displayed.
+
+The road led through an olive-grove, and here the solitary inn was
+situated. Ten or twelve crippled-beggars had encamped outside. The
+healthiest of them resembled, to use an expression of Marryat’s,
+“Hunger’s eldest son when he had come of age”; the others were either
+blind, had withered legs and crept about on their hands, or withered
+arms and fingerless hands. It was the most wretched misery, dragged
+from among the filthiest rags. “Excellenza, miserabili!” sighed they,
+thrusting forth their deformed limbs to view. Even the hostess, with
+bare feet, uncombed hair, and dressed in a garment of doubtful color,
+received the guests grumblingly. The doors were fastened with a loop of
+string; the floor of the rooms presented a stone paving half torn
+up; bats fluttered wildly about the ceiling; and as to the smell
+therein--no--that was beyond description.
+
+“You had better lay the cloth below in the stable,” said one of the
+travellers; “there, at all events, one knows what one is breathing.”
+
+The windows were quickly opened, to let in a little fresh air. Quicker,
+however, than the breeze, the withered, sallow arms of the beggars were
+thrust in, accompanied by the eternal whine of “Miserabili, miserabili,
+excellenza!” On the walls were displayed innumerable inscriptions,
+written in nearly every language of Europe, some in verse, some in
+prose, most of them not very laudatory of “bella Italia.”
+
+The meal was served. It consisted of a soup of salted water, seasoned
+with pepper and rancid oil. The last ingredient played a very prominent
+part in the salad; stale eggs and roasted cocks’-combs furnished the
+grand dish of the repast; the wine even was not without a disgusting
+taste--it was like a medicinal draught.
+
+At night the boxes and other effects of the passengers were placed
+against the rickety doors. One of the travellers kept watch while the
+others slept. The sentry was our young Divine. How close it was in the
+chamber! The heat oppressive to suffocation--the gnats hummed and stung
+unceasingly--the “miserabili” without whined and moaned in their sleep.
+
+“Travelling would be agreeable enough,” said he groaning, “if one only
+had no body, or could send it to rest while the spirit went on its
+pilgrimage unhindered, whither the voice within might call it. Wherever
+I go, I am pursued by a longing that is insatiable--that I cannot
+explain to myself, and that tears my very heart. I want something better
+than what is but what is fled in an instant. But what is it, and where
+is it to be found? Yet, I know in reality what it is I wish for. Oh!
+most happy were I, could I but reach one aim--could but reach the
+happiest of all!”
+
+And as he spoke the word he was again in his home; the long white
+curtains hung down from the windows, and in the middle of the floor
+stood the black coffin; in it he lay in the sleep of death. His wish
+was fulfilled--the body rested, while the spirit went unhindered on its
+pilgrimage. “Let no one deem himself happy before his end,” were the
+words of Solon; and here was a new and brilliant proof of the wisdom of
+the old apothegm.
+
+Every corpse is a sphynx of immortality; here too on the black coffin
+the sphynx gave us no answer to what he who lay within had written two
+days before:
+
+     “O mighty Death! thy silence teaches nought,
+       Thou leadest only to the near grave’s brink;
+      Is broken now the ladder of my thoughts?
+     Do I instead of mounting only sink?
+
+     Our heaviest grief the world oft seeth not,
+      Our sorest pain we hide from stranger eyes:
+      And for the sufferer there is nothing left
+     But the green mound that o’er the coffin lies.”
+
+Two figures were moving in the chamber. We knew them both; it was the
+fairy of Care, and the emissary of Fortune. They both bent over the
+corpse.
+
+“Do you now see,” said Care, “what happiness your Galoshes have brought
+to mankind?”
+
+“To him, at least, who slumbers here, they have brought an imperishable
+blessing,” answered the other.
+
+“Ah no!” replied Care. “He took his departure himself; he was not called
+away. His mental powers here below were not strong enough to reach the
+treasures lying beyond this life, and which his destiny ordained he
+should obtain. I will now confer a benefit on him.”
+
+And she took the Galoshes from his feet; his sleep of death was ended;
+and he who had been thus called back again to life arose from his
+dread couch in all the vigor of youth. Care vanished, and with her the
+Galoshes. She has no doubt taken them for herself, to keep them to all
+eternity.
+
+
+
+
+THE FIR TREE
+
+Out in the woods stood a nice little Fir Tree. The place he had was a
+very good one: the sun shone on him: as to fresh air, there was enough
+of that, and round him grew many large-sized comrades, pines as well as
+firs. But the little Fir wanted so very much to be a grown-up tree.
+
+He did not think of the warm sun and of the fresh air; he did not care
+for the little cottage children that ran about and prattled when they
+were in the woods looking for wild-strawberries. The children often came
+with a whole pitcher full of berries, or a long row of them threaded on
+a straw, and sat down near the young tree and said, “Oh, how pretty he
+is! What a nice little fir!” But this was what the Tree could not bear
+to hear.
+
+At the end of a year he had shot up a good deal, and after another year
+he was another long bit taller; for with fir trees one can always tell
+by the shoots how many years old they are.
+
+“Oh! Were I but such a high tree as the others are,” sighed he. “Then I
+should be able to spread out my branches, and with the tops to look into
+the wide world! Then would the birds build nests among my branches: and
+when there was a breeze, I could bend with as much stateliness as the
+others!”
+
+Neither the sunbeams, nor the birds, nor the red clouds which morning
+and evening sailed above him, gave the little Tree any pleasure.
+
+In winter, when the snow lay glittering on the ground, a hare would
+often come leaping along, and jump right over the little Tree. Oh, that
+made him so angry! But two winters were past, and in the third the Tree
+was so large that the hare was obliged to go round it. “To grow and
+grow, to get older and be tall,” thought the Tree--“that, after all, is
+the most delightful thing in the world!”
+
+In autumn the wood-cutters always came and felled some of the largest
+trees. This happened every year; and the young Fir Tree, that had now
+grown to a very comely size, trembled at the sight; for the magnificent
+great trees fell to the earth with noise and cracking, the branches were
+lopped off, and the trees looked long and bare; they were hardly to be
+recognised; and then they were laid in carts, and the horses dragged
+them out of the wood.
+
+Where did they go to? What became of them?
+
+In spring, when the swallows and the storks came, the Tree asked them,
+“Don’t you know where they have been taken? Have you not met them
+anywhere?”
+
+The swallows did not know anything about it; but the Stork looked
+musing, nodded his head, and said, “Yes; I think I know; I met many
+ships as I was flying hither from Egypt; on the ships were magnificent
+masts, and I venture to assert that it was they that smelt so of fir.
+I may congratulate you, for they lifted themselves on high most
+majestically!”
+
+“Oh, were I but old enough to fly across the sea! But how does the sea
+look in reality? What is it like?”
+
+“That would take a long time to explain,” said the Stork, and with these
+words off he went.
+
+“Rejoice in thy growth!” said the Sunbeams. “Rejoice in thy vigorous
+growth, and in the fresh life that moveth within thee!”
+
+And the Wind kissed the Tree, and the Dew wept tears over him; but the
+Fir understood it not.
+
+When Christmas came, quite young trees were cut down: trees which often
+were not even as large or of the same age as this Fir Tree, who could
+never rest, but always wanted to be off. These young trees, and they
+were always the finest looking, retained their branches; they were laid
+on carts, and the horses drew them out of the wood.
+
+“Where are they going to?” asked the Fir. “They are not taller than
+I; there was one indeed that was considerably shorter; and why do they
+retain all their branches? Whither are they taken?”
+
+“We know! We know!” chirped the Sparrows. “We have peeped in at the
+windows in the town below! We know whither they are taken! The greatest
+splendor and the greatest magnificence one can imagine await them. We
+peeped through the windows, and saw them planted in the middle of the
+warm room and ornamented with the most splendid things, with gilded
+apples, with gingerbread, with toys, and many hundred lights!”
+
+“And then?” asked the Fir Tree, trembling in every bough. “And then?
+What happens then?”
+
+“We did not see anything more: it was incomparably beautiful.”
+
+“I would fain know if I am destined for so glorious a career,” cried
+the Tree, rejoicing. “That is still better than to cross the sea! What
+a longing do I suffer! Were Christmas but come! I am now tall, and my
+branches spread like the others that were carried off last year! Oh!
+were I but already on the cart! Were I in the warm room with all the
+splendor and magnificence! Yes; then something better, something still
+grander, will surely follow, or wherefore should they thus ornament me?
+Something better, something still grander must follow--but what? Oh, how
+I long, how I suffer! I do not know myself what is the matter with me!”
+
+“Rejoice in our presence!” said the Air and the Sunlight. “Rejoice in
+thy own fresh youth!”
+
+But the Tree did not rejoice at all; he grew and grew, and was green
+both winter and summer. People that saw him said, “What a fine tree!”
+ and towards Christmas he was one of the first that was cut down. The axe
+struck deep into the very pith; the Tree fell to the earth with a sigh;
+he felt a pang--it was like a swoon; he could not think of happiness,
+for he was sorrowful at being separated from his home, from the place
+where he had sprung up. He well knew that he should never see his dear
+old comrades, the little bushes and flowers around him, anymore; perhaps
+not even the birds! The departure was not at all agreeable.
+
+The Tree only came to himself when he was unloaded in a court-yard with
+the other trees, and heard a man say, “That one is splendid! We don’t
+want the others.” Then two servants came in rich livery and carried the
+Fir Tree into a large and splendid drawing-room. Portraits were hanging
+on the walls, and near the white porcelain stove stood two large Chinese
+vases with lions on the covers. There, too, were large easy-chairs,
+silken sofas, large tables full of picture-books and full of toys, worth
+hundreds and hundreds of crowns--at least the children said so. And the
+Fir Tree was stuck upright in a cask that was filled with sand; but no
+one could see that it was a cask, for green cloth was hung all round it,
+and it stood on a large gaily-colored carpet. Oh! how the Tree quivered!
+What was to happen? The servants, as well as the young ladies, decorated
+it. On one branch there hung little nets cut out of colored paper, and
+each net was filled with sugarplums; and among the other boughs gilded
+apples and walnuts were suspended, looking as though they had grown
+there, and little blue and white tapers were placed among the leaves.
+Dolls that looked for all the world like men--the Tree had never beheld
+such before--were seen among the foliage, and at the very top a
+large star of gold tinsel was fixed. It was really splendid--beyond
+description splendid.
+
+“This evening!” they all said. “How it will shine this evening!”
+
+“Oh!” thought the Tree. “If the evening were but come! If the tapers
+were but lighted! And then I wonder what will happen! Perhaps the other
+trees from the forest will come to look at me! Perhaps the sparrows will
+beat against the windowpanes! I wonder if I shall take root here, and
+winter and summer stand covered with ornaments!”
+
+He knew very much about the matter--but he was so impatient that for
+sheer longing he got a pain in his back, and this with trees is the same
+thing as a headache with us.
+
+The candles were now lighted--what brightness! What splendor! The
+Tree trembled so in every bough that one of the tapers set fire to the
+foliage. It blazed up famously.
+
+“Help! Help!” cried the young ladies, and they quickly put out the fire.
+
+Now the Tree did not even dare tremble. What a state he was in! He was
+so uneasy lest he should lose something of his splendor, that he was
+quite bewildered amidst the glare and brightness; when suddenly both
+folding-doors opened and a troop of children rushed in as if they would
+upset the Tree. The older persons followed quietly; the little ones
+stood quite still. But it was only for a moment; then they shouted that
+the whole place re-echoed with their rejoicing; they danced round the
+Tree, and one present after the other was pulled off.
+
+“What are they about?” thought the Tree. “What is to happen now!” And
+the lights burned down to the very branches, and as they burned down
+they were put out one after the other, and then the children had
+permission to plunder the Tree. So they fell upon it with such violence
+that all its branches cracked; if it had not been fixed firmly in the
+ground, it would certainly have tumbled down.
+
+The children danced about with their beautiful playthings; no one looked
+at the Tree except the old nurse, who peeped between the branches; but
+it was only to see if there was a fig or an apple left that had been
+forgotten.
+
+“A story! A story!” cried the children, drawing a little fat man towards
+the Tree. He seated himself under it and said, “Now we are in the shade,
+and the Tree can listen too. But I shall tell only one story. Now which
+will you have; that about Ivedy-Avedy, or about Humpy-Dumpy, who
+tumbled downstairs, and yet after all came to the throne and married the
+princess?”
+
+“Ivedy-Avedy,” cried some; “Humpy-Dumpy,” cried the others. There was
+such a bawling and screaming--the Fir Tree alone was silent, and he
+thought to himself, “Am I not to bawl with the rest? Am I to do nothing
+whatever?” for he was one of the company, and had done what he had to
+do.
+
+And the man told about Humpy-Dumpy that tumbled down, who
+notwithstanding came to the throne, and at last married the princess.
+And the children clapped their hands, and cried. “Oh, go on! Do go on!”
+ They wanted to hear about Ivedy-Avedy too, but the little man only told
+them about Humpy-Dumpy. The Fir Tree stood quite still and absorbed
+in thought; the birds in the wood had never related the like of this.
+“Humpy-Dumpy fell downstairs, and yet he married the princess! Yes, yes!
+That’s the way of the world!” thought the Fir Tree, and believed it all,
+because the man who told the story was so good-looking. “Well, well! who
+knows, perhaps I may fall downstairs, too, and get a princess as wife!”
+ And he looked forward with joy to the morrow, when he hoped to be decked
+out again with lights, playthings, fruits, and tinsel.
+
+“I won’t tremble to-morrow!” thought the Fir Tree. “I will enjoy to
+the full all my splendor! To-morrow I shall hear again the story of
+Humpy-Dumpy, and perhaps that of Ivedy-Avedy too.” And the whole night
+the Tree stood still and in deep thought.
+
+In the morning the servant and the housemaid came in.
+
+“Now then the splendor will begin again,” thought the Fir. But they
+dragged him out of the room, and up the stairs into the loft: and here,
+in a dark corner, where no daylight could enter, they left him. “What’s
+the meaning of this?” thought the Tree. “What am I to do here? What
+shall I hear now, I wonder?” And he leaned against the wall lost in
+reverie. Time enough had he too for his reflections; for days and nights
+passed on, and nobody came up; and when at last somebody did come, it
+was only to put some great trunks in a corner, out of the way. There
+stood the Tree quite hidden; it seemed as if he had been entirely
+forgotten.
+
+“‘Tis now winter out-of-doors!” thought the Tree. “The earth is hard and
+covered with snow; men cannot plant me now, and therefore I have been
+put up here under shelter till the spring-time comes! How thoughtful
+that is! How kind man is, after all! If it only were not so dark here,
+and so terribly lonely! Not even a hare! And out in the woods it was
+so pleasant, when the snow was on the ground, and the hare leaped by;
+yes--even when he jumped over me; but I did not like it then! It is
+really terribly lonely here!”
+
+“Squeak! Squeak!” said a little Mouse, at the same moment, peeping out
+of his hole. And then another little one came. They snuffed about the
+Fir Tree, and rustled among the branches.
+
+“It is dreadfully cold,” said the Mouse. “But for that, it would be
+delightful here, old Fir, wouldn’t it?”
+
+“I am by no means old,” said the Fir Tree. “There’s many a one
+considerably older than I am.”
+
+“Where do you come from,” asked the Mice; “and what can you do?” They
+were so extremely curious. “Tell us about the most beautiful spot on the
+earth. Have you never been there? Were you never in the larder, where
+cheeses lie on the shelves, and hams hang from above; where one dances
+about on tallow candles: that place where one enters lean, and comes out
+again fat and portly?”
+
+“I know no such place,” said the Tree. “But I know the wood, where the
+sun shines and where the little birds sing.” And then he told all about
+his youth; and the little Mice had never heard the like before; and they
+listened and said,
+
+“Well, to be sure! How much you have seen! How happy you must have
+been!”
+
+“I!” said the Fir Tree, thinking over what he had himself related.
+“Yes, in reality those were happy times.” And then he told about
+Christmas-eve, when he was decked out with cakes and candles.
+
+“Oh,” said the little Mice, “how fortunate you have been, old Fir Tree!”
+
+“I am by no means old,” said he. “I came from the wood this winter; I am
+in my prime, and am only rather short for my age.”
+
+“What delightful stories you know,” said the Mice: and the next night
+they came with four other little Mice, who were to hear what the Tree
+recounted: and the more he related, the more he remembered himself; and
+it appeared as if those times had really been happy times. “But they may
+still come--they may still come! Humpy-Dumpy fell downstairs, and yet
+he got a princess!” and he thought at the moment of a nice little Birch
+Tree growing out in the woods: to the Fir, that would be a real charming
+princess.
+
+“Who is Humpy-Dumpy?” asked the Mice. So then the Fir Tree told the
+whole fairy tale, for he could remember every single word of it; and the
+little Mice jumped for joy up to the very top of the Tree. Next night
+two more Mice came, and on Sunday two Rats even; but they said the
+stories were not interesting, which vexed the little Mice; and they,
+too, now began to think them not so very amusing either.
+
+“Do you know only one story?” asked the Rats.
+
+“Only that one,” answered the Tree. “I heard it on my happiest evening;
+but I did not then know how happy I was.”
+
+“It is a very stupid story! Don’t you know one about bacon and tallow
+candles? Can’t you tell any larder stories?”
+
+“No,” said the Tree.
+
+“Then good-bye,” said the Rats; and they went home.
+
+At last the little Mice stayed away also; and the Tree sighed: “After
+all, it was very pleasant when the sleek little Mice sat round me, and
+listened to what I told them. Now that too is over. But I will take good
+care to enjoy myself when I am brought out again.”
+
+But when was that to be? Why, one morning there came a quantity of
+people and set to work in the loft. The trunks were moved, the tree was
+pulled out and thrown--rather hard, it is true--down on the floor, but a
+man drew him towards the stairs, where the daylight shone.
+
+“Now a merry life will begin again,” thought the Tree. He felt the fresh
+air, the first sunbeam--and now he was out in the courtyard. All passed
+so quickly, there was so much going on around him, the Tree quite forgot
+to look to himself. The court adjoined a garden, and all was in flower;
+the roses hung so fresh and odorous over the balustrade, the lindens
+were in blossom, the Swallows flew by, and said, “Quirre-vit! My husband
+is come!” but it was not the Fir Tree that they meant.
+
+“Now, then, I shall really enjoy life,” said he exultingly, and spread
+out his branches; but, alas, they were all withered and yellow! It was
+in a corner that he lay, among weeds and nettles. The golden star of
+tinsel was still on the top of the Tree, and glittered in the sunshine.
+
+In the court-yard some of the merry children were playing who had danced
+at Christmas round the Fir Tree, and were so glad at the sight of him.
+One of the youngest ran and tore off the golden star.
+
+“Only look what is still on the ugly old Christmas tree!” said he,
+trampling on the branches, so that they all cracked beneath his feet.
+
+And the Tree beheld all the beauty of the flowers, and the freshness in
+the garden; he beheld himself, and wished he had remained in his dark
+corner in the loft; he thought of his first youth in the wood, of the
+merry Christmas-eve, and of the little Mice who had listened with so
+much pleasure to the story of Humpy-Dumpy.
+
+“‘Tis over--‘tis past!” said the poor Tree. “Had I but rejoiced when I
+had reason to do so! But now ‘tis past, ‘tis past!”
+
+And the gardener’s boy chopped the Tree into small pieces; there was a
+whole heap lying there. The wood flamed up splendidly under the large
+brewing copper, and it sighed so deeply! Each sigh was like a shot.
+
+The boys played about in the court, and the youngest wore the gold star
+on his breast which the Tree had had on the happiest evening of his
+life. However, that was over now--the Tree gone, the story at an end.
+All, all was over--every tale must end at last.
+
+
+
+
+THE SNOW QUEEN
+
+FIRST STORY. Which Treats of a Mirror and of the Splinters
+
+Now then, let us begin. When we are at the end of the story, we shall
+know more than we know now: but to begin.
+
+Once upon a time there was a wicked sprite, indeed he was the most
+mischievous of all sprites. One day he was in a very good humor, for
+he had made a mirror with the power of causing all that was good and
+beautiful when it was reflected therein, to look poor and mean; but
+that which was good-for-nothing and looked ugly was shown magnified
+and increased in ugliness. In this mirror the most beautiful landscapes
+looked like boiled spinach, and the best persons were turned into
+frights, or appeared to stand on their heads; their faces were so
+distorted that they were not to be recognised; and if anyone had a mole,
+you might be sure that it would be magnified and spread over both nose
+and mouth.
+
+“That’s glorious fun!” said the sprite. If a good thought passed through
+a man’s mind, then a grin was seen in the mirror, and the sprite laughed
+heartily at his clever discovery. All the little sprites who went to his
+school--for he kept a sprite school--told each other that a miracle had
+happened; and that now only, as they thought, it would be possible to
+see how the world really looked. They ran about with the mirror; and at
+last there was not a land or a person who was not represented distorted
+in the mirror. So then they thought they would fly up to the sky,
+and have a joke there. The higher they flew with the mirror, the more
+terribly it grinned: they could hardly hold it fast. Higher and higher
+still they flew, nearer and nearer to the stars, when suddenly the
+mirror shook so terribly with grinning, that it flew out of their hands
+and fell to the earth, where it was dashed in a hundred million and more
+pieces. And now it worked much more evil than before; for some of these
+pieces were hardly so large as a grain of sand, and they flew about in
+the wide world, and when they got into people’s eyes, there they stayed;
+and then people saw everything perverted, or only had an eye for that
+which was evil. This happened because the very smallest bit had the
+same power which the whole mirror had possessed. Some persons even got
+a splinter in their heart, and then it made one shudder, for their heart
+became like a lump of ice. Some of the broken pieces were so large that
+they were used for windowpanes, through which one could not see one’s
+friends. Other pieces were put in spectacles; and that was a sad affair
+when people put on their glasses to see well and rightly. Then the
+wicked sprite laughed till he almost choked, for all this tickled his
+fancy. The fine splinters still flew about in the air: and now we shall
+hear what happened next.
+
+
+SECOND STORY. A Little Boy and a Little Girl
+
+In a large town, where there are so many houses, and so many people,
+that there is no roof left for everybody to have a little garden; and
+where, on this account, most persons are obliged to content themselves
+with flowers in pots; there lived two little children, who had a garden
+somewhat larger than a flower-pot. They were not brother and sister; but
+they cared for each other as much as if they were. Their parents lived
+exactly opposite. They inhabited two garrets; and where the roof of the
+one house joined that of the other, and the gutter ran along the extreme
+end of it, there was to each house a small window: one needed only to
+step over the gutter to get from one window to the other.
+
+The children’s parents had large wooden boxes there, in which vegetables
+for the kitchen were planted, and little rosetrees besides: there was a
+rose in each box, and they grew splendidly. They now thought of placing
+the boxes across the gutter, so that they nearly reached from one window
+to the other, and looked just like two walls of flowers. The tendrils
+of the peas hung down over the boxes; and the rose-trees shot up long
+branches, twined round the windows, and then bent towards each other: it
+was almost like a triumphant arch of foliage and flowers. The boxes were
+very high, and the children knew that they must not creep over them; so
+they often obtained permission to get out of the windows to each other,
+and to sit on their little stools among the roses, where they could play
+delightfully. In winter there was an end of this pleasure. The windows
+were often frozen over; but then they heated copper farthings on the
+stove, and laid the hot farthing on the windowpane, and then they had a
+capital peep-hole, quite nicely rounded; and out of each peeped a gentle
+friendly eye--it was the little boy and the little girl who were looking
+out. His name was Kay, hers was Gerda. In summer, with one jump, they
+could get to each other; but in winter they were obliged first to
+go down the long stairs, and then up the long stairs again: and
+out-of-doors there was quite a snow-storm.
+
+“It is the white bees that are swarming,” said Kay’s old grandmother.
+
+“Do the white bees choose a queen?” asked the little boy; for he knew
+that the honey-bees always have one.
+
+“Yes,” said the grandmother, “she flies where the swarm hangs in the
+thickest clusters. She is the largest of all; and she can never remain
+quietly on the earth, but goes up again into the black clouds. Many a
+winter’s night she flies through the streets of the town, and peeps in
+at the windows; and they then freeze in so wondrous a manner that they
+look like flowers.”
+
+“Yes, I have seen it,” said both the children; and so they knew that it
+was true.
+
+“Can the Snow Queen come in?” said the little girl.
+
+“Only let her come in!” said the little boy. “Then I’d put her on the
+stove, and she’d melt.”
+
+And then his grandmother patted his head and told him other stories.
+
+In the evening, when little Kay was at home, and half undressed, he
+climbed up on the chair by the window, and peeped out of the little
+hole. A few snow-flakes were falling, and one, the largest of all,
+remained lying on the edge of a flower-pot.
+
+The flake of snow grew larger and larger; and at last it was like a
+young lady, dressed in the finest white gauze, made of a million little
+flakes like stars. She was so beautiful and delicate, but she was of
+ice, of dazzling, sparkling ice; yet she lived; her eyes gazed fixedly,
+like two stars; but there was neither quiet nor repose in them. She
+nodded towards the window, and beckoned with her hand. The little boy
+was frightened, and jumped down from the chair; it seemed to him as if,
+at the same moment, a large bird flew past the window.
+
+The next day it was a sharp frost--and then the spring came; the sun
+shone, the green leaves appeared, the swallows built their nests, the
+windows were opened, and the little children again sat in their pretty
+garden, high up on the leads at the top of the house.
+
+That summer the roses flowered in unwonted beauty. The little girl had
+learned a hymn, in which there was something about roses; and then she
+thought of her own flowers; and she sang the verse to the little boy,
+who then sang it with her:
+
+     “The rose in the valley is blooming so sweet,
+     And angels descend there the children to greet.”
+
+And the children held each other by the hand, kissed the roses, looked
+up at the clear sunshine, and spoke as though they really saw angels
+there. What lovely summer-days those were! How delightful to be out in
+the air, near the fresh rose-bushes, that seem as if they would never
+finish blossoming!
+
+Kay and Gerda looked at the picture-book full of beasts and of birds;
+and it was then--the clock in the church-tower was just striking
+five--that Kay said, “Oh! I feel such a sharp pain in my heart; and now
+something has got into my eye!”
+
+The little girl put her arms around his neck. He winked his eyes; now
+there was nothing to be seen.
+
+“I think it is out now,” said he; but it was not. It was just one of
+those pieces of glass from the magic mirror that had got into his eye;
+and poor Kay had got another piece right in his heart. It will soon
+become like ice. It did not hurt any longer, but there it was.
+
+“What are you crying for?” asked he. “You look so ugly! There’s nothing
+the matter with me. Ah,” said he at once, “that rose is cankered! And
+look, this one is quite crooked! After all, these roses are very ugly!
+They are just like the box they are planted in!” And then he gave the
+box a good kick with his foot, and pulled both the roses up.
+
+“What are you doing?” cried the little girl; and as he perceived her
+fright, he pulled up another rose, got in at the window, and hastened
+off from dear little Gerda.
+
+Afterwards, when she brought her picture-book, he asked, “What horrid
+beasts have you there?” And if his grandmother told them stories, he
+always interrupted her; besides, if he could manage it, he would get
+behind her, put on her spectacles, and imitate her way of speaking; he
+copied all her ways, and then everybody laughed at him. He was soon able
+to imitate the gait and manner of everyone in the street. Everything
+that was peculiar and displeasing in them--that Kay knew how to imitate:
+and at such times all the people said, “The boy is certainly very
+clever!” But it was the glass he had got in his eye; the glass that was
+sticking in his heart, which made him tease even little Gerda, whose
+whole soul was devoted to him.
+
+His games now were quite different to what they had formerly been, they
+were so very knowing. One winter’s day, when the flakes of snow were
+flying about, he spread the skirts of his blue coat, and caught the snow
+as it fell.
+
+“Look through this glass, Gerda,” said he. And every flake seemed
+larger, and appeared like a magnificent flower, or beautiful star; it
+was splendid to look at!
+
+“Look, how clever!” said Kay. “That’s much more interesting than real
+flowers! They are as exact as possible; there is not a fault in them, if
+they did not melt!”
+
+It was not long after this, that Kay came one day with large gloves on,
+and his little sledge at his back, and bawled right into Gerda’s ears,
+“I have permission to go out into the square where the others are
+playing”; and off he was in a moment.
+
+There, in the market-place, some of the boldest of the boys used to tie
+their sledges to the carts as they passed by, and so they were pulled
+along, and got a good ride. It was so capital! Just as they were in the
+very height of their amusement, a large sledge passed by: it was painted
+quite white, and there was someone in it wrapped up in a rough white
+mantle of fur, with a rough white fur cap on his head. The sledge drove
+round the square twice, and Kay tied on his sledge as quickly as he
+could, and off he drove with it. On they went quicker and quicker into
+the next street; and the person who drove turned round to Kay, and
+nodded to him in a friendly manner, just as if they knew each other.
+Every time he was going to untie his sledge, the person nodded to him,
+and then Kay sat quiet; and so on they went till they came outside
+the gates of the town. Then the snow began to fall so thickly that the
+little boy could not see an arm’s length before him, but still on he
+went: when suddenly he let go the string he held in his hand in order
+to get loose from the sledge, but it was of no use; still the little
+vehicle rushed on with the quickness of the wind. He then cried as loud
+as he could, but no one heard him; the snow drifted and the sledge flew
+on, and sometimes it gave a jerk as though they were driving over hedges
+and ditches. He was quite frightened, and he tried to repeat the
+Lord’s Prayer; but all he could do, he was only able to remember the
+multiplication table.
+
+The snow-flakes grew larger and larger, till at last they looked just
+like great white fowls. Suddenly they flew on one side; the large sledge
+stopped, and the person who drove rose up. It was a lady; her cloak and
+cap were of snow. She was tall and of slender figure, and of a dazzling
+whiteness. It was the Snow Queen.
+
+“We have travelled fast,” said she; “but it is freezingly cold. Come
+under my bearskin.” And she put him in the sledge beside her,
+wrapped the fur round him, and he felt as though he were sinking in a
+snow-wreath.
+
+“Are you still cold?” asked she; and then she kissed his forehead.
+Ah! it was colder than ice; it penetrated to his very heart, which was
+already almost a frozen lump; it seemed to him as if he were about to
+die--but a moment more and it was quite congenial to him, and he did not
+remark the cold that was around him.
+
+“My sledge! Do not forget my sledge!” It was the first thing he thought
+of. It was there tied to one of the white chickens, who flew along with
+it on his back behind the large sledge. The Snow Queen kissed Kay once
+more, and then he forgot little Gerda, grandmother, and all whom he had
+left at his home.
+
+“Now you will have no more kisses,” said she, “or else I should kiss you
+to death!”
+
+Kay looked at her. She was very beautiful; a more clever, or a more
+lovely countenance he could not fancy to himself; and she no longer
+appeared of ice as before, when she sat outside the window, and beckoned
+to him; in his eyes she was perfect, he did not fear her at all, and
+told her that he could calculate in his head and with fractions, even;
+that he knew the number of square miles there were in the different
+countries, and how many inhabitants they contained; and she smiled while
+he spoke. It then seemed to him as if what he knew was not enough, and
+he looked upwards in the large huge empty space above him, and on she
+flew with him; flew high over the black clouds, while the storm moaned
+and whistled as though it were singing some old tune. On they flew
+over woods and lakes, over seas, and many lands; and beneath them the
+chilling storm rushed fast, the wolves howled, the snow crackled; above
+them flew large screaming crows, but higher up appeared the moon, quite
+large and bright; and it was on it that Kay gazed during the long long
+winter’s night; while by day he slept at the feet of the Snow Queen.
+
+
+THIRD STORY. Of the Flower-Garden At the Old Woman’s Who Understood
+Witchcraft
+
+But what became of little Gerda when Kay did not return? Where could he
+be? Nobody knew; nobody could give any intelligence. All the boys knew
+was, that they had seen him tie his sledge to another large and splendid
+one, which drove down the street and out of the town. Nobody knew
+where he was; many sad tears were shed, and little Gerda wept long and
+bitterly; at last she said he must be dead; that he had been drowned in
+the river which flowed close to the town. Oh! those were very long and
+dismal winter evenings!
+
+At last spring came, with its warm sunshine.
+
+“Kay is dead and gone!” said little Gerda.
+
+“That I don’t believe,” said the Sunshine.
+
+“Kay is dead and gone!” said she to the Swallows.
+
+“That I don’t believe,” said they: and at last little Gerda did not
+think so any longer either.
+
+“I’ll put on my red shoes,” said she, one morning; “Kay has never seen
+them, and then I’ll go down to the river and ask there.”
+
+It was quite early; she kissed her old grandmother, who was still
+asleep, put on her red shoes, and went alone to the river.
+
+“Is it true that you have taken my little playfellow? I will make you a
+present of my red shoes, if you will give him back to me.”
+
+And, as it seemed to her, the blue waves nodded in a strange manner;
+then she took off her red shoes, the most precious things she possessed,
+and threw them both into the river. But they fell close to the bank, and
+the little waves bore them immediately to land; it was as if the stream
+would not take what was dearest to her; for in reality it had not got
+little Kay; but Gerda thought that she had not thrown the shoes out far
+enough, so she clambered into a boat which lay among the rushes, went
+to the farthest end, and threw out the shoes. But the boat was not
+fastened, and the motion which she occasioned, made it drift from the
+shore. She observed this, and hastened to get back; but before she could
+do so, the boat was more than a yard from the land, and was gliding
+quickly onward.
+
+Little Gerda was very frightened, and began to cry; but no one heard her
+except the sparrows, and they could not carry her to land; but they flew
+along the bank, and sang as if to comfort her, “Here we are! Here we
+are!” The boat drifted with the stream, little Gerda sat quite still
+without shoes, for they were swimming behind the boat, but she could not
+reach them, because the boat went much faster than they did.
+
+The banks on both sides were beautiful; lovely flowers, venerable trees,
+and slopes with sheep and cows, but not a human being was to be seen.
+
+“Perhaps the river will carry me to little Kay,” said she; and then
+she grew less sad. She rose, and looked for many hours at the beautiful
+green banks. Presently she sailed by a large cherry-orchard, where was
+a little cottage with curious red and blue windows; it was thatched,
+and before it two wooden soldiers stood sentry, and presented arms when
+anyone went past.
+
+Gerda called to them, for she thought they were alive; but they, of
+course, did not answer. She came close to them, for the stream drifted
+the boat quite near the land.
+
+Gerda called still louder, and an old woman then came out of the
+cottage, leaning upon a crooked stick. She had a large broad-brimmed hat
+on, painted with the most splendid flowers.
+
+“Poor little child!” said the old woman. “How did you get upon the large
+rapid river, to be driven about so in the wide world!” And then the
+old woman went into the water, caught hold of the boat with her crooked
+stick, drew it to the bank, and lifted little Gerda out.
+
+And Gerda was so glad to be on dry land again; but she was rather afraid
+of the strange old woman.
+
+“But come and tell me who you are, and how you came here,” said she.
+
+And Gerda told her all; and the old woman shook her head and said,
+“A-hem! a-hem!” and when Gerda had told her everything, and asked her if
+she had not seen little Kay, the woman answered that he had not passed
+there, but he no doubt would come; and she told her not to be cast down,
+but taste her cherries, and look at her flowers, which were finer than
+any in a picture-book, each of which could tell a whole story. She then
+took Gerda by the hand, led her into the little cottage, and locked the
+door.
+
+The windows were very high up; the glass was red, blue, and green, and
+the sunlight shone through quite wondrously in all sorts of colors. On
+the table stood the most exquisite cherries, and Gerda ate as many as
+she chose, for she had permission to do so. While she was eating, the
+old woman combed her hair with a golden comb, and her hair curled and
+shone with a lovely golden color around that sweet little face, which
+was so round and so like a rose.
+
+“I have often longed for such a dear little girl,” said the old woman.
+“Now you shall see how well we agree together”; and while she combed
+little Gerda’s hair, the child forgot her foster-brother Kay more and
+more, for the old woman understood magic; but she was no evil being, she
+only practised witchcraft a little for her own private amusement, and
+now she wanted very much to keep little Gerda. She therefore went out
+in the garden, stretched out her crooked stick towards the rose-bushes,
+which, beautifully as they were blowing, all sank into the earth and no
+one could tell where they had stood. The old woman feared that if Gerda
+should see the roses, she would then think of her own, would remember
+little Kay, and run away from her.
+
+She now led Gerda into the flower-garden. Oh, what odour and what
+loveliness was there! Every flower that one could think of, and of every
+season, stood there in fullest bloom; no picture-book could be gayer or
+more beautiful. Gerda jumped for joy, and played till the sun set behind
+the tall cherry-tree; she then had a pretty bed, with a red silken
+coverlet filled with blue violets. She fell asleep, and had as pleasant
+dreams as ever a queen on her wedding-day.
+
+The next morning she went to play with the flowers in the warm sunshine,
+and thus passed away a day. Gerda knew every flower; and, numerous as
+they were, it still seemed to Gerda that one was wanting, though she
+did not know which. One day while she was looking at the hat of the old
+woman painted with flowers, the most beautiful of them all seemed to her
+to be a rose. The old woman had forgotten to take it from her hat
+when she made the others vanish in the earth. But so it is when one’s
+thoughts are not collected. “What!” said Gerda. “Are there no roses
+here?” and she ran about amongst the flowerbeds, and looked, and looked,
+but there was not one to be found. She then sat down and wept; but her
+hot tears fell just where a rose-bush had sunk; and when her warm tears
+watered the ground, the tree shot up suddenly as fresh and blooming as
+when it had been swallowed up. Gerda kissed the roses, thought of her
+own dear roses at home, and with them of little Kay.
+
+“Oh, how long I have stayed!” said the little girl. “I intended to look
+for Kay! Don’t you know where he is?” she asked of the roses. “Do you
+think he is dead and gone?”
+
+“Dead he certainly is not,” said the Roses. “We have been in the earth
+where all the dead are, but Kay was not there.”
+
+“Many thanks!” said little Gerda; and she went to the other flowers,
+looked into their cups, and asked, “Don’t you know where little Kay is?”
+
+But every flower stood in the sunshine, and dreamed its own fairy tale
+or its own story: and they all told her very many things, but not one
+knew anything of Kay.
+
+Well, what did the Tiger-Lily say?
+
+“Hearest thou not the drum? Bum! Bum! Those are the only two tones.
+Always bum! Bum! Hark to the plaintive song of the old woman, to the
+call of the priests! The Hindoo woman in her long robe stands upon the
+funeral pile; the flames rise around her and her dead husband, but the
+Hindoo woman thinks on the living one in the surrounding circle; on him
+whose eyes burn hotter than the flames--on him, the fire of whose eyes
+pierces her heart more than the flames which soon will burn her body to
+ashes. Can the heart’s flame die in the flame of the funeral pile?”
+
+“I don’t understand that at all,” said little Gerda.
+
+“That is my story,” said the Lily.
+
+What did the Convolvulus say?
+
+“Projecting over a narrow mountain-path there hangs an old feudal
+castle. Thick evergreens grow on the dilapidated walls, and around the
+altar, where a lovely maiden is standing: she bends over the railing and
+looks out upon the rose. No fresher rose hangs on the branches than she;
+no appleblossom carried away by the wind is more buoyant! How her silken
+robe is rustling!
+
+“‘Is he not yet come?’”
+
+“Is it Kay that you mean?” asked little Gerda.
+
+“I am speaking about my story--about my dream,” answered the
+Convolvulus.
+
+What did the Snowdrops say?
+
+“Between the trees a long board is hanging--it is a swing. Two little
+girls are sitting in it, and swing themselves backwards and forwards;
+their frocks are as white as snow, and long green silk ribands flutter
+from their bonnets. Their brother, who is older than they are, stands up
+in the swing; he twines his arms round the cords to hold himself fast,
+for in one hand he has a little cup, and in the other a clay-pipe. He is
+blowing soap-bubbles. The swing moves, and the bubbles float in charming
+changing colors: the last is still hanging to the end of the pipe, and
+rocks in the breeze. The swing moves. The little black dog, as light as
+a soap-bubble, jumps up on his hind legs to try to get into the swing.
+It moves, the dog falls down, barks, and is angry. They tease him; the
+bubble bursts! A swing, a bursting bubble--such is my song!”
+
+“What you relate may be very pretty, but you tell it in so melancholy a
+manner, and do not mention Kay.”
+
+What do the Hyacinths say?
+
+“There were once upon a time three sisters, quite transparent, and very
+beautiful. The robe of the one was red, that of the second blue, and
+that of the third white. They danced hand in hand beside the calm
+lake in the clear moonshine. They were not elfin maidens, but mortal
+children. A sweet fragrance was smelt, and the maidens vanished in the
+wood; the fragrance grew stronger--three coffins, and in them three
+lovely maidens, glided out of the forest and across the lake: the
+shining glow-worms flew around like little floating lights. Do the
+dancing maidens sleep, or are they dead? The odour of the flowers says
+they are corpses; the evening bell tolls for the dead!”
+
+“You make me quite sad,” said little Gerda. “I cannot help thinking of
+the dead maidens. Oh! is little Kay really dead? The Roses have been in
+the earth, and they say no.”
+
+“Ding, dong!” sounded the Hyacinth bells. “We do not toll for little
+Kay; we do not know him. That is our way of singing, the only one we
+have.”
+
+And Gerda went to the Ranunculuses, that looked forth from among the
+shining green leaves.
+
+“You are a little bright sun!” said Gerda. “Tell me if you know where I
+can find my playfellow.”
+
+And the Ranunculus shone brightly, and looked again at Gerda. What
+song could the Ranunculus sing? It was one that said nothing about Kay
+either.
+
+“In a small court the bright sun was shining in the first days of
+spring. The beams glided down the white walls of a neighbor’s house, and
+close by the fresh yellow flowers were growing, shining like gold in
+the warm sun-rays. An old grandmother was sitting in the air; her
+grand-daughter, the poor and lovely servant just come for a short visit.
+She knows her grandmother. There was gold, pure virgin gold in that
+blessed kiss. There, that is my little story,” said the Ranunculus.
+
+“My poor old grandmother!” sighed Gerda. “Yes, she is longing for me,
+no doubt: she is sorrowing for me, as she did for little Kay. But I
+will soon come home, and then I will bring Kay with me. It is of no use
+asking the flowers; they only know their own old rhymes, and can tell me
+nothing.” And she tucked up her frock, to enable her to run quicker; but
+the Narcissus gave her a knock on the leg, just as she was going to
+jump over it. So she stood still, looked at the long yellow flower, and
+asked, “You perhaps know something?” and she bent down to the Narcissus.
+And what did it say?
+
+“I can see myself--I can see myself! Oh, how odorous I am! Up in the
+little garret there stands, half-dressed, a little Dancer. She stands
+now on one leg, now on both; she despises the whole world; yet she lives
+only in imagination. She pours water out of the teapot over a piece of
+stuff which she holds in her hand; it is the bodice; cleanliness is a
+fine thing. The white dress is hanging on the hook; it was washed in the
+teapot, and dried on the roof. She puts it on, ties a saffron-colored
+kerchief round her neck, and then the gown looks whiter. I can see
+myself--I can see myself!”
+
+“That’s nothing to me,” said little Gerda. “That does not concern me.”
+ And then off she ran to the further end of the garden.
+
+The gate was locked, but she shook the rusted bolt till it was loosened,
+and the gate opened; and little Gerda ran off barefooted into the wide
+world. She looked round her thrice, but no one followed her. At last she
+could run no longer; she sat down on a large stone, and when she looked
+about her, she saw that the summer had passed; it was late in the
+autumn, but that one could not remark in the beautiful garden, where
+there was always sunshine, and where there were flowers the whole year
+round.
+
+“Dear me, how long I have staid!” said Gerda. “Autumn is come. I must
+not rest any longer.” And she got up to go further.
+
+Oh, how tender and wearied her little feet were! All around it looked
+so cold and raw: the long willow-leaves were quite yellow, and the fog
+dripped from them like water; one leaf fell after the other: the sloes
+only stood full of fruit, which set one’s teeth on edge. Oh, how dark
+and comfortless it was in the dreary world!
+
+
+FOURTH STORY. The Prince and Princess
+
+Gerda was obliged to rest herself again, when, exactly opposite to her,
+a large Raven came hopping over the white snow. He had long been looking
+at Gerda and shaking his head; and now he said, “Caw! Caw!” Good day!
+Good day! He could not say it better; but he felt a sympathy for the
+little girl, and asked her where she was going all alone. The word
+“alone” Gerda understood quite well, and felt how much was expressed
+by it; so she told the Raven her whole history, and asked if he had not
+seen Kay.
+
+The Raven nodded very gravely, and said, “It may be--it may be!”
+
+“What, do you really think so?” cried the little girl; and she nearly
+squeezed the Raven to death, so much did she kiss him.
+
+“Gently, gently,” said the Raven. “I think I know; I think that it may
+be little Kay. But now he has forgotten you for the Princess.”
+
+“Does he live with a Princess?” asked Gerda.
+
+“Yes--listen,” said the Raven; “but it will be difficult for me to
+speak your language. If you understand the Raven language I can tell you
+better.”
+
+“No, I have not learnt it,” said Gerda; “but my grandmother understands
+it, and she can speak gibberish too. I wish I had learnt it.”
+
+“No matter,” said the Raven; “I will tell you as well as I can; however,
+it will be bad enough.” And then he told all he knew.
+
+“In the kingdom where we now are there lives a Princess, who is
+extraordinarily clever; for she has read all the newspapers in the whole
+world, and has forgotten them again--so clever is she. She was lately,
+it is said, sitting on her throne--which is not very amusing after
+all--when she began humming an old tune, and it was just, ‘Oh, why
+should I not be married?’ ‘That song is not without its meaning,’ said
+she, and so then she was determined to marry; but she would have a
+husband who knew how to give an answer when he was spoken to--not
+one who looked only as if he were a great personage, for that is so
+tiresome. She then had all the ladies of the court drummed together; and
+when they heard her intention, all were very pleased, and said, ‘We are
+very glad to hear it; it is the very thing we were thinking of.’ You may
+believe every word I say,” said the Raven; “for I have a tame sweetheart
+that hops about in the palace quite free, and it was she who told me all
+this.
+
+“The newspapers appeared forthwith with a border of hearts and the
+initials of the Princess; and therein you might read that every
+good-looking young man was at liberty to come to the palace and speak to
+the Princess; and he who spoke in such wise as showed he felt himself at
+home there, that one the Princess would choose for her husband.
+
+“Yes, Yes,” said the Raven, “you may believe it; it is as true as I am
+sitting here. People came in crowds; there was a crush and a hurry, but
+no one was successful either on the first or second day. They could all
+talk well enough when they were out in the street; but as soon as
+they came inside the palace gates, and saw the guard richly dressed
+in silver, and the lackeys in gold on the staircase, and the large
+illuminated saloons, then they were abashed; and when they stood before
+the throne on which the Princess was sitting, all they could do was
+to repeat the last word they had uttered, and to hear it again did not
+interest her very much. It was just as if the people within were under
+a charm, and had fallen into a trance till they came out again into the
+street; for then--oh, then--they could chatter enough. There was a whole
+row of them standing from the town-gates to the palace. I was there
+myself to look,” said the Raven. “They grew hungry and thirsty; but from
+the palace they got nothing whatever, not even a glass of water. Some
+of the cleverest, it is true, had taken bread and butter with them:
+but none shared it with his neighbor, for each thought, ‘Let him look
+hungry, and then the Princess won’t have him.’”
+
+“But Kay--little Kay,” said Gerda, “when did he come? Was he among the
+number?”
+
+“Patience, patience; we are just come to him. It was on the third day
+when a little personage without horse or equipage, came marching right
+boldly up to the palace; his eyes shone like yours, he had beautiful
+long hair, but his clothes were very shabby.”
+
+“That was Kay,” cried Gerda, with a voice of delight. “Oh, now I’ve
+found him!” and she clapped her hands for joy.
+
+“He had a little knapsack at his back,” said the Raven.
+
+“No, that was certainly his sledge,” said Gerda; “for when he went away
+he took his sledge with him.”
+
+“That may be,” said the Raven; “I did not examine him so minutely; but
+I know from my tame sweetheart, that when he came into the court-yard
+of the palace, and saw the body-guard in silver, the lackeys on the
+staircase, he was not the least abashed; he nodded, and said to them,
+‘It must be very tiresome to stand on the stairs; for my part, I shall
+go in.’ The saloons were gleaming with lustres--privy councillors and
+excellencies were walking about barefooted, and wore gold keys; it was
+enough to make any one feel uncomfortable. His boots creaked, too, so
+loudly, but still he was not at all afraid.”
+
+“That’s Kay for certain,” said Gerda. “I know he had on new boots; I
+have heard them creaking in grandmama’s room.”
+
+“Yes, they creaked,” said the Raven. “And on he went boldly up to the
+Princess, who was sitting on a pearl as large as a spinning-wheel.
+All the ladies of the court, with their attendants and attendants’
+attendants, and all the cavaliers, with their gentlemen and gentlemen’s
+gentlemen, stood round; and the nearer they stood to the door, the
+prouder they looked. It was hardly possible to look at the gentleman’s
+gentleman, so very haughtily did he stand in the doorway.”
+
+“It must have been terrible,” said little Gerda. “And did Kay get the
+Princess?”
+
+“Were I not a Raven, I should have taken the Princess myself, although
+I am promised. It is said he spoke as well as I speak when I talk Raven
+language; this I learned from my tame sweetheart. He was bold and nicely
+behaved; he had not come to woo the Princess, but only to hear her
+wisdom. She pleased him, and he pleased her.”
+
+“Yes, yes; for certain that was Kay,” said Gerda. “He was so clever;
+he could reckon fractions in his head. Oh, won’t you take me to the
+palace?”
+
+“That is very easily said,” answered the Raven. “But how are we to
+manage it? I’ll speak to my tame sweetheart about it: she must advise
+us; for so much I must tell you, such a little girl as you are will
+never get permission to enter.”
+
+“Oh, yes I shall,” said Gerda; “when Kay hears that I am here, he will
+come out directly to fetch me.”
+
+“Wait for me here on these steps,” said the Raven. He moved his head
+backwards and forwards and flew away.
+
+The evening was closing in when the Raven returned. “Caw--caw!” said he.
+“She sends you her compliments; and here is a roll for you. She took
+it out of the kitchen, where there is bread enough. You are hungry,
+no doubt. It is not possible for you to enter the palace, for you are
+barefooted: the guards in silver, and the lackeys in gold, would not
+allow it; but do not cry, you shall come in still. My sweetheart knows a
+little back stair that leads to the bedchamber, and she knows where she
+can get the key of it.”
+
+And they went into the garden in the large avenue, where one leaf was
+falling after the other; and when the lights in the palace had all
+gradually disappeared, the Raven led little Gerda to the back door,
+which stood half open.
+
+Oh, how Gerda’s heart beat with anxiety and longing! It was just as if
+she had been about to do something wrong; and yet she only wanted to
+know if little Kay was there. Yes, he must be there. She called to mind
+his intelligent eyes, and his long hair, so vividly, she could quite see
+him as he used to laugh when they were sitting under the roses at home.
+“He will, no doubt, be glad to see you--to hear what a long way you have
+come for his sake; to know how unhappy all at home were when he did not
+come back.”
+
+Oh, what a fright and a joy it was!
+
+They were now on the stairs. A single lamp was burning there; and on the
+floor stood the tame Raven, turning her head on every side and looking
+at Gerda, who bowed as her grandmother had taught her to do.
+
+“My intended has told me so much good of you, my dear young lady,” said
+the tame Raven. “Your tale is very affecting. If you will take the lamp,
+I will go before. We will go straight on, for we shall meet no one.”
+
+“I think there is somebody just behind us,” said Gerda; and something
+rushed past: it was like shadowy figures on the wall; horses with
+flowing manes and thin legs, huntsmen, ladies and gentlemen on
+horseback.
+
+“They are only dreams,” said the Raven. “They come to fetch the thoughts
+of the high personages to the chase; ‘tis well, for now you can observe
+them in bed all the better. But let me find, when you enjoy honor and
+distinction, that you possess a grateful heart.”
+
+“Tut! That’s not worth talking about,” said the Raven of the woods.
+
+They now entered the first saloon, which was of rose-colored satin, with
+artificial flowers on the wall. Here the dreams were rushing past,
+but they hastened by so quickly that Gerda could not see the high
+personages. One hall was more magnificent than the other; one might
+indeed well be abashed; and at last they came into the bedchamber. The
+ceiling of the room resembled a large palm-tree with leaves of glass,
+of costly glass; and in the middle, from a thick golden stem, hung two
+beds, each of which resembled a lily. One was white, and in this lay the
+Princess; the other was red, and it was here that Gerda was to look for
+little Kay. She bent back one of the red leaves, and saw a brown neck.
+Oh! that was Kay! She called him quite loud by name, held the lamp
+towards him--the dreams rushed back again into the chamber--he awoke,
+turned his head, and--it was not little Kay!
+
+The Prince was only like him about the neck; but he was young and
+handsome. And out of the white lily leaves the Princess peeped, too,
+and asked what was the matter. Then little Gerda cried, and told her her
+whole history, and all that the Ravens had done for her.
+
+“Poor little thing!” said the Prince and the Princess. They praised the
+Ravens very much, and told them they were not at all angry with them,
+but they were not to do so again. However, they should have a reward.
+“Will you fly about here at liberty,” asked the Princess; “or would you
+like to have a fixed appointment as court ravens, with all the broken
+bits from the kitchen?”
+
+And both the Ravens nodded, and begged for a fixed appointment; for
+they thought of their old age, and said, “It is a good thing to have a
+provision for our old days.”
+
+And the Prince got up and let Gerda sleep in his bed, and more than this
+he could not do. She folded her little hands and thought, “How good men
+and animals are!” and she then fell asleep and slept soundly. All the
+dreams flew in again, and they now looked like the angels; they drew
+a little sledge, in which little Kay sat and nodded his head; but the
+whole was only a dream, and therefore it all vanished as soon as she
+awoke.
+
+The next day she was dressed from head to foot in silk and velvet. They
+offered to let her stay at the palace, and lead a happy life; but she
+begged to have a little carriage with a horse in front, and for a small
+pair of shoes; then, she said, she would again go forth in the wide
+world and look for Kay.
+
+Shoes and a muff were given her; she was, too, dressed very nicely; and
+when she was about to set off, a new carriage stopped before the door.
+It was of pure gold, and the arms of the Prince and Princess shone
+like a star upon it; the coachman, the footmen, and the outriders, for
+outriders were there, too, all wore golden crowns. The Prince and the
+Princess assisted her into the carriage themselves, and wished her all
+success. The Raven of the woods, who was now married, accompanied her
+for the first three miles. He sat beside Gerda, for he could not bear
+riding backwards; the other Raven stood in the doorway, and flapped her
+wings; she could not accompany Gerda, because she suffered from headache
+since she had had a fixed appointment and ate so much. The carriage
+was lined inside with sugar-plums, and in the seats were fruits and
+gingerbread.
+
+“Farewell! Farewell!” cried Prince and Princess; and Gerda wept, and
+the Raven wept. Thus passed the first miles; and then the Raven bade her
+farewell, and this was the most painful separation of all. He flew into
+a tree, and beat his black wings as long as he could see the carriage,
+that shone from afar like a sunbeam.
+
+
+FIFTH STORY. The Little Robber Maiden
+
+They drove through the dark wood; but the carriage shone like a torch,
+and it dazzled the eyes of the robbers, so that they could not bear to
+look at it.
+
+“‘Tis gold! ‘Tis gold!” they cried; and they rushed forward, seized
+the horses, knocked down the little postilion, the coachman, and the
+servants, and pulled little Gerda out of the carriage.
+
+“How plump, how beautiful she is! She must have been fed on
+nut-kernels,” said the old female robber, who had a long, scrubby beard,
+and bushy eyebrows that hung down over her eyes. “She is as good as a
+fatted lamb! How nice she will be!” And then she drew out a knife, the
+blade of which shone so that it was quite dreadful to behold.
+
+“Oh!” cried the woman at the same moment. She had been bitten in the ear
+by her own little daughter, who hung at her back; and who was so wild
+and unmanageable, that it was quite amusing to see her. “You naughty
+child!” said the mother: and now she had not time to kill Gerda.
+
+“She shall play with me,” said the little robber child. “She shall give
+me her muff, and her pretty frock; she shall sleep in my bed!” And then
+she gave her mother another bite, so that she jumped, and ran round with
+the pain; and the Robbers laughed, and said, “Look, how she is dancing
+with the little one!”
+
+“I will go into the carriage,” said the little robber maiden; and she
+would have her will, for she was very spoiled and very headstrong. She
+and Gerda got in; and then away they drove over the stumps of felled
+trees, deeper and deeper into the woods. The little robber maiden was as
+tall as Gerda, but stronger, broader-shouldered, and of dark complexion;
+her eyes were quite black; they looked almost melancholy. She embraced
+little Gerda, and said, “They shall not kill you as long as I am not
+displeased with you. You are, doubtless, a Princess?”
+
+“No,” said little Gerda; who then related all that had happened to her,
+and how much she cared about little Kay.
+
+The little robber maiden looked at her with a serious air, nodded her
+head slightly, and said, “They shall not kill you, even if I am angry
+with you: then I will do it myself”; and she dried Gerda’s eyes, and put
+both her hands in the handsome muff, which was so soft and warm.
+
+At length the carriage stopped. They were in the midst of the court-yard
+of a robber’s castle. It was full of cracks from top to bottom; and out
+of the openings magpies and rooks were flying; and the great bull-dogs,
+each of which looked as if he could swallow a man, jumped up, but they
+did not bark, for that was forbidden.
+
+In the midst of the large, old, smoking hall burnt a great fire on the
+stone floor. The smoke disappeared under the stones, and had to seek
+its own egress. In an immense caldron soup was boiling; and rabbits and
+hares were being roasted on a spit.
+
+“You shall sleep with me to-night, with all my animals,” said the little
+robber maiden. They had something to eat and drink; and then went into
+a corner, where straw and carpets were lying. Beside them, on laths and
+perches, sat nearly a hundred pigeons, all asleep, seemingly; but yet
+they moved a little when the robber maiden came. “They are all mine,”
+ said she, at the same time seizing one that was next to her by the legs
+and shaking it so that its wings fluttered. “Kiss it,” cried the little
+girl, and flung the pigeon in Gerda’s face. “Up there is the rabble of
+the wood,” continued she, pointing to several laths which were fastened
+before a hole high up in the wall; “that’s the rabble; they would all
+fly away immediately, if they were not well fastened in. And here is my
+dear old Bac”; and she laid hold of the horns of a reindeer, that had a
+bright copper ring round its neck, and was tethered to the spot. “We are
+obliged to lock this fellow in too, or he would make his escape. Every
+evening I tickle his neck with my sharp knife; he is so frightened at
+it!” and the little girl drew forth a long knife, from a crack in the
+wall, and let it glide over the Reindeer’s neck. The poor animal kicked;
+the girl laughed, and pulled Gerda into bed with her.
+
+“Do you intend to keep your knife while you sleep?” asked Gerda; looking
+at it rather fearfully.
+
+“I always sleep with the knife,” said the little robber maiden. “There
+is no knowing what may happen. But tell me now, once more, all about
+little Kay; and why you have started off in the wide world alone.” And
+Gerda related all, from the very beginning: the Wood-pigeons cooed above
+in their cage, and the others slept. The little robber maiden wound her
+arm round Gerda’s neck, held the knife in the other hand, and snored so
+loud that everybody could hear her; but Gerda could not close her eyes,
+for she did not know whether she was to live or die. The robbers sat
+round the fire, sang and drank; and the old female robber jumped about
+so, that it was quite dreadful for Gerda to see her.
+
+Then the Wood-pigeons said, “Coo! Coo! We have seen little Kay! A white
+hen carries his sledge; he himself sat in the carriage of the Snow
+Queen, who passed here, down just over the wood, as we lay in our nest.
+She blew upon us young ones; and all died except we two. Coo! Coo!”
+
+“What is that you say up there?” cried little Gerda. “Where did the Snow
+Queen go to? Do you know anything about it?”
+
+“She is no doubt gone to Lapland; for there is always snow and ice
+there. Only ask the Reindeer, who is tethered there.”
+
+“Ice and snow is there! There it is, glorious and beautiful!” said the
+Reindeer. “One can spring about in the large shining valleys! The Snow
+Queen has her summer-tent there; but her fixed abode is high up towards
+the North Pole, on the Island called Spitzbergen.”
+
+“Oh, Kay! Poor little Kay!” sighed Gerda.
+
+“Do you choose to be quiet?” said the robber maiden. “If you don’t, I
+shall make you.”
+
+In the morning Gerda told her all that the Wood-pigeons had said; and
+the little maiden looked very serious, but she nodded her head, and
+said, “That’s no matter--that’s no matter. Do you know where Lapland
+lies!” she asked of the Reindeer.
+
+“Who should know better than I?” said the animal; and his eyes rolled in
+his head. “I was born and bred there--there I leapt about on the fields
+of snow.”
+
+“Listen,” said the robber maiden to Gerda. “You see that the men are
+gone; but my mother is still here, and will remain. However, towards
+morning she takes a draught out of the large flask, and then she sleeps
+a little: then I will do something for you.” She now jumped out of bed,
+flew to her mother; with her arms round her neck, and pulling her by the
+beard, said, “Good morrow, my own sweet nanny-goat of a mother.” And her
+mother took hold of her nose, and pinched it till it was red and blue;
+but this was all done out of pure love.
+
+When the mother had taken a sup at her flask, and was having a nap, the
+little robber maiden went to the Reindeer, and said, “I should very much
+like to give you still many a tickling with the sharp knife, for then
+you are so amusing; however, I will untether you, and help you out,
+so that you may go back to Lapland. But you must make good use of your
+legs; and take this little girl for me to the palace of the Snow Queen,
+where her playfellow is. You have heard, I suppose, all she said; for
+she spoke loud enough, and you were listening.”
+
+The Reindeer gave a bound for joy. The robber maiden lifted up little
+Gerda, and took the precaution to bind her fast on the Reindeer’s back;
+she even gave her a small cushion to sit on. “Here are your worsted
+leggins, for it will be cold; but the muff I shall keep for myself, for
+it is so very pretty. But I do not wish you to be cold. Here is a pair
+of lined gloves of my mother’s; they just reach up to your elbow. On
+with them! Now you look about the hands just like my ugly old mother!”
+
+And Gerda wept for joy.
+
+“I can’t bear to see you fretting,” said the little robber maiden. “This
+is just the time when you ought to look pleased. Here are two loaves and
+a ham for you, so that you won’t starve.” The bread and the meat were
+fastened to the Reindeer’s back; the little maiden opened the door,
+called in all the dogs, and then with her knife cut the rope that
+fastened the animal, and said to him, “Now, off with you; but take good
+care of the little girl!”
+
+And Gerda stretched out her hands with the large wadded gloves towards
+the robber maiden, and said, “Farewell!” and the Reindeer flew on over
+bush and bramble through the great wood, over moor and heath, as fast as
+he could go.
+
+“Ddsa! Ddsa!” was heard in the sky. It was just as if somebody was
+sneezing.
+
+“These are my old northern-lights,” said the Reindeer, “look how they
+gleam!” And on he now sped still quicker--day and night on he went: the
+loaves were consumed, and the ham too; and now they were in Lapland.
+
+
+SIXTH STORY. The Lapland Woman and the Finland Woman
+
+Suddenly they stopped before a little house, which looked very
+miserable. The roof reached to the ground; and the door was so low, that
+the family were obliged to creep upon their stomachs when they went in
+or out. Nobody was at home except an old Lapland woman, who was dressing
+fish by the light of an oil lamp. And the Reindeer told her the whole
+of Gerda’s history, but first of all his own; for that seemed to him of
+much greater importance. Gerda was so chilled that she could not speak.
+
+“Poor thing,” said the Lapland woman, “you have far to run still. You
+have more than a hundred miles to go before you get to Finland; there
+the Snow Queen has her country-house, and burns blue lights every
+evening. I will give you a few words from me, which I will write on a
+dried haberdine, for paper I have none; this you can take with you to
+the Finland woman, and she will be able to give you more information
+than I can.”
+
+When Gerda had warmed herself, and had eaten and drunk, the Lapland
+woman wrote a few words on a dried haberdine, begged Gerda to take care
+of them, put her on the Reindeer, bound her fast, and away sprang the
+animal. “Ddsa! Ddsa!” was again heard in the air; the most charming
+blue lights burned the whole night in the sky, and at last they came to
+Finland. They knocked at the chimney of the Finland woman; for as to a
+door, she had none.
+
+There was such a heat inside that the Finland woman herself went about
+almost naked. She was diminutive and dirty. She immediately loosened
+little Gerda’s clothes, pulled off her thick gloves and boots; for
+otherwise the heat would have been too great--and after laying a piece
+of ice on the Reindeer’s head, read what was written on the fish-skin.
+She read it three times: she then knew it by heart; so she put the fish
+into the cupboard--for it might very well be eaten, and she never threw
+anything away.
+
+Then the Reindeer related his own story first, and afterwards that of
+little Gerda; and the Finland woman winked her eyes, but said nothing.
+
+“You are so clever,” said the Reindeer; “you can, I know, twist all the
+winds of the world together in a knot. If the seaman loosens one knot,
+then he has a good wind; if a second, then it blows pretty stiffly; if
+he undoes the third and fourth, then it rages so that the forests are
+upturned. Will you give the little maiden a potion, that she may possess
+the strength of twelve men, and vanquish the Snow Queen?”
+
+“The strength of twelve men!” said the Finland woman. “Much good that
+would be!” Then she went to a cupboard, and drew out a large skin rolled
+up. When she had unrolled it, strange characters were to be seen written
+thereon; and the Finland woman read at such a rate that the perspiration
+trickled down her forehead.
+
+But the Reindeer begged so hard for little Gerda, and Gerda looked so
+imploringly with tearful eyes at the Finland woman, that she winked, and
+drew the Reindeer aside into a corner, where they whispered together,
+while the animal got some fresh ice put on his head.
+
+“‘Tis true little Kay is at the Snow Queen’s, and finds everything there
+quite to his taste; and he thinks it the very best place in the world;
+but the reason of that is, he has a splinter of glass in his eye, and in
+his heart. These must be got out first; otherwise he will never go back
+to mankind, and the Snow Queen will retain her power over him.”
+
+“But can you give little Gerda nothing to take which will endue her with
+power over the whole?”
+
+“I can give her no more power than what she has already. Don’t you see
+how great it is? Don’t you see how men and animals are forced to serve
+her; how well she gets through the world barefooted? She must not hear
+of her power from us; that power lies in her heart, because she is
+a sweet and innocent child! If she cannot get to the Snow Queen by
+herself, and rid little Kay of the glass, we cannot help her. Two miles
+hence the garden of the Snow Queen begins; thither you may carry the
+little girl. Set her down by the large bush with red berries, standing
+in the snow; don’t stay talking, but hasten back as fast as possible.”
+ And now the Finland woman placed little Gerda on the Reindeer’s back,
+and off he ran with all imaginable speed.
+
+“Oh! I have not got my boots! I have not brought my gloves!” cried
+little Gerda. She remarked she was without them from the cutting frost;
+but the Reindeer dared not stand still; on he ran till he came to the
+great bush with the red berries, and there he set Gerda down, kissed her
+mouth, while large bright tears flowed from the animal’s eyes, and then
+back he went as fast as possible. There stood poor Gerda now, without
+shoes or gloves, in the very middle of dreadful icy Finland.
+
+She ran on as fast as she could. There then came a whole regiment of
+snow-flakes, but they did not fall from above, and they were quite
+bright and shining from the Aurora Borealis. The flakes ran along
+the ground, and the nearer they came the larger they grew. Gerda well
+remembered how large and strange the snow-flakes appeared when she
+once saw them through a magnifying-glass; but now they were large and
+terrific in another manner--they were all alive. They were the outposts
+of the Snow Queen. They had the most wondrous shapes; some looked like
+large ugly porcupines; others like snakes knotted together, with their
+heads sticking out; and others, again, like small fat bears, with the
+hair standing on end: all were of dazzling whiteness--all were living
+snow-flakes.
+
+Little Gerda repeated the Lord’s Prayer. The cold was so intense that
+she could see her own breath, which came like smoke out of her mouth. It
+grew thicker and thicker, and took the form of little angels, that grew
+more and more when they touched the earth. All had helms on their heads,
+and lances and shields in their hands; they increased in numbers; and
+when Gerda had finished the Lord’s Prayer, she was surrounded by a whole
+legion. They thrust at the horrid snow-flakes with their spears, so that
+they flew into a thousand pieces; and little Gerda walked on bravely and
+in security. The angels patted her hands and feet; and then she felt the
+cold less, and went on quickly towards the palace of the Snow Queen.
+
+But now we shall see how Kay fared. He never thought of Gerda, and least
+of all that she was standing before the palace.
+
+
+SEVENTH STORY. What Took Place in the Palace of the Snow Queen, and what
+Happened Afterward.
+
+The walls of the palace were of driving snow, and the windows and doors
+of cutting winds. There were more than a hundred halls there, according
+as the snow was driven by the winds. The largest was many miles in
+extent; all were lighted up by the powerful Aurora Borealis, and all
+were so large, so empty, so icy cold, and so resplendent! Mirth never
+reigned there; there was never even a little bear-ball, with the storm
+for music, while the polar bears went on their hind legs and showed off
+their steps. Never a little tea-party of white young lady foxes; vast,
+cold, and empty were the halls of the Snow Queen. The northern-lights
+shone with such precision that one could tell exactly when they were
+at their highest or lowest degree of brightness. In the middle of the
+empty, endless hall of snow, was a frozen lake; it was cracked in a
+thousand pieces, but each piece was so like the other, that it seemed
+the work of a cunning artificer. In the middle of this lake sat the Snow
+Queen when she was at home; and then she said she was sitting in the
+Mirror of Understanding, and that this was the only one and the best
+thing in the world.
+
+Little Kay was quite blue, yes nearly black with cold; but he did not
+observe it, for she had kissed away all feeling of cold from his body,
+and his heart was a lump of ice. He was dragging along some pointed
+flat pieces of ice, which he laid together in all possible ways, for he
+wanted to make something with them; just as we have little flat pieces
+of wood to make geometrical figures with, called the Chinese Puzzle.
+Kay made all sorts of figures, the most complicated, for it was
+an ice-puzzle for the understanding. In his eyes the figures were
+extraordinarily beautiful, and of the utmost importance; for the bit
+of glass which was in his eye caused this. He found whole figures which
+represented a written word; but he never could manage to represent just
+the word he wanted--that word was “eternity”; and the Snow Queen had
+said, “If you can discover that figure, you shall be your own master,
+and I will make you a present of the whole world and a pair of new
+skates.” But he could not find it out.
+
+“I am going now to warm lands,” said the Snow Queen. “I must have a look
+down into the black caldrons.” It was the volcanoes Vesuvius and Etna
+that she meant. “I will just give them a coating of white, for that is
+as it ought to be; besides, it is good for the oranges and the grapes.”
+ And then away she flew, and Kay sat quite alone in the empty halls of
+ice that were miles long, and looked at the blocks of ice, and thought
+and thought till his skull was almost cracked. There he sat quite
+benumbed and motionless; one would have imagined he was frozen to death.
+
+Suddenly little Gerda stepped through the great portal into the palace.
+The gate was formed of cutting winds; but Gerda repeated her evening
+prayer, and the winds were laid as though they slept; and the little
+maiden entered the vast, empty, cold halls. There she beheld Kay: she
+recognised him, flew to embrace him, and cried out, her arms firmly
+holding him the while, “Kay, sweet little Kay! Have I then found you at
+last?”
+
+But he sat quite still, benumbed and cold. Then little Gerda shed
+burning tears; and they fell on his bosom, they penetrated to his
+heart, they thawed the lumps of ice, and consumed the splinters of the
+looking-glass; he looked at her, and she sang the hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+Hereupon Kay burst into tears; he wept so much that the splinter rolled
+out of his eye, and he recognised her, and shouted, “Gerda, sweet little
+Gerda! Where have you been so long? And where have I been?” He looked
+round him. “How cold it is here!” said he. “How empty and cold!” And he
+held fast by Gerda, who laughed and wept for joy. It was so beautiful,
+that even the blocks of ice danced about for joy; and when they were
+tired and laid themselves down, they formed exactly the letters which
+the Snow Queen had told him to find out; so now he was his own master,
+and he would have the whole world and a pair of new skates into the
+bargain.
+
+Gerda kissed his cheeks, and they grew quite blooming; she kissed his
+eyes, and they shone like her own; she kissed his hands and feet, and he
+was again well and merry. The Snow Queen might come back as soon as she
+liked; there stood his discharge written in resplendent masses of ice.
+
+They took each other by the hand, and wandered forth out of the large
+hall; they talked of their old grandmother, and of the roses upon the
+roof; and wherever they went, the winds ceased raging, and the sun burst
+forth. And when they reached the bush with the red berries, they found
+the Reindeer waiting for them. He had brought another, a young one, with
+him, whose udder was filled with milk, which he gave to the little ones,
+and kissed their lips. They then carried Kay and Gerda--first to the
+Finland woman, where they warmed themselves in the warm room, and
+learned what they were to do on their journey home; and they went to
+the Lapland woman, who made some new clothes for them and repaired their
+sledges.
+
+The Reindeer and the young hind leaped along beside them, and
+accompanied them to the boundary of the country. Here the first
+vegetation peeped forth; here Kay and Gerda took leave of the Lapland
+woman. “Farewell! Farewell!” they all said. And the first green buds
+appeared, the first little birds began to chirrup; and out of the wood
+came, riding on a magnificent horse, which Gerda knew (it was one of the
+leaders in the golden carriage), a young damsel with a bright-red cap on
+her head, and armed with pistols. It was the little robber maiden, who,
+tired of being at home, had determined to make a journey to the north;
+and afterwards in another direction, if that did not please her. She
+recognised Gerda immediately, and Gerda knew her too. It was a joyful
+meeting.
+
+“You are a fine fellow for tramping about,” said she to little Kay; “I
+should like to know, faith, if you deserve that one should run from one
+end of the world to the other for your sake?”
+
+But Gerda patted her cheeks, and inquired for the Prince and Princess.
+
+“They are gone abroad,” said the other.
+
+“But the Raven?” asked little Gerda.
+
+“Oh! The Raven is dead,” she answered. “His tame sweetheart is a
+widow, and wears a bit of black worsted round her leg; she laments most
+piteously, but it’s all mere talk and stuff! Now tell me what you’ve
+been doing and how you managed to catch him.”
+
+And Gerda and Kay both told their story.
+
+And “Schnipp-schnapp-schnurre-basselurre,” said the robber maiden; and
+she took the hands of each, and promised that if she should some day
+pass through the town where they lived, she would come and visit them;
+and then away she rode. Kay and Gerda took each other’s hand: it was
+lovely spring weather, with abundance of flowers and of verdure. The
+church-bells rang, and the children recognised the high towers, and the
+large town; it was that in which they dwelt. They entered and hastened
+up to their grandmother’s room, where everything was standing as
+formerly. The clock said “tick! tack!” and the finger moved round; but
+as they entered, they remarked that they were now grown up. The roses
+on the leads hung blooming in at the open window; there stood the little
+children’s chairs, and Kay and Gerda sat down on them, holding each
+other by the hand; they both had forgotten the cold empty splendor of
+the Snow Queen, as though it had been a dream. The grandmother sat in
+the bright sunshine, and read aloud from the Bible: “Unless ye become as
+little children, ye cannot enter the kingdom of heaven.”
+
+And Kay and Gerda looked in each other’s eyes, and all at once they
+understood the old hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+There sat the two grown-up persons; grown-up, and yet children; children
+at least in heart; and it was summer-time; summer, glorious summer!
+
+
+
+
+THE LEAP-FROG
+
+A Flea, a Grasshopper, and a Leap-frog once wanted to see which could
+jump highest; and they invited the whole world, and everybody else
+besides who chose to come to see the festival. Three famous jumpers were
+they, as everyone would say, when they all met together in the room.
+
+“I will give my daughter to him who jumps highest,” exclaimed the King;
+“for it is not so amusing where there is no prize to jump for.”
+
+The Flea was the first to step forward. He had exquisite manners, and
+bowed to the company on all sides; for he had noble blood, and was,
+moreover, accustomed to the society of man alone; and that makes a great
+difference.
+
+Then came the Grasshopper. He was considerably heavier, but he was
+well-mannered, and wore a green uniform, which he had by right of birth;
+he said, moreover, that he belonged to a very ancient Egyptian family,
+and that in the house where he then was, he was thought much of. The
+fact was, he had been just brought out of the fields, and put in a
+pasteboard house, three stories high, all made of court-cards, with the
+colored side inwards; and doors and windows cut out of the body of
+the Queen of Hearts. “I sing so well,” said he, “that sixteen native
+grasshoppers who have chirped from infancy, and yet got no house built
+of cards to live in, grew thinner than they were before for sheer
+vexation when they heard me.”
+
+It was thus that the Flea and the Grasshopper gave an account of
+themselves, and thought they were quite good enough to marry a Princess.
+
+The Leap-frog said nothing; but people gave it as their opinion, that
+he therefore thought the more; and when the housedog snuffed at him
+with his nose, he confessed the Leap-frog was of good family. The old
+councillor, who had had three orders given him to make him hold his
+tongue, asserted that the Leap-frog was a prophet; for that one could
+see on his back, if there would be a severe or mild winter, and that
+was what one could not see even on the back of the man who writes the
+almanac.
+
+“I say nothing, it is true,” exclaimed the King; “but I have my own
+opinion, notwithstanding.”
+
+Now the trial was to take place. The Flea jumped so high that nobody
+could see where he went to; so they all asserted he had not jumped at
+all; and that was dishonorable.
+
+The Grasshopper jumped only half as high; but he leaped into the King’s
+face, who said that was ill-mannered.
+
+The Leap-frog stood still for a long time lost in thought; it was
+believed at last he would not jump at all.
+
+“I only hope he is not unwell,” said the house-dog; when, pop! he made a
+jump all on one side into the lap of the Princess, who was sitting on a
+little golden stool close by.
+
+Hereupon the King said, “There is nothing above my daughter; therefore
+to bound up to her is the highest jump that can be made; but for this,
+one must possess understanding, and the Leap-frog has shown that he has
+understanding. He is brave and intellectual.”
+
+And so he won the Princess.
+
+“It’s all the same to me,” said the Flea. “She may have the old
+Leap-frog, for all I care. I jumped the highest; but in this world
+merit seldom meets its reward. A fine exterior is what people look at
+now-a-days.”
+
+The Flea then went into foreign service, where, it is said, he was
+killed.
+
+The Grasshopper sat without on a green bank, and reflected on worldly
+things; and he said too, “Yes, a fine exterior is everything--a fine
+exterior is what people care about.” And then he began chirping his
+peculiar melancholy song, from which we have taken this history; and
+which may, very possibly, be all untrue, although it does stand here
+printed in black and white.
+
+
+
+
+THE ELDERBUSH
+
+Once upon a time there was a little boy who had taken cold. He had
+gone out and got his feet wet; though nobody could imagine how it had
+happened, for it was quite dry weather. So his mother undressed him, put
+him to bed, and had the tea-pot brought in, to make him a good cup of
+Elderflower tea. Just at that moment the merry old man came in who
+lived up a-top of the house all alone; for he had neither wife nor
+children--but he liked children very much, and knew so many fairy tales,
+that it was quite delightful.
+
+“Now drink your tea,” said the boy’s mother; “then, perhaps, you may
+hear a fairy tale.”
+
+“If I had but something new to tell,” said the old man. “But how did the
+child get his feet wet?”
+
+“That is the very thing that nobody can make out,” said his mother.
+
+“Am I to hear a fairy tale?” asked the little boy.
+
+“Yes, if you can tell me exactly--for I must know that first--how deep
+the gutter is in the little street opposite, that you pass through in
+going to school.”
+
+“Just up to the middle of my boot,” said the child; “but then I must go
+into the deep hole.”
+
+“Ah, ah! That’s where the wet feet came from,” said the old man. “I
+ought now to tell you a story; but I don’t know any more.”
+
+“You can make one in a moment,” said the little boy. “My mother says
+that all you look at can be turned into a fairy tale: and that you can
+find a story in everything.”
+
+“Yes, but such tales and stories are good for nothing. The right sort
+come of themselves; they tap at my forehead and say, ‘Here we are.’”
+
+“Won’t there be a tap soon?” asked the little boy. And his mother
+laughed, put some Elder-flowers in the tea-pot, and poured boiling water
+upon them.
+
+“Do tell me something! Pray do!”
+
+“Yes, if a fairy tale would come of its own accord; but they are proud
+and haughty, and come only when they choose. Stop!” said he, all on a
+sudden. “I have it! Pay attention! There is one in the tea-pot!”
+
+And the little boy looked at the tea-pot. The cover rose more and more;
+and the Elder-flowers came forth so fresh and white, and shot up long
+branches. Out of the spout even did they spread themselves on all sides,
+and grew larger and larger; it was a splendid Elderbush, a whole tree;
+and it reached into the very bed, and pushed the curtains aside. How
+it bloomed! And what an odour! In the middle of the bush sat a
+friendly-looking old woman in a most strange dress. It was quite
+green, like the leaves of the elder, and was trimmed with large white
+Elder-flowers; so that at first one could not tell whether it was a
+stuff, or a natural green and real flowers.
+
+“What’s that woman’s name?” asked the little boy.
+
+“The Greeks and Romans,” said the old man, “called her a Dryad; but that
+we do not understand. The people who live in the New Booths [*] have a much
+better name for her; they call her ‘old Granny’--and she it is to
+whom you are to pay attention. Now listen, and look at the beautiful
+Elderbush.
+
+     * A row of buildings for seamen in Copenhagen.
+
+“Just such another large blooming Elder Tree stands near the New Booths.
+It grew there in the corner of a little miserable court-yard; and under
+it sat, of an afternoon, in the most splendid sunshine, two old
+people; an old, old seaman, and his old, old wife. They had
+great-grand-children, and were soon to celebrate the fiftieth
+anniversary of their marriage; but they could not exactly recollect the
+date: and old Granny sat in the tree, and looked as pleased as now. ‘I
+know the date,’ said she; but those below did not hear her, for they
+were talking about old times.
+
+“‘Yes, can’t you remember when we were very little,’ said the old
+seaman, ‘and ran and played about? It was the very same court-yard where
+we now are, and we stuck slips in the ground, and made a garden.’
+
+“‘I remember it well,’ said the old woman; ‘I remember it quite well. We
+watered the slips, and one of them was an Elderbush. It took root, put
+forth green shoots, and grew up to be the large tree under which we old
+folks are now sitting.’
+
+“‘To be sure,’ said he. ‘And there in the corner stood a waterpail,
+where I used to swim my boats.’
+
+“‘True; but first we went to school to learn somewhat,’ said she; ‘and
+then we were confirmed. We both cried; but in the afternoon we went up
+the Round Tower, and looked down on Copenhagen, and far, far away over
+the water; then we went to Friedericksberg, where the King and the Queen
+were sailing about in their splendid barges.’
+
+“‘But I had a different sort of sailing to that, later; and that, too,
+for many a year; a long way off, on great voyages.’
+
+“‘Yes, many a time have I wept for your sake,’ said she. ‘I thought you
+were dead and gone, and lying down in the deep waters. Many a night have
+I got up to see if the wind had not changed: and changed it had, sure
+enough; but you never came. I remember so well one day, when the rain
+was pouring down in torrents, the scavengers were before the house where
+I was in service, and I had come up with the dust, and remained standing
+at the door--it was dreadful weather--when just as I was there, the
+postman came and gave me a letter. It was from you! What a tour that
+letter had made! I opened it instantly and read: I laughed and wept.
+I was so happy. In it I read that you were in warm lands where the
+coffee-tree grows. What a blessed land that must be! You related so
+much, and I saw it all the while the rain was pouring down, and I
+standing there with the dust-box. At the same moment came someone who
+embraced me.’
+
+“‘Yes; but you gave him a good box on his ear that made it tingle!’
+
+“‘But I did not know it was you. You arrived as soon as your letter,
+and you were so handsome--that you still are--and had a long yellow silk
+handkerchief round your neck, and a bran new hat on; oh, you were so
+dashing! Good heavens! What weather it was, and what a state the street
+was in!’
+
+“‘And then we married,’ said he. ‘Don’t you remember? And then we
+had our first little boy, and then Mary, and Nicholas, and Peter, and
+Christian.’
+
+“‘Yes, and how they all grew up to be honest people, and were beloved by
+everybody.’
+
+“‘And their children also have children,’ said the old sailor; ‘yes,
+those are our grand-children, full of strength and vigor. It was,
+methinks about this season that we had our wedding.’
+
+“‘Yes, this very day is the fiftieth anniversary of the marriage,’ said
+old Granny, sticking her head between the two old people; who thought
+it was their neighbor who nodded to them. They looked at each other and
+held one another by the hand. Soon after came their children, and their
+grand-children; for they knew well enough that it was the day of the
+fiftieth anniversary, and had come with their gratulations that very
+morning; but the old people had forgotten it, although they were able
+to remember all that had happened many years ago. And the Elderbush sent
+forth a strong odour in the sun, that was just about to set, and shone
+right in the old people’s faces. They both looked so rosy-cheeked; and
+the youngest of the grandchildren danced around them, and called out
+quite delighted, that there was to be something very splendid that
+evening--they were all to have hot potatoes. And old Nanny nodded in the
+bush, and shouted ‘hurrah!’ with the rest.”
+
+“But that is no fairy tale,” said the little boy, who was listening to
+the story.
+
+“The thing is, you must understand it,” said the narrator; “let us ask
+old Nanny.”
+
+“That was no fairy tale, ‘tis true,” said old Nanny; “but now it’s
+coming. The most wonderful fairy tales grow out of that which is
+reality; were that not the case, you know, my magnificent Elderbush
+could not have grown out of the tea-pot.” And then she took the little
+boy out of bed, laid him on her bosom, and the branches of the Elder
+Tree, full of flowers, closed around her. They sat in an aerial
+dwelling, and it flew with them through the air. Oh, it was wondrous
+beautiful! Old Nanny had grown all of a sudden a young and pretty
+maiden; but her robe was still the same green stuff with white flowers,
+which she had worn before. On her bosom she had a real Elderflower,
+and in her yellow waving hair a wreath of the flowers; her eyes were so
+large and blue that it was a pleasure to look at them; she kissed the
+boy, and now they were of the same age and felt alike.
+
+Hand in hand they went out of the bower, and they were standing in the
+beautiful garden of their home. Near the green lawn papa’s walking-stick
+was tied, and for the little ones it seemed to be endowed with life; for
+as soon as they got astride it, the round polished knob was turned into
+a magnificent neighing head, a long black mane fluttered in the breeze,
+and four slender yet strong legs shot out. The animal was strong and
+handsome, and away they went at full gallop round the lawn.
+
+“Huzza! Now we are riding miles off,” said the boy. “We are riding away
+to the castle where we were last year!”
+
+And on they rode round the grass-plot; and the little maiden, who, we
+know, was no one else but old Nanny, kept on crying out, “Now we are in
+the country! Don’t you see the farm-house yonder? And there is an Elder
+Tree standing beside it; and the cock is scraping away the earth for the
+hens, look, how he struts! And now we are close to the church. It lies
+high upon the hill, between the large oak-trees, one of which is half
+decayed. And now we are by the smithy, where the fire is blazing, and
+where the half-naked men are banging with their hammers till the sparks
+fly about. Away! away! To the beautiful country-seat!”
+
+And all that the little maiden, who sat behind on the stick, spoke of,
+flew by in reality. The boy saw it all, and yet they were only going
+round the grass-plot. Then they played in a side avenue, and marked out
+a little garden on the earth; and they took Elder-blossoms from their
+hair, planted them, and they grew just like those the old people planted
+when they were children, as related before. They went hand in hand, as
+the old people had done when they were children; but not to the Round
+Tower, or to Friedericksberg; no, the little damsel wound her arms round
+the boy, and then they flew far away through all Denmark. And spring
+came, and summer; and then it was autumn, and then winter; and a
+thousand pictures were reflected in the eye and in the heart of the boy;
+and the little girl always sang to him, “This you will never forget.”
+ And during their whole flight the Elder Tree smelt so sweet and odorous;
+he remarked the roses and the fresh beeches, but the Elder Tree had
+a more wondrous fragrance, for its flowers hung on the breast of the
+little maiden; and there, too, did he often lay his head during the
+flight.
+
+“It is lovely here in spring!” said the young maiden. And they stood in
+a beech-wood that had just put on its first green, where the woodroof [*]
+at their feet sent forth its fragrance, and the pale-red anemony looked
+so pretty among the verdure. “Oh, would it were always spring in the
+sweetly-smelling Danish beech-forests!”
+
+     * Asperula odorata.
+
+“It is lovely here in summer!” said she. And she flew past old castles
+of by-gone days of chivalry, where the red walls and the embattled
+gables were mirrored in the canal, where the swans were swimming, and
+peered up into the old cool avenues. In the fields the corn was waving
+like the sea; in the ditches red and yellow flowers were growing; while
+wild-drone flowers, and blooming convolvuluses were creeping in the
+hedges; and towards evening the moon rose round and large, and the
+haycocks in the meadows smelt so sweetly. “This one never forgets!”
+
+“It is lovely here in autumn!” said the little maiden. And suddenly the
+atmosphere grew as blue again as before; the forest grew red, and green,
+and yellow-colored. The dogs came leaping along, and whole flocks of
+wild-fowl flew over the cairn, where blackberry-bushes were hanging
+round the old stones. The sea was dark blue, covered with ships full
+of white sails; and in the barn old women, maidens, and children were
+sitting picking hops into a large cask; the young sang songs, but the
+old told fairy tales of mountain-sprites and soothsayers. Nothing could
+be more charming.
+
+“It is delightful here in winter!” said the little maiden. And all the
+trees were covered with hoar-frost; they looked like white corals; the
+snow crackled under foot, as if one had new boots on; and one falling
+star after the other was seen in the sky. The Christmas-tree was lighted
+in the room; presents were there, and good-humor reigned. In the country
+the violin sounded in the room of the peasant; the newly-baked cakes
+were attacked; even the poorest child said, “It is really delightful
+here in winter!”
+
+Yes, it was delightful; and the little maiden showed the boy everything;
+and the Elder Tree still was fragrant, and the red flag, with the white
+cross, was still waving: the flag under which the old seaman in the New
+Booths had sailed. And the boy grew up to be a lad, and was to go forth
+in the wide world-far, far away to warm lands, where the coffee-tree
+grows; but at his departure the little maiden took an Elder-blossom from
+her bosom, and gave it him to keep; and it was placed between the leaves
+of his Prayer-Book; and when in foreign lands he opened the book, it
+was always at the place where the keepsake-flower lay; and the more he
+looked at it, the fresher it became; he felt as it were, the fragrance
+of the Danish groves; and from among the leaves of the flowers he could
+distinctly see the little maiden, peeping forth with her bright blue
+eyes--and then she whispered, “It is delightful here in Spring, Summer,
+Autumn, and Winter”; and a hundred visions glided before his mind.
+
+Thus passed many years, and he was now an old man, and sat with his old
+wife under the blooming tree. They held each other by the hand, as the
+old grand-father and grand-mother yonder in the New Booths did, and they
+talked exactly like them of old times, and of the fiftieth anniversary
+of their wedding. The little maiden, with the blue eyes, and with
+Elder-blossoms in her hair, sat in the tree, nodded to both of them,
+and said, “To-day is the fiftieth anniversary!” And then she took two
+flowers out of her hair, and kissed them. First, they shone like silver,
+then like gold; and when they laid them on the heads of the old people,
+each flower became a golden crown. So there they both sat, like a king
+and a queen, under the fragrant tree, that looked exactly like an elder:
+the old man told his wife the story of “Old Nanny,” as it had been told
+him when a boy. And it seemed to both of them it contained much that
+resembled their own history; and those parts that were like it pleased
+them best.
+
+“Thus it is,” said the little maiden in the tree, “some call me ‘Old
+Nanny,’ others a ‘Dryad,’ but, in reality, my name is ‘Remembrance’;
+‘tis I who sit in the tree that grows and grows! I can remember; I can
+tell things! Let me see if you have my flower still?”
+
+And the old man opened his Prayer-Book. There lay the Elder-blossom,
+as fresh as if it had been placed there but a short time before; and
+Remembrance nodded, and the old people, decked with crowns of gold, sat
+in the flush of the evening sun. They closed their eyes, and--and--!
+Yes, that’s the end of the story!
+
+The little boy lay in his bed; he did not know if he had dreamed or
+not, or if he had been listening while someone told him the story. The
+tea-pot was standing on the table, but no Elder Tree was growing out
+of it! And the old man, who had been talking, was just on the point of
+going out at the door, and he did go.
+
+“How splendid that was!” said the little boy. “Mother, I have been to
+warm countries.”
+
+“So I should think,” said his mother. “When one has drunk two good
+cupfuls of Elder-flower tea, ‘tis likely enough one goes into warm
+climates”; and she tucked him up nicely, least he should take cold. “You
+have had a good sleep while I have been sitting here, and arguing with
+him whether it was a story or a fairy tale.”
+
+“And where is old Nanny?” asked the little boy.
+
+“In the tea-pot,” said his mother; “and there she may remain.”
+
+
+
+
+THE BELL
+
+People said “The Evening Bell is sounding, the sun is setting.” For a
+strange wondrous tone was heard in the narrow streets of a large town.
+It was like the sound of a church-bell: but it was only heard for a
+moment, for the rolling of the carriages and the voices of the multitude
+made too great a noise.
+
+Those persons who were walking outside the town, where the houses were
+farther apart, with gardens or little fields between them, could see
+the evening sky still better, and heard the sound of the bell much
+more distinctly. It was as if the tones came from a church in the still
+forest; people looked thitherward, and felt their minds attuned most
+solemnly.
+
+A long time passed, and people said to each other--“I wonder if there
+is a church out in the wood? The bell has a tone that is wondrous sweet;
+let us stroll thither, and examine the matter nearer.” And the rich
+people drove out, and the poor walked, but the way seemed strangely
+long to them; and when they came to a clump of willows which grew on the
+skirts of the forest, they sat down, and looked up at the long
+branches, and fancied they were now in the depth of the green wood. The
+confectioner of the town came out, and set up his booth there; and soon
+after came another confectioner, who hung a bell over his stand, as
+a sign or ornament, but it had no clapper, and it was tarred over to
+preserve it from the rain. When all the people returned home, they said
+it had been very romantic, and that it was quite a different sort of
+thing to a pic-nic or tea-party. There were three persons who asserted
+they had penetrated to the end of the forest, and that they had always
+heard the wonderful sounds of the bell, but it had seemed to them as if
+it had come from the town. One wrote a whole poem about it, and said the
+bell sounded like the voice of a mother to a good dear child, and
+that no melody was sweeter than the tones of the bell. The king of the
+country was also observant of it, and vowed that he who could discover
+whence the sounds proceeded, should have the title of “Universal
+Bell-ringer,” even if it were not really a bell.
+
+Many persons now went to the wood, for the sake of getting the place,
+but one only returned with a sort of explanation; for nobody went far
+enough, that one not further than the others. However, he said that
+the sound proceeded from a very large owl, in a hollow tree; a sort of
+learned owl, that continually knocked its head against the branches. But
+whether the sound came from his head or from the hollow tree, that no
+one could say with certainty. So now he got the place of “Universal
+Bell-ringer,” and wrote yearly a short treatise “On the Owl”; but
+everybody was just as wise as before.
+
+It was the day of confirmation. The clergyman had spoken so touchingly,
+the children who were confirmed had been greatly moved; it was
+an eventful day for them; from children they become all at once
+grown-up-persons; it was as if their infant souls were now to fly all
+at once into persons with more understanding. The sun was shining
+gloriously; the children that had been confirmed went out of the town;
+and from the wood was borne towards them the sounds of the unknown bell
+with wonderful distinctness. They all immediately felt a wish to go
+thither; all except three. One of them had to go home to try on a
+ball-dress; for it was just the dress and the ball which had caused her
+to be confirmed this time, for otherwise she would not have come;
+the other was a poor boy, who had borrowed his coat and boots to be
+confirmed in from the innkeeper’s son, and he was to give them back by
+a certain hour; the third said that he never went to a strange place
+if his parents were not with him--that he had always been a good boy
+hitherto, and would still be so now that he was confirmed, and that one
+ought not to laugh at him for it: the others, however, did make fun of
+him, after all.
+
+There were three, therefore, that did not go; the others hastened on.
+The sun shone, the birds sang, and the children sang too, and each held
+the other by the hand; for as yet they had none of them any high office,
+and were all of equal rank in the eye of God.
+
+But two of the youngest soon grew tired, and both returned to town; two
+little girls sat down, and twined garlands, so they did not go either;
+and when the others reached the willow-tree, where the confectioner was,
+they said, “Now we are there! In reality the bell does not exist; it is
+only a fancy that people have taken into their heads!”
+
+At the same moment the bell sounded deep in the wood, so clear and
+solemnly that five or six determined to penetrate somewhat further. It
+was so thick, and the foliage so dense, that it was quite fatiguing
+to proceed. Woodroof and anemonies grew almost too high; blooming
+convolvuluses and blackberry-bushes hung in long garlands from tree to
+tree, where the nightingale sang and the sunbeams were playing: it was
+very beautiful, but it was no place for girls to go; their clothes would
+get so torn. Large blocks of stone lay there, overgrown with moss of
+every color; the fresh spring bubbled forth, and made a strange gurgling
+sound.
+
+“That surely cannot be the bell,” said one of the children, lying down
+and listening. “This must be looked to.” So he remained, and let the
+others go on without him.
+
+They afterwards came to a little house, made of branches and the bark of
+trees; a large wild apple-tree bent over it, as if it would shower down
+all its blessings on the roof, where roses were blooming. The long stems
+twined round the gable, on which there hung a small bell.
+
+Was it that which people had heard? Yes, everybody was unanimous on the
+subject, except one, who said that the bell was too small and too fine
+to be heard at so great a distance, and besides it was very different
+tones to those that could move a human heart in such a manner. It was a
+king’s son who spoke; whereon the others said, “Such people always want
+to be wiser than everybody else.”
+
+They now let him go on alone; and as he went, his breast was filled more
+and more with the forest solitude; but he still heard the little bell
+with which the others were so satisfied, and now and then, when the
+wind blew, he could also hear the people singing who were sitting at tea
+where the confectioner had his tent; but the deep sound of the bell rose
+louder; it was almost as if an organ were accompanying it, and the tones
+came from the left hand, the side where the heart is placed. A rustling
+was heard in the bushes, and a little boy stood before the King’s Son, a
+boy in wooden shoes, and with so short a jacket that one could see what
+long wrists he had. Both knew each other: the boy was that one among
+the children who could not come because he had to go home and return his
+jacket and boots to the innkeeper’s son. This he had done, and was now
+going on in wooden shoes and in his humble dress, for the bell sounded
+with so deep a tone, and with such strange power, that proceed he must.
+
+“Why, then, we can go together,” said the King’s Son. But the poor
+child that had been confirmed was quite ashamed; he looked at his wooden
+shoes, pulled at the short sleeves of his jacket, and said that he was
+afraid he could not walk so fast; besides, he thought that the bell must
+be looked for to the right; for that was the place where all sorts of
+beautiful things were to be found.
+
+“But there we shall not meet,” said the King’s Son, nodding at the same
+time to the poor boy, who went into the darkest, thickest part of the
+wood, where thorns tore his humble dress, and scratched his face and
+hands and feet till they bled. The King’s Son got some scratches too;
+but the sun shone on his path, and it is him that we will follow, for he
+was an excellent and resolute youth.
+
+“I must and will find the bell,” said he, “even if I am obliged to go to
+the end of the world.”
+
+The ugly apes sat upon the trees, and grinned. “Shall we thrash him?”
+ said they. “Shall we thrash him? He is the son of a king!”
+
+But on he went, without being disheartened, deeper and deeper into the
+wood, where the most wonderful flowers were growing. There stood white
+lilies with blood-red stamina, skyblue tulips, which shone as they waved
+in the winds, and apple-trees, the apples of which looked exactly like
+large soapbubbles: so only think how the trees must have sparkled in the
+sunshine! Around the nicest green meads, where the deer were playing in
+the grass, grew magnificent oaks and beeches; and if the bark of one of
+the trees was cracked, there grass and long creeping plants grew in
+the crevices. And there were large calm lakes there too, in which white
+swans were swimming, and beat the air with their wings. The King’s Son
+often stood still and listened. He thought the bell sounded from the
+depths of these still lakes; but then he remarked again that the tone
+proceeded not from there, but farther off, from out the depths of the
+forest.
+
+The sun now set: the atmosphere glowed like fire. It was still in the
+woods, so very still; and he fell on his knees, sung his evening hymn,
+and said: “I cannot find what I seek; the sun is going down, and night
+is coming--the dark, dark night. Yet perhaps I may be able once more
+to see the round red sun before he entirely disappears. I will climb up
+yonder rock.”
+
+And he seized hold of the creeping-plants, and the roots of
+trees--climbed up the moist stones where the water-snakes were writhing
+and the toads were croaking--and he gained the summit before the sun
+had quite gone down. How magnificent was the sight from this height! The
+sea--the great, the glorious sea, that dashed its long waves against the
+coast--was stretched out before him. And yonder, where sea and sky meet,
+stood the sun, like a large shining altar, all melted together in the
+most glowing colors. And the wood and the sea sang a song of rejoicing,
+and his heart sang with the rest: all nature was a vast holy church,
+in which the trees and the buoyant clouds were the pillars, flowers and
+grass the velvet carpeting, and heaven itself the large cupola. The red
+colors above faded away as the sun vanished, but a million stars were
+lighted, a million lamps shone; and the King’s Son spread out his arms
+towards heaven, and wood, and sea; when at the same moment, coming by
+a path to the right, appeared, in his wooden shoes and jacket, the poor
+boy who had been confirmed with him. He had followed his own path, and
+had reached the spot just as soon as the son of the king had done. They
+ran towards each other, and stood together hand in hand in the vast
+church of nature and of poetry, while over them sounded the invisible
+holy bell: blessed spirits floated around them, and lifted up their
+voices in a rejoicing hallelujah!
+
+
+
+
+THE OLD HOUSE
+
+In the street, up there, was an old, a very old house--it was almost
+three hundred years old, for that might be known by reading the great
+beam on which the date of the year was carved: together with tulips and
+hop-binds there were whole verses spelled as in former times, and over
+every window was a distorted face cut out in the beam. The one story
+stood forward a great way over the other; and directly under the eaves
+was a leaden spout with a dragon’s head; the rain-water should have run
+out of the mouth, but it ran out of the belly, for there was a hole in
+the spout.
+
+All the other houses in the street were so new and so neat, with large
+window panes and smooth walls, one could easily see that they would have
+nothing to do with the old house: they certainly thought, “How long is
+that old decayed thing to stand here as a spectacle in the street? And
+then the projecting windows stand so far out, that no one can see from
+our windows what happens in that direction! The steps are as broad as
+those of a palace, and as high as to a church tower. The iron railings
+look just like the door to an old family vault, and then they have brass
+tops--that’s so stupid!”
+
+On the other side of the street were also new and neat houses, and they
+thought just as the others did; but at the window opposite the old house
+there sat a little boy with fresh rosy cheeks and bright beaming eyes:
+he certainly liked the old house best, and that both in sunshine and
+moonshine. And when he looked across at the wall where the mortar
+had fallen out, he could sit and find out there the strangest figures
+imaginable; exactly as the street had appeared before, with steps,
+projecting windows, and pointed gables; he could see soldiers with
+halberds, and spouts where the water ran, like dragons and serpents.
+That was a house to look at; and there lived an old man, who wore plush
+breeches; and he had a coat with large brass buttons, and a wig that one
+could see was a real wig. Every morning there came an old fellow to him
+who put his rooms in order, and went on errands; otherwise, the old man
+in the plush breeches was quite alone in the old house. Now and then he
+came to the window and looked out, and the little boy nodded to him,
+and the old man nodded again, and so they became acquaintances, and then
+they were friends, although they had never spoken to each other--but
+that made no difference. The little boy heard his parents say, “The old
+man opposite is very well off, but he is so very, very lonely!”
+
+The Sunday following, the little boy took something, and wrapped it up
+in a piece of paper, went downstairs, and stood in the doorway; and when
+the man who went on errands came past, he said to him--
+
+“I say, master! will you give this to the old man over the way from me?
+I have two pewter soldiers--this is one of them, and he shall have it,
+for I know he is so very, very lonely.”
+
+And the old errand man looked quite pleased, nodded, and took the pewter
+soldier over to the old house. Afterwards there came a message; it was
+to ask if the little boy himself had not a wish to come over and pay a
+visit; and so he got permission of his parents, and then went over to
+the old house.
+
+And the brass balls on the iron railings shone much brighter than ever;
+one would have thought they were polished on account of the visit; and
+it was as if the carved-out trumpeters--for there were trumpeters, who
+stood in tulips, carved out on the door--blew with all their
+might, their cheeks appeared so much rounder than before. Yes, they
+blew--“Trateratra! The little boy comes! Trateratra!”--and then the door
+opened.
+
+The whole passage was hung with portraits of knights in armor, and
+ladies in silken gowns; and the armor rattled, and the silken gowns
+rustled! And then there was a flight of stairs which went a good way
+upwards, and a little way downwards, and then one came on a balcony
+which was in a very dilapidated state, sure enough, with large holes and
+long crevices, but grass grew there and leaves out of them altogether,
+for the whole balcony outside, the yard, and the walls, were overgrown
+with so much green stuff, that it looked like a garden; only a balcony.
+Here stood old flower-pots with faces and asses’ ears, and the flowers
+grew just as they liked. One of the pots was quite overrun on all sides
+with pinks, that is to say, with the green part; shoot stood by shoot,
+and it said quite distinctly, “The air has cherished me, the sun has
+kissed me, and promised me a little flower on Sunday! a little flower on
+Sunday!”
+
+And then they entered a chamber where the walls were covered with hog’s
+leather, and printed with gold flowers.
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+said the walls.
+
+And there stood easy-chairs, with such high backs, and so carved out,
+and with arms on both sides. “Sit down! sit down!” said they. “Ugh! how
+I creak; now I shall certainly get the gout, like the old clothespress,
+ugh!”
+
+And then the little boy came into the room where the projecting windows
+were, and where the old man sat.
+
+“I thank you for the pewter soldier, my little friend!” said the old
+man. “And I thank you because you come over to me.”
+
+“Thankee! thankee!” or “cranky! cranky!” sounded from all the furniture;
+there was so much of it, that each article stood in the other’s way, to
+get a look at the little boy.
+
+In the middle of the wall hung a picture representing a beautiful lady,
+so young, so glad, but dressed quite as in former times, with clothes
+that stood quite stiff, and with powder in her hair; she neither said
+“thankee, thankee!” nor “cranky, cranky!” but looked with her mild eyes
+at the little boy, who directly asked the old man, “Where did you get
+her?”
+
+“Yonder, at the broker’s,” said the old man, “where there are so many
+pictures hanging. No one knows or cares about them, for they are all of
+them buried; but I knew her in by-gone days, and now she has been dead
+and gone these fifty years!”
+
+Under the picture, in a glazed frame, there hung a bouquet of withered
+flowers; they were almost fifty years old; they looked so very old!
+
+The pendulum of the great clock went to and fro, and the hands turned,
+and everything in the room became still older; but they did not observe
+it.
+
+“They say at home,” said the little boy, “that you are so very, very
+lonely!”
+
+“Oh!” said he. “The old thoughts, with what they may bring with them,
+come and visit me, and now you also come! I am very well off!”
+
+Then he took a book with pictures in it down from the shelf; there were
+whole long processions and pageants, with the strangest characters,
+which one never sees now-a-days; soldiers like the knave of clubs,
+and citizens with waving flags: the tailors had theirs, with a pair of
+shears held by two lions--and the shoemakers theirs, without boots,
+but with an eagle that had two heads, for the shoemakers must have
+everything so that they can say, it is a pair! Yes, that was a picture
+book!
+
+The old man now went into the other room to fetch preserves, apples, and
+nuts--yes, it was delightful over there in the old house.
+
+“I cannot bear it any longer!” said the pewter soldier, who sat on the
+drawers. “It is so lonely and melancholy here! But when one has been in
+a family circle one cannot accustom oneself to this life! I cannot bear
+it any longer! The whole day is so long, and the evenings are still
+longer! Here it is not at all as it is over the way at your home, where
+your father and mother spoke so pleasantly, and where you and all your
+sweet children made such a delightful noise. Nay, how lonely the old man
+is--do you think that he gets kisses? Do you think he gets mild eyes,
+or a Christmas tree? He will get nothing but a grave! I can bear it no
+longer!”
+
+“You must not let it grieve you so much,” said the little boy. “I find
+it so very delightful here, and then all the old thoughts, with what
+they may bring with them, they come and visit here.”
+
+“Yes, it’s all very well, but I see nothing of them, and I don’t know
+them!” said the pewter soldier. “I cannot bear it!”
+
+“But you must!” said the little boy.
+
+Then in came the old man with the most pleased and happy face, the most
+delicious preserves, apples, and nuts, and so the little boy thought no
+more about the pewter soldier.
+
+The little boy returned home happy and pleased, and weeks and days
+passed away, and nods were made to the old house, and from the old
+house, and then the little boy went over there again.
+
+The carved trumpeters blew, “Trateratra! There is the little boy!
+Trateratra!” and the swords and armor on the knights’ portraits rattled,
+and the silk gowns rustled; the hog’s leather spoke, and the old chairs
+had the gout in their legs and rheumatism in their backs: Ugh! it was
+exactly like the first time, for over there one day and hour was just
+like another.
+
+“I cannot bear it!” said the pewter soldier. “I have shed pewter tears!
+It is too melancholy! Rather let me go to the wars and lose arms and
+legs! It would at least be a change. I cannot bear it longer! Now, I
+know what it is to have a visit from one’s old thoughts, with what they
+may bring with them! I have had a visit from mine, and you may be sure
+it is no pleasant thing in the end; I was at last about to jump down
+from the drawers.
+
+“I saw you all over there at home so distinctly, as if you really were
+here; it was again that Sunday morning; all you children stood before
+the table and sung your Psalms, as you do every morning. You stood
+devoutly with folded hands; and father and mother were just as pious;
+and then the door was opened, and little sister Mary, who is not two
+years old yet, and who always dances when she hears music or singing, of
+whatever kind it may be, was put into the room--though she ought not to
+have been there--and then she began to dance, but could not keep time,
+because the tones were so long; and then she stood, first on the one
+leg, and bent her head forwards, and then on the other leg, and bent
+her head forwards--but all would not do. You stood very seriously all
+together, although it was difficult enough; but I laughed to myself, and
+then I fell off the table, and got a bump, which I have still--for it
+was not right of me to laugh. But the whole now passes before me again
+in thought, and everything that I have lived to see; and these are the
+old thoughts, with what they may bring with them.
+
+“Tell me if you still sing on Sundays? Tell me something about little
+Mary! And how my comrade, the other pewter soldier, lives! Yes, he is
+happy enough, that’s sure! I cannot bear it any longer!”
+
+“You are given away as a present!” said the little boy. “You must
+remain. Can you not understand that?”
+
+The old man now came with a drawer, in which there was much to be seen,
+both “tin boxes” and “balsam boxes,” old cards, so large and so gilded,
+such as one never sees them now. And several drawers were opened, and
+the piano was opened; it had landscapes on the inside of the lid, and it
+was so hoarse when the old man played on it! and then he hummed a song.
+
+“Yes, she could sing that!” said he, and nodded to the portrait, which
+he had bought at the broker’s, and the old man’s eyes shone so bright!
+
+“I will go to the wars! I will go to the wars!” shouted the pewter
+soldier as loud as he could, and threw himself off the drawers right
+down on the floor. What became of him? The old man sought, and the
+little boy sought; he was away, and he stayed away.
+
+“I shall find him!” said the old man; but he never found him. The floor
+was too open--the pewter soldier had fallen through a crevice, and there
+he lay as in an open tomb.
+
+That day passed, and the little boy went home, and that week passed,
+and several weeks too. The windows were quite frozen, the little boy was
+obliged to sit and breathe on them to get a peep-hole over to the old
+house, and there the snow had been blown into all the carved work and
+inscriptions; it lay quite up over the steps, just as if there was no
+one at home--nor was there any one at home--the old man was dead!
+
+In the evening there was a hearse seen before the door, and he was borne
+into it in his coffin: he was now to go out into the country, to lie in
+his grave. He was driven out there, but no one followed; all his friends
+were dead, and the little boy kissed his hand to the coffin as it was
+driven away.
+
+Some days afterwards there was an auction at the old house, and the
+little boy saw from his window how they carried the old knights and the
+old ladies away, the flower-pots with the long ears, the old chairs, and
+the old clothes-presses. Something came here, and something came there;
+the portrait of her who had been found at the broker’s came to the
+broker’s again; and there it hung, for no one knew her more--no one
+cared about the old picture.
+
+In the spring they pulled the house down, for, as people said, it was
+a ruin. One could see from the street right into the room with the
+hog’s-leather hanging, which was slashed and torn; and the green grass
+and leaves about the balcony hung quite wild about the falling beams.
+And then it was put to rights.
+
+“That was a relief,” said the neighboring houses.
+
+A fine house was built there, with large windows, and smooth white
+walls; but before it, where the old house had in fact stood, was a
+little garden laid out, and a wild grapevine ran up the wall of the
+neighboring house. Before the garden there was a large iron railing
+with an iron door, it looked quite splendid, and people stood still and
+peeped in, and the sparrows hung by scores in the vine, and chattered
+away at each other as well as they could, but it was not about the old
+house, for they could not remember it, so many years had passed--so many
+that the little boy had grown up to a whole man, yes, a clever man, and
+a pleasure to his parents; and he had just been married, and, together
+with his little wife, had come to live in the house here, where the
+garden was; and he stood by her there whilst she planted a field-flower
+that she found so pretty; she planted it with her little hand, and
+pressed the earth around it with her fingers. Oh! what was that? She
+had stuck herself. There sat something pointed, straight out of the soft
+mould.
+
+It was--yes, guess! It was the pewter soldier, he that was lost up at
+the old man’s, and had tumbled and turned about amongst the timber and
+the rubbish, and had at last laid for many years in the ground.
+
+The young wife wiped the dirt off the soldier, first with a green leaf,
+and then with her fine handkerchief--it had such a delightful smell,
+that it was to the pewter soldier just as if he had awaked from a
+trance.
+
+“Let me see him,” said the young man. He laughed, and then shook his
+head. “Nay, it cannot be he; but he reminds me of a story about a pewter
+soldier which I had when I was a little boy!” And then he told his wife
+about the old house, and the old man, and about the pewter soldier that
+he sent over to him because he was so very, very lonely; and he told it
+as correctly as it had really been, so that the tears came into the eyes
+of his young wife, on account of the old house and the old man.
+
+“It may possibly be, however, that it is the same pewter soldier!” said
+she. “I will take care of it, and remember all that you have told me;
+but you must show me the old man’s grave!”
+
+“But I do not know it,” said he, “and no one knows it! All his friends
+were dead, no one took care of it, and I was then a little boy!”
+
+“How very, very lonely he must have been!” said she.
+
+“Very, very lonely!” said the pewter soldier. “But it is delightful not
+to be forgotten!”
+
+“Delightful!” shouted something close by; but no one, except the pewter
+soldier, saw that it was a piece of the hog’s-leather hangings; it had
+lost all its gilding, it looked like a piece of wet clay, but it had an
+opinion, and it gave it:
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+This the pewter soldier did not believe.
+
+
+
+
+THE HAPPY FAMILY
+
+Really, the largest green leaf in this country is a dock-leaf; if one
+holds it before one, it is like a whole apron, and if one holds it over
+one’s head in rainy weather, it is almost as good as an umbrella, for
+it is so immensely large. The burdock never grows alone, but where there
+grows one there always grow several: it is a great delight, and all this
+delightfulness is snails’ food. The great white snails which persons of
+quality in former times made fricassees of, ate, and said, “Hem,
+hem! how delicious!” for they thought it tasted so delicate--lived on
+dock-leaves, and therefore burdock seeds were sown.
+
+Now, there was an old manor-house, where they no longer ate snails, they
+were quite extinct; but the burdocks were not extinct, they grew and
+grew all over the walks and all the beds; they could not get the mastery
+over them--it was a whole forest of burdocks. Here and there stood an
+apple and a plum-tree, or else one never would have thought that it was
+a garden; all was burdocks, and there lived the two last venerable old
+snails.
+
+They themselves knew not how old they were, but they could remember
+very well that there had been many more; that they were of a family
+from foreign lands, and that for them and theirs the whole forest was
+planted. They had never been outside it, but they knew that there was
+still something more in the world, which was called the manor-house, and
+that there they were boiled, and then they became black, and were then
+placed on a silver dish; but what happened further they knew not; or, in
+fact, what it was to be boiled, and to lie on a silver dish, they could
+not possibly imagine; but it was said to be delightful, and particularly
+genteel. Neither the chafers, the toads, nor the earth-worms, whom they
+asked about it could give them any information--none of them had been
+boiled or laid on a silver dish.
+
+The old white snails were the first persons of distinction in the
+world, that they knew; the forest was planted for their sake, and the
+manor-house was there that they might be boiled and laid on a silver
+dish.
+
+Now they lived a very lonely and happy life; and as they had no children
+themselves, they had adopted a little common snail, which they brought
+up as their own; but the little one would not grow, for he was of a
+common family; but the old ones, especially Dame Mother Snail, thought
+they could observe how he increased in size, and she begged father,
+if he could not see it, that he would at least feel the little snail’s
+shell; and then he felt it, and found the good dame was right.
+
+One day there was a heavy storm of rain.
+
+“Hear how it beats like a drum on the dock-leaves!” said Father Snail.
+
+“There are also rain-drops!” said Mother Snail. “And now the rain pours
+right down the stalk! You will see that it will be wet here! I am very
+happy to think that we have our good house, and the little one has
+his also! There is more done for us than for all other creatures, sure
+enough; but can you not see that we are folks of quality in the world?
+We are provided with a house from our birth, and the burdock forest is
+planted for our sakes! I should like to know how far it extends, and
+what there is outside!”
+
+“There is nothing at all,” said Father Snail. “No place can be better
+than ours, and I have nothing to wish for!”
+
+“Yes,” said the dame. “I would willingly go to the manorhouse, be
+boiled, and laid on a silver dish; all our forefathers have been treated
+so; there is something extraordinary in it, you may be sure!”
+
+“The manor-house has most likely fallen to ruin!” said Father Snail. “Or
+the burdocks have grown up over it, so that they cannot come out. There
+need not, however, be any haste about that; but you are always in such a
+tremendous hurry, and the little one is beginning to be the same. Has he
+not been creeping up that stalk these three days? It gives me a headache
+when I look up to him!”
+
+“You must not scold him,” said Mother Snail. “He creeps so carefully; he
+will afford us much pleasure--and we have nothing but him to live for!
+But have you not thought of it? Where shall we get a wife for him? Do
+you not think that there are some of our species at a great distance in
+the interior of the burdock forest?”
+
+“Black snails, I dare say, there are enough of,” said the old one.
+“Black snails without a house--but they are so common, and so conceited.
+But we might give the ants a commission to look out for us; they run
+to and fro as if they had something to do, and they certainly know of a
+wife for our little snail!”
+
+“I know one, sure enough--the most charming one!” said one of the ants.
+“But I am afraid we shall hardly succeed, for she is a queen!”
+
+“That is nothing!” said the old folks. “Has she a house?”
+
+“She has a palace!” said the ant. “The finest ant’s palace, with seven
+hundred passages!”
+
+“I thank you!” said Mother Snail. “Our son shall not go into an
+ant-hill; if you know nothing better than that, we shall give the
+commission to the white gnats. They fly far and wide, in rain and
+sunshine; they know the whole forest here, both within and without.”
+
+“We have a wife for him,” said the gnats. “At a hundred human paces from
+here there sits a little snail in her house, on a gooseberry bush; she
+is quite lonely, and old enough to be married. It is only a hundred
+human paces!”
+
+“Well, then, let her come to him!” said the old ones. “He has a whole
+forest of burdocks, she has only a bush!”
+
+And so they went and fetched little Miss Snail. It was a whole week
+before she arrived; but therein was just the very best of it, for one
+could thus see that she was of the same species.
+
+And then the marriage was celebrated. Six earth-worms shone as well as
+they could. In other respects the whole went off very quietly, for the
+old folks could not bear noise and merriment; but old Dame Snail made
+a brilliant speech. Father Snail could not speak, he was too much
+affected; and so they gave them as a dowry and inheritance, the whole
+forest of burdocks, and said--what they had always said--that it was
+the best in the world; and if they lived honestly and decently, and
+increased and multiplied, they and their children would once in the
+course of time come to the manor-house, be boiled black, and laid on
+silver dishes. After this speech was made, the old ones crept into their
+shells, and never more came out. They slept; the young couple governed
+in the forest, and had a numerous progeny, but they were never boiled,
+and never came on the silver dishes; so from this they concluded that
+the manor-house had fallen to ruins, and that all the men in the world
+were extinct; and as no one contradicted them, so, of course it was so.
+And the rain beat on the dock-leaves to make drum-music for their sake,
+and the sun shone in order to give the burdock forest a color for their
+sakes; and they were very happy, and the whole family was happy; for
+they, indeed were so.
+
+
+
+
+THE STORY OF A MOTHER
+
+A mother sat there with her little child. She was so downcast, so
+afraid that it should die! It was so pale, the small eyes had closed
+themselves, and it drew its breath so softly, now and then, with a
+deep respiration, as if it sighed; and the mother looked still more
+sorrowfully on the little creature.
+
+Then a knocking was heard at the door, and in came a poor old man
+wrapped up as in a large horse-cloth, for it warms one, and he needed
+it, as it was the cold winter season! Everything out-of-doors was
+covered with ice and snow, and the wind blew so that it cut the face.
+
+As the old man trembled with cold, and the little child slept a moment,
+the mother went and poured some ale into a pot and set it on the stove,
+that it might be warm for him; the old man sat and rocked the cradle,
+and the mother sat down on a chair close by him, and looked at her
+little sick child that drew its breath so deep, and raised its little
+hand.
+
+“Do you not think that I shall save him?” said she. “Our Lord will not
+take him from me!”
+
+And the old man--it was Death himself--he nodded so strangely, it could
+just as well signify yes as no. And the mother looked down in her lap,
+and the tears ran down over her cheeks; her head became so heavy--she
+had not closed her eyes for three days and nights; and now she slept,
+but only for a minute, when she started up and trembled with cold.
+
+“What is that?” said she, and looked on all sides; but the old man was
+gone, and her little child was gone--he had taken it with him; and the
+old clock in the corner burred, and burred, the great leaden weight ran
+down to the floor, bump! and then the clock also stood still.
+
+But the poor mother ran out of the house and cried aloud for her child.
+
+Out there, in the midst of the snow, there sat a woman in long, black
+clothes; and she said, “Death has been in thy chamber, and I saw him
+hasten away with thy little child; he goes faster than the wind, and he
+never brings back what he takes!”
+
+“Oh, only tell me which way he went!” said the mother. “Tell me the way,
+and I shall find him!”
+
+“I know it!” said the woman in the black clothes. “But before I tell it,
+thou must first sing for me all the songs thou hast sung for thy child!
+I am fond of them. I have heard them before; I am Night; I saw thy tears
+whilst thou sang’st them!”
+
+“I will sing them all, all!” said the mother. “But do not stop me now--I
+may overtake him--I may find my child!”
+
+But Night stood still and mute. Then the mother wrung her hands, sang
+and wept, and there were many songs, but yet many more tears; and then
+Night said, “Go to the right, into the dark pine forest; thither I saw
+Death take his way with thy little child!”
+
+The roads crossed each other in the depths of the forest, and she no
+longer knew whither she should go! then there stood a thorn-bush;
+there was neither leaf nor flower on it, it was also in the cold winter
+season, and ice-flakes hung on the branches.
+
+“Hast thou not seen Death go past with my little child?” said the
+mother.
+
+“Yes,” said the thorn-bush; “but I will not tell thee which way he took,
+unless thou wilt first warm me up at thy heart. I am freezing to death;
+I shall become a lump of ice!”
+
+And she pressed the thorn-bush to her breast, so firmly, that it might
+be thoroughly warmed, and the thorns went right into her flesh, and her
+blood flowed in large drops, but the thornbush shot forth fresh green
+leaves, and there came flowers on it in the cold winter night, the heart
+of the afflicted mother was so warm; and the thorn-bush told her the way
+she should go.
+
+She then came to a large lake, where there was neither ship nor boat.
+The lake was not frozen sufficiently to bear her; neither was it open,
+nor low enough that she could wade through it; and across it she must go
+if she would find her child! Then she lay down to drink up the lake, and
+that was an impossibility for a human being, but the afflicted mother
+thought that a miracle might happen nevertheless.
+
+“Oh, what would I not give to come to my child!” said the weeping
+mother; and she wept still more, and her eyes sunk down in the depths of
+the waters, and became two precious pearls; but the water bore her up,
+as if she sat in a swing, and she flew in the rocking waves to the shore
+on the opposite side, where there stood a mile-broad, strange house, one
+knew not if it were a mountain with forests and caverns, or if it were
+built up; but the poor mother could not see it; she had wept her eyes
+out.
+
+“Where shall I find Death, who took away my little child?” said she.
+
+“He has not come here yet!” said the old grave woman, who was appointed
+to look after Death’s great greenhouse! “How have you been able to find
+the way hither? And who has helped you?”
+
+“OUR LORD has helped me,” said she. “He is merciful, and you will also
+be so! Where shall I find my little child?”
+
+“Nay, I know not,” said the woman, “and you cannot see! Many flowers and
+trees have withered this night; Death will soon come and plant them over
+again! You certainly know that every person has his or her life’s tree
+or flower, just as everyone happens to be settled; they look like other
+plants, but they have pulsations of the heart. Children’s hearts can
+also beat; go after yours, perhaps you may know your child’s; but what
+will you give me if I tell you what you shall do more?”
+
+“I have nothing to give,” said the afflicted mother, “but I will go to
+the world’s end for you!”
+
+“Nay, I have nothing to do there!” said the woman. “But you can give
+me your long black hair; you know yourself that it is fine, and that
+I like! You shall have my white hair instead, and that’s always
+something!”
+
+“Do you demand nothing else?” said she. “That I will gladly give you!”
+ And she gave her her fine black hair, and got the old woman’s snow-white
+hair instead.
+
+So they went into Death’s great greenhouse, where flowers and trees
+grew strangely into one another. There stood fine hyacinths under glass
+bells, and there stood strong-stemmed peonies; there grew water plants,
+some so fresh, others half sick, the water-snakes lay down on them,
+and black crabs pinched their stalks. There stood beautiful palm-trees,
+oaks, and plantains; there stood parsley and flowering thyme: every tree
+and every flower had its name; each of them was a human life, the human
+frame still lived--one in China, and another in Greenland--round about
+in the world. There were large trees in small pots, so that they stood
+so stunted in growth, and ready to burst the pots; in other places,
+there was a little dull flower in rich mould, with moss round about it,
+and it was so petted and nursed. But the distressed mother bent down
+over all the smallest plants, and heard within them how the human heart
+beat; and amongst millions she knew her child’s.
+
+“There it is!” cried she, and stretched her hands out over a little blue
+crocus, that hung quite sickly on one side.
+
+“Don’t touch the flower!” said the old woman. “But place yourself here,
+and when Death comes--I expect him every moment--do not let him pluck
+the flower up, but threaten him that you will do the same with the
+others. Then he will be afraid! He is responsible for them to OUR LORD,
+and no one dares to pluck them up before HE gives leave.”
+
+All at once an icy cold rushed through the great hall, and the blind
+mother could feel that it was Death that came.
+
+“How hast thou been able to find thy way hither?” he asked. “How couldst
+thou come quicker than I?”
+
+“I am a mother,” said she.
+
+And Death stretched out his long hand towards the fine little flower,
+but she held her hands fast around his, so tight, and yet afraid that
+she should touch one of the leaves. Then Death blew on her hands, and
+she felt that it was colder than the cold wind, and her hands fell down
+powerless.
+
+“Thou canst not do anything against me!” said Death.
+
+“But OUR LORD can!” said she.
+
+“I only do His bidding!” said Death. “I am His gardener, I take all His
+flowers and trees, and plant them out in the great garden of Paradise,
+in the unknown land; but how they grow there, and how it is there I dare
+not tell thee.”
+
+“Give me back my child!” said the mother, and she wept and prayed. At
+once she seized hold of two beautiful flowers close by, with each hand,
+and cried out to Death, “I will tear all thy flowers off, for I am in
+despair.”
+
+“Touch them not!” said Death. “Thou say’st that thou art so unhappy, and
+now thou wilt make another mother equally unhappy.”
+
+“Another mother!” said the poor woman, and directly let go her hold of
+both the flowers.
+
+“There, thou hast thine eyes,” said Death; “I fished them up from the
+lake, they shone so bright; I knew not they were thine. Take them again,
+they are now brighter than before; now look down into the deep well
+close by; I shall tell thee the names of the two flowers thou wouldst
+have torn up, and thou wilt see their whole future life--their whole
+human existence: and see what thou wast about to disturb and destroy.”
+
+And she looked down into the well; and it was a happiness to see how the
+one became a blessing to the world, to see how much happiness and joy
+were felt everywhere. And she saw the other’s life, and it was sorrow
+and distress, horror, and wretchedness.
+
+“Both of them are God’s will!” said Death.
+
+“Which of them is Misfortune’s flower and which is that of Happiness?”
+ asked she.
+
+“That I will not tell thee,” said Death; “but this thou shalt know from
+me, that the one flower was thy own child! it was thy child’s fate thou
+saw’st--thy own child’s future life!”
+
+Then the mother screamed with terror, “Which of them was my child? Tell
+it me! Save the innocent! Save my child from all that misery! Rather
+take it away! Take it into God’s kingdom! Forget my tears, forget my
+prayers, and all that I have done!”
+
+“I do not understand thee!” said Death. “Wilt thou have thy child again,
+or shall I go with it there, where thou dost not know!”
+
+Then the mother wrung her hands, fell on her knees, and prayed to our
+Lord: “Oh, hear me not when I pray against Thy will, which is the best!
+hear me not! hear me not!”
+
+And she bowed her head down in her lap, and Death took her child and
+went with it into the unknown land.
+
+
+
+
+THE FALSE COLLAR
+
+There was once a fine gentleman, all of whose moveables were a boot-jack
+and a hair-comb: but he had the finest false collars in the world; and
+it is about one of these collars that we are now to hear a story.
+
+It was so old, that it began to think of marriage; and it happened that
+it came to be washed in company with a garter.
+
+“Nay!” said the collar. “I never did see anything so slender and so
+fine, so soft and so neat. May I not ask your name?”
+
+“That I shall not tell you!” said the garter.
+
+“Where do you live?” asked the collar.
+
+But the garter was so bashful, so modest, and thought it was a strange
+question to answer.
+
+“You are certainly a girdle,” said the collar; “that is to say an inside
+girdle. I see well that you are both for use and ornament, my dear young
+lady.”
+
+“I will thank you not to speak to me,” said the garter. “I think I have
+not given the least occasion for it.”
+
+“Yes! When one is as handsome as you,” said the collar, “that is
+occasion enough.”
+
+“Don’t come so near me, I beg of you!” said the garter. “You look so
+much like those men-folks.”
+
+“I am also a fine gentleman,” said the collar. “I have a bootjack and a
+hair-comb.”
+
+But that was not true, for it was his master who had them: but he
+boasted.
+
+“Don’t come so near me,” said the garter: “I am not accustomed to it.”
+
+“Prude!” exclaimed the collar; and then it was taken out of the
+washing-tub. It was starched, hung over the back of a chair in the
+sunshine, and was then laid on the ironing-blanket; then came the warm
+box-iron. “Dear lady!” said the collar. “Dear widow-lady! I feel quite
+hot. I am quite changed. I begin to unfold myself. You will burn a hole
+in me. Oh! I offer you my hand.”
+
+“Rag!” said the box-iron; and went proudly over the collar: for she
+fancied she was a steam-engine, that would go on the railroad and draw
+the waggons. “Rag!” said the box-iron.
+
+The collar was a little jagged at the edge, and so came the long
+scissors to cut off the jagged part. “Oh!” said the collar. “You are
+certainly the first opera dancer. How well you can stretch your legs
+out! It is the most graceful performance I have ever seen. No one can
+imitate you.”
+
+“I know it,” said the scissors.
+
+“You deserve to be a baroness,” said the collar. “All that I have is a
+fine gentleman, a boot-jack, and a hair-comb. If I only had the barony!”
+
+“Do you seek my hand?” said the scissors; for she was angry; and without
+more ado, she CUT HIM, and then he was condemned.
+
+“I shall now be obliged to ask the hair-comb. It is surprising how well
+you preserve your teeth, Miss,” said the collar. “Have you never thought
+of being betrothed?”
+
+“Yes, of course! you may be sure of that,” said the hair-comb. “I AM
+betrothed--to the boot-jack!”
+
+“Betrothed!” exclaimed the collar. Now there was no other to court, and
+so he despised it.
+
+A long time passed away, then the collar came into the rag chest at the
+paper mill; there was a large company of rags, the fine by themselves,
+and the coarse by themselves, just as it should be. They all had much to
+say, but the collar the most; for he was a real boaster.
+
+“I have had such an immense number of sweethearts!” said the collar.
+“I could not be in peace! It is true, I was always a fine starched-up
+gentleman! I had both a boot-jack and a hair-comb, which I never used!
+You should have seen me then, you should have seen me when I lay down!
+I shall never forget MY FIRST LOVE--she was a girdle, so fine, so soft,
+and so charming, she threw herself into a tub of water for my sake!
+There was also a widow, who became glowing hot, but I left her standing
+till she got black again; there was also the first opera dancer, she
+gave me that cut which I now go with, she was so ferocious! My
+own hair-comb was in love with me, she lost all her teeth from the
+heart-ache; yes, I have lived to see much of that sort of thing; but I
+am extremely sorry for the garter--I mean the girdle--that went into the
+water-tub. I have much on my conscience, I want to become white paper!”
+
+And it became so, all the rags were turned into white paper; but the
+collar came to be just this very piece of white paper we here see,
+and on which the story is printed; and that was because it boasted so
+terribly afterwards of what had never happened to it. It would be well
+for us to beware, that we may not act in a similar manner, for we can
+never know if we may not, in the course of time, also come into the
+rag chest, and be made into white paper, and then have our whole life’s
+history printed on it, even the most secret, and be obliged to run about
+and tell it ourselves, just like this collar.
+
+
+
+
+THE SHADOW
+
+It is in the hot lands that the sun burns, sure enough! there the people
+become quite a mahogany brown, ay, and in the HOTTEST lands they are
+burnt to Negroes. But now it was only to the HOT lands that a learned
+man had come from the cold; there he thought that he could run about
+just as when at home, but he soon found out his mistake.
+
+He, and all sensible folks, were obliged to stay within doors--the
+window-shutters and doors were closed the whole day; it looked as if the
+whole house slept, or there was no one at home.
+
+The narrow street with the high houses, was built so that the sunshine
+must fall there from morning till evening--it was really not to be
+borne.
+
+The learned man from the cold lands--he was a young man, and seemed to
+be a clever man--sat in a glowing oven; it took effect on him, he became
+quite meagre--even his shadow shrunk in, for the sun had also an effect
+on it. It was first towards evening when the sun was down, that they
+began to freshen up again.
+
+In the warm lands every window has a balcony, and the people came out on
+all the balconies in the street--for one must have air, even if one be
+accustomed to be mahogany!* It was lively both up and down the
+street. Tailors, and shoemakers, and all the folks, moved out into the
+street--chairs and tables were brought forth--and candles burnt--yes,
+above a thousand lights were burning--and the one talked and the other
+sung; and people walked and church-bells rang, and asses went along with
+a dingle-dingle-dong! for they too had bells on. The street boys were
+screaming and hooting, and shouting and shooting, with devils and
+detonating balls--and there came corpse bearers and hood wearers--for
+there were funerals with psalm and hymn--and then the din of carriages
+driving and company arriving: yes, it was, in truth, lively enough down
+in the street. Only in that single house, which stood opposite that in
+which the learned foreigner lived, it was quite still; and yet some one
+lived there, for there stood flowers in the balcony--they grew so
+well in the sun’s heat! and that they could not do unless they were
+watered--and some one must water them--there must be somebody there.
+The door opposite was also opened late in the evening, but it was dark
+within, at least in the front room; further in there was heard the sound
+of music. The learned foreigner thought it quite marvellous, but now--it
+might be that he only imagined it--for he found everything marvellous
+out there, in the warm lands, if there had only been no sun. The
+stranger’s landlord said that he didn’t know who had taken the house
+opposite, one saw no person about, and as to the music, it appeared
+to him to be extremely tiresome. “It is as if some one sat there, and
+practised a piece that he could not master--always the same piece. ‘I
+shall master it!’ says he; but yet he cannot master it, however long he
+plays.”
+
+* The word mahogany can be understood, in Danish, as having two
+meanings. In general, it means the reddish-brown wood itself; but in
+jest, it signifies “excessively fine,” which arose from an anecdote of
+Nyboder, in Copenhagen, (the seamen’s quarter.) A sailor’s wife, who was
+always proud and fine, in her way, came to her neighbor, and complained
+that she had got a splinter in her finger. “What of?” asked the
+neighbor’s wife. “It is a mahogany splinter,” said the other. “Mahogany!
+It cannot be less with you!” exclaimed the woman--and thence the
+proverb, “It is so mahogany!”--(that is, so excessively fine)--is
+derived.
+
+
+One night the stranger awoke--he slept with the doors of the balcony
+open--the curtain before it was raised by the wind, and he thought
+that a strange lustre came from the opposite neighbor’s house; all the
+flowers shone like flames, in the most beautiful colors, and in the
+midst of the flowers stood a slender, graceful maiden--it was as if she
+also shone; the light really hurt his eyes. He now opened them quite
+wide--yes, he was quite awake; with one spring he was on the floor; he
+crept gently behind the curtain, but the maiden was gone; the flowers
+shone no longer, but there they stood, fresh and blooming as ever;
+the door was ajar, and, far within, the music sounded so soft and
+delightful, one could really melt away in sweet thoughts from it. Yet
+it was like a piece of enchantment. And who lived there? Where was the
+actual entrance? The whole of the ground-floor was a row of shops, and
+there people could not always be running through.
+
+One evening the stranger sat out on the balcony. The light burnt in the
+room behind him; and thus it was quite natural that his shadow should
+fall on his opposite neighbor’s wall. Yes! there it sat, directly
+opposite, between the flowers on the balcony; and when the stranger
+moved, the shadow also moved: for that it always does.
+
+“I think my shadow is the only living thing one sees over there,” said
+the learned man. “See, how nicely it sits between the flowers. The door
+stands half-open: now the shadow should be cunning, and go into the
+room, look about, and then come and tell me what it had seen. Come, now!
+Be useful, and do me a service,” said he, in jest. “Have the kindness to
+step in. Now! Art thou going?” and then he nodded to the shadow, and the
+shadow nodded again. “Well then, go! But don’t stay away.”
+
+The stranger rose, and his shadow on the opposite neighbor’s balcony
+rose also; the stranger turned round and the shadow also turned round.
+Yes! if anyone had paid particular attention to it, they would have
+seen, quite distinctly, that the shadow went in through the half-open
+balcony-door of their opposite neighbor, just as the stranger went into
+his own room, and let the long curtain fall down after him.
+
+Next morning, the learned man went out to drink coffee and read the
+newspapers.
+
+“What is that?” said he, as he came out into the sunshine. “I have no
+shadow! So then, it has actually gone last night, and not come again. It
+is really tiresome!”
+
+This annoyed him: not so much because the shadow was gone, but because
+he knew there was a story about a man without a shadow.* It was known
+to everybody at home, in the cold lands; and if the learned man now came
+there and told his story, they would say that he was imitating it, and
+that he had no need to do. He would, therefore, not talk about it at
+all; and that was wisely thought.
+
+*Peter Schlemihl, the shadowless man.
+
+
+In the evening he went out again on the balcony. He had placed the light
+directly behind him, for he knew that the shadow would always have its
+master for a screen, but he could not entice it. He made himself little;
+he made himself great: but no shadow came again. He said, “Hem! hem!”
+ but it was of no use.
+
+It was vexatious; but in the warm lands everything grows so quickly; and
+after the lapse of eight days he observed, to his great joy, that a new
+shadow came in the sunshine. In the course of three weeks he had a very
+fair shadow, which, when he set out for his home in the northern lands,
+grew more and more in the journey, so that at last it was so long and so
+large, that it was more than sufficient.
+
+The learned man then came home, and he wrote books about what was true
+in the world, and about what was good and what was beautiful; and there
+passed days and years--yes! many years passed away.
+
+One evening, as he was sitting in his room, there was a gentle knocking
+at the door.
+
+“Come in!” said he; but no one came in; so he opened the door, and there
+stood before him such an extremely lean man, that he felt quite strange.
+As to the rest, the man was very finely dressed--he must be a gentleman.
+
+“Whom have I the honor of speaking?” asked the learned man.
+
+“Yes! I thought as much,” said the fine man. “I thought you would not
+know me. I have got so much body. I have even got flesh and clothes. You
+certainly never thought of seeing me so well off. Do you not know your
+old shadow? You certainly thought I should never more return. Things
+have gone on well with me since I was last with you. I have, in all
+respects, become very well off. Shall I purchase my freedom from
+service? If so, I can do it”; and then he rattled a whole bunch of
+valuable seals that hung to his watch, and he stuck his hand in the
+thick gold chain he wore around his neck--nay! how all his fingers
+glittered with diamond rings; and then all were pure gems.
+
+“Nay; I cannot recover from my surprise!” said the learned man. “What is
+the meaning of all this?”
+
+“Something common, is it not,” said the shadow. “But you yourself do not
+belong to the common order; and I, as you know well, have from a child
+followed in your footsteps. As soon as you found I was capable to go
+out alone in the world, I went my own way. I am in the most brilliant
+circumstances, but there came a sort of desire over me to see you once
+more before you die; you will die, I suppose? I also wished to see this
+land again--for you know we always love our native land. I know you have
+got another shadow again; have I anything to pay to it or you? If so,
+you will oblige me by saying what it is.”
+
+“Nay, is it really thou?” said the learned man. “It is most remarkable:
+I never imagined that one’s old shadow could come again as a man.”
+
+“Tell me what I have to pay,” said the shadow; “for I don’t like to be
+in any sort of debt.”
+
+“How canst thou talk so?” said the learned man. “What debt is there to
+talk about? Make thyself as free as anyone else. I am extremely glad to
+hear of thy good fortune: sit down, old friend, and tell me a little
+how it has gone with thee, and what thou hast seen at our opposite
+neighbor’s there--in the warm lands.”
+
+“Yes, I will tell you all about it,” said the shadow, and sat down: “but
+then you must also promise me, that, wherever you may meet me, you will
+never say to anyone here in the town that I have been your shadow. I
+intend to get betrothed, for I can provide for more than one family.”
+
+“Be quite at thy ease about that,” said the learned man; “I shall not
+say to anyone who thou actually art: here is my hand--I promise it, and
+a man’s bond is his word.”
+
+“A word is a shadow,” said the shadow, “and as such it must speak.”
+
+It was really quite astonishing how much of a man it was. It was dressed
+entirely in black, and of the very finest cloth; it had patent leather
+boots, and a hat that could be folded together, so that it was bare
+crown and brim; not to speak of what we already know it had--seals, gold
+neck-chain, and diamond rings; yes, the shadow was well-dressed, and it
+was just that which made it quite a man.
+
+“Now I shall tell you my adventures,” said the shadow; and then he
+sat, with the polished boots, as heavily as he could, on the arm of the
+learned man’s new shadow, which lay like a poodle-dog at his feet.
+Now this was perhaps from arrogance; and the shadow on the ground kept
+itself so still and quiet, that it might hear all that passed: it wished
+to know how it could get free, and work its way up, so as to become its
+own master.
+
+“Do you know who lived in our opposite neighbor’s house?” said the
+shadow. “It was the most charming of all beings, it was Poesy! I was
+there for three weeks, and that has as much effect as if one had lived
+three thousand years, and read all that was composed and written;
+that is what I say, and it is right. I have seen everything and I know
+everything!”
+
+“Poesy!” cried the learned man. “Yes, yes, she often dwells a recluse
+in large cities! Poesy! Yes, I have seen her--a single short moment,
+but sleep came into my eyes! She stood on the balcony and shone as the
+Aurora Borealis shines. Go on, go on--thou wert on the balcony, and went
+through the doorway, and then--”
+
+“Then I was in the antechamber,” said the shadow. “You always sat and
+looked over to the antechamber. There was no light; there was a sort
+of twilight, but the one door stood open directly opposite the other
+through a long row of rooms and saloons, and there it was lighted up. I
+should have been completely killed if I had gone over to the maiden; but
+I was circumspect, I took time to think, and that one must always do.”
+
+“And what didst thou then see?” asked the learned man.
+
+“I saw everything, and I shall tell all to you: but--it is no pride on
+my part--as a free man, and with the knowledge I have, not to speak of
+my position in life, my excellent circumstances--I certainly wish that
+you would say YOU* to me!”
+
+* It is the custom in Denmark for intimate acquaintances to use the
+second person singular, “Du,” (thou) when speaking to each other. When
+a friendship is formed between men, they generally affirm it, when
+occasion offers, either in public or private, by drinking to each other
+and exclaiming, “thy health,” at the same time striking their glasses
+together. This is called drinking “Duus”: they are then, “Duus Brodre,”
+ (thou brothers) and ever afterwards use the pronoun “thou,” to each
+other, it being regarded as more familiar than “De,” (you). Father and
+mother, sister and brother say thou to one another--without regard to
+age or rank. Master and mistress say thou to their servants the superior
+to the inferior. But servants and inferiors do not use the same term
+to their masters, or superiors--nor is it ever used when speaking to a
+stranger, or anyone with whom they are but slightly acquainted--they
+then say as in English--you.
+
+
+“I beg your pardon,” said the learned man; “it is an old habit with me.
+YOU are perfectly right, and I shall remember it; but now you must tell
+me all YOU saw!”
+
+“Everything!” said the shadow. “For I saw everything, and I know
+everything!”
+
+“How did it look in the furthest saloon?” asked the learned man. “Was it
+there as in the fresh woods? Was it there as in a holy church? Were the
+saloons like the starlit firmament when we stand on the high mountains?”
+
+“Everything was there!” said the shadow. “I did not go quite in, I
+remained in the foremost room, in the twilight, but I stood there
+quite well; I saw everything, and I know everything! I have been in the
+antechamber at the court of Poesy.”
+
+“But WHAT DID you see? Did all the gods of the olden times pass through
+the large saloons? Did the old heroes combat there? Did sweet children
+play there, and relate their dreams?”
+
+“I tell you I was there, and you can conceive that I saw everything
+there was to be seen. Had you come over there, you would not have been
+a man; but I became so! And besides, I learned to know my inward nature,
+my innate qualities, the relationship I had with Poesy. At the time I
+was with you, I thought not of that, but always--you know it well--when
+the sun rose, and when the sun went down, I became so strangely great;
+in the moonlight I was very near being more distinct than yourself; at
+that time I did not understand my nature; it was revealed to me in the
+antechamber! I became a man! I came out matured; but you were no longer
+in the warm lands; as a man I was ashamed to go as I did. I was in
+want of boots, of clothes, of the whole human varnish that makes a man
+perceptible. I took my way--I tell it to you, but you will not put it in
+any book--I took my way to the cake woman--I hid myself behind her;
+the woman didn’t think how much she concealed. I went out first in the
+evening; I ran about the streets in the moonlight; I made myself long up
+the walls--it tickles the back so delightfully! I ran up, and ran down,
+peeped into the highest windows, into the saloons, and on the roofs, I
+peeped in where no one could peep, and I saw what no one else saw, what
+no one else should see! This is, in fact, a base world! I would not be a
+man if it were not now once accepted and regarded as something to be so!
+I saw the most unimaginable things with the women, with the men, with
+parents, and with the sweet, matchless children; I saw,” said the
+shadow, “what no human being must know, but what they would all
+so willingly know--what is bad in their neighbor. Had I written a
+newspaper, it would have been read! But I wrote direct to the persons
+themselves, and there was consternation in all the towns where I came.
+They were so afraid of me, and yet they were so excessively fond of
+me. The professors made a professor of me; the tailors gave me new
+clothes--I am well furnished; the master of the mint struck new coin for
+me, and the women said I was so handsome! And so I became the man I am.
+And I now bid you farewell. Here is my card--I live on the sunny side
+of the street, and am always at home in rainy weather!” And so away went
+the shadow. “That was most extraordinary!” said the learned man. Years
+and days passed away, then the shadow came again. “How goes it?” said
+the shadow.
+
+“Alas!” said the learned man. “I write about the true, and the good,
+and the beautiful, but no one cares to hear such things; I am quite
+desperate, for I take it so much to heart!”
+
+“But I don’t!” said the shadow. “I become fat, and it is that one wants
+to become! You do not understand the world. You will become ill by it.
+You must travel! I shall make a tour this summer; will you go with me?
+I should like to have a travelling companion! Will you go with me, as
+shadow? It will be a great pleasure for me to have you with me; I shall
+pay the travelling expenses!”
+
+“Nay, this is too much!” said the learned man.
+
+“It is just as one takes it!” said the shadow. “It will do you much good
+to travel! Will you be my shadow? You shall have everything free on the
+journey!”
+
+“Nay, that is too bad!” said the learned man.
+
+“But it is just so with the world!” said the shadow, “and so it will
+be!” and away it went again.
+
+The learned man was not at all in the most enviable state; grief and
+torment followed him, and what he said about the true, and the good, and
+the beautiful, was, to most persons, like roses for a cow! He was quite
+ill at last.
+
+“You really look like a shadow!” said his friends to him; and the
+learned man trembled, for he thought of it.
+
+“You must go to a watering-place!” said the shadow, who came and visited
+him. “There is nothing else for it! I will take you with me for old
+acquaintance’ sake; I will pay the travelling expenses, and you write
+the descriptions--and if they are a little amusing for me on the way!
+I will go to a watering-place--my beard does not grow out as it
+ought--that is also a sickness--and one must have a beard! Now you be
+wise and accept the offer; we shall travel as comrades!”
+
+And so they travelled; the shadow was master, and the master was the
+shadow; they drove with each other, they rode and walked together, side
+by side, before and behind, just as the sun was; the shadow always took
+care to keep itself in the master’s place. Now the learned man didn’t
+think much about that; he was a very kind-hearted man, and particularly
+mild and friendly, and so he said one day to the shadow: “As we have
+now become companions, and in this way have grown up together from
+childhood, shall we not drink ‘thou’ together, it is more familiar?”
+
+“You are right,” said the shadow, who was now the proper master. “It is
+said in a very straight-forward and well-meant manner. You, as a learned
+man, certainly know how strange nature is. Some persons cannot bear to
+touch grey paper, or they become ill; others shiver in every limb if one
+rub a pane of glass with a nail: I have just such a feeling on hearing
+you say thou to me; I feel myself as if pressed to the earth in my first
+situation with you. You see that it is a feeling; that it is not pride:
+I cannot allow you to say THOU to me, but I will willingly say THOU to
+you, so it is half done!”
+
+So the shadow said THOU to its former master.
+
+“This is rather too bad,” thought he, “that I must say YOU and he say
+THOU,” but he was now obliged to put up with it.
+
+So they came to a watering-place where there were many strangers, and
+amongst them was a princess, who was troubled with seeing too well; and
+that was so alarming!
+
+She directly observed that the stranger who had just come was quite a
+different sort of person to all the others; “He has come here in order
+to get his beard to grow, they say, but I see the real cause, he cannot
+cast a shadow.”
+
+She had become inquisitive; and so she entered into conversation
+directly with the strange gentleman, on their promenades. As the
+daughter of a king, she needed not to stand upon trifles, so she said,
+“Your complaint is, that you cannot cast a shadow?”
+
+“Your Royal Highness must be improving considerably,” said the shadow,
+“I know your complaint is, that you see too clearly, but it has
+decreased, you are cured. I just happen to have a very unusual shadow!
+Do you not see that person who always goes with me? Other persons have
+a common shadow, but I do not like what is common to all. We give our
+servants finer cloth for their livery than we ourselves use, and so I
+had my shadow trimmed up into a man: yes, you see I have even given him
+a shadow. It is somewhat expensive, but I like to have something for
+myself!”
+
+“What!” thought the princess. “Should I really be cured! These baths are
+the first in the world! In our time water has wonderful powers. But I
+shall not leave the place, for it now begins to be amusing here. I am
+extremely fond of that stranger: would that his beard should not grow,
+for in that case he will leave us!”
+
+In the evening, the princess and the shadow danced together in the large
+ball-room. She was light, but he was still lighter; she had never had
+such a partner in the dance. She told him from what land she came, and
+he knew that land; he had been there, but then she was not at home; he
+had peeped in at the window, above and below--he had seen both the
+one and the other, and so he could answer the princess, and make
+insinuations, so that she was quite astonished; he must be the wisest
+man in the whole world! She felt such respect for what he knew! So that
+when they again danced together she fell in love with him; and that the
+shadow could remark, for she almost pierced him through with her eyes.
+So they danced once more together; and she was about to declare herself,
+but she was discreet; she thought of her country and kingdom, and of the
+many persons she would have to reign over.
+
+“He is a wise man,” said she to herself--“It is well; and he dances
+delightfully--that is also good; but has he solid knowledge? That is
+just as important! He must be examined.”
+
+So she began, by degrees, to question him about the most difficult
+things she could think of, and which she herself could not have
+answered; so that the shadow made a strange face.
+
+“You cannot answer these questions?” said the princess.
+
+“They belong to my childhood’s learning,” said the shadow. “I really
+believe my shadow, by the door there, can answer them!”
+
+“Your shadow!” said the princess. “That would indeed be marvellous!”
+
+“I will not say for a certainty that he can,” said the shadow, “but I
+think so; he has now followed me for so many years, and listened to my
+conversation--I should think it possible. But your royal highness will
+permit me to observe, that he is so proud of passing himself off for
+a man, that when he is to be in a proper humor--and he must be so to
+answer well--he must be treated quite like a man.”
+
+“Oh! I like that!” said the princess.
+
+So she went to the learned man by the door, and she spoke to him about
+the sun and the moon, and about persons out of and in the world, and he
+answered with wisdom and prudence.
+
+“What a man that must be who has so wise a shadow!” thought she. “It
+will be a real blessing to my people and kingdom if I choose him for my
+consort--I will do it!”
+
+They were soon agreed, both the princess and the shadow; but no one was
+to know about it before she arrived in her own kingdom.
+
+“No one--not even my shadow!” said the shadow, and he had his own
+thoughts about it!
+
+Now they were in the country where the princess reigned when she was at
+home.
+
+“Listen, my good friend,” said the shadow to the learned man. “I have
+now become as happy and mighty as anyone can be; I will, therefore, do
+something particular for thee! Thou shalt always live with me in the
+palace, drive with me in my royal carriage, and have ten thousand
+pounds a year; but then thou must submit to be called SHADOW by all and
+everyone; thou must not say that thou hast ever been a man; and once
+a year, when I sit on the balcony in the sunshine, thou must lie at my
+feet, as a shadow shall do! I must tell thee: I am going to marry the
+king’s daughter, and the nuptials are to take place this evening!”
+
+“Nay, this is going too far!” said the learned man. “I will not have it;
+I will not do it! It is to deceive the whole country and the princess
+too! I will tell everything! That I am a man, and that thou art a
+shadow--thou art only dressed up!”
+
+“There is no one who will believe it!” said the shadow. “Be reasonable,
+or I will call the guard!”
+
+“I will go directly to the princess!” said the learned man.
+
+“But I will go first!” said the shadow. “And thou wilt go to prison!”
+ and that he was obliged to do--for the sentinels obeyed him whom they
+knew the king’s daughter was to marry.
+
+“You tremble!” said the princess, as the shadow came into her chamber.
+“Has anything happened? You must not be unwell this evening, now that we
+are to have our nuptials celebrated.”
+
+“I have lived to see the most cruel thing that anyone can live to
+see!” said the shadow. “Only imagine--yes, it is true, such a poor
+shadow-skull cannot bear much--only think, my shadow has become mad;
+he thinks that he is a man, and that I--now only think--that I am his
+shadow!”
+
+“It is terrible!” said the princess; “but he is confined, is he not?”
+
+“That he is. I am afraid that he will never recover.”
+
+“Poor shadow!” said the princess. “He is very unfortunate; it would be
+a real work of charity to deliver him from the little life he has, and,
+when I think properly over the matter, I am of opinion that it will be
+necessary to do away with him in all stillness!”
+
+“It is certainly hard,” said the shadow, “for he was a faithful
+servant!” and then he gave a sort of sigh.
+
+“You are a noble character!” said the princess.
+
+The whole city was illuminated in the evening, and the cannons went off
+with a bum! bum! and the soldiers presented arms. That was a marriage!
+The princess and the shadow went out on the balcony to show themselves,
+and get another hurrah!
+
+The learned man heard nothing of all this--for they had deprived him of
+life.
+
+
+
+
+THE LITTLE MATCH GIRL
+
+Most terribly cold it was; it snowed, and was nearly quite dark, and
+evening--the last evening of the year. In this cold and darkness there
+went along the street a poor little girl, bareheaded, and with naked
+feet. When she left home she had slippers on, it is true; but what was
+the good of that? They were very large slippers, which her mother had
+hitherto worn; so large were they; and the poor little thing lost them
+as she scuffled away across the street, because of two carriages that
+rolled by dreadfully fast.
+
+One slipper was nowhere to be found; the other had been laid hold of by
+an urchin, and off he ran with it; he thought it would do capitally for
+a cradle when he some day or other should have children himself. So the
+little maiden walked on with her tiny naked feet, that were quite red
+and blue from cold. She carried a quantity of matches in an old apron,
+and she held a bundle of them in her hand. Nobody had bought anything of
+her the whole livelong day; no one had given her a single farthing.
+
+She crept along trembling with cold and hunger--a very picture of
+sorrow, the poor little thing!
+
+The flakes of snow covered her long fair hair, which fell in beautiful
+curls around her neck; but of that, of course, she never once now
+thought. From all the windows the candles were gleaming, and it smelt so
+deliciously of roast goose, for you know it was New Year’s Eve; yes, of
+that she thought.
+
+In a corner formed by two houses, of which one advanced more than the
+other, she seated herself down and cowered together. Her little feet
+she had drawn close up to her, but she grew colder and colder, and to go
+home she did not venture, for she had not sold any matches and could
+not bring a farthing of money: from her father she would certainly get
+blows, and at home it was cold too, for above her she had only the roof,
+through which the wind whistled, even though the largest cracks were
+stopped up with straw and rags.
+
+Her little hands were almost numbed with cold. Oh! a match might afford
+her a world of comfort, if she only dared take a single one out of the
+bundle, draw it against the wall, and warm her fingers by it. She drew
+one out. “Rischt!” how it blazed, how it burnt! It was a warm, bright
+flame, like a candle, as she held her hands over it: it was a wonderful
+light. It seemed really to the little maiden as though she were sitting
+before a large iron stove, with burnished brass feet and a brass
+ornament at top. The fire burned with such blessed influence; it warmed
+so delightfully. The little girl had already stretched out her feet to
+warm them too; but--the small flame went out, the stove vanished: she
+had only the remains of the burnt-out match in her hand.
+
+She rubbed another against the wall: it burned brightly, and where the
+light fell on the wall, there the wall became transparent like a
+veil, so that she could see into the room. On the table was spread a
+snow-white tablecloth; upon it was a splendid porcelain service, and the
+roast goose was steaming famously with its stuffing of apple and dried
+plums. And what was still more capital to behold was, the goose hopped
+down from the dish, reeled about on the floor with knife and fork in its
+breast, till it came up to the poor little girl; when--the match went
+out and nothing but the thick, cold, damp wall was left behind.
+She lighted another match. Now there she was sitting under the most
+magnificent Christmas tree: it was still larger, and more decorated than
+the one which she had seen through the glass door in the rich merchant’s
+house.
+
+Thousands of lights were burning on the green branches, and
+gaily-colored pictures, such as she had seen in the shop-windows, looked
+down upon her. The little maiden stretched out her hands towards them
+when--the match went out. The lights of the Christmas tree rose higher
+and higher, she saw them now as stars in heaven; one fell down and
+formed a long trail of fire.
+
+“Someone is just dead!” said the little girl; for her old grandmother,
+the only person who had loved her, and who was now no more, had told
+her, that when a star falls, a soul ascends to God.
+
+She drew another match against the wall: it was again light, and in the
+lustre there stood the old grandmother, so bright and radiant, so mild,
+and with such an expression of love.
+
+“Grandmother!” cried the little one. “Oh, take me with you! You go
+away when the match burns out; you vanish like the warm stove, like the
+delicious roast goose, and like the magnificent Christmas tree!” And
+she rubbed the whole bundle of matches quickly against the wall, for
+she wanted to be quite sure of keeping her grandmother near her. And
+the matches gave such a brilliant light that it was brighter than at
+noon-day: never formerly had the grandmother been so beautiful and
+so tall. She took the little maiden, on her arm, and both flew in
+brightness and in joy so high, so very high, and then above was neither
+cold, nor hunger, nor anxiety--they were with God.
+
+But in the corner, at the cold hour of dawn, sat the poor girl, with
+rosy cheeks and with a smiling mouth, leaning against the wall--frozen
+to death on the last evening of the old year. Stiff and stark sat the
+child there with her matches, of which one bundle had been burnt. “She
+wanted to warm herself,” people said. No one had the slightest suspicion
+of what beautiful things she had seen; no one even dreamed of the
+splendor in which, with her grandmother she had entered on the joys of a
+new year.
+
+
+
+
+THE DREAM OF LITTLE TUK
+
+Ah! yes, that was little Tuk: in reality his name was not Tuk, but that
+was what he called himself before he could speak plain: he meant it for
+Charles, and it is all well enough if one does but know it. He had now
+to take care of his little sister Augusta, who was much younger than
+himself, and he was, besides, to learn his lesson at the same time; but
+these two things would not do together at all. There sat the poor little
+fellow, with his sister on his lap, and he sang to her all the songs he
+knew; and he glanced the while from time to time into the geography-book
+that lay open before him. By the next morning he was to have learnt
+all the towns in Zealand by heart, and to know about them all that is
+possible to be known.
+
+His mother now came home, for she had been out, and took little Augusta
+on her arm. Tuk ran quickly to the window, and read so eagerly that he
+pretty nearly read his eyes out; for it got darker and darker, but his
+mother had no money to buy a candle.
+
+“There goes the old washerwoman over the way,” said his mother, as she
+looked out of the window. “The poor woman can hardly drag herself along,
+and she must now drag the pail home from the fountain. Be a good boy,
+Tukey, and run across and help the old woman, won’t you?”
+
+So Tuk ran over quickly and helped her; but when he came back again into
+the room it was quite dark, and as to a light, there was no thought of
+such a thing. He was now to go to bed; that was an old turn-up bedstead;
+in it he lay and thought about his geography lesson, and of Zealand, and
+of all that his master had told him. He ought, to be sure, to have read
+over his lesson again, but that, you know, he could not do. He therefore
+put his geography-book under his pillow, because he had heard that was
+a very good thing to do when one wants to learn one’s lesson; but one
+cannot, however, rely upon it entirely. Well, there he lay, and thought
+and thought, and all at once it was just as if someone kissed his eyes
+and mouth: he slept, and yet he did not sleep; it was as though the old
+washerwoman gazed on him with her mild eyes and said, “It were a great
+sin if you were not to know your lesson tomorrow morning. You have aided
+me, I therefore will now help you; and the loving God will do so at all
+times.” And all of a sudden the book under Tuk’s pillow began scraping
+and scratching.
+
+“Kickery-ki! kluk! kluk! kluk!”--that was an old hen who came creeping
+along, and she was from Kjoge. “I am a Kjoger hen,” [*] said she, and then
+she related how many inhabitants there were there, and about the battle
+that had taken place, and which, after all, was hardly worth talking
+about.
+
+     * Kjoge, a town in the bay of Kjoge. “To see the Kjoge
+     hens,” is an expression similar to “showing a child London,”
+      which is said to be done by taking his head in both bands,
+     and so lifting him off the ground. At the invasion of the
+     English in 1807, an encounter of a no very glorious nature
+     took place between the British troops and the undisciplined
+     Danish militia.
+
+“Kribledy, krabledy--plump!” down fell somebody: it was a wooden bird,
+the popinjay used at the shooting-matches at Prastoe. Now he said that
+there were just as many inhabitants as he had nails in his body; and he
+was very proud. “Thorwaldsen lived almost next door to me.* Plump! Here
+I lie capitally.”
+
+* Prastoe, a still smaller town than Kjoge. Some hundred paces from
+it lies the manor-house Ny Soe, where Thorwaldsen, the famed sculptor,
+generally sojourned during his stay in Denmark, and where he called many
+of his immortal works into existence.
+
+
+But little Tuk was no longer lying down: all at once he was on
+horseback. On he went at full gallop, still galloping on and on. A
+knight with a gleaming plume, and most magnificently dressed, held him
+before him on the horse, and thus they rode through the wood to the old
+town of Bordingborg, and that was a large and very lively town. High
+towers rose from the castle of the king, and the brightness of many
+candles streamed from all the windows; within was dance and song,
+and King Waldemar and the young, richly-attired maids of honor danced
+together. The morn now came; and as soon as the sun appeared, the whole
+town and the king’s palace crumbled together, and one tower after the
+other; and at last only a single one remained standing where the castle
+had been before,* and the town was so small and poor, and the school
+boys came along with their books under their arms, and said, “2000
+inhabitants!” but that was not true, for there were not so many.
+
+*Bordingborg, in the reign of King Waldemar, a considerable place, now
+an unimportant little town. One solitary tower only, and some remains of
+a wall, show where the castle once stood.
+
+
+And little Tukey lay in his bed: it seemed to him as if he dreamed, and
+yet as if he were not dreaming; however, somebody was close beside him.
+
+“Little Tukey! Little Tukey!” cried someone near. It was a seaman,
+quite a little personage, so little as if he were a midshipman; but a
+midshipman it was not.
+
+“Many remembrances from Corsor.* That is a town that is just rising
+into importance; a lively town that has steam-boats and stagecoaches:
+formerly people called it ugly, but that is no longer true. I lie on
+the sea,” said Corsor; “I have high roads and gardens, and I have given
+birth to a poet who was witty and amusing, which all poets are not. I
+once intended to equip a ship that was to sail all round the earth; but
+I did not do it, although I could have done so: and then, too, I smell
+so deliciously, for close before the gate bloom the most beautiful
+roses.”
+
+*Corsor, on the Great Belt, called, formerly, before the introduction
+of steam-vessels, when travellers were often obliged to wait a long time
+for a favorable wind, “the most tiresome of towns.” The poet Baggesen
+was born here.
+
+
+Little Tuk looked, and all was red and green before his eyes; but as
+soon as the confusion of colors was somewhat over, all of a sudden there
+appeared a wooded slope close to the bay, and high up above stood a
+magnificent old church, with two high pointed towers. From out the
+hill-side spouted fountains in thick streams of water, so that there
+was a continual splashing; and close beside them sat an old king with
+a golden crown upon his white head: that was King Hroar, near the
+fountains, close to the town of Roeskilde, as it is now called. And up
+the slope into the old church went all the kings and queens of Denmark,
+hand in hand, all with their golden crowns; and the organ played and
+the fountains rustled. Little Tuk saw all, heard all. “Do not forget the
+diet,” said King Hroar.*
+
+*Roeskilde, once the capital of Denmark. The town takes its name from
+King Hroar, and the many fountains in the neighborhood. In the beautiful
+cathedral the greater number of the kings and queens of Denmark are
+interred. In Roeskilde, too, the members of the Danish Diet assemble.
+
+
+Again all suddenly disappeared. Yes, and whither? It seemed to him
+just as if one turned over a leaf in a book. And now stood there an
+old peasant-woman, who came from Soroe,* where grass grows in the
+market-place. She had an old grey linen apron hanging over her head and
+back: it was so wet, it certainly must have been raining. “Yes, that it
+has,” said she; and she now related many pretty things out of Holberg’s
+comedies, and about Waldemar and Absalon; but all at once she cowered
+together, and her head began shaking backwards and forwards, and she
+looked as she were going to make a spring. “Croak! croak!” said she.
+“It is wet, it is wet; there is such a pleasant deathlike stillness in
+Sorbe!” She was now suddenly a frog, “Croak”; and now she was an old
+woman. “One must dress according to the weather,” said she. “It is wet;
+it is wet. My town is just like a bottle; and one gets in by the neck,
+and by the neck one must get out again! In former times I had the
+finest fish, and now I have fresh rosy-cheeked boys at the bottom of the
+bottle, who learn wisdom, Hebrew, Greek--Croak!”
+
+* Sorbe, a very quiet little town, beautifully situated, surrounded by
+woods and lakes. Holberg, Denmark’s Moliere, founded here an academy
+for the sons of the nobles. The poets Hauch and Ingemann were appointed
+professors here. The latter lives there still.
+
+
+When she spoke it sounded just like the noise of frogs, or as if one
+walked with great boots over a moor; always the same tone, so uniform
+and so tiring that little Tuk fell into a good sound sleep, which, by
+the bye, could not do him any harm.
+
+But even in this sleep there came a dream, or whatever else it was: his
+little sister Augusta, she with the blue eyes and the fair curling hair,
+was suddenly a tall, beautiful girl, and without having wings was yet
+able to fly; and she now flew over Zealand--over the green woods and the
+blue lakes.
+
+“Do you hear the cock crow, Tukey? Cock-a-doodle-doo! The cocks are
+flying up from Kjoge! You will have a farm-yard, so large, oh! so very
+large! You will suffer neither hunger nor thirst! You will get on in the
+world! You will be a rich and happy man! Your house will exalt itself
+like King Waldemar’s tower, and will be richly decorated with marble
+statues, like that at Prastoe. You understand what I mean. Your name
+shall circulate with renown all round the earth, like unto the ship that
+was to have sailed from Corsor; and in Roeskilde--”
+
+“Do not forget the diet!” said King Hroar.
+
+“Then you will speak well and wisely, little Tukey; and when at last you
+sink into your grave, you shall sleep as quietly--”
+
+“As if I lay in Soroe,” said Tuk, awaking. It was bright day, and he was
+now quite unable to call to mind his dream; that, however, was not at
+all necessary, for one may not know what the future will bring.
+
+And out of bed he jumped, and read in his book, and now all at once he
+knew his whole lesson. And the old washerwoman popped her head in at the
+door, nodded to him friendly, and said, “Thanks, many thanks, my good
+child, for your help! May the good ever-loving God fulfil your loveliest
+dream!”
+
+Little Tukey did not at all know what he had dreamed, but the loving God
+knew it.
+
+
+
+
+THE NAUGHTY BOY
+
+Along time ago, there lived an old poet, a thoroughly kind old poet. As
+he was sitting one evening in his room, a dreadful storm arose without,
+and the rain streamed down from heaven; but the old poet sat warm
+and comfortable in his chimney-corner, where the fire blazed and the
+roasting apple hissed.
+
+“Those who have not a roof over their heads will be wetted to the skin,”
+ said the good old poet.
+
+“Oh let me in! Let me in! I am cold, and I’m so wet!” exclaimed suddenly
+a child that stood crying at the door and knocking for admittance, while
+the rain poured down, and the wind made all the windows rattle.
+
+“Poor thing!” said the old poet, as he went to open the door. There
+stood a little boy, quite naked, and the water ran down from his long
+golden hair; he trembled with cold, and had he not come into a warm room
+he would most certainly have perished in the frightful tempest.
+
+“Poor child!” said the old poet, as he took the boy by the hand. “Come
+in, come in, and I will soon restore thee! Thou shalt have wine and
+roasted apples, for thou art verily a charming child!” And the boy was
+so really. His eyes were like two bright stars; and although the water
+trickled down his hair, it waved in beautiful curls. He looked exactly
+like a little angel, but he was so pale, and his whole body trembled
+with cold. He had a nice little bow in his hand, but it was quite
+spoiled by the rain, and the tints of his many-colored arrows ran one
+into the other.
+
+The old poet seated himself beside his hearth, and took the little
+fellow on his lap; he squeezed the water out of his dripping hair,
+warmed his hands between his own, and boiled for him some sweet wine.
+Then the boy recovered, his cheeks again grew rosy, he jumped down from
+the lap where he was sitting, and danced round the kind old poet.
+
+“You are a merry fellow,” said the old man. “What’s your name?”
+
+“My name is Cupid,” answered the boy. “Don’t you know me? There lies my
+bow; it shoots well, I can assure you! Look, the weather is now clearing
+up, and the moon is shining clear again through the window.”
+
+“Why, your bow is quite spoiled,” said the old poet.
+
+“That were sad indeed,” said the boy, and he took the bow in his hand
+and examined it on every side. “Oh, it is dry again, and is not hurt at
+all; the string is quite tight. I will try it directly.” And he bent his
+bow, took aim, and shot an arrow at the old poet, right into his heart.
+“You see now that my bow was not spoiled,” said he laughing; and away he
+ran.
+
+The naughty boy, to shoot the old poet in that way; he who had taken him
+into his warm room, who had treated him so kindly, and who had given him
+warm wine and the very best apples!
+
+The poor poet lay on the earth and wept, for the arrow had really flown
+into his heart.
+
+“Fie!” said he. “How naughty a boy Cupid is! I will tell all children
+about him, that they may take care and not play with him, for he will
+only cause them sorrow and many a heartache.”
+
+And all good children to whom he related this story, took great heed
+of this naughty Cupid; but he made fools of them still, for he is
+astonishingly cunning. When the university students come from the
+lectures, he runs beside them in a black coat, and with a book under his
+arm. It is quite impossible for them to know him, and they walk along
+with him arm in arm, as if he, too, were a student like themselves; and
+then, unperceived, he thrusts an arrow to their bosom. When the young
+maidens come from being examined by the clergyman, or go to church to
+be confirmed, there he is again close behind them. Yes, he is forever
+following people. At the play, he sits in the great chandelier and burns
+in bright flames, so that people think it is really a flame, but they
+soon discover it is something else. He roves about in the garden of the
+palace and upon the ramparts: yes, once he even shot your father and
+mother right in the heart. Ask them only and you will hear what they’ll
+tell you. Oh, he is a naughty boy, that Cupid; you must never have
+anything to do with him. He is forever running after everybody. Only
+think, he shot an arrow once at your old grandmother! But that is a
+long time ago, and it is all past now; however, a thing of that sort she
+never forgets. Fie, naughty Cupid! But now you know him, and you know,
+too, how ill-behaved he is!
+
+
+
+
+THE RED SHOES
+
+There was once a little girl who was very pretty and delicate, but in
+summer she was forced to run about with bare feet, she was so poor, and
+in winter wear very large wooden shoes, which made her little insteps
+quite red, and that looked so dangerous!
+
+In the middle of the village lived old Dame Shoemaker; she sat and sewed
+together, as well as she could, a little pair of shoes out of old red
+strips of cloth; they were very clumsy, but it was a kind thought. They
+were meant for the little girl. The little girl was called Karen.
+
+On the very day her mother was buried, Karen received the red shoes,
+and wore them for the first time. They were certainly not intended for
+mourning, but she had no others, and with stockingless feet she followed
+the poor straw coffin in them.
+
+Suddenly a large old carriage drove up, and a large old lady sat in it:
+she looked at the little girl, felt compassion for her, and then said to
+the clergyman:
+
+“Here, give me the little girl. I will adopt her!”
+
+And Karen believed all this happened on account of the red shoes, but
+the old lady thought they were horrible, and they were burnt. But Karen
+herself was cleanly and nicely dressed; she must learn to read and sew;
+and people said she was a nice little thing, but the looking-glass said:
+“Thou art more than nice, thou art beautiful!”
+
+Now the queen once travelled through the land, and she had her little
+daughter with her. And this little daughter was a princess, and people
+streamed to the castle, and Karen was there also, and the little
+princess stood in her fine white dress, in a window, and let herself be
+stared at; she had neither a train nor a golden crown, but splendid
+red morocco shoes. They were certainly far handsomer than those Dame
+Shoemaker had made for little Karen. Nothing in the world can be
+compared with red shoes.
+
+Now Karen was old enough to be confirmed; she had new clothes and was to
+have new shoes also. The rich shoemaker in the city took the measure of
+her little foot. This took place at his house, in his room; where stood
+large glass-cases, filled with elegant shoes and brilliant boots. All
+this looked charming, but the old lady could not see well, and so had
+no pleasure in them. In the midst of the shoes stood a pair of red ones,
+just like those the princess had worn. How beautiful they were! The
+shoemaker said also they had been made for the child of a count, but had
+not fitted.
+
+“That must be patent leather!” said the old lady. “They shine so!”
+
+“Yes, they shine!” said Karen, and they fitted, and were bought, but the
+old lady knew nothing about their being red, else she would never have
+allowed Karen to have gone in red shoes to be confirmed. Yet such was
+the case.
+
+Everybody looked at her feet; and when she stepped through the chancel
+door on the church pavement, it seemed to her as if the old figures on
+the tombs, those portraits of old preachers and preachers’ wives, with
+stiff ruffs, and long black dresses, fixed their eyes on her red shoes.
+And she thought only of them as the clergyman laid his hand upon her
+head, and spoke of the holy baptism, of the covenant with God, and how
+she should be now a matured Christian; and the organ pealed so solemnly;
+the sweet children’s voices sang, and the old music-directors sang, but
+Karen only thought of her red shoes.
+
+In the afternoon, the old lady heard from everyone that the shoes had
+been red, and she said that it was very wrong of Karen, that it was not
+at all becoming, and that in future Karen should only go in black shoes
+to church, even when she should be older.
+
+The next Sunday there was the sacrament, and Karen looked at the black
+shoes, looked at the red ones--looked at them again, and put on the red
+shoes.
+
+The sun shone gloriously; Karen and the old lady walked along the path
+through the corn; it was rather dusty there.
+
+At the church door stood an old soldier with a crutch, and with a
+wonderfully long beard, which was more red than white, and he bowed to
+the ground, and asked the old lady whether he might dust her shoes. And
+Karen stretched out her little foot.
+
+“See, what beautiful dancing shoes!” said the soldier. “Sit firm when
+you dance”; and he put his hand out towards the soles.
+
+And the old lady gave the old soldier alms, and went into the church
+with Karen.
+
+And all the people in the church looked at Karen’s red shoes, and all
+the pictures, and as Karen knelt before the altar, and raised the cup to
+her lips, she only thought of the red shoes, and they seemed to swim
+in it; and she forgot to sing her psalm, and she forgot to pray, “Our
+Father in Heaven!”
+
+Now all the people went out of church, and the old lady got into her
+carriage. Karen raised her foot to get in after her, when the old
+soldier said,
+
+“Look, what beautiful dancing shoes!”
+
+And Karen could not help dancing a step or two, and when she began her
+feet continued to dance; it was just as though the shoes had power over
+them. She danced round the church corner, she could not leave off; the
+coachman was obliged to run after and catch hold of her, and he lifted
+her in the carriage, but her feet continued to dance so that she trod on
+the old lady dreadfully. At length she took the shoes off, and then her
+legs had peace.
+
+The shoes were placed in a closet at home, but Karen could not avoid
+looking at them.
+
+Now the old lady was sick, and it was said she could not recover. She
+must be nursed and waited upon, and there was no one whose duty it was
+so much as Karen’s. But there was a great ball in the city, to which
+Karen was invited. She looked at the old lady, who could not recover,
+she looked at the red shoes, and she thought there could be no sin in
+it; she put on the red shoes, she might do that also, she thought. But
+then she went to the ball and began to dance.
+
+When she wanted to dance to the right, the shoes would dance to the
+left, and when she wanted to dance up the room, the shoes danced back
+again, down the steps, into the street, and out of the city gate. She
+danced, and was forced to dance straight out into the gloomy wood.
+
+Then it was suddenly light up among the trees, and she fancied it must
+be the moon, for there was a face; but it was the old soldier with
+the red beard; he sat there, nodded his head, and said, “Look, what
+beautiful dancing shoes!”
+
+Then she was terrified, and wanted to fling off the red shoes, but they
+clung fast; and she pulled down her stockings, but the shoes seemed to
+have grown to her feet. And she danced, and must dance, over fields and
+meadows, in rain and sunshine, by night and day; but at night it was the
+most fearful.
+
+She danced over the churchyard, but the dead did not dance--they had
+something better to do than to dance. She wished to seat herself on a
+poor man’s grave, where the bitter tansy grew; but for her there was
+neither peace nor rest; and when she danced towards the open church
+door, she saw an angel standing there. He wore long, white garments; he
+had wings which reached from his shoulders to the earth; his countenance
+was severe and grave; and in his hand he held a sword, broad and
+glittering.
+
+“Dance shalt thou!” said he. “Dance in thy red shoes till thou art pale
+and cold! Till thy skin shrivels up and thou art a skeleton! Dance shalt
+thou from door to door, and where proud, vain children dwell, thou shalt
+knock, that they may hear thee and tremble! Dance shalt thou--!”
+
+“Mercy!” cried Karen. But she did not hear the angel’s reply, for the
+shoes carried her through the gate into the fields, across roads and
+bridges, and she must keep ever dancing.
+
+One morning she danced past a door which she well knew. Within sounded
+a psalm; a coffin, decked with flowers, was borne forth. Then she knew
+that the old lady was dead, and felt that she was abandoned by all, and
+condemned by the angel of God.
+
+She danced, and she was forced to dance through the gloomy night. The
+shoes carried her over stack and stone; she was torn till she bled; she
+danced over the heath till she came to a little house. Here, she knew,
+dwelt the executioner; and she tapped with her fingers at the window,
+and said, “Come out! Come out! I cannot come in, for I am forced to
+dance!”
+
+And the executioner said, “Thou dost not know who I am, I fancy? I
+strike bad people’s heads off; and I hear that my axe rings!”
+
+“Don’t strike my head off!” said Karen. “Then I can’t repent of my sins!
+But strike off my feet in the red shoes!”
+
+And then she confessed her entire sin, and the executioner struck off
+her feet with the red shoes, but the shoes danced away with the little
+feet across the field into the deep wood.
+
+And he carved out little wooden feet for her, and crutches, taught
+her the psalm criminals always sing; and she kissed the hand which had
+wielded the axe, and went over the heath.
+
+“Now I have suffered enough for the red shoes!” said she. “Now I will
+go into the church that people may see me!” And she hastened towards the
+church door: but when she was near it, the red shoes danced before her,
+and she was terrified, and turned round. The whole week she was unhappy,
+and wept many bitter tears; but when Sunday returned, she said, “Well,
+now I have suffered and struggled enough! I really believe I am as good
+as many a one who sits in the church, and holds her head so high!”
+
+And away she went boldly; but she had not got farther than the
+churchyard gate before she saw the red shoes dancing before her; and she
+was frightened, and turned back, and repented of her sin from her heart.
+
+And she went to the parsonage, and begged that they would take her
+into service; she would be very industrious, she said, and would do
+everything she could; she did not care about the wages, only she wished
+to have a home, and be with good people. And the clergyman’s wife was
+sorry for her and took her into service; and she was industrious and
+thoughtful. She sat still and listened when the clergyman read the Bible
+in the evenings. All the children thought a great deal of her; but when
+they spoke of dress, and grandeur, and beauty, she shook her head.
+
+The following Sunday, when the family was going to church, they asked
+her whether she would not go with them; but she glanced sorrowfully,
+with tears in her eyes, at her crutches. The family went to hear the
+word of God; but she went alone into her little chamber; there was only
+room for a bed and chair to stand in it; and here she sat down with her
+Prayer-Book; and whilst she read with a pious mind, the wind bore
+the strains of the organ towards her, and she raised her tearful
+countenance, and said, “O God, help me!”
+
+And the sun shone so clearly, and straight before her stood the angel
+of God in white garments, the same she had seen that night at the church
+door; but he no longer carried the sharp sword, but in its stead a
+splendid green spray, full of roses. And he touched the ceiling with the
+spray, and the ceiling rose so high, and where he had touched it there
+gleamed a golden star. And he touched the walls, and they widened out,
+and she saw the organ which was playing; she saw the old pictures of the
+preachers and the preachers’ wives. The congregation sat in cushioned
+seats, and sang out of their Prayer-Books. For the church itself had
+come to the poor girl in her narrow chamber, or else she had come into
+the church. She sat in the pew with the clergyman’s family, and when
+they had ended the psalm and looked up, they nodded and said, “It is
+right that thou art come!”
+
+“It was through mercy!” she said.
+
+And the organ pealed, and the children’s voices in the choir sounded so
+sweet and soft! The clear sunshine streamed so warmly through the window
+into the pew where Karen sat! Her heart was so full of sunshine, peace,
+and joy, that it broke. Her soul flew on the sunshine to God, and there
+no one asked after the RED SHOES.
+
+
+
+
+
+End of Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+***** This file should be named 1597-0.txt or 1597-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/5/9/1597/
+
+Produced by Dianne Bean
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/around-the-world-in-eighty-days.txt
+++ b/jet/hadoop/src/main/resources/books/around-the-world-in-eighty-days.txt
@@ -1,0 +1,8406 @@
+﻿The Project Gutenberg EBook of Around the World in 80 Days, by Jules Verne
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Around the World in 80 Days
+
+Author: Jules Verne
+
+Release Date: May 15, 2008 [EBook #103]
+Last updated: February 18, 2012
+Last updated: May 5, 2012
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+
+
+
+
+
+
+
+
+
+
+
+
+AROUND THE WORLD IN EIGHTY DAYS
+
+
+
+CONTENTS
+
+
+CHAPTER
+
+      I  IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER, THE
+         ONE AS MASTER, THE OTHER AS MAN
+
+     II  IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND
+         HIS IDEAL
+
+    III  IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST
+         PHILEAS FOGG DEAR
+
+     IV  IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+      V  IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN,
+         APPEARS ON 'CHANGE
+
+     VI  IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+    VII  WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS
+         AIDS TO dETECTIVES
+
+   VIII  IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+     IX  IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS
+         TO THE DESIGNS OF PHILEAS FOGG
+
+      X  IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS
+         OF HIS SHOES
+
+     XI  IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE
+         AT A FABULOUS PRICE
+
+    XII  IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE
+         INDIAN FORESTS, AND WHAT ENSUED
+
+   XIII  IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS
+         THE BRAVE
+
+    XIV  IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL
+         VALLEY OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+     XV  IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS
+         MORE
+
+    XVI  IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS
+         SAID TO HIM
+
+   XVII  SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+  XVIII  IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS
+         BUSINESS
+
+    XIX  IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER,
+         AND WHAT COMES OF IT
+
+     XX  IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+    XXI  IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING
+         A REWARD OF TWO HUNDRED POUNDS
+
+   XXII  IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES,
+         IT IS CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+  XXIII  IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+  XXIV  DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+    XXV  IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+   XXVI  IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+  XXVII  IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN
+         HOUR, A COURSE OF MORMON HISTORY
+
+ XXVIII  IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN
+         TO REASON
+
+   XXIX  IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET
+         WITH ON AMERICAN RAILROADS
+
+    XXX  IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+   XXXI  IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS
+         OF PHILEAS FOGG
+
+  XXXII  IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD
+         FORTUNE
+
+ XXXIII  IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+  XXXIV  IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+   XXXV  IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+         PASSEPARTOUT TWICE
+
+  XXXVI  IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+ XXXVII  IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+         AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+
+
+Chapter I
+
+IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER,
+THE ONE AS MASTER, THE OTHER AS MAN
+
+
+Mr. Phileas Fogg lived, in 1872, at No. 7, Saville Row, Burlington
+Gardens, the house in which Sheridan died in 1814.  He was one of the
+most noticeable members of the Reform Club, though he seemed always to
+avoid attracting attention; an enigmatical personage, about whom little
+was known, except that he was a polished man of the world.  People said
+that he resembled Byron--at least that his head was Byronic; but he was
+a bearded, tranquil Byron, who might live on a thousand years without
+growing old.
+
+Certainly an Englishman, it was more doubtful whether Phileas Fogg was
+a Londoner.  He was never seen on 'Change, nor at the Bank, nor in the
+counting-rooms of the "City"; no ships ever came into London docks of
+which he was the owner; he had no public employment; he had never been
+entered at any of the Inns of Court, either at the Temple, or Lincoln's
+Inn, or Gray's Inn; nor had his voice ever resounded in the Court of
+Chancery, or in the Exchequer, or the Queen's Bench, or the
+Ecclesiastical Courts.  He certainly was not a manufacturer; nor was he
+a merchant or a gentleman farmer.  His name was strange to the
+scientific and learned societies, and he never was known to take part
+in the sage deliberations of the Royal Institution or the London
+Institution, the Artisan's Association, or the Institution of Arts and
+Sciences.  He belonged, in fact, to none of the numerous societies
+which swarm in the English capital, from the Harmonic to that of the
+Entomologists, founded mainly for the purpose of abolishing pernicious
+insects.
+
+Phileas Fogg was a member of the Reform, and that was all.
+
+The way in which he got admission to this exclusive club was simple
+enough.
+
+He was recommended by the Barings, with whom he had an open credit.
+His cheques were regularly paid at sight from his account current,
+which was always flush.
+
+Was Phileas Fogg rich?  Undoubtedly.  But those who knew him best could
+not imagine how he had made his fortune, and Mr. Fogg was the last
+person to whom to apply for the information.  He was not lavish, nor,
+on the contrary, avaricious; for, whenever he knew that money was
+needed for a noble, useful, or benevolent purpose, he supplied it
+quietly and sometimes anonymously.  He was, in short, the least
+communicative of men.  He talked very little, and seemed all the more
+mysterious for his taciturn manner.  His daily habits were quite open
+to observation; but whatever he did was so exactly the same thing that
+he had always done before, that the wits of the curious were fairly
+puzzled.
+
+Had he travelled?  It was likely, for no one seemed to know the world
+more familiarly; there was no spot so secluded that he did not appear
+to have an intimate acquaintance with it.  He often corrected, with a
+few clear words, the thousand conjectures advanced by members of the
+club as to lost and unheard-of travellers, pointing out the true
+probabilities, and seeming as if gifted with a sort of second sight, so
+often did events justify his predictions.  He must have travelled
+everywhere, at least in the spirit.
+
+It was at least certain that Phileas Fogg had not absented himself from
+London for many years.  Those who were honoured by a better
+acquaintance with him than the rest, declared that nobody could pretend
+to have ever seen him anywhere else.  His sole pastimes were reading
+the papers and playing whist.  He often won at this game, which, as a
+silent one, harmonised with his nature; but his winnings never went
+into his purse, being reserved as a fund for his charities.  Mr. Fogg
+played, not to win, but for the sake of playing.  The game was in his
+eyes a contest, a struggle with a difficulty, yet a motionless,
+unwearying struggle, congenial to his tastes.
+
+Phileas Fogg was not known to have either wife or children, which may
+happen to the most honest people; either relatives or near friends,
+which is certainly more unusual.  He lived alone in his house in
+Saville Row, whither none penetrated.  A single domestic sufficed to
+serve him.  He breakfasted and dined at the club, at hours
+mathematically fixed, in the same room, at the same table, never taking
+his meals with other members, much less bringing a guest with him; and
+went home at exactly midnight, only to retire at once to bed.  He never
+used the cosy chambers which the Reform provides for its favoured
+members.  He passed ten hours out of the twenty-four in Saville Row,
+either in sleeping or making his toilet.  When he chose to take a walk
+it was with a regular step in the entrance hall with its mosaic
+flooring, or in the circular gallery with its dome supported by twenty
+red porphyry Ionic columns, and illumined by blue painted windows.
+When he breakfasted or dined all the resources of the club--its
+kitchens and pantries, its buttery and dairy--aided to crowd his table
+with their most succulent stores; he was served by the gravest waiters,
+in dress coats, and shoes with swan-skin soles, who proffered the
+viands in special porcelain, and on the finest linen; club decanters,
+of a lost mould, contained his sherry, his port, and his
+cinnamon-spiced claret; while his beverages were refreshingly cooled
+with ice, brought at great cost from the American lakes.
+
+If to live in this style is to be eccentric, it must be confessed that
+there is something good in eccentricity.
+
+The mansion in Saville Row, though not sumptuous, was exceedingly
+comfortable.  The habits of its occupant were such as to demand but
+little from the sole domestic, but Phileas Fogg required him to be
+almost superhumanly prompt and regular.  On this very 2nd of October he
+had dismissed James Forster, because that luckless youth had brought
+him shaving-water at eighty-four degrees Fahrenheit instead of
+eighty-six; and he was awaiting his successor, who was due at the house
+between eleven and half-past.
+
+Phileas Fogg was seated squarely in his armchair, his feet close
+together like those of a grenadier on parade, his hands resting on his
+knees, his body straight, his head erect; he was steadily watching a
+complicated clock which indicated the hours, the minutes, the seconds,
+the days, the months, and the years.  At exactly half-past eleven Mr.
+Fogg would, according to his daily habit, quit Saville Row, and repair
+to the Reform.
+
+A rap at this moment sounded on the door of the cosy apartment where
+Phileas Fogg was seated, and James Forster, the dismissed servant,
+appeared.
+
+"The new servant," said he.
+
+A young man of thirty advanced and bowed.
+
+"You are a Frenchman, I believe," asked Phileas Fogg, "and your name is
+John?"
+
+"Jean, if monsieur pleases," replied the newcomer, "Jean Passepartout,
+a surname which has clung to me because I have a natural aptness for
+going out of one business into another.  I believe I'm honest,
+monsieur, but, to be outspoken, I've had several trades.  I've been an
+itinerant singer, a circus-rider, when I used to vault like Leotard,
+and dance on a rope like Blondin.  Then I got to be a professor of
+gymnastics, so as to make better use of my talents; and then I was a
+sergeant fireman at Paris, and assisted at many a big fire.  But I
+quitted France five years ago, and, wishing to taste the sweets of
+domestic life, took service as a valet here in England.  Finding myself
+out of place, and hearing that Monsieur Phileas Fogg was the most exact
+and settled gentleman in the United Kingdom, I have come to monsieur in
+the hope of living with him a tranquil life, and forgetting even the
+name of Passepartout."
+
+"Passepartout suits me," responded Mr. Fogg.  "You are well recommended
+to me; I hear a good report of you.  You know my conditions?"
+
+"Yes, monsieur."
+
+"Good!  What time is it?"
+
+"Twenty-two minutes after eleven," returned Passepartout, drawing an
+enormous silver watch from the depths of his pocket.
+
+"You are too slow," said Mr. Fogg.
+
+"Pardon me, monsieur, it is impossible--"
+
+"You are four minutes too slow.  No matter; it's enough to mention the
+error.  Now from this moment, twenty-nine minutes after eleven, a.m.,
+this Wednesday, 2nd October, you are in my service."
+
+Phileas Fogg got up, took his hat in his left hand, put it on his head
+with an automatic motion, and went off without a word.
+
+Passepartout heard the street door shut once; it was his new master
+going out.  He heard it shut again; it was his predecessor, James
+Forster, departing in his turn.  Passepartout remained alone in the
+house in Saville Row.
+
+
+
+
+Chapter II
+
+IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND HIS IDEAL
+
+
+"Faith," muttered Passepartout, somewhat flurried, "I've seen people at
+Madame Tussaud's as lively as my new master!"
+
+Madame Tussaud's "people," let it be said, are of wax, and are much
+visited in London; speech is all that is wanting to make them human.
+
+During his brief interview with Mr. Fogg, Passepartout had been
+carefully observing him.  He appeared to be a man about forty years of
+age, with fine, handsome features, and a tall, well-shaped figure; his
+hair and whiskers were light, his forehead compact and unwrinkled, his
+face rather pale, his teeth magnificent.  His countenance possessed in
+the highest degree what physiognomists call "repose in action," a
+quality of those who act rather than talk.  Calm and phlegmatic, with a
+clear eye, Mr. Fogg seemed a perfect type of that English composure
+which Angelica Kauffmann has so skilfully represented on canvas.  Seen
+in the various phases of his daily life, he gave the idea of being
+perfectly well-balanced, as exactly regulated as a Leroy chronometer.
+Phileas Fogg was, indeed, exactitude personified, and this was betrayed
+even in the expression of his very hands and feet; for in men, as well
+as in animals, the limbs themselves are expressive of the passions.
+
+He was so exact that he was never in a hurry, was always ready, and was
+economical alike of his steps and his motions.  He never took one step
+too many, and always went to his destination by the shortest cut; he
+made no superfluous gestures, and was never seen to be moved or
+agitated.  He was the most deliberate person in the world, yet always
+reached his destination at the exact moment.
+
+He lived alone, and, so to speak, outside of every social relation; and
+as he knew that in this world account must be taken of friction, and
+that friction retards, he never rubbed against anybody.
+
+As for Passepartout, he was a true Parisian of Paris.  Since he had
+abandoned his own country for England, taking service as a valet, he
+had in vain searched for a master after his own heart.  Passepartout
+was by no means one of those pert dunces depicted by Moliere with a
+bold gaze and a nose held high in the air; he was an honest fellow,
+with a pleasant face, lips a trifle protruding, soft-mannered and
+serviceable, with a good round head, such as one likes to see on the
+shoulders of a friend.  His eyes were blue, his complexion rubicund,
+his figure almost portly and well-built, his body muscular, and his
+physical powers fully developed by the exercises of his younger days.
+His brown hair was somewhat tumbled; for, while the ancient sculptors
+are said to have known eighteen methods of arranging Minerva's tresses,
+Passepartout was familiar with but one of dressing his own: three
+strokes of a large-tooth comb completed his toilet.
+
+It would be rash to predict how Passepartout's lively nature would
+agree with Mr. Fogg.  It was impossible to tell whether the new servant
+would turn out as absolutely methodical as his master required;
+experience alone could solve the question.  Passepartout had been a
+sort of vagrant in his early years, and now yearned for repose; but so
+far he had failed to find it, though he had already served in ten
+English houses.  But he could not take root in any of these; with
+chagrin, he found his masters invariably whimsical and irregular,
+constantly running about the country, or on the look-out for adventure.
+His last master, young Lord Longferry, Member of Parliament, after
+passing his nights in the Haymarket taverns, was too often brought home
+in the morning on policemen's shoulders.  Passepartout, desirous of
+respecting the gentleman whom he served, ventured a mild remonstrance
+on such conduct; which, being ill-received, he took his leave.  Hearing
+that Mr. Phileas Fogg was looking for a servant, and that his life was
+one of unbroken regularity, that he neither travelled nor stayed from
+home overnight, he felt sure that this would be the place he was after.
+He presented himself, and was accepted, as has been seen.
+
+At half-past eleven, then, Passepartout found himself alone in the
+house in Saville Row.  He began its inspection without delay, scouring
+it from cellar to garret.  So clean, well-arranged, solemn a mansion
+pleased him; it seemed to him like a snail's shell, lighted and warmed
+by gas, which sufficed for both these purposes.  When Passepartout
+reached the second story he recognised at once the room which he was to
+inhabit, and he was well satisfied with it.  Electric bells and
+speaking-tubes afforded communication with the lower stories; while on
+the mantel stood an electric clock, precisely like that in Mr. Fogg's
+bedchamber, both beating the same second at the same instant.  "That's
+good, that'll do," said Passepartout to himself.
+
+He suddenly observed, hung over the clock, a card which, upon
+inspection, proved to be a programme of the daily routine of the house.
+It comprised all that was required of the servant, from eight in the
+morning, exactly at which hour Phileas Fogg rose, till half-past
+eleven, when he left the house for the Reform Club--all the details of
+service, the tea and toast at twenty-three minutes past eight, the
+shaving-water at thirty-seven minutes past nine, and the toilet at
+twenty minutes before ten.  Everything was regulated and foreseen that
+was to be done from half-past eleven a.m. till midnight, the hour at
+which the methodical gentleman retired.
+
+Mr. Fogg's wardrobe was amply supplied and in the best taste.  Each
+pair of trousers, coat, and vest bore a number, indicating the time of
+year and season at which they were in turn to be laid out for wearing;
+and the same system was applied to the master's shoes.  In short, the
+house in Saville Row, which must have been a very temple of disorder
+and unrest under the illustrious but dissipated Sheridan, was cosiness,
+comfort, and method idealised.  There was no study, nor were there
+books, which would have been quite useless to Mr. Fogg; for at the
+Reform two libraries, one of general literature and the other of law
+and politics, were at his service.  A moderate-sized safe stood in his
+bedroom, constructed so as to defy fire as well as burglars; but
+Passepartout found neither arms nor hunting weapons anywhere;
+everything betrayed the most tranquil and peaceable habits.
+
+Having scrutinised the house from top to bottom, he rubbed his hands, a
+broad smile overspread his features, and he said joyfully, "This is
+just what I wanted!  Ah, we shall get on together, Mr. Fogg and I!
+What a domestic and regular gentleman!  A real machine; well, I don't
+mind serving a machine."
+
+
+
+
+Chapter III
+
+IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST PHILEAS
+FOGG DEAR
+
+
+Phileas Fogg, having shut the door of his house at half-past eleven,
+and having put his right foot before his left five hundred and
+seventy-five times, and his left foot before his right five hundred and
+seventy-six times, reached the Reform Club, an imposing edifice in Pall
+Mall, which could not have cost less than three millions.  He repaired
+at once to the dining-room, the nine windows of which open upon a
+tasteful garden, where the trees were already gilded with an autumn
+colouring; and took his place at the habitual table, the cover of which
+had already been laid for him.  His breakfast consisted of a side-dish,
+a broiled fish with Reading sauce, a scarlet slice of roast beef
+garnished with mushrooms, a rhubarb and gooseberry tart, and a morsel
+of Cheshire cheese, the whole being washed down with several cups of
+tea, for which the Reform is famous.  He rose at thirteen minutes to
+one, and directed his steps towards the large hall, a sumptuous
+apartment adorned with lavishly-framed paintings.  A flunkey handed him
+an uncut Times, which he proceeded to cut with a skill which betrayed
+familiarity with this delicate operation.  The perusal of this paper
+absorbed Phileas Fogg until a quarter before four, whilst the Standard,
+his next task, occupied him till the dinner hour.  Dinner passed as
+breakfast had done, and Mr. Fogg re-appeared in the reading-room and
+sat down to the Pall Mall at twenty minutes before six.  Half an hour
+later several members of the Reform came in and drew up to the
+fireplace, where a coal fire was steadily burning.  They were Mr.
+Fogg's usual partners at whist: Andrew Stuart, an engineer; John
+Sullivan and Samuel Fallentin, bankers; Thomas Flanagan, a brewer; and
+Gauthier Ralph, one of the Directors of the Bank of England--all rich
+and highly respectable personages, even in a club which comprises the
+princes of English trade and finance.
+
+"Well, Ralph," said Thomas Flanagan, "what about that robbery?"
+
+"Oh," replied Stuart, "the Bank will lose the money."
+
+"On the contrary," broke in Ralph, "I hope we may put our hands on the
+robber.  Skilful detectives have been sent to all the principal ports
+of America and the Continent, and he'll be a clever fellow if he slips
+through their fingers."
+
+"But have you got the robber's description?" asked Stuart.
+
+"In the first place, he is no robber at all," returned Ralph,
+positively.
+
+"What! a fellow who makes off with fifty-five thousand pounds, no
+robber?"
+
+"No."
+
+"Perhaps he's a manufacturer, then."
+
+"The Daily Telegraph says that he is a gentleman."
+
+It was Phileas Fogg, whose head now emerged from behind his newspapers,
+who made this remark.  He bowed to his friends, and entered into the
+conversation.  The affair which formed its subject, and which was town
+talk, had occurred three days before at the Bank of England.  A package
+of banknotes, to the value of fifty-five thousand pounds, had been
+taken from the principal cashier's table, that functionary being at the
+moment engaged in registering the receipt of three shillings and
+sixpence.  Of course, he could not have his eyes everywhere.  Let it be
+observed that the Bank of England reposes a touching confidence in the
+honesty of the public.  There are neither guards nor gratings to
+protect its treasures; gold, silver, banknotes are freely exposed, at
+the mercy of the first comer.  A keen observer of English customs
+relates that, being in one of the rooms of the Bank one day, he had the
+curiosity to examine a gold ingot weighing some seven or eight pounds.
+He took it up, scrutinised it, passed it to his neighbour, he to the
+next man, and so on until the ingot, going from hand to hand, was
+transferred to the end of a dark entry; nor did it return to its place
+for half an hour.  Meanwhile, the cashier had not so much as raised his
+head.  But in the present instance things had not gone so smoothly.
+The package of notes not being found when five o'clock sounded from the
+ponderous clock in the "drawing office," the amount was passed to the
+account of profit and loss.  As soon as the robbery was discovered,
+picked detectives hastened off to Liverpool, Glasgow, Havre, Suez,
+Brindisi, New York, and other ports, inspired by the proffered reward
+of two thousand pounds, and five per cent. on the sum that might be
+recovered.  Detectives were also charged with narrowly watching those
+who arrived at or left London by rail, and a judicial examination was
+at once entered upon.
+
+There were real grounds for supposing, as the Daily Telegraph said,
+that the thief did not belong to a professional band.  On the day of
+the robbery a well-dressed gentleman of polished manners, and with a
+well-to-do air, had been observed going to and fro in the paying room
+where the crime was committed.  A description of him was easily
+procured and sent to the detectives; and some hopeful spirits, of whom
+Ralph was one, did not despair of his apprehension.  The papers and
+clubs were full of the affair, and everywhere people were discussing
+the probabilities of a successful pursuit; and the Reform Club was
+especially agitated, several of its members being Bank officials.
+
+Ralph would not concede that the work of the detectives was likely to
+be in vain, for he thought that the prize offered would greatly
+stimulate their zeal and activity.  But Stuart was far from sharing
+this confidence; and, as they placed themselves at the whist-table,
+they continued to argue the matter.  Stuart and Flanagan played
+together, while Phileas Fogg had Fallentin for his partner.  As the
+game proceeded the conversation ceased, excepting between the rubbers,
+when it revived again.
+
+"I maintain," said Stuart, "that the chances are in favour of the
+thief, who must be a shrewd fellow."
+
+"Well, but where can he fly to?" asked Ralph.  "No country is safe for
+him."
+
+"Pshaw!"
+
+"Where could he go, then?"
+
+"Oh, I don't know that.  The world is big enough."
+
+"It was once," said Phileas Fogg, in a low tone.  "Cut, sir," he added,
+handing the cards to Thomas Flanagan.
+
+The discussion fell during the rubber, after which Stuart took up its
+thread.
+
+"What do you mean by `once'?  Has the world grown smaller?"
+
+"Certainly," returned Ralph.  "I agree with Mr. Fogg.  The world has
+grown smaller, since a man can now go round it ten times more quickly
+than a hundred years ago.  And that is why the search for this thief
+will be more likely to succeed."
+
+"And also why the thief can get away more easily."
+
+"Be so good as to play, Mr. Stuart," said Phileas Fogg.
+
+But the incredulous Stuart was not convinced, and when the hand was
+finished, said eagerly: "You have a strange way, Ralph, of proving that
+the world has grown smaller.  So, because you can go round it in three
+months--"
+
+"In eighty days," interrupted Phileas Fogg.
+
+"That is true, gentlemen," added John Sullivan.  "Only eighty days, now
+that the section between Rothal and Allahabad, on the Great Indian
+Peninsula Railway, has been opened.  Here is the estimate made by the
+Daily Telegraph:
+
+  From London to Suez via Mont Cenis and
+    Brindisi, by rail and steamboats .................  7 days
+  From Suez to Bombay, by steamer .................... 13  "
+  From Bombay to Calcutta, by rail ...................  3  "
+  From Calcutta to Hong Kong, by steamer ............. 13  "
+  From Hong Kong to Yokohama (Japan), by steamer .....  6  "
+  From Yokohama to San Francisco, by steamer ......... 22  "
+  From San Francisco to New York, by rail ............. 7  "
+  From New York to London, by steamer and rail ........ 9  "
+                                                       ------
+    Total ............................................ 80 days."
+
+"Yes, in eighty days!" exclaimed Stuart, who in his excitement made a
+false deal.  "But that doesn't take into account bad weather, contrary
+winds, shipwrecks, railway accidents, and so on."
+
+"All included," returned Phileas Fogg, continuing to play despite the
+discussion.
+
+"But suppose the Hindoos or Indians pull up the rails," replied Stuart;
+"suppose they stop the trains, pillage the luggage-vans, and scalp the
+passengers!"
+
+"All included," calmly retorted Fogg; adding, as he threw down the
+cards, "Two trumps."
+
+Stuart, whose turn it was to deal, gathered them up, and went on: "You
+are right, theoretically, Mr. Fogg, but practically--"
+
+"Practically also, Mr. Stuart."
+
+"I'd like to see you do it in eighty days."
+
+"It depends on you.  Shall we go?"
+
+"Heaven preserve me!  But I would wager four thousand pounds that such
+a journey, made under these conditions, is impossible."
+
+"Quite possible, on the contrary," returned Mr. Fogg.
+
+"Well, make it, then!"
+
+"The journey round the world in eighty days?"
+
+"Yes."
+
+"I should like nothing better."
+
+"When?"
+
+"At once.  Only I warn you that I shall do it at your expense."
+
+"It's absurd!" cried Stuart, who was beginning to be annoyed at the
+persistency of his friend.  "Come, let's go on with the game."
+
+"Deal over again, then," said Phileas Fogg.  "There's a false deal."
+
+Stuart took up the pack with a feverish hand; then suddenly put them
+down again.
+
+"Well, Mr. Fogg," said he, "it shall be so: I will wager the four
+thousand on it."
+
+"Calm yourself, my dear Stuart," said Fallentin.  "It's only a joke."
+
+"When I say I'll wager," returned Stuart, "I mean it."  
+
+"All right," said Mr. Fogg; and, turning to the others, he continued:
+"I have a deposit of twenty thousand at Baring's which I will willingly
+risk upon it."
+
+"Twenty thousand pounds!" cried Sullivan.  "Twenty thousand pounds,
+which you would lose by a single accidental delay!"
+
+"The unforeseen does not exist," quietly replied Phileas Fogg.
+
+"But, Mr. Fogg, eighty days are only the estimate of the least possible
+time in which the journey can be made."
+
+"A well-used minimum suffices for everything."
+
+"But, in order not to exceed it, you must jump mathematically from the
+trains upon the steamers, and from the steamers upon the trains again."
+
+"I will jump--mathematically."
+
+"You are joking."
+
+"A true Englishman doesn't joke when he is talking about so serious a
+thing as a wager," replied Phileas Fogg, solemnly.  "I will bet twenty
+thousand pounds against anyone who wishes that I will make the tour of
+the world in eighty days or less; in nineteen hundred and twenty hours,
+or a hundred and fifteen thousand two hundred minutes.  Do you accept?"
+
+"We accept," replied Messrs. Stuart, Fallentin, Sullivan, Flanagan, and
+Ralph, after consulting each other.
+
+"Good," said Mr. Fogg.  "The train leaves for Dover at a quarter before
+nine.  I will take it."
+
+"This very evening?" asked Stuart.
+
+"This very evening," returned Phileas Fogg.  He took out and consulted
+a pocket almanac, and added,  "As today is Wednesday, the 2nd of
+October, I shall be due in London in this very room of the Reform Club,
+on Saturday, the 21st of December, at a quarter before nine p.m.; or
+else the twenty thousand pounds, now deposited in my name at Baring's,
+will belong to you, in fact and in right, gentlemen.  Here is a cheque
+for the amount."
+
+A memorandum of the wager was at once drawn up and signed by the six
+parties, during which Phileas Fogg preserved a stoical composure.  He
+certainly did not bet to win, and had only staked the twenty thousand
+pounds, half of his fortune, because he foresaw that he might have to
+expend the other half to carry out this difficult, not to say
+unattainable, project.  As for his antagonists, they seemed much
+agitated; not so much by the value of their stake, as because they had
+some scruples about betting under conditions so difficult to their
+friend.
+
+The clock struck seven, and the party offered to suspend the game so
+that Mr. Fogg might make his preparations for departure.
+
+"I am quite ready now," was his tranquil response.  "Diamonds are
+trumps: be so good as to play, gentlemen."
+
+
+
+
+Chapter IV
+
+IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+
+Having won twenty guineas at whist, and taken leave of his friends,
+Phileas Fogg, at twenty-five minutes past seven, left the Reform Club.
+
+Passepartout, who had conscientiously studied the programme of his
+duties, was more than surprised to see his master guilty of the
+inexactness of appearing at this unaccustomed hour; for, according to
+rule, he was not due in Saville Row until precisely midnight.
+
+Mr. Fogg repaired to his bedroom, and called out, "Passepartout!"
+
+Passepartout did not reply.  It could not be he who was called; it was
+not the right hour.
+
+"Passepartout!" repeated Mr. Fogg, without raising his voice.
+
+Passepartout made his appearance.
+
+"I've called you twice," observed his master.
+
+"But it is not midnight," responded the other, showing his watch.
+
+"I know it; I don't blame you.  We start for Dover and Calais in ten
+minutes."
+
+A puzzled grin overspread Passepartout's round face; clearly he had not
+comprehended his master.
+
+"Monsieur is going to leave home?"
+
+"Yes," returned Phileas Fogg.  "We are going round the world."
+
+Passepartout opened wide his eyes, raised his eyebrows, held up his
+hands, and seemed about to collapse, so overcome was he with stupefied
+astonishment.
+
+"Round the world!" he murmured.
+
+"In eighty days," responded Mr. Fogg.  "So we haven't a moment to lose."
+
+"But the trunks?" gasped Passepartout, unconsciously swaying his head
+from right to left.
+
+"We'll have no trunks; only a carpet-bag, with two shirts and three
+pairs of stockings for me, and the same for you.  We'll buy our clothes
+on the way.  Bring down my mackintosh and traveling-cloak, and some
+stout shoes, though we shall do little walking.  Make haste!"
+
+Passepartout tried to reply, but could not.  He went out, mounted to
+his own room, fell into a chair, and muttered: "That's good, that is!
+And I, who wanted to remain quiet!"
+
+He mechanically set about making the preparations for departure.
+Around the world in eighty days!  Was his master a fool?  No.  Was this
+a joke, then?  They were going to Dover; good!  To Calais; good again!
+After all, Passepartout, who had been away from France five years,
+would not be sorry to set foot on his native soil again.  Perhaps they
+would go as far as Paris, and it would do his eyes good to see Paris
+once more.  But surely a gentleman so chary of his steps would stop
+there; no doubt--but, then, it was none the less true that he was
+going away, this so domestic person hitherto!
+
+By eight o'clock Passepartout had packed the modest carpet-bag,
+containing the wardrobes of his master and himself; then, still
+troubled in mind, he carefully shut the door of his room, and descended
+to Mr. Fogg.
+
+Mr. Fogg was quite ready.  Under his arm might have been observed a
+red-bound copy of Bradshaw's Continental Railway Steam Transit and
+General Guide, with its timetables showing the arrival and departure of
+steamers and railways.  He took the carpet-bag, opened it, and slipped
+into it a goodly roll of Bank of England notes, which would pass
+wherever he might go.
+
+"You have forgotten nothing?" asked he.
+
+"Nothing, monsieur."
+
+"My mackintosh and cloak?"
+
+"Here they are."
+
+"Good!  Take this carpet-bag," handing it to Passepartout.  "Take good
+care of it, for there are twenty thousand pounds in it."
+
+Passepartout nearly dropped the bag, as if the twenty thousand pounds
+were in gold, and weighed him down.
+
+Master and man then descended, the street-door was double-locked, and
+at the end of Saville Row they took a cab and drove rapidly to Charing
+Cross.  The cab stopped before the railway station at twenty minutes
+past eight.  Passepartout jumped off the box and followed his master,
+who, after paying the cabman, was about to enter the station, when a
+poor beggar-woman, with a child in her arms, her naked feet smeared
+with mud, her head covered with a wretched bonnet, from which hung a
+tattered feather, and her shoulders shrouded in a ragged shawl,
+approached, and mournfully asked for alms.
+
+Mr. Fogg took out the twenty guineas he had just won at whist, and
+handed them to the beggar, saying, "Here, my good woman.  I'm glad that
+I met you;" and passed on.
+
+Passepartout had a moist sensation about the eyes; his master's action
+touched his susceptible heart.
+
+Two first-class tickets for Paris having been speedily purchased, Mr.
+Fogg was crossing the station to the train, when he perceived his five
+friends of the Reform.
+
+"Well, gentlemen," said he, "I'm off, you see; and, if you will examine
+my passport when I get back, you will be able to judge whether I have
+accomplished the journey agreed upon."
+
+"Oh, that would be quite unnecessary, Mr. Fogg," said Ralph politely.
+"We will trust your word, as a gentleman of honour."
+
+"You do not forget when you are due in London again?"  asked Stuart.
+
+"In eighty days; on Saturday, the 21st of December, 1872, at a quarter
+before nine p.m.  Good-bye, gentlemen."
+
+Phileas Fogg and his servant seated themselves in a first-class
+carriage at twenty minutes before nine; five minutes later the whistle
+screamed, and the train slowly glided out of the station.
+
+The night was dark, and a fine, steady rain was falling.  Phileas Fogg,
+snugly ensconced in his corner, did not open his lips.  Passepartout,
+not yet recovered from his stupefaction, clung mechanically to the
+carpet-bag, with its enormous treasure.
+
+Just as the train was whirling through Sydenham, Passepartout suddenly
+uttered a cry of despair.
+
+"What's the matter?" asked Mr. Fogg.
+
+"Alas!  In my hurry--I--I forgot--"
+
+"What?"
+
+"To turn off the gas in my room!"
+
+"Very well, young man," returned Mr. Fogg, coolly; "it will burn--at
+your expense."
+
+
+
+
+Chapter V
+
+
+IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN, APPEARS ON
+'CHANGE
+
+
+Phileas Fogg rightly suspected that his departure from London would
+create a lively sensation at the West End.  The news of the bet spread
+through the Reform Club, and afforded an exciting topic of conversation
+to its members.  From the club it soon got into the papers throughout
+England.  The boasted "tour of the world" was talked about, disputed,
+argued with as much warmth as if the subject were another Alabama
+claim.  Some took sides with Phileas Fogg, but the large majority shook
+their heads and declared against him; it was absurd, impossible, they
+declared, that the tour of the world could be made, except
+theoretically and on paper, in this minimum of time, and with the
+existing means of travelling.  The Times, Standard, Morning Post, and
+Daily News, and twenty other highly respectable newspapers scouted Mr.
+Fogg's project as madness; the Daily Telegraph alone hesitatingly
+supported him.  People in general thought him a lunatic, and blamed his
+Reform Club friends for having accepted a wager which betrayed the
+mental aberration of its proposer.
+
+Articles no less passionate than logical appeared on the question, for
+geography is one of the pet subjects of the English; and the columns
+devoted to Phileas Fogg's venture were eagerly devoured by all classes
+of readers.  At first some rash individuals, principally of the gentler
+sex, espoused his cause, which became still more popular when the
+Illustrated London News came out with his portrait, copied from a
+photograph in the Reform Club.  A few readers of the Daily Telegraph
+even dared to say, "Why not, after all?  Stranger things have come to
+pass."
+
+At last a long article appeared, on the 7th of October, in the bulletin
+of the Royal Geographical Society, which treated the question from
+every point of view, and demonstrated the utter folly of the enterprise.
+
+Everything, it said, was against the travellers, every obstacle imposed
+alike by man and by nature.  A miraculous agreement of the times of
+departure and arrival, which was impossible, was absolutely necessary
+to his success.  He might, perhaps, reckon on the arrival of trains at
+the designated hours, in Europe, where the distances were relatively
+moderate; but when he calculated upon crossing India in three days, and
+the United States in seven, could he rely beyond misgiving upon
+accomplishing his task?  There were accidents to machinery, the
+liability of trains to run off the line, collisions, bad weather, the
+blocking up by snow--were not all these against Phileas Fogg?  Would he
+not find himself, when travelling by steamer in winter, at the mercy of
+the winds and fogs?  Is it uncommon for the best ocean steamers to be
+two or three days behind time?  But a single delay would suffice to
+fatally break the chain of communication; should Phileas Fogg once
+miss, even by an hour; a steamer, he would have to wait for the next,
+and that would irrevocably render his attempt vain.
+
+This article made a great deal of noise, and, being copied into all the
+papers, seriously depressed the advocates of the rash tourist.
+
+Everybody knows that England is the world of betting men, who are of a
+higher class than mere gamblers; to bet is in the English temperament.
+Not only the members of the Reform, but the general public, made heavy
+wagers for or against Phileas Fogg, who was set down in the betting
+books as if he were a race-horse.  Bonds were issued, and made their
+appearance on 'Change; "Phileas Fogg bonds" were offered at par or at a
+premium, and a great business was done in them.  But five days after
+the article in the bulletin of the Geographical Society appeared, the
+demand began to subside:  "Phileas Fogg" declined.  They were offered
+by packages, at first of five, then of ten, until at last nobody would
+take less than twenty, fifty, a hundred!
+
+Lord Albemarle, an elderly paralytic gentleman, was now the only
+advocate of Phileas Fogg left.  This noble lord, who was fastened to
+his chair, would have given his fortune to be able to make the tour of
+the world, if it took ten years; and he bet five thousand pounds on
+Phileas Fogg.  When the folly as well as the uselessness of the
+adventure was pointed out to him, he contented himself with replying,
+"If the thing is feasible, the first to do it ought to be an
+Englishman."
+
+The Fogg party dwindled more and more, everybody was going against him,
+and the bets stood a hundred and fifty and two hundred to one; and a
+week after his departure an incident occurred which deprived him of
+backers at any price.
+
+The commissioner of police was sitting in his office at nine o'clock
+one evening, when the following telegraphic dispatch was put into his
+hands:
+
+Suez to London.
+
+Rowan, Commissioner of Police, Scotland Yard:
+
+I've found the bank robber, Phileas Fogg.  Send with out delay warrant
+of arrest to Bombay.
+
+Fix, Detective.
+
+The effect of this dispatch was instantaneous.  The polished gentleman
+disappeared to give place to the bank robber.  His photograph, which
+was hung with those of the rest of the members at the Reform Club, was
+minutely examined, and it betrayed, feature by feature, the description
+of the robber which had been provided to the police.  The mysterious
+habits of Phileas Fogg were recalled; his solitary ways, his sudden
+departure; and it seemed clear that, in undertaking a tour round the
+world on the pretext of a wager, he had had no other end in view than
+to elude the detectives, and throw them off his track.
+
+
+
+
+Chapter VI
+
+IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+
+The circumstances under which this telegraphic dispatch about Phileas
+Fogg was sent were as follows:
+
+The steamer Mongolia, belonging to the Peninsular and Oriental Company,
+built of iron, of two thousand eight hundred tons burden, and five
+hundred horse-power, was due at eleven o'clock a.m. on Wednesday, the
+9th of October, at Suez.  The Mongolia plied regularly between Brindisi
+and Bombay via the Suez Canal, and was one of the fastest steamers
+belonging to the company, always making more than ten knots an hour
+between Brindisi and Suez, and nine and a half between Suez and Bombay.
+
+Two men were promenading up and down the wharves, among the crowd of
+natives and strangers who were sojourning at this once straggling
+village--now, thanks to the enterprise of M. Lesseps, a fast-growing
+town.  One was the British consul at Suez, who, despite the prophecies
+of the English Government, and the unfavourable predictions of
+Stephenson, was in the habit of seeing, from his office window, English
+ships daily passing to and fro on the great canal, by which the old
+roundabout route from England to India by the Cape of Good Hope was
+abridged by at least a half.  The other was a small, slight-built
+personage, with a nervous, intelligent face, and bright eyes peering
+out from under eyebrows which he was incessantly twitching.  He was
+just now manifesting unmistakable signs of impatience, nervously pacing
+up and down, and unable to stand still for a moment.  This was Fix, one
+of the detectives who had been dispatched from England in search of the
+bank robber; it was his task to narrowly watch every passenger who
+arrived at Suez, and to follow up all who seemed to be suspicious
+characters, or bore a resemblance to the description of the criminal,
+which he had received two days before from the police headquarters at
+London.  The detective was evidently inspired by the hope of obtaining
+the splendid reward which would be the prize of success, and awaited
+with a feverish impatience, easy to understand, the arrival of the
+steamer Mongolia.
+
+"So you say, consul," asked he for the twentieth time, "that this
+steamer is never behind time?"
+
+"No, Mr. Fix," replied the consul.  "She was bespoken yesterday at Port
+Said, and the rest of the way is of no account to such a craft.  I
+repeat that the Mongolia has been in advance of the time required by
+the company's regulations, and gained the prize awarded for excess of
+speed."
+
+"Does she come directly from Brindisi?"
+
+"Directly from Brindisi; she takes on the Indian mails there, and she
+left there Saturday at five p.m.  Have patience, Mr. Fix; she will not
+be late.  But really, I don't see how, from the description you have,
+you will be able to recognise your man, even if he is on board the
+Mongolia."
+
+"A man rather feels the presence of these fellows, consul, than
+recognises them.  You must have a scent for them, and a scent is like a
+sixth sense which combines hearing, seeing, and smelling.  I've
+arrested more than one of these gentlemen in my time, and, if my thief
+is on board, I'll answer for it; he'll not slip through my fingers."
+
+"I hope so, Mr. Fix, for it was a heavy robbery."
+
+"A magnificent robbery, consul; fifty-five thousand pounds!  We don't
+often have such windfalls.  Burglars are getting to be so contemptible
+nowadays!  A fellow gets hung for a handful of shillings!"
+
+"Mr. Fix," said the consul, "I like your way of talking, and hope
+you'll succeed; but I fear you will find it far from easy.  Don't you
+see, the description which you have there has a singular resemblance to
+an honest man?"
+
+"Consul," remarked the detective, dogmatically, "great robbers always
+resemble honest folks.  Fellows who have rascally faces have only one
+course to take, and that is to remain honest; otherwise they would be
+arrested off-hand.  The artistic thing is, to unmask honest
+countenances; it's no light task, I admit, but a real art."
+
+Mr. Fix evidently was not wanting in a tinge of self-conceit.
+
+Little by little the scene on the quay became more animated; sailors of
+various nations, merchants, ship-brokers, porters, fellahs, bustled to
+and fro as if the steamer were immediately expected.  The weather was
+clear, and slightly chilly.  The minarets of the town loomed above the
+houses in the pale rays of the sun.  A jetty pier, some two thousand
+yards along, extended into the roadstead.  A number of fishing-smacks
+and coasting boats, some retaining the fantastic fashion of ancient
+galleys, were discernible on the Red Sea.
+
+As he passed among the busy crowd, Fix, according to habit, scrutinised
+the passers-by with a keen, rapid glance.
+
+It was now half-past ten.
+
+"The steamer doesn't come!" he exclaimed, as the port clock struck.
+
+"She can't be far off now," returned his companion.
+
+"How long will she stop at Suez?"
+
+"Four hours; long enough to get in her coal.  It is thirteen hundred
+and ten miles from Suez to Aden, at the other end of the Red Sea, and
+she has to take in a fresh coal supply."
+
+"And does she go from Suez directly to Bombay?"
+
+"Without putting in anywhere."
+
+"Good!" said Fix.  "If the robber is on board he will no doubt get off
+at Suez, so as to reach the Dutch or French colonies in Asia by some
+other route.  He ought to know that he would not be safe an hour in
+India, which is English soil."
+
+"Unless," objected the consul, "he is exceptionally shrewd.  An English
+criminal, you know, is always better concealed in London than anywhere
+else."
+
+This observation furnished the detective food for thought, and
+meanwhile the consul went away to his office.  Fix, left alone, was
+more impatient than ever, having a presentiment that the robber was on
+board the Mongolia.  If he had indeed left London intending to reach
+the New World, he would naturally take the route via India, which was
+less watched and more difficult to watch than that of the Atlantic.
+But Fix's reflections were soon interrupted by a succession of sharp
+whistles, which announced the arrival of the Mongolia.  The porters and
+fellahs rushed down the quay, and a dozen boats pushed off from the
+shore to go and meet the steamer.  Soon her gigantic hull appeared
+passing along between the banks, and eleven o'clock struck as she
+anchored in the road.  She brought an unusual number of passengers,
+some of whom remained on deck to scan the picturesque panorama of the
+town, while the greater part disembarked in the boats, and landed on
+the quay.
+
+Fix took up a position, and carefully examined each face and figure
+which made its appearance.  Presently one of the passengers, after
+vigorously pushing his way through the importunate crowd of porters,
+came up to him and politely asked if he could point out the English
+consulate, at the same time showing a passport which he wished to have
+visaed.  Fix instinctively took the passport, and with a rapid glance
+read the description of its bearer.  An involuntary motion of surprise
+nearly escaped him, for the description in the passport was identical
+with that of the bank robber which he had received from Scotland Yard.
+
+"Is this your passport?" asked he.
+
+"No, it's my master's."
+
+"And your master is--"
+
+"He stayed on board."
+
+"But he must go to the consul's in person, so as to establish his
+identity."
+
+"Oh, is that necessary?"
+
+"Quite indispensable."
+
+"And where is the consulate?"
+
+"There, on the corner of the square," said Fix, pointing to a house two
+hundred steps off.
+
+"I'll go and fetch my master, who won't be much pleased, however, to be
+disturbed."
+
+The passenger bowed to Fix, and returned to the steamer.
+
+
+
+
+Chapter VII
+
+WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS AIDS TO
+DETECTIVES
+
+
+The detective passed down the quay, and rapidly made his way to the
+consul's office, where he was at once admitted to the presence of that
+official.
+
+"Consul," said he, without preamble, "I have strong reasons for
+believing that my man is a passenger on the Mongolia." And he narrated
+what had just passed concerning the passport.
+
+"Well, Mr. Fix," replied the consul, "I shall not be sorry to see the
+rascal's face; but perhaps he won't come here--that is, if he is the
+person you suppose him to be.  A robber doesn't quite like to leave
+traces of his flight behind him; and, besides, he is not obliged to
+have his passport countersigned."
+
+"If he is as shrewd as I think he is, consul, he will come."
+
+"To have his passport visaed?"
+
+"Yes.  Passports are only good for annoying honest folks, and aiding in
+the flight of rogues.  I assure you it will be quite the thing for him
+to do; but I hope you will not visa the passport."
+
+"Why not?  If the passport is genuine I have no right to refuse."
+
+"Still, I must keep this man here until I can get a warrant to arrest
+him from London."
+
+"Ah, that's your look-out.  But I cannot--"
+
+The consul did not finish his sentence, for as he spoke a knock was
+heard at the door, and two strangers entered, one of whom was the
+servant whom Fix had met on the quay.  The other, who was his master,
+held out his passport with the request that the consul would do him the
+favour to visa it.  The consul took the document and carefully read it,
+whilst Fix observed, or rather devoured, the stranger with his eyes
+from a corner of the room.
+
+"You are Mr. Phileas Fogg?" said the consul, after reading the passport.
+
+"I am."
+
+"And this man is your servant?"
+
+"He is: a Frenchman, named Passepartout."
+
+"You are from London?"
+
+"Yes."
+
+"And you are going--"
+
+"To Bombay."
+
+"Very good, sir.  You know that a visa is useless, and that no passport
+is required?"
+
+"I know it, sir," replied Phileas Fogg; "but I wish to prove, by your
+visa, that I came by Suez."
+
+"Very well, sir."
+
+The consul proceeded to sign and date the passport, after which he
+added his official seal.  Mr. Fogg paid the customary fee, coldly
+bowed, and went out, followed by his servant.
+
+"Well?" queried the detective.
+
+"Well, he looks and acts like a perfectly honest man," replied the
+consul.
+
+"Possibly; but that is not the question.  Do you think, consul, that
+this phlegmatic gentleman resembles, feature by feature, the robber
+whose description I have received?"
+
+"I concede that; but then, you know, all descriptions--"
+
+"I'll make certain of it," interrupted Fix.  "The servant seems to me
+less mysterious than the master; besides, he's a Frenchman, and can't
+help talking.  Excuse me for a little while, consul."
+
+Fix started off in search of Passepartout.
+
+Meanwhile Mr. Fogg, after leaving the consulate, repaired to the quay,
+gave some orders to Passepartout, went off to the    Mongolia in a
+boat, and descended to his cabin.  He took up his note-book, which
+contained the following memoranda:
+
+"Left London, Wednesday, October 2nd, at 8.45 p.m.  "Reached Paris,
+Thursday, October 3rd, at 7.20 a.m.  "Left Paris, Thursday, at 8.40
+a.m.  "Reached Turin by Mont Cenis, Friday, October 4th, at 6.35 a.m.
+"Left Turin, Friday, at 7.20 a.m.  "Arrived at Brindisi, Saturday,
+October 5th, at 4 p.m.  "Sailed on the Mongolia, Saturday, at 5 p.m.
+"Reached Suez, Wednesday, October 9th, at 11 a.m.  "Total of hours
+spent, 158+; or, in days, six days and a half."
+
+These dates were inscribed in an itinerary divided into columns,
+indicating the month, the day of the month, and the day for the
+stipulated and actual arrivals at each principal point Paris, Brindisi,
+Suez, Bombay, Calcutta, Singapore, Hong Kong, Yokohama, San Francisco,
+New York, and London--from the 2nd of October to the 21st of December;
+and giving a space for setting down the gain made or the loss suffered
+on arrival at each locality.  This methodical record thus contained an
+account of everything needed, and Mr. Fogg always knew whether he was
+behind-hand or in advance of his time.  On this Friday, October 9th, he
+noted his arrival at Suez, and observed that he had as yet neither
+gained nor lost.  He sat down quietly to breakfast in his cabin, never
+once thinking of inspecting the town, being one of those Englishmen who
+are wont to see foreign countries through the eyes of their domestics.
+
+
+
+
+Chapter VIII
+
+IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+
+Fix soon rejoined Passepartout, who was lounging and looking about on
+the quay, as if he did not feel that he, at least, was obliged not to
+see anything.
+
+"Well, my friend," said the detective, coming up with him, "is your
+passport visaed?"
+
+"Ah, it's you, is it, monsieur?" responded Passepartout.  "Thanks, yes,
+the passport is all right."
+
+"And you are looking about you?"
+
+"Yes; but we travel so fast that I seem to be journeying in a dream.
+So this is Suez?"
+
+"Yes."
+
+"In Egypt?"
+
+"Certainly, in Egypt."
+
+"And in Africa?"
+
+"In Africa."
+
+"In Africa!" repeated Passepartout.  "Just think, monsieur, I had no
+idea that we should go farther than Paris; and all that I saw of Paris
+was between twenty minutes past seven and twenty minutes before nine in
+the morning, between the Northern and the Lyons stations, through the
+windows of a car, and in a driving rain!  How I regret not having seen
+once more Pere la Chaise and the circus in the Champs Elysees!"
+
+"You are in a great hurry, then?"
+
+"I am not, but my master is.  By the way, I must buy some shoes and
+shirts.  We came away without trunks, only with a carpet-bag."
+
+"I will show you an excellent shop for getting what you want."
+
+"Really, monsieur, you are very kind."
+
+And they walked off together, Passepartout chatting volubly as they
+went along.
+
+"Above all," said he; "don't let me lose the steamer."
+
+"You have plenty of time; it's only twelve o'clock."
+
+Passepartout pulled out his big watch.  "Twelve!" he exclaimed; "why,
+it's only eight minutes before ten."
+
+"Your watch is slow."
+
+"My watch?  A family watch, monsieur, which has come down from my
+great-grandfather!  It doesn't vary five minutes in the year.  It's a
+perfect chronometer, look you."
+
+"I see how it is," said Fix.  "You have kept London time, which is two
+hours behind that of Suez.  You ought to regulate your watch at noon in
+each country."
+
+"I regulate my watch?  Never!"
+
+"Well, then, it will not agree with the sun."
+
+"So much the worse for the sun, monsieur.  The sun will be wrong, then!"
+
+And the worthy fellow returned the watch to its fob with a defiant
+gesture.  After a few minutes silence, Fix resumed: "You left London
+hastily, then?"
+
+"I rather think so!  Last Friday at eight o'clock in the evening,
+Monsieur Fogg came home from his club, and three-quarters of an hour
+afterwards we were off."
+
+"But where is your master going?"
+
+"Always straight ahead.  He is going round the world."
+
+"Round the world?" cried Fix.
+
+"Yes, and in eighty days!  He says it is on a wager; but, between us, I
+don't believe a word of it.  That wouldn't be common sense.  There's
+something else in the wind."
+
+"Ah!  Mr. Fogg is a character, is he?"
+
+"I should say he was."
+
+"Is he rich?"
+
+"No doubt, for he is carrying an enormous sum in brand new banknotes
+with him.  And he doesn't spare the money on the way, either: he has
+offered a large reward to the engineer of the Mongolia if he gets us to
+Bombay well in advance of time."
+
+"And you have known your master a long time?"
+
+"Why, no; I entered his service the very day we left London."
+
+The effect of these replies upon the already suspicious and excited
+detective may be imagined.  The hasty departure from London soon after
+the robbery; the large sum carried by Mr. Fogg; his eagerness to reach
+distant countries; the pretext of an eccentric and foolhardy bet--all
+confirmed Fix in his theory.  He continued to pump poor Passepartout,
+and learned that he really knew little or nothing of his master, who
+lived a solitary existence in London, was said to be rich, though no
+one knew whence came his riches, and was mysterious and impenetrable in
+his affairs and habits.  Fix felt sure that Phileas Fogg would not land
+at Suez, but was really going on to Bombay.
+
+"Is Bombay far from here?" asked Passepartout.
+
+"Pretty far.  It is a ten days' voyage by sea."
+
+"And in what country is Bombay?"
+
+"India."
+
+"In Asia?"
+
+"Certainly."
+
+"The deuce!  I was going to tell you there's one thing that worries
+me--my burner!"
+
+"What burner?"
+
+"My gas-burner, which I forgot to turn off, and which is at this moment
+burning at my expense.  I have calculated, monsieur, that I lose two
+shillings every four and twenty hours, exactly sixpence more than I
+earn; and you will understand that the longer our journey--"
+
+Did Fix pay any attention to Passepartout's trouble about the gas?  It
+is not probable.  He was not listening, but was cogitating a project.
+Passepartout and he had now reached the shop, where Fix left his
+companion to make his purchases, after recommending him not to miss the
+steamer, and hurried back to the consulate.  Now that he was fully
+convinced, Fix had quite recovered his equanimity.
+
+"Consul," said he, "I have no longer any doubt.  I have spotted my man.
+He passes himself off as an odd stick who is going round the world in
+eighty days."
+
+"Then he's a sharp fellow," returned the consul, "and counts on
+returning to London after putting the police of the two countries off
+his track."
+
+"We'll see about that," replied Fix.
+
+"But are you not mistaken?"
+
+"I am not mistaken."
+
+"Why was this robber so anxious to prove, by the visa, that he had
+passed through Suez?"
+
+"Why?  I have no idea; but listen to me."
+
+He reported in a few words the most important parts of his conversation
+with Passepartout.
+
+"In short," said the consul, "appearances are wholly against this man.
+And what are you going to do?"
+
+"Send a dispatch to London for a warrant of arrest to be dispatched
+instantly to Bombay, take passage on board the Mongolia, follow my
+rogue to India, and there, on English ground, arrest him politely, with
+my warrant in my hand, and my hand on his shoulder."
+
+Having uttered these words with a cool, careless air, the detective
+took leave of the consul, and repaired to the telegraph office, whence
+he sent the dispatch which we have seen to the London police office.  A
+quarter of an hour later found Fix, with a small bag in his hand,
+proceeding on board the Mongolia; and, ere many moments longer, the
+noble steamer rode out at full steam upon the waters of the Red Sea.
+
+
+
+
+Chapter IX
+
+IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS TO THE
+DESIGNS OF PHILEAS FOGG
+
+
+The distance between Suez and Aden is precisely thirteen hundred and
+ten miles, and the regulations of the company allow the steamers one
+hundred and thirty-eight hours in which to traverse it.  The Mongolia,
+thanks to the vigorous exertions of the engineer, seemed likely, so
+rapid was her speed, to reach her destination considerably within that
+time.  The greater part of the passengers from Brindisi were bound for
+India some for Bombay, others for Calcutta by way of Bombay, the
+nearest route thither, now that a railway crosses the Indian peninsula.
+Among the passengers was a number of officials and military officers of
+various grades, the latter being either attached to the regular British
+forces or commanding the Sepoy troops, and receiving high salaries ever
+since the central government has assumed the powers of the East India
+Company: for the sub-lieutenants get 280 pounds, brigadiers, 2,400
+pounds, and generals of divisions, 4,000 pounds.  What with the
+military men, a number of rich young Englishmen on their travels, and
+the hospitable efforts of the purser, the time passed quickly on the
+Mongolia.  The best of fare was spread upon the cabin tables at
+breakfast, lunch, dinner, and the eight o'clock supper, and the ladies
+scrupulously changed their toilets twice a day; and the hours were
+whirled away, when the sea was tranquil, with music, dancing, and games.
+
+But the Red Sea is full of caprice, and often boisterous, like most
+long and narrow gulfs.  When the wind came from the African or Asian
+coast the Mongolia, with her long hull, rolled fearfully.  Then the
+ladies speedily disappeared below; the pianos were silent; singing and
+dancing suddenly ceased.  Yet the good ship ploughed straight on,
+unretarded by wind or wave, towards the straits of Bab-el-Mandeb.  What
+was Phileas Fogg doing all this time?  It might be thought that, in his
+anxiety, he would be constantly watching the changes of the wind, the
+disorderly raging of the billows--every chance, in short, which might
+force the Mongolia to slacken her speed, and thus interrupt his
+journey.  But, if he thought of these possibilities, he did not betray
+the fact by any outward sign.
+
+Always the same impassible member of the Reform Club, whom no incident
+could surprise, as unvarying as the ship's chronometers, and seldom
+having the curiosity even to go upon the deck, he passed through the
+memorable scenes of the Red Sea with cold indifference; did not care to
+recognise the historic towns and villages which, along its borders,
+raised their picturesque outlines against the sky; and betrayed no fear
+of the dangers of the Arabic Gulf, which the old historians always
+spoke of with horror, and upon which the ancient navigators never
+ventured without propitiating the gods by ample sacrifices.  How did
+this eccentric personage pass his time on the Mongolia?  He made his
+four hearty meals every day, regardless of the most persistent rolling
+and pitching on the part of the steamer; and he played whist
+indefatigably, for he had found partners as enthusiastic in the game as
+himself.  A tax-collector, on the way to his post at Goa; the Rev.
+Decimus Smith, returning to his parish at Bombay; and a
+brigadier-general of the English army, who was about to rejoin his
+brigade at Benares, made up the party, and, with Mr. Fogg, played whist
+by the hour together in absorbing silence.
+
+As for Passepartout, he, too, had escaped sea-sickness, and took his
+meals conscientiously in the forward cabin.  He rather enjoyed the
+voyage, for he was well fed and well lodged, took a great interest in
+the scenes through which they were passing, and consoled himself with
+the delusion that his master's whim would end at Bombay.  He was
+pleased, on the day after leaving Suez, to find on deck the obliging
+person with whom he had walked and chatted on the quays.
+
+"If I am not mistaken," said he, approaching this person, with his most
+amiable smile, "you are the gentleman who so kindly volunteered to
+guide me at Suez?"
+
+"Ah!  I quite recognise you.  You are the servant of the strange
+Englishman--"
+
+"Just so, monsieur--"
+
+"Fix."
+
+"Monsieur Fix," resumed Passepartout, "I'm charmed to find you on
+board.  Where are you bound?"
+
+"Like you, to Bombay."
+
+"That's capital!  Have you made this trip before?"
+
+"Several times.  I am one of the agents of the Peninsular Company."
+
+"Then you know India?"
+
+"Why yes," replied Fix, who spoke cautiously.
+
+"A curious place, this India?"
+
+"Oh, very curious.  Mosques, minarets, temples, fakirs, pagodas,
+tigers, snakes, elephants!  I hope you will have ample time to see the
+sights."
+
+"I hope so, Monsieur Fix.  You see, a man of sound sense ought not to
+spend his life jumping from a steamer upon a railway train, and from a
+railway train upon a steamer again, pretending to make the tour of the
+world in eighty days!  No; all these gymnastics, you may be sure, will
+cease at Bombay."
+
+"And Mr. Fogg is getting on well?" asked Fix, in the most natural tone
+in the world.
+
+"Quite well, and I too.  I eat like a famished ogre; it's the sea air."
+
+"But I never see your master on deck."
+
+"Never; he hasn't the least curiosity."
+
+"Do you know, Mr. Passepartout, that this pretended tour in eighty days
+may conceal some secret errand--perhaps a diplomatic mission?"
+
+"Faith, Monsieur Fix, I assure you I know nothing about it, nor would I
+give half a crown to find out."
+
+After this meeting, Passepartout and Fix got into the habit of chatting
+together, the latter making it a point to gain the worthy man's
+confidence.  He frequently offered him a glass of whiskey or pale ale
+in the steamer bar-room, which Passepartout never failed to accept with
+graceful alacrity, mentally pronouncing Fix the best of good fellows.
+
+Meanwhile the Mongolia was pushing forward rapidly; on the 13th, Mocha,
+surrounded by its ruined walls whereon date-trees were growing, was
+sighted, and on the mountains beyond were espied vast coffee-fields.
+Passepartout was ravished to behold this celebrated place, and thought
+that, with its circular walls and dismantled fort, it looked like an
+immense coffee-cup and saucer. The following night they passed through
+the Strait of Bab-el-Mandeb, which means in Arabic The Bridge of Tears,
+and the next day they put in at Steamer Point, north-west of Aden
+harbour, to take in coal.  This matter of fuelling steamers is a
+serious one at such distances from the coal-mines; it costs the
+Peninsular Company some eight hundred thousand pounds a year.  In these
+distant seas, coal is worth three or four pounds sterling a ton.
+
+The Mongolia had still sixteen hundred and fifty miles to traverse
+before reaching Bombay, and was obliged to remain four hours at Steamer
+Point to coal up.  But this delay, as it was foreseen, did not affect
+Phileas Fogg's programme; besides, the Mongolia, instead of reaching
+Aden on the morning of the 15th, when she was due, arrived there on the
+evening of the 14th, a gain of fifteen hours.
+
+Mr. Fogg and his servant went ashore at Aden to have the passport again
+visaed; Fix, unobserved, followed them.  The visa procured, Mr. Fogg
+returned on board to resume his former habits; while Passepartout,
+according to custom, sauntered about among the mixed population of
+Somalis, Banyans, Parsees, Jews, Arabs, and Europeans who comprise the
+twenty-five thousand inhabitants of Aden.  He gazed with wonder upon
+the fortifications which make this place the Gibraltar of the Indian
+Ocean, and the vast cisterns where the English engineers were still at
+work, two thousand years after the engineers of Solomon.
+
+"Very curious, very curious," said Passepartout to himself, on
+returning to the steamer.  "I see that it is by no means useless to
+travel, if a man wants to see something new."  At six p.m.  the
+Mongolia slowly moved out of the roadstead, and was soon once more on
+the Indian Ocean.  She had a hundred and sixty-eight hours in which to
+reach Bombay, and the sea was favourable, the wind being in the
+north-west, and all sails aiding the engine.  The steamer rolled but
+little, the ladies, in fresh toilets, reappeared on deck, and the
+singing and dancing were resumed.  The trip was being accomplished most
+successfully, and Passepartout was enchanted with the congenial
+companion which chance had secured him in the person of the delightful
+Fix.  On Sunday, October 20th, towards noon, they came in sight of the
+Indian coast: two hours later the pilot came on board.  A range of
+hills lay against the sky in the horizon, and soon the rows of palms
+which adorn Bombay came distinctly into view.  The steamer entered the
+road formed by the islands in the bay, and at half-past four she hauled
+up at the quays of Bombay.
+
+Phileas Fogg was in the act of finishing the thirty-third rubber of the
+voyage, and his partner and himself having, by a bold stroke, captured
+all thirteen of the tricks, concluded this fine campaign with a
+brilliant victory.
+
+The Mongolia was due at Bombay on the 22nd; she arrived on the 20th.
+This was a gain to Phileas Fogg of two days since his departure from
+London, and he calmly entered the fact in the itinerary, in the column
+of gains.
+
+
+
+
+Chapter X
+
+IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS OF HIS
+SHOES
+
+
+Everybody knows that the great reversed triangle of land, with its base
+in the north and its apex in the south, which is called India, embraces
+fourteen hundred thousand square miles, upon which is spread unequally
+a population of one hundred and eighty millions of souls.  The British
+Crown exercises a real and despotic dominion over the larger portion of
+this vast country, and has a governor-general stationed at Calcutta,
+governors at Madras, Bombay, and in Bengal, and a lieutenant-governor
+at Agra.
+
+But British India, properly so called, only embraces seven hundred
+thousand square miles, and a population of from one hundred to one
+hundred and ten millions of inhabitants.  A considerable portion of
+India is still free from British authority; and there are certain
+ferocious rajahs in the interior who are absolutely independent.  The
+celebrated East India Company was all-powerful from 1756, when the
+English first gained a foothold on the spot where now stands the city
+of Madras, down to the time of the great Sepoy insurrection.  It
+gradually annexed province after province, purchasing them of the
+native chiefs, whom it seldom paid, and appointed the governor-general
+and his subordinates, civil and military.  But the East India Company
+has now passed away, leaving the British possessions in India directly
+under the control of the Crown.  The aspect of the country, as well as
+the manners and distinctions of race, is daily changing.
+
+Formerly one was obliged to travel in India by the old cumbrous methods
+of going on foot or on horseback, in palanquins or unwieldy coaches;
+now fast steamboats ply on the Indus and the Ganges, and a great
+railway, with branch lines joining the main line at many points on its
+route, traverses the peninsula from Bombay to Calcutta in three days.
+This railway does not run in a direct line across India.  The distance
+between Bombay and Calcutta, as the bird flies, is only from one
+thousand to eleven hundred miles; but the deflections of the road
+increase this distance by more than a third.
+
+The general route of the Great Indian Peninsula Railway is as follows:
+Leaving Bombay, it passes through Salcette, crossing to the continent
+opposite Tannah, goes over the chain of the Western Ghauts, runs thence
+north-east as far as Burhampoor, skirts the nearly independent
+territory of Bundelcund, ascends to Allahabad, turns thence eastwardly,
+meeting the Ganges at Benares, then departs from the river a little,
+and, descending south-eastward by Burdivan and the French town of
+Chandernagor, has its terminus at Calcutta.
+
+The passengers of the Mongolia went ashore at half-past four p.m.; at
+exactly eight the train would start for Calcutta.
+
+Mr. Fogg, after bidding good-bye to his whist partners, left the
+steamer, gave his servant several errands to do, urged it upon him to
+be at the station promptly at eight, and, with his regular step, which
+beat to the second, like an astronomical clock, directed his steps to
+the passport office.  As for the wonders of Bombay--its famous city
+hall, its splendid library, its forts and docks, its bazaars, mosques,
+synagogues, its Armenian churches, and the noble pagoda on Malabar
+Hill, with its two polygonal towers--he cared not a straw to see them.
+He would not deign to examine even the masterpieces of Elephanta, or
+the mysterious hypogea, concealed south-east from the docks, or those
+fine remains of Buddhist architecture, the Kanherian grottoes of the
+island of Salcette.
+
+Having transacted his business at the passport office, Phileas Fogg
+repaired quietly to the railway station, where he ordered dinner.
+Among the dishes served up to him, the landlord especially recommended
+a certain giblet of "native rabbit," on which he prided himself.
+
+Mr. Fogg accordingly tasted the dish, but, despite its spiced sauce,
+found it far from palatable.  He rang for the landlord, and, on his
+appearance, said, fixing his clear eyes upon him, "Is this rabbit, sir?"
+
+"Yes, my lord," the rogue boldly replied, "rabbit from the jungles."
+
+"And this rabbit did not mew when he was killed?"
+
+"Mew, my lord!  What, a rabbit mew!  I swear to you--"
+
+"Be so good, landlord, as not to swear, but remember this: cats were
+formerly considered, in India, as sacred animals.  That was a good
+time."
+
+"For the cats, my lord?"
+
+"Perhaps for the travellers as well!"
+
+After which Mr. Fogg quietly continued his dinner.  Fix had gone on
+shore shortly after Mr. Fogg, and his first destination was the
+headquarters of the Bombay police.  He made himself known as a London
+detective, told his business at Bombay, and the position of affairs
+relative to the supposed robber, and nervously asked if a warrant had
+arrived from London.  It had not reached the office; indeed, there had
+not yet been time for it to arrive.  Fix was sorely disappointed, and
+tried to obtain an order of arrest from the director of the Bombay
+police.  This the director refused, as the matter concerned the London
+office, which alone could legally deliver the warrant.  Fix did not
+insist, and was fain to resign himself to await the arrival of the
+important document; but he was determined not to lose sight of the
+mysterious rogue as long as he stayed in Bombay.  He did not doubt for
+a moment, any more than Passepartout, that Phileas Fogg would remain
+there, at least until it was time for the warrant to arrive.
+
+Passepartout, however, had no sooner heard his master's orders on
+leaving the Mongolia than he saw at once that they were to leave Bombay
+as they had done Suez and Paris, and that the journey would be extended
+at least as far as Calcutta, and perhaps beyond that place.  He began
+to ask himself if this bet that Mr. Fogg talked about was not really in
+good earnest, and whether his fate was not in truth forcing him,
+despite his love of repose, around the world in eighty days!
+
+Having purchased the usual quota of shirts and shoes, he took a
+leisurely promenade about the streets, where crowds of people of many
+nationalities--Europeans, Persians with pointed caps, Banyas with round
+turbans, Sindes with square bonnets, Parsees with black mitres, and
+long-robed Armenians--were collected.  It happened to be the day of a
+Parsee festival.  These descendants of the sect of Zoroaster--the most
+thrifty, civilised, intelligent, and austere of the East Indians, among
+whom are counted the richest native merchants of Bombay--were
+celebrating a sort of religious carnival, with processions and shows,
+in the midst of which Indian dancing-girls, clothed in rose-coloured
+gauze, looped up with gold and silver, danced airily, but with perfect
+modesty, to the sound of viols and the clanging of tambourines.  It is
+needless to say that Passepartout watched these curious ceremonies with
+staring eyes and gaping mouth, and that his countenance was that of the
+greenest booby imaginable.
+
+Unhappily for his master, as well as himself, his curiosity drew him
+unconsciously farther off than he intended to go.  At last, having seen
+the Parsee carnival wind away in the distance, he was turning his steps
+towards the station, when he happened to espy the splendid pagoda on
+Malabar Hill, and was seized with an irresistible desire to see its
+interior.  He was quite ignorant that it is forbidden to Christians to
+enter certain Indian temples, and that even the faithful must not go in
+without first leaving their shoes outside the door.  It may be said
+here that the wise policy of the British Government severely punishes a
+disregard of the practices of the native religions.
+
+Passepartout, however, thinking no harm, went in like a simple tourist,
+and was soon lost in admiration of the splendid Brahmin ornamentation
+which everywhere met his eyes, when of a sudden he found himself
+sprawling on the sacred flagging.  He looked up to behold three enraged
+priests, who forthwith fell upon him; tore off his shoes, and began to
+beat him with loud, savage exclamations.  The agile Frenchman was soon
+upon his feet again, and lost no time in knocking down two of his
+long-gowned adversaries with his fists and a vigorous application of
+his toes; then, rushing out of the pagoda as fast as his legs could
+carry him, he soon escaped the third priest by mingling with the crowd
+in the streets.
+
+At five minutes before eight, Passepartout, hatless, shoeless, and
+having in the squabble lost his package of shirts and shoes, rushed
+breathlessly into the station.
+
+Fix, who had followed Mr. Fogg to the station, and saw that he was
+really going to leave Bombay, was there, upon the platform.  He had
+resolved to follow the supposed robber to Calcutta, and farther, if
+necessary.  Passepartout did not observe the detective, who stood in an
+obscure corner; but Fix heard him relate his adventures in a few words
+to Mr. Fogg.
+
+"I hope that this will not happen again," said Phileas Fogg coldly, as
+he got into the train.  Poor Passepartout, quite crestfallen, followed
+his master without a word.  Fix was on the point of entering another
+carriage, when an idea struck him which induced him to alter his plan.
+
+"No, I'll stay," muttered he.  "An offence has been committed on Indian
+soil.  I've got my man."
+
+Just then the locomotive gave a sharp screech, and the train passed out
+into the darkness of the night.
+
+
+
+
+Chapter XI
+
+IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE AT A
+FABULOUS PRICE
+
+
+The train had started punctually.  Among the passengers were a number
+of officers, Government officials, and opium and indigo merchants,
+whose business called them to the eastern coast.  Passepartout rode in
+the same carriage with his master, and a third passenger occupied a
+seat opposite to them.  This was Sir Francis Cromarty, one of Mr.
+Fogg's whist partners on the Mongolia, now on his way to join his corps
+at Benares.  Sir Francis was a tall, fair man of fifty, who had greatly
+distinguished himself in the last Sepoy revolt.  He made India his
+home, only paying brief visits to England at rare intervals; and was
+almost as familiar as a native with the customs, history, and character
+of India and its people.  But Phileas Fogg, who was not travelling, but
+only describing a circumference, took no pains to inquire into these
+subjects; he was a solid body, traversing an orbit around the
+terrestrial globe, according to the laws of rational mechanics.  He was
+at this moment calculating in his mind the number of hours spent since
+his departure from London, and, had it been in his nature to make a
+useless demonstration, would have rubbed his hands for satisfaction.
+Sir Francis Cromarty had observed the oddity of his travelling
+companion--although the only opportunity he had for studying him had
+been while he was dealing the cards, and between two rubbers--and
+questioned himself whether a human heart really beat beneath this cold
+exterior, and whether Phileas Fogg had any sense of the beauties of
+nature.  The brigadier-general was free to mentally confess that, of
+all the eccentric persons he had ever met, none was comparable to this
+product of the exact sciences.
+
+Phileas Fogg had not concealed from Sir Francis his design of going
+round the world, nor the circumstances under which he set out; and the
+general only saw in the wager a useless eccentricity and a lack of
+sound common sense.  In the way this strange gentleman was going on, he
+would leave the world without having done any good to himself or
+anybody else.
+
+An hour after leaving Bombay the train had passed the viaducts and the
+Island of Salcette, and had got into the open country.  At Callyan they
+reached the junction of the branch line which descends towards
+south-eastern India by Kandallah and Pounah; and, passing Pauwell, they
+entered the defiles of the mountains, with their basalt bases, and
+their summits crowned with thick and verdant forests.  Phileas Fogg and
+Sir Francis Cromarty exchanged a few words from time to time, and now
+Sir Francis, reviving the conversation, observed, "Some years ago, Mr.
+Fogg, you would have met with a delay at this point which would
+probably have lost you your wager."
+
+"How so, Sir Francis?"
+
+"Because the railway stopped at the base of these mountains, which the
+passengers were obliged to cross in palanquins or on ponies to
+Kandallah, on the other side."
+
+"Such a delay would not have deranged my plans in the least," said Mr.
+Fogg.  "I have constantly foreseen the likelihood of certain obstacles."
+
+"But, Mr. Fogg," pursued Sir Francis, "you run the risk of having some
+difficulty about this worthy fellow's adventure at the pagoda."
+Passepartout, his feet comfortably wrapped in his travelling-blanket,
+was sound asleep and did not dream that anybody was talking about him.
+"The Government is very severe upon that kind of offence.  It takes
+particular care that the religious customs of the Indians should be
+respected, and if your servant were caught--"
+
+"Very well, Sir Francis," replied Mr. Fogg; "if he had been caught he
+would have been condemned and punished, and then would have quietly
+returned to Europe.  I don't see how this affair could have delayed his
+master."
+
+The conversation fell again.  During the night the train left the
+mountains behind, and passed Nassik, and the next day proceeded over
+the flat, well-cultivated country of the Khandeish, with its straggling
+villages, above which rose the minarets of the pagodas.  This fertile
+territory is watered by numerous small rivers and limpid streams,
+mostly tributaries of the Godavery.
+
+Passepartout, on waking and looking out, could not realise that he was
+actually crossing India in a railway train.  The locomotive, guided by
+an English engineer and fed with English coal, threw out its smoke upon
+cotton, coffee, nutmeg, clove, and pepper plantations, while the steam
+curled in spirals around groups of palm-trees, in the midst of which
+were seen picturesque bungalows, viharis (sort of abandoned
+monasteries), and marvellous temples enriched by the exhaustless
+ornamentation of Indian architecture.  Then they came upon vast tracts
+extending to the horizon, with jungles inhabited by snakes and tigers,
+which fled at the noise of the train; succeeded by forests penetrated
+by the railway, and still haunted by elephants which, with pensive
+eyes, gazed at the train as it passed.  The travellers crossed, beyond
+Milligaum, the fatal country so often stained with blood by the
+sectaries of the goddess Kali.  Not far off rose Ellora, with its
+graceful pagodas, and the famous Aurungabad, capital of the ferocious
+Aureng-Zeb, now the chief town of one of the detached provinces of the
+kingdom of the Nizam.  It was thereabouts that Feringhea, the Thuggee
+chief, king of the stranglers, held his sway.  These ruffians, united
+by a secret bond, strangled victims of every age in honour of the
+goddess Death, without ever shedding blood; there was a period when
+this part of the country could scarcely be travelled over without
+corpses being found in every direction.  The English Government has
+succeeded in greatly diminishing these murders, though the Thuggees
+still exist, and pursue the exercise of their horrible rites.
+
+At half-past twelve the train stopped at Burhampoor where Passepartout
+was able to purchase some Indian slippers, ornamented with false
+pearls, in which, with evident vanity, he proceeded to encase his feet.
+The travellers made a hasty breakfast and started off for Assurghur,
+after skirting for a little the banks of the small river Tapty, which
+empties into the Gulf of Cambray, near Surat.
+
+Passepartout was now plunged into absorbing reverie.  Up to his arrival
+at Bombay, he had entertained hopes that their journey would end there;
+but, now that they were plainly whirling across India at full speed, a
+sudden change had come over the spirit of his dreams.  His old vagabond
+nature returned to him; the fantastic ideas of his youth once more took
+possession of him.  He came to regard his master's project as intended
+in good earnest, believed in the reality of the bet, and therefore in
+the tour of the world and the necessity of making it without fail
+within the designated period.  Already he began to worry about possible
+delays, and accidents which might happen on the way.  He recognised
+himself as being personally interested in the wager, and trembled at
+the thought that he might have been the means of losing it by his
+unpardonable folly of the night before.  Being much less cool-headed
+than Mr. Fogg, he was much more restless, counting and recounting the
+days passed over, uttering maledictions when the train stopped, and
+accusing it of sluggishness, and mentally blaming Mr. Fogg for not
+having bribed the engineer.  The worthy fellow was ignorant that, while
+it was possible by such means to hasten the rate of a steamer, it could
+not be done on the railway.
+
+The train entered the defiles of the Sutpour Mountains, which separate
+the Khandeish from Bundelcund, towards evening.  The next day Sir
+Francis Cromarty asked Passepartout what time it was; to which, on
+consulting his watch, he replied that it was three in the morning.
+This famous timepiece, always regulated on the Greenwich meridian,
+which was now some seventy-seven degrees westward, was at least four
+hours slow.  Sir Francis corrected Passepartout's time, whereupon the
+latter made the same remark that he had done to Fix; and upon the
+general insisting that the watch should be regulated in each new
+meridian, since he was constantly going eastward, that is in the face
+of the sun, and therefore the days were shorter by four minutes for
+each degree gone over, Passepartout obstinately refused to alter his
+watch, which he kept at London time.  It was an innocent delusion which
+could harm no one.
+
+The train stopped, at eight o'clock, in the midst of a glade some
+fifteen miles beyond Rothal, where there were several bungalows, and
+workmen's cabins.  The conductor, passing along the carriages, shouted,
+"Passengers will get out here!"
+
+Phileas Fogg looked at Sir Francis Cromarty for an explanation; but the
+general could not tell what meant a halt in the midst of this forest of
+dates and acacias.
+
+Passepartout, not less surprised, rushed out and speedily returned,
+crying: "Monsieur, no more railway!"
+
+"What do you mean?" asked Sir Francis.
+
+"I mean to say that the train isn't going on."
+
+The general at once stepped out, while Phileas Fogg calmly followed
+him, and they proceeded together to the conductor.
+
+"Where are we?" asked Sir Francis.
+
+"At the hamlet of Kholby."
+
+"Do we stop here?"
+
+"Certainly.  The railway isn't finished."
+
+"What! not finished?"
+
+"No.  There's still a matter of fifty miles to be laid from here to
+Allahabad, where the line begins again."
+
+"But the papers announced the opening of the railway throughout."
+
+"What would you have, officer?  The papers were mistaken."
+
+"Yet you sell tickets from Bombay to Calcutta," retorted Sir Francis,
+who was growing warm.
+
+"No doubt," replied the conductor; "but the passengers know that they
+must provide means of transportation for themselves from Kholby to
+Allahabad."
+
+Sir Francis was furious.  Passepartout would willingly have knocked the
+conductor down, and did not dare to look at his master.
+
+"Sir Francis," said Mr. Fogg quietly, "we will, if you please, look
+about for some means of conveyance to Allahabad."
+
+"Mr. Fogg, this is a delay greatly to your disadvantage."
+
+"No, Sir Francis; it was foreseen."
+
+"What!  You knew that the way--"
+
+"Not at all; but I knew that some obstacle or other would sooner or
+later arise on my route.  Nothing, therefore, is lost. I have two days,
+which I have already gained, to sacrifice.  A steamer leaves Calcutta
+for Hong Kong at noon, on the 25th.  This is the 22nd, and we shall
+reach Calcutta in time."
+
+There was nothing to say to so confident a response.
+
+It was but too true that the railway came to a termination at this
+point.  The papers were like some watches, which have a way of getting
+too fast, and had been premature in their announcement of the
+completion of the line.  The greater part of the travellers were aware
+of this interruption, and, leaving the train, they began to engage such
+vehicles as the village could provide four-wheeled palkigharis, waggons
+drawn by zebus, carriages that looked like perambulating pagodas,
+palanquins, ponies, and what not.
+
+Mr. Fogg and Sir Francis Cromarty, after searching the village from end
+to end, came back without having found anything.
+
+"I shall go afoot," said Phileas Fogg.
+
+Passepartout, who had now rejoined his master, made a wry grimace, as
+he thought of his magnificent, but too frail Indian shoes.  Happily he
+too had been looking about him, and, after a moment's hesitation, said,
+"Monsieur, I think I have found a means of conveyance."
+
+"What?"
+
+"An elephant!  An elephant that belongs to an Indian who lives but a
+hundred steps from here."
+
+"Let's go and see the elephant," replied Mr. Fogg.
+
+They soon reached a small hut, near which, enclosed within some high
+palings, was the animal in question.  An Indian came out of the hut,
+and, at their request, conducted them within the enclosure.  The
+elephant, which its owner had reared, not for a beast of burden, but
+for warlike purposes, was half domesticated.  The Indian had begun
+already, by often irritating him, and feeding him every three months on
+sugar and butter, to impart to him a ferocity not in his nature, this
+method being often employed by those who train the Indian elephants for
+battle.  Happily, however, for Mr. Fogg, the animal's instruction in
+this direction had not gone far, and the elephant still preserved his
+natural gentleness.  Kiouni--this was the name of the beast--could
+doubtless travel rapidly for a long time, and, in default of any other
+means of conveyance, Mr. Fogg resolved to hire him.  But elephants are
+far from cheap in India, where they are becoming scarce, the males,
+which alone are suitable for circus shows, are much sought, especially
+as but few of them are domesticated.  When therefore Mr. Fogg proposed
+to the Indian to hire Kiouni, he refused point-blank.  Mr. Fogg
+persisted, offering the excessive sum of ten pounds an hour for the
+loan of the beast to Allahabad.  Refused.  Twenty pounds?  Refused
+also.  Forty pounds?  Still refused.  Passepartout jumped at each
+advance; but the Indian declined to be tempted.  Yet the offer was an
+alluring one, for, supposing it took the elephant fifteen hours to
+reach Allahabad, his owner would receive no less than six hundred
+pounds sterling.
+
+Phileas Fogg, without getting in the least flurried, then proposed to
+purchase the animal outright, and at first offered a thousand pounds
+for him.  The Indian, perhaps thinking he was going to make a great
+bargain, still refused.
+
+Sir Francis Cromarty took Mr. Fogg aside, and begged him to reflect
+before he went any further; to which that gentleman replied that he was
+not in the habit of acting rashly, that a bet of twenty thousand pounds
+was at stake, that the elephant was absolutely necessary to him, and
+that he would secure him if he had to pay twenty times his value.
+Returning to the Indian, whose small, sharp eyes, glistening with
+avarice, betrayed that with him it was only a question of how great a
+price he could obtain.  Mr. Fogg offered first twelve hundred, then
+fifteen hundred, eighteen hundred, two thousand pounds.  Passepartout,
+usually so rubicund, was fairly white with suspense.
+
+At two thousand pounds the Indian yielded.
+
+"What a price, good heavens!" cried Passepartout, "for an elephant."
+
+It only remained now to find a guide, which was comparatively easy.  A
+young Parsee, with an intelligent face, offered his services, which Mr.
+Fogg accepted, promising so generous a reward as to materially
+stimulate his zeal.  The elephant was led out and equipped.  The
+Parsee, who was an accomplished elephant driver, covered his back with
+a sort of saddle-cloth, and attached to each of his flanks some
+curiously uncomfortable howdahs.  Phileas Fogg paid the Indian with
+some banknotes which he extracted from the famous carpet-bag, a
+proceeding that seemed to deprive poor Passepartout of his vitals.
+Then he offered to carry Sir Francis to Allahabad, which the brigadier
+gratefully accepted, as one traveller the more would not be likely to
+fatigue the gigantic beast.  Provisions were purchased at Kholby, and,
+while Sir Francis and Mr. Fogg took the howdahs on either side,
+Passepartout got astride the saddle-cloth between them.  The Parsee
+perched himself on the elephant's neck, and at nine o'clock they set
+out from the village, the animal marching off through the dense forest
+of palms by the shortest cut.
+
+
+
+
+Chapter XII
+
+IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE INDIAN
+FORESTS, AND WHAT ENSUED
+
+
+In order to shorten the journey, the guide passed to the left of the
+line where the railway was still in process of being built.  This line,
+owing to the capricious turnings of the Vindhia Mountains, did not
+pursue a straight course.  The Parsee, who was quite familiar with the
+roads and paths in the district, declared that they would gain twenty
+miles by striking directly through the forest.
+
+Phileas Fogg and Sir Francis Cromarty, plunged to the neck in the
+peculiar howdahs provided for them, were horribly jostled by the swift
+trotting of the elephant, spurred on as he was by the skilful Parsee;
+but they endured the discomfort with true British phlegm, talking
+little, and scarcely able to catch a glimpse of each other.  As for
+Passepartout, who was mounted on the beast's back, and received the
+direct force of each concussion as he trod along, he was very careful,
+in accordance with his master's advice, to keep his tongue from between
+his teeth, as it would otherwise have been bitten off short.  The
+worthy fellow bounced from the elephant's neck to his rump, and vaulted
+like a clown on a spring-board; yet he laughed in the midst of his
+bouncing, and from time to time took a piece of sugar out of his
+pocket, and inserted it in Kiouni's trunk, who received it without in
+the least slackening his regular trot.
+
+After two hours the guide stopped the elephant, and gave him an hour
+for rest, during which Kiouni, after quenching his thirst at a
+neighbouring spring, set to devouring the branches and shrubs round
+about him.  Neither Sir Francis nor Mr. Fogg regretted the delay, and
+both descended with a feeling of relief.  "Why, he's made of iron!"
+exclaimed the general, gazing admiringly on Kiouni.
+
+"Of forged iron," replied Passepartout, as he set about preparing a
+hasty breakfast.
+
+At noon the Parsee gave the signal of departure.  The country soon
+presented a very savage aspect.  Copses of dates and dwarf-palms
+succeeded the dense forests; then vast, dry plains, dotted with scanty
+shrubs, and sown with great blocks of syenite.  All this portion of
+Bundelcund, which is little frequented by travellers, is inhabited by a
+fanatical population, hardened in the most horrible practices of the
+Hindoo faith.  The English have not been able to secure complete
+dominion over this territory, which is subjected to the influence of
+rajahs, whom it is almost impossible to reach in their inaccessible
+mountain fastnesses. The travellers several times saw bands of
+ferocious Indians, who, when they perceived the elephant striding
+across-country, made angry and threatening motions.  The Parsee avoided
+them as much as possible.  Few animals were observed on the route; even
+the monkeys hurried from their path with contortions and grimaces which
+convulsed Passepartout with laughter.
+
+In the midst of his gaiety, however, one thought troubled the worthy
+servant.  What would Mr. Fogg do with the elephant when he got to
+Allahabad?  Would he carry him on with him?  Impossible!  The cost of
+transporting him would make him ruinously expensive.  Would he sell
+him, or set him free?  The estimable beast certainly deserved some
+consideration.  Should Mr. Fogg choose to make him, Passepartout, a
+present of Kiouni, he would be very much embarrassed; and these
+thoughts did not cease worrying him for a long time.
+
+The principal chain of the Vindhias was crossed by eight in the
+evening, and another halt was made on the northern slope, in a ruined
+bungalow.  They had gone nearly twenty-five miles that day, and an
+equal distance still separated them from the station of Allahabad.
+
+The night was cold.  The Parsee lit a fire in the bungalow with a few
+dry branches, and the warmth was very grateful, provisions purchased at
+Kholby sufficed for supper, and the travellers ate ravenously.  The
+conversation, beginning with a few disconnected phrases, soon gave
+place to loud and steady snores.  The guide watched Kiouni, who slept
+standing, bolstering himself against the trunk of a large tree.
+Nothing occurred during the night to disturb the slumberers, although
+occasional growls from panthers and chatterings of monkeys broke the
+silence; the more formidable beasts made no cries or hostile
+demonstration against the occupants of the bungalow.  Sir Francis slept
+heavily, like an honest soldier overcome with fatigue.  Passepartout
+was wrapped in uneasy dreams of the bouncing of the day before.  As for
+Mr. Fogg, he slumbered as peacefully as if he had been in his serene
+mansion in Saville Row.
+
+The journey was resumed at six in the morning; the guide hoped to reach
+Allahabad by evening.  In that case, Mr. Fogg would only lose a part of
+the forty-eight hours saved since the beginning of the tour.  Kiouni,
+resuming his rapid gait, soon descended the lower spurs of the
+Vindhias, and towards noon they passed by the village of Kallenger, on
+the Cani, one of the branches of the Ganges.  The guide avoided
+inhabited places, thinking it safer to keep the open country, which
+lies along the first depressions of the basin of the great river.
+Allahabad was now only twelve miles to the north-east.  They stopped
+under a clump of bananas, the fruit of which, as healthy as bread and
+as succulent as cream, was amply partaken of and appreciated.
+
+At two o'clock the guide entered a thick forest which extended several
+miles; he preferred to travel under cover of the woods.  They had not
+as yet had any unpleasant encounters, and the journey seemed on the
+point of being successfully accomplished, when the elephant, becoming
+restless, suddenly stopped.
+
+It was then four o'clock.
+
+"What's the matter?" asked Sir Francis, putting out his head.
+
+"I don't know, officer," replied the Parsee, listening attentively to a
+confused murmur which came through the thick branches.
+
+The murmur soon became more distinct; it now seemed like a distant
+concert of human voices accompanied by brass instruments.  Passepartout
+was all eyes and ears.  Mr. Fogg patiently waited without a word.  The
+Parsee jumped to the ground, fastened the elephant to a tree, and
+plunged into the thicket.  He soon returned, saying:
+
+"A procession of Brahmins is coming this way.  We must prevent their
+seeing us, if possible."
+
+The guide unloosed the elephant and led him into a thicket, at the same
+time asking the travellers not to stir.  He held himself ready to
+bestride the animal at a moment's notice, should flight become
+necessary; but he evidently thought that the procession of the faithful
+would pass without perceiving them amid the thick foliage, in which
+they were wholly concealed.
+
+The discordant tones of the voices and instruments drew nearer, and now
+droning songs mingled with the sound of the tambourines and cymbals.
+The head of the procession soon appeared beneath the trees, a hundred
+paces away; and the strange figures who performed the religious
+ceremony were easily distinguished through the branches.  First came
+the priests, with mitres on their heads, and clothed in long lace
+robes.  They were surrounded by men, women, and children, who sang a
+kind of lugubrious psalm, interrupted at regular intervals by the
+tambourines and cymbals; while behind them was drawn a car with large
+wheels, the spokes of which represented serpents entwined with each
+other.  Upon the car, which was drawn by four richly caparisoned zebus,
+stood a hideous statue with four arms, the body coloured a dull red,
+with haggard eyes, dishevelled hair, protruding tongue, and lips tinted
+with betel.  It stood upright upon the figure of a prostrate and
+headless giant.
+
+Sir Francis, recognising the statue, whispered, "The goddess Kali; the
+goddess of love and death."
+
+"Of death, perhaps," muttered back Passepartout, "but of love--that
+ugly old hag?  Never!"
+
+The Parsee made a motion to keep silence.
+
+A group of old fakirs were capering and making a wild ado round the
+statue; these were striped with ochre, and covered with cuts whence
+their blood issued drop by drop--stupid fanatics, who, in the great
+Indian ceremonies, still throw themselves under the wheels of
+Juggernaut.  Some Brahmins, clad in all the sumptuousness of Oriental
+apparel, and leading a woman who faltered at every step, followed.
+This woman was young, and as fair as a European.  Her head and neck,
+shoulders, ears, arms, hands, and toes were loaded down with jewels and
+gems with bracelets, earrings, and rings; while a tunic bordered with
+gold, and covered with a light muslin robe, betrayed the outline of her
+form.
+
+The guards who followed the young woman presented a violent contrast to
+her, armed as they were with naked sabres hung at their waists, and
+long damascened pistols, and bearing a corpse on a palanquin.  It was
+the body of an old man, gorgeously arrayed in the habiliments of a
+rajah, wearing, as in life, a turban embroidered with pearls, a robe of
+tissue of silk and gold, a scarf of cashmere sewed with diamonds, and
+the magnificent weapons of a Hindoo prince.  Next came the musicians
+and a rearguard of capering fakirs, whose cries sometimes drowned the
+noise of the instruments; these closed the procession.
+
+Sir Francis watched the procession with a sad countenance, and, turning
+to the guide, said, "A suttee."
+
+The Parsee nodded, and put his finger to his lips.  The procession
+slowly wound under the trees, and soon its last ranks disappeared in
+the depths of the wood.  The songs gradually died away; occasionally
+cries were heard in the distance, until at last all was silence again.
+
+Phileas Fogg had heard what Sir Francis said, and, as soon as the
+procession had disappeared, asked: "What is a suttee?"
+
+"A suttee," returned the general, "is a human sacrifice, but a
+voluntary one.  The woman you have just seen will be burned to-morrow
+at the dawn of day."
+
+"Oh, the scoundrels!" cried Passepartout, who could not repress his
+indignation.
+
+"And the corpse?" asked Mr. Fogg.
+
+"Is that of the prince, her husband," said the guide; "an independent
+rajah of Bundelcund."
+
+"Is it possible," resumed Phileas Fogg, his voice betraying not the
+least emotion, "that these barbarous customs still exist in India, and
+that the English have been unable to put a stop to them?"
+
+"These sacrifices do not occur in the larger portion of India," replied
+Sir Francis; "but we have no power over these savage territories, and
+especially here in Bundelcund.  The whole district north of the
+Vindhias is the theatre of incessant murders and pillage."
+
+"The poor wretch!" exclaimed Passepartout, "to be burned alive!"
+
+"Yes," returned Sir Francis, "burned alive.  And, if she were not, you
+cannot conceive what treatment she would be obliged to submit to from
+her relatives.  They would shave off her hair, feed her on a scanty
+allowance of rice, treat her with contempt; she would be looked upon as
+an unclean creature, and would die in some corner, like a scurvy dog.
+The prospect of so frightful an existence drives these poor creatures
+to the sacrifice much more than love or religious fanaticism.
+Sometimes, however, the sacrifice is really voluntary, and it requires
+the active interference of the Government to prevent it.  Several years
+ago, when I was living at Bombay, a young widow asked permission of the
+governor to be burned along with her husband's body; but, as you may
+imagine, he refused.  The woman left the town, took refuge with an
+independent rajah, and there carried out her self-devoted purpose."
+
+While Sir Francis was speaking, the guide shook his head several times,
+and now said: "The sacrifice which will take place to-morrow at dawn is
+not a voluntary one."
+
+"How do you know?"
+
+"Everybody knows about this affair in Bundelcund."
+
+"But the wretched creature did not seem to be making any resistance,"
+observed Sir Francis.
+
+"That was because they had intoxicated her with fumes of hemp and
+opium."
+
+"But where are they taking her?"
+
+"To the pagoda of Pillaji, two miles from here; she will pass the night
+there."
+
+"And the sacrifice will take place--"
+
+"To-morrow, at the first light of dawn."
+
+The guide now led the elephant out of the thicket, and leaped upon his
+neck.  Just at the moment that he was about to urge Kiouni forward with
+a peculiar whistle, Mr. Fogg stopped him, and, turning to Sir Francis
+Cromarty, said, "Suppose we save this woman."
+
+"Save the woman, Mr. Fogg!"
+
+"I have yet twelve hours to spare; I can devote them to that."
+
+"Why, you are a man of heart!"
+
+"Sometimes," replied Phileas Fogg, quietly; "when I have the time."
+
+
+
+
+Chapter XIII
+
+IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS THE BRAVE
+
+
+The project was a bold one, full of difficulty, perhaps impracticable.
+Mr. Fogg was going to risk life, or at least liberty, and therefore the
+success of his tour.  But he did not hesitate, and he found in Sir
+Francis Cromarty an enthusiastic ally.
+
+As for Passepartout, he was ready for anything that might be proposed.
+His master's idea charmed him; he perceived a heart, a soul, under that
+icy exterior.  He began to love Phileas Fogg.
+
+There remained the guide: what course would he adopt?  Would he not
+take part with the Indians?  In default of his assistance, it was
+necessary to be assured of his neutrality.
+
+Sir Francis frankly put the question to him.
+
+"Officers," replied the guide, "I am a Parsee, and this woman is a
+Parsee.  Command me as you will."
+
+"Excellent!" said Mr. Fogg.
+
+"However," resumed the guide, "it is certain, not only that we shall
+risk our lives, but horrible tortures, if we are taken."
+
+"That is foreseen," replied Mr. Fogg.  "I think we must wait till night
+before acting."
+
+"I think so," said the guide.
+
+The worthy Indian then gave some account of the victim, who, he said,
+was a celebrated beauty of the Parsee race, and the daughter of a
+wealthy Bombay merchant.  She had received a thoroughly English
+education in that city, and, from her manners and intelligence, would
+be thought an European.  Her name was Aouda.  Left an orphan, she was
+married against her will to the old rajah of Bundelcund; and, knowing
+the fate that awaited her, she escaped, was retaken, and devoted by the
+rajah's relatives, who had an interest in her death, to the sacrifice
+from which it seemed she could not escape.
+
+The Parsee's narrative only confirmed Mr. Fogg and his companions in
+their generous design.  It was decided that the guide should direct the
+elephant towards the pagoda of Pillaji, which he accordingly approached
+as quickly as possible.  They halted, half an hour afterwards, in a
+copse, some five hundred feet from the pagoda, where they were well
+concealed; but they could hear the groans and cries of the fakirs
+distinctly.
+
+They then discussed the means of getting at the victim.  The guide was
+familiar with the pagoda of Pillaji, in which, as he declared, the
+young woman was imprisoned.  Could they enter any of its doors while
+the whole party of Indians was plunged in a drunken sleep, or was it
+safer to attempt to make a hole in the walls?  This could only be
+determined at the moment and the place themselves; but it was certain
+that the abduction must be made that night, and not when, at break of
+day, the victim was led to her funeral pyre.  Then no human
+intervention could save her.
+
+As soon as night fell, about six o'clock, they decided to make a
+reconnaissance around the pagoda.  The cries of the fakirs were just
+ceasing; the Indians were in the act of plunging themselves into the
+drunkenness caused by liquid opium mingled with hemp, and it might be
+possible to slip between them to the temple itself.
+
+The Parsee, leading the others, noiselessly crept through the wood, and
+in ten minutes they found themselves on the banks of a small stream,
+whence, by the light of the rosin torches, they perceived a pyre of
+wood, on the top of which lay the embalmed body of the rajah, which was
+to be burned with his wife.  The pagoda, whose minarets loomed above
+the trees in the deepening dusk, stood a hundred steps away.
+
+"Come!" whispered the guide.
+
+He slipped more cautiously than ever through the brush, followed by his
+companions; the silence around was only broken by the low murmuring of
+the wind among the branches.
+
+Soon the Parsee stopped on the borders of the glade, which was lit up
+by the torches.  The ground was covered by groups of the Indians,
+motionless in their drunken sleep; it seemed a battlefield strewn with
+the dead.  Men, women, and children lay together.
+
+In the background, among the trees, the pagoda of Pillaji loomed
+distinctly.  Much to the guide's disappointment, the guards of the
+rajah, lighted by torches, were watching at the doors and marching to
+and fro with naked sabres; probably the priests, too, were watching
+within.
+
+The Parsee, now convinced that it was impossible to force an entrance
+to the temple, advanced no farther, but led his companions back again.
+Phileas Fogg and Sir Francis Cromarty also saw that nothing could be
+attempted in that direction.  They stopped, and engaged in a whispered
+colloquy.
+
+"It is only eight now," said the brigadier, "and these guards may also
+go to sleep."
+
+"It is not impossible," returned the Parsee.
+
+They lay down at the foot of a tree, and waited.
+
+The time seemed long; the guide ever and anon left them to take an
+observation on the edge of the wood, but the guards watched steadily by
+the glare of the torches, and a dim light crept through the windows of
+the pagoda.
+
+They waited till midnight; but no change took place among the guards,
+and it became apparent that their yielding to sleep could not be
+counted on.  The other plan must be carried out; an opening in the
+walls of the pagoda must be made.  It remained to ascertain whether the
+priests were watching by the side of their victim as assiduously as
+were the soldiers at the door.
+
+After a last consultation, the guide announced that he was ready for
+the attempt, and advanced, followed by the others.  They took a
+roundabout way, so as to get at the pagoda on the rear.  They reached
+the walls about half-past twelve, without having met anyone; here there
+was no guard, nor were there either windows or doors.
+
+The night was dark.  The moon, on the wane, scarcely left the horizon,
+and was covered with heavy clouds; the height of the trees deepened the
+darkness.
+
+It was not enough to reach the walls; an opening in them must be
+accomplished, and to attain this purpose the party only had their
+pocket-knives.  Happily the temple walls were built of brick and wood,
+which could be penetrated with little difficulty; after one brick had
+been taken out, the rest would yield easily.
+
+They set noiselessly to work, and the Parsee on one side and
+Passepartout on the other began to loosen the bricks so as to make an
+aperture two feet wide.  They were getting on rapidly, when suddenly a
+cry was heard in the interior of the temple, followed almost instantly
+by other cries replying from the outside.  Passepartout and the guide
+stopped.  Had they been heard?  Was the alarm being given?  Common
+prudence urged them to retire, and they did so, followed by Phileas
+Fogg and Sir Francis.  They again hid themselves in the wood, and
+waited till the disturbance, whatever it might be, ceased, holding
+themselves ready to resume their attempt without delay.  But, awkwardly
+enough, the guards now appeared at the rear of the temple, and there
+installed themselves, in readiness to prevent a surprise.
+
+It would be difficult to describe the disappointment of the party, thus
+interrupted in their work.  They could not now reach the victim; how,
+then, could they save her?  Sir Francis shook his fists, Passepartout
+was beside himself, and the guide gnashed his teeth with rage.  The
+tranquil Fogg waited, without betraying any emotion.
+
+"We have nothing to do but to go away," whispered Sir Francis.
+
+"Nothing but to go away," echoed the guide.
+
+"Stop," said Fogg.  "I am only due at Allahabad tomorrow before noon."
+
+"But what can you hope to do?" asked Sir Francis.  "In a few hours it
+will be daylight, and--"
+
+"The chance which now seems lost may present itself at the last moment."
+
+Sir Francis would have liked to read Phileas Fogg's eyes.  What was
+this cool Englishman thinking of?  Was he planning to make a rush for
+the young woman at the very moment of the sacrifice, and boldly snatch
+her from her executioners?
+
+This would be utter folly, and it was hard to admit that Fogg was such
+a fool.  Sir Francis consented, however, to remain to the end of this
+terrible drama.  The guide led them to the rear of the glade, where
+they were able to observe the sleeping groups.
+
+Meanwhile Passepartout, who had perched himself on the lower branches
+of a tree, was resolving an idea which had at first struck him like a
+flash, and which was now firmly lodged in his brain.
+
+He had commenced by saying to himself, "What folly!" and then he
+repeated, "Why not, after all?  It's a chance,--perhaps the only one; and
+with such sots!" Thinking thus, he slipped, with the suppleness of a
+serpent, to the lowest branches, the ends of which bent almost to the
+ground.
+
+The hours passed, and the lighter shades now announced the approach of
+day, though it was not yet light.  This was the moment.  The slumbering
+multitude became animated, the tambourines sounded, songs and cries
+arose; the hour of the sacrifice had come.  The doors of the pagoda
+swung open, and a bright light escaped from its interior, in the midst
+of which Mr. Fogg and Sir Francis espied the victim.  She seemed,
+having shaken off the stupor of intoxication, to be striving to escape
+from her executioner.  Sir Francis's heart throbbed; and, convulsively
+seizing Mr. Fogg's hand, found in it an open knife.  Just at this
+moment the crowd began to move.  The young woman had again fallen into
+a stupor caused by the fumes of hemp, and passed among the fakirs, who
+escorted her with their wild, religious cries.
+
+Phileas Fogg and his companions, mingling in the rear ranks of the
+crowd, followed; and in two minutes they reached the banks of the
+stream, and stopped fifty paces from the pyre, upon which still lay the
+rajah's corpse.  In the semi-obscurity they saw the victim, quite
+senseless, stretched out beside her husband's body. Then a torch was
+brought, and the wood, heavily soaked with oil, instantly took fire.
+
+At this moment Sir Francis and the guide seized Phileas Fogg, who, in
+an instant of mad generosity, was about to rush upon the pyre.  But he
+had quickly pushed them aside, when the whole scene suddenly changed.
+A cry of terror arose.  The whole multitude prostrated themselves,
+terror-stricken, on the ground.
+
+The old rajah was not dead, then, since he rose of a sudden, like a
+spectre, took up his wife in his arms, and descended from the pyre in
+the midst of the clouds of smoke, which only heightened his ghostly
+appearance.
+
+Fakirs and soldiers and priests, seized with instant terror, lay there,
+with their faces on the ground, not daring to lift their eyes and
+behold such a prodigy.
+
+The inanimate victim was borne along by the vigorous arms which
+supported her, and which she did not seem in the least to burden.  Mr.
+Fogg and Sir Francis stood erect, the Parsee bowed his head, and
+Passepartout was, no doubt, scarcely less stupefied.
+
+The resuscitated rajah approached Sir Francis and Mr. Fogg, and, in an
+abrupt tone, said, "Let us be off!"
+
+It was Passepartout himself, who had slipped upon the pyre in the midst
+of the smoke and, profiting by the still overhanging darkness, had
+delivered the young woman from death!  It was Passepartout who, playing
+his part with a happy audacity, had passed through the crowd amid the
+general terror.
+
+A moment after all four of the party had disappeared in the woods, and
+the elephant was bearing them away at a rapid pace. But the cries and
+noise, and a ball which whizzed through Phileas Fogg's hat, apprised
+them that the trick had been discovered.
+
+The old rajah's body, indeed, now appeared upon the burning pyre; and
+the priests, recovered from their terror, perceived that an abduction
+had taken place.  They hastened into the forest, followed by the
+soldiers, who fired a volley after the fugitives; but the latter
+rapidly increased the distance between them, and ere long found
+themselves beyond the reach of the bullets and arrows.
+
+
+
+
+Chapter XIV
+
+IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL VALLEY
+OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+
+The rash exploit had been accomplished; and for an hour Passepartout
+laughed gaily at his success.  Sir Francis pressed the worthy fellow's
+hand, and his master said, "Well done!" which, from him, was high
+commendation; to which Passepartout replied that all the credit of the
+affair belonged to Mr. Fogg.  As for him, he had only been struck with
+a "queer" idea; and he laughed to think that for a few moments he,
+Passepartout, the ex-gymnast, ex-sergeant fireman, had been the spouse
+of a charming woman, a venerable, embalmed rajah!  As for the young
+Indian woman, she had been unconscious throughout of what was passing,
+and now, wrapped up in a travelling-blanket, was reposing in one of the
+howdahs.
+
+The elephant, thanks to the skilful guidance of the Parsee, was
+advancing rapidly through the still darksome forest, and, an hour after
+leaving the pagoda, had crossed a vast plain.  They made a halt at
+seven o'clock, the young woman being still in a state of complete
+prostration.  The guide made her drink a little brandy and water, but
+the drowsiness which stupefied her could not yet be shaken off.  Sir
+Francis, who was familiar with the effects of the intoxication produced
+by the fumes of hemp, reassured his companions on her account.  But he
+was more disturbed at the prospect of her future fate.  He told Phileas
+Fogg that, should Aouda remain in India, she would inevitably fall
+again into the hands of her executioners.  These fanatics were
+scattered throughout the county, and would, despite the English police,
+recover their victim at Madras, Bombay, or Calcutta.  She would only be
+safe by quitting India for ever.
+
+Phileas Fogg replied that he would reflect upon the matter.
+
+The station at Allahabad was reached about ten o'clock, and, the
+interrupted line of railway being resumed, would enable them to reach
+Calcutta in less than twenty-four hours.  Phileas Fogg would thus be
+able to arrive in time to take the steamer which left Calcutta the next
+day, October 25th, at noon, for Hong Kong.
+
+The young woman was placed in one of the waiting-rooms of the station,
+whilst Passepartout was charged with purchasing for her various
+articles of toilet, a dress, shawl, and some furs; for which his master
+gave him unlimited credit.  Passepartout started off forthwith, and
+found himself in the streets of Allahabad, that is, the City of God,
+one of the most venerated in India, being built at the junction of the
+two sacred rivers, Ganges and Jumna, the waters of which attract
+pilgrims from every part of the peninsula.  The Ganges, according to
+the legends of the Ramayana, rises in heaven, whence, owing to Brahma's
+agency, it descends to the earth.
+
+Passepartout made it a point, as he made his purchases, to take a good
+look at the city.  It was formerly defended by a noble fort, which has
+since become a state prison; its commerce has dwindled away, and
+Passepartout in vain looked about him for such a bazaar as he used to
+frequent in Regent Street.  At last he came upon an elderly, crusty
+Jew, who sold second-hand articles, and from whom he purchased a dress
+of Scotch stuff, a large mantle, and a fine otter-skin pelisse, for
+which he did not hesitate to pay seventy-five pounds.  He then returned
+triumphantly to the station.
+
+The influence to which the priests of Pillaji had subjected Aouda began
+gradually to yield, and she became more herself, so that her fine eyes
+resumed all their soft Indian expression.
+
+When the poet-king, Ucaf Uddaul, celebrates the charms of the queen of
+Ahmehnagara, he speaks thus:
+
+"Her shining tresses, divided in two parts, encircle the harmonious
+contour of her white and delicate cheeks, brilliant in their glow and
+freshness.  Her ebony brows have the form and charm of the bow of Kama,
+the god of love, and beneath her long silken lashes the purest
+reflections and a celestial light swim, as in the sacred lakes of
+Himalaya, in the black pupils of her great clear eyes.  Her teeth,
+fine, equal, and white, glitter between her smiling lips like dewdrops
+in a passion-flower's half-enveloped breast.  Her delicately formed
+ears, her vermilion hands, her little feet, curved and tender as the
+lotus-bud, glitter with the brilliancy of the loveliest pearls of
+Ceylon, the most dazzling diamonds of Golconda.  Her narrow and supple
+waist, which a hand may clasp around, sets forth the outline of her
+rounded figure and the beauty of her bosom, where youth in its flower
+displays the wealth of its treasures; and beneath the silken folds of
+her tunic she seems to have been modelled in pure silver by the godlike
+hand of Vicvarcarma, the immortal sculptor."
+
+It is enough to say, without applying this poetical rhapsody to Aouda,
+that she was a charming woman, in all the European acceptation of the
+phrase.  She spoke English with great purity, and the guide had not
+exaggerated in saying that the young Parsee had been transformed by her
+bringing up.
+
+The train was about to start from Allahabad, and Mr. Fogg proceeded to
+pay the guide the price agreed upon for his service, and not a farthing
+more; which astonished Passepartout, who remembered all that his master
+owed to the guide's devotion.  He had, indeed, risked his life in the
+adventure at Pillaji, and, if he should be caught afterwards by the
+Indians, he would with difficulty escape their vengeance.  Kiouni,
+also, must be disposed of.  What should be done with the elephant,
+which had been so dearly purchased?  Phileas Fogg had already
+determined this question.
+
+"Parsee," said he to the guide, "you have been serviceable and devoted.
+I have paid for your service, but not for your devotion.  Would you
+like to have this elephant?  He is yours."
+
+The guide's eyes glistened.
+
+"Your honour is giving me a fortune!" cried he.
+
+"Take him, guide," returned Mr. Fogg, "and I shall still be your
+debtor."
+
+"Good!" exclaimed Passepartout.  "Take him, friend.  Kiouni is a brave
+and faithful beast."  And, going up to the elephant, he gave him
+several lumps of sugar, saying, "Here, Kiouni, here, here."
+
+The elephant grunted out his satisfaction, and, clasping Passepartout
+around the waist with his trunk, lifted him as high as his head.
+Passepartout, not in the least alarmed, caressed the animal, which
+replaced him gently on the ground.
+
+Soon after, Phileas Fogg, Sir Francis Cromarty, and Passepartout,
+installed in a carriage with Aouda, who had the best seat, were
+whirling at full speed towards Benares.  It was a run of eighty miles,
+and was accomplished in two hours.  During the journey, the young woman
+fully recovered her senses.  What was her astonishment to find herself
+in this carriage, on the railway, dressed in European habiliments, and
+with travellers who were quite strangers to her!  Her companions first
+set about fully reviving her with a little liquor, and then Sir Francis
+narrated to her what had passed, dwelling upon the courage with which
+Phileas Fogg had not hesitated to risk his life to save her, and
+recounting the happy sequel of the venture, the result of
+Passepartout's rash idea.  Mr. Fogg said nothing; while Passepartout,
+abashed, kept repeating that "it wasn't worth telling."
+
+Aouda pathetically thanked her deliverers, rather with tears than
+words; her fine eyes interpreted her gratitude better than her lips.
+Then, as her thoughts strayed back to the scene of the sacrifice, and
+recalled the dangers which still menaced her, she shuddered with terror.
+
+Phileas Fogg understood what was passing in Aouda's mind, and offered,
+in order to reassure her, to escort her to Hong Kong, where she might
+remain safely until the affair was hushed up--an offer which she
+eagerly and gratefully accepted.  She had, it seems, a Parsee relation,
+who was one of the principal merchants of Hong Kong, which is wholly an
+English city, though on an island on the Chinese coast.
+
+At half-past twelve the train stopped at Benares.  The Brahmin legends
+assert that this city is built on the site of the ancient Casi, which,
+like Mahomet's tomb, was once suspended between heaven and earth;
+though the Benares of to-day, which the Orientalists call the Athens of
+India, stands quite unpoetically on the solid earth, Passepartout
+caught glimpses of its brick houses and clay huts, giving an aspect of
+desolation to the place, as the train entered it.
+
+Benares was Sir Francis Cromarty's destination, the troops he was
+rejoining being encamped some miles northward of the city.  He bade
+adieu to Phileas Fogg, wishing him all success, and expressing the hope
+that he would come that way again in a less original but more
+profitable fashion.  Mr. Fogg lightly pressed him by the hand.  The
+parting of Aouda, who did not forget what she owed to Sir Francis,
+betrayed more warmth; and, as for Passepartout, he received a hearty
+shake of the hand from the gallant general.
+
+The railway, on leaving Benares, passed for a while along the valley of
+the Ganges.  Through the windows of their carriage the travellers had
+glimpses of the diversified landscape of Behar, with its mountains
+clothed in verdure, its fields of barley, wheat, and corn, its jungles
+peopled with green alligators, its neat villages, and its still
+thickly-leaved forests.  Elephants were bathing in the waters of the
+sacred river, and groups of Indians, despite the advanced season and
+chilly air, were performing solemnly their pious ablutions.  These were
+fervent Brahmins, the bitterest foes of Buddhism, their deities being
+Vishnu, the solar god, Shiva, the divine impersonation of natural
+forces, and Brahma, the supreme ruler of priests and legislators.  What
+would these divinities think of India, anglicised as it is to-day, with
+steamers whistling and scudding along the Ganges, frightening the gulls
+which float upon its surface, the turtles swarming along its banks, and
+the faithful dwelling upon its borders?
+
+The panorama passed before their eyes like a flash, save when the steam
+concealed it fitfully from the view; the travellers could scarcely
+discern the fort of Chupenie, twenty miles south-westward from Benares,
+the ancient stronghold of the rajahs of Behar; or Ghazipur and its
+famous rose-water factories; or the tomb of Lord Cornwallis, rising on
+the left bank of the Ganges; the fortified town of Buxar, or Patna, a
+large manufacturing and trading-place, where is held the principal
+opium market of India; or Monghir, a more than European town, for it is
+as English as Manchester or Birmingham, with its iron foundries,
+edgetool factories, and high chimneys puffing clouds of black smoke
+heavenward.
+
+Night came on; the train passed on at full speed, in the midst of the
+roaring of the tigers, bears, and wolves which fled before the
+locomotive; and the marvels of Bengal, Golconda ruined Gour,
+Murshedabad, the ancient capital, Burdwan, Hugly, and the French town
+of Chandernagor, where Passepartout would have been proud to see his
+country's flag flying, were hidden from their view in the darkness.
+
+Calcutta was reached at seven in the morning, and the packet left for
+Hong Kong at noon; so that Phileas Fogg had five hours before him.
+
+According to his journal, he was due at Calcutta on the 25th of
+October, and that was the exact date of his actual arrival.  He was
+therefore neither behind-hand nor ahead of time.  The two days gained
+between London and Bombay had been lost, as has been seen, in the
+journey across India.  But it is not to be supposed that Phileas Fogg
+regretted them.
+
+
+
+
+Chapter XV
+
+IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS MORE
+
+
+The train entered the station, and Passepartout jumping out first, was
+followed by Mr. Fogg, who assisted his fair companion to descend.
+Phileas Fogg intended to proceed at once to the Hong Kong steamer, in
+order to get Aouda comfortably settled for the voyage.  He was
+unwilling to leave her while they were still on dangerous ground.
+
+Just as he was leaving the station a policeman came up to him, and
+said, "Mr. Phileas Fogg?"
+
+"I am he."
+
+"Is this man your servant?" added the policeman, pointing to
+Passepartout.
+
+"Yes."
+
+"Be so good, both of you, as to follow me."
+
+Mr. Fogg betrayed no surprise whatever.  The policeman was a
+representative of the law, and law is sacred to an Englishman.
+Passepartout tried to reason about the matter, but the policeman tapped
+him with his stick, and Mr. Fogg made him a signal to obey.
+
+"May this young lady go with us?" asked he.
+
+"She may," replied the policeman.
+
+Mr. Fogg, Aouda, and Passepartout were conducted to a palkigahri, a
+sort of four-wheeled carriage, drawn by two horses, in which they took
+their places and were driven away.  No one spoke during the twenty
+minutes which elapsed before they reached their destination.  They
+first passed through the "black town," with its narrow streets, its
+miserable, dirty huts, and squalid population; then through the
+"European town," which presented a relief in its bright brick mansions,
+shaded by coconut-trees and bristling with masts, where, although it
+was early morning, elegantly dressed horsemen and handsome equipages
+were passing back and forth.
+
+The carriage stopped before a modest-looking house, which, however, did
+not have the appearance of a private mansion.  The policeman having
+requested his prisoners--for so, truly, they might be called--to descend,
+conducted them into a room with barred windows, and said:  "You will
+appear before Judge Obadiah at half-past eight."
+
+He then retired, and closed the door.
+
+"Why, we are prisoners!" exclaimed Passepartout, falling into a chair.
+
+Aouda, with an emotion she tried to conceal, said to Mr. Fogg: "Sir,
+you must leave me to my fate!  It is on my account that you receive
+this treatment, it is for having saved me!"
+
+Phileas Fogg contented himself with saying that it was impossible.  It
+was quite unlikely that he should be arrested for preventing a suttee.
+The complainants would not dare present themselves with such a charge.
+There was some mistake.  Moreover, he would not, in any event, abandon
+Aouda, but would escort her to Hong Kong.
+
+"But the steamer leaves at noon!" observed Passepartout, nervously.
+
+"We shall be on board by noon," replied his master, placidly.
+
+It was said so positively that Passepartout could not help muttering to
+himself, "Parbleu that's certain!  Before noon we shall be on board."
+But he was by no means reassured.
+
+At half-past eight the door opened, the policeman appeared, and,
+requesting them to follow him, led the way to an adjoining hall.  It
+was evidently a court-room, and a crowd of Europeans and natives
+already occupied the rear of the apartment.
+
+Mr. Fogg and his two companions took their places on a bench opposite
+the desks of the magistrate and his clerk.  Immediately after, Judge
+Obadiah, a fat, round man, followed by the clerk, entered.  He
+proceeded to take down a wig which was hanging on a nail, and put it
+hurriedly on his head.
+
+"The first case," said he.  Then, putting his hand to his head, he
+exclaimed, "Heh!  This is not my wig!"
+
+"No, your worship," returned the clerk, "it is mine."
+
+"My dear Mr. Oysterpuff, how can a judge give a wise sentence in a
+clerk's wig?"
+
+The wigs were exchanged.
+
+Passepartout was getting nervous, for the hands on the face of the big
+clock over the judge seemed to go around with terrible rapidity.
+
+"The first case," repeated Judge Obadiah.
+
+"Phileas Fogg?" demanded Oysterpuff.
+
+"I am here," replied Mr. Fogg.
+
+"Passepartout?"
+
+"Present," responded Passepartout.
+
+"Good," said the judge.  "You have been looked for, prisoners, for two
+days on the trains from Bombay."
+
+"But of what are we accused?" asked Passepartout, impatiently.
+
+"You are about to be informed."
+
+"I am an English subject, sir," said Mr. Fogg, "and I have the right--"
+
+"Have you been ill-treated?"
+
+"Not at all."
+
+"Very well; let the complainants come in."
+
+A door was swung open by order of the judge, and three Indian priests
+entered.
+
+"That's it," muttered Passepartout; "these are the rogues who were
+going to burn our young lady."
+
+The priests took their places in front of the judge, and the clerk
+proceeded to read in a loud voice a complaint of sacrilege against
+Phileas Fogg and his servant, who were accused of having violated a
+place held consecrated by the Brahmin religion.
+
+"You hear the charge?" asked the judge.
+
+"Yes, sir," replied Mr. Fogg, consulting his watch, "and I admit it."
+
+"You admit it?"
+
+"I admit it, and I wish to hear these priests admit, in their turn,
+what they were going to do at the pagoda of Pillaji."
+
+The priests looked at each other; they did not seem to understand what
+was said.
+
+"Yes," cried Passepartout, warmly; "at the pagoda of Pillaji, where
+they were on the point of burning their victim."
+
+The judge stared with astonishment, and the priests were stupefied.
+
+"What victim?" said Judge Obadiah.  "Burn whom?  In Bombay itself?"
+
+"Bombay?" cried Passepartout.
+
+"Certainly.  We are not talking of the pagoda of Pillaji, but of the
+pagoda of Malabar Hill, at Bombay."
+
+"And as a proof," added the clerk, "here are the desecrator's very
+shoes, which he left behind him."
+
+Whereupon he placed a pair of shoes on his desk.
+
+"My shoes!" cried Passepartout, in his surprise permitting this
+imprudent exclamation to escape him.
+
+The confusion of master and man, who had quite forgotten the affair at
+Bombay, for which they were now detained at Calcutta, may be imagined.
+
+Fix the detective, had foreseen the advantage which Passepartout's
+escapade gave him, and, delaying his departure for twelve hours, had
+consulted the priests of Malabar Hill.  Knowing that the English
+authorities dealt very severely with this kind of misdemeanour, he
+promised them a goodly sum in damages, and sent them forward to
+Calcutta by the next train.  Owing to the delay caused by the rescue of
+the young widow, Fix and the priests reached the Indian capital before
+Mr. Fogg and his servant, the magistrates having been already warned by
+a dispatch to arrest them should they arrive.  Fix's disappointment
+when he learned that Phileas Fogg had not made his appearance in
+Calcutta may be imagined.  He made up his mind that the robber had
+stopped somewhere on the route and taken refuge in the southern
+provinces.  For twenty-four hours Fix watched the station with feverish
+anxiety; at last he was rewarded by seeing Mr. Fogg and Passepartout
+arrive, accompanied by a young woman, whose presence he was wholly at a
+loss to explain.  He hastened for a policeman; and this was how the
+party came to be arrested and brought before Judge Obadiah.
+
+Had Passepartout been a little less preoccupied, he would have espied
+the detective ensconced in a corner of the court-room, watching the
+proceedings with an interest easily understood; for the warrant had
+failed to reach him at Calcutta, as it had done at Bombay and Suez.
+
+Judge Obadiah had unfortunately caught Passepartout's rash exclamation,
+which the poor fellow would have given the world to recall.
+
+"The facts are admitted?" asked the judge.
+
+"Admitted," replied Mr. Fogg, coldly.
+
+"Inasmuch," resumed the judge, "as the English law protects equally and
+sternly the religions of the Indian people, and as the man Passepartout
+has admitted that he violated the sacred pagoda of Malabar Hill, at
+Bombay, on the 20th of October, I condemn the said Passepartout to
+imprisonment for fifteen days and a fine of three hundred pounds."
+
+"Three hundred pounds!" cried Passepartout, startled at the largeness
+of the sum.
+
+"Silence!" shouted the constable.
+
+"And inasmuch," continued the judge, "as it is not proved that the act
+was not done by the connivance of the master with the servant, and as
+the master in any case must be held responsible for the acts of his
+paid servant, I condemn Phileas Fogg to a week's imprisonment and a
+fine of one hundred and fifty pounds."
+
+Fix rubbed his hands softly with satisfaction; if Phileas Fogg could be
+detained in Calcutta a week, it would be more than time for the warrant
+to arrive.  Passepartout was stupefied.  This sentence ruined his
+master.  A wager of twenty thousand pounds lost, because he, like a
+precious fool, had gone into that abominable pagoda!
+
+Phileas Fogg, as self-composed as if the judgment did not in the least
+concern him, did not even lift his eyebrows while it was being
+pronounced.  Just as the clerk was calling the next case, he rose, and
+said, "I offer bail."
+
+"You have that right," returned the judge.
+
+Fix's blood ran cold, but he resumed his composure when he heard the
+judge announce that the bail required for each prisoner would be one
+thousand pounds.
+
+"I will pay it at once," said Mr. Fogg, taking a roll of bank-bills
+from the carpet-bag, which Passepartout had by him, and placing them on
+the clerk's desk.
+
+"This sum will be restored to you upon your release from prison," said
+the judge.  "Meanwhile, you are liberated on bail."
+
+"Come!" said Phileas Fogg to his servant.
+
+"But let them at least give me back my shoes!" cried Passepartout
+angrily.
+
+"Ah, these are pretty dear shoes!" he muttered, as they were handed to
+him.  "More than a thousand pounds apiece; besides, they pinch my feet."
+
+Mr. Fogg, offering his arm to Aouda, then departed, followed by the
+crestfallen Passepartout.  Fix still nourished hopes that the robber
+would not, after all, leave the two thousand pounds behind him, but
+would decide to serve out his week in jail, and issued forth on Mr.
+Fogg's traces.  That gentleman took a carriage, and the party were soon
+landed on one of the quays.
+
+The Rangoon was moored half a mile off in the harbour, its signal of
+departure hoisted at the mast-head.  Eleven o'clock was striking; Mr.
+Fogg was an hour in advance of time.  Fix saw them leave the carriage
+and push off in a boat for the steamer, and stamped his feet with
+disappointment.
+
+"The rascal is off, after all!" he exclaimed.  "Two thousand pounds
+sacrificed!  He's as prodigal as a thief!  I'll follow him to the end
+of the world if necessary; but, at the rate he is going on, the stolen
+money will soon be exhausted."
+
+The detective was not far wrong in making this conjecture.  Since
+leaving London, what with travelling expenses, bribes, the purchase of
+the elephant, bails, and fines, Mr. Fogg had already spent more than
+five thousand pounds on the way, and the percentage of the sum
+recovered from the bank robber promised to the detectives, was rapidly
+diminishing.
+
+
+
+
+Chapter XVI
+
+IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS SAID TO
+HIM
+
+
+The Rangoon--one of the Peninsular and Oriental Company's boats plying
+in the Chinese and Japanese seas--was a screw steamer, built of iron,
+weighing about seventeen hundred and seventy tons, and with engines of
+four hundred horse-power.  She was as fast, but not as well fitted up,
+as the Mongolia, and Aouda was not as comfortably provided for on board
+of her as Phileas Fogg could have wished.  However, the trip from
+Calcutta to Hong Kong only comprised some three thousand five hundred
+miles, occupying from ten to twelve days, and the young woman was not
+difficult to please.
+
+During the first days of the journey Aouda became better acquainted
+with her protector, and constantly gave evidence of her deep gratitude
+for what he had done.  The phlegmatic gentleman listened to her,
+apparently at least, with coldness, neither his voice nor his manner
+betraying the slightest emotion; but he seemed to be always on the
+watch that nothing should be wanting to Aouda's comfort.  He visited
+her regularly each day at certain hours, not so much to talk himself,
+as to sit and hear her talk.  He treated her with the strictest
+politeness, but with the precision of an automaton, the movements of
+which had been arranged for this purpose.  Aouda did not quite know
+what to make of him, though Passepartout had given her some hints of
+his master's eccentricity, and made her smile by telling her of the
+wager which was sending him round the world.  After all, she owed
+Phileas Fogg her life, and she always regarded him through the exalting
+medium of her gratitude.
+
+Aouda confirmed the Parsee guide's narrative of her touching history.
+She did, indeed, belong to the highest of the native races of India.
+Many of the Parsee merchants have made great fortunes there by dealing
+in cotton; and one of them, Sir Jametsee Jeejeebhoy, was made a baronet
+by the English government.  Aouda was a relative of this great man, and
+it was his cousin, Jeejeeh, whom she hoped to join at Hong Kong.
+Whether she would find a protector in him she could not tell; but Mr.
+Fogg essayed to calm her anxieties, and to assure her that everything
+would be mathematically--he used the very word--arranged.  Aouda
+fastened her great eyes, "clear as the sacred lakes of the Himalaya,"
+upon him; but the intractable Fogg, as reserved as ever, did not seem
+at all inclined to throw himself into this lake.
+
+The first few days of the voyage passed prosperously, amid favourable
+weather and propitious winds, and they soon came in sight of the great
+Andaman, the principal of the islands in the Bay of Bengal, with its
+picturesque Saddle Peak, two thousand four hundred feet high, looming
+above the waters.  The steamer passed along near the shores, but the
+savage Papuans, who are in the lowest scale of humanity, but are not,
+as has been asserted, cannibals, did not make their appearance.
+
+The panorama of the islands, as they steamed by them, was superb.  Vast
+forests of palms, arecs, bamboo, teakwood, of the gigantic mimosa, and
+tree-like ferns covered the foreground, while behind, the graceful
+outlines of the mountains were traced against the sky; and along the
+coasts swarmed by thousands the precious swallows whose nests furnish a
+luxurious dish to the tables of the Celestial Empire.  The varied
+landscape afforded by the Andaman Islands was soon passed, however, and
+the Rangoon rapidly approached the Straits of Malacca, which gave
+access to the China seas.
+
+What was detective Fix, so unluckily drawn on from country to country,
+doing all this while?  He had managed to embark on the Rangoon at
+Calcutta without being seen by Passepartout, after leaving orders that,
+if the warrant should arrive, it should be forwarded to him at Hong
+Kong; and he hoped to conceal his presence to the end of the voyage.
+It would have been difficult to explain why he was on board without
+awakening Passepartout's suspicions, who thought him still at Bombay.
+But necessity impelled him, nevertheless, to renew his acquaintance
+with the worthy servant, as will be seen.
+
+All the detective's hopes and wishes were now centred on Hong Kong; for
+the steamer's stay at Singapore would be too brief to enable him to
+take any steps there.  The arrest must be made at Hong Kong, or the
+robber would probably escape him for ever.  Hong Kong was the last
+English ground on which he would set foot; beyond, China, Japan,
+America offered to Fogg an almost certain refuge.  If the warrant
+should at last make its appearance at Hong Kong, Fix could arrest him
+and give him into the hands of the local police, and there would be no
+further trouble.  But beyond Hong Kong, a simple warrant would be of no
+avail; an extradition warrant would be necessary, and that would result
+in delays and obstacles, of which the rascal would take advantage to
+elude justice.
+
+Fix thought over these probabilities during the long hours which he
+spent in his cabin, and kept repeating to himself, "Now, either the
+warrant will be at Hong Kong, in which case I shall arrest my man, or
+it will not be there; and this time it is absolutely necessary that I
+should delay his departure.  I have failed at Bombay, and I have failed
+at Calcutta; if I fail at Hong Kong, my reputation is lost:  Cost what
+it may, I must succeed!  But how shall I prevent his departure, if that
+should turn out to be my last resource?"
+
+Fix made up his mind that, if worst came to worst, he would make a
+confidant of Passepartout, and tell him what kind of a fellow his
+master really was.  That Passepartout was not Fogg's accomplice, he was
+very certain.  The servant, enlightened by his disclosure, and afraid
+of being himself implicated in the crime, would doubtless become an
+ally of the detective.  But this method was a dangerous one, only to be
+employed when everything else had failed.  A word from Passepartout to
+his master would ruin all.  The detective was therefore in a sore
+strait.  But suddenly a new idea struck him.  The presence of Aouda on
+the Rangoon, in company with Phileas Fogg, gave him new material for
+reflection.
+
+Who was this woman?  What combination of events had made her Fogg's
+travelling companion?  They had evidently met somewhere between Bombay
+and Calcutta; but where?  Had they met accidentally, or had Fogg gone
+into the interior purposely in quest of this charming damsel?  Fix was
+fairly puzzled.  He asked himself whether there had not been a wicked
+elopement; and this idea so impressed itself upon his mind that he
+determined to make use of the supposed intrigue.  Whether the young
+woman were married or not, he would be able to create such difficulties
+for Mr. Fogg at Hong Kong that he could not escape by paying any amount
+of money.
+
+But could he even wait till they reached Hong Kong?  Fogg had an
+abominable way of jumping from one boat to another, and, before
+anything could be effected, might get full under way again for Yokohama.
+
+Fix decided that he must warn the English authorities, and signal the
+Rangoon before her arrival.  This was easy to do, since the steamer
+stopped at Singapore, whence there is a telegraphic wire to Hong Kong.
+He finally resolved, moreover, before acting more positively, to
+question Passepartout.  It would not be difficult to make him talk;
+and, as there was no time to lose, Fix prepared to make himself known.
+
+It was now the 30th of October, and on the following day the Rangoon
+was due at Singapore.
+
+Fix emerged from his cabin and went on deck.  Passepartout was
+promenading up and down in the forward part of the steamer.  The
+detective rushed forward with every appearance of extreme surprise, and
+exclaimed, "You here, on the Rangoon?"
+
+"What, Monsieur Fix, are you on board?" returned the really astonished
+Passepartout, recognising his crony of the Mongolia.  "Why, I left you
+at Bombay, and here you are, on the way to Hong Kong!  Are you going
+round the world too?"
+
+"No, no," replied Fix; "I shall stop at Hong Kong--at least for some
+days."
+
+"Hum!" said Passepartout, who seemed for an instant perplexed.  "But
+how is it I have not seen you on board since we left Calcutta?"
+
+"Oh, a trifle of sea-sickness--I've been staying in my berth.  The Gulf
+of Bengal does not agree with me as well as the Indian Ocean.  And how
+is Mr. Fogg?"
+
+"As well and as punctual as ever, not a day behind time!  But, Monsieur
+Fix, you don't know that we have a young lady with us."
+
+"A young lady?" replied the detective, not seeming to comprehend what
+was said.
+
+Passepartout thereupon recounted Aouda's history, the affair at the
+Bombay pagoda, the purchase of the elephant for two thousand pounds,
+the rescue, the arrest, and sentence of the Calcutta court, and the
+restoration of Mr. Fogg and himself to liberty on bail.  Fix, who was
+familiar with the last events, seemed to be equally ignorant of all
+that Passepartout related; and the later was charmed to find so
+interested a listener.
+
+"But does your master propose to carry this young woman to Europe?"
+
+"Not at all.  We are simply going to place her under the protection of
+one of her relatives, a rich merchant at Hong Kong."
+
+"Nothing to be done there," said Fix to himself, concealing his
+disappointment.  "A glass of gin, Mr. Passepartout?"
+
+"Willingly, Monsieur Fix.  We must at least have a friendly glass on
+board the Rangoon."
+
+
+
+
+Chapter XVII
+
+SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+
+The detective and Passepartout met often on deck after this interview,
+though Fix was reserved, and did not attempt to induce his companion to
+divulge any more facts concerning Mr. Fogg.  He caught a glimpse of
+that mysterious gentleman once or twice; but Mr. Fogg usually confined
+himself to the cabin, where he kept Aouda company, or, according to his
+inveterate habit, took a hand at whist.
+
+Passepartout began very seriously to conjecture what strange chance
+kept Fix still on the route that his master was pursuing.  It was
+really worth considering why this certainly very amiable and complacent
+person, whom he had first met at Suez, had then encountered on board
+the Mongolia, who disembarked at Bombay, which he announced as his
+destination, and now turned up so unexpectedly on the Rangoon, was
+following Mr. Fogg's tracks step by step.  What was Fix's object?
+Passepartout was ready to wager his Indian shoes--which he religiously
+preserved--that Fix would also leave Hong Kong at the same time with
+them, and probably on the same steamer.
+
+Passepartout might have cudgelled his brain for a century without
+hitting upon the real object which the detective had in view.  He never
+could have imagined that Phileas Fogg was being tracked as a robber
+around the globe.  But, as it is in human nature to attempt the
+solution of every mystery, Passepartout suddenly discovered an
+explanation of Fix's movements, which was in truth far from
+unreasonable.  Fix, he thought, could only be an agent of Mr. Fogg's
+friends at the Reform Club, sent to follow him up, and to ascertain
+that he really went round the world as had been agreed upon.
+
+"It's clear!" repeated the worthy servant to himself, proud of his
+shrewdness.  "He's a spy sent to keep us in view!  That isn't quite the
+thing, either, to be spying Mr. Fogg, who is so honourable a man!  Ah,
+gentlemen of the Reform, this shall cost you dear!"
+
+Passepartout, enchanted with his discovery, resolved to say nothing to
+his master, lest he should be justly offended at this mistrust on the
+part of his adversaries.  But he determined to chaff Fix, when he had
+the chance, with mysterious allusions, which, however, need not betray
+his real suspicions.
+
+During the afternoon of Wednesday, 30th October, the Rangoon entered
+the Strait of Malacca, which separates the peninsula of that name from
+Sumatra.  The mountainous and craggy islets intercepted the beauties of
+this noble island from the view of the travellers.  The Rangoon weighed
+anchor at Singapore the next day at four a.m., to receive coal, having
+gained half a day on the prescribed time of her arrival.  Phileas Fogg
+noted this gain in his journal, and then, accompanied by Aouda, who
+betrayed a desire for a walk on shore, disembarked.
+
+Fix, who suspected Mr. Fogg's every movement, followed them cautiously,
+without being himself perceived; while Passepartout, laughing in his
+sleeve at Fix's manoeuvres, went about his usual errands.
+
+The island of Singapore is not imposing in aspect, for there are no
+mountains; yet its appearance is not without attractions.  It is a park
+checkered by pleasant highways and avenues.  A handsome carriage, drawn
+by a sleek pair of New Holland horses, carried Phileas Fogg and Aouda
+into the midst of rows of palms with brilliant foliage, and of
+clove-trees, whereof the cloves form the heart of a half-open flower.
+Pepper plants replaced the prickly hedges of European fields;
+sago-bushes, large ferns with gorgeous branches, varied the aspect of
+this tropical clime; while nutmeg-trees in full foliage filled the air
+with a penetrating perfume.  Agile and grinning bands of monkeys
+skipped about in the trees, nor were tigers wanting in the jungles.
+
+After a drive of two hours through the country, Aouda and Mr. Fogg
+returned to the town, which is a vast collection of heavy-looking,
+irregular houses, surrounded by charming gardens rich in tropical
+fruits and plants; and at ten o'clock they re-embarked, closely
+followed by the detective, who had kept them constantly in sight.
+
+Passepartout, who had been purchasing several dozen mangoes--a fruit
+as large as good-sized apples, of a dark-brown colour outside and a
+bright red within, and whose white pulp, melting in the mouth, affords
+gourmands a delicious sensation--was waiting for them on deck.  He was
+only too glad to offer some mangoes to Aouda, who thanked him very
+gracefully for them.
+
+At eleven o'clock the Rangoon rode out of Singapore harbour, and in a
+few hours the high mountains of Malacca, with their forests, inhabited
+by the most beautifully-furred tigers in the world, were lost to view.
+Singapore is distant some thirteen hundred miles from the island of
+Hong Kong, which is a little English colony near the Chinese coast.
+Phileas Fogg hoped to accomplish the journey in six days, so as to be
+in time for the steamer which would leave on the 6th of November for
+Yokohama, the principal Japanese port.
+
+The Rangoon had a large quota of passengers, many of whom disembarked
+at Singapore, among them a number of Indians, Ceylonese, Chinamen,
+Malays, and Portuguese, mostly second-class travellers.
+
+The weather, which had hitherto been fine, changed with the last
+quarter of the moon.  The sea rolled heavily, and the wind at intervals
+rose almost to a storm, but happily blew from the south-west, and thus
+aided the steamer's progress.  The captain as often as possible put up
+his sails, and under the double action of steam and sail the vessel
+made rapid progress along the coasts of Anam and Cochin China.  Owing
+to the defective construction of the Rangoon, however, unusual
+precautions became necessary in unfavourable weather; but the loss of
+time which resulted from this cause, while it nearly drove Passepartout
+out of his senses, did not seem to affect his master in the least.
+Passepartout blamed the captain, the engineer, and the crew, and
+consigned all who were connected with the ship to the land where the
+pepper grows.  Perhaps the thought of the gas, which was remorselessly
+burning at his expense in Saville Row, had something to do with his hot
+impatience.
+
+"You are in a great hurry, then," said Fix to him one day, "to reach
+Hong Kong?"
+
+"A very great hurry!"
+
+"Mr. Fogg, I suppose, is anxious to catch the steamer for Yokohama?"
+
+"Terribly anxious."
+
+"You believe in this journey around the world, then?"
+
+"Absolutely.  Don't you, Mr. Fix?"
+
+"I?  I don't believe a word of it."
+
+"You're a sly dog!" said Passepartout, winking at him.
+
+This expression rather disturbed Fix, without his knowing why.  Had the
+Frenchman guessed his real purpose?  He knew not what to think.  But
+how could Passepartout have discovered that he was a detective?  Yet,
+in speaking as he did, the man evidently meant more than he expressed.
+
+Passepartout went still further the next day; he could not hold his
+tongue.
+
+"Mr. Fix," said he, in a bantering tone, "shall we be so unfortunate as
+to lose you when we get to Hong Kong?"
+
+"Why," responded Fix, a little embarrassed, "I don't know; perhaps--"
+
+"Ah, if you would only go on with us!  An agent of the Peninsular
+Company, you know, can't stop on the way!  You were only going to
+Bombay, and here you are in China.  America is not far off, and from
+America to Europe is only a step."
+
+Fix looked intently at his companion, whose countenance was as serene
+as possible, and laughed with him.  But Passepartout persisted in
+chaffing him by asking him if he made much by his present occupation.
+
+"Yes, and no," returned Fix; "there is good and bad luck in such
+things.  But you must understand that I don't travel at my own expense."
+
+"Oh, I am quite sure of that!" cried Passepartout, laughing heartily.
+
+Fix, fairly puzzled, descended to his cabin and gave himself up to his
+reflections.  He was evidently suspected; somehow or other the
+Frenchman had found out that he was a detective.  But had he told his
+master?  What part was he playing in all this: was he an accomplice or
+not?  Was the game, then, up?  Fix spent several hours turning these
+things over in his mind, sometimes thinking that all was lost, then
+persuading himself that Fogg was ignorant of his presence, and then
+undecided what course it was best to take.
+
+Nevertheless, he preserved his coolness of mind, and at last resolved
+to deal plainly with Passepartout.  If he did not find it practicable
+to arrest Fogg at Hong Kong, and if Fogg made preparations to leave
+that last foothold of English territory, he, Fix, would tell
+Passepartout all.  Either the servant was the accomplice of his master,
+and in this case the master knew of his operations, and he should fail;
+or else the servant knew nothing about the robbery, and then his
+interest would be to abandon the robber.
+
+Such was the situation between Fix and Passepartout.  Meanwhile Phileas
+Fogg moved about above them in the most majestic and unconscious
+indifference.  He was passing methodically in his orbit around the
+world, regardless of the lesser stars which gravitated around him.  Yet
+there was near by what the astronomers would call a disturbing star,
+which might have produced an agitation in this gentleman's heart.  But
+no! the charms of Aouda failed to act, to Passepartout's great
+surprise; and the disturbances, if they existed, would have been more
+difficult to calculate than those of Uranus which led to the discovery
+of Neptune.
+
+It was every day an increasing wonder to Passepartout, who read in
+Aouda's eyes the depths of her gratitude to his master.  Phileas Fogg,
+though brave and gallant, must be, he thought, quite heartless.  As to
+the sentiment which this journey might have awakened in him, there was
+clearly no trace of such a thing; while poor Passepartout existed in
+perpetual reveries.
+
+One day he was leaning on the railing of the engine-room, and was
+observing the engine, when a sudden pitch of the steamer threw the
+screw out of the water.  The steam came hissing out of the valves; and
+this made Passepartout indignant.
+
+"The valves are not sufficiently charged!" he exclaimed.  "We are not
+going.  Oh, these English!  If this was an American craft, we should
+blow up, perhaps, but we should at all events go faster!"
+
+
+
+
+Chapter XVIII
+
+IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS BUSINESS
+
+
+The weather was bad during the latter days of the voyage.  The wind,
+obstinately remaining in the north-west, blew a gale, and retarded the
+steamer.  The Rangoon rolled heavily and the passengers became
+impatient of the long, monstrous waves which the wind raised before
+their path.  A sort of tempest arose on the 3rd of November, the squall
+knocking the vessel about with fury, and the waves running high.  The
+Rangoon reefed all her sails, and even the rigging proved too much,
+whistling and shaking amid the squall.  The steamer was forced to
+proceed slowly, and the captain estimated that she would reach Hong
+Kong twenty hours behind time, and more if the storm lasted.
+
+Phileas Fogg gazed at the tempestuous sea, which seemed to be
+struggling especially to delay him, with his habitual tranquillity.  He
+never changed countenance for an instant, though a delay of twenty
+hours, by making him too late for the Yokohama boat, would almost
+inevitably cause the loss of the wager.  But this man of nerve
+manifested neither impatience nor annoyance; it seemed as if the storm
+were a part of his programme, and had been foreseen.  Aouda was amazed
+to find him as calm as he had been from the first time she saw him.
+
+Fix did not look at the state of things in the same light.  The storm
+greatly pleased him.  His satisfaction would have been complete had the
+Rangoon been forced to retreat before the violence of wind and waves.
+Each delay filled him with hope, for it became more and more probable
+that Fogg would be obliged to remain some days at Hong Kong; and now
+the heavens themselves became his allies, with the gusts and squalls.
+It mattered not that they made him sea-sick--he made no account of this
+inconvenience; and, whilst his body was writhing under their effects,
+his spirit bounded with hopeful exultation.
+
+Passepartout was enraged beyond expression by the unpropitious weather.
+Everything had gone so well till now!  Earth and sea had seemed to be
+at his master's service; steamers and railways obeyed him; wind and
+steam united to speed his journey.  Had the hour of adversity come?
+Passepartout was as much excited as if the twenty thousand pounds were
+to come from his own pocket.  The storm exasperated him, the gale made
+him furious, and he longed to lash the obstinate sea into obedience.
+Poor fellow!  Fix carefully concealed from him his own satisfaction,
+for, had he betrayed it, Passepartout could scarcely have restrained
+himself from personal violence.
+
+Passepartout remained on deck as long as the tempest lasted, being
+unable to remain quiet below, and taking it into his head to aid the
+progress of the ship by lending a hand with the crew.  He overwhelmed
+the captain, officers, and sailors, who could not help laughing at his
+impatience, with all sorts of questions.  He wanted to know exactly how
+long the storm was going to last; whereupon he was referred to the
+barometer, which seemed to have no intention of rising.  Passepartout
+shook it, but with no perceptible effect; for neither shaking nor
+maledictions could prevail upon it to change its mind.
+
+On the 4th, however, the sea became more calm, and the storm lessened
+its violence; the wind veered southward, and was once more favourable.
+Passepartout cleared up with the weather.  Some of the sails were
+unfurled, and the Rangoon resumed its most rapid speed.  The time lost
+could not, however, be regained.  Land was not signalled until five
+o'clock on the morning of the 6th; the steamer was due on the 5th.
+Phileas Fogg was twenty-four hours behind-hand, and the Yokohama
+steamer would, of course, be missed.
+
+The pilot went on board at six, and took his place on the bridge, to
+guide the Rangoon through the channels to the port of Hong Kong.
+Passepartout longed to ask him if the steamer had left for Yokohama;
+but he dared not, for he wished to preserve the spark of hope, which
+still remained till the last moment.  He had confided his anxiety to
+Fix who--the sly rascal!--tried to console him by saying that Mr. Fogg
+would be in time if he took the next boat; but this only put
+Passepartout in a passion.
+
+Mr. Fogg, bolder than his servant, did not hesitate to approach the
+pilot, and tranquilly ask him if he knew when a steamer would leave
+Hong Kong for Yokohama.
+
+"At high tide to-morrow morning," answered the pilot.
+
+"Ah!" said Mr. Fogg, without betraying any astonishment.
+
+Passepartout, who heard what passed, would willingly have embraced the
+pilot, while Fix would have been glad to twist his neck.
+
+"What is the steamer's name?" asked Mr. Fogg.
+
+"The Carnatic."
+
+"Ought she not to have gone yesterday?"
+
+"Yes, sir; but they had to repair one of her boilers, and so her
+departure was postponed till to-morrow."
+
+"Thank you," returned Mr. Fogg, descending mathematically to the saloon.
+
+Passepartout clasped the pilot's hand and shook it heartily in his
+delight, exclaiming, "Pilot, you are the best of good fellows!"
+
+The pilot probably does not know to this day why his responses won him
+this enthusiastic greeting.  He remounted the bridge, and guided the
+steamer through the flotilla of junks, tankas, and fishing boats which
+crowd the harbour of Hong Kong.
+
+At one o'clock the Rangoon was at the quay, and the passengers were
+going ashore.
+
+Chance had strangely favoured Phileas Fogg, for had not the Carnatic
+been forced to lie over for repairing her boilers, she would have left
+on the 6th of November, and the passengers for Japan would have been
+obliged to await for a week the sailing of the next steamer.  Mr. Fogg
+was, it is true, twenty-four hours behind his time; but this could not
+seriously imperil the remainder of his tour.
+
+The steamer which crossed the Pacific from Yokohama to San Francisco
+made a direct connection with that from Hong Kong, and it could not
+sail until the latter reached Yokohama; and if Mr. Fogg was twenty-four
+hours late on reaching Yokohama, this time would no doubt be easily
+regained in the voyage of twenty-two days across the Pacific.  He found
+himself, then, about twenty-four hours behind-hand, thirty-five days
+after leaving London.
+
+The Carnatic was announced to leave Hong Kong at five the next morning.
+Mr. Fogg had sixteen hours in which to attend to his business there,
+which was to deposit Aouda safely with her wealthy relative.
+
+On landing, he conducted her to a palanquin, in which they repaired to
+the Club Hotel.  A room was engaged for the young woman, and Mr. Fogg,
+after seeing that she wanted for nothing, set out in search of her
+cousin Jeejeeh.  He instructed Passepartout to remain at the hotel
+until his return, that Aouda might not be left entirely alone.
+
+Mr. Fogg repaired to the Exchange, where, he did not doubt, every one
+would know so wealthy and considerable a personage as the Parsee
+merchant.  Meeting a broker, he made the inquiry, to learn that Jeejeeh
+had left China two years before, and, retiring from business with an
+immense fortune, had taken up his residence in Europe--in Holland the
+broker thought, with the merchants of which country he had principally
+traded.  Phileas Fogg returned to the hotel, begged a moment's
+conversation with Aouda, and without more ado, apprised her that
+Jeejeeh was no longer at Hong Kong, but probably in Holland.
+
+Aouda at first said nothing.  She passed her hand across her forehead,
+and reflected a few moments.  Then, in her sweet, soft voice, she said:
+"What ought I to do, Mr. Fogg?"
+
+"It is very simple," responded the gentleman.  "Go on to Europe."
+
+"But I cannot intrude--"
+
+"You do not intrude, nor do you in the least embarrass my project.
+Passepartout!"
+
+"Monsieur."
+
+"Go to the Carnatic, and engage three cabins."
+
+Passepartout, delighted that the young woman, who was very gracious to
+him, was going to continue the journey with them, went off at a brisk
+gait to obey his master's order.
+
+
+
+
+Chapter XIX
+
+IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER, AND
+WHAT COMES OF IT
+
+
+Hong Kong is an island which came into the possession of the English by
+the Treaty of Nankin, after the war of 1842; and the colonising genius
+of the English has created upon it an important city and an excellent
+port.  The island is situated at the mouth of the Canton River, and is
+separated by about sixty miles from the Portuguese town of Macao, on
+the opposite coast.  Hong Kong has beaten Macao in the struggle for the
+Chinese trade, and now the greater part of the transportation of
+Chinese goods finds its depot at the former place.  Docks, hospitals,
+wharves, a Gothic cathedral, a government house, macadamised streets,
+give to Hong Kong the appearance of a town in Kent or Surrey
+transferred by some strange magic to the antipodes.
+
+Passepartout wandered, with his hands in his pockets, towards the
+Victoria port, gazing as he went at the curious palanquins and other
+modes of conveyance, and the groups of Chinese, Japanese, and Europeans
+who passed to and fro in the streets.  Hong Kong seemed to him not
+unlike Bombay, Calcutta, and Singapore, since, like them, it betrayed
+everywhere the evidence of English supremacy.  At the Victoria port he
+found a confused mass of ships of all nations: English, French,
+American, and Dutch, men-of-war and trading vessels, Japanese and
+Chinese junks, sempas, tankas, and flower-boats, which formed so many
+floating parterres.  Passepartout noticed in the crowd a number of the
+natives who seemed very old and were dressed in yellow.  On going into
+a barber's to get shaved he learned that these ancient men were all at
+least eighty years old, at which age they are permitted to wear yellow,
+which is the Imperial colour.  Passepartout, without exactly knowing
+why, thought this very funny.
+
+On reaching the quay where they were to embark on the Carnatic, he was
+not astonished to find Fix walking up and down.  The detective seemed
+very much disturbed and disappointed.
+
+"This is bad," muttered Passepartout, "for the gentlemen of the Reform
+Club!"  He accosted Fix with a merry smile, as if he had not perceived
+that gentleman's chagrin.  The detective had, indeed, good reasons to
+inveigh against the bad luck which pursued him.  The warrant had not
+come!  It was certainly on the way, but as certainly it could not now
+reach Hong Kong for several days; and, this being the last English
+territory on Mr. Fogg's route, the robber would escape, unless he could
+manage to detain him.
+
+"Well, Monsieur Fix," said Passepartout, "have you decided to go with
+us so far as America?"
+
+"Yes," returned Fix, through his set teeth.
+
+"Good!" exclaimed Passepartout, laughing heartily.  "I knew you could
+not persuade yourself to separate from us.  Come and engage your berth."
+
+They entered the steamer office and secured cabins for four persons.
+The clerk, as he gave them the tickets, informed them that, the repairs
+on the Carnatic having been completed, the steamer would leave that
+very evening, and not next morning, as had been announced.
+
+"That will suit my master all the better," said Passepartout.  "I will
+go and let him know."
+
+Fix now decided to make a bold move; he resolved to tell Passepartout
+all.  It seemed to be the only possible means of keeping Phileas Fogg
+several days longer at Hong Kong.  He accordingly invited his companion
+into a tavern which caught his eye on the quay.  On entering, they
+found themselves in a large room handsomely decorated, at the end of
+which was a large camp-bed furnished with cushions.  Several persons
+lay upon this bed in a deep sleep.  At the small tables which were
+arranged about the room some thirty customers were drinking English
+beer, porter, gin, and brandy; smoking, the while, long red clay pipes
+stuffed with little balls of opium mingled with essence of rose.  From
+time to time one of the smokers, overcome with the narcotic, would slip
+under the table, whereupon the waiters, taking him by the head and
+feet, carried and laid him upon the bed.  The bed already supported
+twenty of these stupefied sots.
+
+Fix and Passepartout saw that they were in a smoking-house haunted by
+those wretched, cadaverous, idiotic creatures to whom the English
+merchants sell every year the miserable drug called opium, to the
+amount of one million four hundred thousand pounds--thousands devoted
+to one of the most despicable vices which afflict humanity!  The
+Chinese government has in vain attempted to deal with the evil by
+stringent laws.  It passed gradually from the rich, to whom it was at
+first exclusively reserved, to the lower classes, and then its ravages
+could not be arrested.  Opium is smoked everywhere, at all times, by
+men and women, in the Celestial Empire; and, once accustomed to it, the
+victims cannot dispense with it, except by suffering horrible bodily
+contortions and agonies.  A great smoker can smoke as many as eight
+pipes a day; but he dies in five years.  It was in one of these dens
+that Fix and Passepartout, in search of a friendly glass, found
+themselves.  Passepartout had no money, but willingly accepted Fix's
+invitation in the hope of returning the obligation at some future time.
+
+They ordered two bottles of port, to which the Frenchman did ample
+justice, whilst Fix observed him with close attention.  They chatted
+about the journey, and Passepartout was especially merry at the idea
+that Fix was going to continue it with them.  When the bottles were
+empty, however, he rose to go and tell his master of the change in the
+time of the sailing of the Carnatic.
+
+Fix caught him by the arm, and said, "Wait a moment."
+
+"What for, Mr. Fix?"
+
+"I want to have a serious talk with you."
+
+"A serious talk!" cried Passepartout, drinking up the little wine that
+was left in the bottom of his glass.  "Well, we'll talk about it
+to-morrow; I haven't time now."
+
+"Stay!  What I have to say concerns your master."
+
+Passepartout, at this, looked attentively at his companion.  Fix's face
+seemed to have a singular expression.  He resumed his seat.
+
+"What is it that you have to say?"
+
+Fix placed his hand upon Passepartout's arm, and, lowering his voice,
+said, "You have guessed who I am?"
+
+"Parbleu!" said Passepartout, smiling.
+
+"Then I'm going to tell you everything--"
+
+"Now that I know everything, my friend!  Ah! that's very good.  But go
+on, go on.  First, though, let me tell you that those gentlemen have
+put themselves to a useless expense."
+
+"Useless!" said Fix.  "You speak confidently.  It's clear that you
+don't know how large the sum is."
+
+"Of course I do," returned Passepartout.  "Twenty thousand pounds."
+
+"Fifty-five thousand!" answered Fix, pressing his companion's hand.
+
+"What!" cried the Frenchman.  "Has Monsieur Fogg dared--fifty-five
+thousand pounds!  Well, there's all the more reason for not losing an
+instant," he continued, getting up hastily.
+
+Fix pushed Passepartout back in his chair, and resumed: "Fifty-five
+thousand pounds; and if I succeed, I get two thousand pounds.  If
+you'll help me, I'll let you have five hundred of them."
+
+"Help you?" cried Passepartout, whose eyes were standing wide open.
+
+"Yes; help me keep Mr. Fogg here for two or three days."
+
+"Why, what are you saying?  Those gentlemen are not satisfied with
+following my master and suspecting his honour, but they must try to put
+obstacles in his way!  I blush for them!"
+
+"What do you mean?"
+
+"I mean that it is a piece of shameful trickery.  They might as well
+waylay Mr. Fogg and put his money in their pockets!"
+
+"That's just what we count on doing."
+
+"It's a conspiracy, then," cried Passepartout, who became more and more
+excited as the liquor mounted in his head, for he drank without
+perceiving it.  "A real conspiracy!  And gentlemen, too. Bah!"
+
+Fix began to be puzzled.
+
+"Members of the Reform Club!" continued Passepartout.  "You must know,
+Monsieur Fix, that my master is an honest man, and that, when he makes
+a wager, he tries to win it fairly!"
+
+"But who do you think I am?" asked Fix, looking at him intently.
+
+"Parbleu!  An agent of the members of the Reform Club, sent out here to
+interrupt my master's journey.  But, though I found you out some time
+ago, I've taken good care to say nothing about it to Mr. Fogg."
+
+"He knows nothing, then?"
+
+"Nothing," replied Passepartout, again emptying his glass.
+
+The detective passed his hand across his forehead, hesitating before he
+spoke again.  What should he do?  Passepartout's mistake seemed
+sincere, but it made his design more difficult.  It was evident that
+the servant was not the master's accomplice, as Fix had been inclined
+to suspect.
+
+"Well," said the detective to himself, "as he is not an accomplice, he
+will help me."
+
+He had no time to lose: Fogg must be detained at Hong Kong, so he
+resolved to make a clean breast of it.
+
+"Listen to me," said Fix abruptly.  "I am not, as you think, an agent
+of the members of the Reform Club--"
+
+"Bah!" retorted Passepartout, with an air of raillery.
+
+"I am a police detective, sent out here by the London office."
+
+"You, a detective?"
+
+"I will prove it.  Here is my commission."
+
+Passepartout was speechless with astonishment when Fix displayed this
+document, the genuineness of which could not be doubted.
+
+"Mr. Fogg's wager," resumed Fix, "is only a pretext, of which you and
+the gentlemen of the Reform are dupes.  He had a motive for securing
+your innocent complicity."
+
+"But why?"
+
+"Listen.  On the 28th of last September a robbery of fifty-five
+thousand pounds was committed at the Bank of England by a person whose
+description was fortunately secured.  Here is his description; it
+answers exactly to that of Mr. Phileas Fogg."
+
+"What nonsense!" cried Passepartout, striking the table with his fist.
+"My master is the most honourable of men!"
+
+"How can you tell?  You know scarcely anything about him.  You went
+into his service the day he came away; and he came away on a foolish
+pretext, without trunks, and carrying a large amount in banknotes.  And
+yet you are bold enough to assert that he is an honest man!"
+
+"Yes, yes," repeated the poor fellow, mechanically.
+
+"Would you like to be arrested as his accomplice?"
+
+Passepartout, overcome by what he had heard, held his head between his
+hands, and did not dare to look at the detective.  Phileas Fogg, the
+saviour of Aouda, that brave and generous man, a robber!  And yet how
+many presumptions there were against him!  Passepartout essayed to
+reject the suspicions which forced themselves upon his mind; he did not
+wish to believe that his master was guilty.
+
+"Well, what do you want of me?" said he, at last, with an effort.
+
+"See here," replied Fix; "I have tracked Mr. Fogg to this place, but as
+yet I have failed to receive the warrant of arrest for which I sent to
+London.  You must help me to keep him here in Hong Kong--"
+
+"I!  But I--"
+
+"I will share with you the two thousand pounds reward offered by the
+Bank of England."
+
+"Never!" replied Passepartout, who tried to rise, but fell back,
+exhausted in mind and body.
+
+"Mr. Fix," he stammered, "even should what you say be true--if my
+master is really the robber you are seeking for--which I deny--I have
+been, am, in his service; I have seen his generosity and goodness; and
+I will never betray him--not for all the gold in the world.  I come
+from a village where they don't eat that kind of bread!"
+
+"You refuse?"
+
+"I refuse."
+
+"Consider that I've said nothing," said Fix; "and let us drink."
+
+"Yes; let us drink!"
+
+Passepartout felt himself yielding more and more to the effects of the
+liquor.  Fix, seeing that he must, at all hazards, be separated from
+his master, wished to entirely overcome him.  Some pipes full of opium
+lay upon the table.  Fix slipped one into Passepartout's hand.  He took
+it, put it between his lips, lit it, drew several puffs, and his head,
+becoming heavy under the influence of the narcotic, fell upon the table.
+
+"At last!" said Fix, seeing Passepartout unconscious.  "Mr. Fogg will
+not be informed of the Carnatic's departure; and, if he is, he will
+have to go without this cursed Frenchman!"
+
+And, after paying his bill, Fix left the tavern.
+
+
+
+
+Chapter XX
+
+IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+
+While these events were passing at the opium-house, Mr. Fogg,
+unconscious of the danger he was in of losing the steamer, was quietly
+escorting Aouda about the streets of the English quarter, making the
+necessary purchases for the long voyage before them.  It was all very
+well for an Englishman like Mr. Fogg to make the tour of the world with
+a carpet-bag; a lady could not be expected to travel comfortably under
+such conditions.  He acquitted his task with characteristic serenity,
+and invariably replied to the remonstrances of his fair companion, who
+was confused by his patience and generosity:
+
+"It is in the interest of my journey--a part of my programme."
+
+The purchases made, they returned to the hotel, where they dined at a
+sumptuously served table-d'hote; after which Aouda, shaking hands with
+her protector after the English fashion, retired to her room for rest.
+Mr. Fogg absorbed himself throughout the evening in the perusal of The
+Times and Illustrated London News.
+
+Had he been capable of being astonished at anything, it would have been
+not to see his servant return at bedtime.  But, knowing that the
+steamer was not to leave for Yokohama until the next morning, he did
+not disturb himself about the matter.  When Passepartout did not appear
+the next morning to answer his master's bell, Mr. Fogg, not betraying
+the least vexation, contented himself with taking his carpet-bag,
+calling Aouda, and sending for a palanquin.
+
+It was then eight o'clock; at half-past nine, it being then high tide,
+the Carnatic would leave the harbour.  Mr. Fogg and Aouda got into the
+palanquin, their luggage being brought after on a wheelbarrow, and half
+an hour later stepped upon the quay whence they were to embark.  Mr.
+Fogg then learned that the Carnatic had sailed the evening before.  He
+had expected to find not only the steamer, but his domestic, and was
+forced to give up both; but no sign of disappointment appeared on his
+face, and he merely remarked to Aouda, "It is an accident, madam;
+nothing more."
+
+At this moment a man who had been observing him attentively approached.
+It was Fix, who, bowing, addressed Mr. Fogg:  "Were you not, like me,
+sir, a passenger by the Rangoon, which arrived yesterday?"
+
+"I was, sir," replied Mr. Fogg coldly.  "But I have not the honour--"
+
+"Pardon me; I thought I should find your servant here."
+
+"Do you know where he is, sir?" asked Aouda anxiously.
+
+"What!" responded Fix, feigning surprise.  "Is he not with you?"
+
+"No," said Aouda.  "He has not made his appearance since yesterday.
+Could he have gone on board the Carnatic without us?"
+
+"Without you, madam?" answered the detective.  "Excuse me, did you
+intend to sail in the Carnatic?"
+
+"Yes, sir."
+
+"So did I, madam, and I am excessively disappointed.  The Carnatic, its
+repairs being completed, left Hong Kong twelve hours before the stated
+time, without any notice being given; and we must now wait a week for
+another steamer."
+
+As he said "a week" Fix felt his heart leap for joy.  Fogg detained at
+Hong Kong for a week!  There would be time for the warrant to arrive,
+and fortune at last favoured the representative of the law.  His horror
+may be imagined when he heard Mr. Fogg say, in his placid voice, "But
+there are other vessels besides the Carnatic, it seems to me, in the
+harbour of Hong Kong."
+
+And, offering his arm to Aouda, he directed his steps toward the docks
+in search of some craft about to start.  Fix, stupefied, followed; it
+seemed as if he were attached to Mr. Fogg by an invisible thread.
+Chance, however, appeared really to have abandoned the man it had
+hitherto served so well.  For three hours Phileas Fogg wandered about
+the docks, with the determination, if necessary, to charter a vessel to
+carry him to Yokohama; but he could only find vessels which were
+loading or unloading, and which could not therefore set sail.  Fix
+began to hope again.
+
+But Mr. Fogg, far from being discouraged, was continuing his search,
+resolved not to stop if he had to resort to Macao, when he was accosted
+by a sailor on one of the wharves.
+
+"Is your honour looking for a boat?"
+
+"Have you a boat ready to sail?"
+
+"Yes, your honour; a pilot-boat--No. 43--the best in the harbour."
+
+"Does she go fast?"
+
+"Between eight and nine knots the hour.  Will you look at her?"
+
+"Yes."
+
+"Your honour will be satisfied with her.  Is it for a sea excursion?"
+
+"No; for a voyage."
+
+"A voyage?"
+
+"Yes, will you agree to take me to Yokohama?"
+
+The sailor leaned on the railing, opened his eyes wide, and said, "Is
+your honour joking?"
+
+"No.  I have missed the Carnatic, and I must get to Yokohama by the
+14th at the latest, to take the boat for San Francisco."
+
+"I am sorry," said the sailor; "but it is impossible."
+
+"I offer you a hundred pounds per day, and an additional reward of two
+hundred pounds if I reach Yokohama in time."
+
+"Are you in earnest?"
+
+"Very much so."
+
+The pilot walked away a little distance, and gazed out to sea,
+evidently struggling between the anxiety to gain a large sum and the
+fear of venturing so far.  Fix was in mortal suspense.
+
+Mr. Fogg turned to Aouda and asked her, "You would not be afraid, would
+you, madam?"
+
+"Not with you, Mr. Fogg," was her answer.
+
+The pilot now returned, shuffling his hat in his hands.
+
+"Well, pilot?" said Mr. Fogg.
+
+"Well, your honour," replied he, "I could not risk myself, my men, or
+my little boat of scarcely twenty tons on so long a voyage at this time
+of year.  Besides, we could not reach Yokohama in time, for it is
+sixteen hundred and sixty miles from Hong Kong."
+
+"Only sixteen hundred," said Mr. Fogg.
+
+"It's the same thing."
+
+Fix breathed more freely.
+
+"But," added the pilot, "it might be arranged another way."
+
+Fix ceased to breathe at all.
+
+"How?" asked Mr. Fogg.
+
+"By going to Nagasaki, at the extreme south of Japan, or even to
+Shanghai, which is only eight hundred miles from here.  In going to
+Shanghai we should not be forced to sail wide of the Chinese coast,
+which would be a great advantage, as the currents run northward, and
+would aid us."
+
+"Pilot," said Mr. Fogg, "I must take the American steamer at Yokohama,
+and not at Shanghai or Nagasaki."
+
+"Why not?" returned the pilot.  "The San Francisco steamer does not
+start from Yokohama.  It puts in at Yokohama and Nagasaki, but it
+starts from Shanghai."
+
+"You are sure of that?"
+
+"Perfectly."
+
+"And when does the boat leave Shanghai?"
+
+"On the 11th, at seven in the evening.  We have, therefore, four days
+before us, that is ninety-six hours; and in that time, if we had good
+luck and a south-west wind, and the sea was calm, we could make those
+eight hundred miles to Shanghai."
+
+"And you could go--"
+
+"In an hour; as soon as provisions could be got aboard and the sails
+put up."
+
+"It is a bargain.  Are you the master of the boat?"
+
+"Yes; John Bunsby, master of the Tankadere."
+
+"Would you like some earnest-money?"
+
+"If it would not put your honour out--"
+
+"Here are two hundred pounds on account sir," added Phileas Fogg,
+turning to Fix, "if you would like to take advantage--"
+
+"Thanks, sir; I was about to ask the favour."
+
+"Very well.  In half an hour we shall go on board."
+
+"But poor Passepartout?" urged Aouda, who was much disturbed by the
+servant's disappearance.
+
+"I shall do all I can to find him," replied Phileas Fogg.
+
+While Fix, in a feverish, nervous state, repaired to the pilot-boat,
+the others directed their course to the police-station at Hong Kong.
+Phileas Fogg there gave Passepartout's description, and left a sum of
+money to be spent in the search for him.  The same formalities having
+been gone through at the French consulate, and the palanquin having
+stopped at the hotel for the luggage, which had been sent back there,
+they returned to the wharf.
+
+It was now three o'clock; and pilot-boat No. 43, with its crew on
+board, and its provisions stored away, was ready for departure.
+
+The Tankadere was a neat little craft of twenty tons, as gracefully
+built as if she were a racing yacht.  Her shining copper sheathing, her
+galvanised iron-work, her deck, white as ivory, betrayed the pride
+taken by John Bunsby in making her presentable.  Her two masts leaned a
+trifle backward; she carried brigantine, foresail, storm-jib, and
+standing-jib, and was well rigged for running before the wind; and she
+seemed capable of brisk speed, which, indeed, she had already proved by
+gaining several prizes in pilot-boat races.  The crew of the Tankadere
+was composed of John Bunsby, the master, and four hardy mariners, who
+were familiar with the Chinese seas.  John Bunsby, himself, a man of
+forty-five or thereabouts, vigorous, sunburnt, with a sprightly
+expression of the eye, and energetic and self-reliant countenance,
+would have inspired confidence in the most timid.
+
+Phileas Fogg and Aouda went on board, where they found Fix already
+installed.  Below deck was a square cabin, of which the walls bulged
+out in the form of cots, above a circular divan; in the centre was a
+table provided with a swinging lamp.  The accommodation was confined,
+but neat.
+
+"I am sorry to have nothing better to offer you," said Mr. Fogg to Fix,
+who bowed without responding.
+
+The detective had a feeling akin to humiliation in profiting by the
+kindness of Mr. Fogg.
+
+"It's certain," thought he, "though rascal as he is, he is a polite
+one!"
+
+The sails and the English flag were hoisted at ten minutes past three.
+Mr. Fogg and Aouda, who were seated on deck, cast a last glance at the
+quay, in the hope of espying Passepartout.  Fix was not without his
+fears lest chance should direct the steps of the unfortunate servant,
+whom he had so badly treated, in this direction; in which case an
+explanation the reverse of satisfactory to the detective must have
+ensued.  But the Frenchman did not appear, and, without doubt, was
+still lying under the stupefying influence of the opium.
+
+John Bunsby, master, at length gave the order to start, and the
+Tankadere, taking the wind under her brigantine, foresail, and
+standing-jib, bounded briskly forward over the waves.
+
+
+
+
+Chapter XXI
+
+IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING A
+REWARD OF TWO HUNDRED POUNDS
+
+
+This voyage of eight hundred miles was a perilous venture on a craft of
+twenty tons, and at that season of the year.  The Chinese seas are
+usually boisterous, subject to terrible gales of wind, and especially
+during the equinoxes; and it was now early November.
+
+It would clearly have been to the master's advantage to carry his
+passengers to Yokohama, since he was paid a certain sum per day; but he
+would have been rash to attempt such a voyage, and it was imprudent
+even to attempt to reach Shanghai.  But John Bunsby believed in the
+Tankadere, which rode on the waves like a seagull; and perhaps he was
+not wrong.
+
+Late in the day they passed through the capricious channels of Hong
+Kong, and the Tankadere, impelled by favourable winds, conducted
+herself admirably.
+
+"I do not need, pilot," said Phileas Fogg, when they got into the open
+sea, "to advise you to use all possible speed."
+
+"Trust me, your honour.  We are carrying all the sail the wind will let
+us.  The poles would add nothing, and are only used when we are going
+into port."
+
+"It's your trade, not mine, pilot, and I confide in you."
+
+Phileas Fogg, with body erect and legs wide apart, standing like a
+sailor, gazed without staggering at the swelling waters.  The young
+woman, who was seated aft, was profoundly affected as she looked out
+upon the ocean, darkening now with the twilight, on which she had
+ventured in so frail a vessel.  Above her head rustled the white sails,
+which seemed like great white wings.  The boat, carried forward by the
+wind, seemed to be flying in the air.
+
+Night came.  The moon was entering her first quarter, and her
+insufficient light would soon die out in the mist on the horizon.
+Clouds were rising from the east, and already overcast a part of the
+heavens.
+
+The pilot had hung out his lights, which was very necessary in these
+seas crowded with vessels bound landward; for collisions are not
+uncommon occurrences, and, at the speed she was going, the least shock
+would shatter the gallant little craft.
+
+Fix, seated in the bow, gave himself up to meditation.  He kept apart
+from his fellow-travellers, knowing Mr. Fogg's taciturn tastes;
+besides, he did not quite like to talk to the man whose favours he had
+accepted.  He was thinking, too, of the future.  It seemed certain that
+Fogg would not stop at Yokohama, but would at once take the boat for
+San Francisco; and the vast extent of America would ensure him impunity
+and safety.  Fogg's plan appeared to him the simplest in the world.
+Instead of sailing directly from England to the United States, like a
+common villain, he had traversed three quarters of the globe, so as to
+gain the American continent more surely; and there, after throwing the
+police off his track, he would quietly enjoy himself with the fortune
+stolen from the bank.  But, once in the United States, what should he,
+Fix, do?  Should he abandon this man?  No, a hundred times no!  Until
+he had secured his extradition, he would not lose sight of him for an
+hour.  It was his duty, and he would fulfil it to the end.  At all
+events, there was one thing to be thankful for; Passepartout was not
+with his master; and it was above all important, after the confidences
+Fix had imparted to him, that the servant should never have speech with
+his master.
+
+Phileas Fogg was also thinking of Passepartout, who had so strangely
+disappeared.  Looking at the matter from every point of view, it did
+not seem to him impossible that, by some mistake, the man might have
+embarked on the Carnatic at the last moment; and this was also Aouda's
+opinion, who regretted very much the loss of the worthy fellow to whom
+she owed so much.  They might then find him at Yokohama; for, if the
+Carnatic was carrying him thither, it would be easy to ascertain if he
+had been on board.
+
+A brisk breeze arose about ten o'clock; but, though it might have been
+prudent to take in a reef, the pilot, after carefully examining the
+heavens, let the craft remain rigged as before.  The Tankadere bore
+sail admirably, as she drew a great deal of water, and everything was
+prepared for high speed in case of a gale.
+
+Mr. Fogg and Aouda descended into the cabin at midnight, having been
+already preceded by Fix, who had lain down on one of the cots.  The
+pilot and crew remained on deck all night.
+
+At sunrise the next day, which was 8th November, the boat had made more
+than one hundred miles.  The log indicated a mean speed of between
+eight and nine miles.  The Tankadere still carried all sail, and was
+accomplishing her greatest capacity of speed.  If the wind held as it
+was, the chances would be in her favour.  During the day she kept along
+the coast, where the currents were favourable; the coast, irregular in
+profile, and visible sometimes across the clearings, was at most five
+miles distant.  The sea was less boisterous, since the wind came off
+land--a fortunate circumstance for the boat, which would suffer, owing
+to its small tonnage, by a heavy surge on the sea.
+
+The breeze subsided a little towards noon, and set in from the
+south-west.  The pilot put up his poles, but took them down again
+within two hours, as the wind freshened up anew.
+
+Mr. Fogg and Aouda, happily unaffected by the roughness of the sea, ate
+with a good appetite, Fix being invited to share their repast, which he
+accepted with secret chagrin.  To travel at this man's expense and live
+upon his provisions was not palatable to him.  Still, he was obliged to
+eat, and so he ate.
+
+When the meal was over, he took Mr. Fogg apart, and said, "sir"--this
+"sir" scorched his lips, and he had to control himself to avoid
+collaring this "gentleman"--"sir, you have been very kind to give me a
+passage on this boat.  But, though my means will not admit of my
+expending them as freely as you, I must ask to pay my share--"
+
+"Let us not speak of that, sir," replied Mr. Fogg.
+
+"But, if I insist--"
+
+"No, sir," repeated Mr. Fogg, in a tone which did not admit of a reply.
+"This enters into my general expenses."
+
+Fix, as he bowed, had a stifled feeling, and, going forward, where he
+ensconced himself, did not open his mouth for the rest of the day.
+
+Meanwhile they were progressing famously, and John Bunsby was in high
+hope.  He several times assured Mr. Fogg that they would reach Shanghai
+in time; to which that gentleman responded that he counted upon it.
+The crew set to work in good earnest, inspired by the reward to be
+gained.  There was not a sheet which was not tightened, not a sail which
+was not vigorously hoisted; not a lurch could be charged to the man at
+the helm.  They worked as desperately as if they were contesting in a
+Royal yacht regatta.
+
+By evening, the log showed that two hundred and twenty miles had been
+accomplished from Hong Kong, and Mr. Fogg might hope that he would be
+able to reach Yokohama without recording any delay in his journal; in
+which case, the many misadventures which had overtaken him since he
+left London would not seriously affect his journey.
+
+The Tankadere entered the Straits of Fo-Kien, which separate the island
+of Formosa from the Chinese coast, in the small hours of the night, and
+crossed the Tropic of Cancer.  The sea was very rough in the straits,
+full of eddies formed by the counter-currents, and the chopping waves
+broke her course, whilst it became very difficult to stand on deck.
+
+At daybreak the wind began to blow hard again, and the heavens seemed
+to predict a gale.  The barometer announced a speedy change, the
+mercury rising and falling capriciously; the sea also, in the
+south-east, raised long surges which indicated a tempest.  The sun had
+set the evening before in a red mist, in the midst of the
+phosphorescent scintillations of the ocean.
+
+John Bunsby long examined the threatening aspect of the heavens,
+muttering indistinctly between his teeth.  At last he said in a low
+voice to Mr. Fogg, "Shall I speak out to your honour?"
+
+"Of course."
+
+"Well, we are going to have a squall."
+
+"Is the wind north or south?" asked Mr. Fogg quietly.
+
+"South.  Look! a typhoon is coming up."
+
+"Glad it's a typhoon from the south, for it will carry us forward."
+
+"Oh, if you take it that way," said John Bunsby, "I've nothing more to
+say." John Bunsby's suspicions were confirmed.  At a less advanced
+season of the year the typhoon, according to a famous meteorologist,
+would have passed away like a luminous cascade of electric flame; but
+in the winter equinox it was to be feared that it would burst upon them
+with great violence.
+
+The pilot took his precautions in advance.  He reefed all sail, the
+pole-masts were dispensed with; all hands went forward to the bows.  A
+single triangular sail, of strong canvas, was hoisted as a storm-jib,
+so as to hold the wind from behind.  Then they waited.
+
+John Bunsby had requested his passengers to go below; but this
+imprisonment in so narrow a space, with little air, and the boat
+bouncing in the gale, was far from pleasant.  Neither Mr. Fogg, Fix,
+nor Aouda consented to leave the deck.
+
+The storm of rain and wind descended upon them towards eight o'clock.
+With but its bit of sail, the Tankadere was lifted like a feather by a
+wind, an idea of whose violence can scarcely be given.  To compare her
+speed to four times that of a locomotive going on full steam would be
+below the truth.
+
+The boat scudded thus northward during the whole day, borne on by
+monstrous waves, preserving always, fortunately, a speed equal to
+theirs.  Twenty times she seemed almost to be submerged by these
+mountains of water which rose behind her; but the adroit management of
+the pilot saved her.  The passengers were often bathed in spray, but
+they submitted to it philosophically.  Fix cursed it, no doubt; but
+Aouda, with her eyes fastened upon her protector, whose coolness amazed
+her, showed herself worthy of him, and bravely weathered the storm.  As
+for Phileas Fogg, it seemed just as if the typhoon were a part of his
+programme.
+
+Up to this time the Tankadere had always held her course to the north;
+but towards evening the wind, veering three quarters, bore down from
+the north-west.  The boat, now lying in the trough of the waves, shook
+and rolled terribly; the sea struck her with fearful violence.  At
+night the tempest increased in violence.  John Bunsby saw the approach
+of darkness and the rising of the storm with dark misgivings.  He
+thought awhile, and then asked his crew if it was not time to slacken
+speed.  After a consultation he approached Mr. Fogg, and said, "I
+think, your honour, that we should do well to make for one of the ports
+on the coast."
+
+"I think so too."
+
+"Ah!" said the pilot.  "But which one?"
+
+"I know of but one," returned Mr. Fogg tranquilly.
+
+"And that is--"
+
+"Shanghai."
+
+The pilot, at first, did not seem to comprehend; he could scarcely
+realise so much determination and tenacity.  Then he cried, "Well--yes!
+Your honour is right.  To Shanghai!"
+
+So the Tankadere kept steadily on her northward track.
+
+The night was really terrible; it would be a miracle if the craft did
+not founder.  Twice it could have been all over with her if the crew
+had not been constantly on the watch.  Aouda was exhausted, but did not
+utter a complaint.  More than once Mr. Fogg rushed to protect her from
+the violence of the waves.
+
+Day reappeared.  The tempest still raged with undiminished fury; but
+the wind now returned to the south-east.  It was a favourable change,
+and the Tankadere again bounded forward on this mountainous sea, though
+the waves crossed each other, and imparted shocks and counter-shocks
+which would have crushed a craft less solidly built.  From time to time
+the coast was visible through the broken mist, but no vessel was in
+sight.  The Tankadere was alone upon the sea.
+
+There were some signs of a calm at noon, and these became more distinct
+as the sun descended toward the horizon.  The tempest had been as brief
+as terrific.  The passengers, thoroughly exhausted, could now eat a
+little, and take some repose.
+
+The night was comparatively quiet.  Some of the sails were again
+hoisted, and the speed of the boat was very good.  The next morning at
+dawn they espied the coast, and John Bunsby was able to assert that
+they were not one hundred miles from Shanghai.  A hundred miles, and
+only one day to traverse them!  That very evening Mr. Fogg was due at
+Shanghai, if he did not wish to miss the steamer to Yokohama.  Had
+there been no storm, during which several hours were lost, they would
+be at this moment within thirty miles of their destination.
+
+The wind grew decidedly calmer, and happily the sea fell with it.  All
+sails were now hoisted, and at noon the Tankadere was within forty-five
+miles of Shanghai.  There remained yet six hours in which to accomplish
+that distance.  All on board feared that it could not be done, and
+every one--Phileas Fogg, no doubt, excepted--felt his heart beat with
+impatience.  The boat must keep up an average of nine miles an hour,
+and the wind was becoming calmer every moment!  It was a capricious
+breeze, coming from the coast, and after it passed the sea became
+smooth.  Still, the Tankadere was so light, and her fine sails caught
+the fickle zephyrs so well, that, with the aid of the currents John
+Bunsby found himself at six o'clock not more than ten miles from the
+mouth of Shanghai River.  Shanghai itself is situated at least twelve
+miles up the stream.  At seven they were still three miles from
+Shanghai.  The pilot swore an angry oath; the reward of two hundred
+pounds was evidently on the point of escaping him.  He looked at Mr.
+Fogg.  Mr. Fogg was perfectly tranquil; and yet his whole fortune was
+at this moment at stake.
+
+At this moment, also, a long black funnel, crowned with wreaths of
+smoke, appeared on the edge of the waters.  It was the American
+steamer, leaving for Yokohama at the appointed time.
+
+"Confound her!" cried John Bunsby, pushing back the rudder with a
+desperate jerk.
+
+"Signal her!" said Phileas Fogg quietly.
+
+A small brass cannon stood on the forward deck of the Tankadere, for
+making signals in the fogs.  It was loaded to the muzzle; but just as
+the pilot was about to apply a red-hot coal to the touchhole, Mr. Fogg
+said, "Hoist your flag!"
+
+The flag was run up at half-mast, and, this being the signal of
+distress, it was hoped that the American steamer, perceiving it, would
+change her course a little, so as to succour the pilot-boat.
+
+"Fire!" said Mr. Fogg.  And the booming of the little cannon resounded
+in the air.
+
+
+
+
+Chapter XXII
+
+IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES, IT IS
+CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+
+The Carnatic, setting sail from Hong Kong at half-past six on the 7th
+of November, directed her course at full steam towards Japan.  She
+carried a large cargo and a well-filled cabin of passengers.  Two
+state-rooms in the rear were, however, unoccupied--those which had been
+engaged by Phileas Fogg.
+
+The next day a passenger with a half-stupefied eye, staggering gait,
+and disordered hair, was seen to emerge from the second cabin, and to
+totter to a seat on deck.
+
+It was Passepartout; and what had happened to him was as follows:
+Shortly after Fix left the opium den, two waiters had lifted the
+unconscious Passepartout, and had carried him to the bed reserved for
+the smokers.  Three hours later, pursued even in his dreams by a fixed
+idea, the poor fellow awoke, and struggled against the stupefying
+influence of the narcotic.  The thought of a duty unfulfilled shook off
+his torpor, and he hurried from the abode of drunkenness.  Staggering
+and holding himself up by keeping against the walls, falling down and
+creeping up again, and irresistibly impelled by a kind of instinct, he
+kept crying out, "The Carnatic! the Carnatic!"
+
+The steamer lay puffing alongside the quay, on the point of starting.
+Passepartout had but few steps to go; and, rushing upon the plank, he
+crossed it, and fell unconscious on the deck, just as the Carnatic was
+moving off.  Several sailors, who were evidently accustomed to this
+sort of scene, carried the poor Frenchman down into the second cabin,
+and Passepartout did not wake until they were one hundred and fifty
+miles away from China.  Thus he found himself the next morning on the
+deck of the Carnatic, and eagerly inhaling the exhilarating sea-breeze.
+The pure air sobered him.  He began to collect his sense, which he
+found a difficult task; but at last he recalled the events of the
+evening before, Fix's revelation, and the opium-house.
+
+"It is evident," said he to himself, "that I have been abominably
+drunk!  What will Mr. Fogg say?  At least I have not missed the
+steamer, which is the most important thing."
+
+Then, as Fix occurred to him: "As for that rascal, I hope we are well
+rid of him, and that he has not dared, as he proposed, to follow us on
+board the Carnatic.  A detective on the track of Mr. Fogg, accused of
+robbing the Bank of England!  Pshaw!  Mr. Fogg is no more a robber than
+I am a murderer."
+
+Should he divulge Fix's real errand to his master?  Would it do to tell
+the part the detective was playing?  Would it not be better to wait
+until Mr. Fogg reached London again, and then impart to him that an
+agent of the metropolitan police had been following him round the
+world, and have a good laugh over it?  No doubt; at least, it was worth
+considering.  The first thing to do was to find Mr. Fogg, and apologise
+for his singular behaviour.
+
+Passepartout got up and proceeded, as well as he could with the rolling
+of the steamer, to the after-deck.  He saw no one who resembled either
+his master or Aouda.  "Good!"  muttered he; "Aouda has not got up yet,
+and Mr. Fogg has probably found some partners at whist."
+
+He descended to the saloon.  Mr. Fogg was not there.  Passepartout had
+only, however, to ask the purser the number of his master's state-room.
+The purser replied that he did not know any passenger by the name of
+Fogg.
+
+"I beg your pardon," said Passepartout persistently.  "He is a tall
+gentleman, quiet, and not very talkative, and has with him a young
+lady--"
+
+"There is no young lady on board," interrupted the purser.  "Here is a
+list of the passengers; you may see for yourself."
+
+Passepartout scanned the list, but his master's name was not upon it.
+All at once an idea struck him.
+
+"Ah! am I on the Carnatic?"
+
+"Yes."
+
+"On the way to Yokohama?"
+
+"Certainly."
+
+Passepartout had for an instant feared that he was on the wrong boat;
+but, though he was really on the Carnatic, his master was not there.
+
+He fell thunderstruck on a seat.  He saw it all now.  He remembered
+that the time of sailing had been changed, that he should have informed
+his master of that fact, and that he had not done so.  It was his
+fault, then, that Mr. Fogg and Aouda had missed the steamer.  Yes, but
+it was still more the fault of the traitor who, in order to separate
+him from his master, and detain the latter at Hong Kong, had inveigled
+him into getting drunk!  He now saw the detective's trick; and at this
+moment Mr. Fogg was certainly ruined, his bet was lost, and he himself
+perhaps arrested and imprisoned!  At this thought Passepartout tore his
+hair.  Ah, if Fix ever came within his reach, what a settling of
+accounts there would be!
+
+After his first depression, Passepartout became calmer, and began to
+study his situation.  It was certainly not an enviable one.  He found
+himself on the way to Japan, and what should he do when he got there?
+His pocket was empty; he had not a solitary shilling, not so much as a
+penny.  His passage had fortunately been paid for in advance; and he
+had five or six days in which to decide upon his future course.  He
+fell to at meals with an appetite, and ate for Mr. Fogg, Aouda, and
+himself.  He helped himself as generously as if Japan were a desert,
+where nothing to eat was to be looked for.
+
+At dawn on the 13th the Carnatic entered the port of Yokohama.  This is
+an important port of call in the Pacific, where all the mail-steamers,
+and those carrying travellers between North America, China, Japan, and
+the Oriental islands put in.  It is situated in the bay of Yeddo, and
+at but a short distance from that second capital of the Japanese
+Empire, and the residence of the Tycoon, the civil Emperor, before the
+Mikado, the spiritual Emperor, absorbed his office in his own.  The
+Carnatic anchored at the quay near the custom-house, in the midst of a
+crowd of ships bearing the flags of all nations.
+
+Passepartout went timidly ashore on this so curious territory of the
+Sons of the Sun.  He had nothing better to do than, taking chance for
+his guide, to wander aimlessly through the streets of Yokohama.  He
+found himself at first in a thoroughly European quarter, the houses
+having low fronts, and being adorned with verandas, beneath which he
+caught glimpses of neat peristyles.  This quarter occupied, with its
+streets, squares, docks, and warehouses, all the space between the
+"promontory of the Treaty" and the river.  Here, as at Hong Kong and
+Calcutta, were mixed crowds of all races, Americans and English,
+Chinamen and Dutchmen, mostly merchants ready to buy or sell anything.
+The Frenchman felt himself as much alone among them as if he had
+dropped down in the midst of Hottentots.
+
+He had, at least, one resource,--to call on the French and English
+consuls at Yokohama for assistance.  But he shrank from telling the
+story of his adventures, intimately connected as it was with that of
+his master; and, before doing so, he determined to exhaust all other
+means of aid.  As chance did not favour him in the European quarter, he
+penetrated that inhabited by the native Japanese, determined, if
+necessary, to push on to Yeddo.
+
+The Japanese quarter of Yokohama is called Benten, after the goddess of
+the sea, who is worshipped on the islands round about.  There
+Passepartout beheld beautiful fir and cedar groves, sacred gates of a
+singular architecture, bridges half hid in the midst of bamboos and
+reeds, temples shaded by immense cedar-trees, holy retreats where were
+sheltered Buddhist priests and sectaries of Confucius, and interminable
+streets, where a perfect harvest of rose-tinted and red-cheeked
+children, who looked as if they had been cut out of Japanese screens,
+and who were playing in the midst of short-legged poodles and yellowish
+cats, might have been gathered.
+
+The streets were crowded with people.  Priests were passing in
+processions, beating their dreary tambourines; police and custom-house
+officers with pointed hats encrusted with lac and carrying two sabres
+hung to their waists; soldiers, clad in blue cotton with white stripes,
+and bearing guns; the Mikado's guards, enveloped in silken doubles,
+hauberks and coats of mail; and numbers of military folk of all
+ranks--for the military profession is as much respected in Japan as it
+is despised in China--went hither and thither in groups and pairs.
+Passepartout saw, too, begging friars, long-robed pilgrims, and simple
+civilians, with their warped and jet-black hair, big heads, long busts,
+slender legs, short stature, and complexions varying from copper-colour
+to a dead white, but never yellow, like the Chinese, from whom the
+Japanese widely differ.  He did not fail to observe the curious
+equipages--carriages and palanquins, barrows supplied with sails, and
+litters made of bamboo; nor the women--whom he thought not especially
+handsome--who took little steps with their little feet, whereon they
+wore canvas shoes, straw sandals, and clogs of worked wood, and who
+displayed tight-looking eyes, flat chests, teeth fashionably blackened,
+and gowns crossed with silken scarfs, tied in an enormous knot behind
+an ornament which the modern Parisian ladies seem to have borrowed from
+the dames of Japan.
+
+Passepartout wandered for several hours in the midst of this motley
+crowd, looking in at the windows of the rich and curious shops, the
+jewellery establishments glittering with quaint Japanese ornaments, the
+restaurants decked with streamers and banners, the tea-houses, where
+the odorous beverage was being drunk with saki, a liquor concocted from
+the fermentation of rice, and the comfortable smoking-houses, where
+they were puffing, not opium, which is almost unknown in Japan, but a
+very fine, stringy tobacco.  He went on till he found himself in the
+fields, in the midst of vast rice plantations.  There he saw dazzling
+camellias expanding themselves, with flowers which were giving forth
+their last colours and perfumes, not on bushes, but on trees, and
+within bamboo enclosures, cherry, plum, and apple trees, which the
+Japanese cultivate rather for their blossoms than their fruit, and
+which queerly-fashioned, grinning scarecrows protected from the
+sparrows, pigeons, ravens, and other voracious birds.  On the branches
+of the cedars were perched large eagles; amid the foliage of the
+weeping willows were herons, solemnly standing on one leg; and on every
+hand were crows, ducks, hawks, wild birds, and a multitude of cranes,
+which the Japanese consider sacred, and which to their minds symbolise
+long life and prosperity.
+
+As he was strolling along, Passepartout espied some violets among the
+shrubs.
+
+"Good!" said he; "I'll have some supper."
+
+But, on smelling them, he found that they were odourless.
+
+"No chance there," thought he.
+
+The worthy fellow had certainly taken good care to eat as hearty a
+breakfast as possible before leaving the Carnatic; but, as he had been
+walking about all day, the demands of hunger were becoming importunate.
+He observed that the butchers stalls contained neither mutton, goat,
+nor pork; and, knowing also that it is a sacrilege to kill cattle,
+which are preserved solely for farming, he made up his mind that meat
+was far from plentiful in Yokohama--nor was he mistaken; and, in
+default of butcher's meat, he could have wished for a quarter of wild
+boar or deer, a partridge, or some quails, some game or fish, which,
+with rice, the Japanese eat almost exclusively.  But he found it
+necessary to keep up a stout heart, and to postpone the meal he craved
+till the following morning.  Night came, and Passepartout re-entered
+the native quarter, where he wandered through the streets, lit by
+vari-coloured lanterns, looking on at the dancers, who were executing
+skilful steps and boundings, and the astrologers who stood in the open
+air with their telescopes.  Then he came to the harbour, which was lit
+up by the resin torches of the fishermen, who were fishing from their
+boats.
+
+The streets at last became quiet, and the patrol, the officers of
+which, in their splendid costumes, and surrounded by their suites,
+Passepartout thought seemed like ambassadors, succeeded the bustling
+crowd.  Each time a company passed, Passepartout chuckled, and said to
+himself: "Good! another Japanese embassy departing for Europe!"
+
+
+
+
+Chapter XXIII
+
+IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+
+The next morning poor, jaded, famished Passepartout said to himself
+that he must get something to eat at all hazards, and the sooner he did
+so the better.  He might, indeed, sell his watch; but he would have
+starved first.  Now or never he must use the strong, if not melodious
+voice which nature had bestowed upon him.  He knew several French and
+English songs, and resolved to try them upon the Japanese, who must be
+lovers of music, since they were for ever pounding on their cymbals,
+tam-tams, and tambourines, and could not but appreciate European talent.
+
+It was, perhaps, rather early in the morning to get up a concert, and
+the audience prematurely aroused from their slumbers, might not
+possibly pay their entertainer with coin bearing the Mikado's features.
+Passepartout therefore decided to wait several hours; and, as he was
+sauntering along, it occurred to him that he would seem rather too well
+dressed for a wandering artist.  The idea struck him to change his
+garments for clothes more in harmony with his project; by which he
+might also get a little money to satisfy the immediate cravings of
+hunger.  The resolution taken, it remained to carry it out.
+
+It was only after a long search that Passepartout discovered a native
+dealer in old clothes, to whom he applied for an exchange.  The man
+liked the European costume, and ere long Passepartout issued from his
+shop accoutred in an old Japanese coat, and a sort of one-sided turban,
+faded with long use.  A few small pieces of silver, moreover, jingled
+in his pocket.
+
+"Good!" thought he.  "I will imagine I am at the Carnival!"
+
+His first care, after being thus "Japanesed," was to enter a tea-house
+of modest appearance, and, upon half a bird and a little rice, to
+breakfast like a man for whom dinner was as yet a problem to be solved.
+
+"Now," thought he, when he had eaten heartily, "I mustn't lose my head.
+I can't sell this costume again for one still more Japanese.  I must
+consider how to leave this country of the Sun, of which I shall not
+retain the most delightful of memories, as quickly as possible."
+
+It occurred to him to visit the steamers which were about to leave for
+America.  He would offer himself as a cook or servant, in payment of
+his passage and meals.  Once at San Francisco, he would find some means
+of going on.  The difficulty was, how to traverse the four thousand
+seven hundred miles of the Pacific which lay between Japan and the New
+World.
+
+Passepartout was not the man to let an idea go begging, and directed
+his steps towards the docks.  But, as he approached them, his project,
+which at first had seemed so simple, began to grow more and more
+formidable to his mind.  What need would they have of a cook or servant
+on an American steamer, and what confidence would they put in him,
+dressed as he was?  What references could he give?
+
+As he was reflecting in this wise, his eyes fell upon an immense
+placard which a sort of clown was carrying through the streets.  This
+placard, which was in English, read as follows:
+
+          ACROBATIC JAPANESE TROUPE,
+   HONOURABLE WILLIAM BATULCAR, PROPRIETOR,
+           LAST REPRESENTATIONS,
+PRIOR TO THEIR DEPARTURE TO THE UNITED STATES,
+                  OF THE
+        LONG NOSES!   LONG NOSES!
+UNDER THE DIRECT PATRONAGE OF THE GOD TINGOU!
+           GREAT ATTRACTION!
+
+"The United States!" said Passepartout; "that's just what I want!"
+
+He followed the clown, and soon found himself once more in the Japanese
+quarter.  A quarter of an hour later he stopped before a large cabin,
+adorned with several clusters of streamers, the exterior walls of which
+were designed to represent, in violent colours and without perspective,
+a company of jugglers.
+
+This was the Honourable William Batulcar's establishment.  That
+gentleman was a sort of Barnum, the director of a troupe of
+mountebanks, jugglers, clowns, acrobats, equilibrists, and gymnasts,
+who, according to the placard, was giving his last performances before
+leaving the Empire of the Sun for the States of the Union.
+
+Passepartout entered and asked for Mr. Batulcar, who straightway
+appeared in person.
+
+"What do you want?" said he to Passepartout, whom he at first took for
+a native.
+
+"Would you like a servant, sir?" asked Passepartout.
+
+"A servant!" cried Mr. Batulcar, caressing the thick grey beard which
+hung from his chin.  "I already have two who are obedient and faithful,
+have never left me, and serve me for their nourishment and here they
+are," added he, holding out his two robust arms, furrowed with veins as
+large as the strings of a bass-viol.
+
+"So I can be of no use to you?"
+
+"None."
+
+"The devil!  I should so like to cross the Pacific with you!"
+
+"Ah!" said the Honourable Mr. Batulcar.  "You are no more a Japanese
+than I am a monkey!  Who are you dressed up in that way?"
+
+"A man dresses as he can."
+
+"That's true.  You are a Frenchman, aren't you?"
+
+"Yes; a Parisian of Paris."
+
+"Then you ought to know how to make grimaces?"
+
+"Why," replied Passepartout, a little vexed that his nationality should
+cause this question, "we Frenchmen know how to make grimaces, it is
+true but not any better than the Americans do."
+
+"True.  Well, if I can't take you as a servant, I can as a clown.  You
+see, my friend, in France they exhibit foreign clowns, and in foreign
+parts French clowns."
+
+"Ah!"
+
+"You are pretty strong, eh?"
+
+"Especially after a good meal."
+
+"And you can sing?"
+
+"Yes," returned Passepartout, who had formerly been wont to sing in the
+streets.
+
+"But can you sing standing on your head, with a top spinning on your
+left foot, and a sabre balanced on your right?"
+
+"Humph!  I think so," replied Passepartout, recalling the exercises of
+his younger days.
+
+"Well, that's enough," said the Honourable William Batulcar.
+
+The engagement was concluded there and then.
+
+Passepartout had at last found something to do.  He was engaged to act
+in the celebrated Japanese troupe.  It was not a very dignified
+position, but within a week he would be on his way to San Francisco.
+
+The performance, so noisily announced by the Honourable Mr. Batulcar,
+was to commence at three o'clock, and soon the deafening instruments of
+a Japanese orchestra resounded at the door.  Passepartout, though he
+had not been able to study or rehearse a part, was designated to lend
+the aid of his sturdy shoulders in the great exhibition of the "human
+pyramid," executed by the Long Noses of the god Tingou.  This "great
+attraction" was to close the performance.
+
+Before three o'clock the large shed was invaded by the spectators,
+comprising Europeans and natives, Chinese and Japanese, men, women and
+children, who precipitated themselves upon the narrow benches and into
+the boxes opposite the stage.  The musicians took up a position inside,
+and were vigorously performing on their gongs, tam-tams, flutes, bones,
+tambourines, and immense drums.
+
+The performance was much like all acrobatic displays; but it must be
+confessed that the Japanese are the first equilibrists in the world.
+
+One, with a fan and some bits of paper, performed the graceful trick of
+the butterflies and the flowers; another traced in the air, with the
+odorous smoke of his pipe, a series of blue words, which composed a
+compliment to the audience; while a third juggled with some lighted
+candles, which he extinguished successively as they passed his lips,
+and relit again without interrupting for an instant his juggling.
+Another reproduced the most singular combinations with a spinning-top;
+in his hands the revolving tops seemed to be animated with a life of
+their own in their interminable whirling; they ran over pipe-stems, the
+edges of sabres, wires and even hairs stretched across the stage; they
+turned around on the edges of large glasses, crossed bamboo ladders,
+dispersed into all the corners, and produced strange musical effects by
+the combination of their various pitches of tone.  The jugglers tossed
+them in the air, threw them like shuttlecocks with wooden battledores,
+and yet they kept on spinning; they put them into their pockets, and
+took them out still whirling as before.
+
+It is useless to describe the astonishing performances of the acrobats
+and gymnasts.  The turning on ladders, poles, balls, barrels, &c., was
+executed with wonderful precision.
+
+But the principal attraction was the exhibition of the Long Noses, a
+show to which Europe is as yet a stranger.
+
+The Long Noses form a peculiar company, under the direct patronage of
+the god Tingou.  Attired after the fashion of the Middle Ages, they
+bore upon their shoulders a splendid pair of wings; but what especially
+distinguished them was the long noses which were fastened to their
+faces, and the uses which they made of them.  These noses were made of
+bamboo, and were five, six, and even ten feet long, some straight,
+others curved, some ribboned, and some having imitation warts upon
+them.  It was upon these appendages, fixed tightly on their real noses,
+that they performed their gymnastic exercises.  A dozen of these
+sectaries of Tingou lay flat upon their backs, while others, dressed to
+represent lightning-rods, came and frolicked on their noses, jumping
+from one to another, and performing the most skilful leapings and
+somersaults.
+
+As a last scene, a "human pyramid" had been announced, in which fifty
+Long Noses were to represent the Car of Juggernaut.  But, instead of
+forming a pyramid by mounting each other's shoulders, the artists were
+to group themselves on top of the noses.  It happened that the
+performer who had hitherto formed the base of the Car had quitted the
+troupe, and as, to fill this part, only strength and adroitness were
+necessary, Passepartout had been chosen to take his place.
+
+The poor fellow really felt sad when--melancholy reminiscence of his
+youth!--he donned his costume, adorned with vari-coloured wings, and
+fastened to his natural feature a false nose six feet long.  But he
+cheered up when he thought that this nose was winning him something to
+eat.
+
+He went upon the stage, and took his place beside the rest who were to
+compose the base of the Car of Juggernaut.  They all stretched
+themselves on the floor, their noses pointing to the ceiling.  A second
+group of artists disposed themselves on these long appendages, then a
+third above these, then a fourth, until a human monument reaching to
+the very cornices of the theatre soon arose on top of the noses.  This
+elicited loud applause, in the midst of which the orchestra was just
+striking up a deafening air, when the pyramid tottered, the balance was
+lost, one of the lower noses vanished from the pyramid, and the human
+monument was shattered like a castle built of cards!
+
+It was Passepartout's fault.  Abandoning his position, clearing the
+footlights without the aid of his wings, and, clambering up to the
+right-hand gallery, he fell at the feet of one of the spectators,
+crying, "Ah, my master! my master!"
+
+"You here?"
+
+"Myself."
+
+"Very well; then let us go to the steamer, young man!"
+
+Mr. Fogg, Aouda, and Passepartout passed through the lobby of the
+theatre to the outside, where they encountered the Honourable Mr.
+Batulcar, furious with rage.  He demanded damages for the "breakage" of
+the pyramid; and Phileas Fogg appeased him by giving him a handful of
+banknotes.
+
+At half-past six, the very hour of departure, Mr. Fogg and Aouda,
+followed by Passepartout, who in his hurry had retained his wings, and
+nose six feet long, stepped upon the American steamer.
+
+
+
+
+Chapter XXIV
+
+DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+
+What happened when the pilot-boat came in sight of Shanghai will be
+easily guessed.  The signals made by the Tankadere had been seen by the
+captain of the Yokohama steamer, who, espying the flag at half-mast,
+had directed his course towards the little craft.  Phileas Fogg, after
+paying the stipulated price of his passage to John Busby, and rewarding
+that worthy with the additional sum of five hundred and fifty pounds,
+ascended the steamer with Aouda and Fix; and they started at once for
+Nagasaki and Yokohama.
+
+They reached their destination on the morning of the 14th of November.
+Phileas Fogg lost no time in going on board the Carnatic, where he
+learned, to Aouda's great delight--and perhaps to his own, though he
+betrayed no emotion--that Passepartout, a Frenchman, had really arrived
+on her the day before.
+
+The San Francisco steamer was announced to leave that very evening, and
+it became necessary to find Passepartout, if possible, without delay.
+Mr. Fogg applied in vain to the French and English consuls, and, after
+wandering through the streets a long time, began to despair of finding
+his missing servant.  Chance, or perhaps a kind of presentiment, at
+last led him into the Honourable Mr. Batulcar's theatre.  He certainly
+would not have recognised Passepartout in the eccentric mountebank's
+costume; but the latter, lying on his back, perceived his master in the
+gallery.  He could not help starting, which so changed the position of
+his nose as to bring the "pyramid" pell-mell upon the stage.
+
+All this Passepartout learned from Aouda, who recounted to him what had
+taken place on the voyage from Hong Kong to Shanghai on the Tankadere,
+in company with one Mr. Fix.
+
+Passepartout did not change countenance on hearing this name.  He
+thought that the time had not yet arrived to divulge to his master what
+had taken place between the detective and himself; and, in the account
+he gave of his absence, he simply excused himself for having been
+overtaken by drunkenness, in smoking opium at a tavern in Hong Kong.
+
+Mr. Fogg heard this narrative coldly, without a word; and then
+furnished his man with funds necessary to obtain clothing more in
+harmony with his position.  Within an hour the Frenchman had cut off
+his nose and parted with his wings, and retained nothing about him
+which recalled the sectary of the god Tingou.
+
+The steamer which was about to depart from Yokohama to San Francisco
+belonged to the Pacific Mail Steamship Company, and was named the
+General Grant.  She was a large paddle-wheel steamer of two thousand
+five hundred tons; well equipped and very fast.  The massive
+walking-beam rose and fell above the deck; at one end a piston-rod
+worked up and down; and at the other was a connecting-rod which, in
+changing the rectilinear motion to a circular one, was directly
+connected with the shaft of the paddles.  The General Grant was rigged
+with three masts, giving a large capacity for sails, and thus
+materially aiding the steam power.  By making twelve miles an hour, she
+would cross the ocean in twenty-one days.  Phileas Fogg was therefore
+justified in hoping that he would reach San Francisco by the 2nd of
+December, New York by the 11th, and London on the 20th--thus gaining
+several hours on the fatal date of the 21st of December.
+
+There was a full complement of passengers on board, among them English,
+many Americans, a large number of coolies on their way to California,
+and several East Indian officers, who were spending their vacation in
+making the tour of the world.  Nothing of moment happened on the
+voyage; the steamer, sustained on its large paddles, rolled but little,
+and the Pacific almost justified its name.  Mr. Fogg was as calm and
+taciturn as ever.  His young companion felt herself more and more
+attached to him by other ties than gratitude; his silent but generous
+nature impressed her more than she thought; and it was almost
+unconsciously that she yielded to emotions which did not seem to have
+the least effect upon her protector.  Aouda took the keenest interest
+in his plans, and became impatient at any incident which seemed likely
+to retard his journey.
+
+She often chatted with Passepartout, who did not fail to perceive the
+state of the lady's heart; and, being the most faithful of domestics,
+he never exhausted his eulogies of Phileas Fogg's honesty, generosity,
+and devotion.  He took pains to calm Aouda's doubts of a successful
+termination of the journey, telling her that the most difficult part of
+it had passed, that now they were beyond the fantastic countries of
+Japan and China, and were fairly on their way to civilised places
+again.  A railway train from San Francisco to New York, and a
+transatlantic steamer from New York to Liverpool, would doubtless bring
+them to the end of this impossible journey round the world within the
+period agreed upon.
+
+On the ninth day after leaving Yokohama, Phileas Fogg had traversed
+exactly one half of the terrestrial globe.  The General Grant passed,
+on the 23rd of November, the one hundred and eightieth meridian, and
+was at the very antipodes of London.  Mr. Fogg had, it is true,
+exhausted fifty-two of the eighty days in which he was to complete the
+tour, and there were only twenty-eight left.  But, though he was only
+half-way by the difference of meridians, he had really gone over
+two-thirds of the whole journey; for he had been obliged to make long
+circuits from London to Aden, from Aden to Bombay, from Calcutta to
+Singapore, and from Singapore to Yokohama.  Could he have followed
+without deviation the fiftieth parallel, which is that of London, the
+whole distance would only have been about twelve thousand miles;
+whereas he would be forced, by the irregular methods of locomotion, to
+traverse twenty-six thousand, of which he had, on the 23rd of November,
+accomplished seventeen thousand five hundred.  And now the course was a
+straight one, and Fix was no longer there to put obstacles in their way!
+
+It happened also, on the 23rd of November, that Passepartout made a
+joyful discovery.  It will be remembered that the obstinate fellow had
+insisted on keeping his famous family watch at London time, and on
+regarding that of the countries he had passed through as quite false
+and unreliable.  Now, on this day, though he had not changed the hands,
+he found that his watch exactly agreed with the ship's chronometers.
+His triumph was hilarious.  He would have liked to know what Fix would
+say if he were aboard!
+
+"The rogue told me a lot of stories," repeated Passepartout, "about the
+meridians, the sun, and the moon!  Moon, indeed!  moonshine more
+likely!  If one listened to that sort of people, a pretty sort of time
+one would keep!  I was sure that the sun would some day regulate itself
+by my watch!"
+
+Passepartout was ignorant that, if the face of his watch had been
+divided into twenty-four hours, like the Italian clocks, he would have
+no reason for exultation; for the hands of his watch would then,
+instead of as now indicating nine o'clock in the morning, indicate nine
+o'clock in the evening, that is, the twenty-first hour after midnight
+precisely the difference between London time and that of the one
+hundred and eightieth meridian.  But if Fix had been able to explain
+this purely physical effect, Passepartout would not have admitted, even
+if he had comprehended it.  Moreover, if the detective had been on
+board at that moment, Passepartout would have joined issue with him on
+a quite different subject, and in an entirely different manner.
+
+Where was Fix at that moment?
+
+He was actually on board the General Grant.
+
+On reaching Yokohama, the detective, leaving Mr. Fogg, whom he expected
+to meet again during the day, had repaired at once to the English
+consulate, where he at last found the warrant of arrest.  It had
+followed him from Bombay, and had come by the Carnatic, on which
+steamer he himself was supposed to be.  Fix's disappointment may be
+imagined when he reflected that the warrant was now useless.  Mr. Fogg
+had left English ground, and it was now necessary to procure his
+extradition!
+
+"Well," thought Fix, after a moment of anger, "my warrant is not good
+here, but it will be in England.  The rogue evidently intends to return
+to his own country, thinking he has thrown the police off his track.
+Good!  I will follow him across the Atlantic.  As for the money, heaven
+grant there may be some left!  But the fellow has already spent in
+travelling, rewards, trials, bail, elephants, and all sorts of charges,
+more than five thousand pounds.  Yet, after all, the Bank is rich!"
+
+His course decided on, he went on board the General Grant, and was
+there when Mr. Fogg and Aouda arrived.  To his utter amazement, he
+recognised Passepartout, despite his theatrical disguise.  He quickly
+concealed himself in his cabin, to avoid an awkward explanation, and
+hoped--thanks to the number of passengers--to remain unperceived by Mr.
+Fogg's servant.
+
+On that very day, however, he met Passepartout face to face on the
+forward deck.  The latter, without a word, made a rush for him, grasped
+him by the throat, and, much to the amusement of a group of Americans,
+who immediately began to bet on him, administered to the detective a
+perfect volley of blows, which proved the great superiority of French
+over English pugilistic skill.
+
+When Passepartout had finished, he found himself relieved and
+comforted.  Fix got up in a somewhat rumpled condition, and, looking at
+his adversary, coldly said, "Have you done?"
+
+"For this time--yes."
+
+"Then let me have a word with you."
+
+"But I--"
+
+"In your master's interests."
+
+Passepartout seemed to be vanquished by Fix's coolness, for he quietly
+followed him, and they sat down aside from the rest of the passengers.
+
+"You have given me a thrashing," said Fix.  "Good, I expected it.  Now,
+listen to me.  Up to this time I have been Mr. Fogg's adversary.  I am
+now in his game."
+
+"Aha!" cried Passepartout; "you are convinced he is an honest man?"
+
+"No," replied Fix coldly, "I think him a rascal.  Sh! don't budge, and
+let me speak.  As long as Mr. Fogg was on English ground, it was for my
+interest to detain him there until my warrant of arrest arrived.  I did
+everything I could to keep him back.  I sent the Bombay priests after
+him, I got you intoxicated at Hong Kong, I separated you from him, and
+I made him miss the Yokohama steamer."
+
+Passepartout listened, with closed fists.
+
+"Now," resumed Fix, "Mr. Fogg seems to be going back to England.  Well,
+I will follow him there.  But hereafter I will do as much to keep
+obstacles out of his way as I have done up to this time to put them in
+his path.  I've changed my game, you see, and simply because it was for
+my interest to change it.  Your interest is the same as mine; for it is
+only in England that you will ascertain whether you are in the service
+of a criminal or an honest man."
+
+Passepartout listened very attentively to Fix, and was convinced that
+he spoke with entire good faith.
+
+"Are we friends?" asked the detective.
+
+"Friends?--no," replied Passepartout; "but allies, perhaps.  At the
+least sign of treason, however, I'll twist your neck for you."
+
+"Agreed," said the detective quietly.
+
+Eleven days later, on the 3rd of December, the General Grant entered
+the bay of the Golden Gate, and reached San Francisco.
+
+Mr. Fogg had neither gained nor lost a single day.
+
+
+
+
+Chapter XXV
+
+IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+
+It was seven in the morning when Mr. Fogg, Aouda, and Passepartout set
+foot upon the American continent, if this name can be given to the
+floating quay upon which they disembarked.  These quays, rising and
+falling with the tide, thus facilitate the loading and unloading of
+vessels.  Alongside them were clippers of all sizes, steamers of all
+nationalities, and the steamboats, with several decks rising one above
+the other, which ply on the Sacramento and its tributaries.  There were
+also heaped up the products of a commerce which extends to Mexico,
+Chili, Peru, Brazil, Europe, Asia, and all the Pacific islands.
+
+Passepartout, in his joy on reaching at last the American continent,
+thought he would manifest it by executing a perilous vault in fine
+style; but, tumbling upon some worm-eaten planks, he fell through them.
+Put out of countenance by the manner in which he thus "set foot" upon
+the New World, he uttered a loud cry, which so frightened the
+innumerable cormorants and pelicans that are always perched upon these
+movable quays, that they flew noisily away.
+
+Mr. Fogg, on reaching shore, proceeded to find out at what hour the
+first train left for New York, and learned that this was at six o'clock
+p.m.; he had, therefore, an entire day to spend in the Californian
+capital.  Taking a carriage at a charge of three dollars, he and Aouda
+entered it, while Passepartout mounted the box beside the driver, and
+they set out for the International Hotel.
+
+From his exalted position Passepartout observed with much curiosity the
+wide streets, the low, evenly ranged houses, the Anglo-Saxon Gothic
+churches, the great docks, the palatial wooden and brick warehouses,
+the numerous conveyances, omnibuses, horse-cars, and upon the
+side-walks, not only Americans and Europeans, but Chinese and Indians.
+Passepartout was surprised at all he saw.  San Francisco was no longer
+the legendary city of 1849--a city of banditti, assassins, and
+incendiaries, who had flocked hither in crowds in pursuit of plunder; a
+paradise of outlaws, where they gambled with gold-dust, a revolver in
+one hand and a bowie-knife in the other: it was now a great commercial
+emporium.
+
+The lofty tower of its City Hall overlooked the whole panorama of the
+streets and avenues, which cut each other at right-angles, and in the
+midst of which appeared pleasant, verdant squares, while beyond
+appeared the Chinese quarter, seemingly imported from the Celestial
+Empire in a toy-box.  Sombreros and red shirts and plumed Indians were
+rarely to be seen; but there were silk hats and black coats everywhere
+worn by a multitude of nervously active, gentlemanly-looking men.  Some
+of the streets--especially Montgomery Street, which is to San Francisco
+what Regent Street is to London, the Boulevard des Italiens to Paris,
+and Broadway to New York--were lined with splendid and spacious
+stores, which exposed in their windows the products of the entire world.
+
+When Passepartout reached the International Hotel, it did not seem to
+him as if he had left England at all.
+
+The ground floor of the hotel was occupied by a large bar, a sort of
+restaurant freely open to all passers-by, who might partake of dried
+beef, oyster soup, biscuits, and cheese, without taking out their
+purses.  Payment was made only for the ale, porter, or sherry which was
+drunk.  This seemed "very American" to Passepartout.  The hotel
+refreshment-rooms were comfortable, and Mr. Fogg and Aouda, installing
+themselves at a table, were abundantly served on diminutive plates by
+negroes of darkest hue.
+
+After breakfast, Mr. Fogg, accompanied by Aouda, started for the
+English consulate to have his passport visaed.  As he was going out, he
+met Passepartout, who asked him if it would not be well, before taking
+the train, to purchase some dozens of Enfield rifles and Colt's
+revolvers.  He had been listening to stories of attacks upon the trains
+by the Sioux and Pawnees.  Mr. Fogg thought it a useless precaution,
+but told him to do as he thought best, and went on to the consulate.
+
+He had not proceeded two hundred steps, however, when, "by the greatest
+chance in the world," he met Fix.  The detective seemed wholly taken by
+surprise.  What!  Had Mr. Fogg and himself crossed the Pacific
+together, and not met on the steamer!  At least Fix felt honoured to
+behold once more the gentleman to whom he owed so much, and, as his
+business recalled him to Europe, he should be delighted to continue the
+journey in such pleasant company.
+
+Mr. Fogg replied that the honour would be his; and the detective--who
+was determined not to lose sight of him--begged permission to accompany
+them in their walk about San Francisco--a request which Mr. Fogg
+readily granted.
+
+They soon found themselves in Montgomery Street, where a great crowd
+was collected; the side-walks, street, horsecar rails, the shop-doors,
+the windows of the houses, and even the roofs, were full of people.
+Men were going about carrying large posters, and flags and streamers
+were floating in the wind; while loud cries were heard on every hand.
+
+"Hurrah for Camerfield!"
+
+"Hurrah for Mandiboy!"
+
+It was a political meeting; at least so Fix conjectured, who said to
+Mr. Fogg, "Perhaps we had better not mingle with the crowd.  There may
+be danger in it."
+
+"Yes," returned Mr. Fogg; "and blows, even if they are political are
+still blows."
+
+Fix smiled at this remark; and, in order to be able to see without
+being jostled about, the party took up a position on the top of a
+flight of steps situated at the upper end of Montgomery Street.
+Opposite them, on the other side of the street, between a coal wharf
+and a petroleum warehouse, a large platform had been erected in the
+open air, towards which the current of the crowd seemed to be directed.
+
+For what purpose was this meeting?  What was the occasion of this
+excited assemblage?  Phileas Fogg could not imagine.  Was it to
+nominate some high official--a governor or member of Congress?  It was
+not improbable, so agitated was the multitude before them.
+
+Just at this moment there was an unusual stir in the human mass.  All
+the hands were raised in the air.  Some, tightly closed, seemed to
+disappear suddenly in the midst of the cries--an energetic way, no
+doubt, of casting a vote.  The crowd swayed back, the banners and flags
+wavered, disappeared an instant, then reappeared in tatters.  The
+undulations of the human surge reached the steps, while all the heads
+floundered on the surface like a sea agitated by a squall.  Many of the
+black hats disappeared, and the greater part of the crowd seemed to
+have diminished in height.
+
+"It is evidently a meeting," said Fix, "and its object must be an
+exciting one.  I should not wonder if it were about the Alabama,
+despite the fact that that question is settled."
+
+"Perhaps," replied Mr. Fogg, simply.
+
+"At least, there are two champions in presence of each other, the
+Honourable Mr. Camerfield and the Honourable Mr. Mandiboy."
+
+Aouda, leaning upon Mr. Fogg's arm, observed the tumultuous scene with
+surprise, while Fix asked a man near him what the cause of it all was.
+Before the man could reply, a fresh agitation arose; hurrahs and
+excited shouts were heard; the staffs of the banners began to be used
+as offensive weapons; and fists flew about in every direction.  Thumps
+were exchanged from the tops of the carriages and omnibuses which had
+been blocked up in the crowd.  Boots and shoes went whirling through
+the air, and Mr. Fogg thought he even heard the crack of revolvers
+mingling in the din, the rout approached the stairway, and flowed over
+the lower step.  One of the parties had evidently been repulsed; but
+the mere lookers-on could not tell whether Mandiboy or Camerfield had
+gained the upper hand.
+
+"It would be prudent for us to retire," said Fix, who was anxious that
+Mr. Fogg should not receive any injury, at least until they got back to
+London.  "If there is any question about England in all this, and we
+were recognised, I fear it would go hard with us."
+
+"An English subject--" began Mr. Fogg.
+
+He did not finish his sentence; for a terrific hubbub now arose on the
+terrace behind the flight of steps where they stood, and there were
+frantic shouts of, "Hurrah for Mandiboy!  Hip, hip, hurrah!"
+
+It was a band of voters coming to the rescue of their allies, and
+taking the Camerfield forces in flank.  Mr. Fogg, Aouda, and Fix found
+themselves between two fires; it was too late to escape.  The torrent
+of men, armed with loaded canes and sticks, was irresistible.  Phileas
+Fogg and Fix were roughly hustled in their attempts to protect their
+fair companion; the former, as cool as ever, tried to defend himself
+with the weapons which nature has placed at the end of every
+Englishman's arm, but in vain.  A big brawny fellow with a red beard,
+flushed face, and broad shoulders, who seemed to be the chief of the
+band, raised his clenched fist to strike Mr. Fogg, whom he would have
+given a crushing blow, had not Fix rushed in and received it in his
+stead.  An enormous bruise immediately made its appearance under the
+detective's silk hat, which was completely smashed in.
+
+"Yankee!" exclaimed Mr. Fogg, darting a contemptuous look at the
+ruffian.
+
+"Englishman!" returned the other.  "We will meet again!"
+
+"When you please."
+
+"What is your name?"
+
+"Phileas Fogg.  And yours?"
+
+"Colonel Stamp Proctor."
+
+The human tide now swept by, after overturning Fix, who speedily got
+upon his feet again, though with tattered clothes.  Happily, he was not
+seriously hurt.  His travelling overcoat was divided into two unequal
+parts, and his trousers resembled those of certain Indians, which fit
+less compactly than they are easy to put on.  Aouda had escaped
+unharmed, and Fix alone bore marks of the fray in his black and blue
+bruise.
+
+"Thanks," said Mr. Fogg to the detective, as soon as they were out of
+the crowd.
+
+"No thanks are necessary," replied.  Fix; "but let us go."
+
+"Where?"
+
+"To a tailor's."
+
+Such a visit was, indeed, opportune.  The clothing of both Mr. Fogg and
+Fix was in rags, as if they had themselves been actively engaged in the
+contest between Camerfield and Mandiboy.  An hour after, they were once
+more suitably attired, and with Aouda returned to the International
+Hotel.
+
+Passepartout was waiting for his master, armed with half a dozen
+six-barrelled revolvers.  When he perceived Fix, he knit his brows; but
+Aouda having, in a few words, told him of their adventure, his
+countenance resumed its placid expression.  Fix evidently was no longer
+an enemy, but an ally; he was faithfully keeping his word.
+
+Dinner over, the coach which was to convey the passengers and their
+luggage to the station drew up to the door.  As he was getting in, Mr.
+Fogg said to Fix, "You have not seen this Colonel Proctor again?"
+
+"No."
+
+"I will come back to America to find him," said Phileas Fogg calmly.
+"It would not be right for an Englishman to permit himself to be
+treated in that way, without retaliating."
+
+The detective smiled, but did not reply.  It was clear that Mr. Fogg
+was one of those Englishmen who, while they do not tolerate duelling at
+home, fight abroad when their honour is attacked.
+
+At a quarter before six the travellers reached the station, and found
+the train ready to depart.  As he was about to enter it, Mr. Fogg
+called a porter, and said to him: "My friend, was there not some
+trouble to-day in San Francisco?"
+
+"It was a political meeting, sir," replied the porter.
+
+"But I thought there was a great deal of disturbance in the streets."
+
+"It was only a meeting assembled for an election."
+
+"The election of a general-in-chief, no doubt?" asked Mr. Fogg.
+
+"No, sir; of a justice of the peace."
+
+Phileas Fogg got into the train, which started off at full speed.
+
+
+
+
+Chapter XXVI
+
+IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+
+"From ocean to ocean"--so say the Americans; and these four words
+compose the general designation of the "great trunk line" which crosses
+the entire width of the United States.  The Pacific Railroad is,
+however, really divided into two distinct lines: the Central Pacific,
+between San Francisco and Ogden, and the Union Pacific, between Ogden
+and Omaha.  Five main lines connect Omaha with New York.
+
+New York and San Francisco are thus united by an uninterrupted metal
+ribbon, which measures no less than three thousand seven hundred and
+eighty-six miles.  Between Omaha and the Pacific the railway crosses a
+territory which is still infested by Indians and wild beasts, and a
+large tract which the Mormons, after they were driven from Illinois in
+1845, began to colonise.
+
+The journey from New York to San Francisco consumed, formerly, under
+the most favourable conditions, at least six months.  It is now
+accomplished in seven days.
+
+It was in 1862 that, in spite of the Southern Members of Congress, who
+wished a more southerly route, it was decided to lay the road between
+the forty-first and forty-second parallels.  President Lincoln himself
+fixed the end of the line at Omaha, in Nebraska.  The work was at once
+commenced, and pursued with true American energy; nor did the rapidity
+with which it went on injuriously affect its good execution.  The road
+grew, on the prairies, a mile and a half a day.  A locomotive, running
+on the rails laid down the evening before, brought the rails to be laid
+on the morrow, and advanced upon them as fast as they were put in
+position.
+
+The Pacific Railroad is joined by several branches in Iowa, Kansas,
+Colorado, and Oregon.  On leaving Omaha, it passes along the left bank
+of the Platte River as far as the junction of its northern branch,
+follows its southern branch, crosses the Laramie territory and the
+Wahsatch Mountains, turns the Great Salt Lake, and reaches Salt Lake
+City, the Mormon capital, plunges into the Tuilla Valley, across the
+American Desert, Cedar and Humboldt Mountains, the Sierra Nevada, and
+descends, via Sacramento, to the Pacific--its grade, even on the Rocky
+Mountains, never exceeding one hundred and twelve feet to the mile.
+
+Such was the road to be traversed in seven days, which would enable
+Phileas Fogg--at least, so he hoped--to take the Atlantic steamer at
+New York on the 11th for Liverpool.
+
+The car which he occupied was a sort of long omnibus on eight wheels,
+and with no compartments in the interior.  It was supplied with two
+rows of seats, perpendicular to the direction of the train on either
+side of an aisle which conducted to the front and rear platforms.
+These platforms were found throughout the train, and the passengers
+were able to pass from one end of the train to the other.  It was
+supplied with saloon cars, balcony cars, restaurants, and smoking-cars;
+theatre cars alone were wanting, and they will have these some day.
+
+Book and news dealers, sellers of edibles, drinkables, and cigars, who
+seemed to have plenty of customers, were continually circulating in the
+aisles.
+
+The train left Oakland station at six o'clock.  It was already night,
+cold and cheerless, the heavens being overcast with clouds which seemed
+to threaten snow.  The train did not proceed rapidly; counting the
+stoppages, it did not run more than twenty miles an hour, which was a
+sufficient speed, however, to enable it to reach Omaha within its
+designated time.
+
+There was but little conversation in the car, and soon many of the
+passengers were overcome with sleep.  Passepartout found himself beside
+the detective; but he did not talk to him.  After recent events, their
+relations with each other had grown somewhat cold; there could no
+longer be mutual sympathy or intimacy between them.  Fix's manner had
+not changed; but Passepartout was very reserved, and ready to strangle
+his former friend on the slightest provocation.
+
+Snow began to fall an hour after they started, a fine snow, however,
+which happily could not obstruct the train; nothing could be seen from
+the windows but a vast, white sheet, against which the smoke of the
+locomotive had a greyish aspect.
+
+At eight o'clock a steward entered the car and announced that the time
+for going to bed had arrived; and in a few minutes the car was
+transformed into a dormitory.  The backs of the seats were thrown back,
+bedsteads carefully packed were rolled out by an ingenious system,
+berths were suddenly improvised, and each traveller had soon at his
+disposition a comfortable bed, protected from curious eyes by thick
+curtains.  The sheets were clean and the pillows soft.  It only
+remained to go to bed and sleep which everybody did--while the train
+sped on across the State of California.
+
+The country between San Francisco and Sacramento is not very hilly.
+The Central Pacific, taking Sacramento for its starting-point, extends
+eastward to meet the road from Omaha.  The line from San Francisco to
+Sacramento runs in a north-easterly direction, along the American
+River, which empties into San Pablo Bay.  The one hundred and twenty
+miles between these cities were accomplished in six hours, and towards
+midnight, while fast asleep, the travellers passed through Sacramento;
+so that they saw nothing of that important place, the seat of the State
+government, with its fine quays, its broad streets, its noble hotels,
+squares, and churches.
+
+The train, on leaving Sacramento, and passing the junction, Roclin,
+Auburn, and Colfax, entered the range of the Sierra Nevada.  'Cisco was
+reached at seven in the morning; and an hour later the dormitory was
+transformed into an ordinary car, and the travellers could observe the
+picturesque beauties of the mountain region through which they were
+steaming.  The railway track wound in and out among the passes, now
+approaching the mountain-sides, now suspended over precipices, avoiding
+abrupt angles by bold curves, plunging into narrow defiles, which
+seemed to have no outlet.  The locomotive, its great funnel emitting a
+weird light, with its sharp bell, and its cow-catcher extended like a
+spur, mingled its shrieks and bellowings with the noise of torrents and
+cascades, and twined its smoke among the branches of the gigantic pines.
+
+There were few or no bridges or tunnels on the route.  The railway
+turned around the sides of the mountains, and did not attempt to
+violate nature by taking the shortest cut from one point to another.
+
+The train entered the State of Nevada through the Carson Valley about
+nine o'clock, going always northeasterly; and at midday reached Reno,
+where there was a delay of twenty minutes for breakfast.
+
+From this point the road, running along Humboldt River, passed
+northward for several miles by its banks; then it turned eastward, and
+kept by the river until it reached the Humboldt Range, nearly at the
+extreme eastern limit of Nevada.
+
+Having breakfasted, Mr. Fogg and his companions resumed their places in
+the car, and observed the varied landscape which unfolded itself as
+they passed along the vast prairies, the mountains lining the horizon,
+and the creeks, with their frothy, foaming streams.  Sometimes a great
+herd of buffaloes, massing together in the distance, seemed like a
+moveable dam.  These innumerable multitudes of ruminating beasts often
+form an insurmountable obstacle to the passage of the trains; thousands
+of them have been seen passing over the track for hours together, in
+compact ranks.  The locomotive is then forced to stop and wait till the
+road is once more clear.
+
+This happened, indeed, to the train in which Mr. Fogg was travelling.
+About twelve o'clock a troop of ten or twelve thousand head of buffalo
+encumbered the track.  The locomotive, slackening its speed, tried to
+clear the way with its cow-catcher; but the mass of animals was too
+great.  The buffaloes marched along with a tranquil gait, uttering now
+and then deafening bellowings.  There was no use of interrupting them,
+for, having taken a particular direction, nothing can moderate and
+change their course; it is a torrent of living flesh which no dam could
+contain.
+
+The travellers gazed on this curious spectacle from the platforms; but
+Phileas Fogg, who had the most reason of all to be in a hurry, remained
+in his seat, and waited philosophically until it should please the
+buffaloes to get out of the way.
+
+Passepartout was furious at the delay they occasioned, and longed to
+discharge his arsenal of revolvers upon them.
+
+"What a country!" cried he.  "Mere cattle stop the trains, and go by in
+a procession, just as if they were not impeding travel!  Parbleu!  I
+should like to know if Mr. Fogg foresaw this mishap in his programme!
+And here's an engineer who doesn't dare to run the locomotive into this
+herd of beasts!"
+
+The engineer did not try to overcome the obstacle, and he was wise.  He
+would have crushed the first buffaloes, no doubt, with the cow-catcher;
+but the locomotive, however powerful, would soon have been checked, the
+train would inevitably have been thrown off the track, and would then
+have been helpless.
+
+The best course was to wait patiently, and regain the lost time by
+greater speed when the obstacle was removed.  The procession of
+buffaloes lasted three full hours, and it was night before the track
+was clear.  The last ranks of the herd were now passing over the rails,
+while the first had already disappeared below the southern horizon.
+
+It was eight o'clock when the train passed through the defiles of the
+Humboldt Range, and half-past nine when it penetrated Utah, the region
+of the Great Salt Lake, the singular colony of the Mormons.
+
+
+
+
+Chapter XXVII
+
+IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN HOUR, A
+COURSE OF MORMON HISTORY
+
+
+During the night of the 5th of December, the train ran south-easterly
+for about fifty miles; then rose an equal distance in a north-easterly
+direction, towards the Great Salt Lake.
+
+Passepartout, about nine o'clock, went out upon the platform to take
+the air.  The weather was cold, the heavens grey, but it was not
+snowing.  The sun's disc, enlarged by the mist, seemed an enormous ring
+of gold, and Passepartout was amusing himself by calculating its value
+in pounds sterling, when he was diverted from this interesting study by
+a strange-looking personage who made his appearance on the platform.
+
+This personage, who had taken the train at Elko, was tall and dark,
+with black moustache, black stockings, a black silk hat, a black
+waistcoat, black trousers, a white cravat, and dogskin gloves.  He
+might have been taken for a clergyman.  He went from one end of the
+train to the other, and affixed to the door of each car a notice
+written in manuscript.
+
+Passepartout approached and read one of these notices, which stated
+that Elder William Hitch, Mormon missionary, taking advantage of his
+presence on train No. 48, would deliver a lecture on Mormonism in car
+No. 117, from eleven to twelve o'clock; and that he invited all who
+were desirous of being instructed concerning the mysteries of the
+religion of the "Latter Day Saints" to attend.
+
+"I'll go," said Passepartout to himself.  He knew nothing of Mormonism
+except the custom of polygamy, which is its foundation.
+
+The news quickly spread through the train, which contained about one
+hundred passengers, thirty of whom, at most, attracted by the notice,
+ensconced themselves in car No. 117.  Passepartout took one of the
+front seats.  Neither Mr. Fogg nor Fix cared to attend.
+
+At the appointed hour Elder William Hitch rose, and, in an irritated
+voice, as if he had already been contradicted, said, "I tell you that
+Joe Smith is a martyr, that his brother Hiram is a martyr, and that the
+persecutions of the United States Government against the prophets will
+also make a martyr of Brigham Young.  Who dares to say the contrary?"
+
+No one ventured to gainsay the missionary, whose excited tone
+contrasted curiously with his naturally calm visage.  No doubt his
+anger arose from the hardships to which the Mormons were actually
+subjected.  The government had just succeeded, with some difficulty, in
+reducing these independent fanatics to its rule.  It had made itself
+master of Utah, and subjected that territory to the laws of the Union,
+after imprisoning Brigham Young on a charge of rebellion and polygamy.
+The disciples of the prophet had since redoubled their efforts, and
+resisted, by words at least, the authority of Congress.  Elder Hitch,
+as is seen, was trying to make proselytes on the very railway trains.
+
+Then, emphasising his words with his loud voice and frequent gestures,
+he related the history of the Mormons from Biblical times: how that, in
+Israel, a Mormon prophet of the tribe of Joseph published the annals of
+the new religion, and bequeathed them to his son Mormon; how, many
+centuries later, a translation of this precious book, which was written
+in Egyptian, was made by Joseph Smith, junior, a Vermont farmer, who
+revealed himself as a mystical prophet in 1825; and how, in short, the
+celestial messenger appeared to him in an illuminated forest, and gave
+him the annals of the Lord.
+
+Several of the audience, not being much interested in the missionary's
+narrative, here left the car; but Elder Hitch, continuing his lecture,
+related how Smith, junior, with his father, two brothers, and a few
+disciples, founded the church of the "Latter Day Saints," which,
+adopted not only in America, but in England, Norway and Sweden, and
+Germany, counts many artisans, as well as men engaged in the liberal
+professions, among its members; how a colony was established in Ohio, a
+temple erected there at a cost of two hundred thousand dollars, and a
+town built at Kirkland; how Smith became an enterprising banker, and
+received from a simple mummy showman a papyrus scroll written by
+Abraham and several famous Egyptians.
+
+The Elder's story became somewhat wearisome, and his audience grew
+gradually less, until it was reduced to twenty passengers.  But this
+did not disconcert the enthusiast, who proceeded with the story of
+Joseph Smith's bankruptcy in 1837, and how his ruined creditors gave
+him a coat of tar and feathers; his reappearance some years afterwards,
+more honourable and honoured than ever, at Independence, Missouri, the
+chief of a flourishing colony of three thousand disciples, and his
+pursuit thence by outraged Gentiles, and retirement into the Far West.
+
+Ten hearers only were now left, among them honest Passepartout, who was
+listening with all his ears.  Thus he learned that, after long
+persecutions, Smith reappeared in Illinois, and in 1839 founded a
+community at Nauvoo, on the Mississippi, numbering twenty-five thousand
+souls, of which he became mayor, chief justice, and general-in-chief;
+that he announced himself, in 1843, as a candidate for the Presidency
+of the United States; and that finally, being drawn into ambuscade at
+Carthage, he was thrown into prison, and assassinated by a band of men
+disguised in masks.
+
+Passepartout was now the only person left in the car, and the Elder,
+looking him full in the face, reminded him that, two years after the
+assassination of Joseph Smith, the inspired prophet, Brigham Young, his
+successor, left Nauvoo for the banks of the Great Salt Lake, where, in
+the midst of that fertile region, directly on the route of the
+emigrants who crossed Utah on their way to California, the new colony,
+thanks to the polygamy practised by the Mormons, had flourished beyond
+expectations.
+
+"And this," added Elder William Hitch, "this is why the jealousy of
+Congress has been aroused against us!  Why have the soldiers of the
+Union invaded the soil of Utah?  Why has Brigham Young, our chief, been
+imprisoned, in contempt of all justice?  Shall we yield to force?
+Never!  Driven from Vermont, driven from Illinois, driven from Ohio,
+driven from Missouri, driven from Utah, we shall yet find some
+independent territory on which to plant our tents.  And you, my
+brother," continued the Elder, fixing his angry eyes upon his single
+auditor, "will you not plant yours there, too, under the shadow of our
+flag?"
+
+"No!" replied Passepartout courageously, in his turn retiring from the
+car, and leaving the Elder to preach to vacancy.
+
+During the lecture the train had been making good progress, and towards
+half-past twelve it reached the northwest border of the Great Salt
+Lake.  Thence the passengers could observe the vast extent of this
+interior sea, which is also called the Dead Sea, and into which flows
+an American Jordan.  It is a picturesque expanse, framed in lofty crags
+in large strata, encrusted with white salt--a superb sheet of water,
+which was formerly of larger extent than now, its shores having
+encroached with the lapse of time, and thus at once reduced its breadth
+and increased its depth.
+
+The Salt Lake, seventy miles long and thirty-five wide, is situated
+three miles eight hundred feet above the sea.  Quite different from
+Lake Asphaltite, whose depression is twelve hundred feet below the sea,
+it contains considerable salt, and one quarter of the weight of its
+water is solid matter, its specific weight being 1,170, and, after
+being distilled, 1,000.  Fishes are, of course, unable to live in it,
+and those which descend through the Jordan, the Weber, and other
+streams soon perish.
+
+The country around the lake was well cultivated, for the Mormons are
+mostly farmers; while ranches and pens for domesticated animals, fields
+of wheat, corn, and other cereals, luxuriant prairies, hedges of wild
+rose, clumps of acacias and milk-wort, would have been seen six months
+later.  Now the ground was covered with a thin powdering of snow.
+
+The train reached Ogden at two o'clock, where it rested for six hours,
+Mr. Fogg and his party had time to pay a visit to Salt Lake City,
+connected with Ogden by a branch road; and they spent two hours in this
+strikingly American town, built on the pattern of other cities of the
+Union, like a checker-board, "with the sombre sadness of right-angles,"
+as Victor Hugo expresses it.  The founder of the City of the Saints
+could not escape from the taste for symmetry which distinguishes the
+Anglo-Saxons.  In this strange country, where the people are certainly
+not up to the level of their institutions, everything is done
+"squarely"--cities, houses, and follies.
+
+The travellers, then, were promenading, at three o'clock, about the
+streets of the town built between the banks of the Jordan and the spurs
+of the Wahsatch Range.  They saw few or no churches, but the prophet's
+mansion, the court-house, and the arsenal, blue-brick houses with
+verandas and porches, surrounded by gardens bordered with acacias,
+palms, and locusts.  A clay and pebble wall, built in 1853, surrounded
+the town; and in the principal street were the market and several
+hotels adorned with pavilions.  The place did not seem thickly
+populated.  The streets were almost deserted, except in the vicinity of
+the temple, which they only reached after having traversed several
+quarters surrounded by palisades.  There were many women, which was
+easily accounted for by the "peculiar institution" of the Mormons; but
+it must not be supposed that all the Mormons are polygamists.  They are
+free to marry or not, as they please; but it is worth noting that it is
+mainly the female citizens of Utah who are anxious to marry, as,
+according to the Mormon religion, maiden ladies are not admitted to the
+possession of its highest joys.  These poor creatures seemed to be
+neither well off nor happy.  Some--the more well-to-do, no doubt--wore
+short, open, black silk dresses, under a hood or modest shawl; others
+were habited in Indian fashion.
+
+Passepartout could not behold without a certain fright these women,
+charged, in groups, with conferring happiness on a single Mormon.  His
+common sense pitied, above all, the husband.  It seemed to him a
+terrible thing to have to guide so many wives at once across the
+vicissitudes of life, and to conduct them, as it were, in a body to the
+Mormon paradise with the prospect of seeing them in the company of the
+glorious Smith, who doubtless was the chief ornament of that delightful
+place, to all eternity.  He felt decidedly repelled from such a
+vocation, and he imagined--perhaps he was mistaken--that the fair ones
+of Salt Lake City cast rather alarming glances on his person.  Happily,
+his stay there was but brief.  At four the party found themselves again
+at the station, took their places in the train, and the whistle sounded
+for starting.  Just at the moment, however, that the locomotive wheels
+began to move, cries of "Stop! stop!" were heard.
+
+Trains, like time and tide, stop for no one.  The gentleman who uttered
+the cries was evidently a belated Mormon.  He was breathless with
+running.  Happily for him, the station had neither gates nor barriers.
+He rushed along the track, jumped on the rear platform of the train,
+and fell, exhausted, into one of the seats.
+
+Passepartout, who had been anxiously watching this amateur gymnast,
+approached him with lively interest, and learned that he had taken
+flight after an unpleasant domestic scene.
+
+When the Mormon had recovered his breath, Passepartout ventured to ask
+him politely how many wives he had; for, from the manner in which he
+had decamped, it might be thought that he had twenty at least.
+
+"One, sir," replied the Mormon, raising his arms heavenward--"one, and
+that was enough!"
+
+
+
+
+Chapter XXVIII
+
+IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN TO
+REASON
+
+
+The train, on leaving Great Salt Lake at Ogden, passed northward for an
+hour as far as Weber River, having completed nearly nine hundred miles
+from San Francisco.  From this point it took an easterly direction
+towards the jagged Wahsatch Mountains.  It was in the section included
+between this range and the Rocky Mountains that the American engineers
+found the most formidable difficulties in laying the road, and that the
+government granted a subsidy of forty-eight thousand dollars per mile,
+instead of sixteen thousand allowed for the work done on the plains.
+But the engineers, instead of violating nature, avoided its
+difficulties by winding around, instead of penetrating the rocks.  One
+tunnel only, fourteen thousand feet in length, was pierced in order to
+arrive at the great basin.
+
+The track up to this time had reached its highest elevation at the
+Great Salt Lake.  From this point it described a long curve, descending
+towards Bitter Creek Valley, to rise again to the dividing ridge of the
+waters between the Atlantic and the Pacific.  There were many creeks in
+this mountainous region, and it was necessary to cross Muddy Creek,
+Green Creek, and others, upon culverts.
+
+Passepartout grew more and more impatient as they went on, while Fix
+longed to get out of this difficult region, and was more anxious than
+Phileas Fogg himself to be beyond the danger of delays and accidents,
+and set foot on English soil.
+
+At ten o'clock at night the train stopped at Fort Bridger station, and
+twenty minutes later entered Wyoming Territory, following the valley of
+Bitter Creek throughout.  The next day, 7th December, they stopped for
+a quarter of an hour at Green River station.  Snow had fallen
+abundantly during the night, but, being mixed with rain, it had half
+melted, and did not interrupt their progress.  The bad weather,
+however, annoyed Passepartout; for the accumulation of snow, by
+blocking the wheels of the cars, would certainly have been fatal to Mr.
+Fogg's tour.
+
+"What an idea!" he said to himself.  "Why did my master make this
+journey in winter?  Couldn't he have waited for the good season to
+increase his chances?"
+
+While the worthy Frenchman was absorbed in the state of the sky and the
+depression of the temperature, Aouda was experiencing fears from a
+totally different cause.
+
+Several passengers had got off at Green River, and were walking up and
+down the platforms; and among these Aouda recognised Colonel Stamp
+Proctor, the same who had so grossly insulted Phileas Fogg at the San
+Francisco meeting.  Not wishing to be recognised, the young woman drew
+back from the window, feeling much alarm at her discovery.  She was
+attached to the man who, however coldly, gave her daily evidences of
+the most absolute devotion.  She did not comprehend, perhaps, the depth
+of the sentiment with which her protector inspired her, which she
+called gratitude, but which, though she was unconscious of it, was
+really more than that.  Her heart sank within her when she recognised
+the man whom Mr. Fogg desired, sooner or later, to call to account for
+his conduct.  Chance alone, it was clear, had brought Colonel Proctor
+on this train; but there he was, and it was necessary, at all hazards,
+that Phileas Fogg should not perceive his adversary.
+
+Aouda seized a moment when Mr. Fogg was asleep to tell Fix and
+Passepartout whom she had seen.
+
+"That Proctor on this train!" cried Fix.  "Well, reassure yourself,
+madam; before he settles with Mr. Fogg; he has got to deal with me!  It
+seems to me that I was the more insulted of the two."
+
+"And, besides," added Passepartout, "I'll take charge of him, colonel
+as he is."
+
+"Mr. Fix," resumed Aouda, "Mr. Fogg will allow no one to avenge him.
+He said that he would come back to America to find this man.  Should he
+perceive Colonel Proctor, we could not prevent a collision which might
+have terrible results.  He must not see him."
+
+"You are right, madam," replied Fix; "a meeting between them might ruin
+all.  Whether he were victorious or beaten, Mr. Fogg would be delayed,
+and--"
+
+"And," added Passepartout, "that would play the game of the gentlemen
+of the Reform Club.  In four days we shall be in New York.  Well, if my
+master does not leave this car during those four days, we may hope that
+chance will not bring him face to face with this confounded American.
+We must, if possible, prevent his stirring out of it."
+
+The conversation dropped.  Mr. Fogg had just woke up, and was looking
+out of the window.  Soon after Passepartout, without being heard by his
+master or Aouda, whispered to the detective, "Would you really fight
+for him?"
+
+"I would do anything," replied Fix, in a tone which betrayed determined
+will, "to get him back living to Europe!"
+
+Passepartout felt something like a shudder shoot through his frame, but
+his confidence in his master remained unbroken.
+
+Was there any means of detaining Mr. Fogg in the car, to avoid a
+meeting between him and the colonel?  It ought not to be a difficult
+task, since that gentleman was naturally sedentary and little curious.
+The detective, at least, seemed to have found a way; for, after a few
+moments, he said to Mr. Fogg, "These are long and slow hours, sir, that
+we are passing on the railway."
+
+"Yes," replied Mr. Fogg; "but they pass."
+
+"You were in the habit of playing whist," resumed Fix, "on the
+steamers."
+
+"Yes; but it would be difficult to do so here.  I have neither cards
+nor partners."
+
+"Oh, but we can easily buy some cards, for they are sold on all the
+American trains.  And as for partners, if madam plays--"
+
+"Certainly, sir," Aouda quickly replied; "I understand whist.  It is
+part of an English education."
+
+"I myself have some pretensions to playing a good game.  Well, here are
+three of us, and a dummy--"
+
+"As you please, sir," replied Phileas Fogg, heartily glad to resume his
+favourite pastime even on the railway.
+
+Passepartout was dispatched in search of the steward, and soon returned
+with two packs of cards, some pins, counters, and a shelf covered with
+cloth.
+
+The game commenced.  Aouda understood whist sufficiently well, and even
+received some compliments on her playing from Mr. Fogg.  As for the
+detective, he was simply an adept, and worthy of being matched against
+his present opponent.
+
+"Now," thought Passepartout, "we've got him.  He won't budge."
+
+At eleven in the morning the train had reached the dividing ridge of
+the waters at Bridger Pass, seven thousand five hundred and twenty-four
+feet above the level of the sea, one of the highest points attained by
+the track in crossing the Rocky Mountains.  After going about two
+hundred miles, the travellers at last found themselves on one of those
+vast plains which extend to the Atlantic, and which nature has made so
+propitious for laying the iron road.
+
+On the declivity of the Atlantic basin the first streams, branches of
+the North Platte River, already appeared.  The whole northern and
+eastern horizon was bounded by the immense semi-circular curtain which
+is formed by the southern portion of the Rocky Mountains, the highest
+being Laramie Peak.  Between this and the railway extended vast plains,
+plentifully irrigated.  On the right rose the lower spurs of the
+mountainous mass which extends southward to the sources of the Arkansas
+River, one of the great tributaries of the Missouri.
+
+At half-past twelve the travellers caught sight for an instant of Fort
+Halleck, which commands that section; and in a few more hours the Rocky
+Mountains were crossed.  There was reason to hope, then, that no
+accident would mark the journey through this difficult country.  The
+snow had ceased falling, and the air became crisp and cold.  Large
+birds, frightened by the locomotive, rose and flew off in the distance.
+No wild beast appeared on the plain.  It was a desert in its vast
+nakedness.
+
+After a comfortable breakfast, served in the car, Mr. Fogg and his
+partners had just resumed whist, when a violent whistling was heard,
+and the train stopped.  Passepartout put his head out of the door, but
+saw nothing to cause the delay; no station was in view.
+
+Aouda and Fix feared that Mr. Fogg might take it into his head to get
+out; but that gentleman contented himself with saying to his servant,
+"See what is the matter."
+
+Passepartout rushed out of the car.  Thirty or forty passengers had
+already descended, amongst them Colonel Stamp Proctor.
+
+The train had stopped before a red signal which blocked the way.  The
+engineer and conductor were talking excitedly with a signal-man, whom
+the station-master at Medicine Bow, the next stopping place, had sent
+on before.  The passengers drew around and took part in the discussion,
+in which Colonel Proctor, with his insolent manner, was conspicuous.
+
+Passepartout, joining the group, heard the signal-man say, "No! you
+can't pass.  The bridge at Medicine Bow is shaky, and would not bear
+the weight of the train."
+
+This was a suspension-bridge thrown over some rapids, about a mile from
+the place where they now were.  According to the signal-man, it was in
+a ruinous condition, several of the iron wires being broken; and it was
+impossible to risk the passage.  He did not in any way exaggerate the
+condition of the bridge.  It may be taken for granted that, rash as the
+Americans usually are, when they are prudent there is good reason for
+it.
+
+Passepartout, not daring to apprise his master of what he heard,
+listened with set teeth, immovable as a statue.
+
+"Hum!" cried Colonel Proctor; "but we are not going to stay here, I
+imagine, and take root in the snow?"
+
+"Colonel," replied the conductor, "we have telegraphed to Omaha for a
+train, but it is not likely that it will reach Medicine Bow in less
+than six hours."
+
+"Six hours!" cried Passepartout.
+
+"Certainly," returned the conductor, "besides, it will take us as long
+as that to reach Medicine Bow on foot."
+
+"But it is only a mile from here," said one of the passengers.
+
+"Yes, but it's on the other side of the river."
+
+"And can't we cross that in a boat?" asked the colonel.
+
+"That's impossible.  The creek is swelled by the rains.  It is a rapid,
+and we shall have to make a circuit of ten miles to the north to find a
+ford."
+
+The colonel launched a volley of oaths, denouncing the railway company
+and the conductor; and Passepartout, who was furious, was not
+disinclined to make common cause with him.  Here was an obstacle,
+indeed, which all his master's banknotes could not remove.
+
+There was a general disappointment among the passengers, who, without
+reckoning the delay, saw themselves compelled to trudge fifteen miles
+over a plain covered with snow.  They grumbled and protested, and would
+certainly have thus attracted Phileas Fogg's attention if he had not
+been completely absorbed in his game.
+
+Passepartout found that he could not avoid telling his master what had
+occurred, and, with hanging head, he was turning towards the car, when
+the engineer, a true Yankee, named Forster called out, "Gentlemen,
+perhaps there is a way, after all, to get over."
+
+"On the bridge?" asked a passenger.
+
+"On the bridge."
+
+"With our train?"
+
+"With our train."
+
+Passepartout stopped short, and eagerly listened to the engineer.
+
+"But the bridge is unsafe," urged the conductor.
+
+"No matter," replied Forster; "I think that by putting on the very
+highest speed we might have a chance of getting over."
+
+"The devil!" muttered Passepartout.
+
+But a number of the passengers were at once attracted by the engineer's
+proposal, and Colonel Proctor was especially delighted, and found the
+plan a very feasible one.  He told stories about engineers leaping
+their trains over rivers without bridges, by putting on full steam; and
+many of those present avowed themselves of the engineer's mind.
+
+"We have fifty chances out of a hundred of getting over," said one.
+
+"Eighty! ninety!"
+
+Passepartout was astounded, and, though ready to attempt anything to
+get over Medicine Creek, thought the experiment proposed a little too
+American.  "Besides," thought he, "there's a still more simple way, and
+it does not even occur to any of these people!  Sir," said he aloud to
+one of the passengers, "the engineer's plan seems to me a little
+dangerous, but--"
+
+"Eighty chances!" replied the passenger, turning his back on him.
+
+"I know it," said Passepartout, turning to another passenger, "but a
+simple idea--"
+
+"Ideas are no use," returned the American, shrugging his shoulders, "as
+the engineer assures us that we can pass."
+
+"Doubtless," urged Passepartout, "we can pass, but perhaps it would be
+more prudent--"
+
+"What!  Prudent!" cried Colonel Proctor, whom this word seemed to
+excite prodigiously.  "At full speed, don't you see, at full speed!"
+
+"I know--I see," repeated Passepartout; "but it would be, if not more
+prudent, since that word displeases you, at least more natural--"
+
+"Who!  What!  What's the matter with this fellow?" cried several.
+
+The poor fellow did not know to whom to address himself.
+
+"Are you afraid?" asked Colonel Proctor.
+
+"I afraid?  Very well; I will show these people that a Frenchman can be
+as American as they!"
+
+"All aboard!" cried the conductor.
+
+"Yes, all aboard!" repeated Passepartout, and immediately.  "But they
+can't prevent me from thinking that it would be more natural for us to
+cross the bridge on foot, and let the train come after!"
+
+But no one heard this sage reflection, nor would anyone have
+acknowledged its justice.  The passengers resumed their places in the
+cars.  Passepartout took his seat without telling what had passed.  The
+whist-players were quite absorbed in their game.
+
+The locomotive whistled vigorously; the engineer, reversing the steam,
+backed the train for nearly a mile--retiring, like a jumper, in order
+to take a longer leap.  Then, with another whistle, he began to move
+forward; the train increased its speed, and soon its rapidity became
+frightful; a prolonged screech issued from the locomotive; the piston
+worked up and down twenty strokes to the second.  They perceived that
+the whole train, rushing on at the rate of a hundred miles an hour,
+hardly bore upon the rails at all.
+
+And they passed over!  It was like a flash.  No one saw the bridge.
+The train leaped, so to speak, from one bank to the other, and the
+engineer could not stop it until it had gone five miles beyond the
+station.  But scarcely had the train passed the river, when the bridge,
+completely ruined, fell with a crash into the rapids of Medicine Bow.
+
+
+
+
+Chapter XXIX
+
+IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET WITH
+ON AMERICAN RAILROADS
+
+
+The train pursued its course, that evening, without interruption,
+passing Fort Saunders, crossing Cheyne Pass, and reaching Evans Pass.
+The road here attained the highest elevation of the journey, eight
+thousand and ninety-two feet above the level of the sea.  The
+travellers had now only to descend to the Atlantic by limitless plains,
+levelled by nature.  A branch of the "grand trunk" led off southward to
+Denver, the capital of Colorado.  The country round about is rich in
+gold and silver, and more than fifty thousand inhabitants are already
+settled there.
+
+Thirteen hundred and eighty-two miles had been passed over from San
+Francisco, in three days and three nights; four days and nights more
+would probably bring them to New York.  Phileas Fogg was not as yet
+behind-hand.
+
+During the night Camp Walbach was passed on the left; Lodge Pole Creek
+ran parallel with the road, marking the boundary between the
+territories of Wyoming and Colorado.  They entered Nebraska at eleven,
+passed near Sedgwick, and touched at Julesburg, on the southern branch
+of the Platte River.
+
+It was here that the Union Pacific Railroad was inaugurated on the 23rd
+of October, 1867, by the chief engineer, General Dodge.  Two powerful
+locomotives, carrying nine cars of invited guests, amongst whom was
+Thomas C. Durant, vice-president of the road, stopped at this point;
+cheers were given, the Sioux and Pawnees performed an imitation Indian
+battle, fireworks were let off, and the first number of the Railway
+Pioneer was printed by a press brought on the train.  Thus was
+celebrated the inauguration of this great railroad, a mighty instrument
+of progress and civilisation, thrown across the desert, and destined to
+link together cities and towns which do not yet exist.  The whistle of
+the locomotive, more powerful than Amphion's lyre, was about to bid
+them rise from American soil.
+
+Fort McPherson was left behind at eight in the morning, and three
+hundred and fifty-seven miles had yet to be traversed before reaching
+Omaha.  The road followed the capricious windings of the southern
+branch of the Platte River, on its left bank.  At nine the train
+stopped at the important town of North Platte, built between the two
+arms of the river, which rejoin each other around it and form a single
+artery, a large tributary, whose waters empty into the Missouri a
+little above Omaha.
+
+The one hundred and first meridian was passed.
+
+Mr. Fogg and his partners had resumed their game; no one--not even the
+dummy--complained of the length of the trip.  Fix had begun by winning
+several guineas, which he seemed likely to lose; but he showed himself
+a not less eager whist-player than Mr. Fogg.  During the morning,
+chance distinctly favoured that gentleman.  Trumps and honours were
+showered upon his hands.
+
+Once, having resolved on a bold stroke, he was on the point of playing
+a spade, when a voice behind him said, "I should play a diamond."
+
+Mr. Fogg, Aouda, and Fix raised their heads, and beheld Colonel Proctor.
+
+Stamp Proctor and Phileas Fogg recognised each other at once.
+
+"Ah! it's you, is it, Englishman?" cried the colonel; "it's you who are
+going to play a spade!"
+
+"And who plays it," replied Phileas Fogg coolly, throwing down the ten
+of spades.
+
+"Well, it pleases me to have it diamonds," replied Colonel Proctor, in
+an insolent tone.
+
+He made a movement as if to seize the card which had just been played,
+adding, "You don't understand anything about whist."
+
+"Perhaps I do, as well as another," said Phileas Fogg, rising.
+
+"You have only to try, son of John Bull," replied the colonel.
+
+Aouda turned pale, and her blood ran cold.  She seized Mr. Fogg's arm
+and gently pulled him back.  Passepartout was ready to pounce upon the
+American, who was staring insolently at his opponent.  But Fix got up,
+and, going to Colonel Proctor said, "You forget that it is I with whom
+you have to deal, sir; for it was I whom you not only insulted, but
+struck!"
+
+"Mr. Fix," said Mr. Fogg, "pardon me, but this affair is mine, and mine
+only.  The colonel has again insulted me, by insisting that I should
+not play a spade, and he shall give me satisfaction for it."
+
+"When and where you will," replied the American, "and with whatever
+weapon you choose."
+
+Aouda in vain attempted to retain Mr. Fogg; as vainly did the detective
+endeavour to make the quarrel his.  Passepartout wished to throw the
+colonel out of the window, but a sign from his master checked him.
+Phileas Fogg left the car, and the American followed him upon the
+platform.  "Sir," said Mr. Fogg to his adversary, "I am in a great
+hurry to get back to Europe, and any delay whatever will be greatly to
+my disadvantage."
+
+"Well, what's that to me?" replied Colonel Proctor.
+
+"Sir," said Mr. Fogg, very politely, "after our meeting at San
+Francisco, I determined to return to America and find you as soon as I
+had completed the business which called me to England."
+
+"Really!"
+
+"Will you appoint a meeting for six months hence?"
+
+"Why not ten years hence?"
+
+"I say six months," returned Phileas Fogg; "and I shall be at the place
+of meeting promptly."
+
+"All this is an evasion," cried Stamp Proctor.  "Now or never!"
+
+"Very good.  You are going to New York?"
+
+"No."
+
+"To Chicago?"
+
+"No."
+
+"To Omaha?"
+
+"What difference is it to you?  Do you know Plum Creek?"
+
+"No," replied Mr. Fogg.
+
+"It's the next station.  The train will be there in an hour, and will
+stop there ten minutes.  In ten minutes several revolver-shots could be
+exchanged."
+
+"Very well," said Mr. Fogg.  "I will stop at Plum Creek."
+
+"And I guess you'll stay there too," added the American insolently.
+
+"Who knows?" replied Mr. Fogg, returning to the car as coolly as usual.
+He began to reassure Aouda, telling her that blusterers were never to
+be feared, and begged Fix to be his second at the approaching duel, a
+request which the detective could not refuse.  Mr. Fogg resumed the
+interrupted game with perfect calmness.
+
+At eleven o'clock the locomotive's whistle announced that they were
+approaching Plum Creek station.  Mr. Fogg rose, and, followed by Fix,
+went out upon the platform.  Passepartout accompanied him, carrying a
+pair of revolvers.  Aouda remained in the car, as pale as death.
+
+The door of the next car opened, and Colonel Proctor appeared on the
+platform, attended by a Yankee of his own stamp as his second.  But
+just as the combatants were about to step from the train, the conductor
+hurried up, and shouted, "You can't get off, gentlemen!"
+
+"Why not?" asked the colonel.
+
+"We are twenty minutes late, and we shall not stop."
+
+"But I am going to fight a duel with this gentleman."
+
+"I am sorry," said the conductor; "but we shall be off at once.
+There's the bell ringing now."
+
+The train started.
+
+"I'm really very sorry, gentlemen," said the conductor.  "Under any
+other circumstances I should have been happy to oblige you.  But, after
+all, as you have not had time to fight here, why not fight as we go
+along?"
+
+"That wouldn't be convenient, perhaps, for this gentleman," said the
+colonel, in a jeering tone.
+
+"It would be perfectly so," replied Phileas Fogg.
+
+"Well, we are really in America," thought Passepartout, "and the
+conductor is a gentleman of the first order!"
+
+So muttering, he followed his master.
+
+The two combatants, their seconds, and the conductor passed through the
+cars to the rear of the train.  The last car was only occupied by a
+dozen passengers, whom the conductor politely asked if they would not
+be so kind as to leave it vacant for a few moments, as two gentlemen
+had an affair of honour to settle.  The passengers granted the request
+with alacrity, and straightway disappeared on the platform.
+
+The car, which was some fifty feet long, was very convenient for their
+purpose.  The adversaries might march on each other in the aisle, and
+fire at their ease.  Never was duel more easily arranged.  Mr. Fogg and
+Colonel Proctor, each provided with two six-barrelled revolvers,
+entered the car.  The seconds, remaining outside, shut them in.  They
+were to begin firing at the first whistle of the locomotive.  After an
+interval of two minutes, what remained of the two gentlemen would be
+taken from the car.
+
+Nothing could be more simple.  Indeed, it was all so simple that Fix
+and Passepartout felt their hearts beating as if they would crack.
+They were listening for the whistle agreed upon, when suddenly savage
+cries resounded in the air, accompanied by reports which certainly did
+not issue from the car where the duellists were.  The reports continued
+in front and the whole length of the train.  Cries of terror proceeded
+from the interior of the cars.
+
+Colonel Proctor and Mr. Fogg, revolvers in hand, hastily quitted their
+prison, and rushed forward where the noise was most clamorous.  They
+then perceived that the train was attacked by a band of Sioux.
+
+This was not the first attempt of these daring Indians, for more than
+once they had waylaid trains on the road.  A hundred of them had,
+according to their habit, jumped upon the steps without stopping the
+train, with the ease of a clown mounting a horse at full gallop.
+
+The Sioux were armed with guns, from which came the reports, to which
+the passengers, who were almost all armed, responded by revolver-shots.
+
+The Indians had first mounted the engine, and half stunned the engineer
+and stoker with blows from their muskets.  A Sioux chief, wishing to
+stop the train, but not knowing how to work the regulator, had opened
+wide instead of closing the steam-valve, and the locomotive was
+plunging forward with terrific velocity.
+
+The Sioux had at the same time invaded the cars, skipping like enraged
+monkeys over the roofs, thrusting open the doors, and fighting hand to
+hand with the passengers.  Penetrating the baggage-car, they pillaged
+it, throwing the trunks out of the train.  The cries and shots were
+constant.  The travellers defended themselves bravely; some of the cars
+were barricaded, and sustained a siege, like moving forts, carried
+along at a speed of a hundred miles an hour.
+
+Aouda behaved courageously from the first.  She defended herself like a
+true heroine with a revolver, which she shot through the broken windows
+whenever a savage made his appearance.  Twenty Sioux had fallen
+mortally wounded to the ground, and the wheels crushed those who fell
+upon the rails as if they had been worms.  Several passengers, shot or
+stunned, lay on the seats.
+
+It was necessary to put an end to the struggle, which had lasted for
+ten minutes, and which would result in the triumph of the Sioux if the
+train was not stopped.  Fort Kearney station, where there was a
+garrison, was only two miles distant; but, that once passed, the Sioux
+would be masters of the train between Fort Kearney and the station
+beyond.
+
+The conductor was fighting beside Mr. Fogg, when he was shot and fell.
+At the same moment he cried, "Unless the train is stopped in five
+minutes, we are lost!"
+
+"It shall be stopped," said Phileas Fogg, preparing to rush from the
+car.
+
+"Stay, monsieur," cried Passepartout; "I will go."
+
+Mr. Fogg had not time to stop the brave fellow, who, opening a door
+unperceived by the Indians, succeeded in slipping under the car; and
+while the struggle continued and the balls whizzed across each other
+over his head, he made use of his old acrobatic experience, and with
+amazing agility worked his way under the cars, holding on to the
+chains, aiding himself by the brakes and edges of the sashes, creeping
+from one car to another with marvellous skill, and thus gaining the
+forward end of the train.
+
+There, suspended by one hand between the baggage-car and the tender,
+with the other he loosened the safety chains; but, owing to the
+traction, he would never have succeeded in unscrewing the yoking-bar,
+had not a violent concussion jolted this bar out.  The train, now
+detached from the engine, remained a little behind, whilst the
+locomotive rushed forward with increased speed.
+
+Carried on by the force already acquired, the train still moved for
+several minutes; but the brakes were worked and at last they stopped,
+less than a hundred feet from Kearney station.
+
+The soldiers of the fort, attracted by the shots, hurried up; the Sioux
+had not expected them, and decamped in a body before the train entirely
+stopped.
+
+But when the passengers counted each other on the station platform
+several were found missing; among others the courageous Frenchman,
+whose devotion had just saved them.
+
+
+
+
+Chapter XXX
+
+IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+
+Three passengers including Passepartout had disappeared.  Had they been
+killed in the struggle?  Were they taken prisoners by the Sioux?  It
+was impossible to tell.
+
+There were many wounded, but none mortally.  Colonel Proctor was one of
+the most seriously hurt; he had fought bravely, and a ball had entered
+his groin.  He was carried into the station with the other wounded
+passengers, to receive such attention as could be of avail.
+
+Aouda was safe; and Phileas Fogg, who had been in the thickest of the
+fight, had not received a scratch.  Fix was slightly wounded in the
+arm.  But Passepartout was not to be found, and tears coursed down
+Aouda's cheeks.
+
+All the passengers had got out of the train, the wheels of which were
+stained with blood.  From the tyres and spokes hung ragged pieces of
+flesh.  As far as the eye could reach on the white plain behind, red
+trails were visible.  The last Sioux were disappearing in the south,
+along the banks of Republican River.
+
+Mr. Fogg, with folded arms, remained motionless.  He had a serious
+decision to make.  Aouda, standing near him, looked at him without
+speaking, and he understood her look.  If his servant was a prisoner,
+ought he not to risk everything to rescue him from the Indians?  "I
+will find him, living or dead," said he quietly to Aouda.
+
+"Ah, Mr.--Mr. Fogg!" cried she, clasping his hands and covering them
+with tears.
+
+"Living," added Mr. Fogg, "if we do not lose a moment."
+
+Phileas Fogg, by this resolution, inevitably sacrificed himself; he
+pronounced his own doom.  The delay of a single day would make him lose
+the steamer at New York, and his bet would be certainly lost.  But as
+he thought, "It is my duty," he did not hesitate.
+
+The commanding officer of Fort Kearney was there.  A hundred of his
+soldiers had placed themselves in a position to defend the station,
+should the Sioux attack it.
+
+"Sir," said Mr. Fogg to the captain, "three passengers have
+disappeared."
+
+"Dead?" asked the captain.
+
+"Dead or prisoners; that is the uncertainty which must be solved.  Do
+you propose to pursue the Sioux?"
+
+"That's a serious thing to do, sir," returned the captain.  "These
+Indians may retreat beyond the Arkansas, and I cannot leave the fort
+unprotected."
+
+"The lives of three men are in question, sir," said Phileas Fogg.
+
+"Doubtless; but can I risk the lives of fifty men to save three?"
+
+"I don't know whether you can, sir; but you ought to do so."
+
+"Nobody here," returned the other, "has a right to teach me my duty."
+
+"Very well," said Mr. Fogg, coldly.  "I will go alone."
+
+"You, sir!" cried Fix, coming up; "you go alone in pursuit of the
+Indians?"
+
+"Would you have me leave this poor fellow to perish--him to whom every
+one present owes his life?  I shall go."
+
+"No, sir, you shall not go alone," cried the captain, touched in spite
+of himself.  "No! you are a brave man.  Thirty volunteers!" he added,
+turning to the soldiers.
+
+The whole company started forward at once.  The captain had only to
+pick his men.  Thirty were chosen, and an old sergeant placed at their
+head.
+
+"Thanks, captain," said Mr. Fogg.
+
+"Will you let me go with you?" asked Fix.
+
+"Do as you please, sir.  But if you wish to do me a favour, you will
+remain with Aouda.  In case anything should happen to me--"
+
+A sudden pallor overspread the detective's face.  Separate himself from
+the man whom he had so persistently followed step by step!  Leave him
+to wander about in this desert!  Fix gazed attentively at Mr. Fogg,
+and, despite his suspicions and of the struggle which was going on
+within him, he lowered his eyes before that calm and frank look.
+
+"I will stay," said he.
+
+A few moments after, Mr. Fogg pressed the young woman's hand, and,
+having confided to her his precious carpet-bag, went off with the
+sergeant and his little squad.  But, before going, he had said to the
+soldiers, "My friends, I will divide five thousand dollars among you,
+if we save the prisoners."
+
+It was then a little past noon.
+
+Aouda retired to a waiting-room, and there she waited alone, thinking
+of the simple and noble generosity, the tranquil courage of Phileas
+Fogg.  He had sacrificed his fortune, and was now risking his life, all
+without hesitation, from duty, in silence.
+
+Fix did not have the same thoughts, and could scarcely conceal his
+agitation.  He walked feverishly up and down the platform, but soon
+resumed his outward composure.  He now saw the folly of which he had
+been guilty in letting Fogg go alone.  What!  This man, whom he had
+just followed around the world, was permitted now to separate himself
+from him!  He began to accuse and abuse himself, and, as if he were
+director of police, administered to himself a sound lecture for his
+greenness.
+
+"I have been an idiot!" he thought, "and this man will see it.  He has
+gone, and won't come back!  But how is it that I, Fix, who have in my
+pocket a warrant for his arrest, have been so fascinated by him?
+Decidedly, I am nothing but an ass!"
+
+So reasoned the detective, while the hours crept by all too slowly.  He
+did not know what to do.  Sometimes he was tempted to tell Aouda all;
+but he could not doubt how the young woman would receive his
+confidences.  What course should he take?  He thought of pursuing Fogg
+across the vast white plains; it did not seem impossible that he might
+overtake him.  Footsteps were easily printed on the snow!  But soon,
+under a new sheet, every imprint would be effaced.
+
+Fix became discouraged.  He felt a sort of insurmountable longing to
+abandon the game altogether.  He could now leave Fort Kearney station,
+and pursue his journey homeward in peace.
+
+Towards two o'clock in the afternoon, while it was snowing hard, long
+whistles were heard approaching from the east.  A great shadow,
+preceded by a wild light, slowly advanced, appearing still larger
+through the mist, which gave it a fantastic aspect.  No train was
+expected from the east, neither had there been time for the succour
+asked for by telegraph to arrive; the train from Omaha to San Francisco
+was not due till the next day.  The mystery was soon explained.
+
+The locomotive, which was slowly approaching with deafening whistles,
+was that which, having been detached from the train, had continued its
+route with such terrific rapidity, carrying off the unconscious
+engineer and stoker.  It had run several miles, when, the fire becoming
+low for want of fuel, the steam had slackened; and it had finally
+stopped an hour after, some twenty miles beyond Fort Kearney.  Neither
+the engineer nor the stoker was dead, and, after remaining for some
+time in their swoon, had come to themselves.  The train had then
+stopped.  The engineer, when he found himself in the desert, and the
+locomotive without cars, understood what had happened.  He could not
+imagine how the locomotive had become separated from the train; but he
+did not doubt that the train left behind was in distress.
+
+He did not hesitate what to do.  It would be prudent to continue on to
+Omaha, for it would be dangerous to return to the train, which the
+Indians might still be engaged in pillaging.  Nevertheless, he began to
+rebuild the fire in the furnace; the pressure again mounted, and the
+locomotive returned, running backwards to Fort Kearney.  This it was
+which was whistling in the mist.
+
+The travellers were glad to see the locomotive resume its place at the
+head of the train.  They could now continue the journey so terribly
+interrupted.
+
+Aouda, on seeing the locomotive come up, hurried out of the station,
+and asked the conductor, "Are you going to start?"
+
+"At once, madam."
+
+"But the prisoners, our unfortunate fellow-travellers--"
+
+"I cannot interrupt the trip," replied the conductor.  "We are already
+three hours behind time."
+
+"And when will another train pass here from San Francisco?"
+
+"To-morrow evening, madam."
+
+"To-morrow evening!  But then it will be too late!  We must wait--"
+
+"It is impossible," responded the conductor.  "If you wish to go,
+please get in."
+
+"I will not go," said Aouda.
+
+Fix had heard this conversation.  A little while before, when there was
+no prospect of proceeding on the journey, he had made up his mind to
+leave Fort Kearney; but now that the train was there, ready to start,
+and he had only to take his seat in the car, an irresistible influence
+held him back.  The station platform burned his feet, and he could not
+stir.  The conflict in his mind again began; anger and failure stifled
+him.  He wished to struggle on to the end.
+
+Meanwhile the passengers and some of the wounded, among them Colonel
+Proctor, whose injuries were serious, had taken their places in the
+train.  The buzzing of the over-heated boiler was heard, and the steam
+was escaping from the valves.  The engineer whistled, the train
+started, and soon disappeared, mingling its white smoke with the eddies
+of the densely falling snow.
+
+The detective had remained behind.
+
+Several hours passed.  The weather was dismal, and it was very cold.
+Fix sat motionless on a bench in the station; he might have been
+thought asleep.  Aouda, despite the storm, kept coming out of the
+waiting-room, going to the end of the platform, and peering through the
+tempest of snow, as if to pierce the mist which narrowed the horizon
+around her, and to hear, if possible, some welcome sound.  She heard
+and saw nothing.  Then she would return, chilled through, to issue out
+again after the lapse of a few moments, but always in vain.
+
+Evening came, and the little band had not returned.  Where could they
+be?  Had they found the Indians, and were they having a conflict with
+them, or were they still wandering amid the mist?  The commander of the
+fort was anxious, though he tried to conceal his apprehensions.  As
+night approached, the snow fell less plentifully, but it became
+intensely cold.  Absolute silence rested on the plains.  Neither flight
+of bird nor passing of beast troubled the perfect calm.
+
+Throughout the night Aouda, full of sad forebodings, her heart stifled
+with anguish, wandered about on the verge of the plains.  Her
+imagination carried her far off, and showed her innumerable dangers.
+What she suffered through the long hours it would be impossible to
+describe.
+
+Fix remained stationary in the same place, but did not sleep.  Once a
+man approached and spoke to him, and the detective merely replied by
+shaking his head.
+
+Thus the night passed.  At dawn, the half-extinguished disc of the sun
+rose above a misty horizon; but it was now possible to recognise
+objects two miles off.  Phileas Fogg and the squad had gone southward;
+in the south all was still vacancy.  It was then seven o'clock.
+
+The captain, who was really alarmed, did not know what course to take.
+
+Should he send another detachment to the rescue of the first?  Should
+he sacrifice more men, with so few chances of saving those already
+sacrificed?  His hesitation did not last long, however.  Calling one of
+his lieutenants, he was on the point of ordering a reconnaissance, when
+gunshots were heard.  Was it a signal?  The soldiers rushed out of the
+fort, and half a mile off they perceived a little band returning in
+good order.
+
+Mr. Fogg was marching at their head, and just behind him were
+Passepartout and the other two travellers, rescued from the Sioux.
+
+They had met and fought the Indians ten miles south of Fort Kearney.
+Shortly before the detachment arrived, Passepartout and his companions
+had begun to struggle with their captors, three of whom the Frenchman
+had felled with his fists, when his master and the soldiers hastened up
+to their relief.
+
+All were welcomed with joyful cries.  Phileas Fogg distributed the
+reward he had promised to the soldiers, while Passepartout, not without
+reason, muttered to himself, "It must certainly be confessed that I
+cost my master dear!"
+
+Fix, without saying a word, looked at Mr. Fogg, and it would have been
+difficult to analyse the thoughts which struggled within him.  As for
+Aouda, she took her protector's hand and pressed it in her own, too
+much moved to speak.
+
+Meanwhile, Passepartout was looking about for the train; he thought he
+should find it there, ready to start for Omaha, and he hoped that the
+time lost might be regained.
+
+"The train! the train!" cried he.
+
+"Gone," replied Fix.
+
+"And when does the next train pass here?" said Phileas Fogg.
+
+"Not till this evening."
+
+"Ah!" returned the impassible gentleman quietly.
+
+
+
+
+Chapter XXXI
+
+IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS OF
+PHILEAS FOGG
+
+
+Phileas Fogg found himself twenty hours behind time.  Passepartout, the
+involuntary cause of this delay, was desperate.  He had ruined his
+master!
+
+At this moment the detective approached Mr. Fogg, and, looking him
+intently in the face, said:
+
+"Seriously, sir, are you in great haste?"
+
+"Quite seriously."
+
+"I have a purpose in asking," resumed Fix.  "Is it absolutely necessary
+that you should be in New York on the 11th, before nine o'clock in the
+evening, the time that the steamer leaves for Liverpool?"
+
+"It is absolutely necessary."
+
+"And, if your journey had not been interrupted by these Indians, you
+would have reached New York on the morning of the 11th?"
+
+"Yes; with eleven hours to spare before the steamer left."
+
+"Good! you are therefore twenty hours behind.  Twelve from twenty
+leaves eight.  You must regain eight hours.  Do you wish to try to do
+so?"
+
+"On foot?" asked Mr. Fogg.
+
+"No; on a sledge," replied Fix.  "On a sledge with sails.  A man has
+proposed such a method to me."
+
+It was the man who had spoken to Fix during the night, and whose offer
+he had refused.
+
+Phileas Fogg did not reply at once; but Fix, having pointed out the
+man, who was walking up and down in front of the station, Mr. Fogg went
+up to him.  An instant after, Mr. Fogg and the American, whose name was
+Mudge, entered a hut built just below the fort.
+
+There Mr. Fogg examined a curious vehicle, a kind of frame on two long
+beams, a little raised in front like the runners of a sledge, and upon
+which there was room for five or six persons.  A high mast was fixed on
+the frame, held firmly by metallic lashings, to which was attached a
+large brigantine sail.  This mast held an iron stay upon which to hoist
+a jib-sail.  Behind, a sort of rudder served to guide the vehicle.  It
+was, in short, a sledge rigged like a sloop.  During the winter, when
+the trains are blocked up by the snow, these sledges make extremely
+rapid journeys across the frozen plains from one station to another.
+Provided with more sails than a cutter, and with the wind behind them,
+they slip over the surface of the prairies with a speed equal if not
+superior to that of the express trains.
+
+Mr. Fogg readily made a bargain with the owner of this land-craft.  The
+wind was favourable, being fresh, and blowing from the west.  The snow
+had hardened, and Mudge was very confident of being able to transport
+Mr. Fogg in a few hours to Omaha.  Thence the trains eastward run
+frequently to Chicago and New York.  It was not impossible that the
+lost time might yet be recovered; and such an opportunity was not to be
+rejected.
+
+Not wishing to expose Aouda to the discomforts of travelling in the
+open air, Mr. Fogg proposed to leave her with Passepartout at Fort
+Kearney, the servant taking upon himself to escort her to Europe by a
+better route and under more favourable conditions.  But Aouda refused
+to separate from Mr. Fogg, and Passepartout was delighted with her
+decision; for nothing could induce him to leave his master while Fix
+was with him.
+
+It would be difficult to guess the detective's thoughts.  Was this
+conviction shaken by Phileas Fogg's return, or did he still regard him
+as an exceedingly shrewd rascal, who, his journey round the world
+completed, would think himself absolutely safe in England?  Perhaps
+Fix's opinion of Phileas Fogg was somewhat modified; but he was
+nevertheless resolved to do his duty, and to hasten the return of the
+whole party to England as much as possible.
+
+At eight o'clock the sledge was ready to start.  The passengers took
+their places on it, and wrapped themselves up closely in their
+travelling-cloaks.  The two great sails were hoisted, and under the
+pressure of the wind the sledge slid over the hardened snow with a
+velocity of forty miles an hour.
+
+The distance between Fort Kearney and Omaha, as the birds fly, is at
+most two hundred miles.  If the wind held good, the distance might be
+traversed in five hours; if no accident happened the sledge might reach
+Omaha by one o'clock.
+
+What a journey!  The travellers, huddled close together, could not
+speak for the cold, intensified by the rapidity at which they were
+going.  The sledge sped on as lightly as a boat over the waves.  When
+the breeze came skimming the earth the sledge seemed to be lifted off
+the ground by its sails.  Mudge, who was at the rudder, kept in a
+straight line, and by a turn of his hand checked the lurches which the
+vehicle had a tendency to make.  All the sails were up, and the jib was
+so arranged as not to screen the brigantine.  A top-mast was hoisted,
+and another jib, held out to the wind, added its force to the other
+sails.  Although the speed could not be exactly estimated, the sledge
+could not be going at less than forty miles an hour.
+
+"If nothing breaks," said Mudge, "we shall get there!"
+
+Mr. Fogg had made it for Mudge's interest to reach Omaha within the
+time agreed on, by the offer of a handsome reward.
+
+The prairie, across which the sledge was moving in a straight line, was
+as flat as a sea.  It seemed like a vast frozen lake.  The railroad
+which ran through this section ascended from the south-west to the
+north-west by Great Island, Columbus, an important Nebraska town,
+Schuyler, and Fremont, to Omaha.  It followed throughout the right bank
+of the Platte River.  The sledge, shortening this route, took a chord
+of the arc described by the railway.  Mudge was not afraid of being
+stopped by the Platte River, because it was frozen.  The road, then,
+was quite clear of obstacles, and Phileas Fogg had but two things to
+fear--an accident to the sledge, and a change or calm in the wind.
+
+But the breeze, far from lessening its force, blew as if to bend the
+mast, which, however, the metallic lashings held firmly.  These
+lashings, like the chords of a stringed instrument, resounded as if
+vibrated by a violin bow.  The sledge slid along in the midst of a
+plaintively intense melody.
+
+"Those chords give the fifth and the octave," said Mr. Fogg.
+
+These were the only words he uttered during the journey.  Aouda, cosily
+packed in furs and cloaks, was sheltered as much as possible from the
+attacks of the freezing wind.  As for Passepartout, his face was as red
+as the sun's disc when it sets in the mist, and he laboriously inhaled
+the biting air.  With his natural buoyancy of spirits, he began to hope
+again.  They would reach New York on the evening, if not on the
+morning, of the 11th, and there was still some chances that it would be
+before the steamer sailed for Liverpool.
+
+Passepartout even felt a strong desire to grasp his ally, Fix, by the
+hand.  He remembered that it was the detective who procured the sledge,
+the only means of reaching Omaha in time; but, checked by some
+presentiment, he kept his usual reserve.  One thing, however,
+Passepartout would never forget, and that was the sacrifice which Mr.
+Fogg had made, without hesitation, to rescue him from the Sioux.  Mr.
+Fogg had risked his fortune and his life. No!  His servant would never
+forget that!
+
+While each of the party was absorbed in reflections so different, the
+sledge flew past over the vast carpet of snow.  The creeks it passed
+over were not perceived.  Fields and streams disappeared under the
+uniform whiteness.  The plain was absolutely deserted.  Between the
+Union Pacific road and the branch which unites Kearney with Saint
+Joseph it formed a great uninhabited island.  Neither village, station,
+nor fort appeared.  From time to time they sped by some phantom-like
+tree, whose white skeleton twisted and rattled in the wind.  Sometimes
+flocks of wild birds rose, or bands of gaunt, famished, ferocious
+prairie-wolves ran howling after the sledge.  Passepartout, revolver in
+hand, held himself ready to fire on those which came too near.  Had an
+accident then happened to the sledge, the travellers, attacked by these
+beasts, would have been in the most terrible danger; but it held on its
+even course, soon gained on the wolves, and ere long left the howling
+band at a safe distance behind.
+
+About noon Mudge perceived by certain landmarks that he was crossing
+the Platte River.  He said nothing, but he felt certain that he was now
+within twenty miles of Omaha.  In less than an hour he left the rudder
+and furled his sails, whilst the sledge, carried forward by the great
+impetus the wind had given it, went on half a mile further with its
+sails unspread.
+
+It stopped at last, and Mudge, pointing to a mass of roofs white with
+snow, said: "We have got there!"
+
+Arrived!  Arrived at the station which is in daily communication, by
+numerous trains, with the Atlantic seaboard!
+
+Passepartout and Fix jumped off, stretched their stiffened limbs, and
+aided Mr. Fogg and the young woman to descend from the sledge.  Phileas
+Fogg generously rewarded Mudge, whose hand Passepartout warmly grasped,
+and the party directed their steps to the Omaha railway station.
+
+The Pacific Railroad proper finds its terminus at this important
+Nebraska town.  Omaha is connected with Chicago by the Chicago and Rock
+Island Railroad, which runs directly east, and passes fifty stations.
+
+A train was ready to start when Mr. Fogg and his party reached the
+station, and they only had time to get into the cars.  They had seen
+nothing of Omaha; but Passepartout confessed to himself that this was
+not to be regretted, as they were not travelling to see the sights.
+
+The train passed rapidly across the State of Iowa, by Council Bluffs,
+Des Moines, and Iowa City.  During the night it crossed the Mississippi
+at Davenport, and by Rock Island entered Illinois.  The next day, which
+was the 10th, at four o'clock in the evening, it reached Chicago,
+already risen from its ruins, and more proudly seated than ever on the
+borders of its beautiful Lake Michigan.
+
+Nine hundred miles separated Chicago from New York; but trains are not
+wanting at Chicago.  Mr. Fogg passed at once from one to the other, and
+the locomotive of the Pittsburgh, Fort Wayne, and Chicago Railway left
+at full speed, as if it fully comprehended that that gentleman had no
+time to lose.  It traversed Indiana, Ohio, Pennsylvania, and New Jersey
+like a flash, rushing through towns with antique names, some of which
+had streets and car-tracks, but as yet no houses.  At last the Hudson
+came into view; and, at a quarter-past eleven in the evening of the
+11th, the train stopped in the station on the right bank of the river,
+before the very pier of the Cunard line.
+
+The China, for Liverpool, had started three-quarters of an hour before!
+
+
+
+
+Chapter XXXII
+
+IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD FORTUNE
+
+
+The China, in leaving, seemed to have carried off Phileas Fogg's last
+hope.  None of the other steamers were able to serve his projects.  The
+Pereire, of the French Transatlantic Company, whose admirable steamers
+are equal to any in speed and comfort, did not leave until the 14th;
+the Hamburg boats did not go directly to Liverpool or London, but to
+Havre; and the additional trip from Havre to Southampton would render
+Phileas Fogg's last efforts of no avail.  The Inman steamer did not
+depart till the next day, and could not cross the Atlantic in time to
+save the wager.
+
+Mr. Fogg learned all this in consulting his Bradshaw, which gave him
+the daily movements of the trans-Atlantic steamers.
+
+Passepartout was crushed; it overwhelmed him to lose the boat by
+three-quarters of an hour.  It was his fault, for, instead of helping
+his master, he had not ceased putting obstacles in his path!  And when
+he recalled all the incidents of the tour, when he counted up the sums
+expended in pure loss and on his own account, when he thought that the
+immense stake, added to the heavy charges of this useless journey,
+would completely ruin Mr. Fogg, he overwhelmed himself with bitter
+self-accusations.  Mr. Fogg, however, did not reproach him; and, on
+leaving the Cunard pier, only said: "We will consult about what is best
+to-morrow.  Come."
+
+The party crossed the Hudson in the Jersey City ferryboat, and drove in
+a carriage to the St. Nicholas Hotel, on Broadway.  Rooms were engaged,
+and the night passed, briefly to Phileas Fogg, who slept profoundly,
+but very long to Aouda and the others, whose agitation did not permit
+them to rest.
+
+The next day was the 12th of December.  From seven in the morning of
+the 12th to a quarter before nine in the evening of the 21st there were
+nine days, thirteen hours, and forty-five minutes.  If Phileas Fogg had
+left in the China, one of the fastest steamers on the Atlantic, he
+would have reached Liverpool, and then London, within the period agreed
+upon.
+
+Mr. Fogg left the hotel alone, after giving Passepartout instructions
+to await his return, and inform Aouda to be ready at an instant's
+notice.  He proceeded to the banks of the Hudson, and looked about
+among the vessels moored or anchored in the river, for any that were
+about to depart.  Several had departure signals, and were preparing to
+put to sea at morning tide; for in this immense and admirable port
+there is not one day in a hundred that vessels do not set out for every
+quarter of the globe.  But they were mostly sailing vessels, of which,
+of course, Phileas Fogg could make no use.
+
+He seemed about to give up all hope, when he espied, anchored at the
+Battery, a cable's length off at most, a trading vessel, with a screw,
+well-shaped, whose funnel, puffing a cloud of smoke, indicated that she
+was getting ready for departure.
+
+Phileas Fogg hailed a boat, got into it, and soon found himself on
+board the Henrietta, iron-hulled, wood-built above.  He ascended to the
+deck, and asked for the captain, who forthwith presented himself.  He
+was a man of fifty, a sort of sea-wolf, with big eyes, a complexion of
+oxidised copper, red hair and thick neck, and a growling voice.
+
+"The captain?" asked Mr. Fogg.
+
+"I am the captain."
+
+"I am Phileas Fogg, of London."
+
+"And I am Andrew Speedy, of Cardiff."
+
+"You are going to put to sea?"
+
+"In an hour."
+
+"You are bound for--"
+
+"Bordeaux."
+
+"And your cargo?"
+
+"No freight.  Going in ballast."
+
+"Have you any passengers?"
+
+"No passengers.  Never have passengers.  Too much in the way."
+
+"Is your vessel a swift one?"
+
+"Between eleven and twelve knots.  The Henrietta, well known."
+
+"Will you carry me and three other persons to Liverpool?"
+
+"To Liverpool?  Why not to China?"
+
+"I said Liverpool."
+
+"No!"
+
+"No?"
+
+"No.  I am setting out for Bordeaux, and shall go to Bordeaux."
+
+"Money is no object?"
+
+"None."
+
+The captain spoke in a tone which did not admit of a reply.
+
+"But the owners of the Henrietta--" resumed Phileas Fogg.
+
+"The owners are myself," replied the captain.  "The vessel belongs to
+me."
+
+"I will freight it for you."
+
+"No."
+
+"I will buy it of you."
+
+"No."
+
+Phileas Fogg did not betray the least disappointment; but the situation
+was a grave one.  It was not at New York as at Hong Kong, nor with the
+captain of the Henrietta as with the captain of the Tankadere.  Up to
+this time money had smoothed away every obstacle.  Now money failed.
+
+Still, some means must be found to cross the Atlantic on a boat, unless
+by balloon--which would have been venturesome, besides not being
+capable of being put in practice.  It seemed that Phileas Fogg had an
+idea, for he said to the captain, "Well, will you carry me to Bordeaux?"
+
+"No, not if you paid me two hundred dollars."
+
+"I offer you two thousand."
+
+"Apiece?"
+
+"Apiece."
+
+"And there are four of you?"
+
+"Four."
+
+Captain Speedy began to scratch his head.  There were eight thousand
+dollars to gain, without changing his route; for which it was well
+worth conquering the repugnance he had for all kinds of passengers.
+Besides, passengers at two thousand dollars are no longer passengers,
+but valuable merchandise.  "I start at nine o'clock," said Captain
+Speedy, simply.  "Are you and your party ready?"
+
+"We will be on board at nine o'clock," replied, no less simply, Mr.
+Fogg.
+
+It was half-past eight.  To disembark from the Henrietta, jump into a
+hack, hurry to the St. Nicholas, and return with Aouda, Passepartout,
+and even the inseparable Fix was the work of a brief time, and was
+performed by Mr. Fogg with the coolness which never abandoned him.
+They were on board when the Henrietta made ready to weigh anchor.
+
+When Passepartout heard what this last voyage was going to cost, he
+uttered a prolonged "Oh!" which extended throughout his vocal gamut.
+
+As for Fix, he said to himself that the Bank of England would certainly
+not come out of this affair well indemnified.  When they reached
+England, even if Mr. Fogg did not throw some handfuls of bank-bills
+into the sea, more than seven thousand pounds would have been spent!
+
+
+
+
+Chapter XXXIII
+
+IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+
+An hour after, the Henrietta passed the lighthouse which marks the
+entrance of the Hudson, turned the point of Sandy Hook, and put to sea.
+During the day she skirted Long Island, passed Fire Island, and
+directed her course rapidly eastward.
+
+At noon the next day, a man mounted the bridge to ascertain the
+vessel's position.  It might be thought that this was Captain Speedy.
+Not the least in the world.  It was Phileas Fogg, Esquire.  As for
+Captain Speedy, he was shut up in his cabin under lock and key, and was
+uttering loud cries, which signified an anger at once pardonable and
+excessive.
+
+What had happened was very simple.  Phileas Fogg wished to go to
+Liverpool, but the captain would not carry him there.  Then Phileas
+Fogg had taken passage for Bordeaux, and, during the thirty hours he
+had been on board, had so shrewdly managed with his banknotes that the
+sailors and stokers, who were only an occasional crew, and were not on
+the best terms with the captain, went over to him in a body.  This was
+why Phileas Fogg was in command instead of Captain Speedy; why the
+captain was a prisoner in his cabin; and why, in short, the Henrietta
+was directing her course towards Liverpool.  It was very clear, to see
+Mr. Fogg manage the craft, that he had been a sailor.
+
+How the adventure ended will be seen anon.  Aouda was anxious, though
+she said nothing.  As for Passepartout, he thought Mr. Fogg's manoeuvre
+simply glorious.  The captain had said "between eleven and twelve
+knots," and the Henrietta confirmed his prediction.
+
+If, then--for there were "ifs" still--the sea did not become too
+boisterous, if the wind did not veer round to the east, if no accident
+happened to the boat or its machinery, the Henrietta might cross the
+three thousand miles from New York to Liverpool in the nine days,
+between the 12th and the 21st of December.  It is true that, once
+arrived, the affair on board the Henrietta, added to that of the Bank
+of England, might create more difficulties for Mr. Fogg than he
+imagined or could desire.
+
+During the first days, they went along smoothly enough.  The sea was
+not very unpropitious, the wind seemed stationary in the north-east,
+the sails were hoisted, and the Henrietta ploughed across the waves
+like a real trans-Atlantic steamer.
+
+Passepartout was delighted.  His master's last exploit, the
+consequences of which he ignored, enchanted him.  Never had the crew
+seen so jolly and dexterous a fellow.  He formed warm friendships with
+the sailors, and amazed them with his acrobatic feats.  He thought they
+managed the vessel like gentlemen, and that the stokers fired up like
+heroes.  His loquacious good-humour infected everyone.  He had
+forgotten the past, its vexations and delays.  He only thought of the
+end, so nearly accomplished; and sometimes he boiled over with
+impatience, as if heated by the furnaces of the Henrietta.  Often,
+also, the worthy fellow revolved around Fix, looking at him with a
+keen, distrustful eye; but he did not speak to him, for their old
+intimacy no longer existed.
+
+Fix, it must be confessed, understood nothing of what was going on.
+The conquest of the Henrietta, the bribery of the crew, Fogg managing
+the boat like a skilled seaman, amazed and confused him.  He did not
+know what to think.  For, after all, a man who began by stealing
+fifty-five thousand pounds might end by stealing a vessel; and Fix was
+not unnaturally inclined to conclude that the Henrietta under Fogg's
+command, was not going to Liverpool at all, but to some part of the
+world where the robber, turned into a pirate, would quietly put himself
+in safety.  The conjecture was at least a plausible one, and the
+detective began to seriously regret that he had embarked on the affair.
+
+As for Captain Speedy, he continued to howl and growl in his cabin; and
+Passepartout, whose duty it was to carry him his meals, courageous as
+he was, took the greatest precautions.  Mr. Fogg did not seem even to
+know that there was a captain on board.
+
+On the 13th they passed the edge of the Banks of Newfoundland, a
+dangerous locality; during the winter, especially, there are frequent
+fogs and heavy gales of wind.  Ever since the evening before the
+barometer, suddenly falling, had indicated an approaching change in the
+atmosphere; and during the night the temperature varied, the cold
+became sharper, and the wind veered to the south-east.
+
+This was a misfortune.  Mr. Fogg, in order not to deviate from his
+course, furled his sails and increased the force of the steam; but the
+vessel's speed slackened, owing to the state of the sea, the long waves
+of which broke against the stern.  She pitched violently, and this
+retarded her progress.  The breeze little by little swelled into a
+tempest, and it was to be feared that the Henrietta might not be able
+to maintain herself upright on the waves.
+
+Passepartout's visage darkened with the skies, and for two days the
+poor fellow experienced constant fright.  But Phileas Fogg was a bold
+mariner, and knew how to maintain headway against the sea; and he kept
+on his course, without even decreasing his steam.  The Henrietta, when
+she could not rise upon the waves, crossed them, swamping her deck, but
+passing safely.  Sometimes the screw rose out of the water, beating its
+protruding end, when a mountain of water raised the stern above the
+waves; but the craft always kept straight ahead.
+
+The wind, however, did not grow as boisterous as might have been
+feared; it was not one of those tempests which burst, and rush on with
+a speed of ninety miles an hour.  It continued fresh, but, unhappily,
+it remained obstinately in the south-east, rendering the sails useless.
+
+The 16th of December was the seventy-fifth day since Phileas Fogg's
+departure from London, and the Henrietta had not yet been seriously
+delayed.  Half of the voyage was almost accomplished, and the worst
+localities had been passed.  In summer, success would have been
+well-nigh certain.  In winter, they were at the mercy of the bad
+season.  Passepartout said nothing; but he cherished hope in secret,
+and comforted himself with the reflection that, if the wind failed
+them, they might still count on the steam.
+
+On this day the engineer came on deck, went up to Mr. Fogg, and began
+to speak earnestly with him.  Without knowing why it was a
+presentiment, perhaps Passepartout became vaguely uneasy.  He would
+have given one of his ears to hear with the other what the engineer was
+saying.  He finally managed to catch a few words, and was sure he heard
+his master say, "You are certain of what you tell me?"
+
+"Certain, sir," replied the engineer.  "You must remember that, since
+we started, we have kept up hot fires in all our furnaces, and, though
+we had coal enough to go on short steam from New York to Bordeaux, we
+haven't enough to go with all steam from New York to Liverpool." "I
+will consider," replied Mr. Fogg.
+
+Passepartout understood it all; he was seized with mortal anxiety.  The
+coal was giving out!  "Ah, if my master can get over that," muttered
+he, "he'll be a famous man!"  He could not help imparting to Fix what
+he had overheard.
+
+"Then you believe that we really are going to Liverpool?"
+
+"Of course."
+
+"Ass!" replied the detective, shrugging his shoulders and turning on
+his heel.
+
+Passepartout was on the point of vigorously resenting the epithet, the
+reason of which he could not for the life of him comprehend; but he
+reflected that the unfortunate Fix was probably very much disappointed
+and humiliated in his self-esteem, after having so awkwardly followed a
+false scent around the world, and refrained.
+
+And now what course would Phileas Fogg adopt?  It was difficult to
+imagine.  Nevertheless he seemed to have decided upon one, for that
+evening he sent for the engineer, and said to him, "Feed all the fires
+until the coal is exhausted."
+
+A few moments after, the funnel of the Henrietta vomited forth torrents
+of smoke.  The vessel continued to proceed with all steam on; but on
+the 18th, the engineer, as he had predicted, announced that the coal
+would give out in the course of the day.
+
+"Do not let the fires go down," replied Mr. Fogg.  "Keep them up to the
+last.  Let the valves be filled."
+
+Towards noon Phileas Fogg, having ascertained their position, called
+Passepartout, and ordered him to go for Captain Speedy.  It was as if
+the honest fellow had been commanded to unchain a tiger.  He went to
+the poop, saying to himself, "He will be like a madman!"
+
+In a few moments, with cries and oaths, a bomb appeared on the
+poop-deck.  The bomb was Captain Speedy.  It was clear that he was on
+the point of bursting.  "Where are we?"  were the first words his anger
+permitted him to utter.  Had the poor man been an apoplectic, he could
+never have recovered from his paroxysm of wrath.
+
+"Where are we?" he repeated, with purple face.
+
+"Seven hundred and seven miles from Liverpool," replied Mr. Fogg, with
+imperturbable calmness.
+
+"Pirate!" cried Captain Speedy.
+
+"I have sent for you, sir--"
+
+"Pickaroon!"
+
+"--sir," continued Mr. Fogg, "to ask you to sell me your vessel."
+
+"No!  By all the devils, no!"
+
+"But I shall be obliged to burn her."
+
+"Burn the Henrietta!"
+
+"Yes; at least the upper part of her.  The coal has given out."
+
+"Burn my vessel!" cried Captain Speedy, who could scarcely pronounce
+the words.  "A vessel worth fifty thousand dollars!"
+
+"Here are sixty thousand," replied Phileas Fogg, handing the captain a
+roll of bank-bills.  This had a prodigious effect on Andrew Speedy.  An
+American can scarcely remain unmoved at the sight of sixty thousand
+dollars.  The captain forgot in an instant his anger, his imprisonment,
+and all his grudges against his passenger.  The Henrietta was twenty
+years old; it was a great bargain.  The bomb would not go off after
+all.  Mr. Fogg had taken away the match.
+
+"And I shall still have the iron hull," said the captain in a softer
+tone.
+
+"The iron hull and the engine.  Is it agreed?"
+
+"Agreed."
+
+And Andrew Speedy, seizing the banknotes, counted them and consigned
+them to his pocket.
+
+During this colloquy, Passepartout was as white as a sheet, and Fix
+seemed on the point of having an apoplectic fit.  Nearly twenty
+thousand pounds had been expended, and Fogg left the hull and engine to
+the captain, that is, near the whole value of the craft!  It was true,
+however, that fifty-five thousand pounds had been stolen from the Bank.
+
+When Andrew Speedy had pocketed the money, Mr. Fogg said to him, "Don't
+let this astonish you, sir.  You must know that I shall lose twenty
+thousand pounds, unless I arrive in London by a quarter before nine on
+the evening of the 21st of December.  I missed the steamer at New York,
+and as you refused to take me to Liverpool--"
+
+"And I did well!" cried Andrew Speedy; "for I have gained at least
+forty thousand dollars by it!"  He added, more sedately, "Do you know
+one thing, Captain--"
+
+"Fogg."
+
+"Captain Fogg, you've got something of the Yankee about you."
+
+And, having paid his passenger what he considered a high compliment, he
+was going away, when Mr. Fogg said, "The vessel now belongs to me?"
+
+"Certainly, from the keel to the truck of the masts--all the wood, that
+is."
+
+"Very well.  Have the interior seats, bunks, and frames pulled down,
+and burn them."
+
+It was necessary to have dry wood to keep the steam up to the adequate
+pressure, and on that day the poop, cabins, bunks, and the spare deck
+were sacrificed.  On the next day, the 19th of December, the masts,
+rafts, and spars were burned; the crew worked lustily, keeping up the
+fires.  Passepartout hewed, cut, and sawed away with all his might.
+There was a perfect rage for demolition.
+
+The railings, fittings, the greater part of the deck, and top sides
+disappeared on the 20th, and the Henrietta was now only a flat hulk.
+But on this day they sighted the Irish coast and Fastnet Light.  By ten
+in the evening they were passing Queenstown.  Phileas Fogg had only
+twenty-four hours more in which to get to London; that length of time
+was necessary to reach Liverpool, with all steam on.  And the steam was
+about to give out altogether!
+
+"Sir," said Captain Speedy, who was now deeply interested in Mr. Fogg's
+project, "I really commiserate you.  Everything is against you.  We are
+only opposite Queenstown."
+
+"Ah," said Mr. Fogg, "is that place where we see the lights Queenstown?"
+
+"Yes."
+
+"Can we enter the harbour?"
+
+"Not under three hours.  Only at high tide."
+
+"Stay," replied Mr. Fogg calmly, without betraying in his features that
+by a supreme inspiration he was about to attempt once more to conquer
+ill-fortune.
+
+Queenstown is the Irish port at which the trans-Atlantic steamers stop
+to put off the mails.  These mails are carried to Dublin by express
+trains always held in readiness to start; from Dublin they are sent on
+to Liverpool by the most rapid boats, and thus gain twelve hours on the
+Atlantic steamers.
+
+Phileas Fogg counted on gaining twelve hours in the same way.  Instead
+of arriving at Liverpool the next evening by the Henrietta, he would be
+there by noon, and would therefore have time to reach London before a
+quarter before nine in the evening.
+
+The Henrietta entered Queenstown Harbour at one o'clock in the morning,
+it then being high tide; and Phileas Fogg, after being grasped heartily
+by the hand by Captain Speedy, left that gentleman on the levelled hulk
+of his craft, which was still worth half what he had sold it for.
+
+The party went on shore at once.  Fix was greatly tempted to arrest Mr.
+Fogg on the spot; but he did not.  Why?  What struggle was going on
+within him?  Had he changed his mind about "his man"?  Did he
+understand that he had made a grave mistake?  He did not, however,
+abandon Mr. Fogg.  They all got upon the train, which was just ready to
+start, at half-past one; at dawn of day they were in Dublin; and they
+lost no time in embarking on a steamer which, disdaining to rise upon
+the waves, invariably cut through them.
+
+Phileas Fogg at last disembarked on the Liverpool quay, at twenty
+minutes before twelve, 21st December.  He was only six hours distant
+from London.
+
+But at this moment Fix came up, put his hand upon Mr. Fogg's shoulder,
+and, showing his warrant, said, "You are really Phileas Fogg?"
+
+"I am."
+
+"I arrest you in the Queen's name!"
+
+
+
+
+Chapter XXXIV
+
+IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+
+Phileas Fogg was in prison.  He had been shut up in the Custom House,
+and he was to be transferred to London the next day.
+
+Passepartout, when he saw his master arrested, would have fallen upon
+Fix had he not been held back by some policemen.  Aouda was
+thunderstruck at the suddenness of an event which she could not
+understand.  Passepartout explained to her how it was that the honest
+and courageous Fogg was arrested as a robber.  The young woman's heart
+revolted against so heinous a charge, and when she saw that she could
+attempt to do nothing to save her protector, she wept bitterly.
+
+As for Fix, he had arrested Mr. Fogg because it was his duty, whether
+Mr. Fogg were guilty or not.
+
+The thought then struck Passepartout, that he was the cause of this new
+misfortune!  Had he not concealed Fix's errand from his master?  When
+Fix revealed his true character and purpose, why had he not told Mr.
+Fogg?  If the latter had been warned, he would no doubt have given Fix
+proof of his innocence, and satisfied him of his mistake; at least, Fix
+would not have continued his journey at the expense and on the heels of
+his master, only to arrest him the moment he set foot on English soil.
+Passepartout wept till he was blind, and felt like blowing his brains
+out.
+
+Aouda and he had remained, despite the cold, under the portico of the
+Custom House.  Neither wished to leave the place; both were anxious to
+see Mr. Fogg again.
+
+That gentleman was really ruined, and that at the moment when he was
+about to attain his end.  This arrest was fatal.  Having arrived at
+Liverpool at twenty minutes before twelve on the 21st of December, he
+had till a quarter before nine that evening to reach the Reform Club,
+that is, nine hours and a quarter; the journey from Liverpool to London
+was six hours.
+
+If anyone, at this moment, had entered the Custom House, he would have
+found Mr. Fogg seated, motionless, calm, and without apparent anger,
+upon a wooden bench.  He was not, it is true, resigned; but this last
+blow failed to force him into an outward betrayal of any emotion.  Was
+he being devoured by one of those secret rages, all the more terrible
+because contained, and which only burst forth, with an irresistible
+force, at the last moment?  No one could tell.  There he sat, calmly
+waiting--for what?  Did he still cherish hope?  Did he still believe,
+now that the door of this prison was closed upon him, that he would
+succeed?
+
+However that may have been, Mr. Fogg carefully put his watch upon the
+table, and observed its advancing hands.  Not a word escaped his lips,
+but his look was singularly set and stern.  The situation, in any
+event, was a terrible one, and might be thus stated: if Phileas Fogg
+was honest he was ruined; if he was a knave, he was caught.
+
+Did escape occur to him?  Did he examine to see if there were any
+practicable outlet from his prison?  Did he think of escaping from it?
+Possibly; for once he walked slowly around the room.  But the door was
+locked, and the window heavily barred with iron rods.  He sat down
+again, and drew his journal from his pocket.  On the line where these
+words were written, "21st December, Saturday, Liverpool," he added,
+"80th day, 11.40 a.m.," and waited.
+
+The Custom House clock struck one.  Mr. Fogg observed that his watch
+was two hours too fast.
+
+Two hours!  Admitting that he was at this moment taking an express
+train, he could reach London and the Reform Club by a quarter before
+nine, p.m.  His forehead slightly wrinkled.
+
+At thirty-three minutes past two he heard a singular noise outside,
+then a hasty opening of doors.  Passepartout's voice was audible, and
+immediately after that of Fix.  Phileas Fogg's eyes brightened for an
+instant.
+
+The door swung open, and he saw Passepartout, Aouda, and Fix, who
+hurried towards him.
+
+Fix was out of breath, and his hair was in disorder.  He could not
+speak.  "Sir," he stammered, "sir--forgive me--most--unfortunate
+resemblance--robber arrested three days ago--you are free!"
+
+Phileas Fogg was free!  He walked to the detective, looked him steadily
+in the face, and with the only rapid motion he had ever made in his
+life, or which he ever would make, drew back his arms, and with the
+precision of a machine knocked Fix down.
+
+"Well hit!" cried Passepartout, "Parbleu! that's what you might call a
+good application of English fists!"
+
+Fix, who found himself on the floor, did not utter a word.  He had only
+received his deserts.  Mr. Fogg, Aouda, and Passepartout left the
+Custom House without delay, got into a cab, and in a few moments
+descended at the station.
+
+Phileas Fogg asked if there was an express train about to leave for
+London.  It was forty minutes past two.  The express train had left
+thirty-five minutes before.  Phileas Fogg then ordered a special train.
+
+There were several rapid locomotives on hand; but the railway
+arrangements did not permit the special train to leave until three
+o'clock.
+
+At that hour Phileas Fogg, having stimulated the engineer by the offer
+of a generous reward, at last set out towards London with Aouda and his
+faithful servant.
+
+It was necessary to make the journey in five hours and a half; and this
+would have been easy on a clear road throughout.  But there were forced
+delays, and when Mr. Fogg stepped from the train at the terminus, all
+the clocks in London were striking ten minutes before nine.
+
+Having made the tour of the world, he was behind-hand five minutes.  He
+had lost the wager!
+
+
+
+
+Chapter XXXV
+
+IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+PASSEPARTOUT TWICE
+
+
+The dwellers in Saville Row would have been surprised the next day, if
+they had been told that Phileas Fogg had returned home.  His doors and
+windows were still closed, no appearance of change was visible.
+
+After leaving the station, Mr. Fogg gave Passepartout instructions to
+purchase some provisions, and quietly went to his domicile.
+
+He bore his misfortune with his habitual tranquillity.  Ruined!  And by
+the blundering of the detective!  After having steadily traversed that
+long journey, overcome a hundred obstacles, braved many dangers, and
+still found time to do some good on his way, to fail near the goal by a
+sudden event which he could not have foreseen, and against which he was
+unarmed; it was terrible!  But a few pounds were left of the large sum
+he had carried with him.  There only remained of his fortune the twenty
+thousand pounds deposited at Barings, and this amount he owed to his
+friends of the Reform Club.  So great had been the expense of his tour
+that, even had he won, it would not have enriched him; and it is
+probable that he had not sought to enrich himself, being a man who
+rather laid wagers for honour's sake than for the stake proposed.  But
+this wager totally ruined him.
+
+Mr. Fogg's course, however, was fully decided upon; he knew what
+remained for him to do.
+
+A room in the house in Saville Row was set apart for Aouda, who was
+overwhelmed with grief at her protector's misfortune.  From the words
+which Mr. Fogg dropped, she saw that he was meditating some serious
+project.
+
+Knowing that Englishmen governed by a fixed idea sometimes resort to
+the desperate expedient of suicide, Passepartout kept a narrow watch
+upon his master, though he carefully concealed the appearance of so
+doing.
+
+First of all, the worthy fellow had gone up to his room, and had
+extinguished the gas burner, which had been burning for eighty days.
+He had found in the letter-box a bill from the gas company, and he
+thought it more than time to put a stop to this expense, which he had
+been doomed to bear.
+
+The night passed.  Mr. Fogg went to bed, but did he sleep?  Aouda did
+not once close her eyes.  Passepartout watched all night, like a
+faithful dog, at his master's door.
+
+Mr. Fogg called him in the morning, and told him to get Aouda's
+breakfast, and a cup of tea and a chop for himself.  He desired Aouda
+to excuse him from breakfast and dinner, as his time would be absorbed
+all day in putting his affairs to rights.  In the evening he would ask
+permission to have a few moment's conversation with the young lady.
+
+Passepartout, having received his orders, had nothing to do but obey
+them.  He looked at his imperturbable master, and could scarcely bring
+his mind to leave him.  His heart was full, and his conscience tortured
+by remorse; for he accused himself more bitterly than ever of being the
+cause of the irretrievable disaster.  Yes! if he had warned Mr. Fogg,
+and had betrayed Fix's projects to him, his master would certainly not
+have given the detective passage to Liverpool, and then--
+
+Passepartout could hold in no longer.
+
+"My master!  Mr. Fogg!" he cried, "why do you not curse me?  It was my
+fault that--"
+
+"I blame no one," returned Phileas Fogg, with perfect calmness.  "Go!"
+
+Passepartout left the room, and went to find Aouda, to whom he
+delivered his master's message.
+
+"Madam," he added, "I can do nothing myself--nothing!  I have no
+influence over my master; but you, perhaps--"
+
+"What influence could I have?" replied Aouda.  "Mr. Fogg is influenced
+by no one.  Has he ever understood that my gratitude to him is
+overflowing?  Has he ever read my heart?  My friend, he must not be
+left alone an instant!  You say he is going to speak with me this
+evening?"
+
+"Yes, madam; probably to arrange for your protection and comfort in
+England."
+
+"We shall see," replied Aouda, becoming suddenly pensive.
+
+Throughout this day (Sunday) the house in Saville Row was as if
+uninhabited, and Phileas Fogg, for the first time since he had lived in
+that house, did not set out for his club when Westminster clock struck
+half-past eleven.
+
+Why should he present himself at the Reform?  His friends no longer
+expected him there.  As Phileas Fogg had not appeared in the saloon on
+the evening before (Saturday, the 21st of December, at a quarter before
+nine), he had lost his wager.  It was not even necessary that he should
+go to his bankers for the twenty thousand pounds; for his antagonists
+already had his cheque in their hands, and they had only to fill it out
+and send it to the Barings to have the amount transferred to their
+credit.
+
+Mr. Fogg, therefore, had no reason for going out, and so he remained at
+home.  He shut himself up in his room, and busied himself putting his
+affairs in order.  Passepartout continually ascended and descended the
+stairs.  The hours were long for him. He listened at his master's door,
+and looked through the keyhole, as if he had a perfect right so to do,
+and as if he feared that something terrible might happen at any moment.
+Sometimes he thought of Fix, but no longer in anger.  Fix, like all the
+world, had been mistaken in Phileas Fogg, and had only done his duty in
+tracking and arresting him; while he, Passepartout. . . .  This thought
+haunted him, and he never ceased cursing his miserable folly.
+
+Finding himself too wretched to remain alone, he knocked at Aouda's
+door, went into her room, seated himself, without speaking, in a
+corner, and looked ruefully at the young woman. Aouda was still pensive.
+
+About half-past seven in the evening Mr. Fogg sent to know if Aouda
+would receive him, and in a few moments he found himself alone with her.
+
+Phileas Fogg took a chair, and sat down near the fireplace, opposite
+Aouda.  No emotion was visible on his face.  Fogg returned was exactly
+the Fogg who had gone away; there was the same calm, the same
+impassibility.
+
+He sat several minutes without speaking; then, bending his eyes on
+Aouda, "Madam," said he, "will you pardon me for bringing you to
+England?"
+
+"I, Mr. Fogg!" replied Aouda, checking the pulsations of her heart.
+
+"Please let me finish," returned Mr. Fogg.  "When I decided to bring
+you far away from the country which was so unsafe for you, I was rich,
+and counted on putting a portion of my fortune at your disposal; then
+your existence would have been free and happy.  But now I am ruined."
+
+"I know it, Mr. Fogg," replied Aouda; "and I ask you in my turn, will
+you forgive me for having followed you, and--who knows?--for having,
+perhaps, delayed you, and thus contributed to your ruin?"
+
+"Madam, you could not remain in India, and your safety could only be
+assured by bringing you to such a distance that your persecutors could
+not take you."
+
+"So, Mr. Fogg," resumed Aouda, "not content with rescuing me from a
+terrible death, you thought yourself bound to secure my comfort in a
+foreign land?"
+
+"Yes, madam; but circumstances have been against me.  Still, I beg to
+place the little I have left at your service."
+
+"But what will become of you, Mr. Fogg?"
+
+"As for me, madam," replied the gentleman, coldly, "I have need of
+nothing."
+
+"But how do you look upon the fate, sir, which awaits you?"
+
+"As I am in the habit of doing."
+
+"At least," said Aouda, "want should not overtake a man like you.  Your
+friends--"
+
+"I have no friends, madam."
+
+"Your relatives--"
+
+"I have no longer any relatives."
+
+"I pity you, then, Mr. Fogg, for solitude is a sad thing, with no heart
+to which to confide your griefs.  They say, though, that misery itself,
+shared by two sympathetic souls, may be borne with patience."
+
+"They say so, madam."
+
+"Mr. Fogg," said Aouda, rising and seizing his hand, "do you wish at
+once a kinswoman and friend?  Will you have me for your wife?"
+
+Mr. Fogg, at this, rose in his turn.  There was an unwonted light in
+his eyes, and a slight trembling of his lips.  Aouda looked into his
+face.  The sincerity, rectitude, firmness, and sweetness of this soft
+glance of a noble woman, who could dare all to save him to whom she
+owed all, at first astonished, then penetrated him.  He shut his eyes
+for an instant, as if to avoid her look.  When he opened them again, "I
+love you!" he said, simply.  "Yes, by all that is holiest, I love you,
+and I am entirely yours!"
+
+"Ah!" cried Aouda, pressing his hand to her heart.
+
+Passepartout was summoned and appeared immediately.  Mr. Fogg still
+held Aouda's hand in his own; Passepartout understood, and his big,
+round face became as radiant as the tropical sun at its zenith.
+
+Mr. Fogg asked him if it was not too late to notify the Reverend Samuel
+Wilson, of Marylebone parish, that evening.
+
+Passepartout smiled his most genial smile, and said, "Never too late."
+
+It was five minutes past eight.
+
+"Will it be for to-morrow, Monday?"
+
+"For to-morrow, Monday," said Mr. Fogg, turning to Aouda.
+
+"Yes; for to-morrow, Monday," she replied.
+
+Passepartout hurried off as fast as his legs could carry him.
+
+
+
+
+Chapter XXXVI
+
+IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+
+It is time to relate what a change took place in English public opinion
+when it transpired that the real bankrobber, a certain James Strand,
+had been arrested, on the 17th day of December, at Edinburgh.  Three
+days before, Phileas Fogg had been a criminal, who was being
+desperately followed up by the police; now he was an honourable
+gentleman, mathematically pursuing his eccentric journey round the
+world.
+
+The papers resumed their discussion about the wager; all those who had
+laid bets, for or against him, revived their interest, as if by magic;
+the "Phileas Fogg bonds" again became negotiable, and many new wagers
+were made.  Phileas Fogg's name was once more at a premium on 'Change.
+
+His five friends of the Reform Club passed these three days in a state
+of feverish suspense.  Would Phileas Fogg, whom they had forgotten,
+reappear before their eyes!  Where was he at this moment?  The 17th of
+December, the day of James Strand's arrest, was the seventy-sixth since
+Phileas Fogg's departure, and no news of him had been received.  Was he
+dead?  Had he abandoned the effort, or was he continuing his journey
+along the route agreed upon?  And would he appear on Saturday, the 21st
+of December, at a quarter before nine in the evening, on the threshold
+of the Reform Club saloon?
+
+The anxiety in which, for three days, London society existed, cannot be
+described.  Telegrams were sent to America and Asia for news of Phileas
+Fogg.  Messengers were dispatched to the house in Saville Row morning
+and evening.  No news.  The police were ignorant what had become of the
+detective, Fix, who had so unfortunately followed up a false scent.
+Bets increased, nevertheless, in number and value.  Phileas Fogg, like
+a racehorse, was drawing near his last turning-point.  The bonds were
+quoted, no longer at a hundred below par, but at twenty, at ten, and at
+five; and paralytic old Lord Albemarle bet even in his favour.
+
+A great crowd was collected in Pall Mall and the neighbouring streets
+on Saturday evening; it seemed like a multitude of brokers permanently
+established around the Reform Club.  Circulation was impeded, and
+everywhere disputes, discussions, and financial transactions were going
+on.  The police had great difficulty in keeping back the crowd, and as
+the hour when Phileas Fogg was due approached, the excitement rose to
+its highest pitch.
+
+The five antagonists of Phileas Fogg had met in the great saloon of the
+club.  John Sullivan and Samuel Fallentin, the bankers, Andrew Stuart,
+the engineer, Gauthier Ralph, the director of the Bank of England, and
+Thomas Flanagan, the brewer, one and all waited anxiously.
+
+When the clock indicated twenty minutes past eight, Andrew Stuart got
+up, saying, "Gentlemen, in twenty minutes the time agreed upon between
+Mr. Fogg and ourselves will have expired."
+
+"What time did the last train arrive from Liverpool?"  asked Thomas
+Flanagan.
+
+"At twenty-three minutes past seven," replied Gauthier Ralph; "and the
+next does not arrive till ten minutes after twelve."
+
+"Well, gentlemen," resumed Andrew Stuart, "if Phileas Fogg had come in
+the 7:23 train, he would have got here by this time.  We can,
+therefore, regard the bet as won."
+
+"Wait; don't let us be too hasty," replied Samuel Fallentin.  "You know
+that Mr. Fogg is very eccentric.  His punctuality is well known; he
+never arrives too soon, or too late; and I should not be surprised if
+he appeared before us at the last minute."
+
+"Why," said Andrew Stuart nervously, "if I should see him, I should not
+believe it was he."
+
+"The fact is," resumed Thomas Flanagan, "Mr. Fogg's project was
+absurdly foolish.  Whatever his punctuality, he could not prevent the
+delays which were certain to occur; and a delay of only two or three
+days would be fatal to his tour."
+
+"Observe, too," added John Sullivan, "that we have received no
+intelligence from him, though there are telegraphic lines all along his
+route."
+
+"He has lost, gentleman," said Andrew Stuart, "he has a hundred times
+lost!  You know, besides, that the China the only steamer he could have
+taken from New York to get here in time arrived yesterday.  I have seen
+a list of the passengers, and the name of Phileas Fogg is not among
+them.  Even if we admit that fortune has favoured him, he can scarcely
+have reached America.  I think he will be at least twenty days
+behind-hand, and that Lord Albemarle will lose a cool five thousand."
+
+"It is clear," replied Gauthier Ralph; "and we have nothing to do but
+to present Mr. Fogg's cheque at Barings to-morrow."
+
+At this moment, the hands of the club clock pointed to twenty minutes
+to nine.
+
+"Five minutes more," said Andrew Stuart.
+
+The five gentlemen looked at each other.  Their anxiety was becoming
+intense; but, not wishing to betray it, they readily assented to Mr.
+Fallentin's proposal of a rubber.
+
+"I wouldn't give up my four thousand of the bet," said Andrew Stuart,
+as he took his seat, "for three thousand nine hundred and ninety-nine."
+
+The clock indicated eighteen minutes to nine.
+
+The players took up their cards, but could not keep their eyes off the
+clock.  Certainly, however secure they felt, minutes had never seemed
+so long to them!
+
+"Seventeen minutes to nine," said Thomas Flanagan, as he cut the cards
+which Ralph handed to him.
+
+Then there was a moment of silence.  The great saloon was perfectly
+quiet; but the murmurs of the crowd outside were heard, with now and
+then a shrill cry.  The pendulum beat the seconds, which each player
+eagerly counted, as he listened, with mathematical regularity.
+
+"Sixteen minutes to nine!" said John Sullivan, in a voice which
+betrayed his emotion.
+
+One minute more, and the wager would be won.  Andrew Stuart and his
+partners suspended their game.  They left their cards, and counted the
+seconds.
+
+At the fortieth second, nothing.  At the fiftieth, still nothing.
+
+At the fifty-fifth, a loud cry was heard in the street, followed by
+applause, hurrahs, and some fierce growls.
+
+The players rose from their seats.
+
+At the fifty-seventh second the door of the saloon opened; and the
+pendulum had not beat the sixtieth second when Phileas Fogg appeared,
+followed by an excited crowd who had forced their way through the club
+doors, and in his calm voice, said, "Here I am, gentlemen!"
+
+
+
+
+Chapter XXXVII
+
+IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+Yes; Phileas Fogg in person.
+
+The reader will remember that at five minutes past eight in the
+evening--about five and twenty hours after the arrival of the
+travellers in London--Passepartout had been sent by his master to
+engage the services of the Reverend Samuel Wilson in a certain marriage
+ceremony, which was to take place the next day.
+
+Passepartout went on his errand enchanted.  He soon reached the
+clergyman's house, but found him not at home.  Passepartout waited a
+good twenty minutes, and when he left the reverend gentleman, it was
+thirty-five minutes past eight.  But in what a state he was!  With his
+hair in disorder, and without his hat, he ran along the street as never
+man was seen to run before, overturning passers-by, rushing over the
+sidewalk like a waterspout.
+
+In three minutes he was in Saville Row again, and staggered back into
+Mr. Fogg's room.
+
+He could not speak.
+
+"What is the matter?" asked Mr. Fogg.
+
+"My master!" gasped Passepartout--"marriage--impossible--"
+
+"Impossible?"
+
+"Impossible--for to-morrow."
+
+"Why so?"
+
+"Because to-morrow--is Sunday!"
+
+"Monday," replied Mr. Fogg.
+
+"No--to-day is Saturday."
+
+"Saturday?  Impossible!"
+
+"Yes, yes, yes, yes!" cried Passepartout.  "You have made a mistake of
+one day!  We arrived twenty-four hours ahead of time; but there are
+only ten minutes left!"
+
+Passepartout had seized his master by the collar, and was dragging him
+along with irresistible force.
+
+Phileas Fogg, thus kidnapped, without having time to think, left his
+house, jumped into a cab, promised a hundred pounds to the cabman, and,
+having run over two dogs and overturned five carriages, reached the
+Reform Club.
+
+The clock indicated a quarter before nine when he appeared in the great
+saloon.
+
+Phileas Fogg had accomplished the journey round the world in eighty
+days!
+
+Phileas Fogg had won his wager of twenty thousand pounds!
+
+How was it that a man so exact and fastidious could have made this
+error of a day?  How came he to think that he had arrived in London on
+Saturday, the twenty-first day of December, when it was really Friday,
+the twentieth, the seventy-ninth day only from his departure?
+
+The cause of the error is very simple.
+
+Phileas Fogg had, without suspecting it, gained one day on his journey,
+and this merely because he had travelled constantly eastward; he would,
+on the contrary, have lost a day had he gone in the opposite direction,
+that is, westward.
+
+In journeying eastward he had gone towards the sun, and the days
+therefore diminished for him as many times four minutes as he crossed
+degrees in this direction.  There are three hundred and sixty degrees
+on the circumference of the earth; and these three hundred and sixty
+degrees, multiplied by four minutes, gives precisely twenty-four
+hours--that is, the day unconsciously gained.  In other words, while
+Phileas Fogg, going eastward, saw the sun pass the meridian eighty
+times, his friends in London only saw it pass the meridian seventy-nine
+times.  This is why they awaited him at the Reform Club on Saturday,
+and not Sunday, as Mr. Fogg thought.
+
+And Passepartout's famous family watch, which had always kept London
+time, would have betrayed this fact, if it had marked the days as well
+as the hours and the minutes!
+
+Phileas Fogg, then, had won the twenty thousand pounds; but, as he had
+spent nearly nineteen thousand on the way, the pecuniary gain was
+small.  His object was, however, to be victorious, and not to win
+money.  He divided the one thousand pounds that remained between
+Passepartout and the unfortunate Fix, against whom he cherished no
+grudge.  He deducted, however, from Passepartout's share the cost of
+the gas which had burned in his room for nineteen hundred and twenty
+hours, for the sake of regularity.
+
+That evening, Mr. Fogg, as tranquil and phlegmatic as ever, said to
+Aouda: "Is our marriage still agreeable to you?"
+
+"Mr. Fogg," replied she, "it is for me to ask that question.  You were
+ruined, but now you are rich again."
+
+"Pardon me, madam; my fortune belongs to you.  If you had not suggested
+our marriage, my servant would not have gone to the Reverend Samuel
+Wilson's, I should not have been apprised of my error, and--"
+
+"Dear Mr. Fogg!" said the young woman.
+
+"Dear Aouda!" replied Phileas Fogg.
+
+It need not be said that the marriage took place forty-eight hours
+after, and that Passepartout, glowing and dazzling, gave the bride
+away.  Had he not saved her, and was he not entitled to this honour?
+
+The next day, as soon as it was light, Passepartout rapped vigorously
+at his master's door.  Mr. Fogg opened it, and asked, "What's the
+matter, Passepartout?"
+
+"What is it, sir?  Why, I've just this instant found out--"
+
+"What?"
+
+"That we might have made the tour of the world in only seventy-eight
+days."
+
+"No doubt," returned Mr. Fogg, "by not crossing India.  But if I had
+not crossed India, I should not have saved Aouda; she would not have
+been my wife, and--"
+
+Mr. Fogg quietly shut the door.
+
+Phileas Fogg had won his wager, and had made his journey around the
+world in eighty days.  To do this he had employed every means of
+conveyance--steamers, railways, carriages, yachts, trading-vessels,
+sledges, elephants.  The eccentric gentleman had throughout displayed
+all his marvellous qualities of coolness and exactitude.  But what
+then?  What had he really gained by all this trouble?  What had he
+brought back from this long and weary journey?
+
+Nothing, say you?  Perhaps so; nothing but a charming woman, who,
+strange as it may appear, made him the happiest of men!
+
+Truly, would you not for less than that make the tour around the world?
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's Around the World in 80 Days, by Jules Verne
+
+*** END OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+***** This file should be named 103.txt or 103.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/0/103/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/dorian-gray.txt
+++ b/jet/hadoop/src/main/resources/books/dorian-gray.txt
@@ -1,0 +1,8904 @@
+﻿The Project Gutenberg EBook of The Picture of Dorian Gray, by Oscar Wilde
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Picture of Dorian Gray
+
+Author: Oscar Wilde
+
+Release Date: June 9, 2008 [EBook #174]
+[This file last updated on July 2, 2011]
+[This file last updated on July 23, 2014]
+
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+
+
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+The Picture of Dorian Gray
+
+by
+
+Oscar Wilde
+
+
+
+
+THE PREFACE
+
+The artist is the creator of beautiful things.  To reveal art and
+conceal the artist is art's aim.  The critic is he who can translate
+into another manner or a new material his impression of beautiful
+things.
+
+The highest as the lowest form of criticism is a mode of autobiography.
+Those who find ugly meanings in beautiful things are corrupt without
+being charming.  This is a fault.
+
+Those who find beautiful meanings in beautiful things are the
+cultivated.  For these there is hope.  They are the elect to whom
+beautiful things mean only beauty.
+
+There is no such thing as a moral or an immoral book.  Books are well
+written, or badly written.  That is all.
+
+The nineteenth century dislike of realism is the rage of Caliban seeing
+his own face in a glass.
+
+The nineteenth century dislike of romanticism is the rage of Caliban
+not seeing his own face in a glass.  The moral life of man forms part
+of the subject-matter of the artist, but the morality of art consists
+in the perfect use of an imperfect medium.  No artist desires to prove
+anything.  Even things that are true can be proved.  No artist has
+ethical sympathies.  An ethical sympathy in an artist is an
+unpardonable mannerism of style.  No artist is ever morbid.  The artist
+can express everything.  Thought and language are to the artist
+instruments of an art.  Vice and virtue are to the artist materials for
+an art.  From the point of view of form, the type of all the arts is
+the art of the musician.  From the point of view of feeling, the
+actor's craft is the type.  All art is at once surface and symbol.
+Those who go beneath the surface do so at their peril.  Those who read
+the symbol do so at their peril.  It is the spectator, and not life,
+that art really mirrors.  Diversity of opinion about a work of art
+shows that the work is new, complex, and vital.  When critics disagree,
+the artist is in accord with himself.  We can forgive a man for making
+a useful thing as long as he does not admire it.  The only excuse for
+making a useless thing is that one admires it intensely.
+
+               All art is quite useless.
+
+                            OSCAR WILDE
+
+
+
+
+CHAPTER 1
+
+The studio was filled with the rich odour of roses, and when the light
+summer wind stirred amidst the trees of the garden, there came through
+the open door the heavy scent of the lilac, or the more delicate
+perfume of the pink-flowering thorn.
+
+From the corner of the divan of Persian saddle-bags on which he was
+lying, smoking, as was his custom, innumerable cigarettes, Lord Henry
+Wotton could just catch the gleam of the honey-sweet and honey-coloured
+blossoms of a laburnum, whose tremulous branches seemed hardly able to
+bear the burden of a beauty so flamelike as theirs; and now and then
+the fantastic shadows of birds in flight flitted across the long
+tussore-silk curtains that were stretched in front of the huge window,
+producing a kind of momentary Japanese effect, and making him think of
+those pallid, jade-faced painters of Tokyo who, through the medium of
+an art that is necessarily immobile, seek to convey the sense of
+swiftness and motion.  The sullen murmur of the bees shouldering their
+way through the long unmown grass, or circling with monotonous
+insistence round the dusty gilt horns of the straggling woodbine,
+seemed to make the stillness more oppressive.  The dim roar of London
+was like the bourdon note of a distant organ.
+
+In the centre of the room, clamped to an upright easel, stood the
+full-length portrait of a young man of extraordinary personal beauty,
+and in front of it, some little distance away, was sitting the artist
+himself, Basil Hallward, whose sudden disappearance some years ago
+caused, at the time, such public excitement and gave rise to so many
+strange conjectures.
+
+As the painter looked at the gracious and comely form he had so
+skilfully mirrored in his art, a smile of pleasure passed across his
+face, and seemed about to linger there.  But he suddenly started up,
+and closing his eyes, placed his fingers upon the lids, as though he
+sought to imprison within his brain some curious dream from which he
+feared he might awake.
+
+"It is your best work, Basil, the best thing you have ever done," said
+Lord Henry languidly.  "You must certainly send it next year to the
+Grosvenor.  The Academy is too large and too vulgar.  Whenever I have
+gone there, there have been either so many people that I have not been
+able to see the pictures, which was dreadful, or so many pictures that
+I have not been able to see the people, which was worse.  The Grosvenor
+is really the only place."
+
+"I don't think I shall send it anywhere," he answered, tossing his head
+back in that odd way that used to make his friends laugh at him at
+Oxford.  "No, I won't send it anywhere."
+
+Lord Henry elevated his eyebrows and looked at him in amazement through
+the thin blue wreaths of smoke that curled up in such fanciful whorls
+from his heavy, opium-tainted cigarette.  "Not send it anywhere?  My
+dear fellow, why?  Have you any reason?  What odd chaps you painters
+are!  You do anything in the world to gain a reputation.  As soon as
+you have one, you seem to want to throw it away.  It is silly of you,
+for there is only one thing in the world worse than being talked about,
+and that is not being talked about.  A portrait like this would set you
+far above all the young men in England, and make the old men quite
+jealous, if old men are ever capable of any emotion."
+
+"I know you will laugh at me," he replied, "but I really can't exhibit
+it.  I have put too much of myself into it."
+
+Lord Henry stretched himself out on the divan and laughed.
+
+"Yes, I knew you would; but it is quite true, all the same."
+
+"Too much of yourself in it! Upon my word, Basil, I didn't know you
+were so vain; and I really can't see any resemblance between you, with
+your rugged strong face and your coal-black hair, and this young
+Adonis, who looks as if he was made out of ivory and rose-leaves. Why,
+my dear Basil, he is a Narcissus, and you--well, of course you have an
+intellectual expression and all that.  But beauty, real beauty, ends
+where an intellectual expression begins.  Intellect is in itself a mode
+of exaggeration, and destroys the harmony of any face.  The moment one
+sits down to think, one becomes all nose, or all forehead, or something
+horrid.  Look at the successful men in any of the learned professions.
+How perfectly hideous they are!  Except, of course, in the Church.  But
+then in the Church they don't think.  A bishop keeps on saying at the
+age of eighty what he was told to say when he was a boy of eighteen,
+and as a natural consequence he always looks absolutely delightful.
+Your mysterious young friend, whose name you have never told me, but
+whose picture really fascinates me, never thinks.  I feel quite sure of
+that.  He is some brainless beautiful creature who should be always
+here in winter when we have no flowers to look at, and always here in
+summer when we want something to chill our intelligence.  Don't flatter
+yourself, Basil:  you are not in the least like him."
+
+"You don't understand me, Harry," answered the artist.  "Of course I am
+not like him.  I know that perfectly well.  Indeed, I should be sorry
+to look like him.  You shrug your shoulders?  I am telling you the
+truth.  There is a fatality about all physical and intellectual
+distinction, the sort of fatality that seems to dog through history the
+faltering steps of kings.  It is better not to be different from one's
+fellows.  The ugly and the stupid have the best of it in this world.
+They can sit at their ease and gape at the play.  If they know nothing
+of victory, they are at least spared the knowledge of defeat.  They
+live as we all should live--undisturbed, indifferent, and without
+disquiet.  They neither bring ruin upon others, nor ever receive it
+from alien hands.  Your rank and wealth, Harry; my brains, such as they
+are--my art, whatever it may be worth; Dorian Gray's good looks--we
+shall all suffer for what the gods have given us, suffer terribly."
+
+"Dorian Gray?  Is that his name?" asked Lord Henry, walking across the
+studio towards Basil Hallward.
+
+"Yes, that is his name.  I didn't intend to tell it to you."
+
+"But why not?"
+
+"Oh, I can't explain.  When I like people immensely, I never tell their
+names to any one.  It is like surrendering a part of them.  I have
+grown to love secrecy.  It seems to be the one thing that can make
+modern life mysterious or marvellous to us.  The commonest thing is
+delightful if one only hides it.  When I leave town now I never tell my
+people where I am going.  If I did, I would lose all my pleasure.  It
+is a silly habit, I dare say, but somehow it seems to bring a great
+deal of romance into one's life.  I suppose you think me awfully
+foolish about it?"
+
+"Not at all," answered Lord Henry, "not at all, my dear Basil.  You
+seem to forget that I am married, and the one charm of marriage is that
+it makes a life of deception absolutely necessary for both parties.  I
+never know where my wife is, and my wife never knows what I am doing.
+When we meet--we do meet occasionally, when we dine out together, or go
+down to the Duke's--we tell each other the most absurd stories with the
+most serious faces.  My wife is very good at it--much better, in fact,
+than I am.  She never gets confused over her dates, and I always do.
+But when she does find me out, she makes no row at all.  I sometimes
+wish she would; but she merely laughs at me."
+
+"I hate the way you talk about your married life, Harry," said Basil
+Hallward, strolling towards the door that led into the garden.  "I
+believe that you are really a very good husband, but that you are
+thoroughly ashamed of your own virtues.  You are an extraordinary
+fellow.  You never say a moral thing, and you never do a wrong thing.
+Your cynicism is simply a pose."
+
+"Being natural is simply a pose, and the most irritating pose I know,"
+cried Lord Henry, laughing; and the two young men went out into the
+garden together and ensconced themselves on a long bamboo seat that
+stood in the shade of a tall laurel bush.  The sunlight slipped over
+the polished leaves.  In the grass, white daisies were tremulous.
+
+After a pause, Lord Henry pulled out his watch.  "I am afraid I must be
+going, Basil," he murmured, "and before I go, I insist on your
+answering a question I put to you some time ago."
+
+"What is that?" said the painter, keeping his eyes fixed on the ground.
+
+"You know quite well."
+
+"I do not, Harry."
+
+"Well, I will tell you what it is.  I want you to explain to me why you
+won't exhibit Dorian Gray's picture.  I want the real reason."
+
+"I told you the real reason."
+
+"No, you did not.  You said it was because there was too much of
+yourself in it.  Now, that is childish."
+
+"Harry," said Basil Hallward, looking him straight in the face, "every
+portrait that is painted with feeling is a portrait of the artist, not
+of the sitter.  The sitter is merely the accident, the occasion.  It is
+not he who is revealed by the painter; it is rather the painter who, on
+the coloured canvas, reveals himself.  The reason I will not exhibit
+this picture is that I am afraid that I have shown in it the secret of
+my own soul."
+
+Lord Henry laughed.  "And what is that?" he asked.
+
+"I will tell you," said Hallward; but an expression of perplexity came
+over his face.
+
+"I am all expectation, Basil," continued his companion, glancing at him.
+
+"Oh, there is really very little to tell, Harry," answered the painter;
+"and I am afraid you will hardly understand it.  Perhaps you will
+hardly believe it."
+
+Lord Henry smiled, and leaning down, plucked a pink-petalled daisy from
+the grass and examined it.  "I am quite sure I shall understand it," he
+replied, gazing intently at the little golden, white-feathered disk,
+"and as for believing things, I can believe anything, provided that it
+is quite incredible."
+
+The wind shook some blossoms from the trees, and the heavy
+lilac-blooms, with their clustering stars, moved to and fro in the
+languid air.  A grasshopper began to chirrup by the wall, and like a
+blue thread a long thin dragon-fly floated past on its brown gauze
+wings.  Lord Henry felt as if he could hear Basil Hallward's heart
+beating, and wondered what was coming.
+
+"The story is simply this," said the painter after some time.  "Two
+months ago I went to a crush at Lady Brandon's. You know we poor
+artists have to show ourselves in society from time to time, just to
+remind the public that we are not savages.  With an evening coat and a
+white tie, as you told me once, anybody, even a stock-broker, can gain
+a reputation for being civilized.  Well, after I had been in the room
+about ten minutes, talking to huge overdressed dowagers and tedious
+academicians, I suddenly became conscious that some one was looking at
+me.  I turned half-way round and saw Dorian Gray for the first time.
+When our eyes met, I felt that I was growing pale.  A curious sensation
+of terror came over me.  I knew that I had come face to face with some
+one whose mere personality was so fascinating that, if I allowed it to
+do so, it would absorb my whole nature, my whole soul, my very art
+itself.  I did not want any external influence in my life.  You know
+yourself, Harry, how independent I am by nature.  I have always been my
+own master; had at least always been so, till I met Dorian Gray.
+Then--but I don't know how to explain it to you.  Something seemed to
+tell me that I was on the verge of a terrible crisis in my life.  I had
+a strange feeling that fate had in store for me exquisite joys and
+exquisite sorrows.  I grew afraid and turned to quit the room.  It was
+not conscience that made me do so:  it was a sort of cowardice.  I take
+no credit to myself for trying to escape."
+
+"Conscience and cowardice are really the same things, Basil.
+Conscience is the trade-name of the firm.  That is all."
+
+"I don't believe that, Harry, and I don't believe you do either.
+However, whatever was my motive--and it may have been pride, for I used
+to be very proud--I certainly struggled to the door.  There, of course,
+I stumbled against Lady Brandon.  'You are not going to run away so
+soon, Mr. Hallward?' she screamed out.  You know her curiously shrill
+voice?"
+
+"Yes; she is a peacock in everything but beauty," said Lord Henry,
+pulling the daisy to bits with his long nervous fingers.
+
+"I could not get rid of her.  She brought me up to royalties, and
+people with stars and garters, and elderly ladies with gigantic tiaras
+and parrot noses.  She spoke of me as her dearest friend.  I had only
+met her once before, but she took it into her head to lionize me.  I
+believe some picture of mine had made a great success at the time, at
+least had been chattered about in the penny newspapers, which is the
+nineteenth-century standard of immortality.  Suddenly I found myself
+face to face with the young man whose personality had so strangely
+stirred me.  We were quite close, almost touching.  Our eyes met again.
+It was reckless of me, but I asked Lady Brandon to introduce me to him.
+Perhaps it was not so reckless, after all.  It was simply inevitable.
+We would have spoken to each other without any introduction.  I am sure
+of that.  Dorian told me so afterwards.  He, too, felt that we were
+destined to know each other."
+
+"And how did Lady Brandon describe this wonderful young man?" asked his
+companion.  "I know she goes in for giving a rapid _precis_ of all her
+guests.  I remember her bringing me up to a truculent and red-faced old
+gentleman covered all over with orders and ribbons, and hissing into my
+ear, in a tragic whisper which must have been perfectly audible to
+everybody in the room, the most astounding details.  I simply fled.  I
+like to find out people for myself.  But Lady Brandon treats her guests
+exactly as an auctioneer treats his goods.  She either explains them
+entirely away, or tells one everything about them except what one wants
+to know."
+
+"Poor Lady Brandon!  You are hard on her, Harry!" said Hallward
+listlessly.
+
+"My dear fellow, she tried to found a _salon_, and only succeeded in
+opening a restaurant.  How could I admire her?  But tell me, what did
+she say about Mr. Dorian Gray?"
+
+"Oh, something like, 'Charming boy--poor dear mother and I absolutely
+inseparable.  Quite forget what he does--afraid he--doesn't do
+anything--oh, yes, plays the piano--or is it the violin, dear Mr.
+Gray?'  Neither of us could help laughing, and we became friends at
+once."
+
+"Laughter is not at all a bad beginning for a friendship, and it is far
+the best ending for one," said the young lord, plucking another daisy.
+
+Hallward shook his head.  "You don't understand what friendship is,
+Harry," he murmured--"or what enmity is, for that matter.  You like
+every one; that is to say, you are indifferent to every one."
+
+"How horribly unjust of you!" cried Lord Henry, tilting his hat back
+and looking up at the little clouds that, like ravelled skeins of
+glossy white silk, were drifting across the hollowed turquoise of the
+summer sky.  "Yes; horribly unjust of you.  I make a great difference
+between people.  I choose my friends for their good looks, my
+acquaintances for their good characters, and my enemies for their good
+intellects.  A man cannot be too careful in the choice of his enemies.
+I have not got one who is a fool.  They are all men of some
+intellectual power, and consequently they all appreciate me.  Is that
+very vain of me?  I think it is rather vain."
+
+"I should think it was, Harry.  But according to your category I must
+be merely an acquaintance."
+
+"My dear old Basil, you are much more than an acquaintance."
+
+"And much less than a friend.  A sort of brother, I suppose?"
+
+"Oh, brothers!  I don't care for brothers.  My elder brother won't die,
+and my younger brothers seem never to do anything else."
+
+"Harry!" exclaimed Hallward, frowning.
+
+"My dear fellow, I am not quite serious.  But I can't help detesting my
+relations.  I suppose it comes from the fact that none of us can stand
+other people having the same faults as ourselves.  I quite sympathize
+with the rage of the English democracy against what they call the vices
+of the upper orders.  The masses feel that drunkenness, stupidity, and
+immorality should be their own special property, and that if any one of
+us makes an ass of himself, he is poaching on their preserves.  When
+poor Southwark got into the divorce court, their indignation was quite
+magnificent.  And yet I don't suppose that ten per cent of the
+proletariat live correctly."
+
+"I don't agree with a single word that you have said, and, what is
+more, Harry, I feel sure you don't either."
+
+Lord Henry stroked his pointed brown beard and tapped the toe of his
+patent-leather boot with a tasselled ebony cane.  "How English you are
+Basil!  That is the second time you have made that observation.  If one
+puts forward an idea to a true Englishman--always a rash thing to
+do--he never dreams of considering whether the idea is right or wrong.
+The only thing he considers of any importance is whether one believes
+it oneself.  Now, the value of an idea has nothing whatsoever to do
+with the sincerity of the man who expresses it.  Indeed, the
+probabilities are that the more insincere the man is, the more purely
+intellectual will the idea be, as in that case it will not be coloured
+by either his wants, his desires, or his prejudices.  However, I don't
+propose to discuss politics, sociology, or metaphysics with you.  I
+like persons better than principles, and I like persons with no
+principles better than anything else in the world.  Tell me more about
+Mr. Dorian Gray.  How often do you see him?"
+
+"Every day.  I couldn't be happy if I didn't see him every day.  He is
+absolutely necessary to me."
+
+"How extraordinary!  I thought you would never care for anything but
+your art."
+
+"He is all my art to me now," said the painter gravely.  "I sometimes
+think, Harry, that there are only two eras of any importance in the
+world's history.  The first is the appearance of a new medium for art,
+and the second is the appearance of a new personality for art also.
+What the invention of oil-painting was to the Venetians, the face of
+Antinous was to late Greek sculpture, and the face of Dorian Gray will
+some day be to me.  It is not merely that I paint from him, draw from
+him, sketch from him.  Of course, I have done all that.  But he is much
+more to me than a model or a sitter.  I won't tell you that I am
+dissatisfied with what I have done of him, or that his beauty is such
+that art cannot express it.  There is nothing that art cannot express,
+and I know that the work I have done, since I met Dorian Gray, is good
+work, is the best work of my life.  But in some curious way--I wonder
+will you understand me?--his personality has suggested to me an
+entirely new manner in art, an entirely new mode of style.  I see
+things differently, I think of them differently.  I can now recreate
+life in a way that was hidden from me before.  'A dream of form in days
+of thought'--who is it who says that?  I forget; but it is what Dorian
+Gray has been to me.  The merely visible presence of this lad--for he
+seems to me little more than a lad, though he is really over
+twenty--his merely visible presence--ah!  I wonder can you realize all
+that that means?  Unconsciously he defines for me the lines of a fresh
+school, a school that is to have in it all the passion of the romantic
+spirit, all the perfection of the spirit that is Greek.  The harmony of
+soul and body--how much that is!  We in our madness have separated the
+two, and have invented a realism that is vulgar, an ideality that is
+void.  Harry! if you only knew what Dorian Gray is to me!  You remember
+that landscape of mine, for which Agnew offered me such a huge price
+but which I would not part with?  It is one of the best things I have
+ever done.  And why is it so?  Because, while I was painting it, Dorian
+Gray sat beside me.  Some subtle influence passed from him to me, and
+for the first time in my life I saw in the plain woodland the wonder I
+had always looked for and always missed."
+
+"Basil, this is extraordinary!  I must see Dorian Gray."
+
+Hallward got up from the seat and walked up and down the garden.  After
+some time he came back.  "Harry," he said, "Dorian Gray is to me simply
+a motive in art.  You might see nothing in him.  I see everything in
+him.  He is never more present in my work than when no image of him is
+there.  He is a suggestion, as I have said, of a new manner.  I find
+him in the curves of certain lines, in the loveliness and subtleties of
+certain colours.  That is all."
+
+"Then why won't you exhibit his portrait?" asked Lord Henry.
+
+"Because, without intending it, I have put into it some expression of
+all this curious artistic idolatry, of which, of course, I have never
+cared to speak to him.  He knows nothing about it.  He shall never know
+anything about it.  But the world might guess it, and I will not bare
+my soul to their shallow prying eyes.  My heart shall never be put
+under their microscope.  There is too much of myself in the thing,
+Harry--too much of myself!"
+
+"Poets are not so scrupulous as you are.  They know how useful passion
+is for publication.  Nowadays a broken heart will run to many editions."
+
+"I hate them for it," cried Hallward.  "An artist should create
+beautiful things, but should put nothing of his own life into them.  We
+live in an age when men treat art as if it were meant to be a form of
+autobiography.  We have lost the abstract sense of beauty.  Some day I
+will show the world what it is; and for that reason the world shall
+never see my portrait of Dorian Gray."
+
+"I think you are wrong, Basil, but I won't argue with you.  It is only
+the intellectually lost who ever argue.  Tell me, is Dorian Gray very
+fond of you?"
+
+The painter considered for a few moments.  "He likes me," he answered
+after a pause; "I know he likes me.  Of course I flatter him
+dreadfully.  I find a strange pleasure in saying things to him that I
+know I shall be sorry for having said.  As a rule, he is charming to
+me, and we sit in the studio and talk of a thousand things.  Now and
+then, however, he is horribly thoughtless, and seems to take a real
+delight in giving me pain.  Then I feel, Harry, that I have given away
+my whole soul to some one who treats it as if it were a flower to put
+in his coat, a bit of decoration to charm his vanity, an ornament for a
+summer's day."
+
+"Days in summer, Basil, are apt to linger," murmured Lord Henry.
+"Perhaps you will tire sooner than he will.  It is a sad thing to think
+of, but there is no doubt that genius lasts longer than beauty.  That
+accounts for the fact that we all take such pains to over-educate
+ourselves.  In the wild struggle for existence, we want to have
+something that endures, and so we fill our minds with rubbish and
+facts, in the silly hope of keeping our place.  The thoroughly
+well-informed man--that is the modern ideal.  And the mind of the
+thoroughly well-informed man is a dreadful thing.  It is like a
+_bric-a-brac_ shop, all monsters and dust, with everything priced above
+its proper value.  I think you will tire first, all the same.  Some day
+you will look at your friend, and he will seem to you to be a little
+out of drawing, or you won't like his tone of colour, or something.
+You will bitterly reproach him in your own heart, and seriously think
+that he has behaved very badly to you.  The next time he calls, you
+will be perfectly cold and indifferent.  It will be a great pity, for
+it will alter you.  What you have told me is quite a romance, a romance
+of art one might call it, and the worst of having a romance of any kind
+is that it leaves one so unromantic."
+
+"Harry, don't talk like that.  As long as I live, the personality of
+Dorian Gray will dominate me.  You can't feel what I feel.  You change
+too often."
+
+"Ah, my dear Basil, that is exactly why I can feel it.  Those who are
+faithful know only the trivial side of love: it is the faithless who
+know love's tragedies."  And Lord Henry struck a light on a dainty
+silver case and began to smoke a cigarette with a self-conscious and
+satisfied air, as if he had summed up the world in a phrase.  There was
+a rustle of chirruping sparrows in the green lacquer leaves of the ivy,
+and the blue cloud-shadows chased themselves across the grass like
+swallows.  How pleasant it was in the garden!  And how delightful other
+people's emotions were!--much more delightful than their ideas, it
+seemed to him.  One's own soul, and the passions of one's
+friends--those were the fascinating things in life.  He pictured to
+himself with silent amusement the tedious luncheon that he had missed
+by staying so long with Basil Hallward.  Had he gone to his aunt's, he
+would have been sure to have met Lord Goodbody there, and the whole
+conversation would have been about the feeding of the poor and the
+necessity for model lodging-houses. Each class would have preached the
+importance of those virtues, for whose exercise there was no necessity
+in their own lives.  The rich would have spoken on the value of thrift,
+and the idle grown eloquent over the dignity of labour.  It was
+charming to have escaped all that!  As he thought of his aunt, an idea
+seemed to strike him.  He turned to Hallward and said, "My dear fellow,
+I have just remembered."
+
+"Remembered what, Harry?"
+
+"Where I heard the name of Dorian Gray."
+
+"Where was it?" asked Hallward, with a slight frown.
+
+"Don't look so angry, Basil.  It was at my aunt, Lady Agatha's.  She
+told me she had discovered a wonderful young man who was going to help
+her in the East End, and that his name was Dorian Gray.  I am bound to
+state that she never told me he was good-looking. Women have no
+appreciation of good looks; at least, good women have not.  She said
+that he was very earnest and had a beautiful nature.  I at once
+pictured to myself a creature with spectacles and lank hair, horribly
+freckled, and tramping about on huge feet.  I wish I had known it was
+your friend."
+
+"I am very glad you didn't, Harry."
+
+"Why?"
+
+"I don't want you to meet him."
+
+"You don't want me to meet him?"
+
+"No."
+
+"Mr. Dorian Gray is in the studio, sir," said the butler, coming into
+the garden.
+
+"You must introduce me now," cried Lord Henry, laughing.
+
+The painter turned to his servant, who stood blinking in the sunlight.
+"Ask Mr. Gray to wait, Parker:  I shall be in in a few moments." The
+man bowed and went up the walk.
+
+Then he looked at Lord Henry.  "Dorian Gray is my dearest friend," he
+said.  "He has a simple and a beautiful nature.  Your aunt was quite
+right in what she said of him.  Don't spoil him.  Don't try to
+influence him.  Your influence would be bad.  The world is wide, and
+has many marvellous people in it.  Don't take away from me the one
+person who gives to my art whatever charm it possesses:  my life as an
+artist depends on him.  Mind, Harry, I trust you."  He spoke very
+slowly, and the words seemed wrung out of him almost against his will.
+
+"What nonsense you talk!" said Lord Henry, smiling, and taking Hallward
+by the arm, he almost led him into the house.
+
+
+
+CHAPTER 2
+
+As they entered they saw Dorian Gray.  He was seated at the piano, with
+his back to them, turning over the pages of a volume of Schumann's
+"Forest Scenes."  "You must lend me these, Basil," he cried.  "I want
+to learn them.  They are perfectly charming."
+
+"That entirely depends on how you sit to-day, Dorian."
+
+"Oh, I am tired of sitting, and I don't want a life-sized portrait of
+myself," answered the lad, swinging round on the music-stool in a
+wilful, petulant manner.  When he caught sight of Lord Henry, a faint
+blush coloured his cheeks for a moment, and he started up.  "I beg your
+pardon, Basil, but I didn't know you had any one with you."
+
+"This is Lord Henry Wotton, Dorian, an old Oxford friend of mine.  I
+have just been telling him what a capital sitter you were, and now you
+have spoiled everything."
+
+"You have not spoiled my pleasure in meeting you, Mr. Gray," said Lord
+Henry, stepping forward and extending his hand.  "My aunt has often
+spoken to me about you.  You are one of her favourites, and, I am
+afraid, one of her victims also."
+
+"I am in Lady Agatha's black books at present," answered Dorian with a
+funny look of penitence.  "I promised to go to a club in Whitechapel
+with her last Tuesday, and I really forgot all about it.  We were to
+have played a duet together--three duets, I believe.  I don't know what
+she will say to me.  I am far too frightened to call."
+
+"Oh, I will make your peace with my aunt.  She is quite devoted to you.
+And I don't think it really matters about your not being there.  The
+audience probably thought it was a duet.  When Aunt Agatha sits down to
+the piano, she makes quite enough noise for two people."
+
+"That is very horrid to her, and not very nice to me," answered Dorian,
+laughing.
+
+Lord Henry looked at him.  Yes, he was certainly wonderfully handsome,
+with his finely curved scarlet lips, his frank blue eyes, his crisp
+gold hair.  There was something in his face that made one trust him at
+once.  All the candour of youth was there, as well as all youth's
+passionate purity.  One felt that he had kept himself unspotted from
+the world.  No wonder Basil Hallward worshipped him.
+
+"You are too charming to go in for philanthropy, Mr. Gray--far too
+charming." And Lord Henry flung himself down on the divan and opened
+his cigarette-case.
+
+The painter had been busy mixing his colours and getting his brushes
+ready.  He was looking worried, and when he heard Lord Henry's last
+remark, he glanced at him, hesitated for a moment, and then said,
+"Harry, I want to finish this picture to-day. Would you think it
+awfully rude of me if I asked you to go away?"
+
+Lord Henry smiled and looked at Dorian Gray.  "Am I to go, Mr. Gray?"
+he asked.
+
+"Oh, please don't, Lord Henry.  I see that Basil is in one of his sulky
+moods, and I can't bear him when he sulks.  Besides, I want you to tell
+me why I should not go in for philanthropy."
+
+"I don't know that I shall tell you that, Mr. Gray.  It is so tedious a
+subject that one would have to talk seriously about it.  But I
+certainly shall not run away, now that you have asked me to stop.  You
+don't really mind, Basil, do you?  You have often told me that you
+liked your sitters to have some one to chat to."
+
+Hallward bit his lip.  "If Dorian wishes it, of course you must stay.
+Dorian's whims are laws to everybody, except himself."
+
+Lord Henry took up his hat and gloves.  "You are very pressing, Basil,
+but I am afraid I must go.  I have promised to meet a man at the
+Orleans.  Good-bye, Mr. Gray.  Come and see me some afternoon in Curzon
+Street.  I am nearly always at home at five o'clock. Write to me when
+you are coming.  I should be sorry to miss you."
+
+"Basil," cried Dorian Gray, "if Lord Henry Wotton goes, I shall go,
+too.  You never open your lips while you are painting, and it is
+horribly dull standing on a platform and trying to look pleasant.  Ask
+him to stay.  I insist upon it."
+
+"Stay, Harry, to oblige Dorian, and to oblige me," said Hallward,
+gazing intently at his picture.  "It is quite true, I never talk when I
+am working, and never listen either, and it must be dreadfully tedious
+for my unfortunate sitters.  I beg you to stay."
+
+"But what about my man at the Orleans?"
+
+The painter laughed.  "I don't think there will be any difficulty about
+that.  Sit down again, Harry.  And now, Dorian, get up on the platform,
+and don't move about too much, or pay any attention to what Lord Henry
+says.  He has a very bad influence over all his friends, with the
+single exception of myself."
+
+Dorian Gray stepped up on the dais with the air of a young Greek
+martyr, and made a little _moue_ of discontent to Lord Henry, to whom he
+had rather taken a fancy.  He was so unlike Basil.  They made a
+delightful contrast.  And he had such a beautiful voice.  After a few
+moments he said to him, "Have you really a very bad influence, Lord
+Henry?  As bad as Basil says?"
+
+"There is no such thing as a good influence, Mr. Gray.  All influence
+is immoral--immoral from the scientific point of view."
+
+"Why?"
+
+"Because to influence a person is to give him one's own soul.  He does
+not think his natural thoughts, or burn with his natural passions.  His
+virtues are not real to him.  His sins, if there are such things as
+sins, are borrowed.  He becomes an echo of some one else's music, an
+actor of a part that has not been written for him.  The aim of life is
+self-development. To realize one's nature perfectly--that is what each
+of us is here for.  People are afraid of themselves, nowadays.  They
+have forgotten the highest of all duties, the duty that one owes to
+one's self.  Of course, they are charitable.  They feed the hungry and
+clothe the beggar.  But their own souls starve, and are naked.  Courage
+has gone out of our race.  Perhaps we never really had it.  The terror
+of society, which is the basis of morals, the terror of God, which is
+the secret of religion--these are the two things that govern us.  And
+yet--"
+
+"Just turn your head a little more to the right, Dorian, like a good
+boy," said the painter, deep in his work and conscious only that a look
+had come into the lad's face that he had never seen there before.
+
+"And yet," continued Lord Henry, in his low, musical voice, and with
+that graceful wave of the hand that was always so characteristic of
+him, and that he had even in his Eton days, "I believe that if one man
+were to live out his life fully and completely, were to give form to
+every feeling, expression to every thought, reality to every dream--I
+believe that the world would gain such a fresh impulse of joy that we
+would forget all the maladies of mediaevalism, and return to the
+Hellenic ideal--to something finer, richer than the Hellenic ideal, it
+may be.  But the bravest man amongst us is afraid of himself.  The
+mutilation of the savage has its tragic survival in the self-denial
+that mars our lives.  We are punished for our refusals.  Every impulse
+that we strive to strangle broods in the mind and poisons us.  The body
+sins once, and has done with its sin, for action is a mode of
+purification.  Nothing remains then but the recollection of a pleasure,
+or the luxury of a regret.  The only way to get rid of a temptation is
+to yield to it.  Resist it, and your soul grows sick with longing for
+the things it has forbidden to itself, with desire for what its
+monstrous laws have made monstrous and unlawful.  It has been said that
+the great events of the world take place in the brain.  It is in the
+brain, and the brain only, that the great sins of the world take place
+also.  You, Mr. Gray, you yourself, with your rose-red youth and your
+rose-white boyhood, you have had passions that have made you afraid,
+thoughts that have filled you with terror, day-dreams and sleeping
+dreams whose mere memory might stain your cheek with shame--"
+
+"Stop!" faltered Dorian Gray, "stop! you bewilder me.  I don't know
+what to say.  There is some answer to you, but I cannot find it.  Don't
+speak.  Let me think.  Or, rather, let me try not to think."
+
+For nearly ten minutes he stood there, motionless, with parted lips and
+eyes strangely bright.  He was dimly conscious that entirely fresh
+influences were at work within him.  Yet they seemed to him to have
+come really from himself.  The few words that Basil's friend had said
+to him--words spoken by chance, no doubt, and with wilful paradox in
+them--had touched some secret chord that had never been touched before,
+but that he felt was now vibrating and throbbing to curious pulses.
+
+Music had stirred him like that.  Music had troubled him many times.
+But music was not articulate.  It was not a new world, but rather
+another chaos, that it created in us.  Words!  Mere words!  How
+terrible they were!  How clear, and vivid, and cruel!  One could not
+escape from them.  And yet what a subtle magic there was in them!  They
+seemed to be able to give a plastic form to formless things, and to
+have a music of their own as sweet as that of viol or of lute.  Mere
+words!  Was there anything so real as words?
+
+Yes; there had been things in his boyhood that he had not understood.
+He understood them now.  Life suddenly became fiery-coloured to him.
+It seemed to him that he had been walking in fire.  Why had he not
+known it?
+
+With his subtle smile, Lord Henry watched him.  He knew the precise
+psychological moment when to say nothing.  He felt intensely
+interested.  He was amazed at the sudden impression that his words had
+produced, and, remembering a book that he had read when he was sixteen,
+a book which had revealed to him much that he had not known before, he
+wondered whether Dorian Gray was passing through a similar experience.
+He had merely shot an arrow into the air.  Had it hit the mark?  How
+fascinating the lad was!
+
+Hallward painted away with that marvellous bold touch of his, that had
+the true refinement and perfect delicacy that in art, at any rate comes
+only from strength.  He was unconscious of the silence.
+
+"Basil, I am tired of standing," cried Dorian Gray suddenly.  "I must
+go out and sit in the garden.  The air is stifling here."
+
+"My dear fellow, I am so sorry.  When I am painting, I can't think of
+anything else.  But you never sat better.  You were perfectly still.
+And I have caught the effect I wanted--the half-parted lips and the
+bright look in the eyes.  I don't know what Harry has been saying to
+you, but he has certainly made you have the most wonderful expression.
+I suppose he has been paying you compliments.  You mustn't believe a
+word that he says."
+
+"He has certainly not been paying me compliments.  Perhaps that is the
+reason that I don't believe anything he has told me."
+
+"You know you believe it all," said Lord Henry, looking at him with his
+dreamy languorous eyes.  "I will go out to the garden with you.  It is
+horribly hot in the studio.  Basil, let us have something iced to
+drink, something with strawberries in it."
+
+"Certainly, Harry.  Just touch the bell, and when Parker comes I will
+tell him what you want.  I have got to work up this background, so I
+will join you later on.  Don't keep Dorian too long.  I have never been
+in better form for painting than I am to-day. This is going to be my
+masterpiece.  It is my masterpiece as it stands."
+
+Lord Henry went out to the garden and found Dorian Gray burying his
+face in the great cool lilac-blossoms, feverishly drinking in their
+perfume as if it had been wine.  He came close to him and put his hand
+upon his shoulder.  "You are quite right to do that," he murmured.
+"Nothing can cure the soul but the senses, just as nothing can cure the
+senses but the soul."
+
+The lad started and drew back.  He was bareheaded, and the leaves had
+tossed his rebellious curls and tangled all their gilded threads.
+There was a look of fear in his eyes, such as people have when they are
+suddenly awakened.  His finely chiselled nostrils quivered, and some
+hidden nerve shook the scarlet of his lips and left them trembling.
+
+"Yes," continued Lord Henry, "that is one of the great secrets of
+life--to cure the soul by means of the senses, and the senses by means
+of the soul.  You are a wonderful creation.  You know more than you
+think you know, just as you know less than you want to know."
+
+Dorian Gray frowned and turned his head away.  He could not help liking
+the tall, graceful young man who was standing by him.  His romantic,
+olive-coloured face and worn expression interested him.  There was
+something in his low languid voice that was absolutely fascinating.
+His cool, white, flowerlike hands, even, had a curious charm.  They
+moved, as he spoke, like music, and seemed to have a language of their
+own.  But he felt afraid of him, and ashamed of being afraid.  Why had
+it been left for a stranger to reveal him to himself?  He had known
+Basil Hallward for months, but the friendship between them had never
+altered him.  Suddenly there had come some one across his life who
+seemed to have disclosed to him life's mystery.  And, yet, what was
+there to be afraid of?  He was not a schoolboy or a girl.  It was
+absurd to be frightened.
+
+"Let us go and sit in the shade," said Lord Henry.  "Parker has brought
+out the drinks, and if you stay any longer in this glare, you will be
+quite spoiled, and Basil will never paint you again.  You really must
+not allow yourself to become sunburnt.  It would be unbecoming."
+
+"What can it matter?" cried Dorian Gray, laughing, as he sat down on
+the seat at the end of the garden.
+
+"It should matter everything to you, Mr. Gray."
+
+"Why?"
+
+"Because you have the most marvellous youth, and youth is the one thing
+worth having."
+
+"I don't feel that, Lord Henry."
+
+"No, you don't feel it now.  Some day, when you are old and wrinkled
+and ugly, when thought has seared your forehead with its lines, and
+passion branded your lips with its hideous fires, you will feel it, you
+will feel it terribly.  Now, wherever you go, you charm the world.
+Will it always be so? ... You have a wonderfully beautiful face, Mr.
+Gray.  Don't frown.  You have.  And beauty is a form of genius--is
+higher, indeed, than genius, as it needs no explanation.  It is of the
+great facts of the world, like sunlight, or spring-time, or the
+reflection in dark waters of that silver shell we call the moon.  It
+cannot be questioned.  It has its divine right of sovereignty.  It
+makes princes of those who have it.  You smile?  Ah! when you have lost
+it you won't smile.... People say sometimes that beauty is only
+superficial.  That may be so, but at least it is not so superficial as
+thought is.  To me, beauty is the wonder of wonders.  It is only
+shallow people who do not judge by appearances.  The true mystery of
+the world is the visible, not the invisible.... Yes, Mr. Gray, the
+gods have been good to you.  But what the gods give they quickly take
+away.  You have only a few years in which to live really, perfectly,
+and fully.  When your youth goes, your beauty will go with it, and then
+you will suddenly discover that there are no triumphs left for you, or
+have to content yourself with those mean triumphs that the memory of
+your past will make more bitter than defeats.  Every month as it wanes
+brings you nearer to something dreadful.  Time is jealous of you, and
+wars against your lilies and your roses.  You will become sallow, and
+hollow-cheeked, and dull-eyed.  You will suffer horribly.... Ah!
+realize your youth while you have it.  Don't squander the gold of your
+days, listening to the tedious, trying to improve the hopeless failure,
+or giving away your life to the ignorant, the common, and the vulgar.
+These are the sickly aims, the false ideals, of our age.  Live!  Live
+the wonderful life that is in you!  Let nothing be lost upon you.  Be
+always searching for new sensations.  Be afraid of nothing.... A new
+Hedonism--that is what our century wants.  You might be its visible
+symbol.  With your personality there is nothing you could not do.  The
+world belongs to you for a season.... The moment I met you I saw that
+you were quite unconscious of what you really are, of what you really
+might be.  There was so much in you that charmed me that I felt I must
+tell you something about yourself.  I thought how tragic it would be if
+you were wasted.  For there is such a little time that your youth will
+last--such a little time.  The common hill-flowers wither, but they
+blossom again.  The laburnum will be as yellow next June as it is now.
+In a month there will be purple stars on the clematis, and year after
+year the green night of its leaves will hold its purple stars.  But we
+never get back our youth.  The pulse of joy that beats in us at twenty
+becomes sluggish.  Our limbs fail, our senses rot.  We degenerate into
+hideous puppets, haunted by the memory of the passions of which we were
+too much afraid, and the exquisite temptations that we had not the
+courage to yield to.  Youth!  Youth!  There is absolutely nothing in
+the world but youth!"
+
+Dorian Gray listened, open-eyed and wondering.  The spray of lilac fell
+from his hand upon the gravel.  A furry bee came and buzzed round it
+for a moment.  Then it began to scramble all over the oval stellated
+globe of the tiny blossoms.  He watched it with that strange interest
+in trivial things that we try to develop when things of high import
+make us afraid, or when we are stirred by some new emotion for which we
+cannot find expression, or when some thought that terrifies us lays
+sudden siege to the brain and calls on us to yield.  After a time the
+bee flew away.  He saw it creeping into the stained trumpet of a Tyrian
+convolvulus.  The flower seemed to quiver, and then swayed gently to
+and fro.
+
+Suddenly the painter appeared at the door of the studio and made
+staccato signs for them to come in.  They turned to each other and
+smiled.
+
+"I am waiting," he cried.  "Do come in.  The light is quite perfect,
+and you can bring your drinks."
+
+They rose up and sauntered down the walk together.  Two green-and-white
+butterflies fluttered past them, and in the pear-tree at the corner of
+the garden a thrush began to sing.
+
+"You are glad you have met me, Mr. Gray," said Lord Henry, looking at
+him.
+
+"Yes, I am glad now.  I wonder shall I always be glad?"
+
+"Always!  That is a dreadful word.  It makes me shudder when I hear it.
+Women are so fond of using it.  They spoil every romance by trying to
+make it last for ever.  It is a meaningless word, too.  The only
+difference between a caprice and a lifelong passion is that the caprice
+lasts a little longer."
+
+As they entered the studio, Dorian Gray put his hand upon Lord Henry's
+arm.  "In that case, let our friendship be a caprice," he murmured,
+flushing at his own boldness, then stepped up on the platform and
+resumed his pose.
+
+Lord Henry flung himself into a large wicker arm-chair and watched him.
+The sweep and dash of the brush on the canvas made the only sound that
+broke the stillness, except when, now and then, Hallward stepped back
+to look at his work from a distance.  In the slanting beams that
+streamed through the open doorway the dust danced and was golden.  The
+heavy scent of the roses seemed to brood over everything.
+
+After about a quarter of an hour Hallward stopped painting, looked for
+a long time at Dorian Gray, and then for a long time at the picture,
+biting the end of one of his huge brushes and frowning.  "It is quite
+finished," he cried at last, and stooping down he wrote his name in
+long vermilion letters on the left-hand corner of the canvas.
+
+Lord Henry came over and examined the picture.  It was certainly a
+wonderful work of art, and a wonderful likeness as well.
+
+"My dear fellow, I congratulate you most warmly," he said.  "It is the
+finest portrait of modern times.  Mr. Gray, come over and look at
+yourself."
+
+The lad started, as if awakened from some dream.
+
+"Is it really finished?" he murmured, stepping down from the platform.
+
+"Quite finished," said the painter.  "And you have sat splendidly
+to-day. I am awfully obliged to you."
+
+"That is entirely due to me," broke in Lord Henry.  "Isn't it, Mr.
+Gray?"
+
+Dorian made no answer, but passed listlessly in front of his picture
+and turned towards it.  When he saw it he drew back, and his cheeks
+flushed for a moment with pleasure.  A look of joy came into his eyes,
+as if he had recognized himself for the first time.  He stood there
+motionless and in wonder, dimly conscious that Hallward was speaking to
+him, but not catching the meaning of his words.  The sense of his own
+beauty came on him like a revelation.  He had never felt it before.
+Basil Hallward's compliments had seemed to him to be merely the
+charming exaggeration of friendship.  He had listened to them, laughed
+at them, forgotten them.  They had not influenced his nature.  Then had
+come Lord Henry Wotton with his strange panegyric on youth, his
+terrible warning of its brevity.  That had stirred him at the time, and
+now, as he stood gazing at the shadow of his own loveliness, the full
+reality of the description flashed across him.  Yes, there would be a
+day when his face would be wrinkled and wizen, his eyes dim and
+colourless, the grace of his figure broken and deformed.  The scarlet
+would pass away from his lips and the gold steal from his hair.  The
+life that was to make his soul would mar his body.  He would become
+dreadful, hideous, and uncouth.
+
+As he thought of it, a sharp pang of pain struck through him like a
+knife and made each delicate fibre of his nature quiver.  His eyes
+deepened into amethyst, and across them came a mist of tears.  He felt
+as if a hand of ice had been laid upon his heart.
+
+"Don't you like it?" cried Hallward at last, stung a little by the
+lad's silence, not understanding what it meant.
+
+"Of course he likes it," said Lord Henry.  "Who wouldn't like it?  It
+is one of the greatest things in modern art.  I will give you anything
+you like to ask for it.  I must have it."
+
+"It is not my property, Harry."
+
+"Whose property is it?"
+
+"Dorian's, of course," answered the painter.
+
+"He is a very lucky fellow."
+
+"How sad it is!" murmured Dorian Gray with his eyes still fixed upon
+his own portrait.  "How sad it is!  I shall grow old, and horrible, and
+dreadful.  But this picture will remain always young.  It will never be
+older than this particular day of June.... If it were only the other
+way!  If it were I who was to be always young, and the picture that was
+to grow old!  For that--for that--I would give everything!  Yes, there
+is nothing in the whole world I would not give!  I would give my soul
+for that!"
+
+"You would hardly care for such an arrangement, Basil," cried Lord
+Henry, laughing.  "It would be rather hard lines on your work."
+
+"I should object very strongly, Harry," said Hallward.
+
+Dorian Gray turned and looked at him.  "I believe you would, Basil.
+You like your art better than your friends.  I am no more to you than a
+green bronze figure.  Hardly as much, I dare say."
+
+The painter stared in amazement.  It was so unlike Dorian to speak like
+that.  What had happened?  He seemed quite angry.  His face was flushed
+and his cheeks burning.
+
+"Yes," he continued, "I am less to you than your ivory Hermes or your
+silver Faun.  You will like them always.  How long will you like me?
+Till I have my first wrinkle, I suppose.  I know, now, that when one
+loses one's good looks, whatever they may be, one loses everything.
+Your picture has taught me that.  Lord Henry Wotton is perfectly right.
+Youth is the only thing worth having.  When I find that I am growing
+old, I shall kill myself."
+
+Hallward turned pale and caught his hand.  "Dorian!  Dorian!" he cried,
+"don't talk like that.  I have never had such a friend as you, and I
+shall never have such another.  You are not jealous of material things,
+are you?--you who are finer than any of them!"
+
+"I am jealous of everything whose beauty does not die.  I am jealous of
+the portrait you have painted of me.  Why should it keep what I must
+lose?  Every moment that passes takes something from me and gives
+something to it.  Oh, if it were only the other way!  If the picture
+could change, and I could be always what I am now!  Why did you paint
+it?  It will mock me some day--mock me horribly!"  The hot tears welled
+into his eyes; he tore his hand away and, flinging himself on the
+divan, he buried his face in the cushions, as though he was praying.
+
+"This is your doing, Harry," said the painter bitterly.
+
+Lord Henry shrugged his shoulders.  "It is the real Dorian Gray--that
+is all."
+
+"It is not."
+
+"If it is not, what have I to do with it?"
+
+"You should have gone away when I asked you," he muttered.
+
+"I stayed when you asked me," was Lord Henry's answer.
+
+"Harry, I can't quarrel with my two best friends at once, but between
+you both you have made me hate the finest piece of work I have ever
+done, and I will destroy it.  What is it but canvas and colour?  I will
+not let it come across our three lives and mar them."
+
+Dorian Gray lifted his golden head from the pillow, and with pallid
+face and tear-stained eyes, looked at him as he walked over to the deal
+painting-table that was set beneath the high curtained window.  What
+was he doing there?  His fingers were straying about among the litter
+of tin tubes and dry brushes, seeking for something.  Yes, it was for
+the long palette-knife, with its thin blade of lithe steel.  He had
+found it at last.  He was going to rip up the canvas.
+
+With a stifled sob the lad leaped from the couch, and, rushing over to
+Hallward, tore the knife out of his hand, and flung it to the end of
+the studio.  "Don't, Basil, don't!" he cried.  "It would be murder!"
+
+"I am glad you appreciate my work at last, Dorian," said the painter
+coldly when he had recovered from his surprise.  "I never thought you
+would."
+
+"Appreciate it?  I am in love with it, Basil.  It is part of myself.  I
+feel that."
+
+"Well, as soon as you are dry, you shall be varnished, and framed, and
+sent home.  Then you can do what you like with yourself." And he walked
+across the room and rang the bell for tea.  "You will have tea, of
+course, Dorian?  And so will you, Harry?  Or do you object to such
+simple pleasures?"
+
+"I adore simple pleasures," said Lord Henry.  "They are the last refuge
+of the complex.  But I don't like scenes, except on the stage.  What
+absurd fellows you are, both of you!  I wonder who it was defined man
+as a rational animal.  It was the most premature definition ever given.
+Man is many things, but he is not rational.  I am glad he is not, after
+all--though I wish you chaps would not squabble over the picture.  You
+had much better let me have it, Basil.  This silly boy doesn't really
+want it, and I really do."
+
+"If you let any one have it but me, Basil, I shall never forgive you!"
+cried Dorian Gray; "and I don't allow people to call me a silly boy."
+
+"You know the picture is yours, Dorian.  I gave it to you before it
+existed."
+
+"And you know you have been a little silly, Mr. Gray, and that you
+don't really object to being reminded that you are extremely young."
+
+"I should have objected very strongly this morning, Lord Henry."
+
+"Ah! this morning!  You have lived since then."
+
+There came a knock at the door, and the butler entered with a laden
+tea-tray and set it down upon a small Japanese table.  There was a
+rattle of cups and saucers and the hissing of a fluted Georgian urn.
+Two globe-shaped china dishes were brought in by a page.  Dorian Gray
+went over and poured out the tea.  The two men sauntered languidly to
+the table and examined what was under the covers.
+
+"Let us go to the theatre to-night," said Lord Henry.  "There is sure
+to be something on, somewhere.  I have promised to dine at White's, but
+it is only with an old friend, so I can send him a wire to say that I
+am ill, or that I am prevented from coming in consequence of a
+subsequent engagement.  I think that would be a rather nice excuse:  it
+would have all the surprise of candour."
+
+"It is such a bore putting on one's dress-clothes," muttered Hallward.
+"And, when one has them on, they are so horrid."
+
+"Yes," answered Lord Henry dreamily, "the costume of the nineteenth
+century is detestable.  It is so sombre, so depressing.  Sin is the
+only real colour-element left in modern life."
+
+"You really must not say things like that before Dorian, Harry."
+
+"Before which Dorian?  The one who is pouring out tea for us, or the
+one in the picture?"
+
+"Before either."
+
+"I should like to come to the theatre with you, Lord Henry," said the
+lad.
+
+"Then you shall come; and you will come, too, Basil, won't you?"
+
+"I can't, really.  I would sooner not.  I have a lot of work to do."
+
+"Well, then, you and I will go alone, Mr. Gray."
+
+"I should like that awfully."
+
+The painter bit his lip and walked over, cup in hand, to the picture.
+"I shall stay with the real Dorian," he said, sadly.
+
+"Is it the real Dorian?" cried the original of the portrait, strolling
+across to him.  "Am I really like that?"
+
+"Yes; you are just like that."
+
+"How wonderful, Basil!"
+
+"At least you are like it in appearance.  But it will never alter,"
+sighed Hallward.  "That is something."
+
+"What a fuss people make about fidelity!" exclaimed Lord Henry.  "Why,
+even in love it is purely a question for physiology.  It has nothing to
+do with our own will.  Young men want to be faithful, and are not; old
+men want to be faithless, and cannot: that is all one can say."
+
+"Don't go to the theatre to-night, Dorian," said Hallward.  "Stop and
+dine with me."
+
+"I can't, Basil."
+
+"Why?"
+
+"Because I have promised Lord Henry Wotton to go with him."
+
+"He won't like you the better for keeping your promises.  He always
+breaks his own.  I beg you not to go."
+
+Dorian Gray laughed and shook his head.
+
+"I entreat you."
+
+The lad hesitated, and looked over at Lord Henry, who was watching them
+from the tea-table with an amused smile.
+
+"I must go, Basil," he answered.
+
+"Very well," said Hallward, and he went over and laid down his cup on
+the tray.  "It is rather late, and, as you have to dress, you had
+better lose no time.  Good-bye, Harry.  Good-bye, Dorian.  Come and see
+me soon.  Come to-morrow."
+
+"Certainly."
+
+"You won't forget?"
+
+"No, of course not," cried Dorian.
+
+"And ... Harry!"
+
+"Yes, Basil?"
+
+"Remember what I asked you, when we were in the garden this morning."
+
+"I have forgotten it."
+
+"I trust you."
+
+"I wish I could trust myself," said Lord Henry, laughing.  "Come, Mr.
+Gray, my hansom is outside, and I can drop you at your own place.
+Good-bye, Basil.  It has been a most interesting afternoon."
+
+As the door closed behind them, the painter flung himself down on a
+sofa, and a look of pain came into his face.
+
+
+
+CHAPTER 3
+
+At half-past twelve next day Lord Henry Wotton strolled from Curzon
+Street over to the Albany to call on his uncle, Lord Fermor, a genial
+if somewhat rough-mannered old bachelor, whom the outside world called
+selfish because it derived no particular benefit from him, but who was
+considered generous by Society as he fed the people who amused him.
+His father had been our ambassador at Madrid when Isabella was young
+and Prim unthought of, but had retired from the diplomatic service in a
+capricious moment of annoyance on not being offered the Embassy at
+Paris, a post to which he considered that he was fully entitled by
+reason of his birth, his indolence, the good English of his dispatches,
+and his inordinate passion for pleasure.  The son, who had been his
+father's secretary, had resigned along with his chief, somewhat
+foolishly as was thought at the time, and on succeeding some months
+later to the title, had set himself to the serious study of the great
+aristocratic art of doing absolutely nothing.  He had two large town
+houses, but preferred to live in chambers as it was less trouble, and
+took most of his meals at his club.  He paid some attention to the
+management of his collieries in the Midland counties, excusing himself
+for this taint of industry on the ground that the one advantage of
+having coal was that it enabled a gentleman to afford the decency of
+burning wood on his own hearth.  In politics he was a Tory, except when
+the Tories were in office, during which period he roundly abused them
+for being a pack of Radicals.  He was a hero to his valet, who bullied
+him, and a terror to most of his relations, whom he bullied in turn.
+Only England could have produced him, and he always said that the
+country was going to the dogs.  His principles were out of date, but
+there was a good deal to be said for his prejudices.
+
+When Lord Henry entered the room, he found his uncle sitting in a rough
+shooting-coat, smoking a cheroot and grumbling over _The Times_.  "Well,
+Harry," said the old gentleman, "what brings you out so early?  I
+thought you dandies never got up till two, and were not visible till
+five."
+
+"Pure family affection, I assure you, Uncle George.  I want to get
+something out of you."
+
+"Money, I suppose," said Lord Fermor, making a wry face.  "Well, sit
+down and tell me all about it.  Young people, nowadays, imagine that
+money is everything."
+
+"Yes," murmured Lord Henry, settling his button-hole in his coat; "and
+when they grow older they know it.  But I don't want money.  It is only
+people who pay their bills who want that, Uncle George, and I never pay
+mine.  Credit is the capital of a younger son, and one lives charmingly
+upon it.  Besides, I always deal with Dartmoor's tradesmen, and
+consequently they never bother me.  What I want is information:  not
+useful information, of course; useless information."
+
+"Well, I can tell you anything that is in an English Blue Book, Harry,
+although those fellows nowadays write a lot of nonsense.  When I was in
+the Diplomatic, things were much better.  But I hear they let them in
+now by examination.  What can you expect?  Examinations, sir, are pure
+humbug from beginning to end.  If a man is a gentleman, he knows quite
+enough, and if he is not a gentleman, whatever he knows is bad for him."
+
+"Mr. Dorian Gray does not belong to Blue Books, Uncle George," said
+Lord Henry languidly.
+
+"Mr. Dorian Gray?  Who is he?" asked Lord Fermor, knitting his bushy
+white eyebrows.
+
+"That is what I have come to learn, Uncle George.  Or rather, I know
+who he is.  He is the last Lord Kelso's grandson.  His mother was a
+Devereux, Lady Margaret Devereux.  I want you to tell me about his
+mother.  What was she like?  Whom did she marry?  You have known nearly
+everybody in your time, so you might have known her.  I am very much
+interested in Mr. Gray at present.  I have only just met him."
+
+"Kelso's grandson!" echoed the old gentleman.  "Kelso's grandson! ...
+Of course.... I knew his mother intimately.  I believe I was at her
+christening.  She was an extraordinarily beautiful girl, Margaret
+Devereux, and made all the men frantic by running away with a penniless
+young fellow--a mere nobody, sir, a subaltern in a foot regiment, or
+something of that kind.  Certainly.  I remember the whole thing as if
+it happened yesterday.  The poor chap was killed in a duel at Spa a few
+months after the marriage.  There was an ugly story about it.  They
+said Kelso got some rascally adventurer, some Belgian brute, to insult
+his son-in-law in public--paid him, sir, to do it, paid him--and that
+the fellow spitted his man as if he had been a pigeon.  The thing was
+hushed up, but, egad, Kelso ate his chop alone at the club for some
+time afterwards.  He brought his daughter back with him, I was told,
+and she never spoke to him again.  Oh, yes; it was a bad business.  The
+girl died, too, died within a year.  So she left a son, did she?  I had
+forgotten that.  What sort of boy is he?  If he is like his mother, he
+must be a good-looking chap."
+
+"He is very good-looking," assented Lord Henry.
+
+"I hope he will fall into proper hands," continued the old man.  "He
+should have a pot of money waiting for him if Kelso did the right thing
+by him.  His mother had money, too.  All the Selby property came to
+her, through her grandfather.  Her grandfather hated Kelso, thought him
+a mean dog.  He was, too.  Came to Madrid once when I was there.  Egad,
+I was ashamed of him.  The Queen used to ask me about the English noble
+who was always quarrelling with the cabmen about their fares.  They
+made quite a story of it.  I didn't dare show my face at Court for a
+month.  I hope he treated his grandson better than he did the jarvies."
+
+"I don't know," answered Lord Henry.  "I fancy that the boy will be
+well off.  He is not of age yet.  He has Selby, I know.  He told me so.
+And ... his mother was very beautiful?"
+
+"Margaret Devereux was one of the loveliest creatures I ever saw,
+Harry.  What on earth induced her to behave as she did, I never could
+understand.  She could have married anybody she chose.  Carlington was
+mad after her.  She was romantic, though.  All the women of that family
+were.  The men were a poor lot, but, egad! the women were wonderful.
+Carlington went on his knees to her.  Told me so himself.  She laughed
+at him, and there wasn't a girl in London at the time who wasn't after
+him.  And by the way, Harry, talking about silly marriages, what is
+this humbug your father tells me about Dartmoor wanting to marry an
+American?  Ain't English girls good enough for him?"
+
+"It is rather fashionable to marry Americans just now, Uncle George."
+
+"I'll back English women against the world, Harry," said Lord Fermor,
+striking the table with his fist.
+
+"The betting is on the Americans."
+
+"They don't last, I am told," muttered his uncle.
+
+"A long engagement exhausts them, but they are capital at a
+steeplechase.  They take things flying.  I don't think Dartmoor has a
+chance."
+
+"Who are her people?" grumbled the old gentleman.  "Has she got any?"
+
+Lord Henry shook his head.  "American girls are as clever at concealing
+their parents, as English women are at concealing their past," he said,
+rising to go.
+
+"They are pork-packers, I suppose?"
+
+"I hope so, Uncle George, for Dartmoor's sake.  I am told that
+pork-packing is the most lucrative profession in America, after
+politics."
+
+"Is she pretty?"
+
+"She behaves as if she was beautiful.  Most American women do.  It is
+the secret of their charm."
+
+"Why can't these American women stay in their own country?  They are
+always telling us that it is the paradise for women."
+
+"It is.  That is the reason why, like Eve, they are so excessively
+anxious to get out of it," said Lord Henry.  "Good-bye, Uncle George.
+I shall be late for lunch, if I stop any longer.  Thanks for giving me
+the information I wanted.  I always like to know everything about my
+new friends, and nothing about my old ones."
+
+"Where are you lunching, Harry?"
+
+"At Aunt Agatha's. I have asked myself and Mr. Gray.  He is her latest
+_protege_."
+
+"Humph! tell your Aunt Agatha, Harry, not to bother me any more with
+her charity appeals.  I am sick of them.  Why, the good woman thinks
+that I have nothing to do but to write cheques for her silly fads."
+
+"All right, Uncle George, I'll tell her, but it won't have any effect.
+Philanthropic people lose all sense of humanity.  It is their
+distinguishing characteristic."
+
+The old gentleman growled approvingly and rang the bell for his
+servant.  Lord Henry passed up the low arcade into Burlington Street
+and turned his steps in the direction of Berkeley Square.
+
+So that was the story of Dorian Gray's parentage.  Crudely as it had
+been told to him, it had yet stirred him by its suggestion of a
+strange, almost modern romance.  A beautiful woman risking everything
+for a mad passion.  A few wild weeks of happiness cut short by a
+hideous, treacherous crime.  Months of voiceless agony, and then a
+child born in pain.  The mother snatched away by death, the boy left to
+solitude and the tyranny of an old and loveless man.  Yes; it was an
+interesting background.  It posed the lad, made him more perfect, as it
+were.  Behind every exquisite thing that existed, there was something
+tragic.  Worlds had to be in travail, that the meanest flower might
+blow.... And how charming he had been at dinner the night before, as
+with startled eyes and lips parted in frightened pleasure he had sat
+opposite to him at the club, the red candleshades staining to a richer
+rose the wakening wonder of his face.  Talking to him was like playing
+upon an exquisite violin.  He answered to every touch and thrill of the
+bow.... There was something terribly enthralling in the exercise of
+influence.  No other activity was like it.  To project one's soul into
+some gracious form, and let it tarry there for a moment; to hear one's
+own intellectual views echoed back to one with all the added music of
+passion and youth; to convey one's temperament into another as though
+it were a subtle fluid or a strange perfume: there was a real joy in
+that--perhaps the most satisfying joy left to us in an age so limited
+and vulgar as our own, an age grossly carnal in its pleasures, and
+grossly common in its aims.... He was a marvellous type, too, this lad,
+whom by so curious a chance he had met in Basil's studio, or could be
+fashioned into a marvellous type, at any rate.  Grace was his, and the
+white purity of boyhood, and beauty such as old Greek marbles kept for
+us.  There was nothing that one could not do with him.  He could be
+made a Titan or a toy.  What a pity it was that such beauty was
+destined to fade! ...  And Basil?  From a psychological point of view,
+how interesting he was!  The new manner in art, the fresh mode of
+looking at life, suggested so strangely by the merely visible presence
+of one who was unconscious of it all; the silent spirit that dwelt in
+dim woodland, and walked unseen in open field, suddenly showing
+herself, Dryadlike and not afraid, because in his soul who sought for
+her there had been wakened that wonderful vision to which alone are
+wonderful things revealed; the mere shapes and patterns of things
+becoming, as it were, refined, and gaining a kind of symbolical value,
+as though they were themselves patterns of some other and more perfect
+form whose shadow they made real:  how strange it all was!  He
+remembered something like it in history.  Was it not Plato, that artist
+in thought, who had first analyzed it?  Was it not Buonarotti who had
+carved it in the coloured marbles of a sonnet-sequence? But in our own
+century it was strange.... Yes; he would try to be to Dorian Gray
+what, without knowing it, the lad was to the painter who had fashioned
+the wonderful portrait.  He would seek to dominate him--had already,
+indeed, half done so.  He would make that wonderful spirit his own.
+There was something fascinating in this son of love and death.
+
+Suddenly he stopped and glanced up at the houses.  He found that he had
+passed his aunt's some distance, and, smiling to himself, turned back.
+When he entered the somewhat sombre hall, the butler told him that they
+had gone in to lunch.  He gave one of the footmen his hat and stick and
+passed into the dining-room.
+
+"Late as usual, Harry," cried his aunt, shaking her head at him.
+
+He invented a facile excuse, and having taken the vacant seat next to
+her, looked round to see who was there.  Dorian bowed to him shyly from
+the end of the table, a flush of pleasure stealing into his cheek.
+Opposite was the Duchess of Harley, a lady of admirable good-nature and
+good temper, much liked by every one who knew her, and of those ample
+architectural proportions that in women who are not duchesses are
+described by contemporary historians as stoutness.  Next to her sat, on
+her right, Sir Thomas Burdon, a Radical member of Parliament, who
+followed his leader in public life and in private life followed the
+best cooks, dining with the Tories and thinking with the Liberals, in
+accordance with a wise and well-known rule.  The post on her left was
+occupied by Mr. Erskine of Treadley, an old gentleman of considerable
+charm and culture, who had fallen, however, into bad habits of silence,
+having, as he explained once to Lady Agatha, said everything that he
+had to say before he was thirty.  His own neighbour was Mrs. Vandeleur,
+one of his aunt's oldest friends, a perfect saint amongst women, but so
+dreadfully dowdy that she reminded one of a badly bound hymn-book.
+Fortunately for him she had on the other side Lord Faudel, a most
+intelligent middle-aged mediocrity, as bald as a ministerial statement
+in the House of Commons, with whom she was conversing in that intensely
+earnest manner which is the one unpardonable error, as he remarked once
+himself, that all really good people fall into, and from which none of
+them ever quite escape.
+
+"We are talking about poor Dartmoor, Lord Henry," cried the duchess,
+nodding pleasantly to him across the table.  "Do you think he will
+really marry this fascinating young person?"
+
+"I believe she has made up her mind to propose to him, Duchess."
+
+"How dreadful!" exclaimed Lady Agatha.  "Really, some one should
+interfere."
+
+"I am told, on excellent authority, that her father keeps an American
+dry-goods store," said Sir Thomas Burdon, looking supercilious.
+
+"My uncle has already suggested pork-packing, Sir Thomas."
+
+"Dry-goods! What are American dry-goods?" asked the duchess, raising
+her large hands in wonder and accentuating the verb.
+
+"American novels," answered Lord Henry, helping himself to some quail.
+
+The duchess looked puzzled.
+
+"Don't mind him, my dear," whispered Lady Agatha.  "He never means
+anything that he says."
+
+"When America was discovered," said the Radical member--and he began to
+give some wearisome facts.  Like all people who try to exhaust a
+subject, he exhausted his listeners.  The duchess sighed and exercised
+her privilege of interruption.  "I wish to goodness it never had been
+discovered at all!" she exclaimed.  "Really, our girls have no chance
+nowadays.  It is most unfair."
+
+"Perhaps, after all, America never has been discovered," said Mr.
+Erskine; "I myself would say that it had merely been detected."
+
+"Oh! but I have seen specimens of the inhabitants," answered the
+duchess vaguely.  "I must confess that most of them are extremely
+pretty.  And they dress well, too.  They get all their dresses in
+Paris.  I wish I could afford to do the same."
+
+"They say that when good Americans die they go to Paris," chuckled Sir
+Thomas, who had a large wardrobe of Humour's cast-off clothes.
+
+"Really!  And where do bad Americans go to when they die?" inquired the
+duchess.
+
+"They go to America," murmured Lord Henry.
+
+Sir Thomas frowned.  "I am afraid that your nephew is prejudiced
+against that great country," he said to Lady Agatha.  "I have travelled
+all over it in cars provided by the directors, who, in such matters,
+are extremely civil.  I assure you that it is an education to visit it."
+
+"But must we really see Chicago in order to be educated?" asked Mr.
+Erskine plaintively.  "I don't feel up to the journey."
+
+Sir Thomas waved his hand.  "Mr. Erskine of Treadley has the world on
+his shelves. We practical men like to see things, not to read about
+them. The Americans are an extremely interesting people. They are
+absolutely reasonable. I think that is their distinguishing
+characteristic. Yes, Mr. Erskine, an absolutely reasonable people. I
+assure you there is no nonsense about the Americans."
+
+"How dreadful!" cried Lord Henry.  "I can stand brute force, but brute
+reason is quite unbearable.  There is something unfair about its use.
+It is hitting below the intellect."
+
+"I do not understand you," said Sir Thomas, growing rather red.
+
+"I do, Lord Henry," murmured Mr. Erskine, with a smile.
+
+"Paradoxes are all very well in their way...." rejoined the baronet.
+
+"Was that a paradox?" asked Mr. Erskine.  "I did not think so.  Perhaps
+it was.  Well, the way of paradoxes is the way of truth.  To test
+reality we must see it on the tight rope.  When the verities become
+acrobats, we can judge them."
+
+"Dear me!" said Lady Agatha, "how you men argue!  I am sure I never can
+make out what you are talking about.  Oh!  Harry, I am quite vexed with
+you.  Why do you try to persuade our nice Mr. Dorian Gray to give up
+the East End?  I assure you he would be quite invaluable.  They would
+love his playing."
+
+"I want him to play to me," cried Lord Henry, smiling, and he looked
+down the table and caught a bright answering glance.
+
+"But they are so unhappy in Whitechapel," continued Lady Agatha.
+
+"I can sympathize with everything except suffering," said Lord Henry,
+shrugging his shoulders.  "I cannot sympathize with that.  It is too
+ugly, too horrible, too distressing.  There is something terribly
+morbid in the modern sympathy with pain.  One should sympathize with
+the colour, the beauty, the joy of life.  The less said about life's
+sores, the better."
+
+"Still, the East End is a very important problem," remarked Sir Thomas
+with a grave shake of the head.
+
+"Quite so," answered the young lord.  "It is the problem of slavery,
+and we try to solve it by amusing the slaves."
+
+The politician looked at him keenly.  "What change do you propose,
+then?" he asked.
+
+Lord Henry laughed.  "I don't desire to change anything in England
+except the weather," he answered.  "I am quite content with philosophic
+contemplation.  But, as the nineteenth century has gone bankrupt
+through an over-expenditure of sympathy, I would suggest that we should
+appeal to science to put us straight.  The advantage of the emotions is
+that they lead us astray, and the advantage of science is that it is
+not emotional."
+
+"But we have such grave responsibilities," ventured Mrs. Vandeleur
+timidly.
+
+"Terribly grave," echoed Lady Agatha.
+
+Lord Henry looked over at Mr. Erskine.  "Humanity takes itself too
+seriously.  It is the world's original sin.  If the caveman had known
+how to laugh, history would have been different."
+
+"You are really very comforting," warbled the duchess.  "I have always
+felt rather guilty when I came to see your dear aunt, for I take no
+interest at all in the East End.  For the future I shall be able to
+look her in the face without a blush."
+
+"A blush is very becoming, Duchess," remarked Lord Henry.
+
+"Only when one is young," she answered.  "When an old woman like myself
+blushes, it is a very bad sign.  Ah!  Lord Henry, I wish you would tell
+me how to become young again."
+
+He thought for a moment.  "Can you remember any great error that you
+committed in your early days, Duchess?" he asked, looking at her across
+the table.
+
+"A great many, I fear," she cried.
+
+"Then commit them over again," he said gravely.  "To get back one's
+youth, one has merely to repeat one's follies."
+
+"A delightful theory!" she exclaimed.  "I must put it into practice."
+
+"A dangerous theory!" came from Sir Thomas's tight lips.  Lady Agatha
+shook her head, but could not help being amused.  Mr. Erskine listened.
+
+"Yes," he continued, "that is one of the great secrets of life.
+Nowadays most people die of a sort of creeping common sense, and
+discover when it is too late that the only things one never regrets are
+one's mistakes."
+
+A laugh ran round the table.
+
+He played with the idea and grew wilful; tossed it into the air and
+transformed it; let it escape and recaptured it; made it iridescent
+with fancy and winged it with paradox.  The praise of folly, as he went
+on, soared into a philosophy, and philosophy herself became young, and
+catching the mad music of pleasure, wearing, one might fancy, her
+wine-stained robe and wreath of ivy, danced like a Bacchante over the
+hills of life, and mocked the slow Silenus for being sober.  Facts fled
+before her like frightened forest things.  Her white feet trod the huge
+press at which wise Omar sits, till the seething grape-juice rose round
+her bare limbs in waves of purple bubbles, or crawled in red foam over
+the vat's black, dripping, sloping sides.  It was an extraordinary
+improvisation.  He felt that the eyes of Dorian Gray were fixed on him,
+and the consciousness that amongst his audience there was one whose
+temperament he wished to fascinate seemed to give his wit keenness and
+to lend colour to his imagination.  He was brilliant, fantastic,
+irresponsible.  He charmed his listeners out of themselves, and they
+followed his pipe, laughing.  Dorian Gray never took his gaze off him,
+but sat like one under a spell, smiles chasing each other over his lips
+and wonder growing grave in his darkening eyes.
+
+At last, liveried in the costume of the age, reality entered the room
+in the shape of a servant to tell the duchess that her carriage was
+waiting.  She wrung her hands in mock despair.  "How annoying!" she
+cried.  "I must go.  I have to call for my husband at the club, to take
+him to some absurd meeting at Willis's Rooms, where he is going to be
+in the chair.  If I am late he is sure to be furious, and I couldn't
+have a scene in this bonnet.  It is far too fragile.  A harsh word
+would ruin it.  No, I must go, dear Agatha.  Good-bye, Lord Henry, you
+are quite delightful and dreadfully demoralizing.  I am sure I don't
+know what to say about your views.  You must come and dine with us some
+night.  Tuesday?  Are you disengaged Tuesday?"
+
+"For you I would throw over anybody, Duchess," said Lord Henry with a
+bow.
+
+"Ah! that is very nice, and very wrong of you," she cried; "so mind you
+come"; and she swept out of the room, followed by Lady Agatha and the
+other ladies.
+
+When Lord Henry had sat down again, Mr. Erskine moved round, and taking
+a chair close to him, placed his hand upon his arm.
+
+"You talk books away," he said; "why don't you write one?"
+
+"I am too fond of reading books to care to write them, Mr. Erskine.  I
+should like to write a novel certainly, a novel that would be as lovely
+as a Persian carpet and as unreal.  But there is no literary public in
+England for anything except newspapers, primers, and encyclopaedias.
+Of all people in the world the English have the least sense of the
+beauty of literature."
+
+"I fear you are right," answered Mr. Erskine.  "I myself used to have
+literary ambitions, but I gave them up long ago.  And now, my dear
+young friend, if you will allow me to call you so, may I ask if you
+really meant all that you said to us at lunch?"
+
+"I quite forget what I said," smiled Lord Henry.  "Was it all very bad?"
+
+"Very bad indeed.  In fact I consider you extremely dangerous, and if
+anything happens to our good duchess, we shall all look on you as being
+primarily responsible.  But I should like to talk to you about life.
+The generation into which I was born was tedious.  Some day, when you
+are tired of London, come down to Treadley and expound to me your
+philosophy of pleasure over some admirable Burgundy I am fortunate
+enough to possess."
+
+"I shall be charmed.  A visit to Treadley would be a great privilege.
+It has a perfect host, and a perfect library."
+
+"You will complete it," answered the old gentleman with a courteous
+bow.  "And now I must bid good-bye to your excellent aunt.  I am due at
+the Athenaeum.  It is the hour when we sleep there."
+
+"All of you, Mr. Erskine?"
+
+"Forty of us, in forty arm-chairs. We are practising for an English
+Academy of Letters."
+
+Lord Henry laughed and rose.  "I am going to the park," he cried.
+
+As he was passing out of the door, Dorian Gray touched him on the arm.
+"Let me come with you," he murmured.
+
+"But I thought you had promised Basil Hallward to go and see him,"
+answered Lord Henry.
+
+"I would sooner come with you; yes, I feel I must come with you.  Do
+let me.  And you will promise to talk to me all the time?  No one talks
+so wonderfully as you do."
+
+"Ah!  I have talked quite enough for to-day," said Lord Henry, smiling.
+"All I want now is to look at life.  You may come and look at it with
+me, if you care to."
+
+
+
+CHAPTER 4
+
+One afternoon, a month later, Dorian Gray was reclining in a luxurious
+arm-chair, in the little library of Lord Henry's house in Mayfair.  It
+was, in its way, a very charming room, with its high panelled
+wainscoting of olive-stained oak, its cream-coloured frieze and ceiling
+of raised plasterwork, and its brickdust felt carpet strewn with silk,
+long-fringed Persian rugs.  On a tiny satinwood table stood a statuette
+by Clodion, and beside it lay a copy of Les Cent Nouvelles, bound for
+Margaret of Valois by Clovis Eve and powdered with the gilt daisies
+that Queen had selected for her device.  Some large blue china jars and
+parrot-tulips were ranged on the mantelshelf, and through the small
+leaded panes of the window streamed the apricot-coloured light of a
+summer day in London.
+
+Lord Henry had not yet come in.  He was always late on principle, his
+principle being that punctuality is the thief of time.  So the lad was
+looking rather sulky, as with listless fingers he turned over the pages
+of an elaborately illustrated edition of Manon Lescaut that he had
+found in one of the book-cases. The formal monotonous ticking of the
+Louis Quatorze clock annoyed him.  Once or twice he thought of going
+away.
+
+At last he heard a step outside, and the door opened.  "How late you
+are, Harry!" he murmured.
+
+"I am afraid it is not Harry, Mr. Gray," answered a shrill voice.
+
+He glanced quickly round and rose to his feet.  "I beg your pardon.  I
+thought--"
+
+"You thought it was my husband.  It is only his wife.  You must let me
+introduce myself.  I know you quite well by your photographs.  I think
+my husband has got seventeen of them."
+
+"Not seventeen, Lady Henry?"
+
+"Well, eighteen, then.  And I saw you with him the other night at the
+opera."  She laughed nervously as she spoke, and watched him with her
+vague forget-me-not eyes.  She was a curious woman, whose dresses
+always looked as if they had been designed in a rage and put on in a
+tempest.  She was usually in love with somebody, and, as her passion
+was never returned, she had kept all her illusions.  She tried to look
+picturesque, but only succeeded in being untidy.  Her name was
+Victoria, and she had a perfect mania for going to church.
+
+"That was at Lohengrin, Lady Henry, I think?"
+
+"Yes; it was at dear Lohengrin.  I like Wagner's music better than
+anybody's. It is so loud that one can talk the whole time without other
+people hearing what one says.  That is a great advantage, don't you
+think so, Mr. Gray?"
+
+The same nervous staccato laugh broke from her thin lips, and her
+fingers began to play with a long tortoise-shell paper-knife.
+
+Dorian smiled and shook his head:  "I am afraid I don't think so, Lady
+Henry.  I never talk during music--at least, during good music.  If one
+hears bad music, it is one's duty to drown it in conversation."
+
+"Ah! that is one of Harry's views, isn't it, Mr. Gray?  I always hear
+Harry's views from his friends.  It is the only way I get to know of
+them.  But you must not think I don't like good music.  I adore it, but
+I am afraid of it.  It makes me too romantic.  I have simply worshipped
+pianists--two at a time, sometimes, Harry tells me.  I don't know what
+it is about them.  Perhaps it is that they are foreigners.  They all
+are, ain't they?  Even those that are born in England become foreigners
+after a time, don't they?  It is so clever of them, and such a
+compliment to art.  Makes it quite cosmopolitan, doesn't it?  You have
+never been to any of my parties, have you, Mr. Gray?  You must come.  I
+can't afford orchids, but I spare no expense in foreigners.  They make
+one's rooms look so picturesque.  But here is Harry!  Harry, I came in
+to look for you, to ask you something--I forget what it was--and I
+found Mr. Gray here.  We have had such a pleasant chat about music.  We
+have quite the same ideas.  No; I think our ideas are quite different.
+But he has been most pleasant.  I am so glad I've seen him."
+
+"I am charmed, my love, quite charmed," said Lord Henry, elevating his
+dark, crescent-shaped eyebrows and looking at them both with an amused
+smile.  "So sorry I am late, Dorian.  I went to look after a piece of
+old brocade in Wardour Street and had to bargain for hours for it.
+Nowadays people know the price of everything and the value of nothing."
+
+"I am afraid I must be going," exclaimed Lady Henry, breaking an
+awkward silence with her silly sudden laugh.  "I have promised to drive
+with the duchess.  Good-bye, Mr. Gray.  Good-bye, Harry.  You are
+dining out, I suppose?  So am I. Perhaps I shall see you at Lady
+Thornbury's."
+
+"I dare say, my dear," said Lord Henry, shutting the door behind her
+as, looking like a bird of paradise that had been out all night in the
+rain, she flitted out of the room, leaving a faint odour of
+frangipanni.  Then he lit a cigarette and flung himself down on the
+sofa.
+
+"Never marry a woman with straw-coloured hair, Dorian," he said after a
+few puffs.
+
+"Why, Harry?"
+
+"Because they are so sentimental."
+
+"But I like sentimental people."
+
+"Never marry at all, Dorian.  Men marry because they are tired; women,
+because they are curious:  both are disappointed."
+
+"I don't think I am likely to marry, Harry.  I am too much in love.
+That is one of your aphorisms.  I am putting it into practice, as I do
+everything that you say."
+
+"Who are you in love with?" asked Lord Henry after a pause.
+
+"With an actress," said Dorian Gray, blushing.
+
+Lord Henry shrugged his shoulders.  "That is a rather commonplace
+_debut_."
+
+"You would not say so if you saw her, Harry."
+
+"Who is she?"
+
+"Her name is Sibyl Vane."
+
+"Never heard of her."
+
+"No one has.  People will some day, however.  She is a genius."
+
+"My dear boy, no woman is a genius.  Women are a decorative sex.  They
+never have anything to say, but they say it charmingly.  Women
+represent the triumph of matter over mind, just as men represent the
+triumph of mind over morals."
+
+"Harry, how can you?"
+
+"My dear Dorian, it is quite true.  I am analysing women at present, so
+I ought to know.  The subject is not so abstruse as I thought it was.
+I find that, ultimately, there are only two kinds of women, the plain
+and the coloured.  The plain women are very useful.  If you want to
+gain a reputation for respectability, you have merely to take them down
+to supper.  The other women are very charming.  They commit one
+mistake, however.  They paint in order to try and look young.  Our
+grandmothers painted in order to try and talk brilliantly.  _Rouge_ and
+_esprit_ used to go together.  That is all over now.  As long as a woman
+can look ten years younger than her own daughter, she is perfectly
+satisfied.  As for conversation, there are only five women in London
+worth talking to, and two of these can't be admitted into decent
+society.  However, tell me about your genius.  How long have you known
+her?"
+
+"Ah!  Harry, your views terrify me."
+
+"Never mind that.  How long have you known her?"
+
+"About three weeks."
+
+"And where did you come across her?"
+
+"I will tell you, Harry, but you mustn't be unsympathetic about it.
+After all, it never would have happened if I had not met you.  You
+filled me with a wild desire to know everything about life.  For days
+after I met you, something seemed to throb in my veins.  As I lounged
+in the park, or strolled down Piccadilly, I used to look at every one
+who passed me and wonder, with a mad curiosity, what sort of lives they
+led.  Some of them fascinated me.  Others filled me with terror.  There
+was an exquisite poison in the air.  I had a passion for sensations....
+Well, one evening about seven o'clock, I determined to go out in search
+of some adventure.  I felt that this grey monstrous London of ours,
+with its myriads of people, its sordid sinners, and its splendid sins,
+as you once phrased it, must have something in store for me.  I fancied
+a thousand things.  The mere danger gave me a sense of delight.  I
+remembered what you had said to me on that wonderful evening when we
+first dined together, about the search for beauty being the real secret
+of life.  I don't know what I expected, but I went out and wandered
+eastward, soon losing my way in a labyrinth of grimy streets and black
+grassless squares.  About half-past eight I passed by an absurd little
+theatre, with great flaring gas-jets and gaudy play-bills.  A hideous
+Jew, in the most amazing waistcoat I ever beheld in my life, was
+standing at the entrance, smoking a vile cigar.  He had greasy
+ringlets, and an enormous diamond blazed in the centre of a soiled
+shirt. 'Have a box, my Lord?' he said, when he saw me, and he took off
+his hat with an air of gorgeous servility.  There was something about
+him, Harry, that amused me.  He was such a monster.  You will laugh at
+me, I know, but I really went in and paid a whole guinea for the
+stage-box. To the present day I can't make out why I did so; and yet if
+I hadn't--my dear Harry, if I hadn't--I should have missed the greatest
+romance of my life.  I see you are laughing.  It is horrid of you!"
+
+"I am not laughing, Dorian; at least I am not laughing at you.  But you
+should not say the greatest romance of your life.  You should say the
+first romance of your life.  You will always be loved, and you will
+always be in love with love.  A _grande passion_ is the privilege of
+people who have nothing to do.  That is the one use of the idle classes
+of a country.  Don't be afraid.  There are exquisite things in store
+for you.  This is merely the beginning."
+
+"Do you think my nature so shallow?" cried Dorian Gray angrily.
+
+"No; I think your nature so deep."
+
+"How do you mean?"
+
+"My dear boy, the people who love only once in their lives are really
+the shallow people.  What they call their loyalty, and their fidelity,
+I call either the lethargy of custom or their lack of imagination.
+Faithfulness is to the emotional life what consistency is to the life
+of the intellect--simply a confession of failure.  Faithfulness!  I
+must analyse it some day.  The passion for property is in it.  There
+are many things that we would throw away if we were not afraid that
+others might pick them up.  But I don't want to interrupt you.  Go on
+with your story."
+
+"Well, I found myself seated in a horrid little private box, with a
+vulgar drop-scene staring me in the face.  I looked out from behind the
+curtain and surveyed the house.  It was a tawdry affair, all Cupids and
+cornucopias, like a third-rate wedding-cake. The gallery and pit were
+fairly full, but the two rows of dingy stalls were quite empty, and
+there was hardly a person in what I suppose they called the
+dress-circle.  Women went about with oranges and ginger-beer, and there
+was a terrible consumption of nuts going on."
+
+"It must have been just like the palmy days of the British drama."
+
+"Just like, I should fancy, and very depressing.  I began to wonder
+what on earth I should do when I caught sight of the play-bill.  What
+do you think the play was, Harry?"
+
+"I should think 'The Idiot Boy', or 'Dumb but Innocent'.  Our fathers
+used to like that sort of piece, I believe.  The longer I live, Dorian,
+the more keenly I feel that whatever was good enough for our fathers is
+not good enough for us.  In art, as in politics, _les grandperes ont
+toujours tort_."
+
+"This play was good enough for us, Harry.  It was Romeo and Juliet.  I
+must admit that I was rather annoyed at the idea of seeing Shakespeare
+done in such a wretched hole of a place.  Still, I felt interested, in
+a sort of way.  At any rate, I determined to wait for the first act.
+There was a dreadful orchestra, presided over by a young Hebrew who sat
+at a cracked piano, that nearly drove me away, but at last the
+drop-scene was drawn up and the play began.  Romeo was a stout elderly
+gentleman, with corked eyebrows, a husky tragedy voice, and a figure
+like a beer-barrel. Mercutio was almost as bad.  He was played by the
+low-comedian, who had introduced gags of his own and was on most
+friendly terms with the pit.  They were both as grotesque as the
+scenery, and that looked as if it had come out of a country-booth. But
+Juliet!  Harry, imagine a girl, hardly seventeen years of age, with a
+little, flowerlike face, a small Greek head with plaited coils of
+dark-brown hair, eyes that were violet wells of passion, lips that were
+like the petals of a rose.  She was the loveliest thing I had ever seen
+in my life.  You said to me once that pathos left you unmoved, but that
+beauty, mere beauty, could fill your eyes with tears.  I tell you,
+Harry, I could hardly see this girl for the mist of tears that came
+across me.  And her voice--I never heard such a voice.  It was very low
+at first, with deep mellow notes that seemed to fall singly upon one's
+ear.  Then it became a little louder, and sounded like a flute or a
+distant hautboy.  In the garden-scene it had all the tremulous ecstasy
+that one hears just before dawn when nightingales are singing.  There
+were moments, later on, when it had the wild passion of violins.  You
+know how a voice can stir one.  Your voice and the voice of Sibyl Vane
+are two things that I shall never forget.  When I close my eyes, I hear
+them, and each of them says something different.  I don't know which to
+follow.  Why should I not love her?  Harry, I do love her.  She is
+everything to me in life.  Night after night I go to see her play.  One
+evening she is Rosalind, and the next evening she is Imogen.  I have
+seen her die in the gloom of an Italian tomb, sucking the poison from
+her lover's lips.  I have watched her wandering through the forest of
+Arden, disguised as a pretty boy in hose and doublet and dainty cap.
+She has been mad, and has come into the presence of a guilty king, and
+given him rue to wear and bitter herbs to taste of.  She has been
+innocent, and the black hands of jealousy have crushed her reedlike
+throat.  I have seen her in every age and in every costume.  Ordinary
+women never appeal to one's imagination.  They are limited to their
+century.  No glamour ever transfigures them.  One knows their minds as
+easily as one knows their bonnets.  One can always find them.  There is
+no mystery in any of them.  They ride in the park in the morning and
+chatter at tea-parties in the afternoon.  They have their stereotyped
+smile and their fashionable manner.  They are quite obvious.  But an
+actress!  How different an actress is!  Harry! why didn't you tell me
+that the only thing worth loving is an actress?"
+
+"Because I have loved so many of them, Dorian."
+
+"Oh, yes, horrid people with dyed hair and painted faces."
+
+"Don't run down dyed hair and painted faces.  There is an extraordinary
+charm in them, sometimes," said Lord Henry.
+
+"I wish now I had not told you about Sibyl Vane."
+
+"You could not have helped telling me, Dorian.  All through your life
+you will tell me everything you do."
+
+"Yes, Harry, I believe that is true.  I cannot help telling you things.
+You have a curious influence over me.  If I ever did a crime, I would
+come and confess it to you.  You would understand me."
+
+"People like you--the wilful sunbeams of life--don't commit crimes,
+Dorian.  But I am much obliged for the compliment, all the same.  And
+now tell me--reach me the matches, like a good boy--thanks--what are
+your actual relations with Sibyl Vane?"
+
+Dorian Gray leaped to his feet, with flushed cheeks and burning eyes.
+"Harry!  Sibyl Vane is sacred!"
+
+"It is only the sacred things that are worth touching, Dorian," said
+Lord Henry, with a strange touch of pathos in his voice.  "But why
+should you be annoyed?  I suppose she will belong to you some day.
+When one is in love, one always begins by deceiving one's self, and one
+always ends by deceiving others.  That is what the world calls a
+romance.  You know her, at any rate, I suppose?"
+
+"Of course I know her.  On the first night I was at the theatre, the
+horrid old Jew came round to the box after the performance was over and
+offered to take me behind the scenes and introduce me to her.  I was
+furious with him, and told him that Juliet had been dead for hundreds
+of years and that her body was lying in a marble tomb in Verona.  I
+think, from his blank look of amazement, that he was under the
+impression that I had taken too much champagne, or something."
+
+"I am not surprised."
+
+"Then he asked me if I wrote for any of the newspapers.  I told him I
+never even read them.  He seemed terribly disappointed at that, and
+confided to me that all the dramatic critics were in a conspiracy
+against him, and that they were every one of them to be bought."
+
+"I should not wonder if he was quite right there.  But, on the other
+hand, judging from their appearance, most of them cannot be at all
+expensive."
+
+"Well, he seemed to think they were beyond his means," laughed Dorian.
+"By this time, however, the lights were being put out in the theatre,
+and I had to go.  He wanted me to try some cigars that he strongly
+recommended.  I declined.  The next night, of course, I arrived at the
+place again.  When he saw me, he made me a low bow and assured me that
+I was a munificent patron of art.  He was a most offensive brute,
+though he had an extraordinary passion for Shakespeare.  He told me
+once, with an air of pride, that his five bankruptcies were entirely
+due to 'The Bard,' as he insisted on calling him.  He seemed to think
+it a distinction."
+
+"It was a distinction, my dear Dorian--a great distinction.  Most
+people become bankrupt through having invested too heavily in the prose
+of life.  To have ruined one's self over poetry is an honour.  But when
+did you first speak to Miss Sibyl Vane?"
+
+"The third night.  She had been playing Rosalind.  I could not help
+going round.  I had thrown her some flowers, and she had looked at
+me--at least I fancied that she had.  The old Jew was persistent.  He
+seemed determined to take me behind, so I consented.  It was curious my
+not wanting to know her, wasn't it?"
+
+"No; I don't think so."
+
+"My dear Harry, why?"
+
+"I will tell you some other time.  Now I want to know about the girl."
+
+"Sibyl?  Oh, she was so shy and so gentle.  There is something of a
+child about her.  Her eyes opened wide in exquisite wonder when I told
+her what I thought of her performance, and she seemed quite unconscious
+of her power.  I think we were both rather nervous.  The old Jew stood
+grinning at the doorway of the dusty greenroom, making elaborate
+speeches about us both, while we stood looking at each other like
+children.  He would insist on calling me 'My Lord,' so I had to assure
+Sibyl that I was not anything of the kind.  She said quite simply to
+me, 'You look more like a prince.  I must call you Prince Charming.'"
+
+"Upon my word, Dorian, Miss Sibyl knows how to pay compliments."
+
+"You don't understand her, Harry.  She regarded me merely as a person
+in a play.  She knows nothing of life.  She lives with her mother, a
+faded tired woman who played Lady Capulet in a sort of magenta
+dressing-wrapper on the first night, and looks as if she had seen
+better days."
+
+"I know that look.  It depresses me," murmured Lord Henry, examining
+his rings.
+
+"The Jew wanted to tell me her history, but I said it did not interest
+me."
+
+"You were quite right.  There is always something infinitely mean about
+other people's tragedies."
+
+"Sibyl is the only thing I care about.  What is it to me where she came
+from?  From her little head to her little feet, she is absolutely and
+entirely divine.  Every night of my life I go to see her act, and every
+night she is more marvellous."
+
+"That is the reason, I suppose, that you never dine with me now.  I
+thought you must have some curious romance on hand.  You have; but it
+is not quite what I expected."
+
+"My dear Harry, we either lunch or sup together every day, and I have
+been to the opera with you several times," said Dorian, opening his
+blue eyes in wonder.
+
+"You always come dreadfully late."
+
+"Well, I can't help going to see Sibyl play," he cried, "even if it is
+only for a single act.  I get hungry for her presence; and when I think
+of the wonderful soul that is hidden away in that little ivory body, I
+am filled with awe."
+
+"You can dine with me to-night, Dorian, can't you?"
+
+He shook his head.  "To-night she is Imogen," he answered, "and
+to-morrow night she will be Juliet."
+
+"When is she Sibyl Vane?"
+
+"Never."
+
+"I congratulate you."
+
+"How horrid you are!  She is all the great heroines of the world in
+one.  She is more than an individual.  You laugh, but I tell you she
+has genius.  I love her, and I must make her love me.  You, who know
+all the secrets of life, tell me how to charm Sibyl Vane to love me!  I
+want to make Romeo jealous.  I want the dead lovers of the world to
+hear our laughter and grow sad.  I want a breath of our passion to stir
+their dust into consciousness, to wake their ashes into pain.  My God,
+Harry, how I worship her!"  He was walking up and down the room as he
+spoke.  Hectic spots of red burned on his cheeks.  He was terribly
+excited.
+
+Lord Henry watched him with a subtle sense of pleasure.  How different
+he was now from the shy frightened boy he had met in Basil Hallward's
+studio!  His nature had developed like a flower, had borne blossoms of
+scarlet flame.  Out of its secret hiding-place had crept his soul, and
+desire had come to meet it on the way.
+
+"And what do you propose to do?" said Lord Henry at last.
+
+"I want you and Basil to come with me some night and see her act.  I
+have not the slightest fear of the result.  You are certain to
+acknowledge her genius.  Then we must get her out of the Jew's hands.
+She is bound to him for three years--at least for two years and eight
+months--from the present time.  I shall have to pay him something, of
+course.  When all that is settled, I shall take a West End theatre and
+bring her out properly.  She will make the world as mad as she has made
+me."
+
+"That would be impossible, my dear boy."
+
+"Yes, she will.  She has not merely art, consummate art-instinct, in
+her, but she has personality also; and you have often told me that it
+is personalities, not principles, that move the age."
+
+"Well, what night shall we go?"
+
+"Let me see.  To-day is Tuesday.  Let us fix to-morrow. She plays
+Juliet to-morrow."
+
+"All right.  The Bristol at eight o'clock; and I will get Basil."
+
+"Not eight, Harry, please.  Half-past six.  We must be there before the
+curtain rises.  You must see her in the first act, where she meets
+Romeo."
+
+"Half-past six!  What an hour!  It will be like having a meat-tea, or
+reading an English novel.  It must be seven.  No gentleman dines before
+seven.  Shall you see Basil between this and then?  Or shall I write to
+him?"
+
+"Dear Basil!  I have not laid eyes on him for a week.  It is rather
+horrid of me, as he has sent me my portrait in the most wonderful
+frame, specially designed by himself, and, though I am a little jealous
+of the picture for being a whole month younger than I am, I must admit
+that I delight in it.  Perhaps you had better write to him.  I don't
+want to see him alone.  He says things that annoy me.  He gives me good
+advice."
+
+Lord Henry smiled.  "People are very fond of giving away what they need
+most themselves.  It is what I call the depth of generosity."
+
+"Oh, Basil is the best of fellows, but he seems to me to be just a bit
+of a Philistine.  Since I have known you, Harry, I have discovered
+that."
+
+"Basil, my dear boy, puts everything that is charming in him into his
+work.  The consequence is that he has nothing left for life but his
+prejudices, his principles, and his common sense.  The only artists I
+have ever known who are personally delightful are bad artists.  Good
+artists exist simply in what they make, and consequently are perfectly
+uninteresting in what they are.  A great poet, a really great poet, is
+the most unpoetical of all creatures.  But inferior poets are
+absolutely fascinating.  The worse their rhymes are, the more
+picturesque they look.  The mere fact of having published a book of
+second-rate sonnets makes a man quite irresistible.  He lives the
+poetry that he cannot write.  The others write the poetry that they
+dare not realize."
+
+"I wonder is that really so, Harry?" said Dorian Gray, putting some
+perfume on his handkerchief out of a large, gold-topped bottle that
+stood on the table.  "It must be, if you say it.  And now I am off.
+Imogen is waiting for me.  Don't forget about to-morrow. Good-bye."
+
+As he left the room, Lord Henry's heavy eyelids drooped, and he began
+to think.  Certainly few people had ever interested him so much as
+Dorian Gray, and yet the lad's mad adoration of some one else caused
+him not the slightest pang of annoyance or jealousy.  He was pleased by
+it.  It made him a more interesting study.  He had been always
+enthralled by the methods of natural science, but the ordinary
+subject-matter of that science had seemed to him trivial and of no
+import.  And so he had begun by vivisecting himself, as he had ended by
+vivisecting others.  Human life--that appeared to him the one thing
+worth investigating.  Compared to it there was nothing else of any
+value.  It was true that as one watched life in its curious crucible of
+pain and pleasure, one could not wear over one's face a mask of glass,
+nor keep the sulphurous fumes from troubling the brain and making the
+imagination turbid with monstrous fancies and misshapen dreams.  There
+were poisons so subtle that to know their properties one had to sicken
+of them.  There were maladies so strange that one had to pass through
+them if one sought to understand their nature.  And, yet, what a great
+reward one received!  How wonderful the whole world became to one!  To
+note the curious hard logic of passion, and the emotional coloured life
+of the intellect--to observe where they met, and where they separated,
+at what point they were in unison, and at what point they were at
+discord--there was a delight in that!  What matter what the cost was?
+One could never pay too high a price for any sensation.
+
+He was conscious--and the thought brought a gleam of pleasure into his
+brown agate eyes--that it was through certain words of his, musical
+words said with musical utterance, that Dorian Gray's soul had turned
+to this white girl and bowed in worship before her.  To a large extent
+the lad was his own creation.  He had made him premature.  That was
+something.  Ordinary people waited till life disclosed to them its
+secrets, but to the few, to the elect, the mysteries of life were
+revealed before the veil was drawn away.  Sometimes this was the effect
+of art, and chiefly of the art of literature, which dealt immediately
+with the passions and the intellect.  But now and then a complex
+personality took the place and assumed the office of art, was indeed,
+in its way, a real work of art, life having its elaborate masterpieces,
+just as poetry has, or sculpture, or painting.
+
+Yes, the lad was premature.  He was gathering his harvest while it was
+yet spring.  The pulse and passion of youth were in him, but he was
+becoming self-conscious. It was delightful to watch him.  With his
+beautiful face, and his beautiful soul, he was a thing to wonder at.
+It was no matter how it all ended, or was destined to end.  He was like
+one of those gracious figures in a pageant or a play, whose joys seem
+to be remote from one, but whose sorrows stir one's sense of beauty,
+and whose wounds are like red roses.
+
+Soul and body, body and soul--how mysterious they were!  There was
+animalism in the soul, and the body had its moments of spirituality.
+The senses could refine, and the intellect could degrade.  Who could
+say where the fleshly impulse ceased, or the psychical impulse began?
+How shallow were the arbitrary definitions of ordinary psychologists!
+And yet how difficult to decide between the claims of the various
+schools!  Was the soul a shadow seated in the house of sin?  Or was the
+body really in the soul, as Giordano Bruno thought?  The separation of
+spirit from matter was a mystery, and the union of spirit with matter
+was a mystery also.
+
+He began to wonder whether we could ever make psychology so absolute a
+science that each little spring of life would be revealed to us.  As it
+was, we always misunderstood ourselves and rarely understood others.
+Experience was of no ethical value.  It was merely the name men gave to
+their mistakes.  Moralists had, as a rule, regarded it as a mode of
+warning, had claimed for it a certain ethical efficacy in the formation
+of character, had praised it as something that taught us what to follow
+and showed us what to avoid.  But there was no motive power in
+experience.  It was as little of an active cause as conscience itself.
+All that it really demonstrated was that our future would be the same
+as our past, and that the sin we had done once, and with loathing, we
+would do many times, and with joy.
+
+It was clear to him that the experimental method was the only method by
+which one could arrive at any scientific analysis of the passions; and
+certainly Dorian Gray was a subject made to his hand, and seemed to
+promise rich and fruitful results.  His sudden mad love for Sibyl Vane
+was a psychological phenomenon of no small interest.  There was no
+doubt that curiosity had much to do with it, curiosity and the desire
+for new experiences, yet it was not a simple, but rather a very complex
+passion.  What there was in it of the purely sensuous instinct of
+boyhood had been transformed by the workings of the imagination,
+changed into something that seemed to the lad himself to be remote from
+sense, and was for that very reason all the more dangerous.  It was the
+passions about whose origin we deceived ourselves that tyrannized most
+strongly over us.  Our weakest motives were those of whose nature we
+were conscious.  It often happened that when we thought we were
+experimenting on others we were really experimenting on ourselves.
+
+While Lord Henry sat dreaming on these things, a knock came to the
+door, and his valet entered and reminded him it was time to dress for
+dinner.  He got up and looked out into the street.  The sunset had
+smitten into scarlet gold the upper windows of the houses opposite.
+The panes glowed like plates of heated metal.  The sky above was like a
+faded rose.  He thought of his friend's young fiery-coloured life and
+wondered how it was all going to end.
+
+When he arrived home, about half-past twelve o'clock, he saw a telegram
+lying on the hall table.  He opened it and found it was from Dorian
+Gray.  It was to tell him that he was engaged to be married to Sibyl
+Vane.
+
+
+
+CHAPTER 5
+
+"Mother, Mother, I am so happy!" whispered the girl, burying her face
+in the lap of the faded, tired-looking woman who, with back turned to
+the shrill intrusive light, was sitting in the one arm-chair that their
+dingy sitting-room contained.  "I am so happy!" she repeated, "and you
+must be happy, too!"
+
+Mrs. Vane winced and put her thin, bismuth-whitened hands on her
+daughter's head.  "Happy!" she echoed, "I am only happy, Sibyl, when I
+see you act.  You must not think of anything but your acting.  Mr.
+Isaacs has been very good to us, and we owe him money."
+
+The girl looked up and pouted.  "Money, Mother?" she cried, "what does
+money matter?  Love is more than money."
+
+"Mr. Isaacs has advanced us fifty pounds to pay off our debts and to
+get a proper outfit for James.  You must not forget that, Sibyl.  Fifty
+pounds is a very large sum.  Mr. Isaacs has been most considerate."
+
+"He is not a gentleman, Mother, and I hate the way he talks to me,"
+said the girl, rising to her feet and going over to the window.
+
+"I don't know how we could manage without him," answered the elder
+woman querulously.
+
+Sibyl Vane tossed her head and laughed.  "We don't want him any more,
+Mother.  Prince Charming rules life for us now." Then she paused.  A
+rose shook in her blood and shadowed her cheeks.  Quick breath parted
+the petals of her lips.  They trembled.  Some southern wind of passion
+swept over her and stirred the dainty folds of her dress.  "I love
+him," she said simply.
+
+"Foolish child! foolish child!" was the parrot-phrase flung in answer.
+The waving of crooked, false-jewelled fingers gave grotesqueness to the
+words.
+
+The girl laughed again.  The joy of a caged bird was in her voice.  Her
+eyes caught the melody and echoed it in radiance, then closed for a
+moment, as though to hide their secret.  When they opened, the mist of
+a dream had passed across them.
+
+Thin-lipped wisdom spoke at her from the worn chair, hinted at
+prudence, quoted from that book of cowardice whose author apes the name
+of common sense.  She did not listen.  She was free in her prison of
+passion.  Her prince, Prince Charming, was with her.  She had called on
+memory to remake him.  She had sent her soul to search for him, and it
+had brought him back.  His kiss burned again upon her mouth.  Her
+eyelids were warm with his breath.
+
+Then wisdom altered its method and spoke of espial and discovery.  This
+young man might be rich.  If so, marriage should be thought of.
+Against the shell of her ear broke the waves of worldly cunning.  The
+arrows of craft shot by her.  She saw the thin lips moving, and smiled.
+
+Suddenly she felt the need to speak.  The wordy silence troubled her.
+"Mother, Mother," she cried, "why does he love me so much?  I know why
+I love him.  I love him because he is like what love himself should be.
+But what does he see in me?  I am not worthy of him.  And yet--why, I
+cannot tell--though I feel so much beneath him, I don't feel humble.  I
+feel proud, terribly proud.  Mother, did you love my father as I love
+Prince Charming?"
+
+The elder woman grew pale beneath the coarse powder that daubed her
+cheeks, and her dry lips twitched with a spasm of pain.  Sybil rushed
+to her, flung her arms round her neck, and kissed her.  "Forgive me,
+Mother.  I know it pains you to talk about our father.  But it only
+pains you because you loved him so much.  Don't look so sad.  I am as
+happy to-day as you were twenty years ago.  Ah! let me be happy for
+ever!"
+
+"My child, you are far too young to think of falling in love.  Besides,
+what do you know of this young man?  You don't even know his name.  The
+whole thing is most inconvenient, and really, when James is going away
+to Australia, and I have so much to think of, I must say that you
+should have shown more consideration.  However, as I said before, if he
+is rich ..."
+
+"Ah!  Mother, Mother, let me be happy!"
+
+Mrs. Vane glanced at her, and with one of those false theatrical
+gestures that so often become a mode of second nature to a
+stage-player, clasped her in her arms.  At this moment, the door opened
+and a young lad with rough brown hair came into the room.  He was
+thick-set of figure, and his hands and feet were large and somewhat
+clumsy in movement.  He was not so finely bred as his sister.  One
+would hardly have guessed the close relationship that existed between
+them.  Mrs. Vane fixed her eyes on him and intensified her smile.  She
+mentally elevated her son to the dignity of an audience.  She felt sure
+that the _tableau_ was interesting.
+
+"You might keep some of your kisses for me, Sibyl, I think," said the
+lad with a good-natured grumble.
+
+"Ah! but you don't like being kissed, Jim," she cried.  "You are a
+dreadful old bear."  And she ran across the room and hugged him.
+
+James Vane looked into his sister's face with tenderness.  "I want you
+to come out with me for a walk, Sibyl.  I don't suppose I shall ever
+see this horrid London again.  I am sure I don't want to."
+
+"My son, don't say such dreadful things," murmured Mrs. Vane, taking up
+a tawdry theatrical dress, with a sigh, and beginning to patch it.  She
+felt a little disappointed that he had not joined the group.  It would
+have increased the theatrical picturesqueness of the situation.
+
+"Why not, Mother?  I mean it."
+
+"You pain me, my son.  I trust you will return from Australia in a
+position of affluence.  I believe there is no society of any kind in
+the Colonies--nothing that I would call society--so when you have made
+your fortune, you must come back and assert yourself in London."
+
+"Society!" muttered the lad.  "I don't want to know anything about
+that.  I should like to make some money to take you and Sibyl off the
+stage.  I hate it."
+
+"Oh, Jim!" said Sibyl, laughing, "how unkind of you!  But are you
+really going for a walk with me?  That will be nice!  I was afraid you
+were going to say good-bye to some of your friends--to Tom Hardy, who
+gave you that hideous pipe, or Ned Langton, who makes fun of you for
+smoking it.  It is very sweet of you to let me have your last
+afternoon.  Where shall we go?  Let us go to the park."
+
+"I am too shabby," he answered, frowning.  "Only swell people go to the
+park."
+
+"Nonsense, Jim," she whispered, stroking the sleeve of his coat.
+
+He hesitated for a moment.  "Very well," he said at last, "but don't be
+too long dressing."  She danced out of the door.  One could hear her
+singing as she ran upstairs.  Her little feet pattered overhead.
+
+He walked up and down the room two or three times.  Then he turned to
+the still figure in the chair.  "Mother, are my things ready?" he asked.
+
+"Quite ready, James," she answered, keeping her eyes on her work.  For
+some months past she had felt ill at ease when she was alone with this
+rough stern son of hers.  Her shallow secret nature was troubled when
+their eyes met.  She used to wonder if he suspected anything.  The
+silence, for he made no other observation, became intolerable to her.
+She began to complain.  Women defend themselves by attacking, just as
+they attack by sudden and strange surrenders.  "I hope you will be
+contented, James, with your sea-faring life," she said.  "You must
+remember that it is your own choice.  You might have entered a
+solicitor's office.  Solicitors are a very respectable class, and in
+the country often dine with the best families."
+
+"I hate offices, and I hate clerks," he replied.  "But you are quite
+right.  I have chosen my own life.  All I say is, watch over Sibyl.
+Don't let her come to any harm.  Mother, you must watch over her."
+
+"James, you really talk very strangely.  Of course I watch over Sibyl."
+
+"I hear a gentleman comes every night to the theatre and goes behind to
+talk to her.  Is that right?  What about that?"
+
+"You are speaking about things you don't understand, James.  In the
+profession we are accustomed to receive a great deal of most gratifying
+attention.  I myself used to receive many bouquets at one time.  That
+was when acting was really understood.  As for Sibyl, I do not know at
+present whether her attachment is serious or not.  But there is no
+doubt that the young man in question is a perfect gentleman.  He is
+always most polite to me.  Besides, he has the appearance of being
+rich, and the flowers he sends are lovely."
+
+"You don't know his name, though," said the lad harshly.
+
+"No," answered his mother with a placid expression in her face.  "He
+has not yet revealed his real name.  I think it is quite romantic of
+him.  He is probably a member of the aristocracy."
+
+James Vane bit his lip.  "Watch over Sibyl, Mother," he cried, "watch
+over her."
+
+"My son, you distress me very much.  Sibyl is always under my special
+care.  Of course, if this gentleman is wealthy, there is no reason why
+she should not contract an alliance with him.  I trust he is one of the
+aristocracy.  He has all the appearance of it, I must say.  It might be
+a most brilliant marriage for Sibyl.  They would make a charming
+couple.  His good looks are really quite remarkable; everybody notices
+them."
+
+The lad muttered something to himself and drummed on the window-pane
+with his coarse fingers.  He had just turned round to say something
+when the door opened and Sibyl ran in.
+
+"How serious you both are!" she cried.  "What is the matter?"
+
+"Nothing," he answered.  "I suppose one must be serious sometimes.
+Good-bye, Mother; I will have my dinner at five o'clock. Everything is
+packed, except my shirts, so you need not trouble."
+
+"Good-bye, my son," she answered with a bow of strained stateliness.
+
+She was extremely annoyed at the tone he had adopted with her, and
+there was something in his look that had made her feel afraid.
+
+"Kiss me, Mother," said the girl.  Her flowerlike lips touched the
+withered cheek and warmed its frost.
+
+"My child! my child!" cried Mrs. Vane, looking up to the ceiling in
+search of an imaginary gallery.
+
+"Come, Sibyl," said her brother impatiently.  He hated his mother's
+affectations.
+
+They went out into the flickering, wind-blown sunlight and strolled
+down the dreary Euston Road.  The passersby glanced in wonder at the
+sullen heavy youth who, in coarse, ill-fitting clothes, was in the
+company of such a graceful, refined-looking girl.  He was like a common
+gardener walking with a rose.
+
+Jim frowned from time to time when he caught the inquisitive glance of
+some stranger.  He had that dislike of being stared at, which comes on
+geniuses late in life and never leaves the commonplace.  Sibyl,
+however, was quite unconscious of the effect she was producing.  Her
+love was trembling in laughter on her lips.  She was thinking of Prince
+Charming, and, that she might think of him all the more, she did not
+talk of him, but prattled on about the ship in which Jim was going to
+sail, about the gold he was certain to find, about the wonderful
+heiress whose life he was to save from the wicked, red-shirted
+bushrangers.  For he was not to remain a sailor, or a supercargo, or
+whatever he was going to be.  Oh, no!  A sailor's existence was
+dreadful.  Fancy being cooped up in a horrid ship, with the hoarse,
+hump-backed waves trying to get in, and a black wind blowing the masts
+down and tearing the sails into long screaming ribands!  He was to
+leave the vessel at Melbourne, bid a polite good-bye to the captain,
+and go off at once to the gold-fields. Before a week was over he was to
+come across a large nugget of pure gold, the largest nugget that had
+ever been discovered, and bring it down to the coast in a waggon
+guarded by six mounted policemen.  The bushrangers were to attack them
+three times, and be defeated with immense slaughter.  Or, no.  He was
+not to go to the gold-fields at all.  They were horrid places, where
+men got intoxicated, and shot each other in bar-rooms, and used bad
+language.  He was to be a nice sheep-farmer, and one evening, as he was
+riding home, he was to see the beautiful heiress being carried off by a
+robber on a black horse, and give chase, and rescue her.  Of course,
+she would fall in love with him, and he with her, and they would get
+married, and come home, and live in an immense house in London.  Yes,
+there were delightful things in store for him.  But he must be very
+good, and not lose his temper, or spend his money foolishly.  She was
+only a year older than he was, but she knew so much more of life.  He
+must be sure, also, to write to her by every mail, and to say his
+prayers each night before he went to sleep.  God was very good, and
+would watch over him.  She would pray for him, too, and in a few years
+he would come back quite rich and happy.
+
+The lad listened sulkily to her and made no answer.  He was heart-sick
+at leaving home.
+
+Yet it was not this alone that made him gloomy and morose.
+Inexperienced though he was, he had still a strong sense of the danger
+of Sibyl's position.  This young dandy who was making love to her could
+mean her no good.  He was a gentleman, and he hated him for that, hated
+him through some curious race-instinct for which he could not account,
+and which for that reason was all the more dominant within him.  He was
+conscious also of the shallowness and vanity of his mother's nature,
+and in that saw infinite peril for Sibyl and Sibyl's happiness.
+Children begin by loving their parents; as they grow older they judge
+them; sometimes they forgive them.
+
+His mother!  He had something on his mind to ask of her, something that
+he had brooded on for many months of silence.  A chance phrase that he
+had heard at the theatre, a whispered sneer that had reached his ears
+one night as he waited at the stage-door, had set loose a train of
+horrible thoughts.  He remembered it as if it had been the lash of a
+hunting-crop across his face.  His brows knit together into a wedge-like
+furrow, and with a twitch of pain he bit his underlip.
+
+"You are not listening to a word I am saying, Jim," cried Sibyl, "and I
+am making the most delightful plans for your future.  Do say something."
+
+"What do you want me to say?"
+
+"Oh! that you will be a good boy and not forget us," she answered,
+smiling at him.
+
+He shrugged his shoulders.  "You are more likely to forget me than I am
+to forget you, Sibyl."
+
+She flushed.  "What do you mean, Jim?" she asked.
+
+"You have a new friend, I hear.  Who is he?  Why have you not told me
+about him?  He means you no good."
+
+"Stop, Jim!" she exclaimed.  "You must not say anything against him.  I
+love him."
+
+"Why, you don't even know his name," answered the lad.  "Who is he?  I
+have a right to know."
+
+"He is called Prince Charming.  Don't you like the name.  Oh! you silly
+boy! you should never forget it.  If you only saw him, you would think
+him the most wonderful person in the world.  Some day you will meet
+him--when you come back from Australia.  You will like him so much.
+Everybody likes him, and I ... love him.  I wish you could come to the
+theatre to-night. He is going to be there, and I am to play Juliet.
+Oh! how I shall play it!  Fancy, Jim, to be in love and play Juliet!
+To have him sitting there!  To play for his delight!  I am afraid I may
+frighten the company, frighten or enthrall them.  To be in love is to
+surpass one's self.  Poor dreadful Mr. Isaacs will be shouting 'genius'
+to his loafers at the bar.  He has preached me as a dogma; to-night he
+will announce me as a revelation.  I feel it.  And it is all his, his
+only, Prince Charming, my wonderful lover, my god of graces.  But I am
+poor beside him.  Poor?  What does that matter?  When poverty creeps in
+at the door, love flies in through the window.  Our proverbs want
+rewriting.  They were made in winter, and it is summer now; spring-time
+for me, I think, a very dance of blossoms in blue skies."
+
+"He is a gentleman," said the lad sullenly.
+
+"A prince!" she cried musically.  "What more do you want?"
+
+"He wants to enslave you."
+
+"I shudder at the thought of being free."
+
+"I want you to beware of him."
+
+"To see him is to worship him; to know him is to trust him."
+
+"Sibyl, you are mad about him."
+
+She laughed and took his arm.  "You dear old Jim, you talk as if you
+were a hundred.  Some day you will be in love yourself.  Then you will
+know what it is.  Don't look so sulky.  Surely you should be glad to
+think that, though you are going away, you leave me happier than I have
+ever been before.  Life has been hard for us both, terribly hard and
+difficult.  But it will be different now.  You are going to a new
+world, and I have found one.  Here are two chairs; let us sit down and
+see the smart people go by."
+
+They took their seats amidst a crowd of watchers.  The tulip-beds
+across the road flamed like throbbing rings of fire.  A white
+dust--tremulous cloud of orris-root it seemed--hung in the panting air.
+The brightly coloured parasols danced and dipped like monstrous
+butterflies.
+
+She made her brother talk of himself, his hopes, his prospects.  He
+spoke slowly and with effort.  They passed words to each other as
+players at a game pass counters.  Sibyl felt oppressed.  She could not
+communicate her joy.  A faint smile curving that sullen mouth was all
+the echo she could win.  After some time she became silent.  Suddenly
+she caught a glimpse of golden hair and laughing lips, and in an open
+carriage with two ladies Dorian Gray drove past.
+
+She started to her feet.  "There he is!" she cried.
+
+"Who?" said Jim Vane.
+
+"Prince Charming," she answered, looking after the victoria.
+
+He jumped up and seized her roughly by the arm.  "Show him to me.
+Which is he?  Point him out.  I must see him!" he exclaimed; but at
+that moment the Duke of Berwick's four-in-hand came between, and when
+it had left the space clear, the carriage had swept out of the park.
+
+"He is gone," murmured Sibyl sadly.  "I wish you had seen him."
+
+"I wish I had, for as sure as there is a God in heaven, if he ever does
+you any wrong, I shall kill him."
+
+She looked at him in horror.  He repeated his words.  They cut the air
+like a dagger.  The people round began to gape.  A lady standing close
+to her tittered.
+
+"Come away, Jim; come away," she whispered.  He followed her doggedly
+as she passed through the crowd.  He felt glad at what he had said.
+
+When they reached the Achilles Statue, she turned round.  There was
+pity in her eyes that became laughter on her lips.  She shook her head
+at him.  "You are foolish, Jim, utterly foolish; a bad-tempered boy,
+that is all.  How can you say such horrible things?  You don't know
+what you are talking about.  You are simply jealous and unkind.  Ah!  I
+wish you would fall in love.  Love makes people good, and what you said
+was wicked."
+
+"I am sixteen," he answered, "and I know what I am about.  Mother is no
+help to you.  She doesn't understand how to look after you.  I wish now
+that I was not going to Australia at all.  I have a great mind to chuck
+the whole thing up.  I would, if my articles hadn't been signed."
+
+"Oh, don't be so serious, Jim.  You are like one of the heroes of those
+silly melodramas Mother used to be so fond of acting in.  I am not
+going to quarrel with you.  I have seen him, and oh! to see him is
+perfect happiness.  We won't quarrel.  I know you would never harm any
+one I love, would you?"
+
+"Not as long as you love him, I suppose," was the sullen answer.
+
+"I shall love him for ever!" she cried.
+
+"And he?"
+
+"For ever, too!"
+
+"He had better."
+
+She shrank from him.  Then she laughed and put her hand on his arm.  He
+was merely a boy.
+
+At the Marble Arch they hailed an omnibus, which left them close to
+their shabby home in the Euston Road.  It was after five o'clock, and
+Sibyl had to lie down for a couple of hours before acting.  Jim
+insisted that she should do so.  He said that he would sooner part with
+her when their mother was not present.  She would be sure to make a
+scene, and he detested scenes of every kind.
+
+In Sybil's own room they parted.  There was jealousy in the lad's
+heart, and a fierce murderous hatred of the stranger who, as it seemed
+to him, had come between them.  Yet, when her arms were flung round his
+neck, and her fingers strayed through his hair, he softened and kissed
+her with real affection.  There were tears in his eyes as he went
+downstairs.
+
+His mother was waiting for him below.  She grumbled at his
+unpunctuality, as he entered.  He made no answer, but sat down to his
+meagre meal.  The flies buzzed round the table and crawled over the
+stained cloth.  Through the rumble of omnibuses, and the clatter of
+street-cabs, he could hear the droning voice devouring each minute that
+was left to him.
+
+After some time, he thrust away his plate and put his head in his
+hands.  He felt that he had a right to know.  It should have been told
+to him before, if it was as he suspected.  Leaden with fear, his mother
+watched him.  Words dropped mechanically from her lips.  A tattered
+lace handkerchief twitched in her fingers.  When the clock struck six,
+he got up and went to the door.  Then he turned back and looked at her.
+Their eyes met.  In hers he saw a wild appeal for mercy.  It enraged
+him.
+
+"Mother, I have something to ask you," he said.  Her eyes wandered
+vaguely about the room.  She made no answer.  "Tell me the truth.  I
+have a right to know.  Were you married to my father?"
+
+She heaved a deep sigh.  It was a sigh of relief.  The terrible moment,
+the moment that night and day, for weeks and months, she had dreaded,
+had come at last, and yet she felt no terror.  Indeed, in some measure
+it was a disappointment to her.  The vulgar directness of the question
+called for a direct answer.  The situation had not been gradually led
+up to.  It was crude.  It reminded her of a bad rehearsal.
+
+"No," she answered, wondering at the harsh simplicity of life.
+
+"My father was a scoundrel then!" cried the lad, clenching his fists.
+
+She shook her head.  "I knew he was not free.  We loved each other very
+much.  If he had lived, he would have made provision for us.  Don't
+speak against him, my son.  He was your father, and a gentleman.
+Indeed, he was highly connected."
+
+An oath broke from his lips.  "I don't care for myself," he exclaimed,
+"but don't let Sibyl.... It is a gentleman, isn't it, who is in love
+with her, or says he is?  Highly connected, too, I suppose."
+
+For a moment a hideous sense of humiliation came over the woman.  Her
+head drooped.  She wiped her eyes with shaking hands.  "Sibyl has a
+mother," she murmured; "I had none."
+
+The lad was touched.  He went towards her, and stooping down, he kissed
+her.  "I am sorry if I have pained you by asking about my father," he
+said, "but I could not help it.  I must go now.  Good-bye. Don't forget
+that you will have only one child now to look after, and believe me
+that if this man wrongs my sister, I will find out who he is, track him
+down, and kill him like a dog.  I swear it."
+
+The exaggerated folly of the threat, the passionate gesture that
+accompanied it, the mad melodramatic words, made life seem more vivid
+to her.  She was familiar with the atmosphere.  She breathed more
+freely, and for the first time for many months she really admired her
+son.  She would have liked to have continued the scene on the same
+emotional scale, but he cut her short.  Trunks had to be carried down
+and mufflers looked for.  The lodging-house drudge bustled in and out.
+There was the bargaining with the cabman.  The moment was lost in
+vulgar details.  It was with a renewed feeling of disappointment that
+she waved the tattered lace handkerchief from the window, as her son
+drove away.  She was conscious that a great opportunity had been
+wasted.  She consoled herself by telling Sibyl how desolate she felt
+her life would be, now that she had only one child to look after.  She
+remembered the phrase.  It had pleased her.  Of the threat she said
+nothing.  It was vividly and dramatically expressed.  She felt that
+they would all laugh at it some day.
+
+
+
+CHAPTER 6
+
+"I suppose you have heard the news, Basil?" said Lord Henry that
+evening as Hallward was shown into a little private room at the Bristol
+where dinner had been laid for three.
+
+"No, Harry," answered the artist, giving his hat and coat to the bowing
+waiter.  "What is it?  Nothing about politics, I hope!  They don't
+interest me.  There is hardly a single person in the House of Commons
+worth painting, though many of them would be the better for a little
+whitewashing."
+
+"Dorian Gray is engaged to be married," said Lord Henry, watching him
+as he spoke.
+
+Hallward started and then frowned.  "Dorian engaged to be married!" he
+cried.  "Impossible!"
+
+"It is perfectly true."
+
+"To whom?"
+
+"To some little actress or other."
+
+"I can't believe it.  Dorian is far too sensible."
+
+"Dorian is far too wise not to do foolish things now and then, my dear
+Basil."
+
+"Marriage is hardly a thing that one can do now and then, Harry."
+
+"Except in America," rejoined Lord Henry languidly.  "But I didn't say
+he was married.  I said he was engaged to be married.  There is a great
+difference.  I have a distinct remembrance of being married, but I have
+no recollection at all of being engaged.  I am inclined to think that I
+never was engaged."
+
+"But think of Dorian's birth, and position, and wealth.  It would be
+absurd for him to marry so much beneath him."
+
+"If you want to make him marry this girl, tell him that, Basil.  He is
+sure to do it, then.  Whenever a man does a thoroughly stupid thing, it
+is always from the noblest motives."
+
+"I hope the girl is good, Harry.  I don't want to see Dorian tied to
+some vile creature, who might degrade his nature and ruin his
+intellect."
+
+"Oh, she is better than good--she is beautiful," murmured Lord Henry,
+sipping a glass of vermouth and orange-bitters. "Dorian says she is
+beautiful, and he is not often wrong about things of that kind.  Your
+portrait of him has quickened his appreciation of the personal
+appearance of other people.  It has had that excellent effect, amongst
+others.  We are to see her to-night, if that boy doesn't forget his
+appointment."
+
+"Are you serious?"
+
+"Quite serious, Basil.  I should be miserable if I thought I should
+ever be more serious than I am at the present moment."
+
+"But do you approve of it, Harry?" asked the painter, walking up and
+down the room and biting his lip.  "You can't approve of it, possibly.
+It is some silly infatuation."
+
+"I never approve, or disapprove, of anything now.  It is an absurd
+attitude to take towards life.  We are not sent into the world to air
+our moral prejudices.  I never take any notice of what common people
+say, and I never interfere with what charming people do.  If a
+personality fascinates me, whatever mode of expression that personality
+selects is absolutely delightful to me.  Dorian Gray falls in love with
+a beautiful girl who acts Juliet, and proposes to marry her.  Why not?
+If he wedded Messalina, he would be none the less interesting.  You
+know I am not a champion of marriage.  The real drawback to marriage is
+that it makes one unselfish.  And unselfish people are colourless.
+They lack individuality.  Still, there are certain temperaments that
+marriage makes more complex.  They retain their egotism, and add to it
+many other egos.  They are forced to have more than one life.  They
+become more highly organized, and to be highly organized is, I should
+fancy, the object of man's existence.  Besides, every experience is of
+value, and whatever one may say against marriage, it is certainly an
+experience.  I hope that Dorian Gray will make this girl his wife,
+passionately adore her for six months, and then suddenly become
+fascinated by some one else.  He would be a wonderful study."
+
+"You don't mean a single word of all that, Harry; you know you don't.
+If Dorian Gray's life were spoiled, no one would be sorrier than
+yourself.  You are much better than you pretend to be."
+
+Lord Henry laughed.  "The reason we all like to think so well of others
+is that we are all afraid for ourselves.  The basis of optimism is
+sheer terror.  We think that we are generous because we credit our
+neighbour with the possession of those virtues that are likely to be a
+benefit to us.  We praise the banker that we may overdraw our account,
+and find good qualities in the highwayman in the hope that he may spare
+our pockets.  I mean everything that I have said.  I have the greatest
+contempt for optimism.  As for a spoiled life, no life is spoiled but
+one whose growth is arrested.  If you want to mar a nature, you have
+merely to reform it.  As for marriage, of course that would be silly,
+but there are other and more interesting bonds between men and women.
+I will certainly encourage them.  They have the charm of being
+fashionable.  But here is Dorian himself.  He will tell you more than I
+can."
+
+"My dear Harry, my dear Basil, you must both congratulate me!" said the
+lad, throwing off his evening cape with its satin-lined wings and
+shaking each of his friends by the hand in turn.  "I have never been so
+happy.  Of course, it is sudden--all really delightful things are.  And
+yet it seems to me to be the one thing I have been looking for all my
+life." He was flushed with excitement and pleasure, and looked
+extraordinarily handsome.
+
+"I hope you will always be very happy, Dorian," said Hallward, "but I
+don't quite forgive you for not having let me know of your engagement.
+You let Harry know."
+
+"And I don't forgive you for being late for dinner," broke in Lord
+Henry, putting his hand on the lad's shoulder and smiling as he spoke.
+"Come, let us sit down and try what the new _chef_ here is like, and then
+you will tell us how it all came about."
+
+"There is really not much to tell," cried Dorian as they took their
+seats at the small round table.  "What happened was simply this.  After
+I left you yesterday evening, Harry, I dressed, had some dinner at that
+little Italian restaurant in Rupert Street you introduced me to, and
+went down at eight o'clock to the theatre.  Sibyl was playing Rosalind.
+Of course, the scenery was dreadful and the Orlando absurd.  But Sibyl!
+You should have seen her!  When she came on in her boy's clothes, she
+was perfectly wonderful.  She wore a moss-coloured velvet jerkin with
+cinnamon sleeves, slim, brown, cross-gartered hose, a dainty little
+green cap with a hawk's feather caught in a jewel, and a hooded cloak
+lined with dull red.  She had never seemed to me more exquisite.  She
+had all the delicate grace of that Tanagra figurine that you have in
+your studio, Basil.  Her hair clustered round her face like dark leaves
+round a pale rose.  As for her acting--well, you shall see her
+to-night. She is simply a born artist.  I sat in the dingy box
+absolutely enthralled.  I forgot that I was in London and in the
+nineteenth century.  I was away with my love in a forest that no man
+had ever seen.  After the performance was over, I went behind and spoke
+to her.  As we were sitting together, suddenly there came into her eyes
+a look that I had never seen there before.  My lips moved towards hers.
+We kissed each other.  I can't describe to you what I felt at that
+moment.  It seemed to me that all my life had been narrowed to one
+perfect point of rose-coloured joy.  She trembled all over and shook
+like a white narcissus.  Then she flung herself on her knees and kissed
+my hands.  I feel that I should not tell you all this, but I can't help
+it.  Of course, our engagement is a dead secret.  She has not even told
+her own mother.  I don't know what my guardians will say.  Lord Radley
+is sure to be furious.  I don't care.  I shall be of age in less than a
+year, and then I can do what I like.  I have been right, Basil, haven't
+I, to take my love out of poetry and to find my wife in Shakespeare's
+plays?  Lips that Shakespeare taught to speak have whispered their
+secret in my ear.  I have had the arms of Rosalind around me, and
+kissed Juliet on the mouth."
+
+"Yes, Dorian, I suppose you were right," said Hallward slowly.
+
+"Have you seen her to-day?" asked Lord Henry.
+
+Dorian Gray shook his head.  "I left her in the forest of Arden; I
+shall find her in an orchard in Verona."
+
+Lord Henry sipped his champagne in a meditative manner.  "At what
+particular point did you mention the word marriage, Dorian?  And what
+did she say in answer?  Perhaps you forgot all about it."
+
+"My dear Harry, I did not treat it as a business transaction, and I did
+not make any formal proposal.  I told her that I loved her, and she
+said she was not worthy to be my wife.  Not worthy!  Why, the whole
+world is nothing to me compared with her."
+
+"Women are wonderfully practical," murmured Lord Henry, "much more
+practical than we are.  In situations of that kind we often forget to
+say anything about marriage, and they always remind us."
+
+Hallward laid his hand upon his arm.  "Don't, Harry.  You have annoyed
+Dorian.  He is not like other men.  He would never bring misery upon
+any one.  His nature is too fine for that."
+
+Lord Henry looked across the table.  "Dorian is never annoyed with me,"
+he answered.  "I asked the question for the best reason possible, for
+the only reason, indeed, that excuses one for asking any
+question--simple curiosity.  I have a theory that it is always the
+women who propose to us, and not we who propose to the women.  Except,
+of course, in middle-class life.  But then the middle classes are not
+modern."
+
+Dorian Gray laughed, and tossed his head.  "You are quite incorrigible,
+Harry; but I don't mind.  It is impossible to be angry with you.  When
+you see Sibyl Vane, you will feel that the man who could wrong her
+would be a beast, a beast without a heart.  I cannot understand how any
+one can wish to shame the thing he loves.  I love Sibyl Vane.  I want
+to place her on a pedestal of gold and to see the world worship the
+woman who is mine.  What is marriage?  An irrevocable vow.  You mock at
+it for that.  Ah! don't mock.  It is an irrevocable vow that I want to
+take.  Her trust makes me faithful, her belief makes me good.  When I
+am with her, I regret all that you have taught me.  I become different
+from what you have known me to be.  I am changed, and the mere touch of
+Sibyl Vane's hand makes me forget you and all your wrong, fascinating,
+poisonous, delightful theories."
+
+"And those are ...?" asked Lord Henry, helping himself to some salad.
+
+"Oh, your theories about life, your theories about love, your theories
+about pleasure.  All your theories, in fact, Harry."
+
+"Pleasure is the only thing worth having a theory about," he answered
+in his slow melodious voice.  "But I am afraid I cannot claim my theory
+as my own.  It belongs to Nature, not to me.  Pleasure is Nature's
+test, her sign of approval.  When we are happy, we are always good, but
+when we are good, we are not always happy."
+
+"Ah! but what do you mean by good?" cried Basil Hallward.
+
+"Yes," echoed Dorian, leaning back in his chair and looking at Lord
+Henry over the heavy clusters of purple-lipped irises that stood in the
+centre of the table, "what do you mean by good, Harry?"
+
+"To be good is to be in harmony with one's self," he replied, touching
+the thin stem of his glass with his pale, fine-pointed fingers.
+"Discord is to be forced to be in harmony with others.  One's own
+life--that is the important thing.  As for the lives of one's
+neighbours, if one wishes to be a prig or a Puritan, one can flaunt
+one's moral views about them, but they are not one's concern.  Besides,
+individualism has really the higher aim.  Modern morality consists in
+accepting the standard of one's age.  I consider that for any man of
+culture to accept the standard of his age is a form of the grossest
+immorality."
+
+"But, surely, if one lives merely for one's self, Harry, one pays a
+terrible price for doing so?" suggested the painter.
+
+"Yes, we are overcharged for everything nowadays.  I should fancy that
+the real tragedy of the poor is that they can afford nothing but
+self-denial. Beautiful sins, like beautiful things, are the privilege
+of the rich."
+
+"One has to pay in other ways but money."
+
+"What sort of ways, Basil?"
+
+"Oh!  I should fancy in remorse, in suffering, in ... well, in the
+consciousness of degradation."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, mediaeval art is
+charming, but mediaeval emotions are out of date.  One can use them in
+fiction, of course.  But then the only things that one can use in
+fiction are the things that one has ceased to use in fact.  Believe me,
+no civilized man ever regrets a pleasure, and no uncivilized man ever
+knows what a pleasure is."
+
+"I know what pleasure is," cried Dorian Gray.  "It is to adore some
+one."
+
+"That is certainly better than being adored," he answered, toying with
+some fruits.  "Being adored is a nuisance.  Women treat us just as
+humanity treats its gods.  They worship us, and are always bothering us
+to do something for them."
+
+"I should have said that whatever they ask for they had first given to
+us," murmured the lad gravely.  "They create love in our natures.  They
+have a right to demand it back."
+
+"That is quite true, Dorian," cried Hallward.
+
+"Nothing is ever quite true," said Lord Henry.
+
+"This is," interrupted Dorian.  "You must admit, Harry, that women give
+to men the very gold of their lives."
+
+"Possibly," he sighed, "but they invariably want it back in such very
+small change.  That is the worry.  Women, as some witty Frenchman once
+put it, inspire us with the desire to do masterpieces and always
+prevent us from carrying them out."
+
+"Harry, you are dreadful!  I don't know why I like you so much."
+
+"You will always like me, Dorian," he replied.  "Will you have some
+coffee, you fellows?  Waiter, bring coffee, and _fine-champagne_, and
+some cigarettes.  No, don't mind the cigarettes--I have some.  Basil, I
+can't allow you to smoke cigars.  You must have a cigarette.  A
+cigarette is the perfect type of a perfect pleasure.  It is exquisite,
+and it leaves one unsatisfied.  What more can one want?  Yes, Dorian,
+you will always be fond of me.  I represent to you all the sins you
+have never had the courage to commit."
+
+"What nonsense you talk, Harry!" cried the lad, taking a light from a
+fire-breathing silver dragon that the waiter had placed on the table.
+"Let us go down to the theatre.  When Sibyl comes on the stage you will
+have a new ideal of life.  She will represent something to you that you
+have never known."
+
+"I have known everything," said Lord Henry, with a tired look in his
+eyes, "but I am always ready for a new emotion.  I am afraid, however,
+that, for me at any rate, there is no such thing.  Still, your
+wonderful girl may thrill me.  I love acting.  It is so much more real
+than life.  Let us go.  Dorian, you will come with me.  I am so sorry,
+Basil, but there is only room for two in the brougham.  You must follow
+us in a hansom."
+
+They got up and put on their coats, sipping their coffee standing.  The
+painter was silent and preoccupied.  There was a gloom over him.  He
+could not bear this marriage, and yet it seemed to him to be better
+than many other things that might have happened.  After a few minutes,
+they all passed downstairs.  He drove off by himself, as had been
+arranged, and watched the flashing lights of the little brougham in
+front of him.  A strange sense of loss came over him.  He felt that
+Dorian Gray would never again be to him all that he had been in the
+past.  Life had come between them.... His eyes darkened, and the
+crowded flaring streets became blurred to his eyes.  When the cab drew
+up at the theatre, it seemed to him that he had grown years older.
+
+
+
+CHAPTER 7
+
+For some reason or other, the house was crowded that night, and the fat
+Jew manager who met them at the door was beaming from ear to ear with
+an oily tremulous smile.  He escorted them to their box with a sort of
+pompous humility, waving his fat jewelled hands and talking at the top
+of his voice.  Dorian Gray loathed him more than ever.  He felt as if
+he had come to look for Miranda and had been met by Caliban.  Lord
+Henry, upon the other hand, rather liked him.  At least he declared he
+did, and insisted on shaking him by the hand and assuring him that he
+was proud to meet a man who had discovered a real genius and gone
+bankrupt over a poet.  Hallward amused himself with watching the faces
+in the pit.  The heat was terribly oppressive, and the huge sunlight
+flamed like a monstrous dahlia with petals of yellow fire.  The youths
+in the gallery had taken off their coats and waistcoats and hung them
+over the side.  They talked to each other across the theatre and shared
+their oranges with the tawdry girls who sat beside them.  Some women
+were laughing in the pit.  Their voices were horribly shrill and
+discordant.  The sound of the popping of corks came from the bar.
+
+"What a place to find one's divinity in!" said Lord Henry.
+
+"Yes!" answered Dorian Gray.  "It was here I found her, and she is
+divine beyond all living things.  When she acts, you will forget
+everything.  These common rough people, with their coarse faces and
+brutal gestures, become quite different when she is on the stage.  They
+sit silently and watch her.  They weep and laugh as she wills them to
+do.  She makes them as responsive as a violin.  She spiritualizes them,
+and one feels that they are of the same flesh and blood as one's self."
+
+"The same flesh and blood as one's self!  Oh, I hope not!" exclaimed
+Lord Henry, who was scanning the occupants of the gallery through his
+opera-glass.
+
+"Don't pay any attention to him, Dorian," said the painter.  "I
+understand what you mean, and I believe in this girl.  Any one you love
+must be marvellous, and any girl who has the effect you describe must
+be fine and noble.  To spiritualize one's age--that is something worth
+doing.  If this girl can give a soul to those who have lived without
+one, if she can create the sense of beauty in people whose lives have
+been sordid and ugly, if she can strip them of their selfishness and
+lend them tears for sorrows that are not their own, she is worthy of
+all your adoration, worthy of the adoration of the world.  This
+marriage is quite right.  I did not think so at first, but I admit it
+now.  The gods made Sibyl Vane for you.  Without her you would have
+been incomplete."
+
+"Thanks, Basil," answered Dorian Gray, pressing his hand.  "I knew that
+you would understand me.  Harry is so cynical, he terrifies me.  But
+here is the orchestra.  It is quite dreadful, but it only lasts for
+about five minutes.  Then the curtain rises, and you will see the girl
+to whom I am going to give all my life, to whom I have given everything
+that is good in me."
+
+A quarter of an hour afterwards, amidst an extraordinary turmoil of
+applause, Sibyl Vane stepped on to the stage.  Yes, she was certainly
+lovely to look at--one of the loveliest creatures, Lord Henry thought,
+that he had ever seen.  There was something of the fawn in her shy
+grace and startled eyes.  A faint blush, like the shadow of a rose in a
+mirror of silver, came to her cheeks as she glanced at the crowded
+enthusiastic house.  She stepped back a few paces and her lips seemed
+to tremble.  Basil Hallward leaped to his feet and began to applaud.
+Motionless, and as one in a dream, sat Dorian Gray, gazing at her.
+Lord Henry peered through his glasses, murmuring, "Charming! charming!"
+
+The scene was the hall of Capulet's house, and Romeo in his pilgrim's
+dress had entered with Mercutio and his other friends.  The band, such
+as it was, struck up a few bars of music, and the dance began.  Through
+the crowd of ungainly, shabbily dressed actors, Sibyl Vane moved like a
+creature from a finer world.  Her body swayed, while she danced, as a
+plant sways in the water.  The curves of her throat were the curves of
+a white lily.  Her hands seemed to be made of cool ivory.
+
+Yet she was curiously listless.  She showed no sign of joy when her
+eyes rested on Romeo.  The few words she had to speak--
+
+    Good pilgrim, you do wrong your hand too much,
+        Which mannerly devotion shows in this;
+    For saints have hands that pilgrims' hands do touch,
+        And palm to palm is holy palmers' kiss--
+
+with the brief dialogue that follows, were spoken in a thoroughly
+artificial manner.  The voice was exquisite, but from the point of view
+of tone it was absolutely false.  It was wrong in colour.  It took away
+all the life from the verse.  It made the passion unreal.
+
+Dorian Gray grew pale as he watched her.  He was puzzled and anxious.
+Neither of his friends dared to say anything to him.  She seemed to
+them to be absolutely incompetent.  They were horribly disappointed.
+
+Yet they felt that the true test of any Juliet is the balcony scene of
+the second act.  They waited for that.  If she failed there, there was
+nothing in her.
+
+She looked charming as she came out in the moonlight.  That could not
+be denied.  But the staginess of her acting was unbearable, and grew
+worse as she went on.  Her gestures became absurdly artificial.  She
+overemphasized everything that she had to say.  The beautiful passage--
+
+    Thou knowest the mask of night is on my face,
+    Else would a maiden blush bepaint my cheek
+    For that which thou hast heard me speak to-night--
+
+was declaimed with the painful precision of a schoolgirl who has been
+taught to recite by some second-rate professor of elocution. When she
+leaned over the balcony and came to those wonderful lines--
+
+        Although I joy in thee,
+    I have no joy of this contract to-night:
+    It is too rash, too unadvised, too sudden;
+    Too like the lightning, which doth cease to be
+    Ere one can say, "It lightens."  Sweet, good-night!
+    This bud of love by summer's ripening breath
+    May prove a beauteous flower when next we meet--
+
+she spoke the words as though they conveyed no meaning to her. It was
+not nervousness. Indeed, so far from being nervous, she was absolutely
+self-contained. It was simply bad art. She was a complete failure.
+
+Even the common uneducated audience of the pit and gallery lost their
+interest in the play. They got restless, and began to talk loudly and
+to whistle. The Jew manager, who was standing at the back of the
+dress-circle, stamped and swore with rage. The only person unmoved was
+the girl herself.
+
+When the second act was over, there came a storm of hisses, and Lord
+Henry got up from his chair and put on his coat.  "She is quite
+beautiful, Dorian," he said, "but she can't act.  Let us go."
+
+"I am going to see the play through," answered the lad, in a hard
+bitter voice.  "I am awfully sorry that I have made you waste an
+evening, Harry.  I apologize to you both."
+
+"My dear Dorian, I should think Miss Vane was ill," interrupted
+Hallward.  "We will come some other night."
+
+"I wish she were ill," he rejoined.  "But she seems to me to be simply
+callous and cold.  She has entirely altered.  Last night she was a
+great artist.  This evening she is merely a commonplace mediocre
+actress."
+
+"Don't talk like that about any one you love, Dorian.  Love is a more
+wonderful thing than art."
+
+"They are both simply forms of imitation," remarked Lord Henry.  "But
+do let us go.  Dorian, you must not stay here any longer.  It is not
+good for one's morals to see bad acting.  Besides, I don't suppose you
+will want your wife to act, so what does it matter if she plays Juliet
+like a wooden doll?  She is very lovely, and if she knows as little
+about life as she does about acting, she will be a delightful
+experience.  There are only two kinds of people who are really
+fascinating--people who know absolutely everything, and people who know
+absolutely nothing.  Good heavens, my dear boy, don't look so tragic!
+The secret of remaining young is never to have an emotion that is
+unbecoming.  Come to the club with Basil and myself.  We will smoke
+cigarettes and drink to the beauty of Sibyl Vane.  She is beautiful.
+What more can you want?"
+
+"Go away, Harry," cried the lad.  "I want to be alone.  Basil, you must
+go.  Ah! can't you see that my heart is breaking?"  The hot tears came
+to his eyes.  His lips trembled, and rushing to the back of the box, he
+leaned up against the wall, hiding his face in his hands.
+
+"Let us go, Basil," said Lord Henry with a strange tenderness in his
+voice, and the two young men passed out together.
+
+A few moments afterwards the footlights flared up and the curtain rose
+on the third act.  Dorian Gray went back to his seat.  He looked pale,
+and proud, and indifferent.  The play dragged on, and seemed
+interminable.  Half of the audience went out, tramping in heavy boots
+and laughing.  The whole thing was a _fiasco_.  The last act was played
+to almost empty benches.  The curtain went down on a titter and some
+groans.
+
+As soon as it was over, Dorian Gray rushed behind the scenes into the
+greenroom.  The girl was standing there alone, with a look of triumph
+on her face.  Her eyes were lit with an exquisite fire.  There was a
+radiance about her.  Her parted lips were smiling over some secret of
+their own.
+
+When he entered, she looked at him, and an expression of infinite joy
+came over her.  "How badly I acted to-night, Dorian!" she cried.
+
+"Horribly!" he answered, gazing at her in amazement.  "Horribly!  It
+was dreadful.  Are you ill?  You have no idea what it was.  You have no
+idea what I suffered."
+
+The girl smiled.  "Dorian," she answered, lingering over his name with
+long-drawn music in her voice, as though it were sweeter than honey to
+the red petals of her mouth.  "Dorian, you should have understood.  But
+you understand now, don't you?"
+
+"Understand what?" he asked, angrily.
+
+"Why I was so bad to-night. Why I shall always be bad.  Why I shall
+never act well again."
+
+He shrugged his shoulders.  "You are ill, I suppose.  When you are ill
+you shouldn't act.  You make yourself ridiculous.  My friends were
+bored.  I was bored."
+
+She seemed not to listen to him.  She was transfigured with joy.  An
+ecstasy of happiness dominated her.
+
+"Dorian, Dorian," she cried, "before I knew you, acting was the one
+reality of my life.  It was only in the theatre that I lived.  I
+thought that it was all true.  I was Rosalind one night and Portia the
+other.  The joy of Beatrice was my joy, and the sorrows of Cordelia
+were mine also.  I believed in everything.  The common people who acted
+with me seemed to me to be godlike.  The painted scenes were my world.
+I knew nothing but shadows, and I thought them real.  You came--oh, my
+beautiful love!--and you freed my soul from prison.  You taught me what
+reality really is.  To-night, for the first time in my life, I saw
+through the hollowness, the sham, the silliness of the empty pageant in
+which I had always played.  To-night, for the first time, I became
+conscious that the Romeo was hideous, and old, and painted, that the
+moonlight in the orchard was false, that the scenery was vulgar, and
+that the words I had to speak were unreal, were not my words, were not
+what I wanted to say.  You had brought me something higher, something
+of which all art is but a reflection.  You had made me understand what
+love really is.  My love!  My love!  Prince Charming!  Prince of life!
+I have grown sick of shadows.  You are more to me than all art can ever
+be.  What have I to do with the puppets of a play?  When I came on
+to-night, I could not understand how it was that everything had gone
+from me.  I thought that I was going to be wonderful.  I found that I
+could do nothing.  Suddenly it dawned on my soul what it all meant.
+The knowledge was exquisite to me.  I heard them hissing, and I smiled.
+What could they know of love such as ours?  Take me away, Dorian--take
+me away with you, where we can be quite alone.  I hate the stage.  I
+might mimic a passion that I do not feel, but I cannot mimic one that
+burns me like fire.  Oh, Dorian, Dorian, you understand now what it
+signifies?  Even if I could do it, it would be profanation for me to
+play at being in love.  You have made me see that."
+
+He flung himself down on the sofa and turned away his face.  "You have
+killed my love," he muttered.
+
+She looked at him in wonder and laughed.  He made no answer.  She came
+across to him, and with her little fingers stroked his hair.  She knelt
+down and pressed his hands to her lips.  He drew them away, and a
+shudder ran through him.
+
+Then he leaped up and went to the door.  "Yes," he cried, "you have
+killed my love.  You used to stir my imagination.  Now you don't even
+stir my curiosity.  You simply produce no effect.  I loved you because
+you were marvellous, because you had genius and intellect, because you
+realized the dreams of great poets and gave shape and substance to the
+shadows of art.  You have thrown it all away.  You are shallow and
+stupid.  My God! how mad I was to love you!  What a fool I have been!
+You are nothing to me now.  I will never see you again.  I will never
+think of you.  I will never mention your name.  You don't know what you
+were to me, once.  Why, once ... Oh, I can't bear to think of it!  I
+wish I had never laid eyes upon you!  You have spoiled the romance of
+my life.  How little you can know of love, if you say it mars your art!
+Without your art, you are nothing.  I would have made you famous,
+splendid, magnificent.  The world would have worshipped you, and you
+would have borne my name.  What are you now?  A third-rate actress with
+a pretty face."
+
+The girl grew white, and trembled.  She clenched her hands together,
+and her voice seemed to catch in her throat.  "You are not serious,
+Dorian?" she murmured.  "You are acting."
+
+"Acting!  I leave that to you.  You do it so well," he answered
+bitterly.
+
+She rose from her knees and, with a piteous expression of pain in her
+face, came across the room to him.  She put her hand upon his arm and
+looked into his eyes.  He thrust her back.  "Don't touch me!" he cried.
+
+A low moan broke from her, and she flung herself at his feet and lay
+there like a trampled flower.  "Dorian, Dorian, don't leave me!" she
+whispered.  "I am so sorry I didn't act well.  I was thinking of you
+all the time.  But I will try--indeed, I will try.  It came so suddenly
+across me, my love for you.  I think I should never have known it if
+you had not kissed me--if we had not kissed each other.  Kiss me again,
+my love.  Don't go away from me.  I couldn't bear it.  Oh! don't go
+away from me.  My brother ... No; never mind.  He didn't mean it.  He
+was in jest.... But you, oh! can't you forgive me for to-night? I will
+work so hard and try to improve.  Don't be cruel to me, because I love
+you better than anything in the world.  After all, it is only once that
+I have not pleased you.  But you are quite right, Dorian.  I should
+have shown myself more of an artist.  It was foolish of me, and yet I
+couldn't help it.  Oh, don't leave me, don't leave me." A fit of
+passionate sobbing choked her.  She crouched on the floor like a
+wounded thing, and Dorian Gray, with his beautiful eyes, looked down at
+her, and his chiselled lips curled in exquisite disdain.  There is
+always something ridiculous about the emotions of people whom one has
+ceased to love.  Sibyl Vane seemed to him to be absurdly melodramatic.
+Her tears and sobs annoyed him.
+
+"I am going," he said at last in his calm clear voice.  "I don't wish
+to be unkind, but I can't see you again.  You have disappointed me."
+
+She wept silently, and made no answer, but crept nearer.  Her little
+hands stretched blindly out, and appeared to be seeking for him.  He
+turned on his heel and left the room.  In a few moments he was out of
+the theatre.
+
+Where he went to he hardly knew.  He remembered wandering through dimly
+lit streets, past gaunt, black-shadowed archways and evil-looking
+houses.  Women with hoarse voices and harsh laughter had called after
+him.  Drunkards had reeled by, cursing and chattering to themselves
+like monstrous apes.  He had seen grotesque children huddled upon
+door-steps, and heard shrieks and oaths from gloomy courts.
+
+As the dawn was just breaking, he found himself close to Covent Garden.
+The darkness lifted, and, flushed with faint fires, the sky hollowed
+itself into a perfect pearl.  Huge carts filled with nodding lilies
+rumbled slowly down the polished empty street.  The air was heavy with
+the perfume of the flowers, and their beauty seemed to bring him an
+anodyne for his pain.  He followed into the market and watched the men
+unloading their waggons.  A white-smocked carter offered him some
+cherries.  He thanked him, wondered why he refused to accept any money
+for them, and began to eat them listlessly.  They had been plucked at
+midnight, and the coldness of the moon had entered into them.  A long
+line of boys carrying crates of striped tulips, and of yellow and red
+roses, defiled in front of him, threading their way through the huge,
+jade-green piles of vegetables.  Under the portico, with its grey,
+sun-bleached pillars, loitered a troop of draggled bareheaded girls,
+waiting for the auction to be over.  Others crowded round the swinging
+doors of the coffee-house in the piazza.  The heavy cart-horses slipped
+and stamped upon the rough stones, shaking their bells and trappings.
+Some of the drivers were lying asleep on a pile of sacks.  Iris-necked
+and pink-footed, the pigeons ran about picking up seeds.
+
+After a little while, he hailed a hansom and drove home.  For a few
+moments he loitered upon the doorstep, looking round at the silent
+square, with its blank, close-shuttered windows and its staring blinds.
+The sky was pure opal now, and the roofs of the houses glistened like
+silver against it.  From some chimney opposite a thin wreath of smoke
+was rising.  It curled, a violet riband, through the nacre-coloured air.
+
+In the huge gilt Venetian lantern, spoil of some Doge's barge, that
+hung from the ceiling of the great, oak-panelled hall of entrance,
+lights were still burning from three flickering jets: thin blue petals
+of flame they seemed, rimmed with white fire.  He turned them out and,
+having thrown his hat and cape on the table, passed through the library
+towards the door of his bedroom, a large octagonal chamber on the
+ground floor that, in his new-born feeling for luxury, he had just had
+decorated for himself and hung with some curious Renaissance tapestries
+that had been discovered stored in a disused attic at Selby Royal.  As
+he was turning the handle of the door, his eye fell upon the portrait
+Basil Hallward had painted of him.  He started back as if in surprise.
+Then he went on into his own room, looking somewhat puzzled.  After he
+had taken the button-hole out of his coat, he seemed to hesitate.
+Finally, he came back, went over to the picture, and examined it.  In
+the dim arrested light that struggled through the cream-coloured silk
+blinds, the face appeared to him to be a little changed.  The
+expression looked different.  One would have said that there was a
+touch of cruelty in the mouth.  It was certainly strange.
+
+He turned round and, walking to the window, drew up the blind.  The
+bright dawn flooded the room and swept the fantastic shadows into dusky
+corners, where they lay shuddering.  But the strange expression that he
+had noticed in the face of the portrait seemed to linger there, to be
+more intensified even.  The quivering ardent sunlight showed him the
+lines of cruelty round the mouth as clearly as if he had been looking
+into a mirror after he had done some dreadful thing.
+
+He winced and, taking up from the table an oval glass framed in ivory
+Cupids, one of Lord Henry's many presents to him, glanced hurriedly
+into its polished depths.  No line like that warped his red lips.  What
+did it mean?
+
+He rubbed his eyes, and came close to the picture, and examined it
+again.  There were no signs of any change when he looked into the
+actual painting, and yet there was no doubt that the whole expression
+had altered.  It was not a mere fancy of his own.  The thing was
+horribly apparent.
+
+He threw himself into a chair and began to think.  Suddenly there
+flashed across his mind what he had said in Basil Hallward's studio the
+day the picture had been finished.  Yes, he remembered it perfectly.
+He had uttered a mad wish that he himself might remain young, and the
+portrait grow old; that his own beauty might be untarnished, and the
+face on the canvas bear the burden of his passions and his sins; that
+the painted image might be seared with the lines of suffering and
+thought, and that he might keep all the delicate bloom and loveliness
+of his then just conscious boyhood.  Surely his wish had not been
+fulfilled?  Such things were impossible.  It seemed monstrous even to
+think of them.  And, yet, there was the picture before him, with the
+touch of cruelty in the mouth.
+
+Cruelty!  Had he been cruel?  It was the girl's fault, not his.  He had
+dreamed of her as a great artist, had given his love to her because he
+had thought her great.  Then she had disappointed him.  She had been
+shallow and unworthy.  And, yet, a feeling of infinite regret came over
+him, as he thought of her lying at his feet sobbing like a little
+child.  He remembered with what callousness he had watched her.  Why
+had he been made like that?  Why had such a soul been given to him?
+But he had suffered also.  During the three terrible hours that the
+play had lasted, he had lived centuries of pain, aeon upon aeon of
+torture.  His life was well worth hers.  She had marred him for a
+moment, if he had wounded her for an age.  Besides, women were better
+suited to bear sorrow than men.  They lived on their emotions.  They
+only thought of their emotions.  When they took lovers, it was merely
+to have some one with whom they could have scenes.  Lord Henry had told
+him that, and Lord Henry knew what women were.  Why should he trouble
+about Sibyl Vane?  She was nothing to him now.
+
+But the picture?  What was he to say of that?  It held the secret of
+his life, and told his story.  It had taught him to love his own
+beauty.  Would it teach him to loathe his own soul?  Would he ever look
+at it again?
+
+No; it was merely an illusion wrought on the troubled senses.  The
+horrible night that he had passed had left phantoms behind it.
+Suddenly there had fallen upon his brain that tiny scarlet speck that
+makes men mad.  The picture had not changed.  It was folly to think so.
+
+Yet it was watching him, with its beautiful marred face and its cruel
+smile.  Its bright hair gleamed in the early sunlight.  Its blue eyes
+met his own.  A sense of infinite pity, not for himself, but for the
+painted image of himself, came over him.  It had altered already, and
+would alter more.  Its gold would wither into grey.  Its red and white
+roses would die.  For every sin that he committed, a stain would fleck
+and wreck its fairness.  But he would not sin.  The picture, changed or
+unchanged, would be to him the visible emblem of conscience.  He would
+resist temptation.  He would not see Lord Henry any more--would not, at
+any rate, listen to those subtle poisonous theories that in Basil
+Hallward's garden had first stirred within him the passion for
+impossible things.  He would go back to Sibyl Vane, make her amends,
+marry her, try to love her again.  Yes, it was his duty to do so.  She
+must have suffered more than he had.  Poor child!  He had been selfish
+and cruel to her.  The fascination that she had exercised over him
+would return.  They would be happy together.  His life with her would
+be beautiful and pure.
+
+He got up from his chair and drew a large screen right in front of the
+portrait, shuddering as he glanced at it.  "How horrible!" he murmured
+to himself, and he walked across to the window and opened it.  When he
+stepped out on to the grass, he drew a deep breath.  The fresh morning
+air seemed to drive away all his sombre passions.  He thought only of
+Sibyl.  A faint echo of his love came back to him.  He repeated her
+name over and over again.  The birds that were singing in the
+dew-drenched garden seemed to be telling the flowers about her.
+
+
+
+CHAPTER 8
+
+It was long past noon when he awoke.  His valet had crept several times
+on tiptoe into the room to see if he was stirring, and had wondered
+what made his young master sleep so late.  Finally his bell sounded,
+and Victor came in softly with a cup of tea, and a pile of letters, on
+a small tray of old Sevres china, and drew back the olive-satin
+curtains, with their shimmering blue lining, that hung in front of the
+three tall windows.
+
+"Monsieur has well slept this morning," he said, smiling.
+
+"What o'clock is it, Victor?" asked Dorian Gray drowsily.
+
+"One hour and a quarter, Monsieur."
+
+How late it was!  He sat up, and having sipped some tea, turned over
+his letters.  One of them was from Lord Henry, and had been brought by
+hand that morning.  He hesitated for a moment, and then put it aside.
+The others he opened listlessly.  They contained the usual collection
+of cards, invitations to dinner, tickets for private views, programmes
+of charity concerts, and the like that are showered on fashionable
+young men every morning during the season.  There was a rather heavy
+bill for a chased silver Louis-Quinze toilet-set that he had not yet
+had the courage to send on to his guardians, who were extremely
+old-fashioned people and did not realize that we live in an age when
+unnecessary things are our only necessities; and there were several
+very courteously worded communications from Jermyn Street money-lenders
+offering to advance any sum of money at a moment's notice and at the
+most reasonable rates of interest.
+
+After about ten minutes he got up, and throwing on an elaborate
+dressing-gown of silk-embroidered cashmere wool, passed into the
+onyx-paved bathroom.  The cool water refreshed him after his long
+sleep.  He seemed to have forgotten all that he had gone through.  A
+dim sense of having taken part in some strange tragedy came to him once
+or twice, but there was the unreality of a dream about it.
+
+As soon as he was dressed, he went into the library and sat down to a
+light French breakfast that had been laid out for him on a small round
+table close to the open window.  It was an exquisite day.  The warm air
+seemed laden with spices.  A bee flew in and buzzed round the
+blue-dragon bowl that, filled with sulphur-yellow roses, stood before
+him.  He felt perfectly happy.
+
+Suddenly his eye fell on the screen that he had placed in front of the
+portrait, and he started.
+
+"Too cold for Monsieur?" asked his valet, putting an omelette on the
+table.  "I shut the window?"
+
+Dorian shook his head.  "I am not cold," he murmured.
+
+Was it all true?  Had the portrait really changed?  Or had it been
+simply his own imagination that had made him see a look of evil where
+there had been a look of joy?  Surely a painted canvas could not alter?
+The thing was absurd.  It would serve as a tale to tell Basil some day.
+It would make him smile.
+
+And, yet, how vivid was his recollection of the whole thing!  First in
+the dim twilight, and then in the bright dawn, he had seen the touch of
+cruelty round the warped lips.  He almost dreaded his valet leaving the
+room.  He knew that when he was alone he would have to examine the
+portrait.  He was afraid of certainty.  When the coffee and cigarettes
+had been brought and the man turned to go, he felt a wild desire to
+tell him to remain.  As the door was closing behind him, he called him
+back.  The man stood waiting for his orders.  Dorian looked at him for
+a moment.  "I am not at home to any one, Victor," he said with a sigh.
+The man bowed and retired.
+
+Then he rose from the table, lit a cigarette, and flung himself down on
+a luxuriously cushioned couch that stood facing the screen.  The screen
+was an old one, of gilt Spanish leather, stamped and wrought with a
+rather florid Louis-Quatorze pattern.  He scanned it curiously,
+wondering if ever before it had concealed the secret of a man's life.
+
+Should he move it aside, after all?  Why not let it stay there?  What
+was the use of knowing? If the thing was true, it was terrible.  If it
+was not true, why trouble about it?  But what if, by some fate or
+deadlier chance, eyes other than his spied behind and saw the horrible
+change?  What should he do if Basil Hallward came and asked to look at
+his own picture?  Basil would be sure to do that.  No; the thing had to
+be examined, and at once.  Anything would be better than this dreadful
+state of doubt.
+
+He got up and locked both doors.  At least he would be alone when he
+looked upon the mask of his shame.  Then he drew the screen aside and
+saw himself face to face.  It was perfectly true.  The portrait had
+altered.
+
+As he often remembered afterwards, and always with no small wonder, he
+found himself at first gazing at the portrait with a feeling of almost
+scientific interest.  That such a change should have taken place was
+incredible to him.  And yet it was a fact.  Was there some subtle
+affinity between the chemical atoms that shaped themselves into form
+and colour on the canvas and the soul that was within him?  Could it be
+that what that soul thought, they realized?--that what it dreamed, they
+made true?  Or was there some other, more terrible reason?  He
+shuddered, and felt afraid, and, going back to the couch, lay there,
+gazing at the picture in sickened horror.
+
+One thing, however, he felt that it had done for him.  It had made him
+conscious how unjust, how cruel, he had been to Sibyl Vane.  It was not
+too late to make reparation for that.  She could still be his wife.
+His unreal and selfish love would yield to some higher influence, would
+be transformed into some nobler passion, and the portrait that Basil
+Hallward had painted of him would be a guide to him through life, would
+be to him what holiness is to some, and conscience to others, and the
+fear of God to us all.  There were opiates for remorse, drugs that
+could lull the moral sense to sleep.  But here was a visible symbol of
+the degradation of sin.  Here was an ever-present sign of the ruin men
+brought upon their souls.
+
+Three o'clock struck, and four, and the half-hour rang its double
+chime, but Dorian Gray did not stir.  He was trying to gather up the
+scarlet threads of life and to weave them into a pattern; to find his
+way through the sanguine labyrinth of passion through which he was
+wandering.  He did not know what to do, or what to think.  Finally, he
+went over to the table and wrote a passionate letter to the girl he had
+loved, imploring her forgiveness and accusing himself of madness.  He
+covered page after page with wild words of sorrow and wilder words of
+pain.  There is a luxury in self-reproach. When we blame ourselves, we
+feel that no one else has a right to blame us.  It is the confession,
+not the priest, that gives us absolution.  When Dorian had finished the
+letter, he felt that he had been forgiven.
+
+Suddenly there came a knock to the door, and he heard Lord Henry's
+voice outside.  "My dear boy, I must see you.  Let me in at once.  I
+can't bear your shutting yourself up like this."
+
+He made no answer at first, but remained quite still.  The knocking
+still continued and grew louder.  Yes, it was better to let Lord Henry
+in, and to explain to him the new life he was going to lead, to quarrel
+with him if it became necessary to quarrel, to part if parting was
+inevitable.  He jumped up, drew the screen hastily across the picture,
+and unlocked the door.
+
+"I am so sorry for it all, Dorian," said Lord Henry as he entered.
+"But you must not think too much about it."
+
+"Do you mean about Sibyl Vane?" asked the lad.
+
+"Yes, of course," answered Lord Henry, sinking into a chair and slowly
+pulling off his yellow gloves.  "It is dreadful, from one point of
+view, but it was not your fault.  Tell me, did you go behind and see
+her, after the play was over?"
+
+"Yes."
+
+"I felt sure you had.  Did you make a scene with her?"
+
+"I was brutal, Harry--perfectly brutal.  But it is all right now.  I am
+not sorry for anything that has happened.  It has taught me to know
+myself better."
+
+"Ah, Dorian, I am so glad you take it in that way!  I was afraid I
+would find you plunged in remorse and tearing that nice curly hair of
+yours."
+
+"I have got through all that," said Dorian, shaking his head and
+smiling.  "I am perfectly happy now.  I know what conscience is, to
+begin with.  It is not what you told me it was.  It is the divinest
+thing in us.  Don't sneer at it, Harry, any more--at least not before
+me.  I want to be good.  I can't bear the idea of my soul being
+hideous."
+
+"A very charming artistic basis for ethics, Dorian!  I congratulate you
+on it.  But how are you going to begin?"
+
+"By marrying Sibyl Vane."
+
+"Marrying Sibyl Vane!" cried Lord Henry, standing up and looking at him
+in perplexed amazement.  "But, my dear Dorian--"
+
+"Yes, Harry, I know what you are going to say.  Something dreadful
+about marriage.  Don't say it.  Don't ever say things of that kind to
+me again.  Two days ago I asked Sibyl to marry me.  I am not going to
+break my word to her.  She is to be my wife."
+
+"Your wife!  Dorian! ... Didn't you get my letter?  I wrote to you this
+morning, and sent the note down by my own man."
+
+"Your letter?  Oh, yes, I remember.  I have not read it yet, Harry.  I
+was afraid there might be something in it that I wouldn't like.  You
+cut life to pieces with your epigrams."
+
+"You know nothing then?"
+
+"What do you mean?"
+
+Lord Henry walked across the room, and sitting down by Dorian Gray,
+took both his hands in his own and held them tightly.  "Dorian," he
+said, "my letter--don't be frightened--was to tell you that Sibyl Vane
+is dead."
+
+A cry of pain broke from the lad's lips, and he leaped to his feet,
+tearing his hands away from Lord Henry's grasp.  "Dead!  Sibyl dead!
+It is not true!  It is a horrible lie!  How dare you say it?"
+
+"It is quite true, Dorian," said Lord Henry, gravely.  "It is in all
+the morning papers.  I wrote down to you to ask you not to see any one
+till I came.  There will have to be an inquest, of course, and you must
+not be mixed up in it.  Things like that make a man fashionable in
+Paris.  But in London people are so prejudiced.  Here, one should never
+make one's _debut_ with a scandal.  One should reserve that to give an
+interest to one's old age.  I suppose they don't know your name at the
+theatre?  If they don't, it is all right.  Did any one see you going
+round to her room?  That is an important point."
+
+Dorian did not answer for a few moments.  He was dazed with horror.
+Finally he stammered, in a stifled voice, "Harry, did you say an
+inquest?  What did you mean by that?  Did Sibyl--? Oh, Harry, I can't
+bear it!  But be quick.  Tell me everything at once."
+
+"I have no doubt it was not an accident, Dorian, though it must be put
+in that way to the public.  It seems that as she was leaving the
+theatre with her mother, about half-past twelve or so, she said she had
+forgotten something upstairs.  They waited some time for her, but she
+did not come down again.  They ultimately found her lying dead on the
+floor of her dressing-room. She had swallowed something by mistake,
+some dreadful thing they use at theatres.  I don't know what it was,
+but it had either prussic acid or white lead in it.  I should fancy it
+was prussic acid, as she seems to have died instantaneously."
+
+"Harry, Harry, it is terrible!" cried the lad.
+
+"Yes; it is very tragic, of course, but you must not get yourself mixed
+up in it.  I see by _The Standard_ that she was seventeen.  I should have
+thought she was almost younger than that.  She looked such a child, and
+seemed to know so little about acting.  Dorian, you mustn't let this
+thing get on your nerves.  You must come and dine with me, and
+afterwards we will look in at the opera.  It is a Patti night, and
+everybody will be there.  You can come to my sister's box.  She has got
+some smart women with her."
+
+"So I have murdered Sibyl Vane," said Dorian Gray, half to himself,
+"murdered her as surely as if I had cut her little throat with a knife.
+Yet the roses are not less lovely for all that.  The birds sing just as
+happily in my garden.  And to-night I am to dine with you, and then go
+on to the opera, and sup somewhere, I suppose, afterwards.  How
+extraordinarily dramatic life is!  If I had read all this in a book,
+Harry, I think I would have wept over it.  Somehow, now that it has
+happened actually, and to me, it seems far too wonderful for tears.
+Here is the first passionate love-letter I have ever written in my
+life.  Strange, that my first passionate love-letter should have been
+addressed to a dead girl.  Can they feel, I wonder, those white silent
+people we call the dead?  Sibyl!  Can she feel, or know, or listen?
+Oh, Harry, how I loved her once!  It seems years ago to me now.  She
+was everything to me.  Then came that dreadful night--was it really
+only last night?--when she played so badly, and my heart almost broke.
+She explained it all to me.  It was terribly pathetic.  But I was not
+moved a bit.  I thought her shallow.  Suddenly something happened that
+made me afraid.  I can't tell you what it was, but it was terrible.  I
+said I would go back to her.  I felt I had done wrong.  And now she is
+dead.  My God!  My God!  Harry, what shall I do?  You don't know the
+danger I am in, and there is nothing to keep me straight.  She would
+have done that for me.  She had no right to kill herself.  It was
+selfish of her."
+
+"My dear Dorian," answered Lord Henry, taking a cigarette from his case
+and producing a gold-latten matchbox, "the only way a woman can ever
+reform a man is by boring him so completely that he loses all possible
+interest in life.  If you had married this girl, you would have been
+wretched.  Of course, you would have treated her kindly.  One can
+always be kind to people about whom one cares nothing.  But she would
+have soon found out that you were absolutely indifferent to her.  And
+when a woman finds that out about her husband, she either becomes
+dreadfully dowdy, or wears very smart bonnets that some other woman's
+husband has to pay for.  I say nothing about the social mistake, which
+would have been abject--which, of course, I would not have allowed--but
+I assure you that in any case the whole thing would have been an
+absolute failure."
+
+"I suppose it would," muttered the lad, walking up and down the room
+and looking horribly pale.  "But I thought it was my duty.  It is not
+my fault that this terrible tragedy has prevented my doing what was
+right.  I remember your saying once that there is a fatality about good
+resolutions--that they are always made too late.  Mine certainly were."
+
+"Good resolutions are useless attempts to interfere with scientific
+laws.  Their origin is pure vanity.  Their result is absolutely _nil_.
+They give us, now and then, some of those luxurious sterile emotions
+that have a certain charm for the weak.  That is all that can be said
+for them.  They are simply cheques that men draw on a bank where they
+have no account."
+
+"Harry," cried Dorian Gray, coming over and sitting down beside him,
+"why is it that I cannot feel this tragedy as much as I want to?  I
+don't think I am heartless.  Do you?"
+
+"You have done too many foolish things during the last fortnight to be
+entitled to give yourself that name, Dorian," answered Lord Henry with
+his sweet melancholy smile.
+
+The lad frowned.  "I don't like that explanation, Harry," he rejoined,
+"but I am glad you don't think I am heartless.  I am nothing of the
+kind.  I know I am not.  And yet I must admit that this thing that has
+happened does not affect me as it should.  It seems to me to be simply
+like a wonderful ending to a wonderful play.  It has all the terrible
+beauty of a Greek tragedy, a tragedy in which I took a great part, but
+by which I have not been wounded."
+
+"It is an interesting question," said Lord Henry, who found an
+exquisite pleasure in playing on the lad's unconscious egotism, "an
+extremely interesting question.  I fancy that the true explanation is
+this:  It often happens that the real tragedies of life occur in such
+an inartistic manner that they hurt us by their crude violence, their
+absolute incoherence, their absurd want of meaning, their entire lack
+of style.  They affect us just as vulgarity affects us.  They give us
+an impression of sheer brute force, and we revolt against that.
+Sometimes, however, a tragedy that possesses artistic elements of
+beauty crosses our lives.  If these elements of beauty are real, the
+whole thing simply appeals to our sense of dramatic effect.  Suddenly
+we find that we are no longer the actors, but the spectators of the
+play.  Or rather we are both.  We watch ourselves, and the mere wonder
+of the spectacle enthralls us.  In the present case, what is it that
+has really happened?  Some one has killed herself for love of you.  I
+wish that I had ever had such an experience.  It would have made me in
+love with love for the rest of my life.  The people who have adored
+me--there have not been very many, but there have been some--have
+always insisted on living on, long after I had ceased to care for them,
+or they to care for me.  They have become stout and tedious, and when I
+meet them, they go in at once for reminiscences.  That awful memory of
+woman!  What a fearful thing it is!  And what an utter intellectual
+stagnation it reveals!  One should absorb the colour of life, but one
+should never remember its details.  Details are always vulgar."
+
+"I must sow poppies in my garden," sighed Dorian.
+
+"There is no necessity," rejoined his companion.  "Life has always
+poppies in her hands.  Of course, now and then things linger.  I once
+wore nothing but violets all through one season, as a form of artistic
+mourning for a romance that would not die.  Ultimately, however, it did
+die.  I forget what killed it.  I think it was her proposing to
+sacrifice the whole world for me.  That is always a dreadful moment.
+It fills one with the terror of eternity.  Well--would you believe
+it?--a week ago, at Lady Hampshire's, I found myself seated at dinner
+next the lady in question, and she insisted on going over the whole
+thing again, and digging up the past, and raking up the future.  I had
+buried my romance in a bed of asphodel.  She dragged it out again and
+assured me that I had spoiled her life.  I am bound to state that she
+ate an enormous dinner, so I did not feel any anxiety.  But what a lack
+of taste she showed!  The one charm of the past is that it is the past.
+But women never know when the curtain has fallen.  They always want a
+sixth act, and as soon as the interest of the play is entirely over,
+they propose to continue it.  If they were allowed their own way, every
+comedy would have a tragic ending, and every tragedy would culminate in
+a farce.  They are charmingly artificial, but they have no sense of
+art.  You are more fortunate than I am.  I assure you, Dorian, that not
+one of the women I have known would have done for me what Sibyl Vane
+did for you.  Ordinary women always console themselves.  Some of them
+do it by going in for sentimental colours.  Never trust a woman who
+wears mauve, whatever her age may be, or a woman over thirty-five who
+is fond of pink ribbons.  It always means that they have a history.
+Others find a great consolation in suddenly discovering the good
+qualities of their husbands.  They flaunt their conjugal felicity in
+one's face, as if it were the most fascinating of sins.  Religion
+consoles some.  Its mysteries have all the charm of a flirtation, a
+woman once told me, and I can quite understand it.  Besides, nothing
+makes one so vain as being told that one is a sinner.  Conscience makes
+egotists of us all.  Yes; there is really no end to the consolations
+that women find in modern life.  Indeed, I have not mentioned the most
+important one."
+
+"What is that, Harry?" said the lad listlessly.
+
+"Oh, the obvious consolation.  Taking some one else's admirer when one
+loses one's own.  In good society that always whitewashes a woman.  But
+really, Dorian, how different Sibyl Vane must have been from all the
+women one meets!  There is something to me quite beautiful about her
+death.  I am glad I am living in a century when such wonders happen.
+They make one believe in the reality of the things we all play with,
+such as romance, passion, and love."
+
+"I was terribly cruel to her.  You forget that."
+
+"I am afraid that women appreciate cruelty, downright cruelty, more
+than anything else.  They have wonderfully primitive instincts.  We
+have emancipated them, but they remain slaves looking for their
+masters, all the same.  They love being dominated.  I am sure you were
+splendid.  I have never seen you really and absolutely angry, but I can
+fancy how delightful you looked.  And, after all, you said something to
+me the day before yesterday that seemed to me at the time to be merely
+fanciful, but that I see now was absolutely true, and it holds the key
+to everything."
+
+"What was that, Harry?"
+
+"You said to me that Sibyl Vane represented to you all the heroines of
+romance--that she was Desdemona one night, and Ophelia the other; that
+if she died as Juliet, she came to life as Imogen."
+
+"She will never come to life again now," muttered the lad, burying his
+face in his hands.
+
+"No, she will never come to life.  She has played her last part.  But
+you must think of that lonely death in the tawdry dressing-room simply
+as a strange lurid fragment from some Jacobean tragedy, as a wonderful
+scene from Webster, or Ford, or Cyril Tourneur.  The girl never really
+lived, and so she has never really died.  To you at least she was
+always a dream, a phantom that flitted through Shakespeare's plays and
+left them lovelier for its presence, a reed through which Shakespeare's
+music sounded richer and more full of joy.  The moment she touched
+actual life, she marred it, and it marred her, and so she passed away.
+Mourn for Ophelia, if you like.  Put ashes on your head because
+Cordelia was strangled.  Cry out against Heaven because the daughter of
+Brabantio died.  But don't waste your tears over Sibyl Vane.  She was
+less real than they are."
+
+There was a silence.  The evening darkened in the room.  Noiselessly,
+and with silver feet, the shadows crept in from the garden.  The
+colours faded wearily out of things.
+
+After some time Dorian Gray looked up.  "You have explained me to
+myself, Harry," he murmured with something of a sigh of relief.  "I
+felt all that you have said, but somehow I was afraid of it, and I
+could not express it to myself.  How well you know me!  But we will not
+talk again of what has happened.  It has been a marvellous experience.
+That is all.  I wonder if life has still in store for me anything as
+marvellous."
+
+"Life has everything in store for you, Dorian.  There is nothing that
+you, with your extraordinary good looks, will not be able to do."
+
+"But suppose, Harry, I became haggard, and old, and wrinkled?  What
+then?"
+
+"Ah, then," said Lord Henry, rising to go, "then, my dear Dorian, you
+would have to fight for your victories.  As it is, they are brought to
+you.  No, you must keep your good looks.  We live in an age that reads
+too much to be wise, and that thinks too much to be beautiful.  We
+cannot spare you.  And now you had better dress and drive down to the
+club.  We are rather late, as it is."
+
+"I think I shall join you at the opera, Harry.  I feel too tired to eat
+anything.  What is the number of your sister's box?"
+
+"Twenty-seven, I believe.  It is on the grand tier.  You will see her
+name on the door.  But I am sorry you won't come and dine."
+
+"I don't feel up to it," said Dorian listlessly.  "But I am awfully
+obliged to you for all that you have said to me.  You are certainly my
+best friend.  No one has ever understood me as you have."
+
+"We are only at the beginning of our friendship, Dorian," answered Lord
+Henry, shaking him by the hand.  "Good-bye. I shall see you before
+nine-thirty, I hope.  Remember, Patti is singing."
+
+As he closed the door behind him, Dorian Gray touched the bell, and in
+a few minutes Victor appeared with the lamps and drew the blinds down.
+He waited impatiently for him to go.  The man seemed to take an
+interminable time over everything.
+
+As soon as he had left, he rushed to the screen and drew it back.  No;
+there was no further change in the picture.  It had received the news
+of Sibyl Vane's death before he had known of it himself.  It was
+conscious of the events of life as they occurred.  The vicious cruelty
+that marred the fine lines of the mouth had, no doubt, appeared at the
+very moment that the girl had drunk the poison, whatever it was.  Or
+was it indifferent to results?  Did it merely take cognizance of what
+passed within the soul?  He wondered, and hoped that some day he would
+see the change taking place before his very eyes, shuddering as he
+hoped it.
+
+Poor Sibyl!  What a romance it had all been!  She had often mimicked
+death on the stage.  Then Death himself had touched her and taken her
+with him.  How had she played that dreadful last scene?  Had she cursed
+him, as she died?  No; she had died for love of him, and love would
+always be a sacrament to him now.  She had atoned for everything by the
+sacrifice she had made of her life.  He would not think any more of
+what she had made him go through, on that horrible night at the
+theatre.  When he thought of her, it would be as a wonderful tragic
+figure sent on to the world's stage to show the supreme reality of
+love.  A wonderful tragic figure?  Tears came to his eyes as he
+remembered her childlike look, and winsome fanciful ways, and shy
+tremulous grace.  He brushed them away hastily and looked again at the
+picture.
+
+He felt that the time had really come for making his choice.  Or had
+his choice already been made?  Yes, life had decided that for
+him--life, and his own infinite curiosity about life.  Eternal youth,
+infinite passion, pleasures subtle and secret, wild joys and wilder
+sins--he was to have all these things.  The portrait was to bear the
+burden of his shame: that was all.
+
+A feeling of pain crept over him as he thought of the desecration that
+was in store for the fair face on the canvas.  Once, in boyish mockery
+of Narcissus, he had kissed, or feigned to kiss, those painted lips
+that now smiled so cruelly at him.  Morning after morning he had sat
+before the portrait wondering at its beauty, almost enamoured of it, as
+it seemed to him at times.  Was it to alter now with every mood to
+which he yielded?  Was it to become a monstrous and loathsome thing, to
+be hidden away in a locked room, to be shut out from the sunlight that
+had so often touched to brighter gold the waving wonder of its hair?
+The pity of it! the pity of it!
+
+For a moment, he thought of praying that the horrible sympathy that
+existed between him and the picture might cease.  It had changed in
+answer to a prayer; perhaps in answer to a prayer it might remain
+unchanged.  And yet, who, that knew anything about life, would
+surrender the chance of remaining always young, however fantastic that
+chance might be, or with what fateful consequences it might be fraught?
+Besides, was it really under his control?  Had it indeed been prayer
+that had produced the substitution?  Might there not be some curious
+scientific reason for it all?  If thought could exercise its influence
+upon a living organism, might not thought exercise an influence upon
+dead and inorganic things?  Nay, without thought or conscious desire,
+might not things external to ourselves vibrate in unison with our moods
+and passions, atom calling to atom in secret love or strange affinity?
+But the reason was of no importance.  He would never again tempt by a
+prayer any terrible power.  If the picture was to alter, it was to
+alter.  That was all.  Why inquire too closely into it?
+
+For there would be a real pleasure in watching it.  He would be able to
+follow his mind into its secret places.  This portrait would be to him
+the most magical of mirrors.  As it had revealed to him his own body,
+so it would reveal to him his own soul.  And when winter came upon it,
+he would still be standing where spring trembles on the verge of
+summer.  When the blood crept from its face, and left behind a pallid
+mask of chalk with leaden eyes, he would keep the glamour of boyhood.
+Not one blossom of his loveliness would ever fade.  Not one pulse of
+his life would ever weaken.  Like the gods of the Greeks, he would be
+strong, and fleet, and joyous.  What did it matter what happened to the
+coloured image on the canvas?  He would be safe.  That was everything.
+
+He drew the screen back into its former place in front of the picture,
+smiling as he did so, and passed into his bedroom, where his valet was
+already waiting for him.  An hour later he was at the opera, and Lord
+Henry was leaning over his chair.
+
+
+
+CHAPTER 9
+
+As he was sitting at breakfast next morning, Basil Hallward was shown
+into the room.
+
+"I am so glad I have found you, Dorian," he said gravely.  "I called
+last night, and they told me you were at the opera.  Of course, I knew
+that was impossible.  But I wish you had left word where you had really
+gone to.  I passed a dreadful evening, half afraid that one tragedy
+might be followed by another.  I think you might have telegraphed for
+me when you heard of it first.  I read of it quite by chance in a late
+edition of _The Globe_ that I picked up at the club.  I came here at once
+and was miserable at not finding you.  I can't tell you how
+heart-broken I am about the whole thing.  I know what you must suffer.
+But where were you?  Did you go down and see the girl's mother?  For a
+moment I thought of following you there.  They gave the address in the
+paper.  Somewhere in the Euston Road, isn't it?  But I was afraid of
+intruding upon a sorrow that I could not lighten.  Poor woman!  What a
+state she must be in!  And her only child, too!  What did she say about
+it all?"
+
+"My dear Basil, how do I know?" murmured Dorian Gray, sipping some
+pale-yellow wine from a delicate, gold-beaded bubble of Venetian glass
+and looking dreadfully bored.  "I was at the opera.  You should have
+come on there.  I met Lady Gwendolen, Harry's sister, for the first
+time.  We were in her box.  She is perfectly charming; and Patti sang
+divinely.  Don't talk about horrid subjects.  If one doesn't talk about
+a thing, it has never happened.  It is simply expression, as Harry
+says, that gives reality to things.  I may mention that she was not the
+woman's only child.  There is a son, a charming fellow, I believe.  But
+he is not on the stage.  He is a sailor, or something.  And now, tell
+me about yourself and what you are painting."
+
+"You went to the opera?" said Hallward, speaking very slowly and with a
+strained touch of pain in his voice.  "You went to the opera while
+Sibyl Vane was lying dead in some sordid lodging?  You can talk to me
+of other women being charming, and of Patti singing divinely, before
+the girl you loved has even the quiet of a grave to sleep in?  Why,
+man, there are horrors in store for that little white body of hers!"
+
+"Stop, Basil!  I won't hear it!" cried Dorian, leaping to his feet.
+"You must not tell me about things.  What is done is done.  What is
+past is past."
+
+"You call yesterday the past?"
+
+"What has the actual lapse of time got to do with it?  It is only
+shallow people who require years to get rid of an emotion.  A man who
+is master of himself can end a sorrow as easily as he can invent a
+pleasure.  I don't want to be at the mercy of my emotions.  I want to
+use them, to enjoy them, and to dominate them."
+
+"Dorian, this is horrible!  Something has changed you completely.  You
+look exactly the same wonderful boy who, day after day, used to come
+down to my studio to sit for his picture.  But you were simple,
+natural, and affectionate then.  You were the most unspoiled creature
+in the whole world.  Now, I don't know what has come over you.  You
+talk as if you had no heart, no pity in you.  It is all Harry's
+influence.  I see that."
+
+The lad flushed up and, going to the window, looked out for a few
+moments on the green, flickering, sun-lashed garden.  "I owe a great
+deal to Harry, Basil," he said at last, "more than I owe to you.  You
+only taught me to be vain."
+
+"Well, I am punished for that, Dorian--or shall be some day."
+
+"I don't know what you mean, Basil," he exclaimed, turning round.  "I
+don't know what you want.  What do you want?"
+
+"I want the Dorian Gray I used to paint," said the artist sadly.
+
+"Basil," said the lad, going over to him and putting his hand on his
+shoulder, "you have come too late.  Yesterday, when I heard that Sibyl
+Vane had killed herself--"
+
+"Killed herself!  Good heavens! is there no doubt about that?" cried
+Hallward, looking up at him with an expression of horror.
+
+"My dear Basil!  Surely you don't think it was a vulgar accident?  Of
+course she killed herself."
+
+The elder man buried his face in his hands.  "How fearful," he
+muttered, and a shudder ran through him.
+
+"No," said Dorian Gray, "there is nothing fearful about it.  It is one
+of the great romantic tragedies of the age.  As a rule, people who act
+lead the most commonplace lives.  They are good husbands, or faithful
+wives, or something tedious.  You know what I mean--middle-class virtue
+and all that kind of thing.  How different Sibyl was!  She lived her
+finest tragedy.  She was always a heroine.  The last night she
+played--the night you saw her--she acted badly because she had known
+the reality of love.  When she knew its unreality, she died, as Juliet
+might have died.  She passed again into the sphere of art.  There is
+something of the martyr about her.  Her death has all the pathetic
+uselessness of martyrdom, all its wasted beauty.  But, as I was saying,
+you must not think I have not suffered.  If you had come in yesterday
+at a particular moment--about half-past five, perhaps, or a quarter to
+six--you would have found me in tears.  Even Harry, who was here, who
+brought me the news, in fact, had no idea what I was going through.  I
+suffered immensely.  Then it passed away.  I cannot repeat an emotion.
+No one can, except sentimentalists.  And you are awfully unjust, Basil.
+You come down here to console me.  That is charming of you.  You find
+me consoled, and you are furious.  How like a sympathetic person!  You
+remind me of a story Harry told me about a certain philanthropist who
+spent twenty years of his life in trying to get some grievance
+redressed, or some unjust law altered--I forget exactly what it was.
+Finally he succeeded, and nothing could exceed his disappointment.  He
+had absolutely nothing to do, almost died of _ennui_, and became a
+confirmed misanthrope.  And besides, my dear old Basil, if you really
+want to console me, teach me rather to forget what has happened, or to
+see it from a proper artistic point of view.  Was it not Gautier who
+used to write about _la consolation des arts_?  I remember picking up a
+little vellum-covered book in your studio one day and chancing on that
+delightful phrase.  Well, I am not like that young man you told me of
+when we were down at Marlow together, the young man who used to say
+that yellow satin could console one for all the miseries of life.  I
+love beautiful things that one can touch and handle.  Old brocades,
+green bronzes, lacquer-work, carved ivories, exquisite surroundings,
+luxury, pomp--there is much to be got from all these.  But the artistic
+temperament that they create, or at any rate reveal, is still more to
+me.  To become the spectator of one's own life, as Harry says, is to
+escape the suffering of life.  I know you are surprised at my talking
+to you like this.  You have not realized how I have developed.  I was a
+schoolboy when you knew me.  I am a man now.  I have new passions, new
+thoughts, new ideas.  I am different, but you must not like me less.  I
+am changed, but you must always be my friend.  Of course, I am very
+fond of Harry.  But I know that you are better than he is.  You are not
+stronger--you are too much afraid of life--but you are better.  And how
+happy we used to be together!  Don't leave me, Basil, and don't quarrel
+with me.  I am what I am.  There is nothing more to be said."
+
+The painter felt strangely moved.  The lad was infinitely dear to him,
+and his personality had been the great turning point in his art.  He
+could not bear the idea of reproaching him any more.  After all, his
+indifference was probably merely a mood that would pass away.  There
+was so much in him that was good, so much in him that was noble.
+
+"Well, Dorian," he said at length, with a sad smile, "I won't speak to
+you again about this horrible thing, after to-day.  I only trust your
+name won't be mentioned in connection with it.  The inquest is to take
+place this afternoon.  Have they summoned you?"
+
+Dorian shook his head, and a look of annoyance passed over his face at
+the mention of the word "inquest."  There was something so crude and
+vulgar about everything of the kind.  "They don't know my name," he
+answered.
+
+"But surely she did?"
+
+"Only my Christian name, and that I am quite sure she never mentioned
+to any one.  She told me once that they were all rather curious to
+learn who I was, and that she invariably told them my name was Prince
+Charming.  It was pretty of her.  You must do me a drawing of Sibyl,
+Basil.  I should like to have something more of her than the memory of
+a few kisses and some broken pathetic words."
+
+"I will try and do something, Dorian, if it would please you.  But you
+must come and sit to me yourself again.  I can't get on without you."
+
+"I can never sit to you again, Basil.  It is impossible!" he exclaimed,
+starting back.
+
+The painter stared at him.  "My dear boy, what nonsense!" he cried.
+"Do you mean to say you don't like what I did of you?  Where is it?
+Why have you pulled the screen in front of it?  Let me look at it.  It
+is the best thing I have ever done.  Do take the screen away, Dorian.
+It is simply disgraceful of your servant hiding my work like that.  I
+felt the room looked different as I came in."
+
+"My servant has nothing to do with it, Basil.  You don't imagine I let
+him arrange my room for me?  He settles my flowers for me
+sometimes--that is all.  No; I did it myself.  The light was too strong
+on the portrait."
+
+"Too strong!  Surely not, my dear fellow?  It is an admirable place for
+it.  Let me see it."  And Hallward walked towards the corner of the
+room.
+
+A cry of terror broke from Dorian Gray's lips, and he rushed between
+the painter and the screen.  "Basil," he said, looking very pale, "you
+must not look at it.  I don't wish you to."
+
+"Not look at my own work!  You are not serious.  Why shouldn't I look
+at it?" exclaimed Hallward, laughing.
+
+"If you try to look at it, Basil, on my word of honour I will never
+speak to you again as long as I live.  I am quite serious.  I don't
+offer any explanation, and you are not to ask for any.  But, remember,
+if you touch this screen, everything is over between us."
+
+Hallward was thunderstruck.  He looked at Dorian Gray in absolute
+amazement.  He had never seen him like this before.  The lad was
+actually pallid with rage.  His hands were clenched, and the pupils of
+his eyes were like disks of blue fire.  He was trembling all over.
+
+"Dorian!"
+
+"Don't speak!"
+
+"But what is the matter?  Of course I won't look at it if you don't
+want me to," he said, rather coldly, turning on his heel and going over
+towards the window.  "But, really, it seems rather absurd that I
+shouldn't see my own work, especially as I am going to exhibit it in
+Paris in the autumn.  I shall probably have to give it another coat of
+varnish before that, so I must see it some day, and why not to-day?"
+
+"To exhibit it!  You want to exhibit it?" exclaimed Dorian Gray, a
+strange sense of terror creeping over him.  Was the world going to be
+shown his secret?  Were people to gape at the mystery of his life?
+That was impossible.  Something--he did not know what--had to be done
+at once.
+
+"Yes; I don't suppose you will object to that.  Georges Petit is going
+to collect all my best pictures for a special exhibition in the Rue de
+Seze, which will open the first week in October.  The portrait will
+only be away a month.  I should think you could easily spare it for
+that time.  In fact, you are sure to be out of town.  And if you keep
+it always behind a screen, you can't care much about it."
+
+Dorian Gray passed his hand over his forehead.  There were beads of
+perspiration there.  He felt that he was on the brink of a horrible
+danger.  "You told me a month ago that you would never exhibit it," he
+cried.  "Why have you changed your mind?  You people who go in for
+being consistent have just as many moods as others have.  The only
+difference is that your moods are rather meaningless.  You can't have
+forgotten that you assured me most solemnly that nothing in the world
+would induce you to send it to any exhibition.  You told Harry exactly
+the same thing." He stopped suddenly, and a gleam of light came into
+his eyes.  He remembered that Lord Henry had said to him once, half
+seriously and half in jest, "If you want to have a strange quarter of
+an hour, get Basil to tell you why he won't exhibit your picture.  He
+told me why he wouldn't, and it was a revelation to me."  Yes, perhaps
+Basil, too, had his secret.  He would ask him and try.
+
+"Basil," he said, coming over quite close and looking him straight in
+the face, "we have each of us a secret.  Let me know yours, and I shall
+tell you mine.  What was your reason for refusing to exhibit my
+picture?"
+
+The painter shuddered in spite of himself.  "Dorian, if I told you, you
+might like me less than you do, and you would certainly laugh at me.  I
+could not bear your doing either of those two things.  If you wish me
+never to look at your picture again, I am content.  I have always you
+to look at.  If you wish the best work I have ever done to be hidden
+from the world, I am satisfied.  Your friendship is dearer to me than
+any fame or reputation."
+
+"No, Basil, you must tell me," insisted Dorian Gray.  "I think I have a
+right to know."  His feeling of terror had passed away, and curiosity
+had taken its place.  He was determined to find out Basil Hallward's
+mystery.
+
+"Let us sit down, Dorian," said the painter, looking troubled.  "Let us
+sit down.  And just answer me one question.  Have you noticed in the
+picture something curious?--something that probably at first did not
+strike you, but that revealed itself to you suddenly?"
+
+"Basil!" cried the lad, clutching the arms of his chair with trembling
+hands and gazing at him with wild startled eyes.
+
+"I see you did.  Don't speak.  Wait till you hear what I have to say.
+Dorian, from the moment I met you, your personality had the most
+extraordinary influence over me.  I was dominated, soul, brain, and
+power, by you.  You became to me the visible incarnation of that unseen
+ideal whose memory haunts us artists like an exquisite dream.  I
+worshipped you.  I grew jealous of every one to whom you spoke.  I
+wanted to have you all to myself.  I was only happy when I was with
+you.  When you were away from me, you were still present in my art....
+Of course, I never let you know anything about this.  It would have
+been impossible.  You would not have understood it.  I hardly
+understood it myself.  I only knew that I had seen perfection face to
+face, and that the world had become wonderful to my eyes--too
+wonderful, perhaps, for in such mad worships there is peril, the peril
+of losing them, no less than the peril of keeping them....  Weeks and
+weeks went on, and I grew more and more absorbed in you.  Then came a
+new development.  I had drawn you as Paris in dainty armour, and as
+Adonis with huntsman's cloak and polished boar-spear. Crowned with
+heavy lotus-blossoms you had sat on the prow of Adrian's barge, gazing
+across the green turbid Nile.  You had leaned over the still pool of
+some Greek woodland and seen in the water's silent silver the marvel of
+your own face.  And it had all been what art should be--unconscious,
+ideal, and remote.  One day, a fatal day I sometimes think, I
+determined to paint a wonderful portrait of you as you actually are,
+not in the costume of dead ages, but in your own dress and in your own
+time.  Whether it was the realism of the method, or the mere wonder of
+your own personality, thus directly presented to me without mist or
+veil, I cannot tell.  But I know that as I worked at it, every flake
+and film of colour seemed to me to reveal my secret.  I grew afraid
+that others would know of my idolatry.  I felt, Dorian, that I had told
+too much, that I had put too much of myself into it.  Then it was that
+I resolved never to allow the picture to be exhibited.  You were a
+little annoyed; but then you did not realize all that it meant to me.
+Harry, to whom I talked about it, laughed at me.  But I did not mind
+that.  When the picture was finished, and I sat alone with it, I felt
+that I was right.... Well, after a few days the thing left my studio,
+and as soon as I had got rid of the intolerable fascination of its
+presence, it seemed to me that I had been foolish in imagining that I
+had seen anything in it, more than that you were extremely good-looking
+and that I could paint.  Even now I cannot help feeling that it is a
+mistake to think that the passion one feels in creation is ever really
+shown in the work one creates.  Art is always more abstract than we
+fancy.  Form and colour tell us of form and colour--that is all.  It
+often seems to me that art conceals the artist far more completely than
+it ever reveals him.  And so when I got this offer from Paris, I
+determined to make your portrait the principal thing in my exhibition.
+It never occurred to me that you would refuse.  I see now that you were
+right.  The picture cannot be shown.  You must not be angry with me,
+Dorian, for what I have told you.  As I said to Harry, once, you are
+made to be worshipped."
+
+Dorian Gray drew a long breath.  The colour came back to his cheeks,
+and a smile played about his lips.  The peril was over.  He was safe
+for the time.  Yet he could not help feeling infinite pity for the
+painter who had just made this strange confession to him, and wondered
+if he himself would ever be so dominated by the personality of a
+friend.  Lord Henry had the charm of being very dangerous.  But that
+was all.  He was too clever and too cynical to be really fond of.
+Would there ever be some one who would fill him with a strange
+idolatry?  Was that one of the things that life had in store?
+
+"It is extraordinary to me, Dorian," said Hallward, "that you should
+have seen this in the portrait.  Did you really see it?"
+
+"I saw something in it," he answered, "something that seemed to me very
+curious."
+
+"Well, you don't mind my looking at the thing now?"
+
+Dorian shook his head.  "You must not ask me that, Basil.  I could not
+possibly let you stand in front of that picture."
+
+"You will some day, surely?"
+
+"Never."
+
+"Well, perhaps you are right.  And now good-bye, Dorian.  You have been
+the one person in my life who has really influenced my art.  Whatever I
+have done that is good, I owe to you.  Ah! you don't know what it cost
+me to tell you all that I have told you."
+
+"My dear Basil," said Dorian, "what have you told me?  Simply that you
+felt that you admired me too much.  That is not even a compliment."
+
+"It was not intended as a compliment.  It was a confession.  Now that I
+have made it, something seems to have gone out of me.  Perhaps one
+should never put one's worship into words."
+
+"It was a very disappointing confession."
+
+"Why, what did you expect, Dorian?  You didn't see anything else in the
+picture, did you?  There was nothing else to see?"
+
+"No; there was nothing else to see.  Why do you ask?  But you mustn't
+talk about worship.  It is foolish.  You and I are friends, Basil, and
+we must always remain so."
+
+"You have got Harry," said the painter sadly.
+
+"Oh, Harry!" cried the lad, with a ripple of laughter.  "Harry spends
+his days in saying what is incredible and his evenings in doing what is
+improbable.  Just the sort of life I would like to lead.  But still I
+don't think I would go to Harry if I were in trouble.  I would sooner
+go to you, Basil."
+
+"You will sit to me again?"
+
+"Impossible!"
+
+"You spoil my life as an artist by refusing, Dorian.  No man comes
+across two ideal things.  Few come across one."
+
+"I can't explain it to you, Basil, but I must never sit to you again.
+There is something fatal about a portrait.  It has a life of its own.
+I will come and have tea with you.  That will be just as pleasant."
+
+"Pleasanter for you, I am afraid," murmured Hallward regretfully.  "And
+now good-bye. I am sorry you won't let me look at the picture once
+again.  But that can't be helped.  I quite understand what you feel
+about it."
+
+As he left the room, Dorian Gray smiled to himself.  Poor Basil!  How
+little he knew of the true reason!  And how strange it was that,
+instead of having been forced to reveal his own secret, he had
+succeeded, almost by chance, in wresting a secret from his friend!  How
+much that strange confession explained to him!  The painter's absurd
+fits of jealousy, his wild devotion, his extravagant panegyrics, his
+curious reticences--he understood them all now, and he felt sorry.
+There seemed to him to be something tragic in a friendship so coloured
+by romance.
+
+He sighed and touched the bell.  The portrait must be hidden away at
+all costs.  He could not run such a risk of discovery again.  It had
+been mad of him to have allowed the thing to remain, even for an hour,
+in a room to which any of his friends had access.
+
+
+
+CHAPTER 10
+
+When his servant entered, he looked at him steadfastly and wondered if
+he had thought of peering behind the screen.  The man was quite
+impassive and waited for his orders.  Dorian lit a cigarette and walked
+over to the glass and glanced into it.  He could see the reflection of
+Victor's face perfectly.  It was like a placid mask of servility.
+There was nothing to be afraid of, there.  Yet he thought it best to be
+on his guard.
+
+Speaking very slowly, he told him to tell the house-keeper that he
+wanted to see her, and then to go to the frame-maker and ask him to
+send two of his men round at once.  It seemed to him that as the man
+left the room his eyes wandered in the direction of the screen.  Or was
+that merely his own fancy?
+
+After a few moments, in her black silk dress, with old-fashioned thread
+mittens on her wrinkled hands, Mrs. Leaf bustled into the library.  He
+asked her for the key of the schoolroom.
+
+"The old schoolroom, Mr. Dorian?" she exclaimed.  "Why, it is full of
+dust.  I must get it arranged and put straight before you go into it.
+It is not fit for you to see, sir.  It is not, indeed."
+
+"I don't want it put straight, Leaf.  I only want the key."
+
+"Well, sir, you'll be covered with cobwebs if you go into it.  Why, it
+hasn't been opened for nearly five years--not since his lordship died."
+
+He winced at the mention of his grandfather.  He had hateful memories
+of him.  "That does not matter," he answered.  "I simply want to see
+the place--that is all.  Give me the key."
+
+"And here is the key, sir," said the old lady, going over the contents
+of her bunch with tremulously uncertain hands.  "Here is the key.  I'll
+have it off the bunch in a moment.  But you don't think of living up
+there, sir, and you so comfortable here?"
+
+"No, no," he cried petulantly.  "Thank you, Leaf.  That will do."
+
+She lingered for a few moments, and was garrulous over some detail of
+the household.  He sighed and told her to manage things as she thought
+best.  She left the room, wreathed in smiles.
+
+As the door closed, Dorian put the key in his pocket and looked round
+the room.  His eye fell on a large, purple satin coverlet heavily
+embroidered with gold, a splendid piece of late seventeenth-century
+Venetian work that his grandfather had found in a convent near Bologna.
+Yes, that would serve to wrap the dreadful thing in.  It had perhaps
+served often as a pall for the dead.  Now it was to hide something that
+had a corruption of its own, worse than the corruption of death
+itself--something that would breed horrors and yet would never die.
+What the worm was to the corpse, his sins would be to the painted image
+on the canvas.  They would mar its beauty and eat away its grace.  They
+would defile it and make it shameful.  And yet the thing would still
+live on.  It would be always alive.
+
+He shuddered, and for a moment he regretted that he had not told Basil
+the true reason why he had wished to hide the picture away.  Basil
+would have helped him to resist Lord Henry's influence, and the still
+more poisonous influences that came from his own temperament.  The love
+that he bore him--for it was really love--had nothing in it that was
+not noble and intellectual.  It was not that mere physical admiration
+of beauty that is born of the senses and that dies when the senses
+tire.  It was such love as Michelangelo had known, and Montaigne, and
+Winckelmann, and Shakespeare himself.  Yes, Basil could have saved him.
+But it was too late now.  The past could always be annihilated.
+Regret, denial, or forgetfulness could do that.  But the future was
+inevitable.  There were passions in him that would find their terrible
+outlet, dreams that would make the shadow of their evil real.
+
+He took up from the couch the great purple-and-gold texture that
+covered it, and, holding it in his hands, passed behind the screen.
+Was the face on the canvas viler than before?  It seemed to him that it
+was unchanged, and yet his loathing of it was intensified.  Gold hair,
+blue eyes, and rose-red lips--they all were there.  It was simply the
+expression that had altered.  That was horrible in its cruelty.
+Compared to what he saw in it of censure or rebuke, how shallow Basil's
+reproaches about Sibyl Vane had been!--how shallow, and of what little
+account!  His own soul was looking out at him from the canvas and
+calling him to judgement.  A look of pain came across him, and he flung
+the rich pall over the picture.  As he did so, a knock came to the
+door.  He passed out as his servant entered.
+
+"The persons are here, Monsieur."
+
+He felt that the man must be got rid of at once.  He must not be
+allowed to know where the picture was being taken to.  There was
+something sly about him, and he had thoughtful, treacherous eyes.
+Sitting down at the writing-table he scribbled a note to Lord Henry,
+asking him to send him round something to read and reminding him that
+they were to meet at eight-fifteen that evening.
+
+"Wait for an answer," he said, handing it to him, "and show the men in
+here."
+
+In two or three minutes there was another knock, and Mr. Hubbard
+himself, the celebrated frame-maker of South Audley Street, came in
+with a somewhat rough-looking young assistant.  Mr. Hubbard was a
+florid, red-whiskered little man, whose admiration for art was
+considerably tempered by the inveterate impecuniosity of most of the
+artists who dealt with him.  As a rule, he never left his shop.  He
+waited for people to come to him.  But he always made an exception in
+favour of Dorian Gray.  There was something about Dorian that charmed
+everybody.  It was a pleasure even to see him.
+
+"What can I do for you, Mr. Gray?" he said, rubbing his fat freckled
+hands.  "I thought I would do myself the honour of coming round in
+person.  I have just got a beauty of a frame, sir.  Picked it up at a
+sale.  Old Florentine.  Came from Fonthill, I believe.  Admirably
+suited for a religious subject, Mr. Gray."
+
+"I am so sorry you have given yourself the trouble of coming round, Mr.
+Hubbard.  I shall certainly drop in and look at the frame--though I
+don't go in much at present for religious art--but to-day I only want a
+picture carried to the top of the house for me.  It is rather heavy, so
+I thought I would ask you to lend me a couple of your men."
+
+"No trouble at all, Mr. Gray.  I am delighted to be of any service to
+you.  Which is the work of art, sir?"
+
+"This," replied Dorian, moving the screen back.  "Can you move it,
+covering and all, just as it is?  I don't want it to get scratched
+going upstairs."
+
+"There will be no difficulty, sir," said the genial frame-maker,
+beginning, with the aid of his assistant, to unhook the picture from
+the long brass chains by which it was suspended.  "And, now, where
+shall we carry it to, Mr. Gray?"
+
+"I will show you the way, Mr. Hubbard, if you will kindly follow me.
+Or perhaps you had better go in front.  I am afraid it is right at the
+top of the house.  We will go up by the front staircase, as it is
+wider."
+
+He held the door open for them, and they passed out into the hall and
+began the ascent.  The elaborate character of the frame had made the
+picture extremely bulky, and now and then, in spite of the obsequious
+protests of Mr. Hubbard, who had the true tradesman's spirited dislike
+of seeing a gentleman doing anything useful, Dorian put his hand to it
+so as to help them.
+
+"Something of a load to carry, sir," gasped the little man when they
+reached the top landing.  And he wiped his shiny forehead.
+
+"I am afraid it is rather heavy," murmured Dorian as he unlocked the
+door that opened into the room that was to keep for him the curious
+secret of his life and hide his soul from the eyes of men.
+
+He had not entered the place for more than four years--not, indeed,
+since he had used it first as a play-room when he was a child, and then
+as a study when he grew somewhat older.  It was a large,
+well-proportioned room, which had been specially built by the last Lord
+Kelso for the use of the little grandson whom, for his strange likeness
+to his mother, and also for other reasons, he had always hated and
+desired to keep at a distance.  It appeared to Dorian to have but
+little changed.  There was the huge Italian _cassone_, with its
+fantastically painted panels and its tarnished gilt mouldings, in which
+he had so often hidden himself as a boy.  There the satinwood book-case
+filled with his dog-eared schoolbooks.  On the wall behind it was
+hanging the same ragged Flemish tapestry where a faded king and queen
+were playing chess in a garden, while a company of hawkers rode by,
+carrying hooded birds on their gauntleted wrists.  How well he
+remembered it all!  Every moment of his lonely childhood came back to
+him as he looked round.  He recalled the stainless purity of his boyish
+life, and it seemed horrible to him that it was here the fatal portrait
+was to be hidden away.  How little he had thought, in those dead days,
+of all that was in store for him!
+
+But there was no other place in the house so secure from prying eyes as
+this.  He had the key, and no one else could enter it.  Beneath its
+purple pall, the face painted on the canvas could grow bestial, sodden,
+and unclean.  What did it matter?  No one could see it.  He himself
+would not see it.  Why should he watch the hideous corruption of his
+soul?  He kept his youth--that was enough.  And, besides, might not
+his nature grow finer, after all?  There was no reason that the future
+should be so full of shame.  Some love might come across his life, and
+purify him, and shield him from those sins that seemed to be already
+stirring in spirit and in flesh--those curious unpictured sins whose
+very mystery lent them their subtlety and their charm.  Perhaps, some
+day, the cruel look would have passed away from the scarlet sensitive
+mouth, and he might show to the world Basil Hallward's masterpiece.
+
+No; that was impossible.  Hour by hour, and week by week, the thing
+upon the canvas was growing old.  It might escape the hideousness of
+sin, but the hideousness of age was in store for it.  The cheeks would
+become hollow or flaccid.  Yellow crow's feet would creep round the
+fading eyes and make them horrible.  The hair would lose its
+brightness, the mouth would gape or droop, would be foolish or gross,
+as the mouths of old men are.  There would be the wrinkled throat, the
+cold, blue-veined hands, the twisted body, that he remembered in the
+grandfather who had been so stern to him in his boyhood.  The picture
+had to be concealed.  There was no help for it.
+
+"Bring it in, Mr. Hubbard, please," he said, wearily, turning round.
+"I am sorry I kept you so long.  I was thinking of something else."
+
+"Always glad to have a rest, Mr. Gray," answered the frame-maker, who
+was still gasping for breath.  "Where shall we put it, sir?"
+
+"Oh, anywhere.  Here:  this will do.  I don't want to have it hung up.
+Just lean it against the wall.  Thanks."
+
+"Might one look at the work of art, sir?"
+
+Dorian started.  "It would not interest you, Mr. Hubbard," he said,
+keeping his eye on the man.  He felt ready to leap upon him and fling
+him to the ground if he dared to lift the gorgeous hanging that
+concealed the secret of his life.  "I shan't trouble you any more now.
+I am much obliged for your kindness in coming round."
+
+"Not at all, not at all, Mr. Gray.  Ever ready to do anything for you,
+sir." And Mr. Hubbard tramped downstairs, followed by the assistant,
+who glanced back at Dorian with a look of shy wonder in his rough
+uncomely face.  He had never seen any one so marvellous.
+
+When the sound of their footsteps had died away, Dorian locked the door
+and put the key in his pocket.  He felt safe now.  No one would ever
+look upon the horrible thing.  No eye but his would ever see his shame.
+
+On reaching the library, he found that it was just after five o'clock
+and that the tea had been already brought up.  On a little table of
+dark perfumed wood thickly incrusted with nacre, a present from Lady
+Radley, his guardian's wife, a pretty professional invalid who had
+spent the preceding winter in Cairo, was lying a note from Lord Henry,
+and beside it was a book bound in yellow paper, the cover slightly torn
+and the edges soiled.  A copy of the third edition of _The St. James's
+Gazette_ had been placed on the tea-tray. It was evident that Victor had
+returned.  He wondered if he had met the men in the hall as they were
+leaving the house and had wormed out of them what they had been doing.
+He would be sure to miss the picture--had no doubt missed it already,
+while he had been laying the tea-things. The screen had not been set
+back, and a blank space was visible on the wall.  Perhaps some night he
+might find him creeping upstairs and trying to force the door of the
+room.  It was a horrible thing to have a spy in one's house.  He had
+heard of rich men who had been blackmailed all their lives by some
+servant who had read a letter, or overheard a conversation, or picked
+up a card with an address, or found beneath a pillow a withered flower
+or a shred of crumpled lace.
+
+He sighed, and having poured himself out some tea, opened Lord Henry's
+note.  It was simply to say that he sent him round the evening paper,
+and a book that might interest him, and that he would be at the club at
+eight-fifteen. He opened _The St. James's_ languidly, and looked through
+it.  A red pencil-mark on the fifth page caught his eye.  It drew
+attention to the following paragraph:
+
+
+INQUEST ON AN ACTRESS.--An inquest was held this morning at the Bell
+Tavern, Hoxton Road, by Mr. Danby, the District Coroner, on the body of
+Sibyl Vane, a young actress recently engaged at the Royal Theatre,
+Holborn.  A verdict of death by misadventure was returned.
+Considerable sympathy was expressed for the mother of the deceased, who
+was greatly affected during the giving of her own evidence, and that of
+Dr. Birrell, who had made the post-mortem examination of the deceased.
+
+
+He frowned, and tearing the paper in two, went across the room and
+flung the pieces away.  How ugly it all was!  And how horribly real
+ugliness made things!  He felt a little annoyed with Lord Henry for
+having sent him the report.  And it was certainly stupid of him to have
+marked it with red pencil.  Victor might have read it.  The man knew
+more than enough English for that.
+
+Perhaps he had read it and had begun to suspect something.  And, yet,
+what did it matter?  What had Dorian Gray to do with Sibyl Vane's
+death?  There was nothing to fear.  Dorian Gray had not killed her.
+
+His eye fell on the yellow book that Lord Henry had sent him.  What was
+it, he wondered.  He went towards the little, pearl-coloured octagonal
+stand that had always looked to him like the work of some strange
+Egyptian bees that wrought in silver, and taking up the volume, flung
+himself into an arm-chair and began to turn over the leaves.  After a
+few minutes he became absorbed.  It was the strangest book that he had
+ever read.  It seemed to him that in exquisite raiment, and to the
+delicate sound of flutes, the sins of the world were passing in dumb
+show before him.  Things that he had dimly dreamed of were suddenly
+made real to him.  Things of which he had never dreamed were gradually
+revealed.
+
+It was a novel without a plot and with only one character, being,
+indeed, simply a psychological study of a certain young Parisian who
+spent his life trying to realize in the nineteenth century all the
+passions and modes of thought that belonged to every century except his
+own, and to sum up, as it were, in himself the various moods through
+which the world-spirit had ever passed, loving for their mere
+artificiality those renunciations that men have unwisely called virtue,
+as much as those natural rebellions that wise men still call sin.  The
+style in which it was written was that curious jewelled style, vivid
+and obscure at once, full of _argot_ and of archaisms, of technical
+expressions and of elaborate paraphrases, that characterizes the work
+of some of the finest artists of the French school of _Symbolistes_.
+There were in it metaphors as monstrous as orchids and as subtle in
+colour.  The life of the senses was described in the terms of mystical
+philosophy.  One hardly knew at times whether one was reading the
+spiritual ecstasies of some mediaeval saint or the morbid confessions
+of a modern sinner.  It was a poisonous book.  The heavy odour of
+incense seemed to cling about its pages and to trouble the brain.  The
+mere cadence of the sentences, the subtle monotony of their music, so
+full as it was of complex refrains and movements elaborately repeated,
+produced in the mind of the lad, as he passed from chapter to chapter,
+a form of reverie, a malady of dreaming, that made him unconscious of
+the falling day and creeping shadows.
+
+Cloudless, and pierced by one solitary star, a copper-green sky gleamed
+through the windows.  He read on by its wan light till he could read no
+more.  Then, after his valet had reminded him several times of the
+lateness of the hour, he got up, and going into the next room, placed
+the book on the little Florentine table that always stood at his
+bedside and began to dress for dinner.
+
+It was almost nine o'clock before he reached the club, where he found
+Lord Henry sitting alone, in the morning-room, looking very much bored.
+
+"I am so sorry, Harry," he cried, "but really it is entirely your
+fault.  That book you sent me so fascinated me that I forgot how the
+time was going."
+
+"Yes, I thought you would like it," replied his host, rising from his
+chair.
+
+"I didn't say I liked it, Harry.  I said it fascinated me.  There is a
+great difference."
+
+"Ah, you have discovered that?" murmured Lord Henry.  And they passed
+into the dining-room.
+
+
+
+CHAPTER 11
+
+For years, Dorian Gray could not free himself from the influence of
+this book.  Or perhaps it would be more accurate to say that he never
+sought to free himself from it.  He procured from Paris no less than
+nine large-paper copies of the first edition, and had them bound in
+different colours, so that they might suit his various moods and the
+changing fancies of a nature over which he seemed, at times, to have
+almost entirely lost control.  The hero, the wonderful young Parisian
+in whom the romantic and the scientific temperaments were so strangely
+blended, became to him a kind of prefiguring type of himself.  And,
+indeed, the whole book seemed to him to contain the story of his own
+life, written before he had lived it.
+
+In one point he was more fortunate than the novel's fantastic hero.  He
+never knew--never, indeed, had any cause to know--that somewhat
+grotesque dread of mirrors, and polished metal surfaces, and still
+water which came upon the young Parisian so early in his life, and was
+occasioned by the sudden decay of a beau that had once, apparently,
+been so remarkable.  It was with an almost cruel joy--and perhaps in
+nearly every joy, as certainly in every pleasure, cruelty has its
+place--that he used to read the latter part of the book, with its
+really tragic, if somewhat overemphasized, account of the sorrow and
+despair of one who had himself lost what in others, and the world, he
+had most dearly valued.
+
+For the wonderful beauty that had so fascinated Basil Hallward, and
+many others besides him, seemed never to leave him.  Even those who had
+heard the most evil things against him--and from time to time strange
+rumours about his mode of life crept through London and became the
+chatter of the clubs--could not believe anything to his dishonour when
+they saw him.  He had always the look of one who had kept himself
+unspotted from the world.  Men who talked grossly became silent when
+Dorian Gray entered the room.  There was something in the purity of his
+face that rebuked them.  His mere presence seemed to recall to them the
+memory of the innocence that they had tarnished.  They wondered how one
+so charming and graceful as he was could have escaped the stain of an
+age that was at once sordid and sensual.
+
+Often, on returning home from one of those mysterious and prolonged
+absences that gave rise to such strange conjecture among those who were
+his friends, or thought that they were so, he himself would creep
+upstairs to the locked room, open the door with the key that never left
+him now, and stand, with a mirror, in front of the portrait that Basil
+Hallward had painted of him, looking now at the evil and aging face on
+the canvas, and now at the fair young face that laughed back at him
+from the polished glass.  The very sharpness of the contrast used to
+quicken his sense of pleasure.  He grew more and more enamoured of his
+own beauty, more and more interested in the corruption of his own soul.
+He would examine with minute care, and sometimes with a monstrous and
+terrible delight, the hideous lines that seared the wrinkling forehead
+or crawled around the heavy sensual mouth, wondering sometimes which
+were the more horrible, the signs of sin or the signs of age.  He would
+place his white hands beside the coarse bloated hands of the picture,
+and smile.  He mocked the misshapen body and the failing limbs.
+
+There were moments, indeed, at night, when, lying sleepless in his own
+delicately scented chamber, or in the sordid room of the little
+ill-famed tavern near the docks which, under an assumed name and in
+disguise, it was his habit to frequent, he would think of the ruin he
+had brought upon his soul with a pity that was all the more poignant
+because it was purely selfish.  But moments such as these were rare.
+That curiosity about life which Lord Henry had first stirred in him, as
+they sat together in the garden of their friend, seemed to increase
+with gratification.  The more he knew, the more he desired to know.  He
+had mad hungers that grew more ravenous as he fed them.
+
+Yet he was not really reckless, at any rate in his relations to
+society.  Once or twice every month during the winter, and on each
+Wednesday evening while the season lasted, he would throw open to the
+world his beautiful house and have the most celebrated musicians of the
+day to charm his guests with the wonders of their art.  His little
+dinners, in the settling of which Lord Henry always assisted him, were
+noted as much for the careful selection and placing of those invited,
+as for the exquisite taste shown in the decoration of the table, with
+its subtle symphonic arrangements of exotic flowers, and embroidered
+cloths, and antique plate of gold and silver.  Indeed, there were many,
+especially among the very young men, who saw, or fancied that they saw,
+in Dorian Gray the true realization of a type of which they had often
+dreamed in Eton or Oxford days, a type that was to combine something of
+the real culture of the scholar with all the grace and distinction and
+perfect manner of a citizen of the world.  To them he seemed to be of
+the company of those whom Dante describes as having sought to "make
+themselves perfect by the worship of beauty."  Like Gautier, he was one
+for whom "the visible world existed."
+
+And, certainly, to him life itself was the first, the greatest, of the
+arts, and for it all the other arts seemed to be but a preparation.
+Fashion, by which what is really fantastic becomes for a moment
+universal, and dandyism, which, in its own way, is an attempt to assert
+the absolute modernity of beauty, had, of course, their fascination for
+him.  His mode of dressing, and the particular styles that from time to
+time he affected, had their marked influence on the young exquisites of
+the Mayfair balls and Pall Mall club windows, who copied him in
+everything that he did, and tried to reproduce the accidental charm of
+his graceful, though to him only half-serious, fopperies.
+
+For, while he was but too ready to accept the position that was almost
+immediately offered to him on his coming of age, and found, indeed, a
+subtle pleasure in the thought that he might really become to the
+London of his own day what to imperial Neronian Rome the author of the
+Satyricon once had been, yet in his inmost heart he desired to be
+something more than a mere _arbiter elegantiarum_, to be consulted on the
+wearing of a jewel, or the knotting of a necktie, or the conduct of a
+cane.  He sought to elaborate some new scheme of life that would have
+its reasoned philosophy and its ordered principles, and find in the
+spiritualizing of the senses its highest realization.
+
+The worship of the senses has often, and with much justice, been
+decried, men feeling a natural instinct of terror about passions and
+sensations that seem stronger than themselves, and that they are
+conscious of sharing with the less highly organized forms of existence.
+But it appeared to Dorian Gray that the true nature of the senses had
+never been understood, and that they had remained savage and animal
+merely because the world had sought to starve them into submission or
+to kill them by pain, instead of aiming at making them elements of a
+new spirituality, of which a fine instinct for beauty was to be the
+dominant characteristic.  As he looked back upon man moving through
+history, he was haunted by a feeling of loss.  So much had been
+surrendered! and to such little purpose!  There had been mad wilful
+rejections, monstrous forms of self-torture and self-denial, whose
+origin was fear and whose result was a degradation infinitely more
+terrible than that fancied degradation from which, in their ignorance,
+they had sought to escape; Nature, in her wonderful irony, driving out
+the anchorite to feed with the wild animals of the desert and giving to
+the hermit the beasts of the field as his companions.
+
+Yes:  there was to be, as Lord Henry had prophesied, a new Hedonism
+that was to recreate life and to save it from that harsh uncomely
+puritanism that is having, in our own day, its curious revival.  It was
+to have its service of the intellect, certainly, yet it was never to
+accept any theory or system that would involve the sacrifice of any
+mode of passionate experience.  Its aim, indeed, was to be experience
+itself, and not the fruits of experience, sweet or bitter as they might
+be.  Of the asceticism that deadens the senses, as of the vulgar
+profligacy that dulls them, it was to know nothing.  But it was to
+teach man to concentrate himself upon the moments of a life that is
+itself but a moment.
+
+There are few of us who have not sometimes wakened before dawn, either
+after one of those dreamless nights that make us almost enamoured of
+death, or one of those nights of horror and misshapen joy, when through
+the chambers of the brain sweep phantoms more terrible than reality
+itself, and instinct with that vivid life that lurks in all grotesques,
+and that lends to Gothic art its enduring vitality, this art being, one
+might fancy, especially the art of those whose minds have been troubled
+with the malady of reverie.  Gradually white fingers creep through the
+curtains, and they appear to tremble.  In black fantastic shapes, dumb
+shadows crawl into the corners of the room and crouch there.  Outside,
+there is the stirring of birds among the leaves, or the sound of men
+going forth to their work, or the sigh and sob of the wind coming down
+from the hills and wandering round the silent house, as though it
+feared to wake the sleepers and yet must needs call forth sleep from
+her purple cave.  Veil after veil of thin dusky gauze is lifted, and by
+degrees the forms and colours of things are restored to them, and we
+watch the dawn remaking the world in its antique pattern.  The wan
+mirrors get back their mimic life.  The flameless tapers stand where we
+had left them, and beside them lies the half-cut book that we had been
+studying, or the wired flower that we had worn at the ball, or the
+letter that we had been afraid to read, or that we had read too often.
+Nothing seems to us changed.  Out of the unreal shadows of the night
+comes back the real life that we had known.  We have to resume it where
+we had left off, and there steals over us a terrible sense of the
+necessity for the continuance of energy in the same wearisome round of
+stereotyped habits, or a wild longing, it may be, that our eyelids
+might open some morning upon a world that had been refashioned anew in
+the darkness for our pleasure, a world in which things would have fresh
+shapes and colours, and be changed, or have other secrets, a world in
+which the past would have little or no place, or survive, at any rate,
+in no conscious form of obligation or regret, the remembrance even of
+joy having its bitterness and the memories of pleasure their pain.
+
+It was the creation of such worlds as these that seemed to Dorian Gray
+to be the true object, or amongst the true objects, of life; and in his
+search for sensations that would be at once new and delightful, and
+possess that element of strangeness that is so essential to romance, he
+would often adopt certain modes of thought that he knew to be really
+alien to his nature, abandon himself to their subtle influences, and
+then, having, as it were, caught their colour and satisfied his
+intellectual curiosity, leave them with that curious indifference that
+is not incompatible with a real ardour of temperament, and that,
+indeed, according to certain modern psychologists, is often a condition
+of it.
+
+It was rumoured of him once that he was about to join the Roman
+Catholic communion, and certainly the Roman ritual had always a great
+attraction for him.  The daily sacrifice, more awful really than all
+the sacrifices of the antique world, stirred him as much by its superb
+rejection of the evidence of the senses as by the primitive simplicity
+of its elements and the eternal pathos of the human tragedy that it
+sought to symbolize.  He loved to kneel down on the cold marble
+pavement and watch the priest, in his stiff flowered dalmatic, slowly
+and with white hands moving aside the veil of the tabernacle, or
+raising aloft the jewelled, lantern-shaped monstrance with that pallid
+wafer that at times, one would fain think, is indeed the "_panis
+caelestis_," the bread of angels, or, robed in the garments of the
+Passion of Christ, breaking the Host into the chalice and smiting his
+breast for his sins.  The fuming censers that the grave boys, in their
+lace and scarlet, tossed into the air like great gilt flowers had their
+subtle fascination for him.  As he passed out, he used to look with
+wonder at the black confessionals and long to sit in the dim shadow of
+one of them and listen to men and women whispering through the worn
+grating the true story of their lives.
+
+But he never fell into the error of arresting his intellectual
+development by any formal acceptance of creed or system, or of
+mistaking, for a house in which to live, an inn that is but suitable
+for the sojourn of a night, or for a few hours of a night in which
+there are no stars and the moon is in travail.  Mysticism, with its
+marvellous power of making common things strange to us, and the subtle
+antinomianism that always seems to accompany it, moved him for a
+season; and for a season he inclined to the materialistic doctrines of
+the _Darwinismus_ movement in Germany, and found a curious pleasure in
+tracing the thoughts and passions of men to some pearly cell in the
+brain, or some white nerve in the body, delighting in the conception of
+the absolute dependence of the spirit on certain physical conditions,
+morbid or healthy, normal or diseased.  Yet, as has been said of him
+before, no theory of life seemed to him to be of any importance
+compared with life itself.  He felt keenly conscious of how barren all
+intellectual speculation is when separated from action and experiment.
+He knew that the senses, no less than the soul, have their spiritual
+mysteries to reveal.
+
+And so he would now study perfumes and the secrets of their
+manufacture, distilling heavily scented oils and burning odorous gums
+from the East.  He saw that there was no mood of the mind that had not
+its counterpart in the sensuous life, and set himself to discover their
+true relations, wondering what there was in frankincense that made one
+mystical, and in ambergris that stirred one's passions, and in violets
+that woke the memory of dead romances, and in musk that troubled the
+brain, and in champak that stained the imagination; and seeking often
+to elaborate a real psychology of perfumes, and to estimate the several
+influences of sweet-smelling roots and scented, pollen-laden flowers;
+of aromatic balms and of dark and fragrant woods; of spikenard, that
+sickens; of hovenia, that makes men mad; and of aloes, that are said to
+be able to expel melancholy from the soul.
+
+At another time he devoted himself entirely to music, and in a long
+latticed room, with a vermilion-and-gold ceiling and walls of
+olive-green lacquer, he used to give curious concerts in which mad
+gipsies tore wild music from little zithers, or grave, yellow-shawled
+Tunisians plucked at the strained strings of monstrous lutes, while
+grinning Negroes beat monotonously upon copper drums and, crouching
+upon scarlet mats, slim turbaned Indians blew through long pipes of
+reed or brass and charmed--or feigned to charm--great hooded snakes and
+horrible horned adders.  The harsh intervals and shrill discords of
+barbaric music stirred him at times when Schubert's grace, and Chopin's
+beautiful sorrows, and the mighty harmonies of Beethoven himself, fell
+unheeded on his ear.  He collected together from all parts of the world
+the strangest instruments that could be found, either in the tombs of
+dead nations or among the few savage tribes that have survived contact
+with Western civilizations, and loved to touch and try them.  He had
+the mysterious _juruparis_ of the Rio Negro Indians, that women are not
+allowed to look at and that even youths may not see till they have been
+subjected to fasting and scourging, and the earthen jars of the
+Peruvians that have the shrill cries of birds, and flutes of human
+bones such as Alfonso de Ovalle heard in Chile, and the sonorous green
+jaspers that are found near Cuzco and give forth a note of singular
+sweetness.  He had painted gourds filled with pebbles that rattled when
+they were shaken; the long _clarin_ of the Mexicans, into which the
+performer does not blow, but through which he inhales the air; the
+harsh _ture_ of the Amazon tribes, that is sounded by the sentinels who
+sit all day long in high trees, and can be heard, it is said, at a
+distance of three leagues; the _teponaztli_, that has two vibrating
+tongues of wood and is beaten with sticks that are smeared with an
+elastic gum obtained from the milky juice of plants; the _yotl_-bells of
+the Aztecs, that are hung in clusters like grapes; and a huge
+cylindrical drum, covered with the skins of great serpents, like the
+one that Bernal Diaz saw when he went with Cortes into the Mexican
+temple, and of whose doleful sound he has left us so vivid a
+description.  The fantastic character of these instruments fascinated
+him, and he felt a curious delight in the thought that art, like
+Nature, has her monsters, things of bestial shape and with hideous
+voices.  Yet, after some time, he wearied of them, and would sit in his
+box at the opera, either alone or with Lord Henry, listening in rapt
+pleasure to "Tannhauser" and seeing in the prelude to that great work
+of art a presentation of the tragedy of his own soul.
+
+On one occasion he took up the study of jewels, and appeared at a
+costume ball as Anne de Joyeuse, Admiral of France, in a dress covered
+with five hundred and sixty pearls.  This taste enthralled him for
+years, and, indeed, may be said never to have left him.  He would often
+spend a whole day settling and resettling in their cases the various
+stones that he had collected, such as the olive-green chrysoberyl that
+turns red by lamplight, the cymophane with its wirelike line of silver,
+the pistachio-coloured peridot, rose-pink and wine-yellow topazes,
+carbuncles of fiery scarlet with tremulous, four-rayed stars, flame-red
+cinnamon-stones, orange and violet spinels, and amethysts with their
+alternate layers of ruby and sapphire.  He loved the red gold of the
+sunstone, and the moonstone's pearly whiteness, and the broken rainbow
+of the milky opal.  He procured from Amsterdam three emeralds of
+extraordinary size and richness of colour, and had a turquoise _de la
+vieille roche_ that was the envy of all the connoisseurs.
+
+He discovered wonderful stories, also, about jewels.  In Alphonso's
+Clericalis Disciplina a serpent was mentioned with eyes of real
+jacinth, and in the romantic history of Alexander, the Conqueror of
+Emathia was said to have found in the vale of Jordan snakes "with
+collars of real emeralds growing on their backs." There was a gem in
+the brain of the dragon, Philostratus told us, and "by the exhibition
+of golden letters and a scarlet robe" the monster could be thrown into
+a magical sleep and slain.  According to the great alchemist, Pierre de
+Boniface, the diamond rendered a man invisible, and the agate of India
+made him eloquent.  The cornelian appeased anger, and the hyacinth
+provoked sleep, and the amethyst drove away the fumes of wine.  The
+garnet cast out demons, and the hydropicus deprived the moon of her
+colour.  The selenite waxed and waned with the moon, and the meloceus,
+that discovers thieves, could be affected only by the blood of kids.
+Leonardus Camillus had seen a white stone taken from the brain of a
+newly killed toad, that was a certain antidote against poison.  The
+bezoar, that was found in the heart of the Arabian deer, was a charm
+that could cure the plague.  In the nests of Arabian birds was the
+aspilates, that, according to Democritus, kept the wearer from any
+danger by fire.
+
+The King of Ceilan rode through his city with a large ruby in his hand,
+as the ceremony of his coronation.  The gates of the palace of John the
+Priest were "made of sardius, with the horn of the horned snake
+inwrought, so that no man might bring poison within." Over the gable
+were "two golden apples, in which were two carbuncles," so that the
+gold might shine by day and the carbuncles by night.  In Lodge's
+strange romance 'A Margarite of America', it was stated that in the
+chamber of the queen one could behold "all the chaste ladies of the
+world, inchased out of silver, looking through fair mirrours of
+chrysolites, carbuncles, sapphires, and greene emeraults." Marco Polo
+had seen the inhabitants of Zipangu place rose-coloured pearls in the
+mouths of the dead.  A sea-monster had been enamoured of the pearl that
+the diver brought to King Perozes, and had slain the thief, and mourned
+for seven moons over its loss.  When the Huns lured the king into the
+great pit, he flung it away--Procopius tells the story--nor was it ever
+found again, though the Emperor Anastasius offered five hundred-weight
+of gold pieces for it.  The King of Malabar had shown to a certain
+Venetian a rosary of three hundred and four pearls, one for every god
+that he worshipped.
+
+When the Duke de Valentinois, son of Alexander VI, visited Louis XII of
+France, his horse was loaded with gold leaves, according to Brantome,
+and his cap had double rows of rubies that threw out a great light.
+Charles of England had ridden in stirrups hung with four hundred and
+twenty-one diamonds.  Richard II had a coat, valued at thirty thousand
+marks, which was covered with balas rubies.  Hall described Henry VIII,
+on his way to the Tower previous to his coronation, as wearing "a
+jacket of raised gold, the placard embroidered with diamonds and other
+rich stones, and a great bauderike about his neck of large balasses."
+The favourites of James I wore ear-rings of emeralds set in gold
+filigrane.  Edward II gave to Piers Gaveston a suit of red-gold armour
+studded with jacinths, a collar of gold roses set with
+turquoise-stones, and a skull-cap _parseme_ with pearls.  Henry II wore
+jewelled gloves reaching to the elbow, and had a hawk-glove sewn with
+twelve rubies and fifty-two great orients.  The ducal hat of Charles
+the Rash, the last Duke of Burgundy of his race, was hung with
+pear-shaped pearls and studded with sapphires.
+
+How exquisite life had once been!  How gorgeous in its pomp and
+decoration!  Even to read of the luxury of the dead was wonderful.
+
+Then he turned his attention to embroideries and to the tapestries that
+performed the office of frescoes in the chill rooms of the northern
+nations of Europe.  As he investigated the subject--and he always had
+an extraordinary faculty of becoming absolutely absorbed for the moment
+in whatever he took up--he was almost saddened by the reflection of the
+ruin that time brought on beautiful and wonderful things.  He, at any
+rate, had escaped that.  Summer followed summer, and the yellow
+jonquils bloomed and died many times, and nights of horror repeated the
+story of their shame, but he was unchanged.  No winter marred his face
+or stained his flowerlike bloom.  How different it was with material
+things!  Where had they passed to?  Where was the great crocus-coloured
+robe, on which the gods fought against the giants, that had been worked
+by brown girls for the pleasure of Athena?  Where the huge velarium
+that Nero had stretched across the Colosseum at Rome, that Titan sail
+of purple on which was represented the starry sky, and Apollo driving a
+chariot drawn by white, gilt-reined steeds?  He longed to see the
+curious table-napkins wrought for the Priest of the Sun, on which were
+displayed all the dainties and viands that could be wanted for a feast;
+the mortuary cloth of King Chilperic, with its three hundred golden
+bees; the fantastic robes that excited the indignation of the Bishop of
+Pontus and were figured with "lions, panthers, bears, dogs, forests,
+rocks, hunters--all, in fact, that a painter can copy from nature"; and
+the coat that Charles of Orleans once wore, on the sleeves of which
+were embroidered the verses of a song beginning "_Madame, je suis tout
+joyeux_," the musical accompaniment of the words being wrought in gold
+thread, and each note, of square shape in those days, formed with four
+pearls.  He read of the room that was prepared at the palace at Rheims
+for the use of Queen Joan of Burgundy and was decorated with "thirteen
+hundred and twenty-one parrots, made in broidery, and blazoned with the
+king's arms, and five hundred and sixty-one butterflies, whose wings
+were similarly ornamented with the arms of the queen, the whole worked
+in gold."  Catherine de Medicis had a mourning-bed made for her of
+black velvet powdered with crescents and suns.  Its curtains were of
+damask, with leafy wreaths and garlands, figured upon a gold and silver
+ground, and fringed along the edges with broideries of pearls, and it
+stood in a room hung with rows of the queen's devices in cut black
+velvet upon cloth of silver.  Louis XIV had gold embroidered caryatides
+fifteen feet high in his apartment.  The state bed of Sobieski, King of
+Poland, was made of Smyrna gold brocade embroidered in turquoises with
+verses from the Koran.  Its supports were of silver gilt, beautifully
+chased, and profusely set with enamelled and jewelled medallions.  It
+had been taken from the Turkish camp before Vienna, and the standard of
+Mohammed had stood beneath the tremulous gilt of its canopy.
+
+And so, for a whole year, he sought to accumulate the most exquisite
+specimens that he could find of textile and embroidered work, getting
+the dainty Delhi muslins, finely wrought with gold-thread palmates and
+stitched over with iridescent beetles' wings; the Dacca gauzes, that
+from their transparency are known in the East as "woven air," and
+"running water," and "evening dew"; strange figured cloths from Java;
+elaborate yellow Chinese hangings; books bound in tawny satins or fair
+blue silks and wrought with _fleurs-de-lis_, birds and images; veils of
+_lacis_ worked in Hungary point; Sicilian brocades and stiff Spanish
+velvets; Georgian work, with its gilt coins, and Japanese _Foukousas_,
+with their green-toned golds and their marvellously plumaged birds.
+
+He had a special passion, also, for ecclesiastical vestments, as indeed
+he had for everything connected with the service of the Church.  In the
+long cedar chests that lined the west gallery of his house, he had
+stored away many rare and beautiful specimens of what is really the
+raiment of the Bride of Christ, who must wear purple and jewels and
+fine linen that she may hide the pallid macerated body that is worn by
+the suffering that she seeks for and wounded by self-inflicted pain.
+He possessed a gorgeous cope of crimson silk and gold-thread damask,
+figured with a repeating pattern of golden pomegranates set in
+six-petalled formal blossoms, beyond which on either side was the
+pine-apple device wrought in seed-pearls. The orphreys were divided
+into panels representing scenes from the life of the Virgin, and the
+coronation of the Virgin was figured in coloured silks upon the hood.
+This was Italian work of the fifteenth century.  Another cope was of
+green velvet, embroidered with heart-shaped groups of acanthus-leaves,
+from which spread long-stemmed white blossoms, the details of which
+were picked out with silver thread and coloured crystals.  The morse
+bore a seraph's head in gold-thread raised work.  The orphreys were
+woven in a diaper of red and gold silk, and were starred with
+medallions of many saints and martyrs, among whom was St. Sebastian.
+He had chasubles, also, of amber-coloured silk, and blue silk and gold
+brocade, and yellow silk damask and cloth of gold, figured with
+representations of the Passion and Crucifixion of Christ, and
+embroidered with lions and peacocks and other emblems; dalmatics of
+white satin and pink silk damask, decorated with tulips and dolphins
+and _fleurs-de-lis_; altar frontals of crimson velvet and blue linen; and
+many corporals, chalice-veils, and sudaria.  In the mystic offices to
+which such things were put, there was something that quickened his
+imagination.
+
+For these treasures, and everything that he collected in his lovely
+house, were to be to him means of forgetfulness, modes by which he
+could escape, for a season, from the fear that seemed to him at times
+to be almost too great to be borne.  Upon the walls of the lonely
+locked room where he had spent so much of his boyhood, he had hung with
+his own hands the terrible portrait whose changing features showed him
+the real degradation of his life, and in front of it had draped the
+purple-and-gold pall as a curtain.  For weeks he would not go there,
+would forget the hideous painted thing, and get back his light heart,
+his wonderful joyousness, his passionate absorption in mere existence.
+Then, suddenly, some night he would creep out of the house, go down to
+dreadful places near Blue Gate Fields, and stay there, day after day,
+until he was driven away.  On his return he would sit in front of the
+picture, sometimes loathing it and himself, but filled, at other
+times, with that pride of individualism that is half the
+fascination of sin, and smiling with secret pleasure at the misshapen
+shadow that had to bear the burden that should have been his own.
+
+After a few years he could not endure to be long out of England, and
+gave up the villa that he had shared at Trouville with Lord Henry, as
+well as the little white walled-in house at Algiers where they had more
+than once spent the winter.  He hated to be separated from the picture
+that was such a part of his life, and was also afraid that during his
+absence some one might gain access to the room, in spite of the
+elaborate bars that he had caused to be placed upon the door.
+
+He was quite conscious that this would tell them nothing.  It was true
+that the portrait still preserved, under all the foulness and ugliness
+of the face, its marked likeness to himself; but what could they learn
+from that?  He would laugh at any one who tried to taunt him.  He had
+not painted it.  What was it to him how vile and full of shame it
+looked?  Even if he told them, would they believe it?
+
+Yet he was afraid.  Sometimes when he was down at his great house in
+Nottinghamshire, entertaining the fashionable young men of his own rank
+who were his chief companions, and astounding the county by the wanton
+luxury and gorgeous splendour of his mode of life, he would suddenly
+leave his guests and rush back to town to see that the door had not
+been tampered with and that the picture was still there.  What if it
+should be stolen?  The mere thought made him cold with horror.  Surely
+the world would know his secret then.  Perhaps the world already
+suspected it.
+
+For, while he fascinated many, there were not a few who distrusted him.
+He was very nearly blackballed at a West End club of which his birth
+and social position fully entitled him to become a member, and it was
+said that on one occasion, when he was brought by a friend into the
+smoking-room of the Churchill, the Duke of Berwick and another
+gentleman got up in a marked manner and went out.  Curious stories
+became current about him after he had passed his twenty-fifth year.  It
+was rumoured that he had been seen brawling with foreign sailors in a
+low den in the distant parts of Whitechapel, and that he consorted with
+thieves and coiners and knew the mysteries of their trade.  His
+extraordinary absences became notorious, and, when he used to reappear
+again in society, men would whisper to each other in corners, or pass
+him with a sneer, or look at him with cold searching eyes, as though
+they were determined to discover his secret.
+
+Of such insolences and attempted slights he, of course, took no notice,
+and in the opinion of most people his frank debonair manner, his
+charming boyish smile, and the infinite grace of that wonderful youth
+that seemed never to leave him, were in themselves a sufficient answer
+to the calumnies, for so they termed them, that were circulated about
+him.  It was remarked, however, that some of those who had been most
+intimate with him appeared, after a time, to shun him.  Women who had
+wildly adored him, and for his sake had braved all social censure and
+set convention at defiance, were seen to grow pallid with shame or
+horror if Dorian Gray entered the room.
+
+Yet these whispered scandals only increased in the eyes of many his
+strange and dangerous charm.  His great wealth was a certain element of
+security.  Society--civilized society, at least--is never very ready to
+believe anything to the detriment of those who are both rich and
+fascinating.  It feels instinctively that manners are of more
+importance than morals, and, in its opinion, the highest respectability
+is of much less value than the possession of a good _chef_.  And, after
+all, it is a very poor consolation to be told that the man who has
+given one a bad dinner, or poor wine, is irreproachable in his private
+life.  Even the cardinal virtues cannot atone for half-cold _entrees_, as
+Lord Henry remarked once, in a discussion on the subject, and there is
+possibly a good deal to be said for his view.  For the canons of good
+society are, or should be, the same as the canons of art.  Form is
+absolutely essential to it.  It should have the dignity of a ceremony,
+as well as its unreality, and should combine the insincere character of
+a romantic play with the wit and beauty that make such plays delightful
+to us.  Is insincerity such a terrible thing?  I think not.  It is
+merely a method by which we can multiply our personalities.
+
+Such, at any rate, was Dorian Gray's opinion.  He used to wonder at the
+shallow psychology of those who conceive the ego in man as a thing
+simple, permanent, reliable, and of one essence.  To him, man was a
+being with myriad lives and myriad sensations, a complex multiform
+creature that bore within itself strange legacies of thought and
+passion, and whose very flesh was tainted with the monstrous maladies
+of the dead.  He loved to stroll through the gaunt cold picture-gallery
+of his country house and look at the various portraits of those whose
+blood flowed in his veins.  Here was Philip Herbert, described by
+Francis Osborne, in his Memoires on the Reigns of Queen Elizabeth and
+King James, as one who was "caressed by the Court for his handsome
+face, which kept him not long company."  Was it young Herbert's life
+that he sometimes led?  Had some strange poisonous germ crept from body
+to body till it had reached his own?  Was it some dim sense of that
+ruined grace that had made him so suddenly, and almost without cause,
+give utterance, in Basil Hallward's studio, to the mad prayer that had
+so changed his life?  Here, in gold-embroidered red doublet, jewelled
+surcoat, and gilt-edged ruff and wristbands, stood Sir Anthony Sherard,
+with his silver-and-black armour piled at his feet.  What had this
+man's legacy been?  Had the lover of Giovanna of Naples bequeathed him
+some inheritance of sin and shame?  Were his own actions merely the
+dreams that the dead man had not dared to realize?  Here, from the
+fading canvas, smiled Lady Elizabeth Devereux, in her gauze hood, pearl
+stomacher, and pink slashed sleeves.  A flower was in her right hand,
+and her left clasped an enamelled collar of white and damask roses.  On
+a table by her side lay a mandolin and an apple.  There were large
+green rosettes upon her little pointed shoes.  He knew her life, and
+the strange stories that were told about her lovers.  Had he something
+of her temperament in him?  These oval, heavy-lidded eyes seemed to
+look curiously at him.  What of George Willoughby, with his powdered
+hair and fantastic patches?  How evil he looked!  The face was
+saturnine and swarthy, and the sensual lips seemed to be twisted with
+disdain.  Delicate lace ruffles fell over the lean yellow hands that
+were so overladen with rings.  He had been a macaroni of the eighteenth
+century, and the friend, in his youth, of Lord Ferrars.  What of the
+second Lord Beckenham, the companion of the Prince Regent in his
+wildest days, and one of the witnesses at the secret marriage with Mrs.
+Fitzherbert?  How proud and handsome he was, with his chestnut curls
+and insolent pose!  What passions had he bequeathed?  The world had
+looked upon him as infamous.  He had led the orgies at Carlton House.
+The star of the Garter glittered upon his breast.  Beside him hung the
+portrait of his wife, a pallid, thin-lipped woman in black.  Her blood,
+also, stirred within him.  How curious it all seemed!  And his mother
+with her Lady Hamilton face and her moist, wine-dashed lips--he knew
+what he had got from her.  He had got from her his beauty, and his
+passion for the beauty of others.  She laughed at him in her loose
+Bacchante dress.  There were vine leaves in her hair.  The purple
+spilled from the cup she was holding.  The carnations of the painting
+had withered, but the eyes were still wonderful in their depth and
+brilliancy of colour.  They seemed to follow him wherever he went.
+
+Yet one had ancestors in literature as well as in one's own race,
+nearer perhaps in type and temperament, many of them, and certainly
+with an influence of which one was more absolutely conscious.  There
+were times when it appeared to Dorian Gray that the whole of history
+was merely the record of his own life, not as he had lived it in act
+and circumstance, but as his imagination had created it for him, as it
+had been in his brain and in his passions.  He felt that he had known
+them all, those strange terrible figures that had passed across the
+stage of the world and made sin so marvellous and evil so full of
+subtlety.  It seemed to him that in some mysterious way their lives had
+been his own.
+
+The hero of the wonderful novel that had so influenced his life had
+himself known this curious fancy.  In the seventh chapter he tells how,
+crowned with laurel, lest lightning might strike him, he had sat, as
+Tiberius, in a garden at Capri, reading the shameful books of
+Elephantis, while dwarfs and peacocks strutted round him and the
+flute-player mocked the swinger of the censer; and, as Caligula, had
+caroused with the green-shirted jockeys in their stables and supped in
+an ivory manger with a jewel-frontleted horse; and, as Domitian, had
+wandered through a corridor lined with marble mirrors, looking round
+with haggard eyes for the reflection of the dagger that was to end his
+days, and sick with that ennui, that terrible _taedium vitae_, that comes
+on those to whom life denies nothing; and had peered through a clear
+emerald at the red shambles of the circus and then, in a litter of
+pearl and purple drawn by silver-shod mules, been carried through the
+Street of Pomegranates to a House of Gold and heard men cry on Nero
+Caesar as he passed by; and, as Elagabalus, had painted his face with
+colours, and plied the distaff among the women, and brought the Moon
+from Carthage and given her in mystic marriage to the Sun.
+
+Over and over again Dorian used to read this fantastic chapter, and the
+two chapters immediately following, in which, as in some curious
+tapestries or cunningly wrought enamels, were pictured the awful and
+beautiful forms of those whom vice and blood and weariness had made
+monstrous or mad:  Filippo, Duke of Milan, who slew his wife and
+painted her lips with a scarlet poison that her lover might suck death
+from the dead thing he fondled; Pietro Barbi, the Venetian, known as
+Paul the Second, who sought in his vanity to assume the title of
+Formosus, and whose tiara, valued at two hundred thousand florins, was
+bought at the price of a terrible sin; Gian Maria Visconti, who used
+hounds to chase living men and whose murdered body was covered with
+roses by a harlot who had loved him; the Borgia on his white horse,
+with Fratricide riding beside him and his mantle stained with the blood
+of Perotto; Pietro Riario, the young Cardinal Archbishop of Florence,
+child and minion of Sixtus IV, whose beauty was equalled only by his
+debauchery, and who received Leonora of Aragon in a pavilion of white
+and crimson silk, filled with nymphs and centaurs, and gilded a boy
+that he might serve at the feast as Ganymede or Hylas; Ezzelin, whose
+melancholy could be cured only by the spectacle of death, and who had a
+passion for red blood, as other men have for red wine--the son of the
+Fiend, as was reported, and one who had cheated his father at dice when
+gambling with him for his own soul; Giambattista Cibo, who in mockery
+took the name of Innocent and into whose torpid veins the blood of
+three lads was infused by a Jewish doctor; Sigismondo Malatesta, the
+lover of Isotta and the lord of Rimini, whose effigy was burned at Rome
+as the enemy of God and man, who strangled Polyssena with a napkin, and
+gave poison to Ginevra d'Este in a cup of emerald, and in honour of a
+shameful passion built a pagan church for Christian worship; Charles
+VI, who had so wildly adored his brother's wife that a leper had warned
+him of the insanity that was coming on him, and who, when his brain had
+sickened and grown strange, could only be soothed by Saracen cards
+painted with the images of love and death and madness; and, in his
+trimmed jerkin and jewelled cap and acanthuslike curls, Grifonetto
+Baglioni, who slew Astorre with his bride, and Simonetto with his page,
+and whose comeliness was such that, as he lay dying in the yellow
+piazza of Perugia, those who had hated him could not choose but weep,
+and Atalanta, who had cursed him, blessed him.
+
+There was a horrible fascination in them all.  He saw them at night,
+and they troubled his imagination in the day.  The Renaissance knew of
+strange manners of poisoning--poisoning by a helmet and a lighted
+torch, by an embroidered glove and a jewelled fan, by a gilded pomander
+and by an amber chain.  Dorian Gray had been poisoned by a book.  There
+were moments when he looked on evil simply as a mode through which he
+could realize his conception of the beautiful.
+
+
+
+CHAPTER 12
+
+It was on the ninth of November, the eve of his own thirty-eighth
+birthday, as he often remembered afterwards.
+
+He was walking home about eleven o'clock from Lord Henry's, where he
+had been dining, and was wrapped in heavy furs, as the night was cold
+and foggy.  At the corner of Grosvenor Square and South Audley Street,
+a man passed him in the mist, walking very fast and with the collar of
+his grey ulster turned up.  He had a bag in his hand.  Dorian
+recognized him.  It was Basil Hallward.  A strange sense of fear, for
+which he could not account, came over him.  He made no sign of
+recognition and went on quickly in the direction of his own house.
+
+But Hallward had seen him.  Dorian heard him first stopping on the
+pavement and then hurrying after him.  In a few moments, his hand was
+on his arm.
+
+"Dorian!  What an extraordinary piece of luck!  I have been waiting for
+you in your library ever since nine o'clock. Finally I took pity on
+your tired servant and told him to go to bed, as he let me out.  I am
+off to Paris by the midnight train, and I particularly wanted to see
+you before I left.  I thought it was you, or rather your fur coat, as
+you passed me.  But I wasn't quite sure.  Didn't you recognize me?"
+
+"In this fog, my dear Basil?  Why, I can't even recognize Grosvenor
+Square.  I believe my house is somewhere about here, but I don't feel
+at all certain about it.  I am sorry you are going away, as I have not
+seen you for ages.  But I suppose you will be back soon?"
+
+"No:  I am going to be out of England for six months.  I intend to take
+a studio in Paris and shut myself up till I have finished a great
+picture I have in my head.  However, it wasn't about myself I wanted to
+talk.  Here we are at your door.  Let me come in for a moment.  I have
+something to say to you."
+
+"I shall be charmed.  But won't you miss your train?" said Dorian Gray
+languidly as he passed up the steps and opened the door with his
+latch-key.
+
+The lamplight struggled out through the fog, and Hallward looked at his
+watch.  "I have heaps of time," he answered.  "The train doesn't go
+till twelve-fifteen, and it is only just eleven.  In fact, I was on my
+way to the club to look for you, when I met you.  You see, I shan't
+have any delay about luggage, as I have sent on my heavy things.  All I
+have with me is in this bag, and I can easily get to Victoria in twenty
+minutes."
+
+Dorian looked at him and smiled.  "What a way for a fashionable painter
+to travel!  A Gladstone bag and an ulster!  Come in, or the fog will
+get into the house.  And mind you don't talk about anything serious.
+Nothing is serious nowadays.  At least nothing should be."
+
+Hallward shook his head, as he entered, and followed Dorian into the
+library.  There was a bright wood fire blazing in the large open
+hearth.  The lamps were lit, and an open Dutch silver spirit-case
+stood, with some siphons of soda-water and large cut-glass tumblers, on
+a little marqueterie table.
+
+"You see your servant made me quite at home, Dorian.  He gave me
+everything I wanted, including your best gold-tipped cigarettes.  He is
+a most hospitable creature.  I like him much better than the Frenchman
+you used to have.  What has become of the Frenchman, by the bye?"
+
+Dorian shrugged his shoulders.  "I believe he married Lady Radley's
+maid, and has established her in Paris as an English dressmaker.
+Anglomania is very fashionable over there now, I hear.  It seems silly
+of the French, doesn't it?  But--do you know?--he was not at all a bad
+servant.  I never liked him, but I had nothing to complain about.  One
+often imagines things that are quite absurd.  He was really very
+devoted to me and seemed quite sorry when he went away.  Have another
+brandy-and-soda? Or would you like hock-and-seltzer? I always take
+hock-and-seltzer myself.  There is sure to be some in the next room."
+
+"Thanks, I won't have anything more," said the painter, taking his cap
+and coat off and throwing them on the bag that he had placed in the
+corner.  "And now, my dear fellow, I want to speak to you seriously.
+Don't frown like that.  You make it so much more difficult for me."
+
+"What is it all about?" cried Dorian in his petulant way, flinging
+himself down on the sofa.  "I hope it is not about myself.  I am tired
+of myself to-night. I should like to be somebody else."
+
+"It is about yourself," answered Hallward in his grave deep voice, "and
+I must say it to you.  I shall only keep you half an hour."
+
+Dorian sighed and lit a cigarette.  "Half an hour!" he murmured.
+
+"It is not much to ask of you, Dorian, and it is entirely for your own
+sake that I am speaking.  I think it right that you should know that
+the most dreadful things are being said against you in London."
+
+"I don't wish to know anything about them.  I love scandals about other
+people, but scandals about myself don't interest me.  They have not got
+the charm of novelty."
+
+"They must interest you, Dorian.  Every gentleman is interested in his
+good name.  You don't want people to talk of you as something vile and
+degraded.  Of course, you have your position, and your wealth, and all
+that kind of thing.  But position and wealth are not everything.  Mind
+you, I don't believe these rumours at all.  At least, I can't believe
+them when I see you.  Sin is a thing that writes itself across a man's
+face.  It cannot be concealed.  People talk sometimes of secret vices.
+There are no such things.  If a wretched man has a vice, it shows
+itself in the lines of his mouth, the droop of his eyelids, the
+moulding of his hands even.  Somebody--I won't mention his name, but
+you know him--came to me last year to have his portrait done.  I had
+never seen him before, and had never heard anything about him at the
+time, though I have heard a good deal since.  He offered an extravagant
+price.  I refused him.  There was something in the shape of his fingers
+that I hated.  I know now that I was quite right in what I fancied
+about him.  His life is dreadful.  But you, Dorian, with your pure,
+bright, innocent face, and your marvellous untroubled youth--I can't
+believe anything against you.  And yet I see you very seldom, and you
+never come down to the studio now, and when I am away from you, and I
+hear all these hideous things that people are whispering about you, I
+don't know what to say.  Why is it, Dorian, that a man like the Duke of
+Berwick leaves the room of a club when you enter it?  Why is it that so
+many gentlemen in London will neither go to your house or invite you to
+theirs?  You used to be a friend of Lord Staveley.  I met him at dinner
+last week.  Your name happened to come up in conversation, in
+connection with the miniatures you have lent to the exhibition at the
+Dudley.  Staveley curled his lip and said that you might have the most
+artistic tastes, but that you were a man whom no pure-minded girl
+should be allowed to know, and whom no chaste woman should sit in the
+same room with.  I reminded him that I was a friend of yours, and asked
+him what he meant.  He told me.  He told me right out before everybody.
+It was horrible!  Why is your friendship so fatal to young men?  There
+was that wretched boy in the Guards who committed suicide.  You were
+his great friend.  There was Sir Henry Ashton, who had to leave England
+with a tarnished name.  You and he were inseparable.  What about Adrian
+Singleton and his dreadful end?  What about Lord Kent's only son and
+his career?  I met his father yesterday in St. James's Street.  He
+seemed broken with shame and sorrow.  What about the young Duke of
+Perth?  What sort of life has he got now?  What gentleman would
+associate with him?"
+
+"Stop, Basil.  You are talking about things of which you know nothing,"
+said Dorian Gray, biting his lip, and with a note of infinite contempt
+in his voice.  "You ask me why Berwick leaves a room when I enter it.
+It is because I know everything about his life, not because he knows
+anything about mine.  With such blood as he has in his veins, how could
+his record be clean?  You ask me about Henry Ashton and young Perth.
+Did I teach the one his vices, and the other his debauchery?  If Kent's
+silly son takes his wife from the streets, what is that to me?  If
+Adrian Singleton writes his friend's name across a bill, am I his
+keeper?  I know how people chatter in England.  The middle classes air
+their moral prejudices over their gross dinner-tables, and whisper
+about what they call the profligacies of their betters in order to try
+and pretend that they are in smart society and on intimate terms with
+the people they slander.  In this country, it is enough for a man to
+have distinction and brains for every common tongue to wag against him.
+And what sort of lives do these people, who pose as being moral, lead
+themselves?  My dear fellow, you forget that we are in the native land
+of the hypocrite."
+
+"Dorian," cried Hallward, "that is not the question.  England is bad
+enough I know, and English society is all wrong.  That is the reason
+why I want you to be fine.  You have not been fine.  One has a right to
+judge of a man by the effect he has over his friends.  Yours seem to
+lose all sense of honour, of goodness, of purity.  You have filled them
+with a madness for pleasure.  They have gone down into the depths.  You
+led them there.  Yes:  you led them there, and yet you can smile, as
+you are smiling now.  And there is worse behind.  I know you and Harry
+are inseparable.  Surely for that reason, if for none other, you should
+not have made his sister's name a by-word."
+
+"Take care, Basil.  You go too far."
+
+"I must speak, and you must listen.  You shall listen.  When you met
+Lady Gwendolen, not a breath of scandal had ever touched her.  Is there
+a single decent woman in London now who would drive with her in the
+park?  Why, even her children are not allowed to live with her.  Then
+there are other stories--stories that you have been seen creeping at
+dawn out of dreadful houses and slinking in disguise into the foulest
+dens in London.  Are they true?  Can they be true?  When I first heard
+them, I laughed.  I hear them now, and they make me shudder.  What
+about your country-house and the life that is led there?  Dorian, you
+don't know what is said about you.  I won't tell you that I don't want
+to preach to you.  I remember Harry saying once that every man who
+turned himself into an amateur curate for the moment always began by
+saying that, and then proceeded to break his word.  I do want to preach
+to you.  I want you to lead such a life as will make the world respect
+you.  I want you to have a clean name and a fair record.  I want you to
+get rid of the dreadful people you associate with.  Don't shrug your
+shoulders like that.  Don't be so indifferent.  You have a wonderful
+influence.  Let it be for good, not for evil.  They say that you
+corrupt every one with whom you become intimate, and that it is quite
+sufficient for you to enter a house for shame of some kind to follow
+after.  I don't know whether it is so or not.  How should I know?  But
+it is said of you.  I am told things that it seems impossible to doubt.
+Lord Gloucester was one of my greatest friends at Oxford.  He showed me
+a letter that his wife had written to him when she was dying alone in
+her villa at Mentone.  Your name was implicated in the most terrible
+confession I ever read.  I told him that it was absurd--that I knew you
+thoroughly and that you were incapable of anything of the kind.  Know
+you?  I wonder do I know you?  Before I could answer that, I should
+have to see your soul."
+
+"To see my soul!" muttered Dorian Gray, starting up from the sofa and
+turning almost white from fear.
+
+"Yes," answered Hallward gravely, and with deep-toned sorrow in his
+voice, "to see your soul.  But only God can do that."
+
+A bitter laugh of mockery broke from the lips of the younger man.  "You
+shall see it yourself, to-night!" he cried, seizing a lamp from the
+table.  "Come:  it is your own handiwork.  Why shouldn't you look at
+it?  You can tell the world all about it afterwards, if you choose.
+Nobody would believe you.  If they did believe you, they would like me
+all the better for it.  I know the age better than you do, though you
+will prate about it so tediously.  Come, I tell you.  You have
+chattered enough about corruption.  Now you shall look on it face to
+face."
+
+There was the madness of pride in every word he uttered.  He stamped
+his foot upon the ground in his boyish insolent manner.  He felt a
+terrible joy at the thought that some one else was to share his secret,
+and that the man who had painted the portrait that was the origin of
+all his shame was to be burdened for the rest of his life with the
+hideous memory of what he had done.
+
+"Yes," he continued, coming closer to him and looking steadfastly into
+his stern eyes, "I shall show you my soul.  You shall see the thing
+that you fancy only God can see."
+
+Hallward started back.  "This is blasphemy, Dorian!" he cried.  "You
+must not say things like that.  They are horrible, and they don't mean
+anything."
+
+"You think so?"  He laughed again.
+
+"I know so.  As for what I said to you to-night, I said it for your
+good.  You know I have been always a stanch friend to you."
+
+"Don't touch me.  Finish what you have to say."
+
+A twisted flash of pain shot across the painter's face.  He paused for
+a moment, and a wild feeling of pity came over him.  After all, what
+right had he to pry into the life of Dorian Gray?  If he had done a
+tithe of what was rumoured about him, how much he must have suffered!
+Then he straightened himself up, and walked over to the fire-place, and
+stood there, looking at the burning logs with their frostlike ashes and
+their throbbing cores of flame.
+
+"I am waiting, Basil," said the young man in a hard clear voice.
+
+He turned round.  "What I have to say is this," he cried.  "You must
+give me some answer to these horrible charges that are made against
+you.  If you tell me that they are absolutely untrue from beginning to
+end, I shall believe you.  Deny them, Dorian, deny them!  Can't you see
+what I am going through?  My God! don't tell me that you are bad, and
+corrupt, and shameful."
+
+Dorian Gray smiled.  There was a curl of contempt in his lips.  "Come
+upstairs, Basil," he said quietly.  "I keep a diary of my life from day
+to day, and it never leaves the room in which it is written.  I shall
+show it to you if you come with me."
+
+"I shall come with you, Dorian, if you wish it.  I see I have missed my
+train.  That makes no matter.  I can go to-morrow. But don't ask me to
+read anything to-night. All I want is a plain answer to my question."
+
+"That shall be given to you upstairs.  I could not give it here.  You
+will not have to read long."
+
+
+
+CHAPTER 13
+
+He passed out of the room and began the ascent, Basil Hallward
+following close behind.  They walked softly, as men do instinctively at
+night.  The lamp cast fantastic shadows on the wall and staircase.  A
+rising wind made some of the windows rattle.
+
+When they reached the top landing, Dorian set the lamp down on the
+floor, and taking out the key, turned it in the lock.  "You insist on
+knowing, Basil?" he asked in a low voice.
+
+"Yes."
+
+"I am delighted," he answered, smiling.  Then he added, somewhat
+harshly, "You are the one man in the world who is entitled to know
+everything about me.  You have had more to do with my life than you
+think"; and, taking up the lamp, he opened the door and went in.  A
+cold current of air passed them, and the light shot up for a moment in
+a flame of murky orange.  He shuddered.  "Shut the door behind you," he
+whispered, as he placed the lamp on the table.
+
+Hallward glanced round him with a puzzled expression.  The room looked
+as if it had not been lived in for years.  A faded Flemish tapestry, a
+curtained picture, an old Italian _cassone_, and an almost empty
+book-case--that was all that it seemed to contain, besides a chair and
+a table.  As Dorian Gray was lighting a half-burned candle that was
+standing on the mantelshelf, he saw that the whole place was covered
+with dust and that the carpet was in holes.  A mouse ran scuffling
+behind the wainscoting.  There was a damp odour of mildew.
+
+"So you think that it is only God who sees the soul, Basil?  Draw that
+curtain back, and you will see mine."
+
+The voice that spoke was cold and cruel.  "You are mad, Dorian, or
+playing a part," muttered Hallward, frowning.
+
+"You won't? Then I must do it myself," said the young man, and he tore
+the curtain from its rod and flung it on the ground.
+
+An exclamation of horror broke from the painter's lips as he saw in the
+dim light the hideous face on the canvas grinning at him.  There was
+something in its expression that filled him with disgust and loathing.
+Good heavens! it was Dorian Gray's own face that he was looking at!
+The horror, whatever it was, had not yet entirely spoiled that
+marvellous beauty.  There was still some gold in the thinning hair and
+some scarlet on the sensual mouth.  The sodden eyes had kept something
+of the loveliness of their blue, the noble curves had not yet
+completely passed away from chiselled nostrils and from plastic throat.
+Yes, it was Dorian himself.  But who had done it?  He seemed to
+recognize his own brushwork, and the frame was his own design.  The
+idea was monstrous, yet he felt afraid.  He seized the lighted candle,
+and held it to the picture.  In the left-hand corner was his own name,
+traced in long letters of bright vermilion.
+
+It was some foul parody, some infamous ignoble satire.  He had never
+done that.  Still, it was his own picture.  He knew it, and he felt as
+if his blood had changed in a moment from fire to sluggish ice.  His
+own picture!  What did it mean?  Why had it altered?  He turned and
+looked at Dorian Gray with the eyes of a sick man.  His mouth twitched,
+and his parched tongue seemed unable to articulate.  He passed his hand
+across his forehead.  It was dank with clammy sweat.
+
+The young man was leaning against the mantelshelf, watching him with
+that strange expression that one sees on the faces of those who are
+absorbed in a play when some great artist is acting.  There was neither
+real sorrow in it nor real joy.  There was simply the passion of the
+spectator, with perhaps a flicker of triumph in his eyes.  He had taken
+the flower out of his coat, and was smelling it, or pretending to do so.
+
+"What does this mean?" cried Hallward, at last.  His own voice sounded
+shrill and curious in his ears.
+
+"Years ago, when I was a boy," said Dorian Gray, crushing the flower in
+his hand, "you met me, flattered me, and taught me to be vain of my
+good looks.  One day you introduced me to a friend of yours, who
+explained to me the wonder of youth, and you finished a portrait of me
+that revealed to me the wonder of beauty.  In a mad moment that, even
+now, I don't know whether I regret or not, I made a wish, perhaps you
+would call it a prayer...."
+
+"I remember it!  Oh, how well I remember it!  No! the thing is
+impossible.  The room is damp.  Mildew has got into the canvas.  The
+paints I used had some wretched mineral poison in them.  I tell you the
+thing is impossible."
+
+"Ah, what is impossible?" murmured the young man, going over to the
+window and leaning his forehead against the cold, mist-stained glass.
+
+"You told me you had destroyed it."
+
+"I was wrong.  It has destroyed me."
+
+"I don't believe it is my picture."
+
+"Can't you see your ideal in it?" said Dorian bitterly.
+
+"My ideal, as you call it..."
+
+"As you called it."
+
+"There was nothing evil in it, nothing shameful.  You were to me such
+an ideal as I shall never meet again.  This is the face of a satyr."
+
+"It is the face of my soul."
+
+"Christ! what a thing I must have worshipped!  It has the eyes of a
+devil."
+
+"Each of us has heaven and hell in him, Basil," cried Dorian with a
+wild gesture of despair.
+
+Hallward turned again to the portrait and gazed at it.  "My God!  If it
+is true," he exclaimed, "and this is what you have done with your life,
+why, you must be worse even than those who talk against you fancy you
+to be!" He held the light up again to the canvas and examined it.  The
+surface seemed to be quite undisturbed and as he had left it.  It was
+from within, apparently, that the foulness and horror had come.
+Through some strange quickening of inner life the leprosies of sin were
+slowly eating the thing away.  The rotting of a corpse in a watery
+grave was not so fearful.
+
+His hand shook, and the candle fell from its socket on the floor and
+lay there sputtering.  He placed his foot on it and put it out.  Then
+he flung himself into the rickety chair that was standing by the table
+and buried his face in his hands.
+
+"Good God, Dorian, what a lesson!  What an awful lesson!" There was no
+answer, but he could hear the young man sobbing at the window.  "Pray,
+Dorian, pray," he murmured.  "What is it that one was taught to say in
+one's boyhood?  'Lead us not into temptation.  Forgive us our sins.
+Wash away our iniquities.'  Let us say that together.  The prayer of
+your pride has been answered.  The prayer of your repentance will be
+answered also.  I worshipped you too much.  I am punished for it.  You
+worshipped yourself too much.  We are both punished."
+
+Dorian Gray turned slowly around and looked at him with tear-dimmed
+eyes.  "It is too late, Basil," he faltered.
+
+"It is never too late, Dorian.  Let us kneel down and try if we cannot
+remember a prayer.  Isn't there a verse somewhere, 'Though your sins be
+as scarlet, yet I will make them as white as snow'?"
+
+"Those words mean nothing to me now."
+
+"Hush!  Don't say that.  You have done enough evil in your life.  My
+God!  Don't you see that accursed thing leering at us?"
+
+Dorian Gray glanced at the picture, and suddenly an uncontrollable
+feeling of hatred for Basil Hallward came over him, as though it had
+been suggested to him by the image on the canvas, whispered into his
+ear by those grinning lips.  The mad passions of a hunted animal
+stirred within him, and he loathed the man who was seated at the table,
+more than in his whole life he had ever loathed anything.  He glanced
+wildly around.  Something glimmered on the top of the painted chest
+that faced him.  His eye fell on it.  He knew what it was.  It was a
+knife that he had brought up, some days before, to cut a piece of cord,
+and had forgotten to take away with him.  He moved slowly towards it,
+passing Hallward as he did so.  As soon as he got behind him, he seized
+it and turned round.  Hallward stirred in his chair as if he was going
+to rise.  He rushed at him and dug the knife into the great vein that
+is behind the ear, crushing the man's head down on the table and
+stabbing again and again.
+
+There was a stifled groan and the horrible sound of some one choking
+with blood.  Three times the outstretched arms shot up convulsively,
+waving grotesque, stiff-fingered hands in the air.  He stabbed him
+twice more, but the man did not move.  Something began to trickle on
+the floor.  He waited for a moment, still pressing the head down.  Then
+he threw the knife on the table, and listened.
+
+He could hear nothing, but the drip, drip on the threadbare carpet.  He
+opened the door and went out on the landing.  The house was absolutely
+quiet.  No one was about.  For a few seconds he stood bending over the
+balustrade and peering down into the black seething well of darkness.
+Then he took out the key and returned to the room, locking himself in
+as he did so.
+
+The thing was still seated in the chair, straining over the table with
+bowed head, and humped back, and long fantastic arms.  Had it not been
+for the red jagged tear in the neck and the clotted black pool that was
+slowly widening on the table, one would have said that the man was
+simply asleep.
+
+How quickly it had all been done!  He felt strangely calm, and walking
+over to the window, opened it and stepped out on the balcony.  The wind
+had blown the fog away, and the sky was like a monstrous peacock's
+tail, starred with myriads of golden eyes.  He looked down and saw the
+policeman going his rounds and flashing the long beam of his lantern on
+the doors of the silent houses.  The crimson spot of a prowling hansom
+gleamed at the corner and then vanished.  A woman in a fluttering shawl
+was creeping slowly by the railings, staggering as she went.  Now and
+then she stopped and peered back.  Once, she began to sing in a hoarse
+voice.  The policeman strolled over and said something to her.  She
+stumbled away, laughing.  A bitter blast swept across the square.  The
+gas-lamps flickered and became blue, and the leafless trees shook their
+black iron branches to and fro.  He shivered and went back, closing the
+window behind him.
+
+Having reached the door, he turned the key and opened it.  He did not
+even glance at the murdered man.  He felt that the secret of the whole
+thing was not to realize the situation.  The friend who had painted the
+fatal portrait to which all his misery had been due had gone out of his
+life.  That was enough.
+
+Then he remembered the lamp.  It was a rather curious one of Moorish
+workmanship, made of dull silver inlaid with arabesques of burnished
+steel, and studded with coarse turquoises.  Perhaps it might be missed
+by his servant, and questions would be asked.  He hesitated for a
+moment, then he turned back and took it from the table.  He could not
+help seeing the dead thing.  How still it was!  How horribly white the
+long hands looked!  It was like a dreadful wax image.
+
+Having locked the door behind him, he crept quietly downstairs.  The
+woodwork creaked and seemed to cry out as if in pain.  He stopped
+several times and waited.  No:  everything was still.  It was merely
+the sound of his own footsteps.
+
+When he reached the library, he saw the bag and coat in the corner.
+They must be hidden away somewhere.  He unlocked a secret press that
+was in the wainscoting, a press in which he kept his own curious
+disguises, and put them into it.  He could easily burn them afterwards.
+Then he pulled out his watch.  It was twenty minutes to two.
+
+He sat down and began to think.  Every year--every month, almost--men
+were strangled in England for what he had done.  There had been a
+madness of murder in the air.  Some red star had come too close to the
+earth.... And yet, what evidence was there against him?  Basil Hallward
+had left the house at eleven.  No one had seen him come in again.  Most
+of the servants were at Selby Royal.  His valet had gone to bed....
+Paris!  Yes.  It was to Paris that Basil had gone, and by the midnight
+train, as he had intended.  With his curious reserved habits, it would
+be months before any suspicions would be roused.  Months!  Everything
+could be destroyed long before then.
+
+A sudden thought struck him.  He put on his fur coat and hat and went
+out into the hall.  There he paused, hearing the slow heavy tread of
+the policeman on the pavement outside and seeing the flash of the
+bull's-eye reflected in the window.  He waited and held his breath.
+
+After a few moments he drew back the latch and slipped out, shutting
+the door very gently behind him.  Then he began ringing the bell.  In
+about five minutes his valet appeared, half-dressed and looking very
+drowsy.
+
+"I am sorry to have had to wake you up, Francis," he said, stepping in;
+"but I had forgotten my latch-key. What time is it?"
+
+"Ten minutes past two, sir," answered the man, looking at the clock and
+blinking.
+
+"Ten minutes past two?  How horribly late!  You must wake me at nine
+to-morrow. I have some work to do."
+
+"All right, sir."
+
+"Did any one call this evening?"
+
+"Mr. Hallward, sir.  He stayed here till eleven, and then he went away
+to catch his train."
+
+"Oh!  I am sorry I didn't see him.  Did he leave any message?"
+
+"No, sir, except that he would write to you from Paris, if he did not
+find you at the club."
+
+"That will do, Francis.  Don't forget to call me at nine to-morrow."
+
+"No, sir."
+
+The man shambled down the passage in his slippers.
+
+Dorian Gray threw his hat and coat upon the table and passed into the
+library.  For a quarter of an hour he walked up and down the room,
+biting his lip and thinking.  Then he took down the Blue Book from one
+of the shelves and began to turn over the leaves.  "Alan Campbell, 152,
+Hertford Street, Mayfair."  Yes; that was the man he wanted.
+
+
+
+CHAPTER 14
+
+At nine o'clock the next morning his servant came in with a cup of
+chocolate on a tray and opened the shutters.  Dorian was sleeping quite
+peacefully, lying on his right side, with one hand underneath his
+cheek.  He looked like a boy who had been tired out with play, or study.
+
+The man had to touch him twice on the shoulder before he woke, and as
+he opened his eyes a faint smile passed across his lips, as though he
+had been lost in some delightful dream.  Yet he had not dreamed at all.
+His night had been untroubled by any images of pleasure or of pain.
+But youth smiles without any reason.  It is one of its chiefest charms.
+
+He turned round, and leaning upon his elbow, began to sip his
+chocolate.  The mellow November sun came streaming into the room.  The
+sky was bright, and there was a genial warmth in the air.  It was
+almost like a morning in May.
+
+Gradually the events of the preceding night crept with silent,
+blood-stained feet into his brain and reconstructed themselves there
+with terrible distinctness.  He winced at the memory of all that he had
+suffered, and for a moment the same curious feeling of loathing for
+Basil Hallward that had made him kill him as he sat in the chair came
+back to him, and he grew cold with passion.  The dead man was still
+sitting there, too, and in the sunlight now.  How horrible that was!
+Such hideous things were for the darkness, not for the day.
+
+He felt that if he brooded on what he had gone through he would sicken
+or grow mad.  There were sins whose fascination was more in the memory
+than in the doing of them, strange triumphs that gratified the pride
+more than the passions, and gave to the intellect a quickened sense of
+joy, greater than any joy they brought, or could ever bring, to the
+senses.  But this was not one of them.  It was a thing to be driven out
+of the mind, to be drugged with poppies, to be strangled lest it might
+strangle one itself.
+
+When the half-hour struck, he passed his hand across his forehead, and
+then got up hastily and dressed himself with even more than his usual
+care, giving a good deal of attention to the choice of his necktie and
+scarf-pin and changing his rings more than once.  He spent a long time
+also over breakfast, tasting the various dishes, talking to his valet
+about some new liveries that he was thinking of getting made for the
+servants at Selby, and going through his correspondence.  At some of
+the letters, he smiled.  Three of them bored him.  One he read several
+times over and then tore up with a slight look of annoyance in his
+face.  "That awful thing, a woman's memory!" as Lord Henry had once
+said.
+
+After he had drunk his cup of black coffee, he wiped his lips slowly
+with a napkin, motioned to his servant to wait, and going over to the
+table, sat down and wrote two letters.  One he put in his pocket, the
+other he handed to the valet.
+
+"Take this round to 152, Hertford Street, Francis, and if Mr. Campbell
+is out of town, get his address."
+
+As soon as he was alone, he lit a cigarette and began sketching upon a
+piece of paper, drawing first flowers and bits of architecture, and
+then human faces.  Suddenly he remarked that every face that he drew
+seemed to have a fantastic likeness to Basil Hallward.  He frowned, and
+getting up, went over to the book-case and took out a volume at hazard.
+He was determined that he would not think about what had happened until
+it became absolutely necessary that he should do so.
+
+When he had stretched himself on the sofa, he looked at the title-page
+of the book.  It was Gautier's Emaux et Camees, Charpentier's
+Japanese-paper edition, with the Jacquemart etching.  The binding was
+of citron-green leather, with a design of gilt trellis-work and dotted
+pomegranates.  It had been given to him by Adrian Singleton.  As he
+turned over the pages, his eye fell on the poem about the hand of
+Lacenaire, the cold yellow hand "_du supplice encore mal lavee_," with
+its downy red hairs and its "_doigts de faune_."  He glanced at his own
+white taper fingers, shuddering slightly in spite of himself, and
+passed on, till he came to those lovely stanzas upon Venice:
+
+     Sur une gamme chromatique,
+       Le sein de peries ruisselant,
+     La Venus de l'Adriatique
+       Sort de l'eau son corps rose et blanc.
+
+     Les domes, sur l'azur des ondes
+       Suivant la phrase au pur contour,
+     S'enflent comme des gorges rondes
+       Que souleve un soupir d'amour.
+
+     L'esquif aborde et me depose,
+       Jetant son amarre au pilier,
+     Devant une facade rose,
+       Sur le marbre d'un escalier.
+
+
+How exquisite they were!  As one read them, one seemed to be floating
+down the green water-ways of the pink and pearl city, seated in a black
+gondola with silver prow and trailing curtains.  The mere lines looked
+to him like those straight lines of turquoise-blue that follow one as
+one pushes out to the Lido.  The sudden flashes of colour reminded him
+of the gleam of the opal-and-iris-throated birds that flutter round the
+tall honeycombed Campanile, or stalk, with such stately grace, through
+the dim, dust-stained arcades.  Leaning back with half-closed eyes, he
+kept saying over and over to himself:
+
+     "Devant une facade rose,
+        Sur le marbre d'un escalier."
+
+The whole of Venice was in those two lines.  He remembered the autumn
+that he had passed there, and a wonderful love that had stirred him to
+mad delightful follies.  There was romance in every place.  But Venice,
+like Oxford, had kept the background for romance, and, to the true
+romantic, background was everything, or almost everything.  Basil had
+been with him part of the time, and had gone wild over Tintoret.  Poor
+Basil!  What a horrible way for a man to die!
+
+He sighed, and took up the volume again, and tried to forget.  He read
+of the swallows that fly in and out of the little _cafe_ at Smyrna where
+the Hadjis sit counting their amber beads and the turbaned merchants
+smoke their long tasselled pipes and talk gravely to each other; he
+read of the Obelisk in the Place de la Concorde that weeps tears of
+granite in its lonely sunless exile and longs to be back by the hot,
+lotus-covered Nile, where there are Sphinxes, and rose-red ibises, and
+white vultures with gilded claws, and crocodiles with small beryl eyes
+that crawl over the green steaming mud; he began to brood over those
+verses which, drawing music from kiss-stained marble, tell of that
+curious statue that Gautier compares to a contralto voice, the "_monstre
+charmant_" that couches in the porphyry-room of the Louvre.  But after a
+time the book fell from his hand.  He grew nervous, and a horrible fit
+of terror came over him.  What if Alan Campbell should be out of
+England?  Days would elapse before he could come back.  Perhaps he
+might refuse to come.  What could he do then?  Every moment was of
+vital importance.
+
+They had been great friends once, five years before--almost
+inseparable, indeed.  Then the intimacy had come suddenly to an end.
+When they met in society now, it was only Dorian Gray who smiled:  Alan
+Campbell never did.
+
+He was an extremely clever young man, though he had no real
+appreciation of the visible arts, and whatever little sense of the
+beauty of poetry he possessed he had gained entirely from Dorian.  His
+dominant intellectual passion was for science.  At Cambridge he had
+spent a great deal of his time working in the laboratory, and had taken
+a good class in the Natural Science Tripos of his year.  Indeed, he was
+still devoted to the study of chemistry, and had a laboratory of his
+own in which he used to shut himself up all day long, greatly to the
+annoyance of his mother, who had set her heart on his standing for
+Parliament and had a vague idea that a chemist was a person who made up
+prescriptions.  He was an excellent musician, however, as well, and
+played both the violin and the piano better than most amateurs.  In
+fact, it was music that had first brought him and Dorian Gray
+together--music and that indefinable attraction that Dorian seemed to
+be able to exercise whenever he wished--and, indeed, exercised often
+without being conscious of it.  They had met at Lady Berkshire's the
+night that Rubinstein played there, and after that used to be always
+seen together at the opera and wherever good music was going on.  For
+eighteen months their intimacy lasted.  Campbell was always either at
+Selby Royal or in Grosvenor Square.  To him, as to many others, Dorian
+Gray was the type of everything that is wonderful and fascinating in
+life.  Whether or not a quarrel had taken place between them no one
+ever knew.  But suddenly people remarked that they scarcely spoke when
+they met and that Campbell seemed always to go away early from any
+party at which Dorian Gray was present.  He had changed, too--was
+strangely melancholy at times, appeared almost to dislike hearing
+music, and would never himself play, giving as his excuse, when he was
+called upon, that he was so absorbed in science that he had no time
+left in which to practise.  And this was certainly true.  Every day he
+seemed to become more interested in biology, and his name appeared once
+or twice in some of the scientific reviews in connection with certain
+curious experiments.
+
+This was the man Dorian Gray was waiting for.  Every second he kept
+glancing at the clock.  As the minutes went by he became horribly
+agitated.  At last he got up and began to pace up and down the room,
+looking like a beautiful caged thing.  He took long stealthy strides.
+His hands were curiously cold.
+
+The suspense became unbearable.  Time seemed to him to be crawling with
+feet of lead, while he by monstrous winds was being swept towards the
+jagged edge of some black cleft of precipice.  He knew what was waiting
+for him there; saw it, indeed, and, shuddering, crushed with dank hands
+his burning lids as though he would have robbed the very brain of sight
+and driven the eyeballs back into their cave.  It was useless.  The
+brain had its own food on which it battened, and the imagination, made
+grotesque by terror, twisted and distorted as a living thing by pain,
+danced like some foul puppet on a stand and grinned through moving
+masks.  Then, suddenly, time stopped for him.  Yes:  that blind,
+slow-breathing thing crawled no more, and horrible thoughts, time being
+dead, raced nimbly on in front, and dragged a hideous future from its
+grave, and showed it to him.  He stared at it.  Its very horror made
+him stone.
+
+At last the door opened and his servant entered.  He turned glazed eyes
+upon him.
+
+"Mr. Campbell, sir," said the man.
+
+A sigh of relief broke from his parched lips, and the colour came back
+to his cheeks.
+
+"Ask him to come in at once, Francis."  He felt that he was himself
+again.  His mood of cowardice had passed away.
+
+The man bowed and retired.  In a few moments, Alan Campbell walked in,
+looking very stern and rather pale, his pallor being intensified by his
+coal-black hair and dark eyebrows.
+
+"Alan!  This is kind of you.  I thank you for coming."
+
+"I had intended never to enter your house again, Gray.  But you said it
+was a matter of life and death."  His voice was hard and cold.  He
+spoke with slow deliberation.  There was a look of contempt in the
+steady searching gaze that he turned on Dorian.  He kept his hands in
+the pockets of his Astrakhan coat, and seemed not to have noticed the
+gesture with which he had been greeted.
+
+"Yes:  it is a matter of life and death, Alan, and to more than one
+person.  Sit down."
+
+Campbell took a chair by the table, and Dorian sat opposite to him.
+The two men's eyes met.  In Dorian's there was infinite pity.  He knew
+that what he was going to do was dreadful.
+
+After a strained moment of silence, he leaned across and said, very
+quietly, but watching the effect of each word upon the face of him he
+had sent for, "Alan, in a locked room at the top of this house, a room
+to which nobody but myself has access, a dead man is seated at a table.
+He has been dead ten hours now.  Don't stir, and don't look at me like
+that.  Who the man is, why he died, how he died, are matters that do
+not concern you.  What you have to do is this--"
+
+"Stop, Gray.  I don't want to know anything further.  Whether what you
+have told me is true or not true doesn't concern me.  I entirely
+decline to be mixed up in your life.  Keep your horrible secrets to
+yourself.  They don't interest me any more."
+
+"Alan, they will have to interest you.  This one will have to interest
+you.  I am awfully sorry for you, Alan.  But I can't help myself.  You
+are the one man who is able to save me.  I am forced to bring you into
+the matter.  I have no option.  Alan, you are scientific.  You know
+about chemistry and things of that kind.  You have made experiments.
+What you have got to do is to destroy the thing that is upstairs--to
+destroy it so that not a vestige of it will be left.  Nobody saw this
+person come into the house.  Indeed, at the present moment he is
+supposed to be in Paris.  He will not be missed for months.  When he is
+missed, there must be no trace of him found here.  You, Alan, you must
+change him, and everything that belongs to him, into a handful of ashes
+that I may scatter in the air."
+
+"You are mad, Dorian."
+
+"Ah!  I was waiting for you to call me Dorian."
+
+"You are mad, I tell you--mad to imagine that I would raise a finger to
+help you, mad to make this monstrous confession.  I will have nothing
+to do with this matter, whatever it is.  Do you think I am going to
+peril my reputation for you?  What is it to me what devil's work you
+are up to?"
+
+"It was suicide, Alan."
+
+"I am glad of that.  But who drove him to it?  You, I should fancy."
+
+"Do you still refuse to do this for me?"
+
+"Of course I refuse.  I will have absolutely nothing to do with it.  I
+don't care what shame comes on you.  You deserve it all.  I should not
+be sorry to see you disgraced, publicly disgraced.  How dare you ask
+me, of all men in the world, to mix myself up in this horror?  I should
+have thought you knew more about people's characters.  Your friend Lord
+Henry Wotton can't have taught you much about psychology, whatever else
+he has taught you.  Nothing will induce me to stir a step to help you.
+You have come to the wrong man.  Go to some of your friends.  Don't
+come to me."
+
+"Alan, it was murder.  I killed him.  You don't know what he had made
+me suffer.  Whatever my life is, he had more to do with the making or
+the marring of it than poor Harry has had.  He may not have intended
+it, the result was the same."
+
+"Murder!  Good God, Dorian, is that what you have come to?  I shall not
+inform upon you.  It is not my business.  Besides, without my stirring
+in the matter, you are certain to be arrested.  Nobody ever commits a
+crime without doing something stupid.  But I will have nothing to do
+with it."
+
+"You must have something to do with it.  Wait, wait a moment; listen to
+me.  Only listen, Alan.  All I ask of you is to perform a certain
+scientific experiment.  You go to hospitals and dead-houses, and the
+horrors that you do there don't affect you.  If in some hideous
+dissecting-room or fetid laboratory you found this man lying on a
+leaden table with red gutters scooped out in it for the blood to flow
+through, you would simply look upon him as an admirable subject.  You
+would not turn a hair.  You would not believe that you were doing
+anything wrong.  On the contrary, you would probably feel that you were
+benefiting the human race, or increasing the sum of knowledge in the
+world, or gratifying intellectual curiosity, or something of that kind.
+What I want you to do is merely what you have often done before.
+Indeed, to destroy a body must be far less horrible than what you are
+accustomed to work at.  And, remember, it is the only piece of evidence
+against me.  If it is discovered, I am lost; and it is sure to be
+discovered unless you help me."
+
+"I have no desire to help you.  You forget that.  I am simply
+indifferent to the whole thing.  It has nothing to do with me."
+
+"Alan, I entreat you.  Think of the position I am in.  Just before you
+came I almost fainted with terror.  You may know terror yourself some
+day.  No! don't think of that.  Look at the matter purely from the
+scientific point of view.  You don't inquire where the dead things on
+which you experiment come from.  Don't inquire now.  I have told you
+too much as it is.  But I beg of you to do this.  We were friends once,
+Alan."
+
+"Don't speak about those days, Dorian--they are dead."
+
+"The dead linger sometimes.  The man upstairs will not go away.  He is
+sitting at the table with bowed head and outstretched arms.  Alan!
+Alan!  If you don't come to my assistance, I am ruined.  Why, they will
+hang me, Alan!  Don't you understand?  They will hang me for what I
+have done."
+
+"There is no good in prolonging this scene.  I absolutely refuse to do
+anything in the matter.  It is insane of you to ask me."
+
+"You refuse?"
+
+"Yes."
+
+"I entreat you, Alan."
+
+"It is useless."
+
+The same look of pity came into Dorian Gray's eyes.  Then he stretched
+out his hand, took a piece of paper, and wrote something on it.  He
+read it over twice, folded it carefully, and pushed it across the
+table.  Having done this, he got up and went over to the window.
+
+Campbell looked at him in surprise, and then took up the paper, and
+opened it.  As he read it, his face became ghastly pale and he fell
+back in his chair.  A horrible sense of sickness came over him.  He
+felt as if his heart was beating itself to death in some empty hollow.
+
+After two or three minutes of terrible silence, Dorian turned round and
+came and stood behind him, putting his hand upon his shoulder.
+
+"I am so sorry for you, Alan," he murmured, "but you leave me no
+alternative.  I have a letter written already.  Here it is.  You see
+the address.  If you don't help me, I must send it.  If you don't help
+me, I will send it.  You know what the result will be.  But you are
+going to help me.  It is impossible for you to refuse now.  I tried to
+spare you.  You will do me the justice to admit that.  You were stern,
+harsh, offensive.  You treated me as no man has ever dared to treat
+me--no living man, at any rate.  I bore it all.  Now it is for me to
+dictate terms."
+
+Campbell buried his face in his hands, and a shudder passed through him.
+
+"Yes, it is my turn to dictate terms, Alan.  You know what they are.
+The thing is quite simple.  Come, don't work yourself into this fever.
+The thing has to be done.  Face it, and do it."
+
+A groan broke from Campbell's lips and he shivered all over.  The
+ticking of the clock on the mantelpiece seemed to him to be dividing
+time into separate atoms of agony, each of which was too terrible to be
+borne.  He felt as if an iron ring was being slowly tightened round his
+forehead, as if the disgrace with which he was threatened had already
+come upon him.  The hand upon his shoulder weighed like a hand of lead.
+It was intolerable.  It seemed to crush him.
+
+"Come, Alan, you must decide at once."
+
+"I cannot do it," he said, mechanically, as though words could alter
+things.
+
+"You must.  You have no choice.  Don't delay."
+
+He hesitated a moment.  "Is there a fire in the room upstairs?"
+
+"Yes, there is a gas-fire with asbestos."
+
+"I shall have to go home and get some things from the laboratory."
+
+"No, Alan, you must not leave the house.  Write out on a sheet of
+notepaper what you want and my servant will take a cab and bring the
+things back to you."
+
+Campbell scrawled a few lines, blotted them, and addressed an envelope
+to his assistant.  Dorian took the note up and read it carefully.  Then
+he rang the bell and gave it to his valet, with orders to return as
+soon as possible and to bring the things with him.
+
+As the hall door shut, Campbell started nervously, and having got up
+from the chair, went over to the chimney-piece. He was shivering with a
+kind of ague.  For nearly twenty minutes, neither of the men spoke.  A
+fly buzzed noisily about the room, and the ticking of the clock was
+like the beat of a hammer.
+
+As the chime struck one, Campbell turned round, and looking at Dorian
+Gray, saw that his eyes were filled with tears.  There was something in
+the purity and refinement of that sad face that seemed to enrage him.
+"You are infamous, absolutely infamous!" he muttered.
+
+"Hush, Alan.  You have saved my life," said Dorian.
+
+"Your life?  Good heavens! what a life that is!  You have gone from
+corruption to corruption, and now you have culminated in crime.  In
+doing what I am going to do--what you force me to do--it is not of your
+life that I am thinking."
+
+"Ah, Alan," murmured Dorian with a sigh, "I wish you had a thousandth
+part of the pity for me that I have for you." He turned away as he
+spoke and stood looking out at the garden.  Campbell made no answer.
+
+After about ten minutes a knock came to the door, and the servant
+entered, carrying a large mahogany chest of chemicals, with a long coil
+of steel and platinum wire and two rather curiously shaped iron clamps.
+
+"Shall I leave the things here, sir?" he asked Campbell.
+
+"Yes," said Dorian.  "And I am afraid, Francis, that I have another
+errand for you.  What is the name of the man at Richmond who supplies
+Selby with orchids?"
+
+"Harden, sir."
+
+"Yes--Harden.  You must go down to Richmond at once, see Harden
+personally, and tell him to send twice as many orchids as I ordered,
+and to have as few white ones as possible.  In fact, I don't want any
+white ones.  It is a lovely day, Francis, and Richmond is a very pretty
+place--otherwise I wouldn't bother you about it."
+
+"No trouble, sir.  At what time shall I be back?"
+
+Dorian looked at Campbell.  "How long will your experiment take, Alan?"
+he said in a calm indifferent voice.  The presence of a third person in
+the room seemed to give him extraordinary courage.
+
+Campbell frowned and bit his lip.  "It will take about five hours," he
+answered.
+
+"It will be time enough, then, if you are back at half-past seven,
+Francis.  Or stay:  just leave my things out for dressing.  You can
+have the evening to yourself.  I am not dining at home, so I shall not
+want you."
+
+"Thank you, sir," said the man, leaving the room.
+
+"Now, Alan, there is not a moment to be lost.  How heavy this chest is!
+I'll take it for you.  You bring the other things."  He spoke rapidly
+and in an authoritative manner.  Campbell felt dominated by him.  They
+left the room together.
+
+When they reached the top landing, Dorian took out the key and turned
+it in the lock.  Then he stopped, and a troubled look came into his
+eyes.  He shuddered.  "I don't think I can go in, Alan," he murmured.
+
+"It is nothing to me.  I don't require you," said Campbell coldly.
+
+Dorian half opened the door.  As he did so, he saw the face of his
+portrait leering in the sunlight.  On the floor in front of it the torn
+curtain was lying.  He remembered that the night before he had
+forgotten, for the first time in his life, to hide the fatal canvas,
+and was about to rush forward, when he drew back with a shudder.
+
+What was that loathsome red dew that gleamed, wet and glistening, on
+one of the hands, as though the canvas had sweated blood?  How horrible
+it was!--more horrible, it seemed to him for the moment, than the
+silent thing that he knew was stretched across the table, the thing
+whose grotesque misshapen shadow on the spotted carpet showed him that
+it had not stirred, but was still there, as he had left it.
+
+He heaved a deep breath, opened the door a little wider, and with
+half-closed eyes and averted head, walked quickly in, determined that
+he would not look even once upon the dead man.  Then, stooping down and
+taking up the gold-and-purple hanging, he flung it right over the
+picture.
+
+There he stopped, feeling afraid to turn round, and his eyes fixed
+themselves on the intricacies of the pattern before him.  He heard
+Campbell bringing in the heavy chest, and the irons, and the other
+things that he had required for his dreadful work.  He began to wonder
+if he and Basil Hallward had ever met, and, if so, what they had
+thought of each other.
+
+"Leave me now," said a stern voice behind him.
+
+He turned and hurried out, just conscious that the dead man had been
+thrust back into the chair and that Campbell was gazing into a
+glistening yellow face.  As he was going downstairs, he heard the key
+being turned in the lock.
+
+It was long after seven when Campbell came back into the library.  He
+was pale, but absolutely calm.  "I have done what you asked me to do,"
+he muttered. "And now, good-bye. Let us never see each other again."
+
+"You have saved me from ruin, Alan.  I cannot forget that," said Dorian
+simply.
+
+As soon as Campbell had left, he went upstairs.  There was a horrible
+smell of nitric acid in the room.  But the thing that had been sitting
+at the table was gone.
+
+
+
+CHAPTER 15
+
+That evening, at eight-thirty, exquisitely dressed and wearing a large
+button-hole of Parma violets, Dorian Gray was ushered into Lady
+Narborough's drawing-room by bowing servants.  His forehead was
+throbbing with maddened nerves, and he felt wildly excited, but his
+manner as he bent over his hostess's hand was as easy and graceful as
+ever.  Perhaps one never seems so much at one's ease as when one has to
+play a part.  Certainly no one looking at Dorian Gray that night could
+have believed that he had passed through a tragedy as horrible as any
+tragedy of our age.  Those finely shaped fingers could never have
+clutched a knife for sin, nor those smiling lips have cried out on God
+and goodness.  He himself could not help wondering at the calm of his
+demeanour, and for a moment felt keenly the terrible pleasure of a
+double life.
+
+It was a small party, got up rather in a hurry by Lady Narborough, who
+was a very clever woman with what Lord Henry used to describe as the
+remains of really remarkable ugliness.  She had proved an excellent
+wife to one of our most tedious ambassadors, and having buried her
+husband properly in a marble mausoleum, which she had herself designed,
+and married off her daughters to some rich, rather elderly men, she
+devoted herself now to the pleasures of French fiction, French cookery,
+and French _esprit_ when she could get it.
+
+Dorian was one of her especial favourites, and she always told him that
+she was extremely glad she had not met him in early life.  "I know, my
+dear, I should have fallen madly in love with you," she used to say,
+"and thrown my bonnet right over the mills for your sake.  It is most
+fortunate that you were not thought of at the time.  As it was, our
+bonnets were so unbecoming, and the mills were so occupied in trying to
+raise the wind, that I never had even a flirtation with anybody.
+However, that was all Narborough's fault.  He was dreadfully
+short-sighted, and there is no pleasure in taking in a husband who
+never sees anything."
+
+Her guests this evening were rather tedious.  The fact was, as she
+explained to Dorian, behind a very shabby fan, one of her married
+daughters had come up quite suddenly to stay with her, and, to make
+matters worse, had actually brought her husband with her.  "I think it
+is most unkind of her, my dear," she whispered.  "Of course I go and
+stay with them every summer after I come from Homburg, but then an old
+woman like me must have fresh air sometimes, and besides, I really wake
+them up.  You don't know what an existence they lead down there.  It is
+pure unadulterated country life.  They get up early, because they have
+so much to do, and go to bed early, because they have so little to
+think about.  There has not been a scandal in the neighbourhood since
+the time of Queen Elizabeth, and consequently they all fall asleep
+after dinner.  You shan't sit next either of them.  You shall sit by me
+and amuse me."
+
+Dorian murmured a graceful compliment and looked round the room.  Yes:
+it was certainly a tedious party.  Two of the people he had never seen
+before, and the others consisted of Ernest Harrowden, one of those
+middle-aged mediocrities so common in London clubs who have no enemies,
+but are thoroughly disliked by their friends; Lady Ruxton, an
+overdressed woman of forty-seven, with a hooked nose, who was always
+trying to get herself compromised, but was so peculiarly plain that to
+her great disappointment no one would ever believe anything against
+her; Mrs. Erlynne, a pushing nobody, with a delightful lisp and
+Venetian-red hair; Lady Alice Chapman, his hostess's daughter, a dowdy
+dull girl, with one of those characteristic British faces that, once
+seen, are never remembered; and her husband, a red-cheeked,
+white-whiskered creature who, like so many of his class, was under the
+impression that inordinate joviality can atone for an entire lack of
+ideas.
+
+He was rather sorry he had come, till Lady Narborough, looking at the
+great ormolu gilt clock that sprawled in gaudy curves on the
+mauve-draped mantelshelf, exclaimed:  "How horrid of Henry Wotton to be
+so late!  I sent round to him this morning on chance and he promised
+faithfully not to disappoint me."
+
+It was some consolation that Harry was to be there, and when the door
+opened and he heard his slow musical voice lending charm to some
+insincere apology, he ceased to feel bored.
+
+But at dinner he could not eat anything.  Plate after plate went away
+untasted.  Lady Narborough kept scolding him for what she called "an
+insult to poor Adolphe, who invented the _menu_ specially for you," and
+now and then Lord Henry looked across at him, wondering at his silence
+and abstracted manner.  From time to time the butler filled his glass
+with champagne.  He drank eagerly, and his thirst seemed to increase.
+
+"Dorian," said Lord Henry at last, as the _chaud-froid_ was being handed
+round, "what is the matter with you to-night? You are quite out of
+sorts."
+
+"I believe he is in love," cried Lady Narborough, "and that he is
+afraid to tell me for fear I should be jealous.  He is quite right.  I
+certainly should."
+
+"Dear Lady Narborough," murmured Dorian, smiling, "I have not been in
+love for a whole week--not, in fact, since Madame de Ferrol left town."
+
+"How you men can fall in love with that woman!" exclaimed the old lady.
+"I really cannot understand it."
+
+"It is simply because she remembers you when you were a little girl,
+Lady Narborough," said Lord Henry.  "She is the one link between us and
+your short frocks."
+
+"She does not remember my short frocks at all, Lord Henry.  But I
+remember her very well at Vienna thirty years ago, and how _decolletee_
+she was then."
+
+"She is still _decolletee_," he answered, taking an olive in his long
+fingers; "and when she is in a very smart gown she looks like an
+_edition de luxe_ of a bad French novel.  She is really wonderful, and
+full of surprises.  Her capacity for family affection is extraordinary.
+When her third husband died, her hair turned quite gold from grief."
+
+"How can you, Harry!" cried Dorian.
+
+"It is a most romantic explanation," laughed the hostess.  "But her
+third husband, Lord Henry!  You don't mean to say Ferrol is the fourth?"
+
+"Certainly, Lady Narborough."
+
+"I don't believe a word of it."
+
+"Well, ask Mr. Gray.  He is one of her most intimate friends."
+
+"Is it true, Mr. Gray?"
+
+"She assures me so, Lady Narborough," said Dorian.  "I asked her
+whether, like Marguerite de Navarre, she had their hearts embalmed and
+hung at her girdle.  She told me she didn't, because none of them had
+had any hearts at all."
+
+"Four husbands!  Upon my word that is _trop de zele_."
+
+"_Trop d'audace_, I tell her," said Dorian.
+
+"Oh! she is audacious enough for anything, my dear.  And what is Ferrol
+like?  I don't know him."
+
+"The husbands of very beautiful women belong to the criminal classes,"
+said Lord Henry, sipping his wine.
+
+Lady Narborough hit him with her fan.  "Lord Henry, I am not at all
+surprised that the world says that you are extremely wicked."
+
+"But what world says that?" asked Lord Henry, elevating his eyebrows.
+"It can only be the next world.  This world and I are on excellent
+terms."
+
+"Everybody I know says you are very wicked," cried the old lady,
+shaking her head.
+
+Lord Henry looked serious for some moments.  "It is perfectly
+monstrous," he said, at last, "the way people go about nowadays saying
+things against one behind one's back that are absolutely and entirely
+true."
+
+"Isn't he incorrigible?" cried Dorian, leaning forward in his chair.
+
+"I hope so," said his hostess, laughing.  "But really, if you all
+worship Madame de Ferrol in this ridiculous way, I shall have to marry
+again so as to be in the fashion."
+
+"You will never marry again, Lady Narborough," broke in Lord Henry.
+"You were far too happy.  When a woman marries again, it is because she
+detested her first husband.  When a man marries again, it is because he
+adored his first wife.  Women try their luck; men risk theirs."
+
+"Narborough wasn't perfect," cried the old lady.
+
+"If he had been, you would not have loved him, my dear lady," was the
+rejoinder.  "Women love us for our defects.  If we have enough of them,
+they will forgive us everything, even our intellects.  You will never
+ask me to dinner again after saying this, I am afraid, Lady Narborough,
+but it is quite true."
+
+"Of course it is true, Lord Henry.  If we women did not love you for
+your defects, where would you all be?  Not one of you would ever be
+married.  You would be a set of unfortunate bachelors.  Not, however,
+that that would alter you much.  Nowadays all the married men live like
+bachelors, and all the bachelors like married men."
+
+"_Fin de siecle_," murmured Lord Henry.
+
+"_Fin du globe_," answered his hostess.
+
+"I wish it were _fin du globe_," said Dorian with a sigh.  "Life is a
+great disappointment."
+
+"Ah, my dear," cried Lady Narborough, putting on her gloves, "don't
+tell me that you have exhausted life.  When a man says that one knows
+that life has exhausted him.  Lord Henry is very wicked, and I
+sometimes wish that I had been; but you are made to be good--you look
+so good.  I must find you a nice wife.  Lord Henry, don't you think
+that Mr. Gray should get married?"
+
+"I am always telling him so, Lady Narborough," said Lord Henry with a
+bow.
+
+"Well, we must look out for a suitable match for him.  I shall go
+through Debrett carefully to-night and draw out a list of all the
+eligible young ladies."
+
+"With their ages, Lady Narborough?" asked Dorian.
+
+"Of course, with their ages, slightly edited.  But nothing must be done
+in a hurry.  I want it to be what _The Morning Post_ calls a suitable
+alliance, and I want you both to be happy."
+
+"What nonsense people talk about happy marriages!" exclaimed Lord
+Henry.  "A man can be happy with any woman, as long as he does not love
+her."
+
+"Ah! what a cynic you are!" cried the old lady, pushing back her chair
+and nodding to Lady Ruxton.  "You must come and dine with me soon
+again.  You are really an admirable tonic, much better than what Sir
+Andrew prescribes for me.  You must tell me what people you would like
+to meet, though.  I want it to be a delightful gathering."
+
+"I like men who have a future and women who have a past," he answered.
+"Or do you think that would make it a petticoat party?"
+
+"I fear so," she said, laughing, as she stood up.  "A thousand pardons,
+my dear Lady Ruxton," she added, "I didn't see you hadn't finished your
+cigarette."
+
+"Never mind, Lady Narborough.  I smoke a great deal too much.  I am
+going to limit myself, for the future."
+
+"Pray don't, Lady Ruxton," said Lord Henry.  "Moderation is a fatal
+thing.  Enough is as bad as a meal.  More than enough is as good as a
+feast."
+
+Lady Ruxton glanced at him curiously.  "You must come and explain that
+to me some afternoon, Lord Henry.  It sounds a fascinating theory," she
+murmured, as she swept out of the room.
+
+"Now, mind you don't stay too long over your politics and scandal,"
+cried Lady Narborough from the door.  "If you do, we are sure to
+squabble upstairs."
+
+The men laughed, and Mr. Chapman got up solemnly from the foot of the
+table and came up to the top.  Dorian Gray changed his seat and went
+and sat by Lord Henry.  Mr. Chapman began to talk in a loud voice about
+the situation in the House of Commons.  He guffawed at his adversaries.
+The word _doctrinaire_--word full of terror to the British
+mind--reappeared from time to time between his explosions.  An
+alliterative prefix served as an ornament of oratory.  He hoisted the
+Union Jack on the pinnacles of thought.  The inherited stupidity of the
+race--sound English common sense he jovially termed it--was shown to be
+the proper bulwark for society.
+
+A smile curved Lord Henry's lips, and he turned round and looked at
+Dorian.
+
+"Are you better, my dear fellow?" he asked.  "You seemed rather out of
+sorts at dinner."
+
+"I am quite well, Harry.  I am tired.  That is all."
+
+"You were charming last night.  The little duchess is quite devoted to
+you.  She tells me she is going down to Selby."
+
+"She has promised to come on the twentieth."
+
+"Is Monmouth to be there, too?"
+
+"Oh, yes, Harry."
+
+"He bores me dreadfully, almost as much as he bores her.  She is very
+clever, too clever for a woman.  She lacks the indefinable charm of
+weakness.  It is the feet of clay that make the gold of the image
+precious.  Her feet are very pretty, but they are not feet of clay.
+White porcelain feet, if you like.  They have been through the fire,
+and what fire does not destroy, it hardens.  She has had experiences."
+
+"How long has she been married?" asked Dorian.
+
+"An eternity, she tells me.  I believe, according to the peerage, it is
+ten years, but ten years with Monmouth must have been like eternity,
+with time thrown in.  Who else is coming?"
+
+"Oh, the Willoughbys, Lord Rugby and his wife, our hostess, Geoffrey
+Clouston, the usual set.  I have asked Lord Grotrian."
+
+"I like him," said Lord Henry.  "A great many people don't, but I find
+him charming.  He atones for being occasionally somewhat overdressed by
+being always absolutely over-educated. He is a very modern type."
+
+"I don't know if he will be able to come, Harry.  He may have to go to
+Monte Carlo with his father."
+
+"Ah! what a nuisance people's people are!  Try and make him come.  By
+the way, Dorian, you ran off very early last night.  You left before
+eleven.  What did you do afterwards?  Did you go straight home?"
+
+Dorian glanced at him hurriedly and frowned.
+
+"No, Harry," he said at last, "I did not get home till nearly three."
+
+"Did you go to the club?"
+
+"Yes," he answered.  Then he bit his lip.  "No, I don't mean that.  I
+didn't go to the club.  I walked about.  I forget what I did.... How
+inquisitive you are, Harry!  You always want to know what one has been
+doing.  I always want to forget what I have been doing.  I came in at
+half-past two, if you wish to know the exact time.  I had left my
+latch-key at home, and my servant had to let me in.  If you want any
+corroborative evidence on the subject, you can ask him."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, as if I cared!
+Let us go up to the drawing-room. No sherry, thank you, Mr. Chapman.
+Something has happened to you, Dorian.  Tell me what it is.  You are
+not yourself to-night."
+
+"Don't mind me, Harry.  I am irritable, and out of temper.  I shall
+come round and see you to-morrow, or next day.  Make my excuses to Lady
+Narborough.  I shan't go upstairs.  I shall go home.  I must go home."
+
+"All right, Dorian.  I dare say I shall see you to-morrow at tea-time.
+The duchess is coming."
+
+"I will try to be there, Harry," he said, leaving the room.  As he
+drove back to his own house, he was conscious that the sense of terror
+he thought he had strangled had come back to him.  Lord Henry's casual
+questioning had made him lose his nerve for the moment, and he wanted
+his nerve still.  Things that were dangerous had to be destroyed.  He
+winced.  He hated the idea of even touching them.
+
+Yet it had to be done.  He realized that, and when he had locked the
+door of his library, he opened the secret press into which he had
+thrust Basil Hallward's coat and bag.  A huge fire was blazing.  He
+piled another log on it.  The smell of the singeing clothes and burning
+leather was horrible.  It took him three-quarters of an hour to consume
+everything.  At the end he felt faint and sick, and having lit some
+Algerian pastilles in a pierced copper brazier, he bathed his hands and
+forehead with a cool musk-scented vinegar.
+
+Suddenly he started.  His eyes grew strangely bright, and he gnawed
+nervously at his underlip.  Between two of the windows stood a large
+Florentine cabinet, made out of ebony and inlaid with ivory and blue
+lapis.  He watched it as though it were a thing that could fascinate
+and make afraid, as though it held something that he longed for and yet
+almost loathed.  His breath quickened.  A mad craving came over him.
+He lit a cigarette and then threw it away.  His eyelids drooped till
+the long fringed lashes almost touched his cheek.  But he still watched
+the cabinet.  At last he got up from the sofa on which he had been
+lying, went over to it, and having unlocked it, touched some hidden
+spring.  A triangular drawer passed slowly out.  His fingers moved
+instinctively towards it, dipped in, and closed on something.  It was a
+small Chinese box of black and gold-dust lacquer, elaborately wrought,
+the sides patterned with curved waves, and the silken cords hung with
+round crystals and tasselled in plaited metal threads.  He opened it.
+Inside was a green paste, waxy in lustre, the odour curiously heavy and
+persistent.
+
+He hesitated for some moments, with a strangely immobile smile upon his
+face.  Then shivering, though the atmosphere of the room was terribly
+hot, he drew himself up and glanced at the clock.  It was twenty
+minutes to twelve.  He put the box back, shutting the cabinet doors as
+he did so, and went into his bedroom.
+
+As midnight was striking bronze blows upon the dusky air, Dorian Gray,
+dressed commonly, and with a muffler wrapped round his throat, crept
+quietly out of his house.  In Bond Street he found a hansom with a good
+horse.  He hailed it and in a low voice gave the driver an address.
+
+The man shook his head.  "It is too far for me," he muttered.
+
+"Here is a sovereign for you," said Dorian.  "You shall have another if
+you drive fast."
+
+"All right, sir," answered the man, "you will be there in an hour," and
+after his fare had got in he turned his horse round and drove rapidly
+towards the river.
+
+
+
+CHAPTER 16
+
+A cold rain began to fall, and the blurred street-lamps looked ghastly
+in the dripping mist.  The public-houses were just closing, and dim men
+and women were clustering in broken groups round their doors.  From
+some of the bars came the sound of horrible laughter.  In others,
+drunkards brawled and screamed.
+
+Lying back in the hansom, with his hat pulled over his forehead, Dorian
+Gray watched with listless eyes the sordid shame of the great city, and
+now and then he repeated to himself the words that Lord Henry had said
+to him on the first day they had met, "To cure the soul by means of the
+senses, and the senses by means of the soul."  Yes, that was the
+secret.  He had often tried it, and would try it again now.  There were
+opium dens where one could buy oblivion, dens of horror where the
+memory of old sins could be destroyed by the madness of sins that were
+new.
+
+The moon hung low in the sky like a yellow skull.  From time to time a
+huge misshapen cloud stretched a long arm across and hid it.  The
+gas-lamps grew fewer, and the streets more narrow and gloomy.  Once the
+man lost his way and had to drive back half a mile.  A steam rose from
+the horse as it splashed up the puddles.  The sidewindows of the hansom
+were clogged with a grey-flannel mist.
+
+"To cure the soul by means of the senses, and the senses by means of
+the soul!"  How the words rang in his ears!  His soul, certainly, was
+sick to death.  Was it true that the senses could cure it?  Innocent
+blood had been spilled.  What could atone for that?  Ah! for that there
+was no atonement; but though forgiveness was impossible, forgetfulness
+was possible still, and he was determined to forget, to stamp the thing
+out, to crush it as one would crush the adder that had stung one.
+Indeed, what right had Basil to have spoken to him as he had done?  Who
+had made him a judge over others?  He had said things that were
+dreadful, horrible, not to be endured.
+
+On and on plodded the hansom, going slower, it seemed to him, at each
+step.  He thrust up the trap and called to the man to drive faster.
+The hideous hunger for opium began to gnaw at him.  His throat burned
+and his delicate hands twitched nervously together.  He struck at the
+horse madly with his stick.  The driver laughed and whipped up.  He
+laughed in answer, and the man was silent.
+
+The way seemed interminable, and the streets like the black web of some
+sprawling spider.  The monotony became unbearable, and as the mist
+thickened, he felt afraid.
+
+Then they passed by lonely brickfields.  The fog was lighter here, and
+he could see the strange, bottle-shaped kilns with their orange,
+fanlike tongues of fire.  A dog barked as they went by, and far away in
+the darkness some wandering sea-gull screamed.  The horse stumbled in a
+rut, then swerved aside and broke into a gallop.
+
+After some time they left the clay road and rattled again over
+rough-paven streets.  Most of the windows were dark, but now and then
+fantastic shadows were silhouetted against some lamplit blind.  He
+watched them curiously.  They moved like monstrous marionettes and made
+gestures like live things.  He hated them.  A dull rage was in his
+heart.  As they turned a corner, a woman yelled something at them from
+an open door, and two men ran after the hansom for about a hundred
+yards.  The driver beat at them with his whip.
+
+It is said that passion makes one think in a circle.  Certainly with
+hideous iteration the bitten lips of Dorian Gray shaped and reshaped
+those subtle words that dealt with soul and sense, till he had found in
+them the full expression, as it were, of his mood, and justified, by
+intellectual approval, passions that without such justification would
+still have dominated his temper.  From cell to cell of his brain crept
+the one thought; and the wild desire to live, most terrible of all
+man's appetites, quickened into force each trembling nerve and fibre.
+Ugliness that had once been hateful to him because it made things real,
+became dear to him now for that very reason.  Ugliness was the one
+reality.  The coarse brawl, the loathsome den, the crude violence of
+disordered life, the very vileness of thief and outcast, were more
+vivid, in their intense actuality of impression, than all the gracious
+shapes of art, the dreamy shadows of song.  They were what he needed
+for forgetfulness.  In three days he would be free.
+
+Suddenly the man drew up with a jerk at the top of a dark lane.  Over
+the low roofs and jagged chimney-stacks of the houses rose the black
+masts of ships.  Wreaths of white mist clung like ghostly sails to the
+yards.
+
+"Somewhere about here, sir, ain't it?" he asked huskily through the
+trap.
+
+Dorian started and peered round.  "This will do," he answered, and
+having got out hastily and given the driver the extra fare he had
+promised him, he walked quickly in the direction of the quay.  Here and
+there a lantern gleamed at the stern of some huge merchantman.  The
+light shook and splintered in the puddles.  A red glare came from an
+outward-bound steamer that was coaling.  The slimy pavement looked like
+a wet mackintosh.
+
+He hurried on towards the left, glancing back now and then to see if he
+was being followed.  In about seven or eight minutes he reached a small
+shabby house that was wedged in between two gaunt factories.  In one of
+the top-windows stood a lamp.  He stopped and gave a peculiar knock.
+
+After a little time he heard steps in the passage and the chain being
+unhooked.  The door opened quietly, and he went in without saying a
+word to the squat misshapen figure that flattened itself into the
+shadow as he passed.  At the end of the hall hung a tattered green
+curtain that swayed and shook in the gusty wind which had followed him
+in from the street.  He dragged it aside and entered a long low room
+which looked as if it had once been a third-rate dancing-saloon. Shrill
+flaring gas-jets, dulled and distorted in the fly-blown mirrors that
+faced them, were ranged round the walls.  Greasy reflectors of ribbed
+tin backed them, making quivering disks of light.  The floor was
+covered with ochre-coloured sawdust, trampled here and there into mud,
+and stained with dark rings of spilled liquor.  Some Malays were
+crouching by a little charcoal stove, playing with bone counters and
+showing their white teeth as they chattered.  In one corner, with his
+head buried in his arms, a sailor sprawled over a table, and by the
+tawdrily painted bar that ran across one complete side stood two
+haggard women, mocking an old man who was brushing the sleeves of his
+coat with an expression of disgust.  "He thinks he's got red ants on
+him," laughed one of them, as Dorian passed by.  The man looked at her
+in terror and began to whimper.
+
+At the end of the room there was a little staircase, leading to a
+darkened chamber.  As Dorian hurried up its three rickety steps, the
+heavy odour of opium met him.  He heaved a deep breath, and his
+nostrils quivered with pleasure.  When he entered, a young man with
+smooth yellow hair, who was bending over a lamp lighting a long thin
+pipe, looked up at him and nodded in a hesitating manner.
+
+"You here, Adrian?" muttered Dorian.
+
+"Where else should I be?" he answered, listlessly.  "None of the chaps
+will speak to me now."
+
+"I thought you had left England."
+
+"Darlington is not going to do anything.  My brother paid the bill at
+last.  George doesn't speak to me either.... I don't care," he added
+with a sigh.  "As long as one has this stuff, one doesn't want friends.
+I think I have had too many friends."
+
+Dorian winced and looked round at the grotesque things that lay in such
+fantastic postures on the ragged mattresses.  The twisted limbs, the
+gaping mouths, the staring lustreless eyes, fascinated him.  He knew in
+what strange heavens they were suffering, and what dull hells were
+teaching them the secret of some new joy.  They were better off than he
+was.  He was prisoned in thought.  Memory, like a horrible malady, was
+eating his soul away.  From time to time he seemed to see the eyes of
+Basil Hallward looking at him.  Yet he felt he could not stay.  The
+presence of Adrian Singleton troubled him.  He wanted to be where no
+one would know who he was.  He wanted to escape from himself.
+
+"I am going on to the other place," he said after a pause.
+
+"On the wharf?"
+
+"Yes."
+
+"That mad-cat is sure to be there.  They won't have her in this place
+now."
+
+Dorian shrugged his shoulders.  "I am sick of women who love one.
+Women who hate one are much more interesting.  Besides, the stuff is
+better."
+
+"Much the same."
+
+"I like it better.  Come and have something to drink.  I must have
+something."
+
+"I don't want anything," murmured the young man.
+
+"Never mind."
+
+Adrian Singleton rose up wearily and followed Dorian to the bar.  A
+half-caste, in a ragged turban and a shabby ulster, grinned a hideous
+greeting as he thrust a bottle of brandy and two tumblers in front of
+them.  The women sidled up and began to chatter.  Dorian turned his
+back on them and said something in a low voice to Adrian Singleton.
+
+A crooked smile, like a Malay crease, writhed across the face of one of
+the women.  "We are very proud to-night," she sneered.
+
+"For God's sake don't talk to me," cried Dorian, stamping his foot on
+the ground.  "What do you want?  Money?  Here it is.  Don't ever talk
+to me again."
+
+Two red sparks flashed for a moment in the woman's sodden eyes, then
+flickered out and left them dull and glazed.  She tossed her head and
+raked the coins off the counter with greedy fingers.  Her companion
+watched her enviously.
+
+"It's no use," sighed Adrian Singleton.  "I don't care to go back.
+What does it matter?  I am quite happy here."
+
+"You will write to me if you want anything, won't you?" said Dorian,
+after a pause.
+
+"Perhaps."
+
+"Good night, then."
+
+"Good night," answered the young man, passing up the steps and wiping
+his parched mouth with a handkerchief.
+
+Dorian walked to the door with a look of pain in his face.  As he drew
+the curtain aside, a hideous laugh broke from the painted lips of the
+woman who had taken his money.  "There goes the devil's bargain!" she
+hiccoughed, in a hoarse voice.
+
+"Curse you!" he answered, "don't call me that."
+
+She snapped her fingers.  "Prince Charming is what you like to be
+called, ain't it?" she yelled after him.
+
+The drowsy sailor leaped to his feet as she spoke, and looked wildly
+round.  The sound of the shutting of the hall door fell on his ear.  He
+rushed out as if in pursuit.
+
+Dorian Gray hurried along the quay through the drizzling rain.  His
+meeting with Adrian Singleton had strangely moved him, and he wondered
+if the ruin of that young life was really to be laid at his door, as
+Basil Hallward had said to him with such infamy of insult.  He bit his
+lip, and for a few seconds his eyes grew sad.  Yet, after all, what did
+it matter to him?  One's days were too brief to take the burden of
+another's errors on one's shoulders.  Each man lived his own life and
+paid his own price for living it.  The only pity was one had to pay so
+often for a single fault.  One had to pay over and over again, indeed.
+In her dealings with man, destiny never closed her accounts.
+
+There are moments, psychologists tell us, when the passion for sin, or
+for what the world calls sin, so dominates a nature that every fibre of
+the body, as every cell of the brain, seems to be instinct with fearful
+impulses.  Men and women at such moments lose the freedom of their
+will.  They move to their terrible end as automatons move.  Choice is
+taken from them, and conscience is either killed, or, if it lives at
+all, lives but to give rebellion its fascination and disobedience its
+charm.  For all sins, as theologians weary not of reminding us, are
+sins of disobedience.  When that high spirit, that morning star of
+evil, fell from heaven, it was as a rebel that he fell.
+
+Callous, concentrated on evil, with stained mind, and soul hungry for
+rebellion, Dorian Gray hastened on, quickening his step as he went, but
+as he darted aside into a dim archway, that had served him often as a
+short cut to the ill-famed place where he was going, he felt himself
+suddenly seized from behind, and before he had time to defend himself,
+he was thrust back against the wall, with a brutal hand round his
+throat.
+
+He struggled madly for life, and by a terrible effort wrenched the
+tightening fingers away.  In a second he heard the click of a revolver,
+and saw the gleam of a polished barrel, pointing straight at his head,
+and the dusky form of a short, thick-set man facing him.
+
+"What do you want?" he gasped.
+
+"Keep quiet," said the man.  "If you stir, I shoot you."
+
+"You are mad.  What have I done to you?"
+
+"You wrecked the life of Sibyl Vane," was the answer, "and Sibyl Vane
+was my sister.  She killed herself.  I know it.  Her death is at your
+door.  I swore I would kill you in return.  For years I have sought
+you.  I had no clue, no trace.  The two people who could have described
+you were dead.  I knew nothing of you but the pet name she used to call
+you.  I heard it to-night by chance.  Make your peace with God, for
+to-night you are going to die."
+
+Dorian Gray grew sick with fear.  "I never knew her," he stammered.  "I
+never heard of her.  You are mad."
+
+"You had better confess your sin, for as sure as I am James Vane, you
+are going to die."  There was a horrible moment.  Dorian did not know
+what to say or do.  "Down on your knees!" growled the man.  "I give you
+one minute to make your peace--no more.  I go on board to-night for
+India, and I must do my job first.  One minute.  That's all."
+
+Dorian's arms fell to his side.  Paralysed with terror, he did not know
+what to do.  Suddenly a wild hope flashed across his brain.  "Stop," he
+cried.  "How long ago is it since your sister died?  Quick, tell me!"
+
+"Eighteen years," said the man.  "Why do you ask me?  What do years
+matter?"
+
+"Eighteen years," laughed Dorian Gray, with a touch of triumph in his
+voice.  "Eighteen years!  Set me under the lamp and look at my face!"
+
+James Vane hesitated for a moment, not understanding what was meant.
+Then he seized Dorian Gray and dragged him from the archway.
+
+Dim and wavering as was the wind-blown light, yet it served to show him
+the hideous error, as it seemed, into which he had fallen, for the face
+of the man he had sought to kill had all the bloom of boyhood, all the
+unstained purity of youth.  He seemed little more than a lad of twenty
+summers, hardly older, if older indeed at all, than his sister had been
+when they had parted so many years ago.  It was obvious that this was
+not the man who had destroyed her life.
+
+He loosened his hold and reeled back.  "My God! my God!" he cried, "and
+I would have murdered you!"
+
+Dorian Gray drew a long breath.  "You have been on the brink of
+committing a terrible crime, my man," he said, looking at him sternly.
+"Let this be a warning to you not to take vengeance into your own
+hands."
+
+"Forgive me, sir," muttered James Vane.  "I was deceived.  A chance
+word I heard in that damned den set me on the wrong track."
+
+"You had better go home and put that pistol away, or you may get into
+trouble," said Dorian, turning on his heel and going slowly down the
+street.
+
+James Vane stood on the pavement in horror.  He was trembling from head
+to foot.  After a little while, a black shadow that had been creeping
+along the dripping wall moved out into the light and came close to him
+with stealthy footsteps.  He felt a hand laid on his arm and looked
+round with a start.  It was one of the women who had been drinking at
+the bar.
+
+"Why didn't you kill him?" she hissed out, putting haggard face quite
+close to his.  "I knew you were following him when you rushed out from
+Daly's. You fool!  You should have killed him.  He has lots of money,
+and he's as bad as bad."
+
+"He is not the man I am looking for," he answered, "and I want no man's
+money.  I want a man's life.  The man whose life I want must be nearly
+forty now.  This one is little more than a boy.  Thank God, I have not
+got his blood upon my hands."
+
+The woman gave a bitter laugh.  "Little more than a boy!" she sneered.
+"Why, man, it's nigh on eighteen years since Prince Charming made me
+what I am."
+
+"You lie!" cried James Vane.
+
+She raised her hand up to heaven.  "Before God I am telling the truth,"
+she cried.
+
+"Before God?"
+
+"Strike me dumb if it ain't so.  He is the worst one that comes here.
+They say he has sold himself to the devil for a pretty face.  It's nigh
+on eighteen years since I met him.  He hasn't changed much since then.
+I have, though," she added, with a sickly leer.
+
+"You swear this?"
+
+"I swear it," came in hoarse echo from her flat mouth.  "But don't give
+me away to him," she whined; "I am afraid of him.  Let me have some
+money for my night's lodging."
+
+He broke from her with an oath and rushed to the corner of the street,
+but Dorian Gray had disappeared.  When he looked back, the woman had
+vanished also.
+
+
+
+CHAPTER 17
+
+A week later Dorian Gray was sitting in the conservatory at Selby
+Royal, talking to the pretty Duchess of Monmouth, who with her husband,
+a jaded-looking man of sixty, was amongst his guests.  It was tea-time,
+and the mellow light of the huge, lace-covered lamp that stood on the
+table lit up the delicate china and hammered silver of the service at
+which the duchess was presiding.  Her white hands were moving daintily
+among the cups, and her full red lips were smiling at something that
+Dorian had whispered to her.  Lord Henry was lying back in a
+silk-draped wicker chair, looking at them.  On a peach-coloured divan
+sat Lady Narborough, pretending to listen to the duke's description of
+the last Brazilian beetle that he had added to his collection.  Three
+young men in elaborate smoking-suits were handing tea-cakes to some of
+the women.  The house-party consisted of twelve people, and there were
+more expected to arrive on the next day.
+
+"What are you two talking about?" said Lord Henry, strolling over to
+the table and putting his cup down.  "I hope Dorian has told you about
+my plan for rechristening everything, Gladys.  It is a delightful idea."
+
+"But I don't want to be rechristened, Harry," rejoined the duchess,
+looking up at him with her wonderful eyes.  "I am quite satisfied with
+my own name, and I am sure Mr. Gray should be satisfied with his."
+
+"My dear Gladys, I would not alter either name for the world.  They are
+both perfect.  I was thinking chiefly of flowers.  Yesterday I cut an
+orchid, for my button-hole. It was a marvellous spotted thing, as
+effective as the seven deadly sins.  In a thoughtless moment I asked
+one of the gardeners what it was called.  He told me it was a fine
+specimen of _Robinsoniana_, or something dreadful of that kind.  It is a
+sad truth, but we have lost the faculty of giving lovely names to
+things.  Names are everything.  I never quarrel with actions.  My one
+quarrel is with words.  That is the reason I hate vulgar realism in
+literature.  The man who could call a spade a spade should be compelled
+to use one.  It is the only thing he is fit for."
+
+"Then what should we call you, Harry?" she asked.
+
+"His name is Prince Paradox," said Dorian.
+
+"I recognize him in a flash," exclaimed the duchess.
+
+"I won't hear of it," laughed Lord Henry, sinking into a chair.  "From
+a label there is no escape!  I refuse the title."
+
+"Royalties may not abdicate," fell as a warning from pretty lips.
+
+"You wish me to defend my throne, then?"
+
+"Yes."
+
+"I give the truths of to-morrow."
+
+"I prefer the mistakes of to-day," she answered.
+
+"You disarm me, Gladys," he cried, catching the wilfulness of her mood.
+
+"Of your shield, Harry, not of your spear."
+
+"I never tilt against beauty," he said, with a wave of his hand.
+
+"That is your error, Harry, believe me.  You value beauty far too much."
+
+"How can you say that?  I admit that I think that it is better to be
+beautiful than to be good.  But on the other hand, no one is more ready
+than I am to acknowledge that it is better to be good than to be ugly."
+
+"Ugliness is one of the seven deadly sins, then?" cried the duchess.
+"What becomes of your simile about the orchid?"
+
+"Ugliness is one of the seven deadly virtues, Gladys.  You, as a good
+Tory, must not underrate them.  Beer, the Bible, and the seven deadly
+virtues have made our England what she is."
+
+"You don't like your country, then?" she asked.
+
+"I live in it."
+
+"That you may censure it the better."
+
+"Would you have me take the verdict of Europe on it?" he inquired.
+
+"What do they say of us?"
+
+"That Tartuffe has emigrated to England and opened a shop."
+
+"Is that yours, Harry?"
+
+"I give it to you."
+
+"I could not use it.  It is too true."
+
+"You need not be afraid.  Our countrymen never recognize a description."
+
+"They are practical."
+
+"They are more cunning than practical.  When they make up their ledger,
+they balance stupidity by wealth, and vice by hypocrisy."
+
+"Still, we have done great things."
+
+"Great things have been thrust on us, Gladys."
+
+"We have carried their burden."
+
+"Only as far as the Stock Exchange."
+
+She shook her head.  "I believe in the race," she cried.
+
+"It represents the survival of the pushing."
+
+"It has development."
+
+"Decay fascinates me more."
+
+"What of art?" she asked.
+
+"It is a malady."
+
+"Love?"
+
+"An illusion."
+
+"Religion?"
+
+"The fashionable substitute for belief."
+
+"You are a sceptic."
+
+"Never!  Scepticism is the beginning of faith."
+
+"What are you?"
+
+"To define is to limit."
+
+"Give me a clue."
+
+"Threads snap.  You would lose your way in the labyrinth."
+
+"You bewilder me.  Let us talk of some one else."
+
+"Our host is a delightful topic.  Years ago he was christened Prince
+Charming."
+
+"Ah! don't remind me of that," cried Dorian Gray.
+
+"Our host is rather horrid this evening," answered the duchess,
+colouring.  "I believe he thinks that Monmouth married me on purely
+scientific principles as the best specimen he could find of a modern
+butterfly."
+
+"Well, I hope he won't stick pins into you, Duchess," laughed Dorian.
+
+"Oh! my maid does that already, Mr. Gray, when she is annoyed with me."
+
+"And what does she get annoyed with you about, Duchess?"
+
+"For the most trivial things, Mr. Gray, I assure you.  Usually because
+I come in at ten minutes to nine and tell her that I must be dressed by
+half-past eight."
+
+"How unreasonable of her!  You should give her warning."
+
+"I daren't, Mr. Gray.  Why, she invents hats for me.  You remember the
+one I wore at Lady Hilstone's garden-party?  You don't, but it is nice
+of you to pretend that you do.  Well, she made it out of nothing.  All
+good hats are made out of nothing."
+
+"Like all good reputations, Gladys," interrupted Lord Henry.  "Every
+effect that one produces gives one an enemy.  To be popular one must be
+a mediocrity."
+
+"Not with women," said the duchess, shaking her head; "and women rule
+the world.  I assure you we can't bear mediocrities.  We women, as some
+one says, love with our ears, just as you men love with your eyes, if
+you ever love at all."
+
+"It seems to me that we never do anything else," murmured Dorian.
+
+"Ah! then, you never really love, Mr. Gray," answered the duchess with
+mock sadness.
+
+"My dear Gladys!" cried Lord Henry.  "How can you say that?  Romance
+lives by repetition, and repetition converts an appetite into an art.
+Besides, each time that one loves is the only time one has ever loved.
+Difference of object does not alter singleness of passion.  It merely
+intensifies it.  We can have in life but one great experience at best,
+and the secret of life is to reproduce that experience as often as
+possible."
+
+"Even when one has been wounded by it, Harry?" asked the duchess after
+a pause.
+
+"Especially when one has been wounded by it," answered Lord Henry.
+
+The duchess turned and looked at Dorian Gray with a curious expression
+in her eyes.  "What do you say to that, Mr. Gray?" she inquired.
+
+Dorian hesitated for a moment.  Then he threw his head back and
+laughed.  "I always agree with Harry, Duchess."
+
+"Even when he is wrong?"
+
+"Harry is never wrong, Duchess."
+
+"And does his philosophy make you happy?"
+
+"I have never searched for happiness.  Who wants happiness?  I have
+searched for pleasure."
+
+"And found it, Mr. Gray?"
+
+"Often.  Too often."
+
+The duchess sighed.  "I am searching for peace," she said, "and if I
+don't go and dress, I shall have none this evening."
+
+"Let me get you some orchids, Duchess," cried Dorian, starting to his
+feet and walking down the conservatory.
+
+"You are flirting disgracefully with him," said Lord Henry to his
+cousin.  "You had better take care.  He is very fascinating."
+
+"If he were not, there would be no battle."
+
+"Greek meets Greek, then?"
+
+"I am on the side of the Trojans.  They fought for a woman."
+
+"They were defeated."
+
+"There are worse things than capture," she answered.
+
+"You gallop with a loose rein."
+
+"Pace gives life," was the _riposte_.
+
+"I shall write it in my diary to-night."
+
+"What?"
+
+"That a burnt child loves the fire."
+
+"I am not even singed.  My wings are untouched."
+
+"You use them for everything, except flight."
+
+"Courage has passed from men to women.  It is a new experience for us."
+
+"You have a rival."
+
+"Who?"
+
+He laughed.  "Lady Narborough," he whispered.  "She perfectly adores
+him."
+
+"You fill me with apprehension.  The appeal to antiquity is fatal to us
+who are romanticists."
+
+"Romanticists!  You have all the methods of science."
+
+"Men have educated us."
+
+"But not explained you."
+
+"Describe us as a sex," was her challenge.
+
+"Sphinxes without secrets."
+
+She looked at him, smiling.  "How long Mr. Gray is!" she said.  "Let us
+go and help him.  I have not yet told him the colour of my frock."
+
+"Ah! you must suit your frock to his flowers, Gladys."
+
+"That would be a premature surrender."
+
+"Romantic art begins with its climax."
+
+"I must keep an opportunity for retreat."
+
+"In the Parthian manner?"
+
+"They found safety in the desert.  I could not do that."
+
+"Women are not always allowed a choice," he answered, but hardly had he
+finished the sentence before from the far end of the conservatory came
+a stifled groan, followed by the dull sound of a heavy fall.  Everybody
+started up.  The duchess stood motionless in horror.  And with fear in
+his eyes, Lord Henry rushed through the flapping palms to find Dorian
+Gray lying face downwards on the tiled floor in a deathlike swoon.
+
+He was carried at once into the blue drawing-room and laid upon one of
+the sofas.  After a short time, he came to himself and looked round
+with a dazed expression.
+
+"What has happened?" he asked.  "Oh!  I remember.  Am I safe here,
+Harry?" He began to tremble.
+
+"My dear Dorian," answered Lord Henry, "you merely fainted.  That was
+all.  You must have overtired yourself.  You had better not come down
+to dinner.  I will take your place."
+
+"No, I will come down," he said, struggling to his feet.  "I would
+rather come down.  I must not be alone."
+
+He went to his room and dressed.  There was a wild recklessness of
+gaiety in his manner as he sat at table, but now and then a thrill of
+terror ran through him when he remembered that, pressed against the
+window of the conservatory, like a white handkerchief, he had seen the
+face of James Vane watching him.
+
+
+
+CHAPTER 18
+
+The next day he did not leave the house, and, indeed, spent most of the
+time in his own room, sick with a wild terror of dying, and yet
+indifferent to life itself.  The consciousness of being hunted, snared,
+tracked down, had begun to dominate him.  If the tapestry did but
+tremble in the wind, he shook.  The dead leaves that were blown against
+the leaded panes seemed to him like his own wasted resolutions and wild
+regrets.  When he closed his eyes, he saw again the sailor's face
+peering through the mist-stained glass, and horror seemed once more to
+lay its hand upon his heart.
+
+But perhaps it had been only his fancy that had called vengeance out of
+the night and set the hideous shapes of punishment before him.  Actual
+life was chaos, but there was something terribly logical in the
+imagination.  It was the imagination that set remorse to dog the feet
+of sin.  It was the imagination that made each crime bear its misshapen
+brood.  In the common world of fact the wicked were not punished, nor
+the good rewarded.  Success was given to the strong, failure thrust
+upon the weak.  That was all.  Besides, had any stranger been prowling
+round the house, he would have been seen by the servants or the
+keepers.  Had any foot-marks been found on the flower-beds, the
+gardeners would have reported it.  Yes, it had been merely fancy.
+Sibyl Vane's brother had not come back to kill him.  He had sailed away
+in his ship to founder in some winter sea.  From him, at any rate, he
+was safe.  Why, the man did not know who he was, could not know who he
+was.  The mask of youth had saved him.
+
+And yet if it had been merely an illusion, how terrible it was to think
+that conscience could raise such fearful phantoms, and give them
+visible form, and make them move before one!  What sort of life would
+his be if, day and night, shadows of his crime were to peer at him from
+silent corners, to mock him from secret places, to whisper in his ear
+as he sat at the feast, to wake him with icy fingers as he lay asleep!
+As the thought crept through his brain, he grew pale with terror, and
+the air seemed to him to have become suddenly colder.  Oh! in what a
+wild hour of madness he had killed his friend!  How ghastly the mere
+memory of the scene!  He saw it all again.  Each hideous detail came
+back to him with added horror.  Out of the black cave of time, terrible
+and swathed in scarlet, rose the image of his sin.  When Lord Henry
+came in at six o'clock, he found him crying as one whose heart will
+break.
+
+It was not till the third day that he ventured to go out.  There was
+something in the clear, pine-scented air of that winter morning that
+seemed to bring him back his joyousness and his ardour for life.  But
+it was not merely the physical conditions of environment that had
+caused the change.  His own nature had revolted against the excess of
+anguish that had sought to maim and mar the perfection of its calm.
+With subtle and finely wrought temperaments it is always so.  Their
+strong passions must either bruise or bend.  They either slay the man,
+or themselves die.  Shallow sorrows and shallow loves live on.  The
+loves and sorrows that are great are destroyed by their own plenitude.
+Besides, he had convinced himself that he had been the victim of a
+terror-stricken imagination, and looked back now on his fears with
+something of pity and not a little of contempt.
+
+After breakfast, he walked with the duchess for an hour in the garden
+and then drove across the park to join the shooting-party. The crisp
+frost lay like salt upon the grass.  The sky was an inverted cup of
+blue metal.  A thin film of ice bordered the flat, reed-grown lake.
+
+At the corner of the pine-wood he caught sight of Sir Geoffrey
+Clouston, the duchess's brother, jerking two spent cartridges out of
+his gun.  He jumped from the cart, and having told the groom to take
+the mare home, made his way towards his guest through the withered
+bracken and rough undergrowth.
+
+"Have you had good sport, Geoffrey?" he asked.
+
+"Not very good, Dorian.  I think most of the birds have gone to the
+open.  I dare say it will be better after lunch, when we get to new
+ground."
+
+Dorian strolled along by his side.  The keen aromatic air, the brown
+and red lights that glimmered in the wood, the hoarse cries of the
+beaters ringing out from time to time, and the sharp snaps of the guns
+that followed, fascinated him and filled him with a sense of delightful
+freedom.  He was dominated by the carelessness of happiness, by the
+high indifference of joy.
+
+Suddenly from a lumpy tussock of old grass some twenty yards in front
+of them, with black-tipped ears erect and long hinder limbs throwing it
+forward, started a hare.  It bolted for a thicket of alders.  Sir
+Geoffrey put his gun to his shoulder, but there was something in the
+animal's grace of movement that strangely charmed Dorian Gray, and he
+cried out at once, "Don't shoot it, Geoffrey.  Let it live."
+
+"What nonsense, Dorian!" laughed his companion, and as the hare bounded
+into the thicket, he fired.  There were two cries heard, the cry of a
+hare in pain, which is dreadful, the cry of a man in agony, which is
+worse.
+
+"Good heavens!  I have hit a beater!" exclaimed Sir Geoffrey.  "What an
+ass the man was to get in front of the guns!  Stop shooting there!" he
+called out at the top of his voice.  "A man is hurt."
+
+The head-keeper came running up with a stick in his hand.
+
+"Where, sir?  Where is he?" he shouted.  At the same time, the firing
+ceased along the line.
+
+"Here," answered Sir Geoffrey angrily, hurrying towards the thicket.
+"Why on earth don't you keep your men back?  Spoiled my shooting for
+the day."
+
+Dorian watched them as they plunged into the alder-clump, brushing the
+lithe swinging branches aside.  In a few moments they emerged, dragging
+a body after them into the sunlight.  He turned away in horror.  It
+seemed to him that misfortune followed wherever he went.  He heard Sir
+Geoffrey ask if the man was really dead, and the affirmative answer of
+the keeper.  The wood seemed to him to have become suddenly alive with
+faces.  There was the trampling of myriad feet and the low buzz of
+voices.  A great copper-breasted pheasant came beating through the
+boughs overhead.
+
+After a few moments--that were to him, in his perturbed state, like
+endless hours of pain--he felt a hand laid on his shoulder.  He started
+and looked round.
+
+"Dorian," said Lord Henry, "I had better tell them that the shooting is
+stopped for to-day. It would not look well to go on."
+
+"I wish it were stopped for ever, Harry," he answered bitterly.  "The
+whole thing is hideous and cruel.  Is the man ...?"
+
+He could not finish the sentence.
+
+"I am afraid so," rejoined Lord Henry.  "He got the whole charge of
+shot in his chest.  He must have died almost instantaneously.  Come;
+let us go home."
+
+They walked side by side in the direction of the avenue for nearly
+fifty yards without speaking.  Then Dorian looked at Lord Henry and
+said, with a heavy sigh, "It is a bad omen, Harry, a very bad omen."
+
+"What is?" asked Lord Henry.  "Oh! this accident, I suppose.  My dear
+fellow, it can't be helped.  It was the man's own fault.  Why did he
+get in front of the guns?  Besides, it is nothing to us.  It is rather
+awkward for Geoffrey, of course.  It does not do to pepper beaters.  It
+makes people think that one is a wild shot.  And Geoffrey is not; he
+shoots very straight.  But there is no use talking about the matter."
+
+Dorian shook his head.  "It is a bad omen, Harry.  I feel as if
+something horrible were going to happen to some of us.  To myself,
+perhaps," he added, passing his hand over his eyes, with a gesture of
+pain.
+
+The elder man laughed.  "The only horrible thing in the world is _ennui_,
+Dorian.  That is the one sin for which there is no forgiveness.  But we
+are not likely to suffer from it unless these fellows keep chattering
+about this thing at dinner.  I must tell them that the subject is to be
+tabooed.  As for omens, there is no such thing as an omen.  Destiny
+does not send us heralds.  She is too wise or too cruel for that.
+Besides, what on earth could happen to you, Dorian?  You have
+everything in the world that a man can want.  There is no one who would
+not be delighted to change places with you."
+
+"There is no one with whom I would not change places, Harry.  Don't
+laugh like that.  I am telling you the truth.  The wretched peasant who
+has just died is better off than I am.  I have no terror of death.  It
+is the coming of death that terrifies me.  Its monstrous wings seem to
+wheel in the leaden air around me.  Good heavens! don't you see a man
+moving behind the trees there, watching me, waiting for me?"
+
+Lord Henry looked in the direction in which the trembling gloved hand
+was pointing.  "Yes," he said, smiling, "I see the gardener waiting for
+you.  I suppose he wants to ask you what flowers you wish to have on
+the table to-night. How absurdly nervous you are, my dear fellow!  You
+must come and see my doctor, when we get back to town."
+
+Dorian heaved a sigh of relief as he saw the gardener approaching.  The
+man touched his hat, glanced for a moment at Lord Henry in a hesitating
+manner, and then produced a letter, which he handed to his master.
+"Her Grace told me to wait for an answer," he murmured.
+
+Dorian put the letter into his pocket.  "Tell her Grace that I am
+coming in," he said, coldly.  The man turned round and went rapidly in
+the direction of the house.
+
+"How fond women are of doing dangerous things!" laughed Lord Henry.
+"It is one of the qualities in them that I admire most.  A woman will
+flirt with anybody in the world as long as other people are looking on."
+
+"How fond you are of saying dangerous things, Harry!  In the present
+instance, you are quite astray.  I like the duchess very much, but I
+don't love her."
+
+"And the duchess loves you very much, but she likes you less, so you
+are excellently matched."
+
+"You are talking scandal, Harry, and there is never any basis for
+scandal."
+
+"The basis of every scandal is an immoral certainty," said Lord Henry,
+lighting a cigarette.
+
+"You would sacrifice anybody, Harry, for the sake of an epigram."
+
+"The world goes to the altar of its own accord," was the answer.
+
+"I wish I could love," cried Dorian Gray with a deep note of pathos in
+his voice.  "But I seem to have lost the passion and forgotten the
+desire.  I am too much concentrated on myself.  My own personality has
+become a burden to me.  I want to escape, to go away, to forget.  It
+was silly of me to come down here at all.  I think I shall send a wire
+to Harvey to have the yacht got ready.  On a yacht one is safe."
+
+"Safe from what, Dorian?  You are in some trouble.  Why not tell me
+what it is?  You know I would help you."
+
+"I can't tell you, Harry," he answered sadly.  "And I dare say it is
+only a fancy of mine.  This unfortunate accident has upset me.  I have
+a horrible presentiment that something of the kind may happen to me."
+
+"What nonsense!"
+
+"I hope it is, but I can't help feeling it.  Ah! here is the duchess,
+looking like Artemis in a tailor-made gown.  You see we have come back,
+Duchess."
+
+"I have heard all about it, Mr. Gray," she answered.  "Poor Geoffrey is
+terribly upset.  And it seems that you asked him not to shoot the hare.
+How curious!"
+
+"Yes, it was very curious.  I don't know what made me say it.  Some
+whim, I suppose.  It looked the loveliest of little live things.  But I
+am sorry they told you about the man.  It is a hideous subject."
+
+"It is an annoying subject," broke in Lord Henry.  "It has no
+psychological value at all.  Now if Geoffrey had done the thing on
+purpose, how interesting he would be!  I should like to know some one
+who had committed a real murder."
+
+"How horrid of you, Harry!" cried the duchess.  "Isn't it, Mr. Gray?
+Harry, Mr. Gray is ill again.  He is going to faint."
+
+Dorian drew himself up with an effort and smiled.  "It is nothing,
+Duchess," he murmured; "my nerves are dreadfully out of order.  That is
+all.  I am afraid I walked too far this morning.  I didn't hear what
+Harry said.  Was it very bad?  You must tell me some other time.  I
+think I must go and lie down.  You will excuse me, won't you?"
+
+They had reached the great flight of steps that led from the
+conservatory on to the terrace.  As the glass door closed behind
+Dorian, Lord Henry turned and looked at the duchess with his slumberous
+eyes.  "Are you very much in love with him?" he asked.
+
+She did not answer for some time, but stood gazing at the landscape.
+"I wish I knew," she said at last.
+
+He shook his head.  "Knowledge would be fatal.  It is the uncertainty
+that charms one.  A mist makes things wonderful."
+
+"One may lose one's way."
+
+"All ways end at the same point, my dear Gladys."
+
+"What is that?"
+
+"Disillusion."
+
+"It was my _debut_ in life," she sighed.
+
+"It came to you crowned."
+
+"I am tired of strawberry leaves."
+
+"They become you."
+
+"Only in public."
+
+"You would miss them," said Lord Henry.
+
+"I will not part with a petal."
+
+"Monmouth has ears."
+
+"Old age is dull of hearing."
+
+"Has he never been jealous?"
+
+"I wish he had been."
+
+He glanced about as if in search of something.  "What are you looking
+for?" she inquired.
+
+"The button from your foil," he answered.  "You have dropped it."
+
+She laughed.  "I have still the mask."
+
+"It makes your eyes lovelier," was his reply.
+
+She laughed again.  Her teeth showed like white seeds in a scarlet
+fruit.
+
+Upstairs, in his own room, Dorian Gray was lying on a sofa, with terror
+in every tingling fibre of his body.  Life had suddenly become too
+hideous a burden for him to bear.  The dreadful death of the unlucky
+beater, shot in the thicket like a wild animal, had seemed to him to
+pre-figure death for himself also.  He had nearly swooned at what Lord
+Henry had said in a chance mood of cynical jesting.
+
+At five o'clock he rang his bell for his servant and gave him orders to
+pack his things for the night-express to town, and to have the brougham
+at the door by eight-thirty. He was determined not to sleep another
+night at Selby Royal.  It was an ill-omened place.  Death walked there
+in the sunlight.  The grass of the forest had been spotted with blood.
+
+Then he wrote a note to Lord Henry, telling him that he was going up to
+town to consult his doctor and asking him to entertain his guests in
+his absence.  As he was putting it into the envelope, a knock came to
+the door, and his valet informed him that the head-keeper wished to see
+him.  He frowned and bit his lip.  "Send him in," he muttered, after
+some moments' hesitation.
+
+As soon as the man entered, Dorian pulled his chequebook out of a
+drawer and spread it out before him.
+
+"I suppose you have come about the unfortunate accident of this
+morning, Thornton?" he said, taking up a pen.
+
+"Yes, sir," answered the gamekeeper.
+
+"Was the poor fellow married?  Had he any people dependent on him?"
+asked Dorian, looking bored.  "If so, I should not like them to be left
+in want, and will send them any sum of money you may think necessary."
+
+"We don't know who he is, sir.  That is what I took the liberty of
+coming to you about."
+
+"Don't know who he is?" said Dorian, listlessly.  "What do you mean?
+Wasn't he one of your men?"
+
+"No, sir.  Never saw him before.  Seems like a sailor, sir."
+
+The pen dropped from Dorian Gray's hand, and he felt as if his heart
+had suddenly stopped beating.  "A sailor?" he cried out.  "Did you say
+a sailor?"
+
+"Yes, sir.  He looks as if he had been a sort of sailor; tattooed on
+both arms, and that kind of thing."
+
+"Was there anything found on him?" said Dorian, leaning forward and
+looking at the man with startled eyes.  "Anything that would tell his
+name?"
+
+"Some money, sir--not much, and a six-shooter. There was no name of any
+kind.  A decent-looking man, sir, but rough-like. A sort of sailor we
+think."
+
+Dorian started to his feet.  A terrible hope fluttered past him.  He
+clutched at it madly.  "Where is the body?" he exclaimed.  "Quick!  I
+must see it at once."
+
+"It is in an empty stable in the Home Farm, sir.  The folk don't like
+to have that sort of thing in their houses.  They say a corpse brings
+bad luck."
+
+"The Home Farm!  Go there at once and meet me.  Tell one of the grooms
+to bring my horse round.  No. Never mind.  I'll go to the stables
+myself.  It will save time."
+
+In less than a quarter of an hour, Dorian Gray was galloping down the
+long avenue as hard as he could go.  The trees seemed to sweep past him
+in spectral procession, and wild shadows to fling themselves across his
+path.  Once the mare swerved at a white gate-post and nearly threw him.
+He lashed her across the neck with his crop.  She cleft the dusky air
+like an arrow.  The stones flew from her hoofs.
+
+At last he reached the Home Farm.  Two men were loitering in the yard.
+He leaped from the saddle and threw the reins to one of them.  In the
+farthest stable a light was glimmering.  Something seemed to tell him
+that the body was there, and he hurried to the door and put his hand
+upon the latch.
+
+There he paused for a moment, feeling that he was on the brink of a
+discovery that would either make or mar his life.  Then he thrust the
+door open and entered.
+
+On a heap of sacking in the far corner was lying the dead body of a man
+dressed in a coarse shirt and a pair of blue trousers.  A spotted
+handkerchief had been placed over the face.  A coarse candle, stuck in
+a bottle, sputtered beside it.
+
+Dorian Gray shuddered.  He felt that his could not be the hand to take
+the handkerchief away, and called out to one of the farm-servants to
+come to him.
+
+"Take that thing off the face.  I wish to see it," he said, clutching
+at the door-post for support.
+
+When the farm-servant had done so, he stepped forward.  A cry of joy
+broke from his lips.  The man who had been shot in the thicket was
+James Vane.
+
+He stood there for some minutes looking at the dead body.  As he rode
+home, his eyes were full of tears, for he knew he was safe.
+
+
+
+CHAPTER 19
+
+"There is no use your telling me that you are going to be good," cried
+Lord Henry, dipping his white fingers into a red copper bowl filled
+with rose-water. "You are quite perfect.  Pray, don't change."
+
+Dorian Gray shook his head.  "No, Harry, I have done too many dreadful
+things in my life.  I am not going to do any more.  I began my good
+actions yesterday."
+
+"Where were you yesterday?"
+
+"In the country, Harry.  I was staying at a little inn by myself."
+
+"My dear boy," said Lord Henry, smiling, "anybody can be good in the
+country.  There are no temptations there.  That is the reason why
+people who live out of town are so absolutely uncivilized.
+Civilization is not by any means an easy thing to attain to.  There are
+only two ways by which man can reach it.  One is by being cultured, the
+other by being corrupt.  Country people have no opportunity of being
+either, so they stagnate."
+
+"Culture and corruption," echoed Dorian.  "I have known something of
+both.  It seems terrible to me now that they should ever be found
+together.  For I have a new ideal, Harry.  I am going to alter.  I
+think I have altered."
+
+"You have not yet told me what your good action was.  Or did you say
+you had done more than one?" asked his companion as he spilled into his
+plate a little crimson pyramid of seeded strawberries and, through a
+perforated, shell-shaped spoon, snowed white sugar upon them.
+
+"I can tell you, Harry.  It is not a story I could tell to any one
+else.  I spared somebody.  It sounds vain, but you understand what I
+mean.  She was quite beautiful and wonderfully like Sibyl Vane.  I
+think it was that which first attracted me to her.  You remember Sibyl,
+don't you?  How long ago that seems!  Well, Hetty was not one of our
+own class, of course.  She was simply a girl in a village.  But I
+really loved her.  I am quite sure that I loved her.  All during this
+wonderful May that we have been having, I used to run down and see her
+two or three times a week.  Yesterday she met me in a little orchard.
+The apple-blossoms kept tumbling down on her hair, and she was
+laughing.  We were to have gone away together this morning at dawn.
+Suddenly I determined to leave her as flowerlike as I had found her."
+
+"I should think the novelty of the emotion must have given you a thrill
+of real pleasure, Dorian," interrupted Lord Henry.  "But I can finish
+your idyll for you.  You gave her good advice and broke her heart.
+That was the beginning of your reformation."
+
+"Harry, you are horrible!  You mustn't say these dreadful things.
+Hetty's heart is not broken.  Of course, she cried and all that.  But
+there is no disgrace upon her.  She can live, like Perdita, in her
+garden of mint and marigold."
+
+"And weep over a faithless Florizel," said Lord Henry, laughing, as he
+leaned back in his chair.  "My dear Dorian, you have the most curiously
+boyish moods.  Do you think this girl will ever be really content now
+with any one of her own rank?  I suppose she will be married some day
+to a rough carter or a grinning ploughman.  Well, the fact of having
+met you, and loved you, will teach her to despise her husband, and she
+will be wretched.  From a moral point of view, I cannot say that I
+think much of your great renunciation.  Even as a beginning, it is
+poor.  Besides, how do you know that Hetty isn't floating at the
+present moment in some starlit mill-pond, with lovely water-lilies
+round her, like Ophelia?"
+
+"I can't bear this, Harry!  You mock at everything, and then suggest
+the most serious tragedies.  I am sorry I told you now.  I don't care
+what you say to me.  I know I was right in acting as I did.  Poor
+Hetty!  As I rode past the farm this morning, I saw her white face at
+the window, like a spray of jasmine.  Don't let us talk about it any
+more, and don't try to persuade me that the first good action I have
+done for years, the first little bit of self-sacrifice I have ever
+known, is really a sort of sin.  I want to be better.  I am going to be
+better.  Tell me something about yourself.  What is going on in town?
+I have not been to the club for days."
+
+"The people are still discussing poor Basil's disappearance."
+
+"I should have thought they had got tired of that by this time," said
+Dorian, pouring himself out some wine and frowning slightly.
+
+"My dear boy, they have only been talking about it for six weeks, and
+the British public are really not equal to the mental strain of having
+more than one topic every three months.  They have been very fortunate
+lately, however.  They have had my own divorce-case and Alan Campbell's
+suicide.  Now they have got the mysterious disappearance of an artist.
+Scotland Yard still insists that the man in the grey ulster who left
+for Paris by the midnight train on the ninth of November was poor
+Basil, and the French police declare that Basil never arrived in Paris
+at all.  I suppose in about a fortnight we shall be told that he has
+been seen in San Francisco.  It is an odd thing, but every one who
+disappears is said to be seen at San Francisco.  It must be a
+delightful city, and possess all the attractions of the next world."
+
+"What do you think has happened to Basil?" asked Dorian, holding up his
+Burgundy against the light and wondering how it was that he could
+discuss the matter so calmly.
+
+"I have not the slightest idea.  If Basil chooses to hide himself, it
+is no business of mine.  If he is dead, I don't want to think about
+him.  Death is the only thing that ever terrifies me.  I hate it."
+
+"Why?" said the younger man wearily.
+
+"Because," said Lord Henry, passing beneath his nostrils the gilt
+trellis of an open vinaigrette box, "one can survive everything
+nowadays except that.  Death and vulgarity are the only two facts in
+the nineteenth century that one cannot explain away.  Let us have our
+coffee in the music-room, Dorian.  You must play Chopin to me.  The man
+with whom my wife ran away played Chopin exquisitely.  Poor Victoria!
+I was very fond of her.  The house is rather lonely without her.  Of
+course, married life is merely a habit, a bad habit.  But then one
+regrets the loss even of one's worst habits.  Perhaps one regrets them
+the most.  They are such an essential part of one's personality."
+
+Dorian said nothing, but rose from the table, and passing into the next
+room, sat down to the piano and let his fingers stray across the white
+and black ivory of the keys.  After the coffee had been brought in, he
+stopped, and looking over at Lord Henry, said, "Harry, did it ever
+occur to you that Basil was murdered?"
+
+Lord Henry yawned.  "Basil was very popular, and always wore a
+Waterbury watch.  Why should he have been murdered?  He was not clever
+enough to have enemies.  Of course, he had a wonderful genius for
+painting.  But a man can paint like Velasquez and yet be as dull as
+possible.  Basil was really rather dull.  He only interested me once,
+and that was when he told me, years ago, that he had a wild adoration
+for you and that you were the dominant motive of his art."
+
+"I was very fond of Basil," said Dorian with a note of sadness in his
+voice.  "But don't people say that he was murdered?"
+
+"Oh, some of the papers do.  It does not seem to me to be at all
+probable.  I know there are dreadful places in Paris, but Basil was not
+the sort of man to have gone to them.  He had no curiosity.  It was his
+chief defect."
+
+"What would you say, Harry, if I told you that I had murdered Basil?"
+said the younger man.  He watched him intently after he had spoken.
+
+"I would say, my dear fellow, that you were posing for a character that
+doesn't suit you.  All crime is vulgar, just as all vulgarity is crime.
+It is not in you, Dorian, to commit a murder.  I am sorry if I hurt
+your vanity by saying so, but I assure you it is true.  Crime belongs
+exclusively to the lower orders.  I don't blame them in the smallest
+degree.  I should fancy that crime was to them what art is to us,
+simply a method of procuring extraordinary sensations."
+
+"A method of procuring sensations?  Do you think, then, that a man who
+has once committed a murder could possibly do the same crime again?
+Don't tell me that."
+
+"Oh! anything becomes a pleasure if one does it too often," cried Lord
+Henry, laughing.  "That is one of the most important secrets of life.
+I should fancy, however, that murder is always a mistake.  One should
+never do anything that one cannot talk about after dinner.  But let us
+pass from poor Basil.  I wish I could believe that he had come to such
+a really romantic end as you suggest, but I can't. I dare say he fell
+into the Seine off an omnibus and that the conductor hushed up the
+scandal.  Yes:  I should fancy that was his end.  I see him lying now
+on his back under those dull-green waters, with the heavy barges
+floating over him and long weeds catching in his hair.  Do you know, I
+don't think he would have done much more good work.  During the last
+ten years his painting had gone off very much."
+
+Dorian heaved a sigh, and Lord Henry strolled across the room and began
+to stroke the head of a curious Java parrot, a large, grey-plumaged
+bird with pink crest and tail, that was balancing itself upon a bamboo
+perch.  As his pointed fingers touched it, it dropped the white scurf
+of crinkled lids over black, glasslike eyes and began to sway backwards
+and forwards.
+
+"Yes," he continued, turning round and taking his handkerchief out of
+his pocket; "his painting had quite gone off.  It seemed to me to have
+lost something.  It had lost an ideal.  When you and he ceased to be
+great friends, he ceased to be a great artist.  What was it separated
+you?  I suppose he bored you.  If so, he never forgave you.  It's a
+habit bores have.  By the way, what has become of that wonderful
+portrait he did of you?  I don't think I have ever seen it since he
+finished it.  Oh!  I remember your telling me years ago that you had
+sent it down to Selby, and that it had got mislaid or stolen on the
+way.  You never got it back?  What a pity! it was really a
+masterpiece.  I remember I wanted to buy it.  I wish I had now.  It
+belonged to Basil's best period.  Since then, his work was that curious
+mixture of bad painting and good intentions that always entitles a man
+to be called a representative British artist.  Did you advertise for
+it?  You should."
+
+"I forget," said Dorian.  "I suppose I did.  But I never really liked
+it.  I am sorry I sat for it.  The memory of the thing is hateful to
+me.  Why do you talk of it?  It used to remind me of those curious
+lines in some play--Hamlet, I think--how do they run?--
+
+    "Like the painting of a sorrow,
+     A face without a heart."
+
+Yes:  that is what it was like."
+
+Lord Henry laughed.  "If a man treats life artistically, his brain is
+his heart," he answered, sinking into an arm-chair.
+
+Dorian Gray shook his head and struck some soft chords on the piano.
+"'Like the painting of a sorrow,'" he repeated, "'a face without a
+heart.'"
+
+The elder man lay back and looked at him with half-closed eyes.  "By
+the way, Dorian," he said after a pause, "'what does it profit a man if
+he gain the whole world and lose--how does the quotation run?--his own
+soul'?"
+
+The music jarred, and Dorian Gray started and stared at his friend.
+"Why do you ask me that, Harry?"
+
+"My dear fellow," said Lord Henry, elevating his eyebrows in surprise,
+"I asked you because I thought you might be able to give me an answer.
+That is all.  I was going through the park last Sunday, and close by
+the Marble Arch there stood a little crowd of shabby-looking people
+listening to some vulgar street-preacher. As I passed by, I heard the
+man yelling out that question to his audience.  It struck me as being
+rather dramatic.  London is very rich in curious effects of that kind.
+A wet Sunday, an uncouth Christian in a mackintosh, a ring of sickly
+white faces under a broken roof of dripping umbrellas, and a wonderful
+phrase flung into the air by shrill hysterical lips--it was really very
+good in its way, quite a suggestion.  I thought of telling the prophet
+that art had a soul, but that man had not.  I am afraid, however, he
+would not have understood me."
+
+"Don't, Harry.  The soul is a terrible reality.  It can be bought, and
+sold, and bartered away.  It can be poisoned, or made perfect.  There
+is a soul in each one of us.  I know it."
+
+"Do you feel quite sure of that, Dorian?"
+
+"Quite sure."
+
+"Ah! then it must be an illusion.  The things one feels absolutely
+certain about are never true.  That is the fatality of faith, and the
+lesson of romance.  How grave you are!  Don't be so serious.  What have
+you or I to do with the superstitions of our age?  No:  we have given
+up our belief in the soul.  Play me something.  Play me a nocturne,
+Dorian, and, as you play, tell me, in a low voice, how you have kept
+your youth.  You must have some secret.  I am only ten years older than
+you are, and I am wrinkled, and worn, and yellow.  You are really
+wonderful, Dorian.  You have never looked more charming than you do
+to-night. You remind me of the day I saw you first.  You were rather
+cheeky, very shy, and absolutely extraordinary.  You have changed, of
+course, but not in appearance.  I wish you would tell me your secret.
+To get back my youth I would do anything in the world, except take
+exercise, get up early, or be respectable.  Youth!  There is nothing
+like it.  It's absurd to talk of the ignorance of youth.  The only
+people to whose opinions I listen now with any respect are people much
+younger than myself.  They seem in front of me.  Life has revealed to
+them her latest wonder.  As for the aged, I always contradict the aged.
+I do it on principle.  If you ask them their opinion on something that
+happened yesterday, they solemnly give you the opinions current in
+1820, when people wore high stocks, believed in everything, and knew
+absolutely nothing.  How lovely that thing you are playing is!  I
+wonder, did Chopin write it at Majorca, with the sea weeping round the
+villa and the salt spray dashing against the panes?  It is marvellously
+romantic.  What a blessing it is that there is one art left to us that
+is not imitative!  Don't stop.  I want music to-night. It seems to me
+that you are the young Apollo and that I am Marsyas listening to you.
+I have sorrows, Dorian, of my own, that even you know nothing of.  The
+tragedy of old age is not that one is old, but that one is young.  I am
+amazed sometimes at my own sincerity.  Ah, Dorian, how happy you are!
+What an exquisite life you have had!  You have drunk deeply of
+everything.  You have crushed the grapes against your palate.  Nothing
+has been hidden from you.  And it has all been to you no more than the
+sound of music.  It has not marred you.  You are still the same."
+
+"I am not the same, Harry."
+
+"Yes, you are the same.  I wonder what the rest of your life will be.
+Don't spoil it by renunciations.  At present you are a perfect type.
+Don't make yourself incomplete.  You are quite flawless now.  You need
+not shake your head:  you know you are.  Besides, Dorian, don't deceive
+yourself.  Life is not governed by will or intention.  Life is a
+question of nerves, and fibres, and slowly built-up cells in which
+thought hides itself and passion has its dreams.  You may fancy
+yourself safe and think yourself strong.  But a chance tone of colour
+in a room or a morning sky, a particular perfume that you had once
+loved and that brings subtle memories with it, a line from a forgotten
+poem that you had come across again, a cadence from a piece of music
+that you had ceased to play--I tell you, Dorian, that it is on things
+like these that our lives depend.  Browning writes about that
+somewhere; but our own senses will imagine them for us.  There are
+moments when the odour of _lilas blanc_ passes suddenly across me, and I
+have to live the strangest month of my life over again.  I wish I could
+change places with you, Dorian.  The world has cried out against us
+both, but it has always worshipped you.  It always will worship you.
+You are the type of what the age is searching for, and what it is
+afraid it has found.  I am so glad that you have never done anything,
+never carved a statue, or painted a picture, or produced anything
+outside of yourself!  Life has been your art.  You have set yourself to
+music.  Your days are your sonnets."
+
+Dorian rose up from the piano and passed his hand through his hair.
+"Yes, life has been exquisite," he murmured, "but I am not going to
+have the same life, Harry.  And you must not say these extravagant
+things to me.  You don't know everything about me.  I think that if you
+did, even you would turn from me.  You laugh.  Don't laugh."
+
+"Why have you stopped playing, Dorian?  Go back and give me the
+nocturne over again.  Look at that great, honey-coloured moon that
+hangs in the dusky air.  She is waiting for you to charm her, and if
+you play she will come closer to the earth.  You won't?  Let us go to
+the club, then.  It has been a charming evening, and we must end it
+charmingly.  There is some one at White's who wants immensely to know
+you--young Lord Poole, Bournemouth's eldest son.  He has already copied
+your neckties, and has begged me to introduce him to you.  He is quite
+delightful and rather reminds me of you."
+
+"I hope not," said Dorian with a sad look in his eyes.  "But I am tired
+to-night, Harry.  I shan't go to the club.  It is nearly eleven, and I
+want to go to bed early."
+
+"Do stay.  You have never played so well as to-night. There was
+something in your touch that was wonderful.  It had more expression
+than I had ever heard from it before."
+
+"It is because I am going to be good," he answered, smiling.  "I am a
+little changed already."
+
+"You cannot change to me, Dorian," said Lord Henry.  "You and I will
+always be friends."
+
+"Yet you poisoned me with a book once.  I should not forgive that.
+Harry, promise me that you will never lend that book to any one.  It
+does harm."
+
+"My dear boy, you are really beginning to moralize.  You will soon be
+going about like the converted, and the revivalist, warning people
+against all the sins of which you have grown tired.  You are much too
+delightful to do that.  Besides, it is no use.  You and I are what we
+are, and will be what we will be.  As for being poisoned by a book,
+there is no such thing as that.  Art has no influence upon action.  It
+annihilates the desire to act.  It is superbly sterile.  The books that
+the world calls immoral are books that show the world its own shame.
+That is all.  But we won't discuss literature.  Come round to-morrow. I
+am going to ride at eleven.  We might go together, and I will take you
+to lunch afterwards with Lady Branksome.  She is a charming woman, and
+wants to consult you about some tapestries she is thinking of buying.
+Mind you come.  Or shall we lunch with our little duchess?  She says
+she never sees you now.  Perhaps you are tired of Gladys?  I thought
+you would be.  Her clever tongue gets on one's nerves.  Well, in any
+case, be here at eleven."
+
+"Must I really come, Harry?"
+
+"Certainly.  The park is quite lovely now.  I don't think there have
+been such lilacs since the year I met you."
+
+"Very well.  I shall be here at eleven," said Dorian.  "Good night,
+Harry."  As he reached the door, he hesitated for a moment, as if he
+had something more to say.  Then he sighed and went out.
+
+
+
+CHAPTER 20
+
+It was a lovely night, so warm that he threw his coat over his arm and
+did not even put his silk scarf round his throat.  As he strolled home,
+smoking his cigarette, two young men in evening dress passed him.  He
+heard one of them whisper to the other, "That is Dorian Gray." He
+remembered how pleased he used to be when he was pointed out, or stared
+at, or talked about.  He was tired of hearing his own name now.  Half
+the charm of the little village where he had been so often lately was
+that no one knew who he was.  He had often told the girl whom he had
+lured to love him that he was poor, and she had believed him.  He had
+told her once that he was wicked, and she had laughed at him and
+answered that wicked people were always very old and very ugly.  What a
+laugh she had!--just like a thrush singing.  And how pretty she had
+been in her cotton dresses and her large hats!  She knew nothing, but
+she had everything that he had lost.
+
+When he reached home, he found his servant waiting up for him.  He sent
+him to bed, and threw himself down on the sofa in the library, and
+began to think over some of the things that Lord Henry had said to him.
+
+Was it really true that one could never change?  He felt a wild longing
+for the unstained purity of his boyhood--his rose-white boyhood, as
+Lord Henry had once called it.  He knew that he had tarnished himself,
+filled his mind with corruption and given horror to his fancy; that he
+had been an evil influence to others, and had experienced a terrible
+joy in being so; and that of the lives that had crossed his own, it had
+been the fairest and the most full of promise that he had brought to
+shame.  But was it all irretrievable?  Was there no hope for him?
+
+Ah! in what a monstrous moment of pride and passion he had prayed that
+the portrait should bear the burden of his days, and he keep the
+unsullied splendour of eternal youth!  All his failure had been due to
+that.  Better for him that each sin of his life had brought its sure
+swift penalty along with it.  There was purification in punishment.
+Not "Forgive us our sins" but "Smite us for our iniquities" should be
+the prayer of man to a most just God.
+
+The curiously carved mirror that Lord Henry had given to him, so many
+years ago now, was standing on the table, and the white-limbed Cupids
+laughed round it as of old.  He took it up, as he had done on that
+night of horror when he had first noted the change in the fatal
+picture, and with wild, tear-dimmed eyes looked into its polished
+shield.  Once, some one who had terribly loved him had written to him a
+mad letter, ending with these idolatrous words: "The world is changed
+because you are made of ivory and gold.  The curves of your lips
+rewrite history."  The phrases came back to his memory, and he repeated
+them over and over to himself.  Then he loathed his own beauty, and
+flinging the mirror on the floor, crushed it into silver splinters
+beneath his heel.  It was his beauty that had ruined him, his beauty
+and the youth that he had prayed for.  But for those two things, his
+life might have been free from stain.  His beauty had been to him but a
+mask, his youth but a mockery.  What was youth at best?  A green, an
+unripe time, a time of shallow moods, and sickly thoughts.  Why had he
+worn its livery?  Youth had spoiled him.
+
+It was better not to think of the past.  Nothing could alter that.  It
+was of himself, and of his own future, that he had to think.  James
+Vane was hidden in a nameless grave in Selby churchyard.  Alan Campbell
+had shot himself one night in his laboratory, but had not revealed the
+secret that he had been forced to know.  The excitement, such as it
+was, over Basil Hallward's disappearance would soon pass away.  It was
+already waning.  He was perfectly safe there.  Nor, indeed, was it the
+death of Basil Hallward that weighed most upon his mind.  It was the
+living death of his own soul that troubled him.  Basil had painted the
+portrait that had marred his life.  He could not forgive him that.  It
+was the portrait that had done everything.  Basil had said things to
+him that were unbearable, and that he had yet borne with patience.  The
+murder had been simply the madness of a moment.  As for Alan Campbell,
+his suicide had been his own act.  He had chosen to do it.  It was
+nothing to him.
+
+A new life!  That was what he wanted.  That was what he was waiting
+for.  Surely he had begun it already.  He had spared one innocent
+thing, at any rate.  He would never again tempt innocence.  He would be
+good.
+
+As he thought of Hetty Merton, he began to wonder if the portrait in
+the locked room had changed.  Surely it was not still so horrible as it
+had been?  Perhaps if his life became pure, he would be able to expel
+every sign of evil passion from the face.  Perhaps the signs of evil
+had already gone away.  He would go and look.
+
+He took the lamp from the table and crept upstairs.  As he unbarred the
+door, a smile of joy flitted across his strangely young-looking face
+and lingered for a moment about his lips.  Yes, he would be good, and
+the hideous thing that he had hidden away would no longer be a terror
+to him.  He felt as if the load had been lifted from him already.
+
+He went in quietly, locking the door behind him, as was his custom, and
+dragged the purple hanging from the portrait.  A cry of pain and
+indignation broke from him.  He could see no change, save that in the
+eyes there was a look of cunning and in the mouth the curved wrinkle of
+the hypocrite.  The thing was still loathsome--more loathsome, if
+possible, than before--and the scarlet dew that spotted the hand seemed
+brighter, and more like blood newly spilled.  Then he trembled.  Had it
+been merely vanity that had made him do his one good deed?  Or the
+desire for a new sensation, as Lord Henry had hinted, with his mocking
+laugh?  Or that passion to act a part that sometimes makes us do things
+finer than we are ourselves?  Or, perhaps, all these?  And why was the
+red stain larger than it had been?  It seemed to have crept like a
+horrible disease over the wrinkled fingers.  There was blood on the
+painted feet, as though the thing had dripped--blood even on the hand
+that had not held the knife.  Confess?  Did it mean that he was to
+confess?  To give himself up and be put to death?  He laughed.  He felt
+that the idea was monstrous.  Besides, even if he did confess, who
+would believe him?  There was no trace of the murdered man anywhere.
+Everything belonging to him had been destroyed.  He himself had burned
+what had been below-stairs. The world would simply say that he was mad.
+They would shut him up if he persisted in his story.... Yet it was
+his duty to confess, to suffer public shame, and to make public
+atonement.  There was a God who called upon men to tell their sins to
+earth as well as to heaven.  Nothing that he could do would cleanse him
+till he had told his own sin.  His sin?  He shrugged his shoulders.
+The death of Basil Hallward seemed very little to him.  He was thinking
+of Hetty Merton.  For it was an unjust mirror, this mirror of his soul
+that he was looking at.  Vanity?  Curiosity?  Hypocrisy?  Had there
+been nothing more in his renunciation than that?  There had been
+something more.  At least he thought so.  But who could tell? ... No.
+There had been nothing more.  Through vanity he had spared her.  In
+hypocrisy he had worn the mask of goodness.  For curiosity's sake he
+had tried the denial of self.  He recognized that now.
+
+But this murder--was it to dog him all his life?  Was he always to be
+burdened by his past?  Was he really to confess?  Never.  There was
+only one bit of evidence left against him.  The picture itself--that
+was evidence.  He would destroy it.  Why had he kept it so long?  Once
+it had given him pleasure to watch it changing and growing old.  Of
+late he had felt no such pleasure.  It had kept him awake at night.
+When he had been away, he had been filled with terror lest other eyes
+should look upon it.  It had brought melancholy across his passions.
+Its mere memory had marred many moments of joy.  It had been like
+conscience to him.  Yes, it had been conscience.  He would destroy it.
+
+He looked round and saw the knife that had stabbed Basil Hallward.  He
+had cleaned it many times, till there was no stain left upon it.  It
+was bright, and glistened.  As it had killed the painter, so it would
+kill the painter's work, and all that that meant.  It would kill the
+past, and when that was dead, he would be free.  It would kill this
+monstrous soul-life, and without its hideous warnings, he would be at
+peace.  He seized the thing, and stabbed the picture with it.
+
+There was a cry heard, and a crash.  The cry was so horrible in its
+agony that the frightened servants woke and crept out of their rooms.
+Two gentlemen, who were passing in the square below, stopped and looked
+up at the great house.  They walked on till they met a policeman and
+brought him back.  The man rang the bell several times, but there was
+no answer.  Except for a light in one of the top windows, the house was
+all dark.  After a time, he went away and stood in an adjoining portico
+and watched.
+
+"Whose house is that, Constable?" asked the elder of the two gentlemen.
+
+"Mr. Dorian Gray's, sir," answered the policeman.
+
+They looked at each other, as they walked away, and sneered.  One of
+them was Sir Henry Ashton's uncle.
+
+Inside, in the servants' part of the house, the half-clad domestics
+were talking in low whispers to each other.  Old Mrs. Leaf was crying
+and wringing her hands.  Francis was as pale as death.
+
+After about a quarter of an hour, he got the coachman and one of the
+footmen and crept upstairs.  They knocked, but there was no reply.
+They called out.  Everything was still.  Finally, after vainly trying
+to force the door, they got on the roof and dropped down on to the
+balcony.  The windows yielded easily--their bolts were old.
+
+When they entered, they found hanging upon the wall a splendid portrait
+of their master as they had last seen him, in all the wonder of his
+exquisite youth and beauty.  Lying on the floor was a dead man, in
+evening dress, with a knife in his heart.  He was withered, wrinkled,
+and loathsome of visage.  It was not till they had examined the rings
+that they recognized who it was.
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's The Picture of Dorian Gray, by Oscar Wilde
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+***** This file should be named 174.txt or 174.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/174/
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/edgar-allan-poe-works-1.txt
+++ b/jet/hadoop/src/main/resources/books/edgar-allan-poe-works-1.txt
@@ -1,0 +1,9226 @@
+﻿Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Works of Edgar Allan Poe
+       Volume 1 (of 5) of the Raven Edition
+
+Author: Edgar Allan Poe
+
+Release Date: May 19, 2008 [EBook #2147]
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+
+
+
+Produced by David Widger and Carlo Traverso
+
+
+
+
+
+
+
+
+THE WORKS OF EDGAR ALLAN POE
+
+IN FIVE VOLUMES
+
+
+The Raven Edition
+
+
+
+
+VOLUME I
+
+
+Contents:
+
+     Edgar Allan Poe, An Appreciation
+     Life of Poe, by James Russell Lowell
+     Death of Poe, by N. P. Willis
+     The Unparalleled Adventures of One Hans Pfaall
+     The Gold-Bug
+     Four Beasts in One
+     The Murders in the Rue Morgue
+     The Mystery of Marie Rogêt
+     The Balloon-Hoax
+     MS. Found in a Bottle
+     The Oval Portrait
+
+
+
+
+EDGAR ALLAN POE
+
+AN APPRECIATION
+
+
+   Caught from some unhappy master whom unmerciful Disaster
+   Followed fast and followed faster till his songs one burden bore--
+   Till the dirges of his Hope that melancholy burden bore
+         Of “never--never more!”
+
+THIS stanza from “The Raven” was recommended by James Russell Lowell as
+an inscription upon the Baltimore monument which marks the resting place
+of Edgar Allan Poe, the most interesting and original figure in American
+letters. And, to signify that peculiar musical quality of Poe’s genius
+which inthralls every reader, Mr. Lowell suggested this additional
+verse, from the “Haunted Palace”:
+
+   And all with pearl and ruby glowing
+    Was the fair palace door,
+   Through which came flowing, flowing, flowing,
+    And sparkling ever more,
+   A troop of Echoes, whose sweet duty
+    Was but to sing,
+   In voices of surpassing beauty,
+    The wit and wisdom of their king.
+
+
+Born in poverty at Boston, January 19, 1809, dying under painful
+circumstances at Baltimore, October 7, 1849, his whole literary career
+of scarcely fifteen years a pitiful struggle for mere subsistence, his
+memory malignantly misrepresented by his earliest biographer, Griswold,
+how completely has truth at last routed falsehood and how magnificently
+has Poe come into his own. For “The Raven,” first published in 1845,
+and, within a few months, read, recited and parodied wherever the
+English language was spoken, the half-starved poet received $10! Less
+than a year later his brother poet, N. P. Willis, issued this touching
+appeal to the admirers of genius on behalf of the neglected author, his
+dying wife and her devoted mother, then living under very straitened
+circumstances in a little cottage at Fordham, N. Y.:
+
+“Here is one of the finest scholars, one of the most original men of
+genius, and one of the most industrious of the literary profession of
+our country, whose temporary suspension of labor, from bodily illness,
+drops him immediately to a level with the common objects of public
+charity. There is no intermediate stopping-place, no respectful shelter,
+where, with the delicacy due to genius and culture, he might secure
+aid, till, with returning health, he would resume his labors, and his
+unmortified sense of independence.”
+
+And this was the tribute paid by the American public to the master who
+had given to it such tales of conjuring charm, of witchery and mystery
+as “The Fall of the House of Usher” and “Ligeia”; such fascinating
+hoaxes as “The Unparalleled Adventure of Hans Pfaall,” “MSS. Found in a
+Bottle,” “A Descent Into a Maelstrom” and “The Balloon-Hoax”; such tales
+of conscience as “William Wilson,” “The Black Cat” and “The Tell-tale
+Heart,” wherein the retributions of remorse are portrayed with an awful
+fidelity; such tales of natural beauty as “The Island of the Fay” and
+“The Domain of Arnheim”; such marvellous studies in ratiocination as the
+“Gold-bug,” “The Murders in the Rue Morgue,” “The Purloined Letter”
+ and “The Mystery of Marie Roget,” the latter, a recital of fact,
+demonstrating the author’s wonderful capability of correctly analyzing
+the mysteries of the human mind; such tales of illusion and banter
+as “The Premature Burial” and “The System of Dr. Tarr and Professor
+Fether”; such bits of extravaganza as “The Devil in the Belfry” and “The
+Angel of the Odd”; such tales of adventure as “The Narrative of Arthur
+Gordon Pym”; such papers of keen criticism and review as won for Poe the
+enthusiastic admiration of Charles Dickens, although they made him many
+enemies among the over-puffed minor American writers so mercilessly
+exposed by him; such poems of beauty and melody as “The Bells,” “The
+Haunted Palace,” “Tamerlane,” “The City in the Sea” and “The Raven.”
+ What delight for the jaded senses of the reader is this enchanted domain
+of wonder-pieces! What an atmosphere of beauty, music, color! What
+resources of imagination, construction, analysis and absolute art! One
+might almost sympathize with Sarah Helen Whitman, who, confessing to
+a half faith in the old superstition of the significance of anagrams,
+found, in the transposed letters of Edgar Poe’s name, the words “a
+God-peer.” His mind, she says, was indeed a “Haunted Palace,” echoing to
+the footfalls of angels and demons.
+
+“No man,” Poe himself wrote, “has recorded, no man has dared to record,
+the wonders of his inner life.”
+
+In these twentieth century days--of lavish recognition--artistic,
+popular and material--of genius, what rewards might not a Poe claim!
+
+Edgar’s father, a son of General David Poe, the American revolutionary
+patriot and friend of Lafayette, had married Mrs. Hopkins, an English
+actress, and, the match meeting with parental disapproval, had himself
+taken to the stage as a profession. Notwithstanding Mrs. Poe’s beauty
+and talent the young couple had a sorry struggle for existence. When
+Edgar, at the age of two years, was orphaned, the family was in the
+utmost destitution. Apparently the future poet was to be cast upon the
+world homeless and friendless. But fate decreed that a few glimmers of
+sunshine were to illumine his life, for the little fellow was adopted
+by John Allan, a wealthy merchant of Richmond, Va. A brother and sister,
+the remaining children, were cared for by others.
+
+In his new home Edgar found all the luxury and advantages money could
+provide. He was petted, spoiled and shown off to strangers. In Mrs.
+Allan he found all the affection a childless wife could bestow. Mr.
+Allan took much pride in the captivating, precocious lad. At the age of
+five the boy recited, with fine effect, passages of English poetry to
+the visitors at the Allan house.
+
+From his eighth to his thirteenth year he attended the Manor House
+school, at Stoke-Newington, a suburb of London. It was the Rev. Dr.
+Bransby, head of the school, whom Poe so quaintly portrayed in “William
+Wilson.” Returning to Richmond in 1820 Edgar was sent to the school
+of Professor Joseph H. Clarke. He proved an apt pupil. Years afterward
+Professor Clarke thus wrote:
+
+“While the other boys wrote mere mechanical verses, Poe wrote genuine
+poetry; the boy was a born poet. As a scholar he was ambitious to
+excel. He was remarkable for self-respect, without haughtiness. He had
+a sensitive and tender heart and would do anything for a friend. His
+nature was entirely free from selfishness.”
+
+At the age of seventeen Poe entered the University of Virginia at
+Charlottesville. He left that institution after one session. Official
+records prove that he was not expelled. On the contrary, he gained
+a creditable record as a student, although it is admitted that he
+contracted debts and had “an ungovernable passion for card-playing.”
+ These debts may have led to his quarrel with Mr. Allan which eventually
+compelled him to make his own way in the world.
+
+Early in 1827 Poe made his first literary venture. He induced Calvin
+Thomas, a poor and youthful printer, to publish a small volume of his
+verses under the title “Tamerlane and Other Poems.” In 1829 we find Poe
+in Baltimore with another manuscript volume of verses, which was soon
+published. Its title was “Al Aaraaf, Tamerlane and Other Poems.” Neither
+of these ventures seems to have attracted much attention.
+
+Soon after Mrs. Allan’s death, which occurred in 1829, Poe, through
+the aid of Mr. Allan, secured admission to the United States Military
+Academy at West Point. Any glamour which may have attached to cadet life
+in Poe’s eyes was speedily lost, for discipline at West Point was never
+so severe nor were the accommodations ever so poor. Poe’s bent was
+more and more toward literature. Life at the academy daily became
+increasingly distasteful. Soon he began to purposely neglect his studies
+and to disregard his duties, his aim being to secure his dismissal from
+the United States service. In this he succeeded. On March 7, 1831, Poe
+found himself free. Mr. Allan’s second marriage had thrown the lad on
+his own resources. His literary career was to begin.
+
+Poe’s first genuine victory was won in 1833, when he was the successful
+competitor for a prize of $100 offered by a Baltimore periodical for the
+best prose story. “A MSS. Found in a Bottle” was the winning tale. Poe
+had submitted six stories in a volume. “Our only difficulty,” says Mr.
+Latrobe, one of the judges, “was in selecting from the rich contents of
+the volume.”
+
+During the fifteen years of his literary life Poe was connected with
+various newspapers and magazines in Richmond, Philadelphia and New York.
+He was faithful, punctual, industrious, thorough. N. P. Willis, who for
+some time employed Poe as critic and sub-editor on the “Evening Mirror,”
+ wrote thus:
+
+“With the highest admiration for Poe’s genius, and a willingness to
+let it alone for more than ordinary irregularity, we were led by
+common report to expect a very capricious attention to his duties, and
+occasionally a scene of violence and difficulty. Time went on,
+however, and he was invariably punctual and industrious. We saw but
+one presentiment of the man-a quiet, patient, industrious and most
+gentlemanly person.
+
+“We heard, from one who knew him well (what should be stated in all
+mention of his lamentable irregularities), that with a single glass of
+wine his whole nature was reversed, the demon became uppermost, and,
+though none of the usual signs of intoxication were visible, his will
+was palpably insane. In this reversed character, we repeat, it was never
+our chance to meet him.”
+
+On September 22, 1835, Poe married his cousin, Virginia Clemm, in
+Baltimore. She had barely turned thirteen years, Poe himself was but
+twenty-six. He then was a resident of Richmond and a regular contributor
+to the “Southern Literary Messenger.” It was not until a year later that
+the bride and her widowed mother followed him thither.
+
+Poe’s devotion to his child-wife was one of the most beautiful features
+of his life. Many of his famous poetic productions were inspired by her
+beauty and charm. Consumption had marked her for its victim, and the
+constant efforts of husband and mother were to secure for her all the
+comfort and happiness their slender means permitted. Virginia died
+January 30, 1847, when but twenty-five years of age. A friend of the
+family pictures the death-bed scene--mother and husband trying to impart
+warmth to her by chafing her hands and her feet, while her pet cat was
+suffered to nestle upon her bosom for the sake of added warmth.
+
+These verses from “Annabel Lee,” written by Poe in 1849, the last year
+of his life, tell of his sorrow at the loss of his child-wife:
+
+     I was a child and _she_ was a child,
+      In a kingdom by the sea;
+
+     But we loved with _a _love that was more than love--
+       I and my Annabel Lee;
+
+     With a love that the winged seraphs of heaven
+      Coveted her and me.
+     And this was the reason that, long ago;
+      In this kingdom by the sea.
+     A wind blew out of a cloud, chilling
+      My beautiful Annabel Lee;
+
+     So that her high-born kinsmen came
+      And bore her away from me,
+     To shut her up in a sepulchre
+      In this kingdom by the sea,
+
+
+Poe was connected at various times and in various capacities with the
+“Southern Literary Messenger” in Richmond, Va.; “Graham’s Magazine” and
+the “Gentleman’s Magazine” in Philadelphia; the “Evening Mirror,” the
+“Broadway Journal,” and “Godey’s Lady’s Book” in New York. Everywhere
+Poe’s life was one of unremitting toil. No tales and poems were ever
+produced at a greater cost of brain and spirit.
+
+Poe’s initial salary with the “Southern Literary Messenger,” to which
+he contributed the first drafts of a number of his best-known tales,
+was $10 a week! Two years later his salary was but $600 a year. Even in
+1844, when his literary reputation was established securely, he wrote to
+a friend expressing his pleasure because a magazine to which he was to
+contribute had agreed to pay him $20 monthly for two pages of criticism.
+
+Those were discouraging times in American literature, but Poe never
+lost faith. He was finally to triumph wherever pre-eminent talents win
+admirers. His genius has had no better description than in this stanza
+from William Winter’s poem, read at the dedication exercises of the
+Actors’ Monument to Poe, May 4, 1885, in New York:
+
+     He was the voice of beauty and of woe,
+     Passion and mystery and the dread unknown;
+     Pure as the mountains of perpetual snow,
+     Cold as the icy winds that round them moan,
+     Dark as the caves wherein earth’s thunders groan,
+     Wild as the tempests of the upper sky,
+     Sweet as the faint, far-off celestial tone of angel
+         whispers, fluttering from on high,
+     And tender as love’s tear when youth and beauty die.
+
+
+In the two and a half score years that have elapsed since Poe’s death
+he has come fully into his own. For a while Griswold’s malignant
+misrepresentations colored the public estimate of Poe as man and as
+writer. But, thanks to J. H. Ingram, W. F. Gill, Eugene Didier, Sarah
+Helen Whitman and others these scandals have been dispelled and Poe is
+seen as he actually was-not as a man without failings, it is true, but
+as the finest and most original genius in American letters. As the
+years go on his fame increases. His works have been translated into
+many foreign languages. His is a household name in France and England-in
+fact, the latter nation has often uttered the reproach that Poe’s own
+country has been slow to appreciate him. But that reproach, if it ever
+was warranted, certainly is untrue.
+
+                                     W. H. R.
+
+
+
+
+EDGAR ALLAN POE
+
+By James Russell Lowell
+
+
+THE situation of American literature is anomalous. It has no centre, or,
+if it have, it is like that of the sphere of Hermes. It is divided
+into many systems, each revolving round its several suns, and often
+presenting to the rest only the faint glimmer of a milk-and-water way.
+Our capital city, unlike London or Paris, is not a great central heart
+from which life and vigor radiate to the extremities, but resembles more
+an isolated umbilicus stuck down as near as may be to the centre of the
+land, and seeming rather to tell a legend of former usefulness than to
+serve any present need. Boston, New York, Philadelphia, each has its
+literature almost more distinct than those of the different dialects
+of Germany; and the Young Queen of the West has also one of her own,
+of which some articulate rumor barely has reached us dwellers by the
+Atlantic.
+
+Perhaps there is no task more difficult than the just criticism of
+contemporary literature. It is even more grateful to give praise where
+it is needed than where it is deserved, and friendship so often seduces
+the iron stylus of justice into a vague flourish, that she writes what
+seems rather like an epitaph than a criticism. Yet if praise be given
+as an alms, we could not drop so poisonous a one into any man’s hat. The
+critic’s ink may suffer equally from too large an infusion of nutgalls
+or of sugar. But it is easier to be generous than to be just, and we
+might readily put faith in that fabulous direction to the hiding place
+of truth, did we judge from the amount of water which we usually find
+mixed with it.
+
+Remarkable experiences are usually confined to the inner life of
+imaginative men, but Mr. Poe’s biography displays a vicissitude and
+peculiarity of interest such as is rarely met with. The offspring of a
+romantic marriage, and left an orphan at an early age, he was adopted
+by Mr. Allan, a wealthy Virginian, whose barren marriage-bed seemed the
+warranty of a large estate to the young poet.
+
+Having received a classical education in England, he returned home and
+entered the University of Virginia, where, after an extravagant course,
+followed by reformation at the last extremity, he was graduated with
+the highest honors of his class. Then came a boyish attempt to join the
+fortunes of the insurgent Greeks, which ended at St. Petersburg, where
+he got into difficulties through want of a passport, from which he
+was rescued by the American consul and sent home. He now entered the
+military academy at West Point, from which he obtained a dismissal
+on hearing of the birth of a son to his adopted father, by a second
+marriage, an event which cut off his expectations as an heir. The death
+of Mr. Allan, in whose will his name was not mentioned, soon after
+relieved him of all doubt in this regard, and he committed himself at
+once to authorship for a support. Previously to this, however, he had
+published (in 1827) a small volume of poems, which soon ran through
+three editions, and excited high expectations of its author’s future
+distinction in the minds of many competent judges.
+
+That no certain augury can be drawn from a poet’s earliest lispings
+there are instances enough to prove. Shakespeare’s first poems, though
+brimful of vigor and youth and picturesqueness, give but a very faint
+promise of the directness, condensation and overflowing moral of his
+maturer works. Perhaps, however, Shakespeare is hardly a case in
+point, his “Venus and Adonis” having been published, we believe, in his
+twenty-sixth year. Milton’s Latin verses show tenderness, a fine eye for
+nature, and a delicate appreciation of classic models, but give no hint
+of the author of a new style in poetry. Pope’s youthful pieces have
+all the sing-song, wholly unrelieved by the glittering malignity
+and eloquent irreligion of his later productions. Collins’ callow
+namby-pamby died and gave no sign of the vigorous and original genius
+which he afterward displayed. We have never thought that the world lost
+more in the “marvellous boy,” Chatterton, than a very ingenious imitator
+of obscure and antiquated dulness. Where he becomes original (as it is
+called), the interest of ingenuity ceases and he becomes stupid. Kirke
+White’s promises were indorsed by the respectable name of Mr. Southey,
+but surely with no authority from Apollo. They have the merit of a
+traditional piety, which to our mind, if uttered at all, had been less
+objectionable in the retired closet of a diary, and in the sober raiment
+of prose. They do not clutch hold of the memory with the drowning
+pertinacity of Watts; neither have they the interest of his occasional
+simple, lucky beauty. Burns having fortunately been rescued by his
+humble station from the contaminating society of the “Best models,”
+ wrote well and naturally from the first. Had he been unfortunate enough
+to have had an educated taste, we should have had a series of poems from
+which, as from his letters, we could sift here and there a kernel from
+the mass of chaff. Coleridge’s youthful efforts give no promise whatever
+of that poetical genius which produced at once the wildest, tenderest,
+most original and most purely imaginative poems of modern times. Byron’s
+“Hours of Idleness” would never find a reader except from an intrepid
+and indefatigable curiosity. In Wordsworth’s first preludings there
+is but a dim foreboding of the creator of an era. From Southey’s early
+poems, a safer augury might have been drawn. They show the patient
+investigator, the close student of history, and the unwearied explorer
+of the beauties of predecessors, but they give no assurances of a man
+who should add aught to stock of household words, or to the rarer
+and more sacred delights of the fireside or the arbor. The earliest
+specimens of Shelley’s poetic mind already, also, give tokens of that
+ethereal sublimation in which the spirit seems to soar above the regions
+of words, but leaves its body, the verse, to be entombed, without hope
+of resurrection, in a mass of them. Cowley is generally instanced as a
+wonder of precocity. But his early insipidities show only a capacity
+for rhyming and for the metrical arrangement of certain conventional
+combinations of words, a capacity wholly dependent on a delicate
+physical organization, and an unhappy memory. An early poem is only
+remarkable when it displays an effort of _reason, _and the rudest verses
+in which we can trace some conception of the ends of poetry, are worth
+all the miracles of smooth juvenile versification. A school-boy, one
+would say, might acquire the regular see-saw of Pope merely by an
+association with the motion of the play-ground tilt.
+
+Mr. Poe’s early productions show that he could see through the verse to
+the spirit beneath, and that he already had a feeling that all the life
+and grace of the one must depend on and be modulated by the will of the
+other. We call them the most remarkable boyish poems that we have
+ever read. We know of none that can compare with them for maturity of
+purpose, and a nice understanding of the effects of language and metre.
+Such pieces are only valuable when they display what we can only express
+by the contradictory phrase of _innate experience. _We copy one of the
+shorter poems, written when the author was only fourteen. There is a
+little dimness in the filling up, but the grace and symmetry of the
+outline are such as few poets ever attain. There is a smack of ambrosia
+about it.
+
+     TO HELEN
+
+     Helen, thy beauty is to me
+       Like those Nicean barks of yore,
+     That gently, o’er a perfumed sea,
+       The weary, way-worn wanderer bore
+     To his own native shore.
+
+     On desperate seas long wont to roam,
+       Thy hyacinth hair, thy classic face,
+     Thy Naiad airs have brought me home
+       To the glory that was Greece
+     And the grandeur that was Rome.
+
+     Lo! in yon brilliant window-niche
+       How statue-like I see thee stand!
+     The agate lamp within thy hand,
+       Ah! Psyche, from the regions which
+     Are Holy Land!
+
+
+It is the tendency of the young poet that impresses us. Here is no
+“withering scorn,” no heart “blighted” ere it has safely got into its
+teens, none of the drawing-room sansculottism which Byron had brought
+into vogue. All is limpid and serene, with a pleasant dash of the Greek
+Helicon in it. The melody of the whole, too, is remarkable. It is not of
+that kind which can be demonstrated arithmetically upon the tips of
+the fingers. It is of that finer sort which the inner ear alone
+_can _estimate. It seems simple, like a Greek column, because of its
+perfection. In a poem named “Ligeia,” under which title he intended
+to personify the music of nature, our boy-poet gives us the following
+exquisite picture:
+
+       Ligeia! Ligeia!
+     My beautiful one,
+       Whose harshest idea
+     Will to melody run,
+       Say, is it thy will,
+     On the breezes to toss,
+       Or, capriciously still,
+     Like the lone albatross,
+       Incumbent on night,
+     As she on the air,
+       To keep watch with delight
+     On the harmony there?
+
+John Neal, himself a man of genius, and whose lyre has been too long
+capriciously silent, appreciated the high merit of these and similar
+passages, and drew a proud horoscope for their author.
+
+Mr. Poe had that indescribable something which men have agreed to call
+_genius_. No man could ever tell us precisely what it is, and yet there
+is none who is not inevitably aware of its presence and its power. Let
+talent writhe and contort itself as it may, it has no such magnetism.
+Larger of bone and sinew it may be, but the wings are wanting. Talent
+sticks fast to earth, and its most perfect works have still one foot of
+clay. Genius claims kindred with the very workings of Nature herself, so
+that a sunset shall seem like a quotation from Dante, and if Shakespeare
+be read in the very presence of the sea itself, his verses shall but
+seem nobler for the sublime criticism of ocean. Talent may make friends
+for itself, but only genius can give to its creations the divine power
+of winning love and veneration. Enthusiasm cannot cling to what itself
+is unenthusiastic, nor will he ever have disciples who has not himself
+impulsive zeal enough to be a disciple. Great wits are allied to madness
+only inasmuch as they are possessed and carried away by their demon,
+while talent keeps him, as Paracelsus did, securely prisoned in the
+pommel of his sword. To the eye of genius, the veil of the spiritual
+world is ever rent asunder that it may perceive the ministers of good
+and evil who throng continually around it. No man of mere talent ever
+flung his inkstand at the devil.
+
+When we say that Mr. Poe had genius, we do not mean to say that he has
+produced evidence of the highest. But to say that he possesses it at
+all is to say that he needs only zeal, industry, and a reverence for the
+trust reposed in him, to achieve the proudest triumphs and the greenest
+laurels. If we may believe the Longinuses and Aristotles of our
+newspapers, we have quite too many geniuses of the loftiest order to
+render a place among them at all desirable, whether for its hardness
+of attainment or its seclusion. The highest peak of our Parnassus is,
+according to these gentlemen, by far the most thickly settled portion
+of the country, a circumstance which must make it an uncomfortable
+residence for individuals of a poetical temperament, if love of
+solitude be, as immemorial tradition asserts, a necessary part of their
+idiosyncrasy.
+
+Mr. Poe has two of the prime qualities of genius, a faculty of vigorous
+yet minute analysis, and a wonderful fecundity of imagination. The first
+of these faculties is as needful to the artist in words, as a knowledge
+of anatomy is to the artist in colors or in stone. This enables him to
+conceive truly, to maintain a proper relation of parts, and to draw a
+correct outline, while the second groups, fills up and colors. Both
+of these Mr. Poe has displayed with singular distinctness in his prose
+works, the last predominating in his earlier tales, and the first in his
+later ones. In judging of the merit of an author, and assigning him his
+niche among our household gods, we have a right to regard him from
+our own point of view, and to measure him by our own standard. But,
+in estimating the amount of power displayed in his works, we must be
+governed by his own design, and placing them by the side of his own
+ideal, find how much is wanting. We differ from Mr. Poe in his opinions
+of the objects of art. He esteems that object to be the creation of
+Beauty, and perhaps it is only in the definition of that word that we
+disagree with him. But in what we shall say of his writings, we shall
+take his own standard as our guide. The temple of the god of song is
+equally accessible from every side, and there is room enough in it for
+all who bring offerings, or seek in oracle.
+
+In his tales, Mr. Poe has chosen to exhibit his power chiefly in that
+dim region which stretches from the very utmost limits of the probable
+into the weird confines of superstition and unreality. He combines in
+a very remarkable manner two faculties which are seldom found united; a
+power of influencing the mind of the reader by the impalpable shadows
+of mystery, and a minuteness of detail which does not leave a pin or
+a button unnoticed. Both are, in truth, the natural results of the
+predominating quality of his mind, to which we have before alluded,
+analysis. It is this which distinguishes the artist. His mind at once
+reaches forward to the effect to be produced. Having resolved to bring
+about certain emotions in the reader, he makes all subordinate parts
+tend strictly to the common centre. Even his mystery is mathematical
+to his own mind. To him X is a known quantity all along. In any picture
+that he paints he understands the chemical properties of all his
+colors. However vague some of his figures may seem, however formless
+the shadows, to him the outline is as clear and distinct as that of
+a geometrical diagram. For this reason Mr. Poe has no sympathy with
+Mysticism. The Mystic dwells in the mystery, is enveloped with it; it
+colors all his thoughts; it affects his optic nerve especially, and the
+commonest things get a rainbow edging from it. Mr. Poe, on the other
+hand, is a spectator _ab extra_. He analyzes, he dissects, he watches
+
+        “with an eye serene,
+     The very pulse of the machine,”
+
+
+for such it practically is to him, with wheels and cogs and piston-rods,
+all working to produce a certain end.
+
+This analyzing tendency of his mind balances the poetical, and by giving
+him the patience to be minute, enables him to throw a wonderful reality
+into his most unreal fancies. A monomania he paints with great power. He
+loves to dissect one of these cancers of the mind, and to trace all the
+subtle ramifications of its roots. In raising images of horror, also,
+he has strange success, conveying to us sometimes by a dusky hint
+some terrible _doubt _which is the secret of all horror. He leaves to
+imagination the task of finishing the picture, a task to which only she
+is competent.
+
+     “For much imaginary work was there;
+     Conceit deceitful, so compact, so kind,
+     That for Achilles’ image stood his spear
+     Grasped in an armed hand; himself behind
+     Was left unseen, save to the eye of mind.”
+
+Besides the merit of conception, Mr. Poe’s writings have also that of
+form.
+
+His style is highly finished, graceful and truly classical. It would be
+hard to find a living author who had displayed such varied powers. As an
+example of his style we would refer to one of his tales, “The House
+of Usher,” in the first volume of his “Tales of the Grotesque and
+Arabesque.” It has a singular charm for us, and we think that no one
+could read it without being strongly moved by its serene and sombre
+beauty. Had its author written nothing else, it would alone have been
+enough to stamp him as a man of genius, and the master of a classic
+style. In this tale occurs, perhaps, the most beautiful of his poems.
+
+The great masters of imagination have seldom resorted to the vague and
+the unreal as sources of effect. They have not used dread and horror
+alone, but only in combination with other qualities, as means of
+subjugating the fancies of their readers. The loftiest muse has ever a
+household and fireside charm about her. Mr. Poe’s secret lies mainly in
+the skill with which he has employed the strange fascination of mystery
+and terror. In this his success is so great and striking as to deserve
+the name of art, not artifice. We cannot call his materials the noblest
+or purest, but we must concede to him the highest merit of construction.
+
+As a critic, Mr. Poe was aesthetically deficient. Unerring in his
+analysis of dictions, metres and plots, he seemed wanting in the faculty
+of perceiving the profounder ethics of art. His criticisms are, however,
+distinguished for scientific precision and coherence of logic. They
+have the exactness, and at the same time, the coldness of mathematical
+demonstrations. Yet they stand in strikingly refreshing contrast with
+the vague generalisms and sharp personalities of the day. If deficient
+in warmth, they are also without the heat of partisanship. They are
+especially valuable as illustrating the great truth, too generally
+overlooked, that analytic power is a subordinate quality of the critic.
+
+On the whole, it may be considered certain that Mr. Poe has attained an
+individual eminence in our literature which he will keep. He has given
+proof of power and originality. He has done that which could only be
+done once with success or safety, and the imitation or repetition of
+which would produce weariness.
+
+
+
+
+DEATH OF EDGAR A. POE
+
+By N. P. Willis
+
+
+THE ancient fable of two antagonistic spirits imprisoned in one body,
+equally powerful and having the complete mastery by turns-of one man,
+that is to say, inhabited by both a devil and an angel seems to
+have been realized, if all we hear is true, in the character of the
+extraordinary man whose name we have written above. Our own impression
+of the nature of Edgar A. Poe, differs in some important degree,
+however, from that which has been generally conveyed in the notices of
+his death. Let us, before telling what we personally know of him, copy
+a graphic and highly finished portraiture, from the pen of Dr. Rufus W.
+Griswold, which appeared in a recent number of the “Tribune”:
+
+“Edgar Allen Poe is dead. He died in Baltimore on Sunday, October 7th.
+This announcement will startle many, but few will be grieved by it. The
+poet was known, personally or by reputation, in all this country; he had
+readers in England and in several of the states of Continental Europe;
+but he had few or no friends; and the regrets for his death will be
+suggested principally by the consideration that in him literary art has
+lost one of its most brilliant but erratic stars.
+
+“His conversation was at times almost supramortal in its eloquence. His
+voice was modulated with astonishing skill, and his large and variably
+expressive eyes looked repose or shot fiery tumult into theirs who
+listened, while his own face glowed, or was changeless in pallor, as his
+imagination quickened his blood or drew it back frozen to his heart. His
+imagery was from the worlds which no mortals can see but with the vision
+of genius. Suddenly starting from a proposition, exactly and sharply
+defined, in terms of utmost simplicity and clearness, he rejected the
+forms of customary logic, and by a crystalline process of accretion,
+built up his ocular demonstrations in forms of gloomiest and ghastliest
+grandeur, or in those of the most airy and delicious beauty, so minutely
+and distinctly, yet so rapidly, that the attention which was yielded
+to him was chained till it stood among his wonderful creations, till he
+himself dissolved the spell, and brought his hearers back to common
+and base existence, by vulgar fancies or exhibitions of the ignoblest
+passion.
+
+“He was at all times a dreamer dwelling in ideal realms, in heaven or
+hell, peopled with the creatures and the accidents of his brain. He
+walked the streets, in madness or melancholy, with lips moving in
+indistinct curses, or with eyes upturned in passionate prayer (never for
+himself, for he felt, or professed to feel, that he was already damned,
+but) for their happiness who at the moment were objects of his idolatry;
+or with his glances introverted to a heart gnawed with anguish, and with
+a face shrouded in gloom, he would brave the wildest storms, and all
+night, with drenched garments and arms beating the winds and rains,
+would speak as if the spirits that at such times only could be evoked by
+him from the Aidenn, close by whose portals his disturbed soul sought to
+forget the ills to which his constitution subjected him--close by the
+Aidenn where were those he loved--the Aidenn which he might never see,
+but in fitful glimpses, as its gates opened to receive the less fiery
+and more happy natures whose destiny to sin did not involve the doom of
+death.
+
+“He seemed, except when some fitful pursuit subjugated his will and
+engrossed his faculties, always to bear the memory of some controlling
+sorrow. The remarkable poem of ‘The Raven’ was probably much more nearly
+than has been supposed, even by those who were very intimate with him, a
+reflection and an echo of his own history. _He_ was that bird’s
+
+     “‘Unhappy master whom unmerciful Disaster
+     Followed fast and followed faster till his songs one burden bore--
+     Till the dirges of his Hope that melancholy burden bore
+          Of ‘Never-never more.’
+
+
+“Every genuine author in a greater or less degree leaves in his works,
+whatever their design, traces of his personal character: elements of his
+immortal being, in which the individual survives the person. While we
+read the pages of the ‘Fall of the House of Usher,’ or of ‘Mesmeric
+Revelations,’ we see in the solemn and stately gloom which invests one,
+and in the subtle metaphysical analysis of both, indications of the
+idiosyncrasies of what was most remarkable and peculiar in the author’s
+intellectual nature. But we see here only the better phases of his
+nature, only the symbols of his juster action, for his harsh experience
+had deprived him of all faith in man or woman. He had made up his mind
+upon the numberless complexities of the social world, and the whole
+system with him was an imposture. This conviction gave a direction to
+his shrewd and naturally unamiable character. Still, though he regarded
+society as composed altogether of villains, the sharpness of his
+intellect was not of that kind which enabled him to cope with villany,
+while it continually caused him by overshots to fail of the success of
+honesty. He was in many respects like Francis Vivian in Bulwer’s novel
+of ‘The Caxtons.’ Passion, in him, comprehended--many of the worst
+emotions which militate against human happiness. You could not
+contradict him, but you raised quick choler; you could not speak of
+wealth, but his cheek paled with gnawing envy. The astonishing natural
+advantages of this poor boy--his beauty, his readiness, the daring
+spirit that breathed around him like a fiery atmosphere--had raised his
+constitutional self-confidence into an arrogance that turned his
+very claims to admiration into prejudices against him. Irascible,
+envious--bad enough, but not the worst, for these salient angles were
+all varnished over with a cold, repellant cynicism, his passions vented
+themselves in sneers. There seemed to him no moral susceptibility; and,
+what was more remarkable in a proud nature, little or nothing of the
+true point of honor. He had, to a morbid excess, that, desire to rise
+which is vulgarly called ambition, but no wish for the esteem or the
+love of his species; only the hard wish to succeed-not shine, not
+serve--succeed, that he might have the right to despise a world which
+galled his self-conceit.
+
+“We have suggested the influence of his aims and vicissitudes upon his
+literature. It was more conspicuous in his later than in his
+earlier writings. Nearly all that he wrote in the last two or three
+years-including much of his best poetry-was in some sense biographical;
+in draperies of his imagination, those who had taken the trouble to
+trace his steps, could perceive, but slightly concealed, the figure of
+himself.”
+
+Apropos of the disparaging portion of the above well-written sketch, let
+us truthfully say:
+
+Some four or five years since, when editing a daily paper in this
+city, Mr. Poe was employed by us, for several months, as critic and
+sub-editor. This was our first personal acquaintance with him. He
+resided with his wife and mother at Fordham, a few miles out of town,
+but was at his desk in the office, from nine in the morning till the
+evening paper went to press. With the highest admiration for his genius,
+and a willingness to let it atone for more than ordinary irregularity,
+we were led by common report to expect a very capricious attention to
+his duties, and occasionally a scene of violence and difficulty. Time
+went on, however, and he was invariably punctual and industrious. With
+his pale, beautiful, and intellectual face, as a reminder of what genius
+was in him, it was impossible, of course, not to treat him always with
+deferential courtesy, and, to our occasional request that he would not
+probe too deep in a criticism, or that he would erase a passage colored
+too highly with his resentments against society and mankind, he readily
+and courteously assented-far more yielding than most men, we thought,
+on points so excusably sensitive. With a prospect of taking the lead in
+another periodical, he, at last, voluntarily gave up his employment
+with us, and, through all this considerable period, we had seen but
+one presentment of the man-a quiet, patient, industrious, and most
+gentlemanly person, commanding the utmost respect and good feeling by
+his unvarying deportment and ability.
+
+Residing as he did in the country, we never met Mr. Poe in hours of
+leisure; but he frequently called on us afterward at our place of
+business, and we met him often in the street-invariably the same sad
+mannered, winning and refined gentleman, such as we had always known
+him. It was by rumor only, up to the day of his death, that we knew of
+any other development of manner or character. We heard, from one who
+knew him well (what should be stated in all mention of his lamentable
+irregularities), that, with a single glass of wine, his whole nature
+was reversed, the demon became uppermost, and, though none of the
+usual signs of intoxication were visible, his will was palpably insane.
+Possessing his reasoning faculties in excited activity, at such times,
+and seeking his acquaintances with his wonted look and memory, he easily
+seemed personating only another phase of his natural character, and was
+accused, accordingly, of insulting arrogance and bad-heartedness. In
+this reversed character, we repeat, it was never our chance to see him.
+We know it from hearsay, and we mention it in connection with this sad
+infirmity of physical constitution; which puts it upon very nearly the
+ground of a temporary and almost irresponsible insanity.
+
+The arrogance, vanity, and depravity of heart, of which Mr. Poe was
+generally accused, seem to us referable altogether to this reversed
+phase of his character. Under that degree of intoxication which only
+acted upon him by demonizing his sense of truth and right, he doubtless
+said and did much that was wholly irreconcilable with his better nature;
+but, when himself, and as we knew him only, his modesty and unaffected
+humility, as to his own deservings, were a constant charm to his
+character. His letters, of which the constant application for autographs
+has taken from us, we are sorry to confess, the greater portion,
+exhibited this quality very strongly. In one of the carelessly written
+notes of which we chance still to retain possession, for instance, he
+speaks of “The Raven”--that extraordinary poem which electrified the
+world of imaginative readers, and has become the type of a school of
+poetry of its own-and, in evident earnest, attributes its success to
+the few words of commendation with which we had prefaced it in this
+paper.--It will throw light on his sane character to give a literal copy
+of the note:
+
+                                  “FORDHAM, April 20, 1849
+
+
+“My DEAR WILLIS--The poem which I inclose, and which I am so vain as to
+hope you will like, in some respects, has been just published in a paper
+for which sheer necessity compels me to write, now and then. It pays
+well as times go-but unquestionably it ought to pay ten prices; for
+whatever I send it I feel I am consigning to the tomb of the Capulets.
+The verses accompanying this, may I beg you to take out of the tomb, and
+bring them to light in the ‘Home journal?’ If you can oblige me so far
+as to copy them, I do not think it will be necessary to say ‘From the
+----, that would be too bad; and, perhaps, ‘From a late ---- paper,’
+would do.
+
+“I have not forgotten how a ‘good word in season’ from you made ‘The
+Raven,’ and made ‘Ulalume’ (which by-the-way, people have done me the
+honor of attributing to you), therefore, I would ask you (if I dared) to
+say something of these lines if they please you.
+
+                      “Truly yours ever,
+
+                        “EDGAR A. POE.”
+
+
+In double proof of his earnest disposition to do the best for himself,
+and of the trustful and grateful nature which has been denied him, we
+give another of the only three of his notes which we chance to retain:
+
+                          “FORDHAM, January 22, 1848.
+
+
+“My DEAR MR. WILLIS--I am about to make an effort at re-establishing
+myself in the literary world, and _feel _that I may depend upon your
+aid.
+
+“My general aim is to start a Magazine, to be called ‘The Stylus,’ but
+it would be useless to me, even when established, if not entirely out of
+the control of a publisher. I mean, therefore, to get up a journal which
+shall be _my own_ at all points. With this end in view, I must get a
+list of at least five hundred subscribers to begin with; nearly two
+hundred I have already. I propose, however, to go South and West,
+among my personal and literary friends--old college and West Point
+acquaintances--and see what I can do. In order to get the means of
+taking the first step, I propose to lecture at the Society Library,
+on Thursday, the 3d of February, and, that there may be no cause of
+_squabbling_, my subject shall _not be literary _at all. I have chosen a
+broad text: ‘The Universe.’
+
+“Having thus given you _the facts_ of the case, I leave all the rest
+to the suggestions of your own tact and generosity. Gratefully, _most
+gratefully,_
+
+                         _“Your friend always,_
+
+                             _“EDGAR A. POE._”
+
+
+Brief and chance-taken as these letters are, we think they sufficiently
+prove the existence of the very qualities denied to Mr. Poe-humility,
+willingness to persevere, belief in another’s friendship, and capability
+of cordial and grateful friendship! Such he assuredly was when sane.
+Such only he has invariably seemed to us, in all we have happened
+personally to know of him, through a friendship of five or six years.
+And so much easier is it to believe what we have seen and known, than
+what we hear of only, that we remember him but with admiration and
+respect; these descriptions of him, when morally insane, seeming to
+us like portraits, painted in sickness, of a man we have only known in
+health.
+
+But there is another, more touching, and far more forcible evidence that
+there was _goodness _in Edgar A. Poe. To reveal it we are obliged to
+venture upon the lifting of the veil which sacredly covers grief and
+refinement in poverty; but we think it may be excused, if so we can
+brighten the memory of the poet, even were there not a more needed and
+immediate service which it may render to the nearest link broken by his
+death.
+
+Our first knowledge of Mr. Poe’s removal to this city was by a call
+which we received from a lady who introduced herself to us as the mother
+of his wife. She was in search of employment for him, and she excused
+her errand by mentioning that he was ill, that her daughter was a
+confirmed invalid, and that their circumstances were such as compelled
+her taking it upon herself. The countenance of this lady, made beautiful
+and saintly with an evidently complete giving up of her life to
+privation and sorrowful tenderness, her gentle and mournful voice urging
+its plea, her long-forgotten but habitually and unconsciously refined
+manners, and her appealing and yet appreciative mention of the claims
+and abilities of her son, disclosed at once the presence of one of those
+angels upon earth that women in adversity can be. It was a hard fate
+that she was watching over. Mr. Poe wrote with fastidious difficulty,
+and in a style too much above the popular level to be well paid. He was
+always in pecuniary difficulty, and, with his sick wife, frequently in
+want of the merest necessaries of life. Winter after winter, for
+years, the most touching sight to us, in this whole city, has been that
+tireless minister to genius, thinly and insufficiently clad, going from
+office to office with a poem, or an article on some literary subject, to
+sell, sometimes simply pleading in a broken voice that he was ill, and
+begging for him, mentioning nothing but that “he was ill,” whatever
+might be the reason for his writing nothing, and never, amid all her
+tears and recitals of distress, suffering one syllable to escape her
+lips that could convey a doubt of him, or a complaint, or a lessening of
+pride in his genius and good intentions. Her daughter died a year and
+a half since, but she did not desert him. She continued his ministering
+angel--living with him, caring for him, guarding him against exposure,
+and when he was carried away by temptation, amid grief and the
+loneliness of feelings unreplied to, and awoke from his self abandonment
+prostrated in destitution and suffering, _begging _for him still. If
+woman’s devotion, born with a first love, and fed with human passion,
+hallow its object, as it is allowed to do, what does not a devotion
+like this-pure, disinterested and holy as the watch of an invisible
+spirit-say for him who inspired it?
+
+We have a letter before us, written by this lady, Mrs. Clemm, on the
+morning in which she heard of the death of this object of her untiring
+care. It is merely a request that we would call upon her, but we will
+copy a few of its words--sacred as its privacy is--to warrant the truth
+of the picture we have drawn above, and add force to the appeal we wish
+to make for her:
+
+“I have this morning heard of the death of my darling Eddie.... Can you
+give me any circumstances or particulars?... Oh! do not desert your
+poor friend in his bitter affliction!... Ask Mr. ---- to come, as I must
+deliver a message to him from my poor Eddie.... I need not ask you to
+notice his death and to speak well of him. I know you will. But say what
+an affectionate son he was to me, his poor desolate mother...”
+
+To hedge round a grave with respect, what choice is there, between the
+relinquished wealth and honors of the world, and the story of such a
+woman’s unrewarded devotion! Risking what we do, in delicacy, by making
+it public, we feel--other reasons aside--that it betters the world to
+make known that there are such ministrations to its erring and gifted.
+What we have said will speak to some hearts. There are those who will
+be glad to know how the lamp, whose light of poetry has beamed on their
+far-away recognition, was watched over with care and pain, that they
+may send to her, who is more darkened than they by its extinction, some
+token of their sympathy. She is destitute and alone. If any, far or
+near, will send to us what may aid and cheer her through the remainder
+of her life, we will joyfully place it in her hands.
+
+
+
+
+
+THE UNPARALLELED ADVENTURES OF ONE HANS PFAALL (*1)
+
+BY late accounts from Rotterdam, that city seems to be in a high state
+of philosophical excitement. Indeed, phenomena have there occurred of
+a nature so completely unexpected--so entirely novel--so utterly at
+variance with preconceived opinions--as to leave no doubt on my mind
+that long ere this all Europe is in an uproar, all physics in a ferment,
+all reason and astronomy together by the ears.
+
+It appears that on the---- day of---- (I am not positive about the
+date), a vast crowd of people, for purposes not specifically
+mentioned, were assembled in the great square of the Exchange in the
+well-conditioned city of Rotterdam. The day was warm--unusually so for
+the season--there was hardly a breath of air stirring; and the multitude
+were in no bad humor at being now and then besprinkled with friendly
+showers of momentary duration, that fell from large white masses
+of cloud which chequered in a fitful manner the blue vault of the
+firmament. Nevertheless, about noon, a slight but remarkable agitation
+became apparent in the assembly: the clattering of ten thousand tongues
+succeeded; and, in an instant afterward, ten thousand faces were
+upturned toward the heavens, ten thousand pipes descended simultaneously
+from the corners of ten thousand mouths, and a shout, which could be
+compared to nothing but the roaring of Niagara, resounded long, loudly,
+and furiously, through all the environs of Rotterdam.
+
+The origin of this hubbub soon became sufficiently evident. From behind
+the huge bulk of one of those sharply-defined masses of cloud already
+mentioned, was seen slowly to emerge into an open area of blue space, a
+queer, heterogeneous, but apparently solid substance, so oddly shaped,
+so whimsically put together, as not to be in any manner comprehended,
+and never to be sufficiently admired, by the host of sturdy burghers who
+stood open-mouthed below. What could it be? In the name of all the vrows
+and devils in Rotterdam, what could it possibly portend? No one knew, no
+one could imagine; no one--not even the burgomaster Mynheer Superbus Von
+Underduk--had the slightest clew by which to unravel the mystery; so, as
+nothing more reasonable could be done, every one to a man replaced his
+pipe carefully in the corner of his mouth, and cocking up his right
+eye towards the phenomenon, puffed, paused, waddled about, and grunted
+significantly--then waddled back, grunted, paused, and finally--puffed
+again.
+
+In the meantime, however, lower and still lower toward the goodly city,
+came the object of so much curiosity, and the cause of so much smoke. In
+a very few minutes it arrived near enough to be accurately discerned. It
+appeared to be--yes! it was undoubtedly a species of balloon; but surely
+no such balloon had ever been seen in Rotterdam before. For who, let me
+ask, ever heard of a balloon manufactured entirely of dirty newspapers?
+No man in Holland certainly; yet here, under the very noses of the
+people, or rather at some distance above their noses was the identical
+thing in question, and composed, I have it on the best authority, of
+the precise material which no one had ever before known to be used for
+a similar purpose. It was an egregious insult to the good sense of the
+burghers of Rotterdam. As to the shape of the phenomenon, it was even
+still more reprehensible. Being little or nothing better than a huge
+foolscap turned upside down. And this similitude was regarded as by no
+means lessened when, upon nearer inspection, there was perceived a large
+tassel depending from its apex, and, around the upper rim or base of the
+cone, a circle of little instruments, resembling sheep-bells, which kept
+up a continual tinkling to the tune of Betty Martin. But still worse.
+Suspended by blue ribbons to the end of this fantastic machine,
+there hung, by way of car, an enormous drab beaver hat, with a brim
+superlatively broad, and a hemispherical crown with a black band and a
+silver buckle. It is, however, somewhat remarkable that many citizens
+of Rotterdam swore to having seen the same hat repeatedly before; and
+indeed the whole assembly seemed to regard it with eyes of familiarity;
+while the vrow Grettel Pfaall, upon sight of it, uttered an exclamation
+of joyful surprise, and declared it to be the identical hat of her good
+man himself. Now this was a circumstance the more to be observed, as
+Pfaall, with three companions, had actually disappeared from Rotterdam
+about five years before, in a very sudden and unaccountable manner, and
+up to the date of this narrative all attempts had failed of obtaining
+any intelligence concerning them whatsoever. To be sure, some bones
+which were thought to be human, mixed up with a quantity of odd-looking
+rubbish, had been lately discovered in a retired situation to the east
+of Rotterdam, and some people went so far as to imagine that in this
+spot a foul murder had been committed, and that the sufferers were in
+all probability Hans Pfaall and his associates. But to return.
+
+The balloon (for such no doubt it was) had now descended to within
+a hundred feet of the earth, allowing the crowd below a sufficiently
+distinct view of the person of its occupant. This was in truth a very
+droll little somebody. He could not have been more than two feet in
+height; but this altitude, little as it was, would have been sufficient
+to destroy his equilibrium, and tilt him over the edge of his tiny
+car, but for the intervention of a circular rim reaching as high as
+the breast, and rigged on to the cords of the balloon. The body of the
+little man was more than proportionately broad, giving to his entire
+figure a rotundity highly absurd. His feet, of course, could not be seen
+at all, although a horny substance of suspicious nature was occasionally
+protruded through a rent in the bottom of the car, or to speak more
+properly, in the top of the hat. His hands were enormously large. His
+hair was extremely gray, and collected in a cue behind. His nose was
+prodigiously long, crooked, and inflammatory; his eyes full, brilliant,
+and acute; his chin and cheeks, although wrinkled with age, were broad,
+puffy, and double; but of ears of any kind or character there was not a
+semblance to be discovered upon any portion of his head. This odd little
+gentleman was dressed in a loose surtout of sky-blue satin, with tight
+breeches to match, fastened with silver buckles at the knees. His vest
+was of some bright yellow material; a white taffety cap was set jauntily
+on one side of his head; and, to complete his equipment, a blood-red
+silk handkerchief enveloped his throat, and fell down, in a dainty
+manner, upon his bosom, in a fantastic bow-knot of super-eminent
+dimensions.
+
+Having descended, as I said before, to about one hundred feet from the
+surface of the earth, the little old gentleman was suddenly seized
+with a fit of trepidation, and appeared disinclined to make any nearer
+approach to terra firma. Throwing out, therefore, a quantity of sand
+from a canvas bag, which, he lifted with great difficulty, he became
+stationary in an instant. He then proceeded, in a hurried and agitated
+manner, to extract from a side-pocket in his surtout a large morocco
+pocket-book. This he poised suspiciously in his hand, then eyed it with
+an air of extreme surprise, and was evidently astonished at its weight.
+He at length opened it, and drawing there from a huge letter sealed with
+red sealing-wax and tied carefully with red tape, let it fall precisely
+at the feet of the burgomaster, Superbus Von Underduk. His Excellency
+stooped to take it up. But the aeronaut, still greatly discomposed, and
+having apparently no farther business to detain him in Rotterdam, began
+at this moment to make busy preparations for departure; and it being
+necessary to discharge a portion of ballast to enable him to reascend,
+the half dozen bags which he threw out, one after another, without
+taking the trouble to empty their contents, tumbled, every one of them,
+most unfortunately upon the back of the burgomaster, and rolled him over
+and over no less than one-and-twenty times, in the face of every man in
+Rotterdam. It is not to be supposed, however, that the great Underduk
+suffered this impertinence on the part of the little old man to pass off
+with impunity. It is said, on the contrary, that during each and every
+one of his one-and twenty circumvolutions he emitted no less than
+one-and-twenty distinct and furious whiffs from his pipe, to which he
+held fast the whole time with all his might, and to which he intends
+holding fast until the day of his death.
+
+In the meantime the balloon arose like a lark, and, soaring far away
+above the city, at length drifted quietly behind a cloud similar to that
+from which it had so oddly emerged, and was thus lost forever to the
+wondering eyes of the good citizens of Rotterdam. All attention was
+now directed to the letter, the descent of which, and the consequences
+attending thereupon, had proved so fatally subversive of both person and
+personal dignity to his Excellency, the illustrious Burgomaster Mynheer
+Superbus Von Underduk. That functionary, however, had not failed, during
+his circumgyratory movements, to bestow a thought upon the important
+subject of securing the packet in question, which was seen, upon
+inspection, to have fallen into the most proper hands, being actually
+addressed to himself and Professor Rub-a-dub, in their official
+capacities of President and Vice-President of the Rotterdam College of
+Astronomy. It was accordingly opened by those dignitaries upon the
+spot, and found to contain the following extraordinary, and indeed very
+serious, communications.
+
+To their Excellencies Von Underduk and Rub-a-dub, President and
+Vice-President of the States’ College of Astronomers, in the city of
+Rotterdam.
+
+“Your Excellencies may perhaps be able to remember an humble artizan, by
+name Hans Pfaall, and by occupation a mender of bellows, who, with three
+others, disappeared from Rotterdam, about five years ago, in a manner
+which must have been considered by all parties at once sudden, and
+extremely unaccountable. If, however, it so please your Excellencies, I,
+the writer of this communication, am the identical Hans Pfaall himself.
+It is well known to most of my fellow citizens, that for the period of
+forty years I continued to occupy the little square brick building, at
+the head of the alley called Sauerkraut, in which I resided at the time
+of my disappearance. My ancestors have also resided therein time out of
+mind--they, as well as myself, steadily following the respectable and
+indeed lucrative profession of mending of bellows. For, to speak the
+truth, until of late years, that the heads of all the people have been
+set agog with politics, no better business than my own could an
+honest citizen of Rotterdam either desire or deserve. Credit was good,
+employment was never wanting, and on all hands there was no lack of
+either money or good-will. But, as I was saying, we soon began to feel
+the effects of liberty and long speeches, and radicalism, and all that
+sort of thing. People who were formerly, the very best customers in the
+world, had now not a moment of time to think of us at all. They had, so
+they said, as much as they could do to read about the revolutions, and
+keep up with the march of intellect and the spirit of the age. If a fire
+wanted fanning, it could readily be fanned with a newspaper, and as the
+government grew weaker, I have no doubt that leather and iron acquired
+durability in proportion, for, in a very short time, there was not a
+pair of bellows in all Rotterdam that ever stood in need of a stitch or
+required the assistance of a hammer. This was a state of things not
+to be endured. I soon grew as poor as a rat, and, having a wife and
+children to provide for, my burdens at length became intolerable, and I
+spent hour after hour in reflecting upon the most convenient method of
+putting an end to my life. Duns, in the meantime, left me little leisure
+for contemplation. My house was literally besieged from morning till
+night, so that I began to rave, and foam, and fret like a caged
+tiger against the bars of his enclosure. There were three fellows in
+particular who worried me beyond endurance, keeping watch continually
+about my door, and threatening me with the law. Upon these three I
+internally vowed the bitterest revenge, if ever I should be so happy as
+to get them within my clutches; and I believe nothing in the world but
+the pleasure of this anticipation prevented me from putting my plan
+of suicide into immediate execution, by blowing my brains out with a
+blunderbuss. I thought it best, however, to dissemble my wrath, and to
+treat them with promises and fair words, until, by some good turn of
+fate, an opportunity of vengeance should be afforded me.
+
+“One day, having given my creditors the slip, and feeling more than
+usually dejected, I continued for a long time to wander about the most
+obscure streets without object whatever, until at length I chanced to
+stumble against the corner of a bookseller’s stall. Seeing a chair close
+at hand, for the use of customers, I threw myself doggedly into it,
+and, hardly knowing why, opened the pages of the first volume which
+came within my reach. It proved to be a small pamphlet treatise on
+Speculative Astronomy, written either by Professor Encke of Berlin or
+by a Frenchman of somewhat similar name. I had some little tincture of
+information on matters of this nature, and soon became more and more
+absorbed in the contents of the book, reading it actually through twice
+before I awoke to a recollection of what was passing around me. By this
+time it began to grow dark, and I directed my steps toward home. But
+the treatise had made an indelible impression on my mind, and, as I
+sauntered along the dusky streets, I revolved carefully over in my
+memory the wild and sometimes unintelligible reasonings of the writer.
+There are some particular passages which affected my imagination in a
+powerful and extraordinary manner. The longer I meditated upon these
+the more intense grew the interest which had been excited within me.
+The limited nature of my education in general, and more especially my
+ignorance on subjects connected with natural philosophy, so far from
+rendering me diffident of my own ability to comprehend what I had read,
+or inducing me to mistrust the many vague notions which had arisen in
+consequence, merely served as a farther stimulus to imagination; and I
+was vain enough, or perhaps reasonable enough, to doubt whether
+those crude ideas which, arising in ill-regulated minds, have all the
+appearance, may not often in effect possess all the force, the reality,
+and other inherent properties, of instinct or intuition; whether, to
+proceed a step farther, profundity itself might not, in matters of a
+purely speculative nature, be detected as a legitimate source of falsity
+and error. In other words, I believed, and still do believe, that truth,
+is frequently of its own essence, superficial, and that, in many cases,
+the depth lies more in the abysses where we seek her, than in the actual
+situations wherein she may be found. Nature herself seemed to afford
+me corroboration of these ideas. In the contemplation of the heavenly
+bodies it struck me forcibly that I could not distinguish a star with
+nearly as much precision, when I gazed on it with earnest, direct and
+undeviating attention, as when I suffered my eye only to glance in
+its vicinity alone. I was not, of course, at that time aware that this
+apparent paradox was occasioned by the center of the visual area being
+less susceptible of feeble impressions of light than the exterior
+portions of the retina. This knowledge, and some of another kind, came
+afterwards in the course of an eventful five years, during which I
+have dropped the prejudices of my former humble situation in life, and
+forgotten the bellows-mender in far different occupations. But at the
+epoch of which I speak, the analogy which a casual observation of a star
+offered to the conclusions I had already drawn, struck me with the force
+of positive conformation, and I then finally made up my mind to the
+course which I afterwards pursued.
+
+“It was late when I reached home, and I went immediately to bed. My
+mind, however, was too much occupied to sleep, and I lay the whole night
+buried in meditation. Arising early in the morning, and contriving
+again to escape the vigilance of my creditors, I repaired eagerly to the
+bookseller’s stall, and laid out what little ready money I possessed,
+in the purchase of some volumes of Mechanics and Practical Astronomy.
+Having arrived at home safely with these, I devoted every spare moment
+to their perusal, and soon made such proficiency in studies of this
+nature as I thought sufficient for the execution of my plan. In the
+intervals of this period, I made every endeavor to conciliate the
+three creditors who had given me so much annoyance. In this I finally
+succeeded--partly by selling enough of my household furniture to satisfy
+a moiety of their claim, and partly by a promise of paying the balance
+upon completion of a little project which I told them I had in view, and
+for assistance in which I solicited their services. By these means--for
+they were ignorant men--I found little difficulty in gaining them over
+to my purpose.
+
+“Matters being thus arranged, I contrived, by the aid of my wife and
+with the greatest secrecy and caution, to dispose of what property I had
+remaining, and to borrow, in small sums, under various pretences,
+and without paying any attention to my future means of repayment, no
+inconsiderable quantity of ready money. With the means thus accruing I
+proceeded to procure at intervals, cambric muslin, very fine, in pieces
+of twelve yards each; twine; a lot of the varnish of caoutchouc; a
+large and deep basket of wicker-work, made to order; and several other
+articles necessary in the construction and equipment of a balloon of
+extraordinary dimensions. This I directed my wife to make up as soon as
+possible, and gave her all requisite information as to the particular
+method of proceeding. In the meantime I worked up the twine into
+a net-work of sufficient dimensions; rigged it with a hoop and the
+necessary cords; bought a quadrant, a compass, a spy-glass, a common
+barometer with some important modifications, and two astronomical
+instruments not so generally known. I then took opportunities of
+conveying by night, to a retired situation east of Rotterdam, five
+iron-bound casks, to contain about fifty gallons each, and one of a
+larger size; six tinned ware tubes, three inches in diameter, properly
+shaped, and ten feet in length; a quantity of a particular metallic
+substance, or semi-metal, which I shall not name, and a dozen demijohns
+of a very common acid. The gas to be formed from these latter materials
+is a gas never yet generated by any other person than myself--or at
+least never applied to any similar purpose. The secret I would make no
+difficulty in disclosing, but that it of right belongs to a citizen of
+Nantz, in France, by whom it was conditionally communicated to myself.
+The same individual submitted to me, without being at all aware of my
+intentions, a method of constructing balloons from the membrane of a
+certain animal, through which substance any escape of gas was nearly an
+impossibility. I found it, however, altogether too expensive, and was
+not sure, upon the whole, whether cambric muslin with a coating of
+gum caoutchouc, was not equally as good. I mention this circumstance,
+because I think it probable that hereafter the individual in question
+may attempt a balloon ascension with the novel gas and material I have
+spoken of, and I do not wish to deprive him of the honor of a very
+singular invention.
+
+“On the spot which I intended each of the smaller casks to occupy
+respectively during the inflation of the balloon, I privately dug a hole
+two feet deep; the holes forming in this manner a circle twenty-five
+feet in diameter. In the centre of this circle, being the station
+designed for the large cask, I also dug a hole three feet in depth. In
+each of the five smaller holes, I deposited a canister containing
+fifty pounds, and in the larger one a keg holding one hundred and fifty
+pounds, of cannon powder. These--the keg and canisters--I connected in
+a proper manner with covered trains; and having let into one of the
+canisters the end of about four feet of slow match, I covered up the
+hole, and placed the cask over it, leaving the other end of the match
+protruding about an inch, and barely visible beyond the cask. I then
+filled up the remaining holes, and placed the barrels over them in their
+destined situation.
+
+“Besides the articles above enumerated, I conveyed to the depot, and
+there secreted, one of M. Grimm’s improvements upon the apparatus for
+condensation of the atmospheric air. I found this machine, however,
+to require considerable alteration before it could be adapted to the
+purposes to which I intended making it applicable. But, with severe
+labor and unremitting perseverance, I at length met with entire success
+in all my preparations. My balloon was soon completed. It would contain
+more than forty thousand cubic feet of gas; would take me up easily, I
+calculated, with all my implements, and, if I managed rightly, with
+one hundred and seventy-five pounds of ballast into the bargain. It
+had received three coats of varnish, and I found the cambric muslin to
+answer all the purposes of silk itself, quite as strong and a good deal
+less expensive.
+
+“Everything being now ready, I exacted from my wife an oath of secrecy
+in relation to all my actions from the day of my first visit to the
+bookseller’s stall; and promising, on my part, to return as soon as
+circumstances would permit, I gave her what little money I had left,
+and bade her farewell. Indeed I had no fear on her account. She was
+what people call a notable woman, and could manage matters in the world
+without my assistance. I believe, to tell the truth, she always looked
+upon me as an idle boy, a mere make-weight, good for nothing but
+building castles in the air, and was rather glad to get rid of me.
+It was a dark night when I bade her good-bye, and taking with me, as
+aides-de-camp, the three creditors who had given me so much trouble,
+we carried the balloon, with the car and accoutrements, by a roundabout
+way, to the station where the other articles were deposited. We there
+found them all unmolested, and I proceeded immediately to business.
+
+“It was the first of April. The night, as I said before, was dark; there
+was not a star to be seen; and a drizzling rain, falling at intervals,
+rendered us very uncomfortable. But my chief anxiety was concerning
+the balloon, which, in spite of the varnish with which it was defended,
+began to grow rather heavy with the moisture; the powder also was liable
+to damage. I therefore kept my three duns working with great diligence,
+pounding down ice around the central cask, and stirring the acid in the
+others. They did not cease, however, importuning me with questions as
+to what I intended to do with all this apparatus, and expressed much
+dissatisfaction at the terrible labor I made them undergo. They could
+not perceive, so they said, what good was likely to result from
+their getting wet to the skin, merely to take a part in such horrible
+incantations. I began to get uneasy, and worked away with all my might,
+for I verily believe the idiots supposed that I had entered into a
+compact with the devil, and that, in short, what I was now doing was
+nothing better than it should be. I was, therefore, in great fear of
+their leaving me altogether. I contrived, however, to pacify them by
+promises of payment of all scores in full, as soon as I could bring
+the present business to a termination. To these speeches they gave, of
+course, their own interpretation; fancying, no doubt, that at all events
+I should come into possession of vast quantities of ready money; and
+provided I paid them all I owed, and a trifle more, in consideration of
+their services, I dare say they cared very little what became of either
+my soul or my carcass.
+
+“In about four hours and a half I found the balloon sufficiently
+inflated. I attached the car, therefore, and put all my implements in
+it--not forgetting the condensing apparatus, a copious supply of water,
+and a large quantity of provisions, such as pemmican, in which much
+nutriment is contained in comparatively little bulk. I also secured in
+the car a pair of pigeons and a cat. It was now nearly daybreak, and I
+thought it high time to take my departure. Dropping a lighted cigar on
+the ground, as if by accident, I took the opportunity, in stooping to
+pick it up, of igniting privately the piece of slow match, whose end,
+as I said before, protruded a very little beyond the lower rim of one of
+the smaller casks. This manoeuvre was totally unperceived on the part of
+the three duns; and, jumping into the car, I immediately cut the single
+cord which held me to the earth, and was pleased to find that I shot
+upward, carrying with all ease one hundred and seventy-five pounds of
+leaden ballast, and able to have carried up as many more.
+
+“Scarcely, however, had I attained the height of fifty yards, when,
+roaring and rumbling up after me in the most horrible and tumultuous
+manner, came so dense a hurricane of fire, and smoke, and sulphur, and
+legs and arms, and gravel, and burning wood, and blazing metal, that
+my very heart sunk within me, and I fell down in the bottom of the car,
+trembling with unmitigated terror. Indeed, I now perceived that I had
+entirely overdone the business, and that the main consequences of the
+shock were yet to be experienced. Accordingly, in less than a second,
+I felt all the blood in my body rushing to my temples, and immediately
+thereupon, a concussion, which I shall never forget, burst abruptly
+through the night and seemed to rip the very firmament asunder. When
+I afterward had time for reflection, I did not fail to attribute the
+extreme violence of the explosion, as regarded myself, to its proper
+cause--my situation directly above it, and in the line of its greatest
+power. But at the time, I thought only of preserving my life. The
+balloon at first collapsed, then furiously expanded, then whirled round
+and round with horrible velocity, and finally, reeling and staggering
+like a drunken man, hurled me with great force over the rim of the car,
+and left me dangling, at a terrific height, with my head downward, and
+my face outwards, by a piece of slender cord about three feet in
+length, which hung accidentally through a crevice near the bottom of
+the wicker-work, and in which, as I fell, my left foot became most
+providentially entangled. It is impossible--utterly impossible--to form
+any adequate idea of the horror of my situation. I gasped convulsively
+for breath--a shudder resembling a fit of the ague agitated every nerve
+and muscle of my frame--I felt my eyes starting from their sockets--a
+horrible nausea overwhelmed me--and at length I fainted away.
+
+“How long I remained in this state it is impossible to say. It must,
+however, have been no inconsiderable time, for when I partially
+recovered the sense of existence, I found the day breaking, the balloon
+at a prodigious height over a wilderness of ocean, and not a trace
+of land to be discovered far and wide within the limits of the vast
+horizon. My sensations, however, upon thus recovering, were by no means
+so rife with agony as might have been anticipated. Indeed, there was
+much of incipient madness in the calm survey which I began to take of my
+situation. I drew up to my eyes each of my hands, one after the other,
+and wondered what occurrence could have given rise to the swelling of
+the veins, and the horrible blackness of the fingernails. I afterward
+carefully examined my head, shaking it repeatedly, and feeling it with
+minute attention, until I succeeded in satisfying myself that it was
+not, as I had more than half suspected, larger than my balloon. Then,
+in a knowing manner, I felt in both my breeches pockets, and, missing
+therefrom a set of tablets and a toothpick case, endeavored to account
+for their disappearance, and not being able to do so, felt inexpressibly
+chagrined. It now occurred to me that I suffered great uneasiness in the
+joint of my left ankle, and a dim consciousness of my situation began to
+glimmer through my mind. But, strange to say! I was neither astonished
+nor horror-stricken. If I felt any emotion at all, it was a kind of
+chuckling satisfaction at the cleverness I was about to display in
+extricating myself from this dilemma; and I never, for a moment, looked
+upon my ultimate safety as a question susceptible of doubt. For a few
+minutes I remained wrapped in the profoundest meditation. I have a
+distinct recollection of frequently compressing my lips, putting
+my forefinger to the side of my nose, and making use of other
+gesticulations and grimaces common to men who, at ease in their
+arm-chairs, meditate upon matters of intricacy or importance. Having,
+as I thought, sufficiently collected my ideas, I now, with great caution
+and deliberation, put my hands behind my back, and unfastened the large
+iron buckle which belonged to the waistband of my inexpressibles. This
+buckle had three teeth, which, being somewhat rusty, turned with great
+difficulty on their axis. I brought them, however, after some trouble,
+at right angles to the body of the buckle, and was glad to find them
+remain firm in that position. Holding the instrument thus obtained
+within my teeth, I now proceeded to untie the knot of my cravat. I had
+to rest several times before I could accomplish this manoeuvre, but it
+was at length accomplished. To one end of the cravat I then made fast
+the buckle, and the other end I tied, for greater security, tightly
+around my wrist. Drawing now my body upwards, with a prodigious exertion
+of muscular force, I succeeded, at the very first trial, in throwing
+the buckle over the car, and entangling it, as I had anticipated, in the
+circular rim of the wicker-work.
+
+“My body was now inclined towards the side of the car, at an angle
+of about forty-five degrees; but it must not be understood that I was
+therefore only forty-five degrees below the perpendicular. So far from
+it, I still lay nearly level with the plane of the horizon; for the
+change of situation which I had acquired, had forced the bottom of the
+car considerably outwards from my position, which was accordingly one
+of the most imminent and deadly peril. It should be remembered, however,
+that when I fell in the first instance, from the car, if I had fallen
+with my face turned toward the balloon, instead of turned outwardly from
+it, as it actually was; or if, in the second place, the cord by which
+I was suspended had chanced to hang over the upper edge, instead of
+through a crevice near the bottom of the car,--I say it may be readily
+conceived that, in either of these supposed cases, I should have been
+unable to accomplish even as much as I had now accomplished, and the
+wonderful adventures of Hans Pfaall would have been utterly lost to
+posterity, I had therefore every reason to be grateful; although, in
+point of fact, I was still too stupid to be anything at all, and hung
+for, perhaps, a quarter of an hour in that extraordinary manner, without
+making the slightest farther exertion whatsoever, and in a singularly
+tranquil state of idiotic enjoyment. But this feeling did not fail to
+die rapidly away, and thereunto succeeded horror, and dismay, and a
+chilling sense of utter helplessness and ruin. In fact, the blood so
+long accumulating in the vessels of my head and throat, and which had
+hitherto buoyed up my spirits with madness and delirium, had now begun
+to retire within their proper channels, and the distinctness which was
+thus added to my perception of the danger, merely served to deprive me
+of the self-possession and courage to encounter it. But this weakness
+was, luckily for me, of no very long duration. In good time came to my
+rescue the spirit of despair, and, with frantic cries and struggles, I
+jerked my way bodily upwards, till at length, clutching with a vise-like
+grip the long-desired rim, I writhed my person over it, and fell
+headlong and shuddering within the car.
+
+“It was not until some time afterward that I recovered myself
+sufficiently to attend to the ordinary cares of the balloon. I then,
+however, examined it with attention, and found it, to my great relief,
+uninjured. My implements were all safe, and, fortunately, I had lost
+neither ballast nor provisions. Indeed, I had so well secured them in
+their places, that such an accident was entirely out of the question.
+Looking at my watch, I found it six o’clock. I was still rapidly
+ascending, and my barometer gave a present altitude of three and
+three-quarter miles. Immediately beneath me in the ocean, lay a small
+black object, slightly oblong in shape, seemingly about the size, and
+in every way bearing a great resemblance to one of those childish
+toys called a domino. Bringing my telescope to bear upon it, I plainly
+discerned it to be a British ninety four-gun ship, close-hauled, and
+pitching heavily in the sea with her head to the W.S.W. Besides this
+ship, I saw nothing but the ocean and the sky, and the sun, which had
+long arisen.
+
+“It is now high time that I should explain to your Excellencies the
+object of my perilous voyage. Your Excellencies will bear in mind that
+distressed circumstances in Rotterdam had at length driven me to the
+resolution of committing suicide. It was not, however, that to life
+itself I had any, positive disgust, but that I was harassed beyond
+endurance by the adventitious miseries attending my situation. In this
+state of mind, wishing to live, yet wearied with life, the treatise at
+the stall of the bookseller opened a resource to my imagination. I then
+finally made up my mind. I determined to depart, yet live--to leave the
+world, yet continue to exist--in short, to drop enigmas, I resolved, let
+what would ensue, to force a passage, if I could, to the moon. Now, lest
+I should be supposed more of a madman than I actually am, I will detail,
+as well as I am able, the considerations which led me to believe that
+an achievement of this nature, although without doubt difficult, and
+incontestably full of danger, was not absolutely, to a bold spirit,
+beyond the confines of the possible.
+
+“The moon’s actual distance from the earth was the first thing to be
+attended to. Now, the mean or average interval between the centres of
+the two planets is 59.9643 of the earth’s equatorial radii, or only
+about 237,000 miles. I say the mean or average interval. But it must
+be borne in mind that the form of the moon’s orbit being an ellipse of
+eccentricity amounting to no less than 0.05484 of the major semi-axis of
+the ellipse itself, and the earth’s centre being situated in its focus,
+if I could, in any manner, contrive to meet the moon, as it were, in its
+perigee, the above mentioned distance would be materially diminished.
+But, to say nothing at present of this possibility, it was very certain
+that, at all events, from the 237,000 miles I would have to deduct the
+radius of the earth, say 4,000, and the radius of the moon, say 1080,
+in all 5,080, leaving an actual interval to be traversed, under average
+circumstances, of 231,920 miles. Now this, I reflected, was no
+very extraordinary distance. Travelling on land has been repeatedly
+accomplished at the rate of thirty miles per hour, and indeed a much
+greater speed may be anticipated. But even at this velocity, it would
+take me no more than 322 days to reach the surface of the moon. There
+were, however, many particulars inducing me to believe that my average
+rate of travelling might possibly very much exceed that of thirty miles
+per hour, and, as these considerations did not fail to make a deep
+impression upon my mind, I will mention them more fully hereafter.
+
+“The next point to be regarded was a matter of far greater importance.
+From indications afforded by the barometer, we find that, in ascensions
+from the surface of the earth we have, at the height of 1,000 feet, left
+below us about one-thirtieth of the entire mass of atmospheric air, that
+at 10,600 we have ascended through nearly one-third; and that at 18,000,
+which is not far from the elevation of Cotopaxi, we have surmounted
+one-half the material, or, at all events, one-half the ponderable,
+body of air incumbent upon our globe. It is also calculated that at an
+altitude not exceeding the hundredth part of the earth’s diameter--that
+is, not exceeding eighty miles--the rarefaction would be so excessive
+that animal life could in no manner be sustained, and, moreover, that
+the most delicate means we possess of ascertaining the presence of the
+atmosphere would be inadequate to assure us of its existence. But I
+did not fail to perceive that these latter calculations are founded
+altogether on our experimental knowledge of the properties of air, and
+the mechanical laws regulating its dilation and compression, in what may
+be called, comparatively speaking, the immediate vicinity of the earth
+itself; and, at the same time, it is taken for granted that animal
+life is and must be essentially incapable of modification at any given
+unattainable distance from the surface. Now, all such reasoning and from
+such data must, of course, be simply analogical. The greatest height
+ever reached by man was that of 25,000 feet, attained in the aeronautic
+expedition of Messieurs Gay-Lussac and Biot. This is a moderate
+altitude, even when compared with the eighty miles in question; and I
+could not help thinking that the subject admitted room for doubt and
+great latitude for speculation.
+
+“But, in point of fact, an ascension being made to any given altitude,
+the ponderable quantity of air surmounted in any farther ascension is
+by no means in proportion to the additional height ascended (as may
+be plainly seen from what has been stated before), but in a ratio
+constantly decreasing. It is therefore evident that, ascend as high as
+we may, we cannot, literally speaking, arrive at a limit beyond which
+no atmosphere is to be found. It must exist, I argued; although it may
+exist in a state of infinite rarefaction.
+
+“On the other hand, I was aware that arguments have not been wanting
+to prove the existence of a real and definite limit to the atmosphere,
+beyond which there is absolutely no air whatsoever. But a circumstance
+which has been left out of view by those who contend for such a limit
+seemed to me, although no positive refutation of their creed, still
+a point worthy very serious investigation. On comparing the intervals
+between the successive arrivals of Encke’s comet at its perihelion,
+after giving credit, in the most exact manner, for all the disturbances
+due to the attractions of the planets, it appears that the periods are
+gradually diminishing; that is to say, the major axis of the comet’s
+ellipse is growing shorter, in a slow but perfectly regular decrease.
+Now, this is precisely what ought to be the case, if we suppose a
+resistance experienced from the comet from an extremely rare ethereal
+medium pervading the regions of its orbit. For it is evident that such
+a medium must, in retarding the comet’s velocity, increase its
+centripetal, by weakening its centrifugal force. In other words, the
+sun’s attraction would be constantly attaining greater power, and the
+comet would be drawn nearer at every revolution. Indeed, there is no
+other way of accounting for the variation in question. But again. The
+real diameter of the same comet’s nebulosity is observed to contract
+rapidly as it approaches the sun, and dilate with equal rapidity in its
+departure towards its aphelion. Was I not justifiable in supposing with
+M. Valz, that this apparent condensation of volume has its origin in
+the compression of the same ethereal medium I have spoken of before,
+and which is only denser in proportion to its solar vicinity? The
+lenticular-shaped phenomenon, also called the zodiacal light, was a
+matter worthy of attention. This radiance, so apparent in the tropics,
+and which cannot be mistaken for any meteoric lustre, extends from the
+horizon obliquely upward, and follows generally the direction of the
+sun’s equator. It appeared to me evidently in the nature of a rare
+atmosphere extending from the sun outward, beyond the orbit of Venus at
+least, and I believed indefinitely farther.(*2) Indeed, this medium I
+could not suppose confined to the path of the comet’s ellipse, or to
+the immediate neighborhood of the sun. It was easy, on the contrary,
+to imagine it pervading the entire regions of our planetary system,
+condensed into what we call atmosphere at the planets themselves, and
+perhaps at some of them modified by considerations, so to speak, purely
+geological.
+
+“Having adopted this view of the subject, I had little further
+hesitation. Granting that on my passage I should meet with atmosphere
+essentially the same as at the surface of the earth, I conceived that,
+by means of the very ingenious apparatus of M. Grimm, I should readily
+be enabled to condense it in sufficient quantity for the purposes of
+respiration. This would remove the chief obstacle in a journey to the
+moon. I had indeed spent some money and great labor in adapting the
+apparatus to the object intended, and confidently looked forward to its
+successful application, if I could manage to complete the voyage within
+any reasonable period. This brings me back to the rate at which it might
+be possible to travel.
+
+“It is true that balloons, in the first stage of their ascensions from
+the earth, are known to rise with a velocity comparatively moderate.
+Now, the power of elevation lies altogether in the superior lightness of
+the gas in the balloon compared with the atmospheric air; and, at
+first sight, it does not appear probable that, as the balloon acquires
+altitude, and consequently arrives successively in atmospheric strata
+of densities rapidly diminishing--I say, it does not appear at all
+reasonable that, in this its progress upwards, the original velocity
+should be accelerated. On the other hand, I was not aware that, in any
+recorded ascension, a diminution was apparent in the absolute rate
+of ascent; although such should have been the case, if on account
+of nothing else, on account of the escape of gas through balloons
+ill-constructed, and varnished with no better material than the ordinary
+varnish. It seemed, therefore, that the effect of such escape was only
+sufficient to counterbalance the effect of some accelerating power. I
+now considered that, provided in my passage I found the medium I
+had imagined, and provided that it should prove to be actually
+and essentially what we denominate atmospheric air, it could make
+comparatively little difference at what extreme state of rarefaction
+I should discover it--that is to say, in regard to my power of
+ascending--for the gas in the balloon would not only be itself subject
+to rarefaction partially similar (in proportion to the occurrence of
+which, I could suffer an escape of so much as would be requisite to
+prevent explosion), but, being what it was, would, at all events,
+continue specifically lighter than any compound whatever of mere
+nitrogen and oxygen. In the meantime, the force of gravitation would be
+constantly diminishing, in proportion to the squares of the distances,
+and thus, with a velocity prodigiously accelerating, I should at
+length arrive in those distant regions where the force of the earth’s
+attraction would be superseded by that of the moon. In accordance with
+these ideas, I did not think it worth while to encumber myself with more
+provisions than would be sufficient for a period of forty days.
+
+“There was still, however, another difficulty, which occasioned me some
+little disquietude. It has been observed, that, in balloon ascensions to
+any considerable height, besides the pain attending respiration, great
+uneasiness is experienced about the head and body, often accompanied
+with bleeding at the nose, and other symptoms of an alarming kind,
+and growing more and more inconvenient in proportion to the altitude
+attained.(*3) This was a reflection of a nature somewhat startling. Was
+it not probable that these symptoms would increase indefinitely, or at
+least until terminated by death itself? I finally thought not. Their
+origin was to be looked for in the progressive removal of the customary
+atmospheric pressure upon the surface of the body, and consequent
+distention of the superficial blood-vessels--not in any positive
+disorganization of the animal system, as in the case of difficulty in
+breathing, where the atmospheric density is chemically insufficient
+for the due renovation of blood in a ventricle of the heart. Unless for
+default of this renovation, I could see no reason, therefore, why
+life could not be sustained even in a vacuum; for the expansion and
+compression of chest, commonly called breathing, is action purely
+muscular, and the cause, not the effect, of respiration. In a word,
+I conceived that, as the body should become habituated to the want
+of atmospheric pressure, the sensations of pain would gradually
+diminish--and to endure them while they continued, I relied with
+confidence upon the iron hardihood of my constitution.
+
+“Thus, may it please your Excellencies, I have detailed some, though by
+no means all, the considerations which led me to form the project of
+a lunar voyage. I shall now proceed to lay before you the result of an
+attempt so apparently audacious in conception, and, at all events, so
+utterly unparalleled in the annals of mankind.
+
+“Having attained the altitude before mentioned, that is to say three
+miles and three-quarters, I threw out from the car a quantity of
+feathers, and found that I still ascended with sufficient rapidity;
+there was, therefore, no necessity for discharging any ballast. I was
+glad of this, for I wished to retain with me as much weight as I could
+carry, for reasons which will be explained in the sequel. I as yet
+suffered no bodily inconvenience, breathing with great freedom, and
+feeling no pain whatever in the head. The cat was lying very demurely
+upon my coat, which I had taken off, and eyeing the pigeons with an air
+of nonchalance. These latter being tied by the leg, to prevent their
+escape, were busily employed in picking up some grains of rice scattered
+for them in the bottom of the car.
+
+“At twenty minutes past six o’clock, the barometer showed an elevation
+of 26,400 feet, or five miles to a fraction. The prospect seemed
+unbounded. Indeed, it is very easily calculated by means of spherical
+geometry, what a great extent of the earth’s area I beheld. The convex
+surface of any segment of a sphere is, to the entire surface of the
+sphere itself, as the versed sine of the segment to the diameter of the
+sphere. Now, in my case, the versed sine--that is to say, the thickness
+of the segment beneath me--was about equal to my elevation, or the
+elevation of the point of sight above the surface. ‘As five miles, then,
+to eight thousand,’ would express the proportion of the earth’s area
+seen by me. In other words, I beheld as much as a sixteen-hundredth
+part of the whole surface of the globe. The sea appeared unruffled as a
+mirror, although, by means of the spy-glass, I could perceive it to be
+in a state of violent agitation. The ship was no longer visible, having
+drifted away, apparently to the eastward. I now began to experience, at
+intervals, severe pain in the head, especially about the ears--still,
+however, breathing with tolerable freedom. The cat and pigeons seemed to
+suffer no inconvenience whatsoever.
+
+“At twenty minutes before seven, the balloon entered a long series of
+dense cloud, which put me to great trouble, by damaging my condensing
+apparatus and wetting me to the skin. This was, to be sure, a singular
+recontre, for I had not believed it possible that a cloud of this nature
+could be sustained at so great an elevation. I thought it best, however,
+to throw out two five-pound pieces of ballast, reserving still a weight
+of one hundred and sixty-five pounds. Upon so doing, I soon rose above
+the difficulty, and perceived immediately, that I had obtained a great
+increase in my rate of ascent. In a few seconds after my leaving the
+cloud, a flash of vivid lightning shot from one end of it to the other,
+and caused it to kindle up, throughout its vast extent, like a mass of
+ignited and glowing charcoal. This, it must be remembered, was in the
+broad light of day. No fancy may picture the sublimity which might have
+been exhibited by a similar phenomenon taking place amid the darkness of
+the night. Hell itself might have been found a fitting image. Even as
+it was, my hair stood on end, while I gazed afar down within the yawning
+abysses, letting imagination descend, as it were, and stalk about in the
+strange vaulted halls, and ruddy gulfs, and red ghastly chasms of the
+hideous and unfathomable fire. I had indeed made a narrow escape. Had
+the balloon remained a very short while longer within the cloud--that
+is to say--had not the inconvenience of getting wet, determined me to
+discharge the ballast, inevitable ruin would have been the consequence.
+Such perils, although little considered, are perhaps the greatest which
+must be encountered in balloons. I had by this time, however, attained
+too great an elevation to be any longer uneasy on this head.
+
+“I was now rising rapidly, and by seven o’clock the barometer indicated
+an altitude of no less than nine miles and a half. I began to find great
+difficulty in drawing my breath. My head, too, was excessively painful;
+and, having felt for some time a moisture about my cheeks, I at length
+discovered it to be blood, which was oozing quite fast from the drums of
+my ears. My eyes, also, gave me great uneasiness. Upon passing the
+hand over them they seemed to have protruded from their sockets in no
+inconsiderable degree; and all objects in the car, and even the balloon
+itself, appeared distorted to my vision. These symptoms were more than
+I had expected, and occasioned me some alarm. At this juncture, very
+imprudently, and without consideration, I threw out from the car three
+five-pound pieces of ballast. The accelerated rate of ascent thus
+obtained, carried me too rapidly, and without sufficient gradation, into
+a highly rarefied stratum of the atmosphere, and the result had nearly
+proved fatal to my expedition and to myself. I was suddenly seized with
+a spasm which lasted for more than five minutes, and even when this, in
+a measure, ceased, I could catch my breath only at long intervals, and
+in a gasping manner--bleeding all the while copiously at the nose and
+ears, and even slightly at the eyes. The pigeons appeared distressed
+in the extreme, and struggled to escape; while the cat mewed piteously,
+and, with her tongue hanging out of her mouth, staggered to and fro in
+the car as if under the influence of poison. I now too late discovered
+the great rashness of which I had been guilty in discharging the
+ballast, and my agitation was excessive. I anticipated nothing less than
+death, and death in a few minutes. The physical suffering I underwent
+contributed also to render me nearly incapable of making any exertion
+for the preservation of my life. I had, indeed, little power of
+reflection left, and the violence of the pain in my head seemed to be
+greatly on the increase. Thus I found that my senses would shortly give
+way altogether, and I had already clutched one of the valve ropes with
+the view of attempting a descent, when the recollection of the trick I
+had played the three creditors, and the possible consequences to myself,
+should I return, operated to deter me for the moment. I lay down in the
+bottom of the car, and endeavored to collect my faculties. In this I
+so far succeeded as to determine upon the experiment of losing blood.
+Having no lancet, however, I was constrained to perform the operation in
+the best manner I was able, and finally succeeded in opening a vein
+in my right arm, with the blade of my penknife. The blood had hardly
+commenced flowing when I experienced a sensible relief, and by the time
+I had lost about half a moderate basin full, most of the worst symptoms
+had abandoned me entirely. I nevertheless did not think it expedient to
+attempt getting on my feet immediately; but, having tied up my arm as
+well as I could, I lay still for about a quarter of an hour. At the end
+of this time I arose, and found myself freer from absolute pain of any
+kind than I had been during the last hour and a quarter of my ascension.
+The difficulty of breathing, however, was diminished in a very slight
+degree, and I found that it would soon be positively necessary to make
+use of my condenser. In the meantime, looking toward the cat, who was
+again snugly stowed away upon my coat, I discovered to my infinite
+surprise, that she had taken the opportunity of my indisposition to
+bring into light a litter of three little kittens. This was an addition
+to the number of passengers on my part altogether unexpected; but I was
+pleased at the occurrence. It would afford me a chance of bringing to a
+kind of test the truth of a surmise, which, more than anything else,
+had influenced me in attempting this ascension. I had imagined that the
+habitual endurance of the atmospheric pressure at the surface of
+the earth was the cause, or nearly so, of the pain attending animal
+existence at a distance above the surface. Should the kittens be found
+to suffer uneasiness in an equal degree with their mother, I must
+consider my theory in fault, but a failure to do so I should look upon
+as a strong confirmation of my idea.
+
+“By eight o’clock I had actually attained an elevation of seventeen
+miles above the surface of the earth. Thus it seemed to me evident that
+my rate of ascent was not only on the increase, but that the progression
+would have been apparent in a slight degree even had I not discharged
+the ballast which I did. The pains in my head and ears returned, at
+intervals, with violence, and I still continued to bleed occasionally at
+the nose; but, upon the whole, I suffered much less than might have
+been expected. I breathed, however, at every moment, with more and
+more difficulty, and each inhalation was attended with a troublesome
+spasmodic action of the chest. I now unpacked the condensing apparatus,
+and got it ready for immediate use.
+
+“The view of the earth, at this period of my ascension, was beautiful
+indeed. To the westward, the northward, and the southward, as far as I
+could see, lay a boundless sheet of apparently unruffled ocean, which
+every moment gained a deeper and a deeper tint of blue and began already
+to assume a slight appearance of convexity. At a vast distance to the
+eastward, although perfectly discernible, extended the islands of Great
+Britain, the entire Atlantic coasts of France and Spain, with a small
+portion of the northern part of the continent of Africa. Of individual
+edifices not a trace could be discovered, and the proudest cities of
+mankind had utterly faded away from the face of the earth. From the rock
+of Gibraltar, now dwindled into a dim speck, the dark Mediterranean sea,
+dotted with shining islands as the heaven is dotted with stars, spread
+itself out to the eastward as far as my vision extended, until its
+entire mass of waters seemed at length to tumble headlong over the abyss
+of the horizon, and I found myself listening on tiptoe for the echoes
+of the mighty cataract. Overhead, the sky was of a jetty black, and the
+stars were brilliantly visible.
+
+“The pigeons about this time seeming to undergo much suffering, I
+determined upon giving them their liberty. I first untied one of them,
+a beautiful gray-mottled pigeon, and placed him upon the rim of the
+wicker-work. He appeared extremely uneasy, looking anxiously around him,
+fluttering his wings, and making a loud cooing noise, but could not be
+persuaded to trust himself from off the car. I took him up at last,
+and threw him to about half a dozen yards from the balloon. He made,
+however, no attempt to descend as I had expected, but struggled with
+great vehemence to get back, uttering at the same time very shrill and
+piercing cries. He at length succeeded in regaining his former station
+on the rim, but had hardly done so when his head dropped upon his
+breast, and he fell dead within the car. The other one did not prove so
+unfortunate. To prevent his following the example of his companion, and
+accomplishing a return, I threw him downward with all my force, and was
+pleased to find him continue his descent, with great velocity, making
+use of his wings with ease, and in a perfectly natural manner. In a very
+short time he was out of sight, and I have no doubt he reached home in
+safety. Puss, who seemed in a great measure recovered from her illness,
+now made a hearty meal of the dead bird and then went to sleep with much
+apparent satisfaction. Her kittens were quite lively, and so far evinced
+not the slightest sign of any uneasiness whatever.
+
+“At a quarter-past eight, being no longer able to draw breath without
+the most intolerable pain, I proceeded forthwith to adjust around
+the car the apparatus belonging to the condenser. This apparatus will
+require some little explanation, and your Excellencies will please to
+bear in mind that my object, in the first place, was to surround myself
+and cat entirely with a barricade against the highly rarefied atmosphere
+in which I was existing, with the intention of introducing within this
+barricade, by means of my condenser, a quantity of this same atmosphere
+sufficiently condensed for the purposes of respiration. With this object
+in view I had prepared a very strong perfectly air-tight, but flexible
+gum-elastic bag. In this bag, which was of sufficient dimensions, the
+entire car was in a manner placed. That is to say, it (the bag) was
+drawn over the whole bottom of the car, up its sides, and so on, along
+the outside of the ropes, to the upper rim or hoop where the net-work
+is attached. Having pulled the bag up in this way, and formed a complete
+enclosure on all sides, and at bottom, it was now necessary to fasten
+up its top or mouth, by passing its material over the hoop of the
+net-work--in other words, between the net-work and the hoop. But if the
+net-work were separated from the hoop to admit this passage, what was
+to sustain the car in the meantime? Now the net-work was not permanently
+fastened to the hoop, but attached by a series of running loops or
+nooses. I therefore undid only a few of these loops at one time, leaving
+the car suspended by the remainder. Having thus inserted a portion of
+the cloth forming the upper part of the bag, I refastened the loops--not
+to the hoop, for that would have been impossible, since the cloth
+now intervened--but to a series of large buttons, affixed to the cloth
+itself, about three feet below the mouth of the bag, the intervals
+between the buttons having been made to correspond to the intervals
+between the loops. This done, a few more of the loops were unfastened
+from the rim, a farther portion of the cloth introduced, and the
+disengaged loops then connected with their proper buttons. In this way
+it was possible to insert the whole upper part of the bag between the
+net-work and the hoop. It is evident that the hoop would now drop down
+within the car, while the whole weight of the car itself, with all its
+contents, would be held up merely by the strength of the buttons. This,
+at first sight, would seem an inadequate dependence; but it was by no
+means so, for the buttons were not only very strong in themselves, but
+so close together that a very slight portion of the whole weight was
+supported by any one of them. Indeed, had the car and contents been
+three times heavier than they were, I should not have been at
+all uneasy. I now raised up the hoop again within the covering of
+gum-elastic, and propped it at nearly its former height by means of
+three light poles prepared for the occasion. This was done, of course,
+to keep the bag distended at the top, and to preserve the lower part
+of the net-work in its proper situation. All that now remained was to
+fasten up the mouth of the enclosure; and this was readily accomplished
+by gathering the folds of the material together, and twisting them up
+very tightly on the inside by means of a kind of stationary tourniquet.
+
+“In the sides of the covering thus adjusted round the car, had been
+inserted three circular panes of thick but clear glass, through which I
+could see without difficulty around me in every horizontal direction.
+In that portion of the cloth forming the bottom, was likewise, a fourth
+window, of the same kind, and corresponding with a small aperture in the
+floor of the car itself. This enabled me to see perpendicularly
+down, but having found it impossible to place any similar contrivance
+overhead, on account of the peculiar manner of closing up the opening
+there, and the consequent wrinkles in the cloth, I could expect to see
+no objects situated directly in my zenith. This, of course, was a matter
+of little consequence; for had I even been able to place a window at
+top, the balloon itself would have prevented my making any use of it.
+
+“About a foot below one of the side windows was a circular opening,
+eight inches in diameter, and fitted with a brass rim adapted in its
+inner edge to the windings of a screw. In this rim was screwed the large
+tube of the condenser, the body of the machine being, of course, within
+the chamber of gum-elastic. Through this tube a quantity of the rare
+atmosphere circumjacent being drawn by means of a vacuum created in the
+body of the machine, was thence discharged, in a state of condensation,
+to mingle with the thin air already in the chamber. This operation being
+repeated several times, at length filled the chamber with atmosphere
+proper for all the purposes of respiration. But in so confined a space
+it would, in a short time, necessarily become foul, and unfit for use
+from frequent contact with the lungs. It was then ejected by a small
+valve at the bottom of the car--the dense air readily sinking into the
+thinner atmosphere below. To avoid the inconvenience of making a total
+vacuum at any moment within the chamber, this purification was never
+accomplished all at once, but in a gradual manner--the valve being
+opened only for a few seconds, then closed again, until one or two
+strokes from the pump of the condenser had supplied the place of the
+atmosphere ejected. For the sake of experiment I had put the cat and
+kittens in a small basket, and suspended it outside the car to a button
+at the bottom, close by the valve, through which I could feed them at
+any moment when necessary. I did this at some little risk, and before
+closing the mouth of the chamber, by reaching under the car with one of
+the poles before mentioned to which a hook had been attached.
+
+“By the time I had fully completed these arrangements and filled the
+chamber as explained, it wanted only ten minutes of nine o’clock. During
+the whole period of my being thus employed, I endured the most terrible
+distress from difficulty of respiration, and bitterly did I repent the
+negligence or rather fool-hardiness, of which I had been guilty, of
+putting off to the last moment a matter of so much importance. But
+having at length accomplished it, I soon began to reap the benefit of
+my invention. Once again I breathed with perfect freedom and ease--and
+indeed why should I not? I was also agreeably surprised to find myself,
+in a great measure, relieved from the violent pains which had hitherto
+tormented me. A slight headache, accompanied with a sensation of fulness
+or distention about the wrists, the ankles, and the throat, was nearly
+all of which I had now to complain. Thus it seemed evident that a
+greater part of the uneasiness attending the removal of atmospheric
+pressure had actually worn off, as I had expected, and that much of
+the pain endured for the last two hours should have been attributed
+altogether to the effects of a deficient respiration.
+
+“At twenty minutes before nine o’clock--that is to say, a short time
+prior to my closing up the mouth of the chamber, the mercury attained
+its limit, or ran down, in the barometer, which, as I mentioned before,
+was one of an extended construction. It then indicated an altitude on
+my part of 132,000 feet, or five-and-twenty miles, and I consequently
+surveyed at that time an extent of the earth’s area amounting to no less
+than the three hundred-and-twentieth part of its entire superficies.
+At nine o’clock I had again lost sight of land to the eastward, but not
+before I became aware that the balloon was drifting rapidly to the N.
+N. W. The convexity of the ocean beneath me was very evident indeed,
+although my view was often interrupted by the masses of cloud which
+floated to and fro. I observed now that even the lightest vapors never
+rose to more than ten miles above the level of the sea.
+
+“At half past nine I tried the experiment of throwing out a handful of
+feathers through the valve. They did not float as I had expected; but
+dropped down perpendicularly, like a bullet, en masse, and with the
+greatest velocity--being out of sight in a very few seconds. I did not
+at first know what to make of this extraordinary phenomenon; not being
+able to believe that my rate of ascent had, of a sudden, met with
+so prodigious an acceleration. But it soon occurred to me that the
+atmosphere was now far too rare to sustain even the feathers; that they
+actually fell, as they appeared to do, with great rapidity; and that I
+had been surprised by the united velocities of their descent and my own
+elevation.
+
+“By ten o’clock I found that I had very little to occupy my immediate
+attention. Affairs went swimmingly, and I believed the balloon to be
+going upward with a speed increasing momently although I had no longer
+any means of ascertaining the progression of the increase. I suffered no
+pain or uneasiness of any kind, and enjoyed better spirits than I had
+at any period since my departure from Rotterdam, busying myself now in
+examining the state of my various apparatus, and now in regenerating the
+atmosphere within the chamber. This latter point I determined to
+attend to at regular intervals of forty minutes, more on account of
+the preservation of my health, than from so frequent a renovation
+being absolutely necessary. In the meanwhile I could not help making
+anticipations. Fancy revelled in the wild and dreamy regions of the
+moon. Imagination, feeling herself for once unshackled, roamed at will
+among the ever-changing wonders of a shadowy and unstable land. Now
+there were hoary and time-honored forests, and craggy precipices, and
+waterfalls tumbling with a loud noise into abysses without a bottom.
+Then I came suddenly into still noonday solitudes, where no wind of
+heaven ever intruded, and where vast meadows of poppies, and slender,
+lily-looking flowers spread themselves out a weary distance, all silent
+and motionless forever. Then again I journeyed far down away into
+another country where it was all one dim and vague lake, with a boundary
+line of clouds. And out of this melancholy water arose a forest of tall
+eastern trees, like a wilderness of dreams. And I have in mind that
+the shadows of the trees which fell upon the lake remained not on
+the surface where they fell, but sunk slowly and steadily down, and
+commingled with the waves, while from the trunks of the trees other
+shadows were continually coming out, and taking the place of their
+brothers thus entombed. “This then,” I said thoughtfully, “is the very
+reason why the waters of this lake grow blacker with age, and more
+melancholy as the hours run on.” But fancies such as these were not the
+sole possessors of my brain. Horrors of a nature most stern and most
+appalling would too frequently obtrude themselves upon my mind, and
+shake the innermost depths of my soul with the bare supposition of their
+possibility. Yet I would not suffer my thoughts for any length of time
+to dwell upon these latter speculations, rightly judging the real and
+palpable dangers of the voyage sufficient for my undivided attention.
+
+“At five o’clock, p.m., being engaged in regenerating the atmosphere
+within the chamber, I took that opportunity of observing the cat and
+kittens through the valve. The cat herself appeared to suffer again very
+much, and I had no hesitation in attributing her uneasiness chiefly to a
+difficulty in breathing; but my experiment with the kittens had resulted
+very strangely. I had expected, of course, to see them betray a sense of
+pain, although in a less degree than their mother, and this would have
+been sufficient to confirm my opinion concerning the habitual endurance
+of atmospheric pressure. But I was not prepared to find them, upon close
+examination, evidently enjoying a high degree of health, breathing with
+the greatest ease and perfect regularity, and evincing not the slightest
+sign of any uneasiness whatever. I could only account for all this by
+extending my theory, and supposing that the highly rarefied atmosphere
+around might perhaps not be, as I had taken for granted, chemically
+insufficient for the purposes of life, and that a person born in such
+a medium might, possibly, be unaware of any inconvenience attending its
+inhalation, while, upon removal to the denser strata near the earth,
+he might endure tortures of a similar nature to those I had so lately
+experienced. It has since been to me a matter of deep regret that an
+awkward accident, at this time, occasioned me the loss of my little
+family of cats, and deprived me of the insight into this matter which a
+continued experiment might have afforded. In passing my hand through
+the valve, with a cup of water for the old puss, the sleeves of my shirt
+became entangled in the loop which sustained the basket, and thus, in
+a moment, loosened it from the bottom. Had the whole actually vanished
+into air, it could not have shot from my sight in a more abrupt and
+instantaneous manner. Positively, there could not have intervened the
+tenth part of a second between the disengagement of the basket and its
+absolute and total disappearance with all that it contained. My good
+wishes followed it to the earth, but of course, I had no hope that
+either cat or kittens would ever live to tell the tale of their
+misfortune.
+
+“At six o’clock, I perceived a great portion of the earth’s visible area
+to the eastward involved in thick shadow, which continued to advance
+with great rapidity, until, at five minutes before seven, the whole
+surface in view was enveloped in the darkness of night. It was not,
+however, until long after this time that the rays of the setting sun
+ceased to illumine the balloon; and this circumstance, although of
+course fully anticipated, did not fail to give me an infinite deal
+of pleasure. It was evident that, in the morning, I should behold the
+rising luminary many hours at least before the citizens of Rotterdam, in
+spite of their situation so much farther to the eastward, and thus, day
+after day, in proportion to the height ascended, would I enjoy the light
+of the sun for a longer and a longer period. I now determined to keep a
+journal of my passage, reckoning the days from one to twenty-four
+hours continuously, without taking into consideration the intervals of
+darkness.
+
+“At ten o’clock, feeling sleepy, I determined to lie down for the rest
+of the night; but here a difficulty presented itself, which, obvious as
+it may appear, had escaped my attention up to the very moment of which
+I am now speaking. If I went to sleep as I proposed, how could the
+atmosphere in the chamber be regenerated in the interim? To breathe
+it for more than an hour, at the farthest, would be a matter of
+impossibility, or, if even this term could be extended to an hour and a
+quarter, the most ruinous consequences might ensue. The consideration
+of this dilemma gave me no little disquietude; and it will hardly be
+believed, that, after the dangers I had undergone, I should look
+upon this business in so serious a light, as to give up all hope of
+accomplishing my ultimate design, and finally make up my mind to the
+necessity of a descent. But this hesitation was only momentary. I
+reflected that man is the veriest slave of custom, and that many points
+in the routine of his existence are deemed essentially important, which
+are only so at all by his having rendered them habitual. It was very
+certain that I could not do without sleep; but I might easily bring
+myself to feel no inconvenience from being awakened at intervals of an
+hour during the whole period of my repose. It would require but five
+minutes at most to regenerate the atmosphere in the fullest manner, and
+the only real difficulty was to contrive a method of arousing myself
+at the proper moment for so doing. But this was a question which, I am
+willing to confess, occasioned me no little trouble in its solution. To
+be sure, I had heard of the student who, to prevent his falling asleep
+over his books, held in one hand a ball of copper, the din of whose
+descent into a basin of the same metal on the floor beside his chair,
+served effectually to startle him up, if, at any moment, he should
+be overcome with drowsiness. My own case, however, was very different
+indeed, and left me no room for any similar idea; for I did not wish to
+keep awake, but to be aroused from slumber at regular intervals of time.
+I at length hit upon the following expedient, which, simple as it may
+seem, was hailed by me, at the moment of discovery, as an invention
+fully equal to that of the telescope, the steam-engine, or the art of
+printing itself.
+
+“It is necessary to premise, that the balloon, at the elevation now
+attained, continued its course upward with an even and undeviating
+ascent, and the car consequently followed with a steadiness so perfect
+that it would have been impossible to detect in it the slightest
+vacillation whatever. This circumstance favored me greatly in the
+project I now determined to adopt. My supply of water had been put on
+board in kegs containing five gallons each, and ranged very securely
+around the interior of the car. I unfastened one of these, and taking
+two ropes tied them tightly across the rim of the wicker-work from one
+side to the other; placing them about a foot apart and parallel so as to
+form a kind of shelf, upon which I placed the keg, and steadied it in a
+horizontal position. About eight inches immediately below these ropes,
+and four feet from the bottom of the car I fastened another shelf--but
+made of thin plank, being the only similar piece of wood I had. Upon
+this latter shelf, and exactly beneath one of the rims of the keg, a
+small earthern pitcher was deposited. I now bored a hole in the end of
+the keg over the pitcher, and fitted in a plug of soft wood, cut in a
+tapering or conical shape. This plug I pushed in or pulled out, as might
+happen, until, after a few experiments, it arrived at that exact degree
+of tightness, at which the water, oozing from the hole, and falling into
+the pitcher below, would fill the latter to the brim in the period
+of sixty minutes. This, of course, was a matter briefly and easily
+ascertained, by noticing the proportion of the pitcher filled in any
+given time. Having arranged all this, the rest of the plan is obvious.
+My bed was so contrived upon the floor of the car, as to bring my
+head, in lying down, immediately below the mouth of the pitcher. It was
+evident, that, at the expiration of an hour, the pitcher, getting full,
+would be forced to run over, and to run over at the mouth, which was
+somewhat lower than the rim. It was also evident, that the water thus
+falling from a height of more than four feet, could not do otherwise
+than fall upon my face, and that the sure consequences would be, to
+waken me up instantaneously, even from the soundest slumber in the
+world.
+
+“It was fully eleven by the time I had completed these arrangements,
+and I immediately betook myself to bed, with full confidence in the
+efficiency of my invention. Nor in this matter was I disappointed.
+Punctually every sixty minutes was I aroused by my trusty chronometer,
+when, having emptied the pitcher into the bung-hole of the keg, and
+performed the duties of the condenser, I retired again to bed. These
+regular interruptions to my slumber caused me even less discomfort than
+I had anticipated; and when I finally arose for the day, it was seven
+o’clock, and the sun had attained many degrees above the line of my
+horizon.
+
+“April 3d. I found the balloon at an immense height indeed, and the
+earth’s apparent convexity increased in a material degree. Below me in
+the ocean lay a cluster of black specks, which undoubtedly were islands.
+Far away to the northward I perceived a thin, white, and exceedingly
+brilliant line, or streak, on the edge of the horizon, and I had no
+hesitation in supposing it to be the southern disk of the ices of the
+Polar Sea. My curiosity was greatly excited, for I had hopes of passing
+on much farther to the north, and might possibly, at some period, find
+myself placed directly above the Pole itself. I now lamented that my
+great elevation would, in this case, prevent my taking as accurate a
+survey as I could wish. Much, however, might be ascertained. Nothing
+else of an extraordinary nature occurred during the day. My apparatus
+all continued in good order, and the balloon still ascended without any
+perceptible vacillation. The cold was intense, and obliged me to wrap
+up closely in an overcoat. When darkness came over the earth, I betook
+myself to bed, although it was for many hours afterward broad daylight
+all around my immediate situation. The water-clock was punctual in its
+duty, and I slept until next morning soundly, with the exception of the
+periodical interruption.
+
+“April 4th. Arose in good health and spirits, and was astonished at the
+singular change which had taken place in the appearance of the sea.
+It had lost, in a great measure, the deep tint of blue it had hitherto
+worn, being now of a grayish-white, and of a lustre dazzling to the eye.
+The islands were no longer visible; whether they had passed down the
+horizon to the southeast, or whether my increasing elevation had left
+them out of sight, it is impossible to say. I was inclined, however, to
+the latter opinion. The rim of ice to the northward was growing more
+and more apparent. Cold by no means so intense. Nothing of importance
+occurred, and I passed the day in reading, having taken care to supply
+myself with books.
+
+“April 5th. Beheld the singular phenomenon of the sun rising while
+nearly the whole visible surface of the earth continued to be involved
+in darkness. In time, however, the light spread itself over all, and I
+again saw the line of ice to the northward. It was now very distinct,
+and appeared of a much darker hue than the waters of the ocean. I was
+evidently approaching it, and with great rapidity. Fancied I could
+again distinguish a strip of land to the eastward, and one also to the
+westward, but could not be certain. Weather moderate. Nothing of any
+consequence happened during the day. Went early to bed.
+
+“April 6th. Was surprised at finding the rim of ice at a very moderate
+distance, and an immense field of the same material stretching away off
+to the horizon in the north. It was evident that if the balloon held its
+present course, it would soon arrive above the Frozen Ocean, and I had
+now little doubt of ultimately seeing the Pole. During the whole of the
+day I continued to near the ice. Toward night the limits of my horizon
+very suddenly and materially increased, owing undoubtedly to the
+earth’s form being that of an oblate spheroid, and my arriving above the
+flattened regions in the vicinity of the Arctic circle. When darkness at
+length overtook me, I went to bed in great anxiety, fearing to pass over
+the object of so much curiosity when I should have no opportunity of
+observing it.
+
+“April 7th. Arose early, and, to my great joy, at length beheld what
+there could be no hesitation in supposing the northern Pole itself. It
+was there, beyond a doubt, and immediately beneath my feet; but, alas! I
+had now ascended to so vast a distance, that nothing could with accuracy
+be discerned. Indeed, to judge from the progression of the numbers
+indicating my various altitudes, respectively, at different periods,
+between six A.M. on the second of April, and twenty minutes before nine
+A.M. of the same day (at which time the barometer ran down), it might be
+fairly inferred that the balloon had now, at four o’clock in the morning
+of April the seventh, reached a height of not less, certainly, than
+7,254 miles above the surface of the sea. This elevation may appear
+immense, but the estimate upon which it is calculated gave a result in
+all probability far inferior to the truth. At all events I undoubtedly
+beheld the whole of the earth’s major diameter; the entire northern
+hemisphere lay beneath me like a chart orthographically projected: and
+the great circle of the equator itself formed the boundary line of
+my horizon. Your Excellencies may, however, readily imagine that the
+confined regions hitherto unexplored within the limits of the Arctic
+circle, although situated directly beneath me, and therefore seen
+without any appearance of being foreshortened, were still, in
+themselves, comparatively too diminutive, and at too great a distance
+from the point of sight, to admit of any very accurate examination.
+Nevertheless, what could be seen was of a nature singular and exciting.
+Northwardly from that huge rim before mentioned, and which, with slight
+qualification, may be called the limit of human discovery in these
+regions, one unbroken, or nearly unbroken, sheet of ice continues to
+extend. In the first few degrees of this its progress, its surface is
+very sensibly flattened, farther on depressed into a plane, and finally,
+becoming not a little concave, it terminates, at the Pole itself, in a
+circular centre, sharply defined, whose apparent diameter subtended at
+the balloon an angle of about sixty-five seconds, and whose dusky hue,
+varying in intensity, was, at all times, darker than any other spot upon
+the visible hemisphere, and occasionally deepened into the most
+absolute and impenetrable blackness. Farther than this, little could
+be ascertained. By twelve o’clock the circular centre had materially
+decreased in circumference, and by seven P.M. I lost sight of it
+entirely; the balloon passing over the western limb of the ice, and
+floating away rapidly in the direction of the equator.
+
+“April 8th. Found a sensible diminution in the earth’s apparent
+diameter, besides a material alteration in its general color and
+appearance. The whole visible area partook in different degrees of a
+tint of pale yellow, and in some portions had acquired a brilliancy even
+painful to the eye. My view downward was also considerably impeded by
+the dense atmosphere in the vicinity of the surface being loaded with
+clouds, between whose masses I could only now and then obtain a glimpse
+of the earth itself. This difficulty of direct vision had troubled me
+more or less for the last forty-eight hours; but my present enormous
+elevation brought closer together, as it were, the floating bodies of
+vapor, and the inconvenience became, of course, more and more palpable
+in proportion to my ascent. Nevertheless, I could easily perceive that
+the balloon now hovered above the range of great lakes in the continent
+of North America, and was holding a course, due south, which would bring
+me to the tropics. This circumstance did not fail to give me the most
+heartful satisfaction, and I hailed it as a happy omen of ultimate
+success. Indeed, the direction I had hitherto taken, had filled me with
+uneasiness; for it was evident that, had I continued it much longer,
+there would have been no possibility of my arriving at the moon at all,
+whose orbit is inclined to the ecliptic at only the small angle of 5
+degrees 8’ 48”.
+
+“April 9th. To-day the earth’s diameter was greatly diminished, and the
+color of the surface assumed hourly a deeper tint of yellow. The balloon
+kept steadily on her course to the southward, and arrived, at nine P.M.,
+over the northern edge of the Mexican Gulf.
+
+“April 10th. I was suddenly aroused from slumber, about five o’clock
+this morning, by a loud, crackling, and terrific sound, for which I
+could in no manner account. It was of very brief duration, but, while
+it lasted resembled nothing in the world of which I had any previous
+experience. It is needless to say that I became excessively alarmed,
+having, in the first instance, attributed the noise to the bursting of
+the balloon. I examined all my apparatus, however, with great attention,
+and could discover nothing out of order. Spent a great part of the day
+in meditating upon an occurrence so extraordinary, but could find no
+means whatever of accounting for it. Went to bed dissatisfied, and in a
+state of great anxiety and agitation.
+
+“April 11th. Found a startling diminution in the apparent diameter of
+the earth, and a considerable increase, now observable for the first
+time, in that of the moon itself, which wanted only a few days of being
+full. It now required long and excessive labor to condense within the
+chamber sufficient atmospheric air for the sustenance of life.
+
+“April 12th. A singular alteration took place in regard to the direction
+of the balloon, and although fully anticipated, afforded me the most
+unequivocal delight. Having reached, in its former course, about the
+twentieth parallel of southern latitude, it turned off suddenly, at an
+acute angle, to the eastward, and thus proceeded throughout the day,
+keeping nearly, if not altogether, in the exact plane of the lunar
+elipse. What was worthy of remark, a very perceptible vacillation in
+the car was a consequence of this change of route--a vacillation which
+prevailed, in a more or less degree, for a period of many hours.
+
+“April 13th. Was again very much alarmed by a repetition of the loud,
+crackling noise which terrified me on the tenth. Thought long upon
+the subject, but was unable to form any satisfactory conclusion. Great
+decrease in the earth’s apparent diameter, which now subtended from the
+balloon an angle of very little more than twenty-five degrees. The moon
+could not be seen at all, being nearly in my zenith. I still continued
+in the plane of the elipse, but made little progress to the eastward.
+
+“April 14th. Extremely rapid decrease in the diameter of the earth.
+To-day I became strongly impressed with the idea, that the balloon was
+now actually running up the line of apsides to the point of perigee--in
+other words, holding the direct course which would bring it immediately
+to the moon in that part of its orbit the nearest to the earth. The moon
+itself was directly overhead, and consequently hidden from my view.
+Great and long-continued labor necessary for the condensation of the
+atmosphere.
+
+“April 15th. Not even the outlines of continents and seas could now
+be traced upon the earth with anything approaching distinctness. About
+twelve o’clock I became aware, for the third time, of that appalling
+sound which had so astonished me before. It now, however, continued for
+some moments, and gathered intensity as it continued. At length, while,
+stupefied and terror-stricken, I stood in expectation of I knew not what
+hideous destruction, the car vibrated with excessive violence, and
+a gigantic and flaming mass of some material which I could not
+distinguish, came with a voice of a thousand thunders, roaring and
+booming by the balloon. When my fears and astonishment had in some
+degree subsided, I had little difficulty in supposing it to be some
+mighty volcanic fragment ejected from that world to which I was so
+rapidly approaching, and, in all probability, one of that singular class
+of substances occasionally picked up on the earth, and termed meteoric
+stones for want of a better appellation.
+
+“April 16th. To-day, looking upward as well as I could, through each
+of the side windows alternately, I beheld, to my great delight, a very
+small portion of the moon’s disk protruding, as it were, on all sides
+beyond the huge circumference of the balloon. My agitation was extreme;
+for I had now little doubt of soon reaching the end of my perilous
+voyage. Indeed, the labor now required by the condenser had increased
+to a most oppressive degree, and allowed me scarcely any respite from
+exertion. Sleep was a matter nearly out of the question. I became quite
+ill, and my frame trembled with exhaustion. It was impossible that human
+nature could endure this state of intense suffering much longer. During
+the now brief interval of darkness a meteoric stone again passed in my
+vicinity, and the frequency of these phenomena began to occasion me much
+apprehension.
+
+“April 17th. This morning proved an epoch in my voyage. It will be
+remembered that, on the thirteenth, the earth subtended an angular
+breadth of twenty-five degrees. On the fourteenth this had greatly
+diminished; on the fifteenth a still more remarkable decrease was
+observable; and, on retiring on the night of the sixteenth, I had
+noticed an angle of no more than about seven degrees and fifteen
+minutes. What, therefore, must have been my amazement, on awakening
+from a brief and disturbed slumber, on the morning of this day,
+the seventeenth, at finding the surface beneath me so suddenly and
+wonderfully augmented in volume, as to subtend no less than thirty-nine
+degrees in apparent angular diameter! I was thunderstruck! No words
+can give any adequate idea of the extreme, the absolute horror and
+astonishment, with which I was seized possessed, and altogether
+overwhelmed. My knees tottered beneath me--my teeth chattered--my hair
+started up on end. “The balloon, then, had actually burst!” These were
+the first tumultuous ideas that hurried through my mind: “The balloon
+had positively burst!--I was falling--falling with the most impetuous,
+the most unparalleled velocity! To judge by the immense distance already
+so quickly passed over, it could not be more than ten minutes, at the
+farthest, before I should meet the surface of the earth, and be hurled
+into annihilation!” But at length reflection came to my relief. I
+paused; I considered; and I began to doubt. The matter was impossible.
+I could not in any reason have so rapidly come down. Besides, although
+I was evidently approaching the surface below me, it was with a speed
+by no means commensurate with the velocity I had at first so horribly
+conceived. This consideration served to calm the perturbation of my
+mind, and I finally succeeded in regarding the phenomenon in its proper
+point of view. In fact, amazement must have fairly deprived me of my
+senses, when I could not see the vast difference, in appearance, between
+the surface below me, and the surface of my mother earth. The latter
+was indeed over my head, and completely hidden by the balloon, while the
+moon--the moon itself in all its glory--lay beneath me, and at my feet.
+
+“The stupor and surprise produced in my mind by this extraordinary
+change in the posture of affairs was perhaps, after all, that part of
+the adventure least susceptible of explanation. For the bouleversement
+in itself was not only natural and inevitable, but had been long
+actually anticipated as a circumstance to be expected whenever I should
+arrive at that exact point of my voyage where the attraction of the
+planet should be superseded by the attraction of the satellite--or, more
+precisely, where the gravitation of the balloon toward the earth should
+be less powerful than its gravitation toward the moon. To be sure I
+arose from a sound slumber, with all my senses in confusion, to the
+contemplation of a very startling phenomenon, and one which, although
+expected, was not expected at the moment. The revolution itself must, of
+course, have taken place in an easy and gradual manner, and it is by no
+means clear that, had I even been awake at the time of the occurrence,
+I should have been made aware of it by any internal evidence of an
+inversion--that is to say, by any inconvenience or disarrangement,
+either about my person or about my apparatus.
+
+“It is almost needless to say that, upon coming to a due sense of my
+situation, and emerging from the terror which had absorbed every faculty
+of my soul, my attention was, in the first place, wholly directed to
+the contemplation of the general physical appearance of the moon. It
+lay beneath me like a chart--and although I judged it to be still at no
+inconsiderable distance, the indentures of its surface were defined
+to my vision with a most striking and altogether unaccountable
+distinctness. The entire absence of ocean or sea, and indeed of any lake
+or river, or body of water whatsoever, struck me, at first glance, as
+the most extraordinary feature in its geological condition. Yet, strange
+to say, I beheld vast level regions of a character decidedly alluvial,
+although by far the greater portion of the hemisphere in sight was
+covered with innumerable volcanic mountains, conical in shape, and
+having more the appearance of artificial than of natural protuberance.
+The highest among them does not exceed three and three-quarter miles
+in perpendicular elevation; but a map of the volcanic districts of the
+Campi Phlegraei would afford to your Excellencies a better idea of their
+general surface than any unworthy description I might think proper to
+attempt. The greater part of them were in a state of evident eruption,
+and gave me fearfully to understand their fury and their power, by the
+repeated thunders of the miscalled meteoric stones, which now rushed
+upward by the balloon with a frequency more and more appalling.
+
+“April 18th. To-day I found an enormous increase in the moon’s apparent
+bulk--and the evidently accelerated velocity of my descent began to fill
+me with alarm. It will be remembered, that, in the earliest stage of
+my speculations upon the possibility of a passage to the moon, the
+existence, in its vicinity, of an atmosphere, dense in proportion to the
+bulk of the planet, had entered largely into my calculations; this too
+in spite of many theories to the contrary, and, it may be added, in
+spite of a general disbelief in the existence of any lunar atmosphere at
+all. But, in addition to what I have already urged in regard to Encke’s
+comet and the zodiacal light, I had been strengthened in my opinion by
+certain observations of Mr. Schroeter, of Lilienthal. He observed the
+moon when two days and a half old, in the evening soon after sunset,
+before the dark part was visible, and continued to watch it until it
+became visible. The two cusps appeared tapering in a very sharp faint
+prolongation, each exhibiting its farthest extremity faintly illuminated
+by the solar rays, before any part of the dark hemisphere was
+visible. Soon afterward, the whole dark limb became illuminated. This
+prolongation of the cusps beyond the semicircle, I thought, must have
+arisen from the refraction of the sun’s rays by the moon’s atmosphere. I
+computed, also, the height of the atmosphere (which could refract light
+enough into its dark hemisphere to produce a twilight more luminous than
+the light reflected from the earth when the moon is about 32 degrees
+from the new) to be 1,356 Paris feet; in this view, I supposed the
+greatest height capable of refracting the solar ray, to be 5,376 feet.
+My ideas on this topic had also received confirmation by a passage in
+the eighty-second volume of the Philosophical Transactions, in which
+it is stated that at an occultation of Jupiter’s satellites, the third
+disappeared after having been about 1” or 2” of time indistinct, and the
+fourth became indiscernible near the limb.(*4)
+
+“Cassini frequently observed Saturn, Jupiter, and the fixed stars,
+when approaching the moon to occultation, to have their circular figure
+changed into an oval one; and, in other occultations, he found no
+alteration of figure at all. Hence it might be supposed, that at some
+times and not at others, there is a dense matter encompassing the moon
+wherein the rays of the stars are refracted.
+
+“Upon the resistance or, more properly, upon the support of an
+atmosphere, existing in the state of density imagined, I had, of course,
+entirely depended for the safety of my ultimate descent. Should I then,
+after all, prove to have been mistaken, I had in consequence nothing
+better to expect, as a finale to my adventure, than being dashed into
+atoms against the rugged surface of the satellite. And, indeed, I
+had now every reason to be terrified. My distance from the moon was
+comparatively trifling, while the labor required by the condenser was
+diminished not at all, and I could discover no indication whatever of a
+decreasing rarity in the air.
+
+“April 19th. This morning, to my great joy, about nine o’clock, the
+surface of the moon being frightfully near, and my apprehensions excited
+to the utmost, the pump of my condenser at length gave evident tokens
+of an alteration in the atmosphere. By ten, I had reason to believe
+its density considerably increased. By eleven, very little labor was
+necessary at the apparatus; and at twelve o’clock, with some hesitation,
+I ventured to unscrew the tourniquet, when, finding no inconvenience
+from having done so, I finally threw open the gum-elastic chamber, and
+unrigged it from around the car. As might have been expected, spasms
+and violent headache were the immediate consequences of an experiment
+so precipitate and full of danger. But these and other difficulties
+attending respiration, as they were by no means so great as to put me
+in peril of my life, I determined to endure as I best could, in
+consideration of my leaving them behind me momently in my approach
+to the denser strata near the moon. This approach, however, was still
+impetuous in the extreme; and it soon became alarmingly certain that,
+although I had probably not been deceived in the expectation of an
+atmosphere dense in proportion to the mass of the satellite, still I
+had been wrong in supposing this density, even at the surface, at all
+adequate to the support of the great weight contained in the car of my
+balloon. Yet this should have been the case, and in an equal degree
+as at the surface of the earth, the actual gravity of bodies at either
+planet supposed in the ratio of the atmospheric condensation. That
+it was not the case, however, my precipitous downfall gave testimony
+enough; why it was not so, can only be explained by a reference to those
+possible geological disturbances to which I have formerly alluded. At
+all events I was now close upon the planet, and coming down with the
+most terrible impetuosity. I lost not a moment, accordingly, in throwing
+overboard first my ballast, then my water-kegs, then my condensing
+apparatus and gum-elastic chamber, and finally every article within the
+car. But it was all to no purpose. I still fell with horrible rapidity,
+and was now not more than half a mile from the surface. As a last
+resource, therefore, having got rid of my coat, hat, and boots, I cut
+loose from the balloon the car itself, which was of no inconsiderable
+weight, and thus, clinging with both hands to the net-work, I had barely
+time to observe that the whole country, as far as the eye could reach,
+was thickly interspersed with diminutive habitations, ere I tumbled
+headlong into the very heart of a fantastical-looking city, and into the
+middle of a vast crowd of ugly little people, who none of them uttered
+a single syllable, or gave themselves the least trouble to render me
+assistance, but stood, like a parcel of idiots, grinning in a ludicrous
+manner, and eyeing me and my balloon askant, with their arms set
+a-kimbo. I turned from them in contempt, and, gazing upward at the earth
+so lately left, and left perhaps for ever, beheld it like a huge, dull,
+copper shield, about two degrees in diameter, fixed immovably in the
+heavens overhead, and tipped on one of its edges with a crescent
+border of the most brilliant gold. No traces of land or water could be
+discovered, and the whole was clouded with variable spots, and belted
+with tropical and equatorial zones.
+
+“Thus, may it please your Excellencies, after a series of great
+anxieties, unheard of dangers, and unparalleled escapes, I had, at
+length, on the nineteenth day of my departure from Rotterdam, arrived in
+safety at the conclusion of a voyage undoubtedly the most extraordinary,
+and the most momentous, ever accomplished, undertaken, or conceived by
+any denizen of earth. But my adventures yet remain to be related. And
+indeed your Excellencies may well imagine that, after a residence of
+five years upon a planet not only deeply interesting in its own peculiar
+character, but rendered doubly so by its intimate connection, in
+capacity of satellite, with the world inhabited by man, I may have
+intelligence for the private ear of the States’ College of Astronomers
+of far more importance than the details, however wonderful, of the mere
+voyage which so happily concluded. This is, in fact, the case. I
+have much--very much which it would give me the greatest pleasure to
+communicate. I have much to say of the climate of the planet; of its
+wonderful alternations of heat and cold, of unmitigated and burning
+sunshine for one fortnight, and more than polar frigidity for the next;
+of a constant transfer of moisture, by distillation like that in vacuo,
+from the point beneath the sun to the point the farthest from it; of
+a variable zone of running water, of the people themselves; of their
+manners, customs, and political institutions; of their peculiar physical
+construction; of their ugliness; of their want of ears, those useless
+appendages in an atmosphere so peculiarly modified; of their consequent
+ignorance of the use and properties of speech; of their substitute
+for speech in a singular method of inter-communication; of the
+incomprehensible connection between each particular individual in
+the moon with some particular individual on the earth--a connection
+analogous with, and depending upon, that of the orbs of the planet and
+the satellites, and by means of which the lives and destinies of the
+inhabitants of the one are interwoven with the lives and destinies
+of the inhabitants of the other; and above all, if it so please your
+Excellencies--above all, of those dark and hideous mysteries which lie
+in the outer regions of the moon--regions which, owing to the almost
+miraculous accordance of the satellite’s rotation on its own axis with
+its sidereal revolution about the earth, have never yet been turned,
+and, by God’s mercy, never shall be turned, to the scrutiny of the
+telescopes of man. All this, and more--much more--would I most
+willingly detail. But, to be brief, I must have my reward. I am pining
+for a return to my family and to my home, and as the price of any
+farther communication on my part--in consideration of the light which
+I have it in my power to throw upon many very important branches of
+physical and metaphysical science--I must solicit, through the influence
+of your honorable body, a pardon for the crime of which I have been
+guilty in the death of the creditors upon my departure from Rotterdam.
+This, then, is the object of the present paper. Its bearer, an
+inhabitant of the moon, whom I have prevailed upon, and properly
+instructed, to be my messenger to the earth, will await your
+Excellencies’ pleasure, and return to me with the pardon in question, if
+it can, in any manner, be obtained.
+
+“I have the honor to be, etc., your Excellencies’ very humble servant,
+
+“HANS PFAALL.”
+
+Upon finishing the perusal of this very extraordinary document,
+Professor Rub-a-dub, it is said, dropped his pipe upon the ground in
+the extremity of his surprise, and Mynheer Superbus Von Underduk having
+taken off his spectacles, wiped them, and deposited them in his pocket,
+so far forgot both himself and his dignity, as to turn round three times
+upon his heel in the quintessence of astonishment and admiration. There
+was no doubt about the matter--the pardon should be obtained. So at
+least swore, with a round oath, Professor Rub-a-dub, and so finally
+thought the illustrious Von Underduk, as he took the arm of his brother
+in science, and without saying a word, began to make the best of his way
+home to deliberate upon the measures to be adopted. Having reached the
+door, however, of the burgomaster’s dwelling, the professor ventured to
+suggest that as the messenger had thought proper to disappear--no
+doubt frightened to death by the savage appearance of the burghers of
+Rotterdam--the pardon would be of little use, as no one but a man of
+the moon would undertake a voyage to so vast a distance. To the truth of
+this observation the burgomaster assented, and the matter was therefore
+at an end. Not so, however, rumors and speculations. The letter, having
+been published, gave rise to a variety of gossip and opinion. Some of
+the over-wise even made themselves ridiculous by decrying the whole
+business; as nothing better than a hoax. But hoax, with these sort
+of people, is, I believe, a general term for all matters above their
+comprehension. For my part, I cannot conceive upon what data they have
+founded such an accusation. Let us see what they say:
+
+Imprimus. That certain wags in Rotterdam have certain especial
+antipathies to certain burgomasters and astronomers.
+
+Don’t understand at all.
+
+Secondly. That an odd little dwarf and bottle conjurer, both of whose
+ears, for some misdemeanor, have been cut off close to his head, has
+been missing for several days from the neighboring city of Bruges.
+
+Well--what of that?
+
+Thirdly. That the newspapers which were stuck all over the little
+balloon were newspapers of Holland, and therefore could not have been
+made in the moon. They were dirty papers--very dirty--and Gluck, the
+printer, would take his Bible oath to their having been printed in
+Rotterdam.
+
+He was mistaken--undoubtedly--mistaken.
+
+Fourthly, That Hans Pfaall himself, the drunken villain, and the three
+very idle gentlemen styled his creditors, were all seen, no longer than
+two or three days ago, in a tippling house in the suburbs, having just
+returned, with money in their pockets, from a trip beyond the sea.
+
+Don’t believe it--don’t believe a word of it.
+
+Lastly. That it is an opinion very generally received, or which ought
+to be generally received, that the College of Astronomers in the city
+of Rotterdam, as well as other colleges in all other parts of the
+world,--not to mention colleges and astronomers in general,--are, to say
+the least of the matter, not a whit better, nor greater, nor wiser than
+they ought to be.
+
+~~~ End of Text ~~~
+
+Notes to Hans Pfaal
+
+(*1) NOTE--Strictly speaking, there is but little similarity between the
+above sketchy trifle and the celebrated “Moon-Story” of Mr. Locke; but
+as both have the character of _hoaxes _(although the one is in a tone of
+banter, the other of downright earnest), and as both hoaxes are on the
+same subject, the moon--moreover, as both attempt to give plausibility
+by scientific detail--the author of “Hans Pfaall” thinks it necessary to
+say, in _self-defence, _that his own _jeu d’esprit _was published in the
+“Southern Literary Messenger” about three weeks before the commencement
+of Mr. L’s in the “New York Sun.” Fancying a likeness which, perhaps,
+does not exist, some of the New York papers copied “Hans Pfaall,” and
+collated it with the “Moon-Hoax,” by way of detecting the writer of the
+one in the writer of the other.
+
+As many more persons were actually gulled by the “Moon-Hoax” than would
+be willing to acknowledge the fact, it may here afford some little
+amusement to show why no one should have been deceived-to point out
+those particulars of the story which should have been sufficient to
+establish its real character. Indeed, however rich the imagination
+displayed in this ingenious fiction, it wanted much of the force which
+might have been given it by a more scrupulous attention to facts and
+to general analogy. That the public were misled, even for an instant,
+merely proves the gross ignorance which is so generally prevalent upon
+subjects of an astronomical nature.
+
+The moon’s distance from the earth is, in round numbers, 240,000 miles.
+If we desire to ascertain how near, apparently, a lens would bring the
+satellite (or any distant object), we, of course, have but to divide the
+distance by the magnifying or, more strictly, by the space-penetrating
+power of the glass. Mr. L. makes his lens have a power of 42,000 times.
+By this divide 240,000 (the moon’s real distance), and we have five
+miles and five sevenths, as the apparent distance. No animal at all
+could be seen so far; much less the minute points particularized in the
+story. Mr. L. speaks about Sir John Herschel’s perceiving flowers (the
+Papaver rheas, etc.), and even detecting the color and the shape of the
+eyes of small birds. Shortly before, too, he has himself observed that
+the lens would not render perceptible objects of less than eighteen
+inches in diameter; but even this, as I have said, is giving the glass
+by far too great power. It may be observed, in passing, that this
+prodigious glass is said to have been molded at the glasshouse of
+Messrs. Hartley and Grant, in Dumbarton; but Messrs. H. and G.’s
+establishment had ceased operations for many years previous to the
+publication of the hoax.
+
+On page 13, pamphlet edition, speaking of “a hairy veil” over the eyes
+of a species of bison, the author says: “It immediately occurred to the
+acute mind of Dr. Herschel that this was a providential contrivance
+to protect the eyes of the animal from the great extremes of light
+and darkness to which all the inhabitants of our side of the moon are
+periodically subjected.” But this cannot be thought a very “acute”
+ observation of the Doctor’s. The inhabitants of our side of the moon
+have, evidently, no darkness at all, so there can be nothing of the
+“extremes” mentioned. In the absence of the sun they have a light from
+the earth equal to that of thirteen full unclouded moons.
+
+The topography throughout, even when professing to accord with Blunt’s
+Lunar Chart, is entirely at variance with that or any other lunar chart,
+and even grossly at variance with itself. The points of the compass,
+too, are in inextricable confusion; the writer appearing to be ignorant
+that, on a lunar map, these are not in accordance with terrestrial
+points; the east being to the left, etc.
+
+Deceived, perhaps, by the vague titles, Mare Nubium, Mare
+Tranquillitatis, Mare Faecunditatis, etc., given to the dark spots by
+former astronomers, Mr. L. has entered into details regarding oceans
+and other large bodies of water in the moon; whereas there is no
+astronomical point more positively ascertained than that no such bodies
+exist there. In examining the boundary between light and darkness (in
+the crescent or gibbous moon) where this boundary crosses any of the
+dark places, the line of division is found to be rough and jagged; but,
+were these dark places liquid, it would evidently be even.
+
+The description of the wings of the man-bat, on page 21, is but a
+literal copy of Peter Wilkins’ account of the wings of his flying
+islanders. This simple fact should have induced suspicion, at least, it
+might be thought.
+
+On page 23, we have the following: “What a prodigious influence must our
+thirteen times larger globe have exercised upon this satellite when an
+embryo in the womb of time, the passive subject of chemical affinity!”
+ This is very fine; but it should be observed that no astronomer would
+have made such remark, especially to any journal of Science; for the
+earth, in the sense intended, is not only thirteen, but forty-nine times
+larger than the moon. A similar objection applies to the whole of the
+concluding pages, where, by way of introduction to some discoveries in
+Saturn, the philosophical correspondent enters into a minute schoolboy
+account of that planet--this to the “Edinburgh journal of Science!”
+
+But there is one point, in particular, which should have betrayed the
+fiction. Let us imagine the power actually possessed of seeing animals
+upon the moon’s surface--what would first arrest the attention of an
+observer from the earth? Certainly neither their shape, size, nor any
+other such peculiarity, so soon as their remarkable _situation_. They
+would appear to be walking, with heels up and head down, in the manner
+of flies on a ceiling. The _real_ observer would have uttered an instant
+ejaculation of surprise (however prepared by previous knowledge) at the
+singularity of their position; the _fictitious_ observer has not even
+mentioned the subject, but speaks of seeing the entire bodies of such
+creatures, when it is demonstrable that he could have seen only the
+diameter of their heads!
+
+It might as well be remarked, in conclusion, that the size, and
+particularly the powers of the man-bats (for example, their ability to
+fly in so rare an atmosphere--if, indeed, the moon have any), with most
+of the other fancies in regard to animal and vegetable existence, are at
+variance, generally, with all analogical reasoning on these themes; and
+that analogy here will often amount to conclusive demonstration. It is,
+perhaps, scarcely necessary to add, that all the suggestions attributed
+to Brewster and Herschel, in the beginning of the article, about “a
+transfusion of artificial light through the focal object of vision,”
+ etc., etc., belong to that species of figurative writing which comes,
+most properly, under the denomination of rigmarole.
+
+There is a real and very definite limit to optical discovery among the
+stars--a limit whose nature need only be stated to be understood. If,
+indeed, the casting of large lenses were all that is required, man’s
+ingenuity would ultimately prove equal to the task, and we might have
+them of any size demanded. But, unhappily, in proportion to the increase
+of size in the lens, and consequently of space-penetrating power, is the
+diminution of light from the object, by diffusion of its rays. And for
+this evil there is no remedy within human ability; for an object is seen
+by means of that light alone which proceeds from itself, whether direct
+or reflected. Thus the only “artificial” light which could avail
+Mr. Locke, would be some artificial light which he should be able to
+throw-not upon the “focal object of vision,” but upon the real object
+to be viewed-to wit: upon the moon. It has been easily calculated that,
+when the light proceeding from a star becomes so diffused as to be as
+weak as the natural light proceeding from the whole of the stars, in
+a clear and moonless night, then the star is no longer visible for any
+practical purpose.
+
+The Earl of Ross’s telescope, lately constructed in England, has
+a _speculum_ with a reflecting surface of 4,071 square inches; the
+Herschel telescope having one of only 1,811. The metal of the Earl of
+Ross’s is 6 feet diameter; it is 5 1/2 inches thick at the edges, and 5
+at the centre. The weight is 3 tons. The focal length is 50 feet.
+
+I have lately read a singular and somewhat ingenious little book, whose
+title-page runs thus: “L’Homme dans la lvne ou le Voyage Chimerique
+fait au Monde de la Lvne, nouellement decouvert par Dominique Gonzales,
+Aduanturier Espagnol, autrem?t dit le Courier volant. Mis en notre
+langve par J. B. D. A. Paris, chez Francois Piot, pres la Fontaine de
+Saint Benoist. Et chez J. Goignard, au premier pilier de la grand’salle
+du Palais, proche les Consultations, MDCXLVII.” Pp. 76.
+
+The writer professes to have translated his work from the English of one
+Mr. D’Avisson (Davidson?) although there is a terrible ambiguity in the
+statement. “J’ en ai eu,” says he “l’original de Monsieur D’Avisson,
+medecin des mieux versez qui soient aujourd’huy dans la cõnoissance des
+Belles Lettres, et sur tout de la Philosophic Naturelle. Je lui ai cette
+obligation entre les autres, de m’ auoir non seulement mis en main
+cc Livre en anglois, mais encore le Manuscrit du Sieur Thomas D’Anan,
+gentilhomme Eccossois, recommandable pour sa vertu, sur la version
+duquel j’ advoue que j’ ay tiré le plan de la mienne.”
+
+After some irrelevant adventures, much in the manner of Gil Blas, and
+which occupy the first thirty pages, the author relates that, being
+ill during a sea voyage, the crew abandoned him, together with a
+negro servant, on the island of St. Helena. To increase the chances of
+obtaining food, the two separate, and live as far apart as possible.
+This brings about a training of birds, to serve the purpose of
+carrier-pigeons between them. By and by these are taught to carry
+parcels of some weight-and this weight is gradually increased. At length
+the idea is entertained of uniting the force of a great number of the
+birds, with a view to raising the author himself. A machine is contrived
+for the purpose, and we have a minute description of it, which is
+materially helped out by a steel engraving. Here we perceive the
+Signor Gonzales, with point ruffles and a huge periwig, seated astride
+something which resembles very closely a broomstick, and borne aloft by
+a multitude of wild swans _(ganzas) _who had strings reaching from their
+tails to the machine.
+
+The main event detailed in the Signor’s narrative depends upon a very
+important fact, of which the reader is kept in ignorance until near the
+end of the book. The _ganzas, _with whom he had become so familiar, were
+not really denizens of St. Helena, but of the moon. Thence it had been
+their custom, time out of mind, to migrate annually to some portion of
+the earth. In proper season, of course, they would return home; and
+the author, happening, one day, to require their services for a short
+voyage, is unexpectedly carried straight tip, and in a very brief period
+arrives at the satellite. Here he finds, among other odd things, that
+the people enjoy extreme happiness; that they have no _law; _that they
+die without pain; that they are from ten to thirty feet in height;
+that they live five thousand years; that they have an emperor called
+Irdonozur; and that they can jump sixty feet high, when, being out of
+the gravitating influence, they fly about with fans.
+
+I cannot forbear giving a specimen of the general _philosophy _of the
+volume.
+
+“I must not forget here, that the stars appeared only on that side of
+the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also me and the earth. As to the
+stars, _since there was no night where I was, they always had the same
+appearance; not brilliant, as usual, but pale, and very nearly like the
+moon of a morning. _But few of them were visible, and these ten times
+larger (as well as I could judge) than they seem to the inhabitants
+of the earth. The moon, which wanted two days of being full, was of a
+terrible bigness.
+
+ “I must not forget here, that the stars appeared only on that side
+of the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also to inform you that, whether it was
+calm weather or stormy, I found myself _always immediately between the
+moon and the earth._ I_ _was convinced of this for two reasons-because
+my birds always flew in a straight line; and because whenever we
+attempted to rest, _we were carried insensibly around the globe of the
+earth. _For I admit the opinion of Copernicus, who maintains that it
+never ceases to revolve _from the east to the west, _not upon the poles
+of the Equinoctial, commonly called the poles of the world, but upon
+those of the Zodiac, a question of which I propose to speak more at
+length here-after, when I shall have leisure to refresh my memory in
+regard to the astrology which I learned at Salamanca when young, and
+have since forgotten.”
+
+Notwithstanding the blunders italicized, the book is not without
+some claim to attention, as affording a naive specimen of the current
+astronomical notions of the time. One of these assumed, that the
+“gravitating power” extended but a short distance from the earth’s
+surface, and, accordingly, we find our voyager “carried insensibly
+around the globe,” etc.
+
+There have been other “voyages to the moon,” but none of higher merit
+than the one just mentioned. That of Bergerac is utterly meaningless. In
+the third volume of the “American Quarterly Review” will be found
+quite an elaborate criticism upon a certain “journey” of the kind in
+question--a criticism in which it is difficult to say whether the critic
+most exposes the stupidity of the book, or his own absurd ignorance of
+astronomy. I forget the title of the work; but the _means _of the voyage
+are more deplorably ill conceived than are even the _ganzas _of our
+friend the Signor Gonzales. The adventurer, in digging the earth,
+happens to discover a peculiar metal for which the moon has a strong
+attraction, and straightway constructs of it a box, which, when cast
+loose from its terrestrial fastenings, flies with him, forthwith, to
+the satellite. The “Flight of Thomas O’Rourke,” is a _jeu d’ esprit _not
+altogether contemptible, and has been translated into German. Thomas,
+the hero, was, in fact, the gamekeeper of an Irish peer, whose
+eccentricities gave rise to the tale. The “flight” is made on an eagle’s
+back, from Hungry Hill, a lofty mountain at the end of Bantry Bay.
+
+In these various _brochures _the aim is always satirical; the theme
+being a description of Lunarian customs as compared with ours. In none
+is there any effort at _plausibility _in the details of the voyage
+itself. The writers seem, in each instance, to be utterly uninformed in
+respect to astronomy. In “Hans Pfaall” the design is original, inasmuch
+as regards an attempt at _verisimilitude, _in the application of
+scientific principles (so far as the whimsical nature of the subject
+would permit), to the actual passage between the earth and the moon.
+
+(*2) The zodiacal light is probably what the ancients called Trabes.
+Emicant Trabes quos docos vocant.--Pliny, lib. 2, p. 26.
+
+(*3) Since the original publication of Hans Pfaall, I find that Mr.
+Green, of Nassau balloon notoriety, and other late aeronauts, deny
+the assertions of Humboldt, in this respect, and speak of a decreasing
+inconvenience,--precisely in accordance with the theory here urged in a
+mere spirit of banter.
+
+(*4) Havelius writes that he has several times found, in skies
+perfectly clear, when even stars of the sixth and seventh magnitude
+were conspicuous, that, at the same altitude of the moon, at the
+same elongation from the earth, and with one and the same excellent
+telescope, the moon and its maculae did not appear equally lucid at all
+times. From the circumstances of the observation, it is evident that the
+cause of this phenomenon is not either in our air, in the tube, in
+the moon, or in the eye of the spectator, but must be looked for in
+something (an atmosphere?) existing about the moon.
+
+
+
+
+THE GOLD-BUG
+
+          What ho! what ho! this fellow is dancing mad!
+
+               He hath been bitten by the Tarantula.
+
+                    _--All in the Wrong._
+
+MANY years ago, I contracted an intimacy with a Mr. William Legrand.
+He was of an ancient Huguenot family, and had once been wealthy; but
+a series of misfortunes had reduced him to want. To avoid the
+mortification consequent upon his disasters, he left New Orleans, the
+city of his forefathers, and took up his residence at Sullivan’s Island,
+near Charleston, South Carolina. This Island is a very singular one.
+It consists of little else than the sea sand, and is about three
+miles long. Its breadth at no point exceeds a quarter of a mile. It is
+separated from the main land by a scarcely perceptible creek, oozing its
+way through a wilderness of reeds and slime, a favorite resort of the
+marsh hen. The vegetation, as might be supposed, is scant, or at least
+dwarfish. No trees of any magnitude are to be seen. Near the western
+extremity, where Fort Moultrie stands, and where are some miserable
+frame buildings, tenanted, during summer, by the fugitives from
+Charleston dust and fever, may be found, indeed, the bristly palmetto;
+but the whole island, with the exception of this western point, and
+a line of hard, white beach on the seacoast, is covered with a dense
+undergrowth of the sweet myrtle, so much prized by the horticulturists
+of England. The shrub here often attains the height of fifteen or twenty
+feet, and forms an almost impenetrable coppice, burthening the air with
+its fragrance.
+
+In the inmost recesses of this coppice, not far from the eastern or more
+remote end of the island, Legrand had built himself a small hut, which
+he occupied when I first, by mere accident, made his acquaintance.
+This soon ripened into friendship--for there was much in the recluse
+to excite interest and esteem. I found him well educated, with unusual
+powers of mind, but infected with misanthropy, and subject to perverse
+moods of alternate enthusiasm and melancholy. He had with him many
+books, but rarely employed them. His chief amusements were gunning and
+fishing, or sauntering along the beach and through the myrtles, in quest
+of shells or entomological specimens;--his collection of the latter
+might have been envied by a Swammerdamm. In these excursions he was
+usually accompanied by an old negro, called Jupiter, who had been
+manumitted before the reverses of the family, but who could be induced,
+neither by threats nor by promises, to abandon what he considered his
+right of attendance upon the footsteps of his young “Massa Will.” It
+is not improbable that the relatives of Legrand, conceiving him to be
+somewhat unsettled in intellect, had contrived to instil this obstinacy
+into Jupiter, with a view to the supervision and guardianship of the
+wanderer.
+
+The winters in the latitude of Sullivan’s Island are seldom very severe,
+and in the fall of the year it is a rare event indeed when a fire is
+considered necessary. About the middle of October, 18-, there occurred,
+however, a day of remarkable chilliness. Just before sunset I scrambled
+my way through the evergreens to the hut of my friend, whom I had
+not visited for several weeks--my residence being, at that time,
+in Charleston, a distance of nine miles from the Island, while the
+facilities of passage and re-passage were very far behind those of
+the present day. Upon reaching the hut I rapped, as was my custom,
+and getting no reply, sought for the key where I knew it was secreted,
+unlocked the door and went in. A fine fire was blazing upon the hearth.
+It was a novelty, and by no means an ungrateful one. I threw off an
+overcoat, took an arm-chair by the crackling logs, and awaited patiently
+the arrival of my hosts.
+
+Soon after dark they arrived, and gave me a most cordial welcome.
+Jupiter, grinning from ear to ear, bustled about to prepare some
+marsh-hens for supper. Legrand was in one of his fits--how else shall
+I term them?--of enthusiasm. He had found an unknown bivalve, forming
+a new genus, and, more than this, he had hunted down and secured, with
+Jupiter’s assistance, a scarabæus which he believed to be totally new,
+but in respect to which he wished to have my opinion on the morrow.
+
+“And why not to-night?” I asked, rubbing my hands over the blaze, and
+wishing the whole tribe of scarabæi at the devil.
+
+“Ah, if I had only known you were here!” said Legrand, “but it’s so long
+since I saw you; and how could I foresee that you would pay me a visit
+this very night of all others? As I was coming home I met Lieutenant
+G--, from the fort, and, very foolishly, I lent him the bug; so it will
+be impossible for you to see it until the morning. Stay here to-night,
+and I will send Jup down for it at sunrise. It is the loveliest thing in
+creation!”
+
+“What?--sunrise?”
+
+“Nonsense! no!--the bug. It is of a brilliant gold color--about the size
+of a large hickory-nut--with two jet black spots near one extremity of
+the back, and another, somewhat longer, at the other. The antennæ are--”
+
+“Dey aint no tin in him, Massa Will, I keep a tellin on you,” here
+interrupted Jupiter; “de bug is a goole bug, solid, ebery bit of him,
+inside and all, sep him wing--neber feel half so hebby a bug in my
+life.”
+
+“Well, suppose it is, Jup,” replied Legrand, somewhat more earnestly,
+it seemed to me, than the case demanded, “is that any reason for your
+letting the birds burn? The color”--here he turned to me--“is really
+almost enough to warrant Jupiter’s idea. You never saw a more brilliant
+metallic lustre than the scales emit--but of this you cannot judge
+till tomorrow. In the mean time I can give you some idea of the shape.”
+ Saying this, he seated himself at a small table, on which were a pen and
+ink, but no paper. He looked for some in a drawer, but found none.
+
+“Never mind,” said he at length, “this will answer;” and he drew from
+his waistcoat pocket a scrap of what I took to be very dirty foolscap,
+and made upon it a rough drawing with the pen. While he did this, I
+retained my seat by the fire, for I was still chilly. When the design
+was complete, he handed it to me without rising. As I received it, a
+loud growl was heard, succeeded by a scratching at the door. Jupiter
+opened it, and a large Newfoundland, belonging to Legrand, rushed in,
+leaped upon my shoulders, and loaded me with caresses; for I had shown
+him much attention during previous visits. When his gambols were over, I
+looked at the paper, and, to speak the truth, found myself not a little
+puzzled at what my friend had depicted.
+
+“Well!” I said, after contemplating it for some minutes, “this is a
+strange scarabæus, I must confess: new to me: never saw anything like it
+before--unless it was a skull, or a death’s-head--which it more nearly
+resembles than anything else that has come under my observation.”
+
+“A death’s-head!” echoed Legrand--“Oh--yes--well, it has something of
+that appearance upon paper, no doubt. The two upper black spots look
+like eyes, eh? and the longer one at the bottom like a mouth--and then
+the shape of the whole is oval.”
+
+“Perhaps so,” said I; “but, Legrand, I fear you are no artist. I must
+wait until I see the beetle itself, if I am to form any idea of its
+personal appearance.”
+
+“Well, I don’t know,” said he, a little nettled, “I draw
+tolerably--should do it at least--have had good masters, and flatter
+myself that I am not quite a blockhead.”
+
+“But, my dear fellow, you are joking then,” said I, “this is a very
+passable skull--indeed, I may say that it is a very excellent skull,
+according to the vulgar notions about such specimens of physiology--and
+your scarabæus must be the queerest scarabæus in the world if it
+resembles it. Why, we may get up a very thrilling bit of superstition
+upon this hint. I presume you will call the bug scarabæus caput hominis,
+or something of that kind--there are many similar titles in the Natural
+Histories. But where are the antennæ you spoke of?”
+
+“The antennæ!” said Legrand, who seemed to be getting unaccountably warm
+upon the subject; “I am sure you must see the antennæ. I made them
+as distinct as they are in the original insect, and I presume that is
+sufficient.”
+
+“Well, well,” I said, “perhaps you have--still I don’t see them;” and
+I handed him the paper without additional remark, not wishing to ruffle
+his temper; but I was much surprised at the turn affairs had taken; his
+ill humor puzzled me--and, as for the drawing of the beetle, there
+were positively no antennæ visible, and the whole did bear a very close
+resemblance to the ordinary cuts of a death’s-head.
+
+He received the paper very peevishly, and was about to crumple it,
+apparently to throw it in the fire, when a casual glance at the design
+seemed suddenly to rivet his attention. In an instant his face grew
+violently red--in another as excessively pale. For some minutes he
+continued to scrutinize the drawing minutely where he sat. At length he
+arose, took a candle from the table, and proceeded to seat himself upon
+a sea-chest in the farthest corner of the room. Here again he made an
+anxious examination of the paper; turning it in all directions. He said
+nothing, however, and his conduct greatly astonished me; yet I thought
+it prudent not to exacerbate the growing moodiness of his temper by any
+comment. Presently he took from his coat pocket a wallet, placed the
+paper carefully in it, and deposited both in a writing-desk, which he
+locked. He now grew more composed in his demeanor; but his original air
+of enthusiasm had quite disappeared. Yet he seemed not so much sulky as
+abstracted. As the evening wore away he became more and more absorbed in
+reverie, from which no sallies of mine could arouse him. It had been my
+intention to pass the night at the hut, as I had frequently done before,
+but, seeing my host in this mood, I deemed it proper to take leave. He
+did not press me to remain, but, as I departed, he shook my hand with
+even more than his usual cordiality.
+
+It was about a month after this (and during the interval I had seen
+nothing of Legrand) when I received a visit, at Charleston, from his
+man, Jupiter. I had never seen the good old negro look so dispirited,
+and I feared that some serious disaster had befallen my friend.
+
+“Well, Jup,” said I, “what is the matter now?--how is your master?”
+
+“Why, to speak de troof, massa, him not so berry well as mought be.”
+
+“Not well! I am truly sorry to hear it. What does he complain of?”
+
+“Dar! dat’s it!--him neber plain of notin--but him berry sick for all
+dat.”
+
+“Very sick, Jupiter!--why didn’t you say so at once? Is he confined to
+bed?”
+
+“No, dat he aint!--he aint find nowhar--dat’s just whar de shoe
+pinch--my mind is got to be berry hebby bout poor Massa Will.”
+
+“Jupiter, I should like to understand what it is you are talking about.
+You say your master is sick. Hasn’t he told you what ails him?”
+
+“Why, massa, taint worf while for to git mad about de matter--Massa
+Will say noffin at all aint de matter wid him--but den what make him go
+about looking dis here way, wid he head down and he soldiers up, and as
+white as a gose? And den he keep a syphon all de time--”
+
+“Keeps a what, Jupiter?”
+
+“Keeps a syphon wid de figgurs on de slate--de queerest figgurs I ebber
+did see. Ise gittin to be skeered, I tell you. Hab for to keep mighty
+tight eye pon him noovers. Todder day he gib me slip fore de sun up and
+was gone de whole ob de blessed day. I had a big stick ready cut for to
+gib him deuced good beating when he did come--but Ise sich a fool dat I
+hadn’t de heart arter all--he look so berry poorly.”
+
+“Eh?--what?--ah yes!--upon the whole I think you had better not be too
+severe with the poor fellow--don’t flog him, Jupiter--he can’t very well
+stand it--but can you form no idea of what has occasioned this illness,
+or rather this change of conduct? Has anything unpleasant happened since
+I saw you?”
+
+“No, massa, dey aint bin noffin unpleasant since den--‘twas fore den I’m
+feared--‘twas de berry day you was dare.”
+
+“How? what do you mean?”
+
+“Why, massa, I mean de bug--dare now.”
+
+“The what?”
+
+“De bug,--I’m berry sartain dat Massa Will bin bit somewhere bout de
+head by dat goole-bug.”
+
+“And what cause have you, Jupiter, for such a supposition?”
+
+“Claws enuff, massa, and mouth too. I nebber did see sick a deuced
+bug--he kick and he bite ebery ting what cum near him. Massa Will cotch
+him fuss, but had for to let him go gin mighty quick, I tell you--den
+was de time he must ha got de bite. I did n’t like de look oh de bug
+mouff, myself, no how, so I would n’t take hold ob him wid my finger,
+but I cotch him wid a piece ob paper dat I found. I rap him up in de
+paper and stuff piece ob it in he mouff--dat was de way.”
+
+“And you think, then, that your master was really bitten by the beetle,
+and that the bite made him sick?”
+
+“I do n’t tink noffin about it--I nose it. What make him dream bout de
+goole so much, if taint cause he bit by de goole-bug? Ise heerd bout dem
+goole-bugs fore dis.”
+
+“But how do you know he dreams about gold?”
+
+“How I know? why cause he talk about it in he sleep--dat’s how I nose.”
+
+“Well, Jup, perhaps you are right; but to what fortunate circumstance am
+I to attribute the honor of a visit from you to-day?”
+
+“What de matter, massa?”
+
+“Did you bring any message from Mr. Legrand?”
+
+“No, massa, I bring dis here pissel;” and here Jupiter handed me a note
+which ran thus:
+
+    MY DEAR ----
+
+Why have I not seen you for so long a time? I hope you have not been so
+foolish as to take offence at any little _brusquerie_ of mine; but no,
+that is improbable. Since I saw you I have had great cause for anxiety.
+I have something to tell you, yet scarcely know how to tell it, or
+whether I should tell it at all.
+
+I have not been quite well for some days past, and poor old Jup annoys
+me, almost beyond endurance, by his well-meant attentions Would you
+believe it?--he had prepared a huge stick, the other day, with which
+to chastise me for giving him the slip, and spending the day, _solus_,
+among the hills on the main land. I verily believe that my ill looks
+alone saved me a flogging.
+
+I have made no addition to my cabinet since we met.
+
+If you can, in any way, make it convenient, come over with Jupiter.
+_Do_ come. I wish to see you to-_night_, upon business of importance. I
+assure you that it is of the _highest_ importance.
+
+        Ever yours,                     WILLIAM LEGRAND.
+
+There was something in the tone of this note which gave me great
+uneasiness. Its whole style differed materially from that of Legrand.
+What could he be dreaming of? What new crotchet possessed his excitable
+brain? What “business of the highest importance” could he possibly have
+to transact? Jupiter’s account of him boded no good. I dreaded lest the
+continued pressure of misfortune had, at length, fairly unsettled
+the reason of my friend. Without a moment’s hesitation, therefore, I
+prepared to accompany the negro.
+
+Upon reaching the wharf, I noticed a scythe and three spades, all
+apparently new, lying in the bottom of the boat in which we were to
+embark.
+
+“What is the meaning of all this, Jup?” I inquired.
+
+“Him syfe, massa, and spade.”
+
+“Very true; but what are they doing here?”
+
+“Him de syfe and de spade what Massa Will sis pon my buying for him in
+de town, and de debbils own lot of money I had to gib for em.”
+
+“But what, in the name of all that is mysterious, is your ‘Massa Will’
+going to do with scythes and spades?”
+
+“Dat’s more dan I know, and debbil take me if I don’t blieve ‘tis more
+dan he know, too. But it’s all cum ob do bug.”
+
+Finding that no satisfaction was to be obtained of Jupiter, whose whole
+intellect seemed to be absorbed by “de bug,” I now stepped into the boat
+and made sail. With a fair and strong breeze we soon ran into the little
+cove to the northward of Fort Moultrie, and a walk of some two miles
+brought us to the hut. It was about three in the afternoon when we
+arrived. Legrand had been awaiting us in eager expectation. He grasped
+my hand with a nervous empressement which alarmed me and strengthened
+the suspicions already entertained. His countenance was pale even to
+ghastliness, and his deep-set eyes glared with unnatural lustre. After
+some inquiries respecting his health, I asked him, not knowing what
+better to say, if he had yet obtained the scarabæus from Lieutenant
+G ----.
+
+“Oh, yes,” he replied, coloring violently, “I got it from him the next
+morning. Nothing should tempt me to part with that scarabæus. Do you
+know that Jupiter is quite right about it?”
+
+“In what way?” I asked, with a sad foreboding at heart.
+
+“In supposing it to be a bug of real gold.” He said this with an air of
+profound seriousness, and I felt inexpressibly shocked.
+
+“This bug is to make my fortune,” he continued, with a triumphant smile,
+“to reinstate me in my family possessions. Is it any wonder, then, that
+I prize it? Since Fortune has thought fit to bestow it upon me, I have
+only to use it properly and I shall arrive at the gold of which it is
+the index. Jupiter; bring me that scarabæus!”
+
+“What! de bug, massa? I’d rudder not go fer trubble dat bug--you mus git
+him for your own self.” Hereupon Legrand arose, with a grave and
+stately air, and brought me the beetle from a glass case in which it was
+enclosed. It was a beautiful scarabæus, and, at that time, unknown to
+naturalists--of course a great prize in a scientific point of view.
+There were two round, black spots near one extremity of the back, and
+a long one near the other. The scales were exceedingly hard and glossy,
+with all the appearance of burnished gold. The weight of the insect
+was very remarkable, and, taking all things into consideration, I could
+hardly blame Jupiter for his opinion respecting it; but what to make of
+Legrand’s concordance with that opinion, I could not, for the life of
+me, tell.
+
+“I sent for you,” said he, in a grandiloquent tone, when I had completed
+my examination of the beetle, “I sent for you, that I might have your
+counsel and assistance in furthering the views of Fate and of the bug”--
+
+“My dear Legrand,” I cried, interrupting him, “you are certainly unwell,
+and had better use some little precautions. You shall go to bed, and
+I will remain with you a few days, until you get over this. You are
+feverish and”--
+
+“Feel my pulse,” said he.
+
+I felt it, and, to say the truth, found not the slightest indication of
+fever.
+
+“But you may be ill and yet have no fever. Allow me this once to
+prescribe for you. In the first place, go to bed. In the next”--
+
+“You are mistaken,” he interposed, “I am as well as I can expect to be
+under the excitement which I suffer. If you really wish me well, you
+will relieve this excitement.”
+
+“And how is this to be done?”
+
+“Very easily. Jupiter and myself are going upon an expedition into the
+hills, upon the main land, and, in this expedition we shall need the
+aid of some person in whom we can confide. You are the only one we can
+trust. Whether we succeed or fail, the excitement which you now perceive
+in me will be equally allayed.”
+
+“I am anxious to oblige you in any way,” I replied; “but do you mean to
+say that this infernal beetle has any connection with your expedition
+into the hills?”
+
+“It has.”
+
+“Then, Legrand, I can become a party to no such absurd proceeding.”
+
+“I am sorry--very sorry--for we shall have to try it by ourselves.”
+
+“Try it by yourselves! The man is surely mad!--but stay!--how long do
+you propose to be absent?”
+
+“Probably all night. We shall start immediately, and be back, at all
+events, by sunrise.”
+
+“And will you promise me, upon your honor, that when this freak of yours
+is over, and the bug business (good God!) settled to your satisfaction,
+you will then return home and follow my advice implicitly, as that of
+your physician?”
+
+“Yes; I promise; and now let us be off, for we have no time to lose.”
+
+With a heavy heart I accompanied my friend. We started about four
+o’clock--Legrand, Jupiter, the dog, and myself. Jupiter had with him the
+scythe and spades--the whole of which he insisted upon carrying--more
+through fear, it seemed to me, of trusting either of the implements
+within reach of his master, than from any excess of industry or
+complaisance. His demeanor was dogged in the extreme, and “dat deuced
+bug” were the sole words which escaped his lips during the journey. For
+my own part, I had charge of a couple of dark lanterns, while Legrand
+contented himself with the scarabæus, which he carried attached to the
+end of a bit of whip-cord; twirling it to and fro, with the air of a
+conjuror, as he went. When I observed this last, plain evidence of my
+friend’s aberration of mind, I could scarcely refrain from tears. I
+thought it best, however, to humor his fancy, at least for the present,
+or until I could adopt some more energetic measures with a chance of
+success. In the mean time I endeavored, but all in vain, to sound him in
+regard to the object of the expedition. Having succeeded in inducing
+me to accompany him, he seemed unwilling to hold conversation upon any
+topic of minor importance, and to all my questions vouchsafed no other
+reply than “we shall see!”
+
+We crossed the creek at the head of the island by means of a skiff; and,
+ascending the high grounds on the shore of the main land, proceeded in a
+northwesterly direction, through a tract of country excessively wild and
+desolate, where no trace of a human footstep was to be seen. Legrand led
+the way with decision; pausing only for an instant, here and there, to
+consult what appeared to be certain landmarks of his own contrivance
+upon a former occasion.
+
+In this manner we journeyed for about two hours, and the sun was just
+setting when we entered a region infinitely more dreary than any yet
+seen. It was a species of table land, near the summit of an almost
+inaccessible hill, densely wooded from base to pinnacle, and
+interspersed with huge crags that appeared to lie loosely upon the soil,
+and in many cases were prevented from precipitating themselves into the
+valleys below, merely by the support of the trees against which they
+reclined. Deep ravines, in various directions, gave an air of still
+sterner solemnity to the scene.
+
+The natural platform to which we had clambered was thickly overgrown
+with brambles, through which we soon discovered that it would have
+been impossible to force our way but for the scythe; and Jupiter, by
+direction of his master, proceeded to clear for us a path to the foot of
+an enormously tall tulip-tree, which stood, with some eight or ten oaks,
+upon the level, and far surpassed them all, and all other trees which I
+had then ever seen, in the beauty of its foliage and form, in the wide
+spread of its branches, and in the general majesty of its appearance.
+When we reached this tree, Legrand turned to Jupiter, and asked him if
+he thought he could climb it. The old man seemed a little staggered
+by the question, and for some moments made no reply. At length he
+approached the huge trunk, walked slowly around it, and examined it with
+minute attention. When he had completed his scrutiny, he merely said,
+
+“Yes, massa, Jup climb any tree he ebber see in he life.”
+
+“Then up with you as soon as possible, for it will soon be too dark to
+see what we are about.”
+
+“How far mus go up, massa?” inquired Jupiter.
+
+“Get up the main trunk first, and then I will tell you which way to
+go--and here--stop! take this beetle with you.”
+
+“De bug, Massa Will!--de goole bug!” cried the negro, drawing back in
+dismay--“what for mus tote de bug way up de tree?--d-n if I do!”
+
+“If you are afraid, Jup, a great big negro like you, to take hold of
+a harmless little dead beetle, why you can carry it up by this
+string--but, if you do not take it up with you in some way, I shall be
+under the necessity of breaking your head with this shovel.”
+
+“What de matter now, massa?” said Jup, evidently shamed into compliance;
+“always want for to raise fuss wid old nigger. Was only funnin any how.
+Me feered de bug! what I keer for de bug?” Here he took cautiously hold
+of the extreme end of the string, and, maintaining the insect as far
+from his person as circumstances would permit, prepared to ascend the
+tree.
+
+In youth, the tulip-tree, or Liriodendron Tulipferum, the most
+magnificent of American foresters, has a trunk peculiarly smooth, and
+often rises to a great height without lateral branches; but, in its
+riper age, the bark becomes gnarled and uneven, while many short limbs
+make their appearance on the stem. Thus the difficulty of ascension, in
+the present case, lay more in semblance than in reality. Embracing the
+huge cylinder, as closely as possible, with his arms and knees, seizing
+with his hands some projections, and resting his naked toes upon
+others, Jupiter, after one or two narrow escapes from falling, at length
+wriggled himself into the first great fork, and seemed to consider the
+whole business as virtually accomplished. The risk of the achievement
+was, in fact, now over, although the climber was some sixty or seventy
+feet from the ground.
+
+“Which way mus go now, Massa Will?” he asked.
+
+“Keep up the largest branch--the one on this side,” said Legrand. The
+negro obeyed him promptly, and apparently with but little trouble;
+ascending higher and higher, until no glimpse of his squat figure could
+be obtained through the dense foliage which enveloped it. Presently his
+voice was heard in a sort of halloo.
+
+“How much fudder is got for go?”
+
+“How high up are you?” asked Legrand.
+
+“Ebber so fur,” replied the negro; “can see de sky fru de top ob de
+tree.”
+
+“Never mind the sky, but attend to what I say. Look down the trunk and
+count the limbs below you on this side. How many limbs have you passed?”
+
+“One, two, tree, four, fibe--I done pass fibe big limb, massa, pon dis
+side.”
+
+“Then go one limb higher.”
+
+In a few minutes the voice was heard again, announcing that the seventh
+limb was attained.
+
+“Now, Jup,” cried Legrand, evidently much excited, “I want you to work
+your way out upon that limb as far as you can. If you see anything
+strange, let me know.” By this time what little doubt I might have
+entertained of my poor friend’s insanity, was put finally at rest. I had
+no alternative but to conclude him stricken with lunacy, and I became
+seriously anxious about getting him home. While I was pondering upon
+what was best to be done, Jupiter’s voice was again heard.
+
+“Mos feerd for to ventur pon dis limb berry far--tis dead limb putty
+much all de way.”
+
+“Did you say it was a dead limb, Jupiter?” cried Legrand in a quavering
+voice.
+
+“Yes, massa, him dead as de door-nail--done up for sartain--done
+departed dis here life.”
+
+“What in the name heaven shall I do?” asked Legrand, seemingly in the
+greatest distress. “Do!” said I, glad of an opportunity to interpose
+a word, “why come home and go to bed. Come now!--that’s a fine fellow.
+It’s getting late, and, besides, you remember your promise.”
+
+“Jupiter,” cried he, without heeding me in the least, “do you hear me?”
+
+“Yes, Massa Will, hear you ebber so plain.”
+
+“Try the wood well, then, with your knife, and see if you think it very
+rotten.”
+
+“Him rotten, massa, sure nuff,” replied the negro in a few moments, “but
+not so berry rotten as mought be. Mought ventur out leetle way pon de
+limb by myself, dat’s true.”
+
+“By yourself!--what do you mean?”
+
+“Why I mean de bug. ‘Tis berry hebby bug. Spose I drop him down fuss,
+and den de limb won’t break wid just de weight ob one nigger.”
+
+“You infernal scoundrel!” cried Legrand, apparently much relieved, “what
+do you mean by telling me such nonsense as that? As sure as you drop
+that beetle I’ll break your neck. Look here, Jupiter, do you hear me?”
+
+“Yes, massa, needn’t hollo at poor nigger dat style.”
+
+“Well! now listen!--if you will venture out on the limb as far as you
+think safe, and not let go the beetle, I’ll make you a present of a
+silver dollar as soon as you get down.”
+
+“I’m gwine, Massa Will--deed I is,” replied the negro very
+promptly--“mos out to the eend now.”
+
+“Out to the end!” here fairly screamed Legrand, “do you say you are out
+to the end of that limb?”
+
+“Soon be to de eend, massa,--o-o-o-o-oh! Lor-gol-a-marcy! what is dis
+here pon de tree?”
+
+“Well!” cried Legrand, highly delighted, “what is it?”
+
+“Why taint noffin but a skull--somebody bin lef him head up de tree, and
+de crows done gobble ebery bit ob de meat off.”
+
+“A skull, you say!--very well!--how is it fastened to the limb?--what
+holds it on?”
+
+“Sure nuff, massa; mus look. Why dis berry curous sarcumstance, pon my
+word--dare’s a great big nail in de skull, what fastens ob it on to de
+tree.”
+
+“Well now, Jupiter, do exactly as I tell you--do you hear?”
+
+“Yes, massa.”
+
+“Pay attention, then!--find the left eye of the skull.”
+
+“Hum! hoo! dat’s good! why dare aint no eye lef at all.”
+
+“Curse your stupidity! do you know your right hand from your left?”
+
+“Yes, I nose dat--nose all bout dat--tis my lef hand what I chops de
+wood wid.”
+
+“To be sure! you are left-handed; and your left eye is on the same
+side as your left hand. Now, I suppose, you can find the left eye of the
+skull, or the place where the left eye has been. Have you found it?”
+
+Here was a long pause. At length the negro asked,
+
+“Is de lef eye of de skull pon de same side as de lef hand of de skull,
+too?--cause de skull aint got not a bit ob a hand at all--nebber mind!
+I got de lef eye now--here de lef eye! what mus do wid it?”
+
+“Let the beetle drop through it, as far as the string will reach--but
+be careful and not let go your hold of the string.”
+
+“All dat done, Massa Will; mighty easy ting for to put de bug fru de
+hole--look out for him dare below!”
+
+During this colloquy no portion of Jupiter’s person could be seen; but
+the beetle, which he had suffered to descend, was now visible at the
+end of the string, and glistened, like a globe of burnished gold, in the
+last rays of the setting sun, some of which still faintly illumined
+the eminence upon which we stood. The scarabæus hung quite clear of
+any branches, and, if allowed to fall, would have fallen at our feet.
+Legrand immediately took the scythe, and cleared with it a circular
+space, three or four yards in diameter, just beneath the insect, and,
+having accomplished this, ordered Jupiter to let go the string and come
+down from the tree.
+
+Driving a peg, with great nicety, into the ground, at the precise spot
+where the beetle fell, my friend now produced from his pocket a tape
+measure. Fastening one end of this at that point of the trunk, of the
+tree which was nearest the peg, he unrolled it till it reached the peg,
+and thence farther unrolled it, in the direction already established
+by the two points of the tree and the peg, for the distance of fifty
+feet--Jupiter clearing away the brambles with the scythe. At the spot
+thus attained a second peg was driven, and about this, as a centre, a
+rude circle, about four feet in diameter, described. Taking now a spade
+himself, and giving one to Jupiter and one to me, Legrand begged us to
+set about digging as quickly as possible.
+
+To speak the truth, I had no especial relish for such amusement at any
+time, and, at that particular moment, would most willingly have declined
+it; for the night was coming on, and I felt much fatigued with the
+exercise already taken; but I saw no mode of escape, and was fearful
+of disturbing my poor friend’s equanimity by a refusal. Could I have
+depended, indeed, upon Jupiter’s aid, I would have had no hesitation in
+attempting to get the lunatic home by force; but I was too well assured
+of the old negro’s disposition, to hope that he would assist me, under
+any circumstances, in a personal contest with his master. I made no
+doubt that the latter had been infected with some of the innumerable
+Southern superstitions about money buried, and that his phantasy had
+received confirmation by the finding of the scarabæus, or, perhaps, by
+Jupiter’s obstinacy in maintaining it to be “a bug of real gold.” A
+mind disposed to lunacy would readily be led away by such
+suggestions--especially if chiming in with favorite preconceived
+ideas--and then I called to mind the poor fellow’s speech about the
+beetle’s being “the index of his fortune.” Upon the whole, I was sadly
+vexed and puzzled, but, at length, I concluded to make a virtue of
+necessity--to dig with a good will, and thus the sooner to convince the
+visionary, by ocular demonstration, of the fallacy of the opinions he
+entertained.
+
+The lanterns having been lit, we all fell to work with a zeal worthy
+a more rational cause; and, as the glare fell upon our persons and
+implements, I could not help thinking how picturesque a group we
+composed, and how strange and suspicious our labors must have appeared
+to any interloper who, by chance, might have stumbled upon our
+whereabouts.
+
+We dug very steadily for two hours. Little was said; and our chief
+embarrassment lay in the yelpings of the dog, who took exceeding
+interest in our proceedings. He, at length, became so obstreperous
+that we grew fearful of his giving the alarm to some stragglers in
+the vicinity;--or, rather, this was the apprehension of Legrand;--for
+myself, I should have rejoiced at any interruption which might have
+enabled me to get the wanderer home. The noise was, at length, very
+effectually silenced by Jupiter, who, getting out of the hole with a
+dogged air of deliberation, tied the brute’s mouth up with one of his
+suspenders, and then returned, with a grave chuckle, to his task.
+
+When the time mentioned had expired, we had reached a depth of five
+feet, and yet no signs of any treasure became manifest. A general pause
+ensued, and I began to hope that the farce was at an end. Legrand,
+however, although evidently much disconcerted, wiped his brow
+thoughtfully and recommenced. We had excavated the entire circle of four
+feet diameter, and now we slightly enlarged the limit, and went to the
+farther depth of two feet. Still nothing appeared. The gold-seeker, whom
+I sincerely pitied, at length clambered from the pit, with the bitterest
+disappointment imprinted upon every feature, and proceeded, slowly
+and reluctantly, to put on his coat, which he had thrown off at the
+beginning of his labor. In the mean time I made no remark. Jupiter, at a
+signal from his master, began to gather up his tools. This done, and the
+dog having been unmuzzled, we turned in profound silence towards home.
+
+We had taken, perhaps, a dozen steps in this direction, when, with a
+loud oath, Legrand strode up to Jupiter, and seized him by the collar.
+The astonished negro opened his eyes and mouth to the fullest extent,
+let fall the spades, and fell upon his knees.
+
+“You scoundrel,” said Legrand, hissing out the syllables from between
+his clenched teeth--“you infernal black villain!--speak, I tell
+you!--answer me this instant, without prevarication!--which--which is
+your left eye?”
+
+“Oh, my golly, Massa Will! aint dis here my lef eye for sartain?” roared
+the terrified Jupiter, placing his hand upon his right organ of vision,
+and holding it there with a desperate pertinacity, as if in immediate
+dread of his master’s attempt at a gouge.
+
+“I thought so!--I knew it! hurrah!” vociferated Legrand, letting the
+negro go, and executing a series of curvets and caracols, much to the
+astonishment of his valet, who, arising from his knees, looked, mutely,
+from his master to myself, and then from myself to his master.
+
+“Come! we must go back,” said the latter, “the game’s not up yet;” and
+he again led the way to the tulip-tree.
+
+“Jupiter,” said he, when we reached its foot, “come here! was the skull
+nailed to the limb with the face outwards, or with the face to the
+limb?”
+
+“De face was out, massa, so dat de crows could get at de eyes good,
+widout any trouble.”
+
+“Well, then, was it this eye or that through which you dropped the
+beetle?”--here Legrand touched each of Jupiter’s eyes.
+
+“Twas dis eye, massa--de lef eye--jis as you tell me,” and here it was
+his right eye that the negro indicated.
+
+“That will do--must try it again.”
+
+Here my friend, about whose madness I now saw, or fancied that I saw,
+certain indications of method, removed the peg which marked the spot
+where the beetle fell, to a spot about three inches to the westward
+of its former position. Taking, now, the tape measure from the nearest
+point of the trunk to the peg, as before, and continuing the extension
+in a straight line to the distance of fifty feet, a spot was indicated,
+removed, by several yards, from the point at which we had been digging.
+
+Around the new position a circle, somewhat larger than in the former
+instance, was now described, and we again set to work with the spades.
+I was dreadfully weary, but, scarcely understanding what had occasioned
+the change in my thoughts, I felt no longer any great aversion from the
+labor imposed. I had become most unaccountably interested--nay, even
+excited. Perhaps there was something, amid all the extravagant demeanor
+of Legrand--some air of forethought, or of deliberation, which impressed
+me. I dug eagerly, and now and then caught myself actually looking,
+with something that very much resembled expectation, for the fancied
+treasure, the vision of which had demented my unfortunate companion. At
+a period when such vagaries of thought most fully possessed me, and
+when we had been at work perhaps an hour and a half, we were again
+interrupted by the violent howlings of the dog. His uneasiness, in the
+first instance, had been, evidently, but the result of playfulness or
+caprice, but he now assumed a bitter and serious tone. Upon Jupiter’s
+again attempting to muzzle him, he made furious resistance, and, leaping
+into the hole, tore up the mould frantically with his claws. In a few
+seconds he had uncovered a mass of human bones, forming two complete
+skeletons, intermingled with several buttons of metal, and what appeared
+to be the dust of decayed woollen. One or two strokes of a spade
+upturned the blade of a large Spanish knife, and, as we dug farther,
+three or four loose pieces of gold and silver coin came to light.
+
+At sight of these the joy of Jupiter could scarcely be restrained, but
+the countenance of his master wore an air of extreme disappointment He
+urged us, however, to continue our exertions, and the words were hardly
+uttered when I stumbled and fell forward, having caught the toe of my
+boot in a large ring of iron that lay half buried in the loose earth.
+
+We now worked in earnest, and never did I pass ten minutes of more
+intense excitement. During this interval we had fairly unearthed an
+oblong chest of wood, which, from its perfect preservation and
+wonderful hardness, had plainly been subjected to some mineralizing
+process--perhaps that of the Bi-chloride of Mercury. This box was three
+feet and a half long, three feet broad, and two and a half feet deep. It
+was firmly secured by bands of wrought iron, riveted, and forming a kind
+of open trelliswork over the whole. On each side of the chest, near the
+top, were three rings of iron--six in all--by means of which a firm hold
+could be obtained by six persons. Our utmost united endeavors served
+only to disturb the coffer very slightly in its bed. We at once saw
+the impossibility of removing so great a weight. Luckily, the sole
+fastenings of the lid consisted of two sliding bolts. These we drew
+back--trembling and panting with anxiety. In an instant, a treasure of
+incalculable value lay gleaming before us. As the rays of the lanterns
+fell within the pit, there flashed upwards a glow and a glare, from a
+confused heap of gold and of jewels, that absolutely dazzled our eyes.
+
+I shall not pretend to describe the feelings with which I gazed.
+Amazement was, of course, predominant. Legrand appeared exhausted with
+excitement, and spoke very few words. Jupiter’s countenance wore, for
+some minutes, as deadly a pallor as it is possible, in nature of things,
+for any negro’s visage to assume. He seemed stupified--thunderstricken.
+Presently he fell upon his knees in the pit, and, burying his naked
+arms up to the elbows in gold, let them there remain, as if enjoying the
+luxury of a bath. At length, with a deep sigh, he exclaimed, as if in a
+soliloquy,
+
+“And dis all cum ob de goole-bug! de putty goole bug! de poor little
+goole-bug, what I boosed in dat sabage kind ob style! Aint you shamed ob
+yourself, nigger?--answer me dat!”
+
+It became necessary, at last, that I should arouse both master and valet
+to the expediency of removing the treasure. It was growing late, and
+it behooved us to make exertion, that we might get every thing housed
+before daylight. It was difficult to say what should be done, and much
+time was spent in deliberation--so confused were the ideas of all. We,
+finally, lightened the box by removing two thirds of its contents,
+when we were enabled, with some trouble, to raise it from the hole. The
+articles taken out were deposited among the brambles, and the dog
+left to guard them, with strict orders from Jupiter neither, upon any
+pretence, to stir from the spot, nor to open his mouth until our return.
+We then hurriedly made for home with the chest; reaching the hut in
+safety, but after excessive toil, at one o’clock in the morning. Worn
+out as we were, it was not in human nature to do more immediately. We
+rested until two, and had supper; starting for the hills immediately
+afterwards, armed with three stout sacks, which, by good luck, were upon
+the premises. A little before four we arrived at the pit, divided the
+remainder of the booty, as equally as might be, among us, and, leaving
+the holes unfilled, again set out for the hut, at which, for the second
+time, we deposited our golden burthens, just as the first faint streaks
+of the dawn gleamed from over the tree-tops in the East.
+
+We were now thoroughly broken down; but the intense excitement of the
+time denied us repose. After an unquiet slumber of some three or four
+hours’ duration, we arose, as if by preconcert, to make examination of
+our treasure.
+
+The chest had been full to the brim, and we spent the whole day, and the
+greater part of the next night, in a scrutiny of its contents. There had
+been nothing like order or arrangement. Every thing had been heaped
+in promiscuously. Having assorted all with care, we found ourselves
+possessed of even vaster wealth than we had at first supposed. In
+coin there was rather more than four hundred and fifty thousand
+dollars--estimating the value of the pieces, as accurately as we could,
+by the tables of the period. There was not a particle of silver. All was
+gold of antique date and of great variety--French, Spanish, and German
+money, with a few English guineas, and some counters, of which we had
+never seen specimens before. There were several very large and heavy
+coins, so worn that we could make nothing of their inscriptions. There
+was no American money. The value of the jewels we found more difficulty
+in estimating. There were diamonds--some of them exceedingly large and
+fine--a hundred and ten in all, and not one of them small; eighteen
+rubies of remarkable brilliancy;--three hundred and ten emeralds, all
+very beautiful; and twenty-one sapphires, with an opal. These stones had
+all been broken from their settings and thrown loose in the chest. The
+settings themselves, which we picked out from among the other gold,
+appeared to have been beaten up with hammers, as if to prevent
+identification. Besides all this, there was a vast quantity of solid
+gold ornaments;--nearly two hundred massive finger and earrings;--rich
+chains--thirty of these, if I remember;--eighty-three very large and
+heavy crucifixes;--five gold censers of great value;--a prodigious
+golden punch bowl, ornamented with richly chased vine-leaves and
+Bacchanalian figures; with two sword-handles exquisitely embossed, and
+many other smaller articles which I cannot recollect. The weight of
+these valuables exceeded three hundred and fifty pounds avoirdupois; and
+in this estimate I have not included one hundred and ninety-seven superb
+gold watches; three of the number being worth each five hundred dollars,
+if one. Many of them were very old, and as time keepers valueless; the
+works having suffered, more or less, from corrosion--but all were richly
+jewelled and in cases of great worth. We estimated the entire contents
+of the chest, that night, at a million and a half of dollars; and upon
+the subsequent disposal of the trinkets and jewels (a few being retained
+for our own use), it was found that we had greatly undervalued the
+treasure. When, at length, we had concluded our examination, and the
+intense excitement of the time had, in some measure, subsided, Legrand,
+who saw that I was dying with impatience for a solution of this
+most extraordinary riddle, entered into a full detail of all the
+circumstances connected with it.
+
+“You remember;” said he, “the night when I handed you the rough sketch I
+had made of the scarabæus. You recollect also, that I became quite vexed
+at you for insisting that my drawing resembled a death’s-head. When you
+first made this assertion I thought you were jesting; but afterwards
+I called to mind the peculiar spots on the back of the insect, and
+admitted to myself that your remark had some little foundation in fact.
+Still, the sneer at my graphic powers irritated me--for I am considered
+a good artist--and, therefore, when you handed me the scrap of
+parchment, I was about to crumple it up and throw it angrily into the
+fire.”
+
+“The scrap of paper, you mean,” said I.
+
+“No; it had much of the appearance of paper, and at first I supposed it
+to be such, but when I came to draw upon it, I discovered it, at once,
+to be a piece of very thin parchment. It was quite dirty, you remember.
+Well, as I was in the very act of crumpling it up, my glance fell
+upon the sketch at which you had been looking, and you may imagine my
+astonishment when I perceived, in fact, the figure of a death’s-head
+just where, it seemed to me, I had made the drawing of the beetle. For
+a moment I was too much amazed to think with accuracy. I knew that my
+design was very different in detail from this--although there was a
+certain similarity in general outline. Presently I took a candle, and
+seating myself at the other end of the room, proceeded to scrutinize the
+parchment more closely. Upon turning it over, I saw my own sketch
+upon the reverse, just as I had made it. My first idea, now, was mere
+surprise at the really remarkable similarity of outline--at the singular
+coincidence involved in the fact, that unknown to me, there should have
+been a skull upon the other side of the parchment, immediately beneath
+my figure of the scarabæus, and that this skull, not only in outline,
+but in size, should so closely resemble my drawing. I say the
+singularity of this coincidence absolutely stupified me for a time.
+This is the usual effect of such coincidences. The mind struggles to
+establish a connexion--a sequence of cause and effect--and, being
+unable to do so, suffers a species of temporary paralysis. But, when I
+recovered from this stupor, there dawned upon me gradually a conviction
+which startled me even far more than the coincidence. I began
+distinctly, positively, to remember that there had been no drawing upon
+the parchment when I made my sketch of the scarabæus. I became perfectly
+certain of this; for I recollected turning up first one side and then
+the other, in search of the cleanest spot. Had the skull been then
+there, of course I could not have failed to notice it. Here was indeed
+a mystery which I felt it impossible to explain; but, even at that early
+moment, there seemed to glimmer, faintly, within the most remote and
+secret chambers of my intellect, a glow-worm-like conception of
+that truth which last night’s adventure brought to so magnificent a
+demonstration. I arose at once, and putting the parchment securely away,
+dismissed all farther reflection until I should be alone.
+
+“When you had gone, and when Jupiter was fast asleep, I betook myself
+to a more methodical investigation of the affair. In the first place
+I considered the manner in which the parchment had come into my
+possession. The spot where we discovered the scarabaeus was on the coast
+of the main land, about a mile eastward of the island, and but a short
+distance above high water mark. Upon my taking hold of it, it gave me a
+sharp bite, which caused me to let it drop. Jupiter, with his accustomed
+caution, before seizing the insect, which had flown towards him, looked
+about him for a leaf, or something of that nature, by which to take hold
+of it. It was at this moment that his eyes, and mine also, fell upon the
+scrap of parchment, which I then supposed to be paper. It was lying half
+buried in the sand, a corner sticking up. Near the spot where we found
+it, I observed the remnants of the hull of what appeared to have been a
+ship’s long boat. The wreck seemed to have been there for a very great
+while; for the resemblance to boat timbers could scarcely be traced.
+
+“Well, Jupiter picked up the parchment, wrapped the beetle in it, and
+gave it to me. Soon afterwards we turned to go home, and on the way met
+Lieutenant G-. I showed him the insect, and he begged me to let him
+take it to the fort. Upon my consenting, he thrust it forthwith into his
+waistcoat pocket, without the parchment in which it had been wrapped,
+and which I had continued to hold in my hand during his inspection.
+Perhaps he dreaded my changing my mind, and thought it best to make sure
+of the prize at once--you know how enthusiastic he is on all subjects
+connected with Natural History. At the same time, without being
+conscious of it, I must have deposited the parchment in my own pocket.
+
+“You remember that when I went to the table, for the purpose of making
+a sketch of the beetle, I found no paper where it was usually kept.
+I looked in the drawer, and found none there. I searched my pockets,
+hoping to find an old letter, when my hand fell upon the parchment. I
+thus detail the precise mode in which it came into my possession; for
+the circumstances impressed me with peculiar force.
+
+“No doubt you will think me fanciful--but I had already established a
+kind of connexion. I had put together two links of a great chain. There
+was a boat lying upon a sea-coast, and not far from the boat was a
+parchment--not a paper--with a skull depicted upon it. You will,
+of course, ask ‘where is the connexion?’ I reply that the skull, or
+death’s-head, is the well-known emblem of the pirate. The flag of the
+death’s head is hoisted in all engagements.
+
+“I have said that the scrap was parchment, and not paper. Parchment
+is durable--almost imperishable. Matters of little moment are rarely
+consigned to parchment; since, for the mere ordinary purposes of drawing
+or writing, it is not nearly so well adapted as paper. This reflection
+suggested some meaning--some relevancy--in the death’s-head. I did not
+fail to observe, also, the form of the parchment. Although one of its
+corners had been, by some accident, destroyed, it could be seen that the
+original form was oblong. It was just such a slip, indeed, as might
+have been chosen for a memorandum--for a record of something to be long
+remembered and carefully preserved.”
+
+“But,” I interposed, “you say that the skull was not upon the parchment
+when you made the drawing of the beetle. How then do you trace any
+connexion between the boat and the skull--since this latter, according
+to your own admission, must have been designed (God only knows how or by
+whom) at some period subsequent to your sketching the scarabæus?”
+
+“Ah, hereupon turns the whole mystery; although the secret, at this
+point, I had comparatively little difficulty in solving. My steps were
+sure, and could afford but a single result. I reasoned, for example,
+thus: When I drew the scarabæus, there was no skull apparent upon
+the parchment. When I had completed the drawing I gave it to you, and
+observed you narrowly until you returned it. You, therefore, did not
+design the skull, and no one else was present to do it. Then it was not
+done by human agency. And nevertheless it was done.
+
+“At this stage of my reflections I endeavored to remember, and did
+remember, with entire distinctness, every incident which occurred about
+the period in question. The weather was chilly (oh rare and happy
+accident!), and a fire was blazing upon the hearth. I was heated with
+exercise and sat near the table. You, however, had drawn a chair close
+to the chimney. Just as I placed the parchment in your hand, and as you
+were in the act of inspecting it, Wolf, the Newfoundland, entered,
+and leaped upon your shoulders. With your left hand you caressed him and
+kept him off, while your right, holding the parchment, was permitted to
+fall listlessly between your knees, and in close proximity to the fire.
+At one moment I thought the blaze had caught it, and was about to
+caution you, but, before I could speak, you had withdrawn it, and were
+engaged in its examination. When I considered all these particulars, I
+doubted not for a moment that heat had been the agent in bringing to
+light, upon the parchment, the skull which I saw designed upon it. You
+are well aware that chemical preparations exist, and have existed time
+out of mind, by means of which it is possible to write upon either paper
+or vellum, so that the characters shall become visible only when
+subjected to the action of fire. Zaffre, digested in aqua regia, and
+diluted with four times its weight of water, is sometimes employed; a
+green tint results. The regulus of cobalt, dissolved in spirit of nitre,
+gives a red. These colors disappear at longer or shorter intervals after
+the material written upon cools, but again become apparent upon the
+re-application of heat.
+
+“I now scrutinized the death’s-head with care. Its outer edges--the
+edges of the drawing nearest the edge of the vellum--were far more
+distinct than the others. It was clear that the action of the caloric
+had been imperfect or unequal. I immediately kindled a fire, and
+subjected every portion of the parchment to a glowing heat. At first,
+the only effect was the strengthening of the faint lines in the skull;
+but, upon persevering in the experiment, there became visible, at
+the corner of the slip, diagonally opposite to the spot in which the
+death’s-head was delineated, the figure of what I at first supposed to
+be a goat. A closer scrutiny, however, satisfied me that it was intended
+for a kid.”
+
+“Ha! ha!” said I, “to be sure I have no right to laugh at you--a million
+and a half of money is too serious a matter for mirth--but you are not
+about to establish a third link in your chain--you will not find any
+especial connexion between your pirates and a goat--pirates, you know,
+have nothing to do with goats; they appertain to the farming interest.”
+
+“But I have just said that the figure was not that of a goat.”
+
+“Well, a kid then--pretty much the same thing.”
+
+“Pretty much, but not altogether,” said Legrand. “You may have heard of
+one Captain Kidd. I at once looked upon the figure of the animal as a
+kind of punning or hieroglyphical signature. I say signature; because
+its position upon the vellum suggested this idea. The death’s-head at
+the corner diagonally opposite, had, in the same manner, the air of a
+stamp, or seal. But I was sorely put out by the absence of all else--of
+the body to my imagined instrument--of the text for my context.”
+
+“I presume you expected to find a letter between the stamp and the
+signature.”
+
+“Something of that kind. The fact is, I felt irresistibly impressed with
+a presentiment of some vast good fortune impending. I can scarcely
+say why. Perhaps, after all, it was rather a desire than an actual
+belief;--but do you know that Jupiter’s silly words, about the bug
+being of solid gold, had a remarkable effect upon my fancy? And then the
+series of accidents and coincidences--these were so very extraordinary.
+Do you observe how mere an accident it was that these events should have
+occurred upon the sole day of all the year in which it has been, or may
+be, sufficiently cool for fire, and that without the fire, or without
+the intervention of the dog at the precise moment in which he appeared,
+I should never have become aware of the death’s-head, and so never the
+possessor of the treasure?”
+
+“But proceed--I am all impatience.”
+
+“Well; you have heard, of course, the many stories current--the thousand
+vague rumors afloat about money buried, somewhere upon the Atlantic
+coast, by Kidd and his associates. These rumors must have had some
+foundation in fact. And that the rumors have existed so long and so
+continuous, could have resulted, it appeared to me, only from the
+circumstance of the buried treasure still remaining entombed. Had Kidd
+concealed his plunder for a time, and afterwards reclaimed it, the
+rumors would scarcely have reached us in their present unvarying form.
+You will observe that the stories told are all about money-seekers,
+not about money-finders. Had the pirate recovered his money, there the
+affair would have dropped. It seemed to me that some accident--say the
+loss of a memorandum indicating its locality--had deprived him of the
+means of recovering it, and that this accident had become known to his
+followers, who otherwise might never have heard that treasure had been
+concealed at all, and who, busying themselves in vain, because unguided
+attempts, to regain it, had given first birth, and then universal
+currency, to the reports which are now so common. Have you ever heard of
+any important treasure being unearthed along the coast?”
+
+“Never.”
+
+“But that Kidd’s accumulations were immense, is well known. I took it
+for granted, therefore, that the earth still held them; and you will
+scarcely be surprised when I tell you that I felt a hope, nearly
+amounting to certainty, that the parchment so strangely found, involved
+a lost record of the place of deposit.”
+
+“But how did you proceed?”
+
+“I held the vellum again to the fire, after increasing the heat; but
+nothing appeared. I now thought it possible that the coating of dirt
+might have something to do with the failure; so I carefully rinsed the
+parchment by pouring warm water over it, and, having done this, I
+placed it in a tin pan, with the skull downwards, and put the pan upon
+a furnace of lighted charcoal. In a few minutes, the pan having become
+thoroughly heated, I removed the slip, and, to my inexpressible joy,
+found it spotted, in several places, with what appeared to be figures
+arranged in lines. Again I placed it in the pan, and suffered it to
+remain another minute. Upon taking it off, the whole was just as you see
+it now.” Here Legrand, having re-heated the parchment, submitted it to
+my inspection. The following characters were rudely traced, in a red
+tint, between the death’s-head and the goat:
+
+  “53‡‡†305))6*;4826)4‡)4‡);806*;48†8¶60))85;1‡);:‡
+  *8†83(88)5*†;46(;88*96*?;8)*‡(;485);5*†2:*‡(;4956*
+  2(5*--4)8¶8*;4069285);)6†8)4‡‡;1(‡9;48081;8:8‡1;4
+  8†85;4)485†528806*81(‡9;48;(88;4(‡?34;48)4‡;161;:
+  188;‡?;”
+
+“But,” said I, returning him the slip, “I am as much in the dark as
+ever. Were all the jewels of Golconda awaiting me upon my solution of
+this enigma, I am quite sure that I should be unable to earn them.”
+
+“And yet,” said Legrand, “the solution is by no means so difficult as
+you might be lead to imagine from the first hasty inspection of the
+characters. These characters, as any one might readily guess, form a
+cipher--that is to say, they convey a meaning; but then, from what is
+known of Kidd, I could not suppose him capable of constructing any of
+the more abstruse cryptographs. I made up my mind, at once, that this
+was of a simple species--such, however, as would appear, to the crude
+intellect of the sailor, absolutely insoluble without the key.”
+
+“And you really solved it?”
+
+“Readily; I have solved others of an abstruseness ten thousand times
+greater. Circumstances, and a certain bias of mind, have led me to
+take interest in such riddles, and it may well be doubted whether human
+ingenuity can construct an enigma of the kind which human ingenuity may
+not, by proper application, resolve. In fact, having once established
+connected and legible characters, I scarcely gave a thought to the mere
+difficulty of developing their import.
+
+“In the present case--indeed in all cases of secret writing--the first
+question regards the language of the cipher; for the principles of
+solution, so far, especially, as the more simple ciphers are concerned,
+depend upon, and are varied by, the genius of the particular idiom.
+In general, there is no alternative but experiment (directed by
+probabilities) of every tongue known to him who attempts the solution,
+until the true one be attained. But, with the cipher now before us, all
+difficulty was removed by the signature. The pun upon the word ‘Kidd’
+is appreciable in no other language than the English. But for this
+consideration I should have begun my attempts with the Spanish and
+French, as the tongues in which a secret of this kind would most
+naturally have been written by a pirate of the Spanish main. As it was,
+I assumed the cryptograph to be English.
+
+“You observe there are no divisions between the words. Had there been
+divisions, the task would have been comparatively easy. In such case
+I should have commenced with a collation and analysis of the shorter
+words, and, had a word of a single letter occurred, as is most likely,
+(a or I, for example,) I should have considered the solution as assured.
+But, there being no division, my first step was to ascertain the
+predominant letters, as well as the least frequent. Counting all, I
+constructed a table, thus:
+
+Of the character 8 there are 33.
+
+                          ;        “     26.
+                          4        “     19.
+                        ‡ )        “     16.
+                          *        “     13.
+                          5        “     12.
+                          6        “     11.
+                        † 1        “      8.
+                          0        “      6.
+                        9 2        “      5.
+                        : 3        “      4.
+                          ?        “      3.
+                          ¶        “      2.
+                         -.        “      1.
+
+“Now, in English, the letter which most frequently occurs is e.
+Afterwards, succession runs thus: _a o i d h n r s t u y c f g l m w b k
+p q x z_. _E_ predominates so remarkably that an individual sentence of
+any length is rarely seen, in which it is not the prevailing character.
+
+“Here, then, we leave, in the very beginning, the groundwork for
+something more than a mere guess. The general use which may be made of
+the table is obvious--but, in this particular cipher, we shall only very
+partially require its aid. As our predominant character is 8, we will
+commence by assuming it as the _e_ of the natural alphabet. To verify
+the supposition, let us observe if the 8 be seen often in couples--for
+_e_ is doubled with great frequency in English--in such words, for
+example, as ‘meet,’ ‘.fleet,’ ‘speed,’ ‘seen,’ been,’ ‘agree,’ &c. In
+the present instance we see it doubled no less than five times, although
+the cryptograph is brief.
+
+“Let us assume 8, then, as _e_. Now, of all _words_ in the language,
+‘the’ is most usual; let us see, therefore, whether there are not
+repetitions of any three characters, in the same order of collocation,
+the last of them being 8. If we discover repetitions of such letters,
+so arranged, they will most probably represent the word ‘the.’ Upon
+inspection, we find no less than seven such arrangements, the characters
+being;48. We may, therefore, assume that; represents _t_, 4 represents
+_h_, and 8 represents _e_--the last being now well confirmed. Thus a
+great step has been taken.
+
+“But, having established a single word, we are enabled to establish
+a vastly important point; that is to say, several commencements and
+terminations of other words. Let us refer, for example, to the last
+instance but one, in which the combination;48 occurs--not far from
+the end of the cipher. We know that the; immediately ensuing is the
+commencement of a word, and, of the six characters succeeding this
+‘the,’ we are cognizant of no less than five. Let us set these
+characters down, thus, by the letters we know them to represent, leaving
+a space for the unknown--
+
+t eeth.
+
+“Here we are enabled, at once, to discard the ‘th,’ as forming no
+portion of the word commencing with the first t; since, by experiment
+of the entire alphabet for a letter adapted to the vacancy, we perceive
+that no word can be formed of which this _th_ can be a part. We are thus
+narrowed into
+
+t ee,
+
+and, going through the alphabet, if necessary, as before, we arrive
+at the word ‘tree,’ as the sole possible reading. We thus gain
+another letter, _r_, represented by (, with the words ‘the tree’ in
+juxtaposition.
+
+“Looking beyond these words, for a short distance, we again see
+the combination;48, and employ it by way of _termination_ to what
+immediately precedes. We have thus this arrangement:
+
+the tree;4(‡?34 the,
+
+or, substituting the natural letters, where known, it reads thus:
+
+the tree thr‡?3h the.
+
+“Now, if, in place of the unknown characters, we leave blank spaces, or
+substitute dots, we read thus:
+
+the tree thr...h the,
+
+when the word ‘_through_’ makes itself evident at once. But this
+discovery gives us three new letters, _o_, _u_ and _g_, represented by
+‡? and 3.
+
+“Looking now, narrowly, through the cipher for combinations of known
+characters, we find, not very far from the beginning, this arrangement,
+
+83(88, or egree,
+
+which, plainly, is the conclusion of the word ‘degree,’ and gives us
+another letter, _d_, represented by †.
+
+“Four letters beyond the word ‘degree,’ we perceive the combination
+
+;46(;88.
+
+“Translating the known characters, and representing the unknown by dots,
+as before, we read thus: th rtee. an arrangement immediately suggestive
+of the word ‘thirteen,’ and again furnishing us with two new characters,
+_i_ and _n_, represented by 6 and *.
+
+“Referring, now, to the beginning of the cryptograph, we find the
+combination,
+
+53‡‡†.
+
+“Translating, as before, we obtain
+
+good,
+
+which assures us that the first letter is _A_, and that the first two
+words are ‘A good.’
+
+“It is now time that we arrange our key, as far as discovered, in a
+tabular form, to avoid confusion. It will stand thus:
+
+                5 represents      a
+                †       “         d
+                8       “         e
+                3       “         g
+                4       “         h
+                6       “         i
+                *       “         n
+                ‡       “         o
+                (       “         r
+                ;       “         t
+
+“We have, therefore, no less than ten of the most important letters
+represented, and it will be unnecessary to proceed with the details of
+the solution. I have said enough to convince you that ciphers of this
+nature are readily soluble, and to give you some insight into the
+rationale of their development. But be assured that the specimen before
+us appertains to the very simplest species of cryptograph. It now only
+remains to give you the full translation of the characters upon the
+parchment, as unriddled. Here it is:
+
+“‘_A good glass in the bishop’s hostel in the devil’s seat forty-one
+degrees and thirteen minutes northeast and by north main branch seventh
+limb east side shoot from the left eye of the death’s-head a bee line
+from the tree through the shot fifty feet out_.’”
+
+“But,” said I, “the enigma seems still in as bad a condition as ever.
+How is it possible to extort a meaning from all this jargon about
+‘devil’s seats,’ ‘death’s heads,’ and ‘bishop’s hotels?’”
+
+“I confess,” replied Legrand, “that the matter still wears a serious
+aspect, when regarded with a casual glance. My first endeavor was
+to divide the sentence into the natural division intended by the
+cryptographist.”
+
+“You mean, to punctuate it?”
+
+“Something of that kind.”
+
+“But how was it possible to effect this?”
+
+“I reflected that it had been a point with the writer to run his words
+together without division, so as to increase the difficulty of solution.
+Now, a not over-acute man, in pursuing such an object would be nearly
+certain to overdo the matter. When, in the course of his composition, he
+arrived at a break in his subject which would naturally require a pause,
+or a point, he would be exceedingly apt to run his characters, at this
+place, more than usually close together. If you will observe the MS., in
+the present instance, you will easily detect five such cases of unusual
+crowding. Acting upon this hint, I made the division thus: ‘A good
+glass in the Bishop’s hostel in the Devil’s seat--forty-one degrees and
+thirteen minutes--northeast and by north--main branch seventh limb east
+side--shoot from the left eye of the death’s-head--a bee-line from the
+tree through the shot fifty feet out.’”
+
+“Even this division,” said I, “leaves me still in the dark.”
+
+“It left me also in the dark,” replied Legrand, “for a few days; during
+which I made diligent inquiry, in the neighborhood of Sullivan’s Island,
+for any building which went by the name of the ‘Bishop’s Hotel;’ for, of
+course, I dropped the obsolete word ‘hostel.’ Gaining no information on
+the subject, I was on the point of extending my sphere of search, and
+proceeding in a more systematic manner, when, one morning, it entered
+into my head, quite suddenly, that this ‘Bishop’s Hostel’ might have
+some reference to an old family, of the name of Bessop, which, time out
+of mind, had held possession of an ancient manor-house, about four
+miles to the northward of the Island. I accordingly went over to the
+plantation, and re-instituted my inquiries among the older negroes of
+the place. At length one of the most aged of the women said that she
+had heard of such a place as Bessop’s Castle, and thought that she could
+guide me to it, but that it was not a castle nor a tavern, but a high
+rock.
+
+“I offered to pay her well for her trouble, and, after some demur,
+she consented to accompany me to the spot. We found it without much
+difficulty, when, dismissing her, I proceeded to examine the place. The
+‘castle’ consisted of an irregular assemblage of cliffs and rocks--one
+of the latter being quite remarkable for its height as well as for its
+insulated and artificial appearance I clambered to its apex, and then
+felt much at a loss as to what should be next done.
+
+“While I was busied in reflection, my eyes fell upon a narrow ledge in
+the eastern face of the rock, perhaps a yard below the summit upon which
+I stood. This ledge projected about eighteen inches, and was not more
+than a foot wide, while a niche in the cliff just above it, gave it
+a rude resemblance to one of the hollow-backed chairs used by our
+ancestors. I made no doubt that here was the ‘devil’s seat’ alluded to
+in the MS., and now I seemed to grasp the full secret of the riddle.
+
+“The ‘good glass,’ I knew, could have reference to nothing but a
+telescope; for the word ‘glass’ is rarely employed in any other sense
+by seamen. Now here, I at once saw, was a telescope to be used, and a
+definite point of view, admitting no variation, from which to use it.
+Nor did I hesitate to believe that the phrases, “forty-one degrees
+and thirteen minutes,’ and ‘northeast and by north,’ were intended as
+directions for the levelling of the glass. Greatly excited by these
+discoveries, I hurried home, procured a telescope, and returned to the
+rock.
+
+“I let myself down to the ledge, and found that it was impossible to
+retain a seat upon it except in one particular position. This fact
+confirmed my preconceived idea. I proceeded to use the glass. Of course,
+the ‘forty-one degrees and thirteen minutes’ could allude to nothing but
+elevation above the visible horizon, since the horizontal direction was
+clearly indicated by the words, ‘northeast and by north.’ This latter
+direction I at once established by means of a pocket-compass; then,
+pointing the glass as nearly at an angle of forty-one degrees of
+elevation as I could do it by guess, I moved it cautiously up or down,
+until my attention was arrested by a circular rift or opening in the
+foliage of a large tree that overtopped its fellows in the distance.
+In the centre of this rift I perceived a white spot, but could not, at
+first, distinguish what it was. Adjusting the focus of the telescope, I
+again looked, and now made it out to be a human skull.
+
+“Upon this discovery I was so sanguine as to consider the enigma solved;
+for the phrase ‘main branch, seventh limb, east side,’ could refer only
+to the position of the skull upon the tree, while ‘shoot from the left
+eye of the death’s head’ admitted, also, of but one interpretation, in
+regard to a search for buried treasure. I perceived that the design was
+to drop a bullet from the left eye of the skull, and that a bee-line,
+or, in other words, a straight line, drawn from the nearest point of
+the trunk through ‘the shot,’ (or the spot where the bullet fell,) and
+thence extended to a distance of fifty feet, would indicate a definite
+point--and beneath this point I thought it at least possible that a
+deposit of value lay concealed.”
+
+“All this,” I said, “is exceedingly clear, and, although ingenious,
+still simple and explicit. When you left the Bishop’s Hotel, what then?”
+
+“Why, having carefully taken the bearings of the tree, I turned
+homewards. The instant that I left ‘the devil’s seat,’ however, the
+circular rift vanished; nor could I get a glimpse of it afterwards, turn
+as I would. What seems to me the chief ingenuity in this whole business,
+is the fact (for repeated experiment has convinced me it is a fact) that
+the circular opening in question is visible from no other attainable
+point of view than that afforded by the narrow ledge upon the face of
+the rock.
+
+“In this expedition to the ‘Bishop’s Hotel’ I had been attended
+by Jupiter, who had, no doubt, observed, for some weeks past, the
+abstraction of my demeanor, and took especial care not to leave me
+alone. But, on the next day, getting up very early, I contrived to give
+him the slip, and went into the hills in search of the tree. After much
+toil I found it. When I came home at night my valet proposed to give
+me a flogging. With the rest of the adventure I believe you are as well
+acquainted as myself.”
+
+“I suppose,” said I, “you missed the spot, in the first attempt at
+digging, through Jupiter’s stupidity in letting the bug fall through the
+right instead of through the left eye of the skull.”
+
+“Precisely. This mistake made a difference of about two inches and a
+half in the ‘shot’--that is to say, in the position of the peg nearest
+the tree; and had the treasure been beneath the ‘shot,’ the error would
+have been of little moment; but ‘the shot,’ together with the nearest
+point of the tree, were merely two points for the establishment of
+a line of direction; of course the error, however trivial in the
+beginning, increased as we proceeded with the line, and by the time
+we had gone fifty feet, threw us quite off the scent. But for my
+deep-seated impressions that treasure was here somewhere actually
+buried, we might have had all our labor in vain.”
+
+“But your grandiloquence, and your conduct in swinging the beetle--how
+excessively odd! I was sure you were mad. And why did you insist upon
+letting fall the bug, instead of a bullet, from the skull?”
+
+“Why, to be frank, I felt somewhat annoyed by your evident suspicions
+touching my sanity, and so resolved to punish you quietly, in my own
+way, by a little bit of sober mystification. For this reason I swung
+the beetle, and for this reason I let it fall it from the tree. An
+observation of yours about its great weight suggested the latter idea.”
+
+“Yes, I perceive; and now there is only one point which puzzles me. What
+are we to make of the skeletons found in the hole?”
+
+“That is a question I am no more able to answer than yourself. There
+seems, however, only one plausible way of accounting for them--and yet
+it is dreadful to believe in such atrocity as my suggestion would imply.
+It is clear that Kidd--if Kidd indeed secreted this treasure, which I
+doubt not--it is clear that he must have had assistance in the labor.
+But this labor concluded, he may have thought it expedient to remove
+all participants in his secret. Perhaps a couple of blows with a mattock
+were sufficient, while his coadjutors were busy in the pit; perhaps it
+required a dozen--who shall tell?”
+
+
+
+
+FOUR BEASTS IN ONE--THE HOMO-CAMELEOPARD
+
+                     Chacun a ses vertus.
+                        --_Crebillon’s Xerxes._
+
+ANTIOCHUS EPIPHANES is very generally looked upon as the Gog of the
+prophet Ezekiel. This honor is, however, more properly attributable to
+Cambyses, the son of Cyrus. And, indeed, the character of the
+Syrian monarch does by no means stand in need of any adventitious
+embellishment. His accession to the throne, or rather his usurpation of
+the sovereignty, a hundred and seventy-one years before the coming
+of Christ; his attempt to plunder the temple of Diana at Ephesus; his
+implacable hostility to the Jews; his pollution of the Holy of Holies;
+and his miserable death at Taba, after a tumultuous reign of eleven
+years, are circumstances of a prominent kind, and therefore more
+generally noticed by the historians of his time than the impious,
+dastardly, cruel, silly, and whimsical achievements which make up the
+sum total of his private life and reputation.
+
+Let us suppose, gentle reader, that it is now the year of the world
+three thousand eight hundred and thirty, and let us, for a few minutes,
+imagine ourselves at that most grotesque habitation of man, the
+remarkable city of Antioch. To be sure there were, in Syria and other
+countries, sixteen cities of that appellation, besides the one to which
+I more particularly allude. But ours is that which went by the name of
+Antiochia Epidaphne, from its vicinity to the little village of Daphne,
+where stood a temple to that divinity. It was built (although about this
+matter there is some dispute) by Seleucus Nicanor, the first king of the
+country after Alexander the Great, in memory of his father Antiochus,
+and became immediately the residence of the Syrian monarchy. In the
+flourishing times of the Roman Empire, it was the ordinary station of
+the prefect of the eastern provinces; and many of the emperors of the
+queen city (among whom may be mentioned, especially, Verus and Valens)
+spent here the greater part of their time. But I perceive we have
+arrived at the city itself. Let us ascend this battlement, and throw our
+eyes upon the town and neighboring country.
+
+“What broad and rapid river is that which forces its way, with
+innumerable falls, through the mountainous wilderness, and finally
+through the wilderness of buildings?”
+
+That is the Orontes, and it is the only water in sight, with the
+exception of the Mediterranean, which stretches, like a broad mirror,
+about twelve miles off to the southward. Every one has seen the
+Mediterranean; but let me tell you, there are few who have had a peep at
+Antioch. By few, I mean, few who, like you and me, have had, at the same
+time, the advantages of a modern education. Therefore cease to regard
+that sea, and give your whole attention to the mass of houses that lie
+beneath us. You will remember that it is now the year of the world three
+thousand eight hundred and thirty. Were it later--for example, were
+it the year of our Lord eighteen hundred and forty-five, we should be
+deprived of this extraordinary spectacle. In the nineteenth century
+Antioch is--that is to say, Antioch will be--in a lamentable state
+of decay. It will have been, by that time, totally destroyed, at three
+different periods, by three successive earthquakes. Indeed, to say the
+truth, what little of its former self may then remain, will be found in
+so desolate and ruinous a state that the patriarch shall have removed
+his residence to Damascus. This is well. I see you profit by my advice,
+and are making the most of your time in inspecting the premises--in
+
+-satisfying your eyes
+
+With the memorials and the things of fame
+
+That most renown this city.--
+
+I beg pardon; I had forgotten that Shakespeare will not flourish for
+seventeen hundred and fifty years to come. But does not the appearance
+of Epidaphne justify me in calling it grotesque?
+
+“It is well fortified; and in this respect is as much indebted to nature
+as to art.”
+
+Very true.
+
+“There are a prodigious number of stately palaces.”
+
+There are.
+
+“And the numerous temples, sumptuous and magnificent, may bear
+comparison with the most lauded of antiquity.”
+
+All this I must acknowledge. Still there is an infinity of mud huts, and
+abominable hovels. We cannot help perceiving abundance of filth in
+every kennel, and, were it not for the over-powering fumes of idolatrous
+incense, I have no doubt we should find a most intolerable stench.
+Did you ever behold streets so insufferably narrow, or houses so
+miraculously tall? What gloom their shadows cast upon the ground! It
+is well the swinging lamps in those endless colonnades are kept burning
+throughout the day; we should otherwise have the darkness of Egypt in
+the time of her desolation.
+
+“It is certainly a strange place! What is the meaning of yonder singular
+building? See! it towers above all others, and lies to the eastward of
+what I take to be the royal palace.”
+
+That is the new Temple of the Sun, who is adored in Syria under the
+title of Elah Gabalah. Hereafter a very notorious Roman Emperor
+will institute this worship in Rome, and thence derive a cognomen,
+Heliogabalus. I dare say you would like to take a peep at the divinity
+of the temple. You need not look up at the heavens; his Sunship is not
+there--at least not the Sunship adored by the Syrians. That deity will
+be found in the interior of yonder building. He is worshipped under the
+figure of a large stone pillar terminating at the summit in a cone or
+pyramid, whereby is denoted Fire.
+
+“Hark--behold!--who can those ridiculous beings be, half naked, with
+their faces painted, shouting and gesticulating to the rabble?”
+
+Some few are mountebanks. Others more particularly belong to the race
+of philosophers. The greatest portion, however--those especially who
+belabor the populace with clubs--are the principal courtiers of the
+palace, executing as in duty bound, some laudable comicality of the
+king’s.
+
+“But what have we here? Heavens! the town is swarming with wild beasts!
+How terrible a spectacle!--how dangerous a peculiarity!”
+
+Terrible, if you please; but not in the least degree dangerous. Each
+animal if you will take the pains to observe, is following, very
+quietly, in the wake of its master. Some few, to be sure, are led with a
+rope about the neck, but these are chiefly the lesser or timid species.
+The lion, the tiger, and the leopard are entirely without restraint.
+They have been trained without difficulty to their present
+profession, and attend upon their respective owners in the capacity of
+valets-de-chambre. It is true, there are occasions when Nature asserts
+her violated dominions;--but then the devouring of a man-at-arms, or the
+throttling of a consecrated bull, is a circumstance of too little moment
+to be more than hinted at in Epidaphne.
+
+“But what extraordinary tumult do I hear? Surely this is a loud noise
+even for Antioch! It argues some commotion of unusual interest.”
+
+Yes--undoubtedly. The king has ordered some novel spectacle--some
+gladiatorial exhibition at the hippodrome--or perhaps the massacre of
+the Scythian prisoners--or the conflagration of his new palace--or the
+tearing down of a handsome temple--or, indeed, a bonfire of a few Jews.
+The uproar increases. Shouts of laughter ascend the skies. The air
+becomes dissonant with wind instruments, and horrible with clamor of a
+million throats. Let us descend, for the love of fun, and see what is
+going on! This way--be careful! Here we are in the principal street,
+which is called the street of Timarchus. The sea of people is coming
+this way, and we shall find a difficulty in stemming the tide. They are
+pouring through the alley of Heraclides, which leads directly from the
+palace;--therefore the king is most probably among the rioters. Yes;--I
+hear the shouts of the herald proclaiming his approach in the pompous
+phraseology of the East. We shall have a glimpse of his person as
+he passes by the temple of Ashimah. Let us ensconce ourselves in the
+vestibule of the sanctuary; he will be here anon. In the meantime let
+us survey this image. What is it? Oh! it is the god Ashimah in proper
+person. You perceive, however, that he is neither a lamb, nor a
+goat, nor a satyr, neither has he much resemblance to the Pan of the
+Arcadians. Yet all these appearances have been given--I beg pardon--will
+be given--by the learned of future ages, to the Ashimah of the Syrians.
+Put on your spectacles, and tell me what it is. What is it?
+
+“Bless me! it is an ape!”
+
+True--a baboon; but by no means the less a deity. His name is a
+derivation of the Greek Simia--what great fools are antiquarians! But
+see!--see!--yonder scampers a ragged little urchin. Where is he going?
+What is he bawling about? What does he say? Oh! he says the king
+is coming in triumph; that he is dressed in state; that he has just
+finished putting to death, with his own hand, a thousand chained
+Israelitish prisoners! For this exploit the ragamuffin is lauding him to
+the skies. Hark! here comes a troop of a similar description. They have
+made a Latin hymn upon the valor of the king, and are singing it as they
+go:
+
+Mille, mille, mille,
+
+Mille, mille, mille,
+
+Decollavimus, unus homo!
+
+Mille, mille, mille, mille, decollavimus!
+
+Mille, mille, mille,
+
+Vivat qui mille mille occidit!
+
+Tantum vini habet nemo
+
+Quantum sanguinis effudit!(*1)
+
+Which may be thus paraphrased:
+
+A thousand, a thousand, a thousand,
+
+A thousand, a thousand, a thousand,
+
+We, with one warrior, have slain!
+
+A thousand, a thousand, a thousand, a thousand.
+
+Sing a thousand over again!
+
+Soho!--let us sing
+
+Long life to our king,
+
+Who knocked over a thousand so fine!
+
+Soho!--let us roar,
+
+He has given us more
+
+Red gallons of gore
+
+Than all Syria can furnish of wine!
+
+“Do you hear that flourish of trumpets?”
+
+Yes: the king is coming! See! the people are aghast with admiration,
+and lift up their eyes to the heavens in reverence. He comes;--he is
+coming;--there he is!
+
+“Who?--where?--the king?--do not behold him--cannot say that I perceive
+him.”
+
+Then you must be blind.
+
+“Very possible. Still I see nothing but a tumultuous mob of idiots
+and madmen, who are busy in prostrating themselves before a gigantic
+cameleopard, and endeavoring to obtain a kiss of the animal’s hoofs.
+See! the beast has very justly kicked one of the rabble over--and
+another--and another--and another. Indeed, I cannot help admiring the
+animal for the excellent use he is making of his feet.”
+
+Rabble, indeed!--why these are the noble and free citizens of Epidaphne!
+Beasts, did you say?--take care that you are not overheard. Do you not
+perceive that the animal has the visage of a man? Why, my dear sir,
+that cameleopard is no other than Antiochus Epiphanes, Antiochus the
+Illustrious, King of Syria, and the most potent of all the autocrats
+of the East! It is true, that he is entitled, at times, Antiochus
+Epimanes--Antiochus the madman--but that is because all people have not
+the capacity to appreciate his merits. It is also certain that he is at
+present ensconced in the hide of a beast, and is doing his best to play
+the part of a cameleopard; but this is done for the better sustaining
+his dignity as king. Besides, the monarch is of gigantic stature,
+and the dress is therefore neither unbecoming nor over large. We may,
+however, presume he would not have adopted it but for some occasion
+of especial state. Such, you will allow, is the massacre of a thousand
+Jews. With how superior a dignity the monarch perambulates on all fours!
+His tail, you perceive, is held aloft by his two principal concubines,
+Elline and Argelais; and his whole appearance would be infinitely
+prepossessing, were it not for the protuberance of his eyes, which will
+certainly start out of his head, and the queer color of his face, which
+has become nondescript from the quantity of wine he has swallowed. Let
+us follow him to the hippodrome, whither he is proceeding, and listen to
+the song of triumph which he is commencing:
+
+Who is king but Epiphanes?
+
+Say--do you know?
+
+Who is king but Epiphanes?
+
+Bravo!--bravo!
+
+There is none but Epiphanes,
+
+No--there is none:
+
+So tear down the temples,
+
+And put out the sun!
+
+Well and strenuously sung! The populace are hailing him ‘Prince of
+Poets,’ as well as ‘Glory of the East,’ ‘Delight of the Universe,’ and
+‘Most Remarkable of Cameleopards.’ They have encored his effusion,
+and do you hear?--he is singing it over again. When he arrives at the
+hippodrome, he will be crowned with the poetic wreath, in anticipation
+of his victory at the approaching Olympics.
+
+“But, good Jupiter! what is the matter in the crowd behind us?”
+
+Behind us, did you say?--oh! ah!--I perceive. My friend, it is well
+that you spoke in time. Let us get into a place of safety as soon as
+possible. Here!--let us conceal ourselves in the arch of this aqueduct,
+and I will inform you presently of the origin of the commotion. It has
+turned out as I have been anticipating. The singular appearance of the
+cameleopard and the head of a man, has, it seems, given offence to
+the notions of propriety entertained, in general, by the wild animals
+domesticated in the city. A mutiny has been the result; and, as is usual
+upon such occasions, all human efforts will be of no avail in quelling
+the mob. Several of the Syrians have already been devoured; but the
+general voice of the four-footed patriots seems to be for eating up the
+cameleopard. ‘The Prince of Poets,’ therefore, is upon his hinder legs,
+running for his life. His courtiers have left him in the lurch, and
+his concubines have followed so excellent an example. ‘Delight of the
+Universe,’ thou art in a sad predicament! ‘Glory of the East,’ thou art
+in danger of mastication! Therefore never regard so piteously thy tail;
+it will undoubtedly be draggled in the mud, and for this there is no
+help. Look not behind thee, then, at its unavoidable degradation; but
+take courage, ply thy legs with vigor, and scud for the hippodrome!
+Remember that thou art Antiochus Epiphanes. Antiochus the
+Illustrious!--also ‘Prince of Poets,’ ‘Glory of the East,’ ‘Delight of
+the Universe,’ and ‘Most Remarkable of Cameleopards!’ Heavens! what a
+power of speed thou art displaying! What a capacity for leg-bail
+thou art developing! Run, Prince!--Bravo, Epiphanes! Well done,
+Cameleopard!--Glorious Antiochus!--He runs!--he leaps!--he flies! Like
+an arrow from a catapult he approaches the hippodrome! He leaps!--he
+shrieks!--he is there! This is well; for hadst thou, ‘Glory of
+the East,’ been half a second longer in reaching the gates of the
+Amphitheatre, there is not a bear’s cub in Epidaphne that would not
+have had a nibble at thy carcase. Let us be off--let us take our
+departure!--for we shall find our delicate modern ears unable to endure
+the vast uproar which is about to commence in celebration of the king’s
+escape! Listen! it has already commenced. See!--the whole town is
+topsy-turvy.
+
+“Surely this is the most populous city of the East! What a wilderness
+of people! what a jumble of all ranks and ages! what a multiplicity
+of sects and nations! what a variety of costumes! what a Babel of
+languages! what a screaming of beasts! what a tinkling of instruments!
+what a parcel of philosophers!”
+
+Come let us be off.
+
+“Stay a moment! I see a vast hubbub in the hippodrome; what is the
+meaning of it, I beseech you?”
+
+That?--oh, nothing! The noble and free citizens of Epidaphne being, as
+they declare, well satisfied of the faith, valor, wisdom, and divinity
+of their king, and having, moreover, been eye-witnesses of his late
+superhuman agility, do think it no more than their duty to invest his
+brows (in addition to the poetic crown) with the wreath of victory
+in the footrace--a wreath which it is evident he must obtain at the
+celebration of the next Olympiad, and which, therefore, they now give
+him in advance.
+
+
+Footnotes--Four Beasts
+
+(*1) Flavius Vospicus says, that the hymn here introduced was sung by
+the rabble upon the occasion of Aurelian, in the Sarmatic war, having
+slain, with his own hand, nine hundred and fifty of the enemy.
+
+
+
+
+THE MURDERS IN THE RUE MORGUE
+
+  What song the Syrens sang, or what name Achilles assumed when he hid
+  himself among women, although puzzling questions, are not beyond
+  _all_ conjecture.
+
+                    --_Sir Thomas Browne._
+
+
+The mental features discoursed of as the analytical, are, in themselves,
+but little susceptible of analysis. We appreciate them only in their
+effects. We know of them, among other things, that they are always to
+their possessor, when inordinately possessed, a source of the liveliest
+enjoyment. As the strong man exults in his physical ability, delighting
+in such exercises as call his muscles into action, so glories the
+analyst in that moral activity which _disentangles._ He derives pleasure
+from even the most trivial occupations bringing his talent into play. He
+is fond of enigmas, of conundrums, of hieroglyphics; exhibiting in his
+solutions of each a degree of _acumen_ which appears to the ordinary
+apprehension præternatural. His results, brought about by the very soul
+and essence of method, have, in truth, the whole air of intuition.
+
+The faculty of re-solution is possibly much invigorated by mathematical
+study, and especially by that highest branch of it which, unjustly, and
+merely on account of its retrograde operations, has been called, as
+if _par excellence_, analysis. Yet to calculate is not in itself to
+analyse. A chess-player, for example, does the one without effort at
+the other. It follows that the game of chess, in its effects upon mental
+character, is greatly misunderstood. I am not now writing a treatise,
+but simply prefacing a somewhat peculiar narrative by observations very
+much at random; I will, therefore, take occasion to assert that the
+higher powers of the reflective intellect are more decidedly and more
+usefully tasked by the unostentatious game of draughts than by all the
+elaborate frivolity of chess. In this latter, where the pieces have
+different and _bizarre_ motions, with various and variable values, what
+is only complex is mistaken (a not unusual error) for what is profound.
+The _attention_ is here called powerfully into play. If it flag for an
+instant, an oversight is committed resulting in injury or defeat. The
+possible moves being not only manifold but involute, the chances of such
+oversights are multiplied; and in nine cases out of ten it is the
+more concentrative rather than the more acute player who conquers. In
+draughts, on the contrary, where the moves are _unique_ and have but
+little variation, the probabilities of inadvertence are diminished, and
+the mere attention being left comparatively unemployed, what advantages
+are obtained by either party are obtained by superior _acumen_. To be
+less abstract--Let us suppose a game of draughts where the pieces are
+reduced to four kings, and where, of course, no oversight is to be
+expected. It is obvious that here the victory can be decided (the
+players being at all equal) only by some _recherché_ movement, the
+result of some strong exertion of the intellect. Deprived of ordinary
+resources, the analyst throws himself into the spirit of his opponent,
+identifies himself therewith, and not unfrequently sees thus, at a
+glance, the sole methods (sometime indeed absurdly simple ones) by which
+he may seduce into error or hurry into miscalculation.
+
+Whist has long been noted for its influence upon what is termed the
+calculating power; and men of the highest order of intellect have been
+known to take an apparently unaccountable delight in it, while eschewing
+chess as frivolous. Beyond doubt there is nothing of a similar nature
+so greatly tasking the faculty of analysis. The best chess-player in
+Christendom _may_ be little more than the best player of chess; but
+proficiency in whist implies capacity for success in all those more
+important undertakings where mind struggles with mind. When I say
+proficiency, I mean that perfection in the game which includes a
+comprehension of _all_ the sources whence legitimate advantage may be
+derived. These are not only manifold but multiform, and lie frequently
+among recesses of thought altogether inaccessible to the ordinary
+understanding. To observe attentively is to remember distinctly; and,
+so far, the concentrative chess-player will do very well at whist; while
+the rules of Hoyle (themselves based upon the mere mechanism of the
+game) are sufficiently and generally comprehensible. Thus to have a
+retentive memory, and to proceed by “the book,” are points commonly
+regarded as the sum total of good playing. But it is in matters beyond
+the limits of mere rule that the skill of the analyst is evinced. He
+makes, in silence, a host of observations and inferences. So, perhaps,
+do his companions; and the difference in the extent of the information
+obtained, lies not so much in the validity of the inference as in the
+quality of the observation. The necessary knowledge is that of _what_ to
+observe. Our player confines himself not at all; nor, because the game
+is the object, does he reject deductions from things external to the
+game. He examines the countenance of his partner, comparing it carefully
+with that of each of his opponents. He considers the mode of assorting
+the cards in each hand; often counting trump by trump, and honor by
+honor, through the glances bestowed by their holders upon each. He notes
+every variation of face as the play progresses, gathering a fund
+of thought from the differences in the expression of certainty, of
+surprise, of triumph, or of chagrin. From the manner of gathering up
+a trick he judges whether the person taking it can make another in the
+suit. He recognises what is played through feint, by the air with
+which it is thrown upon the table. A casual or inadvertent word; the
+accidental dropping or turning of a card, with the accompanying anxiety
+or carelessness in regard to its concealment; the counting of the
+tricks, with the order of their arrangement; embarrassment, hesitation,
+eagerness or trepidation--all afford, to his apparently intuitive
+perception, indications of the true state of affairs. The first two
+or three rounds having been played, he is in full possession of the
+contents of each hand, and thenceforward puts down his cards with as
+absolute a precision of purpose as if the rest of the party had turned
+outward the faces of their own.
+
+The analytical power should not be confounded with ample ingenuity; for
+while the analyst is necessarily ingenious, the ingenious man is often
+remarkably incapable of analysis. The constructive or combining power,
+by which ingenuity is usually manifested, and to which the phrenologists
+(I believe erroneously) have assigned a separate organ, supposing it a
+primitive faculty, has been so frequently seen in those whose intellect
+bordered otherwise upon idiocy, as to have attracted general observation
+among writers on morals. Between ingenuity and the analytic ability
+there exists a difference far greater, indeed, than that between the
+fancy and the imagination, but of a character very strictly analogous.
+It will be found, in fact, that the ingenious are always fanciful, and
+the _truly_ imaginative never otherwise than analytic.
+
+The narrative which follows will appear to the reader somewhat in the
+light of a commentary upon the propositions just advanced.
+
+Residing in Paris during the spring and part of the summer of 18--, I
+there became acquainted with a Monsieur C. Auguste Dupin. This young
+gentleman was of an excellent--indeed of an illustrious family, but, by
+a variety of untoward events, had been reduced to such poverty that the
+energy of his character succumbed beneath it, and he ceased to bestir
+himself in the world, or to care for the retrieval of his fortunes.
+By courtesy of his creditors, there still remained in his possession a
+small remnant of his patrimony; and, upon the income arising from this,
+he managed, by means of a rigorous economy, to procure the necessaries
+of life, without troubling himself about its superfluities. Books,
+indeed, were his sole luxuries, and in Paris these are easily obtained.
+
+Our first meeting was at an obscure library in the Rue Montmartre, where
+the accident of our both being in search of the same very rare and very
+remarkable volume, brought us into closer communion. We saw each other
+again and again. I was deeply interested in the little family history
+which he detailed to me with all that candor which a Frenchman indulges
+whenever mere self is his theme. I was astonished, too, at the vast
+extent of his reading; and, above all, I felt my soul enkindled within
+me by the wild fervor, and the vivid freshness of his imagination.
+Seeking in Paris the objects I then sought, I felt that the society of
+such a man would be to me a treasure beyond price; and this feeling I
+frankly confided to him. It was at length arranged that we should live
+together during my stay in the city; and as my worldly circumstances
+were somewhat less embarrassed than his own, I was permitted to be
+at the expense of renting, and furnishing in a style which suited the
+rather fantastic gloom of our common temper, a time-eaten and grotesque
+mansion, long deserted through superstitions into which we did not
+inquire, and tottering to its fall in a retired and desolate portion of
+the Faubourg St. Germain.
+
+Had the routine of our life at this place been known to the world, we
+should have been regarded as madmen--although, perhaps, as madmen of
+a harmless nature. Our seclusion was perfect. We admitted no visitors.
+Indeed the locality of our retirement had been carefully kept a secret
+from my own former associates; and it had been many years since Dupin
+had ceased to know or be known in Paris. We existed within ourselves
+alone.
+
+It was a freak of fancy in my friend (for what else shall I call it?) to
+be enamored of the Night for her own sake; and into this _bizarrerie_,
+as into all his others, I quietly fell; giving myself up to his wild
+whims with a perfect _abandon_. The sable divinity would not herself
+dwell with us always; but we could counterfeit her presence. At the
+first dawn of the morning we closed all the messy shutters of our old
+building; lighting a couple of tapers which, strongly perfumed, threw
+out only the ghastliest and feeblest of rays. By the aid of these we
+then busied our souls in dreams--reading, writing, or conversing, until
+warned by the clock of the advent of the true Darkness. Then we sallied
+forth into the streets arm in arm, continuing the topics of the day, or
+roaming far and wide until a late hour, seeking, amid the wild lights
+and shadows of the populous city, that infinity of mental excitement
+which quiet observation can afford.
+
+At such times I could not help remarking and admiring (although from
+his rich ideality I had been prepared to expect it) a peculiar analytic
+ability in Dupin. He seemed, too, to take an eager delight in its
+exercise--if not exactly in its display--and did not hesitate to confess
+the pleasure thus derived. He boasted to me, with a low chuckling laugh,
+that most men, in respect to himself, wore windows in their bosoms,
+and was wont to follow up such assertions by direct and very startling
+proofs of his intimate knowledge of my own. His manner at these moments
+was frigid and abstract; his eyes were vacant in expression; while his
+voice, usually a rich tenor, rose into a treble which would have sounded
+petulantly but for the deliberateness and entire distinctness of the
+enunciation. Observing him in these moods, I often dwelt meditatively
+upon the old philosophy of the Bi-Part Soul, and amused myself with the
+fancy of a double Dupin--the creative and the resolvent.
+
+Let it not be supposed, from what I have just said, that I am detailing
+any mystery, or penning any romance. What I have described in the
+Frenchman, was merely the result of an excited, or perhaps of a diseased
+intelligence. But of the character of his remarks at the periods in
+question an example will best convey the idea.
+
+We were strolling one night down a long dirty street in the vicinity of
+the Palais Royal. Being both, apparently, occupied with thought, neither
+of us had spoken a syllable for fifteen minutes at least. All at once
+Dupin broke forth with these words:
+
+“He is a very little fellow, that’s true, and would do better for the
+_Théâtre des Variétés_.”
+
+“There can be no doubt of that,” I replied unwittingly, and not at first
+observing (so much had I been absorbed in reflection) the extraordinary
+manner in which the speaker had chimed in with my meditations. In
+an instant afterward I recollected myself, and my astonishment was
+profound.
+
+“Dupin,” said I, gravely, “this is beyond my comprehension. I do not
+hesitate to say that I am amazed, and can scarcely credit my senses. How
+was it possible you should know I was thinking of -----?” Here I paused,
+to ascertain beyond a doubt whether he really knew of whom I thought.
+
+--“of Chantilly,” said he, “why do you pause? You were remarking to
+yourself that his diminutive figure unfitted him for tragedy.”
+
+This was precisely what had formed the subject of my reflections.
+Chantilly was a _quondam_ cobbler of the Rue St. Denis, who, becoming
+stage-mad, had attempted the _rôle_ of Xerxes, in Crébillon’s tragedy so
+called, and been notoriously Pasquinaded for his pains.
+
+“Tell me, for Heaven’s sake,” I exclaimed, “the method--if method there
+is--by which you have been enabled to fathom my soul in this matter.” In
+fact I was even more startled than I would have been willing to express.
+
+“It was the fruiterer,” replied my friend, “who brought you to the
+conclusion that the mender of soles was not of sufficient height for
+Xerxes _et id genus omne_.”
+
+“The fruiterer!--you astonish me--I know no fruiterer whomsoever.”
+
+“The man who ran up against you as we entered the street--it may have
+been fifteen minutes ago.”
+
+I now remembered that, in fact, a fruiterer, carrying upon his head a
+large basket of apples, had nearly thrown me down, by accident, as we
+passed from the Rue C ---- into the thoroughfare where we stood; but
+what this had to do with Chantilly I could not possibly understand.
+
+There was not a particle of _charlatanerie_ about Dupin. “I will
+explain,” he said, “and that you may comprehend all clearly, we will
+first retrace the course of your meditations, from the moment in which
+I spoke to you until that of the _rencontre_ with the fruiterer in
+question. The larger links of the chain run thus--Chantilly, Orion, Dr.
+Nichols, Epicurus, Stereotomy, the street stones, the fruiterer.”
+
+There are few persons who have not, at some period of their lives,
+amused themselves in retracing the steps by which particular conclusions
+of their own minds have been attained. The occupation is often full of
+interest and he who attempts it for the first time is astonished by
+the apparently illimitable distance and incoherence between the
+starting-point and the goal. What, then, must have been my amazement
+when I heard the Frenchman speak what he had just spoken, and when I
+could not help acknowledging that he had spoken the truth. He continued:
+
+“We had been talking of horses, if I remember aright, just before
+leaving the Rue C ----. This was the last subject we discussed. As we
+crossed into this street, a fruiterer, with a large basket upon his
+head, brushing quickly past us, thrust you upon a pile of paving stones
+collected at a spot where the causeway is undergoing repair. You stepped
+upon one of the loose fragments, slipped, slightly strained your ankle,
+appeared vexed or sulky, muttered a few words, turned to look at the
+pile, and then proceeded in silence. I was not particularly attentive to
+what you did; but observation has become with me, of late, a species of
+necessity.
+
+“You kept your eyes upon the ground--glancing, with a petulant
+expression, at the holes and ruts in the pavement, (so that I saw you
+were still thinking of the stones,) until we reached the little alley
+called Lamartine, which has been paved, by way of experiment, with the
+overlapping and riveted blocks. Here your countenance brightened up,
+and, perceiving your lips move, I could not doubt that you murmured the
+word ‘stereotomy,’ a term very affectedly applied to this species of
+pavement. I knew that you could not say to yourself ‘stereotomy’ without
+being brought to think of atomies, and thus of the theories of Epicurus;
+and since, when we discussed this subject not very long ago, I mentioned
+to you how singularly, yet with how little notice, the vague guesses
+of that noble Greek had met with confirmation in the late nebular
+cosmogony, I felt that you could not avoid casting your eyes upward to
+the great _nebula_ in Orion, and I certainly expected that you would do
+so. You did look up; and I was now assured that I had correctly followed
+your steps. But in that bitter _tirade_ upon Chantilly, which appeared
+in yesterday’s ‘_Musée_,’ the satirist, making some disgraceful
+allusions to the cobbler’s change of name upon assuming the buskin,
+quoted a Latin line about which we have often conversed. I mean the line
+
+     Perdidit antiquum litera sonum.
+
+“I had told you that this was in reference to Orion, formerly written
+Urion; and, from certain pungencies connected with this explanation, I
+was aware that you could not have forgotten it. It was clear, therefore,
+that you would not fail to combine the two ideas of Orion and Chantilly.
+That you did combine them I saw by the character of the smile which
+passed over your lips. You thought of the poor cobbler’s immolation. So
+far, you had been stooping in your gait; but now I saw you draw yourself
+up to your full height. I was then sure that you reflected upon the
+diminutive figure of Chantilly. At this point I interrupted your
+meditations to remark that as, in fact, he was a very little
+fellow--that Chantilly--he would do better at the _Théâtre des
+Variétés_.”
+
+Not long after this, we were looking over an evening edition of the
+“Gazette des Tribunaux,” when the following paragraphs arrested our
+attention.
+
+“EXTRAORDINARY MURDERS.--This morning, about three o’clock, the
+inhabitants of the Quartier St. Roch were aroused from sleep by a
+succession of terrific shrieks, issuing, apparently, from the fourth
+story of a house in the Rue Morgue, known to be in the sole occupancy of
+one Madame L’Espanaye, and her daughter Mademoiselle Camille L’Espanaye.
+After some delay, occasioned by a fruitless attempt to procure admission
+in the usual manner, the gateway was broken in with a crowbar, and eight
+or ten of the neighbors entered accompanied by two _gendarmes_. By this
+time the cries had ceased; but, as the party rushed up the first
+flight of stairs, two or more rough voices in angry contention were
+distinguished and seemed to proceed from the upper part of the house.
+As the second landing was reached, these sounds, also, had ceased and
+everything remained perfectly quiet. The party spread themselves and
+hurried from room to room. Upon arriving at a large back chamber in
+the fourth story, (the door of which, being found locked, with the key
+inside, was forced open,) a spectacle presented itself which struck
+every one present not less with horror than with astonishment.
+
+“The apartment was in the wildest disorder--the furniture broken and
+thrown about in all directions. There was only one bedstead; and from
+this the bed had been removed, and thrown into the middle of the floor.
+On a chair lay a razor, besmeared with blood. On the hearth were two or
+three long and thick tresses of grey human hair, also dabbled in blood,
+and seeming to have been pulled out by the roots. Upon the floor were
+found four Napoleons, an ear-ring of topaz, three large silver spoons,
+three smaller of_ métal d’Alger_, and two bags, containing nearly four
+thousand francs in gold. The drawers of a _bureau_, which stood in
+one corner were open, and had been, apparently, rifled, although many
+articles still remained in them. A small iron safe was discovered under
+the _bed_ (not under the bedstead). It was open, with the key still in
+the door. It had no contents beyond a few old letters, and other papers
+of little consequence.
+
+“Of Madame L’Espanaye no traces were here seen; but an unusual quantity
+of soot being observed in the fire-place, a search was made in the
+chimney, and (horrible to relate!) the corpse of the daughter, head
+downward, was dragged therefrom; it having been thus forced up the
+narrow aperture for a considerable distance. The body was quite warm.
+Upon examining it, many excoriations were perceived, no doubt occasioned
+by the violence with which it had been thrust up and disengaged. Upon
+the face were many severe scratches, and, upon the throat, dark bruises,
+and deep indentations of finger nails, as if the deceased had been
+throttled to death.
+
+“After a thorough investigation of every portion of the house, without
+farther discovery, the party made its way into a small paved yard in
+the rear of the building, where lay the corpse of the old lady, with her
+throat so entirely cut that, upon an attempt to raise her, the head fell
+off. The body, as well as the head, was fearfully mutilated--the former
+so much so as scarcely to retain any semblance of humanity.
+
+“To this horrible mystery there is not as yet, we believe, the slightest
+clew.”
+
+The next day’s paper had these additional particulars.
+
+“_The Tragedy in the Rue Morgue._ Many individuals have been examined
+in relation to this most extraordinary and frightful affair. [The word
+‘affaire’ has not yet, in France, that levity of import which it conveys
+with us,] “but nothing whatever has transpired to throw light upon it.
+We give below all the material testimony elicited.
+
+“_Pauline Dubourg_, laundress, deposes that she has known both the
+deceased for three years, having washed for them during that period.
+The old lady and her daughter seemed on good terms--very affectionate
+towards each other. They were excellent pay. Could not speak in regard
+to their mode or means of living. Believed that Madame L. told fortunes
+for a living. Was reputed to have money put by. Never met any persons
+in the house when she called for the clothes or took them home. Was sure
+that they had no servant in employ. There appeared to be no furniture in
+any part of the building except in the fourth story.
+
+“_Pierre Moreau_, tobacconist, deposes that he has been in the habit of
+selling small quantities of tobacco and snuff to Madame L’Espanaye for
+nearly four years. Was born in the neighborhood, and has always resided
+there. The deceased and her daughter had occupied the house in which the
+corpses were found, for more than six years. It was formerly occupied by
+a jeweller, who under-let the upper rooms to various persons. The house
+was the property of Madame L. She became dissatisfied with the abuse of
+the premises by her tenant, and moved into them herself, refusing to let
+any portion. The old lady was childish. Witness had seen the daughter
+some five or six times during the six years. The two lived an
+exceedingly retired life--were reputed to have money. Had heard it said
+among the neighbors that Madame L. told fortunes--did not believe it.
+Had never seen any person enter the door except the old lady and her
+daughter, a porter once or twice, and a physician some eight or ten
+times.
+
+“Many other persons, neighbors, gave evidence to the same effect. No one
+was spoken of as frequenting the house. It was not known whether there
+were any living connexions of Madame L. and her daughter. The shutters
+of the front windows were seldom opened. Those in the rear were always
+closed, with the exception of the large back room, fourth story. The
+house was a good house--not very old.
+
+“_Isidore Muset_, _gendarme_, deposes that he was called to the house
+about three o’clock in the morning, and found some twenty or thirty
+persons at the gateway, endeavoring to gain admittance. Forced it open,
+at length, with a bayonet--not with a crowbar. Had but little difficulty
+in getting it open, on account of its being a double or folding gate,
+and bolted neither at bottom not top. The shrieks were continued until
+the gate was forced--and then suddenly ceased. They seemed to be screams
+of some person (or persons) in great agony--were loud and drawn out,
+not short and quick. Witness led the way up stairs. Upon reaching the
+first landing, heard two voices in loud and angry contention--the one
+a gruff voice, the other much shriller--a very strange voice. Could
+distinguish some words of the former, which was that of a Frenchman. Was
+positive that it was not a woman’s voice. Could distinguish the words
+‘_sacré_’ and ‘_diable._’ The shrill voice was that of a foreigner.
+Could not be sure whether it was the voice of a man or of a woman. Could
+not make out what was said, but believed the language to be Spanish. The
+state of the room and of the bodies was described by this witness as we
+described them yesterday.
+
+“_Henri Duval_, a neighbor, and by trade a silver-smith, deposes that
+he was one of the party who first entered the house. Corroborates the
+testimony of Muset in general. As soon as they forced an entrance, they
+reclosed the door, to keep out the crowd, which collected very fast,
+notwithstanding the lateness of the hour. The shrill voice, this witness
+thinks, was that of an Italian. Was certain it was not French. Could not
+be sure that it was a man’s voice. It might have been a woman’s. Was not
+acquainted with the Italian language. Could not distinguish the words,
+but was convinced by the intonation that the speaker was an Italian.
+Knew Madame L. and her daughter. Had conversed with both frequently. Was
+sure that the shrill voice was not that of either of the deceased.
+
+“--_Odenheimer, restaurateur._ This witness volunteered his testimony.
+Not speaking French, was examined through an interpreter. Is a native of
+Amsterdam. Was passing the house at the time of the shrieks. They lasted
+for several minutes--probably ten. They were long and loud--very awful
+and distressing. Was one of those who entered the building. Corroborated
+the previous evidence in every respect but one. Was sure that the shrill
+voice was that of a man--of a Frenchman. Could not distinguish the
+words uttered. They were loud and quick--unequal--spoken apparently in
+fear as well as in anger. The voice was harsh--not so much shrill as
+harsh. Could not call it a shrill voice. The gruff voice said repeatedly
+‘_sacré_,’ ‘_diable_,’ and once ‘_mon Dieu._’
+
+“_Jules Mignaud_, banker, of the firm of Mignaud et Fils, Rue Deloraine.
+Is the elder Mignaud. Madame L’Espanaye had some property. Had opened an
+account with his banking house in the spring of the year--(eight years
+previously). Made frequent deposits in small sums. Had checked for
+nothing until the third day before her death, when she took out in
+person the sum of 4000 francs. This sum was paid in gold, and a clerk
+went home with the money.
+
+“_Adolphe Le Bon_, clerk to Mignaud et Fils, deposes that on the day in
+question, about noon, he accompanied Madame L’Espanaye to her residence
+with the 4000 francs, put up in two bags. Upon the door being opened,
+Mademoiselle L. appeared and took from his hands one of the bags, while
+the old lady relieved him of the other. He then bowed and departed. Did
+not see any person in the street at the time. It is a bye-street--very
+lonely.
+
+“_William Bird_, tailor deposes that he was one of the party who entered
+the house. Is an Englishman. Has lived in Paris two years. Was one of
+the first to ascend the stairs. Heard the voices in contention. The
+gruff voice was that of a Frenchman. Could make out several words, but
+cannot now remember all. Heard distinctly ‘_sacré_’ and ‘_mon Dieu._’
+There was a sound at the moment as if of several persons struggling--a
+scraping and scuffling sound. The shrill voice was very loud--louder
+than the gruff one. Is sure that it was not the voice of an Englishman.
+Appeared to be that of a German. Might have been a woman’s voice. Does
+not understand German.
+
+“Four of the above-named witnesses, being recalled, deposed that the
+door of the chamber in which was found the body of Mademoiselle L.
+was locked on the inside when the party reached it. Every thing was
+perfectly silent--no groans or noises of any kind. Upon forcing the door
+no person was seen. The windows, both of the back and front room, were
+down and firmly fastened from within. A door between the two rooms was
+closed, but not locked. The door leading from the front room into the
+passage was locked, with the key on the inside. A small room in the
+front of the house, on the fourth story, at the head of the passage was
+open, the door being ajar. This room was crowded with old beds, boxes,
+and so forth. These were carefully removed and searched. There was not
+an inch of any portion of the house which was not carefully searched.
+Sweeps were sent up and down the chimneys. The house was a four story
+one, with garrets (_mansardes._) A trap-door on the roof was nailed down
+very securely--did not appear to have been opened for years. The
+time elapsing between the hearing of the voices in contention and the
+breaking open of the room door, was variously stated by the witnesses.
+Some made it as short as three minutes--some as long as five. The door
+was opened with difficulty.
+
+“_Alfonzo Garcio_, undertaker, deposes that he resides in the Rue
+Morgue. Is a native of Spain. Was one of the party who entered the
+house. Did not proceed up stairs. Is nervous, and was apprehensive of
+the consequences of agitation. Heard the voices in contention. The gruff
+voice was that of a Frenchman. Could not distinguish what was said.
+The shrill voice was that of an Englishman--is sure of this. Does not
+understand the English language, but judges by the intonation.
+
+“_Alberto Montani_, confectioner, deposes that he was among the first
+to ascend the stairs. Heard the voices in question. The gruff voice was
+that of a Frenchman. Distinguished several words. The speaker appeared
+to be expostulating. Could not make out the words of the shrill voice.
+Spoke quick and unevenly. Thinks it the voice of a Russian. Corroborates
+the general testimony. Is an Italian. Never conversed with a native of
+Russia.
+
+“Several witnesses, recalled, here testified that the chimneys of all
+the rooms on the fourth story were too narrow to admit the passage of a
+human being. By ‘sweeps’ were meant cylindrical sweeping brushes, such
+as are employed by those who clean chimneys. These brushes were passed
+up and down every flue in the house. There is no back passage by which
+any one could have descended while the party proceeded up stairs. The
+body of Mademoiselle L’Espanaye was so firmly wedged in the chimney that
+it could not be got down until four or five of the party united their
+strength.
+
+“_Paul Dumas_, physician, deposes that he was called to view the
+bodies about day-break. They were both then lying on the sacking of the
+bedstead in the chamber where Mademoiselle L. was found. The corpse of
+the young lady was much bruised and excoriated. The fact that it
+had been thrust up the chimney would sufficiently account for these
+appearances. The throat was greatly chafed. There were several deep
+scratches just below the chin, together with a series of livid spots
+which were evidently the impression of fingers. The face was fearfully
+discolored, and the eye-balls protruded. The tongue had been partially
+bitten through. A large bruise was discovered upon the pit of the
+stomach, produced, apparently, by the pressure of a knee. In the opinion
+of M. Dumas, Mademoiselle L’Espanaye had been throttled to death by
+some person or persons unknown. The corpse of the mother was horribly
+mutilated. All the bones of the right leg and arm were more or less
+shattered. The left _tibia_ much splintered, as well as all the ribs of
+the left side. Whole body dreadfully bruised and discolored. It was not
+possible to say how the injuries had been inflicted. A heavy club of
+wood, or a broad bar of iron--a chair--any large, heavy, and obtuse
+weapon would have produced such results, if wielded by the hands of
+a very powerful man. No woman could have inflicted the blows with any
+weapon. The head of the deceased, when seen by witness, was entirely
+separated from the body, and was also greatly shattered. The throat
+had evidently been cut with some very sharp instrument--probably with a
+razor.
+
+“_Alexandre Etienne_, surgeon, was called with M. Dumas to view the
+bodies. Corroborated the testimony, and the opinions of M. Dumas.
+
+“Nothing farther of importance was elicited, although several other
+persons were examined. A murder so mysterious, and so perplexing in all
+its particulars, was never before committed in Paris--if indeed a murder
+has been committed at all. The police are entirely at fault--an unusual
+occurrence in affairs of this nature. There is not, however, the shadow
+of a clew apparent.”
+
+The evening edition of the paper stated that the greatest excitement
+still continued in the Quartier St. Roch--that the premises in question
+had been carefully re-searched, and fresh examinations of witnesses
+instituted, but all to no purpose. A postscript, however, mentioned
+that Adolphe Le Bon had been arrested and imprisoned--although nothing
+appeared to criminate him, beyond the facts already detailed.
+
+Dupin seemed singularly interested in the progress of this affair--at
+least so I judged from his manner, for he made no comments. It was only
+after the announcement that Le Bon had been imprisoned, that he asked me
+my opinion respecting the murders.
+
+I could merely agree with all Paris in considering them an insoluble
+mystery. I saw no means by which it would be possible to trace the
+murderer.
+
+“We must not judge of the means,” said Dupin, “by this shell of an
+examination. The Parisian police, so much extolled for _acumen_, are
+cunning, but no more. There is no method in their proceedings, beyond
+the method of the moment. They make a vast parade of measures; but, not
+unfrequently, these are so ill adapted to the objects proposed, as
+to put us in mind of Monsieur Jourdain’s calling for his
+_robe-de-chambre--pour mieux entendre la musique._ The results attained
+by them are not unfrequently surprising, but, for the most part, are
+brought about by simple diligence and activity. When these qualities are
+unavailing, their schemes fail. Vidocq, for example, was a good
+guesser and a persevering man. But, without educated thought, he erred
+continually by the very intensity of his investigations. He impaired his
+vision by holding the object too close. He might see, perhaps, one or
+two points with unusual clearness, but in so doing he, necessarily, lost
+sight of the matter as a whole. Thus there is such a thing as being too
+profound. Truth is not always in a well. In fact, as regards the more
+important knowledge, I do believe that she is invariably superficial.
+The depth lies in the valleys where we seek her, and not upon the
+mountain-tops where she is found. The modes and sources of this kind of
+error are well typified in the contemplation of the heavenly bodies.
+To look at a star by glances--to view it in a side-long way, by turning
+toward it the exterior portions of the _retina_ (more susceptible of
+feeble impressions of light than the interior), is to behold the star
+distinctly--is to have the best appreciation of its lustre--a lustre
+which grows dim just in proportion as we turn our vision _fully_ upon
+it. A greater number of rays actually fall upon the eye in the latter
+case, but, in the former, there is the more refined capacity for
+comprehension. By undue profundity we perplex and enfeeble thought; and
+it is possible to make even Venus herself vanish from the firmanent by a
+scrutiny too sustained, too concentrated, or too direct.
+
+“As for these murders, let us enter into some examinations for
+ourselves, before we make up an opinion respecting them. An inquiry will
+afford us amusement,” [I thought this an odd term, so applied, but said
+nothing] “and, besides, Le Bon once rendered me a service for which I
+am not ungrateful. We will go and see the premises with our own eyes.
+I know G----, the Prefect of Police, and shall have no difficulty in
+obtaining the necessary permission.”
+
+The permission was obtained, and we proceeded at once to the Rue Morgue.
+This is one of those miserable thoroughfares which intervene between the
+Rue Richelieu and the Rue St. Roch. It was late in the afternoon when we
+reached it; as this quarter is at a great distance from that in which we
+resided. The house was readily found; for there were still many persons
+gazing up at the closed shutters, with an objectless curiosity, from
+the opposite side of the way. It was an ordinary Parisian house, with
+a gateway, on one side of which was a glazed watch-box, with a sliding
+panel in the window, indicating a _loge de concierge._ Before going in
+we walked up the street, turned down an alley, and then, again turning,
+passed in the rear of the building--Dupin, meanwhile examining the whole
+neighborhood, as well as the house, with a minuteness of attention for
+which I could see no possible object.
+
+Retracing our steps, we came again to the front of the dwelling, rang,
+and, having shown our credentials, were admitted by the agents
+in charge. We went up stairs--into the chamber where the body of
+Mademoiselle L’Espanaye had been found, and where both the deceased
+still lay. The disorders of the room had, as usual, been suffered to
+exist. I saw nothing beyond what had been stated in the “Gazette des
+Tribunaux.” Dupin scrutinized every thing--not excepting the bodies of
+the victims. We then went into the other rooms, and into the yard; a
+_gendarme_ accompanying us throughout. The examination occupied us until
+dark, when we took our departure. On our way home my companion stepped
+in for a moment at the office of one of the daily papers.
+
+I have said that the whims of my friend were manifold, and that _Je les
+ménageais_:--for this phrase there is no English equivalent. It was his
+humor, now, to decline all conversation on the subject of the murder,
+until about noon the next day. He then asked me, suddenly, if I had
+observed any thing _peculiar_ at the scene of the atrocity.
+
+There was something in his manner of emphasizing the word “peculiar,”
+ which caused me to shudder, without knowing why.
+
+“No, nothing _peculiar_,” I said; “nothing more, at least, than we both
+saw stated in the paper.”
+
+“The ‘Gazette,’” he replied, “has not entered, I fear, into the unusual
+horror of the thing. But dismiss the idle opinions of this print. It
+appears to me that this mystery is considered insoluble, for the very
+reason which should cause it to be regarded as easy of solution--I mean
+for the _outré_ character of its features. The police are confounded by
+the seeming absence of motive--not for the murder itself--but for
+the atrocity of the murder. They are puzzled, too, by the seeming
+impossibility of reconciling the voices heard in contention, with
+the facts that no one was discovered up stairs but the assassinated
+Mademoiselle L’Espanaye, and that there were no means of egress without
+the notice of the party ascending. The wild disorder of the room; the
+corpse thrust, with the head downward, up the chimney; the frightful
+mutilation of the body of the old lady; these considerations, with those
+just mentioned, and others which I need not mention, have sufficed
+to paralyze the powers, by putting completely at fault the boasted
+_acumen_, of the government agents. They have fallen into the gross but
+common error of confounding the unusual with the abstruse. But it is by
+these deviations from the plane of the ordinary, that reason feels its
+way, if at all, in its search for the true. In investigations such as we
+are now pursuing, it should not be so much asked ‘what has occurred,’
+as ‘what has occurred that has never occurred before.’ In fact, the
+facility with which I shall arrive, or have arrived, at the solution of
+this mystery, is in the direct ratio of its apparent insolubility in the
+eyes of the police.”
+
+I stared at the speaker in mute astonishment.
+
+“I am now awaiting,” continued he, looking toward the door of our
+apartment--“I am now awaiting a person who, although perhaps not
+the perpetrator of these butcheries, must have been in some measure
+implicated in their perpetration. Of the worst portion of the crimes
+committed, it is probable that he is innocent. I hope that I am right
+in this supposition; for upon it I build my expectation of reading the
+entire riddle. I look for the man here--in this room--every moment. It
+is true that he may not arrive; but the probability is that he will.
+Should he come, it will be necessary to detain him. Here are pistols;
+and we both know how to use them when occasion demands their use.”
+
+I took the pistols, scarcely knowing what I did, or believing what
+I heard, while Dupin went on, very much as if in a soliloquy. I have
+already spoken of his abstract manner at such times. His discourse was
+addressed to myself; but his voice, although by no means loud, had that
+intonation which is commonly employed in speaking to some one at a great
+distance. His eyes, vacant in expression, regarded only the wall.
+
+“That the voices heard in contention,” he said, “by the party upon the
+stairs, were not the voices of the women themselves, was fully proved
+by the evidence. This relieves us of all doubt upon the question whether
+the old lady could have first destroyed the daughter and afterward have
+committed suicide. I speak of this point chiefly for the sake of method;
+for the strength of Madame L’Espanaye would have been utterly unequal
+to the task of thrusting her daughter’s corpse up the chimney as it
+was found; and the nature of the wounds upon her own person entirely
+preclude the idea of self-destruction. Murder, then, has been committed
+by some third party; and the voices of this third party were those heard
+in contention. Let me now advert--not to the whole testimony respecting
+these voices--but to what was _peculiar_ in that testimony. Did you
+observe any thing peculiar about it?”
+
+I remarked that, while all the witnesses agreed in supposing the gruff
+voice to be that of a Frenchman, there was much disagreement in regard
+to the shrill, or, as one individual termed it, the harsh voice.
+
+“That was the evidence itself,” said Dupin, “but it was not the
+peculiarity of the evidence. You have observed nothing distinctive.
+Yet there _was_ something to be observed. The witnesses, as you remark,
+agreed about the gruff voice; they were here unanimous. But in regard to
+the shrill voice, the peculiarity is--not that they disagreed--but
+that, while an Italian, an Englishman, a Spaniard, a Hollander, and a
+Frenchman attempted to describe it, each one spoke of it as that _of
+a foreigner_. Each is sure that it was not the voice of one of his own
+countrymen. Each likens it--not to the voice of an individual of any
+nation with whose language he is conversant--but the converse.
+The Frenchman supposes it the voice of a Spaniard, and ‘might have
+distinguished some words _had he been acquainted with the Spanish._’ The
+Dutchman maintains it to have been that of a Frenchman; but we find it
+stated that ‘_not understanding French this witness was examined through
+an interpreter._’ The Englishman thinks it the voice of a German, and
+‘_does not understand German._’ The Spaniard ‘is sure’ that it was that
+of an Englishman, but ‘judges by the intonation’ altogether, ‘_as he has
+no knowledge of the English._’ The Italian believes it the voice of a
+Russian, but ‘_has never conversed with a native of Russia._’ A second
+Frenchman differs, moreover, with the first, and is positive that the
+voice was that of an Italian; but, _not being cognizant of that tongue_,
+is, like the Spaniard, ‘convinced by the intonation.’ Now, how strangely
+unusual must that voice have really been, about which such testimony as
+this _could_ have been elicited!--in whose _tones_, even, denizens of
+the five great divisions of Europe could recognise nothing familiar! You
+will say that it might have been the voice of an Asiatic--of an African.
+Neither Asiatics nor Africans abound in Paris; but, without denying the
+inference, I will now merely call your attention to three points.
+The voice is termed by one witness ‘harsh rather than shrill.’ It
+is represented by two others to have been ‘quick and _unequal._’ No
+words--no sounds resembling words--were by any witness mentioned as
+distinguishable.
+
+“I know not,” continued Dupin, “what impression I may have made, so
+far, upon your own understanding; but I do not hesitate to say that
+legitimate deductions even from this portion of the testimony--the
+portion respecting the gruff and shrill voices--are in themselves
+sufficient to engender a suspicion which should give direction to all
+farther progress in the investigation of the mystery. I said ‘legitimate
+deductions;’ but my meaning is not thus fully expressed. I designed
+to imply that the deductions are the _sole_ proper ones, and that the
+suspicion arises _inevitably_ from them as the single result. What the
+suspicion is, however, I will not say just yet. I merely wish you to
+bear in mind that, with myself, it was sufficiently forcible to give a
+definite form--a certain tendency--to my inquiries in the chamber.
+
+“Let us now transport ourselves, in fancy, to this chamber. What shall
+we first seek here? The means of egress employed by the murderers. It is
+not too much to say that neither of us believe in præternatural events.
+Madame and Mademoiselle L’Espanaye were not destroyed by spirits. The
+doers of the deed were material, and escaped materially. Then how?
+Fortunately, there is but one mode of reasoning upon the point, and that
+mode _must_ lead us to a definite decision.--Let us examine, each by
+each, the possible means of egress. It is clear that the assassins were
+in the room where Mademoiselle L’Espanaye was found, or at least in the
+room adjoining, when the party ascended the stairs. It is then only from
+these two apartments that we have to seek issues. The police have laid
+bare the floors, the ceilings, and the masonry of the walls, in every
+direction. No _secret_ issues could have escaped their vigilance. But,
+not trusting to _their_ eyes, I examined with my own. There were, then,
+no secret issues. Both doors leading from the rooms into the passage
+were securely locked, with the keys inside. Let us turn to the chimneys.
+These, although of ordinary width for some eight or ten feet above the
+hearths, will not admit, throughout their extent, the body of a large
+cat. The impossibility of egress, by means already stated, being thus
+absolute, we are reduced to the windows. Through those of the front room
+no one could have escaped without notice from the crowd in the street.
+The murderers _must_ have passed, then, through those of the back room.
+Now, brought to this conclusion in so unequivocal a manner as we are,
+it is not our part, as reasoners, to reject it on account of apparent
+impossibilities. It is only left for us to prove that these apparent
+‘impossibilities’ are, in reality, not such.
+
+“There are two windows in the chamber. One of them is unobstructed by
+furniture, and is wholly visible. The lower portion of the other is
+hidden from view by the head of the unwieldy bedstead which is thrust
+close up against it. The former was found securely fastened from within.
+It resisted the utmost force of those who endeavored to raise it. A
+large gimlet-hole had been pierced in its frame to the left, and a very
+stout nail was found fitted therein, nearly to the head. Upon examining
+the other window, a similar nail was seen similarly fitted in it; and
+a vigorous attempt to raise this sash, failed also. The police were now
+entirely satisfied that egress had not been in these directions. And,
+_therefore_, it was thought a matter of supererogation to withdraw the
+nails and open the windows.
+
+“My own examination was somewhat more particular, and was so for the
+reason I have just given--because here it was, I knew, that all apparent
+impossibilities _must_ be proved to be not such in reality.
+
+“I proceeded to think thus--_a posteriori_. The murderers did escape
+from one of these windows. This being so, they could not have refastened
+the sashes from the inside, as they were found fastened;--the
+consideration which put a stop, through its obviousness, to the scrutiny
+of the police in this quarter. Yet the sashes _were_ fastened. They
+_must_, then, have the power of fastening themselves. There was no
+escape from this conclusion. I stepped to the unobstructed casement,
+withdrew the nail with some difficulty and attempted to raise the sash.
+It resisted all my efforts, as I had anticipated. A concealed spring
+must, I now know, exist; and this corroboration of my idea convinced
+me that my premises at least, were correct, however mysterious still
+appeared the circumstances attending the nails. A careful search soon
+brought to light the hidden spring. I pressed it, and, satisfied with
+the discovery, forbore to upraise the sash.
+
+“I now replaced the nail and regarded it attentively. A person passing
+out through this window might have reclosed it, and the spring would
+have caught--but the nail could not have been replaced. The conclusion
+was plain, and again narrowed in the field of my investigations. The
+assassins _must_ have escaped through the other window. Supposing, then,
+the springs upon each sash to be the same, as was probable, there _must_
+be found a difference between the nails, or at least between the modes
+of their fixture. Getting upon the sacking of the bedstead, I looked
+over the head-board minutely at the second casement. Passing my hand
+down behind the board, I readily discovered and pressed the spring,
+which was, as I had supposed, identical in character with its neighbor.
+I now looked at the nail. It was as stout as the other, and apparently
+fitted in the same manner--driven in nearly up to the head.
+
+“You will say that I was puzzled; but, if you think so, you must have
+misunderstood the nature of the inductions. To use a sporting phrase,
+I had not been once ‘at fault.’ The scent had never for an instant
+been lost. There was no flaw in any link of the chain. I had traced the
+secret to its ultimate result,--and that result was _the nail._ It
+had, I say, in every respect, the appearance of its fellow in the other
+window; but this fact was an absolute nullity (conclusive us it might
+seem to be) when compared with the consideration that here, at this
+point, terminated the clew. ‘There _must_ be something wrong,’ I said,
+‘about the nail.’ I touched it; and the head, with about a quarter of an
+inch of the shank, came off in my fingers. The rest of the shank was in
+the gimlet-hole where it had been broken off. The fracture was an old
+one (for its edges were incrusted with rust), and had apparently been
+accomplished by the blow of a hammer, which had partially imbedded,
+in the top of the bottom sash, the head portion of the nail. I now
+carefully replaced this head portion in the indentation whence I had
+taken it, and the resemblance to a perfect nail was complete--the
+fissure was invisible. Pressing the spring, I gently raised the sash
+for a few inches; the head went up with it, remaining firm in its bed.
+I closed the window, and the semblance of the whole nail was again
+perfect.
+
+“The riddle, so far, was now unriddled. The assassin had escaped through
+the window which looked upon the bed. Dropping of its own accord upon
+his exit (or perhaps purposely closed), it had become fastened by the
+spring; and it was the retention of this spring which had been mistaken
+by the police for that of the nail,--farther inquiry being thus
+considered unnecessary.
+
+“The next question is that of the mode of descent. Upon this point I had
+been satisfied in my walk with you around the building. About five feet
+and a half from the casement in question there runs a lightning-rod.
+From this rod it would have been impossible for any one to reach the
+window itself, to say nothing of entering it. I observed, however, that
+the shutters of the fourth story were of the peculiar kind called by
+Parisian carpenters _ferrades_--a kind rarely employed at the present
+day, but frequently seen upon very old mansions at Lyons and Bordeaux.
+They are in the form of an ordinary door, (a single, not a folding door)
+except that the lower half is latticed or worked in open trellis--thus
+affording an excellent hold for the hands. In the present instance these
+shutters are fully three feet and a half broad. When we saw them from
+the rear of the house, they were both about half open--that is to say,
+they stood off at right angles from the wall. It is probable that the
+police, as well as myself, examined the back of the tenement; but, if
+so, in looking at these _ferrades_ in the line of their breadth (as they
+must have done), they did not perceive this great breadth itself, or,
+at all events, failed to take it into due consideration. In fact, having
+once satisfied themselves that no egress could have been made in this
+quarter, they would naturally bestow here a very cursory examination.
+It was clear to me, however, that the shutter belonging to the window
+at the head of the bed, would, if swung fully back to the wall, reach
+to within two feet of the lightning-rod. It was also evident that, by
+exertion of a very unusual degree of activity and courage, an entrance
+into the window, from the rod, might have been thus effected.--By
+reaching to the distance of two feet and a half (we now suppose the
+shutter open to its whole extent) a robber might have taken a firm grasp
+upon the trellis-work. Letting go, then, his hold upon the rod, placing
+his feet securely against the wall, and springing boldly from it, he
+might have swung the shutter so as to close it, and, if we imagine the
+window open at the time, might even have swung himself into the room.
+
+“I wish you to bear especially in mind that I have spoken of a _very_
+unusual degree of activity as requisite to success in so hazardous and
+so difficult a feat. It is my design to show you, first, that the thing
+might possibly have been accomplished:--but, secondly and _chiefly_, I
+wish to impress upon your understanding the _very extraordinary_--the
+almost præternatural character of that agility which could have
+accomplished it.
+
+“You will say, no doubt, using the language of the law, that ‘to make
+out my case,’ I should rather undervalue, than insist upon a full
+estimation of the activity required in this matter. This may be the
+practice in law, but it is not the usage of reason. My ultimate object
+is only the truth. My immediate purpose is to lead you to place in
+juxtaposition, that _very unusual_ activity of which I have just spoken
+with that _very peculiar_ shrill (or harsh) and _unequal_ voice, about
+whose nationality no two persons could be found to agree, and in whose
+utterance no syllabification could be detected.”
+
+At these words a vague and half-formed conception of the meaning
+of Dupin flitted over my mind. I seemed to be upon the verge of
+comprehension without power to comprehend--men, at times, find
+themselves upon the brink of remembrance without being able, in the end,
+to remember. My friend went on with his discourse.
+
+“You will see,” he said, “that I have shifted the question from the mode
+of egress to that of ingress. It was my design to convey the idea that
+both were effected in the same manner, at the same point. Let us now
+revert to the interior of the room. Let us survey the appearances here.
+The drawers of the bureau, it is said, had been rifled, although many
+articles of apparel still remained within them. The conclusion here is
+absurd. It is a mere guess--a very silly one--and no more. How are
+we to know that the articles found in the drawers were not all these
+drawers had originally contained? Madame L’Espanaye and her daughter
+lived an exceedingly retired life--saw no company--seldom went out--had
+little use for numerous changes of habiliment. Those found were at least
+of as good quality as any likely to be possessed by these ladies. If a
+thief had taken any, why did he not take the best--why did he not take
+all? In a word, why did he abandon four thousand francs in gold to
+encumber himself with a bundle of linen? The gold _was _abandoned.
+Nearly the whole sum mentioned by Monsieur Mignaud, the banker, was
+discovered, in bags, upon the floor. I wish you, therefore, to discard
+from your thoughts the blundering idea of _motive_, engendered in the
+brains of the police by that portion of the evidence which speaks of
+money delivered at the door of the house. Coincidences ten times as
+remarkable as this (the delivery of the money, and murder committed
+within three days upon the party receiving it), happen to all of us
+every hour of our lives, without attracting even momentary notice.
+Coincidences, in general, are great stumbling-blocks in the way of that
+class of thinkers who have been educated to know nothing of the theory
+of probabilities--that theory to which the most glorious objects of
+human research are indebted for the most glorious of illustration. In
+the present instance, had the gold been gone, the fact of its delivery
+three days before would have formed something more than a coincidence.
+It would have been corroborative of this idea of motive. But, under the
+real circumstances of the case, if we are to suppose gold the motive
+of this outrage, we must also imagine the perpetrator so vacillating an
+idiot as to have abandoned his gold and his motive together.
+
+“Keeping now steadily in mind the points to which I have drawn your
+attention--that peculiar voice, that unusual agility, and that startling
+absence of motive in a murder so singularly atrocious as this--let us
+glance at the butchery itself. Here is a woman strangled to death
+by manual strength, and thrust up a chimney, head downward. Ordinary
+assassins employ no such modes of murder as this. Least of all, do they
+thus dispose of the murdered. In the manner of thrusting the corpse
+up the chimney, you will admit that there was something _excessively
+outré_--something altogether irreconcilable with our common notions of
+human action, even when we suppose the actors the most depraved of men.
+Think, too, how great must have been that strength which could have
+thrust the body _up_ such an aperture so forcibly that the united vigor
+of several persons was found barely sufficient to drag it _down!_
+
+“Turn, now, to other indications of the employment of a vigor most
+marvellous. On the hearth were thick tresses--very thick tresses--of
+grey human hair. These had been torn out by the roots. You are aware of
+the great force necessary in tearing thus from the head even twenty or
+thirty hairs together. You saw the locks in question as well as myself.
+Their roots (a hideous sight!) were clotted with fragments of the flesh
+of the scalp--sure token of the prodigious power which had been exerted
+in uprooting perhaps half a million of hairs at a time. The throat of
+the old lady was not merely cut, but the head absolutely severed from
+the body: the instrument was a mere razor. I wish you also to look at
+the _brutal_ ferocity of these deeds. Of the bruises upon the body
+of Madame L’Espanaye I do not speak. Monsieur Dumas, and his worthy
+coadjutor Monsieur Etienne, have pronounced that they were inflicted by
+some obtuse instrument; and so far these gentlemen are very correct. The
+obtuse instrument was clearly the stone pavement in the yard, upon which
+the victim had fallen from the window which looked in upon the bed. This
+idea, however simple it may now seem, escaped the police for the same
+reason that the breadth of the shutters escaped them--because, by the
+affair of the nails, their perceptions had been hermetically sealed
+against the possibility of the windows having ever been opened at all.
+
+“If now, in addition to all these things, you have properly reflected
+upon the odd disorder of the chamber, we have gone so far as to combine
+the ideas of an agility astounding, a strength superhuman, a ferocity
+brutal, a butchery without motive, a _grotesquerie_ in horror absolutely
+alien from humanity, and a voice foreign in tone to the ears of men
+of many nations, and devoid of all distinct or intelligible
+syllabification. What result, then, has ensued? What impression have I
+made upon your fancy?”
+
+I felt a creeping of the flesh as Dupin asked me the question. “A
+madman,” I said, “has done this deed--some raving maniac, escaped from a
+neighboring _Maison de Santé._”
+
+“In some respects,” he replied, “your idea is not irrelevant. But the
+voices of madmen, even in their wildest paroxysms, are never found to
+tally with that peculiar voice heard upon the stairs. Madmen are of some
+nation, and their language, however incoherent in its words, has always
+the coherence of syllabification. Besides, the hair of a madman is not
+such as I now hold in my hand. I disentangled this little tuft from the
+rigidly clutched fingers of Madame L’Espanaye. Tell me what you can make
+of it.”
+
+“Dupin!” I said, completely unnerved; “this hair is most unusual--this
+is no _human_ hair.”
+
+“I have not asserted that it is,” said he; “but, before we decide this
+point, I wish you to glance at the little sketch I have here traced upon
+this paper. It is a _fac-simile_ drawing of what has been described in
+one portion of the testimony as ‘dark bruises, and deep indentations
+of finger nails,’ upon the throat of Mademoiselle L’Espanaye, and in
+another, (by Messrs. Dumas and Etienne,) as a ‘series of livid spots,
+evidently the impression of fingers.’
+
+“You will perceive,” continued my friend, spreading out the paper upon
+the table before us, “that this drawing gives the idea of a firm
+and fixed hold. There is no _slipping_ apparent. Each finger has
+retained--possibly until the death of the victim--the fearful grasp by
+which it originally imbedded itself. Attempt, now, to place all your
+fingers, at the same time, in the respective impressions as you see
+them.”
+
+I made the attempt in vain.
+
+“We are possibly not giving this matter a fair trial,” he said. “The
+paper is spread out upon a plane surface; but the human throat is
+cylindrical. Here is a billet of wood, the circumference of which
+is about that of the throat. Wrap the drawing around it, and try the
+experiment again.”
+
+I did so; but the difficulty was even more obvious than before. “This,”
+ I said, “is the mark of no human hand.”
+
+“Read now,” replied Dupin, “this passage from Cuvier.”
+
+It was a minute anatomical and generally descriptive account of the
+large fulvous Ourang-Outang of the East Indian Islands. The gigantic
+stature, the prodigious strength and activity, the wild ferocity, and
+the imitative propensities of these mammalia are sufficiently well known
+to all. I understood the full horrors of the murder at once.
+
+“The description of the digits,” said I, as I made an end of reading,
+“is in exact accordance with this drawing. I see that no animal but an
+Ourang-Outang, of the species here mentioned, could have impressed the
+indentations as you have traced them. This tuft of tawny hair, too, is
+identical in character with that of the beast of Cuvier. But I cannot
+possibly comprehend the particulars of this frightful mystery. Besides,
+there were _two_ voices heard in contention, and one of them was
+unquestionably the voice of a Frenchman.”
+
+“True; and you will remember an expression attributed almost
+unanimously, by the evidence, to this voice,--the expression, ‘_mon
+Dieu!_’ This, under the circumstances, has been justly characterized by
+one of the witnesses (Montani, the confectioner,) as an expression of
+remonstrance or expostulation. Upon these two words, therefore, I have
+mainly built my hopes of a full solution of the riddle. A Frenchman
+was cognizant of the murder. It is possible--indeed it is far more
+than probable--that he was innocent of all participation in the bloody
+transactions which took place. The Ourang-Outang may have escaped from
+him. He may have traced it to the chamber; but, under the agitating
+circumstances which ensued, he could never have re-captured it. It is
+still at large. I will not pursue these guesses--for I have no right to
+call them more--since the shades of reflection upon which they are based
+are scarcely of sufficient depth to be appreciable by my own intellect,
+and since I could not pretend to make them intelligible to the
+understanding of another. We will call them guesses then, and speak
+of them as such. If the Frenchman in question is indeed, as I suppose,
+innocent of this atrocity, this advertisement which I left last night,
+upon our return home, at the office of ‘Le Monde,’ (a paper devoted to
+the shipping interest, and much sought by sailors,) will bring him to
+our residence.”
+
+He handed me a paper, and I read thus:
+
+CAUGHT--_In the Bois de Boulogne, early in the morning of the--inst.,_
+(the morning of the murder,) _a very large, tawny Ourang-Outang of
+the Bornese species. The owner, (who is ascertained to be a sailor,
+belonging to a Maltese vessel,) may have the animal again, upon
+identifying it satisfactorily, and paying a few charges arising from
+its capture and keeping. Call at No. ----, Rue ----, Faubourg St.
+Germain--au troisiême._
+
+“How was it possible,” I asked, “that you should know the man to be a
+sailor, and belonging to a Maltese vessel?”
+
+“I do _not_ know it,” said Dupin. “I am not _sure_ of it. Here, however,
+is a small piece of ribbon, which from its form, and from its greasy
+appearance, has evidently been used in tying the hair in one of those
+long _queues_ of which sailors are so fond. Moreover, this knot is one
+which few besides sailors can tie, and is peculiar to the Maltese. I
+picked the ribbon up at the foot of the lightning-rod. It could not have
+belonged to either of the deceased. Now if, after all, I am wrong in my
+induction from this ribbon, that the Frenchman was a sailor belonging to
+a Maltese vessel, still I can have done no harm in saying what I did in
+the advertisement. If I am in error, he will merely suppose that I have
+been misled by some circumstance into which he will not take the trouble
+to inquire. But if I am right, a great point is gained. Cognizant
+although innocent of the murder, the Frenchman will naturally hesitate
+about replying to the advertisement--about demanding the Ourang-Outang.
+He will reason thus:--‘I am innocent; I am poor; my Ourang-Outang is of
+great value--to one in my circumstances a fortune of itself--why should
+I lose it through idle apprehensions of danger? Here it is, within my
+grasp. It was found in the Bois de Boulogne--at a vast distance from the
+scene of that butchery. How can it ever be suspected that a brute beast
+should have done the deed? The police are at fault--they have failed to
+procure the slightest clew. Should they even trace the animal, it would
+be impossible to prove me cognizant of the murder, or to implicate me
+in guilt on account of that cognizance. Above all, _I am known._ The
+advertiser designates me as the possessor of the beast. I am not sure to
+what limit his knowledge may extend. Should I avoid claiming a property
+of so great value, which it is known that I possess, I will render the
+animal at least, liable to suspicion. It is not my policy to attract
+attention either to myself or to the beast. I will answer the
+advertisement, get the Ourang-Outang, and keep it close until this
+matter has blown over.’”
+
+At this moment we heard a step upon the stairs.
+
+“Be ready,” said Dupin, “with your pistols, but neither use them nor
+show them until at a signal from myself.”
+
+The front door of the house had been left open, and the visiter had
+entered, without ringing, and advanced several steps upon the staircase.
+Now, however, he seemed to hesitate. Presently we heard him descending.
+Dupin was moving quickly to the door, when we again heard him coming up.
+He did not turn back a second time, but stepped up with decision, and
+rapped at the door of our chamber.
+
+“Come in,” said Dupin, in a cheerful and hearty tone.
+
+A man entered. He was a sailor, evidently,--a tall, stout, and
+muscular-looking person, with a certain dare-devil expression of
+countenance, not altogether unprepossessing. His face, greatly sunburnt,
+was more than half hidden by whisker and _mustachio._ He had with him
+a huge oaken cudgel, but appeared to be otherwise unarmed. He bowed
+awkwardly, and bade us “good evening,” in French accents, which,
+although somewhat Neufchatelish, were still sufficiently indicative of a
+Parisian origin.
+
+“Sit down, my friend,” said Dupin. “I suppose you have called about the
+Ourang-Outang. Upon my word, I almost envy you the possession of him;
+a remarkably fine, and no doubt a very valuable animal. How old do you
+suppose him to be?”
+
+The sailor drew a long breath, with the air of a man relieved of some
+intolerable burden, and then replied, in an assured tone:
+
+“I have no way of telling--but he can’t be more than four or five years
+old. Have you got him here?”
+
+“Oh no, we had no conveniences for keeping him here. He is at a livery
+stable in the Rue Dubourg, just by. You can get him in the morning. Of
+course you are prepared to identify the property?”
+
+“To be sure I am, sir.”
+
+“I shall be sorry to part with him,” said Dupin.
+
+“I don’t mean that you should be at all this trouble for nothing, sir,”
+ said the man. “Couldn’t expect it. Am very willing to pay a reward for
+the finding of the animal--that is to say, any thing in reason.”
+
+“Well,” replied my friend, “that is all very fair, to be sure. Let me
+think!--what should I have? Oh! I will tell you. My reward shall be
+this. You shall give me all the information in your power about these
+murders in the Rue Morgue.”
+
+Dupin said the last words in a very low tone, and very quietly. Just as
+quietly, too, he walked toward the door, locked it and put the key in
+his pocket. He then drew a pistol from his bosom and placed it, without
+the least flurry, upon the table.
+
+The sailor’s face flushed up as if he were struggling with suffocation.
+He started to his feet and grasped his cudgel, but the next moment he
+fell back into his seat, trembling violently, and with the countenance
+of death itself. He spoke not a word. I pitied him from the bottom of my
+heart.
+
+“My friend,” said Dupin, in a kind tone, “you are alarming yourself
+unnecessarily--you are indeed. We mean you no harm whatever. I pledge
+you the honor of a gentleman, and of a Frenchman, that we intend you no
+injury. I perfectly well know that you are innocent of the atrocities
+in the Rue Morgue. It will not do, however, to deny that you are in some
+measure implicated in them. From what I have already said, you must know
+that I have had means of information about this matter--means of which
+you could never have dreamed. Now the thing stands thus. You have done
+nothing which you could have avoided--nothing, certainly, which renders
+you culpable. You were not even guilty of robbery, when you might have
+robbed with impunity. You have nothing to conceal. You have no reason
+for concealment. On the other hand, you are bound by every principle
+of honor to confess all you know. An innocent man is now imprisoned,
+charged with that crime of which you can point out the perpetrator.”
+
+The sailor had recovered his presence of mind, in a great measure, while
+Dupin uttered these words; but his original boldness of bearing was all
+gone.
+
+“So help me God,” said he, after a brief pause, “I will tell you all I
+know about this affair;--but I do not expect you to believe one half I
+say--I would be a fool indeed if I did. Still, I am innocent, and I will
+make a clean breast if I die for it.”
+
+What he stated was, in substance, this. He had lately made a voyage
+to the Indian Archipelago. A party, of which he formed one, landed
+at Borneo, and passed into the interior on an excursion of pleasure.
+Himself and a companion had captured the Ourang-Outang. This companion
+dying, the animal fell into his own exclusive possession. After great
+trouble, occasioned by the intractable ferocity of his captive during
+the home voyage, he at length succeeded in lodging it safely at his own
+residence in Paris, where, not to attract toward himself the unpleasant
+curiosity of his neighbors, he kept it carefully secluded, until such
+time as it should recover from a wound in the foot, received from a
+splinter on board ship. His ultimate design was to sell it.
+
+Returning home from some sailors’ frolic the night, or rather in the
+morning of the murder, he found the beast occupying his own bed-room,
+into which it had broken from a closet adjoining, where it had been, as
+was thought, securely confined. Razor in hand, and fully lathered, it
+was sitting before a looking-glass, attempting the operation of shaving,
+in which it had no doubt previously watched its master through the
+key-hole of the closet. Terrified at the sight of so dangerous a weapon
+in the possession of an animal so ferocious, and so well able to use
+it, the man, for some moments, was at a loss what to do. He had been
+accustomed, however, to quiet the creature, even in its fiercest moods,
+by the use of a whip, and to this he now resorted. Upon sight of it, the
+Ourang-Outang sprang at once through the door of the chamber, down
+the stairs, and thence, through a window, unfortunately open, into the
+street.
+
+The Frenchman followed in despair; the ape, razor still in hand,
+occasionally stopping to look back and gesticulate at its pursuer, until
+the latter had nearly come up with it. It then again made off. In this
+manner the chase continued for a long time. The streets were profoundly
+quiet, as it was nearly three o’clock in the morning. In passing down
+an alley in the rear of the Rue Morgue, the fugitive’s attention was
+arrested by a light gleaming from the open window of Madame L’Espanaye’s
+chamber, in the fourth story of her house. Rushing to the building, it
+perceived the lightning rod, clambered up with inconceivable agility,
+grasped the shutter, which was thrown fully back against the wall, and,
+by its means, swung itself directly upon the headboard of the bed. The
+whole feat did not occupy a minute. The shutter was kicked open again by
+the Ourang-Outang as it entered the room.
+
+The sailor, in the meantime, was both rejoiced and perplexed. He had
+strong hopes of now recapturing the brute, as it could scarcely escape
+from the trap into which it had ventured, except by the rod, where it
+might be intercepted as it came down. On the other hand, there was
+much cause for anxiety as to what it might do in the house. This latter
+reflection urged the man still to follow the fugitive. A lightning rod
+is ascended without difficulty, especially by a sailor; but, when he had
+arrived as high as the window, which lay far to his left, his career was
+stopped; the most that he could accomplish was to reach over so as to
+obtain a glimpse of the interior of the room. At this glimpse he nearly
+fell from his hold through excess of horror. Now it was that those
+hideous shrieks arose upon the night, which had startled from slumber
+the inmates of the Rue Morgue. Madame L’Espanaye and her daughter,
+habited in their night clothes, had apparently been occupied in
+arranging some papers in the iron chest already mentioned, which had
+been wheeled into the middle of the room. It was open, and its contents
+lay beside it on the floor. The victims must have been sitting with
+their backs toward the window; and, from the time elapsing between the
+ingress of the beast and the screams, it seems probable that it was not
+immediately perceived. The flapping-to of the shutter would naturally
+have been attributed to the wind.
+
+As the sailor looked in, the gigantic animal had seized Madame
+L’Espanaye by the hair, (which was loose, as she had been combing
+it,) and was flourishing the razor about her face, in imitation of the
+motions of a barber. The daughter lay prostrate and motionless; she had
+swooned. The screams and struggles of the old lady (during which the
+hair was torn from her head) had the effect of changing the probably
+pacific purposes of the Ourang-Outang into those of wrath. With one
+determined sweep of its muscular arm it nearly severed her head from her
+body. The sight of blood inflamed its anger into phrenzy. Gnashing its
+teeth, and flashing fire from its eyes, it flew upon the body of the
+girl, and imbedded its fearful talons in her throat, retaining its grasp
+until she expired. Its wandering and wild glances fell at this moment
+upon the head of the bed, over which the face of its master, rigid with
+horror, was just discernible. The fury of the beast, who no doubt bore
+still in mind the dreaded whip, was instantly converted into fear.
+Conscious of having deserved punishment, it seemed desirous of
+concealing its bloody deeds, and skipped about the chamber in an agony
+of nervous agitation; throwing down and breaking the furniture as it
+moved, and dragging the bed from the bedstead. In conclusion, it seized
+first the corpse of the daughter, and thrust it up the chimney, as
+it was found; then that of the old lady, which it immediately hurled
+through the window headlong.
+
+As the ape approached the casement with its mutilated burden, the sailor
+shrank aghast to the rod, and, rather gliding than clambering down it,
+hurried at once home--dreading the consequences of the butchery, and
+gladly abandoning, in his terror, all solicitude about the fate of the
+Ourang-Outang. The words heard by the party upon the staircase were the
+Frenchman’s exclamations of horror and affright, commingled with the
+fiendish jabberings of the brute.
+
+I have scarcely anything to add. The Ourang-Outang must have escaped
+from the chamber, by the rod, just before the break of the door. It
+must have closed the window as it passed through it. It was subsequently
+caught by the owner himself, who obtained for it a very large sum at the
+_Jardin des Plantes._ Le Don was instantly released, upon our narration
+of the circumstances (with some comments from Dupin) at the bureau of
+the Prefect of Police. This functionary, however well disposed to my
+friend, could not altogether conceal his chagrin at the turn which
+affairs had taken, and was fain to indulge in a sarcasm or two, about
+the propriety of every person minding his own business.
+
+“Let him talk,” said Dupin, who had not thought it necessary to reply.
+“Let him discourse; it will ease his conscience, I am satisfied with
+having defeated him in his own castle. Nevertheless, that he failed
+in the solution of this mystery, is by no means that matter for wonder
+which he supposes it; for, in truth, our friend the Prefect is somewhat
+too cunning to be profound. In his wisdom is no _stamen._ It is all head
+and no body, like the pictures of the Goddess Laverna,--or, at best, all
+head and shoulders, like a codfish. But he is a good creature after all.
+I like him especially for one master stroke of cant, by which he has
+attained his reputation for ingenuity. I mean the way he has ‘_de nier
+ce qui est, et d’expliquer ce qui n’est pas._’” (*)
+
+(*) Rousseau--Nouvelle Heloise.
+
+
+
+
+THE MYSTERY OF MARIE ROGET.(*1)
+
+A SEQUEL TO “THE MURDERS IN THE RUE MORGUE.”
+
+
+  Es giebt eine Reihe idealischer Begebenheiten, die der Wirklichkeit
+  parallel lauft. Selten fallen sie zusammen. Menschen und zufalle
+  modifieiren gewohulich die idealische Begebenheit, so dass sie
+  unvollkommen erscheint, und ihre Folgen gleichfalls unvollkommen
+  sind. So bei der Reformation; statt des Protestantismus kam das
+  Lutherthum hervor.
+
+  There are ideal series of events which run parallel with the real
+  ones. They rarely coincide. Men and circumstances generally modify
+  the ideal train of events, so that it seems imperfect, and its
+  consequences are equally imperfect. Thus with the Reformation;
+  instead of Protestantism came Lutheranism.
+
+              --Novalis. (*2) Moral Ansichten.
+
+THERE are few persons, even among the calmest thinkers, who have not
+occasionally been startled into a vague yet thrilling half-credence in
+the supernatural, by coincidences of so seemingly marvellous a character
+that, as mere coincidences, the intellect has been unable to receive
+them. Such sentiments--for the half-credences of which I speak have
+never the full force of thought--such sentiments are seldom thoroughly
+stifled unless by reference to the doctrine of chance, or, as it is
+technically termed, the Calculus of Probabilities. Now this Calculus is,
+in its essence, purely mathematical; and thus we have the anomaly of the
+most rigidly exact in science applied to the shadow and spirituality of
+the most intangible in speculation.
+
+The extraordinary details which I am now called upon to make public,
+will be found to form, as regards sequence of time, the primary branch
+of a series of scarcely intelligible coincidences, whose secondary or
+concluding branch will be recognized by all readers in the late murder
+of Mary Cecila Rogers, at New York.
+
+When, in an article entitled “The Murders in the Rue Morgue,” I
+endeavored, about a year ago, to depict some very remarkable features
+in the mental character of my friend, the Chevalier C. Auguste Dupin,
+it did not occur to me that I should ever resume the subject. This
+depicting of character constituted my design; and this design was
+thoroughly fulfilled in the wild train of circumstances brought to
+instance Dupin’s idiosyncrasy. I might have adduced other examples, but
+I should have proven no more. Late events, however, in their surprising
+development, have startled me into some farther details, which will
+carry with them the air of extorted confession. Hearing what I have
+lately heard, it would be indeed strange should I remain silent in
+regard to what I both heard and saw so long ago.
+
+Upon the winding up of the tragedy involved in the deaths of Madame
+L’Espanaye and her daughter, the Chevalier dismissed the affair at once
+from his attention, and relapsed into his old habits of moody reverie.
+Prone, at all times, to abstraction, I readily fell in with his humor;
+and, continuing to occupy our chambers in the Faubourg Saint Germain, we
+gave the Future to the winds, and slumbered tranquilly in the Present,
+weaving the dull world around us into dreams.
+
+But these dreams were not altogether uninterrupted. It may readily be
+supposed that the part played by my friend, in the drama at the Rue
+Morgue, had not failed of its impression upon the fancies of the
+Parisian police. With its emissaries, the name of Dupin had grown into a
+household word. The simple character of those inductions by which he
+had disentangled the mystery never having been explained even to the
+Prefect, or to any other individual than myself, of course it is not
+surprising that the affair was regarded as little less than miraculous,
+or that the Chevalier’s analytical abilities acquired for him the
+credit of intuition. His frankness would have led him to disabuse every
+inquirer of such prejudice; but his indolent humor forbade all farther
+agitation of a topic whose interest to himself had long ceased. It thus
+happened that he found himself the cynosure of the political eyes; and
+the cases were not few in which attempt was made to engage his services
+at the Prefecture. One of the most remarkable instances was that of the
+murder of a young girl named Marie Rogêt.
+
+This event occurred about two years after the atrocity in the Rue
+Morgue. Marie, whose Christian and family name will at once arrest
+attention from their resemblance to those of the unfortunate
+“cigargirl,” was the only daughter of the widow Estelle Rogêt. The
+father had died during the child’s infancy, and from the period of his
+death, until within eighteen months before the assassination which forms
+the subject of our narrative, the mother and daughter had dwelt together
+in the Rue Pavée Saint Andrée; (*3) Madame there keeping a pension,
+assisted by Marie. Affairs went on thus until the latter had attained
+her twenty-second year, when her great beauty attracted the notice of a
+perfumer, who occupied one of the shops in the basement of the Palais
+Royal, and whose custom lay chiefly among the desperate adventurers
+infesting that neighborhood. Monsieur Le Blanc (*4) was not unaware of
+the advantages to be derived from the attendance of the fair Marie in
+his perfumery; and his liberal proposals were accepted eagerly by the
+girl, although with somewhat more of hesitation by Madame.
+
+The anticipations of the shopkeeper were realized, and his rooms soon
+became notorious through the charms of the sprightly grisette. She had
+been in his employ about a year, when her admirers were thrown info
+confusion by her sudden disappearance from the shop. Monsieur Le Blanc
+was unable to account for her absence, and Madame Rogêt was distracted
+with anxiety and terror. The public papers immediately took up
+the theme, and the police were upon the point of making serious
+investigations, when, one fine morning, after the lapse of a week,
+Marie, in good health, but with a somewhat saddened air, made her
+re-appearance at her usual counter in the perfumery. All inquiry, except
+that of a private character, was of course immediately hushed. Monsieur
+Le Blanc professed total ignorance, as before. Marie, with Madame,
+replied to all questions, that the last week had been spent at the
+house of a relation in the country. Thus the affair died away, and was
+generally forgotten; for the girl, ostensibly to relieve herself from
+the impertinence of curiosity, soon bade a final adieu to the perfumer,
+and sought the shelter of her mother’s residence in the Rue Pavée Saint
+Andrée.
+
+It was about five months after this return home, that her friends were
+alarmed by her sudden disappearance for the second time. Three days
+elapsed, and nothing was heard of her. On the fourth her corpse was
+found floating in the Seine, * near the shore which is opposite the
+Quartier of the Rue Saint Andree, and at a point not very far distant
+from the secluded neighborhood of the Barrière du Roule. (*6)
+
+The atrocity of this murder, (for it was at once evident that murder had
+been committed,) the youth and beauty of the victim, and, above all, her
+previous notoriety, conspired to produce intense excitement in the minds
+of the sensitive Parisians. I can call to mind no similar occurrence
+producing so general and so intense an effect. For several weeks, in
+the discussion of this one absorbing theme, even the momentous political
+topics of the day were forgotten. The Prefect made unusual exertions;
+and the powers of the whole Parisian police were, of course, tasked to
+the utmost extent.
+
+Upon the first discovery of the corpse, it was not supposed that the
+murderer would be able to elude, for more than a very brief period,
+the inquisition which was immediately set on foot. It was not until the
+expiration of a week that it was deemed necessary to offer a reward; and
+even then this reward was limited to a thousand francs. In the mean time
+the investigation proceeded with vigor, if not always with judgment, and
+numerous individuals were examined to no purpose; while, owing to the
+continual absence of all clue to the mystery, the popular excitement
+greatly increased. At the end of the tenth day it was thought advisable
+to double the sum originally proposed; and, at length, the second week
+having elapsed without leading to any discoveries, and the prejudice
+which always exists in Paris against the Police having given vent to
+itself in several serious émeutes, the Prefect took it upon himself
+to offer the sum of twenty thousand francs “for the conviction of the
+assassin,” or, if more than one should prove to have been implicated,
+“for the conviction of any one of the assassins.” In the proclamation
+setting forth this reward, a full pardon was promised to any accomplice
+who should come forward in evidence against his fellow; and to the whole
+was appended, wherever it appeared, the private placard of a committee
+of citizens, offering ten thousand francs, in addition to the amount
+proposed by the Prefecture. The entire reward thus stood at no less than
+thirty thousand francs, which will be regarded as an extraordinary
+sum when we consider the humble condition of the girl, and the great
+frequency, in large cities, of such atrocities as the one described.
+
+No one doubted now that the mystery of this murder would be immediately
+brought to light. But although, in one or two instances, arrests were
+made which promised elucidation, yet nothing was elicited which could
+implicate the parties suspected; and they were discharged forthwith.
+Strange as it may appear, the third week from the discovery of the body
+had passed, and passed without any light being thrown upon the subject,
+before even a rumor of the events which had so agitated the public
+mind, reached the ears of Dupin and myself. Engaged in researches which
+absorbed our whole attention, it had been nearly a month since either of
+us had gone abroad, or received a visiter, or more than glanced at
+the leading political articles in one of the daily papers. The first
+intelligence of the murder was brought us by G ----, in person. He
+called upon us early in the afternoon of the thirteenth of July, 18--,
+and remained with us until late in the night. He had been piqued by
+the failure of all his endeavors to ferret out the assassins. His
+reputation--so he said with a peculiarly Parisian air--was at stake.
+Even his honor was concerned. The eyes of the public were upon him; and
+there was really no sacrifice which he would not be willing to make for
+the development of the mystery. He concluded a somewhat droll speech
+with a compliment upon what he was pleased to term the tact of Dupin,
+and made him a direct, and certainly a liberal proposition, the precise
+nature of which I do not feel myself at liberty to disclose, but which
+has no bearing upon the proper subject of my narrative.
+
+The compliment my friend rebutted as best he could, but the proposition
+he accepted at once, although its advantages were altogether
+provisional. This point being settled, the Prefect broke forth at
+once into explanations of his own views, interspersing them with
+long comments upon the evidence; of which latter we were not yet in
+possession. He discoursed much, and beyond doubt, learnedly; while
+I hazarded an occasional suggestion as the night wore drowsily away.
+Dupin, sitting steadily in his accustomed arm-chair, was the embodiment
+of respectful attention. He wore spectacles, during the whole interview;
+and an occasional signal glance beneath their green glasses, sufficed
+to convince me that he slept not the less soundly, because silently,
+throughout the seven or eight leaden-footed hours which immediately
+preceded the departure of the Prefect.
+
+In the morning, I procured, at the Prefecture, a full report of all
+the evidence elicited, and, at the various newspaper offices, a copy
+of every paper in which, from first to last, had been published any
+decisive information in regard to this sad affair. Freed from all that
+was positively disproved, this mass of information stood thus:
+
+Marie Rogêt left the residence of her mother, in the Rue Pavée
+St. Andrée, about nine o’clock in the morning of Sunday June the
+twenty-second, 18--. In going out, she gave notice to a Monsieur Jacques
+St. Eustache, (*7) and to him only, of her intent intention to spend the
+day with an aunt who resided in the Rue des Drômes. The Rue des Drômes
+is a short and narrow but populous thoroughfare, not far from the banks
+of the river, and at a distance of some two miles, in the most direct
+course possible, from the pension of Madame Rogêt. St. Eustache was the
+accepted suitor of Marie, and lodged, as well as took his meals, at
+the pension. He was to have gone for his betrothed at dusk, and to
+have escorted her home. In the afternoon, however, it came on to rain
+heavily; and, supposing that she would remain all night at her aunt’s,
+(as she had done under similar circumstances before,) he did not think
+it necessary to keep his promise. As night drew on, Madame Rogêt (who
+was an infirm old lady, seventy years of age,) was heard to express
+a fear “that she should never see Marie again;” but this observation
+attracted little attention at the time.
+
+On Monday, it was ascertained that the girl had not been to the Rue des
+Drômes; and when the day elapsed without tidings of her, a tardy search
+was instituted at several points in the city, and its environs. It was
+not, however until the fourth day from the period of disappearance that
+any thing satisfactory was ascertained respecting her. On this day,
+(Wednesday, the twenty-fifth of June,) a Monsieur Beauvais, (*8) who,
+with a friend, had been making inquiries for Marie near the Barrière
+du Roule, on the shore of the Seine which is opposite the Rue Pavée St.
+Andrée, was informed that a corpse had just been towed ashore by some
+fishermen, who had found it floating in the river. Upon seeing the
+body, Beauvais, after some hesitation, identified it as that of the
+perfumery-girl. His friend recognized it more promptly.
+
+The face was suffused with dark blood, some of which issued from the
+mouth. No foam was seen, as in the case of the merely drowned. There was
+no discoloration in the cellular tissue. About the throat were bruises
+and impressions of fingers. The arms were bent over on the chest and
+were rigid. The right hand was clenched; the left partially open. On
+the left wrist were two circular excoriations, apparently the effect
+of ropes, or of a rope in more than one volution. A part of the right
+wrist, also, was much chafed, as well as the back throughout its extent,
+but more especially at the shoulder-blades. In bringing the body to
+the shore the fishermen had attached to it a rope; but none of the
+excoriations had been effected by this. The flesh of the neck was much
+swollen. There were no cuts apparent, or bruises which appeared the
+effect of blows. A piece of lace was found tied so tightly around the
+neck as to be hidden from sight; it was completely buried in the flesh,
+and was fasted by a knot which lay just under the left ear. This alone
+would have sufficed to produce death. The medical testimony spoke
+confidently of the virtuous character of the deceased. She had been
+subjected, it said, to brutal violence. The corpse was in such condition
+when found, that there could have been no difficulty in its recognition
+by friends.
+
+The dress was much torn and otherwise disordered. In the outer garment,
+a slip, about a foot wide, had been torn upward from the bottom hem to
+the waist, but not torn off. It was wound three times around the waist,
+and secured by a sort of hitch in the back. The dress immediately
+beneath the frock was of fine muslin; and from this a slip eighteen
+inches wide had been torn entirely out--torn very evenly and with great
+care. It was found around her neck, fitting loosely, and secured with a
+hard knot. Over this muslin slip and the slip of lace, the strings of a
+bonnet were attached; the bonnet being appended. The knot by which the
+strings of the bonnet were fastened, was not a lady’s, but a slip or
+sailor’s knot.
+
+After the recognition of the corpse, it was not, as usual, taken to the
+Morgue, (this formality being superfluous,) but hastily interred not far
+from the spot at which it was brought ashore. Through the exertions of
+Beauvais, the matter was industriously hushed up, as far as possible;
+and several days had elapsed before any public emotion resulted. A
+weekly paper, (*9) however, at length took up the theme; the corpse was
+disinterred, and a re-examination instituted; but nothing was elicited
+beyond what has been already noted. The clothes, however, were
+now submitted to the mother and friends of the deceased, and fully
+identified as those worn by the girl upon leaving home.
+
+Meantime, the excitement increased hourly. Several individuals were
+arrested and discharged. St. Eustache fell especially under suspicion;
+and he failed, at first, to give an intelligible account of his
+whereabouts during the Sunday on which Marie left home. Subsequently,
+however, he submitted to Monsieur G----, affidavits, accounting
+satisfactorily for every hour of the day in question. As time passed and
+no discovery ensued, a thousand contradictory rumors were circulated,
+and journalists busied themselves in suggestions. Among these, the one
+which attracted the most notice, was the idea that Marie Rogêt still
+lived--that the corpse found in the Seine was that of some other
+unfortunate. It will be proper that I submit to the reader some passages
+which embody the suggestion alluded to. These passages are literal
+translations from L’Etoile, (*10) a paper conducted, in general, with
+much ability.
+
+“Mademoiselle Rogêt left her mother’s house on Sunday morning, June the
+twenty-second, 18--, with the ostensible purpose of going to see her
+aunt, or some other connexion, in the Rue des Drômes. From that hour,
+nobody is proved to have seen her. There is no trace or tidings of her
+at all.... There has no person, whatever, come forward, so far, who
+saw her at all, on that day, after she left her mother’s door.... Now,
+though we have no evidence that Marie Rogêt was in the land of the
+living after nine o’clock on Sunday, June the twenty-second, we have
+proof that, up to that hour, she was alive. On Wednesday noon, at
+twelve, a female body was discovered afloat on the shore of the Barrière
+de Roule. This was, even if we presume that Marie Rogêt was thrown into
+the river within three hours after she left her mother’s house, only
+three days from the time she left her home--three days to an hour. But
+it is folly to suppose that the murder, if murder was committed on
+her body, could have been consummated soon enough to have enabled her
+murderers to throw the body into the river before midnight. Those who
+are guilty of such horrid crimes, choose darkness rather the light....
+Thus we see that if the body found in the river was that of Marie Rogêt,
+it could only have been in the water two and a half days, or three at
+the outside. All experience has shown that drowned bodies, or bodies
+thrown into the water immediately after death by violence, require from
+six to ten days for decomposition to take place to bring them to the top
+of the water. Even where a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again, if let
+alone. Now, we ask, what was there in this cave to cause a departure
+from the ordinary course of nature?... If the body had been kept in its
+mangled state on shore until Tuesday night, some trace would be found on
+shore of the murderers. It is a doubtful point, also, whether the body
+would be so soon afloat, even were it thrown in after having been
+dead two days. And, furthermore, it is exceedingly improbable that any
+villains who had committed such a murder as is here supposed, would
+have thrown the body in without weight to sink it, when such a precaution
+could have so easily been taken.”
+
+The editor here proceeds to argue that the body must have been in the
+water “not three days merely, but, at least, five times three days,”
+ because it was so far decomposed that Beauvais had great difficulty
+in recognizing it. This latter point, however, was fully disproved. I
+continue the translation:
+
+“What, then, are the facts on which M. Beauvais says that he has no
+doubt the body was that of Marie Rogêt? He ripped up the gown sleeve,
+and says he found marks which satisfied him of the identity. The public
+generally supposed those marks to have consisted of some description
+of scars. He rubbed the arm and found hair upon it--something as
+indefinite, we think, as can readily be imagined--as little conclusive
+as finding an arm in the sleeve. M. Beauvais did not return that night,
+but sent word to Madame Rogêt, at seven o’clock, on Wednesday evening,
+that an investigation was still in progress respecting her daughter. If
+we allow that Madame Rogêt, from her age and grief, could not go over,
+(which is allowing a great deal,) there certainly must have been some
+one who would have thought it worth while to go over and attend the
+investigation, if they thought the body was that of Marie. Nobody went
+over. There was nothing said or heard about the matter in the Rue Pavée
+St. Andrée, that reached even the occupants of the same building. M. St.
+Eustache, the lover and intended husband of Marie, who boarded in her
+mother’s house, deposes that he did not hear of the discovery of the
+body of his intended until the next morning, when M. Beauvais came
+into his chamber and told him of it. For an item of news like this, it
+strikes us it was very coolly received.”
+
+In this way the journal endeavored to create the impression of an apathy
+on the part of the relatives of Marie, inconsistent with the supposition
+that these relatives believed the corpse to be hers. Its insinuations
+amount to this:--that Marie, with the connivance of her friends, had
+absented herself from the city for reasons involving a charge against
+her chastity; and that these friends, upon the discovery of a corpse in
+the Seine, somewhat resembling that of the girl, had availed themselves
+of the opportunity to impress the public with the belief of her
+death. But L’Etoile was again over-hasty. It was distinctly proved
+that no apathy, such as was imagined, existed; that the old lady was
+exceedingly feeble, and so agitated as to be unable to attend to any
+duty, that St. Eustache, so far from receiving the news coolly, was
+distracted with grief, and bore himself so frantically, that M. Beauvais
+prevailed upon a friend and relative to take charge of him, and prevent
+his attending the examination at the disinterment. Moreover, although
+it was stated by L’Etoile, that the corpse was re-interred at the public
+expense--that an advantageous offer of private sculpture was absolutely
+declined by the family--and that no member of the family attended the
+ceremonial:--although, I say, all this was asserted by L’Etoile in
+furtherance of the impression it designed to convey--yet all this
+was satisfactorily disproved. In a subsequent number of the paper, an
+attempt was made to throw suspicion upon Beauvais himself. The editor
+says:
+
+“Now, then, a change comes over the matter. We are told that on one
+occasion, while a Madame B---- was at Madame Rogêt’s house, M. Beauvais,
+who was going out, told her that a gendarme was expected there, and she,
+Madame B., must not say anything to the gendarme until he returned,
+but let the matter be for him.... In the present posture of affairs,
+M. Beauvais appears to have the whole matter locked up in his head. A
+single step cannot be taken without M. Beauvais; for, go which way you
+will, you run against him.... For some reason, he determined that nobody
+shall have any thing to do with the proceedings but himself, and he
+has elbowed the male relatives out of the way, according to their
+representations, in a very singular manner. He seems to have been very
+much averse to permitting the relatives to see the body.”
+
+By the following fact, some color was given to the suspicion thus thrown
+upon Beauvais. A visiter at his office, a few days prior to the girl’s
+disappearance, and during the absence of its occupant, had observed a
+rose in the key-hole of the door, and the name “Marie” inscribed upon a
+slate which hung near at hand.
+
+The general impression, so far as we were enabled to glean it from the
+newspapers, seemed to be, that Marie had been the victim of a gang
+of desperadoes--that by these she had been borne across the river,
+maltreated and murdered. Le Commerciel, (*11) however, a print of
+extensive influence, was earnest in combating this popular idea. I quote
+a passage or two from its columns:
+
+“We are persuaded that pursuit has hitherto been on a false scent, so
+far as it has been directed to the Barrière du Roule. It is impossible
+that a person so well known to thousands as this young woman was, should
+have passed three blocks without some one having seen her; and any one
+who saw her would have remembered it, for she interested all who knew
+her. It was when the streets were full of people, when she went out....
+It is impossible that she could have gone to the Barrière du Roule, or
+to the Rue des Drômes, without being recognized by a dozen persons; yet
+no one has come forward who saw her outside of her mother’s door, and
+there is no evidence, except the testimony concerning her expressed
+intentions, that she did go out at all. Her gown was torn, bound round
+her, and tied; and by that the body was carried as a bundle. If the
+murder had been committed at the Barrière du Roule, there would have
+been no necessity for any such arrangement. The fact that the body was
+found floating near the Barrière, is no proof as to where it was thrown
+into the water..... A piece of one of the unfortunate girl’s petticoats,
+two feet long and one foot wide, was torn out and tied under her chin
+around the back of her head, probably to prevent screams. This was done
+by fellows who had no pocket-handkerchief.”
+
+A day or two before the Prefect called upon us, however, some important
+information reached the police, which seemed to overthrow, at least,
+the chief portion of Le Commerciel’s argument. Two small boys, sons of a
+Madame Deluc, while roaming among the woods near the Barrière du Roule,
+chanced to penetrate a close thicket, within which were three or four
+large stones, forming a kind of seat, with a back and footstool. On
+the upper stone lay a white petticoat; on the second a silk scarf. A
+parasol, gloves, and a pocket-handkerchief were also here found. The
+handkerchief bore the name “Marie Rogêt.” Fragments of dress were
+discovered on the brambles around. The earth was trampled, the bushes
+were broken, and there was every evidence of a struggle. Between the
+thicket and the river, the fences were found taken down, and the ground
+bore evidence of some heavy burthen having been dragged along it.
+
+A weekly paper, Le Soleil,(*12) had the following comments upon this
+discovery--comments which merely echoed the sentiment of the whole
+Parisian press:
+
+“The things had all evidently been there at least three or four weeks;
+they were all mildewed down hard with the action of the rain and stuck
+together from mildew. The grass had grown around and over some of them.
+The silk on the parasol was strong, but the threads of it were run
+together within. The upper part, where it had been doubled and folded,
+was all mildewed and rotten, and tore on its being opened..... The
+pieces of her frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock, and it had been
+mended; the other piece was part of the skirt, not the hem. They looked
+like strips torn off, and were on the thorn bush, about a foot from
+the ground..... There can be no doubt, therefore, that the spot of this
+appalling outrage has been discovered.”
+
+Consequent upon this discovery, new evidence appeared. Madame Deluc
+testified that she keeps a roadside inn not far from the bank of the
+river, opposite the Barrière du Roule. The neighborhood is
+secluded--particularly so. It is the usual Sunday resort of blackguards
+from the city, who cross the river in boats. About three o’clock, in the
+afternoon of the Sunday in question, a young girl arrived at the inn,
+accompanied by a young man of dark complexion. The two remained here for
+some time. On their departure, they took the road to some thick woods in
+the vicinity. Madame Deluc’s attention was called to the dress worn by
+the girl, on account of its resemblance to one worn by a deceased
+relative. A scarf was particularly noticed. Soon after the departure of
+the couple, a gang of miscreants made their appearance, behaved
+boisterously, ate and drank without making payment, followed in the
+route of the young man and girl, returned to the inn about dusk, and
+re-crossed the river as if in great haste.
+
+It was soon after dark, upon this same evening, that Madame Deluc, as
+well as her eldest son, heard the screams of a female in the vicinity
+of the inn. The screams were violent but brief. Madame D. recognized not
+only the scarf which was found in the thicket, but the dress which was
+discovered upon the corpse. An omnibus driver, Valence, (*13) now also
+testified that he saw Marie Rogêt cross a ferry on the Seine, on the
+Sunday in question, in company with a young man of dark complexion.
+He, Valence, knew Marie, and could not be mistaken in her identity. The
+articles found in the thicket were fully identified by the relatives of
+Marie.
+
+The items of evidence and information thus collected by myself, from
+the newspapers, at the suggestion of Dupin, embraced only one more
+point--but this was a point of seemingly vast consequence. It appears
+that, immediately after the discovery of the clothes as above described,
+the lifeless, or nearly lifeless body of St. Eustache, Marie’s
+betrothed, was found in the vicinity of what all now supposed the scene
+of the outrage. A phial labelled “laudanum,” and emptied, was found near
+him. His breath gave evidence of the poison. He died without speaking.
+Upon his person was found a letter, briefly stating his love for Marie,
+with his design of self-destruction.
+
+“I need scarcely tell you,” said Dupin, as he finished the perusal of
+my notes, “that this is a far more intricate case than that of the
+Rue Morgue; from which it differs in one important respect. This is
+an ordinary, although an atrocious instance of crime. There is nothing
+peculiarly outré about it. You will observe that, for this reason, the
+mystery has been considered easy, when, for this reason, it should have
+been considered difficult, of solution. Thus; at first, it was thought
+unnecessary to offer a reward. The myrmidons of G---- were able at once
+to comprehend how and why such an atrocity might have been committed.
+They could picture to their imaginations a mode--many modes--and a
+motive--many motives; and because it was not impossible that either of
+these numerous modes and motives could have been the actual one, they
+have taken it for granted that one of them must. But the case with which
+these variable fancies were entertained, and the very plausibility which
+each assumed, should have been understood as indicative rather of the
+difficulties than of the facilities which must attend elucidation. I
+have before observed that it is by prominences above the plane of the
+ordinary, that reason feels her way, if at all, in her search for the
+true, and that the proper question in cases such as this, is not so
+much ‘what has occurred?’ as ‘what has occurred that has never occurred
+before?’ In the investigations at the house of Madame L’Espanaye,
+(*14) the agents of G---- were discouraged and confounded by that
+very unusualness which, to a properly regulated intellect, would have
+afforded the surest omen of success; while this same intellect might
+have been plunged in despair at the ordinary character of all that met
+the eye in the case of the perfumery-girl, and yet told of nothing but
+easy triumph to the functionaries of the Prefecture.
+
+“In the case of Madame L’Espanaye and her daughter there was, even
+at the beginning of our investigation, no doubt that murder had been
+committed. The idea of suicide was excluded at once. Here, too, we are
+freed, at the commencement, from all supposition of self-murder. The
+body found at the Barrière du Roule, was found under such circumstances
+as to leave us no room for embarrassment upon this important point. But
+it has been suggested that the corpse discovered, is not that of the
+Marie Rogêt for the conviction of whose assassin, or assassins, the
+reward is offered, and respecting whom, solely, our agreement has been
+arranged with the Prefect. We both know this gentleman well. It will not
+do to trust him too far. If, dating our inquiries from the body found,
+and thence tracing a murderer, we yet discover this body to be that of
+some other individual than Marie; or, if starting from the living Marie,
+we find her, yet find her unassassinated--in either case we lose our
+labor; since it is Monsieur G---- with whom we have to deal. For our
+own purpose, therefore, if not for the purpose of justice, it is
+indispensable that our first step should be the determination of the
+identity of the corpse with the Marie Rogêt who is missing.
+
+“With the public the arguments of L’Etoile have had weight; and that the
+journal itself is convinced of their importance would appear from
+the manner in which it commences one of its essays upon the
+subject--‘Several of the morning papers of the day,’ it says, ‘speak of
+the _conclusive_ article in Monday’s Etoile.’ To me, this article
+appears conclusive of little beyond the zeal of its inditer. We should
+bear in mind that, in general, it is the object of our newspapers rather
+to create a sensation--to make a point--than to further the cause of
+truth. The latter end is only pursued when it seems coincident with the
+former. The print which merely falls in with ordinary opinion (however
+well founded this opinion may be) earns for itself no credit with the
+mob. The mass of the people regard as profound only him who suggests
+_pungent contradictions_ of the general idea. In ratiocination, not less
+than in literature, it is the epigram which is the most immediately and
+the most universally appreciated. In both, it is of the lowest order of
+merit.
+
+“What I mean to say is, that it is the mingled epigram and melodrame
+of the idea, that Marie Rogêt still lives, rather than any true
+plausibility in this idea, which have suggested it to L’Etoile, and
+secured it a favorable reception with the public. Let us examine the
+heads of this journal’s argument; endeavoring to avoid the incoherence
+with which it is originally set forth.
+
+“The first aim of the writer is to show, from the brevity of the
+interval between Marie’s disappearance and the finding of the floating
+corpse, that this corpse cannot be that of Marie. The reduction of this
+interval to its smallest possible dimension, becomes thus, at once, an
+object with the reasoner. In the rash pursuit of this object, he rushes
+into mere assumption at the outset. ‘It is folly to suppose,’ he says,
+‘that the murder, if murder was committed on her body, could have been
+consummated soon enough to have enabled her murderers to throw the body
+into the river before midnight.’ We demand at once, and very naturally,
+why? Why is it folly to suppose that the murder was committed _within
+five minutes_ after the girl’s quitting her mother’s house? Why is it
+folly to suppose that the murder was committed at any given period
+of the day? There have been assassinations at all hours. But, had the
+murder taken place at any moment between nine o’clock in the morning of
+Sunday, and a quarter before midnight, there would still have been
+time enough ‘to throw the body into the river before midnight.’ This
+assumption, then, amounts precisely to this--that the murder was not
+committed on Sunday at all--and, if we allow L’Etoile to assume this,
+we may permit it any liberties whatever. The paragraph beginning ‘It is
+folly to suppose that the murder, etc.,’ however it appears as printed
+in L’Etoile, may be imagined to have existed actually thus in the brain
+of its inditer--‘It is folly to suppose that the murder, if murder was
+committed on the body, could have been committed soon enough to have
+enabled her murderers to throw the body into the river before midnight;
+it is folly, we say, to suppose all this, and to suppose at the same
+time, (as we are resolved to suppose,) that the body was not thrown
+in until after midnight’--a sentence sufficiently inconsequential in
+itself, but not so utterly preposterous as the one printed.
+
+“Were it my purpose,” continued Dupin, “merely to _make out a case_
+against this passage of L’Etoile’s argument, I might safely leave it
+where it is. It is not, however, with L’Etoile that we have to do, but
+with the truth. The sentence in question has but one meaning, as it
+stands; and this meaning I have fairly stated: but it is material
+that we go behind the mere words, for an idea which these words have
+obviously intended, and failed to convey. It was the design of the
+journalist to say that, at whatever period of the day or night of Sunday
+this murder was committed, it was improbable that the assassins would
+have ventured to bear the corpse to the river before midnight. And
+herein lies, really, the assumption of which I complain. It is assumed
+that the murder was committed at such a position, and under such
+circumstances, that the bearing it to the river became necessary. Now,
+the assassination might have taken place upon the river’s brink, or on
+the river itself; and, thus, the throwing the corpse in the water might
+have been resorted to, at any period of the day or night, as the most
+obvious and most immediate mode of disposal. You will understand that I
+suggest nothing here as probable, or as cöincident with my own opinion.
+My design, so far, has no reference to the facts of the case. I wish
+merely to caution you against the whole tone of L’Etoile’s suggestion,
+by calling your attention to its ex parte character at the outset.
+
+“Having prescribed thus a limit to suit its own preconceived notions;
+having assumed that, if this were the body of Marie, it could have been
+in the water but a very brief time; the journal goes on to say:
+
+‘All experience has shown that drowned bodies, or bodies thrown into the
+water immediately after death by violence, require from six to ten days
+for sufficient decomposition to take place to bring them to the top
+of the water. Even when a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again if let
+alone.’
+
+“These assertions have been tacitly received by every paper in Paris,
+with the exception of Le Moniteur. (*15) This latter print endeavors
+to combat that portion of the paragraph which has reference to ‘drowned
+bodies’ only, by citing some five or six instances in which the bodies
+of individuals known to be drowned were found floating after the lapse
+of less time than is insisted upon by L’Etoile. But there is something
+excessively unphilosophical in the attempt on the part of Le Moniteur,
+to rebut the general assertion of L’Etoile, by a citation of particular
+instances militating against that assertion. Had it been possible to
+adduce fifty instead of five examples of bodies found floating at the
+end of two or three days, these fifty examples could still have been
+properly regarded only as exceptions to L’Etoile’s rule, until such time
+as the rule itself should be confuted. Admitting the rule, (and this
+Le Moniteur does not deny, insisting merely upon its exceptions,) the
+argument of L’Etoile is suffered to remain in full force; for this
+argument does not pretend to involve more than a question of the
+probability of the body having risen to the surface in less than three
+days; and this probability will be in favor of L’Etoile’s position until
+the instances so childishly adduced shall be sufficient in number to
+establish an antagonistical rule.
+
+“You will see at once that all argument upon this head should be urged,
+if at all, against the rule itself; and for this end we must examine the
+rationale of the rule. Now the human body, in general, is neither much
+lighter nor much heavier than the water of the Seine; that is to say,
+the specific gravity of the human body, in its natural condition, is
+about equal to the bulk of fresh water which it displaces. The bodies
+of fat and fleshy persons, with small bones, and of women generally,
+are lighter than those of the lean and large-boned, and of men; and the
+specific gravity of the water of a river is somewhat influenced by the
+presence of the tide from sea. But, leaving this tide out of question,
+it may be said that very few human bodies will sink at all, even in
+fresh water, of their own accord. Almost any one, falling into a river,
+will be enabled to float, if he suffer the specific gravity of the water
+fairly to be adduced in comparison with his own--that is to say, if
+he suffer his whole person to be immersed, with as little exception as
+possible. The proper position for one who cannot swim, is the upright
+position of the walker on land, with the head thrown fully back, and
+immersed; the mouth and nostrils alone remaining above the surface.
+Thus circumstanced, we shall find that we float without difficulty and
+without exertion. It is evident, however, that the gravities of the
+body, and of the bulk of water displaced, are very nicely balanced, and
+that a trifle will cause either to preponderate. An arm, for instance,
+uplifted from the water, and thus deprived of its support, is an
+additional weight sufficient to immerse the whole head, while the
+accidental aid of the smallest piece of timber will enable us to elevate
+the head so as to look about. Now, in the struggles of one unused to
+swimming, the arms are invariably thrown upwards, while an attempt is
+made to keep the head in its usual perpendicular position. The result
+is the immersion of the mouth and nostrils, and the inception, during
+efforts to breathe while beneath the surface, of water into the lungs.
+Much is also received into the stomach, and the whole body becomes
+heavier by the difference between the weight of the air originally
+distending these cavities, and that of the fluid which now fills them.
+This difference is sufficient to cause the body to sink, as a general
+rule; but is insufficient in the cases of individuals with small bones
+and an abnormal quantity of flaccid or fatty matter. Such individuals
+float even after drowning.
+
+“The corpse, being supposed at the bottom of the river, will there
+remain until, by some means, its specific gravity again becomes less
+than that of the bulk of water which it displaces. This effect
+is brought about by decomposition, or otherwise. The result of
+decomposition is the generation of gas, distending the cellular tissues
+and all the cavities, and giving the puffed appearance which is so
+horrible. When this distension has so far progressed that the bulk of
+the corpse is materially increased without a corresponding increase of
+mass or weight, its specific gravity becomes less than that of the water
+displaced, and it forthwith makes its appearance at the surface. But
+decomposition is modified by innumerable circumstances--is hastened or
+retarded by innumerable agencies; for example, by the heat or cold of
+the season, by the mineral impregnation or purity of the water, by its
+depth or shallowness, by its currency or stagnation, by the temperament
+of the body, by its infection or freedom from disease before death.
+Thus it is evident that we can assign no period, with any thing like
+accuracy, at which the corpse shall rise through decomposition. Under
+certain conditions this result would be brought about within an hour;
+under others, it might not take place at all. There are chemical
+infusions by which the animal frame can be preserved forever from
+corruption; the Bi-chloride of Mercury is one. But, apart from
+decomposition, there may be, and very usually is, a generation of gas
+within the stomach, from the acetous fermentation of vegetable matter
+(or within other cavities from other causes) sufficient to induce a
+distension which will bring the body to the surface. The effect produced
+by the firing of a cannon is that of simple vibration. This may either
+loosen the corpse from the soft mud or ooze in which it is imbedded,
+thus permitting it to rise when other agencies have already prepared
+it for so doing; or it may overcome the tenacity of some putrescent
+portions of the cellular tissue; allowing the cavities to distend under
+the influence of the gas.
+
+“Having thus before us the whole philosophy of this subject, we can
+easily test by it the assertions of L’Etoile. ‘All experience shows,’
+says this paper, ‘that drowned bodies, or bodies thrown into the water
+immediately after death by violence, require from six to ten days for
+sufficient decomposition to take place to bring them to the top of the
+water. Even when a cannon is fired over a corpse, and it rises before at
+least five or six days’ immersion, it sinks again if let alone.’
+
+“The whole of this paragraph must now appear a tissue of inconsequence
+and incoherence. All experience does not show that ‘drowned bodies’
+require from six to ten days for sufficient decomposition to take place
+to bring them to the surface. Both science and experience show that the
+period of their rising is, and necessarily must be, indeterminate. If,
+moreover, a body has risen to the surface through firing of cannon,
+it will not ‘sink again if let alone,’ until decomposition has so far
+progressed as to permit the escape of the generated gas. But I wish to
+call your attention to the distinction which is made between ‘drowned
+bodies,’ and ‘bodies thrown into the water immediately after death by
+violence.’ Although the writer admits the distinction, he yet includes
+them all in the same category. I have shown how it is that the body of
+a drowning man becomes specifically heavier than its bulk of water,
+and that he would not sink at all, except for the struggles by which
+he elevates his arms above the surface, and his gasps for breath while
+beneath the surface--gasps which supply by water the place of the
+original air in the lungs. But these struggles and these gasps would
+not occur in the body ‘thrown into the water immediately after death by
+violence.’ Thus, in the latter instance, the body, as a general rule,
+would not sink at all--a fact of which L’Etoile is evidently ignorant.
+When decomposition had proceeded to a very great extent--when the flesh
+had in a great measure left the bones--then, indeed, but not till then,
+should we lose sight of the corpse.
+
+“And now what are we to make of the argument, that the body found could
+not be that of Marie Rogêt, because, three days only having elapsed,
+this body was found floating? If drowned, being a woman, she might never
+have sunk; or having sunk, might have reappeared in twenty-four hours,
+or less. But no one supposes her to have been drowned; and, dying before
+being thrown into the river, she might have been found floating at any
+period afterwards whatever.
+
+“‘But,’ says L’Etoile, ‘if the body had been kept in its mangled state
+on shore until Tuesday night, some trace would be found on shore of the
+murderers.’ Here it is at first difficult to perceive the intention
+of the reasoner. He means to anticipate what he imagines would be an
+objection to his theory--viz: that the body was kept on shore two days,
+suffering rapid decomposition--more rapid than if immersed in water. He
+supposes that, had this been the case, it might have appeared at the
+surface on the Wednesday, and thinks that only under such circumstances
+it could so have appeared. He is accordingly in haste to show that it
+was not kept on shore; for, if so, ‘some trace would be found on shore
+of the murderers.’ I presume you smile at the sequitur. You cannot
+be made to see how the mere duration of the corpse on the shore could
+operate to multiply traces of the assassins. Nor can I.
+
+“‘And furthermore it is exceedingly improbable,’ continues our journal,
+‘that any villains who had committed such a murder as is here supposed,
+would have thrown the body in without weight to sink it, when such
+a precaution could have so easily been taken.’ Observe, here, the
+laughable confusion of thought! No one--not even L’Etoile--disputes
+the murder committed _on the body found_. The marks of violence are too
+obvious. It is our reasoner’s object merely to show that this body is
+not Marie’s. He wishes to prove that Marie is not assassinated--not that
+the corpse was not. Yet his observation proves only the latter point.
+Here is a corpse without weight attached. Murderers, casting it in,
+would not have failed to attach a weight. Therefore it was not thrown in
+by murderers. This is all which is proved, if any thing is. The question
+of identity is not even approached, and L’Etoile has been at great pains
+merely to gainsay now what it has admitted only a moment before. ‘We
+are perfectly convinced,’ it says, ‘that the body found was that of a
+murdered female.’
+
+“Nor is this the sole instance, even in this division of his subject,
+where our reasoner unwittingly reasons against himself. His evident
+object, I have already said, is to reduce, as much as possible, the
+interval between Marie’s disappearance and the finding of the corpse.
+Yet we find him urging the point that no person saw the girl from the
+moment of her leaving her mother’s house. ‘We have no evidence,’ he
+says, ‘that Marie Rogêt was in the land of the living after nine o’clock
+on Sunday, June the twenty-second.’ As his argument is obviously an ex
+parte one, he should, at least, have left this matter out of sight; for
+had any one been known to see Marie, say on Monday, or on Tuesday,
+the interval in question would have been much reduced, and, by his own
+ratiocination, the probability much diminished of the corpse being that
+of the grisette. It is, nevertheless, amusing to observe that L’Etoile
+insists upon its point in the full belief of its furthering its general
+argument.
+
+“Reperuse now that portion of this argument which has reference to the
+identification of the corpse by Beauvais. In regard to the hair upon the
+arm, L’Etoile has been obviously disingenuous. M. Beauvais, not being an
+idiot, could never have urged, in identification of the corpse, simply
+hair upon its arm. No arm is without hair. The generality of the
+expression of L’Etoile is a mere perversion of the witness’ phraseology.
+He must have spoken of some peculiarity in this hair. It must have been
+a peculiarity of color, of quantity, of length, or of situation.
+
+“‘Her foot,’ says the journal, ‘was small--so are thousands of feet. Her
+garter is no proof whatever--nor is her shoe--for shoes and garters are
+sold in packages. The same may be said of the flowers in her hat. One
+thing upon which M. Beauvais strongly insists is, that the clasp on the
+garter found, had been set back to take it in. This amounts to nothing;
+for most women find it proper to take a pair of garters home and fit
+them to the size of the limbs they are to encircle, rather than to try
+them in the store where they purchase.’ Here it is difficult to suppose
+the reasoner in earnest. Had M. Beauvais, in his search for the body of
+Marie, discovered a corpse corresponding in general size and appearance
+to the missing girl, he would have been warranted (without reference to
+the question of habiliment at all) in forming an opinion that his search
+had been successful. If, in addition to the point of general size and
+contour, he had found upon the arm a peculiar hairy appearance which he
+had observed upon the living Marie, his opinion might have been justly
+strengthened; and the increase of positiveness might well have been in
+the ratio of the peculiarity, or unusualness, of the hairy mark. If,
+the feet of Marie being small, those of the corpse were also small, the
+increase of probability that the body was that of Marie would not be an
+increase in a ratio merely arithmetical, but in one highly geometrical,
+or accumulative. Add to all this shoes such as she had been known to
+wear upon the day of her disappearance, and, although these shoes may be
+‘sold in packages,’ you so far augment the probability as to verge upon
+the certain. What, of itself, would be no evidence of identity, becomes
+through its corroborative position, proof most sure. Give us, then,
+flowers in the hat corresponding to those worn by the missing girl, and
+we seek for nothing farther. If only one flower, we seek for nothing
+farther--what then if two or three, or more? Each successive one
+is multiple evidence--proof not _added_ to proof, but multiplied by
+hundreds or thousands. Let us now discover, upon the deceased, garters
+such as the living used, and it is almost folly to proceed. But these
+garters are found to be tightened, by the setting back of a clasp,
+in just such a manner as her own had been tightened by Marie, shortly
+previous to her leaving home. It is now madness or hypocrisy to doubt.
+What L’Etoile says in respect to this abbreviation of the garter’s being
+an usual occurrence, shows nothing beyond its own pertinacity in error.
+The elastic nature of the clasp-garter is self-demonstration of the
+unusualness of the abbreviation. What is made to adjust itself, must of
+necessity require foreign adjustment but rarely. It must have been by an
+accident, in its strictest sense, that these garters of Marie needed
+the tightening described. They alone would have amply established her
+identity. But it is not that the corpse was found to have the garters
+of the missing girl, or found to have her shoes, or her bonnet, or the
+flowers of her bonnet, or her feet, or a peculiar mark upon the arm,
+or her general size and appearance--it is that the corpse had each,
+and _all collectively_. Could it be proved that the editor of L’Etoile
+_really_ entertained a doubt, under the circumstances, there would be
+no need, in his case, of a commission de lunatico inquirendo. He has
+thought it sagacious to echo the small talk of the lawyers, who, for the
+most part, content themselves with echoing the rectangular precepts of
+the courts. I would here observe that very much of what is rejected as
+evidence by a court, is the best of evidence to the intellect. For
+the court, guiding itself by the general principles of evidence--the
+recognized and _booked_ principles--is averse from swerving at
+particular instances. And this steadfast adherence to principle, with
+rigorous disregard of the conflicting exception, is a sure mode of
+attaining the maximum of attainable truth, in any long sequence of time.
+The practice, in mass, is therefore philosophical; but it is not the
+less certain that it engenders vast individual error. (*16)
+
+“In respect to the insinuations levelled at Beauvais, you will be
+willing to dismiss them in a breath. You have already fathomed the
+true character of this good gentleman. He is a busy-body, with much
+of romance and little of wit. Any one so constituted will readily so
+conduct himself, upon occasion of real excitement, as to render himself
+liable to suspicion on the part of the over acute, or the ill-disposed.
+M. Beauvais (as it appears from your notes) had some personal interviews
+with the editor of L’Etoile, and offended him by venturing an opinion
+that the corpse, notwithstanding the theory of the editor, was, in sober
+fact, that of Marie. ‘He persists,’ says the paper, ‘in asserting the
+corpse to be that of Marie, but cannot give a circumstance, in addition
+to those which we have commented upon, to make others believe.’ Now,
+without re-adverting to the fact that stronger evidence ‘to make others
+believe,’ could never have been adduced, it may be remarked that a man
+may very well be understood to believe, in a case of this kind, without
+the ability to advance a single reason for the belief of a second party.
+Nothing is more vague than impressions of individual identity. Each man
+recognizes his neighbor, yet there are few instances in which any one
+is prepared to give a reason for his recognition. The editor of L’Etoile
+had no right to be offended at M. Beauvais’ unreasoning belief.
+
+“The suspicious circumstances which invest him, will be found to tally
+much better with my hypothesis of romantic busy-bodyism, than with
+the reasoner’s suggestion of guilt. Once adopting the more charitable
+interpretation, we shall find no difficulty in comprehending the rose
+in the key-hole; the ‘Marie’ upon the slate; the ‘elbowing the male
+relatives out of the way;’ the ‘aversion to permitting them to see
+the body;’ the caution given to Madame B----, that she must hold no
+conversation with the gendarme until his return (Beauvais’); and,
+lastly, his apparent determination ‘that nobody should have anything to
+do with the proceedings except himself.’ It seems to me unquestionable
+that Beauvais was a suitor of Marie’s; that she coquetted with him; and
+that he was ambitious of being thought to enjoy her fullest intimacy
+and confidence. I shall say nothing more upon this point; and, as the
+evidence fully rebuts the assertion of L’Etoile, touching the matter
+of apathy on the part of the mother and other relatives--an apathy
+inconsistent with the supposition of their believing the corpse to be
+that of the perfumery-girl--we shall now proceed as if the question of
+identity were settled to our perfect satisfaction.”
+
+“And what,” I here demanded, “do you think of the opinions of Le
+Commerciel?”
+
+“That, in spirit, they are far more worthy of attention than any which
+have been promulgated upon the subject. The deductions from the premises
+are philosophical and acute; but the premises, in two instances, at
+least, are founded in imperfect observation. Le Commerciel wishes to
+intimate that Marie was seized by some gang of low ruffians not far from
+her mother’s door. ‘It is impossible,’ it urges, ‘that a person so well
+known to thousands as this young woman was, should have passed three
+blocks without some one having seen her.’ This is the idea of a man long
+resident in Paris--a public man--and one whose walks to and fro in the
+city, have been mostly limited to the vicinity of the public offices.
+He is aware that he seldom passes so far as a dozen blocks from his own
+bureau, without being recognized and accosted. And, knowing the extent
+of his personal acquaintance with others, and of others with him, he
+compares his notoriety with that of the perfumery-girl, finds no great
+difference between them, and reaches at once the conclusion that she, in
+her walks, would be equally liable to recognition with himself in
+his. This could only be the case were her walks of the same unvarying,
+methodical character, and within the same species of limited region
+as are his own. He passes to and fro, at regular intervals, within a
+confined periphery, abounding in individuals who are led to observation
+of his person through interest in the kindred nature of his occupation
+with their own. But the walks of Marie may, in general, be supposed
+discursive. In this particular instance, it will be understood as most
+probable, that she proceeded upon a route of more than average diversity
+from her accustomed ones. The parallel which we imagine to have existed
+in the mind of Le Commerciel would only be sustained in the event of the
+two individuals’ traversing the whole city. In this case, granting the
+personal acquaintances to be equal, the chances would be also equal that
+an equal number of personal rencounters would be made. For my own
+part, I should hold it not only as possible, but as very far more than
+probable, that Marie might have proceeded, at any given period, by any
+one of the many routes between her own residence and that of her aunt,
+without meeting a single individual whom she knew, or by whom she was
+known. In viewing this question in its full and proper light, we must
+hold steadily in mind the great disproportion between the personal
+acquaintances of even the most noted individual in Paris, and the entire
+population of Paris itself.
+
+“But whatever force there may still appear to be in the suggestion of Le
+Commerciel, will be much diminished when we take into consideration the
+hour at which the girl went abroad. ‘It was when the streets were full
+of people,’ says Le Commerciel, ‘that she went out.’ But not so. It was
+at nine o’clock in the morning. Now at nine o’clock of every morning in
+the week, _with the exception of Sunday_, the streets of the city are,
+it is true, thronged with people. At nine on Sunday, the populace are
+chiefly within doors _preparing for church_. No observing person can
+have failed to notice the peculiarly deserted air of the town, from
+about eight until ten on the morning of every Sabbath. Between ten and
+eleven the streets are thronged, but not at so early a period as that
+designated.
+
+“There is another point at which there seems a deficiency of observation
+on the part of Le Commerciel. ‘A piece,’ it says, ‘of one of the
+unfortunate girl’s petticoats, two feet long, and one foot wide, was
+torn out and tied under her chin, and around the back of her head,
+probably to prevent screams. This was done, by fellows who had no
+pocket-handkerchiefs.’ Whether this idea is, or is not well founded,
+we will endeavor to see hereafter; but by ‘fellows who have no
+pocket-handkerchiefs’ the editor intends the lowest class of ruffians.
+These, however, are the very description of people who will always be
+found to have handkerchiefs even when destitute of shirts. You must have
+had occasion to observe how absolutely indispensable, of late years, to
+the thorough blackguard, has become the pocket-handkerchief.”
+
+“And what are we to think,” I asked, “of the article in Le Soleil?”
+
+“That it is a vast pity its inditer was not born a parrot--in which
+case he would have been the most illustrious parrot of his race. He has
+merely repeated the individual items of the already published opinion;
+collecting them, with a laudable industry, from this paper and from
+that. ‘The things had all evidently been there,’ he says, ‘at least,
+three or four weeks, and there can be _no doubt_ that the spot of this
+appalling outrage has been discovered.’ The facts here re-stated by
+Le Soleil, are very far indeed from removing my own doubts upon this
+subject, and we will examine them more particularly hereafter in
+connexion with another division of the theme.
+
+“At present we must occupy ourselves with other investigations. You
+cannot fail to have remarked the extreme laxity of the examination of
+the corpse. To be sure, the question of identity was readily determined,
+or should have been; but there were other points to be ascertained. Had
+the body been in any respect despoiled? Had the deceased any articles
+of jewelry about her person upon leaving home? if so, had she any when
+found? These are important questions utterly untouched by the evidence;
+and there are others of equal moment, which have met with no attention.
+We must endeavor to satisfy ourselves by personal inquiry. The case of
+St. Eustache must be re-examined. I have no suspicion of this person;
+but let us proceed methodically. We will ascertain beyond a doubt the
+validity of the affidavits in regard to his whereabouts on the Sunday.
+Affidavits of this character are readily made matter of mystification.
+Should there be nothing wrong here, however, we will dismiss St.
+Eustache from our investigations. His suicide, however corroborative of
+suspicion, were there found to be deceit in the affidavits, is, without
+such deceit, in no respect an unaccountable circumstance, or one which
+need cause us to deflect from the line of ordinary analysis.
+
+“In that which I now propose, we will discard the interior points of
+this tragedy, and concentrate our attention upon its outskirts. Not the
+least usual error, in investigations such as this, is the limiting of
+inquiry to the immediate, with total disregard of the collateral or
+circumstantial events. It is the mal-practice of the courts to confine
+evidence and discussion to the bounds of apparent relevancy. Yet
+experience has shown, and a true philosophy will always show, that a
+vast, perhaps the larger portion of truth, arises from the seemingly
+irrelevant. It is through the spirit of this principle, if not precisely
+through its letter, that modern science has resolved to calculate upon
+the unforeseen. But perhaps you do not comprehend me. The history of
+human knowledge has so uninterruptedly shown that to collateral, or
+incidental, or accidental events we are indebted for the most numerous
+and most valuable discoveries, that it has at length become necessary,
+in any prospective view of improvement, to make not only large, but the
+largest allowances for inventions that shall arise by chance, and quite
+out of the range of ordinary expectation. It is no longer philosophical
+to base, upon what has been, a vision of what is to be. Accident is
+admitted as a portion of the substructure. We make chance a matter of
+absolute calculation. We subject the unlooked for and unimagined, to the
+mathematical _formulae_ of the schools.
+
+“I repeat that it is no more than fact, that the larger portion of all
+truth has sprung from the collateral; and it is but in accordance with
+the spirit of the principle involved in this fact, that I would divert
+inquiry, in the present case, from the trodden and hitherto unfruitful
+ground of the event itself, to the contemporary circumstances which
+surround it. While you ascertain the validity of the affidavits, I will
+examine the newspapers more generally than you have as yet done. So far,
+we have only reconnoitred the field of investigation; but it will be
+strange indeed if a comprehensive survey, such as I propose, of the
+public prints, will not afford us some minute points which shall
+establish a direction for inquiry.”
+
+In pursuance of Dupin’s suggestion, I made scrupulous examination of
+the affair of the affidavits. The result was a firm conviction of their
+validity, and of the consequent innocence of St. Eustache. In the mean
+time my friend occupied himself, with what seemed to me a minuteness
+altogether objectless, in a scrutiny of the various newspaper files. At
+the end of a week he placed before me the following extracts:
+
+“About three years and a half ago, a disturbance very similar to the
+present, was caused by the disappearance of this same Marie Rogêt, from
+the parfumerie of Monsieur Le Blanc, in the Palais Royal. At the end of
+a week, however, she re-appeared at her customary comptoir, as well as
+ever, with the exception of a slight paleness not altogether usual. It
+was given out by Monsieur Le Blanc and her mother, that she had merely
+been on a visit to some friend in the country; and the affair was
+speedily hushed up. We presume that the present absence is a freak of
+the same nature, and that, at the expiration of a week, or perhaps of
+a month, we shall have her among us again.”--Evening Paper--Monday June
+23. (*17)
+
+“An evening journal of yesterday, refers to a former mysterious
+disappearance of Mademoiselle Rogêt. It is well known that, during the
+week of her absence from Le Blanc’s parfumerie, she was in the company
+of a young naval officer, much noted for his debaucheries. A quarrel, it
+is supposed, providentially led to her return home. We have the name of
+the Lothario in question, who is, at present, stationed in Paris, but,
+for obvious reasons, forbear to make it public.”--Le Mercurie--Tuesday
+Morning, June 24. (*18)
+
+“An outrage of the most atrocious character was perpetrated near this
+city the day before yesterday. A gentleman, with his wife and daughter,
+engaged, about dusk, the services of six young men, who were idly rowing
+a boat to and fro near the banks of the Seine, to convey him across the
+river. Upon reaching the opposite shore, the three passengers stepped
+out, and had proceeded so far as to be beyond the view of the boat,
+when the daughter discovered that she had left in it her parasol. She
+returned for it, was seized by the gang, carried out into the stream,
+gagged, brutally treated, and finally taken to the shore at a point
+not far from that at which she had originally entered the boat with her
+parents. The villains have escaped for the time, but the police are upon
+their trail, and some of them will soon be taken.”--Morning Paper--June
+25. (*19)
+
+“We have received one or two communications, the object of which is to
+fasten the crime of the late atrocity upon Mennais; (*20) but as this
+gentleman has been fully exonerated by a loyal inquiry, and as the
+arguments of our several correspondents appear to be more zealous than
+profound, we do not think it advisable to make them public.”--Morning
+Paper--June 28. (*21)
+
+“We have received several forcibly written communications, apparently
+from various sources, and which go far to render it a matter of
+certainty that the unfortunate Marie Rogêt has become a victim of one of
+the numerous bands of blackguards which infest the vicinity of the city
+upon Sunday. Our own opinion is decidedly in favor of this
+supposition. We shall endeavor to make room for some of these arguments
+hereafter.”--Evening Paper--Tuesday, June 31. (*22)
+
+“On Monday, one of the bargemen connected with the revenue service, saw
+a empty boat floating down the Seine. Sails were lying in the bottom of
+the boat. The bargeman towed it under the barge office. The next morning
+it was taken from thence, without the knowledge of any of the officers.
+The rudder is now at the barge office.”--Le Diligence--Thursday, June
+26.
+
+Upon reading these various extracts, they not only seemed to me
+irrelevant, but I could perceive no mode in which any one of them
+could be brought to bear upon the matter in hand. I waited for some
+explanation from Dupin.
+
+“It is not my present design,” he said, “to dwell upon the first and
+second of those extracts. I have copied them chiefly to show you the
+extreme remissness of the police, who, as far as I can understand from
+the Prefect, have not troubled themselves, in any respect, with an
+examination of the naval officer alluded to. Yet it is mere folly to say
+that between the first and second disappearance of Marie, there is
+no _supposable_ connection. Let us admit the first elopement to have
+resulted in a quarrel between the lovers, and the return home of the
+betrayed. We are now prepared to view a second elopement (if we know
+that an elopement has again taken place) as indicating a renewal of the
+betrayer’s advances, rather than as the result of new proposals by a
+second individual--we are prepared to regard it as a ‘making up’ of the
+old amour, rather than as the commencement of a new one. The chances are
+ten to one, that he who had once eloped with Marie, would again propose
+an elopement, rather than that she to whom proposals of elopement had
+been made by one individual, should have them made to her by another.
+And here let me call your attention to the fact, that the time elapsing
+between the first ascertained, and the second supposed elopement, is
+a few months more than the general period of the cruises of our
+men-of-war. Had the lover been interrupted in his first villany by the
+necessity of departure to sea, and had he seized the first moment of his
+return to renew the base designs not yet altogether accomplished--or
+not yet altogether accomplished by _him?_ Of all these things we know
+nothing.
+
+“You will say, however, that, in the second instance, there was no
+elopement as imagined. Certainly not--but are we prepared to say that
+there was not the frustrated design? Beyond St. Eustache, and perhaps
+Beauvais, we find no recognized, no open, no honorable suitors of Marie.
+Of none other is there any thing said. Who, then, is the secret lover,
+of whom the relatives (at least most of them) know nothing, but whom
+Marie meets upon the morning of Sunday, and who is so deeply in her
+confidence, that she hesitates not to remain with him until the shades
+of the evening descend, amid the solitary groves of the Barrière du
+Roule? Who is that secret lover, I ask, of whom, at least, most of the
+relatives know nothing? And what means the singular prophecy of Madame
+Rogêt on the morning of Marie’s departure?--‘I fear that I shall never
+see Marie again.’
+
+“But if we cannot imagine Madame Rogêt privy to the design of elopement,
+may we not at least suppose this design entertained by the girl? Upon
+quitting home, she gave it to be understood that she was about to visit
+her aunt in the Rue des Drômes and St. Eustache was requested to call
+for her at dark. Now, at first glance, this fact strongly militates
+against my suggestion;--but let us reflect. That she did meet some
+companion, and proceed with him across the river, reaching the Barrière
+du Roule at so late an hour as three o’clock in the afternoon, is
+known. But in consenting so to accompany this individual, (_for whatever
+purpose--to her mother known or unknown,_) she must have thought of her
+expressed intention when leaving home, and of the surprise and suspicion
+aroused in the bosom of her affianced suitor, St. Eustache, when,
+calling for her, at the hour appointed, in the Rue des Drômes, he should
+find that she had not been there, and when, moreover, upon returning to
+the pension with this alarming intelligence, he should become aware of
+her continued absence from home. She must have thought of these things,
+I say. She must have foreseen the chagrin of St. Eustache, the suspicion
+of all. She could not have thought of returning to brave this suspicion;
+but the suspicion becomes a point of trivial importance to her, if we
+suppose her not intending to return.
+
+“We may imagine her thinking thus--‘I am to meet a certain person for
+the purpose of elopement, or for certain other purposes known only to
+myself. It is necessary that there be no chance of interruption--there
+must be sufficient time given us to elude pursuit--I will give it to be
+understood that I shall visit and spend the day with my aunt at the Rue
+des Drômes--I well tell St. Eustache not to call for me until dark--in
+this way, my absence from home for the longest possible period, without
+causing suspicion or anxiety, will be accounted for, and I shall gain
+more time than in any other manner. If I bid St. Eustache call for me
+at dark, he will be sure not to call before; but, if I wholly neglect
+to bid him call, my time for escape will be diminished, since it will
+be expected that I return the earlier, and my absence will the sooner
+excite anxiety. Now, if it were my design to return at all--if I had in
+contemplation merely a stroll with the individual in question--it would
+not be my policy to bid St. Eustache call; for, calling, he will be sure
+to ascertain that I have played him false--a fact of which I might keep
+him for ever in ignorance, by leaving home without notifying him of my
+intention, by returning before dark, and by then stating that I had been
+to visit my aunt in the Rue des Drômes. But, as it is my design never
+to return--or not for some weeks--or not until certain concealments are
+effected--the gaining of time is the only point about which I need give
+myself any concern.’
+
+“You have observed, in your notes, that the most general opinion in
+relation to this sad affair is, and was from the first, that the girl
+had been the victim of a gang of blackguards. Now, the popular opinion,
+under certain conditions, is not to be disregarded. When arising of
+itself--when manifesting itself in a strictly spontaneous manner--we
+should look upon it as analogous with that _intuition_ which is the
+idiosyncrasy of the individual man of genius. In ninety-nine cases from
+the hundred I would abide by its decision. But it is important that we
+find no palpable traces of _suggestion_. The opinion must be rigorously
+_the public’s own_; and the distinction is often exceedingly difficult
+to perceive and to maintain. In the present instance, it appears to me
+that this ‘public opinion’ in respect to a gang, has been superinduced
+by the collateral event which is detailed in the third of my extracts.
+All Paris is excited by the discovered corpse of Marie, a girl young,
+beautiful and notorious. This corpse is found, bearing marks of
+violence, and floating in the river. But it is now made known that, at
+the very period, or about the very period, in which it is supposed that
+the girl was assassinated, an outrage similar in nature to that endured
+by the deceased, although less in extent, was perpetuated, by a gang
+of young ruffians, upon the person of a second young female. Is it
+wonderful that the one known atrocity should influence the popular
+judgment in regard to the other unknown? This judgment awaited
+direction, and the known outrage seemed so opportunely to afford it!
+Marie, too, was found in the river; and upon this very river was this
+known outrage committed. The connexion of the two events had about it so
+much of the palpable, that the true wonder would have been a failure
+of the populace to appreciate and to seize it. But, in fact, the one
+atrocity, known to be so committed, is, if any thing, evidence that the
+other, committed at a time nearly coincident, was not so committed.
+It would have been a miracle indeed, if, while a gang of ruffians were
+perpetrating, at a given locality, a most unheard-of wrong, there should
+have been another similar gang, in a similar locality, in the same
+city, under the same circumstances, with the same means and appliances,
+engaged in a wrong of precisely the same aspect, at precisely the
+same period of time! Yet in what, if not in this marvellous train of
+coincidence, does the accidentally suggested opinion of the populace
+call upon us to believe?
+
+“Before proceeding farther, let us consider the supposed scene of the
+assassination, in the thicket at the Barrière du Roule. This thicket,
+although dense, was in the close vicinity of a public road. Within
+were three or four large stones, forming a kind of seat with a back and
+footstool. On the upper stone was discovered a white petticoat; on the
+second, a silk scarf. A parasol, gloves, and a pocket-handkerchief,
+were also here found. The handkerchief bore the name, ‘Marie Rogêt.’
+Fragments of dress were seen on the branches around. The earth was
+trampled, the bushes were broken, and there was every evidence of a
+violent struggle.
+
+“Notwithstanding the acclamation with which the discovery of this
+thicket was received by the press, and the unanimity with which it
+was supposed to indicate the precise scene of the outrage, it must be
+admitted that there was some very good reason for doubt. That it was the
+scene, I may or I may not believe--but there was excellent reason for
+doubt. Had the true scene been, as Le Commerciel suggested, in the
+neighborhood of the Rue Pavée St. Andrée, the perpetrators of the
+crime, supposing them still resident in Paris, would naturally have been
+stricken with terror at the public attention thus acutely directed into
+the proper channel; and, in certain classes of minds, there would have
+arisen, at once, a sense of the necessity of some exertion to redivert
+this attention. And thus, the thicket of the Barrière du Roule having
+been already suspected, the idea of placing the articles where they were
+found, might have been naturally entertained. There is no real evidence,
+although Le Soleil so supposes, that the articles discovered had
+been more than a very few days in the thicket; while there is much
+circumstantial proof that they could not have remained there, without
+attracting attention, during the twenty days elapsing between the fatal
+Sunday and the afternoon upon which they were found by the boys. ‘They
+were all _mildewed_ down hard,’ says Le Soleil, adopting the opinions of
+its predecessors, ‘with the action of the rain, and stuck together from
+_mildew_. The grass had grown around and over some of them. The silk of
+the parasol was strong, but the threads of it were run together within.
+The upper part, where it had been doubled and folded, was all _mildewed_
+and rotten, and tore on being opened.’ In respect to the grass having
+‘grown around and over some of them,’ it is obvious that the fact
+could only have been ascertained from the words, and thus from the
+recollections, of two small boys; for these boys removed the articles
+and took them home before they had been seen by a third party. But grass
+will grow, especially in warm and damp weather, (such as was that of the
+period of the murder,) as much as two or three inches in a single day.
+A parasol lying upon a newly turfed ground, might, in a single week,
+be entirely concealed from sight by the upspringing grass. And touching
+that mildew upon which the editor of Le Soleil so pertinaciously
+insists, that he employs the word no less than three times in the
+brief paragraph just quoted, is he really unaware of the nature of this
+mildew? Is he to be told that it is one of the many classes of fungus,
+of which the most ordinary feature is its upspringing and decadence
+within twenty-four hours?
+
+“Thus we see, at a glance, that what has been most triumphantly adduced
+in support of the idea that the articles had been ‘for at least three
+or four weeks’ in the thicket, is most absurdly null as regards any
+evidence of that fact. On the other hand, it is exceedingly difficult
+to believe that these articles could have remained in the thicket
+specified, for a longer period than a single week--for a longer period
+than from one Sunday to the next. Those who know any thing of the
+vicinity of Paris, know the extreme difficulty of finding seclusion
+unless at a great distance from its suburbs. Such a thing as an
+unexplored, or even an unfrequently visited recess, amid its woods or
+groves, is not for a moment to be imagined. Let any one who, being at
+heart a lover of nature, is yet chained by duty to the dust and heat
+of this great metropolis--let any such one attempt, even during the
+weekdays, to slake his thirst for solitude amid the scenes of natural
+loveliness which immediately surround us. At every second step, he will
+find the growing charm dispelled by the voice and personal intrusion
+of some ruffian or party of carousing blackguards. He will seek privacy
+amid the densest foliage, all in vain. Here are the very nooks where the
+unwashed most abound--here are the temples most desecrate. With sickness
+of the heart the wanderer will flee back to the polluted Paris as to
+a less odious because less incongruous sink of pollution. But if the
+vicinity of the city is so beset during the working days of the week,
+how much more so on the Sabbath! It is now especially that, released
+from the claims of labor, or deprived of the customary opportunities of
+crime, the town blackguard seeks the precincts of the town, not through
+love of the rural, which in his heart he despises, but by way of escape
+from the restraints and conventionalities of society. He desires
+less the fresh air and the green trees, than the utter license of the
+country. Here, at the road-side inn, or beneath the foliage of the
+woods, he indulges, unchecked by any eye except those of his boon
+companions, in all the mad excess of a counterfeit hilarity--the joint
+offspring of liberty and of rum. I say nothing more than what must
+be obvious to every dispassionate observer, when I repeat that the
+circumstance of the articles in question having remained undiscovered,
+for a longer period--than from one Sunday to another, in any thicket in
+the immediate neighborhood of Paris, is to be looked upon as little less
+than miraculous.
+
+“But there are not wanting other grounds for the suspicion that the
+articles were placed in the thicket with the view of diverting attention
+from the real scene of the outrage. And, first, let me direct your
+notice to the date of the discovery of the articles. Collate this with
+the date of the fifth extract made by myself from the newspapers. You
+will find that the discovery followed, almost immediately, the urgent
+communications sent to the evening paper. These communications, although
+various and apparently from various sources, tended all to the same
+point--viz., the directing of attention to a gang as the perpetrators
+of the outrage, and to the neighborhood of the Barrière du Roule as its
+scene. Now here, of course, the suspicion is not that, in consequence of
+these communications, or of the public attention by them directed, the
+articles were found by the boys; but the suspicion might and may well
+have been, that the articles were not before found by the boys, for the
+reason that the articles had not before been in the thicket; having
+been deposited there only at so late a period as at the date, or shortly
+prior to the date of the communications by the guilty authors of these
+communications themselves.
+
+“This thicket was a singular--an exceedingly singular one. It was
+unusually dense. Within its naturally walled enclosure were three
+extraordinary stones, forming a seat with a back and footstool. And this
+thicket, so full of a natural art, was in the immediate vicinity, within
+a few rods, of the dwelling of Madame Deluc, whose boys were in the
+habit of closely examining the shrubberies about them in search of
+the bark of the sassafras. Would it be a rash wager--a wager of one
+thousand to one--that a day never passed over the heads of these boys
+without finding at least one of them ensconced in the umbrageous hall,
+and enthroned upon its natural throne? Those who would hesitate at such
+a wager, have either never been boys themselves, or have forgotten the
+boyish nature. I repeat--it is exceedingly hard to comprehend how the
+articles could have remained in this thicket undiscovered, for a longer
+period than one or two days; and that thus there is good ground for
+suspicion, in spite of the dogmatic ignorance of Le Soleil, that they
+were, at a comparatively late date, deposited where found.
+
+“But there are still other and stronger reasons for believing them so
+deposited, than any which I have as yet urged. And, now, let me beg
+your notice to the highly artificial arrangement of the articles. On the
+upper stone lay a white petticoat; on the second a silk scarf; scattered
+around, were a parasol, gloves, and a pocket-handkerchief bearing the
+name, ‘Marie Rogêt.’ Here is just such an arrangement as would naturally
+be made by a not over-acute person wishing to dispose the articles
+naturally. But it is by no means a really natural arrangement. I
+should rather have looked to see the things all lying on the ground and
+trampled under foot. In the narrow limits of that bower, it would have
+been scarcely possible that the petticoat and scarf should have retained
+a position upon the stones, when subjected to the brushing to and fro
+of many struggling persons. ‘There was evidence,’ it is said, ‘of a
+struggle; and the earth was trampled, the bushes were broken,’--but the
+petticoat and the scarf are found deposited as if upon shelves. ‘The
+pieces of the frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock and it had been
+mended. They looked like strips torn off.’ Here, inadvertently, Le
+Soleil has employed an exceedingly suspicious phrase. The pieces, as
+described, do indeed ‘look like strips torn off;’ but purposely and by
+hand. It is one of the rarest of accidents that a piece is ‘torn off,’
+from any garment such as is now in question, by the agency of a thorn.
+From the very nature of such fabrics, a thorn or nail becoming entangled
+in them, tears them rectangularly--divides them into two longitudinal
+rents, at right angles with each other, and meeting at an apex where the
+thorn enters--but it is scarcely possible to conceive the piece ‘torn
+off.’ I never so knew it, nor did you. To tear a piece off from such
+fabric, two distinct forces, in different directions, will be, in almost
+every case, required. If there be two edges to the fabric--if, for
+example, it be a pocket-handkerchief, and it is desired to tear from it
+a slip, then, and then only, will the one force serve the purpose. But
+in the present case the question is of a dress, presenting but one edge.
+To tear a piece from the interior, where no edge is presented, could
+only be effected by a miracle through the agency of thorns, and no one
+thorn could accomplish it. But, even where an edge is presented, two
+thorns will be necessary, operating, the one in two distinct directions,
+and the other in one. And this in the supposition that the edge is
+unhemmed. If hemmed, the matter is nearly out of the question. We thus
+see the numerous and great obstacles in the way of pieces being ‘torn
+off’ through the simple agency of ‘thorns;’ yet we are required to
+believe not only that one piece but that many have been so torn. ‘And
+one part,’ too, ‘was the hem of the frock!’ Another piece was ‘part
+of the skirt, not the hem,’--that is to say, was torn completely out
+through the agency of thorns, from the uncaged interior of the
+dress! These, I say, are things which one may well be pardoned for
+disbelieving; yet, taken collectedly, they form, perhaps, less of
+reasonable ground for suspicion, than the one startling circumstance of
+the articles’ having been left in this thicket at all, by any murderers
+who had enough precaution to think of removing the corpse. You will not
+have apprehended me rightly, however, if you suppose it my design to
+deny this thicket as the scene of the outrage. There might have been a
+wrong here, or, more possibly, an accident at Madame Deluc’s. But, in
+fact, this is a point of minor importance. We are not engaged in an
+attempt to discover the scene, but to produce the perpetrators of the
+murder. What I have adduced, notwithstanding the minuteness with which I
+have adduced it, has been with the view, first, to show the folly of the
+positive and headlong assertions of Le Soleil, but secondly and chiefly,
+to bring you, by the most natural route, to a further contemplation of
+the doubt whether this assassination has, or has not been, the work of a
+gang.
+
+“We will resume this question by mere allusion to the revolting details
+of the surgeon examined at the inquest. It is only necessary to say that
+his published inferences, in regard to the number of ruffians, have been
+properly ridiculed as unjust and totally baseless, by all the reputable
+anatomists of Paris. Not that the matter might not have been as
+inferred, but that there was no ground for the inference:--was there not
+much for another?
+
+“Let us reflect now upon ‘the traces of a struggle;’ and let me ask what
+these traces have been supposed to demonstrate. A gang. But do they not
+rather demonstrate the absence of a gang? What struggle could have taken
+place--what struggle so violent and so enduring as to have left its
+‘traces’ in all directions--between a weak and defenceless girl and the
+gang of ruffians imagined? The silent grasp of a few rough arms and all
+would have been over. The victim must have been absolutely passive at
+their will. You will here bear in mind that the arguments urged against
+the thicket as the scene, are applicable in chief part, only against it
+as the scene of an outrage committed by more than a single individual.
+If we imagine but one violator, we can conceive, and thus only conceive,
+the struggle of so violent and so obstinate a nature as to have left the
+‘traces’ apparent.
+
+“And again. I have already mentioned the suspicion to be excited by the
+fact that the articles in question were suffered to remain at all in
+the thicket where discovered. It seems almost impossible that these
+evidences of guilt should have been accidentally left where found. There
+was sufficient presence of mind (it is supposed) to remove the corpse;
+and yet a more positive evidence than the corpse itself (whose features
+might have been quickly obliterated by decay,) is allowed to lie
+conspicuously in the scene of the outrage--I allude to the handkerchief
+with the name of the deceased. If this was accident, it was not
+the accident of a gang. We can imagine it only the accident of an
+individual. Let us see. An individual has committed the murder. He
+is alone with the ghost of the departed. He is appalled by what lies
+motionless before him. The fury of his passion is over, and there is
+abundant room in his heart for the natural awe of the deed. His is none
+of that confidence which the presence of numbers inevitably inspires.
+He is alone with the dead. He trembles and is bewildered. Yet there is
+a necessity for disposing of the corpse. He bears it to the river, but
+leaves behind him the other evidences of guilt; for it is difficult, if
+not impossible to carry all the burthen at once, and it will be easy to
+return for what is left. But in his toilsome journey to the water his
+fears redouble within him. The sounds of life encompass his path. A
+dozen times he hears or fancies the step of an observer. Even the very
+lights from the city bewilder him. Yet, in time and by long and frequent
+pauses of deep agony, he reaches the river’s brink, and disposes of
+his ghastly charge--perhaps through the medium of a boat. But now what
+treasure does the world hold--what threat of vengeance could it hold
+out--which would have power to urge the return of that lonely murderer
+over that toilsome and perilous path, to the thicket and its blood
+chilling recollections? He returns not, let the consequences be what
+they may. He could not return if he would. His sole thought is immediate
+escape. He turns his back forever upon those dreadful shrubberies and
+flees as from the wrath to come.
+
+“But how with a gang? Their number would have inspired them with
+confidence; if, indeed confidence is ever wanting in the breast of the
+arrant blackguard; and of arrant blackguards alone are the supposed
+gangs ever constituted. Their number, I say, would have prevented the
+bewildering and unreasoning terror which I have imagined to paralyze the
+single man. Could we suppose an oversight in one, or two, or three, this
+oversight would have been remedied by a fourth. They would have left
+nothing behind them; for their number would have enabled them to carry
+all at once. There would have been no need of return.
+
+“Consider now the circumstance that in the outer garment of the corpse
+when found, ‘a slip, about a foot wide had been torn upward from the
+bottom hem to the waist wound three times round the waist, and secured
+by a sort of hitch in the back.’ This was done with the obvious design
+of affording a handle by which to carry the body. But would any number
+of men have dreamed of resorting to such an expedient? To three or four,
+the limbs of the corpse would have afforded not only a sufficient, but
+the best possible hold. The device is that of a single individual; and
+this brings us to the fact that ‘between the thicket and the river, the
+rails of the fences were found taken down, and the ground bore evident
+traces of some heavy burden having been dragged along it!’ But would a
+number of men have put themselves to the superfluous trouble of taking
+down a fence, for the purpose of dragging through it a corpse which they
+might have lifted over any fence in an instant? Would a number of men
+have so dragged a corpse at all as to have left evident traces of the
+dragging?
+
+“And here we must refer to an observation of Le Commerciel; an
+observation upon which I have already, in some measure, commented. ‘A
+piece,’ says this journal, ‘of one of the unfortunate girl’s petticoats
+was torn out and tied under her chin, and around the back of her
+head, probably to prevent screams. This was done by fellows who had no
+pocket-handkerchiefs.’
+
+“I have before suggested that a genuine blackguard is never without a
+pocket-handkerchief. But it is not to this fact that I now especially
+advert. That it was not through want of a handkerchief for the purpose
+imagined by Le Commerciel, that this bandage was employed, is rendered
+apparent by the handkerchief left in the thicket; and that the object
+was not ‘to prevent screams’ appears, also, from the bandage having been
+employed in preference to what would so much better have answered
+the purpose. But the language of the evidence speaks of the strip in
+question as ‘found around the neck, fitting loosely, and secured with
+a hard knot.’ These words are sufficiently vague, but differ materially
+from those of Le Commerciel. The slip was eighteen inches wide, and
+therefore, although of muslin, would form a strong band when folded or
+rumpled longitudinally. And thus rumpled it was discovered. My inference
+is this. The solitary murderer, having borne the corpse, for some
+distance, (whether from the thicket or elsewhere) by means of the
+bandage hitched around its middle, found the weight, in this mode
+of procedure, too much for his strength. He resolved to drag the
+burthen--the evidence goes to show that it was dragged. With this object
+in view, it became necessary to attach something like a rope to one of
+the extremities. It could be best attached about the neck, where the
+head would prevent its slipping off. And, now, the murderer bethought
+him, unquestionably, of the bandage about the loins. He would have used
+this, but for its volution about the corpse, the hitch which embarrassed
+it, and the reflection that it had not been ‘torn off’ from the garment.
+It was easier to tear a new slip from the petticoat. He tore it, made
+it fast about the neck, and so dragged his victim to the brink of the
+river. That this ‘bandage,’ only attainable with trouble and delay, and
+but imperfectly answering its purpose--that this bandage was employed
+at all, demonstrates that the necessity for its employment sprang from
+circumstances arising at a period when the handkerchief was no longer
+attainable--that is to say, arising, as we have imagined, after quitting
+the thicket, (if the thicket it was), and on the road between the
+thicket and the river.
+
+“But the evidence, you will say, of Madame Deluc, (!) points especially
+to the presence of a gang, in the vicinity of the thicket, at or about
+the epoch of the murder. This I grant. I doubt if there were not a dozen
+gangs, such as described by Madame Deluc, in and about the vicinity of
+the Barrière du Roule at or about the period of this tragedy. But the
+gang which has drawn upon itself the pointed animadversion, although the
+somewhat tardy and very suspicious evidence of Madame Deluc, is the
+only gang which is represented by that honest and scrupulous old lady
+as having eaten her cakes and swallowed her brandy, without putting
+themselves to the trouble of making her payment. Et hinc illæ iræ?
+
+“But what is the precise evidence of Madame Deluc? ‘A gang of miscreants
+made their appearance, behaved boisterously, ate and drank without
+making payment, followed in the route of the young man and girl,
+returned to the inn about dusk, and recrossed the river as if in great
+haste.’
+
+“Now this ‘great haste’ very possibly seemed greater haste in the eyes
+of Madame Deluc, since she dwelt lingeringly and lamentingly upon her
+violated cakes and ale--cakes and ale for which she might still have
+entertained a faint hope of compensation. Why, otherwise, since it was
+about dusk, should she make a point of the haste? It is no cause for
+wonder, surely, that even a gang of blackguards should make haste to
+get home, when a wide river is to be crossed in small boats, when storm
+impends, and when night approaches.
+
+“I say approaches; for the night had not yet arrived. It was only about
+dusk that the indecent haste of these ‘miscreants’ offended the sober
+eyes of Madame Deluc. But we are told that it was upon this very evening
+that Madame Deluc, as well as her eldest son, ‘heard the screams of a
+female in the vicinity of the inn.’ And in what words does Madame Deluc
+designate the period of the evening at which these screams were heard?
+‘It was soon after dark,’ she says. But ‘soon after dark,’ is, at least,
+dark; and ‘about dusk’ is as certainly daylight. Thus it is abundantly
+clear that the gang quitted the Barrière du Roule prior to the screams
+overheard (?) by Madame Deluc. And although, in all the many reports of
+the evidence, the relative expressions in question are distinctly and
+invariably employed just as I have employed them in this conversation
+with yourself, no notice whatever of the gross discrepancy has, as yet,
+been taken by any of the public journals, or by any of the Myrmidons of
+police.
+
+“I shall add but one to the arguments against a gang; but this one has,
+to my own understanding at least, a weight altogether irresistible.
+Under the circumstances of large reward offered, and full pardon to
+any King’s evidence, it is not to be imagined, for a moment, that some
+member of a gang of low ruffians, or of any body of men, would not long
+ago have betrayed his accomplices. Each one of a gang so placed, is not
+so much greedy of reward, or anxious for escape, as fearful of betrayal.
+He betrays eagerly and early that he may not himself be betrayed. That
+the secret has not been divulged, is the very best of proof that it is,
+in fact, a secret. The horrors of this dark deed are known only to one,
+or two, living human beings, and to God.
+
+“Let us sum up now the meagre yet certain fruits of our long analysis.
+We have attained the idea either of a fatal accident under the roof of
+Madame Deluc, or of a murder perpetrated, in the thicket at the Barrière
+du Roule, by a lover, or at least by an intimate and secret associate of
+the deceased. This associate is of swarthy complexion. This complexion,
+the ‘hitch’ in the bandage, and the ‘sailor’s knot,’ with which the
+bonnet-ribbon is tied, point to a seaman. His companionship with the
+deceased, a gay, but not an abject young girl, designates him as
+above the grade of the common sailor. Here the well written and urgent
+communications to the journals are much in the way of corroboration. The
+circumstance of the first elopement, as mentioned by Le Mercurie, tends
+to blend the idea of this seaman with that of the ‘naval officer’ who is
+first known to have led the unfortunate into crime.
+
+“And here, most fitly, comes the consideration of the continued
+absence of him of the dark complexion. Let me pause to observe that the
+complexion of this man is dark and swarthy; it was no common swarthiness
+which constituted the sole point of remembrance, both as regards Valence
+and Madame Deluc. But why is this man absent? Was he murdered by the
+gang? If so, why are there only traces of the assassinated girl? The
+scene of the two outrages will naturally be supposed identical. And
+where is his corpse? The assassins would most probably have disposed
+of both in the same way. But it may be said that this man lives, and is
+deterred from making himself known, through dread of being charged with
+the murder. This consideration might be supposed to operate upon him
+now--at this late period--since it has been given in evidence that he
+was seen with Marie--but it would have had no force at the period of the
+deed. The first impulse of an innocent man would have been to announce
+the outrage, and to aid in identifying the ruffians. This policy would
+have suggested. He had been seen with the girl. He had crossed the river
+with her in an open ferry-boat. The denouncing of the assassins would
+have appeared, even to an idiot, the surest and sole means of relieving
+himself from suspicion. We cannot suppose him, on the night of the fatal
+Sunday, both innocent himself and incognizant of an outrage committed.
+Yet only under such circumstances is it possible to imagine that he
+would have failed, if alive, in the denouncement of the assassins.
+
+“And what means are ours, of attaining the truth? We shall find these
+means multiplying and gathering distinctness as we proceed. Let us sift
+to the bottom this affair of the first elopement. Let us know the
+full history of ‘the officer,’ with his present circumstances, and
+his whereabouts at the precise period of the murder. Let us carefully
+compare with each other the various communications sent to the evening
+paper, in which the object was to inculpate a gang. This done, let us
+compare these communications, both as regards style and MS., with
+those sent to the morning paper, at a previous period, and insisting so
+vehemently upon the guilt of Mennais. And, all this done, let us again
+compare these various communications with the known MSS. of the officer.
+Let us endeavor to ascertain, by repeated questionings of Madame Deluc
+and her boys, as well as of the omnibus driver, Valence, something more
+of the personal appearance and bearing of the ‘man of dark complexion.’
+Queries, skilfully directed, will not fail to elicit, from some of
+these parties, information on this particular point (or upon
+others)--information which the parties themselves may not even be aware
+of possessing. And let us now trace the boat picked up by the bargeman
+on the morning of Monday the twenty-third of June, and which was
+removed from the barge-office, without the cognizance of the officer
+in attendance, and without the rudder, at some period prior to the
+discovery of the corpse. With a proper caution and perseverance we shall
+infallibly trace this boat; for not only can the bargeman who picked
+it up identify it, but the rudder is at hand. The rudder of a sail-boat
+would not have been abandoned, without inquiry, by one altogether at
+ease in heart. And here let me pause to insinuate a question. There was
+no advertisement of the picking up of this boat. It was silently
+taken to the barge-office, and as silently removed. But its owner or
+employer--how happened he, at so early a period as Tuesday morning, to
+be informed, without the agency of advertisement, of the locality of
+the boat taken up on Monday, unless we imagine some connexion with the
+navy--some personal permanent connexion leading to cognizance of its
+minute in interests--its petty local news?
+
+“In speaking of the lonely assassin dragging his burden to the shore,
+I have already suggested the probability of his availing himself of a
+boat. Now we are to understand that Marie Rogêt was precipitated from a
+boat. This would naturally have been the case. The corpse could not have
+been trusted to the shallow waters of the shore. The peculiar marks on
+the back and shoulders of the victim tell of the bottom ribs of a boat.
+That the body was found without weight is also corroborative of the
+idea. If thrown from the shore a weight would have been attached. We can
+only account for its absence by supposing the murderer to have neglected
+the precaution of supplying himself with it before pushing off. In the
+act of consigning the corpse to the water, he would unquestionably have
+noticed his oversight; but then no remedy would have been at hand.
+Any risk would have been preferred to a return to that accursed shore.
+Having rid himself of his ghastly charge, the murderer would have
+hastened to the city. There, at some obscure wharf, he would have leaped
+on land. But the boat--would he have secured it? He would have been
+in too great haste for such things as securing a boat. Moreover, in
+fastening it to the wharf, he would have felt as if securing evidence
+against himself. His natural thought would have been to cast from him,
+as far as possible, all that had held connection with his crime. He
+would not only have fled from the wharf, but he would not have permitted
+the boat to remain. Assuredly he would have cast it adrift. Let us
+pursue our fancies.--In the morning, the wretch is stricken with
+unutterable horror at finding that the boat has been picked up and
+detained at a locality which he is in the daily habit of frequenting
+--at a locality, perhaps, which his duty compels him to frequent. The
+next night, without daring to ask for the rudder, he removes it. Now
+where is that rudderless boat? Let it be one of our first purposes
+to discover. With the first glimpse we obtain of it, the dawn of our
+success shall begin. This boat shall guide us, with a rapidity which
+will surprise even ourselves, to him who employed it in the midnight of
+the fatal Sabbath. Corroboration will rise upon corroboration, and the
+murderer will be traced.”
+
+[For reasons which we shall not specify, but which to many readers will
+appear obvious, we have taken the liberty of here omitting, from the
+MSS. placed in our hands, such portion as details the following up of
+the apparently slight clew obtained by Dupin. We feel it advisable only
+to state, in brief, that the result desired was brought to pass; and
+that the Prefect fulfilled punctually, although with reluctance, the
+terms of his compact with the Chevalier. Mr. Poe’s article concludes
+with the following words.--Eds. (*23)]
+
+It will be understood that I speak of coincidences and no more. What
+I have said above upon this topic must suffice. In my own heart there
+dwells no faith in præter-nature. That Nature and its God are two, no
+man who thinks, will deny. That the latter, creating the former, can, at
+will, control or modify it, is also unquestionable. I say “at will;” for
+the question is of will, and not, as the insanity of logic has assumed,
+of power. It is not that the Deity cannot modify his laws, but that we
+insult him in imagining a possible necessity for modification. In their
+origin these laws were fashioned to embrace all contingencies which
+could lie in the Future. With God all is Now.
+
+I repeat, then, that I speak of these things only as of coincidences.
+And farther: in what I relate it will be seen that between the fate of
+the unhappy Mary Cecilia Rogers, so far as that fate is known, and the
+fate of one Marie Rogêt up to a certain epoch in her history, there has
+existed a parallel in the contemplation of whose wonderful exactitude
+the reason becomes embarrassed. I say all this will be seen. But let it
+not for a moment be supposed that, in proceeding with the sad narrative
+of Marie from the epoch just mentioned, and in tracing to its dénouement
+the mystery which enshrouded her, it is my covert design to hint at an
+extension of the parallel, or even to suggest that the measures adopted
+in Paris for the discovery of the assassin of a grisette, or measures
+founded in any similar ratiocination, would produce any similar result.
+
+For, in respect to the latter branch of the supposition, it should be
+considered that the most trifling variation in the facts of the
+two cases might give rise to the most important miscalculations,
+by diverting thoroughly the two courses of events; very much as,
+in arithmetic, an error which, in its own individuality, may be
+inappreciable, produces, at length, by dint of multiplication at all
+points of the process, a result enormously at variance with truth. And,
+in regard to the former branch, we must not fail to hold in view that
+the very Calculus of Probabilities to which I have referred, forbids all
+idea of the extension of the parallel:--forbids it with a positiveness
+strong and decided just in proportion as this parallel has already been
+long-drawn and exact. This is one of those anomalous propositions which,
+seemingly appealing to thought altogether apart from the mathematical,
+is yet one which only the mathematician can fully entertain. Nothing,
+for example, is more difficult than to convince the merely general
+reader that the fact of sixes having been thrown twice in succession by
+a player at dice, is sufficient cause for betting the largest odds that
+sixes will not be thrown in the third attempt. A suggestion to this
+effect is usually rejected by the intellect at once. It does not
+appear that the two throws which have been completed, and which lie now
+absolutely in the Past, can have influence upon the throw which exists
+only in the Future. The chance for throwing sixes seems to be precisely
+as it was at any ordinary time--that is to say, subject only to the
+influence of the various other throws which may be made by the dice. And
+this is a reflection which appears so exceedingly obvious that attempts
+to controvert it are received more frequently with a derisive smile
+than with anything like respectful attention. The error here involved--a
+gross error redolent of mischief--I cannot pretend to expose within the
+limits assigned me at present; and with the philosophical it needs
+no exposure. It may be sufficient here to say that it forms one of an
+infinite series of mistakes which arise in the path of Reason through
+her propensity for seeking truth in detail.
+
+Footnotes--Marie Rogêt
+
+(*1) Upon the original publication of “Marie Roget,” the foot-notes now
+appended were considered unnecessary; but the lapse of several years
+since the tragedy upon which the tale is based, renders it expedient
+to give them, and also to say a few words in explanation of the general
+design. A young girl, Mary Cecilia Rogers, was murdered in the
+vicinity of New York; and, although her death occasioned an intense and
+long-enduring excitement, the mystery attending it had remained
+unsolved at the period when the present paper was written and published
+(November, 1842). Herein, under pretence of relating the fate of
+a Parisian grisette, the author has followed in minute detail, the
+essential, while merely paralleling the inessential facts of the real
+murder of Mary Rogers. Thus all argument founded upon the fiction is
+applicable to the truth: and the investigation of the truth was the
+object. The “Mystery of Marie Roget” was composed at a distance from the
+scene of the atrocity, and with no other means of investigation than the
+newspapers afforded. Thus much escaped the writer of which he could have
+availed himself had he been upon the spot, and visited the localities.
+It may not be improper to record, nevertheless, that the confessions of
+two persons, (one of them the Madame Deluc of the narrative) made, at
+different periods, long subsequent to the publication, confirmed, in
+full, not only the general conclusion, but absolutely all the chief
+hypothetical details by which that conclusion was attained.
+
+(*2) The nom de plume of Von Hardenburg.
+
+(*3) Nassau Street.
+
+(*4) Anderson.
+
+(*5) The Hudson.
+
+(*6) Weehawken.
+
+(*7) Payne.
+
+(*8) Crommelin.
+
+(*9) The New York “Mercury.”
+
+(*10) The New York “Brother Jonathan,” edited by H. Hastings Weld, Esq.
+
+(*11) New York “Journal of Commerce.”
+
+(*12) Philadelphia “Saturday Evening Post,” edited by C. I. Peterson,
+Esq.
+
+(*13) Adam
+
+(*14) See “Murders in the Rue Morgue.”
+
+(*15) The New York “Commercial Advertiser,” edited by Col. Stone.
+
+(*16) “A theory based on the qualities of an object, will prevent its
+being unfolded according to its objects; and he who arranges topics in
+reference to their causes, will cease to value them according to their
+results. Thus the jurisprudence of every nation will show that, when law
+becomes a science and a system, it ceases to be justice. The errors
+into which a blind devotion to principles of classification has led the
+common law, will be seen by observing how often the legislature has
+been obliged to come forward to restore the equity its scheme had
+lost.”--Landor.
+
+(*17) New York “Express”
+
+(*18) New York “Herald.”
+
+(*19) New York “Courier and Inquirer.”
+
+(*20) Mennais was one of the parties originally suspected and arrested,
+but discharged through total lack of evidence.
+
+(*21) New York “Courier and Inquirer.”
+
+(*22) New York “Evening Post.”
+
+(*23) Of the Magazine in which the article was originally published.
+
+
+
+
+THE BALLOON-HOAX
+
+ [Astounding News by Express, _via_ Norfolk!--The Atlantic
+ crossed in Three Days!  Signal Triumph of Mr. Monck Mason’s Flying
+ Machine!--Arrival at Sullivan’s Island, near Charlestown, S.C., of
+ Mr. Mason, Mr. Robert Holland, Mr. Henson, Mr. Harrison Ainsworth,
+ and four others, in the Steering Balloon, “Victoria,” after a passage
+ of Seventy-five Hours from Land to Land!  Full Particulars of the
+ Voyage!
+
+ The subjoined _jeu d’esprit_ with the preceding heading in
+ magnificent capitals, well interspersed with notes of admiration, was
+ originally published, as matter of fact, in the “New York Sun,” a
+ daily newspaper, and therein fully subserved the purpose of creating
+ indigestible aliment for the _quidnuncs_ during the few hours
+ intervening between a couple of the Charleston mails.  The rush for
+ the “sole paper which had the news,” was something beyond even the
+ prodigious;  and, in fact, if (as some assert) the “Victoria” _did_
+ not absolutely accomplish the voyage recorded, it will be difficult
+ to assign a reason why she _should_ not have accomplished it.]
+
+THE great problem is at length solved! The air, as well as the earth
+and the ocean, has been subdued by science, and will become a common and
+convenient highway for mankind. _The Atlantic has been actually crossed
+in a Balloon!_ and this too without difficulty--without any great
+apparent danger--with thorough control of the machine--and in the
+inconceivably brief period of seventy-five hours from shore to shore!
+By the energy of an agent at Charleston, S.C., we are enabled to be
+the first to furnish the public with a detailed account of this most
+extraordinary voyage, which was performed between Saturday, the 6th
+instant, at 11, A.M., and 2, P.M., on Tuesday, the 9th instant, by Sir
+Everard Bringhurst; Mr. Osborne, a nephew of Lord Bentinck’s; Mr. Monck
+Mason and Mr. Robert Holland, the well-known æronauts; Mr. Harrison
+Ainsworth, author of “Jack Sheppard,” &c.; and Mr. Henson, the
+projector of the late unsuccessful flying machine--with two seamen from
+Woolwich--in all, eight persons. The particulars furnished below may be
+relied on as authentic and accurate in every respect, as, with a slight
+exception, they are copied _verbatim_ from the joint diaries of Mr.
+Monck Mason and Mr. Harrison Ainsworth, to whose politeness our agent is
+also indebted for much verbal information respecting the balloon itself,
+its construction, and other matters of interest. The only alteration in
+the MS. received, has been made for the purpose of throwing the hurried
+account of our agent, Mr. Forsyth, into a connected and intelligible
+form.
+
+“THE BALLOON.
+
+“Two very decided failures, of late--those of Mr. Henson and Sir George
+Cayley--had much weakened the public interest in the subject of aerial
+navigation. Mr. Henson’s scheme (which at first was considered very
+feasible even by men of science,) was founded upon the principle of an
+inclined plane, started from an eminence by an extrinsic force, applied
+and continued by the revolution of impinging vanes, in form and number
+resembling the vanes of a windmill. But, in all the experiments made
+with models at the Adelaide Gallery, it was found that the operation of
+these fans not only did not propel the machine, but actually impeded
+its flight. The only propelling force it ever exhibited, was the mere
+_impetus_ acquired from the descent of the inclined plane; and this
+_impetus_ carried the machine farther when the vanes were at rest, than
+when they were in motion--a fact which sufficiently demonstrates their
+inutility; and in the absence of the propelling, which was also the
+_sustaining_ power, the whole fabric would necessarily descend.
+This consideration led Sir George Cayley to think only of adapting
+a propeller to some machine having of itself an independent power of
+support--in a word, to a balloon; the idea, however, being novel,
+or original, with Sir George, only so far as regards the mode of its
+application to practice. He exhibited a model of his invention at the
+Polytechnic Institution. The propelling principle, or power, was here,
+also, applied to interrupted surfaces, or vanes, put in revolution.
+These vanes were four in number, but were found entirely ineffectual in
+moving the balloon, or in aiding its ascending power. The whole project
+was thus a complete failure.
+
+“It was at this juncture that Mr. Monck Mason (whose voyage from Dover
+to Weilburg in the balloon, “Nassau,” occasioned so much excitement in
+1837,) conceived the idea of employing the principle of the Archimedean
+screw for the purpose of propulsion through the air--rightly
+attributing the failure of Mr. Henson’s scheme, and of Sir George
+Cayley’s, to the interruption of surface in the independent vanes.
+He made the first public experiment at Willis’s Rooms, but afterward
+removed his model to the Adelaide Gallery.
+
+“Like Sir George Cayley’s balloon, his own was an ellipsoid. Its
+length was thirteen feet six inches--height, six feet eight inches. It
+contained about three hundred and twenty cubic feet of gas, which, if
+pure hydrogen, would support twenty-one pounds upon its first inflation,
+before the gas has time to deteriorate or escape. The weight of the
+whole machine and apparatus was seventeen pounds--leaving about four
+pounds to spare. Beneath the centre of the balloon, was a frame of light
+wood, about nine feet long, and rigged on to the balloon itself with
+a network in the customary manner. From this framework was suspended a
+wicker basket or car.
+
+“The screw consists of an axis of hollow brass tube, eighteen inches in
+length, through which, upon a semi-spiral inclined at fifteen degrees,
+pass a series of steel wire radii, two feet long, and thus projecting a
+foot on either side. These radii are connected at the outer extremities
+by two bands of flattened wire--the whole in this manner forming the
+framework of the screw, which is completed by a covering of oiled silk
+cut into gores, and tightened so as to present a tolerably uniform
+surface. At each end of its axis this screw is supported by pillars of
+hollow brass tube descending from the hoop. In the lower ends of these
+tubes are holes in which the pivots of the axis revolve. From the end
+of the axis which is next the car, proceeds a shaft of steel, connecting
+the screw with the pinion of a piece of spring machinery fixed in the
+car. By the operation of this spring, the screw is made to revolve with
+great rapidity, communicating a progressive motion to the whole. By
+means of the rudder, the machine was readily turned in any direction.
+The spring was of great power, compared with its dimensions, being
+capable of raising forty-five pounds upon a barrel of four inches
+diameter, after the first turn, and gradually increasing as it was wound
+up. It weighed, altogether, eight pounds six ounces. The rudder was
+a light frame of cane covered with silk, shaped somewhat like a
+battle-door, and was about three feet long, and at the widest, one foot.
+Its weight was about two ounces. It could be turned _flat_, and directed
+upwards or downwards, as well as to the right or left; and thus enabled
+the æronaut to transfer the resistance of the air which in an inclined
+position it must generate in its passage, to any side upon which he
+might desire to act; thus determining the balloon in the opposite
+direction.
+
+“This model (which, through want of time, we have necessarily described
+in an imperfect manner,) was put in action at the Adelaide Gallery,
+where it accomplished a velocity of five miles per hour; although,
+strange to say, it excited very little interest in comparison with the
+previous complex machine of Mr. Henson--so resolute is the world
+to despise anything which carries with it an air of simplicity. To
+accomplish the great desideratum of ærial navigation, it was very
+generally supposed that some exceedingly complicated application must be
+made of some unusually profound principle in dynamics.
+
+“So well satisfied, however, was Mr. Mason of the ultimate success of
+his invention, that he determined to construct immediately, if possible,
+a balloon of sufficient capacity to test the question by a voyage of
+some extent--the original design being to cross the British Channel, as
+before, in the Nassau balloon. To carry out his views, he solicited and
+obtained the patronage of Sir Everard Bringhurst and Mr. Osborne, two
+gentlemen well known for scientific acquirement, and especially for the
+interest they have exhibited in the progress of ærostation. The project,
+at the desire of Mr. Osborne, was kept a profound secret from the
+public--the only persons entrusted with the design being those actually
+engaged in the construction of the machine, which was built (under the
+superintendence of Mr. Mason, Mr. Holland, Sir Everard Bringhurst, and
+Mr. Osborne,) at the seat of the latter gentleman near Penstruthal, in
+Wales. Mr. Henson, accompanied by his friend Mr. Ainsworth, was admitted
+to a private view of the balloon, on Saturday last--when the two
+gentlemen made final arrangements to be included in the adventure. We
+are not informed for what reason the two seamen were also included in
+the party--but, in the course of a day or two, we shall put our readers
+in possession of the minutest particulars respecting this extraordinary
+voyage.
+
+“The balloon is composed of silk, varnished with the liquid gum
+caoutchouc. It is of vast dimensions, containing more than 40,000 cubic
+feet of gas; but as coal gas was employed in place of the more expensive
+and inconvenient hydrogen, the supporting power of the machine, when
+fully inflated, and immediately after inflation, is not more than about
+2500 pounds. The coal gas is not only much less costly, but is easily
+procured and managed.
+
+“For its introduction into common use for purposes of aerostation, we
+are indebted to Mr. Charles Green. Up to his discovery, the process of
+inflation was not only exceedingly expensive, but uncertain. Two, and
+even three days, have frequently been wasted in futile attempts to
+procure a sufficiency of hydrogen to fill a balloon, from which it
+had great tendency to escape, owing to its extreme subtlety, and its
+affinity for the surrounding atmosphere. In a balloon sufficiently
+perfect to retain its contents of coal-gas unaltered, in quantity or
+amount, for six months, an equal quantity of hydrogen could not be
+maintained in equal purity for six weeks.
+
+“The supporting power being estimated at 2500 pounds, and the united
+weights of the party amounting only to about 1200, there was left a
+surplus of 1300, of which again 1200 was exhausted by ballast, arranged
+in bags of different sizes, with their respective weights marked upon
+them--by cordage, barometers, telescopes, barrels containing provision
+for a fortnight, water-casks, cloaks, carpet-bags, and various other
+indispensable matters, including a coffee-warmer, contrived for warming
+coffee by means of slack-lime, so as to dispense altogether with fire,
+if it should be judged prudent to do so. All these articles, with the
+exception of the ballast, and a few trifles, were suspended from the
+hoop overhead. The car is much smaller and lighter, in proportion, than
+the one appended to the model. It is formed of a light wicker, and is
+wonderfully strong, for so frail looking a machine. Its rim is about
+four feet deep. The rudder is also very much larger, in proportion, than
+that of the model; and the screw is considerably smaller. The balloon is
+furnished besides with a grapnel, and a guide-rope; which latter is of
+the most indispensable importance. A few words, in explanation, will
+here be necessary for such of our readers as are not conversant with the
+details of aerostation.
+
+“As soon as the balloon quits the earth, it is subjected to the
+influence of many circumstances tending to create a difference in its
+weight; augmenting or diminishing its ascending power. For example,
+there may be a deposition of dew upon the silk, to the extent, even,
+of several hundred pounds; ballast has then to be thrown out, or the
+machine may descend. This ballast being discarded, and a clear sunshine
+evaporating the dew, and at the same time expanding the gas in the silk,
+the whole will again rapidly ascend. To check this ascent, the only
+recourse is, (or rather _was_, until Mr. Green’s invention of the
+guide-rope,) the permission of the escape of gas from the valve; but, in
+the loss of gas, is a proportionate general loss of ascending power; so
+that, in a comparatively brief period, the best-constructed balloon must
+necessarily exhaust all its resources, and come to the earth. This was
+the great obstacle to voyages of length.
+
+“The guide-rope remedies the difficulty in the simplest manner
+conceivable. It is merely a very long rope which is suffered to trail
+from the car, and the effect of which is to prevent the balloon from
+changing its level in any material degree. If, for example, there should
+be a deposition of moisture upon the silk, and the machine begins to
+descend in consequence, there will be no necessity for discharging
+ballast to remedy the increase of weight, for it is remedied, or
+counteracted, in an exactly just proportion, by the deposit on the
+ground of just so much of the end of the rope as is necessary. If,
+on the other hand, any circumstances should cause undue levity, and
+consequent ascent, this levity is immediately counteracted by the
+additional weight of rope upraised from the earth. Thus, the balloon
+can neither ascend or descend, except within very narrow limits, and its
+resources, either in gas or ballast, remain comparatively unimpaired.
+When passing over an expanse of water, it becomes necessary to employ
+small kegs of copper or wood, filled with liquid ballast of a lighter
+nature than water. These float, and serve all the purposes of a mere
+rope on land. Another most important office of the guide-rope, is to
+point out the _direction_ of the balloon. The rope _drags_, either on
+land or sea, while the balloon is free; the latter, consequently, is
+always in advance, when any progress whatever is made: a comparison,
+therefore, by means of the compass, of the relative positions of the two
+objects, will always indicate the _course_. In the same way, the angle
+formed by the rope with the vertical axis of the machine, indicates
+the _velocity_. When there is _no_ angle--in other words, when the rope
+hangs perpendicularly, the whole apparatus is stationary; but the larger
+the angle, that is to say, the farther the balloon precedes the end of
+the rope, the greater the velocity; and the converse.
+
+“As the original design was to cross the British Channel, and alight as
+near Paris as possible, the voyagers had taken the precaution to prepare
+themselves with passports directed to all parts of the Continent,
+specifying the nature of the expedition, as in the case of the Nassau
+voyage, and entitling the adventurers to exemption from the usual
+formalities of office: unexpected events, however, rendered these
+passports superfluous.
+
+“The inflation was commenced very quietly at daybreak, on Saturday
+morning, the 6th instant, in the Court-Yard of Weal-Vor House, Mr.
+Osborne’s seat, about a mile from Penstruthal, in North Wales; and at 7
+minutes past 11, every thing being ready for departure, the balloon was
+set free, rising gently but steadily, in a direction nearly South; no
+use being made, for the first half hour, of either the screw or the
+rudder. We proceed now with the journal, as transcribed by Mr. Forsyth
+from the joint MSS. Of Mr. Monck Mason, and Mr. Ainsworth. The body of
+the journal, as given, is in the hand-writing of Mr. Mason, and a P.
+S. is appended, each day, by Mr. Ainsworth, who has in preparation, and
+will shortly give the public a more minute, and no doubt, a thrillingly
+interesting account of the voyage.
+
+“THE JOURNAL.
+
+“_Saturday, April the 6th_.--Every preparation likely to embarrass us,
+having been made over night, we commenced the inflation this morning at
+daybreak; but owing to a thick fog, which encumbered the folds of the
+silk and rendered it unmanageable, we did not get through before nearly
+eleven o’clock. Cut loose, then, in high spirits, and rose gently but
+steadily, with a light breeze at North, which bore us in the direction
+of the British Channel. Found the ascending force greater than we had
+expected; and as we arose higher and so got clear of the cliffs, and
+more in the sun’s rays, our ascent became very rapid. I did not wish,
+however, to lose gas at so early a period of the adventure, and so
+concluded to ascend for the present. We soon ran out our guide-rope;
+but even when we had raised it clear of the earth, we still went up very
+rapidly. The balloon was unusually steady, and looked beautifully. In
+about ten minutes after starting, the barometer indicated an altitude
+of 15,000 feet. The weather was remarkably fine, and the view of the
+subjacent country--a most romantic one when seen from any point,--was
+now especially sublime. The numerous deep gorges presented the
+appearance of lakes, on account of the dense vapors with which they
+were filled, and the pinnacles and crags to the South East, piled in
+inextricable confusion, resembling nothing so much as the giant cities
+of eastern fable. We were rapidly approaching the mountains in the
+South; but our elevation was more than sufficient to enable us to pass
+them in safety. In a few minutes we soared over them in fine style; and
+Mr. Ainsworth, with the seamen, was surprised at their apparent want of
+altitude when viewed from the car, the tendency of great elevation in a
+balloon being to reduce inequalities of the surface below, to nearly
+a dead level. At half-past eleven still proceeding nearly South, we
+obtained our first view of the Bristol Channel; and, in fifteen minutes
+afterward, the line of breakers on the coast appeared immediately
+beneath us, and we were fairly out at sea. We now resolved to let off
+enough gas to bring our guide-rope, with the buoys affixed, into the
+water. This was immediately done, and we commenced a gradual descent.
+In about twenty minutes our first buoy dipped, and at the touch of the
+second soon afterwards, we remained stationary as to elevation. We were
+all now anxious to test the efficiency of the rudder and screw, and we
+put them both into requisition forthwith, for the purpose of altering
+our direction more to the eastward, and in a line for Paris. By means of
+the rudder we instantly effected the necessary change of direction, and
+our course was brought nearly at right angles to that of the wind; when
+we set in motion the spring of the screw, and were rejoiced to find it
+propel us readily as desired. Upon this we gave nine hearty cheers, and
+dropped in the sea a bottle, enclosing a slip of parchment with a brief
+account of the principle of the invention. Hardly, however, had we
+done with our rejoicings, when an unforeseen accident occurred which
+discouraged us in no little degree. The steel rod connecting the spring
+with the propeller was suddenly jerked out of place, at the car end, (by
+a swaying of the car through some movement of one of the two seamen we
+had taken up,) and in an instant hung dangling out of reach, from the
+pivot of the axis of the screw. While we were endeavoring to regain it,
+our attention being completely absorbed, we became involved in a strong
+current of wind from the East, which bore us, with rapidly increasing
+force, towards the Atlantic. We soon found ourselves driving out to sea
+at the rate of not less, certainly, than fifty or sixty miles an hour,
+so that we came up with Cape Clear, at some forty miles to our North,
+before we had secured the rod, and had time to think what we were about.
+It was now that Mr. Ainsworth made an extraordinary, but to my fancy,
+a by no means unreasonable or chimerical proposition, in which he was
+instantly seconded by Mr. Holland--viz.: that we should take advantage
+of the strong gale which bore us on, and in place of beating back to
+Paris, make an attempt to reach the coast of North America. After slight
+reflection I gave a willing assent to this bold proposition, which
+(strange to say) met with objection from the two seamen only. As the
+stronger party, however, we overruled their fears, and kept resolutely
+upon our course. We steered due West; but as the trailing of the buoys
+materially impeded our progress, and we had the balloon abundantly at
+command, either for ascent or descent, we first threw out fifty pounds
+of ballast, and then wound up (by means of a windlass) so much of the
+rope as brought it quite clear of the sea. We perceived the effect of
+this manoeuvre immediately, in a vastly increased rate of progress; and,
+as the gale freshened, we flew with a velocity nearly inconceivable; the
+guide-rope flying out behind the car, like a streamer from a vessel. It
+is needless to say that a very short time sufficed us to lose sight of
+the coast. We passed over innumerable vessels of all kinds, a few of
+which were endeavoring to beat up, but the most of them lying to. We
+occasioned the greatest excitement on board all--an excitement greatly
+relished by ourselves, and especially by our two men, who, now under the
+influence of a dram of Geneva, seemed resolved to give all scruple, or
+fear, to the wind. Many of the vessels fired signal guns; and in all
+we were saluted with loud cheers (which we heard with surprising
+distinctness) and the waving of caps and handkerchiefs. We kept on in
+this manner throughout the day, with no material incident, and, as
+the shades of night closed around us, we made a rough estimate of the
+distance traversed. It could not have been less than five hundred
+miles, and was probably much more. The propeller was kept in constant
+operation, and, no doubt, aided our progress materially. As the sun
+went down, the gale freshened into an absolute hurricane, and the ocean
+beneath was clearly visible on account of its phosphorescence. The wind
+was from the East all night, and gave us the brightest omen of success.
+We suffered no little from cold, and the dampness of the atmosphere was
+most unpleasant; but the ample space in the car enabled us to lie down,
+and by means of cloaks and a few blankets, we did sufficiently well.
+
+“P.S. (by Mr. Ainsworth.) The last nine hours have been unquestionably
+the most exciting of my life. I can conceive nothing more sublimating
+than the strange peril and novelty of an adventure such as this. May
+God grant that we succeed! I ask not success for mere safety to my
+insignificant person, but for the sake of human knowledge and--for the
+vastness of the triumph. And yet the feat is only so evidently feasible
+that the sole wonder is why men have scrupled to attempt it before. One
+single gale such as now befriends us--let such a tempest whirl forward
+a balloon for four or five days (these gales often last longer) and the
+voyager will be easily borne, in that period, from coast to coast. In
+view of such a gale the broad Atlantic becomes a mere lake. I am more
+struck, just now, with the supreme silence which reigns in the
+sea beneath us, notwithstanding its agitation, than with any other
+phenomenon presenting itself. The waters give up no voice to
+the heavens. The immense flaming ocean writhes and is tortured
+uncomplainingly. The mountainous surges suggest the idea of innumerable
+dumb gigantic fiends struggling in impotent agony. In a night such as is
+this to me, a man _lives_--lives a whole century of ordinary life--nor
+would I forego this rapturous delight for that of a whole century of
+ordinary existence.
+
+“_Sunday, the seventh_. [Mr. Mason’s MS.] This morning the gale, by 10,
+had subsided to an eight or nine--knot breeze, (for a vessel at sea,)
+and bears us, perhaps, thirty miles per hour, or more. It has veered,
+however, very considerably to the north; and now, at sundown, we are
+holding our course due west, principally by the screw and rudder, which
+answer their purposes to admiration. I regard the project as thoroughly
+successful, and the easy navigation of the air in any direction (not
+exactly in the teeth of a gale) as no longer problematical. We could not
+have made head against the strong wind of yesterday; but, by ascending,
+we might have got out of its influence, if requisite. Against a pretty
+stiff breeze, I feel convinced, we can make our way with the propeller.
+At noon, to-day, ascended to an elevation of nearly 25,000 feet, by
+discharging ballast. Did this to search for a more direct current, but
+found none so favorable as the one we are now in. We have an abundance
+of gas to take us across this small pond, even should the voyage
+last three weeks. I have not the slightest fear for the result. The
+difficulty has been strangely exaggerated and misapprehended. I can
+choose my current, and should I find _all_ currents against me, I can
+make very tolerable headway with the propeller. We have had no incidents
+worth recording. The night promises fair.
+
+P.S. [By Mr. Ainsworth.] I have little to record, except the fact (to me
+quite a surprising one) that, at an elevation equal to that of Cotopaxi,
+I experienced neither very intense cold, nor headache, nor difficulty
+of breathing; neither, I find, did Mr. Mason, nor Mr. Holland, nor Sir
+Everard. Mr. Osborne complained of constriction of the chest--but this
+soon wore off. We have flown at a great rate during the day, and we
+must be more than half way across the Atlantic. We have passed over
+some twenty or thirty vessels of various kinds, and all seem to be
+delightfully astonished. Crossing the ocean in a balloon is not so
+difficult a feat after all. _Omne ignotum pro magnifico. Mem:_ at
+25,000 feet elevation the sky appears nearly black, and the stars are
+distinctly visible; while the sea does not seem convex (as one might
+suppose) but absolutely and most unequivocally _concave_.(*1)
+
+“_Monday, the 8th_. [Mr. Mason’s MS.] This morning we had again some
+little trouble with the rod of the propeller, which must be entirely
+remodelled, for fear of serious accident--I mean the steel rod--not
+the vanes. The latter could not be improved. The wind has been blowing
+steadily and strongly from the north-east all day and so far fortune
+seems bent upon favoring us. Just before day, we were all somewhat
+alarmed at some odd noises and concussions in the balloon, accompanied
+with the apparent rapid subsidence of the whole machine. These phenomena
+were occasioned by the expansion of the gas, through increase of heat in
+the atmosphere, and the consequent disruption of the minute particles of
+ice with which the network had become encrusted during the night. Threw
+down several bottles to the vessels below. Saw one of them picked up by
+a large ship--seemingly one of the New York line packets. Endeavored to
+make out her name, but could not be sure of it. Mr. Osborne’s telescope
+made it out something like “Atalanta.” It is now 12, at night, and we
+are still going nearly west, at a rapid pace. The sea is peculiarly
+phosphorescent.
+
+“P.S. [By Mr. Ainsworth.] It is now 2, A.M., and nearly calm, as well as
+I can judge--but it is very difficult to determine this point, since
+we move _with_ the air so completely. I have not slept since quitting
+Wheal-Vor, but can stand it no longer, and must take a nap. We cannot be
+far from the American coast.
+
+“_Tuesday, the _9_th_. [Mr. Ainsworth’s MS.] _One, P.M. We are in
+full view of the low coast of South Carolina_. The great problem is
+accomplished. We have crossed the Atlantic--fairly and _easily_
+crossed it in a balloon! God be praised! Who shall say that anything is
+impossible hereafter?”
+
+The Journal here ceases. Some particulars of the descent were
+communicated, however, by Mr. Ainsworth to Mr. Forsyth. It was nearly
+dead calm when the voyagers first came in view of the coast, which
+was immediately recognized by both the seamen, and by Mr. Osborne.
+The latter gentleman having acquaintances at Fort Moultrie, it was
+immediately resolved to descend in its vicinity. The balloon was brought
+over the beach (the tide being out and the sand hard, smooth, and
+admirably adapted for a descent,) and the grapnel let go, which took
+firm hold at once. The inhabitants of the island, and of the fort,
+thronged out, of course, to see the balloon; but it was with the
+greatest difficulty that any one could be made to credit the actual
+voyage--_the crossing of the Atlantic_. The grapnel caught at 2, P.M.,
+precisely; and thus the whole voyage was completed in seventy-five
+hours; or rather less, counting from shore to shore. No serious accident
+occurred. No real danger was at any time apprehended. The balloon was
+exhausted and secured without trouble; and when the MS.  from which this
+narrative is compiled was despatched from Charleston, the party were
+still at Fort Moultrie. Their farther intentions were not ascertained;
+but we can safely promise our readers some additional information either
+on Monday or in the course of the next day, at farthest.
+
+This is unquestionably the most stupendous, the most interesting, and
+the most important undertaking, ever accomplished or even attempted by
+man. What magnificent events may ensue, it would be useless now to think
+of determining.
+
+(*1) _Note_.--Mr. Ainsworth has not attempted to account for this
+phenomenon, which, however, is quite susceptible of explanation. A line
+dropped from an elevation of 25,000 feet, perpendicularly to the surface
+of the earth (or sea), would form the perpendicular of a right-angled
+triangle, of which the base would extend from the right angle to the
+horizon, and the hypothenuse from the horizon to the balloon. But the
+25,000 feet of altitude is little or nothing, in comparison with the
+extent of the prospect. In other words, the base and hypothenuse of the
+supposed triangle would be so long when compared with the perpendicular,
+that the two former may be regarded as nearly parallel. In this manner
+the horizon of the æronaut would appear to be _on a level_ with the
+car. But, as the point immediately beneath him seems, and is, at a great
+distance below him, it seems, of course, also, at a great distance below
+the horizon. Hence the impression of _concavity_; and this impression
+must remain, until the elevation shall bear so great a proportion to
+the extent of prospect, that the apparent parallelism of the base and
+hypothenuse disappears--when the earth’s real convexity must become
+apparent.
+
+
+
+
+MS. FOUND IN A BOTTLE
+
+               Qui n’a plus qu’un moment a vivre
+
+               N’a plus rien a dissimuler.
+
+                            --Quinault--Atys.
+
+OF my country and of my family I have little to say. Ill usage and
+length of years have driven me from the one, and estranged me from the
+other. Hereditary wealth afforded me an education of no common order,
+and a contemplative turn of mind enabled me to methodize the stores
+which early study very diligently garnered up.--Beyond all things,
+the study of the German moralists gave me great delight; not from any
+ill-advised admiration of their eloquent madness, but from the ease with
+which my habits of rigid thought enabled me to detect their falsities.
+I have often been reproached with the aridity of my genius; a deficiency
+of imagination has been imputed to me as a crime; and the Pyrrhonism
+of my opinions has at all times rendered me notorious. Indeed, a strong
+relish for physical philosophy has, I fear, tinctured my mind with
+a very common error of this age--I mean the habit of referring
+occurrences, even the least susceptible of such reference, to the
+principles of that science. Upon the whole, no person could be less
+liable than myself to be led away from the severe precincts of truth by
+the ignes fatui of superstition. I have thought proper to premise thus
+much, lest the incredible tale I have to tell should be considered
+rather the raving of a crude imagination, than the positive experience
+of a mind to which the reveries of fancy have been a dead letter and a
+nullity.
+
+After many years spent in foreign travel, I sailed in the year 18-- ,
+from the port of Batavia, in the rich and populous island of Java, on
+a voyage to the Archipelago of the Sunda islands. I went as
+passenger--having no other inducement than a kind of nervous
+restlessness which haunted me as a fiend.
+
+Our vessel was a beautiful ship of about four hundred tons,
+copper-fastened, and built at Bombay of Malabar teak. She was freighted
+with cotton-wool and oil, from the Lachadive islands. We had also on
+board coir, jaggeree, ghee, cocoa-nuts, and a few cases of opium. The
+stowage was clumsily done, and the vessel consequently crank.
+
+We got under way with a mere breath of wind, and for many days stood
+along the eastern coast of Java, without any other incident to beguile
+the monotony of our course than the occasional meeting with some of the
+small grabs of the Archipelago to which we were bound.
+
+One evening, leaning over the taffrail, I observed a very singular,
+isolated cloud, to the N.W. It was remarkable, as well for its color, as
+from its being the first we had seen since our departure from Batavia.
+I watched it attentively until sunset, when it spread all at once to
+the eastward and westward, girting in the horizon with a narrow strip
+of vapor, and looking like a long line of low beach. My notice was soon
+afterwards attracted by the dusky-red appearance of the moon, and the
+peculiar character of the sea. The latter was undergoing a rapid change,
+and the water seemed more than usually transparent. Although I could
+distinctly see the bottom, yet, heaving the lead, I found the ship in
+fifteen fathoms. The air now became intolerably hot, and was loaded with
+spiral exhalations similar to those arising from heat iron. As night
+came on, every breath of wind died away, an more entire calm it is
+impossible to conceive. The flame of a candle burned upon the poop
+without the least perceptible motion, and a long hair, held between the
+finger and thumb, hung without the possibility of detecting a vibration.
+However, as the captain said he could perceive no indication of danger,
+and as we were drifting in bodily to shore, he ordered the sails to
+be furled, and the anchor let go. No watch was set, and the crew,
+consisting principally of Malays, stretched themselves deliberately upon
+deck. I went below--not without a full presentiment of evil. Indeed,
+every appearance warranted me in apprehending a Simoom. I told the
+captain my fears; but he paid no attention to what I said, and left me
+without deigning to give a reply. My uneasiness, however, prevented me
+from sleeping, and about midnight I went upon deck.--As I placed my foot
+upon the upper step of the companion-ladder, I was startled by a
+loud, humming noise, like that occasioned by the rapid revolution of a
+mill-wheel, and before I could ascertain its meaning, I found the ship
+quivering to its centre. In the next instant, a wilderness of foam
+hurled us upon our beam-ends, and, rushing over us fore and aft, swept
+the entire decks from stem to stern.
+
+The extreme fury of the blast proved, in a great measure, the salvation
+of the ship. Although completely water-logged, yet, as her masts had
+gone by the board, she rose, after a minute, heavily from the sea, and,
+staggering awhile beneath the immense pressure of the tempest, finally
+righted.
+
+By what miracle I escaped destruction, it is impossible to say. Stunned
+by the shock of the water, I found myself, upon recovery, jammed in
+between the stern-post and rudder. With great difficulty I gained my
+feet, and looking dizzily around, was, at first, struck with the idea of
+our being among breakers; so terrific, beyond the wildest imagination,
+was the whirlpool of mountainous and foaming ocean within which we were
+engulfed. After a while, I heard the voice of an old Swede, who had
+shipped with us at the moment of our leaving port. I hallooed to
+him with all my strength, and presently he came reeling aft. We soon
+discovered that we were the sole survivors of the accident. All on deck,
+with the exception of ourselves, had been swept overboard;--the captain
+and mates must have perished as they slept, for the cabins were deluged
+with water. Without assistance, we could expect to do little for the
+security of the ship, and our exertions were at first paralyzed by the
+momentary expectation of going down. Our cable had, of course, parted
+like pack-thread, at the first breath of the hurricane, or we should
+have been instantaneously overwhelmed. We scudded with frightful
+velocity before the sea, and the water made clear breaches over us. The
+frame-work of our stern was shattered excessively, and, in almost every
+respect, we had received considerable injury; but to our extreme Joy we
+found the pumps unchoked, and that we had made no great shifting of
+our ballast. The main fury of the blast had already blown over, and we
+apprehended little danger from the violence of the wind; but we looked
+forward to its total cessation with dismay; well believing, that, in our
+shattered condition, we should inevitably perish in the tremendous swell
+which would ensue. But this very just apprehension seemed by no means
+likely to be soon verified. For five entire days and nights--during
+which our only subsistence was a small quantity of jaggeree, procured
+with great difficulty from the forecastle--the hulk flew at a rate
+defying computation, before rapidly succeeding flaws of wind, which,
+without equalling the first violence of the Simoom, were still more
+terrific than any tempest I had before encountered. Our course for the
+first four days was, with trifling variations, S.E. and by S.; and we
+must have run down the coast of New Holland.--On the fifth day the cold
+became extreme, although the wind had hauled round a point more to the
+northward.--The sun arose with a sickly yellow lustre, and clambered a
+very few degrees above the horizon--emitting no decisive light.--There
+were no clouds apparent, yet the wind was upon the increase, and blew
+with a fitful and unsteady fury. About noon, as nearly as we could
+guess, our attention was again arrested by the appearance of the sun.
+It gave out no light, properly so called, but a dull and sullen glow
+without reflection, as if all its rays were polarized. Just before
+sinking within the turgid sea, its central fires suddenly went out, as
+if hurriedly extinguished by some unaccountable power. It was a dim,
+sliver-like rim, alone, as it rushed down the unfathomable ocean.
+
+We waited in vain for the arrival of the sixth day--that day to me
+has not arrived--to the Swede, never did arrive. Thenceforward we were
+enshrouded in patchy darkness, so that we could not have seen an object
+at twenty paces from the ship. Eternal night continued to envelop us,
+all unrelieved by the phosphoric sea-brilliancy to which we had been
+accustomed in the tropics. We observed too, that, although the tempest
+continued to rage with unabated violence, there was no longer to be
+discovered the usual appearance of surf, or foam, which had hitherto
+attended us. All around were horror, and thick gloom, and a black
+sweltering desert of ebony.--Superstitious terror crept by degrees into
+the spirit of the old Swede, and my own soul was wrapped up in silent
+wonder. We neglected all care of the ship, as worse than useless, and
+securing ourselves, as well as possible, to the stump of the mizen-mast,
+looked out bitterly into the world of ocean. We had no means of
+calculating time, nor could we form any guess of our situation. We were,
+however, well aware of having made farther to the southward than any
+previous navigators, and felt great amazement at not meeting with the
+usual impediments of ice. In the meantime every moment threatened to be
+our last--every mountainous billow hurried to overwhelm us. The swell
+surpassed anything I had imagined possible, and that we were not
+instantly buried is a miracle. My companion spoke of the lightness of
+our cargo, and reminded me of the excellent qualities of our ship; but
+I could not help feeling the utter hopelessness of hope itself, and
+prepared myself gloomily for that death which I thought nothing could
+defer beyond an hour, as, with every knot of way the ship made,
+the swelling of the black stupendous seas became more dismally
+appalling. At times we gasped for breath at an elevation beyond the
+albatross--at times became dizzy with the velocity of our descent into
+some watery hell, where the air grew stagnant, and no sound disturbed
+the slumbers of the kraken.
+
+We were at the bottom of one of these abysses, when a quick scream
+from my companion broke fearfully upon the night. “See! see!” cried he,
+shrieking in my ears, “Almighty God! see! see!” As he spoke, I became
+aware of a dull, sullen glare of red light which streamed down the sides
+of the vast chasm where we lay, and threw a fitful brilliancy upon our
+deck. Casting my eyes upwards, I beheld a spectacle which froze the
+current of my blood. At a terrific height directly above us, and upon
+the very verge of the precipitous descent, hovered a gigantic ship of,
+perhaps, four thousand tons. Although upreared upon the summit of a wave
+more than a hundred times her own altitude, her apparent size exceeded
+that of any ship of the line or East Indiaman in existence. Her huge
+hull was of a deep dingy black, unrelieved by any of the customary
+carvings of a ship. A single row of brass cannon protruded from her open
+ports, and dashed from their polished surfaces the fires of innumerable
+battle-lanterns, which swung to and fro about her rigging. But what
+mainly inspired us with horror and astonishment, was that she bore up
+under a press of sail in the very teeth of that supernatural sea, and of
+that ungovernable hurricane. When we first discovered her, her bows
+were alone to be seen, as she rose slowly from the dim and horrible gulf
+beyond her. For a moment of intense terror she paused upon the giddy
+pinnacle, as if in contemplation of her own sublimity, then trembled and
+tottered, and--came down.
+
+At this instant, I know not what sudden self-possession came over my
+spirit. Staggering as far aft as I could, I awaited fearlessly the ruin
+that was to overwhelm. Our own vessel was at length ceasing from her
+struggles, and sinking with her head to the sea. The shock of the
+descending mass struck her, consequently, in that portion of her frame
+which was already under water, and the inevitable result was to hurl me,
+with irresistible violence, upon the rigging of the stranger.
+
+As I fell, the ship hove in stays, and went about; and to the confusion
+ensuing I attributed my escape from the notice of the crew. With little
+difficulty I made my way unperceived to the main hatchway, which was
+partially open, and soon found an opportunity of secreting myself in the
+hold. Why I did so I can hardly tell. An indefinite sense of awe, which
+at first sight of the navigators of the ship had taken hold of my mind,
+was perhaps the principle of my concealment. I was unwilling to trust
+myself with a race of people who had offered, to the cursory glance I
+had taken, so many points of vague novelty, doubt, and apprehension. I
+therefore thought proper to contrive a hiding-place in the hold. This I
+did by removing a small portion of the shifting-boards, in such a manner
+as to afford me a convenient retreat between the huge timbers of the
+ship.
+
+I had scarcely completed my work, when a footstep in the hold forced me
+to make use of it. A man passed by my place of concealment with a feeble
+and unsteady gait. I could not see his face, but had an opportunity
+of observing his general appearance. There was about it an evidence of
+great age and infirmity. His knees tottered beneath a load of years, and
+his entire frame quivered under the burthen. He muttered to himself,
+in a low broken tone, some words of a language which I could not
+understand, and groped in a corner among a pile of singular-looking
+instruments, and decayed charts of navigation. His manner was a wild
+mixture of the peevishness of second childhood, and the solemn dignity
+of a God. He at length went on deck, and I saw him no more.
+
+* * * * *
+
+A feeling, for which I have no name, has taken possession of my soul
+--a sensation which will admit of no analysis, to which the lessons of
+bygone times are inadequate, and for which I fear futurity itself
+will offer me no key. To a mind constituted like my own, the latter
+consideration is an evil. I shall never--I know that I shall
+never--be satisfied with regard to the nature of my conceptions. Yet it
+is not wonderful that these conceptions are indefinite, since they have
+their origin in sources so utterly novel. A new sense--a new entity is
+added to my soul.
+
+* * * * *
+
+It is long since I first trod the deck of this terrible ship, and the
+rays of my destiny are, I think, gathering to a focus. Incomprehensible
+men! Wrapped up in meditations of a kind which I cannot divine, they
+pass me by unnoticed. Concealment is utter folly on my part, for the
+people will not see. It was but just now that I passed directly before
+the eyes of the mate--it was no long while ago that I ventured into the
+captain’s own private cabin, and took thence the materials with which
+I write, and have written. I shall from time to time continue this
+Journal. It is true that I may not find an opportunity of transmitting
+it to the world, but I will not fall to make the endeavour. At the last
+moment I will enclose the MS. in a bottle, and cast it within the sea.
+
+* * * * *
+
+An incident has occurred which has given me new room for meditation. Are
+such things the operation of ungoverned Chance? I had ventured upon deck
+and thrown myself down, without attracting any notice, among a pile of
+ratlin-stuff and old sails in the bottom of the yawl. While musing upon
+the singularity of my fate, I unwittingly daubed with a tar-brush the
+edges of a neatly-folded studding-sail which lay near me on a barrel.
+The studding-sail is now bent upon the ship, and the thoughtless touches
+of the brush are spread out into the word DISCOVERY.
+
+I have made many observations lately upon the structure of the vessel.
+Although well armed, she is not, I think, a ship of war. Her rigging,
+build, and general equipment, all negative a supposition of this
+kind. What she is not, I can easily perceive--what she is I fear it is
+impossible to say. I know not how it is, but in scrutinizing her strange
+model and singular cast of spars, her huge size and overgrown suits
+of canvas, her severely simple bow and antiquated stern, there will
+occasionally flash across my mind a sensation of familiar things, and
+there is always mixed up with such indistinct shadows of recollection,
+an unaccountable memory of old foreign chronicles and ages long ago.
+
+* * * * *
+
+I have been looking at the timbers of the ship. She is built of a
+material to which I am a stranger. There is a peculiar character about
+the wood which strikes me as rendering it unfit for the purpose to
+which it has been applied. I mean its extreme porousness, considered
+independently by the worm-eaten condition which is a consequence of
+navigation in these seas, and apart from the rottenness attendant upon
+age. It will appear perhaps an observation somewhat over-curious, but
+this wood would have every characteristic of Spanish oak, if Spanish oak
+were distended by any unnatural means.
+
+In reading the above sentence a curious apothegm of an old
+weather-beaten Dutch navigator comes full upon my recollection. “It
+is as sure,” he was wont to say, when any doubt was entertained of his
+veracity, “as sure as there is a sea where the ship itself will grow in
+bulk like the living body of the seaman.”
+
+* * * * *
+
+About an hour ago, I made bold to thrust myself among a group of the
+crew. They paid me no manner of attention, and, although I stood in the
+very midst of them all, seemed utterly unconscious of my presence. Like
+the one I had at first seen in the hold, they all bore about them the
+marks of a hoary old age. Their knees trembled with infirmity; their
+shoulders were bent double with decrepitude; their shrivelled skins
+rattled in the wind; their voices were low, tremulous and broken; their
+eyes glistened with the rheum of years; and their gray hairs streamed
+terribly in the tempest. Around them, on every part of the deck, lay
+scattered mathematical instruments of the most quaint and obsolete
+construction.
+
+* * * * *
+
+I mentioned some time ago the bending of a studding-sail. From that
+period the ship, being thrown dead off the wind, has continued her
+terrific course due south, with every rag of canvas packed upon her,
+from her trucks to her lower studding-sail booms, and rolling every
+moment her top-gallant yard-arms into the most appalling hell of water
+which it can enter into the mind of a man to imagine. I have just left
+the deck, where I find it impossible to maintain a footing, although the
+crew seem to experience little inconvenience. It appears to me a miracle
+of miracles that our enormous bulk is not swallowed up at once and
+forever. We are surely doomed to hover continually upon the brink of
+Eternity, without taking a final plunge into the abyss. From billows a
+thousand times more stupendous than any I have ever seen, we glide away
+with the facility of the arrowy sea-gull; and the colossal waters rear
+their heads above us like demons of the deep, but like demons confined
+to simple threats and forbidden to destroy. I am led to attribute these
+frequent escapes to the only natural cause which can account for such
+effect.--I must suppose the ship to be within the influence of some
+strong current, or impetuous under-tow.
+
+* * * * *
+
+I have seen the captain face to face, and in his own cabin--but, as I
+expected, he paid me no attention. Although in his appearance there is,
+to a casual observer, nothing which might bespeak him more or less than
+man--still a feeling of irrepressible reverence and awe mingled with the
+sensation of wonder with which I regarded him. In stature he is nearly
+my own height; that is, about five feet eight inches. He is of a
+well-knit and compact frame of body, neither robust nor remarkably
+otherwise. But it is the singularity of the expression which reigns upon
+the face--it is the intense, the wonderful, the thrilling evidence of
+old age, so utter, so extreme, which excites within my spirit a sense--a
+sentiment ineffable. His forehead, although little wrinkled, seems to
+bear upon it the stamp of a myriad of years.--His gray hairs are records
+of the past, and his grayer eyes are Sybils of the future. The cabin
+floor was thickly strewn with strange, iron-clasped folios, and
+mouldering instruments of science, and obsolete long-forgotten charts.
+His head was bowed down upon his hands, and he pored, with a fiery
+unquiet eye, over a paper which I took to be a commission, and which, at
+all events, bore the signature of a monarch. He muttered to himself, as
+did the first seaman whom I saw in the hold, some low peevish syllables
+of a foreign tongue, and although the speaker was close at my elbow, his
+voice seemed to reach my ears from the distance of a mile.
+
+* * * * *
+
+The ship and all in it are imbued with the spirit of Eld. The crew glide
+to and fro like the ghosts of buried centuries; their eyes have an eager
+and uneasy meaning; and when their fingers fall athwart my path in the
+wild glare of the battle-lanterns, I feel as I have never felt before,
+although I have been all my life a dealer in antiquities, and have
+imbibed the shadows of fallen columns at Balbec, and Tadmor, and
+Persepolis, until my very soul has become a ruin.
+
+* * * * *
+
+When I look around me I feel ashamed of my former apprehensions. If I
+trembled at the blast which has hitherto attended us, shall I not stand
+aghast at a warring of wind and ocean, to convey any idea of which
+the words tornado and simoom are trivial and ineffective? All in the
+immediate vicinity of the ship is the blackness of eternal night, and a
+chaos of foamless water; but, about a league on either side of us, may
+be seen, indistinctly and at intervals, stupendous ramparts of ice,
+towering away into the desolate sky, and looking like the walls of the
+universe.
+
+* * * * *
+
+As I imagined, the ship proves to be in a current; if that appellation
+can properly be given to a tide which, howling and shrieking by the
+white ice, thunders on to the southward with a velocity like the
+headlong dashing of a cataract.
+
+* * * * *
+
+To conceive the horror of my sensations is, I presume, utterly
+impossible; yet a curiosity to penetrate the mysteries of these awful
+regions, predominates even over my despair, and will reconcile me to the
+most hideous aspect of death. It is evident that we are hurrying onwards
+to some exciting knowledge--some never-to-be-imparted secret, whose
+attainment is destruction. Perhaps this current leads us to the southern
+pole itself. It must be confessed that a supposition apparently so wild
+has every probability in its favor.
+
+* * * * *
+
+The crew pace the deck with unquiet and tremulous step; but there is
+upon their countenances an expression more of the eagerness of hope than
+of the apathy of despair.
+
+In the meantime the wind is still in our poop, and, as we carry a crowd
+of canvas, the ship is at times lifted bodily from out the sea--Oh,
+horror upon horror! the ice opens suddenly to the right, and to the
+left, and we are whirling dizzily, in immense concentric circles, round
+and round the borders of a gigantic amphitheatre, the summit of whose
+walls is lost in the darkness and the distance. But little time will be
+left me to ponder upon my destiny--the circles rapidly grow small--we
+are plunging madly within the grasp of the whirlpool--and amid a
+roaring, and bellowing, and thundering of ocean and of tempest, the ship
+is quivering, oh God! and--going down.
+
+NOTE.--The “MS. Found in a Bottle,” was originally published in 1831,
+and it was not until many years afterwards that I became acquainted with
+the maps of Mercator, in which the ocean is represented as rushing, by
+four mouths, into the (northern) Polar Gulf, to be absorbed into the
+bowels of the earth; the Pole itself being represented by a black rock,
+towering to a prodigious height.
+
+
+
+
+THE OVAL PORTRAIT
+
+THE chateau into which my valet had ventured to make forcible entrance,
+rather than permit me, in my desperately wounded condition, to pass a
+night in the open air, was one of those piles of commingled gloom and
+grandeur which have so long frowned among the Appennines, not less in
+fact than in the fancy of Mrs. Radcliffe. To all appearance it had been
+temporarily and very lately abandoned. We established ourselves in one
+of the smallest and least sumptuously furnished apartments. It lay in a
+remote turret of the building. Its decorations were rich, yet tattered
+and antique. Its walls were hung with tapestry and bedecked with
+manifold and multiform armorial trophies, together with an unusually
+great number of very spirited modern paintings in frames of rich golden
+arabesque. In these paintings, which depended from the walls not only
+in their main surfaces, but in very many nooks which the bizarre
+architecture of the chateau rendered necessary--in these paintings my
+incipient delirium, perhaps, had caused me to take deep interest; so
+that I bade Pedro to close the heavy shutters of the room--since it was
+already night--to light the tongues of a tall candelabrum which stood by
+the head of my bed--and to throw open far and wide the fringed curtains
+of black velvet which enveloped the bed itself. I wished all this done
+that I might resign myself, if not to sleep, at least alternately to the
+contemplation of these pictures, and the perusal of a small volume which
+had been found upon the pillow, and which purported to criticise and
+describe them.
+
+Long--long I read--and devoutly, devotedly I gazed. Rapidly and
+gloriously the hours flew by and the deep midnight came. The position of
+the candelabrum displeased me, and outreaching my hand with difficulty,
+rather than disturb my slumbering valet, I placed it so as to throw its
+rays more fully upon the book.
+
+But the action produced an effect altogether unanticipated. The rays of
+the numerous candles (for there were many) now fell within a niche of
+the room which had hitherto been thrown into deep shade by one of the
+bed-posts. I thus saw in vivid light a picture all unnoticed before. It
+was the portrait of a young girl just ripening into womanhood. I glanced
+at the painting hurriedly, and then closed my eyes. Why I did this
+was not at first apparent even to my own perception. But while my lids
+remained thus shut, I ran over in my mind my reason for so shutting
+them. It was an impulsive movement to gain time for thought--to make
+sure that my vision had not deceived me--to calm and subdue my fancy for
+a more sober and more certain gaze. In a very few moments I again looked
+fixedly at the painting.
+
+That I now saw aright I could not and would not doubt; for the first
+flashing of the candles upon that canvas had seemed to dissipate the
+dreamy stupor which was stealing over my senses, and to startle me at
+once into waking life.
+
+The portrait, I have already said, was that of a young girl. It was a
+mere head and shoulders, done in what is technically termed a vignette
+manner; much in the style of the favorite heads of Sully. The arms, the
+bosom, and even the ends of the radiant hair melted imperceptibly into
+the vague yet deep shadow which formed the back-ground of the whole. The
+frame was oval, richly gilded and filigreed in Moresque. As a thing of
+art nothing could be more admirable than the painting itself. But it
+could have been neither the execution of the work, nor the immortal
+beauty of the countenance, which had so suddenly and so vehemently moved
+me. Least of all, could it have been that my fancy, shaken from its half
+slumber, had mistaken the head for that of a living person. I saw at
+once that the peculiarities of the design, of the vignetting, and of the
+frame, must have instantly dispelled such idea--must have prevented even
+its momentary entertainment. Thinking earnestly upon these points, I
+remained, for an hour perhaps, half sitting, half reclining, with my
+vision riveted upon the portrait. At length, satisfied with the true
+secret of its effect, I fell back within the bed. I had found the spell
+of the picture in an absolute life-likeliness of expression, which, at
+first startling, finally confounded, subdued, and appalled me. With deep
+and reverent awe I replaced the candelabrum in its former position. The
+cause of my deep agitation being thus shut from view, I sought eagerly
+the volume which discussed the paintings and their histories. Turning
+to the number which designated the oval portrait, I there read the vague
+and quaint words which follow:
+
+“She was a maiden of rarest beauty, and not more lovely than full of
+glee. And evil was the hour when she saw, and loved, and wedded the
+painter. He, passionate, studious, austere, and having already a bride
+in his Art; she a maiden of rarest beauty, and not more lovely than full
+of glee; all light and smiles, and frolicsome as the young fawn; loving
+and cherishing all things; hating only the Art which was her rival;
+dreading only the pallet and brushes and other untoward instruments
+which deprived her of the countenance of her lover. It was thus a
+terrible thing for this lady to hear the painter speak of his desire to
+portray even his young bride. But she was humble and obedient, and sat
+meekly for many weeks in the dark, high turret-chamber where the light
+dripped upon the pale canvas only from overhead. But he, the painter,
+took glory in his work, which went on from hour to hour, and from day to
+day. And he was a passionate, and wild, and moody man, who became lost
+in reveries; so that he would not see that the light which fell so
+ghastly in that lone turret withered the health and the spirits of his
+bride, who pined visibly to all but him. Yet she smiled on and still on,
+uncomplainingly, because she saw that the painter (who had high renown)
+took a fervid and burning pleasure in his task, and wrought day and
+night to depict her who so loved him, yet who grew daily more dispirited
+and weak. And in sooth some who beheld the portrait spoke of its
+resemblance in low words, as of a mighty marvel, and a proof not less of
+the power of the painter than of his deep love for her whom he depicted
+so surpassingly well. But at length, as the labor drew nearer to its
+conclusion, there were admitted none into the turret; for the painter
+had grown wild with the ardor of his work, and turned his eyes from
+canvas merely, even to regard the countenance of his wife. And he would
+not see that the tints which he spread upon the canvas were drawn from
+the cheeks of her who sate beside him. And when many weeks had passed,
+and but little remained to do, save one brush upon the mouth and one
+tint upon the eye, the spirit of the lady again flickered up as the
+flame within the socket of the lamp. And then the brush was given,
+and then the tint was placed; and, for one moment, the painter stood
+entranced before the work which he had wrought; but in the next, while
+he yet gazed, he grew tremulous and very pallid, and aghast, and crying
+with a loud voice, ‘This is indeed Life itself!’ turned suddenly to
+regard his beloved:--She was dead!”
+
+
+
+
+
+
+
+End of Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+***** This file should be named 2147-0.txt or 2147-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/1/4/2147/
+
+Produced by David Widger and Carlo Traverso
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/frankenstein.txt
+++ b/jet/hadoop/src/main/resources/books/frankenstein.txt
@@ -1,0 +1,7653 @@
+﻿Project Gutenberg's Frankenstein, by Mary Wollstonecraft (Godwin) Shelley
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Frankenstein
+       or The Modern Prometheus
+
+Author: Mary Wollstonecraft (Godwin) Shelley
+
+Release Date: June 17, 2008 [EBook #84]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+
+
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+Frankenstein,
+
+or the Modern Prometheus
+
+
+by
+
+Mary Wollstonecraft (Godwin) Shelley
+
+
+
+
+Letter 1
+
+
+St. Petersburgh, Dec. 11th, 17--
+
+TO Mrs. Saville, England
+
+You will rejoice to hear that no disaster has accompanied the
+commencement of an enterprise which you have regarded with such evil
+forebodings.  I arrived here yesterday, and my first task is to assure
+my dear sister of my welfare and increasing confidence in the success
+of my undertaking.
+
+I am already far north of London, and as I walk in the streets of
+Petersburgh, I feel a cold northern breeze play upon my cheeks, which
+braces my nerves and fills me with delight.  Do you understand this
+feeling?  This breeze, which has travelled from the regions towards
+which I am advancing, gives me a foretaste of those icy climes.
+Inspirited by this wind of promise, my daydreams become more fervent
+and vivid.  I try in vain to be persuaded that the pole is the seat of
+frost and desolation; it ever presents itself to my imagination as the
+region of beauty and delight.  There, Margaret, the sun is forever
+visible, its broad disk just skirting the horizon and diffusing a
+perpetual splendour.  There--for with your leave, my sister, I will put
+some trust in preceding navigators--there snow and frost are banished;
+and, sailing over a calm sea, we may be wafted to a land surpassing in
+wonders and in beauty every region hitherto discovered on the habitable
+globe.  Its productions and features may be without example, as the
+phenomena of the heavenly bodies undoubtedly are in those undiscovered
+solitudes.  What may not be expected in a country of eternal light?  I
+may there discover the wondrous power which attracts the needle and may
+regulate a thousand celestial observations that require only this
+voyage to render their seeming eccentricities consistent forever.  I
+shall satiate my ardent curiosity with the sight of a part of the world
+never before visited, and may tread a land never before imprinted by
+the foot of man. These are my enticements, and they are sufficient to
+conquer all fear of danger or death and to induce me to commence this
+laborious voyage with the joy a child feels when he embarks in a little
+boat, with his holiday mates, on an expedition of discovery up his
+native river. But supposing all these conjectures to be false, you
+cannot contest the inestimable benefit which I shall confer on all
+mankind, to the last generation, by discovering a passage near the pole
+to those countries, to reach which at present so many months are
+requisite; or by ascertaining the secret of the magnet, which, if at
+all possible, can only be effected by an undertaking such as mine.
+
+These reflections have dispelled the agitation with which I began my
+letter, and I feel my heart glow with an enthusiasm which elevates me
+to heaven, for nothing contributes so much to tranquillize the mind as
+a steady purpose--a point on which the soul may fix its intellectual
+eye.  This expedition has been the favourite dream of my early years. I
+have read with ardour the accounts of the various voyages which have
+been made in the prospect of arriving at the North Pacific Ocean
+through the seas which surround the pole.  You may remember that a
+history of all the voyages made for purposes of discovery composed the
+whole of our good Uncle Thomas' library.  My education was neglected,
+yet I was passionately fond of reading.  These volumes were my study
+day and night, and my familiarity with them increased that regret which
+I had felt, as a child, on learning that my father's dying injunction
+had forbidden my uncle to allow me to embark in a seafaring life.
+
+These visions faded when I perused, for the first time, those poets
+whose effusions entranced my soul and lifted it to heaven.  I also
+became a poet and for one year lived in a paradise of my own creation;
+I imagined that I also might obtain a niche in the temple where the
+names of Homer and Shakespeare are consecrated.  You are well
+acquainted with my failure and how heavily I bore the disappointment.
+But just at that time I inherited the fortune of my cousin, and my
+thoughts were turned into the channel of their earlier bent.
+
+Six years have passed since I resolved on my present undertaking.  I
+can, even now, remember the hour from which I dedicated myself to this
+great enterprise.  I commenced by inuring my body to hardship.  I
+accompanied the whale-fishers on several expeditions to the North Sea;
+I voluntarily endured cold, famine, thirst, and want of sleep; I often
+worked harder than the common sailors during the day and devoted my
+nights to the study of mathematics, the theory of medicine, and those
+branches of physical science from which a naval adventurer might derive
+the greatest practical advantage.  Twice I actually hired myself as an
+under-mate in a Greenland whaler, and acquitted myself to admiration. I
+must own I felt a little proud when my captain offered me the second
+dignity in the vessel and entreated me to remain with the greatest
+earnestness, so valuable did he consider my services.  And now, dear
+Margaret, do I not deserve to accomplish some great purpose?  My life
+might have been passed in ease and luxury, but I preferred glory to
+every enticement that wealth placed in my path.  Oh, that some
+encouraging voice would answer in the affirmative!  My courage and my
+resolution is firm; but my hopes fluctuate, and my spirits are often
+depressed.  I am about to proceed on a long and difficult voyage, the
+emergencies of which will demand all my fortitude:  I am required not
+only to raise the spirits of others, but sometimes to sustain my own,
+when theirs are failing.
+
+This is the most favourable period for travelling in Russia.  They fly
+quickly over the snow in their sledges; the motion is pleasant, and, in
+my opinion, far more agreeable than that of an English stagecoach.  The
+cold is not excessive, if you are wrapped in furs--a dress which I have
+already adopted, for there is a great difference between walking the
+deck and remaining seated motionless for hours, when no exercise
+prevents the blood from actually freezing in your veins.  I have no
+ambition to lose my life on the post-road between St. Petersburgh and
+Archangel. I shall depart for the latter town in a fortnight or three
+weeks; and my intention is to hire a ship there, which can easily be
+done by paying the insurance for the owner, and to engage as many
+sailors as I think necessary among those who are accustomed to the
+whale-fishing.  I do not intend to sail until the month of June; and
+when shall I return?  Ah, dear sister, how can I answer this question?
+If I succeed, many, many months, perhaps years, will pass before you
+and I may meet.  If I fail, you will see me again soon, or never.
+Farewell, my dear, excellent Margaret. Heaven shower down blessings on
+you, and save me, that I may again and again testify my gratitude for
+all your love and kindness.
+
+Your affectionate brother,
+  R. Walton
+
+
+
+Letter 2
+
+
+Archangel, 28th March, 17--
+
+To Mrs. Saville, England
+
+How slowly the time passes here, encompassed as I am by frost and snow!
+Yet a second step is taken towards my enterprise.  I have hired a
+vessel and am occupied in collecting my sailors; those whom I have
+already engaged appear to be men on whom I can depend and are certainly
+possessed of dauntless courage.
+
+But I have one want which I have never yet been able to satisfy, and
+the absence of the object of which I now feel as a most severe evil, I
+have no friend, Margaret:  when I am glowing with the enthusiasm of
+success, there will be none to participate my joy; if I am assailed by
+disappointment, no one will endeavour to sustain me in dejection. I
+shall commit my thoughts to paper, it is true; but that is a poor
+medium for the communication of feeling.  I desire the company of a man
+who could sympathize with me, whose eyes would reply to mine. You may
+deem me romantic, my dear sister, but I bitterly feel the want of a
+friend.  I have no one near me, gentle yet courageous, possessed of a
+cultivated as well as of a capacious mind, whose tastes are like my
+own, to approve or amend my plans.  How would such a friend repair the
+faults of your poor brother!  I am too ardent in execution and too
+impatient of difficulties.  But it is a still greater evil to me that I
+am self-educated:  for the first fourteen years of my life I ran wild
+on a common and read nothing but our Uncle Thomas' books of voyages. At
+that age I became acquainted with the celebrated poets of our own
+country; but it was only when it had ceased to be in my power to derive
+its most important benefits from such a conviction that I perceived the
+necessity of becoming acquainted with more languages than that of my
+native country.  Now I am twenty-eight and am in reality more
+illiterate than many schoolboys of fifteen.  It is true that I have
+thought more and that my daydreams are more extended and magnificent,
+but they want (as the painters call it) KEEPING; and I greatly need a
+friend who would have sense enough not to despise me as romantic, and
+affection enough for me to endeavour to regulate my mind.  Well, these
+are useless complaints; I shall certainly find no friend on the wide
+ocean, nor even here in Archangel, among merchants and seamen.  Yet
+some feelings, unallied to the dross of human nature, beat even in
+these rugged bosoms.  My lieutenant, for instance, is a man of
+wonderful courage and enterprise; he is madly desirous of glory, or
+rather, to word my phrase more characteristically, of advancement in
+his profession.  He is an Englishman, and in the midst of national and
+professional prejudices, unsoftened by cultivation, retains some of the
+noblest endowments of humanity.  I first became acquainted with him on
+board a whale vessel; finding that he was unemployed in this city, I
+easily engaged him to assist in my enterprise.  The master is a person
+of an excellent disposition and is remarkable in the ship for his
+gentleness and the mildness of his discipline.  This circumstance,
+added to his well-known integrity and dauntless courage, made me very
+desirous to engage him.  A youth passed in solitude, my best years
+spent under your gentle and feminine fosterage, has so refined the
+groundwork of my character that I cannot overcome an intense distaste
+to the usual brutality exercised on board ship:  I have never believed
+it to be necessary, and when I heard of a mariner equally noted for his
+kindliness of heart and the respect and obedience paid to him by his
+crew, I felt myself peculiarly fortunate in being able to secure his
+services.  I heard of him first in rather a romantic manner, from a
+lady who owes to him the happiness of her life.  This, briefly, is his
+story.  Some years ago he loved a young Russian lady of moderate
+fortune, and having amassed a considerable sum in prize-money, the
+father of the girl consented to the match.  He saw his mistress once
+before the destined ceremony; but she was bathed in tears, and throwing
+herself at his feet, entreated him to spare her, confessing at the same
+time that she loved another, but that he was poor, and that her father
+would never consent to the union.  My generous friend reassured the
+suppliant, and on being informed of the name of her lover, instantly
+abandoned his pursuit.  He had already bought a farm with his money, on
+which he had designed to pass the remainder of his life; but he
+bestowed the whole on his rival, together with the remains of his
+prize-money to purchase stock, and then himself solicited the young
+woman's father to consent to her marriage with her lover.  But the old
+man decidedly refused, thinking himself bound in honour to my friend,
+who, when he found the father inexorable, quitted his country, nor
+returned until he heard that his former mistress was married according
+to her inclinations.  "What a noble fellow!" you will exclaim.  He is
+so; but then he is wholly uneducated:  he is as silent as a Turk, and a
+kind of ignorant carelessness attends him, which, while it renders his
+conduct the more astonishing, detracts from the interest and sympathy
+which otherwise he would command.
+
+Yet do not suppose, because I complain a little or because I can
+conceive a consolation for my toils which I may never know, that I am
+wavering in my resolutions.  Those are as fixed as fate, and my voyage
+is only now delayed until the weather shall permit my embarkation.  The
+winter has been dreadfully severe, but the spring promises well, and it
+is considered as a remarkably early season, so that perhaps I may sail
+sooner than I expected.  I shall do nothing rashly:  you know me
+sufficiently to confide in my prudence and considerateness whenever the
+safety of others is committed to my care.
+
+I cannot describe to you my sensations on the near prospect of my
+undertaking.  It is impossible to communicate to you a conception of
+the trembling sensation, half pleasurable and half fearful, with which
+I am preparing to depart.  I am going to unexplored regions, to "the
+land of mist and snow," but I shall kill no albatross; therefore do not
+be alarmed for my safety or if I should come back to you as worn and
+woeful as the "Ancient Mariner."  You will smile at my allusion, but I
+will disclose a secret.  I have often attributed my attachment to, my
+passionate enthusiasm for, the dangerous mysteries of ocean to that
+production of the most imaginative of modern poets.  There is something
+at work in my soul which I do not understand.  I am practically
+industrious--painstaking, a workman to execute with perseverance and
+labour--but besides this there is a love for the marvellous, a belief
+in the marvellous, intertwined in all my projects, which hurries me out
+of the common pathways of men, even to the wild sea and unvisited
+regions I am about to explore. But to return to dearer considerations.
+Shall I meet you again, after having traversed immense seas, and
+returned by the most southern cape of Africa or America?  I dare not
+expect such success, yet I cannot bear to look on the reverse of the
+picture.  Continue for the present to write to me by every opportunity:
+I may receive your letters on some occasions when I need them most to
+support my spirits.  I love you very tenderly.  Remember me with
+affection, should you never hear from me again.
+
+Your affectionate brother,
+  Robert Walton
+
+
+
+Letter 3
+
+
+
+July 7th, 17--
+
+To Mrs. Saville, England
+
+My dear Sister,
+
+I write a few lines in haste to say that I am safe--and well advanced
+on my voyage.  This letter will reach England by a merchantman now on
+its homeward voyage from Archangel; more fortunate than I, who may not
+see my native land, perhaps, for many years.  I am, however, in good
+spirits:  my men are bold and apparently firm of purpose, nor do the
+floating sheets of ice that continually pass us, indicating the dangers
+of the region towards which we are advancing, appear to dismay them. We
+have already reached a very high latitude; but it is the height of
+summer, and although not so warm as in England, the southern gales,
+which blow us speedily towards those shores which I so ardently desire
+to attain, breathe a degree of renovating warmth which I had not
+expected.
+
+No incidents have hitherto befallen us that would make a figure in a
+letter.  One or two stiff gales and the springing of a leak are
+accidents which experienced navigators scarcely remember to record, and
+I shall be well content if nothing worse happen to us during our voyage.
+
+Adieu, my dear Margaret.  Be assured that for my own sake, as well as
+yours, I will not rashly encounter danger.  I will be cool,
+persevering, and prudent.
+
+But success SHALL crown my endeavours.  Wherefore not?  Thus far I have
+gone, tracing a secure way over the pathless seas, the very stars
+themselves being witnesses and testimonies of my triumph.  Why not
+still proceed over the untamed yet obedient element?  What can stop the
+determined heart and resolved will of man?
+
+My swelling heart involuntarily pours itself out thus.  But I must
+finish.  Heaven bless my beloved sister!
+
+R.W.
+
+
+
+Letter 4
+
+
+
+August 5th, 17--
+
+To Mrs. Saville, England
+
+So strange an accident has happened to us that I cannot forbear
+recording it, although it is very probable that you will see me before
+these papers can come into your possession.
+
+Last Monday (July 31st) we were nearly surrounded by ice, which closed
+in the ship on all sides, scarcely leaving her the sea-room in which
+she floated.  Our situation was somewhat dangerous, especially as we
+were compassed round by a very thick fog.  We accordingly lay to,
+hoping that some change would take place in the atmosphere and weather.
+
+About two o'clock the mist cleared away, and we beheld, stretched out
+in every direction, vast and irregular plains of ice, which seemed to
+have no end.  Some of my comrades groaned, and my own mind began to
+grow watchful with anxious thoughts, when a strange sight suddenly
+attracted our attention and diverted our solicitude from our own
+situation.  We perceived a low carriage, fixed on a sledge and drawn by
+dogs, pass on towards the north, at the distance of half a mile; a
+being which had the shape of a man, but apparently of gigantic stature,
+sat in the sledge and guided the dogs.  We watched the rapid progress
+of the traveller with our telescopes until he was lost among the
+distant inequalities of the ice.  This appearance excited our
+unqualified wonder.  We were, as we believed, many hundred miles from
+any land; but this apparition seemed to denote that it was not, in
+reality, so distant as we had supposed.  Shut in, however, by ice, it
+was impossible to follow his track, which we had observed with the
+greatest attention.  About two hours after this occurrence we heard the
+ground sea, and before night the ice broke and freed our ship.  We,
+however, lay to until the morning, fearing to encounter in the dark
+those large loose masses which float about after the breaking up of the
+ice.  I profited of this time to rest for a few hours.
+
+In the morning, however, as soon as it was light, I went upon deck and
+found all the sailors busy on one side of the vessel, apparently
+talking to someone in the sea.  It was, in fact, a sledge, like that we
+had seen before, which had drifted towards us in the night on a large
+fragment of ice.  Only one dog remained alive; but there was a human
+being within it whom the sailors were persuading to enter the vessel.
+He was not, as the other traveller seemed to be, a savage inhabitant of
+some undiscovered island, but a European.  When I appeared on deck the
+master said, "Here is our captain, and he will not allow you to perish
+on the open sea."
+
+On perceiving me, the stranger addressed me in English, although with a
+foreign accent.  "Before I come on board your vessel," said he, "will
+you have the kindness to inform me whither you are bound?"
+
+You may conceive my astonishment on hearing such a question addressed
+to me from a man on the brink of destruction and to whom I should have
+supposed that my vessel would have been a resource which he would not
+have exchanged for the most precious wealth the earth can afford.  I
+replied, however, that we were on a voyage of discovery towards the
+northern pole.
+
+Upon hearing this he appeared satisfied and consented to come on board.
+Good God!  Margaret, if you had seen the man who thus capitulated for
+his safety, your surprise would have been boundless.  His limbs were
+nearly frozen, and his body dreadfully emaciated by fatigue and
+suffering.  I never saw a man in so wretched a condition.  We attempted
+to carry him into the cabin, but as soon as he had quitted the fresh
+air he fainted.  We accordingly brought him back to the deck and
+restored him to animation by rubbing him with brandy and forcing him to
+swallow a small quantity.  As soon as he showed signs of life we
+wrapped him up in blankets and placed him near the chimney of the
+kitchen stove.  By slow degrees he recovered and ate a little soup,
+which restored him wonderfully.
+
+Two days passed in this manner before he was able to speak, and I often
+feared that his sufferings had deprived him of understanding.  When he
+had in some measure recovered, I removed him to my own cabin and
+attended on him as much as my duty would permit.  I never saw a more
+interesting creature:  his eyes have generally an expression of
+wildness, and even madness, but there are moments when, if anyone
+performs an act of kindness towards him or does him any the most
+trifling service, his whole countenance is lighted up, as it were, with
+a beam of benevolence and sweetness that I never saw equalled.  But he
+is generally melancholy and despairing, and sometimes he gnashes his
+teeth, as if impatient of the weight of woes that oppresses him.
+
+When my guest was a little recovered I had great trouble to keep off
+the men, who wished to ask him a thousand questions; but I would not
+allow him to be tormented by their idle curiosity, in a state of body
+and mind whose restoration evidently depended upon entire repose.
+Once, however, the lieutenant asked why he had come so far upon the ice
+in so strange a vehicle.
+
+His countenance instantly assumed an aspect of the deepest gloom, and
+he replied, "To seek one who fled from me."
+
+"And did the man whom you pursued travel in the same fashion?"
+
+"Yes."
+
+"Then I fancy we have seen him, for the day before we picked you up we
+saw some dogs drawing a sledge, with a man in it, across the ice."
+
+This aroused the stranger's attention, and he asked a multitude of
+questions concerning the route which the demon, as he called him, had
+pursued.  Soon after, when he was alone with me, he said, "I have,
+doubtless, excited your curiosity, as well as that of these good
+people; but you are too considerate to make inquiries."
+
+"Certainly; it would indeed be very impertinent and inhuman in me to
+trouble you with any inquisitiveness of mine."
+
+"And yet you rescued me from a strange and perilous situation; you have
+benevolently restored me to life."
+
+Soon after this he inquired if I thought that the breaking up of the
+ice had destroyed the other sledge.  I replied that I could not answer
+with any degree of certainty, for the ice had not broken until near
+midnight, and the traveller might have arrived at a place of safety
+before that time; but of this I could not judge.  From this time a new
+spirit of life animated the decaying frame of the stranger.  He
+manifested the greatest eagerness to be upon deck to watch for the
+sledge which had before appeared; but I have persuaded him to remain in
+the cabin, for he is far too weak to sustain the rawness of the
+atmosphere.  I have promised that someone should watch for him and give
+him instant notice if any new object should appear in sight.
+
+Such is my journal of what relates to this strange occurrence up to the
+present day.  The stranger has gradually improved in health but is very
+silent and appears uneasy when anyone except myself enters his cabin.
+Yet his manners are so conciliating and gentle that the sailors are all
+interested in him, although they have had very little communication
+with him.  For my own part, I begin to love him as a brother, and his
+constant and deep grief fills me with sympathy and compassion.  He must
+have been a noble creature in his better days, being even now in wreck
+so attractive and amiable.  I said in one of my letters, my dear
+Margaret, that I should find no friend on the wide ocean; yet I have
+found a man who, before his spirit had been broken by misery, I should
+have been happy to have possessed as the brother of my heart.
+
+I shall continue my journal concerning the stranger at intervals,
+should I have any fresh incidents to record.
+
+
+August 13th, 17--
+
+My affection for my guest increases every day.  He excites at once my
+admiration and my pity to an astonishing degree.  How can I see so
+noble a creature destroyed by misery without feeling the most poignant
+grief?  He is so gentle, yet so wise; his mind is so cultivated, and
+when he speaks, although his words are culled with the choicest art,
+yet they flow with rapidity and unparalleled eloquence.  He is now much
+recovered from his illness and is continually on the deck, apparently
+watching for the sledge that preceded his own.  Yet, although unhappy,
+he is not so utterly occupied by his own misery but that he interests
+himself deeply in the projects of others.  He has frequently conversed
+with me on mine, which I have communicated to him without disguise.  He
+entered attentively into all my arguments in favour of my eventual
+success and into every minute detail of the measures I had taken to
+secure it.  I was easily led by the sympathy which he evinced to use
+the language of my heart, to give utterance to the burning ardour of my
+soul and to say, with all the fervour that warmed me, how gladly I
+would sacrifice my fortune, my existence, my every hope, to the
+furtherance of my enterprise.  One man's life or death were but a small
+price to pay for the acquirement of the knowledge which I sought, for
+the dominion I should acquire and transmit over the elemental foes of
+our race.  As I spoke, a dark gloom spread over my listener's
+countenance.  At first I perceived that he tried to suppress his
+emotion; he placed his hands before his eyes, and my voice quivered and
+failed me as I beheld tears trickle fast from between his fingers; a
+groan burst from his heaving breast.  I paused; at length he spoke, in
+broken accents:  "Unhappy man!  Do you share my madness?  Have you
+drunk also of the intoxicating draught?  Hear me; let me reveal my
+tale, and you will dash the cup from your lips!"
+
+Such words, you may imagine, strongly excited my curiosity; but the
+paroxysm of grief that had seized the stranger overcame his weakened
+powers, and many hours of repose and tranquil conversation were
+necessary to restore his composure.  Having conquered the violence of
+his feelings, he appeared to despise himself for being the slave of
+passion; and quelling the dark tyranny of despair, he led me again to
+converse concerning myself personally.  He asked me the history of my
+earlier years.  The tale was quickly told, but it awakened various
+trains of reflection.  I spoke of my desire of finding a friend, of my
+thirst for a more intimate sympathy with a fellow mind than had ever
+fallen to my lot, and expressed my conviction that a man could boast of
+little happiness who did not enjoy this blessing.  "I agree with you,"
+replied the stranger; "we are unfashioned creatures, but half made up,
+if one wiser, better, dearer than ourselves--such a friend ought to
+be--do not lend his aid to perfectionate our weak and faulty natures. I
+once had a friend, the most noble of human creatures, and am entitled,
+therefore, to judge respecting friendship.  You have hope, and the
+world before you, and have no cause for despair.  But I--I have lost
+everything and cannot begin life anew."
+
+As he said this his countenance became expressive of a calm, settled
+grief that touched me to the heart.  But he was silent and presently
+retired to his cabin.
+
+Even broken in spirit as he is, no one can feel more deeply than he
+does the beauties of nature.  The starry sky, the sea, and every sight
+afforded by these wonderful regions seem still to have the power of
+elevating his soul from earth.  Such a man has a double existence:  he
+may suffer misery and be overwhelmed by disappointments, yet when he
+has retired into himself, he will be like a celestial spirit that has a
+halo around him, within whose circle no grief or folly ventures.
+
+Will you smile at the enthusiasm I express concerning this divine
+wanderer?  You would not if you saw him.  You have been tutored and
+refined by books and retirement from the world, and you are therefore
+somewhat fastidious; but this only renders you the more fit to
+appreciate the extraordinary merits of this wonderful man.  Sometimes I
+have endeavoured to discover what quality it is which he possesses that
+elevates him so immeasurably above any other person I ever knew.  I
+believe it to be an intuitive discernment, a quick but never-failing
+power of judgment, a penetration into the causes of things, unequalled
+for clearness and precision; add to this a facility of expression and a
+voice whose varied intonations are soul-subduing music.
+
+
+August 19, 17--
+
+Yesterday the stranger said to me, "You may easily perceive, Captain
+Walton, that I have suffered great and unparalleled misfortunes.  I had
+determined at one time that the memory of these evils should die with
+me, but you have won me to alter my determination.  You seek for
+knowledge and wisdom, as I once did; and I ardently hope that the
+gratification of your wishes may not be a serpent to sting you, as mine
+has been.  I do not know that the relation of my disasters will be
+useful to you; yet, when I reflect that you are pursuing the same
+course, exposing yourself to the same dangers which have rendered me
+what I am, I imagine that you may deduce an apt moral from my tale, one
+that may direct you if you succeed in your undertaking and console you
+in case of failure.  Prepare to hear of occurrences which are usually
+deemed marvellous.  Were we among the tamer scenes of nature I might
+fear to encounter your unbelief, perhaps your ridicule; but many things
+will appear possible in these wild and mysterious regions which would
+provoke the laughter of those unacquainted with the ever-varied powers
+of nature; nor can I doubt but that my tale conveys in its series
+internal evidence of the truth of the events of which it is composed."
+
+You may easily imagine that I was much gratified by the offered
+communication, yet I could not endure that he should renew his grief by
+a recital of his misfortunes.  I felt the greatest eagerness to hear
+the promised narrative, partly from curiosity and partly from a strong
+desire to ameliorate his fate if it were in my power.  I expressed
+these feelings in my answer.
+
+"I thank you," he replied, "for your sympathy, but it is useless; my
+fate is nearly fulfilled.  I wait but for one event, and then I shall
+repose in peace.  I understand your feeling," continued he, perceiving
+that I wished to interrupt him; "but you are mistaken, my friend, if
+thus you will allow me to name you; nothing can alter my destiny;
+listen to my history, and you will perceive how irrevocably it is
+determined."
+
+He then told me that he would commence his narrative the next day when
+I should be at leisure.  This promise drew from me the warmest thanks.
+I have resolved every night, when I am not imperatively occupied by my
+duties, to record, as nearly as possible in his own words, what he has
+related during the day.  If I should be engaged, I will at least make
+notes.  This manuscript will doubtless afford you the greatest
+pleasure; but to me, who know him, and who hear it from his own
+lips--with what interest and sympathy shall I read it in some future
+day!  Even now, as I commence my task, his full-toned voice swells in
+my ears; his lustrous eyes dwell on me with all their melancholy
+sweetness; I see his thin hand raised in animation, while the
+lineaments of his face are irradiated by the soul within.
+
+Strange and harrowing must be his story, frightful the storm which
+embraced the gallant vessel on its course and wrecked it--thus!
+
+
+
+Chapter 1
+
+I am by birth a Genevese, and my family is one of the most
+distinguished of that republic.  My ancestors had been for many years
+counsellors and syndics, and my father had filled several public
+situations with honour and reputation.  He was respected by all who
+knew him for his integrity and indefatigable attention to public
+business.  He passed his younger days perpetually occupied by the
+affairs of his country; a variety of circumstances had prevented his
+marrying early, nor was it until the decline of life that he became a
+husband and the father of a family.
+
+As the circumstances of his marriage illustrate his character, I cannot
+refrain from relating them.  One of his most intimate friends was a
+merchant who, from a flourishing state, fell, through numerous
+mischances, into poverty.  This man, whose name was Beaufort, was of a
+proud and unbending disposition and could not bear to live in poverty
+and oblivion in the same country where he had formerly been
+distinguished for his rank and magnificence.  Having paid his debts,
+therefore, in the most honourable manner, he retreated with his
+daughter to the town of Lucerne, where he lived unknown and in
+wretchedness.  My father loved Beaufort with the truest friendship and
+was deeply grieved by his retreat in these unfortunate circumstances.
+He bitterly deplored the false pride which led his friend to a conduct
+so little worthy of the affection that united them.  He lost no time in
+endeavouring to seek him out, with the hope of persuading him to begin
+the world again through his credit and assistance.
+
+Beaufort had taken effectual measures to conceal himself, and it was ten
+months before my father discovered his abode.  Overjoyed at this
+discovery, he hastened to the house, which was situated in a mean street
+near the Reuss.  But when he entered, misery and despair alone welcomed
+him.  Beaufort had saved but a very small sum of money from the wreck of
+his fortunes, but it was sufficient to provide him with sustenance for
+some months, and in the meantime he hoped to procure some respectable
+employment in a merchant's house.  The interval was, consequently, spent
+in inaction; his grief only became more deep and rankling when he had
+leisure for reflection, and at length it took so fast hold of his mind
+that at the end of three months he lay on a bed of sickness, incapable
+of any exertion.
+
+His daughter attended him with the greatest tenderness, but she saw
+with despair that their little fund was rapidly decreasing and that
+there was no other prospect of support.  But Caroline Beaufort
+possessed a mind of an uncommon mould, and her courage rose to support
+her in her adversity.  She procured plain work; she plaited straw and
+by various means contrived to earn a pittance scarcely sufficient to
+support life.
+
+Several months passed in this manner.  Her father grew worse; her time
+was more entirely occupied in attending him; her means of subsistence
+decreased; and in the tenth month her father died in her arms, leaving
+her an orphan and a beggar.  This last blow overcame her, and she knelt
+by Beaufort's coffin weeping bitterly, when my father entered the
+chamber.  He came like a protecting spirit to the poor girl, who
+committed herself to his care; and after the interment of his friend he
+conducted her to Geneva and placed her under the protection of a
+relation.  Two years after this event Caroline became his wife.
+
+There was a considerable difference between the ages of my parents, but
+this circumstance seemed to unite them only closer in bonds of devoted
+affection.  There was a sense of justice in my father's upright mind
+which rendered it necessary that he should approve highly to love
+strongly.  Perhaps during former years he had suffered from the
+late-discovered unworthiness of one beloved and so was disposed to set
+a greater value on tried worth.  There was a show of gratitude and
+worship in his attachment to my mother, differing wholly from the
+doting fondness of age, for it was inspired by reverence for her
+virtues and a desire to be the means of, in some degree, recompensing
+her for the sorrows she had endured, but which gave inexpressible grace
+to his behaviour to her.  Everything was made to yield to her wishes
+and her convenience.  He strove to shelter her, as a fair exotic is
+sheltered by the gardener, from every rougher wind and to surround her
+with all that could tend to excite pleasurable emotion in her soft and
+benevolent mind.  Her health, and even the tranquillity of her hitherto
+constant spirit, had been shaken by what she had gone through.  During
+the two years that had elapsed previous to their marriage my father had
+gradually relinquished all his public functions; and immediately after
+their union they sought the pleasant climate of Italy, and the change
+of scene and interest attendant on a tour through that land of wonders,
+as a restorative for her weakened frame.
+
+From Italy they visited Germany and France.  I, their eldest child, was
+born at Naples, and as an infant accompanied them in their rambles.  I
+remained for several years their only child.  Much as they were
+attached to each other, they seemed to draw inexhaustible stores of
+affection from a very mine of love to bestow them upon me.  My mother's
+tender caresses and my father's smile of benevolent pleasure while
+regarding me are my first recollections.  I was their plaything and
+their idol, and something better--their child, the innocent and
+helpless creature bestowed on them by heaven, whom to bring up to good,
+and whose future lot it was in their hands to direct to happiness or
+misery, according as they fulfilled their duties towards me.  With this
+deep consciousness of what they owed towards the being to which they
+had given life, added to the active spirit of tenderness that animated
+both, it may be imagined that while during every hour of my infant life
+I received a lesson of patience, of charity, and of self-control, I was
+so guided by a silken cord that all seemed but one train of enjoyment
+to me. For a long time I was their only care.  My mother had much
+desired to have a daughter, but I continued their single offspring.
+When I was about five years old, while making an excursion beyond the
+frontiers of Italy, they passed a week on the shores of the Lake of
+Como.  Their benevolent disposition often made them enter the cottages
+of the poor.  This, to my mother, was more than a duty; it was a
+necessity, a passion--remembering what she had suffered, and how she
+had been relieved--for her to act in her turn the guardian angel to the
+afflicted.  During one of their walks a poor cot in the foldings of a
+vale attracted their notice as being singularly disconsolate, while the
+number of half-clothed children gathered about it spoke of penury in
+its worst shape.  One day, when my father had gone by himself to Milan,
+my mother, accompanied by me, visited this abode.  She found a peasant
+and his wife, hard working, bent down by care and labour, distributing
+a scanty meal to five hungry babes.  Among these there was one which
+attracted my mother far above all the rest.  She appeared of a
+different stock.  The four others were dark-eyed, hardy little
+vagrants; this child was thin and very fair.  Her hair was the
+brightest living gold, and despite the poverty of her clothing, seemed
+to set a crown of distinction on her head.  Her brow was clear and
+ample, her blue eyes cloudless, and her lips and the moulding of her
+face so expressive of sensibility and sweetness that none could behold
+her without looking on her as of a distinct species, a being
+heaven-sent, and bearing a celestial stamp in all her features. The
+peasant woman, perceiving that my mother fixed eyes of wonder and
+admiration on this lovely girl, eagerly communicated her history.  She
+was not her child, but the daughter of a Milanese nobleman.  Her mother
+was a German and had died on giving her birth.  The infant had been
+placed with these good people to nurse:  they were better off then.
+They had not been long married, and their eldest child was but just
+born.  The father of their charge was one of those Italians nursed in
+the memory of the antique glory of Italy--one among the schiavi ognor
+frementi, who exerted himself to obtain the liberty of his country.  He
+became the victim of its weakness.  Whether he had died or still
+lingered in the dungeons of Austria was not known.  His property was
+confiscated; his child became an orphan and a beggar.  She continued
+with her foster parents and bloomed in their rude abode, fairer than a
+garden rose among dark-leaved brambles.  When my father returned from
+Milan, he found playing with me in the hall of our villa a child fairer
+than pictured cherub--a creature who seemed to shed radiance from her
+looks and whose form and motions were lighter than the chamois of the
+hills.  The apparition was soon explained.  With his permission my
+mother prevailed on her rustic guardians to yield their charge to her.
+They were fond of the sweet orphan.  Her presence had seemed a blessing
+to them, but it would be unfair to her to keep her in poverty and want
+when Providence afforded her such powerful protection.  They consulted
+their village priest, and the result was that Elizabeth Lavenza became
+the inmate of my parents' house--my more than sister--the beautiful and
+adored companion of all my occupations and my pleasures.
+
+Everyone loved Elizabeth.  The passionate and almost reverential
+attachment with which all regarded her became, while I shared it, my
+pride and my delight.  On the evening previous to her being brought to
+my home, my mother had said playfully, "I have a pretty present for my
+Victor--tomorrow he shall have it."  And when, on the morrow, she
+presented Elizabeth to me as her promised gift, I, with childish
+seriousness, interpreted her words literally and looked upon Elizabeth
+as mine--mine to protect, love, and cherish.  All praises bestowed on
+her I received as made to a possession of my own.  We called each other
+familiarly by the name of cousin.  No word, no expression could body
+forth the kind of relation in which she stood to me--my more than
+sister, since till death she was to be mine only.
+
+
+
+Chapter 2
+
+We were brought up together; there was not quite a year difference in
+our ages.  I need not say that we were strangers to any species of
+disunion or dispute.  Harmony was the soul of our companionship, and
+the diversity and contrast that subsisted in our characters drew us
+nearer together.  Elizabeth was of a calmer and more concentrated
+disposition; but, with all my ardour, I was capable of a more intense
+application and was more deeply smitten with the thirst for knowledge.
+She busied herself with following the aerial creations of the poets;
+and in the majestic and wondrous scenes which surrounded our Swiss home
+--the sublime shapes of the mountains, the changes of the seasons,
+tempest and calm, the silence of winter, and the life and turbulence of
+our Alpine summers--she found ample scope for admiration and delight.
+While my companion contemplated with a serious and satisfied spirit the
+magnificent appearances of things, I delighted in investigating their
+causes.  The world was to me a secret which I desired to divine.
+Curiosity, earnest research to learn the hidden laws of nature,
+gladness akin to rapture, as they were unfolded to me, are among the
+earliest sensations I can remember.
+
+On the birth of a second son, my junior by seven years, my parents gave
+up entirely their wandering life and fixed themselves in their native
+country.  We possessed a house in Geneva, and a campagne on Belrive,
+the eastern shore of the lake, at the distance of rather more than a
+league from the city.  We resided principally in the latter, and the
+lives of my parents were passed in considerable seclusion.  It was my
+temper to avoid a crowd and to attach myself fervently to a few.  I was
+indifferent, therefore, to my school-fellows in general; but I united
+myself in the bonds of the closest friendship to one among them.  Henry
+Clerval was the son of a merchant of Geneva.  He was a boy of singular
+talent and fancy.  He loved enterprise, hardship, and even danger for
+its own sake.  He was deeply read in books of chivalry and romance.  He
+composed heroic songs and began to write many a tale of enchantment and
+knightly adventure.  He tried to make us act plays and to enter into
+masquerades, in which the characters were drawn from the heroes of
+Roncesvalles, of the Round Table of King Arthur, and the chivalrous
+train who shed their blood to redeem the holy sepulchre from the hands
+of the infidels.
+
+No human being could have passed a happier childhood than myself.  My
+parents were possessed by the very spirit of kindness and indulgence.
+We felt that they were not the tyrants to rule our lot according to
+their caprice, but the agents and creators of all the many delights
+which we enjoyed.  When I mingled with other families I distinctly
+discerned how peculiarly fortunate my lot was, and gratitude assisted
+the development of filial love.
+
+My temper was sometimes violent, and my passions vehement; but by some
+law in my temperature they were turned not towards childish pursuits
+but to an eager desire to learn, and not to learn all things
+indiscriminately.  I confess that neither the structure of languages,
+nor the code of governments, nor the politics of various states
+possessed attractions for me.  It was the secrets of heaven and earth
+that I desired to learn; and whether it was the outward substance of
+things or the inner spirit of nature and the mysterious soul of man
+that occupied me, still my inquiries were directed to the metaphysical,
+or in its highest sense, the physical secrets of the world.
+
+Meanwhile Clerval occupied himself, so to speak, with the moral
+relations of things.  The busy stage of life, the virtues of heroes,
+and the actions of men were his theme; and his hope and his dream was
+to become one among those whose names are recorded in story as the
+gallant and adventurous benefactors of our species.  The saintly soul
+of Elizabeth shone like a shrine-dedicated lamp in our peaceful home.
+Her sympathy was ours; her smile, her soft voice, the sweet glance of
+her celestial eyes, were ever there to bless and animate us.  She was
+the living spirit of love to soften and attract; I might have become
+sullen in my study, rough through the ardour of my nature, but that
+she was there to subdue me to a semblance of her own gentleness.  And
+Clerval--could aught ill entrench on the noble spirit of Clerval?  Yet
+he might not have been so perfectly humane, so thoughtful in his
+generosity, so full of kindness and tenderness amidst his passion for
+adventurous exploit, had she not unfolded to him the real loveliness of
+beneficence and made the doing good the end and aim of his soaring
+ambition.
+
+I feel exquisite pleasure in dwelling on the recollections of
+childhood, before misfortune had tainted my mind and changed its bright
+visions of extensive usefulness into gloomy and narrow reflections upon
+self.  Besides, in drawing the picture of my early days, I also record
+those events which led, by insensible steps, to my after tale of
+misery, for when I would account to myself for the birth of that
+passion which afterwards ruled my destiny I find it arise, like a
+mountain river, from ignoble and almost forgotten sources; but,
+swelling as it proceeded, it became the torrent which, in its course,
+has swept away all my hopes and joys.  Natural philosophy is the genius
+that has regulated my fate; I desire, therefore, in this narration, to
+state those facts which led to my predilection for that science.  When
+I was thirteen years of age we all went on a party of pleasure to the
+baths near Thonon; the inclemency of the weather obliged us to remain a
+day confined to the inn.  In this house I chanced to find a volume of
+the works of Cornelius Agrippa.  I opened it with apathy; the theory
+which he attempts to demonstrate and the wonderful facts which he
+relates soon changed this feeling into enthusiasm.  A new light seemed
+to dawn upon my mind, and bounding with joy, I communicated my
+discovery to my father.  My father looked carelessly at the title page
+of my book and said, "Ah!  Cornelius Agrippa!  My dear Victor, do not
+waste your time upon this; it is sad trash."
+
+If, instead of this remark, my father had taken the pains to explain to
+me that the principles of Agrippa had been entirely exploded and that a
+modern system of science had been introduced which possessed much
+greater powers than the ancient, because the powers of the latter were
+chimerical, while those of the former were real and practical, under
+such circumstances I should certainly have thrown Agrippa aside and
+have contented my imagination, warmed as it was, by returning with
+greater ardour to my former studies.  It is even possible that the
+train of my ideas would never have received the fatal impulse that led
+to my ruin.  But the cursory glance my father had taken of my volume by
+no means assured me that he was acquainted with its contents, and I
+continued to read with the greatest avidity.  When I returned home my
+first care was to procure the whole works of this author, and
+afterwards of Paracelsus and Albertus Magnus.  I read and studied the
+wild fancies of these writers with delight; they appeared to me
+treasures known to few besides myself.  I have described myself as
+always having been imbued with a fervent longing to penetrate the
+secrets of nature.  In spite of the intense labour and wonderful
+discoveries of modern philosophers, I always came from my studies
+discontented and unsatisfied.  Sir Isaac Newton is said to have avowed
+that he felt like a child picking up shells beside the great and
+unexplored ocean of truth.  Those of his successors in each branch of
+natural philosophy with whom I was acquainted appeared even to my boy's
+apprehensions as tyros engaged in the same pursuit.
+
+The untaught peasant beheld the elements around him and was acquainted
+with their practical uses.  The most learned philosopher knew little
+more.  He had partially unveiled the face of Nature, but her immortal
+lineaments were still a wonder and a mystery.  He might dissect,
+anatomize, and give names; but, not to speak of a final cause, causes
+in their secondary and tertiary grades were utterly unknown to him.  I
+had gazed upon the fortifications and impediments that seemed to keep
+human beings from entering the citadel of nature, and rashly and
+ignorantly I had repined.
+
+But here were books, and here were men who had penetrated deeper and
+knew more.  I took their word for all that they averred, and I became
+their disciple.  It may appear strange that such should arise in the
+eighteenth century; but while I followed the routine of education in
+the schools of Geneva, I was, to a great degree, self-taught with
+regard to my favourite studies.  My father was not scientific, and I
+was left to struggle with a child's blindness, added to a student's
+thirst for knowledge.  Under the guidance of my new preceptors I
+entered with the greatest diligence into the search of the
+philosopher's stone and the elixir of life; but the latter soon
+obtained my undivided attention.  Wealth was an inferior object, but
+what glory would attend the discovery if I could banish disease from
+the human frame and render man invulnerable to any but a violent death!
+Nor were these my only visions.  The raising of ghosts or devils was a
+promise liberally accorded by my favourite authors, the fulfilment of
+which I most eagerly sought; and if my incantations were always
+unsuccessful, I attributed the failure rather to my own inexperience
+and mistake than to a want of skill or fidelity in my instructors.  And
+thus for a time I was occupied by exploded systems, mingling, like an
+unadept, a thousand contradictory theories and floundering desperately
+in a very slough of multifarious knowledge, guided by an ardent
+imagination and childish reasoning, till an accident again changed the
+current of my ideas.  When I was about fifteen years old we had retired
+to our house near Belrive, when we witnessed a most violent and
+terrible thunderstorm.  It advanced from behind the mountains of Jura,
+and the thunder burst at once with frightful loudness from various
+quarters of the heavens.  I remained, while the storm lasted, watching
+its progress with curiosity and delight.  As I stood at the door, on a
+sudden I beheld a stream of fire issue from an old and beautiful oak
+which stood about twenty yards from our house; and so soon as the
+dazzling light vanished, the oak had disappeared, and nothing remained
+but a blasted stump.  When we visited it the next morning, we found the
+tree shattered in a singular manner.  It was not splintered by the
+shock, but entirely reduced to thin ribbons of wood.  I never beheld
+anything so utterly destroyed.
+
+Before this I was not unacquainted with the more obvious laws of
+electricity.  On this occasion a man of great research in natural
+philosophy was with us, and excited by this catastrophe, he entered on
+the explanation of a theory which he had formed on the subject of
+electricity and galvanism, which was at once new and astonishing to me.
+All that he said threw greatly into the shade Cornelius Agrippa,
+Albertus Magnus, and Paracelsus, the lords of my imagination; but by
+some fatality the overthrow of these men disinclined me to pursue my
+accustomed studies.  It seemed to me as if nothing would or could ever
+be known.  All that had so long engaged my attention suddenly grew
+despicable.  By one of those caprices of the mind which we are perhaps
+most subject to in early youth, I at once gave up my former
+occupations, set down natural history and all its progeny as a deformed
+and abortive creation, and entertained the greatest disdain for a
+would-be science which could never even step within the threshold of
+real knowledge.  In this mood of mind I betook myself to the
+mathematics and the branches of study appertaining to that science as
+being built upon secure foundations, and so worthy of my consideration.
+
+Thus strangely are our souls constructed, and by such slight ligaments
+are we bound to prosperity or ruin.  When I look back, it seems to me
+as if this almost miraculous change of inclination and will was the
+immediate suggestion of the guardian angel of my life--the last effort
+made by the spirit of preservation to avert the storm that was even
+then hanging in the stars and ready to envelop me.  Her victory was
+announced by an unusual tranquillity and gladness of soul which
+followed the relinquishing of my ancient and latterly tormenting
+studies.  It was thus that I was to be taught to associate evil with
+their prosecution, happiness with their disregard.
+
+It was a strong effort of the spirit of good, but it was ineffectual.
+Destiny was too potent, and her immutable laws had decreed my utter and
+terrible destruction.
+
+
+
+Chapter 3
+
+When I had attained the age of seventeen my parents resolved that I
+should become a student at the university of Ingolstadt.  I had
+hitherto attended the schools of Geneva, but my father thought it
+necessary for the completion of my education that I should be made
+acquainted with other customs than those of my native country.  My
+departure was therefore fixed at an early date, but before the day
+resolved upon could arrive, the first misfortune of my life
+occurred--an omen, as it were, of my future misery.  Elizabeth had
+caught the scarlet fever; her illness was severe, and she was in the
+greatest danger.  During her illness many arguments had been urged to
+persuade my mother to refrain from attending upon her.  She had at
+first yielded to our entreaties, but when she heard that the life of
+her favourite was menaced, she could no longer control her anxiety. She
+attended her sickbed; her watchful attentions triumphed over the
+malignity of the distemper--Elizabeth was saved, but the consequences
+of this imprudence were fatal to her preserver.  On the third day my
+mother sickened; her fever was accompanied by the most alarming
+symptoms, and the looks of her medical attendants prognosticated the
+worst event.  On her deathbed the fortitude and benignity of this best
+of women did not desert her.  She joined the hands of Elizabeth and
+myself.  "My children," she said, "my firmest hopes of future happiness
+were placed on the prospect of your union.  This expectation will now
+be the consolation of your father.  Elizabeth, my love, you must supply
+my place to my younger children.  Alas!  I regret that I am taken from
+you; and, happy and beloved as I have been, is it not hard to quit you
+all?  But these are not thoughts befitting me; I will endeavour to
+resign myself cheerfully to death and will indulge a hope of meeting
+you in another world."
+
+She died calmly, and her countenance expressed affection even in death.
+I need not describe the feelings of those whose dearest ties are rent
+by that most irreparable evil, the void that presents itself to the
+soul, and the despair that is exhibited on the countenance.  It is so
+long before the mind can persuade itself that she whom we saw every day
+and whose very existence appeared a part of our own can have departed
+forever--that the brightness of a beloved eye can have been
+extinguished and the sound of a voice so familiar and dear to the ear
+can be hushed, never more to be heard.  These are the reflections of
+the first days; but when the lapse of time proves the reality of the
+evil, then the actual bitterness of grief commences.  Yet from whom has
+not that rude hand rent away some dear connection?  And why should I
+describe a sorrow which all have felt, and must feel?  The time at
+length arrives when grief is rather an indulgence than a necessity; and
+the smile that plays upon the lips, although it may be deemed a
+sacrilege, is not banished.  My mother was dead, but we had still
+duties which we ought to perform; we must continue our course with the
+rest and learn to think ourselves fortunate whilst one remains whom the
+spoiler has not seized.
+
+My departure for Ingolstadt, which had been deferred by these events,
+was now again determined upon.  I obtained from my father a respite of
+some weeks.  It appeared to me sacrilege so soon to leave the repose,
+akin to death, of the house of mourning and to rush into the thick of
+life.  I was new to sorrow, but it did not the less alarm me.  I was
+unwilling to quit the sight of those that remained to me, and above
+all, I desired to see my sweet Elizabeth in some degree consoled.
+
+She indeed veiled her grief and strove to act the comforter to us all.
+She looked steadily on life and assumed its duties with courage and
+zeal.  She devoted herself to those whom she had been taught to call
+her uncle and cousins.  Never was she so enchanting as at this time,
+when she recalled the sunshine of her smiles and spent them upon us.
+She forgot even her own regret in her endeavours to make us forget.
+
+The day of my departure at length arrived.  Clerval spent the last
+evening with us.  He had endeavoured to persuade his father to permit
+him to accompany me and to become my fellow student, but in vain.  His
+father was a narrow-minded trader and saw idleness and ruin in the
+aspirations and ambition of his son.  Henry deeply felt the misfortune
+of being debarred from a liberal education.  He said little, but when
+he spoke I read in his kindling eye and in his animated glance a
+restrained but firm resolve not to be chained to the miserable details
+of commerce.
+
+We sat late.  We could not tear ourselves away from each other nor
+persuade ourselves to say the word "Farewell!"  It was said, and we
+retired under the pretence of seeking repose, each fancying that the
+other was deceived; but when at morning's dawn I descended to the
+carriage which was to convey me away, they were all there--my father
+again to bless me, Clerval to press my hand once more, my Elizabeth to
+renew her entreaties that I would write often and to bestow the last
+feminine attentions on her playmate and friend.
+
+I threw myself into the chaise that was to convey me away and indulged
+in the most melancholy reflections.  I, who had ever been surrounded by
+amiable companions, continually engaged in endeavouring to bestow
+mutual pleasure--I was now alone.  In the university whither I was
+going I must form my own friends and be my own protector.  My life had
+hitherto been remarkably secluded and domestic, and this had given me
+invincible repugnance to new countenances.  I loved my brothers,
+Elizabeth, and Clerval; these were "old familiar faces," but I believed
+myself totally unfitted for the company of strangers.  Such were my
+reflections as I commenced my journey; but as I proceeded, my spirits
+and hopes rose.  I ardently desired the acquisition of knowledge.  I
+had often, when at home, thought it hard to remain during my youth
+cooped up in one place and had longed to enter the world and take my
+station among other human beings.  Now my desires were complied with,
+and it would, indeed, have been folly to repent.
+
+I had sufficient leisure for these and many other reflections during my
+journey to Ingolstadt, which was long and fatiguing.  At length the
+high white steeple of the town met my eyes.  I alighted and was
+conducted to my solitary apartment to spend the evening as I pleased.
+
+The next morning I delivered my letters of introduction and paid a
+visit to some of the principal professors.  Chance--or rather the evil
+influence, the Angel of Destruction, which asserted omnipotent sway
+over me from the moment I turned my reluctant steps from my father's
+door--led me first to M. Krempe, professor of natural philosophy.  He
+was an uncouth man, but deeply imbued in the secrets of his science. He
+asked me several questions concerning my progress in the different
+branches of science appertaining to natural philosophy.  I replied
+carelessly, and partly in contempt, mentioned the names of my
+alchemists as the principal authors I had studied.  The professor
+stared.  "Have you," he said, "really spent your time in studying such
+nonsense?"
+
+I replied in the affirmative.  "Every minute," continued M. Krempe with
+warmth, "every instant that you have wasted on those books is utterly
+and entirely lost.  You have burdened your memory with exploded systems
+and useless names.  Good God!  In what desert land have you lived,
+where no one was kind enough to inform you that these fancies which you
+have so greedily imbibed are a thousand years old and as musty as they
+are ancient?  I little expected, in this enlightened and scientific
+age, to find a disciple of Albertus Magnus and Paracelsus.  My dear
+sir, you must begin your studies entirely anew."
+
+So saying, he stepped aside and wrote down a list of several books
+treating of natural philosophy which he desired me to procure, and
+dismissed me after mentioning that in the beginning of the following
+week he intended to commence a course of lectures upon natural
+philosophy in its general relations, and that M. Waldman, a fellow
+professor, would lecture upon chemistry the alternate days that he
+omitted.
+
+I returned home not disappointed, for I have said that I had long
+considered those authors useless whom the professor reprobated; but I
+returned not at all the more inclined to recur to these studies in any
+shape.  M. Krempe was a little squat man with a gruff voice and a
+repulsive countenance; the teacher, therefore, did not prepossess me in
+favour of his pursuits.  In rather a too philosophical and connected a
+strain, perhaps, I have given an account of the conclusions I had come
+to concerning them in my early years.  As a child I had not been
+content with the results promised by the modern professors of natural
+science.  With a confusion of ideas only to be accounted for by my
+extreme youth and my want of a guide on such matters, I had retrod the
+steps of knowledge along the paths of time and exchanged the
+discoveries of recent inquirers for the dreams of forgotten alchemists.
+Besides, I had a contempt for the uses of modern natural philosophy.
+It was very different when the masters of the science sought
+immortality and power; such views, although futile, were grand; but now
+the scene was changed.  The ambition of the inquirer seemed to limit
+itself to the annihilation of those visions on which my interest in
+science was chiefly founded.  I was required to exchange chimeras of
+boundless grandeur for realities of little worth.
+
+Such were my reflections during the first two or three days of my
+residence at Ingolstadt, which were chiefly spent in becoming
+acquainted with the localities and the principal residents in my new
+abode.  But as the ensuing week commenced, I thought of the information
+which M. Krempe had given me concerning the lectures.  And although I
+could not consent to go and hear that little conceited fellow deliver
+sentences out of a pulpit, I recollected what he had said of M.
+Waldman, whom I had never seen, as he had hitherto been out of town.
+
+Partly from curiosity and partly from idleness, I went into the
+lecturing room, which M. Waldman entered shortly after.  This professor
+was very unlike his colleague.  He appeared about fifty years of age,
+but with an aspect expressive of the greatest benevolence; a few grey
+hairs covered his temples, but those at the back of his head were
+nearly black.  His person was short but remarkably erect and his voice
+the sweetest I had ever heard.  He began his lecture by a
+recapitulation of the history of chemistry and the various improvements
+made by different men of learning, pronouncing with fervour the names
+of the most distinguished discoverers.  He then took a cursory view of
+the present state of the science and explained many of its elementary
+terms.  After having made a few preparatory experiments, he concluded
+with a panegyric upon modern chemistry, the terms of which I shall
+never forget:  "The ancient teachers of this science," said he,
+"promised impossibilities and performed nothing.  The modern masters
+promise very little; they know that metals cannot be transmuted and
+that the elixir of life is a chimera but these philosophers, whose
+hands seem only made to dabble in dirt, and their eyes to pore over the
+microscope or crucible, have indeed performed miracles.  They penetrate
+into the recesses of nature and show how she works in her
+hiding-places.  They ascend into the heavens; they have discovered how
+the blood circulates, and the nature of the air we breathe.  They have
+acquired new and almost unlimited powers; they can command the thunders
+of heaven, mimic the earthquake, and even mock the invisible world with
+its own shadows."
+
+Such were the professor's words--rather let me say such the words of
+the fate--enounced to destroy me.  As he went on I felt as if my soul
+were grappling with a palpable enemy; one by one the various keys were
+touched which formed the mechanism of my being; chord after chord was
+sounded, and soon my mind was filled with one thought, one conception,
+one purpose.  So much has been done, exclaimed the soul of
+Frankenstein--more, far more, will I achieve; treading in the steps
+already marked, I will pioneer a new way, explore unknown powers, and
+unfold to the world the deepest mysteries of creation.
+
+I closed not my eyes that night.  My internal being was in a state of
+insurrection and turmoil; I felt that order would thence arise, but I
+had no power to produce it.  By degrees, after the morning's dawn,
+sleep came.  I awoke, and my yesternight's thoughts were as a dream.
+There only remained a resolution to return to my ancient studies and to
+devote myself to a science for which I believed myself to possess a
+natural talent.  On the same day I paid M. Waldman a visit.  His
+manners in private were even more mild and attractive than in public,
+for there was a certain dignity in his mien during his lecture which in
+his own house was replaced by the greatest affability and kindness.  I
+gave him pretty nearly the same account of my former pursuits as I had
+given to his fellow professor.  He heard with attention the little
+narration concerning my studies and smiled at the names of Cornelius
+Agrippa and Paracelsus, but without the contempt that M. Krempe had
+exhibited. He said that "These were men to whose indefatigable zeal
+modern philosophers were indebted for most of the foundations of their
+knowledge.  They had left to us, as an easier task, to give new names
+and arrange in connected classifications the facts which they in a
+great degree had been the instruments of bringing to light.  The
+labours of men of genius, however erroneously directed, scarcely ever
+fail in ultimately turning to the solid advantage of mankind."  I
+listened to his statement, which was delivered without any presumption
+or affectation, and then added that his lecture had removed my
+prejudices against modern chemists; I expressed myself in measured
+terms, with the modesty and deference due from a youth to his
+instructor, without letting escape (inexperience in life would have
+made me ashamed) any of the enthusiasm which stimulated my intended
+labours.  I requested his advice concerning the books I ought to
+procure.
+
+"I am happy," said M. Waldman, "to have gained a disciple; and if your
+application equals your ability, I have no doubt of your success.
+Chemistry is that branch of natural philosophy in which the greatest
+improvements have been and may be made; it is on that account that I
+have made it my peculiar study; but at the same time, I have not
+neglected the other branches of science.  A man would make but a very
+sorry chemist if he attended to that department of human knowledge
+alone.  If your wish is to become really a man of science and not
+merely a petty experimentalist, I should advise you to apply to every
+branch of natural philosophy, including mathematics."  He then took me
+into his laboratory and explained to me the uses of his various
+machines, instructing me as to what I ought to procure and promising me
+the use of his own when I should have advanced far enough in the
+science not to derange their mechanism.  He also gave me the list of
+books which I had requested, and I took my leave.
+
+Thus ended a day memorable to me; it decided my future destiny.
+
+
+
+Chapter 4
+
+From this day natural philosophy, and particularly chemistry, in the
+most comprehensive sense of the term, became nearly my sole occupation.
+I read with ardour those works, so full of genius and discrimination,
+which modern inquirers have written on these subjects.  I attended the
+lectures and cultivated the acquaintance of the men of science of the
+university, and I found even in M. Krempe a great deal of sound sense
+and real information, combined, it is true, with a repulsive
+physiognomy and manners, but not on that account the less valuable.  In
+M. Waldman I found a true friend.  His gentleness was never tinged by
+dogmatism, and his instructions were given with an air of frankness and
+good nature that banished every idea of pedantry.  In a thousand ways
+he smoothed for me the path of knowledge and made the most abstruse
+inquiries clear and facile to my apprehension.  My application was at
+first fluctuating and uncertain; it gained strength as I proceeded and
+soon became so ardent and eager that the stars often disappeared in the
+light of morning whilst I was yet engaged in my laboratory.
+
+As I applied so closely, it may be easily conceived that my progress
+was rapid.  My ardour was indeed the astonishment of the students, and
+my proficiency that of the masters.  Professor Krempe often asked me,
+with a sly smile, how Cornelius Agrippa went on, whilst M. Waldman
+expressed the most heartfelt exultation in my progress.  Two years
+passed in this manner, during which I paid no visit to Geneva, but was
+engaged, heart and soul, in the pursuit of some discoveries which I
+hoped to make.  None but those who have experienced them can conceive
+of the enticements of science.  In other studies you go as far as
+others have gone before you, and there is nothing more to know; but in
+a scientific pursuit there is continual food for discovery and wonder.
+A mind of moderate capacity which closely pursues one study must
+infallibly arrive at great proficiency in that study; and I, who
+continually sought the attainment of one object of pursuit and was
+solely wrapped up in this, improved so rapidly that at the end of two
+years I made some discoveries in the improvement of some chemical
+instruments, which procured me great esteem and admiration at the
+university.  When I had arrived at this point and had become as well
+acquainted with the theory and practice of natural philosophy as
+depended on the lessons of any of the professors at Ingolstadt, my
+residence there being no longer conducive to my improvements, I thought
+of returning to my friends and my native town, when an incident
+happened that protracted my stay.
+
+One of the phenomena which had peculiarly attracted my attention was
+the structure of the human frame, and, indeed, any animal endued with
+life.  Whence, I often asked myself, did the principle of life proceed?
+It was a bold question, and one which has ever been considered as a
+mystery; yet with how many things are we upon the brink of becoming
+acquainted, if cowardice or carelessness did not restrain our
+inquiries.  I revolved these circumstances in my mind and determined
+thenceforth to apply myself more particularly to those branches of
+natural philosophy which relate to physiology.  Unless I had been
+animated by an almost supernatural enthusiasm, my application to this
+study would have been irksome and almost intolerable.  To examine the
+causes of life, we must first have recourse to death.  I became
+acquainted with the science of anatomy, but this was not sufficient; I
+must also observe the natural decay and corruption of the human body.
+In my education my father had taken the greatest precautions that my
+mind should be impressed with no supernatural horrors.  I do not ever
+remember to have trembled at a tale of superstition or to have feared
+the apparition of a spirit.  Darkness had no effect upon my fancy, and
+a churchyard was to me merely the receptacle of bodies deprived of
+life, which, from being the seat of beauty and strength, had become
+food for the worm.  Now I was led to examine the cause and progress of
+this decay and forced to spend days and nights in vaults and
+charnel-houses.  My attention was fixed upon every object the most
+insupportable to the delicacy of the human feelings.  I saw how the
+fine form of man was degraded and wasted; I beheld the corruption of
+death succeed to the blooming cheek of life; I saw how the worm
+inherited the wonders of the eye and brain.  I paused, examining and
+analysing all the minutiae of causation, as exemplified in the change
+from life to death, and death to life, until from the midst of this
+darkness a sudden light broke in upon me--a light so brilliant and
+wondrous, yet so simple, that while I became dizzy with the immensity
+of the prospect which it illustrated, I was surprised that among so
+many men of genius who had directed their inquiries towards the same
+science, that I alone should be reserved to discover so astonishing a
+secret.
+
+Remember, I am not recording the vision of a madman.  The sun does not
+more certainly shine in the heavens than that which I now affirm is
+true.  Some miracle might have produced it, yet the stages of the
+discovery were distinct and probable.  After days and nights of
+incredible labour and fatigue, I succeeded in discovering the cause of
+generation and life; nay, more, I became myself capable of bestowing
+animation upon lifeless matter.
+
+The astonishment which I had at first experienced on this discovery
+soon gave place to delight and rapture.  After so much time spent in
+painful labour, to arrive at once at the summit of my desires was the
+most gratifying consummation of my toils.  But this discovery was so
+great and overwhelming that all the steps by which I had been
+progressively led to it were obliterated, and I beheld only the result.
+What had been the study and desire of the wisest men since the creation
+of the world was now within my grasp.  Not that, like a magic scene, it
+all opened upon me at once:  the information I had obtained was of a
+nature rather to direct my endeavours so soon as I should point them
+towards the object of my search than to exhibit that object already
+accomplished.  I was like the Arabian who had been buried with the dead
+and found a passage to life, aided only by one glimmering and seemingly
+ineffectual light.
+
+I see by your eagerness and the wonder and hope which your eyes
+express, my friend, that you expect to be informed of the secret with
+which I am acquainted; that cannot be; listen patiently until the end
+of my story, and you will easily perceive why I am reserved upon that
+subject.  I will not lead you on, unguarded and ardent as I then was,
+to your destruction and infallible misery.  Learn from me, if not by my
+precepts, at least by my example, how dangerous is the acquirement of
+knowledge and how much happier that man is who believes his native town
+to be the world, than he who aspires to become greater than his nature
+will allow.
+
+When I found so astonishing a power placed within my hands, I hesitated
+a long time concerning the manner in which I should employ it.
+Although I possessed the capacity of bestowing animation, yet to
+prepare a frame for the reception of it, with all its intricacies of
+fibres, muscles, and veins, still remained a work of inconceivable
+difficulty and labour.  I doubted at first whether I should attempt the
+creation of a being like myself, or one of simpler organization; but my
+imagination was too much exalted by my first success to permit me to
+doubt of my ability to give life to an animal as complex and wonderful
+as man.  The materials at present within my command hardly appeared
+adequate to so arduous an undertaking, but I doubted not that I should
+ultimately succeed.  I prepared myself for a multitude of reverses; my
+operations might be incessantly baffled, and at last my work be
+imperfect, yet when I considered the improvement which every day takes
+place in science and mechanics, I was encouraged to hope my present
+attempts would at least lay the foundations of future success.  Nor
+could I consider the magnitude and complexity of my plan as any
+argument of its impracticability.  It was with these feelings that I
+began the creation of a human being.  As the minuteness of the parts
+formed a great hindrance to my speed, I resolved, contrary to my first
+intention, to make the being of a gigantic stature, that is to say,
+about eight feet in height, and proportionably large.  After having
+formed this determination and having spent some months in successfully
+collecting and arranging my materials, I began.
+
+No one can conceive the variety of feelings which bore me onwards, like
+a hurricane, in the first enthusiasm of success.  Life and death
+appeared to me ideal bounds, which I should first break through, and
+pour a torrent of light into our dark world.  A new species would bless
+me as its creator and source; many happy and excellent natures would
+owe their being to me.  No father could claim the gratitude of his
+child so completely as I should deserve theirs.  Pursuing these
+reflections, I thought that if I could bestow animation upon lifeless
+matter, I might in process of time (although I now found it impossible)
+renew life where death had apparently devoted the body to corruption.
+
+These thoughts supported my spirits, while I pursued my undertaking
+with unremitting ardour.  My cheek had grown pale with study, and my
+person had become emaciated with confinement.  Sometimes, on the very
+brink of certainty, I failed; yet still I clung to the hope which the
+next day or the next hour might realize.  One secret which I alone
+possessed was the hope to which I had dedicated myself; and the moon
+gazed on my midnight labours, while, with unrelaxed and breathless
+eagerness, I pursued nature to her hiding-places.  Who shall conceive
+the horrors of my secret toil as I dabbled among the unhallowed damps
+of the grave or tortured the living animal to animate the lifeless
+clay?  My limbs now tremble, and my eyes swim with the remembrance; but
+then a resistless and almost frantic impulse urged me forward; I seemed
+to have lost all soul or sensation but for this one pursuit.  It was
+indeed but a passing trance, that only made me feel with renewed
+acuteness so soon as, the unnatural stimulus ceasing to operate, I had
+returned to my old habits.  I collected bones from charnel-houses and
+disturbed, with profane fingers, the tremendous secrets of the human
+frame.  In a solitary chamber, or rather cell, at the top of the house,
+and separated from all the other apartments by a gallery and staircase,
+I kept my workshop of filthy creation; my eyeballs were starting from
+their sockets in attending to the details of my employment.  The
+dissecting room and the slaughter-house furnished many of my materials;
+and often did my human nature turn with loathing from my occupation,
+whilst, still urged on by an eagerness which perpetually increased, I
+brought my work near to a conclusion.
+
+The summer months passed while I was thus engaged, heart and soul, in
+one pursuit.  It was a most beautiful season; never did the fields
+bestow a more plentiful harvest or the vines yield a more luxuriant
+vintage, but my eyes were insensible to the charms of nature.  And the
+same feelings which made me neglect the scenes around me caused me also
+to forget those friends who were so many miles absent, and whom I had
+not seen for so long a time.  I knew my silence disquieted them, and I
+well remembered the words of my father:  "I know that while you are
+pleased with yourself you will think of us with affection, and we shall
+hear regularly from you.  You must pardon me if I regard any
+interruption in your correspondence as a proof that your other duties
+are equally neglected."
+
+I knew well therefore what would be my father's feelings, but I could
+not tear my thoughts from my employment, loathsome in itself, but which
+had taken an irresistible hold of my imagination.  I wished, as it
+were, to procrastinate all that related to my feelings of affection
+until the great object, which swallowed up every habit of my nature,
+should be completed.
+
+I then thought that my father would be unjust if he ascribed my neglect
+to vice or faultiness on my part, but I am now convinced that he was
+justified in conceiving that I should not be altogether free from
+blame.  A human being in perfection ought always to preserve a calm and
+peaceful mind and never to allow passion or a transitory desire to
+disturb his tranquillity.  I do not think that the pursuit of knowledge
+is an exception to this rule.  If the study to which you apply yourself
+has a tendency to weaken your affections and to destroy your taste for
+those simple pleasures in which no alloy can possibly mix, then that
+study is certainly unlawful, that is to say, not befitting the human
+mind.  If this rule were always observed; if no man allowed any pursuit
+whatsoever to interfere with the tranquillity of his domestic
+affections, Greece had not been enslaved, Caesar would have spared his
+country, America would have been discovered more gradually, and the
+empires of Mexico and Peru had not been destroyed.
+
+But I forget that I am moralizing in the most interesting part of my
+tale, and your looks remind me to proceed.  My father made no reproach
+in his letters and only took notice of my silence by inquiring into my
+occupations more particularly than before.  Winter, spring, and summer
+passed away during my labours; but I did not watch the blossom or the
+expanding leaves--sights which before always yielded me supreme
+delight--so deeply was I engrossed in my occupation.  The leaves of
+that year had withered before my work drew near to a close, and now
+every day showed me more plainly how well I had succeeded.  But my
+enthusiasm was checked by my anxiety, and I appeared rather like one
+doomed by slavery to toil in the mines, or any other unwholesome trade
+than an artist occupied by his favourite employment.  Every night I was
+oppressed by a slow fever, and I became nervous to a most painful
+degree; the fall of a leaf startled me, and I shunned my fellow
+creatures as if I had been guilty of a crime.  Sometimes I grew alarmed
+at the wreck I perceived that I had become; the energy of my purpose
+alone sustained me:  my labours would soon end, and I believed that
+exercise and amusement would then drive away incipient disease; and I
+promised myself both of these when my creation should be complete.
+
+
+
+Chapter 5
+
+It was on a dreary night of November that I beheld the accomplishment
+of my toils.  With an anxiety that almost amounted to agony, I
+collected the instruments of life around me, that I might infuse a
+spark of being into the lifeless thing that lay at my feet.  It was
+already one in the morning; the rain pattered dismally against the
+panes, and my candle was nearly burnt out, when, by the glimmer of the
+half-extinguished light, I saw the dull yellow eye of the creature
+open; it breathed hard, and a convulsive motion agitated its limbs.
+
+How can I describe my emotions at this catastrophe, or how delineate
+the wretch whom with such infinite pains and care I had endeavoured to
+form?  His limbs were in proportion, and I had selected his features as
+beautiful.  Beautiful!  Great God!  His yellow skin scarcely covered
+the work of muscles and arteries beneath; his hair was of a lustrous
+black, and flowing; his teeth of a pearly whiteness; but these
+luxuriances only formed a more horrid contrast with his watery eyes,
+that seemed almost of the same colour as the dun-white sockets in which
+they were set, his shrivelled complexion and straight black lips.
+
+The different accidents of life are not so changeable as the feelings
+of human nature.  I had worked hard for nearly two years, for the sole
+purpose of infusing life into an inanimate body.  For this I had
+deprived myself of rest and health.  I had desired it with an ardour
+that far exceeded moderation; but now that I had finished, the beauty
+of the dream vanished, and breathless horror and disgust filled my
+heart.  Unable to endure the aspect of the being I had created, I
+rushed out of the room and continued a long time traversing my
+bed-chamber, unable to compose my mind to sleep.  At length lassitude
+succeeded to the tumult I had before endured, and I threw myself on the
+bed in my clothes, endeavouring to seek a few moments of forgetfulness.
+But it was in vain; I slept, indeed, but I was disturbed by the wildest
+dreams.  I thought I saw Elizabeth, in the bloom of health, walking in
+the streets of Ingolstadt.  Delighted and surprised, I embraced her,
+but as I imprinted the first kiss on her lips, they became livid with
+the hue of death; her features appeared to change, and I thought that I
+held the corpse of my dead mother in my arms; a shroud enveloped her
+form, and I saw the grave-worms crawling in the folds of the flannel.
+I started from my sleep with horror; a cold dew covered my forehead, my
+teeth chattered, and every limb became convulsed; when, by the dim and
+yellow light of the moon, as it forced its way through the window
+shutters, I beheld the wretch--the miserable monster whom I had
+created.  He held up the curtain of the bed; and his eyes, if eyes they
+may be called, were fixed on me.  His jaws opened, and he muttered some
+inarticulate sounds, while a grin wrinkled his cheeks.  He might have
+spoken, but I did not hear; one hand was stretched out, seemingly to
+detain me, but I escaped and rushed downstairs.  I took refuge in the
+courtyard belonging to the house which I inhabited, where I remained
+during the rest of the night, walking up and down in the greatest
+agitation, listening attentively, catching and fearing each sound as if
+it were to announce the approach of the demoniacal corpse to which I
+had so miserably given life.
+
+Oh!  No mortal could support the horror of that countenance.  A mummy
+again endued with animation could not be so hideous as that wretch.  I
+had gazed on him while unfinished; he was ugly then, but when those
+muscles and joints were rendered capable of motion, it became a thing
+such as even Dante could not have conceived.
+
+I passed the night wretchedly.  Sometimes my pulse beat so quickly and
+hardly that I felt the palpitation of every artery; at others, I nearly
+sank to the ground through languor and extreme weakness.  Mingled with
+this horror, I felt the bitterness of disappointment; dreams that had
+been my food and pleasant rest for so long a space were now become a
+hell to me; and the change was so rapid, the overthrow so complete!
+
+Morning, dismal and wet, at length dawned and discovered to my
+sleepless and aching eyes the church of Ingolstadt, its white steeple
+and clock, which indicated the sixth hour.  The porter opened the gates
+of the court, which had that night been my asylum, and I issued into
+the streets, pacing them with quick steps, as if I sought to avoid the
+wretch whom I feared every turning of the street would present to my
+view.  I did not dare return to the apartment which I inhabited, but
+felt impelled to hurry on, although drenched by the rain which poured
+from a black and comfortless sky.
+
+I continued walking in this manner for some time, endeavouring by
+bodily exercise to ease the load that weighed upon my mind.  I
+traversed the streets without any clear conception of where I was or
+what I was doing.  My heart palpitated in the sickness of fear, and I
+hurried on with irregular steps, not daring to look about me:
+
+
+  Like one who, on a lonely road,
+  Doth walk in fear and dread,
+  And, having once turned round, walks on,
+  And turns no more his head;
+  Because he knows a frightful fiend
+  Doth close behind him tread.
+
+  [Coleridge's "Ancient Mariner."]
+
+
+Continuing thus, I came at length opposite to the inn at which the
+various diligences and carriages usually stopped.  Here I paused, I
+knew not why; but I remained some minutes with my eyes fixed on a coach
+that was coming towards me from the other end of the street.  As it
+drew nearer I observed that it was the Swiss diligence; it stopped just
+where I was standing, and on the door being opened, I perceived Henry
+Clerval, who, on seeing me, instantly sprung out.  "My dear
+Frankenstein," exclaimed he, "how glad I am to see you!  How fortunate
+that you should be here at the very moment of my alighting!"
+
+Nothing could equal my delight on seeing Clerval; his presence brought
+back to my thoughts my father, Elizabeth, and all those scenes of home
+so dear to my recollection.  I grasped his hand, and in a moment forgot
+my horror and misfortune; I felt suddenly, and for the first time
+during many months, calm and serene joy.  I welcomed my friend,
+therefore, in the most cordial manner, and we walked towards my
+college.  Clerval continued talking for some time about our mutual
+friends and his own good fortune in being permitted to come to
+Ingolstadt.  "You may easily believe," said he, "how great was the
+difficulty to persuade my father that all necessary knowledge was not
+comprised in the noble art of book-keeping; and, indeed, I believe I
+left him incredulous to the last, for his constant answer to my
+unwearied entreaties was the same as that of the Dutch schoolmaster in
+The Vicar of Wakefield:  'I have ten thousand florins a year without
+Greek, I eat heartily without Greek.'  But his affection for me at
+length overcame his dislike of learning, and he has permitted me to
+undertake a voyage of discovery to the land of knowledge."
+
+"It gives me the greatest delight to see you; but tell me how you left
+my father, brothers, and Elizabeth."
+
+"Very well, and very happy, only a little uneasy that they hear from
+you so seldom.  By the by, I mean to lecture you a little upon their
+account myself.  But, my dear Frankenstein," continued he, stopping
+short and gazing full in my face, "I did not before remark how very ill
+you appear; so thin and pale; you look as if you had been watching for
+several nights."
+
+"You have guessed right; I have lately been so deeply engaged in one
+occupation that I have not allowed myself sufficient rest, as you see;
+but I hope, I sincerely hope, that all these employments are now at an
+end and that I am at length free."
+
+I trembled excessively; I could not endure to think of, and far less to
+allude to, the occurrences of the preceding night.  I walked with a
+quick pace, and we soon arrived at my college.  I then reflected, and
+the thought made me shiver, that the creature whom I had left in my
+apartment might still be there, alive and walking about.  I dreaded to
+behold this monster, but I feared still more that Henry should see him.
+Entreating him, therefore, to remain a few minutes at the bottom of the
+stairs, I darted up towards my own room.  My hand was already on the
+lock of the door before I recollected myself.  I then paused, and a
+cold shivering came over me.  I threw the door forcibly open, as
+children are accustomed to do when they expect a spectre to stand in
+waiting for them on the other side; but nothing appeared.  I stepped
+fearfully in:  the apartment was empty, and my bedroom was also freed
+from its hideous guest.  I could hardly believe that so great a good
+fortune could have befallen me, but when I became assured that my enemy
+had indeed fled, I clapped my hands for joy and ran down to Clerval.
+
+We ascended into my room, and the servant presently brought breakfast;
+but I was unable to contain myself.  It was not joy only that possessed
+me; I felt my flesh tingle with excess of sensitiveness, and my pulse
+beat rapidly.  I was unable to remain for a single instant in the same
+place; I jumped over the chairs, clapped my hands, and laughed aloud.
+Clerval at first attributed my unusual spirits to joy on his arrival,
+but when he observed me more attentively, he saw a wildness in my eyes
+for which he could not account, and my loud, unrestrained, heartless
+laughter frightened and astonished him.
+
+"My dear Victor," cried he, "what, for God's sake, is the matter?  Do
+not laugh in that manner.  How ill you are!  What is the cause of all
+this?"
+
+"Do not ask me," cried I, putting my hands before my eyes, for I
+thought I saw the dreaded spectre glide into the room; "HE can tell.
+Oh, save me!  Save me!"  I imagined that the monster seized me; I
+struggled furiously and fell down in a fit.
+
+Poor Clerval!  What must have been his feelings?  A meeting, which he
+anticipated with such joy, so strangely turned to bitterness.  But I
+was not the witness of his grief, for I was lifeless and did not
+recover my senses for a long, long time.
+
+This was the commencement of a nervous fever which confined me for
+several months.  During all that time Henry was my only nurse.  I
+afterwards learned that, knowing my father's advanced age and unfitness
+for so long a journey, and how wretched my sickness would make
+Elizabeth, he spared them this grief by concealing the extent of my
+disorder.  He knew that I could not have a more kind and attentive
+nurse than himself; and, firm in the hope he felt of my recovery, he
+did not doubt that, instead of doing harm, he performed the kindest
+action that he could towards them.
+
+But I was in reality very ill, and surely nothing but the unbounded and
+unremitting attentions of my friend could have restored me to life.
+The form of the monster on whom I had bestowed existence was forever
+before my eyes, and I raved incessantly concerning him.  Doubtless my
+words surprised Henry; he at first believed them to be the wanderings
+of my disturbed imagination, but the pertinacity with which I
+continually recurred to the same subject persuaded him that my disorder
+indeed owed its origin to some uncommon and terrible event.
+
+By very slow degrees, and with frequent relapses that alarmed and
+grieved my friend, I recovered.  I remember the first time I became
+capable of observing outward objects with any kind of pleasure, I
+perceived that the fallen leaves had disappeared and that the young
+buds were shooting forth from the trees that shaded my window.  It was
+a divine spring, and the season contributed greatly to my
+convalescence.  I felt also sentiments of joy and affection revive in
+my bosom; my gloom disappeared, and in a short time I became as
+cheerful as before I was attacked by the fatal passion.
+
+"Dearest Clerval," exclaimed I, "how kind, how very good you are to me.
+This whole winter, instead of being spent in study, as you promised
+yourself, has been consumed in my sick room.  How shall I ever repay
+you?  I feel the greatest remorse for the disappointment of which I
+have been the occasion, but you will forgive me."
+
+"You will repay me entirely if you do not discompose yourself, but get
+well as fast as you can; and since you appear in such good spirits, I
+may speak to you on one subject, may I not?"
+
+I trembled.  One subject!  What could it be?  Could he allude to an
+object on whom I dared not even think?  "Compose yourself," said
+Clerval, who observed my change of colour, "I will not mention it if it
+agitates you; but your father and cousin would be very happy if they
+received a letter from you in your own handwriting.  They hardly know
+how ill you have been and are uneasy at your long silence."
+
+"Is that all, my dear Henry?  How could you suppose that my first
+thought would not fly towards those dear, dear friends whom I love and
+who are so deserving of my love?"
+
+"If this is your present temper, my friend, you will perhaps be glad to
+see a letter that has been lying here some days for you; it is from
+your cousin, I believe."
+
+
+
+Chapter 6
+
+Clerval then put the following letter into my hands.  It was from my
+own Elizabeth:
+
+"My dearest Cousin,
+
+"You have been ill, very ill, and even the constant letters of dear
+kind Henry are not sufficient to reassure me on your account.  You are
+forbidden to write--to hold a pen; yet one word from you, dear Victor,
+is necessary to calm our apprehensions.  For a long time I have thought
+that each post would bring this line, and my persuasions have
+restrained my uncle from undertaking a journey to Ingolstadt.  I have
+prevented his encountering the inconveniences and perhaps dangers of so
+long a journey, yet how often have I regretted not being able to
+perform it myself!  I figure to myself that the task of attending on
+your sickbed has devolved on some mercenary old nurse, who could never
+guess your wishes nor minister to them with the care and affection of
+your poor cousin.  Yet that is over now:  Clerval writes that indeed
+you are getting better.  I eagerly hope that you will confirm this
+intelligence soon in your own handwriting.
+
+"Get well--and return to us.  You will find a happy, cheerful home and
+friends who love you dearly.  Your father's health is vigorous, and he
+asks but to see you, but to be assured that you are well; and not a
+care will ever cloud his benevolent countenance.  How pleased you would
+be to remark the improvement of our Ernest!  He is now sixteen and full
+of activity and spirit.  He is desirous to be a true Swiss and to enter
+into foreign service, but we cannot part with him, at least until his
+elder brother returns to us.  My uncle is not pleased with the idea of
+a military career in a distant country, but Ernest never had your
+powers of application.  He looks upon study as an odious fetter; his
+time is spent in the open air, climbing the hills or rowing on the
+lake.  I fear that he will become an idler unless we yield the point
+and permit him to enter on the profession which he has selected.
+
+"Little alteration, except the growth of our dear children, has taken
+place since you left us.  The blue lake and snow-clad mountains--they
+never change; and I think our placid home and our contented hearts are
+regulated by the same immutable laws.  My trifling occupations take up
+my time and amuse me, and I am rewarded for any exertions by seeing
+none but happy, kind faces around me.  Since you left us, but one
+change has taken place in our little household.  Do you remember on
+what occasion Justine Moritz entered our family?  Probably you do not;
+I will relate her history, therefore in a few words.  Madame Moritz,
+her mother, was a widow with four children, of whom Justine was the
+third.  This girl had always been the favourite of her father, but
+through a strange perversity, her mother could not endure her, and
+after the death of M. Moritz, treated her very ill.  My aunt observed
+this, and when Justine was twelve years of age, prevailed on her mother
+to allow her to live at our house.  The republican institutions of our
+country have produced simpler and happier manners than those which
+prevail in the great monarchies that surround it.  Hence there is less
+distinction between the several classes of its inhabitants; and the
+lower orders, being neither so poor nor so despised, their manners are
+more refined and moral.  A servant in Geneva does not mean the same
+thing as a servant in France and England.  Justine, thus received in
+our family, learned the duties of a servant, a condition which, in our
+fortunate country, does not include the idea of ignorance and a
+sacrifice of the dignity of a human being.
+
+"Justine, you may remember, was a great favourite of yours; and I
+recollect you once remarked that if you were in an ill humour, one
+glance from Justine could dissipate it, for the same reason that
+Ariosto gives concerning the beauty of Angelica--she looked so
+frank-hearted and happy.  My aunt conceived a great attachment for her,
+by which she was induced to give her an education superior to that
+which she had at first intended.  This benefit was fully repaid;
+Justine was the most grateful little creature in the world:  I do not
+mean that she made any professions I never heard one pass her lips, but
+you could see by her eyes that she almost adored her protectress.
+Although her disposition was gay and in many respects inconsiderate,
+yet she paid the greatest attention to every gesture of my aunt.  She
+thought her the model of all excellence and endeavoured to imitate her
+phraseology and manners, so that even now she often reminds me of her.
+
+"When my dearest aunt died every one was too much occupied in their own
+grief to notice poor Justine, who had attended her during her illness
+with the most anxious affection.  Poor Justine was very ill; but other
+trials were reserved for her.
+
+"One by one, her brothers and sister died; and her mother, with the
+exception of her neglected daughter, was left childless.  The
+conscience of the woman was troubled; she began to think that the
+deaths of her favourites was a judgement from heaven to chastise her
+partiality.  She was a Roman Catholic; and I believe her confessor
+confirmed the idea which she had conceived.  Accordingly, a few months
+after your departure for Ingolstadt, Justine was called home by her
+repentant mother.  Poor girl!  She wept when she quitted our house; she
+was much altered since the death of my aunt; grief had given softness
+and a winning mildness to her manners, which had before been remarkable
+for vivacity.  Nor was her residence at her mother's house of a nature
+to restore her gaiety.  The poor woman was very vacillating in her
+repentance.  She sometimes begged Justine to forgive her unkindness,
+but much oftener accused her of having caused the deaths of her
+brothers and sister.  Perpetual fretting at length threw Madame Moritz
+into a decline, which at first increased her irritability, but she is
+now at peace for ever.  She died on the first approach of cold weather,
+at the beginning of this last winter.  Justine has just returned to us;
+and I assure you I love her tenderly.  She is very clever and gentle,
+and extremely pretty; as I mentioned before, her mien and her
+expression continually remind me of my dear aunt.
+
+"I must say also a few words to you, my dear cousin, of little darling
+William.  I wish you could see him; he is very tall of his age, with
+sweet laughing blue eyes, dark eyelashes, and curling hair.  When he
+smiles, two little dimples appear on each cheek, which are rosy with
+health.  He has already had one or two little WIVES, but Louisa Biron
+is his favourite, a pretty little girl of five years of age.
+
+"Now, dear Victor, I dare say you wish to be indulged in a little
+gossip concerning the good people of Geneva.  The pretty Miss Mansfield
+has already received the congratulatory visits on her approaching
+marriage with a young Englishman, John Melbourne, Esq.  Her ugly
+sister, Manon, married M. Duvillard, the rich banker, last autumn. Your
+favourite schoolfellow, Louis Manoir, has suffered several misfortunes
+since the departure of Clerval from Geneva.  But he has already
+recovered his spirits, and is reported to be on the point of marrying a
+lively pretty Frenchwoman, Madame Tavernier.  She is a widow, and much
+older than Manoir; but she is very much admired, and a favourite with
+everybody.
+
+"I have written myself into better spirits, dear cousin; but my anxiety
+returns upon me as I conclude.  Write, dearest Victor,--one line--one
+word will be a blessing to us.  Ten thousand thanks to Henry for his
+kindness, his affection, and his many letters; we are sincerely
+grateful.  Adieu!  my cousin; take care of your self; and, I entreat
+you, write!
+
+"Elizabeth Lavenza.
+
+"Geneva, March 18, 17--."
+
+
+"Dear, dear Elizabeth!" I exclaimed, when I had read her letter:  "I
+will write instantly and relieve them from the anxiety they must feel."
+I wrote, and this exertion greatly fatigued me; but my convalescence
+had commenced, and proceeded regularly.  In another fortnight I was
+able to leave my chamber.
+
+One of my first duties on my recovery was to introduce Clerval to the
+several professors of the university.  In doing this, I underwent a
+kind of rough usage, ill befitting the wounds that my mind had
+sustained.  Ever since the fatal night, the end of my labours, and the
+beginning of my misfortunes, I had conceived a violent antipathy even
+to the name of natural philosophy.  When I was otherwise quite restored
+to health, the sight of a chemical instrument would renew all the agony
+of my nervous symptoms.  Henry saw this, and had removed all my
+apparatus from my view.  He had also changed my apartment; for he
+perceived that I had acquired a dislike for the room which had
+previously been my laboratory.  But these cares of Clerval were made of
+no avail when I visited the professors.  M. Waldman inflicted torture
+when he praised, with kindness and warmth, the astonishing progress I
+had made in the sciences.  He soon perceived that I disliked the
+subject; but not guessing the real cause, he attributed my feelings to
+modesty, and changed the subject from my improvement, to the science
+itself, with a desire, as I evidently saw, of drawing me out.  What
+could I do?  He meant to please, and he tormented me.  I felt as if he
+had placed carefully, one by one, in my view those instruments which
+were to be afterwards used in putting me to a slow and cruel death.  I
+writhed under his words, yet dared not exhibit the pain I felt.
+Clerval, whose eyes and feelings were always quick in discerning the
+sensations of others, declined the subject, alleging, in excuse, his
+total ignorance; and the conversation took a more general turn.  I
+thanked my friend from my heart, but I did not speak.  I saw plainly
+that he was surprised, but he never attempted to draw my secret from
+me; and although I loved him with a mixture of affection and reverence
+that knew no bounds, yet I could never persuade myself to confide in
+him that event which was so often present to my recollection, but which
+I feared the detail to another would only impress more deeply.
+
+M. Krempe was not equally docile; and in my condition at that time, of
+almost insupportable sensitiveness, his harsh blunt encomiums gave me
+even more pain than the benevolent approbation of M. Waldman.  "D--n
+the fellow!" cried he; "why, M. Clerval, I assure you he has outstript
+us all.  Ay, stare if you please; but it is nevertheless true.  A
+youngster who, but a few years ago, believed in Cornelius Agrippa as
+firmly as in the gospel, has now set himself at the head of the
+university; and if he is not soon pulled down, we shall all be out of
+countenance.--Ay, ay," continued he, observing my face expressive of
+suffering, "M. Frankenstein is modest; an excellent quality in a young
+man.  Young men should be diffident of themselves, you know, M.
+Clerval:  I was myself when young; but that wears out in a very short
+time."
+
+M. Krempe had now commenced an eulogy on himself, which happily turned
+the conversation from a subject that was so annoying to me.
+
+Clerval had never sympathized in my tastes for natural science; and his
+literary pursuits differed wholly from those which had occupied me.  He
+came to the university with the design of making himself complete
+master of the oriental languages, and thus he should open a field for
+the plan of life he had marked out for himself.  Resolved to pursue no
+inglorious career, he turned his eyes toward the East, as affording
+scope for his spirit of enterprise.  The Persian, Arabic, and Sanskrit
+languages engaged his attention, and I was easily induced to enter on
+the same studies.  Idleness had ever been irksome to me, and now that I
+wished to fly from reflection, and hated my former studies, I felt
+great relief in being the fellow-pupil with my friend, and found not
+only instruction but consolation in the works of the orientalists.  I
+did not, like him, attempt a critical knowledge of their dialects, for
+I did not contemplate making any other use of them than temporary
+amusement.  I read merely to understand their meaning, and they well
+repaid my labours.  Their melancholy is soothing, and their joy
+elevating, to a degree I never experienced in studying the authors of
+any other country.  When you read their writings, life appears to
+consist in a warm sun and a garden of roses,--in the smiles and frowns
+of a fair enemy, and the fire that consumes your own heart.  How
+different from the manly and heroical poetry of Greece and Rome!
+
+Summer passed away in these occupations, and my return to Geneva was
+fixed for the latter end of autumn; but being delayed by several
+accidents, winter and snow arrived, the roads were deemed impassable,
+and my journey was retarded until the ensuing spring.  I felt this
+delay very bitterly; for I longed to see my native town and my beloved
+friends.  My return had only been delayed so long, from an
+unwillingness to leave Clerval in a strange place, before he had become
+acquainted with any of its inhabitants.  The winter, however, was spent
+cheerfully; and although the spring was uncommonly late, when it came
+its beauty compensated for its dilatoriness.
+
+The month of May had already commenced, and I expected the letter daily
+which was to fix the date of my departure, when Henry proposed a
+pedestrian tour in the environs of Ingolstadt, that I might bid a
+personal farewell to the country I had so long inhabited.  I acceded
+with pleasure to this proposition:  I was fond of exercise, and Clerval
+had always been my favourite companion in the ramble of this nature
+that I had taken among the scenes of my native country.
+
+We passed a fortnight in these perambulations:  my health and spirits
+had long been restored, and they gained additional strength from the
+salubrious air I breathed, the natural incidents of our progress, and
+the conversation of my friend.  Study had before secluded me from the
+intercourse of my fellow-creatures, and rendered me unsocial; but
+Clerval called forth the better feelings of my heart; he again taught
+me to love the aspect of nature, and the cheerful faces of children.
+Excellent friend!  how sincerely you did love me, and endeavour to
+elevate my mind until it was on a level with your own.  A selfish
+pursuit had cramped and narrowed me, until your gentleness and
+affection warmed and opened my senses; I became the same happy creature
+who, a few years ago, loved and beloved by all, had no sorrow or care.
+When happy, inanimate nature had the power of bestowing on me the most
+delightful sensations.  A serene sky and verdant fields filled me with
+ecstasy.  The present season was indeed divine; the flowers of spring
+bloomed in the hedges, while those of summer were already in bud.  I
+was undisturbed by thoughts which during the preceding year had pressed
+upon me, notwithstanding my endeavours to throw them off, with an
+invincible burden.
+
+Henry rejoiced in my gaiety, and sincerely sympathised in my feelings:
+he exerted himself to amuse me, while he expressed the sensations that
+filled his soul.  The resources of his mind on this occasion were truly
+astonishing:  his conversation was full of imagination; and very often,
+in imitation of the Persian and Arabic writers, he invented tales of
+wonderful fancy and passion.  At other times he repeated my favourite
+poems, or drew me out into arguments, which he supported with great
+ingenuity.  We returned to our college on a Sunday afternoon:  the
+peasants were dancing, and every one we met appeared gay and happy.  My
+own spirits were high, and I bounded along with feelings of unbridled
+joy and hilarity.
+
+
+
+Chapter 7
+
+On my return, I found the following letter from my father:--
+
+
+"My dear Victor,
+
+"You have probably waited impatiently for a letter to fix the date of
+your return to us; and I was at first tempted to write only a few
+lines, merely mentioning the day on which I should expect you.  But
+that would be a cruel kindness, and I dare not do it.  What would be
+your surprise, my son, when you expected a happy and glad welcome, to
+behold, on the contrary, tears and wretchedness?  And how, Victor, can
+I relate our misfortune?  Absence cannot have rendered you callous to
+our joys and griefs; and how shall I inflict pain on my long absent
+son?  I wish to prepare you for the woeful news, but I know it is
+impossible; even now your eye skims over the page to seek the words
+which are to convey to you the horrible tidings.
+
+"William is dead!--that sweet child, whose smiles delighted and warmed
+my heart, who was so gentle, yet so gay!  Victor, he is murdered!
+
+"I will not attempt to console you; but will simply relate the
+circumstances of the transaction.
+
+"Last Thursday (May 7th), I, my niece, and your two brothers, went to
+walk in Plainpalais.  The evening was warm and serene, and we prolonged
+our walk farther than usual.  It was already dusk before we thought of
+returning; and then we discovered that William and Ernest, who had gone
+on before, were not to be found.  We accordingly rested on a seat until
+they should return.  Presently Ernest came, and enquired if we had seen
+his brother; he said, that he had been playing with him, that William
+had run away to hide himself, and that he vainly sought for him, and
+afterwards waited for a long time, but that he did not return.
+
+"This account rather alarmed us, and we continued to search for him
+until night fell, when Elizabeth conjectured that he might have
+returned to the house.  He was not there.  We returned again, with
+torches; for I could not rest, when I thought that my sweet boy had
+lost himself, and was exposed to all the damps and dews of night;
+Elizabeth also suffered extreme anguish.  About five in the morning I
+discovered my lovely boy, whom the night before I had seen blooming and
+active in health, stretched on the grass livid and motionless; the
+print of the murder's finger was on his neck.
+
+"He was conveyed home, and the anguish that was visible in my
+countenance betrayed the secret to Elizabeth.  She was very earnest to
+see the corpse.  At first I attempted to prevent her but she persisted,
+and entering the room where it lay, hastily examined the neck of the
+victim, and clasping her hands exclaimed, 'O God!  I have murdered my
+darling child!'
+
+"She fainted, and was restored with extreme difficulty.  When she again
+lived, it was only to weep and sigh.  She told me, that that same
+evening William had teased her to let him wear a very valuable
+miniature that she possessed of your mother.  This picture is gone, and
+was doubtless the temptation which urged the murderer to the deed.  We
+have no trace of him at present, although our exertions to discover him
+are unremitted; but they will not restore my beloved William!
+
+"Come, dearest Victor; you alone can console Elizabeth.  She weeps
+continually, and accuses herself unjustly as the cause of his death;
+her words pierce my heart.  We are all unhappy; but will not that be an
+additional motive for you, my son, to return and be our comforter?
+Your dear mother!  Alas, Victor!  I now say, Thank God she did not live
+to witness the cruel, miserable death of her youngest darling!
+
+"Come, Victor; not brooding thoughts of vengeance against the assassin,
+but with feelings of peace and gentleness, that will heal, instead of
+festering, the wounds of our minds.  Enter the house of mourning, my
+friend, but with kindness and affection for those who love you, and not
+with hatred for your enemies.
+
+               "Your affectionate and afflicted father,
+                              "Alphonse Frankenstein.
+
+
+
+"Geneva, May 12th, 17--."
+
+Clerval, who had watched my countenance as I read this letter, was
+surprised to observe the despair that succeeded the joy I at first
+expressed on receiving new from my friends.  I threw the letter on the
+table, and covered my face with my hands.
+
+"My dear Frankenstein," exclaimed Henry, when he perceived me weep with
+bitterness, "are you always to be unhappy?  My dear friend, what has
+happened?"
+
+I motioned him to take up the letter, while I walked up and down the
+room in the extremest agitation.  Tears also gushed from the eyes of
+Clerval, as he read the account of my misfortune.
+
+"I can offer you no consolation, my friend," said he; "your disaster is
+irreparable.  What do you intend to do?"
+
+"To go instantly to Geneva: come with me, Henry, to order the horses."
+
+During our walk, Clerval endeavoured to say a few words of consolation;
+he could only express his heartfelt sympathy.  "Poor William!" said he,
+"dear lovely child, he now sleeps with his angel mother!  Who that had
+seen him bright and joyous in his young beauty, but must weep over his
+untimely loss!  To die so miserably; to feel the murderer's grasp!  How
+much more a murdered that could destroy radiant innocence!  Poor little
+fellow! one only consolation have we; his friends mourn and weep, but
+he is at rest. The pang is over, his sufferings are at an end for ever.
+A sod covers his gentle form, and he knows no pain.  He can no longer
+be a subject for pity; we must reserve that for his miserable
+survivors."
+
+Clerval spoke thus as we hurried through the streets; the words
+impressed themselves on my mind and I remembered them afterwards in
+solitude.  But now, as soon as the horses arrived, I hurried into a
+cabriolet, and bade farewell to my friend.
+
+My journey was very melancholy.  At first I wished to hurry on, for I
+longed to console and sympathise with my loved and sorrowing friends;
+but when I drew near my native town, I slackened my progress.  I could
+hardly sustain the multitude of feelings that crowded into my mind.  I
+passed through scenes familiar to my youth, but which I had not seen
+for nearly six years.  How altered every thing might be during that
+time!  One sudden and desolating change had taken place; but a thousand
+little circumstances might have by degrees worked other alterations,
+which, although they were done more tranquilly, might not be the less
+decisive.  Fear overcame me; I dared no advance, dreading a thousand
+nameless evils that made me tremble, although I was unable to define
+them.  I remained two days at Lausanne, in this painful state of mind.
+I contemplated the lake:  the waters were placid; all around was calm;
+and the snowy mountains, 'the palaces of nature,' were not changed.  By
+degrees the calm and heavenly scene restored me, and I continued my
+journey towards Geneva.
+
+The road ran by the side of the lake, which became narrower as I
+approached my native town.  I discovered more distinctly the black
+sides of Jura, and the bright summit of Mont Blanc.  I wept like a
+child.  "Dear mountains! my own beautiful lake! how do you welcome your
+wanderer?  Your summits are clear; the sky and lake are blue and
+placid.  Is this to prognosticate peace, or to mock at my unhappiness?"
+
+I fear, my friend, that I shall render myself tedious by dwelling on
+these preliminary circumstances; but they were days of comparative
+happiness, and I think of them with pleasure.  My country, my beloved
+country! who but a native can tell the delight I took in again
+beholding thy streams, thy mountains, and, more than all, thy lovely
+lake!
+
+Yet, as I drew nearer home, grief and fear again overcame me.  Night
+also closed around; and when I could hardly see the dark mountains, I
+felt still more gloomily.  The picture appeared a vast and dim scene of
+evil, and I foresaw obscurely that I was destined to become the most
+wretched of human beings.  Alas!  I prophesied truly, and failed only
+in one single circumstance, that in all the misery I imagined and
+dreaded, I did not conceive the hundredth part of the anguish I was
+destined to endure.  It was completely dark when I arrived in the
+environs of Geneva; the gates of the town were already shut; and I was
+obliged to pass the night at Secheron, a village at the distance of
+half a league from the city.  The sky was serene; and, as I was unable
+to rest, I resolved to visit the spot where my poor William had been
+murdered.  As I could not pass through the town, I was obliged to cross
+the lake in a boat to arrive at Plainpalais.  During this short voyage
+I saw the lightning playing on the summit of Mont Blanc in the most
+beautiful figures.  The storm appeared to approach rapidly, and, on
+landing, I ascended a low hill, that I might observe its progress.  It
+advanced; the heavens were clouded, and I soon felt the rain coming
+slowly in large drops, but its violence quickly increased.
+
+I quitted my seat, and walked on, although the darkness and storm
+increased every minute, and the thunder burst with a terrific crash
+over my head.  It was echoed from Saleve, the Juras, and the Alps of
+Savoy; vivid flashes of lightning dazzled my eyes, illuminating the
+lake, making it appear like a vast sheet of fire; then for an instant
+every thing seemed of a pitchy darkness, until the eye recovered itself
+from the preceding flash.  The storm, as is often the case in
+Switzerland, appeared at once in various parts of the heavens.  The
+most violent storm hung exactly north of the town, over the part of the
+lake which lies between the promontory of Belrive and the village of
+Copet.  Another storm enlightened Jura with faint flashes; and another
+darkened and sometimes disclosed the Mole, a peaked mountain to the
+east of the lake.
+
+While I watched the tempest, so beautiful yet terrific, I wandered on
+with a hasty step.  This noble war in the sky elevated my spirits; I
+clasped my hands, and exclaimed aloud, "William, dear angel! this is
+thy funeral, this thy dirge!" As I said these words, I perceived in the
+gloom a figure which stole from behind a clump of trees near me; I
+stood fixed, gazing intently:  I could not be mistaken.  A flash of
+lightning illuminated the object, and discovered its shape plainly to
+me; its gigantic stature, and the deformity of its aspect more hideous
+than belongs to humanity, instantly informed me that it was the wretch,
+the filthy daemon, to whom I had given life.  What did he there?  Could
+he be (I shuddered at the conception) the murderer of my brother?  No
+sooner did that idea cross my imagination, than I became convinced of
+its truth; my teeth chattered, and I was forced to lean against a tree
+for support.  The figure passed me quickly, and I lost it in the gloom.
+
+Nothing in human shape could have destroyed the fair child.  HE was the
+murderer!  I could not doubt it.  The mere presence of the idea was an
+irresistible proof of the fact.  I thought of pursuing the devil; but
+it would have been in vain, for another flash discovered him to me
+hanging among the rocks of the nearly perpendicular ascent of Mont
+Saleve, a hill that bounds Plainpalais on the south.  He soon reached
+the summit, and disappeared.
+
+I remained motionless.  The thunder ceased; but the rain still
+continued, and the scene was enveloped in an impenetrable darkness.  I
+revolved in my mind the events which I had until now sought to forget:
+the whole train of my progress toward the creation; the appearance of
+the works of my own hands at my bedside; its departure.  Two years had
+now nearly elapsed since the night on which he first received life; and
+was this his first crime?  Alas!  I had turned loose into the world a
+depraved wretch, whose delight was in carnage and misery; had he not
+murdered my brother?
+
+No one can conceive the anguish I suffered during the remainder of the
+night, which I spent, cold and wet, in the open air.  But I did not
+feel the inconvenience of the weather; my imagination was busy in
+scenes of evil and despair.  I considered the being whom I had cast
+among mankind, and endowed with the will and power to effect purposes
+of horror, such as the deed which he had now done, nearly in the light
+of my own vampire, my own spirit let loose from the grave, and forced
+to destroy all that was dear to me.
+
+Day dawned; and I directed my steps towards the town.  The gates were
+open, and I hastened to my father's house.  My first thought was to
+discover what I knew of the murderer, and cause instant pursuit to be
+made.  But I paused when I reflected on the story that I had to tell. A
+being whom I myself had formed, and endued with life, had met me at
+midnight among the precipices of an inaccessible mountain.  I
+remembered also the nervous fever with which I had been seized just at
+the time that I dated my creation, and which would give an air of
+delirium to a tale otherwise so utterly improbable.  I well knew that
+if any other had communicated such a relation to me, I should have
+looked upon it as the ravings of insanity.  Besides, the strange nature
+of the animal would elude all pursuit, even if I were so far credited
+as to persuade my relatives to commence it.  And then of what use would
+be pursuit?  Who could arrest a creature capable of scaling the
+overhanging sides of Mont Saleve?  These reflections determined me, and
+I resolved to remain silent.
+
+It was about five in the morning when I entered my father's house.  I
+told the servants not to disturb the family, and went into the library
+to attend their usual hour of rising.
+
+Six years had elapsed, passed in a dream but for one indelible trace,
+and I stood in the same place where I had last embraced my father
+before my departure for Ingolstadt.  Beloved and venerable parent!  He
+still remained to me.  I gazed on the picture of my mother, which stood
+over the mantel-piece.  It was an historical subject, painted at my
+father's desire, and represented Caroline Beaufort in an agony of
+despair, kneeling by the coffin of her dead father.  Her garb was
+rustic, and her cheek pale; but there was an air of dignity and beauty,
+that hardly permitted the sentiment of pity.  Below this picture was a
+miniature of William; and my tears flowed when I looked upon it.  While
+I was thus engaged, Ernest entered:  he had heard me arrive, and
+hastened to welcome me:  "Welcome, my dearest Victor," said he.  "Ah! I
+wish you had come three months ago, and then you would have found us
+all joyous and delighted.  You come to us now to share a misery which
+nothing can alleviate; yet your presence will, I hope, revive our
+father, who seems sinking under his misfortune; and your persuasions
+will induce poor Elizabeth to cease her vain and tormenting
+self-accusations.--Poor William! he was our darling and our pride!"
+
+Tears, unrestrained, fell from my brother's eyes; a sense of mortal
+agony crept over my frame.  Before, I had only imagined the
+wretchedness of my desolated home; the reality came on me as a new, and
+a not less terrible, disaster.  I tried to calm Ernest; I enquired more
+minutely concerning my father, and here I named my cousin.
+
+"She most of all," said Ernest, "requires consolation; she accused
+herself of having caused the death of my brother, and that made her
+very wretched.  But since the murderer has been discovered--"
+
+"The murderer discovered!  Good God! how can that be? who could attempt
+to pursue him?  It is impossible; one might as well try to overtake the
+winds, or confine a mountain-stream with a straw.  I saw him too; he
+was free last night!"
+
+"I do not know what you mean," replied my brother, in accents of
+wonder, "but to us the discovery we have made completes our misery.  No
+one would believe it at first; and even now Elizabeth will not be
+convinced, notwithstanding all the evidence.  Indeed, who would credit
+that Justine Moritz, who was so amiable, and fond of all the family,
+could suddenly become so capable of so frightful, so appalling a crime?"
+
+"Justine Moritz!  Poor, poor girl, is she the accused?  But it is
+wrongfully; every one knows that; no one believes it, surely, Ernest?"
+
+"No one did at first; but several circumstances came out, that have
+almost forced conviction upon us; and her own behaviour has been so
+confused, as to add to the evidence of facts a weight that, I fear,
+leaves no hope for doubt.  But she will be tried today, and you will
+then hear all."
+
+He then related that, the morning on which the murder of poor William
+had been discovered, Justine had been taken ill, and confined to her
+bed for several days.  During this interval, one of the servants,
+happening to examine the apparel she had worn on the night of the
+murder, had discovered in her pocket the picture of my mother, which
+had been judged to be the temptation of the murderer.  The servant
+instantly showed it to one of the others, who, without saying a word to
+any of the family, went to a magistrate; and, upon their deposition,
+Justine was apprehended.  On being charged with the fact, the poor girl
+confirmed the suspicion in a great measure by her extreme confusion of
+manner.
+
+This was a strange tale, but it did not shake my faith; and I replied
+earnestly, "You are all mistaken; I know the murderer.  Justine, poor,
+good Justine, is innocent."
+
+At that instant my father entered.  I saw unhappiness deeply impressed
+on his countenance, but he endeavoured to welcome me cheerfully; and,
+after we had exchanged our mournful greeting, would have introduced
+some other topic than that of our disaster, had not Ernest exclaimed,
+"Good God, papa!  Victor says that he knows who was the murderer of
+poor William."
+
+"We do also, unfortunately," replied my father, "for indeed I had
+rather have been for ever ignorant than have discovered so much
+depravity and ungratitude in one I valued so highly."
+
+"My dear father, you are mistaken; Justine is innocent."
+
+"If she is, God forbid that she should suffer as guilty.  She is to be
+tried today, and I hope, I sincerely hope, that she will be acquitted."
+
+This speech calmed me.  I was firmly convinced in my own mind that
+Justine, and indeed every human being, was guiltless of this murder.  I
+had no fear, therefore, that any circumstantial evidence could be
+brought forward strong enough to convict her.  My tale was not one to
+announce publicly; its astounding horror would be looked upon as
+madness by the vulgar.  Did any one indeed exist, except I, the
+creator, who would believe, unless his senses convinced him, in the
+existence of the living monument of presumption and rash ignorance
+which I had let loose upon the world?
+
+We were soon joined by Elizabeth.  Time had altered her since I last
+beheld her; it had endowed her with loveliness surpassing the beauty of
+her childish years.  There was the same candour, the same vivacity, but
+it was allied to an expression more full of sensibility and intellect.
+She welcomed me with the greatest affection.  "Your arrival, my dear
+cousin," said she, "fills me with hope.  You perhaps will find some
+means to justify my poor guiltless Justine.  Alas! who is safe, if she
+be convicted of crime?  I rely on her innocence as certainly as I do
+upon my own.  Our misfortune is doubly hard to us; we have not only
+lost that lovely darling boy, but this poor girl, whom I sincerely
+love, is to be torn away by even a worse fate.  If she is condemned, I
+never shall know joy more.  But she will not, I am sure she will not;
+and then I shall be happy again, even after the sad death of my little
+William."
+
+"She is innocent, my Elizabeth," said I, "and that shall be proved;
+fear nothing, but let your spirits be cheered by the assurance of her
+acquittal."
+
+"How kind and generous you are! every one else believes in her guilt,
+and that made me wretched, for I knew that it was impossible:  and to
+see every one else prejudiced in so deadly a manner rendered me
+hopeless and despairing."  She wept.
+
+"Dearest niece," said my father, "dry your tears.  If she is, as you
+believe, innocent, rely on the justice of our laws, and the activity
+with which I shall prevent the slightest shadow of partiality."
+
+
+
+Chapter 8
+
+We passed a few sad hours until eleven o'clock, when the trial was to
+commence.  My father and the rest of the family being obliged to attend
+as witnesses, I accompanied them to the court.  During the whole of
+this wretched mockery of justice I suffered living torture.  It was to
+be decided whether the result of my curiosity and lawless devices would
+cause the death of two of my fellow beings:  one a smiling babe full of
+innocence and joy, the other far more dreadfully murdered, with every
+aggravation of infamy that could make the murder memorable in horror.
+Justine also was a girl of merit and possessed qualities which promised
+to render her life happy; now all was to be obliterated in an
+ignominious grave, and I the cause!  A thousand times rather would I
+have confessed myself guilty of the crime ascribed to Justine, but I
+was absent when it was committed, and such a declaration would have
+been considered as the ravings of a madman and would not have
+exculpated her who suffered through me.
+
+The appearance of Justine was calm.  She was dressed in mourning, and
+her countenance, always engaging, was rendered, by the solemnity of her
+feelings, exquisitely beautiful.  Yet she appeared confident in
+innocence and did not tremble, although gazed on and execrated by
+thousands, for all the kindness which her beauty might otherwise have
+excited was obliterated in the minds of the spectators by the
+imagination of the enormity she was supposed to have committed.  She
+was tranquil, yet her tranquillity was evidently constrained; and as
+her confusion had before been adduced as a proof of her guilt, she
+worked up her mind to an appearance of courage.  When she entered the
+court she threw her eyes round it and quickly discovered where we were
+seated.  A tear seemed to dim her eye when she saw us, but she quickly
+recovered herself, and a look of sorrowful affection seemed to attest
+her utter guiltlessness.
+
+The trial began, and after the advocate against her had stated the
+charge, several witnesses were called.  Several strange facts combined
+against her, which might have staggered anyone who had not such proof
+of her innocence as I had.  She had been out the whole of the night on
+which the murder had been committed and towards morning had been
+perceived by a market-woman not far from the spot where the body of the
+murdered child had been afterwards found.  The woman asked her what she
+did there, but she looked very strangely and only returned a confused
+and unintelligible answer.  She returned to the house about eight
+o'clock, and when one inquired where she had passed the night, she
+replied that she had been looking for the child and demanded earnestly
+if anything had been heard concerning him.  When shown the body, she
+fell into violent hysterics and kept her bed for several days.  The
+picture was then produced which the servant had found in her pocket;
+and when Elizabeth, in a faltering voice, proved that it was the same
+which, an hour before the child had been missed, she had placed round
+his neck, a murmur of horror and indignation filled the court.
+
+Justine was called on for her defence.  As the trial had proceeded, her
+countenance had altered.  Surprise, horror, and misery were strongly
+expressed.  Sometimes she struggled with her tears, but when she was
+desired to plead, she collected her powers and spoke in an audible
+although variable voice.
+
+"God knows," she said, "how entirely I am innocent.  But I do not
+pretend that my protestations should acquit me; I rest my innocence on
+a plain and simple explanation of the facts which have been adduced
+against me, and I hope the character I have always borne will incline
+my judges to a favourable interpretation where any circumstance appears
+doubtful or suspicious."
+
+She then related that, by the permission of Elizabeth, she had passed
+the evening of the night on which the murder had been committed at the
+house of an aunt at Chene, a village situated at about a league from
+Geneva.  On her return, at about nine o'clock, she met a man who asked
+her if she had seen anything of the child who was lost.  She was
+alarmed by this account and passed several hours in looking for him,
+when the gates of Geneva were shut, and she was forced to remain
+several hours of the night in a barn belonging to a cottage, being
+unwilling to call up the inhabitants, to whom she was well known.  Most
+of the night she spent here watching; towards morning she believed that
+she slept for a few minutes; some steps disturbed her, and she awoke.
+It was dawn, and she quitted her asylum, that she might again endeavour
+to find my brother.  If she had gone near the spot where his body lay,
+it was without her knowledge.  That she had been bewildered when
+questioned by the market-woman was not surprising, since she had passed
+a sleepless night and the fate of poor William was yet uncertain.
+Concerning the picture she could give no account.
+
+"I know," continued the unhappy victim, "how heavily and fatally this
+one circumstance weighs against me, but I have no power of explaining
+it; and when I have expressed my utter ignorance, I am only left to
+conjecture concerning the probabilities by which it might have been
+placed in my pocket.  But here also I am checked.  I believe that I
+have no enemy on earth, and none surely would have been so wicked as to
+destroy me wantonly.  Did the murderer place it there?  I know of no
+opportunity afforded him for so doing; or, if I had, why should he have
+stolen the jewel, to part with it again so soon?
+
+"I commit my cause to the justice of my judges, yet I see no room for
+hope.  I beg permission to have a few witnesses examined concerning my
+character, and if their testimony shall not overweigh my supposed
+guilt, I must be condemned, although I would pledge my salvation on my
+innocence."
+
+Several witnesses were called who had known her for many years, and
+they spoke well of her; but fear and hatred of the crime of which they
+supposed her guilty rendered them timorous and unwilling to come
+forward.  Elizabeth saw even this last resource, her excellent
+dispositions and irreproachable conduct, about to fail the accused,
+when, although violently agitated, she desired permission to address
+the court.
+
+"I am," said she, "the cousin of the unhappy child who was murdered, or
+rather his sister, for I was educated by and have lived with his
+parents ever since and even long before his birth.  It may therefore be
+judged indecent in me to come forward on this occasion, but when I see
+a fellow creature about to perish through the cowardice of her
+pretended friends, I wish to be allowed to speak, that I may say what I
+know of her character.  I am well acquainted with the accused.  I have
+lived in the same house with her, at one time for five and at another
+for nearly two years.  During all that period she appeared to me the
+most amiable and benevolent of human creatures.  She nursed Madame
+Frankenstein, my aunt, in her last illness, with the greatest affection
+and care and afterwards attended her own mother during a tedious
+illness, in a manner that excited the admiration of all who knew her,
+after which she again lived in my uncle's house, where she was beloved
+by all the family.  She was warmly attached to the child who is now
+dead and acted towards him like a most affectionate mother.  For my own
+part, I do not hesitate to say that, notwithstanding all the evidence
+produced against her, I believe and rely on her perfect innocence.  She
+had no temptation for such an action; as to the bauble on which the
+chief proof rests, if she had earnestly desired it, I should have
+willingly given it to her, so much do I esteem and value her."
+
+A murmur of approbation followed Elizabeth's simple and powerful
+appeal, but it was excited by her generous interference, and not in
+favour of poor Justine, on whom the public indignation was turned with
+renewed violence, charging her with the blackest ingratitude.  She
+herself wept as Elizabeth spoke, but she did not answer.  My own
+agitation and anguish was extreme during the whole trial.  I believed
+in her innocence; I knew it.  Could the demon who had (I did not for a
+minute doubt) murdered my brother also in his hellish sport have
+betrayed the innocent to death and ignominy?  I could not sustain the
+horror of my situation, and when I perceived that the popular voice and
+the countenances of the judges had already condemned my unhappy victim,
+I rushed out of the court in agony.  The tortures of the accused did
+not equal mine; she was sustained by innocence, but the fangs of
+remorse tore my bosom and would not forgo their hold.
+
+I passed a night of unmingled wretchedness.  In the morning I went to
+the court; my lips and throat were parched.  I dared not ask the fatal
+question, but I was known, and the officer guessed the cause of my
+visit.  The ballots had been thrown; they were all black, and Justine
+was condemned.
+
+I cannot pretend to describe what I then felt.  I had before
+experienced sensations of horror, and I have endeavoured to bestow upon
+them adequate expressions, but words cannot convey an idea of the
+heart-sickening despair that I then endured.  The person to whom I
+addressed myself added that Justine had already confessed her guilt.
+"That evidence," he observed, "was hardly required in so glaring a
+case, but I am glad of it, and, indeed, none of our judges like to
+condemn a criminal upon circumstantial evidence, be it ever so
+decisive."
+
+This was strange and unexpected intelligence; what could it mean?  Had
+my eyes deceived me?  And was I really as mad as the whole world would
+believe me to be if I disclosed the object of my suspicions?  I
+hastened to return home, and Elizabeth eagerly demanded the result.
+
+"My cousin," replied I, "it is decided as you may have expected; all
+judges had rather that ten innocent should suffer than that one guilty
+should escape.  But she has confessed."
+
+This was a dire blow to poor Elizabeth, who had relied with firmness
+upon Justine's innocence.  "Alas!" said she.  "How shall I ever again
+believe in human goodness?  Justine, whom I loved and esteemed as my
+sister, how could she put on those smiles of innocence only to betray?
+Her mild eyes seemed incapable of any severity or guile, and yet she
+has committed a murder."
+
+Soon after we heard that the poor victim had expressed a desire to see
+my cousin.  My father wished her not to go but said that he left it to
+her own judgment and feelings to decide.  "Yes," said Elizabeth, "I
+will go, although she is guilty; and you, Victor, shall accompany me; I
+cannot go alone."  The idea of this visit was torture to me, yet I
+could not refuse.  We entered the gloomy prison chamber and beheld
+Justine sitting on some straw at the farther end; her hands were
+manacled, and her head rested on her knees.  She rose on seeing us
+enter, and when we were left alone with her, she threw herself at the
+feet of Elizabeth, weeping bitterly.  My cousin wept also.
+
+"Oh, Justine!" said she.  "Why did you rob me of my last consolation?
+I relied on your innocence, and although I was then very wretched, I
+was not so miserable as I am now."
+
+"And do you also believe that I am so very, very wicked?  Do you also
+join with my enemies to crush me, to condemn me as a murderer?" Her
+voice was suffocated with sobs.
+
+"Rise, my poor girl," said Elizabeth; "why do you kneel, if you are
+innocent?  I am not one of your enemies, I believed you guiltless,
+notwithstanding every evidence, until I heard that you had yourself
+declared your guilt.  That report, you say, is false; and be assured,
+dear Justine, that nothing can shake my confidence in you for a moment,
+but your own confession."
+
+"I did confess, but I confessed a lie.  I confessed, that I might
+obtain absolution; but now that falsehood lies heavier at my heart than
+all my other sins.  The God of heaven forgive me!  Ever since I was
+condemned, my confessor has besieged me; he threatened and menaced,
+until I almost began to think that I was the monster that he said I
+was.  He threatened excommunication and hell fire in my last moments if
+I continued obdurate.  Dear lady, I had none to support me; all looked
+on me as a wretch doomed to ignominy and perdition.  What could I do?
+In an evil hour I subscribed to a lie; and now only am I truly
+miserable."
+
+She paused, weeping, and then continued, "I thought with horror, my
+sweet lady, that you should believe your Justine, whom your blessed
+aunt had so highly honoured, and whom you loved, was a creature capable
+of a crime which none but the devil himself could have perpetrated.
+Dear William! dearest blessed child!  I soon shall see you again in
+heaven, where we shall all be happy; and that consoles me, going as I
+am to suffer ignominy and death."
+
+"Oh, Justine!  Forgive me for having for one moment distrusted you.
+Why did you confess?  But do not mourn, dear girl.  Do not fear.  I
+will proclaim, I will prove your innocence.  I will melt the stony
+hearts of your enemies by my tears and prayers.  You shall not die!
+You, my playfellow, my companion, my sister, perish on the scaffold!
+No!  No!  I never could survive so horrible a misfortune."
+
+Justine shook her head mournfully.  "I do not fear to die," she said;
+"that pang is past.  God raises my weakness and gives me courage to
+endure the worst.  I leave a sad and bitter world; and if you remember
+me and think of me as of one unjustly condemned, I am resigned to the
+fate awaiting me.  Learn from me, dear lady, to submit in patience to
+the will of heaven!"
+
+During this conversation I had retired to a corner of the prison room,
+where I could conceal the horrid anguish that possessed me.  Despair!
+Who dared talk of that?  The poor victim, who on the morrow was to pass
+the awful boundary between life and death, felt not, as I did, such
+deep and bitter agony.  I gnashed my teeth and ground them together,
+uttering a groan that came from my inmost soul.  Justine started.  When
+she saw who it was, she approached me and said, "Dear sir, you are very
+kind to visit me; you, I hope, do not believe that I am guilty?"
+
+I could not answer.  "No, Justine," said Elizabeth; "he is more
+convinced of your innocence than I was, for even when he heard that you
+had confessed, he did not credit it."
+
+"I truly thank him.  In these last moments I feel the sincerest
+gratitude towards those who think of me with kindness.  How sweet is
+the affection of others to such a wretch as I am!  It removes more than
+half my misfortune, and I feel as if I could die in peace now that my
+innocence is acknowledged by you, dear lady, and your cousin."
+
+Thus the poor sufferer tried to comfort others and herself.  She indeed
+gained the resignation she desired.  But I, the true murderer, felt the
+never-dying worm alive in my bosom, which allowed of no hope or
+consolation.  Elizabeth also wept and was unhappy, but hers also was
+the misery of innocence, which, like a cloud that passes over the fair
+moon, for a while hides but cannot tarnish its brightness.  Anguish and
+despair had penetrated into the core of my heart; I bore a hell within
+me which nothing could extinguish.  We stayed several hours with
+Justine, and it was with great difficulty that Elizabeth could tear
+herself away.  "I wish," cried she, "that I were to die with you; I
+cannot live in this world of misery."
+
+Justine assumed an air of cheerfulness, while she with difficulty
+repressed her bitter tears.  She embraced Elizabeth and said in a voice
+of half-suppressed emotion, "Farewell, sweet lady, dearest Elizabeth,
+my beloved and only friend; may heaven, in its bounty, bless and
+preserve you; may this be the last misfortune that you will ever
+suffer!  Live, and be happy, and make others so."
+
+And on the morrow Justine died.  Elizabeth's heart-rending eloquence
+failed to move the judges from their settled conviction in the
+criminality of the saintly sufferer.  My passionate and indignant
+appeals were lost upon them.  And when I received their cold answers
+and heard the harsh, unfeeling reasoning of these men, my purposed
+avowal died away on my lips.  Thus I might proclaim myself a madman,
+but not revoke the sentence passed upon my wretched victim.  She
+perished on the scaffold as a murderess!
+
+From the tortures of my own heart, I turned to contemplate the deep and
+voiceless grief of my Elizabeth.  This also was my doing!  And my
+father's woe, and the desolation of that late so smiling home all was
+the work of my thrice-accursed hands!  Ye weep, unhappy ones, but these
+are not your last tears!  Again shall you raise the funeral wail, and
+the sound of your lamentations shall again and again be heard!
+Frankenstein, your son, your kinsman, your early, much-loved friend; he
+who would spend each vital drop of blood for your sakes, who has no
+thought nor sense of joy except as it is mirrored also in your dear
+countenances, who would fill the air with blessings and spend his life
+in serving you--he bids you weep, to shed countless tears; happy beyond
+his hopes, if thus inexorable fate be satisfied, and if the destruction
+pause before the peace of the grave have succeeded to your sad torments!
+
+Thus spoke my prophetic soul, as, torn by remorse, horror, and despair,
+I beheld those I loved spend vain sorrow upon the graves of William and
+Justine, the first hapless victims to my unhallowed arts.
+
+
+
+Chapter 9
+
+Nothing is more painful to the human mind than, after the feelings have
+been worked up by a quick succession of events, the dead calmness of
+inaction and certainty which follows and deprives the soul both of hope
+and fear.  Justine died, she rested, and I was alive.  The blood flowed
+freely in my veins, but a weight of despair and remorse pressed on my
+heart which nothing could remove.  Sleep fled from my eyes; I wandered
+like an evil spirit, for I had committed deeds of mischief beyond
+description horrible, and more, much more (I persuaded myself) was yet
+behind.  Yet my heart overflowed with kindness and the love of virtue.
+I had begun life with benevolent intentions and thirsted for the moment
+when I should put them in practice and make myself useful to my fellow
+beings.  Now all was blasted; instead of that serenity of conscience
+which allowed me to look back upon the past with self-satisfaction, and
+from thence to gather promise of new hopes, I was seized by remorse and
+the sense of guilt, which hurried me away to a hell of intense tortures
+such as no language can describe.
+
+This state of mind preyed upon my health, which had perhaps never
+entirely recovered from the first shock it had sustained.  I shunned
+the face of man; all sound of joy or complacency was torture to me;
+solitude was my only consolation--deep, dark, deathlike solitude.
+
+My father observed with pain the alteration perceptible in my
+disposition and habits and endeavoured by arguments deduced from the
+feelings of his serene conscience and guiltless life to inspire me with
+fortitude and awaken in me the courage to dispel the dark cloud which
+brooded over me.  "Do you think, Victor," said he, "that I do not
+suffer also?  No one could love a child more than I loved your
+brother"--tears came into his eyes as he spoke--"but is it not a duty
+to the survivors that we should refrain from augmenting their
+unhappiness by an appearance of immoderate grief?  It is also a duty
+owed to yourself, for excessive sorrow prevents improvement or
+enjoyment, or even the discharge of daily usefulness, without which no
+man is fit for society."
+
+This advice, although good, was totally inapplicable to my case; I
+should have been the first to hide my grief and console my friends if
+remorse had not mingled its bitterness, and terror its alarm, with my
+other sensations.  Now I could only answer my father with a look of
+despair and endeavour to hide myself from his view.
+
+About this time we retired to our house at Belrive.  This change was
+particularly agreeable to me.  The shutting of the gates regularly at
+ten o'clock and the impossibility of remaining on the lake after that
+hour had rendered our residence within the walls of Geneva very irksome
+to me.  I was now free.  Often, after the rest of the family had
+retired for the night, I took the boat and passed many hours upon the
+water.  Sometimes, with my sails set, I was carried by the wind; and
+sometimes, after rowing into the middle of the lake, I left the boat to
+pursue its own course and gave way to my own miserable reflections.  I
+was often tempted, when all was at peace around me, and I the only
+unquiet thing that wandered restless in a scene so beautiful and
+heavenly--if I except some bat, or the frogs, whose harsh and
+interrupted croaking was heard only when I approached the shore--often,
+I say, I was tempted to plunge into the silent lake, that the waters
+might close over me and my calamities forever.  But I was restrained,
+when I thought of the heroic and suffering Elizabeth, whom I tenderly
+loved, and whose existence was bound up in mine.  I thought also of my
+father and surviving brother; should I by my base desertion leave them
+exposed and unprotected to the malice of the fiend whom I had let loose
+among them?
+
+At these moments I wept bitterly and wished that peace would revisit my
+mind only that I might afford them consolation and happiness.  But that
+could not be.  Remorse extinguished every hope.  I had been the author
+of unalterable evils, and I lived in daily fear lest the monster whom I
+had created should perpetrate some new wickedness.  I had an obscure
+feeling that all was not over and that he would still commit some
+signal crime, which by its enormity should almost efface the
+recollection of the past.  There was always scope for fear so long as
+anything I loved remained behind.  My abhorrence of this fiend cannot
+be conceived.  When I thought of him I gnashed my teeth, my eyes became
+inflamed, and I ardently wished to extinguish that life which I had so
+thoughtlessly bestowed.  When I reflected on his crimes and malice, my
+hatred and revenge burst all bounds of moderation.  I would have made a
+pilgrimage to the highest peak of the Andes, could I when there have
+precipitated him to their base.  I wished to see him again, that I
+might wreak the utmost extent of abhorrence on his head and avenge the
+deaths of William and Justine.  Our house was the house of mourning. My
+father's health was deeply shaken by the horror of the recent events.
+Elizabeth was sad and desponding; she no longer took delight in her
+ordinary occupations; all pleasure seemed to her sacrilege toward the
+dead; eternal woe and tears she then thought was the just tribute she
+should pay to innocence so blasted and destroyed.  She was no longer
+that happy creature who in earlier youth wandered with me on the banks
+of the lake and talked with ecstasy of our future prospects.  The first
+of those sorrows which are sent to wean us from the earth had visited
+her, and its dimming influence quenched her dearest smiles.
+
+"When I reflect, my dear cousin," said she, "on the miserable death of
+Justine Moritz, I no longer see the world and its works as they before
+appeared to me.  Before, I looked upon the accounts of vice and
+injustice that I read in books or heard from others as tales of ancient
+days or imaginary evils; at least they were remote and more familiar to
+reason than to the imagination; but now misery has come home, and men
+appear to me as monsters thirsting for each other's blood.  Yet I am
+certainly unjust.  Everybody believed that poor girl to be guilty; and
+if she could have committed the crime for which she suffered, assuredly
+she would have been the most depraved of human creatures.  For the sake
+of a few jewels, to have murdered the son of her benefactor and friend,
+a child whom she had nursed from its birth, and appeared to love as if
+it had been her own!  I could not consent to the death of any human
+being, but certainly I should have thought such a creature unfit to
+remain in the society of men.  But she was innocent.  I know, I feel
+she was innocent; you are of the same opinion, and that confirms me.
+Alas!  Victor, when falsehood can look so like the truth, who can
+assure themselves of certain happiness?  I feel as if I were walking on
+the edge of a precipice, towards which thousands are crowding and
+endeavouring to plunge me into the abyss.  William and Justine were
+assassinated, and the murderer escapes; he walks about the world free,
+and perhaps respected.  But even if I were condemned to suffer on the
+scaffold for the same crimes, I would not change places with such a
+wretch."
+
+I listened to this discourse with the extremest agony.  I, not in deed,
+but in effect, was the true murderer.  Elizabeth read my anguish in my
+countenance, and kindly taking my hand, said, "My dearest friend, you
+must calm yourself.  These events have affected me, God knows how
+deeply; but I am not so wretched as you are.  There is an expression of
+despair, and sometimes of revenge, in your countenance that makes me
+tremble.  Dear Victor, banish these dark passions.  Remember the
+friends around you, who centre all their hopes in you.  Have we lost
+the power of rendering you happy?  Ah!  While we love, while we are
+true to each other, here in this land of peace and beauty, your native
+country, we may reap every tranquil blessing--what can disturb our
+peace?"
+
+And could not such words from her whom I fondly prized before every
+other gift of fortune suffice to chase away the fiend that lurked in my
+heart?  Even as she spoke I drew near to her, as if in terror, lest at
+that very moment the destroyer had been near to rob me of her.
+
+Thus not the tenderness of friendship, nor the beauty of earth, nor of
+heaven, could redeem my soul from woe; the very accents of love were
+ineffectual.  I was encompassed by a cloud which no beneficial
+influence could penetrate.  The wounded deer dragging its fainting
+limbs to some untrodden brake, there to gaze upon the arrow which had
+pierced it, and to die, was but a type of me.
+
+Sometimes I could cope with the sullen despair that overwhelmed me, but
+sometimes the whirlwind passions of my soul drove me to seek, by bodily
+exercise and by change of place, some relief from my intolerable
+sensations.  It was during an access of this kind that I suddenly left
+my home, and bending my steps towards the near Alpine valleys, sought
+in the magnificence, the eternity of such scenes, to forget myself and
+my ephemeral, because human, sorrows.  My wanderings were directed
+towards the valley of Chamounix.  I had visited it frequently during my
+boyhood.  Six years had passed since then:  _I_ was a wreck, but nought
+had changed in those savage and enduring scenes.
+
+I performed the first part of my journey on horseback.  I afterwards
+hired a mule, as the more sure-footed and least liable to receive
+injury on these rugged roads.  The weather was fine; it was about the
+middle of the month of August, nearly two months after the death of
+Justine, that miserable epoch from which I dated all my woe.  The
+weight upon my spirit was sensibly lightened as I plunged yet deeper in
+the ravine of Arve.  The immense mountains and precipices that overhung
+me on every side, the sound of the river raging among the rocks, and
+the dashing of the waterfalls around spoke of a power mighty as
+Omnipotence--and I ceased to fear or to bend before any being less
+almighty than that which had created and ruled the elements, here
+displayed in their most terrific guise.  Still, as I ascended higher,
+the valley assumed a more magnificent and astonishing character.
+Ruined castles hanging on the precipices of piny mountains, the
+impetuous Arve, and cottages every here and there peeping forth from
+among the trees formed a scene of singular beauty.  But it was
+augmented and rendered sublime by the mighty Alps, whose white and
+shining pyramids and domes towered above all, as belonging to another
+earth, the habitations of another race of beings.
+
+I passed the bridge of Pelissier, where the ravine, which the river
+forms, opened before me, and I began to ascend the mountain that
+overhangs it.  Soon after, I entered the valley of Chamounix.  This
+valley is more wonderful and sublime, but not so beautiful and
+picturesque as that of Servox, through which I had just passed.  The
+high and snowy mountains were its immediate boundaries, but I saw no
+more ruined castles and fertile fields.  Immense glaciers approached
+the road; I heard the rumbling thunder of the falling avalanche and
+marked the smoke of its passage.  Mont Blanc, the supreme and
+magnificent Mont Blanc, raised itself from the surrounding aiguilles,
+and its tremendous dome overlooked the valley.
+
+A tingling long-lost sense of pleasure often came across me during this
+journey.  Some turn in the road, some new object suddenly perceived and
+recognized, reminded me of days gone by, and were associated with the
+lighthearted gaiety of boyhood.  The very winds whispered in soothing
+accents, and maternal Nature bade me weep no more.  Then again the
+kindly influence ceased to act--I found myself fettered again to grief
+and indulging in all the misery of reflection.  Then I spurred on my
+animal, striving so to forget the world, my fears, and more than all,
+myself--or, in a more desperate fashion, I alighted and threw myself on
+the grass, weighed down by horror and despair.
+
+At length I arrived at the village of Chamounix.  Exhaustion succeeded
+to the extreme fatigue both of body and of mind which I had endured.
+For a short space of time I remained at the window watching the pallid
+lightnings that played above Mont Blanc and listening to the rushing of
+the Arve, which pursued its noisy way beneath.  The same lulling sounds
+acted as a lullaby to my too keen sensations; when I placed my head
+upon my pillow, sleep crept over me; I felt it as it came and blessed
+the giver of oblivion.
+
+
+
+Chapter 10
+
+I spent the following day roaming through the valley.  I stood beside
+the sources of the Arveiron, which take their rise in a glacier, that
+with slow pace is advancing down from the summit of the hills to
+barricade the valley.  The abrupt sides of vast mountains were before
+me; the icy wall of the glacier overhung me; a few shattered pines were
+scattered around; and the solemn silence of this glorious
+presence-chamber of imperial nature was broken only by the brawling
+waves or the fall of some vast fragment, the thunder sound of the
+avalanche or the cracking, reverberated along the mountains, of the
+accumulated ice, which, through the silent working of immutable laws,
+was ever and anon rent and torn, as if it had been but a plaything in
+their hands.  These sublime and magnificent scenes afforded me the
+greatest consolation that I was capable of receiving.  They elevated me
+from all littleness of feeling, and although they did not remove my
+grief, they subdued and tranquillized it.  In some degree, also, they
+diverted my mind from the thoughts over which it had brooded for the
+last month.  I retired to rest at night; my slumbers, as it were,
+waited on and ministered to by the assemblance of grand shapes which I
+had contemplated during the day.  They congregated round me; the
+unstained snowy mountain-top, the glittering pinnacle, the pine woods,
+and ragged bare ravine, the eagle, soaring amidst the clouds--they all
+gathered round me and bade me be at peace.
+
+Where had they fled when the next morning I awoke?  All of
+soul-inspiriting fled with sleep, and dark melancholy clouded every
+thought.  The rain was pouring in torrents, and thick mists hid the
+summits of the mountains, so that I even saw not the faces of those
+mighty friends.  Still I would penetrate their misty veil and seek them
+in their cloudy retreats.  What were rain and storm to me?  My mule was
+brought to the door, and I resolved to ascend to the summit of
+Montanvert.  I remembered the effect that the view of the tremendous
+and ever-moving glacier had produced upon my mind when I first saw it.
+It had then filled me with a sublime ecstasy that gave wings to the
+soul and allowed it to soar from the obscure world to light and joy.
+The sight of the awful and majestic in nature had indeed always the
+effect of solemnizing my mind and causing me to forget the passing
+cares of life.  I determined to go without a guide, for I was well
+acquainted with the path, and the presence of another would destroy the
+solitary grandeur of the scene.
+
+The ascent is precipitous, but the path is cut into continual and short
+windings, which enable you to surmount the perpendicularity of the
+mountain.  It is a scene terrifically desolate.  In a thousand spots
+the traces of the winter avalanche may be perceived, where trees lie
+broken and strewed on the ground, some entirely destroyed, others bent,
+leaning upon the jutting rocks of the mountain or transversely upon
+other trees.  The path, as you ascend higher, is intersected by ravines
+of snow, down which stones continually roll from above; one of them is
+particularly dangerous, as the slightest sound, such as even speaking
+in a loud voice, produces a concussion of air sufficient to draw
+destruction upon the head of the speaker.  The pines are not tall or
+luxuriant, but they are sombre and add an air of severity to the scene.
+I looked on the valley beneath; vast mists were rising from the rivers
+which ran through it and curling in thick wreaths around the opposite
+mountains, whose summits were hid in the uniform clouds, while rain
+poured from the dark sky and added to the melancholy impression I
+received from the objects around me.  Alas!  Why does man boast of
+sensibilities superior to those apparent in the brute; it only renders
+them more necessary beings.  If our impulses were confined to hunger,
+thirst, and desire, we might be nearly free; but now we are moved by
+every wind that blows and a chance word or scene that that word may
+convey to us.
+
+
+  We rest; a dream has power to poison sleep.
+   We rise; one wand'ring thought pollutes the day.
+  We feel, conceive, or reason; laugh or weep,
+   Embrace fond woe, or cast our cares away;
+  It is the same:  for, be it joy or sorrow,
+   The path of its departure still is free.
+  Man's yesterday may ne'er be like his morrow;
+   Nought may endure but mutability!
+
+
+It was nearly noon when I arrived at the top of the ascent.  For some
+time I sat upon the rock that overlooks the sea of ice.  A mist covered
+both that and the surrounding mountains.  Presently a breeze dissipated
+the cloud, and I descended upon the glacier.  The surface is very
+uneven, rising like the waves of a troubled sea, descending low, and
+interspersed by rifts that sink deep.  The field of ice is almost a
+league in width, but I spent nearly two hours in crossing it.  The
+opposite mountain is a bare perpendicular rock.  From the side where I
+now stood Montanvert was exactly opposite, at the distance of a league;
+and above it rose Mont Blanc, in awful majesty.  I remained in a recess
+of the rock, gazing on this wonderful and stupendous scene.  The sea,
+or rather the vast river of ice, wound among its dependent mountains,
+whose aerial summits hung over its recesses.  Their icy and glittering
+peaks shone in the sunlight over the clouds.  My heart, which was
+before sorrowful, now swelled with something like joy; I exclaimed,
+"Wandering spirits, if indeed ye wander, and do not rest in your narrow
+beds, allow me this faint happiness, or take me, as your companion,
+away from the joys of life."
+
+As I said this I suddenly beheld the figure of a man, at some distance,
+advancing towards me with superhuman speed.  He bounded over the
+crevices in the ice, among which I had walked with caution; his
+stature, also, as he approached, seemed to exceed that of man.  I was
+troubled; a mist came over my eyes, and I felt a faintness seize me,
+but I was quickly restored by the cold gale of the mountains.  I
+perceived, as the shape came nearer (sight tremendous and abhorred!)
+that it was the wretch whom I had created.  I trembled with rage and
+horror, resolving to wait his approach and then close with him in
+mortal combat.  He approached; his countenance bespoke bitter anguish,
+combined with disdain and malignity, while its unearthly ugliness
+rendered it almost too horrible for human eyes.  But I scarcely
+observed this; rage and hatred had at first deprived me of utterance,
+and I recovered only to overwhelm him with words expressive of furious
+detestation and contempt.
+
+"Devil," I exclaimed, "do you dare approach me?  And do not you fear
+the fierce vengeance of my arm wreaked on your miserable head?  Begone,
+vile insect!  Or rather, stay, that I may trample you to dust!  And,
+oh!  That I could, with the extinction of your miserable existence,
+restore those victims whom you have so diabolically murdered!"
+
+"I expected this reception," said the daemon.  "All men hate the
+wretched; how, then, must I be hated, who am miserable beyond all
+living things!  Yet you, my creator, detest and spurn me, thy creature,
+to whom thou art bound by ties only dissoluble by the annihilation of
+one of us.  You purpose to kill me.  How dare you sport thus with life?
+Do your duty towards me, and I will do mine towards you and the rest of
+mankind.  If you will comply with my conditions, I will leave them and
+you at peace; but if you refuse, I will glut the maw of death, until it
+be satiated with the blood of your remaining friends."
+
+"Abhorred monster!  Fiend that thou art!  The tortures of hell are too
+mild a vengeance for thy crimes.  Wretched devil!  You reproach me with
+your creation, come on, then, that I may extinguish the spark which I
+so negligently bestowed."
+
+My rage was without bounds; I sprang on him, impelled by all the
+feelings which can arm one being against the existence of another.
+
+He easily eluded me and said,
+
+"Be calm!  I entreat you to hear me before you give vent to your hatred
+on my devoted head.  Have I not suffered enough, that you seek to
+increase my misery?  Life, although it may only be an accumulation of
+anguish, is dear to me, and I will defend it.  Remember, thou hast made
+me more powerful than thyself; my height is superior to thine, my
+joints more supple.  But I will not be tempted to set myself in
+opposition to thee.  I am thy creature, and I will be even mild and
+docile to my natural lord and king if thou wilt also perform thy part,
+the which thou owest me.  Oh, Frankenstein, be not equitable to every
+other and trample upon me alone, to whom thy justice, and even thy
+clemency and affection, is most due.  Remember that I am thy creature;
+I ought to be thy Adam, but I am rather the fallen angel, whom thou
+drivest from joy for no misdeed.  Everywhere I see bliss, from which I
+alone am irrevocably excluded.  I was benevolent and good; misery made
+me a fiend.  Make me happy, and I shall again be virtuous."
+
+"Begone!  I will not hear you.  There can be no community between you
+and me; we are enemies.  Begone, or let us try our strength in a fight,
+in which one must fall."
+
+"How can I move thee?  Will no entreaties cause thee to turn a
+favourable eye upon thy creature, who implores thy goodness and
+compassion?  Believe me, Frankenstein, I was benevolent; my soul glowed
+with love and humanity; but am I not alone, miserably alone?  You, my
+creator, abhor me; what hope can I gather from your fellow creatures,
+who owe me nothing?  They spurn and hate me.  The desert mountains and
+dreary glaciers are my refuge.  I have wandered here many days; the
+caves of ice, which I only do not fear, are a dwelling to me, and the
+only one which man does not grudge.  These bleak skies I hail, for they
+are kinder to me than your fellow beings.  If the multitude of mankind
+knew of my existence, they would do as you do, and arm themselves for
+my destruction.  Shall I not then hate them who abhor me?  I will keep
+no terms with my enemies.  I am miserable, and they shall share my
+wretchedness.  Yet it is in your power to recompense me, and deliver
+them from an evil which it only remains for you to make so great, that
+not only you and your family, but thousands of others, shall be
+swallowed up in the whirlwinds of its rage.  Let your compassion be
+moved, and do not disdain me.  Listen to my tale; when you have heard
+that, abandon or commiserate me, as you shall judge that I deserve.
+But hear me.  The guilty are allowed, by human laws, bloody as they
+are, to speak in their own defence before they are condemned.  Listen
+to me, Frankenstein.  You accuse me of murder, and yet you would, with
+a satisfied conscience, destroy your own creature.  Oh, praise the
+eternal justice of man!  Yet I ask you not to spare me; listen to me,
+and then, if you can, and if you will, destroy the work of your hands."
+
+"Why do you call to my remembrance," I rejoined, "circumstances of
+which I shudder to reflect, that I have been the miserable origin and
+author?  Cursed be the day, abhorred devil, in which you first saw
+light!  Cursed (although I curse myself) be the hands that formed you!
+You have made me wretched beyond expression.  You have left me no power
+to consider whether I am just to you or not.  Begone!  Relieve me from
+the sight of your detested form."
+
+"Thus I relieve thee, my creator," he said, and placed his hated hands
+before my eyes, which I flung from me with violence; "thus I take from
+thee a sight which you abhor.  Still thou canst listen to me and grant
+me thy compassion.  By the virtues that I once possessed, I demand this
+from you.  Hear my tale; it is long and strange, and the temperature of
+this place is not fitting to your fine sensations; come to the hut upon
+the mountain.  The sun is yet high in the heavens; before it descends
+to hide itself behind your snowy precipices and illuminate another
+world, you will have heard my story and can decide.  On you it rests,
+whether I quit forever the neighbourhood of man and lead a harmless
+life, or become the scourge of your fellow creatures and the author of
+your own speedy ruin."
+
+As he said this he led the way across the ice; I followed.  My heart
+was full, and I did not answer him, but as I proceeded, I weighed the
+various arguments that he had used and determined at least to listen to
+his tale.  I was partly urged by curiosity, and compassion confirmed my
+resolution.  I had hitherto supposed him to be the murderer of my
+brother, and I eagerly sought a confirmation or denial of this opinion.
+For the first time, also, I felt what the duties of a creator towards
+his creature were, and that I ought to render him happy before I
+complained of his wickedness.  These motives urged me to comply with
+his demand.  We crossed the ice, therefore, and ascended the opposite
+rock.  The air was cold, and the rain again began to descend; we
+entered the hut, the fiend with an air of exultation, I with a heavy
+heart and depressed spirits.  But I consented to listen, and seating
+myself by the fire which my odious companion had lighted, he thus began
+his tale.
+
+
+
+Chapter 11
+
+"It is with considerable difficulty that I remember the original era of
+my being; all the events of that period appear confused and indistinct.
+A strange multiplicity of sensations seized me, and I saw, felt, heard,
+and smelt at the same time; and it was, indeed, a long time before I
+learned to distinguish between the operations of my various senses.  By
+degrees, I remember, a stronger light pressed upon my nerves, so that I
+was obliged to shut my eyes.  Darkness then came over me and troubled
+me, but hardly had I felt this when, by opening my eyes, as I now
+suppose, the light poured in upon me again.  I walked and, I believe,
+descended, but I presently found a great alteration in my sensations.
+Before, dark and opaque bodies had surrounded me, impervious to my
+touch or sight; but I now found that I could wander on at liberty, with
+no obstacles which I could not either surmount or avoid.  The light
+became more and more oppressive to me, and the heat wearying me as I
+walked, I sought a place where I could receive shade.  This was the
+forest near Ingolstadt; and here I lay by the side of a brook resting
+from my fatigue, until I felt tormented by hunger and thirst.  This
+roused me from my nearly dormant state, and I ate some berries which I
+found hanging on the trees or lying on the ground.  I slaked my thirst
+at the brook, and then lying down, was overcome by sleep.
+
+"It was dark when I awoke; I felt cold also, and half frightened, as it
+were, instinctively, finding myself so desolate.  Before I had quitted
+your apartment, on a sensation of cold, I had covered myself with some
+clothes, but these were insufficient to secure me from the dews of
+night.  I was a poor, helpless, miserable wretch; I knew, and could
+distinguish, nothing; but feeling pain invade me on all sides, I sat
+down and wept.
+
+"Soon a gentle light stole over the heavens and gave me a sensation of
+pleasure.  I started up and beheld a radiant form rise from among the
+trees.  [The moon]  I gazed with a kind of wonder.  It moved slowly,
+but it enlightened my path, and I again went out in search of berries.
+I was still cold when under one of the trees I found a huge cloak, with
+which I covered myself, and sat down upon the ground.  No distinct
+ideas occupied my mind; all was confused.  I felt light, and hunger,
+and thirst, and darkness; innumerable sounds rang in my ears, and on
+all sides various scents saluted me; the only object that I could
+distinguish was the bright moon, and I fixed my eyes on that with
+pleasure.
+
+"Several changes of day and night passed, and the orb of night had
+greatly lessened, when I began to distinguish my sensations from each
+other.  I gradually saw plainly the clear stream that supplied me with
+drink and the trees that shaded me with their foliage.  I was delighted
+when I first discovered that a pleasant sound, which often saluted my
+ears, proceeded from the throats of the little winged animals who had
+often intercepted the light from my eyes.  I began also to observe,
+with greater accuracy, the forms that surrounded me and to perceive the
+boundaries of the radiant roof of light which canopied me.  Sometimes I
+tried to imitate the pleasant songs of the birds but was unable.
+Sometimes I wished to express my sensations in my own mode, but the
+uncouth and inarticulate sounds which broke from me frightened me into
+silence again.
+
+"The moon had disappeared from the night, and again, with a lessened
+form, showed itself, while I still remained in the forest.  My
+sensations had by this time become distinct, and my mind received every
+day additional ideas.  My eyes became accustomed to the light and to
+perceive objects in their right forms; I distinguished the insect from
+the herb, and by degrees, one herb from another.  I found that the
+sparrow uttered none but harsh notes, whilst those of the blackbird and
+thrush were sweet and enticing.
+
+"One day, when I was oppressed by cold, I found a fire which had been
+left by some wandering beggars, and was overcome with delight at the
+warmth I experienced from it.  In my joy I thrust my hand into the live
+embers, but quickly drew it out again with a cry of pain.  How strange,
+I thought, that the same cause should produce such opposite effects!  I
+examined the materials of the fire, and to my joy found it to be
+composed of wood.  I quickly collected some branches, but they were wet
+and would not burn.  I was pained at this and sat still watching the
+operation of the fire.  The wet wood which I had placed near the heat
+dried and itself became inflamed.  I reflected on this, and by touching
+the various branches, I discovered the cause and busied myself in
+collecting a great quantity of wood, that I might dry it and have a
+plentiful supply of fire.  When night came on and brought sleep with
+it, I was in the greatest fear lest my fire should be extinguished.  I
+covered it carefully with dry wood and leaves and placed wet branches
+upon it; and then, spreading my cloak, I lay on the ground and sank
+into sleep.
+
+"It was morning when I awoke, and my first care was to visit the fire.
+I uncovered it, and a gentle breeze quickly fanned it into a flame.  I
+observed this also and contrived a fan of branches, which roused the
+embers when they were nearly extinguished.  When night came again I
+found, with pleasure, that the fire gave light as well as heat and that
+the discovery of this element was useful to me in my food, for I found
+some of the offals that the travellers had left had been roasted, and
+tasted much more savoury than the berries I gathered from the trees.  I
+tried, therefore, to dress my food in the same manner, placing it on
+the live embers.  I found that the berries were spoiled by this
+operation, and the nuts and roots much improved.
+
+"Food, however, became scarce, and I often spent the whole day
+searching in vain for a few acorns to assuage the pangs of hunger. When
+I found this, I resolved to quit the place that I had hitherto
+inhabited, to seek for one where the few wants I experienced would be
+more easily satisfied.  In this emigration I exceedingly lamented the
+loss of the fire which I had obtained through accident and knew not how
+to reproduce it.  I gave several hours to the serious consideration of
+this difficulty, but I was obliged to relinquish all attempt to supply
+it, and wrapping myself up in my cloak, I struck across the wood
+towards the setting sun.  I passed three days in these rambles and at
+length discovered the open country.  A great fall of snow had taken
+place the night before, and the fields were of one uniform white; the
+appearance was disconsolate, and I found my feet chilled by the cold
+damp substance that covered the ground.
+
+"It was about seven in the morning, and I longed to obtain food and
+shelter; at length I perceived a small hut, on a rising ground, which
+had doubtless been built for the convenience of some shepherd.  This
+was a new sight to me, and I examined the structure with great
+curiosity.  Finding the door open, I entered.  An old man sat in it,
+near a fire, over which he was preparing his breakfast.  He turned on
+hearing a noise, and perceiving me, shrieked loudly, and quitting the
+hut, ran across the fields with a speed of which his debilitated form
+hardly appeared capable.  His appearance, different from any I had ever
+before seen, and his flight somewhat surprised me.  But I was enchanted
+by the appearance of the hut; here the snow and rain could not
+penetrate; the ground was dry; and it presented to me then as exquisite
+and divine a retreat as Pandemonium appeared to the demons of hell
+after their sufferings in the lake of fire.  I greedily devoured the
+remnants of the shepherd's breakfast, which consisted of bread, cheese,
+milk, and wine; the latter, however, I did not like.  Then, overcome by
+fatigue, I lay down among some straw and fell asleep.
+
+"It was noon when I awoke, and allured by the warmth of the sun, which
+shone brightly on the white ground, I determined to recommence my
+travels; and, depositing the remains of the peasant's breakfast in a
+wallet I found, I proceeded across the fields for several hours, until
+at sunset I arrived at a village.  How miraculous did this appear!  The
+huts, the neater cottages, and stately houses engaged my admiration by
+turns.  The vegetables in the gardens, the milk and cheese that I saw
+placed at the windows of some of the cottages, allured my appetite. One
+of the best of these I entered, but I had hardly placed my foot within
+the door before the children shrieked, and one of the women fainted.
+The whole village was roused; some fled, some attacked me, until,
+grievously bruised by stones and many other kinds of missile weapons, I
+escaped to the open country and fearfully took refuge in a low hovel,
+quite bare, and making a wretched appearance after the palaces I had
+beheld in the village.  This hovel however, joined a cottage of a neat
+and pleasant appearance, but after my late dearly bought experience, I
+dared not enter it.  My place of refuge was constructed of wood, but so
+low that I could with difficulty sit upright in it.  No wood, however,
+was placed on the earth, which formed the floor, but it was dry; and
+although the wind entered it by innumerable chinks, I found it an
+agreeable asylum from the snow and rain.
+
+"Here, then, I retreated and lay down happy to have found a shelter,
+however miserable, from the inclemency of the season, and still more
+from the barbarity of man.  As soon as morning dawned I crept from my
+kennel, that I might view the adjacent cottage and discover if I could
+remain in the habitation I had found.  It was situated against the back
+of the cottage and surrounded on the sides which were exposed by a pig
+sty and a clear pool of water.  One part was open, and by that I had
+crept in; but now I covered every crevice by which I might be perceived
+with stones and wood, yet in such a manner that I might move them on
+occasion to pass out; all the light I enjoyed came through the sty, and
+that was sufficient for me.
+
+"Having thus arranged my dwelling and carpeted it with clean straw, I
+retired, for I saw the figure of a man at a distance, and I remembered
+too well my treatment the night before to trust myself in his power.  I
+had first, however, provided for my sustenance for that day by a loaf
+of coarse bread, which I purloined, and a cup with which I could drink
+more conveniently than from my hand of the pure water which flowed by
+my retreat.  The floor was a little raised, so that it was kept
+perfectly dry, and by its vicinity to the chimney of the cottage it was
+tolerably warm.
+
+"Being thus provided, I resolved to reside in this hovel until
+something should occur which might alter my determination.  It was
+indeed a paradise compared to the bleak forest, my former residence,
+the rain-dropping branches, and dank earth.  I ate my breakfast with
+pleasure and was about to remove a plank to procure myself a little
+water when I heard a step, and looking through a small chink, I beheld
+a young creature, with a pail on her head, passing before my hovel. The
+girl was young and of gentle demeanour, unlike what I have since found
+cottagers and farmhouse servants to be.  Yet she was meanly dressed, a
+coarse blue petticoat and a linen jacket being her only garb; her fair
+hair was plaited but not adorned:  she looked patient yet sad.  I lost
+sight of her, and in about a quarter of an hour she returned bearing
+the pail, which was now partly filled with milk.  As she walked along,
+seemingly incommoded by the burden, a young man met her, whose
+countenance expressed a deeper despondence.  Uttering a few sounds with
+an air of melancholy, he took the pail from her head and bore it to the
+cottage himself.  She followed, and they disappeared.  Presently I saw
+the young man again, with some tools in his hand, cross the field
+behind the cottage; and the girl was also busied, sometimes in the
+house and sometimes in the yard.
+
+"On examining my dwelling, I found that one of the windows of the
+cottage had formerly occupied a part of it, but the panes had been
+filled up with wood. In one of these was a small and almost
+imperceptible chink through which the eye could just penetrate.
+Through this crevice a small room was visible, whitewashed and clean
+but very bare of furniture. In one corner, near a small fire, sat an
+old man, leaning his head on his hands in a disconsolate attitude. The
+young girl was occupied in arranging the cottage; but presently she
+took something out of a drawer, which employed her hands, and she sat
+down beside the old man, who, taking up an instrument, began to play
+and to produce sounds sweeter than the voice of the thrush or the
+nightingale. It was a lovely sight, even to me, poor wretch who had
+never beheld aught beautiful before. The silver hair and benevolent
+countenance of the aged cottager won my reverence, while the gentle
+manners of the girl enticed my love. He played a sweet mournful air
+which I perceived drew tears from the eyes of his amiable companion, of
+which the old man took no notice, until she sobbed audibly; he then
+pronounced a few sounds, and the fair creature, leaving her work, knelt
+at his feet. He raised her and smiled with such kindness and affection
+that I felt sensations of a peculiar and overpowering nature; they were
+a mixture of pain and pleasure, such as I had never before experienced,
+either from hunger or cold, warmth or food; and I withdrew from the
+window, unable to bear these emotions.
+
+"Soon after this the young man returned, bearing on his shoulders a
+load of wood.  The girl met him at the door, helped to relieve him of
+his burden, and taking some of the fuel into the cottage, placed it on
+the fire; then she and the youth went apart into a nook of the cottage,
+and he showed her a large loaf and a piece of cheese.  She seemed
+pleased and went into the garden for some roots and plants, which she
+placed in water, and then upon the fire.  She afterwards continued her
+work, whilst the young man went into the garden and appeared busily
+employed in digging and pulling up roots.  After he had been employed
+thus about an hour, the young woman joined him and they entered the
+cottage together.
+
+"The old man had, in the meantime, been pensive, but on the appearance
+of his companions he assumed a more cheerful air, and they sat down to
+eat.  The meal was quickly dispatched.  The young woman was again
+occupied in arranging the cottage, the old man walked before the
+cottage in the sun for a few minutes, leaning on the arm of the youth.
+Nothing could exceed in beauty the contrast between these two excellent
+creatures.  One was old, with silver hairs and a countenance beaming
+with benevolence and love; the younger was slight and graceful in his
+figure, and his features were moulded with the finest symmetry, yet his
+eyes and attitude expressed the utmost sadness and despondency.  The
+old man returned to the cottage, and the youth, with tools different
+from those he had used in the morning, directed his steps across the
+fields.
+
+"Night quickly shut in, but to my extreme wonder, I found that the
+cottagers had a means of prolonging light by the use of tapers, and was
+delighted to find that the setting of the sun did not put an end to the
+pleasure I experienced in watching my human neighbours.  In the evening
+the young girl and her companion were employed in various occupations
+which I did not understand; and the old man again took up the
+instrument which produced the divine sounds that had enchanted me in
+the morning.  So soon as he had finished, the youth began, not to play,
+but to utter sounds that were monotonous, and neither resembling the
+harmony of the old man's instrument nor the songs of the birds; I since
+found that he read aloud, but at that time I knew nothing of the
+science of words or letters.
+
+"The family, after having been thus occupied for a short time,
+extinguished their lights and retired, as I conjectured, to rest."
+
+
+
+Chapter 12
+
+"I lay on my straw, but I could not sleep.  I thought of the
+occurrences of the day.  What chiefly struck me was the gentle manners
+of these people, and I longed to join them, but dared not.  I
+remembered too well the treatment I had suffered the night before from
+the barbarous villagers, and resolved, whatever course of conduct I
+might hereafter think it right to pursue, that for the present I would
+remain quietly in my hovel, watching and endeavouring to discover the
+motives which influenced their actions.
+
+"The cottagers arose the next morning before the sun.  The young woman
+arranged the cottage and prepared the food, and the youth departed
+after the first meal.
+
+"This day was passed in the same routine as that which preceded it.
+The young man was constantly employed out of doors, and the girl in
+various laborious occupations within.  The old man, whom I soon
+perceived to be blind, employed his leisure hours on his instrument or
+in contemplation.  Nothing could exceed the love and respect which the
+younger cottagers exhibited towards their venerable companion.  They
+performed towards him every little office of affection and duty with
+gentleness, and he rewarded them by his benevolent smiles.
+
+"They were not entirely happy.  The young man and his companion often
+went apart and appeared to weep.  I saw no cause for their unhappiness,
+but I was deeply affected by it.  If such lovely creatures were
+miserable, it was less strange that I, an imperfect and solitary being,
+should be wretched.  Yet why were these gentle beings unhappy?  They
+possessed a delightful house (for such it was in my eyes) and every
+luxury; they had a fire to warm them when chill and delicious viands
+when hungry; they were dressed in excellent clothes; and, still more,
+they enjoyed one another's company and speech, interchanging each day
+looks of affection and kindness.  What did their tears imply?  Did they
+really express pain?  I was at first unable to solve these questions,
+but perpetual attention and time explained to me many appearances which
+were at first enigmatic.
+
+"A considerable period elapsed before I discovered one of the causes of
+the uneasiness of this amiable family:  it was poverty, and they
+suffered that evil in a very distressing degree.  Their nourishment
+consisted entirely of the vegetables of their garden and the milk of
+one cow, which gave very little during the winter, when its masters
+could scarcely procure food to support it.  They often, I believe,
+suffered the pangs of hunger very poignantly, especially the two
+younger cottagers, for several times they placed food before the old
+man when they reserved none for themselves.
+
+"This trait of kindness moved me sensibly.  I had been accustomed,
+during the night, to steal a part of their store for my own
+consumption, but when I found that in doing this I inflicted pain on
+the cottagers, I abstained and satisfied myself with berries, nuts, and
+roots which I gathered from a neighbouring wood.
+
+"I discovered also another means through which I was enabled to assist
+their labours.  I found that the youth spent a great part of each day
+in collecting wood for the family fire, and during the night I often
+took his tools, the use of which I quickly discovered, and brought home
+firing sufficient for the consumption of several days.
+
+"I remember, the first time that I did this, the young woman, when she
+opened the door in the morning, appeared greatly astonished on seeing a
+great pile of wood on the outside.  She uttered some words in a loud
+voice, and the youth joined her, who also expressed surprise.  I
+observed, with pleasure, that he did not go to the forest that day, but
+spent it in repairing the cottage and cultivating the garden.
+
+"By degrees I made a discovery of still greater moment.  I found that
+these people possessed a method of communicating their experience and
+feelings to one another by articulate sounds.  I perceived that the
+words they spoke sometimes produced pleasure or pain, smiles or
+sadness, in the minds and countenances of the hearers.  This was indeed
+a godlike science, and I ardently desired to become acquainted with it.
+But I was baffled in every attempt I made for this purpose.  Their
+pronunciation was quick, and the words they uttered, not having any
+apparent connection with visible objects, I was unable to discover any
+clue by which I could unravel the mystery of their reference.  By great
+application, however, and after having remained during the space of
+several revolutions of the moon in my hovel, I discovered the names
+that were given to some of the most familiar objects of discourse; I
+learned and applied the words, 'fire,' 'milk,' 'bread,' and 'wood.'  I
+learned also the names of the cottagers themselves.  The youth and his
+companion had each of them several names, but the old man had only one,
+which was 'father.' The girl was called 'sister' or 'Agatha,' and the
+youth 'Felix,' 'brother,' or 'son.'  I cannot describe the delight I
+felt when I learned the ideas appropriated to each of these sounds and
+was able to pronounce them.  I distinguished several other words
+without being able as yet to understand or apply them, such as 'good,'
+'dearest,' 'unhappy.'
+
+"I spent the winter in this manner.  The gentle manners and beauty of
+the cottagers greatly endeared them to me; when they were unhappy, I
+felt depressed; when they rejoiced, I sympathized in their joys.  I saw
+few human beings besides them, and if any other happened to enter the
+cottage, their harsh manners and rude gait only enhanced to me the
+superior accomplishments of my friends.  The old man, I could perceive,
+often endeavoured to encourage his children, as sometimes I found that
+he called them, to cast off their melancholy.  He would talk in a
+cheerful accent, with an expression of goodness that bestowed pleasure
+even upon me.  Agatha listened with respect, her eyes sometimes filled
+with tears, which she endeavoured to wipe away unperceived; but I
+generally found that her countenance and tone were more cheerful after
+having listened to the exhortations of her father.  It was not thus
+with Felix.  He was always the saddest of the group, and even to my
+unpractised senses, he appeared to have suffered more deeply than his
+friends.  But if his countenance was more sorrowful, his voice was more
+cheerful than that of his sister, especially when he addressed the old
+man.
+
+"I could mention innumerable instances which, although slight, marked
+the dispositions of these amiable cottagers.  In the midst of poverty
+and want, Felix carried with pleasure to his sister the first little
+white flower that peeped out from beneath the snowy ground.  Early in
+the morning, before she had risen, he cleared away the snow that
+obstructed her path to the milk-house, drew water from the well, and
+brought the wood from the outhouse, where, to his perpetual
+astonishment, he found his store always replenished by an invisible
+hand.  In the day, I believe, he worked sometimes for a neighbouring
+farmer, because he often went forth and did not return until dinner,
+yet brought no wood with him.  At other times he worked in the garden,
+but as there was little to do in the frosty season, he read to the old
+man and Agatha.
+
+"This reading had puzzled me extremely at first, but by degrees I
+discovered that he uttered many of the same sounds when he read as when
+he talked.  I conjectured, therefore, that he found on the paper signs
+for speech which he understood, and I ardently longed to comprehend
+these also; but how was that possible when I did not even understand
+the sounds for which they stood as signs?  I improved, however,
+sensibly in this science, but not sufficiently to follow up any kind of
+conversation, although I applied my whole mind to the endeavour, for I
+easily perceived that, although I eagerly longed to discover myself to
+the cottagers, I ought not to make the attempt until I had first become
+master of their language, which knowledge might enable me to make them
+overlook the deformity of my figure, for with this also the contrast
+perpetually presented to my eyes had made me acquainted.
+
+"I had admired the perfect forms of my cottagers--their grace, beauty,
+and delicate complexions; but how was I terrified when I viewed myself
+in a transparent pool!  At first I started back, unable to believe that
+it was indeed I who was reflected in the mirror; and when I became
+fully convinced that I was in reality the monster that I am, I was
+filled with the bitterest sensations of despondence and mortification.
+Alas!  I did not yet entirely know the fatal effects of this miserable
+deformity.
+
+"As the sun became warmer and the light of day longer, the snow
+vanished, and I beheld the bare trees and the black earth.  From this
+time Felix was more employed, and the heart-moving indications of
+impending famine disappeared.  Their food, as I afterwards found, was
+coarse, but it was wholesome; and they procured a sufficiency of it.
+Several new kinds of plants sprang up in the garden, which they
+dressed; and these signs of comfort increased daily as the season
+advanced.
+
+"The old man, leaning on his son, walked each day at noon, when it did
+not rain, as I found it was called when the heavens poured forth its
+waters.  This frequently took place, but a high wind quickly dried the
+earth, and the season became far more pleasant than it had been.
+
+"My mode of life in my hovel was uniform.  During the morning I
+attended the motions of the cottagers, and when they were dispersed in
+various occupations, I slept; the remainder of the day was spent in
+observing my friends.  When they had retired to rest, if there was any
+moon or the night was star-light, I went into the woods and collected
+my own food and fuel for the cottage.  When I returned, as often as it
+was necessary, I cleared their path from the snow and performed those
+offices that I had seen done by Felix.  I afterwards found that these
+labours, performed by an invisible hand, greatly astonished them; and
+once or twice I heard them, on these occasions, utter the words 'good
+spirit,' 'wonderful'; but I did not then understand the signification
+of these terms.
+
+"My thoughts now became more active, and I longed to discover the
+motives and feelings of these lovely creatures; I was inquisitive to
+know why Felix appeared so miserable and Agatha so sad.  I thought
+(foolish wretch!) that it might be in my power to restore happiness to
+these deserving people.  When I slept or was absent, the forms of the
+venerable blind father, the gentle Agatha, and the excellent Felix
+flitted before me.  I looked upon them as superior beings who would be
+the arbiters of my future destiny.  I formed in my imagination a
+thousand pictures of presenting myself to them, and their reception of
+me.  I imagined that they would be disgusted, until, by my gentle
+demeanour and conciliating words, I should first win their favour and
+afterwards their love.
+
+"These thoughts exhilarated me and led me to apply with fresh ardour to
+the acquiring the art of language.  My organs were indeed harsh, but
+supple; and although my voice was very unlike the soft music of their
+tones, yet I pronounced such words as I understood with tolerable ease.
+It was as the ass and the lap-dog; yet surely the gentle ass whose
+intentions were affectionate, although his manners were rude, deserved
+better treatment than blows and execration.
+
+"The pleasant showers and genial warmth of spring greatly altered the
+aspect of the earth.  Men who before this change seemed to have been
+hid in caves dispersed themselves and were employed in various arts of
+cultivation.  The birds sang in more cheerful notes, and the leaves
+began to bud forth on the trees.  Happy, happy earth!  Fit habitation
+for gods, which, so short a time before, was bleak, damp, and
+unwholesome.  My spirits were elevated by the enchanting appearance of
+nature; the past was blotted from my memory, the present was tranquil,
+and the future gilded by bright rays of hope and anticipations of joy."
+
+
+
+Chapter 13
+
+"I now hasten to the more moving part of my story.  I shall relate
+events that impressed me with feelings which, from what I had been,
+have made me what I am.
+
+"Spring advanced rapidly; the weather became fine and the skies
+cloudless.  It surprised me that what before was desert and gloomy
+should now bloom with the most beautiful flowers and verdure.  My
+senses were gratified and refreshed by a thousand scents of delight and
+a thousand sights of beauty.
+
+"It was on one of these days, when my cottagers periodically rested
+from labour--the old man played on his guitar, and the children
+listened to him--that I observed the countenance of Felix was
+melancholy beyond expression; he sighed frequently, and once his father
+paused in his music, and I conjectured by his manner that he inquired
+the cause of his son's sorrow.  Felix replied in a cheerful accent, and
+the old man was recommencing his music when someone tapped at the door.
+
+"It was a lady on horseback, accompanied by a country-man as a guide.
+The lady was dressed in a dark suit and covered with a thick black
+veil.  Agatha asked a question, to which the stranger only replied by
+pronouncing, in a sweet accent, the name of Felix.  Her voice was
+musical but unlike that of either of my friends.  On hearing this word,
+Felix came up hastily to the lady, who, when she saw him, threw up her
+veil, and I beheld a countenance of angelic beauty and expression.  Her
+hair of a shining raven black, and curiously braided; her eyes were
+dark, but gentle, although animated; her features of a regular
+proportion, and her complexion wondrously fair, each cheek tinged with
+a lovely pink.
+
+"Felix seemed ravished with delight when he saw her, every trait of
+sorrow vanished from his face, and it instantly expressed a degree of
+ecstatic joy, of which I could hardly have believed it capable; his
+eyes sparkled, as his cheek flushed with pleasure; and at that moment I
+thought him as beautiful as the stranger.  She appeared affected by
+different feelings; wiping a few tears from her lovely eyes, she held
+out her hand to Felix, who kissed it rapturously and called her, as
+well as I could distinguish, his sweet Arabian.  She did not appear to
+understand him, but smiled.  He assisted her to dismount, and
+dismissing her guide, conducted her into the cottage.  Some
+conversation took place between him and his father, and the young
+stranger knelt at the old man's feet and would have kissed his hand,
+but he raised her and embraced her affectionately.
+
+"I soon perceived that although the stranger uttered articulate sounds
+and appeared to have a language of her own, she was neither understood
+by nor herself understood the cottagers.  They made many signs which I
+did not comprehend, but I saw that her presence diffused gladness
+through the cottage, dispelling their sorrow as the sun dissipates the
+morning mists.  Felix seemed peculiarly happy and with smiles of
+delight welcomed his Arabian.  Agatha, the ever-gentle Agatha, kissed
+the hands of the lovely stranger, and pointing to her brother, made
+signs which appeared to me to mean that he had been sorrowful until she
+came.  Some hours passed thus, while they, by their countenances,
+expressed joy, the cause of which I did not comprehend.  Presently I
+found, by the frequent recurrence of some sound which the stranger
+repeated after them, that she was endeavouring to learn their language;
+and the idea instantly occurred to me that I should make use of the
+same instructions to the same end.  The stranger learned about twenty
+words at the first lesson; most of them, indeed, were those which I had
+before understood, but I profited by the others.
+
+"As night came on, Agatha and the Arabian retired early.  When they
+separated Felix kissed the hand of the stranger and said, 'Good night
+sweet Safie.'  He sat up much longer, conversing with his father, and
+by the frequent repetition of her name I conjectured that their lovely
+guest was the subject of their conversation.  I ardently desired to
+understand them, and bent every faculty towards that purpose, but found
+it utterly impossible.
+
+"The next morning Felix went out to his work, and after the usual
+occupations of Agatha were finished, the Arabian sat at the feet of the
+old man, and taking his guitar, played some airs so entrancingly
+beautiful that they at once drew tears of sorrow and delight from my
+eyes.  She sang, and her voice flowed in a rich cadence, swelling or
+dying away like a nightingale of the woods.
+
+"When she had finished, she gave the guitar to Agatha, who at first
+declined it.  She played a simple air, and her voice accompanied it in
+sweet accents, but unlike the wondrous strain of the stranger.  The old
+man appeared enraptured and said some words which Agatha endeavoured to
+explain to Safie, and by which he appeared to wish to express that she
+bestowed on him the greatest delight by her music.
+
+"The days now passed as peaceably as before, with the sole alteration
+that joy had taken place of sadness in the countenances of my friends.
+Safie was always gay and happy; she and I improved rapidly in the
+knowledge of language, so that in two months I began to comprehend most
+of the words uttered by my protectors.
+
+"In the meanwhile also the black ground was covered with herbage, and
+the green banks interspersed with innumerable flowers, sweet to the
+scent and the eyes, stars of pale radiance among the moonlight woods;
+the sun became warmer, the nights clear and balmy; and my nocturnal
+rambles were an extreme pleasure to me, although they were considerably
+shortened by the late setting and early rising of the sun, for I never
+ventured abroad during daylight, fearful of meeting with the same
+treatment I had formerly endured in the first village which I entered.
+
+"My days were spent in close attention, that I might more speedily
+master the language; and I may boast that I improved more rapidly than
+the Arabian, who understood very little and conversed in broken
+accents, whilst I comprehended and could imitate almost every word that
+was spoken.
+
+"While I improved in speech, I also learned the science of letters as
+it was taught to the stranger, and this opened before me a wide field
+for wonder and delight.
+
+"The book from which Felix instructed Safie was Volney's Ruins of
+Empires.  I should not have understood the purport of this book had not
+Felix, in reading it, given very minute explanations.  He had chosen
+this work, he said, because the declamatory style was framed in
+imitation of the Eastern authors.  Through this work I obtained a
+cursory knowledge of history and a view of the several empires at
+present existing in the world; it gave me an insight into the manners,
+governments, and religions of the different nations of the earth.  I
+heard of the slothful Asiatics, of the stupendous genius and mental
+activity of the Grecians, of the wars and wonderful virtue of the early
+Romans--of their subsequent degenerating--of the decline of that mighty
+empire, of chivalry, Christianity, and kings.  I heard of the discovery
+of the American hemisphere and wept with Safie over the hapless fate of
+its original inhabitants.
+
+"These wonderful narrations inspired me with strange feelings.  Was
+man, indeed, at once so powerful, so virtuous and magnificent, yet so
+vicious and base?  He appeared at one time a mere scion of the evil
+principle and at another as all that can be conceived of noble and
+godlike.  To be a great and virtuous man appeared the highest honour
+that can befall a sensitive being; to be base and vicious, as many on
+record have been, appeared the lowest degradation, a condition more
+abject than that of the blind mole or harmless worm.  For a long time I
+could not conceive how one man could go forth to murder his fellow, or
+even why there were laws and governments; but when I heard details of
+vice and bloodshed, my wonder ceased and I turned away with disgust and
+loathing.
+
+"Every conversation of the cottagers now opened new wonders to me.
+While I listened to the instructions which Felix bestowed upon the
+Arabian, the strange system of human society was explained to me.  I
+heard of the division of property, of immense wealth and squalid
+poverty, of rank, descent, and noble blood.
+
+"The words induced me to turn towards myself.  I learned that the
+possessions most esteemed by your fellow creatures were high and
+unsullied descent united with riches.  A man might be respected with
+only one of these advantages, but without either he was considered,
+except in very rare instances, as a vagabond and a slave, doomed to
+waste his powers for the profits of the chosen few!  And what was I? Of
+my creation and creator I was absolutely ignorant, but I knew that I
+possessed no money, no friends, no kind of property.  I was, besides,
+endued with a figure hideously deformed and loathsome; I was not even
+of the same nature as man.  I was more agile than they and could
+subsist upon coarser diet; I bore the extremes of heat and cold with
+less injury to my frame; my stature far exceeded theirs.  When I looked
+around I saw and heard of none like me.  Was I, then, a monster, a blot
+upon the earth, from which all men fled and whom all men disowned?
+
+"I cannot describe to you the agony that these reflections inflicted
+upon me; I tried to dispel them, but sorrow only increased with
+knowledge.  Oh, that I had forever remained in my native wood, nor
+known nor felt beyond the sensations of hunger, thirst, and heat!
+
+"Of what a strange nature is knowledge!  It clings to the mind when it
+has once seized on it like a lichen on the rock.  I wished sometimes to
+shake off all thought and feeling, but I learned that there was but one
+means to overcome the sensation of pain, and that was death--a state
+which I feared yet did not understand.  I admired virtue and good
+feelings and loved the gentle manners and amiable qualities of my
+cottagers, but I was shut out from intercourse with them, except
+through means which I obtained by stealth, when I was unseen and
+unknown, and which rather increased than satisfied the desire I had of
+becoming one among my fellows.  The gentle words of Agatha and  the
+animated smiles of the charming Arabian were not for me.  The mild
+exhortations of the old man and the lively conversation of the loved
+Felix were not for me. Miserable, unhappy wretch!
+
+"Other lessons were impressed upon me even more deeply.  I heard of the
+difference of sexes, and the birth and growth of children, how the
+father doted on the smiles of the infant, and the lively sallies of the
+older child, how all the life and cares of the mother were wrapped up
+in the precious charge, how the mind of youth expanded and gained
+knowledge, of brother, sister, and all the various relationships which
+bind one human being to another in mutual bonds.
+
+"But where were my friends and relations?  No father had watched my
+infant days, no mother had blessed me with smiles and caresses; or if
+they had, all my past life was now a blot, a blind vacancy in which I
+distinguished nothing.  From my earliest remembrance I had been as I
+then was in height and proportion.  I had never yet seen a being
+resembling me or who claimed any intercourse with me.  What was I?  The
+question again recurred, to be answered only with groans.
+
+"I will soon explain to what these feelings tended, but allow me now to
+return to the cottagers, whose story excited in me such various
+feelings of indignation, delight, and wonder, but which all terminated
+in additional love and reverence for my protectors (for so I loved, in
+an innocent, half-painful self-deceit, to call them)."
+
+
+
+Chapter 14
+
+"Some time elapsed before I learned the history of my friends.  It was
+one which could not fail to impress itself deeply on my mind, unfolding
+as it did a number of circumstances, each interesting and wonderful to
+one so utterly inexperienced as I was.
+
+"The name of the old man was De Lacey.  He was descended from a good
+family in France, where he had lived for many years in affluence,
+respected by his superiors and beloved by his equals.  His son was bred
+in the service of his country, and Agatha had ranked with ladies of the
+highest distinction.  A few months before my arrival they had lived in
+a large and luxurious city called Paris, surrounded by friends and
+possessed of every enjoyment which virtue, refinement of intellect, or
+taste, accompanied by a moderate fortune, could afford.
+
+"The father of Safie had been the cause of their ruin.  He was a
+Turkish merchant and had inhabited Paris for many years, when, for some
+reason which I could not learn, he became obnoxious to the government.
+He was seized and cast into prison the very day that Safie arrived from
+Constantinople to join him.  He was tried and condemned to death.  The
+injustice of his sentence was very flagrant; all Paris was indignant;
+and it was judged that his religion and wealth rather than the crime
+alleged against him had been the cause of his condemnation.
+
+"Felix had accidentally been present at the trial; his horror and
+indignation were uncontrollable when he heard the decision of the
+court.  He made, at that moment, a solemn vow to deliver him and then
+looked around for the means.  After many fruitless attempts to gain
+admittance to the prison, he found a strongly grated window in an
+unguarded part of the building, which lighted the dungeon of the
+unfortunate Muhammadan, who, loaded with chains, waited in despair the
+execution of the barbarous sentence.  Felix visited the grate at night
+and made known to the prisoner his intentions in his favour.  The Turk,
+amazed and delighted, endeavoured to kindle the zeal of his deliverer
+by promises of reward and wealth.  Felix rejected his offers with
+contempt, yet when he saw the lovely Safie, who was allowed to visit
+her father and who by her gestures expressed her lively gratitude, the
+youth could not help owning to his own mind that the captive possessed
+a treasure which would fully reward his toil and hazard.
+
+"The Turk quickly perceived the impression that his daughter had made
+on the heart of Felix and endeavoured to secure him more entirely in
+his interests by the promise of her hand in marriage so soon as he
+should be conveyed to a place of safety.  Felix was too delicate to
+accept this offer, yet he looked forward to the probability of the
+event as to the consummation of his happiness.
+
+"During the ensuing days, while the preparations were going forward for
+the escape of the merchant, the zeal of Felix was warmed by several
+letters that he received from this lovely girl, who found means to
+express her thoughts in the language of her lover by the aid of an old
+man, a servant of her father who understood French.  She thanked him in
+the most ardent terms for his intended services towards her parent, and
+at the same time she gently deplored her own fate.
+
+"I have copies of these letters, for I found means, during my residence
+in the hovel, to procure the implements of writing; and the letters
+were often in the hands of Felix or Agatha.  Before I depart I will
+give them to you; they will prove the truth of my tale; but at present,
+as the sun is already far declined, I shall only have time to repeat
+the substance of them to you.
+
+"Safie related that her mother was a Christian Arab, seized and made a
+slave by the Turks; recommended by her beauty, she had won the heart of
+the father of Safie, who married her.  The young girl spoke in high and
+enthusiastic terms of her mother, who, born in freedom, spurned the
+bondage to which she was now reduced.  She instructed her daughter in
+the tenets of her religion and taught her to aspire to higher powers of
+intellect and an independence of spirit forbidden to the female
+followers of Muhammad.  This lady died, but her lessons were indelibly
+impressed on the mind of Safie, who sickened at the prospect of again
+returning to Asia and being immured within the walls of a harem,
+allowed only to occupy herself with infantile amusements, ill-suited to
+the temper of her soul, now accustomed to grand ideas and a noble
+emulation for virtue.  The prospect of marrying a Christian and
+remaining in a country where women were allowed to take a rank in
+society was enchanting to her.
+
+"The day for the execution of the Turk was fixed, but on the night
+previous to it he quitted his prison and before morning was distant
+many leagues from Paris.  Felix had procured passports in the name of
+his father, sister, and himself.  He had previously communicated his
+plan to the former, who aided the deceit by quitting his house, under
+the pretence of a journey and concealed himself, with his daughter, in
+an obscure part of Paris.
+
+"Felix conducted the fugitives through France to Lyons and across Mont
+Cenis to Leghorn, where the merchant had decided to wait a favourable
+opportunity of passing into some part of the Turkish dominions.
+
+"Safie resolved to remain with her father until the moment of his
+departure, before which time the Turk renewed his promise that she
+should be united to his deliverer; and Felix remained with them in
+expectation of that event; and in the meantime he enjoyed the society
+of the Arabian, who exhibited towards him the simplest and tenderest
+affection.  They conversed with one another through the means of an
+interpreter, and sometimes with the interpretation of looks; and Safie
+sang to him the divine airs of her native country.
+
+"The Turk allowed this intimacy to take place and encouraged the hopes
+of the youthful lovers, while in his heart he had formed far other
+plans.  He loathed the idea that his daughter should be united to a
+Christian, but he feared the resentment of Felix if he should appear
+lukewarm, for he knew that he was still in the power of his deliverer
+if he should choose to betray him to the Italian state which they
+inhabited.  He revolved a thousand plans by which he should be enabled
+to prolong the deceit until it might be no longer necessary, and
+secretly to take his daughter with him when he departed.  His plans
+were facilitated by the news which arrived from Paris.
+
+"The government of France were greatly enraged at the escape of their
+victim and spared no pains to detect and punish his deliverer.  The
+plot of Felix was quickly discovered, and De Lacey and Agatha were
+thrown into prison.  The news reached Felix and roused him from his
+dream of pleasure.  His blind and aged father and his gentle sister lay
+in a noisome dungeon while he enjoyed the free air and the society of
+her whom he loved.  This idea was torture to him.  He quickly arranged
+with the Turk that if the latter should find a favourable opportunity
+for escape before Felix could return to Italy, Safie should remain as a
+boarder at a convent at Leghorn; and then, quitting the lovely Arabian,
+he hastened to Paris and delivered himself up to the vengeance of the
+law, hoping to free De Lacey and Agatha by this proceeding.
+
+"He did not succeed.  They remained confined for five months before the
+trial took place, the result of which deprived them of their fortune
+and condemned them to a perpetual exile from their native country.
+
+"They found a miserable asylum in the cottage in Germany, where I
+discovered them.  Felix soon learned that the treacherous Turk, for
+whom he and his family endured such unheard-of oppression, on
+discovering that his deliverer was thus reduced to poverty and ruin,
+became a traitor to good feeling and honour and had quitted Italy with
+his daughter, insultingly sending Felix a pittance of money to aid him,
+as he said, in some plan of future maintenance.
+
+"Such were the events that preyed on the heart of Felix and rendered
+him, when I first saw him, the most miserable of his family.  He could
+have endured poverty, and while this distress had been the meed of his
+virtue, he gloried in it; but the ingratitude of the Turk and the loss
+of his beloved Safie were misfortunes more bitter and irreparable.  The
+arrival of the Arabian now infused new life into his soul.
+
+"When the news reached Leghorn that Felix was deprived of his wealth
+and rank, the merchant commanded his daughter to think no more of her
+lover, but to prepare to return to her native country.  The generous
+nature of Safie was outraged by this command; she attempted to
+expostulate with her father, but he left her angrily, reiterating his
+tyrannical mandate.
+
+"A few days after, the Turk entered his daughter's apartment and told
+her hastily that he had reason to believe that his residence at Leghorn
+had been divulged and that he should speedily be delivered up to the
+French government; he had consequently hired a vessel to convey him to
+Constantinople, for which city he should sail in a few hours.  He
+intended to leave his daughter under the care of a confidential
+servant, to follow at her leisure with the greater part of his
+property, which had not yet arrived at Leghorn.
+
+"When alone, Safie resolved in her own mind the plan of conduct that it
+would become her to pursue in this emergency.  A residence in Turkey
+was abhorrent to her; her religion and her feelings were alike averse
+to it.  By some papers of her father which fell into her hands she
+heard of the exile of her lover and learnt the name of the spot where
+he then resided.  She hesitated some time, but at length she formed her
+determination.  Taking with her some jewels that belonged to her and a
+sum of money, she quitted Italy with an attendant, a native of Leghorn,
+but who understood the common language of Turkey, and departed for
+Germany.
+
+"She arrived in safety at a town about twenty leagues from the cottage
+of De Lacey, when her attendant fell dangerously ill.  Safie nursed her
+with the most devoted affection, but the poor girl died, and the
+Arabian was left alone, unacquainted with the language of the country
+and utterly ignorant of the customs of the world.  She fell, however,
+into good hands.  The Italian had mentioned the name of the spot for
+which they were bound, and after her death the woman of the house in
+which they had lived took care that Safie should arrive in safety at
+the cottage of her lover."
+
+
+
+Chapter 15
+
+"Such was the history of my beloved cottagers.  It impressed me deeply.
+I learned, from the views of social life which it developed, to admire
+their virtues and to deprecate the vices of mankind.
+
+"As yet I looked upon crime as a distant evil, benevolence and
+generosity were ever present before me, inciting within me a desire to
+become an actor in the busy scene where so many admirable qualities
+were called forth and displayed.  But in giving an account of the
+progress of my intellect, I must not omit a circumstance which occurred
+in the beginning of the month of August of the same year.
+
+"One night during my accustomed visit to the neighbouring wood where I
+collected my own food and brought home firing for my protectors, I
+found on the ground a leathern portmanteau containing several articles
+of dress and some books.  I eagerly seized the prize and returned with
+it to my hovel.  Fortunately the books were written in the language,
+the elements of which I had acquired at the cottage; they consisted of
+Paradise Lost, a volume of Plutarch's Lives, and the Sorrows of Werter.
+The possession of these treasures gave me extreme delight; I now
+continually studied and exercised my mind upon these histories, whilst
+my friends were employed in their ordinary occupations.
+
+"I can hardly describe to you the effect of these books.  They produced
+in me an infinity of new images and feelings, that sometimes raised me
+to ecstasy, but more frequently sunk me into the lowest dejection.  In
+the Sorrows of Werter, besides the interest of its simple and affecting
+story, so many opinions are canvassed and so many lights thrown upon
+what had hitherto been to me obscure subjects that I found in it a
+never-ending source of speculation and astonishment.  The gentle and
+domestic manners it described, combined with lofty sentiments and
+feelings, which had for their object something out of self, accorded
+well with my experience among my protectors and with the wants which
+were forever alive in my own bosom.  But I thought Werter himself a
+more divine being than I had ever beheld or imagined; his character
+contained no pretension, but it sank deep.  The disquisitions upon
+death and suicide were calculated to fill  me with wonder.  I did not
+pretend to enter into the merits of the case, yet I inclined towards
+the opinions of the hero, whose extinction I wept, without precisely
+understanding it.
+
+"As I read, however, I applied much personally to my own feelings and
+condition.  I found myself similar yet at the same time strangely
+unlike to the beings concerning whom I read and to whose conversation I
+was a listener.  I sympathized with and partly understood them, but I
+was unformed in mind; I was dependent on none and related to none.
+'The path of my departure was free,' and there was none to lament my
+annihilation.  My person was hideous and my stature gigantic.  What did
+this mean?  Who was I?  What was I?  Whence did I come?  What was my
+destination?  These questions continually recurred, but I was unable to
+solve them.
+
+"The volume of Plutarch's Lives which I possessed contained the
+histories of the first founders of the ancient republics.  This book
+had a far different effect upon me from the Sorrows of Werter.  I
+learned from Werter's imaginations despondency and gloom, but Plutarch
+taught me high thoughts; he elevated me above the wretched sphere of my
+own reflections, to admire and love the heroes of past ages.  Many
+things I read surpassed my understanding and experience.  I had a very
+confused knowledge of kingdoms, wide extents of country, mighty rivers,
+and boundless seas.  But I was perfectly unacquainted with towns and
+large assemblages of men. The cottage of my protectors had been the
+only school in which I had studied human nature, but this book
+developed new and mightier scenes of action.  I read of men concerned
+in public affairs, governing or massacring their species.  I felt the
+greatest ardour for virtue rise within me, and abhorrence for vice, as
+far as I understood the signification of those terms, relative as they
+were, as I applied them, to pleasure and pain alone.  Induced by these
+feelings, I was of course led to admire peaceable lawgivers, Numa,
+Solon, and Lycurgus, in preference to Romulus and Theseus.  The
+patriarchal lives of my protectors caused these impressions to take a
+firm hold on my mind; perhaps, if my first introduction to humanity had
+been made by a young soldier, burning for glory and slaughter, I should
+have been imbued with different sensations.
+
+"But Paradise Lost excited different and far deeper emotions.  I read
+it, as I had read the other volumes which had fallen into my hands, as
+a true history.  It moved every feeling of wonder and awe that the
+picture of an omnipotent God warring with his creatures was capable of
+exciting.  I often referred the several situations, as their similarity
+struck me, to my own.  Like Adam, I was apparently united by no link to
+any other being in existence; but his state was far different from mine
+in every other respect.  He had come forth from the hands of God a
+perfect creature, happy and prosperous, guarded by the especial care of
+his Creator; he was allowed to converse with and acquire knowledge from
+beings of a superior nature, but I was wretched, helpless, and alone.
+Many times I considered Satan as the fitter emblem of my condition, for
+often, like him, when I viewed the bliss of my protectors, the bitter
+gall of envy rose within me.
+
+"Another circumstance strengthened and confirmed these feelings.  Soon
+after my arrival in the hovel I discovered some papers in the pocket of
+the dress which I had taken from your laboratory.  At first I had
+neglected them, but now that I was able to decipher the characters in
+which they were written, I began to study them with diligence.  It was
+your journal of the four months that preceded my creation.  You
+minutely described in these papers every step you took in the progress
+of your work; this history was mingled with accounts of domestic
+occurrences.  You doubtless recollect these papers.  Here they are.
+Everything is related in them which bears reference to my accursed
+origin; the whole detail of that series of disgusting circumstances
+which produced it is set in view; the minutest description of my odious
+and loathsome person is given, in language which painted your own
+horrors and rendered mine indelible.  I sickened as I read.  'Hateful
+day when I received life!' I exclaimed in agony.  'Accursed creator!
+Why did you form a monster so hideous that even YOU turned from me in
+disgust?  God, in pity, made man beautiful and alluring, after his own
+image; but my form is a filthy type of yours, more horrid even from the
+very resemblance.  Satan had his companions, fellow devils, to admire
+and encourage him, but I am solitary and abhorred.'
+
+"These were the reflections of my hours of despondency and solitude;
+but when I contemplated the virtues of the cottagers, their amiable and
+benevolent dispositions, I persuaded myself that when they should
+become acquainted with my admiration of their virtues they  would
+compassionate me and overlook my personal deformity.  Could they turn
+from their door one, however monstrous, who solicited their compassion
+and friendship?  I resolved, at least, not to despair, but in every way
+to fit myself for an interview with them which would decide my fate.  I
+postponed this attempt for some months longer, for the importance
+attached to its success inspired me with a dread lest I should fail.
+Besides, I found that my understanding improved so much with every
+day's experience that I was unwilling to commence this undertaking
+until a few more months should have added to my sagacity.
+
+"Several changes, in the meantime, took place in the cottage.  The
+presence of Safie diffused happiness among its inhabitants, and I also
+found that a greater degree of plenty reigned there.  Felix and Agatha
+spent more time in amusement and conversation, and were assisted in
+their labours by servants.  They did not appear rich, but they were
+contented and happy; their feelings were serene and peaceful, while
+mine became every day more tumultuous.  Increase of knowledge only
+discovered to me more clearly what a wretched outcast I was.  I
+cherished hope, it is true, but it vanished when I beheld my person
+reflected in water or my shadow in the moonshine, even as that frail
+image and that inconstant shade.
+
+"I endeavoured to crush these fears and to fortify myself for the trial
+which in a few months I resolved to undergo; and sometimes I allowed my
+thoughts, unchecked by reason, to ramble in the fields of Paradise, and
+dared to fancy amiable and lovely creatures sympathizing with my
+feelings and cheering my gloom; their angelic countenances breathed
+smiles of consolation.  But it was all a dream; no Eve soothed my
+sorrows nor shared my thoughts; I was alone.  I remembered Adam's
+supplication to his Creator.  But where was mine?  He had abandoned me,
+and in the bitterness of my heart I cursed him.
+
+"Autumn passed thus.  I saw, with surprise and grief, the leaves decay
+and fall, and nature again assume the barren and bleak appearance it
+had worn when I first beheld the woods and the lovely moon.  Yet I did
+not heed the bleakness of the weather; I was better fitted by my
+conformation for the endurance of cold than heat.  But my chief
+delights were the sight of the flowers, the birds, and all the gay
+apparel of summer; when those deserted me, I turned with more attention
+towards the cottagers.  Their happiness was not decreased by the
+absence of summer.  They loved and sympathized with one another; and
+their joys, depending on each other, were not interrupted by the
+casualties that took place around them.  The more I saw of them, the
+greater became my desire to claim their protection and kindness; my
+heart yearned to be known and loved by these amiable creatures; to see
+their sweet looks directed towards me with affection was the utmost
+limit of my ambition.  I dared not think that they would turn them from
+me with disdain and horror.  The poor that stopped at their door were
+never driven away.  I asked, it is true, for greater treasures than a
+little food or rest:  I required kindness and sympathy; but I did not
+believe myself utterly unworthy of it.
+
+"The winter advanced, and an entire revolution of the seasons had taken
+place since I awoke into life.  My attention at this time was solely
+directed towards my plan of introducing myself into the cottage of my
+protectors.  I revolved many projects, but that on which I finally
+fixed was to enter the dwelling when the blind old man should be alone.
+I had sagacity enough to discover that the unnatural hideousness of my
+person was the chief object of horror with those who had formerly
+beheld me.  My voice, although harsh, had nothing terrible in it; I
+thought, therefore, that if in the absence of his children I could gain
+the good will and mediation of the old De Lacey, I might by his means
+be tolerated by my younger protectors.
+
+"One day, when the sun shone on the red leaves that strewed the ground
+and diffused cheerfulness, although it denied warmth, Safie, Agatha,
+and Felix departed on a long country walk, and the old man, at his own
+desire, was left alone in the cottage.  When his children had departed,
+he took up his guitar and played several mournful but sweet airs, more
+sweet and mournful than I had ever heard him play before.  At first his
+countenance was illuminated with pleasure, but as he continued,
+thoughtfulness and sadness succeeded; at length, laying aside the
+instrument, he sat absorbed in reflection.
+
+"My heart beat quick; this was the hour and moment of trial, which
+would decide my hopes or realize my fears.  The servants were gone to a
+neighbouring fair.  All was silent in and around the cottage; it was an
+excellent opportunity; yet, when I proceeded to execute my plan, my
+limbs failed me and I sank to the ground.  Again I rose, and exerting
+all the firmness of which I was master, removed the planks which I had
+placed before my hovel to conceal my retreat.  The fresh air revived
+me, and with renewed determination I approached the door of their
+cottage.
+
+"I knocked.  'Who is there?' said the old man.  'Come in.'
+
+"I entered.  'Pardon this intrusion,' said I; 'I am a traveller in want
+of a little rest; you would greatly oblige me if you would allow me to
+remain a few minutes before the fire.'
+
+"'Enter,' said De Lacey, 'and I will try in what manner I can to
+relieve your wants; but, unfortunately, my children are from home, and
+as I am blind, I am afraid I shall find it difficult to procure food
+for you.'
+
+"'Do not trouble yourself, my kind host; I have food; it is warmth and
+rest only that I need.'
+
+"I sat down, and a silence ensued.  I knew that every minute was
+precious to me, yet I remained irresolute in what manner to commence
+the interview, when the old man addressed me.  'By your language,
+stranger, I suppose you are my countryman; are you French?'
+
+"'No; but I was educated by a French family and understand that
+language only.  I am now going to claim the protection of some friends,
+whom I sincerely love, and of whose favour I have some hopes.'
+
+"'Are they Germans?'
+
+"'No, they are French.  But let us change the subject.  I am an
+unfortunate and deserted creature, I look around and I have no relation
+or friend upon earth.  These amiable people to whom I go have never
+seen me and know little of me.  I am full of fears, for if I fail
+there, I am an outcast in the world forever.'
+
+"'Do not despair.  To be friendless is indeed to be unfortunate, but
+the hearts of men, when unprejudiced by any obvious self-interest, are
+full of brotherly love and charity.  Rely, therefore, on your hopes;
+and if these friends are good and amiable, do not despair.'
+
+"'They are kind--they are the most excellent creatures in the world;
+but, unfortunately, they are prejudiced against me.  I have good
+dispositions; my life has been hitherto harmless and in some degree
+beneficial; but a fatal prejudice clouds their eyes, and where they
+ought to see a feeling and kind friend, they behold only a detestable
+monster.'
+
+"'That is indeed unfortunate; but if you are really blameless, cannot
+you undeceive them?'
+
+"'I am about to undertake that task; and it is on that account that I
+feel so many overwhelming terrors.  I tenderly love these friends; I
+have, unknown to them, been for many months in the habits of daily
+kindness towards them; but they believe that I wish to injure them, and
+it is that prejudice which I wish to overcome.'
+
+"'Where do these friends reside?'
+
+"'Near this spot.'
+
+"The old man paused and then continued, 'If you will unreservedly
+confide to me the particulars of your tale, I perhaps may be of use in
+undeceiving them.  I am blind and cannot judge of your countenance, but
+there is something in your words which persuades me that you are
+sincere.  I am poor and an exile, but it will afford me true pleasure
+to be in any way serviceable to a human creature.'
+
+"'Excellent man!  I thank you and accept your generous offer.  You
+raise me from the dust by this kindness; and I trust that, by your aid,
+I shall not be driven from the society and sympathy of your fellow
+creatures.'
+
+"'Heaven forbid!  Even if you were really criminal, for that can only
+drive you to desperation, and not instigate you to virtue.  I also am
+unfortunate; I and my family have been condemned, although innocent;
+judge, therefore, if I do not feel for your misfortunes.'
+
+"'How can I thank you, my best and only benefactor?  From your lips
+first have I heard the voice of kindness directed towards me; I shall
+be forever grateful; and your present humanity assures me of success
+with those friends whom I am on the point of meeting.'
+
+"'May I know the names and residence of those friends?'
+
+"I paused. This, I thought, was the moment of decision, which was to
+rob me of or bestow happiness on me forever.  I struggled vainly for
+firmness sufficient to answer him, but the effort destroyed all my
+remaining strength; I sank on the chair and sobbed aloud.  At that
+moment I heard the steps of my younger protectors.  I had not a moment
+to lose, but seizing the hand of the old man, I cried, 'Now is the
+time!  Save and protect me!  You and your family are the friends whom I
+seek.  Do not you desert me in the hour of trial!'
+
+"'Great God!' exclaimed the old man.  'Who are you?'
+
+"At that instant the cottage door was opened, and Felix, Safie, and
+Agatha entered.  Who can describe their horror and consternation on
+beholding me?  Agatha fainted, and Safie, unable to attend to her
+friend, rushed out of the cottage.  Felix darted forward, and with
+supernatural force tore me from his father, to whose knees I clung, in
+a transport of fury, he dashed me to the ground and struck me violently
+with a stick.  I could have torn him limb from limb, as the lion rends
+the antelope.  But my heart sank within me as with bitter sickness, and
+I refrained.  I saw him on the point of repeating his blow, when,
+overcome by pain and anguish, I quitted the cottage, and in the general
+tumult escaped unperceived to my hovel."
+
+
+
+Chapter 16
+
+"Cursed, cursed creator!  Why did I live?  Why, in that instant, did I
+not extinguish the spark of existence which you had so wantonly
+bestowed?  I know not; despair had not yet taken possession of me; my
+feelings were those of rage and revenge.  I could with pleasure have
+destroyed the cottage and its inhabitants and have glutted myself with
+their shrieks and misery.
+
+"When night came I quitted my retreat and wandered in the wood; and
+now, no longer restrained by the fear of discovery, I gave vent to my
+anguish in fearful howlings.  I was like a wild beast that had broken
+the toils, destroying the objects that obstructed me and ranging
+through the wood with a stag-like swiftness.  Oh!  What a miserable
+night I passed!  The cold stars shone in mockery, and the bare trees
+waved their branches above me; now and then the sweet voice of a bird
+burst forth amidst the universal stillness.  All, save I, were at rest
+or in enjoyment; I, like the arch-fiend, bore a hell within me, and
+finding myself unsympathized with, wished to tear up the trees, spread
+havoc and destruction around me, and then to have sat down and enjoyed
+the ruin.
+
+"But this was a luxury of sensation that could not endure; I became
+fatigued with excess of bodily exertion and sank on the damp grass in
+the sick impotence of despair.  There was none among the myriads of men
+that existed who would pity or assist me; and should I feel kindness
+towards my enemies?  No; from that moment I declared everlasting war
+against the species, and more than all, against him who had formed me
+and sent me forth to this insupportable misery.
+
+"The sun rose; I heard the voices of men and knew that it was
+impossible to return to my retreat during that day.  Accordingly I hid
+myself in some thick underwood, determining to devote the ensuing hours
+to reflection on my situation.
+
+"The pleasant sunshine and the pure air of day restored me to some
+degree of tranquillity; and when I considered what had passed at the
+cottage, I could not help believing that I had been too hasty in my
+conclusions.  I had certainly acted imprudently.  It was apparent that
+my conversation had interested the father in my behalf, and  I was a
+fool in having exposed my person to the horror of his children.  I
+ought to have familiarized the old De Lacey to me, and by degrees to
+have discovered myself to the rest of his family, when they should have
+been  prepared for my approach.  But I did not believe my errors to be
+irretrievable, and after much consideration I resolved to return to the
+cottage, seek the old man, and by my representations win him to my
+party.
+
+"These thoughts calmed me, and in the afternoon I sank into a profound
+sleep; but the fever of my blood did not allow me to be visited by
+peaceful dreams.  The horrible scene of the preceding day was forever
+acting before my eyes; the females were flying and the enraged Felix
+tearing me from his father's feet.  I awoke exhausted, and finding that
+it was already night, I crept forth from my hiding-place, and went in
+search of food.
+
+"When my hunger was appeased, I directed my steps towards the
+well-known path that conducted to the cottage.  All there was at peace.
+I crept into my hovel and remained in silent expectation of the
+accustomed hour when the family arose.  That hour passed, the sun
+mounted high in the heavens, but the cottagers did not appear.  I
+trembled violently, apprehending some dreadful misfortune.  The inside
+of the cottage was dark, and I heard no motion; I cannot describe the
+agony of this suspense.
+
+"Presently two countrymen passed by, but pausing near the cottage, they
+entered into conversation, using violent gesticulations; but I did not
+understand what they said, as they spoke the language of the country,
+which differed from that of my protectors.  Soon after, however, Felix
+approached with another man; I was surprised, as I knew that he had not
+quitted the cottage that morning, and waited anxiously to discover from
+his discourse the meaning of these unusual appearances.
+
+"'Do you consider,' said his companion to him, 'that you will be
+obliged to pay three months' rent and to lose the produce of your
+garden?  I do not wish to take any unfair advantage, and I beg
+therefore that you will take some days to consider of your
+determination.'
+
+"'It is utterly useless,' replied Felix; 'we can never again inhabit
+your cottage.  The life of my father is in the greatest danger, owing
+to the dreadful circumstance that I have related.  My wife and my
+sister will never recover from their horror.  I entreat you not to
+reason with me any more.  Take possession of your tenement and let me
+fly from this place.'
+
+"Felix trembled violently as he said this.  He and his companion
+entered the cottage, in which they remained for a few minutes, and then
+departed.  I never saw any of the family of De Lacey more.
+
+"I continued for the remainder of the day in my hovel in a state of
+utter and stupid despair.  My protectors had departed and had broken
+the only link that held me to the world.  For the first time the
+feelings of revenge and hatred filled my bosom, and I did not strive to
+control them, but allowing myself to be borne away by the stream, I
+bent my mind towards injury and death.  When I thought of my friends,
+of the mild voice of De Lacey, the gentle eyes of Agatha, and the
+exquisite beauty of the Arabian, these thoughts vanished and a gush of
+tears somewhat soothed me.  But again when I reflected that they had
+spurned and deserted me, anger returned, a rage of anger, and unable to
+injure anything human, I turned my fury towards inanimate objects.  As
+night advanced I placed a variety of combustibles around the cottage,
+and after having destroyed every vestige of cultivation in the garden,
+I waited with forced impatience until the moon had sunk to commence my
+operations.
+
+"As the night advanced, a fierce wind arose from the woods and quickly
+dispersed the clouds that had loitered in the heavens; the blast tore
+along like a mighty avalanche and produced a kind of insanity in my
+spirits that burst all bounds of reason and reflection.  I lighted the
+dry branch of a tree and danced with fury around the devoted cottage,
+my eyes still fixed on the western horizon, the edge of which the moon
+nearly touched.  A part of its orb was at length hid, and I waved my
+brand; it sank, and with a loud scream I fired the straw, and heath,
+and bushes, which I had collected.  The wind fanned the fire, and the
+cottage was quickly enveloped by the flames, which clung to it and
+licked it with their forked and destroying tongues.
+
+"As soon as I was convinced that no assistance could save any part of
+the habitation, I quitted the scene and sought for refuge in the woods.
+
+"And now, with the world before me, whither should I bend my steps?  I
+resolved to fly far from the scene of my misfortunes; but to me, hated
+and despised, every country must be equally horrible.  At length the
+thought of you crossed my mind.  I learned from your papers that you
+were my father, my creator; and to whom could I apply with more fitness
+than to him who had given me life?  Among the lessons that Felix had
+bestowed upon Safie, geography had not been omitted; I had learned from
+these the relative situations of the different countries of the earth.
+You had mentioned Geneva as the name of your native town, and towards
+this place I resolved to proceed.
+
+"But how was I to direct myself?  I knew that I must travel in a
+southwesterly direction to reach my destination, but the sun was my
+only guide.  I did not know the names of the towns that I was to pass
+through, nor could I ask information from a single human being; but I
+did not despair.  From you only could I hope for succour, although
+towards you I felt no sentiment but that of hatred.  Unfeeling,
+heartless creator!  You had endowed me with perceptions and passions
+and then cast me abroad an object for the scorn and horror of mankind.
+But on you only had I any claim for pity and redress, and from you I
+determined to seek that justice which I vainly attempted to gain from
+any other being that wore the human form.
+
+"My travels were long and the sufferings I endured intense.  It was
+late in autumn when I quitted the district where I had so long resided.
+I travelled only at night, fearful of encountering the visage of a
+human being.  Nature decayed around me, and the sun became heatless;
+rain and snow poured around me; mighty rivers were frozen; the surface
+of the earth was hard and chill, and bare, and I found no shelter.  Oh,
+earth!  How often did I imprecate curses on the cause of my being!  The
+mildness of my nature had fled, and all within me was turned to gall
+and bitterness.  The nearer I approached to your habitation, the more
+deeply did I feel the spirit of revenge enkindled in my heart.  Snow
+fell, and the waters were hardened, but I rested not.  A few incidents
+now and then directed me, and I possessed a map of the country; but I
+often wandered wide from my path.  The agony of my feelings allowed me
+no respite; no incident occurred from which my rage and misery could
+not extract its food; but a circumstance that happened when I arrived
+on the confines of Switzerland, when the sun had recovered its warmth
+and the earth again began to look green, confirmed in an especial
+manner the bitterness and horror of my feelings.
+
+"I generally rested during the day and travelled only when I was
+secured by night from the view of man.  One morning, however, finding
+that my path lay through a deep wood, I ventured to continue my journey
+after the sun had risen; the day, which was one of the first of spring,
+cheered even me by the loveliness of its sunshine and the balminess of
+the air.  I felt emotions of gentleness and pleasure, that had long
+appeared dead, revive within me.  Half surprised by the novelty of
+these sensations, I allowed myself to be borne away by them, and
+forgetting my solitude and deformity, dared to be happy.  Soft tears
+again bedewed my cheeks, and I even raised my humid eyes with
+thankfulness towards the blessed sun, which bestowed such joy upon me.
+
+"I continued to wind among the paths of the wood, until I came to its
+boundary, which was skirted by a deep and rapid river, into which many
+of the trees bent their branches, now budding with the fresh spring.
+Here I paused, not exactly knowing what path to pursue, when I heard
+the sound of voices, that induced me to conceal myself under the shade
+of a cypress.  I was scarcely hid when a young girl came running
+towards the spot where I was concealed, laughing, as if she ran from
+someone in sport.  She continued her course along the precipitous sides
+of the river, when suddenly her foot slipped, and she fell into the
+rapid stream.  I rushed from my hiding-place and with extreme labour,
+from the force of the current, saved her and dragged her to shore.  She
+was senseless, and I endeavoured by every means in my power to restore
+animation, when I was suddenly interrupted by the approach of a rustic,
+who was probably the person from whom she had playfully fled.  On
+seeing me, he darted towards me, and tearing the girl from my arms,
+hastened towards the deeper parts of the wood.  I followed speedily, I
+hardly knew why; but when the man saw me draw near, he aimed a gun,
+which he carried, at my body and fired.  I sank to the ground, and my
+injurer, with increased swiftness, escaped into the wood.
+
+"This was then the reward of my benevolence!  I had saved a human being
+from destruction, and as a recompense I now writhed under the miserable
+pain of a wound which shattered the flesh and bone.  The feelings of
+kindness and gentleness which I had entertained but a few moments
+before gave place to hellish rage and gnashing of teeth.  Inflamed by
+pain, I vowed eternal hatred and vengeance to all mankind.  But the
+agony of my wound overcame me; my pulses paused, and I fainted.
+
+"For some weeks I led a miserable life in the woods, endeavouring to
+cure the wound which I had received.  The ball had entered my shoulder,
+and I knew not whether it had remained there or passed through; at any
+rate I had no means of extracting it.  My sufferings were augmented
+also by the oppressive sense of the injustice and ingratitude of their
+infliction.  My daily vows rose for revenge--a deep and deadly revenge,
+such as would alone compensate for the outrages and anguish I had
+endured.
+
+"After some weeks my wound healed, and I continued my journey.  The
+labours I endured were no longer to be alleviated by the bright sun or
+gentle breezes of spring; all joy was but a mockery which insulted my
+desolate state and made me feel more painfully that I was not made for
+the enjoyment of pleasure.
+
+"But my toils now drew near a close, and in two months from this time I
+reached the environs of Geneva.
+
+"It was evening when I arrived, and I retired to a hiding-place among
+the fields that surround it to meditate in what manner I should apply
+to you.  I was oppressed by fatigue and hunger and far too unhappy to
+enjoy the gentle breezes of evening or the prospect of the sun setting
+behind the stupendous mountains of Jura.
+
+"At this time a slight sleep relieved me from the pain of reflection,
+which was disturbed by the approach of a beautiful child, who came
+running into the recess I had chosen, with all the sportiveness of
+infancy.  Suddenly, as I gazed on him, an idea seized me that this
+little creature was unprejudiced and had lived too short a time to have
+imbibed a horror of deformity.  If, therefore, I could seize him and
+educate him as my companion and friend, I should not be so desolate in
+this peopled earth.
+
+"Urged by this impulse, I seized on the boy as he passed and drew him
+towards me.  As soon as he beheld my form, he placed his hands before
+his eyes and uttered a shrill scream; I drew his hand forcibly from his
+face and said, 'Child, what is the meaning of this?  I do not intend to
+hurt you; listen to me.'
+
+"He struggled violently.  'Let me go,' he cried; 'monster!  Ugly
+wretch!  You wish to eat me and tear me to pieces.  You are an ogre.
+Let me go, or I will tell my papa.'
+
+"'Boy, you will never see your father again; you must come with me.'
+
+"'Hideous monster!  Let me go.  My papa is a syndic--he is M.
+Frankenstein--he will punish you.  You dare not keep me.'
+
+"'Frankenstein! you belong then to my enemy--to him towards whom I have
+sworn eternal revenge; you shall be my first victim.'
+
+"The child still struggled and loaded me with epithets which carried
+despair to my heart; I grasped his throat to silence him, and in a
+moment he lay dead at my feet.
+
+"I gazed on my victim, and my heart swelled with exultation and hellish
+triumph; clapping my hands, I exclaimed, 'I too can create desolation;
+my enemy is not invulnerable; this death will carry despair to him, and
+a thousand other miseries shall torment and destroy him.'
+
+"As I fixed my eyes on the child, I saw something glittering on his
+breast.  I took it; it was a portrait of a most lovely woman.  In spite
+of my malignity, it softened and attracted me.  For a few moments I
+gazed with delight on her dark eyes, fringed by deep lashes, and her
+lovely lips; but presently my rage returned; I remembered that I was
+forever deprived of the delights that such beautiful creatures could
+bestow and that she whose resemblance I contemplated would, in
+regarding me, have changed that air of divine benignity to one
+expressive of disgust and affright.
+
+"Can you wonder that such thoughts transported me with rage?  I only
+wonder that at that moment, instead of venting my sensations in
+exclamations and agony, I did not rush among mankind and perish in the
+attempt to destroy them.
+
+"While I was overcome by these feelings, I left the spot where I had
+committed the murder, and seeking a more secluded hiding-place, I
+entered a barn which had appeared to me to be empty.  A woman was
+sleeping on some straw; she was young, not indeed so beautiful as her
+whose portrait I held, but of an agreeable aspect and blooming in the
+loveliness of youth and health.  Here, I thought, is one of those whose
+joy-imparting smiles are bestowed on all but me.  And then I bent over
+her and whispered, 'Awake, fairest, thy lover is near--he who would
+give his life but to obtain one look of affection from thine eyes; my
+beloved, awake!'
+
+"The sleeper stirred; a thrill of terror ran through me.  Should she
+indeed awake, and see me, and curse me, and denounce the murderer? Thus
+would she assuredly act if her darkened eyes opened and she beheld me.
+The thought was madness; it stirred the fiend within me--not I, but
+she, shall suffer; the murder I have committed because I am forever
+robbed of all that she could give me, she shall atone.  The crime had
+its source in her; be hers the punishment!  Thanks to the lessons of
+Felix and the sanguinary laws of man, I had learned now to work
+mischief.  I bent over her and placed the portrait securely in one of
+the folds of her dress.  She moved again, and I fled.
+
+"For some days I haunted the spot where these scenes had taken place,
+sometimes wishing to see you, sometimes resolved to quit the world and
+its miseries forever.  At length I wandered towards these mountains,
+and have ranged through their immense recesses, consumed by a burning
+passion which you alone can gratify.  We may not part until you have
+promised to comply with my requisition.  I am alone and miserable; man
+will not associate with me; but one as deformed and horrible as myself
+would not deny herself to me.  My companion must be of the same species
+and have the same defects.  This being you must create."
+
+
+
+Chapter 17
+
+The being finished speaking and fixed his looks upon me in the
+expectation of a reply.  But I was bewildered, perplexed, and unable to
+arrange my ideas sufficiently to understand the full extent of his
+proposition.  He continued,
+
+"You must create a female for me with whom I can live in the
+interchange of those sympathies necessary for my being.  This you alone
+can do, and I demand it of you as a right which you must not refuse to
+concede."
+
+The latter part of his tale had kindled anew in me the anger that had
+died away while he narrated his peaceful life among the cottagers, and
+as he said this I could no longer suppress the rage that burned within
+me.
+
+"I do refuse it," I replied; "and no torture shall ever extort a
+consent from me.  You may render me the most miserable of men, but you
+shall never make me base in my own eyes.  Shall I create another like
+yourself, whose joint wickedness might desolate the world.  Begone!  I
+have answered you; you may torture me, but I will never consent."
+
+"You are in the wrong," replied the fiend; "and instead of threatening,
+I am content to reason with you.  I am malicious because I am
+miserable.  Am I not shunned and hated by all mankind?  You, my
+creator, would tear me to pieces and triumph; remember that, and tell
+me why I should pity man more than he pities me?  You would not call it
+murder if you could precipitate me into one of those ice-rifts and
+destroy my frame, the work of your own hands.  Shall I respect man when
+he condemns me?  Let him live with me in the interchange of kindness,
+and instead of injury I would bestow every benefit upon him with tears
+of gratitude at his acceptance.  But that cannot be; the human senses
+are insurmountable barriers to our union.  Yet mine shall not be the
+submission of abject slavery.  I will revenge my injuries; if I cannot
+inspire love, I will cause fear, and chiefly towards you my arch-enemy,
+because my creator, do I swear inextinguishable hatred.  Have a care; I
+will work at your destruction, nor finish until I desolate your heart,
+so that you shall curse the hour of your birth."
+
+A fiendish rage animated him as he said this; his face was wrinkled
+into contortions too horrible for human eyes to behold; but presently
+he calmed himself and proceeded--
+
+"I intended to reason.  This passion is detrimental to me, for you do
+not reflect that YOU are the cause of its excess.  If any being felt
+emotions of benevolence towards me, I should return them a hundred and
+a hundredfold; for that one creature's sake I would make peace with the
+whole kind!  But I now indulge in dreams of bliss that cannot be
+realized.  What I ask of you is reasonable and moderate; I demand a
+creature of another sex, but as hideous as myself; the gratification is
+small, but it is all that I can receive, and it shall content me.  It
+is true, we shall be monsters, cut off from all the world; but on that
+account we shall be more attached to one another.  Our lives will not
+be happy, but they will be harmless and free from the misery I now
+feel.  Oh!  My creator, make me happy; let me feel gratitude towards
+you for one benefit!  Let me see that I excite the sympathy of some
+existing thing; do not deny me my request!"
+
+I was moved.  I shuddered when I thought of the possible consequences
+of my consent, but I felt that there was some justice in his argument.
+His tale and the feelings he now expressed proved him to be a creature
+of fine sensations, and did I not as his maker owe him all the portion
+of happiness that it was in my power to bestow?  He saw my change of
+feeling and continued,
+
+"If you consent, neither you nor any other human being shall ever see
+us again; I will go to the vast wilds of South America.  My food is not
+that of man; I do not destroy the lamb and the kid to glut my appetite;
+acorns and berries afford me sufficient nourishment.  My companion will
+be of the same nature as myself and will be content with the same fare.
+We shall make our bed of dried leaves; the sun will shine on us as on
+man and will ripen our food.  The picture I present to you is peaceful
+and human, and you must feel that you could deny it only in the
+wantonness of power and cruelty.  Pitiless as you have been towards me,
+I now see compassion in your eyes; let me seize the favourable moment
+and persuade you to promise what I so ardently desire."
+
+"You propose," replied I, "to fly from the habitations of man, to dwell
+in those wilds where the beasts of the field will be your only
+companions.  How can you, who long for the love and sympathy of man,
+persevere in this exile?  You will return and again seek their
+kindness, and you will meet with their detestation; your evil passions
+will be renewed, and you will then have a companion to aid you in the
+task of destruction.  This may not be; cease to argue the point, for I
+cannot consent."
+
+"How inconstant are your feelings!  But a moment ago you were moved by
+my representations, and why do you again harden yourself to my
+complaints?  I swear to you, by the earth which I inhabit, and by you
+that made me, that with the companion you bestow I will quit the
+neighbourhood of man and dwell, as it may chance, in the most savage of
+places.  My evil passions will have fled, for I shall meet with
+sympathy!  My life will flow quietly away, and in my dying moments I
+shall not curse my maker."
+
+His words had a strange effect upon me.  I compassionated him and
+sometimes felt a wish to console him, but when I looked upon him, when
+I saw the filthy mass that moved and talked, my heart sickened and my
+feelings were altered to those of horror and hatred.  I tried to stifle
+these sensations; I thought that as I could not sympathize with him, I
+had no right to withhold from him the small portion of happiness which
+was yet in my power to bestow.
+
+"You swear," I said, "to be harmless; but have you not already shown a
+degree of malice that should reasonably make me distrust you?  May not
+even this be a feint that will increase your triumph by affording a
+wider scope for your revenge?"
+
+"How is this?  I must not be trifled with, and I demand an answer.  If
+I have no ties and no affections, hatred and vice must be my portion;
+the love of another will destroy the cause of my crimes, and I shall
+become a thing of whose existence everyone will be ignorant.  My vices
+are the children of a forced solitude that I abhor, and my virtues will
+necessarily arise when I live in communion with an equal.  I shall feel
+the affections of a sensitive being and become linked to the chain of
+existence and events from which I am now excluded."
+
+I paused some time to reflect on all he had related and the various
+arguments which he had employed.  I thought of the promise of virtues
+which he had displayed on the opening of his existence and the
+subsequent blight of all kindly feeling by the loathing and scorn which
+his protectors had manifested towards him.  His power and threats were
+not omitted in my calculations; a creature who could exist in the ice
+caves of the glaciers and hide himself from pursuit among the ridges of
+inaccessible precipices was a being possessing faculties it would be
+vain to cope with.  After a long pause of reflection I concluded that
+the justice due both to him and my fellow creatures demanded of me that
+I should comply with his request.  Turning to him, therefore, I said,
+
+"I consent to your demand, on your solemn oath to quit Europe forever,
+and every other place in the neighbourhood of man, as soon as I shall
+deliver into your hands a female who will accompany you in your exile."
+
+"I swear," he cried, "by the sun, and by the blue sky of heaven, and by
+the fire of love that burns my heart, that if you grant my prayer,
+while they exist you shall never behold me again.  Depart to your home
+and commence your labours; I shall watch their progress with
+unutterable anxiety; and fear not but that when you are ready I shall
+appear."
+
+Saying this, he suddenly quitted me, fearful, perhaps, of any change in
+my sentiments.  I saw him descend the mountain with greater speed than
+the flight of an eagle, and quickly lost among the undulations of the
+sea of ice.
+
+His tale had occupied the whole day, and the sun was upon the verge of
+the horizon when he departed.  I knew that I ought to hasten my descent
+towards the valley, as I should soon be encompassed in darkness; but my
+heart was heavy, and my steps slow.  The labour of winding among the
+little paths of the mountain and fixing my feet firmly as I advanced
+perplexed me, occupied as I was by the emotions which the occurrences
+of the day had produced.  Night was far advanced when I came to the
+halfway resting-place and seated myself beside the fountain.  The stars
+shone at intervals as the clouds passed from over them; the dark pines
+rose before me, and every here and there a broken tree lay on the
+ground; it was a scene of wonderful solemnity and stirred strange
+thoughts within me.  I wept bitterly, and clasping my hands in agony, I
+exclaimed, "Oh!  Stars and clouds and winds, ye are all about to mock
+me; if ye really pity me, crush sensation and memory; let me become as
+nought; but if not, depart, depart, and leave me in darkness."
+
+These were wild and miserable thoughts, but I cannot describe to you
+how the eternal twinkling of the stars weighed upon me and how I
+listened to every blast of wind as if it were a dull ugly siroc on its
+way to consume me.
+
+Morning dawned before I arrived at the village of Chamounix; I took no
+rest, but returned immediately to Geneva.  Even in my own heart I could
+give no expression to my sensations--they weighed on me with a
+mountain's weight and their excess destroyed my agony beneath them.
+Thus I returned home, and entering the house, presented myself to the
+family.  My haggard and wild appearance awoke intense alarm, but I
+answered no question, scarcely did I speak.  I felt as if I were placed
+under a ban--as if I had no right to claim their sympathies--as if
+never more might I enjoy companionship with them.  Yet even thus I
+loved them to adoration; and to save them, I resolved to dedicate
+myself to my most abhorred task.  The prospect of such an occupation
+made every other circumstance of existence pass before me like a dream,
+and that thought only had to me the reality of life.
+
+
+
+Chapter 18
+
+Day after day, week after week, passed away on my return to Geneva; and
+I could not collect the courage to recommence my work.  I feared the
+vengeance of the disappointed fiend, yet I was unable to overcome my
+repugnance to the task which was enjoined me.  I found that I could not
+compose a female without again devoting several months to profound
+study and laborious disquisition.  I had heard of some discoveries
+having been made by an English philosopher, the knowledge of which was
+material to my success, and I sometimes thought of obtaining my
+father's consent to visit England for this purpose; but I clung to
+every pretence of delay and shrank from taking the first step in an
+undertaking whose immediate necessity began to appear less absolute to
+me.  A change indeed had taken place in me; my health, which had
+hitherto declined, was now much restored; and my spirits, when
+unchecked by the memory of my unhappy promise, rose proportionably.  My
+father saw this change with pleasure, and he turned his thoughts
+towards the best method of eradicating the remains of my melancholy,
+which every now and then would return by fits, and with a devouring
+blackness overcast the approaching sunshine.  At these moments I took
+refuge in the most perfect solitude.  I passed whole days on the lake
+alone in a little boat, watching the clouds and listening to the
+rippling of the waves, silent and listless.  But the fresh air and
+bright sun seldom failed to restore me to some degree of composure, and
+on my return I met the salutations of my friends with a readier smile
+and a more cheerful heart.
+
+It was after my return from one of these rambles that my father,
+calling me aside, thus addressed me,
+
+"I am happy to remark, my dear son, that you have resumed your former
+pleasures and seem to be returning to yourself.  And yet you are still
+unhappy and still avoid our society.  For some time I was lost in
+conjecture as to the cause of this, but yesterday an idea struck me,
+and if it is well founded, I conjure you to avow it.  Reserve on such a
+point would be not only useless, but draw down treble misery on us all."
+
+I trembled violently at his exordium, and my father continued--"I
+confess, my son, that I have always looked forward to your marriage
+with our dear Elizabeth as the tie of our domestic comfort and the stay
+of my declining years.  You were attached to each other from your
+earliest infancy; you studied together, and appeared, in dispositions
+and tastes, entirely suited to one another.  But so blind is the
+experience of man that what I conceived to be the best assistants to my
+plan may have entirely destroyed it.  You, perhaps, regard her as your
+sister, without any wish that she might become your wife.  Nay, you may
+have met with another whom you may love; and considering yourself as
+bound in honour to Elizabeth, this struggle may occasion the poignant
+misery which you appear to feel."
+
+"My dear father, reassure yourself.  I love my cousin tenderly and
+sincerely.  I never saw any woman who excited, as Elizabeth does, my
+warmest admiration and affection.  My future hopes and prospects are
+entirely bound up in the expectation of our union."
+
+"The expression of your sentiments of this subject, my dear Victor,
+gives me more pleasure than I have for some time experienced.  If you
+feel thus, we shall assuredly be happy, however present events may cast
+a gloom over us.  But it is this gloom which appears to have taken so
+strong a hold of your mind that I wish to dissipate.  Tell me,
+therefore, whether you object to an immediate solemnization of the
+marriage.  We have been unfortunate, and recent events have drawn us
+from that everyday tranquillity befitting my years and infirmities. You
+are younger; yet I do not suppose, possessed as you are of a competent
+fortune, that an early marriage would at all interfere with any future
+plans of honour and utility that you may have formed.  Do not suppose,
+however, that I wish to dictate happiness to you or that a delay on
+your part would cause me any serious uneasiness.  Interpret my words
+with candour and answer me, I conjure you, with confidence and
+sincerity."
+
+I listened to my father in silence and remained for some time incapable
+of offering any reply.  I revolved rapidly in my mind a multitude of
+thoughts and endeavoured to arrive at some conclusion.  Alas!  To me
+the idea of an immediate union with my Elizabeth was one of horror and
+dismay.  I was bound by a solemn promise which I had not yet fulfilled
+and dared not break, or if I did, what manifold miseries might not
+impend over me and my devoted family!  Could I enter into a festival
+with this deadly weight yet hanging round my neck and bowing me to the
+ground?  I must perform my engagement and let the monster depart with
+his mate before I allowed myself to enjoy the delight of a union from
+which I expected peace.
+
+I remembered also the necessity imposed upon me of either journeying to
+England or entering into a long correspondence with those philosophers
+of that country whose knowledge and discoveries were of indispensable
+use to me in my present undertaking.  The latter method of obtaining
+the desired intelligence was dilatory and unsatisfactory; besides, I
+had an insurmountable aversion to the idea of engaging myself in my
+loathsome task in my father's house while in habits of familiar
+intercourse with those I loved.  I knew that a thousand fearful
+accidents might occur, the slightest of which would disclose a tale to
+thrill all connected with me with horror.  I was aware also that I
+should often lose all self-command, all capacity of hiding the
+harrowing sensations that would possess me during the progress of my
+unearthly occupation.  I must absent myself from all I loved while thus
+employed.  Once commenced, it would quickly be achieved, and I might be
+restored to my family in peace and happiness.  My promise fulfilled,
+the monster would depart forever.  Or (so my fond fancy imaged) some
+accident might meanwhile occur to destroy him and put an end to my
+slavery forever.
+
+These feelings dictated my answer to my father.  I expressed a wish to
+visit England, but concealing the true reasons of this request, I
+clothed my desires under a guise which excited no suspicion, while I
+urged my desire with an earnestness that easily induced my father to
+comply.  After so long a period of an absorbing melancholy that
+resembled madness in its intensity and effects, he was glad to find
+that I was capable of taking pleasure in the idea of such a journey,
+and he hoped that change of scene and varied amusement would, before my
+return, have restored me entirely to myself.
+
+The duration of my absence was left to my own choice; a few months, or
+at most a year, was the period contemplated.  One paternal kind
+precaution he had taken to ensure my having a companion.  Without
+previously communicating with me, he had, in concert with Elizabeth,
+arranged that Clerval should join me at Strasbourg.  This interfered
+with the solitude I coveted for the prosecution of my task; yet at the
+commencement of my journey the presence of my friend could in no way be
+an impediment, and truly I rejoiced that thus I should be saved many
+hours of lonely, maddening reflection.  Nay, Henry might stand between
+me and the intrusion of my foe.  If I were alone, would he not at times
+force his abhorred presence on me to remind me of my task or to
+contemplate its progress?
+
+To England, therefore, I was bound, and it was understood that my union
+with Elizabeth should take place immediately on my return.  My father's
+age rendered him extremely averse to delay.  For myself, there was one
+reward I promised myself from my detested toils--one consolation for my
+unparalleled sufferings; it was the prospect of that day when,
+enfranchised from my miserable slavery, I might claim Elizabeth and
+forget the past in my union with her.
+
+I now made arrangements for my journey, but one feeling haunted me
+which filled me with fear and agitation.  During my absence I should
+leave my friends unconscious of the existence of their enemy and
+unprotected from his attacks, exasperated as he might be by my
+departure.  But he had promised to follow me wherever I might go, and
+would he not accompany me to England?  This imagination was dreadful in
+itself, but soothing inasmuch as it supposed the safety of my friends.
+I was agonized with the idea of the possibility that the reverse of
+this might happen.  But through the whole period during which I was the
+slave of my creature I allowed myself to be governed by the impulses of
+the moment; and my present sensations strongly intimated that the fiend
+would follow me and exempt my family from the danger of his
+machinations.
+
+It was in the latter end of September that I again quitted my native
+country.  My journey had been my own suggestion, and Elizabeth
+therefore acquiesced, but she was filled with disquiet at the idea of
+my suffering, away from her, the inroads of misery and grief.  It had
+been her care which provided me a companion in Clerval--and yet a man
+is blind to a thousand minute circumstances which call forth a woman's
+sedulous attention.  She longed to bid me hasten my return; a thousand
+conflicting emotions rendered her mute as she bade me a tearful, silent
+farewell.
+
+I threw myself into the carriage that was to convey me away, hardly
+knowing whither I was going, and careless of what was passing around.
+I remembered only, and it was with a bitter anguish that I reflected on
+it, to order that my chemical instruments should be packed to go with
+me.  Filled with dreary imaginations, I passed through many beautiful
+and majestic scenes, but my eyes were fixed and unobserving.  I could
+only think of the bourne of my travels and the work which was to occupy
+me whilst they endured.
+
+After some days spent in listless indolence, during which I traversed
+many leagues, I arrived at Strasbourg, where I waited two days for
+Clerval.  He came.  Alas, how great was the contrast between us!  He
+was alive to every new scene, joyful when he saw the beauties of the
+setting sun, and more happy when he beheld it rise and recommence a new
+day.  He pointed out to me the shifting colours of the landscape and
+the appearances of the sky.  "This is what it is to live," he cried;
+"how I enjoy existence!  But you, my dear Frankenstein, wherefore are
+you desponding and sorrowful!" In truth, I was occupied by gloomy
+thoughts and neither saw the descent of the evening star nor the golden
+sunrise reflected in the Rhine.  And you, my friend, would be far more
+amused with the journal of Clerval, who observed the scenery with an
+eye of feeling and delight, than in listening to my reflections.  I, a
+miserable wretch, haunted by a curse that shut up every avenue to
+enjoyment.
+
+We had agreed to descend the Rhine in a boat from Strasbourg to
+Rotterdam, whence we might take shipping for London.  During this
+voyage we passed many willowy islands and saw several beautiful towns.
+We stayed a day at Mannheim, and on the fifth from our departure from
+Strasbourg, arrived at Mainz.  The course of the Rhine below Mainz
+becomes much more picturesque.  The river descends rapidly and winds
+between hills, not high, but steep, and of beautiful forms.  We saw
+many ruined castles standing on the edges of precipices, surrounded by
+black woods, high and inaccessible.  This part of the Rhine, indeed,
+presents a singularly variegated landscape.  In one spot you view
+rugged hills, ruined castles overlooking tremendous precipices, with
+the dark Rhine rushing beneath; and on the sudden turn of a promontory,
+flourishing vineyards with green sloping banks and a meandering river
+and populous towns occupy the scene.
+
+We travelled at the time of the vintage and heard the song of the
+labourers as we glided down the stream.  Even I, depressed in mind, and
+my spirits continually agitated by gloomy feelings, even I was pleased.
+I lay at the bottom of the boat, and as I gazed on the cloudless blue
+sky, I seemed to drink in a tranquillity to which I had long been a
+stranger.  And if these were my sensations, who can describe those of
+Henry?  He felt as if he had been transported to fairy-land and enjoyed
+a happiness seldom tasted by man.  "I have seen," he said, "the most
+beautiful scenes of my own country; I have visited the lakes of Lucerne
+and Uri, where the snowy mountains descend almost perpendicularly to
+the water, casting black and impenetrable shades, which would cause a
+gloomy and mournful appearance were it not for the most verdant islands
+that believe the eye by their gay appearance; I have seen this lake
+agitated by a tempest, when the wind tore up whirlwinds of water and
+gave you an idea of what the water-spout must be on the great ocean;
+and the waves dash with fury the base of the mountain, where the priest
+and his mistress were overwhelmed by an avalanche and where their dying
+voices are still said to be heard amid the pauses of the nightly wind;
+I have seen the mountains of La Valais, and the Pays de Vaud; but this
+country, Victor, pleases me more than all those wonders.  The mountains
+of Switzerland are more majestic and strange, but there is a charm in
+the banks of this divine river that I never before saw equalled.  Look
+at that castle which overhangs yon precipice; and that also on the
+island, almost concealed amongst the foliage of those lovely trees; and
+now that group of labourers coming from among their vines; and that
+village half hid in the recess of the mountain.  Oh, surely the spirit
+that inhabits and guards this place has a soul more in harmony with man
+than those who pile the glacier or retire to the inaccessible peaks of
+the mountains of our own country." Clerval!  Beloved friend!  Even now
+it delights me to record your words and to dwell on the praise of which
+you are so eminently deserving.  He was a being formed in the "very
+poetry of nature." His wild and enthusiastic imagination was chastened
+by the sensibility of his heart.  His soul overflowed with ardent
+affections, and his friendship was of that devoted and wondrous nature
+that the world-minded teach us to look for only in the imagination. But
+even human sympathies were not sufficient to satisfy his eager mind.
+The scenery of external nature, which others regard only with
+admiration, he loved with ardour:--
+
+
+     ----The sounding cataract
+     Haunted him like a passion:  the tall rock,
+     The mountain, and the deep and gloomy wood,
+     Their colours and their forms, were then to him
+     An appetite; a feeling, and a love,
+     That had no need of a remoter charm,
+     By thought supplied, or any interest
+     Unborrow'd from the eye.
+
+                    [Wordsworth's "Tintern Abbey".]
+
+
+And where does he now exist?  Is this gentle and lovely being lost
+forever?  Has this mind, so replete with ideas, imaginations fanciful
+and magnificent, which formed a world, whose existence depended on the
+life of its creator;--has this mind perished?  Does it now only exist
+in my memory?  No, it is not thus; your form so divinely wrought, and
+beaming with beauty, has decayed, but your spirit still visits and
+consoles your unhappy friend.
+
+Pardon this gush of sorrow; these ineffectual words are but a slight
+tribute to the unexampled worth of Henry, but they soothe my heart,
+overflowing with the anguish which his remembrance creates.  I will
+proceed with my tale.
+
+Beyond Cologne we descended to the plains of Holland; and we resolved
+to post the remainder of our way, for the wind was contrary and the
+stream of the river was too gentle to aid us.  Our journey here lost
+the interest arising from beautiful scenery, but we arrived in a few
+days at Rotterdam, whence we proceeded by sea to England.  It was on a
+clear morning, in the latter days of December, that I first saw the
+white cliffs of Britain.  The banks of the Thames presented a new
+scene; they were flat but fertile, and almost every town was marked by
+the remembrance of some story.  We saw Tilbury Fort and remembered the
+Spanish Armada, Gravesend, Woolwich, and Greenwich--places which I had
+heard of even in my country.
+
+At length we saw the numerous steeples of London, St. Paul's towering
+above all, and the Tower famed in English history.
+
+
+
+Chapter 19
+
+London was our present point of rest; we determined to remain several
+months in this wonderful and celebrated city.  Clerval desired the
+intercourse of the men of genius and talent who flourished at this
+time, but this was with me a secondary object; I was principally
+occupied with the means of obtaining the information necessary for the
+completion of my promise and quickly availed myself of the letters of
+introduction that I had brought with me, addressed to the most
+distinguished natural philosophers.
+
+If this journey had taken place during my days of study and happiness,
+it would have afforded me inexpressible pleasure.  But a blight had
+come over my existence, and I only visited these people for the sake of
+the information they might give me on the subject in which my interest
+was so terribly profound.  Company was irksome to me; when alone, I
+could fill my mind with the sights of heaven and earth; the voice of
+Henry soothed me, and I could thus cheat myself into a transitory
+peace.  But busy, uninteresting, joyous faces brought back despair to
+my heart.  I saw an insurmountable barrier placed between me and my
+fellow men; this barrier was sealed with the blood of William and
+Justine, and to reflect on the events connected with those names filled
+my soul with anguish.
+
+But in Clerval I saw the image of my former self; he was inquisitive
+and anxious to gain experience and instruction.  The difference of
+manners which he observed was to him an inexhaustible source of
+instruction and amusement.  He was also pursuing an object he had long
+had in view.  His design was to visit India, in the belief that he had
+in his knowledge of its various languages, and in the views he had
+taken of its society, the means of materially assisting the progress of
+European colonization and trade.  In Britain only could he further the
+execution of his plan.  He was forever busy, and the only check to his
+enjoyments was my sorrowful and dejected mind.  I tried to conceal this
+as much as possible, that I might not debar him from the pleasures
+natural to one who was entering on a new scene of life, undisturbed by
+any care or bitter recollection.  I often refused to accompany him,
+alleging another engagement, that I might remain alone.  I now also
+began to collect the materials necessary for my new creation, and this
+was to me like the torture of single drops of water continually falling
+on the head.  Every thought that was devoted to it was an extreme
+anguish, and every word that I spoke in allusion to it caused my lips
+to quiver, and my heart to palpitate.
+
+After passing some months in London, we received a letter from a person
+in Scotland who had formerly been our visitor at Geneva.  He mentioned
+the beauties of his native country and asked us if those were not
+sufficient allurements to induce us to prolong our journey as far north
+as Perth, where he resided.  Clerval eagerly desired to accept this
+invitation, and I, although I abhorred society, wished to view again
+mountains and streams and all the wondrous works with which Nature
+adorns her chosen dwelling-places.  We had arrived in England at the
+beginning of October, and it was now February.  We accordingly
+determined to commence our journey towards the north at the expiration
+of another month.  In this expedition we did not intend to follow the
+great road to Edinburgh, but to visit Windsor, Oxford, Matlock, and the
+Cumberland lakes, resolving to arrive at the completion of this tour
+about the end of July.  I packed up my chemical instruments and the
+materials I had collected, resolving to finish my labours in some
+obscure nook in the northern highlands of Scotland.
+
+We quitted London on the 27th of March and remained a few days at
+Windsor, rambling in its beautiful forest.  This was a new scene to us
+mountaineers; the majestic oaks, the quantity of game, and the herds of
+stately deer were all novelties to us.
+
+From thence we proceeded to Oxford.  As we entered this city our minds
+were filled with the remembrance of the events that had been transacted
+there more than a century and a half before.  It was here that Charles
+I. had collected his forces.  This city had remained faithful to him,
+after the whole nation had forsaken his cause to join the standard of
+Parliament and liberty.  The memory of that unfortunate king and his
+companions, the amiable Falkland, the insolent Goring, his queen, and
+son, gave a peculiar interest to every part of the city which they
+might be supposed to have inhabited.  The spirit of elder days found a
+dwelling here, and we delighted to trace its footsteps.  If these
+feelings had not found an imaginary gratification, the appearance of
+the city had yet in itself sufficient beauty to obtain our admiration.
+The colleges are ancient and picturesque; the streets are almost
+magnificent; and the lovely Isis, which flows beside it through meadows
+of exquisite verdure, is spread forth into a placid expanse of waters,
+which reflects its majestic assemblage of towers, and spires, and
+domes, embosomed among aged trees.
+
+I enjoyed this scene, and yet my enjoyment was embittered both by the
+memory of the past and the anticipation of the future.  I was formed
+for peaceful happiness.  During my youthful days discontent never
+visited my mind, and if I was ever overcome by ennui, the sight of what
+is beautiful in nature or the study of what is excellent and sublime in
+the productions of man could always interest my heart and communicate
+elasticity to my spirits.  But I am a blasted tree; the bolt has
+entered my soul; and I felt then that I should survive to exhibit what
+I shall soon cease to be--a miserable spectacle of wrecked humanity,
+pitiable to others and intolerable to myself.
+
+We passed a considerable period at Oxford, rambling among its environs
+and endeavouring to identify every spot which might relate to the most
+animating epoch of English history.  Our little voyages of discovery
+were often prolonged by the successive objects that presented
+themselves.  We visited the tomb of the illustrious Hampden and the
+field on which that patriot fell.  For a moment my soul was elevated
+from its debasing and miserable fears to contemplate the divine ideas
+of liberty and self sacrifice of which these sights were the monuments
+and the remembrancers.  For an instant I dared to shake off my chains
+and look around me with a free and lofty spirit, but the iron had eaten
+into my flesh, and I sank again, trembling and hopeless, into my
+miserable self.
+
+We left Oxford with regret and proceeded to Matlock, which was our next
+place of rest.  The country in the neighbourhood of this village
+resembled, to a greater degree, the scenery of Switzerland; but
+everything is on a lower scale, and the green hills want the crown of
+distant white Alps which always attend on the piny mountains of my
+native country.  We visited the wondrous cave and the little cabinets
+of natural history, where the curiosities are disposed in the same
+manner as in the collections at Servox and Chamounix.  The latter name
+made me tremble when pronounced by Henry, and I hastened to quit
+Matlock, with which that terrible scene was thus associated.
+
+From Derby, still journeying northwards, we passed two months in
+Cumberland and Westmorland.  I could now almost fancy myself among the
+Swiss mountains.  The little patches of snow which yet lingered on the
+northern sides of the mountains, the lakes, and the dashing of the
+rocky streams were all familiar and dear sights to me.  Here also we
+made some acquaintances, who almost contrived to cheat me into
+happiness.  The delight of Clerval was proportionably greater than
+mine; his mind expanded in the company of men of talent, and he found
+in his own nature greater capacities and resources than he could have
+imagined himself to have possessed while he associated with his
+inferiors.  "I could pass my life here," said he to me; "and among
+these mountains I should scarcely regret Switzerland and the Rhine."
+
+But he found that a traveller's life is one that includes much pain
+amidst its enjoyments.  His feelings are forever on the stretch; and
+when he begins to sink into repose, he finds himself obliged to quit
+that on which he rests in pleasure for something new, which again
+engages his attention, and which also he forsakes for other novelties.
+
+We had scarcely visited the various lakes of Cumberland and Westmorland
+and conceived an affection for some of the inhabitants when the period
+of our appointment with our Scotch friend approached, and we left them
+to travel on.  For my own part I was not sorry.  I had now neglected my
+promise for some time, and I feared the effects of the daemon's
+disappointment.  He might remain in Switzerland and wreak his vengeance
+on my relatives.  This idea pursued me and tormented me at every moment
+from which I might otherwise have snatched repose and peace.  I waited
+for my letters with feverish impatience; if they were delayed I was
+miserable and overcome by a thousand fears; and when they arrived and I
+saw the superscription of Elizabeth or my father, I hardly dared to
+read and ascertain my fate.  Sometimes I thought that the fiend
+followed me and might expedite my remissness by murdering my companion.
+When these thoughts possessed me, I would not quit Henry for a moment,
+but followed him as his shadow, to protect him from the fancied rage of
+his destroyer.  I felt as if I had committed some great crime, the
+consciousness of which haunted me.  I was guiltless, but I had indeed
+drawn down a horrible curse upon my head, as mortal as that of crime.
+
+I visited Edinburgh with languid eyes and mind; and yet that city might
+have interested the most unfortunate being.  Clerval did not like it so
+well as Oxford, for the antiquity of the latter city was more pleasing
+to him.  But the beauty and regularity of the new town of Edinburgh,
+its romantic castle and its environs, the most delightful in the world,
+Arthur's Seat, St. Bernard's Well, and the Pentland Hills compensated
+him for the change and filled him with cheerfulness and admiration. But
+I was impatient to arrive at the termination of my journey.
+
+We left Edinburgh in a week, passing through Coupar, St. Andrew's, and
+along the banks of the Tay, to Perth, where our friend expected us.
+But I was in no mood to laugh and talk with strangers or enter into
+their feelings or plans with the good humour expected from a guest; and
+accordingly I told Clerval that I wished to make the tour of Scotland
+alone.  "Do you," said I, "enjoy yourself, and let this be our
+rendezvous.  I may be absent a month or two; but do not interfere with
+my motions, I entreat you; leave me to peace and solitude for a short
+time; and when I return, I hope it will be with a lighter heart, more
+congenial to your own temper."
+
+Henry wished to dissuade me, but seeing me bent on this plan, ceased to
+remonstrate.  He entreated me to write often.  "I had rather be with
+you," he said, "in your solitary rambles, than with these Scotch
+people, whom I do not know; hasten, then, my dear  friend, to return,
+that I may again feel myself somewhat at home, which I cannot do in
+your absence."
+
+Having parted from my friend, I determined to visit some remote spot of
+Scotland and finish my work in solitude.  I did not doubt but that the
+monster followed me and would discover himself to me when I should have
+finished, that he might receive his companion.  With this resolution I
+traversed the northern highlands and fixed on one of the remotest of
+the Orkneys as the scene of my labours.  It was a place fitted for such
+a work, being hardly more than a rock whose high sides were continually
+beaten upon by the waves.  The soil was barren, scarcely affording
+pasture for a few miserable cows, and oatmeal for its inhabitants,
+which consisted of five persons, whose gaunt and scraggy limbs gave
+tokens of their miserable fare.  Vegetables and bread, when they
+indulged in such luxuries, and even fresh water, was to be procured
+from the mainland, which was about five miles distant.
+
+On the whole island there were but three miserable huts, and one of
+these was vacant when I arrived.  This I hired.  It contained but two
+rooms, and these exhibited all the squalidness of the most miserable
+penury.  The thatch had fallen in, the walls were unplastered, and the
+door was off its hinges.  I ordered it to be repaired, bought some
+furniture, and took possession, an incident which would doubtless have
+occasioned some surprise had not all the senses of the cottagers been
+benumbed by want and squalid poverty.  As it was, I lived ungazed at
+and unmolested, hardly thanked for the pittance of food and clothes
+which I gave, so much does suffering blunt even the coarsest sensations
+of men.
+
+In this retreat I devoted the morning to labour; but in the evening,
+when the weather permitted, I walked on the stony beach of the sea to
+listen to the waves as they roared and dashed at my feet.  It was a
+monotonous yet ever-changing scene.  I thought of Switzerland; it was
+far different from this desolate and appalling landscape.  Its hills
+are covered with vines, and its cottages are scattered thickly in the
+plains.  Its fair lakes reflect a blue and gentle sky, and when
+troubled by the winds, their tumult is but as the play of a lively
+infant when compared to the roarings of the giant ocean.
+
+In this manner I distributed my occupations when I first arrived, but
+as I proceeded in my labour, it became every day more horrible and
+irksome to me.  Sometimes I could not prevail on myself to enter my
+laboratory for several days, and at other times I toiled day and night
+in order to complete my work.  It was, indeed, a filthy process in
+which I was engaged.  During my first experiment, a kind of
+enthusiastic frenzy had blinded me to the horror of my employment; my
+mind was intently fixed on the consummation of my labour, and my eyes
+were shut to the horror of my proceedings.  But now I went to it in
+cold blood, and my heart often sickened at the work of my hands.
+
+Thus situated, employed in the most detestable occupation, immersed in
+a solitude where nothing could for an instant call my attention from
+the actual scene in which I was engaged, my spirits became unequal; I
+grew restless and nervous.  Every moment I feared to meet my
+persecutor.  Sometimes I sat with my eyes fixed on the ground, fearing
+to raise them lest they should encounter the object which I so much
+dreaded to behold.  I feared to wander from the sight of my fellow
+creatures lest when alone he should come to claim his companion.
+
+In the mean time I worked on, and my labour was already considerably
+advanced.  I looked towards its completion with a tremulous and eager
+hope, which I dared not trust myself to question but which was
+intermixed with obscure forebodings of evil that made my heart sicken
+in my bosom.
+
+
+
+Chapter 20
+
+I sat one evening in my laboratory; the sun had set, and the moon was
+just rising from the sea; I had not sufficient light for my employment,
+and I remained idle, in a pause of consideration of whether I should
+leave my labour for the night or hasten its conclusion by an
+unremitting attention to it.  As I sat, a train of reflection occurred
+to me which led me to consider the effects of what I was now doing.
+Three years before, I was engaged in the same manner and had created a
+fiend whose unparalleled barbarity had desolated my heart and filled it
+forever with the bitterest remorse.  I was now about to form another
+being of whose dispositions I was alike ignorant; she might become ten
+thousand times more malignant than her mate and delight, for its own
+sake, in murder and wretchedness.  He had sworn to quit the
+neighbourhood of man and hide himself in deserts, but she had not; and
+she, who in all probability was to become a thinking and reasoning
+animal, might refuse to comply with a compact made before her creation.
+They might even hate each other; the creature who already lived loathed
+his own deformity, and might he not conceive a greater abhorrence for
+it when it came before his eyes in the female form?  She also might
+turn with disgust from him to the superior beauty of man; she might
+quit him, and he be again alone, exasperated by the fresh provocation
+of being deserted by one of his own species.  Even if they were to
+leave Europe and inhabit the deserts of the new world, yet one of the
+first results of those sympathies for which the daemon thirsted would
+be children, and a race of devils would be propagated upon the earth
+who might make the very existence of the species of man a condition
+precarious and full of terror.  Had I right, for my own benefit, to
+inflict this curse upon everlasting generations?  I had before been
+moved by the sophisms of the being I had created; I had been struck
+senseless by his fiendish threats; but now, for the first time, the
+wickedness of my promise burst upon me; I shuddered to think that
+future ages might curse me as their pest, whose selfishness had not
+hesitated to buy its own peace at the price, perhaps, of the existence
+of the whole human race.
+
+I trembled and my heart failed within me, when, on looking up, I saw by
+the light of the moon the daemon at the casement.  A ghastly grin
+wrinkled his lips as he gazed on me, where I sat fulfilling the task
+which he had allotted to me.  Yes, he had followed me in my travels; he
+had loitered in forests, hid himself in caves, or taken refuge in wide
+and desert heaths; and he now came to mark my progress and claim the
+fulfilment of my promise.
+
+As I looked on him, his countenance expressed the utmost extent of
+malice and treachery.  I thought with a sensation of madness on my
+promise of creating another like to him, and trembling with passion,
+tore to pieces the thing on which I was engaged.  The wretch saw me
+destroy the creature on whose future existence he depended for
+happiness, and with a howl of devilish despair and revenge, withdrew.
+
+I left the room, and locking the door, made a solemn vow in my own
+heart never to resume my labours; and then, with trembling steps, I
+sought my own apartment. I was alone; none were near me to dissipate
+the gloom and relieve me from the sickening oppression of the most
+terrible reveries.
+
+Several hours passed, and I remained near my window gazing on the sea;
+it was almost motionless, for the winds were hushed, and all nature
+reposed under the eye of the quiet moon.  A few fishing vessels alone
+specked the water, and now and then the gentle breeze wafted the sound
+of voices as the fishermen called to one another.  I felt the silence,
+although I was hardly conscious of its extreme profundity, until my ear
+was suddenly arrested by the paddling of oars near the shore, and a
+person landed close to my house.
+
+In a few minutes after, I heard the creaking of my door, as if some one
+endeavoured to open it softly.  I trembled from head to foot; I felt a
+presentiment of who it was and wished to rouse one of the peasants who
+dwelt in a cottage not far from mine; but I was overcome by the
+sensation of helplessness, so often felt in frightful dreams, when you
+in vain endeavour to fly from an impending danger, and was rooted to
+the spot. Presently I heard the sound of footsteps along the passage;
+the door opened, and the wretch whom I dreaded appeared.
+
+Shutting the door, he approached me and said in a smothered voice, "You
+have destroyed the work which you began; what is it that you intend?
+Do you dare to break your promise?  I have endured toil and misery; I
+left Switzerland with you; I crept along the shores of the Rhine, among
+its willow islands and over the summits of its hills.  I have dwelt
+many months in the heaths of England and among the deserts of Scotland.
+I have endured incalculable fatigue, and cold, and hunger; do you dare
+destroy my hopes?"
+
+"Begone!  I do break my promise; never will I create another like
+yourself, equal in deformity and wickedness."
+
+"Slave, I before reasoned with you, but you have proved yourself
+unworthy of my condescension.  Remember that I have power; you believe
+yourself miserable, but I can make you so wretched that the light of
+day will be hateful to you.  You are my creator, but I am your master;
+obey!"
+
+"The hour of my irresolution is past, and the period of your power is
+arrived.  Your threats cannot move me to do an act of wickedness; but
+they confirm me in a determination of not creating you a companion in
+vice.  Shall I, in cool blood, set loose upon the earth a daemon whose
+delight is in death and wretchedness?  Begone!  I am firm, and your
+words will only exasperate my rage."
+
+The monster saw my determination in my face and gnashed his teeth in
+the impotence of anger.  "Shall each man," cried he, "find a wife for
+his bosom, and each beast have his mate, and I be alone?  I had
+feelings of affection, and they were requited by detestation and scorn.
+Man!  You may hate, but beware!  Your hours will pass in dread and
+misery, and soon the bolt  will fall which must ravish from you your
+happiness forever.  Are you to be happy while I grovel in the intensity
+of my wretchedness?  You can blast my other passions, but revenge
+remains--revenge, henceforth dearer than light or food!  I may die, but
+first you, my tyrant and tormentor, shall curse the sun that gazes on
+your misery.  Beware, for I am fearless and therefore powerful.  I will
+watch with the wiliness of a snake, that I may sting with its venom.
+Man, you shall repent of the injuries you inflict."
+
+"Devil, cease; and do not poison the air with these sounds of malice.
+I have declared my resolution to you, and I am no coward to bend
+beneath words.  Leave me; I am inexorable."
+
+"It is well.  I go; but remember, I shall be with you on your
+wedding-night."
+
+I started forward and exclaimed, "Villain!  Before you sign my
+death-warrant, be sure that you are yourself safe."
+
+I would have seized him, but he eluded me and quitted the house with
+precipitation.  In a few moments I saw him in his boat, which shot
+across the waters with an arrowy swiftness and was soon lost amidst the
+waves.
+
+All was again silent, but his words rang in my ears.  I burned with
+rage to pursue the murderer of my peace and precipitate him into the
+ocean.  I walked up and down my room hastily and perturbed, while my
+imagination conjured up a thousand images to torment and sting me.  Why
+had I not followed him and closed with him in mortal strife?  But I had
+suffered him to depart, and he had directed his course towards the
+mainland.  I shuddered to think who might be the next victim sacrificed
+to his insatiate revenge.  And then I thought again of his words--"I
+WILL BE WITH YOU ON YOUR WEDDING-NIGHT."  That, then, was the period
+fixed for the fulfilment of my destiny.  In that hour I should die and
+at once satisfy and extinguish his malice.  The prospect did not move
+me to fear; yet when I thought of my beloved Elizabeth, of her tears
+and endless sorrow, when she should find her lover so barbarously
+snatched from her, tears, the first I had shed for many months,
+streamed from my eyes, and I resolved not to fall before my enemy
+without a bitter struggle.
+
+The night passed away, and the sun rose from the ocean; my feelings
+became calmer, if it may be called calmness when the violence of rage
+sinks into the depths of despair.  I left the house, the horrid scene
+of the last night's contention, and walked on the beach of the sea,
+which I almost regarded as an insuperable barrier between me and my
+fellow creatures; nay, a wish that such should prove the fact stole
+across me.
+
+I desired that I might pass my life on that barren rock, wearily, it is
+true, but uninterrupted by any sudden shock of misery.  If I returned,
+it was to be sacrificed or to see those whom I most loved die under the
+grasp of a daemon whom I had myself created.
+
+I walked about the isle like a restless spectre, separated from all it
+loved and miserable in the separation.  When it became noon, and the
+sun rose higher, I lay down on the grass and was overpowered by a deep
+sleep.  I had been awake the whole of the preceding night, my nerves
+were agitated, and my eyes inflamed by watching and misery.  The sleep
+into which I now sank refreshed me; and when I awoke, I again felt as
+if I belonged to a race of human beings like myself, and I began to
+reflect upon what had passed with greater composure; yet still the
+words of the fiend rang in my ears like a death-knell; they appeared
+like a dream, yet distinct and oppressive as a reality.
+
+The sun had far descended, and I still sat on the shore, satisfying my
+appetite, which had become ravenous, with an oaten cake, when I saw a
+fishing-boat land close to me, and one of the men brought me a packet;
+it contained letters from Geneva, and one from Clerval entreating me to
+join him.  He said that he was wearing away his time fruitlessly where
+he was, that letters from the friends he had formed in London desired
+his return to complete the negotiation they had entered into for his
+Indian enterprise.  He could not any longer delay his departure; but as
+his journey to London might be followed, even sooner than he now
+conjectured, by his longer voyage, he entreated me to bestow as much of
+my society on him as I could spare.  He besought me, therefore, to
+leave my solitary isle and to meet him at Perth, that we might proceed
+southwards together.  This letter in a degree recalled me to life, and
+I determined to quit my island at the expiration of two days.  Yet,
+before I departed, there was a task to perform, on which I shuddered to
+reflect; I must pack up my chemical instruments, and for that purpose I
+must enter the room which had been the scene of my odious work, and I
+must handle those utensils the sight of which was sickening to me. The
+next morning, at daybreak, I summoned sufficient courage and unlocked
+the door of my laboratory.  The remains of the half-finished creature,
+whom I had destroyed, lay scattered on the floor, and I almost felt as
+if I had mangled the living flesh of a human being.  I paused to
+collect myself and then entered the chamber.  With trembling hand I
+conveyed the instruments out of the room, but I reflected that I ought
+not to leave the relics of my work to excite the horror and suspicion
+of the peasants; and I accordingly put them into a basket, with a great
+quantity of stones, and laying them up, determined to throw them into
+the sea that very night; and in the meantime I sat upon the beach,
+employed in cleaning and arranging my chemical apparatus.
+
+Nothing could be more complete than the alteration that had taken place
+in my feelings since the night of the appearance of the daemon.  I had
+before regarded my promise with a gloomy despair as a thing that, with
+whatever consequences, must be fulfilled; but I now felt as if a film
+had been taken from before my eyes and that I for the first time saw
+clearly.  The idea of renewing my labours did not for one instant occur
+to me; the threat I had heard weighed on my thoughts, but I did not
+reflect that a voluntary act of mine could avert it.  I had resolved in
+my own mind that to create another like the fiend I had first made
+would be an act of the basest and most atrocious selfishness, and I
+banished from my mind every thought that could lead to a different
+conclusion.
+
+Between two and three in the morning the moon rose; and I then, putting
+my basket aboard a little skiff, sailed out about four miles from the
+shore.  The scene was perfectly solitary; a few boats were returning
+towards land, but I sailed away from them.  I felt as if I was about
+the commission of a dreadful crime and avoided with shuddering anxiety
+any encounter with my fellow creatures.  At one time the moon, which
+had before been clear, was suddenly overspread by a thick cloud, and I
+took advantage of the moment of darkness and cast my basket into the
+sea; I listened to the gurgling sound as it sank and then sailed away
+from the spot.  The sky became clouded, but the air was pure, although
+chilled by the northeast breeze that was then rising.  But it refreshed
+me and filled me with such agreeable sensations that I resolved to
+prolong my stay on the water, and fixing the rudder in a direct
+position, stretched myself at the bottom of the boat.  Clouds hid the
+moon, everything was obscure, and I heard only the sound of the boat as
+its keel cut through the waves; the murmur lulled me, and in a short
+time I slept soundly. I do not know how long I remained in this
+situation, but when I awoke I found that the sun had already mounted
+considerably.  The wind was high, and the waves continually threatened
+the safety of my little skiff.  I found that the wind was northeast and
+must have driven me far from the coast from which I had embarked.  I
+endeavoured to change my course but quickly found that if I again made
+the attempt the boat would be instantly filled with water.  Thus
+situated, my only resource was to drive before the wind.  I confess
+that I felt a few sensations of terror.  I had no compass with me and
+was so slenderly acquainted with the geography of this part of the
+world that the sun was of little benefit to me.  I might be driven into
+the wide Atlantic and feel all the tortures of starvation or be
+swallowed up in the immeasurable waters that roared and buffeted around
+me.  I had already been out many hours and felt the torment of a
+burning thirst, a prelude to my other sufferings.  I looked on the
+heavens, which were covered by clouds that flew before the wind, only
+to be replaced by others; I looked upon the sea; it was to be my grave.
+"Fiend," I exclaimed, "your task is already fulfilled!"  I thought of
+Elizabeth, of my father, and of Clerval--all left behind, on whom the
+monster might satisfy his sanguinary and merciless passions.  This idea
+plunged me into a reverie so despairing and frightful that even now,
+when the scene is on the point of closing before me forever, I shudder
+to reflect on it.
+
+Some hours passed thus; but by degrees, as the sun declined towards the
+horizon, the wind died away into a gentle breeze and the sea became
+free from breakers.  But these gave place to a heavy swell; I felt sick
+and hardly able to hold the rudder, when suddenly I saw a line of high
+land towards the south.
+
+Almost spent, as I was, by fatigue and the dreadful suspense I endured
+for several hours, this sudden certainty of life rushed like a flood of
+warm joy to my heart, and tears gushed from my eyes.
+
+How mutable are our feelings, and how strange is that clinging love we
+have of life even in the excess of misery!  I constructed another sail
+with a part of my dress and eagerly steered my course towards the land.
+It had a wild and rocky appearance, but as I approached nearer I easily
+perceived the traces of cultivation.  I saw vessels near the shore and
+found myself suddenly transported back to the neighbourhood of
+civilized man.  I carefully traced the windings of the land and hailed
+a steeple which I at length saw issuing from behind a small promontory.
+As I was in a state of extreme debility, I resolved to sail directly
+towards the town, as a place where I could most easily procure
+nourishment.  Fortunately I had money with me.
+
+As I turned the promontory I perceived a small neat town and a good
+harbour, which I entered, my heart bounding with joy at my unexpected
+escape.
+
+As I was occupied in fixing the boat and arranging the sails, several
+people crowded towards the spot.  They seemed much surprised at my
+appearance, but instead of offering me any assistance, whispered
+together with gestures that at any other time might have produced in me
+a slight sensation of alarm. As it was, I merely remarked that they
+spoke English, and I therefore addressed them in that language.  "My
+good friends," said I, "will you be so kind as to tell me the name of
+this town and inform me where I am?"
+
+"You will know that soon enough," replied a man with a hoarse voice.
+"Maybe you are come to a place that will not prove much to your taste,
+but you will not be consulted as to your quarters, I promise you."
+
+I was exceedingly surprised on receiving so rude an answer from a
+stranger, and I was also disconcerted on perceiving the frowning and
+angry countenances of his companions.  "Why do you answer me so
+roughly?"  I replied.  "Surely it is not the custom of Englishmen to
+receive strangers so inhospitably."
+
+"I do not know," said the man, "what the custom of the English may be,
+but it is the custom of the Irish to hate villains." While this strange
+dialogue continued, I perceived the crowd rapidly increase.  Their
+faces expressed a mixture of curiosity and anger, which annoyed  and in
+some degree alarmed me.
+
+I inquired the way to the inn, but no one replied.  I then moved
+forward, and a murmuring sound arose from the crowd as they followed
+and surrounded me, when an ill-looking man approaching tapped me on the
+shoulder and said, "Come, sir, you must follow me to Mr. Kirwin's to
+give an account of yourself."
+
+"Who is Mr. Kirwin?  Why am I to give an account of myself?  Is not
+this a free country?"
+
+"Ay, sir, free enough for honest folks.  Mr. Kirwin is a magistrate,
+and you are to give an account of the death of a gentleman who was
+found murdered here last night."
+
+This answer startled me, but I presently recovered myself.  I was
+innocent; that could easily be proved; accordingly I followed my
+conductor in silence and was led to one of the best houses in the town.
+I was ready to sink from fatigue and hunger, but being surrounded by a
+crowd, I thought it politic to rouse all my strength, that no physical
+debility might be construed into apprehension or conscious guilt.
+Little did I then expect the calamity that was in a few moments to
+overwhelm me and extinguish in horror and despair all fear of ignominy
+or death. I must pause here, for it requires all my fortitude to recall
+the memory of the frightful events which I am about to relate, in
+proper detail, to my recollection.
+
+
+
+Chapter 21
+
+I was soon introduced into the presence of the magistrate, an old
+benevolent man with calm and mild manners.  He looked upon me, however,
+with some degree of severity, and then, turning towards my conductors,
+he asked who appeared as witnesses on this occasion.
+
+About half a dozen men came forward; and, one being selected by the
+magistrate, he deposed that he had been out fishing the night before
+with his son and brother-in-law, Daniel Nugent, when, about ten
+o'clock, they observed a strong northerly blast rising, and they
+accordingly put in for port.  It was a very dark night, as the moon had
+not yet risen; they did not land at the harbour, but, as they had been
+accustomed, at a creek about two miles below.  He walked on first,
+carrying a part of the fishing tackle, and his companions followed him
+at some distance.
+
+As he was proceeding along the sands, he struck his foot against
+something and fell at his length on the ground. His companions came up
+to assist him, and by the light of their lantern they found that he had
+fallen on the body of a man, who was to all appearance dead.  Their
+first supposition was that it was the corpse of some person who had
+been drowned and was thrown on shore by the waves, but on examination
+they found that the clothes were not wet and even that the body was not
+then cold.  They instantly carried it to the cottage of an old woman
+near the spot and endeavoured, but in vain, to restore it to life.  It
+appeared to be a handsome young man, about five and twenty years of
+age.  He had apparently been strangled, for there was no sign of any
+violence except the black mark of fingers on his neck.
+
+The first part of this deposition did not in the least interest me, but
+when the mark of the fingers was mentioned I remembered the murder of
+my brother and felt myself extremely agitated; my limbs trembled, and a
+mist came over my eyes, which obliged me to lean on a chair for
+support.  The magistrate observed me with a keen eye and of course drew
+an unfavourable augury from my manner.
+
+The son confirmed his father's account, but when Daniel Nugent was
+called he swore positively that just before the fall of his companion,
+he saw a boat, with a single man in it, at a short distance from the
+shore; and as far as he could judge by the light of a few stars, it was
+the same boat in which I had just landed.  A woman deposed that she
+lived near the beach and was standing at the door of her cottage,
+waiting for the return of the fishermen, about an hour before she heard
+of the discovery of the body, when she saw a boat with only one man in
+it push off from that part of the shore where the corpse was afterwards
+found.
+
+Another woman confirmed the account of the fishermen having brought the
+body into her house; it was not cold.  They put it into a bed and
+rubbed it, and Daniel went to the town for an apothecary, but life was
+quite gone.
+
+Several other men were examined concerning my landing, and they agreed
+that, with the strong north wind that had arisen during the night, it
+was very probable that I had beaten about for many hours and had been
+obliged to return nearly to the same spot from which I had departed.
+Besides, they observed that it appeared that I had brought the body
+from another place, and it was likely that as I did not appear to know
+the shore, I might have put into the harbour ignorant of the distance
+of the town of ---- from the place where I had deposited the corpse.
+
+Mr. Kirwin, on hearing this evidence, desired that I should be taken
+into the room where the body lay for interment, that it might be
+observed what effect the sight of it would produce upon me.  This idea
+was probably suggested by the extreme agitation I had exhibited when
+the mode of the murder had been described.  I was accordingly
+conducted, by the magistrate and several other persons, to the inn.  I
+could not help being struck by the strange coincidences that had taken
+place during this eventful night; but, knowing that I had been
+conversing with several persons in the island I had inhabited about the
+time that the body had been found, I was perfectly tranquil as to the
+consequences of the affair.  I entered the room where the corpse lay
+and was led up to the coffin.  How can I describe my sensations on
+beholding it?  I feel yet parched with horror, nor can I reflect on
+that terrible moment without shuddering and agony.  The examination,
+the presence of the magistrate and witnesses, passed like a dream from
+my memory when I saw the lifeless form of Henry Clerval stretched
+before me.  I gasped for breath, and throwing myself on the body, I
+exclaimed, "Have my murderous machinations deprived you also, my
+dearest Henry, of life?  Two I have already destroyed; other victims
+await their destiny; but you, Clerval, my friend, my benefactor--"
+
+The human frame could no longer support the agonies that I endured, and
+I was carried out of the room in strong convulsions.  A fever succeeded
+to this.  I lay for two months on the point of death; my ravings, as I
+afterwards heard, were frightful; I called myself the murderer of
+William, of Justine, and of Clerval.  Sometimes I entreated my
+attendants to assist me in the destruction of the fiend by whom I was
+tormented; and at others I felt the fingers of the monster already
+grasping my neck, and screamed aloud with agony and terror.
+Fortunately, as I spoke my native language, Mr. Kirwin alone understood
+me; but my gestures and bitter cries were sufficient to affright the
+other witnesses.  Why did I not die?  More miserable than man ever was
+before, why did I not sink into forgetfulness and rest?  Death snatches
+away many blooming children, the only hopes of their doting parents;
+how many brides and youthful lovers have been one day in the bloom of
+health and hope, and the next a prey for worms and the decay of the
+tomb!  Of what materials was I made that I could thus resist so many
+shocks, which, like the turning of the wheel, continually renewed the
+torture?
+
+But I was doomed to live and in two months found myself as awaking from
+a dream, in a prison, stretched on a wretched bed, surrounded by
+jailers, turnkeys, bolts, and all the miserable apparatus of a dungeon.
+It was morning, I remember, when I thus awoke to understanding; I had
+forgotten the particulars of what had happened and only felt as if some
+great misfortune had suddenly overwhelmed me; but when I looked around
+and saw the barred windows and the squalidness of the room in which I
+was, all flashed across my memory and I groaned bitterly.
+
+This sound disturbed an old woman who was sleeping in a chair beside
+me.  She was a hired nurse, the wife of one of the turnkeys, and her
+countenance expressed all those bad qualities which often characterize
+that class.  The lines of her face were hard and rude, like that of
+persons accustomed to see without sympathizing in sights of misery. Her
+tone expressed her entire indifference; she addressed me in English,
+and the voice struck me as one that I had heard during my sufferings.
+"Are you better now, sir?" said she.
+
+I replied in the same language, with a feeble voice, "I believe I am;
+but if it be all true, if indeed I did not dream, I am sorry that I am
+still alive to feel this misery and horror."
+
+"For that matter," replied the old woman, "if you mean about the
+gentleman you murdered, I believe that it were better for you if you
+were dead, for I fancy it will go hard with you!  However, that's none
+of my business; I am sent to nurse you and get you well; I do my duty
+with a safe conscience; it were well if everybody did the same."
+
+I turned with loathing from the woman who could utter so unfeeling a
+speech to a person just saved, on the very edge of death; but I felt
+languid and unable to reflect on all that had passed.  The whole series
+of my life appeared to me as a dream; I sometimes doubted if indeed it
+were all true, for it never presented itself to my mind with the force
+of reality.
+
+As the images that floated before me became more distinct, I grew
+feverish; a darkness pressed around me; no one was near me who soothed
+me with the gentle voice of love; no dear hand supported me.  The
+physician came and prescribed medicines, and the old woman prepared
+them for me; but utter carelessness was visible in the first, and the
+expression of brutality was strongly marked in the visage of the
+second.  Who could be interested in the fate of a murderer but the
+hangman who would gain his fee?
+
+These were my first reflections, but I soon learned that Mr. Kirwin had
+shown me extreme kindness.  He had caused the best room in the prison
+to be prepared for me (wretched indeed was the best); and it was he who
+had provided a physician and a nurse.  It is true, he seldom came to
+see me, for although he ardently desired to relieve the sufferings of
+every human creature, he did not wish to be present at the agonies and
+miserable ravings of a murderer.  He came, therefore, sometimes to see
+that I was not neglected, but his visits were short and with long
+intervals.  One day, while I was gradually recovering, I was seated in
+a chair, my eyes half open and my cheeks livid like those in death.  I
+was overcome by gloom and misery and often reflected I had better seek
+death than desire to remain in a world which to me was replete with
+wretchedness.  At one time I considered whether I should not declare
+myself guilty and suffer the penalty of the law, less innocent than
+poor Justine had been.  Such were my thoughts when the door of my
+apartment was opened and Mr. Kirwin entered.  His countenance expressed
+sympathy and compassion; he drew a chair close to mine and addressed me
+in French, "I fear that this place is very shocking to you; can I do
+anything to make you more comfortable?"
+
+"I thank you, but all that you mention is nothing to me; on the whole
+earth there is no comfort which I am capable of receiving."
+
+"I know that the sympathy of a stranger can be but of little relief to
+one borne down as you are by so strange a misfortune.  But you will, I
+hope, soon quit this melancholy abode, for doubtless evidence can
+easily be brought to free you from the criminal charge."
+
+"That is my least concern; I am, by a course of strange events, become
+the most miserable of mortals.  Persecuted and tortured as I am and
+have been, can death be any evil to me?"
+
+"Nothing indeed could be more unfortunate and agonizing than the
+strange chances that have lately occurred.  You were thrown, by some
+surprising accident, on this shore, renowned for its hospitality,
+seized immediately, and charged with murder.  The first sight that was
+presented to your eyes was the body of your friend, murdered in so
+unaccountable a manner and placed, as it were, by some fiend across
+your path."
+
+As Mr. Kirwin said this, notwithstanding the agitation I endured on
+this retrospect of my sufferings, I also felt considerable surprise at
+the knowledge he seemed to possess concerning me.  I suppose some
+astonishment was exhibited in my countenance, for Mr. Kirwin hastened
+to say, "Immediately upon your being taken ill, all the papers that
+were on your person were brought me, and I examined them that I might
+discover some trace by which I could send to your relations an account
+of your misfortune and illness. I found several letters, and, among
+others, one which I discovered from its commencement to be from your
+father.  I instantly wrote to Geneva; nearly two months have elapsed
+since the departure of my letter.  But you are ill; even now you
+tremble; you are unfit for agitation of any kind."
+
+"This suspense is a thousand times worse than the most horrible event;
+tell me what new scene of death has been acted, and whose murder I am
+now to lament?"
+
+"Your family is perfectly well," said Mr. Kirwin with gentleness; "and
+someone, a friend, is come to visit you."
+
+I know not by what chain of thought the idea presented itself, but it
+instantly darted into my mind that the murderer had come to mock at my
+misery and taunt me with the death of Clerval, as a new incitement for
+me to comply with his hellish desires.  I put my hand before my eyes,
+and cried out in agony, "Oh! Take him away!  I cannot see him; for
+God's sake, do not let him enter!"
+
+Mr. Kirwin regarded me with a troubled countenance.  He could not help
+regarding my exclamation as a presumption of my guilt and said in
+rather a severe tone, "I should have thought, young man, that the
+presence of your father would have been welcome instead of inspiring
+such violent repugnance."
+
+"My father!" cried I, while every feature and every muscle was relaxed
+from anguish to pleasure.  "Is my father indeed come?  How kind, how
+very kind!  But where is he, why does he not hasten to me?"
+
+My change of manner surprised and pleased the magistrate; perhaps he
+thought that my former exclamation was a momentary return of delirium,
+and now he instantly resumed his former benevolence.  He rose and
+quitted the room with my nurse, and in a moment my father entered it.
+
+Nothing, at this moment, could have given me greater pleasure than the
+arrival of my father.  I stretched out my hand to him and cried, "Are
+you, then, safe--and Elizabeth--and Ernest?" My father calmed me with
+assurances of their welfare and endeavoured, by dwelling on these
+subjects so interesting to my heart, to raise my desponding spirits;
+but he soon felt that a prison cannot be the abode of cheerfulness.
+
+"What a place is this that you inhabit, my son!" said he, looking
+mournfully at the barred windows and wretched appearance of the room.
+"You travelled to seek happiness, but a fatality seems to pursue you.
+And poor Clerval--"
+
+The name of my unfortunate and murdered friend was an agitation too
+great to be endured in my weak state; I shed tears.  "Alas!  Yes, my
+father," replied I; "some destiny of the most horrible kind hangs over
+me, and I must live to fulfil it, or surely I should have died on the
+coffin of Henry."
+
+We were not allowed to converse for any length of time, for the
+precarious state of my health rendered every precaution necessary that
+could ensure tranquillity.  Mr. Kirwin came in and insisted that my
+strength should not be exhausted by too much exertion.  But the
+appearance of my father was to me like that of my good angel, and I
+gradually recovered my health.
+
+As my sickness quitted me, I was absorbed by a gloomy and black
+melancholy that nothing could dissipate.  The image of Clerval was
+forever before me, ghastly and murdered.  More than once the agitation
+into which these reflections threw me made my friends dread a dangerous
+relapse.  Alas!  Why did they preserve so miserable and detested a
+life?  It was surely that I might fulfil my destiny, which is now
+drawing to a close.  Soon, oh, very soon, will death extinguish these
+throbbings and relieve me from the mighty weight of anguish that bears
+me to the dust; and, in executing the award of justice, I shall also
+sink to rest.  Then the appearance of death was distant, although the
+wish was ever present to my thoughts; and I often sat for hours
+motionless and speechless, wishing for some mighty revolution that
+might bury me and my destroyer in its ruins.
+
+The season of the assizes approached.  I had already been three months
+in prison, and although I was still weak and in continual danger of a
+relapse, I was obliged to travel nearly a hundred miles to the country
+town where the court was held.  Mr. Kirwin charged himself with every
+care of collecting witnesses and arranging my defence.  I was spared
+the disgrace of appearing publicly as a criminal, as the case was not
+brought before the court that decides on life and death.  The grand
+jury rejected the bill, on its being proved that I was on the Orkney
+Islands at the hour the body of my friend was found; and a fortnight
+after my removal I was liberated from prison.
+
+My father was enraptured on finding me freed from the vexations of a
+criminal charge, that I was again allowed to breathe the fresh
+atmosphere and permitted to return to my native country.  I did not
+participate in these feelings, for to me the walls of a dungeon or a
+palace were alike hateful.  The cup of life was poisoned forever, and
+although the sun shone upon me, as upon the happy and gay of heart, I
+saw around me nothing but a dense and frightful darkness, penetrated by
+no light but the glimmer of two eyes that glared upon me.  Sometimes
+they were the expressive eyes of Henry, languishing in death, the dark
+orbs nearly covered by the lids and the long black lashes that fringed
+them; sometimes it was the watery, clouded eyes of the monster, as I
+first saw them in my chamber at Ingolstadt.
+
+My father tried to awaken in me the feelings of affection.  He talked
+of Geneva, which I should soon visit, of Elizabeth and Ernest; but
+these words only drew deep groans from me.  Sometimes, indeed, I felt a
+wish for happiness and thought with melancholy delight of my beloved
+cousin or longed, with a devouring maladie du pays, to see once more
+the blue lake and rapid Rhone, that had been so dear to me in early
+childhood; but my general state of feeling was a torpor in which a
+prison was as welcome a residence as the divinest scene in nature; and
+these fits were seldom interrupted but by paroxysms of anguish and
+despair.  At these moments I often endeavoured to put an end to the
+existence I loathed, and it required unceasing attendance and vigilance
+to restrain me from committing some dreadful act of violence.
+
+Yet one duty remained to me, the recollection of which finally
+triumphed over my selfish despair.  It was necessary that I should
+return without delay to Geneva, there to watch over the lives of those
+I so fondly loved and to lie in wait for the murderer, that if any
+chance led me to the place of his concealment, or if he dared again to
+blast me by his presence, I might, with unfailing aim, put an end to
+the existence of the monstrous image which  I had endued with the
+mockery of a soul still more monstrous.  My father still desired to
+delay our departure, fearful that I could not sustain the fatigues of a
+journey, for I was a shattered wreck--the shadow of a human being.  My
+strength was gone.  I was a mere skeleton, and fever night and day
+preyed upon my wasted frame.  Still, as I urged our leaving Ireland
+with such inquietude and impatience, my father thought it best to
+yield.  We took our passage on board a vessel bound for Havre-de-Grace
+and sailed with a fair wind from the Irish shores.  It was midnight.  I
+lay on the deck looking at the stars and listening to the dashing of
+the waves.  I hailed the darkness that shut Ireland from my sight, and
+my pulse beat with a feverish joy when I reflected that I should soon
+see Geneva.  The past appeared to me in the light of a frightful dream;
+yet the vessel in which I was, the wind that blew me from the detested
+shore of Ireland, and the sea which surrounded me told me too forcibly
+that I was deceived by no vision and that Clerval, my friend and
+dearest companion, had fallen a victim to me and the monster of my
+creation.  I repassed, in my memory, my whole life--my quiet happiness
+while residing with my family in Geneva, the death of my mother, and my
+departure for Ingolstadt.  I remembered, shuddering, the mad enthusiasm
+that hurried me on to the creation of my hideous enemy, and I called to
+mind the night in which he first lived.  I was unable to pursue the
+train of thought; a thousand feelings pressed upon me, and I wept
+bitterly.  Ever since my recovery from the fever I had been in the
+custom of taking every night a small quantity of laudanum, for it was
+by means of this drug only that I was enabled to gain the rest
+necessary for the preservation of life.  Oppressed by the recollection
+of my various misfortunes, I now swallowed double my usual quantity and
+soon slept profoundly.  But sleep did not afford me respite from
+thought and misery; my dreams presented a thousand objects that scared
+me.  Towards morning I was possessed by a kind of nightmare; I felt the
+fiend's grasp in my neck and could not free myself from it; groans and
+cries rang in my ears.  My father, who was watching over me, perceiving
+my restlessness, awoke me; the dashing waves were around, the cloudy
+sky above, the fiend was not here: a sense of security, a feeling that
+a truce was established between the present hour and the irresistible,
+disastrous future imparted to me a kind of calm forgetfulness, of which
+the human mind is by its structure peculiarly susceptible.
+
+
+
+Chapter 22
+
+The voyage came to an end.  We landed, and proceeded to Paris.  I soon
+found that I had overtaxed my strength and that I must repose before I
+could continue my journey.  My father's care and attentions were
+indefatigable, but he did not know the origin of my sufferings and
+sought erroneous methods to remedy the incurable ill.  He wished me to
+seek amusement in society.  I abhorred the face of man.  Oh, not
+abhorred!  They were my brethren, my fellow beings, and I felt
+attracted even to the most repulsive among them, as to creatures of an
+angelic nature and celestial mechanism.  But I felt that I had no right
+to share their intercourse.  I had unchained an enemy among them whose
+joy it was to shed their blood and to revel in their groans.  How they
+would, each and all, abhor me and hunt me from the world did they know
+my unhallowed acts and the crimes which had their source in me!
+
+My father yielded at length to my desire to avoid society and strove by
+various arguments to banish my despair.  Sometimes he thought that I
+felt deeply the degradation of being obliged to answer a charge of
+murder, and he endeavoured to prove to me the futility of pride.
+
+"Alas!  My father," said I, "how little do you know me.  Human beings,
+their feelings and passions, would indeed be degraded if such a wretch
+as I felt pride.  Justine, poor unhappy Justine, was as innocent as I,
+and she suffered the same charge; she died for it; and I am the cause
+of this--I murdered her.  William, Justine, and Henry--they all died by
+my hands."
+
+My father had often, during my imprisonment, heard me make the same
+assertion; when I thus accused myself, he sometimes seemed to desire an
+explanation, and at others he appeared to consider it as the offspring
+of delirium, and that, during my illness, some idea of this kind had
+presented itself to my imagination, the remembrance of which I
+preserved in my convalescence.
+
+I avoided explanation and maintained a continual silence concerning the
+wretch I had created.  I had a persuasion that I should be supposed
+mad, and this in itself would forever have chained my tongue.  But,
+besides, I could not bring myself to disclose a secret which would fill
+my hearer with consternation and make fear and unnatural horror the
+inmates of his breast.  I checked, therefore, my impatient thirst for
+sympathy and was silent when I would have given the world to have
+confided the fatal secret.  Yet, still, words like those I have
+recorded would burst uncontrollably from me.  I could offer no
+explanation of them, but their truth in part relieved the burden of my
+mysterious woe.  Upon this occasion my father said, with an expression
+of unbounded wonder, "My dearest Victor, what infatuation is this?  My
+dear son, I entreat you never to make such an assertion again."
+
+"I am not mad," I cried energetically; "the sun and the heavens, who
+have viewed my operations, can bear witness of my truth.  I am the
+assassin of those most innocent victims; they died by my machinations.
+A thousand times would I have shed my own blood, drop by drop, to have
+saved their lives; but I could not, my father, indeed I could not
+sacrifice the whole human race."
+
+The conclusion of this speech convinced my father that my ideas were
+deranged, and he instantly changed the subject of our conversation and
+endeavoured to alter the course of my thoughts.  He wished as much as
+possible to obliterate the memory of the scenes that had taken place in
+Ireland and never alluded to them or suffered me to speak of my
+misfortunes.
+
+As time passed away I became more calm; misery had her dwelling in my
+heart, but I no longer talked in the same incoherent manner of my own
+crimes; sufficient for me was the consciousness of them.  By the utmost
+self-violence I curbed the imperious voice of wretchedness, which
+sometimes desired to declare itself to the whole world, and my manners
+were calmer and more composed than they had ever been since my journey
+to the sea of ice.  A few days before we left Paris on our way to
+Switzerland, I received the following letter from Elizabeth:
+
+
+"My dear Friend,
+
+"It gave me the greatest pleasure to receive a letter from my uncle
+dated at Paris; you are no longer at a formidable distance, and I may
+hope to see you in less than a fortnight.  My poor cousin, how much you
+must have suffered!  I expect to see you looking even more ill than
+when you quitted Geneva.  This winter has been passed most miserably,
+tortured as I have been by anxious suspense; yet I hope to see peace in
+your countenance and to find that your heart is not totally void of
+comfort and tranquillity.
+
+"Yet I fear that the same feelings now exist that made you so miserable
+a year ago, even perhaps augmented by time.  I would not disturb you at
+this period, when so many misfortunes weigh upon you, but a
+conversation that I had with my uncle previous to his departure renders
+some explanation necessary before we meet.   Explanation!  You may
+possibly say, What can Elizabeth have to explain?  If you really say
+this, my questions are answered and all my doubts satisfied.  But you
+are distant from me, and it is possible that you may dread and yet be
+pleased with this explanation; and in a probability of this being the
+case, I dare not any longer postpone writing what, during your absence,
+I have often wished to express to you but have never had the courage to
+begin.
+
+"You well know, Victor, that our union had been the favourite plan of
+your parents ever since our infancy.  We were told this when young, and
+taught to look forward to it as an event that would certainly take
+place.  We were affectionate playfellows during childhood, and, I
+believe, dear and valued friends to one another as we grew older. But
+as brother and sister often entertain a lively affection towards each
+other without desiring a more intimate union, may not such also be our
+case?  Tell me, dearest Victor.  Answer me, I conjure you by our mutual
+happiness, with simple truth--Do you not love another?
+
+"You have travelled; you have spent several years of your life at
+Ingolstadt; and I confess to you, my friend, that when I saw you last
+autumn so unhappy, flying to solitude from the society of every
+creature, I could not help supposing that you might regret our
+connection and believe yourself bound in honour to fulfil the wishes of
+your parents, although they opposed themselves to your inclinations.
+But this is false reasoning.  I confess to you, my friend, that I love
+you and that in my airy dreams of futurity you have been my constant
+friend and companion.   But it is your happiness I desire as well as my
+own when I declare to you that our marriage would render me eternally
+miserable unless it were the dictate of your own free choice.  Even now
+I weep to think that, borne down as you are by the cruellest
+misfortunes, you may stifle, by the word 'honour,' all hope of that
+love and happiness which would alone restore you to yourself.  I, who
+have so disinterested an affection for you, may increase your miseries
+tenfold by being an obstacle to your wishes.  Ah! Victor, be assured
+that your cousin and playmate has too sincere a love for you not to be
+made miserable by this supposition.  Be happy, my friend; and if you
+obey me in this one request, remain satisfied that nothing on earth
+will have the power to interrupt my tranquillity.
+
+"Do not let this letter disturb you; do not answer tomorrow, or the
+next day, or even until you come, if it will give you pain.  My uncle
+will send me news of your health, and if I see but one smile on your
+lips when we meet, occasioned by this or any other exertion of mine, I
+shall need no other happiness.
+
+                                                "Elizabeth Lavenza
+
+
+    "Geneva, May 18th, 17--"
+
+
+This letter revived in my memory what I had before forgotten, the
+threat of the fiend--"I WILL BE WITH YOU ON YOUR WEDDING-NIGHT!" Such
+was my sentence, and on that night would the daemon employ every art to
+destroy me and tear me from the glimpse of happiness which promised
+partly to console my sufferings.  On that night he had determined to
+consummate his crimes by my death.  Well, be it so; a deadly struggle
+would then assuredly take place, in which if he were victorious I
+should be at peace and his power over me be at an end.  If he were
+vanquished, I should be a free man.  Alas!  What freedom?  Such as the
+peasant enjoys when his family have been massacred before his eyes, his
+cottage burnt, his lands laid waste, and he is turned adrift, homeless,
+penniless, and alone, but free. Such would be my liberty except that in
+my Elizabeth I possessed a treasure, alas, balanced by those horrors of
+remorse and guilt which would pursue me until death.
+
+Sweet and beloved Elizabeth!  I read and reread her letter, and some
+softened feelings stole into my heart and dared to whisper paradisiacal
+dreams of love and joy; but the apple was already eaten, and the
+angel's arm bared to drive me from all hope.  Yet I would die to make
+her happy.  If the monster executed his threat, death was inevitable;
+yet, again, I considered whether my marriage would hasten my fate.  My
+destruction might indeed arrive a few months sooner, but if my torturer
+should suspect that I postponed it, influenced by his menaces, he would
+surely find other and perhaps more dreadful means of revenge.
+
+He had vowed TO BE WITH ME ON MY WEDDING-NIGHT, yet he did not consider
+that threat as binding him to peace in the meantime, for as if to show
+me that he was not yet satiated with blood, he had murdered Clerval
+immediately after the enunciation of his threats.  I resolved,
+therefore, that if my immediate union with my cousin would conduce
+either to hers or my father's happiness, my adversary's designs against
+my life should not retard it a single hour.
+
+In this state of mind I wrote to Elizabeth.  My letter was calm and
+affectionate.  "I fear, my beloved girl," I said, "little happiness
+remains for us on earth; yet all that I may one day enjoy is centred in
+you.  Chase away your idle fears; to you alone do I consecrate my life
+and my endeavours for contentment.  I have one secret, Elizabeth, a
+dreadful one; when revealed to you, it will chill your frame with
+horror, and then, far from being surprised at my misery, you will only
+wonder that I survive what I have endured.  I will confide this tale of
+misery and terror to you the day after our marriage shall take place,
+for, my sweet cousin, there must be perfect confidence between us.  But
+until then, I conjure you, do not mention or allude to it.  This I most
+earnestly entreat, and I know you will comply."
+
+In about a week after the arrival of Elizabeth's letter we returned to
+Geneva.  The sweet girl welcomed me with warm affection, yet tears were
+in her eyes as she beheld my emaciated frame and feverish  cheeks.  I
+saw a change in her also.  She was thinner and had lost much of that
+heavenly vivacity that had before charmed me; but her gentleness and
+soft looks of compassion made her a more fit companion for one blasted
+and miserable as I was.  The tranquillity which I now enjoyed did not
+endure.  Memory brought madness with it, and when I thought of what had
+passed, a real insanity possessed me; sometimes I was furious and burnt
+with rage, sometimes low and despondent.  I neither spoke nor looked at
+anyone, but sat motionless, bewildered by the multitude of miseries
+that overcame me.
+
+Elizabeth alone had the power to draw me from these fits; her gentle
+voice would soothe me when transported by passion and inspire me with
+human feelings when sunk in torpor.  She wept with me and for me.  When
+reason returned, she would remonstrate and endeavour to inspire me with
+resignation.  Ah!  It is well for the unfortunate to be resigned, but
+for the guilty there is no peace.  The agonies of remorse poison the
+luxury there is otherwise sometimes found in indulging the excess of
+grief.  Soon after my arrival my father spoke of my immediate marriage
+with Elizabeth.  I remained silent.
+
+"Have you, then, some other attachment?"
+
+"None on earth.  I love Elizabeth and look forward to our union with
+delight.  Let the day therefore be fixed; and on it I will consecrate
+myself, in life or death, to the happiness of my cousin."
+
+"My dear Victor, do not speak thus.  Heavy misfortunes have befallen
+us, but let us only cling closer to what remains and transfer our love
+for those whom we have lost to those who yet live.  Our circle will be
+small but bound close by the ties of affection and mutual misfortune.
+And when time shall have softened your despair, new and dear objects of
+care will be born to replace those of whom we have been so cruelly
+deprived."
+
+Such were the lessons of my father.  But to me the remembrance of the
+threat returned; nor can you wonder that, omnipotent as the fiend had
+yet been in his deeds of blood, I should almost regard him as
+invincible, and that when he had pronounced the words "I SHALL BE WITH
+YOU ON YOUR WEDDING-NIGHT," I should regard the threatened fate as
+unavoidable.  But death was no evil to me if the loss of Elizabeth were
+balanced with it, and I therefore, with a contented and even cheerful
+countenance, agreed with my father that if my cousin would consent, the
+ceremony should take place in ten days, and thus put, as I imagined,
+the seal to my fate.
+
+Great God!  If for one instant I had thought what might be the hellish
+intention of my fiendish adversary, I would rather have banished myself
+forever from my native country and wandered a friendless outcast over
+the earth than have consented to this miserable marriage.  But, as if
+possessed of magic powers, the monster had blinded me to his real
+intentions; and when I thought that I had prepared only my own death, I
+hastened that of a far dearer victim.
+
+As the period fixed for our marriage drew nearer, whether from
+cowardice or a prophetic feeling, I felt my heart sink within me.  But
+I concealed my feelings by an appearance of hilarity that brought
+smiles and joy to the countenance of my father, but hardly deceived the
+ever-watchful and nicer eye of Elizabeth.  She looked forward to our
+union with placid contentment, not unmingled with a little fear, which
+past misfortunes had impressed, that what now appeared certain and
+tangible happiness might soon dissipate into an airy dream and leave no
+trace but deep and everlasting regret.  Preparations were made for the
+event, congratulatory visits were received, and all wore a smiling
+appearance.  I shut up, as well as I could, in my own heart the anxiety
+that preyed there and entered with seeming earnestness into the plans
+of my father, although they might only serve as the decorations of my
+tragedy.  Through my father's exertions a part of the inheritance of
+Elizabeth had been restored to her by the Austrian government.  A small
+possession on the shores of Como belonged to her.  It was agreed that,
+immediately after our union, we should proceed to Villa Lavenza and
+spend our first days of happiness beside the beautiful lake near which
+it stood.
+
+In the meantime I took every precaution to defend my person in case the
+fiend should openly attack me.  I carried pistols and a dagger
+constantly about me and was ever on the watch to prevent artifice, and
+by these means gained a greater degree of tranquillity.  Indeed, as the
+period approached, the threat appeared more as a delusion, not to be
+regarded as worthy to disturb my peace, while the happiness I hoped for
+in my marriage wore a greater appearance of certainty as the day fixed
+for its solemnization drew nearer and I heard it continually spoken of
+as an occurrence which no accident could possibly prevent.
+
+Elizabeth seemed happy; my tranquil demeanour contributed greatly to
+calm her mind.  But on the day that was to fulfil my wishes and my
+destiny, she was melancholy, and a presentiment of evil pervaded her;
+and perhaps also she thought of the dreadful secret which I had
+promised to reveal to her on the following day.  My father was in the
+meantime overjoyed and in the bustle of preparation only recognized in
+the melancholy of his niece the diffidence of a bride.
+
+After the ceremony was performed a large party assembled at my
+father's, but it was agreed that Elizabeth and I should commence our
+journey by water, sleeping that night at Evian and continuing our
+voyage on the following day.  The day was fair, the wind favourable;
+all smiled on our nuptial embarkation.
+
+Those were the last moments of my life during which I enjoyed the
+feeling of happiness.  We passed rapidly along; the sun was hot, but we
+were sheltered from its rays by a kind of canopy while we enjoyed the
+beauty of the scene, sometimes on one side of the lake, where we saw
+Mont Saleve, the pleasant banks of Montalegre, and at a distance,
+surmounting all, the beautiful Mont Blanc and the assemblage of snowy
+mountains that in vain endeavour to emulate her; sometimes coasting the
+opposite banks, we saw the mighty Jura opposing its dark side to the
+ambition that would quit its native country, and an almost
+insurmountable barrier to the invader who should wish to enslave it.
+
+I took the hand of Elizabeth.  "You are sorrowful, my love.  Ah!  If
+you knew what I have suffered and what I may yet endure, you would
+endeavour to let me taste the quiet and freedom from despair that this
+one day at least permits me to enjoy."
+
+"Be happy, my dear Victor," replied Elizabeth; "there is, I hope,
+nothing to distress you; and be assured that if a lively joy is not
+painted in my face, my heart is contented.  Something whispers to me
+not to depend too much on the prospect that is opened before us, but I
+will not listen to such a sinister voice.  Observe how fast we move
+along and how the clouds, which sometimes obscure and sometimes rise
+above the dome of Mont Blanc, render this scene of beauty still more
+interesting.  Look also at the innumerable fish that are swimming in
+the clear waters, where we can distinguish every pebble that lies at
+the bottom.  What a divine day!  How happy and serene all nature
+appears!"
+
+Thus Elizabeth endeavoured to divert her thoughts and mine from all
+reflection upon melancholy subjects.  But her temper was fluctuating;
+joy for a few instants shone in her eyes, but it continually gave place
+to distraction and reverie.
+
+The sun sank lower in the heavens; we passed the river Drance and
+observed its path through the chasms of the higher and the glens of the
+lower hills.  The Alps here come closer to the lake, and we approached
+the amphitheatre of mountains which forms its eastern boundary.  The
+spire of Evian shone under the woods that surrounded it and the range
+of mountain above mountain by which it was overhung.
+
+The wind, which had hitherto carried us along with amazing rapidity,
+sank at sunset to a light breeze; the soft air just ruffled the water
+and caused a pleasant motion among the trees as we approached the
+shore, from which it wafted the most delightful scent of flowers and
+hay.  The sun sank beneath the horizon as we landed, and as I touched
+the shore I felt those cares and fears revive which soon were to clasp
+me and cling to me forever.
+
+
+
+Chapter 23
+
+It was eight o'clock when we landed; we walked for a short time on the
+shore, enjoying the transitory light, and then retired to the inn and
+contemplated the lovely scene of waters, woods, and mountains, obscured
+in darkness, yet still displaying their black outlines.
+
+The wind, which had fallen in the south, now rose with great violence
+in the west.  The moon had reached her summit in the heavens and was
+beginning to descend; the clouds swept across it swifter than the
+flight of the vulture and dimmed her rays, while the lake reflected the
+scene of the busy heavens, rendered still busier by the restless waves
+that were beginning to rise.  Suddenly a heavy storm of rain descended.
+
+I had been calm during the day, but so soon as night obscured the
+shapes of objects, a thousand fears arose in my mind.  I was anxious
+and watchful, while my right hand grasped a pistol which was hidden in
+my bosom; every sound terrified me, but I resolved that I would sell my
+life dearly and not shrink from the conflict until my own life or that
+of my adversary was extinguished.  Elizabeth observed my agitation for
+some time in timid and fearful silence, but there was something in my
+glance which communicated terror to her, and trembling, she asked,
+"What is it that agitates you, my dear Victor?  What is it you fear?"
+
+"Oh!  Peace, peace, my love," replied I; "this night, and all will be
+safe; but this night is dreadful, very dreadful."
+
+I passed an hour in this state of mind, when suddenly I reflected how
+fearful the combat which I momentarily expected would be to my wife,
+and I earnestly entreated her to retire, resolving not to join her
+until I had obtained some knowledge as to the situation of my enemy.
+
+She left me, and I continued some time walking up and down the passages
+of the house and inspecting every corner that might afford a retreat to
+my adversary.  But I discovered no trace of him and was beginning to
+conjecture that some fortunate chance had intervened to prevent the
+execution of his menaces when suddenly I heard a shrill and dreadful
+scream.  It came from the room into which Elizabeth had retired.  As I
+heard it, the whole truth rushed into my mind, my arms dropped, the
+motion of every muscle and fibre was suspended; I could feel the blood
+trickling in my veins and tingling in the extremities of my limbs. This
+state lasted but for an instant; the scream was repeated, and I rushed
+into the room.  Great God!  Why did I not then expire!  Why am I here
+to relate the destruction of the best hope and the purest creature on
+earth?  She was there, lifeless and inanimate, thrown across the bed,
+her head hanging down and her pale and distorted features half covered
+by her hair.  Everywhere I turn I see the same figure--her bloodless
+arms and relaxed form flung by the murderer on its bridal bier.  Could
+I behold this and live?  Alas!  Life is obstinate and clings closest
+where it is most hated.  For a moment only did I lose recollection; I
+fell senseless on the ground.
+
+When I recovered I found myself surrounded by the people of the inn;
+their countenances expressed a breathless terror, but the horror of
+others appeared only as a mockery, a shadow of the feelings that
+oppressed me.  I escaped from them to the room where lay the body of
+Elizabeth, my love, my wife, so lately living, so dear, so worthy.  She
+had been moved from the posture in which I had first beheld her, and
+now, as she lay, her head upon her arm and a handkerchief thrown across
+her face and neck, I might have supposed her asleep. I rushed towards
+her and embraced her with ardour, but the deadly languor and coldness
+of the limbs told me that what I now held in my arms had ceased to be
+the Elizabeth whom I had loved and cherished.  The murderous mark of
+the fiend's grasp was on her neck, and the breath had ceased to issue
+from her lips.  While I still hung over her in the agony of despair, I
+happened to look up.  The windows of the room had before been darkened,
+and I felt a kind of panic on seeing the pale yellow light of the moon
+illuminate the chamber.  The shutters had been thrown back, and with a
+sensation of horror not to be described, I saw at the open window a
+figure the most hideous and abhorred.  A grin was on the face of the
+monster; he seemed to jeer, as with his fiendish finger he pointed
+towards the corpse of my wife.  I rushed towards the window, and
+drawing a pistol from my bosom, fired; but he eluded me, leaped from
+his station, and running with the swiftness of lightning, plunged into
+the lake.
+
+The report of the pistol brought a crowd into the room. I pointed to
+the spot where he had disappeared, and we followed the track with
+boats; nets were cast, but in vain.  After passing several hours, we
+returned hopeless, most of my companions believing it to have been a
+form conjured up by my fancy.  After having landed, they proceeded to
+search the country, parties going in different directions among the
+woods and vines.
+
+I attempted to accompany them and proceeded a short distance from the
+house, but my head whirled round, my steps were like those of a drunken
+man, I fell at last in a state of utter exhaustion; a film covered my
+eyes, and my skin was parched with the heat of fever.  In this state I
+was carried back and placed on a bed, hardly conscious of what had
+happened; my eyes wandered round the room as if to seek something that
+I had lost.
+
+After an interval I arose, and as if by instinct, crawled into the room
+where the corpse of my beloved lay.  There were women weeping around; I
+hung over it and joined my sad tears to theirs; all this time no
+distinct idea presented itself to my mind, but my thoughts rambled to
+various subjects, reflecting confusedly on my misfortunes and their
+cause.  I was bewildered, in a cloud of wonder and horror.  The death
+of William, the execution of Justine, the murder of Clerval, and lastly
+of my wife; even at that moment I knew not that my only remaining
+friends were safe from the malignity of the fiend; my father even now
+might be writhing under his grasp, and Ernest might be dead at his
+feet.  This idea made me shudder and recalled me to action.  I started
+up and resolved to return to Geneva with all possible speed.
+
+There were no horses to be procured, and I must return by the lake; but
+the wind was unfavourable, and the rain fell in torrents.  However, it
+was hardly morning, and I might reasonably hope to arrive by night.  I
+hired men to row and took an oar myself, for I had always experienced
+relief from mental torment in bodily exercise.  But the overflowing
+misery I now felt, and the excess of agitation that I endured rendered
+me incapable of any exertion.  I threw down the oar, and leaning my
+head upon my hands, gave way to every gloomy idea that arose.  If I
+looked up, I saw scenes which were familiar to me in my happier time
+and which I had contemplated but the day before in the company of her
+who was now but a shadow and a recollection.  Tears streamed from my
+eyes.  The rain had ceased for a moment, and I saw the fish play in the
+waters as they had done a few hours before; they had then been observed
+by Elizabeth.  Nothing is so painful to the human mind as a great and
+sudden change.  The sun might shine or the clouds might lower, but
+nothing could appear to me as it had done the day before.  A fiend had
+snatched from me every hope of future happiness; no creature had ever
+been so miserable as I was; so frightful an event is single in the
+history of man. But why should I dwell upon the incidents that followed
+this last overwhelming event?  Mine has been a tale of horrors; I have
+reached their acme, and what I must now relate can but be tedious to
+you.  Know that, one by one, my friends were snatched away; I was left
+desolate.  My own strength is exhausted, and I must tell, in a few
+words, what remains of my hideous narration. I arrived at Geneva.  My
+father and Ernest yet lived, but the former sunk under the tidings that
+I bore.  I see him now, excellent and venerable old man!  His eyes
+wandered in vacancy, for they had lost their charm and their
+delight--his Elizabeth, his more than daughter, whom he doted on with
+all that affection which a man feels, who in the decline of life,
+having few affections, clings more earnestly to those that remain.
+Cursed, cursed be the fiend that brought misery on his grey hairs and
+doomed him to waste in wretchedness!  He could not live under the
+horrors that were accumulated around him; the springs of existence
+suddenly gave way; he was unable to rise from his bed, and in a few
+days he died in my arms.
+
+What then became of me?  I know not; I lost sensation, and chains and
+darkness were the only objects that pressed upon me.  Sometimes,
+indeed, I dreamt that I wandered in flowery meadows and pleasant vales
+with the friends of my youth, but I awoke and found myself in a
+dungeon.  Melancholy followed, but by degrees I gained a clear
+conception of my miseries and situation and was then released from my
+prison.  For they had called me mad, and during many months, as I
+understood, a solitary cell had been my habitation.
+
+Liberty, however, had been a useless gift to me, had I not, as I
+awakened to reason, at the same time awakened to revenge.  As the
+memory of past misfortunes pressed upon me, I began to reflect on their
+cause--the monster whom I had created, the miserable daemon whom I had
+sent abroad into the world for my destruction.  I was possessed by a
+maddening rage when I thought of him, and desired and ardently prayed
+that I might have him within my grasp to wreak a great and signal
+revenge on his cursed head.
+
+Nor did my hate long confine itself to useless wishes; I began to
+reflect on the best means of securing him; and for this purpose, about
+a month after my release, I repaired to a criminal judge in the town
+and told him that I had an accusation to make, that I knew the
+destroyer of my family, and that I required him to exert his whole
+authority for the apprehension of the murderer.  The magistrate
+listened to me with attention and kindness.
+
+"Be assured, sir," said he, "no pains or exertions on my part shall be
+spared to discover the villain."
+
+"I thank you," replied I; "listen, therefore, to the deposition that I
+have to make.  It is indeed a tale so strange that I should fear you
+would not credit it were there not something in truth which, however
+wonderful, forces conviction.  The story is too connected to be
+mistaken for a dream, and I have no motive for falsehood." My manner as
+I thus addressed him was impressive but calm; I had formed in my own
+heart a resolution to pursue my destroyer to death, and this purpose
+quieted my agony and for an interval reconciled me to life.  I now
+related my history briefly but with firmness and precision, marking the
+dates with accuracy and never deviating into invective or exclamation.
+
+The magistrate appeared at first perfectly incredulous, but as I
+continued he became more attentive and interested; I saw him sometimes
+shudder with horror; at others a lively surprise, unmingled with
+disbelief, was painted on his countenance.  When I had concluded my
+narration I said, "This is the being whom I accuse and for whose
+seizure and punishment I call upon you to exert your whole power.  It
+is your duty as a magistrate, and I believe and hope that your feelings
+as a man will not revolt from the execution of those functions on this
+occasion."  This address caused a considerable change in the
+physiognomy of my own auditor.  He had heard my story with that half
+kind of belief that is given to a tale of spirits and supernatural
+events; but when he was called upon to act officially in consequence,
+the whole tide of his incredulity returned.  He, however, answered
+mildly, "I would willingly afford you every aid in your pursuit, but
+the creature of whom you speak appears to have powers which would put
+all my exertions to defiance.  Who can follow an animal which can
+traverse the sea of ice and inhabit caves and dens where no man would
+venture to intrude?  Besides, some months have elapsed since the
+commission of his crimes, and no one can conjecture to what place he
+has wandered or what region he may now inhabit."
+
+"I do not doubt that he hovers near the spot which I inhabit, and if he
+has indeed taken refuge in the Alps, he may be hunted like the chamois
+and destroyed as a beast of prey.  But I perceive your thoughts; you do
+not credit my narrative and do not intend to pursue my enemy with the
+punishment which is his desert." As I spoke, rage sparkled in my eyes;
+the magistrate was intimidated.  "You are mistaken," said he.  "I will
+exert myself, and if it is in my power to seize the monster, be assured
+that he shall suffer punishment proportionate to his crimes.  But I
+fear, from what you have yourself described to be his properties, that
+this will prove impracticable; and thus, while every proper measure is
+pursued, you should make up your mind to disappointment."
+
+"That cannot be; but all that I can say will be of little avail.  My
+revenge is of no moment to you; yet, while I allow it to be a vice, I
+confess that it is the devouring and only passion of my soul.  My rage
+is unspeakable when I reflect that the murderer, whom I have turned
+loose upon society, still exists.  You refuse my just demand; I have
+but one resource, and I devote myself, either in my life or death, to
+his destruction."
+
+I trembled with excess of agitation as I said this; there was a frenzy
+in my manner, and something, I doubt not, of that haughty fierceness
+which the martyrs of old are said to have possessed.  But to a Genevan
+magistrate, whose mind was occupied by far other ideas than those of
+devotion and heroism, this elevation of mind had much the appearance of
+madness.  He endeavoured to soothe me as a nurse does a child and
+reverted to my tale as the effects of delirium.
+
+"Man," I cried, "how ignorant art thou in thy pride of wisdom!  Cease;
+you know not what it is you say."
+
+I broke from the house angry and disturbed and retired to meditate on
+some other mode of action.
+
+
+
+Chapter 24
+
+My present situation was one in which all voluntary thought was
+swallowed up and lost.  I was hurried away by fury; revenge alone
+endowed me with strength and composure; it moulded my feelings and
+allowed me to be calculating and calm at periods when otherwise
+delirium or death would have been my portion.
+
+My first resolution was to quit Geneva forever; my country, which, when
+I was happy and beloved, was dear to me, now, in my adversity, became
+hateful.  I provided myself with a sum of money, together with a few
+jewels which had belonged to my mother, and departed.  And now my
+wanderings began which are to cease but with life.  I have traversed a
+vast portion of the earth and have endured all the hardships which
+travellers in deserts and barbarous countries are wont to meet.  How I
+have lived I hardly know; many times have I stretched my failing limbs
+upon the sandy plain and prayed for death.  But revenge kept me alive;
+I dared not die and leave my adversary in being.
+
+When I quitted Geneva my first labour was to gain some clue by which I
+might trace the steps of my fiendish enemy.  But my plan was unsettled,
+and I wandered many hours round the confines of the town, uncertain
+what path I should pursue.  As night approached I found myself at the
+entrance of the cemetery where William, Elizabeth, and my father
+reposed.  I entered it and approached the tomb which marked their
+graves.  Everything was silent except the leaves of the trees, which
+were gently agitated by the wind; the night was nearly dark, and the
+scene would have been solemn and affecting even to an uninterested
+observer.  The spirits of the departed seemed to flit around and to
+cast a shadow, which was felt but not seen, around the head of the
+mourner.
+
+The deep grief which this scene had at first excited quickly gave way
+to rage and despair.  They were dead, and I lived; their murderer also
+lived, and to destroy him I must drag out my weary existence.  I knelt
+on the grass and kissed the earth and with quivering lips exclaimed,
+"By the sacred earth on which I kneel, by the shades that wander near
+me, by the deep and eternal grief that I feel, I swear; and by thee, O
+Night, and the spirits that preside over thee, to pursue the daemon who
+caused this misery, until he or I shall perish in mortal conflict.  For
+this purpose I will preserve my life; to execute this dear revenge will
+I again behold the sun and tread the green herbage of earth, which
+otherwise should vanish from my eyes forever.  And I call on you,
+spirits of the dead, and on you, wandering ministers of vengeance, to
+aid and conduct me in my work.  Let the cursed and hellish monster
+drink deep of agony; let him feel the despair that now torments me."  I
+had begun my adjuration with solemnity and an awe which almost assured
+me that the shades of my murdered friends heard and approved my
+devotion, but the furies possessed me as I concluded, and rage choked
+my utterance.
+
+I was answered through the stillness of night by a loud and fiendish
+laugh.  It rang on my ears long and heavily; the mountains re-echoed
+it, and I felt as if all hell surrounded me with mockery and laughter.
+Surely in that moment I should have been possessed by frenzy and have
+destroyed my miserable existence but that my vow was heard and that I
+was reserved for vengeance.  The laughter died away, when a well-known
+and abhorred voice, apparently close to my ear, addressed me in an
+audible whisper, "I am satisfied, miserable wretch!  You have
+determined to live, and I am satisfied."
+
+I darted towards the spot from which the sound proceeded, but the devil
+eluded my grasp.  Suddenly the broad disk of the moon arose and shone
+full upon his ghastly and distorted shape as he fled with more than
+mortal speed.
+
+I pursued him, and for many months this has been my task.  Guided by a
+slight clue, I followed the windings of the Rhone, but vainly.  The
+blue Mediterranean appeared, and by a strange chance, I saw the fiend
+enter by night and hide himself in a vessel bound for the Black Sea.  I
+took my passage in the same ship, but he escaped, I know not how.
+
+Amidst the wilds of Tartary and Russia, although he still evaded me, I
+have ever followed in his track.  Sometimes the peasants, scared by
+this horrid apparition, informed me of his path; sometimes he himself,
+who feared that if I lost all trace of him I should despair and die,
+left some mark to guide me.  The snows descended on my head, and I saw
+the print of his huge step on the white plain.  To you first entering
+on life, to whom care is new and agony unknown, how can you understand
+what I have felt and still feel?  Cold, want, and fatigue were the
+least pains which I was destined to endure; I was cursed by some devil
+and carried about with me my eternal hell; yet still a spirit of good
+followed and directed my steps and when I most murmured would suddenly
+extricate me from seemingly insurmountable difficulties.  Sometimes,
+when nature, overcome by hunger, sank under the exhaustion, a repast
+was prepared for me in the desert that restored and inspirited me.  The
+fare was, indeed, coarse, such as the peasants of the country ate, but
+I will not doubt that it was set there by the spirits that I had
+invoked to aid me.  Often, when all was dry, the heavens cloudless, and
+I was parched by thirst, a slight cloud would bedim the sky, shed the
+few drops that revived me, and vanish.
+
+I followed, when I could, the courses of the rivers; but the daemon
+generally avoided these, as it was here that the population of the
+country chiefly collected.  In other places human beings were seldom
+seen, and I generally subsisted on the wild animals that crossed my
+path.  I had money with me and gained the friendship of the villagers
+by distributing it; or I brought with me some food that I had killed,
+which, after taking a small part, I always presented to those who had
+provided me with fire and utensils for cooking.
+
+My life, as it passed thus, was indeed hateful to me, and it was during
+sleep alone that I could taste joy.  O blessed sleep!  Often, when most
+miserable, I sank to repose, and my dreams lulled me even to rapture.
+The spirits that guarded me had provided these moments, or rather
+hours, of happiness that I might retain strength to fulfil my
+pilgrimage.  Deprived of this respite, I should have sunk under my
+hardships.  During the day I was sustained and inspirited by the hope
+of night, for in sleep I saw my friends, my wife, and my beloved
+country; again I saw the benevolent countenance of my father, heard the
+silver tones of my Elizabeth's voice, and beheld Clerval enjoying
+health and youth.  Often, when wearied by a toilsome march, I persuaded
+myself that I was dreaming until night should come and that I should
+then enjoy reality in the arms of my dearest friends.  What agonizing
+fondness did I feel for them!  How did I cling to their dear forms, as
+sometimes they haunted even my waking hours, and persuade myself that
+they still lived!  At such moments vengeance, that burned within me,
+died in my heart, and I pursued my path towards the destruction of the
+daemon more as a task enjoined by heaven, as the mechanical impulse of
+some power of which I was unconscious, than as the ardent desire of my
+soul.  What his feelings were whom I pursued I cannot know.  Sometimes,
+indeed, he left marks in writing on the barks of the trees or cut in
+stone that guided me and instigated my fury.  "My reign is not yet
+over"--these words were legible in one of these inscriptions--"you
+live, and my power is complete.  Follow me; I seek the everlasting ices
+of the north, where you will feel the misery of cold and frost, to
+which I am impassive.  You will find near this place, if you follow not
+too tardily, a dead hare; eat and be refreshed.  Come on, my enemy; we
+have yet to wrestle for our lives, but many hard and miserable hours
+must you endure until that period shall arrive."
+
+Scoffing devil!  Again do I vow vengeance; again do I devote thee,
+miserable fiend, to torture and death.  Never will I give up my search
+until he or I perish; and then with what ecstasy shall I join my
+Elizabeth and my departed friends, who even now prepare for me the
+reward of my tedious toil and horrible pilgrimage!
+
+As I still pursued my journey to the northward, the snows thickened and
+the cold increased in a degree almost too severe to support.  The
+peasants were shut up in their hovels, and only a few of the most hardy
+ventured forth to seize the animals whom starvation had forced from
+their hiding-places to seek for prey.  The rivers were covered with
+ice, and no fish could be procured; and thus I was cut off from my
+chief article of maintenance.  The triumph of my enemy increased with
+the difficulty of my labours.  One inscription that he left was in
+these words:  "Prepare!  Your toils only begin; wrap yourself in furs
+and provide food, for we shall soon enter upon a journey where your
+sufferings will satisfy my everlasting hatred."
+
+My courage and perseverance were invigorated by these scoffing words; I
+resolved not to fail in my purpose, and calling on heaven to support
+me, I continued with unabated fervour to traverse immense deserts,
+until the ocean appeared at a distance and formed the utmost boundary
+of the horizon.  Oh!  How unlike it was to the blue seasons of the
+south!  Covered with ice, it was only to be distinguished from land by
+its superior wildness and ruggedness.  The Greeks wept for joy when
+they beheld the Mediterranean from the hills of Asia, and hailed with
+rapture the boundary of their toils.  I did not weep, but I knelt down
+and with a full heart thanked my guiding spirit for conducting me in
+safety to the place where I hoped, notwithstanding my adversary's gibe,
+to meet and grapple with him.
+
+Some weeks before this period I had procured a sledge and dogs and thus
+traversed the snows with inconceivable speed.  I know not whether the
+fiend possessed the same advantages, but I found that, as before I had
+daily lost ground in the pursuit, I now gained on him, so much so that
+when I first saw the ocean he was but one day's journey in advance, and
+I hoped to intercept him before he should reach the beach.  With new
+courage, therefore, I pressed on, and in two days arrived at a wretched
+hamlet on the seashore.  I inquired of the inhabitants concerning the
+fiend and gained accurate information.  A gigantic monster, they said,
+had arrived the night before, armed with a gun and many pistols,
+putting to flight the inhabitants of a solitary cottage through fear of
+his terrific appearance.  He had carried off their store of winter
+food, and placing it in a sledge, to draw which he had seized on a
+numerous drove of trained dogs, he had harnessed them, and the same
+night, to the joy of the horror-struck villagers, had pursued his
+journey across the sea in a direction that led to no land; and they
+conjectured that he must speedily be destroyed by the breaking of the
+ice or frozen by the eternal  frosts.
+
+On hearing this information I suffered a temporary access of despair.
+He had escaped me, and I must commence a destructive and almost endless
+journey across the mountainous ices of the ocean, amidst cold that few
+of the inhabitants could long endure and which I, the native of a
+genial and sunny climate, could not hope to survive.  Yet at the idea
+that the fiend should live and be triumphant, my rage and vengeance
+returned, and like a mighty tide, overwhelmed every other feeling.
+After a slight repose, during which the spirits of the dead hovered
+round and instigated me to toil and revenge, I prepared for my journey.
+I exchanged my land-sledge for one fashioned for the inequalities of
+the frozen ocean, and purchasing a plentiful stock of provisions, I
+departed from land.
+
+I cannot guess how many days have passed since then, but I have endured
+misery which nothing but the eternal sentiment of a just retribution
+burning within my heart could have enabled me to support.  Immense and
+rugged mountains of ice often barred up my passage, and I often heard
+the thunder of the ground sea, which threatened my destruction.  But
+again the frost came and made the paths of the sea secure.
+
+By the quantity of provision which I had consumed, I should guess that
+I had passed three weeks in this journey; and the continual protraction
+of hope, returning back upon the heart, often wrung bitter drops of
+despondency and grief from my eyes.  Despair had indeed almost secured
+her prey, and I should soon have sunk beneath this misery.  Once, after
+the poor animals that conveyed me had with incredible toil gained the
+summit of a sloping ice mountain, and one, sinking under his fatigue,
+died, I viewed the expanse before me with anguish, when suddenly my eye
+caught a dark speck upon the dusky plain.  I strained my sight to
+discover what it could be and uttered a wild cry of ecstasy when I
+distinguished a sledge and the distorted proportions of a well-known
+form within.  Oh!  With what a burning gush did hope revisit my heart!
+Warm tears filled my eyes, which I hastily wiped away, that they might
+not intercept the view I had of the daemon; but still my sight was
+dimmed by the burning drops, until, giving way to the emotions that
+oppressed me, I wept aloud.
+
+But this was not the time for delay; I disencumbered the dogs of their
+dead companion, gave them a plentiful portion of food, and after an
+hour's rest, which was absolutely necessary, and yet which was bitterly
+irksome to me, I continued my route.  The sledge was still visible, nor
+did I again lose sight of it except at the moments when for a short
+time some ice-rock concealed it with its intervening crags.  I indeed
+perceptibly gained on it, and when, after nearly two days' journey, I
+beheld my enemy at no more than a mile distant, my heart bounded within
+me.
+
+But now, when I appeared almost within grasp of my foe, my hopes were
+suddenly extinguished, and I lost all trace of him more utterly than I
+had ever done before.  A ground sea was heard; the thunder of its
+progress, as the waters rolled and swelled beneath me, became every
+moment more ominous and terrific.  I pressed on, but in vain.  The wind
+arose; the sea roared; and, as with the mighty shock of an earthquake,
+it split and cracked with a tremendous and overwhelming sound.  The
+work was soon finished; in a few minutes a tumultuous sea rolled
+between me and my enemy, and I was left drifting on a scattered piece
+of ice that was continually lessening and thus preparing for me a
+hideous death.  In this manner many appalling hours passed; several of
+my dogs died, and I myself was about to sink under the accumulation of
+distress when I saw your vessel riding at anchor and holding forth to
+me hopes of succour and life.  I had no conception that vessels ever
+came so far north and was astounded at the sight.  I quickly destroyed
+part of my sledge to construct oars, and by these means was enabled,
+with infinite fatigue, to move my ice raft in the direction of your
+ship.  I had determined, if you were going southwards, still to trust
+myself to the mercy of the seas rather than abandon my purpose.  I
+hoped to induce you to grant me a boat with which I could pursue my
+enemy.  But your direction was northwards.  You took me on board when
+my vigour was exhausted, and I should soon have sunk under my
+multiplied hardships into a death which I still dread, for my task is
+unfulfilled.
+
+Oh!  When will my guiding spirit, in conducting me to the daemon, allow
+me the rest I so much desire; or must I die, and he yet live?  If I do,
+swear to me, Walton, that he shall not escape, that you will seek him
+and satisfy my vengeance in his death.  And do I dare to ask of you to
+undertake my pilgrimage, to endure the hardships that I have undergone?
+No; I am not so selfish.  Yet, when I am dead, if he should appear, if
+the ministers of vengeance should conduct him to you, swear that he
+shall not live--swear that he shall not triumph over my accumulated
+woes and survive to add to the list of his dark crimes.  He is eloquent
+and persuasive, and once his words had even power over my heart; but
+trust him not.  His soul is as hellish as his form, full of treachery
+and fiend-like malice.  Hear him not; call on the names of William,
+Justine, Clerval, Elizabeth, my father, and of the wretched Victor, and
+thrust your sword into his heart.  I will hover near and direct the
+steel aright.
+
+
+               Walton, in continuation.
+
+
+
+                                                August 26th, 17--
+
+
+You have read this strange and terrific story, Margaret; and do you not
+feel your blood congeal with horror, like that which even now curdles
+mine?  Sometimes, seized with sudden agony, he could not continue his
+tale; at others, his voice broken, yet piercing, uttered with
+difficulty the words so replete with anguish.  His fine and lovely eyes
+were now lighted up with indignation, now subdued to downcast sorrow
+and quenched in infinite wretchedness.  Sometimes he commanded his
+countenance and tones and related the most horrible incidents with a
+tranquil voice, suppressing every mark of agitation; then, like a
+volcano bursting forth, his face would suddenly change to an expression
+of the wildest rage as he shrieked out imprecations on his persecutor.
+
+His tale is connected and told with an appearance of the simplest
+truth, yet I own to you that the letters of Felix and Safie, which he
+showed me, and the apparition of the monster seen from our ship,
+brought to me a greater conviction of the truth of his narrative than
+his asseverations, however earnest and connected.  Such a monster has,
+then, really existence!  I cannot doubt it, yet I am lost in surprise
+and admiration.  Sometimes I endeavoured to gain from Frankenstein the
+particulars of his creature's formation, but on this point he was
+impenetrable. "Are you mad, my friend?" said he.  "Or whither does your
+senseless curiosity lead you?  Would you also create for yourself and
+the world a demoniacal enemy?  Peace, peace!  Learn my miseries and do
+not seek to increase your own."  Frankenstein discovered that I made
+notes concerning his history; he asked to see them and then himself
+corrected and augmented them in many places, but principally in giving
+the life and spirit to the conversations he held with his enemy. "Since
+you have preserved my narration," said he, "I would not that a
+mutilated one should go down to posterity."
+
+Thus has a week passed away, while I have listened to the strangest
+tale that ever imagination formed.  My thoughts and every feeling of my
+soul have been drunk up by the interest for my guest which this tale
+and his own elevated and gentle manners have created.  I wish to soothe
+him, yet can I counsel one so infinitely miserable, so destitute of
+every hope of consolation, to live?  Oh, no!  The only joy that he can
+now know will be when he composes his shattered spirit to peace and
+death.  Yet he enjoys one comfort, the offspring of solitude and
+delirium; he believes that when in dreams he holds converse with his
+friends and derives from that communion consolation for his miseries or
+excitements to his vengeance, that they are not the creations of his
+fancy, but the beings themselves who visit him from the regions of a
+remote world.  This faith gives a solemnity to his reveries that render
+them to me almost as imposing and interesting as truth.
+
+Our conversations are not always confined to his own history and
+misfortunes.  On every point of general literature he displays
+unbounded knowledge and a quick and piercing apprehension.  His
+eloquence is forcible and touching; nor can I hear him, when he relates
+a pathetic incident or endeavours to move the passions of pity or love,
+without tears.  What a glorious creature must he have been in the days
+of his prosperity, when he is thus noble and godlike in ruin!  He seems
+to feel his own worth and the greatness of his fall.
+
+"When younger," said he, "I believed myself destined for some great
+enterprise.  My feelings are profound, but I possessed a  coolness of
+judgment that fitted me for illustrious achievements.  This sentiment
+of the worth of my nature supported me when others would have been
+oppressed, for I deemed it criminal to throw away in useless grief
+those talents that might be useful to my fellow creatures.  When I
+reflected on the work I had completed, no less a one than the creation
+of a sensitive and rational animal, I could not rank myself with the
+herd of common projectors.  But this thought, which supported me in the
+commencement of my career, now serves only to plunge me lower in the
+dust.  All my speculations and hopes are as nothing, and like the
+archangel who aspired to omnipotence, I am chained in an eternal hell.
+My imagination was vivid, yet my powers of analysis and application
+were intense; by the union of these qualities I conceived the idea and
+executed the creation of a man.  Even now I cannot recollect without
+passion my reveries while the work was incomplete.  I trod heaven in my
+thoughts, now exulting in my powers, now burning with the idea of their
+effects.  From my infancy I was imbued with high hopes and a lofty
+ambition; but how am I sunk!  Oh!  My friend, if you had known me as I
+once was, you would not recognize me in this state of degradation.
+Despondency rarely visited my heart; a high destiny seemed to bear me
+on, until I fell, never, never again to rise."  Must I then lose this
+admirable being?  I have longed for a friend; I have sought one who
+would sympathize with and love me.  Behold, on these desert seas I have
+found such a one, but I fear I have gained him only to know his value
+and lose him.  I would reconcile him to life, but he repulses the idea.
+
+"I thank you, Walton," he said, "for your kind intentions towards so
+miserable a wretch; but when you speak of new ties and fresh
+affections, think you that any can replace those who are gone?  Can any
+man be to me as Clerval was, or any woman another Elizabeth?  Even
+where the affections are not strongly moved by any superior excellence,
+the companions of our childhood always possess a certain power over our
+minds which hardly any later friend can obtain.  They know our
+infantine dispositions, which, however they may be afterwards modified,
+are never eradicated; and they can judge of our actions with more
+certain conclusions as to the integrity of our motives.  A sister or a
+brother can never, unless indeed such symptoms have been shown early,
+suspect the other of fraud or false dealing, when another friend,
+however strongly he may be attached, may, in spite of himself, be
+contemplated with suspicion.  But I enjoyed friends, dear not only
+through habit and association, but from their own merits; and wherever
+I am, the soothing voice of my Elizabeth and the conversation of
+Clerval will be ever whispered in my ear. They are dead, and but one
+feeling in such a solitude can persuade me to preserve my life.  If I
+were engaged in any high undertaking or design, fraught with extensive
+utility to my fellow creatures, then could I live to fulfil it.  But
+such is not my destiny; I must pursue and destroy the being to whom I
+gave existence; then my lot on earth will be fulfilled and I may die."
+
+
+
+
+September 2nd
+
+My beloved Sister,
+
+I write to you, encompassed by peril and ignorant whether I am ever
+doomed to see again dear England and the dearer friends that inhabit
+it.  I am surrounded by mountains of ice which admit of no escape and
+threaten every moment to crush my vessel.  The brave fellows whom I
+have persuaded to be my companions look towards me for aid, but I have
+none to bestow.  There is something terribly appalling in our
+situation, yet my courage and hopes do not desert me.  Yet it is
+terrible to reflect that the lives of all these men are endangered
+through me.  If we are lost, my mad schemes are the cause.
+
+And what, Margaret, will be the state of your mind?  You will not hear
+of my destruction, and you will anxiously await my return.  Years will
+pass, and you will have visitings of despair and yet be tortured by
+hope.  Oh!  My beloved sister, the sickening failing of your heart-felt
+expectations is, in prospect, more terrible to me than my own death.
+
+But you have a husband and lovely children; you may be happy.  Heaven
+bless you and make you so!
+
+My unfortunate guest regards me with the tenderest compassion.  He
+endeavours to fill me with hope and talks as if life were a possession
+which he valued.  He reminds me how often the same accidents have
+happened to other navigators who have attempted this sea, and in spite
+of myself, he fills me with cheerful auguries.  Even the sailors feel
+the power of his eloquence; when he speaks, they no longer despair; he
+rouses their energies, and while they hear his voice they believe these
+vast mountains of ice are mole-hills which will vanish before the
+resolutions of man.  These feelings are transitory; each day of
+expectation delayed fills them with fear, and I almost dread a mutiny
+caused by this despair.
+
+
+
+September 5th
+
+
+A scene has just passed of such uncommon interest that, although it is
+highly probable that these papers may never reach you, yet I cannot
+forbear recording it.
+
+We are still surrounded by mountains of ice, still in imminent danger
+of being crushed in their conflict.  The cold is excessive, and many of
+my unfortunate comrades have already found a grave amidst this scene of
+desolation.  Frankenstein has daily declined in health; a feverish fire
+still glimmers in his eyes, but he is exhausted, and when suddenly
+roused to any exertion, he speedily sinks again into apparent
+lifelessness.
+
+I mentioned in my last letter the fears I entertained of a mutiny.
+This morning, as I sat watching the wan countenance of my friend--his
+eyes half closed and his limbs hanging listlessly--I was roused by half
+a dozen of the sailors, who demanded admission into the cabin.  They
+entered, and their leader addressed me.  He told me that he and his
+companions had been chosen by the other sailors to come in deputation
+to me to make me a requisition which, in justice, I could not refuse.
+We were immured in ice and should probably never escape, but they
+feared that if, as was possible, the ice should dissipate and a free
+passage be opened, I should be rash enough to continue my voyage and
+lead them into fresh dangers, after they might happily have surmounted
+this.  They insisted, therefore, that I should engage with a solemn
+promise that if the vessel should be freed I would instantly direct my
+course southwards.
+
+This speech troubled me.  I had not despaired, nor had I yet conceived
+the idea of returning if set free.  Yet could I, in justice, or even in
+possibility, refuse this demand?  I hesitated before I answered, when
+Frankenstein, who had at first been silent, and indeed appeared hardly
+to have force enough to attend, now roused himself; his eyes sparkled,
+and his cheeks flushed with momentary vigour.  Turning towards the men,
+he said, "What do you mean?  What do you demand of your captain?  Are
+you, then, so easily turned from your design?  Did you not call this a
+glorious expedition?
+
+"And wherefore was it glorious?  Not because the way was smooth and
+placid as a southern sea, but because it was full of dangers and
+terror, because at every new incident your fortitude was to be called
+forth and your courage exhibited, because danger and death surrounded
+it, and these you were to brave and overcome.  For this was it a
+glorious, for this was it an honourable undertaking.  You were
+hereafter to be hailed as the benefactors of your species, your names
+adored as belonging to brave men who encountered death for honour and
+the benefit of mankind. And now, behold, with the first imagination of
+danger, or, if you will, the first mighty and terrific trial of your
+courage, you shrink away and are content to be handed down as men who
+had not strength enough to endure cold and peril; and so, poor souls,
+they were chilly and returned to their warm firesides.  Why, that
+requires not this preparation; ye need not have come thus far and
+dragged your captain to the shame of a defeat merely to prove
+yourselves cowards.  Oh!  Be men, or be more than men.  Be steady to
+your purposes and firm as a rock. This ice is not made of such stuff as
+your hearts may be; it is mutable and cannot withstand you if you say
+that it shall not.  Do not return to your families with the stigma of
+disgrace marked on your brows.  Return as heroes who have fought and
+conquered and who know not what it is to turn their backs on the foe."
+He spoke this with a voice so modulated to the different feelings
+expressed in his speech, with an eye so full of lofty design and
+heroism, that can you wonder that these men were moved?  They looked at
+one another and were unable to reply.  I spoke; I told them to retire
+and consider of what had been said, that I would not lead them farther
+north if they strenuously desired the contrary, but that I hoped that,
+with reflection, their courage would return.  They retired and I turned
+towards my friend, but he was sunk in languor and almost deprived of
+life.
+
+How all this will terminate, I know not, but I had rather die than
+return shamefully, my purpose unfulfilled.  Yet I fear such will be my
+fate; the men, unsupported by ideas of glory and honour, can never
+willingly continue to endure their present hardships.
+
+
+
+September 7th
+
+
+The die is cast; I have consented to return if we are not destroyed.
+Thus are my hopes blasted by cowardice and indecision; I come back
+ignorant and disappointed.  It requires more philosophy than I possess
+to bear this injustice with patience.
+
+
+
+September 12th
+
+
+It is past; I am returning to England.  I have lost my hopes of utility
+and glory; I have lost my friend.  But I will endeavour to detail these
+bitter circumstances to you, my dear sister; and while I am wafted
+towards England and towards you, I will not despond.
+
+September 9th, the ice began to move, and roarings like thunder were
+heard at a distance as the islands split and cracked in every
+direction.  We were in the most imminent peril, but as we could only
+remain passive, my chief attention was occupied by my unfortunate guest
+whose illness increased in such a degree that he was entirely confined
+to his bed.  The ice cracked behind us and was driven with force
+towards the north; a breeze sprang from the west, and on the 11th the
+passage towards the south became perfectly free.  When the sailors saw
+this and that their return to their native country was apparently
+assured, a shout of tumultuous joy broke from them, loud and
+long-continued.  Frankenstein, who was dozing, awoke and asked the
+cause of the tumult.  "They shout," I said, "because they will soon
+return to England."
+
+"Do you, then, really return?"
+
+"Alas!  Yes; I cannot withstand their demands.  I cannot lead them
+unwillingly to danger, and I must return."
+
+"Do so, if you will; but I will not.  You may give up your purpose, but
+mine is assigned to me by heaven, and I dare not.  I am weak, but
+surely the spirits who assist my vengeance will endow me with
+sufficient strength."  Saying this, he endeavoured to spring from the
+bed, but the exertion was too great for him; he fell back and fainted.
+
+It was long before he was restored, and I often thought that life was
+entirely extinct.  At length he opened his eyes; he breathed with
+difficulty and was unable to speak.  The surgeon gave him a composing
+draught and ordered us to leave him undisturbed. In the meantime he
+told me that my friend had certainly not many hours to live.
+
+His sentence was pronounced, and I could only grieve and be patient.  I
+sat by his bed, watching him; his eyes were closed, and I thought he
+slept; but presently he called to me in a feeble voice, and bidding me
+come near, said, "Alas!  The strength I relied on is gone; I feel that
+I shall soon die, and he, my enemy and persecutor, may still be in
+being.  Think not, Walton, that in the last moments of my existence I
+feel that burning hatred and ardent desire of revenge I once expressed;
+but I feel myself justified in desiring the death of my adversary.
+During these last days I have been occupied in examining my past
+conduct; nor do I find it blamable.  In a fit of enthusiastic madness I
+created a rational creature and was bound towards him to assure, as far
+as was in my power, his happiness and well-being.
+
+"This was my duty, but there was another still paramount to that.  My
+duties towards the beings of my own species had greater claims to my
+attention because they included a greater proportion of happiness or
+misery.  Urged by this view, I refused, and I did right in refusing, to
+create a companion for the first creature.  He showed unparalleled
+malignity and selfishness in evil; he destroyed my friends; he devoted
+to destruction beings who possessed exquisite sensations, happiness,
+and wisdom; nor do I know where this thirst for vengeance may end.
+Miserable himself that he may render no other wretched, he ought to
+die.  The task of his destruction was mine, but I have failed.  When
+actuated by selfish and vicious motives, I asked you to undertake my
+unfinished work, and I renew this request now, when I am only induced
+by reason and virtue.
+
+"Yet I cannot ask you to renounce your country and friends to fulfil
+this task; and now that you are returning to England, you will have
+little chance of meeting with him.  But the consideration of these
+points, and the well balancing of what you may esteem your duties, I
+leave to you; my judgment and ideas are already disturbed by the near
+approach of death.  I dare not ask you to do what I think right, for I
+may still be misled by passion.
+
+"That he should live to be an instrument of mischief disturbs me; in
+other respects, this hour, when I momentarily expect my release, is the
+only happy one which I have enjoyed for several years.  The forms of
+the beloved dead flit before me, and I hasten to their arms.  Farewell,
+Walton!  Seek happiness in tranquillity and avoid ambition, even if it
+be only the apparently innocent one of distinguishing yourself in
+science and discoveries.  Yet why do I say this?  I have myself been
+blasted in these hopes, yet another may succeed."
+
+His voice became fainter as he spoke, and at length, exhausted by his
+effort, he sank into silence.  About half an hour afterwards he
+attempted again to speak but was unable; he pressed my hand feebly, and
+his eyes closed forever, while the irradiation of a gentle smile passed
+away from his lips.
+
+Margaret, what comment can I make on the untimely extinction of this
+glorious spirit?  What can I say that will enable you to understand the
+depth of my sorrow?  All that I should express would be inadequate and
+feeble.  My tears flow; my mind is overshadowed by a cloud of
+disappointment.  But I journey towards England, and I may there find
+consolation.
+
+I am interrupted.  What do these sounds portend?  It is midnight; the
+breeze blows fairly, and the watch on deck scarcely stir.  Again there
+is a sound as of a human voice, but hoarser; it comes from the cabin
+where the remains of Frankenstein still lie.  I must arise and examine.
+Good night, my sister.
+
+Great God! what a scene has just taken place!  I am yet dizzy with the
+remembrance of it.  I hardly know whether I shall have the power to
+detail it; yet the tale which I have recorded would be incomplete
+without this final and wonderful catastrophe. I entered the cabin where
+lay the remains of my ill-fated and admirable friend.  Over him hung a
+form which I cannot find words to describe--gigantic in stature, yet
+uncouth and distorted in its proportions.  As he hung over the coffin,
+his face was concealed by long locks of ragged hair; but one vast hand
+was extended, in colour and apparent texture like that of a mummy. When
+he heard the sound of my approach, he ceased to utter exclamations of
+grief and horror and sprung towards the window.  Never did I behold a
+vision so horrible as his face, of such loathsome yet appalling
+hideousness.  I shut my eyes involuntarily and endeavoured to recollect
+what were my duties with regard to this destroyer.  I called on him to
+stay.
+
+He paused, looking on me with wonder, and again turning towards the
+lifeless form of his creator, he seemed to forget my presence, and
+every feature and gesture seemed instigated by the wildest rage of some
+uncontrollable passion.
+
+"That is also my victim!" he exclaimed.  "In his murder my crimes are
+consummated; the miserable series of my being is wound to its close!
+Oh, Frankenstein!  Generous and self-devoted being!  What does it avail
+that I now ask thee to pardon me?  I, who irretrievably destroyed thee
+by destroying all thou lovedst.  Alas!  He is cold, he cannot answer
+me." His voice seemed suffocated, and my first impulses, which had
+suggested to me the duty of obeying the dying request of my friend in
+destroying his enemy, were now suspended by a mixture of curiosity and
+compassion.  I approached this tremendous being; I dared not again
+raise my eyes to his face, there was something so scaring and unearthly
+in his ugliness.  I attempted to speak, but the words died away on my
+lips.  The monster continued to utter wild and incoherent
+self-reproaches.  At length I gathered resolution to address him in a
+pause of the tempest of his passion.
+
+"Your repentance," I said, "is now superfluous. If you had listened to
+the voice of conscience and heeded the stings of remorse before you had
+urged your diabolical vengeance to this extremity, Frankenstein would
+yet have lived."
+
+"And do you dream?" said the daemon.  "Do you think that I was then
+dead to agony and remorse?  He," he continued, pointing to the corpse,
+"he suffered not in the consummation of the deed. Oh!  Not the
+ten-thousandth portion of the anguish that was mine during the
+lingering detail of its execution.  A frightful selfishness hurried me
+on, while my heart was poisoned with remorse.  Think you that the
+groans of Clerval were music to my ears?  My heart was fashioned to be
+susceptible of love and sympathy, and when wrenched by misery to vice
+and hatred, it did not endure the violence of the change without
+torture such as you cannot even imagine.
+
+"After the murder of Clerval I returned to Switzerland, heart-broken
+and overcome.  I pitied Frankenstein; my pity amounted to horror; I
+abhorred myself.  But when I discovered that he, the author at once of
+my existence and of its unspeakable torments, dared to hope for
+happiness, that while he accumulated wretchedness and despair upon me
+he sought his own enjoyment in feelings and passions from the
+indulgence of which I was forever barred, then impotent envy and bitter
+indignation filled me with an insatiable thirst for vengeance.  I
+recollected my threat and resolved that it should be accomplished.  I
+knew that I was preparing for myself a deadly torture, but I was the
+slave, not the master, of an impulse which I detested yet could not
+disobey.  Yet when she died!  Nay, then I was not miserable.  I had
+cast off all feeling, subdued all anguish, to riot in the excess of my
+despair.  Evil thenceforth became my good.  Urged thus far, I had no
+choice but to adapt my nature to an element which I had willingly
+chosen.  The completion of my demoniacal design became an insatiable
+passion.  And now it is ended; there is my last victim!"
+
+I was at first touched by the expressions of his misery; yet, when I
+called to mind what Frankenstein had said of his powers of eloquence
+and persuasion, and when I again cast my eyes on the lifeless form of
+my friend, indignation was rekindled within me.  "Wretch!" I said.  "It
+is well that you come here to whine over the desolation that you have
+made.  You throw a torch into a pile of buildings, and when they are
+consumed, you sit among the ruins and lament the fall.  Hypocritical
+fiend!  If he whom you mourn still lived, still would he be the object,
+again would he become the prey, of your accursed vengeance.  It is not
+pity that you feel; you lament only because the victim of your
+malignity is withdrawn from your power."
+
+"Oh, it is not thus--not thus," interrupted the being.  "Yet such must
+be the impression conveyed to you by what appears to be the purport of
+my actions.  Yet I seek not a fellow feeling in my misery.  No sympathy
+may I ever find.  When I first sought it, it was the love of virtue,
+the feelings of happiness and affection with which my whole being
+overflowed, that I wished to be participated.  But now that virtue has
+become to me a shadow, and that happiness and affection are turned into
+bitter and loathing despair, in what should I seek for sympathy?  I am
+content to suffer alone while my sufferings shall endure; when I die, I
+am well satisfied that abhorrence and opprobrium should load my memory.
+Once my fancy was soothed with dreams of virtue, of fame, and of
+enjoyment.  Once I falsely hoped to meet with beings who, pardoning my
+outward form, would love me for the excellent qualities which I was
+capable of unfolding.  I was nourished with high thoughts of honour and
+devotion.  But now crime has degraded me beneath the meanest animal. No
+guilt, no mischief, no malignity, no misery, can be found comparable to
+mine.  When I run over the frightful catalogue of my sins, I cannot
+believe that I am the same creature whose thoughts were once filled
+with sublime and transcendent visions of the beauty and the majesty of
+goodness.  But it is even so; the fallen angel becomes a malignant
+devil.  Yet even that enemy of God and man had friends and associates
+in his desolation; I am alone.
+
+"You, who call Frankenstein your friend, seem to have a knowledge of my
+crimes and his misfortunes. But in the detail which he gave you of them
+he could not sum up the hours and months of misery which I endured
+wasting in impotent passions. For while I destroyed his hopes, I did
+not satisfy my own desires. They were forever ardent and craving; still
+I desired love and fellowship, and I was still spurned.  Was there no
+injustice in this? Am I to be thought the only criminal, when all
+humankind sinned against me? Why do you not hate Felix, who drove his
+friend from his door with contumely? Why do you not execrate the rustic
+who sought to destroy the saviour of his child? Nay, these are virtuous
+and immaculate beings! I, the miserable and the abandoned, am an
+abortion, to be spurned at, and kicked, and trampled on. Even now my
+blood boils at the recollection of this injustice.
+
+"But it is true that I am a wretch.  I have murdered the lovely and the
+helpless; I have strangled the innocent as they slept and grasped to
+death his throat who never injured me or any other living thing.  I
+have devoted my creator, the select specimen of all that is worthy of
+love and admiration among men, to misery; I have pursued him even to
+that irremediable ruin.
+
+"There he lies, white and cold in death.  You hate me, but your
+abhorrence cannot equal that with which I regard myself.  I look on the
+hands which executed the deed; I think on the heart in which the
+imagination of it was conceived and long for the moment when these
+hands will meet my eyes, when that imagination will haunt my thoughts
+no more.
+
+"Fear not that I shall be the instrument of future mischief.  My work
+is nearly complete.  Neither yours nor any man's death is needed to
+consummate the series of my being and accomplish that which must be
+done, but it requires my own.  Do not think that I shall be slow to
+perform this sacrifice.  I shall quit your vessel on the ice raft which
+brought me thither and shall seek the most northern extremity of the
+globe; I shall collect my funeral pile and consume to ashes this
+miserable frame, that its remains may afford no light to any curious
+and unhallowed wretch who would create such another as I have been.  I
+shall die.  I shall no longer feel the agonies which now consume me or
+be the prey of feelings unsatisfied, yet unquenched.  He is dead who
+called me into being; and when I shall be no more, the very remembrance
+of us both will speedily vanish.  I shall no longer see the sun or
+stars or feel the winds play on my cheeks.
+
+"Light, feeling, and sense will pass away; and in this condition must I
+find my happiness.  Some years ago, when the images which this world
+affords first opened upon me, when I felt the cheering warmth of summer
+and heard the rustling of the leaves and the warbling of the birds, and
+these were all to me, I should have wept to die; now it is my only
+consolation.  Polluted by crimes and torn by the bitterest remorse,
+where can I find rest but in death?
+
+"Farewell!  I leave you, and in you the last of humankind whom these
+eyes will ever behold. Farewell, Frankenstein! If thou wert yet alive
+and yet cherished a desire of revenge against me, it would be better
+satiated in my life than in my destruction. But it was not so; thou
+didst seek my extinction, that I might not cause greater wretchedness;
+and if yet, in some mode unknown to me, thou hadst not ceased to think
+and feel, thou wouldst not desire against me a vengeance greater than
+that which I feel. Blasted as thou wert, my agony was still superior to
+thine, for the bitter sting of remorse will not cease to rankle in my
+wounds until death shall close them forever.
+
+"But soon," he cried with sad and solemn enthusiasm, "I shall die, and
+what I now feel be no longer felt.  Soon these burning miseries will be
+extinct.  I shall ascend my funeral pile triumphantly and exult in the
+agony of the torturing flames. The light of that conflagration will
+fade away; my ashes will be swept into the sea by the winds.  My spirit
+will sleep in peace, or if it thinks, it will not surely think thus.
+Farewell."
+
+He sprang from the cabin window as he said this, upon the ice raft
+which lay close to the vessel.  He was soon borne away by the waves and
+lost in darkness and distance.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of Frankenstein, by
+Mary Wollstonecraft (Godwin) Shelley
+
+*** END OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+***** This file should be named 84.txt or 84.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/8/84/
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/grimm-brothers.txt
+++ b/jet/hadoop/src/main/resources/books/grimm-brothers.txt
@@ -1,0 +1,9571 @@
+﻿The Project Gutenberg EBook of Grimms’ Fairy Tales, by The Brothers Grimm
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Grimms’ Fairy Tales
+
+Author: The Brothers Grimm
+
+Translator: Edgar Taylor and Marian Edwardes
+
+Posting Date: December 14, 2008 [EBook #2591]
+Release Date: April, 2001
+Last Updated: November 7, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+
+
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+
+
+
+
+FAIRY TALES
+
+By The Brothers Grimm
+
+
+
+PREPARER’S NOTE
+
+     The text is based on translations from
+     the Grimms’ Kinder und Hausmarchen by
+     Edgar Taylor and Marian Edwardes.
+
+
+
+
+CONTENTS:
+
+     THE GOLDEN BIRD
+     HANS IN LUCK
+     JORINDA AND JORINDEL
+     THE TRAVELLING MUSICIANS
+     OLD SULTAN
+     THE STRAW, THE COAL, AND THE BEAN
+     BRIAR ROSE
+     THE DOG AND THE SPARROW
+     THE TWELVE DANCING PRINCESSES
+     THE FISHERMAN AND HIS WIFE
+     THE WILLOW-WREN AND THE BEAR
+     THE FROG-PRINCE
+     CAT AND MOUSE IN PARTNERSHIP
+     THE GOOSE-GIRL
+     THE ADVENTURES OF CHANTICLEER AND PARTLET
+       1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+       2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+     RAPUNZEL
+     FUNDEVOGEL
+     THE VALIANT LITTLE TAILOR
+     HANSEL AND GRETEL
+     THE MOUSE, THE BIRD, AND THE SAUSAGE
+     MOTHER HOLLE
+     LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+     THE ROBBER BRIDEGROOM
+     TOM THUMB
+     RUMPELSTILTSKIN
+     CLEVER GRETEL
+     THE OLD MAN AND HIS GRANDSON
+     THE LITTLE PEASANT
+     FREDERICK AND CATHERINE
+     SWEETHEART ROLAND
+     SNOWDROP
+     THE PINK
+     CLEVER ELSIE
+     THE MISER IN THE BUSH
+     ASHPUTTEL
+     THE WHITE SNAKE
+     THE WOLF AND THE SEVEN LITTLE KIDS
+     THE QUEEN BEE
+     THE ELVES AND THE SHOEMAKER
+     THE JUNIPER-TREE
+     the juniper-tree.
+     THE TURNIP
+     CLEVER HANS
+     THE THREE LANGUAGES
+     THE FOX AND THE CAT
+     THE FOUR CLEVER BROTHERS
+     LILY AND THE LION
+     THE FOX AND THE HORSE
+     THE BLUE LIGHT
+     THE RAVEN
+     THE GOLDEN GOOSE
+     THE WATER OF LIFE
+     THE TWELVE HUNTSMEN
+     THE KING OF THE GOLDEN MOUNTAIN
+     DOCTOR KNOWALL
+     THE SEVEN RAVENS
+     THE WEDDING OF MRS FOX
+     FIRST STORY
+     SECOND STORY
+     THE SALAD
+     THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+     KING GRISLY-BEARD
+     IRON HANS
+     CAT-SKIN
+     SNOW-WHITE AND ROSE-RED
+
+
+
+
+THE BROTHERS GRIMM FAIRY TALES
+
+
+
+
+THE GOLDEN BIRD
+
+A certain king had a beautiful garden, and in the garden stood a tree
+which bore golden apples. These apples were always counted, and about
+the time when they began to grow ripe it was found that every night one
+of them was gone. The king became very angry at this, and ordered the
+gardener to keep watch all night under the tree. The gardener set his
+eldest son to watch; but about twelve o’clock he fell asleep, and in
+the morning another of the apples was missing. Then the second son was
+ordered to watch; and at midnight he too fell asleep, and in the morning
+another apple was gone. Then the third son offered to keep watch; but
+the gardener at first would not let him, for fear some harm should come
+to him: however, at last he consented, and the young man laid himself
+under the tree to watch. As the clock struck twelve he heard a rustling
+noise in the air, and a bird came flying that was of pure gold; and as
+it was snapping at one of the apples with its beak, the gardener’s son
+jumped up and shot an arrow at it. But the arrow did the bird no harm;
+only it dropped a golden feather from its tail, and then flew away.
+The golden feather was brought to the king in the morning, and all the
+council was called together. Everyone agreed that it was worth more than
+all the wealth of the kingdom: but the king said, ‘One feather is of no
+use to me, I must have the whole bird.’
+
+Then the gardener’s eldest son set out and thought to find the golden
+bird very easily; and when he had gone but a little way, he came to a
+wood, and by the side of the wood he saw a fox sitting; so he took his
+bow and made ready to shoot at it. Then the fox said, ‘Do not shoot me,
+for I will give you good counsel; I know what your business is, and
+that you want to find the golden bird. You will reach a village in the
+evening; and when you get there, you will see two inns opposite to each
+other, one of which is very pleasant and beautiful to look at: go not in
+there, but rest for the night in the other, though it may appear to you
+to be very poor and mean.’ But the son thought to himself, ‘What can
+such a beast as this know about the matter?’ So he shot his arrow at
+the fox; but he missed it, and it set up its tail above its back and
+ran into the wood. Then he went his way, and in the evening came to
+the village where the two inns were; and in one of these were people
+singing, and dancing, and feasting; but the other looked very dirty,
+and poor. ‘I should be very silly,’ said he, ‘if I went to that shabby
+house, and left this charming place’; so he went into the smart house,
+and ate and drank at his ease, and forgot the bird, and his country too.
+
+Time passed on; and as the eldest son did not come back, and no tidings
+were heard of him, the second son set out, and the same thing happened
+to him. He met the fox, who gave him the good advice: but when he came
+to the two inns, his eldest brother was standing at the window where
+the merrymaking was, and called to him to come in; and he could not
+withstand the temptation, but went in, and forgot the golden bird and
+his country in the same manner.
+
+Time passed on again, and the youngest son too wished to set out into
+the wide world to seek for the golden bird; but his father would not
+listen to it for a long while, for he was very fond of his son, and
+was afraid that some ill luck might happen to him also, and prevent his
+coming back. However, at last it was agreed he should go, for he would
+not rest at home; and as he came to the wood, he met the fox, and heard
+the same good counsel. But he was thankful to the fox, and did not
+attempt his life as his brothers had done; so the fox said, ‘Sit upon my
+tail, and you will travel faster.’ So he sat down, and the fox began to
+run, and away they went over stock and stone so quick that their hair
+whistled in the wind.
+
+When they came to the village, the son followed the fox’s counsel, and
+without looking about him went to the shabby inn and rested there all
+night at his ease. In the morning came the fox again and met him as he
+was beginning his journey, and said, ‘Go straight forward, till you come
+to a castle, before which lie a whole troop of soldiers fast asleep and
+snoring: take no notice of them, but go into the castle and pass on and
+on till you come to a room, where the golden bird sits in a wooden cage;
+close by it stands a beautiful golden cage; but do not try to take the
+bird out of the shabby cage and put it into the handsome one, otherwise
+you will repent it.’ Then the fox stretched out his tail again, and the
+young man sat himself down, and away they went over stock and stone till
+their hair whistled in the wind.
+
+Before the castle gate all was as the fox had said: so the son went in
+and found the chamber where the golden bird hung in a wooden cage, and
+below stood the golden cage, and the three golden apples that had been
+lost were lying close by it. Then thought he to himself, ‘It will be a
+very droll thing to bring away such a fine bird in this shabby cage’; so
+he opened the door and took hold of it and put it into the golden cage.
+But the bird set up such a loud scream that all the soldiers awoke, and
+they took him prisoner and carried him before the king. The next morning
+the court sat to judge him; and when all was heard, it sentenced him to
+die, unless he should bring the king the golden horse which could run as
+swiftly as the wind; and if he did this, he was to have the golden bird
+given him for his own.
+
+So he set out once more on his journey, sighing, and in great despair,
+when on a sudden his friend the fox met him, and said, ‘You see now
+what has happened on account of your not listening to my counsel. I will
+still, however, tell you how to find the golden horse, if you will do as
+I bid you. You must go straight on till you come to the castle where the
+horse stands in his stall: by his side will lie the groom fast asleep
+and snoring: take away the horse quietly, but be sure to put the old
+leathern saddle upon him, and not the golden one that is close by it.’
+Then the son sat down on the fox’s tail, and away they went over stock
+and stone till their hair whistled in the wind.
+
+All went right, and the groom lay snoring with his hand upon the golden
+saddle. But when the son looked at the horse, he thought it a great pity
+to put the leathern saddle upon it. ‘I will give him the good one,’
+said he; ‘I am sure he deserves it.’ As he took up the golden saddle the
+groom awoke and cried out so loud, that all the guards ran in and took
+him prisoner, and in the morning he was again brought before the court
+to be judged, and was sentenced to die. But it was agreed, that, if he
+could bring thither the beautiful princess, he should live, and have the
+bird and the horse given him for his own.
+
+Then he went his way very sorrowful; but the old fox came and said, ‘Why
+did not you listen to me? If you had, you would have carried away
+both the bird and the horse; yet will I once more give you counsel. Go
+straight on, and in the evening you will arrive at a castle. At twelve
+o’clock at night the princess goes to the bathing-house: go up to her
+and give her a kiss, and she will let you lead her away; but take care
+you do not suffer her to go and take leave of her father and mother.’
+Then the fox stretched out his tail, and so away they went over stock
+and stone till their hair whistled again.
+
+As they came to the castle, all was as the fox had said, and at twelve
+o’clock the young man met the princess going to the bath and gave her the
+kiss, and she agreed to run away with him, but begged with many tears
+that he would let her take leave of her father. At first he refused,
+but she wept still more and more, and fell at his feet, till at last
+he consented; but the moment she came to her father’s house the guards
+awoke and he was taken prisoner again.
+
+Then he was brought before the king, and the king said, ‘You shall never
+have my daughter unless in eight days you dig away the hill that stops
+the view from my window.’ Now this hill was so big that the whole world
+could not take it away: and when he had worked for seven days, and had
+done very little, the fox came and said. ‘Lie down and go to sleep; I
+will work for you.’ And in the morning he awoke and the hill was gone;
+so he went merrily to the king, and told him that now that it was
+removed he must give him the princess.
+
+Then the king was obliged to keep his word, and away went the young man
+and the princess; and the fox came and said to him, ‘We will have all
+three, the princess, the horse, and the bird.’ ‘Ah!’ said the young man,
+‘that would be a great thing, but how can you contrive it?’
+
+‘If you will only listen,’ said the fox, ‘it can be done. When you come
+to the king, and he asks for the beautiful princess, you must say, “Here
+she is!” Then he will be very joyful; and you will mount the golden
+horse that they are to give you, and put out your hand to take leave of
+them; but shake hands with the princess last. Then lift her quickly on
+to the horse behind you; clap your spurs to his side, and gallop away as
+fast as you can.’
+
+All went right: then the fox said, ‘When you come to the castle where
+the bird is, I will stay with the princess at the door, and you will
+ride in and speak to the king; and when he sees that it is the right
+horse, he will bring out the bird; but you must sit still, and say that
+you want to look at it, to see whether it is the true golden bird; and
+when you get it into your hand, ride away.’
+
+This, too, happened as the fox said; they carried off the bird, the
+princess mounted again, and they rode on to a great wood. Then the fox
+came, and said, ‘Pray kill me, and cut off my head and my feet.’ But the
+young man refused to do it: so the fox said, ‘I will at any rate give
+you good counsel: beware of two things; ransom no one from the gallows,
+and sit down by the side of no river.’ Then away he went. ‘Well,’
+thought the young man, ‘it is no hard matter to keep that advice.’
+
+He rode on with the princess, till at last he came to the village where
+he had left his two brothers. And there he heard a great noise and
+uproar; and when he asked what was the matter, the people said, ‘Two men
+are going to be hanged.’ As he came nearer, he saw that the two men were
+his brothers, who had turned robbers; so he said, ‘Cannot they in any
+way be saved?’ But the people said ‘No,’ unless he would bestow all his
+money upon the rascals and buy their liberty. Then he did not stay to
+think about the matter, but paid what was asked, and his brothers were
+given up, and went on with him towards their home.
+
+And as they came to the wood where the fox first met them, it was so
+cool and pleasant that the two brothers said, ‘Let us sit down by the
+side of the river, and rest a while, to eat and drink.’ So he said,
+‘Yes,’ and forgot the fox’s counsel, and sat down on the side of the
+river; and while he suspected nothing, they came behind, and threw him
+down the bank, and took the princess, the horse, and the bird, and went
+home to the king their master, and said. ‘All this have we won by our
+labour.’ Then there was great rejoicing made; but the horse would not
+eat, the bird would not sing, and the princess wept.
+
+The youngest son fell to the bottom of the river’s bed: luckily it was
+nearly dry, but his bones were almost broken, and the bank was so steep
+that he could find no way to get out. Then the old fox came once more,
+and scolded him for not following his advice; otherwise no evil would
+have befallen him: ‘Yet,’ said he, ‘I cannot leave you here, so lay hold
+of my tail and hold fast.’ Then he pulled him out of the river, and said
+to him, as he got upon the bank, ‘Your brothers have set watch to kill
+you, if they find you in the kingdom.’ So he dressed himself as a poor
+man, and came secretly to the king’s court, and was scarcely within the
+doors when the horse began to eat, and the bird to sing, and the princess
+left off weeping. Then he went to the king, and told him all his
+brothers’ roguery; and they were seized and punished, and he had the
+princess given to him again; and after the king’s death he was heir to
+his kingdom.
+
+A long while after, he went to walk one day in the wood, and the old fox
+met him, and besought him with tears in his eyes to kill him, and cut
+off his head and feet. And at last he did so, and in a moment the
+fox was changed into a man, and turned out to be the brother of the
+princess, who had been lost a great many many years.
+
+
+
+
+HANS IN LUCK
+
+Some men are born to good luck: all they do or try to do comes
+right--all that falls to them is so much gain--all their geese are
+swans--all their cards are trumps--toss them which way you will, they
+will always, like poor puss, alight upon their legs, and only move on so
+much the faster. The world may very likely not always think of them as
+they think of themselves, but what care they for the world? what can it
+know about the matter?
+
+One of these lucky beings was neighbour Hans. Seven long years he had
+worked hard for his master. At last he said, ‘Master, my time is up; I
+must go home and see my poor mother once more: so pray pay me my wages
+and let me go.’ And the master said, ‘You have been a faithful and good
+servant, Hans, so your pay shall be handsome.’ Then he gave him a lump
+of silver as big as his head.
+
+Hans took out his pocket-handkerchief, put the piece of silver into it,
+threw it over his shoulder, and jogged off on his road homewards. As he
+went lazily on, dragging one foot after another, a man came in sight,
+trotting gaily along on a capital horse. ‘Ah!’ said Hans aloud, ‘what a
+fine thing it is to ride on horseback! There he sits as easy and happy
+as if he was at home, in the chair by his fireside; he trips against no
+stones, saves shoe-leather, and gets on he hardly knows how.’ Hans did
+not speak so softly but the horseman heard it all, and said, ‘Well,
+friend, why do you go on foot then?’ ‘Ah!’ said he, ‘I have this load to
+carry: to be sure it is silver, but it is so heavy that I can’t hold up
+my head, and you must know it hurts my shoulder sadly.’ ‘What do you say
+of making an exchange?’ said the horseman. ‘I will give you my horse,
+and you shall give me the silver; which will save you a great deal of
+trouble in carrying such a heavy load about with you.’ ‘With all my
+heart,’ said Hans: ‘but as you are so kind to me, I must tell you one
+thing--you will have a weary task to draw that silver about with you.’
+However, the horseman got off, took the silver, helped Hans up, gave him
+the bridle into one hand and the whip into the other, and said, ‘When
+you want to go very fast, smack your lips loudly together, and cry
+“Jip!”’
+
+Hans was delighted as he sat on the horse, drew himself up, squared his
+elbows, turned out his toes, cracked his whip, and rode merrily off, one
+minute whistling a merry tune, and another singing,
+
+ ‘No care and no sorrow,
+  A fig for the morrow!
+  We’ll laugh and be merry,
+  Sing neigh down derry!’
+
+After a time he thought he should like to go a little faster, so he
+smacked his lips and cried ‘Jip!’ Away went the horse full gallop; and
+before Hans knew what he was about, he was thrown off, and lay on his
+back by the road-side. His horse would have ran off, if a shepherd who
+was coming by, driving a cow, had not stopped it. Hans soon came to
+himself, and got upon his legs again, sadly vexed, and said to the
+shepherd, ‘This riding is no joke, when a man has the luck to get upon
+a beast like this that stumbles and flings him off as if it would break
+his neck. However, I’m off now once for all: I like your cow now a great
+deal better than this smart beast that played me this trick, and has
+spoiled my best coat, you see, in this puddle; which, by the by, smells
+not very like a nosegay. One can walk along at one’s leisure behind that
+cow--keep good company, and have milk, butter, and cheese, every day,
+into the bargain. What would I give to have such a prize!’ ‘Well,’ said
+the shepherd, ‘if you are so fond of her, I will change my cow for your
+horse; I like to do good to my neighbours, even though I lose by it
+myself.’ ‘Done!’ said Hans, merrily. ‘What a noble heart that good man
+has!’ thought he. Then the shepherd jumped upon the horse, wished Hans
+and the cow good morning, and away he rode.
+
+Hans brushed his coat, wiped his face and hands, rested a while, and
+then drove off his cow quietly, and thought his bargain a very lucky
+one. ‘If I have only a piece of bread (and I certainly shall always be
+able to get that), I can, whenever I like, eat my butter and cheese with
+it; and when I am thirsty I can milk my cow and drink the milk: and what
+can I wish for more?’ When he came to an inn, he halted, ate up all his
+bread, and gave away his last penny for a glass of beer. When he had
+rested himself he set off again, driving his cow towards his mother’s
+village. But the heat grew greater as soon as noon came on, till at
+last, as he found himself on a wide heath that would take him more than
+an hour to cross, he began to be so hot and parched that his tongue
+clave to the roof of his mouth. ‘I can find a cure for this,’ thought
+he; ‘now I will milk my cow and quench my thirst’: so he tied her to the
+stump of a tree, and held his leathern cap to milk into; but not a drop
+was to be had. Who would have thought that this cow, which was to bring
+him milk and butter and cheese, was all that time utterly dry? Hans had
+not thought of looking to that.
+
+While he was trying his luck in milking, and managing the matter very
+clumsily, the uneasy beast began to think him very troublesome; and at
+last gave him such a kick on the head as knocked him down; and there he
+lay a long while senseless. Luckily a butcher soon came by, driving a
+pig in a wheelbarrow. ‘What is the matter with you, my man?’ said the
+butcher, as he helped him up. Hans told him what had happened, how he
+was dry, and wanted to milk his cow, but found the cow was dry too. Then
+the butcher gave him a flask of ale, saying, ‘There, drink and refresh
+yourself; your cow will give you no milk: don’t you see she is an old
+beast, good for nothing but the slaughter-house?’ ‘Alas, alas!’ said
+Hans, ‘who would have thought it? What a shame to take my horse, and
+give me only a dry cow! If I kill her, what will she be good for? I hate
+cow-beef; it is not tender enough for me. If it were a pig now--like
+that fat gentleman you are driving along at his ease--one could do
+something with it; it would at any rate make sausages.’ ‘Well,’ said
+the butcher, ‘I don’t like to say no, when one is asked to do a kind,
+neighbourly thing. To please you I will change, and give you my fine fat
+pig for the cow.’ ‘Heaven reward you for your kindness and self-denial!’
+said Hans, as he gave the butcher the cow; and taking the pig off the
+wheel-barrow, drove it away, holding it by the string that was tied to
+its leg.
+
+So on he jogged, and all seemed now to go right with him: he had met
+with some misfortunes, to be sure; but he was now well repaid for all.
+How could it be otherwise with such a travelling companion as he had at
+last got?
+
+The next man he met was a countryman carrying a fine white goose. The
+countryman stopped to ask what was o’clock; this led to further chat;
+and Hans told him all his luck, how he had so many good bargains, and
+how all the world went gay and smiling with him. The countryman then
+began to tell his tale, and said he was going to take the goose to a
+christening. ‘Feel,’ said he, ‘how heavy it is, and yet it is only eight
+weeks old. Whoever roasts and eats it will find plenty of fat upon it,
+it has lived so well!’ ‘You’re right,’ said Hans, as he weighed it in
+his hand; ‘but if you talk of fat, my pig is no trifle.’ Meantime the
+countryman began to look grave, and shook his head. ‘Hark ye!’ said he,
+‘my worthy friend, you seem a good sort of fellow, so I can’t help doing
+you a kind turn. Your pig may get you into a scrape. In the village I
+just came from, the squire has had a pig stolen out of his sty. I was
+dreadfully afraid when I saw you that you had got the squire’s pig. If
+you have, and they catch you, it will be a bad job for you. The least
+they will do will be to throw you into the horse-pond. Can you swim?’
+
+Poor Hans was sadly frightened. ‘Good man,’ cried he, ‘pray get me out
+of this scrape. I know nothing of where the pig was either bred or born;
+but he may have been the squire’s for aught I can tell: you know this
+country better than I do, take my pig and give me the goose.’ ‘I ought
+to have something into the bargain,’ said the countryman; ‘give a fat
+goose for a pig, indeed! ‘Tis not everyone would do so much for you as
+that. However, I will not be hard upon you, as you are in trouble.’ Then
+he took the string in his hand, and drove off the pig by a side path;
+while Hans went on the way homewards free from care. ‘After all,’
+thought he, ‘that chap is pretty well taken in. I don’t care whose pig
+it is, but wherever it came from it has been a very good friend to me. I
+have much the best of the bargain. First there will be a capital roast;
+then the fat will find me in goose-grease for six months; and then there
+are all the beautiful white feathers. I will put them into my pillow,
+and then I am sure I shall sleep soundly without rocking. How happy my
+mother will be! Talk of a pig, indeed! Give me a fine fat goose.’
+
+As he came to the next village, he saw a scissor-grinder with his wheel,
+working and singing,
+
+ ‘O’er hill and o’er dale
+  So happy I roam,
+  Work light and live well,
+  All the world is my home;
+  Then who so blythe, so merry as I?’
+
+Hans stood looking on for a while, and at last said, ‘You must be well
+off, master grinder! you seem so happy at your work.’ ‘Yes,’ said the
+other, ‘mine is a golden trade; a good grinder never puts his hand
+into his pocket without finding money in it--but where did you get that
+beautiful goose?’ ‘I did not buy it, I gave a pig for it.’ ‘And where
+did you get the pig?’ ‘I gave a cow for it.’ ‘And the cow?’ ‘I gave a
+horse for it.’ ‘And the horse?’ ‘I gave a lump of silver as big as my
+head for it.’ ‘And the silver?’ ‘Oh! I worked hard for that seven long
+years.’ ‘You have thriven well in the world hitherto,’ said the grinder,
+‘now if you could find money in your pocket whenever you put your hand
+in it, your fortune would be made.’ ‘Very true: but how is that to be
+managed?’ ‘How? Why, you must turn grinder like myself,’ said the other;
+‘you only want a grindstone; the rest will come of itself. Here is one
+that is but little the worse for wear: I would not ask more than the
+value of your goose for it--will you buy?’ ‘How can you ask?’ said
+Hans; ‘I should be the happiest man in the world, if I could have money
+whenever I put my hand in my pocket: what could I want more? there’s
+the goose.’ ‘Now,’ said the grinder, as he gave him a common rough stone
+that lay by his side, ‘this is a most capital stone; do but work it well
+enough, and you can make an old nail cut with it.’
+
+Hans took the stone, and went his way with a light heart: his eyes
+sparkled for joy, and he said to himself, ‘Surely I must have been born
+in a lucky hour; everything I could want or wish for comes of itself.
+People are so kind; they seem really to think I do them a favour in
+letting them make me rich, and giving me good bargains.’
+
+Meantime he began to be tired, and hungry too, for he had given away his
+last penny in his joy at getting the cow.
+
+At last he could go no farther, for the stone tired him sadly: and he
+dragged himself to the side of a river, that he might take a drink of
+water, and rest a while. So he laid the stone carefully by his side on
+the bank: but, as he stooped down to drink, he forgot it, pushed it a
+little, and down it rolled, plump into the stream.
+
+For a while he watched it sinking in the deep clear water; then sprang
+up and danced for joy, and again fell upon his knees and thanked Heaven,
+with tears in his eyes, for its kindness in taking away his only plague,
+the ugly heavy stone.
+
+‘How happy am I!’ cried he; ‘nobody was ever so lucky as I.’ Then up he
+got with a light heart, free from all his troubles, and walked on till
+he reached his mother’s house, and told her how very easy the road to
+good luck was.
+
+
+
+
+JORINDA AND JORINDEL
+
+There was once an old castle, that stood in the middle of a deep gloomy
+wood, and in the castle lived an old fairy. Now this fairy could take
+any shape she pleased. All the day long she flew about in the form of
+an owl, or crept about the country like a cat; but at night she always
+became an old woman again. When any young man came within a hundred
+paces of her castle, he became quite fixed, and could not move a step
+till she came and set him free; which she would not do till he had given
+her his word never to come there again: but when any pretty maiden came
+within that space she was changed into a bird, and the fairy put her
+into a cage, and hung her up in a chamber in the castle. There were
+seven hundred of these cages hanging in the castle, and all with
+beautiful birds in them.
+
+Now there was once a maiden whose name was Jorinda. She was prettier
+than all the pretty girls that ever were seen before, and a shepherd
+lad, whose name was Jorindel, was very fond of her, and they were soon
+to be married. One day they went to walk in the wood, that they might be
+alone; and Jorindel said, ‘We must take care that we don’t go too near
+to the fairy’s castle.’ It was a beautiful evening; the last rays of the
+setting sun shone bright through the long stems of the trees upon
+the green underwood beneath, and the turtle-doves sang from the tall
+birches.
+
+Jorinda sat down to gaze upon the sun; Jorindel sat by her side; and
+both felt sad, they knew not why; but it seemed as if they were to be
+parted from one another for ever. They had wandered a long way; and when
+they looked to see which way they should go home, they found themselves
+at a loss to know what path to take.
+
+The sun was setting fast, and already half of its circle had sunk behind
+the hill: Jorindel on a sudden looked behind him, and saw through the
+bushes that they had, without knowing it, sat down close under the old
+walls of the castle. Then he shrank for fear, turned pale, and trembled.
+Jorinda was just singing,
+
+ ‘The ring-dove sang from the willow spray,
+  Well-a-day! Well-a-day!
+  He mourn’d for the fate of his darling mate,
+  Well-a-day!’
+
+when her song stopped suddenly. Jorindel turned to see the reason, and
+beheld his Jorinda changed into a nightingale, so that her song ended
+with a mournful _jug, jug_. An owl with fiery eyes flew three times
+round them, and three times screamed:
+
+ ‘Tu whu! Tu whu! Tu whu!’
+
+Jorindel could not move; he stood fixed as a stone, and could neither
+weep, nor speak, nor stir hand or foot. And now the sun went quite down;
+the gloomy night came; the owl flew into a bush; and a moment after the
+old fairy came forth pale and meagre, with staring eyes, and a nose and
+chin that almost met one another.
+
+She mumbled something to herself, seized the nightingale, and went away
+with it in her hand. Poor Jorindel saw the nightingale was gone--but
+what could he do? He could not speak, he could not move from the spot
+where he stood. At last the fairy came back and sang with a hoarse
+voice:
+
+ ‘Till the prisoner is fast,
+  And her doom is cast,
+  There stay! Oh, stay!
+  When the charm is around her,
+  And the spell has bound her,
+  Hie away! away!’
+
+On a sudden Jorindel found himself free. Then he fell on his knees
+before the fairy, and prayed her to give him back his dear Jorinda: but
+she laughed at him, and said he should never see her again; then she
+went her way.
+
+He prayed, he wept, he sorrowed, but all in vain. ‘Alas!’ he said, ‘what
+will become of me?’ He could not go back to his own home, so he went to
+a strange village, and employed himself in keeping sheep. Many a time
+did he walk round and round as near to the hated castle as he dared go,
+but all in vain; he heard or saw nothing of Jorinda.
+
+At last he dreamt one night that he found a beautiful purple flower,
+and that in the middle of it lay a costly pearl; and he dreamt that he
+plucked the flower, and went with it in his hand into the castle, and
+that everything he touched with it was disenchanted, and that there he
+found his Jorinda again.
+
+In the morning when he awoke, he began to search over hill and dale for
+this pretty flower; and eight long days he sought for it in vain: but
+on the ninth day, early in the morning, he found the beautiful purple
+flower; and in the middle of it was a large dewdrop, as big as a costly
+pearl. Then he plucked the flower, and set out and travelled day and
+night, till he came again to the castle.
+
+He walked nearer than a hundred paces to it, and yet he did not become
+fixed as before, but found that he could go quite close up to the door.
+Jorindel was very glad indeed to see this. Then he touched the door with
+the flower, and it sprang open; so that he went in through the court,
+and listened when he heard so many birds singing. At last he came to the
+chamber where the fairy sat, with the seven hundred birds singing in
+the seven hundred cages. When she saw Jorindel she was very angry, and
+screamed with rage; but she could not come within two yards of him, for
+the flower he held in his hand was his safeguard. He looked around at
+the birds, but alas! there were many, many nightingales, and how then
+should he find out which was his Jorinda? While he was thinking what to
+do, he saw the fairy had taken down one of the cages, and was making the
+best of her way off through the door. He ran or flew after her, touched
+the cage with the flower, and Jorinda stood before him, and threw her
+arms round his neck looking as beautiful as ever, as beautiful as when
+they walked together in the wood.
+
+Then he touched all the other birds with the flower, so that they all
+took their old forms again; and he took Jorinda home, where they were
+married, and lived happily together many years: and so did a good many
+other lads, whose maidens had been forced to sing in the old fairy’s
+cages by themselves, much longer than they liked.
+
+
+
+
+THE TRAVELLING MUSICIANS
+
+An honest farmer had once an ass that had been a faithful servant to him
+a great many years, but was now growing old and every day more and more
+unfit for work. His master therefore was tired of keeping him and
+began to think of putting an end to him; but the ass, who saw that some
+mischief was in the wind, took himself slyly off, and began his journey
+towards the great city, ‘For there,’ thought he, ‘I may turn musician.’
+
+After he had travelled a little way, he spied a dog lying by the
+roadside and panting as if he were tired. ‘What makes you pant so, my
+friend?’ said the ass. ‘Alas!’ said the dog, ‘my master was going to
+knock me on the head, because I am old and weak, and can no longer make
+myself useful to him in hunting; so I ran away; but what can I do to
+earn my livelihood?’ ‘Hark ye!’ said the ass, ‘I am going to the great
+city to turn musician: suppose you go with me, and try what you can
+do in the same way?’ The dog said he was willing, and they jogged on
+together.
+
+They had not gone far before they saw a cat sitting in the middle of the
+road and making a most rueful face. ‘Pray, my good lady,’ said the ass,
+‘what’s the matter with you? You look quite out of spirits!’ ‘Ah, me!’
+said the cat, ‘how can one be in good spirits when one’s life is in
+danger? Because I am beginning to grow old, and had rather lie at my
+ease by the fire than run about the house after the mice, my mistress
+laid hold of me, and was going to drown me; and though I have been lucky
+enough to get away from her, I do not know what I am to live upon.’
+‘Oh,’ said the ass, ‘by all means go with us to the great city; you are
+a good night singer, and may make your fortune as a musician.’ The cat
+was pleased with the thought, and joined the party.
+
+Soon afterwards, as they were passing by a farmyard, they saw a cock
+perched upon a gate, and screaming out with all his might and main.
+‘Bravo!’ said the ass; ‘upon my word, you make a famous noise; pray what
+is all this about?’ ‘Why,’ said the cock, ‘I was just now saying that
+we should have fine weather for our washing-day, and yet my mistress and
+the cook don’t thank me for my pains, but threaten to cut off my
+head tomorrow, and make broth of me for the guests that are coming
+on Sunday!’ ‘Heaven forbid!’ said the ass, ‘come with us Master
+Chanticleer; it will be better, at any rate, than staying here to have
+your head cut off! Besides, who knows? If we care to sing in tune, we
+may get up some kind of a concert; so come along with us.’ ‘With all my
+heart,’ said the cock: so they all four went on jollily together.
+
+They could not, however, reach the great city the first day; so when
+night came on, they went into a wood to sleep. The ass and the dog laid
+themselves down under a great tree, and the cat climbed up into the
+branches; while the cock, thinking that the higher he sat the safer he
+should be, flew up to the very top of the tree, and then, according to
+his custom, before he went to sleep, looked out on all sides of him to
+see that everything was well. In doing this, he saw afar off something
+bright and shining and calling to his companions said, ‘There must be a
+house no great way off, for I see a light.’ ‘If that be the case,’ said
+the ass, ‘we had better change our quarters, for our lodging is not the
+best in the world!’ ‘Besides,’ added the dog, ‘I should not be the
+worse for a bone or two, or a bit of meat.’ So they walked off together
+towards the spot where Chanticleer had seen the light, and as they drew
+near it became larger and brighter, till they at last came close to a
+house in which a gang of robbers lived.
+
+The ass, being the tallest of the company, marched up to the window and
+peeped in. ‘Well, Donkey,’ said Chanticleer, ‘what do you see?’ ‘What
+do I see?’ replied the ass. ‘Why, I see a table spread with all kinds of
+good things, and robbers sitting round it making merry.’ ‘That would
+be a noble lodging for us,’ said the cock. ‘Yes,’ said the ass, ‘if we
+could only get in’; so they consulted together how they should contrive
+to get the robbers out; and at last they hit upon a plan. The ass placed
+himself upright on his hind legs, with his forefeet resting against the
+window; the dog got upon his back; the cat scrambled up to the dog’s
+shoulders, and the cock flew up and sat upon the cat’s head. When
+all was ready a signal was given, and they began their music. The ass
+brayed, the dog barked, the cat mewed, and the cock screamed; and then
+they all broke through the window at once, and came tumbling into
+the room, amongst the broken glass, with a most hideous clatter! The
+robbers, who had been not a little frightened by the opening concert,
+had now no doubt that some frightful hobgoblin had broken in upon them,
+and scampered away as fast as they could.
+
+The coast once clear, our travellers soon sat down and dispatched what
+the robbers had left, with as much eagerness as if they had not expected
+to eat again for a month. As soon as they had satisfied themselves, they
+put out the lights, and each once more sought out a resting-place to
+his own liking. The donkey laid himself down upon a heap of straw in
+the yard, the dog stretched himself upon a mat behind the door, the
+cat rolled herself up on the hearth before the warm ashes, and the
+cock perched upon a beam on the top of the house; and, as they were all
+rather tired with their journey, they soon fell asleep.
+
+But about midnight, when the robbers saw from afar that the lights were
+out and that all seemed quiet, they began to think that they had been in
+too great a hurry to run away; and one of them, who was bolder than
+the rest, went to see what was going on. Finding everything still, he
+marched into the kitchen, and groped about till he found a match in
+order to light a candle; and then, espying the glittering fiery eyes of
+the cat, he mistook them for live coals, and held the match to them to
+light it. But the cat, not understanding this joke, sprang at his face,
+and spat, and scratched at him. This frightened him dreadfully, and away
+he ran to the back door; but there the dog jumped up and bit him in the
+leg; and as he was crossing over the yard the ass kicked him; and the
+cock, who had been awakened by the noise, crowed with all his might. At
+this the robber ran back as fast as he could to his comrades, and told
+the captain how a horrid witch had got into the house, and had spat at
+him and scratched his face with her long bony fingers; how a man with a
+knife in his hand had hidden himself behind the door, and stabbed him
+in the leg; how a black monster stood in the yard and struck him with a
+club, and how the devil had sat upon the top of the house and cried out,
+‘Throw the rascal up here!’ After this the robbers never dared to go
+back to the house; but the musicians were so pleased with their quarters
+that they took up their abode there; and there they are, I dare say, at
+this very day.
+
+
+
+
+OLD SULTAN
+
+A shepherd had a faithful dog, called Sultan, who was grown very old,
+and had lost all his teeth. And one day when the shepherd and his wife
+were standing together before the house the shepherd said, ‘I will shoot
+old Sultan tomorrow morning, for he is of no use now.’ But his wife
+said, ‘Pray let the poor faithful creature live; he has served us well a
+great many years, and we ought to give him a livelihood for the rest of
+his days.’ ‘But what can we do with him?’ said the shepherd, ‘he has not
+a tooth in his head, and the thieves don’t care for him at all; to
+be sure he has served us, but then he did it to earn his livelihood;
+tomorrow shall be his last day, depend upon it.’
+
+Poor Sultan, who was lying close by them, heard all that the shepherd
+and his wife said to one another, and was very much frightened to think
+tomorrow would be his last day; so in the evening he went to his good
+friend the wolf, who lived in the wood, and told him all his sorrows,
+and how his master meant to kill him in the morning. ‘Make yourself
+easy,’ said the wolf, ‘I will give you some good advice. Your master,
+you know, goes out every morning very early with his wife into the
+field; and they take their little child with them, and lay it down
+behind the hedge in the shade while they are at work. Now do you lie
+down close by the child, and pretend to be watching it, and I will come
+out of the wood and run away with it; you must run after me as fast as
+you can, and I will let it drop; then you may carry it back, and they
+will think you have saved their child, and will be so thankful to you
+that they will take care of you as long as you live.’ The dog liked this
+plan very well; and accordingly so it was managed. The wolf ran with the
+child a little way; the shepherd and his wife screamed out; but Sultan
+soon overtook him, and carried the poor little thing back to his master
+and mistress. Then the shepherd patted him on the head, and said, ‘Old
+Sultan has saved our child from the wolf, and therefore he shall live
+and be well taken care of, and have plenty to eat. Wife, go home, and
+give him a good dinner, and let him have my old cushion to sleep on
+as long as he lives.’ So from this time forward Sultan had all that he
+could wish for.
+
+Soon afterwards the wolf came and wished him joy, and said, ‘Now, my
+good fellow, you must tell no tales, but turn your head the other way
+when I want to taste one of the old shepherd’s fine fat sheep.’ ‘No,’
+said the Sultan; ‘I will be true to my master.’ However, the wolf
+thought he was in joke, and came one night to get a dainty morsel. But
+Sultan had told his master what the wolf meant to do; so he laid wait
+for him behind the barn door, and when the wolf was busy looking out for
+a good fat sheep, he had a stout cudgel laid about his back, that combed
+his locks for him finely.
+
+Then the wolf was very angry, and called Sultan ‘an old rogue,’ and
+swore he would have his revenge. So the next morning the wolf sent the
+boar to challenge Sultan to come into the wood to fight the matter. Now
+Sultan had nobody he could ask to be his second but the shepherd’s old
+three-legged cat; so he took her with him, and as the poor thing limped
+along with some trouble, she stuck up her tail straight in the air.
+
+The wolf and the wild boar were first on the ground; and when they
+espied their enemies coming, and saw the cat’s long tail standing
+straight in the air, they thought she was carrying a sword for Sultan to
+fight with; and every time she limped, they thought she was picking up
+a stone to throw at them; so they said they should not like this way of
+fighting, and the boar lay down behind a bush, and the wolf jumped
+up into a tree. Sultan and the cat soon came up, and looked about and
+wondered that no one was there. The boar, however, had not quite hidden
+himself, for his ears stuck out of the bush; and when he shook one of
+them a little, the cat, seeing something move, and thinking it was a
+mouse, sprang upon it, and bit and scratched it, so that the boar jumped
+up and grunted, and ran away, roaring out, ‘Look up in the tree, there
+sits the one who is to blame.’ So they looked up, and espied the wolf
+sitting amongst the branches; and they called him a cowardly rascal,
+and would not suffer him to come down till he was heartily ashamed of
+himself, and had promised to be good friends again with old Sultan.
+
+
+
+
+THE STRAW, THE COAL, AND THE BEAN
+
+In a village dwelt a poor old woman, who had gathered together a dish
+of beans and wanted to cook them. So she made a fire on her hearth, and
+that it might burn the quicker, she lighted it with a handful of straw.
+When she was emptying the beans into the pan, one dropped without her
+observing it, and lay on the ground beside a straw, and soon afterwards
+a burning coal from the fire leapt down to the two. Then the straw
+began and said: ‘Dear friends, from whence do you come here?’ The coal
+replied: ‘I fortunately sprang out of the fire, and if I had not escaped
+by sheer force, my death would have been certain,--I should have been
+burnt to ashes.’ The bean said: ‘I too have escaped with a whole skin,
+but if the old woman had got me into the pan, I should have been made
+into broth without any mercy, like my comrades.’ ‘And would a better
+fate have fallen to my lot?’ said the straw. ‘The old woman has
+destroyed all my brethren in fire and smoke; she seized sixty of them at
+once, and took their lives. I luckily slipped through her fingers.’
+
+‘But what are we to do now?’ said the coal.
+
+‘I think,’ answered the bean, ‘that as we have so fortunately escaped
+death, we should keep together like good companions, and lest a new
+mischance should overtake us here, we should go away together, and
+repair to a foreign country.’
+
+The proposition pleased the two others, and they set out on their way
+together. Soon, however, they came to a little brook, and as there was
+no bridge or foot-plank, they did not know how they were to get over
+it. The straw hit on a good idea, and said: ‘I will lay myself straight
+across, and then you can walk over on me as on a bridge.’ The straw
+therefore stretched itself from one bank to the other, and the coal,
+who was of an impetuous disposition, tripped quite boldly on to the
+newly-built bridge. But when she had reached the middle, and heard the
+water rushing beneath her, she was after all, afraid, and stood still,
+and ventured no farther. The straw, however, began to burn, broke in
+two pieces, and fell into the stream. The coal slipped after her, hissed
+when she got into the water, and breathed her last. The bean, who had
+prudently stayed behind on the shore, could not but laugh at the event,
+was unable to stop, and laughed so heartily that she burst. It would
+have been all over with her, likewise, if, by good fortune, a tailor who
+was travelling in search of work, had not sat down to rest by the brook.
+As he had a compassionate heart he pulled out his needle and thread,
+and sewed her together. The bean thanked him most prettily, but as the
+tailor used black thread, all beans since then have a black seam.
+
+
+
+
+BRIAR ROSE
+
+A king and queen once upon a time reigned in a country a great way off,
+where there were in those days fairies. Now this king and queen had
+plenty of money, and plenty of fine clothes to wear, and plenty of
+good things to eat and drink, and a coach to ride out in every day: but
+though they had been married many years they had no children, and this
+grieved them very much indeed. But one day as the queen was walking
+by the side of the river, at the bottom of the garden, she saw a poor
+little fish, that had thrown itself out of the water, and lay gasping
+and nearly dead on the bank. Then the queen took pity on the little
+fish, and threw it back again into the river; and before it swam away
+it lifted its head out of the water and said, ‘I know what your wish is,
+and it shall be fulfilled, in return for your kindness to me--you will
+soon have a daughter.’ What the little fish had foretold soon came to
+pass; and the queen had a little girl, so very beautiful that the king
+could not cease looking on it for joy, and said he would hold a great
+feast and make merry, and show the child to all the land. So he asked
+his kinsmen, and nobles, and friends, and neighbours. But the queen
+said, ‘I will have the fairies also, that they might be kind and good
+to our little daughter.’ Now there were thirteen fairies in the kingdom;
+but as the king and queen had only twelve golden dishes for them to eat
+out of, they were forced to leave one of the fairies without asking her.
+So twelve fairies came, each with a high red cap on her head, and red
+shoes with high heels on her feet, and a long white wand in her hand:
+and after the feast was over they gathered round in a ring and gave all
+their best gifts to the little princess. One gave her goodness, another
+beauty, another riches, and so on till she had all that was good in the
+world.
+
+Just as eleven of them had done blessing her, a great noise was heard in
+the courtyard, and word was brought that the thirteenth fairy was
+come, with a black cap on her head, and black shoes on her feet, and a
+broomstick in her hand: and presently up she came into the dining-hall.
+Now, as she had not been asked to the feast she was very angry, and
+scolded the king and queen very much, and set to work to take her
+revenge. So she cried out, ‘The king’s daughter shall, in her fifteenth
+year, be wounded by a spindle, and fall down dead.’ Then the twelfth of
+the friendly fairies, who had not yet given her gift, came forward, and
+said that the evil wish must be fulfilled, but that she could soften its
+mischief; so her gift was, that the king’s daughter, when the spindle
+wounded her, should not really die, but should only fall asleep for a
+hundred years.
+
+However, the king hoped still to save his dear child altogether from
+the threatened evil; so he ordered that all the spindles in the kingdom
+should be bought up and burnt. But all the gifts of the first eleven
+fairies were in the meantime fulfilled; for the princess was so
+beautiful, and well behaved, and good, and wise, that everyone who knew
+her loved her.
+
+It happened that, on the very day she was fifteen years old, the king
+and queen were not at home, and she was left alone in the palace. So she
+roved about by herself, and looked at all the rooms and chambers, till
+at last she came to an old tower, to which there was a narrow staircase
+ending with a little door. In the door there was a golden key, and when
+she turned it the door sprang open, and there sat an old lady spinning
+away very busily. ‘Why, how now, good mother,’ said the princess; ‘what
+are you doing there?’ ‘Spinning,’ said the old lady, and nodded her
+head, humming a tune, while buzz! went the wheel. ‘How prettily that
+little thing turns round!’ said the princess, and took the spindle
+and began to try and spin. But scarcely had she touched it, before the
+fairy’s prophecy was fulfilled; the spindle wounded her, and she fell
+down lifeless on the ground.
+
+However, she was not dead, but had only fallen into a deep sleep; and
+the king and the queen, who had just come home, and all their court,
+fell asleep too; and the horses slept in the stables, and the dogs in
+the court, the pigeons on the house-top, and the very flies slept upon
+the walls. Even the fire on the hearth left off blazing, and went to
+sleep; the jack stopped, and the spit that was turning about with a
+goose upon it for the king’s dinner stood still; and the cook, who was
+at that moment pulling the kitchen-boy by the hair to give him a box
+on the ear for something he had done amiss, let him go, and both fell
+asleep; the butler, who was slyly tasting the ale, fell asleep with the
+jug at his lips: and thus everything stood still, and slept soundly.
+
+A large hedge of thorns soon grew round the palace, and every year it
+became higher and thicker; till at last the old palace was surrounded
+and hidden, so that not even the roof or the chimneys could be seen. But
+there went a report through all the land of the beautiful sleeping Briar
+Rose (for so the king’s daughter was called): so that, from time to
+time, several kings’ sons came, and tried to break through the thicket
+into the palace. This, however, none of them could ever do; for the
+thorns and bushes laid hold of them, as it were with hands; and there
+they stuck fast, and died wretchedly.
+
+After many, many years there came a king’s son into that land: and an
+old man told him the story of the thicket of thorns; and how a beautiful
+palace stood behind it, and how a wonderful princess, called Briar Rose,
+lay in it asleep, with all her court. He told, too, how he had heard
+from his grandfather that many, many princes had come, and had tried to
+break through the thicket, but that they had all stuck fast in it, and
+died. Then the young prince said, ‘All this shall not frighten me; I
+will go and see this Briar Rose.’ The old man tried to hinder him, but
+he was bent upon going.
+
+Now that very day the hundred years were ended; and as the prince came
+to the thicket he saw nothing but beautiful flowering shrubs, through
+which he went with ease, and they shut in after him as thick as ever.
+Then he came at last to the palace, and there in the court lay the dogs
+asleep; and the horses were standing in the stables; and on the roof sat
+the pigeons fast asleep, with their heads under their wings. And when he
+came into the palace, the flies were sleeping on the walls; the spit
+was standing still; the butler had the jug of ale at his lips, going
+to drink a draught; the maid sat with a fowl in her lap ready to be
+plucked; and the cook in the kitchen was still holding up her hand, as
+if she was going to beat the boy.
+
+Then he went on still farther, and all was so still that he could hear
+every breath he drew; till at last he came to the old tower, and opened
+the door of the little room in which Briar Rose was; and there she lay,
+fast asleep on a couch by the window. She looked so beautiful that he
+could not take his eyes off her, so he stooped down and gave her a kiss.
+But the moment he kissed her she opened her eyes and awoke, and smiled
+upon him; and they went out together; and soon the king and queen also
+awoke, and all the court, and gazed on each other with great wonder.
+And the horses shook themselves, and the dogs jumped up and barked; the
+pigeons took their heads from under their wings, and looked about and
+flew into the fields; the flies on the walls buzzed again; the fire in
+the kitchen blazed up; round went the jack, and round went the spit,
+with the goose for the king’s dinner upon it; the butler finished his
+draught of ale; the maid went on plucking the fowl; and the cook gave
+the boy the box on his ear.
+
+And then the prince and Briar Rose were married, and the wedding feast
+was given; and they lived happily together all their lives long.
+
+
+
+
+THE DOG AND THE SPARROW
+
+A shepherd’s dog had a master who took no care of him, but often let him
+suffer the greatest hunger. At last he could bear it no longer; so he
+took to his heels, and off he ran in a very sad and sorrowful mood.
+On the road he met a sparrow that said to him, ‘Why are you so sad,
+my friend?’ ‘Because,’ said the dog, ‘I am very very hungry, and have
+nothing to eat.’ ‘If that be all,’ answered the sparrow, ‘come with me
+into the next town, and I will soon find you plenty of food.’ So on they
+went together into the town: and as they passed by a butcher’s shop,
+the sparrow said to the dog, ‘Stand there a little while till I peck you
+down a piece of meat.’ So the sparrow perched upon the shelf: and having
+first looked carefully about her to see if anyone was watching her, she
+pecked and scratched at a steak that lay upon the edge of the shelf,
+till at last down it fell. Then the dog snapped it up, and scrambled
+away with it into a corner, where he soon ate it all up. ‘Well,’ said
+the sparrow, ‘you shall have some more if you will; so come with me to
+the next shop, and I will peck you down another steak.’ When the dog had
+eaten this too, the sparrow said to him, ‘Well, my good friend, have you
+had enough now?’ ‘I have had plenty of meat,’ answered he, ‘but I should
+like to have a piece of bread to eat after it.’ ‘Come with me then,’
+said the sparrow, ‘and you shall soon have that too.’ So she took him
+to a baker’s shop, and pecked at two rolls that lay in the window, till
+they fell down: and as the dog still wished for more, she took him to
+another shop and pecked down some more for him. When that was eaten, the
+sparrow asked him whether he had had enough now. ‘Yes,’ said he; ‘and
+now let us take a walk a little way out of the town.’ So they both went
+out upon the high road; but as the weather was warm, they had not gone
+far before the dog said, ‘I am very much tired--I should like to take a
+nap.’ ‘Very well,’ answered the sparrow, ‘do so, and in the meantime
+I will perch upon that bush.’ So the dog stretched himself out on the
+road, and fell fast asleep. Whilst he slept, there came by a carter with
+a cart drawn by three horses, and loaded with two casks of wine. The
+sparrow, seeing that the carter did not turn out of the way, but would
+go on in the track in which the dog lay, so as to drive over him, called
+out, ‘Stop! stop! Mr Carter, or it shall be the worse for you.’ But the
+carter, grumbling to himself, ‘You make it the worse for me, indeed!
+what can you do?’ cracked his whip, and drove his cart over the poor
+dog, so that the wheels crushed him to death. ‘There,’ cried the
+sparrow, ‘thou cruel villain, thou hast killed my friend the dog. Now
+mind what I say. This deed of thine shall cost thee all thou art worth.’
+‘Do your worst, and welcome,’ said the brute, ‘what harm can you do me?’
+and passed on. But the sparrow crept under the tilt of the cart, and
+pecked at the bung of one of the casks till she loosened it; and then
+all the wine ran out, without the carter seeing it. At last he looked
+round, and saw that the cart was dripping, and the cask quite empty.
+‘What an unlucky wretch I am!’ cried he. ‘Not wretch enough yet!’ said
+the sparrow, as she alighted upon the head of one of the horses, and
+pecked at him till he reared up and kicked. When the carter saw this,
+he drew out his hatchet and aimed a blow at the sparrow, meaning to kill
+her; but she flew away, and the blow fell upon the poor horse’s head
+with such force, that he fell down dead. ‘Unlucky wretch that I am!’
+cried he. ‘Not wretch enough yet!’ said the sparrow. And as the carter
+went on with the other two horses, she again crept under the tilt of the
+cart, and pecked out the bung of the second cask, so that all the wine
+ran out. When the carter saw this, he again cried out, ‘Miserable wretch
+that I am!’ But the sparrow answered, ‘Not wretch enough yet!’ and
+perched on the head of the second horse, and pecked at him too. The
+carter ran up and struck at her again with his hatchet; but away she
+flew, and the blow fell upon the second horse and killed him on the
+spot. ‘Unlucky wretch that I am!’ said he. ‘Not wretch enough yet!’ said
+the sparrow; and perching upon the third horse, she began to peck him
+too. The carter was mad with fury; and without looking about him, or
+caring what he was about, struck again at the sparrow; but killed his
+third horse as he done the other two. ‘Alas! miserable wretch that I
+am!’ cried he. ‘Not wretch enough yet!’ answered the sparrow as she flew
+away; ‘now will I plague and punish thee at thy own house.’ The
+carter was forced at last to leave his cart behind him, and to go home
+overflowing with rage and vexation. ‘Alas!’ said he to his wife, ‘what
+ill luck has befallen me!--my wine is all spilt, and my horses all three
+dead.’ ‘Alas! husband,’ replied she, ‘and a wicked bird has come into
+the house, and has brought with her all the birds in the world, I am
+sure, and they have fallen upon our corn in the loft, and are eating it
+up at such a rate!’ Away ran the husband upstairs, and saw thousands of
+birds sitting upon the floor eating up his corn, with the sparrow in the
+midst of them. ‘Unlucky wretch that I am!’ cried the carter; for he saw
+that the corn was almost all gone. ‘Not wretch enough yet!’ said the
+sparrow; ‘thy cruelty shall cost thee thy life yet!’ and away she flew.
+
+The carter seeing that he had thus lost all that he had, went down
+into his kitchen; and was still not sorry for what he had done, but sat
+himself angrily and sulkily in the chimney corner. But the sparrow sat
+on the outside of the window, and cried ‘Carter! thy cruelty shall cost
+thee thy life!’ With that he jumped up in a rage, seized his hatchet,
+and threw it at the sparrow; but it missed her, and only broke the
+window. The sparrow now hopped in, perched upon the window-seat, and
+cried, ‘Carter! it shall cost thee thy life!’ Then he became mad and
+blind with rage, and struck the window-seat with such force that he
+cleft it in two: and as the sparrow flew from place to place, the carter
+and his wife were so furious, that they broke all their furniture,
+glasses, chairs, benches, the table, and at last the walls, without
+touching the bird at all. In the end, however, they caught her: and the
+wife said, ‘Shall I kill her at once?’ ‘No,’ cried he, ‘that is letting
+her off too easily: she shall die a much more cruel death; I will eat
+her.’ But the sparrow began to flutter about, and stretch out her neck
+and cried, ‘Carter! it shall cost thee thy life yet!’ With that he
+could wait no longer: so he gave his wife the hatchet, and cried, ‘Wife,
+strike at the bird and kill her in my hand.’ And the wife struck; but
+she missed her aim, and hit her husband on the head so that he fell down
+dead, and the sparrow flew quietly home to her nest.
+
+
+
+
+THE TWELVE DANCING PRINCESSES
+
+There was a king who had twelve beautiful daughters. They slept in
+twelve beds all in one room; and when they went to bed, the doors were
+shut and locked up; but every morning their shoes were found to be quite
+worn through as if they had been danced in all night; and yet nobody
+could find out how it happened, or where they had been.
+
+Then the king made it known to all the land, that if any person could
+discover the secret, and find out where it was that the princesses
+danced in the night, he should have the one he liked best for his
+wife, and should be king after his death; but whoever tried and did not
+succeed, after three days and nights, should be put to death.
+
+A king’s son soon came. He was well entertained, and in the evening was
+taken to the chamber next to the one where the princesses lay in their
+twelve beds. There he was to sit and watch where they went to dance;
+and, in order that nothing might pass without his hearing it, the door
+of his chamber was left open. But the king’s son soon fell asleep; and
+when he awoke in the morning he found that the princesses had all been
+dancing, for the soles of their shoes were full of holes. The same thing
+happened the second and third night: so the king ordered his head to be
+cut off. After him came several others; but they had all the same luck,
+and all lost their lives in the same manner.
+
+Now it chanced that an old soldier, who had been wounded in battle
+and could fight no longer, passed through the country where this king
+reigned: and as he was travelling through a wood, he met an old woman,
+who asked him where he was going. ‘I hardly know where I am going, or
+what I had better do,’ said the soldier; ‘but I think I should like very
+well to find out where it is that the princesses dance, and then in time
+I might be a king.’ ‘Well,’ said the old dame, ‘that is no very hard
+task: only take care not to drink any of the wine which one of the
+princesses will bring to you in the evening; and as soon as she leaves
+you pretend to be fast asleep.’
+
+Then she gave him a cloak, and said, ‘As soon as you put that on
+you will become invisible, and you will then be able to follow the
+princesses wherever they go.’ When the soldier heard all this good
+counsel, he determined to try his luck: so he went to the king, and said
+he was willing to undertake the task.
+
+He was as well received as the others had been, and the king ordered
+fine royal robes to be given him; and when the evening came he was led
+to the outer chamber. Just as he was going to lie down, the eldest of
+the princesses brought him a cup of wine; but the soldier threw it all
+away secretly, taking care not to drink a drop. Then he laid himself
+down on his bed, and in a little while began to snore very loud as if
+he was fast asleep. When the twelve princesses heard this they laughed
+heartily; and the eldest said, ‘This fellow too might have done a wiser
+thing than lose his life in this way!’ Then they rose up and opened
+their drawers and boxes, and took out all their fine clothes, and
+dressed themselves at the glass, and skipped about as if they were eager
+to begin dancing. But the youngest said, ‘I don’t know how it is, while
+you are so happy I feel very uneasy; I am sure some mischance will
+befall us.’ ‘You simpleton,’ said the eldest, ‘you are always afraid;
+have you forgotten how many kings’ sons have already watched in vain?
+And as for this soldier, even if I had not given him his sleeping
+draught, he would have slept soundly enough.’
+
+When they were all ready, they went and looked at the soldier; but he
+snored on, and did not stir hand or foot: so they thought they were
+quite safe; and the eldest went up to her own bed and clapped her hands,
+and the bed sank into the floor and a trap-door flew open. The soldier
+saw them going down through the trap-door one after another, the eldest
+leading the way; and thinking he had no time to lose, he jumped up, put
+on the cloak which the old woman had given him, and followed them;
+but in the middle of the stairs he trod on the gown of the youngest
+princess, and she cried out to her sisters, ‘All is not right; someone
+took hold of my gown.’ ‘You silly creature!’ said the eldest, ‘it is
+nothing but a nail in the wall.’ Then down they all went, and at the
+bottom they found themselves in a most delightful grove of trees; and
+the leaves were all of silver, and glittered and sparkled beautifully.
+The soldier wished to take away some token of the place; so he broke
+off a little branch, and there came a loud noise from the tree. Then the
+youngest daughter said again, ‘I am sure all is not right--did not you
+hear that noise? That never happened before.’ But the eldest said, ‘It
+is only our princes, who are shouting for joy at our approach.’
+
+Then they came to another grove of trees, where all the leaves were of
+gold; and afterwards to a third, where the leaves were all glittering
+diamonds. And the soldier broke a branch from each; and every time there
+was a loud noise, which made the youngest sister tremble with fear; but
+the eldest still said, it was only the princes, who were crying for joy.
+So they went on till they came to a great lake; and at the side of the
+lake there lay twelve little boats with twelve handsome princes in them,
+who seemed to be waiting there for the princesses.
+
+One of the princesses went into each boat, and the soldier stepped into
+the same boat with the youngest. As they were rowing over the lake, the
+prince who was in the boat with the youngest princess and the soldier
+said, ‘I do not know why it is, but though I am rowing with all my might
+we do not get on so fast as usual, and I am quite tired: the boat
+seems very heavy today.’ ‘It is only the heat of the weather,’ said the
+princess: ‘I feel it very warm too.’
+
+On the other side of the lake stood a fine illuminated castle, from
+which came the merry music of horns and trumpets. There they all landed,
+and went into the castle, and each prince danced with his princess; and
+the soldier, who was all the time invisible, danced with them too; and
+when any of the princesses had a cup of wine set by her, he drank it
+all up, so that when she put the cup to her mouth it was empty. At this,
+too, the youngest sister was terribly frightened, but the eldest always
+silenced her. They danced on till three o’clock in the morning, and then
+all their shoes were worn out, so that they were obliged to leave off.
+The princes rowed them back again over the lake (but this time the
+soldier placed himself in the boat with the eldest princess); and on the
+opposite shore they took leave of each other, the princesses promising
+to come again the next night.
+
+When they came to the stairs, the soldier ran on before the princesses,
+and laid himself down; and as the twelve sisters slowly came up very
+much tired, they heard him snoring in his bed; so they said, ‘Now all
+is quite safe’; then they undressed themselves, put away their fine
+clothes, pulled off their shoes, and went to bed. In the morning the
+soldier said nothing about what had happened, but determined to see more
+of this strange adventure, and went again the second and third night;
+and every thing happened just as before; the princesses danced each time
+till their shoes were worn to pieces, and then returned home. However,
+on the third night the soldier carried away one of the golden cups as a
+token of where he had been.
+
+As soon as the time came when he was to declare the secret, he was taken
+before the king with the three branches and the golden cup; and the
+twelve princesses stood listening behind the door to hear what he would
+say. And when the king asked him. ‘Where do my twelve daughters dance at
+night?’ he answered, ‘With twelve princes in a castle under ground.’ And
+then he told the king all that had happened, and showed him the three
+branches and the golden cup which he had brought with him. Then the king
+called for the princesses, and asked them whether what the soldier said
+was true: and when they saw that they were discovered, and that it was
+of no use to deny what had happened, they confessed it all. And the king
+asked the soldier which of them he would choose for his wife; and he
+answered, ‘I am not very young, so I will have the eldest.’--And they
+were married that very day, and the soldier was chosen to be the king’s
+heir.
+
+
+
+
+THE FISHERMAN AND HIS WIFE
+
+There was once a fisherman who lived with his wife in a pigsty, close
+by the seaside. The fisherman used to go out all day long a-fishing; and
+one day, as he sat on the shore with his rod, looking at the sparkling
+waves and watching his line, all on a sudden his float was dragged away
+deep into the water: and in drawing it up he pulled out a great fish.
+But the fish said, ‘Pray let me live! I am not a real fish; I am an
+enchanted prince: put me in the water again, and let me go!’ ‘Oh, ho!’
+said the man, ‘you need not make so many words about the matter; I will
+have nothing to do with a fish that can talk: so swim away, sir, as soon
+as you please!’ Then he put him back into the water, and the fish darted
+straight down to the bottom, and left a long streak of blood behind him
+on the wave.
+
+When the fisherman went home to his wife in the pigsty, he told her how
+he had caught a great fish, and how it had told him it was an enchanted
+prince, and how, on hearing it speak, he had let it go again. ‘Did not
+you ask it for anything?’ said the wife, ‘we live very wretchedly here,
+in this nasty dirty pigsty; do go back and tell the fish we want a snug
+little cottage.’
+
+The fisherman did not much like the business: however, he went to the
+seashore; and when he came back there the water looked all yellow and
+green. And he stood at the water’s edge, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+Then the fish came swimming to him, and said, ‘Well, what is her will?
+What does your wife want?’ ‘Ah!’ said the fisherman, ‘she says that when
+I had caught you, I ought to have asked you for something before I let
+you go; she does not like living any longer in the pigsty, and wants
+a snug little cottage.’ ‘Go home, then,’ said the fish; ‘she is in the
+cottage already!’ So the man went home, and saw his wife standing at the
+door of a nice trim little cottage. ‘Come in, come in!’ said she; ‘is
+not this much better than the filthy pigsty we had?’ And there was a
+parlour, and a bedchamber, and a kitchen; and behind the cottage there
+was a little garden, planted with all sorts of flowers and fruits; and
+there was a courtyard behind, full of ducks and chickens. ‘Ah!’ said the
+fisherman, ‘how happily we shall live now!’ ‘We will try to do so, at
+least,’ said his wife.
+
+Everything went right for a week or two, and then Dame Ilsabill said,
+‘Husband, there is not near room enough for us in this cottage; the
+courtyard and the garden are a great deal too small; I should like to
+have a large stone castle to live in: go to the fish again and tell him
+to give us a castle.’ ‘Wife,’ said the fisherman, ‘I don’t like to go to
+him again, for perhaps he will be angry; we ought to be easy with this
+pretty cottage to live in.’ ‘Nonsense!’ said the wife; ‘he will do it
+very willingly, I know; go along and try!’
+
+The fisherman went, but his heart was very heavy: and when he came to
+the sea, it looked blue and gloomy, though it was very calm; and he went
+close to the edge of the waves, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what does she want now?’ said the fish. ‘Ah!’ said the man,
+dolefully, ‘my wife wants to live in a stone castle.’ ‘Go home, then,’
+said the fish; ‘she is standing at the gate of it already.’ So away went
+the fisherman, and found his wife standing before the gate of a great
+castle. ‘See,’ said she, ‘is not this grand?’ With that they went into
+the castle together, and found a great many servants there, and the
+rooms all richly furnished, and full of golden chairs and tables; and
+behind the castle was a garden, and around it was a park half a
+mile long, full of sheep, and goats, and hares, and deer; and in the
+courtyard were stables and cow-houses. ‘Well,’ said the man, ‘now we
+will live cheerful and happy in this beautiful castle for the rest of
+our lives.’ ‘Perhaps we may,’ said the wife; ‘but let us sleep upon it,
+before we make up our minds to that.’ So they went to bed.
+
+The next morning when Dame Ilsabill awoke it was broad daylight, and
+she jogged the fisherman with her elbow, and said, ‘Get up, husband,
+and bestir yourself, for we must be king of all the land.’ ‘Wife, wife,’
+said the man, ‘why should we wish to be the king? I will not be king.’
+‘Then I will,’ said she. ‘But, wife,’ said the fisherman, ‘how can you
+be king--the fish cannot make you a king?’ ‘Husband,’ said she, ‘say
+no more about it, but go and try! I will be king.’ So the man went away
+quite sorrowful to think that his wife should want to be king. This time
+the sea looked a dark grey colour, and was overspread with curling waves
+and the ridges of foam as he cried out:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what would she have now?’ said the fish. ‘Alas!’ said the poor
+man, ‘my wife wants to be king.’ ‘Go home,’ said the fish; ‘she is king
+already.’
+
+Then the fisherman went home; and as he came close to the palace he saw
+a troop of soldiers, and heard the sound of drums and trumpets. And when
+he went in he saw his wife sitting on a throne of gold and diamonds,
+with a golden crown upon her head; and on each side of her stood six
+fair maidens, each a head taller than the other. ‘Well, wife,’ said the
+fisherman, ‘are you king?’ ‘Yes,’ said she, ‘I am king.’ And when he had
+looked at her for a long time, he said, ‘Ah, wife! what a fine thing it
+is to be king! Now we shall never have anything more to wish for as long
+as we live.’ ‘I don’t know how that may be,’ said she; ‘never is a long
+time. I am king, it is true; but I begin to be tired of that, and I
+think I should like to be emperor.’ ‘Alas, wife! why should you wish to
+be emperor?’ said the fisherman. ‘Husband,’ said she, ‘go to the fish!
+I say I will be emperor.’ ‘Ah, wife!’ replied the fisherman, ‘the fish
+cannot make an emperor, I am sure, and I should not like to ask him for
+such a thing.’ ‘I am king,’ said Ilsabill, ‘and you are my slave; so go
+at once!’
+
+So the fisherman was forced to go; and he muttered as he went along,
+‘This will come to no good, it is too much to ask; the fish will be
+tired at last, and then we shall be sorry for what we have done.’ He
+soon came to the seashore; and the water was quite black and muddy, and
+a mighty whirlwind blew over the waves and rolled them about, but he
+went as near as he could to the water’s brink, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What would she have now?’ said the fish. ‘Ah!’ said the fisherman,
+‘she wants to be emperor.’ ‘Go home,’ said the fish; ‘she is emperor
+already.’
+
+So he went home again; and as he came near he saw his wife Ilsabill
+sitting on a very lofty throne made of solid gold, with a great crown on
+her head full two yards high; and on each side of her stood her guards
+and attendants in a row, each one smaller than the other, from the
+tallest giant down to a little dwarf no bigger than my finger. And
+before her stood princes, and dukes, and earls: and the fisherman went
+up to her and said, ‘Wife, are you emperor?’ ‘Yes,’ said she, ‘I am
+emperor.’ ‘Ah!’ said the man, as he gazed upon her, ‘what a fine thing
+it is to be emperor!’ ‘Husband,’ said she, ‘why should we stop at being
+emperor? I will be pope next.’ ‘O wife, wife!’ said he, ‘how can you be
+pope? there is but one pope at a time in Christendom.’ ‘Husband,’ said
+she, ‘I will be pope this very day.’ ‘But,’ replied the husband, ‘the
+fish cannot make you pope.’ ‘What nonsense!’ said she; ‘if he can make
+an emperor, he can make a pope: go and try him.’
+
+So the fisherman went. But when he came to the shore the wind was raging
+and the sea was tossed up and down in boiling waves, and the ships were
+in trouble, and rolled fearfully upon the tops of the billows. In the
+middle of the heavens there was a little piece of blue sky, but towards
+the south all was red, as if a dreadful storm was rising. At this sight
+the fisherman was dreadfully frightened, and he trembled so that his
+knees knocked together: but still he went down near to the shore, and
+said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said the fisherman, ‘my
+wife wants to be pope.’ ‘Go home,’ said the fish; ‘she is pope already.’
+
+Then the fisherman went home, and found Ilsabill sitting on a throne
+that was two miles high. And she had three great crowns on her head, and
+around her stood all the pomp and power of the Church. And on each side
+of her were two rows of burning lights, of all sizes, the greatest as
+large as the highest and biggest tower in the world, and the least no
+larger than a small rushlight. ‘Wife,’ said the fisherman, as he looked
+at all this greatness, ‘are you pope?’ ‘Yes,’ said she, ‘I am pope.’
+‘Well, wife,’ replied he, ‘it is a grand thing to be pope; and now
+you must be easy, for you can be nothing greater.’ ‘I will think about
+that,’ said the wife. Then they went to bed: but Dame Ilsabill could not
+sleep all night for thinking what she should be next. At last, as she
+was dropping asleep, morning broke, and the sun rose. ‘Ha!’ thought she,
+as she woke up and looked at it through the window, ‘after all I cannot
+prevent the sun rising.’ At this thought she was very angry, and wakened
+her husband, and said, ‘Husband, go to the fish and tell him I must
+be lord of the sun and moon.’ The fisherman was half asleep, but the
+thought frightened him so much that he started and fell out of bed.
+‘Alas, wife!’ said he, ‘cannot you be easy with being pope?’ ‘No,’
+said she, ‘I am very uneasy as long as the sun and moon rise without my
+leave. Go to the fish at once!’
+
+Then the man went shivering with fear; and as he was going down to
+the shore a dreadful storm arose, so that the trees and the very rocks
+shook. And all the heavens became black with stormy clouds, and the
+lightnings played, and the thunders rolled; and you might have seen in
+the sea great black waves, swelling up like mountains with crowns of
+white foam upon their heads. And the fisherman crept towards the sea,
+and cried out, as well as he could:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said he, ‘she wants to
+be lord of the sun and moon.’ ‘Go home,’ said the fish, ‘to your pigsty
+again.’
+
+And there they live to this very day.
+
+
+
+
+THE WILLOW-WREN AND THE BEAR
+
+Once in summer-time the bear and the wolf were walking in the forest,
+and the bear heard a bird singing so beautifully that he said: ‘Brother
+wolf, what bird is it that sings so well?’ ‘That is the King of birds,’
+said the wolf, ‘before whom we must bow down.’ In reality the bird was
+the willow-wren. ‘IF that’s the case,’ said the bear, ‘I should very
+much like to see his royal palace; come, take me thither.’ ‘That is not
+done quite as you seem to think,’ said the wolf; ‘you must wait until
+the Queen comes,’ Soon afterwards, the Queen arrived with some food in
+her beak, and the lord King came too, and they began to feed their young
+ones. The bear would have liked to go at once, but the wolf held him
+back by the sleeve, and said: ‘No, you must wait until the lord and lady
+Queen have gone away again.’ So they took stock of the hole where the
+nest lay, and trotted away. The bear, however, could not rest until he
+had seen the royal palace, and when a short time had passed, went to it
+again. The King and Queen had just flown out, so he peeped in and saw
+five or six young ones lying there. ‘Is that the royal palace?’ cried
+the bear; ‘it is a wretched palace, and you are not King’s children, you
+are disreputable children!’ When the young wrens heard that, they were
+frightfully angry, and screamed: ‘No, that we are not! Our parents are
+honest people! Bear, you will have to pay for that!’
+
+The bear and the wolf grew uneasy, and turned back and went into their
+holes. The young willow-wrens, however, continued to cry and scream, and
+when their parents again brought food they said: ‘We will not so much as
+touch one fly’s leg, no, not if we were dying of hunger, until you have
+settled whether we are respectable children or not; the bear has been
+here and has insulted us!’ Then the old King said: ‘Be easy, he shall
+be punished,’ and he at once flew with the Queen to the bear’s cave, and
+called in: ‘Old Growler, why have you insulted my children? You shall
+suffer for it--we will punish you by a bloody war.’ Thus war was
+announced to the Bear, and all four-footed animals were summoned to take
+part in it, oxen, asses, cows, deer, and every other animal the earth
+contained. And the willow-wren summoned everything which flew in the
+air, not only birds, large and small, but midges, and hornets, bees and
+flies had to come.
+
+When the time came for the war to begin, the willow-wren sent out spies
+to discover who was the enemy’s commander-in-chief. The gnat, who was
+the most crafty, flew into the forest where the enemy was assembled,
+and hid herself beneath a leaf of the tree where the password was to be
+announced. There stood the bear, and he called the fox before him
+and said: ‘Fox, you are the most cunning of all animals, you shall be
+general and lead us.’ ‘Good,’ said the fox, ‘but what signal shall we
+agree upon?’ No one knew that, so the fox said: ‘I have a fine long
+bushy tail, which almost looks like a plume of red feathers. When I lift
+my tail up quite high, all is going well, and you must charge; but if I
+let it hang down, run away as fast as you can.’ When the gnat had heard
+that, she flew away again, and revealed everything, down to the minutest
+detail, to the willow-wren. When day broke, and the battle was to begin,
+all the four-footed animals came running up with such a noise that the
+earth trembled. The willow-wren with his army also came flying through
+the air with such a humming, and whirring, and swarming that every one
+was uneasy and afraid, and on both sides they advanced against each
+other. But the willow-wren sent down the hornet, with orders to settle
+beneath the fox’s tail, and sting with all his might. When the fox felt
+the first string, he started so that he lifted one leg, from pain, but
+he bore it, and still kept his tail high in the air; at the second
+sting, he was forced to put it down for a moment; at the third, he could
+hold out no longer, screamed, and put his tail between his legs. When
+the animals saw that, they thought all was lost, and began to flee, each
+into his hole, and the birds had won the battle.
+
+Then the King and Queen flew home to their children and cried:
+‘Children, rejoice, eat and drink to your heart’s content, we have won
+the battle!’ But the young wrens said: ‘We will not eat yet, the bear
+must come to the nest, and beg for pardon and say that we are honourable
+children, before we will do that.’ Then the willow-wren flew to the
+bear’s hole and cried: ‘Growler, you are to come to the nest to my
+children, and beg their pardon, or else every rib of your body shall
+be broken.’ So the bear crept thither in the greatest fear, and begged
+their pardon. And now at last the young wrens were satisfied, and sat
+down together and ate and drank, and made merry till quite late into the
+night.
+
+
+
+
+THE FROG-PRINCE
+
+One fine evening a young princess put on her bonnet and clogs, and went
+out to take a walk by herself in a wood; and when she came to a cool
+spring of water, that rose in the midst of it, she sat herself down
+to rest a while. Now she had a golden ball in her hand, which was her
+favourite plaything; and she was always tossing it up into the air, and
+catching it again as it fell. After a time she threw it up so high that
+she missed catching it as it fell; and the ball bounded away, and rolled
+along upon the ground, till at last it fell down into the spring. The
+princess looked into the spring after her ball, but it was very deep, so
+deep that she could not see the bottom of it. Then she began to bewail
+her loss, and said, ‘Alas! if I could only get my ball again, I would
+give all my fine clothes and jewels, and everything that I have in the
+world.’
+
+Whilst she was speaking, a frog put its head out of the water, and said,
+‘Princess, why do you weep so bitterly?’ ‘Alas!’ said she, ‘what can you
+do for me, you nasty frog? My golden ball has fallen into the spring.’
+The frog said, ‘I want not your pearls, and jewels, and fine clothes;
+but if you will love me, and let me live with you and eat from off
+your golden plate, and sleep upon your bed, I will bring you your ball
+again.’ ‘What nonsense,’ thought the princess, ‘this silly frog is
+talking! He can never even get out of the spring to visit me, though
+he may be able to get my ball for me, and therefore I will tell him he
+shall have what he asks.’ So she said to the frog, ‘Well, if you will
+bring me my ball, I will do all you ask.’ Then the frog put his head
+down, and dived deep under the water; and after a little while he came
+up again, with the ball in his mouth, and threw it on the edge of the
+spring. As soon as the young princess saw her ball, she ran to pick
+it up; and she was so overjoyed to have it in her hand again, that she
+never thought of the frog, but ran home with it as fast as she could.
+The frog called after her, ‘Stay, princess, and take me with you as you
+said,’ But she did not stop to hear a word.
+
+The next day, just as the princess had sat down to dinner, she heard a
+strange noise--tap, tap--plash, plash--as if something was coming up the
+marble staircase: and soon afterwards there was a gentle knock at the
+door, and a little voice cried out and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the princess ran to the door and opened it, and there she saw
+the frog, whom she had quite forgotten. At this sight she was sadly
+frightened, and shutting the door as fast as she could came back to her
+seat. The king, her father, seeing that something had frightened her,
+asked her what was the matter. ‘There is a nasty frog,’ said she, ‘at
+the door, that lifted my ball for me out of the spring this morning: I
+told him that he should live with me here, thinking that he could never
+get out of the spring; but there he is at the door, and he wants to come
+in.’
+
+While she was speaking the frog knocked again at the door, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the king said to the young princess, ‘As you have given your word
+you must keep it; so go and let him in.’ She did so, and the frog hopped
+into the room, and then straight on--tap, tap--plash, plash--from the
+bottom of the room to the top, till he came up close to the table where
+the princess sat. ‘Pray lift me upon chair,’ said he to the princess,
+‘and let me sit next to you.’ As soon as she had done this, the frog
+said, ‘Put your plate nearer to me, that I may eat out of it.’ This
+she did, and when he had eaten as much as he could, he said, ‘Now I am
+tired; carry me upstairs, and put me into your bed.’ And the princess,
+though very unwilling, took him up in her hand, and put him upon the
+pillow of her own bed, where he slept all night long. As soon as it was
+light he jumped up, hopped downstairs, and went out of the house.
+‘Now, then,’ thought the princess, ‘at last he is gone, and I shall be
+troubled with him no more.’
+
+But she was mistaken; for when night came again she heard the same
+tapping at the door; and the frog came once more, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+And when the princess opened the door the frog came in, and slept upon
+her pillow as before, till the morning broke. And the third night he did
+the same. But when the princess awoke on the following morning she was
+astonished to see, instead of the frog, a handsome prince, gazing on her
+with the most beautiful eyes she had ever seen, and standing at the head
+of her bed.
+
+He told her that he had been enchanted by a spiteful fairy, who had
+changed him into a frog; and that he had been fated so to abide till
+some princess should take him out of the spring, and let him eat from
+her plate, and sleep upon her bed for three nights. ‘You,’ said the
+prince, ‘have broken his cruel charm, and now I have nothing to wish for
+but that you should go with me into my father’s kingdom, where I will
+marry you, and love you as long as you live.’
+
+The young princess, you may be sure, was not long in saying ‘Yes’ to
+all this; and as they spoke a gay coach drove up, with eight beautiful
+horses, decked with plumes of feathers and a golden harness; and behind
+the coach rode the prince’s servant, faithful Heinrich, who had bewailed
+the misfortunes of his dear master during his enchantment so long and so
+bitterly, that his heart had well-nigh burst.
+
+They then took leave of the king, and got into the coach with eight
+horses, and all set out, full of joy and merriment, for the prince’s
+kingdom, which they reached safely; and there they lived happily a great
+many years.
+
+
+
+
+CAT AND MOUSE IN PARTNERSHIP
+
+A certain cat had made the acquaintance of a mouse, and had said so much
+to her about the great love and friendship she felt for her, that at
+length the mouse agreed that they should live and keep house together.
+‘But we must make a provision for winter, or else we shall suffer
+from hunger,’ said the cat; ‘and you, little mouse, cannot venture
+everywhere, or you will be caught in a trap some day.’ The good advice
+was followed, and a pot of fat was bought, but they did not know where
+to put it. At length, after much consideration, the cat said: ‘I know no
+place where it will be better stored up than in the church, for no one
+dares take anything away from there. We will set it beneath the altar,
+and not touch it until we are really in need of it.’ So the pot was
+placed in safety, but it was not long before the cat had a great
+yearning for it, and said to the mouse: ‘I want to tell you something,
+little mouse; my cousin has brought a little son into the world, and has
+asked me to be godmother; he is white with brown spots, and I am to hold
+him over the font at the christening. Let me go out today, and you look
+after the house by yourself.’ ‘Yes, yes,’ answered the mouse, ‘by all
+means go, and if you get anything very good to eat, think of me. I
+should like a drop of sweet red christening wine myself.’ All this,
+however, was untrue; the cat had no cousin, and had not been asked to
+be godmother. She went straight to the church, stole to the pot of fat,
+began to lick at it, and licked the top of the fat off. Then she took a
+walk upon the roofs of the town, looked out for opportunities, and then
+stretched herself in the sun, and licked her lips whenever she thought
+of the pot of fat, and not until it was evening did she return home.
+‘Well, here you are again,’ said the mouse, ‘no doubt you have had a
+merry day.’ ‘All went off well,’ answered the cat. ‘What name did they
+give the child?’ ‘Top off!’ said the cat quite coolly. ‘Top off!’ cried
+the mouse, ‘that is a very odd and uncommon name, is it a usual one in
+your family?’ ‘What does that matter,’ said the cat, ‘it is no worse
+than Crumb-stealer, as your godchildren are called.’
+
+Before long the cat was seized by another fit of yearning. She said to
+the mouse: ‘You must do me a favour, and once more manage the house for
+a day alone. I am again asked to be godmother, and, as the child has a
+white ring round its neck, I cannot refuse.’ The good mouse consented,
+but the cat crept behind the town walls to the church, and devoured
+half the pot of fat. ‘Nothing ever seems so good as what one keeps to
+oneself,’ said she, and was quite satisfied with her day’s work. When
+she went home the mouse inquired: ‘And what was the child christened?’
+‘Half-done,’ answered the cat. ‘Half-done! What are you saying? I
+never heard the name in my life, I’ll wager anything it is not in the
+calendar!’
+
+The cat’s mouth soon began to water for some more licking. ‘All good
+things go in threes,’ said she, ‘I am asked to stand godmother again.
+The child is quite black, only it has white paws, but with that
+exception, it has not a single white hair on its whole body; this only
+happens once every few years, you will let me go, won’t you?’ ‘Top-off!
+Half-done!’ answered the mouse, ‘they are such odd names, they make me
+very thoughtful.’ ‘You sit at home,’ said the cat, ‘in your dark-grey
+fur coat and long tail, and are filled with fancies, that’s because
+you do not go out in the daytime.’ During the cat’s absence the mouse
+cleaned the house, and put it in order, but the greedy cat entirely
+emptied the pot of fat. ‘When everything is eaten up one has some
+peace,’ said she to herself, and well filled and fat she did not return
+home till night. The mouse at once asked what name had been given to
+the third child. ‘It will not please you more than the others,’ said the
+cat. ‘He is called All-gone.’ ‘All-gone,’ cried the mouse ‘that is the
+most suspicious name of all! I have never seen it in print. All-gone;
+what can that mean?’ and she shook her head, curled herself up, and lay
+down to sleep.
+
+From this time forth no one invited the cat to be godmother, but
+when the winter had come and there was no longer anything to be found
+outside, the mouse thought of their provision, and said: ‘Come, cat,
+we will go to our pot of fat which we have stored up for ourselves--we
+shall enjoy that.’ ‘Yes,’ answered the cat, ‘you will enjoy it as much
+as you would enjoy sticking that dainty tongue of yours out of the
+window.’ They set out on their way, but when they arrived, the pot of
+fat certainly was still in its place, but it was empty. ‘Alas!’ said the
+mouse, ‘now I see what has happened, now it comes to light! You are a true
+friend! You have devoured all when you were standing godmother. First
+top off, then half-done, then--’ ‘Will you hold your tongue,’ cried the
+cat, ‘one word more, and I will eat you too.’ ‘All-gone’ was already on
+the poor mouse’s lips; scarcely had she spoken it before the cat sprang
+on her, seized her, and swallowed her down. Verily, that is the way of
+the world.
+
+
+
+
+THE GOOSE-GIRL
+
+The king of a great land died, and left his queen to take care of their
+only child. This child was a daughter, who was very beautiful; and her
+mother loved her dearly, and was very kind to her. And there was a good
+fairy too, who was fond of the princess, and helped her mother to watch
+over her. When she grew up, she was betrothed to a prince who lived a
+great way off; and as the time drew near for her to be married, she
+got ready to set off on her journey to his country. Then the queen her
+mother, packed up a great many costly things; jewels, and gold, and
+silver; trinkets, fine dresses, and in short everything that became a
+royal bride. And she gave her a waiting-maid to ride with her, and give
+her into the bridegroom’s hands; and each had a horse for the journey.
+Now the princess’s horse was the fairy’s gift, and it was called Falada,
+and could speak.
+
+When the time came for them to set out, the fairy went into her
+bed-chamber, and took a little knife, and cut off a lock of her hair,
+and gave it to the princess, and said, ‘Take care of it, dear child; for
+it is a charm that may be of use to you on the road.’ Then they all took
+a sorrowful leave of the princess; and she put the lock of hair into
+her bosom, got upon her horse, and set off on her journey to her
+bridegroom’s kingdom.
+
+One day, as they were riding along by a brook, the princess began to
+feel very thirsty: and she said to her maid, ‘Pray get down, and fetch
+me some water in my golden cup out of yonder brook, for I want to
+drink.’ ‘Nay,’ said the maid, ‘if you are thirsty, get off yourself, and
+stoop down by the water and drink; I shall not be your waiting-maid any
+longer.’ Then she was so thirsty that she got down, and knelt over the
+little brook, and drank; for she was frightened, and dared not bring out
+her golden cup; and she wept and said, ‘Alas! what will become of me?’
+And the lock answered her, and said:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+But the princess was very gentle and meek, so she said nothing to her
+maid’s ill behaviour, but got upon her horse again.
+
+Then all rode farther on their journey, till the day grew so warm, and
+the sun so scorching, that the bride began to feel very thirsty again;
+and at last, when they came to a river, she forgot her maid’s rude
+speech, and said, ‘Pray get down, and fetch me some water to drink in
+my golden cup.’ But the maid answered her, and even spoke more haughtily
+than before: ‘Drink if you will, but I shall not be your waiting-maid.’
+Then the princess was so thirsty that she got off her horse, and lay
+down, and held her head over the running stream, and cried and said,
+‘What will become of me?’ And the lock of hair answered her again:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And as she leaned down to drink, the lock of hair fell from her bosom,
+and floated away with the water. Now she was so frightened that she did
+not see it; but her maid saw it, and was very glad, for she knew the
+charm; and she saw that the poor bride would be in her power, now that
+she had lost the hair. So when the bride had done drinking, and would
+have got upon Falada again, the maid said, ‘I shall ride upon Falada,
+and you may have my horse instead’; so she was forced to give up her
+horse, and soon afterwards to take off her royal clothes and put on her
+maid’s shabby ones.
+
+At last, as they drew near the end of their journey, this treacherous
+servant threatened to kill her mistress if she ever told anyone what had
+happened. But Falada saw it all, and marked it well.
+
+Then the waiting-maid got upon Falada, and the real bride rode upon the
+other horse, and they went on in this way till at last they came to the
+royal court. There was great joy at their coming, and the prince flew to
+meet them, and lifted the maid from her horse, thinking she was the one
+who was to be his wife; and she was led upstairs to the royal chamber;
+but the true princess was told to stay in the court below.
+
+Now the old king happened just then to have nothing else to do; so he
+amused himself by sitting at his kitchen window, looking at what was
+going on; and he saw her in the courtyard. As she looked very pretty,
+and too delicate for a waiting-maid, he went up into the royal chamber
+to ask the bride who it was she had brought with her, that was thus left
+standing in the court below. ‘I brought her with me for the sake of her
+company on the road,’ said she; ‘pray give the girl some work to do,
+that she may not be idle.’ The old king could not for some time think
+of any work for her to do; but at last he said, ‘I have a lad who takes
+care of my geese; she may go and help him.’ Now the name of this lad,
+that the real bride was to help in watching the king’s geese, was
+Curdken.
+
+But the false bride said to the prince, ‘Dear husband, pray do me one
+piece of kindness.’ ‘That I will,’ said the prince. ‘Then tell one of
+your slaughterers to cut off the head of the horse I rode upon, for it
+was very unruly, and plagued me sadly on the road’; but the truth was,
+she was very much afraid lest Falada should some day or other speak, and
+tell all she had done to the princess. She carried her point, and the
+faithful Falada was killed; but when the true princess heard of it, she
+wept, and begged the man to nail up Falada’s head against a large
+dark gate of the city, through which she had to pass every morning
+and evening, that there she might still see him sometimes. Then the
+slaughterer said he would do as she wished; and cut off the head, and
+nailed it up under the dark gate.
+
+Early the next morning, as she and Curdken went out through the gate,
+she said sorrowfully:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then they went out of the city, and drove the geese on. And when she
+came to the meadow, she sat down upon a bank there, and let down her
+waving locks of hair, which were all of pure silver; and when Curdken
+saw it glitter in the sun, he ran up, and would have pulled some of the
+locks out, but she cried:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then there came a wind, so strong that it blew off Curdken’s hat; and
+away it flew over the hills: and he was forced to turn and run after
+it; till, by the time he came back, she had done combing and curling her
+hair, and had put it up again safe. Then he was very angry and sulky,
+and would not speak to her at all; but they watched the geese until it
+grew dark in the evening, and then drove them homewards.
+
+The next morning, as they were going through the dark gate, the poor
+girl looked up at Falada’s head, and cried:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then she drove on the geese, and sat down again in the meadow, and began
+to comb out her hair as before; and Curdken ran up to her, and wanted to
+take hold of it; but she cried out quickly:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then the wind came and blew away his hat; and off it flew a great way,
+over the hills and far away, so that he had to run after it; and when
+he came back she had bound up her hair again, and all was safe. So they
+watched the geese till it grew dark.
+
+In the evening, after they came home, Curdken went to the old king, and
+said, ‘I cannot have that strange girl to help me to keep the geese any
+longer.’ ‘Why?’ said the king. ‘Because, instead of doing any good, she
+does nothing but tease me all day long.’ Then the king made him tell him
+what had happened. And Curdken said, ‘When we go in the morning through
+the dark gate with our flock of geese, she cries and talks with the head
+of a horse that hangs upon the wall, and says:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answers:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And Curdken went on telling the king what had happened upon the meadow
+where the geese fed; how his hat was blown away; and how he was forced
+to run after it, and to leave his flock of geese to themselves. But the
+old king told the boy to go out again the next day: and when morning
+came, he placed himself behind the dark gate, and heard how she spoke
+to Falada, and how Falada answered. Then he went into the field, and
+hid himself in a bush by the meadow’s side; and he soon saw with his own
+eyes how they drove the flock of geese; and how, after a little time,
+she let down her hair that glittered in the sun. And then he heard her
+say:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+And soon came a gale of wind, and carried away Curdken’s hat, and away
+went Curdken after it, while the girl went on combing and curling her
+hair. All this the old king saw: so he went home without being seen; and
+when the little goose-girl came back in the evening he called her aside,
+and asked her why she did so: but she burst into tears, and said, ‘That
+I must not tell you or any man, or I shall lose my life.’
+
+But the old king begged so hard, that she had no peace till she had told
+him all the tale, from beginning to end, word for word. And it was very
+lucky for her that she did so, for when she had done the king ordered
+royal clothes to be put upon her, and gazed on her with wonder, she was
+so beautiful. Then he called his son and told him that he had only a
+false bride; for that she was merely a waiting-maid, while the true
+bride stood by. And the young king rejoiced when he saw her beauty, and
+heard how meek and patient she had been; and without saying anything to
+the false bride, the king ordered a great feast to be got ready for all
+his court. The bridegroom sat at the top, with the false princess on one
+side, and the true one on the other; but nobody knew her again, for her
+beauty was quite dazzling to their eyes; and she did not seem at all
+like the little goose-girl, now that she had her brilliant dress on.
+
+When they had eaten and drank, and were very merry, the old king said
+he would tell them a tale. So he began, and told all the story of the
+princess, as if it was one that he had once heard; and he asked the
+true waiting-maid what she thought ought to be done to anyone who would
+behave thus. ‘Nothing better,’ said this false bride, ‘than that she
+should be thrown into a cask stuck round with sharp nails, and that
+two white horses should be put to it, and should drag it from street to
+street till she was dead.’ ‘Thou art she!’ said the old king; ‘and as
+thou has judged thyself, so shall it be done to thee.’ And the young
+king was then married to his true wife, and they reigned over the
+kingdom in peace and happiness all their lives; and the good fairy came
+to see them, and restored the faithful Falada to life again.
+
+
+
+
+THE ADVENTURES OF CHANTICLEER AND PARTLET
+
+
+1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+
+‘The nuts are quite ripe now,’ said Chanticleer to his wife Partlet,
+‘suppose we go together to the mountains, and eat as many as we can,
+before the squirrel takes them all away.’ ‘With all my heart,’ said
+Partlet, ‘let us go and make a holiday of it together.’
+
+So they went to the mountains; and as it was a lovely day, they stayed
+there till the evening. Now, whether it was that they had eaten so many
+nuts that they could not walk, or whether they were lazy and would not,
+I do not know: however, they took it into their heads that it did not
+become them to go home on foot. So Chanticleer began to build a little
+carriage of nutshells: and when it was finished, Partlet jumped into
+it and sat down, and bid Chanticleer harness himself to it and draw her
+home. ‘That’s a good joke!’ said Chanticleer; ‘no, that will never do;
+I had rather by half walk home; I’ll sit on the box and be coachman,
+if you like, but I’ll not draw.’ While this was passing, a duck came
+quacking up and cried out, ‘You thieving vagabonds, what business have
+you in my grounds? I’ll give it you well for your insolence!’ and upon
+that she fell upon Chanticleer most lustily. But Chanticleer was no
+coward, and returned the duck’s blows with his sharp spurs so fiercely
+that she soon began to cry out for mercy; which was only granted her
+upon condition that she would draw the carriage home for them. This she
+agreed to do; and Chanticleer got upon the box, and drove, crying, ‘Now,
+duck, get on as fast as you can.’ And away they went at a pretty good
+pace.
+
+After they had travelled along a little way, they met a needle and a pin
+walking together along the road: and the needle cried out, ‘Stop, stop!’
+and said it was so dark that they could hardly find their way, and such
+dirty walking they could not get on at all: he told them that he and his
+friend, the pin, had been at a public-house a few miles off, and had sat
+drinking till they had forgotten how late it was; he begged therefore
+that the travellers would be so kind as to give them a lift in their
+carriage. Chanticleer observing that they were but thin fellows, and not
+likely to take up much room, told them they might ride, but made them
+promise not to dirty the wheels of the carriage in getting in, nor to
+tread on Partlet’s toes.
+
+Late at night they arrived at an inn; and as it was bad travelling in
+the dark, and the duck seemed much tired, and waddled about a good
+deal from one side to the other, they made up their minds to fix their
+quarters there: but the landlord at first was unwilling, and said his
+house was full, thinking they might not be very respectable company:
+however, they spoke civilly to him, and gave him the egg which Partlet
+had laid by the way, and said they would give him the duck, who was in
+the habit of laying one every day: so at last he let them come in, and
+they bespoke a handsome supper, and spent the evening very jollily.
+
+Early in the morning, before it was quite light, and when nobody was
+stirring in the inn, Chanticleer awakened his wife, and, fetching the
+egg, they pecked a hole in it, ate it up, and threw the shells into the
+fireplace: they then went to the pin and needle, who were fast asleep,
+and seizing them by the heads, stuck one into the landlord’s easy chair
+and the other into his handkerchief; and, having done this, they crept
+away as softly as possible. However, the duck, who slept in the open
+air in the yard, heard them coming, and jumping into the brook which ran
+close by the inn, soon swam out of their reach.
+
+An hour or two afterwards the landlord got up, and took his handkerchief
+to wipe his face, but the pin ran into him and pricked him: then he
+walked into the kitchen to light his pipe at the fire, but when he
+stirred it up the eggshells flew into his eyes, and almost blinded him.
+‘Bless me!’ said he, ‘all the world seems to have a design against my
+head this morning’: and so saying, he threw himself sulkily into his
+easy chair; but, oh dear! the needle ran into him; and this time the
+pain was not in his head. He now flew into a very great passion, and,
+suspecting the company who had come in the night before, he went to look
+after them, but they were all off; so he swore that he never again
+would take in such a troop of vagabonds, who ate a great deal, paid no
+reckoning, and gave him nothing for his trouble but their apish tricks.
+
+
+2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+
+Another day, Chanticleer and Partlet wished to ride out together;
+so Chanticleer built a handsome carriage with four red wheels, and
+harnessed six mice to it; and then he and Partlet got into the carriage,
+and away they drove. Soon afterwards a cat met them, and said, ‘Where
+are you going?’ And Chanticleer replied,
+
+ ‘All on our way
+  A visit to pay
+  To Mr Korbes, the fox, today.’
+
+Then the cat said, ‘Take me with you,’ Chanticleer said, ‘With all my
+heart: get up behind, and be sure you do not fall off.’
+
+ ‘Take care of this handsome coach of mine,
+  Nor dirty my pretty red wheels so fine!
+  Now, mice, be ready,
+  And, wheels, run steady!
+  For we are going a visit to pay
+  To Mr Korbes, the fox, today.’
+
+Soon after came up a millstone, an egg, a duck, and a pin; and
+Chanticleer gave them all leave to get into the carriage and go with
+them.
+
+When they arrived at Mr Korbes’s house, he was not at home; so the mice
+drew the carriage into the coach-house, Chanticleer and Partlet flew
+upon a beam, the cat sat down in the fireplace, the duck got into
+the washing cistern, the pin stuck himself into the bed pillow, the
+millstone laid himself over the house door, and the egg rolled himself
+up in the towel.
+
+When Mr Korbes came home, he went to the fireplace to make a fire; but
+the cat threw all the ashes in his eyes: so he ran to the kitchen to
+wash himself; but there the duck splashed all the water in his face; and
+when he tried to wipe himself, the egg broke to pieces in the towel all
+over his face and eyes. Then he was very angry, and went without his
+supper to bed; but when he laid his head on the pillow, the pin ran into
+his cheek: at this he became quite furious, and, jumping up, would have
+run out of the house; but when he came to the door, the millstone fell
+down on his head, and killed him on the spot.
+
+
+3. HOW PARTLET DIED AND WAS BURIED, AND HOW CHANTICLEER DIED OF GRIEF
+
+Another day Chanticleer and Partlet agreed to go again to the mountains
+to eat nuts; and it was settled that all the nuts which they found
+should be shared equally between them. Now Partlet found a very large
+nut; but she said nothing about it to Chanticleer, and kept it all to
+herself: however, it was so big that she could not swallow it, and it
+stuck in her throat. Then she was in a great fright, and cried out to
+Chanticleer, ‘Pray run as fast as you can, and fetch me some water, or I
+shall be choked.’ Chanticleer ran as fast as he could to the river, and
+said, ‘River, give me some water, for Partlet lies in the mountain, and
+will be choked by a great nut.’ The river said, ‘Run first to the bride,
+and ask her for a silken cord to draw up the water.’ Chanticleer ran to
+the bride, and said, ‘Bride, you must give me a silken cord, for then
+the river will give me water, and the water I will carry to Partlet, who
+lies on the mountain, and will be choked by a great nut.’ But the bride
+said, ‘Run first, and bring me my garland that is hanging on a willow
+in the garden.’ Then Chanticleer ran to the garden, and took the garland
+from the bough where it hung, and brought it to the bride; and then
+the bride gave him the silken cord, and he took the silken cord to
+the river, and the river gave him water, and he carried the water to
+Partlet; but in the meantime she was choked by the great nut, and lay
+quite dead, and never moved any more.
+
+Then Chanticleer was very sorry, and cried bitterly; and all the beasts
+came and wept with him over poor Partlet. And six mice built a little
+hearse to carry her to her grave; and when it was ready they harnessed
+themselves before it, and Chanticleer drove them. On the way they
+met the fox. ‘Where are you going, Chanticleer?’ said he. ‘To bury my
+Partlet,’ said the other. ‘May I go with you?’ said the fox. ‘Yes; but
+you must get up behind, or my horses will not be able to draw you.’ Then
+the fox got up behind; and presently the wolf, the bear, the goat, and
+all the beasts of the wood, came and climbed upon the hearse.
+
+So on they went till they came to a rapid stream. ‘How shall we get
+over?’ said Chanticleer. Then said a straw, ‘I will lay myself across,
+and you may pass over upon me.’ But as the mice were going over, the
+straw slipped away and fell into the water, and the six mice all fell in
+and were drowned. What was to be done? Then a large log of wood came
+and said, ‘I am big enough; I will lay myself across the stream, and you
+shall pass over upon me.’ So he laid himself down; but they managed
+so clumsily, that the log of wood fell in and was carried away by the
+stream. Then a stone, who saw what had happened, came up and kindly
+offered to help poor Chanticleer by laying himself across the stream;
+and this time he got safely to the other side with the hearse, and
+managed to get Partlet out of it; but the fox and the other mourners,
+who were sitting behind, were too heavy, and fell back into the water
+and were all carried away by the stream and drowned.
+
+Thus Chanticleer was left alone with his dead Partlet; and having dug
+a grave for her, he laid her in it, and made a little hillock over her.
+Then he sat down by the grave, and wept and mourned, till at last he
+died too; and so all were dead.
+
+
+
+
+RAPUNZEL
+
+There were once a man and a woman who had long in vain wished for a
+child. At length the woman hoped that God was about to grant her desire.
+These people had a little window at the back of their house from which
+a splendid garden could be seen, which was full of the most beautiful
+flowers and herbs. It was, however, surrounded by a high wall, and no
+one dared to go into it because it belonged to an enchantress, who had
+great power and was dreaded by all the world. One day the woman was
+standing by this window and looking down into the garden, when she saw a
+bed which was planted with the most beautiful rampion (rapunzel), and it
+looked so fresh and green that she longed for it, she quite pined away,
+and began to look pale and miserable. Then her husband was alarmed, and
+asked: ‘What ails you, dear wife?’ ‘Ah,’ she replied, ‘if I can’t eat
+some of the rampion, which is in the garden behind our house, I shall
+die.’ The man, who loved her, thought: ‘Sooner than let your wife die,
+bring her some of the rampion yourself, let it cost what it will.’
+At twilight, he clambered down over the wall into the garden of the
+enchantress, hastily clutched a handful of rampion, and took it to his
+wife. She at once made herself a salad of it, and ate it greedily. It
+tasted so good to her--so very good, that the next day she longed for it
+three times as much as before. If he was to have any rest, her husband
+must once more descend into the garden. In the gloom of evening
+therefore, he let himself down again; but when he had clambered down the
+wall he was terribly afraid, for he saw the enchantress standing before
+him. ‘How can you dare,’ said she with angry look, ‘descend into my
+garden and steal my rampion like a thief? You shall suffer for it!’
+‘Ah,’ answered he, ‘let mercy take the place of justice, I only made
+up my mind to do it out of necessity. My wife saw your rampion from the
+window, and felt such a longing for it that she would have died if she
+had not got some to eat.’ Then the enchantress allowed her anger to be
+softened, and said to him: ‘If the case be as you say, I will allow
+you to take away with you as much rampion as you will, only I make one
+condition, you must give me the child which your wife will bring into
+the world; it shall be well treated, and I will care for it like a
+mother.’ The man in his terror consented to everything, and when the
+woman was brought to bed, the enchantress appeared at once, gave the
+child the name of Rapunzel, and took it away with her.
+
+Rapunzel grew into the most beautiful child under the sun. When she was
+twelve years old, the enchantress shut her into a tower, which lay in
+a forest, and had neither stairs nor door, but quite at the top was a
+little window. When the enchantress wanted to go in, she placed herself
+beneath it and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Rapunzel had magnificent long hair, fine as spun gold, and when she
+heard the voice of the enchantress she unfastened her braided tresses,
+wound them round one of the hooks of the window above, and then the hair
+fell twenty ells down, and the enchantress climbed up by it.
+
+After a year or two, it came to pass that the king’s son rode through
+the forest and passed by the tower. Then he heard a song, which was so
+charming that he stood still and listened. This was Rapunzel, who in her
+solitude passed her time in letting her sweet voice resound. The king’s
+son wanted to climb up to her, and looked for the door of the tower,
+but none was to be found. He rode home, but the singing had so deeply
+touched his heart, that every day he went out into the forest and
+listened to it. Once when he was thus standing behind a tree, he saw
+that an enchantress came there, and he heard how she cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Then Rapunzel let down the braids of her hair, and the enchantress
+climbed up to her. ‘If that is the ladder by which one mounts, I too
+will try my fortune,’ said he, and the next day when it began to grow
+dark, he went to the tower and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Immediately the hair fell down and the king’s son climbed up.
+
+At first Rapunzel was terribly frightened when a man, such as her eyes
+had never yet beheld, came to her; but the king’s son began to talk to
+her quite like a friend, and told her that his heart had been so stirred
+that it had let him have no rest, and he had been forced to see her.
+Then Rapunzel lost her fear, and when he asked her if she would take
+him for her husband, and she saw that he was young and handsome, she
+thought: ‘He will love me more than old Dame Gothel does’; and she said
+yes, and laid her hand in his. She said: ‘I will willingly go away with
+you, but I do not know how to get down. Bring with you a skein of silk
+every time that you come, and I will weave a ladder with it, and when
+that is ready I will descend, and you will take me on your horse.’ They
+agreed that until that time he should come to her every evening, for the
+old woman came by day. The enchantress remarked nothing of this, until
+once Rapunzel said to her: ‘Tell me, Dame Gothel, how it happens that
+you are so much heavier for me to draw up than the young king’s son--he
+is with me in a moment.’ ‘Ah! you wicked child,’ cried the enchantress.
+‘What do I hear you say! I thought I had separated you from all
+the world, and yet you have deceived me!’ In her anger she clutched
+Rapunzel’s beautiful tresses, wrapped them twice round her left hand,
+seized a pair of scissors with the right, and snip, snap, they were cut
+off, and the lovely braids lay on the ground. And she was so pitiless
+that she took poor Rapunzel into a desert where she had to live in great
+grief and misery.
+
+On the same day that she cast out Rapunzel, however, the enchantress
+fastened the braids of hair, which she had cut off, to the hook of the
+window, and when the king’s son came and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+she let the hair down. The king’s son ascended, but instead of finding
+his dearest Rapunzel, he found the enchantress, who gazed at him with
+wicked and venomous looks. ‘Aha!’ she cried mockingly, ‘you would fetch
+your dearest, but the beautiful bird sits no longer singing in the nest;
+the cat has got it, and will scratch out your eyes as well. Rapunzel is
+lost to you; you will never see her again.’ The king’s son was beside
+himself with pain, and in his despair he leapt down from the tower. He
+escaped with his life, but the thorns into which he fell pierced his
+eyes. Then he wandered quite blind about the forest, ate nothing but
+roots and berries, and did naught but lament and weep over the loss of
+his dearest wife. Thus he roamed about in misery for some years, and at
+length came to the desert where Rapunzel, with the twins to which she
+had given birth, a boy and a girl, lived in wretchedness. He heard a
+voice, and it seemed so familiar to him that he went towards it, and
+when he approached, Rapunzel knew him and fell on his neck and wept. Two
+of her tears wetted his eyes and they grew clear again, and he could
+see with them as before. He led her to his kingdom where he was
+joyfully received, and they lived for a long time afterwards, happy and
+contented.
+
+
+
+
+FUNDEVOGEL
+
+There was once a forester who went into the forest to hunt, and as
+he entered it he heard a sound of screaming as if a little child were
+there. He followed the sound, and at last came to a high tree, and at
+the top of this a little child was sitting, for the mother had fallen
+asleep under the tree with the child, and a bird of prey had seen it in
+her arms, had flown down, snatched it away, and set it on the high tree.
+
+The forester climbed up, brought the child down, and thought to himself:
+‘You will take him home with you, and bring him up with your Lina.’ He
+took it home, therefore, and the two children grew up together. And the
+one, which he had found on a tree was called Fundevogel, because a bird
+had carried it away. Fundevogel and Lina loved each other so dearly that
+when they did not see each other they were sad.
+
+Now the forester had an old cook, who one evening took two pails and
+began to fetch water, and did not go once only, but many times, out
+to the spring. Lina saw this and said, ‘Listen, old Sanna, why are you
+fetching so much water?’ ‘If you will never repeat it to anyone, I will
+tell you why.’ So Lina said, no, she would never repeat it to anyone,
+and then the cook said: ‘Early tomorrow morning, when the forester
+is out hunting, I will heat the water, and when it is boiling in the
+kettle, I will throw in Fundevogel, and will boil him in it.’
+
+Early next morning the forester got up and went out hunting, and when he
+was gone the children were still in bed. Then Lina said to Fundevogel:
+‘If you will never leave me, I too will never leave you.’ Fundevogel
+said: ‘Neither now, nor ever will I leave you.’ Then said Lina: ‘Then
+will I tell you. Last night, old Sanna carried so many buckets of water
+into the house that I asked her why she was doing that, and she said
+that if I would promise not to tell anyone, and she said that early
+tomorrow morning when father was out hunting, she would set the kettle
+full of water, throw you into it and boil you; but we will get up
+quickly, dress ourselves, and go away together.’
+
+The two children therefore got up, dressed themselves quickly, and went
+away. When the water in the kettle was boiling, the cook went into the
+bedroom to fetch Fundevogel and throw him into it. But when she came in,
+and went to the beds, both the children were gone. Then she was terribly
+alarmed, and she said to herself: ‘What shall I say now when the
+forester comes home and sees that the children are gone? They must be
+followed instantly to get them back again.’
+
+Then the cook sent three servants after them, who were to run and
+overtake the children. The children, however, were sitting outside the
+forest, and when they saw from afar the three servants running, Lina
+said to Fundevogel: ‘Never leave me, and I will never leave you.’
+Fundevogel said: ‘Neither now, nor ever.’ Then said Lina: ‘Do you become
+a rose-tree, and I the rose upon it.’ When the three servants came to
+the forest, nothing was there but a rose-tree and one rose on it, but
+the children were nowhere. Then said they: ‘There is nothing to be done
+here,’ and they went home and told the cook that they had seen nothing
+in the forest but a little rose-bush with one rose on it. Then the
+old cook scolded and said: ‘You simpletons, you should have cut the
+rose-bush in two, and have broken off the rose and brought it home with
+you; go, and do it at once.’ They had therefore to go out and look for
+the second time. The children, however, saw them coming from a distance.
+Then Lina said: ‘Fundevogel, never leave me, and I will never leave
+you.’ Fundevogel said: ‘Neither now; nor ever.’ Said Lina: ‘Then do you
+become a church, and I’ll be the chandelier in it.’ So when the three
+servants came, nothing was there but a church, with a chandelier in
+it. They said therefore to each other: ‘What can we do here, let us go
+home.’ When they got home, the cook asked if they had not found them;
+so they said no, they had found nothing but a church, and there was a
+chandelier in it. And the cook scolded them and said: ‘You fools! why
+did you not pull the church to pieces, and bring the chandelier home
+with you?’ And now the old cook herself got on her legs, and went with
+the three servants in pursuit of the children. The children, however,
+saw from afar that the three servants were coming, and the cook waddling
+after them. Then said Lina: ‘Fundevogel, never leave me, and I will
+never leave you.’ Then said Fundevogel: ‘Neither now, nor ever.’
+Said Lina: ‘Be a fishpond, and I will be the duck upon it.’ The cook,
+however, came up to them, and when she saw the pond she lay down by it,
+and was about to drink it up. But the duck swam quickly to her, seized
+her head in its beak and drew her into the water, and there the old
+witch had to drown. Then the children went home together, and were
+heartily delighted, and if they have not died, they are living still.
+
+
+
+
+THE VALIANT LITTLE TAILOR
+
+One summer’s morning a little tailor was sitting on his table by the
+window; he was in good spirits, and sewed with all his might. Then came
+a peasant woman down the street crying: ‘Good jams, cheap! Good jams,
+cheap!’ This rang pleasantly in the tailor’s ears; he stretched his
+delicate head out of the window, and called: ‘Come up here, dear woman;
+here you will get rid of your goods.’ The woman came up the three steps
+to the tailor with her heavy basket, and he made her unpack all the pots
+for him. He inspected each one, lifted it up, put his nose to it, and
+at length said: ‘The jam seems to me to be good, so weigh me out four
+ounces, dear woman, and if it is a quarter of a pound that is of no
+consequence.’ The woman who had hoped to find a good sale, gave him
+what he desired, but went away quite angry and grumbling. ‘Now, this jam
+shall be blessed by God,’ cried the little tailor, ‘and give me health
+and strength’; so he brought the bread out of the cupboard, cut himself
+a piece right across the loaf and spread the jam over it. ‘This won’t
+taste bitter,’ said he, ‘but I will just finish the jacket before I
+take a bite.’ He laid the bread near him, sewed on, and in his joy, made
+bigger and bigger stitches. In the meantime the smell of the sweet jam
+rose to where the flies were sitting in great numbers, and they were
+attracted and descended on it in hosts. ‘Hi! who invited you?’ said the
+little tailor, and drove the unbidden guests away. The flies, however,
+who understood no German, would not be turned away, but came back
+again in ever-increasing companies. The little tailor at last lost all
+patience, and drew a piece of cloth from the hole under his work-table,
+and saying: ‘Wait, and I will give it to you,’ struck it mercilessly on
+them. When he drew it away and counted, there lay before him no fewer
+than seven, dead and with legs stretched out. ‘Are you a fellow of that
+sort?’ said he, and could not help admiring his own bravery. ‘The whole
+town shall know of this!’ And the little tailor hastened to cut himself
+a girdle, stitched it, and embroidered on it in large letters: ‘Seven at
+one stroke!’ ‘What, the town!’ he continued, ‘the whole world shall hear
+of it!’ and his heart wagged with joy like a lamb’s tail. The tailor
+put on the girdle, and resolved to go forth into the world, because he
+thought his workshop was too small for his valour. Before he went away,
+he sought about in the house to see if there was anything which he could
+take with him; however, he found nothing but an old cheese, and that
+he put in his pocket. In front of the door he observed a bird which
+had caught itself in the thicket. It had to go into his pocket with the
+cheese. Now he took to the road boldly, and as he was light and nimble,
+he felt no fatigue. The road led him up a mountain, and when he had
+reached the highest point of it, there sat a powerful giant looking
+peacefully about him. The little tailor went bravely up, spoke to him,
+and said: ‘Good day, comrade, so you are sitting there overlooking the
+wide-spread world! I am just on my way thither, and want to try my luck.
+Have you any inclination to go with me?’ The giant looked contemptuously
+at the tailor, and said: ‘You ragamuffin! You miserable creature!’
+
+‘Oh, indeed?’ answered the little tailor, and unbuttoned his coat, and
+showed the giant the girdle, ‘there may you read what kind of a man I
+am!’ The giant read: ‘Seven at one stroke,’ and thought that they had
+been men whom the tailor had killed, and began to feel a little respect
+for the tiny fellow. Nevertheless, he wished to try him first, and took
+a stone in his hand and squeezed it together so that water dropped out
+of it. ‘Do that likewise,’ said the giant, ‘if you have strength.’ ‘Is
+that all?’ said the tailor, ‘that is child’s play with us!’ and put his
+hand into his pocket, brought out the soft cheese, and pressed it until
+the liquid ran out of it. ‘Faith,’ said he, ‘that was a little better,
+wasn’t it?’ The giant did not know what to say, and could not believe it
+of the little man. Then the giant picked up a stone and threw it so high
+that the eye could scarcely follow it. ‘Now, little mite of a man, do
+that likewise,’ ‘Well thrown,’ said the tailor, ‘but after all the stone
+came down to earth again; I will throw you one which shall never come
+back at all,’ and he put his hand into his pocket, took out the bird,
+and threw it into the air. The bird, delighted with its liberty,
+rose, flew away and did not come back. ‘How does that shot please you,
+comrade?’ asked the tailor. ‘You can certainly throw,’ said the giant,
+‘but now we will see if you are able to carry anything properly.’ He
+took the little tailor to a mighty oak tree which lay there felled on
+the ground, and said: ‘If you are strong enough, help me to carry the
+tree out of the forest.’ ‘Readily,’ answered the little man; ‘take you
+the trunk on your shoulders, and I will raise up the branches and twigs;
+after all, they are the heaviest.’ The giant took the trunk on his
+shoulder, but the tailor seated himself on a branch, and the giant, who
+could not look round, had to carry away the whole tree, and the little
+tailor into the bargain: he behind, was quite merry and happy, and
+whistled the song: ‘Three tailors rode forth from the gate,’ as if
+carrying the tree were child’s play. The giant, after he had dragged the
+heavy burden part of the way, could go no further, and cried: ‘Hark
+you, I shall have to let the tree fall!’ The tailor sprang nimbly down,
+seized the tree with both arms as if he had been carrying it, and said
+to the giant: ‘You are such a great fellow, and yet cannot even carry
+the tree!’
+
+They went on together, and as they passed a cherry-tree, the giant laid
+hold of the top of the tree where the ripest fruit was hanging, bent it
+down, gave it into the tailor’s hand, and bade him eat. But the little
+tailor was much too weak to hold the tree, and when the giant let it go,
+it sprang back again, and the tailor was tossed into the air with it.
+When he had fallen down again without injury, the giant said: ‘What is
+this? Have you not strength enough to hold the weak twig?’ ‘There is no
+lack of strength,’ answered the little tailor. ‘Do you think that could
+be anything to a man who has struck down seven at one blow? I leapt over
+the tree because the huntsmen are shooting down there in the thicket.
+Jump as I did, if you can do it.’ The giant made the attempt but he
+could not get over the tree, and remained hanging in the branches, so
+that in this also the tailor kept the upper hand.
+
+The giant said: ‘If you are such a valiant fellow, come with me into our
+cavern and spend the night with us.’ The little tailor was willing, and
+followed him. When they went into the cave, other giants were sitting
+there by the fire, and each of them had a roasted sheep in his hand and
+was eating it. The little tailor looked round and thought: ‘It is much
+more spacious here than in my workshop.’ The giant showed him a bed, and
+said he was to lie down in it and sleep. The bed, however, was too
+big for the little tailor; he did not lie down in it, but crept into
+a corner. When it was midnight, and the giant thought that the little
+tailor was lying in a sound sleep, he got up, took a great iron bar,
+cut through the bed with one blow, and thought he had finished off the
+grasshopper for good. With the earliest dawn the giants went into the
+forest, and had quite forgotten the little tailor, when all at once he
+walked up to them quite merrily and boldly. The giants were terrified,
+they were afraid that he would strike them all dead, and ran away in a
+great hurry.
+
+The little tailor went onwards, always following his own pointed nose.
+After he had walked for a long time, he came to the courtyard of a royal
+palace, and as he felt weary, he lay down on the grass and fell asleep.
+Whilst he lay there, the people came and inspected him on all sides, and
+read on his girdle: ‘Seven at one stroke.’ ‘Ah!’ said they, ‘what does
+the great warrior want here in the midst of peace? He must be a mighty
+lord.’ They went and announced him to the king, and gave it as their
+opinion that if war should break out, this would be a weighty and useful
+man who ought on no account to be allowed to depart. The counsel pleased
+the king, and he sent one of his courtiers to the little tailor to offer
+him military service when he awoke. The ambassador remained standing by
+the sleeper, waited until he stretched his limbs and opened his eyes,
+and then conveyed to him this proposal. ‘For this very reason have
+I come here,’ the tailor replied, ‘I am ready to enter the king’s
+service.’ He was therefore honourably received, and a special dwelling
+was assigned him.
+
+The soldiers, however, were set against the little tailor, and wished
+him a thousand miles away. ‘What is to be the end of this?’ they said
+among themselves. ‘If we quarrel with him, and he strikes about him,
+seven of us will fall at every blow; not one of us can stand against
+him.’ They came therefore to a decision, betook themselves in a body to
+the king, and begged for their dismissal. ‘We are not prepared,’ said
+they, ‘to stay with a man who kills seven at one stroke.’ The king was
+sorry that for the sake of one he should lose all his faithful servants,
+wished that he had never set eyes on the tailor, and would willingly
+have been rid of him again. But he did not venture to give him his
+dismissal, for he dreaded lest he should strike him and all his people
+dead, and place himself on the royal throne. He thought about it for a
+long time, and at last found good counsel. He sent to the little tailor
+and caused him to be informed that as he was a great warrior, he had one
+request to make to him. In a forest of his country lived two giants,
+who caused great mischief with their robbing, murdering, ravaging,
+and burning, and no one could approach them without putting himself in
+danger of death. If the tailor conquered and killed these two giants, he
+would give him his only daughter to wife, and half of his kingdom as a
+dowry, likewise one hundred horsemen should go with him to assist him.
+‘That would indeed be a fine thing for a man like me!’ thought the
+little tailor. ‘One is not offered a beautiful princess and half a
+kingdom every day of one’s life!’ ‘Oh, yes,’ he replied, ‘I will soon
+subdue the giants, and do not require the help of the hundred horsemen
+to do it; he who can hit seven with one blow has no need to be afraid of
+two.’
+
+The little tailor went forth, and the hundred horsemen followed him.
+When he came to the outskirts of the forest, he said to his followers:
+‘Just stay waiting here, I alone will soon finish off the giants.’ Then
+he bounded into the forest and looked about right and left. After a
+while he perceived both giants. They lay sleeping under a tree, and
+snored so that the branches waved up and down. The little tailor, not
+idle, gathered two pocketsful of stones, and with these climbed up the
+tree. When he was halfway up, he slipped down by a branch, until he sat
+just above the sleepers, and then let one stone after another fall on
+the breast of one of the giants. For a long time the giant felt nothing,
+but at last he awoke, pushed his comrade, and said: ‘Why are you
+knocking me?’ ‘You must be dreaming,’ said the other, ‘I am not knocking
+you.’ They laid themselves down to sleep again, and then the tailor
+threw a stone down on the second. ‘What is the meaning of this?’ cried
+the other ‘Why are you pelting me?’ ‘I am not pelting you,’ answered
+the first, growling. They disputed about it for a time, but as they were
+weary they let the matter rest, and their eyes closed once more. The
+little tailor began his game again, picked out the biggest stone, and
+threw it with all his might on the breast of the first giant. ‘That
+is too bad!’ cried he, and sprang up like a madman, and pushed his
+companion against the tree until it shook. The other paid him back in
+the same coin, and they got into such a rage that they tore up trees and
+belaboured each other so long, that at last they both fell down dead on
+the ground at the same time. Then the little tailor leapt down. ‘It is
+a lucky thing,’ said he, ‘that they did not tear up the tree on which
+I was sitting, or I should have had to sprint on to another like a
+squirrel; but we tailors are nimble.’ He drew out his sword and gave
+each of them a couple of thrusts in the breast, and then went out to the
+horsemen and said: ‘The work is done; I have finished both of them
+off, but it was hard work! They tore up trees in their sore need, and
+defended themselves with them, but all that is to no purpose when a man
+like myself comes, who can kill seven at one blow.’ ‘But are you not
+wounded?’ asked the horsemen. ‘You need not concern yourself about
+that,’ answered the tailor, ‘they have not bent one hair of mine.’ The
+horsemen would not believe him, and rode into the forest; there they
+found the giants swimming in their blood, and all round about lay the
+torn-up trees.
+
+The little tailor demanded of the king the promised reward; he, however,
+repented of his promise, and again bethought himself how he could get
+rid of the hero. ‘Before you receive my daughter, and the half of my
+kingdom,’ said he to him, ‘you must perform one more heroic deed. In
+the forest roams a unicorn which does great harm, and you must catch
+it first.’ ‘I fear one unicorn still less than two giants. Seven at one
+blow, is my kind of affair.’ He took a rope and an axe with him, went
+forth into the forest, and again bade those who were sent with him to
+wait outside. He had not long to seek. The unicorn soon came towards
+him, and rushed directly on the tailor, as if it would gore him with its
+horn without more ado. ‘Softly, softly; it can’t be done as quickly as
+that,’ said he, and stood still and waited until the animal was quite
+close, and then sprang nimbly behind the tree. The unicorn ran against
+the tree with all its strength, and stuck its horn so fast in the trunk
+that it had not the strength enough to draw it out again, and thus it
+was caught. ‘Now, I have got the bird,’ said the tailor, and came out
+from behind the tree and put the rope round its neck, and then with his
+axe he hewed the horn out of the tree, and when all was ready he led the
+beast away and took it to the king.
+
+The king still would not give him the promised reward, and made a third
+demand. Before the wedding the tailor was to catch him a wild boar that
+made great havoc in the forest, and the huntsmen should give him their
+help. ‘Willingly,’ said the tailor, ‘that is child’s play!’ He did not
+take the huntsmen with him into the forest, and they were well pleased
+that he did not, for the wild boar had several times received them in
+such a manner that they had no inclination to lie in wait for him. When
+the boar perceived the tailor, it ran on him with foaming mouth and
+whetted tusks, and was about to throw him to the ground, but the hero
+fled and sprang into a chapel which was near and up to the window at
+once, and in one bound out again. The boar ran after him, but the tailor
+ran round outside and shut the door behind it, and then the raging
+beast, which was much too heavy and awkward to leap out of the window,
+was caught. The little tailor called the huntsmen thither that they
+might see the prisoner with their own eyes. The hero, however, went to
+the king, who was now, whether he liked it or not, obliged to keep his
+promise, and gave his daughter and the half of his kingdom. Had he known
+that it was no warlike hero, but a little tailor who was standing before
+him, it would have gone to his heart still more than it did. The wedding
+was held with great magnificence and small joy, and out of a tailor a
+king was made.
+
+After some time the young queen heard her husband say in his dreams at
+night: ‘Boy, make me the doublet, and patch the pantaloons, or else I
+will rap the yard-measure over your ears.’ Then she discovered in what
+state of life the young lord had been born, and next morning complained
+of her wrongs to her father, and begged him to help her to get rid of
+her husband, who was nothing else but a tailor. The king comforted her
+and said: ‘Leave your bedroom door open this night, and my servants
+shall stand outside, and when he has fallen asleep shall go in, bind
+him, and take him on board a ship which shall carry him into the wide
+world.’ The woman was satisfied with this; but the king’s armour-bearer,
+who had heard all, was friendly with the young lord, and informed him of
+the whole plot. ‘I’ll put a screw into that business,’ said the little
+tailor. At night he went to bed with his wife at the usual time, and
+when she thought that he had fallen asleep, she got up, opened the door,
+and then lay down again. The little tailor, who was only pretending to
+be asleep, began to cry out in a clear voice: ‘Boy, make me the doublet
+and patch me the pantaloons, or I will rap the yard-measure over your
+ears. I smote seven at one blow. I killed two giants, I brought away one
+unicorn, and caught a wild boar, and am I to fear those who are standing
+outside the room.’ When these men heard the tailor speaking thus, they
+were overcome by a great dread, and ran as if the wild huntsman were
+behind them, and none of them would venture anything further against
+him. So the little tailor was and remained a king to the end of his
+life.
+
+
+
+
+HANSEL AND GRETEL
+
+Hard by a great forest dwelt a poor wood-cutter with his wife and his
+two children. The boy was called Hansel and the girl Gretel. He had
+little to bite and to break, and once when great dearth fell on the
+land, he could no longer procure even daily bread. Now when he thought
+over this by night in his bed, and tossed about in his anxiety, he
+groaned and said to his wife: ‘What is to become of us? How are we
+to feed our poor children, when we no longer have anything even for
+ourselves?’ ‘I’ll tell you what, husband,’ answered the woman, ‘early
+tomorrow morning we will take the children out into the forest to where
+it is the thickest; there we will light a fire for them, and give each
+of them one more piece of bread, and then we will go to our work and
+leave them alone. They will not find the way home again, and we shall be
+rid of them.’ ‘No, wife,’ said the man, ‘I will not do that; how can I
+bear to leave my children alone in the forest?--the wild animals would
+soon come and tear them to pieces.’ ‘O, you fool!’ said she, ‘then we
+must all four die of hunger, you may as well plane the planks for our
+coffins,’ and she left him no peace until he consented. ‘But I feel very
+sorry for the poor children, all the same,’ said the man.
+
+The two children had also not been able to sleep for hunger, and had
+heard what their stepmother had said to their father. Gretel wept
+bitter tears, and said to Hansel: ‘Now all is over with us.’ ‘Be quiet,
+Gretel,’ said Hansel, ‘do not distress yourself, I will soon find a way
+to help us.’ And when the old folks had fallen asleep, he got up, put
+on his little coat, opened the door below, and crept outside. The moon
+shone brightly, and the white pebbles which lay in front of the house
+glittered like real silver pennies. Hansel stooped and stuffed the
+little pocket of his coat with as many as he could get in. Then he went
+back and said to Gretel: ‘Be comforted, dear little sister, and sleep in
+peace, God will not forsake us,’ and he lay down again in his bed. When
+day dawned, but before the sun had risen, the woman came and awoke the
+two children, saying: ‘Get up, you sluggards! we are going into the
+forest to fetch wood.’ She gave each a little piece of bread, and said:
+‘There is something for your dinner, but do not eat it up before then,
+for you will get nothing else.’ Gretel took the bread under her apron,
+as Hansel had the pebbles in his pocket. Then they all set out together
+on the way to the forest. When they had walked a short time, Hansel
+stood still and peeped back at the house, and did so again and again.
+His father said: ‘Hansel, what are you looking at there and staying
+behind for? Pay attention, and do not forget how to use your legs.’ ‘Ah,
+father,’ said Hansel, ‘I am looking at my little white cat, which is
+sitting up on the roof, and wants to say goodbye to me.’ The wife said:
+‘Fool, that is not your little cat, that is the morning sun which is
+shining on the chimneys.’ Hansel, however, had not been looking back at
+the cat, but had been constantly throwing one of the white pebble-stones
+out of his pocket on the road.
+
+When they had reached the middle of the forest, the father said: ‘Now,
+children, pile up some wood, and I will light a fire that you may not
+be cold.’ Hansel and Gretel gathered brushwood together, as high as a
+little hill. The brushwood was lighted, and when the flames were burning
+very high, the woman said: ‘Now, children, lay yourselves down by the
+fire and rest, we will go into the forest and cut some wood. When we
+have done, we will come back and fetch you away.’
+
+Hansel and Gretel sat by the fire, and when noon came, each ate a little
+piece of bread, and as they heard the strokes of the wood-axe they
+believed that their father was near. It was not the axe, however, but
+a branch which he had fastened to a withered tree which the wind was
+blowing backwards and forwards. And as they had been sitting such a long
+time, their eyes closed with fatigue, and they fell fast asleep. When
+at last they awoke, it was already dark night. Gretel began to cry and
+said: ‘How are we to get out of the forest now?’ But Hansel comforted
+her and said: ‘Just wait a little, until the moon has risen, and then we
+will soon find the way.’ And when the full moon had risen, Hansel took
+his little sister by the hand, and followed the pebbles which shone like
+newly-coined silver pieces, and showed them the way.
+
+They walked the whole night long, and by break of day came once more
+to their father’s house. They knocked at the door, and when the woman
+opened it and saw that it was Hansel and Gretel, she said: ‘You naughty
+children, why have you slept so long in the forest?--we thought you were
+never coming back at all!’ The father, however, rejoiced, for it had cut
+him to the heart to leave them behind alone.
+
+Not long afterwards, there was once more great dearth throughout the
+land, and the children heard their mother saying at night to their
+father: ‘Everything is eaten again, we have one half loaf left, and that
+is the end. The children must go, we will take them farther into the
+wood, so that they will not find their way out again; there is no other
+means of saving ourselves!’ The man’s heart was heavy, and he thought:
+‘It would be better for you to share the last mouthful with your
+children.’ The woman, however, would listen to nothing that he had to
+say, but scolded and reproached him. He who says A must say B, likewise,
+and as he had yielded the first time, he had to do so a second time
+also.
+
+The children, however, were still awake and had heard the conversation.
+When the old folks were asleep, Hansel again got up, and wanted to go
+out and pick up pebbles as he had done before, but the woman had locked
+the door, and Hansel could not get out. Nevertheless he comforted his
+little sister, and said: ‘Do not cry, Gretel, go to sleep quietly, the
+good God will help us.’
+
+Early in the morning came the woman, and took the children out of their
+beds. Their piece of bread was given to them, but it was still smaller
+than the time before. On the way into the forest Hansel crumbled his
+in his pocket, and often stood still and threw a morsel on the ground.
+‘Hansel, why do you stop and look round?’ said the father, ‘go on.’ ‘I
+am looking back at my little pigeon which is sitting on the roof, and
+wants to say goodbye to me,’ answered Hansel. ‘Fool!’ said the woman,
+‘that is not your little pigeon, that is the morning sun that is shining
+on the chimney.’ Hansel, however little by little, threw all the crumbs
+on the path.
+
+The woman led the children still deeper into the forest, where they had
+never in their lives been before. Then a great fire was again made, and
+the mother said: ‘Just sit there, you children, and when you are tired
+you may sleep a little; we are going into the forest to cut wood, and in
+the evening when we are done, we will come and fetch you away.’ When
+it was noon, Gretel shared her piece of bread with Hansel, who had
+scattered his by the way. Then they fell asleep and evening passed, but
+no one came to the poor children. They did not awake until it was dark
+night, and Hansel comforted his little sister and said: ‘Just wait,
+Gretel, until the moon rises, and then we shall see the crumbs of bread
+which I have strewn about, they will show us our way home again.’ When
+the moon came they set out, but they found no crumbs, for the many
+thousands of birds which fly about in the woods and fields had picked
+them all up. Hansel said to Gretel: ‘We shall soon find the way,’ but
+they did not find it. They walked the whole night and all the next day
+too from morning till evening, but they did not get out of the forest,
+and were very hungry, for they had nothing to eat but two or three
+berries, which grew on the ground. And as they were so weary that their
+legs would carry them no longer, they lay down beneath a tree and fell
+asleep.
+
+It was now three mornings since they had left their father’s house. They
+began to walk again, but they always came deeper into the forest, and if
+help did not come soon, they must die of hunger and weariness. When it
+was mid-day, they saw a beautiful snow-white bird sitting on a bough,
+which sang so delightfully that they stood still and listened to it. And
+when its song was over, it spread its wings and flew away before them,
+and they followed it until they reached a little house, on the roof of
+which it alighted; and when they approached the little house they saw
+that it was built of bread and covered with cakes, but that the windows
+were of clear sugar. ‘We will set to work on that,’ said Hansel, ‘and
+have a good meal. I will eat a bit of the roof, and you Gretel, can eat
+some of the window, it will taste sweet.’ Hansel reached up above, and
+broke off a little of the roof to try how it tasted, and Gretel leant
+against the window and nibbled at the panes. Then a soft voice cried
+from the parlour:
+
+ ‘Nibble, nibble, gnaw,
+  Who is nibbling at my little house?’
+
+The children answered:
+
+ ‘The wind, the wind,
+  The heaven-born wind,’
+
+and went on eating without disturbing themselves. Hansel, who liked the
+taste of the roof, tore down a great piece of it, and Gretel pushed out
+the whole of one round window-pane, sat down, and enjoyed herself with
+it. Suddenly the door opened, and a woman as old as the hills, who
+supported herself on crutches, came creeping out. Hansel and Gretel were
+so terribly frightened that they let fall what they had in their
+hands. The old woman, however, nodded her head, and said: ‘Oh, you dear
+children, who has brought you here? do come in, and stay with me. No
+harm shall happen to you.’ She took them both by the hand, and led them
+into her little house. Then good food was set before them, milk and
+pancakes, with sugar, apples, and nuts. Afterwards two pretty little
+beds were covered with clean white linen, and Hansel and Gretel lay down
+in them, and thought they were in heaven.
+
+The old woman had only pretended to be so kind; she was in reality
+a wicked witch, who lay in wait for children, and had only built the
+little house of bread in order to entice them there. When a child fell
+into her power, she killed it, cooked and ate it, and that was a feast
+day with her. Witches have red eyes, and cannot see far, but they have
+a keen scent like the beasts, and are aware when human beings draw near.
+When Hansel and Gretel came into her neighbourhood, she laughed with
+malice, and said mockingly: ‘I have them, they shall not escape me
+again!’ Early in the morning before the children were awake, she was
+already up, and when she saw both of them sleeping and looking so
+pretty, with their plump and rosy cheeks she muttered to herself: ‘That
+will be a dainty mouthful!’ Then she seized Hansel with her shrivelled
+hand, carried him into a little stable, and locked him in behind a
+grated door. Scream as he might, it would not help him. Then she went to
+Gretel, shook her till she awoke, and cried: ‘Get up, lazy thing, fetch
+some water, and cook something good for your brother, he is in the
+stable outside, and is to be made fat. When he is fat, I will eat him.’
+Gretel began to weep bitterly, but it was all in vain, for she was
+forced to do what the wicked witch commanded.
+
+And now the best food was cooked for poor Hansel, but Gretel got nothing
+but crab-shells. Every morning the woman crept to the little stable, and
+cried: ‘Hansel, stretch out your finger that I may feel if you will soon
+be fat.’ Hansel, however, stretched out a little bone to her, and
+the old woman, who had dim eyes, could not see it, and thought it was
+Hansel’s finger, and was astonished that there was no way of fattening
+him. When four weeks had gone by, and Hansel still remained thin, she
+was seized with impatience and would not wait any longer. ‘Now, then,
+Gretel,’ she cried to the girl, ‘stir yourself, and bring some water.
+Let Hansel be fat or lean, tomorrow I will kill him, and cook him.’ Ah,
+how the poor little sister did lament when she had to fetch the water,
+and how her tears did flow down her cheeks! ‘Dear God, do help us,’ she
+cried. ‘If the wild beasts in the forest had but devoured us, we should
+at any rate have died together.’ ‘Just keep your noise to yourself,’
+said the old woman, ‘it won’t help you at all.’
+
+Early in the morning, Gretel had to go out and hang up the cauldron with
+the water, and light the fire. ‘We will bake first,’ said the old woman,
+‘I have already heated the oven, and kneaded the dough.’ She pushed poor
+Gretel out to the oven, from which flames of fire were already darting.
+‘Creep in,’ said the witch, ‘and see if it is properly heated, so that
+we can put the bread in.’ And once Gretel was inside, she intended to
+shut the oven and let her bake in it, and then she would eat her, too.
+But Gretel saw what she had in mind, and said: ‘I do not know how I am
+to do it; how do I get in?’ ‘Silly goose,’ said the old woman. ‘The door
+is big enough; just look, I can get in myself!’ and she crept up and
+thrust her head into the oven. Then Gretel gave her a push that drove
+her far into it, and shut the iron door, and fastened the bolt. Oh! then
+she began to howl quite horribly, but Gretel ran away and the godless
+witch was miserably burnt to death.
+
+Gretel, however, ran like lightning to Hansel, opened his little stable,
+and cried: ‘Hansel, we are saved! The old witch is dead!’ Then Hansel
+sprang like a bird from its cage when the door is opened. How they did
+rejoice and embrace each other, and dance about and kiss each other! And
+as they had no longer any need to fear her, they went into the witch’s
+house, and in every corner there stood chests full of pearls and jewels.
+‘These are far better than pebbles!’ said Hansel, and thrust into his
+pockets whatever could be got in, and Gretel said: ‘I, too, will take
+something home with me,’ and filled her pinafore full. ‘But now we must
+be off,’ said Hansel, ‘that we may get out of the witch’s forest.’
+
+When they had walked for two hours, they came to a great stretch of
+water. ‘We cannot cross,’ said Hansel, ‘I see no foot-plank, and no
+bridge.’ ‘And there is also no ferry,’ answered Gretel, ‘but a white
+duck is swimming there: if I ask her, she will help us over.’ Then she
+cried:
+
+ ‘Little duck, little duck, dost thou see,
+  Hansel and Gretel are waiting for thee?
+  There’s never a plank, or bridge in sight,
+  Take us across on thy back so white.’
+
+The duck came to them, and Hansel seated himself on its back, and told
+his sister to sit by him. ‘No,’ replied Gretel, ‘that will be too heavy
+for the little duck; she shall take us across, one after the other.’ The
+good little duck did so, and when they were once safely across and had
+walked for a short time, the forest seemed to be more and more familiar
+to them, and at length they saw from afar their father’s house. Then
+they began to run, rushed into the parlour, and threw themselves round
+their father’s neck. The man had not known one happy hour since he had
+left the children in the forest; the woman, however, was dead. Gretel
+emptied her pinafore until pearls and precious stones ran about the
+room, and Hansel threw one handful after another out of his pocket to
+add to them. Then all anxiety was at an end, and they lived together
+in perfect happiness. My tale is done, there runs a mouse; whosoever
+catches it, may make himself a big fur cap out of it.
+
+
+
+
+THE MOUSE, THE BIRD, AND THE SAUSAGE
+
+Once upon a time, a mouse, a bird, and a sausage, entered into
+partnership and set up house together. For a long time all went well;
+they lived in great comfort, and prospered so far as to be able to add
+considerably to their stores. The bird’s duty was to fly daily into the
+wood and bring in fuel; the mouse fetched the water, and the sausage saw
+to the cooking.
+
+When people are too well off they always begin to long for something
+new. And so it came to pass, that the bird, while out one day, met a
+fellow bird, to whom he boastfully expatiated on the excellence of his
+household arrangements. But the other bird sneered at him for being a
+poor simpleton, who did all the hard work, while the other two stayed
+at home and had a good time of it. For, when the mouse had made the fire
+and fetched in the water, she could retire into her little room and rest
+until it was time to set the table. The sausage had only to watch the
+pot to see that the food was properly cooked, and when it was near
+dinner-time, he just threw himself into the broth, or rolled in and out
+among the vegetables three or four times, and there they were, buttered,
+and salted, and ready to be served. Then, when the bird came home and
+had laid aside his burden, they sat down to table, and when they had
+finished their meal, they could sleep their fill till the following
+morning: and that was really a very delightful life.
+
+Influenced by those remarks, the bird next morning refused to bring in
+the wood, telling the others that he had been their servant long enough,
+and had been a fool into the bargain, and that it was now time to make a
+change, and to try some other way of arranging the work. Beg and pray
+as the mouse and the sausage might, it was of no use; the bird remained
+master of the situation, and the venture had to be made. They therefore
+drew lots, and it fell to the sausage to bring in the wood, to the mouse
+to cook, and to the bird to fetch the water.
+
+And now what happened? The sausage started in search of wood, the bird
+made the fire, and the mouse put on the pot, and then these two waited
+till the sausage returned with the fuel for the following day. But the
+sausage remained so long away, that they became uneasy, and the bird
+flew out to meet him. He had not flown far, however, when he came across
+a dog who, having met the sausage, had regarded him as his legitimate
+booty, and so seized and swallowed him. The bird complained to the dog
+of this bare-faced robbery, but nothing he said was of any avail, for
+the dog answered that he found false credentials on the sausage, and
+that was the reason his life had been forfeited.
+
+He picked up the wood, and flew sadly home, and told the mouse all he
+had seen and heard. They were both very unhappy, but agreed to make the
+best of things and to remain with one another.
+
+So now the bird set the table, and the mouse looked after the food and,
+wishing to prepare it in the same way as the sausage, by rolling in and
+out among the vegetables to salt and butter them, she jumped into the
+pot; but she stopped short long before she reached the bottom, having
+already parted not only with her skin and hair, but also with life.
+
+Presently the bird came in and wanted to serve up the dinner, but he
+could nowhere see the cook. In his alarm and flurry, he threw the wood
+here and there about the floor, called and searched, but no cook was to
+be found. Then some of the wood that had been carelessly thrown down,
+caught fire and began to blaze. The bird hastened to fetch some water,
+but his pail fell into the well, and he after it, and as he was unable
+to recover himself, he was drowned.
+
+
+
+
+MOTHER HOLLE
+
+Once upon a time there was a widow who had two daughters; one of them
+was beautiful and industrious, the other ugly and lazy. The mother,
+however, loved the ugly and lazy one best, because she was her own
+daughter, and so the other, who was only her stepdaughter, was made
+to do all the work of the house, and was quite the Cinderella of the
+family. Her stepmother sent her out every day to sit by the well in
+the high road, there to spin until she made her fingers bleed. Now it
+chanced one day that some blood fell on to the spindle, and as the girl
+stopped over the well to wash it off, the spindle suddenly sprang out
+of her hand and fell into the well. She ran home crying to tell of her
+misfortune, but her stepmother spoke harshly to her, and after giving
+her a violent scolding, said unkindly, ‘As you have let the spindle fall
+into the well you may go yourself and fetch it out.’
+
+The girl went back to the well not knowing what to do, and at last in
+her distress she jumped into the water after the spindle.
+
+She remembered nothing more until she awoke and found herself in a
+beautiful meadow, full of sunshine, and with countless flowers blooming
+in every direction.
+
+She walked over the meadow, and presently she came upon a baker’s oven
+full of bread, and the loaves cried out to her, ‘Take us out, take us
+out, or alas! we shall be burnt to a cinder; we were baked through long
+ago.’ So she took the bread-shovel and drew them all out.
+
+She went on a little farther, till she came to a tree full of apples.
+‘Shake me, shake me, I pray,’ cried the tree; ‘my apples, one and all,
+are ripe.’ So she shook the tree, and the apples came falling down upon
+her like rain; but she continued shaking until there was not a single
+apple left upon it. Then she carefully gathered the apples together in a
+heap and walked on again.
+
+The next thing she came to was a little house, and there she saw an old
+woman looking out, with such large teeth, that she was terrified, and
+turned to run away. But the old woman called after her, ‘What are you
+afraid of, dear child? Stay with me; if you will do the work of my house
+properly for me, I will make you very happy. You must be very careful,
+however, to make my bed in the right way, for I wish you always to shake
+it thoroughly, so that the feathers fly about; then they say, down there
+in the world, that it is snowing; for I am Mother Holle.’ The old woman
+spoke so kindly, that the girl summoned up courage and agreed to enter
+into her service.
+
+She took care to do everything according to the old woman’s bidding and
+every time she made the bed she shook it with all her might, so that the
+feathers flew about like so many snowflakes. The old woman was as good
+as her word: she never spoke angrily to her, and gave her roast and
+boiled meats every day.
+
+So she stayed on with Mother Holle for some time, and then she began
+to grow unhappy. She could not at first tell why she felt sad, but she
+became conscious at last of great longing to go home; then she knew she
+was homesick, although she was a thousand times better off with Mother
+Holle than with her mother and sister. After waiting awhile, she went
+to Mother Holle and said, ‘I am so homesick, that I cannot stay with
+you any longer, for although I am so happy here, I must return to my own
+people.’
+
+Then Mother Holle said, ‘I am pleased that you should want to go back
+to your own people, and as you have served me so well and faithfully, I
+will take you home myself.’
+
+Thereupon she led the girl by the hand up to a broad gateway. The gate
+was opened, and as the girl passed through, a shower of gold fell upon
+her, and the gold clung to her, so that she was covered with it from
+head to foot.
+
+‘That is a reward for your industry,’ said Mother Holle, and as she
+spoke she handed her the spindle which she had dropped into the well.
+
+The gate was then closed, and the girl found herself back in the old
+world close to her mother’s house. As she entered the courtyard, the
+cock who was perched on the well, called out:
+
+ ‘Cock-a-doodle-doo!
+  Your golden daughter’s come back to you.’
+
+Then she went in to her mother and sister, and as she was so richly
+covered with gold, they gave her a warm welcome. She related to them
+all that had happened, and when the mother heard how she had come by her
+great riches, she thought she should like her ugly, lazy daughter to go
+and try her fortune. So she made the sister go and sit by the well
+and spin, and the girl pricked her finger and thrust her hand into a
+thorn-bush, so that she might drop some blood on to the spindle; then
+she threw it into the well, and jumped in herself.
+
+Like her sister she awoke in the beautiful meadow, and walked over it
+till she came to the oven. ‘Take us out, take us out, or alas! we shall
+be burnt to a cinder; we were baked through long ago,’ cried the loaves
+as before. But the lazy girl answered, ‘Do you think I am going to dirty
+my hands for you?’ and walked on.
+
+Presently she came to the apple-tree. ‘Shake me, shake me, I pray; my
+apples, one and all, are ripe,’ it cried. But she only answered, ‘A nice
+thing to ask me to do, one of the apples might fall on my head,’ and
+passed on.
+
+At last she came to Mother Holle’s house, and as she had heard all about
+the large teeth from her sister, she was not afraid of them, and engaged
+herself without delay to the old woman.
+
+The first day she was very obedient and industrious, and exerted herself
+to please Mother Holle, for she thought of the gold she should get in
+return. The next day, however, she began to dawdle over her work, and
+the third day she was more idle still; then she began to lie in bed in
+the mornings and refused to get up. Worse still, she neglected to
+make the old woman’s bed properly, and forgot to shake it so that the
+feathers might fly about. So Mother Holle very soon got tired of her,
+and told her she might go. The lazy girl was delighted at this, and
+thought to herself, ‘The gold will soon be mine.’ Mother Holle led her,
+as she had led her sister, to the broad gateway; but as she was passing
+through, instead of the shower of gold, a great bucketful of pitch came
+pouring over her.
+
+‘That is in return for your services,’ said the old woman, and she shut
+the gate.
+
+So the lazy girl had to go home covered with pitch, and the cock on the
+well called out as she saw her:
+
+ ‘Cock-a-doodle-doo!
+  Your dirty daughter’s come back to you.’
+
+But, try what she would, she could not get the pitch off and it stuck to
+her as long as she lived.
+
+
+
+
+LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+
+Once upon a time there was a dear little girl who was loved by everyone
+who looked at her, but most of all by her grandmother, and there was
+nothing that she would not have given to the child. Once she gave her a
+little cap of red velvet, which suited her so well that she would never
+wear anything else; so she was always called ‘Little Red-Cap.’
+
+One day her mother said to her: ‘Come, Little Red-Cap, here is a piece
+of cake and a bottle of wine; take them to your grandmother, she is ill
+and weak, and they will do her good. Set out before it gets hot, and
+when you are going, walk nicely and quietly and do not run off the path,
+or you may fall and break the bottle, and then your grandmother will
+get nothing; and when you go into her room, don’t forget to say, “Good
+morning”, and don’t peep into every corner before you do it.’
+
+‘I will take great care,’ said Little Red-Cap to her mother, and gave
+her hand on it.
+
+The grandmother lived out in the wood, half a league from the village,
+and just as Little Red-Cap entered the wood, a wolf met her. Red-Cap
+did not know what a wicked creature he was, and was not at all afraid of
+him.
+
+‘Good day, Little Red-Cap,’ said he.
+
+‘Thank you kindly, wolf.’
+
+‘Whither away so early, Little Red-Cap?’
+
+‘To my grandmother’s.’
+
+‘What have you got in your apron?’
+
+‘Cake and wine; yesterday was baking-day, so poor sick grandmother is to
+have something good, to make her stronger.’
+
+‘Where does your grandmother live, Little Red-Cap?’
+
+‘A good quarter of a league farther on in the wood; her house stands
+under the three large oak-trees, the nut-trees are just below; you
+surely must know it,’ replied Little Red-Cap.
+
+The wolf thought to himself: ‘What a tender young creature! what a nice
+plump mouthful--she will be better to eat than the old woman. I must
+act craftily, so as to catch both.’ So he walked for a short time by
+the side of Little Red-Cap, and then he said: ‘See, Little Red-Cap, how
+pretty the flowers are about here--why do you not look round? I believe,
+too, that you do not hear how sweetly the little birds are singing; you
+walk gravely along as if you were going to school, while everything else
+out here in the wood is merry.’
+
+Little Red-Cap raised her eyes, and when she saw the sunbeams dancing
+here and there through the trees, and pretty flowers growing everywhere,
+she thought: ‘Suppose I take grandmother a fresh nosegay; that would
+please her too. It is so early in the day that I shall still get there
+in good time’; and so she ran from the path into the wood to look for
+flowers. And whenever she had picked one, she fancied that she saw a
+still prettier one farther on, and ran after it, and so got deeper and
+deeper into the wood.
+
+Meanwhile the wolf ran straight to the grandmother’s house and knocked
+at the door.
+
+‘Who is there?’
+
+‘Little Red-Cap,’ replied the wolf. ‘She is bringing cake and wine; open
+the door.’
+
+‘Lift the latch,’ called out the grandmother, ‘I am too weak, and cannot
+get up.’
+
+The wolf lifted the latch, the door sprang open, and without saying a
+word he went straight to the grandmother’s bed, and devoured her. Then
+he put on her clothes, dressed himself in her cap laid himself in bed
+and drew the curtains.
+
+Little Red-Cap, however, had been running about picking flowers,
+and when she had gathered so many that she could carry no more, she
+remembered her grandmother, and set out on the way to her.
+
+She was surprised to find the cottage-door standing open, and when she
+went into the room, she had such a strange feeling that she said to
+herself: ‘Oh dear! how uneasy I feel today, and at other times I like
+being with grandmother so much.’ She called out: ‘Good morning,’ but
+received no answer; so she went to the bed and drew back the curtains.
+There lay her grandmother with her cap pulled far over her face, and
+looking very strange.
+
+‘Oh! grandmother,’ she said, ‘what big ears you have!’
+
+‘The better to hear you with, my child,’ was the reply.
+
+‘But, grandmother, what big eyes you have!’ she said.
+
+‘The better to see you with, my dear.’
+
+‘But, grandmother, what large hands you have!’
+
+‘The better to hug you with.’
+
+‘Oh! but, grandmother, what a terrible big mouth you have!’
+
+‘The better to eat you with!’
+
+And scarcely had the wolf said this, than with one bound he was out of
+bed and swallowed up Red-Cap.
+
+When the wolf had appeased his appetite, he lay down again in the bed,
+fell asleep and began to snore very loud. The huntsman was just passing
+the house, and thought to himself: ‘How the old woman is snoring! I must
+just see if she wants anything.’ So he went into the room, and when he
+came to the bed, he saw that the wolf was lying in it. ‘Do I find you
+here, you old sinner!’ said he. ‘I have long sought you!’ Then just as
+he was going to fire at him, it occurred to him that the wolf might have
+devoured the grandmother, and that she might still be saved, so he did
+not fire, but took a pair of scissors, and began to cut open the stomach
+of the sleeping wolf. When he had made two snips, he saw the little
+Red-Cap shining, and then he made two snips more, and the little girl
+sprang out, crying: ‘Ah, how frightened I have been! How dark it was
+inside the wolf’; and after that the aged grandmother came out alive
+also, but scarcely able to breathe. Red-Cap, however, quickly fetched
+great stones with which they filled the wolf’s belly, and when he awoke,
+he wanted to run away, but the stones were so heavy that he collapsed at
+once, and fell dead.
+
+Then all three were delighted. The huntsman drew off the wolf’s skin and
+went home with it; the grandmother ate the cake and drank the wine which
+Red-Cap had brought, and revived, but Red-Cap thought to herself: ‘As
+long as I live, I will never by myself leave the path, to run into the
+wood, when my mother has forbidden me to do so.’
+
+
+
+
+It also related that once when Red-Cap was again taking cakes to the old
+grandmother, another wolf spoke to her, and tried to entice her from the
+path. Red-Cap, however, was on her guard, and went straight forward on
+her way, and told her grandmother that she had met the wolf, and that he
+had said ‘good morning’ to her, but with such a wicked look in his eyes,
+that if they had not been on the public road she was certain he would
+have eaten her up. ‘Well,’ said the grandmother, ‘we will shut the door,
+that he may not come in.’ Soon afterwards the wolf knocked, and cried:
+‘Open the door, grandmother, I am Little Red-Cap, and am bringing you
+some cakes.’ But they did not speak, or open the door, so the grey-beard
+stole twice or thrice round the house, and at last jumped on the roof,
+intending to wait until Red-Cap went home in the evening, and then to
+steal after her and devour her in the darkness. But the grandmother
+saw what was in his thoughts. In front of the house was a great stone
+trough, so she said to the child: ‘Take the pail, Red-Cap; I made some
+sausages yesterday, so carry the water in which I boiled them to the
+trough.’ Red-Cap carried until the great trough was quite full. Then the
+smell of the sausages reached the wolf, and he sniffed and peeped down,
+and at last stretched out his neck so far that he could no longer keep
+his footing and began to slip, and slipped down from the roof straight
+into the great trough, and was drowned. But Red-Cap went joyously home,
+and no one ever did anything to harm her again.
+
+
+
+
+THE ROBBER BRIDEGROOM
+
+There was once a miller who had one beautiful daughter, and as she was
+grown up, he was anxious that she should be well married and provided
+for. He said to himself, ‘I will give her to the first suitable man who
+comes and asks for her hand.’ Not long after a suitor appeared, and as
+he appeared to be very rich and the miller could see nothing in him with
+which to find fault, he betrothed his daughter to him. But the girl did
+not care for the man as a girl ought to care for her betrothed husband.
+She did not feel that she could trust him, and she could not look at him
+nor think of him without an inward shudder. One day he said to her, ‘You
+have not yet paid me a visit, although we have been betrothed for some
+time.’ ‘I do not know where your house is,’ she answered. ‘My house is
+out there in the dark forest,’ he said. She tried to excuse herself by
+saying that she would not be able to find the way thither. Her betrothed
+only replied, ‘You must come and see me next Sunday; I have already
+invited guests for that day, and that you may not mistake the way, I
+will strew ashes along the path.’
+
+When Sunday came, and it was time for the girl to start, a feeling of
+dread came over her which she could not explain, and that she might
+be able to find her path again, she filled her pockets with peas and
+lentils to sprinkle on the ground as she went along. On reaching the
+entrance to the forest she found the path strewed with ashes, and these
+she followed, throwing down some peas on either side of her at every
+step she took. She walked the whole day until she came to the deepest,
+darkest part of the forest. There she saw a lonely house, looking so
+grim and mysterious, that it did not please her at all. She stepped
+inside, but not a soul was to be seen, and a great silence reigned
+throughout. Suddenly a voice cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl looked up and saw that the voice came from a bird hanging in a
+cage on the wall. Again it cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl passed on, going from room to room of the house, but they were
+all empty, and still she saw no one. At last she came to the cellar,
+and there sat a very, very old woman, who could not keep her head from
+shaking. ‘Can you tell me,’ asked the girl, ‘if my betrothed husband
+lives here?’
+
+‘Ah, you poor child,’ answered the old woman, ‘what a place for you to
+come to! This is a murderers’ den. You think yourself a promised bride,
+and that your marriage will soon take place, but it is with death that
+you will keep your marriage feast. Look, do you see that large cauldron
+of water which I am obliged to keep on the fire! As soon as they have
+you in their power they will kill you without mercy, and cook and eat
+you, for they are eaters of men. If I did not take pity on you and save
+you, you would be lost.’
+
+Thereupon the old woman led her behind a large cask, which quite hid her
+from view. ‘Keep as still as a mouse,’ she said; ‘do not move or speak,
+or it will be all over with you. Tonight, when the robbers are
+all asleep, we will flee together. I have long been waiting for an
+opportunity to escape.’
+
+The words were hardly out of her mouth when the godless crew returned,
+dragging another young girl along with them. They were all drunk, and
+paid no heed to her cries and lamentations. They gave her wine to drink,
+three glasses full, one of white wine, one of red, and one of yellow,
+and with that her heart gave way and she died. Then they tore off her
+dainty clothing, laid her on a table, and cut her beautiful body into
+pieces, and sprinkled salt upon it.
+
+The poor betrothed girl crouched trembling and shuddering behind the
+cask, for she saw what a terrible fate had been intended for her by
+the robbers. One of them now noticed a gold ring still remaining on
+the little finger of the murdered girl, and as he could not draw it off
+easily, he took a hatchet and cut off the finger; but the finger sprang
+into the air, and fell behind the cask into the lap of the girl who was
+hiding there. The robber took a light and began looking for it, but he
+could not find it. ‘Have you looked behind the large cask?’ said one of
+the others. But the old woman called out, ‘Come and eat your suppers,
+and let the thing be till tomorrow; the finger won’t run away.’
+
+‘The old woman is right,’ said the robbers, and they ceased looking for
+the finger and sat down.
+
+The old woman then mixed a sleeping draught with their wine, and before
+long they were all lying on the floor of the cellar, fast asleep and
+snoring. As soon as the girl was assured of this, she came from behind
+the cask. She was obliged to step over the bodies of the sleepers, who
+were lying close together, and every moment she was filled with renewed
+dread lest she should awaken them. But God helped her, so that she
+passed safely over them, and then she and the old woman went upstairs,
+opened the door, and hastened as fast as they could from the murderers’
+den. They found the ashes scattered by the wind, but the peas and
+lentils had sprouted, and grown sufficiently above the ground, to guide
+them in the moonlight along the path. All night long they walked, and it
+was morning before they reached the mill. Then the girl told her father
+all that had happened.
+
+The day came that had been fixed for the marriage. The bridegroom
+arrived and also a large company of guests, for the miller had taken
+care to invite all his friends and relations. As they sat at the feast,
+each guest in turn was asked to tell a tale; the bride sat still and did
+not say a word.
+
+‘And you, my love,’ said the bridegroom, turning to her, ‘is there no
+tale you know? Tell us something.’
+
+‘I will tell you a dream, then,’ said the bride. ‘I went alone through a
+forest and came at last to a house; not a soul could I find within, but
+a bird that was hanging in a cage on the wall cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+and again a second time it said these words.’
+
+‘My darling, this is only a dream.’
+
+‘I went on through the house from room to room, but they were all empty,
+and everything was so grim and mysterious. At last I went down to the
+cellar, and there sat a very, very old woman, who could not keep her
+head still. I asked her if my betrothed lived here, and she answered,
+“Ah, you poor child, you are come to a murderers’ den; your betrothed
+does indeed live here, but he will kill you without mercy and afterwards
+cook and eat you.”’
+
+‘My darling, this is only a dream.’
+
+‘The old woman hid me behind a large cask, and scarcely had she done
+this when the robbers returned home, dragging a young girl along with
+them. They gave her three kinds of wine to drink, white, red, and
+yellow, and with that she died.’
+
+‘My darling, this is only a dream.’
+
+‘Then they tore off her dainty clothing, and cut her beautiful body into
+pieces and sprinkled salt upon it.’
+
+‘My darling, this is only a dream.’
+
+‘And one of the robbers saw that there was a gold ring still left on her
+finger, and as it was difficult to draw off, he took a hatchet and cut
+off her finger; but the finger sprang into the air and fell behind the
+great cask into my lap. And here is the finger with the ring.’ And
+with these words the bride drew forth the finger and shewed it to the
+assembled guests.
+
+The bridegroom, who during this recital had grown deadly pale, up and
+tried to escape, but the guests seized him and held him fast. They
+delivered him up to justice, and he and all his murderous band were
+condemned to death for their wicked deeds.
+
+
+
+
+TOM THUMB
+
+A poor woodman sat in his cottage one night, smoking his pipe by the
+fireside, while his wife sat by his side spinning. ‘How lonely it is,
+wife,’ said he, as he puffed out a long curl of smoke, ‘for you and me
+to sit here by ourselves, without any children to play about and amuse
+us while other people seem so happy and merry with their children!’
+‘What you say is very true,’ said the wife, sighing, and turning round
+her wheel; ‘how happy should I be if I had but one child! If it were
+ever so small--nay, if it were no bigger than my thumb--I should be very
+happy, and love it dearly.’ Now--odd as you may think it--it came to
+pass that this good woman’s wish was fulfilled, just in the very way she
+had wished it; for, not long afterwards, she had a little boy, who was
+quite healthy and strong, but was not much bigger than my thumb. So
+they said, ‘Well, we cannot say we have not got what we wished for, and,
+little as he is, we will love him dearly.’ And they called him Thomas
+Thumb.
+
+They gave him plenty of food, yet for all they could do he never grew
+bigger, but kept just the same size as he had been when he was born.
+Still, his eyes were sharp and sparkling, and he soon showed himself to
+be a clever little fellow, who always knew well what he was about.
+
+One day, as the woodman was getting ready to go into the wood to cut
+fuel, he said, ‘I wish I had someone to bring the cart after me, for I
+want to make haste.’ ‘Oh, father,’ cried Tom, ‘I will take care of that;
+the cart shall be in the wood by the time you want it.’ Then the woodman
+laughed, and said, ‘How can that be? you cannot reach up to the horse’s
+bridle.’ ‘Never mind that, father,’ said Tom; ‘if my mother will only
+harness the horse, I will get into his ear and tell him which way to
+go.’ ‘Well,’ said the father, ‘we will try for once.’
+
+When the time came the mother harnessed the horse to the cart, and put
+Tom into his ear; and as he sat there the little man told the beast how
+to go, crying out, ‘Go on!’ and ‘Stop!’ as he wanted: and thus the horse
+went on just as well as if the woodman had driven it himself into the
+wood. It happened that as the horse was going a little too fast, and Tom
+was calling out, ‘Gently! gently!’ two strangers came up. ‘What an odd
+thing that is!’ said one: ‘there is a cart going along, and I hear a
+carter talking to the horse, but yet I can see no one.’ ‘That is queer,
+indeed,’ said the other; ‘let us follow the cart, and see where it
+goes.’ So they went on into the wood, till at last they came to the
+place where the woodman was. Then Tom Thumb, seeing his father, cried
+out, ‘See, father, here I am with the cart, all right and safe! now take
+me down!’ So his father took hold of the horse with one hand, and with
+the other took his son out of the horse’s ear, and put him down upon a
+straw, where he sat as merry as you please.
+
+The two strangers were all this time looking on, and did not know what
+to say for wonder. At last one took the other aside, and said, ‘That
+little urchin will make our fortune, if we can get him, and carry him
+about from town to town as a show; we must buy him.’ So they went up to
+the woodman, and asked him what he would take for the little man. ‘He
+will be better off,’ said they, ‘with us than with you.’ ‘I won’t sell
+him at all,’ said the father; ‘my own flesh and blood is dearer to me
+than all the silver and gold in the world.’ But Tom, hearing of the
+bargain they wanted to make, crept up his father’s coat to his shoulder
+and whispered in his ear, ‘Take the money, father, and let them have me;
+I’ll soon come back to you.’
+
+So the woodman at last said he would sell Tom to the strangers for a
+large piece of gold, and they paid the price. ‘Where would you like to
+sit?’ said one of them. ‘Oh, put me on the rim of your hat; that will be
+a nice gallery for me; I can walk about there and see the country as we
+go along.’ So they did as he wished; and when Tom had taken leave of his
+father they took him away with them.
+
+They journeyed on till it began to be dusky, and then the little man
+said, ‘Let me get down, I’m tired.’ So the man took off his hat, and
+put him down on a clod of earth, in a ploughed field by the side of the
+road. But Tom ran about amongst the furrows, and at last slipped into
+an old mouse-hole. ‘Good night, my masters!’ said he, ‘I’m off! mind and
+look sharp after me the next time.’ Then they ran at once to the place,
+and poked the ends of their sticks into the mouse-hole, but all in vain;
+Tom only crawled farther and farther in; and at last it became quite
+dark, so that they were forced to go their way without their prize, as
+sulky as could be.
+
+When Tom found they were gone, he came out of his hiding-place. ‘What
+dangerous walking it is,’ said he, ‘in this ploughed field! If I were to
+fall from one of these great clods, I should undoubtedly break my neck.’
+At last, by good luck, he found a large empty snail-shell. ‘This is
+lucky,’ said he, ‘I can sleep here very well’; and in he crept.
+
+Just as he was falling asleep, he heard two men passing by, chatting
+together; and one said to the other, ‘How can we rob that rich parson’s
+house of his silver and gold?’ ‘I’ll tell you!’ cried Tom. ‘What noise
+was that?’ said the thief, frightened; ‘I’m sure I heard someone speak.’
+They stood still listening, and Tom said, ‘Take me with you, and I’ll
+soon show you how to get the parson’s money.’ ‘But where are you?’ said
+they. ‘Look about on the ground,’ answered he, ‘and listen where the
+sound comes from.’ At last the thieves found him out, and lifted him
+up in their hands. ‘You little urchin!’ they said, ‘what can you do for
+us?’ ‘Why, I can get between the iron window-bars of the parson’s house,
+and throw you out whatever you want.’ ‘That’s a good thought,’ said the
+thieves; ‘come along, we shall see what you can do.’
+
+When they came to the parson’s house, Tom slipped through the
+window-bars into the room, and then called out as loud as he could bawl,
+‘Will you have all that is here?’ At this the thieves were frightened,
+and said, ‘Softly, softly! Speak low, that you may not awaken anybody.’
+But Tom seemed as if he did not understand them, and bawled out again,
+‘How much will you have? Shall I throw it all out?’ Now the cook lay in
+the next room; and hearing a noise she raised herself up in her bed and
+listened. Meantime the thieves were frightened, and ran off a little
+way; but at last they plucked up their hearts, and said, ‘The little
+urchin is only trying to make fools of us.’ So they came back and
+whispered softly to him, saying, ‘Now let us have no more of your
+roguish jokes; but throw us out some of the money.’ Then Tom called out
+as loud as he could, ‘Very well! hold your hands! here it comes.’
+
+The cook heard this quite plain, so she sprang out of bed, and ran to
+open the door. The thieves ran off as if a wolf was at their tails: and
+the maid, having groped about and found nothing, went away for a light.
+By the time she came back, Tom had slipped off into the barn; and when
+she had looked about and searched every hole and corner, and found
+nobody, she went to bed, thinking she must have been dreaming with her
+eyes open.
+
+The little man crawled about in the hay-loft, and at last found a snug
+place to finish his night’s rest in; so he laid himself down, meaning
+to sleep till daylight, and then find his way home to his father and
+mother. But alas! how woefully he was undone! what crosses and sorrows
+happen to us all in this world! The cook got up early, before daybreak,
+to feed the cows; and going straight to the hay-loft, carried away
+a large bundle of hay, with the little man in the middle of it, fast
+asleep. He still, however, slept on, and did not awake till he found
+himself in the mouth of the cow; for the cook had put the hay into the
+cow’s rick, and the cow had taken Tom up in a mouthful of it. ‘Good
+lack-a-day!’ said he, ‘how came I to tumble into the mill?’ But he soon
+found out where he really was; and was forced to have all his wits about
+him, that he might not get between the cow’s teeth, and so be crushed to
+death. At last down he went into her stomach. ‘It is rather dark,’ said
+he; ‘they forgot to build windows in this room to let the sun in; a
+candle would be no bad thing.’
+
+Though he made the best of his bad luck, he did not like his quarters at
+all; and the worst of it was, that more and more hay was always coming
+down, and the space left for him became smaller and smaller. At last he
+cried out as loud as he could, ‘Don’t bring me any more hay! Don’t bring
+me any more hay!’
+
+The maid happened to be just then milking the cow; and hearing someone
+speak, but seeing nobody, and yet being quite sure it was the same voice
+that she had heard in the night, she was so frightened that she fell off
+her stool, and overset the milk-pail. As soon as she could pick herself
+up out of the dirt, she ran off as fast as she could to her master the
+parson, and said, ‘Sir, sir, the cow is talking!’ But the parson
+said, ‘Woman, thou art surely mad!’ However, he went with her into the
+cow-house, to try and see what was the matter.
+
+Scarcely had they set foot on the threshold, when Tom called out, ‘Don’t
+bring me any more hay!’ Then the parson himself was frightened; and
+thinking the cow was surely bewitched, told his man to kill her on the
+spot. So the cow was killed, and cut up; and the stomach, in which Tom
+lay, was thrown out upon a dunghill.
+
+Tom soon set himself to work to get out, which was not a very easy
+task; but at last, just as he had made room to get his head out, fresh
+ill-luck befell him. A hungry wolf sprang out, and swallowed up the
+whole stomach, with Tom in it, at one gulp, and ran away.
+
+Tom, however, was still not disheartened; and thinking the wolf would
+not dislike having some chat with him as he was going along, he called
+out, ‘My good friend, I can show you a famous treat.’ ‘Where’s that?’
+said the wolf. ‘In such and such a house,’ said Tom, describing his own
+father’s house. ‘You can crawl through the drain into the kitchen and
+then into the pantry, and there you will find cakes, ham, beef, cold
+chicken, roast pig, apple-dumplings, and everything that your heart can
+wish.’
+
+The wolf did not want to be asked twice; so that very night he went to
+the house and crawled through the drain into the kitchen, and then into
+the pantry, and ate and drank there to his heart’s content. As soon as
+he had had enough he wanted to get away; but he had eaten so much that
+he could not go out by the same way he came in.
+
+This was just what Tom had reckoned upon; and now he began to set up a
+great shout, making all the noise he could. ‘Will you be easy?’ said the
+wolf; ‘you’ll awaken everybody in the house if you make such a clatter.’
+‘What’s that to me?’ said the little man; ‘you have had your frolic, now
+I’ve a mind to be merry myself’; and he began, singing and shouting as
+loud as he could.
+
+The woodman and his wife, being awakened by the noise, peeped through
+a crack in the door; but when they saw a wolf was there, you may well
+suppose that they were sadly frightened; and the woodman ran for his
+axe, and gave his wife a scythe. ‘Do you stay behind,’ said the woodman,
+‘and when I have knocked him on the head you must rip him up with the
+scythe.’ Tom heard all this, and cried out, ‘Father, father! I am here,
+the wolf has swallowed me.’ And his father said, ‘Heaven be praised! we
+have found our dear child again’; and he told his wife not to use the
+scythe for fear she should hurt him. Then he aimed a great blow, and
+struck the wolf on the head, and killed him on the spot! and when he was
+dead they cut open his body, and set Tommy free. ‘Ah!’ said the father,
+‘what fears we have had for you!’ ‘Yes, father,’ answered he; ‘I have
+travelled all over the world, I think, in one way or other, since we
+parted; and now I am very glad to come home and get fresh air again.’
+‘Why, where have you been?’ said his father. ‘I have been in a
+mouse-hole--and in a snail-shell--and down a cow’s throat--and in the
+wolf’s belly; and yet here I am again, safe and sound.’
+
+‘Well,’ said they, ‘you are come back, and we will not sell you again
+for all the riches in the world.’
+
+Then they hugged and kissed their dear little son, and gave him plenty
+to eat and drink, for he was very hungry; and then they fetched new
+clothes for him, for his old ones had been quite spoiled on his journey.
+So Master Thumb stayed at home with his father and mother, in peace; for
+though he had been so great a traveller, and had done and seen so many
+fine things, and was fond enough of telling the whole story, he always
+agreed that, after all, there’s no place like HOME!
+
+
+
+
+RUMPELSTILTSKIN
+
+By the side of a wood, in a country a long way off, ran a fine stream
+of water; and upon the stream there stood a mill. The miller’s house was
+close by, and the miller, you must know, had a very beautiful daughter.
+She was, moreover, very shrewd and clever; and the miller was so proud
+of her, that he one day told the king of the land, who used to come and
+hunt in the wood, that his daughter could spin gold out of straw. Now
+this king was very fond of money; and when he heard the miller’s boast
+his greediness was raised, and he sent for the girl to be brought before
+him. Then he led her to a chamber in his palace where there was a great
+heap of straw, and gave her a spinning-wheel, and said, ‘All this must
+be spun into gold before morning, as you love your life.’ It was in vain
+that the poor maiden said that it was only a silly boast of her father,
+for that she could do no such thing as spin straw into gold: the chamber
+door was locked, and she was left alone.
+
+She sat down in one corner of the room, and began to bewail her hard
+fate; when on a sudden the door opened, and a droll-looking little man
+hobbled in, and said, ‘Good morrow to you, my good lass; what are you
+weeping for?’ ‘Alas!’ said she, ‘I must spin this straw into gold, and
+I know not how.’ ‘What will you give me,’ said the hobgoblin, ‘to do it
+for you?’ ‘My necklace,’ replied the maiden. He took her at her word,
+and sat himself down to the wheel, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+And round about the wheel went merrily; the work was quickly done, and
+the straw was all spun into gold.
+
+When the king came and saw this, he was greatly astonished and pleased;
+but his heart grew still more greedy of gain, and he shut up the poor
+miller’s daughter again with a fresh task. Then she knew not what to do,
+and sat down once more to weep; but the dwarf soon opened the door, and
+said, ‘What will you give me to do your task?’ ‘The ring on my finger,’
+said she. So her little friend took the ring, and began to work at the
+wheel again, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+till, long before morning, all was done again.
+
+The king was greatly delighted to see all this glittering treasure;
+but still he had not enough: so he took the miller’s daughter to a yet
+larger heap, and said, ‘All this must be spun tonight; and if it is,
+you shall be my queen.’ As soon as she was alone that dwarf came in, and
+said, ‘What will you give me to spin gold for you this third time?’
+‘I have nothing left,’ said she. ‘Then say you will give me,’ said
+the little man, ‘the first little child that you may have when you are
+queen.’ ‘That may never be,’ thought the miller’s daughter: and as she
+knew no other way to get her task done, she said she would do what he
+asked. Round went the wheel again to the old song, and the manikin once
+more spun the heap into gold. The king came in the morning, and, finding
+all he wanted, was forced to keep his word; so he married the miller’s
+daughter, and she really became queen.
+
+At the birth of her first little child she was very glad, and forgot the
+dwarf, and what she had said. But one day he came into her room, where
+she was sitting playing with her baby, and put her in mind of it. Then
+she grieved sorely at her misfortune, and said she would give him all
+the wealth of the kingdom if he would let her off, but in vain; till at
+last her tears softened him, and he said, ‘I will give you three days’
+grace, and if during that time you tell me my name, you shall keep your
+child.’
+
+Now the queen lay awake all night, thinking of all the odd names that
+she had ever heard; and she sent messengers all over the land to find
+out new ones. The next day the little man came, and she began with
+TIMOTHY, ICHABOD, BENJAMIN, JEREMIAH, and all the names she could
+remember; but to all and each of them he said, ‘Madam, that is not my
+name.’
+
+The second day she began with all the comical names she could hear of,
+BANDY-LEGS, HUNCHBACK, CROOK-SHANKS, and so on; but the little gentleman
+still said to every one of them, ‘Madam, that is not my name.’
+
+The third day one of the messengers came back, and said, ‘I have
+travelled two days without hearing of any other names; but yesterday, as
+I was climbing a high hill, among the trees of the forest where the fox
+and the hare bid each other good night, I saw a little hut; and before
+the hut burnt a fire; and round about the fire a funny little dwarf was
+dancing upon one leg, and singing:
+
+ “Merrily the feast I’ll make.
+  Today I’ll brew, tomorrow bake;
+  Merrily I’ll dance and sing,
+  For next day will a stranger bring.
+  Little does my lady dream
+  Rumpelstiltskin is my name!”
+
+When the queen heard this she jumped for joy, and as soon as her little
+friend came she sat down upon her throne, and called all her court round
+to enjoy the fun; and the nurse stood by her side with the baby in her
+arms, as if it was quite ready to be given up. Then the little man began
+to chuckle at the thought of having the poor child, to take home with
+him to his hut in the woods; and he cried out, ‘Now, lady, what is my
+name?’ ‘Is it JOHN?’ asked she. ‘No, madam!’ ‘Is it TOM?’ ‘No, madam!’
+‘Is it JEMMY?’ ‘It is not.’ ‘Can your name be RUMPELSTILTSKIN?’ said the
+lady slyly. ‘Some witch told you that!--some witch told you that!’ cried
+the little man, and dashed his right foot in a rage so deep into the
+floor, that he was forced to lay hold of it with both hands to pull it
+out.
+
+Then he made the best of his way off, while the nurse laughed and the
+baby crowed; and all the court jeered at him for having had so much
+trouble for nothing, and said, ‘We wish you a very good morning, and a
+merry feast, Mr RUMPLESTILTSKIN!’
+
+
+
+
+CLEVER GRETEL
+
+There was once a cook named Gretel, who wore shoes with red heels, and
+when she walked out with them on, she turned herself this way and that,
+was quite happy and thought: ‘You certainly are a pretty girl!’ And when
+she came home she drank, in her gladness of heart, a draught of wine,
+and as wine excites a desire to eat, she tasted the best of whatever she
+was cooking until she was satisfied, and said: ‘The cook must know what
+the food is like.’
+
+It came to pass that the master one day said to her: ‘Gretel, there is a
+guest coming this evening; prepare me two fowls very daintily.’ ‘I will
+see to it, master,’ answered Gretel. She killed two fowls, scalded them,
+plucked them, put them on the spit, and towards evening set them before
+the fire, that they might roast. The fowls began to turn brown, and were
+nearly ready, but the guest had not yet arrived. Then Gretel called out
+to her master: ‘If the guest does not come, I must take the fowls away
+from the fire, but it will be a sin and a shame if they are not eaten
+the moment they are at their juiciest.’ The master said: ‘I will run
+myself, and fetch the guest.’ When the master had turned his back,
+Gretel laid the spit with the fowls on one side, and thought: ‘Standing
+so long by the fire there, makes one sweat and thirsty; who knows
+when they will come? Meanwhile, I will run into the cellar, and take a
+drink.’ She ran down, set a jug, said: ‘God bless it for you, Gretel,’
+and took a good drink, and thought that wine should flow on, and should
+not be interrupted, and took yet another hearty draught.
+
+Then she went and put the fowls down again to the fire, basted them,
+and drove the spit merrily round. But as the roast meat smelt so good,
+Gretel thought: ‘Something might be wrong, it ought to be tasted!’
+She touched it with her finger, and said: ‘Ah! how good fowls are! It
+certainly is a sin and a shame that they are not eaten at the right
+time!’ She ran to the window, to see if the master was not coming with
+his guest, but she saw no one, and went back to the fowls and thought:
+‘One of the wings is burning! I had better take it off and eat it.’
+So she cut it off, ate it, and enjoyed it, and when she had done, she
+thought: ‘The other must go down too, or else master will observe that
+something is missing.’ When the two wings were eaten, she went and
+looked for her master, and did not see him. It suddenly occurred to
+her: ‘Who knows? They are perhaps not coming at all, and have turned in
+somewhere.’ Then she said: ‘Well, Gretel, enjoy yourself, one fowl has
+been cut into, take another drink, and eat it up entirely; when it is
+eaten you will have some peace, why should God’s good gifts be spoilt?’
+So she ran into the cellar again, took an enormous drink and ate up the
+one chicken in great glee. When one of the chickens was swallowed down,
+and still her master did not come, Gretel looked at the other and said:
+‘What one is, the other should be likewise, the two go together; what’s
+right for the one is right for the other; I think if I were to take
+another draught it would do me no harm.’ So she took another hearty
+drink, and let the second chicken follow the first.
+
+While she was making the most of it, her master came and cried: ‘Hurry
+up, Gretel, the guest is coming directly after me!’ ‘Yes, sir, I will
+soon serve up,’ answered Gretel. Meantime the master looked to see that
+the table was properly laid, and took the great knife, wherewith he was
+going to carve the chickens, and sharpened it on the steps. Presently
+the guest came, and knocked politely and courteously at the house-door.
+Gretel ran, and looked to see who was there, and when she saw the guest,
+she put her finger to her lips and said: ‘Hush! hush! go away as quickly
+as you can, if my master catches you it will be the worse for you; he
+certainly did ask you to supper, but his intention is to cut off your
+two ears. Just listen how he is sharpening the knife for it!’ The guest
+heard the sharpening, and hurried down the steps again as fast as he
+could. Gretel was not idle; she ran screaming to her master, and cried:
+‘You have invited a fine guest!’ ‘Why, Gretel? What do you mean by
+that?’ ‘Yes,’ said she, ‘he has taken the chickens which I was just
+going to serve up, off the dish, and has run away with them!’ ‘That’s a
+nice trick!’ said her master, and lamented the fine chickens. ‘If he had
+but left me one, so that something remained for me to eat.’ He called to
+him to stop, but the guest pretended not to hear. Then he ran after him
+with the knife still in his hand, crying: ‘Just one, just one,’ meaning
+that the guest should leave him just one chicken, and not take both. The
+guest, however, thought no otherwise than that he was to give up one of
+his ears, and ran as if fire were burning under him, in order to take
+them both with him.
+
+
+
+
+THE OLD MAN AND HIS GRANDSON
+
+There was once a very old man, whose eyes had become dim, his ears dull
+of hearing, his knees trembled, and when he sat at table he could hardly
+hold the spoon, and spilt the broth upon the table-cloth or let it run
+out of his mouth. His son and his son’s wife were disgusted at this, so
+the old grandfather at last had to sit in the corner behind the stove,
+and they gave him his food in an earthenware bowl, and not even enough
+of it. And he used to look towards the table with his eyes full of
+tears. Once, too, his trembling hands could not hold the bowl, and it
+fell to the ground and broke. The young wife scolded him, but he said
+nothing and only sighed. Then they brought him a wooden bowl for a few
+half-pence, out of which he had to eat.
+
+They were once sitting thus when the little grandson of four years old
+began to gather together some bits of wood upon the ground. ‘What are
+you doing there?’ asked the father. ‘I am making a little trough,’
+answered the child, ‘for father and mother to eat out of when I am big.’
+
+The man and his wife looked at each other for a while, and presently
+began to cry. Then they took the old grandfather to the table, and
+henceforth always let him eat with them, and likewise said nothing if he
+did spill a little of anything.
+
+
+
+
+THE LITTLE PEASANT
+
+There was a certain village wherein no one lived but really rich
+peasants, and just one poor one, whom they called the little peasant. He
+had not even so much as a cow, and still less money to buy one, and
+yet he and his wife did so wish to have one. One day he said to her:
+‘Listen, I have a good idea, there is our gossip the carpenter, he shall
+make us a wooden calf, and paint it brown, so that it looks like any
+other, and in time it will certainly get big and be a cow.’ the woman
+also liked the idea, and their gossip the carpenter cut and planed
+the calf, and painted it as it ought to be, and made it with its head
+hanging down as if it were eating.
+
+Next morning when the cows were being driven out, the little peasant
+called the cow-herd in and said: ‘Look, I have a little calf there,
+but it is still small and has to be carried.’ The cow-herd said: ‘All
+right,’ and took it in his arms and carried it to the pasture, and set
+it among the grass. The little calf always remained standing like one
+which was eating, and the cow-herd said: ‘It will soon run by itself,
+just look how it eats already!’ At night when he was going to drive the
+herd home again, he said to the calf: ‘If you can stand there and eat
+your fill, you can also go on your four legs; I don’t care to drag you
+home again in my arms.’ But the little peasant stood at his door, and
+waited for his little calf, and when the cow-herd drove the cows through
+the village, and the calf was missing, he inquired where it was. The
+cow-herd answered: ‘It is still standing out there eating. It would not
+stop and come with us.’ But the little peasant said: ‘Oh, but I must
+have my beast back again.’ Then they went back to the meadow together,
+but someone had stolen the calf, and it was gone. The cow-herd said: ‘It
+must have run away.’ The peasant, however, said: ‘Don’t tell me
+that,’ and led the cow-herd before the mayor, who for his carelessness
+condemned him to give the peasant a cow for the calf which had run away.
+
+And now the little peasant and his wife had the cow for which they had
+so long wished, and they were heartily glad, but they had no food for
+it, and could give it nothing to eat, so it soon had to be killed. They
+salted the flesh, and the peasant went into the town and wanted to sell
+the skin there, so that he might buy a new calf with the proceeds. On
+the way he passed by a mill, and there sat a raven with broken wings,
+and out of pity he took him and wrapped him in the skin. But as the
+weather grew so bad and there was a storm of rain and wind, he could
+go no farther, and turned back to the mill and begged for shelter. The
+miller’s wife was alone in the house, and said to the peasant: ‘Lay
+yourself on the straw there,’ and gave him a slice of bread and cheese.
+The peasant ate it, and lay down with his skin beside him, and the woman
+thought: ‘He is tired and has gone to sleep.’ In the meantime came the
+parson; the miller’s wife received him well, and said: ‘My husband is
+out, so we will have a feast.’ The peasant listened, and when he heard
+them talk about feasting he was vexed that he had been forced to make
+shift with a slice of bread and cheese. Then the woman served up four
+different things, roast meat, salad, cakes, and wine.
+
+Just as they were about to sit down and eat, there was a knocking
+outside. The woman said: ‘Oh, heavens! It is my husband!’ she quickly
+hid the roast meat inside the tiled stove, the wine under the pillow,
+the salad on the bed, the cakes under it, and the parson in the closet
+on the porch. Then she opened the door for her husband, and said: ‘Thank
+heaven, you are back again! There is such a storm, it looks as if the
+world were coming to an end.’ The miller saw the peasant lying on the
+straw, and asked, ‘What is that fellow doing there?’ ‘Ah,’ said the
+wife, ‘the poor knave came in the storm and rain, and begged for
+shelter, so I gave him a bit of bread and cheese, and showed him where
+the straw was.’ The man said: ‘I have no objection, but be quick and get
+me something to eat.’ The woman said: ‘But I have nothing but bread and
+cheese.’ ‘I am contented with anything,’ replied the husband, ‘so far as
+I am concerned, bread and cheese will do,’ and looked at the peasant and
+said: ‘Come and eat some more with me.’ The peasant did not require to
+be invited twice, but got up and ate. After this the miller saw the skin
+in which the raven was, lying on the ground, and asked: ‘What have you
+there?’ The peasant answered: ‘I have a soothsayer inside it.’ ‘Can
+he foretell anything to me?’ said the miller. ‘Why not?’ answered
+the peasant: ‘but he only says four things, and the fifth he keeps to
+himself.’ The miller was curious, and said: ‘Let him foretell something
+for once.’ Then the peasant pinched the raven’s head, so that he croaked
+and made a noise like krr, krr. The miller said: ‘What did he say?’ The
+peasant answered: ‘In the first place, he says that there is some wine
+hidden under the pillow.’ ‘Bless me!’ cried the miller, and went there
+and found the wine. ‘Now go on,’ said he. The peasant made the raven
+croak again, and said: ‘In the second place, he says that there is some
+roast meat in the tiled stove.’ ‘Upon my word!’ cried the miller, and
+went thither, and found the roast meat. The peasant made the raven
+prophesy still more, and said: ‘Thirdly, he says that there is some
+salad on the bed.’ ‘That would be a fine thing!’ cried the miller, and
+went there and found the salad. At last the peasant pinched the raven
+once more till he croaked, and said: ‘Fourthly, he says that there
+are some cakes under the bed.’ ‘That would be a fine thing!’ cried the
+miller, and looked there, and found the cakes.
+
+And now the two sat down to the table together, but the miller’s wife
+was frightened to death, and went to bed and took all the keys with
+her. The miller would have liked much to know the fifth, but the little
+peasant said: ‘First, we will quickly eat the four things, for the fifth
+is something bad.’ So they ate, and after that they bargained how much
+the miller was to give for the fifth prophecy, until they agreed on
+three hundred talers. Then the peasant once more pinched the raven’s
+head till he croaked loudly. The miller asked: ‘What did he say?’ The
+peasant replied: ‘He says that the Devil is hiding outside there in
+the closet on the porch.’ The miller said: ‘The Devil must go out,’ and
+opened the house-door; then the woman was forced to give up the keys,
+and the peasant unlocked the closet. The parson ran out as fast as he
+could, and the miller said: ‘It was true; I saw the black rascal with my
+own eyes.’ The peasant, however, made off next morning by daybreak with
+the three hundred talers.
+
+At home the small peasant gradually launched out; he built a beautiful
+house, and the peasants said: ‘The small peasant has certainly been to
+the place where golden snow falls, and people carry the gold home in
+shovels.’ Then the small peasant was brought before the mayor, and
+bidden to say from whence his wealth came. He answered: ‘I sold my cow’s
+skin in the town, for three hundred talers.’ When the peasants heard
+that, they too wished to enjoy this great profit, and ran home, killed
+all their cows, and stripped off their skins in order to sell them in
+the town to the greatest advantage. The mayor, however, said: ‘But my
+servant must go first.’ When she came to the merchant in the town, he
+did not give her more than two talers for a skin, and when the others
+came, he did not give them so much, and said: ‘What can I do with all
+these skins?’
+
+Then the peasants were vexed that the small peasant should have thus
+outwitted them, wanted to take vengeance on him, and accused him of this
+treachery before the mayor. The innocent little peasant was unanimously
+sentenced to death, and was to be rolled into the water, in a barrel
+pierced full of holes. He was led forth, and a priest was brought who
+was to say a mass for his soul. The others were all obliged to retire to
+a distance, and when the peasant looked at the priest, he recognized the
+man who had been with the miller’s wife. He said to him: ‘I set you free
+from the closet, set me free from the barrel.’ At this same moment up
+came, with a flock of sheep, the very shepherd whom the peasant knew had
+long been wishing to be mayor, so he cried with all his might: ‘No, I
+will not do it; if the whole world insists on it, I will not do it!’ The
+shepherd hearing that, came up to him, and asked: ‘What are you about?
+What is it that you will not do?’ The peasant said: ‘They want to make
+me mayor, if I will but put myself in the barrel, but I will not do it.’
+The shepherd said: ‘If nothing more than that is needful in order to be
+mayor, I would get into the barrel at once.’ The peasant said: ‘If you
+will get in, you will be mayor.’ The shepherd was willing, and got in,
+and the peasant shut the top down on him; then he took the shepherd’s
+flock for himself, and drove it away. The parson went to the crowd,
+and declared that the mass had been said. Then they came and rolled the
+barrel towards the water. When the barrel began to roll, the shepherd
+cried: ‘I am quite willing to be mayor.’ They believed no otherwise than
+that it was the peasant who was saying this, and answered: ‘That is
+what we intend, but first you shall look about you a little down below
+there,’ and they rolled the barrel down into the water.
+
+After that the peasants went home, and as they were entering the
+village, the small peasant also came quietly in, driving a flock of
+sheep and looking quite contented. Then the peasants were astonished,
+and said: ‘Peasant, from whence do you come? Have you come out of the
+water?’ ‘Yes, truly,’ replied the peasant, ‘I sank deep, deep down,
+until at last I got to the bottom; I pushed the bottom out of the
+barrel, and crept out, and there were pretty meadows on which a number
+of lambs were feeding, and from thence I brought this flock away with
+me.’ Said the peasants: ‘Are there any more there?’ ‘Oh, yes,’ said he,
+‘more than I could want.’ Then the peasants made up their minds that
+they too would fetch some sheep for themselves, a flock apiece, but the
+mayor said: ‘I come first.’ So they went to the water together, and just
+then there were some of the small fleecy clouds in the blue sky, which
+are called little lambs, and they were reflected in the water, whereupon
+the peasants cried: ‘We already see the sheep down below!’ The mayor
+pressed forward and said: ‘I will go down first, and look about me, and
+if things promise well I’ll call you.’ So he jumped in; splash! went
+the water; it sounded as if he were calling them, and the whole crowd
+plunged in after him as one man. Then the entire village was dead, and
+the small peasant, as sole heir, became a rich man.
+
+
+
+
+FREDERICK AND CATHERINE
+
+There was once a man called Frederick: he had a wife whose name was
+Catherine, and they had not long been married. One day Frederick said.
+‘Kate! I am going to work in the fields; when I come back I shall be
+hungry so let me have something nice cooked, and a good draught of ale.’
+‘Very well,’ said she, ‘it shall all be ready.’ When dinner-time drew
+nigh, Catherine took a nice steak, which was all the meat she had, and
+put it on the fire to fry. The steak soon began to look brown, and to
+crackle in the pan; and Catherine stood by with a fork and turned it:
+then she said to herself, ‘The steak is almost ready, I may as well go
+to the cellar for the ale.’ So she left the pan on the fire and took a
+large jug and went into the cellar and tapped the ale cask. The beer ran
+into the jug and Catherine stood looking on. At last it popped into her
+head, ‘The dog is not shut up--he may be running away with the steak;
+that’s well thought of.’ So up she ran from the cellar; and sure enough
+the rascally cur had got the steak in his mouth, and was making off with
+it.
+
+Away ran Catherine, and away ran the dog across the field: but he ran
+faster than she, and stuck close to the steak. ‘It’s all gone, and “what
+can’t be cured must be endured”,’ said Catherine. So she turned round;
+and as she had run a good way and was tired, she walked home leisurely
+to cool herself.
+
+Now all this time the ale was running too, for Catherine had not turned
+the cock; and when the jug was full the liquor ran upon the floor till
+the cask was empty. When she got to the cellar stairs she saw what had
+happened. ‘My stars!’ said she, ‘what shall I do to keep Frederick from
+seeing all this slopping about?’ So she thought a while; and at last
+remembered that there was a sack of fine meal bought at the last fair,
+and that if she sprinkled this over the floor it would suck up the ale
+nicely. ‘What a lucky thing,’ said she, ‘that we kept that meal! we have
+now a good use for it.’ So away she went for it: but she managed to set
+it down just upon the great jug full of beer, and upset it; and thus
+all the ale that had been saved was set swimming on the floor also. ‘Ah!
+well,’ said she, ‘when one goes another may as well follow.’ Then she
+strewed the meal all about the cellar, and was quite pleased with her
+cleverness, and said, ‘How very neat and clean it looks!’
+
+At noon Frederick came home. ‘Now, wife,’ cried he, ‘what have you for
+dinner?’ ‘O Frederick!’ answered she, ‘I was cooking you a steak; but
+while I went down to draw the ale, the dog ran away with it; and while
+I ran after him, the ale ran out; and when I went to dry up the ale
+with the sack of meal that we got at the fair, I upset the jug: but the
+cellar is now quite dry, and looks so clean!’ ‘Kate, Kate,’ said he,
+‘how could you do all this?’ Why did you leave the steak to fry, and the
+ale to run, and then spoil all the meal?’ ‘Why, Frederick,’ said she, ‘I
+did not know I was doing wrong; you should have told me before.’
+
+The husband thought to himself, ‘If my wife manages matters thus, I must
+look sharp myself.’ Now he had a good deal of gold in the house: so he
+said to Catherine, ‘What pretty yellow buttons these are! I shall put
+them into a box and bury them in the garden; but take care that you
+never go near or meddle with them.’ ‘No, Frederick,’ said she, ‘that
+I never will.’ As soon as he was gone, there came by some pedlars with
+earthenware plates and dishes, and they asked her whether she would buy.
+‘Oh dear me, I should like to buy very much, but I have no money: if
+you had any use for yellow buttons, I might deal with you.’ ‘Yellow
+buttons!’ said they: ‘let us have a look at them.’ ‘Go into the garden
+and dig where I tell you, and you will find the yellow buttons: I dare
+not go myself.’ So the rogues went: and when they found what these
+yellow buttons were, they took them all away, and left her plenty of
+plates and dishes. Then she set them all about the house for a show:
+and when Frederick came back, he cried out, ‘Kate, what have you been
+doing?’ ‘See,’ said she, ‘I have bought all these with your yellow
+buttons: but I did not touch them myself; the pedlars went themselves
+and dug them up.’ ‘Wife, wife,’ said Frederick, ‘what a pretty piece of
+work you have made! those yellow buttons were all my money: how came you
+to do such a thing?’ ‘Why,’ answered she, ‘I did not know there was any
+harm in it; you should have told me.’
+
+Catherine stood musing for a while, and at last said to her husband,
+‘Hark ye, Frederick, we will soon get the gold back: let us run after
+the thieves.’ ‘Well, we will try,’ answered he; ‘but take some butter
+and cheese with you, that we may have something to eat by the way.’
+‘Very well,’ said she; and they set out: and as Frederick walked the
+fastest, he left his wife some way behind. ‘It does not matter,’ thought
+she: ‘when we turn back, I shall be so much nearer home than he.’
+
+Presently she came to the top of a hill, down the side of which there
+was a road so narrow that the cart wheels always chafed the trees
+on each side as they passed. ‘Ah, see now,’ said she, ‘how they have
+bruised and wounded those poor trees; they will never get well.’ So she
+took pity on them, and made use of the butter to grease them all, so
+that the wheels might not hurt them so much. While she was doing this
+kind office one of her cheeses fell out of the basket, and rolled down
+the hill. Catherine looked, but could not see where it had gone; so she
+said, ‘Well, I suppose the other will go the same way and find you; he
+has younger legs than I have.’ Then she rolled the other cheese after
+it; and away it went, nobody knows where, down the hill. But she said
+she supposed that they knew the road, and would follow her, and she
+could not stay there all day waiting for them.
+
+At last she overtook Frederick, who desired her to give him something to
+eat. Then she gave him the dry bread. ‘Where are the butter and cheese?’
+said he. ‘Oh!’ answered she, ‘I used the butter to grease those poor
+trees that the wheels chafed so: and one of the cheeses ran away so I
+sent the other after it to find it, and I suppose they are both on
+the road together somewhere.’ ‘What a goose you are to do such silly
+things!’ said the husband. ‘How can you say so?’ said she; ‘I am sure
+you never told me not.’
+
+They ate the dry bread together; and Frederick said, ‘Kate, I hope you
+locked the door safe when you came away.’ ‘No,’ answered she, ‘you did
+not tell me.’ ‘Then go home, and do it now before we go any farther,’
+said Frederick, ‘and bring with you something to eat.’
+
+Catherine did as he told her, and thought to herself by the way,
+‘Frederick wants something to eat; but I don’t think he is very fond of
+butter and cheese: I’ll bring him a bag of fine nuts, and the vinegar,
+for I have often seen him take some.’
+
+When she reached home, she bolted the back door, but the front door she
+took off the hinges, and said, ‘Frederick told me to lock the door, but
+surely it can nowhere be so safe if I take it with me.’ So she took
+her time by the way; and when she overtook her husband she cried
+out, ‘There, Frederick, there is the door itself, you may watch it as
+carefully as you please.’ ‘Alas! alas!’ said he, ‘what a clever wife I
+have! I sent you to make the house fast, and you take the door away, so
+that everybody may go in and out as they please--however, as you have
+brought the door, you shall carry it about with you for your pains.’
+‘Very well,’ answered she, ‘I’ll carry the door; but I’ll not carry the
+nuts and vinegar bottle also--that would be too much of a load; so if
+you please, I’ll fasten them to the door.’
+
+Frederick of course made no objection to that plan, and they set off
+into the wood to look for the thieves; but they could not find them: and
+when it grew dark, they climbed up into a tree to spend the night there.
+Scarcely were they up, than who should come by but the very rogues they
+were looking for. They were in truth great rascals, and belonged to that
+class of people who find things before they are lost; they were tired;
+so they sat down and made a fire under the very tree where Frederick and
+Catherine were. Frederick slipped down on the other side, and picked up
+some stones. Then he climbed up again, and tried to hit the thieves on
+the head with them: but they only said, ‘It must be near morning, for
+the wind shakes the fir-apples down.’
+
+Catherine, who had the door on her shoulder, began to be very tired;
+but she thought it was the nuts upon it that were so heavy: so she said
+softly, ‘Frederick, I must let the nuts go.’ ‘No,’ answered he, ‘not
+now, they will discover us.’ ‘I can’t help that: they must go.’ ‘Well,
+then, make haste and throw them down, if you will.’ Then away rattled
+the nuts down among the boughs and one of the thieves cried, ‘Bless me,
+it is hailing.’
+
+A little while after, Catherine thought the door was still very heavy:
+so she whispered to Frederick, ‘I must throw the vinegar down.’ ‘Pray
+don’t,’ answered he, ‘it will discover us.’ ‘I can’t help that,’ said
+she, ‘go it must.’ So she poured all the vinegar down; and the thieves
+said, ‘What a heavy dew there is!’
+
+At last it popped into Catherine’s head that it was the door itself that
+was so heavy all the time: so she whispered, ‘Frederick, I must throw
+the door down soon.’ But he begged and prayed her not to do so, for he
+was sure it would betray them. ‘Here goes, however,’ said she: and down
+went the door with such a clatter upon the thieves, that they cried
+out ‘Murder!’ and not knowing what was coming, ran away as fast as they
+could, and left all the gold. So when Frederick and Catherine came down,
+there they found all their money safe and sound.
+
+
+
+
+SWEETHEART ROLAND
+
+There was once upon a time a woman who was a real witch and had two
+daughters, one ugly and wicked, and this one she loved because she was
+her own daughter, and one beautiful and good, and this one she hated,
+because she was her stepdaughter. The stepdaughter once had a pretty
+apron, which the other fancied so much that she became envious, and
+told her mother that she must and would have that apron. ‘Be quiet, my
+child,’ said the old woman, ‘and you shall have it. Your stepsister has
+long deserved death; tonight when she is asleep I will come and cut her
+head off. Only be careful that you are at the far side of the bed, and
+push her well to the front.’ It would have been all over with the poor
+girl if she had not just then been standing in a corner, and heard
+everything. All day long she dared not go out of doors, and when bedtime
+had come, the witch’s daughter got into bed first, so as to lie at the
+far side, but when she was asleep, the other pushed her gently to the
+front, and took for herself the place at the back, close by the wall. In
+the night, the old woman came creeping in, she held an axe in her right
+hand, and felt with her left to see if anyone were lying at the outside,
+and then she grasped the axe with both hands, and cut her own child’s
+head off.
+
+When she had gone away, the girl got up and went to her sweetheart, who
+was called Roland, and knocked at his door. When he came out, she said
+to him: ‘Listen, dearest Roland, we must fly in all haste; my stepmother
+wanted to kill me, but has struck her own child. When daylight comes,
+and she sees what she has done, we shall be lost.’ ‘But,’ said Roland,
+‘I counsel you first to take away her magic wand, or we cannot escape
+if she pursues us.’ The maiden fetched the magic wand, and she took the
+dead girl’s head and dropped three drops of blood on the ground, one in
+front of the bed, one in the kitchen, and one on the stairs. Then she
+hurried away with her lover.
+
+When the old witch got up next morning, she called her daughter, and
+wanted to give her the apron, but she did not come. Then the witch
+cried: ‘Where are you?’ ‘Here, on the stairs, I am sweeping,’ answered
+the first drop of blood. The old woman went out, but saw no one on the
+stairs, and cried again: ‘Where are you?’ ‘Here in the kitchen, I am
+warming myself,’ cried the second drop of blood. She went into the
+kitchen, but found no one. Then she cried again: ‘Where are you?’ ‘Ah,
+here in the bed, I am sleeping,’ cried the third drop of blood. She went
+into the room to the bed. What did she see there? Her own child,
+whose head she had cut off, bathed in her blood. The witch fell into
+a passion, sprang to the window, and as she could look forth quite far
+into the world, she perceived her stepdaughter hurrying away with her
+sweetheart Roland. ‘That shall not help you,’ cried she, ‘even if you
+have got a long way off, you shall still not escape me.’ She put on her
+many-league boots, in which she covered an hour’s walk at every step,
+and it was not long before she overtook them. The girl, however, when
+she saw the old woman striding towards her, changed, with her magic
+wand, her sweetheart Roland into a lake, and herself into a duck
+swimming in the middle of it. The witch placed herself on the shore,
+threw breadcrumbs in, and went to endless trouble to entice the duck;
+but the duck did not let herself be enticed, and the old woman had to
+go home at night as she had come. At this the girl and her sweetheart
+Roland resumed their natural shapes again, and they walked on the whole
+night until daybreak. Then the maiden changed herself into a beautiful
+flower which stood in the midst of a briar hedge, and her sweetheart
+Roland into a fiddler. It was not long before the witch came striding up
+towards them, and said to the musician: ‘Dear musician, may I pluck that
+beautiful flower for myself?’ ‘Oh, yes,’ he replied, ‘I will play to
+you while you do it.’ As she was hastily creeping into the hedge and was
+just going to pluck the flower, knowing perfectly well who the flower
+was, he began to play, and whether she would or not, she was forced
+to dance, for it was a magical dance. The faster he played, the more
+violent springs was she forced to make, and the thorns tore her clothes
+from her body, and pricked her and wounded her till she bled, and as he
+did not stop, she had to dance till she lay dead on the ground.
+
+As they were now set free, Roland said: ‘Now I will go to my father and
+arrange for the wedding.’ ‘Then in the meantime I will stay here and
+wait for you,’ said the girl, ‘and that no one may recognize me, I will
+change myself into a red stone landmark.’ Then Roland went away, and the
+girl stood like a red landmark in the field and waited for her beloved.
+But when Roland got home, he fell into the snares of another, who so
+fascinated him that he forgot the maiden. The poor girl remained there a
+long time, but at length, as he did not return at all, she was sad, and
+changed herself into a flower, and thought: ‘Someone will surely come
+this way, and trample me down.’
+
+It befell, however, that a shepherd kept his sheep in the field and saw
+the flower, and as it was so pretty, plucked it, took it with him, and
+laid it away in his chest. From that time forth, strange things happened
+in the shepherd’s house. When he arose in the morning, all the work was
+already done, the room was swept, the table and benches cleaned, the
+fire in the hearth was lighted, and the water was fetched, and at noon,
+when he came home, the table was laid, and a good dinner served. He
+could not conceive how this came to pass, for he never saw a human being
+in his house, and no one could have concealed himself in it. He was
+certainly pleased with this good attendance, but still at last he was so
+afraid that he went to a wise woman and asked for her advice. The wise
+woman said: ‘There is some enchantment behind it, listen very early some
+morning if anything is moving in the room, and if you see anything, no
+matter what it is, throw a white cloth over it, and then the magic will
+be stopped.’
+
+The shepherd did as she bade him, and next morning just as day dawned,
+he saw the chest open, and the flower come out. Swiftly he
+sprang towards it, and threw a white cloth over it. Instantly the
+transformation came to an end, and a beautiful girl stood before him,
+who admitted to him that she had been the flower, and that up to this
+time she had attended to his house-keeping. She told him her story,
+and as she pleased him he asked her if she would marry him, but she
+answered: ‘No,’ for she wanted to remain faithful to her sweetheart
+Roland, although he had deserted her. Nevertheless, she promised not to
+go away, but to continue keeping house for the shepherd.
+
+And now the time drew near when Roland’s wedding was to be celebrated,
+and then, according to an old custom in the country, it was announced
+that all the girls were to be present at it, and sing in honour of the
+bridal pair. When the faithful maiden heard of this, she grew so sad
+that she thought her heart would break, and she would not go thither,
+but the other girls came and took her. When it came to her turn to sing,
+she stepped back, until at last she was the only one left, and then she
+could not refuse. But when she began her song, and it reached Roland’s
+ears, he sprang up and cried: ‘I know the voice, that is the true
+bride, I will have no other!’ Everything he had forgotten, and which had
+vanished from his mind, had suddenly come home again to his heart. Then
+the faithful maiden held her wedding with her sweetheart Roland, and
+grief came to an end and joy began.
+
+
+
+
+SNOWDROP
+
+It was the middle of winter, when the broad flakes of snow were falling
+around, that the queen of a country many thousand miles off sat working
+at her window. The frame of the window was made of fine black ebony, and
+as she sat looking out upon the snow, she pricked her finger, and three
+drops of blood fell upon it. Then she gazed thoughtfully upon the red
+drops that sprinkled the white snow, and said, ‘Would that my little
+daughter may be as white as that snow, as red as that blood, and as
+black as this ebony windowframe!’ And so the little girl really did grow
+up; her skin was as white as snow, her cheeks as rosy as the blood, and
+her hair as black as ebony; and she was called Snowdrop.
+
+But this queen died; and the king soon married another wife, who became
+queen, and was very beautiful, but so vain that she could not bear
+to think that anyone could be handsomer than she was. She had a fairy
+looking-glass, to which she used to go, and then she would gaze upon
+herself in it, and say:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass had always answered:
+
+ ‘Thou, queen, art the fairest in all the land.’
+
+But Snowdrop grew more and more beautiful; and when she was seven years
+old she was as bright as the day, and fairer than the queen herself.
+Then the glass one day answered the queen, when she went to look in it
+as usual:
+
+ ‘Thou, queen, art fair, and beauteous to see,
+  But Snowdrop is lovelier far than thee!’
+
+When she heard this she turned pale with rage and envy, and called to
+one of her servants, and said, ‘Take Snowdrop away into the wide wood,
+that I may never see her any more.’ Then the servant led her away; but
+his heart melted when Snowdrop begged him to spare her life, and he
+said, ‘I will not hurt you, thou pretty child.’ So he left her by
+herself; and though he thought it most likely that the wild beasts would
+tear her in pieces, he felt as if a great weight were taken off his
+heart when he had made up his mind not to kill her but to leave her to
+her fate, with the chance of someone finding and saving her.
+
+Then poor Snowdrop wandered along through the wood in great fear; and
+the wild beasts roared about her, but none did her any harm. In the
+evening she came to a cottage among the hills, and went in to rest, for
+her little feet would carry her no further. Everything was spruce and
+neat in the cottage: on the table was spread a white cloth, and there
+were seven little plates, seven little loaves, and seven little glasses
+with wine in them; and seven knives and forks laid in order; and by
+the wall stood seven little beds. As she was very hungry, she picked
+a little piece of each loaf and drank a very little wine out of each
+glass; and after that she thought she would lie down and rest. So she
+tried all the little beds; but one was too long, and another was too
+short, till at last the seventh suited her: and there she laid herself
+down and went to sleep.
+
+By and by in came the masters of the cottage. Now they were seven little
+dwarfs, that lived among the mountains, and dug and searched for gold.
+They lighted up their seven lamps, and saw at once that all was not
+right. The first said, ‘Who has been sitting on my stool?’ The second,
+‘Who has been eating off my plate?’ The third, ‘Who has been picking my
+bread?’ The fourth, ‘Who has been meddling with my spoon?’ The fifth,
+‘Who has been handling my fork?’ The sixth, ‘Who has been cutting with
+my knife?’ The seventh, ‘Who has been drinking my wine?’ Then the first
+looked round and said, ‘Who has been lying on my bed?’ And the rest came
+running to him, and everyone cried out that somebody had been upon his
+bed. But the seventh saw Snowdrop, and called all his brethren to come
+and see her; and they cried out with wonder and astonishment and brought
+their lamps to look at her, and said, ‘Good heavens! what a lovely child
+she is!’ And they were very glad to see her, and took care not to wake
+her; and the seventh dwarf slept an hour with each of the other dwarfs
+in turn, till the night was gone.
+
+In the morning Snowdrop told them all her story; and they pitied her,
+and said if she would keep all things in order, and cook and wash and
+knit and spin for them, she might stay where she was, and they would
+take good care of her. Then they went out all day long to their work,
+seeking for gold and silver in the mountains: but Snowdrop was left at
+home; and they warned her, and said, ‘The queen will soon find out where
+you are, so take care and let no one in.’
+
+But the queen, now that she thought Snowdrop was dead, believed that she
+must be the handsomest lady in the land; and she went to her glass and
+said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the queen was very much frightened; for she knew that the glass
+always spoke the truth, and was sure that the servant had betrayed her.
+And she could not bear to think that anyone lived who was more beautiful
+than she was; so she dressed herself up as an old pedlar, and went
+her way over the hills, to the place where the dwarfs dwelt. Then she
+knocked at the door, and cried, ‘Fine wares to sell!’ Snowdrop looked
+out at the window, and said, ‘Good day, good woman! what have you to
+sell?’ ‘Good wares, fine wares,’ said she; ‘laces and bobbins of all
+colours.’ ‘I will let the old lady in; she seems to be a very good
+sort of body,’ thought Snowdrop, as she ran down and unbolted the door.
+‘Bless me!’ said the old woman, ‘how badly your stays are laced! Let me
+lace them up with one of my nice new laces.’ Snowdrop did not dream of
+any mischief; so she stood before the old woman; but she set to work
+so nimbly, and pulled the lace so tight, that Snowdrop’s breath was
+stopped, and she fell down as if she were dead. ‘There’s an end to all
+thy beauty,’ said the spiteful queen, and went away home.
+
+In the evening the seven dwarfs came home; and I need not say how
+grieved they were to see their faithful Snowdrop stretched out upon the
+ground, as if she was quite dead. However, they lifted her up, and when
+they found what ailed her, they cut the lace; and in a little time she
+began to breathe, and very soon came to life again. Then they said, ‘The
+old woman was the queen herself; take care another time, and let no one
+in when we are away.’
+
+When the queen got home, she went straight to her glass, and spoke to it
+as before; but to her great grief it still said:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the blood ran cold in her heart with spite and malice, to see that
+Snowdrop still lived; and she dressed herself up again, but in quite
+another dress from the one she wore before, and took with her a poisoned
+comb. When she reached the dwarfs’ cottage, she knocked at the door, and
+cried, ‘Fine wares to sell!’ But Snowdrop said, ‘I dare not let anyone
+in.’ Then the queen said, ‘Only look at my beautiful combs!’ and gave
+her the poisoned one. And it looked so pretty, that she took it up and
+put it into her hair to try it; but the moment it touched her head,
+the poison was so powerful that she fell down senseless. ‘There you may
+lie,’ said the queen, and went her way. But by good luck the dwarfs
+came in very early that evening; and when they saw Snowdrop lying on
+the ground, they thought what had happened, and soon found the poisoned
+comb. And when they took it away she got well, and told them all that
+had passed; and they warned her once more not to open the door to
+anyone.
+
+Meantime the queen went home to her glass, and shook with rage when she
+read the very same answer as before; and she said, ‘Snowdrop shall die,
+if it cost me my life.’ So she went by herself into her chamber, and got
+ready a poisoned apple: the outside looked very rosy and tempting, but
+whoever tasted it was sure to die. Then she dressed herself up as a
+peasant’s wife, and travelled over the hills to the dwarfs’ cottage,
+and knocked at the door; but Snowdrop put her head out of the window and
+said, ‘I dare not let anyone in, for the dwarfs have told me not.’ ‘Do
+as you please,’ said the old woman, ‘but at any rate take this pretty
+apple; I will give it you.’ ‘No,’ said Snowdrop, ‘I dare not take it.’
+‘You silly girl!’ answered the other, ‘what are you afraid of? Do you
+think it is poisoned? Come! do you eat one part, and I will eat the
+other.’ Now the apple was so made up that one side was good, though the
+other side was poisoned. Then Snowdrop was much tempted to taste, for
+the apple looked so very nice; and when she saw the old woman eat, she
+could wait no longer. But she had scarcely put the piece into her mouth,
+when she fell down dead upon the ground. ‘This time nothing will save
+thee,’ said the queen; and she went home to her glass, and at last it
+said:
+
+ ‘Thou, queen, art the fairest of all the fair.’
+
+And then her wicked heart was glad, and as happy as such a heart could
+be.
+
+When evening came, and the dwarfs had gone home, they found Snowdrop
+lying on the ground: no breath came from her lips, and they were afraid
+that she was quite dead. They lifted her up, and combed her hair, and
+washed her face with wine and water; but all was in vain, for the little
+girl seemed quite dead. So they laid her down upon a bier, and all seven
+watched and bewailed her three whole days; and then they thought they
+would bury her: but her cheeks were still rosy; and her face looked just
+as it did while she was alive; so they said, ‘We will never bury her in
+the cold ground.’ And they made a coffin of glass, so that they might
+still look at her, and wrote upon it in golden letters what her name
+was, and that she was a king’s daughter. And the coffin was set among
+the hills, and one of the dwarfs always sat by it and watched. And the
+birds of the air came too, and bemoaned Snowdrop; and first of all came
+an owl, and then a raven, and at last a dove, and sat by her side.
+
+And thus Snowdrop lay for a long, long time, and still only looked as
+though she was asleep; for she was even now as white as snow, and as red
+as blood, and as black as ebony. At last a prince came and called at the
+dwarfs’ house; and he saw Snowdrop, and read what was written in golden
+letters. Then he offered the dwarfs money, and prayed and besought them
+to let him take her away; but they said, ‘We will not part with her for
+all the gold in the world.’ At last, however, they had pity on him, and
+gave him the coffin; but the moment he lifted it up to carry it home
+with him, the piece of apple fell from between her lips, and Snowdrop
+awoke, and said, ‘Where am I?’ And the prince said, ‘Thou art quite safe
+with me.’
+
+Then he told her all that had happened, and said, ‘I love you far better
+than all the world; so come with me to my father’s palace, and you shall
+be my wife.’ And Snowdrop consented, and went home with the prince;
+and everything was got ready with great pomp and splendour for their
+wedding.
+
+To the feast was asked, among the rest, Snowdrop’s old enemy the queen;
+and as she was dressing herself in fine rich clothes, she looked in the
+glass and said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, lady, art loveliest here, I ween;
+  But lovelier far is the new-made queen.’
+
+When she heard this she started with rage; but her envy and curiosity
+were so great, that she could not help setting out to see the bride. And
+when she got there, and saw that it was no other than Snowdrop, who, as
+she thought, had been dead a long while, she choked with rage, and fell
+down and died: but Snowdrop and the prince lived and reigned happily
+over that land many, many years; and sometimes they went up into the
+mountains, and paid a visit to the little dwarfs, who had been so kind
+to Snowdrop in her time of need.
+
+
+
+
+THE PINK
+
+There was once upon a time a queen to whom God had given no children.
+Every morning she went into the garden and prayed to God in heaven to
+bestow on her a son or a daughter. Then an angel from heaven came to her
+and said: ‘Be at rest, you shall have a son with the power of wishing,
+so that whatsoever in the world he wishes for, that shall he have.’ Then
+she went to the king, and told him the joyful tidings, and when the time
+was come she gave birth to a son, and the king was filled with gladness.
+
+Every morning she went with the child to the garden where the wild
+beasts were kept, and washed herself there in a clear stream. It
+happened once when the child was a little older, that it was lying in
+her arms and she fell asleep. Then came the old cook, who knew that the
+child had the power of wishing, and stole it away, and he took a hen,
+and cut it in pieces, and dropped some of its blood on the queen’s apron
+and on her dress. Then he carried the child away to a secret place,
+where a nurse was obliged to suckle it, and he ran to the king and
+accused the queen of having allowed her child to be taken from her by
+the wild beasts. When the king saw the blood on her apron, he believed
+this, fell into such a passion that he ordered a high tower to be built,
+in which neither sun nor moon could be seen and had his wife put into
+it, and walled up. Here she was to stay for seven years without meat
+or drink, and die of hunger. But God sent two angels from heaven in the
+shape of white doves, which flew to her twice a day, and carried her
+food until the seven years were over.
+
+The cook, however, thought to himself: ‘If the child has the power of
+wishing, and I am here, he might very easily get me into trouble.’ So
+he left the palace and went to the boy, who was already big enough to
+speak, and said to him: ‘Wish for a beautiful palace for yourself with
+a garden, and all else that pertains to it.’ Scarcely were the words out
+of the boy’s mouth, when everything was there that he had wished for.
+After a while the cook said to him: ‘It is not well for you to be so
+alone, wish for a pretty girl as a companion.’ Then the king’s son
+wished for one, and she immediately stood before him, and was more
+beautiful than any painter could have painted her. The two played
+together, and loved each other with all their hearts, and the old cook
+went out hunting like a nobleman. The thought occurred to him, however,
+that the king’s son might some day wish to be with his father, and thus
+bring him into great peril. So he went out and took the maiden aside,
+and said: ‘Tonight when the boy is asleep, go to his bed and plunge this
+knife into his heart, and bring me his heart and tongue, and if you do
+not do it, you shall lose your life.’ Thereupon he went away, and when
+he returned next day she had not done it, and said: ‘Why should I shed
+the blood of an innocent boy who has never harmed anyone?’ The cook once
+more said: ‘If you do not do it, it shall cost you your own life.’ When
+he had gone away, she had a little hind brought to her, and ordered her
+to be killed, and took her heart and tongue, and laid them on a plate,
+and when she saw the old man coming, she said to the boy: ‘Lie down in
+your bed, and draw the clothes over you.’ Then the wicked wretch came in
+and said: ‘Where are the boy’s heart and tongue?’ The girl reached the
+plate to him, but the king’s son threw off the quilt, and said: ‘You old
+sinner, why did you want to kill me? Now will I pronounce thy sentence.
+You shall become a black poodle and have a gold collar round your neck,
+and shall eat burning coals, till the flames burst forth from your
+throat.’ And when he had spoken these words, the old man was changed
+into a poodle dog, and had a gold collar round his neck, and the cooks
+were ordered to bring up some live coals, and these he ate, until the
+flames broke forth from his throat. The king’s son remained there a
+short while longer, and he thought of his mother, and wondered if she
+were still alive. At length he said to the maiden: ‘I will go home to my
+own country; if you will go with me, I will provide for you.’ ‘Ah,’
+she replied, ‘the way is so long, and what shall I do in a strange land
+where I am unknown?’ As she did not seem quite willing, and as they
+could not be parted from each other, he wished that she might be changed
+into a beautiful pink, and took her with him. Then he went away to his
+own country, and the poodle had to run after him. He went to the tower
+in which his mother was confined, and as it was so high, he wished for
+a ladder which would reach up to the very top. Then he mounted up and
+looked inside, and cried: ‘Beloved mother, Lady Queen, are you still
+alive, or are you dead?’ She answered: ‘I have just eaten, and am still
+satisfied,’ for she thought the angels were there. Said he: ‘I am your
+dear son, whom the wild beasts were said to have torn from your arms;
+but I am alive still, and will soon set you free.’ Then he descended
+again, and went to his father, and caused himself to be announced as a
+strange huntsman, and asked if he could offer him service. The king said
+yes, if he was skilful and could get game for him, he should come to
+him, but that deer had never taken up their quarters in any part of the
+district or country. Then the huntsman promised to procure as much game
+for him as he could possibly use at the royal table. So he summoned all
+the huntsmen together, and bade them go out into the forest with him.
+And he went with them and made them form a great circle, open at one end
+where he stationed himself, and began to wish. Two hundred deer and more
+came running inside the circle at once, and the huntsmen shot them.
+Then they were all placed on sixty country carts, and driven home to the
+king, and for once he was able to deck his table with game, after having
+had none at all for years.
+
+Now the king felt great joy at this, and commanded that his entire
+household should eat with him next day, and made a great feast. When
+they were all assembled together, he said to the huntsman: ‘As you are
+so clever, you shall sit by me.’ He replied: ‘Lord King, your majesty
+must excuse me, I am a poor huntsman.’ But the king insisted on it,
+and said: ‘You shall sit by me,’ until he did it. Whilst he was sitting
+there, he thought of his dearest mother, and wished that one of the
+king’s principal servants would begin to speak of her, and would ask how
+it was faring with the queen in the tower, and if she were alive still,
+or had perished. Hardly had he formed the wish than the marshal began,
+and said: ‘Your majesty, we live joyously here, but how is the queen
+living in the tower? Is she still alive, or has she died?’ But the king
+replied: ‘She let my dear son be torn to pieces by wild beasts; I will
+not have her named.’ Then the huntsman arose and said: ‘Gracious lord
+father she is alive still, and I am her son, and I was not carried away
+by wild beasts, but by that wretch the old cook, who tore me from her
+arms when she was asleep, and sprinkled her apron with the blood of a
+chicken.’ Thereupon he took the dog with the golden collar, and said:
+‘That is the wretch!’ and caused live coals to be brought, and these the
+dog was compelled to devour before the sight of all, until flames burst
+forth from its throat. On this the huntsman asked the king if he would
+like to see the dog in his true shape, and wished him back into the form
+of the cook, in the which he stood immediately, with his white apron,
+and his knife by his side. When the king saw him he fell into a passion,
+and ordered him to be cast into the deepest dungeon. Then the huntsman
+spoke further and said: ‘Father, will you see the maiden who brought me
+up so tenderly and who was afterwards to murder me, but did not do it,
+though her own life depended on it?’ The king replied: ‘Yes, I would
+like to see her.’ The son said: ‘Most gracious father, I will show her
+to you in the form of a beautiful flower,’ and he thrust his hand into
+his pocket and brought forth the pink, and placed it on the royal table,
+and it was so beautiful that the king had never seen one to equal it.
+Then the son said: ‘Now will I show her to you in her own form,’ and
+wished that she might become a maiden, and she stood there looking so
+beautiful that no painter could have made her look more so.
+
+And the king sent two waiting-maids and two attendants into the tower,
+to fetch the queen and bring her to the royal table. But when she was
+led in she ate nothing, and said: ‘The gracious and merciful God who has
+supported me in the tower, will soon set me free.’ She lived three days
+more, and then died happily, and when she was buried, the two white
+doves which had brought her food to the tower, and were angels of
+heaven, followed her body and seated themselves on her grave. The aged
+king ordered the cook to be torn in four pieces, but grief consumed the
+king’s own heart, and he soon died. His son married the beautiful maiden
+whom he had brought with him as a flower in his pocket, and whether they
+are still alive or not, is known to God.
+
+
+
+
+CLEVER ELSIE
+
+There was once a man who had a daughter who was called Clever Elsie. And
+when she had grown up her father said: ‘We will get her married.’ ‘Yes,’
+said the mother, ‘if only someone would come who would have her.’ At
+length a man came from a distance and wooed her, who was called Hans;
+but he stipulated that Clever Elsie should be really smart. ‘Oh,’ said
+the father, ‘she has plenty of good sense’; and the mother said: ‘Oh,
+she can see the wind coming up the street, and hear the flies coughing.’
+‘Well,’ said Hans, ‘if she is not really smart, I won’t have her.’ When
+they were sitting at dinner and had eaten, the mother said: ‘Elsie, go
+into the cellar and fetch some beer.’ Then Clever Elsie took the pitcher
+from the wall, went into the cellar, and tapped the lid briskly as she
+went, so that the time might not appear long. When she was below she
+fetched herself a chair, and set it before the barrel so that she had
+no need to stoop, and did not hurt her back or do herself any unexpected
+injury. Then she placed the can before her, and turned the tap, and
+while the beer was running she would not let her eyes be idle, but
+looked up at the wall, and after much peering here and there, saw a
+pick-axe exactly above her, which the masons had accidentally left
+there.
+
+Then Clever Elsie began to weep and said: ‘If I get Hans, and we have
+a child, and he grows big, and we send him into the cellar here to draw
+beer, then the pick-axe will fall on his head and kill him.’ Then she
+sat and wept and screamed with all the strength of her body, over the
+misfortune which lay before her. Those upstairs waited for the drink,
+but Clever Elsie still did not come. Then the woman said to the servant:
+‘Just go down into the cellar and see where Elsie is.’ The maid went and
+found her sitting in front of the barrel, screaming loudly. ‘Elsie why
+do you weep?’ asked the maid. ‘Ah,’ she answered, ‘have I not reason to
+weep? If I get Hans, and we have a child, and he grows big, and has to
+draw beer here, the pick-axe will perhaps fall on his head, and kill
+him.’ Then said the maid: ‘What a clever Elsie we have!’ and sat down
+beside her and began loudly to weep over the misfortune. After a while,
+as the maid did not come back, and those upstairs were thirsty for the
+beer, the man said to the boy: ‘Just go down into the cellar and see
+where Elsie and the girl are.’ The boy went down, and there sat Clever
+Elsie and the girl both weeping together. Then he asked: ‘Why are you
+weeping?’ ‘Ah,’ said Elsie, ‘have I not reason to weep? If I get Hans,
+and we have a child, and he grows big, and has to draw beer here, the
+pick-axe will fall on his head and kill him.’ Then said the boy: ‘What
+a clever Elsie we have!’ and sat down by her, and likewise began to
+howl loudly. Upstairs they waited for the boy, but as he still did not
+return, the man said to the woman: ‘Just go down into the cellar and see
+where Elsie is!’ The woman went down, and found all three in the midst
+of their lamentations, and inquired what was the cause; then Elsie told
+her also that her future child was to be killed by the pick-axe, when it
+grew big and had to draw beer, and the pick-axe fell down. Then said the
+mother likewise: ‘What a clever Elsie we have!’ and sat down and wept
+with them. The man upstairs waited a short time, but as his wife did not
+come back and his thirst grew ever greater, he said: ‘I must go into the
+cellar myself and see where Elsie is.’ But when he got into the cellar,
+and they were all sitting together crying, and he heard the reason, and
+that Elsie’s child was the cause, and the Elsie might perhaps bring one
+into the world some day, and that he might be killed by the pick-axe, if
+he should happen to be sitting beneath it, drawing beer just at the very
+time when it fell down, he cried: ‘Oh, what a clever Elsie!’ and sat
+down, and likewise wept with them. The bridegroom stayed upstairs alone
+for a long time; then as no one would come back he thought: ‘They must be
+waiting for me below: I too must go there and see what they are about.’
+When he got down, the five of them were sitting screaming and lamenting
+quite piteously, each out-doing the other. ‘What misfortune has happened
+then?’ asked he. ‘Ah, dear Hans,’ said Elsie, ‘if we marry each other
+and have a child, and he is big, and we perhaps send him here to draw
+something to drink, then the pick-axe which has been left up there might
+dash his brains out if it were to fall down, so have we not reason to
+weep?’ ‘Come,’ said Hans, ‘more understanding than that is not needed
+for my household, as you are such a clever Elsie, I will have you,’ and
+seized her hand, took her upstairs with him, and married her.
+
+After Hans had had her some time, he said: ‘Wife, I am going out to work
+and earn some money for us; go into the field and cut the corn that we
+may have some bread.’ ‘Yes, dear Hans, I will do that.’ After Hans had
+gone away, she cooked herself some good broth and took it into the field
+with her. When she came to the field she said to herself: ‘What shall I
+do; shall I cut first, or shall I eat first? Oh, I will eat first.’ Then
+she drank her cup of broth and when she was fully satisfied, she once
+more said: ‘What shall I do? Shall I cut first, or shall I sleep first?
+I will sleep first.’ Then she lay down among the corn and fell asleep.
+Hans had been at home for a long time, but Elsie did not come; then said
+he: ‘What a clever Elsie I have; she is so industrious that she does not
+even come home to eat.’ But when evening came and she still stayed away,
+Hans went out to see what she had cut, but nothing was cut, and she
+was lying among the corn asleep. Then Hans hastened home and brought
+a fowler’s net with little bells and hung it round about her, and she
+still went on sleeping. Then he ran home, shut the house-door, and sat
+down in his chair and worked. At length, when it was quite dark, Clever
+Elsie awoke and when she got up there was a jingling all round about
+her, and the bells rang at each step which she took. Then she was
+alarmed, and became uncertain whether she really was Clever Elsie or
+not, and said: ‘Is it I, or is it not I?’ But she knew not what answer
+to make to this, and stood for a time in doubt; at length she thought:
+‘I will go home and ask if it be I, or if it be not I, they will be sure
+to know.’ She ran to the door of her own house, but it was shut; then
+she knocked at the window and cried: ‘Hans, is Elsie within?’ ‘Yes,’
+answered Hans, ‘she is within.’ Hereupon she was terrified, and said:
+‘Ah, heavens! Then it is not I,’ and went to another door; but when the
+people heard the jingling of the bells they would not open it, and she
+could get in nowhere. Then she ran out of the village, and no one has
+seen her since.
+
+
+
+
+THE MISER IN THE BUSH
+
+A farmer had a faithful and diligent servant, who had worked hard for
+him three years, without having been paid any wages. At last it came
+into the man’s head that he would not go on thus without pay any longer;
+so he went to his master, and said, ‘I have worked hard for you a long
+time, I will trust to you to give me what I deserve to have for my
+trouble.’ The farmer was a sad miser, and knew that his man was very
+simple-hearted; so he took out threepence, and gave him for every year’s
+service a penny. The poor fellow thought it was a great deal of money to
+have, and said to himself, ‘Why should I work hard, and live here on bad
+fare any longer? I can now travel into the wide world, and make myself
+merry.’ With that he put his money into his purse, and set out, roaming
+over hill and valley.
+
+As he jogged along over the fields, singing and dancing, a little dwarf
+met him, and asked him what made him so merry. ‘Why, what should make
+me down-hearted?’ said he; ‘I am sound in health and rich in purse, what
+should I care for? I have saved up my three years’ earnings and have it
+all safe in my pocket.’ ‘How much may it come to?’ said the little man.
+‘Full threepence,’ replied the countryman. ‘I wish you would give them
+to me,’ said the other; ‘I am very poor.’ Then the man pitied him, and
+gave him all he had; and the little dwarf said in return, ‘As you have
+such a kind honest heart, I will grant you three wishes--one for every
+penny; so choose whatever you like.’ Then the countryman rejoiced at
+his good luck, and said, ‘I like many things better than money: first, I
+will have a bow that will bring down everything I shoot at; secondly,
+a fiddle that will set everyone dancing that hears me play upon it; and
+thirdly, I should like that everyone should grant what I ask.’ The dwarf
+said he should have his three wishes; so he gave him the bow and fiddle,
+and went his way.
+
+Our honest friend journeyed on his way too; and if he was merry before,
+he was now ten times more so. He had not gone far before he met an old
+miser: close by them stood a tree, and on the topmost twig sat a thrush
+singing away most joyfully. ‘Oh, what a pretty bird!’ said the miser; ‘I
+would give a great deal of money to have such a one.’ ‘If that’s all,’
+said the countryman, ‘I will soon bring it down.’ Then he took up his
+bow, and down fell the thrush into the bushes at the foot of the tree.
+The miser crept into the bush to find it; but directly he had got into
+the middle, his companion took up his fiddle and played away, and the
+miser began to dance and spring about, capering higher and higher in
+the air. The thorns soon began to tear his clothes till they all hung
+in rags about him, and he himself was all scratched and wounded, so that
+the blood ran down. ‘Oh, for heaven’s sake!’ cried the miser, ‘Master!
+master! pray let the fiddle alone. What have I done to deserve this?’
+‘Thou hast shaved many a poor soul close enough,’ said the other; ‘thou
+art only meeting thy reward’: so he played up another tune. Then the
+miser began to beg and promise, and offered money for his liberty; but
+he did not come up to the musician’s price for some time, and he danced
+him along brisker and brisker, and the miser bid higher and higher, till
+at last he offered a round hundred of florins that he had in his purse,
+and had just gained by cheating some poor fellow. When the countryman
+saw so much money, he said, ‘I will agree to your proposal.’ So he took
+the purse, put up his fiddle, and travelled on very pleased with his
+bargain.
+
+Meanwhile the miser crept out of the bush half-naked and in a piteous
+plight, and began to ponder how he should take his revenge, and serve
+his late companion some trick. At last he went to the judge, and
+complained that a rascal had robbed him of his money, and beaten him
+into the bargain; and that the fellow who did it carried a bow at his
+back and a fiddle hung round his neck. Then the judge sent out his
+officers to bring up the accused wherever they should find him; and he
+was soon caught and brought up to be tried.
+
+The miser began to tell his tale, and said he had been robbed of
+his money. ‘No, you gave it me for playing a tune to you.’ said the
+countryman; but the judge told him that was not likely, and cut the
+matter short by ordering him off to the gallows.
+
+So away he was taken; but as he stood on the steps he said, ‘My Lord
+Judge, grant me one last request.’ ‘Anything but thy life,’ replied the
+other. ‘No,’ said he, ‘I do not ask my life; only to let me play upon
+my fiddle for the last time.’ The miser cried out, ‘Oh, no! no! for
+heaven’s sake don’t listen to him! don’t listen to him!’ But the judge
+said, ‘It is only this once, he will soon have done.’ The fact was, he
+could not refuse the request, on account of the dwarf’s third gift.
+
+Then the miser said, ‘Bind me fast, bind me fast, for pity’s sake.’ But
+the countryman seized his fiddle, and struck up a tune, and at the first
+note judge, clerks, and jailer were in motion; all began capering, and
+no one could hold the miser. At the second note the hangman let his
+prisoner go, and danced also, and by the time he had played the first
+bar of the tune, all were dancing together--judge, court, and miser, and
+all the people who had followed to look on. At first the thing was merry
+and pleasant enough; but when it had gone on a while, and there seemed
+to be no end of playing or dancing, they began to cry out, and beg him
+to leave off; but he stopped not a whit the more for their entreaties,
+till the judge not only gave him his life, but promised to return him
+the hundred florins.
+
+Then he called to the miser, and said, ‘Tell us now, you vagabond, where
+you got that gold, or I shall play on for your amusement only,’ ‘I stole
+it,’ said the miser in the presence of all the people; ‘I acknowledge
+that I stole it, and that you earned it fairly.’ Then the countryman
+stopped his fiddle, and left the miser to take his place at the gallows.
+
+
+
+
+ASHPUTTEL
+
+The wife of a rich man fell sick; and when she felt that her end drew
+nigh, she called her only daughter to her bed-side, and said, ‘Always be
+a good girl, and I will look down from heaven and watch over you.’ Soon
+afterwards she shut her eyes and died, and was buried in the garden;
+and the little girl went every day to her grave and wept, and was always
+good and kind to all about her. And the snow fell and spread a beautiful
+white covering over the grave; but by the time the spring came, and the
+sun had melted it away again, her father had married another wife. This
+new wife had two daughters of her own, that she brought home with her;
+they were fair in face but foul at heart, and it was now a sorry time
+for the poor little girl. ‘What does the good-for-nothing want in the
+parlour?’ said they; ‘they who would eat bread should first earn it;
+away with the kitchen-maid!’ Then they took away her fine clothes, and
+gave her an old grey frock to put on, and laughed at her, and turned her
+into the kitchen.
+
+There she was forced to do hard work; to rise early before daylight, to
+bring the water, to make the fire, to cook and to wash. Besides that,
+the sisters plagued her in all sorts of ways, and laughed at her. In the
+evening when she was tired, she had no bed to lie down on, but was made
+to lie by the hearth among the ashes; and as this, of course, made her
+always dusty and dirty, they called her Ashputtel.
+
+It happened once that the father was going to the fair, and asked his
+wife’s daughters what he should bring them. ‘Fine clothes,’ said the
+first; ‘Pearls and diamonds,’ cried the second. ‘Now, child,’ said he
+to his own daughter, ‘what will you have?’ ‘The first twig, dear
+father, that brushes against your hat when you turn your face to come
+homewards,’ said she. Then he bought for the first two the fine clothes
+and pearls and diamonds they had asked for: and on his way home, as he
+rode through a green copse, a hazel twig brushed against him, and almost
+pushed off his hat: so he broke it off and brought it away; and when he
+got home he gave it to his daughter. Then she took it, and went to
+her mother’s grave and planted it there; and cried so much that it was
+watered with her tears; and there it grew and became a fine tree. Three
+times every day she went to it and cried; and soon a little bird came
+and built its nest upon the tree, and talked with her, and watched over
+her, and brought her whatever she wished for.
+
+Now it happened that the king of that land held a feast, which was to
+last three days; and out of those who came to it his son was to choose
+a bride for himself. Ashputtel’s two sisters were asked to come; so they
+called her up, and said, ‘Now, comb our hair, brush our shoes, and tie
+our sashes for us, for we are going to dance at the king’s feast.’
+Then she did as she was told; but when all was done she could not help
+crying, for she thought to herself, she should so have liked to have
+gone with them to the ball; and at last she begged her mother very hard
+to let her go. ‘You, Ashputtel!’ said she; ‘you who have nothing to
+wear, no clothes at all, and who cannot even dance--you want to go to
+the ball? And when she kept on begging, she said at last, to get rid of
+her, ‘I will throw this dishful of peas into the ash-heap, and if in
+two hours’ time you have picked them all out, you shall go to the feast
+too.’
+
+Then she threw the peas down among the ashes, but the little maiden ran
+out at the back door into the garden, and cried out:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves, flying in at the kitchen window; next
+came two turtle-doves; and after them came all the little birds under
+heaven, chirping and fluttering in: and they flew down into the ashes.
+And the little doves stooped their heads down and set to work, pick,
+pick, pick; and then the others began to pick, pick, pick: and among
+them all they soon picked out all the good grain, and put it into a dish
+but left the ashes. Long before the end of the hour the work was quite
+done, and all flew out again at the windows.
+
+Then Ashputtel brought the dish to her mother, overjoyed at the thought
+that now she should go to the ball. But the mother said, ‘No, no! you
+slut, you have no clothes, and cannot dance; you shall not go.’ And when
+Ashputtel begged very hard to go, she said, ‘If you can in one hour’s
+time pick two of those dishes of peas out of the ashes, you shall go
+too.’ And thus she thought she should at least get rid of her. So she
+shook two dishes of peas into the ashes.
+
+But the little maiden went out into the garden at the back of the house,
+and cried out as before:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves in at the kitchen window; next came two
+turtle-doves; and after them came all the little birds under heaven,
+chirping and hopping about. And they flew down into the ashes; and the
+little doves put their heads down and set to work, pick, pick, pick; and
+then the others began pick, pick, pick; and they put all the good grain
+into the dishes, and left all the ashes. Before half an hour’s time all
+was done, and out they flew again. And then Ashputtel took the dishes to
+her mother, rejoicing to think that she should now go to the ball.
+But her mother said, ‘It is all of no use, you cannot go; you have no
+clothes, and cannot dance, and you would only put us to shame’: and off
+she went with her two daughters to the ball.
+
+Now when all were gone, and nobody left at home, Ashputtel went
+sorrowfully and sat down under the hazel-tree, and cried out:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her friend the bird flew out of the tree, and brought a gold and
+silver dress for her, and slippers of spangled silk; and she put them
+on, and followed her sisters to the feast. But they did not know her,
+and thought it must be some strange princess, she looked so fine and
+beautiful in her rich clothes; and they never once thought of Ashputtel,
+taking it for granted that she was safe at home in the dirt.
+
+The king’s son soon came up to her, and took her by the hand and danced
+with her, and no one else: and he never left her hand; but when anyone
+else came to ask her to dance, he said, ‘This lady is dancing with me.’
+
+Thus they danced till a late hour of the night; and then she wanted to
+go home: and the king’s son said, ‘I shall go and take care of you to
+your home’; for he wanted to see where the beautiful maiden lived. But
+she slipped away from him, unawares, and ran off towards home; and as
+the prince followed her, she jumped up into the pigeon-house and shut
+the door. Then he waited till her father came home, and told him that
+the unknown maiden, who had been at the feast, had hid herself in the
+pigeon-house. But when they had broken open the door they found no one
+within; and as they came back into the house, Ashputtel was lying, as
+she always did, in her dirty frock by the ashes, and her dim little
+lamp was burning in the chimney. For she had run as quickly as she could
+through the pigeon-house and on to the hazel-tree, and had there taken
+off her beautiful clothes, and put them beneath the tree, that the bird
+might carry them away, and had lain down again amid the ashes in her
+little grey frock.
+
+The next day when the feast was again held, and her father, mother, and
+sisters were gone, Ashputtel went to the hazel-tree, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+And the bird came and brought a still finer dress than the one she
+had worn the day before. And when she came in it to the ball, everyone
+wondered at her beauty: but the king’s son, who was waiting for her,
+took her by the hand, and danced with her; and when anyone asked her to
+dance, he said as before, ‘This lady is dancing with me.’
+
+When night came she wanted to go home; and the king’s son followed here
+as before, that he might see into what house she went: but she sprang
+away from him all at once into the garden behind her father’s house.
+In this garden stood a fine large pear-tree full of ripe fruit; and
+Ashputtel, not knowing where to hide herself, jumped up into it without
+being seen. Then the king’s son lost sight of her, and could not find
+out where she was gone, but waited till her father came home, and said
+to him, ‘The unknown lady who danced with me has slipped away, and I
+think she must have sprung into the pear-tree.’ The father thought to
+himself, ‘Can it be Ashputtel?’ So he had an axe brought; and they cut
+down the tree, but found no one upon it. And when they came back into
+the kitchen, there lay Ashputtel among the ashes; for she had slipped
+down on the other side of the tree, and carried her beautiful clothes
+back to the bird at the hazel-tree, and then put on her little grey
+frock.
+
+The third day, when her father and mother and sisters were gone, she
+went again into the garden, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her kind friend the bird brought a dress still finer than the
+former one, and slippers which were all of gold: so that when she came
+to the feast no one knew what to say, for wonder at her beauty: and the
+king’s son danced with nobody but her; and when anyone else asked her to
+dance, he said, ‘This lady is _my_ partner, sir.’
+
+When night came she wanted to go home; and the king’s son would go with
+her, and said to himself, ‘I will not lose her this time’; but, however,
+she again slipped away from him, though in such a hurry that she dropped
+her left golden slipper upon the stairs.
+
+The prince took the shoe, and went the next day to the king his father,
+and said, ‘I will take for my wife the lady that this golden slipper
+fits.’ Then both the sisters were overjoyed to hear it; for they
+had beautiful feet, and had no doubt that they could wear the golden
+slipper. The eldest went first into the room where the slipper was, and
+wanted to try it on, and the mother stood by. But her great toe could
+not go into it, and the shoe was altogether much too small for her. Then
+the mother gave her a knife, and said, ‘Never mind, cut it off; when you
+are queen you will not care about toes; you will not want to walk.’ So
+the silly girl cut off her great toe, and thus squeezed on the shoe,
+and went to the king’s son. Then he took her for his bride, and set her
+beside him on his horse, and rode away with her homewards.
+
+But on their way home they had to pass by the hazel-tree that Ashputtel
+had planted; and on the branch sat a little dove singing:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then the prince got down and looked at her foot; and he saw, by the
+blood that streamed from it, what a trick she had played him. So he
+turned his horse round, and brought the false bride back to her home,
+and said, ‘This is not the right bride; let the other sister try and put
+on the slipper.’ Then she went into the room and got her foot into the
+shoe, all but the heel, which was too large. But her mother squeezed it
+in till the blood came, and took her to the king’s son: and he set her
+as his bride by his side on his horse, and rode away with her.
+
+But when they came to the hazel-tree the little dove sat there still,
+and sang:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then he looked down, and saw that the blood streamed so much from the
+shoe, that her white stockings were quite red. So he turned his horse
+and brought her also back again. ‘This is not the true bride,’ said he
+to the father; ‘have you no other daughters?’ ‘No,’ said he; ‘there is
+only a little dirty Ashputtel here, the child of my first wife; I am
+sure she cannot be the bride.’ The prince told him to send her. But the
+mother said, ‘No, no, she is much too dirty; she will not dare to show
+herself.’ However, the prince would have her come; and she first washed
+her face and hands, and then went in and curtsied to him, and he reached
+her the golden slipper. Then she took her clumsy shoe off her left foot,
+and put on the golden slipper; and it fitted her as if it had been made
+for her. And when he drew near and looked at her face he knew her, and
+said, ‘This is the right bride.’ But the mother and both the sisters
+were frightened, and turned pale with anger as he took Ashputtel on his
+horse, and rode away with her. And when they came to the hazel-tree, the
+white dove sang:
+
+ ‘Home! home! look at the shoe!
+  Princess! the shoe was made for you!
+  Prince! prince! take home thy bride,
+  For she is the true one that sits by thy side!’
+
+And when the dove had done its song, it came flying, and perched upon
+her right shoulder, and so went home with her.
+
+
+
+
+THE WHITE SNAKE
+
+A long time ago there lived a king who was famed for his wisdom through
+all the land. Nothing was hidden from him, and it seemed as if news of
+the most secret things was brought to him through the air. But he had a
+strange custom; every day after dinner, when the table was cleared,
+and no one else was present, a trusty servant had to bring him one more
+dish. It was covered, however, and even the servant did not know what
+was in it, neither did anyone know, for the king never took off the
+cover to eat of it until he was quite alone.
+
+This had gone on for a long time, when one day the servant, who took
+away the dish, was overcome with such curiosity that he could not help
+carrying the dish into his room. When he had carefully locked the door,
+he lifted up the cover, and saw a white snake lying on the dish. But
+when he saw it he could not deny himself the pleasure of tasting it,
+so he cut of a little bit and put it into his mouth. No sooner had it
+touched his tongue than he heard a strange whispering of little voices
+outside his window. He went and listened, and then noticed that it was
+the sparrows who were chattering together, and telling one another of
+all kinds of things which they had seen in the fields and woods. Eating
+the snake had given him power of understanding the language of animals.
+
+Now it so happened that on this very day the queen lost her most
+beautiful ring, and suspicion of having stolen it fell upon this trusty
+servant, who was allowed to go everywhere. The king ordered the man to
+be brought before him, and threatened with angry words that unless he
+could before the morrow point out the thief, he himself should be looked
+upon as guilty and executed. In vain he declared his innocence; he was
+dismissed with no better answer.
+
+In his trouble and fear he went down into the courtyard and took thought
+how to help himself out of his trouble. Now some ducks were sitting
+together quietly by a brook and taking their rest; and, whilst they
+were making their feathers smooth with their bills, they were having a
+confidential conversation together. The servant stood by and listened.
+They were telling one another of all the places where they had been
+waddling about all the morning, and what good food they had found; and
+one said in a pitiful tone: ‘Something lies heavy on my stomach; as
+I was eating in haste I swallowed a ring which lay under the queen’s
+window.’ The servant at once seized her by the neck, carried her to the
+kitchen, and said to the cook: ‘Here is a fine duck; pray, kill her.’
+‘Yes,’ said the cook, and weighed her in his hand; ‘she has spared
+no trouble to fatten herself, and has been waiting to be roasted long
+enough.’ So he cut off her head, and as she was being dressed for the
+spit, the queen’s ring was found inside her.
+
+The servant could now easily prove his innocence; and the king, to make
+amends for the wrong, allowed him to ask a favour, and promised him
+the best place in the court that he could wish for. The servant refused
+everything, and only asked for a horse and some money for travelling, as
+he had a mind to see the world and go about a little. When his request
+was granted he set out on his way, and one day came to a pond, where he
+saw three fishes caught in the reeds and gasping for water. Now, though
+it is said that fishes are dumb, he heard them lamenting that they must
+perish so miserably, and, as he had a kind heart, he got off his
+horse and put the three prisoners back into the water. They leapt with
+delight, put out their heads, and cried to him: ‘We will remember you
+and repay you for saving us!’
+
+He rode on, and after a while it seemed to him that he heard a voice in
+the sand at his feet. He listened, and heard an ant-king complain: ‘Why
+cannot folks, with their clumsy beasts, keep off our bodies? That stupid
+horse, with his heavy hoofs, has been treading down my people without
+mercy!’ So he turned on to a side path and the ant-king cried out to
+him: ‘We will remember you--one good turn deserves another!’
+
+The path led him into a wood, and there he saw two old ravens standing
+by their nest, and throwing out their young ones. ‘Out with you, you
+idle, good-for-nothing creatures!’ cried they; ‘we cannot find food for
+you any longer; you are big enough, and can provide for yourselves.’
+But the poor young ravens lay upon the ground, flapping their wings, and
+crying: ‘Oh, what helpless chicks we are! We must shift for ourselves,
+and yet we cannot fly! What can we do, but lie here and starve?’ So the
+good young fellow alighted and killed his horse with his sword, and gave
+it to them for food. Then they came hopping up to it, satisfied their
+hunger, and cried: ‘We will remember you--one good turn deserves
+another!’
+
+And now he had to use his own legs, and when he had walked a long
+way, he came to a large city. There was a great noise and crowd in
+the streets, and a man rode up on horseback, crying aloud: ‘The king’s
+daughter wants a husband; but whoever seeks her hand must perform a hard
+task, and if he does not succeed he will forfeit his life.’ Many had
+already made the attempt, but in vain; nevertheless when the youth
+saw the king’s daughter he was so overcome by her great beauty that he
+forgot all danger, went before the king, and declared himself a suitor.
+
+So he was led out to the sea, and a gold ring was thrown into it, before
+his eyes; then the king ordered him to fetch this ring up from the
+bottom of the sea, and added: ‘If you come up again without it you will
+be thrown in again and again until you perish amid the waves.’ All the
+people grieved for the handsome youth; then they went away, leaving him
+alone by the sea.
+
+He stood on the shore and considered what he should do, when suddenly
+he saw three fishes come swimming towards him, and they were the very
+fishes whose lives he had saved. The one in the middle held a mussel in
+its mouth, which it laid on the shore at the youth’s feet, and when he
+had taken it up and opened it, there lay the gold ring in the shell.
+Full of joy he took it to the king and expected that he would grant him
+the promised reward.
+
+But when the proud princess perceived that he was not her equal in
+birth, she scorned him, and required him first to perform another
+task. She went down into the garden and strewed with her own hands ten
+sacksful of millet-seed on the grass; then she said: ‘Tomorrow morning
+before sunrise these must be picked up, and not a single grain be
+wanting.’
+
+The youth sat down in the garden and considered how it might be possible
+to perform this task, but he could think of nothing, and there he sat
+sorrowfully awaiting the break of day, when he should be led to death.
+But as soon as the first rays of the sun shone into the garden he saw
+all the ten sacks standing side by side, quite full, and not a single
+grain was missing. The ant-king had come in the night with thousands
+and thousands of ants, and the grateful creatures had by great industry
+picked up all the millet-seed and gathered them into the sacks.
+
+Presently the king’s daughter herself came down into the garden, and was
+amazed to see that the young man had done the task she had given him.
+But she could not yet conquer her proud heart, and said: ‘Although he
+has performed both the tasks, he shall not be my husband until he had
+brought me an apple from the Tree of Life.’ The youth did not know where
+the Tree of Life stood, but he set out, and would have gone on for ever,
+as long as his legs would carry him, though he had no hope of finding
+it. After he had wandered through three kingdoms, he came one evening to
+a wood, and lay down under a tree to sleep. But he heard a rustling in
+the branches, and a golden apple fell into his hand. At the same time
+three ravens flew down to him, perched themselves upon his knee, and
+said: ‘We are the three young ravens whom you saved from starving; when
+we had grown big, and heard that you were seeking the Golden Apple,
+we flew over the sea to the end of the world, where the Tree of Life
+stands, and have brought you the apple.’ The youth, full of joy, set out
+homewards, and took the Golden Apple to the king’s beautiful daughter,
+who had now no more excuses left to make. They cut the Apple of Life in
+two and ate it together; and then her heart became full of love for him,
+and they lived in undisturbed happiness to a great age.
+
+
+
+
+THE WOLF AND THE SEVEN LITTLE KIDS
+
+There was once upon a time an old goat who had seven little kids, and
+loved them with all the love of a mother for her children. One day she
+wanted to go into the forest and fetch some food. So she called all
+seven to her and said: ‘Dear children, I have to go into the forest,
+be on your guard against the wolf; if he comes in, he will devour you
+all--skin, hair, and everything. The wretch often disguises himself, but
+you will know him at once by his rough voice and his black feet.’ The
+kids said: ‘Dear mother, we will take good care of ourselves; you may go
+away without any anxiety.’ Then the old one bleated, and went on her way
+with an easy mind.
+
+It was not long before someone knocked at the house-door and called:
+‘Open the door, dear children; your mother is here, and has brought
+something back with her for each of you.’ But the little kids knew that
+it was the wolf, by the rough voice. ‘We will not open the door,’ cried
+they, ‘you are not our mother. She has a soft, pleasant voice, but
+your voice is rough; you are the wolf!’ Then the wolf went away to a
+shopkeeper and bought himself a great lump of chalk, ate this and made
+his voice soft with it. Then he came back, knocked at the door of the
+house, and called: ‘Open the door, dear children, your mother is here
+and has brought something back with her for each of you.’ But the wolf
+had laid his black paws against the window, and the children saw them
+and cried: ‘We will not open the door, our mother has not black feet
+like you: you are the wolf!’ Then the wolf ran to a baker and said: ‘I
+have hurt my feet, rub some dough over them for me.’ And when the baker
+had rubbed his feet over, he ran to the miller and said: ‘Strew some
+white meal over my feet for me.’ The miller thought to himself: ‘The
+wolf wants to deceive someone,’ and refused; but the wolf said: ‘If you
+will not do it, I will devour you.’ Then the miller was afraid, and made
+his paws white for him. Truly, this is the way of mankind.
+
+So now the wretch went for the third time to the house-door, knocked at
+it and said: ‘Open the door for me, children, your dear little mother
+has come home, and has brought every one of you something back from the
+forest with her.’ The little kids cried: ‘First show us your paws that
+we may know if you are our dear little mother.’ Then he put his paws
+in through the window and when the kids saw that they were white, they
+believed that all he said was true, and opened the door. But who should
+come in but the wolf! They were terrified and wanted to hide themselves.
+One sprang under the table, the second into the bed, the third into the
+stove, the fourth into the kitchen, the fifth into the cupboard, the
+sixth under the washing-bowl, and the seventh into the clock-case. But
+the wolf found them all, and used no great ceremony; one after the
+other he swallowed them down his throat. The youngest, who was in
+the clock-case, was the only one he did not find. When the wolf had
+satisfied his appetite he took himself off, laid himself down under a
+tree in the green meadow outside, and began to sleep. Soon afterwards
+the old goat came home again from the forest. Ah! what a sight she saw
+there! The house-door stood wide open. The table, chairs, and benches
+were thrown down, the washing-bowl lay broken to pieces, and the quilts
+and pillows were pulled off the bed. She sought her children, but they
+were nowhere to be found. She called them one after another by name, but
+no one answered. At last, when she came to the youngest, a soft voice
+cried: ‘Dear mother, I am in the clock-case.’ She took the kid out, and
+it told her that the wolf had come and had eaten all the others. Then
+you may imagine how she wept over her poor children.
+
+At length in her grief she went out, and the youngest kid ran with her.
+When they came to the meadow, there lay the wolf by the tree and snored
+so loud that the branches shook. She looked at him on every side and
+saw that something was moving and struggling in his gorged belly. ‘Ah,
+heavens,’ she said, ‘is it possible that my poor children whom he has
+swallowed down for his supper, can be still alive?’ Then the kid had to
+run home and fetch scissors, and a needle and thread, and the goat cut
+open the monster’s stomach, and hardly had she made one cut, than one
+little kid thrust its head out, and when she had cut farther, all six
+sprang out one after another, and were all still alive, and had suffered
+no injury whatever, for in his greediness the monster had swallowed them
+down whole. What rejoicing there was! They embraced their dear mother,
+and jumped like a tailor at his wedding. The mother, however, said: ‘Now
+go and look for some big stones, and we will fill the wicked beast’s
+stomach with them while he is still asleep.’ Then the seven kids dragged
+the stones thither with all speed, and put as many of them into this
+stomach as they could get in; and the mother sewed him up again in the
+greatest haste, so that he was not aware of anything and never once
+stirred.
+
+When the wolf at length had had his fill of sleep, he got on his legs,
+and as the stones in his stomach made him very thirsty, he wanted to
+go to a well to drink. But when he began to walk and to move about, the
+stones in his stomach knocked against each other and rattled. Then cried
+he:
+
+ ‘What rumbles and tumbles
+  Against my poor bones?
+  I thought ‘twas six kids,
+  But it feels like big stones.’
+
+And when he got to the well and stooped over the water to drink, the
+heavy stones made him fall in, and he drowned miserably. When the seven
+kids saw that, they came running to the spot and cried aloud: ‘The wolf
+is dead! The wolf is dead!’ and danced for joy round about the well with
+their mother.
+
+
+
+
+THE QUEEN BEE
+
+Two kings’ sons once upon a time went into the world to seek their
+fortunes; but they soon fell into a wasteful foolish way of living, so
+that they could not return home again. Then their brother, who was a
+little insignificant dwarf, went out to seek for his brothers: but when
+he had found them they only laughed at him, to think that he, who was so
+young and simple, should try to travel through the world, when they, who
+were so much wiser, had been unable to get on. However, they all set
+out on their journey together, and came at last to an ant-hill. The two
+elder brothers would have pulled it down, in order to see how the poor
+ants in their fright would run about and carry off their eggs. But the
+little dwarf said, ‘Let the poor things enjoy themselves, I will not
+suffer you to trouble them.’
+
+So on they went, and came to a lake where many many ducks were swimming
+about. The two brothers wanted to catch two, and roast them. But the
+dwarf said, ‘Let the poor things enjoy themselves, you shall not kill
+them.’ Next they came to a bees’-nest in a hollow tree, and there was
+so much honey that it ran down the trunk; and the two brothers wanted to
+light a fire under the tree and kill the bees, so as to get their honey.
+But the dwarf held them back, and said, ‘Let the pretty insects enjoy
+themselves, I cannot let you burn them.’
+
+At length the three brothers came to a castle: and as they passed by the
+stables they saw fine horses standing there, but all were of marble, and
+no man was to be seen. Then they went through all the rooms, till they
+came to a door on which were three locks: but in the middle of the door
+was a wicket, so that they could look into the next room. There they saw
+a little grey old man sitting at a table; and they called to him once or
+twice, but he did not hear: however, they called a third time, and then
+he rose and came out to them.
+
+He said nothing, but took hold of them and led them to a beautiful
+table covered with all sorts of good things: and when they had eaten and
+drunk, he showed each of them to a bed-chamber.
+
+The next morning he came to the eldest and took him to a marble table,
+where there were three tablets, containing an account of the means by
+which the castle might be disenchanted. The first tablet said: ‘In the
+wood, under the moss, lie the thousand pearls belonging to the king’s
+daughter; they must all be found: and if one be missing by set of sun,
+he who seeks them will be turned into marble.’
+
+The eldest brother set out, and sought for the pearls the whole day:
+but the evening came, and he had not found the first hundred: so he was
+turned into stone as the tablet had foretold.
+
+The next day the second brother undertook the task; but he succeeded no
+better than the first; for he could only find the second hundred of the
+pearls; and therefore he too was turned into stone.
+
+At last came the little dwarf’s turn; and he looked in the moss; but it
+was so hard to find the pearls, and the job was so tiresome!--so he sat
+down upon a stone and cried. And as he sat there, the king of the ants
+(whose life he had saved) came to help him, with five thousand ants; and
+it was not long before they had found all the pearls and laid them in a
+heap.
+
+The second tablet said: ‘The key of the princess’s bed-chamber must be
+fished up out of the lake.’ And as the dwarf came to the brink of it,
+he saw the two ducks whose lives he had saved swimming about; and they
+dived down and soon brought in the key from the bottom.
+
+The third task was the hardest. It was to choose out the youngest and
+the best of the king’s three daughters. Now they were all beautiful, and
+all exactly alike: but he was told that the eldest had eaten a piece of
+sugar, the next some sweet syrup, and the youngest a spoonful of honey;
+so he was to guess which it was that had eaten the honey.
+
+Then came the queen of the bees, who had been saved by the little dwarf
+from the fire, and she tried the lips of all three; but at last she sat
+upon the lips of the one that had eaten the honey: and so the dwarf knew
+which was the youngest. Thus the spell was broken, and all who had been
+turned into stones awoke, and took their proper forms. And the dwarf
+married the youngest and the best of the princesses, and was king after
+her father’s death; but his two brothers married the other two sisters.
+
+
+
+
+THE ELVES AND THE SHOEMAKER
+
+There was once a shoemaker, who worked very hard and was very honest:
+but still he could not earn enough to live upon; and at last all he
+had in the world was gone, save just leather enough to make one pair of
+shoes.
+
+Then he cut his leather out, all ready to make up the next day, meaning
+to rise early in the morning to his work. His conscience was clear and
+his heart light amidst all his troubles; so he went peaceably to bed,
+left all his cares to Heaven, and soon fell asleep. In the morning after
+he had said his prayers, he sat himself down to his work; when, to his
+great wonder, there stood the shoes all ready made, upon the table. The
+good man knew not what to say or think at such an odd thing happening.
+He looked at the workmanship; there was not one false stitch in the
+whole job; all was so neat and true, that it was quite a masterpiece.
+
+The same day a customer came in, and the shoes suited him so well that
+he willingly paid a price higher than usual for them; and the poor
+shoemaker, with the money, bought leather enough to make two pairs more.
+In the evening he cut out the work, and went to bed early, that he might
+get up and begin betimes next day; but he was saved all the trouble, for
+when he got up in the morning the work was done ready to his hand. Soon
+in came buyers, who paid him handsomely for his goods, so that he bought
+leather enough for four pair more. He cut out the work again overnight
+and found it done in the morning, as before; and so it went on for some
+time: what was got ready in the evening was always done by daybreak, and
+the good man soon became thriving and well off again.
+
+One evening, about Christmas-time, as he and his wife were sitting over
+the fire chatting together, he said to her, ‘I should like to sit up and
+watch tonight, that we may see who it is that comes and does my work for
+me.’ The wife liked the thought; so they left a light burning, and hid
+themselves in a corner of the room, behind a curtain that was hung up
+there, and watched what would happen.
+
+As soon as it was midnight, there came in two little naked dwarfs; and
+they sat themselves upon the shoemaker’s bench, took up all the work
+that was cut out, and began to ply with their little fingers, stitching
+and rapping and tapping away at such a rate, that the shoemaker was all
+wonder, and could not take his eyes off them. And on they went, till the
+job was quite done, and the shoes stood ready for use upon the table.
+This was long before daybreak; and then they bustled away as quick as
+lightning.
+
+The next day the wife said to the shoemaker. ‘These little wights have
+made us rich, and we ought to be thankful to them, and do them a good
+turn if we can. I am quite sorry to see them run about as they do; and
+indeed it is not very decent, for they have nothing upon their backs to
+keep off the cold. I’ll tell you what, I will make each of them a shirt,
+and a coat and waistcoat, and a pair of pantaloons into the bargain; and
+do you make each of them a little pair of shoes.’
+
+The thought pleased the good cobbler very much; and one evening, when
+all the things were ready, they laid them on the table, instead of the
+work that they used to cut out, and then went and hid themselves, to
+watch what the little elves would do.
+
+About midnight in they came, dancing and skipping, hopped round the
+room, and then went to sit down to their work as usual; but when they
+saw the clothes lying for them, they laughed and chuckled, and seemed
+mightily delighted.
+
+Then they dressed themselves in the twinkling of an eye, and danced and
+capered and sprang about, as merry as could be; till at last they danced
+out at the door, and away over the green.
+
+The good couple saw them no more; but everything went well with them
+from that time forward, as long as they lived.
+
+
+
+
+THE JUNIPER-TREE
+
+Long, long ago, some two thousand years or so, there lived a rich
+man with a good and beautiful wife. They loved each other dearly, but
+sorrowed much that they had no children. So greatly did they desire
+to have one, that the wife prayed for it day and night, but still they
+remained childless.
+
+In front of the house there was a court, in which grew a juniper-tree.
+One winter’s day the wife stood under the tree to peel some apples, and
+as she was peeling them, she cut her finger, and the blood fell on the
+snow. ‘Ah,’ sighed the woman heavily, ‘if I had but a child, as red as
+blood and as white as snow,’ and as she spoke the words, her heart grew
+light within her, and it seemed to her that her wish was granted, and
+she returned to the house feeling glad and comforted. A month passed,
+and the snow had all disappeared; then another month went by, and all
+the earth was green. So the months followed one another, and first the
+trees budded in the woods, and soon the green branches grew thickly
+intertwined, and then the blossoms began to fall. Once again the wife
+stood under the juniper-tree, and it was so full of sweet scent that her
+heart leaped for joy, and she was so overcome with her happiness, that
+she fell on her knees. Presently the fruit became round and firm, and
+she was glad and at peace; but when they were fully ripe she picked the
+berries and ate eagerly of them, and then she grew sad and ill. A little
+while later she called her husband, and said to him, weeping. ‘If I
+die, bury me under the juniper-tree.’ Then she felt comforted and happy
+again, and before another month had passed she had a little child, and
+when she saw that it was as white as snow and as red as blood, her joy
+was so great that she died.
+
+Her husband buried her under the juniper-tree, and wept bitterly for
+her. By degrees, however, his sorrow grew less, and although at times he
+still grieved over his loss, he was able to go about as usual, and later
+on he married again.
+
+He now had a little daughter born to him; the child of his first wife
+was a boy, who was as red as blood and as white as snow. The mother
+loved her daughter very much, and when she looked at her and then looked
+at the boy, it pierced her heart to think that he would always stand in
+the way of her own child, and she was continually thinking how she could
+get the whole of the property for her. This evil thought took possession
+of her more and more, and made her behave very unkindly to the boy. She
+drove him from place to place with cuffings and buffetings, so that the
+poor child went about in fear, and had no peace from the time he left
+school to the time he went back.
+
+One day the little daughter came running to her mother in the
+store-room, and said, ‘Mother, give me an apple.’ ‘Yes, my child,’ said
+the wife, and she gave her a beautiful apple out of the chest; the chest
+had a very heavy lid and a large iron lock.
+
+‘Mother,’ said the little daughter again, ‘may not brother have one
+too?’ The mother was angry at this, but she answered, ‘Yes, when he
+comes out of school.’
+
+Just then she looked out of the window and saw him coming, and it seemed
+as if an evil spirit entered into her, for she snatched the apple out
+of her little daughter’s hand, and said, ‘You shall not have one before
+your brother.’ She threw the apple into the chest and shut it to. The
+little boy now came in, and the evil spirit in the wife made her say
+kindly to him, ‘My son, will you have an apple?’ but she gave him a
+wicked look. ‘Mother,’ said the boy, ‘how dreadful you look! Yes, give
+me an apple.’ The thought came to her that she would kill him. ‘Come
+with me,’ she said, and she lifted up the lid of the chest; ‘take one
+out for yourself.’ And as he bent over to do so, the evil spirit urged
+her, and crash! down went the lid, and off went the little boy’s head.
+Then she was overwhelmed with fear at the thought of what she had done.
+‘If only I can prevent anyone knowing that I did it,’ she thought. So
+she went upstairs to her room, and took a white handkerchief out of
+her top drawer; then she set the boy’s head again on his shoulders, and
+bound it with the handkerchief so that nothing could be seen, and placed
+him on a chair by the door with an apple in his hand.
+
+Soon after this, little Marleen came up to her mother who was stirring
+a pot of boiling water over the fire, and said, ‘Mother, brother is
+sitting by the door with an apple in his hand, and he looks so pale;
+and when I asked him to give me the apple, he did not answer, and that
+frightened me.’
+
+‘Go to him again,’ said her mother, ‘and if he does not answer, give him
+a box on the ear.’ So little Marleen went, and said, ‘Brother, give me
+that apple,’ but he did not say a word; then she gave him a box on the
+ear, and his head rolled off. She was so terrified at this, that she ran
+crying and screaming to her mother. ‘Oh!’ she said, ‘I have knocked off
+brother’s head,’ and then she wept and wept, and nothing would stop her.
+
+‘What have you done!’ said her mother, ‘but no one must know about it,
+so you must keep silence; what is done can’t be undone; we will make
+him into puddings.’ And she took the little boy and cut him up, made him
+into puddings, and put him in the pot. But Marleen stood looking on,
+and wept and wept, and her tears fell into the pot, so that there was no
+need of salt.
+
+Presently the father came home and sat down to his dinner; he asked,
+‘Where is my son?’ The mother said nothing, but gave him a large dish of
+black pudding, and Marleen still wept without ceasing.
+
+The father again asked, ‘Where is my son?’
+
+‘Oh,’ answered the wife, ‘he is gone into the country to his mother’s
+great uncle; he is going to stay there some time.’
+
+‘What has he gone there for, and he never even said goodbye to me!’
+
+‘Well, he likes being there, and he told me he should be away quite six
+weeks; he is well looked after there.’
+
+‘I feel very unhappy about it,’ said the husband, ‘in case it should not
+be all right, and he ought to have said goodbye to me.’
+
+With this he went on with his dinner, and said, ‘Little Marleen, why do
+you weep? Brother will soon be back.’ Then he asked his wife for more
+pudding, and as he ate, he threw the bones under the table.
+
+Little Marleen went upstairs and took her best silk handkerchief out of
+her bottom drawer, and in it she wrapped all the bones from under the
+table and carried them outside, and all the time she did nothing but
+weep. Then she laid them in the green grass under the juniper-tree, and
+she had no sooner done so, then all her sadness seemed to leave her,
+and she wept no more. And now the juniper-tree began to move, and the
+branches waved backwards and forwards, first away from one another, and
+then together again, as it might be someone clapping their hands for
+joy. After this a mist came round the tree, and in the midst of it there
+was a burning as of fire, and out of the fire there flew a beautiful
+bird, that rose high into the air, singing magnificently, and when it
+could no more be seen, the juniper-tree stood there as before, and the
+silk handkerchief and the bones were gone.
+
+Little Marleen now felt as lighthearted and happy as if her brother were
+still alive, and she went back to the house and sat down cheerfully to
+the table and ate.
+
+The bird flew away and alighted on the house of a goldsmith and began to
+sing:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The goldsmith was in his workshop making a gold chain, when he heard the
+song of the bird on his roof. He thought it so beautiful that he got
+up and ran out, and as he crossed the threshold he lost one of his
+slippers. But he ran on into the middle of the street, with a slipper on
+one foot and a sock on the other; he still had on his apron, and still
+held the gold chain and the pincers in his hands, and so he stood gazing
+up at the bird, while the sun came shining brightly down on the street.
+
+‘Bird,’ he said, ‘how beautifully you sing! Sing me that song again.’
+
+‘Nay,’ said the bird, ‘I do not sing twice for nothing. Give that gold
+chain, and I will sing it you again.’
+
+‘Here is the chain, take it,’ said the goldsmith. ‘Only sing me that
+again.’
+
+The bird flew down and took the gold chain in his right claw, and then
+he alighted again in front of the goldsmith and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+Then he flew away, and settled on the roof of a shoemaker’s house and
+sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The shoemaker heard him, and he jumped up and ran out in his
+shirt-sleeves, and stood looking up at the bird on the roof with his
+hand over his eyes to keep himself from being blinded by the sun.
+
+‘Bird,’ he said, ‘how beautifully you sing!’ Then he called through the
+door to his wife: ‘Wife, come out; here is a bird, come and look at it
+and hear how beautifully it sings.’ Then he called his daughter and the
+children, then the apprentices, girls and boys, and they all ran up the
+street to look at the bird, and saw how splendid it was with its red
+and green feathers, and its neck like burnished gold, and eyes like two
+bright stars in its head.
+
+‘Bird,’ said the shoemaker, ‘sing me that song again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; you must
+give me something.’
+
+‘Wife,’ said the man, ‘go into the garret; on the upper shelf you will
+see a pair of red shoes; bring them to me.’ The wife went in and fetched
+the shoes.
+
+‘There, bird,’ said the shoemaker, ‘now sing me that song again.’
+
+The bird flew down and took the red shoes in his left claw, and then he
+went back to the roof and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+When he had finished, he flew away. He had the chain in his right claw
+and the shoes in his left, and he flew right away to a mill, and the
+mill went ‘Click clack, click clack, click clack.’ Inside the mill were
+twenty of the miller’s men hewing a stone, and as they went ‘Hick hack,
+hick hack, hick hack,’ the mill went ‘Click clack, click clack, click
+clack.’
+
+The bird settled on a lime-tree in front of the mill and sang:
+
+ ‘My mother killed her little son;
+
+then one of the men left off,
+
+  My father grieved when I was gone;
+
+two more men left off and listened,
+
+  My sister loved me best of all;
+
+then four more left off,
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+now there were only eight at work,
+
+  Underneath
+
+And now only five,
+
+  the juniper-tree.
+
+And now only one,
+
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+then he looked up and the last one had left off work.
+
+‘Bird,’ he said, ‘what a beautiful song that is you sing! Let me hear it
+too; sing it again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; give me that
+millstone, and I will sing it again.’
+
+‘If it belonged to me alone,’ said the man, ‘you should have it.’
+
+‘Yes, yes,’ said the others: ‘if he will sing again, he can have it.’
+
+The bird came down, and all the twenty millers set to and lifted up the
+stone with a beam; then the bird put his head through the hole and took
+the stone round his neck like a collar, and flew back with it to the
+tree and sang--
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And when he had finished his song, he spread his wings, and with the
+chain in his right claw, the shoes in his left, and the millstone round
+his neck, he flew right away to his father’s house.
+
+The father, the mother, and little Marleen were having their dinner.
+
+‘How lighthearted I feel,’ said the father, ‘so pleased and cheerful.’
+
+‘And I,’ said the mother, ‘I feel so uneasy, as if a heavy thunderstorm
+were coming.’
+
+But little Marleen sat and wept and wept.
+
+Then the bird came flying towards the house and settled on the roof.
+
+‘I do feel so happy,’ said the father, ‘and how beautifully the sun
+shines; I feel just as if I were going to see an old friend again.’
+
+‘Ah!’ said the wife, ‘and I am so full of distress and uneasiness that
+my teeth chatter, and I feel as if there were a fire in my veins,’ and
+she tore open her dress; and all the while little Marleen sat in the
+corner and wept, and the plate on her knees was wet with her tears.
+
+The bird now flew to the juniper-tree and began singing:
+
+ ‘My mother killed her little son;
+
+the mother shut her eyes and her ears, that she might see and hear
+nothing, but there was a roaring sound in her ears like that of a
+violent storm, and in her eyes a burning and flashing like lightning:
+
+  My father grieved when I was gone;
+
+‘Look, mother,’ said the man, ‘at the beautiful bird that is singing so
+magnificently; and how warm and bright the sun is, and what a delicious
+scent of spice in the air!’
+
+  My sister loved me best of all;
+
+then little Marleen laid her head down on her knees and sobbed.
+
+‘I must go outside and see the bird nearer,’ said the man.
+
+‘Ah, do not go!’ cried the wife. ‘I feel as if the whole house were in
+flames!’
+
+But the man went out and looked at the bird.
+
+ She laid her kerchief over me,
+ And took my bones that they might lie
+ Underneath the juniper-tree
+ Kywitt, Kywitt, what a beautiful bird am I!’
+
+With that the bird let fall the gold chain, and it fell just round the
+man’s neck, so that it fitted him exactly.
+
+He went inside, and said, ‘See, what a splendid bird that is; he has
+given me this beautiful gold chain, and looks so beautiful himself.’
+
+But the wife was in such fear and trouble, that she fell on the floor,
+and her cap fell from her head.
+
+Then the bird began again:
+
+ ‘My mother killed her little son;
+
+‘Ah me!’ cried the wife, ‘if I were but a thousand feet beneath the
+earth, that I might not hear that song.’
+
+  My father grieved when I was gone;
+
+then the woman fell down again as if dead.
+
+  My sister loved me best of all;
+
+‘Well,’ said little Marleen, ‘I will go out too and see if the bird will
+give me anything.’
+
+So she went out.
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+and he threw down the shoes to her,
+
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And she now felt quite happy and lighthearted; she put on the shoes and
+danced and jumped about in them. ‘I was so miserable,’ she said, ‘when I
+came out, but that has all passed away; that is indeed a splendid bird,
+and he has given me a pair of red shoes.’
+
+The wife sprang up, with her hair standing out from her head like flames
+of fire. ‘Then I will go out too,’ she said, ‘and see if it will lighten
+my misery, for I feel as if the world were coming to an end.’
+
+But as she crossed the threshold, crash! the bird threw the millstone
+down on her head, and she was crushed to death.
+
+The father and little Marleen heard the sound and ran out, but they only
+saw mist and flame and fire rising from the spot, and when these had
+passed, there stood the little brother, and he took the father and
+little Marleen by the hand; then they all three rejoiced, and went
+inside together and sat down to their dinners and ate.
+
+
+
+
+THE TURNIP
+
+There were two brothers who were both soldiers; the one was rich and
+the other poor. The poor man thought he would try to better himself; so,
+pulling off his red coat, he became a gardener, and dug his ground well,
+and sowed turnips.
+
+When the seed came up, there was one plant bigger than all the rest; and
+it kept getting larger and larger, and seemed as if it would never cease
+growing; so that it might have been called the prince of turnips for
+there never was such a one seen before, and never will again. At last it
+was so big that it filled a cart, and two oxen could hardly draw it; and
+the gardener knew not what in the world to do with it, nor whether it
+would be a blessing or a curse to him. One day he said to himself, ‘What
+shall I do with it? if I sell it, it will bring no more than another;
+and for eating, the little turnips are better than this; the best thing
+perhaps is to carry it and give it to the king as a mark of respect.’
+
+Then he yoked his oxen, and drew the turnip to the court, and gave it
+to the king. ‘What a wonderful thing!’ said the king; ‘I have seen many
+strange things, but such a monster as this I never saw. Where did you
+get the seed? or is it only your good luck? If so, you are a true child
+of fortune.’ ‘Ah, no!’ answered the gardener, ‘I am no child of fortune;
+I am a poor soldier, who never could get enough to live upon; so I
+laid aside my red coat, and set to work, tilling the ground. I have a
+brother, who is rich, and your majesty knows him well, and all the world
+knows him; but because I am poor, everybody forgets me.’
+
+The king then took pity on him, and said, ‘You shall be poor no
+longer. I will give you so much that you shall be even richer than your
+brother.’ Then he gave him gold and lands and flocks, and made him so
+rich that his brother’s fortune could not at all be compared with his.
+
+When the brother heard of all this, and how a turnip had made the
+gardener so rich, he envied him sorely, and bethought himself how he
+could contrive to get the same good fortune for himself. However, he
+determined to manage more cleverly than his brother, and got together a
+rich present of gold and fine horses for the king; and thought he must
+have a much larger gift in return; for if his brother had received so
+much for only a turnip, what must his present be worth?
+
+The king took the gift very graciously, and said he knew not what to
+give in return more valuable and wonderful than the great turnip; so
+the soldier was forced to put it into a cart, and drag it home with him.
+When he reached home, he knew not upon whom to vent his rage and spite;
+and at length wicked thoughts came into his head, and he resolved to
+kill his brother.
+
+So he hired some villains to murder him; and having shown them where to
+lie in ambush, he went to his brother, and said, ‘Dear brother, I have
+found a hidden treasure; let us go and dig it up, and share it between
+us.’ The other had no suspicions of his roguery: so they went out
+together, and as they were travelling along, the murderers rushed out
+upon him, bound him, and were going to hang him on a tree.
+
+But whilst they were getting all ready, they heard the trampling of a
+horse at a distance, which so frightened them that they pushed their
+prisoner neck and shoulders together into a sack, and swung him up by a
+cord to the tree, where they left him dangling, and ran away. Meantime
+he worked and worked away, till he made a hole large enough to put out
+his head.
+
+When the horseman came up, he proved to be a student, a merry fellow,
+who was journeying along on his nag, and singing as he went. As soon as
+the man in the sack saw him passing under the tree, he cried out, ‘Good
+morning! good morning to thee, my friend!’ The student looked about
+everywhere; and seeing no one, and not knowing where the voice came
+from, cried out, ‘Who calls me?’
+
+Then the man in the tree answered, ‘Lift up thine eyes, for behold here
+I sit in the sack of wisdom; here have I, in a short time, learned great
+and wondrous things. Compared to this seat, all the learning of the
+schools is as empty air. A little longer, and I shall know all that man
+can know, and shall come forth wiser than the wisest of mankind. Here
+I discern the signs and motions of the heavens and the stars; the laws
+that control the winds; the number of the sands on the seashore; the
+healing of the sick; the virtues of all simples, of birds, and of
+precious stones. Wert thou but once here, my friend, though wouldst feel
+and own the power of knowledge.
+
+The student listened to all this and wondered much; at last he said,
+‘Blessed be the day and hour when I found you; cannot you contrive to
+let me into the sack for a little while?’ Then the other answered, as if
+very unwillingly, ‘A little space I may allow thee to sit here, if thou
+wilt reward me well and entreat me kindly; but thou must tarry yet an
+hour below, till I have learnt some little matters that are yet unknown
+to me.’
+
+So the student sat himself down and waited a while; but the time hung
+heavy upon him, and he begged earnestly that he might ascend forthwith,
+for his thirst for knowledge was great. Then the other pretended to give
+way, and said, ‘Thou must let the sack of wisdom descend, by untying
+yonder cord, and then thou shalt enter.’ So the student let him down,
+opened the sack, and set him free. ‘Now then,’ cried he, ‘let me ascend
+quickly.’ As he began to put himself into the sack heels first, ‘Wait a
+while,’ said the gardener, ‘that is not the way.’ Then he pushed him
+in head first, tied up the sack, and soon swung up the searcher after
+wisdom dangling in the air. ‘How is it with thee, friend?’ said he,
+‘dost thou not feel that wisdom comes unto thee? Rest there in peace,
+till thou art a wiser man than thou wert.’
+
+So saying, he trotted off on the student’s nag, and left the poor fellow
+to gather wisdom till somebody should come and let him down.
+
+
+
+
+CLEVER HANS
+
+The mother of Hans said: ‘Whither away, Hans?’ Hans answered: ‘To
+Gretel.’ ‘Behave well, Hans.’ ‘Oh, I’ll behave well. Goodbye, mother.’
+‘Goodbye, Hans.’ Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day,
+Hans. What do you bring that is good?’ ‘I bring nothing, I want to have
+something given me.’ Gretel presents Hans with a needle, Hans says:
+‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the needle, sticks it into a hay-cart, and follows the cart
+home. ‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’
+‘With Gretel.’ ‘What did you take her?’ ‘Took nothing; had something
+given me.’ ‘What did Gretel give you?’ ‘Gave me a needle.’ ‘Where is the
+needle, Hans?’ ‘Stuck in the hay-cart.’ ‘That was ill done, Hans. You
+should have stuck the needle in your sleeve.’ ‘Never mind, I’ll do
+better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What do you bring that is
+good?’ ‘I bring nothing. I want to have something given to me.’ Gretel
+presents Hans with a knife. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans
+takes the knife, sticks it in his sleeve, and goes home. ‘Good evening,
+mother.’ ‘Good evening, Hans. Where have you been?’ ‘With Gretel.’ What
+did you take her?’ ‘Took her nothing, she gave me something.’ ‘What did
+Gretel give you?’ ‘Gave me a knife.’ ‘Where is the knife, Hans?’ ‘Stuck
+in my sleeve.’ ‘That’s ill done, Hans, you should have put the knife in
+your pocket.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a young goat. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans takes
+the goat, ties its legs, and puts it in his pocket. When he gets home it
+is suffocated. ‘Good evening, mother.’ ‘Good evening, Hans. Where have
+you been?’ ‘With Gretel.’ ‘What did you take her?’ ‘Took nothing, she
+gave me something.’ ‘What did Gretel give you?’ ‘She gave me a goat.’
+‘Where is the goat, Hans?’ ‘Put it in my pocket.’ ‘That was ill done,
+Hans, you should have put a rope round the goat’s neck.’ ‘Never mind,
+will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a piece of bacon. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the bacon, ties it to a rope, and drags it away behind him.
+The dogs come and devour the bacon. When he gets home, he has the rope
+in his hand, and there is no longer anything hanging on to it. ‘Good
+evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took her nothing, she gave me
+something.’ ‘What did Gretel give you?’ ‘Gave me a bit of bacon.’ ‘Where
+is the bacon, Hans?’ ‘I tied it to a rope, brought it home, dogs took
+it.’ ‘That was ill done, Hans, you should have carried the bacon on your
+head.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to Gretel.
+‘Good day, Gretel.’ ‘Good day, Hans, What good thing do you bring?’ ‘I
+bring nothing, but would have something given.’ Gretel presents Hans
+with a calf. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the calf, puts it on his head, and the calf kicks his face.
+‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took nothing, but had something
+given me.’ ‘What did Gretel give you?’ ‘A calf.’ ‘Where have you the
+calf, Hans?’ ‘I set it on my head and it kicked my face.’ ‘That was
+ill done, Hans, you should have led the calf, and put it in the stall.’
+‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’
+
+Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good
+thing do you bring?’ ‘I bring nothing, but would have something given.’
+Gretel says to Hans: ‘I will go with you.’
+
+Hans takes Gretel, ties her to a rope, leads her to the rack, and binds
+her fast. Then Hans goes to his mother. ‘Good evening, mother.’ ‘Good
+evening, Hans. Where have you been?’ ‘With Gretel.’ ‘What did you take
+her?’ ‘I took her nothing.’ ‘What did Gretel give you?’ ‘She gave me
+nothing, she came with me.’ ‘Where have you left Gretel?’ ‘I led her by
+the rope, tied her to the rack, and scattered some grass for her.’ ‘That
+was ill done, Hans, you should have cast friendly eyes on her.’ ‘Never
+mind, will do better.’
+
+Hans went into the stable, cut out all the calves’ and sheep’s eyes,
+and threw them in Gretel’s face. Then Gretel became angry, tore herself
+loose and ran away, and was no longer the bride of Hans.
+
+
+
+
+THE THREE LANGUAGES
+
+An aged count once lived in Switzerland, who had an only son, but he
+was stupid, and could learn nothing. Then said the father: ‘Hark you,
+my son, try as I will I can get nothing into your head. You must go from
+hence, I will give you into the care of a celebrated master, who shall
+see what he can do with you.’ The youth was sent into a strange town,
+and remained a whole year with the master. At the end of this time,
+he came home again, and his father asked: ‘Now, my son, what have you
+learnt?’ ‘Father, I have learnt what the dogs say when they bark.’ ‘Lord
+have mercy on us!’ cried the father; ‘is that all you have learnt? I
+will send you into another town, to another master.’ The youth was taken
+thither, and stayed a year with this master likewise. When he came back
+the father again asked: ‘My son, what have you learnt?’ He answered:
+‘Father, I have learnt what the birds say.’ Then the father fell into a
+rage and said: ‘Oh, you lost man, you have spent the precious time and
+learnt nothing; are you not ashamed to appear before my eyes? I will
+send you to a third master, but if you learn nothing this time also, I
+will no longer be your father.’ The youth remained a whole year with the
+third master also, and when he came home again, and his father inquired:
+‘My son, what have you learnt?’ he answered: ‘Dear father, I have this
+year learnt what the frogs croak.’ Then the father fell into the most
+furious anger, sprang up, called his people thither, and said: ‘This man
+is no longer my son, I drive him forth, and command you to take him
+out into the forest, and kill him.’ They took him forth, but when they
+should have killed him, they could not do it for pity, and let him go,
+and they cut the eyes and tongue out of a deer that they might carry
+them to the old man as a token.
+
+The youth wandered on, and after some time came to a fortress where he
+begged for a night’s lodging. ‘Yes,’ said the lord of the castle, ‘if
+you will pass the night down there in the old tower, go thither; but I
+warn you, it is at the peril of your life, for it is full of wild dogs,
+which bark and howl without stopping, and at certain hours a man has to
+be given to them, whom they at once devour.’ The whole district was in
+sorrow and dismay because of them, and yet no one could do anything to
+stop this. The youth, however, was without fear, and said: ‘Just let me
+go down to the barking dogs, and give me something that I can throw to
+them; they will do nothing to harm me.’ As he himself would have it so,
+they gave him some food for the wild animals, and led him down to the
+tower. When he went inside, the dogs did not bark at him, but wagged
+their tails quite amicably around him, ate what he set before them, and
+did not hurt one hair of his head. Next morning, to the astonishment of
+everyone, he came out again safe and unharmed, and said to the lord of
+the castle: ‘The dogs have revealed to me, in their own language, why
+they dwell there, and bring evil on the land. They are bewitched, and
+are obliged to watch over a great treasure which is below in the tower,
+and they can have no rest until it is taken away, and I have likewise
+learnt, from their discourse, how that is to be done.’ Then all who
+heard this rejoiced, and the lord of the castle said he would adopt him
+as a son if he accomplished it successfully. He went down again, and
+as he knew what he had to do, he did it thoroughly, and brought a chest
+full of gold out with him. The howling of the wild dogs was henceforth
+heard no more; they had disappeared, and the country was freed from the
+trouble.
+
+After some time he took it in his head that he would travel to Rome. On
+the way he passed by a marsh, in which a number of frogs were sitting
+croaking. He listened to them, and when he became aware of what they
+were saying, he grew very thoughtful and sad. At last he arrived in
+Rome, where the Pope had just died, and there was great doubt among
+the cardinals as to whom they should appoint as his successor. They at
+length agreed that the person should be chosen as pope who should be
+distinguished by some divine and miraculous token. And just as that was
+decided on, the young count entered into the church, and suddenly two
+snow-white doves flew on his shoulders and remained sitting there. The
+ecclesiastics recognized therein the token from above, and asked him on
+the spot if he would be pope. He was undecided, and knew not if he were
+worthy of this, but the doves counselled him to do it, and at length he
+said yes. Then was he anointed and consecrated, and thus was fulfilled
+what he had heard from the frogs on his way, which had so affected him,
+that he was to be his Holiness the Pope. Then he had to sing a mass, and
+did not know one word of it, but the two doves sat continually on his
+shoulders, and said it all in his ear.
+
+
+
+
+THE FOX AND THE CAT
+
+It happened that the cat met the fox in a forest, and as she thought to
+herself: ‘He is clever and full of experience, and much esteemed in the
+world,’ she spoke to him in a friendly way. ‘Good day, dear Mr Fox,
+how are you? How is all with you? How are you getting on in these hard
+times?’ The fox, full of all kinds of arrogance, looked at the cat from
+head to foot, and for a long time did not know whether he would give
+any answer or not. At last he said: ‘Oh, you wretched beard-cleaner, you
+piebald fool, you hungry mouse-hunter, what can you be thinking of? Have
+you the cheek to ask how I am getting on? What have you learnt? How
+many arts do you understand?’ ‘I understand but one,’ replied the
+cat, modestly. ‘What art is that?’ asked the fox. ‘When the hounds are
+following me, I can spring into a tree and save myself.’ ‘Is that all?’
+said the fox. ‘I am master of a hundred arts, and have into the bargain
+a sackful of cunning. You make me sorry for you; come with me, I will
+teach you how people get away from the hounds.’ Just then came a hunter
+with four dogs. The cat sprang nimbly up a tree, and sat down at the top
+of it, where the branches and foliage quite concealed her. ‘Open your
+sack, Mr Fox, open your sack,’ cried the cat to him, but the dogs had
+already seized him, and were holding him fast. ‘Ah, Mr Fox,’ cried the
+cat. ‘You with your hundred arts are left in the lurch! Had you been
+able to climb like me, you would not have lost your life.’
+
+
+
+
+THE FOUR CLEVER BROTHERS
+
+‘Dear children,’ said a poor man to his four sons, ‘I have nothing to
+give you; you must go out into the wide world and try your luck. Begin
+by learning some craft or another, and see how you can get on.’ So the
+four brothers took their walking-sticks in their hands, and their little
+bundles on their shoulders, and after bidding their father goodbye, went
+all out at the gate together. When they had got on some way they came
+to four crossways, each leading to a different country. Then the eldest
+said, ‘Here we must part; but this day four years we will come back
+to this spot, and in the meantime each must try what he can do for
+himself.’
+
+So each brother went his way; and as the eldest was hastening on a man
+met him, and asked him where he was going, and what he wanted. ‘I am
+going to try my luck in the world, and should like to begin by learning
+some art or trade,’ answered he. ‘Then,’ said the man, ‘go with me, and
+I will teach you to become the cunningest thief that ever was.’ ‘No,’
+said the other, ‘that is not an honest calling, and what can one look
+to earn by it in the end but the gallows?’ ‘Oh!’ said the man, ‘you need
+not fear the gallows; for I will only teach you to steal what will be
+fair game: I meddle with nothing but what no one else can get or care
+anything about, and where no one can find you out.’ So the young man
+agreed to follow his trade, and he soon showed himself so clever, that
+nothing could escape him that he had once set his mind upon.
+
+The second brother also met a man, who, when he found out what he was
+setting out upon, asked him what craft he meant to follow. ‘I do not
+know yet,’ said he. ‘Then come with me, and be a star-gazer. It is a
+noble art, for nothing can be hidden from you, when once you understand
+the stars.’ The plan pleased him much, and he soon became such a skilful
+star-gazer, that when he had served out his time, and wanted to leave
+his master, he gave him a glass, and said, ‘With this you can see all
+that is passing in the sky and on earth, and nothing can be hidden from
+you.’
+
+The third brother met a huntsman, who took him with him, and taught him
+so well all that belonged to hunting, that he became very clever in the
+craft of the woods; and when he left his master he gave him a bow, and
+said, ‘Whatever you shoot at with this bow you will be sure to hit.’
+
+The youngest brother likewise met a man who asked him what he wished to
+do. ‘Would not you like,’ said he, ‘to be a tailor?’ ‘Oh, no!’ said
+the young man; ‘sitting cross-legged from morning to night, working
+backwards and forwards with a needle and goose, will never suit me.’
+‘Oh!’ answered the man, ‘that is not my sort of tailoring; come with me,
+and you will learn quite another kind of craft from that.’ Not knowing
+what better to do, he came into the plan, and learnt tailoring from the
+beginning; and when he left his master, he gave him a needle, and said,
+‘You can sew anything with this, be it as soft as an egg or as hard as
+steel; and the joint will be so fine that no seam will be seen.’
+
+After the space of four years, at the time agreed upon, the four
+brothers met at the four cross-roads; and having welcomed each other,
+set off towards their father’s home, where they told him all that had
+happened to them, and how each had learned some craft.
+
+Then, one day, as they were sitting before the house under a very high
+tree, the father said, ‘I should like to try what each of you can do in
+this way.’ So he looked up, and said to the second son, ‘At the top of
+this tree there is a chaffinch’s nest; tell me how many eggs there are
+in it.’ The star-gazer took his glass, looked up, and said, ‘Five.’
+‘Now,’ said the father to the eldest son, ‘take away the eggs without
+letting the bird that is sitting upon them and hatching them know
+anything of what you are doing.’ So the cunning thief climbed up the
+tree, and brought away to his father the five eggs from under the bird;
+and it never saw or felt what he was doing, but kept sitting on at its
+ease. Then the father took the eggs, and put one on each corner of the
+table, and the fifth in the middle, and said to the huntsman, ‘Cut all
+the eggs in two pieces at one shot.’ The huntsman took up his bow, and
+at one shot struck all the five eggs as his father wished.
+
+‘Now comes your turn,’ said he to the young tailor; ‘sew the eggs and
+the young birds in them together again, so neatly that the shot shall
+have done them no harm.’ Then the tailor took his needle, and sewed the
+eggs as he was told; and when he had done, the thief was sent to take
+them back to the nest, and put them under the bird without its knowing
+it. Then she went on sitting, and hatched them: and in a few days they
+crawled out, and had only a little red streak across their necks, where
+the tailor had sewn them together.
+
+‘Well done, sons!’ said the old man; ‘you have made good use of your
+time, and learnt something worth the knowing; but I am sure I do not
+know which ought to have the prize. Oh, that a time might soon come for
+you to turn your skill to some account!’
+
+Not long after this there was a great bustle in the country; for the
+king’s daughter had been carried off by a mighty dragon, and the king
+mourned over his loss day and night, and made it known that whoever
+brought her back to him should have her for a wife. Then the four
+brothers said to each other, ‘Here is a chance for us; let us try
+what we can do.’ And they agreed to see whether they could not set the
+princess free. ‘I will soon find out where she is, however,’ said the
+star-gazer, as he looked through his glass; and he soon cried out, ‘I
+see her afar off, sitting upon a rock in the sea, and I can spy the
+dragon close by, guarding her.’ Then he went to the king, and asked for
+a ship for himself and his brothers; and they sailed together over the
+sea, till they came to the right place. There they found the princess
+sitting, as the star-gazer had said, on the rock; and the dragon was
+lying asleep, with his head upon her lap. ‘I dare not shoot at him,’
+said the huntsman, ‘for I should kill the beautiful young lady also.’
+‘Then I will try my skill,’ said the thief, and went and stole her away
+from under the dragon, so quietly and gently that the beast did not know
+it, but went on snoring.
+
+Then away they hastened with her full of joy in their boat towards the
+ship; but soon came the dragon roaring behind them through the air; for
+he awoke and missed the princess. But when he got over the boat, and
+wanted to pounce upon them and carry off the princess, the huntsman took
+up his bow and shot him straight through the heart so that he fell down
+dead. They were still not safe; for he was such a great beast that in
+his fall he overset the boat, and they had to swim in the open sea
+upon a few planks. So the tailor took his needle, and with a few large
+stitches put some of the planks together; and he sat down upon these,
+and sailed about and gathered up all pieces of the boat; and then tacked
+them together so quickly that the boat was soon ready, and they then
+reached the ship and got home safe.
+
+When they had brought home the princess to her father, there was great
+rejoicing; and he said to the four brothers, ‘One of you shall marry
+her, but you must settle amongst yourselves which it is to be.’ Then
+there arose a quarrel between them; and the star-gazer said, ‘If I had
+not found the princess out, all your skill would have been of no use;
+therefore she ought to be mine.’ ‘Your seeing her would have been of
+no use,’ said the thief, ‘if I had not taken her away from the dragon;
+therefore she ought to be mine.’ ‘No, she is mine,’ said the huntsman;
+‘for if I had not killed the dragon, he would, after all, have torn you
+and the princess into pieces.’ ‘And if I had not sewn the boat together
+again,’ said the tailor, ‘you would all have been drowned, therefore she
+is mine.’ Then the king put in a word, and said, ‘Each of you is right;
+and as all cannot have the young lady, the best way is for neither of
+you to have her: for the truth is, there is somebody she likes a great
+deal better. But to make up for your loss, I will give each of you, as a
+reward for his skill, half a kingdom.’ So the brothers agreed that this
+plan would be much better than either quarrelling or marrying a lady who
+had no mind to have them. And the king then gave to each half a kingdom,
+as he had said; and they lived very happily the rest of their days, and
+took good care of their father; and somebody took better care of the
+young lady, than to let either the dragon or one of the craftsmen have
+her again.
+
+
+
+
+LILY AND THE LION
+
+A merchant, who had three daughters, was once setting out upon a
+journey; but before he went he asked each daughter what gift he should
+bring back for her. The eldest wished for pearls; the second for jewels;
+but the third, who was called Lily, said, ‘Dear father, bring me a
+rose.’ Now it was no easy task to find a rose, for it was the middle
+of winter; yet as she was his prettiest daughter, and was very fond of
+flowers, her father said he would try what he could do. So he kissed all
+three, and bid them goodbye.
+
+And when the time came for him to go home, he had bought pearls and
+jewels for the two eldest, but he had sought everywhere in vain for the
+rose; and when he went into any garden and asked for such a thing, the
+people laughed at him, and asked him whether he thought roses grew in
+snow. This grieved him very much, for Lily was his dearest child; and as
+he was journeying home, thinking what he should bring her, he came to a
+fine castle; and around the castle was a garden, in one half of which it
+seemed to be summer-time and in the other half winter. On one side the
+finest flowers were in full bloom, and on the other everything looked
+dreary and buried in the snow. ‘A lucky hit!’ said he, as he called to
+his servant, and told him to go to a beautiful bed of roses that was
+there, and bring him away one of the finest flowers.
+
+This done, they were riding away well pleased, when up sprang a fierce
+lion, and roared out, ‘Whoever has stolen my roses shall be eaten up
+alive!’ Then the man said, ‘I knew not that the garden belonged to you;
+can nothing save my life?’ ‘No!’ said the lion, ‘nothing, unless you
+undertake to give me whatever meets you on your return home; if you
+agree to this, I will give you your life, and the rose too for your
+daughter.’ But the man was unwilling to do so and said, ‘It may be my
+youngest daughter, who loves me most, and always runs to meet me when
+I go home.’ Then the servant was greatly frightened, and said, ‘It may
+perhaps be only a cat or a dog.’ And at last the man yielded with a
+heavy heart, and took the rose; and said he would give the lion whatever
+should meet him first on his return.
+
+And as he came near home, it was Lily, his youngest and dearest
+daughter, that met him; she came running, and kissed him, and welcomed
+him home; and when she saw that he had brought her the rose, she was
+still more glad. But her father began to be very sorrowful, and to weep,
+saying, ‘Alas, my dearest child! I have bought this flower at a high
+price, for I have said I would give you to a wild lion; and when he has
+you, he will tear you in pieces, and eat you.’ Then he told her all that
+had happened, and said she should not go, let what would happen.
+
+But she comforted him, and said, ‘Dear father, the word you have given
+must be kept; I will go to the lion, and soothe him: perhaps he will let
+me come safe home again.’
+
+The next morning she asked the way she was to go, and took leave of her
+father, and went forth with a bold heart into the wood. But the lion was
+an enchanted prince. By day he and all his court were lions, but in the
+evening they took their right forms again. And when Lily came to the
+castle, he welcomed her so courteously that she agreed to marry him. The
+wedding-feast was held, and they lived happily together a long time. The
+prince was only to be seen as soon as evening came, and then he held his
+court; but every morning he left his bride, and went away by himself,
+she knew not whither, till the night came again.
+
+After some time he said to her, ‘Tomorrow there will be a great feast in
+your father’s house, for your eldest sister is to be married; and if
+you wish to go and visit her my lions shall lead you thither.’ Then she
+rejoiced much at the thoughts of seeing her father once more, and set
+out with the lions; and everyone was overjoyed to see her, for they had
+thought her dead long since. But she told them how happy she was, and
+stayed till the feast was over, and then went back to the wood.
+
+Her second sister was soon after married, and when Lily was asked to
+go to the wedding, she said to the prince, ‘I will not go alone this
+time--you must go with me.’ But he would not, and said that it would be
+a very hazardous thing; for if the least ray of the torch-light should
+fall upon him his enchantment would become still worse, for he should be
+changed into a dove, and be forced to wander about the world for seven
+long years. However, she gave him no rest, and said she would take care
+no light should fall upon him. So at last they set out together, and
+took with them their little child; and she chose a large hall with thick
+walls for him to sit in while the wedding-torches were lighted; but,
+unluckily, no one saw that there was a crack in the door. Then the
+wedding was held with great pomp, but as the train came from the church,
+and passed with the torches before the hall, a very small ray of light
+fell upon the prince. In a moment he disappeared, and when his wife came
+in and looked for him, she found only a white dove; and it said to her,
+‘Seven years must I fly up and down over the face of the earth, but
+every now and then I will let fall a white feather, that will show you
+the way I am going; follow it, and at last you may overtake and set me
+free.’
+
+This said, he flew out at the door, and poor Lily followed; and every
+now and then a white feather fell, and showed her the way she was to
+journey. Thus she went roving on through the wide world, and looked
+neither to the right hand nor to the left, nor took any rest, for seven
+years. Then she began to be glad, and thought to herself that the time
+was fast coming when all her troubles should end; yet repose was still
+far off, for one day as she was travelling on she missed the white
+feather, and when she lifted up her eyes she could nowhere see the dove.
+‘Now,’ thought she to herself, ‘no aid of man can be of use to me.’ So
+she went to the sun and said, ‘Thou shinest everywhere, on the hill’s
+top and the valley’s depth--hast thou anywhere seen my white dove?’
+‘No,’ said the sun, ‘I have not seen it; but I will give thee a
+casket--open it when thy hour of need comes.’
+
+So she thanked the sun, and went on her way till eventide; and when
+the moon arose, she cried unto it, and said, ‘Thou shinest through the
+night, over field and grove--hast thou nowhere seen my white dove?’
+‘No,’ said the moon, ‘I cannot help thee but I will give thee an
+egg--break it when need comes.’
+
+Then she thanked the moon, and went on till the night-wind blew; and she
+raised up her voice to it, and said, ‘Thou blowest through every tree
+and under every leaf--hast thou not seen my white dove?’ ‘No,’ said the
+night-wind, ‘but I will ask three other winds; perhaps they have seen
+it.’ Then the east wind and the west wind came, and said they too had
+not seen it, but the south wind said, ‘I have seen the white dove--he
+has fled to the Red Sea, and is changed once more into a lion, for the
+seven years are passed away, and there he is fighting with a dragon;
+and the dragon is an enchanted princess, who seeks to separate him from
+you.’ Then the night-wind said, ‘I will give thee counsel. Go to the
+Red Sea; on the right shore stand many rods--count them, and when thou
+comest to the eleventh, break it off, and smite the dragon with it; and
+so the lion will have the victory, and both of them will appear to you
+in their own forms. Then look round and thou wilt see a griffin, winged
+like bird, sitting by the Red Sea; jump on to his back with thy beloved
+one as quickly as possible, and he will carry you over the waters to
+your home. I will also give thee this nut,’ continued the night-wind.
+‘When you are half-way over, throw it down, and out of the waters will
+immediately spring up a high nut-tree on which the griffin will be able
+to rest, otherwise he would not have the strength to bear you the whole
+way; if, therefore, thou dost forget to throw down the nut, he will let
+you both fall into the sea.’
+
+So our poor wanderer went forth, and found all as the night-wind had
+said; and she plucked the eleventh rod, and smote the dragon, and the
+lion forthwith became a prince, and the dragon a princess again. But
+no sooner was the princess released from the spell, than she seized
+the prince by the arm and sprang on to the griffin’s back, and went off
+carrying the prince away with her.
+
+Thus the unhappy traveller was again forsaken and forlorn; but she
+took heart and said, ‘As far as the wind blows, and so long as the cock
+crows, I will journey on, till I find him once again.’ She went on for
+a long, long way, till at length she came to the castle whither the
+princess had carried the prince; and there was a feast got ready, and
+she heard that the wedding was about to be held. ‘Heaven aid me now!’
+said she; and she took the casket that the sun had given her, and found
+that within it lay a dress as dazzling as the sun itself. So she put it
+on, and went into the palace, and all the people gazed upon her; and
+the dress pleased the bride so much that she asked whether it was to be
+sold. ‘Not for gold and silver.’ said she, ‘but for flesh and blood.’
+The princess asked what she meant, and she said, ‘Let me speak with the
+bridegroom this night in his chamber, and I will give thee the dress.’
+At last the princess agreed, but she told her chamberlain to give the
+prince a sleeping draught, that he might not hear or see her. When
+evening came, and the prince had fallen asleep, she was led into
+his chamber, and she sat herself down at his feet, and said: ‘I have
+followed thee seven years. I have been to the sun, the moon, and the
+night-wind, to seek thee, and at last I have helped thee to overcome
+the dragon. Wilt thou then forget me quite?’ But the prince all the time
+slept so soundly, that her voice only passed over him, and seemed like
+the whistling of the wind among the fir-trees.
+
+Then poor Lily was led away, and forced to give up the golden dress; and
+when she saw that there was no help for her, she went out into a meadow,
+and sat herself down and wept. But as she sat she bethought herself of
+the egg that the moon had given her; and when she broke it, there ran
+out a hen and twelve chickens of pure gold, that played about, and then
+nestled under the old one’s wings, so as to form the most beautiful
+sight in the world. And she rose up and drove them before her, till the
+bride saw them from her window, and was so pleased that she came forth
+and asked her if she would sell the brood. ‘Not for gold or silver, but
+for flesh and blood: let me again this evening speak with the bridegroom
+in his chamber, and I will give thee the whole brood.’
+
+Then the princess thought to betray her as before, and agreed to
+what she asked: but when the prince went to his chamber he asked
+the chamberlain why the wind had whistled so in the night. And the
+chamberlain told him all--how he had given him a sleeping draught, and
+how a poor maiden had come and spoken to him in his chamber, and was
+to come again that night. Then the prince took care to throw away the
+sleeping draught; and when Lily came and began again to tell him what
+woes had befallen her, and how faithful and true to him she had been,
+he knew his beloved wife’s voice, and sprang up, and said, ‘You have
+awakened me as from a dream, for the strange princess had thrown a spell
+around me, so that I had altogether forgotten you; but Heaven hath sent
+you to me in a lucky hour.’
+
+And they stole away out of the palace by night unawares, and seated
+themselves on the griffin, who flew back with them over the Red Sea.
+When they were half-way across Lily let the nut fall into the water,
+and immediately a large nut-tree arose from the sea, whereon the griffin
+rested for a while, and then carried them safely home. There they found
+their child, now grown up to be comely and fair; and after all their
+troubles they lived happily together to the end of their days.
+
+
+
+
+THE FOX AND THE HORSE
+
+A farmer had a horse that had been an excellent faithful servant to
+him: but he was now grown too old to work; so the farmer would give him
+nothing more to eat, and said, ‘I want you no longer, so take yourself
+off out of my stable; I shall not take you back again until you are
+stronger than a lion.’ Then he opened the door and turned him adrift.
+
+The poor horse was very melancholy, and wandered up and down in the
+wood, seeking some little shelter from the cold wind and rain. Presently
+a fox met him: ‘What’s the matter, my friend?’ said he, ‘why do you hang
+down your head and look so lonely and woe-begone?’ ‘Ah!’ replied the
+horse, ‘justice and avarice never dwell in one house; my master has
+forgotten all that I have done for him so many years, and because I
+can no longer work he has turned me adrift, and says unless I become
+stronger than a lion he will not take me back again; what chance can I
+have of that? he knows I have none, or he would not talk so.’
+
+However, the fox bid him be of good cheer, and said, ‘I will help you;
+lie down there, stretch yourself out quite stiff, and pretend to be
+dead.’ The horse did as he was told, and the fox went straight to the
+lion who lived in a cave close by, and said to him, ‘A little way off
+lies a dead horse; come with me and you may make an excellent meal of
+his carcase.’ The lion was greatly pleased, and set off immediately; and
+when they came to the horse, the fox said, ‘You will not be able to eat
+him comfortably here; I’ll tell you what--I will tie you fast to
+his tail, and then you can draw him to your den, and eat him at your
+leisure.’
+
+This advice pleased the lion, so he laid himself down quietly for the
+fox to make him fast to the horse. But the fox managed to tie his legs
+together and bound all so hard and fast that with all his strength he
+could not set himself free. When the work was done, the fox clapped the
+horse on the shoulder, and said, ‘Jip! Dobbin! Jip!’ Then up he sprang,
+and moved off, dragging the lion behind him. The beast began to roar
+and bellow, till all the birds of the wood flew away for fright; but the
+horse let him sing on, and made his way quietly over the fields to his
+master’s house.
+
+‘Here he is, master,’ said he, ‘I have got the better of him’: and when
+the farmer saw his old servant, his heart relented, and he said. ‘Thou
+shalt stay in thy stable and be well taken care of.’ And so the poor old
+horse had plenty to eat, and lived--till he died.
+
+
+
+
+THE BLUE LIGHT
+
+There was once upon a time a soldier who for many years had served the
+king faithfully, but when the war came to an end could serve no longer
+because of the many wounds which he had received. The king said to him:
+‘You may return to your home, I need you no longer, and you will not
+receive any more money, for he only receives wages who renders me
+service for them.’ Then the soldier did not know how to earn a living,
+went away greatly troubled, and walked the whole day, until in the
+evening he entered a forest. When darkness came on, he saw a light,
+which he went up to, and came to a house wherein lived a witch. ‘Do give
+me one night’s lodging, and a little to eat and drink,’ said he to
+her, ‘or I shall starve.’ ‘Oho!’ she answered, ‘who gives anything to a
+run-away soldier? Yet will I be compassionate, and take you in, if you
+will do what I wish.’ ‘What do you wish?’ said the soldier. ‘That you
+should dig all round my garden for me, tomorrow.’ The soldier consented,
+and next day laboured with all his strength, but could not finish it by
+the evening. ‘I see well enough,’ said the witch, ‘that you can do no
+more today, but I will keep you yet another night, in payment for
+which you must tomorrow chop me a load of wood, and chop it small.’ The
+soldier spent the whole day in doing it, and in the evening the witch
+proposed that he should stay one night more. ‘Tomorrow, you shall only
+do me a very trifling piece of work. Behind my house, there is an old
+dry well, into which my light has fallen, it burns blue, and never goes
+out, and you shall bring it up again.’ Next day the old woman took him
+to the well, and let him down in a basket. He found the blue light, and
+made her a signal to draw him up again. She did draw him up, but when he
+came near the edge, she stretched down her hand and wanted to take the
+blue light away from him. ‘No,’ said he, perceiving her evil intention,
+‘I will not give you the light until I am standing with both feet upon
+the ground.’ The witch fell into a passion, let him fall again into the
+well, and went away.
+
+The poor soldier fell without injury on the moist ground, and the blue
+light went on burning, but of what use was that to him? He saw very well
+that he could not escape death. He sat for a while very sorrowfully,
+then suddenly he felt in his pocket and found his tobacco pipe, which
+was still half full. ‘This shall be my last pleasure,’ thought he,
+pulled it out, lit it at the blue light and began to smoke. When the
+smoke had circled about the cavern, suddenly a little black dwarf stood
+before him, and said: ‘Lord, what are your commands?’ ‘What my commands
+are?’ replied the soldier, quite astonished. ‘I must do everything you
+bid me,’ said the little man. ‘Good,’ said the soldier; ‘then in the
+first place help me out of this well.’ The little man took him by the
+hand, and led him through an underground passage, but he did not forget
+to take the blue light with him. On the way the dwarf showed him the
+treasures which the witch had collected and hidden there, and the
+soldier took as much gold as he could carry. When he was above, he said
+to the little man: ‘Now go and bind the old witch, and carry her before
+the judge.’ In a short time she came by like the wind, riding on a wild
+tom-cat and screaming frightfully. Nor was it long before the little man
+reappeared. ‘It is all done,’ said he, ‘and the witch is already hanging
+on the gallows. What further commands has my lord?’ inquired the dwarf.
+‘At this moment, none,’ answered the soldier; ‘you can return home, only
+be at hand immediately, if I summon you.’ ‘Nothing more is needed than
+that you should light your pipe at the blue light, and I will appear
+before you at once.’ Thereupon he vanished from his sight.
+
+The soldier returned to the town from which he came. He went to the
+best inn, ordered himself handsome clothes, and then bade the landlord
+furnish him a room as handsome as possible. When it was ready and the
+soldier had taken possession of it, he summoned the little black manikin
+and said: ‘I have served the king faithfully, but he has dismissed me,
+and left me to hunger, and now I want to take my revenge.’ ‘What am I to
+do?’ asked the little man. ‘Late at night, when the king’s daughter is
+in bed, bring her here in her sleep, she shall do servant’s work for
+me.’ The manikin said: ‘That is an easy thing for me to do, but a very
+dangerous thing for you, for if it is discovered, you will fare ill.’
+When twelve o’clock had struck, the door sprang open, and the manikin
+carried in the princess. ‘Aha! are you there?’ cried the soldier, ‘get
+to your work at once! Fetch the broom and sweep the chamber.’ When
+she had done this, he ordered her to come to his chair, and then he
+stretched out his feet and said: ‘Pull off my boots,’ and then he
+threw them in her face, and made her pick them up again, and clean
+and brighten them. She, however, did everything he bade her, without
+opposition, silently and with half-shut eyes. When the first cock
+crowed, the manikin carried her back to the royal palace, and laid her
+in her bed.
+
+Next morning when the princess arose she went to her father, and told
+him that she had had a very strange dream. ‘I was carried through the
+streets with the rapidity of lightning,’ said she, ‘and taken into a
+soldier’s room, and I had to wait upon him like a servant, sweep his
+room, clean his boots, and do all kinds of menial work. It was only a
+dream, and yet I am just as tired as if I really had done everything.’
+‘The dream may have been true,’ said the king. ‘I will give you a piece
+of advice. Fill your pocket full of peas, and make a small hole in the
+pocket, and then if you are carried away again, they will fall out and
+leave a track in the streets.’ But unseen by the king, the manikin was
+standing beside him when he said that, and heard all. At night when
+the sleeping princess was again carried through the streets, some peas
+certainly did fall out of her pocket, but they made no track, for the
+crafty manikin had just before scattered peas in every street there
+was. And again the princess was compelled to do servant’s work until
+cock-crow.
+
+Next morning the king sent his people out to seek the track, but it was
+all in vain, for in every street poor children were sitting, picking up
+peas, and saying: ‘It must have rained peas, last night.’ ‘We must think
+of something else,’ said the king; ‘keep your shoes on when you go to
+bed, and before you come back from the place where you are taken, hide
+one of them there, I will soon contrive to find it.’ The black manikin
+heard this plot, and at night when the soldier again ordered him to
+bring the princess, revealed it to him, and told him that he knew of no
+expedient to counteract this stratagem, and that if the shoe were found
+in the soldier’s house it would go badly with him. ‘Do what I bid you,’
+replied the soldier, and again this third night the princess was obliged
+to work like a servant, but before she went away, she hid her shoe under
+the bed.
+
+Next morning the king had the entire town searched for his daughter’s
+shoe. It was found at the soldier’s, and the soldier himself, who at the
+entreaty of the dwarf had gone outside the gate, was soon brought back,
+and thrown into prison. In his flight he had forgotten the most valuable
+things he had, the blue light and the gold, and had only one ducat in
+his pocket. And now loaded with chains, he was standing at the window of
+his dungeon, when he chanced to see one of his comrades passing by. The
+soldier tapped at the pane of glass, and when this man came up, said to
+him: ‘Be so kind as to fetch me the small bundle I have left lying in
+the inn, and I will give you a ducat for doing it.’ His comrade ran
+thither and brought him what he wanted. As soon as the soldier was alone
+again, he lighted his pipe and summoned the black manikin. ‘Have no
+fear,’ said the latter to his master. ‘Go wheresoever they take you, and
+let them do what they will, only take the blue light with you.’ Next day
+the soldier was tried, and though he had done nothing wicked, the judge
+condemned him to death. When he was led forth to die, he begged a last
+favour of the king. ‘What is it?’ asked the king. ‘That I may smoke one
+more pipe on my way.’ ‘You may smoke three,’ answered the king, ‘but do
+not imagine that I will spare your life.’ Then the soldier pulled out
+his pipe and lighted it at the blue light, and as soon as a few wreaths
+of smoke had ascended, the manikin was there with a small cudgel in his
+hand, and said: ‘What does my lord command?’ ‘Strike down to earth that
+false judge there, and his constable, and spare not the king who has
+treated me so ill.’ Then the manikin fell on them like lightning,
+darting this way and that way, and whosoever was so much as touched by
+his cudgel fell to earth, and did not venture to stir again. The king
+was terrified; he threw himself on the soldier’s mercy, and merely to
+be allowed to live at all, gave him his kingdom for his own, and his
+daughter to wife.
+
+
+
+
+THE RAVEN
+
+There was once a queen who had a little daughter, still too young to run
+alone. One day the child was very troublesome, and the mother could not
+quiet it, do what she would. She grew impatient, and seeing the ravens
+flying round the castle, she opened the window, and said: ‘I wish you
+were a raven and would fly away, then I should have a little peace.’
+Scarcely were the words out of her mouth, when the child in her arms was
+turned into a raven, and flew away from her through the open window. The
+bird took its flight to a dark wood and remained there for a long time,
+and meanwhile the parents could hear nothing of their child.
+
+Long after this, a man was making his way through the wood when he heard
+a raven calling, and he followed the sound of the voice. As he drew
+near, the raven said, ‘I am by birth a king’s daughter, but am now under
+the spell of some enchantment; you can, however, set me free.’ ‘What
+am I to do?’ he asked. She replied, ‘Go farther into the wood until you
+come to a house, wherein lives an old woman; she will offer you food and
+drink, but you must not take of either; if you do, you will fall into
+a deep sleep, and will not be able to help me. In the garden behind the
+house is a large tan-heap, and on that you must stand and watch for me.
+I shall drive there in my carriage at two o’clock in the afternoon for
+three successive days; the first day it will be drawn by four white, the
+second by four chestnut, and the last by four black horses; but if you
+fail to keep awake and I find you sleeping, I shall not be set free.’
+
+The man promised to do all that she wished, but the raven said, ‘Alas! I
+know even now that you will take something from the woman and be unable
+to save me.’ The man assured her again that he would on no account touch
+a thing to eat or drink.
+
+When he came to the house and went inside, the old woman met him, and
+said, ‘Poor man! how tired you are! Come in and rest and let me give you
+something to eat and drink.’
+
+‘No,’ answered the man, ‘I will neither eat not drink.’
+
+But she would not leave him alone, and urged him saying, ‘If you will
+not eat anything, at least you might take a draught of wine; one drink
+counts for nothing,’ and at last he allowed himself to be persuaded, and
+drank.
+
+As it drew towards the appointed hour, he went outside into the garden
+and mounted the tan-heap to await the raven. Suddenly a feeling of
+fatigue came over him, and unable to resist it, he lay down for a little
+while, fully determined, however, to keep awake; but in another minute
+his eyes closed of their own accord, and he fell into such a deep sleep,
+that all the noises in the world would not have awakened him. At two
+o’clock the raven came driving along, drawn by her four white horses;
+but even before she reached the spot, she said to herself, sighing, ‘I
+know he has fallen asleep.’ When she entered the garden, there she found
+him as she had feared, lying on the tan-heap, fast asleep. She got out
+of her carriage and went to him; she called him and shook him, but it
+was all in vain, he still continued sleeping.
+
+The next day at noon, the old woman came to him again with food and
+drink which he at first refused. At last, overcome by her persistent
+entreaties that he would take something, he lifted the glass and drank
+again.
+
+Towards two o’clock he went into the garden and on to the tan-heap to
+watch for the raven. He had not been there long before he began to feel
+so tired that his limbs seemed hardly able to support him, and he could
+not stand upright any longer; so again he lay down and fell fast asleep.
+As the raven drove along her four chestnut horses, she said sorrowfully
+to herself, ‘I know he has fallen asleep.’ She went as before to look
+for him, but he slept, and it was impossible to awaken him.
+
+The following day the old woman said to him, ‘What is this? You are not
+eating or drinking anything, do you want to kill yourself?’
+
+He answered, ‘I may not and will not either eat or drink.’
+
+But she put down the dish of food and the glass of wine in front of him,
+and when he smelt the wine, he was unable to resist the temptation, and
+took a deep draught.
+
+When the hour came round again he went as usual on to the tan-heap in
+the garden to await the king’s daughter, but he felt even more overcome
+with weariness than on the two previous days, and throwing himself down,
+he slept like a log. At two o’clock the raven could be seen approaching,
+and this time her coachman and everything about her, as well as her
+horses, were black.
+
+She was sadder than ever as she drove along, and said mournfully, ‘I
+know he has fallen asleep, and will not be able to set me free.’ She
+found him sleeping heavily, and all her efforts to awaken him were of no
+avail. Then she placed beside him a loaf, and some meat, and a flask
+of wine, of such a kind, that however much he took of them, they would
+never grow less. After that she drew a gold ring, on which her name was
+engraved, off her finger, and put it upon one of his. Finally, she laid
+a letter near him, in which, after giving him particulars of the food
+and drink she had left for him, she finished with the following words:
+‘I see that as long as you remain here you will never be able to set me
+free; if, however, you still wish to do so, come to the golden castle
+of Stromberg; this is well within your power to accomplish.’ She then
+returned to her carriage and drove to the golden castle of Stromberg.
+
+When the man awoke and found that he had been sleeping, he was grieved
+at heart, and said, ‘She has no doubt been here and driven away again,
+and it is now too late for me to save her.’ Then his eyes fell on the
+things which were lying beside him; he read the letter, and knew from it
+all that had happened. He rose up without delay, eager to start on his
+way and to reach the castle of Stromberg, but he had no idea in which
+direction he ought to go. He travelled about a long time in search of it
+and came at last to a dark forest, through which he went on walking for
+fourteen days and still could not find a way out. Once more the night
+came on, and worn out he lay down under a bush and fell asleep. Again
+the next day he pursued his way through the forest, and that evening,
+thinking to rest again, he lay down as before, but he heard such a
+howling and wailing that he found it impossible to sleep. He waited till
+it was darker and people had begun to light up their houses, and then
+seeing a little glimmer ahead of him, he went towards it.
+
+He found that the light came from a house which looked smaller than
+it really was, from the contrast of its height with that of an immense
+giant who stood in front of it. He thought to himself, ‘If the giant
+sees me going in, my life will not be worth much.’ However, after a
+while he summoned up courage and went forward. When the giant saw him,
+he called out, ‘It is lucky for that you have come, for I have not had
+anything to eat for a long time. I can have you now for my supper.’ ‘I
+would rather you let that alone,’ said the man, ‘for I do not willingly
+give myself up to be eaten; if you are wanting food I have enough to
+satisfy your hunger.’ ‘If that is so,’ replied the giant, ‘I will leave
+you in peace; I only thought of eating you because I had nothing else.’
+
+So they went indoors together and sat down, and the man brought out the
+bread, meat, and wine, which although he had eaten and drunk of them,
+were still unconsumed. The giant was pleased with the good cheer, and
+ate and drank to his heart’s content. When he had finished his supper
+the man asked him if he could direct him to the castle of Stromberg.
+The giant said, ‘I will look on my map; on it are marked all the towns,
+villages, and houses.’ So he fetched his map, and looked for the castle,
+but could not find it. ‘Never mind,’ he said, ‘I have larger maps
+upstairs in the cupboard, we will look on those,’ but they searched in
+vain, for the castle was not marked even on these. The man now thought
+he should like to continue his journey, but the giant begged him to
+remain for a day or two longer until the return of his brother, who was
+away in search of provisions. When the brother came home, they asked him
+about the castle of Stromberg, and he told them he would look on his own
+maps as soon as he had eaten and appeased his hunger. Accordingly, when
+he had finished his supper, they all went up together to his room and
+looked through his maps, but the castle was not to be found. Then he
+fetched other older maps, and they went on looking for the castle until
+at last they found it, but it was many thousand miles away. ‘How shall I
+be able to get there?’ asked the man. ‘I have two hours to spare,’ said
+the giant, ‘and I will carry you into the neighbourhood of the castle; I
+must then return to look after the child who is in our care.’
+
+The giant, thereupon, carried the man to within about a hundred leagues
+of the castle, where he left him, saying, ‘You will be able to walk the
+remainder of the way yourself.’ The man journeyed on day and night
+till he reached the golden castle of Stromberg. He found it situated,
+however, on a glass mountain, and looking up from the foot he saw the
+enchanted maiden drive round her castle and then go inside. He was
+overjoyed to see her, and longed to get to the top of the mountain, but
+the sides were so slippery that every time he attempted to climb he
+fell back again. When he saw that it was impossible to reach her, he was
+greatly grieved, and said to himself, ‘I will remain here and wait for
+her,’ so he built himself a little hut, and there he sat and watched for
+a whole year, and every day he saw the king’s daughter driving round her
+castle, but still was unable to get nearer to her.
+
+Looking out from his hut one day he saw three robbers fighting and he
+called out to them, ‘God be with you.’ They stopped when they heard the
+call, but looking round and seeing nobody, they went on again with their
+fighting, which now became more furious. ‘God be with you,’ he cried
+again, and again they paused and looked about, but seeing no one went
+back to their fighting. A third time he called out, ‘God be with you,’
+and then thinking he should like to know the cause of dispute between
+the three men, he went out and asked them why they were fighting so
+angrily with one another. One of them said that he had found a stick,
+and that he had but to strike it against any door through which he
+wished to pass, and it immediately flew open. Another told him that he
+had found a cloak which rendered its wearer invisible; and the third had
+caught a horse which would carry its rider over any obstacle, and even
+up the glass mountain. They had been unable to decide whether they
+would keep together and have the things in common, or whether they would
+separate. On hearing this, the man said, ‘I will give you something in
+exchange for those three things; not money, for that I have not got,
+but something that is of far more value. I must first, however, prove
+whether all you have told me about your three things is true.’ The
+robbers, therefore, made him get on the horse, and handed him the stick
+and the cloak, and when he had put this round him he was no longer
+visible. Then he fell upon them with the stick and beat them one after
+another, crying, ‘There, you idle vagabonds, you have got what you
+deserve; are you satisfied now!’
+
+After this he rode up the glass mountain. When he reached the gate of
+the castle, he found it closed, but he gave it a blow with his stick,
+and it flew wide open at once and he passed through. He mounted the
+steps and entered the room where the maiden was sitting, with a golden
+goblet full of wine in front of her. She could not see him for he still
+wore his cloak. He took the ring which she had given him off his finger,
+and threw it into the goblet, so that it rang as it touched the bottom.
+‘That is my own ring,’ she exclaimed, ‘and if that is so the man must
+also be here who is coming to set me free.’
+
+She sought for him about the castle, but could find him nowhere.
+Meanwhile he had gone outside again and mounted his horse and thrown off
+the cloak. When therefore she came to the castle gate she saw him, and
+cried aloud for joy. Then he dismounted and took her in his arms; and
+she kissed him, and said, ‘Now you have indeed set me free, and tomorrow
+we will celebrate our marriage.’
+
+
+
+
+THE GOLDEN GOOSE
+
+There was a man who had three sons, the youngest of whom was called
+Dummling,[*] and was despised, mocked, and sneered at on every occasion.
+
+It happened that the eldest wanted to go into the forest to hew wood,
+and before he went his mother gave him a beautiful sweet cake and a
+bottle of wine in order that he might not suffer from hunger or thirst.
+
+When he entered the forest he met a little grey-haired old man who bade
+him good day, and said: ‘Do give me a piece of cake out of your pocket,
+and let me have a draught of your wine; I am so hungry and thirsty.’ But
+the clever son answered: ‘If I give you my cake and wine, I shall have
+none for myself; be off with you,’ and he left the little man standing
+and went on.
+
+But when he began to hew down a tree, it was not long before he made a
+false stroke, and the axe cut him in the arm, so that he had to go home
+and have it bound up. And this was the little grey man’s doing.
+
+After this the second son went into the forest, and his mother gave him,
+like the eldest, a cake and a bottle of wine. The little old grey man
+met him likewise, and asked him for a piece of cake and a drink of wine.
+But the second son, too, said sensibly enough: ‘What I give you will be
+taken away from myself; be off!’ and he left the little man standing and
+went on. His punishment, however, was not delayed; when he had made a
+few blows at the tree he struck himself in the leg, so that he had to be
+carried home.
+
+Then Dummling said: ‘Father, do let me go and cut wood.’ The father
+answered: ‘Your brothers have hurt themselves with it, leave it alone,
+you do not understand anything about it.’ But Dummling begged so long
+that at last he said: ‘Just go then, you will get wiser by hurting
+yourself.’ His mother gave him a cake made with water and baked in the
+cinders, and with it a bottle of sour beer.
+
+When he came to the forest the little old grey man met him likewise,
+and greeting him, said: ‘Give me a piece of your cake and a drink out
+of your bottle; I am so hungry and thirsty.’ Dummling answered: ‘I have
+only cinder-cake and sour beer; if that pleases you, we will sit
+down and eat.’ So they sat down, and when Dummling pulled out his
+cinder-cake, it was a fine sweet cake, and the sour beer had become good
+wine. So they ate and drank, and after that the little man said: ‘Since
+you have a good heart, and are willing to divide what you have, I will
+give you good luck. There stands an old tree, cut it down, and you will
+find something at the roots.’ Then the little man took leave of him.
+
+Dummling went and cut down the tree, and when it fell there was a goose
+sitting in the roots with feathers of pure gold. He lifted her up, and
+taking her with him, went to an inn where he thought he would stay the
+night. Now the host had three daughters, who saw the goose and were
+curious to know what such a wonderful bird might be, and would have
+liked to have one of its golden feathers.
+
+The eldest thought: ‘I shall soon find an opportunity of pulling out a
+feather,’ and as soon as Dummling had gone out she seized the goose by
+the wing, but her finger and hand remained sticking fast to it.
+
+The second came soon afterwards, thinking only of how she might get a
+feather for herself, but she had scarcely touched her sister than she
+was held fast.
+
+At last the third also came with the like intent, and the others
+screamed out: ‘Keep away; for goodness’ sake keep away!’ But she did
+not understand why she was to keep away. ‘The others are there,’ she
+thought, ‘I may as well be there too,’ and ran to them; but as soon as
+she had touched her sister, she remained sticking fast to her. So they
+had to spend the night with the goose.
+
+The next morning Dummling took the goose under his arm and set out,
+without troubling himself about the three girls who were hanging on to
+it. They were obliged to run after him continually, now left, now right,
+wherever his legs took him.
+
+In the middle of the fields the parson met them, and when he saw the
+procession he said: ‘For shame, you good-for-nothing girls, why are you
+running across the fields after this young man? Is that seemly?’ At the
+same time he seized the youngest by the hand in order to pull her away,
+but as soon as he touched her he likewise stuck fast, and was himself
+obliged to run behind.
+
+Before long the sexton came by and saw his master, the parson, running
+behind three girls. He was astonished at this and called out: ‘Hi!
+your reverence, whither away so quickly? Do not forget that we have a
+christening today!’ and running after him he took him by the sleeve, but
+was also held fast to it.
+
+Whilst the five were trotting thus one behind the other, two labourers
+came with their hoes from the fields; the parson called out to them
+and begged that they would set him and the sexton free. But they had
+scarcely touched the sexton when they were held fast, and now there were
+seven of them running behind Dummling and the goose.
+
+Soon afterwards he came to a city, where a king ruled who had a daughter
+who was so serious that no one could make her laugh. So he had put forth
+a decree that whosoever should be able to make her laugh should marry
+her. When Dummling heard this, he went with his goose and all her train
+before the king’s daughter, and as soon as she saw the seven people
+running on and on, one behind the other, she began to laugh quite
+loudly, and as if she would never stop. Thereupon Dummling asked to have
+her for his wife; but the king did not like the son-in-law, and made all
+manner of excuses and said he must first produce a man who could drink
+a cellarful of wine. Dummling thought of the little grey man, who could
+certainly help him; so he went into the forest, and in the same place
+where he had felled the tree, he saw a man sitting, who had a very
+sorrowful face. Dummling asked him what he was taking to heart so
+sorely, and he answered: ‘I have such a great thirst and cannot quench
+it; cold water I cannot stand, a barrel of wine I have just emptied, but
+that to me is like a drop on a hot stone!’
+
+‘There, I can help you,’ said Dummling, ‘just come with me and you shall
+be satisfied.’
+
+He led him into the king’s cellar, and the man bent over the huge
+barrels, and drank and drank till his loins hurt, and before the day was
+out he had emptied all the barrels. Then Dummling asked once more
+for his bride, but the king was vexed that such an ugly fellow, whom
+everyone called Dummling, should take away his daughter, and he made a
+new condition; he must first find a man who could eat a whole mountain
+of bread. Dummling did not think long, but went straight into the
+forest, where in the same place there sat a man who was tying up his
+body with a strap, and making an awful face, and saying: ‘I have eaten a
+whole ovenful of rolls, but what good is that when one has such a hunger
+as I? My stomach remains empty, and I must tie myself up if I am not to
+die of hunger.’
+
+At this Dummling was glad, and said: ‘Get up and come with me; you shall
+eat yourself full.’ He led him to the king’s palace where all the
+flour in the whole Kingdom was collected, and from it he caused a huge
+mountain of bread to be baked. The man from the forest stood before it,
+began to eat, and by the end of one day the whole mountain had vanished.
+Then Dummling for the third time asked for his bride; but the king again
+sought a way out, and ordered a ship which could sail on land and on
+water. ‘As soon as you come sailing back in it,’ said he, ‘you shall
+have my daughter for wife.’
+
+Dummling went straight into the forest, and there sat the little grey
+man to whom he had given his cake. When he heard what Dummling wanted,
+he said: ‘Since you have given me to eat and to drink, I will give you
+the ship; and I do all this because you once were kind to me.’ Then he
+gave him the ship which could sail on land and water, and when the king
+saw that, he could no longer prevent him from having his daughter. The
+wedding was celebrated, and after the king’s death, Dummling inherited
+his kingdom and lived for a long time contentedly with his wife.
+
+     [*] Simpleton
+
+
+
+
+THE WATER OF LIFE
+
+Long before you or I were born, there reigned, in a country a great way
+off, a king who had three sons. This king once fell very ill--so ill
+that nobody thought he could live. His sons were very much grieved
+at their father’s sickness; and as they were walking together very
+mournfully in the garden of the palace, a little old man met them and
+asked what was the matter. They told him that their father was very ill,
+and that they were afraid nothing could save him. ‘I know what would,’
+said the little old man; ‘it is the Water of Life. If he could have a
+draught of it he would be well again; but it is very hard to get.’ Then
+the eldest son said, ‘I will soon find it’: and he went to the sick
+king, and begged that he might go in search of the Water of Life, as
+it was the only thing that could save him. ‘No,’ said the king. ‘I had
+rather die than place you in such great danger as you must meet with in
+your journey.’ But he begged so hard that the king let him go; and the
+prince thought to himself, ‘If I bring my father this water, he will
+make me sole heir to his kingdom.’
+
+Then he set out: and when he had gone on his way some time he came to a
+deep valley, overhung with rocks and woods; and as he looked around, he
+saw standing above him on one of the rocks a little ugly dwarf, with a
+sugarloaf cap and a scarlet cloak; and the dwarf called to him and said,
+‘Prince, whither so fast?’ ‘What is that to thee, you ugly imp?’ said
+the prince haughtily, and rode on.
+
+But the dwarf was enraged at his behaviour, and laid a fairy spell
+of ill-luck upon him; so that as he rode on the mountain pass became
+narrower and narrower, and at last the way was so straitened that he
+could not go to step forward: and when he thought to have turned his
+horse round and go back the way he came, he heard a loud laugh ringing
+round him, and found that the path was closed behind him, so that he was
+shut in all round. He next tried to get off his horse and make his way
+on foot, but again the laugh rang in his ears, and he found himself
+unable to move a step, and thus he was forced to abide spellbound.
+
+Meantime the old king was lingering on in daily hope of his son’s
+return, till at last the second son said, ‘Father, I will go in search
+of the Water of Life.’ For he thought to himself, ‘My brother is surely
+dead, and the kingdom will fall to me if I find the water.’ The king was
+at first very unwilling to let him go, but at last yielded to his wish.
+So he set out and followed the same road which his brother had done,
+and met with the same elf, who stopped him at the same spot in the
+mountains, saying, as before, ‘Prince, prince, whither so fast?’ ‘Mind
+your own affairs, busybody!’ said the prince scornfully, and rode on.
+
+But the dwarf put the same spell upon him as he put on his elder
+brother, and he, too, was at last obliged to take up his abode in the
+heart of the mountains. Thus it is with proud silly people, who think
+themselves above everyone else, and are too proud to ask or take advice.
+
+When the second prince had thus been gone a long time, the youngest son
+said he would go and search for the Water of Life, and trusted he should
+soon be able to make his father well again. So he set out, and the dwarf
+met him too at the same spot in the valley, among the mountains, and
+said, ‘Prince, whither so fast?’ And the prince said, ‘I am going in
+search of the Water of Life, because my father is ill, and like to die:
+can you help me? Pray be kind, and aid me if you can!’ ‘Do you know
+where it is to be found?’ asked the dwarf. ‘No,’ said the prince, ‘I do
+not. Pray tell me if you know.’ ‘Then as you have spoken to me kindly,
+and are wise enough to seek for advice, I will tell you how and where to
+go. The water you seek springs from a well in an enchanted castle; and,
+that you may be able to reach it in safety, I will give you an iron wand
+and two little loaves of bread; strike the iron door of the castle three
+times with the wand, and it will open: two hungry lions will be lying
+down inside gaping for their prey, but if you throw them the bread they
+will let you pass; then hasten on to the well, and take some of the
+Water of Life before the clock strikes twelve; for if you tarry longer
+the door will shut upon you for ever.’
+
+Then the prince thanked his little friend with the scarlet cloak for his
+friendly aid, and took the wand and the bread, and went travelling on
+and on, over sea and over land, till he came to his journey’s end, and
+found everything to be as the dwarf had told him. The door flew open at
+the third stroke of the wand, and when the lions were quieted he went on
+through the castle and came at length to a beautiful hall. Around it he
+saw several knights sitting in a trance; then he pulled off their rings
+and put them on his own fingers. In another room he saw on a table a
+sword and a loaf of bread, which he also took. Further on he came to a
+room where a beautiful young lady sat upon a couch; and she welcomed him
+joyfully, and said, if he would set her free from the spell that bound
+her, the kingdom should be his, if he would come back in a year and
+marry her. Then she told him that the well that held the Water of Life
+was in the palace gardens; and bade him make haste, and draw what he
+wanted before the clock struck twelve.
+
+He walked on; and as he walked through beautiful gardens he came to a
+delightful shady spot in which stood a couch; and he thought to himself,
+as he felt tired, that he would rest himself for a while, and gaze on
+the lovely scenes around him. So he laid himself down, and sleep
+fell upon him unawares, so that he did not wake up till the clock was
+striking a quarter to twelve. Then he sprang from the couch dreadfully
+frightened, ran to the well, filled a cup that was standing by him full
+of water, and hastened to get away in time. Just as he was going out of
+the iron door it struck twelve, and the door fell so quickly upon him
+that it snapped off a piece of his heel.
+
+When he found himself safe, he was overjoyed to think that he had got
+the Water of Life; and as he was going on his way homewards, he passed
+by the little dwarf, who, when he saw the sword and the loaf, said, ‘You
+have made a noble prize; with the sword you can at a blow slay whole
+armies, and the bread will never fail you.’ Then the prince thought
+to himself, ‘I cannot go home to my father without my brothers’; so he
+said, ‘My dear friend, cannot you tell me where my two brothers are, who
+set out in search of the Water of Life before me, and never came back?’
+‘I have shut them up by a charm between two mountains,’ said the dwarf,
+‘because they were proud and ill-behaved, and scorned to ask advice.’
+The prince begged so hard for his brothers, that the dwarf at last set
+them free, though unwillingly, saying, ‘Beware of them, for they have
+bad hearts.’ Their brother, however, was greatly rejoiced to see them,
+and told them all that had happened to him; how he had found the Water
+of Life, and had taken a cup full of it; and how he had set a beautiful
+princess free from a spell that bound her; and how she had engaged to
+wait a whole year, and then to marry him, and to give him the kingdom.
+
+Then they all three rode on together, and on their way home came to a
+country that was laid waste by war and a dreadful famine, so that it was
+feared all must die for want. But the prince gave the king of the land
+the bread, and all his kingdom ate of it. And he lent the king the
+wonderful sword, and he slew the enemy’s army with it; and thus the
+kingdom was once more in peace and plenty. In the same manner he
+befriended two other countries through which they passed on their way.
+
+When they came to the sea, they got into a ship and during their voyage
+the two eldest said to themselves, ‘Our brother has got the water which
+we could not find, therefore our father will forsake us and give him the
+kingdom, which is our right’; so they were full of envy and revenge, and
+agreed together how they could ruin him. Then they waited till he was
+fast asleep, and poured the Water of Life out of the cup, and took it
+for themselves, giving him bitter sea-water instead.
+
+When they came to their journey’s end, the youngest son brought his cup
+to the sick king, that he might drink and be healed. Scarcely, however,
+had he tasted the bitter sea-water when he became worse even than he was
+before; and then both the elder sons came in, and blamed the youngest
+for what they had done; and said that he wanted to poison their father,
+but that they had found the Water of Life, and had brought it with them.
+He no sooner began to drink of what they brought him, than he felt his
+sickness leave him, and was as strong and well as in his younger days.
+Then they went to their brother, and laughed at him, and said, ‘Well,
+brother, you found the Water of Life, did you? You have had the trouble
+and we shall have the reward. Pray, with all your cleverness, why did
+not you manage to keep your eyes open? Next year one of us will take
+away your beautiful princess, if you do not take care. You had better
+say nothing about this to our father, for he does not believe a word you
+say; and if you tell tales, you shall lose your life into the bargain:
+but be quiet, and we will let you off.’
+
+The old king was still very angry with his youngest son, and thought
+that he really meant to have taken away his life; so he called his court
+together, and asked what should be done, and all agreed that he ought to
+be put to death. The prince knew nothing of what was going on, till one
+day, when the king’s chief huntsmen went a-hunting with him, and they
+were alone in the wood together, the huntsman looked so sorrowful that
+the prince said, ‘My friend, what is the matter with you?’ ‘I cannot and
+dare not tell you,’ said he. But the prince begged very hard, and said,
+‘Only tell me what it is, and do not think I shall be angry, for I will
+forgive you.’ ‘Alas!’ said the huntsman; ‘the king has ordered me to
+shoot you.’ The prince started at this, and said, ‘Let me live, and I
+will change dresses with you; you shall take my royal coat to show to my
+father, and do you give me your shabby one.’ ‘With all my heart,’ said
+the huntsman; ‘I am sure I shall be glad to save you, for I could not
+have shot you.’ Then he took the prince’s coat, and gave him the shabby
+one, and went away through the wood.
+
+Some time after, three grand embassies came to the old king’s court,
+with rich gifts of gold and precious stones for his youngest son; now
+all these were sent from the three kings to whom he had lent his sword
+and loaf of bread, in order to rid them of their enemy and feed their
+people. This touched the old king’s heart, and he thought his son might
+still be guiltless, and said to his court, ‘O that my son were still
+alive! how it grieves me that I had him killed!’ ‘He is still alive,’
+said the huntsman; ‘and I am glad that I had pity on him, but let him
+go in peace, and brought home his royal coat.’ At this the king was
+overwhelmed with joy, and made it known throughout all his kingdom, that
+if his son would come back to his court he would forgive him.
+
+Meanwhile the princess was eagerly waiting till her deliverer should
+come back; and had a road made leading up to her palace all of shining
+gold; and told her courtiers that whoever came on horseback, and rode
+straight up to the gate upon it, was her true lover; and that they must
+let him in: but whoever rode on one side of it, they must be sure was
+not the right one; and that they must send him away at once.
+
+The time soon came, when the eldest brother thought that he would make
+haste to go to the princess, and say that he was the one who had set
+her free, and that he should have her for his wife, and the kingdom with
+her. As he came before the palace and saw the golden road, he stopped to
+look at it, and he thought to himself, ‘It is a pity to ride upon this
+beautiful road’; so he turned aside and rode on the right-hand side of
+it. But when he came to the gate, the guards, who had seen the road
+he took, said to him, he could not be what he said he was, and must go
+about his business.
+
+The second prince set out soon afterwards on the same errand; and when
+he came to the golden road, and his horse had set one foot upon it,
+he stopped to look at it, and thought it very beautiful, and said to
+himself, ‘What a pity it is that anything should tread here!’ Then he
+too turned aside and rode on the left side of it. But when he came to
+the gate the guards said he was not the true prince, and that he too
+must go away about his business; and away he went.
+
+Now when the full year was come round, the third brother left the forest
+in which he had lain hid for fear of his father’s anger, and set out in
+search of his betrothed bride. So he journeyed on, thinking of her all
+the way, and rode so quickly that he did not even see what the road was
+made of, but went with his horse straight over it; and as he came to the
+gate it flew open, and the princess welcomed him with joy, and said
+he was her deliverer, and should now be her husband and lord of the
+kingdom. When the first joy at their meeting was over, the princess told
+him she had heard of his father having forgiven him, and of his wish to
+have him home again: so, before his wedding with the princess, he went
+to visit his father, taking her with him. Then he told him everything;
+how his brothers had cheated and robbed him, and yet that he had borne
+all those wrongs for the love of his father. And the old king was very
+angry, and wanted to punish his wicked sons; but they made their escape,
+and got into a ship and sailed away over the wide sea, and where they
+went to nobody knew and nobody cared.
+
+And now the old king gathered together his court, and asked all his
+kingdom to come and celebrate the wedding of his son and the princess.
+And young and old, noble and squire, gentle and simple, came at once
+on the summons; and among the rest came the friendly dwarf, with the
+sugarloaf hat, and a new scarlet cloak.
+
+  And the wedding was held, and the merry bells run.
+  And all the good people they danced and they sung,
+  And feasted and frolick’d I can’t tell how long.
+
+
+
+
+THE TWELVE HUNTSMEN
+
+There was once a king’s son who had a bride whom he loved very much. And
+when he was sitting beside her and very happy, news came that his father
+lay sick unto death, and desired to see him once again before his end.
+Then he said to his beloved: ‘I must now go and leave you, I give you
+a ring as a remembrance of me. When I am king, I will return and fetch
+you.’ So he rode away, and when he reached his father, the latter was
+dangerously ill, and near his death. He said to him: ‘Dear son, I wished
+to see you once again before my end, promise me to marry as I wish,’ and
+he named a certain king’s daughter who was to be his wife. The son was
+in such trouble that he did not think what he was doing, and said: ‘Yes,
+dear father, your will shall be done,’ and thereupon the king shut his
+eyes, and died.
+
+When therefore the son had been proclaimed king, and the time of
+mourning was over, he was forced to keep the promise which he had given
+his father, and caused the king’s daughter to be asked in marriage, and
+she was promised to him. His first betrothed heard of this, and fretted
+so much about his faithfulness that she nearly died. Then her father
+said to her: ‘Dearest child, why are you so sad? You shall have
+whatsoever you will.’ She thought for a moment and said: ‘Dear father,
+I wish for eleven girls exactly like myself in face, figure, and size.’
+The father said: ‘If it be possible, your desire shall be fulfilled,’
+and he caused a search to be made in his whole kingdom, until eleven
+young maidens were found who exactly resembled his daughter in face,
+figure, and size.
+
+When they came to the king’s daughter, she had twelve suits of
+huntsmen’s clothes made, all alike, and the eleven maidens had to put
+on the huntsmen’s clothes, and she herself put on the twelfth suit.
+Thereupon she took her leave of her father, and rode away with them,
+and rode to the court of her former betrothed, whom she loved so dearly.
+Then she asked if he required any huntsmen, and if he would take all of
+them into his service. The king looked at her and did not know her, but
+as they were such handsome fellows, he said: ‘Yes,’ and that he would
+willingly take them, and now they were the king’s twelve huntsmen.
+
+The king, however, had a lion which was a wondrous animal, for he knew
+all concealed and secret things. It came to pass that one evening he
+said to the king: ‘You think you have twelve huntsmen?’ ‘Yes,’ said the
+king, ‘they are twelve huntsmen.’ The lion continued: ‘You are mistaken,
+they are twelve girls.’ The king said: ‘That cannot be true! How
+will you prove that to me?’ ‘Oh, just let some peas be strewn in the
+ante-chamber,’ answered the lion, ‘and then you will soon see. Men have
+a firm step, and when they walk over peas none of them stir, but girls
+trip and skip, and drag their feet, and the peas roll about.’ The king
+was well pleased with the counsel, and caused the peas to be strewn.
+
+There was, however, a servant of the king’s who favoured the huntsmen,
+and when he heard that they were going to be put to this test he went to
+them and repeated everything, and said: ‘The lion wants to make the king
+believe that you are girls.’ Then the king’s daughter thanked him, and
+said to her maidens: ‘Show some strength, and step firmly on the peas.’
+So next morning when the king had the twelve huntsmen called before
+him, and they came into the ante-chamber where the peas were lying, they
+stepped so firmly on them, and had such a strong, sure walk, that not
+one of the peas either rolled or stirred. Then they went away again,
+and the king said to the lion: ‘You have lied to me, they walk just like
+men.’ The lion said: ‘They have been informed that they were going to
+be put to the test, and have assumed some strength. Just let twelve
+spinning-wheels be brought into the ante-chamber, and they will go to
+them and be pleased with them, and that is what no man would do.’
+The king liked the advice, and had the spinning-wheels placed in the
+ante-chamber.
+
+But the servant, who was well disposed to the huntsmen, went to them,
+and disclosed the project. So when they were alone the king’s daughter
+said to her eleven girls: ‘Show some constraint, and do not look round
+at the spinning-wheels.’ And next morning when the king had his twelve
+huntsmen summoned, they went through the ante-chamber, and never once
+looked at the spinning-wheels. Then the king again said to the lion:
+‘You have deceived me, they are men, for they have not looked at the
+spinning-wheels.’ The lion replied: ‘They have restrained themselves.’
+The king, however, would no longer believe the lion.
+
+The twelve huntsmen always followed the king to the chase, and his
+liking for them continually increased. Now it came to pass that
+once when they were out hunting, news came that the king’s bride was
+approaching. When the true bride heard that, it hurt her so much that
+her heart was almost broken, and she fell fainting to the ground. The
+king thought something had happened to his dear huntsman, ran up to him,
+wanted to help him, and drew his glove off. Then he saw the ring which
+he had given to his first bride, and when he looked in her face he
+recognized her. Then his heart was so touched that he kissed her, and
+when she opened her eyes he said: ‘You are mine, and I am yours, and
+no one in the world can alter that.’ He sent a messenger to the other
+bride, and entreated her to return to her own kingdom, for he had a wife
+already, and someone who had just found an old key did not require a new
+one. Thereupon the wedding was celebrated, and the lion was again taken
+into favour, because, after all, he had told the truth.
+
+
+
+
+THE KING OF THE GOLDEN MOUNTAIN
+
+There was once a merchant who had only one child, a son, that was very
+young, and barely able to run alone. He had two richly laden ships then
+making a voyage upon the seas, in which he had embarked all his wealth,
+in the hope of making great gains, when the news came that both were
+lost. Thus from being a rich man he became all at once so very poor that
+nothing was left to him but one small plot of land; and there he often
+went in an evening to take his walk, and ease his mind of a little of
+his trouble.
+
+One day, as he was roaming along in a brown study, thinking with no
+great comfort on what he had been and what he now was, and was like
+to be, all on a sudden there stood before him a little, rough-looking,
+black dwarf. ‘Prithee, friend, why so sorrowful?’ said he to the
+merchant; ‘what is it you take so deeply to heart?’ ‘If you would do me
+any good I would willingly tell you,’ said the merchant. ‘Who knows but
+I may?’ said the little man: ‘tell me what ails you, and perhaps you
+will find I may be of some use.’ Then the merchant told him how all his
+wealth was gone to the bottom of the sea, and how he had nothing left
+but that little plot of land. ‘Oh, trouble not yourself about that,’
+said the dwarf; ‘only undertake to bring me here, twelve years hence,
+whatever meets you first on your going home, and I will give you as much
+as you please.’ The merchant thought this was no great thing to ask;
+that it would most likely be his dog or his cat, or something of that
+sort, but forgot his little boy Heinel; so he agreed to the bargain, and
+signed and sealed the bond to do what was asked of him.
+
+But as he drew near home, his little boy was so glad to see him that he
+crept behind him, and laid fast hold of his legs, and looked up in
+his face and laughed. Then the father started, trembling with fear and
+horror, and saw what it was that he had bound himself to do; but as no
+gold was come, he made himself easy by thinking that it was only a joke
+that the dwarf was playing him, and that, at any rate, when the money
+came, he should see the bearer, and would not take it in.
+
+About a month afterwards he went upstairs into a lumber-room to look
+for some old iron, that he might sell it and raise a little money; and
+there, instead of his iron, he saw a large pile of gold lying on the
+floor. At the sight of this he was overjoyed, and forgetting all about
+his son, went into trade again, and became a richer merchant than
+before.
+
+Meantime little Heinel grew up, and as the end of the twelve years drew
+near the merchant began to call to mind his bond, and became very sad
+and thoughtful; so that care and sorrow were written upon his face. The
+boy one day asked what was the matter, but his father would not tell for
+some time; at last, however, he said that he had, without knowing it,
+sold him for gold to a little, ugly-looking, black dwarf, and that the
+twelve years were coming round when he must keep his word. Then Heinel
+said, ‘Father, give yourself very little trouble about that; I shall be
+too much for the little man.’
+
+When the time came, the father and son went out together to the place
+agreed upon: and the son drew a circle on the ground, and set himself
+and his father in the middle of it. The little black dwarf soon came,
+and walked round and round about the circle, but could not find any way
+to get into it, and he either could not, or dared not, jump over it. At
+last the boy said to him. ‘Have you anything to say to us, my friend, or
+what do you want?’ Now Heinel had found a friend in a good fairy, that
+was fond of him, and had told him what to do; for this fairy knew what
+good luck was in store for him. ‘Have you brought me what you said you
+would?’ said the dwarf to the merchant. The old man held his tongue, but
+Heinel said again, ‘What do you want here?’ The dwarf said, ‘I come to
+talk with your father, not with you.’ ‘You have cheated and taken in my
+father,’ said the son; ‘pray give him up his bond at once.’ ‘Fair and
+softly,’ said the little old man; ‘right is right; I have paid my money,
+and your father has had it, and spent it; so be so good as to let me
+have what I paid it for.’ ‘You must have my consent to that first,’ said
+Heinel, ‘so please to step in here, and let us talk it over.’ The old
+man grinned, and showed his teeth, as if he should have been very glad
+to get into the circle if he could. Then at last, after a long talk,
+they came to terms. Heinel agreed that his father must give him up, and
+that so far the dwarf should have his way: but, on the other hand, the
+fairy had told Heinel what fortune was in store for him, if he followed
+his own course; and he did not choose to be given up to his hump-backed
+friend, who seemed so anxious for his company.
+
+So, to make a sort of drawn battle of the matter, it was settled that
+Heinel should be put into an open boat, that lay on the sea-shore hard
+by; that the father should push him off with his own hand, and that he
+should thus be set adrift, and left to the bad or good luck of wind and
+weather. Then he took leave of his father, and set himself in the boat,
+but before it got far off a wave struck it, and it fell with one side
+low in the water, so the merchant thought that poor Heinel was lost, and
+went home very sorrowful, while the dwarf went his way, thinking that at
+any rate he had had his revenge.
+
+The boat, however, did not sink, for the good fairy took care of her
+friend, and soon raised the boat up again, and it went safely on. The
+young man sat safe within, till at length it ran ashore upon an unknown
+land. As he jumped upon the shore he saw before him a beautiful castle
+but empty and dreary within, for it was enchanted. ‘Here,’ said he to
+himself, ‘must I find the prize the good fairy told me of.’ So he once
+more searched the whole palace through, till at last he found a white
+snake, lying coiled up on a cushion in one of the chambers.
+
+Now the white snake was an enchanted princess; and she was very glad
+to see him, and said, ‘Are you at last come to set me free? Twelve
+long years have I waited here for the fairy to bring you hither as she
+promised, for you alone can save me. This night twelve men will come:
+their faces will be black, and they will be dressed in chain armour.
+They will ask what you do here, but give no answer; and let them do
+what they will--beat, whip, pinch, prick, or torment you--bear all; only
+speak not a word, and at twelve o’clock they must go away. The second
+night twelve others will come: and the third night twenty-four, who
+will even cut off your head; but at the twelfth hour of that night their
+power is gone, and I shall be free, and will come and bring you the
+Water of Life, and will wash you with it, and bring you back to life
+and health.’ And all came to pass as she had said; Heinel bore all, and
+spoke not a word; and the third night the princess came, and fell on his
+neck and kissed him. Joy and gladness burst forth throughout the castle,
+the wedding was celebrated, and he was crowned king of the Golden
+Mountain.
+
+They lived together very happily, and the queen had a son. And thus
+eight years had passed over their heads, when the king thought of his
+father; and he began to long to see him once again. But the queen was
+against his going, and said, ‘I know well that misfortunes will come
+upon us if you go.’ However, he gave her no rest till she agreed. At his
+going away she gave him a wishing-ring, and said, ‘Take this ring, and
+put it on your finger; whatever you wish it will bring you; only promise
+never to make use of it to bring me hence to your father’s house.’ Then
+he said he would do what she asked, and put the ring on his finger, and
+wished himself near the town where his father lived.
+
+Heinel found himself at the gates in a moment; but the guards would
+not let him go in, because he was so strangely clad. So he went up to a
+neighbouring hill, where a shepherd dwelt, and borrowed his old frock,
+and thus passed unknown into the town. When he came to his father’s
+house, he said he was his son; but the merchant would not believe him,
+and said he had had but one son, his poor Heinel, who he knew was long
+since dead: and as he was only dressed like a poor shepherd, he would
+not even give him anything to eat. The king, however, still vowed that
+he was his son, and said, ‘Is there no mark by which you would know me
+if I am really your son?’ ‘Yes,’ said his mother, ‘our Heinel had a mark
+like a raspberry on his right arm.’ Then he showed them the mark, and
+they knew that what he had said was true.
+
+He next told them how he was king of the Golden Mountain, and was
+married to a princess, and had a son seven years old. But the merchant
+said, ‘that can never be true; he must be a fine king truly who travels
+about in a shepherd’s frock!’ At this the son was vexed; and forgetting
+his word, turned his ring, and wished for his queen and son. In an
+instant they stood before him; but the queen wept, and said he had
+broken his word, and bad luck would follow. He did all he could to
+soothe her, and she at last seemed to be appeased; but she was not so in
+truth, and was only thinking how she should punish him.
+
+One day he took her to walk with him out of the town, and showed her
+the spot where the boat was set adrift upon the wide waters. Then he sat
+himself down, and said, ‘I am very much tired; sit by me, I will rest my
+head in your lap, and sleep a while.’ As soon as he had fallen asleep,
+however, she drew the ring from his finger, and crept softly away, and
+wished herself and her son at home in their kingdom. And when he awoke
+he found himself alone, and saw that the ring was gone from his finger.
+‘I can never go back to my father’s house,’ said he; ‘they would say I
+am a sorcerer: I will journey forth into the world, till I come again to
+my kingdom.’
+
+So saying he set out and travelled till he came to a hill, where three
+giants were sharing their father’s goods; and as they saw him pass they
+cried out and said, ‘Little men have sharp wits; he shall part the goods
+between us.’ Now there was a sword that cut off an enemy’s head whenever
+the wearer gave the words, ‘Heads off!’; a cloak that made the owner
+invisible, or gave him any form he pleased; and a pair of boots that
+carried the wearer wherever he wished. Heinel said they must first let
+him try these wonderful things, then he might know how to set a value
+upon them. Then they gave him the cloak, and he wished himself a fly,
+and in a moment he was a fly. ‘The cloak is very well,’ said he: ‘now
+give me the sword.’ ‘No,’ said they; ‘not unless you undertake not to
+say, “Heads off!” for if you do we are all dead men.’ So they gave it
+him, charging him to try it on a tree. He next asked for the boots also;
+and the moment he had all three in his power, he wished himself at
+the Golden Mountain; and there he was at once. So the giants were left
+behind with no goods to share or quarrel about.
+
+As Heinel came near his castle he heard the sound of merry music; and
+the people around told him that his queen was about to marry another
+husband. Then he threw his cloak around him, and passed through the
+castle hall, and placed himself by the side of the queen, where no one
+saw him. But when anything to eat was put upon her plate, he took it
+away and ate it himself; and when a glass of wine was handed to her, he
+took it and drank it; and thus, though they kept on giving her meat and
+drink, her plate and cup were always empty.
+
+Upon this, fear and remorse came over her, and she went into her chamber
+alone, and sat there weeping; and he followed her there. ‘Alas!’ said
+she to herself, ‘was I not once set free? Why then does this enchantment
+still seem to bind me?’
+
+‘False and fickle one!’ said he. ‘One indeed came who set thee free, and
+he is now near thee again; but how have you used him? Ought he to
+have had such treatment from thee?’ Then he went out and sent away the
+company, and said the wedding was at an end, for that he was come back
+to the kingdom. But the princes, peers, and great men mocked at him.
+However, he would enter into no parley with them, but only asked them
+if they would go in peace or not. Then they turned upon him and tried
+to seize him; but he drew his sword. ‘Heads Off!’ cried he; and with the
+word the traitors’ heads fell before him, and Heinel was once more king
+of the Golden Mountain.
+
+
+
+
+DOCTOR KNOWALL
+
+There was once upon a time a poor peasant called Crabb, who drove with
+two oxen a load of wood to the town, and sold it to a doctor for two
+talers. When the money was being counted out to him, it so happened that
+the doctor was sitting at table, and when the peasant saw how well he
+ate and drank, his heart desired what he saw, and would willingly
+have been a doctor too. So he remained standing a while, and at length
+inquired if he too could not be a doctor. ‘Oh, yes,’ said the doctor,
+‘that is soon managed.’ ‘What must I do?’ asked the peasant. ‘In the
+first place buy yourself an A B C book of the kind which has a cock on
+the frontispiece; in the second, turn your cart and your two oxen into
+money, and get yourself some clothes, and whatsoever else pertains to
+medicine; thirdly, have a sign painted for yourself with the words: “I
+am Doctor Knowall,” and have that nailed up above your house-door.’ The
+peasant did everything that he had been told to do. When he had doctored
+people awhile, but not long, a rich and great lord had some money
+stolen. Then he was told about Doctor Knowall who lived in such and such
+a village, and must know what had become of the money. So the lord had
+the horses harnessed to his carriage, drove out to the village, and
+asked Crabb if he were Doctor Knowall. Yes, he was, he said. Then he was
+to go with him and bring back the stolen money. ‘Oh, yes, but Grete, my
+wife, must go too.’ The lord was willing, and let both of them have a
+seat in the carriage, and they all drove away together. When they came
+to the nobleman’s castle, the table was spread, and Crabb was told to
+sit down and eat. ‘Yes, but my wife, Grete, too,’ said he, and he seated
+himself with her at the table. And when the first servant came with a
+dish of delicate fare, the peasant nudged his wife, and said: ‘Grete,
+that was the first,’ meaning that was the servant who brought the first
+dish. The servant, however, thought he intended by that to say: ‘That is
+the first thief,’ and as he actually was so, he was terrified, and said
+to his comrade outside: ‘The doctor knows all: we shall fare ill, he
+said I was the first.’ The second did not want to go in at all, but was
+forced. So when he went in with his dish, the peasant nudged his wife,
+and said: ‘Grete, that is the second.’ This servant was equally alarmed,
+and he got out as fast as he could. The third fared no better, for the
+peasant again said: ‘Grete, that is the third.’ The fourth had to carry
+in a dish that was covered, and the lord told the doctor that he was to
+show his skill, and guess what was beneath the cover. Actually, there
+were crabs. The doctor looked at the dish, had no idea what to say, and
+cried: ‘Ah, poor Crabb.’ When the lord heard that, he cried: ‘There! he
+knows it; he must also know who has the money!’
+
+On this the servants looked terribly uneasy, and made a sign to the
+doctor that they wished him to step outside for a moment. When therefore
+he went out, all four of them confessed to him that they had stolen
+the money, and said that they would willingly restore it and give him a
+heavy sum into the bargain, if he would not denounce them, for if he
+did they would be hanged. They led him to the spot where the money was
+concealed. With this the doctor was satisfied, and returned to the hall,
+sat down to the table, and said: ‘My lord, now will I search in my book
+where the gold is hidden.’ The fifth servant, however, crept into the
+stove to hear if the doctor knew still more. But the doctor sat still
+and opened his A B C book, turned the pages backwards and forwards, and
+looked for the cock. As he could not find it immediately he said: ‘I
+know you are there, so you had better come out!’ Then the fellow in the
+stove thought that the doctor meant him, and full of terror, sprang out,
+crying: ‘That man knows everything!’ Then Doctor Knowall showed the lord
+where the money was, but did not say who had stolen it, and received
+from both sides much money in reward, and became a renowned man.
+
+
+
+
+THE SEVEN RAVENS
+
+There was once a man who had seven sons, and last of all one daughter.
+Although the little girl was very pretty, she was so weak and small that
+they thought she could not live; but they said she should at once be
+christened.
+
+So the father sent one of his sons in haste to the spring to get some
+water, but the other six ran with him. Each wanted to be first at
+drawing the water, and so they were in such a hurry that all let their
+pitchers fall into the well, and they stood very foolishly looking at
+one another, and did not know what to do, for none dared go home. In the
+meantime the father was uneasy, and could not tell what made the
+young men stay so long. ‘Surely,’ said he, ‘the whole seven must have
+forgotten themselves over some game of play’; and when he had waited
+still longer and they yet did not come, he flew into a rage and wished
+them all turned into ravens. Scarcely had he spoken these words when he
+heard a croaking over his head, and looked up and saw seven ravens as
+black as coal flying round and round. Sorry as he was to see his wish
+so fulfilled, he did not know how what was done could be undone, and
+comforted himself as well as he could for the loss of his seven sons
+with his dear little daughter, who soon became stronger and every day
+more beautiful.
+
+For a long time she did not know that she had ever had any brothers; for
+her father and mother took care not to speak of them before her: but one
+day by chance she heard the people about her speak of them. ‘Yes,’ said
+they, ‘she is beautiful indeed, but still ‘tis a pity that her brothers
+should have been lost for her sake.’ Then she was much grieved, and went
+to her father and mother, and asked if she had any brothers, and what
+had become of them. So they dared no longer hide the truth from her, but
+said it was the will of Heaven, and that her birth was only the innocent
+cause of it; but the little girl mourned sadly about it every day, and
+thought herself bound to do all she could to bring her brothers back;
+and she had neither rest nor ease, till at length one day she stole
+away, and set out into the wide world to find her brothers, wherever
+they might be, and free them, whatever it might cost her.
+
+She took nothing with her but a little ring which her father and mother
+had given her, a loaf of bread in case she should be hungry, a little
+pitcher of water in case she should be thirsty, and a little stool
+to rest upon when she should be weary. Thus she went on and on, and
+journeyed till she came to the world’s end; then she came to the sun,
+but the sun looked much too hot and fiery; so she ran away quickly to
+the moon, but the moon was cold and chilly, and said, ‘I smell flesh
+and blood this way!’ so she took herself away in a hurry and came to the
+stars, and the stars were friendly and kind to her, and each star sat
+upon his own little stool; but the morning star rose up and gave her a
+little piece of wood, and said, ‘If you have not this little piece of
+wood, you cannot unlock the castle that stands on the glass-mountain,
+and there your brothers live.’ The little girl took the piece of wood,
+rolled it up in a little cloth, and went on again until she came to the
+glass-mountain, and found the door shut. Then she felt for the little
+piece of wood; but when she unwrapped the cloth it was not there, and
+she saw she had lost the gift of the good stars. What was to be done?
+She wanted to save her brothers, and had no key of the castle of the
+glass-mountain; so this faithful little sister took a knife out of her
+pocket and cut off her little finger, that was just the size of the
+piece of wood she had lost, and put it in the door and opened it.
+
+As she went in, a little dwarf came up to her, and said, ‘What are you
+seeking for?’ ‘I seek for my brothers, the seven ravens,’ answered she.
+Then the dwarf said, ‘My masters are not at home; but if you will wait
+till they come, pray step in.’ Now the little dwarf was getting their
+dinner ready, and he brought their food upon seven little plates, and
+their drink in seven little glasses, and set them upon the table, and
+out of each little plate their sister ate a small piece, and out of each
+little glass she drank a small drop; but she let the ring that she had
+brought with her fall into the last glass.
+
+On a sudden she heard a fluttering and croaking in the air, and the
+dwarf said, ‘Here come my masters.’ When they came in, they wanted to
+eat and drink, and looked for their little plates and glasses. Then said
+one after the other,
+
+‘Who has eaten from my little plate? And who has been drinking out of my
+little glass?’
+
+ ‘Caw! Caw! well I ween
+  Mortal lips have this way been.’
+
+When the seventh came to the bottom of his glass, and found there the
+ring, he looked at it, and knew that it was his father’s and mother’s,
+and said, ‘O that our little sister would but come! then we should be
+free.’ When the little girl heard this (for she stood behind the door
+all the time and listened), she ran forward, and in an instant all
+the ravens took their right form again; and all hugged and kissed each
+other, and went merrily home.
+
+
+
+
+THE WEDDING OF MRS FOX
+
+
+FIRST STORY
+
+There was once upon a time an old fox with nine tails, who believed that
+his wife was not faithful to him, and wished to put her to the test. He
+stretched himself out under the bench, did not move a limb, and behaved
+as if he were stone dead. Mrs Fox went up to her room, shut herself in,
+and her maid, Miss Cat, sat by the fire, and did the cooking. When it
+became known that the old fox was dead, suitors presented themselves.
+The maid heard someone standing at the house-door, knocking. She went
+and opened it, and it was a young fox, who said:
+
+ ‘What may you be about, Miss Cat?
+  Do you sleep or do you wake?’
+
+She answered:
+
+ ‘I am not sleeping, I am waking,
+  Would you know what I am making?
+  I am boiling warm beer with butter,
+  Will you be my guest for supper?’
+
+‘No, thank you, miss,’ said the fox, ‘what is Mrs Fox doing?’ The maid
+replied:
+
+ ‘She is sitting in her room,
+  Moaning in her gloom,
+  Weeping her little eyes quite red,
+  Because old Mr Fox is dead.’
+
+‘Do just tell her, miss, that a young fox is here, who would like to woo
+her.’ ‘Certainly, young sir.’
+
+  The cat goes up the stairs trip, trap,
+  The door she knocks at tap, tap, tap,
+ ‘Mistress Fox, are you inside?’
+ ‘Oh, yes, my little cat,’ she cried.
+ ‘A wooer he stands at the door out there.’
+ ‘What does he look like, my dear?’
+
+‘Has he nine as beautiful tails as the late Mr Fox?’ ‘Oh, no,’ answered
+the cat, ‘he has only one.’ ‘Then I will not have him.’
+
+Miss Cat went downstairs and sent the wooer away. Soon afterwards there
+was another knock, and another fox was at the door who wished to woo Mrs
+Fox. He had two tails, but he did not fare better than the first. After
+this still more came, each with one tail more than the other, but they
+were all turned away, until at last one came who had nine tails, like
+old Mr Fox. When the widow heard that, she said joyfully to the cat:
+
+ ‘Now open the gates and doors all wide,
+  And carry old Mr Fox outside.’
+
+But just as the wedding was going to be solemnized, old Mr Fox stirred
+under the bench, and cudgelled all the rabble, and drove them and Mrs
+Fox out of the house.
+
+
+SECOND STORY
+
+When old Mr Fox was dead, the wolf came as a suitor, and knocked at the
+door, and the cat who was servant to Mrs Fox, opened it for him. The
+wolf greeted her, and said:
+
+ ‘Good day, Mrs Cat of Kehrewit,
+  How comes it that alone you sit?
+  What are you making good?’
+
+The cat replied:
+
+ ‘In milk I’m breaking bread so sweet,
+  Will you be my guest, and eat?’
+
+‘No, thank you, Mrs Cat,’ answered the wolf. ‘Is Mrs Fox not at home?’
+
+The cat said:
+
+ ‘She sits upstairs in her room,
+  Bewailing her sorrowful doom,
+  Bewailing her trouble so sore,
+  For old Mr Fox is no more.’
+
+The wolf answered:
+
+ ‘If she’s in want of a husband now,
+  Then will it please her to step below?’
+  The cat runs quickly up the stair,
+  And lets her tail fly here and there,
+  Until she comes to the parlour door.
+  With her five gold rings at the door she knocks:
+ ‘Are you within, good Mistress Fox?
+  If you’re in want of a husband now,
+  Then will it please you to step below?
+
+Mrs Fox asked: ‘Has the gentleman red stockings on, and has he a pointed
+mouth?’ ‘No,’ answered the cat. ‘Then he won’t do for me.’
+
+When the wolf was gone, came a dog, a stag, a hare, a bear, a lion, and
+all the beasts of the forest, one after the other. But one of the good
+qualities which old Mr Fox had possessed, was always lacking, and the
+cat had continually to send the suitors away. At length came a young
+fox. Then Mrs Fox said: ‘Has the gentleman red stockings on, and has a
+little pointed mouth?’ ‘Yes,’ said the cat, ‘he has.’ ‘Then let him come
+upstairs,’ said Mrs Fox, and ordered the servant to prepare the wedding
+feast.
+
+ ‘Sweep me the room as clean as you can,
+  Up with the window, fling out my old man!
+  For many a fine fat mouse he brought,
+  Yet of his wife he never thought,
+  But ate up every one he caught.’
+
+Then the wedding was solemnized with young Mr Fox, and there was much
+rejoicing and dancing; and if they have not left off, they are dancing
+still.
+
+
+
+
+THE SALAD
+
+As a merry young huntsman was once going briskly along through a wood,
+there came up a little old woman, and said to him, ‘Good day, good day;
+you seem merry enough, but I am hungry and thirsty; do pray give me
+something to eat.’ The huntsman took pity on her, and put his hand in
+his pocket and gave her what he had. Then he wanted to go his way; but
+she took hold of him, and said, ‘Listen, my friend, to what I am going
+to tell you; I will reward you for your kindness; go your way, and after
+a little time you will come to a tree where you will see nine birds
+sitting on a cloak. Shoot into the midst of them, and one will fall down
+dead: the cloak will fall too; take it, it is a wishing-cloak, and when
+you wear it you will find yourself at any place where you may wish to
+be. Cut open the dead bird, take out its heart and keep it, and you will
+find a piece of gold under your pillow every morning when you rise. It
+is the bird’s heart that will bring you this good luck.’
+
+The huntsman thanked her, and thought to himself, ‘If all this does
+happen, it will be a fine thing for me.’ When he had gone a hundred
+steps or so, he heard a screaming and chirping in the branches over him,
+and looked up and saw a flock of birds pulling a cloak with their bills
+and feet; screaming, fighting, and tugging at each other as if
+each wished to have it himself. ‘Well,’ said the huntsman, ‘this is
+wonderful; this happens just as the old woman said’; then he shot into
+the midst of them so that their feathers flew all about. Off went the
+flock chattering away; but one fell down dead, and the cloak with it.
+Then the huntsman did as the old woman told him, cut open the bird, took
+out the heart, and carried the cloak home with him.
+
+The next morning when he awoke he lifted up his pillow, and there lay
+the piece of gold glittering underneath; the same happened next day, and
+indeed every day when he arose. He heaped up a great deal of gold, and
+at last thought to himself, ‘Of what use is this gold to me whilst I am
+at home? I will go out into the world and look about me.’
+
+Then he took leave of his friends, and hung his bag and bow about his
+neck, and went his way. It so happened that his road one day led through
+a thick wood, at the end of which was a large castle in a green meadow,
+and at one of the windows stood an old woman with a very beautiful young
+lady by her side looking about them. Now the old woman was a witch, and
+said to the young lady, ‘There is a young man coming out of the wood who
+carries a wonderful prize; we must get it away from him, my dear child,
+for it is more fit for us than for him. He has a bird’s heart that
+brings a piece of gold under his pillow every morning.’ Meantime the
+huntsman came nearer and looked at the lady, and said to himself, ‘I
+have been travelling so long that I should like to go into this castle
+and rest myself, for I have money enough to pay for anything I want’;
+but the real reason was, that he wanted to see more of the beautiful
+lady. Then he went into the house, and was welcomed kindly; and it was
+not long before he was so much in love that he thought of nothing else
+but looking at the lady’s eyes, and doing everything that she wished.
+Then the old woman said, ‘Now is the time for getting the bird’s heart.’
+So the lady stole it away, and he never found any more gold under his
+pillow, for it lay now under the young lady’s, and the old woman took it
+away every morning; but he was so much in love that he never missed his
+prize.
+
+‘Well,’ said the old witch, ‘we have got the bird’s heart, but not the
+wishing-cloak yet, and that we must also get.’ ‘Let us leave him that,’
+said the young lady; ‘he has already lost his wealth.’ Then the witch
+was very angry, and said, ‘Such a cloak is a very rare and wonderful
+thing, and I must and will have it.’ So she did as the old woman told
+her, and set herself at the window, and looked about the country and
+seemed very sorrowful; then the huntsman said, ‘What makes you so sad?’
+‘Alas! dear sir,’ said she, ‘yonder lies the granite rock where all the
+costly diamonds grow, and I want so much to go there, that whenever I
+think of it I cannot help being sorrowful, for who can reach it? only
+the birds and the flies--man cannot.’ ‘If that’s all your grief,’ said
+the huntsman, ‘I’ll take you there with all my heart’; so he drew her under
+his cloak, and the moment he wished to be on the granite mountain they
+were both there. The diamonds glittered so on all sides that they were
+delighted with the sight and picked up the finest. But the old witch
+made a deep sleep come upon him, and he said to the young lady, ‘Let us
+sit down and rest ourselves a little, I am so tired that I cannot stand
+any longer.’ So they sat down, and he laid his head in her lap and
+fell asleep; and whilst he was sleeping on she took the cloak from
+his shoulders, hung it on her own, picked up the diamonds, and wished
+herself home again.
+
+When he awoke and found that his lady had tricked him, and left him
+alone on the wild rock, he said, ‘Alas! what roguery there is in the
+world!’ and there he sat in great grief and fear, not knowing what to
+do. Now this rock belonged to fierce giants who lived upon it; and as
+he saw three of them striding about, he thought to himself, ‘I can only
+save myself by feigning to be asleep’; so he laid himself down as if he
+were in a sound sleep. When the giants came up to him, the first pushed
+him with his foot, and said, ‘What worm is this that lies here curled
+up?’ ‘Tread upon him and kill him,’ said the second. ‘It’s not worth the
+trouble,’ said the third; ‘let him live, he’ll go climbing higher up the
+mountain, and some cloud will come rolling and carry him away.’ And they
+passed on. But the huntsman had heard all they said; and as soon as they
+were gone, he climbed to the top of the mountain, and when he had sat
+there a short time a cloud came rolling around him, and caught him in a
+whirlwind and bore him along for some time, till it settled in a garden,
+and he fell quite gently to the ground amongst the greens and cabbages.
+
+Then he looked around him, and said, ‘I wish I had something to eat, if
+not I shall be worse off than before; for here I see neither apples
+nor pears, nor any kind of fruits, nothing but vegetables.’ At last he
+thought to himself, ‘I can eat salad, it will refresh and strengthen
+me.’ So he picked out a fine head and ate of it; but scarcely had he
+swallowed two bites when he felt himself quite changed, and saw with
+horror that he was turned into an ass. However, he still felt very
+hungry, and the salad tasted very nice; so he ate on till he came
+to another kind of salad, and scarcely had he tasted it when he felt
+another change come over him, and soon saw that he was lucky enough to
+have found his old shape again.
+
+Then he laid himself down and slept off a little of his weariness; and
+when he awoke the next morning he broke off a head both of the good and
+the bad salad, and thought to himself, ‘This will help me to my fortune
+again, and enable me to pay off some folks for their treachery.’ So he
+went away to try and find the castle of his friends; and after wandering
+about a few days he luckily found it. Then he stained his face all over
+brown, so that even his mother would not have known him, and went into
+the castle and asked for a lodging; ‘I am so tired,’ said he, ‘that I
+can go no farther.’ ‘Countryman,’ said the witch, ‘who are you? and what
+is your business?’ ‘I am,’ said he, ‘a messenger sent by the king to
+find the finest salad that grows under the sun. I have been lucky
+enough to find it, and have brought it with me; but the heat of the sun
+scorches so that it begins to wither, and I don’t know that I can carry
+it farther.’
+
+When the witch and the young lady heard of his beautiful salad, they
+longed to taste it, and said, ‘Dear countryman, let us just taste it.’
+‘To be sure,’ answered he; ‘I have two heads of it with me, and will
+give you one’; so he opened his bag and gave them the bad. Then the
+witch herself took it into the kitchen to be dressed; and when it was
+ready she could not wait till it was carried up, but took a few leaves
+immediately and put them in her mouth, and scarcely were they swallowed
+when she lost her own form and ran braying down into the court in the
+form of an ass. Now the servant-maid came into the kitchen, and seeing
+the salad ready, was going to carry it up; but on the way she too felt a
+wish to taste it as the old woman had done, and ate some leaves; so she
+also was turned into an ass and ran after the other, letting the dish
+with the salad fall on the ground. The messenger sat all this time with
+the beautiful young lady, and as nobody came with the salad and she
+longed to taste it, she said, ‘I don’t know where the salad can be.’
+Then he thought something must have happened, and said, ‘I will go
+into the kitchen and see.’ And as he went he saw two asses in the court
+running about, and the salad lying on the ground. ‘All right!’ said
+he; ‘those two have had their share.’ Then he took up the rest of
+the leaves, laid them on the dish and brought them to the young lady,
+saying, ‘I bring you the dish myself that you may not wait any longer.’
+So she ate of it, and like the others ran off into the court braying
+away.
+
+Then the huntsman washed his face and went into the court that they
+might know him. ‘Now you shall be paid for your roguery,’ said he; and
+tied them all three to a rope and took them along with him till he
+came to a mill and knocked at the window. ‘What’s the matter?’ said the
+miller. ‘I have three tiresome beasts here,’ said the other; ‘if you
+will take them, give them food and room, and treat them as I tell you,
+I will pay you whatever you ask.’ ‘With all my heart,’ said the miller;
+‘but how shall I treat them?’ Then the huntsman said, ‘Give the old
+one stripes three times a day and hay once; give the next (who was
+the servant-maid) stripes once a day and hay three times; and give
+the youngest (who was the beautiful lady) hay three times a day and
+no stripes’: for he could not find it in his heart to have her beaten.
+After this he went back to the castle, where he found everything he
+wanted.
+
+Some days after, the miller came to him and told him that the old ass
+was dead; ‘The other two,’ said he, ‘are alive and eat, but are so
+sorrowful that they cannot last long.’ Then the huntsman pitied them,
+and told the miller to drive them back to him, and when they came, he
+gave them some of the good salad to eat. And the beautiful young lady
+fell upon her knees before him, and said, ‘O dearest huntsman! forgive
+me all the ill I have done you; my mother forced me to it, it was
+against my will, for I always loved you very much. Your wishing-cloak
+hangs up in the closet, and as for the bird’s heart, I will give it you
+too.’ But he said, ‘Keep it, it will be just the same thing, for I mean
+to make you my wife.’ So they were married, and lived together very
+happily till they died.
+
+
+
+
+THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+
+A certain father had two sons, the elder of who was smart and sensible,
+and could do everything, but the younger was stupid and could neither
+learn nor understand anything, and when people saw him they said:
+‘There’s a fellow who will give his father some trouble!’ When anything
+had to be done, it was always the elder who was forced to do it; but
+if his father bade him fetch anything when it was late, or in the
+night-time, and the way led through the churchyard, or any other dismal
+place, he answered: ‘Oh, no father, I’ll not go there, it makes me
+shudder!’ for he was afraid. Or when stories were told by the fire at
+night which made the flesh creep, the listeners sometimes said: ‘Oh,
+it makes us shudder!’ The younger sat in a corner and listened with
+the rest of them, and could not imagine what they could mean. ‘They are
+always saying: “It makes me shudder, it makes me shudder!” It does not
+make me shudder,’ thought he. ‘That, too, must be an art of which I
+understand nothing!’
+
+Now it came to pass that his father said to him one day: ‘Hearken to me,
+you fellow in the corner there, you are growing tall and strong, and you
+too must learn something by which you can earn your bread. Look how your
+brother works, but you do not even earn your salt.’ ‘Well, father,’ he
+replied, ‘I am quite willing to learn something--indeed, if it could but
+be managed, I should like to learn how to shudder. I don’t understand
+that at all yet.’ The elder brother smiled when he heard that, and
+thought to himself: ‘Goodness, what a blockhead that brother of mine is!
+He will never be good for anything as long as he lives! He who wants to
+be a sickle must bend himself betimes.’
+
+The father sighed, and answered him: ‘You shall soon learn what it is to
+shudder, but you will not earn your bread by that.’
+
+Soon after this the sexton came to the house on a visit, and the father
+bewailed his trouble, and told him how his younger son was so backward
+in every respect that he knew nothing and learnt nothing. ‘Just think,’
+said he, ‘when I asked him how he was going to earn his bread, he
+actually wanted to learn to shudder.’ ‘If that be all,’ replied the
+sexton, ‘he can learn that with me. Send him to me, and I will soon
+polish him.’ The father was glad to do it, for he thought: ‘It will
+train the boy a little.’ The sexton therefore took him into his house,
+and he had to ring the church bell. After a day or two, the sexton awoke
+him at midnight, and bade him arise and go up into the church tower and
+ring the bell. ‘You shall soon learn what shuddering is,’ thought he,
+and secretly went there before him; and when the boy was at the top of
+the tower and turned round, and was just going to take hold of the bell
+rope, he saw a white figure standing on the stairs opposite the sounding
+hole. ‘Who is there?’ cried he, but the figure made no reply, and did
+not move or stir. ‘Give an answer,’ cried the boy, ‘or take yourself
+off, you have no business here at night.’
+
+The sexton, however, remained standing motionless that the boy might
+think he was a ghost. The boy cried a second time: ‘What do you want
+here?--speak if you are an honest fellow, or I will throw you down the
+steps!’ The sexton thought: ‘He can’t mean to be as bad as his words,’
+uttered no sound and stood as if he were made of stone. Then the boy
+called to him for the third time, and as that was also to no purpose,
+he ran against him and pushed the ghost down the stairs, so that it fell
+down the ten steps and remained lying there in a corner. Thereupon he
+rang the bell, went home, and without saying a word went to bed, and
+fell asleep. The sexton’s wife waited a long time for her husband, but
+he did not come back. At length she became uneasy, and wakened the boy,
+and asked: ‘Do you know where my husband is? He climbed up the tower
+before you did.’ ‘No, I don’t know,’ replied the boy, ‘but someone was
+standing by the sounding hole on the other side of the steps, and as he
+would neither gave an answer nor go away, I took him for a scoundrel,
+and threw him downstairs. Just go there and you will see if it was he.
+I should be sorry if it were.’ The woman ran away and found her husband,
+who was lying moaning in the corner, and had broken his leg.
+
+She carried him down, and then with loud screams she hastened to the
+boy’s father, ‘Your boy,’ cried she, ‘has been the cause of a great
+misfortune! He has thrown my husband down the steps so that he broke his
+leg. Take the good-for-nothing fellow out of our house.’ The father was
+terrified, and ran thither and scolded the boy. ‘What wicked tricks
+are these?’ said he. ‘The devil must have put them into your head.’
+‘Father,’ he replied, ‘do listen to me. I am quite innocent. He was
+standing there by night like one intent on doing evil. I did not know
+who it was, and I entreated him three times either to speak or to go
+away.’ ‘Ah,’ said the father, ‘I have nothing but unhappiness with you.
+Go out of my sight. I will see you no more.’
+
+‘Yes, father, right willingly, wait only until it is day. Then will I
+go forth and learn how to shudder, and then I shall, at any rate,
+understand one art which will support me.’ ‘Learn what you will,’ spoke
+the father, ‘it is all the same to me. Here are fifty talers for you.
+Take these and go into the wide world, and tell no one from whence you
+come, and who is your father, for I have reason to be ashamed of you.’
+‘Yes, father, it shall be as you will. If you desire nothing more than
+that, I can easily keep it in mind.’
+
+When the day dawned, therefore, the boy put his fifty talers into his
+pocket, and went forth on the great highway, and continually said to
+himself: ‘If I could but shudder! If I could but shudder!’ Then a man
+approached who heard this conversation which the youth was holding with
+himself, and when they had walked a little farther to where they could
+see the gallows, the man said to him: ‘Look, there is the tree where
+seven men have married the ropemaker’s daughter, and are now learning
+how to fly. Sit down beneath it, and wait till night comes, and you will
+soon learn how to shudder.’ ‘If that is all that is wanted,’ answered
+the youth, ‘it is easily done; but if I learn how to shudder as fast as
+that, you shall have my fifty talers. Just come back to me early in the
+morning.’ Then the youth went to the gallows, sat down beneath it, and
+waited till evening came. And as he was cold, he lighted himself a fire,
+but at midnight the wind blew so sharply that in spite of his fire, he
+could not get warm. And as the wind knocked the hanged men against each
+other, and they moved backwards and forwards, he thought to himself:
+‘If you shiver below by the fire, how those up above must freeze and
+suffer!’ And as he felt pity for them, he raised the ladder, and climbed
+up, unbound one of them after the other, and brought down all seven.
+Then he stoked the fire, blew it, and set them all round it to warm
+themselves. But they sat there and did not stir, and the fire caught
+their clothes. So he said: ‘Take care, or I will hang you up again.’ The
+dead men, however, did not hear, but were quite silent, and let their
+rags go on burning. At this he grew angry, and said: ‘If you will not
+take care, I cannot help you, I will not be burnt with you,’ and he hung
+them up again each in his turn. Then he sat down by his fire and fell
+asleep, and the next morning the man came to him and wanted to have
+the fifty talers, and said: ‘Well do you know how to shudder?’ ‘No,’
+answered he, ‘how should I know? Those fellows up there did not open
+their mouths, and were so stupid that they let the few old rags which
+they had on their bodies get burnt.’ Then the man saw that he would not
+get the fifty talers that day, and went away saying: ‘Such a youth has
+never come my way before.’
+
+The youth likewise went his way, and once more began to mutter to
+himself: ‘Ah, if I could but shudder! Ah, if I could but shudder!’ A
+waggoner who was striding behind him heard this and asked: ‘Who are
+you?’ ‘I don’t know,’ answered the youth. Then the waggoner asked: ‘From
+whence do you come?’ ‘I know not.’ ‘Who is your father?’ ‘That I may
+not tell you.’ ‘What is it that you are always muttering between your
+teeth?’ ‘Ah,’ replied the youth, ‘I do so wish I could shudder, but
+no one can teach me how.’ ‘Enough of your foolish chatter,’ said the
+waggoner. ‘Come, go with me, I will see about a place for you.’ The
+youth went with the waggoner, and in the evening they arrived at an inn
+where they wished to pass the night. Then at the entrance of the parlour
+the youth again said quite loudly: ‘If I could but shudder! If I could
+but shudder!’ The host who heard this, laughed and said: ‘If that is
+your desire, there ought to be a good opportunity for you here.’ ‘Ah,
+be silent,’ said the hostess, ‘so many prying persons have already lost
+their lives, it would be a pity and a shame if such beautiful eyes as
+these should never see the daylight again.’
+
+But the youth said: ‘However difficult it may be, I will learn it. For
+this purpose indeed have I journeyed forth.’ He let the host have
+no rest, until the latter told him, that not far from thence stood a
+haunted castle where anyone could very easily learn what shuddering was,
+if he would but watch in it for three nights. The king had promised that
+he who would venture should have his daughter to wife, and she was the
+most beautiful maiden the sun shone on. Likewise in the castle lay great
+treasures, which were guarded by evil spirits, and these treasures would
+then be freed, and would make a poor man rich enough. Already many men
+had gone into the castle, but as yet none had come out again. Then the
+youth went next morning to the king, and said: ‘If it be allowed, I will
+willingly watch three nights in the haunted castle.’
+
+The king looked at him, and as the youth pleased him, he said: ‘You may
+ask for three things to take into the castle with you, but they must
+be things without life.’ Then he answered: ‘Then I ask for a fire, a
+turning lathe, and a cutting-board with the knife.’
+
+The king had these things carried into the castle for him during the
+day. When night was drawing near, the youth went up and made himself
+a bright fire in one of the rooms, placed the cutting-board and knife
+beside it, and seated himself by the turning-lathe. ‘Ah, if I could
+but shudder!’ said he, ‘but I shall not learn it here either.’ Towards
+midnight he was about to poke his fire, and as he was blowing it,
+something cried suddenly from one corner: ‘Au, miau! how cold we are!’
+‘You fools!’ cried he, ‘what are you crying about? If you are cold, come
+and take a seat by the fire and warm yourselves.’ And when he had said
+that, two great black cats came with one tremendous leap and sat down
+on each side of him, and looked savagely at him with their fiery
+eyes. After a short time, when they had warmed themselves, they said:
+‘Comrade, shall we have a game of cards?’ ‘Why not?’ he replied, ‘but
+just show me your paws.’ Then they stretched out their claws. ‘Oh,’ said
+he, ‘what long nails you have! Wait, I must first cut them for you.’
+Thereupon he seized them by the throats, put them on the cutting-board
+and screwed their feet fast. ‘I have looked at your fingers,’ said he,
+‘and my fancy for card-playing has gone,’ and he struck them dead and
+threw them out into the water. But when he had made away with these two,
+and was about to sit down again by his fire, out from every hole and
+corner came black cats and black dogs with red-hot chains, and more
+and more of them came until he could no longer move, and they yelled
+horribly, and got on his fire, pulled it to pieces, and tried to put
+it out. He watched them for a while quietly, but at last when they were
+going too far, he seized his cutting-knife, and cried: ‘Away with you,
+vermin,’ and began to cut them down. Some of them ran away, the others
+he killed, and threw out into the fish-pond. When he came back he fanned
+the embers of his fire again and warmed himself. And as he thus sat, his
+eyes would keep open no longer, and he felt a desire to sleep. Then he
+looked round and saw a great bed in the corner. ‘That is the very thing
+for me,’ said he, and got into it. When he was just going to shut his
+eyes, however, the bed began to move of its own accord, and went over
+the whole of the castle. ‘That’s right,’ said he, ‘but go faster.’ Then
+the bed rolled on as if six horses were harnessed to it, up and down,
+over thresholds and stairs, but suddenly hop, hop, it turned over upside
+down, and lay on him like a mountain. But he threw quilts and pillows up
+in the air, got out and said: ‘Now anyone who likes, may drive,’ and
+lay down by his fire, and slept till it was day. In the morning the king
+came, and when he saw him lying there on the ground, he thought the evil
+spirits had killed him and he was dead. Then said he: ‘After all it is a
+pity,--for so handsome a man.’ The youth heard it, got up, and said: ‘It
+has not come to that yet.’ Then the king was astonished, but very glad,
+and asked how he had fared. ‘Very well indeed,’ answered he; ‘one
+night is past, the two others will pass likewise.’ Then he went to the
+innkeeper, who opened his eyes very wide, and said: ‘I never expected to
+see you alive again! Have you learnt how to shudder yet?’ ‘No,’ said he,
+‘it is all in vain. If someone would but tell me!’
+
+The second night he again went up into the old castle, sat down by the
+fire, and once more began his old song: ‘If I could but shudder!’ When
+midnight came, an uproar and noise of tumbling about was heard; at
+first it was low, but it grew louder and louder. Then it was quiet for
+a while, and at length with a loud scream, half a man came down the
+chimney and fell before him. ‘Hullo!’ cried he, ‘another half belongs
+to this. This is not enough!’ Then the uproar began again, there was a
+roaring and howling, and the other half fell down likewise. ‘Wait,’ said
+he, ‘I will just stoke up the fire a little for you.’ When he had done
+that and looked round again, the two pieces were joined together, and a
+hideous man was sitting in his place. ‘That is no part of our bargain,’
+said the youth, ‘the bench is mine.’ The man wanted to push him away;
+the youth, however, would not allow that, but thrust him off with all
+his strength, and seated himself again in his own place. Then still more
+men fell down, one after the other; they brought nine dead men’s legs
+and two skulls, and set them up and played at nine-pins with them. The
+youth also wanted to play and said: ‘Listen you, can I join you?’ ‘Yes,
+if you have any money.’ ‘Money enough,’ replied he, ‘but your balls are
+not quite round.’ Then he took the skulls and put them in the lathe and
+turned them till they were round. ‘There, now they will roll better!’
+said he. ‘Hurrah! now we’ll have fun!’ He played with them and lost some
+of his money, but when it struck twelve, everything vanished from his
+sight. He lay down and quietly fell asleep. Next morning the king came
+to inquire after him. ‘How has it fared with you this time?’ asked he.
+‘I have been playing at nine-pins,’ he answered, ‘and have lost a couple
+of farthings.’ ‘Have you not shuddered then?’ ‘What?’ said he, ‘I have
+had a wonderful time! If I did but know what it was to shudder!’
+
+The third night he sat down again on his bench and said quite sadly:
+‘If I could but shudder.’ When it grew late, six tall men came in and
+brought a coffin. Then he said: ‘Ha, ha, that is certainly my little
+cousin, who died only a few days ago,’ and he beckoned with his finger,
+and cried: ‘Come, little cousin, come.’ They placed the coffin on the
+ground, but he went to it and took the lid off, and a dead man lay
+therein. He felt his face, but it was cold as ice. ‘Wait,’ said he, ‘I
+will warm you a little,’ and went to the fire and warmed his hand and
+laid it on the dead man’s face, but he remained cold. Then he took him
+out, and sat down by the fire and laid him on his breast and rubbed his
+arms that the blood might circulate again. As this also did no good, he
+thought to himself: ‘When two people lie in bed together, they warm each
+other,’ and carried him to the bed, covered him over and lay down by
+him. After a short time the dead man became warm too, and began to move.
+Then said the youth, ‘See, little cousin, have I not warmed you?’ The
+dead man, however, got up and cried: ‘Now will I strangle you.’
+
+‘What!’ said he, ‘is that the way you thank me? You shall at once go
+into your coffin again,’ and he took him up, threw him into it, and shut
+the lid. Then came the six men and carried him away again. ‘I cannot
+manage to shudder,’ said he. ‘I shall never learn it here as long as I
+live.’
+
+Then a man entered who was taller than all others, and looked terrible.
+He was old, however, and had a long white beard. ‘You wretch,’ cried he,
+‘you shall soon learn what it is to shudder, for you shall die.’ ‘Not so
+fast,’ replied the youth. ‘If I am to die, I shall have to have a say
+in it.’ ‘I will soon seize you,’ said the fiend. ‘Softly, softly, do not
+talk so big. I am as strong as you are, and perhaps even stronger.’
+‘We shall see,’ said the old man. ‘If you are stronger, I will let you
+go--come, we will try.’ Then he led him by dark passages to a smith’s
+forge, took an axe, and with one blow struck an anvil into the ground.
+‘I can do better than that,’ said the youth, and went to the other
+anvil. The old man placed himself near and wanted to look on, and his
+white beard hung down. Then the youth seized the axe, split the anvil
+with one blow, and in it caught the old man’s beard. ‘Now I have you,’
+said the youth. ‘Now it is your turn to die.’ Then he seized an iron bar
+and beat the old man till he moaned and entreated him to stop, when he
+would give him great riches. The youth drew out the axe and let him go.
+The old man led him back into the castle, and in a cellar showed him
+three chests full of gold. ‘Of these,’ said he, ‘one part is for the
+poor, the other for the king, the third yours.’ In the meantime it
+struck twelve, and the spirit disappeared, so that the youth stood in
+darkness. ‘I shall still be able to find my way out,’ said he, and felt
+about, found the way into the room, and slept there by his fire.
+Next morning the king came and said: ‘Now you must have learnt what
+shuddering is?’ ‘No,’ he answered; ‘what can it be? My dead cousin was
+here, and a bearded man came and showed me a great deal of money down
+below, but no one told me what it was to shudder.’ ‘Then,’ said the
+king, ‘you have saved the castle, and shall marry my daughter.’ ‘That
+is all very well,’ said he, ‘but still I do not know what it is to
+shudder!’
+
+Then the gold was brought up and the wedding celebrated; but howsoever
+much the young king loved his wife, and however happy he was, he still
+said always: ‘If I could but shudder--if I could but shudder.’ And this
+at last angered her. Her waiting-maid said: ‘I will find a cure for him;
+he shall soon learn what it is to shudder.’ She went out to the stream
+which flowed through the garden, and had a whole bucketful of gudgeons
+brought to her. At night when the young king was sleeping, his wife was
+to draw the clothes off him and empty the bucket full of cold water
+with the gudgeons in it over him, so that the little fishes would
+sprawl about him. Then he woke up and cried: ‘Oh, what makes me shudder
+so?--what makes me shudder so, dear wife? Ah! now I know what it is to
+shudder!’
+
+
+
+
+KING GRISLY-BEARD
+
+A great king of a land far away in the East had a daughter who was very
+beautiful, but so proud, and haughty, and conceited, that none of the
+princes who came to ask her in marriage was good enough for her, and she
+only made sport of them.
+
+Once upon a time the king held a great feast, and asked thither all
+her suitors; and they all sat in a row, ranged according to their
+rank--kings, and princes, and dukes, and earls, and counts, and barons,
+and knights. Then the princess came in, and as she passed by them she
+had something spiteful to say to every one. The first was too fat: ‘He’s
+as round as a tub,’ said she. The next was too tall: ‘What a maypole!’
+said she. The next was too short: ‘What a dumpling!’ said she. The
+fourth was too pale, and she called him ‘Wallface.’ The fifth was too
+red, so she called him ‘Coxcomb.’ The sixth was not straight enough;
+so she said he was like a green stick, that had been laid to dry over
+a baker’s oven. And thus she had some joke to crack upon every one: but
+she laughed more than all at a good king who was there. ‘Look at
+him,’ said she; ‘his beard is like an old mop; he shall be called
+Grisly-beard.’ So the king got the nickname of Grisly-beard.
+
+But the old king was very angry when he saw how his daughter behaved,
+and how she ill-treated all his guests; and he vowed that, willing or
+unwilling, she should marry the first man, be he prince or beggar, that
+came to the door.
+
+Two days after there came by a travelling fiddler, who began to play
+under the window and beg alms; and when the king heard him, he said,
+‘Let him come in.’ So they brought in a dirty-looking fellow; and when
+he had sung before the king and the princess, he begged a boon. Then the
+king said, ‘You have sung so well, that I will give you my daughter for
+your wife.’ The princess begged and prayed; but the king said, ‘I have
+sworn to give you to the first comer, and I will keep my word.’ So words
+and tears were of no avail; the parson was sent for, and she was married
+to the fiddler. When this was over the king said, ‘Now get ready to
+go--you must not stay here--you must travel on with your husband.’
+
+Then the fiddler went his way, and took her with him, and they soon came
+to a great wood. ‘Pray,’ said she, ‘whose is this wood?’ ‘It belongs
+to King Grisly-beard,’ answered he; ‘hadst thou taken him, all had been
+thine.’ ‘Ah! unlucky wretch that I am!’ sighed she; ‘would that I had
+married King Grisly-beard!’ Next they came to some fine meadows. ‘Whose
+are these beautiful green meadows?’ said she. ‘They belong to King
+Grisly-beard, hadst thou taken him, they had all been thine.’ ‘Ah!
+unlucky wretch that I am!’ said she; ‘would that I had married King
+Grisly-beard!’
+
+Then they came to a great city. ‘Whose is this noble city?’ said she.
+‘It belongs to King Grisly-beard; hadst thou taken him, it had all been
+thine.’ ‘Ah! wretch that I am!’ sighed she; ‘why did I not marry King
+Grisly-beard?’ ‘That is no business of mine,’ said the fiddler: ‘why
+should you wish for another husband? Am not I good enough for you?’
+
+At last they came to a small cottage. ‘What a paltry place!’ said she;
+‘to whom does that little dirty hole belong?’ Then the fiddler said,
+‘That is your and my house, where we are to live.’ ‘Where are your
+servants?’ cried she. ‘What do we want with servants?’ said he; ‘you
+must do for yourself whatever is to be done. Now make the fire, and put
+on water and cook my supper, for I am very tired.’ But the princess knew
+nothing of making fires and cooking, and the fiddler was forced to help
+her. When they had eaten a very scanty meal they went to bed; but the
+fiddler called her up very early in the morning to clean the house. Thus
+they lived for two days: and when they had eaten up all there was in the
+cottage, the man said, ‘Wife, we can’t go on thus, spending money and
+earning nothing. You must learn to weave baskets.’ Then he went out and
+cut willows, and brought them home, and she began to weave; but it made
+her fingers very sore. ‘I see this work won’t do,’ said he: ‘try and
+spin; perhaps you will do that better.’ So she sat down and tried to
+spin; but the threads cut her tender fingers till the blood ran. ‘See
+now,’ said the fiddler, ‘you are good for nothing; you can do no work:
+what a bargain I have got! However, I’ll try and set up a trade in pots
+and pans, and you shall stand in the market and sell them.’ ‘Alas!’
+sighed she, ‘if any of my father’s court should pass by and see me
+standing in the market, how they will laugh at me!’
+
+But her husband did not care for that, and said she must work, if she
+did not wish to die of hunger. At first the trade went well; for many
+people, seeing such a beautiful woman, went to buy her wares, and paid
+their money without thinking of taking away the goods. They lived on
+this as long as it lasted; and then her husband bought a fresh lot of
+ware, and she sat herself down with it in the corner of the market; but
+a drunken soldier soon came by, and rode his horse against her stall,
+and broke all her goods into a thousand pieces. Then she began to cry,
+and knew not what to do. ‘Ah! what will become of me?’ said she; ‘what
+will my husband say?’ So she ran home and told him all. ‘Who would
+have thought you would have been so silly,’ said he, ‘as to put an
+earthenware stall in the corner of the market, where everybody passes?
+but let us have no more crying; I see you are not fit for this sort of
+work, so I have been to the king’s palace, and asked if they did not
+want a kitchen-maid; and they say they will take you, and there you will
+have plenty to eat.’
+
+Thus the princess became a kitchen-maid, and helped the cook to do all
+the dirtiest work; but she was allowed to carry home some of the meat
+that was left, and on this they lived.
+
+She had not been there long before she heard that the king’s eldest son
+was passing by, going to be married; and she went to one of the windows
+and looked out. Everything was ready, and all the pomp and brightness of
+the court was there. Then she bitterly grieved for the pride and folly
+which had brought her so low. And the servants gave her some of the rich
+meats, which she put into her basket to take home.
+
+All on a sudden, as she was going out, in came the king’s son in golden
+clothes; and when he saw a beautiful woman at the door, he took her
+by the hand, and said she should be his partner in the dance; but she
+trembled for fear, for she saw that it was King Grisly-beard, who was
+making sport of her. However, he kept fast hold, and led her in; and the
+cover of the basket came off, so that the meats in it fell about. Then
+everybody laughed and jeered at her; and she was so abashed, that she
+wished herself a thousand feet deep in the earth. She sprang to the
+door to run away; but on the steps King Grisly-beard overtook her, and
+brought her back and said, ‘Fear me not! I am the fiddler who has lived
+with you in the hut. I brought you there because I really loved you. I
+am also the soldier that overset your stall. I have done all this only
+to cure you of your silly pride, and to show you the folly of your
+ill-treatment of me. Now all is over: you have learnt wisdom, and it is
+time to hold our marriage feast.’
+
+Then the chamberlains came and brought her the most beautiful robes; and
+her father and his whole court were there already, and welcomed her home
+on her marriage. Joy was in every face and every heart. The feast was
+grand; they danced and sang; all were merry; and I only wish that you
+and I had been of the party.
+
+
+
+
+IRON HANS
+
+There was once upon a time a king who had a great forest near his
+palace, full of all kinds of wild animals. One day he sent out a
+huntsman to shoot him a roe, but he did not come back. ‘Perhaps some
+accident has befallen him,’ said the king, and the next day he sent out
+two more huntsmen who were to search for him, but they too stayed away.
+Then on the third day, he sent for all his huntsmen, and said: ‘Scour
+the whole forest through, and do not give up until you have found all
+three.’ But of these also, none came home again, none were seen again.
+From that time forth, no one would any longer venture into the forest,
+and it lay there in deep stillness and solitude, and nothing was seen
+of it, but sometimes an eagle or a hawk flying over it. This lasted for
+many years, when an unknown huntsman announced himself to the king as
+seeking a situation, and offered to go into the dangerous forest. The
+king, however, would not give his consent, and said: ‘It is not safe in
+there; I fear it would fare with you no better than with the others,
+and you would never come out again.’ The huntsman replied: ‘Lord, I will
+venture it at my own risk, of fear I know nothing.’
+
+The huntsman therefore betook himself with his dog to the forest. It was
+not long before the dog fell in with some game on the way, and wanted to
+pursue it; but hardly had the dog run two steps when it stood before a
+deep pool, could go no farther, and a naked arm stretched itself out of
+the water, seized it, and drew it under. When the huntsman saw that, he
+went back and fetched three men to come with buckets and bale out the
+water. When they could see to the bottom there lay a wild man whose body
+was brown like rusty iron, and whose hair hung over his face down to his
+knees. They bound him with cords, and led him away to the castle. There
+was great astonishment over the wild man; the king, however, had him put
+in an iron cage in his courtyard, and forbade the door to be opened
+on pain of death, and the queen herself was to take the key into her
+keeping. And from this time forth everyone could again go into the
+forest with safety.
+
+The king had a son of eight years, who was once playing in the
+courtyard, and while he was playing, his golden ball fell into the cage.
+The boy ran thither and said: ‘Give me my ball out.’ ‘Not till you have
+opened the door for me,’ answered the man. ‘No,’ said the boy, ‘I will
+not do that; the king has forbidden it,’ and ran away. The next day he
+again went and asked for his ball; the wild man said: ‘Open my door,’
+but the boy would not. On the third day the king had ridden out hunting,
+and the boy went once more and said: ‘I cannot open the door even if I
+wished, for I have not the key.’ Then the wild man said: ‘It lies under
+your mother’s pillow, you can get it there.’ The boy, who wanted to have
+his ball back, cast all thought to the winds, and brought the key. The
+door opened with difficulty, and the boy pinched his fingers. When it
+was open the wild man stepped out, gave him the golden ball, and hurried
+away. The boy had become afraid; he called and cried after him: ‘Oh,
+wild man, do not go away, or I shall be beaten!’ The wild man turned
+back, took him up, set him on his shoulder, and went with hasty steps
+into the forest. When the king came home, he observed the empty cage,
+and asked the queen how that had happened. She knew nothing about it,
+and sought the key, but it was gone. She called the boy, but no one
+answered. The king sent out people to seek for him in the fields, but
+they did not find him. Then he could easily guess what had happened, and
+much grief reigned in the royal court.
+
+When the wild man had once more reached the dark forest, he took the boy
+down from his shoulder, and said to him: ‘You will never see your father
+and mother again, but I will keep you with me, for you have set me free,
+and I have compassion on you. If you do all I bid you, you shall fare
+well. Of treasure and gold have I enough, and more than anyone in the
+world.’ He made a bed of moss for the boy on which he slept, and the
+next morning the man took him to a well, and said: ‘Behold, the gold
+well is as bright and clear as crystal, you shall sit beside it, and
+take care that nothing falls into it, or it will be polluted. I will
+come every evening to see if you have obeyed my order.’ The boy placed
+himself by the brink of the well, and often saw a golden fish or a
+golden snake show itself therein, and took care that nothing fell in.
+As he was thus sitting, his finger hurt him so violently that he
+involuntarily put it in the water. He drew it quickly out again, but saw
+that it was quite gilded, and whatsoever pains he took to wash the gold
+off again, all was to no purpose. In the evening Iron Hans came back,
+looked at the boy, and said: ‘What has happened to the well?’ ‘Nothing
+nothing,’ he answered, and held his finger behind his back, that the
+man might not see it. But he said: ‘You have dipped your finger into
+the water, this time it may pass, but take care you do not again let
+anything go in.’ By daybreak the boy was already sitting by the well and
+watching it. His finger hurt him again and he passed it over his head,
+and then unhappily a hair fell down into the well. He took it quickly
+out, but it was already quite gilded. Iron Hans came, and already knew
+what had happened. ‘You have let a hair fall into the well,’ said he.
+‘I will allow you to watch by it once more, but if this happens for the
+third time then the well is polluted and you can no longer remain with
+me.’
+
+On the third day, the boy sat by the well, and did not stir his finger,
+however much it hurt him. But the time was long to him, and he looked at
+the reflection of his face on the surface of the water. And as he
+still bent down more and more while he was doing so, and trying to look
+straight into the eyes, his long hair fell down from his shoulders into
+the water. He raised himself up quickly, but the whole of the hair of
+his head was already golden and shone like the sun. You can imagine how
+terrified the poor boy was! He took his pocket-handkerchief and tied it
+round his head, in order that the man might not see it. When he came he
+already knew everything, and said: ‘Take the handkerchief off.’ Then the
+golden hair streamed forth, and let the boy excuse himself as he might,
+it was of no use. ‘You have not stood the trial and can stay here no
+longer. Go forth into the world, there you will learn what poverty is.
+But as you have not a bad heart, and as I mean well by you, there is
+one thing I will grant you; if you fall into any difficulty, come to the
+forest and cry: “Iron Hans,” and then I will come and help you. My
+power is great, greater than you think, and I have gold and silver in
+abundance.’
+
+Then the king’s son left the forest, and walked by beaten and unbeaten
+paths ever onwards until at length he reached a great city. There he
+looked for work, but could find none, and he learnt nothing by which he
+could help himself. At length he went to the palace, and asked if they
+would take him in. The people about court did not at all know what use
+they could make of him, but they liked him, and told him to stay. At
+length the cook took him into his service, and said he might carry wood
+and water, and rake the cinders together. Once when it so happened that
+no one else was at hand, the cook ordered him to carry the food to the
+royal table, but as he did not like to let his golden hair be seen, he
+kept his little cap on. Such a thing as that had never yet come under
+the king’s notice, and he said: ‘When you come to the royal table you
+must take your hat off.’ He answered: ‘Ah, Lord, I cannot; I have a bad
+sore place on my head.’ Then the king had the cook called before him
+and scolded him, and asked how he could take such a boy as that into his
+service; and that he was to send him away at once. The cook, however,
+had pity on him, and exchanged him for the gardener’s boy.
+
+And now the boy had to plant and water the garden, hoe and dig, and bear
+the wind and bad weather. Once in summer when he was working alone in
+the garden, the day was so warm he took his little cap off that the air
+might cool him. As the sun shone on his hair it glittered and flashed so
+that the rays fell into the bedroom of the king’s daughter, and up she
+sprang to see what that could be. Then she saw the boy, and cried to
+him: ‘Boy, bring me a wreath of flowers.’ He put his cap on with all
+haste, and gathered wild field-flowers and bound them together. When he
+was ascending the stairs with them, the gardener met him, and said: ‘How
+can you take the king’s daughter a garland of such common flowers? Go
+quickly, and get another, and seek out the prettiest and rarest.’ ‘Oh,
+no,’ replied the boy, ‘the wild ones have more scent, and will please
+her better.’ When he got into the room, the king’s daughter said: ‘Take
+your cap off, it is not seemly to keep it on in my presence.’ He again
+said: ‘I may not, I have a sore head.’ She, however, caught at his
+cap and pulled it off, and then his golden hair rolled down on his
+shoulders, and it was splendid to behold. He wanted to run out, but she
+held him by the arm, and gave him a handful of ducats. With these he
+departed, but he cared nothing for the gold pieces. He took them to the
+gardener, and said: ‘I present them to your children, they can play with
+them.’ The following day the king’s daughter again called to him that he
+was to bring her a wreath of field-flowers, and then he went in with it,
+she instantly snatched at his cap, and wanted to take it away from him,
+but he held it fast with both hands. She again gave him a handful of
+ducats, but he would not keep them, and gave them to the gardener for
+playthings for his children. On the third day things went just the
+same; she could not get his cap away from him, and he would not have her
+money.
+
+Not long afterwards, the country was overrun by war. The king gathered
+together his people, and did not know whether or not he could offer any
+opposition to the enemy, who was superior in strength and had a mighty
+army. Then said the gardener’s boy: ‘I am grown up, and will go to the
+wars also, only give me a horse.’ The others laughed, and said: ‘Seek
+one for yourself when we are gone, we will leave one behind us in the
+stable for you.’ When they had gone forth, he went into the stable, and
+led the horse out; it was lame of one foot, and limped hobblety jib,
+hobblety jib; nevertheless he mounted it, and rode away to the dark
+forest. When he came to the outskirts, he called ‘Iron Hans’ three
+times so loudly that it echoed through the trees. Thereupon the wild man
+appeared immediately, and said: ‘What do you desire?’ ‘I want a strong
+steed, for I am going to the wars.’ ‘That you shall have, and still more
+than you ask for.’ Then the wild man went back into the forest, and it
+was not long before a stable-boy came out of it, who led a horse that
+snorted with its nostrils, and could hardly be restrained, and behind
+them followed a great troop of warriors entirely equipped in iron, and
+their swords flashed in the sun. The youth made over his three-legged
+horse to the stable-boy, mounted the other, and rode at the head of the
+soldiers. When he got near the battlefield a great part of the king’s
+men had already fallen, and little was wanting to make the rest give
+way. Then the youth galloped thither with his iron soldiers, broke like
+a hurricane over the enemy, and beat down all who opposed him. They
+began to flee, but the youth pursued, and never stopped, until there
+was not a single man left. Instead of returning to the king, however, he
+conducted his troop by byways back to the forest, and called forth Iron
+Hans. ‘What do you desire?’ asked the wild man. ‘Take back your horse
+and your troops, and give me my three-legged horse again.’ All that he
+asked was done, and soon he was riding on his three-legged horse. When
+the king returned to his palace, his daughter went to meet him, and
+wished him joy of his victory. ‘I am not the one who carried away the
+victory,’ said he, ‘but a strange knight who came to my assistance with
+his soldiers.’ The daughter wanted to hear who the strange knight was,
+but the king did not know, and said: ‘He followed the enemy, and I did
+not see him again.’ She inquired of the gardener where his boy was, but
+he smiled, and said: ‘He has just come home on his three-legged horse,
+and the others have been mocking him, and crying: “Here comes our
+hobblety jib back again!” They asked, too: “Under what hedge have you
+been lying sleeping all the time?” So he said: “I did the best of all,
+and it would have gone badly without me.” And then he was still more
+ridiculed.’
+
+The king said to his daughter: ‘I will proclaim a great feast that shall
+last for three days, and you shall throw a golden apple. Perhaps the
+unknown man will show himself.’ When the feast was announced, the youth
+went out to the forest, and called Iron Hans. ‘What do you desire?’
+asked he. ‘That I may catch the king’s daughter’s golden apple.’ ‘It is
+as safe as if you had it already,’ said Iron Hans. ‘You shall likewise
+have a suit of red armour for the occasion, and ride on a spirited
+chestnut-horse.’ When the day came, the youth galloped to the spot, took
+his place amongst the knights, and was recognized by no one. The king’s
+daughter came forward, and threw a golden apple to the knights, but none
+of them caught it but he, only as soon as he had it he galloped away.
+
+On the second day Iron Hans equipped him as a white knight, and gave him
+a white horse. Again he was the only one who caught the apple, and
+he did not linger an instant, but galloped off with it. The king grew
+angry, and said: ‘That is not allowed; he must appear before me and tell
+his name.’ He gave the order that if the knight who caught the apple,
+should go away again they should pursue him, and if he would not come
+back willingly, they were to cut him down and stab him.
+
+On the third day, he received from Iron Hans a suit of black armour and
+a black horse, and again he caught the apple. But when he was riding off
+with it, the king’s attendants pursued him, and one of them got so near
+him that he wounded the youth’s leg with the point of his sword. The
+youth nevertheless escaped from them, but his horse leapt so violently
+that the helmet fell from the youth’s head, and they could see that he
+had golden hair. They rode back and announced this to the king.
+
+The following day the king’s daughter asked the gardener about his
+boy. ‘He is at work in the garden; the queer creature has been at the
+festival too, and only came home yesterday evening; he has likewise
+shown my children three golden apples which he has won.’
+
+The king had him summoned into his presence, and he came and again had
+his little cap on his head. But the king’s daughter went up to him and
+took it off, and then his golden hair fell down over his shoulders, and
+he was so handsome that all were amazed. ‘Are you the knight who came
+every day to the festival, always in different colours, and who caught
+the three golden apples?’ asked the king. ‘Yes,’ answered he, ‘and here
+the apples are,’ and he took them out of his pocket, and returned them
+to the king. ‘If you desire further proof, you may see the wound which
+your people gave me when they followed me. But I am likewise the knight
+who helped you to your victory over your enemies.’ ‘If you can perform
+such deeds as that, you are no gardener’s boy; tell me, who is your
+father?’ ‘My father is a mighty king, and gold have I in plenty as great
+as I require.’ ‘I well see,’ said the king, ‘that I owe my thanks to
+you; can I do anything to please you?’ ‘Yes,’ answered he, ‘that indeed
+you can. Give me your daughter to wife.’ The maiden laughed, and said:
+‘He does not stand much on ceremony, but I have already seen by his
+golden hair that he was no gardener’s boy,’ and then she went and
+kissed him. His father and mother came to the wedding, and were in great
+delight, for they had given up all hope of ever seeing their dear
+son again. And as they were sitting at the marriage-feast, the music
+suddenly stopped, the doors opened, and a stately king came in with a
+great retinue. He went up to the youth, embraced him and said: ‘I am
+Iron Hans, and was by enchantment a wild man, but you have set me free;
+all the treasures which I possess, shall be your property.’
+
+
+
+
+CAT-SKIN
+
+There was once a king, whose queen had hair of the purest gold, and was
+so beautiful that her match was not to be met with on the whole face of
+the earth. But this beautiful queen fell ill, and when she felt that her
+end drew near she called the king to her and said, ‘Promise me that you
+will never marry again, unless you meet with a wife who is as beautiful
+as I am, and who has golden hair like mine.’ Then when the king in his
+grief promised all she asked, she shut her eyes and died. But the king
+was not to be comforted, and for a long time never thought of taking
+another wife. At last, however, his wise men said, ‘this will not do;
+the king must marry again, that we may have a queen.’ So messengers were
+sent far and wide, to seek for a bride as beautiful as the late queen.
+But there was no princess in the world so beautiful; and if there had
+been, still there was not one to be found who had golden hair. So the
+messengers came home, and had had all their trouble for nothing.
+
+Now the king had a daughter, who was just as beautiful as her mother,
+and had the same golden hair. And when she was grown up, the king looked
+at her and saw that she was just like this late queen: then he said to
+his courtiers, ‘May I not marry my daughter? She is the very image of my
+dead wife: unless I have her, I shall not find any bride upon the whole
+earth, and you say there must be a queen.’ When the courtiers heard this
+they were shocked, and said, ‘Heaven forbid that a father should marry
+his daughter! Out of so great a sin no good can come.’ And his daughter
+was also shocked, but hoped the king would soon give up such thoughts;
+so she said to him, ‘Before I marry anyone I must have three dresses:
+one must be of gold, like the sun; another must be of shining silver,
+like the moon; and a third must be dazzling as the stars: besides this,
+I want a mantle of a thousand different kinds of fur put together, to
+which every beast in the kingdom must give a part of his skin.’ And thus
+she thought he would think of the matter no more. But the king made the
+most skilful workmen in his kingdom weave the three dresses: one golden,
+like the sun; another silvery, like the moon; and a third sparkling,
+like the stars: and his hunters were told to hunt out all the beasts in
+his kingdom, and to take the finest fur out of their skins: and thus a
+mantle of a thousand furs was made.
+
+When all were ready, the king sent them to her; but she got up in the
+night when all were asleep, and took three of her trinkets, a golden
+ring, a golden necklace, and a golden brooch, and packed the three
+dresses--of the sun, the moon, and the stars--up in a nutshell, and
+wrapped herself up in the mantle made of all sorts of fur, and besmeared
+her face and hands with soot. Then she threw herself upon Heaven for
+help in her need, and went away, and journeyed on the whole night, till
+at last she came to a large wood. As she was very tired, she sat herself
+down in the hollow of a tree and soon fell asleep: and there she slept
+on till it was midday.
+
+Now as the king to whom the wood belonged was hunting in it, his dogs
+came to the tree, and began to snuff about, and run round and round, and
+bark. ‘Look sharp!’ said the king to the huntsmen, ‘and see what sort
+of game lies there.’ And the huntsmen went up to the tree, and when they
+came back again said, ‘In the hollow tree there lies a most wonderful
+beast, such as we never saw before; its skin seems to be of a thousand
+kinds of fur, but there it lies fast asleep.’ ‘See,’ said the king, ‘if
+you can catch it alive, and we will take it with us.’ So the huntsmen
+took it up, and the maiden awoke and was greatly frightened, and said,
+‘I am a poor child that has neither father nor mother left; have pity on
+me and take me with you.’ Then they said, ‘Yes, Miss Cat-skin, you will
+do for the kitchen; you can sweep up the ashes, and do things of that
+sort.’ So they put her into the coach, and took her home to the king’s
+palace. Then they showed her a little corner under the staircase, where
+no light of day ever peeped in, and said, ‘Cat-skin, you may lie and
+sleep there.’ And she was sent into the kitchen, and made to fetch wood
+and water, to blow the fire, pluck the poultry, pick the herbs, sift the
+ashes, and do all the dirty work.
+
+Thus Cat-skin lived for a long time very sorrowfully. ‘Ah! pretty
+princess!’ thought she, ‘what will now become of thee?’ But it happened
+one day that a feast was to be held in the king’s castle, so she said to
+the cook, ‘May I go up a little while and see what is going on? I will
+take care and stand behind the door.’ And the cook said, ‘Yes, you may
+go, but be back again in half an hour’s time, to rake out the ashes.’
+Then she took her little lamp, and went into her cabin, and took off the
+fur skin, and washed the soot from off her face and hands, so that her
+beauty shone forth like the sun from behind the clouds. She next opened
+her nutshell, and brought out of it the dress that shone like the sun,
+and so went to the feast. Everyone made way for her, for nobody knew
+her, and they thought she could be no less than a king’s daughter. But
+the king came up to her, and held out his hand and danced with her; and
+he thought in his heart, ‘I never saw any one half so beautiful.’
+
+When the dance was at an end she curtsied; and when the king looked
+round for her, she was gone, no one knew wither. The guards that stood
+at the castle gate were called in: but they had seen no one. The truth
+was, that she had run into her little cabin, pulled off her dress,
+blackened her face and hands, put on the fur-skin cloak, and was
+Cat-skin again. When she went into the kitchen to her work, and began
+to rake the ashes, the cook said, ‘Let that alone till the morning, and
+heat the king’s soup; I should like to run up now and give a peep: but
+take care you don’t let a hair fall into it, or you will run a chance of
+never eating again.’
+
+As soon as the cook went away, Cat-skin heated the king’s soup, and
+toasted a slice of bread first, as nicely as ever she could; and when it
+was ready, she went and looked in the cabin for her little golden ring,
+and put it into the dish in which the soup was. When the dance was over,
+the king ordered his soup to be brought in; and it pleased him so well,
+that he thought he had never tasted any so good before. At the bottom
+he saw a gold ring lying; and as he could not make out how it had got
+there, he ordered the cook to be sent for. The cook was frightened when
+he heard the order, and said to Cat-skin, ‘You must have let a hair fall
+into the soup; if it be so, you will have a good beating.’ Then he went
+before the king, and he asked him who had cooked the soup. ‘I did,’
+answered the cook. But the king said, ‘That is not true; it was better
+done than you could do it.’ Then he answered, ‘To tell the truth I did
+not cook it, but Cat-skin did.’ ‘Then let Cat-skin come up,’ said the
+king: and when she came he said to her, ‘Who are you?’ ‘I am a poor
+child,’ said she, ‘that has lost both father and mother.’ ‘How came you
+in my palace?’ asked he. ‘I am good for nothing,’ said she, ‘but to be
+scullion-girl, and to have boots and shoes thrown at my head.’ ‘But how
+did you get the ring that was in the soup?’ asked the king. Then she
+would not own that she knew anything about the ring; so the king sent
+her away again about her business.
+
+After a time there was another feast, and Cat-skin asked the cook to let
+her go up and see it as before. ‘Yes,’ said he, ‘but come again in half
+an hour, and cook the king the soup that he likes so much.’ Then she
+ran to her little cabin, washed herself quickly, and took her dress
+out which was silvery as the moon, and put it on; and when she went in,
+looking like a king’s daughter, the king went up to her, and rejoiced at
+seeing her again, and when the dance began he danced with her. After the
+dance was at an end she managed to slip out, so slyly that the king did
+not see where she was gone; but she sprang into her little cabin, and
+made herself into Cat-skin again, and went into the kitchen to cook the
+soup. Whilst the cook was above stairs, she got the golden necklace and
+dropped it into the soup; then it was brought to the king, who ate it,
+and it pleased him as well as before; so he sent for the cook, who
+was again forced to tell him that Cat-skin had cooked it. Cat-skin was
+brought again before the king, but she still told him that she was only
+fit to have boots and shoes thrown at her head.
+
+But when the king had ordered a feast to be got ready for the third
+time, it happened just the same as before. ‘You must be a witch,
+Cat-skin,’ said the cook; ‘for you always put something into your soup,
+so that it pleases the king better than mine.’ However, he let her go up
+as before. Then she put on her dress which sparkled like the stars, and
+went into the ball-room in it; and the king danced with her again, and
+thought she had never looked so beautiful as she did then. So whilst
+he was dancing with her, he put a gold ring on her finger without her
+seeing it, and ordered that the dance should be kept up a long time.
+When it was at an end, he would have held her fast by the hand, but she
+slipped away, and sprang so quickly through the crowd that he lost sight
+of her: and she ran as fast as she could into her little cabin under
+the stairs. But this time she kept away too long, and stayed beyond the
+half-hour; so she had not time to take off her fine dress, and threw her
+fur mantle over it, and in her haste did not blacken herself all over
+with soot, but left one of her fingers white.
+
+Then she ran into the kitchen, and cooked the king’s soup; and as soon
+as the cook was gone, she put the golden brooch into the dish. When the
+king got to the bottom, he ordered Cat-skin to be called once more, and
+soon saw the white finger, and the ring that he had put on it whilst
+they were dancing: so he seized her hand, and kept fast hold of it, and
+when she wanted to loose herself and spring away, the fur cloak fell off
+a little on one side, and the starry dress sparkled underneath it.
+
+Then he got hold of the fur and tore it off, and her golden hair and
+beautiful form were seen, and she could no longer hide herself: so she
+washed the soot and ashes from her face, and showed herself to be the
+most beautiful princess upon the face of the earth. But the king said,
+‘You are my beloved bride, and we will never more be parted from each
+other.’ And the wedding feast was held, and a merry day it was, as ever
+was heard of or seen in that country, or indeed in any other.
+
+
+
+
+SNOW-WHITE AND ROSE-RED
+
+There was once a poor widow who lived in a lonely cottage. In front of
+the cottage was a garden wherein stood two rose-trees, one of which bore
+white and the other red roses. She had two children who were like the
+two rose-trees, and one was called Snow-white, and the other Rose-red.
+They were as good and happy, as busy and cheerful as ever two children
+in the world were, only Snow-white was more quiet and gentle than
+Rose-red. Rose-red liked better to run about in the meadows and fields
+seeking flowers and catching butterflies; but Snow-white sat at home
+with her mother, and helped her with her housework, or read to her when
+there was nothing to do.
+
+The two children were so fond of one another that they always held each
+other by the hand when they went out together, and when Snow-white said:
+‘We will not leave each other,’ Rose-red answered: ‘Never so long as we
+live,’ and their mother would add: ‘What one has she must share with the
+other.’
+
+They often ran about the forest alone and gathered red berries, and no
+beasts did them any harm, but came close to them trustfully. The little
+hare would eat a cabbage-leaf out of their hands, the roe grazed by
+their side, the stag leapt merrily by them, and the birds sat still upon
+the boughs, and sang whatever they knew.
+
+No mishap overtook them; if they had stayed too late in the forest, and
+night came on, they laid themselves down near one another upon the moss,
+and slept until morning came, and their mother knew this and did not
+worry on their account.
+
+Once when they had spent the night in the wood and the dawn had roused
+them, they saw a beautiful child in a shining white dress sitting near
+their bed. He got up and looked quite kindly at them, but said nothing
+and went into the forest. And when they looked round they found that
+they had been sleeping quite close to a precipice, and would certainly
+have fallen into it in the darkness if they had gone only a few paces
+further. And their mother told them that it must have been the angel who
+watches over good children.
+
+Snow-white and Rose-red kept their mother’s little cottage so neat that
+it was a pleasure to look inside it. In the summer Rose-red took care
+of the house, and every morning laid a wreath of flowers by her mother’s
+bed before she awoke, in which was a rose from each tree. In the winter
+Snow-white lit the fire and hung the kettle on the hob. The kettle
+was of brass and shone like gold, so brightly was it polished. In the
+evening, when the snowflakes fell, the mother said: ‘Go, Snow-white, and
+bolt the door,’ and then they sat round the hearth, and the mother took
+her spectacles and read aloud out of a large book, and the two girls
+listened as they sat and spun. And close by them lay a lamb upon the
+floor, and behind them upon a perch sat a white dove with its head
+hidden beneath its wings.
+
+One evening, as they were thus sitting comfortably together, someone
+knocked at the door as if he wished to be let in. The mother said:
+‘Quick, Rose-red, open the door, it must be a traveller who is seeking
+shelter.’ Rose-red went and pushed back the bolt, thinking that it was a
+poor man, but it was not; it was a bear that stretched his broad, black
+head within the door.
+
+Rose-red screamed and sprang back, the lamb bleated, the dove fluttered,
+and Snow-white hid herself behind her mother’s bed. But the bear began
+to speak and said: ‘Do not be afraid, I will do you no harm! I am
+half-frozen, and only want to warm myself a little beside you.’
+
+‘Poor bear,’ said the mother, ‘lie down by the fire, only take care that
+you do not burn your coat.’ Then she cried: ‘Snow-white, Rose-red, come
+out, the bear will do you no harm, he means well.’ So they both came
+out, and by-and-by the lamb and dove came nearer, and were not afraid
+of him. The bear said: ‘Here, children, knock the snow out of my coat a
+little’; so they brought the broom and swept the bear’s hide clean;
+and he stretched himself by the fire and growled contentedly and
+comfortably. It was not long before they grew quite at home, and played
+tricks with their clumsy guest. They tugged his hair with their hands,
+put their feet upon his back and rolled him about, or they took a
+hazel-switch and beat him, and when he growled they laughed. But the
+bear took it all in good part, only when they were too rough he called
+out: ‘Leave me alive, children,
+
+  Snow-white, Rose-red,
+  Will you beat your wooer dead?’
+
+When it was bed-time, and the others went to bed, the mother said to the
+bear: ‘You can lie there by the hearth, and then you will be safe from
+the cold and the bad weather.’ As soon as day dawned the two children
+let him out, and he trotted across the snow into the forest.
+
+Henceforth the bear came every evening at the same time, laid himself
+down by the hearth, and let the children amuse themselves with him as
+much as they liked; and they got so used to him that the doors were
+never fastened until their black friend had arrived.
+
+When spring had come and all outside was green, the bear said one
+morning to Snow-white: ‘Now I must go away, and cannot come back for the
+whole summer.’ ‘Where are you going, then, dear bear?’ asked Snow-white.
+‘I must go into the forest and guard my treasures from the wicked
+dwarfs. In the winter, when the earth is frozen hard, they are obliged
+to stay below and cannot work their way through; but now, when the sun
+has thawed and warmed the earth, they break through it, and come out to
+pry and steal; and what once gets into their hands, and in their caves,
+does not easily see daylight again.’
+
+Snow-white was quite sorry at his departure, and as she unbolted the
+door for him, and the bear was hurrying out, he caught against the bolt
+and a piece of his hairy coat was torn off, and it seemed to Snow-white
+as if she had seen gold shining through it, but she was not sure about
+it. The bear ran away quickly, and was soon out of sight behind the
+trees.
+
+A short time afterwards the mother sent her children into the forest
+to get firewood. There they found a big tree which lay felled on the
+ground, and close by the trunk something was jumping backwards and
+forwards in the grass, but they could not make out what it was. When
+they came nearer they saw a dwarf with an old withered face and a
+snow-white beard a yard long. The end of the beard was caught in a
+crevice of the tree, and the little fellow was jumping about like a dog
+tied to a rope, and did not know what to do.
+
+He glared at the girls with his fiery red eyes and cried: ‘Why do you
+stand there? Can you not come here and help me?’ ‘What are you up to,
+little man?’ asked Rose-red. ‘You stupid, prying goose!’ answered the
+dwarf: ‘I was going to split the tree to get a little wood for cooking.
+The little bit of food that we people get is immediately burnt up with
+heavy logs; we do not swallow so much as you coarse, greedy folk. I had
+just driven the wedge safely in, and everything was going as I wished;
+but the cursed wedge was too smooth and suddenly sprang out, and the
+tree closed so quickly that I could not pull out my beautiful white
+beard; so now it is tight and I cannot get away, and the silly, sleek,
+milk-faced things laugh! Ugh! how odious you are!’
+
+The children tried very hard, but they could not pull the beard out, it
+was caught too fast. ‘I will run and fetch someone,’ said Rose-red. ‘You
+senseless goose!’ snarled the dwarf; ‘why should you fetch someone? You
+are already two too many for me; can you not think of something better?’
+‘Don’t be impatient,’ said Snow-white, ‘I will help you,’ and she pulled
+her scissors out of her pocket, and cut off the end of the beard.
+
+As soon as the dwarf felt himself free he laid hold of a bag which lay
+amongst the roots of the tree, and which was full of gold, and lifted it
+up, grumbling to himself: ‘Uncouth people, to cut off a piece of my fine
+beard. Bad luck to you!’ and then he swung the bag upon his back, and
+went off without even once looking at the children.
+
+Some time afterwards Snow-white and Rose-red went to catch a dish
+of fish. As they came near the brook they saw something like a large
+grasshopper jumping towards the water, as if it were going to leap in.
+They ran to it and found it was the dwarf. ‘Where are you going?’ said
+Rose-red; ‘you surely don’t want to go into the water?’ ‘I am not such
+a fool!’ cried the dwarf; ‘don’t you see that the accursed fish wants
+to pull me in?’ The little man had been sitting there fishing, and
+unluckily the wind had tangled up his beard with the fishing-line; a
+moment later a big fish made a bite and the feeble creature had not
+strength to pull it out; the fish kept the upper hand and pulled the
+dwarf towards him. He held on to all the reeds and rushes, but it was of
+little good, for he was forced to follow the movements of the fish, and
+was in urgent danger of being dragged into the water.
+
+The girls came just in time; they held him fast and tried to free his
+beard from the line, but all in vain, beard and line were entangled fast
+together. There was nothing to do but to bring out the scissors and cut
+the beard, whereby a small part of it was lost. When the dwarf saw that
+he screamed out: ‘Is that civil, you toadstool, to disfigure a man’s
+face? Was it not enough to clip off the end of my beard? Now you have
+cut off the best part of it. I cannot let myself be seen by my people.
+I wish you had been made to run the soles off your shoes!’ Then he took
+out a sack of pearls which lay in the rushes, and without another word
+he dragged it away and disappeared behind a stone.
+
+It happened that soon afterwards the mother sent the two children to the
+town to buy needles and thread, and laces and ribbons. The road led them
+across a heath upon which huge pieces of rock lay strewn about. There
+they noticed a large bird hovering in the air, flying slowly round and
+round above them; it sank lower and lower, and at last settled near a
+rock not far away. Immediately they heard a loud, piteous cry. They ran
+up and saw with horror that the eagle had seized their old acquaintance
+the dwarf, and was going to carry him off.
+
+The children, full of pity, at once took tight hold of the little man,
+and pulled against the eagle so long that at last he let his booty go.
+As soon as the dwarf had recovered from his first fright he cried
+with his shrill voice: ‘Could you not have done it more carefully! You
+dragged at my brown coat so that it is all torn and full of holes, you
+clumsy creatures!’ Then he took up a sack full of precious stones, and
+slipped away again under the rock into his hole. The girls, who by
+this time were used to his ingratitude, went on their way and did their
+business in town.
+
+As they crossed the heath again on their way home they surprised the
+dwarf, who had emptied out his bag of precious stones in a clean spot,
+and had not thought that anyone would come there so late. The evening
+sun shone upon the brilliant stones; they glittered and sparkled with
+all colours so beautifully that the children stood still and stared
+at them. ‘Why do you stand gaping there?’ cried the dwarf, and his
+ashen-grey face became copper-red with rage. He was still cursing when a
+loud growling was heard, and a black bear came trotting towards them out
+of the forest. The dwarf sprang up in a fright, but he could not reach
+his cave, for the bear was already close. Then in the dread of his heart
+he cried: ‘Dear Mr Bear, spare me, I will give you all my treasures;
+look, the beautiful jewels lying there! Grant me my life; what do you
+want with such a slender little fellow as I? you would not feel me
+between your teeth. Come, take these two wicked girls, they are tender
+morsels for you, fat as young quails; for mercy’s sake eat them!’ The
+bear took no heed of his words, but gave the wicked creature a single
+blow with his paw, and he did not move again.
+
+The girls had run away, but the bear called to them: ‘Snow-white and
+Rose-red, do not be afraid; wait, I will come with you.’ Then they
+recognized his voice and waited, and when he came up to them suddenly
+his bearskin fell off, and he stood there a handsome man, clothed all in
+gold. ‘I am a king’s son,’ he said, ‘and I was bewitched by that wicked
+dwarf, who had stolen my treasures; I have had to run about the forest
+as a savage bear until I was freed by his death. Now he has got his
+well-deserved punishment.
+
+Snow-white was married to him, and Rose-red to his brother, and they
+divided between them the great treasure which the dwarf had gathered
+together in his cave. The old mother lived peacefully and happily with
+her children for many years. She took the two rose-trees with her, and
+they stood before her window, and every year bore the most beautiful
+roses, white and red.
+
+
+*****
+
+
+The Brothers Grimm, Jacob (1785-1863) and Wilhelm (1786-1859), were born
+in Hanau, near Frankfurt, in the German state of Hesse. Throughout
+their lives they remained close friends, and both studied law at Marburg
+University. Jacob was a pioneer in the study of German philology,
+and although Wilhelm’s work was hampered by poor health the brothers
+collaborated in the creation of a German dictionary, not completed until
+a century after their deaths. But they were best (and universally) known
+for the collection of over two hundred folk tales they made from oral
+sources and published in two volumes of ‘Nursery and Household Tales’ in
+1812 and 1814. Although their intention was to preserve such material as
+part of German cultural and literary history, and their collection was
+first published with scholarly notes and no illustration, the tales soon
+came into the possession of young readers. This was in part due to Edgar
+Taylor, who made the first English translation in 1823, selecting about
+fifty stories ‘with the amusement of some young friends principally in
+view.’ They have been an essential ingredient of children’s reading ever
+since.
+
+
+
+
+
+End of Project Gutenberg’s Grimms’ Fairy Tales, by The Brothers Grimm
+
+*** END OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+***** This file should be named 2591-0.txt or 2591-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/5/9/2591/
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/huckleberry-finn.txt
+++ b/jet/hadoop/src/main/resources/books/huckleberry-finn.txt
@@ -1,0 +1,12363 @@
+﻿
+
+The Project Gutenberg EBook of Adventures of Huckleberry Finn, Complete
+by Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: Adventures of Huckleberry Finn, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #76]
+
+Last Updated: August 17, 2016]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+Produced by David Widger
+
+
+
+
+
+ADVENTURES
+
+OF
+
+HUCKLEBERRY FINN
+
+(Tom Sawyer’s Comrade)
+
+By Mark Twain
+
+Complete
+
+
+
+
+CONTENTS.
+
+CHAPTER I. Civilizing Huck.--Miss Watson.--Tom Sawyer Waits.
+
+CHAPTER II. The Boys Escape Jim.--Torn Sawyer’s Gang.--Deep-laid Plans.
+
+CHAPTER III. A Good Going-over.--Grace Triumphant.--“One of Tom Sawyers’s
+Lies”.
+
+CHAPTER IV. Huck and the Judge.--Superstition.
+
+CHAPTER V. Huck’s Father.--The Fond Parent.--Reform.
+
+CHAPTER VI. He Went for Judge Thatcher.--Huck Decided to Leave.--Political
+Economy.--Thrashing Around.
+
+CHAPTER VII. Laying for Him.--Locked in the Cabin.--Sinking the
+Body.--Resting.
+
+CHAPTER VIII. Sleeping in the Woods.--Raising the Dead.--Exploring the
+Island.--Finding Jim.--Jim’s Escape.--Signs.--Balum.
+
+CHAPTER IX. The Cave.--The Floating House.
+
+CHAPTER X. The Find.--Old Hank Bunker.--In Disguise.
+
+CHAPTER XI. Huck and the Woman.--The Search.--Prevarication.--Going to
+Goshen.
+
+CHAPTER XII. Slow Navigation.--Borrowing Things.--Boarding the Wreck.--The
+Plotters.--Hunting for the Boat.
+
+CHAPTER XIII. Escaping from the Wreck.--The Watchman.--Sinking.
+
+CHAPTER XIV. A General Good Time.--The Harem.--French.
+
+CHAPTER XV. Huck Loses the Raft.--In the Fog.--Huck Finds the Raft.--Trash.
+
+CHAPTER XVI. Expectation.--A White Lie.--Floating Currency.--Running by
+Cairo.--Swimming Ashore.
+
+CHAPTER XVII. An Evening Call.--The Farm in Arkansaw.--Interior
+Decorations.--Stephen Dowling Bots.--Poetical Effusions.
+
+CHAPTER XVIII. Col. Grangerford.--Aristocracy.--Feuds.--The
+Testament.--Recovering the Raft.--The Wood--pile.--Pork and Cabbage.
+
+CHAPTER XIX. Tying Up Day--times.--An Astronomical Theory.--Running a
+Temperance Revival.--The Duke of Bridgewater.--The Troubles of Royalty.
+
+CHAPTER XX. Huck Explains.--Laying Out a Campaign.--Working the
+Camp--meeting.--A Pirate at the Camp--meeting.--The Duke as a Printer.
+
+CHAPTER XXI. Sword Exercise.--Hamlet’s Soliloquy.--They Loafed Around
+Town.--A Lazy Town.--Old Boggs.--Dead.
+
+CHAPTER XXII. Sherburn.--Attending the Circus.--Intoxication in the
+Ring.--The Thrilling Tragedy.
+
+CHAPTER XXIII. Sold.--Royal Comparisons.--Jim Gets Home-sick.
+
+CHAPTER XXIV. Jim in Royal Robes.--They Take a Passenger.--Getting
+Information.--Family Grief.
+
+CHAPTER XXV. Is It Them?--Singing the “Doxologer.”--Awful Square--Funeral
+Orgies.--A Bad Investment .
+
+CHAPTER XXVI. A Pious King.--The King’s Clergy.--She Asked His
+Pardon.--Hiding in the Room.--Huck Takes the Money.
+
+CHAPTER XXVII. The Funeral.--Satisfying Curiosity.--Suspicious of
+Huck,--Quick Sales and Small.
+
+CHAPTER XXVIII. The Trip to England.--“The Brute!”--Mary Jane Decides to
+Leave.--Huck Parting with Mary Jane.--Mumps.--The Opposition Line.
+
+CHAPTER XXIX. Contested Relationship.--The King Explains the Loss.--A
+Question of Handwriting.--Digging up the Corpse.--Huck Escapes.
+
+CHAPTER XXX. The King Went for Him.--A Royal Row.--Powerful Mellow.
+
+CHAPTER XXXI. Ominous Plans.--News from Jim.--Old Recollections.--A Sheep
+Story.--Valuable Information.
+
+CHAPTER XXXII. Still and Sunday--like.--Mistaken Identity.--Up a Stump.--In
+a Dilemma.
+
+CHAPTER XXXIII. A Nigger Stealer.--Southern Hospitality.--A Pretty Long
+Blessing.--Tar and Feathers.
+
+CHAPTER XXXIV. The Hut by the Ash Hopper.--Outrageous.--Climbing the
+Lightning Rod.--Troubled with Witches.
+
+CHAPTER XXXV. Escaping Properly.--Dark Schemes.--Discrimination in
+Stealing.--A Deep Hole.
+
+CHAPTER XXXVI. The Lightning Rod.--His Level Best.--A Bequest to
+Posterity.--A High Figure.
+
+CHAPTER XXXVII. The Last Shirt.--Mooning Around.--Sailing Orders.--The
+Witch Pie.
+
+CHAPTER XXXVIII. The Coat of Arms.--A Skilled Superintendent.--Unpleasant
+Glory.--A Tearful Subject.
+
+CHAPTER XXXIX. Rats.--Lively Bed--fellows.--The Straw Dummy.
+
+CHAPTER XL. Fishing.--The Vigilance Committee.--A Lively Run.--Jim Advises
+a Doctor.
+
+CHAPTER XLI. The Doctor.--Uncle Silas.--Sister Hotchkiss.--Aunt Sally in
+Trouble.
+
+CHAPTER XLII. Tom Sawyer Wounded.--The Doctor’s Story.--Tom
+Confesses.--Aunt Polly Arrives.--Hand Out Them Letters    .
+
+CHAPTER THE LAST. Out of Bondage.--Paying the Captive.--Yours Truly, Huck
+Finn.
+
+
+
+
+ILLUSTRATIONS.
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+Getting out of the Way
+
+Solid Comfort
+
+Thinking it Over
+
+Raising a Howl
+
+“Git Up”
+
+The Shanty
+
+Shooting the Pig
+
+Taking a Rest
+
+In the Woods
+
+Watching the Boat
+
+Discovering the Camp Fire
+
+Jim and the Ghost
+
+Misto Bradish’s Nigger
+
+Exploring the Cave
+
+In the Cave
+
+Jim sees a Dead Man
+
+They Found Eight Dollars
+
+Jim and the Snake
+
+Old Hank Bunker
+
+“A Fair Fit”
+
+“Come In”
+
+“Him and another Man”
+
+She puts up a Snack
+
+“Hump Yourself”
+
+On the Raft
+
+He sometimes Lifted a Chicken
+
+“Please don’t, Bill”
+
+“It ain’t Good Morals”
+
+“Oh! Lordy, Lordy!”
+
+In a Fix
+
+“Hello, What’s Up?”
+
+The Wreck
+
+We turned in and Slept
+
+Turning over the Truck
+
+Solomon and his Million Wives
+
+The story of “Sollermun”
+
+“We Would Sell the Raft”
+
+Among the Snags
+
+Asleep on the Raft
+
+“Something being Raftsman”
+
+“Boy, that’s a Lie”
+
+“Here I is, Huck”
+
+Climbing up the Bank
+
+“Who’s There?”
+
+“Buck”
+
+“It made Her look Spidery”
+
+“They got him out and emptied Him”  
+
+The House
+
+Col. Grangerford
+
+Young Harney Shepherdson
+
+Miss Charlotte
+
+“And asked me if I Liked Her”
+
+“Behind the Wood-pile”
+
+Hiding Day-times
+
+“And Dogs a-Coming”
+
+“By rights I am a Duke!”
+
+“I am the Late Dauphin”
+
+Tail Piece
+
+On the Raft
+
+The King as Juliet
+
+“Courting on the Sly”
+
+“A Pirate for Thirty Years”
+
+Another little Job
+
+Practizing
+
+Hamlet’s Soliloquy
+
+“Gimme a Chaw”
+
+A Little Monthly Drunk
+
+The Death of Boggs
+
+Sherburn steps out
+
+A Dead Head
+
+He shed Seventeen Suits
+
+Tragedy
+
+Their Pockets Bulged
+
+Henry the Eighth in Boston Harbor
+
+Harmless
+
+Adolphus
+
+He fairly emptied that Young Fellow
+
+“Alas, our Poor Brother”
+
+“You Bet it is”
+
+Leaking
+
+Making up the “Deffisit”
+
+Going for him
+
+The Doctor
+
+The Bag of Money
+
+The Cubby
+
+Supper with the Hare-Lip
+
+Honest Injun
+
+The Duke looks under the Bed
+
+Huck takes the Money
+
+A Crack in the Dining-room Door
+
+The Undertaker
+
+“He had a Rat!”
+
+“Was you in my Room?”
+
+Jawing
+
+In Trouble
+
+Indignation
+
+How to Find Them
+
+He Wrote
+
+Hannah with the Mumps
+
+The Auction
+
+The True Brothers
+
+The Doctor leads Huck
+
+The Duke Wrote
+
+“Gentlemen, Gentlemen!”
+
+“Jim Lit Out”
+
+The King shakes Huck
+
+The Duke went for Him
+
+Spanish Moss
+
+“Who Nailed Him?”
+
+Thinking
+
+He gave him Ten Cents
+
+Striking for the Back Country
+
+Still and Sunday-like
+
+She hugged him tight
+
+“Who do you reckon it is?”
+
+“It was Tom Sawyer”
+
+“Mr. Archibald Nichols, I presume?”
+
+A pretty long Blessing
+
+Traveling By Rail
+
+Vittles
+
+A Simple Job
+
+Witches
+
+Getting Wood
+
+One of the Best Authorities
+
+The Breakfast-Horn
+
+Smouching the Knives
+
+Going down the Lightning-Rod
+
+Stealing spoons
+
+Tom advises a Witch Pie
+
+The Rubbage-Pile
+
+“Missus, dey’s a Sheet Gone”
+
+In a Tearing Way
+
+One of his Ancestors
+
+Jim’s Coat of Arms
+
+A Tough Job
+
+Buttons on their Tails
+
+Irrigation
+
+Keeping off Dull Times
+
+Sawdust Diet
+
+Trouble is Brewing
+
+Fishing
+
+Every one had a Gun
+
+Tom caught on a Splinter
+
+Jim advises a Doctor
+
+The Doctor
+
+Uncle Silas in Danger
+
+Old Mrs. Hotchkiss
+
+Aunt Sally talks to Huck
+
+Tom Sawyer wounded
+
+The Doctor speaks for Jim
+
+Tom rose square up in Bed
+
+“Hand out them Letters”
+
+Out of Bondage
+
+Tom’s Liberality
+
+Yours Truly
+
+
+
+
+EXPLANATORY
+
+IN this book a number of dialects are used, to wit:  the Missouri negro
+dialect; the extremest form of the backwoods Southwestern dialect; the
+ordinary “Pike County” dialect; and four modified varieties of this
+last. The shadings have not been done in a haphazard fashion, or by
+guesswork; but painstakingly, and with the trustworthy guidance and
+support of personal familiarity with these several forms of speech.
+
+I make this explanation for the reason that without it many readers
+would suppose that all these characters were trying to talk alike and
+not succeeding.
+
+THE AUTHOR.
+
+
+
+
+HUCKLEBERRY FINN
+
+Scene:  The Mississippi Valley Time:  Forty to fifty years ago
+
+
+
+
+CHAPTER I.
+
+YOU don’t know about me without you have read a book by the name of The
+Adventures of Tom Sawyer; but that ain’t no matter.  That book was made
+by Mr. Mark Twain, and he told the truth, mainly.  There was things
+which he stretched, but mainly he told the truth.  That is nothing.  I
+never seen anybody but lied one time or another, without it was Aunt
+Polly, or the widow, or maybe Mary.  Aunt Polly--Tom’s Aunt Polly, she
+is--and Mary, and the Widow Douglas is all told about in that book, which
+is mostly a true book, with some stretchers, as I said before.
+
+Now the way that the book winds up is this:  Tom and me found the money
+that the robbers hid in the cave, and it made us rich.  We got six
+thousand dollars apiece--all gold.  It was an awful sight of money when
+it was piled up.  Well, Judge Thatcher he took it and put it out
+at interest, and it fetched us a dollar a day apiece all the year
+round--more than a body could tell what to do with.  The Widow Douglas
+she took me for her son, and allowed she would sivilize me; but it was
+rough living in the house all the time, considering how dismal regular
+and decent the widow was in all her ways; and so when I couldn’t stand
+it no longer I lit out.  I got into my old rags and my sugar-hogshead
+again, and was free and satisfied.  But Tom Sawyer he hunted me up and
+said he was going to start a band of robbers, and I might join if I
+would go back to the widow and be respectable.  So I went back.
+
+The widow she cried over me, and called me a poor lost lamb, and she
+called me a lot of other names, too, but she never meant no harm by
+it. She put me in them new clothes again, and I couldn’t do nothing but
+sweat and sweat, and feel all cramped up.  Well, then, the old thing
+commenced again.  The widow rung a bell for supper, and you had to come
+to time. When you got to the table you couldn’t go right to eating, but
+you had to wait for the widow to tuck down her head and grumble a little
+over the victuals, though there warn’t really anything the matter with
+them,--that is, nothing only everything was cooked by itself.  In a
+barrel of odds and ends it is different; things get mixed up, and the
+juice kind of swaps around, and the things go better.
+
+After supper she got out her book and learned me about Moses and the
+Bulrushers, and I was in a sweat to find out all about him; but by and
+by she let it out that Moses had been dead a considerable long time; so
+then I didn’t care no more about him, because I don’t take no stock in
+dead people.
+
+Pretty soon I wanted to smoke, and asked the widow to let me.  But she
+wouldn’t.  She said it was a mean practice and wasn’t clean, and I must
+try to not do it any more.  That is just the way with some people.  They
+get down on a thing when they don’t know nothing about it.  Here she was
+a-bothering about Moses, which was no kin to her, and no use to anybody,
+being gone, you see, yet finding a power of fault with me for doing a
+thing that had some good in it.  And she took snuff, too; of course that
+was all right, because she done it herself.
+
+Her sister, Miss Watson, a tolerable slim old maid, with goggles on,
+had just come to live with her, and took a set at me now with a
+spelling-book. She worked me middling hard for about an hour, and then
+the widow made her ease up.  I couldn’t stood it much longer.  Then for
+an hour it was deadly dull, and I was fidgety.  Miss Watson would say,
+“Don’t put your feet up there, Huckleberry;” and “Don’t scrunch up
+like that, Huckleberry--set up straight;” and pretty soon she would
+say, “Don’t gap and stretch like that, Huckleberry--why don’t you try to
+behave?”  Then she told me all about the bad place, and I said I wished
+I was there. She got mad then, but I didn’t mean no harm.  All I wanted
+was to go somewheres; all I wanted was a change, I warn’t particular.
+ She said it was wicked to say what I said; said she wouldn’t say it for
+the whole world; she was going to live so as to go to the good place.
+ Well, I couldn’t see no advantage in going where she was going, so I
+made up my mind I wouldn’t try for it.  But I never said so, because it
+would only make trouble, and wouldn’t do no good.
+
+Now she had got a start, and she went on and told me all about the good
+place.  She said all a body would have to do there was to go around all
+day long with a harp and sing, forever and ever.  So I didn’t think
+much of it. But I never said so.  I asked her if she reckoned Tom Sawyer
+would go there, and she said not by a considerable sight.  I was glad
+about that, because I wanted him and me to be together.
+
+Miss Watson she kept pecking at me, and it got tiresome and lonesome.
+ By and by they fetched the niggers in and had prayers, and then
+everybody was off to bed.  I went up to my room with a piece of candle,
+and put it on the table.  Then I set down in a chair by the window and
+tried to think of something cheerful, but it warn’t no use.  I felt
+so lonesome I most wished I was dead.  The stars were shining, and the
+leaves rustled in the woods ever so mournful; and I heard an owl, away
+off, who-whooing about somebody that was dead, and a whippowill and a
+dog crying about somebody that was going to die; and the wind was trying
+to whisper something to me, and I couldn’t make out what it was, and so
+it made the cold shivers run over me. Then away out in the woods I heard
+that kind of a sound that a ghost makes when it wants to tell about
+something that’s on its mind and can’t make itself understood, and so
+can’t rest easy in its grave, and has to go about that way every night
+grieving.  I got so down-hearted and scared I did wish I had some
+company.  Pretty soon a spider went crawling up my shoulder, and I
+flipped it off and it lit in the candle; and before I could budge it
+was all shriveled up.  I didn’t need anybody to tell me that that was
+an awful bad sign and would fetch me some bad luck, so I was scared
+and most shook the clothes off of me. I got up and turned around in my
+tracks three times and crossed my breast every time; and then I tied
+up a little lock of my hair with a thread to keep witches away.  But
+I hadn’t no confidence.  You do that when you’ve lost a horseshoe that
+you’ve found, instead of nailing it up over the door, but I hadn’t ever
+heard anybody say it was any way to keep off bad luck when you’d killed
+a spider.
+
+I set down again, a-shaking all over, and got out my pipe for a smoke;
+for the house was all as still as death now, and so the widow wouldn’t
+know. Well, after a long time I heard the clock away off in the town
+go boom--boom--boom--twelve licks; and all still again--stiller than
+ever. Pretty soon I heard a twig snap down in the dark amongst the
+trees--something was a stirring.  I set still and listened.  Directly I
+could just barely hear a “me-yow! me-yow!” down there.  That was good!
+ Says I, “me-yow! me-yow!” as soft as I could, and then I put out the
+light and scrambled out of the window on to the shed.  Then I slipped
+down to the ground and crawled in among the trees, and, sure enough,
+there was Tom Sawyer waiting for me.
+
+
+
+
+CHAPTER II.
+
+WE went tiptoeing along a path amongst the trees back towards the end of
+the widow’s garden, stooping down so as the branches wouldn’t scrape our
+heads. When we was passing by the kitchen I fell over a root and made
+a noise.  We scrouched down and laid still.  Miss Watson’s big nigger,
+named Jim, was setting in the kitchen door; we could see him pretty
+clear, because there was a light behind him.  He got up and stretched
+his neck out about a minute, listening.  Then he says:
+
+“Who dah?”
+
+He listened some more; then he come tiptoeing down and stood right
+between us; we could a touched him, nearly.  Well, likely it was
+minutes and minutes that there warn’t a sound, and we all there so close
+together.  There was a place on my ankle that got to itching, but I
+dasn’t scratch it; and then my ear begun to itch; and next my back,
+right between my shoulders.  Seemed like I’d die if I couldn’t scratch.
+ Well, I’ve noticed that thing plenty times since.  If you are with
+the quality, or at a funeral, or trying to go to sleep when you ain’t
+sleepy--if you are anywheres where it won’t do for you to scratch, why
+you will itch all over in upwards of a thousand places. Pretty soon Jim
+says:
+
+“Say, who is you?  Whar is you?  Dog my cats ef I didn’ hear sumf’n.
+Well, I know what I’s gwyne to do:  I’s gwyne to set down here and
+listen tell I hears it agin.”
+
+So he set down on the ground betwixt me and Tom.  He leaned his back up
+against a tree, and stretched his legs out till one of them most touched
+one of mine.  My nose begun to itch.  It itched till the tears come into
+my eyes.  But I dasn’t scratch.  Then it begun to itch on the inside.
+Next I got to itching underneath.  I didn’t know how I was going to set
+still. This miserableness went on as much as six or seven minutes; but
+it seemed a sight longer than that.  I was itching in eleven different
+places now.  I reckoned I couldn’t stand it more’n a minute longer,
+but I set my teeth hard and got ready to try.  Just then Jim begun
+to breathe heavy; next he begun to snore--and then I was pretty soon
+comfortable again.
+
+Tom he made a sign to me--kind of a little noise with his mouth--and we
+went creeping away on our hands and knees.  When we was ten foot off Tom
+whispered to me, and wanted to tie Jim to the tree for fun.  But I said
+no; he might wake and make a disturbance, and then they’d find out I
+warn’t in. Then Tom said he hadn’t got candles enough, and he would slip
+in the kitchen and get some more.  I didn’t want him to try.  I said Jim
+might wake up and come.  But Tom wanted to resk it; so we slid in there
+and got three candles, and Tom laid five cents on the table for pay.
+Then we got out, and I was in a sweat to get away; but nothing would do
+Tom but he must crawl to where Jim was, on his hands and knees, and play
+something on him.  I waited, and it seemed a good while, everything was
+so still and lonesome.
+
+As soon as Tom was back we cut along the path, around the garden fence,
+and by and by fetched up on the steep top of the hill the other side of
+the house.  Tom said he slipped Jim’s hat off of his head and hung it
+on a limb right over him, and Jim stirred a little, but he didn’t wake.
+Afterwards Jim said the witches be witched him and put him in a trance,
+and rode him all over the State, and then set him under the trees again,
+and hung his hat on a limb to show who done it.  And next time Jim told
+it he said they rode him down to New Orleans; and, after that, every
+time he told it he spread it more and more, till by and by he said they
+rode him all over the world, and tired him most to death, and his back
+was all over saddle-boils.  Jim was monstrous proud about it, and he
+got so he wouldn’t hardly notice the other niggers.  Niggers would come
+miles to hear Jim tell about it, and he was more looked up to than any
+nigger in that country.  Strange niggers would stand with their mouths
+open and look him all over, same as if he was a wonder.  Niggers is
+always talking about witches in the dark by the kitchen fire; but
+whenever one was talking and letting on to know all about such things,
+Jim would happen in and say, “Hm!  What you know ‘bout witches?” and
+that nigger was corked up and had to take a back seat.  Jim always kept
+that five-center piece round his neck with a string, and said it was a
+charm the devil give to him with his own hands, and told him he could
+cure anybody with it and fetch witches whenever he wanted to just by
+saying something to it; but he never told what it was he said to it.
+ Niggers would come from all around there and give Jim anything they
+had, just for a sight of that five-center piece; but they wouldn’t touch
+it, because the devil had had his hands on it.  Jim was most ruined for
+a servant, because he got stuck up on account of having seen the devil
+and been rode by witches.
+
+Well, when Tom and me got to the edge of the hilltop we looked away down
+into the village and could see three or four lights twinkling, where
+there was sick folks, maybe; and the stars over us was sparkling ever
+so fine; and down by the village was the river, a whole mile broad, and
+awful still and grand.  We went down the hill and found Jo Harper and
+Ben Rogers, and two or three more of the boys, hid in the old tanyard.
+ So we unhitched a skiff and pulled down the river two mile and a half,
+to the big scar on the hillside, and went ashore.
+
+We went to a clump of bushes, and Tom made everybody swear to keep the
+secret, and then showed them a hole in the hill, right in the thickest
+part of the bushes.  Then we lit the candles, and crawled in on our
+hands and knees.  We went about two hundred yards, and then the cave
+opened up. Tom poked about amongst the passages, and pretty soon ducked
+under a wall where you wouldn’t a noticed that there was a hole.  We
+went along a narrow place and got into a kind of room, all damp and
+sweaty and cold, and there we stopped.  Tom says:
+
+“Now, we’ll start this band of robbers and call it Tom Sawyer’s Gang.
+Everybody that wants to join has got to take an oath, and write his name
+in blood.”
+
+Everybody was willing.  So Tom got out a sheet of paper that he had
+wrote the oath on, and read it.  It swore every boy to stick to the
+band, and never tell any of the secrets; and if anybody done anything to
+any boy in the band, whichever boy was ordered to kill that person and
+his family must do it, and he mustn’t eat and he mustn’t sleep till he
+had killed them and hacked a cross in their breasts, which was the sign
+of the band. And nobody that didn’t belong to the band could use that
+mark, and if he did he must be sued; and if he done it again he must be
+killed.  And if anybody that belonged to the band told the secrets, he
+must have his throat cut, and then have his carcass burnt up and the
+ashes scattered all around, and his name blotted off of the list with
+blood and never mentioned again by the gang, but have a curse put on it
+and be forgot forever.
+
+Everybody said it was a real beautiful oath, and asked Tom if he got
+it out of his own head.  He said, some of it, but the rest was out of
+pirate-books and robber-books, and every gang that was high-toned had
+it.
+
+Some thought it would be good to kill the _families_ of boys that told
+the secrets.  Tom said it was a good idea, so he took a pencil and wrote
+it in. Then Ben Rogers says:
+
+“Here’s Huck Finn, he hain’t got no family; what you going to do ‘bout
+him?”
+
+“Well, hain’t he got a father?” says Tom Sawyer.
+
+“Yes, he’s got a father, but you can’t never find him these days.  He
+used to lay drunk with the hogs in the tanyard, but he hain’t been seen
+in these parts for a year or more.”
+
+They talked it over, and they was going to rule me out, because they
+said every boy must have a family or somebody to kill, or else it
+wouldn’t be fair and square for the others.  Well, nobody could think of
+anything to do--everybody was stumped, and set still.  I was most ready
+to cry; but all at once I thought of a way, and so I offered them Miss
+Watson--they could kill her.  Everybody said:
+
+“Oh, she’ll do.  That’s all right.  Huck can come in.”
+
+Then they all stuck a pin in their fingers to get blood to sign with,
+and I made my mark on the paper.
+
+“Now,” says Ben Rogers, “what’s the line of business of this Gang?”
+
+“Nothing only robbery and murder,” Tom said.
+
+“But who are we going to rob?--houses, or cattle, or--”
+
+“Stuff! stealing cattle and such things ain’t robbery; it’s burglary,”
+ says Tom Sawyer.  “We ain’t burglars.  That ain’t no sort of style.  We
+are highwaymen.  We stop stages and carriages on the road, with masks
+on, and kill the people and take their watches and money.”
+
+“Must we always kill the people?”
+
+“Oh, certainly.  It’s best.  Some authorities think different, but
+mostly it’s considered best to kill them--except some that you bring to
+the cave here, and keep them till they’re ransomed.”
+
+“Ransomed?  What’s that?”
+
+“I don’t know.  But that’s what they do.  I’ve seen it in books; and so
+of course that’s what we’ve got to do.”
+
+“But how can we do it if we don’t know what it is?”
+
+“Why, blame it all, we’ve _got_ to do it.  Don’t I tell you it’s in the
+books?  Do you want to go to doing different from what’s in the books,
+and get things all muddled up?”
+
+“Oh, that’s all very fine to _say_, Tom Sawyer, but how in the nation
+are these fellows going to be ransomed if we don’t know how to do it
+to them?--that’s the thing I want to get at.  Now, what do you reckon it
+is?”
+
+“Well, I don’t know.  But per’aps if we keep them till they’re ransomed,
+it means that we keep them till they’re dead.”
+
+“Now, that’s something _like_.  That’ll answer.  Why couldn’t you said
+that before?  We’ll keep them till they’re ransomed to death; and a
+bothersome lot they’ll be, too--eating up everything, and always trying
+to get loose.”
+
+“How you talk, Ben Rogers.  How can they get loose when there’s a guard
+over them, ready to shoot them down if they move a peg?”
+
+“A guard!  Well, that _is_ good.  So somebody’s got to set up all night
+and never get any sleep, just so as to watch them.  I think that’s
+foolishness. Why can’t a body take a club and ransom them as soon as
+they get here?”
+
+“Because it ain’t in the books so--that’s why.  Now, Ben Rogers, do you
+want to do things regular, or don’t you?--that’s the idea.  Don’t you
+reckon that the people that made the books knows what’s the correct
+thing to do?  Do you reckon _you_ can learn ‘em anything?  Not by a good
+deal. No, sir, we’ll just go on and ransom them in the regular way.”
+
+“All right.  I don’t mind; but I say it’s a fool way, anyhow.  Say, do
+we kill the women, too?”
+
+“Well, Ben Rogers, if I was as ignorant as you I wouldn’t let on.  Kill
+the women?  No; nobody ever saw anything in the books like that.  You
+fetch them to the cave, and you’re always as polite as pie to them;
+and by and by they fall in love with you, and never want to go home any
+more.”
+
+“Well, if that’s the way I’m agreed, but I don’t take no stock in it.
+Mighty soon we’ll have the cave so cluttered up with women, and fellows
+waiting to be ransomed, that there won’t be no place for the robbers.
+But go ahead, I ain’t got nothing to say.”
+
+Little Tommy Barnes was asleep now, and when they waked him up he was
+scared, and cried, and said he wanted to go home to his ma, and didn’t
+want to be a robber any more.
+
+So they all made fun of him, and called him cry-baby, and that made him
+mad, and he said he would go straight and tell all the secrets.  But
+Tom give him five cents to keep quiet, and said we would all go home and
+meet next week, and rob somebody and kill some people.
+
+Ben Rogers said he couldn’t get out much, only Sundays, and so he wanted
+to begin next Sunday; but all the boys said it would be wicked to do it
+on Sunday, and that settled the thing.  They agreed to get together and
+fix a day as soon as they could, and then we elected Tom Sawyer first
+captain and Jo Harper second captain of the Gang, and so started home.
+
+I clumb up the shed and crept into my window just before day was
+breaking. My new clothes was all greased up and clayey, and I was
+dog-tired.
+
+
+
+
+CHAPTER III.
+
+WELL, I got a good going-over in the morning from old Miss Watson on
+account of my clothes; but the widow she didn’t scold, but only cleaned
+off the grease and clay, and looked so sorry that I thought I would
+behave awhile if I could.  Then Miss Watson she took me in the closet
+and prayed, but nothing come of it.  She told me to pray every day, and
+whatever I asked for I would get it.  But it warn’t so.  I tried it.
+Once I got a fish-line, but no hooks.  It warn’t any good to me without
+hooks.  I tried for the hooks three or four times, but somehow I
+couldn’t make it work.  By and by, one day, I asked Miss Watson to
+try for me, but she said I was a fool.  She never told me why, and I
+couldn’t make it out no way.
+
+I set down one time back in the woods, and had a long think about it.
+ I says to myself, if a body can get anything they pray for, why don’t
+Deacon Winn get back the money he lost on pork?  Why can’t the widow get
+back her silver snuffbox that was stole?  Why can’t Miss Watson fat up?
+No, says I to my self, there ain’t nothing in it.  I went and told the
+widow about it, and she said the thing a body could get by praying for
+it was “spiritual gifts.”  This was too many for me, but she told me
+what she meant--I must help other people, and do everything I could for
+other people, and look out for them all the time, and never think about
+myself. This was including Miss Watson, as I took it.  I went out in the
+woods and turned it over in my mind a long time, but I couldn’t see no
+advantage about it--except for the other people; so at last I reckoned
+I wouldn’t worry about it any more, but just let it go.  Sometimes the
+widow would take me one side and talk about Providence in a way to make
+a body’s mouth water; but maybe next day Miss Watson would take hold
+and knock it all down again.  I judged I could see that there was two
+Providences, and a poor chap would stand considerable show with the
+widow’s Providence, but if Miss Watson’s got him there warn’t no help
+for him any more.  I thought it all out, and reckoned I would belong
+to the widow’s if he wanted me, though I couldn’t make out how he was
+a-going to be any better off then than what he was before, seeing I was
+so ignorant, and so kind of low-down and ornery.
+
+Pap he hadn’t been seen for more than a year, and that was comfortable
+for me; I didn’t want to see him no more.  He used to always whale me
+when he was sober and could get his hands on me; though I used to take
+to the woods most of the time when he was around.  Well, about this time
+he was found in the river drownded, about twelve mile above town, so
+people said.  They judged it was him, anyway; said this drownded man was
+just his size, and was ragged, and had uncommon long hair, which was all
+like pap; but they couldn’t make nothing out of the face, because it had
+been in the water so long it warn’t much like a face at all.  They said
+he was floating on his back in the water.  They took him and buried him
+on the bank.  But I warn’t comfortable long, because I happened to think
+of something.  I knowed mighty well that a drownded man don’t float on
+his back, but on his face.  So I knowed, then, that this warn’t pap, but
+a woman dressed up in a man’s clothes.  So I was uncomfortable again.
+ I judged the old man would turn up again by and by, though I wished he
+wouldn’t.
+
+We played robber now and then about a month, and then I resigned.  All
+the boys did.  We hadn’t robbed nobody, hadn’t killed any people, but
+only just pretended.  We used to hop out of the woods and go charging
+down on hog-drivers and women in carts taking garden stuff to market,
+but we never hived any of them.  Tom Sawyer called the hogs “ingots,”
+ and he called the turnips and stuff “julery,” and we would go to the
+cave and powwow over what we had done, and how many people we had killed
+and marked.  But I couldn’t see no profit in it.  One time Tom sent a
+boy to run about town with a blazing stick, which he called a slogan
+(which was the sign for the Gang to get together), and then he said he
+had got secret news by his spies that next day a whole parcel of Spanish
+merchants and rich A-rabs was going to camp in Cave Hollow with two
+hundred elephants, and six hundred camels, and over a thousand “sumter”
+ mules, all loaded down with di’monds, and they didn’t have only a guard
+of four hundred soldiers, and so we would lay in ambuscade, as he called
+it, and kill the lot and scoop the things.  He said we must slick up
+our swords and guns, and get ready.  He never could go after even a
+turnip-cart but he must have the swords and guns all scoured up for it,
+though they was only lath and broomsticks, and you might scour at them
+till you rotted, and then they warn’t worth a mouthful of ashes more
+than what they was before.  I didn’t believe we could lick such a crowd
+of Spaniards and A-rabs, but I wanted to see the camels and elephants,
+so I was on hand next day, Saturday, in the ambuscade; and when we got
+the word we rushed out of the woods and down the hill.  But there warn’t
+no Spaniards and A-rabs, and there warn’t no camels nor no elephants.
+ It warn’t anything but a Sunday-school picnic, and only a primer-class
+at that.  We busted it up, and chased the children up the hollow; but we
+never got anything but some doughnuts and jam, though Ben Rogers got
+a rag doll, and Jo Harper got a hymn-book and a tract; and then the
+teacher charged in, and made us drop everything and cut.
+
+ I didn’t see no di’monds, and I told Tom Sawyer so.  He said there was
+loads of them there, anyway; and he said there was A-rabs there, too,
+and elephants and things.  I said, why couldn’t we see them, then?  He
+said if I warn’t so ignorant, but had read a book called Don Quixote, I
+would know without asking.  He said it was all done by enchantment.  He
+said there was hundreds of soldiers there, and elephants and treasure,
+and so on, but we had enemies which he called magicians; and they had
+turned the whole thing into an infant Sunday-school, just out of spite.
+ I said, all right; then the thing for us to do was to go for the
+magicians.  Tom Sawyer said I was a numskull.
+
+“Why,” said he, “a magician could call up a lot of genies, and they
+would hash you up like nothing before you could say Jack Robinson.  They
+are as tall as a tree and as big around as a church.”
+
+“Well,” I says, “s’pose we got some genies to help _us_--can’t we lick
+the other crowd then?”
+
+“How you going to get them?”
+
+“I don’t know.  How do _they_ get them?”
+
+“Why, they rub an old tin lamp or an iron ring, and then the genies
+come tearing in, with the thunder and lightning a-ripping around and the
+smoke a-rolling, and everything they’re told to do they up and do it.
+ They don’t think nothing of pulling a shot-tower up by the roots, and
+belting a Sunday-school superintendent over the head with it--or any
+other man.”
+
+“Who makes them tear around so?”
+
+“Why, whoever rubs the lamp or the ring.  They belong to whoever rubs
+the lamp or the ring, and they’ve got to do whatever he says.  If he
+tells them to build a palace forty miles long out of di’monds, and fill
+it full of chewing-gum, or whatever you want, and fetch an emperor’s
+daughter from China for you to marry, they’ve got to do it--and they’ve
+got to do it before sun-up next morning, too.  And more:  they’ve got
+to waltz that palace around over the country wherever you want it, you
+understand.”
+
+“Well,” says I, “I think they are a pack of flat-heads for not keeping
+the palace themselves ‘stead of fooling them away like that.  And what’s
+more--if I was one of them I would see a man in Jericho before I would
+drop my business and come to him for the rubbing of an old tin lamp.”
+
+“How you talk, Huck Finn.  Why, you’d _have_ to come when he rubbed it,
+whether you wanted to or not.”
+
+“What! and I as high as a tree and as big as a church?  All right, then;
+I _would_ come; but I lay I’d make that man climb the highest tree there
+was in the country.”
+
+“Shucks, it ain’t no use to talk to you, Huck Finn.  You don’t seem to
+know anything, somehow--perfect saphead.”
+
+I thought all this over for two or three days, and then I reckoned I
+would see if there was anything in it.  I got an old tin lamp and an
+iron ring, and went out in the woods and rubbed and rubbed till I sweat
+like an Injun, calculating to build a palace and sell it; but it warn’t
+no use, none of the genies come.  So then I judged that all that stuff
+was only just one of Tom Sawyer’s lies.  I reckoned he believed in the
+A-rabs and the elephants, but as for me I think different.  It had all
+the marks of a Sunday-school.
+
+
+
+
+CHAPTER IV.
+
+WELL, three or four months run along, and it was well into the winter
+now. I had been to school most all the time and could spell and read and
+write just a little, and could say the multiplication table up to six
+times seven is thirty-five, and I don’t reckon I could ever get any
+further than that if I was to live forever.  I don’t take no stock in
+mathematics, anyway.
+
+At first I hated the school, but by and by I got so I could stand it.
+Whenever I got uncommon tired I played hookey, and the hiding I got next
+day done me good and cheered me up.  So the longer I went to school the
+easier it got to be.  I was getting sort of used to the widow’s ways,
+too, and they warn’t so raspy on me.  Living in a house and sleeping in
+a bed pulled on me pretty tight mostly, but before the cold weather I
+used to slide out and sleep in the woods sometimes, and so that was a
+rest to me.  I liked the old ways best, but I was getting so I liked the
+new ones, too, a little bit. The widow said I was coming along slow but
+sure, and doing very satisfactory.  She said she warn’t ashamed of me.
+
+One morning I happened to turn over the salt-cellar at breakfast.
+ I reached for some of it as quick as I could to throw over my left
+shoulder and keep off the bad luck, but Miss Watson was in ahead of me,
+and crossed me off. She says, “Take your hands away, Huckleberry; what
+a mess you are always making!”  The widow put in a good word for me, but
+that warn’t going to keep off the bad luck, I knowed that well enough.
+ I started out, after breakfast, feeling worried and shaky, and
+wondering where it was going to fall on me, and what it was going to be.
+ There is ways to keep off some kinds of bad luck, but this wasn’t one
+of them kind; so I never tried to do anything, but just poked along
+low-spirited and on the watch-out.
+
+I went down to the front garden and clumb over the stile where you go
+through the high board fence.  There was an inch of new snow on the
+ground, and I seen somebody’s tracks.  They had come up from the quarry
+and stood around the stile a while, and then went on around the garden
+fence.  It was funny they hadn’t come in, after standing around so.  I
+couldn’t make it out.  It was very curious, somehow.  I was going to
+follow around, but I stooped down to look at the tracks first.  I didn’t
+notice anything at first, but next I did.  There was a cross in the left
+boot-heel made with big nails, to keep off the devil.
+
+I was up in a second and shinning down the hill.  I looked over my
+shoulder every now and then, but I didn’t see nobody.  I was at Judge
+Thatcher’s as quick as I could get there.  He said:
+
+“Why, my boy, you are all out of breath.  Did you come for your
+interest?”
+
+“No, sir,” I says; “is there some for me?”
+
+“Oh, yes, a half-yearly is in last night--over a hundred and fifty
+dollars.  Quite a fortune for you.  You had better let me invest it
+along with your six thousand, because if you take it you’ll spend it.”
+
+“No, sir,” I says, “I don’t want to spend it.  I don’t want it at
+all--nor the six thousand, nuther.  I want you to take it; I want to give
+it to you--the six thousand and all.”
+
+He looked surprised.  He couldn’t seem to make it out.  He says:
+
+“Why, what can you mean, my boy?”
+
+I says, “Don’t you ask me no questions about it, please.  You’ll take
+it--won’t you?”
+
+He says:
+
+“Well, I’m puzzled.  Is something the matter?”
+
+“Please take it,” says I, “and don’t ask me nothing--then I won’t have to
+tell no lies.”
+
+He studied a while, and then he says:
+
+“Oho-o!  I think I see.  You want to _sell_ all your property to me--not
+give it.  That’s the correct idea.”
+
+Then he wrote something on a paper and read it over, and says:
+
+“There; you see it says ‘for a consideration.’  That means I have bought
+it of you and paid you for it.  Here’s a dollar for you.  Now you sign
+it.”
+
+So I signed it, and left.
+
+Miss Watson’s nigger, Jim, had a hair-ball as big as your fist, which
+had been took out of the fourth stomach of an ox, and he used to do
+magic with it.  He said there was a spirit inside of it, and it knowed
+everything.  So I went to him that night and told him pap was here
+again, for I found his tracks in the snow.  What I wanted to know was,
+what he was going to do, and was he going to stay?  Jim got out his
+hair-ball and said something over it, and then he held it up and dropped
+it on the floor.  It fell pretty solid, and only rolled about an inch.
+ Jim tried it again, and then another time, and it acted just the same.
+ Jim got down on his knees, and put his ear against it and listened.
+ But it warn’t no use; he said it wouldn’t talk. He said sometimes it
+wouldn’t talk without money.  I told him I had an old slick counterfeit
+quarter that warn’t no good because the brass showed through the silver
+a little, and it wouldn’t pass nohow, even if the brass didn’t show,
+because it was so slick it felt greasy, and so that would tell on it
+every time.  (I reckoned I wouldn’t say nothing about the dollar I got
+from the judge.) I said it was pretty bad money, but maybe the hair-ball
+would take it, because maybe it wouldn’t know the difference.  Jim smelt
+it and bit it and rubbed it, and said he would manage so the hair-ball
+would think it was good.  He said he would split open a raw Irish potato
+and stick the quarter in between and keep it there all night, and next
+morning you couldn’t see no brass, and it wouldn’t feel greasy no more,
+and so anybody in town would take it in a minute, let alone a hair-ball.
+ Well, I knowed a potato would do that before, but I had forgot it.
+
+Jim put the quarter under the hair-ball, and got down and listened
+again. This time he said the hair-ball was all right.  He said it
+would tell my whole fortune if I wanted it to.  I says, go on.  So the
+hair-ball talked to Jim, and Jim told it to me.  He says:
+
+“Yo’ ole father doan’ know yit what he’s a-gwyne to do.  Sometimes he
+spec he’ll go ‘way, en den agin he spec he’ll stay.  De bes’ way is to
+res’ easy en let de ole man take his own way.  Dey’s two angels hoverin’
+roun’ ‘bout him.  One uv ‘em is white en shiny, en t’other one is black.
+De white one gits him to go right a little while, den de black one sail
+in en bust it all up.  A body can’t tell yit which one gwyne to fetch
+him at de las’.  But you is all right.  You gwyne to have considable
+trouble in yo’ life, en considable joy.  Sometimes you gwyne to git
+hurt, en sometimes you gwyne to git sick; but every time you’s gwyne
+to git well agin.  Dey’s two gals flyin’ ‘bout you in yo’ life.  One
+uv ‘em’s light en t’other one is dark. One is rich en t’other is po’.
+ You’s gwyne to marry de po’ one fust en de rich one by en by.  You
+wants to keep ‘way fum de water as much as you kin, en don’t run no
+resk, ‘kase it’s down in de bills dat you’s gwyne to git hung.”
+
+When I lit my candle and went up to my room that night there sat pap his
+own self!
+
+
+
+
+CHAPTER V.
+
+I had shut the door to.  Then I turned around and there he was.  I used
+to be scared of him all the time, he tanned me so much.  I reckoned I
+was scared now, too; but in a minute I see I was mistaken--that is, after
+the first jolt, as you may say, when my breath sort of hitched, he being
+so unexpected; but right away after I see I warn’t scared of him worth
+bothring about.
+
+He was most fifty, and he looked it.  His hair was long and tangled and
+greasy, and hung down, and you could see his eyes shining through
+like he was behind vines.  It was all black, no gray; so was his long,
+mixed-up whiskers.  There warn’t no color in his face, where his face
+showed; it was white; not like another man’s white, but a white to make
+a body sick, a white to make a body’s flesh crawl--a tree-toad white, a
+fish-belly white.  As for his clothes--just rags, that was all.  He had
+one ankle resting on t’other knee; the boot on that foot was busted, and
+two of his toes stuck through, and he worked them now and then.  His hat
+was laying on the floor--an old black slouch with the top caved in, like
+a lid.
+
+I stood a-looking at him; he set there a-looking at me, with his chair
+tilted back a little.  I set the candle down.  I noticed the window was
+up; so he had clumb in by the shed.  He kept a-looking me all over.  By
+and by he says:
+
+“Starchy clothes--very.  You think you’re a good deal of a big-bug,
+_don’t_ you?”
+
+“Maybe I am, maybe I ain’t,” I says.
+
+“Don’t you give me none o’ your lip,” says he.  “You’ve put on
+considerable many frills since I been away.  I’ll take you down a peg
+before I get done with you.  You’re educated, too, they say--can read and
+write.  You think you’re better’n your father, now, don’t you, because
+he can’t?  _I’ll_ take it out of you.  Who told you you might meddle
+with such hifalut’n foolishness, hey?--who told you you could?”
+
+“The widow.  She told me.”
+
+“The widow, hey?--and who told the widow she could put in her shovel
+about a thing that ain’t none of her business?”
+
+“Nobody never told her.”
+
+“Well, I’ll learn her how to meddle.  And looky here--you drop that
+school, you hear?  I’ll learn people to bring up a boy to put on airs
+over his own father and let on to be better’n what _he_ is.  You lemme
+catch you fooling around that school again, you hear?  Your mother
+couldn’t read, and she couldn’t write, nuther, before she died.  None
+of the family couldn’t before _they_ died.  I can’t; and here you’re
+a-swelling yourself up like this.  I ain’t the man to stand it--you hear?
+Say, lemme hear you read.”
+
+I took up a book and begun something about General Washington and the
+wars. When I’d read about a half a minute, he fetched the book a whack
+with his hand and knocked it across the house.  He says:
+
+“It’s so.  You can do it.  I had my doubts when you told me.  Now looky
+here; you stop that putting on frills.  I won’t have it.  I’ll lay for
+you, my smarty; and if I catch you about that school I’ll tan you good.
+First you know you’ll get religion, too.  I never see such a son.”
+
+He took up a little blue and yaller picture of some cows and a boy, and
+says:
+
+“What’s this?”
+
+“It’s something they give me for learning my lessons good.”
+
+He tore it up, and says:
+
+“I’ll give you something better--I’ll give you a cowhide.”
+
+He set there a-mumbling and a-growling a minute, and then he says:
+
+“_Ain’t_ you a sweet-scented dandy, though?  A bed; and bedclothes; and
+a look’n’-glass; and a piece of carpet on the floor--and your own father
+got to sleep with the hogs in the tanyard.  I never see such a son.  I
+bet I’ll take some o’ these frills out o’ you before I’m done with you.
+Why, there ain’t no end to your airs--they say you’re rich.  Hey?--how’s
+that?”
+
+“They lie--that’s how.”
+
+“Looky here--mind how you talk to me; I’m a-standing about all I can
+stand now--so don’t gimme no sass.  I’ve been in town two days, and I
+hain’t heard nothing but about you bein’ rich.  I heard about it
+away down the river, too.  That’s why I come.  You git me that money
+to-morrow--I want it.”
+
+“I hain’t got no money.”
+
+“It’s a lie.  Judge Thatcher’s got it.  You git it.  I want it.”
+
+“I hain’t got no money, I tell you.  You ask Judge Thatcher; he’ll tell
+you the same.”
+
+“All right.  I’ll ask him; and I’ll make him pungle, too, or I’ll know
+the reason why.  Say, how much you got in your pocket?  I want it.”
+
+“I hain’t got only a dollar, and I want that to--”
+
+“It don’t make no difference what you want it for--you just shell it
+out.”
+
+He took it and bit it to see if it was good, and then he said he was
+going down town to get some whisky; said he hadn’t had a drink all day.
+When he had got out on the shed he put his head in again, and cussed
+me for putting on frills and trying to be better than him; and when I
+reckoned he was gone he come back and put his head in again, and told me
+to mind about that school, because he was going to lay for me and lick
+me if I didn’t drop that.
+
+Next day he was drunk, and he went to Judge Thatcher’s and bullyragged
+him, and tried to make him give up the money; but he couldn’t, and then
+he swore he’d make the law force him.
+
+The judge and the widow went to law to get the court to take me away
+from him and let one of them be my guardian; but it was a new judge that
+had just come, and he didn’t know the old man; so he said courts mustn’t
+interfere and separate families if they could help it; said he’d druther
+not take a child away from its father.  So Judge Thatcher and the widow
+had to quit on the business.
+
+That pleased the old man till he couldn’t rest.  He said he’d cowhide
+me till I was black and blue if I didn’t raise some money for him.  I
+borrowed three dollars from Judge Thatcher, and pap took it and got
+drunk, and went a-blowing around and cussing and whooping and carrying
+on; and he kept it up all over town, with a tin pan, till most midnight;
+then they jailed him, and next day they had him before court, and jailed
+him again for a week.  But he said _he_ was satisfied; said he was boss
+of his son, and he’d make it warm for _him_.
+
+When he got out the new judge said he was a-going to make a man of him.
+So he took him to his own house, and dressed him up clean and nice, and
+had him to breakfast and dinner and supper with the family, and was just
+old pie to him, so to speak.  And after supper he talked to him about
+temperance and such things till the old man cried, and said he’d been
+a fool, and fooled away his life; but now he was a-going to turn over
+a new leaf and be a man nobody wouldn’t be ashamed of, and he hoped the
+judge would help him and not look down on him.  The judge said he could
+hug him for them words; so he cried, and his wife she cried again; pap
+said he’d been a man that had always been misunderstood before, and the
+judge said he believed it.  The old man said that what a man wanted
+that was down was sympathy, and the judge said it was so; so they cried
+again.  And when it was bedtime the old man rose up and held out his
+hand, and says:
+
+“Look at it, gentlemen and ladies all; take a-hold of it; shake it.
+There’s a hand that was the hand of a hog; but it ain’t so no more; it’s
+the hand of a man that’s started in on a new life, and’ll die before
+he’ll go back.  You mark them words--don’t forget I said them.  It’s a
+clean hand now; shake it--don’t be afeard.”
+
+So they shook it, one after the other, all around, and cried.  The
+judge’s wife she kissed it.  Then the old man he signed a pledge--made
+his mark. The judge said it was the holiest time on record, or something
+like that. Then they tucked the old man into a beautiful room, which was
+the spare room, and in the night some time he got powerful thirsty and
+clumb out on to the porch-roof and slid down a stanchion and traded his
+new coat for a jug of forty-rod, and clumb back again and had a good old
+time; and towards daylight he crawled out again, drunk as a fiddler, and
+rolled off the porch and broke his left arm in two places, and was most
+froze to death when somebody found him after sun-up.  And when they come
+to look at that spare room they had to take soundings before they could
+navigate it.
+
+The judge he felt kind of sore.  He said he reckoned a body could reform
+the old man with a shotgun, maybe, but he didn’t know no other way.
+
+
+
+
+CHAPTER VI.
+
+WELL, pretty soon the old man was up and around again, and then he went
+for Judge Thatcher in the courts to make him give up that money, and he
+went for me, too, for not stopping school.  He catched me a couple of
+times and thrashed me, but I went to school just the same, and dodged
+him or outrun him most of the time.  I didn’t want to go to school much
+before, but I reckoned I’d go now to spite pap.  That law trial was a
+slow business--appeared like they warn’t ever going to get started on it;
+so every now and then I’d borrow two or three dollars off of the judge
+for him, to keep from getting a cowhiding.  Every time he got money he
+got drunk; and every time he got drunk he raised Cain around town; and
+every time he raised Cain he got jailed.  He was just suited--this kind
+of thing was right in his line.
+
+He got to hanging around the widow’s too much and so she told him at
+last that if he didn’t quit using around there she would make trouble
+for him. Well, _wasn’t_ he mad?  He said he would show who was Huck
+Finn’s boss.  So he watched out for me one day in the spring, and
+catched me, and took me up the river about three mile in a skiff, and
+crossed over to the Illinois shore where it was woody and there warn’t
+no houses but an old log hut in a place where the timber was so thick
+you couldn’t find it if you didn’t know where it was.
+
+He kept me with him all the time, and I never got a chance to run off.
+We lived in that old cabin, and he always locked the door and put the
+key under his head nights.  He had a gun which he had stole, I reckon,
+and we fished and hunted, and that was what we lived on.  Every little
+while he locked me in and went down to the store, three miles, to the
+ferry, and traded fish and game for whisky, and fetched it home and got
+drunk and had a good time, and licked me.  The widow she found out where
+I was by and by, and she sent a man over to try to get hold of me; but
+pap drove him off with the gun, and it warn’t long after that till I was
+used to being where I was, and liked it--all but the cowhide part.
+
+It was kind of lazy and jolly, laying off comfortable all day, smoking
+and fishing, and no books nor study.  Two months or more run along, and
+my clothes got to be all rags and dirt, and I didn’t see how I’d ever
+got to like it so well at the widow’s, where you had to wash, and eat on
+a plate, and comb up, and go to bed and get up regular, and be forever
+bothering over a book, and have old Miss Watson pecking at you all the
+time.  I didn’t want to go back no more.  I had stopped cussing, because
+the widow didn’t like it; but now I took to it again because pap hadn’t
+no objections.  It was pretty good times up in the woods there, take it
+all around.
+
+But by and by pap got too handy with his hick’ry, and I couldn’t stand
+it. I was all over welts.  He got to going away so much, too, and
+locking me in.  Once he locked me in and was gone three days.  It was
+dreadful lonesome.  I judged he had got drownded, and I wasn’t ever
+going to get out any more.  I was scared.  I made up my mind I would fix
+up some way to leave there.  I had tried to get out of that cabin many
+a time, but I couldn’t find no way.  There warn’t a window to it big
+enough for a dog to get through.  I couldn’t get up the chimbly; it
+was too narrow.  The door was thick, solid oak slabs.  Pap was pretty
+careful not to leave a knife or anything in the cabin when he was away;
+I reckon I had hunted the place over as much as a hundred times; well, I
+was most all the time at it, because it was about the only way to put in
+the time.  But this time I found something at last; I found an old rusty
+wood-saw without any handle; it was laid in between a rafter and the
+clapboards of the roof. I greased it up and went to work.  There was an
+old horse-blanket nailed against the logs at the far end of the cabin
+behind the table, to keep the wind from blowing through the chinks and
+putting the candle out.  I got under the table and raised the blanket,
+and went to work to saw a section of the big bottom log out--big enough
+to let me through.  Well, it was a good long job, but I was getting
+towards the end of it when I heard pap’s gun in the woods.  I got rid of
+the signs of my work, and dropped the blanket and hid my saw, and pretty
+soon pap come in.
+
+Pap warn’t in a good humor--so he was his natural self.  He said he was
+down town, and everything was going wrong.  His lawyer said he reckoned
+he would win his lawsuit and get the money if they ever got started on
+the trial; but then there was ways to put it off a long time, and Judge
+Thatcher knowed how to do it. And he said people allowed there’d be
+another trial to get me away from him and give me to the widow for my
+guardian, and they guessed it would win this time.  This shook me up
+considerable, because I didn’t want to go back to the widow’s any more
+and be so cramped up and sivilized, as they called it.  Then the old man
+got to cussing, and cussed everything and everybody he could think of,
+and then cussed them all over again to make sure he hadn’t skipped any,
+and after that he polished off with a kind of a general cuss all round,
+including a considerable parcel of people which he didn’t know the names
+of, and so called them what’s-his-name when he got to them, and went
+right along with his cussing.
+
+He said he would like to see the widow get me.  He said he would watch
+out, and if they tried to come any such game on him he knowed of a place
+six or seven mile off to stow me in, where they might hunt till they
+dropped and they couldn’t find me.  That made me pretty uneasy again,
+but only for a minute; I reckoned I wouldn’t stay on hand till he got
+that chance.
+
+The old man made me go to the skiff and fetch the things he had
+got. There was a fifty-pound sack of corn meal, and a side of bacon,
+ammunition, and a four-gallon jug of whisky, and an old book and two
+newspapers for wadding, besides some tow.  I toted up a load, and went
+back and set down on the bow of the skiff to rest.  I thought it all
+over, and I reckoned I would walk off with the gun and some lines, and
+take to the woods when I run away.  I guessed I wouldn’t stay in one
+place, but just tramp right across the country, mostly night times, and
+hunt and fish to keep alive, and so get so far away that the old man nor
+the widow couldn’t ever find me any more.  I judged I would saw out and
+leave that night if pap got drunk enough, and I reckoned he would.  I
+got so full of it I didn’t notice how long I was staying till the old
+man hollered and asked me whether I was asleep or drownded.
+
+I got the things all up to the cabin, and then it was about dark.  While
+I was cooking supper the old man took a swig or two and got sort of
+warmed up, and went to ripping again.  He had been drunk over in town,
+and laid in the gutter all night, and he was a sight to look at.  A body
+would a thought he was Adam--he was just all mud.  Whenever his liquor
+begun to work he most always went for the govment, this time he says:
+
+“Call this a govment! why, just look at it and see what it’s like.
+Here’s the law a-standing ready to take a man’s son away from him--a
+man’s own son, which he has had all the trouble and all the anxiety
+and all the expense of raising.  Yes, just as that man has got that
+son raised at last, and ready to go to work and begin to do suthin’ for
+_him_ and give him a rest, the law up and goes for him.  And they call
+_that_ govment!  That ain’t all, nuther.  The law backs that old Judge
+Thatcher up and helps him to keep me out o’ my property.  Here’s what
+the law does:  The law takes a man worth six thousand dollars and
+up’ards, and jams him into an old trap of a cabin like this, and lets
+him go round in clothes that ain’t fitten for a hog. They call that
+govment!  A man can’t get his rights in a govment like this. Sometimes
+I’ve a mighty notion to just leave the country for good and all. Yes,
+and I _told_ ‘em so; I told old Thatcher so to his face.  Lots of ‘em
+heard me, and can tell what I said.  Says I, for two cents I’d leave the
+blamed country and never come a-near it agin.  Them’s the very words.  I
+says look at my hat--if you call it a hat--but the lid raises up and the
+rest of it goes down till it’s below my chin, and then it ain’t rightly
+a hat at all, but more like my head was shoved up through a jint o’
+stove-pipe.  Look at it, says I--such a hat for me to wear--one of the
+wealthiest men in this town if I could git my rights.
+
+“Oh, yes, this is a wonderful govment, wonderful.  Why, looky here.
+There was a free nigger there from Ohio--a mulatter, most as white as
+a white man.  He had the whitest shirt on you ever see, too, and the
+shiniest hat; and there ain’t a man in that town that’s got as fine
+clothes as what he had; and he had a gold watch and chain, and a
+silver-headed cane--the awfulest old gray-headed nabob in the State.  And
+what do you think?  They said he was a p’fessor in a college, and could
+talk all kinds of languages, and knowed everything.  And that ain’t the
+wust. They said he could _vote_ when he was at home.  Well, that let me
+out. Thinks I, what is the country a-coming to?  It was ‘lection day,
+and I was just about to go and vote myself if I warn’t too drunk to get
+there; but when they told me there was a State in this country where
+they’d let that nigger vote, I drawed out.  I says I’ll never vote agin.
+ Them’s the very words I said; they all heard me; and the country may
+rot for all me--I’ll never vote agin as long as I live.  And to see the
+cool way of that nigger--why, he wouldn’t a give me the road if I hadn’t
+shoved him out o’ the way.  I says to the people, why ain’t this nigger
+put up at auction and sold?--that’s what I want to know.  And what do you
+reckon they said? Why, they said he couldn’t be sold till he’d been in
+the State six months, and he hadn’t been there that long yet.  There,
+now--that’s a specimen.  They call that a govment that can’t sell a free
+nigger till he’s been in the State six months.  Here’s a govment that
+calls itself a govment, and lets on to be a govment, and thinks it is a
+govment, and yet’s got to set stock-still for six whole months before
+it can take a hold of a prowling, thieving, infernal, white-shirted free
+nigger, and--”
+
+Pap was agoing on so he never noticed where his old limber legs was
+taking him to, so he went head over heels over the tub of salt pork and
+barked both shins, and the rest of his speech was all the hottest kind
+of language--mostly hove at the nigger and the govment, though he give
+the tub some, too, all along, here and there.  He hopped around the
+cabin considerable, first on one leg and then on the other, holding
+first one shin and then the other one, and at last he let out with his
+left foot all of a sudden and fetched the tub a rattling kick.  But it
+warn’t good judgment, because that was the boot that had a couple of his
+toes leaking out of the front end of it; so now he raised a howl that
+fairly made a body’s hair raise, and down he went in the dirt, and
+rolled there, and held his toes; and the cussing he done then laid over
+anything he had ever done previous.  He said so his own self afterwards.
+ He had heard old Sowberry Hagan in his best days, and he said it laid
+over him, too; but I reckon that was sort of piling it on, maybe.
+
+After supper pap took the jug, and said he had enough whisky there
+for two drunks and one delirium tremens.  That was always his word.  I
+judged he would be blind drunk in about an hour, and then I would steal
+the key, or saw myself out, one or t’other.  He drank and drank, and
+tumbled down on his blankets by and by; but luck didn’t run my way.
+ He didn’t go sound asleep, but was uneasy.  He groaned and moaned and
+thrashed around this way and that for a long time.  At last I got so
+sleepy I couldn’t keep my eyes open all I could do, and so before I
+knowed what I was about I was sound asleep, and the candle burning.
+
+I don’t know how long I was asleep, but all of a sudden there was an
+awful scream and I was up.  There was pap looking wild, and skipping
+around every which way and yelling about snakes.  He said they was
+crawling up his legs; and then he would give a jump and scream, and say
+one had bit him on the cheek--but I couldn’t see no snakes.  He started
+and run round and round the cabin, hollering “Take him off! take him
+off! he’s biting me on the neck!”  I never see a man look so wild in the
+eyes. Pretty soon he was all fagged out, and fell down panting; then he
+rolled over and over wonderful fast, kicking things every which way,
+and striking and grabbing at the air with his hands, and screaming and
+saying there was devils a-hold of him.  He wore out by and by, and laid
+still a while, moaning.  Then he laid stiller, and didn’t make a sound.
+ I could hear the owls and the wolves away off in the woods, and it
+seemed terrible still.  He was laying over by the corner. By and by he
+raised up part way and listened, with his head to one side.  He says,
+very low:
+
+“Tramp--tramp--tramp; that’s the dead; tramp--tramp--tramp; they’re coming
+after me; but I won’t go.  Oh, they’re here! don’t touch me--don’t! hands
+off--they’re cold; let go.  Oh, let a poor devil alone!”
+
+Then he went down on all fours and crawled off, begging them to let him
+alone, and he rolled himself up in his blanket and wallowed in under the
+old pine table, still a-begging; and then he went to crying.  I could
+hear him through the blanket.
+
+By and by he rolled out and jumped up on his feet looking wild, and he
+see me and went for me.  He chased me round and round the place with a
+clasp-knife, calling me the Angel of Death, and saying he would kill me,
+and then I couldn’t come for him no more.  I begged, and told him I
+was only Huck; but he laughed _such_ a screechy laugh, and roared and
+cussed, and kept on chasing me up.  Once when I turned short and
+dodged under his arm he made a grab and got me by the jacket between my
+shoulders, and I thought I was gone; but I slid out of the jacket quick
+as lightning, and saved myself. Pretty soon he was all tired out, and
+dropped down with his back against the door, and said he would rest a
+minute and then kill me. He put his knife under him, and said he would
+sleep and get strong, and then he would see who was who.
+
+So he dozed off pretty soon.  By and by I got the old split-bottom chair
+and clumb up as easy as I could, not to make any noise, and got down the
+gun.  I slipped the ramrod down it to make sure it was loaded, then I
+laid it across the turnip barrel, pointing towards pap, and set down
+behind it to wait for him to stir.  And how slow and still the time did
+drag along.
+
+
+
+
+CHAPTER VII.
+
+“GIT up!  What you ‘bout?”
+
+I opened my eyes and looked around, trying to make out where I was.  It
+was after sun-up, and I had been sound asleep.  Pap was standing over me
+looking sour and sick, too.  He says:
+
+“What you doin’ with this gun?”
+
+I judged he didn’t know nothing about what he had been doing, so I says:
+
+“Somebody tried to get in, so I was laying for him.”
+
+“Why didn’t you roust me out?”
+
+“Well, I tried to, but I couldn’t; I couldn’t budge you.”
+
+“Well, all right.  Don’t stand there palavering all day, but out with
+you and see if there’s a fish on the lines for breakfast.  I’ll be along
+in a minute.”
+
+He unlocked the door, and I cleared out up the river-bank.  I noticed
+some pieces of limbs and such things floating down, and a sprinkling of
+bark; so I knowed the river had begun to rise.  I reckoned I would have
+great times now if I was over at the town.  The June rise used to be
+always luck for me; because as soon as that rise begins here comes
+cordwood floating down, and pieces of log rafts--sometimes a dozen logs
+together; so all you have to do is to catch them and sell them to the
+wood-yards and the sawmill.
+
+I went along up the bank with one eye out for pap and t’other one out
+for what the rise might fetch along.  Well, all at once here comes a
+canoe; just a beauty, too, about thirteen or fourteen foot long, riding
+high like a duck.  I shot head-first off of the bank like a frog,
+clothes and all on, and struck out for the canoe.  I just expected
+there’d be somebody laying down in it, because people often done that
+to fool folks, and when a chap had pulled a skiff out most to it they’d
+raise up and laugh at him.  But it warn’t so this time.  It was a
+drift-canoe sure enough, and I clumb in and paddled her ashore.  Thinks
+I, the old man will be glad when he sees this--she’s worth ten dollars.
+ But when I got to shore pap wasn’t in sight yet, and as I was running
+her into a little creek like a gully, all hung over with vines and
+willows, I struck another idea:  I judged I’d hide her good, and then,
+‘stead of taking to the woods when I run off, I’d go down the river
+about fifty mile and camp in one place for good, and not have such a
+rough time tramping on foot.
+
+It was pretty close to the shanty, and I thought I heard the old man
+coming all the time; but I got her hid; and then I out and looked around
+a bunch of willows, and there was the old man down the path a piece just
+drawing a bead on a bird with his gun.  So he hadn’t seen anything.
+
+When he got along I was hard at it taking up a “trot” line.  He abused
+me a little for being so slow; but I told him I fell in the river, and
+that was what made me so long.  I knowed he would see I was wet, and
+then he would be asking questions.  We got five catfish off the lines
+and went home.
+
+While we laid off after breakfast to sleep up, both of us being about
+wore out, I got to thinking that if I could fix up some way to keep pap
+and the widow from trying to follow me, it would be a certainer thing
+than trusting to luck to get far enough off before they missed me; you
+see, all kinds of things might happen.  Well, I didn’t see no way for a
+while, but by and by pap raised up a minute to drink another barrel of
+water, and he says:
+
+“Another time a man comes a-prowling round here you roust me out, you
+hear? That man warn’t here for no good.  I’d a shot him.  Next time you
+roust me out, you hear?”
+
+Then he dropped down and went to sleep again; but what he had been
+saying give me the very idea I wanted.  I says to myself, I can fix it
+now so nobody won’t think of following me.
+
+About twelve o’clock we turned out and went along up the bank.  The
+river was coming up pretty fast, and lots of driftwood going by on the
+rise. By and by along comes part of a log raft--nine logs fast together.
+ We went out with the skiff and towed it ashore.  Then we had dinner.
+Anybody but pap would a waited and seen the day through, so as to catch
+more stuff; but that warn’t pap’s style.  Nine logs was enough for one
+time; he must shove right over to town and sell.  So he locked me in and
+took the skiff, and started off towing the raft about half-past three.
+ I judged he wouldn’t come back that night.  I waited till I reckoned he
+had got a good start; then I out with my saw, and went to work on that
+log again.  Before he was t’other side of the river I was out of the
+hole; him and his raft was just a speck on the water away off yonder.
+
+I took the sack of corn meal and took it to where the canoe was hid, and
+shoved the vines and branches apart and put it in; then I done the same
+with the side of bacon; then the whisky-jug.  I took all the coffee and
+sugar there was, and all the ammunition; I took the wadding; I took the
+bucket and gourd; I took a dipper and a tin cup, and my old saw and two
+blankets, and the skillet and the coffee-pot.  I took fish-lines and
+matches and other things--everything that was worth a cent.  I cleaned
+out the place.  I wanted an axe, but there wasn’t any, only the one out
+at the woodpile, and I knowed why I was going to leave that.  I fetched
+out the gun, and now I was done.
+
+I had wore the ground a good deal crawling out of the hole and dragging
+out so many things.  So I fixed that as good as I could from the outside
+by scattering dust on the place, which covered up the smoothness and the
+sawdust.  Then I fixed the piece of log back into its place, and put two
+rocks under it and one against it to hold it there, for it was bent up
+at that place and didn’t quite touch ground.  If you stood four or five
+foot away and didn’t know it was sawed, you wouldn’t never notice
+it; and besides, this was the back of the cabin, and it warn’t likely
+anybody would go fooling around there.
+
+It was all grass clear to the canoe, so I hadn’t left a track.  I
+followed around to see.  I stood on the bank and looked out over the
+river.  All safe.  So I took the gun and went up a piece into the woods,
+and was hunting around for some birds when I see a wild pig; hogs soon
+went wild in them bottoms after they had got away from the prairie
+farms. I shot this fellow and took him into camp.
+
+I took the axe and smashed in the door.  I beat it and hacked it
+considerable a-doing it.  I fetched the pig in, and took him back nearly
+to the table and hacked into his throat with the axe, and laid him down
+on the ground to bleed; I say ground because it was ground--hard packed,
+and no boards.  Well, next I took an old sack and put a lot of big rocks
+in it--all I could drag--and I started it from the pig, and dragged it to
+the door and through the woods down to the river and dumped it in, and
+down it sunk, out of sight.  You could easy see that something had been
+dragged over the ground.  I did wish Tom Sawyer was there; I knowed he
+would take an interest in this kind of business, and throw in the fancy
+touches.  Nobody could spread himself like Tom Sawyer in such a thing as
+that.
+
+Well, last I pulled out some of my hair, and blooded the axe good, and
+stuck it on the back side, and slung the axe in the corner.  Then I
+took up the pig and held him to my breast with my jacket (so he couldn’t
+drip) till I got a good piece below the house and then dumped him into
+the river.  Now I thought of something else.  So I went and got the bag
+of meal and my old saw out of the canoe, and fetched them to the house.
+ I took the bag to where it used to stand, and ripped a hole in the
+bottom of it with the saw, for there warn’t no knives and forks on the
+place--pap done everything with his clasp-knife about the cooking.  Then
+I carried the sack about a hundred yards across the grass and through
+the willows east of the house, to a shallow lake that was five mile wide
+and full of rushes--and ducks too, you might say, in the season.  There
+was a slough or a creek leading out of it on the other side that went
+miles away, I don’t know where, but it didn’t go to the river.  The meal
+sifted out and made a little track all the way to the lake.  I dropped
+pap’s whetstone there too, so as to look like it had been done by
+accident. Then I tied up the rip in the meal sack with a string, so it
+wouldn’t leak no more, and took it and my saw to the canoe again.
+
+It was about dark now; so I dropped the canoe down the river under some
+willows that hung over the bank, and waited for the moon to rise.  I
+made fast to a willow; then I took a bite to eat, and by and by laid
+down in the canoe to smoke a pipe and lay out a plan.  I says to myself,
+they’ll follow the track of that sackful of rocks to the shore and then
+drag the river for me.  And they’ll follow that meal track to the lake
+and go browsing down the creek that leads out of it to find the robbers
+that killed me and took the things.  They won’t ever hunt the river for
+anything but my dead carcass. They’ll soon get tired of that, and won’t
+bother no more about me.  All right; I can stop anywhere I want to.
+Jackson’s Island is good enough for me; I know that island pretty well,
+and nobody ever comes there.  And then I can paddle over to town nights,
+and slink around and pick up things I want. Jackson’s Island’s the
+place.
+
+I was pretty tired, and the first thing I knowed I was asleep.  When
+I woke up I didn’t know where I was for a minute.  I set up and looked
+around, a little scared.  Then I remembered.  The river looked miles and
+miles across.  The moon was so bright I could a counted the drift logs
+that went a-slipping along, black and still, hundreds of yards out from
+shore. Everything was dead quiet, and it looked late, and _smelt_ late.
+You know what I mean--I don’t know the words to put it in.
+
+I took a good gap and a stretch, and was just going to unhitch and start
+when I heard a sound away over the water.  I listened.  Pretty soon I
+made it out.  It was that dull kind of a regular sound that comes from
+oars working in rowlocks when it’s a still night.  I peeped out through
+the willow branches, and there it was--a skiff, away across the water.
+ I couldn’t tell how many was in it.  It kept a-coming, and when it was
+abreast of me I see there warn’t but one man in it.  Think’s I, maybe
+it’s pap, though I warn’t expecting him.  He dropped below me with the
+current, and by and by he came a-swinging up shore in the easy water,
+and he went by so close I could a reached out the gun and touched him.
+ Well, it _was_ pap, sure enough--and sober, too, by the way he laid his
+oars.
+
+I didn’t lose no time.  The next minute I was a-spinning down stream
+soft but quick in the shade of the bank.  I made two mile and a half,
+and then struck out a quarter of a mile or more towards the middle of
+the river, because pretty soon I would be passing the ferry landing, and
+people might see me and hail me.  I got out amongst the driftwood, and
+then laid down in the bottom of the canoe and let her float.
+
+ I laid there, and had a good rest and a smoke out of my pipe, looking
+away into the sky; not a cloud in it.  The sky looks ever so deep when
+you lay down on your back in the moonshine; I never knowed it before.
+ And how far a body can hear on the water such nights!  I heard people
+talking at the ferry landing. I heard what they said, too--every word
+of it.  One man said it was getting towards the long days and the short
+nights now.  T’other one said _this_ warn’t one of the short ones, he
+reckoned--and then they laughed, and he said it over again, and they
+laughed again; then they waked up another fellow and told him, and
+laughed, but he didn’t laugh; he ripped out something brisk, and said
+let him alone.  The first fellow said he ‘lowed to tell it to his
+old woman--she would think it was pretty good; but he said that warn’t
+nothing to some things he had said in his time. I heard one man say it
+was nearly three o’clock, and he hoped daylight wouldn’t wait more than
+about a week longer.  After that the talk got further and further away,
+and I couldn’t make out the words any more; but I could hear the mumble,
+and now and then a laugh, too, but it seemed a long ways off.
+
+I was away below the ferry now.  I rose up, and there was Jackson’s
+Island, about two mile and a half down stream, heavy timbered and
+standing up out of the middle of the river, big and dark and solid, like
+a steamboat without any lights.  There warn’t any signs of the bar at
+the head--it was all under water now.
+
+It didn’t take me long to get there.  I shot past the head at a ripping
+rate, the current was so swift, and then I got into the dead water and
+landed on the side towards the Illinois shore.  I run the canoe into
+a deep dent in the bank that I knowed about; I had to part the willow
+branches to get in; and when I made fast nobody could a seen the canoe
+from the outside.
+
+I went up and set down on a log at the head of the island, and looked
+out on the big river and the black driftwood and away over to the town,
+three mile away, where there was three or four lights twinkling.  A
+monstrous big lumber-raft was about a mile up stream, coming along down,
+with a lantern in the middle of it.  I watched it come creeping down,
+and when it was most abreast of where I stood I heard a man say, “Stern
+oars, there! heave her head to stabboard!”  I heard that just as plain
+as if the man was by my side.
+
+There was a little gray in the sky now; so I stepped into the woods, and
+laid down for a nap before breakfast.
+
+
+
+
+CHAPTER VIII.
+
+THE sun was up so high when I waked that I judged it was after eight
+o’clock.  I laid there in the grass and the cool shade thinking about
+things, and feeling rested and ruther comfortable and satisfied.  I
+could see the sun out at one or two holes, but mostly it was big trees
+all about, and gloomy in there amongst them.  There was freckled places
+on the ground where the light sifted down through the leaves, and the
+freckled places swapped about a little, showing there was a little
+breeze up there.  A couple of squirrels set on a limb and jabbered at me
+very friendly.
+
+I was powerful lazy and comfortable--didn’t want to get up and cook
+breakfast.  Well, I was dozing off again when I thinks I hears a deep
+sound of “boom!” away up the river.  I rouses up, and rests on my elbow
+and listens; pretty soon I hears it again.  I hopped up, and went and
+looked out at a hole in the leaves, and I see a bunch of smoke laying
+on the water a long ways up--about abreast the ferry.  And there was the
+ferryboat full of people floating along down.  I knowed what was the
+matter now.  “Boom!” I see the white smoke squirt out of the ferryboat’s
+side.  You see, they was firing cannon over the water, trying to make my
+carcass come to the top.
+
+I was pretty hungry, but it warn’t going to do for me to start a fire,
+because they might see the smoke.  So I set there and watched the
+cannon-smoke and listened to the boom.  The river was a mile wide there,
+and it always looks pretty on a summer morning--so I was having a good
+enough time seeing them hunt for my remainders if I only had a bite to
+eat. Well, then I happened to think how they always put quicksilver in
+loaves of bread and float them off, because they always go right to the
+drownded carcass and stop there.  So, says I, I’ll keep a lookout, and
+if any of them’s floating around after me I’ll give them a show.  I
+changed to the Illinois edge of the island to see what luck I could
+have, and I warn’t disappointed.  A big double loaf come along, and I
+most got it with a long stick, but my foot slipped and she floated out
+further.  Of course I was where the current set in the closest to the
+shore--I knowed enough for that.  But by and by along comes another one,
+and this time I won.  I took out the plug and shook out the little dab
+of quicksilver, and set my teeth in.  It was “baker’s bread”--what the
+quality eat; none of your low-down corn-pone.
+
+I got a good place amongst the leaves, and set there on a log, munching
+the bread and watching the ferry-boat, and very well satisfied.  And
+then something struck me.  I says, now I reckon the widow or the parson
+or somebody prayed that this bread would find me, and here it has gone
+and done it.  So there ain’t no doubt but there is something in that
+thing--that is, there’s something in it when a body like the widow or the
+parson prays, but it don’t work for me, and I reckon it don’t work for
+only just the right kind.
+
+I lit a pipe and had a good long smoke, and went on watching.  The
+ferryboat was floating with the current, and I allowed I’d have a chance
+to see who was aboard when she come along, because she would come in
+close, where the bread did.  When she’d got pretty well along down
+towards me, I put out my pipe and went to where I fished out the bread,
+and laid down behind a log on the bank in a little open place.  Where
+the log forked I could peep through.
+
+By and by she come along, and she drifted in so close that they could
+a run out a plank and walked ashore.  Most everybody was on the boat.
+ Pap, and Judge Thatcher, and Bessie Thatcher, and Jo Harper, and Tom
+Sawyer, and his old Aunt Polly, and Sid and Mary, and plenty more.
+ Everybody was talking about the murder, but the captain broke in and
+says:
+
+“Look sharp, now; the current sets in the closest here, and maybe he’s
+washed ashore and got tangled amongst the brush at the water’s edge.  I
+hope so, anyway.”
+
+I didn’t hope so.  They all crowded up and leaned over the rails, nearly
+in my face, and kept still, watching with all their might.  I could see
+them first-rate, but they couldn’t see me.  Then the captain sung out:
+
+“Stand away!” and the cannon let off such a blast right before me that
+it made me deef with the noise and pretty near blind with the smoke, and
+I judged I was gone.  If they’d a had some bullets in, I reckon they’d
+a got the corpse they was after.  Well, I see I warn’t hurt, thanks to
+goodness. The boat floated on and went out of sight around the shoulder
+of the island.  I could hear the booming now and then, further and
+further off, and by and by, after an hour, I didn’t hear it no more.
+ The island was three mile long.  I judged they had got to the foot, and
+was giving it up.  But they didn’t yet a while.  They turned around
+the foot of the island and started up the channel on the Missouri side,
+under steam, and booming once in a while as they went.  I crossed over
+to that side and watched them. When they got abreast the head of the
+island they quit shooting and dropped over to the Missouri shore and
+went home to the town.
+
+I knowed I was all right now.  Nobody else would come a-hunting after
+me. I got my traps out of the canoe and made me a nice camp in the thick
+woods.  I made a kind of a tent out of my blankets to put my things
+under so the rain couldn’t get at them.  I catched a catfish and haggled
+him open with my saw, and towards sundown I started my camp fire and had
+supper.  Then I set out a line to catch some fish for breakfast.
+
+When it was dark I set by my camp fire smoking, and feeling pretty well
+satisfied; but by and by it got sort of lonesome, and so I went and set
+on the bank and listened to the current swashing along, and counted the
+stars and drift logs and rafts that come down, and then went to bed;
+there ain’t no better way to put in time when you are lonesome; you
+can’t stay so, you soon get over it.
+
+And so for three days and nights.  No difference--just the same thing.
+But the next day I went exploring around down through the island.  I was
+boss of it; it all belonged to me, so to say, and I wanted to know
+all about it; but mainly I wanted to put in the time.  I found plenty
+strawberries, ripe and prime; and green summer grapes, and green
+razberries; and the green blackberries was just beginning to show.  They
+would all come handy by and by, I judged.
+
+Well, I went fooling along in the deep woods till I judged I warn’t
+far from the foot of the island.  I had my gun along, but I hadn’t shot
+nothing; it was for protection; thought I would kill some game nigh
+home. About this time I mighty near stepped on a good-sized snake,
+and it went sliding off through the grass and flowers, and I after
+it, trying to get a shot at it. I clipped along, and all of a sudden I
+bounded right on to the ashes of a camp fire that was still smoking.
+
+My heart jumped up amongst my lungs.  I never waited for to look
+further, but uncocked my gun and went sneaking back on my tiptoes as
+fast as ever I could.  Every now and then I stopped a second amongst the
+thick leaves and listened, but my breath come so hard I couldn’t hear
+nothing else.  I slunk along another piece further, then listened again;
+and so on, and so on.  If I see a stump, I took it for a man; if I trod
+on a stick and broke it, it made me feel like a person had cut one of my
+breaths in two and I only got half, and the short half, too.
+
+When I got to camp I warn’t feeling very brash, there warn’t much sand
+in my craw; but I says, this ain’t no time to be fooling around.  So I
+got all my traps into my canoe again so as to have them out of sight,
+and I put out the fire and scattered the ashes around to look like an
+old last year’s camp, and then clumb a tree.
+
+I reckon I was up in the tree two hours; but I didn’t see nothing,
+I didn’t hear nothing--I only _thought_ I heard and seen as much as a
+thousand things.  Well, I couldn’t stay up there forever; so at last I
+got down, but I kept in the thick woods and on the lookout all the
+time. All I could get to eat was berries and what was left over from
+breakfast.
+
+By the time it was night I was pretty hungry.  So when it was good
+and dark I slid out from shore before moonrise and paddled over to the
+Illinois bank--about a quarter of a mile.  I went out in the woods and
+cooked a supper, and I had about made up my mind I would stay there
+all night when I hear a _plunkety-plunk, plunkety-plunk_, and says
+to myself, horses coming; and next I hear people’s voices.  I got
+everything into the canoe as quick as I could, and then went creeping
+through the woods to see what I could find out.  I hadn’t got far when I
+hear a man say:
+
+“We better camp here if we can find a good place; the horses is about
+beat out.  Let’s look around.”
+
+I didn’t wait, but shoved out and paddled away easy.  I tied up in the
+old place, and reckoned I would sleep in the canoe.
+
+I didn’t sleep much.  I couldn’t, somehow, for thinking.  And every time
+I waked up I thought somebody had me by the neck.  So the sleep didn’t
+do me no good.  By and by I says to myself, I can’t live this way; I’m
+a-going to find out who it is that’s here on the island with me; I’ll
+find it out or bust.  Well, I felt better right off.
+
+So I took my paddle and slid out from shore just a step or two, and
+then let the canoe drop along down amongst the shadows.  The moon was
+shining, and outside of the shadows it made it most as light as day.
+ I poked along well on to an hour, everything still as rocks and sound
+asleep. Well, by this time I was most down to the foot of the island.  A
+little ripply, cool breeze begun to blow, and that was as good as saying
+the night was about done.  I give her a turn with the paddle and brung
+her nose to shore; then I got my gun and slipped out and into the edge
+of the woods.  I sat down there on a log, and looked out through the
+leaves.  I see the moon go off watch, and the darkness begin to blanket
+the river. But in a little while I see a pale streak over the treetops,
+and knowed the day was coming.  So I took my gun and slipped off towards
+where I had run across that camp fire, stopping every minute or two
+to listen.  But I hadn’t no luck somehow; I couldn’t seem to find the
+place.  But by and by, sure enough, I catched a glimpse of fire away
+through the trees.  I went for it, cautious and slow.  By and by I was
+close enough to have a look, and there laid a man on the ground.  It
+most give me the fan-tods. He had a blanket around his head, and his
+head was nearly in the fire.  I set there behind a clump of bushes, in
+about six foot of him, and kept my eyes on him steady.  It was getting
+gray daylight now.  Pretty soon he gapped and stretched himself and hove
+off the blanket, and it was Miss Watson’s Jim!  I bet I was glad to see
+him.  I says:
+
+“Hello, Jim!” and skipped out.
+
+He bounced up and stared at me wild.  Then he drops down on his knees,
+and puts his hands together and says:
+
+“Doan’ hurt me--don’t!  I hain’t ever done no harm to a ghos’.  I alwuz
+liked dead people, en done all I could for ‘em.  You go en git in de
+river agin, whah you b’longs, en doan’ do nuffn to Ole Jim, ‘at ‘uz
+awluz yo’ fren’.”
+
+Well, I warn’t long making him understand I warn’t dead.  I was ever so
+glad to see Jim.  I warn’t lonesome now.  I told him I warn’t afraid of
+_him_ telling the people where I was.  I talked along, but he only set
+there and looked at me; never said nothing.  Then I says:
+
+“It’s good daylight.  Le’s get breakfast.  Make up your camp fire good.”
+
+“What’s de use er makin’ up de camp fire to cook strawbries en sich
+truck? But you got a gun, hain’t you?  Den we kin git sumfn better den
+strawbries.”
+
+“Strawberries and such truck,” I says.  “Is that what you live on?”
+
+“I couldn’ git nuffn else,” he says.
+
+“Why, how long you been on the island, Jim?”
+
+“I come heah de night arter you’s killed.”
+
+“What, all that time?”
+
+“Yes--indeedy.”
+
+“And ain’t you had nothing but that kind of rubbage to eat?”
+
+“No, sah--nuffn else.”
+
+“Well, you must be most starved, ain’t you?”
+
+“I reck’n I could eat a hoss.  I think I could. How long you ben on de
+islan’?”
+
+“Since the night I got killed.”
+
+“No!  W’y, what has you lived on?  But you got a gun.  Oh, yes, you got
+a gun.  Dat’s good.  Now you kill sumfn en I’ll make up de fire.”
+
+So we went over to where the canoe was, and while he built a fire in
+a grassy open place amongst the trees, I fetched meal and bacon and
+coffee, and coffee-pot and frying-pan, and sugar and tin cups, and the
+nigger was set back considerable, because he reckoned it was all done
+with witchcraft. I catched a good big catfish, too, and Jim cleaned him
+with his knife, and fried him.
+
+When breakfast was ready we lolled on the grass and eat it smoking hot.
+Jim laid it in with all his might, for he was most about starved.  Then
+when we had got pretty well stuffed, we laid off and lazied.  By and by
+Jim says:
+
+“But looky here, Huck, who wuz it dat ‘uz killed in dat shanty ef it
+warn’t you?”
+
+Then I told him the whole thing, and he said it was smart.  He said Tom
+Sawyer couldn’t get up no better plan than what I had.  Then I says:
+
+“How do you come to be here, Jim, and how’d you get here?”
+
+He looked pretty uneasy, and didn’t say nothing for a minute.  Then he
+says:
+
+“Maybe I better not tell.”
+
+“Why, Jim?”
+
+“Well, dey’s reasons.  But you wouldn’ tell on me ef I uz to tell you,
+would you, Huck?”
+
+“Blamed if I would, Jim.”
+
+“Well, I b’lieve you, Huck.  I--_I run off_.”
+
+“Jim!”
+
+“But mind, you said you wouldn’ tell--you know you said you wouldn’ tell,
+Huck.”
+
+“Well, I did.  I said I wouldn’t, and I’ll stick to it.  Honest _injun_,
+I will.  People would call me a low-down Abolitionist and despise me for
+keeping mum--but that don’t make no difference.  I ain’t a-going to tell,
+and I ain’t a-going back there, anyways.  So, now, le’s know all about
+it.”
+
+“Well, you see, it ‘uz dis way.  Ole missus--dat’s Miss Watson--she pecks
+on me all de time, en treats me pooty rough, but she awluz said she
+wouldn’ sell me down to Orleans.  But I noticed dey wuz a nigger trader
+roun’ de place considable lately, en I begin to git oneasy.  Well, one
+night I creeps to de do’ pooty late, en de do’ warn’t quite shet, en I
+hear old missus tell de widder she gwyne to sell me down to Orleans, but
+she didn’ want to, but she could git eight hund’d dollars for me, en it
+‘uz sich a big stack o’ money she couldn’ resis’.  De widder she try to
+git her to say she wouldn’ do it, but I never waited to hear de res’.  I
+lit out mighty quick, I tell you.
+
+“I tuck out en shin down de hill, en ‘spec to steal a skift ‘long de
+sho’ som’ers ‘bove de town, but dey wuz people a-stirring yit, so I hid
+in de ole tumble-down cooper-shop on de bank to wait for everybody to
+go ‘way. Well, I wuz dah all night.  Dey wuz somebody roun’ all de time.
+ ‘Long ‘bout six in de mawnin’ skifts begin to go by, en ‘bout eight er
+nine every skift dat went ‘long wuz talkin’ ‘bout how yo’ pap come over
+to de town en say you’s killed.  Dese las’ skifts wuz full o’ ladies en
+genlmen a-goin’ over for to see de place.  Sometimes dey’d pull up at
+de sho’ en take a res’ b’fo’ dey started acrost, so by de talk I got to
+know all ‘bout de killin’.  I ‘uz powerful sorry you’s killed, Huck, but
+I ain’t no mo’ now.
+
+“I laid dah under de shavin’s all day.  I ‘uz hungry, but I warn’t
+afeard; bekase I knowed ole missus en de widder wuz goin’ to start to
+de camp-meet’n’ right arter breakfas’ en be gone all day, en dey knows
+I goes off wid de cattle ‘bout daylight, so dey wouldn’ ‘spec to see me
+roun’ de place, en so dey wouldn’ miss me tell arter dark in de evenin’.
+De yuther servants wouldn’ miss me, kase dey’d shin out en take holiday
+soon as de ole folks ‘uz out’n de way.
+
+“Well, when it come dark I tuck out up de river road, en went ‘bout two
+mile er more to whah dey warn’t no houses.  I’d made up my mine ‘bout
+what I’s agwyne to do.  You see, ef I kep’ on tryin’ to git away afoot,
+de dogs ‘ud track me; ef I stole a skift to cross over, dey’d miss dat
+skift, you see, en dey’d know ‘bout whah I’d lan’ on de yuther side, en
+whah to pick up my track.  So I says, a raff is what I’s arter; it doan’
+_make_ no track.
+
+“I see a light a-comin’ roun’ de p’int bymeby, so I wade’ in en shove’
+a log ahead o’ me en swum more’n half way acrost de river, en got in
+‘mongst de drift-wood, en kep’ my head down low, en kinder swum agin de
+current tell de raff come along.  Den I swum to de stern uv it en tuck
+a-holt.  It clouded up en ‘uz pooty dark for a little while.  So I clumb
+up en laid down on de planks.  De men ‘uz all ‘way yonder in de middle,
+whah de lantern wuz.  De river wuz a-risin’, en dey wuz a good current;
+so I reck’n’d ‘at by fo’ in de mawnin’ I’d be twenty-five mile down de
+river, en den I’d slip in jis b’fo’ daylight en swim asho’, en take to
+de woods on de Illinois side.
+
+“But I didn’ have no luck.  When we ‘uz mos’ down to de head er de
+islan’ a man begin to come aft wid de lantern, I see it warn’t no use
+fer to wait, so I slid overboard en struck out fer de islan’.  Well, I
+had a notion I could lan’ mos’ anywhers, but I couldn’t--bank too bluff.
+ I ‘uz mos’ to de foot er de islan’ b’fo’ I found’ a good place.  I went
+into de woods en jedged I wouldn’ fool wid raffs no mo’, long as dey
+move de lantern roun’ so.  I had my pipe en a plug er dog-leg, en some
+matches in my cap, en dey warn’t wet, so I ‘uz all right.”
+
+“And so you ain’t had no meat nor bread to eat all this time?  Why
+didn’t you get mud-turkles?”
+
+“How you gwyne to git ‘m?  You can’t slip up on um en grab um; en how’s
+a body gwyne to hit um wid a rock?  How could a body do it in de night?
+ En I warn’t gwyne to show mysef on de bank in de daytime.”
+
+“Well, that’s so.  You’ve had to keep in the woods all the time, of
+course. Did you hear ‘em shooting the cannon?”
+
+“Oh, yes.  I knowed dey was arter you.  I see um go by heah--watched um
+thoo de bushes.”
+
+Some young birds come along, flying a yard or two at a time and
+lighting. Jim said it was a sign it was going to rain.  He said it was
+a sign when young chickens flew that way, and so he reckoned it was the
+same way when young birds done it.  I was going to catch some of them,
+but Jim wouldn’t let me.  He said it was death.  He said his father laid
+mighty sick once, and some of them catched a bird, and his old granny
+said his father would die, and he did.
+
+And Jim said you mustn’t count the things you are going to cook for
+dinner, because that would bring bad luck.  The same if you shook the
+table-cloth after sundown.  And he said if a man owned a beehive
+and that man died, the bees must be told about it before sun-up next
+morning, or else the bees would all weaken down and quit work and die.
+ Jim said bees wouldn’t sting idiots; but I didn’t believe that, because
+I had tried them lots of times myself, and they wouldn’t sting me.
+
+I had heard about some of these things before, but not all of them.  Jim
+knowed all kinds of signs.  He said he knowed most everything.  I said
+it looked to me like all the signs was about bad luck, and so I asked
+him if there warn’t any good-luck signs.  He says:
+
+“Mighty few--an’ _dey_ ain’t no use to a body.  What you want to know
+when good luck’s a-comin’ for?  Want to keep it off?”  And he said:  “Ef
+you’s got hairy arms en a hairy breas’, it’s a sign dat you’s agwyne
+to be rich. Well, dey’s some use in a sign like dat, ‘kase it’s so fur
+ahead. You see, maybe you’s got to be po’ a long time fust, en so you
+might git discourage’ en kill yo’sef ‘f you didn’ know by de sign dat
+you gwyne to be rich bymeby.”
+
+“Have you got hairy arms and a hairy breast, Jim?”
+
+“What’s de use to ax dat question?  Don’t you see I has?”
+
+“Well, are you rich?”
+
+“No, but I ben rich wunst, and gwyne to be rich agin.  Wunst I had
+foteen dollars, but I tuck to specalat’n’, en got busted out.”
+
+“What did you speculate in, Jim?”
+
+“Well, fust I tackled stock.”
+
+“What kind of stock?”
+
+“Why, live stock--cattle, you know.  I put ten dollars in a cow.  But
+I ain’ gwyne to resk no mo’ money in stock.  De cow up ‘n’ died on my
+han’s.”
+
+“So you lost the ten dollars.”
+
+“No, I didn’t lose it all.  I on’y los’ ‘bout nine of it.  I sole de
+hide en taller for a dollar en ten cents.”
+
+“You had five dollars and ten cents left.  Did you speculate any more?”
+
+“Yes.  You know that one-laigged nigger dat b’longs to old Misto
+Bradish? Well, he sot up a bank, en say anybody dat put in a dollar
+would git fo’ dollars mo’ at de en’ er de year.  Well, all de niggers
+went in, but dey didn’t have much.  I wuz de on’y one dat had much.  So
+I stuck out for mo’ dan fo’ dollars, en I said ‘f I didn’ git it I’d
+start a bank mysef. Well, o’ course dat nigger want’ to keep me out er
+de business, bekase he says dey warn’t business ‘nough for two banks, so
+he say I could put in my five dollars en he pay me thirty-five at de en’
+er de year.
+
+“So I done it.  Den I reck’n’d I’d inves’ de thirty-five dollars right
+off en keep things a-movin’.  Dey wuz a nigger name’ Bob, dat had
+ketched a wood-flat, en his marster didn’ know it; en I bought it off’n
+him en told him to take de thirty-five dollars when de en’ er de
+year come; but somebody stole de wood-flat dat night, en nex day de
+one-laigged nigger say de bank’s busted.  So dey didn’ none uv us git no
+money.”
+
+“What did you do with the ten cents, Jim?”
+
+“Well, I ‘uz gwyne to spen’ it, but I had a dream, en de dream tole me
+to give it to a nigger name’ Balum--Balum’s Ass dey call him for short;
+he’s one er dem chuckleheads, you know.  But he’s lucky, dey say, en I
+see I warn’t lucky.  De dream say let Balum inves’ de ten cents en he’d
+make a raise for me.  Well, Balum he tuck de money, en when he wuz in
+church he hear de preacher say dat whoever give to de po’ len’ to de
+Lord, en boun’ to git his money back a hund’d times.  So Balum he tuck
+en give de ten cents to de po’, en laid low to see what wuz gwyne to
+come of it.”
+
+“Well, what did come of it, Jim?”
+
+“Nuffn never come of it.  I couldn’ manage to k’leck dat money no way;
+en Balum he couldn’.  I ain’ gwyne to len’ no mo’ money ‘dout I see de
+security.  Boun’ to git yo’ money back a hund’d times, de preacher says!
+Ef I could git de ten _cents_ back, I’d call it squah, en be glad er de
+chanst.”
+
+“Well, it’s all right anyway, Jim, long as you’re going to be rich again
+some time or other.”
+
+“Yes; en I’s rich now, come to look at it.  I owns mysef, en I’s wuth
+eight hund’d dollars.  I wisht I had de money, I wouldn’ want no mo’.”
+
+
+
+
+CHAPTER IX.
+
+I wanted to go and look at a place right about the middle of the island
+that I’d found when I was exploring; so we started and soon got to it,
+because the island was only three miles long and a quarter of a mile
+wide.
+
+This place was a tolerable long, steep hill or ridge about forty foot
+high. We had a rough time getting to the top, the sides was so steep and
+the bushes so thick.  We tramped and clumb around all over it, and by
+and by found a good big cavern in the rock, most up to the top on the
+side towards Illinois.  The cavern was as big as two or three rooms
+bunched together, and Jim could stand up straight in it.  It was cool in
+there. Jim was for putting our traps in there right away, but I said we
+didn’t want to be climbing up and down there all the time.
+
+Jim said if we had the canoe hid in a good place, and had all the traps
+in the cavern, we could rush there if anybody was to come to the island,
+and they would never find us without dogs.  And, besides, he said them
+little birds had said it was going to rain, and did I want the things to
+get wet?
+
+So we went back and got the canoe, and paddled up abreast the cavern,
+and lugged all the traps up there.  Then we hunted up a place close by
+to hide the canoe in, amongst the thick willows.  We took some fish off
+of the lines and set them again, and begun to get ready for dinner.
+
+The door of the cavern was big enough to roll a hogshead in, and on one
+side of the door the floor stuck out a little bit, and was flat and a
+good place to build a fire on.  So we built it there and cooked dinner.
+
+We spread the blankets inside for a carpet, and eat our dinner in there.
+We put all the other things handy at the back of the cavern.  Pretty
+soon it darkened up, and begun to thunder and lighten; so the birds was
+right about it.  Directly it begun to rain, and it rained like all fury,
+too, and I never see the wind blow so.  It was one of these regular
+summer storms.  It would get so dark that it looked all blue-black
+outside, and lovely; and the rain would thrash along by so thick that
+the trees off a little ways looked dim and spider-webby; and here would
+come a blast of wind that would bend the trees down and turn up the
+pale underside of the leaves; and then a perfect ripper of a gust would
+follow along and set the branches to tossing their arms as if they
+was just wild; and next, when it was just about the bluest and
+blackest--_FST_! it was as bright as glory, and you’d have a little
+glimpse of tree-tops a-plunging about away off yonder in the storm,
+hundreds of yards further than you could see before; dark as sin again
+in a second, and now you’d hear the thunder let go with an awful crash,
+and then go rumbling, grumbling, tumbling, down the sky towards the
+under side of the world, like rolling empty barrels down stairs--where
+it’s long stairs and they bounce a good deal, you know.
+
+“Jim, this is nice,” I says.  “I wouldn’t want to be nowhere else but
+here. Pass me along another hunk of fish and some hot corn-bread.”
+
+“Well, you wouldn’t a ben here ‘f it hadn’t a ben for Jim.  You’d a ben
+down dah in de woods widout any dinner, en gittn’ mos’ drownded, too;
+dat you would, honey.  Chickens knows when it’s gwyne to rain, en so do
+de birds, chile.”
+
+The river went on raising and raising for ten or twelve days, till at
+last it was over the banks.  The water was three or four foot deep on
+the island in the low places and on the Illinois bottom.  On that side
+it was a good many miles wide, but on the Missouri side it was the same
+old distance across--a half a mile--because the Missouri shore was just a
+wall of high bluffs.
+
+Daytimes we paddled all over the island in the canoe, It was mighty cool
+and shady in the deep woods, even if the sun was blazing outside.  We
+went winding in and out amongst the trees, and sometimes the vines hung
+so thick we had to back away and go some other way.  Well, on every old
+broken-down tree you could see rabbits and snakes and such things; and
+when the island had been overflowed a day or two they got so tame, on
+account of being hungry, that you could paddle right up and put your
+hand on them if you wanted to; but not the snakes and turtles--they would
+slide off in the water.  The ridge our cavern was in was full of them.
+We could a had pets enough if we’d wanted them.
+
+One night we catched a little section of a lumber raft--nice pine planks.
+It was twelve foot wide and about fifteen or sixteen foot long, and
+the top stood above water six or seven inches--a solid, level floor.  We
+could see saw-logs go by in the daylight sometimes, but we let them go;
+we didn’t show ourselves in daylight.
+
+Another night when we was up at the head of the island, just before
+daylight, here comes a frame-house down, on the west side.  She was
+a two-story, and tilted over considerable.  We paddled out and got
+aboard--clumb in at an upstairs window.  But it was too dark to see yet,
+so we made the canoe fast and set in her to wait for daylight.
+
+The light begun to come before we got to the foot of the island.  Then
+we looked in at the window.  We could make out a bed, and a table, and
+two old chairs, and lots of things around about on the floor, and there
+was clothes hanging against the wall.  There was something laying on the
+floor in the far corner that looked like a man.  So Jim says:
+
+“Hello, you!”
+
+But it didn’t budge.  So I hollered again, and then Jim says:
+
+“De man ain’t asleep--he’s dead.  You hold still--I’ll go en see.”
+
+He went, and bent down and looked, and says:
+
+“It’s a dead man.  Yes, indeedy; naked, too.  He’s ben shot in de back.
+I reck’n he’s ben dead two er three days.  Come in, Huck, but doan’ look
+at his face--it’s too gashly.”
+
+I didn’t look at him at all.  Jim throwed some old rags over him, but
+he needn’t done it; I didn’t want to see him.  There was heaps of old
+greasy cards scattered around over the floor, and old whisky bottles,
+and a couple of masks made out of black cloth; and all over the walls
+was the ignorantest kind of words and pictures made with charcoal.
+ There was two old dirty calico dresses, and a sun-bonnet, and some
+women’s underclothes hanging against the wall, and some men’s clothing,
+too.  We put the lot into the canoe--it might come good.  There was a
+boy’s old speckled straw hat on the floor; I took that, too.  And there
+was a bottle that had had milk in it, and it had a rag stopper for a
+baby to suck.  We would a took the bottle, but it was broke.  There was
+a seedy old chest, and an old hair trunk with the hinges broke.  They
+stood open, but there warn’t nothing left in them that was any account.
+ The way things was scattered about we reckoned the people left in a
+hurry, and warn’t fixed so as to carry off most of their stuff.
+
+We got an old tin lantern, and a butcher-knife without any handle, and
+a bran-new Barlow knife worth two bits in any store, and a lot of tallow
+candles, and a tin candlestick, and a gourd, and a tin cup, and a ratty
+old bedquilt off the bed, and a reticule with needles and pins and
+beeswax and buttons and thread and all such truck in it, and a hatchet
+and some nails, and a fishline as thick as my little finger with some
+monstrous hooks on it, and a roll of buckskin, and a leather dog-collar,
+and a horseshoe, and some vials of medicine that didn’t have no label
+on them; and just as we was leaving I found a tolerable good curry-comb,
+and Jim he found a ratty old fiddle-bow, and a wooden leg.  The straps
+was broke off of it, but, barring that, it was a good enough leg, though
+it was too long for me and not long enough for Jim, and we couldn’t find
+the other one, though we hunted all around.
+
+And so, take it all around, we made a good haul.  When we was ready to
+shove off we was a quarter of a mile below the island, and it was pretty
+broad day; so I made Jim lay down in the canoe and cover up with the
+quilt, because if he set up people could tell he was a nigger a good
+ways off.  I paddled over to the Illinois shore, and drifted down most
+a half a mile doing it.  I crept up the dead water under the bank, and
+hadn’t no accidents and didn’t see nobody.  We got home all safe.
+
+
+
+
+CHAPTER X.
+
+AFTER breakfast I wanted to talk about the dead man and guess out how he
+come to be killed, but Jim didn’t want to.  He said it would fetch bad
+luck; and besides, he said, he might come and ha’nt us; he said a man
+that warn’t buried was more likely to go a-ha’nting around than one
+that was planted and comfortable.  That sounded pretty reasonable, so
+I didn’t say no more; but I couldn’t keep from studying over it and
+wishing I knowed who shot the man, and what they done it for.
+
+We rummaged the clothes we’d got, and found eight dollars in silver
+sewed up in the lining of an old blanket overcoat.  Jim said he reckoned
+the people in that house stole the coat, because if they’d a knowed the
+money was there they wouldn’t a left it.  I said I reckoned they killed
+him, too; but Jim didn’t want to talk about that.  I says:
+
+“Now you think it’s bad luck; but what did you say when I fetched in the
+snake-skin that I found on the top of the ridge day before yesterday?
+You said it was the worst bad luck in the world to touch a snake-skin
+with my hands.  Well, here’s your bad luck!  We’ve raked in all this
+truck and eight dollars besides.  I wish we could have some bad luck
+like this every day, Jim.”
+
+“Never you mind, honey, never you mind.  Don’t you git too peart.  It’s
+a-comin’.  Mind I tell you, it’s a-comin’.”
+
+It did come, too.  It was a Tuesday that we had that talk.  Well, after
+dinner Friday we was laying around in the grass at the upper end of the
+ridge, and got out of tobacco.  I went to the cavern to get some, and
+found a rattlesnake in there.  I killed him, and curled him up on the
+foot of Jim’s blanket, ever so natural, thinking there’d be some fun
+when Jim found him there.  Well, by night I forgot all about the snake,
+and when Jim flung himself down on the blanket while I struck a light
+the snake’s mate was there, and bit him.
+
+He jumped up yelling, and the first thing the light showed was the
+varmint curled up and ready for another spring.  I laid him out in a
+second with a stick, and Jim grabbed pap’s whisky-jug and begun to pour
+it down.
+
+He was barefooted, and the snake bit him right on the heel.  That all
+comes of my being such a fool as to not remember that wherever you leave
+a dead snake its mate always comes there and curls around it.  Jim told
+me to chop off the snake’s head and throw it away, and then skin the
+body and roast a piece of it.  I done it, and he eat it and said it
+would help cure him. He made me take off the rattles and tie them around
+his wrist, too.  He said that that would help.  Then I slid out quiet
+and throwed the snakes clear away amongst the bushes; for I warn’t going
+to let Jim find out it was all my fault, not if I could help it.
+
+Jim sucked and sucked at the jug, and now and then he got out of his
+head and pitched around and yelled; but every time he come to himself he
+went to sucking at the jug again.  His foot swelled up pretty big, and
+so did his leg; but by and by the drunk begun to come, and so I judged
+he was all right; but I’d druther been bit with a snake than pap’s
+whisky.
+
+Jim was laid up for four days and nights.  Then the swelling was all
+gone and he was around again.  I made up my mind I wouldn’t ever take
+a-holt of a snake-skin again with my hands, now that I see what had come
+of it. Jim said he reckoned I would believe him next time.  And he said
+that handling a snake-skin was such awful bad luck that maybe we hadn’t
+got to the end of it yet.  He said he druther see the new moon over his
+left shoulder as much as a thousand times than take up a snake-skin
+in his hand.  Well, I was getting to feel that way myself, though I’ve
+always reckoned that looking at the new moon over your left shoulder is
+one of the carelessest and foolishest things a body can do.  Old Hank
+Bunker done it once, and bragged about it; and in less than two years he
+got drunk and fell off of the shot-tower, and spread himself out so
+that he was just a kind of a layer, as you may say; and they slid him
+edgeways between two barn doors for a coffin, and buried him so, so
+they say, but I didn’t see it.  Pap told me.  But anyway it all come of
+looking at the moon that way, like a fool.
+
+Well, the days went along, and the river went down between its banks
+again; and about the first thing we done was to bait one of the big
+hooks with a skinned rabbit and set it and catch a catfish that was
+as big as a man, being six foot two inches long, and weighed over two
+hundred pounds. We couldn’t handle him, of course; he would a flung us
+into Illinois.  We just set there and watched him rip and tear around
+till he drownded.  We found a brass button in his stomach and a round
+ball, and lots of rubbage.  We split the ball open with the hatchet,
+and there was a spool in it.  Jim said he’d had it there a long time, to
+coat it over so and make a ball of it.  It was as big a fish as was ever
+catched in the Mississippi, I reckon.  Jim said he hadn’t ever seen
+a bigger one.  He would a been worth a good deal over at the village.
+ They peddle out such a fish as that by the pound in the market-house
+there; everybody buys some of him; his meat’s as white as snow and makes
+a good fry.
+
+Next morning I said it was getting slow and dull, and I wanted to get a
+stirring up some way.  I said I reckoned I would slip over the river and
+find out what was going on.  Jim liked that notion; but he said I
+must go in the dark and look sharp.  Then he studied it over and said,
+couldn’t I put on some of them old things and dress up like a girl?
+ That was a good notion, too.  So we shortened up one of the calico
+gowns, and I turned up my trouser-legs to my knees and got into it.  Jim
+hitched it behind with the hooks, and it was a fair fit.  I put on the
+sun-bonnet and tied it under my chin, and then for a body to look in
+and see my face was like looking down a joint of stove-pipe.  Jim said
+nobody would know me, even in the daytime, hardly.  I practiced around
+all day to get the hang of the things, and by and by I could do pretty
+well in them, only Jim said I didn’t walk like a girl; and he said
+I must quit pulling up my gown to get at my britches-pocket.  I took
+notice, and done better.
+
+I started up the Illinois shore in the canoe just after dark.
+
+I started across to the town from a little below the ferry-landing, and
+the drift of the current fetched me in at the bottom of the town.  I
+tied up and started along the bank.  There was a light burning in a
+little shanty that hadn’t been lived in for a long time, and I wondered
+who had took up quarters there.  I slipped up and peeped in at the
+window.  There was a woman about forty year old in there knitting by
+a candle that was on a pine table.  I didn’t know her face; she was a
+stranger, for you couldn’t start a face in that town that I didn’t know.
+ Now this was lucky, because I was weakening; I was getting afraid I had
+come; people might know my voice and find me out.  But if this woman had
+been in such a little town two days she could tell me all I wanted to
+know; so I knocked at the door, and made up my mind I wouldn’t forget I
+was a girl.
+
+
+
+
+CHAPTER XI.
+
+“COME in,” says the woman, and I did.  She says:  “Take a cheer.”
+
+I done it.  She looked me all over with her little shiny eyes, and says:
+
+“What might your name be?”
+
+“Sarah Williams.”
+
+“Where ‘bouts do you live?  In this neighborhood?’
+
+“No’m.  In Hookerville, seven mile below.  I’ve walked all the way and
+I’m all tired out.”
+
+“Hungry, too, I reckon.  I’ll find you something.”
+
+“No’m, I ain’t hungry.  I was so hungry I had to stop two miles below
+here at a farm; so I ain’t hungry no more.  It’s what makes me so late.
+My mother’s down sick, and out of money and everything, and I come to
+tell my uncle Abner Moore.  He lives at the upper end of the town, she
+says.  I hain’t ever been here before.  Do you know him?”
+
+“No; but I don’t know everybody yet.  I haven’t lived here quite two
+weeks. It’s a considerable ways to the upper end of the town.  You
+better stay here all night.  Take off your bonnet.”
+
+“No,” I says; “I’ll rest a while, I reckon, and go on.  I ain’t afeared
+of the dark.”
+
+She said she wouldn’t let me go by myself, but her husband would be in
+by and by, maybe in a hour and a half, and she’d send him along with me.
+Then she got to talking about her husband, and about her relations up
+the river, and her relations down the river, and about how much better
+off they used to was, and how they didn’t know but they’d made a mistake
+coming to our town, instead of letting well alone--and so on and so on,
+till I was afeard I had made a mistake coming to her to find out what
+was going on in the town; but by and by she dropped on to pap and the
+murder, and then I was pretty willing to let her clatter right along.
+ She told about me and Tom Sawyer finding the six thousand dollars (only
+she got it ten) and all about pap and what a hard lot he was, and what
+a hard lot I was, and at last she got down to where I was murdered.  I
+says:
+
+“Who done it?  We’ve heard considerable about these goings on down in
+Hookerville, but we don’t know who ‘twas that killed Huck Finn.”
+
+“Well, I reckon there’s a right smart chance of people _here_ that’d
+like to know who killed him.  Some think old Finn done it himself.”
+
+“No--is that so?”
+
+“Most everybody thought it at first.  He’ll never know how nigh he come
+to getting lynched.  But before night they changed around and judged it
+was done by a runaway nigger named Jim.”
+
+“Why _he_--”
+
+I stopped.  I reckoned I better keep still.  She run on, and never
+noticed I had put in at all:
+
+“The nigger run off the very night Huck Finn was killed.  So there’s a
+reward out for him--three hundred dollars.  And there’s a reward out for
+old Finn, too--two hundred dollars.  You see, he come to town the
+morning after the murder, and told about it, and was out with ‘em on the
+ferryboat hunt, and right away after he up and left.  Before night they
+wanted to lynch him, but he was gone, you see.  Well, next day they
+found out the nigger was gone; they found out he hadn’t ben seen sence
+ten o’clock the night the murder was done.  So then they put it on him,
+you see; and while they was full of it, next day, back comes old Finn,
+and went boo-hooing to Judge Thatcher to get money to hunt for the
+nigger all over Illinois with. The judge gave him some, and that evening
+he got drunk, and was around till after midnight with a couple of mighty
+hard-looking strangers, and then went off with them.  Well, he hain’t
+come back sence, and they ain’t looking for him back till this thing
+blows over a little, for people thinks now that he killed his boy and
+fixed things so folks would think robbers done it, and then he’d get
+Huck’s money without having to bother a long time with a lawsuit.
+ People do say he warn’t any too good to do it.  Oh, he’s sly, I reckon.
+ If he don’t come back for a year he’ll be all right.  You can’t prove
+anything on him, you know; everything will be quieted down then, and
+he’ll walk in Huck’s money as easy as nothing.”
+
+“Yes, I reckon so, ‘m.  I don’t see nothing in the way of it.  Has
+everybody quit thinking the nigger done it?”
+
+“Oh, no, not everybody.  A good many thinks he done it.  But they’ll get
+the nigger pretty soon now, and maybe they can scare it out of him.”
+
+“Why, are they after him yet?”
+
+“Well, you’re innocent, ain’t you!  Does three hundred dollars lay
+around every day for people to pick up?  Some folks think the nigger
+ain’t far from here.  I’m one of them--but I hain’t talked it around.  A
+few days ago I was talking with an old couple that lives next door in
+the log shanty, and they happened to say hardly anybody ever goes to
+that island over yonder that they call Jackson’s Island.  Don’t anybody
+live there? says I. No, nobody, says they.  I didn’t say any more, but
+I done some thinking.  I was pretty near certain I’d seen smoke over
+there, about the head of the island, a day or two before that, so I says
+to myself, like as not that nigger’s hiding over there; anyway, says
+I, it’s worth the trouble to give the place a hunt.  I hain’t seen any
+smoke sence, so I reckon maybe he’s gone, if it was him; but husband’s
+going over to see--him and another man.  He was gone up the river; but he
+got back to-day, and I told him as soon as he got here two hours ago.”
+
+I had got so uneasy I couldn’t set still.  I had to do something with my
+hands; so I took up a needle off of the table and went to threading
+it. My hands shook, and I was making a bad job of it.  When the woman
+stopped talking I looked up, and she was looking at me pretty curious
+and smiling a little.  I put down the needle and thread, and let on to
+be interested--and I was, too--and says:
+
+“Three hundred dollars is a power of money.  I wish my mother could get
+it. Is your husband going over there to-night?”
+
+“Oh, yes.  He went up-town with the man I was telling you of, to get a
+boat and see if they could borrow another gun.  They’ll go over after
+midnight.”
+
+“Couldn’t they see better if they was to wait till daytime?”
+
+“Yes.  And couldn’t the nigger see better, too?  After midnight he’ll
+likely be asleep, and they can slip around through the woods and hunt up
+his camp fire all the better for the dark, if he’s got one.”
+
+“I didn’t think of that.”
+
+The woman kept looking at me pretty curious, and I didn’t feel a bit
+comfortable.  Pretty soon she says,
+
+“What did you say your name was, honey?”
+
+“M--Mary Williams.”
+
+Somehow it didn’t seem to me that I said it was Mary before, so I didn’t
+look up--seemed to me I said it was Sarah; so I felt sort of cornered,
+and was afeared maybe I was looking it, too.  I wished the woman would
+say something more; the longer she set still the uneasier I was.  But
+now she says:
+
+“Honey, I thought you said it was Sarah when you first come in?”
+
+“Oh, yes’m, I did.  Sarah Mary Williams.  Sarah’s my first name.  Some
+calls me Sarah, some calls me Mary.”
+
+“Oh, that’s the way of it?”
+
+“Yes’m.”
+
+I was feeling better then, but I wished I was out of there, anyway.  I
+couldn’t look up yet.
+
+Well, the woman fell to talking about how hard times was, and how poor
+they had to live, and how the rats was as free as if they owned the
+place, and so forth and so on, and then I got easy again.  She was right
+about the rats. You’d see one stick his nose out of a hole in the corner
+every little while.  She said she had to have things handy to throw at
+them when she was alone, or they wouldn’t give her no peace.  She showed
+me a bar of lead twisted up into a knot, and said she was a good shot
+with it generly, but she’d wrenched her arm a day or two ago, and didn’t
+know whether she could throw true now.  But she watched for a chance,
+and directly banged away at a rat; but she missed him wide, and said
+“Ouch!” it hurt her arm so.  Then she told me to try for the next one.
+ I wanted to be getting away before the old man got back, but of course
+I didn’t let on.  I got the thing, and the first rat that showed his
+nose I let drive, and if he’d a stayed where he was he’d a been a
+tolerable sick rat.  She said that was first-rate, and she reckoned I
+would hive the next one.  She went and got the lump of lead and fetched
+it back, and brought along a hank of yarn which she wanted me to help
+her with.  I held up my two hands and she put the hank over them, and
+went on talking about her and her husband’s matters.  But she broke off
+to say:
+
+“Keep your eye on the rats.  You better have the lead in your lap,
+handy.”
+
+So she dropped the lump into my lap just at that moment, and I clapped
+my legs together on it and she went on talking.  But only about a
+minute. Then she took off the hank and looked me straight in the face,
+and very pleasant, and says:
+
+“Come, now, what’s your real name?”
+
+“Wh--what, mum?”
+
+“What’s your real name?  Is it Bill, or Tom, or Bob?--or what is it?”
+
+I reckon I shook like a leaf, and I didn’t know hardly what to do.  But
+I says:
+
+“Please to don’t poke fun at a poor girl like me, mum.  If I’m in the
+way here, I’ll--”
+
+“No, you won’t.  Set down and stay where you are.  I ain’t going to hurt
+you, and I ain’t going to tell on you, nuther.  You just tell me your
+secret, and trust me.  I’ll keep it; and, what’s more, I’ll help
+you. So’ll my old man if you want him to.  You see, you’re a runaway
+‘prentice, that’s all.  It ain’t anything.  There ain’t no harm in it.
+You’ve been treated bad, and you made up your mind to cut.  Bless you,
+child, I wouldn’t tell on you.  Tell me all about it now, that’s a good
+boy.”
+
+So I said it wouldn’t be no use to try to play it any longer, and I
+would just make a clean breast and tell her everything, but she musn’t
+go back on her promise.  Then I told her my father and mother was dead,
+and the law had bound me out to a mean old farmer in the country thirty
+mile back from the river, and he treated me so bad I couldn’t stand it
+no longer; he went away to be gone a couple of days, and so I took my
+chance and stole some of his daughter’s old clothes and cleared out, and
+I had been three nights coming the thirty miles.  I traveled nights,
+and hid daytimes and slept, and the bag of bread and meat I carried from
+home lasted me all the way, and I had a-plenty.  I said I believed my
+uncle Abner Moore would take care of me, and so that was why I struck
+out for this town of Goshen.
+
+“Goshen, child?  This ain’t Goshen.  This is St. Petersburg.  Goshen’s
+ten mile further up the river.  Who told you this was Goshen?”
+
+“Why, a man I met at daybreak this morning, just as I was going to turn
+into the woods for my regular sleep.  He told me when the roads forked I
+must take the right hand, and five mile would fetch me to Goshen.”
+
+“He was drunk, I reckon.  He told you just exactly wrong.”
+
+“Well, he did act like he was drunk, but it ain’t no matter now.  I got
+to be moving along.  I’ll fetch Goshen before daylight.”
+
+“Hold on a minute.  I’ll put you up a snack to eat.  You might want it.”
+
+So she put me up a snack, and says:
+
+“Say, when a cow’s laying down, which end of her gets up first?  Answer
+up prompt now--don’t stop to study over it.  Which end gets up first?”
+
+“The hind end, mum.”
+
+“Well, then, a horse?”
+
+“The for’rard end, mum.”
+
+“Which side of a tree does the moss grow on?”
+
+“North side.”
+
+“If fifteen cows is browsing on a hillside, how many of them eats with
+their heads pointed the same direction?”
+
+“The whole fifteen, mum.”
+
+“Well, I reckon you _have_ lived in the country.  I thought maybe you
+was trying to hocus me again.  What’s your real name, now?”
+
+“George Peters, mum.”
+
+“Well, try to remember it, George.  Don’t forget and tell me it’s
+Elexander before you go, and then get out by saying it’s George
+Elexander when I catch you.  And don’t go about women in that old
+calico.  You do a girl tolerable poor, but you might fool men, maybe.
+ Bless you, child, when you set out to thread a needle don’t hold the
+thread still and fetch the needle up to it; hold the needle still and
+poke the thread at it; that’s the way a woman most always does, but a
+man always does t’other way.  And when you throw at a rat or anything,
+hitch yourself up a tiptoe and fetch your hand up over your head as
+awkward as you can, and miss your rat about six or seven foot. Throw
+stiff-armed from the shoulder, like there was a pivot there for it to
+turn on, like a girl; not from the wrist and elbow, with your arm out
+to one side, like a boy.  And, mind you, when a girl tries to catch
+anything in her lap she throws her knees apart; she don’t clap them
+together, the way you did when you catched the lump of lead.  Why, I
+spotted you for a boy when you was threading the needle; and I contrived
+the other things just to make certain.  Now trot along to your uncle,
+Sarah Mary Williams George Elexander Peters, and if you get into trouble
+you send word to Mrs. Judith Loftus, which is me, and I’ll do what I can
+to get you out of it.  Keep the river road all the way, and next time
+you tramp take shoes and socks with you. The river road’s a rocky one,
+and your feet’ll be in a condition when you get to Goshen, I reckon.”
+
+I went up the bank about fifty yards, and then I doubled on my tracks
+and slipped back to where my canoe was, a good piece below the house.  I
+jumped in, and was off in a hurry.  I went up-stream far enough to
+make the head of the island, and then started across.  I took off the
+sun-bonnet, for I didn’t want no blinders on then.  When I was about the
+middle I heard the clock begin to strike, so I stops and listens; the
+sound come faint over the water but clear--eleven.  When I struck the
+head of the island I never waited to blow, though I was most winded, but
+I shoved right into the timber where my old camp used to be, and started
+a good fire there on a high and dry spot.
+
+Then I jumped in the canoe and dug out for our place, a mile and a half
+below, as hard as I could go.  I landed, and slopped through the timber
+and up the ridge and into the cavern.  There Jim laid, sound asleep on
+the ground.  I roused him out and says:
+
+“Git up and hump yourself, Jim!  There ain’t a minute to lose.  They’re
+after us!”
+
+Jim never asked no questions, he never said a word; but the way he
+worked for the next half an hour showed about how he was scared.  By
+that time everything we had in the world was on our raft, and she was
+ready to be shoved out from the willow cove where she was hid.  We
+put out the camp fire at the cavern the first thing, and didn’t show a
+candle outside after that.
+
+I took the canoe out from the shore a little piece, and took a look;
+but if there was a boat around I couldn’t see it, for stars and shadows
+ain’t good to see by.  Then we got out the raft and slipped along down
+in the shade, past the foot of the island dead still--never saying a
+word.
+
+
+
+
+CHAPTER XII.
+
+IT must a been close on to one o’clock when we got below the island at
+last, and the raft did seem to go mighty slow.  If a boat was to come
+along we was going to take to the canoe and break for the Illinois
+shore; and it was well a boat didn’t come, for we hadn’t ever thought to
+put the gun in the canoe, or a fishing-line, or anything to eat.  We
+was in ruther too much of a sweat to think of so many things.  It warn’t
+good judgment to put _everything_ on the raft.
+
+If the men went to the island I just expect they found the camp fire I
+built, and watched it all night for Jim to come.  Anyways, they stayed
+away from us, and if my building the fire never fooled them it warn’t no
+fault of mine.  I played it as low down on them as I could.
+
+When the first streak of day began to show we tied up to a towhead in a
+big bend on the Illinois side, and hacked off cottonwood branches with
+the hatchet, and covered up the raft with them so she looked like there
+had been a cave-in in the bank there.  A tow-head is a sandbar that has
+cottonwoods on it as thick as harrow-teeth.
+
+We had mountains on the Missouri shore and heavy timber on the Illinois
+side, and the channel was down the Missouri shore at that place, so we
+warn’t afraid of anybody running across us.  We laid there all day,
+and watched the rafts and steamboats spin down the Missouri shore, and
+up-bound steamboats fight the big river in the middle.  I told Jim all
+about the time I had jabbering with that woman; and Jim said she was
+a smart one, and if she was to start after us herself she wouldn’t set
+down and watch a camp fire--no, sir, she’d fetch a dog.  Well, then, I
+said, why couldn’t she tell her husband to fetch a dog?  Jim said he
+bet she did think of it by the time the men was ready to start, and he
+believed they must a gone up-town to get a dog and so they lost all that
+time, or else we wouldn’t be here on a towhead sixteen or seventeen mile
+below the village--no, indeedy, we would be in that same old town again.
+ So I said I didn’t care what was the reason they didn’t get us as long
+as they didn’t.
+
+When it was beginning to come on dark we poked our heads out of the
+cottonwood thicket, and looked up and down and across; nothing in sight;
+so Jim took up some of the top planks of the raft and built a snug
+wigwam to get under in blazing weather and rainy, and to keep the things
+dry. Jim made a floor for the wigwam, and raised it a foot or more above
+the level of the raft, so now the blankets and all the traps was out of
+reach of steamboat waves.  Right in the middle of the wigwam we made a
+layer of dirt about five or six inches deep with a frame around it for
+to hold it to its place; this was to build a fire on in sloppy weather
+or chilly; the wigwam would keep it from being seen.  We made an extra
+steering-oar, too, because one of the others might get broke on a snag
+or something. We fixed up a short forked stick to hang the old lantern
+on, because we must always light the lantern whenever we see a steamboat
+coming down-stream, to keep from getting run over; but we wouldn’t have
+to light it for up-stream boats unless we see we was in what they call
+a “crossing”; for the river was pretty high yet, very low banks being
+still a little under water; so up-bound boats didn’t always run the
+channel, but hunted easy water.
+
+This second night we run between seven and eight hours, with a current
+that was making over four mile an hour.  We catched fish and talked,
+and we took a swim now and then to keep off sleepiness.  It was kind of
+solemn, drifting down the big, still river, laying on our backs looking
+up at the stars, and we didn’t ever feel like talking loud, and it
+warn’t often that we laughed--only a little kind of a low chuckle.  We
+had mighty good weather as a general thing, and nothing ever happened to
+us at all--that night, nor the next, nor the next.
+
+Every night we passed towns, some of them away up on black hillsides,
+nothing but just a shiny bed of lights; not a house could you see.  The
+fifth night we passed St. Louis, and it was like the whole world lit up.
+In St. Petersburg they used to say there was twenty or thirty thousand
+people in St. Louis, but I never believed it till I see that wonderful
+spread of lights at two o’clock that still night.  There warn’t a sound
+there; everybody was asleep.
+
+Every night now I used to slip ashore towards ten o’clock at some little
+village, and buy ten or fifteen cents’ worth of meal or bacon or other
+stuff to eat; and sometimes I lifted a chicken that warn’t roosting
+comfortable, and took him along.  Pap always said, take a chicken when
+you get a chance, because if you don’t want him yourself you can easy
+find somebody that does, and a good deed ain’t ever forgot.  I never see
+pap when he didn’t want the chicken himself, but that is what he used to
+say, anyway.
+
+Mornings before daylight I slipped into cornfields and borrowed a
+watermelon, or a mushmelon, or a punkin, or some new corn, or things of
+that kind.  Pap always said it warn’t no harm to borrow things if you
+was meaning to pay them back some time; but the widow said it warn’t
+anything but a soft name for stealing, and no decent body would do it.
+ Jim said he reckoned the widow was partly right and pap was partly
+right; so the best way would be for us to pick out two or three things
+from the list and say we wouldn’t borrow them any more--then he reckoned
+it wouldn’t be no harm to borrow the others.  So we talked it over all
+one night, drifting along down the river, trying to make up our minds
+whether to drop the watermelons, or the cantelopes, or the mushmelons,
+or what.  But towards daylight we got it all settled satisfactory, and
+concluded to drop crabapples and p’simmons.  We warn’t feeling just
+right before that, but it was all comfortable now.  I was glad the way
+it come out, too, because crabapples ain’t ever good, and the p’simmons
+wouldn’t be ripe for two or three months yet.
+
+We shot a water-fowl now and then that got up too early in the morning
+or didn’t go to bed early enough in the evening.  Take it all round, we
+lived pretty high.
+
+The fifth night below St. Louis we had a big storm after midnight, with
+a power of thunder and lightning, and the rain poured down in a solid
+sheet. We stayed in the wigwam and let the raft take care of itself.
+When the lightning glared out we could see a big straight river ahead,
+and high, rocky bluffs on both sides.  By and by says I, “Hel-_lo_, Jim,
+looky yonder!” It was a steamboat that had killed herself on a rock.
+ We was drifting straight down for her.  The lightning showed her very
+distinct.  She was leaning over, with part of her upper deck above
+water, and you could see every little chimbly-guy clean and clear, and a
+chair by the big bell, with an old slouch hat hanging on the back of it,
+when the flashes come.
+
+Well, it being away in the night and stormy, and all so mysterious-like,
+I felt just the way any other boy would a felt when I see that wreck
+laying there so mournful and lonesome in the middle of the river.  I
+wanted to get aboard of her and slink around a little, and see what
+there was there.  So I says:
+
+“Le’s land on her, Jim.”
+
+But Jim was dead against it at first.  He says:
+
+“I doan’ want to go fool’n ‘long er no wrack.  We’s doin’ blame’ well,
+en we better let blame’ well alone, as de good book says.  Like as not
+dey’s a watchman on dat wrack.”
+
+“Watchman your grandmother,” I says; “there ain’t nothing to watch but
+the texas and the pilot-house; and do you reckon anybody’s going to resk
+his life for a texas and a pilot-house such a night as this, when
+it’s likely to break up and wash off down the river any minute?”  Jim
+couldn’t say nothing to that, so he didn’t try.  “And besides,” I says,
+“we might borrow something worth having out of the captain’s stateroom.
+ Seegars, I bet you--and cost five cents apiece, solid cash.  Steamboat
+captains is always rich, and get sixty dollars a month, and _they_ don’t
+care a cent what a thing costs, you know, long as they want it.  Stick a
+candle in your pocket; I can’t rest, Jim, till we give her a rummaging.
+ Do you reckon Tom Sawyer would ever go by this thing?  Not for pie, he
+wouldn’t. He’d call it an adventure--that’s what he’d call it; and he’d
+land on that wreck if it was his last act.  And wouldn’t he throw style
+into it?--wouldn’t he spread himself, nor nothing?  Why, you’d think it
+was Christopher C’lumbus discovering Kingdom-Come.  I wish Tom Sawyer
+_was_ here.”
+
+Jim he grumbled a little, but give in.  He said we mustn’t talk any more
+than we could help, and then talk mighty low.  The lightning showed us
+the wreck again just in time, and we fetched the stabboard derrick, and
+made fast there.
+
+The deck was high out here.  We went sneaking down the slope of it to
+labboard, in the dark, towards the texas, feeling our way slow with our
+feet, and spreading our hands out to fend off the guys, for it was so
+dark we couldn’t see no sign of them.  Pretty soon we struck the forward
+end of the skylight, and clumb on to it; and the next step fetched us in
+front of the captain’s door, which was open, and by Jimminy, away down
+through the texas-hall we see a light! and all in the same second we
+seem to hear low voices in yonder!
+
+Jim whispered and said he was feeling powerful sick, and told me to come
+along.  I says, all right, and was going to start for the raft; but just
+then I heard a voice wail out and say:
+
+“Oh, please don’t, boys; I swear I won’t ever tell!”
+
+Another voice said, pretty loud:
+
+“It’s a lie, Jim Turner.  You’ve acted this way before.  You always want
+more’n your share of the truck, and you’ve always got it, too, because
+you’ve swore ‘t if you didn’t you’d tell.  But this time you’ve said
+it jest one time too many.  You’re the meanest, treacherousest hound in
+this country.”
+
+By this time Jim was gone for the raft.  I was just a-biling with
+curiosity; and I says to myself, Tom Sawyer wouldn’t back out now,
+and so I won’t either; I’m a-going to see what’s going on here.  So I
+dropped on my hands and knees in the little passage, and crept aft
+in the dark till there warn’t but one stateroom betwixt me and the
+cross-hall of the texas.  Then in there I see a man stretched on the
+floor and tied hand and foot, and two men standing over him, and one
+of them had a dim lantern in his hand, and the other one had a pistol.
+ This one kept pointing the pistol at the man’s head on the floor, and
+saying:
+
+“I’d _like_ to!  And I orter, too--a mean skunk!”
+
+The man on the floor would shrivel up and say, “Oh, please don’t, Bill;
+I hain’t ever goin’ to tell.”
+
+And every time he said that the man with the lantern would laugh and
+say:
+
+“‘Deed you _ain’t!_  You never said no truer thing ‘n that, you bet
+you.” And once he said:  “Hear him beg! and yit if we hadn’t got the
+best of him and tied him he’d a killed us both.  And what _for_?  Jist
+for noth’n. Jist because we stood on our _rights_--that’s what for.  But
+I lay you ain’t a-goin’ to threaten nobody any more, Jim Turner.  Put
+_up_ that pistol, Bill.”
+
+Bill says:
+
+“I don’t want to, Jake Packard.  I’m for killin’ him--and didn’t he kill
+old Hatfield jist the same way--and don’t he deserve it?”
+
+“But I don’t _want_ him killed, and I’ve got my reasons for it.”
+
+“Bless yo’ heart for them words, Jake Packard!  I’ll never forgit you
+long’s I live!” says the man on the floor, sort of blubbering.
+
+Packard didn’t take no notice of that, but hung up his lantern on a nail
+and started towards where I was there in the dark, and motioned Bill
+to come.  I crawfished as fast as I could about two yards, but the boat
+slanted so that I couldn’t make very good time; so to keep from getting
+run over and catched I crawled into a stateroom on the upper side.
+ The man came a-pawing along in the dark, and when Packard got to my
+stateroom, he says:
+
+“Here--come in here.”
+
+And in he come, and Bill after him.  But before they got in I was up
+in the upper berth, cornered, and sorry I come.  Then they stood there,
+with their hands on the ledge of the berth, and talked.  I couldn’t see
+them, but I could tell where they was by the whisky they’d been having.
+ I was glad I didn’t drink whisky; but it wouldn’t made much difference
+anyway, because most of the time they couldn’t a treed me because I
+didn’t breathe.  I was too scared.  And, besides, a body _couldn’t_
+breathe and hear such talk.  They talked low and earnest.  Bill wanted
+to kill Turner.  He says:
+
+“He’s said he’ll tell, and he will.  If we was to give both our shares
+to him _now_ it wouldn’t make no difference after the row and the way
+we’ve served him.  Shore’s you’re born, he’ll turn State’s evidence; now
+you hear _me_.  I’m for putting him out of his troubles.”
+
+“So’m I,” says Packard, very quiet.
+
+“Blame it, I’d sorter begun to think you wasn’t.  Well, then, that’s all
+right.  Le’s go and do it.”
+
+“Hold on a minute; I hain’t had my say yit.  You listen to me.
+Shooting’s good, but there’s quieter ways if the thing’s _got_ to be
+done. But what I say is this:  it ain’t good sense to go court’n around
+after a halter if you can git at what you’re up to in some way that’s
+jist as good and at the same time don’t bring you into no resks.  Ain’t
+that so?”
+
+“You bet it is.  But how you goin’ to manage it this time?”
+
+“Well, my idea is this:  we’ll rustle around and gather up whatever
+pickins we’ve overlooked in the staterooms, and shove for shore and hide
+the truck. Then we’ll wait.  Now I say it ain’t a-goin’ to be more’n two
+hours befo’ this wrack breaks up and washes off down the river.  See?
+He’ll be drownded, and won’t have nobody to blame for it but his own
+self.  I reckon that’s a considerble sight better ‘n killin’ of him.
+ I’m unfavorable to killin’ a man as long as you can git aroun’ it; it
+ain’t good sense, it ain’t good morals.  Ain’t I right?”
+
+“Yes, I reck’n you are.  But s’pose she _don’t_ break up and wash off?”
+
+“Well, we can wait the two hours anyway and see, can’t we?”
+
+“All right, then; come along.”
+
+So they started, and I lit out, all in a cold sweat, and scrambled
+forward. It was dark as pitch there; but I said, in a kind of a coarse
+whisper, “Jim!” and he answered up, right at my elbow, with a sort of a
+moan, and I says:
+
+“Quick, Jim, it ain’t no time for fooling around and moaning; there’s a
+gang of murderers in yonder, and if we don’t hunt up their boat and set
+her drifting down the river so these fellows can’t get away from the
+wreck there’s one of ‘em going to be in a bad fix.  But if we find their
+boat we can put _all_ of ‘em in a bad fix--for the sheriff ‘ll get ‘em.
+Quick--hurry!  I’ll hunt the labboard side, you hunt the stabboard. You
+start at the raft, and--”
+
+“Oh, my lordy, lordy!  _raf’_?  Dey ain’ no raf’ no mo’; she done broke
+loose en gone I--en here we is!”
+
+
+
+
+CHAPTER XIII.
+
+WELL, I catched my breath and most fainted.  Shut up on a wreck with
+such a gang as that!  But it warn’t no time to be sentimentering.  We’d
+_got_ to find that boat now--had to have it for ourselves.  So we went
+a-quaking and shaking down the stabboard side, and slow work it was,
+too--seemed a week before we got to the stern.  No sign of a boat.  Jim
+said he didn’t believe he could go any further--so scared he hadn’t
+hardly any strength left, he said.  But I said, come on, if we get left
+on this wreck we are in a fix, sure.  So on we prowled again.  We struck
+for the stern of the texas, and found it, and then scrabbled along
+forwards on the skylight, hanging on from shutter to shutter, for the
+edge of the skylight was in the water.  When we got pretty close to the
+cross-hall door there was the skiff, sure enough!  I could just barely
+see her.  I felt ever so thankful.  In another second I would a been
+aboard of her, but just then the door opened.  One of the men stuck his
+head out only about a couple of foot from me, and I thought I was gone;
+but he jerked it in again, and says:
+
+“Heave that blame lantern out o’ sight, Bill!”
+
+He flung a bag of something into the boat, and then got in himself and
+set down.  It was Packard.  Then Bill _he_ come out and got in.  Packard
+says, in a low voice:
+
+“All ready--shove off!”
+
+I couldn’t hardly hang on to the shutters, I was so weak.  But Bill
+says:
+
+“Hold on--‘d you go through him?”
+
+“No.  Didn’t you?”
+
+“No.  So he’s got his share o’ the cash yet.”
+
+“Well, then, come along; no use to take truck and leave money.”
+
+“Say, won’t he suspicion what we’re up to?”
+
+“Maybe he won’t.  But we got to have it anyway. Come along.”
+
+So they got out and went in.
+
+The door slammed to because it was on the careened side; and in a half
+second I was in the boat, and Jim come tumbling after me.  I out with my
+knife and cut the rope, and away we went!
+
+We didn’t touch an oar, and we didn’t speak nor whisper, nor hardly even
+breathe.  We went gliding swift along, dead silent, past the tip of the
+paddle-box, and past the stern; then in a second or two more we was a
+hundred yards below the wreck, and the darkness soaked her up, every
+last sign of her, and we was safe, and knowed it.
+
+When we was three or four hundred yards down-stream we see the lantern
+show like a little spark at the texas door for a second, and we knowed
+by that that the rascals had missed their boat, and was beginning to
+understand that they was in just as much trouble now as Jim Turner was.
+
+Then Jim manned the oars, and we took out after our raft.  Now was the
+first time that I begun to worry about the men--I reckon I hadn’t
+had time to before.  I begun to think how dreadful it was, even for
+murderers, to be in such a fix.  I says to myself, there ain’t no
+telling but I might come to be a murderer myself yet, and then how would
+I like it?  So says I to Jim:
+
+“The first light we see we’ll land a hundred yards below it or above
+it, in a place where it’s a good hiding-place for you and the skiff, and
+then I’ll go and fix up some kind of a yarn, and get somebody to go for
+that gang and get them out of their scrape, so they can be hung when
+their time comes.”
+
+But that idea was a failure; for pretty soon it begun to storm again,
+and this time worse than ever.  The rain poured down, and never a light
+showed; everybody in bed, I reckon.  We boomed along down the river,
+watching for lights and watching for our raft.  After a long time the
+rain let up, but the clouds stayed, and the lightning kept whimpering,
+and by and by a flash showed us a black thing ahead, floating, and we
+made for it.
+
+It was the raft, and mighty glad was we to get aboard of it again.  We
+seen a light now away down to the right, on shore.  So I said I would
+go for it. The skiff was half full of plunder which that gang had stole
+there on the wreck.  We hustled it on to the raft in a pile, and I told
+Jim to float along down, and show a light when he judged he had gone
+about two mile, and keep it burning till I come; then I manned my oars
+and shoved for the light.  As I got down towards it three or four more
+showed--up on a hillside.  It was a village.  I closed in above the shore
+light, and laid on my oars and floated.  As I went by I see it was a
+lantern hanging on the jackstaff of a double-hull ferryboat.  I skimmed
+around for the watchman, a-wondering whereabouts he slept; and by and
+by I found him roosting on the bitts forward, with his head down between
+his knees.  I gave his shoulder two or three little shoves, and begun to
+cry.
+
+He stirred up in a kind of a startlish way; but when he see it was only
+me he took a good gap and stretch, and then he says:
+
+“Hello, what’s up?  Don’t cry, bub.  What’s the trouble?”
+
+I says:
+
+“Pap, and mam, and sis, and--”
+
+Then I broke down.  He says:
+
+“Oh, dang it now, _don’t_ take on so; we all has to have our troubles,
+and this ‘n ‘ll come out all right.  What’s the matter with ‘em?”
+
+“They’re--they’re--are you the watchman of the boat?”
+
+“Yes,” he says, kind of pretty-well-satisfied like.  “I’m the captain
+and the owner and the mate and the pilot and watchman and head
+deck-hand; and sometimes I’m the freight and passengers.  I ain’t as
+rich as old Jim Hornback, and I can’t be so blame’ generous and good
+to Tom, Dick, and Harry as what he is, and slam around money the way he
+does; but I’ve told him a many a time ‘t I wouldn’t trade places with
+him; for, says I, a sailor’s life’s the life for me, and I’m derned if
+_I’d_ live two mile out o’ town, where there ain’t nothing ever goin’
+on, not for all his spondulicks and as much more on top of it.  Says I--”
+
+I broke in and says:
+
+“They’re in an awful peck of trouble, and--”
+
+“_Who_ is?”
+
+“Why, pap and mam and sis and Miss Hooker; and if you’d take your
+ferryboat and go up there--”
+
+“Up where?  Where are they?”
+
+“On the wreck.”
+
+“What wreck?”
+
+“Why, there ain’t but one.”
+
+“What, you don’t mean the Walter Scott?”
+
+“Yes.”
+
+“Good land! what are they doin’ _there_, for gracious sakes?”
+
+“Well, they didn’t go there a-purpose.”
+
+“I bet they didn’t!  Why, great goodness, there ain’t no chance for ‘em
+if they don’t git off mighty quick!  Why, how in the nation did they
+ever git into such a scrape?”
+
+“Easy enough.  Miss Hooker was a-visiting up there to the town--”
+
+“Yes, Booth’s Landing--go on.”
+
+“She was a-visiting there at Booth’s Landing, and just in the edge of
+the evening she started over with her nigger woman in the horse-ferry
+to stay all night at her friend’s house, Miss What-you-may-call-her I
+disremember her name--and they lost their steering-oar, and swung
+around and went a-floating down, stern first, about two mile, and
+saddle-baggsed on the wreck, and the ferryman and the nigger woman and
+the horses was all lost, but Miss Hooker she made a grab and got aboard
+the wreck.  Well, about an hour after dark we come along down in our
+trading-scow, and it was so dark we didn’t notice the wreck till we was
+right on it; and so _we_ saddle-baggsed; but all of us was saved but
+Bill Whipple--and oh, he _was_ the best cretur!--I most wish ‘t it had
+been me, I do.”
+
+“My George!  It’s the beatenest thing I ever struck.  And _then_ what
+did you all do?”
+
+“Well, we hollered and took on, but it’s so wide there we couldn’t
+make nobody hear.  So pap said somebody got to get ashore and get help
+somehow. I was the only one that could swim, so I made a dash for it,
+and Miss Hooker she said if I didn’t strike help sooner, come here and
+hunt up her uncle, and he’d fix the thing.  I made the land about a mile
+below, and been fooling along ever since, trying to get people to do
+something, but they said, ‘What, in such a night and such a current?
+There ain’t no sense in it; go for the steam ferry.’  Now if you’ll go
+and--”
+
+“By Jackson, I’d _like_ to, and, blame it, I don’t know but I will; but
+who in the dingnation’s a-going’ to _pay_ for it?  Do you reckon your
+pap--”
+
+“Why _that’s_ all right.  Miss Hooker she tole me, _particular_, that
+her uncle Hornback--”
+
+“Great guns! is _he_ her uncle?  Looky here, you break for that light
+over yonder-way, and turn out west when you git there, and about a
+quarter of a mile out you’ll come to the tavern; tell ‘em to dart you
+out to Jim Hornback’s, and he’ll foot the bill.  And don’t you fool
+around any, because he’ll want to know the news.  Tell him I’ll have
+his niece all safe before he can get to town.  Hump yourself, now; I’m
+a-going up around the corner here to roust out my engineer.”
+
+I struck for the light, but as soon as he turned the corner I went back
+and got into my skiff and bailed her out, and then pulled up shore in
+the easy water about six hundred yards, and tucked myself in among
+some woodboats; for I couldn’t rest easy till I could see the ferryboat
+start. But take it all around, I was feeling ruther comfortable on
+accounts of taking all this trouble for that gang, for not many would
+a done it.  I wished the widow knowed about it.  I judged she would be
+proud of me for helping these rapscallions, because rapscallions and
+dead beats is the kind the widow and good people takes the most interest
+in.
+
+Well, before long here comes the wreck, dim and dusky, sliding along
+down! A kind of cold shiver went through me, and then I struck out for
+her.  She was very deep, and I see in a minute there warn’t much chance
+for anybody being alive in her.  I pulled all around her and hollered
+a little, but there wasn’t any answer; all dead still.  I felt a little
+bit heavy-hearted about the gang, but not much, for I reckoned if they
+could stand it I could.
+
+Then here comes the ferryboat; so I shoved for the middle of the river
+on a long down-stream slant; and when I judged I was out of eye-reach
+I laid on my oars, and looked back and see her go and smell around the
+wreck for Miss Hooker’s remainders, because the captain would know her
+uncle Hornback would want them; and then pretty soon the ferryboat give
+it up and went for the shore, and I laid into my work and went a-booming
+down the river.
+
+It did seem a powerful long time before Jim’s light showed up; and when
+it did show it looked like it was a thousand mile off.  By the time I
+got there the sky was beginning to get a little gray in the east; so we
+struck for an island, and hid the raft, and sunk the skiff, and turned
+in and slept like dead people.
+
+
+
+
+CHAPTER XIV.
+
+BY and by, when we got up, we turned over the truck the gang had stole
+off of the wreck, and found boots, and blankets, and clothes, and all
+sorts of other things, and a lot of books, and a spyglass, and three
+boxes of seegars.  We hadn’t ever been this rich before in neither of
+our lives.  The seegars was prime.  We laid off all the afternoon in the
+woods talking, and me reading the books, and having a general good
+time. I told Jim all about what happened inside the wreck and at the
+ferryboat, and I said these kinds of things was adventures; but he said
+he didn’t want no more adventures.  He said that when I went in the
+texas and he crawled back to get on the raft and found her gone he
+nearly died, because he judged it was all up with _him_ anyway it could
+be fixed; for if he didn’t get saved he would get drownded; and if he
+did get saved, whoever saved him would send him back home so as to get
+the reward, and then Miss Watson would sell him South, sure.  Well, he
+was right; he was most always right; he had an uncommon level head for a
+nigger.
+
+I read considerable to Jim about kings and dukes and earls and such, and
+how gaudy they dressed, and how much style they put on, and called each
+other your majesty, and your grace, and your lordship, and so on, ‘stead
+of mister; and Jim’s eyes bugged out, and he was interested.  He says:
+
+“I didn’ know dey was so many un um.  I hain’t hearn ‘bout none un um,
+skasely, but ole King Sollermun, onless you counts dem kings dat’s in a
+pack er k’yards.  How much do a king git?”
+
+“Get?”  I says; “why, they get a thousand dollars a month if they want
+it; they can have just as much as they want; everything belongs to
+them.”
+
+“_Ain’_ dat gay?  En what dey got to do, Huck?”
+
+“_They_ don’t do nothing!  Why, how you talk! They just set around.”
+
+“No; is dat so?”
+
+“Of course it is.  They just set around--except, maybe, when there’s a
+war; then they go to the war.  But other times they just lazy around; or
+go hawking--just hawking and sp--Sh!--d’ you hear a noise?”
+
+We skipped out and looked; but it warn’t nothing but the flutter of a
+steamboat’s wheel away down, coming around the point; so we come back.
+
+“Yes,” says I, “and other times, when things is dull, they fuss with the
+parlyment; and if everybody don’t go just so he whacks their heads off.
+But mostly they hang round the harem.”
+
+“Roun’ de which?”
+
+“Harem.”
+
+“What’s de harem?”
+
+“The place where he keeps his wives.  Don’t you know about the harem?
+Solomon had one; he had about a million wives.”
+
+“Why, yes, dat’s so; I--I’d done forgot it.  A harem’s a bo’d’n-house, I
+reck’n.  Mos’ likely dey has rackety times in de nussery.  En I reck’n
+de wives quarrels considable; en dat ‘crease de racket.  Yit dey say
+Sollermun de wises’ man dat ever live’.  I doan’ take no stock in
+dat. Bekase why: would a wise man want to live in de mids’ er sich a
+blim-blammin’ all de time?  No--‘deed he wouldn’t.  A wise man ‘ud take
+en buil’ a biler-factry; en den he could shet _down_ de biler-factry
+when he want to res’.”
+
+“Well, but he _was_ the wisest man, anyway; because the widow she told
+me so, her own self.”
+
+“I doan k’yer what de widder say, he _warn’t_ no wise man nuther.  He
+had some er de dad-fetchedes’ ways I ever see.  Does you know ‘bout dat
+chile dat he ‘uz gwyne to chop in two?”
+
+“Yes, the widow told me all about it.”
+
+“_Well_, den!  Warn’ dat de beatenes’ notion in de worl’?  You jes’
+take en look at it a minute.  Dah’s de stump, dah--dat’s one er de women;
+heah’s you--dat’s de yuther one; I’s Sollermun; en dish yer dollar bill’s
+de chile.  Bofe un you claims it.  What does I do?  Does I shin aroun’
+mongs’ de neighbors en fine out which un you de bill _do_ b’long to, en
+han’ it over to de right one, all safe en soun’, de way dat anybody dat
+had any gumption would?  No; I take en whack de bill in _two_, en give
+half un it to you, en de yuther half to de yuther woman.  Dat’s de way
+Sollermun was gwyne to do wid de chile.  Now I want to ast you:  what’s
+de use er dat half a bill?--can’t buy noth’n wid it.  En what use is a
+half a chile?  I wouldn’ give a dern for a million un um.”
+
+“But hang it, Jim, you’ve clean missed the point--blame it, you’ve missed
+it a thousand mile.”
+
+“Who?  Me?  Go ‘long.  Doan’ talk to me ‘bout yo’ pints.  I reck’n I
+knows sense when I sees it; en dey ain’ no sense in sich doin’s as
+dat. De ‘spute warn’t ‘bout a half a chile, de ‘spute was ‘bout a whole
+chile; en de man dat think he kin settle a ‘spute ‘bout a whole chile
+wid a half a chile doan’ know enough to come in out’n de rain.  Doan’
+talk to me ‘bout Sollermun, Huck, I knows him by de back.”
+
+“But I tell you you don’t get the point.”
+
+“Blame de point!  I reck’n I knows what I knows.  En mine you, de _real_
+pint is down furder--it’s down deeper.  It lays in de way Sollermun was
+raised.  You take a man dat’s got on’y one or two chillen; is dat man
+gwyne to be waseful o’ chillen?  No, he ain’t; he can’t ‘ford it.  _He_
+know how to value ‘em.  But you take a man dat’s got ‘bout five million
+chillen runnin’ roun’ de house, en it’s diffunt.  _He_ as soon chop a
+chile in two as a cat. Dey’s plenty mo’.  A chile er two, mo’ er less,
+warn’t no consekens to Sollermun, dad fatch him!”
+
+I never see such a nigger.  If he got a notion in his head once, there
+warn’t no getting it out again.  He was the most down on Solomon of
+any nigger I ever see.  So I went to talking about other kings, and let
+Solomon slide.  I told about Louis Sixteenth that got his head cut off
+in France long time ago; and about his little boy the dolphin, that
+would a been a king, but they took and shut him up in jail, and some say
+he died there.
+
+“Po’ little chap.”
+
+“But some says he got out and got away, and come to America.”
+
+“Dat’s good!  But he’ll be pooty lonesome--dey ain’ no kings here, is
+dey, Huck?”
+
+“No.”
+
+“Den he cain’t git no situation.  What he gwyne to do?”
+
+“Well, I don’t know.  Some of them gets on the police, and some of them
+learns people how to talk French.”
+
+“Why, Huck, doan’ de French people talk de same way we does?”
+
+“_No_, Jim; you couldn’t understand a word they said--not a single word.”
+
+“Well, now, I be ding-busted!  How do dat come?”
+
+“I don’t know; but it’s so.  I got some of their jabber out of a book.
+S’pose a man was to come to you and say Polly-voo-franzy--what would you
+think?”
+
+“I wouldn’ think nuff’n; I’d take en bust him over de head--dat is, if he
+warn’t white.  I wouldn’t ‘low no nigger to call me dat.”
+
+“Shucks, it ain’t calling you anything.  It’s only saying, do you know
+how to talk French?”
+
+“Well, den, why couldn’t he _say_ it?”
+
+“Why, he _is_ a-saying it.  That’s a Frenchman’s _way_ of saying it.”
+
+“Well, it’s a blame ridicklous way, en I doan’ want to hear no mo’ ‘bout
+it.  Dey ain’ no sense in it.”
+
+“Looky here, Jim; does a cat talk like we do?”
+
+“No, a cat don’t.”
+
+“Well, does a cow?”
+
+“No, a cow don’t, nuther.”
+
+“Does a cat talk like a cow, or a cow talk like a cat?”
+
+“No, dey don’t.”
+
+“It’s natural and right for ‘em to talk different from each other, ain’t
+it?”
+
+“Course.”
+
+“And ain’t it natural and right for a cat and a cow to talk different
+from _us_?”
+
+“Why, mos’ sholy it is.”
+
+“Well, then, why ain’t it natural and right for a _Frenchman_ to talk
+different from us?  You answer me that.”
+
+“Is a cat a man, Huck?”
+
+“No.”
+
+“Well, den, dey ain’t no sense in a cat talkin’ like a man.  Is a cow a
+man?--er is a cow a cat?”
+
+“No, she ain’t either of them.”
+
+“Well, den, she ain’t got no business to talk like either one er the
+yuther of ‘em.  Is a Frenchman a man?”
+
+“Yes.”
+
+“_Well_, den!  Dad blame it, why doan’ he _talk_ like a man?  You answer
+me _dat_!”
+
+I see it warn’t no use wasting words--you can’t learn a nigger to argue.
+So I quit.
+
+
+
+
+CHAPTER XV.
+
+WE judged that three nights more would fetch us to Cairo, at the bottom
+of Illinois, where the Ohio River comes in, and that was what we was
+after.  We would sell the raft and get on a steamboat and go way up the
+Ohio amongst the free States, and then be out of trouble.
+
+Well, the second night a fog begun to come on, and we made for a towhead
+to tie to, for it wouldn’t do to try to run in a fog; but when I paddled
+ahead in the canoe, with the line to make fast, there warn’t anything
+but little saplings to tie to.  I passed the line around one of them
+right on the edge of the cut bank, but there was a stiff current, and
+the raft come booming down so lively she tore it out by the roots and
+away she went.  I see the fog closing down, and it made me so sick and
+scared I couldn’t budge for most a half a minute it seemed to me--and
+then there warn’t no raft in sight; you couldn’t see twenty yards.  I
+jumped into the canoe and run back to the stern, and grabbed the paddle
+and set her back a stroke.  But she didn’t come.  I was in such a hurry
+I hadn’t untied her.  I got up and tried to untie her, but I was so
+excited my hands shook so I couldn’t hardly do anything with them.
+
+As soon as I got started I took out after the raft, hot and heavy, right
+down the towhead.  That was all right as far as it went, but the towhead
+warn’t sixty yards long, and the minute I flew by the foot of it I shot
+out into the solid white fog, and hadn’t no more idea which way I was
+going than a dead man.
+
+Thinks I, it won’t do to paddle; first I know I’ll run into the bank
+or a towhead or something; I got to set still and float, and yet it’s
+mighty fidgety business to have to hold your hands still at such a time.
+ I whooped and listened.  Away down there somewheres I hears a small
+whoop, and up comes my spirits.  I went tearing after it, listening
+sharp to hear it again.  The next time it come I see I warn’t heading
+for it, but heading away to the right of it.  And the next time I was
+heading away to the left of it--and not gaining on it much either, for
+I was flying around, this way and that and t’other, but it was going
+straight ahead all the time.
+
+I did wish the fool would think to beat a tin pan, and beat it all the
+time, but he never did, and it was the still places between the whoops
+that was making the trouble for me.  Well, I fought along, and directly
+I hears the whoop _behind_ me.  I was tangled good now.  That was
+somebody else’s whoop, or else I was turned around.
+
+I throwed the paddle down.  I heard the whoop again; it was behind me
+yet, but in a different place; it kept coming, and kept changing its
+place, and I kept answering, till by and by it was in front of me again,
+and I knowed the current had swung the canoe’s head down-stream, and I
+was all right if that was Jim and not some other raftsman hollering.
+ I couldn’t tell nothing about voices in a fog, for nothing don’t look
+natural nor sound natural in a fog.
+
+The whooping went on, and in about a minute I come a-booming down on a
+cut bank with smoky ghosts of big trees on it, and the current throwed
+me off to the left and shot by, amongst a lot of snags that fairly
+roared, the currrent was tearing by them so swift.
+
+In another second or two it was solid white and still again.  I set
+perfectly still then, listening to my heart thump, and I reckon I didn’t
+draw a breath while it thumped a hundred.
+
+I just give up then.  I knowed what the matter was.  That cut bank
+was an island, and Jim had gone down t’other side of it.  It warn’t no
+towhead that you could float by in ten minutes.  It had the big timber
+of a regular island; it might be five or six miles long and more than
+half a mile wide.
+
+I kept quiet, with my ears cocked, about fifteen minutes, I reckon.  I
+was floating along, of course, four or five miles an hour; but you don’t
+ever think of that.  No, you _feel_ like you are laying dead still on
+the water; and if a little glimpse of a snag slips by you don’t think to
+yourself how fast _you’re_ going, but you catch your breath and think,
+my! how that snag’s tearing along.  If you think it ain’t dismal and
+lonesome out in a fog that way by yourself in the night, you try it
+once--you’ll see.
+
+Next, for about a half an hour, I whoops now and then; at last I hears
+the answer a long ways off, and tries to follow it, but I couldn’t do
+it, and directly I judged I’d got into a nest of towheads, for I had
+little dim glimpses of them on both sides of me--sometimes just a narrow
+channel between, and some that I couldn’t see I knowed was there because
+I’d hear the wash of the current against the old dead brush and trash
+that hung over the banks.  Well, I warn’t long loosing the whoops down
+amongst the towheads; and I only tried to chase them a little while,
+anyway, because it was worse than chasing a Jack-o’-lantern.  You never
+knowed a sound dodge around so, and swap places so quick and so much.
+
+I had to claw away from the bank pretty lively four or five times, to
+keep from knocking the islands out of the river; and so I judged the
+raft must be butting into the bank every now and then, or else it would
+get further ahead and clear out of hearing--it was floating a little
+faster than what I was.
+
+Well, I seemed to be in the open river again by and by, but I couldn’t
+hear no sign of a whoop nowheres.  I reckoned Jim had fetched up on a
+snag, maybe, and it was all up with him.  I was good and tired, so I
+laid down in the canoe and said I wouldn’t bother no more.  I didn’t
+want to go to sleep, of course; but I was so sleepy I couldn’t help it;
+so I thought I would take jest one little cat-nap.
+
+But I reckon it was more than a cat-nap, for when I waked up the stars
+was shining bright, the fog was all gone, and I was spinning down a
+big bend stern first.  First I didn’t know where I was; I thought I was
+dreaming; and when things began to come back to me they seemed to come
+up dim out of last week.
+
+It was a monstrous big river here, with the tallest and the thickest
+kind of timber on both banks; just a solid wall, as well as I could see
+by the stars.  I looked away down-stream, and seen a black speck on the
+water. I took after it; but when I got to it it warn’t nothing but a
+couple of sawlogs made fast together.  Then I see another speck, and
+chased that; then another, and this time I was right.  It was the raft.
+
+When I got to it Jim was setting there with his head down between his
+knees, asleep, with his right arm hanging over the steering-oar.  The
+other oar was smashed off, and the raft was littered up with leaves and
+branches and dirt.  So she’d had a rough time.
+
+I made fast and laid down under Jim’s nose on the raft, and began to
+gap, and stretch my fists out against Jim, and says:
+
+“Hello, Jim, have I been asleep?  Why didn’t you stir me up?”
+
+“Goodness gracious, is dat you, Huck?  En you ain’ dead--you ain’
+drownded--you’s back agin?  It’s too good for true, honey, it’s too good
+for true. Lemme look at you chile, lemme feel o’ you.  No, you ain’
+dead! you’s back agin, ‘live en soun’, jis de same ole Huck--de same ole
+Huck, thanks to goodness!”
+
+“What’s the matter with you, Jim?  You been a-drinking?”
+
+“Drinkin’?  Has I ben a-drinkin’?  Has I had a chance to be a-drinkin’?”
+
+“Well, then, what makes you talk so wild?”
+
+“How does I talk wild?”
+
+“_How_?  Why, hain’t you been talking about my coming back, and all that
+stuff, as if I’d been gone away?”
+
+“Huck--Huck Finn, you look me in de eye; look me in de eye.  _Hain’t_ you
+ben gone away?”
+
+“Gone away?  Why, what in the nation do you mean?  I hain’t been gone
+anywheres.  Where would I go to?”
+
+“Well, looky here, boss, dey’s sumf’n wrong, dey is.  Is I _me_, or who
+_is_ I? Is I heah, or whah _is_ I?  Now dat’s what I wants to know.”
+
+“Well, I think you’re here, plain enough, but I think you’re a
+tangle-headed old fool, Jim.”
+
+“I is, is I?  Well, you answer me dis:  Didn’t you tote out de line in
+de canoe fer to make fas’ to de tow-head?”
+
+“No, I didn’t.  What tow-head?  I hain’t see no tow-head.”
+
+“You hain’t seen no towhead?  Looky here, didn’t de line pull loose en
+de raf’ go a-hummin’ down de river, en leave you en de canoe behine in
+de fog?”
+
+“What fog?”
+
+“Why, de fog!--de fog dat’s been aroun’ all night.  En didn’t you whoop,
+en didn’t I whoop, tell we got mix’ up in de islands en one un us got
+los’ en t’other one was jis’ as good as los’, ‘kase he didn’ know whah
+he wuz? En didn’t I bust up agin a lot er dem islands en have a turrible
+time en mos’ git drownded?  Now ain’ dat so, boss--ain’t it so?  You
+answer me dat.”
+
+“Well, this is too many for me, Jim.  I hain’t seen no fog, nor no
+islands, nor no troubles, nor nothing.  I been setting here talking with
+you all night till you went to sleep about ten minutes ago, and I reckon
+I done the same.  You couldn’t a got drunk in that time, so of course
+you’ve been dreaming.”
+
+“Dad fetch it, how is I gwyne to dream all dat in ten minutes?”
+
+“Well, hang it all, you did dream it, because there didn’t any of it
+happen.”
+
+“But, Huck, it’s all jis’ as plain to me as--”
+
+“It don’t make no difference how plain it is; there ain’t nothing in it.
+I know, because I’ve been here all the time.”
+
+Jim didn’t say nothing for about five minutes, but set there studying
+over it.  Then he says:
+
+“Well, den, I reck’n I did dream it, Huck; but dog my cats ef it ain’t
+de powerfullest dream I ever see.  En I hain’t ever had no dream b’fo’
+dat’s tired me like dis one.”
+
+“Oh, well, that’s all right, because a dream does tire a body like
+everything sometimes.  But this one was a staving dream; tell me all
+about it, Jim.”
+
+So Jim went to work and told me the whole thing right through, just as
+it happened, only he painted it up considerable.  Then he said he must
+start in and “‘terpret” it, because it was sent for a warning.  He said
+the first towhead stood for a man that would try to do us some good, but
+the current was another man that would get us away from him.  The whoops
+was warnings that would come to us every now and then, and if we didn’t
+try hard to make out to understand them they’d just take us into bad
+luck, ‘stead of keeping us out of it.  The lot of towheads was troubles
+we was going to get into with quarrelsome people and all kinds of mean
+folks, but if we minded our business and didn’t talk back and aggravate
+them, we would pull through and get out of the fog and into the big
+clear river, which was the free States, and wouldn’t have no more
+trouble.
+
+It had clouded up pretty dark just after I got on to the raft, but it
+was clearing up again now.
+
+“Oh, well, that’s all interpreted well enough as far as it goes, Jim,” I
+says; “but what does _these_ things stand for?”
+
+It was the leaves and rubbish on the raft and the smashed oar.  You
+could see them first-rate now.
+
+Jim looked at the trash, and then looked at me, and back at the trash
+again.  He had got the dream fixed so strong in his head that he
+couldn’t seem to shake it loose and get the facts back into its place
+again right away.  But when he did get the thing straightened around he
+looked at me steady without ever smiling, and says:
+
+“What do dey stan’ for?  I’se gwyne to tell you.  When I got all wore
+out wid work, en wid de callin’ for you, en went to sleep, my heart wuz
+mos’ broke bekase you wuz los’, en I didn’ k’yer no’ mo’ what become
+er me en de raf’.  En when I wake up en fine you back agin, all safe
+en soun’, de tears come, en I could a got down on my knees en kiss yo’
+foot, I’s so thankful. En all you wuz thinkin’ ‘bout wuz how you could
+make a fool uv ole Jim wid a lie.  Dat truck dah is _trash_; en trash
+is what people is dat puts dirt on de head er dey fren’s en makes ‘em
+ashamed.”
+
+Then he got up slow and walked to the wigwam, and went in there without
+saying anything but that.  But that was enough.  It made me feel so mean
+I could almost kissed _his_ foot to get him to take it back.
+
+It was fifteen minutes before I could work myself up to go and humble
+myself to a nigger; but I done it, and I warn’t ever sorry for it
+afterwards, neither.  I didn’t do him no more mean tricks, and I
+wouldn’t done that one if I’d a knowed it would make him feel that way.
+
+
+
+
+CHAPTER XVI.
+
+WE slept most all day, and started out at night, a little ways behind a
+monstrous long raft that was as long going by as a procession.  She had
+four long sweeps at each end, so we judged she carried as many as thirty
+men, likely.  She had five big wigwams aboard, wide apart, and an open
+camp fire in the middle, and a tall flag-pole at each end.  There was a
+power of style about her.  It _amounted_ to something being a raftsman
+on such a craft as that.
+
+We went drifting down into a big bend, and the night clouded up and got
+hot.  The river was very wide, and was walled with solid timber on
+both sides; you couldn’t see a break in it hardly ever, or a light.  We
+talked about Cairo, and wondered whether we would know it when we got to
+it.  I said likely we wouldn’t, because I had heard say there warn’t but
+about a dozen houses there, and if they didn’t happen to have them lit
+up, how was we going to know we was passing a town?  Jim said if the two
+big rivers joined together there, that would show.  But I said maybe
+we might think we was passing the foot of an island and coming into the
+same old river again. That disturbed Jim--and me too.  So the question
+was, what to do?  I said, paddle ashore the first time a light showed,
+and tell them pap was behind, coming along with a trading-scow, and
+was a green hand at the business, and wanted to know how far it was to
+Cairo.  Jim thought it was a good idea, so we took a smoke on it and
+waited.
+
+There warn’t nothing to do now but to look out sharp for the town, and
+not pass it without seeing it.  He said he’d be mighty sure to see it,
+because he’d be a free man the minute he seen it, but if he missed it
+he’d be in a slave country again and no more show for freedom.  Every
+little while he jumps up and says:
+
+“Dah she is?”
+
+But it warn’t.  It was Jack-o’-lanterns, or lightning bugs; so he set
+down again, and went to watching, same as before.  Jim said it made him
+all over trembly and feverish to be so close to freedom.  Well, I can
+tell you it made me all over trembly and feverish, too, to hear him,
+because I begun to get it through my head that he _was_ most free--and
+who was to blame for it?  Why, _me_.  I couldn’t get that out of my
+conscience, no how nor no way. It got to troubling me so I couldn’t
+rest; I couldn’t stay still in one place.  It hadn’t ever come home to
+me before, what this thing was that I was doing.  But now it did; and it
+stayed with me, and scorched me more and more.  I tried to make out to
+myself that I warn’t to blame, because I didn’t run Jim off from his
+rightful owner; but it warn’t no use, conscience up and says, every
+time, “But you knowed he was running for his freedom, and you could a
+paddled ashore and told somebody.”  That was so--I couldn’t get around
+that noway.  That was where it pinched.  Conscience says to me, “What
+had poor Miss Watson done to you that you could see her nigger go off
+right under your eyes and never say one single word?  What did that poor
+old woman do to you that you could treat her so mean?  Why, she tried to
+learn you your book, she tried to learn you your manners, she tried to
+be good to you every way she knowed how.  _That’s_ what she done.”
+
+I got to feeling so mean and so miserable I most wished I was dead.  I
+fidgeted up and down the raft, abusing myself to myself, and Jim was
+fidgeting up and down past me.  We neither of us could keep still.
+ Every time he danced around and says, “Dah’s Cairo!” it went through me
+like a shot, and I thought if it _was_ Cairo I reckoned I would die of
+miserableness.
+
+Jim talked out loud all the time while I was talking to myself.  He was
+saying how the first thing he would do when he got to a free State he
+would go to saving up money and never spend a single cent, and when he
+got enough he would buy his wife, which was owned on a farm close to
+where Miss Watson lived; and then they would both work to buy the
+two children, and if their master wouldn’t sell them, they’d get an
+Ab’litionist to go and steal them.
+
+It most froze me to hear such talk.  He wouldn’t ever dared to talk such
+talk in his life before.  Just see what a difference it made in him the
+minute he judged he was about free.  It was according to the old saying,
+“Give a nigger an inch and he’ll take an ell.”  Thinks I, this is what
+comes of my not thinking.  Here was this nigger, which I had as good
+as helped to run away, coming right out flat-footed and saying he would
+steal his children--children that belonged to a man I didn’t even know; a
+man that hadn’t ever done me no harm.
+
+I was sorry to hear Jim say that, it was such a lowering of him.  My
+conscience got to stirring me up hotter than ever, until at last I says
+to it, “Let up on me--it ain’t too late yet--I’ll paddle ashore at the
+first light and tell.”  I felt easy and happy and light as a feather
+right off.  All my troubles was gone.  I went to looking out sharp for a
+light, and sort of singing to myself.  By and by one showed.  Jim sings
+out:
+
+“We’s safe, Huck, we’s safe!  Jump up and crack yo’ heels!  Dat’s de
+good ole Cairo at las’, I jis knows it!”
+
+I says:
+
+“I’ll take the canoe and go and see, Jim.  It mightn’t be, you know.”
+
+He jumped and got the canoe ready, and put his old coat in the bottom
+for me to set on, and give me the paddle; and as I shoved off, he says:
+
+“Pooty soon I’ll be a-shout’n’ for joy, en I’ll say, it’s all on
+accounts o’ Huck; I’s a free man, en I couldn’t ever ben free ef it
+hadn’ ben for Huck; Huck done it.  Jim won’t ever forgit you, Huck;
+you’s de bes’ fren’ Jim’s ever had; en you’s de _only_ fren’ ole Jim’s
+got now.”
+
+I was paddling off, all in a sweat to tell on him; but when he says
+this, it seemed to kind of take the tuck all out of me.  I went along
+slow then, and I warn’t right down certain whether I was glad I started
+or whether I warn’t.  When I was fifty yards off, Jim says:
+
+“Dah you goes, de ole true Huck; de on’y white genlman dat ever kep’ his
+promise to ole Jim.”
+
+Well, I just felt sick.  But I says, I _got_ to do it--I can’t get _out_
+of it.  Right then along comes a skiff with two men in it with guns, and
+they stopped and I stopped.  One of them says:
+
+“What’s that yonder?”
+
+“A piece of a raft,” I says.
+
+“Do you belong on it?”
+
+“Yes, sir.”
+
+“Any men on it?”
+
+“Only one, sir.”
+
+“Well, there’s five niggers run off to-night up yonder, above the head
+of the bend.  Is your man white or black?”
+
+I didn’t answer up prompt.  I tried to, but the words wouldn’t come. I
+tried for a second or two to brace up and out with it, but I warn’t man
+enough--hadn’t the spunk of a rabbit.  I see I was weakening; so I just
+give up trying, and up and says:
+
+“He’s white.”
+
+“I reckon we’ll go and see for ourselves.”
+
+“I wish you would,” says I, “because it’s pap that’s there, and maybe
+you’d help me tow the raft ashore where the light is.  He’s sick--and so
+is mam and Mary Ann.”
+
+“Oh, the devil! we’re in a hurry, boy.  But I s’pose we’ve got to.
+ Come, buckle to your paddle, and let’s get along.”
+
+I buckled to my paddle and they laid to their oars.  When we had made a
+stroke or two, I says:
+
+“Pap’ll be mighty much obleeged to you, I can tell you.  Everybody goes
+away when I want them to help me tow the raft ashore, and I can’t do it
+by myself.”
+
+“Well, that’s infernal mean.  Odd, too.  Say, boy, what’s the matter
+with your father?”
+
+“It’s the--a--the--well, it ain’t anything much.”
+
+They stopped pulling.  It warn’t but a mighty little ways to the raft
+now. One says:
+
+“Boy, that’s a lie.  What _is_ the matter with your pap?  Answer up
+square now, and it’ll be the better for you.”
+
+“I will, sir, I will, honest--but don’t leave us, please.  It’s
+the--the--Gentlemen, if you’ll only pull ahead, and let me heave you the
+headline, you won’t have to come a-near the raft--please do.”
+
+“Set her back, John, set her back!” says one.  They backed water.  “Keep
+away, boy--keep to looard.  Confound it, I just expect the wind has
+blowed it to us.  Your pap’s got the small-pox, and you know it precious
+well.  Why didn’t you come out and say so?  Do you want to spread it all
+over?”
+
+“Well,” says I, a-blubbering, “I’ve told everybody before, and they just
+went away and left us.”
+
+“Poor devil, there’s something in that.  We are right down sorry for
+you, but we--well, hang it, we don’t want the small-pox, you see.  Look
+here, I’ll tell you what to do.  Don’t you try to land by yourself, or
+you’ll smash everything to pieces.  You float along down about twenty
+miles, and you’ll come to a town on the left-hand side of the river.  It
+will be long after sun-up then, and when you ask for help you tell them
+your folks are all down with chills and fever.  Don’t be a fool again,
+and let people guess what is the matter.  Now we’re trying to do you a
+kindness; so you just put twenty miles between us, that’s a good boy.
+ It wouldn’t do any good to land yonder where the light is--it’s only a
+wood-yard. Say, I reckon your father’s poor, and I’m bound to say he’s
+in pretty hard luck.  Here, I’ll put a twenty-dollar gold piece on this
+board, and you get it when it floats by.  I feel mighty mean to leave
+you; but my kingdom! it won’t do to fool with small-pox, don’t you see?”
+
+“Hold on, Parker,” says the other man, “here’s a twenty to put on the
+board for me.  Good-bye, boy; you do as Mr. Parker told you, and you’ll
+be all right.”
+
+“That’s so, my boy--good-bye, good-bye.  If you see any runaway niggers
+you get help and nab them, and you can make some money by it.”
+
+“Good-bye, sir,” says I; “I won’t let no runaway niggers get by me if I
+can help it.”
+
+They went off and I got aboard the raft, feeling bad and low, because I
+knowed very well I had done wrong, and I see it warn’t no use for me
+to try to learn to do right; a body that don’t get _started_ right when
+he’s little ain’t got no show--when the pinch comes there ain’t nothing
+to back him up and keep him to his work, and so he gets beat.  Then I
+thought a minute, and says to myself, hold on; s’pose you’d a done right
+and give Jim up, would you felt better than what you do now?  No, says
+I, I’d feel bad--I’d feel just the same way I do now.  Well, then, says
+I, what’s the use you learning to do right when it’s troublesome to do
+right and ain’t no trouble to do wrong, and the wages is just the same?
+ I was stuck.  I couldn’t answer that.  So I reckoned I wouldn’t bother
+no more about it, but after this always do whichever come handiest at
+the time.
+
+I went into the wigwam; Jim warn’t there.  I looked all around; he
+warn’t anywhere.  I says:
+
+“Jim!”
+
+“Here I is, Huck.  Is dey out o’ sight yit?  Don’t talk loud.”
+
+He was in the river under the stern oar, with just his nose out.  I told
+him they were out of sight, so he come aboard.  He says:
+
+“I was a-listenin’ to all de talk, en I slips into de river en was gwyne
+to shove for sho’ if dey come aboard.  Den I was gwyne to swim to de
+raf’ agin when dey was gone.  But lawsy, how you did fool ‘em, Huck!
+ Dat _wuz_ de smartes’ dodge!  I tell you, chile, I’spec it save’ ole
+Jim--ole Jim ain’t going to forgit you for dat, honey.”
+
+Then we talked about the money.  It was a pretty good raise--twenty
+dollars apiece.  Jim said we could take deck passage on a steamboat
+now, and the money would last us as far as we wanted to go in the free
+States. He said twenty mile more warn’t far for the raft to go, but he
+wished we was already there.
+
+Towards daybreak we tied up, and Jim was mighty particular about hiding
+the raft good.  Then he worked all day fixing things in bundles, and
+getting all ready to quit rafting.
+
+That night about ten we hove in sight of the lights of a town away down
+in a left-hand bend.
+
+I went off in the canoe to ask about it.  Pretty soon I found a man out
+in the river with a skiff, setting a trot-line.  I ranged up and says:
+
+“Mister, is that town Cairo?”
+
+“Cairo? no.  You must be a blame’ fool.”
+
+“What town is it, mister?”
+
+“If you want to know, go and find out.  If you stay here botherin’
+around me for about a half a minute longer you’ll get something you
+won’t want.”
+
+I paddled to the raft.  Jim was awful disappointed, but I said never
+mind, Cairo would be the next place, I reckoned.
+
+We passed another town before daylight, and I was going out again; but
+it was high ground, so I didn’t go.  No high ground about Cairo, Jim
+said. I had forgot it.  We laid up for the day on a towhead tolerable
+close to the left-hand bank.  I begun to suspicion something.  So did
+Jim.  I says:
+
+“Maybe we went by Cairo in the fog that night.”
+
+He says:
+
+“Doan’ le’s talk about it, Huck.  Po’ niggers can’t have no luck.  I
+awluz ‘spected dat rattlesnake-skin warn’t done wid its work.”
+
+“I wish I’d never seen that snake-skin, Jim--I do wish I’d never laid
+eyes on it.”
+
+“It ain’t yo’ fault, Huck; you didn’ know.  Don’t you blame yo’self
+‘bout it.”
+
+When it was daylight, here was the clear Ohio water inshore, sure
+enough, and outside was the old regular Muddy!  So it was all up with
+Cairo.
+
+We talked it all over.  It wouldn’t do to take to the shore; we couldn’t
+take the raft up the stream, of course.  There warn’t no way but to wait
+for dark, and start back in the canoe and take the chances.  So we slept
+all day amongst the cottonwood thicket, so as to be fresh for the work,
+and when we went back to the raft about dark the canoe was gone!
+
+We didn’t say a word for a good while.  There warn’t anything to
+say.  We both knowed well enough it was some more work of the
+rattlesnake-skin; so what was the use to talk about it?  It would only
+look like we was finding fault, and that would be bound to fetch more
+bad luck--and keep on fetching it, too, till we knowed enough to keep
+still.
+
+By and by we talked about what we better do, and found there warn’t no
+way but just to go along down with the raft till we got a chance to buy
+a canoe to go back in.  We warn’t going to borrow it when there warn’t
+anybody around, the way pap would do, for that might set people after
+us.
+
+So we shoved out after dark on the raft.
+
+Anybody that don’t believe yet that it’s foolishness to handle a
+snake-skin, after all that that snake-skin done for us, will believe it
+now if they read on and see what more it done for us.
+
+The place to buy canoes is off of rafts laying up at shore.  But we
+didn’t see no rafts laying up; so we went along during three hours and
+more.  Well, the night got gray and ruther thick, which is the next
+meanest thing to fog.  You can’t tell the shape of the river, and you
+can’t see no distance. It got to be very late and still, and then along
+comes a steamboat up the river.  We lit the lantern, and judged she
+would see it.  Up-stream boats didn’t generly come close to us; they
+go out and follow the bars and hunt for easy water under the reefs; but
+nights like this they bull right up the channel against the whole river.
+
+We could hear her pounding along, but we didn’t see her good till she
+was close.  She aimed right for us.  Often they do that and try to see
+how close they can come without touching; sometimes the wheel bites off
+a sweep, and then the pilot sticks his head out and laughs, and thinks
+he’s mighty smart.  Well, here she comes, and we said she was going to
+try and shave us; but she didn’t seem to be sheering off a bit.  She
+was a big one, and she was coming in a hurry, too, looking like a black
+cloud with rows of glow-worms around it; but all of a sudden she bulged
+out, big and scary, with a long row of wide-open furnace doors shining
+like red-hot teeth, and her monstrous bows and guards hanging right
+over us.  There was a yell at us, and a jingling of bells to stop the
+engines, a powwow of cussing, and whistling of steam--and as Jim went
+overboard on one side and I on the other, she come smashing straight
+through the raft.
+
+I dived--and I aimed to find the bottom, too, for a thirty-foot wheel
+had got to go over me, and I wanted it to have plenty of room.  I could
+always stay under water a minute; this time I reckon I stayed under a
+minute and a half.  Then I bounced for the top in a hurry, for I was
+nearly busting.  I popped out to my armpits and blowed the water out of
+my nose, and puffed a bit.  Of course there was a booming current; and
+of course that boat started her engines again ten seconds after she
+stopped them, for they never cared much for raftsmen; so now she was
+churning along up the river, out of sight in the thick weather, though I
+could hear her.
+
+I sung out for Jim about a dozen times, but I didn’t get any answer;
+so I grabbed a plank that touched me while I was “treading water,” and
+struck out for shore, shoving it ahead of me.  But I made out to see
+that the drift of the current was towards the left-hand shore, which
+meant that I was in a crossing; so I changed off and went that way.
+
+It was one of these long, slanting, two-mile crossings; so I was a good
+long time in getting over.  I made a safe landing, and clumb up the
+bank. I couldn’t see but a little ways, but I went poking along over
+rough ground for a quarter of a mile or more, and then I run across a
+big old-fashioned double log-house before I noticed it.  I was going to
+rush by and get away, but a lot of dogs jumped out and went to howling
+and barking at me, and I knowed better than to move another peg.
+
+
+
+
+CHAPTER XVII.
+
+IN about a minute somebody spoke out of a window without putting his
+head out, and says:
+
+“Be done, boys!  Who’s there?”
+
+I says:
+
+“It’s me.”
+
+“Who’s me?”
+
+“George Jackson, sir.”
+
+“What do you want?”
+
+“I don’t want nothing, sir.  I only want to go along by, but the dogs
+won’t let me.”
+
+“What are you prowling around here this time of night for--hey?”
+
+“I warn’t prowling around, sir, I fell overboard off of the steamboat.”
+
+“Oh, you did, did you?  Strike a light there, somebody.  What did you
+say your name was?”
+
+“George Jackson, sir.  I’m only a boy.”
+
+“Look here, if you’re telling the truth you needn’t be afraid--nobody’ll
+hurt you.  But don’t try to budge; stand right where you are.  Rouse out
+Bob and Tom, some of you, and fetch the guns.  George Jackson, is there
+anybody with you?”
+
+“No, sir, nobody.”
+
+I heard the people stirring around in the house now, and see a light.
+The man sung out:
+
+“Snatch that light away, Betsy, you old fool--ain’t you got any sense?
+Put it on the floor behind the front door.  Bob, if you and Tom are
+ready, take your places.”
+
+“All ready.”
+
+“Now, George Jackson, do you know the Shepherdsons?”
+
+“No, sir; I never heard of them.”
+
+“Well, that may be so, and it mayn’t.  Now, all ready.  Step forward,
+George Jackson.  And mind, don’t you hurry--come mighty slow.  If there’s
+anybody with you, let him keep back--if he shows himself he’ll be shot.
+Come along now.  Come slow; push the door open yourself--just enough to
+squeeze in, d’ you hear?”
+
+I didn’t hurry; I couldn’t if I’d a wanted to.  I took one slow step at
+a time and there warn’t a sound, only I thought I could hear my heart.
+ The dogs were as still as the humans, but they followed a little behind
+me. When I got to the three log doorsteps I heard them unlocking and
+unbarring and unbolting.  I put my hand on the door and pushed it a
+little and a little more till somebody said, “There, that’s enough--put
+your head in.” I done it, but I judged they would take it off.
+
+The candle was on the floor, and there they all was, looking at me, and
+me at them, for about a quarter of a minute:  Three big men with guns
+pointed at me, which made me wince, I tell you; the oldest, gray
+and about sixty, the other two thirty or more--all of them fine and
+handsome--and the sweetest old gray-headed lady, and back of her two
+young women which I couldn’t see right well.  The old gentleman says:
+
+“There; I reckon it’s all right.  Come in.”
+
+As soon as I was in the old gentleman he locked the door and barred it
+and bolted it, and told the young men to come in with their guns, and
+they all went in a big parlor that had a new rag carpet on the floor,
+and got together in a corner that was out of the range of the front
+windows--there warn’t none on the side.  They held the candle, and took a
+good look at me, and all said, “Why, _he_ ain’t a Shepherdson--no, there
+ain’t any Shepherdson about him.”  Then the old man said he hoped I
+wouldn’t mind being searched for arms, because he didn’t mean no harm by
+it--it was only to make sure.  So he didn’t pry into my pockets, but only
+felt outside with his hands, and said it was all right.  He told me to
+make myself easy and at home, and tell all about myself; but the old
+lady says:
+
+“Why, bless you, Saul, the poor thing’s as wet as he can be; and don’t
+you reckon it may be he’s hungry?”
+
+“True for you, Rachel--I forgot.”
+
+So the old lady says:
+
+“Betsy” (this was a nigger woman), “you fly around and get him something
+to eat as quick as you can, poor thing; and one of you girls go and wake
+up Buck and tell him--oh, here he is himself.  Buck, take this little
+stranger and get the wet clothes off from him and dress him up in some
+of yours that’s dry.”
+
+Buck looked about as old as me--thirteen or fourteen or along there,
+though he was a little bigger than me.  He hadn’t on anything but a
+shirt, and he was very frowzy-headed.  He came in gaping and digging one
+fist into his eyes, and he was dragging a gun along with the other one.
+He says:
+
+“Ain’t they no Shepherdsons around?”
+
+They said, no, ‘twas a false alarm.
+
+“Well,” he says, “if they’d a ben some, I reckon I’d a got one.”
+
+They all laughed, and Bob says:
+
+“Why, Buck, they might have scalped us all, you’ve been so slow in
+coming.”
+
+“Well, nobody come after me, and it ain’t right I’m always kept down; I
+don’t get no show.”
+
+“Never mind, Buck, my boy,” says the old man, “you’ll have show enough,
+all in good time, don’t you fret about that.  Go ‘long with you now, and
+do as your mother told you.”
+
+When we got up-stairs to his room he got me a coarse shirt and a
+roundabout and pants of his, and I put them on.  While I was at it he
+asked me what my name was, but before I could tell him he started to
+tell me about a bluejay and a young rabbit he had catched in the woods
+day before yesterday, and he asked me where Moses was when the candle
+went out.  I said I didn’t know; I hadn’t heard about it before, no way.
+
+“Well, guess,” he says.
+
+“How’m I going to guess,” says I, “when I never heard tell of it
+before?”
+
+“But you can guess, can’t you?  It’s just as easy.”
+
+“_Which_ candle?”  I says.
+
+“Why, any candle,” he says.
+
+“I don’t know where he was,” says I; “where was he?”
+
+“Why, he was in the _dark_!  That’s where he was!”
+
+“Well, if you knowed where he was, what did you ask me for?”
+
+“Why, blame it, it’s a riddle, don’t you see?  Say, how long are you
+going to stay here?  You got to stay always.  We can just have booming
+times--they don’t have no school now.  Do you own a dog?  I’ve got a
+dog--and he’ll go in the river and bring out chips that you throw in.  Do
+you like to comb up Sundays, and all that kind of foolishness?  You bet
+I don’t, but ma she makes me.  Confound these ole britches!  I reckon
+I’d better put ‘em on, but I’d ruther not, it’s so warm.  Are you all
+ready? All right.  Come along, old hoss.”
+
+Cold corn-pone, cold corn-beef, butter and buttermilk--that is what they
+had for me down there, and there ain’t nothing better that ever I’ve
+come across yet.  Buck and his ma and all of them smoked cob pipes,
+except the nigger woman, which was gone, and the two young women.  They
+all smoked and talked, and I eat and talked.  The young women had
+quilts around them, and their hair down their backs.  They all asked me
+questions, and I told them how pap and me and all the family was living
+on a little farm down at the bottom of Arkansaw, and my sister Mary Ann
+run off and got married and never was heard of no more, and Bill went
+to hunt them and he warn’t heard of no more, and Tom and Mort died,
+and then there warn’t nobody but just me and pap left, and he was just
+trimmed down to nothing, on account of his troubles; so when he died
+I took what there was left, because the farm didn’t belong to us, and
+started up the river, deck passage, and fell overboard; and that was how
+I come to be here.  So they said I could have a home there as long as I
+wanted it.  Then it was most daylight and everybody went to bed, and I
+went to bed with Buck, and when I waked up in the morning, drat it all,
+I had forgot what my name was. So I laid there about an hour trying to
+think, and when Buck waked up I says:
+
+“Can you spell, Buck?”
+
+“Yes,” he says.
+
+“I bet you can’t spell my name,” says I.
+
+“I bet you what you dare I can,” says he.
+
+“All right,” says I, “go ahead.”
+
+“G-e-o-r-g-e J-a-x-o-n--there now,” he says.
+
+“Well,” says I, “you done it, but I didn’t think you could.  It ain’t no
+slouch of a name to spell--right off without studying.”
+
+I set it down, private, because somebody might want _me_ to spell it
+next, and so I wanted to be handy with it and rattle it off like I was
+used to it.
+
+It was a mighty nice family, and a mighty nice house, too.  I hadn’t
+seen no house out in the country before that was so nice and had so much
+style.  It didn’t have an iron latch on the front door, nor a wooden one
+with a buckskin string, but a brass knob to turn, the same as houses in
+town. There warn’t no bed in the parlor, nor a sign of a bed; but heaps
+of parlors in towns has beds in them.  There was a big fireplace that
+was bricked on the bottom, and the bricks was kept clean and red by
+pouring water on them and scrubbing them with another brick; sometimes
+they wash them over with red water-paint that they call Spanish-brown,
+same as they do in town.  They had big brass dog-irons that could hold
+up a saw-log. There was a clock on the middle of the mantelpiece, with
+a picture of a town painted on the bottom half of the glass front, and
+a round place in the middle of it for the sun, and you could see the
+pendulum swinging behind it.  It was beautiful to hear that clock tick;
+and sometimes when one of these peddlers had been along and scoured her
+up and got her in good shape, she would start in and strike a hundred
+and fifty before she got tuckered out.  They wouldn’t took any money for
+her.
+
+Well, there was a big outlandish parrot on each side of the clock,
+made out of something like chalk, and painted up gaudy.  By one of the
+parrots was a cat made of crockery, and a crockery dog by the other;
+and when you pressed down on them they squeaked, but didn’t open
+their mouths nor look different nor interested.  They squeaked through
+underneath.  There was a couple of big wild-turkey-wing fans spread out
+behind those things.  On the table in the middle of the room was a kind
+of a lovely crockery basket that had apples and oranges and peaches and
+grapes piled up in it, which was much redder and yellower and prettier
+than real ones is, but they warn’t real because you could see where
+pieces had got chipped off and showed the white chalk, or whatever it
+was, underneath.
+
+This table had a cover made out of beautiful oilcloth, with a red and
+blue spread-eagle painted on it, and a painted border all around.  It
+come all the way from Philadelphia, they said.  There was some books,
+too, piled up perfectly exact, on each corner of the table.  One was a
+big family Bible full of pictures.  One was Pilgrim’s Progress, about a
+man that left his family, it didn’t say why.  I read considerable in it
+now and then.  The statements was interesting, but tough.  Another was
+Friendship’s Offering, full of beautiful stuff and poetry; but I didn’t
+read the poetry.  Another was Henry Clay’s Speeches, and another was Dr.
+Gunn’s Family Medicine, which told you all about what to do if a body
+was sick or dead.  There was a hymn book, and a lot of other books.  And
+there was nice split-bottom chairs, and perfectly sound, too--not bagged
+down in the middle and busted, like an old basket.
+
+They had pictures hung on the walls--mainly Washingtons and Lafayettes,
+and battles, and Highland Marys, and one called “Signing the
+Declaration.” There was some that they called crayons, which one of the
+daughters which was dead made her own self when she was only
+fifteen years old.  They was different from any pictures I ever see
+before--blacker, mostly, than is common.  One was a woman in a slim black
+dress, belted small under the armpits, with bulges like a cabbage in
+the middle of the sleeves, and a large black scoop-shovel bonnet with
+a black veil, and white slim ankles crossed about with black tape, and
+very wee black slippers, like a chisel, and she was leaning pensive on a
+tombstone on her right elbow, under a weeping willow, and her other hand
+hanging down her side holding a white handkerchief and a reticule,
+and underneath the picture it said “Shall I Never See Thee More Alas.”
+  Another one was a young lady with her hair all combed up straight
+to the top of her head, and knotted there in front of a comb like a
+chair-back, and she was crying into a handkerchief and had a dead bird
+laying on its back in her other hand with its heels up, and underneath
+the picture it said “I Shall Never Hear Thy Sweet Chirrup More Alas.”
+  There was one where a young lady was at a window looking up at the
+moon, and tears running down her cheeks; and she had an open letter in
+one hand with black sealing wax showing on one edge of it, and she was
+mashing a locket with a chain to it against her mouth, and underneath
+the picture it said “And Art Thou Gone Yes Thou Art Gone Alas.”  These
+was all nice pictures, I reckon, but I didn’t somehow seem to take
+to them, because if ever I was down a little they always give me the
+fan-tods.  Everybody was sorry she died, because she had laid out a lot
+more of these pictures to do, and a body could see by what she had done
+what they had lost.  But I reckoned that with her disposition she was
+having a better time in the graveyard.  She was at work on what they
+said was her greatest picture when she took sick, and every day and
+every night it was her prayer to be allowed to live till she got it
+done, but she never got the chance.  It was a picture of a young woman
+in a long white gown, standing on the rail of a bridge all ready to jump
+off, with her hair all down her back, and looking up to the moon, with
+the tears running down her face, and she had two arms folded across her
+breast, and two arms stretched out in front, and two more reaching up
+towards the moon--and the idea was to see which pair would look best,
+and then scratch out all the other arms; but, as I was saying, she died
+before she got her mind made up, and now they kept this picture over the
+head of the bed in her room, and every time her birthday come they hung
+flowers on it.  Other times it was hid with a little curtain.  The young
+woman in the picture had a kind of a nice sweet face, but there was so
+many arms it made her look too spidery, seemed to me.
+
+This young girl kept a scrap-book when she was alive, and used to paste
+obituaries and accidents and cases of patient suffering in it out of the
+Presbyterian Observer, and write poetry after them out of her own head.
+It was very good poetry. This is what she wrote about a boy by the name
+of Stephen Dowling Bots that fell down a well and was drownded:
+
+ODE TO STEPHEN DOWLING BOTS, DEC’D
+
+And did young Stephen sicken,    And did young Stephen die? And did the
+sad hearts thicken,    And did the mourners cry?
+
+No; such was not the fate of    Young Stephen Dowling Bots; Though sad
+hearts round him thickened,    ‘Twas not from sickness’ shots.
+
+No whooping-cough did rack his frame,    Nor measles drear with spots;
+Not these impaired the sacred name    Of Stephen Dowling Bots.
+
+Despised love struck not with woe    That head of curly knots, Nor
+stomach troubles laid him low,    Young Stephen Dowling Bots.
+
+O no. Then list with tearful eye,    Whilst I his fate do tell. His soul
+did from this cold world fly    By falling down a well.
+
+They got him out and emptied him;    Alas it was too late; His spirit
+was gone for to sport aloft    In the realms of the good and great.
+
+If Emmeline Grangerford could make poetry like that before she was
+fourteen, there ain’t no telling what she could a done by and by.  Buck
+said she could rattle off poetry like nothing.  She didn’t ever have to
+stop to think.  He said she would slap down a line, and if she couldn’t
+find anything to rhyme with it would just scratch it out and slap down
+another one, and go ahead. She warn’t particular; she could write about
+anything you choose to give her to write about just so it was sadful.
+Every time a man died, or a woman died, or a child died, she would be on
+hand with her “tribute” before he was cold.  She called them tributes.
+The neighbors said it was the doctor first, then Emmeline, then the
+undertaker--the undertaker never got in ahead of Emmeline but once, and
+then she hung fire on a rhyme for the dead person’s name, which was
+Whistler.  She warn’t ever the same after that; she never complained,
+but she kinder pined away and did not live long.  Poor thing, many’s the
+time I made myself go up to the little room that used to be hers and get
+out her poor old scrap-book and read in it when her pictures had been
+aggravating me and I had soured on her a little.  I liked all that
+family, dead ones and all, and warn’t going to let anything come between
+us.  Poor Emmeline made poetry about all the dead people when she was
+alive, and it didn’t seem right that there warn’t nobody to make some
+about her now she was gone; so I tried to sweat out a verse or two
+myself, but I couldn’t seem to make it go somehow.  They kept Emmeline’s
+room trim and nice, and all the things fixed in it just the way she
+liked to have them when she was alive, and nobody ever slept there.
+ The old lady took care of the room herself, though there was plenty
+of niggers, and she sewed there a good deal and read her Bible there
+mostly.
+
+Well, as I was saying about the parlor, there was beautiful curtains on
+the windows:  white, with pictures painted on them of castles with vines
+all down the walls, and cattle coming down to drink.  There was a little
+old piano, too, that had tin pans in it, I reckon, and nothing was ever
+so lovely as to hear the young ladies sing “The Last Link is Broken”
+ and play “The Battle of Prague” on it.  The walls of all the rooms was
+plastered, and most had carpets on the floors, and the whole house was
+whitewashed on the outside.
+
+It was a double house, and the big open place betwixt them was roofed
+and floored, and sometimes the table was set there in the middle of the
+day, and it was a cool, comfortable place.  Nothing couldn’t be better.
+ And warn’t the cooking good, and just bushels of it too!
+
+
+
+
+CHAPTER XVIII.
+
+COL.  Grangerford was a gentleman, you see.  He was a gentleman all
+over; and so was his family.  He was well born, as the saying is, and
+that’s worth as much in a man as it is in a horse, so the Widow Douglas
+said, and nobody ever denied that she was of the first aristocracy
+in our town; and pap he always said it, too, though he warn’t no more
+quality than a mudcat himself.  Col.  Grangerford was very tall and
+very slim, and had a darkish-paly complexion, not a sign of red in it
+anywheres; he was clean shaved every morning all over his thin face, and
+he had the thinnest kind of lips, and the thinnest kind of nostrils, and
+a high nose, and heavy eyebrows, and the blackest kind of eyes, sunk so
+deep back that they seemed like they was looking out of caverns at
+you, as you may say.  His forehead was high, and his hair was black and
+straight and hung to his shoulders. His hands was long and thin, and
+every day of his life he put on a clean shirt and a full suit from head
+to foot made out of linen so white it hurt your eyes to look at it;
+and on Sundays he wore a blue tail-coat with brass buttons on it.  He
+carried a mahogany cane with a silver head to it.  There warn’t no
+frivolishness about him, not a bit, and he warn’t ever loud.  He was
+as kind as he could be--you could feel that, you know, and so you had
+confidence.  Sometimes he smiled, and it was good to see; but when he
+straightened himself up like a liberty-pole, and the lightning begun to
+flicker out from under his eyebrows, you wanted to climb a tree first,
+and find out what the matter was afterwards.  He didn’t ever have to
+tell anybody to mind their manners--everybody was always good-mannered
+where he was.  Everybody loved to have him around, too; he was sunshine
+most always--I mean he made it seem like good weather.  When he turned
+into a cloudbank it was awful dark for half a minute, and that was
+enough; there wouldn’t nothing go wrong again for a week.
+
+When him and the old lady come down in the morning all the family got
+up out of their chairs and give them good-day, and didn’t set down again
+till they had set down.  Then Tom and Bob went to the sideboard where
+the decanter was, and mixed a glass of bitters and handed it to him, and
+he held it in his hand and waited till Tom’s and Bob’s was mixed, and
+then they bowed and said, “Our duty to you, sir, and madam;” and _they_
+bowed the least bit in the world and said thank you, and so they drank,
+all three, and Bob and Tom poured a spoonful of water on the sugar and
+the mite of whisky or apple brandy in the bottom of their tumblers, and
+give it to me and Buck, and we drank to the old people too.
+
+Bob was the oldest and Tom next--tall, beautiful men with very broad
+shoulders and brown faces, and long black hair and black eyes.  They
+dressed in white linen from head to foot, like the old gentleman, and
+wore broad Panama hats.
+
+Then there was Miss Charlotte; she was twenty-five, and tall and proud
+and grand, but as good as she could be when she warn’t stirred up; but
+when she was she had a look that would make you wilt in your tracks,
+like her father.  She was beautiful.
+
+So was her sister, Miss Sophia, but it was a different kind.  She was
+gentle and sweet like a dove, and she was only twenty.
+
+Each person had their own nigger to wait on them--Buck too.  My nigger
+had a monstrous easy time, because I warn’t used to having anybody do
+anything for me, but Buck’s was on the jump most of the time.
+
+This was all there was of the family now, but there used to be
+more--three sons; they got killed; and Emmeline that died.
+
+The old gentleman owned a lot of farms and over a hundred niggers.
+Sometimes a stack of people would come there, horseback, from ten or
+fifteen mile around, and stay five or six days, and have such junketings
+round about and on the river, and dances and picnics in the woods
+daytimes, and balls at the house nights.  These people was mostly
+kinfolks of the family.  The men brought their guns with them.  It was a
+handsome lot of quality, I tell you.
+
+There was another clan of aristocracy around there--five or six
+families--mostly of the name of Shepherdson.  They was as high-toned
+and well born and rich and grand as the tribe of Grangerfords.  The
+Shepherdsons and Grangerfords used the same steamboat landing, which was
+about two mile above our house; so sometimes when I went up there with a
+lot of our folks I used to see a lot of the Shepherdsons there on their
+fine horses.
+
+One day Buck and me was away out in the woods hunting, and heard a horse
+coming.  We was crossing the road.  Buck says:
+
+“Quick!  Jump for the woods!”
+
+We done it, and then peeped down the woods through the leaves.  Pretty
+soon a splendid young man come galloping down the road, setting his
+horse easy and looking like a soldier.  He had his gun across his
+pommel.  I had seen him before.  It was young Harney Shepherdson.  I
+heard Buck’s gun go off at my ear, and Harney’s hat tumbled off from his
+head.  He grabbed his gun and rode straight to the place where we was
+hid.  But we didn’t wait.  We started through the woods on a run.  The
+woods warn’t thick, so I looked over my shoulder to dodge the bullet,
+and twice I seen Harney cover Buck with his gun; and then he rode away
+the way he come--to get his hat, I reckon, but I couldn’t see.  We never
+stopped running till we got home.  The old gentleman’s eyes blazed a
+minute--‘twas pleasure, mainly, I judged--then his face sort of smoothed
+down, and he says, kind of gentle:
+
+“I don’t like that shooting from behind a bush.  Why didn’t you step
+into the road, my boy?”
+
+“The Shepherdsons don’t, father.  They always take advantage.”
+
+Miss Charlotte she held her head up like a queen while Buck was telling
+his tale, and her nostrils spread and her eyes snapped.  The two young
+men looked dark, but never said nothing.  Miss Sophia she turned pale,
+but the color come back when she found the man warn’t hurt.
+
+Soon as I could get Buck down by the corn-cribs under the trees by
+ourselves, I says:
+
+“Did you want to kill him, Buck?”
+
+“Well, I bet I did.”
+
+“What did he do to you?”
+
+“Him?  He never done nothing to me.”
+
+“Well, then, what did you want to kill him for?”
+
+“Why, nothing--only it’s on account of the feud.”
+
+“What’s a feud?”
+
+“Why, where was you raised?  Don’t you know what a feud is?”
+
+“Never heard of it before--tell me about it.”
+
+“Well,” says Buck, “a feud is this way:  A man has a quarrel with
+another man, and kills him; then that other man’s brother kills _him_;
+then the other brothers, on both sides, goes for one another; then the
+_cousins_ chip in--and by and by everybody’s killed off, and there ain’t
+no more feud.  But it’s kind of slow, and takes a long time.”
+
+“Has this one been going on long, Buck?”
+
+“Well, I should _reckon_!  It started thirty year ago, or som’ers along
+there.  There was trouble ‘bout something, and then a lawsuit to settle
+it; and the suit went agin one of the men, and so he up and shot the
+man that won the suit--which he would naturally do, of course.  Anybody
+would.”
+
+“What was the trouble about, Buck?--land?”
+
+“I reckon maybe--I don’t know.”
+
+“Well, who done the shooting?  Was it a Grangerford or a Shepherdson?”
+
+“Laws, how do I know?  It was so long ago.”
+
+“Don’t anybody know?”
+
+“Oh, yes, pa knows, I reckon, and some of the other old people; but they
+don’t know now what the row was about in the first place.”
+
+“Has there been many killed, Buck?”
+
+“Yes; right smart chance of funerals.  But they don’t always kill.  Pa’s
+got a few buckshot in him; but he don’t mind it ‘cuz he don’t weigh
+much, anyway.  Bob’s been carved up some with a bowie, and Tom’s been
+hurt once or twice.”
+
+“Has anybody been killed this year, Buck?”
+
+“Yes; we got one and they got one.  ‘Bout three months ago my cousin
+Bud, fourteen year old, was riding through the woods on t’other side
+of the river, and didn’t have no weapon with him, which was blame’
+foolishness, and in a lonesome place he hears a horse a-coming behind
+him, and sees old Baldy Shepherdson a-linkin’ after him with his gun in
+his hand and his white hair a-flying in the wind; and ‘stead of jumping
+off and taking to the brush, Bud ‘lowed he could out-run him; so they
+had it, nip and tuck, for five mile or more, the old man a-gaining all
+the time; so at last Bud seen it warn’t any use, so he stopped and faced
+around so as to have the bullet holes in front, you know, and the old
+man he rode up and shot him down.  But he didn’t git much chance to
+enjoy his luck, for inside of a week our folks laid _him_ out.”
+
+“I reckon that old man was a coward, Buck.”
+
+“I reckon he _warn’t_ a coward.  Not by a blame’ sight.  There ain’t a
+coward amongst them Shepherdsons--not a one.  And there ain’t no cowards
+amongst the Grangerfords either.  Why, that old man kep’ up his end in a
+fight one day for half an hour against three Grangerfords, and come
+out winner.  They was all a-horseback; he lit off of his horse and got
+behind a little woodpile, and kep’ his horse before him to stop the
+bullets; but the Grangerfords stayed on their horses and capered around
+the old man, and peppered away at him, and he peppered away at them.
+ Him and his horse both went home pretty leaky and crippled, but the
+Grangerfords had to be _fetched_ home--and one of ‘em was dead, and
+another died the next day.  No, sir; if a body’s out hunting for cowards
+he don’t want to fool away any time amongst them Shepherdsons, becuz
+they don’t breed any of that _kind_.”
+
+Next Sunday we all went to church, about three mile, everybody
+a-horseback. The men took their guns along, so did Buck, and kept
+them between their knees or stood them handy against the wall.  The
+Shepherdsons done the same.  It was pretty ornery preaching--all about
+brotherly love, and such-like tiresomeness; but everybody said it was
+a good sermon, and they all talked it over going home, and had such
+a powerful lot to say about faith and good works and free grace and
+preforeordestination, and I don’t know what all, that it did seem to me
+to be one of the roughest Sundays I had run across yet.
+
+About an hour after dinner everybody was dozing around, some in their
+chairs and some in their rooms, and it got to be pretty dull.  Buck and
+a dog was stretched out on the grass in the sun sound asleep.  I went up
+to our room, and judged I would take a nap myself.  I found that sweet
+Miss Sophia standing in her door, which was next to ours, and she took
+me in her room and shut the door very soft, and asked me if I liked her,
+and I said I did; and she asked me if I would do something for her and
+not tell anybody, and I said I would.  Then she said she’d forgot her
+Testament, and left it in the seat at church between two other books,
+and would I slip out quiet and go there and fetch it to her, and not say
+nothing to nobody.  I said I would. So I slid out and slipped off up the
+road, and there warn’t anybody at the church, except maybe a hog or two,
+for there warn’t any lock on the door, and hogs likes a puncheon floor
+in summer-time because it’s cool.  If you notice, most folks don’t go to
+church only when they’ve got to; but a hog is different.
+
+Says I to myself, something’s up; it ain’t natural for a girl to be in
+such a sweat about a Testament.  So I give it a shake, and out drops a
+little piece of paper with “HALF-PAST TWO” wrote on it with a pencil.  I
+ransacked it, but couldn’t find anything else.  I couldn’t make anything
+out of that, so I put the paper in the book again, and when I got home
+and upstairs there was Miss Sophia in her door waiting for me.  She
+pulled me in and shut the door; then she looked in the Testament till
+she found the paper, and as soon as she read it she looked glad; and
+before a body could think she grabbed me and give me a squeeze, and
+said I was the best boy in the world, and not to tell anybody.  She was
+mighty red in the face for a minute, and her eyes lighted up, and it
+made her powerful pretty.  I was a good deal astonished, but when I got
+my breath I asked her what the paper was about, and she asked me if I
+had read it, and I said no, and she asked me if I could read writing,
+and I told her “no, only coarse-hand,” and then she said the paper
+warn’t anything but a book-mark to keep her place, and I might go and
+play now.
+
+I went off down to the river, studying over this thing, and pretty soon
+I noticed that my nigger was following along behind.  When we was out
+of sight of the house he looked back and around a second, and then comes
+a-running, and says:
+
+“Mars Jawge, if you’ll come down into de swamp I’ll show you a whole
+stack o’ water-moccasins.”
+
+Thinks I, that’s mighty curious; he said that yesterday.  He oughter
+know a body don’t love water-moccasins enough to go around hunting for
+them. What is he up to, anyway?  So I says:
+
+“All right; trot ahead.”
+
+I followed a half a mile; then he struck out over the swamp, and waded
+ankle deep as much as another half-mile.  We come to a little flat piece
+of land which was dry and very thick with trees and bushes and vines,
+and he says:
+
+“You shove right in dah jist a few steps, Mars Jawge; dah’s whah dey is.
+I’s seed ‘m befo’; I don’t k’yer to see ‘em no mo’.”
+
+Then he slopped right along and went away, and pretty soon the trees hid
+him.  I poked into the place a-ways and come to a little open patch
+as big as a bedroom all hung around with vines, and found a man laying
+there asleep--and, by jings, it was my old Jim!
+
+I waked him up, and I reckoned it was going to be a grand surprise to
+him to see me again, but it warn’t.  He nearly cried he was so glad, but
+he warn’t surprised.  Said he swum along behind me that night, and heard
+me yell every time, but dasn’t answer, because he didn’t want nobody to
+pick _him_ up and take him into slavery again.  Says he:
+
+“I got hurt a little, en couldn’t swim fas’, so I wuz a considable ways
+behine you towards de las’; when you landed I reck’ned I could ketch
+up wid you on de lan’ ‘dout havin’ to shout at you, but when I see dat
+house I begin to go slow.  I ‘uz off too fur to hear what dey say to
+you--I wuz ‘fraid o’ de dogs; but when it ‘uz all quiet agin I knowed
+you’s in de house, so I struck out for de woods to wait for day.  Early
+in de mawnin’ some er de niggers come along, gwyne to de fields, en dey
+tuk me en showed me dis place, whah de dogs can’t track me on accounts
+o’ de water, en dey brings me truck to eat every night, en tells me how
+you’s a-gitt’n along.”
+
+“Why didn’t you tell my Jack to fetch me here sooner, Jim?”
+
+“Well, ‘twarn’t no use to ‘sturb you, Huck, tell we could do sumfn--but
+we’s all right now.  I ben a-buyin’ pots en pans en vittles, as I got a
+chanst, en a-patchin’ up de raf’ nights when--”
+
+“_What_ raft, Jim?”
+
+“Our ole raf’.”
+
+“You mean to say our old raft warn’t smashed all to flinders?”
+
+“No, she warn’t.  She was tore up a good deal--one en’ of her was; but
+dey warn’t no great harm done, on’y our traps was mos’ all los’.  Ef we
+hadn’ dive’ so deep en swum so fur under water, en de night hadn’ ben
+so dark, en we warn’t so sk’yerd, en ben sich punkin-heads, as de sayin’
+is, we’d a seed de raf’.  But it’s jis’ as well we didn’t, ‘kase now
+she’s all fixed up agin mos’ as good as new, en we’s got a new lot o’
+stuff, in de place o’ what ‘uz los’.”
+
+“Why, how did you get hold of the raft again, Jim--did you catch her?”
+
+“How I gwyne to ketch her en I out in de woods?  No; some er de niggers
+foun’ her ketched on a snag along heah in de ben’, en dey hid her in a
+crick ‘mongst de willows, en dey wuz so much jawin’ ‘bout which un ‘um
+she b’long to de mos’ dat I come to heah ‘bout it pooty soon, so I ups
+en settles de trouble by tellin’ ‘um she don’t b’long to none uv um, but
+to you en me; en I ast ‘m if dey gwyne to grab a young white genlman’s
+propaty, en git a hid’n for it?  Den I gin ‘m ten cents apiece, en dey
+‘uz mighty well satisfied, en wisht some mo’ raf’s ‘ud come along en
+make ‘m rich agin. Dey’s mighty good to me, dese niggers is, en whatever
+I wants ‘m to do fur me I doan’ have to ast ‘m twice, honey.  Dat Jack’s
+a good nigger, en pooty smart.”
+
+“Yes, he is.  He ain’t ever told me you was here; told me to come, and
+he’d show me a lot of water-moccasins.  If anything happens _he_ ain’t
+mixed up in it.  He can say he never seen us together, and it ‘ll be the
+truth.”
+
+I don’t want to talk much about the next day.  I reckon I’ll cut it
+pretty short.  I waked up about dawn, and was a-going to turn over and
+go to sleep again when I noticed how still it was--didn’t seem to be
+anybody stirring.  That warn’t usual.  Next I noticed that Buck was
+up and gone. Well, I gets up, a-wondering, and goes down stairs--nobody
+around; everything as still as a mouse.  Just the same outside.  Thinks
+I, what does it mean?  Down by the wood-pile I comes across my Jack, and
+says:
+
+“What’s it all about?”
+
+Says he:
+
+“Don’t you know, Mars Jawge?”
+
+“No,” says I, “I don’t.”
+
+“Well, den, Miss Sophia’s run off! ‘deed she has.  She run off in de
+night some time--nobody don’t know jis’ when; run off to get married
+to dat young Harney Shepherdson, you know--leastways, so dey ‘spec.  De
+fambly foun’ it out ‘bout half an hour ago--maybe a little mo’--en’ I
+_tell_ you dey warn’t no time los’.  Sich another hurryin’ up guns
+en hosses _you_ never see!  De women folks has gone for to stir up de
+relations, en ole Mars Saul en de boys tuck dey guns en rode up de
+river road for to try to ketch dat young man en kill him ‘fo’ he kin
+git acrost de river wid Miss Sophia.  I reck’n dey’s gwyne to be mighty
+rough times.”
+
+“Buck went off ‘thout waking me up.”
+
+“Well, I reck’n he _did_!  Dey warn’t gwyne to mix you up in it.
+ Mars Buck he loaded up his gun en ‘lowed he’s gwyne to fetch home a
+Shepherdson or bust. Well, dey’ll be plenty un ‘m dah, I reck’n, en you
+bet you he’ll fetch one ef he gits a chanst.”
+
+I took up the river road as hard as I could put.  By and by I begin to
+hear guns a good ways off.  When I come in sight of the log store and
+the woodpile where the steamboats lands I worked along under the trees
+and brush till I got to a good place, and then I clumb up into the
+forks of a cottonwood that was out of reach, and watched.  There was a
+wood-rank four foot high a little ways in front of the tree, and first I
+was going to hide behind that; but maybe it was luckier I didn’t.
+
+There was four or five men cavorting around on their horses in the open
+place before the log store, cussing and yelling, and trying to get at
+a couple of young chaps that was behind the wood-rank alongside of the
+steamboat landing; but they couldn’t come it.  Every time one of them
+showed himself on the river side of the woodpile he got shot at.  The
+two boys was squatting back to back behind the pile, so they could watch
+both ways.
+
+By and by the men stopped cavorting around and yelling.  They started
+riding towards the store; then up gets one of the boys, draws a steady
+bead over the wood-rank, and drops one of them out of his saddle.  All
+the men jumped off of their horses and grabbed the hurt one and started
+to carry him to the store; and that minute the two boys started on the
+run.  They got half way to the tree I was in before the men noticed.
+Then the men see them, and jumped on their horses and took out after
+them.  They gained on the boys, but it didn’t do no good, the boys had
+too good a start; they got to the woodpile that was in front of my tree,
+and slipped in behind it, and so they had the bulge on the men again.
+One of the boys was Buck, and the other was a slim young chap about
+nineteen years old.
+
+The men ripped around awhile, and then rode away.  As soon as they was
+out of sight I sung out to Buck and told him.  He didn’t know what
+to make of my voice coming out of the tree at first.  He was awful
+surprised.  He told me to watch out sharp and let him know when the
+men come in sight again; said they was up to some devilment or
+other--wouldn’t be gone long.  I wished I was out of that tree, but I
+dasn’t come down.  Buck begun to cry and rip, and ‘lowed that him and
+his cousin Joe (that was the other young chap) would make up for this
+day yet.  He said his father and his two brothers was killed, and two
+or three of the enemy.  Said the Shepherdsons laid for them in
+ambush.  Buck said his father and brothers ought to waited for their
+relations--the Shepherdsons was too strong for them.  I asked him what
+was become of young Harney and Miss Sophia.  He said they’d got across
+the river and was safe.  I was glad of that; but the way Buck did take
+on because he didn’t manage to kill Harney that day he shot at him--I
+hain’t ever heard anything like it.
+
+All of a sudden, bang! bang! bang! goes three or four guns--the men had
+slipped around through the woods and come in from behind without their
+horses!  The boys jumped for the river--both of them hurt--and as they
+swum down the current the men run along the bank shooting at them and
+singing out, “Kill them, kill them!”  It made me so sick I most fell out
+of the tree.  I ain’t a-going to tell _all_ that happened--it would make
+me sick again if I was to do that.  I wished I hadn’t ever come ashore
+that night to see such things.  I ain’t ever going to get shut of
+them--lots of times I dream about them.
+
+I stayed in the tree till it begun to get dark, afraid to come down.
+Sometimes I heard guns away off in the woods; and twice I seen little
+gangs of men gallop past the log store with guns; so I reckoned the
+trouble was still a-going on.  I was mighty downhearted; so I made up my
+mind I wouldn’t ever go anear that house again, because I reckoned I
+was to blame, somehow. I judged that that piece of paper meant that Miss
+Sophia was to meet Harney somewheres at half-past two and run off; and
+I judged I ought to told her father about that paper and the curious way
+she acted, and then maybe he would a locked her up, and this awful mess
+wouldn’t ever happened.
+
+When I got down out of the tree I crept along down the river bank a
+piece, and found the two bodies laying in the edge of the water, and
+tugged at them till I got them ashore; then I covered up their faces,
+and got away as quick as I could.  I cried a little when I was covering
+up Buck’s face, for he was mighty good to me.
+
+It was just dark now.  I never went near the house, but struck through
+the woods and made for the swamp.  Jim warn’t on his island, so I
+tramped off in a hurry for the crick, and crowded through the willows,
+red-hot to jump aboard and get out of that awful country.  The raft was
+gone!  My souls, but I was scared!  I couldn’t get my breath for most
+a minute. Then I raised a yell.  A voice not twenty-five foot from me
+says:
+
+“Good lan’! is dat you, honey?  Doan’ make no noise.”
+
+It was Jim’s voice--nothing ever sounded so good before.  I run along the
+bank a piece and got aboard, and Jim he grabbed me and hugged me, he was
+so glad to see me.  He says:
+
+“Laws bless you, chile, I ‘uz right down sho’ you’s dead agin.  Jack’s
+been heah; he say he reck’n you’s ben shot, kase you didn’ come home no
+mo’; so I’s jes’ dis minute a startin’ de raf’ down towards de mouf er
+de crick, so’s to be all ready for to shove out en leave soon as Jack
+comes agin en tells me for certain you _is_ dead.  Lawsy, I’s mighty
+glad to git you back again, honey.”
+
+I says:
+
+“All right--that’s mighty good; they won’t find me, and they’ll think
+I’ve been killed, and floated down the river--there’s something up there
+that ‘ll help them think so--so don’t you lose no time, Jim, but just
+shove off for the big water as fast as ever you can.”
+
+I never felt easy till the raft was two mile below there and out in
+the middle of the Mississippi.  Then we hung up our signal lantern, and
+judged that we was free and safe once more.  I hadn’t had a bite to eat
+since yesterday, so Jim he got out some corn-dodgers and buttermilk,
+and pork and cabbage and greens--there ain’t nothing in the world so good
+when it’s cooked right--and whilst I eat my supper we talked and had a
+good time.  I was powerful glad to get away from the feuds, and so was
+Jim to get away from the swamp.  We said there warn’t no home like a
+raft, after all.  Other places do seem so cramped up and smothery, but a
+raft don’t.  You feel mighty free and easy and comfortable on a raft.
+
+
+
+
+CHAPTER XIX.
+
+TWO or three days and nights went by; I reckon I might say they swum by,
+they slid along so quiet and smooth and lovely.  Here is the way we put
+in the time.  It was a monstrous big river down there--sometimes a mile
+and a half wide; we run nights, and laid up and hid daytimes; soon as
+night was most gone we stopped navigating and tied up--nearly always
+in the dead water under a towhead; and then cut young cottonwoods and
+willows, and hid the raft with them.  Then we set out the lines.  Next
+we slid into the river and had a swim, so as to freshen up and cool
+off; then we set down on the sandy bottom where the water was about knee
+deep, and watched the daylight come.  Not a sound anywheres--perfectly
+still--just like the whole world was asleep, only sometimes the bullfrogs
+a-cluttering, maybe.  The first thing to see, looking away over the
+water, was a kind of dull line--that was the woods on t’other side; you
+couldn’t make nothing else out; then a pale place in the sky; then more
+paleness spreading around; then the river softened up away off, and
+warn’t black any more, but gray; you could see little dark spots
+drifting along ever so far away--trading scows, and such things; and
+long black streaks--rafts; sometimes you could hear a sweep screaking; or
+jumbled up voices, it was so still, and sounds come so far; and by and
+by you could see a streak on the water which you know by the look of the
+streak that there’s a snag there in a swift current which breaks on it
+and makes that streak look that way; and you see the mist curl up off
+of the water, and the east reddens up, and the river, and you make out a
+log-cabin in the edge of the woods, away on the bank on t’other side of
+the river, being a woodyard, likely, and piled by them cheats so you can
+throw a dog through it anywheres; then the nice breeze springs up, and
+comes fanning you from over there, so cool and fresh and sweet to smell
+on account of the woods and the flowers; but sometimes not that way,
+because they’ve left dead fish laying around, gars and such, and they
+do get pretty rank; and next you’ve got the full day, and everything
+smiling in the sun, and the song-birds just going it!
+
+A little smoke couldn’t be noticed now, so we would take some fish off
+of the lines and cook up a hot breakfast.  And afterwards we would watch
+the lonesomeness of the river, and kind of lazy along, and by and by
+lazy off to sleep.  Wake up by and by, and look to see what done it, and
+maybe see a steamboat coughing along up-stream, so far off towards the
+other side you couldn’t tell nothing about her only whether she was
+a stern-wheel or side-wheel; then for about an hour there wouldn’t be
+nothing to hear nor nothing to see--just solid lonesomeness.  Next
+you’d see a raft sliding by, away off yonder, and maybe a galoot on it
+chopping, because they’re most always doing it on a raft; you’d see the
+axe flash and come down--you don’t hear nothing; you see that axe go
+up again, and by the time it’s above the man’s head then you hear the
+_k’chunk_!--it had took all that time to come over the water.  So we
+would put in the day, lazying around, listening to the stillness.  Once
+there was a thick fog, and the rafts and things that went by was beating
+tin pans so the steamboats wouldn’t run over them.  A scow or a
+raft went by so close we could hear them talking and cussing and
+laughing--heard them plain; but we couldn’t see no sign of them; it made
+you feel crawly; it was like spirits carrying on that way in the air.
+ Jim said he believed it was spirits; but I says:
+
+“No; spirits wouldn’t say, ‘Dern the dern fog.’”
+
+Soon as it was night out we shoved; when we got her out to about the
+middle we let her alone, and let her float wherever the current wanted
+her to; then we lit the pipes, and dangled our legs in the water, and
+talked about all kinds of things--we was always naked, day and night,
+whenever the mosquitoes would let us--the new clothes Buck’s folks made
+for me was too good to be comfortable, and besides I didn’t go much on
+clothes, nohow.
+
+Sometimes we’d have that whole river all to ourselves for the longest
+time. Yonder was the banks and the islands, across the water; and maybe
+a spark--which was a candle in a cabin window; and sometimes on the water
+you could see a spark or two--on a raft or a scow, you know; and maybe
+you could hear a fiddle or a song coming over from one of them crafts.
+It’s lovely to live on a raft.  We had the sky up there, all speckled
+with stars, and we used to lay on our backs and look up at them, and
+discuss about whether they was made or only just happened.  Jim he
+allowed they was made, but I allowed they happened; I judged it would
+have took too long to _make_ so many.  Jim said the moon could a _laid_
+them; well, that looked kind of reasonable, so I didn’t say nothing
+against it, because I’ve seen a frog lay most as many, so of course it
+could be done. We used to watch the stars that fell, too, and see them
+streak down.  Jim allowed they’d got spoiled and was hove out of the
+nest.
+
+Once or twice of a night we would see a steamboat slipping along in the
+dark, and now and then she would belch a whole world of sparks up out
+of her chimbleys, and they would rain down in the river and look awful
+pretty; then she would turn a corner and her lights would wink out and
+her powwow shut off and leave the river still again; and by and by her
+waves would get to us, a long time after she was gone, and joggle the
+raft a bit, and after that you wouldn’t hear nothing for you couldn’t
+tell how long, except maybe frogs or something.
+
+After midnight the people on shore went to bed, and then for two or
+three hours the shores was black--no more sparks in the cabin windows.
+ These sparks was our clock--the first one that showed again meant
+morning was coming, so we hunted a place to hide and tie up right away.
+
+One morning about daybreak I found a canoe and crossed over a chute to
+the main shore--it was only two hundred yards--and paddled about a mile
+up a crick amongst the cypress woods, to see if I couldn’t get some
+berries. Just as I was passing a place where a kind of a cowpath crossed
+the crick, here comes a couple of men tearing up the path as tight as
+they could foot it.  I thought I was a goner, for whenever anybody was
+after anybody I judged it was _me_--or maybe Jim.  I was about to dig out
+from there in a hurry, but they was pretty close to me then, and sung
+out and begged me to save their lives--said they hadn’t been doing
+nothing, and was being chased for it--said there was men and dogs
+a-coming.  They wanted to jump right in, but I says:
+
+“Don’t you do it.  I don’t hear the dogs and horses yet; you’ve got time
+to crowd through the brush and get up the crick a little ways; then you
+take to the water and wade down to me and get in--that’ll throw the dogs
+off the scent.”
+
+They done it, and soon as they was aboard I lit out for our towhead,
+and in about five or ten minutes we heard the dogs and the men away off,
+shouting. We heard them come along towards the crick, but couldn’t
+see them; they seemed to stop and fool around a while; then, as we got
+further and further away all the time, we couldn’t hardly hear them at
+all; by the time we had left a mile of woods behind us and struck the
+river, everything was quiet, and we paddled over to the towhead and hid
+in the cottonwoods and was safe.
+
+One of these fellows was about seventy or upwards, and had a bald head
+and very gray whiskers.  He had an old battered-up slouch hat on, and
+a greasy blue woollen shirt, and ragged old blue jeans britches stuffed
+into his boot-tops, and home-knit galluses--no, he only had one.  He had
+an old long-tailed blue jeans coat with slick brass buttons flung over
+his arm, and both of them had big, fat, ratty-looking carpet-bags.
+
+The other fellow was about thirty, and dressed about as ornery.  After
+breakfast we all laid off and talked, and the first thing that come out
+was that these chaps didn’t know one another.
+
+“What got you into trouble?” says the baldhead to t’other chap.
+
+“Well, I’d been selling an article to take the tartar off the teeth--and
+it does take it off, too, and generly the enamel along with it--but I
+stayed about one night longer than I ought to, and was just in the act
+of sliding out when I ran across you on the trail this side of town, and
+you told me they were coming, and begged me to help you to get off.  So
+I told you I was expecting trouble myself, and would scatter out _with_
+you. That’s the whole yarn--what’s yourn?
+
+“Well, I’d ben a-running’ a little temperance revival thar ‘bout a week,
+and was the pet of the women folks, big and little, for I was makin’ it
+mighty warm for the rummies, I _tell_ you, and takin’ as much as five
+or six dollars a night--ten cents a head, children and niggers free--and
+business a-growin’ all the time, when somehow or another a little report
+got around last night that I had a way of puttin’ in my time with a
+private jug on the sly.  A nigger rousted me out this mornin’, and told
+me the people was getherin’ on the quiet with their dogs and horses, and
+they’d be along pretty soon and give me ‘bout half an hour’s start,
+and then run me down if they could; and if they got me they’d tar
+and feather me and ride me on a rail, sure.  I didn’t wait for no
+breakfast--I warn’t hungry.”
+
+“Old man,” said the young one, “I reckon we might double-team it
+together; what do you think?”
+
+“I ain’t undisposed.  What’s your line--mainly?”
+
+“Jour printer by trade; do a little in patent medicines;
+theater-actor--tragedy, you know; take a turn to mesmerism and phrenology
+when there’s a chance; teach singing-geography school for a change;
+sling a lecture sometimes--oh, I do lots of things--most anything that
+comes handy, so it ain’t work.  What’s your lay?”
+
+“I’ve done considerble in the doctoring way in my time.  Layin’ on o’
+hands is my best holt--for cancer and paralysis, and sich things; and I
+k’n tell a fortune pretty good when I’ve got somebody along to find out
+the facts for me.  Preachin’s my line, too, and workin’ camp-meetin’s,
+and missionaryin’ around.”
+
+Nobody never said anything for a while; then the young man hove a sigh
+and says:
+
+“Alas!”
+
+“What ‘re you alassin’ about?” says the bald-head.
+
+“To think I should have lived to be leading such a life, and be degraded
+down into such company.”  And he begun to wipe the corner of his eye
+with a rag.
+
+“Dern your skin, ain’t the company good enough for you?” says the
+baldhead, pretty pert and uppish.
+
+“Yes, it _is_ good enough for me; it’s as good as I deserve; for who
+fetched me so low when I was so high?  I did myself.  I don’t blame
+_you_, gentlemen--far from it; I don’t blame anybody.  I deserve it
+all.  Let the cold world do its worst; one thing I know--there’s a grave
+somewhere for me. The world may go on just as it’s always done, and take
+everything from me--loved ones, property, everything; but it can’t take
+that. Some day I’ll lie down in it and forget it all, and my poor broken
+heart will be at rest.”  He went on a-wiping.
+
+“Drot your pore broken heart,” says the baldhead; “what are you heaving
+your pore broken heart at _us_ f’r?  _we_ hain’t done nothing.”
+
+“No, I know you haven’t.  I ain’t blaming you, gentlemen.  I brought
+myself down--yes, I did it myself.  It’s right I should suffer--perfectly
+right--I don’t make any moan.”
+
+“Brought you down from whar?  Whar was you brought down from?”
+
+“Ah, you would not believe me; the world never believes--let it pass--‘tis
+no matter.  The secret of my birth--”
+
+“The secret of your birth!  Do you mean to say--”
+
+“Gentlemen,” says the young man, very solemn, “I will reveal it to you,
+for I feel I may have confidence in you.  By rights I am a duke!”
+
+Jim’s eyes bugged out when he heard that; and I reckon mine did, too.
+Then the baldhead says:  “No! you can’t mean it?”
+
+“Yes.  My great-grandfather, eldest son of the Duke of Bridgewater, fled
+to this country about the end of the last century, to breathe the pure
+air of freedom; married here, and died, leaving a son, his own father
+dying about the same time.  The second son of the late duke seized the
+titles and estates--the infant real duke was ignored.  I am the lineal
+descendant of that infant--I am the rightful Duke of Bridgewater; and
+here am I, forlorn, torn from my high estate, hunted of men, despised
+by the cold world, ragged, worn, heart-broken, and degraded to the
+companionship of felons on a raft!”
+
+Jim pitied him ever so much, and so did I. We tried to comfort him, but
+he said it warn’t much use, he couldn’t be much comforted; said if we
+was a mind to acknowledge him, that would do him more good than most
+anything else; so we said we would, if he would tell us how.  He said we
+ought to bow when we spoke to him, and say “Your Grace,” or “My Lord,”
+ or “Your Lordship”--and he wouldn’t mind it if we called him plain
+“Bridgewater,” which, he said, was a title anyway, and not a name; and
+one of us ought to wait on him at dinner, and do any little thing for
+him he wanted done.
+
+Well, that was all easy, so we done it.  All through dinner Jim stood
+around and waited on him, and says, “Will yo’ Grace have some o’ dis or
+some o’ dat?” and so on, and a body could see it was mighty pleasing to
+him.
+
+But the old man got pretty silent by and by--didn’t have much to say, and
+didn’t look pretty comfortable over all that petting that was going on
+around that duke.  He seemed to have something on his mind.  So, along
+in the afternoon, he says:
+
+“Looky here, Bilgewater,” he says, “I’m nation sorry for you, but you
+ain’t the only person that’s had troubles like that.”
+
+“No?”
+
+“No you ain’t.  You ain’t the only person that’s ben snaked down
+wrongfully out’n a high place.”
+
+“Alas!”
+
+“No, you ain’t the only person that’s had a secret of his birth.”  And,
+by jings, _he_ begins to cry.
+
+“Hold!  What do you mean?”
+
+“Bilgewater, kin I trust you?” says the old man, still sort of sobbing.
+
+“To the bitter death!”  He took the old man by the hand and squeezed it,
+and says, “That secret of your being:  speak!”
+
+“Bilgewater, I am the late Dauphin!”
+
+You bet you, Jim and me stared this time.  Then the duke says:
+
+“You are what?”
+
+“Yes, my friend, it is too true--your eyes is lookin’ at this very moment
+on the pore disappeared Dauphin, Looy the Seventeen, son of Looy the
+Sixteen and Marry Antonette.”
+
+“You!  At your age!  No!  You mean you’re the late Charlemagne; you must
+be six or seven hundred years old, at the very least.”
+
+“Trouble has done it, Bilgewater, trouble has done it; trouble has brung
+these gray hairs and this premature balditude.  Yes, gentlemen, you
+see before you, in blue jeans and misery, the wanderin’, exiled,
+trampled-on, and sufferin’ rightful King of France.”
+
+Well, he cried and took on so that me and Jim didn’t know hardly what to
+do, we was so sorry--and so glad and proud we’d got him with us, too.
+ So we set in, like we done before with the duke, and tried to comfort
+_him_. But he said it warn’t no use, nothing but to be dead and done
+with it all could do him any good; though he said it often made him feel
+easier and better for a while if people treated him according to his
+rights, and got down on one knee to speak to him, and always called him
+“Your Majesty,” and waited on him first at meals, and didn’t set down
+in his presence till he asked them. So Jim and me set to majestying him,
+and doing this and that and t’other for him, and standing up till he
+told us we might set down.  This done him heaps of good, and so he
+got cheerful and comfortable.  But the duke kind of soured on him, and
+didn’t look a bit satisfied with the way things was going; still,
+the king acted real friendly towards him, and said the duke’s
+great-grandfather and all the other Dukes of Bilgewater was a good
+deal thought of by _his_ father, and was allowed to come to the palace
+considerable; but the duke stayed huffy a good while, till by and by the
+king says:
+
+“Like as not we got to be together a blamed long time on this h-yer
+raft, Bilgewater, and so what’s the use o’ your bein’ sour?  It ‘ll only
+make things oncomfortable.  It ain’t my fault I warn’t born a duke,
+it ain’t your fault you warn’t born a king--so what’s the use to worry?
+ Make the best o’ things the way you find ‘em, says I--that’s my motto.
+ This ain’t no bad thing that we’ve struck here--plenty grub and an easy
+life--come, give us your hand, duke, and le’s all be friends.”
+
+The duke done it, and Jim and me was pretty glad to see it.  It took
+away all the uncomfortableness and we felt mighty good over it, because
+it would a been a miserable business to have any unfriendliness on the
+raft; for what you want, above all things, on a raft, is for everybody
+to be satisfied, and feel right and kind towards the others.
+
+It didn’t take me long to make up my mind that these liars warn’t no
+kings nor dukes at all, but just low-down humbugs and frauds.  But I
+never said nothing, never let on; kept it to myself; it’s the best way;
+then you don’t have no quarrels, and don’t get into no trouble.  If they
+wanted us to call them kings and dukes, I hadn’t no objections, ‘long as
+it would keep peace in the family; and it warn’t no use to tell Jim, so
+I didn’t tell him.  If I never learnt nothing else out of pap, I learnt
+that the best way to get along with his kind of people is to let them
+have their own way.
+
+
+
+
+CHAPTER XX.
+
+THEY asked us considerable many questions; wanted to know what we
+covered up the raft that way for, and laid by in the daytime instead of
+running--was Jim a runaway nigger?  Says I:
+
+“Goodness sakes! would a runaway nigger run _south_?”
+
+No, they allowed he wouldn’t.  I had to account for things some way, so
+I says:
+
+“My folks was living in Pike County, in Missouri, where I was born, and
+they all died off but me and pa and my brother Ike.  Pa, he ‘lowed
+he’d break up and go down and live with Uncle Ben, who’s got a little
+one-horse place on the river, forty-four mile below Orleans.  Pa was
+pretty poor, and had some debts; so when he’d squared up there warn’t
+nothing left but sixteen dollars and our nigger, Jim.  That warn’t
+enough to take us fourteen hundred mile, deck passage nor no other way.
+ Well, when the river rose pa had a streak of luck one day; he ketched
+this piece of a raft; so we reckoned we’d go down to Orleans on it.
+ Pa’s luck didn’t hold out; a steamboat run over the forrard corner of
+the raft one night, and we all went overboard and dove under the wheel;
+Jim and me come up all right, but pa was drunk, and Ike was only four
+years old, so they never come up no more.  Well, for the next day or
+two we had considerable trouble, because people was always coming out in
+skiffs and trying to take Jim away from me, saying they believed he was
+a runaway nigger.  We don’t run daytimes no more now; nights they don’t
+bother us.”
+
+The duke says:
+
+“Leave me alone to cipher out a way so we can run in the daytime if we
+want to.  I’ll think the thing over--I’ll invent a plan that’ll fix it.
+We’ll let it alone for to-day, because of course we don’t want to go by
+that town yonder in daylight--it mightn’t be healthy.”
+
+Towards night it begun to darken up and look like rain; the heat
+lightning was squirting around low down in the sky, and the leaves was
+beginning to shiver--it was going to be pretty ugly, it was easy to see
+that.  So the duke and the king went to overhauling our wigwam, to see
+what the beds was like.  My bed was a straw tick better than Jim’s,
+which was a corn-shuck tick; there’s always cobs around about in a shuck
+tick, and they poke into you and hurt; and when you roll over the dry
+shucks sound like you was rolling over in a pile of dead leaves; it
+makes such a rustling that you wake up.  Well, the duke allowed he would
+take my bed; but the king allowed he wouldn’t.  He says:
+
+“I should a reckoned the difference in rank would a sejested to you that
+a corn-shuck bed warn’t just fitten for me to sleep on.  Your Grace ‘ll
+take the shuck bed yourself.”
+
+Jim and me was in a sweat again for a minute, being afraid there was
+going to be some more trouble amongst them; so we was pretty glad when
+the duke says:
+
+“‘Tis my fate to be always ground into the mire under the iron heel of
+oppression.  Misfortune has broken my once haughty spirit; I yield, I
+submit; ‘tis my fate.  I am alone in the world--let me suffer; can bear
+it.”
+
+We got away as soon as it was good and dark.  The king told us to stand
+well out towards the middle of the river, and not show a light till we
+got a long ways below the town.  We come in sight of the little bunch of
+lights by and by--that was the town, you know--and slid by, about a half
+a mile out, all right.  When we was three-quarters of a mile below we
+hoisted up our signal lantern; and about ten o’clock it come on to rain
+and blow and thunder and lighten like everything; so the king told us
+to both stay on watch till the weather got better; then him and the duke
+crawled into the wigwam and turned in for the night.  It was my watch
+below till twelve, but I wouldn’t a turned in anyway if I’d had a bed,
+because a body don’t see such a storm as that every day in the week, not
+by a long sight.  My souls, how the wind did scream along!  And every
+second or two there’d come a glare that lit up the white-caps for a half
+a mile around, and you’d see the islands looking dusty through the rain,
+and the trees thrashing around in the wind; then comes a H-WHACK!--bum!
+bum! bumble-umble-um-bum-bum-bum-bum--and the thunder would go rumbling
+and grumbling away, and quit--and then RIP comes another flash and
+another sockdolager.  The waves most washed me off the raft sometimes,
+but I hadn’t any clothes on, and didn’t mind.  We didn’t have no trouble
+about snags; the lightning was glaring and flittering around so constant
+that we could see them plenty soon enough to throw her head this way or
+that and miss them.
+
+I had the middle watch, you know, but I was pretty sleepy by that time,
+so Jim he said he would stand the first half of it for me; he was always
+mighty good that way, Jim was.  I crawled into the wigwam, but the king
+and the duke had their legs sprawled around so there warn’t no show for
+me; so I laid outside--I didn’t mind the rain, because it was warm, and
+the waves warn’t running so high now.  About two they come up again,
+though, and Jim was going to call me; but he changed his mind, because
+he reckoned they warn’t high enough yet to do any harm; but he was
+mistaken about that, for pretty soon all of a sudden along comes a
+regular ripper and washed me overboard.  It most killed Jim a-laughing.
+ He was the easiest nigger to laugh that ever was, anyway.
+
+I took the watch, and Jim he laid down and snored away; and by and by
+the storm let up for good and all; and the first cabin-light that showed
+I rousted him out, and we slid the raft into hiding quarters for the
+day.
+
+The king got out an old ratty deck of cards after breakfast, and him
+and the duke played seven-up a while, five cents a game.  Then they got
+tired of it, and allowed they would “lay out a campaign,” as they called
+it. The duke went down into his carpet-bag, and fetched up a lot of
+little printed bills and read them out loud.  One bill said, “The
+celebrated Dr. Armand de Montalban, of Paris,” would “lecture on the
+Science of Phrenology” at such and such a place, on the blank day of
+blank, at ten cents admission, and “furnish charts of character at
+twenty-five cents apiece.”  The duke said that was _him_.  In another
+bill he was the “world-renowned Shakespearian tragedian, Garrick the
+Younger, of Drury Lane, London.”  In other bills he had a lot of other
+names and done other wonderful things, like finding water and gold with
+a “divining-rod,” “dissipating witch spells,” and so on.  By and by he
+says:
+
+“But the histrionic muse is the darling.  Have you ever trod the boards,
+Royalty?”
+
+“No,” says the king.
+
+“You shall, then, before you’re three days older, Fallen Grandeur,” says
+the duke.  “The first good town we come to we’ll hire a hall and do the
+sword fight in Richard III. and the balcony scene in Romeo and Juliet.
+How does that strike you?”
+
+“I’m in, up to the hub, for anything that will pay, Bilgewater; but, you
+see, I don’t know nothing about play-actin’, and hain’t ever seen much
+of it.  I was too small when pap used to have ‘em at the palace.  Do you
+reckon you can learn me?”
+
+“Easy!”
+
+“All right.  I’m jist a-freezn’ for something fresh, anyway.  Le’s
+commence right away.”
+
+So the duke he told him all about who Romeo was and who Juliet was, and
+said he was used to being Romeo, so the king could be Juliet.
+
+“But if Juliet’s such a young gal, duke, my peeled head and my white
+whiskers is goin’ to look oncommon odd on her, maybe.”
+
+“No, don’t you worry; these country jakes won’t ever think of that.
+Besides, you know, you’ll be in costume, and that makes all the
+difference in the world; Juliet’s in a balcony, enjoying the moonlight
+before she goes to bed, and she’s got on her night-gown and her ruffled
+nightcap.  Here are the costumes for the parts.”
+
+He got out two or three curtain-calico suits, which he said was
+meedyevil armor for Richard III. and t’other chap, and a long white
+cotton nightshirt and a ruffled nightcap to match.  The king was
+satisfied; so the duke got out his book and read the parts over in the
+most splendid spread-eagle way, prancing around and acting at the same
+time, to show how it had got to be done; then he give the book to the
+king and told him to get his part by heart.
+
+There was a little one-horse town about three mile down the bend, and
+after dinner the duke said he had ciphered out his idea about how to run
+in daylight without it being dangersome for Jim; so he allowed he would
+go down to the town and fix that thing.  The king allowed he would go,
+too, and see if he couldn’t strike something.  We was out of coffee, so
+Jim said I better go along with them in the canoe and get some.
+
+When we got there there warn’t nobody stirring; streets empty, and
+perfectly dead and still, like Sunday.  We found a sick nigger sunning
+himself in a back yard, and he said everybody that warn’t too young or
+too sick or too old was gone to camp-meeting, about two mile back in the
+woods.  The king got the directions, and allowed he’d go and work that
+camp-meeting for all it was worth, and I might go, too.
+
+The duke said what he was after was a printing-office.  We found it;
+a little bit of a concern, up over a carpenter shop--carpenters and
+printers all gone to the meeting, and no doors locked.  It was a dirty,
+littered-up place, and had ink marks, and handbills with pictures of
+horses and runaway niggers on them, all over the walls.  The duke shed
+his coat and said he was all right now.  So me and the king lit out for
+the camp-meeting.
+
+We got there in about a half an hour fairly dripping, for it was a most
+awful hot day.  There was as much as a thousand people there from
+twenty mile around.  The woods was full of teams and wagons, hitched
+everywheres, feeding out of the wagon-troughs and stomping to keep
+off the flies.  There was sheds made out of poles and roofed over with
+branches, where they had lemonade and gingerbread to sell, and piles of
+watermelons and green corn and such-like truck.
+
+The preaching was going on under the same kinds of sheds, only they was
+bigger and held crowds of people.  The benches was made out of outside
+slabs of logs, with holes bored in the round side to drive sticks into
+for legs. They didn’t have no backs.  The preachers had high platforms
+to stand on at one end of the sheds.  The women had on sun-bonnets;
+and some had linsey-woolsey frocks, some gingham ones, and a few of the
+young ones had on calico.  Some of the young men was barefooted, and
+some of the children didn’t have on any clothes but just a tow-linen
+shirt.  Some of the old women was knitting, and some of the young folks
+was courting on the sly.
+
+The first shed we come to the preacher was lining out a hymn.  He lined
+out two lines, everybody sung it, and it was kind of grand to hear it,
+there was so many of them and they done it in such a rousing way; then
+he lined out two more for them to sing--and so on.  The people woke up
+more and more, and sung louder and louder; and towards the end some
+begun to groan, and some begun to shout.  Then the preacher begun to
+preach, and begun in earnest, too; and went weaving first to one side of
+the platform and then the other, and then a-leaning down over the front
+of it, with his arms and his body going all the time, and shouting his
+words out with all his might; and every now and then he would hold up
+his Bible and spread it open, and kind of pass it around this way and
+that, shouting, “It’s the brazen serpent in the wilderness!  Look upon
+it and live!”  And people would shout out, “Glory!--A-a-_men_!”  And so
+he went on, and the people groaning and crying and saying amen:
+
+“Oh, come to the mourners’ bench! come, black with sin! (_Amen_!) come,
+sick and sore! (_Amen_!) come, lame and halt and blind! (_Amen_!) come,
+pore and needy, sunk in shame! (_A-A-Men_!) come, all that’s worn and
+soiled and suffering!--come with a broken spirit! come with a contrite
+heart! come in your rags and sin and dirt! the waters that cleanse
+is free, the door of heaven stands open--oh, enter in and be at rest!”
+ (_A-A-Men_!  _Glory, Glory Hallelujah!_)
+
+And so on.  You couldn’t make out what the preacher said any more, on
+account of the shouting and crying.  Folks got up everywheres in the
+crowd, and worked their way just by main strength to the mourners’
+bench, with the tears running down their faces; and when all the
+mourners had got up there to the front benches in a crowd, they sung and
+shouted and flung themselves down on the straw, just crazy and wild.
+
+Well, the first I knowed the king got a-going, and you could hear him
+over everybody; and next he went a-charging up on to the platform, and
+the preacher he begged him to speak to the people, and he done it.  He
+told them he was a pirate--been a pirate for thirty years out in the
+Indian Ocean--and his crew was thinned out considerable last spring in
+a fight, and he was home now to take out some fresh men, and thanks to
+goodness he’d been robbed last night and put ashore off of a steamboat
+without a cent, and he was glad of it; it was the blessedest thing that
+ever happened to him, because he was a changed man now, and happy for
+the first time in his life; and, poor as he was, he was going to start
+right off and work his way back to the Indian Ocean, and put in the rest
+of his life trying to turn the pirates into the true path; for he could
+do it better than anybody else, being acquainted with all pirate crews
+in that ocean; and though it would take him a long time to get there
+without money, he would get there anyway, and every time he convinced
+a pirate he would say to him, “Don’t you thank me, don’t you give me no
+credit; it all belongs to them dear people in Pokeville camp-meeting,
+natural brothers and benefactors of the race, and that dear preacher
+there, the truest friend a pirate ever had!”
+
+And then he busted into tears, and so did everybody.  Then somebody
+sings out, “Take up a collection for him, take up a collection!”  Well,
+a half a dozen made a jump to do it, but somebody sings out, “Let _him_
+pass the hat around!”  Then everybody said it, the preacher too.
+
+So the king went all through the crowd with his hat swabbing his eyes,
+and blessing the people and praising them and thanking them for being
+so good to the poor pirates away off there; and every little while the
+prettiest kind of girls, with the tears running down their cheeks, would
+up and ask him would he let them kiss him for to remember him by; and he
+always done it; and some of them he hugged and kissed as many as five or
+six times--and he was invited to stay a week; and everybody wanted him to
+live in their houses, and said they’d think it was an honor; but he said
+as this was the last day of the camp-meeting he couldn’t do no good, and
+besides he was in a sweat to get to the Indian Ocean right off and go to
+work on the pirates.
+
+When we got back to the raft and he come to count up he found he had
+collected eighty-seven dollars and seventy-five cents.  And then he had
+fetched away a three-gallon jug of whisky, too, that he found under a
+wagon when he was starting home through the woods.  The king said,
+take it all around, it laid over any day he’d ever put in in the
+missionarying line.  He said it warn’t no use talking, heathens don’t
+amount to shucks alongside of pirates to work a camp-meeting with.
+
+The duke was thinking _he’d_ been doing pretty well till the king come
+to show up, but after that he didn’t think so so much.  He had set
+up and printed off two little jobs for farmers in that
+printing-office--horse bills--and took the money, four dollars.  And he
+had got in ten dollars’ worth of advertisements for the paper, which he
+said he would put in for four dollars if they would pay in advance--so
+they done it. The price of the paper was two dollars a year, but he took
+in three subscriptions for half a dollar apiece on condition of them
+paying him in advance; they were going to pay in cordwood and onions as
+usual, but he said he had just bought the concern and knocked down the
+price as low as he could afford it, and was going to run it for cash.
+ He set up a little piece of poetry, which he made, himself, out of
+his own head--three verses--kind of sweet and saddish--the name of it was,
+“Yes, crush, cold world, this breaking heart”--and he left that all set
+up and ready to print in the paper, and didn’t charge nothing for it.
+ Well, he took in nine dollars and a half, and said he’d done a pretty
+square day’s work for it.
+
+Then he showed us another little job he’d printed and hadn’t charged
+for, because it was for us.  It had a picture of a runaway nigger with
+a bundle on a stick over his shoulder, and “$200 reward” under it.  The
+reading was all about Jim, and just described him to a dot.  It said
+he run away from St. Jacques’ plantation, forty mile below New Orleans,
+last winter, and likely went north, and whoever would catch him and send
+him back he could have the reward and expenses.
+
+“Now,” says the duke, “after to-night we can run in the daytime if we
+want to.  Whenever we see anybody coming we can tie Jim hand and foot
+with a rope, and lay him in the wigwam and show this handbill and say we
+captured him up the river, and were too poor to travel on a steamboat,
+so we got this little raft on credit from our friends and are going down
+to get the reward.  Handcuffs and chains would look still better on Jim,
+but it wouldn’t go well with the story of us being so poor.  Too much
+like jewelry.  Ropes are the correct thing--we must preserve the unities,
+as we say on the boards.”
+
+We all said the duke was pretty smart, and there couldn’t be no trouble
+about running daytimes.  We judged we could make miles enough that night
+to get out of the reach of the powwow we reckoned the duke’s work in
+the printing office was going to make in that little town; then we could
+boom right along if we wanted to.
+
+We laid low and kept still, and never shoved out till nearly ten
+o’clock; then we slid by, pretty wide away from the town, and didn’t
+hoist our lantern till we was clear out of sight of it.
+
+When Jim called me to take the watch at four in the morning, he says:
+
+“Huck, does you reck’n we gwyne to run acrost any mo’ kings on dis
+trip?”
+
+“No,” I says, “I reckon not.”
+
+“Well,” says he, “dat’s all right, den.  I doan’ mine one er two kings,
+but dat’s enough.  Dis one’s powerful drunk, en de duke ain’ much
+better.”
+
+I found Jim had been trying to get him to talk French, so he could hear
+what it was like; but he said he had been in this country so long, and
+had so much trouble, he’d forgot it.
+
+
+
+
+CHAPTER XXI.
+
+IT was after sun-up now, but we went right on and didn’t tie up.  The
+king and the duke turned out by and by looking pretty rusty; but after
+they’d jumped overboard and took a swim it chippered them up a good
+deal. After breakfast the king he took a seat on the corner of the raft,
+and pulled off his boots and rolled up his britches, and let his legs
+dangle in the water, so as to be comfortable, and lit his pipe, and went
+to getting his Romeo and Juliet by heart.  When he had got it pretty
+good him and the duke begun to practice it together.  The duke had to
+learn him over and over again how to say every speech; and he made him
+sigh, and put his hand on his heart, and after a while he said he done
+it pretty well; “only,” he says, “you mustn’t bellow out _Romeo_!
+that way, like a bull--you must say it soft and sick and languishy,
+so--R-o-o-meo! that is the idea; for Juliet’s a dear sweet mere child of
+a girl, you know, and she doesn’t bray like a jackass.”
+
+Well, next they got out a couple of long swords that the duke made out
+of oak laths, and begun to practice the sword fight--the duke called
+himself Richard III.; and the way they laid on and pranced around
+the raft was grand to see.  But by and by the king tripped and fell
+overboard, and after that they took a rest, and had a talk about all
+kinds of adventures they’d had in other times along the river.
+
+After dinner the duke says:
+
+“Well, Capet, we’ll want to make this a first-class show, you know, so
+I guess we’ll add a little more to it.  We want a little something to
+answer encores with, anyway.”
+
+“What’s onkores, Bilgewater?”
+
+The duke told him, and then says:
+
+“I’ll answer by doing the Highland fling or the sailor’s hornpipe; and
+you--well, let me see--oh, I’ve got it--you can do Hamlet’s soliloquy.”
+
+“Hamlet’s which?”
+
+“Hamlet’s soliloquy, you know; the most celebrated thing in Shakespeare.
+Ah, it’s sublime, sublime!  Always fetches the house.  I haven’t got
+it in the book--I’ve only got one volume--but I reckon I can piece it out
+from memory.  I’ll just walk up and down a minute, and see if I can call
+it back from recollection’s vaults.”
+
+So he went to marching up and down, thinking, and frowning horrible
+every now and then; then he would hoist up his eyebrows; next he would
+squeeze his hand on his forehead and stagger back and kind of moan; next
+he would sigh, and next he’d let on to drop a tear.  It was beautiful
+to see him. By and by he got it.  He told us to give attention.  Then
+he strikes a most noble attitude, with one leg shoved forwards, and his
+arms stretched away up, and his head tilted back, looking up at the sky;
+and then he begins to rip and rave and grit his teeth; and after that,
+all through his speech, he howled, and spread around, and swelled up his
+chest, and just knocked the spots out of any acting ever I see before.
+ This is the speech--I learned it, easy enough, while he was learning it
+to the king:
+
+To be, or not to be; that is the bare bodkin That makes calamity of
+so long life; For who would fardels bear, till Birnam Wood do come
+to Dunsinane, But that the fear of something after death Murders the
+innocent sleep, Great nature’s second course, And makes us rather sling
+the arrows of outrageous fortune Than fly to others that we know not of.
+There’s the respect must give us pause: Wake Duncan with thy knocking! I
+would thou couldst; For who would bear the whips and scorns of time, The
+oppressor’s wrong, the proud man’s contumely, The law’s delay, and the
+quietus which his pangs might take. In the dead waste and middle of the
+night, when churchyards yawn In customary suits of solemn black, But
+that the undiscovered country from whose bourne no traveler returns,
+Breathes forth contagion on the world, And thus the native hue of
+resolution, like the poor cat i’ the adage, Is sicklied o’er with care.
+And all the clouds that lowered o’er our housetops, With this
+regard their currents turn awry, And lose the name of action. ‘Tis a
+consummation devoutly to be wished. But soft you, the fair Ophelia: Ope
+not thy ponderous and marble jaws. But get thee to a nunnery&mdash;go!
+
+Well, the old man he liked that speech, and he mighty soon got it so he
+could do it first rate. It seemed like he was just born for it; and when
+he had his hand in and was excited, it was perfectly lovely the way he
+would rip and tear and rair up behind when he was getting it off.
+
+The first chance we got, the duke he had some show bills printed; and
+after that, for two or three days as we floated along, the raft was a
+most uncommon lively place, for there warn’t nothing but sword-fighting
+and rehearsing--as the duke called it--going on all the time. One morning,
+when we was pretty well down the State of Arkansaw, we come in sight
+of a little one-horse town in a big bend; so we tied up about
+three-quarters of a mile above it, in the mouth of a crick which was
+shut in like a tunnel by the cypress trees, and all of us but Jim took
+the canoe and went down there to see if there was any chance in that
+place for our show.
+
+We struck it mighty lucky; there was going to be a circus there that
+afternoon, and the country people was already beginning to come in, in
+all kinds of old shackly wagons, and on horses. The circus would leave
+before night, so our show would have a pretty good chance. The duke he
+hired the court house, and we went around and stuck up our bills. They
+read like this:
+
+Shaksperean Revival!!!
+
+Wonderful Attraction!
+
+For One Night Only! The world renowned tragedians,
+
+David Garrick the younger, of Drury Lane Theatre, London,
+
+and
+
+Edmund Kean the elder, of the Royal Haymarket Theatre, Whitechapel,
+Pudding Lane, Piccadilly, London, and the Royal Continental Theatres, in
+their sublime Shaksperean Spectacle entitled The Balcony Scene in
+
+Romeo and Juliet!!!
+
+Romeo...................................... Mr. Garrick.
+
+Juliet..................................... Mr. Kean.
+
+Assisted by the whole strength of the company!
+
+New costumes, new scenery, new appointments!
+
+Also:
+
+The thrilling, masterly, and blood-curdling Broad-sword conflict In
+Richard III.!!!
+
+Richard III................................ Mr. Garrick.
+
+Richmond................................... Mr. Kean.
+
+also:
+
+(by special request,)
+
+Hamlet’s Immortal Soliloquy!!
+
+By the Illustrious Kean!
+
+Done by him 300 consecutive nights in Paris!
+
+For One Night Only,
+
+On account of imperative European engagements!
+
+Admission 25 cents; children and servants, 10 cents.
+
+Then we went loafing around the town. The stores and houses was most all
+old shackly dried-up frame concerns that hadn’t ever been painted; they
+was set up three or four foot above ground on stilts, so as to be out of
+reach of the water when the river was overflowed. The houses had little
+gardens around them, but they didn’t seem to raise hardly anything in
+them but jimpson weeds, and sunflowers, and ash-piles, and old curled-up
+boots and shoes, and pieces of bottles, and rags, and played-out
+tin-ware. The fences was made of different kinds of boards, nailed on
+at different times; and they leaned every which-way, and had gates that
+didn’t generly have but one hinge--a leather one. Some of the fences
+had been whitewashed, some time or another, but the duke said it was in
+Clumbus’s time, like enough. There was generly hogs in the garden, and
+people driving them out.
+
+All the stores was along one street.  They had white domestic awnings in
+front, and the country people hitched their horses to the awning-posts.
+There was empty drygoods boxes under the awnings, and loafers roosting
+on them all day long, whittling them with their Barlow knives; and
+chawing tobacco, and gaping and yawning and stretching--a mighty ornery
+lot. They generly had on yellow straw hats most as wide as an umbrella,
+but didn’t wear no coats nor waistcoats, they called one another Bill,
+and Buck, and Hank, and Joe, and Andy, and talked lazy and drawly, and
+used considerable many cuss words.  There was as many as one loafer
+leaning up against every awning-post, and he most always had his hands
+in his britches-pockets, except when he fetched them out to lend a chaw
+of tobacco or scratch.  What a body was hearing amongst them all the
+time was:
+
+“Gimme a chaw ‘v tobacker, Hank.”
+
+“Cain’t; I hain’t got but one chaw left.  Ask Bill.”
+
+Maybe Bill he gives him a chaw; maybe he lies and says he ain’t got
+none. Some of them kinds of loafers never has a cent in the world, nor a
+chaw of tobacco of their own.  They get all their chawing by borrowing;
+they say to a fellow, “I wisht you’d len’ me a chaw, Jack, I jist this
+minute give Ben Thompson the last chaw I had”--which is a lie pretty
+much everytime; it don’t fool nobody but a stranger; but Jack ain’t no
+stranger, so he says:
+
+“_You_ give him a chaw, did you?  So did your sister’s cat’s
+grandmother. You pay me back the chaws you’ve awready borry’d off’n me,
+Lafe Buckner, then I’ll loan you one or two ton of it, and won’t charge
+you no back intrust, nuther.”
+
+“Well, I _did_ pay you back some of it wunst.”
+
+“Yes, you did--‘bout six chaws.  You borry’d store tobacker and paid back
+nigger-head.”
+
+Store tobacco is flat black plug, but these fellows mostly chaws the
+natural leaf twisted.  When they borrow a chaw they don’t generly cut it
+off with a knife, but set the plug in between their teeth, and gnaw with
+their teeth and tug at the plug with their hands till they get it in
+two; then sometimes the one that owns the tobacco looks mournful at it
+when it’s handed back, and says, sarcastic:
+
+“Here, gimme the _chaw_, and you take the _plug_.”
+
+All the streets and lanes was just mud; they warn’t nothing else _but_
+mud--mud as black as tar and nigh about a foot deep in some places,
+and two or three inches deep in _all_ the places.  The hogs loafed and
+grunted around everywheres.  You’d see a muddy sow and a litter of pigs
+come lazying along the street and whollop herself right down in the way,
+where folks had to walk around her, and she’d stretch out and shut her
+eyes and wave her ears whilst the pigs was milking her, and look as
+happy as if she was on salary. And pretty soon you’d hear a loafer
+sing out, “Hi!  _so_ boy! sick him, Tige!” and away the sow would go,
+squealing most horrible, with a dog or two swinging to each ear, and
+three or four dozen more a-coming; and then you would see all the
+loafers get up and watch the thing out of sight, and laugh at the fun
+and look grateful for the noise.  Then they’d settle back again till
+there was a dog fight.  There couldn’t anything wake them up all over,
+and make them happy all over, like a dog fight--unless it might be
+putting turpentine on a stray dog and setting fire to him, or tying a
+tin pan to his tail and see him run himself to death.
+
+On the river front some of the houses was sticking out over the bank,
+and they was bowed and bent, and about ready to tumble in. The people
+had moved out of them.  The bank was caved away under one corner of some
+others, and that corner was hanging over.  People lived in them yet, but
+it was dangersome, because sometimes a strip of land as wide as a house
+caves in at a time.  Sometimes a belt of land a quarter of a mile deep
+will start in and cave along and cave along till it all caves into the
+river in one summer. Such a town as that has to be always moving back,
+and back, and back, because the river’s always gnawing at it.
+
+The nearer it got to noon that day the thicker and thicker was the
+wagons and horses in the streets, and more coming all the time.
+ Families fetched their dinners with them from the country, and eat them
+in the wagons.  There was considerable whisky drinking going on, and I
+seen three fights.  By and by somebody sings out:
+
+“Here comes old Boggs!--in from the country for his little old monthly
+drunk; here he comes, boys!”
+
+All the loafers looked glad; I reckoned they was used to having fun out
+of Boggs.  One of them says:
+
+“Wonder who he’s a-gwyne to chaw up this time.  If he’d a-chawed up all
+the men he’s ben a-gwyne to chaw up in the last twenty year he’d have
+considerable ruputation now.”
+
+Another one says, “I wisht old Boggs ‘d threaten me, ‘cuz then I’d know
+I warn’t gwyne to die for a thousan’ year.”
+
+Boggs comes a-tearing along on his horse, whooping and yelling like an
+Injun, and singing out:
+
+“Cler the track, thar.  I’m on the waw-path, and the price uv coffins is
+a-gwyne to raise.”
+
+He was drunk, and weaving about in his saddle; he was over fifty year
+old, and had a very red face.  Everybody yelled at him and laughed at
+him and sassed him, and he sassed back, and said he’d attend to them and
+lay them out in their regular turns, but he couldn’t wait now because
+he’d come to town to kill old Colonel Sherburn, and his motto was, “Meat
+first, and spoon vittles to top off on.”
+
+He see me, and rode up and says:
+
+“Whar’d you come f’m, boy?  You prepared to die?”
+
+Then he rode on.  I was scared, but a man says:
+
+“He don’t mean nothing; he’s always a-carryin’ on like that when he’s
+drunk.  He’s the best naturedest old fool in Arkansaw--never hurt nobody,
+drunk nor sober.”
+
+Boggs rode up before the biggest store in town, and bent his head down
+so he could see under the curtain of the awning and yells:
+
+“Come out here, Sherburn! Come out and meet the man you’ve swindled.
+You’re the houn’ I’m after, and I’m a-gwyne to have you, too!”
+
+And so he went on, calling Sherburn everything he could lay his tongue
+to, and the whole street packed with people listening and laughing and
+going on.  By and by a proud-looking man about fifty-five--and he was a
+heap the best dressed man in that town, too--steps out of the store, and
+the crowd drops back on each side to let him come.  He says to Boggs,
+mighty ca’m and slow--he says:
+
+“I’m tired of this, but I’ll endure it till one o’clock.  Till one
+o’clock, mind--no longer.  If you open your mouth against me only once
+after that time you can’t travel so far but I will find you.”
+
+Then he turns and goes in.  The crowd looked mighty sober; nobody
+stirred, and there warn’t no more laughing.  Boggs rode off
+blackguarding Sherburn as loud as he could yell, all down the street;
+and pretty soon back he comes and stops before the store, still keeping
+it up.  Some men crowded around him and tried to get him to shut up,
+but he wouldn’t; they told him it would be one o’clock in about fifteen
+minutes, and so he _must_ go home--he must go right away.  But it didn’t
+do no good.  He cussed away with all his might, and throwed his hat down
+in the mud and rode over it, and pretty soon away he went a-raging down
+the street again, with his gray hair a-flying. Everybody that could get
+a chance at him tried their best to coax him off of his horse so they
+could lock him up and get him sober; but it warn’t no use--up the street
+he would tear again, and give Sherburn another cussing.  By and by
+somebody says:
+
+“Go for his daughter!--quick, go for his daughter; sometimes he’ll listen
+to her.  If anybody can persuade him, she can.”
+
+So somebody started on a run.  I walked down street a ways and stopped.
+In about five or ten minutes here comes Boggs again, but not on his
+horse.  He was a-reeling across the street towards me, bare-headed, with
+a friend on both sides of him a-holt of his arms and hurrying him along.
+He was quiet, and looked uneasy; and he warn’t hanging back any, but was
+doing some of the hurrying himself.  Somebody sings out:
+
+“Boggs!”
+
+I looked over there to see who said it, and it was that Colonel
+Sherburn. He was standing perfectly still in the street, and had a
+pistol raised in his right hand--not aiming it, but holding it out with
+the barrel tilted up towards the sky.  The same second I see a young
+girl coming on the run, and two men with her.  Boggs and the men turned
+round to see who called him, and when they see the pistol the men
+jumped to one side, and the pistol-barrel come down slow and steady to
+a level--both barrels cocked. Boggs throws up both of his hands and says,
+“O Lord, don’t shoot!”  Bang! goes the first shot, and he staggers back,
+clawing at the air--bang! goes the second one, and he tumbles backwards
+on to the ground, heavy and solid, with his arms spread out.  That young
+girl screamed out and comes rushing, and down she throws herself on her
+father, crying, and saying, “Oh, he’s killed him, he’s killed him!”  The
+crowd closed up around them, and shouldered and jammed one another, with
+their necks stretched, trying to see, and people on the inside trying to
+shove them back and shouting, “Back, back! give him air, give him air!”
+
+Colonel Sherburn he tossed his pistol on to the ground, and turned
+around on his heels and walked off.
+
+They took Boggs to a little drug store, the crowd pressing around just
+the same, and the whole town following, and I rushed and got a good
+place at the window, where I was close to him and could see in.  They
+laid him on the floor and put one large Bible under his head, and opened
+another one and spread it on his breast; but they tore open his shirt
+first, and I seen where one of the bullets went in.  He made about a
+dozen long gasps, his breast lifting the Bible up when he drawed in his
+breath, and letting it down again when he breathed it out--and after that
+he laid still; he was dead.  Then they pulled his daughter away from
+him, screaming and crying, and took her off.  She was about sixteen, and
+very sweet and gentle looking, but awful pale and scared.
+
+Well, pretty soon the whole town was there, squirming and scrouging and
+pushing and shoving to get at the window and have a look, but people
+that had the places wouldn’t give them up, and folks behind them was
+saying all the time, “Say, now, you’ve looked enough, you fellows;
+‘tain’t right and ‘tain’t fair for you to stay thar all the time, and
+never give nobody a chance; other folks has their rights as well as
+you.”
+
+There was considerable jawing back, so I slid out, thinking maybe
+there was going to be trouble.  The streets was full, and everybody was
+excited. Everybody that seen the shooting was telling how it happened,
+and there was a big crowd packed around each one of these fellows,
+stretching their necks and listening.  One long, lanky man, with long
+hair and a big white fur stovepipe hat on the back of his head, and a
+crooked-handled cane, marked out the places on the ground where Boggs
+stood and where Sherburn stood, and the people following him around from
+one place to t’other and watching everything he done, and bobbing their
+heads to show they understood, and stooping a little and resting their
+hands on their thighs to watch him mark the places on the ground with
+his cane; and then he stood up straight and stiff where Sherburn had
+stood, frowning and having his hat-brim down over his eyes, and sung
+out, “Boggs!” and then fetched his cane down slow to a level, and says
+“Bang!” staggered backwards, says “Bang!” again, and fell down flat on
+his back. The people that had seen the thing said he done it perfect;
+said it was just exactly the way it all happened.  Then as much as a
+dozen people got out their bottles and treated him.
+
+Well, by and by somebody said Sherburn ought to be lynched.  In about a
+minute everybody was saying it; so away they went, mad and yelling, and
+snatching down every clothes-line they come to to do the hanging with.
+
+
+
+
+CHAPTER XXII.
+
+THEY swarmed up towards Sherburn’s house, a-whooping and raging like
+Injuns, and everything had to clear the way or get run over and tromped
+to mush, and it was awful to see.  Children was heeling it ahead of the
+mob, screaming and trying to get out of the way; and every window along
+the road was full of women’s heads, and there was nigger boys in every
+tree, and bucks and wenches looking over every fence; and as soon as the
+mob would get nearly to them they would break and skaddle back out of
+reach.  Lots of the women and girls was crying and taking on, scared
+most to death.
+
+They swarmed up in front of Sherburn’s palings as thick as they could
+jam together, and you couldn’t hear yourself think for the noise.  It
+was a little twenty-foot yard.  Some sung out “Tear down the fence! tear
+down the fence!”  Then there was a racket of ripping and tearing and
+smashing, and down she goes, and the front wall of the crowd begins to
+roll in like a wave.
+
+Just then Sherburn steps out on to the roof of his little front porch,
+with a double-barrel gun in his hand, and takes his stand, perfectly
+ca’m and deliberate, not saying a word.  The racket stopped, and the
+wave sucked back.
+
+Sherburn never said a word--just stood there, looking down.  The
+stillness was awful creepy and uncomfortable.  Sherburn run his eye slow
+along the crowd; and wherever it struck the people tried a little to
+out-gaze him, but they couldn’t; they dropped their eyes and looked
+sneaky. Then pretty soon Sherburn sort of laughed; not the pleasant
+kind, but the kind that makes you feel like when you are eating bread
+that’s got sand in it.
+
+Then he says, slow and scornful:
+
+“The idea of _you_ lynching anybody!  It’s amusing.  The idea of you
+thinking you had pluck enough to lynch a _man_!  Because you’re brave
+enough to tar and feather poor friendless cast-out women that come along
+here, did that make you think you had grit enough to lay your hands on a
+_man_?  Why, a _man’s_ safe in the hands of ten thousand of your kind--as
+long as it’s daytime and you’re not behind him.
+
+“Do I know you?  I know you clear through. I was born and raised in the
+South, and I’ve lived in the North; so I know the average all around.
+The average man’s a coward.  In the North he lets anybody walk over him
+that wants to, and goes home and prays for a humble spirit to bear it.
+In the South one man all by himself, has stopped a stage full of men
+in the daytime, and robbed the lot.  Your newspapers call you a
+brave people so much that you think you are braver than any other
+people--whereas you’re just _as_ brave, and no braver.  Why don’t your
+juries hang murderers?  Because they’re afraid the man’s friends will
+shoot them in the back, in the dark--and it’s just what they _would_ do.
+
+“So they always acquit; and then a _man_ goes in the night, with a
+hundred masked cowards at his back and lynches the rascal.  Your mistake
+is, that you didn’t bring a man with you; that’s one mistake, and the
+other is that you didn’t come in the dark and fetch your masks.  You
+brought _part_ of a man--Buck Harkness, there--and if you hadn’t had him
+to start you, you’d a taken it out in blowing.
+
+“You didn’t want to come.  The average man don’t like trouble and
+danger. _You_ don’t like trouble and danger.  But if only _half_ a
+man--like Buck Harkness, there--shouts ‘Lynch him! lynch him!’ you’re
+afraid to back down--afraid you’ll be found out to be what you
+are--_cowards_--and so you raise a yell, and hang yourselves on to that
+half-a-man’s coat-tail, and come raging up here, swearing what big
+things you’re going to do. The pitifulest thing out is a mob; that’s
+what an army is--a mob; they don’t fight with courage that’s born in
+them, but with courage that’s borrowed from their mass, and from their
+officers.  But a mob without any _man_ at the head of it is _beneath_
+pitifulness.  Now the thing for _you_ to do is to droop your tails and
+go home and crawl in a hole.  If any real lynching’s going to be done it
+will be done in the dark, Southern fashion; and when they come they’ll
+bring their masks, and fetch a _man_ along.  Now _leave_--and take your
+half-a-man with you”--tossing his gun up across his left arm and cocking
+it when he says this.
+
+The crowd washed back sudden, and then broke all apart, and went tearing
+off every which way, and Buck Harkness he heeled it after them, looking
+tolerable cheap.  I could a stayed if I wanted to, but I didn’t want to.
+
+I went to the circus and loafed around the back side till the watchman
+went by, and then dived in under the tent.  I had my twenty-dollar gold
+piece and some other money, but I reckoned I better save it, because
+there ain’t no telling how soon you are going to need it, away from
+home and amongst strangers that way.  You can’t be too careful.  I ain’t
+opposed to spending money on circuses when there ain’t no other way, but
+there ain’t no use in _wasting_ it on them.
+
+It was a real bully circus.  It was the splendidest sight that ever was
+when they all come riding in, two and two, a gentleman and lady, side
+by side, the men just in their drawers and undershirts, and no shoes
+nor stirrups, and resting their hands on their thighs easy and
+comfortable--there must a been twenty of them--and every lady with a
+lovely complexion, and perfectly beautiful, and looking just like a gang
+of real sure-enough queens, and dressed in clothes that cost millions of
+dollars, and just littered with diamonds.  It was a powerful fine sight;
+I never see anything so lovely.  And then one by one they got up
+and stood, and went a-weaving around the ring so gentle and wavy and
+graceful, the men looking ever so tall and airy and straight, with their
+heads bobbing and skimming along, away up there under the tent-roof, and
+every lady’s rose-leafy dress flapping soft and silky around her hips,
+and she looking like the most loveliest parasol.
+
+And then faster and faster they went, all of them dancing, first one
+foot out in the air and then the other, the horses leaning more and
+more, and the ringmaster going round and round the center-pole, cracking
+his whip and shouting “Hi!--hi!” and the clown cracking jokes behind
+him; and by and by all hands dropped the reins, and every lady put her
+knuckles on her hips and every gentleman folded his arms, and then how
+the horses did lean over and hump themselves!  And so one after the
+other they all skipped off into the ring, and made the sweetest bow I
+ever see, and then scampered out, and everybody clapped their hands and
+went just about wild.
+
+Well, all through the circus they done the most astonishing things; and
+all the time that clown carried on so it most killed the people.  The
+ringmaster couldn’t ever say a word to him but he was back at him quick
+as a wink with the funniest things a body ever said; and how he ever
+_could_ think of so many of them, and so sudden and so pat, was what I
+couldn’t noway understand. Why, I couldn’t a thought of them in a year.
+And by and by a drunk man tried to get into the ring--said he wanted to
+ride; said he could ride as well as anybody that ever was.  They argued
+and tried to keep him out, but he wouldn’t listen, and the whole show
+come to a standstill.  Then the people begun to holler at him and make
+fun of him, and that made him mad, and he begun to rip and tear; so that
+stirred up the people, and a lot of men begun to pile down off of the
+benches and swarm towards the ring, saying, “Knock him down! throw him
+out!” and one or two women begun to scream.  So, then, the ringmaster
+he made a little speech, and said he hoped there wouldn’t be no
+disturbance, and if the man would promise he wouldn’t make no more
+trouble he would let him ride if he thought he could stay on the horse.
+ So everybody laughed and said all right, and the man got on. The minute
+he was on, the horse begun to rip and tear and jump and cavort around,
+with two circus men hanging on to his bridle trying to hold him, and the
+drunk man hanging on to his neck, and his heels flying in the air every
+jump, and the whole crowd of people standing up shouting and laughing
+till tears rolled down.  And at last, sure enough, all the circus men
+could do, the horse broke loose, and away he went like the very nation,
+round and round the ring, with that sot laying down on him and hanging
+to his neck, with first one leg hanging most to the ground on one side,
+and then t’other one on t’other side, and the people just crazy.  It
+warn’t funny to me, though; I was all of a tremble to see his danger.
+ But pretty soon he struggled up astraddle and grabbed the bridle,
+a-reeling this way and that; and the next minute he sprung up and
+dropped the bridle and stood! and the horse a-going like a house afire
+too.  He just stood up there, a-sailing around as easy and comfortable
+as if he warn’t ever drunk in his life--and then he begun to pull off his
+clothes and sling them.  He shed them so thick they kind of clogged up
+the air, and altogether he shed seventeen suits. And, then, there he
+was, slim and handsome, and dressed the gaudiest and prettiest you
+ever saw, and he lit into that horse with his whip and made him fairly
+hum--and finally skipped off, and made his bow and danced off to
+the dressing-room, and everybody just a-howling with pleasure and
+astonishment.
+
+Then the ringmaster he see how he had been fooled, and he _was_ the
+sickest ringmaster you ever see, I reckon.  Why, it was one of his own
+men!  He had got up that joke all out of his own head, and never let on
+to nobody. Well, I felt sheepish enough to be took in so, but I wouldn’t
+a been in that ringmaster’s place, not for a thousand dollars.  I don’t
+know; there may be bullier circuses than what that one was, but I
+never struck them yet. Anyways, it was plenty good enough for _me_; and
+wherever I run across it, it can have all of _my_ custom every time.
+
+Well, that night we had _our_ show; but there warn’t only about twelve
+people there--just enough to pay expenses.  And they laughed all the
+time, and that made the duke mad; and everybody left, anyway, before
+the show was over, but one boy which was asleep.  So the duke said these
+Arkansaw lunkheads couldn’t come up to Shakespeare; what they wanted
+was low comedy--and maybe something ruther worse than low comedy, he
+reckoned.  He said he could size their style.  So next morning he got
+some big sheets of wrapping paper and some black paint, and drawed off
+some handbills, and stuck them up all over the village.  The bills said:
+
+
+
+
+CHAPTER XXIII.
+
+WELL, all day him and the king was hard at it, rigging up a stage and
+a curtain and a row of candles for footlights; and that night the house
+was jam full of men in no time.  When the place couldn’t hold no more,
+the duke he quit tending door and went around the back way and come on
+to the stage and stood up before the curtain and made a little speech,
+and praised up this tragedy, and said it was the most thrillingest one
+that ever was; and so he went on a-bragging about the tragedy, and about
+Edmund Kean the Elder, which was to play the main principal part in it;
+and at last when he’d got everybody’s expectations up high enough, he
+rolled up the curtain, and the next minute the king come a-prancing
+out on all fours, naked; and he was painted all over,
+ring-streaked-and-striped, all sorts of colors, as splendid as a
+rainbow.  And--but never mind the rest of his outfit; it was just wild,
+but it was awful funny. The people most killed themselves laughing; and
+when the king got done capering and capered off behind the scenes, they
+roared and clapped and stormed and haw-hawed till he come back and done
+it over again, and after that they made him do it another time. Well, it
+would make a cow laugh to see the shines that old idiot cut.
+
+Then the duke he lets the curtain down, and bows to the people, and says
+the great tragedy will be performed only two nights more, on accounts of
+pressing London engagements, where the seats is all sold already for it
+in Drury Lane; and then he makes them another bow, and says if he has
+succeeded in pleasing them and instructing them, he will be deeply
+obleeged if they will mention it to their friends and get them to come
+and see it.
+
+Twenty people sings out:
+
+“What, is it over?  Is that _all_?”
+
+The duke says yes.  Then there was a fine time.  Everybody sings
+out, “Sold!” and rose up mad, and was a-going for that stage and them
+tragedians.  But a big, fine looking man jumps up on a bench and shouts:
+
+“Hold on!  Just a word, gentlemen.”  They stopped to listen.  “We are
+sold--mighty badly sold.  But we don’t want to be the laughing stock of
+this whole town, I reckon, and never hear the last of this thing as long
+as we live.  _No_.  What we want is to go out of here quiet, and talk
+this show up, and sell the _rest_ of the town!  Then we’ll all be in the
+same boat.  Ain’t that sensible?” (“You bet it is!--the jedge is right!”
+ everybody sings out.) “All right, then--not a word about any sell.  Go
+along home, and advise everybody to come and see the tragedy.”
+
+Next day you couldn’t hear nothing around that town but how splendid
+that show was.  House was jammed again that night, and we sold this
+crowd the same way.  When me and the king and the duke got home to the
+raft we all had a supper; and by and by, about midnight, they made Jim
+and me back her out and float her down the middle of the river, and
+fetch her in and hide her about two mile below town.
+
+The third night the house was crammed again--and they warn’t new-comers
+this time, but people that was at the show the other two nights.  I
+stood by the duke at the door, and I see that every man that went in had
+his pockets bulging, or something muffled up under his coat--and I see it
+warn’t no perfumery, neither, not by a long sight.  I smelt sickly eggs
+by the barrel, and rotten cabbages, and such things; and if I know the
+signs of a dead cat being around, and I bet I do, there was sixty-four
+of them went in.  I shoved in there for a minute, but it was too various
+for me; I couldn’t stand it.  Well, when the place couldn’t hold no more
+people the duke he give a fellow a quarter and told him to tend door
+for him a minute, and then he started around for the stage door, I after
+him; but the minute we turned the corner and was in the dark he says:
+
+“Walk fast now till you get away from the houses, and then shin for the
+raft like the dickens was after you!”
+
+I done it, and he done the same.  We struck the raft at the same time,
+and in less than two seconds we was gliding down stream, all dark and
+still, and edging towards the middle of the river, nobody saying a
+word. I reckoned the poor king was in for a gaudy time of it with the
+audience, but nothing of the sort; pretty soon he crawls out from under
+the wigwam, and says:
+
+“Well, how’d the old thing pan out this time, duke?”  He hadn’t been
+up-town at all.
+
+We never showed a light till we was about ten mile below the village.
+Then we lit up and had a supper, and the king and the duke fairly
+laughed their bones loose over the way they’d served them people.  The
+duke says:
+
+“Greenhorns, flatheads!  I knew the first house would keep mum and let
+the rest of the town get roped in; and I knew they’d lay for us the
+third night, and consider it was _their_ turn now.  Well, it _is_ their
+turn, and I’d give something to know how much they’d take for it.  I
+_would_ just like to know how they’re putting in their opportunity.
+ They can turn it into a picnic if they want to--they brought plenty
+provisions.”
+
+Them rapscallions took in four hundred and sixty-five dollars in that
+three nights.  I never see money hauled in by the wagon-load like that
+before.  By and by, when they was asleep and snoring, Jim says:
+
+“Don’t it s’prise you de way dem kings carries on, Huck?”
+
+“No,” I says, “it don’t.”
+
+“Why don’t it, Huck?”
+
+“Well, it don’t, because it’s in the breed.  I reckon they’re all
+alike.”
+
+“But, Huck, dese kings o’ ourn is reglar rapscallions; dat’s jist what
+dey is; dey’s reglar rapscallions.”
+
+“Well, that’s what I’m a-saying; all kings is mostly rapscallions, as
+fur as I can make out.”
+
+“Is dat so?”
+
+“You read about them once--you’ll see.  Look at Henry the Eight; this ‘n
+‘s a Sunday-school Superintendent to _him_.  And look at Charles Second,
+and Louis Fourteen, and Louis Fifteen, and James Second, and Edward
+Second, and Richard Third, and forty more; besides all them Saxon
+heptarchies that used to rip around so in old times and raise Cain.  My,
+you ought to seen old Henry the Eight when he was in bloom.  He _was_ a
+blossom.  He used to marry a new wife every day, and chop off her head
+next morning.  And he would do it just as indifferent as if he was
+ordering up eggs.  ‘Fetch up Nell Gwynn,’ he says.  They fetch her up.
+Next morning, ‘Chop off her head!’  And they chop it off.  ‘Fetch up
+Jane Shore,’ he says; and up she comes, Next morning, ‘Chop off her
+head’--and they chop it off.  ‘Ring up Fair Rosamun.’  Fair Rosamun
+answers the bell.  Next morning, ‘Chop off her head.’  And he made every
+one of them tell him a tale every night; and he kept that up till he had
+hogged a thousand and one tales that way, and then he put them all in a
+book, and called it Domesday Book--which was a good name and stated the
+case.  You don’t know kings, Jim, but I know them; and this old rip
+of ourn is one of the cleanest I’ve struck in history.  Well, Henry he
+takes a notion he wants to get up some trouble with this country. How
+does he go at it--give notice?--give the country a show?  No.  All of a
+sudden he heaves all the tea in Boston Harbor overboard, and whacks
+out a declaration of independence, and dares them to come on.  That was
+_his_ style--he never give anybody a chance.  He had suspicions of his
+father, the Duke of Wellington.  Well, what did he do?  Ask him to show
+up?  No--drownded him in a butt of mamsey, like a cat.  S’pose people
+left money laying around where he was--what did he do?  He collared it.
+ S’pose he contracted to do a thing, and you paid him, and didn’t set
+down there and see that he done it--what did he do?  He always done the
+other thing. S’pose he opened his mouth--what then?  If he didn’t shut it
+up powerful quick he’d lose a lie every time.  That’s the kind of a bug
+Henry was; and if we’d a had him along ‘stead of our kings he’d a fooled
+that town a heap worse than ourn done.  I don’t say that ourn is lambs,
+because they ain’t, when you come right down to the cold facts; but they
+ain’t nothing to _that_ old ram, anyway.  All I say is, kings is kings,
+and you got to make allowances.  Take them all around, they’re a mighty
+ornery lot. It’s the way they’re raised.”
+
+“But dis one do _smell_ so like de nation, Huck.”
+
+“Well, they all do, Jim.  We can’t help the way a king smells; history
+don’t tell no way.”
+
+“Now de duke, he’s a tolerble likely man in some ways.”
+
+“Yes, a duke’s different.  But not very different.  This one’s
+a middling hard lot for a duke.  When he’s drunk there ain’t no
+near-sighted man could tell him from a king.”
+
+“Well, anyways, I doan’ hanker for no mo’ un um, Huck.  Dese is all I
+kin stan’.”
+
+“It’s the way I feel, too, Jim.  But we’ve got them on our hands, and we
+got to remember what they are, and make allowances.  Sometimes I wish we
+could hear of a country that’s out of kings.”
+
+What was the use to tell Jim these warn’t real kings and dukes?  It
+wouldn’t a done no good; and, besides, it was just as I said:  you
+couldn’t tell them from the real kind.
+
+I went to sleep, and Jim didn’t call me when it was my turn.  He often
+done that.  When I waked up just at daybreak he was sitting there with
+his head down betwixt his knees, moaning and mourning to himself.  I
+didn’t take notice nor let on.  I knowed what it was about.  He was
+thinking about his wife and his children, away up yonder, and he was low
+and homesick; because he hadn’t ever been away from home before in his
+life; and I do believe he cared just as much for his people as white
+folks does for their’n.  It don’t seem natural, but I reckon it’s so.
+ He was often moaning and mourning that way nights, when he judged I
+was asleep, and saying, “Po’ little ‘Lizabeth! po’ little Johnny! it’s
+mighty hard; I spec’ I ain’t ever gwyne to see you no mo’, no mo’!”  He
+was a mighty good nigger, Jim was.
+
+But this time I somehow got to talking to him about his wife and young
+ones; and by and by he says:
+
+“What makes me feel so bad dis time ‘uz bekase I hear sumpn over yonder
+on de bank like a whack, er a slam, while ago, en it mine me er de time
+I treat my little ‘Lizabeth so ornery.  She warn’t on’y ‘bout fo’ year
+ole, en she tuck de sk’yarlet fever, en had a powful rough spell; but
+she got well, en one day she was a-stannin’ aroun’, en I says to her, I
+says:
+
+“‘Shet de do’.’
+
+“She never done it; jis’ stood dah, kiner smilin’ up at me.  It make me
+mad; en I says agin, mighty loud, I says:
+
+“‘Doan’ you hear me?  Shet de do’!’
+
+“She jis stood de same way, kiner smilin’ up.  I was a-bilin’!  I says:
+
+“‘I lay I _make_ you mine!’
+
+“En wid dat I fetch’ her a slap side de head dat sont her a-sprawlin’.
+Den I went into de yuther room, en ‘uz gone ‘bout ten minutes; en when
+I come back dah was dat do’ a-stannin’ open _yit_, en dat chile stannin’
+mos’ right in it, a-lookin’ down and mournin’, en de tears runnin’ down.
+ My, but I _wuz_ mad!  I was a-gwyne for de chile, but jis’ den--it was a
+do’ dat open innerds--jis’ den, ‘long come de wind en slam it to, behine
+de chile, ker-BLAM!--en my lan’, de chile never move’!  My breff mos’
+hop outer me; en I feel so--so--I doan’ know HOW I feel.  I crope out,
+all a-tremblin’, en crope aroun’ en open de do’ easy en slow, en poke my
+head in behine de chile, sof’ en still, en all uv a sudden I says POW!
+jis’ as loud as I could yell.  _She never budge!_  Oh, Huck, I bust out
+a-cryin’ en grab her up in my arms, en say, ‘Oh, de po’ little thing!
+ De Lord God Amighty fogive po’ ole Jim, kaze he never gwyne to fogive
+hisself as long’s he live!’  Oh, she was plumb deef en dumb, Huck, plumb
+deef en dumb--en I’d ben a-treat’n her so!”
+
+
+
+
+CHAPTER XXIV.
+
+NEXT day, towards night, we laid up under a little willow towhead out in
+the middle, where there was a village on each side of the river, and the
+duke and the king begun to lay out a plan for working them towns.  Jim
+he spoke to the duke, and said he hoped it wouldn’t take but a few
+hours, because it got mighty heavy and tiresome to him when he had to
+lay all day in the wigwam tied with the rope.  You see, when we left him
+all alone we had to tie him, because if anybody happened on to him all
+by himself and not tied it wouldn’t look much like he was a runaway
+nigger, you know. So the duke said it _was_ kind of hard to have to lay
+roped all day, and he’d cipher out some way to get around it.
+
+He was uncommon bright, the duke was, and he soon struck it.  He dressed
+Jim up in King Lear’s outfit--it was a long curtain-calico gown, and a
+white horse-hair wig and whiskers; and then he took his theater paint
+and painted Jim’s face and hands and ears and neck all over a dead,
+dull, solid blue, like a man that’s been drownded nine days.  Blamed if
+he warn’t the horriblest looking outrage I ever see.  Then the duke took
+and wrote out a sign on a shingle so:
+
+Sick Arab--but harmless when not out of his head.
+
+And he nailed that shingle to a lath, and stood the lath up four or five
+foot in front of the wigwam.  Jim was satisfied.  He said it was a sight
+better than lying tied a couple of years every day, and trembling all
+over every time there was a sound.  The duke told him to make himself
+free and easy, and if anybody ever come meddling around, he must hop
+out of the wigwam, and carry on a little, and fetch a howl or two like
+a wild beast, and he reckoned they would light out and leave him alone.
+ Which was sound enough judgment; but you take the average man, and he
+wouldn’t wait for him to howl.  Why, he didn’t only look like he was
+dead, he looked considerable more than that.
+
+These rapscallions wanted to try the Nonesuch again, because there was
+so much money in it, but they judged it wouldn’t be safe, because maybe
+the news might a worked along down by this time.  They couldn’t hit no
+project that suited exactly; so at last the duke said he reckoned he’d
+lay off and work his brains an hour or two and see if he couldn’t put up
+something on the Arkansaw village; and the king he allowed he would drop
+over to t’other village without any plan, but just trust in Providence
+to lead him the profitable way--meaning the devil, I reckon.  We had all
+bought store clothes where we stopped last; and now the king put his’n
+on, and he told me to put mine on.  I done it, of course.  The king’s
+duds was all black, and he did look real swell and starchy.  I never
+knowed how clothes could change a body before.  Why, before, he looked
+like the orneriest old rip that ever was; but now, when he’d take off
+his new white beaver and make a bow and do a smile, he looked that grand
+and good and pious that you’d say he had walked right out of the ark,
+and maybe was old Leviticus himself.  Jim cleaned up the canoe, and I
+got my paddle ready.  There was a big steamboat laying at the shore away
+up under the point, about three mile above the town--been there a couple
+of hours, taking on freight.  Says the king:
+
+“Seein’ how I’m dressed, I reckon maybe I better arrive down from St.
+Louis or Cincinnati, or some other big place.  Go for the steamboat,
+Huckleberry; we’ll come down to the village on her.”
+
+I didn’t have to be ordered twice to go and take a steamboat ride.
+ I fetched the shore a half a mile above the village, and then went
+scooting along the bluff bank in the easy water.  Pretty soon we come to
+a nice innocent-looking young country jake setting on a log swabbing the
+sweat off of his face, for it was powerful warm weather; and he had a
+couple of big carpet-bags by him.
+
+“Run her nose in shore,” says the king.  I done it.  “Wher’ you bound
+for, young man?”
+
+“For the steamboat; going to Orleans.”
+
+“Git aboard,” says the king.  “Hold on a minute, my servant ‘ll he’p you
+with them bags.  Jump out and he’p the gentleman, Adolphus”--meaning me,
+I see.
+
+I done so, and then we all three started on again.  The young chap was
+mighty thankful; said it was tough work toting his baggage such weather.
+He asked the king where he was going, and the king told him he’d come
+down the river and landed at the other village this morning, and now he
+was going up a few mile to see an old friend on a farm up there.  The
+young fellow says:
+
+“When I first see you I says to myself, ‘It’s Mr. Wilks, sure, and he
+come mighty near getting here in time.’  But then I says again, ‘No, I
+reckon it ain’t him, or else he wouldn’t be paddling up the river.’  You
+_ain’t_ him, are you?”
+
+“No, my name’s Blodgett--Elexander Blodgett--_Reverend_ Elexander
+Blodgett, I s’pose I must say, as I’m one o’ the Lord’s poor servants.
+ But still I’m jist as able to be sorry for Mr. Wilks for not arriving
+in time, all the same, if he’s missed anything by it--which I hope he
+hasn’t.”
+
+“Well, he don’t miss any property by it, because he’ll get that all
+right; but he’s missed seeing his brother Peter die--which he mayn’t
+mind, nobody can tell as to that--but his brother would a give anything
+in this world to see _him_ before he died; never talked about nothing
+else all these three weeks; hadn’t seen him since they was boys
+together--and hadn’t ever seen his brother William at all--that’s the deef
+and dumb one--William ain’t more than thirty or thirty-five.  Peter and
+George were the only ones that come out here; George was the married
+brother; him and his wife both died last year.  Harvey and William’s the
+only ones that’s left now; and, as I was saying, they haven’t got here
+in time.”
+
+“Did anybody send ‘em word?”
+
+“Oh, yes; a month or two ago, when Peter was first took; because Peter
+said then that he sorter felt like he warn’t going to get well this
+time. You see, he was pretty old, and George’s g’yirls was too young to
+be much company for him, except Mary Jane, the red-headed one; and so he
+was kinder lonesome after George and his wife died, and didn’t seem
+to care much to live.  He most desperately wanted to see Harvey--and
+William, too, for that matter--because he was one of them kind that can’t
+bear to make a will.  He left a letter behind for Harvey, and said he’d
+told in it where his money was hid, and how he wanted the rest of the
+property divided up so George’s g’yirls would be all right--for George
+didn’t leave nothing.  And that letter was all they could get him to put
+a pen to.”
+
+“Why do you reckon Harvey don’t come?  Wher’ does he live?”
+
+“Oh, he lives in England--Sheffield--preaches there--hasn’t ever been in
+this country.  He hasn’t had any too much time--and besides he mightn’t a
+got the letter at all, you know.”
+
+“Too bad, too bad he couldn’t a lived to see his brothers, poor soul.
+You going to Orleans, you say?”
+
+“Yes, but that ain’t only a part of it.  I’m going in a ship, next
+Wednesday, for Ryo Janeero, where my uncle lives.”
+
+“It’s a pretty long journey.  But it’ll be lovely; wisht I was a-going.
+Is Mary Jane the oldest?  How old is the others?”
+
+“Mary Jane’s nineteen, Susan’s fifteen, and Joanna’s about
+fourteen--that’s the one that gives herself to good works and has a
+hare-lip.”
+
+“Poor things! to be left alone in the cold world so.”
+
+“Well, they could be worse off.  Old Peter had friends, and they
+ain’t going to let them come to no harm.  There’s Hobson, the Babtis’
+preacher; and Deacon Lot Hovey, and Ben Rucker, and Abner Shackleford,
+and Levi Bell, the lawyer; and Dr. Robinson, and their wives, and the
+widow Bartley, and--well, there’s a lot of them; but these are the ones
+that Peter was thickest with, and used to write about sometimes, when
+he wrote home; so Harvey ‘ll know where to look for friends when he gets
+here.”
+
+Well, the old man went on asking questions till he just fairly emptied
+that young fellow.  Blamed if he didn’t inquire about everybody and
+everything in that blessed town, and all about the Wilkses; and about
+Peter’s business--which was a tanner; and about George’s--which was a
+carpenter; and about Harvey’s--which was a dissentering minister; and so
+on, and so on.  Then he says:
+
+“What did you want to walk all the way up to the steamboat for?”
+
+“Because she’s a big Orleans boat, and I was afeard she mightn’t stop
+there.  When they’re deep they won’t stop for a hail.  A Cincinnati boat
+will, but this is a St. Louis one.”
+
+“Was Peter Wilks well off?”
+
+“Oh, yes, pretty well off.  He had houses and land, and it’s reckoned he
+left three or four thousand in cash hid up som’ers.”
+
+“When did you say he died?”
+
+“I didn’t say, but it was last night.”
+
+“Funeral to-morrow, likely?”
+
+“Yes, ‘bout the middle of the day.”
+
+“Well, it’s all terrible sad; but we’ve all got to go, one time or
+another. So what we want to do is to be prepared; then we’re all right.”
+
+“Yes, sir, it’s the best way.  Ma used to always say that.”
+
+When we struck the boat she was about done loading, and pretty soon she
+got off.  The king never said nothing about going aboard, so I lost
+my ride, after all.  When the boat was gone the king made me paddle up
+another mile to a lonesome place, and then he got ashore and says:
+
+“Now hustle back, right off, and fetch the duke up here, and the new
+carpet-bags.  And if he’s gone over to t’other side, go over there and
+git him.  And tell him to git himself up regardless.  Shove along, now.”
+
+I see what _he_ was up to; but I never said nothing, of course.  When
+I got back with the duke we hid the canoe, and then they set down on a
+log, and the king told him everything, just like the young fellow had
+said it--every last word of it.  And all the time he was a-doing it he
+tried to talk like an Englishman; and he done it pretty well, too, for
+a slouch. I can’t imitate him, and so I ain’t a-going to try to; but he
+really done it pretty good.  Then he says:
+
+“How are you on the deef and dumb, Bilgewater?”
+
+The duke said, leave him alone for that; said he had played a deef
+and dumb person on the histronic boards.  So then they waited for a
+steamboat.
+
+About the middle of the afternoon a couple of little boats come along,
+but they didn’t come from high enough up the river; but at last there
+was a big one, and they hailed her.  She sent out her yawl, and we went
+aboard, and she was from Cincinnati; and when they found we only wanted
+to go four or five mile they was booming mad, and gave us a cussing, and
+said they wouldn’t land us.  But the king was ca’m.  He says:
+
+“If gentlemen kin afford to pay a dollar a mile apiece to be took on and
+put off in a yawl, a steamboat kin afford to carry ‘em, can’t it?”
+
+So they softened down and said it was all right; and when we got to the
+village they yawled us ashore.  About two dozen men flocked down when
+they see the yawl a-coming, and when the king says:
+
+“Kin any of you gentlemen tell me wher’ Mr. Peter Wilks lives?” they
+give a glance at one another, and nodded their heads, as much as to say,
+“What d’ I tell you?”  Then one of them says, kind of soft and gentle:
+
+“I’m sorry sir, but the best we can do is to tell you where he _did_
+live yesterday evening.”
+
+Sudden as winking the ornery old cretur went an to smash, and fell up
+against the man, and put his chin on his shoulder, and cried down his
+back, and says:
+
+“Alas, alas, our poor brother--gone, and we never got to see him; oh,
+it’s too, too hard!”
+
+Then he turns around, blubbering, and makes a lot of idiotic signs to
+the duke on his hands, and blamed if he didn’t drop a carpet-bag and
+bust out a-crying.  If they warn’t the beatenest lot, them two frauds,
+that ever I struck.
+
+Well, the men gathered around and sympathized with them, and said all
+sorts of kind things to them, and carried their carpet-bags up the hill
+for them, and let them lean on them and cry, and told the king all about
+his brother’s last moments, and the king he told it all over again on
+his hands to the duke, and both of them took on about that dead tanner
+like they’d lost the twelve disciples.  Well, if ever I struck anything
+like it, I’m a nigger. It was enough to make a body ashamed of the human
+race.
+
+
+
+
+CHAPTER XXV.
+
+THE news was all over town in two minutes, and you could see the people
+tearing down on the run from every which way, some of them putting on
+their coats as they come.  Pretty soon we was in the middle of a crowd,
+and the noise of the tramping was like a soldier march.  The windows and
+dooryards was full; and every minute somebody would say, over a fence:
+
+“Is it _them_?”
+
+And somebody trotting along with the gang would answer back and say:
+
+“You bet it is.”
+
+When we got to the house the street in front of it was packed, and the
+three girls was standing in the door.  Mary Jane _was_ red-headed, but
+that don’t make no difference, she was most awful beautiful, and her
+face and her eyes was all lit up like glory, she was so glad her uncles
+was come. The king he spread his arms, and Mary Jane she jumped for
+them, and the hare-lip jumped for the duke, and there they had it!
+ Everybody most, leastways women, cried for joy to see them meet again
+at last and have such good times.
+
+Then the king he hunched the duke private--I see him do it--and then he
+looked around and see the coffin, over in the corner on two chairs; so
+then him and the duke, with a hand across each other’s shoulder, and
+t’other hand to their eyes, walked slow and solemn over there, everybody
+dropping back to give them room, and all the talk and noise stopping,
+people saying “Sh!” and all the men taking their hats off and drooping
+their heads, so you could a heard a pin fall.  And when they got there
+they bent over and looked in the coffin, and took one sight, and then
+they bust out a-crying so you could a heard them to Orleans, most; and
+then they put their arms around each other’s necks, and hung their chins
+over each other’s shoulders; and then for three minutes, or maybe four,
+I never see two men leak the way they done.  And, mind you, everybody
+was doing the same; and the place was that damp I never see anything
+like it. Then one of them got on one side of the coffin, and t’other on
+t’other side, and they kneeled down and rested their foreheads on the
+coffin, and let on to pray all to themselves.  Well, when it come
+to that it worked the crowd like you never see anything like it, and
+everybody broke down and went to sobbing right out loud--the poor girls,
+too; and every woman, nearly, went up to the girls, without saying a
+word, and kissed them, solemn, on the forehead, and then put their hand
+on their head, and looked up towards the sky, with the tears running
+down, and then busted out and went off sobbing and swabbing, and give
+the next woman a show.  I never see anything so disgusting.
+
+Well, by and by the king he gets up and comes forward a little, and
+works himself up and slobbers out a speech, all full of tears and
+flapdoodle about its being a sore trial for him and his poor brother
+to lose the diseased, and to miss seeing diseased alive after the long
+journey of four thousand mile, but it’s a trial that’s sweetened and
+sanctified to us by this dear sympathy and these holy tears, and so he
+thanks them out of his heart and out of his brother’s heart, because out
+of their mouths they can’t, words being too weak and cold, and all that
+kind of rot and slush, till it was just sickening; and then he blubbers
+out a pious goody-goody Amen, and turns himself loose and goes to crying
+fit to bust.
+
+And the minute the words were out of his mouth somebody over in the
+crowd struck up the doxolojer, and everybody joined in with all their
+might, and it just warmed you up and made you feel as good as church
+letting out. Music is a good thing; and after all that soul-butter and
+hogwash I never see it freshen up things so, and sound so honest and
+bully.
+
+Then the king begins to work his jaw again, and says how him and his
+nieces would be glad if a few of the main principal friends of the
+family would take supper here with them this evening, and help set up
+with the ashes of the diseased; and says if his poor brother laying
+yonder could speak he knows who he would name, for they was names that
+was very dear to him, and mentioned often in his letters; and so he will
+name the same, to wit, as follows, vizz.:--Rev. Mr. Hobson, and Deacon
+Lot Hovey, and Mr. Ben Rucker, and Abner Shackleford, and Levi Bell, and
+Dr. Robinson, and their wives, and the widow Bartley.
+
+Rev. Hobson and Dr. Robinson was down to the end of the town a-hunting
+together--that is, I mean the doctor was shipping a sick man to t’other
+world, and the preacher was pinting him right.  Lawyer Bell was away up
+to Louisville on business.  But the rest was on hand, and so they all
+come and shook hands with the king and thanked him and talked to him;
+and then they shook hands with the duke and didn’t say nothing, but just
+kept a-smiling and bobbing their heads like a passel of sapheads whilst
+he made all sorts of signs with his hands and said “Goo-goo--goo-goo-goo”
+ all the time, like a baby that can’t talk.
+
+So the king he blattered along, and managed to inquire about pretty
+much everybody and dog in town, by his name, and mentioned all sorts
+of little things that happened one time or another in the town, or to
+George’s family, or to Peter.  And he always let on that Peter wrote him
+the things; but that was a lie:  he got every blessed one of them out of
+that young flathead that we canoed up to the steamboat.
+
+Then Mary Jane she fetched the letter her father left behind, and the
+king he read it out loud and cried over it.  It give the dwelling-house
+and three thousand dollars, gold, to the girls; and it give the tanyard
+(which was doing a good business), along with some other houses and
+land (worth about seven thousand), and three thousand dollars in gold
+to Harvey and William, and told where the six thousand cash was hid down
+cellar.  So these two frauds said they’d go and fetch it up, and have
+everything square and above-board; and told me to come with a candle.
+ We shut the cellar door behind us, and when they found the bag
+they spilt it out on the floor, and it was a lovely sight, all them
+yaller-boys.  My, the way the king’s eyes did shine!  He slaps the duke
+on the shoulder and says:
+
+“Oh, _this_ ain’t bully nor noth’n!  Oh, no, I reckon not!  Why,
+_bully_, it beats the Nonesuch, _don’t_ it?”
+
+The duke allowed it did.  They pawed the yaller-boys, and sifted them
+through their fingers and let them jingle down on the floor; and the
+king says:
+
+“It ain’t no use talkin’; bein’ brothers to a rich dead man and
+representatives of furrin heirs that’s got left is the line for you and
+me, Bilge.  Thish yer comes of trust’n to Providence.  It’s the best
+way, in the long run.  I’ve tried ‘em all, and ther’ ain’t no better
+way.”
+
+Most everybody would a been satisfied with the pile, and took it on
+trust; but no, they must count it.  So they counts it, and it comes out
+four hundred and fifteen dollars short.  Says the king:
+
+“Dern him, I wonder what he done with that four hundred and fifteen
+dollars?”
+
+They worried over that awhile, and ransacked all around for it.  Then
+the duke says:
+
+“Well, he was a pretty sick man, and likely he made a mistake--I reckon
+that’s the way of it.  The best way’s to let it go, and keep still about
+it.  We can spare it.”
+
+“Oh, shucks, yes, we can _spare_ it.  I don’t k’yer noth’n ‘bout
+that--it’s the _count_ I’m thinkin’ about.  We want to be awful square
+and open and above-board here, you know.  We want to lug this h-yer
+money up stairs and count it before everybody--then ther’ ain’t noth’n
+suspicious.  But when the dead man says ther’s six thous’n dollars, you
+know, we don’t want to--”
+
+“Hold on,” says the duke.  “Le’s make up the deffisit,” and he begun to
+haul out yaller-boys out of his pocket.
+
+“It’s a most amaz’n’ good idea, duke--you _have_ got a rattlin’ clever
+head on you,” says the king.  “Blest if the old Nonesuch ain’t a heppin’
+us out agin,” and _he_ begun to haul out yaller-jackets and stack them
+up.
+
+It most busted them, but they made up the six thousand clean and clear.
+
+“Say,” says the duke, “I got another idea.  Le’s go up stairs and count
+this money, and then take and _give it to the girls_.”
+
+“Good land, duke, lemme hug you!  It’s the most dazzling idea ‘at ever a
+man struck.  You have cert’nly got the most astonishin’ head I ever see.
+Oh, this is the boss dodge, ther’ ain’t no mistake ‘bout it.  Let ‘em
+fetch along their suspicions now if they want to--this ‘ll lay ‘em out.”
+
+When we got up-stairs everybody gethered around the table, and the king
+he counted it and stacked it up, three hundred dollars in a pile--twenty
+elegant little piles.  Everybody looked hungry at it, and licked their
+chops.  Then they raked it into the bag again, and I see the king begin
+to swell himself up for another speech.  He says:
+
+“Friends all, my poor brother that lays yonder has done generous by
+them that’s left behind in the vale of sorrers.  He has done generous by
+these yer poor little lambs that he loved and sheltered, and that’s left
+fatherless and motherless.  Yes, and we that knowed him knows that he
+would a done _more_ generous by ‘em if he hadn’t ben afeard o’ woundin’
+his dear William and me.  Now, _wouldn’t_ he?  Ther’ ain’t no question
+‘bout it in _my_ mind.  Well, then, what kind o’ brothers would it be
+that ‘d stand in his way at sech a time?  And what kind o’ uncles would
+it be that ‘d rob--yes, _rob_--sech poor sweet lambs as these ‘at he loved
+so at sech a time?  If I know William--and I _think_ I do--he--well, I’ll
+jest ask him.” He turns around and begins to make a lot of signs to
+the duke with his hands, and the duke he looks at him stupid and
+leather-headed a while; then all of a sudden he seems to catch his
+meaning, and jumps for the king, goo-gooing with all his might for joy,
+and hugs him about fifteen times before he lets up.  Then the king says,
+“I knowed it; I reckon _that ‘ll_ convince anybody the way _he_ feels
+about it.  Here, Mary Jane, Susan, Joanner, take the money--take it
+_all_.  It’s the gift of him that lays yonder, cold but joyful.”
+
+Mary Jane she went for him, Susan and the hare-lip went for the
+duke, and then such another hugging and kissing I never see yet.  And
+everybody crowded up with the tears in their eyes, and most shook the
+hands off of them frauds, saying all the time:
+
+“You _dear_ good souls!--how _lovely_!--how _could_ you!”
+
+Well, then, pretty soon all hands got to talking about the diseased
+again, and how good he was, and what a loss he was, and all that; and
+before long a big iron-jawed man worked himself in there from outside,
+and stood a-listening and looking, and not saying anything; and nobody
+saying anything to him either, because the king was talking and they was
+all busy listening.  The king was saying--in the middle of something he’d
+started in on--
+
+“--they bein’ partickler friends o’ the diseased.  That’s why they’re
+invited here this evenin’; but tomorrow we want _all_ to come--everybody;
+for he respected everybody, he liked everybody, and so it’s fitten that
+his funeral orgies sh’d be public.”
+
+And so he went a-mooning on and on, liking to hear himself talk, and
+every little while he fetched in his funeral orgies again, till the duke
+he couldn’t stand it no more; so he writes on a little scrap of paper,
+“_Obsequies_, you old fool,” and folds it up, and goes to goo-gooing and
+reaching it over people’s heads to him.  The king he reads it and puts
+it in his pocket, and says:
+
+“Poor William, afflicted as he is, his _heart’s_ aluz right.  Asks me
+to invite everybody to come to the funeral--wants me to make ‘em all
+welcome.  But he needn’t a worried--it was jest what I was at.”
+
+Then he weaves along again, perfectly ca’m, and goes to dropping in his
+funeral orgies again every now and then, just like he done before.  And
+when he done it the third time he says:
+
+“I say orgies, not because it’s the common term, because it
+ain’t--obsequies bein’ the common term--but because orgies is the right
+term. Obsequies ain’t used in England no more now--it’s gone out.  We
+say orgies now in England.  Orgies is better, because it means the thing
+you’re after more exact.  It’s a word that’s made up out’n the Greek
+_orgo_, outside, open, abroad; and the Hebrew _jeesum_, to plant, cover
+up; hence in_ter._  So, you see, funeral orgies is an open er public
+funeral.”
+
+He was the _worst_ I ever struck.  Well, the iron-jawed man he laughed
+right in his face.  Everybody was shocked.  Everybody says, “Why,
+_doctor_!” and Abner Shackleford says:
+
+“Why, Robinson, hain’t you heard the news?  This is Harvey Wilks.”
+
+The king he smiled eager, and shoved out his flapper, and says:
+
+“Is it my poor brother’s dear good friend and physician?  I--”
+
+“Keep your hands off of me!” says the doctor.  “_You_ talk like an
+Englishman, _don’t_ you?  It’s the worst imitation I ever heard.  _You_
+Peter Wilks’s brother!  You’re a fraud, that’s what you are!”
+
+Well, how they all took on!  They crowded around the doctor and tried to
+quiet him down, and tried to explain to him and tell him how Harvey ‘d
+showed in forty ways that he _was_ Harvey, and knowed everybody by name,
+and the names of the very dogs, and begged and _begged_ him not to hurt
+Harvey’s feelings and the poor girl’s feelings, and all that.  But it
+warn’t no use; he stormed right along, and said any man that pretended
+to be an Englishman and couldn’t imitate the lingo no better than what
+he did was a fraud and a liar.  The poor girls was hanging to the king
+and crying; and all of a sudden the doctor ups and turns on _them_.  He
+says:
+
+“I was your father’s friend, and I’m your friend; and I warn you as a
+friend, and an honest one that wants to protect you and keep you out of
+harm and trouble, to turn your backs on that scoundrel and have nothing
+to do with him, the ignorant tramp, with his idiotic Greek and Hebrew,
+as he calls it.  He is the thinnest kind of an impostor--has come here
+with a lot of empty names and facts which he picked up somewheres, and
+you take them for _proofs_, and are helped to fool yourselves by these
+foolish friends here, who ought to know better.  Mary Jane Wilks, you
+know me for your friend, and for your unselfish friend, too.  Now listen
+to me; turn this pitiful rascal out--I _beg_ you to do it.  Will you?”
+
+Mary Jane straightened herself up, and my, but she was handsome!  She
+says:
+
+“_Here_ is my answer.”  She hove up the bag of money and put it in the
+king’s hands, and says, “Take this six thousand dollars, and invest for
+me and my sisters any way you want to, and don’t give us no receipt for
+it.”
+
+Then she put her arm around the king on one side, and Susan and the
+hare-lip done the same on the other.  Everybody clapped their hands and
+stomped on the floor like a perfect storm, whilst the king held up his
+head and smiled proud.  The doctor says:
+
+“All right; I wash _my_ hands of the matter.  But I warn you all that a
+time ‘s coming when you’re going to feel sick whenever you think of this
+day.” And away he went.
+
+“All right, doctor,” says the king, kinder mocking him; “we’ll try and
+get ‘em to send for you;” which made them all laugh, and they said it
+was a prime good hit.
+
+
+
+
+CHAPTER XXVI.
+
+WELL, when they was all gone the king he asks Mary Jane how they was off
+for spare rooms, and she said she had one spare room, which would do for
+Uncle William, and she’d give her own room to Uncle Harvey, which was
+a little bigger, and she would turn into the room with her sisters and
+sleep on a cot; and up garret was a little cubby, with a pallet in it.
+The king said the cubby would do for his valley--meaning me.
+
+So Mary Jane took us up, and she showed them their rooms, which was
+plain but nice.  She said she’d have her frocks and a lot of other traps
+took out of her room if they was in Uncle Harvey’s way, but he said
+they warn’t.  The frocks was hung along the wall, and before them was
+a curtain made out of calico that hung down to the floor.  There was an
+old hair trunk in one corner, and a guitar-box in another, and all sorts
+of little knickknacks and jimcracks around, like girls brisken up a room
+with.  The king said it was all the more homely and more pleasanter for
+these fixings, and so don’t disturb them.  The duke’s room was pretty
+small, but plenty good enough, and so was my cubby.
+
+That night they had a big supper, and all them men and women was there,
+and I stood behind the king and the duke’s chairs and waited on them,
+and the niggers waited on the rest.  Mary Jane she set at the head of
+the table, with Susan alongside of her, and said how bad the biscuits
+was, and how mean the preserves was, and how ornery and tough the fried
+chickens was--and all that kind of rot, the way women always do for to
+force out compliments; and the people all knowed everything was tiptop,
+and said so--said “How _do_ you get biscuits to brown so nice?” and
+“Where, for the land’s sake, _did_ you get these amaz’n pickles?” and
+all that kind of humbug talky-talk, just the way people always does at a
+supper, you know.
+
+And when it was all done me and the hare-lip had supper in the kitchen
+off of the leavings, whilst the others was helping the niggers clean up
+the things.  The hare-lip she got to pumping me about England, and blest
+if I didn’t think the ice was getting mighty thin sometimes.  She says:
+
+“Did you ever see the king?”
+
+“Who?  William Fourth?  Well, I bet I have--he goes to our church.”  I
+knowed he was dead years ago, but I never let on.  So when I says he
+goes to our church, she says:
+
+“What--regular?”
+
+“Yes--regular.  His pew’s right over opposite ourn--on t’other side the
+pulpit.”
+
+“I thought he lived in London?”
+
+“Well, he does.  Where _would_ he live?”
+
+“But I thought _you_ lived in Sheffield?”
+
+I see I was up a stump.  I had to let on to get choked with a chicken
+bone, so as to get time to think how to get down again.  Then I says:
+
+“I mean he goes to our church regular when he’s in Sheffield.  That’s
+only in the summer time, when he comes there to take the sea baths.”
+
+“Why, how you talk--Sheffield ain’t on the sea.”
+
+“Well, who said it was?”
+
+“Why, you did.”
+
+“I _didn’t_ nuther.”
+
+“You did!”
+
+“I didn’t.”
+
+“You did.”
+
+“I never said nothing of the kind.”
+
+“Well, what _did_ you say, then?”
+
+“Said he come to take the sea _baths_--that’s what I said.”
+
+“Well, then, how’s he going to take the sea baths if it ain’t on the
+sea?”
+
+“Looky here,” I says; “did you ever see any Congress-water?”
+
+“Yes.”
+
+“Well, did you have to go to Congress to get it?”
+
+“Why, no.”
+
+“Well, neither does William Fourth have to go to the sea to get a sea
+bath.”
+
+“How does he get it, then?”
+
+“Gets it the way people down here gets Congress-water--in barrels.  There
+in the palace at Sheffield they’ve got furnaces, and he wants his water
+hot.  They can’t bile that amount of water away off there at the sea.
+They haven’t got no conveniences for it.”
+
+“Oh, I see, now.  You might a said that in the first place and saved
+time.”
+
+When she said that I see I was out of the woods again, and so I was
+comfortable and glad.  Next, she says:
+
+“Do you go to church, too?”
+
+“Yes--regular.”
+
+“Where do you set?”
+
+“Why, in our pew.”
+
+“_Whose_ pew?”
+
+“Why, _ourn_--your Uncle Harvey’s.”
+
+“His’n?  What does _he_ want with a pew?”
+
+“Wants it to set in.  What did you _reckon_ he wanted with it?”
+
+“Why, I thought he’d be in the pulpit.”
+
+Rot him, I forgot he was a preacher.  I see I was up a stump again, so I
+played another chicken bone and got another think.  Then I says:
+
+“Blame it, do you suppose there ain’t but one preacher to a church?”
+
+“Why, what do they want with more?”
+
+“What!--to preach before a king?  I never did see such a girl as you.
+They don’t have no less than seventeen.”
+
+“Seventeen!  My land!  Why, I wouldn’t set out such a string as that,
+not if I _never_ got to glory.  It must take ‘em a week.”
+
+“Shucks, they don’t _all_ of ‘em preach the same day--only _one_ of ‘em.”
+
+“Well, then, what does the rest of ‘em do?”
+
+“Oh, nothing much.  Loll around, pass the plate--and one thing or
+another.  But mainly they don’t do nothing.”
+
+“Well, then, what are they _for_?”
+
+“Why, they’re for _style_.  Don’t you know nothing?”
+
+“Well, I don’t _want_ to know no such foolishness as that.  How is
+servants treated in England?  Do they treat ‘em better ‘n we treat our
+niggers?”
+
+“_No_!  A servant ain’t nobody there.  They treat them worse than dogs.”
+
+“Don’t they give ‘em holidays, the way we do, Christmas and New Year’s
+week, and Fourth of July?”
+
+“Oh, just listen!  A body could tell _you_ hain’t ever been to England
+by that.  Why, Hare-l--why, Joanna, they never see a holiday from year’s
+end to year’s end; never go to the circus, nor theater, nor nigger
+shows, nor nowheres.”
+
+“Nor church?”
+
+“Nor church.”
+
+“But _you_ always went to church.”
+
+Well, I was gone up again.  I forgot I was the old man’s servant.  But
+next minute I whirled in on a kind of an explanation how a valley was
+different from a common servant and _had_ to go to church whether he
+wanted to or not, and set with the family, on account of its being the
+law.  But I didn’t do it pretty good, and when I got done I see she
+warn’t satisfied.  She says:
+
+“Honest injun, now, hain’t you been telling me a lot of lies?”
+
+“Honest injun,” says I.
+
+“None of it at all?”
+
+“None of it at all.  Not a lie in it,” says I.
+
+“Lay your hand on this book and say it.”
+
+I see it warn’t nothing but a dictionary, so I laid my hand on it and
+said it.  So then she looked a little better satisfied, and says:
+
+“Well, then, I’ll believe some of it; but I hope to gracious if I’ll
+believe the rest.”
+
+“What is it you won’t believe, Joe?” says Mary Jane, stepping in with
+Susan behind her.  “It ain’t right nor kind for you to talk so to him,
+and him a stranger and so far from his people.  How would you like to be
+treated so?”
+
+“That’s always your way, Maim--always sailing in to help somebody before
+they’re hurt.  I hain’t done nothing to him.  He’s told some stretchers,
+I reckon, and I said I wouldn’t swallow it all; and that’s every bit
+and grain I _did_ say.  I reckon he can stand a little thing like that,
+can’t he?”
+
+“I don’t care whether ‘twas little or whether ‘twas big; he’s here in
+our house and a stranger, and it wasn’t good of you to say it.  If you
+was in his place it would make you feel ashamed; and so you oughtn’t to
+say a thing to another person that will make _them_ feel ashamed.”
+
+“Why, Mam, he said--”
+
+“It don’t make no difference what he _said_--that ain’t the thing.  The
+thing is for you to treat him _kind_, and not be saying things to make
+him remember he ain’t in his own country and amongst his own folks.”
+
+I says to myself, _this_ is a girl that I’m letting that old reptile rob
+her of her money!
+
+Then Susan _she_ waltzed in; and if you’ll believe me, she did give
+Hare-lip hark from the tomb!
+
+Says I to myself, and this is _another_ one that I’m letting him rob her
+of her money!
+
+Then Mary Jane she took another inning, and went in sweet and lovely
+again--which was her way; but when she got done there warn’t hardly
+anything left o’ poor Hare-lip.  So she hollered.
+
+“All right, then,” says the other girls; “you just ask his pardon.”
+
+She done it, too; and she done it beautiful.  She done it so beautiful
+it was good to hear; and I wished I could tell her a thousand lies, so
+she could do it again.
+
+I says to myself, this is _another_ one that I’m letting him rob her of
+her money.  And when she got through they all jest laid theirselves
+out to make me feel at home and know I was amongst friends.  I felt so
+ornery and low down and mean that I says to myself, my mind’s made up;
+I’ll hive that money for them or bust.
+
+So then I lit out--for bed, I said, meaning some time or another.  When
+I got by myself I went to thinking the thing over.  I says to myself,
+shall I go to that doctor, private, and blow on these frauds?  No--that
+won’t do. He might tell who told him; then the king and the duke would
+make it warm for me.  Shall I go, private, and tell Mary Jane?  No--I
+dasn’t do it. Her face would give them a hint, sure; they’ve got the
+money, and they’d slide right out and get away with it.  If she was to
+fetch in help I’d get mixed up in the business before it was done with,
+I judge.  No; there ain’t no good way but one.  I got to steal that
+money, somehow; and I got to steal it some way that they won’t suspicion
+that I done it. They’ve got a good thing here, and they ain’t a-going
+to leave till they’ve played this family and this town for all they’re
+worth, so I’ll find a chance time enough. I’ll steal it and hide it; and
+by and by, when I’m away down the river, I’ll write a letter and tell
+Mary Jane where it’s hid.  But I better hive it tonight if I can,
+because the doctor maybe hasn’t let up as much as he lets on he has; he
+might scare them out of here yet.
+
+So, thinks I, I’ll go and search them rooms.  Upstairs the hall was
+dark, but I found the duke’s room, and started to paw around it with
+my hands; but I recollected it wouldn’t be much like the king to let
+anybody else take care of that money but his own self; so then I went to
+his room and begun to paw around there.  But I see I couldn’t do nothing
+without a candle, and I dasn’t light one, of course.  So I judged I’d
+got to do the other thing--lay for them and eavesdrop.  About that time
+I hears their footsteps coming, and was going to skip under the bed; I
+reached for it, but it wasn’t where I thought it would be; but I touched
+the curtain that hid Mary Jane’s frocks, so I jumped in behind that and
+snuggled in amongst the gowns, and stood there perfectly still.
+
+They come in and shut the door; and the first thing the duke done was to
+get down and look under the bed.  Then I was glad I hadn’t found the bed
+when I wanted it.  And yet, you know, it’s kind of natural to hide under
+the bed when you are up to anything private.  They sets down then, and
+the king says:
+
+“Well, what is it?  And cut it middlin’ short, because it’s better for
+us to be down there a-whoopin’ up the mournin’ than up here givin’ ‘em a
+chance to talk us over.”
+
+“Well, this is it, Capet.  I ain’t easy; I ain’t comfortable.  That
+doctor lays on my mind.  I wanted to know your plans.  I’ve got a
+notion, and I think it’s a sound one.”
+
+“What is it, duke?”
+
+“That we better glide out of this before three in the morning, and clip
+it down the river with what we’ve got.  Specially, seeing we got it so
+easy--_given_ back to us, flung at our heads, as you may say, when of
+course we allowed to have to steal it back.  I’m for knocking off and
+lighting out.”
+
+That made me feel pretty bad.  About an hour or two ago it would a been
+a little different, but now it made me feel bad and disappointed, The
+king rips out and says:
+
+“What!  And not sell out the rest o’ the property?  March off like
+a passel of fools and leave eight or nine thous’n’ dollars’ worth o’
+property layin’ around jest sufferin’ to be scooped in?--and all good,
+salable stuff, too.”
+
+The duke he grumbled; said the bag of gold was enough, and he didn’t
+want to go no deeper--didn’t want to rob a lot of orphans of _everything_
+they had.
+
+“Why, how you talk!” says the king.  “We sha’n’t rob ‘em of nothing at
+all but jest this money.  The people that _buys_ the property is the
+suff’rers; because as soon ‘s it’s found out ‘at we didn’t own it--which
+won’t be long after we’ve slid--the sale won’t be valid, and it ‘ll all
+go back to the estate.  These yer orphans ‘ll git their house back agin,
+and that’s enough for _them_; they’re young and spry, and k’n easy
+earn a livin’.  _they_ ain’t a-goin to suffer.  Why, jest think--there’s
+thous’n’s and thous’n’s that ain’t nigh so well off.  Bless you, _they_
+ain’t got noth’n’ to complain of.”
+
+Well, the king he talked him blind; so at last he give in, and said all
+right, but said he believed it was blamed foolishness to stay, and that
+doctor hanging over them.  But the king says:
+
+“Cuss the doctor!  What do we k’yer for _him_?  Hain’t we got all the
+fools in town on our side?  And ain’t that a big enough majority in any
+town?”
+
+So they got ready to go down stairs again.  The duke says:
+
+“I don’t think we put that money in a good place.”
+
+That cheered me up.  I’d begun to think I warn’t going to get a hint of
+no kind to help me.  The king says:
+
+“Why?”
+
+“Because Mary Jane ‘ll be in mourning from this out; and first you know
+the nigger that does up the rooms will get an order to box these duds
+up and put ‘em away; and do you reckon a nigger can run across money and
+not borrow some of it?”
+
+“Your head’s level agin, duke,” says the king; and he comes a-fumbling
+under the curtain two or three foot from where I was.  I stuck tight to
+the wall and kept mighty still, though quivery; and I wondered what them
+fellows would say to me if they catched me; and I tried to think what
+I’d better do if they did catch me.  But the king he got the bag before
+I could think more than about a half a thought, and he never suspicioned
+I was around.  They took and shoved the bag through a rip in the straw
+tick that was under the feather-bed, and crammed it in a foot or two
+amongst the straw and said it was all right now, because a nigger only
+makes up the feather-bed, and don’t turn over the straw tick only about
+twice a year, and so it warn’t in no danger of getting stole now.
+
+But I knowed better.  I had it out of there before they was half-way
+down stairs.  I groped along up to my cubby, and hid it there till I
+could get a chance to do better.  I judged I better hide it outside
+of the house somewheres, because if they missed it they would give the
+house a good ransacking:  I knowed that very well.  Then I turned in,
+with my clothes all on; but I couldn’t a gone to sleep if I’d a wanted
+to, I was in such a sweat to get through with the business.  By and by I
+heard the king and the duke come up; so I rolled off my pallet and laid
+with my chin at the top of my ladder, and waited to see if anything was
+going to happen.  But nothing did.
+
+So I held on till all the late sounds had quit and the early ones hadn’t
+begun yet; and then I slipped down the ladder.
+
+
+
+
+CHAPTER XXVII.
+
+I crept to their doors and listened; they was snoring.  So I tiptoed
+along, and got down stairs all right.  There warn’t a sound anywheres.
+ I peeped through a crack of the dining-room door, and see the men that
+was watching the corpse all sound asleep on their chairs.  The door
+was open into the parlor, where the corpse was laying, and there was a
+candle in both rooms. I passed along, and the parlor door was open; but
+I see there warn’t nobody in there but the remainders of Peter; so I
+shoved on by; but the front door was locked, and the key wasn’t there.
+ Just then I heard somebody coming down the stairs, back behind me.  I
+run in the parlor and took a swift look around, and the only place I
+see to hide the bag was in the coffin.  The lid was shoved along about
+a foot, showing the dead man’s face down in there, with a wet cloth over
+it, and his shroud on.  I tucked the money-bag in under the lid, just
+down beyond where his hands was crossed, which made me creep, they was
+so cold, and then I run back across the room and in behind the door.
+
+The person coming was Mary Jane.  She went to the coffin, very soft, and
+kneeled down and looked in; then she put up her handkerchief, and I see
+she begun to cry, though I couldn’t hear her, and her back was to me.  I
+slid out, and as I passed the dining-room I thought I’d make sure them
+watchers hadn’t seen me; so I looked through the crack, and everything
+was all right.  They hadn’t stirred.
+
+I slipped up to bed, feeling ruther blue, on accounts of the thing
+playing out that way after I had took so much trouble and run so much
+resk about it.  Says I, if it could stay where it is, all right; because
+when we get down the river a hundred mile or two I could write back to
+Mary Jane, and she could dig him up again and get it; but that ain’t the
+thing that’s going to happen; the thing that’s going to happen is, the
+money ‘ll be found when they come to screw on the lid.  Then the king
+‘ll get it again, and it ‘ll be a long day before he gives anybody
+another chance to smouch it from him. Of course I _wanted_ to slide
+down and get it out of there, but I dasn’t try it.  Every minute it was
+getting earlier now, and pretty soon some of them watchers would begin
+to stir, and I might get catched--catched with six thousand dollars in my
+hands that nobody hadn’t hired me to take care of.  I don’t wish to be
+mixed up in no such business as that, I says to myself.
+
+When I got down stairs in the morning the parlor was shut up, and the
+watchers was gone.  There warn’t nobody around but the family and the
+widow Bartley and our tribe.  I watched their faces to see if anything
+had been happening, but I couldn’t tell.
+
+Towards the middle of the day the undertaker come with his man, and they
+set the coffin in the middle of the room on a couple of chairs, and then
+set all our chairs in rows, and borrowed more from the neighbors till
+the hall and the parlor and the dining-room was full.  I see the coffin
+lid was the way it was before, but I dasn’t go to look in under it, with
+folks around.
+
+Then the people begun to flock in, and the beats and the girls took
+seats in the front row at the head of the coffin, and for a half an hour
+the people filed around slow, in single rank, and looked down at the
+dead man’s face a minute, and some dropped in a tear, and it was
+all very still and solemn, only the girls and the beats holding
+handkerchiefs to their eyes and keeping their heads bent, and sobbing a
+little.  There warn’t no other sound but the scraping of the feet on
+the floor and blowing noses--because people always blows them more at a
+funeral than they do at other places except church.
+
+When the place was packed full the undertaker he slid around in his
+black gloves with his softy soothering ways, putting on the last
+touches, and getting people and things all ship-shape and comfortable,
+and making no more sound than a cat.  He never spoke; he moved people
+around, he squeezed in late ones, he opened up passageways, and done
+it with nods, and signs with his hands.  Then he took his place over
+against the wall. He was the softest, glidingest, stealthiest man I ever
+see; and there warn’t no more smile to him than there is to a ham.
+
+They had borrowed a melodeum--a sick one; and when everything was ready
+a young woman set down and worked it, and it was pretty skreeky and
+colicky, and everybody joined in and sung, and Peter was the only one
+that had a good thing, according to my notion.  Then the Reverend Hobson
+opened up, slow and solemn, and begun to talk; and straight off the most
+outrageous row busted out in the cellar a body ever heard; it was only
+one dog, but he made a most powerful racket, and he kept it up right
+along; the parson he had to stand there, over the coffin, and wait--you
+couldn’t hear yourself think.  It was right down awkward, and nobody
+didn’t seem to know what to do.  But pretty soon they see that
+long-legged undertaker make a sign to the preacher as much as to say,
+“Don’t you worry--just depend on me.”  Then he stooped down and begun
+to glide along the wall, just his shoulders showing over the people’s
+heads.  So he glided along, and the powwow and racket getting more and
+more outrageous all the time; and at last, when he had gone around two
+sides of the room, he disappears down cellar.  Then in about two seconds
+we heard a whack, and the dog he finished up with a most amazing howl or
+two, and then everything was dead still, and the parson begun his solemn
+talk where he left off.  In a minute or two here comes this undertaker’s
+back and shoulders gliding along the wall again; and so he glided and
+glided around three sides of the room, and then rose up, and shaded his
+mouth with his hands, and stretched his neck out towards the preacher,
+over the people’s heads, and says, in a kind of a coarse whisper, “_He
+had a rat_!”  Then he drooped down and glided along the wall again to
+his place.  You could see it was a great satisfaction to the people,
+because naturally they wanted to know.  A little thing like that don’t
+cost nothing, and it’s just the little things that makes a man to be
+looked up to and liked.  There warn’t no more popular man in town than
+what that undertaker was.
+
+Well, the funeral sermon was very good, but pison long and tiresome; and
+then the king he shoved in and got off some of his usual rubbage, and
+at last the job was through, and the undertaker begun to sneak up on the
+coffin with his screw-driver.  I was in a sweat then, and watched him
+pretty keen. But he never meddled at all; just slid the lid along as
+soft as mush, and screwed it down tight and fast.  So there I was!  I
+didn’t know whether the money was in there or not.  So, says I, s’pose
+somebody has hogged that bag on the sly?--now how do I know whether
+to write to Mary Jane or not? S’pose she dug him up and didn’t find
+nothing, what would she think of me? Blame it, I says, I might get
+hunted up and jailed; I’d better lay low and keep dark, and not write at
+all; the thing’s awful mixed now; trying to better it, I’ve worsened it
+a hundred times, and I wish to goodness I’d just let it alone, dad fetch
+the whole business!
+
+They buried him, and we come back home, and I went to watching faces
+again--I couldn’t help it, and I couldn’t rest easy.  But nothing come of
+it; the faces didn’t tell me nothing.
+
+The king he visited around in the evening, and sweetened everybody up,
+and made himself ever so friendly; and he give out the idea that his
+congregation over in England would be in a sweat about him, so he must
+hurry and settle up the estate right away and leave for home.  He was
+very sorry he was so pushed, and so was everybody; they wished he could
+stay longer, but they said they could see it couldn’t be done.  And he
+said of course him and William would take the girls home with them; and
+that pleased everybody too, because then the girls would be well fixed
+and amongst their own relations; and it pleased the girls, too--tickled
+them so they clean forgot they ever had a trouble in the world; and told
+him to sell out as quick as he wanted to, they would be ready.  Them
+poor things was that glad and happy it made my heart ache to see them
+getting fooled and lied to so, but I didn’t see no safe way for me to
+chip in and change the general tune.
+
+Well, blamed if the king didn’t bill the house and the niggers and all
+the property for auction straight off--sale two days after the funeral;
+but anybody could buy private beforehand if they wanted to.
+
+So the next day after the funeral, along about noon-time, the girls’ joy
+got the first jolt.  A couple of nigger traders come along, and the king
+sold them the niggers reasonable, for three-day drafts as they called
+it, and away they went, the two sons up the river to Memphis, and their
+mother down the river to Orleans.  I thought them poor girls and them
+niggers would break their hearts for grief; they cried around each
+other, and took on so it most made me down sick to see it.  The girls
+said they hadn’t ever dreamed of seeing the family separated or sold
+away from the town.  I can’t ever get it out of my memory, the sight of
+them poor miserable girls and niggers hanging around each other’s necks
+and crying; and I reckon I couldn’t a stood it all, but would a had
+to bust out and tell on our gang if I hadn’t knowed the sale warn’t no
+account and the niggers would be back home in a week or two.
+
+The thing made a big stir in the town, too, and a good many come out
+flatfooted and said it was scandalous to separate the mother and the
+children that way.  It injured the frauds some; but the old fool he
+bulled right along, spite of all the duke could say or do, and I tell
+you the duke was powerful uneasy.
+
+Next day was auction day.  About broad day in the morning the king and
+the duke come up in the garret and woke me up, and I see by their look
+that there was trouble.  The king says:
+
+“Was you in my room night before last?”
+
+“No, your majesty”--which was the way I always called him when nobody but
+our gang warn’t around.
+
+“Was you in there yisterday er last night?”
+
+“No, your majesty.”
+
+“Honor bright, now--no lies.”
+
+“Honor bright, your majesty, I’m telling you the truth.  I hain’t been
+a-near your room since Miss Mary Jane took you and the duke and showed
+it to you.”
+
+The duke says:
+
+“Have you seen anybody else go in there?”
+
+“No, your grace, not as I remember, I believe.”
+
+“Stop and think.”
+
+I studied awhile and see my chance; then I says:
+
+“Well, I see the niggers go in there several times.”
+
+Both of them gave a little jump, and looked like they hadn’t ever
+expected it, and then like they _had_.  Then the duke says:
+
+“What, all of them?”
+
+“No--leastways, not all at once--that is, I don’t think I ever see them
+all come _out_ at once but just one time.”
+
+“Hello!  When was that?”
+
+“It was the day we had the funeral.  In the morning.  It warn’t early,
+because I overslept.  I was just starting down the ladder, and I see
+them.”
+
+“Well, go on, _go_ on!  What did they do?  How’d they act?”
+
+“They didn’t do nothing.  And they didn’t act anyway much, as fur as I
+see. They tiptoed away; so I seen, easy enough, that they’d shoved in
+there to do up your majesty’s room, or something, s’posing you was up;
+and found you _warn’t_ up, and so they was hoping to slide out of the
+way of trouble without waking you up, if they hadn’t already waked you
+up.”
+
+“Great guns, _this_ is a go!” says the king; and both of them looked
+pretty sick and tolerable silly.  They stood there a-thinking and
+scratching their heads a minute, and the duke he bust into a kind of a
+little raspy chuckle, and says:
+
+“It does beat all how neat the niggers played their hand.  They let on
+to be _sorry_ they was going out of this region!  And I believed they
+_was_ sorry, and so did you, and so did everybody.  Don’t ever tell _me_
+any more that a nigger ain’t got any histrionic talent.  Why, the way
+they played that thing it would fool _anybody_.  In my opinion, there’s
+a fortune in ‘em.  If I had capital and a theater, I wouldn’t want a
+better lay-out than that--and here we’ve gone and sold ‘em for a song.
+ Yes, and ain’t privileged to sing the song yet.  Say, where _is_ that
+song--that draft?”
+
+“In the bank for to be collected.  Where _would_ it be?”
+
+“Well, _that’s_ all right then, thank goodness.”
+
+Says I, kind of timid-like:
+
+“Is something gone wrong?”
+
+The king whirls on me and rips out:
+
+“None o’ your business!  You keep your head shet, and mind y’r own
+affairs--if you got any.  Long as you’re in this town don’t you forgit
+_that_--you hear?”  Then he says to the duke, “We got to jest swaller it
+and say noth’n’:  mum’s the word for _us_.”
+
+As they was starting down the ladder the duke he chuckles again, and
+says:
+
+“Quick sales _and_ small profits!  It’s a good business--yes.”
+
+The king snarls around on him and says:
+
+“I was trying to do for the best in sellin’ ‘em out so quick.  If the
+profits has turned out to be none, lackin’ considable, and none to
+carry, is it my fault any more’n it’s yourn?”
+
+“Well, _they’d_ be in this house yet and we _wouldn’t_ if I could a got
+my advice listened to.”
+
+The king sassed back as much as was safe for him, and then swapped
+around and lit into _me_ again.  He give me down the banks for not
+coming and _telling_ him I see the niggers come out of his room acting
+that way--said any fool would a _knowed_ something was up.  And then
+waltzed in and cussed _himself_ awhile, and said it all come of him not
+laying late and taking his natural rest that morning, and he’d be
+blamed if he’d ever do it again.  So they went off a-jawing; and I felt
+dreadful glad I’d worked it all off on to the niggers, and yet hadn’t
+done the niggers no harm by it.
+
+
+
+
+CHAPTER XXVIII.
+
+BY and by it was getting-up time.  So I come down the ladder and started
+for down-stairs; but as I come to the girls’ room the door was open, and
+I see Mary Jane setting by her old hair trunk, which was open and she’d
+been packing things in it--getting ready to go to England.  But she
+had stopped now with a folded gown in her lap, and had her face in her
+hands, crying.  I felt awful bad to see it; of course anybody would.  I
+went in there and says:
+
+“Miss Mary Jane, you can’t a-bear to see people in trouble, and I
+can’t--most always.  Tell me about it.”
+
+So she done it.  And it was the niggers--I just expected it.  She said
+the beautiful trip to England was most about spoiled for her; she didn’t
+know _how_ she was ever going to be happy there, knowing the mother and
+the children warn’t ever going to see each other no more--and then busted
+out bitterer than ever, and flung up her hands, and says:
+
+“Oh, dear, dear, to think they ain’t _ever_ going to see each other any
+more!”
+
+“But they _will_--and inside of two weeks--and I _know_ it!” says I.
+
+Laws, it was out before I could think!  And before I could budge she
+throws her arms around my neck and told me to say it _again_, say it
+_again_, say it _again_!
+
+I see I had spoke too sudden and said too much, and was in a close
+place. I asked her to let me think a minute; and she set there, very
+impatient and excited and handsome, but looking kind of happy and
+eased-up, like a person that’s had a tooth pulled out.  So I went to
+studying it out.  I says to myself, I reckon a body that ups and tells
+the truth when he is in a tight place is taking considerable many resks,
+though I ain’t had no experience, and can’t say for certain; but it
+looks so to me, anyway; and yet here’s a case where I’m blest if it
+don’t look to me like the truth is better and actuly _safer_ than a lie.
+ I must lay it by in my mind, and think it over some time or other, it’s
+so kind of strange and unregular. I never see nothing like it.  Well, I
+says to myself at last, I’m a-going to chance it; I’ll up and tell the
+truth this time, though it does seem most like setting down on a kag of
+powder and touching it off just to see where you’ll go to. Then I says:
+
+“Miss Mary Jane, is there any place out of town a little ways where you
+could go and stay three or four days?”
+
+“Yes; Mr. Lothrop’s.  Why?”
+
+“Never mind why yet.  If I’ll tell you how I know the niggers will see
+each other again inside of two weeks--here in this house--and _prove_ how
+I know it--will you go to Mr. Lothrop’s and stay four days?”
+
+“Four days!” she says; “I’ll stay a year!”
+
+“All right,” I says, “I don’t want nothing more out of _you_ than just
+your word--I druther have it than another man’s kiss-the-Bible.”  She
+smiled and reddened up very sweet, and I says, “If you don’t mind it,
+I’ll shut the door--and bolt it.”
+
+Then I come back and set down again, and says:
+
+“Don’t you holler.  Just set still and take it like a man.  I got to
+tell the truth, and you want to brace up, Miss Mary, because it’s a
+bad kind, and going to be hard to take, but there ain’t no help for
+it.  These uncles of yourn ain’t no uncles at all; they’re a couple of
+frauds--regular dead-beats.  There, now we’re over the worst of it, you
+can stand the rest middling easy.”
+
+It jolted her up like everything, of course; but I was over the shoal
+water now, so I went right along, her eyes a-blazing higher and higher
+all the time, and told her every blame thing, from where we first struck
+that young fool going up to the steamboat, clear through to where she
+flung herself on to the king’s breast at the front door and he kissed
+her sixteen or seventeen times--and then up she jumps, with her face
+afire like sunset, and says:
+
+“The brute!  Come, don’t waste a minute--not a _second_--we’ll have them
+tarred and feathered, and flung in the river!”
+
+Says I:
+
+“Cert’nly.  But do you mean _before_ you go to Mr. Lothrop’s, or--”
+
+“Oh,” she says, “what am I _thinking_ about!” she says, and set right
+down again.  “Don’t mind what I said--please don’t--you _won’t,_ now,
+_will_ you?” Laying her silky hand on mine in that kind of a way that
+I said I would die first.  “I never thought, I was so stirred up,” she
+says; “now go on, and I won’t do so any more.  You tell me what to do,
+and whatever you say I’ll do it.”
+
+“Well,” I says, “it’s a rough gang, them two frauds, and I’m fixed so
+I got to travel with them a while longer, whether I want to or not--I
+druther not tell you why; and if you was to blow on them this town would
+get me out of their claws, and I’d be all right; but there’d be another
+person that you don’t know about who’d be in big trouble.  Well, we
+got to save _him_, hain’t we?  Of course.  Well, then, we won’t blow on
+them.”
+
+Saying them words put a good idea in my head.  I see how maybe I could
+get me and Jim rid of the frauds; get them jailed here, and then leave.
+But I didn’t want to run the raft in the daytime without anybody aboard
+to answer questions but me; so I didn’t want the plan to begin working
+till pretty late to-night.  I says:
+
+“Miss Mary Jane, I’ll tell you what we’ll do, and you won’t have to stay
+at Mr. Lothrop’s so long, nuther.  How fur is it?”
+
+“A little short of four miles--right out in the country, back here.”
+
+“Well, that ‘ll answer.  Now you go along out there, and lay low
+till nine or half-past to-night, and then get them to fetch you home
+again--tell them you’ve thought of something.  If you get here before
+eleven put a candle in this window, and if I don’t turn up wait _till_
+eleven, and _then_ if I don’t turn up it means I’m gone, and out of the
+way, and safe. Then you come out and spread the news around, and get
+these beats jailed.”
+
+“Good,” she says, “I’ll do it.”
+
+“And if it just happens so that I don’t get away, but get took up along
+with them, you must up and say I told you the whole thing beforehand,
+and you must stand by me all you can.”
+
+“Stand by you! indeed I will.  They sha’n’t touch a hair of your head!”
+ she says, and I see her nostrils spread and her eyes snap when she said
+it, too.
+
+“If I get away I sha’n’t be here,” I says, “to prove these rapscallions
+ain’t your uncles, and I couldn’t do it if I _was_ here.  I could swear
+they was beats and bummers, that’s all, though that’s worth something.
+Well, there’s others can do that better than what I can, and they’re
+people that ain’t going to be doubted as quick as I’d be.  I’ll tell you
+how to find them.  Gimme a pencil and a piece of paper.  There--‘Royal
+Nonesuch, Bricksville.’  Put it away, and don’t lose it.  When the
+court wants to find out something about these two, let them send up to
+Bricksville and say they’ve got the men that played the Royal Nonesuch,
+and ask for some witnesses--why, you’ll have that entire town down here
+before you can hardly wink, Miss Mary.  And they’ll come a-biling, too.”
+
+I judged we had got everything fixed about right now.  So I says:
+
+“Just let the auction go right along, and don’t worry.  Nobody don’t
+have to pay for the things they buy till a whole day after the auction
+on accounts of the short notice, and they ain’t going out of this till
+they get that money; and the way we’ve fixed it the sale ain’t going to
+count, and they ain’t going to get no money.  It’s just like the way
+it was with the niggers--it warn’t no sale, and the niggers will be
+back before long.  Why, they can’t collect the money for the _niggers_
+yet--they’re in the worst kind of a fix, Miss Mary.”
+
+“Well,” she says, “I’ll run down to breakfast now, and then I’ll start
+straight for Mr. Lothrop’s.”
+
+“‘Deed, _that_ ain’t the ticket, Miss Mary Jane,” I says, “by no manner
+of means; go _before_ breakfast.”
+
+“Why?”
+
+“What did you reckon I wanted you to go at all for, Miss Mary?”
+
+“Well, I never thought--and come to think, I don’t know.  What was it?”
+
+“Why, it’s because you ain’t one of these leather-face people.  I don’t
+want no better book than what your face is.  A body can set down and
+read it off like coarse print.  Do you reckon you can go and face your
+uncles when they come to kiss you good-morning, and never--”
+
+“There, there, don’t!  Yes, I’ll go before breakfast--I’ll be glad to.
+And leave my sisters with them?”
+
+“Yes; never mind about them.  They’ve got to stand it yet a while.  They
+might suspicion something if all of you was to go.  I don’t want you to
+see them, nor your sisters, nor nobody in this town; if a neighbor was
+to ask how is your uncles this morning your face would tell something.
+ No, you go right along, Miss Mary Jane, and I’ll fix it with all of
+them. I’ll tell Miss Susan to give your love to your uncles and say
+you’ve went away for a few hours for to get a little rest and change, or
+to see a friend, and you’ll be back to-night or early in the morning.”
+
+“Gone to see a friend is all right, but I won’t have my love given to
+them.”
+
+“Well, then, it sha’n’t be.”  It was well enough to tell _her_ so--no
+harm in it.  It was only a little thing to do, and no trouble; and it’s
+the little things that smooths people’s roads the most, down here below;
+it would make Mary Jane comfortable, and it wouldn’t cost nothing.  Then
+I says:  “There’s one more thing--that bag of money.”
+
+“Well, they’ve got that; and it makes me feel pretty silly to think
+_how_ they got it.”
+
+“No, you’re out, there.  They hain’t got it.”
+
+“Why, who’s got it?”
+
+“I wish I knowed, but I don’t.  I _had_ it, because I stole it from
+them; and I stole it to give to you; and I know where I hid it, but I’m
+afraid it ain’t there no more.  I’m awful sorry, Miss Mary Jane, I’m
+just as sorry as I can be; but I done the best I could; I did honest.  I
+come nigh getting caught, and I had to shove it into the first place I
+come to, and run--and it warn’t a good place.”
+
+“Oh, stop blaming yourself--it’s too bad to do it, and I won’t allow
+it--you couldn’t help it; it wasn’t your fault.  Where did you hide it?”
+
+I didn’t want to set her to thinking about her troubles again; and I
+couldn’t seem to get my mouth to tell her what would make her see that
+corpse laying in the coffin with that bag of money on his stomach.  So
+for a minute I didn’t say nothing; then I says:
+
+“I’d ruther not _tell_ you where I put it, Miss Mary Jane, if you don’t
+mind letting me off; but I’ll write it for you on a piece of paper, and
+you can read it along the road to Mr. Lothrop’s, if you want to.  Do you
+reckon that ‘ll do?”
+
+“Oh, yes.”
+
+So I wrote:  “I put it in the coffin.  It was in there when you was
+crying there, away in the night.  I was behind the door, and I was
+mighty sorry for you, Miss Mary Jane.”
+
+It made my eyes water a little to remember her crying there all by
+herself in the night, and them devils laying there right under her own
+roof, shaming her and robbing her; and when I folded it up and give it
+to her I see the water come into her eyes, too; and she shook me by the
+hand, hard, and says:
+
+“_Good_-bye.  I’m going to do everything just as you’ve told me; and if
+I don’t ever see you again, I sha’n’t ever forget you and I’ll think of
+you a many and a many a time, and I’ll _pray_ for you, too!”--and she was
+gone.
+
+Pray for me!  I reckoned if she knowed me she’d take a job that was more
+nearer her size.  But I bet she done it, just the same--she was just that
+kind.  She had the grit to pray for Judus if she took the notion--there
+warn’t no back-down to her, I judge.  You may say what you want to, but
+in my opinion she had more sand in her than any girl I ever see; in
+my opinion she was just full of sand.  It sounds like flattery, but it
+ain’t no flattery.  And when it comes to beauty--and goodness, too--she
+lays over them all.  I hain’t ever seen her since that time that I see
+her go out of that door; no, I hain’t ever seen her since, but I reckon
+I’ve thought of her a many and a many a million times, and of her saying
+she would pray for me; and if ever I’d a thought it would do any good
+for me to pray for _her_, blamed if I wouldn’t a done it or bust.
+
+Well, Mary Jane she lit out the back way, I reckon; because nobody see
+her go.  When I struck Susan and the hare-lip, I says:
+
+“What’s the name of them people over on t’other side of the river that
+you all goes to see sometimes?”
+
+They says:
+
+“There’s several; but it’s the Proctors, mainly.”
+
+“That’s the name,” I says; “I most forgot it.  Well, Miss Mary Jane she
+told me to tell you she’s gone over there in a dreadful hurry--one of
+them’s sick.”
+
+“Which one?”
+
+“I don’t know; leastways, I kinder forget; but I thinks it’s--”
+
+“Sakes alive, I hope it ain’t _Hanner_?”
+
+“I’m sorry to say it,” I says, “but Hanner’s the very one.”
+
+“My goodness, and she so well only last week!  Is she took bad?”
+
+“It ain’t no name for it.  They set up with her all night, Miss Mary
+Jane said, and they don’t think she’ll last many hours.”
+
+“Only think of that, now!  What’s the matter with her?”
+
+I couldn’t think of anything reasonable, right off that way, so I says:
+
+“Mumps.”
+
+“Mumps your granny!  They don’t set up with people that’s got the
+mumps.”
+
+“They don’t, don’t they?  You better bet they do with _these_ mumps.
+ These mumps is different.  It’s a new kind, Miss Mary Jane said.”
+
+“How’s it a new kind?”
+
+“Because it’s mixed up with other things.”
+
+“What other things?”
+
+“Well, measles, and whooping-cough, and erysiplas, and consumption, and
+yaller janders, and brain-fever, and I don’t know what all.”
+
+“My land!  And they call it the _mumps_?”
+
+“That’s what Miss Mary Jane said.”
+
+“Well, what in the nation do they call it the _mumps_ for?”
+
+“Why, because it _is_ the mumps.  That’s what it starts with.”
+
+“Well, ther’ ain’t no sense in it.  A body might stump his toe, and take
+pison, and fall down the well, and break his neck, and bust his brains
+out, and somebody come along and ask what killed him, and some numskull
+up and say, ‘Why, he stumped his _toe_.’  Would ther’ be any sense
+in that? _No_.  And ther’ ain’t no sense in _this_, nuther.  Is it
+ketching?”
+
+“Is it _ketching_?  Why, how you talk.  Is a _harrow_ catching--in the
+dark? If you don’t hitch on to one tooth, you’re bound to on another,
+ain’t you? And you can’t get away with that tooth without fetching the
+whole harrow along, can you?  Well, these kind of mumps is a kind of a
+harrow, as you may say--and it ain’t no slouch of a harrow, nuther, you
+come to get it hitched on good.”
+
+“Well, it’s awful, I think,” says the hare-lip.  “I’ll go to Uncle
+Harvey and--”
+
+“Oh, yes,” I says, “I _would_.  Of _course_ I would.  I wouldn’t lose no
+time.”
+
+“Well, why wouldn’t you?”
+
+“Just look at it a minute, and maybe you can see.  Hain’t your uncles
+obleegd to get along home to England as fast as they can?  And do you
+reckon they’d be mean enough to go off and leave you to go all that
+journey by yourselves?  _you_ know they’ll wait for you.  So fur, so
+good. Your uncle Harvey’s a preacher, ain’t he?  Very well, then; is a
+_preacher_ going to deceive a steamboat clerk? is he going to deceive
+a _ship clerk?_--so as to get them to let Miss Mary Jane go aboard?  Now
+_you_ know he ain’t.  What _will_ he do, then?  Why, he’ll say, ‘It’s a
+great pity, but my church matters has got to get along the best way they
+can; for my niece has been exposed to the dreadful pluribus-unum mumps,
+and so it’s my bounden duty to set down here and wait the three months
+it takes to show on her if she’s got it.’  But never mind, if you think
+it’s best to tell your uncle Harvey--”
+
+“Shucks, and stay fooling around here when we could all be having good
+times in England whilst we was waiting to find out whether Mary Jane’s
+got it or not?  Why, you talk like a muggins.”
+
+“Well, anyway, maybe you’d better tell some of the neighbors.”
+
+“Listen at that, now.  You do beat all for natural stupidness.  Can’t
+you _see_ that _they’d_ go and tell?  Ther’ ain’t no way but just to not
+tell anybody at _all_.”
+
+“Well, maybe you’re right--yes, I judge you _are_ right.”
+
+“But I reckon we ought to tell Uncle Harvey she’s gone out a while,
+anyway, so he won’t be uneasy about her?”
+
+“Yes, Miss Mary Jane she wanted you to do that.  She says, ‘Tell them to
+give Uncle Harvey and William my love and a kiss, and say I’ve run over
+the river to see Mr.’--Mr.--what _is_ the name of that rich family your
+uncle Peter used to think so much of?--I mean the one that--”
+
+“Why, you must mean the Apthorps, ain’t it?”
+
+“Of course; bother them kind of names, a body can’t ever seem to
+remember them, half the time, somehow.  Yes, she said, say she has run
+over for to ask the Apthorps to be sure and come to the auction and buy
+this house, because she allowed her uncle Peter would ruther they had
+it than anybody else; and she’s going to stick to them till they say
+they’ll come, and then, if she ain’t too tired, she’s coming home; and
+if she is, she’ll be home in the morning anyway.  She said, don’t say
+nothing about the Proctors, but only about the Apthorps--which ‘ll be
+perfectly true, because she is going there to speak about their buying
+the house; I know it, because she told me so herself.”
+
+“All right,” they said, and cleared out to lay for their uncles, and
+give them the love and the kisses, and tell them the message.
+
+Everything was all right now.  The girls wouldn’t say nothing because
+they wanted to go to England; and the king and the duke would ruther
+Mary Jane was off working for the auction than around in reach of
+Doctor Robinson.  I felt very good; I judged I had done it pretty neat--I
+reckoned Tom Sawyer couldn’t a done it no neater himself.  Of course he
+would a throwed more style into it, but I can’t do that very handy, not
+being brung up to it.
+
+Well, they held the auction in the public square, along towards the end
+of the afternoon, and it strung along, and strung along, and the old man
+he was on hand and looking his level pisonest, up there longside of the
+auctioneer, and chipping in a little Scripture now and then, or a little
+goody-goody saying of some kind, and the duke he was around goo-gooing
+for sympathy all he knowed how, and just spreading himself generly.
+
+But by and by the thing dragged through, and everything was
+sold--everything but a little old trifling lot in the graveyard.  So
+they’d got to work that off--I never see such a girafft as the king was
+for wanting to swallow _everything_.  Well, whilst they was at it a
+steamboat landed, and in about two minutes up comes a crowd a-whooping
+and yelling and laughing and carrying on, and singing out:
+
+“_Here’s_ your opposition line! here’s your two sets o’ heirs to old
+Peter Wilks--and you pays your money and you takes your choice!”
+
+
+
+
+CHAPTER XXIX.
+
+THEY was fetching a very nice-looking old gentleman along, and a
+nice-looking younger one, with his right arm in a sling.  And, my souls,
+how the people yelled and laughed, and kept it up.  But I didn’t see no
+joke about it, and I judged it would strain the duke and the king some
+to see any.  I reckoned they’d turn pale.  But no, nary a pale did
+_they_ turn. The duke he never let on he suspicioned what was up, but
+just went a goo-gooing around, happy and satisfied, like a jug that’s
+googling out buttermilk; and as for the king, he just gazed and gazed
+down sorrowful on them new-comers like it give him the stomach-ache in
+his very heart to think there could be such frauds and rascals in the
+world.  Oh, he done it admirable.  Lots of the principal people
+gethered around the king, to let him see they was on his side.  That old
+gentleman that had just come looked all puzzled to death.  Pretty
+soon he begun to speak, and I see straight off he pronounced _like_ an
+Englishman--not the king’s way, though the king’s _was_ pretty good for
+an imitation.  I can’t give the old gent’s words, nor I can’t imitate
+him; but he turned around to the crowd, and says, about like this:
+
+“This is a surprise to me which I wasn’t looking for; and I’ll
+acknowledge, candid and frank, I ain’t very well fixed to meet it and
+answer it; for my brother and me has had misfortunes; he’s broke his
+arm, and our baggage got put off at a town above here last night in the
+night by a mistake.  I am Peter Wilks’ brother Harvey, and this is his
+brother William, which can’t hear nor speak--and can’t even make signs to
+amount to much, now’t he’s only got one hand to work them with.  We are
+who we say we are; and in a day or two, when I get the baggage, I can
+prove it. But up till then I won’t say nothing more, but go to the hotel
+and wait.”
+
+So him and the new dummy started off; and the king he laughs, and
+blethers out:
+
+“Broke his arm--_very_ likely, _ain’t_ it?--and very convenient, too,
+for a fraud that’s got to make signs, and ain’t learnt how.  Lost
+their baggage! That’s _mighty_ good!--and mighty ingenious--under the
+_circumstances_!”
+
+So he laughed again; and so did everybody else, except three or four,
+or maybe half a dozen.  One of these was that doctor; another one was
+a sharp-looking gentleman, with a carpet-bag of the old-fashioned kind
+made out of carpet-stuff, that had just come off of the steamboat and
+was talking to him in a low voice, and glancing towards the king now and
+then and nodding their heads--it was Levi Bell, the lawyer that was gone
+up to Louisville; and another one was a big rough husky that come along
+and listened to all the old gentleman said, and was listening to the
+king now. And when the king got done this husky up and says:
+
+“Say, looky here; if you are Harvey Wilks, when’d you come to this
+town?”
+
+“The day before the funeral, friend,” says the king.
+
+“But what time o’ day?”
+
+“In the evenin’--‘bout an hour er two before sundown.”
+
+“_How’d_ you come?”
+
+“I come down on the Susan Powell from Cincinnati.”
+
+“Well, then, how’d you come to be up at the Pint in the _mornin_’--in a
+canoe?”
+
+“I warn’t up at the Pint in the mornin’.”
+
+“It’s a lie.”
+
+Several of them jumped for him and begged him not to talk that way to an
+old man and a preacher.
+
+“Preacher be hanged, he’s a fraud and a liar.  He was up at the Pint
+that mornin’.  I live up there, don’t I?  Well, I was up there, and
+he was up there.  I see him there.  He come in a canoe, along with Tim
+Collins and a boy.”
+
+The doctor he up and says:
+
+“Would you know the boy again if you was to see him, Hines?”
+
+“I reckon I would, but I don’t know.  Why, yonder he is, now.  I know
+him perfectly easy.”
+
+It was me he pointed at.  The doctor says:
+
+“Neighbors, I don’t know whether the new couple is frauds or not; but if
+_these_ two ain’t frauds, I am an idiot, that’s all.  I think it’s our
+duty to see that they don’t get away from here till we’ve looked into
+this thing. Come along, Hines; come along, the rest of you.  We’ll take
+these fellows to the tavern and affront them with t’other couple, and I
+reckon we’ll find out _something_ before we get through.”
+
+It was nuts for the crowd, though maybe not for the king’s friends; so
+we all started.  It was about sundown.  The doctor he led me along by
+the hand, and was plenty kind enough, but he never let go my hand.
+
+We all got in a big room in the hotel, and lit up some candles, and
+fetched in the new couple.  First, the doctor says:
+
+“I don’t wish to be too hard on these two men, but I think they’re
+frauds, and they may have complices that we don’t know nothing about.
+ If they have, won’t the complices get away with that bag of gold Peter
+Wilks left?  It ain’t unlikely.  If these men ain’t frauds, they won’t
+object to sending for that money and letting us keep it till they prove
+they’re all right--ain’t that so?”
+
+Everybody agreed to that.  So I judged they had our gang in a pretty
+tight place right at the outstart.  But the king he only looked
+sorrowful, and says:
+
+“Gentlemen, I wish the money was there, for I ain’t got no disposition
+to throw anything in the way of a fair, open, out-and-out investigation
+o’ this misable business; but, alas, the money ain’t there; you k’n send
+and see, if you want to.”
+
+“Where is it, then?”
+
+“Well, when my niece give it to me to keep for her I took and hid it
+inside o’ the straw tick o’ my bed, not wishin’ to bank it for the few
+days we’d be here, and considerin’ the bed a safe place, we not bein’
+used to niggers, and suppos’n’ ‘em honest, like servants in England.
+ The niggers stole it the very next mornin’ after I had went down
+stairs; and when I sold ‘em I hadn’t missed the money yit, so they got
+clean away with it.  My servant here k’n tell you ‘bout it, gentlemen.”
+
+The doctor and several said “Shucks!” and I see nobody didn’t altogether
+believe him.  One man asked me if I see the niggers steal it.  I said
+no, but I see them sneaking out of the room and hustling away, and I
+never thought nothing, only I reckoned they was afraid they had waked up
+my master and was trying to get away before he made trouble with them.
+ That was all they asked me.  Then the doctor whirls on me and says:
+
+“Are _you_ English, too?”
+
+I says yes; and him and some others laughed, and said, “Stuff!”
+
+Well, then they sailed in on the general investigation, and there we had
+it, up and down, hour in, hour out, and nobody never said a word about
+supper, nor ever seemed to think about it--and so they kept it up, and
+kept it up; and it _was_ the worst mixed-up thing you ever see.  They
+made the king tell his yarn, and they made the old gentleman tell his’n;
+and anybody but a lot of prejudiced chuckleheads would a _seen_ that the
+old gentleman was spinning truth and t’other one lies.  And by and by
+they had me up to tell what I knowed.  The king he give me a left-handed
+look out of the corner of his eye, and so I knowed enough to talk on the
+right side.  I begun to tell about Sheffield, and how we lived there,
+and all about the English Wilkses, and so on; but I didn’t get pretty
+fur till the doctor begun to laugh; and Levi Bell, the lawyer, says:
+
+“Set down, my boy; I wouldn’t strain myself if I was you.  I reckon
+you ain’t used to lying, it don’t seem to come handy; what you want is
+practice.  You do it pretty awkward.”
+
+I didn’t care nothing for the compliment, but I was glad to be let off,
+anyway.
+
+The doctor he started to say something, and turns and says:
+
+“If you’d been in town at first, Levi Bell--” The king broke in and
+reached out his hand, and says:
+
+“Why, is this my poor dead brother’s old friend that he’s wrote so often
+about?”
+
+The lawyer and him shook hands, and the lawyer smiled and looked
+pleased, and they talked right along awhile, and then got to one side
+and talked low; and at last the lawyer speaks up and says:
+
+“That ‘ll fix it.  I’ll take the order and send it, along with your
+brother’s, and then they’ll know it’s all right.”
+
+So they got some paper and a pen, and the king he set down and twisted
+his head to one side, and chawed his tongue, and scrawled off something;
+and then they give the pen to the duke--and then for the first time the
+duke looked sick.  But he took the pen and wrote.  So then the lawyer
+turns to the new old gentleman and says:
+
+“You and your brother please write a line or two and sign your names.”
+
+The old gentleman wrote, but nobody couldn’t read it.  The lawyer looked
+powerful astonished, and says:
+
+“Well, it beats _me_”--and snaked a lot of old letters out of his pocket,
+and examined them, and then examined the old man’s writing, and then
+_them_ again; and then says:  “These old letters is from Harvey Wilks;
+and here’s _these_ two handwritings, and anybody can see they didn’t
+write them” (the king and the duke looked sold and foolish, I tell
+you, to see how the lawyer had took them in), “and here’s _this_ old
+gentleman’s hand writing, and anybody can tell, easy enough, _he_ didn’t
+write them--fact is, the scratches he makes ain’t properly _writing_ at
+all.  Now, here’s some letters from--”
+
+The new old gentleman says:
+
+“If you please, let me explain.  Nobody can read my hand but my brother
+there--so he copies for me.  It’s _his_ hand you’ve got there, not mine.”
+
+“_Well_!” says the lawyer, “this _is_ a state of things.  I’ve got some
+of William’s letters, too; so if you’ll get him to write a line or so we
+can com--”
+
+“He _can’t_ write with his left hand,” says the old gentleman.  “If he
+could use his right hand, you would see that he wrote his own letters
+and mine too.  Look at both, please--they’re by the same hand.”
+
+The lawyer done it, and says:
+
+“I believe it’s so--and if it ain’t so, there’s a heap stronger
+resemblance than I’d noticed before, anyway.  Well, well, well!  I
+thought we was right on the track of a solution, but it’s gone to grass,
+partly.  But anyway, one thing is proved--_these_ two ain’t either of ‘em
+Wilkses”--and he wagged his head towards the king and the duke.
+
+Well, what do you think?  That muleheaded old fool wouldn’t give in
+_then_! Indeed he wouldn’t.  Said it warn’t no fair test.  Said his
+brother William was the cussedest joker in the world, and hadn’t tried
+to write--_he_ see William was going to play one of his jokes the minute
+he put the pen to paper.  And so he warmed up and went warbling and
+warbling right along till he was actuly beginning to believe what he was
+saying _himself_; but pretty soon the new gentleman broke in, and says:
+
+“I’ve thought of something.  Is there anybody here that helped to lay
+out my br--helped to lay out the late Peter Wilks for burying?”
+
+“Yes,” says somebody, “me and Ab Turner done it.  We’re both here.”
+
+Then the old man turns towards the king, and says:
+
+“Perhaps this gentleman can tell me what was tattooed on his breast?”
+
+Blamed if the king didn’t have to brace up mighty quick, or he’d a
+squshed down like a bluff bank that the river has cut under, it took
+him so sudden; and, mind you, it was a thing that was calculated to make
+most _anybody_ sqush to get fetched such a solid one as that without any
+notice, because how was _he_ going to know what was tattooed on the man?
+ He whitened a little; he couldn’t help it; and it was mighty still in
+there, and everybody bending a little forwards and gazing at him.  Says
+I to myself, _now_ he’ll throw up the sponge--there ain’t no more use.
+ Well, did he?  A body can’t hardly believe it, but he didn’t.  I reckon
+he thought he’d keep the thing up till he tired them people out, so
+they’d thin out, and him and the duke could break loose and get away.
+ Anyway, he set there, and pretty soon he begun to smile, and says:
+
+“Mf!  It’s a _very_ tough question, _ain’t_ it!  _yes_, sir, I k’n
+tell you what’s tattooed on his breast.  It’s jest a small, thin, blue
+arrow--that’s what it is; and if you don’t look clost, you can’t see it.
+ _now_ what do you say--hey?”
+
+Well, I never see anything like that old blister for clean out-and-out
+cheek.
+
+The new old gentleman turns brisk towards Ab Turner and his pard, and
+his eye lights up like he judged he’d got the king _this_ time, and
+says:
+
+“There--you’ve heard what he said!  Was there any such mark on Peter
+Wilks’ breast?”
+
+Both of them spoke up and says:
+
+“We didn’t see no such mark.”
+
+“Good!” says the old gentleman.  “Now, what you _did_ see on his breast
+was a small dim P, and a B (which is an initial he dropped when he was
+young), and a W, with dashes between them, so:  P--B--W”--and he marked
+them that way on a piece of paper.  “Come, ain’t that what you saw?”
+
+Both of them spoke up again, and says:
+
+“No, we _didn’t_.  We never seen any marks at all.”
+
+Well, everybody _was_ in a state of mind now, and they sings out:
+
+“The whole _bilin_’ of ‘m ‘s frauds!  Le’s duck ‘em! le’s drown ‘em!
+le’s ride ‘em on a rail!” and everybody was whooping at once, and there
+was a rattling powwow.  But the lawyer he jumps on the table and yells,
+and says:
+
+“Gentlemen--gentle_men!_  Hear me just a word--just a _single_ word--if you
+_please_!  There’s one way yet--let’s go and dig up the corpse and look.”
+
+That took them.
+
+“Hooray!” they all shouted, and was starting right off; but the lawyer
+and the doctor sung out:
+
+“Hold on, hold on!  Collar all these four men and the boy, and fetch
+_them_ along, too!”
+
+“We’ll do it!” they all shouted; “and if we don’t find them marks we’ll
+lynch the whole gang!”
+
+I _was_ scared, now, I tell you.  But there warn’t no getting away, you
+know. They gripped us all, and marched us right along, straight for the
+graveyard, which was a mile and a half down the river, and the whole
+town at our heels, for we made noise enough, and it was only nine in the
+evening.
+
+As we went by our house I wished I hadn’t sent Mary Jane out of town;
+because now if I could tip her the wink she’d light out and save me, and
+blow on our dead-beats.
+
+Well, we swarmed along down the river road, just carrying on like
+wildcats; and to make it more scary the sky was darking up, and the
+lightning beginning to wink and flitter, and the wind to shiver amongst
+the leaves. This was the most awful trouble and most dangersome I ever
+was in; and I was kinder stunned; everything was going so different from
+what I had allowed for; stead of being fixed so I could take my own time
+if I wanted to, and see all the fun, and have Mary Jane at my back to
+save me and set me free when the close-fit come, here was nothing in the
+world betwixt me and sudden death but just them tattoo-marks.  If they
+didn’t find them--
+
+I couldn’t bear to think about it; and yet, somehow, I couldn’t think
+about nothing else.  It got darker and darker, and it was a beautiful
+time to give the crowd the slip; but that big husky had me by the
+wrist--Hines--and a body might as well try to give Goliar the slip.  He
+dragged me right along, he was so excited, and I had to run to keep up.
+
+When they got there they swarmed into the graveyard and washed over it
+like an overflow.  And when they got to the grave they found they had
+about a hundred times as many shovels as they wanted, but nobody hadn’t
+thought to fetch a lantern.  But they sailed into digging anyway by the
+flicker of the lightning, and sent a man to the nearest house, a half a
+mile off, to borrow one.
+
+So they dug and dug like everything; and it got awful dark, and the rain
+started, and the wind swished and swushed along, and the lightning come
+brisker and brisker, and the thunder boomed; but them people never took
+no notice of it, they was so full of this business; and one minute
+you could see everything and every face in that big crowd, and the
+shovelfuls of dirt sailing up out of the grave, and the next second the
+dark wiped it all out, and you couldn’t see nothing at all.
+
+At last they got out the coffin and begun to unscrew the lid, and then
+such another crowding and shouldering and shoving as there was, to
+scrouge in and get a sight, you never see; and in the dark, that way, it
+was awful.  Hines he hurt my wrist dreadful pulling and tugging so,
+and I reckon he clean forgot I was in the world, he was so excited and
+panting.
+
+All of a sudden the lightning let go a perfect sluice of white glare,
+and somebody sings out:
+
+“By the living jingo, here’s the bag of gold on his breast!”
+
+Hines let out a whoop, like everybody else, and dropped my wrist and
+give a big surge to bust his way in and get a look, and the way I lit
+out and shinned for the road in the dark there ain’t nobody can tell.
+
+I had the road all to myself, and I fairly flew--leastways, I had it all
+to myself except the solid dark, and the now-and-then glares, and the
+buzzing of the rain, and the thrashing of the wind, and the splitting of
+the thunder; and sure as you are born I did clip it along!
+
+When I struck the town I see there warn’t nobody out in the storm, so
+I never hunted for no back streets, but humped it straight through the
+main one; and when I begun to get towards our house I aimed my eye and
+set it. No light there; the house all dark--which made me feel sorry and
+disappointed, I didn’t know why.  But at last, just as I was sailing by,
+_flash_ comes the light in Mary Jane’s window! and my heart swelled up
+sudden, like to bust; and the same second the house and all was behind
+me in the dark, and wasn’t ever going to be before me no more in this
+world. She _was_ the best girl I ever see, and had the most sand.
+
+The minute I was far enough above the town to see I could make the
+towhead, I begun to look sharp for a boat to borrow, and the first
+time the lightning showed me one that wasn’t chained I snatched it and
+shoved. It was a canoe, and warn’t fastened with nothing but a rope.
+ The towhead was a rattling big distance off, away out there in the
+middle of the river, but I didn’t lose no time; and when I struck the
+raft at last I was so fagged I would a just laid down to blow and gasp
+if I could afforded it.  But I didn’t.  As I sprung aboard I sung out:
+
+“Out with you, Jim, and set her loose!  Glory be to goodness, we’re shut
+of them!”
+
+Jim lit out, and was a-coming for me with both arms spread, he was so
+full of joy; but when I glimpsed him in the lightning my heart shot up
+in my mouth and I went overboard backwards; for I forgot he was old King
+Lear and a drownded A-rab all in one, and it most scared the livers and
+lights out of me.  But Jim fished me out, and was going to hug me and
+bless me, and so on, he was so glad I was back and we was shut of the
+king and the duke, but I says:
+
+“Not now; have it for breakfast, have it for breakfast!  Cut loose and
+let her slide!”
+
+So in two seconds away we went a-sliding down the river, and it _did_
+seem so good to be free again and all by ourselves on the big river, and
+nobody to bother us.  I had to skip around a bit, and jump up and crack
+my heels a few times--I couldn’t help it; but about the third crack
+I noticed a sound that I knowed mighty well, and held my breath and
+listened and waited; and sure enough, when the next flash busted out
+over the water, here they come!--and just a-laying to their oars and
+making their skiff hum!  It was the king and the duke.
+
+So I wilted right down on to the planks then, and give up; and it was
+all I could do to keep from crying.
+
+
+
+
+CHAPTER XXX.
+
+WHEN they got aboard the king went for me, and shook me by the collar,
+and says:
+
+“Tryin’ to give us the slip, was ye, you pup!  Tired of our company,
+hey?”
+
+I says:
+
+“No, your majesty, we warn’t--_please_ don’t, your majesty!”
+
+“Quick, then, and tell us what _was_ your idea, or I’ll shake the
+insides out o’ you!”
+
+“Honest, I’ll tell you everything just as it happened, your majesty.
+ The man that had a-holt of me was very good to me, and kept saying he
+had a boy about as big as me that died last year, and he was sorry
+to see a boy in such a dangerous fix; and when they was all took by
+surprise by finding the gold, and made a rush for the coffin, he lets go
+of me and whispers, ‘Heel it now, or they’ll hang ye, sure!’ and I lit
+out.  It didn’t seem no good for _me_ to stay--I couldn’t do nothing,
+and I didn’t want to be hung if I could get away.  So I never stopped
+running till I found the canoe; and when I got here I told Jim to hurry,
+or they’d catch me and hang me yet, and said I was afeard you and the
+duke wasn’t alive now, and I was awful sorry, and so was Jim, and was
+awful glad when we see you coming; you may ask Jim if I didn’t.”
+
+Jim said it was so; and the king told him to shut up, and said, “Oh,
+yes, it’s _mighty_ likely!” and shook me up again, and said he reckoned
+he’d drownd me.  But the duke says:
+
+“Leggo the boy, you old idiot!  Would _you_ a done any different?  Did
+you inquire around for _him_ when you got loose?  I don’t remember it.”
+
+So the king let go of me, and begun to cuss that town and everybody in
+it. But the duke says:
+
+“You better a blame’ sight give _yourself_ a good cussing, for you’re
+the one that’s entitled to it most.  You hain’t done a thing from the
+start that had any sense in it, except coming out so cool and cheeky
+with that imaginary blue-arrow mark.  That _was_ bright--it was right
+down bully; and it was the thing that saved us.  For if it hadn’t been
+for that they’d a jailed us till them Englishmen’s baggage come--and
+then--the penitentiary, you bet! But that trick took ‘em to the
+graveyard, and the gold done us a still bigger kindness; for if the
+excited fools hadn’t let go all holts and made that rush to get a
+look we’d a slept in our cravats to-night--cravats warranted to _wear_,
+too--longer than _we’d_ need ‘em.”
+
+They was still a minute--thinking; then the king says, kind of
+absent-minded like:
+
+“Mf!  And we reckoned the _niggers_ stole it!”
+
+That made me squirm!
+
+“Yes,” says the duke, kinder slow and deliberate and sarcastic, “_we_
+did.”
+
+After about a half a minute the king drawls out:
+
+“Leastways, I did.”
+
+The duke says, the same way:
+
+“On the contrary, I did.”
+
+The king kind of ruffles up, and says:
+
+“Looky here, Bilgewater, what’r you referrin’ to?”
+
+The duke says, pretty brisk:
+
+“When it comes to that, maybe you’ll let me ask, what was _you_
+referring to?”
+
+“Shucks!” says the king, very sarcastic; “but I don’t know--maybe you was
+asleep, and didn’t know what you was about.”
+
+The duke bristles up now, and says:
+
+“Oh, let _up_ on this cussed nonsense; do you take me for a blame’ fool?
+Don’t you reckon I know who hid that money in that coffin?”
+
+“_Yes_, sir!  I know you _do_ know, because you done it yourself!”
+
+“It’s a lie!”--and the duke went for him.  The king sings out:
+
+“Take y’r hands off!--leggo my throat!--I take it all back!”
+
+The duke says:
+
+“Well, you just own up, first, that you _did_ hide that money there,
+intending to give me the slip one of these days, and come back and dig
+it up, and have it all to yourself.”
+
+“Wait jest a minute, duke--answer me this one question, honest and fair;
+if you didn’t put the money there, say it, and I’ll b’lieve you, and
+take back everything I said.”
+
+“You old scoundrel, I didn’t, and you know I didn’t.  There, now!”
+
+“Well, then, I b’lieve you.  But answer me only jest this one more--now
+_don’t_ git mad; didn’t you have it in your mind to hook the money and
+hide it?”
+
+The duke never said nothing for a little bit; then he says:
+
+“Well, I don’t care if I _did_, I didn’t _do_ it, anyway.  But you not
+only had it in mind to do it, but you _done_ it.”
+
+“I wisht I never die if I done it, duke, and that’s honest.  I won’t say
+I warn’t goin’ to do it, because I _was_; but you--I mean somebody--got in
+ahead o’ me.”
+
+“It’s a lie!  You done it, and you got to _say_ you done it, or--”
+
+The king began to gurgle, and then he gasps out:
+
+“‘Nough!--I _own up!_”
+
+I was very glad to hear him say that; it made me feel much more easier
+than what I was feeling before.  So the duke took his hands off and
+says:
+
+“If you ever deny it again I’ll drown you.  It’s _well_ for you to set
+there and blubber like a baby--it’s fitten for you, after the way
+you’ve acted. I never see such an old ostrich for wanting to gobble
+everything--and I a-trusting you all the time, like you was my own
+father.  You ought to been ashamed of yourself to stand by and hear it
+saddled on to a lot of poor niggers, and you never say a word for ‘em.
+ It makes me feel ridiculous to think I was soft enough to _believe_
+that rubbage.  Cuss you, I can see now why you was so anxious to make
+up the deffisit--you wanted to get what money I’d got out of the Nonesuch
+and one thing or another, and scoop it _all_!”
+
+The king says, timid, and still a-snuffling:
+
+“Why, duke, it was you that said make up the deffisit; it warn’t me.”
+
+“Dry up!  I don’t want to hear no more out of you!” says the duke.  “And
+_now_ you see what you GOT by it.  They’ve got all their own money back,
+and all of _ourn_ but a shekel or two _besides_.  G’long to bed, and
+don’t you deffersit _me_ no more deffersits, long ‘s _you_ live!”
+
+So the king sneaked into the wigwam and took to his bottle for comfort,
+and before long the duke tackled HIS bottle; and so in about a half an
+hour they was as thick as thieves again, and the tighter they got the
+lovinger they got, and went off a-snoring in each other’s arms.  They
+both got powerful mellow, but I noticed the king didn’t get mellow
+enough to forget to remember to not deny about hiding the money-bag
+again.  That made me feel easy and satisfied.  Of course when they got
+to snoring we had a long gabble, and I told Jim everything.
+
+
+
+
+CHAPTER XXXI.
+
+WE dasn’t stop again at any town for days and days; kept right along
+down the river.  We was down south in the warm weather now, and a mighty
+long ways from home.  We begun to come to trees with Spanish moss on
+them, hanging down from the limbs like long, gray beards.  It was the
+first I ever see it growing, and it made the woods look solemn and
+dismal.  So now the frauds reckoned they was out of danger, and they
+begun to work the villages again.
+
+First they done a lecture on temperance; but they didn’t make enough
+for them both to get drunk on.  Then in another village they started
+a dancing-school; but they didn’t know no more how to dance than a
+kangaroo does; so the first prance they made the general public jumped
+in and pranced them out of town.  Another time they tried to go at
+yellocution; but they didn’t yellocute long till the audience got up and
+give them a solid good cussing, and made them skip out.  They tackled
+missionarying, and mesmerizing, and doctoring, and telling fortunes, and
+a little of everything; but they couldn’t seem to have no luck.  So at
+last they got just about dead broke, and laid around the raft as she
+floated along, thinking and thinking, and never saying nothing, by the
+half a day at a time, and dreadful blue and desperate.
+
+And at last they took a change and begun to lay their heads together in
+the wigwam and talk low and confidential two or three hours at a time.
+Jim and me got uneasy.  We didn’t like the look of it.  We judged they
+was studying up some kind of worse deviltry than ever.  We turned it
+over and over, and at last we made up our minds they was going to break
+into somebody’s house or store, or was going into the counterfeit-money
+business, or something. So then we was pretty scared, and made up an
+agreement that we wouldn’t have nothing in the world to do with such
+actions, and if we ever got the least show we would give them the cold
+shake and clear out and leave them behind. Well, early one morning we
+hid the raft in a good, safe place about two mile below a little bit of
+a shabby village named Pikesville, and the king he went ashore and told
+us all to stay hid whilst he went up to town and smelt around to see
+if anybody had got any wind of the Royal Nonesuch there yet. (“House to
+rob, you _mean_,” says I to myself; “and when you get through robbing it
+you’ll come back here and wonder what has become of me and Jim and the
+raft--and you’ll have to take it out in wondering.”) And he said if he
+warn’t back by midday the duke and me would know it was all right, and
+we was to come along.
+
+So we stayed where we was.  The duke he fretted and sweated around, and
+was in a mighty sour way.  He scolded us for everything, and we couldn’t
+seem to do nothing right; he found fault with every little thing.
+Something was a-brewing, sure.  I was good and glad when midday come
+and no king; we could have a change, anyway--and maybe a chance for _the_
+change on top of it.  So me and the duke went up to the village, and
+hunted around there for the king, and by and by we found him in the
+back room of a little low doggery, very tight, and a lot of loafers
+bullyragging him for sport, and he a-cussing and a-threatening with all
+his might, and so tight he couldn’t walk, and couldn’t do nothing to
+them.  The duke he begun to abuse him for an old fool, and the king
+begun to sass back, and the minute they was fairly at it I lit out and
+shook the reefs out of my hind legs, and spun down the river road like
+a deer, for I see our chance; and I made up my mind that it would be a
+long day before they ever see me and Jim again.  I got down there all
+out of breath but loaded up with joy, and sung out:
+
+“Set her loose, Jim! we’re all right now!”
+
+But there warn’t no answer, and nobody come out of the wigwam.  Jim was
+gone!  I set up a shout--and then another--and then another one; and run
+this way and that in the woods, whooping and screeching; but it warn’t
+no use--old Jim was gone.  Then I set down and cried; I couldn’t help
+it. But I couldn’t set still long.  Pretty soon I went out on the road,
+trying to think what I better do, and I run across a boy walking, and
+asked him if he’d seen a strange nigger dressed so and so, and he says:
+
+“Yes.”
+
+“Whereabouts?” says I.
+
+“Down to Silas Phelps’ place, two mile below here.  He’s a runaway
+nigger, and they’ve got him.  Was you looking for him?”
+
+“You bet I ain’t!  I run across him in the woods about an hour or two
+ago, and he said if I hollered he’d cut my livers out--and told me to lay
+down and stay where I was; and I done it.  Been there ever since; afeard
+to come out.”
+
+“Well,” he says, “you needn’t be afeard no more, becuz they’ve got him.
+He run off f’m down South, som’ers.”
+
+“It’s a good job they got him.”
+
+“Well, I _reckon_!  There’s two hunderd dollars reward on him.  It’s
+like picking up money out’n the road.”
+
+“Yes, it is--and I could a had it if I’d been big enough; I see him
+_first_. Who nailed him?”
+
+“It was an old fellow--a stranger--and he sold out his chance in him for
+forty dollars, becuz he’s got to go up the river and can’t wait.  Think
+o’ that, now!  You bet _I’d_ wait, if it was seven year.”
+
+“That’s me, every time,” says I.  “But maybe his chance ain’t worth
+no more than that, if he’ll sell it so cheap.  Maybe there’s something
+ain’t straight about it.”
+
+“But it _is_, though--straight as a string.  I see the handbill myself.
+ It tells all about him, to a dot--paints him like a picture, and tells
+the plantation he’s frum, below Newr_leans_.  No-sirree-_bob_, they
+ain’t no trouble ‘bout _that_ speculation, you bet you.  Say, gimme a
+chaw tobacker, won’t ye?”
+
+I didn’t have none, so he left.  I went to the raft, and set down in the
+wigwam to think.  But I couldn’t come to nothing.  I thought till I wore
+my head sore, but I couldn’t see no way out of the trouble.  After all
+this long journey, and after all we’d done for them scoundrels, here it
+was all come to nothing, everything all busted up and ruined, because
+they could have the heart to serve Jim such a trick as that, and make
+him a slave again all his life, and amongst strangers, too, for forty
+dirty dollars.
+
+Once I said to myself it would be a thousand times better for Jim to
+be a slave at home where his family was, as long as he’d _got_ to be a
+slave, and so I’d better write a letter to Tom Sawyer and tell him to
+tell Miss Watson where he was.  But I soon give up that notion for two
+things: she’d be mad and disgusted at his rascality and ungratefulness
+for leaving her, and so she’d sell him straight down the river again;
+and if she didn’t, everybody naturally despises an ungrateful nigger,
+and they’d make Jim feel it all the time, and so he’d feel ornery and
+disgraced. And then think of _me_!  It would get all around that Huck
+Finn helped a nigger to get his freedom; and if I was ever to see
+anybody from that town again I’d be ready to get down and lick his boots
+for shame.  That’s just the way:  a person does a low-down thing, and
+then he don’t want to take no consequences of it. Thinks as long as he
+can hide it, it ain’t no disgrace.  That was my fix exactly. The more I
+studied about this the more my conscience went to grinding me, and the
+more wicked and low-down and ornery I got to feeling. And at last, when
+it hit me all of a sudden that here was the plain hand of Providence
+slapping me in the face and letting me know my wickedness was being
+watched all the time from up there in heaven, whilst I was stealing a
+poor old woman’s nigger that hadn’t ever done me no harm, and now was
+showing me there’s One that’s always on the lookout, and ain’t a-going
+to allow no such miserable doings to go only just so fur and no further,
+I most dropped in my tracks I was so scared.  Well, I tried the best I
+could to kinder soften it up somehow for myself by saying I was brung
+up wicked, and so I warn’t so much to blame; but something inside of me
+kept saying, “There was the Sunday-school, you could a gone to it; and
+if you’d a done it they’d a learnt you there that people that acts as
+I’d been acting about that nigger goes to everlasting fire.”
+
+It made me shiver.  And I about made up my mind to pray, and see if I
+couldn’t try to quit being the kind of a boy I was and be better.  So
+I kneeled down.  But the words wouldn’t come.  Why wouldn’t they?  It
+warn’t no use to try and hide it from Him.  Nor from _me_, neither.  I
+knowed very well why they wouldn’t come.  It was because my heart warn’t
+right; it was because I warn’t square; it was because I was playing
+double.  I was letting _on_ to give up sin, but away inside of me I was
+holding on to the biggest one of all.  I was trying to make my mouth
+_say_ I would do the right thing and the clean thing, and go and write
+to that nigger’s owner and tell where he was; but deep down in me I
+knowed it was a lie, and He knowed it.  You can’t pray a lie--I found
+that out.
+
+So I was full of trouble, full as I could be; and didn’t know what to
+do. At last I had an idea; and I says, I’ll go and write the letter--and
+then see if I can pray.  Why, it was astonishing, the way I felt as
+light as a feather right straight off, and my troubles all gone.  So I
+got a piece of paper and a pencil, all glad and excited, and set down
+and wrote:
+
+Miss Watson, your runaway nigger Jim is down here two mile below
+Pikesville, and Mr. Phelps has got him and he will give him up for the
+reward if you send.
+
+_Huck Finn._
+
+I felt good and all washed clean of sin for the first time I had ever
+felt so in my life, and I knowed I could pray now.  But I didn’t do it
+straight off, but laid the paper down and set there thinking--thinking
+how good it was all this happened so, and how near I come to being lost
+and going to hell.  And went on thinking.  And got to thinking over our
+trip down the river; and I see Jim before me all the time:  in the day
+and in the night-time, sometimes moonlight, sometimes storms, and we
+a-floating along, talking and singing and laughing.  But somehow I
+couldn’t seem to strike no places to harden me against him, but only the
+other kind.  I’d see him standing my watch on top of his’n, ‘stead of
+calling me, so I could go on sleeping; and see him how glad he was when
+I come back out of the fog; and when I come to him again in the swamp,
+up there where the feud was; and such-like times; and would always call
+me honey, and pet me and do everything he could think of for me, and how
+good he always was; and at last I struck the time I saved him by telling
+the men we had small-pox aboard, and he was so grateful, and said I was
+the best friend old Jim ever had in the world, and the _only_ one he’s
+got now; and then I happened to look around and see that paper.
+
+It was a close place.  I took it up, and held it in my hand.  I was
+a-trembling, because I’d got to decide, forever, betwixt two things, and
+I knowed it.  I studied a minute, sort of holding my breath, and then
+says to myself:
+
+“All right, then, I’ll _go_ to hell”--and tore it up.
+
+It was awful thoughts and awful words, but they was said.  And I let
+them stay said; and never thought no more about reforming.  I shoved the
+whole thing out of my head, and said I would take up wickedness again,
+which was in my line, being brung up to it, and the other warn’t.  And
+for a starter I would go to work and steal Jim out of slavery again;
+and if I could think up anything worse, I would do that, too; because as
+long as I was in, and in for good, I might as well go the whole hog.
+
+Then I set to thinking over how to get at it, and turned over some
+considerable many ways in my mind; and at last fixed up a plan that
+suited me.  So then I took the bearings of a woody island that was down
+the river a piece, and as soon as it was fairly dark I crept out with my
+raft and went for it, and hid it there, and then turned in.  I slept the
+night through, and got up before it was light, and had my breakfast,
+and put on my store clothes, and tied up some others and one thing or
+another in a bundle, and took the canoe and cleared for shore.  I landed
+below where I judged was Phelps’s place, and hid my bundle in the woods,
+and then filled up the canoe with water, and loaded rocks into her and
+sunk her where I could find her again when I wanted her, about a quarter
+of a mile below a little steam sawmill that was on the bank.
+
+Then I struck up the road, and when I passed the mill I see a sign on
+it, “Phelps’s Sawmill,” and when I come to the farm-houses, two or
+three hundred yards further along, I kept my eyes peeled, but didn’t
+see nobody around, though it was good daylight now.  But I didn’t mind,
+because I didn’t want to see nobody just yet--I only wanted to get the
+lay of the land. According to my plan, I was going to turn up there from
+the village, not from below.  So I just took a look, and shoved along,
+straight for town. Well, the very first man I see when I got there was
+the duke.  He was sticking up a bill for the Royal Nonesuch--three-night
+performance--like that other time.  They had the cheek, them frauds!  I
+was right on him before I could shirk.  He looked astonished, and says:
+
+“Hel-_lo_!  Where’d _you_ come from?”  Then he says, kind of glad and
+eager, “Where’s the raft?--got her in a good place?”
+
+I says:
+
+“Why, that’s just what I was going to ask your grace.”
+
+Then he didn’t look so joyful, and says:
+
+“What was your idea for asking _me_?” he says.
+
+“Well,” I says, “when I see the king in that doggery yesterday I says
+to myself, we can’t get him home for hours, till he’s soberer; so I went
+a-loafing around town to put in the time and wait.  A man up and offered
+me ten cents to help him pull a skiff over the river and back to fetch
+a sheep, and so I went along; but when we was dragging him to the boat,
+and the man left me a-holt of the rope and went behind him to shove him
+along, he was too strong for me and jerked loose and run, and we after
+him.  We didn’t have no dog, and so we had to chase him all over the
+country till we tired him out.  We never got him till dark; then we
+fetched him over, and I started down for the raft.  When I got there and
+see it was gone, I says to myself, ‘They’ve got into trouble and had to
+leave; and they’ve took my nigger, which is the only nigger I’ve got in
+the world, and now I’m in a strange country, and ain’t got no property
+no more, nor nothing, and no way to make my living;’ so I set down and
+cried.  I slept in the woods all night.  But what _did_ become of the
+raft, then?--and Jim--poor Jim!”
+
+“Blamed if I know--that is, what’s become of the raft.  That old fool had
+made a trade and got forty dollars, and when we found him in the doggery
+the loafers had matched half-dollars with him and got every cent but
+what he’d spent for whisky; and when I got him home late last night and
+found the raft gone, we said, ‘That little rascal has stole our raft and
+shook us, and run off down the river.’”
+
+“I wouldn’t shake my _nigger_, would I?--the only nigger I had in the
+world, and the only property.”
+
+“We never thought of that.  Fact is, I reckon we’d come to consider him
+_our_ nigger; yes, we did consider him so--goodness knows we had trouble
+enough for him.  So when we see the raft was gone and we flat broke,
+there warn’t anything for it but to try the Royal Nonesuch another
+shake. And I’ve pegged along ever since, dry as a powder-horn.  Where’s
+that ten cents? Give it here.”
+
+I had considerable money, so I give him ten cents, but begged him to
+spend it for something to eat, and give me some, because it was all the
+money I had, and I hadn’t had nothing to eat since yesterday.  He never
+said nothing.  The next minute he whirls on me and says:
+
+“Do you reckon that nigger would blow on us?  We’d skin him if he done
+that!”
+
+“How can he blow?  Hain’t he run off?”
+
+“No!  That old fool sold him, and never divided with me, and the money’s
+gone.”
+
+“_Sold_ him?”  I says, and begun to cry; “why, he was _my_ nigger, and
+that was my money.  Where is he?--I want my nigger.”
+
+“Well, you can’t _get_ your nigger, that’s all--so dry up your
+blubbering. Looky here--do you think _you’d_ venture to blow on us?
+ Blamed if I think I’d trust you.  Why, if you _was_ to blow on us--”
+
+He stopped, but I never see the duke look so ugly out of his eyes
+before. I went on a-whimpering, and says:
+
+“I don’t want to blow on nobody; and I ain’t got no time to blow, nohow.
+I got to turn out and find my nigger.”
+
+He looked kinder bothered, and stood there with his bills fluttering on
+his arm, thinking, and wrinkling up his forehead.  At last he says:
+
+“I’ll tell you something.  We got to be here three days.  If you’ll
+promise you won’t blow, and won’t let the nigger blow, I’ll tell you
+where to find him.”
+
+So I promised, and he says:
+
+“A farmer by the name of Silas Ph--” and then he stopped.  You see, he
+started to tell me the truth; but when he stopped that way, and begun to
+study and think again, I reckoned he was changing his mind.  And so he
+was. He wouldn’t trust me; he wanted to make sure of having me out of
+the way the whole three days.  So pretty soon he says:
+
+“The man that bought him is named Abram Foster--Abram G. Foster--and he
+lives forty mile back here in the country, on the road to Lafayette.”
+
+“All right,” I says, “I can walk it in three days.  And I’ll start this
+very afternoon.”
+
+“No you wont, you’ll start _now_; and don’t you lose any time about it,
+neither, nor do any gabbling by the way.  Just keep a tight tongue in
+your head and move right along, and then you won’t get into trouble with
+_us_, d’ye hear?”
+
+That was the order I wanted, and that was the one I played for.  I
+wanted to be left free to work my plans.
+
+“So clear out,” he says; “and you can tell Mr. Foster whatever you want
+to. Maybe you can get him to believe that Jim _is_ your nigger--some
+idiots don’t require documents--leastways I’ve heard there’s such down
+South here.  And when you tell him the handbill and the reward’s bogus,
+maybe he’ll believe you when you explain to him what the idea was for
+getting ‘em out.  Go ‘long now, and tell him anything you want to; but
+mind you don’t work your jaw any _between_ here and there.”
+
+So I left, and struck for the back country.  I didn’t look around, but I
+kinder felt like he was watching me.  But I knowed I could tire him out
+at that.  I went straight out in the country as much as a mile before
+I stopped; then I doubled back through the woods towards Phelps’.  I
+reckoned I better start in on my plan straight off without fooling
+around, because I wanted to stop Jim’s mouth till these fellows could
+get away.  I didn’t want no trouble with their kind.  I’d seen all I
+wanted to of them, and wanted to get entirely shut of them.
+
+
+
+
+CHAPTER XXXII.
+
+WHEN I got there it was all still and Sunday-like, and hot and sunshiny;
+the hands was gone to the fields; and there was them kind of faint
+dronings of bugs and flies in the air that makes it seem so lonesome and
+like everybody’s dead and gone; and if a breeze fans along and quivers
+the leaves it makes you feel mournful, because you feel like it’s
+spirits whispering--spirits that’s been dead ever so many years--and you
+always think they’re talking about _you_.  As a general thing it makes a
+body wish _he_ was dead, too, and done with it all.
+
+Phelps’ was one of these little one-horse cotton plantations, and they
+all look alike.  A rail fence round a two-acre yard; a stile made out
+of logs sawed off and up-ended in steps, like barrels of a different
+length, to climb over the fence with, and for the women to stand on when
+they are going to jump on to a horse; some sickly grass-patches in the
+big yard, but mostly it was bare and smooth, like an old hat with the
+nap rubbed off; big double log-house for the white folks--hewed logs,
+with the chinks stopped up with mud or mortar, and these mud-stripes
+been whitewashed some time or another; round-log kitchen, with a big
+broad, open but roofed passage joining it to the house; log smoke-house
+back of the kitchen; three little log nigger-cabins in a row t’other
+side the smoke-house; one little hut all by itself away down against
+the back fence, and some outbuildings down a piece the other side;
+ash-hopper and big kettle to bile soap in by the little hut; bench by
+the kitchen door, with bucket of water and a gourd; hound asleep there
+in the sun; more hounds asleep round about; about three shade trees away
+off in a corner; some currant bushes and gooseberry bushes in one place
+by the fence; outside of the fence a garden and a watermelon patch; then
+the cotton fields begins, and after the fields the woods.
+
+I went around and clumb over the back stile by the ash-hopper, and
+started for the kitchen.  When I got a little ways I heard the dim hum
+of a spinning-wheel wailing along up and sinking along down again;
+and then I knowed for certain I wished I was dead--for that _is_ the
+lonesomest sound in the whole world.
+
+I went right along, not fixing up any particular plan, but just trusting
+to Providence to put the right words in my mouth when the time come; for
+I’d noticed that Providence always did put the right words in my mouth
+if I left it alone.
+
+When I got half-way, first one hound and then another got up and went
+for me, and of course I stopped and faced them, and kept still.  And
+such another powwow as they made!  In a quarter of a minute I was a kind
+of a hub of a wheel, as you may say--spokes made out of dogs--circle of
+fifteen of them packed together around me, with their necks and noses
+stretched up towards me, a-barking and howling; and more a-coming; you
+could see them sailing over fences and around corners from everywheres.
+
+A nigger woman come tearing out of the kitchen with a rolling-pin in her
+hand, singing out, “Begone _you_ Tige! you Spot! begone sah!” and she
+fetched first one and then another of them a clip and sent them howling,
+and then the rest followed; and the next second half of them come back,
+wagging their tails around me, and making friends with me.  There ain’t
+no harm in a hound, nohow.
+
+And behind the woman comes a little nigger girl and two little nigger
+boys without anything on but tow-linen shirts, and they hung on to their
+mother’s gown, and peeped out from behind her at me, bashful, the way
+they always do.  And here comes the white woman running from the house,
+about forty-five or fifty year old, bareheaded, and her spinning-stick
+in her hand; and behind her comes her little white children, acting the
+same way the little niggers was doing.  She was smiling all over so she
+could hardly stand--and says:
+
+“It’s _you_, at last!--_ain’t_ it?”
+
+I out with a “Yes’m” before I thought.
+
+She grabbed me and hugged me tight; and then gripped me by both hands
+and shook and shook; and the tears come in her eyes, and run down over;
+and she couldn’t seem to hug and shake enough, and kept saying, “You
+don’t look as much like your mother as I reckoned you would; but law
+sakes, I don’t care for that, I’m so glad to see you!  Dear, dear, it
+does seem like I could eat you up!  Children, it’s your cousin Tom!--tell
+him howdy.”
+
+But they ducked their heads, and put their fingers in their mouths, and
+hid behind her.  So she run on:
+
+“Lize, hurry up and get him a hot breakfast right away--or did you get
+your breakfast on the boat?”
+
+I said I had got it on the boat.  So then she started for the house,
+leading me by the hand, and the children tagging after.  When we got
+there she set me down in a split-bottomed chair, and set herself down on
+a little low stool in front of me, holding both of my hands, and says:
+
+“Now I can have a _good_ look at you; and, laws-a-me, I’ve been hungry
+for it a many and a many a time, all these long years, and it’s come
+at last! We been expecting you a couple of days and more.  What kep’
+you?--boat get aground?”
+
+“Yes’m--she--”
+
+“Don’t say yes’m--say Aunt Sally.  Where’d she get aground?”
+
+I didn’t rightly know what to say, because I didn’t know whether the
+boat would be coming up the river or down.  But I go a good deal on
+instinct; and my instinct said she would be coming up--from down towards
+Orleans. That didn’t help me much, though; for I didn’t know the names
+of bars down that way.  I see I’d got to invent a bar, or forget the
+name of the one we got aground on--or--Now I struck an idea, and fetched
+it out:
+
+“It warn’t the grounding--that didn’t keep us back but a little.  We
+blowed out a cylinder-head.”
+
+“Good gracious! anybody hurt?”
+
+“No’m.  Killed a nigger.”
+
+“Well, it’s lucky; because sometimes people do get hurt.  Two years ago
+last Christmas your uncle Silas was coming up from Newrleans on the old
+Lally Rook, and she blowed out a cylinder-head and crippled a man.  And
+I think he died afterwards.  He was a Baptist.  Your uncle Silas knowed
+a family in Baton Rouge that knowed his people very well.  Yes, I
+remember now, he _did_ die.  Mortification set in, and they had to
+amputate him. But it didn’t save him.  Yes, it was mortification--that
+was it.  He turned blue all over, and died in the hope of a glorious
+resurrection. They say he was a sight to look at.  Your uncle’s been up
+to the town every day to fetch you. And he’s gone again, not more’n an
+hour ago; he’ll be back any minute now. You must a met him on the road,
+didn’t you?--oldish man, with a--”
+
+“No, I didn’t see nobody, Aunt Sally.  The boat landed just at daylight,
+and I left my baggage on the wharf-boat and went looking around the town
+and out a piece in the country, to put in the time and not get here too
+soon; and so I come down the back way.”
+
+“Who’d you give the baggage to?”
+
+“Nobody.”
+
+“Why, child, it ‘ll be stole!”
+
+“Not where I hid it I reckon it won’t,” I says.
+
+“How’d you get your breakfast so early on the boat?”
+
+It was kinder thin ice, but I says:
+
+“The captain see me standing around, and told me I better have something
+to eat before I went ashore; so he took me in the texas to the officers’
+lunch, and give me all I wanted.”
+
+I was getting so uneasy I couldn’t listen good.  I had my mind on the
+children all the time; I wanted to get them out to one side and pump
+them a little, and find out who I was.  But I couldn’t get no show, Mrs.
+Phelps kept it up and run on so.  Pretty soon she made the cold chills
+streak all down my back, because she says:
+
+“But here we’re a-running on this way, and you hain’t told me a word
+about Sis, nor any of them.  Now I’ll rest my works a little, and you
+start up yourn; just tell me _everything_--tell me all about ‘m all every
+one of ‘m; and how they are, and what they’re doing, and what they told
+you to tell me; and every last thing you can think of.”
+
+Well, I see I was up a stump--and up it good.  Providence had stood by
+me this fur all right, but I was hard and tight aground now.  I see it
+warn’t a bit of use to try to go ahead--I’d got to throw up my hand.  So
+I says to myself, here’s another place where I got to resk the truth.
+ I opened my mouth to begin; but she grabbed me and hustled me in behind
+the bed, and says:
+
+“Here he comes!  Stick your head down lower--there, that’ll do; you can’t
+be seen now.  Don’t you let on you’re here.  I’ll play a joke on him.
+Children, don’t you say a word.”
+
+I see I was in a fix now.  But it warn’t no use to worry; there warn’t
+nothing to do but just hold still, and try and be ready to stand from
+under when the lightning struck.
+
+I had just one little glimpse of the old gentleman when he come in; then
+the bed hid him.  Mrs. Phelps she jumps for him, and says:
+
+“Has he come?”
+
+“No,” says her husband.
+
+“Good-_ness_ gracious!” she says, “what in the warld can have become of
+him?”
+
+“I can’t imagine,” says the old gentleman; “and I must say it makes me
+dreadful uneasy.”
+
+“Uneasy!” she says; “I’m ready to go distracted!  He _must_ a come; and
+you’ve missed him along the road.  I _know_ it’s so--something tells me
+so.”
+
+“Why, Sally, I _couldn’t_ miss him along the road--_you_ know that.”
+
+“But oh, dear, dear, what _will_ Sis say!  He must a come!  You must a
+missed him.  He--”
+
+“Oh, don’t distress me any more’n I’m already distressed.  I don’t know
+what in the world to make of it.  I’m at my wit’s end, and I don’t mind
+acknowledging ‘t I’m right down scared.  But there’s no hope that he’s
+come; for he _couldn’t_ come and me miss him.  Sally, it’s terrible--just
+terrible--something’s happened to the boat, sure!”
+
+“Why, Silas!  Look yonder!--up the road!--ain’t that somebody coming?”
+
+He sprung to the window at the head of the bed, and that give Mrs.
+Phelps the chance she wanted.  She stooped down quick at the foot of the
+bed and give me a pull, and out I come; and when he turned back from the
+window there she stood, a-beaming and a-smiling like a house afire, and
+I standing pretty meek and sweaty alongside.  The old gentleman stared,
+and says:
+
+“Why, who’s that?”
+
+“Who do you reckon ‘t is?”
+
+“I hain’t no idea.  Who _is_ it?”
+
+“It’s _Tom Sawyer!_”
+
+By jings, I most slumped through the floor!  But there warn’t no time to
+swap knives; the old man grabbed me by the hand and shook, and kept on
+shaking; and all the time how the woman did dance around and laugh and
+cry; and then how they both did fire off questions about Sid, and Mary,
+and the rest of the tribe.
+
+But if they was joyful, it warn’t nothing to what I was; for it was like
+being born again, I was so glad to find out who I was.  Well, they froze
+to me for two hours; and at last, when my chin was so tired it couldn’t
+hardly go any more, I had told them more about my family--I mean the
+Sawyer family--than ever happened to any six Sawyer families.  And I
+explained all about how we blowed out a cylinder-head at the mouth of
+White River, and it took us three days to fix it.  Which was all right,
+and worked first-rate; because _they_ didn’t know but what it would take
+three days to fix it.  If I’d a called it a bolthead it would a done
+just as well.
+
+Now I was feeling pretty comfortable all down one side, and pretty
+uncomfortable all up the other.  Being Tom Sawyer was easy and
+comfortable, and it stayed easy and comfortable till by and by I hear a
+steamboat coughing along down the river.  Then I says to myself, s’pose
+Tom Sawyer comes down on that boat?  And s’pose he steps in here any
+minute, and sings out my name before I can throw him a wink to keep
+quiet?
+
+Well, I couldn’t _have_ it that way; it wouldn’t do at all.  I must go
+up the road and waylay him.  So I told the folks I reckoned I would go
+up to the town and fetch down my baggage.  The old gentleman was for
+going along with me, but I said no, I could drive the horse myself, and
+I druther he wouldn’t take no trouble about me.
+
+
+
+
+CHAPTER XXXIII.
+
+SO I started for town in the wagon, and when I was half-way I see a
+wagon coming, and sure enough it was Tom Sawyer, and I stopped and
+waited till he come along.  I says “Hold on!” and it stopped alongside,
+and his mouth opened up like a trunk, and stayed so; and he swallowed
+two or three times like a person that’s got a dry throat, and then says:
+
+“I hain’t ever done you no harm.  You know that.  So, then, what you
+want to come back and ha’nt _me_ for?”
+
+I says:
+
+“I hain’t come back--I hain’t been _gone_.”
+
+When he heard my voice it righted him up some, but he warn’t quite
+satisfied yet.  He says:
+
+“Don’t you play nothing on me, because I wouldn’t on you.  Honest injun
+now, you ain’t a ghost?”
+
+“Honest injun, I ain’t,” I says.
+
+“Well--I--I--well, that ought to settle it, of course; but I can’t somehow
+seem to understand it no way.  Looky here, warn’t you ever murdered _at
+all?_”
+
+“No.  I warn’t ever murdered at all--I played it on them.  You come in
+here and feel of me if you don’t believe me.”
+
+So he done it; and it satisfied him; and he was that glad to see me
+again he didn’t know what to do.  And he wanted to know all about it
+right off, because it was a grand adventure, and mysterious, and so it
+hit him where he lived.  But I said, leave it alone till by and by; and
+told his driver to wait, and we drove off a little piece, and I told
+him the kind of a fix I was in, and what did he reckon we better do?  He
+said, let him alone a minute, and don’t disturb him.  So he thought and
+thought, and pretty soon he says:
+
+“It’s all right; I’ve got it.  Take my trunk in your wagon, and let on
+it’s your’n; and you turn back and fool along slow, so as to get to the
+house about the time you ought to; and I’ll go towards town a piece, and
+take a fresh start, and get there a quarter or a half an hour after you;
+and you needn’t let on to know me at first.”
+
+I says:
+
+“All right; but wait a minute.  There’s one more thing--a thing that
+_nobody_ don’t know but me.  And that is, there’s a nigger here that
+I’m a-trying to steal out of slavery, and his name is _Jim_--old Miss
+Watson’s Jim.”
+
+He says:
+
+“What!  Why, Jim is--”
+
+He stopped and went to studying.  I says:
+
+“I know what you’ll say.  You’ll say it’s dirty, low-down business; but
+what if it is?  I’m low down; and I’m a-going to steal him, and I want
+you keep mum and not let on.  Will you?”
+
+His eye lit up, and he says:
+
+“I’ll _help_ you steal him!”
+
+Well, I let go all holts then, like I was shot.  It was the most
+astonishing speech I ever heard--and I’m bound to say Tom Sawyer fell
+considerable in my estimation.  Only I couldn’t believe it.  Tom Sawyer
+a _nigger-stealer!_
+
+“Oh, shucks!”  I says; “you’re joking.”
+
+“I ain’t joking, either.”
+
+“Well, then,” I says, “joking or no joking, if you hear anything said
+about a runaway nigger, don’t forget to remember that _you_ don’t know
+nothing about him, and I don’t know nothing about him.”
+
+Then we took the trunk and put it in my wagon, and he drove off his
+way and I drove mine.  But of course I forgot all about driving slow on
+accounts of being glad and full of thinking; so I got home a heap too
+quick for that length of a trip.  The old gentleman was at the door, and
+he says:
+
+“Why, this is wonderful!  Whoever would a thought it was in that mare
+to do it?  I wish we’d a timed her.  And she hain’t sweated a hair--not
+a hair. It’s wonderful.  Why, I wouldn’t take a hundred dollars for that
+horse now--I wouldn’t, honest; and yet I’d a sold her for fifteen before,
+and thought ‘twas all she was worth.”
+
+That’s all he said.  He was the innocentest, best old soul I ever see.
+But it warn’t surprising; because he warn’t only just a farmer, he was
+a preacher, too, and had a little one-horse log church down back of the
+plantation, which he built it himself at his own expense, for a church
+and schoolhouse, and never charged nothing for his preaching, and it was
+worth it, too.  There was plenty other farmer-preachers like that, and
+done the same way, down South.
+
+In about half an hour Tom’s wagon drove up to the front stile, and Aunt
+Sally she see it through the window, because it was only about fifty
+yards, and says:
+
+“Why, there’s somebody come!  I wonder who ‘tis?  Why, I do believe it’s
+a stranger.  Jimmy” (that’s one of the children) “run and tell Lize to
+put on another plate for dinner.”
+
+Everybody made a rush for the front door, because, of course, a stranger
+don’t come _every_ year, and so he lays over the yaller-fever, for
+interest, when he does come.  Tom was over the stile and starting for
+the house; the wagon was spinning up the road for the village, and we
+was all bunched in the front door.  Tom had his store clothes on, and an
+audience--and that was always nuts for Tom Sawyer.  In them circumstances
+it warn’t no trouble to him to throw in an amount of style that was
+suitable.  He warn’t a boy to meeky along up that yard like a sheep; no,
+he come ca’m and important, like the ram.  When he got a-front of us he
+lifts his hat ever so gracious and dainty, like it was the lid of a box
+that had butterflies asleep in it and he didn’t want to disturb them,
+and says:
+
+“Mr. Archibald Nichols, I presume?”
+
+“No, my boy,” says the old gentleman, “I’m sorry to say ‘t your driver
+has deceived you; Nichols’s place is down a matter of three mile more.
+Come in, come in.”
+
+Tom he took a look back over his shoulder, and says, “Too late--he’s out
+of sight.”
+
+“Yes, he’s gone, my son, and you must come in and eat your dinner with
+us; and then we’ll hitch up and take you down to Nichols’s.”
+
+“Oh, I _can’t_ make you so much trouble; I couldn’t think of it.  I’ll
+walk--I don’t mind the distance.”
+
+“But we won’t _let_ you walk--it wouldn’t be Southern hospitality to do
+it. Come right in.”
+
+“Oh, _do_,” says Aunt Sally; “it ain’t a bit of trouble to us, not a
+bit in the world.  You must stay.  It’s a long, dusty three mile, and
+we can’t let you walk.  And, besides, I’ve already told ‘em to put on
+another plate when I see you coming; so you mustn’t disappoint us.  Come
+right in and make yourself at home.”
+
+So Tom he thanked them very hearty and handsome, and let himself be
+persuaded, and come in; and when he was in he said he was a stranger
+from Hicksville, Ohio, and his name was William Thompson--and he made
+another bow.
+
+Well, he run on, and on, and on, making up stuff about Hicksville and
+everybody in it he could invent, and I getting a little nervious, and
+wondering how this was going to help me out of my scrape; and at last,
+still talking along, he reached over and kissed Aunt Sally right on the
+mouth, and then settled back again in his chair comfortable, and was
+going on talking; but she jumped up and wiped it off with the back of
+her hand, and says:
+
+“You owdacious puppy!”
+
+He looked kind of hurt, and says:
+
+“I’m surprised at you, m’am.”
+
+“You’re s’rp--Why, what do you reckon I am?  I’ve a good notion to take
+and--Say, what do you mean by kissing me?”
+
+He looked kind of humble, and says:
+
+“I didn’t mean nothing, m’am.  I didn’t mean no harm.  I--I--thought you’d
+like it.”
+
+“Why, you born fool!”  She took up the spinning stick, and it looked
+like it was all she could do to keep from giving him a crack with it.
+ “What made you think I’d like it?”
+
+“Well, I don’t know.  Only, they--they--told me you would.”
+
+“_They_ told you I would.  Whoever told you’s _another_ lunatic.  I
+never heard the beat of it.  Who’s _they_?”
+
+“Why, everybody.  They all said so, m’am.”
+
+It was all she could do to hold in; and her eyes snapped, and her
+fingers worked like she wanted to scratch him; and she says:
+
+“Who’s ‘everybody’?  Out with their names, or ther’ll be an idiot
+short.”
+
+He got up and looked distressed, and fumbled his hat, and says:
+
+“I’m sorry, and I warn’t expecting it.  They told me to.  They all told
+me to.  They all said, kiss her; and said she’d like it.  They all said
+it--every one of them.  But I’m sorry, m’am, and I won’t do it no more--I
+won’t, honest.”
+
+“You won’t, won’t you?  Well, I sh’d _reckon_ you won’t!”
+
+“No’m, I’m honest about it; I won’t ever do it again--till you ask me.”
+
+“Till I _ask_ you!  Well, I never see the beat of it in my born days!
+ I lay you’ll be the Methusalem-numskull of creation before ever I ask
+you--or the likes of you.”
+
+“Well,” he says, “it does surprise me so.  I can’t make it out, somehow.
+They said you would, and I thought you would.  But--” He stopped and
+looked around slow, like he wished he could run across a friendly eye
+somewheres, and fetched up on the old gentleman’s, and says, “Didn’t
+_you_ think she’d like me to kiss her, sir?”
+
+“Why, no; I--I--well, no, I b’lieve I didn’t.”
+
+Then he looks on around the same way to me, and says:
+
+“Tom, didn’t _you_ think Aunt Sally ‘d open out her arms and say, ‘Sid
+Sawyer--’”
+
+“My land!” she says, breaking in and jumping for him, “you impudent
+young rascal, to fool a body so--” and was going to hug him, but he
+fended her off, and says:
+
+“No, not till you’ve asked me first.”
+
+So she didn’t lose no time, but asked him; and hugged him and kissed
+him over and over again, and then turned him over to the old man, and he
+took what was left.  And after they got a little quiet again she says:
+
+“Why, dear me, I never see such a surprise.  We warn’t looking for _you_
+at all, but only Tom.  Sis never wrote to me about anybody coming but
+him.”
+
+“It’s because it warn’t _intended_ for any of us to come but Tom,” he
+says; “but I begged and begged, and at the last minute she let me
+come, too; so, coming down the river, me and Tom thought it would be a
+first-rate surprise for him to come here to the house first, and for me
+to by and by tag along and drop in, and let on to be a stranger.  But it
+was a mistake, Aunt Sally.  This ain’t no healthy place for a stranger
+to come.”
+
+“No--not impudent whelps, Sid.  You ought to had your jaws boxed; I
+hain’t been so put out since I don’t know when.  But I don’t care, I
+don’t mind the terms--I’d be willing to stand a thousand such jokes to
+have you here. Well, to think of that performance!  I don’t deny it, I
+was most putrified with astonishment when you give me that smack.”
+
+We had dinner out in that broad open passage betwixt the house and
+the kitchen; and there was things enough on that table for seven
+families--and all hot, too; none of your flabby, tough meat that’s laid
+in a cupboard in a damp cellar all night and tastes like a hunk of
+old cold cannibal in the morning.  Uncle Silas he asked a pretty long
+blessing over it, but it was worth it; and it didn’t cool it a bit,
+neither, the way I’ve seen them kind of interruptions do lots of times.
+ There was a considerable good deal of talk all the afternoon, and me
+and Tom was on the lookout all the time; but it warn’t no use, they
+didn’t happen to say nothing about any runaway nigger, and we was afraid
+to try to work up to it.  But at supper, at night, one of the little
+boys says:
+
+“Pa, mayn’t Tom and Sid and me go to the show?”
+
+“No,” says the old man, “I reckon there ain’t going to be any; and you
+couldn’t go if there was; because the runaway nigger told Burton and
+me all about that scandalous show, and Burton said he would tell the
+people; so I reckon they’ve drove the owdacious loafers out of town
+before this time.”
+
+So there it was!--but I couldn’t help it.  Tom and me was to sleep in the
+same room and bed; so, being tired, we bid good-night and went up to
+bed right after supper, and clumb out of the window and down the
+lightning-rod, and shoved for the town; for I didn’t believe anybody was
+going to give the king and the duke a hint, and so if I didn’t hurry up
+and give them one they’d get into trouble sure.
+
+On the road Tom he told me all about how it was reckoned I was murdered,
+and how pap disappeared pretty soon, and didn’t come back no more, and
+what a stir there was when Jim run away; and I told Tom all about our
+Royal Nonesuch rapscallions, and as much of the raft voyage as I had
+time to; and as we struck into the town and up through the the middle of
+it--it was as much as half-after eight, then--here comes a raging rush of
+people with torches, and an awful whooping and yelling, and banging tin
+pans and blowing horns; and we jumped to one side to let them go by;
+and as they went by I see they had the king and the duke astraddle of a
+rail--that is, I knowed it _was_ the king and the duke, though they was
+all over tar and feathers, and didn’t look like nothing in the
+world that was human--just looked like a couple of monstrous big
+soldier-plumes.  Well, it made me sick to see it; and I was sorry for
+them poor pitiful rascals, it seemed like I couldn’t ever feel any
+hardness against them any more in the world.  It was a dreadful thing to
+see.  Human beings _can_ be awful cruel to one another.
+
+We see we was too late--couldn’t do no good.  We asked some stragglers
+about it, and they said everybody went to the show looking very
+innocent; and laid low and kept dark till the poor old king was in the
+middle of his cavortings on the stage; then somebody give a signal, and
+the house rose up and went for them.
+
+So we poked along back home, and I warn’t feeling so brash as I was
+before, but kind of ornery, and humble, and to blame, somehow--though
+I hadn’t done nothing.  But that’s always the way; it don’t make no
+difference whether you do right or wrong, a person’s conscience ain’t
+got no sense, and just goes for him anyway.  If I had a yaller dog that
+didn’t know no more than a person’s conscience does I would pison him.
+It takes up more room than all the rest of a person’s insides, and yet
+ain’t no good, nohow.  Tom Sawyer he says the same.
+
+
+
+
+CHAPTER XXXIV.
+
+WE stopped talking, and got to thinking.  By and by Tom says:
+
+“Looky here, Huck, what fools we are to not think of it before!  I bet I
+know where Jim is.”
+
+“No!  Where?”
+
+“In that hut down by the ash-hopper.  Why, looky here.  When we was at
+dinner, didn’t you see a nigger man go in there with some vittles?”
+
+“Yes.”
+
+“What did you think the vittles was for?”
+
+“For a dog.”
+
+“So ‘d I. Well, it wasn’t for a dog.”
+
+“Why?”
+
+“Because part of it was watermelon.”
+
+“So it was--I noticed it.  Well, it does beat all that I never thought
+about a dog not eating watermelon.  It shows how a body can see and
+don’t see at the same time.”
+
+“Well, the nigger unlocked the padlock when he went in, and he locked it
+again when he came out.  He fetched uncle a key about the time we got up
+from table--same key, I bet.  Watermelon shows man, lock shows prisoner;
+and it ain’t likely there’s two prisoners on such a little plantation,
+and where the people’s all so kind and good.  Jim’s the prisoner.  All
+right--I’m glad we found it out detective fashion; I wouldn’t give shucks
+for any other way.  Now you work your mind, and study out a plan to
+steal Jim, and I will study out one, too; and we’ll take the one we like
+the best.”
+
+What a head for just a boy to have!  If I had Tom Sawyer’s head I
+wouldn’t trade it off to be a duke, nor mate of a steamboat, nor clown
+in a circus, nor nothing I can think of.  I went to thinking out a plan,
+but only just to be doing something; I knowed very well where the right
+plan was going to come from.  Pretty soon Tom says:
+
+“Ready?”
+
+“Yes,” I says.
+
+“All right--bring it out.”
+
+“My plan is this,” I says.  “We can easy find out if it’s Jim in there.
+Then get up my canoe to-morrow night, and fetch my raft over from the
+island.  Then the first dark night that comes steal the key out of the
+old man’s britches after he goes to bed, and shove off down the river
+on the raft with Jim, hiding daytimes and running nights, the way me and
+Jim used to do before.  Wouldn’t that plan work?”
+
+“_Work_?  Why, cert’nly it would work, like rats a-fighting.  But it’s
+too blame’ simple; there ain’t nothing _to_ it.  What’s the good of a
+plan that ain’t no more trouble than that?  It’s as mild as goose-milk.
+ Why, Huck, it wouldn’t make no more talk than breaking into a soap
+factory.”
+
+I never said nothing, because I warn’t expecting nothing different; but
+I knowed mighty well that whenever he got _his_ plan ready it wouldn’t
+have none of them objections to it.
+
+And it didn’t.  He told me what it was, and I see in a minute it was
+worth fifteen of mine for style, and would make Jim just as free a man
+as mine would, and maybe get us all killed besides.  So I was satisfied,
+and said we would waltz in on it.  I needn’t tell what it was here,
+because I knowed it wouldn’t stay the way, it was.  I knowed he would be
+changing it around every which way as we went along, and heaving in new
+bullinesses wherever he got a chance.  And that is what he done.
+
+Well, one thing was dead sure, and that was that Tom Sawyer was in
+earnest, and was actuly going to help steal that nigger out of slavery.
+That was the thing that was too many for me.  Here was a boy that was
+respectable and well brung up; and had a character to lose; and folks at
+home that had characters; and he was bright and not leather-headed; and
+knowing and not ignorant; and not mean, but kind; and yet here he was,
+without any more pride, or rightness, or feeling, than to stoop to
+this business, and make himself a shame, and his family a shame,
+before everybody.  I _couldn’t_ understand it no way at all.  It was
+outrageous, and I knowed I ought to just up and tell him so; and so be
+his true friend, and let him quit the thing right where he was and save
+himself. And I _did_ start to tell him; but he shut me up, and says:
+
+“Don’t you reckon I know what I’m about?  Don’t I generly know what I’m
+about?”
+
+“Yes.”
+
+“Didn’t I _say_ I was going to help steal the nigger?”
+
+“Yes.”
+
+“_Well_, then.”
+
+That’s all he said, and that’s all I said.  It warn’t no use to say any
+more; because when he said he’d do a thing, he always done it.  But I
+couldn’t make out how he was willing to go into this thing; so I just
+let it go, and never bothered no more about it.  If he was bound to have
+it so, I couldn’t help it.
+
+When we got home the house was all dark and still; so we went on down to
+the hut by the ash-hopper for to examine it.  We went through the yard
+so as to see what the hounds would do.  They knowed us, and didn’t make
+no more noise than country dogs is always doing when anything comes by
+in the night.  When we got to the cabin we took a look at the front and
+the two sides; and on the side I warn’t acquainted with--which was the
+north side--we found a square window-hole, up tolerable high, with just
+one stout board nailed across it.  I says:
+
+“Here’s the ticket.  This hole’s big enough for Jim to get through if we
+wrench off the board.”
+
+Tom says:
+
+“It’s as simple as tit-tat-toe, three-in-a-row, and as easy as
+playing hooky.  I should _hope_ we can find a way that’s a little more
+complicated than _that_, Huck Finn.”
+
+“Well, then,” I says, “how ‘ll it do to saw him out, the way I done
+before I was murdered that time?”
+
+“That’s more _like_,” he says.  “It’s real mysterious, and troublesome,
+and good,” he says; “but I bet we can find a way that’s twice as long.
+ There ain’t no hurry; le’s keep on looking around.”
+
+Betwixt the hut and the fence, on the back side, was a lean-to that
+joined the hut at the eaves, and was made out of plank.  It was as long
+as the hut, but narrow--only about six foot wide.  The door to it was at
+the south end, and was padlocked.  Tom he went to the soap-kettle and
+searched around, and fetched back the iron thing they lift the lid with;
+so he took it and prized out one of the staples.  The chain fell down,
+and we opened the door and went in, and shut it, and struck a match,
+and see the shed was only built against a cabin and hadn’t no connection
+with it; and there warn’t no floor to the shed, nor nothing in it but
+some old rusty played-out hoes and spades and picks and a crippled plow.
+ The match went out, and so did we, and shoved in the staple again, and
+the door was locked as good as ever. Tom was joyful.  He says;
+
+“Now we’re all right.  We’ll _dig_ him out.  It ‘ll take about a week!”
+
+Then we started for the house, and I went in the back door--you only have
+to pull a buckskin latch-string, they don’t fasten the doors--but that
+warn’t romantical enough for Tom Sawyer; no way would do him but he must
+climb up the lightning-rod.  But after he got up half way about three
+times, and missed fire and fell every time, and the last time most
+busted his brains out, he thought he’d got to give it up; but after he
+was rested he allowed he would give her one more turn for luck, and this
+time he made the trip.
+
+In the morning we was up at break of day, and down to the nigger cabins
+to pet the dogs and make friends with the nigger that fed Jim--if it
+_was_ Jim that was being fed.  The niggers was just getting through
+breakfast and starting for the fields; and Jim’s nigger was piling up
+a tin pan with bread and meat and things; and whilst the others was
+leaving, the key come from the house.
+
+This nigger had a good-natured, chuckle-headed face, and his wool was
+all tied up in little bunches with thread.  That was to keep witches
+off.  He said the witches was pestering him awful these nights, and
+making him see all kinds of strange things, and hear all kinds of
+strange words and noises, and he didn’t believe he was ever witched so
+long before in his life.  He got so worked up, and got to running on so
+about his troubles, he forgot all about what he’d been a-going to do.
+ So Tom says:
+
+“What’s the vittles for?  Going to feed the dogs?”
+
+The nigger kind of smiled around gradually over his face, like when you
+heave a brickbat in a mud-puddle, and he says:
+
+“Yes, Mars Sid, A dog.  Cur’us dog, too.  Does you want to go en look at
+‘im?”
+
+“Yes.”
+
+I hunched Tom, and whispers:
+
+“You going, right here in the daybreak?  _that_ warn’t the plan.”
+
+“No, it warn’t; but it’s the plan _now_.”
+
+So, drat him, we went along, but I didn’t like it much.  When we got in
+we couldn’t hardly see anything, it was so dark; but Jim was there, sure
+enough, and could see us; and he sings out:
+
+“Why, _Huck_!  En good _lan_’! ain’ dat Misto Tom?”
+
+I just knowed how it would be; I just expected it.  I didn’t know
+nothing to do; and if I had I couldn’t a done it, because that nigger
+busted in and says:
+
+“Why, de gracious sakes! do he know you genlmen?”
+
+We could see pretty well now.  Tom he looked at the nigger, steady and
+kind of wondering, and says:
+
+“Does _who_ know us?”
+
+“Why, dis-yer runaway nigger.”
+
+“I don’t reckon he does; but what put that into your head?”
+
+“What _put_ it dar?  Didn’ he jis’ dis minute sing out like he knowed
+you?”
+
+Tom says, in a puzzled-up kind of way:
+
+“Well, that’s mighty curious.  _Who_ sung out? _when_ did he sing out?
+ _what_ did he sing out?” And turns to me, perfectly ca’m, and says,
+“Did _you_ hear anybody sing out?”
+
+Of course there warn’t nothing to be said but the one thing; so I says:
+
+“No; I ain’t heard nobody say nothing.”
+
+Then he turns to Jim, and looks him over like he never see him before,
+and says:
+
+“Did you sing out?”
+
+“No, sah,” says Jim; “I hain’t said nothing, sah.”
+
+“Not a word?”
+
+“No, sah, I hain’t said a word.”
+
+“Did you ever see us before?”
+
+“No, sah; not as I knows on.”
+
+So Tom turns to the nigger, which was looking wild and distressed, and
+says, kind of severe:
+
+“What do you reckon’s the matter with you, anyway?  What made you think
+somebody sung out?”
+
+“Oh, it’s de dad-blame’ witches, sah, en I wisht I was dead, I do.
+ Dey’s awluz at it, sah, en dey do mos’ kill me, dey sk’yers me so.
+ Please to don’t tell nobody ‘bout it sah, er ole Mars Silas he’ll scole
+me; ‘kase he say dey _ain’t_ no witches.  I jis’ wish to goodness he was
+heah now--_den_ what would he say!  I jis’ bet he couldn’ fine no way to
+git aroun’ it _dis_ time.  But it’s awluz jis’ so; people dat’s _sot_,
+stays sot; dey won’t look into noth’n’en fine it out f’r deyselves, en
+when _you_ fine it out en tell um ‘bout it, dey doan’ b’lieve you.”
+
+Tom give him a dime, and said we wouldn’t tell nobody; and told him to
+buy some more thread to tie up his wool with; and then looks at Jim, and
+says:
+
+“I wonder if Uncle Silas is going to hang this nigger.  If I was to
+catch a nigger that was ungrateful enough to run away, I wouldn’t give
+him up, I’d hang him.”  And whilst the nigger stepped to the door to
+look at the dime and bite it to see if it was good, he whispers to Jim
+and says:
+
+“Don’t ever let on to know us.  And if you hear any digging going on
+nights, it’s us; we’re going to set you free.”
+
+Jim only had time to grab us by the hand and squeeze it; then the nigger
+come back, and we said we’d come again some time if the nigger wanted
+us to; and he said he would, more particular if it was dark, because the
+witches went for him mostly in the dark, and it was good to have folks
+around then.
+
+
+
+
+CHAPTER XXXV.
+
+IT would be most an hour yet till breakfast, so we left and struck down
+into the woods; because Tom said we got to have _some_ light to see how
+to dig by, and a lantern makes too much, and might get us into trouble;
+what we must have was a lot of them rotten chunks that’s called
+fox-fire, and just makes a soft kind of a glow when you lay them in a
+dark place.  We fetched an armful and hid it in the weeds, and set down
+to rest, and Tom says, kind of dissatisfied:
+
+“Blame it, this whole thing is just as easy and awkward as it can be.
+And so it makes it so rotten difficult to get up a difficult plan.
+ There ain’t no watchman to be drugged--now there _ought_ to be a
+watchman.  There ain’t even a dog to give a sleeping-mixture to.  And
+there’s Jim chained by one leg, with a ten-foot chain, to the leg of his
+bed:  why, all you got to do is to lift up the bedstead and slip off
+the chain.  And Uncle Silas he trusts everybody; sends the key to the
+punkin-headed nigger, and don’t send nobody to watch the nigger.  Jim
+could a got out of that window-hole before this, only there wouldn’t be
+no use trying to travel with a ten-foot chain on his leg.  Why, drat it,
+Huck, it’s the stupidest arrangement I ever see. You got to invent _all_
+the difficulties.  Well, we can’t help it; we got to do the best we can
+with the materials we’ve got. Anyhow, there’s one thing--there’s more
+honor in getting him out through a lot of difficulties and dangers,
+where there warn’t one of them furnished to you by the people who it was
+their duty to furnish them, and you had to contrive them all out of your
+own head.  Now look at just that one thing of the lantern.  When you
+come down to the cold facts, we simply got to _let on_ that a lantern’s
+resky.  Why, we could work with a torchlight procession if we wanted to,
+I believe.  Now, whilst I think of it, we got to hunt up something to
+make a saw out of the first chance we get.”
+
+“What do we want of a saw?”
+
+“What do we _want_ of it?  Hain’t we got to saw the leg of Jim’s bed
+off, so as to get the chain loose?”
+
+“Why, you just said a body could lift up the bedstead and slip the chain
+off.”
+
+“Well, if that ain’t just like you, Huck Finn.  You _can_ get up the
+infant-schooliest ways of going at a thing.  Why, hain’t you ever read
+any books at all?--Baron Trenck, nor Casanova, nor Benvenuto Chelleeny,
+nor Henri IV., nor none of them heroes?  Who ever heard of getting a
+prisoner loose in such an old-maidy way as that?  No; the way all the
+best authorities does is to saw the bed-leg in two, and leave it just
+so, and swallow the sawdust, so it can’t be found, and put some dirt and
+grease around the sawed place so the very keenest seneskal can’t see
+no sign of it’s being sawed, and thinks the bed-leg is perfectly sound.
+Then, the night you’re ready, fetch the leg a kick, down she goes; slip
+off your chain, and there you are.  Nothing to do but hitch your
+rope ladder to the battlements, shin down it, break your leg in the
+moat--because a rope ladder is nineteen foot too short, you know--and
+there’s your horses and your trusty vassles, and they scoop you up and
+fling you across a saddle, and away you go to your native Langudoc, or
+Navarre, or wherever it is. It’s gaudy, Huck.  I wish there was a moat
+to this cabin. If we get time, the night of the escape, we’ll dig one.”
+
+I says:
+
+“What do we want of a moat when we’re going to snake him out from under
+the cabin?”
+
+But he never heard me.  He had forgot me and everything else.  He had
+his chin in his hand, thinking.  Pretty soon he sighs and shakes his
+head; then sighs again, and says:
+
+“No, it wouldn’t do--there ain’t necessity enough for it.”
+
+“For what?”  I says.
+
+“Why, to saw Jim’s leg off,” he says.
+
+“Good land!”  I says; “why, there ain’t _no_ necessity for it.  And what
+would you want to saw his leg off for, anyway?”
+
+“Well, some of the best authorities has done it.  They couldn’t get the
+chain off, so they just cut their hand off and shoved.  And a leg would
+be better still.  But we got to let that go.  There ain’t necessity
+enough in this case; and, besides, Jim’s a nigger, and wouldn’t
+understand the reasons for it, and how it’s the custom in Europe; so
+we’ll let it go.  But there’s one thing--he can have a rope ladder; we
+can tear up our sheets and make him a rope ladder easy enough.  And we
+can send it to him in a pie; it’s mostly done that way.  And I’ve et
+worse pies.”
+
+“Why, Tom Sawyer, how you talk,” I says; “Jim ain’t got no use for a
+rope ladder.”
+
+“He _has_ got use for it.  How _you_ talk, you better say; you don’t
+know nothing about it.  He’s _got_ to have a rope ladder; they all do.”
+
+“What in the nation can he _do_ with it?”
+
+“_Do_ with it?  He can hide it in his bed, can’t he?”  That’s what they
+all do; and _he’s_ got to, too.  Huck, you don’t ever seem to want to do
+anything that’s regular; you want to be starting something fresh all the
+time. S’pose he _don’t_ do nothing with it? ain’t it there in his bed,
+for a clew, after he’s gone? and don’t you reckon they’ll want clews?
+ Of course they will.  And you wouldn’t leave them any?  That would be a
+_pretty_ howdy-do, _wouldn’t_ it!  I never heard of such a thing.”
+
+“Well,” I says, “if it’s in the regulations, and he’s got to have
+it, all right, let him have it; because I don’t wish to go back on no
+regulations; but there’s one thing, Tom Sawyer--if we go to tearing up
+our sheets to make Jim a rope ladder, we’re going to get into trouble
+with Aunt Sally, just as sure as you’re born.  Now, the way I look at
+it, a hickry-bark ladder don’t cost nothing, and don’t waste nothing,
+and is just as good to load up a pie with, and hide in a straw tick,
+as any rag ladder you can start; and as for Jim, he ain’t had no
+experience, and so he don’t care what kind of a--”
+
+“Oh, shucks, Huck Finn, if I was as ignorant as you I’d keep
+still--that’s what I’D do.  Who ever heard of a state prisoner escaping
+by a hickry-bark ladder?  Why, it’s perfectly ridiculous.”
+
+“Well, all right, Tom, fix it your own way; but if you’ll take my
+advice, you’ll let me borrow a sheet off of the clothesline.”
+
+He said that would do.  And that gave him another idea, and he says:
+
+“Borrow a shirt, too.”
+
+“What do we want of a shirt, Tom?”
+
+“Want it for Jim to keep a journal on.”
+
+“Journal your granny--_Jim_ can’t write.”
+
+“S’pose he _can’t_ write--he can make marks on the shirt, can’t he, if
+we make him a pen out of an old pewter spoon or a piece of an old iron
+barrel-hoop?”
+
+“Why, Tom, we can pull a feather out of a goose and make him a better
+one; and quicker, too.”
+
+“_Prisoners_ don’t have geese running around the donjon-keep to pull
+pens out of, you muggins.  They _always_ make their pens out of the
+hardest, toughest, troublesomest piece of old brass candlestick or
+something like that they can get their hands on; and it takes them weeks
+and weeks and months and months to file it out, too, because they’ve got
+to do it by rubbing it on the wall.  _They_ wouldn’t use a goose-quill
+if they had it. It ain’t regular.”
+
+“Well, then, what’ll we make him the ink out of?”
+
+“Many makes it out of iron-rust and tears; but that’s the common sort
+and women; the best authorities uses their own blood.  Jim can do that;
+and when he wants to send any little common ordinary mysterious message
+to let the world know where he’s captivated, he can write it on the
+bottom of a tin plate with a fork and throw it out of the window.  The
+Iron Mask always done that, and it’s a blame’ good way, too.”
+
+“Jim ain’t got no tin plates.  They feed him in a pan.”
+
+“That ain’t nothing; we can get him some.”
+
+“Can’t nobody _read_ his plates.”
+
+“That ain’t got anything to _do_ with it, Huck Finn.  All _he’s_ got to
+do is to write on the plate and throw it out.  You don’t _have_ to be
+able to read it. Why, half the time you can’t read anything a prisoner
+writes on a tin plate, or anywhere else.”
+
+“Well, then, what’s the sense in wasting the plates?”
+
+“Why, blame it all, it ain’t the _prisoner’s_ plates.”
+
+“But it’s _somebody’s_ plates, ain’t it?”
+
+“Well, spos’n it is?  What does the _prisoner_ care whose--”
+
+He broke off there, because we heard the breakfast-horn blowing.  So we
+cleared out for the house.
+
+Along during the morning I borrowed a sheet and a white shirt off of the
+clothes-line; and I found an old sack and put them in it, and we went
+down and got the fox-fire, and put that in too.  I called it borrowing,
+because that was what pap always called it; but Tom said it warn’t
+borrowing, it was stealing.  He said we was representing prisoners; and
+prisoners don’t care how they get a thing so they get it, and nobody
+don’t blame them for it, either.  It ain’t no crime in a prisoner to
+steal the thing he needs to get away with, Tom said; it’s his right; and
+so, as long as we was representing a prisoner, we had a perfect right to
+steal anything on this place we had the least use for to get ourselves
+out of prison with.  He said if we warn’t prisoners it would be a very
+different thing, and nobody but a mean, ornery person would steal when
+he warn’t a prisoner.  So we allowed we would steal everything there was
+that come handy.  And yet he made a mighty fuss, one day, after that,
+when I stole a watermelon out of the nigger-patch and eat it; and he
+made me go and give the niggers a dime without telling them what it
+was for. Tom said that what he meant was, we could steal anything we
+_needed_. Well, I says, I needed the watermelon.  But he said I didn’t
+need it to get out of prison with; there’s where the difference was.
+ He said if I’d a wanted it to hide a knife in, and smuggle it to Jim
+to kill the seneskal with, it would a been all right.  So I let it go at
+that, though I couldn’t see no advantage in my representing a prisoner
+if I got to set down and chaw over a lot of gold-leaf distinctions like
+that every time I see a chance to hog a watermelon.
+
+Well, as I was saying, we waited that morning till everybody was settled
+down to business, and nobody in sight around the yard; then Tom he
+carried the sack into the lean-to whilst I stood off a piece to keep
+watch.  By and by he come out, and we went and set down on the woodpile
+to talk.  He says:
+
+“Everything’s all right now except tools; and that’s easy fixed.”
+
+“Tools?”  I says.
+
+“Yes.”
+
+“Tools for what?”
+
+“Why, to dig with.  We ain’t a-going to _gnaw_ him out, are we?”
+
+“Ain’t them old crippled picks and things in there good enough to dig a
+nigger out with?”  I says.
+
+He turns on me, looking pitying enough to make a body cry, and says:
+
+“Huck Finn, did you _ever_ hear of a prisoner having picks and shovels,
+and all the modern conveniences in his wardrobe to dig himself out with?
+ Now I want to ask you--if you got any reasonableness in you at all--what
+kind of a show would _that_ give him to be a hero?  Why, they might as
+well lend him the key and done with it.  Picks and shovels--why, they
+wouldn’t furnish ‘em to a king.”
+
+“Well, then,” I says, “if we don’t want the picks and shovels, what do
+we want?”
+
+“A couple of case-knives.”
+
+“To dig the foundations out from under that cabin with?”
+
+“Yes.”
+
+“Confound it, it’s foolish, Tom.”
+
+“It don’t make no difference how foolish it is, it’s the _right_ way--and
+it’s the regular way.  And there ain’t no _other_ way, that ever I heard
+of, and I’ve read all the books that gives any information about these
+things. They always dig out with a case-knife--and not through dirt, mind
+you; generly it’s through solid rock.  And it takes them weeks and weeks
+and weeks, and for ever and ever.  Why, look at one of them prisoners in
+the bottom dungeon of the Castle Deef, in the harbor of Marseilles, that
+dug himself out that way; how long was _he_ at it, you reckon?”
+
+“I don’t know.”
+
+“Well, guess.”
+
+“I don’t know.  A month and a half.”
+
+“_Thirty-seven year_--and he come out in China.  _That’s_ the kind.  I
+wish the bottom of _this_ fortress was solid rock.”
+
+“_Jim_ don’t know nobody in China.”
+
+“What’s _that_ got to do with it?  Neither did that other fellow.  But
+you’re always a-wandering off on a side issue.  Why can’t you stick to
+the main point?”
+
+“All right--I don’t care where he comes out, so he _comes_ out; and Jim
+don’t, either, I reckon.  But there’s one thing, anyway--Jim’s too old to
+be dug out with a case-knife.  He won’t last.”
+
+“Yes he will _last_, too.  You don’t reckon it’s going to take
+thirty-seven years to dig out through a _dirt_ foundation, do you?”
+
+“How long will it take, Tom?”
+
+“Well, we can’t resk being as long as we ought to, because it mayn’t
+take very long for Uncle Silas to hear from down there by New Orleans.
+ He’ll hear Jim ain’t from there.  Then his next move will be to
+advertise Jim, or something like that.  So we can’t resk being as long
+digging him out as we ought to.  By rights I reckon we ought to be
+a couple of years; but we can’t.  Things being so uncertain, what I
+recommend is this:  that we really dig right in, as quick as we can;
+and after that, we can _let on_, to ourselves, that we was at it
+thirty-seven years.  Then we can snatch him out and rush him away the
+first time there’s an alarm.  Yes, I reckon that ‘ll be the best way.”
+
+“Now, there’s _sense_ in that,” I says.  “Letting on don’t cost nothing;
+letting on ain’t no trouble; and if it’s any object, I don’t mind
+letting on we was at it a hundred and fifty year.  It wouldn’t strain
+me none, after I got my hand in.  So I’ll mosey along now, and smouch a
+couple of case-knives.”
+
+“Smouch three,” he says; “we want one to make a saw out of.”
+
+“Tom, if it ain’t unregular and irreligious to sejest it,” I says,
+“there’s an old rusty saw-blade around yonder sticking under the
+weather-boarding behind the smoke-house.”
+
+He looked kind of weary and discouraged-like, and says:
+
+“It ain’t no use to try to learn you nothing, Huck.  Run along and
+smouch the knives--three of them.”  So I done it.
+
+
+
+
+CHAPTER XXXVI.
+
+AS soon as we reckoned everybody was asleep that night we went down the
+lightning-rod, and shut ourselves up in the lean-to, and got out our
+pile of fox-fire, and went to work.  We cleared everything out of the
+way, about four or five foot along the middle of the bottom log.  Tom
+said he was right behind Jim’s bed now, and we’d dig in under it, and
+when we got through there couldn’t nobody in the cabin ever know there
+was any hole there, because Jim’s counter-pin hung down most to the
+ground, and you’d have to raise it up and look under to see the hole.
+ So we dug and dug with the case-knives till most midnight; and then
+we was dog-tired, and our hands was blistered, and yet you couldn’t see
+we’d done anything hardly.  At last I says:
+
+“This ain’t no thirty-seven year job; this is a thirty-eight year job,
+Tom Sawyer.”
+
+He never said nothing.  But he sighed, and pretty soon he stopped
+digging, and then for a good little while I knowed that he was thinking.
+Then he says:
+
+“It ain’t no use, Huck, it ain’t a-going to work.  If we was prisoners
+it would, because then we’d have as many years as we wanted, and no
+hurry; and we wouldn’t get but a few minutes to dig, every day, while
+they was changing watches, and so our hands wouldn’t get blistered, and
+we could keep it up right along, year in and year out, and do it right,
+and the way it ought to be done.  But _we_ can’t fool along; we got to
+rush; we ain’t got no time to spare.  If we was to put in another
+night this way we’d have to knock off for a week to let our hands get
+well--couldn’t touch a case-knife with them sooner.”
+
+“Well, then, what we going to do, Tom?”
+
+“I’ll tell you.  It ain’t right, and it ain’t moral, and I wouldn’t like
+it to get out; but there ain’t only just the one way:  we got to dig him
+out with the picks, and _let on_ it’s case-knives.”
+
+“_Now_ you’re _talking_!”  I says; “your head gets leveler and leveler
+all the time, Tom Sawyer,” I says.  “Picks is the thing, moral or no
+moral; and as for me, I don’t care shucks for the morality of it, nohow.
+ When I start in to steal a nigger, or a watermelon, or a Sunday-school
+book, I ain’t no ways particular how it’s done so it’s done.  What I
+want is my nigger; or what I want is my watermelon; or what I want is my
+Sunday-school book; and if a pick’s the handiest thing, that’s the thing
+I’m a-going to dig that nigger or that watermelon or that Sunday-school
+book out with; and I don’t give a dead rat what the authorities thinks
+about it nuther.”
+
+“Well,” he says, “there’s excuse for picks and letting-on in a case like
+this; if it warn’t so, I wouldn’t approve of it, nor I wouldn’t stand by
+and see the rules broke--because right is right, and wrong is wrong,
+and a body ain’t got no business doing wrong when he ain’t ignorant and
+knows better.  It might answer for _you_ to dig Jim out with a pick,
+_without_ any letting on, because you don’t know no better; but it
+wouldn’t for me, because I do know better.  Gimme a case-knife.”
+
+He had his own by him, but I handed him mine.  He flung it down, and
+says:
+
+“Gimme a _case-knife_.”
+
+I didn’t know just what to do--but then I thought.  I scratched around
+amongst the old tools, and got a pickaxe and give it to him, and he took
+it and went to work, and never said a word.
+
+He was always just that particular.  Full of principle.
+
+So then I got a shovel, and then we picked and shoveled, turn about,
+and made the fur fly.  We stuck to it about a half an hour, which was as
+long as we could stand up; but we had a good deal of a hole to show for
+it. When I got up stairs I looked out at the window and see Tom doing
+his level best with the lightning-rod, but he couldn’t come it, his
+hands was so sore.  At last he says:
+
+“It ain’t no use, it can’t be done.  What you reckon I better do?  Can’t
+you think of no way?”
+
+“Yes,” I says, “but I reckon it ain’t regular.  Come up the stairs, and
+let on it’s a lightning-rod.”
+
+So he done it.
+
+Next day Tom stole a pewter spoon and a brass candlestick in the house,
+for to make some pens for Jim out of, and six tallow candles; and I
+hung around the nigger cabins and laid for a chance, and stole three tin
+plates.  Tom says it wasn’t enough; but I said nobody wouldn’t ever see
+the plates that Jim throwed out, because they’d fall in the dog-fennel
+and jimpson weeds under the window-hole--then we could tote them back and
+he could use them over again.  So Tom was satisfied.  Then he says:
+
+“Now, the thing to study out is, how to get the things to Jim.”
+
+“Take them in through the hole,” I says, “when we get it done.”
+
+He only just looked scornful, and said something about nobody ever heard
+of such an idiotic idea, and then he went to studying.  By and by he
+said he had ciphered out two or three ways, but there warn’t no need to
+decide on any of them yet.  Said we’d got to post Jim first.
+
+That night we went down the lightning-rod a little after ten, and took
+one of the candles along, and listened under the window-hole, and heard
+Jim snoring; so we pitched it in, and it didn’t wake him.  Then we
+whirled in with the pick and shovel, and in about two hours and a half
+the job was done.  We crept in under Jim’s bed and into the cabin, and
+pawed around and found the candle and lit it, and stood over Jim awhile,
+and found him looking hearty and healthy, and then we woke him up gentle
+and gradual.  He was so glad to see us he most cried; and called us
+honey, and all the pet names he could think of; and was for having us
+hunt up a cold-chisel to cut the chain off of his leg with right away,
+and clearing out without losing any time.  But Tom he showed him how
+unregular it would be, and set down and told him all about our plans,
+and how we could alter them in a minute any time there was an alarm; and
+not to be the least afraid, because we would see he got away, _sure_.
+ So Jim he said it was all right, and we set there and talked over old
+times awhile, and then Tom asked a lot of questions, and when Jim told
+him Uncle Silas come in every day or two to pray with him, and Aunt
+Sally come in to see if he was comfortable and had plenty to eat, and
+both of them was kind as they could be, Tom says:
+
+“_Now_ I know how to fix it.  We’ll send you some things by them.”
+
+I said, “Don’t do nothing of the kind; it’s one of the most jackass
+ideas I ever struck;” but he never paid no attention to me; went right
+on.  It was his way when he’d got his plans set.
+
+So he told Jim how we’d have to smuggle in the rope-ladder pie and other
+large things by Nat, the nigger that fed him, and he must be on the
+lookout, and not be surprised, and not let Nat see him open them; and
+we would put small things in uncle’s coat-pockets and he must steal them
+out; and we would tie things to aunt’s apron-strings or put them in her
+apron-pocket, if we got a chance; and told him what they would be and
+what they was for.  And told him how to keep a journal on the shirt with
+his blood, and all that. He told him everything.  Jim he couldn’t see
+no sense in the most of it, but he allowed we was white folks and knowed
+better than him; so he was satisfied, and said he would do it all just
+as Tom said.
+
+Jim had plenty corn-cob pipes and tobacco; so we had a right down good
+sociable time; then we crawled out through the hole, and so home to
+bed, with hands that looked like they’d been chawed.  Tom was in high
+spirits. He said it was the best fun he ever had in his life, and the
+most intellectural; and said if he only could see his way to it we would
+keep it up all the rest of our lives and leave Jim to our children to
+get out; for he believed Jim would come to like it better and better the
+more he got used to it.  He said that in that way it could be strung out
+to as much as eighty year, and would be the best time on record.  And he
+said it would make us all celebrated that had a hand in it.
+
+In the morning we went out to the woodpile and chopped up the brass
+candlestick into handy sizes, and Tom put them and the pewter spoon in
+his pocket.  Then we went to the nigger cabins, and while I got Nat’s
+notice off, Tom shoved a piece of candlestick into the middle of a
+corn-pone that was in Jim’s pan, and we went along with Nat to see how
+it would work, and it just worked noble; when Jim bit into it it most
+mashed all his teeth out; and there warn’t ever anything could a worked
+better. Tom said so himself. Jim he never let on but what it was only
+just a piece of rock or something like that that’s always getting into
+bread, you know; but after that he never bit into nothing but what he
+jabbed his fork into it in three or four places first.
+
+And whilst we was a-standing there in the dimmish light, here comes a
+couple of the hounds bulging in from under Jim’s bed; and they kept on
+piling in till there was eleven of them, and there warn’t hardly room
+in there to get your breath.  By jings, we forgot to fasten that lean-to
+door!  The nigger Nat he only just hollered “Witches” once, and keeled
+over on to the floor amongst the dogs, and begun to groan like he was
+dying.  Tom jerked the door open and flung out a slab of Jim’s meat,
+and the dogs went for it, and in two seconds he was out himself and back
+again and shut the door, and I knowed he’d fixed the other door too.
+Then he went to work on the nigger, coaxing him and petting him, and
+asking him if he’d been imagining he saw something again.  He raised up,
+and blinked his eyes around, and says:
+
+“Mars Sid, you’ll say I’s a fool, but if I didn’t b’lieve I see most a
+million dogs, er devils, er some’n, I wisht I may die right heah in dese
+tracks.  I did, mos’ sholy.  Mars Sid, I _felt_ um--I _felt_ um, sah; dey
+was all over me.  Dad fetch it, I jis’ wisht I could git my han’s on one
+er dem witches jis’ wunst--on’y jis’ wunst--it’s all I’d ast.  But mos’ly
+I wisht dey’d lemme ‘lone, I does.”
+
+Tom says:
+
+“Well, I tell you what I think.  What makes them come here just at this
+runaway nigger’s breakfast-time?  It’s because they’re hungry; that’s
+the reason.  You make them a witch pie; that’s the thing for _you_ to
+do.”
+
+“But my lan’, Mars Sid, how’s I gwyne to make ‘m a witch pie?  I doan’
+know how to make it.  I hain’t ever hearn er sich a thing b’fo’.”
+
+“Well, then, I’ll have to make it myself.”
+
+“Will you do it, honey?--will you?  I’ll wusshup de groun’ und’ yo’ foot,
+I will!”
+
+“All right, I’ll do it, seeing it’s you, and you’ve been good to us and
+showed us the runaway nigger.  But you got to be mighty careful.  When
+we come around, you turn your back; and then whatever we’ve put in the
+pan, don’t you let on you see it at all.  And don’t you look when Jim
+unloads the pan--something might happen, I don’t know what.  And above
+all, don’t you _handle_ the witch-things.”
+
+“_Hannel ‘M_, Mars Sid?  What _is_ you a-talkin’ ‘bout?  I wouldn’
+lay de weight er my finger on um, not f’r ten hund’d thous’n billion
+dollars, I wouldn’t.”
+
+
+
+
+CHAPTER XXXVII.
+
+THAT was all fixed.  So then we went away and went to the rubbage-pile
+in the back yard, where they keep the old boots, and rags, and pieces
+of bottles, and wore-out tin things, and all such truck, and scratched
+around and found an old tin washpan, and stopped up the holes as well as
+we could, to bake the pie in, and took it down cellar and stole it full
+of flour and started for breakfast, and found a couple of shingle-nails
+that Tom said would be handy for a prisoner to scrabble his name and
+sorrows on the dungeon walls with, and dropped one of them in Aunt
+Sally’s apron-pocket which was hanging on a chair, and t’other we stuck
+in the band of Uncle Silas’s hat, which was on the bureau, because we
+heard the children say their pa and ma was going to the runaway nigger’s
+house this morning, and then went to breakfast, and Tom dropped the
+pewter spoon in Uncle Silas’s coat-pocket, and Aunt Sally wasn’t come
+yet, so we had to wait a little while.
+
+And when she come she was hot and red and cross, and couldn’t hardly
+wait for the blessing; and then she went to sluicing out coffee with one
+hand and cracking the handiest child’s head with her thimble with the
+other, and says:
+
+“I’ve hunted high and I’ve hunted low, and it does beat all what _has_
+become of your other shirt.”
+
+My heart fell down amongst my lungs and livers and things, and a hard
+piece of corn-crust started down my throat after it and got met on the
+road with a cough, and was shot across the table, and took one of the
+children in the eye and curled him up like a fishing-worm, and let a cry
+out of him the size of a warwhoop, and Tom he turned kinder blue around
+the gills, and it all amounted to a considerable state of things for
+about a quarter of a minute or as much as that, and I would a sold out
+for half price if there was a bidder.  But after that we was all right
+again--it was the sudden surprise of it that knocked us so kind of cold.
+Uncle Silas he says:
+
+“It’s most uncommon curious, I can’t understand it.  I know perfectly
+well I took it _off_, because--”
+
+“Because you hain’t got but one _on_.  Just _listen_ at the man!  I know
+you took it off, and know it by a better way than your wool-gethering
+memory, too, because it was on the clo’s-line yesterday--I see it there
+myself. But it’s gone, that’s the long and the short of it, and you’ll
+just have to change to a red flann’l one till I can get time to make a
+new one. And it ‘ll be the third I’ve made in two years.  It just keeps
+a body on the jump to keep you in shirts; and whatever you do manage to
+_do_ with ‘m all is more’n I can make out.  A body ‘d think you _would_
+learn to take some sort of care of ‘em at your time of life.”
+
+“I know it, Sally, and I do try all I can.  But it oughtn’t to be
+altogether my fault, because, you know, I don’t see them nor have
+nothing to do with them except when they’re on me; and I don’t believe
+I’ve ever lost one of them _off_ of me.”
+
+“Well, it ain’t _your_ fault if you haven’t, Silas; you’d a done it
+if you could, I reckon.  And the shirt ain’t all that’s gone, nuther.
+ Ther’s a spoon gone; and _that_ ain’t all.  There was ten, and now
+ther’s only nine. The calf got the shirt, I reckon, but the calf never
+took the spoon, _that’s_ certain.”
+
+“Why, what else is gone, Sally?”
+
+“Ther’s six _candles_ gone--that’s what.  The rats could a got the
+candles, and I reckon they did; I wonder they don’t walk off with the
+whole place, the way you’re always going to stop their holes and don’t
+do it; and if they warn’t fools they’d sleep in your hair, Silas--_you’d_
+never find it out; but you can’t lay the _spoon_ on the rats, and that I
+know.”
+
+“Well, Sally, I’m in fault, and I acknowledge it; I’ve been remiss; but
+I won’t let to-morrow go by without stopping up them holes.”
+
+“Oh, I wouldn’t hurry; next year ‘ll do.  Matilda Angelina Araminta
+_Phelps!_”
+
+Whack comes the thimble, and the child snatches her claws out of the
+sugar-bowl without fooling around any.  Just then the nigger woman steps
+on to the passage, and says:
+
+“Missus, dey’s a sheet gone.”
+
+“A _sheet_ gone!  Well, for the land’s sake!”
+
+“I’ll stop up them holes to-day,” says Uncle Silas, looking sorrowful.
+
+“Oh, _do_ shet up!--s’pose the rats took the _sheet_?  _where’s_ it gone,
+Lize?”
+
+“Clah to goodness I hain’t no notion, Miss’ Sally.  She wuz on de
+clo’sline yistiddy, but she done gone:  she ain’ dah no mo’ now.”
+
+“I reckon the world _is_ coming to an end.  I _never_ see the beat of it
+in all my born days.  A shirt, and a sheet, and a spoon, and six can--”
+
+“Missus,” comes a young yaller wench, “dey’s a brass cannelstick
+miss’n.”
+
+“Cler out from here, you hussy, er I’ll take a skillet to ye!”
+
+Well, she was just a-biling.  I begun to lay for a chance; I reckoned
+I would sneak out and go for the woods till the weather moderated.  She
+kept a-raging right along, running her insurrection all by herself, and
+everybody else mighty meek and quiet; and at last Uncle Silas, looking
+kind of foolish, fishes up that spoon out of his pocket.  She stopped,
+with her mouth open and her hands up; and as for me, I wished I was in
+Jeruslem or somewheres. But not long, because she says:
+
+“It’s _just_ as I expected.  So you had it in your pocket all the time;
+and like as not you’ve got the other things there, too.  How’d it get
+there?”
+
+“I reely don’t know, Sally,” he says, kind of apologizing, “or you know
+I would tell.  I was a-studying over my text in Acts Seventeen before
+breakfast, and I reckon I put it in there, not noticing, meaning to put
+my Testament in, and it must be so, because my Testament ain’t in; but
+I’ll go and see; and if the Testament is where I had it, I’ll know I
+didn’t put it in, and that will show that I laid the Testament down and
+took up the spoon, and--”
+
+“Oh, for the land’s sake!  Give a body a rest!  Go ‘long now, the whole
+kit and biling of ye; and don’t come nigh me again till I’ve got back my
+peace of mind.”
+
+I’D a heard her if she’d a said it to herself, let alone speaking it
+out; and I’d a got up and obeyed her if I’d a been dead.  As we was
+passing through the setting-room the old man he took up his hat, and the
+shingle-nail fell out on the floor, and he just merely picked it up and
+laid it on the mantel-shelf, and never said nothing, and went out.  Tom
+see him do it, and remembered about the spoon, and says:
+
+“Well, it ain’t no use to send things by _him_ no more, he ain’t
+reliable.” Then he says:  “But he done us a good turn with the spoon,
+anyway, without knowing it, and so we’ll go and do him one without _him_
+knowing it--stop up his rat-holes.”
+
+There was a noble good lot of them down cellar, and it took us a whole
+hour, but we done the job tight and good and shipshape.  Then we heard
+steps on the stairs, and blowed out our light and hid; and here comes
+the old man, with a candle in one hand and a bundle of stuff in t’other,
+looking as absent-minded as year before last.  He went a mooning around,
+first to one rat-hole and then another, till he’d been to them all.
+ Then he stood about five minutes, picking tallow-drip off of his candle
+and thinking.  Then he turns off slow and dreamy towards the stairs,
+saying:
+
+“Well, for the life of me I can’t remember when I done it.  I could
+show her now that I warn’t to blame on account of the rats.  But never
+mind--let it go.  I reckon it wouldn’t do no good.”
+
+And so he went on a-mumbling up stairs, and then we left.  He was a
+mighty nice old man.  And always is.
+
+Tom was a good deal bothered about what to do for a spoon, but he said
+we’d got to have it; so he took a think.  When he had ciphered it out
+he told me how we was to do; then we went and waited around the
+spoon-basket till we see Aunt Sally coming, and then Tom went to
+counting the spoons and laying them out to one side, and I slid one of
+them up my sleeve, and Tom says:
+
+“Why, Aunt Sally, there ain’t but nine spoons _yet_.”
+
+She says:
+
+“Go ‘long to your play, and don’t bother me.  I know better, I counted
+‘m myself.”
+
+“Well, I’ve counted them twice, Aunty, and I can’t make but nine.”
+
+She looked out of all patience, but of course she come to count--anybody
+would.
+
+“I declare to gracious ther’ _ain’t_ but nine!” she says.  “Why, what in
+the world--plague _take_ the things, I’ll count ‘m again.”
+
+So I slipped back the one I had, and when she got done counting, she
+says:
+
+“Hang the troublesome rubbage, ther’s _ten_ now!” and she looked huffy
+and bothered both.  But Tom says:
+
+“Why, Aunty, I don’t think there’s ten.”
+
+“You numskull, didn’t you see me _count ‘m?_”
+
+“I know, but--”
+
+“Well, I’ll count ‘m _again_.”
+
+So I smouched one, and they come out nine, same as the other time.
+ Well, she _was_ in a tearing way--just a-trembling all over, she was so
+mad.  But she counted and counted till she got that addled she’d start
+to count in the basket for a spoon sometimes; and so, three times they
+come out right, and three times they come out wrong.  Then she grabbed
+up the basket and slammed it across the house and knocked the cat
+galley-west; and she said cle’r out and let her have some peace, and if
+we come bothering around her again betwixt that and dinner she’d skin
+us.  So we had the odd spoon, and dropped it in her apron-pocket whilst
+she was a-giving us our sailing orders, and Jim got it all right, along
+with her shingle nail, before noon.  We was very well satisfied with
+this business, and Tom allowed it was worth twice the trouble it took,
+because he said _now_ she couldn’t ever count them spoons twice alike
+again to save her life; and wouldn’t believe she’d counted them right if
+she _did_; and said that after she’d about counted her head off for the
+next three days he judged she’d give it up and offer to kill anybody
+that wanted her to ever count them any more.
+
+So we put the sheet back on the line that night, and stole one out of
+her closet; and kept on putting it back and stealing it again for a
+couple of days till she didn’t know how many sheets she had any more,
+and she didn’t _care_, and warn’t a-going to bullyrag the rest of her
+soul out about it, and wouldn’t count them again not to save her life;
+she druther die first.
+
+So we was all right now, as to the shirt and the sheet and the spoon
+and the candles, by the help of the calf and the rats and the mixed-up
+counting; and as to the candlestick, it warn’t no consequence, it would
+blow over by and by.
+
+But that pie was a job; we had no end of trouble with that pie.  We
+fixed it up away down in the woods, and cooked it there; and we got it
+done at last, and very satisfactory, too; but not all in one day; and we
+had to use up three wash-pans full of flour before we got through, and
+we got burnt pretty much all over, in places, and eyes put out with
+the smoke; because, you see, we didn’t want nothing but a crust, and we
+couldn’t prop it up right, and she would always cave in.  But of course
+we thought of the right way at last--which was to cook the ladder, too,
+in the pie.  So then we laid in with Jim the second night, and tore
+up the sheet all in little strings and twisted them together, and long
+before daylight we had a lovely rope that you could a hung a person
+with.  We let on it took nine months to make it.
+
+And in the forenoon we took it down to the woods, but it wouldn’t go
+into the pie.  Being made of a whole sheet, that way, there was rope
+enough for forty pies if we’d a wanted them, and plenty left over
+for soup, or sausage, or anything you choose.  We could a had a whole
+dinner.
+
+But we didn’t need it.  All we needed was just enough for the pie, and
+so we throwed the rest away.  We didn’t cook none of the pies in the
+wash-pan--afraid the solder would melt; but Uncle Silas he had a noble
+brass warming-pan which he thought considerable of, because it belonged
+to one of his ancesters with a long wooden handle that come over from
+England with William the Conqueror in the Mayflower or one of them early
+ships and was hid away up garret with a lot of other old pots and things
+that was valuable, not on account of being any account, because they
+warn’t, but on account of them being relicts, you know, and we snaked
+her out, private, and took her down there, but she failed on the first
+pies, because we didn’t know how, but she come up smiling on the last
+one.  We took and lined her with dough, and set her in the coals, and
+loaded her up with rag rope, and put on a dough roof, and shut down the
+lid, and put hot embers on top, and stood off five foot, with the long
+handle, cool and comfortable, and in fifteen minutes she turned out a
+pie that was a satisfaction to look at. But the person that et it would
+want to fetch a couple of kags of toothpicks along, for if that rope
+ladder wouldn’t cramp him down to business I don’t know nothing what I’m
+talking about, and lay him in enough stomach-ache to last him till next
+time, too.
+
+Nat didn’t look when we put the witch pie in Jim’s pan; and we put the
+three tin plates in the bottom of the pan under the vittles; and so Jim
+got everything all right, and as soon as he was by himself he busted
+into the pie and hid the rope ladder inside of his straw tick,
+and scratched some marks on a tin plate and throwed it out of the
+window-hole.
+
+
+
+
+CHAPTER XXXVIII.
+
+MAKING them pens was a distressid tough job, and so was the saw; and Jim
+allowed the inscription was going to be the toughest of all.  That’s the
+one which the prisoner has to scrabble on the wall.  But he had to have
+it; Tom said he’d _got_ to; there warn’t no case of a state prisoner not
+scrabbling his inscription to leave behind, and his coat of arms.
+
+“Look at Lady Jane Grey,” he says; “look at Gilford Dudley; look at old
+Northumberland!  Why, Huck, s’pose it _is_ considerble trouble?--what
+you going to do?--how you going to get around it?  Jim’s _got_ to do his
+inscription and coat of arms.  They all do.”
+
+Jim says:
+
+“Why, Mars Tom, I hain’t got no coat o’ arm; I hain’t got nuffn but dish
+yer ole shirt, en you knows I got to keep de journal on dat.”
+
+“Oh, you don’t understand, Jim; a coat of arms is very different.”
+
+“Well,” I says, “Jim’s right, anyway, when he says he ain’t got no coat
+of arms, because he hain’t.”
+
+“I reckon I knowed that,” Tom says, “but you bet he’ll have one before
+he goes out of this--because he’s going out _right_, and there ain’t
+going to be no flaws in his record.”
+
+So whilst me and Jim filed away at the pens on a brickbat apiece, Jim
+a-making his’n out of the brass and I making mine out of the spoon,
+Tom set to work to think out the coat of arms.  By and by he said he’d
+struck so many good ones he didn’t hardly know which to take, but there
+was one which he reckoned he’d decide on.  He says:
+
+“On the scutcheon we’ll have a bend _or_ in the dexter base, a saltire
+_murrey_ in the fess, with a dog, couchant, for common charge, and under
+his foot a chain embattled, for slavery, with a chevron _vert_ in a
+chief engrailed, and three invected lines on a field _azure_, with the
+nombril points rampant on a dancette indented; crest, a runaway nigger,
+_sable_, with his bundle over his shoulder on a bar sinister; and a
+couple of gules for supporters, which is you and me; motto, _Maggiore
+Fretta, Minore Otto._  Got it out of a book--means the more haste the
+less speed.”
+
+“Geewhillikins,” I says, “but what does the rest of it mean?”
+
+“We ain’t got no time to bother over that,” he says; “we got to dig in
+like all git-out.”
+
+“Well, anyway,” I says, “what’s _some_ of it?  What’s a fess?”
+
+“A fess--a fess is--_you_ don’t need to know what a fess is.  I’ll show
+him how to make it when he gets to it.”
+
+“Shucks, Tom,” I says, “I think you might tell a person.  What’s a bar
+sinister?”
+
+“Oh, I don’t know.  But he’s got to have it.  All the nobility does.”
+
+That was just his way.  If it didn’t suit him to explain a thing to you,
+he wouldn’t do it.  You might pump at him a week, it wouldn’t make no
+difference.
+
+He’d got all that coat of arms business fixed, so now he started in to
+finish up the rest of that part of the work, which was to plan out a
+mournful inscription--said Jim got to have one, like they all done.  He
+made up a lot, and wrote them out on a paper, and read them off, so:
+
+1.  Here a captive heart busted. 2.  Here a poor prisoner, forsook by
+the world and friends, fretted his sorrowful life. 3.  Here a lonely
+heart broke, and a worn spirit went to its rest, after thirty-seven
+years of solitary captivity. 4.  Here, homeless and friendless, after
+thirty-seven years of bitter captivity, perished a noble stranger,
+natural son of Louis XIV.
+
+Tom’s voice trembled whilst he was reading them, and he most broke down.
+When he got done he couldn’t no way make up his mind which one for Jim
+to scrabble on to the wall, they was all so good; but at last he allowed
+he would let him scrabble them all on.  Jim said it would take him a
+year to scrabble such a lot of truck on to the logs with a nail, and he
+didn’t know how to make letters, besides; but Tom said he would block
+them out for him, and then he wouldn’t have nothing to do but just
+follow the lines.  Then pretty soon he says:
+
+“Come to think, the logs ain’t a-going to do; they don’t have log walls
+in a dungeon:  we got to dig the inscriptions into a rock.  We’ll fetch
+a rock.”
+
+Jim said the rock was worse than the logs; he said it would take him
+such a pison long time to dig them into a rock he wouldn’t ever get out.
+ But Tom said he would let me help him do it.  Then he took a look to
+see how me and Jim was getting along with the pens.  It was most pesky
+tedious hard work and slow, and didn’t give my hands no show to get
+well of the sores, and we didn’t seem to make no headway, hardly; so Tom
+says:
+
+“I know how to fix it.  We got to have a rock for the coat of arms and
+mournful inscriptions, and we can kill two birds with that same rock.
+There’s a gaudy big grindstone down at the mill, and we’ll smouch it,
+and carve the things on it, and file out the pens and the saw on it,
+too.”
+
+It warn’t no slouch of an idea; and it warn’t no slouch of a grindstone
+nuther; but we allowed we’d tackle it.  It warn’t quite midnight yet,
+so we cleared out for the mill, leaving Jim at work.  We smouched the
+grindstone, and set out to roll her home, but it was a most nation tough
+job. Sometimes, do what we could, we couldn’t keep her from falling
+over, and she come mighty near mashing us every time.  Tom said she was
+going to get one of us, sure, before we got through.  We got her half
+way; and then we was plumb played out, and most drownded with sweat.  We
+see it warn’t no use; we got to go and fetch Jim. So he raised up his
+bed and slid the chain off of the bed-leg, and wrapt it round and round
+his neck, and we crawled out through our hole and down there, and Jim
+and me laid into that grindstone and walked her along like nothing; and
+Tom superintended.  He could out-superintend any boy I ever see.  He
+knowed how to do everything.
+
+Our hole was pretty big, but it warn’t big enough to get the grindstone
+through; but Jim he took the pick and soon made it big enough.  Then Tom
+marked out them things on it with the nail, and set Jim to work on them,
+with the nail for a chisel and an iron bolt from the rubbage in the
+lean-to for a hammer, and told him to work till the rest of his candle
+quit on him, and then he could go to bed, and hide the grindstone under
+his straw tick and sleep on it.  Then we helped him fix his chain back
+on the bed-leg, and was ready for bed ourselves.  But Tom thought of
+something, and says:
+
+“You got any spiders in here, Jim?”
+
+“No, sah, thanks to goodness I hain’t, Mars Tom.”
+
+“All right, we’ll get you some.”
+
+“But bless you, honey, I doan’ _want_ none.  I’s afeard un um.  I jis’
+‘s soon have rattlesnakes aroun’.”
+
+Tom thought a minute or two, and says:
+
+“It’s a good idea.  And I reckon it’s been done.  It _must_ a been done;
+it stands to reason.  Yes, it’s a prime good idea.  Where could you keep
+it?”
+
+“Keep what, Mars Tom?”
+
+“Why, a rattlesnake.”
+
+“De goodness gracious alive, Mars Tom!  Why, if dey was a rattlesnake to
+come in heah I’d take en bust right out thoo dat log wall, I would, wid
+my head.”
+
+“Why, Jim, you wouldn’t be afraid of it after a little.  You could tame
+it.”
+
+“_Tame_ it!”
+
+“Yes--easy enough.  Every animal is grateful for kindness and petting,
+and they wouldn’t _think_ of hurting a person that pets them.  Any book
+will tell you that.  You try--that’s all I ask; just try for two or three
+days. Why, you can get him so, in a little while, that he’ll love you;
+and sleep with you; and won’t stay away from you a minute; and will let
+you wrap him round your neck and put his head in your mouth.”
+
+“_Please_, Mars Tom--_doan_’ talk so!  I can’t _stan_’ it!  He’d _let_
+me shove his head in my mouf--fer a favor, hain’t it?  I lay he’d wait a
+pow’ful long time ‘fo’ I _ast_ him.  En mo’ en dat, I doan’ _want_ him
+to sleep wid me.”
+
+“Jim, don’t act so foolish.  A prisoner’s _got_ to have some kind of a
+dumb pet, and if a rattlesnake hain’t ever been tried, why, there’s more
+glory to be gained in your being the first to ever try it than any other
+way you could ever think of to save your life.”
+
+“Why, Mars Tom, I doan’ _want_ no sich glory.  Snake take ‘n bite
+Jim’s chin off, den _whah_ is de glory?  No, sah, I doan’ want no sich
+doin’s.”
+
+“Blame it, can’t you _try_?  I only _want_ you to try--you needn’t keep
+it up if it don’t work.”
+
+“But de trouble all _done_ ef de snake bite me while I’s a tryin’ him.
+Mars Tom, I’s willin’ to tackle mos’ anything ‘at ain’t onreasonable,
+but ef you en Huck fetches a rattlesnake in heah for me to tame, I’s
+gwyne to _leave_, dat’s _shore_.”
+
+“Well, then, let it go, let it go, if you’re so bull-headed about it.
+ We can get you some garter-snakes, and you can tie some buttons on
+their tails, and let on they’re rattlesnakes, and I reckon that ‘ll have
+to do.”
+
+“I k’n stan’ _dem_, Mars Tom, but blame’ ‘f I couldn’ get along widout
+um, I tell you dat.  I never knowed b’fo’ ‘t was so much bother and
+trouble to be a prisoner.”
+
+“Well, it _always_ is when it’s done right.  You got any rats around
+here?”
+
+“No, sah, I hain’t seed none.”
+
+“Well, we’ll get you some rats.”
+
+“Why, Mars Tom, I doan’ _want_ no rats.  Dey’s de dadblamedest creturs
+to ‘sturb a body, en rustle roun’ over ‘im, en bite his feet, when he’s
+tryin’ to sleep, I ever see.  No, sah, gimme g’yarter-snakes, ‘f I’s
+got to have ‘m, but doan’ gimme no rats; I hain’ got no use f’r um,
+skasely.”
+
+“But, Jim, you _got_ to have ‘em--they all do.  So don’t make no more
+fuss about it.  Prisoners ain’t ever without rats.  There ain’t no
+instance of it.  And they train them, and pet them, and learn them
+tricks, and they get to be as sociable as flies.  But you got to play
+music to them.  You got anything to play music on?”
+
+“I ain’ got nuffn but a coase comb en a piece o’ paper, en a juice-harp;
+but I reck’n dey wouldn’ take no stock in a juice-harp.”
+
+“Yes they would _they_ don’t care what kind of music ‘tis.  A
+jews-harp’s plenty good enough for a rat.  All animals like music--in a
+prison they dote on it.  Specially, painful music; and you can’t get no
+other kind out of a jews-harp.  It always interests them; they come out
+to see what’s the matter with you.  Yes, you’re all right; you’re fixed
+very well.  You want to set on your bed nights before you go to sleep,
+and early in the mornings, and play your jews-harp; play ‘The Last Link
+is Broken’--that’s the thing that ‘ll scoop a rat quicker ‘n anything
+else; and when you’ve played about two minutes you’ll see all the rats,
+and the snakes, and spiders, and things begin to feel worried about you,
+and come.  And they’ll just fairly swarm over you, and have a noble good
+time.”
+
+“Yes, _dey_ will, I reck’n, Mars Tom, but what kine er time is _Jim_
+havin’? Blest if I kin see de pint.  But I’ll do it ef I got to.  I
+reck’n I better keep de animals satisfied, en not have no trouble in de
+house.”
+
+Tom waited to think it over, and see if there wasn’t nothing else; and
+pretty soon he says:
+
+“Oh, there’s one thing I forgot.  Could you raise a flower here, do you
+reckon?”
+
+“I doan know but maybe I could, Mars Tom; but it’s tolable dark in heah,
+en I ain’ got no use f’r no flower, nohow, en she’d be a pow’ful sight
+o’ trouble.”
+
+“Well, you try it, anyway.  Some other prisoners has done it.”
+
+“One er dem big cat-tail-lookin’ mullen-stalks would grow in heah, Mars
+Tom, I reck’n, but she wouldn’t be wuth half de trouble she’d coss.”
+
+“Don’t you believe it.  We’ll fetch you a little one and you plant it in
+the corner over there, and raise it.  And don’t call it mullen, call it
+Pitchiola--that’s its right name when it’s in a prison.  And you want to
+water it with your tears.”
+
+“Why, I got plenty spring water, Mars Tom.”
+
+“You don’t _want_ spring water; you want to water it with your tears.
+ It’s the way they always do.”
+
+“Why, Mars Tom, I lay I kin raise one er dem mullen-stalks twyste wid
+spring water whiles another man’s a _start’n_ one wid tears.”
+
+“That ain’t the idea.  You _got_ to do it with tears.”
+
+“She’ll die on my han’s, Mars Tom, she sholy will; kase I doan’ skasely
+ever cry.”
+
+So Tom was stumped.  But he studied it over, and then said Jim would
+have to worry along the best he could with an onion.  He promised
+he would go to the nigger cabins and drop one, private, in Jim’s
+coffee-pot, in the morning. Jim said he would “jis’ ‘s soon have
+tobacker in his coffee;” and found so much fault with it, and with the
+work and bother of raising the mullen, and jews-harping the rats, and
+petting and flattering up the snakes and spiders and things, on top of
+all the other work he had to do on pens, and inscriptions, and journals,
+and things, which made it more trouble and worry and responsibility to
+be a prisoner than anything he ever undertook, that Tom most lost all
+patience with him; and said he was just loadened down with more gaudier
+chances than a prisoner ever had in the world to make a name for
+himself, and yet he didn’t know enough to appreciate them, and they was
+just about wasted on him.  So Jim he was sorry, and said he wouldn’t
+behave so no more, and then me and Tom shoved for bed.
+
+
+
+
+CHAPTER XXXIX.
+
+IN the morning we went up to the village and bought a wire rat-trap and
+fetched it down, and unstopped the best rat-hole, and in about an hour
+we had fifteen of the bulliest kind of ones; and then we took it and put
+it in a safe place under Aunt Sally’s bed.  But while we was gone for
+spiders little Thomas Franklin Benjamin Jefferson Elexander Phelps found
+it there, and opened the door of it to see if the rats would come out,
+and they did; and Aunt Sally she come in, and when we got back she was
+a-standing on top of the bed raising Cain, and the rats was doing what
+they could to keep off the dull times for her.  So she took and dusted
+us both with the hickry, and we was as much as two hours catching
+another fifteen or sixteen, drat that meddlesome cub, and they warn’t
+the likeliest, nuther, because the first haul was the pick of the flock.
+ I never see a likelier lot of rats than what that first haul was.
+
+We got a splendid stock of sorted spiders, and bugs, and frogs, and
+caterpillars, and one thing or another; and we like to got a hornet’s
+nest, but we didn’t.  The family was at home.  We didn’t give it right
+up, but stayed with them as long as we could; because we allowed we’d
+tire them out or they’d got to tire us out, and they done it.  Then we
+got allycumpain and rubbed on the places, and was pretty near all right
+again, but couldn’t set down convenient.  And so we went for the snakes,
+and grabbed a couple of dozen garters and house-snakes, and put them in
+a bag, and put it in our room, and by that time it was supper-time, and
+a rattling good honest day’s work:  and hungry?--oh, no, I reckon not!
+ And there warn’t a blessed snake up there when we went back--we didn’t
+half tie the sack, and they worked out somehow, and left.  But it didn’t
+matter much, because they was still on the premises somewheres.  So
+we judged we could get some of them again.  No, there warn’t no real
+scarcity of snakes about the house for a considerable spell.  You’d see
+them dripping from the rafters and places every now and then; and they
+generly landed in your plate, or down the back of your neck, and most
+of the time where you didn’t want them.  Well, they was handsome and
+striped, and there warn’t no harm in a million of them; but that never
+made no difference to Aunt Sally; she despised snakes, be the breed what
+they might, and she couldn’t stand them no way you could fix it; and
+every time one of them flopped down on her, it didn’t make no difference
+what she was doing, she would just lay that work down and light out.  I
+never see such a woman.  And you could hear her whoop to Jericho.  You
+couldn’t get her to take a-holt of one of them with the tongs.  And if
+she turned over and found one in bed she would scramble out and lift a
+howl that you would think the house was afire.  She disturbed the old
+man so that he said he could most wish there hadn’t ever been no snakes
+created.  Why, after every last snake had been gone clear out of the
+house for as much as a week Aunt Sally warn’t over it yet; she warn’t
+near over it; when she was setting thinking about something you could
+touch her on the back of her neck with a feather and she would jump
+right out of her stockings.  It was very curious.  But Tom said all
+women was just so.  He said they was made that way for some reason or
+other.
+
+We got a licking every time one of our snakes come in her way, and she
+allowed these lickings warn’t nothing to what she would do if we ever
+loaded up the place again with them.  I didn’t mind the lickings,
+because they didn’t amount to nothing; but I minded the trouble we
+had to lay in another lot.  But we got them laid in, and all the other
+things; and you never see a cabin as blithesome as Jim’s was when they’d
+all swarm out for music and go for him.  Jim didn’t like the spiders,
+and the spiders didn’t like Jim; and so they’d lay for him, and make it
+mighty warm for him.  And he said that between the rats and the snakes
+and the grindstone there warn’t no room in bed for him, skasely; and
+when there was, a body couldn’t sleep, it was so lively, and it was
+always lively, he said, because _they_ never all slept at one time, but
+took turn about, so when the snakes was asleep the rats was on deck, and
+when the rats turned in the snakes come on watch, so he always had one
+gang under him, in his way, and t’other gang having a circus over him,
+and if he got up to hunt a new place the spiders would take a chance at
+him as he crossed over. He said if he ever got out this time he wouldn’t
+ever be a prisoner again, not for a salary.
+
+Well, by the end of three weeks everything was in pretty good shape.
+ The shirt was sent in early, in a pie, and every time a rat bit Jim he
+would get up and write a little in his journal whilst the ink was fresh;
+the pens was made, the inscriptions and so on was all carved on the
+grindstone; the bed-leg was sawed in two, and we had et up the sawdust,
+and it give us a most amazing stomach-ache.  We reckoned we was all
+going to die, but didn’t.  It was the most undigestible sawdust I ever
+see; and Tom said the same.
+
+But as I was saying, we’d got all the work done now, at last; and we was
+all pretty much fagged out, too, but mainly Jim.  The old man had wrote
+a couple of times to the plantation below Orleans to come and get their
+runaway nigger, but hadn’t got no answer, because there warn’t no such
+plantation; so he allowed he would advertise Jim in the St. Louis and
+New Orleans papers; and when he mentioned the St. Louis ones it give me
+the cold shivers, and I see we hadn’t no time to lose. So Tom said, now
+for the nonnamous letters.
+
+“What’s them?”  I says.
+
+“Warnings to the people that something is up.  Sometimes it’s done one
+way, sometimes another.  But there’s always somebody spying around that
+gives notice to the governor of the castle.  When Louis XVI. was going
+to light out of the Tooleries, a servant-girl done it.  It’s a very good
+way, and so is the nonnamous letters.  We’ll use them both.  And it’s
+usual for the prisoner’s mother to change clothes with him, and she
+stays in, and he slides out in her clothes.  We’ll do that, too.”
+
+“But looky here, Tom, what do we want to _warn_ anybody for that
+something’s up?  Let them find it out for themselves--it’s their
+lookout.”
+
+“Yes, I know; but you can’t depend on them.  It’s the way they’ve acted
+from the very start--left us to do _everything_.  They’re so confiding
+and mullet-headed they don’t take notice of nothing at all.  So if we
+don’t _give_ them notice there won’t be nobody nor nothing to interfere
+with us, and so after all our hard work and trouble this escape ‘ll go
+off perfectly flat; won’t amount to nothing--won’t be nothing _to_ it.”
+
+“Well, as for me, Tom, that’s the way I’d like.”
+
+“Shucks!” he says, and looked disgusted.  So I says:
+
+“But I ain’t going to make no complaint.  Any way that suits you suits
+me. What you going to do about the servant-girl?”
+
+“You’ll be her.  You slide in, in the middle of the night, and hook that
+yaller girl’s frock.”
+
+“Why, Tom, that ‘ll make trouble next morning; because, of course, she
+prob’bly hain’t got any but that one.”
+
+“I know; but you don’t want it but fifteen minutes, to carry the
+nonnamous letter and shove it under the front door.”
+
+“All right, then, I’ll do it; but I could carry it just as handy in my
+own togs.”
+
+“You wouldn’t look like a servant-girl _then_, would you?”
+
+“No, but there won’t be nobody to see what I look like, _anyway_.”
+
+“That ain’t got nothing to do with it.  The thing for us to do is just
+to do our _duty_, and not worry about whether anybody _sees_ us do it or
+not. Hain’t you got no principle at all?”
+
+“All right, I ain’t saying nothing; I’m the servant-girl.  Who’s Jim’s
+mother?”
+
+“I’m his mother.  I’ll hook a gown from Aunt Sally.”
+
+“Well, then, you’ll have to stay in the cabin when me and Jim leaves.”
+
+“Not much.  I’ll stuff Jim’s clothes full of straw and lay it on his bed
+to represent his mother in disguise, and Jim ‘ll take the nigger woman’s
+gown off of me and wear it, and we’ll all evade together.  When a
+prisoner of style escapes it’s called an evasion.  It’s always called
+so when a king escapes, f’rinstance.  And the same with a king’s son;
+it don’t make no difference whether he’s a natural one or an unnatural
+one.”
+
+So Tom he wrote the nonnamous letter, and I smouched the yaller wench’s
+frock that night, and put it on, and shoved it under the front door, the
+way Tom told me to.  It said:
+
+Beware.  Trouble is brewing.  Keep a sharp lookout. _Unknown_ _Friend_.
+
+Next night we stuck a picture, which Tom drawed in blood, of a skull and
+crossbones on the front door; and next night another one of a coffin on
+the back door.  I never see a family in such a sweat.  They couldn’t a
+been worse scared if the place had a been full of ghosts laying for them
+behind everything and under the beds and shivering through the air.  If
+a door banged, Aunt Sally she jumped and said “ouch!” if anything fell,
+she jumped and said “ouch!” if you happened to touch her, when she
+warn’t noticing, she done the same; she couldn’t face noway and be
+satisfied, because she allowed there was something behind her every
+time--so she was always a-whirling around sudden, and saying “ouch,” and
+before she’d got two-thirds around she’d whirl back again, and say it
+again; and she was afraid to go to bed, but she dasn’t set up.  So the
+thing was working very well, Tom said; he said he never see a thing work
+more satisfactory. He said it showed it was done right.
+
+So he said, now for the grand bulge!  So the very next morning at the
+streak of dawn we got another letter ready, and was wondering what we
+better do with it, because we heard them say at supper they was going
+to have a nigger on watch at both doors all night.  Tom he went down the
+lightning-rod to spy around; and the nigger at the back door was asleep,
+and he stuck it in the back of his neck and come back.  This letter
+said:
+
+Don’t betray me, I wish to be your friend.  There is a desprate gang of
+cutthroats from over in the Indian Territory going to steal your runaway
+nigger to-night, and they have been trying to scare you so as you will
+stay in the house and not bother them.  I am one of the gang, but have
+got religgion and wish to quit it and lead an honest life again, and
+will betray the helish design. They will sneak down from northards,
+along the fence, at midnight exact, with a false key, and go in the
+nigger’s cabin to get him. I am to be off a piece and blow a tin horn
+if I see any danger; but stead of that I will _baa_ like a sheep soon as
+they get in and not blow at all; then whilst they are getting his
+chains loose, you slip there and lock them in, and can kill them at your
+leasure.  Don’t do anything but just the way I am telling you, if you do
+they will suspicion something and raise whoop-jamboreehoo. I do not wish
+any reward but to know I have done the right thing. _Unknown Friend._
+
+
+
+
+CHAPTER XL.
+
+WE was feeling pretty good after breakfast, and took my canoe and went
+over the river a-fishing, with a lunch, and had a good time, and took a
+look at the raft and found her all right, and got home late to supper,
+and found them in such a sweat and worry they didn’t know which end they
+was standing on, and made us go right off to bed the minute we was done
+supper, and wouldn’t tell us what the trouble was, and never let on a
+word about the new letter, but didn’t need to, because we knowed as much
+about it as anybody did, and as soon as we was half up stairs and her
+back was turned we slid for the cellar cupboard and loaded up a good
+lunch and took it up to our room and went to bed, and got up about
+half-past eleven, and Tom put on Aunt Sally’s dress that he stole and
+was going to start with the lunch, but says:
+
+“Where’s the butter?”
+
+“I laid out a hunk of it,” I says, “on a piece of a corn-pone.”
+
+“Well, you _left_ it laid out, then--it ain’t here.”
+
+“We can get along without it,” I says.
+
+“We can get along _with_ it, too,” he says; “just you slide down cellar
+and fetch it.  And then mosey right down the lightning-rod and come
+along. I’ll go and stuff the straw into Jim’s clothes to represent his
+mother in disguise, and be ready to _baa_ like a sheep and shove soon as
+you get there.”
+
+So out he went, and down cellar went I. The hunk of butter, big as
+a person’s fist, was where I had left it, so I took up the slab of
+corn-pone with it on, and blowed out my light, and started up stairs
+very stealthy, and got up to the main floor all right, but here comes
+Aunt Sally with a candle, and I clapped the truck in my hat, and clapped
+my hat on my head, and the next second she see me; and she says:
+
+“You been down cellar?”
+
+“Yes’m.”
+
+“What you been doing down there?”
+
+“Noth’n.”
+
+“_Noth’n!_”
+
+“No’m.”
+
+“Well, then, what possessed you to go down there this time of night?”
+
+“I don’t know ‘m.”
+
+“You don’t _know_?  Don’t answer me that way. Tom, I want to know what
+you been _doing_ down there.”
+
+“I hain’t been doing a single thing, Aunt Sally, I hope to gracious if I
+have.”
+
+I reckoned she’d let me go now, and as a generl thing she would; but I
+s’pose there was so many strange things going on she was just in a sweat
+about every little thing that warn’t yard-stick straight; so she says,
+very decided:
+
+“You just march into that setting-room and stay there till I come.  You
+been up to something you no business to, and I lay I’ll find out what it
+is before I’M done with you.”
+
+So she went away as I opened the door and walked into the setting-room.
+My, but there was a crowd there!  Fifteen farmers, and every one of them
+had a gun.  I was most powerful sick, and slunk to a chair and set down.
+They was setting around, some of them talking a little, in a low voice,
+and all of them fidgety and uneasy, but trying to look like they warn’t;
+but I knowed they was, because they was always taking off their hats,
+and putting them on, and scratching their heads, and changing their
+seats, and fumbling with their buttons.  I warn’t easy myself, but I
+didn’t take my hat off, all the same.
+
+I did wish Aunt Sally would come, and get done with me, and lick me, if
+she wanted to, and let me get away and tell Tom how we’d overdone this
+thing, and what a thundering hornet’s-nest we’d got ourselves into, so
+we could stop fooling around straight off, and clear out with Jim before
+these rips got out of patience and come for us.
+
+At last she come and begun to ask me questions, but I _couldn’t_ answer
+them straight, I didn’t know which end of me was up; because these men
+was in such a fidget now that some was wanting to start right NOW and
+lay for them desperadoes, and saying it warn’t but a few minutes to
+midnight; and others was trying to get them to hold on and wait for the
+sheep-signal; and here was Aunty pegging away at the questions, and
+me a-shaking all over and ready to sink down in my tracks I was
+that scared; and the place getting hotter and hotter, and the butter
+beginning to melt and run down my neck and behind my ears; and pretty
+soon, when one of them says, “I’M for going and getting in the cabin
+_first_ and right _now_, and catching them when they come,” I most
+dropped; and a streak of butter come a-trickling down my forehead, and
+Aunt Sally she see it, and turns white as a sheet, and says:
+
+“For the land’s sake, what _is_ the matter with the child?  He’s got the
+brain-fever as shore as you’re born, and they’re oozing out!”
+
+And everybody runs to see, and she snatches off my hat, and out comes
+the bread and what was left of the butter, and she grabbed me, and
+hugged me, and says:
+
+“Oh, what a turn you did give me! and how glad and grateful I am it
+ain’t no worse; for luck’s against us, and it never rains but it pours,
+and when I see that truck I thought we’d lost you, for I knowed by
+the color and all it was just like your brains would be if--Dear,
+dear, whyd’nt you _tell_ me that was what you’d been down there for, I
+wouldn’t a cared.  Now cler out to bed, and don’t lemme see no more of
+you till morning!”
+
+I was up stairs in a second, and down the lightning-rod in another one,
+and shinning through the dark for the lean-to.  I couldn’t hardly get my
+words out, I was so anxious; but I told Tom as quick as I could we must
+jump for it now, and not a minute to lose--the house full of men, yonder,
+with guns!
+
+His eyes just blazed; and he says:
+
+“No!--is that so?  _ain’t_ it bully!  Why, Huck, if it was to do over
+again, I bet I could fetch two hundred!  If we could put it off till--”
+
+“Hurry!  _Hurry_!”  I says.  “Where’s Jim?”
+
+“Right at your elbow; if you reach out your arm you can touch him.
+ He’s dressed, and everything’s ready.  Now we’ll slide out and give the
+sheep-signal.”
+
+But then we heard the tramp of men coming to the door, and heard them
+begin to fumble with the pad-lock, and heard a man say:
+
+“I _told_ you we’d be too soon; they haven’t come--the door is locked.
+Here, I’ll lock some of you into the cabin, and you lay for ‘em in the
+dark and kill ‘em when they come; and the rest scatter around a piece,
+and listen if you can hear ‘em coming.”
+
+So in they come, but couldn’t see us in the dark, and most trod on
+us whilst we was hustling to get under the bed.  But we got under all
+right, and out through the hole, swift but soft--Jim first, me next,
+and Tom last, which was according to Tom’s orders.  Now we was in the
+lean-to, and heard trampings close by outside.  So we crept to the door,
+and Tom stopped us there and put his eye to the crack, but couldn’t make
+out nothing, it was so dark; and whispered and said he would listen
+for the steps to get further, and when he nudged us Jim must glide out
+first, and him last.  So he set his ear to the crack and listened, and
+listened, and listened, and the steps a-scraping around out there all
+the time; and at last he nudged us, and we slid out, and stooped down,
+not breathing, and not making the least noise, and slipped stealthy
+towards the fence in Injun file, and got to it all right, and me and Jim
+over it; but Tom’s britches catched fast on a splinter on the top
+rail, and then he hear the steps coming, so he had to pull loose, which
+snapped the splinter and made a noise; and as he dropped in our tracks
+and started somebody sings out:
+
+“Who’s that?  Answer, or I’ll shoot!”
+
+But we didn’t answer; we just unfurled our heels and shoved.  Then there
+was a rush, and a _Bang, Bang, Bang!_ and the bullets fairly whizzed
+around us! We heard them sing out:
+
+“Here they are!  They’ve broke for the river!  After ‘em, boys, and turn
+loose the dogs!”
+
+So here they come, full tilt.  We could hear them because they wore
+boots and yelled, but we didn’t wear no boots and didn’t yell.  We was
+in the path to the mill; and when they got pretty close on to us we
+dodged into the bush and let them go by, and then dropped in behind
+them.  They’d had all the dogs shut up, so they wouldn’t scare off the
+robbers; but by this time somebody had let them loose, and here they
+come, making powwow enough for a million; but they was our dogs; so we
+stopped in our tracks till they catched up; and when they see it warn’t
+nobody but us, and no excitement to offer them, they only just said
+howdy, and tore right ahead towards the shouting and clattering; and
+then we up-steam again, and whizzed along after them till we was nearly
+to the mill, and then struck up through the bush to where my canoe was
+tied, and hopped in and pulled for dear life towards the middle of the
+river, but didn’t make no more noise than we was obleeged to. Then we
+struck out, easy and comfortable, for the island where my raft was; and
+we could hear them yelling and barking at each other all up and down the
+bank, till we was so far away the sounds got dim and died out.  And when
+we stepped on to the raft I says:
+
+“_Now_, old Jim, you’re a free man again, and I bet you won’t ever be a
+slave no more.”
+
+“En a mighty good job it wuz, too, Huck.  It ‘uz planned beautiful, en
+it ‘uz done beautiful; en dey ain’t _nobody_ kin git up a plan dat’s mo’
+mixed-up en splendid den what dat one wuz.”
+
+We was all glad as we could be, but Tom was the gladdest of all because
+he had a bullet in the calf of his leg.
+
+When me and Jim heard that we didn’t feel so brash as what we did
+before. It was hurting him considerable, and bleeding; so we laid him in
+the wigwam and tore up one of the duke’s shirts for to bandage him, but
+he says:
+
+“Gimme the rags; I can do it myself.  Don’t stop now; don’t fool around
+here, and the evasion booming along so handsome; man the sweeps, and set
+her loose!  Boys, we done it elegant!--‘deed we did.  I wish _we’d_ a
+had the handling of Louis XVI., there wouldn’t a been no ‘Son of Saint
+Louis, ascend to heaven!’ wrote down in _his_ biography; no, sir, we’d
+a whooped him over the _border_--that’s what we’d a done with _him_--and
+done it just as slick as nothing at all, too.  Man the sweeps--man the
+sweeps!”
+
+But me and Jim was consulting--and thinking.  And after we’d thought a
+minute, I says:
+
+“Say it, Jim.”
+
+So he says:
+
+“Well, den, dis is de way it look to me, Huck.  Ef it wuz _him_ dat ‘uz
+bein’ sot free, en one er de boys wuz to git shot, would he say, ‘Go on
+en save me, nemmine ‘bout a doctor f’r to save dis one?’  Is dat like
+Mars Tom Sawyer?  Would he say dat?  You _bet_ he wouldn’t!  _well_,
+den, is _Jim_ gywne to say it?  No, sah--I doan’ budge a step out’n dis
+place ‘dout a _doctor_, not if it’s forty year!”
+
+I knowed he was white inside, and I reckoned he’d say what he did say--so
+it was all right now, and I told Tom I was a-going for a doctor.
+ He raised considerable row about it, but me and Jim stuck to it and
+wouldn’t budge; so he was for crawling out and setting the raft loose
+himself; but we wouldn’t let him.  Then he give us a piece of his mind,
+but it didn’t do no good.
+
+So when he sees me getting the canoe ready, he says:
+
+“Well, then, if you’re bound to go, I’ll tell you the way to do when you
+get to the village.  Shut the door and blindfold the doctor tight and
+fast, and make him swear to be silent as the grave, and put a purse
+full of gold in his hand, and then take and lead him all around the
+back alleys and everywheres in the dark, and then fetch him here in the
+canoe, in a roundabout way amongst the islands, and search him and take
+his chalk away from him, and don’t give it back to him till you get him
+back to the village, or else he will chalk this raft so he can find it
+again. It’s the way they all do.”
+
+So I said I would, and left, and Jim was to hide in the woods when he
+see the doctor coming till he was gone again.
+
+
+
+
+CHAPTER XLI.
+
+THE doctor was an old man; a very nice, kind-looking old man when I got
+him up.  I told him me and my brother was over on Spanish Island hunting
+yesterday afternoon, and camped on a piece of a raft we found, and about
+midnight he must a kicked his gun in his dreams, for it went off and
+shot him in the leg, and we wanted him to go over there and fix it and
+not say nothing about it, nor let anybody know, because we wanted to
+come home this evening and surprise the folks.
+
+“Who is your folks?” he says.
+
+“The Phelpses, down yonder.”
+
+“Oh,” he says.  And after a minute, he says:
+
+“How’d you say he got shot?”
+
+“He had a dream,” I says, “and it shot him.”
+
+“Singular dream,” he says.
+
+So he lit up his lantern, and got his saddle-bags, and we started.  But
+when he sees the canoe he didn’t like the look of her--said she was big
+enough for one, but didn’t look pretty safe for two.  I says:
+
+“Oh, you needn’t be afeard, sir, she carried the three of us easy
+enough.”
+
+“What three?”
+
+“Why, me and Sid, and--and--and _the guns_; that’s what I mean.”
+
+“Oh,” he says.
+
+But he put his foot on the gunnel and rocked her, and shook his head,
+and said he reckoned he’d look around for a bigger one.  But they was
+all locked and chained; so he took my canoe, and said for me to wait
+till he come back, or I could hunt around further, or maybe I better
+go down home and get them ready for the surprise if I wanted to.  But
+I said I didn’t; so I told him just how to find the raft, and then he
+started.
+
+I struck an idea pretty soon.  I says to myself, spos’n he can’t fix
+that leg just in three shakes of a sheep’s tail, as the saying is?
+spos’n it takes him three or four days?  What are we going to do?--lay
+around there till he lets the cat out of the bag?  No, sir; I know what
+_I’ll_ do.  I’ll wait, and when he comes back if he says he’s got to
+go any more I’ll get down there, too, if I swim; and we’ll take and tie
+him, and keep him, and shove out down the river; and when Tom’s done
+with him we’ll give him what it’s worth, or all we got, and then let him
+get ashore.
+
+So then I crept into a lumber-pile to get some sleep; and next time I
+waked up the sun was away up over my head!  I shot out and went for the
+doctor’s house, but they told me he’d gone away in the night some time
+or other, and warn’t back yet.  Well, thinks I, that looks powerful bad
+for Tom, and I’ll dig out for the island right off.  So away I shoved,
+and turned the corner, and nearly rammed my head into Uncle Silas’s
+stomach! He says:
+
+“Why, _Tom!_  Where you been all this time, you rascal?”
+
+“I hain’t been nowheres,” I says, “only just hunting for the runaway
+nigger--me and Sid.”
+
+“Why, where ever did you go?” he says.  “Your aunt’s been mighty
+uneasy.”
+
+“She needn’t,” I says, “because we was all right.  We followed the men
+and the dogs, but they outrun us, and we lost them; but we thought we
+heard them on the water, so we got a canoe and took out after them and
+crossed over, but couldn’t find nothing of them; so we cruised along
+up-shore till we got kind of tired and beat out; and tied up the canoe
+and went to sleep, and never waked up till about an hour ago; then we
+paddled over here to hear the news, and Sid’s at the post-office to see
+what he can hear, and I’m a-branching out to get something to eat for
+us, and then we’re going home.”
+
+So then we went to the post-office to get “Sid”; but just as I
+suspicioned, he warn’t there; so the old man he got a letter out of the
+office, and we waited awhile longer, but Sid didn’t come; so the old man
+said, come along, let Sid foot it home, or canoe it, when he got done
+fooling around--but we would ride.  I couldn’t get him to let me stay
+and wait for Sid; and he said there warn’t no use in it, and I must come
+along, and let Aunt Sally see we was all right.
+
+When we got home Aunt Sally was that glad to see me she laughed and
+cried both, and hugged me, and give me one of them lickings of hern that
+don’t amount to shucks, and said she’d serve Sid the same when he come.
+
+And the place was plum full of farmers and farmers’ wives, to dinner;
+and such another clack a body never heard.  Old Mrs. Hotchkiss was the
+worst; her tongue was a-going all the time.  She says:
+
+“Well, Sister Phelps, I’ve ransacked that-air cabin over, an’ I b’lieve
+the nigger was crazy.  I says to Sister Damrell--didn’t I, Sister
+Damrell?--s’I, he’s crazy, s’I--them’s the very words I said.  You all
+hearn me: he’s crazy, s’I; everything shows it, s’I.  Look at that-air
+grindstone, s’I; want to tell _me_’t any cretur ‘t’s in his right mind
+‘s a goin’ to scrabble all them crazy things onto a grindstone, s’I?
+ Here sich ‘n’ sich a person busted his heart; ‘n’ here so ‘n’ so
+pegged along for thirty-seven year, ‘n’ all that--natcherl son o’ Louis
+somebody, ‘n’ sich everlast’n rubbage.  He’s plumb crazy, s’I; it’s what
+I says in the fust place, it’s what I says in the middle, ‘n’ it’s what
+I says last ‘n’ all the time--the nigger’s crazy--crazy ‘s Nebokoodneezer,
+s’I.”
+
+“An’ look at that-air ladder made out’n rags, Sister Hotchkiss,” says
+old Mrs. Damrell; “what in the name o’ goodness _could_ he ever want
+of--”
+
+“The very words I was a-sayin’ no longer ago th’n this minute to Sister
+Utterback, ‘n’ she’ll tell you so herself.  Sh-she, look at that-air rag
+ladder, sh-she; ‘n’ s’I, yes, _look_ at it, s’I--what _could_ he a-wanted
+of it, s’I.  Sh-she, Sister Hotchkiss, sh-she--”
+
+“But how in the nation’d they ever _git_ that grindstone _in_ there,
+_anyway_? ‘n’ who dug that-air _hole_? ‘n’ who--”
+
+“My very _words_, Brer Penrod!  I was a-sayin’--pass that-air sasser o’
+m’lasses, won’t ye?--I was a-sayin’ to Sister Dunlap, jist this minute,
+how _did_ they git that grindstone in there, s’I.  Without _help_, mind
+you--‘thout _help_!  _that’s_ wher ‘tis.  Don’t tell _me_, s’I; there
+_wuz_ help, s’I; ‘n’ ther’ wuz a _plenty_ help, too, s’I; ther’s ben a
+_dozen_ a-helpin’ that nigger, ‘n’ I lay I’d skin every last nigger on
+this place but _I’d_ find out who done it, s’I; ‘n’ moreover, s’I--”
+
+“A _dozen_ says you!--_forty_ couldn’t a done every thing that’s been
+done. Look at them case-knife saws and things, how tedious they’ve been
+made; look at that bed-leg sawed off with ‘m, a week’s work for six men;
+look at that nigger made out’n straw on the bed; and look at--”
+
+“You may _well_ say it, Brer Hightower!  It’s jist as I was a-sayin’
+to Brer Phelps, his own self.  S’e, what do _you_ think of it, Sister
+Hotchkiss, s’e? Think o’ what, Brer Phelps, s’I?  Think o’ that bed-leg
+sawed off that a way, s’e?  _think_ of it, s’I?  I lay it never sawed
+_itself_ off, s’I--somebody _sawed_ it, s’I; that’s my opinion, take it
+or leave it, it mayn’t be no ‘count, s’I, but sich as ‘t is, it’s my
+opinion, s’I, ‘n’ if any body k’n start a better one, s’I, let him _do_
+it, s’I, that’s all.  I says to Sister Dunlap, s’I--”
+
+“Why, dog my cats, they must a ben a house-full o’ niggers in there
+every night for four weeks to a done all that work, Sister Phelps.  Look
+at that shirt--every last inch of it kivered over with secret African
+writ’n done with blood!  Must a ben a raft uv ‘m at it right along, all
+the time, amost.  Why, I’d give two dollars to have it read to me; ‘n’
+as for the niggers that wrote it, I ‘low I’d take ‘n’ lash ‘m t’ll--”
+
+“People to _help_ him, Brother Marples!  Well, I reckon you’d _think_
+so if you’d a been in this house for a while back.  Why, they’ve stole
+everything they could lay their hands on--and we a-watching all the time,
+mind you. They stole that shirt right off o’ the line! and as for that
+sheet they made the rag ladder out of, ther’ ain’t no telling how
+many times they _didn’t_ steal that; and flour, and candles, and
+candlesticks, and spoons, and the old warming-pan, and most a thousand
+things that I disremember now, and my new calico dress; and me and
+Silas and my Sid and Tom on the constant watch day _and_ night, as I was
+a-telling you, and not a one of us could catch hide nor hair nor sight
+nor sound of them; and here at the last minute, lo and behold you, they
+slides right in under our noses and fools us, and not only fools _us_
+but the Injun Territory robbers too, and actuly gets _away_ with that
+nigger safe and sound, and that with sixteen men and twenty-two dogs
+right on their very heels at that very time!  I tell you, it just bangs
+anything I ever _heard_ of. Why, _sperits_ couldn’t a done better and
+been no smarter. And I reckon they must a _been_ sperits--because, _you_
+know our dogs, and ther’ ain’t no better; well, them dogs never even got
+on the _track_ of ‘m once!  You explain _that_ to me if you can!--_any_
+of you!”
+
+“Well, it does beat--”
+
+“Laws alive, I never--”
+
+“So help me, I wouldn’t a be--”
+
+“_House_-thieves as well as--”
+
+“Goodnessgracioussakes, I’d a ben afeard to live in sich a--”
+
+“‘Fraid to _live_!--why, I was that scared I dasn’t hardly go to bed, or
+get up, or lay down, or _set_ down, Sister Ridgeway.  Why, they’d steal
+the very--why, goodness sakes, you can guess what kind of a fluster I was
+in by the time midnight come last night.  I hope to gracious if I warn’t
+afraid they’d steal some o’ the family!  I was just to that pass I
+didn’t have no reasoning faculties no more.  It looks foolish enough
+_now_, in the daytime; but I says to myself, there’s my two poor boys
+asleep, ‘way up stairs in that lonesome room, and I declare to goodness
+I was that uneasy ‘t I crep’ up there and locked ‘em in!  I _did_.  And
+anybody would. Because, you know, when you get scared that way, and it
+keeps running on, and getting worse and worse all the time, and your
+wits gets to addling, and you get to doing all sorts o’ wild things,
+and by and by you think to yourself, spos’n I was a boy, and was away up
+there, and the door ain’t locked, and you--” She stopped, looking kind
+of wondering, and then she turned her head around slow, and when her eye
+lit on me--I got up and took a walk.
+
+Says I to myself, I can explain better how we come to not be in that
+room this morning if I go out to one side and study over it a little.
+ So I done it.  But I dasn’t go fur, or she’d a sent for me.  And when
+it was late in the day the people all went, and then I come in and
+told her the noise and shooting waked up me and “Sid,” and the door was
+locked, and we wanted to see the fun, so we went down the lightning-rod,
+and both of us got hurt a little, and we didn’t never want to try _that_
+no more.  And then I went on and told her all what I told Uncle Silas
+before; and then she said she’d forgive us, and maybe it was all right
+enough anyway, and about what a body might expect of boys, for all boys
+was a pretty harum-scarum lot as fur as she could see; and so, as long
+as no harm hadn’t come of it, she judged she better put in her time
+being grateful we was alive and well and she had us still, stead of
+fretting over what was past and done.  So then she kissed me, and patted
+me on the head, and dropped into a kind of a brown study; and pretty
+soon jumps up, and says:
+
+“Why, lawsamercy, it’s most night, and Sid not come yet!  What _has_
+become of that boy?”
+
+I see my chance; so I skips up and says:
+
+“I’ll run right up to town and get him,” I says.
+
+“No you won’t,” she says.  “You’ll stay right wher’ you are; _one’s_
+enough to be lost at a time.  If he ain’t here to supper, your uncle ‘ll
+go.”
+
+Well, he warn’t there to supper; so right after supper uncle went.
+
+He come back about ten a little bit uneasy; hadn’t run across Tom’s
+track. Aunt Sally was a good _deal_ uneasy; but Uncle Silas he said
+there warn’t no occasion to be--boys will be boys, he said, and you’ll
+see this one turn up in the morning all sound and right.  So she had
+to be satisfied.  But she said she’d set up for him a while anyway, and
+keep a light burning so he could see it.
+
+And then when I went up to bed she come up with me and fetched her
+candle, and tucked me in, and mothered me so good I felt mean, and like
+I couldn’t look her in the face; and she set down on the bed and talked
+with me a long time, and said what a splendid boy Sid was, and didn’t
+seem to want to ever stop talking about him; and kept asking me every
+now and then if I reckoned he could a got lost, or hurt, or maybe
+drownded, and might be laying at this minute somewheres suffering or
+dead, and she not by him to help him, and so the tears would drip down
+silent, and I would tell her that Sid was all right, and would be home
+in the morning, sure; and she would squeeze my hand, or maybe kiss me,
+and tell me to say it again, and keep on saying it, because it done her
+good, and she was in so much trouble.  And when she was going away she
+looked down in my eyes so steady and gentle, and says:
+
+“The door ain’t going to be locked, Tom, and there’s the window and
+the rod; but you’ll be good, _won’t_ you?  And you won’t go?  For _my_
+sake.”
+
+Laws knows I _wanted_ to go bad enough to see about Tom, and was all
+intending to go; but after that I wouldn’t a went, not for kingdoms.
+
+But she was on my mind and Tom was on my mind, so I slept very restless.
+And twice I went down the rod away in the night, and slipped around
+front, and see her setting there by her candle in the window with her
+eyes towards the road and the tears in them; and I wished I could do
+something for her, but I couldn’t, only to swear that I wouldn’t never
+do nothing to grieve her any more.  And the third time I waked up at
+dawn, and slid down, and she was there yet, and her candle was most out,
+and her old gray head was resting on her hand, and she was asleep.
+
+
+
+
+CHAPTER XLII.
+
+THE old man was uptown again before breakfast, but couldn’t get no
+track of Tom; and both of them set at the table thinking, and not saying
+nothing, and looking mournful, and their coffee getting cold, and not
+eating anything. And by and by the old man says:
+
+“Did I give you the letter?”
+
+“What letter?”
+
+“The one I got yesterday out of the post-office.”
+
+“No, you didn’t give me no letter.”
+
+“Well, I must a forgot it.”
+
+So he rummaged his pockets, and then went off somewheres where he had
+laid it down, and fetched it, and give it to her.  She says:
+
+“Why, it’s from St. Petersburg--it’s from Sis.”
+
+I allowed another walk would do me good; but I couldn’t stir.  But
+before she could break it open she dropped it and run--for she see
+something. And so did I. It was Tom Sawyer on a mattress; and that old
+doctor; and Jim, in _her_ calico dress, with his hands tied behind him;
+and a lot of people.  I hid the letter behind the first thing that come
+handy, and rushed.  She flung herself at Tom, crying, and says:
+
+“Oh, he’s dead, he’s dead, I know he’s dead!”
+
+And Tom he turned his head a little, and muttered something or other,
+which showed he warn’t in his right mind; then she flung up her hands,
+and says:
+
+“He’s alive, thank God!  And that’s enough!” and she snatched a kiss of
+him, and flew for the house to get the bed ready, and scattering orders
+right and left at the niggers and everybody else, as fast as her tongue
+could go, every jump of the way.
+
+I followed the men to see what they was going to do with Jim; and the
+old doctor and Uncle Silas followed after Tom into the house.  The men
+was very huffy, and some of them wanted to hang Jim for an example to
+all the other niggers around there, so they wouldn’t be trying to run
+away like Jim done, and making such a raft of trouble, and keeping a
+whole family scared most to death for days and nights.  But the others
+said, don’t do it, it wouldn’t answer at all; he ain’t our nigger, and
+his owner would turn up and make us pay for him, sure.  So that cooled
+them down a little, because the people that’s always the most anxious
+for to hang a nigger that hain’t done just right is always the very
+ones that ain’t the most anxious to pay for him when they’ve got their
+satisfaction out of him.
+
+They cussed Jim considerble, though, and give him a cuff or two side the
+head once in a while, but Jim never said nothing, and he never let on to
+know me, and they took him to the same cabin, and put his own clothes
+on him, and chained him again, and not to no bed-leg this time, but to
+a big staple drove into the bottom log, and chained his hands, too, and
+both legs, and said he warn’t to have nothing but bread and water to
+eat after this till his owner come, or he was sold at auction because
+he didn’t come in a certain length of time, and filled up our hole, and
+said a couple of farmers with guns must stand watch around about the
+cabin every night, and a bulldog tied to the door in the daytime; and
+about this time they was through with the job and was tapering off with
+a kind of generl good-bye cussing, and then the old doctor comes and
+takes a look, and says:
+
+“Don’t be no rougher on him than you’re obleeged to, because he ain’t
+a bad nigger.  When I got to where I found the boy I see I couldn’t cut
+the bullet out without some help, and he warn’t in no condition for
+me to leave to go and get help; and he got a little worse and a little
+worse, and after a long time he went out of his head, and wouldn’t let
+me come a-nigh him any more, and said if I chalked his raft he’d kill
+me, and no end of wild foolishness like that, and I see I couldn’t do
+anything at all with him; so I says, I got to have _help_ somehow; and
+the minute I says it out crawls this nigger from somewheres and says
+he’ll help, and he done it, too, and done it very well.  Of course I
+judged he must be a runaway nigger, and there I _was_! and there I had
+to stick right straight along all the rest of the day and all night.  It
+was a fix, I tell you! I had a couple of patients with the chills, and
+of course I’d of liked to run up to town and see them, but I dasn’t,
+because the nigger might get away, and then I’d be to blame; and yet
+never a skiff come close enough for me to hail.  So there I had to stick
+plumb until daylight this morning; and I never see a nigger that was a
+better nuss or faithfuller, and yet he was risking his freedom to do it,
+and was all tired out, too, and I see plain enough he’d been worked
+main hard lately.  I liked the nigger for that; I tell you, gentlemen, a
+nigger like that is worth a thousand dollars--and kind treatment, too.  I
+had everything I needed, and the boy was doing as well there as he
+would a done at home--better, maybe, because it was so quiet; but there I
+_was_, with both of ‘m on my hands, and there I had to stick till about
+dawn this morning; then some men in a skiff come by, and as good luck
+would have it the nigger was setting by the pallet with his head propped
+on his knees sound asleep; so I motioned them in quiet, and they slipped
+up on him and grabbed him and tied him before he knowed what he was
+about, and we never had no trouble. And the boy being in a kind of a
+flighty sleep, too, we muffled the oars and hitched the raft on, and
+towed her over very nice and quiet, and the nigger never made the least
+row nor said a word from the start.  He ain’t no bad nigger, gentlemen;
+that’s what I think about him.”
+
+Somebody says:
+
+“Well, it sounds very good, doctor, I’m obleeged to say.”
+
+Then the others softened up a little, too, and I was mighty thankful
+to that old doctor for doing Jim that good turn; and I was glad it was
+according to my judgment of him, too; because I thought he had a good
+heart in him and was a good man the first time I see him.  Then they
+all agreed that Jim had acted very well, and was deserving to have some
+notice took of it, and reward.  So every one of them promised, right out
+and hearty, that they wouldn’t cuss him no more.
+
+Then they come out and locked him up.  I hoped they was going to say he
+could have one or two of the chains took off, because they was rotten
+heavy, or could have meat and greens with his bread and water; but they
+didn’t think of it, and I reckoned it warn’t best for me to mix in, but
+I judged I’d get the doctor’s yarn to Aunt Sally somehow or other as
+soon as I’d got through the breakers that was laying just ahead of
+me--explanations, I mean, of how I forgot to mention about Sid being shot
+when I was telling how him and me put in that dratted night paddling
+around hunting the runaway nigger.
+
+But I had plenty time.  Aunt Sally she stuck to the sick-room all day
+and all night, and every time I see Uncle Silas mooning around I dodged
+him.
+
+Next morning I heard Tom was a good deal better, and they said Aunt
+Sally was gone to get a nap.  So I slips to the sick-room, and if I
+found him awake I reckoned we could put up a yarn for the family that
+would wash. But he was sleeping, and sleeping very peaceful, too; and
+pale, not fire-faced the way he was when he come.  So I set down and
+laid for him to wake.  In about half an hour Aunt Sally comes gliding
+in, and there I was, up a stump again!  She motioned me to be still, and
+set down by me, and begun to whisper, and said we could all be joyful
+now, because all the symptoms was first-rate, and he’d been sleeping
+like that for ever so long, and looking better and peacefuller all the
+time, and ten to one he’d wake up in his right mind.
+
+So we set there watching, and by and by he stirs a bit, and opened his
+eyes very natural, and takes a look, and says:
+
+“Hello!--why, I’m at _home_!  How’s that?  Where’s the raft?”
+
+“It’s all right,” I says.
+
+“And _Jim_?”
+
+“The same,” I says, but couldn’t say it pretty brash.  But he never
+noticed, but says:
+
+“Good!  Splendid!  _Now_ we’re all right and safe! Did you tell Aunty?”
+
+I was going to say yes; but she chipped in and says:  “About what, Sid?”
+
+“Why, about the way the whole thing was done.”
+
+“What whole thing?”
+
+“Why, _the_ whole thing.  There ain’t but one; how we set the runaway
+nigger free--me and Tom.”
+
+“Good land!  Set the run--What _is_ the child talking about!  Dear, dear,
+out of his head again!”
+
+“_No_, I ain’t out of my _head_; I know all what I’m talking about.  We
+_did_ set him free--me and Tom.  We laid out to do it, and we _done_ it.
+ And we done it elegant, too.”  He’d got a start, and she never checked
+him up, just set and stared and stared, and let him clip along, and
+I see it warn’t no use for _me_ to put in.  “Why, Aunty, it cost us a
+power of work--weeks of it--hours and hours, every night, whilst you was
+all asleep. And we had to steal candles, and the sheet, and the shirt,
+and your dress, and spoons, and tin plates, and case-knives, and the
+warming-pan, and the grindstone, and flour, and just no end of things,
+and you can’t think what work it was to make the saws, and pens, and
+inscriptions, and one thing or another, and you can’t think _half_ the
+fun it was.  And we had to make up the pictures of coffins and things,
+and nonnamous letters from the robbers, and get up and down the
+lightning-rod, and dig the hole into the cabin, and made the rope ladder
+and send it in cooked up in a pie, and send in spoons and things to work
+with in your apron pocket--”
+
+“Mercy sakes!”
+
+“--and load up the cabin with rats and snakes and so on, for company for
+Jim; and then you kept Tom here so long with the butter in his hat that
+you come near spiling the whole business, because the men come before
+we was out of the cabin, and we had to rush, and they heard us and let
+drive at us, and I got my share, and we dodged out of the path and let
+them go by, and when the dogs come they warn’t interested in us, but
+went for the most noise, and we got our canoe, and made for the
+raft, and was all safe, and Jim was a free man, and we done it all by
+ourselves, and _wasn’t_ it bully, Aunty!”
+
+“Well, I never heard the likes of it in all my born days!  So it was
+_you_, you little rapscallions, that’s been making all this trouble,
+and turned everybody’s wits clean inside out and scared us all most to
+death.  I’ve as good a notion as ever I had in my life to take it out
+o’ you this very minute.  To think, here I’ve been, night after night,
+a--_you_ just get well once, you young scamp, and I lay I’ll tan the Old
+Harry out o’ both o’ ye!”
+
+But Tom, he _was_ so proud and joyful, he just _couldn’t_ hold in,
+and his tongue just _went_ it--she a-chipping in, and spitting fire all
+along, and both of them going it at once, like a cat convention; and she
+says:
+
+“_Well_, you get all the enjoyment you can out of it _now_, for mind I
+tell you if I catch you meddling with him again--”
+
+“Meddling with _who_?”  Tom says, dropping his smile and looking
+surprised.
+
+“With _who_?  Why, the runaway nigger, of course.  Who’d you reckon?”
+
+Tom looks at me very grave, and says:
+
+“Tom, didn’t you just tell me he was all right?  Hasn’t he got away?”
+
+“_Him_?” says Aunt Sally; “the runaway nigger?  ‘Deed he hasn’t.
+ They’ve got him back, safe and sound, and he’s in that cabin again,
+on bread and water, and loaded down with chains, till he’s claimed or
+sold!”
+
+Tom rose square up in bed, with his eye hot, and his nostrils opening
+and shutting like gills, and sings out to me:
+
+“They hain’t no _right_ to shut him up!  SHOVE!--and don’t you lose a
+minute.  Turn him loose! he ain’t no slave; he’s as free as any cretur
+that walks this earth!”
+
+“What _does_ the child mean?”
+
+“I mean every word I _say_, Aunt Sally, and if somebody don’t go, _I’ll_
+go. I’ve knowed him all his life, and so has Tom, there.  Old Miss
+Watson died two months ago, and she was ashamed she ever was going to
+sell him down the river, and _said_ so; and she set him free in her
+will.”
+
+“Then what on earth did _you_ want to set him free for, seeing he was
+already free?”
+
+“Well, that _is_ a question, I must say; and just like women!  Why,
+I wanted the _adventure_ of it; and I’d a waded neck-deep in blood
+to--goodness alive, _Aunt Polly!_”
+
+If she warn’t standing right there, just inside the door, looking as
+sweet and contented as an angel half full of pie, I wish I may never!
+
+Aunt Sally jumped for her, and most hugged the head off of her, and
+cried over her, and I found a good enough place for me under the bed,
+for it was getting pretty sultry for us, seemed to me.  And I peeped
+out, and in a little while Tom’s Aunt Polly shook herself loose and
+stood there looking across at Tom over her spectacles--kind of grinding
+him into the earth, you know.  And then she says:
+
+“Yes, you _better_ turn y’r head away--I would if I was you, Tom.”
+
+“Oh, deary me!” says Aunt Sally; “_Is_ he changed so?  Why, that ain’t
+_Tom_, it’s Sid; Tom’s--Tom’s--why, where is Tom?  He was here a minute
+ago.”
+
+“You mean where’s Huck _Finn_--that’s what you mean!  I reckon I hain’t
+raised such a scamp as my Tom all these years not to know him when I
+_see_ him.  That _would_ be a pretty howdy-do. Come out from under that
+bed, Huck Finn.”
+
+So I done it.  But not feeling brash.
+
+Aunt Sally she was one of the mixed-upest-looking persons I ever
+see--except one, and that was Uncle Silas, when he come in and they told
+it all to him.  It kind of made him drunk, as you may say, and he didn’t
+know nothing at all the rest of the day, and preached a prayer-meeting
+sermon that night that gave him a rattling ruputation, because the
+oldest man in the world couldn’t a understood it.  So Tom’s Aunt Polly,
+she told all about who I was, and what; and I had to up and tell how
+I was in such a tight place that when Mrs. Phelps took me for Tom
+Sawyer--she chipped in and says, “Oh, go on and call me Aunt Sally, I’m
+used to it now, and ‘tain’t no need to change”--that when Aunt Sally took
+me for Tom Sawyer I had to stand it--there warn’t no other way, and
+I knowed he wouldn’t mind, because it would be nuts for him, being
+a mystery, and he’d make an adventure out of it, and be perfectly
+satisfied.  And so it turned out, and he let on to be Sid, and made
+things as soft as he could for me.
+
+And his Aunt Polly she said Tom was right about old Miss Watson setting
+Jim free in her will; and so, sure enough, Tom Sawyer had gone and took
+all that trouble and bother to set a free nigger free! and I couldn’t
+ever understand before, until that minute and that talk, how he _could_
+help a body set a nigger free with his bringing-up.
+
+Well, Aunt Polly she said that when Aunt Sally wrote to her that Tom and
+_Sid_ had come all right and safe, she says to herself:
+
+“Look at that, now!  I might have expected it, letting him go off that
+way without anybody to watch him.  So now I got to go and trapse all
+the way down the river, eleven hundred mile, and find out what that
+creetur’s up to _this_ time, as long as I couldn’t seem to get any
+answer out of you about it.”
+
+“Why, I never heard nothing from you,” says Aunt Sally.
+
+“Well, I wonder!  Why, I wrote you twice to ask you what you could mean
+by Sid being here.”
+
+“Well, I never got ‘em, Sis.”
+
+Aunt Polly she turns around slow and severe, and says:
+
+“You, Tom!”
+
+“Well--_what_?” he says, kind of pettish.
+
+“Don’t you what _me_, you impudent thing--hand out them letters.”
+
+“What letters?”
+
+“_Them_ letters.  I be bound, if I have to take a-holt of you I’ll--”
+
+“They’re in the trunk.  There, now.  And they’re just the same as they
+was when I got them out of the office.  I hain’t looked into them, I
+hain’t touched them.  But I knowed they’d make trouble, and I thought if
+you warn’t in no hurry, I’d--”
+
+“Well, you _do_ need skinning, there ain’t no mistake about it.  And I
+wrote another one to tell you I was coming; and I s’pose he--”
+
+“No, it come yesterday; I hain’t read it yet, but _it’s_ all right, I’ve
+got that one.”
+
+I wanted to offer to bet two dollars she hadn’t, but I reckoned maybe it
+was just as safe to not to.  So I never said nothing.
+
+
+
+
+CHAPTER THE LAST
+
+THE first time I catched Tom private I asked him what was his idea, time
+of the evasion?--what it was he’d planned to do if the evasion worked all
+right and he managed to set a nigger free that was already free before?
+And he said, what he had planned in his head from the start, if we got
+Jim out all safe, was for us to run him down the river on the raft, and
+have adventures plumb to the mouth of the river, and then tell him about
+his being free, and take him back up home on a steamboat, in style,
+and pay him for his lost time, and write word ahead and get out all
+the niggers around, and have them waltz him into town with a torchlight
+procession and a brass-band, and then he would be a hero, and so would
+we.  But I reckoned it was about as well the way it was.
+
+We had Jim out of the chains in no time, and when Aunt Polly and Uncle
+Silas and Aunt Sally found out how good he helped the doctor nurse Tom,
+they made a heap of fuss over him, and fixed him up prime, and give him
+all he wanted to eat, and a good time, and nothing to do.  And we had
+him up to the sick-room, and had a high talk; and Tom give Jim forty
+dollars for being prisoner for us so patient, and doing it up so good,
+and Jim was pleased most to death, and busted out, and says:
+
+“Dah, now, Huck, what I tell you?--what I tell you up dah on Jackson
+islan’?  I _tole_ you I got a hairy breas’, en what’s de sign un it; en
+I _tole_ you I ben rich wunst, en gwineter to be rich _agin_; en it’s
+come true; en heah she is!  _dah_, now! doan’ talk to _me_--signs is
+_signs_, mine I tell you; en I knowed jis’ ‘s well ‘at I ‘uz gwineter be
+rich agin as I’s a-stannin’ heah dis minute!”
+
+And then Tom he talked along and talked along, and says, le’s all three
+slide out of here one of these nights and get an outfit, and go for
+howling adventures amongst the Injuns, over in the Territory, for a
+couple of weeks or two; and I says, all right, that suits me, but I
+ain’t got no money for to buy the outfit, and I reckon I couldn’t get
+none from home, because it’s likely pap’s been back before now, and got
+it all away from Judge Thatcher and drunk it up.
+
+“No, he hain’t,” Tom says; “it’s all there yet--six thousand dollars
+and more; and your pap hain’t ever been back since.  Hadn’t when I come
+away, anyhow.”
+
+Jim says, kind of solemn:
+
+“He ain’t a-comin’ back no mo’, Huck.”
+
+I says:
+
+“Why, Jim?”
+
+“Nemmine why, Huck--but he ain’t comin’ back no mo.”
+
+But I kept at him; so at last he says:
+
+“Doan’ you ‘member de house dat was float’n down de river, en dey wuz a
+man in dah, kivered up, en I went in en unkivered him and didn’ let you
+come in?  Well, den, you kin git yo’ money when you wants it, kase dat
+wuz him.”
+
+Tom’s most well now, and got his bullet around his neck on a watch-guard
+for a watch, and is always seeing what time it is, and so there ain’t
+nothing more to write about, and I am rotten glad of it, because if I’d
+a knowed what a trouble it was to make a book I wouldn’t a tackled it,
+and ain’t a-going to no more.  But I reckon I got to light out for the
+Territory ahead of the rest, because Aunt Sally she’s going to adopt me
+and sivilize me, and I can’t stand it.  I been there before.
+
+THE END. YOURS TRULY, _HUCK FINN_.
+
+
+
+
+
+End of the Project Gutenberg EBook of Adventures of Huckleberry Finn,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+***** This file should be named 76-0.htm or 76-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/76/
+
+Produced by David Widger. Previous editions produced by Ron Burkey and
+Internet Wiretap
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/hadoop/src/main/resources/books/land-of-oz.txt
+++ b/jet/hadoop/src/main/resources/books/land-of-oz.txt
@@ -1,0 +1,6638 @@
+﻿The Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+This eBook is for the use of anyone anywhere in the United States and most
+other parts of the world at no cost and with almost no restrictions
+whatsoever.  You may copy it, give it away or re-use it under the terms of
+the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org.  If you are not located in the United States, you'll have
+to check the laws of the country where you are located before using this ebook.
+
+Title: The Land of Oz
+
+Author: L. Frank Baum
+
+Illustrator: John Neill
+
+Release Date: December 30, 2016 [EBook #53844]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+
+
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+
+
+
+
+
+
+
+
+
+    The
+    Land of Oz
+
+    The Further Adventures of
+
+    A Sequel to
+    THE WIZARD OF OZ
+
+    by
+
+    L. Frank Baum
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration]
+
+The Famous Oz Books
+
+
+Since 1900 when L. Frank Baum introduced to the children of America
+THE WONDERFUL WIZARD OF OZ and all the other exciting characters who
+inhabit the land of Oz, these delightful fairy tales have stimulated
+the imagination of millions of young readers.
+
+These are stories which are genuine fantasy--creative, funny, tender,
+exciting and surprising. Filled with the rarest and most absurd
+creatures, each of the =14= volumes which now comprise the series, has
+been eagerly sought out by generation after generation until today they
+are known to all except the very young or those who were never young at
+all.
+
+When, in a recent survey, =The New York Times= polled a group of
+teenagers on the books they liked best when they were young, the Oz
+books topped the list.
+
+
+
+
+_THE FAMOUS OZ BOOKS_
+
+By L. Frank Baum:
+
+
+    THE WIZARD OF OZ
+    THE LAND OF OZ
+    OZMA OF OZ
+    DOROTHY AND THE WIZARD IN OZ
+    THE ROAD TO OZ
+    THE EMERALD CITY OF OZ
+    THE PATCHWORK GIRL OF OZ
+    TIK-TOK OF OZ
+    THE SCARECROW OF OZ
+    RINKITINK IN OZ
+    THE LOST PRINCESS OF OZ
+    THE TIN WOODMAN OF OZ
+    THE MAGIC OF OZ
+    GLINDA OF OZ
+
+
+    CHICAGO      THE REILLY & LEE CO.      _Publishers_
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration: TIP MANUFACTURES A PUMPKINHEAD]
+
+
+
+
+    The
+    Land of Oz
+
+    Being an account of the
+    further adventures of the
+
+    Scarecrow
+    and Tin Woodman
+
+    and also the strange experiences
+    of the Highly Magnified
+    Woggle-Bug, Jack Pumpkinhead,
+    the Animated Saw-Horse
+    and the Gump;
+    the story being
+
+    A Sequel _to_ The Wizard _of_ Oz
+
+    By
+
+    L. Frank Baum
+
+    Author of Father Goose--His Book; The Wizard of Oz; The Magical Monarch
+    of Mo; The Enchanted Isle of Yew, The Life and Adventures _of_
+    Santa Claus; Dot and Tot of Merryland etc., etc.
+
+    PICTURED BY
+
+    John R. Neill
+
+    CHICAGO
+
+    THE REILLY & LEE COMPANY
+
+
+
+
+[Illustration:
+
+    Copyright 1904
+
+    by
+
+    L. Frank Baum
+
+    All rights reserved
+]
+
+
+
+
+[Illustration:
+
+    Author's Note
+
+
+    After the publication of "The Wonderful Wizard of Oz" I began to
+    receive letters from children, telling me of their pleasure in
+    reading the story and asking me to "write something more" about the
+    Scarecrow and the Tin Woodman. At first I considered these little
+    letters, frank and earnest though they were, in the light of pretty
+    compliments; but the letters continued to come during succeeding
+    months, and even years.
+
+    Finally I promised one little girl, who made a long journey to
+    see me and prefer her request,--and she is a "Dorothy," by the
+    way--that when a thousand little girls had written me a thousand
+    little letters asking for another story of the Scarecrow and the
+    Tin Woodman, I would write the book. Either little Dorothy was a
+    fairy in disguise, and waved her magic wand, or the success of the
+    stage production of "The Wizard of Oz" made new friends for the
+    story. For the thousand letters reached their destination long
+    since--and many more followed them.
+
+    And now, although pleading guilty to a long delay, I have kept my
+    promise in this book.
+
+    L. FRANK BAUM.
+
+        Chicago, June, 1904.
+]
+
+
+
+
+[Illustration:
+
+    To those excellent good fellows and eminent comedians =David C.
+    Montgomery= and =Fred A. Stone= whose clever personations of the
+    Tin Woodman and the Scarecrow have delighted thousands of children
+    throughout the land, this book is gratefully dedicated
+                           by
+                       THE AUTHOR
+]
+
+
+
+
+[Illustration:
+
+    TIP.
+
+    JACK
+
+    MOMBI
+
+    SCARECROW
+
+    TIN WOODMAN
+
+    WOGGLE-BUG
+
+    GUMP
+]
+
+LIST OF CHAPTERS
+
+
+                                     PAGE
+
+    Tip Manufactures a Pumpkinhead            1
+    The Marvelous Powder of Life              9
+    The Flight of the Fugitives              23
+    Tip Makes an Experiment in Magic         33
+    The Awakening of the Saw-Horse           41
+    Jack Pumpkinhead's Ride                  53
+    His Majesty, the Scarecrow               65
+    General Jinjur's Army of Revolt          77
+    The Scarecrow Plans an Escape            91
+    The Journey to the Tin Woodman          103
+    A Nickel-Plated Emperor                 115
+    Mr. H. M. Woggle-Bug, T. E.             129
+    A Highly Magnified History              141
+    Old Mombi Indulges in Witchcraft        153
+    The Prisoners of the Queen              163
+    The Scarecrow Takes Time to Think       175
+    The Astonishing Flight of the Gump      185
+    In the Jackdaws' Nest                   195
+    Dr. Nikidik's Famous Wishing Pills      213
+    The Scarecrow Appeals to Glinda         225
+    The Tin Woodman Plucks a Rose           241
+    The Transformation of Old Mombi         251
+    Princess Ozma of Oz                     259
+    The Riches of Content                   273
+
+[Illustration]
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Manufactures
+    a Pumpkinhead
+]
+
+
+In the Country of the Gillikins, which is at the North of the Land of
+Oz, lived a youth called Tip. There was more to his name than that, for
+old Mombi often declared that his whole name was Tippetarius; but no
+one was expected to say such a long word when "Tip" would do just as
+well.
+
+This boy remembered nothing of his parents, for he had been brought
+when quite young to be reared by the old woman known as Mombi, whose
+reputation, I am sorry to say, was none of the best. For the Gillikin
+people had reason to suspect her of indulging in magical arts, and
+therefore hesitated to associate with her.
+
+Mombi was not exactly a Witch, because the Good Witch who ruled that
+part of the Land of Oz had forbidden any other Witch to exist in her
+dominions. So Tip's guardian, however much she might aspire to working
+magic, realized it was unlawful to be more than a Sorceress, or at most
+a Wizardess.
+
+[Illustration]
+
+Tip was made to carry wood from the forest, that the old woman might
+boil her pot. He also worked in the corn-fields, hoeing and husking;
+and he fed the pigs and milked the four-horned cow that was Mombi's
+especial pride.
+
+But you must not suppose he worked all the time, for he felt that
+would be bad for him. When sent to the forest Tip often climbed trees
+for birds' eggs or amused himself chasing the fleet white rabbits or
+fishing in the brooks with bent pins. Then he would hastily gather
+his armful of wood and carry it home. And when he was supposed to be
+working in the corn-fields, and the tall stalks hid him from Mombi's
+view, Tip would often dig in the gopher holes, or--if the mood seized
+him--lie upon his back between the rows of corn and take a nap. So, by
+taking care not to exhaust his strength, he grew as strong and rugged
+as a boy may be.
+
+Mombi's curious magic often frightened her neighbors, and they treated
+her shyly, yet respectfully, because of her weird powers. But Tip
+frankly hated her, and took no pains to hide his feelings. Indeed, he
+sometimes showed less respect for the old woman than he should have
+done, considering she was his guardian.
+
+[Illustration]
+
+There were pumpkins in Mombi's corn-fields, lying golden red among the
+rows of green stalks; and these had been planted and carefully tended
+that the four-horned cow might eat of them in the winter time. But one
+day, after the corn had all been cut and stacked, and Tip was carrying
+the pumpkins to the stable, he took a notion to make a "Jack Lantern"
+and try to give the old woman a fright with it.
+
+So he selected a fine, big pumpkin--one with a lustrous, orange-red
+color--and began carving it. With the point of his knife he made two
+round eyes, a three-cornered nose, and a mouth shaped like a new moon.
+The face, when completed, could not have been considered strictly
+beautiful; but it wore a smile so big and broad, and was so jolly in
+expression, that even Tip laughed as he looked admiringly at his work.
+
+The child had no playmates, so he did not know that boys often dig
+out the inside of a "pumpkin-jack," and in the space thus made put a
+lighted candle to render the face more startling; but he conceived an
+idea of his own that promised to be quite as effective. He decided to
+manufacture the form of a man, who would wear this pumpkin head, and to
+stand it in a place where old Mombi would meet it face to face.
+
+"And then," said Tip to himself, with a laugh, "she'll squeal louder
+than the brown pig does when I pull her tail, and shiver with fright
+worse than I did last year when I had the ague!"
+
+He had plenty of time to accomplish this task, for Mombi had gone to a
+village--to buy groceries, she said--and it was a journey of at least
+two days.
+
+So he took his axe to the forest, and selected some stout, straight
+saplings, which he cut down and trimmed of all their twigs and leaves.
+From these he would make the arms, and legs, and feet of his man. For
+the body he stripped a sheet of thick bark from around a big tree, and
+with much labor fashioned it into a cylinder of about the right size,
+pinning the edges together with wooden pegs. Then, whistling happily as
+he worked, he carefully jointed the limbs and fastened them to the body
+with pegs whittled into shape with his knife.
+
+By the time this feat had been accomplished it began to grow dark, and
+Tip remembered he must milk the cow and feed the pigs. So he picked up
+his wooden man and carried it back to the house with him.
+
+During the evening, by the light of the fire in the kitchen, Tip
+carefully rounded all the edges of the joints and smoothed the rough
+places in a neat and workmanlike manner. Then he stood the figure up
+against the wall and admired it. It seemed remarkably tall, even for a
+full-grown man; but that was a good point in a small boy's eyes, and
+Tip did not object at all to the size of his creation.
+
+Next morning, when he looked at his work again, Tip saw he had
+forgotten to give the dummy a neck, by means of which he might fasten
+the pumpkinhead to the body. So he went again to the forest, which was
+not far away, and chopped from a tree several pieces of wood with which
+to complete his work. When he returned he fastened a cross-piece to
+the upper end of the body, making a hole through the center to hold
+upright the neck. The bit of wood which formed this neck was also
+sharpened at the upper end, and when all was ready Tip put on the
+pumpkin head, pressing it well down onto the neck, and found that it
+fitted very well. The head could be turned to one side or the other, as
+he pleased, and the hinges of the arms and legs allowed him to place
+the dummy in any position he desired.
+
+"Now, that," declared Tip, proudly, "is really a very fine man, and it
+ought to frighten several screeches out of old Mombi! But it would be
+much more lifelike if it were properly dressed."
+
+To find clothing seemed no easy task; but Tip boldly ransacked the
+great chest in which Mombi kept all her keepsakes and treasures, and
+at the very bottom he discovered some purple trousers, a red shirt
+and a pink vest which was dotted with white spots. These he carried
+away to his man and succeeded, although the garments did not fit very
+well, in dressing the creature in a jaunty fashion. Some knit stockings
+belonging to Mombi and a much worn pair of his own shoes completed the
+man's apparel, and Tip was so delighted that he danced up and down and
+laughed aloud in boyish ecstasy.
+
+"I must give him a name!" he cried. "So good a man as this must surely
+have a name. I believe," he added, after a moment's thought, "I will
+name the fellow 'Jack Pumpkinhead!'"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Marvelous
+    Powder of Life
+]
+
+
+After considering the matter carefully, Tip decided that the best
+place to locate Jack would be at the bend in the road, a little way
+from the house. So he started to carry his man there, but found him
+heavy and rather awkward to handle. After dragging the creature a short
+distance Tip stood him on his feet, and by first bending the joints of
+one leg, and then those of the other,--at the same time pushing from
+behind,--the boy managed to induce Jack to walk to the bend in the
+road. It was not accomplished without a few tumbles, and Tip really
+worked harder than he ever had in the fields or forest; but a love of
+mischief urged him on, and it pleased him to test the cleverness of his
+workmanship.
+
+"Jack's all right, and works fine!" he said to himself, panting with
+the unusual exertion. But just then he discovered the man's left
+arm had fallen off in the journey; so he went back to find it, and
+afterward, by whittling a new and stouter pin for the shoulder-joint,
+he repaired the injury so successfully that the arm was stronger than
+before. Tip also noticed that Jack's pumpkin head had twisted around
+until it faced his back; but this was easily remedied. When, at last,
+the man was set up facing the turn in the path where old Mombi was to
+appear, he looked natural enough to be a fair imitation of a Gillikin
+farmer,--and unnatural enough to startle anyone that came on him
+unawares.
+
+As it was yet too early in the day to expect the old woman to return
+home, Tip went down into the valley below the farm-house and began to
+gather nuts from the trees that grew there.
+
+However, old Mombi returned earlier than usual. She had met a crooked
+wizard who resided in a lonely cave in the mountains, and had traded
+several important secrets of magic with him. Having in this way
+secured three new recipes, four magical powders and a selection of
+herbs of wonderful power and potency, she hobbled home as fast as she
+could, in order to test her new sorceries.
+
+So intent was Mombi on the treasures she had gained that when she
+turned the bend in the road and caught a glimpse of the man, she merely
+nodded and said:
+
+"Good evening, sir."
+
+But, a moment after, noting that the person did not move or reply,
+she cast a shrewd glance into his face and discovered his pumpkin
+head--elaborately carved by Tip's jack-knife.
+
+"Heh!" ejaculated Mombi, giving a sort of grunt; "that rascally boy
+has been playing tricks again! Very good! ve--ry _good_! I'll beat him
+black-and-blue for trying to scare me in this fashion!"
+
+Angrily she raised her stick to smash in the grinning pumpkin head of
+the dummy; but a sudden thought made her pause, the uplifted stick left
+motionless in the air.
+
+"Why, here is a good chance to try my new powder!" said she, eagerly.
+"And then I can tell whether that crooked wizard has fairly traded
+secrets, or whether he has fooled me as wickedly as I fooled him."
+
+So she set down her basket and began fumbling in it for one of the
+precious powders she had obtained.
+
+While Mombi was thus occupied Tip strolled back, with his pockets full
+of nuts, and discovered the old woman standing beside his man and
+apparently not the least bit frightened by it.
+
+At first he was greatly disappointed; but the next moment he became
+curious to know what Mombi was going to do. So he hid behind a hedge,
+where he could see without being seen, and prepared to watch.
+
+After some search the woman drew from her basket an old pepper-box,
+upon the faded label of which the wizard had written with a
+lead-pencil: "Powder of Life."
+
+"Ah--here it is!" she cried, joyfully. "And now let us see if it is
+potent. The stingy wizard didn't give me much of it, but I guess
+there's enough for two or three doses."
+
+[Illustration: "OLD MOMBI DANCED AROUND HIM"]
+
+Tip was much surprised when he overheard this speech. Then he saw old
+Mombi raise her arm and sprinkle the powder from the box over the
+pumpkin head of his man Jack. She did this in the same way one would
+pepper a baked potato, and the powder sifted down from Jack's head and
+scattered over the red shirt and pink waistcoat and purple trousers
+Tip had dressed him in, and a portion even fell upon the patched and
+worn shoes.
+
+Then, putting the pepper-box back into the basket, Mombi lifted her
+left hand, with its little finger pointed upward, and said:
+
+"Weaugh!"
+
+Then she lifted her right hand, with the thumb pointed upward, and said:
+
+"Teaugh!"
+
+Then she lifted both hands, with all the fingers and thumbs spread out,
+and cried:
+
+"Peaugh!"
+
+Jack Pumpkinhead stepped back a pace, at this, and said in a
+reproachful voice:
+
+"Don't yell like that! Do you think I'm deaf?"
+
+Old Mombi danced around him, frantic with delight.
+
+"He lives!" she screamed: "he lives! he lives!"
+
+Then she threw her stick into the air and caught it as it came down;
+and she hugged herself with both arms, and tried to do a step of a jig;
+and all the time she repeated, rapturously:
+
+"He lives!--he lives!--he lives!"
+
+Now you may well suppose that Tip observed all this with amazement.
+
+At first he was so frightened and horrified that he wanted to run
+away, but his legs trembled and shook so badly that he couldn't.
+Then it struck him as a very funny thing for Jack to come to life,
+especially as the expression on his pumpkin face was so droll and
+comical it excited laughter on the instant. So, recovering from his
+first fear, Tip began to laugh; and the merry peals reached old Mombi's
+ears and made her hobble quickly to the hedge, where she seized Tip's
+collar and dragged him back to where she had left her basket and the
+pumpkin-headed man.
+
+"You naughty, sneaking, wicked boy!" she exclaimed, furiously; "I'll
+teach you to spy out my secrets and to make fun of me!"
+
+"I wasn't making fun of you," protested Tip. "I was laughing at old
+Pumpkinhead! Look at him! Isn't he a picture, though?"
+
+"I hope you are not reflecting on my personal appearance," said Jack;
+and it was so funny to hear his grave voice, while his face continued
+to wear its jolly smile, that Tip again burst into a peal of laughter.
+
+Even Mombi was not without a curious interest in the man her magic had
+brought to life; for, after staring at him intently, she presently
+asked:
+
+[Illustration: OLD MOMBI PUTS JACK IN THE STABLE]
+
+"What do you know?"
+
+"Well, that is hard to tell," replied Jack. "For although I feel that
+I know a tremendous lot, I am not yet aware how much there is in the
+world to find out about. It will take me a little time to discover
+whether I am very wise or very foolish."
+
+"To be sure," said Mombi, thoughtfully.
+
+"But what are you going to do with him, now he is alive?" asked Tip,
+wondering.
+
+"I must think it over," answered Mombi. "But we must get home at once,
+for it is growing dark. Help the Pumpkinhead to walk."
+
+"Never mind me," said Jack; "I can walk as well as you can. Haven't I
+got legs and feet, and aren't they jointed?"
+
+"Are they?" asked the woman, turning to Tip.
+
+"Of course they are; I made 'em myself," returned the boy, with pride.
+
+So they started for the house; but when they reached the farm yard old
+Mombi led the pumpkin man to the cow stable and shut him up in an empty
+stall, fastening the door securely on the outside.
+
+"I've got to attend to you, first," she said, nodding her head at Tip.
+
+Hearing this, the boy became uneasy; for he knew Mombi had a bad and
+revengeful heart, and would not hesitate to do any evil thing.
+
+They entered the house. It was a round, dome-shaped structure, as are
+nearly all the farm houses in the Land of Oz.
+
+Mombi bade the boy light a candle, while she put her basket in a
+cupboard and hung her cloak on a peg. Tip obeyed quickly, for he was
+afraid of her.
+
+After the candle had been lighted Mombi ordered him to build a fire
+in the hearth, and while Tip was thus engaged the old woman ate her
+supper. When the flames began to crackle the boy came to her and asked
+a share of the bread and cheese; but Mombi refused him.
+
+"I'm hungry!" said Tip, in a sulky tone.
+
+"You won't be hungry long," replied Mombi, with a grim look.
+
+The boy didn't like this speech, for it sounded like a threat; but he
+happened to remember he had nuts in his pocket, so he cracked some of
+those and ate them while the woman rose, shook the crumbs from her
+apron, and hung above the fire a small black kettle.
+
+Then she measured out equal parts of milk and vinegar and poured them
+into the kettle. Next she produced several packets of herbs and
+powders and began adding a portion of each to the contents of the
+kettle. Occasionally she would draw near the candle and read from a
+yellow paper the recipe of the mess she was concocting.
+
+As Tip watched her his uneasiness increased.
+
+"What is that for?" he asked.
+
+"For you," returned Mombi, briefly.
+
+Tip wriggled around upon his stool and stared awhile at the kettle,
+which was beginning to bubble. Then he would glance at the stern and
+wrinkled features of the witch and wish he were any place but in that
+dim and smoky kitchen, where even the shadows cast by the candle upon
+the wall were enough to give one the horrors. So an hour passed away,
+during which the silence was only broken by the bubbling of the pot and
+the hissing of the flames.
+
+Finally, Tip spoke again.
+
+"Have I got to drink that stuff?" he asked, nodding toward the pot.
+
+"Yes," said Mombi.
+
+"What'll it do to me?" asked Tip.
+
+"If it's properly made," replied Mombi, "it will change or transform
+you into a marble statue."
+
+Tip groaned, and wiped the perspiration from his forehead with his
+sleeve.
+
+"I don't want to be a marble statue!" he protested.
+
+"That doesn't matter; I want you to be one," said the old woman,
+looking at him severely.
+
+"What use'll I be then?" asked Tip. "There won't be any one to work for
+you."
+
+"I'll make the Pumpkinhead work for me," said Mombi.
+
+Again Tip groaned.
+
+"Why don't you change me into a goat, or a chicken?" he asked,
+anxiously. "You can't do anything with a marble statue."
+
+"Oh, yes; I can," returned Mombi. "I'm going to plant a flower garden,
+next Spring, and I'll put you in the middle of it, for an ornament. I
+wonder I haven't thought of that before; you've been a bother to me for
+years."
+
+At this terrible speech Tip felt the beads of perspiration starting all
+over his body; but he sat still and shivered and looked anxiously at
+the kettle.
+
+"Perhaps it won't work," he muttered, in a voice that sounded weak and
+discouraged.
+
+"Oh, I think it will," answered Mombi, cheerfully. "I seldom make a
+mistake."
+
+Again there was a period of silence--a silence so long and gloomy that
+when Mombi finally lifted the kettle from the fire it was close to
+midnight.
+
+[Illustration: "I DON'T WANT TO BE A MARBLE STATUE."]
+
+"You cannot drink it until it has become quite cold," announced the
+old witch--for in spite of the law she had acknowledged practising
+witchcraft. "We must both go to bed now, and at daybreak I will call
+you and at once complete your transformation into a marble statue."
+
+With this she hobbled into her room, bearing the steaming kettle with
+her, and Tip heard her close and lock the door.
+
+The boy did not go to bed, as he had been commanded to do, but still
+sat glaring at the embers of the dying fire.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Flight of the
+    Fugitives
+]
+
+
+Tip reflected.
+
+"It's a hard thing, to be a marble statue," he thought, rebelliously,
+"and I'm not going to stand it. For years I've been a bother to her,
+she says; so she's going to get rid of me. Well, there's an easier way
+than to become a statue. No boy could have any fun forever standing in
+the middle of a flower garden! I'll run away, that's what I'll do--and
+I may as well go before she makes me drink that nasty stuff in the
+kettle."
+
+He waited until the snores of the old witch announced she was fast
+asleep, and then he arose softly and went to the cupboard to find
+something to eat.
+
+"No use starting on a journey without food," he decided, searching upon
+the narrow shelves.
+
+He found some crusts of bread; but he had to look into Mombi's basket
+to find the cheese she had brought from the village. While turning over
+the contents of the basket he came upon the pepper-box which contained
+the "Powder of Life."
+
+"I may as well take this with me," he thought, "or Mombi'll be using it
+to make more mischief with." So he put the box in his pocket, together
+with the bread and cheese.
+
+Then he cautiously left the house and latched the door behind him.
+Outside both moon and stars shone brightly, and the night seemed
+peaceful and inviting after the close and ill-smelling kitchen.
+
+"I'll be glad to get away," said Tip, softly; "for I never did like
+that old woman. I wonder how I ever came to live with her."
+
+He was walking slowly toward the road when a thought made him pause.
+
+"I don't like to leave Jack Pumpkinhead to the tender mercies of old
+Mombi," he muttered. "And Jack belongs to me, for I made him--even if
+the old witch did bring him to life."
+
+He retraced his steps to the cow-stable and opened the door of the
+stall where the pumpkin-headed man had been left.
+
+[Illustration: "TIP LED HIM ALONG THE PATH."]
+
+Jack was standing in the middle of the stall, and by the moonlight Tip
+could see he was smiling just as jovially as ever.
+
+"Come on!" said the boy, beckoning.
+
+"Where to?" asked Jack.
+
+"You'll know as soon as I do," answered Tip, smiling sympathetically
+into the pumpkin face. "All we've got to do now is to tramp."
+
+"Very well," returned Jack, and walked awkwardly out of the stable and
+into the moonlight.
+
+Tip turned toward the road and the man followed him. Jack walked with a
+sort of limp, and occasionally one of the joints of his legs would turn
+backward, instead of frontwise, almost causing him to tumble. But the
+Pumpkinhead was quick to notice this, and began to take more pains to
+step carefully; so that he met with few accidents.
+
+Tip led him along the path without stopping an instant. They could not
+go very fast, but they walked steadily; and by the time the moon sank
+away and the sun peeped over the hills they had travelled so great a
+distance that the boy had no reason to fear pursuit from the old witch.
+Moreover, he had turned first into one path, and then into another, so
+that should anyone follow them it would prove very difficult to guess
+which way they had gone, or where to seek them.
+
+[Illustration]
+
+Fairly satisfied that he had escaped--for a time, at least--being
+turned into a marble statue, the boy stopped his companion and seated
+himself upon a rock by the roadside.
+
+"Let's have some breakfast," he said.
+
+Jack Pumpkinhead watched Tip curiously, but refused to join in the
+repast.
+
+"I don't seem to be made the same way you are," he said.
+
+"I know you are not," returned Tip; "for I made you."
+
+"Oh! Did you?" asked Jack.
+
+"Certainly. And put you together. And carved your eyes and nose and
+ears and mouth," said Tip proudly. "And dressed you."
+
+Jack looked at his body and limbs critically.
+
+"It strikes me you made a very good job of it," he remarked.
+
+"Just so-so," replied Tip, modestly; for he began to see certain
+defects in the construction of his man. "If I'd known we were going to
+travel together I might have been a little more particular."
+
+"Why, then," said the Pumpkinhead, in a tone that expressed surprise,
+"you must be my creator--my parent--my father!"
+
+"Or your inventor," replied the boy with a laugh. "Yes, my son; I
+really believe I am!"
+
+"Then I owe you obedience," continued the man, "and you owe
+me--support."
+
+"That's it, exactly," declared Tip, jumping up. "So let us be off."
+
+"Where are we going?" asked Jack, when they had resumed their journey.
+
+"I'm not exactly sure," said the boy; "but I believe we are headed
+South, and that will bring us, sooner or later, to the Emerald City."
+
+"What city is that?" enquired the Pumpkinhead.
+
+"Why, it's the center of the Land of Oz, and the biggest town in all
+the country. I've never been there, myself, but I've heard all about
+its history. It was built by a mighty and wonderful Wizard named Oz,
+and everything there is of a green color--just as everything in this
+Country of the Gillikins is of a purple color."
+
+"Is everything here purple?" asked Jack.
+
+"Of course it is. Can't you see?" returned the boy.
+
+"I believe I must be color-blind," said the Pumpkinhead, after staring
+about him.
+
+"Well, the grass is purple, and the trees are purple, and the houses
+and fences are purple," explained Tip. "Even the mud in the roads is
+purple. But in the Emerald City everything is green that is purple
+here. And in the Country of the Munchkins, over at the East, everything
+is blue; and in the South country of the Quadlings everything is red;
+and in the West country of the Winkies, where the Tin Woodman rules,
+everything is yellow."
+
+"Oh!" said Jack. Then, after a pause, he asked: "Did you say a Tin
+Woodman rules the Winkies?"
+
+"Yes; he was one of those who helped Dorothy to destroy the Wicked
+Witch of the West, and the Winkies were so grateful that they invited
+him to become their ruler,--just as the people of the Emerald City
+invited the Scarecrow to rule them."
+
+"Dear me!" said Jack. "I'm getting confused with all this history. Who
+is the Scarecrow?"
+
+"Another friend of Dorothy's," replied Tip.
+
+"And who is Dorothy?"
+
+"She was a girl that came here from Kansas, a place in the big, outside
+World. She got blown to the Land of Oz by a cyclone, and while she was
+here the Scarecrow and the Tin Woodman accompanied her on her travels."
+
+"And where is she now?" inquired the Pumpkinhead.
+
+"Glinda the Good, who rules the Quadlings, sent her home again," said
+the boy.
+
+"Oh. And what became of the Scarecrow?"
+
+"I told you. He rules the Emerald City," answered Tip.
+
+"I thought you said it was ruled by a wonderful Wizard," objected Jack,
+seeming more and more confused.
+
+"Well, so I did. Now, pay attention, and I'll explain it," said Tip,
+speaking slowly and looking the smiling Pumpkinhead squarely in the
+eye. "Dorothy went to the Emerald City to ask the Wizard to send her
+back to Kansas; and the Scarecrow and the Tin Woodman went with her.
+But the Wizard couldn't send her back, because he wasn't so much of a
+Wizard as he might have been. And then they got angry at the Wizard,
+and threatened to expose him; so the Wizard made a big balloon and
+escaped in it, and no one has ever seen him since."
+
+"Now, that is very interesting history," said Jack, well pleased; "and
+I understand it perfectly--all but the explanation."
+
+"I'm glad you do," responded Tip. "After the Wizard was gone, the
+people of the Emerald City made His Majesty, the Scarecrow, their King;
+and I have heard that he became a very popular ruler."
+
+"Are we going to see this queer King?" asked Jack, with interest.
+
+"I think we may as well," replied the boy; "unless you have something
+better to do."
+
+"Oh, no, dear father," said the Pumpkinhead. "I am quite willing to go
+wherever you please."
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Makes an
+    Experiment in Magic
+]
+
+
+The boy, small and rather delicate in appearance, seemed somewhat
+embarrassed at being called "father" by the tall, awkward,
+pumpkin-headed man; but to deny the relationship would involve another
+long and tedious explanation; so he changed the subject by asking,
+abruptly:
+
+"Are you tired?"
+
+"Of course not!" replied the other. "But," he continued, after a pause,
+"it is quite certain I shall wear out my wooden joints if I keep on
+walking."
+
+Tip reflected, as they journeyed on, that this was true. He began to
+regret that he had not constructed the wooden limbs more carefully and
+substantially. Yet how could he ever have guessed that the man he had
+made merely to scare old Mombi with would be brought to life by means
+of a magical powder contained in an old pepper-box?
+
+So he ceased to reproach himself, and began to think how he might yet
+remedy the deficiencies of Jack's weak joints.
+
+While thus engaged they came to the edge of a wood, and the boy sat
+down to rest upon an old saw-horse that some woodcutter had left there.
+
+[Illustration]
+
+"Why don't you sit down?" he asked the Pumpkinhead.
+
+"Won't it strain my joints?" inquired the other.
+
+"Of course not. It'll rest them," declared the boy.
+
+So Jack tried to sit down; but as soon as he bent his joints farther
+than usual they gave way altogether, and he came clattering to the
+ground with such a crash that Tip feared he was entirely ruined.
+
+He rushed to the man, lifted him to his feet, straightened his arms and
+legs, and felt of his head to see if by chance it had become cracked.
+But Jack seemed to be in pretty good shape, after all, and Tip said to
+him:
+
+"I guess you'd better remain standing, hereafter. It seems the safest
+way."
+
+"Very well, dear father; just as you say," replied the smiling Jack,
+who had been in no wise confused by his tumble.
+
+Tip sat down again. Presently the Pumpkinhead asked:
+
+"What is that thing you are sitting on?"
+
+"Oh, this is a horse," replied the boy, carelessly.
+
+"What is a horse?" demanded Jack.
+
+"A horse? Why, there are two kinds of horses," returned Tip, slightly
+puzzled how to explain. "One kind of horse is alive, and has four legs
+and a head and a tail. And people ride upon its back."
+
+"I understand," said Jack, cheerfully. "That's the kind of horse you
+are now sitting on."
+
+"No, it isn't," answered Tip, promptly.
+
+"Why not? That one has four legs, and a head, and a tail."
+
+Tip looked at the saw-horse more carefully, and found that the
+Pumpkinhead was right. The body had been formed from a tree-trunk, and
+a branch had been left sticking up at one end that looked very much
+like a tail. In the other end were two big knots that resembled eyes,
+and a place had been chopped away that might easily be mistaken for the
+horse's mouth. As for the legs, they were four straight limbs cut from
+trees and stuck fast into the body, being spread wide apart so that the
+saw-horse would stand firmly when a log was laid across it to be sawed.
+
+"This thing resembles a real horse more than I imagined," said Tip,
+trying to explain. "But a real horse is alive, and trots and prances
+and eats oats, while this is nothing more than a dead horse, made of
+wood, and used to saw logs upon."
+
+"If it were alive, wouldn't it trot, and prance, and eat oats?"
+inquired the Pumpkinhead.
+
+"It would trot and prance, perhaps; but it wouldn't eat oats," replied
+the boy, laughing at the idea. "And of course it can't ever be alive,
+because it is made of wood."
+
+"So am I," answered the man.
+
+Tip looked at him in surprise.
+
+"Why, so you are!" he exclaimed. "And the magic powder that brought you
+to life is here in my pocket."
+
+[Illustration: THE MAGICAL POWDER OF LIFE]
+
+He brought out the pepper box, and eyed it curiously.
+
+"I wonder," said he, musingly, "if it would bring the saw-horse to
+life."
+
+"If it would," returned Jack, calmly--for nothing seemed to surprise
+him--"I could ride on its back, and that would save my joints from
+wearing out."
+
+"I'll try it!" cried the boy, jumping up. "But I wonder if I can
+remember the words old Mombi said, and the way she held her hands up."
+
+He thought it over for a minute, and as he had watched carefully from
+the hedge every motion of the old witch, and listened to her words, he
+believed he could repeat exactly what she had said and done.
+
+So he began by sprinkling some of the magic Powder of Life from the
+pepper-box upon the body of the saw-horse. Then he lifted his left
+hand, with the little finger pointing upward, and said "Weaugh!"
+
+"What does that mean, dear father?" asked Jack, curiously.
+
+"I don't know," answered Tip. Then he lifted his right hand, with the
+thumb pointing upward, and said: "Teaugh!"
+
+"What's that, dear father?" inquired Jack.
+
+"It means you must keep quiet!" replied the boy, provoked at being
+interrupted at so important a moment.
+
+"How fast I am learning!" remarked the Pumpkinhead, with his eternal
+smile.
+
+Tip now lifted both hands above his head, with all the fingers and
+thumbs spread out, and cried in a loud voice: "Peaugh!"
+
+Immediately the saw-horse moved, stretched its legs, yawned with its
+chopped-out mouth, and shook a few grains of the powder off its back.
+The rest of the powder seemed to have vanished into the body of the
+horse.
+
+"Good!" called Jack, while the boy looked on in astonishment. "You are
+a very clever sorcerer, dear father!"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Awakening
+    of the Saw-Horse
+]
+
+
+The Saw-Horse, finding himself alive, seemed even more astonished
+than Tip. He rolled his knotty eyes from side to side, taking a first
+wondering view of the world in which he had now so important an
+existence. Then he tried to look at himself; but he had, indeed, no
+neck to turn; so that in the endeavor to see his body he kept circling
+around and around, without catching even a glimpse of it. His legs
+were stiff and awkward, for there were no knee-joints in them; so that
+presently he bumped against Jack Pumpkinhead and sent that personage
+tumbling upon the moss that lined the roadside.
+
+Tip became alarmed at this accident, as well as at the persistence of
+the Saw-Horse in prancing around in a circle; so he called out:
+
+"Whoa! Whoa, there!"
+
+The Saw-Horse paid no attention whatever to this command, and the next
+instant brought one of his wooden legs down upon Tip's foot so forcibly
+that the boy danced away in pain to a safer distance, from where he
+again yelled:
+
+"Whoa! Whoa, I say!"
+
+Jack had now managed to raise himself to a sitting position, and he
+looked at the Saw-Horse with much interest.
+
+"I don't believe the animal can hear you," he remarked.
+
+"I shout loud enough, don't I?" answered Tip, angrily.
+
+"Yes; but the horse has no ears," said the smiling Pumpkinhead.
+
+"Sure enough!" exclaimed Tip, noting the fact for the first time. "How,
+then, am I going to stop him?"
+
+But at that instant the Saw-Horse stopped himself, having concluded it
+was impossible to see his own body. He saw Tip, however, and came close
+to the boy to observe him more fully.
+
+It was really comical to see the creature walk; for it moved the legs
+on its right side together, and those on its left side together, as a
+pacing horse does; and that made its body rock sidewise, like a cradle.
+
+Tip patted it upon the head, and said "Good boy! Good boy!" in a
+coaxing tone; and the Saw-Horse pranced away to examine with its
+bulging eyes the form of Jack Pumpkinhead.
+
+"I must find a halter for him," said Tip; and having made a search
+in his pocket he produced a roll of strong cord. Unwinding this,
+he approached the Saw-Horse and tied the cord around its neck,
+afterward fastening the other end to a large tree. The Saw-Horse, not
+understanding the action, stepped backward and snapped the string
+easily; but it made no attempt to run away.
+
+"He's stronger than I thought," said the boy, "and rather obstinate,
+too."
+
+"Why don't you make him some ears?" asked Jack. "Then you can tell him
+what to do."
+
+"That's a splendid idea!" said Tip. "How did you happen to think of it?"
+
+"Why, I didn't think of it," answered the Pumpkinhead; "I didn't need
+to, for it's the simplest and easiest thing to do."
+
+So Tip got out his knife and fashioned some ears out of the bark of a
+small tree.
+
+"I mustn't make them too big," he said, as he whittled, "or our horse
+would become a donkey."
+
+"How is that?" inquired Jack, from the roadside.
+
+"Why, a horse has bigger ears than a man; and a donkey has bigger ears
+than a horse," explained Tip.
+
+"Then, if my ears were longer, would I be a horse?" asked Jack.
+
+"My friend," said Tip, gravely, "you'll never be anything but a
+Pumpkinhead, no matter how big your ears are."
+
+"Oh," returned Jack, nodding; "I think I understand."
+
+"If you do, you're a wonder," remarked the boy; "but there's no harm in
+_thinking_ you understand. I guess these ears are ready now. Will you
+hold the horse while I stick them on?"
+
+"Certainly, if you'll help me up," said Jack.
+
+So Tip raised him to his feet, and the Pumpkinhead went to the horse
+and held its head while the boy bored two holes in it with his
+knife-blade and inserted the ears.
+
+"They make him look very handsome," said Jack, admiringly.
+
+But those words, spoken close to the Saw-Horse, and being the first
+sounds he had ever heard, so startled the animal that he made a bound
+forward and tumbled Tip on one side and Jack on the other. Then he
+continued to rush forward as if frightened by the clatter of his own
+footsteps.
+
+"Whoa!" shouted Tip, picking himself up; "whoa! you idiot--whoa!"
+
+The Saw-Horse would probably have paid no attention to this, but just
+then it stepped a leg into a gopher-hole and stumbled head-over-heels
+to the ground, where it lay upon its back, frantically waving its four
+legs in the air.
+
+Tip ran up to it.
+
+"You're a nice sort of a horse, I must say!" he exclaimed. "Why didn't
+you stop when I yelled 'whoa?'"
+
+"Does 'whoa' mean to stop?" asked the Saw-Horse, in a surprised voice,
+as it rolled its eyes upward to look at the boy.
+
+"Of course it does," answered Tip.
+
+"And a hole in the ground means to stop, also, doesn't it?" continued
+the horse.
+
+"To be sure; unless you step over it," said Tip.
+
+"What a strange place this is," the creature exclaimed, as if amazed.
+"What am I doing here, anyway?"
+
+[Illustration: "DO KEEP THOSE LEGS STILL."]
+
+"Why, I've brought you to life," answered the boy; "but it won't hurt
+you any, if you mind me and do as I tell you."
+
+"Then I will do as you tell me," replied the Saw-Horse, humbly. "But
+what happened to me, a moment ago? I don't seem to be just right,
+someway."
+
+"You're upside down," explained Tip. "But just keep those legs still a
+minute and I'll set you right side up again."
+
+"How many sides have I?" asked the creature, wonderingly.
+
+"Several," said Tip, briefly. "But do keep those legs still."
+
+The Saw-Horse now became quiet, and held its legs rigid; so that Tip,
+after several efforts, was able to roll him over and set him upright.
+
+"Ah, I seem all right now," said the queer animal, with a sigh.
+
+"One of your ears is broken," Tip announced, after a careful
+examination. "I'll have to make a new one."
+
+Then he led the Saw-Horse back to where Jack was vainly struggling to
+regain his feet, and after assisting the Pumpkinhead to stand upright
+Tip whittled out a new ear and fastened it to the horse's head.
+
+"Now," said he, addressing his steed, "pay attention to what I'm going
+to tell you. 'Whoa!' means to stop; 'Get-Up!' means to walk forward;
+'Trot!' means to go as fast as you can. Understand?"
+
+"I believe I do," returned the horse.
+
+"Very good. We are all going on a journey to the Emerald City, to see
+His Majesty, the Scarecrow; and Jack Pumpkinhead is going to ride on
+your back, so he won't wear out his joints."
+
+"I don't mind," said the Saw-Horse. "Anything that suits you suits me."
+
+Then Tip assisted Jack to get upon the horse.
+
+"Hold on tight," he cautioned, "or you may fall off and crack your
+pumpkin head."
+
+"That would be horrible!" said Jack, with a shudder. "What shall I hold
+on to?"
+
+"Why, hold on to his ears," replied Tip, after a moment's hesitation.
+
+"Don't do that!" remonstrated the Saw-Horse; "for then I can't hear."
+
+That seemed reasonable, so Tip tried to think of something else.
+
+"I'll fix it!" said he, at length. He went into the wood and cut a
+short length of limb from a young, stout tree. One end of this he
+sharpened to a point, and then he dug a hole in the back of the
+Saw-Horse, just behind its head. Next he brought a piece of rock from
+the road and hammered the post firmly into the animal's back.
+
+[Illustration: "DOES IT HURT?" ASKED THE BOY.]
+
+"Stop! Stop!" shouted the horse; "you're jarring me terribly."
+
+"Does it hurt?" asked the boy.
+
+"Not exactly hurt," answered the animal; "but it makes me quite nervous
+to be jarred."
+
+"Well, it's all over now," said Tip, encouragingly. "Now, Jack, be sure
+to hold fast to this post, and then you can't fall off and get smashed."
+
+So Jack held on tight, and Tip said to the horse:
+
+"Get-up."
+
+The obedient creature at once walked forward, rocking from side to side
+as he raised his feet from the ground.
+
+Tip walked beside the Saw-Horse, quite content with this addition to
+their party. Presently he began to whistle.
+
+"What does that sound mean?" asked the horse.
+
+"Don't pay any attention to it," said Tip. "I'm just whistling, and
+that only means I'm pretty well satisfied."
+
+"I'd whistle myself, if I could push my lips together," remarked Jack.
+"I fear, dear father, that in some respects I am sadly lacking."
+
+After journeying on for some distance the narrow path they were
+following turned into a broad road-way, paved with yellow brick. By the
+side of the road Tip noticed a sign-post that read:
+
+"NINE MILES TO THE EMERALD CITY."
+
+But it was now growing dark, so he decided to camp for the night by the
+roadside and to resume the journey next morning by daybreak. He led the
+Saw-Horse to a grassy mound upon which grew several bushy trees, and
+carefully assisted the Pumpkinhead to alight.
+
+"I think I'll lay you upon the ground, overnight," said the boy. "You
+will be safer that way."
+
+"How about me?" asked the Saw-Horse.
+
+"It won't hurt you to stand," replied Tip; "and, as you can't sleep,
+you may as well watch out and see that no one comes near to disturb us."
+
+Then the boy stretched himself upon the grass beside the Pumpkinhead,
+and being greatly wearied by the journey was soon fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Jack Pumpkinhead's Ride
+    to the Emerald City
+]
+
+
+At daybreak Tip was awakened by the Pumpkinhead. He rubbed the sleep
+from his eyes, bathed in a little brook, and then ate a portion of his
+bread and cheese. Having thus prepared for a new day the boy said:
+
+"Let us start at once. Nine miles is quite a distance, but we ought to
+reach the Emerald City by noon if no accidents happen."
+
+So the Pumpkinhead was again perched upon the back of the Saw-Horse and
+the journey was resumed.
+
+Tip noticed that the purple tint of the grass and trees had now faded
+to a dull lavender, and before long this lavender appeared to take on
+a greenish tinge that gradually brightened as they drew nearer to the
+great City where the Scarecrow ruled.
+
+The little party had traveled but a short two miles upon their way when
+the road of yellow brick was parted by a broad and swift river. Tip was
+puzzled how to cross over; but after a time he discovered a man in a
+ferry-boat approaching from the other side of the stream.
+
+When the man reached the bank Tip asked:
+
+"Will you row us to the other side?"
+
+"Yes, if you have money," returned the ferryman, whose face looked
+cross and disagreeable.
+
+"But I have no money," said Tip.
+
+"None at all?" inquired the man.
+
+"None at all," answered the boy.
+
+"Then I'll not break my back rowing you over," said the ferryman,
+decidedly.
+
+"What a nice man!" remarked the Pumpkinhead, smilingly.
+
+The ferryman stared at him, but made no reply. Tip was trying to
+think, for it was a great disappointment to him to find his journey so
+suddenly brought to an end.
+
+"I must certainly get to the Emerald City," he said to the boatman;
+"but how can I cross the river if you do not take me?"
+
+The man laughed, and it was not a nice laugh.
+
+"That wooden horse will float," said he; "and you can ride him across.
+As for the pumpkin-headed loon who accompanies you, let him sink or
+swim--it won't matter greatly which."
+
+[Illustration]
+
+"Don't worry about me," said Jack, smiling pleasantly upon the crabbed
+ferryman; "I'm sure I ought to float beautifully."
+
+Tip thought the experiment was worth making, and the Saw-Horse, who did
+not know what danger meant, offered no objections whatever. So the boy
+led it down into the water and climbed upon its back. Jack also waded
+in up to his knees and grasped the tail of the horse so that he might
+keep his pumpkin head above the water.
+
+"Now," said Tip, instructing the Saw-Horse, "if you wiggle your legs
+you will probably swim; and if you swim we shall probably reach the
+other side."
+
+The Saw-Horse at once began to wiggle its legs, which acted as oars and
+moved the adventurers slowly across the river to the opposite side.
+So successful was the trip that presently they were climbing, wet and
+dripping, up the grassy bank.
+
+Tip's trouser-legs and shoes were thoroughly soaked; but the Saw-Horse
+had floated so perfectly that from his knees up the boy was entirely
+dry. As for the Pumpkinhead, every stitch of his gorgeous clothing
+dripped water.
+
+"The sun will soon dry us," said Tip; "and, anyhow, we are now safely
+across, in spite of the ferryman, and can continue our journey."
+
+"I didn't mind swimming, at all," remarked the horse.
+
+"Nor did I," added Jack.
+
+They soon regained the road of yellow brick, which proved to be a
+continuation of the road they had left on the other side, and then Tip
+once more mounted the Pumpkinhead upon the back of the Saw-Horse.
+
+"If you ride fast," said he, "the wind will help to dry your clothing.
+I will hold on to the horse's tail and run after you. In this way we
+all will become dry in a very short time."
+
+"Then the horse must step lively," said Jack.
+
+"I'll do my best," returned the Saw-Horse, cheerfully.
+
+Tip grasped the end of the branch that served as tail to the Saw-Horse,
+and called loudly: "Get-up!"
+
+The horse started at a good pace, and Tip followed behind. Then he
+decided they could go faster, so he shouted: "Trot!"
+
+[Illustration]
+
+Now, the Saw-Horse remembered that this word was the command to go as
+fast as he could; so he began rocking along the road at a tremendous
+pace, and Tip had hard work--running faster than he ever had before in
+his life--to keep his feet.
+
+Soon he was out of breath, and although he wanted to call "Whoa!" to
+the horse, he found he could not get the word out of his throat. Then
+the end of the tail he was clutching, being nothing more than a dead
+branch, suddenly broke away, and the next minute the boy was rolling
+in the dust of the road, while the horse and its pumpkin-headed rider
+dashed on and quickly disappeared in the distance.
+
+By the time Tip had picked himself up and cleared the dust from his
+throat so he could say "Whoa!" there was no further need of saying it,
+for the horse was long since out of sight.
+
+So he did the only sensible thing he could do. He sat down and took a
+good rest, and afterward began walking along the road.
+
+"Some time I will surely overtake them," he reflected; "for the road
+will end at the gates of the Emerald City, and they can go no further
+than that."
+
+Meantime Jack was holding fast to the post and the Saw-Horse was
+tearing along the road like a racer. Neither of them knew Tip was left
+behind, for the Pumpkinhead did not look around and the Saw-Horse
+couldn't.
+
+As he rode, Jack noticed that the grass and trees had become a bright
+emerald-green in color, so he guessed they were nearing the Emerald
+City even before the tall spires and domes came into sight.
+
+At length a high wall of green stone, studded thick with emeralds,
+loomed up before them; and fearing the Saw-Horse would not know enough
+to stop and so might smash them both against this wall, Jack ventured
+to cry "Whoa!" as loud as he could.
+
+So suddenly did the horse obey that had it not been for his post Jack
+would have been pitched off head foremost, and his beautiful face
+ruined.
+
+"That was a fast ride, dear father!" he exclaimed; and then, hearing no
+reply, he turned around and discovered for the first time that Tip was
+not there.
+
+This apparent desertion puzzled the Pumpkinhead, and made him uneasy.
+And while he was wondering what had become of the boy, and what he
+ought to do next under such trying circumstances, the gateway in the
+green wall opened and a man came out.
+
+This man was short and round, with a fat face that seemed remarkably
+good-natured. He was clothed all in green and wore a high, peaked green
+hat upon his head and green spectacles over his eyes. Bowing before the
+Pumpkinhead he said:
+
+"I am the Guardian of the Gates of the Emerald City. May I inquire who
+you are, and what is your business?"
+
+"My name is Jack Pumpkinhead," returned the other, smilingly; "but as
+to my business, I haven't the least idea in the world what it is."
+
+The Guardian of the Gates looked surprised, and shook his head as if
+dissatisfied with the reply.
+
+"What are you, a man or a pumpkin?" he asked, politely.
+
+"Both, if you please," answered Jack.
+
+"And this wooden horse--is it alive?" questioned the Guardian.
+
+The horse rolled one knotty eye upward and winked at Jack. Then it gave
+a prance and brought one leg down on the Guardian's toes.
+
+"Ouch!" cried the man; "I'm sorry I asked that question. But the answer
+is most convincing. Have you any errand, sir, in the Emerald City?"
+
+"It seems to me that I have," replied the Pumpkinhead, seriously; "but
+I cannot think what it is. My father knows all about it, but he is not
+here."
+
+"This is a strange affair--very strange!" declared the Guardian. "But
+you seem harmless. Folks do not smile so delightfully when they mean
+mischief."
+
+"As for that," said Jack, "I cannot help my smile, for it is carved on
+my face with a jack-knife."
+
+"Well, come with me into my room," resumed the Guardian, "and I will
+see what can be done for you."
+
+So Jack rode the Saw-Horse through the gate-way into a little room
+built into the wall. The Guardian pulled a bell-cord, and presently
+a very tall soldier--clothed in a green uniform--entered from the
+opposite door. This soldier carried a long green gun over his shoulder
+and had lovely green whiskers that fell quite to his knees. The
+Guardian at once addressed him, saying:
+
+"Here is a strange gentleman who doesn't know why he has come to the
+Emerald City, or what he wants. Tell me, what shall we do with him?"
+
+The Soldier with the Green Whiskers looked at Jack with much care and
+curiosity. Finally he shook his head so positively that little waves
+rippled down his whiskers, and then he said:
+
+"I must take him to His Majesty, the Scarecrow."
+
+"But what will His Majesty, the Scarecrow, do with him?" asked the
+Guardian of the Gates.
+
+"That is His Majesty's business," returned the soldier. "I have
+troubles enough of my own. All outside troubles must be turned over to
+His Majesty. So put the spectacles on this fellow, and I'll take him to
+the royal palace."
+
+So the Guardian opened a big box of spectacles and tried to fit a pair
+to Jack's great round eyes.
+
+"I haven't a pair in stock that will really cover those eyes up," said
+the little man, with a sigh; "and your head is so big that I shall be
+obliged to tie the spectacles on."
+
+"But why need I wear spectacles?" asked Jack.
+
+"It's the fashion here," said the Soldier, "and they will keep you from
+being blinded by the glitter and glare of the gorgeous Emerald City."
+
+"Oh!" exclaimed Jack. "Tie them on, by all means. I don't wish to be
+blinded."
+
+"Nor I!" broke in the Saw-Horse; so a pair of green spectacles was
+quickly fastened over the bulging knots that served it for eyes.
+
+Then the Soldier with the Green Whiskers led them through the inner
+gate and they at once found themselves in the main street of the
+magnificent Emerald City.
+
+Sparkling green gems ornamented the fronts of the beautiful houses and
+the towers and turrets were all faced with emeralds. Even the green
+marble pavement glittered with precious stones, and it was indeed a
+grand and marvelous sight to one who beheld it for the first time.
+
+However, the Pumpkinhead and the Saw-Horse, knowing nothing of wealth
+and beauty, paid little attention to the wonderful sights they saw
+through their green spectacles. They calmly followed after the green
+soldier and scarcely noticed the crowds of green people who stared
+at them in surprise. When a green dog ran out and barked at them the
+Saw-Horse promptly kicked at it with its wooden leg and sent the little
+animal howling into one of the houses; but nothing more serious than
+this happened to interrupt their progress to the royal palace.
+
+The Pumpkinhead wanted to ride up the green marble steps and straight
+into the Scarecrow's presence; but the soldier would not permit that.
+So Jack dismounted, with much difficulty, and a servant led the
+Saw-Horse around to the rear while the Soldier with the Green Whiskers
+escorted the Pumpkinhead into the palace, by the front entrance.
+
+The stranger was left in a handsomely furnished waiting room while the
+soldier went to announce him. It so happened that at this hour His
+Majesty was at leisure and greatly bored for want of something to do,
+so he ordered his visitor to be shown at once into his throne room.
+
+Jack felt no fear or embarrassment at meeting the ruler of this
+magnificent city, for he was entirely ignorant of all worldly customs.
+But when he entered the room and saw for the first time His Majesty
+the Scarecrow seated upon his glittering throne, he stopped short in
+amazement.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    His majesty the Scarecrow
+]
+
+
+I suppose every reader of this book knows what a scarecrow is; but Jack
+Pumpkinhead, never having seen such a creation, was more surprised at
+meeting the remarkable King of the Emerald City than by any other one
+experience of his brief life.
+
+His Majesty the Scarecrow was dressed in a suit of faded blue clothes,
+and his head was merely a small sack stuffed with straw, upon which
+eyes, ears, a nose and a mouth had been rudely painted to represent a
+face. The clothes were also stuffed with straw, and that so unevenly
+or carelessly that his Majesty's legs and arms seemed more bumpy
+than was necessary. Upon his hands were gloves with long fingers,
+and these were padded with cotton. Wisps of straw stuck out from the
+monarch's coat and also from his neck and boot-tops. Upon his head
+he wore a heavy golden crown set thick with sparkling jewels, and
+the weight of this crown caused his brow to sag in wrinkles, giving
+a thoughtful expression to the painted face. Indeed, the crown alone
+betokened majesty; in all else the Scarecrow King was but a simple
+scarecrow--flimsy, awkward, and unsubstantial.
+
+But if the strange appearance of his Majesty the Scarecrow seemed
+startling to Jack, no less wonderful was the form of the Pumpkinhead
+to the Scarecrow. The purple trousers and pink waistcoat and red
+shirt hung loosely over the wooden joints Tip had manufactured, and
+the carved face on the pumpkin grinned perpetually, as if its wearer
+considered life the jolliest thing imaginable.
+
+At first, indeed, His Majesty thought his queer visitor was laughing at
+him, and was inclined to resent such a liberty; but it was not without
+reason that the Scarecrow had attained the reputation of being the
+wisest personage in the Land of Oz. He made a more careful examination
+of his visitor, and soon discovered that Jack's features were carved
+into a smile and that he could not look grave if he wished to.
+
+The King was the first to speak. After regarding
+
+[Illustration]
+
+Jack for some minutes he said, in a tone of wonder:
+
+"Where on earth did you come from, and how do you happen to be alive?"
+
+"I beg your Majesty's pardon," returned the Pumpkinhead; "but I do not
+understand you."
+
+"What don't you understand?" asked the Scarecrow.
+
+"Why, I don't understand your language. You see, I came from the
+Country of the Gillikins, so that I am a foreigner."
+
+"Ah, to be sure!" exclaimed the Scarecrow. "I myself speak the language
+of the Munchkins, which is also the language of the Emerald City. But
+you, I suppose, speak the language of the Pumpkinheads?"
+
+"Exactly so, your Majesty," replied the other, bowing; "so it will be
+impossible for us to understand one another."
+
+"That is unfortunate, certainly," said the Scarecrow, thoughtfully. "We
+must have an interpreter."
+
+"What is an interpreter?" asked Jack.
+
+"A person who understands both my language and your own. When I say
+anything, the interpreter can tell you what I mean; and when you
+say anything the interpreter can tell me what _you_ mean. For the
+interpreter can speak both languages as well as understand them."
+
+"That is certainly clever," said Jack, greatly pleased at finding so
+simple a way out of the difficulty.
+
+So the Scarecrow commanded the Soldier with the Green Whiskers to
+search among his people until he found one who understood the language
+of the Gillikins as well as the language of the Emerald City, and to
+bring that person to him at once.
+
+When the Soldier had departed the Scarecrow said:
+
+"Won't you take a chair while we are waiting?"
+
+"Your Majesty forgets that I cannot understand you," replied the
+Pumpkinhead. "If you wish me to sit down you must make a sign for me to
+do so."
+
+The Scarecrow came down from his throne and rolled an armchair to a
+position behind the Pumpkinhead. Then he gave Jack a sudden push that
+sent him sprawling upon the cushions in so awkward a fashion that he
+doubled up like a jack-knife, and had hard work to untangle himself.
+
+"Did you understand that sign?" asked His Majesty, politely.
+
+"Perfectly," declared Jack, reaching up his arms to turn his head
+to the front, the pumpkin having twisted around upon the stick that
+supported it.
+
+"You seem hastily made," remarked the Scarecrow, watching Jack's
+efforts to straighten himself.
+
+"Not more so than your Majesty," was the frank reply.
+
+"There is this difference between us," said the Scarecrow, "that
+whereas I will bend, but not break, you will break, but not bend."
+
+[Illustration: "HE GAVE JACK A SUDDEN PUSH."]
+
+At this moment the soldier returned leading a young girl by the hand.
+She seemed very sweet and modest, having a pretty face and beautiful
+green eyes and hair. A dainty green silk skirt reached to her knees,
+showing silk stockings embroidered with pea-pods, and green satin
+slippers with bunches of lettuce for decorations instead of bows or
+buckles. Upon her silken waist clover leaves were embroidered, and
+she wore a jaunty little jacket trimmed with sparkling emeralds of a
+uniform size.
+
+"Why, it's little Jellia Jamb!" exclaimed the Scarecrow, as the green
+maiden bowed her pretty head before him. "Do you understand the
+language of the Gillikins, my dear?"
+
+"Yes, your Majesty," she answered, "for I was born in the North
+Country."
+
+"Then you shall be our interpreter," said the Scarecrow, "and explain
+to this Pumpkinhead all that I say, and also explain to me all that
+_he_ says. Is this arrangement satisfactory?" he asked, turning toward
+his guest.
+
+"Very satisfactory indeed," was the reply.
+
+"Then ask him, to begin with," resumed the Scarecrow, turning to
+Jellia, "what brought him to the Emerald City."
+
+But instead of this the girl, who had been staring at Jack, said to
+him:
+
+"You are certainly a wonderful creature. Who made you?"
+
+"A boy named Tip," answered Jack.
+
+"What does he say?" inquired the Scarecrow. "My ears must have deceived
+me. What did he say?"
+
+"He says that your Majesty's brains seem to have come loose," replied
+the girl, demurely.
+
+The Scarecrow moved uneasily upon his throne, and felt of his head with
+his left hand.
+
+"What a fine thing it is to understand two different languages," he
+said, with a perplexed sigh. "Ask him, my dear, if he has any objection
+to being put in jail for insulting the ruler of the Emerald City.
+
+"I didn't insult you!" protested Jack, indignantly.
+
+"Tut--tut!" cautioned the Scarecrow; "wait until Jellia translates my
+speech. What have we got an interpreter for, if you break out in this
+rash way?"
+
+"All right, I'll wait," replied the Pumpkinhead, in a surly
+tone--although his face smiled as genially as ever. "Translate the
+speech, young woman."
+
+"His Majesty inquires if you are hungry," said Jellia.
+
+"Oh, not at all!" answered Jack, more pleasantly. "for it is impossible
+for me to eat."
+
+"It's the same way with me," remarked the Scarecrow. "What did he say,
+Jellia, my dear?"
+
+"He asked if you were aware that one of your eyes is painted larger
+than the other," said the girl, mischievously.
+
+"Don't you believe her, your Majesty," cried Jack.
+
+"Oh, I don't," answered the Scarecrow, calmly. Then, casting a sharp
+look at the girl, he asked:
+
+"Are you quite certain you understand the languages of both the
+Gillikins and the Munchkins?"
+
+"Quite certain, your Majesty," said Jellia Jamb, trying hard not to
+laugh in the face of royalty.
+
+"Then how is it that I seem to understand them myself?" inquired the
+Scarecrow.
+
+"Because they are one and the same!" declared the girl, now laughing
+merrily. "Does not your Majesty know that in all the land of Oz but one
+language is spoken?"
+
+"Is it indeed so?" cried the Scarecrow, much relieved to hear this;
+"then I might easily have been my own interpreter!"
+
+"It was all my fault, your Majesty," said Jack, looking rather foolish,
+"I thought we must surely speak different languages, since we came from
+different countries."
+
+"This should be a warning to you never to think," returned the
+Scarecrow, severely. "For unless one can think wisely it is better to
+remain a dummy--which you most certainly are."
+
+"I am!--I surely am!" agreed the Pumpkinhead.
+
+"It seems to me," continued the Scarecrow, more mildly, "that your
+manufacturer spoiled some good pies to create an indifferent man."
+
+"I assure your Majesty that I did not ask to be created," answered Jack.
+
+"Ah! It was the same in my case," said the King, pleasantly. "And so,
+as we differ from all ordinary people, let us become friends."
+
+"With all my heart!" exclaimed Jack.
+
+"What! Have you a heart?" asked the Scarecrow, surprised.
+
+"No; that was only imaginative--I might say, a figure of speech," said
+the other.
+
+"Well, your most prominent figure seems to be a figure of wood; so I
+must beg you to restrain an imagination which, having no brains, you
+have no right to exercise," suggested the Scarecrow, warningly.
+
+"To be sure!" said Jack, without in the least comprehending.
+
+His Majesty then dismissed Jellia Jamb and the Soldier with the Green
+Whiskers, and when they were gone he took his new friend by the arm and
+led him into the courtyard to play a game of quoits.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Gen. Jinjur's Army
+    of Revolt
+]
+
+
+Tip was so anxious to rejoin his man Jack and the Saw-Horse that he
+walked a full half the distance to the Emerald City without stopping to
+rest. Then he discovered that he was hungry and the crackers and cheese
+he had provided for the journey had all been eaten.
+
+While wondering what he should do in this emergency he came upon a
+girl sitting by the roadside. She wore a costume that struck the boy
+as being remarkably brilliant: her silken waist being of emerald green
+and her skirt of four distinct colors--blue in front, yellow at the
+left side, red at the back and purple at the right side. Fastening the
+waist in front were four buttons--the top one blue, the next yellow, a
+third red and the last purple.
+
+[Illustration]
+
+The splendor of this dress was almost barbaric; so Tip was fully
+justified in staring at the gown for some moments before his eyes
+were attracted by the pretty face above it. Yes, the face was pretty
+enough, he decided; but it wore an expression of discontent coupled to
+a shade of defiance or audacity.
+
+While the boy stared the girl looked upon him calmly. A lunch basket
+stood beside her, and she held a dainty sandwich in one hand and a
+hard-boiled egg in the other, eating with an evident appetite that
+aroused Tip's sympathy.
+
+He was just about to ask a share of the luncheon when the girl stood up
+and brushed the crumbs from her lap.
+
+"There!" said she; "it is time for me to go. Carry that basket for me
+and help yourself to its contents if you are hungry."
+
+Tip seized the basket eagerly and began to eat, following for a time
+the strange girl without bothering to ask questions. She walked along
+before him with swift strides, and there was about her an air of
+decision and importance that led him to suspect she was some great
+personage.
+
+Finally, when he had satisfied his hunger, he ran up beside her and
+tried to keep pace with her swift footsteps--a very difficult feat, for
+she was much taller than he, and evidently in a hurry.
+
+"Thank you very much for the sandwiches," said Tip, as he trotted
+along. "May I ask your name?"
+
+"I am General Jinjur," was the brief reply.
+
+"Oh!" said the boy, surprised. "What sort of a General?"
+
+"I command the Army of Revolt in this war," answered the General, with
+unnecessary sharpness.
+
+"Oh!" he again exclaimed. "I didn't know there was a war."
+
+"You were not supposed to know it," she returned, "for we have kept it
+a secret; and considering that our army is composed entirely of girls,"
+she added, with some pride, "it is surely a remarkable thing that our
+Revolt is not yet discovered."
+
+"It is, indeed," acknowledged Tip. "But where is your army?"
+
+"About a mile from here," said General Jinjur. "The forces have
+assembled from all parts of the Land of Oz, at my express command. For
+this is the day we are to conquer His Majesty the Scarecrow, and wrest
+from him the throne. The Army of Revolt only awaits my coming to march
+upon the Emerald City."
+
+"Well!" declared Tip, drawing a long breath, "this is certainly a
+surprising thing! May I ask why you wish to conquer His Majesty the
+Scarecrow?"
+
+"Because the Emerald City has been ruled by men long enough, for one
+reason," said the girl. "Moreover, the City glitters with beautiful
+gems, which might far better be used for rings, bracelets and
+necklaces; and there is enough money in the King's treasury to buy
+every girl in our Army a dozen new gowns. So we intend to conquer the
+City and run the government to suit ourselves."
+
+Jinjur spoke these words with an eagerness and decision that proved she
+was in earnest.
+
+"But war is a terrible thing," said Tip, thoughtfully.
+
+"This war will be pleasant," replied the girl, cheerfully.
+
+"Many of you will be slain!" continued the boy, in an awed voice.
+
+"Oh, no," said Jinjur. "What man would oppose a girl, or dare to harm
+her? And there is not an ugly face in my entire Army."
+
+Tip laughed.
+
+"Perhaps you are right," said he. "But the Guardian of the Gate is
+considered a faithful Guardian, and the King's Army will not let the
+City be conquered without a struggle."
+
+"The Army is old and feeble," replied General Jinjur, scornfully. "His
+strength has all been used to grow whiskers, and his wife has such a
+temper that she has already pulled more than half of them out by the
+roots. When the Wonderful Wizard reigned the Soldier with the Green
+Whiskers was a very good Royal Army, for people feared the Wizard. But
+no one is afraid of the Scarecrow, so his Royal Army don't count for
+much in time of war."
+
+After this conversation they proceeded some distance in silence, and
+before long reached a large clearing in the forest where fully four
+hundred young women were assembled. These were laughing and talking
+together as gaily as if they had gathered for a picnic instead of a war
+of conquest.
+
+They were divided into four companies, and Tip noticed that all were
+dressed in costumes similar to that worn by General Jinjur. The only
+real difference was that while those girls from the Munchkin country
+had the blue strip in front of their skirts, those from the country of
+the Quadlings had the red strip in front; and those from the country
+of the Winkies had the yellow strip in front, and the Gillikin girls
+wore the purple strip in front. All had green waists, representing the
+Emerald City they intended to conquer, and the top button on each waist
+indicated by its color which country the wearer came from. The uniforms
+were jaunty and becoming, and quite effective when massed together.
+
+Tip thought this strange Army bore no weapons whatever; but in this he
+was wrong. For each girl had stuck through the knot of her back hair
+two long, glittering knitting-needles.
+
+[Illustration]
+
+General Jinjur immediately mounted the stump of a tree and addressed
+her army.
+
+"Friends, fellow-citizens, and girls!" she said; "we are about to begin
+our great Revolt against the men of Oz! We march to conquer the Emerald
+City--to dethrone the Scarecrow King--to acquire thousands of gorgeous
+gems--to rifle the royal treasury--and to obtain power over our former
+oppressors!"
+
+"Hurrah!" said those who had listened; but Tip thought most of the Army
+was too much engaged in chattering to pay attention to the words of the
+General.
+
+The command to march was now given, and the girls formed themselves
+into four bands, or companies, and set off with eager strides toward
+the Emerald City.
+
+[Illustration]
+
+The boy followed after them, carrying several baskets and wraps and
+packages which various members of the Army of Revolt had placed in his
+care. It was not long before they came to the green granite walls of
+the City and halted before the gateway.
+
+The Guardian of the Gate at once came out and looked at them curiously,
+as if a circus had come to town. He carried a bunch of keys swung round
+his neck by a golden chain; his hands were thrust carelessly into
+his pockets, and he seemed to have no idea at all that the City was
+threatened by rebels. Speaking pleasantly to the girls, he said:
+
+"Good morning, my dears! What can I do for you?"
+
+[Illustration]
+
+"Surrender instantly!" answered General Jinjur, standing before him and
+frowning as terribly as her pretty face would allow her to.
+
+"Surrender!" echoed the man, astounded. "Why, it's impossible. It's
+against the law! I never heard of such a thing in my life."
+
+"Still, you must surrender!" exclaimed the General, fiercely. "We are
+revolting!"
+
+"You don't look it," said the Guardian, gazing from one to another,
+admiringly.
+
+"But we are!" cried Jinjur, stamping her foot, impatiently; "and we
+mean to conquer the Emerald City!"
+
+"Good gracious!" returned the surprised Guardian of the Gates; "what
+a nonsensical idea! Go home to your mothers, my good girls, and milk
+the cows and bake the bread. Don't you know it's a dangerous thing to
+conquer a city?"
+
+"We are not afraid!" responded the General; and she looked so
+determined that it made the Guardian uneasy.
+
+So he rang the bell for the Soldier with the Green Whiskers, and the
+next minute was sorry he had done so. For immediately he was surrounded
+by a crowd of girls who drew the knitting-needles from their hair and
+began jabbing them at the Guardian with the sharp points dangerously
+near his fat cheeks and blinking eyes.
+
+The poor man howled loudly for mercy and made no resistance when Jinjur
+drew the bunch of keys from around his neck.
+
+[Illustration: GENERAL JINJUR AND HER ARMY CAPTURE THE CITY.]
+
+Followed by her Army the General now rushed to the gateway, where she
+was confronted by the Royal Army of Oz--which was the other name for
+the Soldier with the Green Whiskers.
+
+"Halt!" he cried, and pointed his long gun full in the face of the
+leader.
+
+Some of the girls screamed and ran back, but General Jinjur bravely
+stood her ground and said, reproachfully:
+
+"Why, how now? Would you shoot a poor, defenceless girl?"
+
+"No," replied the soldier; "for my gun isn't loaded."
+
+"Not loaded?"
+
+"No; for fear of accidents. And I've forgotten where I hid the powder
+and shot to load it with. But if you'll wait a short time I'll try to
+hunt them up."
+
+"Don't trouble yourself," said Jinjur, cheerfully. Then she turned to
+her Army and cried:
+
+"Girls, the gun isn't loaded!"
+
+"Hooray," shrieked the rebels, delighted at this good news, and they
+proceeded to rush upon the Soldier with the Green Whiskers in such a
+crowd that it was a wonder they didn't stick the knitting-needles into
+one another.
+
+But the Royal Army of Oz was too much afraid of women to meet the
+onslaught. He simply turned about and ran with all his might through
+the gate and toward the royal palace, while General Jinjur and her mob
+flocked into the unprotected City.
+
+In this way was the Emerald City captured without a drop of blood being
+spilled. The Army of Revolt had become an Army of Conquerors!
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Plans an escape
+]
+
+
+Tip slipped away from the girls and followed swiftly after the
+Soldier with the Green Whiskers. The invading army entered the City
+more slowly, for they stopped to dig emeralds out of the walls and
+paving-stones with the points of their knitting-needles. So the Soldier
+and the boy reached the palace before the news had spread that the City
+was conquered.
+
+The Scarecrow and Jack Pumpkinhead were still playing at quoits in
+the courtyard when the game was interrupted by the abrupt entrance of
+the Royal Army of Oz, who came flying in without his hat or gun, his
+clothes in sad disarray and his long beard floating a yard behind him
+as he ran.
+
+"Tally one for me," said the Scarecrow, calmly. "What's wrong, my man?"
+he added, addressing the Soldier.
+
+"Oh! your Majesty--your Majesty! The City is conquered!" gasped the
+Royal Army, who was all out of breath.
+
+"This is quite sudden," said the Scarecrow. "But please go and bar all
+the doors and windows of the palace, while I show this Pumpkinhead how
+to throw a quoit."
+
+The Soldier hastened to do this, while Tip, who had arrived at his
+heels, remained in the courtyard to look at the Scarecrow with
+wondering eyes.
+
+His Majesty continued to throw the quoits as coolly as if no danger
+threatened his throne, but the Pumpkinhead, having caught sight of Tip,
+ambled toward the boy as fast as his wooden legs would go.
+
+"Good afternoon, noble parent!" he cried, delightedly. "I'm glad to see
+you are here. That terrible Saw-Horse ran away with me."
+
+"I suspected it," said Tip. "Did you get hurt? Are you cracked at all?"
+
+"No, I arrived safely," answered Jack, "and his Majesty has been very
+kind indeed to me."
+
+At this moment the Soldier with the Green Whiskers returned, and the
+Scarecrow asked:
+
+"By the way, who has conquered me?"
+
+"A regiment of girls, gathered from the four corners of the Land of
+Oz," replied the Soldier, still pale with fear.
+
+"But where was my Standing Army at the time?" inquired his Majesty,
+looking at the Soldier, gravely.
+
+"Your Standing Army was running," answered the fellow, honestly; "for
+no man could face the terrible weapons of the invaders."
+
+"Well," said the Scarecrow, after a moment's thought, "I don't mind
+much the loss of my throne, for it's a tiresome job to rule over the
+Emerald City. And this crown is so heavy that it makes my head ache.
+But I hope the Conquerors have no intention of injuring me, just
+because I happen to be the King."
+
+"I heard them say," remarked Tip, with some hesitation, "that
+they intend to make a rag carpet of your outside and stuff their
+sofa-cushions with your inside."
+
+"Then I am really in danger," declared his Majesty, positively, "and it
+will be wise for me to consider a means to escape."
+
+"Where can you go?" asked Jack Pumpkinhead.
+
+"Why, to my friend the Tin Woodman, who rules over the Winkies, and
+calls himself their Emperor," was the answer. "I am sure he will
+protect me."
+
+[Illustration]
+
+Tip was looking out of the window.
+
+"The palace is surrounded by the enemy," said he. "It is too late to
+escape. They would soon tear you to pieces."
+
+The Scarecrow sighed.
+
+"In an emergency," he announced, "it is always a good thing to pause
+and reflect. Please excuse me while I pause and reflect."
+
+"But we also are in danger," said the Pumpkinhead, anxiously. "If any
+of these girls understand cooking, my end is not far off!"
+
+"Nonsense!" exclaimed the Scarecrow; "they're too busy to cook, even if
+they know how!"
+
+"But should I remain here a prisoner for any length of time," protested
+Jack, "I'm liable to spoil."
+
+"Ah! then you would not be fit to associate with," returned the
+Scarecrow. "The matter is more serious than I suspected."
+
+"You," said the Pumpkinhead, gloomily, "are liable to live for many
+years. My life is necessarily short. So I must take advantage of the
+few days that remain to me."
+
+"There, there! Don't worry," answered the Scarecrow, soothingly; "if
+you'll keep quiet long enough for me to think, I'll try to find some
+way for us all to escape."
+
+So the others waited in patient silence while the Scarecrow walked to
+a corner and stood with his face to the wall for a good five minutes.
+At the end of that time he faced them with a more cheerful expression
+upon his painted face.
+
+"Where is the Saw-Horse you rode here?" he asked the Pumpkinhead.
+
+"Why, I said he was a jewel, and so your man locked him up in the royal
+treasury," said Jack.
+
+"It was the only place I could think of, your Majesty," added the
+Soldier, fearing he had made a blunder.
+
+"It pleases me very much," said the Scarecrow. "Has the animal been
+fed?"
+
+"Oh, yes; I gave him a heaping peck of sawdust."
+
+"Excellent!" cried the Scarecrow. "Bring the horse here at once."
+
+The Soldier hastened away, and presently they heard the clattering
+of the horse's wooden legs upon the pavement as he was led into the
+courtyard.
+
+His Majesty regarded the steed critically.
+
+"He doesn't seem especially graceful," he remarked, musingly; "but I
+suppose he can run?"
+
+"He can, indeed," said Tip, gazing upon the Saw-Horse admiringly.
+
+"Then, bearing us upon his back, he must make a dash through the ranks
+of the rebels and carry us to my friend the Tin Woodman," announced the
+Scarecrow.
+
+"He can't carry four!" objected Tip.
+
+"No, but he may be induced to carry three," said his Majesty. "I shall
+therefore leave my Royal Army behind. For, from the ease with which he
+was conquered, I have little confidence in his powers."
+
+"Still, he can run," declared Tip, laughing.
+
+"I expected this blow," said the Soldier, sulkily; "but I can bear it.
+I shall disguise myself by cutting off my lovely green whiskers. And,
+after all, it is no more dangerous to face those reckless girls than to
+ride this fiery, untamed wooden horse!"
+
+"Perhaps you are right," observed his Majesty. "But, for my part, not
+being a soldier, I am fond of danger. Now, my boy, you must mount
+first. And please sit as close to the horse's neck as possible."
+
+Tip climbed quickly to his place, and the Soldier and the Scarecrow
+managed to hoist the Pumpkinhead to a seat just behind him. There
+remained so little space for the King that he was liable to fall off as
+soon as the horse started.
+
+"Fetch a clothesline," said the King to his Army, "and tie us all
+together. Then if one falls off we will all fall off."
+
+And while the Soldier was gone for the clothesline his Majesty
+continued, "it is well for me to be careful, for my very existence is
+in danger."
+
+"I have to be as careful as you do," said Jack.
+
+"Not exactly," replied the Scarecrow; "for if anything happened to me,
+that would be the end of me. But if anything happened to you, they
+could use you for seed."
+
+The Soldier now returned with a long line and tied all three firmly
+together, also lashing them to the body of the Saw-Horse; so there
+seemed little danger of their tumbling off.
+
+"Now throw open the gates," commanded the Scarecrow, "and we will make
+a dash to liberty or to death."
+
+The courtyard in which they were standing was located in the center of
+the great palace, which surrounded it on all sides. But in one place a
+passage led to an outer gateway, which the Soldier had barred by order
+of his sovereign. It was through this gateway his Majesty proposed to
+escape, and the Royal Army now led the Saw-Horse along the passage and
+unbarred the gate, which swung backward with a loud crash.
+
+"Now," said Tip to the horse, "you must save us all. Run as fast as you
+can for the gate of the City, and don't let anything stop you."
+
+"All right!" answered the Saw-Horse, gruffly, and dashed away so
+suddenly that Tip had to gasp for breath and hold firmly to the post
+he had driven into the creature's neck.
+
+[Illustration: "WE WILL MAKE A DASH TO LIBERTY OR TO DEATH."]
+
+Several of the girls, who stood outside guarding the palace, were
+knocked over by the Saw-Horse's mad rush. Others ran screaming out of
+the way, and only one or two jabbed their knitting-needles frantically
+at the escaping prisoners. Tip got one small prick in his left arm,
+which smarted for an hour afterward; but the needles had no effect upon
+the Scarecrow or Jack Pumpkinhead, who never even suspected they were
+being prodded.
+
+As for the Saw-Horse, he made a wonderful record, upsetting a fruit
+cart, overturning several meek looking men, and finally bowling over
+the new Guardian of the Gate--a fussy little fat woman appointed by
+General Jinjur.
+
+Nor did the impetuous charger stop then. Once outside the walls of the
+Emerald City he dashed along the road to the West with fast and violent
+leaps that shook the breath out of the boy and filled the Scarecrow
+with wonder.
+
+Jack had ridden at this mad rate once before, so he devoted every
+effort to holding, with both hands, his pumpkin head upon its
+stick, enduring meantime the dreadful jolting with the courage of a
+philosopher.
+
+[Illustration: THE WOODEN STEED GAVE ONE FINAL LEAP.]
+
+"Slow him up! Slow him up!" shouted the Scarecrow. "My straw is all
+shaking down into my legs."
+
+But Tip had no breath to speak, so the Saw-Horse continued his wild
+career unchecked and with unabated speed.
+
+Presently they came to the banks of a wide river, and without a pause
+the wooden steed gave one final leap and launched them all in mid-air.
+
+A second later they were rolling, splashing and bobbing about in the
+water, the horse struggling frantically to find a rest for its feet
+and its riders being first plunged beneath the rapid current and then
+floating upon the surface like corks.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Journey to the
+    Tin Woodman
+]
+
+
+Tip was well soaked and dripping water from every angle of his body;
+but he managed to lean forward and shout in the ear of the Saw-Horse:
+
+"Keep still, you fool! Keep still!"
+
+The horse at once ceased struggling and floated calmly upon the
+surface, its wooden body being as buoyant as a raft.
+
+"What does that word 'fool' mean?" enquired the horse.
+
+"It is a term of reproach," answered Tip, somewhat ashamed of the
+expression. "I only use it when I am angry."
+
+"Then it pleases me to be able to call you a fool, in return," said the
+horse. "For I did not make the river, nor put it in our way; so only a
+term of reproach is fit for one who becomes angry with me for falling
+into the water."
+
+"That is quite evident," replied Tip; "so I will acknowledge myself in
+the wrong." Then he called out to the Pumpkinhead: "are you all right,
+Jack?"
+
+There was no reply. So the boy called to the King: "are you all right,
+your majesty?"
+
+The Scarecrow groaned.
+
+"I'm all wrong, somehow," he said, in a weak voice. "How very wet this
+water is!"
+
+Tip was bound so tightly by the cord that he could not turn his head to
+look at his companions; so he said to the Saw-Horse:
+
+"Paddle with your legs toward the shore."
+
+The horse obeyed, and although their progress was slow they finally
+reached the opposite river bank at a place where it was low enough to
+enable the creature to scramble upon dry land.
+
+With some difficulty the boy managed to get his knife out of his pocket
+and cut the cords that bound the riders to one another and to the
+wooden horse. He heard the Scarecrow fall to the ground with a mushy
+sound, and then he himself quickly dismounted and looked at his friend
+Jack.
+
+The wooden body, with its gorgeous clothing, still sat upright upon
+the horse's back; but the pumpkin head was gone, and only the sharpened
+stick that served for a neck was visible. As for the Scarecrow, the
+straw in his body had shaken down with the jolting and packed itself
+into his legs and the lower part of his body--which appeared very plump
+and round while his upper half seemed like an empty sack. Upon his head
+the Scarecrow still wore the heavy crown, which had been sewed on to
+prevent his losing it; but the head was now so damp and limp that the
+weight of the gold and jewels sagged forward and crushed the painted
+face into a mass of wrinkles that made him look exactly like a Japanese
+pug dog.
+
+Tip would have laughed--had he not been so anxious about his man Jack.
+But the Scarecrow, however damaged, was all there, while the pumpkin
+head that was so necessary to Jack's existence was missing; so the boy
+seized a long pole that fortunately lay near at hand and anxiously
+turned again toward the river.
+
+Far out upon the waters he sighted the golden hue of the pumpkin, which
+gently bobbed up and down with the motion of the waves. At that moment
+it was quite out of Tip's reach, but after a time it floated nearer
+and still nearer until the boy was able to reach it with his pole
+and draw it to the shore. Then he brought it to the top of the bank,
+carefully wiped the water from its pumpkin face with his handkerchief,
+and ran with it to Jack and replaced the head upon the man's neck.
+
+[Illustration: TIP RESCUES JACK'S PUMPKIN HEAD.]
+
+"Dear me!" were Jack's first words. "What a dreadful experience! I
+wonder if water is liable to spoil pumpkins?"
+
+Tip did not think a reply was necessary, for he knew that the Scarecrow
+also stood in need of his help. So he carefully removed the straw from
+the King's body and legs, and spread it out in the sun to dry. The wet
+clothing he hung over the body of the Saw-Horse.
+
+"If water spoils pumpkins," observed Jack, with a deep sigh, "then my
+days are numbered."
+
+"I've never noticed that water spoils pumpkins," returned Tip; "unless
+the water happens to be boiling. If your head isn't cracked, my friend,
+you must be in fairly good condition."
+
+"Oh, my head isn't cracked in the least," declared Jack, more
+cheerfully.
+
+"Then don't worry," retorted the boy. "Care once killed a cat."
+
+"Then," said Jack, seriously, "I am very glad indeed that I am not a
+cat."
+
+The sun was fast drying their clothing, and Tip stirred up his
+Majesty's straw so that the warm rays might absorb the moisture and
+make it as crisp and dry as ever. When this had been accomplished he
+stuffed the Scarecrow into symmetrical shape and smoothed out his face
+so that he wore his usual gay and charming expression.
+
+"Thank you very much," said the monarch, brightly, as he walked about
+and found himself to be well balanced. "There are several distinct
+advantages in being a Scarecrow. For if one has friends near at hand to
+repair damages, nothing very serious can happen to you."
+
+"I wonder if hot sunshine is liable to crack pumpkins," said Jack, with
+an anxious ring in his voice.
+
+"Not at all--not at all!" replied the Scarecrow, gaily. "All you
+need fear, my boy, is old age. When your golden youth has decayed we
+shall quickly part company--but you needn't look forward to it; we'll
+discover the fact ourselves, and notify you. But come! Let us resume
+our journey. I am anxious to greet my friend the Tin Woodman."
+
+So they remounted the Saw-Horse, Tip holding to the post, the
+Pumpkinhead clinging to Tip, and the Scarecrow with both arms around
+the wooden form of Jack.
+
+[Illustration: TIP STUFFS THE SCARECROW WITH DRY STRAW.]
+
+"Go slowly, for now there is no danger of pursuit," said Tip to his
+steed.
+
+"All right!" responded the creature, in a voice rather gruff.
+
+"Aren't you a little hoarse?" asked the Pumpkinhead, politely.
+
+The Saw-Horse gave an angry prance and rolled one knotty eye backward
+toward Tip.
+
+"See here," he growled, "can't you protect me from insult?"
+
+"To be sure!" answered Tip, soothingly. "I am sure Jack meant no harm.
+And it will not do for us to quarrel, you know; we must all remain good
+friends."
+
+"I'll have nothing more to do with that Pumpkinhead," declared the
+Saw-Horse, viciously; "he loses his head too easily to suit me."
+
+There seemed no fitting reply to this speech, so for a time they rode
+along in silence.
+
+After a while the Scarecrow remarked:
+
+"This reminds me of old times. It was upon this grassy knoll that I
+once saved Dorothy from the Stinging Bees of the Wicked Witch of the
+West."
+
+"Do Stinging Bees injure pumpkins?" asked Jack, glancing around
+fearfully.
+
+"They are all dead, so it doesn't matter," replied the Scarecrow. "And
+here is where Nick Chopper destroyed the Wicked Witch's Grey Wolves."
+
+"Who was Nick Chopper?" asked Tip.
+
+"That is the name of my friend the Tin Woodman," answered his Majesty.
+"And here is where the Winged Monkeys captured and bound us, and flew
+away with little Dorothy," he continued, after they had traveled a
+little way farther.
+
+"Do Winged Monkeys ever eat pumpkins?" asked Jack, with a shiver of
+fear.
+
+"I do not know; but you have little cause to worry, for the Winged
+Monkeys are now the slaves of Glinda the Good, who owns the Golden Cap
+that commands their services," said the Scarecrow, reflectively.
+
+Then the stuffed monarch became lost in thought, recalling the days
+of past adventures. And the Saw-Horse rocked and rolled over the
+flower-strewn fields and carried its riders swiftly upon their way.
+
+       *       *       *       *       *
+
+Twilight fell, bye and bye, and then the dark shadows of night. So Tip
+stopped the horse and they all proceeded to dismount.
+
+"I'm tired out," said the boy, yawning wearily; "and the grass is soft
+and cool. Let us lie down here and sleep until morning."
+
+"I can't sleep," said Jack.
+
+"I never do," said the Scarecrow.
+
+"I do not even know what sleep is," said the Saw-Horse.
+
+"Still, we must have consideration for this poor boy, who is made of
+flesh and blood and bone, and gets tired," suggested the Scarecrow,
+in his usual thoughtful manner. "I remember it was the same way with
+little Dorothy. We always had to sit through the night while she slept."
+
+"I'm sorry," said Tip, meekly, "but I can't help it. And I'm dreadfully
+hungry, too!"
+
+"Here is a new danger!" remarked Jack, gloomily. "I hope you are not
+fond of eating pumpkins."
+
+"Not unless they're stewed and made into pies," answered the boy,
+laughing. "So have no fears of me, friend Jack."
+
+"What a coward that Pumpkinhead is!" said the Saw-Horse, scornfully.
+
+"You might be a coward yourself, if you knew you were liable to spoil!"
+retorted Jack, angrily.
+
+"There!--there!" interrupted the Scarecrow; "don't let us quarrel.
+We all have our weaknesses, dear friends; so we must strive to be
+considerate of one another. And since this poor boy is hungry and has
+nothing whatever to eat, let us all remain quiet and allow him to
+sleep; for it is said that in sleep a mortal may forget even hunger."
+
+"Thank you!" exclaimed Tip, gratefully. "Your Majesty is fully as good
+as you are wise--and that is saying a good deal!"
+
+He then stretched himself upon the grass and, using the stuffed form of
+the Scarecrow for a pillow, was presently fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Nickel-Plated Emperor
+]
+
+
+Tip awoke soon after dawn, but the Scarecrow had already risen and
+plucked, with his clumsy fingers, a double-handful of ripe berries from
+some bushes near by. These the boy ate greedily, finding them an ample
+breakfast, and afterward the little party resumed its journey.
+
+After an hour's ride they reached the summit of a hill from whence
+they espied the City of the Winkies and noted the tall domes of the
+Emperor's palace rising from the clusters of more modest dwellings.
+
+The Scarecrow became greatly animated at this sight, and exclaimed:
+
+"How delighted I shall be to see my old friend the Tin Woodman again! I
+hope that he rules his people more successfully than I have ruled mine!"
+
+"Is the Tin Woodman the Emperor of the Winkies?" asked the horse.
+
+"Yes, indeed. They invited him to rule over them soon after the Wicked
+Witch was destroyed; and as Nick Chopper has the best heart in all the
+world I am sure he has proved an excellent and able emperor."
+
+"I thought that 'Emperor' was the title of a person who rules an
+empire," said Tip, "and the Country of the Winkies is only a Kingdom."
+
+"Don't mention that to the Tin Woodman!" exclaimed the Scarecrow,
+earnestly. "You would hurt his feelings terribly. He is a proud man,
+as he has every reason to be, and it pleases him to be termed Emperor
+rather than King."
+
+"I'm sure it makes no difference to me," replied the boy.
+
+The Saw-Horse now ambled forward at a pace so fast that its riders
+had hard work to stick upon its back; so there was little further
+conversation until they drew up beside the palace steps.
+
+An aged Winkie, dressed in a uniform of silver cloth, came forward to
+assist them to alight. Said the Scarecrow to this personage:
+
+"Show us at once to your master, the Emperor."
+
+The man looked from one to another of the party in an embarrassed way,
+and finally answered:
+
+"I fear I must ask you to wait for a time. The Emperor is not receiving
+this morning."
+
+"How is that?" enquired the Scarecrow, anxiously. "I hope nothing has
+happened to him."
+
+"Oh, no; nothing serious," returned the man. "But this is his Majesty's
+day for being polished, and just now his august presence is thickly
+smeared with putz-pomade."
+
+"Oh, I see!" cried the Scarecrow, greatly reassured. "My friend was
+ever inclined to be a dandy, and I suppose he is now more proud than
+ever of his personal appearance."
+
+"He is, indeed," said the man, with a polite bow. "Our mighty Emperor
+has lately caused himself to be nickel-plated."
+
+"Good Gracious!" the Scarecrow exclaimed at hearing this. "If his wit
+bears the same polish, how sparkling it must be! But show us in--I'm
+sure the Emperor will receive us, even in his present state."
+
+"The Emperor's state is always magnificent," said the man. "But I will
+venture to tell him of your arrival, and will receive his commands
+concerning you."
+
+So the party followed the servant into a splendid ante-room, and the
+Saw-Horse ambled awkwardly after them, having no knowledge that a horse
+might be expected to remain outside.
+
+The travelers were at first somewhat awed by their surroundings, and
+even the Scarecrow seemed impressed as he examined the rich hangings
+of silver cloth caught up into knots and fastened with tiny silver
+axes. Upon a handsome center-table stood a large silver oil-can,
+richly engraved with scenes from the past adventures of the Tin
+Woodman, Dorothy, the Cowardly Lion and the Scarecrow: the lines of the
+engraving being traced upon the silver in yellow gold. On the walls
+hung several portraits, that of the Scarecrow seeming to be the most
+prominent and carefully executed, while a large painting of the famous
+Wizard of Oz, in the act of presenting the Tin Woodman with a heart,
+covered almost one entire end of the room.
+
+While the visitors gazed at these things in silent admiration they
+suddenly heard a loud voice in the next room exclaim:
+
+"Well! well! well! What a great surprise!"
+
+And then the door burst open and Nick Chopper rushed into their midst
+and caught the Scarecrow in a close and loving embrace that creased him
+into many folds and wrinkles.
+
+"My dear old friend! My noble comrade!" cried the Tin Woodman,
+joyfully; "how delighted I am to meet you once again!"
+
+[Illustration: CAUGHT THE SCARECROW IN A CLOSE AND LOVING EMBRACE.]
+
+And then he released the Scarecrow and held him at arms' length while
+he surveyed the beloved, painted features.
+
+But, alas! the face of the Scarecrow and many portions of his body bore
+great blotches of putz-pomade; for the Tin Woodman, in his eagerness to
+welcome his friend, had quite forgotten the condition of his toilet and
+had rubbed the thick coating of paste from his own body to that of his
+comrade.
+
+"Dear me!" said the Scarecrow, dolefully. "What a mess I'm in!"
+
+"Never mind, my friend," returned the Tin Woodman, "I'll send you to my
+Imperial Laundry, and you'll come out as good as new."
+
+"Won't I be mangled?" asked the Scarecrow.
+
+"No, indeed!" was the reply. "But tell me, how came your Majesty here?
+and who are your companions?"
+
+The Scarecrow, with great politeness, introduced Tip and Jack
+Pumpkinhead, and the latter personage seemed to interest the Tin
+Woodman greatly.
+
+"You are not very substantial, I must admit," said the Emperor; "but
+you are certainly unusual, and therefore worthy to become a member of
+our select society."
+
+"I thank your Majesty," said Jack, humbly.
+
+[Illustration]
+
+"I hope you are enjoying good health?" continued the Woodman.
+
+"At present, yes;" replied the Pumpkinhead, with a sigh; "but I am in
+constant terror of the day when I shall spoil."
+
+"Nonsense!" said the Emperor--but in a kindly, sympathetic tone. "Do
+not, I beg of you, dampen today's sun with the showers of tomorrow. For
+before your head has time to spoil you can have it canned, and in that
+way it may be preserved indefinitely."
+
+Tip, during this conversation, was looking at the Woodman with
+undisguised amazement, and noticed that the celebrated Emperor of
+the Winkies was composed entirely of pieces of tin, neatly soldered
+and riveted together into the form of a man. He rattled and clanked
+a little, as he moved, but in the main he seemed to be most cleverly
+constructed, and his appearance was only marred by the thick coating of
+polishing-paste that covered him from head to foot.
+
+The boy's intent gaze caused the Tin Woodman to remember that he was
+not in the most presentable condition, so he begged his friends to
+excuse him while he retired to his private apartment and allowed his
+servants to polish him. This was accomplished in a short time, and when
+the Emperor returned his nickel-plated body shone so magnificently that
+the Scarecrow heartily congratulated him on his improved appearance.
+
+"That nickel-plate was, I confess, a happy thought," said Nick; "and it
+was the more necessary because I had become somewhat scratched during
+my adventurous experiences. You will observe this engraved star upon
+my left breast. It not only indicates where my excellent heart lies,
+but covers very neatly the patch made by the Wonderful Wizard when he
+placed that valued organ in my breast with his own skillful hands."
+
+"Is your heart, then, a hand-organ?" asked the Pumpkinhead, curiously.
+
+"By no means," responded the Emperor, with dignity. "It is, I am
+convinced, a strictly orthodox heart, although somewhat larger and
+warmer than most people possess."
+
+Then he turned to the Scarecrow and asked:
+
+"Are your subjects happy and contented, my dear friend?"
+
+"I cannot say," was the reply; "for the girls of Oz have risen in
+revolt and driven me out of the Emerald City."
+
+"Great Goodness!" cried the Tin Woodman. "What a calamity! They surely
+do not complain of your wise and gracious rule?"
+
+"No; but they say it is a poor rule that don't work both ways,"
+answered the Scarecrow; "and these females are also of the opinion that
+men have ruled the land long enough. So they have captured my city,
+robbed the treasury of all its jewels, and are running things to suit
+themselves."
+
+"Dear me! What an extraordinary idea!" cried the Emperor, who was both
+shocked and surprised.
+
+"And I heard some of them say," said Tip, "that they intend to march
+here and capture the castle and city of the Tin Woodman."
+
+"Ah! we must not give them time to do that," said the Emperor, quickly;
+"we will go at once and recapture the Emerald City and place the
+Scarecrow again upon his throne."
+
+[Illustration: RENOVATING HIS MAJESTY, THE SCARECROW.]
+
+"I was sure you would help me," remarked the Scarecrow in a pleased
+voice. "How large an army can you assemble?"
+
+"We do not need an army," replied the Woodman. "We four, with the aid
+of my gleaming axe, are enough to strike terror into the hearts of the
+rebels."
+
+"We five," corrected the Pumpkinhead.
+
+"Five?" repeated the Tin Woodman.
+
+"Yes; the Saw-Horse is brave and fearless," answered Jack, forgetting
+his recent quarrel with the quadruped.
+
+The Tin Woodman looked around him in a puzzled way, for the Saw-Horse
+had until now remained quietly standing in a corner, where the Emperor
+had not noticed him. Tip immediately called the odd-looking creature to
+them, and it approached so awkwardly that it nearly upset the beautiful
+center-table and the engraved oil-can.
+
+"I begin to think," remarked the Tin Woodman as he looked earnestly at
+the Saw-Horse, "that wonders will never cease! How came this creature
+alive?"
+
+"I did it with a magic powder," modestly asserted the boy; "and the
+Saw-Horse has been very useful to us."
+
+"He enabled us to escape the rebels," added the Scarecrow.
+
+"Then we must surely accept him as a comrade," declared the Emperor. "A
+live Saw-Horse is a distinct novelty, and should prove an interesting
+study. Does he know anything?"
+
+"Well, I cannot claim any great experience in life," the Saw-Horse
+answered for himself; "but I seem to learn very quickly, and often it
+occurs to me that I know more than any of those around me."
+
+"Perhaps you do," said the Emperor; "for experience does not always
+mean wisdom. But time is precious just now, so let us quickly make
+preparations to start upon our journey."
+
+The Emperor called his Lord High Chancellor and instructed him how to
+run the kingdom during his absence. Meanwhile the Scarecrow was taken
+apart and the painted sack that served him for a head was carefully
+laundered and restuffed with the brains originally given him by the
+great Wizard. His clothes were also cleaned and pressed by the Imperial
+tailors, and his crown polished and again sewed upon his head, for the
+Tin Woodman insisted he should not renounce this badge of royalty. The
+Scarecrow now presented a very respectable appearance, and although
+in no way addicted to vanity he was quite pleased with himself and
+strutted a trifle as he walked. While this was being done Tip mended
+the wooden limbs of Jack Pumpkinhead and made them stronger than
+before, and the Saw-Horse was also inspected to see if he was in good
+working order.
+
+Then bright and early the next morning they set out upon the return
+journey to the Emerald City, the Tin Woodman bearing upon his shoulder
+a gleaming axe and leading the way, while the Pumpkinhead rode upon the
+Saw-Horse and Tip and the Scarecrow walked upon either side to make
+sure that he didn't fall off or become damaged.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Mr. H. M. Woggle-Bug, T. E.
+]
+
+
+Now, General Jinjur--who, you will remember, commanded the Army of
+Revolt--was rendered very uneasy by the escape of the Scarecrow from
+the Emerald City. She feared, and with good reason, that if his Majesty
+and the Tin Woodman joined forces, it would mean danger to her and
+her entire army; for the people of Oz had not yet forgotten the deeds
+of these famous heroes, who had passed successfully through so many
+startling adventures.
+
+So Jinjur sent post-haste for old Mombi, the witch, and promised her
+large rewards if she would come to the assistance of the rebel army.
+
+Mombi was furious at the trick Tip had played upon her, as well as at
+his escape and the theft of the precious Powder of Life; so she needed
+no urging to induce her to travel to the Emerald City to assist Jinjur
+in defeating the Scarecrow and the Tin Woodman, who had made Tip one of
+their friends.
+
+Mombi had no sooner arrived at the royal palace than she discovered,
+by means of her secret magic, that the adventurers were starting upon
+their journey to the Emerald City; so she retired to a small room high
+up in a tower and locked herself in while she practised such arts
+as she could command to prevent the return of the Scarecrow and his
+companions.
+
+That was why the Tin Woodman presently stopped and said:
+
+"Something very curious has happened. I ought to know by heart every
+step of this journey, and yet I fear we have already lost our way."
+
+"That is quite impossible!" protested the Scarecrow. "Why do you think,
+my dear friend, that we have gone astray?"
+
+"Why, here before us is a great field of sunflowers--and I never saw
+this field before in all my life."
+
+At these words they all looked around, only to find that they were
+indeed surrounded by a field of tall stalks, every stalk bearing at
+its top a gigantic sunflower. And not only were these flowers almost
+blinding in their vivid hues of red and gold, but each one whirled
+around upon its stalk like a miniature wind-mill, completely dazzling
+the vision of the beholders and so mystifying them that they knew not
+which way to turn.
+
+"It's witchcraft!" exclaimed Tip.
+
+While they paused, hesitating and wondering, the Tin Woodman uttered
+a cry of impatience and advanced with swinging axe to cut down the
+stalks before him. But now the sunflowers suddenly stopped their rapid
+whirling, and the travelers plainly saw a girl's face appear in the
+center of each flower. These lovely faces looked upon the astonished
+band with mocking smiles, and then burst into a chorus of merry
+laughter at the dismay their appearance caused.
+
+"Stop! stop!" cried Tip, seizing the Woodman's arm; "they're alive!
+they're girls!"
+
+At that moment the flowers began whirling again, and the faces faded
+away and were lost in the rapid revolutions.
+
+The Tin Woodman dropped his axe and sat down upon the ground.
+
+"It would be heartless to chop down those pretty creatures," said he,
+despondently; "and yet I do not know how else we can proceed upon our
+way."
+
+"They looked to me strangely like the faces of the Army of Revolt,"
+mused the Scarecrow. "But I cannot conceive how the girls could have
+followed us here so quickly."
+
+"I believe it's magic," said Tip, positively, "and that someone is
+playing a trick upon us. I've known old Mombi do things like that
+before. Probably it's nothing more than an illusion, and there are no
+sunflowers here at all."
+
+"Then let us shut our eyes and walk forward," suggested the Woodman.
+
+"Excuse me," replied the Scarecrow. "My eyes are not painted to shut.
+Because you happen to have tin eyelids, you must not imagine we are all
+built in the same way."
+
+"And the eyes of the Saw-Horse are knot eyes," said Jack, leaning
+forward to examine them.
+
+"Nevertheless, you must ride quickly forward," commanded Tip, "and we
+will follow after you and so try to escape. My eyes are already so
+dazzled that I can scarcely see."
+
+So the Pumpkinhead rode boldly forward, and Tip grasped the stub tail
+of the Saw-Horse and followed with closed eyes. The Scarecrow and the
+Tin Woodman brought up the rear, and before they had gone many yards a
+joyful shout from Jack announced that the way was clear before them.
+
+Then all paused to look backward, but not a trace of the field of
+sunflowers remained.
+
+More cheerfully, now, they proceeded upon their journey; but old Mombi
+had so changed the appearance of the landscape that they would surely
+have been lost had not the Scarecrow wisely concluded to take their
+direction from the sun. For no witchcraft could change the course of
+the sun, and it was therefore a safe guide.
+
+However, other difficulties lay before them. The Saw-Horse stepped into
+a rabbit hole and fell to the ground. The Pumpkinhead was pitched high
+into the air, and his history would probably have ended at that exact
+moment had not the Tin Woodman skillfully caught the pumpkin as it
+descended and saved it from injury.
+
+Tip soon had it fitted to the neck again and replaced Jack upon his
+feet. But the Saw-Horse did not escape so easily. For when his leg was
+pulled from the rabbit hole it was found to be broken short off, and
+must be replaced or repaired before he could go a step farther.
+
+"This is quite serious," said the Tin Woodman. "If there were trees
+near by I might soon manufacture another leg for this animal; but I
+cannot see even a shrub for miles around."
+
+[Illustration: THE TIN WOODMAN SKILLFULLY CAUGHT THE PUMPKIN]
+
+"And there are neither fences nor houses in this part of the land of
+Oz," added the Scarecrow, disconsolately.
+
+"Then what shall we do?" enquired the boy.
+
+"I suppose I must start my brains working," replied his Majesty the
+Scarecrow; "for experience has taught me that I can do anything if I
+but take time to think it out."
+
+"Let us all think," said Tip; "and perhaps we shall find a way to
+repair the Saw-Horse."
+
+So they sat in a row upon the grass and began to think, while the
+Saw-Horse occupied itself by gazing curiously upon its broken limb.
+
+"Does it hurt?" asked the Tin Woodman, in a soft, sympathetic voice.
+
+"Not in the least," returned the Saw-Horse; "but my pride is injured to
+find that my anatomy is so brittle."
+
+For a time the little group remained in silent thought. Presently the
+Tin Woodman raised his head and looked over the fields.
+
+"What sort of creature is that which approaches us?" he asked,
+wonderingly.
+
+The others followed his gaze, and discovered coming toward them the
+most extraordinary object they had ever beheld. It advanced quickly
+and noiselessly over the soft grass and in a few minutes stood before
+the adventurers and regarded them with an astonishment equal to their
+own.
+
+The Scarecrow was calm under all circumstances.
+
+"Good morning!" he said, politely.
+
+The stranger removed his hat with a flourish, bowed very low, and then
+responded:
+
+[Illustration]
+
+"Good morning, one and all. I hope you are, as an aggregation, enjoying
+excellent health. Permit me to present my card."
+
+With this courteous speech it extended a card toward the Scarecrow, who
+accepted it, turned it over and over, and then handed it with a shake
+of his head to Tip.
+
+The boy read aloud:
+
+"MR. H. M. WOGGLE-BUG, T. E."
+
+"Dear me!" ejaculated the Pumpkinhead, staring somewhat intently.
+
+"How very peculiar!" said the Tin Woodman.
+
+Tip's eyes were round and wondering, and the Saw-Horse uttered a sigh
+and turned away its head.
+
+"Are you really a Woggle-Bug?" enquired the Scarecrow.
+
+"Most certainly, my dear sir!" answered the stranger, briskly. "Is not
+my name upon the card?"
+
+"It is," said the Scarecrow. "But may I ask what 'H. M.' stands for?"
+
+"'H. M.' means Highly Magnified," returned the Woggle-Bug, proudly.
+
+"Oh, I see." The Scarecrow viewed the stranger critically. "And are
+you, in truth, highly magnified?"
+
+"Sir," said the Woggle-Bug, "I take you for a gentleman of judgment
+and discernment. Does it not occur to you that I am several thousand
+times greater than any Woggle-Bug you ever saw before? Therefore it is
+plainly evident that I am Highly Magnified, and there is no good reason
+why you should doubt the fact."
+
+"Pardon me," returned the Scarecrow. "My brains are slightly mixed
+since I was last laundered. Would it be improper for me to ask, also,
+what the 'T. E.' at the end of your name stands for?"
+
+"Those letters express my degree," answered the Woggle-Bug, with a
+condescending smile. "To be more explicit, the initials mean that I am
+Thoroughly Educated."
+
+"Oh!" said the Scarecrow, much relieved.
+
+Tip had not yet taken his eyes off this wonderful personage. What he
+saw was a great, round, bug-like body supported upon two slender legs
+which ended in delicate feet--the toes curling upward. The body of the
+Woggle-Bug was rather flat, and judging from what could be seen of it
+was of a glistening dark brown color upon the back, while the front
+was striped with alternate bands of light brown and white, blending
+together at the edges. Its arms were fully as slender as its legs, and
+upon a rather long neck was perched its head--not unlike the head of a
+man, except that its nose ended in a curling antenna, or "feeler," and
+its ears from the upper points bore antennæ that decorated the sides
+of its head like two miniature, curling pig tails. It must be admitted
+that the round, black eyes were rather bulging in appearance; but the
+expression upon the Woggle-Bug's face was by no means unpleasant.
+
+For dress the insect wore a dark-blue swallow-tail coat with a yellow
+silk lining and a flower in the button-hole; a vest of white duck that
+stretched tightly across the wide body; knickerbockers of fawn-colored
+plush, fastened at the knees with gilt buckles; and, perched upon its
+small head, was jauntily set a tall silk hat.
+
+Standing upright before our amazed friends the Woggle-Bug appeared to
+be fully as tall as the Tin Woodman; and surely no bug in all the Land
+of Oz had ever before attained so enormous a size.
+
+"I confess," said the Scarecrow, "that your abrupt appearance has
+caused me surprise, and no doubt has startled my companions. I hope,
+however, that this circumstance will not distress you. We shall
+probably get used to you in time."
+
+"Do not apologize, I beg of you!" returned the Woggle-Bug, earnestly.
+"It affords me great pleasure to surprise people; for surely I cannot
+be classed with ordinary insects and am entitled to both curiosity and
+admiration from those I meet."
+
+"You are, indeed," agreed his Majesty.
+
+"If you will permit me to seat myself in your august company,"
+continued the stranger, "I will gladly relate my history, so
+that you will be better able to comprehend my unusual--may I say
+remarkable?--appearance."
+
+"You may say what you please," answered the Tin Woodman, briefly.
+
+So the Woggle-Bug sat down upon the grass, facing the little group of
+wanderers, and told them the following story:
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Highly Magnified
+    History
+]
+
+
+"It is but honest that I should acknowledge at the beginning of my
+recital that I was born an ordinary Woggle-Bug," began the creature, in
+a frank and friendly tone. "Knowing no better, I used my arms as well
+as my legs for walking, and crawled under the edges of stones or hid
+among the roots of grasses with no thought beyond finding a few insects
+smaller than myself to feed upon.
+
+"The chill nights rendered me stiff and motionless, for I wore no
+clothing, but each morning the warm rays of the sun gave me new life
+and restored me to activity. A horrible existence is this, but you must
+remember it is the regularly ordained existence of Woggle-Bugs, as well
+as of many other tiny creatures that inhabit the earth.
+
+"But Destiny had singled me out, humble though I was, for a grander
+fate! One day I crawled near to a country school house, and my
+curiosity being excited by the monotonous hum of the students within,
+I made bold to enter and creep along a crack between two boards until
+I reached the far end, where, in front of a hearth of glowing embers,
+sat the master at his desk.
+
+"No one noticed so small a creature as a Woggle-Bug, and when I found
+that the hearth was even warmer and more comfortable than the sunshine,
+I resolved to establish my future home beside it. So I found a charming
+nest between two bricks and hid myself therein for many, many months.
+
+"Professor Nowitall is, doubtless, the most famous scholar in the land
+of Oz, and after a few days I began to listen to the lectures and
+discourses he gave his pupils. Not one of them was more attentive than
+the humble, unnoticed Woggle-Bug, and I acquired in this way a fund of
+knowledge that I will myself confess is simply marvelous. That is why
+I place 'T. E.'--Thoroughly Educated--upon my cards; for my greatest
+pride lies in the fact that the world cannot produce another Woggle-Bug
+with a tenth part of my own culture and erudition."
+
+"I do not blame you," said the Scarecrow. "Education is a thing to
+be proud of. I'm educated myself. The mess of brains given me by the
+Great Wizard is considered by my friends to be unexcelled."
+
+"Nevertheless," interrupted the Tin Woodman, "a good heart is, I
+believe, much more desirable than education or brains."
+
+"To me," said the Saw-Horse, "a good leg is more desirable than either."
+
+"Could seeds be considered in the light of brains?" enquired the
+Pumpkinhead, abruptly.
+
+"Keep quiet!" commanded Tip, sternly.
+
+"Very well, dear father," answered the obedient Jack.
+
+The Woggle-Bug listened patiently--even respectfully--to these remarks,
+and then resumed his story.
+
+"I must have lived fully three years in that secluded school-house
+hearth," said he, "drinking thirstily of the ever-flowing fount of
+limpid knowledge before me."
+
+"Quite poetical," commented the Scarecrow, nodding his head approvingly.
+
+[Illustration: "Caught me between his thumb and forefinger."]
+
+"But one day," continued the Bug, "a marvelous circumstance occurred
+that altered my very existence and brought me to my present pinnacle of
+greatness. The Professor discovered me in the act of crawling across
+the hearth, and before I could escape he had caught me between his
+thumb and forefinger.
+
+"'My dear children,' said he, 'I have captured a Woggle-Bug--a very
+rare and interesting specimen. Do any of you know what a Woggle-Bug is?'
+
+"'No!' yelled the scholars, in chorus.
+
+"'Then,' said the Professor, 'I will get out my famous magnifying-glass
+and throw the insect upon a screen in a highly-magnified condition,
+that you may all study carefully its peculiar construction and become
+acquainted with its habits and manner of life.'
+
+"He then brought from a cupboard a most curious instrument, and before
+I could realize what had happened I found myself thrown upon a screen
+in a highly-magnified state--even as you now behold me.
+
+"The students stood up on their stools and craned their heads forward
+to get a better view of me, and two little girls jumped upon the sill
+of an open window where they could see more plainly.
+
+"'Behold!' cried the Professor, in a loud voice, 'this highly-magnified
+Woggle-Bug; one of the most curious insects in existence!'
+
+"Being Thoroughly Educated, and knowing what is required of a cultured
+gentleman, at this juncture I stood upright and, placing my hand upon
+my bosom, made a very polite bow. My action, being unexpected, must
+have startled them, for one of the little girls perched upon the
+window-sill gave a scream and fell backward out the window, drawing her
+companion with her as she disappeared.
+
+[Illustration: "THE STUDENTS STOOD UP ON THEIR STOOLS."]
+
+"The Professor uttered a cry of horror and rushed away through the
+door to see if the poor children were injured by the fall. The
+scholars followed after him in a wild mob, and I was left alone in the
+school-room, still in a Highly-Magnified state and free to do as I
+pleased.
+
+"It immediately occurred to me that this was a good opportunity to
+escape. I was proud of my great size, and realized that now I could
+safely travel anywhere in the world, while my superior culture would
+make me a fit associate for the most learned person I might chance to
+meet.
+
+"So, while the Professor picked the little girls--who were more
+frightened than hurt--off the ground, and the pupils clustered around
+him closely grouped, I calmly walked out of the school-house, turned a
+corner, and escaped unnoticed to a grove of trees that stood near."
+
+"Wonderful!" exclaimed the Pumpkinhead, admiringly.
+
+"It was, indeed," agreed the Woggle-Bug. "I have never ceased to
+congratulate myself for escaping while I was Highly Magnified; for
+even my excessive knowledge would have proved of little use to me had
+I remained a tiny, insignificant insect."
+
+[Illustration]
+
+"I didn't know before," said Tip, looking at the Woggle-Bug with a
+puzzled expression, "that insects wore clothes."
+
+"Nor do they, in their natural state," returned the stranger. "But
+in the course of my wanderings I had the good fortune to save the
+ninth life of a tailor--tailors having, like cats, nine lives, as
+you probably know. The fellow was exceedingly grateful, for had he
+lost that ninth life it would have been the end of him; so he begged
+permission to furnish me with the stylish costume I now wear. It fits
+very nicely, does it not?" and the Woggle-Bug stood up and turned
+himself around slowly, that all might examine his person.
+
+"He must have been a good tailor," said the Scarecrow, somewhat
+enviously.
+
+"He was a good-hearted tailor, at any rate," observed Nick Chopper.
+
+"But where were you going, when you met us?" Tip asked the Woggle-Bug.
+
+"Nowhere in particular," was the reply, "although it is my intention
+soon to visit the Emerald City and arrange to give a course of lectures
+to select audiences on the 'Advantages of Magnification.'"
+
+"We are bound for the Emerald City now," said the Tin Woodman; "so, if
+it pleases you to do so, you are welcome to travel in our company."
+
+The Woggle-Bug bowed with profound grace.
+
+"It will give me great pleasure," said he, "to accept your kind
+invitation; for nowhere in the Land of Oz could I hope to meet with so
+congenial a company."
+
+"That is true," acknowledged the Pumpkinhead. "We are quite as
+congenial as flies and honey."
+
+"But--pardon me if I seem inquisitive--are you not all
+rather--ahem!--rather unusual?" asked the Woggle-Bug, looking from one
+to another with unconcealed interest.
+
+"Not more so than yourself," answered the Scarecrow. "Everything in
+life is unusual until you get accustomed to it."
+
+"What rare philosophy!" exclaimed the Woggle-Bug, admiringly.
+
+"Yes; my brains are working well today," admitted the Scarecrow, an
+accent of pride in his voice.
+
+"Then, if you are sufficiently rested and refreshed, let us bend our
+steps toward the Emerald City," suggested the magnified one.
+
+"We can't," said Tip. "The Saw-Horse has broken a leg, so he can't bend
+his steps. And there is no wood around to make him a new limb from. And
+we can't leave the horse behind because the Pumpkinhead is so stiff in
+his joints that he has to ride."
+
+"How very unfortunate!" cried the Woggle-Bug. Then he looked the party
+over carefully and said:
+
+"If the Pumpkinhead is to ride, why not use one of his legs to make a
+leg for the horse that carries him? I judge that both are made of wood."
+
+"Now, that is what I call real cleverness," said the Scarecrow,
+approvingly. "I wonder my brains did not think of that long ago! Get to
+work, my dear Nick, and fit the Pumpkinhead's leg to the Saw-Horse."
+
+Jack was not especially pleased with this idea; but he submitted to
+having his left leg amputated by the Tin Woodman and whittled down to
+fit the left leg of the Saw-Horse. Nor was the Saw-Horse especially
+pleased with the operation, either; for he growled a good deal about
+being "butchered," as he called it, and afterward declared that the new
+leg was a disgrace to a respectable Saw-Horse.
+
+"I beg you to be more careful in your speech," said the Pumpkinhead,
+sharply. "Remember, if you please, that it is my leg you are abusing."
+
+"I cannot forget it," retorted the Saw-Horse, "for it is quite as
+flimsy as the rest of your person."
+
+"Flimsy! me flimsy!" cried Jack, in a rage. "How dare you call me
+flimsy?"
+
+"Because you are built as absurdly as a jumping-jack," sneered the
+horse, rolling his knotty eyes in a vicious manner. "Even your head
+won't stay straight, and you never can tell whether you are looking
+backwards or forward!"
+
+"Friends, I entreat you not to quarrel!" pleaded the Tin Woodman,
+anxiously. "As a matter of fact, we are none of us above criticism; so
+let us bear with each others' faults."
+
+"An excellent suggestion," said the Woggle-Bug, approvingly. "You must
+have an excellent heart, my metallic friend."
+
+"I have," returned Nick, well pleased. "My heart is quite the best part
+of me. But now let us start upon our journey."
+
+They perched the one-legged Pumpkinhead upon the Saw-Horse, and tied
+him to his seat with cords, so that he could not possibly fall off.
+
+And then, following the lead of the Scarecrow, they all advanced in the
+direction of the Emerald City.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Old Mombi indulges
+    in Witchcraft
+]
+
+
+They soon discovered that the Saw-Horse limped, for his new leg was a
+trifle too long. So they were obliged to halt while the Tin Woodman
+chopped it down with his axe, after which the wooden steed paced along
+more comfortably. But the Saw-Horse was not entirely satisfied, even
+yet.
+
+"It was a shame that I broke my other leg!" it growled.
+
+"On the contrary," airily remarked the Woggle-Bug, who was walking
+alongside, "you should consider the accident most fortunate. For a
+horse is never of much use until he has been broken."
+
+"I beg your pardon," said Tip, rather provoked, for he felt a warm
+interest in both the Saw-Horse and his man Jack; "but permit me to say
+that your joke is a poor one, and as old as it is poor."
+
+"Still, it is a joke," declared the Woggle-Bug, firmly, "and a joke
+derived from a play upon words is considered among educated people to
+be eminently proper."
+
+"What does that mean?" enquired the Pumpkinhead, stupidly.
+
+"It means, my dear friend," explained the Woggle-Bug, "that our
+language contains many words having a double meaning; and that to
+pronounce a joke that allows both meanings of a certain word, proves
+the joker a person of culture and refinement, who has, moreover, a
+thorough command of the language."
+
+"I don't believe that," said Tip, plainly; "anybody can make a pun."
+
+"Not so," rejoined the Woggle-Bug, stiffly. "It requires education of
+a high order. Are you educated, young sir?"
+
+"Not especially," admitted Tip.
+
+"Then you cannot judge the matter. I myself am Thoroughly Educated, and
+I say that puns display genius. For instance, were I to ride upon this
+Saw-Horse, he would not only be an animal--he would become an equipage.
+For he would then be a horse-and-buggy."
+
+At this the Scarecrow gave a gasp and the Tin Woodman stopped short
+and looked reproachfully at the Woggle-Bug. At the same time the
+Saw-Horse loudly snorted his derision; and even the Pumpkinhead put up
+his hand to hide the smile which, because it was carved upon his face,
+he could not change to a frown.
+
+But the Woggle-Bug strutted along as if he had made some brilliant
+remark, and the Scarecrow was obliged to say:
+
+"I have heard, my dear friend, that a person can become over-educated;
+and although I have a high respect for brains, no matter how they may
+be arranged or classified, I begin to suspect that yours are slightly
+tangled. In any event, I must beg you to restrain your superior
+education while in our society."
+
+"We are not very particular," added the Tin Woodman; "and we are
+exceedingly kind hearted. But if your superior culture gets leaky
+again--" He did not complete the sentence, but he twirled his gleaming
+axe so carelessly that the Woggle-Bug looked frightened, and shrank
+away to a safe distance.
+
+The others marched on in silence, and the Highly-Magnified one, after
+a period of deep thought, said in an humble voice:
+
+"I will endeavor to restrain myself."
+
+"That is all we can expect," returned the Scarecrow, pleasantly; and
+good nature being thus happily restored to the party, they proceeded
+upon their way.
+
+When they again stopped to allow Tip to rest--the boy being the only
+one that seemed to tire--the Tin Woodman noticed many small, round
+holes in the grassy meadow.
+
+"This must be a village of the Field Mice," he said to the Scarecrow.
+"I wonder if my old friend, the Queen of the Mice, is in this
+neighborhood."
+
+"If she is, she may be of great service to us," answered the Scarecrow,
+who was impressed by a sudden thought. "See if you can call her, my
+dear Nick."
+
+So the Tin Woodman blew a shrill note upon a silver whistle that hung
+around his neck, and presently a tiny grey mouse popped from a near-by
+hole and advanced fearlessly toward them. For the Tin Woodman had once
+saved her life, and the Queen of the Field Mice knew he was to be
+trusted.
+
+"Good day, your Majesty," said Nick, politely addressing the mouse; "I
+trust you are enjoying good health?"
+
+"Thank you, I am quite well," answered the Queen, demurely, as she
+sat up and displayed the tiny golden crown upon her head. "Can I do
+anything to assist my old friends?"
+
+"You can, indeed," replied the Scarecrow, eagerly. "Let me, I intreat
+you, take a dozen of your subjects with me to the Emerald City."
+
+"Will they be injured in any way?" asked the Queen, doubtfully.
+
+"I think not," replied the Scarecrow. "I will carry them hidden in
+the straw which stuffs my body, and when I give them the signal by
+unbuttoning my jacket, they have only to rush out and scamper home
+again as fast as they can. By doing this they will assist me to regain
+my throne, which the Army of Revolt has taken from me."
+
+"In that case," said the Queen, "I will not refuse your request.
+Whenever you are ready, I will call twelve of my most intelligent
+subjects."
+
+"I am ready now," returned the Scarecrow. Then he lay flat upon the
+ground and unbuttoned his jacket, displaying the mass of straw with
+which he was stuffed.
+
+The Queen uttered a little piping call, and in an instant a dozen
+pretty field mice had emerged from their holes and stood before their
+ruler, awaiting her orders.
+
+What the Queen said to them none of our travelers could understand,
+for it was in the mouse language; but the field mice obeyed without
+hesitation, running one after the other to the Scarecrow and hiding
+themselves in the straw of his breast.
+
+When all of the twelve mice had thus concealed themselves, the
+Scarecrow buttoned his jacket securely and then arose and thanked the
+Queen for her kindness.
+
+"One thing more you might do to serve us," suggested the Tin Woodman;
+"and that is to run ahead and show us the way to the Emerald City. For
+some enemy is evidently trying to prevent us from reaching it."
+
+"I will do that gladly," returned the Queen. "Are you ready?"
+
+The Tin Woodman looked at Tip.
+
+"I'm rested," said the boy. "Let us start."
+
+Then they resumed their journey, the little grey Queen of the Field
+Mice running swiftly ahead and then pausing until the travelers drew
+near, when away she would dart again.
+
+Without this unerring guide the Scarecrow and his comrades might never
+have gained the Emerald City; for many were the obstacles thrown in
+their way by the arts of old Mombi. Yet not one of the obstacles really
+existed--all were cleverly contrived deceptions. For when they came
+to the banks of a rushing river that threatened to bar their way the
+little Queen kept steadily on, passing through the seeming flood in
+safety; and our travelers followed her without encountering a single
+drop of water.
+
+Again, a high wall of granite towered high above their heads and
+opposed their advance. But the grey Field Mouse walked straight through
+it, and the others did the same, the wall melting into mist as they
+passed it.
+
+Afterward, when they had stopped for a moment to allow Tip to rest,
+they saw forty roads branching off from their feet in forty different
+directions; and soon these forty roads began whirling around like a
+mighty wheel, first in one direction and then in the other, completely
+bewildering their vision.
+
+But the Queen called for them to follow her and darted off in a
+straight line; and when they had gone a few paces the whirling pathways
+vanished and were seen no more.
+
+Mombi's last trick was most fearful of all. She sent a sheet of
+crackling flame rushing over the meadow to consume them; and for the
+first time the Scarecrow became afraid and turned to fly.
+
+"If that fire reaches me I will be gone in no time!" said he, trembling
+until his straw rattled. "It's the most dangerous thing I ever
+encountered."
+
+"I'm off, too!" cried the Saw-Horse, turning and prancing with
+agitation; "for my wood is so dry it would burn like kindlings."
+
+"Is fire dangerous to pumpkins?" asked Jack, fearfully.
+
+[Illustration]
+
+"You'll be baked like a tart--and so will I!" answered the Woggle-Bug,
+getting down on all fours so he could run the faster.
+
+But the Tin Woodman, having no fear of fire, averted the stampede by a
+few sensible words.
+
+"Look at the Field Mouse!" he shouted. "The fire does not burn her in
+the least. In fact, it is no fire at all, but only a deception."
+
+Indeed, to watch the little Queen march calmly through the advancing
+flames restored courage to every member of the party, and they followed
+her without being even scorched.
+
+"This is surely a most extraordinary adventure," said the Woggle-Bug,
+who was greatly amazed; "for it upsets all the Natural Laws that I
+heard Professor Nowitall teach in the school-house."
+
+"Of course it does," said the Scarecrow, wisely. "All magic is
+unnatural, and for that reason is to be feared and avoided. But I see
+before us the gates of the Emerald City, so I imagine we have now
+overcome all the magical obstacles that seemed to oppose us."
+
+Indeed, the walls of the City were plainly visible, and the Queen of
+the Field Mice, who had guided them so faithfully, came near to bid
+them good-bye.
+
+"We are very grateful to your Majesty for your kind assistance," said
+the Tin Woodman, bowing before the pretty creature.
+
+"I am always pleased to be of service to my friends," answered the
+Queen, and in a flash she had darted away upon her journey home.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Prisoners of the Queen
+]
+
+
+Approaching the gateway of the Emerald City the travelers found it
+guarded by two girls of the Army of Revolt, who opposed their entrance
+by drawing the knitting-needles from their hair and threatening to prod
+the first that came near.
+
+But the Tin Woodman was not afraid.
+
+"At the worst they can but scratch my beautiful nickel-plate," he said.
+"But there will be no 'worst,' for I think I can manage to frighten
+these absurd soldiers very easily. Follow me closely, all of you!"
+
+Then, swinging his axe in a great circle to right and left before
+him, he advanced upon the gate, and the others followed him without
+hesitation.
+
+The girls, who had expected no resistance whatever, were terrified by
+the sweep of the glittering axe and fled screaming into the city; so
+that our travelers passed the gates in safety and marched down the
+green marble pavement of the wide street toward the royal palace.
+
+"At this rate we will soon have your Majesty upon the throne again,"
+said the Tin Woodman, laughing at his easy conquest of the guards.
+
+"Thank you, friend Nick," returned the Scarecrow, gratefully. "Nothing
+can resist your kind heart and your sharp axe."
+
+As they passed the rows of houses they saw through the open doors that
+men were sweeping and dusting and washing dishes, while the women sat
+around in groups, gossiping and laughing.
+
+"What has happened?" the Scarecrow asked a sad-looking man with a bushy
+beard, who wore an apron and was wheeling a baby-carriage along the
+sidewalk.
+
+"Why, we've had a revolution, your Majesty--as you ought to know very
+well," replied the man; "and since you went away the women have been
+running things to suit themselves. I'm glad you have decided to come
+back and restore order, for doing housework and minding the children is
+wearing out the strength of every man in the Emerald City."
+
+"Hm!" said the Scarecrow, thoughtfully. "If it is such hard work as
+you say, how did the women manage it so easily?"
+
+"I really do not know," replied the man, with a deep sigh. "Perhaps the
+women are made of cast-iron."
+
+No movement was made, as they passed along the street, to oppose their
+progress. Several of the women stopped their gossip long enough to cast
+curious looks upon our friends, but immediately they would turn away
+with a laugh or a sneer and resume their chatter. And when they met
+with several girls belonging to the Army of Revolt, those soldiers,
+instead of being alarmed or appearing surprised, merely stepped out of
+the way and allowed them to advance without protest.
+
+This action rendered the Scarecrow uneasy.
+
+"I'm afraid we are walking into a trap," said he.
+
+"Nonsense!" returned Nick Chopper, confidently; "the silly creatures
+are conquered already!"
+
+But the Scarecrow shook his head in a way that expressed doubt, and Tip
+said:
+
+"It's too easy, altogether. Look out for trouble ahead."
+
+"I will," returned his Majesty.
+
+[Illustration: "IT'S TOO EASY, ALTOGETHER."]
+
+Unopposed they reached the royal palace and marched up the marble
+steps, which had once been thickly encrusted with emeralds but were
+now filled with tiny holes where the jewels had been ruthlessly torn
+from their settings by the Army of Revolt. And so far not a rebel
+barred their way.
+
+Through the arched hallways and into the magnificent throne room
+marched the Tin Woodman and his followers, and here, when the green
+silken curtains fell behind them, they saw a curious sight.
+
+Seated within the glittering throne was General Jinjur, with the
+Scarecrow's second-best crown upon her head, and the royal sceptre in
+her right hand. A box of caramels, from which she was eating, rested in
+her lap, and the girl seemed entirely at ease in her royal surroundings.
+
+The Scarecrow stepped forward and confronted her, while the Tin Woodman
+leaned upon his axe and the others formed a half-circle back of his
+Majesty's person.
+
+"How dare you sit in my throne?" demanded the Scarecrow, sternly eyeing
+the intruder. "Don't you know you are guilty of treason, and that there
+is a law against treason?"
+
+"The throne belongs to whoever is able to take it," answered Jinjur, as
+she slowly ate another caramel. "I have taken it, as you see; so just
+now I am the Queen, and all who oppose me are guilty of treason, and
+must be punished by the law you have just mentioned."
+
+This view of the case puzzled the Scarecrow.
+
+"How is it, friend Nick?" he asked, turning to the Tin Woodman.
+
+"Why, when it comes to Law, I have nothing to say," answered that
+personage; "for laws were never meant to be understood, and it is
+foolish to make the attempt."
+
+"Then what shall we do?" asked the Scarecrow, in dismay.
+
+"Why don't you marry the Queen? And then you can both rule," suggested
+the Woggle-Bug.
+
+Jinjur glared at the insect fiercely.
+
+"Why don't you send her back to her mother, where she belongs?" asked
+Jack Pumpkinhead.
+
+Jinjur frowned.
+
+"Why don't you shut her up in a closet until she behaves herself, and
+promises to be good?" enquired Tip. Jinjur's lip curled scornfully.
+
+"Or give her a good shaking!" added the Saw-Horse.
+
+"No," said the Tin Woodman, "we must treat the poor girl with
+gentleness. Let us give her all the jewels she can carry, and send her
+away happy and contented."
+
+At this Queen Jinjur laughed aloud, and the next minute clapped her
+pretty hands together thrice, as if for a signal.
+
+"You are very absurd creatures," said she; "but I am tired of your
+nonsense and have no time to bother with you longer."
+
+While the monarch and his friends listened in amazement to this
+impudent speech, a startling thing happened. The Tin Woodman's axe was
+snatched from his grasp by some person behind him, and he found himself
+disarmed and helpless. At the same instant a shout of laughter rang in
+the ears of the devoted band, and turning to see whence this came they
+found themselves surrounded by the Army of Revolt, the girls bearing in
+either hand their glistening knitting-needles. The entire throne room
+seemed to be filled with the rebels, and the Scarecrow and his comrades
+realized that they were prisoners.
+
+"You see how foolish it is to oppose a woman's wit," said Jinjur,
+gaily; "and this event only proves that I am more fit to rule the
+Emerald City than a Scarecrow. I bear you no ill will, I assure you;
+but lest you should prove troublesome to me in the future I shall order
+you all to be destroyed. That is, all except the boy, who belongs
+to old Mombi and must be restored to her keeping. The rest of you
+are not human, and therefore it will not be wicked to demolish you.
+The Saw-Horse and the Pumpkinhead's body I will have chopped up for
+kindling-wood; and the pumpkin shall be made into tarts. The Scarecrow
+will do nicely to start a bonfire, and the tin man can be cut into
+small pieces and fed to the goats. As for this immense Woggle-Bug--"
+
+"Highly Magnified, if you please!" interrupted the insect.
+
+"I think I will ask the cook to make green-turtle soup of you,"
+continued the Queen, reflectively.
+
+The Woggle-Bug shuddered.
+
+"Or, if that won't do, we might use you for a Hungarian goulash, stewed
+and highly spiced," she added, cruelly.
+
+This programme of extermination was so terrible that the prisoners
+looked upon one another in a panic of fear. The Scarecrow alone did not
+give way to despair. He stood quietly before the Queen and his brow was
+wrinkled in deep thought as he strove to find some means to escape.
+
+While thus engaged he felt the straw within his breast move gently. At
+once his expression changed from sadness to joy, and raising his hand
+he quickly unbuttoned the front of his jacket.
+
+[Illustration]
+
+This action did not pass unnoticed by the crowd of girls clustering
+about him, but none of them suspected what he was doing until a tiny
+grey mouse leaped from his bosom to the floor and scampered away
+between the feet of the Army of Revolt. Another mouse quickly followed;
+then another and another, in rapid succession. And suddenly such a
+scream of terror went up from the Army that it might easily have filled
+the stoutest heart with consternation. The flight that ensued turned to
+a stampede, and the stampede to a panic.
+
+For while the startled mice rushed wildly about the room the Scarecrow
+had only time to note a whirl of skirts and a twinkling of feet as the
+girls disappeared from the palace--pushing and crowding one another in
+their mad efforts to escape.
+
+The Queen, at the first alarm, stood up on the cushions of the throne
+and began to dance frantically upon her tiptoes. Then a mouse ran up
+the cushions, and with a terrified leap poor Jinjur shot clear over the
+head of the Scarecrow and escaped through an archway--never pausing in
+her wild career until she had reached the city gates.
+
+So, in less time than I can explain, the throne room was deserted by
+all save the Scarecrow and his friends, and the Woggle-Bug heaved a
+deep sigh of relief as he exclaimed:
+
+"Thank goodness, we are saved!"
+
+"For a time, yes;" answered the Tin Woodman. "But the enemy will soon
+return, I fear."
+
+"Let us bar all the entrances to the palace!" said the Scarecrow. "Then
+we shall have time to think what is best to be done."
+
+So all except Jack Pumpkinhead, who was still tied fast to the
+Saw-Horse, ran to the various entrances of the royal palace and closed
+the heavy doors, bolting and locking them securely. Then, knowing that
+the Army of Revolt could not batter down the barriers in several days,
+the adventurers gathered once more in the throne room for a council of
+war.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Takes Time to Think
+]
+
+
+"It seems to me," began the Scarecrow, when all were again assembled in
+the throne room, "that the girl Jinjur is quite right in claiming to be
+Queen. And if she is right, then I am wrong, and we have no business to
+be occupying her palace."
+
+"But you were the King until she came," said the Woggle-Bug, strutting
+up and down with his hands in his pockets; "so it appears to me that
+she is the interloper instead of you."
+
+"Especially as we have just conquered her and put her to flight," added
+the Pumpkinhead, as he raised his hands to turn his face toward the
+Scarecrow.
+
+"Have we really conquered her?" asked the Scarecrow, quietly. "Look out
+of the window, and tell me what you see."
+
+Tip ran to the window and looked out.
+
+"The palace is surrounded by a double row of girl soldiers," he
+announced.
+
+"I thought so," returned the Scarecrow. "We are as truly their
+prisoners as we were before the mice frightened them from the palace."
+
+"My friend is right," said Nick Chopper, who had been polishing his
+breast with a bit of chamois-leather. "Jinjur is still the Queen, and
+we are her prisoners."
+
+"But I hope she cannot get at us," exclaimed the Pumpkinhead, with a
+shiver of fear. "She threatened to make tarts of me, you know."
+
+"Don't worry," said the Tin Woodman. "It cannot matter greatly. If you
+stay shut up here you will spoil in time, anyway. A good tart is far
+more admirable than a decayed intellect."
+
+"Very true," agreed the Scarecrow.
+
+"Oh, dear!" moaned Jack; "what an unhappy lot is mine! Why, dear
+father, did you not make me out of tin--or even out of straw--so that
+I would keep indefinitely."
+
+"Shucks!" returned Tip, indignantly. "You ought to be glad that I made
+you at all." Then he added, reflectively, "everything has to come to an
+end, some time."
+
+"But I beg to remind you," broke in the Woggle-Bug, who had a
+distressed look in his bulging, round eyes, "that this terrible Queen
+Jinjur suggested making a goulash of me--Me! the only Highly Magnified
+and Thoroughly Educated Woggle-Bug in the wide, wide world!"
+
+"I think it was a brilliant idea," remarked the Scarecrow, approvingly.
+
+"Don't you imagine he would make a better soup?" asked the Tin Woodman,
+turning toward his friend.
+
+"Well, perhaps," acknowledged the Scarecrow.
+
+The Woggle-Bug groaned.
+
+"I can see, in my mind's eye," said he, mournfully, "the goats eating
+small pieces of my dear comrade, the Tin Woodman, while my soup is
+being cooked on a bonfire built of the Saw-Horse and Jack Pumpkinhead's
+body, and Queen Jinjur watches me boil while she feeds the flames with
+my friend the Scarecrow!"
+
+This morbid picture cast a gloom over the entire party, making them
+restless and anxious.
+
+"It can't happen for some time," said the Tin Woodman, trying to speak
+cheerfully; "for we shall be able to keep Jinjur out of the palace
+until she manages to break down the doors."
+
+"And in the meantime I am liable to starve to death, and so is the
+Woggle-Bug," announced Tip.
+
+"As for me," said the Woggle-Bug, "I think that I could live for some
+time on Jack Pumpkinhead. Not that I prefer pumpkins for food; but I
+believe they are somewhat nutritious, and Jack's head is large and
+plump."
+
+"How heartless!" exclaimed the Tin Woodman, greatly shocked. "Are we
+cannibals, let me ask? Or are we faithful friends?"
+
+"I see very clearly that we cannot stay shut up in this palace," said
+the Scarecrow, with decision. "So let us end this mournful talk and try
+to discover a means to escape."
+
+At this suggestion they all gathered eagerly around the throne, wherein
+was seated the Scarecrow, and as Tip sat down upon a stool there fell
+from his pocket a pepper-box, which rolled upon the floor.
+
+"What is this?" asked Nick Chopper, picking up the box.
+
+"Be careful!" cried the boy. "That's my Powder of Life. Don't spill it,
+for it is nearly gone."
+
+"And what is the Powder of Life?" enquired the Scarecrow, as Tip
+replaced the box carefully in his pocket.
+
+"It's some magical stuff old Mombi got from a crooked sorcerer,"
+explained the boy. "She brought Jack to life with it, and afterward I
+used it to bring the Saw-Horse to life. I guess it will make anything
+live that is sprinkled with it; but there's only about one dose left."
+
+"Then it is very precious," said the Tin Woodman.
+
+"Indeed it is," agreed the Scarecrow. "It may prove our best means of
+escape from our difficulties. I believe I will think for a few minutes;
+so I will thank you, friend Tip, to get out your knife and rip this
+heavy crown from my forehead."
+
+Tip soon cut the stitches that had fastened the crown to the
+Scarecrow's head, and the former monarch of the Emerald City removed it
+with a sigh of relief and hung it on a peg beside the throne.
+
+[Illustration]
+
+"That is my last memento of royalty," said he; "and I'm glad to get rid
+of it. The former King of this City, who was named Pastoria, lost the
+crown to the Wonderful Wizard, who passed it on to me. Now the girl
+Jinjur claims it, and I sincerely hope it will not give her a headache."
+
+"A kindly thought, which I greatly admire," said the Tin Woodman,
+nodding approvingly.
+
+"And now I will indulge in a quiet think," continued the Scarecrow,
+lying back in the throne.
+
+The others remained as silent and still as possible, so as not to
+disturb him; for all had great confidence in the extraordinary brains
+of the Scarecrow.
+
+And, after what seemed a very long time indeed to the anxious watchers,
+the thinker sat up, looked upon his friends with his most whimsical
+expression, and said:
+
+"My brains work beautifully today. I'm quite proud of them. Now,
+listen! If we attempt to escape through the doors of the palace we
+shall surely be captured. And, as we can't escape through the ground,
+there is only one other thing to be done. We must escape through the
+air!"
+
+He paused to note the effect of these words; but all his hearers seemed
+puzzled and unconvinced.
+
+"The Wonderful Wizard escaped in a balloon," he continued. "We don't
+know how to make a balloon, of course; but any sort of thing that can
+fly through the air can carry us easily. So I suggest that my friend
+the Tin Woodman, who is a skillful mechanic, shall build some sort of
+a machine, with good strong wings, to carry us; and our friend Tip can
+then bring the Thing to life with his magical powder."
+
+"Bravo!" cried Nick Chopper.
+
+"What splendid brains!" murmured Jack.
+
+"Really quite clever!" said the Educated Woggle-Bug.
+
+[Illustration]
+
+"I believe it can be done," declared Tip; "that is, if the Tin Woodman
+is equal to making the Thing."
+
+"I'll do my best," said Nick, cheerily; "and, as a matter of fact, I do
+not often fail in what I attempt. But the Thing will have to be built
+on the roof of the palace, so it can rise comfortably into the air."
+
+"To be sure," said the Scarecrow.
+
+"Then let us search through the palace," continued the Tin Woodman,
+"and carry all the material we can find to the roof, where I will begin
+my work."
+
+"First, however," said the Pumpkinhead, "I beg you will release me from
+this horse, and make me another leg to walk with. For in my present
+condition I am of no use to myself or to anyone else."
+
+So the Tin Woodman knocked a mahogany center-table to pieces with his
+axe and fitted one of the legs, which was beautifully carved, on to the
+body of Jack Pumpkinhead, who was very proud of the acquisition.
+
+"It seems strange," said he, as he watched the Tin Woodman work, "that
+my left leg should be the most elegant and substantial part of me."
+
+"That proves you are unusual," returned the Scarecrow; "and I am
+convinced that the only people worthy of consideration in this world
+are the unusual ones. For the common folks are like the leaves of a
+tree, and live and die unnoticed."
+
+"Spoken like a philosopher!" cried the Woggle-Bug, as he assisted the
+Tin Woodman to set Jack upon his feet.
+
+"How do you feel now?" asked Tip, watching the Pumpkinhead stump
+around to try his new leg.
+
+"As good as new," answered Jack, joyfully, "and quite ready to assist
+you all to escape."
+
+"Then let us get to work," said the Scarecrow, in a business-like tone.
+
+So, glad to be doing anything that might lead to the end of their
+captivity, the friends separated to wander over the palace in search of
+fitting material to use in the construction of their aerial machine.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Astonishing Flight
+    of the Gump
+]
+
+
+When the adventurers reassembled upon the roof it was found that a
+remarkably queer assortment of articles had been selected by the
+various members of the party. No one seemed to have a very clear idea
+of what was required, but all had brought something.
+
+The Woggle-Bug had taken from its position over the mantle-piece in the
+great hallway the head of a Gump, which was adorned with wide-spreading
+antlers; and this, with great care and greater difficulty, the insect
+had carried up the stairs to the roof. This Gump resembled an Elk's
+head, only the nose turned upward in a saucy manner and there were
+whiskers upon its chin, like those of a billy-goat. Why the Woggle-Bug
+selected this article he could not have explained, except that it had
+aroused his curiosity.
+
+Tip, with the aid of the Saw-Horse, had brought a large, upholstered
+sofa to the roof. It was an old-fashioned piece of furniture, with high
+back and ends, and it was so heavy that even by resting the greatest
+weight upon the back of the Saw-Horse, the boy found himself out of
+breath when at last the clumsy sofa was dumped upon the roof.
+
+The Pumpkinhead had brought a broom, which was the first thing he saw.
+The Scarecrow arrived with a coil of clotheslines and ropes which he
+had taken from the courtyard, and in his trip up the stairs he had
+become so entangled in the loose ends of the ropes that both he and his
+burden tumbled in a heap upon the roof and might have rolled off if Tip
+had not rescued him.
+
+The Tin Woodman appeared last. He also had been to the courtyard, where
+he had cut four great, spreading leaves from a huge palm-tree that was
+the pride of all the inhabitants of the Emerald City.
+
+"My dear Nick!" exclaimed the Scarecrow, seeing what his friend had
+done; "you have been guilty of the greatest crime any person can
+commit in the Emerald City. If I remember rightly, the penalty for
+chopping leaves from the royal palm-tree is to be killed seven times
+and afterward imprisoned for life."
+
+[Illustration: ALL BROUGHT SOMETHING TO THE ROOF.]
+
+"It cannot be helped now," answered the Tin Woodman, throwing down the
+big leaves upon the roof. "But it may be one more reason why it is
+necessary for us to escape. And now let us see what you have found for
+me to work with."
+
+Many were the doubtful looks cast upon the heap of miscellaneous
+material that now cluttered the roof, and finally the Scarecrow shook
+his head and remarked:
+
+"Well, if friend Nick can manufacture, from this mess of rubbish, a
+Thing that will fly through the air and carry us to safety, then I will
+acknowledge him to be a better mechanic than I suspected."
+
+But the Tin Woodman seemed at first by no means sure of his powers, and
+only after polishing his forehead vigorously with the chamois-leather
+did he resolve to undertake the task.
+
+"The first thing required for the machine," said he, "is a body big
+enough to carry the entire party. This sofa is the biggest thing we
+have, and might be used for a body. But, should the machine ever tip
+sideways, we would all slide off and fall to the ground."
+
+"Why not use two sofas?" asked Tip. "There's another one just like this
+down stairs."
+
+"That is a very sensible suggestion," exclaimed the Tin Woodman. "You
+must fetch the other sofa at once."
+
+So Tip and the Saw-Horse managed, with much labor, to get the second
+sofa to the roof; and when the two were placed together, edge to edge,
+the backs and ends formed a protecting rampart all around the seats.
+
+"Excellent!" cried the Scarecrow. "We can ride within this snug nest
+quite at our ease."
+
+The two sofas were now bound firmly together with ropes and
+clotheslines, and then Nick Chopper fastened the Gump's head to one end.
+
+"That will show which is the front end of the Thing," said he, greatly
+pleased with the idea. "And, really, if you examine it critically, the
+Gump looks very well as a figure-head. These great palm-leaves, for
+which I have endangered my life seven times, must serve us as wings."
+
+"Are they strong enough?" asked the boy.
+
+"They are as strong as anything we can get," answered the Woodman; "and
+although they are not in proportion to the Thing's body, we are not in
+a position to be very particular."
+
+So he fastened the palm-leaves to the sofas, two on each side.
+
+Said the Woggle-Bug, with considerable admiration:
+
+"The Thing is now complete, and only needs to be brought to life."
+
+"Stop a moment!" exclaimed Jack. "Are you not going to use my broom?"
+
+"What for?" asked the Scarecrow.
+
+"Why, it can be fastened to the back end for a tail," answered the
+Pumpkinhead. "Surely you would not call the Thing complete without a
+tail."
+
+"Hm!" said the Tin Woodman; "I do not see the use of a tail. We are not
+trying to copy a beast, or a fish, or a bird. All we ask of the Thing
+is to carry us through the air."
+
+"Perhaps, after the Thing is brought to life, it can use a tail to
+steer with," suggested the Scarecrow. "For if it flies through the air
+it will not be unlike a bird, and I've noticed that all birds have
+tails, which they use for a rudder while flying."
+
+"Very well," answered Nick, "the broom shall be used for a tail," and
+he fastened it firmly to the back end of the sofa body.
+
+Tip took the pepper-box from his pocket.
+
+"The Thing looks very big," said he, anxiously; "and I am not sure
+there is enough powder left to bring all of it to life. But I'll make
+it go as far as possible."
+
+"Put most on the wings," said Nick Chopper; "for they must be made as
+strong as possible."
+
+"And don't forget the head!" exclaimed the Woggle-Bug.
+
+"Or the tail!" added Jack Pumpkinhead.
+
+"Do be quiet," said Tip, nervously; "you must give me a chance to work
+the magic charm in the proper manner."
+
+Very carefully he began sprinkling the Thing with the precious powder.
+Each of the four wings was first lightly covered with a layer; then the
+sofas were sprinkled, and the broom given a slight coating.
+
+"The head! The head! Don't, I beg of you, forget the head!" cried the
+Woggle-Bug, excitedly.
+
+"There's only a little of the powder left," announced Tip, looking
+within the box. "And it seems to me it is more important to bring the
+legs of the sofas to life than the head."
+
+"Not so," decided the Scarecrow. "Every thing must have a head to
+direct it; and since this creature is to fly, and not walk, it is
+really unimportant whether its legs are alive or not."
+
+So Tip abided by this decision and sprinkled the Gump's head with the
+remainder of the powder.
+
+"Now," said he, "keep silence while I work the charm!"
+
+Having heard old Mombi pronounce the magic words, and having also
+succeeded in bringing the Saw-Horse to life, Tip did not hesitate an
+instant in speaking the three cabalistic words, each accompanied by the
+peculiar gesture of the hands.
+
+It was a grave and impressive ceremony.
+
+As he finished the incantation the Thing shuddered throughout its
+huge bulk, the Gump gave the screeching cry that is familiar to those
+animals, and then the four wings began flopping furiously.
+
+[Illustration]
+
+Tip managed to grasp a chimney, else he would have been blown off the
+roof by the terrible breeze raised by the wings. The Scarecrow, being
+light in weight, was caught up bodily and borne through the air until
+Tip luckily seized him by one leg and held him fast. The Woggle-Bug
+lay flat upon the roof and so escaped harm, and the Tin Woodman,
+whose weight of tin anchored him firmly, threw both arms around Jack
+Pumpkinhead and managed to save him. The Saw-Horse toppled over upon
+his back and lay with his legs waving helplessly above him.
+
+And now, while all were struggling to recover themselves, the Thing
+rose slowly from the roof and mounted into the air.
+
+"Here! Come back!" cried Tip, in a frightened voice, as he clung to the
+chimney with one hand and the Scarecrow with the other. "Come back at
+once, I command you!"
+
+It was now that the wisdom of the Scarecrow, in bringing the head of
+the Thing to life instead of the legs, was proved beyond a doubt. For
+the Gump, already high in the air, turned its head at Tip's command and
+gradually circled around until it could view the roof of the palace.
+
+"Come back!" shouted the boy, again.
+
+And the Gump obeyed, slowly and gracefully waving its four wings in
+the air until the Thing had settled once more upon the roof and become
+still.
+
+[Illustration: "COME BACK!"]
+
+
+
+
+[Illustration:
+
+    In the Jackdaws' Nest
+]
+
+
+"This," said the Gump, in a squeaky voice not at all proportioned to
+the size of its great body, "is the most novel experience I ever heard
+of. The last thing I remember distinctly is walking through the forest
+and hearing a loud noise. Something probably killed me then, and it
+certainly ought to have been the end of me. Yet here I am, alive again,
+with four monstrous wings and a body which I venture to say would make
+any respectable animal or fowl weep with shame to own. What does it all
+mean? Am I a Gump, or am I a juggernaut?" The creature, as it spoke,
+wiggled its chin whiskers in a very comical manner.
+
+"You're just a Thing," answered Tip, "with a Gump's head on it. And we
+have made you and brought you to life so that you may carry us through
+the air wherever we wish to go."
+
+"Very good!" said the Thing. "As I am not a Gump, I cannot have a
+Gump's pride or independent spirit. So I may as well become your
+servant as anything else. My only satisfaction is that I do not seem
+to have a very strong constitution, and am not likely to live long in
+a state of slavery."
+
+"Don't say that, I beg of you!" cried the Tin Woodman, whose excellent
+heart was strongly affected by this sad speech. "Are you not feeling
+well today?"
+
+"Oh, as for that," returned the Gump, "it is my first day of existence;
+so I cannot judge whether I am feeling well or ill." And it waved its
+broom tail to and fro in a pensive manner.
+
+"Come, come!" said the Scarecrow, kindly; "do try to be more cheerful
+and take life as you find it. We shall be kind masters, and will strive
+to render your existence as pleasant as possible. Are you willing to
+carry us through the air wherever we wish to go?"
+
+"Certainly," answered the Gump. "I greatly prefer to navigate the air.
+For should I travel on the earth and meet with one of my own species,
+my embarrassment would be something awful!"
+
+"I can appreciate that," said the Tin Woodman, sympathetically.
+
+"And yet," continued the Thing, "when I carefully look you over, my
+masters, none of you seems to be constructed much more artistically
+than I am."
+
+"Appearances are deceitful," said the Woggle-Bug, earnestly. "I am both
+Highly Magnified and Thoroughly Educated."
+
+"Indeed!" murmured the Gump, indifferently.
+
+"And my brains are considered remarkably rare specimens," added the
+Scarecrow, proudly.
+
+"How strange!" remarked the Gump.
+
+"Although I am of tin," said the Woodman, "I own a heart altogether the
+warmest and most admirable in the whole world."
+
+"I'm delighted to hear it," replied the Gump, with a slight cough.
+
+"My smile," said Jack Pumpkinhead, "is worthy your best attention. It
+is always the same."
+
+"_Semper idem_," explained the Woggle-Bug, pompously; and the Gump
+turned to stare at him.
+
+"And I," declared the Saw-Horse, filling in an awkward pause, "am only
+remarkable because I can't help it."
+
+"I am proud, indeed, to meet with such exceptional masters," said
+the Gump, in a careless tone. "If I could but secure so complete an
+introduction to myself, I would be more than satisfied."
+
+"That will come in time," remarked the Scarecrow. "To 'Know Thyself'
+is considered quite an accomplishment, which it has taken us, who are
+your elders, months to perfect. But now," he added, turning to the
+others, "let us get aboard and start upon our journey."
+
+"Where shall we go?" asked Tip, as he clambered to a seat on the sofas
+and assisted the Pumpkinhead to follow him.
+
+"In the South Country rules a very delightful Queen called Glinda
+the Good, who I am sure will gladly receive us," said the Scarecrow,
+getting into the Thing clumsily. "Let us go to her and ask her advice."
+
+"That is cleverly thought of," declared Nick Chopper, giving the
+Woggle-Bug a boost and then toppling the Saw-Horse into the rear end
+of the cushioned seats. "I know Glinda the Good, and believe she will
+prove a friend indeed."
+
+"Are we all ready?" asked the boy.
+
+"Yes," announced the Tin Woodman, seating himself beside the Scarecrow.
+
+"Then," said Tip, addressing the Gump, "be kind enough to fly with us
+to the Southward; and do not go higher than to escape the houses and
+trees, for it makes me dizzy to be up so far."
+
+"All right," answered the Gump, briefly.
+
+It flopped its four huge wings and rose slowly into the air; and then,
+while our little band of adventurers clung to the backs and sides of
+the sofas for support, the Gump turned toward the South and soared
+swiftly and majestically away.
+
+"The scenic effect, from this altitude, is marvelous," commented the
+educated Woggle-Bug, as they rode along.
+
+"Never mind the scenery," said the Scarecrow. "Hold on tight, or you
+may get a tumble. The Thing seems to rock badly."
+
+"It will be dark soon," said Tip, observing that the sun was low on the
+horizon. "Perhaps we should have waited until morning. I wonder if the
+Gump can fly in the night."
+
+"I've been wondering that myself," returned the Gump, quietly. "You
+see, this is a new experience to me. I used to have legs that carried
+me swiftly over the ground. But now my legs feel as if they were
+asleep."
+
+"They are," said Tip. "We didn't bring 'em to life."
+
+"You're expected to fly," explained the Scarecrow; "not to walk."
+
+"We can walk ourselves," said the Woggle-Bug.
+
+"I begin to understand what is required of me," remarked the Gump; "so
+I will do my best to please you," and he flew on for a time in silence.
+
+Presently Jack Pumpkinhead became uneasy.
+
+"I wonder if riding through the air is liable to spoil pumpkins," he
+said.
+
+"Not unless you carelessly drop your head over the side," answered the
+Woggle-Bug. "In that event your head would no longer be a pumpkin, for
+it would become a squash."
+
+"Have I not asked you to restrain these unfeeling jokes?" demanded Tip,
+looking at the Woggle-Bug with a severe expression.
+
+"You have; and I've restrained a good many of them," replied the
+insect. "But there are opportunities for so many excellent puns in our
+language that, to an educated person like myself, the temptation to
+express them is almost irresistible."
+
+"People with more or less education discovered those puns centuries
+ago," said Tip.
+
+"Are you sure?" asked the Woggle-Bug, with a startled look.
+
+"Of course I am," answered the boy. "An educated Woggle-Bug may be a
+new thing; but a Woggle-Bug education is as old as the hills, judging
+from the display you make of it."
+
+The insect seemed much impressed by this remark, and for a time
+maintained a meek silence.
+
+The Scarecrow, in shifting his seat, saw upon the cushions the
+pepper-box which Tip had cast aside, and began to examine it.
+
+"Throw it overboard," said the boy; "it's quite empty now, and there's
+no use keeping it."
+
+"Is it really empty?" asked the Scarecrow, looking curiously into the
+box.
+
+"Of course it is," answered Tip. "I shook out every grain of the
+powder."
+
+"Then the box has two bottoms," announced the Scarecrow; "for the
+bottom on the inside is fully an inch away from the bottom on the
+outside."
+
+"Let me see," said the Tin Woodman, taking the box from his friend.
+"Yes," he declared, after looking it over, "the thing certainly has a
+false bottom. Now, I wonder what that is for?"
+
+"Can't you get it apart, and find out?" enquired Tip, now quite
+interested in the mystery.
+
+"Why, yes; the lower bottom unscrews," said the Tin Woodman. "My
+fingers are rather stiff; please see if you can open it."
+
+He handed the pepper-box to Tip, who had no difficulty in unscrewing
+the bottom. And in the cavity below were three silver pills, with a
+carefully folded paper lying underneath them.
+
+This paper the boy proceeded to unfold, taking care not to spill the
+pills, and found several lines clearly written in red ink.
+
+"Read it aloud," said the Scarecrow; so Tip read as follows:
+
+    "DR. NIKIDIK'S CELEBRATED WISHING PILLS.
+
+    "_Directions for Use_: Swallow one pill; count seventeen by twos;
+    then make a Wish.--The Wish will immediately be granted.
+
+    "CAUTION: Keep in a Dry and Dark Place."
+
+"Why, this is a very valuable discovery!" cried the Scarecrow.
+
+"It is, indeed," replied Tip, gravely. "These pills may be of great
+use to us. I wonder if old Mombi knew they were in the bottom of the
+pepper-box. I remember hearing her say that she got the Powder of Life
+from this same Nikidik."
+
+"He must be a powerful Sorcerer!" exclaimed the Tin Woodman; "and since
+the powder proved a success we ought to have confidence in the pills."
+
+"But how," asked the Scarecrow, "can anyone count seventeen by twos?
+Seventeen is an odd number.
+
+"That is true," replied Tip, greatly disappointed. "No one can possibly
+count seventeen by twos."
+
+"Then the pills are of no use to us," wailed the Pumpkinhead; "and this
+fact overwhelms me with grief. For I had intended wishing that my head
+would never spoil."
+
+"Nonsense!" said the Scarecrow, sharply. "If we could use the pills at
+all we would make far better wishes than that."
+
+"I do not see how anything could be better," protested poor Jack. "If
+you were liable to spoil at any time you could understand my anxiety."
+
+"For my part," said the Tin Woodman, "I sympathize with you in every
+respect. But since we cannot count seventeen by twos, sympathy is all
+you are liable to get."
+
+By this time it had become quite dark, and the voyagers found above
+them a cloudy sky, through which the rays of the moon could not
+penetrate.
+
+The Gump flew steadily on, and for some reason the huge sofa-body
+rocked more and more dizzily every hour.
+
+The Woggle-Bug declared he was sea-sick; and Tip was also pale and
+somewhat distressed. But the others clung to the backs of the sofas and
+did not seem to mind the motion as long as they were not tipped out.
+
+Darker and darker grew the night, and on and on sped the Gump through
+the black heavens. The travelers could not even see one another, and
+an oppressive silence settled down upon them.
+
+After a long time Tip, who had been thinking deeply, spoke.
+
+"How are we to know when we come to the palace of Glinda the Good?" he
+asked.
+
+"It's a long way to Glinda's palace," answered the Woodman; "I've
+traveled it."
+
+"But how are we to know how fast the Gump is flying?" persisted the
+boy. "We cannot see a single thing down on the earth, and before
+morning we may be far beyond the place we want to reach."
+
+"That is all true enough," the Scarecrow replied, a little uneasily.
+"But I do not see how we can stop just now; for we might alight in a
+river, or on the top of a steeple; and that would be a great disaster."
+
+So they permitted the Gump to fly on, with regular flops of its great
+wings, and waited patiently for morning.
+
+Then Tip's fears were proven to be well founded; for with the first
+streaks of gray dawn they looked over the sides of the sofas and
+discovered rolling plains dotted with queer villages, where the houses,
+instead of being dome-shaped--as they all are in the Land of Oz--had
+slanting roofs that rose to a peak in the center. Odd looking animals
+were also moving about upon the open plains, and the country was
+unfamiliar to both the Tin Woodman and the Scarecrow, who had formerly
+visited Glinda the Good's domain and knew it well.
+
+"We are lost!" said the Scarecrow, dolefully. "The Gump must have
+carried us entirely out of the Land of Oz and over the sandy deserts
+and into the terrible outside world that Dorothy told us about."
+
+"We must get back," exclaimed the Tin Woodman, earnestly; "we must get
+back as soon as possible!"
+
+"Turn around!" cried Tip to the Gump; "turn as quickly as you can!"
+
+"If I do I shall upset," answered the Gump. "I'm not at all used to
+flying, and the best plan would be for me to alight in some place, and
+then I can turn around and take a fresh start."
+
+Just then, however, there seemed to be no stopping-place that would
+answer their purpose. They flew over a village so big that the
+Woggle-Bug declared it was a city; and then they came to a range of
+high mountains with many deep gorges and steep cliffs showing plainly.
+
+"Now is our chance to stop," said the boy, finding they were very
+close to the mountain tops. Then he turned to the Gump and commanded:
+"Stop at the first level place you see!"
+
+"Very well," answered the Gump, and settled down upon a table of rock
+that stood between two cliffs.
+
+But not being experienced in such matters, the Gump did not judge his
+speed correctly; and instead of coming to a stop upon the flat rock he
+missed it by half the width of his body, breaking off both his right
+wings against the sharp edge of the rock and then tumbling over and
+over down the cliff.
+
+Our friends held on to the sofas as long as they could, but when the
+Gump caught on a projecting rock the Thing stopped suddenly--bottom
+side up--and all were immediately dumped out.
+
+By good fortune they fell only a few feet; for underneath them was a
+monster nest, built by a colony of Jackdaws in a hollow ledge of rock;
+so none of them--not even the Pumpkinhead--was injured by the fall.
+For Jack found his precious head resting on the soft breast of the
+Scarecrow, which made an excellent cushion; and Tip fell on a mass of
+leaves and papers, which saved him from injury. The Woggle-Bug had
+bumped his round head against the Saw-Horse, but without causing him
+more than a moment's inconvenience.
+
+[Illustration: ALL WERE IMMEDIATELY DUMPED OUT.]
+
+The Tin Woodman was at first much alarmed; but finding he had escaped
+without even a scratch upon his beautiful nickel-plate he at once
+regained his accustomed cheerfulness and turned to address his comrades.
+
+"Our journey has ended rather suddenly," said he, "and we cannot justly
+blame our friend the Gump for our accident, because he did the best he
+could under the circumstances. But how we are ever to escape from this
+nest I must leave to someone with better brains than I possess."
+
+Here he gazed at the Scarecrow; who crawled to the edge of the nest and
+looked over. Below them was a sheer precipice several hundred feet in
+depth. Above them was a smooth cliff unbroken save by the point of rock
+where the wrecked body of the Gump still hung suspended from the end of
+one of the sofas. There really seemed to be no means of escape, and as
+they realized their helpless plight the little band of adventurers gave
+way to their bewilderment.
+
+"This is a worse prison than the palace," sadly remarked the Woggle-Bug.
+
+"I wish we had stayed there," moaned Jack. "I'm afraid the mountain
+air isn't good for pumpkins."
+
+"It won't be when the Jackdaws come back," growled the Saw-Horse, which
+lay waving its legs in a vain endeavor to get upon its feet again.
+"Jackdaws are especially fond of pumpkins."
+
+"Do you think the birds will come here?" asked Jack, much distressed.
+
+"Of course they will," said Tip; "for this is their nest. And there
+must be hundreds of them," he continued, "for see what a lot of things
+they have brought here!"
+
+Indeed, the nest was half filled with a most curious collection of
+small articles for which the birds could have no use, but which the
+thieving Jackdaws had stolen during many years from the homes of men.
+And as the nest was safely hidden where no human being could reach it,
+this lost property would never be recovered.
+
+The Woggle-Bug, searching among the rubbish--for the Jackdaws stole
+useless things as well as valuable ones--turned up with his foot a
+beautiful diamond necklace. This was so greatly admired by the Tin
+Woodman that the Woggle-Bug presented it to him with a graceful speech,
+after which the Woodman hung it around his neck with much pride,
+rejoicing exceedingly when the big diamonds glittered in the sun's
+rays.
+
+[Illustration: TURNED UP A BEAUTIFUL DIAMOND NECKLACE.]
+
+But now they heard a great jabbering and flopping of wings, and as the
+sound grew nearer to them Tip exclaimed:
+
+"The Jackdaws are coming! And if they find us here they will surely
+kill us in their anger."
+
+"I was afraid of this!" moaned the Pumpkinhead. "My time has come!"
+
+"And mine, also!" said the Woggle-Bug; "for Jackdaws are the greatest
+enemies of my race."
+
+The others were not at all afraid; but the Scarecrow at once decided
+to save those of the party who were liable to be injured by the angry
+birds. So he commanded Tip to take off Jack's head and lie down with
+it in the bottom of the nest, and when this was done he ordered
+the Woggle-Bug to lie beside Tip. Nick Chopper, who knew from past
+experience just what to do, then took the Scarecrow to pieces--(all
+except his head)--and scattered the straw over Tip and the Woggle-Bug,
+completely covering their bodies.
+
+Hardly had this been accomplished when the flock of Jackdaws reached
+them. Perceiving the intruders in their nest the birds flew down upon
+them with screams of rage.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Dr. Nikidik's
+    Famous Wishing Pills
+]
+
+
+The Tin Woodman was usually a peaceful man, but when occasion required
+he could fight as fiercely as a Roman gladiator. So, when the Jackdaws
+nearly knocked him down in their rush of wings, and their sharp beaks
+and claws threatened to damage his brilliant plating, the Woodman
+picked up his axe and made it whirl swiftly around his head.
+
+But although many were beaten off in this way, the birds were so
+numerous and so brave that they continued the attack as furiously as
+before. Some of them pecked at the eyes of the Gump, which hung over
+the nest in a helpless condition; but the Gump's eyes were of glass and
+could not be injured. Others of the Jackdaws rushed at the Saw-Horse;
+but that animal, being still upon his back, kicked out so viciously
+with his wooden legs that he beat off as many assailants as did the
+Woodman's axe.
+
+Finding themselves thus opposed, the birds fell upon the Scarecrow's
+straw, which lay at the center of the nest, covering Tip and the
+Woggle-Bug and Jack's pumpkin head, and began tearing it away and
+flying off with it, only to let it drop, straw by straw into the great
+gulf beneath.
+
+The Scarecrow's head, noting with dismay this wanton destruction of
+his interior, cried to the Tin Woodman to save him; and that good
+friend responded with renewed energy. His axe fairly flashed among
+the Jackdaws, and fortunately the Gump began wildly waving the two
+wings remaining on the left side of its body. The flutter of these
+great wings filled the Jackdaws with terror, and when the Gump by its
+exertions freed itself from the peg of rock on which it hung, and sank
+flopping into the nest, the alarm of the birds knew no bounds and they
+fled screaming over the mountains.
+
+When the last foe had disappeared, Tip crawled from under the sofas and
+assisted the Woggle-Bug to follow him.
+
+"We are saved!" shouted the boy, delightedly.
+
+"We are, indeed!" responded the Educated Insect, fairly hugging the
+stiff head of the Gump in his joy; "and we owe it all to the flopping
+of the Thing and the good axe of the Woodman!"
+
+"If I am saved, get me out of here!" called Jack, whose head was still
+beneath the sofas; and Tip managed to roll the pumpkin out and place it
+upon its neck again. He also set the Saw-Horse upright, and said to it:
+
+"We owe you many thanks for the gallant fight you made."
+
+"I really think we have escaped very nicely," remarked the Tin Woodman,
+in a tone of pride.
+
+"Not so!" exclaimed a hollow voice.
+
+At this they all turned in surprise to look at the Scarecrow's head,
+which lay at the back of the nest.
+
+[Illustration]
+
+"I am completely ruined!" declared the Scarecrow, as he noted their
+astonishment. "For where is the straw that stuffs my body?"
+
+The awful question startled them all. They gazed around the nest with
+horror, for not a vestige of straw remained. The Jackdaws had stolen
+it to the last wisp and flung it all into the chasm that yawned for
+hundreds of feet beneath the nest.
+
+"My poor, poor friend!" said the Tin Woodman, taking up the Scarecrow's
+head and caressing it tenderly; "whoever could imagine you would come
+to this untimely end?"
+
+"I did it to save my friends," returned the head; "and I am glad that
+I perished in so noble and unselfish a manner."
+
+"But why are you all so despondent?" inquired the Woggle-Bug. "The
+Scarecrow's clothing is still safe."
+
+"Yes," answered the Tin Woodman; "but our friend's clothes are useless
+without stuffing."
+
+"Why not stuff him with money?" asked Tip.
+
+"Money!" they all cried, in an amazed chorus.
+
+"To be sure," said the boy. "In the bottom of the nest are thousands of
+dollar bills--and two-dollar bills--and five-dollar bills--and tens,
+and twenties, and fifties. There are enough of them to stuff a dozen
+Scarecrows. Why not use the money?"
+
+The Tin Woodman began to turn over the rubbish with the handle of his
+axe; and, sure enough, what they had first thought only worthless
+papers were found to be all bills of various denominations, which the
+mischievous Jackdaws had for years been engaged in stealing from the
+villages and cities they visited.
+
+[Illustration]
+
+There was an immense fortune lying in that inaccessible nest; and Tip's
+suggestion was, with the Scarecrow's consent, quickly acted upon.
+
+They selected all the newest and cleanest bills and assorted them
+into various piles. The Scarecrow's left leg boot were stuffed with
+five-dollar bills; his right leg was stuffed with ten-dollar bills, and
+his body so closely filled with fifties, one-hundreds and one-thousands
+that he could scarcely button his jacket with comfort.
+
+"You are now," said the Woggle-Bug, impressively, when the task had
+been completed, "the most valuable member of our party; and as you are
+among faithful friends there is little danger of your being spent."
+
+"Thank you," returned the Scarecrow, gratefully. "I feel like a new
+man; and although at first glance I might be mistaken for a Safety
+Deposit Vault, I beg you to remember that my Brains are still composed
+of the same old material. And these are the possessions that have
+always made me a person to be depended upon in an emergency."
+
+"Well, the emergency is here," observed Tip; "and unless your brains
+help us out of it we shall be compelled to pass the remainder of our
+lives in this nest."
+
+"How about these wishing pills?" enquired the Scarecrow, taking the box
+from his jacket pocket. "Can't we use them to escape?"
+
+"Not unless we can count seventeen by twos," answered the Tin Woodman.
+"But our friend the Woggle-Bug claims to be highly educated, so he
+ought easily to figure out how that can be done."
+
+"It isn't a question of education," returned the Insect; "it's merely a
+question of mathematics. I've seen the Professor work lots of sums on
+the black-board, and he claimed anything could be done with x's and y's
+and a's, and such things, by mixing them up with plenty of plusses and
+minuses and equals, and so forth. But he never said anything, so far
+as I can remember, about counting up to the odd number of seventeen by
+the even numbers of twos."
+
+"Stop! stop!" cried the Pumpkinhead. "You're making my head ache."
+
+"And mine," added the Scarecrow. "Your mathematics seem to me very like
+a bottle of mixed pickles--the more you fish for what you want the less
+chance you have of getting it. I am certain that if the thing can be
+accomplished at all, it is in a very simple manner."
+
+"Yes," said Tip; "old Mombi couldn't use x's and minuses, for she never
+went to school."
+
+"Why not start counting at a half of one?" asked the Saw-Horse,
+abruptly. "Then anyone can count up to seventeen by twos very easily."
+
+They looked at each other in surprise, for the Saw-Horse was considered
+the most stupid of the entire party.
+
+"You make me quite ashamed of myself," said the Scarecrow, bowing low
+to the Saw-Horse.
+
+"Nevertheless, the creature is right," declared the Woggle-Bug; "for
+twice one-half is one, and if you get to one it is easy to count from
+one up to seventeen by twos."
+
+"I wonder I didn't think of that myself," said the Pumpkinhead.
+
+"I don't," returned the Scarecrow. "You're no wiser than the rest of
+us, are you? But let us make a wish at once. Who will swallow the first
+pill?"
+
+"Suppose you do it," suggested Tip.
+
+"I can't," said the Scarecrow.
+
+"Why not? You've a mouth, haven't you?" asked the boy.
+
+"Yes; but my mouth is painted on, and there's no swallow connected with
+it," answered the Scarecrow. "In fact," he continued, looking from one
+to another critically, "I believe the boy and the Woggle-Bug are the
+only ones in our party that are able to swallow."
+
+Observing the truth of this remark, Tip said:
+
+"Then I will undertake to make the first wish. Give me one of the
+Silver Pills."
+
+This the Scarecrow tried to do; but his padded gloves were too clumsy
+to clutch so small an object, and he held the box toward the boy while
+Tip selected one of the pills and swallowed it.
+
+"Count!" cried the Scarecrow.
+
+"One-half, one, three, five, seven, nine, eleven, thirteen, fifteen,
+seventeen!" counted Tip.
+
+"Now wish!" said the Tin Woodman anxiously.
+
+But just then the boy began to suffer such fearful pains that he became
+alarmed.
+
+"The pill has poisoned me!" he gasped; "O--h! O-o-o-o-o! Ouch! Murder!
+Fire! O-o-h!" and here he rolled upon the bottom of the nest in such
+contortions that he frightened them all.
+
+"What can we do for you? Speak, I beg!" entreated the Tin Woodman,
+tears of sympathy running down his nickel cheeks.
+
+"I--I don't know!" answered Tip. "O--h! I wish I'd never swallowed that
+pill!"
+
+Then at once the pain stopped, and the boy rose to his feet again and
+found the Scarecrow looking with amazement at the end of the pepper-box.
+
+"What's happened?" asked the boy, a little ashamed of his recent
+exhibition.
+
+"Why, the three pills are in the box again!" said the Scarecrow.
+
+[Illustration]
+
+"Of course they are," the Woggle-Bug declared. "Didn't Tip wish that
+he'd never swallowed one of them? Well, the wish came true, and he
+_didn't_ swallow one of them. So of course they are all three in the
+box."
+
+"That may be; but the pill gave me a dreadful pain, just the same,"
+said the boy.
+
+"Impossible!" declared the Woggle-Bug. "If you have never swallowed
+it, the pill can not have given you a pain. And as your wish, being
+granted, proves you did not swallow the pill, it is also plain that you
+suffered no pain."
+
+"Then it was a splendid imitation of a pain," retorted Tip, angrily.
+"Suppose you try the next pill yourself. We've wasted one wish already."
+
+"Oh, no, we haven't!" protested the Scarecrow. "Here are still three
+pills in the box, and each pill is good for a wish."
+
+"Now you're making _my_ head ache," said Tip. "I can't understand the
+thing at all. But I won't take another pill, I promise you!" and with
+this remark he retired sulkily to the back of the nest.
+
+"Well," said the Woggle-Bug, "it remains for me to save us in my most
+Highly Magnified and Thoroughly Educated manner; for I seem to be the
+only one able and willing to make a wish. Let me have one of the pills."
+
+He swallowed it without hesitation, and they all stood admiring his
+courage while the Insect counted seventeen by twos in the same way
+that Tip had done. And for some reason--perhaps because Woggle-Bugs
+have stronger stomachs than boys--the silver pellet caused it no pain
+whatever.
+
+"I wish the Gump's broken wings mended, and as good as new!" said the
+Woggle-Bug, in a slow, impressive voice.
+
+All turned to look at the Thing, and so quickly had the wish been
+granted that the Gump lay before them in perfect repair, and as well
+able to fly through the air as when it had first been brought to life
+on the roof of the palace.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow Appeals
+    to Glinda the Good
+]
+
+
+"Hooray!" shouted the Scarecrow, gaily. "We can now leave this
+miserable Jackdaws' nest whenever we please."
+
+"But it is nearly dark," said the Tin Woodman; "and unless we wait
+until morning to make our flight we may get into more trouble. I don't
+like these night trips, for one never knows what will happen."
+
+So it was decided to wait until daylight, and the adventurers amused
+themselves in the twilight by searching the Jackdaws' nest for
+treasures.
+
+The Woggle-Bug found two handsome bracelets of wrought gold, which
+fitted his slender arms very well. The Scarecrow took a fancy for
+rings, of which there were many in the nest. Before long he had fitted
+a ring to each finger of his padded gloves, and not being content
+with that display he added one more to each thumb. As he carefully
+chose those rings set with sparkling stones, such as rubies, amethysts
+and sapphires, the Scarecrow's hands now presented a most brilliant
+appearance.
+
+"This nest would be a picnic for Queen Jinjur," said he, musingly; "for
+as nearly as I can make out she and her girls conquered me merely to
+rob my city of its emeralds."
+
+The Tin Woodman was content with his diamond necklace and refused
+to accept any additional decorations; but Tip secured a fine gold
+watch, which was attached to a heavy fob, and placed it in his pocket
+with much pride. He also pinned several jeweled brooches to Jack
+Pumpkinhead's red waistcoat, and attached a lorgnette, by means of a
+fine chain, to the neck of the Saw-Horse.
+
+"It's very pretty," said the creature, regarding the lorgnette
+approvingly; "but what is it for?"
+
+None of them could answer that question, however; so the Saw-Horse
+decided it was some rare decoration and became very fond of it.
+
+That none of the party might be slighted, they ended by placing several
+large seal rings upon the points of the Gump's antlers, although that
+odd personage seemed by no means gratified by the attention.
+
+Darkness soon fell upon them, and Tip and the Woggle-Bug went to sleep
+while the others sat down to wait patiently for the day.
+
+Next morning they had cause to congratulate themselves upon the useful
+condition of the Gump; for with daylight a great flock of Jackdaws
+approached to engage in one more battle for the possession of the nest.
+
+But our adventurers did not wait for the assault. They tumbled into the
+cushioned seats of the sofas as quickly as possible, and Tip gave the
+word to the Gump to start.
+
+At once it rose into the air, the great wings flopping strongly and
+with regular motions, and in a few moments they were so far from the
+nest that the chattering Jackdaws took possession without any attempt
+at pursuit.
+
+The Thing flew due North, going in the same direction from whence
+it had come. At least, that was the Scarecrow's opinion, and the
+others agreed that the Scarecrow was the best judge of direction.
+After passing over several cities and villages the Gump carried them
+high above a broad plain where houses became more and more scattered
+until they disappeared altogether. Next came the wide, sandy desert
+separating the rest of the world from the Land of Oz, and before noon
+they saw the dome-shaped houses that proved they were once more within
+the borders of their native land.
+
+"But the houses and fences are blue," said the Tin Woodman, "and that
+indicates we are in the land of the Munchkins, and therefore a long
+distance from Glinda the Good."
+
+"What shall we do?" asked the boy, turning to their guide.
+
+"I don't know," replied the Scarecrow, frankly. "If we were at the
+Emerald City we could then move directly southward, and so reach our
+destination. But we dare not go to the Emerald City, and the Gump is
+probably carrying us further in the wrong direction with every flop of
+its wings."
+
+"Then the Woggle-Bug must swallow another pill," said Tip, decidedly,
+"and wish us headed in the right direction."
+
+"Very well," returned the Highly Magnified one; "I'm willing."
+
+But when the Scarecrow searched in his pocket for the pepper-box
+containing the two silver Wishing Pills, it was not to be found. Filled
+with anxiety, the voyagers hunted throughout every inch of the Thing
+for the precious box; but it had disappeared entirely.
+
+And still the Gump flew onward, carrying them they knew not where.
+
+"I must have left the pepper-box in the Jackdaws' nest," said the
+Scarecrow, at length.
+
+"It is a great misfortune," the Tin Woodman declared. "But we are no
+worse off than before we discovered the Wishing Pills."
+
+"We are better off," replied Tip; "for the one pill we used has enabled
+us to escape from that horrible nest."
+
+"Yet the loss of the other two is serious, and I deserve a good
+scolding for my carelessness," the Scarecrow rejoined, penitently. "For
+in such an unusual party as this accidents are liable to happen any
+moment, and even now we may be approaching a new danger."
+
+No one dared contradict this, and a dismal silence ensued.
+
+The Gump flew steadily on.
+
+Suddenly Tip uttered an exclamation of surprise.
+
+"We must have reached the South Country," he cried, "for below us
+everything is red!"
+
+[Illustration]
+
+Immediately they all leaned over the backs of the sofas to look--all
+except Jack, who was too careful of his pumpkin head to risk its
+slipping off his neck. Sure enough; the red houses and fences and
+trees indicated they were within the domain of Glinda the Good; and
+presently, as they glided rapidly on, the Tin Woodman recognized the
+roads and buildings they passed, and altered slightly the flight
+of the Gump so that they might reach the palace of the celebrated
+Sorceress.
+
+"Good!" cried the Scarecrow, delightedly. "We do not need the lost
+Wishing Pills now, for we have arrived at our destination."
+
+Gradually the Thing sank lower and nearer to the ground until at length
+it came to rest within the beautiful gardens of Glinda, settling upon
+a velvety green lawn close by a fountain which sent sprays of flashing
+gems, instead of water, high into the air, whence they fell with a
+soft, tinkling sound into the carved marble basin placed to receive
+them.
+
+Everything was very gorgeous in Glinda's gardens, and while our
+voyagers gazed about with admiring eyes a company of soldiers silently
+appeared and surrounded them. But these soldiers of the great Sorceress
+were entirely different from those of Jinjur's Army of Revolt, although
+they were likewise girls. For Glinda's soldiers wore neat uniforms and
+bore swords and spears; and they marched with a skill and precision
+that proved them well trained in the arts of war.
+
+The Captain commanding this troop--which was Glinda's private Body
+Guard--recognized the Scarecrow and the Tin Woodman at once, and
+greeted them with respectful salutations.
+
+"Good day!" said the Scarecrow, gallantly removing his hat, while the
+Woodman gave a soldierly salute; "we have come to request an audience
+with your fair Ruler."
+
+"Glinda is now within her palace, awaiting you," returned the Captain;
+"for she saw you coming long before you arrived."
+
+"That is strange!" said Tip, wondering.
+
+"Not at all," answered the Scarecrow; "for Glinda the Good is a mighty
+Sorceress, and nothing that goes on in the Land of Oz escapes her
+notice. I suppose she knows why we came as well as we do ourselves."
+
+"Then what was the use of our coming?" asked Jack, stupidly.
+
+[Illustration]
+
+"To prove you are a Pumpkinhead!" retorted the Scarecrow. "But, if the
+Sorceress expects us, we must not keep her waiting."
+
+So they all clambered out of the sofas and followed the Captain toward
+the palace--even the Saw-Horse taking his place in the queer procession.
+
+Upon her throne of finely wrought gold sat Glinda, and she could
+scarcely repress a smile as her peculiar visitors entered and bowed
+before her. Both the Scarecrow and the Tin Woodman she knew and
+liked; but the awkward Pumpkinhead and Highly Magnified Woggle-Bug
+were creatures she had never seen before, and they seemed even more
+curious than the others. As for the Saw-Horse, he looked to be nothing
+more than an animated chunk of wood; and he bowed so stiffly that his
+head bumped against the floor, causing a ripple of laughter among the
+soldiers, in which Glinda frankly joined.
+
+"I beg to announce to your glorious highness," began the Scarecrow, in
+a solemn voice, "that my Emerald City has been overrun by a crowd of
+impudent girls with knitting-needles, who have enslaved all the men,
+robbed the streets and public buildings of all their emerald jewels,
+and usurped my throne."
+
+"I know it," said Glinda.
+
+"They also threatened to destroy me, as well as all the good friends
+and allies you see before you," continued the Scarecrow; "and had we
+not managed to escape their clutches our days would long since have
+ended."
+
+"I know it," repeated Glinda.
+
+"Therefore I have come to beg your assistance," resumed the Scarecrow,
+"for I believe you are always glad to succor the unfortunate and
+oppressed."
+
+"That is true," replied the Sorceress, slowly. "But the Emerald City is
+now ruled by General Jinjur, who has caused herself to be proclaimed
+Queen. What right have I to oppose her?"
+
+"Why, she stole the throne from me," said the Scarecrow.
+
+"And how came you to possess the throne?" asked Glinda.
+
+"I got it from the Wizard of Oz, and by the choice of the people,"
+returned the Scarecrow, uneasy at such questioning.
+
+"And where did the Wizard get it?" she continued, gravely.
+
+"I am told he took it from Pastoria, the former King," said the
+Scarecrow, becoming confused under the intent look of the Sorceress.
+
+"Then," declared Glinda, "the throne of the Emerald City belongs
+neither to you nor to Jinjur, but to this Pastoria from whom the Wizard
+usurped it."
+
+"That is true," acknowledged the Scarecrow, humbly; "but Pastoria is
+now dead and gone, and some one must rule in his place."
+
+"Pastoria had a daughter, who is the rightful heir to the throne of the
+Emerald City. Did you know that?" questioned the Sorceress.
+
+"No," replied the Scarecrow. "But if the girl still lives I will not
+stand in her way. It will satisfy me as well to have Jinjur turned out,
+as an impostor, as to regain the throne myself. In fact, it isn't much
+fun to be King, especially if one has good brains. I have known for
+some time that I am fitted to occupy a far more exalted position. But
+where is this girl who owns the throne, and what is her name?"
+
+"Her name is Ozma," answered Glinda. "But where she is I have tried in
+vain to discover. For the Wizard of Oz, when he stole the throne from
+Ozma's father, hid the girl in some secret place; and by means of a
+magical trick with which I am not familiar he also managed to prevent
+her being discovered--even by so experienced a Sorceress as myself."
+
+"That is strange," interrupted the Woggle-Bug, pompously. "I have
+been informed that the Wonderful Wizard of Oz was nothing more than a
+humbug!"
+
+"Nonsense!" exclaimed the Scarecrow, much provoked by this speech.
+"Didn't he give me a wonderful set of brains?"
+
+"There's no humbug about my heart," announced the Tin Woodman, glaring
+indignantly at the Woggle-Bug.
+
+"Perhaps I was misinformed," stammered the Insect, shrinking back; "I
+never knew the Wizard personally."
+
+"Well, we did," retorted the Scarecrow, "and he was a very great
+Wizard, I assure you. It is true he was guilty of some slight
+impostures, but unless he was a great Wizard how--let me ask--could he
+have hidden this girl Ozma so securely that no one can find her?"
+
+"I--I give it up!" replied the Woggle-Bug, meekly.
+
+"That is the most sensible speech you've made," said the Tin Woodman.
+
+"I must really make another effort to discover where this girl is
+hidden," resumed the Sorceress, thoughtfully. "I have in my library a
+book in which is inscribed every action of the Wizard while he was in
+our land of Oz--or, at least, every action that could be observed by
+my spies. This book I will read carefully tonight, and try to single
+out the acts that may guide us in discovering the lost Ozma. In the
+meantime, pray amuse yourselves in my palace and command my servants as
+if they were your own. I will grant you another audience tomorrow."
+
+With this gracious speech Glinda dismissed the adventurers, and they
+wandered away through the beautiful gardens, where they passed several
+hours enjoying all the delightful things with which the Queen of the
+Southland had surrounded her royal palace.
+
+On the following morning they again appeared before Glinda, who said to
+them:
+
+"I have searched carefully through the records of the Wizard's
+actions, and among them I can find but three that appear to have been
+suspicious. He ate beans with a knife, made three secret visits to old
+Mombi, and limped slightly on his left foot."
+
+"Ah! that last is certainly suspicious!" exclaimed the Pumpkinhead.
+
+"Not necessarily," said the Scarecrow; "he may have had corns. Now, it
+seems to me his eating beans with a knife is more suspicious."
+
+"Perhaps it is a polite custom in Omaha, from which great country the
+Wizard originally came," suggested the Tin Woodman.
+
+"It may be," admitted the Scarecrow.
+
+"But why," asked Glinda, "did he make three secret visits to old Mombi?"
+
+"Ah! Why, indeed!" echoed the Woggle-Bug, impressively.
+
+"We know that the Wizard taught the old woman many of his tricks of
+magic," continued Glinda; "and this he would not have done had she not
+assisted him in some way. So we may suspect with good reason that Mombi
+aided him to hide the girl Ozma, who was the real heir to the throne
+of the Emerald City, and a constant danger to the usurper. For, if the
+people knew that she lived, they would quickly make her their Queen and
+restore her to her rightful position."
+
+"An able argument!" cried the Scarecrow. "I have no doubt that Mombi
+was mixed up in this wicked business. But how does that knowledge help
+us?"
+
+"We must find Mombi," replied Glinda, "and force her to tell where the
+girl is hidden."
+
+"Mombi is now with Queen Jinjur, in the Emerald City," said Tip. "It
+was she who threw so many obstacles in our pathway, and made Jinjur
+threaten to destroy my friends and give me back into the old witch's
+power."
+
+"Then," decided Glinda, "I will march with my army to the Emerald
+City, and take Mombi prisoner. After that we can, perhaps, force her to
+tell the truth about Ozma."
+
+"She is a terrible old woman!" remarked Tip, with a shudder at the
+thought of Mombi's black kettle; "and obstinate, too."
+
+"I am quite obstinate myself," returned the Sorceress, with a sweet
+smile; "so I do not fear Mombi in the least. Today I will make all
+necessary preparations, and we will march upon the Emerald City at
+daybreak tomorrow."
+
+[Illustration: "She is a terrible old woman."]
+
+[Illustration: Jinjur]
+
+
+
+
+[Illustration:
+
+    The Tin-Woodman
+    Plucks a Rose
+]
+
+[Illustration]
+
+The Army of Glinda the Good looked very grand and imposing when it
+assembled at daybreak before the palace gates. The uniforms of the
+girl soldiers were pretty and of gay colors, and their silver-tipped
+spears were bright and glistening, the long shafts being inlaid with
+mother-of-pearl. All the officers wore sharp, gleaming swords, and
+shields edged with peacock-feathers; and it really seemed that no foe
+could by any possibility defeat such a brilliant army.
+
+The Sorceress rode in a beautiful palanquin which was like the body of
+a coach, having doors and windows with silken curtains; but instead
+of wheels, which a coach has, the palanquin rested upon two long,
+horizontal bars, which were borne upon the shoulders of twelve servants.
+
+The Scarecrow and his comrades decided to ride in the Gump, in order
+to keep up with the swift march of the army; so, as soon as Glinda had
+started and her soldiers had marched away to the inspiring strains of
+music played by the royal band, our friends climbed into the sofas
+and followed. The Gump flew along slowly at a point directly over the
+palanquin in which rode the Sorceress.
+
+[Illustration]
+
+"Be careful," said the Tin Woodman to the Scarecrow, who was leaning
+far over the side to look at the army below. "You might fall."
+
+"It wouldn't matter," remarked the educated Woggle-Bug; "he can't get
+broke so long as he is stuffed with money."
+
+"Didn't I ask you--" began Tip, in a reproachful voice.
+
+"You did!" said the Woggle-Bug, promptly. "And I beg your pardon. I
+will really try to restrain myself."
+
+"You'd better," declared the boy. "That is, if you wish to travel in
+our company."
+
+"Ah! I couldn't bear to part with you now," murmured the Insect,
+feelingly; so Tip let the subject drop.
+
+The army moved steadily on, but night had fallen before they came
+to the walls of the Emerald City. By the dim light of the new moon,
+however, Glinda's forces silently surrounded the city and pitched their
+tents of scarlet silk upon the greensward. The tent of the Sorceress
+was larger than the others, and was composed of pure white silk, with
+scarlet banners flying above it. A tent was also pitched for the
+Scarecrow's party; and when these preparations had been made, with
+military precision and quickness, the army retired to rest.
+
+Great was the amazement of Queen Jinjur next morning when her soldiers
+came running to inform her of the vast army surrounding them. She at
+once climbed to a high tower of the royal palace and saw banners waving
+in every direction and the great white tent of Glinda standing directly
+before the gates.
+
+[Illustration]
+
+"We are surely lost!" cried Jinjur, in despair; "for how can our
+knitting-needles avail against the long spears and terrible swords of
+our foes?"
+
+"The best thing we can do," said one of the girls, "is to surrender as
+quickly as possible, before we get hurt."
+
+"Not so," returned Jinjur, more bravely. "The enemy is still outside
+the walls, so we must try to gain time by engaging them in parley. Go
+you with a flag of truce to Glinda and ask her why she has dared to
+invade my dominions, and what are her demands."
+
+So the girl passed through the gates, bearing a white flag to show she
+was on a mission of peace, and came to Glinda's tent.
+
+"Tell your Queen," said the Sorceress to the girl, "that she must
+deliver up to me old Mombi, to be my prisoner. If this is done I will
+not molest her farther."
+
+Now when this message was delivered to the Queen it filled her with
+dismay, for Mombi was her chief counsellor, and Jinjur was terribly
+afraid of the old hag. But she sent for Mombi, and told her what Glinda
+had said.
+
+"I see trouble ahead for all of us," muttered the old witch, after
+glancing into a magic mirror she carried in her pocket. "But we may
+even yet escape by deceiving this sorceress, clever as she thinks
+herself."
+
+"Don't you think it will be safer for me to deliver you into her
+hands?" asked Jinjur, nervously.
+
+"If you do, it will cost you the throne of the Emerald City!" answered
+the witch, positively. "But, if you will let me have my own way, I can
+save us both very easily."
+
+"Then do as you please," replied Jinjur, "for it is so aristocratic to
+be a Queen that I do not wish to be obliged to return home again, to
+make beds and wash dishes for my mother."
+
+So Mombi called Jellia Jamb to her, and performed a certain magical
+rite with which she was familiar. As a result of the enchantment Jellia
+took on the form and features of Mombi, while the old witch grew to
+resemble the girl so closely that it seemed impossible anyone could
+guess the deception.
+
+"Now," said old Mombi to the Queen, "let your soldiers deliver up this
+girl to Glinda. She will think she has the real Mombi in her power, and
+so will return immediately to her own country in the South."
+
+[Illustration]
+
+Therefore Jellia, hobbling along like an aged woman, was led from the
+city gates and taken before Glinda.
+
+"Here is the person you demanded," said one of the guards, "and our
+Queen now begs you will go away, as you promised, and leave us in
+peace."
+
+"That I will surely do," replied Glinda, much pleased; "if this is
+really the person she seems to be."
+
+"It is certainly old Mombi," said the guard, who believed she was
+speaking the truth; and then Jinjur's soldiers returned within the
+city's gates.
+
+The Sorceress quickly summoned the Scarecrow and his friends to her
+tent, and began to question the supposed Mombi about the lost girl
+Ozma. But Jellia knew nothing at all of this affair, and presently she
+grew so nervous under the questioning that she gave way and began to
+weep, to Glinda's great astonishment.
+
+"Here is some foolish trickery!" said the Sorceress, her eyes flashing
+with anger. "This is not Mombi at all, but some other person who has
+been made to resemble her! Tell me," she demanded, turning to the
+trembling girl, "what is your name?"
+
+This Jellia dared not tell, having been threatened with death by the
+witch if she confessed the fraud. But Glinda, sweet and fair though she
+was, understood magic better than any other person in the Land of Oz.
+So, by uttering a few potent words and making a peculiar gesture, she
+quickly transformed the girl into her proper shape, while at the same
+time old Mombi, far away in Jinjur's palace, suddenly resumed her own
+crooked form and evil features.
+
+"Why, it's Jellia Jamb!" cried the Scarecrow, recognizing in the girl
+one of his old friends.
+
+"It's our interpreter!" said the Pumpkinhead, smiling pleasantly.
+
+Then Jellia was forced to tell of the trick Mombi had played, and she
+also begged Glinda's protection, which the Sorceress readily granted.
+But Glinda was now really angry, and sent word to Jinjur that the
+fraud was discovered and she must deliver up the real Mombi or suffer
+terrible consequences. Jinjur was prepared for this message, for the
+witch well understood, when her natural form was thrust upon her, that
+Glinda had discovered her trickery. But the wicked old creature had
+already thought up a new deception, and had made Jinjur promise to
+carry it out. So the Queen said to Glinda's messenger:
+
+[Illustration]
+
+"Tell your mistress that I cannot find Mombi anywhere; but that Glinda
+is welcome to enter the city and search herself for the old woman. She
+may also bring her friends with her, if she likes; but if she does not
+find Mombi by sundown, the Sorceress must promise to go away peaceably
+and bother us no more."
+
+Glinda agreed to these terms, well knowing that Mombi was somewhere
+within the city walls. So Jinjur caused the gates to be thrown open,
+and Glinda marched in at the head of a company of soldiers, followed by
+the Scarecrow and the Tin Woodman, while Jack Pumpkinhead rode astride
+the Saw-Horse, and the Educated, Highly Magnified Woggle-Bug sauntered
+behind in a dignified manner. Tip walked by the side of the Sorceress,
+for Glinda had conceived a great liking for the boy.
+
+Of course old Mombi had no intention of being found by Glinda; so,
+while her enemies were marching up the street, the witch transformed
+herself into a red rose growing upon a bush in the garden of the
+palace. It was a clever idea, and a trick Glinda did not suspect; so
+several precious hours were spent in a vain search for Mombi.
+
+As sundown approached the Sorceress realized she had been defeated by
+the superior cunning of the aged witch; so she gave the command to her
+people to march out of the city and back to their tents.
+
+The Scarecrow and his comrades happened to be searching in the garden
+of the palace just then, and they turned with disappointment to obey
+Glinda's command. But before they left the garden the Tin Woodman,
+who was fond of flowers, chanced to espy a big red rose growing upon
+a bush; so he plucked the flower and fastened it securely in the tin
+button-hole of his tin bosom.
+
+As he did this he fancied he heard a low moan proceed from the rose;
+but he paid no attention to the sound, and Mombi was thus carried out
+of the city and into Glinda's camp without anyone having a suspicion
+that they had succeeded in their quest.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Transformation
+    of Old Mombi
+]
+
+
+The Witch was at first frightened at finding herself captured by the
+enemy; but soon she decided that she was exactly as safe in the Tin
+Woodman's button-hole as growing upon the bush. For no one knew the
+rose and Mombi to be one, and now that she was without the gates of the
+City her chances of escaping altogether from Glinda were much improved.
+
+"But there is no hurry," thought Mombi. "I will wait awhile and enjoy
+the humiliation of this Sorceress when she finds I have outwitted her."
+
+So throughout the night the rose lay quietly on the Woodman's bosom,
+and in the morning, when Glinda summoned our friends to a consultation,
+Nick Chopper carried his pretty flower with him to the white silk tent.
+
+[Illustration]
+
+"For some reason," said Glinda, "we have failed to find this cunning
+old Mombi; so I fear our expedition will prove a failure. And for that
+I am sorry, because without our assistance little Ozma will never be
+rescued and restored to her rightful position as Queen of the Emerald
+City."
+
+"Do not let us give up so easily," said the Pumpkinhead. "Let us do
+something else."
+
+"Something else must really be done," replied Glinda, with a smile;
+"yet I cannot understand how I have been defeated so easily by an old
+Witch who knows far less of magic than I do myself."
+
+"While we are on the ground I believe it would be wise for us to
+conquer the Emerald City for Princess Ozma, and find the girl
+afterward," said the Scarecrow. "And while the girl remains hidden I
+will gladly rule in her place, for I understand the business of ruling
+much better than Jinjur does."
+
+"But I have promised not to molest Jinjur," objected Glinda.
+
+"Suppose you all return with me to my kingdom--or Empire, rather," said
+the Tin Woodman, politely including the entire party in a royal wave of
+his arm. "It will give me great pleasure to entertain you in my castle,
+where there is room enough and to spare. And if any of you wish to be
+nickel-plated, my valet will do it free of all expense."
+
+While the Woodman was speaking Glinda's eyes had been noting the rose
+in his button-hole, and now she imagined she saw the big red leaves of
+the flower tremble slightly. This quickly aroused her suspicions, and
+in a moment more the Sorceress had decided that the seeming rose was
+nothing else than a transformation of old Mombi. At the same instant
+Mombi knew she was discovered and must quickly plan an escape, and
+as transformations were easy to her she immediately took the form of
+a Shadow and glided along the wall of the tent toward the entrance,
+thinking thus to disappear.
+
+But Glinda had not only equal cunning, but far more experience than
+the Witch. So the Sorceress reached the opening of the tent before the
+Shadow, and with a wave of her hand closed the entrance so securely
+that Mombi could not find a crack big enough to creep through. The
+Scarecrow and his friends were greatly surprised at Glinda's actions;
+for none of them had noted the Shadow. But the Sorceress said to them:
+
+"Remain perfectly quiet, all of you! For the old Witch is even now with
+us in this tent, and I hope to capture her."
+
+These words so alarmed Mombi that she quickly transformed herself from
+a shadow to a Black Ant, in which shape she crawled along the ground,
+seeking a crack or crevice in which to hide her tiny body.
+
+Fortunately, the ground where the tent had been pitched, being just
+before the city gates, was hard and smooth; and while the Ant still
+crawled about, Glinda discovered it and ran quickly forward to effect
+its capture. But, just as her hand was descending, the Witch, now
+fairly frantic with fear, made her last transformation, and in the form
+of a huge Griffin sprang through the wall of the tent--tearing the silk
+asunder in her rush--and in a moment had darted away with the speed of
+a whirlwind.
+
+Glinda did not hesitate to follow. She sprang upon the back of the
+Saw-Horse and cried:
+
+"Now you shall prove that you have a right to be alive! Run--run--run!"
+
+The Saw-Horse ran. Like a flash he followed the Griffin, his wooden
+legs moving so fast that they twinkled like the rays of a star. Before
+our friends could recover from their surprise both the Griffin and the
+Saw-Horse had dashed out of sight.
+
+"Come! Let us follow!" cried the Scarecrow.
+
+They ran to the place where the Gump was lying and quickly tumbled
+aboard.
+
+"Fly!" commanded Tip, eagerly.
+
+"Where to?" asked the Gump, in its calm voice.
+
+"I don't know," returned Tip, who was very nervous at the delay; "but
+if you will mount into the air I think we can discover which way Glinda
+has gone."
+
+[Illustration]
+
+"Very well," returned the Gump, quietly; and it spread its great wings
+and mounted high into the air.
+
+Far away, across the meadows, they could now see two tiny specks,
+speeding one after the other; and they knew these specks must be the
+Griffin and the Saw-Horse. So Tip called the Gump's attention to them
+and bade the creature try to overtake the Witch and the Sorceress. But,
+swift as was the Gump's flight, the pursued and pursuer moved more
+swiftly yet, and within a few moments were blotted out against the dim
+horizon.
+
+"Let us continue to follow them, nevertheless," said the Scarecrow;
+"for the Land of Oz is of small extent, and sooner or later they must
+both come to a halt."
+
+Old Mombi had thought herself very wise to choose the form of a
+Griffin, for its legs were exceedingly fleet and its strength more
+enduring than that of other animals. But she had not reckoned on the
+untiring energy of the Saw-Horse, whose wooden limbs could run for days
+without slacking their speed. Therefore, after an hour's hard running,
+the Griffin's breath began to fail, and it panted and gasped painfully,
+and moved more slowly than before. Then it reached the edge of the
+desert and began racing across the deep sands. But its tired feet sank
+far into the sand, and in a few minutes the Griffin fell forward,
+completely exhausted, and lay still upon the desert waste.
+
+Glinda came up a moment later, riding the still vigorous Saw-Horse; and
+having unwound a slender golden thread from her girdle the Sorceress
+threw it over the head of the panting and helpless Griffin, and so
+destroyed the magical power of Mombi's transformation.
+
+For the animal, with one fierce shudder, disappeared from view, while
+in its place was discovered the form of the old Witch, glaring savagely
+at the serene and beautiful face of the Sorceress.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Princess Ozma of Oz
+]
+
+
+"You are my prisoner, and it is useless for you to struggle any
+longer," said Glinda, in her soft, sweet voice. "Lie still a moment,
+and rest yourself, and then I will carry you back to my tent."
+
+"Why do you seek me?" asked Mombi, still scarce able to speak plainly
+for lack of breath. "What have I done to you, to be so persecuted?"
+
+"You have done nothing to me," answered the gentle Sorceress; "but I
+suspect you have been guilty of several wicked actions; and if I find
+it is true that you have so abused your knowledge of magic, I intend to
+punish you severely."
+
+"I defy you!" croaked the old hag. "You dare not harm me!"
+
+Just then the Gump flew up to them and alighted upon the desert sands
+beside Glinda. Our friends were delighted to find that Mombi had
+finally been captured, and after a hurried consultation it was decided
+they should all return to the camp in the Gump. So the Saw-Horse was
+tossed aboard, and then Glinda, still holding an end of the golden
+thread that was around Mombi's neck, forced her prisoner to climb into
+the sofas. The others now followed, and Tip gave the word to the Gump
+to return.
+
+The journey was made in safety, Mombi sitting in her place with a grim
+and sullen air; for the old hag was absolutely helpless so long as the
+magical thread encircled her throat. The army hailed Glinda's return
+with loud cheers, and the party of friends soon gathered again in the
+royal tent, which had been neatly repaired during their absence.
+
+"Now," said the Sorceress to Mombi, "I want you to tell us why the
+Wonderful Wizard of Oz paid you three visits, and what became of the
+child, Ozma, which so curiously disappeared."
+
+The Witch looked at Glinda defiantly, but said not a word.
+
+"Answer me!" cried the Sorceress.
+
+But still Mombi remained silent.
+
+"Perhaps she doesn't know," remarked Jack.
+
+"I beg you will keep quiet," said Tip. "You might spoil everything with
+your foolishness."
+
+"Very well, dear father!" returned the Pumpkinhead, meekly.
+
+"How glad I am to be a Woggle-Bug!" murmured the Highly Magnified
+Insect, softly. "No one can expect wisdom to flow from a pumpkin."
+
+"Well," said the Scarecrow, "what shall we do to make Mombi speak?
+Unless she tells us what we wish to know her capture will do us no good
+at all."
+
+"Suppose we try kindness," suggested the Tin Woodman. "I've heard that
+anyone can be conquered with kindness, no matter how ugly they may be."
+
+At this the Witch turned to glare upon him so horribly that the Tin
+Woodman shrank back abashed.
+
+Glinda had been carefully considering what to do, and now she turned to
+Mombi and said:
+
+"You will gain nothing, I assure you, by thus defying us. For I am
+determined to learn the truth about the girl Ozma, and unless you tell
+me all that you know, I will certainly put you to death."
+
+"Oh, no! Don't do that!" exclaimed the Tin Woodman. "It would be an
+awful thing to kill anyone--even old Mombi!"
+
+"But it is merely a threat," returned Glinda. "I shall not put Mombi to
+death, because she will prefer to tell me the truth."
+
+"Oh, I see!" said the tin man, much relieved.
+
+"Suppose I tell you all that you wish to know," said Mombi, speaking so
+suddenly that she startled them all. "What will you do with me then?"
+
+"In that case," replied Glinda, "I shall merely ask you to drink a
+powerful draught which will cause you to forget all the magic you have
+ever learned."
+
+"Then I would become a helpless old woman!"
+
+"But you would be alive," suggested the Pumpkinhead, consolingly.
+
+"Do try to keep silent!" said Tip, nervously.
+
+"I'll try," responded Jack; "but you will admit that it's a good thing
+to be alive."
+
+"Especially if one happens to be Thoroughly Educated," added the
+Woggle-Bug, nodding approval.
+
+"You may make your choice," Glinda said to old Mombi, "between death if
+you remain silent, and the loss of your magical powers if you tell me
+the truth. But I think you will prefer to live."
+
+Mombi cast an uneasy glance at the Sorceress, and saw that she was in
+earnest, and not to be trifled with. So she replied, slowly:
+
+"I will answer your questions."
+
+"That is what I expected," said Glinda, pleasantly. "You have chosen
+wisely, I assure you."
+
+She then motioned to one of her Captains, who brought her a beautiful
+golden casket. From this the Sorceress drew an immense white pearl,
+attached to a slender chain which she placed around her neck in such a
+way that the pearl rested upon her bosom, directly over her heart.
+
+"Now," said she, "I will ask my first question: Why did the Wizard pay
+you three visits?"
+
+"Because I would not come to him," answered Mombi.
+
+"That is no answer," said Glinda, sternly. "Tell me the truth."
+
+"Well," returned Mombi, with downcast eyes, "he visited me to learn the
+way I make tea-biscuits."
+
+"Look up!" commanded the Sorceress.
+
+Mombi obeyed.
+
+"What is the color of my pearl?" demanded Glinda.
+
+"Why--it is black!" replied the old Witch, in a tone of wonder.
+
+"Then you have told me a falsehood!" cried Glinda, angrily. "Only when
+the truth is spoken will my magic pearl remain a pure white in color."
+
+Mombi now saw how useless it was to try to deceive the Sorceress; so
+she said, meanwhile scowling at her defeat:
+
+"The Wizard brought to me the girl Ozma, who was then no more than a
+baby, and begged me to conceal the child."
+
+"That is what I thought," declared Glinda, calmly. "What did he give
+you for thus serving him?"
+
+"He taught me all the magical tricks he knew. Some were good tricks,
+and some were only frauds; but I have remained faithful to my promise."
+
+"What did you do with the girl?" asked Glinda; and at this question
+everyone bent forward and listened eagerly for the reply.
+
+"I enchanted her," answered Mombi.
+
+"In what way?"
+
+"I transformed her into--into--"
+
+"Into what?" demanded Glinda, as the Witch hesitated.
+
+"_Into a boy!_" said Mombi, in a low tone.
+
+"A boy!" echoed every voice; and then, because they knew that this old
+woman had reared Tip from childhood, all eyes were turned to where the
+boy stood.
+
+"Yes," said the old Witch, nodding her head; "that is the Princess
+Ozma--the child brought to me by the Wizard who stole her father's
+throne. That is the rightful ruler of the Emerald City!" and she
+pointed her long bony finger straight at the boy.
+
+"I!" cried Tip, in amazement. "Why, I'm no Princess Ozma--I'm not a
+girl!"
+
+Glinda smiled, and going to Tip she took his small brown hand within
+her dainty white one.
+
+[Illustration: MOMBI POINTED HER LONG, BONY FINGER AT THE BOY.]
+
+"You are not a girl just now," said she, gently, "because Mombi
+transformed you into a boy. But you were born a girl, and also a
+Princess; so you must resume your proper form, that you may become
+Queen of the Emerald City."
+
+"Oh, let Jinjur be the Queen!" exclaimed Tip, ready to cry. "I want to
+stay a boy, and travel with the Scarecrow and the Tin Woodman, and the
+Woggle-Bug, and Jack--yes! and my friend the Saw-Horse--and the Gump!
+I don't want to be a girl!"
+
+"Never mind, old chap," said the Tin Woodman, soothingly; "it don't
+hurt to be a girl, I'm told; and we will all remain your faithful
+friends just the same. And, to be honest with you, I've always
+considered girls nicer than boys."
+
+"They're just as nice, anyway," added the Scarecrow, patting Tip
+affectionately upon the head.
+
+"And they are equally good students," proclaimed the Woggle-Bug. "I
+should like to become your tutor, when you are transformed into a girl
+again."
+
+"But--see here!" said Jack Pumpkinhead, with a gasp: "if you become a
+girl, you can't be my dear father any more!"
+
+"No," answered Tip, laughing in spite of his anxiety; "and I shall not
+be sorry to escape the relationship." Then he added, hesitatingly, as
+he turned to Glinda: "I might try it for awhile,--just to see how it
+seems, you know. But if I don't like being a girl you must promise to
+change me into a boy again."
+
+[Illustration]
+
+"Really," said the Sorceress, "that is beyond my magic. I never deal in
+transformations, for they are not honest, and no respectable sorceress
+likes to make things appear to be what they are not. Only unscrupulous
+witches use the art, and therefore I must ask Mombi to effect your
+release from her charm, and restore you to your proper form. It will be
+the last opportunity she will have to practice magic."
+
+Now that the truth about Princess Ozma had been discovered, Mombi did
+not care what became of Tip; but she feared Glinda's anger, and the boy
+generously promised to provide for Mombi in her old age if he became
+the ruler of the Emerald City. So the Witch consented to effect the
+transformation, and preparations for the event were at once made.
+
+Glinda ordered her own royal couch to be placed in the center of the
+tent. It was piled high with cushions covered with rose-colored silk,
+and from a golden railing above hung many folds of pink gossamer,
+completely concealing the interior of the couch.
+
+The first act of the Witch was to make the boy drink a potion which
+quickly sent him into a deep and dreamless sleep. Then the Tin Woodman
+and the Woggle-Bug bore him gently to the couch, placed him upon the
+soft cushions, and drew the gossamer hangings to shut him from all
+earthly view.
+
+The Witch squatted upon the ground and kindled a tiny fire of dried
+herbs, which she drew from her bosom. When the blaze shot up and burned
+clearly old Mombi scattered a handful of magical powder over the fire,
+which straightway gave off a rich violet vapor, filling all the tent
+with its fragrance and forcing the Saw-Horse to sneeze--although he had
+been warned to keep quiet.
+
+[Illustration: MOMBI AT HER MAGICAL INCANTATIONS.]
+
+Then, while the others watched her curiously, the hag chanted a
+rhythmical verse in words which no one understood, and bent her lean
+body seven times back and forth over the fire. And now the incantation
+seemed complete, for the Witch stood upright and cried the one word
+"Yeowa!" in a loud voice.
+
+The vapor floated away; the atmosphere became clear again; a whiff of
+fresh air filled the tent, and the pink curtains of the couch trembled
+slightly, as if stirred from within.
+
+Glinda walked to the canopy and parted the silken hangings. Then she
+bent over the cushions, reached out her hand, and from the couch
+arose the form of a young girl, fresh and beautiful as a May morning.
+Her eyes sparkled as two diamonds, and her lips were tinted like a
+tourmaline. All adown her back floated tresses of ruddy gold, with a
+slender jeweled circlet confining them at the brow. Her robes of silken
+gauze floated around her like a cloud, and dainty satin slippers shod
+her feet.
+
+At this exquisite vision Tip's old comrades stared in wonder for
+the space of a full minute, and then every head bent low in honest
+admiration of the lovely Princess Ozma. The girl herself cast one look
+into Glinda's bright face, which glowed with pleasure and satisfaction,
+and then turned upon the others. Speaking the words with sweet
+diffidence, she said:
+
+"I hope none of you will care less for me than you did before. I'm just
+the same Tip, you know; only--only--"
+
+"Only you're different!" said the Pumpkinhead; and everyone thought it
+was the wisest speech he had ever made.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Riches of
+    Content
+]
+
+
+When the wonderful tidings reached the ears of Queen Jinjur--how Mombi
+the Witch had been captured; how she had confessed her crime to Glinda;
+and how the long-lost Princess Ozma had been discovered in no less a
+personage than the boy Tip--she wept real tears of grief and despair.
+
+"To think," she moaned, "that after having ruled as Queen, and lived in
+a palace, I must go back to scrubbing floors and churning butter again!
+It is too horrible to think of! I will never consent!"
+
+So when her soldiers, who spent most of their time making fudge in the
+palace kitchens, counseled Jinjur to resist, she listened to their
+foolish prattle and sent a sharp defiance to Glinda the Good and the
+Princess Ozma. The result was a declaration of war, and the very next
+day Glinda marched upon the Emerald City with pennants flying and bands
+playing, and a forest of shining spears sparkling brightly beneath the
+sun's rays.
+
+But when it came to the walls this brave assembly made a sudden halt;
+for Jinjur had closed and barred every gateway, and the walls of the
+Emerald City were builded high and thick with many blocks of green
+marble. Finding her advance thus baffled, Glinda bent her brows in deep
+thought, while the Woggle-Bug said, in his most positive tone:
+
+"We must lay siege to the city, and starve it into submission. It is
+the only thing we can do."
+
+"Not so," answered the Scarecrow. "We still have the Gump, and the Gump
+can still fly."
+
+The Sorceress turned quickly at this speech, and her face now wore a
+bright smile.
+
+"You are right," she exclaimed, "and certainly have reason to be proud
+of your brains. Let us go to the Gump at once!"
+
+So they passed through the ranks of the army until they came to the
+place, near the Scarecrow's tent, where the Gump lay. Glinda and
+Princess Ozma mounted first, and sat upon the sofas. Then the Scarecrow
+and his friends climbed aboard, and still there was room for a Captain
+and three soldiers, which Glinda considered sufficient for a guard.
+
+[Illustration]
+
+Now, at a word from the Princess, the queer Thing they had called
+the Gump flopped its palm-leaf wings and rose into the air, carrying
+the party of adventurers high above the walls. They hovered over
+the palace, and soon perceived Jinjur reclining in a hammock in the
+courtyard, where she was comfortably reading a novel with a green cover
+and eating green chocolates, confident that the walls would protect her
+from her enemies. Obeying a quick command, the Gump alighted safely in
+this very courtyard, and before Jinjur had time to do more than scream,
+the Captain and three soldiers leaped out and made the former Queen a
+prisoner, locking strong chains upon both her wrists.
+
+That act really ended the war; for the Army of Revolt submitted as
+soon as they knew Jinjur to be a captive, and the Captain marched in
+safety through the streets and up to the gates of the city, which
+she threw wide open. Then the bands played their most stirring music
+while Glinda's army marched into the city, and heralds proclaimed the
+conquest of the audacious Jinjur and the accession of the beautiful
+Princess Ozma to the throne of her royal ancestors.
+
+[Illustration]
+
+At once the men of the Emerald City cast off their aprons. And it is
+said that the women were so tired eating of their husbands' cooking
+that they all hailed the conquest of Jinjur with joy. Certain it is
+that, rushing one and all to the kitchens of their houses, the good
+wives prepared so delicious a feast for the weary men that harmony was
+immediately restored in every family.
+
+Ozma's first act was to oblige the Army of Revolt to return to
+her every emerald or other gem stolen from the public streets and
+buildings; and so great was the number of precious stones picked
+from their settings by these vain girls, that every one of the royal
+jewelers worked steadily for more than a month to replace them in their
+settings.
+
+Meantime the Army of Revolt was disbanded and the girls sent home to
+their mothers. On promise of good behavior Jinjur was likewise released.
+
+Ozma made the loveliest Queen the Emerald City had ever known; and,
+although she was so young and inexperienced, she ruled her people with
+wisdom and justice. For Glinda gave her good advice on all occasions;
+and the Woggle-Bug, who was appointed to the important post of Public
+Educator, was quite helpful to Ozma when her royal duties grew
+perplexing.
+
+The girl, in her gratitude to the Gump for its services, offered the
+creature any reward it might name.
+
+"Then," replied the Gump, "please take me to pieces. I did not wish
+to be brought to life, and I am greatly ashamed of my conglomerate
+personality. Once I was a monarch of the forest, as my antlers fully
+prove; but now, in my present upholstered condition of servitude, I
+am compelled to fly through the air--my legs being of no use to me
+whatever. Therefore I beg to be dispersed."
+
+So Ozma ordered the Gump taken apart. The antlered head was again
+hung over the mantle-piece in the hall, and the sofas were untied and
+placed in the reception parlors. The broom tail resumed its accustomed
+duties in the kitchen, and finally, the Scarecrow replaced all the
+clotheslines and ropes on the pegs from which he had taken them on the
+eventful day when the Thing was constructed.
+
+You might think that was the end of the Gump; and so it was, as a
+flying-machine. But the head over the mantle-piece continued to talk
+whenever it took a notion to do so, and it frequently startled, with
+its abrupt questions, the people who waited in the hall for an audience
+with the Queen.
+
+The Saw-Horse, being Ozma's personal property, was tenderly cared for;
+and often she rode the queer creature along the streets of the Emerald
+City. She had its wooden legs shod with gold, to keep them from
+wearing out, and the tinkle of these golden shoes upon the pavement
+always filled the Queen's subjects with awe as they thought upon this
+evidence of her magical powers.
+
+"The Wonderful Wizard was never so wonderful as Queen Ozma," the people
+said to one another, in whispers; "for he claimed to do many things he
+could not do; whereas our new Queen does many things no one would ever
+expect her to accomplish."
+
+Jack Pumpkinhead remained with Ozma to the end of his days; and he
+did not spoil as soon as he had feared, although he always remained
+as stupid as ever. The Woggle-Bug tried to teach him several arts and
+sciences; but Jack was so poor a student that any attempt to educate
+him was soon abandoned.
+
+After Glinda's army had marched back home, and peace was restored to
+the Emerald City, the Tin Woodman announced his intention to return to
+his own Kingdom of the Winkies.
+
+"It isn't a very big Kingdom," said he to Ozma, "but for that very
+reason it is easier to rule; and I have called myself an Emperor
+because I am an Absolute Monarch, and no one interferes in any way
+with my conduct of public or personal affairs. When I get home I shall
+have a new coat of nickel plate; for I have become somewhat marred and
+scratched lately; and then I shall be glad to have you pay me a visit."
+
+"Thank you," replied Ozma. "Some day I may accept the invitation. But
+what is to become of the Scarecrow?"
+
+"I shall return with my friend the Tin Woodman," said the stuffed one,
+seriously. "We have decided never to be parted in the future."
+
+"And I have made the Scarecrow my Royal Treasurer," explained the Tin
+Woodman. "For it has occurred to me that it is a good thing to have a
+Royal Treasurer who is made of money. What do you think?"
+
+"I think," said the little Queen, smiling, "that your friend must be
+the richest man in all the world."
+
+"I am," returned the Scarecrow; "but not on account of my money. For
+I consider brains far superior to money, in every way. You may have
+noticed that if one has money without brains, he cannot use it to
+advantage; but if one has brains without money, they will enable him to
+live comfortably to the end of his days."
+
+"At the same time," declared the Tin Woodman, "you must acknowledge
+that a good heart is a thing that brains can not create, and that money
+can not buy. Perhaps, after all, it is I who am the richest man in all
+the world."
+
+"You are both rich, my friends," said Ozma, gently; "and your riches
+are the only riches worth having--the riches of content!"
+
+[Illustration:
+
+    The End
+]
+
+
+
+
+THE OZ BOOKS
+
+BY
+
+L. FRANK BAUM
+
+
+_The Wizard of Oz_
+
+[Originally published as _The Wonderful Wizard of Oz_]
+
+It is in this book that Oz is "discovered." A little Kansas
+girl--Dorothy Gale--is carried in her house to Oz when a cyclone whisks
+it through the sky. As the house lands in the Munchkin Country (one of
+the four great countries of Oz) it destroys a wicked witch and sends
+Dorothy off on her first adventure in Oz. She finds the Scarecrow,
+meets the Tin Woodman and the Cowardly Lion, melts a second wicked
+witch with a pail of water and finds her way home. Since this book
+appeared a half-century ago, we have learned many marvelous things
+about the Land of Oz.
+
+
+_The Land of Oz_
+
+[Originally published as _The Marvelous Land of Oz_]
+
+This sequel to _The Wizard of Oz_ deals entirely with the early history
+of Oz. No one from the United States or any other part of the "great
+outside world" appears in it. It takes its readers on a series of
+incredible adventures with Tip, a small boy who runs away from old
+Mombi, the witch, taking with him Jack Pumpkinhead and the wooden
+Saw-Horse. The Scarecrow is King of the Emerald City until he, Tip,
+Jack, and the Tin Woodman are forced to flee the royal palace when it
+is invaded by General Jinjur and her army of rebelling girls. The _Land
+of Oz_ ends with an amazing surprise, and from that moment on Ozma is
+princess of all Oz.
+
+
+_Ozma of Oz_
+
+Few of the Oz books are as crowded with exciting Oz happenings as this
+one. Not only does it bring Dorothy back to Oz on her second visit,
+but it introduces Dorothy to Ozma, relates Ozma's first important
+adventure, and introduces for the first time such famous Oz characters
+as Tik-Tok, the mechanical man, Billina the hen, the Hungry Tiger,
+and--_the Nome King_! Most of the adventures in this book take place
+outside Oz, in the Land of Ev and the Nome Kingdom. Scarcely a page
+fails to quiver with excitement, magic and adventure.
+
+
+_Dorothy and the Wizard in Oz_
+
+Of course, everyone always predicted it would happen! And in this book
+it does--the Wizard comes back to Oz to stay. Best of all, he comes
+with Dorothy, who is having adventure number three that leads her
+to Oz, this time via a California earthquake. In this book we meet
+Dorothy's pink kitten, Eureka, whose manners need adjusting badly,
+and two good friends who we are sorry did not remain in Oz--Jim the
+cabhorse, and Zeb, Dorothy's young cousin, who works on a ranch as a
+hired boy.
+
+
+_The Road to Oz_
+
+We like to think of this volume as "The Party Book of Oz." Almost
+everyone loves a party, and when Ozma has a birthday party with
+notables from every part of fairyland attending--well! It is just like
+attending Ozma's party in person. You meet the famous of Oz, and lots
+of others, such as Queen Zixi of Ix, John Dough, Chick the Cherub, the
+Queen of Merryland, Para Bruin the rubber bear and--best of all--Santa
+Claus himself! Of course there are lots of adventures on that famous
+road to Oz before the party, during which Dorothy, on her way to Oz for
+the fourth time, meets such heart-warming characters as the Shaggy Man,
+Button-Bright, and lovely Polychrome, daughter of the rainbow.
+
+
+_The Emerald City of Oz_
+
+Here is a "double" story of Oz. While Dorothy, her Aunt Em and Uncle
+Henry experience the events that lead to their going to Oz to make
+their home in the Emerald City, the wicked Nome King is plotting to
+conquer Oz and enslave its people. Later we go with Dorothy and her
+friends in the Red Wagon on a grand tour of Oz that is simply packed
+with excitement and events. While this transpires, we learn also of the
+Nome King's elaborate preparations to conquer Oz. As Dorothy and her
+friends return to the Emerald City, the Nome King and his hordes of
+warriors are about to invade it. How Oz is saved is an ending that will
+amaze and delight you.
+
+
+_The Patchwork Girl of Oz_
+
+Here, the Patchwork Girl is brought to life by Dr. Pipt's magic Powder
+of Life. From that moment on the action never slows down in this
+exciting book. It tells of Ojo's quest for the strange ingredients
+necessary to brew a magic liquid that will release his Unk Nunkie from
+a spell--the spell cast by the Liquid of Petrifaction, which has turned
+him into a marble statue. In addition to the Patchwork Girl, Ojo and
+Unk Nunkie, this book introduces those famous Oz creatures, the Woozy,
+and Bungle the glass cat. Oz certainly has become a merrier, happier
+land since the Patchwork Girl came to life, and this is the book that
+tells how Scraps came to be made, how she was brought to life, and all
+about her early adventures.
+
+
+_Tik-Tok of Oz_
+
+For the second time a little girl from the United States comes to Oz.
+Betsy Bobbin is shipwrecked in the Nonestic Ocean with her friend Hank
+the mule. The two drift to shore in the Rose Kingdom on a fragment of
+wreckage. Betsy meets the Shaggy Man and accompanies him to the Nome
+Kingdom, where Shaggy hopes to release his brother, a prisoner of the
+Nome King. On their way to the Nome Kingdom, one fascinating adventure
+follows another. They meet Queen Ann Soforth of Oogaboo and her army,
+and lovely Polychrome, who had lost her rainbow again; they rescue
+Tik-Tok from a well; and are dropped through a Hollow Tube to the other
+side of the world where they meet Quox, the dragon. You'll find it one
+of the most exciting of all the Oz books.
+
+
+_The Scarecrow of Oz_
+
+This is the Oz book which L. Frank Baum considered his best. It starts
+quietly enough with Trot and Cap'n Bill rowing along a shore of the
+Pacific Ocean to visit one of the many caves near their home on the
+California coast. Suddenly, a mighty whirlpool engulfs them. The
+old sailorman and the little girl are miraculously saved and regain
+consciousness to find themselves in a sea cavern. (To this day, Trot
+asserts she felt mermaid arms about her during those terrible moments
+under water.) From here on, one perilous adventure crowds in upon
+another. In Jinxland they meet the Scarecrow who takes charge of things
+once Cap'n Bill is transformed into a tiny grasshopper with a wooden
+leg. An exciting royal reception greets the adventurers upon their
+return to the Emerald City.
+
+
+_Rinkitink in Oz_
+
+Prince Inga of Pingaree is the boy hero of this fine story of
+peril-filled adventure in the islands of the Nonestic Ocean. King
+Rinkitink provides comic relief, and by the time you reach the final
+page you will love this fat, jolly little king. Bilbil the goat,
+with his surly disposition, provides a fine contrast to Rinkitink's
+merriment and Prince Inga's bravery and courage in the face of
+danger. Some may say that the three magic pearls are the real heroes
+of this story, but the pearls would have been of little use to King
+Kitticut and Queen Garee if Prince Inga hadn't used them wisely and
+courageously.
+
+
+_The Lost Princess of Oz_
+
+Talk about _Button-Bright_ getting lost--_Ozma_ is almost as bad! This
+is actually the second time Ozma has been lost. As you know, once
+she was "lost" for many years. But in this book she is lost for only
+a short time. As soon as it is discovered that the ruler of Oz is
+lost--and with her all the important magical instruments in Oz--search
+parties, one for each of the four countries of Oz, set out to find her.
+We follow the adventures of the party headed by Dorothy and the Wizard,
+who explore unknown parts of the Winkie Country in search of Ozma. How
+Ozma is found, and where she has been, will surprise you. Frogman, a
+new character, is introduced in this book.
+
+
+_The Tin Woodman of Oz_
+
+Woot the Wanderer causes this chapter of Oz history to transpire. When
+Woot wanders into the splendid tin castle of Nick Chopper, the Tin
+Woodman and Emperor of the Winkies, he meets the Scarecrow, who is
+visiting his old friend. The Tin Woodman tells Woot the story of how
+he had once been a flesh-and-blood woodman in love with a maiden named
+Nimmie Aimee. Woot suggests that since the Tin Woodman now has a kind
+and loving heart, it is his duty to find Nimmie Aimee and make her
+Empress of the Winkies. The Scarecrow agrees, so the three set off to
+search for the girl. No less surprising than the adventures encountered
+on the journey is Nimmie Aimee's reception of her former suitor.
+
+
+_The Magic of Oz_
+
+Old Ruggedo, the former Nome King, comes to Oz for the second time,
+and makes more trouble than he did on his first visit. Ruggedo never
+gives up the idea of conquering Oz, and this time he has the advantage
+of being in the country without Ozma's knowledge. Also, he has the
+magic and somewhat grudging help of Kiki Aru, the Munchkin boy who
+is illegally practicing the art. If you like magic, then this is a
+book for you. There's magic on every page, and everyone in the story
+eventually is transformed into something else, or bewitched in one way
+or another. Even the wild animals in the great Forest of Gugu do not
+escape.
+
+
+_Glinda of Oz_
+
+This is the last Oz book written by L. Frank Baum. It is one of the
+best in the series, with Dorothy, Ozma, and Glinda in an adventure that
+takes them to an amazing crystal-domed city on an enchanted island.
+This island is situated in a lake in the Gillikin Country. Ozma and
+Glinda are confronted by powerful magic and determined enemies. For a
+time Dorothy and Ozma are prisoners in the crystal-domed city which is
+able to submerge below the surface of the lake. Few of the Oz books
+equal this one in suspense and mystery--a story that is truly "out of
+this world."
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+       *       *       *       *       *
+  +---------------------------------------------------------------------+
+  |                                                                     |
+  |                       Transcriber notes:                            |
+  |                                                                     |
+  | P.6. 'ecstacy.' changed to 'ecstasy.'                               |
+  | P.208. 'nickle-plate' changed to 'nickel-plate'                     |
+  | P.285. 'Liquid of Petrefaction' changed to 'Liquid of Petrifaction'.|
+  | Taken hypen out of pumpkinhead or pumpkinheads.                     |
+  | Fixed various punctuation.                                          |
+  |                                                                     |
+  | Text surrounded by _this_ indicated italics, and text surrounded    |
+  |   by =this= indicates bold.                                         |
+  |                                                                     |
+  +---------------------------------------------------------------------+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+***** This file should be named 53844-8.txt or 53844-8.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/5/3/8/4/53844/
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for the eBooks, unless you receive
+specific permission. If you do not charge anything for copies of this
+eBook, complying with the rules is very easy. You may use this eBook
+for nearly any purpose such as creation of derivative works, reports,
+performances and research. They may be modified and printed and given
+away--you may do practically ANYTHING in the United States with eBooks
+not protected by U.S. copyright law. Redistribution is subject to the
+trademark license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country outside the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you'll have to check the laws of the country where you
+  are located before using this ebook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from both the Project Gutenberg Literary Archive Foundation and The
+Project Gutenberg Trademark LLC, the owner of the Project Gutenberg-tm
+trademark. Contact the Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's principal office is in Fairbanks, Alaska, with the
+mailing address: PO Box 750175, Fairbanks, AK 99775, but its
+volunteers and employees are scattered throughout numerous
+locations. Its business office is located at 809 North 1500 West, Salt
+Lake City, UT 84116, (801) 596-1887. Email contact links and up to
+date contact information can be found at the Foundation's web site and
+official page at www.gutenberg.org/contact
+
+For additional contact information:
+
+    Dr. Gregory B. Newby
+    Chief Executive and Director
+    gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works.
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our Web site which has the main PG search
+facility: www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/madame-bovary.txt
+++ b/jet/hadoop/src/main/resources/books/madame-bovary.txt
@@ -1,0 +1,13856 @@
+﻿The Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Madame Bovary
+
+Author: Gustave Flaubert
+
+Translator: Eleanor Marx-Aveling
+
+Release Date: February 25, 2006 [EBook #2413]
+Last Updated: September 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+
+
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+
+
+
+
+MADAME BOVARY
+
+By Gustave Flaubert
+
+Translated from the French by Eleanor Marx-Aveling
+
+
+To Marie-Antoine-Jules Senard Member of the Paris Bar, Ex-President
+of the National Assembly, and Former Minister of the Interior Dear and
+Illustrious Friend, Permit me to inscribe your name at the head of this
+book, and above its dedication; for it is to you, before all, that I
+owe its publication. Reading over your magnificent defence, my work has
+acquired for myself, as it were, an unexpected authority.
+
+Accept, then, here, the homage of my gratitude, which, how great soever
+it is, will never attain the height of your eloquence and your devotion.
+
+Gustave Flaubert Paris, 12 April 1857
+
+
+
+
+MADAME BOVARY
+
+
+
+
+Part I
+
+
+
+Chapter One
+
+We were in class when the head-master came in, followed by a “new
+fellow,” not wearing the school uniform, and a school servant carrying a
+large desk. Those who had been asleep woke up, and every one rose as if
+just surprised at his work.
+
+The head-master made a sign to us to sit down. Then, turning to the
+class-master, he said to him in a low voice--
+
+“Monsieur Roger, here is a pupil whom I recommend to your care; he’ll be
+in the second. If his work and conduct are satisfactory, he will go into
+one of the upper classes, as becomes his age.”
+
+The “new fellow,” standing in the corner behind the door so that he
+could hardly be seen, was a country lad of about fifteen, and taller
+than any of us. His hair was cut square on his forehead like a village
+chorister’s; he looked reliable, but very ill at ease. Although he was
+not broad-shouldered, his short school jacket of green cloth with black
+buttons must have been tight about the arm-holes, and showed at the
+opening of the cuffs red wrists accustomed to being bare. His legs, in
+blue stockings, looked out from beneath yellow trousers, drawn tight by
+braces, He wore stout, ill-cleaned, hob-nailed boots.
+
+We began repeating the lesson. He listened with all his ears, as
+attentive as if at a sermon, not daring even to cross his legs or lean
+on his elbow; and when at two o’clock the bell rang, the master was
+obliged to tell him to fall into line with the rest of us.
+
+When we came back to work, we were in the habit of throwing our caps on
+the ground so as to have our hands more free; we used from the door to
+toss them under the form, so that they hit against the wall and made a
+lot of dust: it was “the thing.”
+
+But, whether he had not noticed the trick, or did not dare to attempt
+it, the “new fellow,” was still holding his cap on his knees even after
+prayers were over. It was one of those head-gears of composite order, in
+which we can find traces of the bearskin, shako, billycock hat, sealskin
+cap, and cotton night-cap; one of those poor things, in fine, whose
+dumb ugliness has depths of expression, like an imbecile’s face. Oval,
+stiffened with whalebone, it began with three round knobs; then came in
+succession lozenges of velvet and rabbit-skin separated by a red band;
+after that a sort of bag that ended in a cardboard polygon covered with
+complicated braiding, from which hung, at the end of a long thin cord,
+small twisted gold threads in the manner of a tassel. The cap was new;
+its peak shone.
+
+“Rise,” said the master.
+
+He stood up; his cap fell. The whole class began to laugh. He stooped to
+pick it up. A neighbor knocked it down again with his elbow; he picked
+it up once more.
+
+“Get rid of your helmet,” said the master, who was a bit of a wag.
+
+There was a burst of laughter from the boys, which so thoroughly put the
+poor lad out of countenance that he did not know whether to keep his cap
+in his hand, leave it on the ground, or put it on his head. He sat down
+again and placed it on his knee.
+
+“Rise,” repeated the master, “and tell me your name.”
+
+The new boy articulated in a stammering voice an unintelligible name.
+
+“Again!”
+
+The same sputtering of syllables was heard, drowned by the tittering of
+the class.
+
+“Louder!” cried the master; “louder!”
+
+The “new fellow” then took a supreme resolution, opened an inordinately
+large mouth, and shouted at the top of his voice as if calling someone
+in the word “Charbovari.”
+
+A hubbub broke out, rose in crescendo with bursts of shrill voices (they
+yelled, barked, stamped, repeated “Charbovari! Charbovari”), then died
+away into single notes, growing quieter only with great difficulty, and
+now and again suddenly recommencing along the line of a form whence rose
+here and there, like a damp cracker going off, a stifled laugh.
+
+However, amid a rain of impositions, order was gradually re-established
+in the class; and the master having succeeded in catching the name of
+“Charles Bovary,” having had it dictated to him, spelt out, and re-read,
+at once ordered the poor devil to go and sit down on the punishment form
+at the foot of the master’s desk. He got up, but before going hesitated.
+
+“What are you looking for?” asked the master.
+
+“My c-a-p,” timidly said the “new fellow,” casting troubled looks round
+him.
+
+“Five hundred lines for all the class!” shouted in a furious voice
+stopped, like the Quos ego*, a fresh outburst. “Silence!” continued the
+master indignantly, wiping his brow with his handkerchief, which he
+had just taken from his cap. “As to you, ‘new boy,’ you will conjugate
+‘ridiculus sum’ ** twenty times.”
+
+Then, in a gentler tone, “Come, you’ll find your cap again; it hasn’t
+been stolen.”
+
+     *A quotation from the Aeneid signifying a threat.
+
+     **I am ridiculous.
+
+Quiet was restored. Heads bent over desks, and the “new fellow” remained
+for two hours in an exemplary attitude, although from time to time some
+paper pellet flipped from the tip of a pen came bang in his face. But he
+wiped his face with one hand and continued motionless, his eyes lowered.
+
+In the evening, at preparation, he pulled out his pens from his desk,
+arranged his small belongings, and carefully ruled his paper. We saw him
+working conscientiously, looking up every word in the dictionary, and
+taking the greatest pains. Thanks, no doubt, to the willingness he
+showed, he had not to go down to the class below. But though he knew his
+rules passably, he had little finish in composition. It was the cure
+of his village who had taught him his first Latin; his parents, from
+motives of economy, having sent him to school as late as possible.
+
+His father, Monsieur Charles Denis Bartolome Bovary, retired
+assistant-surgeon-major, compromised about 1812 in certain conscription
+scandals, and forced at this time to leave the service, had taken
+advantage of his fine figure to get hold of a dowry of sixty thousand
+francs that offered in the person of a hosier’s daughter who had fallen
+in love with his good looks. A fine man, a great talker, making his
+spurs ring as he walked, wearing whiskers that ran into his moustache,
+his fingers always garnished with rings and dressed in loud colours,
+he had the dash of a military man with the easy go of a commercial
+traveller.
+
+Once married, he lived for three or four years on his wife’s fortune,
+dining well, rising late, smoking long porcelain pipes, not coming in
+at night till after the theatre, and haunting cafes. The father-in-law
+died, leaving little; he was indignant at this, “went in for the
+business,” lost some money in it, then retired to the country, where he
+thought he would make money.
+
+But, as he knew no more about farming than calico, as he rode his horses
+instead of sending them to plough, drank his cider in bottle instead of
+selling it in cask, ate the finest poultry in his farmyard, and greased
+his hunting-boots with the fat of his pigs, he was not long in finding
+out that he would do better to give up all speculation.
+
+For two hundred francs a year he managed to live on the border of
+the provinces of Caux and Picardy, in a kind of place half farm, half
+private house; and here, soured, eaten up with regrets, cursing his
+luck, jealous of everyone, he shut himself up at the age of forty-five,
+sick of men, he said, and determined to live at peace.
+
+His wife had adored him once on a time; she had bored him with a
+thousand servilities that had only estranged him the more. Lively once,
+expansive and affectionate, in growing older she had become (after the
+fashion of wine that, exposed to air, turns to vinegar) ill-tempered,
+grumbling, irritable. She had suffered so much without complaint at
+first, until she had seem him going after all the village drabs, and
+until a score of bad houses sent him back to her at night, weary,
+stinking drunk. Then her pride revolted. After that she was silent,
+burying her anger in a dumb stoicism that she maintained till her death.
+She was constantly going about looking after business matters. She
+called on the lawyers, the president, remembered when bills fell due,
+got them renewed, and at home ironed, sewed, washed, looked after the
+workmen, paid the accounts, while he, troubling himself about nothing,
+eternally besotted in sleepy sulkiness, whence he only roused himself
+to say disagreeable things to her, sat smoking by the fire and spitting
+into the cinders.
+
+When she had a child, it had to be sent out to nurse. When he came home,
+the lad was spoilt as if he were a prince. His mother stuffed him
+with jam; his father let him run about barefoot, and, playing the
+philosopher, even said he might as well go about quite naked like the
+young of animals. As opposed to the maternal ideas, he had a certain
+virile idea of childhood on which he sought to mould his son, wishing
+him to be brought up hardily, like a Spartan, to give him a strong
+constitution. He sent him to bed without any fire, taught him to drink
+off large draughts of rum and to jeer at religious processions. But,
+peaceable by nature, the lad answered only poorly to his notions. His
+mother always kept him near her; she cut out cardboard for him, told him
+tales, entertained him with endless monologues full of melancholy gaiety
+and charming nonsense. In her life’s isolation she centered on the
+child’s head all her shattered, broken little vanities. She dreamed of
+high station; she already saw him, tall, handsome, clever, settled as
+an engineer or in the law. She taught him to read, and even, on an old
+piano, she had taught him two or three little songs. But to all this
+Monsieur Bovary, caring little for letters, said, “It was not worth
+while. Would they ever have the means to send him to a public school, to
+buy him a practice, or start him in business? Besides, with cheek a man
+always gets on in the world.” Madame Bovary bit her lips, and the child
+knocked about the village.
+
+He went after the labourers, drove away with clods of earth the ravens
+that were flying about. He ate blackberries along the hedges, minded the
+geese with a long switch, went haymaking during harvest, ran about in
+the woods, played hop-scotch under the church porch on rainy days, and
+at great fetes begged the beadle to let him toll the bells, that he
+might hang all his weight on the long rope and feel himself borne upward
+by it in its swing. Meanwhile he grew like an oak; he was strong on
+hand, fresh of colour.
+
+When he was twelve years old his mother had her own way; he began
+lessons. The cure took him in hand; but the lessons were so short and
+irregular that they could not be of much use. They were given at spare
+moments in the sacristy, standing up, hurriedly, between a baptism and
+a burial; or else the cure, if he had not to go out, sent for his pupil
+after the Angelus*. They went up to his room and settled down; the
+flies and moths fluttered round the candle. It was close, the child
+fell asleep, and the good man, beginning to doze with his hands on his
+stomach, was soon snoring with his mouth wide open. On other occasions,
+when Monsieur le Cure, on his way back after administering the viaticum
+to some sick person in the neighbourhood, caught sight of Charles
+playing about the fields, he called him, lectured him for a quarter of
+an hour and took advantage of the occasion to make him conjugate his
+verb at the foot of a tree. The rain interrupted them or an acquaintance
+passed. All the same he was always pleased with him, and even said the
+“young man” had a very good memory.
+
+     *A devotion said at morning, noon, and evening, at the sound
+     of a bell. Here, the evening prayer.
+
+Charles could not go on like this. Madame Bovary took strong steps.
+Ashamed, or rather tired out, Monsieur Bovary gave in without a
+struggle, and they waited one year longer, so that the lad should take
+his first communion.
+
+Six months more passed, and the year after Charles was finally sent to
+school at Rouen, where his father took him towards the end of October,
+at the time of the St. Romain fair.
+
+It would now be impossible for any of us to remember anything about him.
+He was a youth of even temperament, who played in playtime, worked in
+school-hours, was attentive in class, slept well in the dormitory,
+and ate well in the refectory. He had in loco parentis* a wholesale
+ironmonger in the Rue Ganterie, who took him out once a month on Sundays
+after his shop was shut, sent him for a walk on the quay to look at
+the boats, and then brought him back to college at seven o’clock before
+supper. Every Thursday evening he wrote a long letter to his mother with
+red ink and three wafers; then he went over his history note-books, or
+read an old volume of “Anarchasis” that was knocking about the study.
+When he went for walks he talked to the servant, who, like himself, came
+from the country.
+
+     *In place of a parent.
+
+By dint of hard work he kept always about the middle of the class; once
+even he got a certificate in natural history. But at the end of his
+third year his parents withdrew him from the school to make him study
+medicine, convinced that he could even take his degree by himself.
+
+His mother chose a room for him on the fourth floor of a dyer’s she
+knew, overlooking the Eau-de-Robec. She made arrangements for his
+board, got him furniture, table and two chairs, sent home for an old
+cherry-tree bedstead, and bought besides a small cast-iron stove with
+the supply of wood that was to warm the poor child.
+
+Then at the end of a week she departed, after a thousand injunctions to
+be good now that he was going to be left to himself.
+
+The syllabus that he read on the notice-board stunned him; lectures
+on anatomy, lectures on pathology, lectures on physiology, lectures on
+pharmacy, lectures on botany and clinical medicine, and therapeutics,
+without counting hygiene and materia medica--all names of whose
+etymologies he was ignorant, and that were to him as so many doors to
+sanctuaries filled with magnificent darkness.
+
+He understood nothing of it all; it was all very well to listen--he did
+not follow. Still he worked; he had bound note-books, he attended all
+the courses, never missed a single lecture. He did his little daily task
+like a mill-horse, who goes round and round with his eyes bandaged, not
+knowing what work he is doing.
+
+To spare him expense his mother sent him every week by the carrier a
+piece of veal baked in the oven, with which he lunched when he came back
+from the hospital, while he sat kicking his feet against the wall.
+After this he had to run off to lectures, to the operation-room, to the
+hospital, and return to his home at the other end of the town. In the
+evening, after the poor dinner of his landlord, he went back to his
+room and set to work again in his wet clothes, which smoked as he sat in
+front of the hot stove.
+
+On the fine summer evenings, at the time when the close streets are
+empty, when the servants are playing shuttle-cock at the doors, he
+opened his window and leaned out. The river, that makes of this quarter
+of Rouen a wretched little Venice, flowed beneath him, between the
+bridges and the railings, yellow, violet, or blue. Working men, kneeling
+on the banks, washed their bare arms in the water. On poles projecting
+from the attics, skeins of cotton were drying in the air. Opposite,
+beyond the roots spread the pure heaven with the red sun setting. How
+pleasant it must be at home! How fresh under the beech-tree! And he
+expanded his nostrils to breathe in the sweet odours of the country
+which did not reach him.
+
+He grew thin, his figure became taller, his face took a saddened look
+that made it nearly interesting. Naturally, through indifference, he
+abandoned all the resolutions he had made. Once he missed a lecture; the
+next day all the lectures; and, enjoying his idleness, little by little,
+he gave up work altogether. He got into the habit of going to the
+public-house, and had a passion for dominoes. To shut himself up every
+evening in the dirty public room, to push about on marble tables the
+small sheep bones with black dots, seemed to him a fine proof of his
+freedom, which raised him in his own esteem. It was beginning to see
+life, the sweetness of stolen pleasures; and when he entered, he put
+his hand on the door-handle with a joy almost sensual. Then many things
+hidden within him came out; he learnt couplets by heart and sang them to
+his boon companions, became enthusiastic about Beranger, learnt how to
+make punch, and, finally, how to make love.
+
+Thanks to these preparatory labours, he failed completely in his
+examination for an ordinary degree. He was expected home the same night
+to celebrate his success. He started on foot, stopped at the beginning
+of the village, sent for his mother, and told her all. She excused
+him, threw the blame of his failure on the injustice of the examiners,
+encouraged him a little, and took upon herself to set matters straight.
+It was only five years later that Monsieur Bovary knew the truth; it was
+old then, and he accepted it. Moreover, he could not believe that a man
+born of him could be a fool.
+
+So Charles set to work again and crammed for his examination,
+ceaselessly learning all the old questions by heart. He passed pretty
+well. What a happy day for his mother! They gave a grand dinner.
+
+Where should he go to practice? To Tostes, where there was only one old
+doctor. For a long time Madame Bovary had been on the look-out for his
+death, and the old fellow had barely been packed off when Charles was
+installed, opposite his place, as his successor.
+
+But it was not everything to have brought up a son, to have had him
+taught medicine, and discovered Tostes, where he could practice it;
+he must have a wife. She found him one--the widow of a bailiff at
+Dieppe--who was forty-five and had an income of twelve hundred francs.
+Though she was ugly, as dry as a bone, her face with as many pimples as
+the spring has buds, Madame Dubuc had no lack of suitors. To attain her
+ends Madame Bovary had to oust them all, and she even succeeded in
+very cleverly baffling the intrigues of a port-butcher backed up by the
+priests.
+
+Charles had seen in marriage the advent of an easier life, thinking he
+would be more free to do as he liked with himself and his money. But his
+wife was master; he had to say this and not say that in company, to fast
+every Friday, dress as she liked, harass at her bidding those patients
+who did not pay. She opened his letter, watched his comings and goings,
+and listened at the partition-wall when women came to consult him in his
+surgery.
+
+She must have her chocolate every morning, attentions without end. She
+constantly complained of her nerves, her chest, her liver. The noise of
+footsteps made her ill; when people left her, solitude became odious to
+her; if they came back, it was doubtless to see her die. When Charles
+returned in the evening, she stretched forth two long thin arms from
+beneath the sheets, put them round his neck, and having made him sit
+down on the edge of the bed, began to talk to him of her troubles: he
+was neglecting her, he loved another. She had been warned she would be
+unhappy; and she ended by asking him for a dose of medicine and a little
+more love.
+
+
+
+Chapter Two
+
+One night towards eleven o’clock they were awakened by the noise of
+a horse pulling up outside their door. The servant opened the
+garret-window and parleyed for some time with a man in the street below.
+He came for the doctor, had a letter for him. Natasie came downstairs
+shivering and undid the bars and bolts one after the other. The man left
+his horse, and, following the servant, suddenly came in behind her. He
+pulled out from his wool cap with grey top-knots a letter wrapped up in
+a rag and presented it gingerly to Charles, who rested on his elbow on
+the pillow to read it. Natasie, standing near the bed, held the light.
+Madame in modesty had turned to the wall and showed only her back.
+
+This letter, sealed with a small seal in blue wax, begged Monsieur
+Bovary to come immediately to the farm of the Bertaux to set a broken
+leg. Now from Tostes to the Bertaux was a good eighteen miles across
+country by way of Longueville and Saint-Victor. It was a dark night;
+Madame Bovary junior was afraid of accidents for her husband. So it was
+decided the stable-boy should go on first; Charles would start three
+hours later when the moon rose. A boy was to be sent to meet him, and
+show him the way to the farm, and open the gates for him.
+
+Towards four o’clock in the morning, Charles, well wrapped up in his
+cloak, set out for the Bertaux. Still sleepy from the warmth of his bed,
+he let himself be lulled by the quiet trot of his horse. When it stopped
+of its own accord in front of those holes surrounded with thorns that
+are dug on the margin of furrows, Charles awoke with a start, suddenly
+remembered the broken leg, and tried to call to mind all the fractures
+he knew. The rain had stopped, day was breaking, and on the branches
+of the leafless trees birds roosted motionless, their little feathers
+bristling in the cold morning wind. The flat country stretched as far as
+eye could see, and the tufts of trees round the farms at long intervals
+seemed like dark violet stains on the cast grey surface, that on the
+horizon faded into the gloom of the sky.
+
+Charles from time to time opened his eyes, his mind grew weary, and,
+sleep coming upon him, he soon fell into a doze wherein, his recent
+sensations blending with memories, he became conscious of a double
+self, at once student and married man, lying in his bed as but now, and
+crossing the operation theatre as of old. The warm smell of poultices
+mingled in his brain with the fresh odour of dew; he heard the iron
+rings rattling along the curtain-rods of the bed and saw his wife
+sleeping. As he passed Vassonville he came upon a boy sitting on the
+grass at the edge of a ditch.
+
+“Are you the doctor?” asked the child.
+
+And on Charles’s answer he took his wooden shoes in his hands and ran on
+in front of him.
+
+The general practitioner, riding along, gathered from his guide’s talk
+that Monsieur Rouault must be one of the well-to-do farmers.
+
+He had broken his leg the evening before on his way home from a
+Twelfth-night feast at a neighbour’s. His wife had been dead for two
+years. There was with him only his daughter, who helped him to keep
+house.
+
+The ruts were becoming deeper; they were approaching the Bertaux.
+
+The little lad, slipping through a hole in the hedge, disappeared;
+then he came back to the end of a courtyard to open the gate. The
+horse slipped on the wet grass; Charles had to stoop to pass under
+the branches. The watchdogs in their kennels barked, dragging at their
+chains. As he entered the Bertaux, the horse took fright and stumbled.
+
+It was a substantial-looking farm. In the stables, over the top of the
+open doors, one could see great cart-horses quietly feeding from new
+racks. Right along the outbuildings extended a large dunghill, from
+which manure liquid oozed, while amidst fowls and turkeys, five or six
+peacocks, a luxury in Chauchois farmyards, were foraging on the top of
+it. The sheepfold was long, the barn high, with walls smooth as your
+hand. Under the cart-shed were two large carts and four ploughs, with
+their whips, shafts and harnesses complete, whose fleeces of blue wool
+were getting soiled by the fine dust that fell from the granaries. The
+courtyard sloped upwards, planted with trees set out symmetrically, and
+the chattering noise of a flock of geese was heard near the pond.
+
+A young woman in a blue merino dress with three flounces came to the
+threshold of the door to receive Monsieur Bovary, whom she led to the
+kitchen, where a large fire was blazing. The servant’s breakfast was
+boiling beside it in small pots of all sizes. Some damp clothes were
+drying inside the chimney-corner. The shovel, tongs, and the nozzle
+of the bellows, all of colossal size, shone like polished steel, while
+along the walls hung many pots and pans in which the clear flame of the
+hearth, mingling with the first rays of the sun coming in through the
+window, was mirrored fitfully.
+
+Charles went up the first floor to see the patient. He found him in his
+bed, sweating under his bed-clothes, having thrown his cotton nightcap
+right away from him. He was a fat little man of fifty, with white skin
+and blue eyes, the forepart of his head bald, and he wore earrings. By
+his side on a chair stood a large decanter of brandy, whence he poured
+himself a little from time to time to keep up his spirits; but as soon
+as he caught sight of the doctor his elation subsided, and instead of
+swearing, as he had been doing for the last twelve hours, began to groan
+freely.
+
+The fracture was a simple one, without any kind of complication.
+
+Charles could not have hoped for an easier case. Then calling to mind
+the devices of his masters at the bedsides of patients, he comforted the
+sufferer with all sorts of kindly remarks, those caresses of the surgeon
+that are like the oil they put on bistouries. In order to make some
+splints a bundle of laths was brought up from the cart-house. Charles
+selected one, cut it into two pieces and planed it with a fragment
+of windowpane, while the servant tore up sheets to make bandages, and
+Mademoiselle Emma tried to sew some pads. As she was a long time before
+she found her work-case, her father grew impatient; she did not answer,
+but as she sewed she pricked her fingers, which she then put to her
+mouth to suck them. Charles was surprised at the whiteness of her nails.
+They were shiny, delicate at the tips, more polished than the ivory of
+Dieppe, and almond-shaped. Yet her hand was not beautiful, perhaps not
+white enough, and a little hard at the knuckles; besides, it was too
+long, with no soft inflections in the outlines. Her real beauty was in
+her eyes. Although brown, they seemed black because of the lashes, and
+her look came at you frankly, with a candid boldness.
+
+The bandaging over, the doctor was invited by Monsieur Rouault himself
+to “pick a bit” before he left.
+
+Charles went down into the room on the ground floor. Knives and forks
+and silver goblets were laid for two on a little table at the foot of a
+huge bed that had a canopy of printed cotton with figures representing
+Turks. There was an odour of iris-root and damp sheets that escaped
+from a large oak chest opposite the window. On the floor in corners were
+sacks of flour stuck upright in rows. These were the overflow from
+the neighbouring granary, to which three stone steps led. By way of
+decoration for the apartment, hanging to a nail in the middle of the
+wall, whose green paint scaled off from the effects of the saltpetre,
+was a crayon head of Minerva in gold frame, underneath which was written
+in Gothic letters “To dear Papa.”
+
+First they spoke of the patient, then of the weather, of the great cold,
+of the wolves that infested the fields at night.
+
+Mademoiselle Rouault did not at all like the country, especially now
+that she had to look after the farm almost alone. As the room was
+chilly, she shivered as she ate. This showed something of her full lips,
+that she had a habit of biting when silent.
+
+Her neck stood out from a white turned-down collar. Her hair, whose
+two black folds seemed each of a single piece, so smooth were they, was
+parted in the middle by a delicate line that curved slightly with the
+curve of the head; and, just showing the tip of the ear, it was joined
+behind in a thick chignon, with a wavy movement at the temples that the
+country doctor saw now for the first time in his life. The upper part of
+her cheek was rose-coloured. She had, like a man, thrust in between two
+buttons of her bodice a tortoise-shell eyeglass.
+
+When Charles, after bidding farewell to old Rouault, returned to the
+room before leaving, he found her standing, her forehead against the
+window, looking into the garden, where the bean props had been knocked
+down by the wind. She turned round. “Are you looking for anything?” she
+asked.
+
+“My whip, if you please,” he answered.
+
+He began rummaging on the bed, behind the doors, under the chairs. It
+had fallen to the floor, between the sacks and the wall. Mademoiselle
+Emma saw it, and bent over the flour sacks.
+
+Charles out of politeness made a dash also, and as he stretched out his
+arm, at the same moment felt his breast brush against the back of the
+young girl bending beneath him. She drew herself up, scarlet, and looked
+at him over her shoulder as she handed him his whip.
+
+Instead of returning to the Bertaux in three days as he had promised,
+he went back the very next day, then regularly twice a week, without
+counting the visits he paid now and then as if by accident.
+
+Everything, moreover, went well; the patient progressed favourably; and
+when, at the end of forty-six days, old Rouault was seen trying to walk
+alone in his “den,” Monsieur Bovary began to be looked upon as a man
+of great capacity. Old Rouault said that he could not have been cured
+better by the first doctor of Yvetot, or even of Rouen.
+
+As to Charles, he did not stop to ask himself why it was a pleasure
+to him to go to the Bertaux. Had he done so, he would, no doubt, have
+attributed his zeal to the importance of the case, or perhaps to the
+money he hoped to make by it. Was it for this, however, that his visits
+to the farm formed a delightful exception to the meagre occupations of
+his life? On these days he rose early, set off at a gallop, urging on
+his horse, then got down to wipe his boots in the grass and put on black
+gloves before entering. He liked going into the courtyard, and noticing
+the gate turn against his shoulder, the cock crow on the wall, the lads
+run to meet him. He liked the granary and the stables; he liked old
+Rouault, who pressed his hand and called him his saviour; he liked the
+small wooden shoes of Mademoiselle Emma on the scoured flags of the
+kitchen--her high heels made her a little taller; and when she walked in
+front of him, the wooden soles springing up quickly struck with a sharp
+sound against the leather of her boots.
+
+She always accompanied him to the first step of the stairs. When his
+horse had not yet been brought round she stayed there. They had said
+“Good-bye”; there was no more talking. The open air wrapped her round,
+playing with the soft down on the back of her neck, or blew to and fro
+on her hips the apron-strings, that fluttered like streamers. Once,
+during a thaw the bark of the trees in the yard was oozing, the snow on
+the roofs of the outbuildings was melting; she stood on the threshold,
+and went to fetch her sunshade and opened it. The sunshade of silk of
+the colour of pigeons’ breasts, through which the sun shone, lighted
+up with shifting hues the white skin of her face. She smiled under the
+tender warmth, and drops of water could be heard falling one by one on
+the stretched silk.
+
+During the first period of Charles’s visits to the Bertaux, Madame
+Bovary junior never failed to inquire after the invalid, and she had
+even chosen in the book that she kept on a system of double entry a
+clean blank page for Monsieur Rouault. But when she heard he had a
+daughter, she began to make inquiries, and she learnt the Mademoiselle
+Rouault, brought up at the Ursuline Convent, had received what is called
+“a good education”; and so knew dancing, geography, drawing, how to
+embroider and play the piano. That was the last straw.
+
+“So it is for this,” she said to herself, “that his face beams when he
+goes to see her, and that he puts on his new waistcoat at the risk of
+spoiling it with the rain. Ah! that woman! That woman!”
+
+And she detested her instinctively. At first she solaced herself by
+allusions that Charles did not understand, then by casual observations
+that he let pass for fear of a storm, finally by open apostrophes to
+which he knew not what to answer. “Why did he go back to the Bertaux now
+that Monsieur Rouault was cured and that these folks hadn’t paid yet?
+Ah! it was because a young lady was there, some one who know how to
+talk, to embroider, to be witty. That was what he cared about; he wanted
+town misses.” And she went on--
+
+“The daughter of old Rouault a town miss! Get out! Their grandfather was
+a shepherd, and they have a cousin who was almost had up at the assizes
+for a nasty blow in a quarrel. It is not worth while making such a fuss,
+or showing herself at church on Sundays in a silk gown like a countess.
+Besides, the poor old chap, if it hadn’t been for the colza last year,
+would have had much ado to pay up his arrears.”
+
+For very weariness Charles left off going to the Bertaux. Heloise made
+him swear, his hand on the prayer-book, that he would go there no more
+after much sobbing and many kisses, in a great outburst of love. He
+obeyed then, but the strength of his desire protested against the
+servility of his conduct; and he thought, with a kind of naive
+hypocrisy, that his interdict to see her gave him a sort of right to
+love her. And then the widow was thin; she had long teeth; wore in all
+weathers a little black shawl, the edge of which hung down between her
+shoulder-blades; her bony figure was sheathed in her clothes as if they
+were a scabbard; they were too short, and displayed her ankles with the
+laces of her large boots crossed over grey stockings.
+
+Charles’s mother came to see them from time to time, but after a few
+days the daughter-in-law seemed to put her own edge on her, and
+then, like two knives, they scarified him with their reflections and
+observations. It was wrong of him to eat so much.
+
+Why did he always offer a glass of something to everyone who came?
+What obstinacy not to wear flannels! In the spring it came about that a
+notary at Ingouville, the holder of the widow Dubuc’s property, one fine
+day went off, taking with him all the money in his office. Heloise,
+it is true, still possessed, besides a share in a boat valued at six
+thousand francs, her house in the Rue St. Francois; and yet, with all
+this fortune that had been so trumpeted abroad, nothing, excepting
+perhaps a little furniture and a few clothes, had appeared in the
+household. The matter had to be gone into. The house at Dieppe was found
+to be eaten up with mortgages to its foundations; what she had placed
+with the notary God only knew, and her share in the boat did not exceed
+one thousand crowns. She had lied, the good lady! In his exasperation,
+Monsieur Bovary the elder, smashing a chair on the flags, accused his
+wife of having caused misfortune to the son by harnessing him to such
+a harridan, whose harness wasn’t worth her hide. They came to Tostes.
+Explanations followed. There were scenes. Heloise in tears, throwing her
+arms about her husband, implored him to defend her from his parents.
+
+Charles tried to speak up for her. They grew angry and left the house.
+
+But “the blow had struck home.” A week after, as she was hanging up some
+washing in her yard, she was seized with a spitting of blood, and
+the next day, while Charles had his back turned to her drawing the
+window-curtain, she said, “O God!” gave a sigh and fainted. She was
+dead! What a surprise! When all was over at the cemetery Charles went
+home. He found no one downstairs; he went up to the first floor to
+their room; saw her dress still hanging at the foot of the alcove; then,
+leaning against the writing-table, he stayed until the evening, buried
+in a sorrowful reverie. She had loved him after all!
+
+
+
+Chapter Three
+
+One morning old Rouault brought Charles the money for setting his
+leg--seventy-five francs in forty-sou pieces, and a turkey. He had heard
+of his loss, and consoled him as well as he could.
+
+“I know what it is,” said he, clapping him on the shoulder; “I’ve been
+through it. When I lost my dear departed, I went into the fields to be
+quite alone. I fell at the foot of a tree; I cried; I called on God; I
+talked nonsense to Him. I wanted to be like the moles that I saw on the
+branches, their insides swarming with worms, dead, and an end of it.
+And when I thought that there were others at that very moment with their
+nice little wives holding them in their embrace, I struck great blows on
+the earth with my stick. I was pretty well mad with not eating; the very
+idea of going to a cafe disgusted me--you wouldn’t believe it. Well,
+quite softly, one day following another, a spring on a winter, and an
+autumn after a summer, this wore away, piece by piece, crumb by crumb;
+it passed away, it is gone, I should say it has sunk; for something
+always remains at the bottom as one would say--a weight here, at one’s
+heart. But since it is the lot of all of us, one must not give way
+altogether, and, because others have died, want to die too. You must
+pull yourself together, Monsieur Bovary. It will pass away. Come to see
+us; my daughter thinks of you now and again, d’ye know, and she says
+you are forgetting her. Spring will soon be here. We’ll have some
+rabbit-shooting in the warrens to amuse you a bit.”
+
+Charles followed his advice. He went back to the Bertaux. He found all
+as he had left it, that is to say, as it was five months ago. The pear
+trees were already in blossom, and Farmer Rouault, on his legs again,
+came and went, making the farm more full of life.
+
+Thinking it his duty to heap the greatest attention upon the doctor
+because of his sad position, he begged him not to take his hat off,
+spoke to him in an undertone as if he had been ill, and even pretended
+to be angry because nothing rather lighter had been prepared for him
+than for the others, such as a little clotted cream or stewed pears. He
+told stories. Charles found himself laughing, but the remembrance of his
+wife suddenly coming back to him depressed him. Coffee was brought in;
+he thought no more about her.
+
+He thought less of her as he grew accustomed to living alone. The new
+delight of independence soon made his loneliness bearable. He could now
+change his meal-times, go in or out without explanation, and when he was
+very tired stretch himself at full length on his bed. So he nursed and
+coddled himself and accepted the consolations that were offered him.
+On the other hand, the death of his wife had not served him ill in his
+business, since for a month people had been saying, “The poor young
+man! what a loss!” His name had been talked about, his practice had
+increased; and moreover, he could go to the Bertaux just as he liked.
+He had an aimless hope, and was vaguely happy; he thought himself better
+looking as he brushed his whiskers before the looking-glass.
+
+One day he got there about three o’clock. Everybody was in the fields.
+He went into the kitchen, but did not at once catch sight of Emma; the
+outside shutters were closed. Through the chinks of the wood the sun
+sent across the flooring long fine rays that were broken at the corners
+of the furniture and trembled along the ceiling. Some flies on the table
+were crawling up the glasses that had been used, and buzzing as they
+drowned themselves in the dregs of the cider. The daylight that came in
+by the chimney made velvet of the soot at the back of the fireplace, and
+touched with blue the cold cinders. Between the window and the hearth
+Emma was sewing; she wore no fichu; he could see small drops of
+perspiration on her bare shoulders.
+
+After the fashion of country folks she asked him to have something to
+drink. He said no; she insisted, and at last laughingly offered to have
+a glass of liqueur with him. So she went to fetch a bottle of curacao
+from the cupboard, reached down two small glasses, filled one to the
+brim, poured scarcely anything into the other, and, after having clinked
+glasses, carried hers to her mouth. As it was almost empty she bent
+back to drink, her head thrown back, her lips pouting, her neck on the
+strain. She laughed at getting none of it, while with the tip of her
+tongue passing between her small teeth she licked drop by drop the
+bottom of her glass.
+
+She sat down again and took up her work, a white cotton stocking she was
+darning. She worked with her head bent down; she did not speak, nor did
+Charles. The air coming in under the door blew a little dust over the
+flags; he watched it drift along, and heard nothing but the throbbing
+in his head and the faint clucking of a hen that had laid an egg in the
+yard. Emma from time to time cooled her cheeks with the palms of her
+hands, and cooled these again on the knobs of the huge fire-dogs.
+
+She complained of suffering since the beginning of the season from
+giddiness; she asked if sea-baths would do her any good; she began
+talking of her convent, Charles of his school; words came to them. They
+went up into her bedroom. She showed him her old music-books, the little
+prizes she had won, and the oak-leaf crowns, left at the bottom of a
+cupboard. She spoke to him, too, of her mother, of the country, and even
+showed him the bed in the garden where, on the first Friday of every
+month, she gathered flowers to put on her mother’s tomb. But the
+gardener they had never knew anything about it; servants are so stupid!
+She would have dearly liked, if only for the winter, to live in town,
+although the length of the fine days made the country perhaps even more
+wearisome in the summer. And, according to what she was saying, her
+voice was clear, sharp, or, on a sudden all languor, drawn out in
+modulations that ended almost in murmurs as she spoke to herself, now
+joyous, opening big naive eyes, then with her eyelids half closed, her
+look full of boredom, her thoughts wandering.
+
+Going home at night, Charles went over her words one by one, trying to
+recall them, to fill out their sense, that he might piece out the life
+she had lived before he knew her. But he never saw her in his thoughts
+other than he had seen her the first time, or as he had just left her.
+Then he asked himself what would become of her--if she would be married,
+and to whom! Alas! Old Rouault was rich, and she!--so beautiful! But
+Emma’s face always rose before his eyes, and a monotone, like the
+humming of a top, sounded in his ears, “If you should marry after
+all! If you should marry!” At night he could not sleep; his throat was
+parched; he was athirst. He got up to drink from the water-bottle and
+opened the window. The night was covered with stars, a warm wind blowing
+in the distance; the dogs were barking. He turned his head towards the
+Bertaux.
+
+Thinking that, after all, he should lose nothing, Charles promised
+himself to ask her in marriage as soon as occasion offered, but each
+time such occasion did offer the fear of not finding the right words
+sealed his lips.
+
+Old Rouault would not have been sorry to be rid of his daughter, who was
+of no use to him in the house. In his heart he excused her, thinking
+her too clever for farming, a calling under the ban of Heaven, since one
+never saw a millionaire in it. Far from having made a fortune by it,
+the good man was losing every year; for if he was good in bargaining, in
+which he enjoyed the dodges of the trade, on the other hand, agriculture
+properly so called, and the internal management of the farm, suited him
+less than most people. He did not willingly take his hands out of his
+pockets, and did not spare expense in all that concerned himself, liking
+to eat well, to have good fires, and to sleep well. He liked old cider,
+underdone legs of mutton, glorias* well beaten up. He took his meals in
+the kitchen alone, opposite the fire, on a little table brought to him
+all ready laid as on the stage.
+
+     *A mixture of coffee and spirits.
+
+When, therefore, he perceived that Charles’s cheeks grew red if near his
+daughter, which meant that he would propose for her one of these days,
+he chewed the cud of the matter beforehand. He certainly thought him a
+little meagre, and not quite the son-in-law he would have liked, but he
+was said to be well brought-up, economical, very learned, and no doubt
+would not make too many difficulties about the dowry. Now, as old
+Rouault would soon be forced to sell twenty-two acres of “his property,”
+ as he owed a good deal to the mason, to the harness-maker, and as the
+shaft of the cider-press wanted renewing, “If he asks for her,” he said
+to himself, “I’ll give her to him.”
+
+At Michaelmas Charles went to spend three days at the Bertaux.
+
+The last had passed like the others in procrastinating from hour to
+hour. Old Rouault was seeing him off; they were walking along the road
+full of ruts; they were about to part. This was the time. Charles gave
+himself as far as to the corner of the hedge, and at last, when past
+it--
+
+“Monsieur Rouault,” he murmured, “I should like to say something to
+you.”
+
+They stopped. Charles was silent.
+
+“Well, tell me your story. Don’t I know all about it?” said old Rouault,
+laughing softly.
+
+“Monsieur Rouault--Monsieur Rouault,” stammered Charles.
+
+“I ask nothing better”, the farmer went on. “Although, no doubt, the
+little one is of my mind, still we must ask her opinion. So you get
+off--I’ll go back home. If it is ‘yes’, you needn’t return because of
+all the people about, and besides it would upset her too much. But so
+that you mayn’t be eating your heart, I’ll open wide the outer shutter
+of the window against the wall; you can see it from the back by leaning
+over the hedge.”
+
+And he went off.
+
+Charles fastened his horse to a tree; he ran into the road and waited.
+Half an hour passed, then he counted nineteen minutes by his watch.
+Suddenly a noise was heard against the wall; the shutter had been thrown
+back; the hook was still swinging.
+
+The next day by nine o’clock he was at the farm. Emma blushed as
+he entered, and she gave a little forced laugh to keep herself in
+countenance. Old Rouault embraced his future son-in-law. The discussion
+of money matters was put off; moreover, there was plenty of time before
+them, as the marriage could not decently take place till Charles was out
+of mourning, that is to say, about the spring of the next year.
+
+The winter passed waiting for this. Mademoiselle Rouault was busy with
+her trousseau. Part of it was ordered at Rouen, and she made herself
+chemises and nightcaps after fashion-plates that she borrowed. When
+Charles visited the farmer, the preparations for the wedding were talked
+over; they wondered in what room they should have dinner; they dreamed
+of the number of dishes that would be wanted, and what should be
+entrees.
+
+Emma would, on the contrary, have preferred to have a midnight wedding
+with torches, but old Rouault could not understand such an idea. So
+there was a wedding at which forty-three persons were present, at which
+they remained sixteen hours at table, began again the next day, and to
+some extent on the days following.
+
+
+
+Chapter Four
+
+The guests arrived early in carriages, in one-horse chaises, two-wheeled
+cars, old open gigs, waggonettes with leather hoods, and the young
+people from the nearer villages in carts, in which they stood up in
+rows, holding on to the sides so as not to fall, going at a trot
+and well shaken up. Some came from a distance of thirty miles, from
+Goderville, from Normanville, and from Cany.
+
+All the relatives of both families had been invited, quarrels between
+friends arranged, acquaintances long since lost sight of written to.
+
+From time to time one heard the crack of a whip behind the hedge; then
+the gates opened, a chaise entered. Galloping up to the foot of the
+steps, it stopped short and emptied its load. They got down from all
+sides, rubbing knees and stretching arms. The ladies, wearing bonnets,
+had on dresses in the town fashion, gold watch chains, pelerines with
+the ends tucked into belts, or little coloured fichus fastened down
+behind with a pin, and that left the back of the neck bare. The lads,
+dressed like their papas, seemed uncomfortable in their new clothes
+(many that day hand-sewed their first pair of boots), and by their
+sides, speaking never a work, wearing the white dress of their first
+communion lengthened for the occasion were some big girls of fourteen or
+sixteen, cousins or elder sisters no doubt, rubicund, bewildered, their
+hair greasy with rose pomade, and very much afraid of dirtying their
+gloves. As there were not enough stable-boys to unharness all the
+carriages, the gentlemen turned up their sleeves and set about it
+themselves. According to their different social positions they wore
+tail-coats, overcoats, shooting jackets, cutaway-coats; fine tail-coats,
+redolent of family respectability, that only came out of the wardrobe
+on state occasions; overcoats with long tails flapping in the wind and
+round capes and pockets like sacks; shooting jackets of coarse
+cloth, generally worn with a cap with a brass-bound peak; very short
+cutaway-coats with two small buttons in the back, close together like
+a pair of eyes, and the tails of which seemed cut out of one piece by a
+carpenter’s hatchet. Some, too (but these, you may be sure, would sit at
+the bottom of the table), wore their best blouses--that is to say,
+with collars turned down to the shoulders, the back gathered into small
+plaits and the waist fastened very low down with a worked belt.
+
+And the shirts stood out from the chests like cuirasses! Everyone had
+just had his hair cut; ears stood out from the heads; they had been
+close-shaved; a few, even, who had had to get up before daybreak, and
+not been able to see to shave, had diagonal gashes under their noses or
+cuts the size of a three-franc piece along the jaws, which the fresh
+air en route had enflamed, so that the great white beaming faces were
+mottled here and there with red dabs.
+
+The mairie was a mile and a half from the farm, and they went thither
+on foot, returning in the same way after the ceremony in the church.
+The procession, first united like one long coloured scarf that undulated
+across the fields, along the narrow path winding amid the green corn,
+soon lengthened out, and broke up into different groups that loitered to
+talk. The fiddler walked in front with his violin, gay with ribbons at
+its pegs. Then came the married pair, the relations, the friends, all
+following pell-mell; the children stayed behind amusing themselves
+plucking the bell-flowers from oat-ears, or playing amongst themselves
+unseen. Emma’s dress, too long, trailed a little on the ground; from
+time to time she stopped to pull it up, and then delicately, with her
+gloved hands, she picked off the coarse grass and the thistledowns,
+while Charles, empty handed, waited till she had finished. Old Rouault,
+with a new silk hat and the cuffs of his black coat covering his hands
+up to the nails, gave his arm to Madame Bovary senior. As to Monsieur
+Bovary senior, who, heartily despising all these folk, had come simply
+in a frock-coat of military cut with one row of buttons--he was passing
+compliments of the bar to a fair young peasant. She bowed, blushed,
+and did not know what to say. The other wedding guests talked of their
+business or played tricks behind each other’s backs, egging one another
+on in advance to be jolly. Those who listened could always catch the
+squeaking of the fiddler, who went on playing across the fields. When
+he saw that the rest were far behind he stopped to take breath, slowly
+rosined his bow, so that the strings should sound more shrilly, then set
+off again, by turns lowering and raising his neck, the better to mark
+time for himself. The noise of the instrument drove away the little
+birds from afar.
+
+The table was laid under the cart-shed. On it were four sirloins, six
+chicken fricassees, stewed veal, three legs of mutton, and in the middle
+a fine roast suckling pig, flanked by four chitterlings with sorrel. At
+the corners were decanters of brandy. Sweet bottled-cider frothed round
+the corks, and all the glasses had been filled to the brim with wine
+beforehand. Large dishes of yellow cream, that trembled with the least
+shake of the table, had designed on their smooth surface the initials of
+the newly wedded pair in nonpareil arabesques. A confectioner of Yvetot
+had been intrusted with the tarts and sweets. As he had only just set up
+on the place, he had taken a lot of trouble, and at dessert he himself
+brought in a set dish that evoked loud cries of wonderment. To begin
+with, at its base there was a square of blue cardboard, representing a
+temple with porticoes, colonnades, and stucco statuettes all round, and
+in the niches constellations of gilt paper stars; then on the second
+stage was a dungeon of Savoy cake, surrounded by many fortifications
+in candied angelica, almonds, raisins, and quarters of oranges; and
+finally, on the upper platform a green field with rocks set in lakes of
+jam, nutshell boats, and a small Cupid balancing himself in a chocolate
+swing whose two uprights ended in real roses for balls at the top.
+
+Until night they ate. When any of them were too tired of sitting, they
+went out for a stroll in the yard, or for a game with corks in the
+granary, and then returned to table. Some towards the finish went to
+sleep and snored. But with the coffee everyone woke up. Then they began
+songs, showed off tricks, raised heavy weights, performed feats with
+their fingers, then tried lifting carts on their shoulders, made broad
+jokes, kissed the women. At night when they left, the horses, stuffed
+up to the nostrils with oats, could hardly be got into the shafts; they
+kicked, reared, the harness broke, their masters laughed or swore;
+and all night in the light of the moon along country roads there were
+runaway carts at full gallop plunging into the ditches, jumping over
+yard after yard of stones, clambering up the hills, with women leaning
+out from the tilt to catch hold of the reins.
+
+Those who stayed at the Bertaux spent the night drinking in the kitchen.
+The children had fallen asleep under the seats.
+
+The bride had begged her father to be spared the usual marriage
+pleasantries. However, a fishmonger, one of their cousins (who had even
+brought a pair of soles for his wedding present), began to squirt water
+from his mouth through the keyhole, when old Rouault came up just in
+time to stop him, and explain to him that the distinguished position
+of his son-in-law would not allow of such liberties. The cousin all the
+same did not give in to these reasons readily. In his heart he accused
+old Rouault of being proud, and he joined four or five other guests in
+a corner, who having, through mere chance, been several times running
+served with the worst helps of meat, also were of opinion they had been
+badly used, and were whispering about their host, and with covered hints
+hoping he would ruin himself.
+
+Madame Bovary, senior, had not opened her mouth all day. She had been
+consulted neither as to the dress of her daughter-in-law nor as to the
+arrangement of the feast; she went to bed early. Her husband, instead
+of following her, sent to Saint-Victor for some cigars, and smoked till
+daybreak, drinking kirsch-punch, a mixture unknown to the company. This
+added greatly to the consideration in which he was held.
+
+Charles, who was not of a facetious turn, did not shine at the wedding.
+He answered feebly to the puns, doubles entendres*, compliments, and
+chaff that it was felt a duty to let off at him as soon as the soup
+appeared.
+
+     *Double meanings.
+
+The next day, on the other hand, he seemed another man. It was he who
+might rather have been taken for the virgin of the evening before,
+whilst the bride gave no sign that revealed anything. The shrewdest did
+not know what to make of it, and they looked at her when she passed
+near them with an unbounded concentration of mind. But Charles concealed
+nothing. He called her “my wife”, tutoyed* her, asked for her of
+everyone, looked for her everywhere, and often he dragged her into the
+yards, where he could be seen from far between the trees, putting his
+arm around her waist, and walking half-bending over her, ruffling the
+chemisette of her bodice with his head.
+
+     *Used the familiar form of address.
+
+Two days after the wedding the married pair left. Charles, on account of
+his patients, could not be away longer. Old Rouault had them driven back
+in his cart, and himself accompanied them as far as Vassonville. Here
+he embraced his daughter for the last time, got down, and went his way.
+When he had gone about a hundred paces he stopped, and as he saw the
+cart disappearing, its wheels turning in the dust, he gave a deep sigh.
+Then he remembered his wedding, the old times, the first pregnancy of
+his wife; he, too, had been very happy the day when he had taken her
+from her father to his home, and had carried her off on a pillion,
+trotting through the snow, for it was near Christmas-time, and the
+country was all white. She held him by one arm, her basket hanging from
+the other; the wind blew the long lace of her Cauchois headdress so that
+it sometimes flapped across his mouth, and when he turned his head he
+saw near him, on his shoulder, her little rosy face, smiling silently
+under the gold bands of her cap. To warm her hands she put them from
+time to time in his breast. How long ago it all was! Their son would
+have been thirty by now. Then he looked back and saw nothing on the
+road. He felt dreary as an empty house; and tender memories mingling
+with the sad thoughts in his brain, addled by the fumes of the feast, he
+felt inclined for a moment to take a turn towards the church. As he was
+afraid, however, that this sight would make him yet more sad, he went
+right away home.
+
+Monsieur and Madame Charles arrived at Tostes about six o’clock.
+
+The neighbors came to the windows to see their doctor’s new wife.
+
+The old servant presented herself, curtsied to her, apologised for not
+having dinner ready, and suggested that madame, in the meantime, should
+look over her house.
+
+
+
+Chapter Five
+
+The brick front was just in a line with the street, or rather the road.
+Behind the door hung a cloak with a small collar, a bridle, and a black
+leather cap, and on the floor, in a corner, were a pair of leggings,
+still covered with dry mud. On the right was the one apartment, that was
+both dining and sitting room. A canary yellow paper, relieved at the
+top by a garland of pale flowers, was puckered everywhere over the badly
+stretched canvas; white calico curtains with a red border hung crossways
+at the length of the window; and on the narrow mantelpiece a clock with
+a head of Hippocrates shone resplendent between two plate candlesticks
+under oval shades. On the other side of the passage was Charles’s
+consulting room, a little room about six paces wide, with a table,
+three chairs, and an office chair. Volumes of the “Dictionary of Medical
+Science,” uncut, but the binding rather the worse for the successive
+sales through which they had gone, occupied almost along the six shelves
+of a deal bookcase.
+
+The smell of melted butter penetrated through the walls when he saw
+patients, just as in the kitchen one could hear the people coughing in
+the consulting room and recounting their histories.
+
+Then, opening on the yard, where the stable was, came a large
+dilapidated room with a stove, now used as a wood-house, cellar, and
+pantry, full of old rubbish, of empty casks, agricultural implements
+past service, and a mass of dusty things whose use it was impossible to
+guess.
+
+The garden, longer than wide, ran between two mud walls with espaliered
+apricots, to a hawthorn hedge that separated it from the field. In the
+middle was a slate sundial on a brick pedestal; four flower beds with
+eglantines surrounded symmetrically the more useful kitchen garden bed.
+Right at the bottom, under the spruce bushes, was a cure in plaster
+reading his breviary.
+
+Emma went upstairs. The first room was not furnished, but in the second,
+which was their bedroom, was a mahogany bedstead in an alcove with red
+drapery. A shell box adorned the chest of drawers, and on the secretary
+near the window a bouquet of orange blossoms tied with white satin
+ribbons stood in a bottle. It was a bride’s bouquet; it was the other
+one’s. She looked at it. Charles noticed it; he took it and carried it
+up to the attic, while Emma seated in an arm-chair (they were putting
+her things down around her) thought of her bridal flowers packed up in
+a bandbox, and wondered, dreaming, what would be done with them if she
+were to die.
+
+During the first days she occupied herself in thinking about changes in
+the house. She took the shades off the candlesticks, had new wallpaper
+put up, the staircase repainted, and seats made in the garden round the
+sundial; she even inquired how she could get a basin with a jet fountain
+and fishes. Finally her husband, knowing that she liked to drive out,
+picked up a second-hand dogcart, which, with new lamps and splashboard
+in striped leather, looked almost like a tilbury.
+
+He was happy then, and without a care in the world. A meal together,
+a walk in the evening on the highroad, a gesture of her hands over her
+hair, the sight of her straw hat hanging from the window-fastener, and
+many another thing in which Charles had never dreamed of pleasure, now
+made up the endless round of his happiness. In bed, in the morning, by
+her side, on the pillow, he watched the sunlight sinking into the down
+on her fair cheek, half hidden by the lappets of her night-cap. Seen
+thus closely, her eyes looked to him enlarged, especially when, on
+waking up, she opened and shut them rapidly many times. Black in the
+shade, dark blue in broad daylight, they had, as it were, depths of
+different colours, that, darker in the centre, grew paler towards the
+surface of the eye. His own eyes lost themselves in these depths; he saw
+himself in miniature down to the shoulders, with his handkerchief round
+his head and the top of his shirt open. He rose. She came to the window
+to see him off, and stayed leaning on the sill between two pots of
+geranium, clad in her dressing gown hanging loosely about her. Charles,
+in the street buckled his spurs, his foot on the mounting stone, while
+she talked to him from above, picking with her mouth some scrap of
+flower or leaf that she blew out at him. Then this, eddying, floating,
+described semicircles in the air like a bird, and was caught before
+it reached the ground in the ill-groomed mane of the old white mare
+standing motionless at the door. Charles from horseback threw her a
+kiss; she answered with a nod; she shut the window, and he set off. And
+then along the highroad, spreading out its long ribbon of dust, along
+the deep lanes that the trees bent over as in arbours, along paths where
+the corn reached to the knees, with the sun on his back and the morning
+air in his nostrils, his heart full of the joys of the past night, his
+mind at rest, his flesh at ease, he went on, re-chewing his happiness,
+like those who after dinner taste again the truffles which they are
+digesting.
+
+Until now what good had he had of his life? His time at school, when
+he remained shut up within the high walls, alone, in the midst of
+companions richer than he or cleverer at their work, who laughed at his
+accent, who jeered at his clothes, and whose mothers came to the school
+with cakes in their muffs? Later on, when he studied medicine, and never
+had his purse full enough to treat some little work-girl who would have
+become his mistress? Afterwards, he had lived fourteen months with the
+widow, whose feet in bed were cold as icicles. But now he had for life
+this beautiful woman whom he adored. For him the universe did not extend
+beyond the circumference of her petticoat, and he reproached himself
+with not loving her. He wanted to see her again; he turned back quickly,
+ran up the stairs with a beating heart. Emma, in her room, was dressing;
+he came up on tiptoe, kissed her back; she gave a cry.
+
+He could not keep from constantly touching her comb, her ring, her
+fichu; sometimes he gave her great sounding kisses with all his mouth on
+her cheeks, or else little kisses in a row all along her bare arm
+from the tip of her fingers up to her shoulder, and she put him away
+half-smiling, half-vexed, as you do a child who hangs about you.
+
+Before marriage she thought herself in love; but the happiness that
+should have followed this love not having come, she must, she thought,
+have been mistaken. And Emma tried to find out what one meant exactly in
+life by the words felicity, passion, rapture, that had seemed to her so
+beautiful in books.
+
+
+
+Chapter Six
+
+She had read “Paul and Virginia,” and she had dreamed of the little
+bamboo-house, the nigger Domingo, the dog Fidele, but above all of the
+sweet friendship of some dear little brother, who seeks red fruit for
+you on trees taller than steeples, or who runs barefoot over the sand,
+bringing you a bird’s nest.
+
+When she was thirteen, her father himself took her to town to place
+her in the convent. They stopped at an inn in the St. Gervais quarter,
+where, at their supper, they used painted plates that set forth the
+story of Mademoiselle de la Valliere. The explanatory legends, chipped
+here and there by the scratching of knives, all glorified religion, the
+tendernesses of the heart, and the pomps of court.
+
+Far from being bored at first at the convent, she took pleasure in the
+society of the good sisters, who, to amuse her, took her to the chapel,
+which one entered from the refectory by a long corridor. She played very
+little during recreation hours, knew her catechism well, and it was she
+who always answered Monsieur le Vicaire’s difficult questions. Living
+thus, without ever leaving the warm atmosphere of the classrooms, and
+amid these pale-faced women wearing rosaries with brass crosses, she
+was softly lulled by the mystic languor exhaled in the perfumes of the
+altar, the freshness of the holy water, and the lights of the tapers.
+Instead of attending to mass, she looked at the pious vignettes with
+their azure borders in her book, and she loved the sick lamb, the sacred
+heart pierced with sharp arrows, or the poor Jesus sinking beneath the
+cross he carries. She tried, by way of mortification, to eat nothing a
+whole day. She puzzled her head to find some vow to fulfil.
+
+When she went to confession, she invented little sins in order that she
+might stay there longer, kneeling in the shadow, her hands joined,
+her face against the grating beneath the whispering of the priest.
+The comparisons of betrothed, husband, celestial lover, and eternal
+marriage, that recur in sermons, stirred within her soul depths of
+unexpected sweetness.
+
+In the evening, before prayers, there was some religious reading in
+the study. On week-nights it was some abstract of sacred history or
+the Lectures of the Abbe Frayssinous, and on Sundays passages from the
+“Genie du Christianisme,” as a recreation. How she listened at first to
+the sonorous lamentations of its romantic melancholies reechoing
+through the world and eternity! If her childhood had been spent in the
+shop-parlour of some business quarter, she might perhaps have opened
+her heart to those lyrical invasions of Nature, which usually come to
+us only through translation in books. But she knew the country too well;
+she knew the lowing of cattle, the milking, the ploughs.
+
+Accustomed to calm aspects of life, she turned, on the contrary, to
+those of excitement. She loved the sea only for the sake of its storms,
+and the green fields only when broken up by ruins.
+
+She wanted to get some personal profit out of things, and she rejected
+as useless all that did not contribute to the immediate desires of her
+heart, being of a temperament more sentimental than artistic, looking
+for emotions, not landscapes.
+
+At the convent there was an old maid who came for a week each month to
+mend the linen. Patronized by the clergy, because she belonged to an
+ancient family of noblemen ruined by the Revolution, she dined in the
+refectory at the table of the good sisters, and after the meal had a bit
+of chat with them before going back to her work. The girls often slipped
+out from the study to go and see her. She knew by heart the love songs
+of the last century, and sang them in a low voice as she stitched away.
+
+She told stories, gave them news, went errands in the town, and on
+the sly lent the big girls some novel, that she always carried in the
+pockets of her apron, and of which the good lady herself swallowed
+long chapters in the intervals of her work. They were all love, lovers,
+sweethearts, persecuted ladies fainting in lonely pavilions, postilions
+killed at every stage, horses ridden to death on every page, sombre
+forests, heartaches, vows, sobs, tears and kisses, little skiffs by
+moonlight, nightingales in shady groves, “gentlemen” brave as lions,
+gentle as lambs, virtuous as no one ever was, always well dressed, and
+weeping like fountains. For six months, then, Emma, at fifteen years of
+age, made her hands dirty with books from old lending libraries.
+
+Through Walter Scott, later on, she fell in love with historical events,
+dreamed of old chests, guard-rooms and minstrels. She would have liked
+to live in some old manor-house, like those long-waisted chatelaines
+who, in the shade of pointed arches, spent their days leaning on the
+stone, chin in hand, watching a cavalier with white plume galloping on
+his black horse from the distant fields. At this time she had a cult
+for Mary Stuart and enthusiastic veneration for illustrious or unhappy
+women. Joan of Arc, Heloise, Agnes Sorel, the beautiful Ferroniere, and
+Clemence Isaure stood out to her like comets in the dark immensity of
+heaven, where also were seen, lost in shadow, and all unconnected, St.
+Louis with his oak, the dying Bayard, some cruelties of Louis XI, a
+little of St. Bartholomew’s Day, the plume of the Bearnais, and always
+the remembrance of the plates painted in honour of Louis XIV.
+
+In the music class, in the ballads she sang, there was nothing but
+little angels with golden wings, madonnas, lagunes, gondoliers;-mild
+compositions that allowed her to catch a glimpse athwart the obscurity
+of style and the weakness of the music of the attractive phantasmagoria
+of sentimental realities. Some of her companions brought “keepsakes”
+ given them as new year’s gifts to the convent. These had to be hidden;
+it was quite an undertaking; they were read in the dormitory. Delicately
+handling the beautiful satin bindings, Emma looked with dazzled eyes at
+the names of the unknown authors, who had signed their verses for the
+most part as counts or viscounts.
+
+She trembled as she blew back the tissue paper over the engraving and
+saw it folded in two and fall gently against the page. Here behind the
+balustrade of a balcony was a young man in a short cloak, holding in his
+arms a young girl in a white dress wearing an alms-bag at her belt; or
+there were nameless portraits of English ladies with fair curls, who
+looked at you from under their round straw hats with their large clear
+eyes. Some there were lounging in their carriages, gliding through
+parks, a greyhound bounding along in front of the equipage driven at
+a trot by two midget postilions in white breeches. Others, dreaming on
+sofas with an open letter, gazed at the moon through a slightly open
+window half draped by a black curtain. The naive ones, a tear on their
+cheeks, were kissing doves through the bars of a Gothic cage, or,
+smiling, their heads on one side, were plucking the leaves of a
+marguerite with their taper fingers, that curved at the tips like peaked
+shoes. And you, too, were there, Sultans with long pipes reclining
+beneath arbours in the arms of Bayaderes; Djiaours, Turkish sabres,
+Greek caps; and you especially, pale landscapes of dithyrambic lands,
+that often show us at once palm trees and firs, tigers on the right, a
+lion to the left, Tartar minarets on the horizon; the whole framed by
+a very neat virgin forest, and with a great perpendicular sunbeam
+trembling in the water, where, standing out in relief like white
+excoriations on a steel-grey ground, swans are swimming about.
+
+And the shade of the argand lamp fastened to the wall above Emma’s head
+lighted up all these pictures of the world, that passed before her one
+by one in the silence of the dormitory, and to the distant noise of some
+belated carriage rolling over the Boulevards.
+
+When her mother died she cried much the first few days. She had a
+funeral picture made with the hair of the deceased, and, in a letter
+sent to the Bertaux full of sad reflections on life, she asked to be
+buried later on in the same grave. The goodman thought she must be ill,
+and came to see her. Emma was secretly pleased that she had reached at
+a first attempt the rare ideal of pale lives, never attained by mediocre
+hearts. She let herself glide along with Lamartine meanderings, listened
+to harps on lakes, to all the songs of dying swans, to the falling of
+the leaves, the pure virgins ascending to heaven, and the voice of
+the Eternal discoursing down the valleys. She wearied of it, would not
+confess it, continued from habit, and at last was surprised to feel
+herself soothed, and with no more sadness at heart than wrinkles on her
+brow.
+
+The good nuns, who had been so sure of her vocation, perceived with
+great astonishment that Mademoiselle Rouault seemed to be slipping
+from them. They had indeed been so lavish to her of prayers, retreats,
+novenas, and sermons, they had so often preached the respect due to
+saints and martyrs, and given so much good advice as to the modesty of
+the body and the salvation of her soul, that she did as tightly reined
+horses; she pulled up short and the bit slipped from her teeth. This
+nature, positive in the midst of its enthusiasms, that had loved the
+church for the sake of the flowers, and music for the words of the
+songs, and literature for its passional stimulus, rebelled against
+the mysteries of faith as it grew irritated by discipline, a thing
+antipathetic to her constitution. When her father took her from school,
+no one was sorry to see her go. The Lady Superior even thought that she
+had latterly been somewhat irreverent to the community.
+
+Emma, at home once more, first took pleasure in looking after the
+servants, then grew disgusted with the country and missed her convent.
+When Charles came to the Bertaux for the first time, she thought herself
+quite disillusioned, with nothing more to learn, and nothing more to
+feel.
+
+But the uneasiness of her new position, or perhaps the disturbance
+caused by the presence of this man, had sufficed to make her believe
+that she at last felt that wondrous passion which, till then, like a
+great bird with rose-coloured wings, hung in the splendour of the skies
+of poesy; and now she could not think that the calm in which she lived
+was the happiness she had dreamed.
+
+
+
+Chapter Seven
+
+She thought, sometimes, that, after all, this was the happiest time
+of her life--the honeymoon, as people called it. To taste the full
+sweetness of it, it would have been necessary doubtless to fly to those
+lands with sonorous names where the days after marriage are full of
+laziness most suave. In post chaises behind blue silken curtains to ride
+slowly up steep road, listening to the song of the postilion re-echoed
+by the mountains, along with the bells of goats and the muffled sound of
+a waterfall; at sunset on the shores of gulfs to breathe in the perfume
+of lemon trees; then in the evening on the villa-terraces above, hand in
+hand to look at the stars, making plans for the future. It seemed to her
+that certain places on earth must bring happiness, as a plant peculiar
+to the soil, and that cannot thrive elsewhere. Why could not she lean
+over balconies in Swiss chalets, or enshrine her melancholy in a Scotch
+cottage, with a husband dressed in a black velvet coat with long tails,
+and thin shoes, a pointed hat and frills? Perhaps she would have liked
+to confide all these things to someone. But how tell an undefinable
+uneasiness, variable as the clouds, unstable as the winds? Words failed
+her--the opportunity, the courage.
+
+If Charles had but wished it, if he had guessed it, if his look had but
+once met her thought, it seemed to her that a sudden plenty would have
+gone out from her heart, as the fruit falls from a tree when shaken by
+a hand. But as the intimacy of their life became deeper, the greater
+became the gulf that separated her from him.
+
+Charles’s conversation was commonplace as a street pavement, and
+everyone’s ideas trooped through it in their everyday garb, without
+exciting emotion, laughter, or thought. He had never had the curiosity,
+he said, while he lived at Rouen, to go to the theatre to see the actors
+from Paris. He could neither swim, nor fence, nor shoot, and one day
+he could not explain some term of horsemanship to her that she had come
+across in a novel.
+
+A man, on the contrary, should he not know everything, excel in manifold
+activities, initiate you into the energies of passion, the refinements
+of life, all mysteries? But this one taught nothing, knew nothing,
+wished nothing. He thought her happy; and she resented this easy calm,
+this serene heaviness, the very happiness she gave him.
+
+Sometimes she would draw; and it was great amusement to Charles to stand
+there bolt upright and watch her bend over her cardboard, with eyes
+half-closed the better to see her work, or rolling, between her fingers,
+little bread-pellets. As to the piano, the more quickly her fingers
+glided over it the more he wondered. She struck the notes with aplomb,
+and ran from top to bottom of the keyboard without a break. Thus shaken
+up, the old instrument, whose strings buzzed, could be heard at the
+other end of the village when the window was open, and often the
+bailiff’s clerk, passing along the highroad bare-headed and in list
+slippers, stopped to listen, his sheet of paper in his hand.
+
+Emma, on the other hand, knew how to look after her house. She sent the
+patients’ accounts in well-phrased letters that had no suggestion of
+a bill. When they had a neighbour to dinner on Sundays, she managed to
+have some tasty dish--piled up pyramids of greengages on vine leaves,
+served up preserves turned out into plates--and even spoke of buying
+finger-glasses for dessert. From all this much consideration was
+extended to Bovary.
+
+Charles finished by rising in his own esteem for possessing such a wife.
+He showed with pride in the sitting room two small pencil sketches by
+her that he had had framed in very large frames, and hung up against the
+wallpaper by long green cords. People returning from mass saw him at his
+door in his wool-work slippers.
+
+He came home late--at ten o’clock, at midnight sometimes. Then he asked
+for something to eat, and as the servant had gone to bed, Emma waited
+on him. He took off his coat to dine more at his ease. He told her, one
+after the other, the people he had met, the villages where he had been,
+the prescriptions he had written, and, well pleased with himself, he
+finished the remainder of the boiled beef and onions, picked pieces off
+the cheese, munched an apple, emptied his water-bottle, and then went to
+bed, and lay on his back and snored.
+
+As he had been for a time accustomed to wear nightcaps, his handkerchief
+would not keep down over his ears, so that his hair in the morning was
+all tumbled pell-mell about his face and whitened with the feathers of
+the pillow, whose strings came untied during the night. He always wore
+thick boots that had two long creases over the instep running obliquely
+towards the ankle, while the rest of the upper continued in a straight
+line as if stretched on a wooden foot. He said that “was quite good
+enough for the country.”
+
+His mother approved of his economy, for she came to see him as formerly
+when there had been some violent row at her place; and yet Madame Bovary
+senior seemed prejudiced against her daughter-in-law. She thought “her
+ways too fine for their position”; the wood, the sugar, and the candles
+disappeared as “at a grand establishment,” and the amount of firing in
+the kitchen would have been enough for twenty-five courses. She put her
+linen in order for her in the presses, and taught her to keep an eye on
+the butcher when he brought the meat. Emma put up with these lessons.
+Madame Bovary was lavish of them; and the words “daughter” and “mother”
+ were exchanged all day long, accompanied by little quiverings of the
+lips, each one uttering gentle words in a voice trembling with anger.
+
+In Madame Dubuc’s time the old woman felt that she was still the
+favorite; but now the love of Charles for Emma seemed to her a desertion
+from her tenderness, an encroachment upon what was hers, and she watched
+her son’s happiness in sad silence, as a ruined man looks through
+the windows at people dining in his old house. She recalled to him as
+remembrances her troubles and her sacrifices, and, comparing these with
+Emma’s negligence, came to the conclusion that it was not reasonable to
+adore her so exclusively.
+
+Charles knew not what to answer: he respected his mother, and he loved
+his wife infinitely; he considered the judgment of the one infallible,
+and yet he thought the conduct of the other irreproachable. When Madam
+Bovary had gone, he tried timidly and in the same terms to hazard one or
+two of the more anodyne observations he had heard from his mamma. Emma
+proved to him with a word that he was mistaken, and sent him off to his
+patients.
+
+And yet, in accord with theories she believed right, she wanted to make
+herself in love with him. By moonlight in the garden she recited all
+the passionate rhymes she knew by heart, and, sighing, sang to him many
+melancholy adagios; but she found herself as calm after as before, and
+Charles seemed no more amorous and no more moved.
+
+When she had thus for a while struck the flint on her heart without
+getting a spark, incapable, moreover, of understanding what she did
+not experience as of believing anything that did not present itself
+in conventional forms, she persuaded herself without difficulty that
+Charles’s passion was nothing very exorbitant. His outbursts became
+regular; he embraced her at certain fixed times. It was one habit among
+other habits, and, like a dessert, looked forward to after the monotony
+of dinner.
+
+A gamekeeper, cured by the doctor of inflammation of the lungs, had
+given madame a little Italian greyhound; she took her out walking, for
+she went out sometimes in order to be alone for a moment, and not to see
+before her eyes the eternal garden and the dusty road. She went as far
+as the beeches of Banneville, near the deserted pavilion which forms an
+angle of the wall on the side of the country. Amidst the vegetation of
+the ditch there are long reeds with leaves that cut you.
+
+She began by looking round her to see if nothing had changed since last
+she had been there. She found again in the same places the foxgloves and
+wallflowers, the beds of nettles growing round the big stones, and
+the patches of lichen along the three windows, whose shutters, always
+closed, were rotting away on their rusty iron bars. Her thoughts,
+aimless at first, wandered at random, like her greyhound, who ran round
+and round in the fields, yelping after the yellow butterflies, chasing
+the shrew-mice, or nibbling the poppies on the edge of a cornfield.
+
+Then gradually her ideas took definite shape, and, sitting on the grass
+that she dug up with little prods of her sunshade, Emma repeated to
+herself, “Good heavens! Why did I marry?”
+
+She asked herself if by some other chance combination it would have not
+been possible to meet another man; and she tried to imagine what would
+have been these unrealised events, this different life, this unknown
+husband. All, surely, could not be like this one. He might have been
+handsome, witty, distinguished, attractive, such as, no doubt, her old
+companions of the convent had married. What were they doing now? In
+town, with the noise of the streets, the buzz of the theatres and the
+lights of the ballroom, they were living lives where the heart expands,
+the senses bourgeon out. But she--her life was cold as a garret whose
+dormer window looks on the north, and ennui, the silent spider, was
+weaving its web in the darkness in every corner of her heart.
+
+She recalled the prize days, when she mounted the platform to receive
+her little crowns, with her hair in long plaits. In her white frock and
+open prunella shoes she had a pretty way, and when she went back to her
+seat, the gentlemen bent over her to congratulate her; the courtyard was
+full of carriages; farewells were called to her through their windows;
+the music master with his violin case bowed in passing by. How far all
+of this! How far away! She called Djali, took her between her knees, and
+smoothed the long delicate head, saying, “Come, kiss mistress; you have
+no troubles.”
+
+Then noting the melancholy face of the graceful animal, who yawned
+slowly, she softened, and comparing her to herself, spoke to her aloud
+as to somebody in trouble whom one is consoling.
+
+Occasionally there came gusts of winds, breezes from the sea rolling in
+one sweep over the whole plateau of the Caux country, which brought
+even to these fields a salt freshness. The rushes, close to the ground,
+whistled; the branches trembled in a swift rustling, while their
+summits, ceaselessly swaying, kept up a deep murmur. Emma drew her shawl
+round her shoulders and rose.
+
+In the avenue a green light dimmed by the leaves lit up the short moss
+that crackled softly beneath her feet. The sun was setting; the sky
+showed red between the branches, and the trunks of the trees, uniform,
+and planted in a straight line, seemed a brown colonnade standing out
+against a background of gold. A fear took hold of her; she called Djali,
+and hurriedly returned to Tostes by the high road, threw herself into an
+armchair, and for the rest of the evening did not speak.
+
+But towards the end of September something extraordinary fell upon her
+life; she was invited by the Marquis d’Andervilliers to Vaubyessard.
+
+Secretary of State under the Restoration, the Marquis, anxious to
+re-enter political life, set about preparing for his candidature to
+the Chamber of Deputies long beforehand. In the winter he distributed a
+great deal of wood, and in the Conseil General always enthusiastically
+demanded new roads for his arrondissement. During the dog-days he had
+suffered from an abscess, which Charles had cured as if by miracle by
+giving a timely little touch with the lancet. The steward sent to Tostes
+to pay for the operation reported in the evening that he had seen some
+superb cherries in the doctor’s little garden. Now cherry trees did not
+thrive at Vaubyessard; the Marquis asked Bovary for some slips; made it
+his business to thank his personally; saw Emma; thought she had a pretty
+figure, and that she did not bow like a peasant; so that he did not
+think he was going beyond the bounds of condescension, nor, on the other
+hand, making a mistake, in inviting the young couple.
+
+On Wednesday at three o’clock, Monsieur and Madame Bovary, seated in
+their dog-cart, set out for Vaubyessard, with a great trunk strapped
+on behind and a bonnet-box in front of the apron. Besides these Charles
+held a bandbox between his knees.
+
+They arrived at nightfall, just as the lamps in the park were being lit
+to show the way for the carriages.
+
+
+
+Chapter Eight
+
+The chateau, a modern building in Italian style, with two projecting
+wings and three flights of steps, lay at the foot of an immense
+green-sward, on which some cows were grazing among groups of large trees
+set out at regular intervals, while large beds of arbutus, rhododendron,
+syringas, and guelder roses bulged out their irregular clusters of
+green along the curve of the gravel path. A river flowed under a bridge;
+through the mist one could distinguish buildings with thatched roofs
+scattered over the field bordered by two gently sloping, well timbered
+hillocks, and in the background amid the trees rose in two parallel
+lines the coach houses and stables, all that was left of the ruined old
+chateau.
+
+Charles’s dog-cart pulled up before the middle flight of steps; servants
+appeared; the Marquis came forward, and, offering his arm to the
+doctor’s wife, conducted her to the vestibule.
+
+It was paved with marble slabs, was very lofty, and the sound of
+footsteps and that of voices re-echoed through it as in a church.
+
+Opposite rose a straight staircase, and on the left a gallery
+overlooking the garden led to the billiard room, through whose door one
+could hear the click of the ivory balls. As she crossed it to go to the
+drawing room, Emma saw standing round the table men with grave faces,
+their chins resting on high cravats. They all wore orders, and smiled
+silently as they made their strokes.
+
+On the dark wainscoting of the walls large gold frames bore at
+the bottom names written in black letters. She read: “Jean-Antoine
+d’Andervilliers d’Yvervonbille, Count de la Vaubyessard and Baron de la
+Fresnay, killed at the battle of Coutras on the 20th of October,
+1587.” And on another: “Jean-Antoine-Henry-Guy d’Andervilliers de
+la Vaubyessard, Admiral of France and Chevalier of the Order of St.
+Michael, wounded at the battle of the Hougue-Saint-Vaast on the 29th of
+May, 1692; died at Vaubyessard on the 23rd of January 1693.” One could
+hardly make out those that followed, for the light of the lamps lowered
+over the green cloth threw a dim shadow round the room. Burnishing the
+horizontal pictures, it broke up against these in delicate lines where
+there were cracks in the varnish, and from all these great black squares
+framed in with gold stood out here and there some lighter portion of the
+painting--a pale brow, two eyes that looked at you, perukes flowing over
+and powdering red-coated shoulders, or the buckle of a garter above a
+well-rounded calf.
+
+The Marquis opened the drawing room door; one of the ladies (the
+Marchioness herself) came to meet Emma. She made her sit down by her on
+an ottoman, and began talking to her as amicably as if she had known her
+a long time. She was a woman of about forty, with fine shoulders, a hook
+nose, a drawling voice, and on this evening she wore over her brown hair
+a simple guipure fichu that fell in a point at the back. A fair young
+woman sat in a high-backed chair in a corner; and gentlemen with flowers
+in their buttonholes were talking to ladies round the fire.
+
+At seven dinner was served. The men, who were in the majority, sat down
+at the first table in the vestibule; the ladies at the second in the
+dining room with the Marquis and Marchioness.
+
+Emma, on entering, felt herself wrapped round by the warm air, a
+blending of the perfume of flowers and of the fine linen, of the fumes
+of the viands, and the odour of the truffles. The silver dish covers
+reflected the lighted wax candles in the candelabra, the cut crystal
+covered with light steam reflected from one to the other pale rays;
+bouquets were placed in a row the whole length of the table; and in
+the large-bordered plates each napkin, arranged after the fashion of a
+bishop’s mitre, held between its two gaping folds a small oval shaped
+roll. The red claws of lobsters hung over the dishes; rich fruit in open
+baskets was piled up on moss; there were quails in their plumage; smoke
+was rising; and in silk stockings, knee-breeches, white cravat, and
+frilled shirt, the steward, grave as a judge, offering ready carved
+dishes between the shoulders of the guests, with a touch of the spoon
+gave you the piece chosen. On the large stove of porcelain inlaid
+with copper baguettes the statue of a woman, draped to the chin, gazed
+motionless on the room full of life.
+
+Madame Bovary noticed that many ladies had not put their gloves in their
+glasses.
+
+But at the upper end of the table, alone amongst all these women, bent
+over his full plate, and his napkin tied round his neck like a child, an
+old man sat eating, letting drops of gravy drip from his mouth. His eyes
+were bloodshot, and he wore a little queue tied with black ribbon. He
+was the Marquis’s father-in-law, the old Duke de Laverdiere, once on
+a time favourite of the Count d’Artois, in the days of the Vaudreuil
+hunting-parties at the Marquis de Conflans’, and had been, it was said,
+the lover of Queen Marie Antoinette, between Monsieur de Coigny and
+Monsieur de Lauzun. He had lived a life of noisy debauch, full of duels,
+bets, elopements; he had squandered his fortune and frightened all his
+family. A servant behind his chair named aloud to him in his ear the
+dishes that he pointed to stammering, and constantly Emma’s eyes
+turned involuntarily to this old man with hanging lips, as to something
+extraordinary. He had lived at court and slept in the bed of queens!
+Iced champagne was poured out. Emma shivered all over as she felt
+it cold in her mouth. She had never seen pomegranates nor tasted
+pineapples. The powdered sugar even seemed to her whiter and finer than
+elsewhere.
+
+The ladies afterwards went to their rooms to prepare for the ball.
+
+Emma made her toilet with the fastidious care of an actress on her
+debut. She did her hair according to the directions of the hairdresser,
+and put on the barege dress spread out upon the bed.
+
+Charles’s trousers were tight across the belly.
+
+“My trouser-straps will be rather awkward for dancing,” he said.
+
+“Dancing?” repeated Emma.
+
+“Yes!”
+
+“Why, you must be mad! They would make fun of you; keep your place.
+Besides, it is more becoming for a doctor,” she added.
+
+Charles was silent. He walked up and down waiting for Emma to finish
+dressing.
+
+He saw her from behind in the glass between two lights. Her black eyes
+seemed blacker than ever. Her hair, undulating towards the ears, shone
+with a blue lustre; a rose in her chignon trembled on its mobile stalk,
+with artificial dewdrops on the tip of the leaves. She wore a gown of
+pale saffron trimmed with three bouquets of pompon roses mixed with
+green.
+
+Charles came and kissed her on her shoulder.
+
+“Let me alone!” she said; “you are tumbling me.”
+
+One could hear the flourish of the violin and the notes of a horn. She
+went downstairs restraining herself from running.
+
+Dancing had begun. Guests were arriving. There was some crushing.
+
+She sat down on a form near the door.
+
+The quadrille over, the floor was occupied by groups of men standing up
+and talking and servants in livery bearing large trays. Along the line
+of seated women painted fans were fluttering, bouquets half hid smiling
+faces, and gold stoppered scent-bottles were turned in partly-closed
+hands, whose white gloves outlined the nails and tightened on the flesh
+at the wrists. Lace trimmings, diamond brooches, medallion bracelets
+trembled on bodices, gleamed on breasts, clinked on bare arms.
+
+The hair, well-smoothed over the temples and knotted at the nape,
+bore crowns, or bunches, or sprays of mytosotis, jasmine, pomegranate
+blossoms, ears of corn, and corn-flowers. Calmly seated in their places,
+mothers with forbidding countenances were wearing red turbans.
+
+Emma’s heart beat rather faster when, her partner holding her by the
+tips of the fingers, she took her place in a line with the dancers, and
+waited for the first note to start. But her emotion soon vanished, and,
+swaying to the rhythm of the orchestra, she glided forward with slight
+movements of the neck. A smile rose to her lips at certain delicate
+phrases of the violin, that sometimes played alone while the other
+instruments were silent; one could hear the clear clink of the louis
+d’or that were being thrown down upon the card tables in the next room;
+then all struck again, the cornet-a-piston uttered its sonorous note,
+feet marked time, skirts swelled and rustled, hands touched and parted;
+the same eyes falling before you met yours again.
+
+A few men (some fifteen or so), of twenty-five to forty, scattered here
+and there among the dancers or talking at the doorways, distinguished
+themselves from the crowd by a certain air of breeding, whatever their
+differences in age, dress, or face.
+
+Their clothes, better made, seemed of finer cloth, and their hair,
+brought forward in curls towards the temples, glossy with more delicate
+pomades. They had the complexion of wealth--that clear complexion that
+is heightened by the pallor of porcelain, the shimmer of satin, the
+veneer of old furniture, and that an ordered regimen of exquisite
+nurture maintains at its best. Their necks moved easily in their low
+cravats, their long whiskers fell over their turned-down collars, they
+wiped their lips upon handkerchiefs with embroidered initials that gave
+forth a subtle perfume. Those who were beginning to grow old had an air
+of youth, while there was something mature in the faces of the young.
+In their unconcerned looks was the calm of passions daily satiated, and
+through all their gentleness of manner pierced that peculiar brutality,
+the result of a command of half-easy things, in which force is exercised
+and vanity amused--the management of thoroughbred horses and the society
+of loose women.
+
+A few steps from Emma a gentleman in a blue coat was talking of Italy
+with a pale young woman wearing a parure of pearls.
+
+They were praising the breadth of the columns of St. Peter’s, Tivoly,
+Vesuvius, Castellamare, and Cassines, the roses of Genoa, the Coliseum
+by moonlight. With her other ear Emma was listening to a conversation
+full of words she did not understand. A circle gathered round a very
+young man who the week before had beaten “Miss Arabella” and “Romolus,”
+ and won two thousand louis jumping a ditch in England. One complained
+that his racehorses were growing fat; another of the printers’ errors
+that had disfigured the name of his horse.
+
+The atmosphere of the ball was heavy; the lamps were growing dim.
+
+Guests were flocking to the billiard room. A servant got upon a chair
+and broke the window-panes. At the crash of the glass Madame Bovary
+turned her head and saw in the garden the faces of peasants pressed
+against the window looking in at them. Then the memory of the Bertaux
+came back to her. She saw the farm again, the muddy pond, her father in
+a blouse under the apple trees, and she saw herself again as formerly,
+skimming with her finger the cream off the milk-pans in the dairy. But
+in the refulgence of the present hour her past life, so distinct until
+then, faded away completely, and she almost doubted having lived it. She
+was there; beyond the ball was only shadow overspreading all the rest.
+She was just eating a maraschino ice that she held with her left hand
+in a silver-gilt cup, her eyes half-closed, and the spoon between her
+teeth.
+
+A lady near her dropped her fan. A gentlemen was passing.
+
+“Would you be so good,” said the lady, “as to pick up my fan that has
+fallen behind the sofa?”
+
+The gentleman bowed, and as he moved to stretch out his arm, Emma saw
+the hand of a young woman throw something white, folded in a triangle,
+into his hat. The gentleman, picking up the fan, offered it to the lady
+respectfully; she thanked him with an inclination of the head, and began
+smelling her bouquet.
+
+After supper, where were plenty of Spanish and Rhine wines, soups a la
+bisque and au lait d’amandes*, puddings a la Trafalgar, and all sorts of
+cold meats with jellies that trembled in the dishes, the carriages one
+after the other began to drive off. Raising the corners of the muslin
+curtain, one could see the light of their lanterns glimmering through
+the darkness. The seats began to empty, some card-players were still
+left; the musicians were cooling the tips of their fingers on their
+tongues. Charles was half asleep, his back propped against a door.
+
+     *With almond milk
+
+At three o’clock the cotillion began. Emma did not know how to waltz.
+Everyone was waltzing, Mademoiselle d’Andervilliers herself and the
+Marquis; only the guests staying at the castle were still there, about a
+dozen persons.
+
+One of the waltzers, however, who was familiarly called Viscount, and
+whose low cut waistcoat seemed moulded to his chest, came a second time
+to ask Madame Bovary to dance, assuring her that he would guide her, and
+that she would get through it very well.
+
+They began slowly, then went more rapidly. They turned; all around them
+was turning--the lamps, the furniture, the wainscoting, the floor, like
+a disc on a pivot. On passing near the doors the bottom of Emma’s dress
+caught against his trousers.
+
+Their legs commingled; he looked down at her; she raised her eyes to
+his. A torpor seized her; she stopped. They started again, and with a
+more rapid movement; the Viscount, dragging her along disappeared with
+her to the end of the gallery, where panting, she almost fell, and for
+a moment rested her head upon his breast. And then, still turning, but
+more slowly, he guided her back to her seat. She leaned back against the
+wall and covered her eyes with her hands.
+
+When she opened them again, in the middle of the drawing room three
+waltzers were kneeling before a lady sitting on a stool.
+
+She chose the Viscount, and the violin struck up once more.
+
+Everyone looked at them. They passed and re-passed, she with rigid body,
+her chin bent down, and he always in the same pose, his figure curved,
+his elbow rounded, his chin thrown forward. That woman knew how to
+waltz! They kept up a long time, and tired out all the others.
+
+Then they talked a few moments longer, and after the goodnights, or
+rather good mornings, the guests of the chateau retired to bed.
+
+Charles dragged himself up by the balusters. His “knees were going
+up into his body.” He had spent five consecutive hours standing
+bolt upright at the card tables, watching them play whist, without
+understanding anything about it, and it was with a deep sigh of relief
+that he pulled off his boots.
+
+Emma threw a shawl over her shoulders, opened the window, and leant out.
+
+The night was dark; some drops of rain were falling. She breathed in the
+damp wind that refreshed her eyelids. The music of the ball was still
+murmuring in her ears. And she tried to keep herself awake in order to
+prolong the illusion of this luxurious life that she would soon have to
+give up.
+
+Day began to break. She looked long at the windows of the chateau,
+trying to guess which were the rooms of all those she had noticed the
+evening before. She would fain have known their lives, have penetrated,
+blended with them. But she was shivering with cold. She undressed, and
+cowered down between the sheets against Charles, who was asleep.
+
+There were a great many people to luncheon. The repast lasted ten
+minutes; no liqueurs were served, which astonished the doctor.
+
+Next, Mademoiselle d’Andervilliers collected some pieces of roll in a
+small basket to take them to the swans on the ornamental waters, and
+they went to walk in the hot-houses, where strange plants, bristling
+with hairs, rose in pyramids under hanging vases, whence, as from
+over-filled nests of serpents, fell long green cords interlacing.
+The orangery, which was at the other end, led by a covered way to the
+outhouses of the chateau. The Marquis, to amuse the young woman, took
+her to see the stables.
+
+Above the basket-shaped racks porcelain slabs bore the names of the
+horses in black letters. Each animal in its stall whisked its tail when
+anyone went near and said “Tchk! tchk!” The boards of the harness room
+shone like the flooring of a drawing room. The carriage harness was
+piled up in the middle against two twisted columns, and the bits, the
+whips, the spurs, the curbs, were ranged in a line all along the wall.
+
+Charles, meanwhile, went to ask a groom to put his horse to. The
+dog-cart was brought to the foot of the steps, and, all the parcels
+being crammed in, the Bovarys paid their respects to the Marquis and
+Marchioness and set out again for Tostes.
+
+Emma watched the turning wheels in silence. Charles, on the extreme edge
+of the seat, held the reins with his two arms wide apart, and the little
+horse ambled along in the shafts that were too big for him. The loose
+reins hanging over his crupper were wet with foam, and the box fastened
+on behind the chaise gave great regular bumps against it.
+
+They were on the heights of Thibourville when suddenly some horsemen
+with cigars between their lips passed laughing. Emma thought she
+recognized the Viscount, turned back, and caught on the horizon only the
+movement of the heads rising or falling with the unequal cadence of the
+trot or gallop.
+
+A mile farther on they had to stop to mend with some string the traces
+that had broken.
+
+But Charles, giving a last look to the harness, saw something on the
+ground between his horse’s legs, and he picked up a cigar-case with
+a green silk border and beblazoned in the centre like the door of a
+carriage.
+
+“There are even two cigars in it,” said he; “they’ll do for this evening
+after dinner.”
+
+“Why, do you smoke?” she asked.
+
+“Sometimes, when I get a chance.”
+
+He put his find in his pocket and whipped up the nag.
+
+When they reached home the dinner was not ready. Madame lost her temper.
+Nastasie answered rudely.
+
+“Leave the room!” said Emma. “You are forgetting yourself. I give you
+warning.”
+
+For dinner there was onion soup and a piece of veal with sorrel.
+
+Charles, seated opposite Emma, rubbed his hands gleefully.
+
+“How good it is to be at home again!”
+
+Nastasie could be heard crying. He was rather fond of the poor girl.
+She had formerly, during the wearisome time of his widowhood, kept him
+company many an evening. She had been his first patient, his oldest
+acquaintance in the place.
+
+“Have you given her warning for good?” he asked at last.
+
+“Yes. Who is to prevent me?” she replied.
+
+Then they warmed themselves in the kitchen while their room was being
+made ready. Charles began to smoke. He smoked with lips protruding,
+spitting every moment, recoiling at every puff.
+
+“You’ll make yourself ill,” she said scornfully.
+
+He put down his cigar and ran to swallow a glass of cold water at the
+pump. Emma seizing hold of the cigar case threw it quickly to the back
+of the cupboard.
+
+The next day was a long one. She walked about her little garden, up
+and down the same walks, stopping before the beds, before the espalier,
+before the plaster curate, looking with amazement at all these things
+of once-on-a-time that she knew so well. How far off the ball seemed
+already! What was it that thus set so far asunder the morning of the day
+before yesterday and the evening of to-day? Her journey to Vaubyessard
+had made a hole in her life, like one of those great crevices that
+a storm will sometimes make in one night in mountains. Still she was
+resigned. She devoutly put away in her drawers her beautiful dress, down
+to the satin shoes whose soles were yellowed with the slippery wax of
+the dancing floor. Her heart was like these. In its friction against
+wealth something had come over it that could not be effaced.
+
+The memory of this ball, then, became an occupation for Emma.
+
+Whenever the Wednesday came round she said to herself as she awoke, “Ah!
+I was there a week--a fortnight--three weeks ago.”
+
+And little by little the faces grew confused in her remembrance.
+
+She forgot the tune of the quadrilles; she no longer saw the liveries
+and appointments so distinctly; some details escaped her, but the regret
+remained with her.
+
+
+
+Chapter Nine
+
+Often when Charles was out she took from the cupboard, between the
+folds of the linen where she had left it, the green silk cigar case.
+She looked at it, opened it, and even smelt the odour of the lining--a
+mixture of verbena and tobacco. Whose was it? The Viscount’s? Perhaps
+it was a present from his mistress. It had been embroidered on some
+rosewood frame, a pretty little thing, hidden from all eyes, that had
+occupied many hours, and over which had fallen the soft curls of the
+pensive worker. A breath of love had passed over the stitches on the
+canvas; each prick of the needle had fixed there a hope or a memory, and
+all those interwoven threads of silk were but the continuity of the same
+silent passion. And then one morning the Viscount had taken it away
+with him. Of what had they spoken when it lay upon the wide-mantelled
+chimneys between flower-vases and Pompadour clocks? She was at Tostes;
+he was at Paris now, far away! What was this Paris like? What a vague
+name! She repeated it in a low voice, for the mere pleasure of it; it
+rang in her ears like a great cathedral bell; it shone before her eyes,
+even on the labels of her pomade-pots.
+
+At night, when the carriers passed under her windows in their carts
+singing the “Marjolaine,” she awoke, and listened to the noise of the
+iron-bound wheels, which, as they gained the country road, was soon
+deadened by the soil. “They will be there to-morrow!” she said to
+herself.
+
+And she followed them in thought up and down the hills, traversing
+villages, gliding along the highroads by the light of the stars. At the
+end of some indefinite distance there was always a confused spot, into
+which her dream died.
+
+She bought a plan of Paris, and with the tip of her finger on the map
+she walked about the capital. She went up the boulevards, stopping at
+every turning, between the lines of the streets, in front of the white
+squares that represented the houses. At last she would close the lids of
+her weary eyes, and see in the darkness the gas jets flaring in the wind
+and the steps of carriages lowered with much noise before the peristyles
+of theatres.
+
+She took in “La Corbeille,” a lady’s journal, and the “Sylphe des
+Salons.” She devoured, without skipping a word, all the accounts of
+first nights, races, and soirees, took interest in the debut of a
+singer, in the opening of a new shop. She knew the latest fashions, the
+addresses of the best tailors, the days of the Bois and the Opera. In
+Eugene Sue she studied descriptions of furniture; she read Balzac and
+George Sand, seeking in them imaginary satisfaction for her own desires.
+Even at table she had her book by her, and turned over the pages
+while Charles ate and talked to her. The memory of the Viscount always
+returned as she read. Between him and the imaginary personages she made
+comparisons. But the circle of which he was the centre gradually widened
+round him, and the aureole that he bore, fading from his form, broadened
+out beyond, lighting up her other dreams.
+
+Paris, more vague than the ocean, glimmered before Emma’s eyes in an
+atmosphere of vermilion. The many lives that stirred amid this tumult
+were, however, divided into parts, classed as distinct pictures. Emma
+perceived only two or three that hid from her all the rest, and in
+themselves represented all humanity. The world of ambassadors moved over
+polished floors in drawing rooms lined with mirrors, round oval tables
+covered with velvet and gold-fringed cloths. There were dresses with
+trains, deep mysteries, anguish hidden beneath smiles. Then came the
+society of the duchesses; all were pale; all got up at four o’clock; the
+women, poor angels, wore English point on their petticoats; and the men,
+unappreciated geniuses under a frivolous outward seeming, rode horses to
+death at pleasure parties, spent the summer season at Baden, and towards
+the forties married heiresses. In the private rooms of restaurants,
+where one sups after midnight by the light of wax candles, laughed the
+motley crowd of men of letters and actresses. They were prodigal as
+kings, full of ideal, ambitious, fantastic frenzy. This was an existence
+outside that of all others, between heaven and earth, in the midst of
+storms, having something of the sublime. For the rest of the world it
+was lost, with no particular place and as if non-existent. The nearer
+things were, moreover, the more her thoughts turned away from them.
+All her immediate surroundings, the wearisome country, the middle-class
+imbeciles, the mediocrity of existence, seemed to her exceptional, a
+peculiar chance that had caught hold of her, while beyond stretched, as
+far as eye could see, an immense land of joys and passions. She confused
+in her desire the sensualities of luxury with the delights of the heart,
+elegance of manners with delicacy of sentiment. Did not love, like
+Indian plants, need a special soil, a particular temperature? Signs
+by moonlight, long embraces, tears flowing over yielded hands, all
+the fevers of the flesh and the languors of tenderness could not be
+separated from the balconies of great castles full of indolence,
+from boudoirs with silken curtains and thick carpets, well-filled
+flower-stands, a bed on a raised dias, nor from the flashing of precious
+stones and the shoulder-knots of liveries.
+
+The lad from the posting house who came to groom the mare every morning
+passed through the passage with his heavy wooden shoes; there were holes
+in his blouse; his feet were bare in list slippers. And this was the
+groom in knee-britches with whom she had to be content! His work done,
+he did not come back again all day, for Charles on his return put up
+his horse himself, unsaddled him and put on the halter, while the
+servant-girl brought a bundle of straw and threw it as best she could
+into the manger.
+
+To replace Nastasie (who left Tostes shedding torrents of tears) Emma
+took into her service a young girl of fourteen, an orphan with a sweet
+face. She forbade her wearing cotton caps, taught her to address her in
+the third person, to bring a glass of water on a plate, to knock before
+coming into a room, to iron, starch, and to dress her--wanted to make a
+lady’s-maid of her. The new servant obeyed without a murmur, so as not
+to be sent away; and as madame usually left the key in the sideboard,
+Felicite every evening took a small supply of sugar that she ate alone
+in her bed after she had said her prayers.
+
+Sometimes in the afternoon she went to chat with the postilions.
+
+Madame was in her room upstairs. She wore an open dressing gown that
+showed between the shawl facings of her bodice a pleated chamisette with
+three gold buttons. Her belt was a corded girdle with great tassels, and
+her small garnet coloured slippers had a large knot of ribbon that fell
+over her instep. She had bought herself a blotting book, writing case,
+pen-holder, and envelopes, although she had no one to write to; she
+dusted her what-not, looked at herself in the glass, picked up a book,
+and then, dreaming between the lines, let it drop on her knees. She
+longed to travel or to go back to her convent. She wished at the same
+time to die and to live in Paris.
+
+Charles in snow and rain trotted across country. He ate omelettes on
+farmhouse tables, poked his arm into damp beds, received the tepid
+spurt of blood-lettings in his face, listened to death-rattles, examined
+basins, turned over a good deal of dirty linen; but every evening he
+found a blazing fire, his dinner ready, easy-chairs, and a well-dressed
+woman, charming with an odour of freshness, though no one could say
+whence the perfume came, or if it were not her skin that made odorous
+her chemise.
+
+She charmed him by numerous attentions; now it was some new way of
+arranging paper sconces for the candles, a flounce that she altered on
+her gown, or an extraordinary name for some very simple dish that the
+servant had spoilt, but that Charles swallowed with pleasure to the last
+mouthful. At Rouen she saw some ladies who wore a bunch of charms on the
+watch-chains; she bought some charms. She wanted for her mantelpiece two
+large blue glass vases, and some time after an ivory necessaire with a
+silver-gilt thimble. The less Charles understood these refinements
+the more they seduced him. They added something to the pleasure of the
+senses and to the comfort of his fireside. It was like a golden dust
+sanding all along the narrow path of his life.
+
+He was well, looked well; his reputation was firmly established.
+
+The country-folk loved him because he was not proud. He petted the
+children, never went to the public house, and, moreover, his morals
+inspired confidence. He was specially successful with catarrhs and chest
+complaints. Being much afraid of killing his patients, Charles, in fact
+only prescribed sedatives, from time to time and emetic, a footbath,
+or leeches. It was not that he was afraid of surgery; he bled people
+copiously like horses, and for the taking out of teeth he had the
+“devil’s own wrist.”
+
+Finally, to keep up with the times, he took in “La Ruche Medicale,”
+ a new journal whose prospectus had been sent him. He read it a little
+after dinner, but in about five minutes the warmth of the room added to
+the effect of his dinner sent him to sleep; and he sat there, his chin
+on his two hands and his hair spreading like a mane to the foot of the
+lamp. Emma looked at him and shrugged her shoulders. Why, at least, was
+not her husband one of those men of taciturn passions who work at their
+books all night, and at last, when about sixty, the age of rheumatism
+sets in, wear a string of orders on their ill-fitting black coat?
+She could have wished this name of Bovary, which was hers, had been
+illustrious, to see it displayed at the booksellers’, repeated in the
+newspapers, known to all France. But Charles had no ambition.
+
+An Yvetot doctor whom he had lately met in consultation had somewhat
+humiliated him at the very bedside of the patient, before the assembled
+relatives. When, in the evening, Charles told her this anecdote, Emma
+inveighed loudly against his colleague. Charles was much touched. He
+kissed her forehead with a tear in his eyes. But she was angered with
+shame; she felt a wild desire to strike him; she went to open the window
+in the passage and breathed in the fresh air to calm herself.
+
+“What a man! What a man!” she said in a low voice, biting her lips.
+
+Besides, she was becoming more irritated with him. As he grew older his
+manner grew heavier; at dessert he cut the corks of the empty bottles;
+after eating he cleaned his teeth with his tongue; in taking soup
+he made a gurgling noise with every spoonful; and, as he was getting
+fatter, the puffed-out cheeks seemed to push the eyes, always small, up
+to the temples.
+
+Sometimes Emma tucked the red borders of his under-vest unto his
+waistcoat, rearranged his cravat, and threw away the dirty gloves he was
+going to put on; and this was not, as he fancied, for himself; it
+was for herself, by a diffusion of egotism, of nervous irritation.
+Sometimes, too, she told him of what she had read, such as a passage in
+a novel, of a new play, or an anecdote of the “upper ten” that she
+had seen in a feuilleton; for, after all, Charles was something, an
+ever-open ear, and ever-ready approbation. She confided many a thing to
+her greyhound. She would have done so to the logs in the fireplace or to
+the pendulum of the clock.
+
+At the bottom of her heart, however, she was waiting for something to
+happen. Like shipwrecked sailors, she turned despairing eyes upon the
+solitude of her life, seeking afar off some white sail in the mists of
+the horizon. She did not know what this chance would be, what wind would
+bring it her, towards what shore it would drive her, if it would be a
+shallop or a three-decker, laden with anguish or full of bliss to the
+portholes. But each morning, as she awoke, she hoped it would come that
+day; she listened to every sound, sprang up with a start, wondered that
+it did not come; then at sunset, always more saddened, she longed for
+the morrow.
+
+Spring came round. With the first warm weather, when the pear trees
+began to blossom, she suffered from dyspnoea.
+
+From the beginning of July she counted how many weeks there were to
+October, thinking that perhaps the Marquis d’Andervilliers would give
+another ball at Vaubyessard. But all September passed without letters or
+visits.
+
+After the ennui of this disappointment her heart once more remained
+empty, and then the same series of days recommenced. So now they would
+thus follow one another, always the same, immovable, and bringing
+nothing. Other lives, however flat, had at least the chance of some
+event. One adventure sometimes brought with it infinite consequences and
+the scene changed. But nothing happened to her; God had willed it so!
+The future was a dark corridor, with its door at the end shut fast.
+
+She gave up music. What was the good of playing? Who would hear her?
+Since she could never, in a velvet gown with short sleeves, striking
+with her light fingers the ivory keys of an Erard at a concert, feel
+the murmur of ecstasy envelop her like a breeze, it was not worth while
+boring herself with practicing. Her drawing cardboard and her embroidery
+she left in the cupboard. What was the good? What was the good? Sewing
+irritated her. “I have read everything,” she said to herself. And she
+sat there making the tongs red-hot, or looked at the rain falling.
+
+How sad she was on Sundays when vespers sounded! She listened with dull
+attention to each stroke of the cracked bell. A cat slowly walking over
+some roof put up his back in the pale rays of the sun. The wind on the
+highroad blew up clouds of dust. Afar off a dog sometimes howled; and
+the bell, keeping time, continued its monotonous ringing that died away
+over the fields.
+
+But the people came out from church. The women in waxed clogs, the
+peasants in new blouses, the little bare-headed children skipping along
+in front of them, all were going home. And till nightfall, five or six
+men, always the same, stayed playing at corks in front of the large door
+of the inn.
+
+The winter was severe. The windows every morning were covered with
+rime, and the light shining through them, dim as through ground-glass,
+sometimes did not change the whole day long. At four o’clock the lamp
+had to be lighted.
+
+On fine days she went down into the garden. The dew had left on the
+cabbages a silver lace with long transparent threads spreading from one
+to the other. No birds were to be heard; everything seemed asleep, the
+espalier covered with straw, and the vine, like a great sick serpent
+under the coping of the wall, along which, on drawing near, one saw the
+many-footed woodlice crawling. Under the spruce by the hedgerow, the
+curie in the three-cornered hat reading his breviary had lost his right
+foot, and the very plaster, scaling off with the frost, had left white
+scabs on his face.
+
+Then she went up again, shut her door, put on coals, and fainting with
+the heat of the hearth, felt her boredom weigh more heavily than ever.
+She would have liked to go down and talk to the servant, but a sense of
+shame restrained her.
+
+Every day at the same time the schoolmaster in a black skullcap opened
+the shutters of his house, and the rural policeman, wearing his sabre
+over his blouse, passed by. Night and morning the post-horses, three by
+three, crossed the street to water at the pond. From time to time the
+bell of a public house door rang, and when it was windy one could hear
+the little brass basins that served as signs for the hairdresser’s shop
+creaking on their two rods. This shop had as decoration an old engraving
+of a fashion-plate stuck against a windowpane and the wax bust of a
+woman with yellow hair. He, too, the hairdresser, lamented his wasted
+calling, his hopeless future, and dreaming of some shop in a big
+town--at Rouen, for example, overlooking the harbour, near the
+theatre--he walked up and down all day from the mairie to the church,
+sombre and waiting for customers. When Madame Bovary looked up, she
+always saw him there, like a sentinel on duty, with his skullcap over
+his ears and his vest of lasting.
+
+Sometimes in the afternoon outside the window of her room, the head of a
+man appeared, a swarthy head with black whiskers, smiling slowly, with
+a broad, gentle smile that showed his white teeth. A waltz immediately
+began and on the organ, in a little drawing room, dancers the size of
+a finger, women in pink turbans, Tyrolians in jackets, monkeys in frock
+coats, gentlemen in knee-breeches, turned and turned between the sofas,
+the consoles, multiplied in the bits of looking glass held together
+at their corners by a piece of gold paper. The man turned his handle,
+looking to the right and left, and up at the windows. Now and again,
+while he shot out a long squirt of brown saliva against the milestone,
+with his knee raised his instrument, whose hard straps tired his
+shoulder; and now, doleful and drawling, or gay and hurried, the music
+escaped from the box, droning through a curtain of pink taffeta under
+a brass claw in arabesque. They were airs played in other places at
+the theatres, sung in drawing rooms, danced to at night under lighted
+lustres, echoes of the world that reached even to Emma. Endless
+sarabands ran through her head, and, like an Indian dancing girl on the
+flowers of a carpet, her thoughts leapt with the notes, swung from dream
+to dream, from sadness to sadness. When the man had caught some coppers
+in his cap, he drew down an old cover of blue cloth, hitched his organ
+on to his back, and went off with a heavy tread. She watched him going.
+
+But it was above all the meal-times that were unbearable to her, in this
+small room on the ground floor, with its smoking stove, its creaking
+door, the walls that sweated, the damp flags; all the bitterness in life
+seemed served up on her plate, and with smoke of the boiled beef there
+rose from her secret soul whiffs of sickliness. Charles was a slow
+eater; she played with a few nuts, or, leaning on her elbow, amused
+herself with drawing lines along the oilcloth table cover with the point
+of her knife.
+
+She now let everything in her household take care of itself, and Madame
+Bovary senior, when she came to spend part of Lent at Tostes, was much
+surprised at the change. She who was formerly so careful, so dainty,
+now passed whole days without dressing, wore grey cotton stockings, and
+burnt tallow candles. She kept saying they must be economical since
+they were not rich, adding that she was very contented, very happy, that
+Tostes pleased her very much, with other speeches that closed the mouth
+of her mother-in-law. Besides, Emma no longer seemed inclined to follow
+her advice; once even, Madame Bovary having thought fit to maintain that
+mistresses ought to keep an eye on the religion of their servants, she
+had answered with so angry a look and so cold a smile that the good
+woman did not interfere again.
+
+Emma was growing difficult, capricious. She ordered dishes for herself,
+then she did not touch them; one day drank only pure milk, the next
+cups of tea by the dozen. Often she persisted in not going out, then,
+stifling, threw open the windows and put on light dresses. After she had
+well scolded her servant she gave her presents or sent her out to see
+neighbours, just as she sometimes threw beggars all the silver in her
+purse, although she was by no means tender-hearted or easily accessible
+to the feelings of others, like most country-bred people, who always
+retain in their souls something of the horny hardness of the paternal
+hands.
+
+Towards the end of February old Rouault, in memory of his cure, himself
+brought his son-in-law a superb turkey, and stayed three days at Tostes.
+Charles being with his patients, Emma kept him company. He smoked in the
+room, spat on the firedogs, talked farming, calves, cows, poultry, and
+municipal council, so that when he left she closed the door on him with
+a feeling of satisfaction that surprised even herself. Moreover she no
+longer concealed her contempt for anything or anybody, and at times she
+set herself to express singular opinions, finding fault with that which
+others approved, and approving things perverse and immoral, all of which
+made her husband open his eyes widely.
+
+Would this misery last for ever? Would she never issue from it? Yet
+she was as good as all the women who were living happily. She had seen
+duchesses at Vaubyessard with clumsier waists and commoner ways, and she
+execrated the injustice of God. She leant her head against the walls
+to weep; she envied lives of stir; longed for masked balls, for violent
+pleasures, with all the wildness that she did not know, but that these
+must surely yield.
+
+She grew pale and suffered from palpitations of the heart.
+
+Charles prescribed valerian and camphor baths. Everything that was tried
+only seemed to irritate her the more.
+
+On certain days she chatted with feverish rapidity, and this
+over-excitement was suddenly followed by a state of torpor, in which
+she remained without speaking, without moving. What then revived her was
+pouring a bottle of eau-de-cologne over her arms.
+
+As she was constantly complaining about Tostes, Charles fancied that her
+illness was no doubt due to some local cause, and fixing on this idea,
+began to think seriously of setting up elsewhere.
+
+From that moment she drank vinegar, contracted a sharp little cough, and
+completely lost her appetite.
+
+It cost Charles much to give up Tostes after living there four years and
+“when he was beginning to get on there.” Yet if it must be! He took her
+to Rouen to see his old master. It was a nervous complaint: change of
+air was needed.
+
+After looking about him on this side and on that, Charles learnt that
+in the Neufchatel arrondissement there was a considerable market town
+called Yonville-l’Abbaye, whose doctor, a Polish refugee, had decamped a
+week before. Then he wrote to the chemist of the place to ask the
+number of the population, the distance from the nearest doctor, what
+his predecessor had made a year, and so forth; and the answer being
+satisfactory, he made up his mind to move towards the spring, if Emma’s
+health did not improve.
+
+One day when, in view of her departure, she was tidying a drawer,
+something pricked her finger. It was a wire of her wedding bouquet.
+The orange blossoms were yellow with dust and the silver bordered satin
+ribbons frayed at the edges. She threw it into the fire. It flared
+up more quickly than dry straw. Then it was, like a red bush in the
+cinders, slowly devoured. She watched it burn.
+
+The little pasteboard berries burst, the wire twisted, the gold
+lace melted; and the shriveled paper corollas, fluttering like black
+butterflies at the back of the stove, at last flew up the chimney.
+
+When they left Tostes at the month of March, Madame Bovary was pregnant.
+
+
+
+
+
+Part II
+
+
+
+Chapter One
+
+Yonville-l’Abbaye (so called from an old Capuchin abbey of which not
+even the ruins remain) is a market-town twenty-four miles from Rouen,
+between the Abbeville and Beauvais roads, at the foot of a valley
+watered by the Rieule, a little river that runs into the Andelle after
+turning three water-mills near its mouth, where there are a few trout
+that the lads amuse themselves by fishing for on Sundays.
+
+We leave the highroad at La Boissiere and keep straight on to the top of
+the Leux hill, whence the valley is seen. The river that runs through it
+makes of it, as it were, two regions with distinct physiognomies--all on
+the left is pasture land, all of the right arable. The meadow stretches
+under a bulge of low hills to join at the back with the pasture land of
+the Bray country, while on the eastern side, the plain, gently rising,
+broadens out, showing as far as eye can follow its blond cornfields. The
+water, flowing by the grass, divides with a white line the colour of the
+roads and of the plains, and the country is like a great unfolded mantle
+with a green velvet cape bordered with a fringe of silver.
+
+Before us, on the verge of the horizon, lie the oaks of the forest of
+Argueil, with the steeps of the Saint-Jean hills scarred from top
+to bottom with red irregular lines; they are rain tracks, and these
+brick-tones standing out in narrow streaks against the grey colour of
+the mountain are due to the quantity of iron springs that flow beyond in
+the neighboring country.
+
+Here we are on the confines of Normandy, Picardy, and the Ile-de-France,
+a bastard land whose language is without accent and its landscape is
+without character. It is there that they make the worst Neufchatel
+cheeses of all the arrondissement; and, on the other hand, farming is
+costly because so much manure is needed to enrich this friable soil full
+of sand and flints.
+
+Up to 1835 there was no practicable road for getting to Yonville, but
+about this time a cross-road was made which joins that of Abbeville to
+that of Amiens, and is occasionally used by the Rouen wagoners on their
+way to Flanders. Yonville-l’Abbaye has remained stationary in spite of
+its “new outlet.” Instead of improving the soil, they persist in keeping
+up the pasture lands, however depreciated they may be in value, and
+the lazy borough, growing away from the plain, has naturally spread
+riverwards. It is seem from afar sprawling along the banks like a
+cowherd taking a siesta by the water-side.
+
+At the foot of the hill beyond the bridge begins a roadway, planted with
+young aspens, that leads in a straight line to the first houses in the
+place. These, fenced in by hedges, are in the middle of courtyards
+full of straggling buildings, wine-presses, cart-sheds and distilleries
+scattered under thick trees, with ladders, poles, or scythes hung on to
+the branches. The thatched roofs, like fur caps drawn over eyes, reach
+down over about a third of the low windows, whose coarse convex glasses
+have knots in the middle like the bottoms of bottles. Against the
+plaster wall diagonally crossed by black joists, a meagre pear-tree
+sometimes leans and the ground-floors have at their door a small
+swing-gate to keep out the chicks that come pilfering crumbs of bread
+steeped in cider on the threshold. But the courtyards grow narrower,
+the houses closer together, and the fences disappear; a bundle of
+ferns swings under a window from the end of a broomstick; there is a
+blacksmith’s forge and then a wheelwright’s, with two or three new carts
+outside that partly block the way. Then across an open space appears a
+white house beyond a grass mound ornamented by a Cupid, his finger
+on his lips; two brass vases are at each end of a flight of steps;
+scutcheons* blaze upon the door. It is the notary’s house, and the
+finest in the place.
+
+     *The panonceaux that have to be hung over the doors of
+     notaries.
+
+The Church is on the other side of the street, twenty paces farther
+down, at the entrance of the square. The little cemetery that surrounds
+it, closed in by a wall breast high, is so full of graves that the old
+stones, level with the ground, form a continuous pavement, on which the
+grass of itself has marked out regular green squares. The church was
+rebuilt during the last years of the reign of Charles X. The wooden roof
+is beginning to rot from the top, and here and there has black hollows
+in its blue colour. Over the door, where the organ should be, is a
+loft for the men, with a spiral staircase that reverberates under their
+wooden shoes.
+
+The daylight coming through the plain glass windows falls obliquely upon
+the pews ranged along the walls, which are adorned here and there with
+a straw mat bearing beneath it the words in large letters, “Mr.
+So-and-so’s pew.” Farther on, at a spot where the building narrows, the
+confessional forms a pendant to a statuette of the Virgin, clothed in
+a satin robe, coifed with a tulle veil sprinkled with silver stars, and
+with red cheeks, like an idol of the Sandwich Islands; and, finally, a
+copy of the “Holy Family, presented by the Minister of the Interior,”
+ overlooking the high altar, between four candlesticks, closes in the
+perspective. The choir stalls, of deal wood, have been left unpainted.
+
+The market, that is to say, a tiled roof supported by some twenty posts,
+occupies of itself about half the public square of Yonville. The town
+hall, constructed “from the designs of a Paris architect,” is a sort of
+Greek temple that forms the corner next to the chemist’s shop. On
+the ground-floor are three Ionic columns and on the first floor a
+semicircular gallery, while the dome that crowns it is occupied by a
+Gallic cock, resting one foot upon the “Charte” and holding in the other
+the scales of Justice.
+
+But that which most attracts the eye is opposite the Lion d’Or inn, the
+chemist’s shop of Monsieur Homais. In the evening especially its argand
+lamp is lit up and the red and green jars that embellish his shop-front
+throw far across the street their two streams of colour; then across
+them as if in Bengal lights is seen the shadow of the chemist
+leaning over his desk. His house from top to bottom is placarded with
+inscriptions written in large hand, round hand, printed hand: “Vichy,
+Seltzer, Barege waters, blood purifiers, Raspail patent medicine,
+Arabian racahout, Darcet lozenges, Regnault paste, trusses, baths,
+hygienic chocolate,” etc. And the signboard, which takes up all the
+breadth of the shop, bears in gold letters, “Homais, Chemist.” Then at
+the back of the shop, behind the great scales fixed to the counter, the
+word “Laboratory” appears on a scroll above a glass door, which about
+half-way up once more repeats “Homais” in gold letters on a black
+ground.
+
+Beyond this there is nothing to see at Yonville. The street (the only
+one) a gunshot in length and flanked by a few shops on either side stops
+short at the turn of the highroad. If it is left on the right hand and
+the foot of the Saint-Jean hills followed the cemetery is soon reached.
+
+At the time of the cholera, in order to enlarge this, a piece of wall
+was pulled down, and three acres of land by its side purchased; but all
+the new portion is almost tenantless; the tombs, as heretofore,
+continue to crowd together towards the gate. The keeper, who is at once
+gravedigger and church beadle (thus making a double profit out of the
+parish corpses), has taken advantage of the unused plot of ground to
+plant potatoes there. From year to year, however, his small field grows
+smaller, and when there is an epidemic, he does not know whether to
+rejoice at the deaths or regret the burials.
+
+“You live on the dead, Lestiboudois!” the curie at last said to him one
+day. This grim remark made him reflect; it checked him for some time;
+but to this day he carries on the cultivation of his little tubers, and
+even maintains stoutly that they grow naturally.
+
+Since the events about to be narrated, nothing in fact has changed
+at Yonville. The tin tricolour flag still swings at the top of the
+church-steeple; the two chintz streamers still flutter in the wind from
+the linen-draper’s; the chemist’s fetuses, like lumps of white amadou,
+rot more and more in their turbid alcohol, and above the big door of
+the inn the old golden lion, faded by rain, still shows passers-by its
+poodle mane.
+
+On the evening when the Bovarys were to arrive at Yonville, Widow
+Lefrancois, the landlady of this inn, was so very busy that she sweated
+great drops as she moved her saucepans. To-morrow was market-day. The
+meat had to be cut beforehand, the fowls drawn, the soup and coffee
+made. Moreover, she had the boarders’ meal to see to, and that of the
+doctor, his wife, and their servant; the billiard-room was echoing with
+bursts of laughter; three millers in a small parlour were calling for
+brandy; the wood was blazing, the brazen pan was hissing, and on the
+long kitchen table, amid the quarters of raw mutton, rose piles of
+plates that rattled with the shaking of the block on which spinach was
+being chopped.
+
+From the poultry-yard was heard the screaming of the fowls whom the
+servant was chasing in order to wring their necks.
+
+A man slightly marked with small-pox, in green leather slippers, and
+wearing a velvet cap with a gold tassel, was warming his back at the
+chimney. His face expressed nothing but self-satisfaction, and he
+appeared to take life as calmly as the goldfinch suspended over his head
+in its wicker cage: this was the chemist.
+
+“Artemise!” shouted the landlady, “chop some wood, fill the water
+bottles, bring some brandy, look sharp! If only I knew what dessert to
+offer the guests you are expecting! Good heavens! Those furniture-movers
+are beginning their racket in the billiard-room again; and their van has
+been left before the front door! The ‘Hirondelle’ might run into it when
+it draws up. Call Polyte and tell him to put it up. Only think, Monsieur
+Homais, that since morning they have had about fifteen games, and drunk
+eight jars of cider! Why, they’ll tear my cloth for me,” she went on,
+looking at them from a distance, her strainer in her hand.
+
+“That wouldn’t be much of a loss,” replied Monsieur Homais. “You would
+buy another.”
+
+“Another billiard-table!” exclaimed the widow.
+
+“Since that one is coming to pieces, Madame Lefrancois. I tell you again
+you are doing yourself harm, much harm! And besides, players now want
+narrow pockets and heavy cues. Hazards aren’t played now; everything is
+changed! One must keep pace with the times! Just look at Tellier!”
+
+The hostess reddened with vexation. The chemist went on--
+
+“You may say what you like; his table is better than yours; and if one
+were to think, for example, of getting up a patriotic pool for Poland or
+the sufferers from the Lyons floods--”
+
+“It isn’t beggars like him that’ll frighten us,” interrupted the
+landlady, shrugging her fat shoulders. “Come, come, Monsieur Homais; as
+long as the ‘Lion d’Or’ exists people will come to it. We’ve feathered
+our nest; while one of these days you’ll find the ‘Cafe Francais’ closed
+with a big placard on the shutters. Change my billiard-table!” she went
+on, speaking to herself, “the table that comes in so handy for folding
+the washing, and on which, in the hunting season, I have slept six
+visitors! But that dawdler, Hivert, doesn’t come!”
+
+“Are you waiting for him for your gentlemen’s dinner?”
+
+“Wait for him! And what about Monsieur Binet? As the clock strikes
+six you’ll see him come in, for he hasn’t his equal under the sun for
+punctuality. He must always have his seat in the small parlour. He’d
+rather die than dine anywhere else. And so squeamish as he is, and so
+particular about the cider! Not like Monsieur Leon; he sometimes comes
+at seven, or even half-past, and he doesn’t so much as look at what he
+eats. Such a nice young man! Never speaks a rough word!”
+
+“Well, you see, there’s a great difference between an educated man and
+an old carabineer who is now a tax-collector.”
+
+Six o’clock struck. Binet came in.
+
+He wore a blue frock-coat falling in a straight line round his thin
+body, and his leather cap, with its lappets knotted over the top of
+his head with string, showed under the turned-up peak a bald forehead,
+flattened by the constant wearing of a helmet. He wore a black cloth
+waistcoat, a hair collar, grey trousers, and, all the year round,
+well-blacked boots, that had two parallel swellings due to the sticking
+out of his big-toes. Not a hair stood out from the regular line of fair
+whiskers, which, encircling his jaws, framed, after the fashion of a
+garden border, his long, wan face, whose eyes were small and the nose
+hooked. Clever at all games of cards, a good hunter, and writing a
+fine hand, he had at home a lathe, and amused himself by turning napkin
+rings, with which he filled up his house, with the jealousy of an artist
+and the egotism of a bourgeois.
+
+He went to the small parlour, but the three millers had to be got out
+first, and during the whole time necessary for laying the cloth, Binet
+remained silent in his place near the stove. Then he shut the door and
+took off his cap in his usual way.
+
+“It isn’t with saying civil things that he’ll wear out his tongue,” said
+the chemist, as soon as he was along with the landlady.
+
+“He never talks more,” she replied. “Last week two travelers in the
+cloth line were here--such clever chaps who told such jokes in the
+evening, that I fairly cried with laughing; and he stood there like a
+dab fish and never said a word.”
+
+“Yes,” observed the chemist; “no imagination, no sallies, nothing that
+makes the society-man.”
+
+“Yet they say he has parts,” objected the landlady.
+
+“Parts!” replied Monsieur Homais; “he, parts! In his own line it is
+possible,” he added in a calmer tone. And he went on--
+
+“Ah! That a merchant, who has large connections, a jurisconsult, a
+doctor, a chemist, should be thus absent-minded, that they should become
+whimsical or even peevish, I can understand; such cases are cited in
+history. But at least it is because they are thinking of something.
+Myself, for example, how often has it happened to me to look on the
+bureau for my pen to write a label, and to find, after all, that I had
+put it behind my ear!”
+
+Madame Lefrancois just then went to the door to see if the “Hirondelle”
+ were not coming. She started. A man dressed in black suddenly came into
+the kitchen. By the last gleam of the twilight one could see that his
+face was rubicund and his form athletic.
+
+“What can I do for you, Monsieur le Curie?” asked the landlady, as she
+reached down from the chimney one of the copper candlesticks placed
+with their candles in a row. “Will you take something? A thimbleful of
+Cassis*? A glass of wine?”
+
+     *Black currant liqueur.
+
+The priest declined very politely. He had come for his umbrella, that
+he had forgotten the other day at the Ernemont convent, and after
+asking Madame Lefrancois to have it sent to him at the presbytery in the
+evening, he left for the church, from which the Angelus was ringing.
+
+When the chemist no longer heard the noise of his boots along the
+square, he thought the priest’s behaviour just now very unbecoming. This
+refusal to take any refreshment seemed to him the most odious hypocrisy;
+all priests tippled on the sly, and were trying to bring back the days
+of the tithe.
+
+The landlady took up the defence of her curie.
+
+“Besides, he could double up four men like you over his knee. Last year
+he helped our people to bring in the straw; he carried as many as six
+trusses at once, he is so strong.”
+
+“Bravo!” said the chemist. “Now just send your daughters to confess to
+fellows which such a temperament! I, if I were the Government, I’d have
+the priests bled once a month. Yes, Madame Lefrancois, every month--a
+good phlebotomy, in the interests of the police and morals.”
+
+“Be quiet, Monsieur Homais. You are an infidel; you’ve no religion.”
+
+The chemist answered: “I have a religion, my religion, and I even have
+more than all these others with their mummeries and their juggling.
+I adore God, on the contrary. I believe in the Supreme Being, in a
+Creator, whatever he may be. I care little who has placed us here below
+to fulfil our duties as citizens and fathers of families; but I don’t
+need to go to church to kiss silver plates, and fatten, out of my
+pocket, a lot of good-for-nothings who live better than we do. For one
+can know Him as well in a wood, in a field, or even contemplating the
+eternal vault like the ancients. My God! Mine is the God of Socrates, of
+Franklin, of Voltaire, and of Beranger! I am for the profession of faith
+of the ‘Savoyard Vicar,’ and the immortal principles of ‘89! And I can’t
+admit of an old boy of a God who takes walks in his garden with a
+cane in his hand, who lodges his friends in the belly of whales, dies
+uttering a cry, and rises again at the end of three days; things absurd
+in themselves, and completely opposed, moreover, to all physical laws,
+which prove to us, by the way, that priests have always wallowed in
+turpid ignorance, in which they would fain engulf the people with them.”
+
+He ceased, looking round for an audience, for in his bubbling over
+the chemist had for a moment fancied himself in the midst of the town
+council. But the landlady no longer heeded him; she was listening to a
+distant rolling. One could distinguish the noise of a carriage mingled
+with the clattering of loose horseshoes that beat against the ground,
+and at last the “Hirondelle” stopped at the door.
+
+It was a yellow box on two large wheels, that, reaching to the tilt,
+prevented travelers from seeing the road and dirtied their shoulders.
+The small panes of the narrow windows rattled in their sashes when the
+coach was closed, and retained here and there patches of mud amid the
+old layers of dust, that not even storms of rain had altogether washed
+away. It was drawn by three horses, the first a leader, and when it came
+down-hill its bottom jolted against the ground.
+
+Some of the inhabitants of Yonville came out into the square; they all
+spoke at once, asking for news, for explanations, for hampers. Hivert
+did not know whom to answer. It was he who did the errands of the place
+in town. He went to the shops and brought back rolls of leather for
+the shoemaker, old iron for the farrier, a barrel of herrings for his
+mistress, caps from the milliner’s, locks from the hair-dresser’s and
+all along the road on his return journey he distributed his parcels,
+which he threw, standing upright on his seat and shouting at the top of
+his voice, over the enclosures of the yards.
+
+An accident had delayed him. Madame Bovary’s greyhound had run across
+the field. They had whistled for him a quarter of an hour; Hivert had
+even gone back a mile and a half expecting every moment to catch sight
+of her; but it had been necessary to go on.
+
+Emma had wept, grown angry; she had accused Charles of this misfortune.
+Monsieur Lheureux, a draper, who happened to be in the coach with
+her, had tried to console her by a number of examples of lost dogs
+recognizing their masters at the end of long years. One, he said had
+been told of, who had come back to Paris from Constantinople. Another
+had gone one hundred and fifty miles in a straight line, and swum four
+rivers; and his own father had possessed a poodle, which, after twelve
+years of absence, had all of a sudden jumped on his back in the street
+as he was going to dine in town.
+
+
+
+Chapter Two
+
+Emma got out first, then Felicite, Monsieur Lheureux, and a nurse, and
+they had to wake up Charles in his corner, where he had slept soundly
+since night set in.
+
+Homais introduced himself; he offered his homages to madame and his
+respects to monsieur; said he was charmed to have been able to render
+them some slight service, and added with a cordial air that he had
+ventured to invite himself, his wife being away.
+
+When Madame Bovary was in the kitchen she went up to the chimney.
+
+With the tips of her fingers she caught her dress at the knee, and
+having thus pulled it up to her ankle, held out her foot in its black
+boot to the fire above the revolving leg of mutton. The flame lit up the
+whole of her, penetrating with a crude light the woof of her gowns, the
+fine pores of her fair skin, and even her eyelids, which she blinked now
+and again. A great red glow passed over her with the blowing of the wind
+through the half-open door.
+
+On the other side of the chimney a young man with fair hair watched her
+silently.
+
+As he was a good deal bored at Yonville, where he was a clerk at the
+notary’s, Monsieur Guillaumin, Monsieur Leon Dupuis (it was he who
+was the second habitue of the “Lion d’Or”) frequently put back his
+dinner-hour in hope that some traveler might come to the inn, with whom
+he could chat in the evening. On the days when his work was done early,
+he had, for want of something else to do, to come punctually, and endure
+from soup to cheese a tete-a-tete with Binet. It was therefore with
+delight that he accepted the landlady’s suggestion that he should dine
+in company with the newcomers, and they passed into the large parlour
+where Madame Lefrancois, for the purpose of showing off, had had the
+table laid for four.
+
+Homais asked to be allowed to keep on his skull-cap, for fear of coryza;
+then, turning to his neighbour--
+
+“Madame is no doubt a little fatigued; one gets jolted so abominably in
+our ‘Hirondelle.’”
+
+“That is true,” replied Emma; “but moving about always amuses me. I like
+change of place.”
+
+“It is so tedious,” sighed the clerk, “to be always riveted to the same
+places.”
+
+“If you were like me,” said Charles, “constantly obliged to be in the
+saddle”--
+
+“But,” Leon went on, addressing himself to Madame Bovary, “nothing, it
+seems to me, is more pleasant--when one can,” he added.
+
+“Moreover,” said the druggist, “the practice of medicine is not very
+hard work in our part of the world, for the state of our roads allows us
+the use of gigs, and generally, as the farmers are prosperous, they pay
+pretty well. We have, medically speaking, besides the ordinary cases
+of enteritis, bronchitis, bilious affections, etc., now and then a
+few intermittent fevers at harvest-time; but on the whole, little of a
+serious nature, nothing special to note, unless it be a great deal of
+scrofula, due, no doubt, to the deplorable hygienic conditions of our
+peasant dwellings. Ah! you will find many prejudices to combat, Monsieur
+Bovary, much obstinacy of routine, with which all the efforts of your
+science will daily come into collision; for people still have recourse
+to novenas, to relics, to the priest, rather than come straight to the
+doctor or the chemist. The climate, however, is not, truth to tell, bad,
+and we even have a few nonagenarians in our parish. The thermometer (I
+have made some observations) falls in winter to 4 degrees Centigrade
+at the outside, which gives us 24 degrees Reaumur as the maximum, or
+otherwise 54 degrees Fahrenheit (English scale), not more. And, as a
+matter of fact, we are sheltered from the north winds by the forest of
+Argueil on the one side, from the west winds by the St. Jean range on
+the other; and this heat, moreover, which, on account of the aqueous
+vapours given off by the river and the considerable number of cattle
+in the fields, which, as you know, exhale much ammonia, that is to say,
+nitrogen, hydrogen and oxygen (no, nitrogen and hydrogen alone), and
+which sucking up into itself the humus from the ground, mixing together
+all those different emanations, unites them into a stack, so to say,
+and combining with the electricity diffused through the atmosphere, when
+there is any, might in the long run, as in tropical countries, engender
+insalubrious miasmata--this heat, I say, finds itself perfectly tempered
+on the side whence it comes, or rather whence it should come--that is to
+say, the southern side--by the south-eastern winds, which, having cooled
+themselves passing over the Seine, reach us sometimes all at once like
+breezes from Russia.”
+
+“At any rate, you have some walks in the neighbourhood?” continued
+Madame Bovary, speaking to the young man.
+
+“Oh, very few,” he answered. “There is a place they call La Pature, on
+the top of the hill, on the edge of the forest. Sometimes, on Sundays, I
+go and stay there with a book, watching the sunset.”
+
+“I think there is nothing so admirable as sunsets,” she resumed; “but
+especially by the side of the sea.”
+
+“Oh, I adore the sea!” said Monsieur Leon.
+
+“And then, does it not seem to you,” continued Madame Bovary, “that the
+mind travels more freely on this limitless expanse, the contemplation of
+which elevates the soul, gives ideas of the infinite, the ideal?”
+
+“It is the same with mountainous landscapes,” continued Leon. “A cousin
+of mine who travelled in Switzerland last year told me that one could
+not picture to oneself the poetry of the lakes, the charm of the
+waterfalls, the gigantic effect of the glaciers. One sees pines of
+incredible size across torrents, cottages suspended over precipices,
+and, a thousand feet below one, whole valleys when the clouds open. Such
+spectacles must stir to enthusiasm, incline to prayer, to ecstasy; and I
+no longer marvel at that celebrated musician who, the better to inspire
+his imagination, was in the habit of playing the piano before some
+imposing site.”
+
+“You play?” she asked.
+
+“No, but I am very fond of music,” he replied.
+
+“Ah! don’t you listen to him, Madame Bovary,” interrupted Homais,
+bending over his plate. “That’s sheer modesty. Why, my dear fellow, the
+other day in your room you were singing ‘L’Ange Gardien’ ravishingly. I
+heard you from the laboratory. You gave it like an actor.”
+
+Leon, in fact, lodged at the chemist’s where he had a small room on the
+second floor, overlooking the Place. He blushed at the compliment of his
+landlord, who had already turned to the doctor, and was enumerating to
+him, one after the other, all the principal inhabitants of Yonville. He
+was telling anecdotes, giving information; the fortune of the notary
+was not known exactly, and “there was the Tuvache household,” who made a
+good deal of show.
+
+Emma continued, “And what music do you prefer?”
+
+“Oh, German music; that which makes you dream.”
+
+“Have you been to the opera?”
+
+“Not yet; but I shall go next year, when I am living at Paris to finish
+reading for the bar.”
+
+“As I had the honour of putting it to your husband,” said the chemist,
+“with regard to this poor Yanoda who has run away, you will find
+yourself, thanks to his extravagance, in the possession of one of the
+most comfortable houses of Yonville. Its greatest convenience for a
+doctor is a door giving on the Walk, where one can go in and out unseen.
+Moreover, it contains everything that is agreeable in a household--a
+laundry, kitchen with offices, sitting-room, fruit-room, and so on. He
+was a gay dog, who didn’t care what he spent. At the end of the garden,
+by the side of the water, he had an arbour built just for the purpose of
+drinking beer in summer; and if madame is fond of gardening she will be
+able--”
+
+“My wife doesn’t care about it,” said Charles; “although she has
+been advised to take exercise, she prefers always sitting in her room
+reading.”
+
+“Like me,” replied Leon. “And indeed, what is better than to sit by
+one’s fireside in the evening with a book, while the wind beats against
+the window and the lamp is burning?”
+
+“What, indeed?” she said, fixing her large black eyes wide open upon
+him.
+
+“One thinks of nothing,” he continued; “the hours slip by. Motionless we
+traverse countries we fancy we see, and your thought, blending with
+the fiction, playing with the details, follows the outline of the
+adventures. It mingles with the characters, and it seems as if it were
+yourself palpitating beneath their costumes.”
+
+“That is true! That is true?” she said.
+
+“Has it ever happened to you,” Leon went on, “to come across some vague
+idea of one’s own in a book, some dim image that comes back to you from
+afar, and as the completest expression of your own slightest sentiment?”
+
+“I have experienced it,” she replied.
+
+“That is why,” he said, “I especially love the poets. I think verse more
+tender than prose, and that it moves far more easily to tears.”
+
+“Still in the long run it is tiring,” continued Emma. “Now I, on the
+contrary, adore stories that rush breathlessly along, that frighten one.
+I detest commonplace heroes and moderate sentiments, such as there are
+in nature.”
+
+“In fact,” observed the clerk, “these works, not touching the heart,
+miss, it seems to me, the true end of art. It is so sweet, amid all
+the disenchantments of life, to be able to dwell in thought upon noble
+characters, pure affections, and pictures of happiness. For myself,
+living here far from the world, this is my one distraction; but Yonville
+affords so few resources.”
+
+“Like Tostes, no doubt,” replied Emma; “and so I always subscribed to a
+lending library.”
+
+“If madame will do me the honour of making use of it”, said the chemist,
+who had just caught the last words, “I have at her disposal a library
+composed of the best authors, Voltaire, Rousseau, Delille, Walter
+Scott, the ‘Echo des Feuilletons’; and in addition I receive various
+periodicals, among them the ‘Fanal de Rouen’ daily, having the advantage
+to be its correspondent for the districts of Buchy, Forges, Neufchatel,
+Yonville, and vicinity.”
+
+For two hours and a half they had been at table; for the servant
+Artemis, carelessly dragging her old list slippers over the flags,
+brought one plate after the other, forgot everything, and constantly
+left the door of the billiard-room half open, so that it beat against
+the wall with its hooks.
+
+Unconsciously, Leon, while talking, had placed his foot on one of the
+bars of the chair on which Madame Bovary was sitting. She wore a small
+blue silk necktie, that kept up like a ruff a gauffered cambric collar,
+and with the movements of her head the lower part of her face gently
+sunk into the linen or came out from it. Thus side by side, while
+Charles and the chemist chatted, they entered into one of those vague
+conversations where the hazard of all that is said brings you back to
+the fixed centre of a common sympathy. The Paris theatres, titles of
+novels, new quadrilles, and the world they did not know; Tostes, where
+she had lived, and Yonville, where they were; they examined all, talked
+of everything till to the end of dinner.
+
+When coffee was served Felicite went away to get ready the room in the
+new house, and the guests soon raised the siege. Madame Lefrancois was
+asleep near the cinders, while the stable-boy, lantern in hand, was
+waiting to show Monsieur and Madame Bovary the way home. Bits of straw
+stuck in his red hair, and he limped with his left leg. When he had
+taken in his other hand the cure’s umbrella, they started.
+
+The town was asleep; the pillars of the market threw great shadows; the
+earth was all grey as on a summer’s night. But as the doctor’s house was
+only some fifty paces from the inn, they had to say good-night almost
+immediately, and the company dispersed.
+
+As soon as she entered the passage, Emma felt the cold of the plaster
+fall about her shoulders like damp linen. The walls were new and the
+wooden stairs creaked. In their bedroom, on the first floor, a whitish
+light passed through the curtainless windows.
+
+She could catch glimpses of tree tops, and beyond, the fields,
+half-drowned in the fog that lay reeking in the moonlight along
+the course of the river. In the middle of the room, pell-mell, were
+scattered drawers, bottles, curtain-rods, gilt poles, with mattresses
+on the chairs and basins on the ground--the two men who had brought the
+furniture had left everything about carelessly.
+
+This was the fourth time that she had slept in a strange place.
+
+The first was the day of her going to the convent; the second, of her
+arrival at Tostes; the third, at Vaubyessard; and this was the fourth.
+And each one had marked, as it were, the inauguration of a new phase in
+her life. She did not believe that things could present themselves in
+the same way in different places, and since the portion of her life
+lived had been bad, no doubt that which remained to be lived would be
+better.
+
+
+
+Chapter Three
+
+The next day, as she was getting up, she saw the clerk on the Place. She
+had on a dressing-gown. He looked up and bowed. She nodded quickly and
+reclosed the window.
+
+Leon waited all day for six o’clock in the evening to come, but on going
+to the inn, he found no one but Monsieur Binet, already at table. The
+dinner of the evening before had been a considerable event for him; he
+had never till then talked for two hours consecutively to a “lady.” How
+then had he been able to explain, and in such language, the number of
+things that he could not have said so well before? He was usually
+shy, and maintained that reserve which partakes at once of modesty and
+dissimulation.
+
+At Yonville he was considered “well-bred.” He listened to the arguments
+of the older people, and did not seem hot about politics--a remarkable
+thing for a young man. Then he had some accomplishments; he painted in
+water-colours, could read the key of G, and readily talked literature
+after dinner when he did not play cards. Monsieur Homais respected him
+for his education; Madame Homais liked him for his good-nature, for
+he often took the little Homais into the garden--little brats who were
+always dirty, very much spoilt, and somewhat lymphatic, like their
+mother. Besides the servant to look after them, they had Justin, the
+chemist’s apprentice, a second cousin of Monsieur Homais, who had been
+taken into the house from charity, and who was useful at the same time
+as a servant.
+
+The druggist proved the best of neighbours. He gave Madame Bovary
+information as to the trades-people, sent expressly for his own cider
+merchant, tasted the drink himself, and saw that the casks were properly
+placed in the cellar; he explained how to set about getting in a
+supply of butter cheap, and made an arrangement with Lestiboudois, the
+sacristan, who, besides his sacerdotal and funeral functions, looked
+after the principal gardens at Yonville by the hour or the year,
+according to the taste of the customers.
+
+The need of looking after others was not the only thing that urged the
+chemist to such obsequious cordiality; there was a plan underneath it
+all.
+
+He had infringed the law of the 19th Ventose, year xi., article I, which
+forbade all persons not having a diploma to practise medicine; so that,
+after certain anonymous denunciations, Homais had been summoned to Rouen
+to see the procurer of the king in his own private room; the magistrate
+receiving him standing up, ermine on shoulder and cap on head. It was
+in the morning, before the court opened. In the corridors one heard
+the heavy boots of the gendarmes walking past, and like a far-off noise
+great locks that were shut. The druggist’s ears tingled as if he were
+about to have an apoplectic stroke; he saw the depths of dungeons,
+his family in tears, his shop sold, all the jars dispersed; and he was
+obliged to enter a cafe and take a glass of rum and seltzer to recover
+his spirits.
+
+Little by little the memory of this reprimand grew fainter, and
+he continued, as heretofore, to give anodyne consultations in his
+back-parlour. But the mayor resented it, his colleagues were jealous,
+everything was to be feared; gaining over Monsieur Bovary by his
+attentions was to earn his gratitude, and prevent his speaking out later
+on, should he notice anything. So every morning Homais brought him “the
+paper,” and often in the afternoon left his shop for a few moments to
+have a chat with the Doctor.
+
+Charles was dull: patients did not come. He remained seated for hours
+without speaking, went into his consulting room to sleep, or watched
+his wife sewing. Then for diversion he employed himself at home as a
+workman; he even tried to do up the attic with some paint which had been
+left behind by the painters. But money matters worried him. He had
+spent so much for repairs at Tostes, for madame’s toilette, and for the
+moving, that the whole dowry, over three thousand crowns, had slipped
+away in two years.
+
+Then how many things had been spoilt or lost during their carriage from
+Tostes to Yonville, without counting the plaster cure, who falling out
+of the coach at an over-severe jolt, had been dashed into a thousand
+fragments on the pavements of Quincampoix! A pleasanter trouble came
+to distract him, namely, the pregnancy of his wife. As the time of her
+confinement approached he cherished her the more. It was another bond of
+the flesh establishing itself, and, as it were, a continued sentiment
+of a more complex union. When from afar he saw her languid walk, and
+her figure without stays turning softly on her hips; when opposite one
+another he looked at her at his ease, while she took tired poses in her
+armchair, then his happiness knew no bounds; he got up, embraced her,
+passed his hands over her face, called her little mamma, wanted to
+make her dance, and half-laughing, half-crying, uttered all kinds of
+caressing pleasantries that came into his head. The idea of having
+begotten a child delighted him. Now he wanted nothing. He knew human
+life from end to end, and he sat down to it with serenity.
+
+Emma at first felt a great astonishment; then was anxious to be
+delivered that she might know what it was to be a mother. But not
+being able to spend as much as she would have liked, to have a
+swing-bassinette with rose silk curtains, and embroidered caps, in a fit
+of bitterness she gave up looking after the trousseau, and ordered the
+whole of it from a village needlewoman, without choosing or discussing
+anything. Thus she did not amuse herself with those preparations that
+stimulate the tenderness of mothers, and so her affection was from the
+very outset, perhaps, to some extent attenuated.
+
+As Charles, however, spoke of the boy at every meal, she soon began to
+think of him more consecutively.
+
+She hoped for a son; he would be strong and dark; she would call him
+George; and this idea of having a male child was like an expected
+revenge for all her impotence in the past. A man, at least, is free; he
+may travel over passions and over countries, overcome obstacles, taste
+of the most far-away pleasures. But a woman is always hampered. At once
+inert and flexible, she has against her the weakness of the flesh and
+legal dependence. Her will, like the veil of her bonnet, held by a
+string, flutters in every wind; there is always some desire that draws
+her, some conventionality that restrains.
+
+She was confined on a Sunday at about six o’clock, as the sun was
+rising.
+
+“It is a girl!” said Charles.
+
+She turned her head away and fainted.
+
+Madame Homais, as well as Madame Lefrancois of the Lion d’Or, almost
+immediately came running in to embrace her. The chemist, as man of
+discretion, only offered a few provincial felicitations through the
+half-opened door. He wished to see the child and thought it well made.
+
+Whilst she was getting well she occupied herself much in seeking a
+name for her daughter. First she went over all those that have Italian
+endings, such as Clara, Louisa, Amanda, Atala; she liked Galsuinde
+pretty well, and Yseult or Leocadie still better.
+
+Charles wanted the child to be called after her mother; Emma opposed
+this. They ran over the calendar from end to end, and then consulted
+outsiders.
+
+“Monsieur Leon,” said the chemist, “with whom I was talking about it
+the other day, wonders you do not chose Madeleine. It is very much in
+fashion just now.”
+
+But Madame Bovary, senior, cried out loudly against this name of a
+sinner. As to Monsieur Homais, he had a preference for all those that
+recalled some great man, an illustrious fact, or a generous idea, and it
+was on this system that he had baptized his four children. Thus Napoleon
+represented glory and Franklin liberty; Irma was perhaps a concession to
+romanticism, but Athalie was a homage to the greatest masterpiece of the
+French stage. For his philosophical convictions did not interfere
+with his artistic tastes; in him the thinker did not stifle the man of
+sentiment; he could make distinctions, make allowances for imagination
+and fanaticism. In this tragedy, for example, he found fault with the
+ideas, but admired the style; he detested the conception, but applauded
+all the details, and loathed the characters while he grew enthusiastic
+over their dialogue. When he read the fine passages he was transported,
+but when he thought that mummers would get something out of them for
+their show, he was disconsolate; and in this confusion of sentiments in
+which he was involved he would have liked at once to crown Racine with
+both his hands and discuss with him for a good quarter of an hour.
+
+At last Emma remembered that at the chateau of Vaubyessard she had heard
+the Marchioness call a young lady Berthe; from that moment this name was
+chosen; and as old Rouault could not come, Monsieur Homais was requested
+to stand godfather. His gifts were all products from his establishment,
+to wit: six boxes of jujubes, a whole jar of racahout, three cakes of
+marshmallow paste, and six sticks of sugar-candy into the bargain that
+he had come across in a cupboard. On the evening of the ceremony there
+was a grand dinner; the cure was present; there was much excitement.
+Monsieur Homais towards liqueur-time began singing “Le Dieu des bonnes
+gens.” Monsieur Leon sang a barcarolle, and Madame Bovary, senior, who
+was godmother, a romance of the time of the Empire; finally, M. Bovary,
+senior, insisted on having the child brought down, and began baptizing
+it with a glass of champagne that he poured over its head. This mockery
+of the first of the sacraments made the Abbe Bournisien angry; old
+Bovary replied by a quotation from “La Guerre des Dieux”; the cure
+wanted to leave; the ladies implored, Homais interfered; and they
+succeeded in making the priest sit down again, and he quietly went on
+with the half-finished coffee in his saucer.
+
+Monsieur Bovary, senior, stayed at Yonville a month, dazzling the
+natives by a superb policeman’s cap with silver tassels that he wore
+in the morning when he smoked his pipe in the square. Being also in the
+habit of drinking a good deal of brandy, he often sent the servant
+to the Lion d’Or to buy him a bottle, which was put down to his
+son’s account, and to perfume his handkerchiefs he used up his
+daughter-in-law’s whole supply of eau-de-cologne.
+
+The latter did not at all dislike his company. He had knocked about the
+world, he talked about Berlin, Vienna, and Strasbourg, of his soldier
+times, of the mistresses he had had, the grand luncheons of which he had
+partaken; then he was amiable, and sometimes even, either on the stairs,
+or in the garden, would seize hold of her waist, crying, “Charles, look
+out for yourself.”
+
+Then Madame Bovary, senior, became alarmed for her son’s happiness, and
+fearing that her husband might in the long-run have an immoral influence
+upon the ideas of the young woman, took care to hurry their departure.
+Perhaps she had more serious reasons for uneasiness. Monsieur Bovary was
+not the man to respect anything.
+
+One day Emma was suddenly seized with the desire to see her little
+girl, who had been put to nurse with the carpenter’s wife, and, without
+looking at the calendar to see whether the six weeks of the Virgin were
+yet passed, she set out for the Rollets’ house, situated at the extreme
+end of the village, between the highroad and the fields.
+
+It was mid-day, the shutters of the houses were closed and the slate
+roofs that glittered beneath the fierce light of the blue sky seemed to
+strike sparks from the crest of the gables. A heavy wind was blowing;
+Emma felt weak as she walked; the stones of the pavement hurt her; she
+was doubtful whether she would not go home again, or go in somewhere to
+rest.
+
+At this moment Monsieur Leon came out from a neighbouring door with a
+bundle of papers under his arm. He came to greet her, and stood in the
+shade in front of the Lheureux’s shop under the projecting grey awning.
+
+Madame Bovary said she was going to see her baby, but that she was
+beginning to grow tired.
+
+“If--” said Leon, not daring to go on.
+
+“Have you any business to attend to?” she asked.
+
+And on the clerk’s answer, she begged him to accompany her. That same
+evening this was known in Yonville, and Madame Tuvache, the mayor’s
+wife, declared in the presence of her servant that “Madame Bovary was
+compromising herself.”
+
+To get to the nurse’s it was necessary to turn to the left on leaving
+the street, as if making for the cemetery, and to follow between little
+houses and yards a small path bordered with privet hedges. They were
+in bloom, and so were the speedwells, eglantines, thistles, and the
+sweetbriar that sprang up from the thickets. Through openings in
+the hedges one could see into the huts, some pigs on a dung-heap, or
+tethered cows rubbing their horns against the trunk of trees. The two,
+side by side walked slowly, she leaning upon him, and he restraining
+his pace, which he regulated by hers; in front of them a swarm of midges
+fluttered, buzzing in the warm air.
+
+They recognized the house by an old walnut-tree which shaded it.
+
+Low and covered with brown tiles, there hung outside it, beneath the
+dormer-window of the garret, a string of onions. Faggots upright
+against a thorn fence surrounded a bed of lettuce, a few square feet of
+lavender, and sweet peas strung on sticks. Dirty water was running here
+and there on the grass, and all round were several indefinite rags,
+knitted stockings, a red calico jacket, and a large sheet of coarse
+linen spread over the hedge. At the noise of the gate the nurse appeared
+with a baby she was suckling on one arm. With her other hand she was
+pulling along a poor puny little fellow, his face covered with scrofula,
+the son of a Rouen hosier, whom his parents, too taken up with their
+business, left in the country.
+
+“Go in,” she said; “your little one is there asleep.”
+
+The room on the ground-floor, the only one in the dwelling, had at its
+farther end, against the wall, a large bed without curtains, while a
+kneading-trough took up the side by the window, one pane of which
+was mended with a piece of blue paper. In the corner behind the door,
+shining hob-nailed shoes stood in a row under the slab of the washstand,
+near a bottle of oil with a feather stuck in its mouth; a Matthieu
+Laensberg lay on the dusty mantelpiece amid gunflints, candle-ends, and
+bits of amadou.
+
+Finally, the last luxury in the apartment was a “Fame” blowing her
+trumpets, a picture cut out, no doubt, from some perfumer’s prospectus
+and nailed to the wall with six wooden shoe-pegs.
+
+Emma’s child was asleep in a wicker-cradle. She took it up in the
+wrapping that enveloped it and began singing softly as she rocked
+herself to and fro.
+
+Leon walked up and down the room; it seemed strange to him to see this
+beautiful woman in her nankeen dress in the midst of all this poverty.
+Madam Bovary reddened; he turned away, thinking perhaps there had been
+an impertinent look in his eyes. Then she put back the little girl, who
+had just been sick over her collar.
+
+The nurse at once came to dry her, protesting that it wouldn’t show.
+
+“She gives me other doses,” she said: “I am always a-washing of her. If
+you would have the goodness to order Camus, the grocer, to let me have
+a little soap, it would really be more convenient for you, as I needn’t
+trouble you then.”
+
+“Very well! very well!” said Emma. “Good morning, Madame Rollet,” and
+she went out, wiping her shoes at the door.
+
+The good woman accompanied her to the end of the garden, talking all the
+time of the trouble she had getting up of nights.
+
+“I’m that worn out sometimes as I drop asleep on my chair. I’m sure you
+might at least give me just a pound of ground coffee; that’d last me a
+month, and I’d take it of a morning with some milk.”
+
+After having submitted to her thanks, Madam Bovary left. She had gone a
+little way down the path when, at the sound of wooden shoes, she turned
+round. It was the nurse.
+
+“What is it?”
+
+Then the peasant woman, taking her aside behind an elm tree, began
+talking to her of her husband, who with his trade and six francs a year
+that the captain--
+
+“Oh, be quick!” said Emma.
+
+“Well,” the nurse went on, heaving sighs between each word, “I’m afraid
+he’ll be put out seeing me have coffee alone, you know men--”
+
+“But you are to have some,” Emma repeated; “I will give you some. You
+bother me!”
+
+“Oh, dear! my poor, dear lady! you see in consequence of his wounds he
+has terrible cramps in the chest. He even says that cider weakens him.”
+
+“Do make haste, Mere Rollet!”
+
+“Well,” the latter continued, making a curtsey, “if it weren’t asking
+too much,” and she curtsied once more, “if you would”--and her eyes
+begged--“a jar of brandy,” she said at last, “and I’d rub your little
+one’s feet with it; they’re as tender as one’s tongue.”
+
+Once rid of the nurse, Emma again took Monsieur Leon’s arm. She walked
+fast for some time, then more slowly, and looking straight in front of
+her, her eyes rested on the shoulder of the young man, whose frock-coat
+had a black-velvety collar. His brown hair fell over it, straight and
+carefully arranged. She noticed his nails which were longer than one
+wore them at Yonville. It was one of the clerk’s chief occupations to
+trim them, and for this purpose he kept a special knife in his writing
+desk.
+
+They returned to Yonville by the water-side. In the warm season the
+bank, wider than at other times, showed to their foot the garden walls
+whence a few steps led to the river. It flowed noiselessly, swift,
+and cold to the eye; long, thin grasses huddled together in it as the
+current drove them, and spread themselves upon the limpid water like
+streaming hair; sometimes at the tip of the reeds or on the leaf of a
+water-lily an insect with fine legs crawled or rested. The sun pierced
+with a ray the small blue bubbles of the waves that, breaking, followed
+each other; branchless old willows mirrored their grey backs in
+the water; beyond, all around, the meadows seemed empty. It was the
+dinner-hour at the farms, and the young woman and her companion heard
+nothing as they walked but the fall of their steps on the earth of the
+path, the words they spoke, and the sound of Emma’s dress rustling round
+her.
+
+The walls of the gardens with pieces of bottle on their coping were
+hot as the glass windows of a conservatory. Wallflowers had sprung up
+between the bricks, and with the tip of her open sunshade Madame Bovary,
+as she passed, made some of their faded flowers crumble into a yellow
+dust, or a spray of overhanging honeysuckle and clematis caught in its
+fringe and dangled for a moment over the silk.
+
+They were talking of a troupe of Spanish dancers who were expected
+shortly at the Rouen theatre.
+
+“Are you going?” she asked.
+
+“If I can,” he answered.
+
+Had they nothing else to say to one another? Yet their eyes were full
+of more serious speech, and while they forced themselves to find trivial
+phrases, they felt the same languor stealing over them both. It was the
+whisper of the soul, deep, continuous, dominating that of their voices.
+Surprised with wonder at this strange sweetness, they did not think of
+speaking of the sensation or of seeking its cause. Coming joys, like
+tropical shores, throw over the immensity before them their inborn
+softness, an odorous wind, and we are lulled by this intoxication
+without a thought of the horizon that we do not even know.
+
+In one place the ground had been trodden down by the cattle; they had to
+step on large green stones put here and there in the mud.
+
+She often stopped a moment to look where to place her foot, and
+tottering on a stone that shook, her arms outspread, her form bent
+forward with a look of indecision, she would laugh, afraid of falling
+into the puddles of water.
+
+When they arrived in front of her garden, Madame Bovary opened the
+little gate, ran up the steps and disappeared.
+
+Leon returned to his office. His chief was away; he just glanced at the
+briefs, then cut himself a pen, and at last took up his hat and went
+out.
+
+He went to La Pature at the top of the Argueil hills at the beginning of
+the forest; he threw himself upon the ground under the pines and watched
+the sky through his fingers.
+
+“How bored I am!” he said to himself, “how bored I am!”
+
+He thought he was to be pitied for living in this village, with Homais
+for a friend and Monsieru Guillaumin for master. The latter, entirely
+absorbed by his business, wearing gold-rimmed spectacles and red
+whiskers over a white cravat, understood nothing of mental refinements,
+although he affected a stiff English manner, which in the beginning had
+impressed the clerk.
+
+As to the chemist’s spouse, she was the best wife in Normandy, gentle
+as a sheep, loving her children, her father, her mother, her cousins,
+weeping for other’s woes, letting everything go in her household, and
+detesting corsets; but so slow of movement, such a bore to listen to, so
+common in appearance, and of such restricted conversation, that although
+she was thirty, he only twenty, although they slept in rooms next each
+other and he spoke to her daily, he never thought that she might be a
+woman for another, or that she possessed anything else of her sex than
+the gown.
+
+And what else was there? Binet, a few shopkeepers, two or three
+publicans, the cure, and finally, Monsieur Tuvache, the mayor, with his
+two sons, rich, crabbed, obtuse persons, who farmed their own lands
+and had feasts among themselves, bigoted to boot, and quite unbearable
+companions.
+
+But from the general background of all these human faces Emma’s stood
+out isolated and yet farthest off; for between her and him he seemed to
+see a vague abyss.
+
+In the beginning he had called on her several times along with the
+druggist. Charles had not appeared particularly anxious to see him
+again, and Leon did not know what to do between his fear of being
+indiscreet and the desire for an intimacy that seemed almost impossible.
+
+
+
+Chapter Four
+
+When the first cold days set in Emma left her bedroom for the
+sitting-room, a long apartment with a low ceiling, in which there was
+on the mantelpiece a large bunch of coral spread out against the
+looking-glass. Seated in her arm chair near the window, she could see
+the villagers pass along the pavement.
+
+Twice a day Leon went from his office to the Lion d’Or. Emma could hear
+him coming from afar; she leant forward listening, and the young man
+glided past the curtain, always dressed in the same way, and without
+turning his head. But in the twilight, when, her chin resting on her
+left hand, she let the embroidery she had begun fall on her knees, she
+often shuddered at the apparition of this shadow suddenly gliding past.
+She would get up and order the table to be laid.
+
+Monsieur Homais called at dinner-time. Skull-cap in hand, he came in on
+tiptoe, in order to disturb no one, always repeating the same phrase,
+“Good evening, everybody.” Then, when he had taken his seat at the table
+between the pair, he asked the doctor about his patients, and the latter
+consulted his as to the probability of their payment. Next they talked
+of “what was in the paper.”
+
+Homais by this hour knew it almost by heart, and he repeated it from end
+to end, with the reflections of the penny-a-liners, and all the stories
+of individual catastrophes that had occurred in France or abroad. But
+the subject becoming exhausted, he was not slow in throwing out some
+remarks on the dishes before him.
+
+Sometimes even, half-rising, he delicately pointed out to madame the
+tenderest morsel, or turning to the servant, gave her some advice on the
+manipulation of stews and the hygiene of seasoning.
+
+He talked aroma, osmazome, juices, and gelatine in a bewildering manner.
+Moreover, Homais, with his head fuller of recipes than his shop of jars,
+excelled in making all kinds of preserves, vinegars, and sweet liqueurs;
+he knew also all the latest inventions in economic stoves, together with
+the art of preserving cheese and of curing sick wines.
+
+At eight o’clock Justin came to fetch him to shut up the shop.
+
+Then Monsieur Homais gave him a sly look, especially if Felicite was
+there, for he half noticed that his apprentice was fond of the doctor’s
+house.
+
+“The young dog,” he said, “is beginning to have ideas, and the devil
+take me if I don’t believe he’s in love with your servant!”
+
+But a more serious fault with which he reproached Justin was his
+constantly listening to conversation. On Sunday, for example, one could
+not get him out of the drawing-room, whither Madame Homais had called
+him to fetch the children, who were falling asleep in the arm-chairs,
+and dragging down with their backs calico chair-covers that were too
+large.
+
+Not many people came to these soirees at the chemist’s, his
+scandal-mongering and political opinions having successfully alienated
+various respectable persons from him. The clerk never failed to be
+there. As soon as he heard the bell he ran to meet Madame Bovary, took
+her shawl, and put away under the shop-counter the thick list shoes that
+she wore over her boots when there was snow.
+
+First they played some hands at trente-et-un; next Monsieur Homais
+played ecarte with Emma; Leon behind her gave her advice.
+
+Standing up with his hands on the back of her chair he saw the teeth of
+her comb that bit into her chignon. With every movement that she made
+to throw her cards the right side of her dress was drawn up. From her
+turned-up hair a dark colour fell over her back, and growing gradually
+paler, lost itself little by little in the shade. Then her dress fell
+on both sides of her chair, puffing out full of folds, and reached the
+ground. When Leon occasionally felt the sole of his boot resting on it,
+he drew back as if he had trodden upon some one.
+
+When the game of cards was over, the druggist and the Doctor played
+dominoes, and Emma, changing her place, leant her elbow on the table,
+turning over the leaves of “L’Illustration”. She had brought her ladies’
+journal with her. Leon sat down near her; they looked at the engravings
+together, and waited for one another at the bottom of the pages. She
+often begged him to read her the verses; Leon declaimed them in a
+languid voice, to which he carefully gave a dying fall in the love
+passages. But the noise of the dominoes annoyed him. Monsieur Homais
+was strong at the game; he could beat Charles and give him a double-six.
+Then the three hundred finished, they both stretched themselves out in
+front of the fire, and were soon asleep. The fire was dying out in the
+cinders; the teapot was empty, Leon was still reading.
+
+Emma listened to him, mechanically turning around the lampshade, on the
+gauze of which were painted clowns in carriages, and tight-rope dances
+with their balancing-poles. Leon stopped, pointing with a gesture to his
+sleeping audience; then they talked in low tones, and their conversation
+seemed the more sweet to them because it was unheard.
+
+Thus a kind of bond was established between them, a constant commerce
+of books and of romances. Monsieur Bovary, little given to jealousy, did
+not trouble himself about it.
+
+On his birthday he received a beautiful phrenological head, all marked
+with figures to the thorax and painted blue. This was an attention of
+the clerk’s. He showed him many others, even to doing errands for him
+at Rouen; and the book of a novelist having made the mania for cactuses
+fashionable, Leon bought some for Madame Bovary, bringing them back on
+his knees in the “Hirondelle,” pricking his fingers on their hard hairs.
+
+She had a board with a balustrade fixed against her window to hold the
+pots. The clerk, too, had his small hanging garden; they saw each other
+tending their flowers at their windows.
+
+Of the windows of the village there was one yet more often occupied; for
+on Sundays from morning to night, and every morning when the weather was
+bright, one could see at the dormer-window of the garret the profile of
+Monsieur Binet bending over his lathe, whose monotonous humming could be
+heard at the Lion d’Or.
+
+One evening on coming home Leon found in his room a rug in velvet and
+wool with leaves on a pale ground. He called Madame Homais, Monsieur
+Homais, Justin, the children, the cook; he spoke of it to his chief;
+every one wanted to see this rug. Why did the doctor’s wife give the
+clerk presents? It looked queer. They decided that she must be his
+lover.
+
+He made this seem likely, so ceaselessly did he talk of her charms and
+of her wit; so much so, that Binet once roughly answered him--
+
+“What does it matter to me since I’m not in her set?”
+
+He tortured himself to find out how he could make his declaration to
+her, and always halting between the fear of displeasing her and the
+shame of being such a coward, he wept with discouragement and desire.
+Then he took energetic resolutions, wrote letters that he tore up, put
+it off to times that he again deferred.
+
+Often he set out with the determination to dare all; but this resolution
+soon deserted him in Emma’s presence, and when Charles, dropping in,
+invited him to jump into his chaise to go with him to see some patient
+in the neighbourhood, he at once accepted, bowed to madame, and went
+out. Her husband, was he not something belonging to her? As to Emma,
+she did not ask herself whether she loved. Love, she thought, must come
+suddenly, with great outbursts and lightnings--a hurricane of the skies,
+which falls upon life, revolutionises it, roots up the will like a leaf,
+and sweeps the whole heart into the abyss. She did not know that on
+the terrace of houses it makes lakes when the pipes are choked, and she
+would thus have remained in her security when she suddenly discovered a
+rent in the wall of it.
+
+
+
+Chapter Five
+
+It was a Sunday in February, an afternoon when the snow was falling.
+
+They had all, Monsieur and Madame Bovary, Homais, and Monsieur Leon,
+gone to see a yarn-mill that was being built in the valley a mile and a
+half from Yonville. The druggist had taken Napoleon and Athalie to give
+them some exercise, and Justin accompanied them, carrying the umbrellas
+on his shoulder.
+
+Nothing, however, could be less curious than this curiosity. A great
+piece of waste ground, on which pell-mell, amid a mass of sand and
+stones, were a few break-wheels, already rusty, surrounded by a
+quadrangular building pierced by a number of little windows. The
+building was unfinished; the sky could be seen through the joists of the
+roofing. Attached to the stop-plank of the gable a bunch of straw mixed
+with corn-ears fluttered its tricoloured ribbons in the wind.
+
+Homais was talking. He explained to the company the future importance
+of this establishment, computed the strength of the floorings, the
+thickness of the walls, and regretted extremely not having a yard-stick
+such as Monsieur Binet possessed for his own special use.
+
+Emma, who had taken his arm, bent lightly against his shoulder, and
+she looked at the sun’s disc shedding afar through the mist his pale
+splendour. She turned. Charles was there. His cap was drawn down over
+his eyebrows, and his two thick lips were trembling, which added a look
+of stupidity to his face; his very back, his calm back, was irritating
+to behold, and she saw written upon his coat all the platitude of the
+bearer.
+
+While she was considering him thus, tasting in her irritation a sort of
+depraved pleasure, Leon made a step forward. The cold that made him pale
+seemed to add a more gentle languor to his face; between his cravat and
+his neck the somewhat loose collar of his shirt showed the skin; the
+lobe of his ear looked out from beneath a lock of hair, and his large
+blue eyes, raised to the clouds, seemed to Emma more limpid and more
+beautiful than those mountain-lakes where the heavens are mirrored.
+
+“Wretched boy!” suddenly cried the chemist.
+
+And he ran to his son, who had just precipitated himself into a heap of
+lime in order to whiten his boots. At the reproaches with which he was
+being overwhelmed Napoleon began to roar, while Justin dried his shoes
+with a wisp of straw. But a knife was wanted; Charles offered his.
+
+“Ah!” she said to herself, “he carried a knife in his pocket like a
+peasant.”
+
+The hoar-frost was falling, and they turned back to Yonville.
+
+In the evening Madame Bovary did not go to her neighbour’s, and when
+Charles had left and she felt herself alone, the comparison re-began
+with the clearness of a sensation almost actual, and with that
+lengthening of perspective which memory gives to things. Looking from
+her bed at the clean fire that was burning, she still saw, as she had
+down there, Leon standing up with one hand behind his cane, and with
+the other holding Athalie, who was quietly sucking a piece of ice. She
+thought him charming; she could not tear herself away from him; she
+recalled his other attitudes on other days, the words he had spoken, the
+sound of his voice, his whole person; and she repeated, pouting out her
+lips as if for a kiss--
+
+“Yes, charming! charming! Is he not in love?” she asked herself; “but
+with whom? With me?”
+
+All the proofs arose before her at once; her heart leapt. The flame of
+the fire threw a joyous light upon the ceiling; she turned on her back,
+stretching out her arms.
+
+Then began the eternal lamentation: “Oh, if Heaven had not willed it!
+And why not? What prevented it?”
+
+When Charles came home at midnight, she seemed to have just awakened,
+and as he made a noise undressing, she complained of a headache, then
+asked carelessly what had happened that evening.
+
+“Monsieur Leon,” he said, “went to his room early.”
+
+She could not help smiling, and she fell asleep, her soul filled with a
+new delight.
+
+The next day, at dusk, she received a visit from Monsieur Lherueux, the
+draper. He was a man of ability, was this shopkeeper. Born a Gascon but
+bred a Norman, he grafted upon his southern volubility the cunning of
+the Cauchois. His fat, flabby, beardless face seemed dyed by a
+decoction of liquorice, and his white hair made even more vivid the
+keen brilliance of his small black eyes. No one knew what he had been
+formerly; a pedlar said some, a banker at Routot according to others.
+What was certain was that he made complex calculations in his head that
+would have frightened Binet himself. Polite to obsequiousness, he always
+held himself with his back bent in the position of one who bows or who
+invites.
+
+After leaving at the door his hat surrounded with crape, he put down
+a green bandbox on the table, and began by complaining to madame, with
+many civilities, that he should have remained till that day without
+gaining her confidence. A poor shop like his was not made to attract
+a “fashionable lady”; he emphasized the words; yet she had only to
+command, and he would undertake to provide her with anything she might
+wish, either in haberdashery or linen, millinery or fancy goods, for
+he went to town regularly four times a month. He was connected with the
+best houses. You could speak of him at the “Trois Freres,” at the “Barbe
+d’Or,” or at the “Grand Sauvage”; all these gentlemen knew him as
+well as the insides of their pockets. To-day, then he had come to show
+madame, in passing, various articles he happened to have, thanks to
+the most rare opportunity. And he pulled out half-a-dozen embroidered
+collars from the box.
+
+Madame Bovary examined them. “I do not require anything,” she said.
+
+Then Monsieur Lheureux delicately exhibited three Algerian scarves,
+several packets of English needles, a pair of straw slippers, and
+finally, four eggcups in cocoanut wood, carved in open work by convicts.
+Then, with both hands on the table, his neck stretched out, his figure
+bent forward, open-mouthed, he watched Emma’s look, who was walking up
+and down undecided amid these goods. From time to time, as if to remove
+some dust, he filliped with his nail the silk of the scarves spread
+out at full length, and they rustled with a little noise, making in the
+green twilight the gold spangles of their tissue scintillate like little
+stars.
+
+“How much are they?”
+
+“A mere nothing,” he replied, “a mere nothing. But there’s no hurry;
+whenever it’s convenient. We are not Jews.”
+
+She reflected for a few moments, and ended by again declining Monsieur
+Lheureux’s offer. He replied quite unconcernedly--
+
+“Very well. We shall understand one another by and by. I have always got
+on with ladies--if I didn’t with my own!”
+
+Emma smiled.
+
+“I wanted to tell you,” he went on good-naturedly, after his joke, “that
+it isn’t the money I should trouble about. Why, I could give you some,
+if need be.”
+
+She made a gesture of surprise.
+
+“Ah!” said he quickly and in a low voice, “I shouldn’t have to go far to
+find you some, rely on that.”
+
+And he began asking after Pere Tellier, the proprietor of the “Cafe
+Francais,” whom Monsieur Bovary was then attending.
+
+“What’s the matter with Pere Tellier? He coughs so that he shakes his
+whole house, and I’m afraid he’ll soon want a deal covering rather than
+a flannel vest. He was such a rake as a young man! Those sort of people,
+madame, have not the least regularity; he’s burnt up with brandy. Still
+it’s sad, all the same, to see an acquaintance go off.”
+
+And while he fastened up his box he discoursed about the doctor’s
+patients.
+
+“It’s the weather, no doubt,” he said, looking frowningly at the floor,
+“that causes these illnesses. I, too, don’t feel the thing. One of these
+days I shall even have to consult the doctor for a pain I have in my
+back. Well, good-bye, Madame Bovary. At your service; your very humble
+servant.” And he closed the door gently.
+
+Emma had her dinner served in her bedroom on a tray by the fireside; she
+was a long time over it; everything was well with her.
+
+“How good I was!” she said to herself, thinking of the scarves.
+
+She heard some steps on the stairs. It was Leon. She got up and took
+from the chest of drawers the first pile of dusters to be hemmed. When
+he came in she seemed very busy.
+
+The conversation languished; Madame Bovary gave it up every few minutes,
+whilst he himself seemed quite embarrassed. Seated on a low chair near
+the fire, he turned round in his fingers the ivory thimble-case. She
+stitched on, or from time to time turned down the hem of the cloth with
+her nail. She did not speak; he was silent, captivated by her silence,
+as he would have been by her speech.
+
+“Poor fellow!” she thought.
+
+“How have I displeased her?” he asked himself.
+
+At last, however, Leon said that he should have, one of these days, to
+go to Rouen on some office business.
+
+“Your music subscription is out; am I to renew it?”
+
+“No,” she replied.
+
+“Why?”
+
+“Because--”
+
+And pursing her lips she slowly drew a long stitch of grey thread.
+
+This work irritated Leon. It seemed to roughen the ends of her fingers.
+A gallant phrase came into his head, but he did not risk it.
+
+“Then you are giving it up?” he went on.
+
+“What?” she asked hurriedly. “Music? Ah! yes! Have I not my house to
+look after, my husband to attend to, a thousand things, in fact, many
+duties that must be considered first?”
+
+She looked at the clock. Charles was late. Then, she affected anxiety.
+Two or three times she even repeated, “He is so good!”
+
+The clerk was fond of Monsieur Bovary. But this tenderness on his behalf
+astonished him unpleasantly; nevertheless he took up on his praises,
+which he said everyone was singing, especially the chemist.
+
+“Ah! he is a good fellow,” continued Emma.
+
+“Certainly,” replied the clerk.
+
+And he began talking of Madame Homais, whose very untidy appearance
+generally made them laugh.
+
+“What does it matter?” interrupted Emma. “A good housewife does not
+trouble about her appearance.”
+
+Then she relapsed into silence.
+
+It was the same on the following days; her talks, her manners,
+everything changed. She took interest in the housework, went to church
+regularly, and looked after her servant with more severity.
+
+She took Berthe from nurse. When visitors called, Felicite brought her
+in, and Madame Bovary undressed her to show off her limbs. She declared
+she adored children; this was her consolation, her joy, her passion,
+and she accompanied her caresses with lyrical outburst which would have
+reminded anyone but the Yonville people of Sachette in “Notre Dame de
+Paris.”
+
+When Charles came home he found his slippers put to warm near the fire.
+His waistcoat now never wanted lining, nor his shirt buttons, and it was
+quite a pleasure to see in the cupboard the night-caps arranged in piles
+of the same height. She no longer grumbled as formerly at taking a turn
+in the garden; what he proposed was always done, although she did not
+understand the wishes to which she submitted without a murmur; and when
+Leon saw him by his fireside after dinner, his two hands on his stomach,
+his two feet on the fender, his two cheeks red with feeding, his eyes
+moist with happiness, the child crawling along the carpet, and this
+woman with the slender waist who came behind his arm-chair to kiss his
+forehead: “What madness!” he said to himself. “And how to reach her!”
+
+And thus she seemed so virtuous and inaccessible to him that he lost all
+hope, even the faintest. But by this renunciation he placed her on
+an extraordinary pinnacle. To him she stood outside those fleshly
+attributes from which he had nothing to obtain, and in his heart she
+rose ever, and became farther removed from him after the magnificent
+manner of an apotheosis that is taking wing. It was one of those pure
+feelings that do not interfere with life, that are cultivated because
+they are rare, and whose loss would afflict more than their passion
+rejoices.
+
+Emma grew thinner, her cheeks paler, her face longer. With her black
+hair, her large eyes, her aquiline nose, her birdlike walk, and always
+silent now, did she not seem to be passing through life scarcely
+touching it, and to bear on her brow the vague impress of some divine
+destiny? She was so sad and so calm, at once so gentle and so reserved,
+that near her one felt oneself seized by an icy charm, as we shudder
+in churches at the perfume of the flowers mingling with the cold of the
+marble. The others even did not escape from this seduction. The chemist
+said--
+
+“She is a woman of great parts, who wouldn’t be misplaced in a
+sub-prefecture.”
+
+The housewives admired her economy, the patients her politeness, the
+poor her charity.
+
+But she was eaten up with desires, with rage, with hate. That dress with
+the narrow folds hid a distracted fear, of whose torment those chaste
+lips said nothing. She was in love with Leon, and sought solitude that
+she might with the more ease delight in his image. The sight of his
+form troubled the voluptuousness of this mediation. Emma thrilled at
+the sound of his step; then in his presence the emotion subsided, and
+afterwards there remained to her only an immense astonishment that ended
+in sorrow.
+
+Leon did not know that when he left her in despair she rose after he had
+gone to see him in the street. She concerned herself about his comings
+and goings; she watched his face; she invented quite a history to find
+an excuse for going to his room. The chemist’s wife seemed happy to her
+to sleep under the same roof, and her thoughts constantly centered upon
+this house, like the “Lion d’Or” pigeons, who came there to dip their
+red feet and white wings in its gutters. But the more Emma recognised
+her love, the more she crushed it down, that it might not be evident,
+that she might make it less. She would have liked Leon to guess it, and
+she imagined chances, catastrophes that should facilitate this.
+
+What restrained her was, no doubt, idleness and fear, and a sense of
+shame also. She thought she had repulsed him too much, that the time was
+past, that all was lost. Then, pride, and joy of being able to say to
+herself, “I am virtuous,” and to look at herself in the glass taking
+resigned poses, consoled her a little for the sacrifice she believed she
+was making.
+
+Then the lusts of the flesh, the longing for money, and the melancholy
+of passion all blended themselves into one suffering, and instead of
+turning her thoughts from it, she clave to it the more, urging herself
+to pain, and seeking everywhere occasion for it. She was irritated by
+an ill-served dish or by a half-open door; bewailed the velvets she had
+not, the happiness she had missed, her too exalted dreams, her narrow
+home.
+
+What exasperated her was that Charles did not seem to notice her
+anguish. His conviction that he was making her happy seemed to her an
+imbecile insult, and his sureness on this point ingratitude. For whose
+sake, then was she virtuous? Was it not for him, the obstacle to all
+felicity, the cause of all misery, and, as it were, the sharp clasp of
+that complex strap that bucked her in on all sides.
+
+On him alone, then, she concentrated all the various hatreds that
+resulted from her boredom, and every effort to diminish only augmented
+it; for this useless trouble was added to the other reasons for despair,
+and contributed still more to the separation between them. Her own
+gentleness to herself made her rebel against him. Domestic mediocrity
+drove her to lewd fancies, marriage tenderness to adulterous desires.
+She would have liked Charles to beat her, that she might have a better
+right to hate him, to revenge herself upon him. She was surprised
+sometimes at the atrocious conjectures that came into her thoughts, and
+she had to go on smiling, to hear repeated to her at all hours that she
+was happy, to pretend to be happy, to let it be believed.
+
+Yet she had loathing of this hypocrisy. She was seized with the
+temptation to flee somewhere with Leon to try a new life; but at once a
+vague chasm full of darkness opened within her soul.
+
+“Besides, he no longer loves me,” she thought. “What is to become of me?
+What help is to be hoped for, what consolation, what solace?”
+
+She was left broken, breathless, inert, sobbing in a low voice, with
+flowing tears.
+
+“Why don’t you tell master?” the servant asked her when she came in
+during these crises.
+
+“It is the nerves,” said Emma. “Do not speak to him of it; it would
+worry him.”
+
+“Ah! yes,” Felicite went on, “you are just like La Guerine, Pere
+Guerin’s daughter, the fisherman at Pollet, that I used to know at
+Dieppe before I came to you. She was so sad, so sad, to see her
+standing upright on the threshold of her house, she seemed to you like a
+winding-sheet spread out before the door. Her illness, it appears, was
+a kind of fog that she had in her head, and the doctors could not do
+anything, nor the priest either. When she was taken too bad she went
+off quite alone to the sea-shore, so that the customs officer, going his
+rounds, often found her lying flat on her face, crying on the shingle.
+Then, after her marriage, it went off, they say.”
+
+“But with me,” replied Emma, “it was after marriage that it began.”
+
+
+
+Chapter Six
+
+One evening when the window was open, and she, sitting by it, had been
+watching Lestiboudois, the beadle, trimming the box, she suddenly heard
+the Angelus ringing.
+
+It was the beginning of April, when the primroses are in bloom, and a
+warm wind blows over the flower-beds newly turned, and the gardens, like
+women, seem to be getting ready for the summer fetes. Through the bars
+of the arbour and away beyond the river seen in the fields, meandering
+through the grass in wandering curves. The evening vapours rose between
+the leafless poplars, touching their outlines with a violet tint, paler
+and more transparent than a subtle gauze caught athwart their branches.
+In the distance cattle moved about; neither their steps nor their lowing
+could be heard; and the bell, still ringing through the air, kept up its
+peaceful lamentation.
+
+With this repeated tinkling the thoughts of the young woman lost
+themselves in old memories of her youth and school-days. She remembered
+the great candlesticks that rose above the vases full of flowers on the
+altar, and the tabernacle with its small columns. She would have liked
+to be once more lost in the long line of white veils, marked off here
+and there by the stuff black hoods of the good sisters bending over
+their prie-Dieu. At mass on Sundays, when she looked up, she saw the
+gentle face of the Virgin amid the blue smoke of the rising incense.
+Then she was moved; she felt herself weak and quite deserted, like the
+down of a bird whirled by the tempest, and it was unconsciously that she
+went towards the church, included to no matter what devotions, so that
+her soul was absorbed and all existence lost in it.
+
+On the Place she met Lestivoudois on his way back, for, in order not
+to shorten his day’s labour, he preferred interrupting his work,
+then beginning it again, so that he rang the Angelus to suit his own
+convenience. Besides, the ringing over a little earlier warned the lads
+of catechism hour.
+
+Already a few who had arrived were playing marbles on the stones of the
+cemetery. Others, astride the wall, swung their legs, kicking with their
+clogs the large nettles growing between the little enclosure and the
+newest graves. This was the only green spot. All the rest was but
+stones, always covered with a fine powder, despite the vestry-broom.
+
+The children in list shoes ran about there as if it were an enclosure
+made for them. The shouts of their voices could be heard through the
+humming of the bell. This grew less and less with the swinging of the
+great rope that, hanging from the top of the belfry, dragged its end on
+the ground. Swallows flitted to and fro uttering little cries, cut the
+air with the edge of their wings, and swiftly returned to their yellow
+nests under the tiles of the coping. At the end of the church a lamp was
+burning, the wick of a night-light in a glass hung up. Its light from a
+distance looked like a white stain trembling in the oil. A long ray of
+the sun fell across the nave and seemed to darken the lower sides and
+the corners.
+
+“Where is the cure?” asked Madame Bovary of one of the lads, who was
+amusing himself by shaking a swivel in a hole too large for it.
+
+“He is just coming,” he answered.
+
+And in fact the door of the presbytery grated; Abbe Bournisien appeared;
+the children, pell-mell, fled into the church.
+
+“These young scamps!” murmured the priest, “always the same!”
+
+Then, picking up a catechism all in rags that he had struck with is
+foot, “They respect nothing!” But as soon as he caught sight of Madame
+Bovary, “Excuse me,” he said; “I did not recognise you.”
+
+He thrust the catechism into his pocket, and stopped short, balancing
+the heavy vestry key between his two fingers.
+
+The light of the setting sun that fell full upon his face paled the
+lasting of his cassock, shiny at the elbows, unravelled at the hem.
+Grease and tobacco stains followed along his broad chest the lines
+of the buttons, and grew more numerous the farther they were from his
+neckcloth, in which the massive folds of his red chin rested; this was
+dotted with yellow spots, that disappeared beneath the coarse hair of
+his greyish beard. He had just dined and was breathing noisily.
+
+“How are you?” he added.
+
+“Not well,” replied Emma; “I am ill.”
+
+“Well, and so am I,” answered the priest. “These first warm days weaken
+one most remarkably, don’t they? But, after all, we are born to suffer,
+as St. Paul says. But what does Monsieur Bovary think of it?”
+
+“He!” she said with a gesture of contempt.
+
+“What!” replied the good fellow, quite astonished, “doesn’t he prescribe
+something for you?”
+
+“Ah!” said Emma, “it is no earthly remedy I need.”
+
+But the cure from time to time looked into the church, where the
+kneeling boys were shouldering one another, and tumbling over like packs
+of cards.
+
+“I should like to know--” she went on.
+
+“You look out, Riboudet,” cried the priest in an angry voice; “I’ll warm
+your ears, you imp!” Then turning to Emma, “He’s Boudet the carpenter’s
+son; his parents are well off, and let him do just as he pleases. Yet he
+could learn quickly if he would, for he is very sharp. And so sometimes
+for a joke I call him Riboudet (like the road one takes to go to
+Maromme) and I even say ‘Mon Riboudet.’ Ha! Ha! ‘Mont Riboudet.’ The
+other day I repeated that just to Monsignor, and he laughed at it; he
+condescended to laugh at it. And how is Monsieur Bovary?”
+
+She seemed not to hear him. And he went on--
+
+“Always very busy, no doubt; for he and I are certainly the busiest
+people in the parish. But he is doctor of the body,” he added with a
+thick laugh, “and I of the soul.”
+
+She fixed her pleading eyes upon the priest. “Yes,” she said, “you
+solace all sorrows.”
+
+“Ah! don’t talk to me of it, Madame Bovary. This morning I had to go to
+Bas-Diauville for a cow that was ill; they thought it was under a spell.
+All their cows, I don’t know how it is--But pardon me! Longuemarre and
+Boudet! Bless me! Will you leave off?”
+
+And with a bound he ran into the church.
+
+The boys were just then clustering round the large desk, climbing over
+the precentor’s footstool, opening the missal; and others on tiptoe were
+just about to venture into the confessional. But the priest suddenly
+distributed a shower of cuffs among them. Seizing them by the collars of
+their coats, he lifted them from the ground, and deposited them on their
+knees on the stones of the choir, firmly, as if he meant planting them
+there.
+
+“Yes,” said he, when he returned to Emma, unfolding his large cotton
+handkerchief, one corner of which he put between his teeth, “farmers are
+much to be pitied.”
+
+“Others, too,” she replied.
+
+“Assuredly. Town-labourers, for example.”
+
+“It is not they--”
+
+“Pardon! I’ve there known poor mothers of families, virtuous women, I
+assure you, real saints, who wanted even bread.”
+
+“But those,” replied Emma, and the corners of her mouth twitched as she
+spoke, “those, Monsieur le Cure, who have bread and have no--”
+
+“Fire in the winter,” said the priest.
+
+“Oh, what does that matter?”
+
+“What! What does it matter? It seems to me that when one has firing and
+food--for, after all--”
+
+“My God! my God!” she sighed.
+
+“It is indigestion, no doubt? You must get home, Madame Bovary; drink
+a little tea, that will strengthen you, or else a glass of fresh water
+with a little moist sugar.”
+
+“Why?” And she looked like one awaking from a dream.
+
+“Well, you see, you were putting your hand to your forehead. I thought
+you felt faint.” Then, bethinking himself, “But you were asking me
+something? What was it? I really don’t remember.”
+
+“I? Nothing! nothing!” repeated Emma.
+
+And the glance she cast round her slowly fell upon the old man in the
+cassock. They looked at one another face to face without speaking.
+
+“Then, Madame Bovary,” he said at last, “excuse me, but duty first, you
+know; I must look after my good-for-nothings. The first communion will
+soon be upon us, and I fear we shall be behind after all. So after
+Ascension Day I keep them recta* an extra hour every Wednesday. Poor
+children! One cannot lead them too soon into the path of the Lord, as,
+moreover, he has himself recommended us to do by the mouth of his Divine
+Son. Good health to you, madame; my respects to your husband.”
+
+     *On the straight and narrow path.
+
+And he went into the church making a genuflexion as soon as he reached
+the door.
+
+Emma saw him disappear between the double row of forms, walking with a
+heavy tread, his head a little bent over his shoulder, and with his two
+hands half-open behind him.
+
+Then she turned on her heel all of one piece, like a statue on a pivot,
+and went homewards. But the loud voice of the priest, the clear voices
+of the boys still reached her ears, and went on behind her.
+
+“Are you a Christian?”
+
+“Yes, I am a Christian.”
+
+“What is a Christian?”
+
+“He who, being baptized-baptized-baptized--”
+
+She went up the steps of the staircase holding on to the banisters, and
+when she was in her room threw herself into an arm-chair.
+
+The whitish light of the window-panes fell with soft undulations.
+
+The furniture in its place seemed to have become more immobile, and to
+lose itself in the shadow as in an ocean of darkness. The fire was out,
+the clock went on ticking, and Emma vaguely marvelled at this calm of
+all things while within herself was such tumult. But little Berthe was
+there, between the window and the work-table, tottering on her knitted
+shoes, and trying to come to her mother to catch hold of the ends of her
+apron-strings.
+
+“Leave me alone,” said the latter, putting her from her with her hand.
+
+The little girl soon came up closer against her knees, and leaning on
+them with her arms, she looked up with her large blue eyes, while a
+small thread of pure saliva dribbled from her lips on to the silk apron.
+
+“Leave me alone,” repeated the young woman quite irritably.
+
+Her face frightened the child, who began to scream.
+
+“Will you leave me alone?” she said, pushing her with her elbow.
+
+Berthe fell at the foot of the drawers against the brass handle, cutting
+her cheek, which began to bleed, against it. Madame Bovary sprang to
+lift her up, broke the bell-rope, called for the servant with all her
+might, and she was just going to curse herself when Charles appeared. It
+was the dinner-hour; he had come home.
+
+“Look, dear!” said Emma, in a calm voice, “the little one fell down
+while she was playing, and has hurt herself.”
+
+Charles reassured her; the case was not a serious one, and he went for
+some sticking plaster.
+
+Madame Bovary did not go downstairs to the dining-room; she wished
+to remain alone to look after the child. Then watching her sleep, the
+little anxiety she felt gradually wore off, and she seemed very stupid
+to herself, and very good to have been so worried just now at so little.
+Berthe, in fact, no longer sobbed.
+
+Her breathing now imperceptibly raised the cotton covering. Big tears
+lay in the corner of the half-closed eyelids, through whose lashes one
+could see two pale sunken pupils; the plaster stuck on her cheek drew
+the skin obliquely.
+
+“It is very strange,” thought Emma, “how ugly this child is!”
+
+When at eleven o’clock Charles came back from the chemist’s shop,
+whither he had gone after dinner to return the remainder of the
+sticking-plaster, he found his wife standing by the cradle.
+
+“I assure you it’s nothing.” he said, kissing her on the forehead.
+“Don’t worry, my poor darling; you will make yourself ill.”
+
+He had stayed a long time at the chemist’s. Although he had not seemed
+much moved, Homais, nevertheless, had exerted himself to buoy him up, to
+“keep up his spirits.” Then they had talked of the various dangers that
+threaten childhood, of the carelessness of servants. Madame Homais knew
+something of it, having still upon her chest the marks left by a basin
+full of soup that a cook had formerly dropped on her pinafore, and
+her good parents took no end of trouble for her. The knives were not
+sharpened, nor the floors waxed; there were iron gratings to the windows
+and strong bars across the fireplace; the little Homais, in spite of
+their spirit, could not stir without someone watching them; at the
+slightest cold their father stuffed them with pectorals; and until
+they were turned four they all, without pity, had to wear wadded
+head-protectors. This, it is true, was a fancy of Madame Homais’; her
+husband was inwardly afflicted at it. Fearing the possible consequences
+of such compression to the intellectual organs. He even went so far as
+to say to her, “Do you want to make Caribs or Botocudos of them?”
+
+Charles, however, had several times tried to interrupt the conversation.
+“I should like to speak to you,” he had whispered in the clerk’s ear,
+who went upstairs in front of him.
+
+“Can he suspect anything?” Leon asked himself. His heart beat, and he
+racked his brain with surmises.
+
+At last, Charles, having shut the door, asked him to see himself
+what would be the price at Rouen of a fine daguerreotypes. It was a
+sentimental surprise he intended for his wife, a delicate attention--his
+portrait in a frock-coat. But he wanted first to know “how much it would
+be.” The inquiries would not put Monsieur Leon out, since he went to
+town almost every week.
+
+Why? Monsieur Homais suspected some “young man’s affair” at the bottom
+of it, an intrigue. But he was mistaken. Leon was after no love-making.
+He was sadder than ever, as Madame Lefrancois saw from the amount of
+food he left on his plate. To find out more about it she questioned
+the tax-collector. Binet answered roughly that he “wasn’t paid by the
+police.”
+
+All the same, his companion seemed very strange to him, for Leon often
+threw himself back in his chair, and stretching out his arms, complained vaguely of life.
+
+“It’s because you don’t take enough recreation,” said the collector.
+
+“What recreation?”
+
+“If I were you I’d have a lathe.”
+
+“But I don’t know how to turn,” answered the clerk.
+
+“Ah! that’s true,” said the other, rubbing his chin with an air of
+mingled contempt and satisfaction.
+
+Leon was weary of loving without any result; moreover he was beginning
+to feel that depression caused by the repetition of the same kind of
+life, when no interest inspires and no hope sustains it. He was so bored
+with Yonville and its inhabitants, that the sight of certain persons,
+of certain houses, irritated him beyond endurance; and the chemist, good
+fellow though he was, was becoming absolutely unbearable to him. Yet
+the prospect of a new condition of life frightened as much as it seduced
+him.
+
+This apprehension soon changed into impatience, and then Paris from afar
+sounded its fanfare of masked balls with the laugh of grisettes. As he
+was to finish reading there, why not set out at once? What prevented
+him? And he began making home-preparations; he arranged his occupations
+beforehand. He furnished in his head an apartment. He would lead an
+artist’s life there! He would take lessons on the guitar! He would have
+a dressing-gown, a Basque cap, blue velvet slippers! He even already was
+admiring two crossed foils over his chimney-piece, with a death’s head
+on the guitar above them.
+
+The difficulty was the consent of his mother; nothing, however, seemed
+more reasonable. Even his employer advised him to go to some other
+chambers where he could advance more rapidly. Taking a middle course,
+then, Leon looked for some place as second clerk at Rouen; found none,
+and at last wrote his mother a long letter full of details, in which
+he set forth the reasons for going to live at Paris immediately. She
+consented.
+
+He did not hurry. Every day for a month Hivert carried boxes, valises,
+parcels for him from Yonville to Rouen and from Rouen to Yonville;
+and when Leon had packed up his wardrobe, had his three arm-chairs
+restuffed, bought a stock of neckties, in a word, had made more
+preparations than for a voyage around the world, he put it off from week
+to week, until he received a second letter from his mother urging him to
+leave, since he wanted to pass his examination before the vacation.
+
+When the moment for the farewells had come, Madame Homais wept, Justin
+sobbed; Homais, as a man of nerve, concealed his emotion; he wished to
+carry his friend’s overcoat himself as far as the gate of the notary,
+who was taking Leon to Rouen in his carriage.
+
+The latter had just time to bid farewell to Monsieur Bovary.
+
+When he reached the head of the stairs, he stopped, he was so out of
+breath. As he came in, Madame Bovary arose hurriedly.
+
+“It is I again!” said Leon.
+
+“I was sure of it!”
+
+She bit her lips, and a rush of blood flowing under her skin made her
+red from the roots of her hair to the top of her collar. She remained
+standing, leaning with her shoulder against the wainscot.
+
+“The doctor is not here?” he went on.
+
+“He is out.” She repeated, “He is out.”
+
+Then there was silence. They looked at one another and their thoughts,
+confounded in the same agony, clung close together like two throbbing
+breasts.
+
+“I should like to kiss Berthe,” said Leon.
+
+Emma went down a few steps and called Felicite.
+
+He threw one long look around him that took in the walls, the
+decorations, the fireplace, as if to penetrate everything, carry away
+everything. But she returned, and the servant brought Berthe, who was
+swinging a windmill roof downwards at the end of a string. Leon kissed
+her several times on the neck.
+
+“Good-bye, poor child! good-bye, dear little one! good-bye!” And he gave
+her back to her mother.
+
+“Take her away,” she said.
+
+They remained alone--Madame Bovary, her back turned, her face pressed
+against a window-pane; Leon held his cap in his hand, knocking it softly
+against his thigh.
+
+“It is going to rain,” said Emma.
+
+“I have a cloak,” he answered.
+
+“Ah!”
+
+She turned around, her chin lowered, her forehead bent forward.
+
+The light fell on it as on a piece of marble, to the curve of the
+eyebrows, without one’s being able to guess what Emma was seeing on the
+horizon or what she was thinking within herself.
+
+“Well, good-bye,” he sighed.
+
+She raised her head with a quick movement.
+
+“Yes, good-bye--go!”
+
+They advanced towards each other; he held out his hand; she hesitated.
+
+“In the English fashion, then,” she said, giving her own hand wholly to
+him, and forcing a laugh.
+
+Leon felt it between his fingers, and the very essence of all his being
+seemed to pass down into that moist palm. Then he opened his hand; their
+eyes met again, and he disappeared.
+
+When he reached the market-place, he stopped and hid behind a pillar to
+look for the last time at this white house with the four green blinds.
+He thought he saw a shadow behind the window in the room; but the
+curtain, sliding along the pole as though no one were touching it,
+slowly opened its long oblique folds that spread out with a single
+movement, and thus hung straight and motionless as a plaster wall. Leon
+set off running.
+
+From afar he saw his employer’s gig in the road, and by it a man in
+a coarse apron holding the horse. Homais and Monsieur Guillaumin were
+talking. They were waiting for him.
+
+“Embrace me,” said the druggist with tears in his eyes. “Here is your
+coat, my good friend. Mind the cold; take care of yourself; look after
+yourself.”
+
+“Come, Leon, jump in,” said the notary.
+
+Homais bent over the splash-board, and in a voice broken by sobs uttered
+these three sad words--
+
+“A pleasant journey!”
+
+“Good-night,” said Monsieur Guillaumin. “Give him his head.” They set
+out, and Homais went back.
+
+Madame Bovary had opened her window overlooking the garden and watched
+the clouds. They gathered around the sunset on the side of Rouen and
+then swiftly rolled back their black columns, behind which the great
+rays of the sun looked out like the golden arrows of a suspended trophy,
+while the rest of the empty heavens was white as porcelain. But a gust
+of wind bowed the poplars, and suddenly the rain fell; it pattered
+against the green leaves.
+
+Then the sun reappeared, the hens clucked, sparrows shook their wings in
+the damp thickets, and the pools of water on the gravel as they flowed
+away carried off the pink flowers of an acacia.
+
+“Ah! how far off he must be already!” she thought.
+
+Monsieur Homais, as usual, came at half-past six during dinner.
+
+“Well,” said he, “so we’ve sent off our young friend!”
+
+“So it seems,” replied the doctor. Then turning on his chair; “Any news
+at home?”
+
+“Nothing much. Only my wife was a little moved this afternoon. You know
+women--a nothing upsets them, especially my wife. And we should be
+wrong to object to that, since their nervous organization is much more
+malleable than ours.”
+
+“Poor Leon!” said Charles. “How will he live at Paris? Will he get used
+to it?”
+
+Madame Bovary sighed.
+
+“Get along!” said the chemist, smacking his lips. “The outings at
+restaurants, the masked balls, the champagne--all that’ll be jolly
+enough, I assure you.”
+
+“I don’t think he’ll go wrong,” objected Bovary.
+
+“Nor do I,” said Monsieur Homais quickly; “although he’ll have to do
+like the rest for fear of passing for a Jesuit. And you don’t know what
+a life those dogs lead in the Latin quarter with actresses. Besides,
+students are thought a great deal of in Paris. Provided they have a few
+accomplishments, they are received in the best society; there are even
+ladies of the Faubourg Saint-Germain who fall in love with them, which
+subsequently furnishes them opportunities for making very good matches.”
+
+“But,” said the doctor, “I fear for him that down there--”
+
+“You are right,” interrupted the chemist; “that is the reverse of the
+medal. And one is constantly obliged to keep one’s hand in one’s pocket
+there. Thus, we will suppose you are in a public garden. An individual
+presents himself, well dressed, even wearing an order, and whom one
+would take for a diplomatist. He approaches you, he insinuates himself;
+offers you a pinch of snuff, or picks up your hat. Then you become more
+intimate; he takes you to a cafe, invites you to his country-house,
+introduces you, between two drinks, to all sorts of people; and
+three-fourths of the time it’s only to plunder your watch or lead you
+into some pernicious step.
+
+“That is true,” said Charles; “but I was thinking especially of
+illnesses--of typhoid fever, for example, that attacks students from the
+provinces.”
+
+Emma shuddered.
+
+“Because of the change of regimen,” continued the chemist, “and of the
+perturbation that results therefrom in the whole system. And then the
+water at Paris, don’t you know! The dishes at restaurants, all the
+spiced food, end by heating the blood, and are not worth, whatever
+people may say of them, a good soup. For my own part, I have always
+preferred plain living; it is more healthy. So when I was studying
+pharmacy at Rouen, I boarded in a boarding house; I dined with the
+professors.”
+
+And thus he went on, expounding his opinions generally and his personal
+likings, until Justin came to fetch him for a mulled egg that was
+wanted.
+
+“Not a moment’s peace!” he cried; “always at it! I can’t go out for a
+minute! Like a plough-horse, I have always to be moiling and toiling.
+What drudgery!” Then, when he was at the door, “By the way, do you know
+the news?”
+
+“What news?”
+
+“That it is very likely,” Homais went on, raising his eyebrows and
+assuming one of his most serious expression, “that the agricultural
+meeting of the Seine-Inferieure will be held this year at
+Yonville-l’Abbaye. The rumour, at all events, is going the round. This
+morning the paper alluded to it. It would be of the utmost importance
+for our district. But we’ll talk it over later on. I can see, thank you;
+Justin has the lantern.”
+
+
+
+Chapter Seven
+
+The next day was a dreary one for Emma. Everything seemed to her
+enveloped in a black atmosphere floating confusedly over the exterior of
+things, and sorrow was engulfed within her soul with soft shrieks such
+as the winter wind makes in ruined castles. It was that reverie which we
+give to things that will not return, the lassitude that seizes you after
+everything was done; that pain, in fine, that the interruption of every
+wonted movement, the sudden cessation of any prolonged vibration, brings
+on.
+
+As on the return from Vaubyessard, when the quadrilles were running in
+her head, she was full of a gloomy melancholy, of a numb despair.
+Leon reappeared, taller, handsomer, more charming, more vague. Though
+separated from her, he had not left her; he was there, and the walls of
+the house seemed to hold his shadow.
+
+She could not detach her eyes from the carpet where he had walked, from
+those empty chairs where he had sat. The river still flowed on, and
+slowly drove its ripples along the slippery banks.
+
+They had often walked there to the murmur of the waves over the
+moss-covered pebbles. How bright the sun had been! What happy afternoons
+they had seen alone in the shade at the end of the garden! He read
+aloud, bareheaded, sitting on a footstool of dry sticks; the fresh wind
+of the meadow set trembling the leaves of the book and the nasturtiums
+of the arbour. Ah! he was gone, the only charm of her life, the only
+possible hope of joy. Why had she not seized this happiness when it came
+to her? Why not have kept hold of it with both hands, with both knees,
+when it was about to flee from her? And she cursed herself for not
+having loved Leon. She thirsted for his lips. The wish took possession
+of her to run after and rejoin him, throw herself into his arms and
+say to him, “It is I; I am yours.” But Emma recoiled beforehand at the
+difficulties of the enterprise, and her desires, increased by regret,
+became only the more acute.
+
+Henceforth the memory of Leon was the centre of her boredom; it burnt
+there more brightly than the fire travellers have left on the snow of
+a Russian steppe. She sprang towards him, she pressed against him, she
+stirred carefully the dying embers, sought all around her anything
+that could revive it; and the most distant reminiscences, like the most
+immediate occasions, what she experienced as well as what she imagined,
+her voluptuous desires that were unsatisfied, her projects of happiness
+that crackled in the wind like dead boughs, her sterile virtue, her
+lost hopes, the domestic tete-a-tete--she gathered it all up, took
+everything, and made it all serve as fuel for her melancholy.
+
+The flames, however, subsided, either because the supply had exhausted
+itself, or because it had been piled up too much. Love, little by
+little, was quelled by absence; regret stifled beneath habit; and this
+incendiary light that had empurpled her pale sky was overspread and
+faded by degrees. In the supineness of her conscience she even took her
+repugnance towards her husband for aspirations towards her lover, the
+burning of hate for the warmth of tenderness; but as the tempest still
+raged, and as passion burnt itself down to the very cinders, and no help
+came, no sun rose, there was night on all sides, and she was lost in the
+terrible cold that pierced her.
+
+Then the evil days of Tostes began again. She thought herself now far
+more unhappy; for she had the experience of grief, with the certainty
+that it would not end.
+
+A woman who had laid on herself such sacrifices could well allow herself
+certain whims. She bought a Gothic prie-dieu, and in a month spent
+fourteen francs on lemons for polishing her nails; she wrote to Rouen
+for a blue cashmere gown; she chose one of Lheureux’s finest scarves,
+and wore it knotted around her waist over her dressing-gown; and, with
+closed blinds and a book in her hand, she lay stretched out on a couch
+in this garb.
+
+She often changed her coiffure; she did her hair a la Chinoise, in
+flowing curls, in plaited coils; she parted in on one side and rolled it
+under like a man’s.
+
+She wanted to learn Italian; she bought dictionaries, a grammar, and
+a supply of white paper. She tried serious reading, history, and
+philosophy. Sometimes in the night Charles woke up with a start,
+thinking he was being called to a patient. “I’m coming,” he stammered;
+and it was the noise of a match Emma had struck to relight the lamp. But
+her reading fared like her piece of embroidery, all of which, only just
+begun, filled her cupboard; she took it up, left it, passed on to other
+books.
+
+She had attacks in which she could easily have been driven to commit any
+folly. She maintained one day, in opposition to her husband, that she
+could drink off a large glass of brandy, and, as Charles was stupid
+enough to dare her to, she swallowed the brandy to the last drop.
+
+In spite of her vapourish airs (as the housewives of Yonville called
+them), Emma, all the same, never seemed gay, and usually she had at the
+corners of her mouth that immobile contraction that puckers the faces of
+old maids, and those of men whose ambition has failed. She was pale all
+over, white as a sheet; the skin of her nose was drawn at the nostrils,
+her eyes looked at you vaguely. After discovering three grey hairs on
+her temples, she talked much of her old age.
+
+She often fainted. One day she even spat blood, and, as Charles fussed
+around her showing his anxiety--
+
+“Bah!” she answered, “what does it matter?”
+
+Charles fled to his study and wept there, both his elbows on the table,
+sitting in an arm-chair at his bureau under the phrenological head.
+
+Then he wrote to his mother begging her to come, and they had many long
+consultations together on the subject of Emma.
+
+What should they decide? What was to be done since she rejected all
+medical treatment? “Do you know what your wife wants?” replied Madame
+Bovary senior.
+
+“She wants to be forced to occupy herself with some manual work. If she
+were obliged, like so many others, to earn her living, she wouldn’t have
+these vapours, that come to her from a lot of ideas she stuffs into her
+head, and from the idleness in which she lives.”
+
+“Yet she is always busy,” said Charles.
+
+“Ah! always busy at what? Reading novels, bad books, works against
+religion, and in which they mock at priests in speeches taken from
+Voltaire. But all that leads you far astray, my poor child. Anyone who
+has no religion always ends by turning out badly.”
+
+So it was decided to stop Emma reading novels. The enterprise did not
+seem easy. The good lady undertook it. She was, when she passed through
+Rouen, to go herself to the lending-library and represent that Emma had
+discontinued her subscription. Would they not have a right to apply
+to the police if the librarian persisted all the same in his poisonous
+trade? The farewells of mother and daughter-in-law were cold. During
+the three weeks that they had been together they had not exchanged
+half-a-dozen words apart from the inquiries and phrases when they met at
+table and in the evening before going to bed.
+
+Madame Bovary left on a Wednesday, the market-day at Yonville.
+
+The Place since morning had been blocked by a row of carts, which, on
+end and their shafts in the air, spread all along the line of houses
+from the church to the inn. On the other side there were canvas booths,
+where cotton checks, blankets, and woollen stockings were sold,
+together with harness for horses, and packets of blue ribbon, whose ends
+fluttered in the wind. The coarse hardware was spread out on the ground
+between pyramids of eggs and hampers of cheeses, from which sticky straw
+stuck out.
+
+Near the corn-machines clucking hens passed their necks through the bars
+of flat cages. The people, crowding in the same place and unwilling
+to move thence, sometimes threatened to smash the shop front of the
+chemist. On Wednesdays his shop was never empty, and the people pushed
+in less to buy drugs than for consultations. So great was Homais’
+reputation in the neighbouring villages. His robust aplomb had
+fascinated the rustics. They considered him a greater doctor than all
+the doctors.
+
+Emma was leaning out at the window; she was often there. The window in
+the provinces replaces the theatre and the promenade, she was amusing
+herself with watching the crowd of boors when she saw a gentleman in
+a green velvet coat. He had on yellow gloves, although he wore heavy
+gaiters; he was coming towards the doctor’s house, followed by a peasant
+walking with a bent head and quite a thoughtful air.
+
+“Can I see the doctor?” he asked Justin, who was talking on the
+doorsteps with Felicite, and, taking him for a servant of the
+house--“Tell him that Monsieur Rodolphe Boulanger of La Huchette is
+here.”
+
+It was not from territorial vanity that the new arrival added “of La
+Huchette” to his name, but to make himself the better known.
+
+La Huchette, in fact, was an estate near Yonville, where he had just
+bought the chateau and two farms that he cultivated himself, without,
+however, troubling very much about them. He lived as a bachelor, and was
+supposed to have “at least fifteen thousand francs a year.”
+
+Charles came into the room. Monsieur Boulanger introduced his man, who
+wanted to be bled because he felt “a tingling all over.”
+
+“That’ll purge me,” he urged as an objection to all reasoning.
+
+So Bovary ordered a bandage and a basin, and asked Justin to hold it.
+Then addressing the peasant, who was already pale--
+
+“Don’t be afraid, my lad.”
+
+“No, no, sir,” said the other; “get on.”
+
+And with an air of bravado he held out his great arm. At the prick of
+the lancet the blood spurted out, splashing against the looking-glass.
+
+“Hold the basin nearer,” exclaimed Charles.
+
+“Lor!” said the peasant, “one would swear it was a little fountain
+flowing. How red my blood is! That’s a good sign, isn’t it?”
+
+“Sometimes,” answered the doctor, “one feels nothing at first, and then
+syncope sets in, and more especially with people of strong constitution
+like this man.”
+
+At these words the rustic let go the lancet-case he was twisting between
+his fingers. A shudder of his shoulders made the chair-back creak. His
+hat fell off.
+
+“I thought as much,” said Bovary, pressing his finger on the vein.
+
+The basin was beginning to tremble in Justin’s hands; his knees shook,
+he turned pale.
+
+“Emma! Emma!” called Charles.
+
+With one bound she came down the staircase.
+
+“Some vinegar,” he cried. “O dear! two at once!”
+
+And in his emotion he could hardly put on the compress.
+
+“It is nothing,” said Monsieur Boulanger quietly, taking Justin in his
+arms. He seated him on the table with his back resting against the wall.
+
+Madame Bovary began taking off his cravat. The strings of his shirt had
+got into a knot, and she was for some minutes moving her light fingers
+about the young fellow’s neck. Then she poured some vinegar on her
+cambric handkerchief; she moistened his temples with little dabs, and
+then blew upon them softly. The ploughman revived, but Justin’s syncope
+still lasted, and his eyeballs disappeared in the pale sclerotics like
+blue flowers in milk.
+
+“We must hide this from him,” said Charles.
+
+Madame Bovary took the basin to put it under the table. With the
+movement she made in bending down, her dress (it was a summer dress with
+four flounces, yellow, long in the waist and wide in the skirt) spread
+out around her on the flags of the room; and as Emma stooping, staggered
+a little as she stretched out her arms.
+
+The stuff here and there gave with the inflections of her bust.
+
+Then she went to fetch a bottle of water, and she was melting some
+pieces of sugar when the chemist arrived. The servant had been to
+fetch him in the tumult. Seeing his pupil’s eyes staring he drew a long
+breath; then going around him he looked at him from head to foot.
+
+“Fool!” he said, “really a little fool! A fool in four letters! A
+phlebotomy’s a big affair, isn’t it! And a fellow who isn’t afraid of
+anything; a kind of squirrel, just as he is who climbs to vertiginous
+heights to shake down nuts. Oh, yes! you just talk to me, boast about
+yourself! Here’s a fine fitness for practising pharmacy later on; for
+under serious circumstances you may be called before the tribunals in
+order to enlighten the minds of the magistrates, and you would have to
+keep your head then, to reason, show yourself a man, or else pass for an
+imbecile.”
+
+Justin did not answer. The chemist went on--
+
+“Who asked you to come? You are always pestering the doctor and madame.
+On Wednesday, moreover, your presence is indispensable to me. There are
+now twenty people in the shop. I left everything because of the interest
+I take in you. Come, get along! Sharp! Wait for me, and keep an eye on
+the jars.”
+
+When Justin, who was rearranging his dress, had gone, they talked for a
+little while about fainting-fits. Madame Bovary had never fainted.
+
+“That is extraordinary for a lady,” said Monsieur Boulanger; “but some
+people are very susceptible. Thus in a duel, I have seen a second lose
+consciousness at the mere sound of the loading of pistols.”
+
+“For my part,” said the chemist, “the sight of other people’s blood
+doesn’t affect me at all, but the mere thought of my own flowing would
+make me faint if I reflected upon it too much.”
+
+Monsieur Boulanger, however, dismissed his servant, advising him to calm
+himself, since his fancy was over.
+
+“It procured me the advantage of making your acquaintance,” he added,
+and he looked at Emma as he said this. Then he put three francs on the
+corner of the table, bowed negligently, and went out.
+
+He was soon on the other side of the river (this was his way back to La
+Huchette), and Emma saw him in the meadow, walking under the poplars,
+slackening his pace now and then as one who reflects.
+
+“She is very pretty,” he said to himself; “she is very pretty, this
+doctor’s wife. Fine teeth, black eyes, a dainty foot, a figure like a
+Parisienne’s. Where the devil does she come from? Wherever did that fat
+fellow pick her up?”
+
+Monsieur Rodolphe Boulanger was thirty-four; he was of brutal
+temperament and intelligent perspicacity, having, moreover, had much to
+do with women, and knowing them well. This one had seemed pretty to him;
+so he was thinking about her and her husband.
+
+“I think he is very stupid. She is tired of him, no doubt. He has dirty
+nails, and hasn’t shaved for three days. While he is trotting after his
+patients, she sits there botching socks. And she gets bored! She would
+like to live in town and dance polkas every evening. Poor little woman!
+She is gaping after love like a carp after water on a kitchen-table.
+With three words of gallantry she’d adore one, I’m sure of it. She’d be
+tender, charming. Yes; but how to get rid of her afterwards?”
+
+Then the difficulties of love-making seen in the distance made him by
+contrast think of his mistress. She was an actress at Rouen, whom he
+kept; and when he had pondered over this image, with which, even in
+remembrance, he was satiated--
+
+“Ah! Madame Bovary,” he thought, “is much prettier, especially fresher.
+Virginie is decidedly beginning to grow fat. She is so finiky about her
+pleasures; and, besides, she has a mania for prawns.”
+
+The fields were empty, and around him Rodolphe only heard the regular
+beating of the grass striking against his boots, with a cry of the
+grasshopper hidden at a distance among the oats. He again saw Emma in
+her room, dressed as he had seen her, and he undressed her.
+
+“Oh, I will have her,” he cried, striking a blow with his stick at a
+clod in front of him. And he at once began to consider the political
+part of the enterprise. He asked himself--
+
+“Where shall we meet? By what means? We shall always be having the brat
+on our hands, and the servant, the neighbours, and husband, all sorts of
+worries. Pshaw! one would lose too much time over it.”
+
+Then he resumed, “She really has eyes that pierce one’s heart like a
+gimlet. And that pale complexion! I adore pale women!”
+
+When he reached the top of the Arguiel hills he had made up his mind.
+“It’s only finding the opportunities. Well, I will call in now and then.
+I’ll send them venison, poultry; I’ll have myself bled, if need be. We
+shall become friends; I’ll invite them to my place. By Jove!” added he,
+“there’s the agricultural show coming on. She’ll be there. I shall see
+her. We’ll begin boldly, for that’s the surest way.”
+
+
+
+Chapter Eight
+
+At last it came, the famous agricultural show. On the morning of the
+solemnity all the inhabitants at their doors were chatting over the
+preparations. The pediment of the town hall had been hung with garlands
+of ivy; a tent had been erected in a meadow for the banquet; and in the
+middle of the Place, in front of the church, a kind of bombarde was
+to announce the arrival of the prefect and the names of the successful
+farmers who had obtained prizes. The National Guard of Buchy (there was
+none at Yonville) had come to join the corps of firemen, of whom Binet
+was captain. On that day he wore a collar even higher than usual; and,
+tightly buttoned in his tunic, his figure was so stiff and motionless
+that the whole vital portion of his person seemed to have descended into
+his legs, which rose in a cadence of set steps with a single movement.
+As there was some rivalry between the tax-collector and the colonel,
+both, to show off their talents, drilled their men separately. One
+saw the red epaulettes and the black breastplates pass and re-pass
+alternately; there was no end to it, and it constantly began again.
+There had never been such a display of pomp. Several citizens had
+scoured their houses the evening before; tri-coloured flags hung from
+half-open windows; all the public-houses were full; and in the lovely
+weather the starched caps, the golden crosses, and the coloured
+neckerchiefs seemed whiter than snow, shone in the sun, and relieved
+with the motley colours the sombre monotony of the frock-coats and blue
+smocks. The neighbouring farmers’ wives, when they got off their horses,
+pulled out the long pins that fastened around them their dresses, turned
+up for fear of mud; and the husbands, for their part, in order to save
+their hats, kept their handkerchiefs around them, holding one corner
+between their teeth.
+
+The crowd came into the main street from both ends of the village.
+People poured in from the lanes, the alleys, the houses; and from time
+to time one heard knockers banging against doors closing behind women
+with their gloves, who were going out to see the fete. What was most
+admired were two long lamp-stands covered with lanterns, that flanked a
+platform on which the authorities were to sit. Besides this there were
+against the four columns of the town hall four kinds of poles,
+each bearing a small standard of greenish cloth, embellished with
+inscriptions in gold letters.
+
+On one was written, “To Commerce”; on the other, “To Agriculture”; on
+the third, “To Industry”; and on the fourth, “To the Fine Arts.”
+
+But the jubilation that brightened all faces seemed to darken that of
+Madame Lefrancois, the innkeeper. Standing on her kitchen-steps she
+muttered to herself, “What rubbish! what rubbish! With their canvas
+booth! Do they think the prefect will be glad to dine down there under
+a tent like a gipsy? They call all this fussing doing good to the place!
+Then it wasn’t worth while sending to Neufchatel for the keeper of a
+cookshop! And for whom? For cowherds! tatterdemalions!”
+
+The druggist was passing. He had on a frock-coat, nankeen trousers,
+beaver shoes, and, for a wonder, a hat with a low crown.
+
+“Your servant! Excuse me, I am in a hurry.” And as the fat widow asked
+where he was going--
+
+“It seems odd to you, doesn’t it, I who am always more cooped up in my
+laboratory than the man’s rat in his cheese.”
+
+“What cheese?” asked the landlady.
+
+“Oh, nothing! nothing!” Homais continued. “I merely wished to convey
+to you, Madame Lefrancois, that I usually live at home like a recluse.
+To-day, however, considering the circumstances, it is necessary--”
+
+“Oh, you’re going down there!” she said contemptuously.
+
+“Yes, I am going,” replied the druggist, astonished. “Am I not a member
+of the consulting commission?”
+
+Mere Lefrancois looked at him for a few moments, and ended by saying
+with a smile--
+
+“That’s another pair of shoes! But what does agriculture matter to you?
+Do you understand anything about it?”
+
+“Certainly I understand it, since I am a druggist--that is to say,
+a chemist. And the object of chemistry, Madame Lefrancois, being the
+knowledge of the reciprocal and molecular action of all natural bodies,
+it follows that agriculture is comprised within its domain. And, in
+fact, the composition of the manure, the fermentation of liquids, the
+analyses of gases, and the influence of miasmata, what, I ask you, is
+all this, if it isn’t chemistry, pure and simple?”
+
+The landlady did not answer. Homais went on--
+
+“Do you think that to be an agriculturist it is necessary to have tilled
+the earth or fattened fowls oneself? It is necessary rather to know the
+composition of the substances in question--the geological strata, the
+atmospheric actions, the quality of the soil, the minerals, the waters,
+the density of the different bodies, their capillarity, and what not.
+And one must be master of all the principles of hygiene in order to
+direct, criticize the construction of buildings, the feeding of animals,
+the diet of domestics. And, moreover, Madame Lefrancois, one must know
+botany, be able to distinguish between plants, you understand, which are
+the wholesome and those that are deleterious, which are unproductive
+and which nutritive, if it is well to pull them up here and re-sow them
+there, to propagate some, destroy others; in brief, one must keep pace
+with science by means of pamphlets and public papers, be always on the
+alert to find out improvements.”
+
+The landlady never took her eyes off the “Cafe Francois” and the chemist
+went on--
+
+“Would to God our agriculturists were chemists, or that at least they
+would pay more attention to the counsels of science. Thus lately I
+myself wrote a considerable tract, a memoir of over seventy-two pages,
+entitled, ‘Cider, its Manufacture and its Effects, together with some
+New Reflections on the Subject,’ that I sent to the Agricultural Society
+of Rouen, and which even procured me the honour of being received among
+its members--Section, Agriculture; Class, Pomological. Well, if my
+work had been given to the public--” But the druggist stopped, Madame
+Lefrancois seemed so preoccupied.
+
+“Just look at them!” she said. “It’s past comprehension! Such a cookshop
+as that!” And with a shrug of the shoulders that stretched out over her
+breast the stitches of her knitted bodice, she pointed with both hands
+at her rival’s inn, whence songs were heard issuing. “Well, it won’t
+last long,” she added. “It’ll be over before a week.”
+
+Homais drew back with stupefaction. She came down three steps and
+whispered in his ear--
+
+“What! you didn’t know it? There is to be an execution in next week.
+It’s Lheureux who is selling him out; he has killed him with bills.”
+
+“What a terrible catastrophe!” cried the druggist, who always found
+expressions in harmony with all imaginable circumstances.
+
+Then the landlady began telling him the story that she had heard from
+Theodore, Monsieur Guillaumin’s servant, and although she detested
+Tellier, she blamed Lheureux. He was “a wheedler, a sneak.”
+
+“There!” she said. “Look at him! he is in the market; he is bowing to
+Madame Bovary, who’s got on a green bonnet. Why, she’s taking Monsieur
+Boulanger’s arm.”
+
+“Madame Bovary!” exclaimed Homais. “I must go at once and pay her my
+respects. Perhaps she’ll be very glad to have a seat in the enclosure
+under the peristyle.” And, without heeding Madame Lefrancois, who was
+calling him back to tell him more about it, the druggist walked off
+rapidly with a smile on his lips, with straight knees, bowing copiously
+to right and left, and taking up much room with the large tails of his
+frock-coat that fluttered behind him in the wind.
+
+Rodolphe, having caught sight of him from afar, hurried on, but Madame
+Bovary lost her breath; so he walked more slowly, and, smiling at her,
+said in a rough tone--
+
+“It’s only to get away from that fat fellow, you know, the druggist.”
+ She pressed his elbow.
+
+“What’s the meaning of that?” he asked himself. And he looked at her out
+of the corner of his eyes.
+
+Her profile was so calm that one could guess nothing from it. It stood
+out in the light from the oval of her bonnet, with pale ribbons on it
+like the leaves of weeds. Her eyes with their long curved lashes looked
+straight before her, and though wide open, they seemed slightly puckered
+by the cheek-bones, because of the blood pulsing gently under the
+delicate skin. A pink line ran along the partition between her nostrils.
+Her head was bent upon her shoulder, and the pearl tips of her white
+teeth were seen between her lips.
+
+“Is she making fun of me?” thought Rodolphe.
+
+Emma’s gesture, however, had only been meant for a warning; for Monsieur
+Lheureux was accompanying them, and spoke now and again as if to enter
+into the conversation.
+
+“What a superb day! Everybody is out! The wind is east!”
+
+And neither Madame Bovary nor Rodolphe answered him, whilst at the
+slightest movement made by them he drew near, saying, “I beg your
+pardon!” and raised his hat.
+
+When they reached the farrier’s house, instead of following the road
+up to the fence, Rodolphe suddenly turned down a path, drawing with him
+Madame Bovary. He called out--
+
+“Good evening, Monsieur Lheureux! See you again presently.”
+
+“How you got rid of him!” she said, laughing.
+
+“Why,” he went on, “allow oneself to be intruded upon by others? And as
+to-day I have the happiness of being with you--”
+
+Emma blushed. He did not finish his sentence. Then he talked of the fine
+weather and of the pleasure of walking on the grass. A few daisies had
+sprung up again.
+
+“Here are some pretty Easter daisies,” he said, “and enough of them to
+furnish oracles to all the amorous maids in the place.”
+
+He added, “Shall I pick some? What do you think?”
+
+“Are you in love?” she asked, coughing a little.
+
+“H’m, h’m! who knows?” answered Rodolphe.
+
+The meadow began to fill, and the housewives hustled you with their
+great umbrellas, their baskets, and their babies. One had often to get
+out of the way of a long file of country folk, servant-maids with blue
+stockings, flat shoes, silver rings, and who smelt of milk, when one
+passed close to them. They walked along holding one another by the hand,
+and thus they spread over the whole field from the row of open trees to
+the banquet tent.
+
+But this was the examination time, and the farmers one after the other
+entered a kind of enclosure formed by a long cord supported on sticks.
+
+The beasts were there, their noses towards the cord, and making a
+confused line with their unequal rumps. Drowsy pigs were burrowing in
+the earth with their snouts, calves were bleating, lambs baaing; the
+cows, on knees folded in, were stretching their bellies on the grass,
+slowly chewing the cud, and blinking their heavy eyelids at the gnats
+that buzzed round them. Plough-men with bare arms were holding by the
+halter prancing stallions that neighed with dilated nostrils looking
+towards the mares. These stood quietly, stretching out their heads and
+flowing manes, while their foals rested in their shadow, or now and then
+came and sucked them. And above the long undulation of these crowded
+animals one saw some white mane rising in the wind like a wave, or some
+sharp horns sticking out, and the heads of men running about. Apart,
+outside the enclosure, a hundred paces off, was a large black bull,
+muzzled, with an iron ring in its nostrils, and who moved no more than
+if he had been in bronze. A child in rags was holding him by a rope.
+
+Between the two lines the committee-men were walking with heavy steps,
+examining each animal, then consulting one another in a low voice. One
+who seemed of more importance now and then took notes in a book as he
+walked along. This was the president of the jury, Monsieur Derozerays de
+la Panville. As soon as he recognised Rodolphe he came forward quickly,
+and smiling amiably, said--
+
+“What! Monsieur Boulanger, you are deserting us?”
+
+Rodolphe protested that he was just coming. But when the president had
+disappeared--
+
+“Ma foi!*” said he, “I shall not go. Your company is better than his.”
+
+     *Upon my word!
+
+And while poking fun at the show, Rodolphe, to move about more easily,
+showed the gendarme his blue card, and even stopped now and then in
+front of some fine beast, which Madame Bovary did not at all admire.
+He noticed this, and began jeering at the Yonville ladies and their
+dresses; then he apologised for the negligence of his own. He had that
+incongruity of common and elegant in which the habitually vulgar think
+they see the revelation of an eccentric existence, of the perturbations
+of sentiment, the tyrannies of art, and always a certain contempt for
+social conventions, that seduces or exasperates them. Thus his cambric
+shirt with plaited cuffs was blown out by the wind in the opening of his
+waistcoat of grey ticking, and his broad-striped trousers disclosed at
+the ankle nankeen boots with patent leather gaiters.
+
+These were so polished that they reflected the grass. He trampled on
+horses’s dung with them, one hand in the pocket of his jacket and his
+straw hat on one side.
+
+“Besides,” added he, “when one lives in the country--”
+
+“It’s waste of time,” said Emma.
+
+“That is true,” replied Rodolphe. “To think that not one of these people
+is capable of understanding even the cut of a coat!”
+
+Then they talked about provincial mediocrity, of the lives it crushed,
+the illusions lost there.
+
+“And I too,” said Rodolphe, “am drifting into depression.”
+
+“You!” she said in astonishment; “I thought you very light-hearted.”
+
+“Ah! yes. I seem so, because in the midst of the world I know how to
+wear the mask of a scoffer upon my face; and yet, how many a time at the
+sight of a cemetery by moonlight have I not asked myself whether it were
+not better to join those sleeping there!”
+
+“Oh! and your friends?” she said. “You do not think of them.”
+
+“My friends! What friends? Have I any? Who cares for me?” And he
+accompanied the last words with a kind of whistling of the lips.
+
+But they were obliged to separate from each other because of a great
+pile of chairs that a man was carrying behind them. He was so overladen
+with them that one could only see the tips of his wooden shoes and the
+ends of his two outstretched arms. It was Lestiboudois, the gravedigger,
+who was carrying the church chairs about amongst the people. Alive to
+all that concerned his interests, he had hit upon this means of turning
+the show to account; and his idea was succeeding, for he no longer knew
+which way to turn. In fact, the villagers, who were hot, quarreled for
+these seats, whose straw smelt of incense, and they leant against the
+thick backs, stained with the wax of candles, with a certain veneration.
+
+Madame Bovary again took Rodolphe’s arm; he went on as if speaking to
+himself--
+
+“Yes, I have missed so many things. Always alone! Ah! if I had some aim
+in life, if I had met some love, if I had found someone! Oh, how I would
+have spent all the energy of which I am capable, surmounted everything,
+overcome everything!”
+
+“Yet it seems to me,” said Emma, “that you are not to be pitied.”
+
+“Ah! you think so?” said Rodolphe.
+
+“For, after all,” she went on, “you are free--” she hesitated, “rich--”
+
+“Do not mock me,” he replied.
+
+And she protested that she was not mocking him, when the report of a
+cannon resounded. Immediately all began hustling one another pell-mell
+towards the village.
+
+It was a false alarm. The prefect seemed not to be coming, and the
+members of the jury felt much embarrassed, not knowing if they ought to
+begin the meeting or still wait.
+
+At last at the end of the Place a large hired landau appeared, drawn by
+two thin horses, which a coachman in a white hat was whipping lustily.
+Binet had only just time to shout, “Present arms!” and the colonel to
+imitate him. All ran towards the enclosure; everyone pushed forward. A
+few even forgot their collars; but the equipage of the prefect seemed
+to anticipate the crowd, and the two yoked jades, trapesing in their
+harness, came up at a little trot in front of the peristyle of the town
+hall at the very moment when the National Guard and firemen deployed,
+beating drums and marking time.
+
+“Present!” shouted Binet.
+
+“Halt!” shouted the colonel. “Left about, march.”
+
+And after presenting arms, during which the clang of the band, letting
+loose, rang out like a brass kettle rolling downstairs, all the guns
+were lowered. Then was seen stepping down from the carriage a gentleman
+in a short coat with silver braiding, with bald brow, and wearing a tuft
+of hair at the back of his head, of a sallow complexion and the most
+benign appearance. His eyes, very large and covered by heavy lids, were
+half-closed to look at the crowd, while at the same time he raised his
+sharp nose, and forced a smile upon his sunken mouth. He recognised the
+mayor by his scarf, and explained to him that the prefect was not able
+to come. He himself was a councillor at the prefecture; then he added
+a few apologies. Monsieur Tuvache answered them with compliments; the
+other confessed himself nervous; and they remained thus, face to face,
+their foreheads almost touching, with the members of the jury all round,
+the municipal council, the notable personages, the National Guard and
+the crowd. The councillor pressing his little cocked hat to his
+breast repeated his bows, while Tuvache, bent like a bow, also smiled,
+stammered, tried to say something, protested his devotion to the
+monarchy and the honour that was being done to Yonville.
+
+Hippolyte, the groom from the inn, took the head of the horses from the
+coachman, and, limping along with his club-foot, led them to the door
+of the “Lion d’Or”, where a number of peasants collected to look at the
+carriage. The drum beat, the howitzer thundered, and the gentlemen one
+by one mounted the platform, where they sat down in red utrecht velvet
+arm-chairs that had been lent by Madame Tuvache.
+
+All these people looked alike. Their fair flabby faces, somewhat tanned
+by the sun, were the colour of sweet cider, and their puffy whiskers
+emerged from stiff collars, kept up by white cravats with broad bows.
+All the waist-coats were of velvet, double-breasted; all the watches
+had, at the end of a long ribbon, an oval cornelian seal; everyone
+rested his two hands on his thighs, carefully stretching the stride of
+their trousers, whose unsponged glossy cloth shone more brilliantly than
+the leather of their heavy boots.
+
+The ladies of the company stood at the back under the vestibule between
+the pillars while the common herd was opposite, standing up or sitting
+on chairs. As a matter of fact, Lestiboudois had brought thither all
+those that he had moved from the field, and he even kept running back
+every minute to fetch others from the church. He caused such confusion
+with this piece of business that one had great difficulty in getting to
+the small steps of the platform.
+
+“I think,” said Monsieur Lheureux to the chemist, who was passing to his
+place, “that they ought to have put up two Venetian masts with something
+rather severe and rich for ornaments; it would have been a very pretty
+effect.”
+
+“To be sure,” replied Homais; “but what can you expect? The mayor took
+everything on his own shoulders. He hasn’t much taste. Poor Tuvache! and
+he is even completely destitute of what is called the genius of art.”
+
+Rodolphe, meanwhile, with Madame Bovary, had gone up to the first
+floor of the town hall, to the “council-room,” and, as it was empty,
+he declared that they could enjoy the sight there more comfortably. He
+fetched three stools from the round table under the bust of the monarch,
+and having carried them to one of the windows, they sat down by each
+other.
+
+There was commotion on the platform, long whisperings, much parleying.
+At last the councillor got up. They knew now that his name was Lieuvain,
+and in the crowd the name was passed from one to the other. After he had
+collated a few pages, and bent over them to see better, he began--
+
+“Gentlemen! May I be permitted first of all (before addressing you on
+the object of our meeting to-day, and this sentiment will, I am sure, be
+shared by you all), may I be permitted, I say, to pay a tribute to the
+higher administration, to the government to the monarch, gentle men, our
+sovereign, to that beloved king, to whom no branch of public or private
+prosperity is a matter of indifference, and who directs with a hand at
+once so firm and wise the chariot of the state amid the incessant perils
+of a stormy sea, knowing, moreover, how to make peace respected as well
+as war, industry, commerce, agriculture, and the fine arts?”
+
+“I ought,” said Rodolphe, “to get back a little further.”
+
+“Why?” said Emma.
+
+But at this moment the voice of the councillor rose to an extraordinary
+pitch. He declaimed--
+
+“This is no longer the time, gentlemen, when civil discord ensanguined
+our public places, when the landlord, the business-man, the working-man
+himself, falling asleep at night, lying down to peaceful sleep, trembled
+lest he should be awakened suddenly by the noise of incendiary tocsins,
+when the most subversive doctrines audaciously sapped foundations.”
+
+“Well, someone down there might see me,” Rodolphe resumed, “then
+I should have to invent excuses for a fortnight; and with my bad
+reputation--”
+
+“Oh, you are slandering yourself,” said Emma.
+
+“No! It is dreadful, I assure you.”
+
+“But, gentlemen,” continued the councillor, “if, banishing from my
+memory the remembrance of these sad pictures, I carry my eyes back
+to the actual situation of our dear country, what do I see there?
+Everywhere commerce and the arts are flourishing; everywhere new means
+of communication, like so many new arteries in the body of the state,
+establish within it new relations. Our great industrial centres have
+recovered all their activity; religion, more consolidated, smiles in
+all hearts; our ports are full, confidence is born again, and France
+breathes once more!”
+
+“Besides,” added Rodolphe, “perhaps from the world’s point of view they
+are right.”
+
+“How so?” she asked.
+
+“What!” said he. “Do you not know that there are souls constantly
+tormented? They need by turns to dream and to act, the purest passions
+and the most turbulent joys, and thus they fling themselves into all
+sorts of fantasies, of follies.”
+
+Then she looked at him as one looks at a traveller who has voyaged over
+strange lands, and went on--
+
+“We have not even this distraction, we poor women!”
+
+“A sad distraction, for happiness isn’t found in it.”
+
+“But is it ever found?” she asked.
+
+“Yes; one day it comes,” he answered.
+
+“And this is what you have understood,” said the councillor.
+
+“You, farmers, agricultural labourers! you pacific pioneers of a work
+that belongs wholly to civilization! you, men of progress and morality,
+you have understood, I say, that political storms are even more
+redoubtable than atmospheric disturbances!”
+
+“It comes one day,” repeated Rodolphe, “one day suddenly, and when
+one is despairing of it. Then the horizon expands; it is as if a voice
+cried, ‘It is here!’ You feel the need of confiding the whole of your
+life, of giving everything, sacrificing everything to this being. There
+is no need for explanations; they understand one another. They have seen
+each other in dreams!”
+
+(And he looked at her.) “In fine, here it is, this treasure so sought
+after, here before you. It glitters, it flashes; yet one still doubts,
+one does not believe it; one remains dazzled, as if one went out from
+darkness into light.”
+
+And as he ended Rodolphe suited the action to the word. He passed his
+hand over his face, like a man seized with giddiness. Then he let it
+fall on Emma’s. She took hers away.
+
+“And who would be surprised at it, gentlemen? He only who is so blind,
+so plunged (I do not fear to say it), so plunged in the prejudices
+of another age as still to misunderstand the spirit of agricultural
+populations. Where, indeed, is to be found more patriotism than in the
+country, greater devotion to the public welfare, more intelligence, in a
+word? And, gentlemen, I do not mean that superficial intelligence,
+vain ornament of idle minds, but rather that profound and balanced
+intelligence that applies itself above all else to useful objects, thus
+contributing to the good of all, to the common amelioration and to
+the support of the state, born of respect for law and the practice of
+duty--”
+
+“Ah! again!” said Rodolphe. “Always ‘duty.’ I am sick of the word.
+They are a lot of old blockheads in flannel vests and of old women with
+foot-warmers and rosaries who constantly drone into our ears ‘Duty,
+duty!’ Ah! by Jove! one’s duty is to feel what is great, cherish the
+beautiful, and not accept all the conventions of society with the
+ignominy that it imposes upon us.”
+
+“Yet--yet--” objected Madame Bovary.
+
+“No, no! Why cry out against the passions? Are they not the one
+beautiful thing on the earth, the source of heroism, of enthusiasm, of
+poetry, music, the arts, of everything, in a word?”
+
+“But one must,” said Emma, “to some extent bow to the opinion of the
+world and accept its moral code.”
+
+“Ah! but there are two,” he replied. “The small, the conventional, that
+of men, that which constantly changes, that brays out so loudly, that
+makes such a commotion here below, of the earth earthly, like the mass
+of imbeciles you see down there. But the other, the eternal, that is
+about us and above, like the landscape that surrounds us, and the blue
+heavens that give us light.”
+
+Monsieur Lieuvain had just wiped his mouth with a pocket-handkerchief.
+He continued--
+
+“And what should I do here gentlemen, pointing out to you the uses
+of agriculture? Who supplies our wants? Who provides our means of
+subsistence? Is it not the agriculturist? The agriculturist, gentlemen,
+who, sowing with laborious hand the fertile furrows of the country,
+brings forth the corn, which, being ground, is made into a powder by
+means of ingenious machinery, comes out thence under the name of flour,
+and from there, transported to our cities, is soon delivered at the
+baker’s, who makes it into food for poor and rich alike. Again, is it
+not the agriculturist who fattens, for our clothes, his abundant
+flocks in the pastures? For how should we clothe ourselves, how nourish
+ourselves, without the agriculturist? And, gentlemen, is it even
+necessary to go so far for examples? Who has not frequently reflected
+on all the momentous things that we get out of that modest animal, the
+ornament of poultry-yards, that provides us at once with a soft pillow
+for our bed, with succulent flesh for our tables, and eggs? But I should
+never end if I were to enumerate one after the other all the different
+products which the earth, well cultivated, like a generous mother,
+lavishes upon her children. Here it is the vine, elsewhere the apple
+tree for cider, there colza, farther on cheeses and flax. Gentlemen, let
+us not forget flax, which has made such great strides of late years, and
+to which I will more particularly call your attention.”
+
+He had no need to call it, for all the mouths of the multitude were wide
+open, as if to drink in his words. Tuvache by his side listened to him
+with staring eyes. Monsieur Derozerays from time to time softly closed
+his eyelids, and farther on the chemist, with his son Napoleon between
+his knees, put his hand behind his ear in order not to lose a syllable.
+The chins of the other members of the jury went slowly up and down in
+their waistcoats in sign of approval. The firemen at the foot of the
+platform rested on their bayonets; and Binet, motionless, stood with
+out-turned elbows, the point of his sabre in the air. Perhaps he could
+hear, but certainly he could see nothing, because of the visor of his
+helmet, that fell down on his nose. His lieutenant, the youngest son of
+Monsieur Tuvache, had a bigger one, for his was enormous, and shook on
+his head, and from it an end of his cotton scarf peeped out. He smiled
+beneath it with a perfectly infantine sweetness, and his pale little
+face, whence drops were running, wore an expression of enjoyment and
+sleepiness.
+
+The square as far as the houses was crowded with people. One saw folk
+leaning on their elbows at all the windows, others standing at doors,
+and Justin, in front of the chemist’s shop, seemed quite transfixed by
+the sight of what he was looking at. In spite of the silence Monsieur
+Lieuvain’s voice was lost in the air. It reached you in fragments of
+phrases, and interrupted here and there by the creaking of chairs in the
+crowd; then you suddenly heard the long bellowing of an ox, or else the
+bleating of the lambs, who answered one another at street corners. In
+fact, the cowherds and shepherds had driven their beasts thus far, and
+these lowed from time to time, while with their tongues they tore down
+some scrap of foliage that hung above their mouths.
+
+Rodolphe had drawn nearer to Emma, and said to her in a low voice,
+speaking rapidly--
+
+“Does not this conspiracy of the world revolt you? Is there a single
+sentiment it does not condemn? The noblest instincts, the purest
+sympathies are persecuted, slandered; and if at length two poor souls do
+meet, all is so organised that they cannot blend together. Yet they will
+make the attempt; they will flutter their wings; they will call upon
+each other. Oh! no matter. Sooner or later, in six months, ten years,
+they will come together, will love; for fate has decreed it, and they
+are born one for the other.”
+
+His arms were folded across his knees, and thus lifting his face towards
+Emma, close by her, he looked fixedly at her. She noticed in his eyes
+small golden lines radiating from black pupils; she even smelt the
+perfume of the pomade that made his hair glossy.
+
+Then a faintness came over her; she recalled the Viscount who had
+waltzed with her at Vaubyessard, and his beard exhaled like this air an
+odour of vanilla and citron, and mechanically she half-closed her eyes
+the better to breathe it in. But in making this movement, as she leant
+back in her chair, she saw in the distance, right on the line of the
+horizon, the old diligence, the “Hirondelle,” that was slowly descending
+the hill of Leux, dragging after it a long trail of dust. It was in this
+yellow carriage that Leon had so often come back to her, and by this
+route down there that he had gone for ever. She fancied she saw him
+opposite at his windows; then all grew confused; clouds gathered; it
+seemed to her that she was again turning in the waltz under the light of
+the lustres on the arm of the Viscount, and that Leon was not far away,
+that he was coming; and yet all the time she was conscious of the scent
+of Rodolphe’s head by her side. This sweetness of sensation pierced
+through her old desires, and these, like grains of sand under a gust
+of wind, eddied to and fro in the subtle breath of the perfume which
+suffused her soul. She opened wide her nostrils several times to drink
+in the freshness of the ivy round the capitals. She took off her gloves,
+she wiped her hands, then fanned her face with her handkerchief, while
+athwart the throbbing of her temples she heard the murmur of the
+crowd and the voice of the councillor intoning his phrases. He
+said--“Continue, persevere; listen neither to the suggestions of
+routine, nor to the over-hasty councils of a rash empiricism.
+
+“Apply yourselves, above all, to the amelioration of the soil, to good
+manures, to the development of the equine, bovine, ovine, and porcine
+races. Let these shows be to you pacific arenas, where the victor in
+leaving it will hold forth a hand to the vanquished, and will fraternise
+with him in the hope of better success. And you, aged servants, humble
+domestics, whose hard labour no Government up to this day has taken into
+consideration, come hither to receive the reward of your silent virtues,
+and be assured that the state henceforward has its eye upon you; that it
+encourages you, protects you; that it will accede to your just
+demands, and alleviate as much as in it lies the burden of your painful
+sacrifices.”
+
+Monsieur Lieuvain then sat down; Monsieur Derozerays got up, beginning
+another speech. His was not perhaps so florid as that of the councillor,
+but it recommended itself by a more direct style, that is to say, by
+more special knowledge and more elevated considerations. Thus the praise
+of the Government took up less space in it; religion and agriculture
+more. He showed in it the relations of these two, and how they had
+always contributed to civilisation. Rodolphe with Madame Bovary was
+talking dreams, presentiments, magnetism. Going back to the cradle of
+society, the orator painted those fierce times when men lived on acorns
+in the heart of woods. Then they had left off the skins of beasts, had
+put on cloth, tilled the soil, planted the vine. Was this a good, and
+in this discovery was there not more of injury than of gain? Monsieur
+Derozerays set himself this problem. From magnetism little by little
+Rodolphe had come to affinities, and while the president was citing
+Cincinnatus and his plough, Diocletian, planting his cabbages, and the
+Emperors of China inaugurating the year by the sowing of seed, the
+young man was explaining to the young woman that these irresistible
+attractions find their cause in some previous state of existence.
+
+“Thus we,” he said, “why did we come to know one another? What chance
+willed it? It was because across the infinite, like two streams that
+flow but to unite; our special bents of mind had driven us towards each
+other.”
+
+And he seized her hand; she did not withdraw it.
+
+“For good farming generally!” cried the president.
+
+“Just now, for example, when I went to your house.”
+
+“To Monsieur Bizat of Quincampoix.”
+
+“Did I know I should accompany you?”
+
+“Seventy francs.”
+
+“A hundred times I wished to go; and I followed you--I remained.”
+
+“Manures!”
+
+“And I shall remain to-night, to-morrow, all other days, all my life!”
+
+“To Monsieur Caron of Argueil, a gold medal!”
+
+“For I have never in the society of any other person found so complete a
+charm.”
+
+“To Monsieur Bain of Givry-Saint-Martin.”
+
+“And I shall carry away with me the remembrance of you.”
+
+“For a merino ram!”
+
+“But you will forget me; I shall pass away like a shadow.”
+
+“To Monsieur Belot of Notre-Dame.”
+
+“Oh, no! I shall be something in your thought, in your life, shall I
+not?”
+
+“Porcine race; prizes--equal, to Messrs. Leherisse and Cullembourg,
+sixty francs!”
+
+Rodolphe was pressing her hand, and he felt it all warm and quivering
+like a captive dove that wants to fly away; but, whether she was trying
+to take it away or whether she was answering his pressure; she made a
+movement with her fingers. He exclaimed--
+
+“Oh, I thank you! You do not repulse me! You are good! You understand
+that I am yours! Let me look at you; let me contemplate you!”
+
+A gust of wind that blew in at the window ruffled the cloth on the
+table, and in the square below all the great caps of the peasant women
+were uplifted by it like the wings of white butterflies fluttering.
+
+“Use of oil-cakes,” continued the president. He was hurrying on:
+“Flemish manure-flax-growing-drainage-long leases-domestic service.”
+
+Rodolphe was no longer speaking. They looked at one another. A supreme
+desire made their dry lips tremble, and wearily, without an effort,
+their fingers intertwined.
+
+“Catherine Nicaise Elizabeth Leroux, of Sassetot-la-Guerriere, for
+fifty-four years of service at the same farm, a silver medal--value,
+twenty-five francs!”
+
+“Where is Catherine Leroux?” repeated the councillor.
+
+She did not present herself, and one could hear voices whispering--
+
+“Go up!”
+
+“Don’t be afraid!”
+
+“Oh, how stupid she is!”
+
+“Well, is she there?” cried Tuvache.
+
+“Yes; here she is.”
+
+“Then let her come up!”
+
+Then there came forward on the platform a little old woman with timid
+bearing, who seemed to shrink within her poor clothes. On her feet she
+wore heavy wooden clogs, and from her hips hung a large blue apron. Her
+pale face framed in a borderless cap was more wrinkled than a withered
+russet apple. And from the sleeves of her red jacket looked out two
+large hands with knotty joints, the dust of barns, the potash of washing
+the grease of wools had so encrusted, roughened, hardened these that
+they seemed dirty, although they had been rinsed in clear water; and
+by dint of long service they remained half open, as if to bear humble
+witness for themselves of so much suffering endured. Something of
+monastic rigidity dignified her face. Nothing of sadness or of emotion
+weakened that pale look. In her constant living with animals she had
+caught their dumbness and their calm. It was the first time that she
+found herself in the midst of so large a company, and inwardly scared by
+the flags, the drums, the gentlemen in frock-coats, and the order of the
+councillor, she stood motionless, not knowing whether to advance or run
+away, nor why the crowd was pushing her and the jury were smiling at
+her.
+
+Thus stood before these radiant bourgeois this half-century of
+servitude.
+
+“Approach, venerable Catherine Nicaise Elizabeth Leroux!” said the
+councillor, who had taken the list of prize-winners from the president;
+and, looking at the piece of paper and the old woman by turns, he
+repeated in a fatherly tone--“Approach! approach!”
+
+“Are you deaf?” said Tuvache, fidgeting in his armchair; and he began
+shouting in her ear, “Fifty-four years of service. A silver medal!
+Twenty-five francs! For you!”
+
+Then, when she had her medal, she looked at it, and a smile of beatitude
+spread over her face; and as she walked away they could hear her
+muttering “I’ll give it to our cure up home, to say some masses for me!”
+
+“What fanaticism!” exclaimed the chemist, leaning across to the notary.
+
+The meeting was over, the crowd dispersed, and now that the speeches had
+been read, each one fell back into his place again, and everything into
+the old grooves; the masters bullied the servants, and these struck the
+animals, indolent victors, going back to the stalls, a green-crown on
+their horns.
+
+The National Guards, however, had gone up to the first floor of the
+town hall with buns spitted on their bayonets, and the drummer of the
+battalion carried a basket with bottles. Madame Bovary took Rodolphe’s
+arm; he saw her home; they separated at her door; then he walked about
+alone in the meadow while he waited for the time of the banquet.
+
+The feast was long, noisy, ill served; the guests were so crowded that
+they could hardly move their elbows; and the narrow planks used for
+forms almost broke down under their weight. They ate hugely. Each one
+stuffed himself on his own account. Sweat stood on every brow, and a
+whitish steam, like the vapour of a stream on an autumn morning, floated
+above the table between the hanging lamps. Rodolphe, leaning against
+the calico of the tent was thinking so earnestly of Emma that he heard
+nothing. Behind him on the grass the servants were piling up the dirty
+plates, his neighbours were talking; he did not answer them; they filled
+his glass, and there was silence in his thoughts in spite of the growing
+noise. He was dreaming of what she had said, of the line of her lips;
+her face, as in a magic mirror, shone on the plates of the shakos, the
+folds of her gown fell along the walls, and days of love unrolled to all
+infinity before him in the vistas of the future.
+
+He saw her again in the evening during the fireworks, but she was with
+her husband, Madame Homais, and the druggist, who was worrying about the
+danger of stray rockets, and every moment he left the company to go and
+give some advice to Binet.
+
+The pyrotechnic pieces sent to Monsieur Tuvache had, through an excess
+of caution, been shut up in his cellar, and so the damp powder would
+not light, and the principal set piece, that was to represent a dragon
+biting his tail, failed completely. Now and then a meagre Roman-candle
+went off; then the gaping crowd sent up a shout that mingled with the
+cry of the women, whose waists were being squeezed in the darkness. Emma
+silently nestled against Charles’s shoulder; then, raising her chin, she
+watched the luminous rays of the rockets against the dark sky. Rodolphe
+gazed at her in the light of the burning lanterns.
+
+They went out one by one. The stars shone out. A few crops of rain began
+to fall. She knotted her fichu round her bare head.
+
+At this moment the councillor’s carriage came out from the inn.
+
+His coachman, who was drunk, suddenly dozed off, and one could see from
+the distance, above the hood, between the two lanterns, the mass of his
+body, that swayed from right to left with the giving of the traces.
+
+“Truly,” said the druggist, “one ought to proceed most rigorously
+against drunkenness! I should like to see written up weekly at the door
+of the town hall on a board ad hoc* the names of all those who during
+the week got intoxicated on alcohol. Besides, with regard to statistics,
+one would thus have, as it were, public records that one could refer to
+in case of need. But excuse me!”
+
+     *Specifically for that.
+
+And he once more ran off to the captain. The latter was going back to
+see his lathe again.
+
+“Perhaps you would not do ill,” Homais said to him, “to send one of your
+men, or to go yourself--”
+
+“Leave me alone!” answered the tax-collector. “It’s all right!”
+
+“Do not be uneasy,” said the druggist, when he returned to his friends.
+“Monsieur Binet has assured me that all precautions have been taken. No
+sparks have fallen; the pumps are full. Let us go to rest.”
+
+“Ma foi! I want it,” said Madame Homais, yawning at large. “But never
+mind; we’ve had a beautiful day for our fete.”
+
+Rodolphe repeated in a low voice, and with a tender look, “Oh, yes! very
+beautiful!”
+
+And having bowed to one another, they separated.
+
+Two days later, in the “Final de Rouen,” there was a long article on the
+show. Homais had composed it with verve the very next morning.
+
+“Why these festoons, these flowers, these garlands? Whither hurries this
+crowd like the waves of a furious sea under the torrents of a tropical
+sun pouring its heat upon our heads?”
+
+Then he spoke of the condition of the peasants. Certainly the Government
+was doing much, but not enough. “Courage!” he cried to it; “a thousand
+reforms are indispensable; let us accomplish them!” Then touching on
+the entry of the councillor, he did not forget “the martial air of our
+militia;” nor “our most merry village maidens;” nor the “bald-headed old
+men like patriarchs who were there, and of whom some, the remnants of
+our phalanxes, still felt their hearts beat at the manly sound of the
+drums.” He cited himself among the first of the members of the jury,
+and he even called attention in a note to the fact that Monsieur Homais,
+chemist, had sent a memoir on cider to the agricultural society.
+
+When he came to the distribution of the prizes, he painted the joy of
+the prize-winners in dithyrambic strophes. “The father embraced the son,
+the brother the brother, the husband his consort. More than one showed
+his humble medal with pride; and no doubt when he got home to his good
+housewife, he hung it up weeping on the modest walls of his cot.
+
+“About six o’clock a banquet prepared in the meadow of Monsieur Leigeard
+brought together the principal personages of the fete. The greatest
+cordiality reigned here. Divers toasts were proposed: Monsieur
+Lieuvain, the King; Monsieur Tuvache, the Prefect; Monsieur Derozerays,
+Agriculture; Monsieur Homais, Industry and the Fine Arts, those twin
+sisters; Monsieur Leplichey, Progress. In the evening some brilliant
+fireworks on a sudden illumined the air. One would have called it a
+veritable kaleidoscope, a real operatic scene; and for a moment our
+little locality might have thought itself transported into the midst of
+a dream of the ‘Thousand and One Nights.’ Let us state that no untoward
+event disturbed this family meeting.” And he added “Only the absence
+of the clergy was remarked. No doubt the priests understand progress in
+another fashion. Just as you please, messieurs the followers of Loyola!”
+
+
+
+Chapter Nine
+
+Six weeks passed. Rodolphe did not come again. At last one evening he
+appeared.
+
+The day after the show he had said to himself--“We mustn’t go back too
+soon; that would be a mistake.”
+
+And at the end of a week he had gone off hunting. After the hunting he
+had thought it was too late, and then he reasoned thus--
+
+“If from the first day she loved me, she must from impatience to see me
+again love me more. Let’s go on with it!”
+
+And he knew that his calculation had been right when, on entering the
+room, he saw Emma turn pale.
+
+She was alone. The day was drawing in. The small muslin curtain along
+the windows deepened the twilight, and the gilding of the barometer, on
+which the rays of the sun fell, shone in the looking-glass between the
+meshes of the coral.
+
+Rodolphe remained standing, and Emma hardly answered his first
+conventional phrases.
+
+“I,” he said, “have been busy. I have been ill.”
+
+“Seriously?” she cried.
+
+“Well,” said Rodolphe, sitting down at her side on a footstool, “no; it
+was because I did not want to come back.”
+
+“Why?”
+
+“Can you not guess?”
+
+He looked at her again, but so hard that she lowered her head, blushing.
+He went on--
+
+“Emma!”
+
+“Sir,” she said, drawing back a little.
+
+“Ah! you see,” replied he in a melancholy voice, “that I was right not
+to come back; for this name, this name that fills my whole soul, and
+that escaped me, you forbid me to use! Madame Bovary! why all the
+world calls you thus! Besides, it is not your name; it is the name of
+another!”
+
+He repeated, “of another!” And he hid his face in his hands.
+
+“Yes, I think of you constantly. The memory of you drives me to despair.
+Ah! forgive me! I will leave you! Farewell! I will go far away, so far
+that you will never hear of me again; and yet--to-day--I know not what
+force impelled me towards you. For one does not struggle against Heaven;
+one cannot resist the smile of angels; one is carried away by that which
+is beautiful, charming, adorable.”
+
+It was the first time that Emma had heard such words spoken to herself,
+and her pride, like one who reposes bathed in warmth, expanded softly
+and fully at this glowing language.
+
+“But if I did not come,” he continued, “if I could not see you, at least
+I have gazed long on all that surrounds you. At night-every night-I
+arose; I came hither; I watched your house, its glimmering in the moon,
+the trees in the garden swaying before your window, and the little lamp,
+a gleam shining through the window-panes in the darkness. Ah! you never
+knew that there, so near you, so far from you, was a poor wretch!”
+
+She turned towards him with a sob.
+
+“Oh, you are good!” she said.
+
+“No, I love you, that is all! You do not doubt that! Tell me--one
+word--only one word!”
+
+And Rodolphe imperceptibly glided from the footstool to the ground; but
+a sound of wooden shoes was heard in the kitchen, and he noticed the
+door of the room was not closed.
+
+“How kind it would be of you,” he went on, rising, “if you would humour
+a whim of mine.” It was to go over her house; he wanted to know it; and
+Madame Bovary seeing no objection to this, they both rose, when Charles
+came in.
+
+“Good morning, doctor,” Rodolphe said to him.
+
+The doctor, flattered at this unexpected title, launched out into
+obsequious phrases. Of this the other took advantage to pull himself
+together a little.
+
+“Madame was speaking to me,” he then said, “about her health.”
+
+Charles interrupted him; he had indeed a thousand anxieties; his wife’s
+palpitations of the heart were beginning again. Then Rodolphe asked if
+riding would not be good.
+
+“Certainly! excellent! just the thing! There’s an idea! You ought to
+follow it up.”
+
+And as she objected that she had no horse, Monsieur Rodolphe offered
+one. She refused his offer; he did not insist. Then to explain his visit
+he said that his ploughman, the man of the blood-letting, still suffered
+from giddiness.
+
+“I’ll call around,” said Bovary.
+
+“No, no! I’ll send him to you; we’ll come; that will be more convenient
+for you.”
+
+“Ah! very good! I thank you.”
+
+And as soon as they were alone, “Why don’t you accept Monsieur
+Boulanger’s kind offer?”
+
+She assumed a sulky air, invented a thousand excuses, and finally
+declared that perhaps it would look odd.
+
+“Well, what the deuce do I care for that?” said Charles, making a
+pirouette. “Health before everything! You are wrong.”
+
+“And how do you think I can ride when I haven’t got a habit?”
+
+“You must order one,” he answered.
+
+The riding-habit decided her.
+
+When the habit was ready, Charles wrote to Monsieur Boulanger that his
+wife was at his command, and that they counted on his good-nature.
+
+The next day at noon Rodolphe appeared at Charles’s door with two
+saddle-horses. One had pink rosettes at his ears and a deerskin
+side-saddle.
+
+Rodolphe had put on high soft boots, saying to himself that no doubt she
+had never seen anything like them. In fact, Emma was charmed with his
+appearance as he stood on the landing in his great velvet coat and white
+corduroy breeches. She was ready; she was waiting for him.
+
+Justin escaped from the chemist’s to see her start, and the chemist also
+came out. He was giving Monsieur Boulanger a little good advice.
+
+“An accident happens so easily. Be careful! Your horses perhaps are
+mettlesome.”
+
+She heard a noise above her; it was Felicite drumming on the windowpanes
+to amuse little Berthe. The child blew her a kiss; her mother answered
+with a wave of her whip.
+
+“A pleasant ride!” cried Monsieur Homais. “Prudence! above all,
+prudence!” And he flourished his newspaper as he saw them disappear.
+
+As soon as he felt the ground, Emma’s horse set off at a gallop.
+
+Rodolphe galloped by her side. Now and then they exchanged a word. Her
+figure slightly bent, her hand well up, and her right arm stretched out,
+she gave herself up to the cadence of the movement that rocked her in
+her saddle. At the bottom of the hill Rodolphe gave his horse its head;
+they started together at a bound, then at the top suddenly the horses
+stopped, and her large blue veil fell about her.
+
+It was early in October. There was fog over the land. Hazy clouds
+hovered on the horizon between the outlines of the hills; others, rent
+asunder, floated up and disappeared. Sometimes through a rift in the
+clouds, beneath a ray of sunshine, gleamed from afar the roots of
+Yonville, with the gardens at the water’s edge, the yards, the walls and
+the church steeple. Emma half closed her eyes to pick out her house, and
+never had this poor village where she lived appeared so small. From the
+height on which they were the whole valley seemed an immense pale lake
+sending off its vapour into the air. Clumps of trees here and there
+stood out like black rocks, and the tall lines of the poplars that rose
+above the mist were like a beach stirred by the wind.
+
+By the side, on the turf between the pines, a brown light shimmered
+in the warm atmosphere. The earth, ruddy like the powder of tobacco,
+deadened the noise of their steps, and with the edge of their shoes the
+horses as they walked kicked the fallen fir cones in front of them.
+
+Rodolphe and Emma thus went along the skirt of the wood. She turned
+away from time to time to avoid his look, and then she saw only the pine
+trunks in lines, whose monotonous succession made her a little giddy.
+The horses were panting; the leather of the saddles creaked.
+
+Just as they were entering the forest the sun shone out.
+
+“God protects us!” said Rodolphe.
+
+“Do you think so?” she said.
+
+“Forward! forward!” he continued.
+
+He “tchk’d” with his tongue. The two beasts set off at a trot.
+
+Long ferns by the roadside caught in Emma’s stirrup.
+
+Rodolphe leant forward and removed them as they rode along. At other
+times, to turn aside the branches, he passed close to her, and Emma felt
+his knee brushing against her leg. The sky was now blue, the leaves no
+longer stirred. There were spaces full of heather in flower, and plots
+of violets alternated with the confused patches of the trees that were
+grey, fawn, or golden coloured, according to the nature of their leaves.
+Often in the thicket was heard the fluttering of wings, or else the
+hoarse, soft cry of the ravens flying off amidst the oaks.
+
+They dismounted. Rodolphe fastened up the horses. She walked on in
+front on the moss between the paths. But her long habit got in her way,
+although she held it up by the skirt; and Rodolphe, walking behind her,
+saw between the black cloth and the black shoe the fineness of her white
+stocking, that seemed to him as if it were a part of her nakedness.
+
+She stopped. “I am tired,” she said.
+
+“Come, try again,” he went on. “Courage!”
+
+Then some hundred paces farther on she again stopped, and through her
+veil, that fell sideways from her man’s hat over her hips, her face
+appeared in a bluish transparency as if she were floating under azure
+waves.
+
+“But where are we going?”
+
+He did not answer. She was breathing irregularly. Rodolphe looked round
+him biting his moustache. They came to a larger space where the coppice
+had been cut. They sat down on the trunk of a fallen tree, and Rodolphe
+began speaking to her of his love. He did not begin by frightening her
+with compliments. He was calm, serious, melancholy.
+
+Emma listened to him with bowed head, and stirred the bits of wood on
+the ground with the tip of her foot. But at the words, “Are not our
+destinies now one?”
+
+“Oh, no!” she replied. “You know that well. It is impossible!” She rose
+to go. He seized her by the wrist. She stopped. Then, having gazed
+at him for a few moments with an amorous and humid look, she said
+hurriedly--
+
+“Ah! do not speak of it again! Where are the horses? Let us go back.”
+
+He made a gesture of anger and annoyance. She repeated:
+
+“Where are the horses? Where are the horses?”
+
+Then smiling a strange smile, his pupil fixed, his teeth set, he
+advanced with outstretched arms. She recoiled trembling. She stammered:
+
+“Oh, you frighten me! You hurt me! Let me go!”
+
+“If it must be,” he went on, his face changing; and he again became
+respectful, caressing, timid. She gave him her arm. They went back. He
+said--
+
+“What was the matter with you? Why? I do not understand. You were
+mistaken, no doubt. In my soul you are as a Madonna on a pedestal, in
+a place lofty, secure, immaculate. But I need you to live! I must have
+your eyes, your voice, your thought! Be my friend, my sister, my angel!”
+
+And he put out his arm round her waist. She feebly tried to disengage
+herself. He supported her thus as they walked along.
+
+But they heard the two horses browsing on the leaves.
+
+“Oh! one moment!” said Rodolphe. “Do not let us go! Stay!”
+
+He drew her farther on to a small pool where duckweeds made a greenness
+on the water. Faded water lilies lay motionless between the reeds.
+At the noise of their steps in the grass, frogs jumped away to hide
+themselves.
+
+“I am wrong! I am wrong!” she said. “I am mad to listen to you!”
+
+“Why? Emma! Emma!”
+
+“Oh, Rodolphe!” said the young woman slowly, leaning on his shoulder.
+
+The cloth of her habit caught against the velvet of his coat. She threw
+back her white neck, swelling with a sigh, and faltering, in tears, with
+a long shudder and hiding her face, she gave herself up to him--
+
+The shades of night were falling; the horizontal sun passing between the
+branches dazzled the eyes. Here and there around her, in the leaves
+or on the ground, trembled luminous patches, as it hummingbirds flying
+about had scattered their feathers. Silence was everywhere; something
+sweet seemed to come forth from the trees; she felt her heart, whose
+beating had begun again, and the blood coursing through her flesh like a
+stream of milk. Then far away, beyond the wood, on the other hills, she
+heard a vague prolonged cry, a voice which lingered, and in silence she
+heard it mingling like music with the last pulsations of her throbbing
+nerves. Rodolphe, a cigar between his lips, was mending with his
+penknife one of the two broken bridles.
+
+They returned to Yonville by the same road. On the mud they saw again
+the traces of their horses side by side, the same thickets, the same
+stones to the grass; nothing around them seemed changed; and yet for her
+something had happened more stupendous than if the mountains had moved
+in their places. Rodolphe now and again bent forward and took her hand
+to kiss it.
+
+She was charming on horseback--upright, with her slender waist, her knee
+bent on the mane of her horse, her face somewhat flushed by the fresh
+air in the red of the evening.
+
+On entering Yonville she made her horse prance in the road. People
+looked at her from the windows.
+
+At dinner her husband thought she looked well, but she pretended not to
+hear him when he inquired about her ride, and she remained sitting there
+with her elbow at the side of her plate between the two lighted candles.
+
+“Emma!” he said.
+
+“What?”
+
+“Well, I spent the afternoon at Monsieur Alexandre’s. He has an old cob,
+still very fine, only a little broken-kneed, and that could be bought; I
+am sure, for a hundred crowns.” He added, “And thinking it might please
+you, I have bespoken it--bought it. Have I done right? Do tell me?”
+
+She nodded her head in assent; then a quarter of an hour later--
+
+“Are you going out to-night?” she asked.
+
+“Yes. Why?”
+
+“Oh, nothing, nothing, my dear!”
+
+And as soon as she had got rid of Charles she went and shut herself up
+in her room.
+
+At first she felt stunned; she saw the trees, the paths, the ditches,
+Rodolphe, and she again felt the pressure of his arm, while the leaves
+rustled and the reeds whistled.
+
+But when she saw herself in the glass she wondered at her face. Never
+had her eyes been so large, so black, of so profound a depth. Something
+subtle about her being transfigured her. She repeated, “I have a lover!
+a lover!” delighting at the idea as if a second puberty had come to her.
+So at last she was to know those joys of love, that fever of happiness
+of which she had despaired! She was entering upon marvels where all
+would be passion, ecstasy, delirium. An azure infinity encompassed
+her, the heights of sentiment sparkled under her thought, and ordinary
+existence appeared only afar off, down below in the shade, through the
+interspaces of these heights.
+
+Then she recalled the heroines of the books that she had read, and the
+lyric legion of these adulterous women began to sing in her memory with
+the voice of sisters that charmed her. She became herself, as it were,
+an actual part of these imaginings, and realised the love-dream of her
+youth as she saw herself in this type of amorous women whom she had
+so envied. Besides, Emma felt a satisfaction of revenge. Had she not
+suffered enough? But now she triumphed, and the love so long pent up
+burst forth in full joyous bubblings. She tasted it without remorse,
+without anxiety, without trouble.
+
+The day following passed with a new sweetness. They made vows to one
+another She told him of her sorrows. Rodolphe interrupted her with
+kisses; and she looking at him through half-closed eyes, asked him to
+call her again by her name--to say that he loved her They were in the
+forest, as yesterday, in the shed of some woodenshoe maker. The walls
+were of straw, and the roof so low they had to stoop. They were seated
+side by side on a bed of dry leaves.
+
+From that day forth they wrote to one another regularly every evening.
+Emma placed her letter at the end of the garden, by the river, in a
+fissure of the wall. Rodolphe came to fetch it, and put another there,
+that she always found fault with as too short.
+
+One morning, when Charles had gone out before day break, she was seized
+with the fancy to see Rodolphe at once. She would go quickly to La
+Huchette, stay there an hour, and be back again at Yonville while
+everyone was still asleep. This idea made her pant with desire, and she
+soon found herself in the middle of the field, walking with rapid steps,
+without looking behind her.
+
+Day was just breaking. Emma from afar recognised her lover’s house. Its
+two dove-tailed weathercocks stood out black against the pale dawn.
+
+Beyond the farmyard there was a detached building that she thought must
+be the chateau She entered--it was if the doors at her approach had
+opened wide of their own accord. A large straight staircase led up to
+the corridor. Emma raised the latch of a door, and suddenly at the end
+of the room she saw a man sleeping. It was Rodolphe. She uttered a cry.
+
+“You here? You here?” he repeated. “How did you manage to come? Ah! your
+dress is damp.”
+
+“I love you,” she answered, throwing her arms about his neck.
+
+This first piece of daring successful, now every time Charles went out
+early Emma dressed quickly and slipped on tiptoe down the steps that led
+to the waterside.
+
+But when the plank for the cows was taken up, she had to go by the walls
+alongside of the river; the bank was slippery; in order not to fall
+she caught hold of the tufts of faded wallflowers. Then she went across
+ploughed fields, in which she sank, stumbling; and clogging her thin
+shoes. Her scarf, knotted round her head, fluttered to the wind in the
+meadows. She was afraid of the oxen; she began to run; she arrived out
+of breath, with rosy cheeks, and breathing out from her whole person a
+fresh perfume of sap, of verdure, of the open air. At this hour Rodolphe
+still slept. It was like a spring morning coming into his room.
+
+The yellow curtains along the windows let a heavy, whitish light enter
+softly. Emma felt about, opening and closing her eyes, while the drops
+of dew hanging from her hair formed, as it were, a topaz aureole around
+her face. Rodolphe, laughing, drew her to him, and pressed her to his
+breast.
+
+Then she examined the apartment, opened the drawers of the tables,
+combed her hair with his comb, and looked at herself in his
+shaving-glass. Often she even put between her teeth the big pipe that
+lay on the table by the bed, amongst lemons and pieces of sugar near a
+bottle of water.
+
+It took them a good quarter of an hour to say goodbye. Then Emma cried.
+She would have wished never to leave Rodolphe. Something stronger than
+herself forced her to him; so much so, that one day, seeing her come
+unexpectedly, he frowned as one put out.
+
+“What is the matter with you?” she said. “Are you ill? Tell me!”
+
+At last he declared with a serious air that her visits were becoming
+imprudent--that she was compromising herself.
+
+
+
+Chapter Ten
+
+Gradually Rodolphe’s fears took possession of her. At first, love had
+intoxicated her; and she had thought of nothing beyond. But now that he
+was indispensable to her life, she feared to lose anything of this, or
+even that it should be disturbed. When she came back from his house she
+looked all about her, anxiously watching every form that passed in the
+horizon, and every village window from which she could be seen. She
+listened for steps, cries, the noise of the ploughs, and she stopped
+short, white, and trembling more than the aspen leaves swaying overhead.
+
+One morning as she was thus returning, she suddenly thought she saw the
+long barrel of a carbine that seemed to be aimed at her. It stuck out
+sideways from the end of a small tub half-buried in the grass on the
+edge of a ditch. Emma, half-fainting with terror, nevertheless walked
+on, and a man stepped out of the tub like a Jack-in-the-box. He had
+gaiters buckled up to the knees, his cap pulled down over his eyes,
+trembling lips, and a red nose. It was Captain Binet lying in ambush for
+wild ducks.
+
+“You ought to have called out long ago!” he exclaimed; “When one sees a
+gun, one should always give warning.”
+
+The tax-collector was thus trying to hide the fright he had had, for
+a prefectorial order having prohibited duckhunting except in boats,
+Monsieur Binet, despite his respect for the laws, was infringing them,
+and so he every moment expected to see the rural guard turn up. But
+this anxiety whetted his pleasure, and, all alone in his tub, he
+congratulated himself on his luck and on his cuteness. At sight of
+Emma he seemed relieved from a great weight, and at once entered upon a
+conversation.
+
+“It isn’t warm; it’s nipping.”
+
+Emma answered nothing. He went on--
+
+“And you’re out so early?”
+
+“Yes,” she said stammering; “I am just coming from the nurse where my
+child is.”
+
+“Ah! very good! very good! For myself, I am here, just as you see me,
+since break of day; but the weather is so muggy, that unless one had the
+bird at the mouth of the gun--”
+
+“Good evening, Monsieur Binet,” she interrupted him, turning on her
+heel.
+
+“Your servant, madame,” he replied drily; and he went back into his tub.
+
+Emma regretted having left the tax-collector so abruptly. No doubt he
+would form unfavourable conjectures. The story about the nurse was the
+worst possible excuse, everyone at Yonville knowing that the little
+Bovary had been at home with her parents for a year. Besides, no one
+was living in this direction; this path led only to La Huchette. Binet,
+then, would guess whence she came, and he would not keep silence; he
+would talk, that was certain. She remained until evening racking her
+brain with every conceivable lying project, and had constantly before
+her eyes that imbecile with the game-bag.
+
+Charles after dinner, seeing her gloomy, proposed, by way of
+distraction, to take her to the chemist’s, and the first person she
+caught sight of in the shop was the taxcollector again. He was standing
+in front of the counter, lit up by the gleams of the red bottle, and was
+saying--
+
+“Please give me half an ounce of vitriol.”
+
+“Justin,” cried the druggist, “bring us the sulphuric acid.” Then to
+Emma, who was going up to Madame Homais’ room, “No, stay here; it isn’t
+worth while going up; she is just coming down. Warm yourself at the
+stove in the meantime. Excuse me. Good-day, doctor,” (for the chemist
+much enjoyed pronouncing the word “doctor,” as if addressing another by
+it reflected on himself some of the grandeur that he found in it). “Now,
+take care not to upset the mortars! You’d better fetch some chairs from
+the little room; you know very well that the arm-chairs are not to be
+taken out of the drawing-room.”
+
+And to put his arm-chair back in its place he was darting away from the
+counter, when Binet asked him for half an ounce of sugar acid.
+
+“Sugar acid!” said the chemist contemptuously, “don’t know it; I’m
+ignorant of it! But perhaps you want oxalic acid. It is oxalic acid,
+isn’t it?”
+
+Binet explained that he wanted a corrosive to make himself some
+copperwater with which to remove rust from his hunting things.
+
+Emma shuddered. The chemist began saying--
+
+“Indeed the weather is not propitious on account of the damp.”
+
+“Nevertheless,” replied the tax-collector, with a sly look, “there are
+people who like it.”
+
+She was stifling.
+
+“And give me--”
+
+“Will he never go?” thought she.
+
+“Half an ounce of resin and turpentine, four ounces of yellow wax,
+and three half ounces of animal charcoal, if you please, to clean the
+varnished leather of my togs.”
+
+The druggist was beginning to cut the wax when Madame Homais appeared,
+Irma in her arms, Napoleon by her side, and Athalie following. She sat
+down on the velvet seat by the window, and the lad squatted down on a
+footstool, while his eldest sister hovered round the jujube box near
+her papa. The latter was filling funnels and corking phials, sticking on
+labels, making up parcels. Around him all were silent; only from time
+to time, were heard the weights jingling in the balance, and a few low
+words from the chemist giving directions to his pupil.
+
+“And how’s the little woman?” suddenly asked Madame Homais.
+
+“Silence!” exclaimed her husband, who was writing down some figures in
+his waste-book.
+
+“Why didn’t you bring her?” she went on in a low voice.
+
+“Hush! hush!” said Emma, pointing with her finger to the druggist.
+
+But Binet, quite absorbed in looking over his bill, had probably heard
+nothing. At last he went out. Then Emma, relieved, uttered a deep sigh.
+
+“How hard you are breathing!” said Madame Homais.
+
+“Well, you see, it’s rather warm,” she replied.
+
+So the next day they talked over how to arrange their rendezvous. Emma
+wanted to bribe her servant with a present, but it would be better to
+find some safe house at Yonville. Rodolphe promised to look for one.
+
+All through the winter, three or four times a week, in the dead of night
+he came to the garden. Emma had on purpose taken away the key of the
+gate, which Charles thought lost.
+
+To call her, Rodolphe threw a sprinkle of sand at the shutters. She
+jumped up with a start; but sometimes he had to wait, for Charles had a
+mania for chatting by the fireside, and he would not stop. She was wild
+with impatience; if her eyes could have done it, she would have hurled
+him out at the window. At last she would begin to undress, then take up
+a book, and go on reading very quietly as if the book amused her. But
+Charles, who was in bed, called to her to come too.
+
+“Come, now, Emma,” he said, “it is time.”
+
+“Yes, I am coming,” she answered.
+
+Then, as the candles dazzled him; he turned to the wall and fell asleep.
+She escaped, smiling, palpitating, undressed. Rodolphe had a large
+cloak; he wrapped her in it, and putting his arm round her waist, he
+drew her without a word to the end of the garden.
+
+It was in the arbour, on the same seat of old sticks where formerly Leon
+had looked at her so amorously on the summer evenings. She never thought
+of him now.
+
+The stars shone through the leafless jasmine branches. Behind them they
+heard the river flowing, and now and again on the bank the rustling
+of the dry reeds. Masses of shadow here and there loomed out in the
+darkness, and sometimes, vibrating with one movement, they rose up and
+swayed like immense black waves pressing forward to engulf them. The
+cold of the nights made them clasp closer; the sighs of their lips
+seemed to them deeper; their eyes that they could hardly see, larger;
+and in the midst of the silence low words were spoken that fell on
+their souls sonorous, crystalline, and that reverberated in multiplied
+vibrations.
+
+When the night was rainy, they took refuge in the consulting-room
+between the cart-shed and the stable. She lighted one of the kitchen
+candles that she had hidden behind the books. Rodolphe settled down
+there as if at home. The sight of the library, of the bureau, of the
+whole apartment, in fine, excited his merriment, and he could not
+refrain from making jokes about Charles, which rather embarrassed Emma.
+She would have liked to see him more serious, and even on occasions
+more dramatic; as, for example, when she thought she heard a noise of
+approaching steps in the alley.
+
+“Someone is coming!” she said.
+
+He blew out the light.
+
+“Have you your pistols?”
+
+“Why?”
+
+“Why, to defend yourself,” replied Emma.
+
+“From your husband? Oh, poor devil!” And Rodolphe finished his sentence
+with a gesture that said, “I could crush him with a flip of my finger.”
+
+She was wonder-stricken at his bravery, although she felt in it a sort
+of indecency and a naive coarseness that scandalised her.
+
+Rodolphe reflected a good deal on the affair of the pistols. If she had
+spoken seriously, it was very ridiculous, he thought, even odious; for
+he had no reason to hate the good Charles, not being what is called
+devoured by jealousy; and on this subject Emma had taken a great vow
+that he did not think in the best of taste.
+
+Besides, she was growing very sentimental. She had insisted on
+exchanging miniatures; they had cut off handfuls of hair, and now she
+was asking for a ring--a real wedding-ring, in sign of an eternal union.
+She often spoke to him of the evening chimes, of the voices of nature.
+Then she talked to him of her mother--hers! and of his mother--his!
+Rodolphe had lost his twenty years ago. Emma none the less consoled
+him with caressing words as one would have done a lost child, and she
+sometimes even said to him, gazing at the moon--
+
+“I am sure that above there together they approve of our love.”
+
+But she was so pretty. He had possessed so few women of such
+ingenuousness. This love without debauchery was a new experience for
+him, and, drawing him out of his lazy habits, caressed at once his pride
+and his sensuality. Emma’s enthusiasm, which his bourgeois good sense
+disdained, seemed to him in his heart of hearts charming, since it
+was lavished on him. Then, sure of being loved, he no longer kept up
+appearances, and insensibly his ways changed.
+
+He had no longer, as formerly, words so gentle that they made her cry,
+nor passionate caresses that made her mad, so that their great love,
+which engrossed her life, seemed to lessen beneath her like the water of
+a stream absorbed into its channel, and she could see the bed of it.
+She would not believe it; she redoubled in tenderness, and Rodolphe
+concealed his indifference less and less.
+
+She did not know if she regretted having yielded to him, or whether she
+did not wish, on the contrary, to enjoy him the more. The humiliation
+of feeling herself weak was turning to rancour, tempered by their
+voluptuous pleasures. It was not affection; it was like a continual
+seduction. He subjugated her; she almost feared him.
+
+Appearances, nevertheless, were calmer than ever, Rodolphe having
+succeeded in carrying out the adultery after his own fancy; and at the
+end of six months, when the spring-time came, they were to one another
+like a married couple, tranquilly keeping up a domestic flame.
+
+It was the time of year when old Rouault sent his turkey in remembrance
+of the setting of his leg. The present always arrived with a letter.
+Emma cut the string that tied it to the basket, and read the following
+lines:--
+
+“My Dear Children--I hope this will find you well, and that this one
+will be as good as the others. For it seems to me a little more tender,
+if I may venture to say so, and heavier. But next time, for a change,
+I’ll give you a turkeycock, unless you have a preference for some dabs;
+and send me back the hamper, if you please, with the two old ones. I
+have had an accident with my cart-sheds, whose covering flew off one
+windy night among the trees. The harvest has not been overgood either.
+Finally, I don’t know when I shall come to see you. It is so difficult
+now to leave the house since I am alone, my poor Emma.”
+
+Here there was a break in the lines, as if the old fellow had dropped
+his pen to dream a little while.
+
+“For myself, I am very well, except for a cold I caught the other day at
+the fair at Yvetot, where I had gone to hire a shepherd, having turned
+away mine because he was too dainty. How we are to be pitied with such
+a lot of thieves! Besides, he was also rude. I heard from a pedlar, who,
+travelling through your part of the country this winter, had a tooth
+drawn, that Bovary was as usual working hard. That doesn’t surprise me;
+and he showed me his tooth; we had some coffee together. I asked him if
+he had seen you, and he said not, but that he had seen two horses in the
+stables, from which I conclude that business is looking up. So much
+the better, my dear children, and may God send you every imaginable
+happiness! It grieves me not yet to have seen my dear little
+grand-daughter, Berthe Bovary. I have planted an Orleans plum-tree for
+her in the garden under your room, and I won’t have it touched unless it
+is to have jam made for her by and bye, that I will keep in the cupboard
+for her when she comes.
+
+“Good-bye, my dear children. I kiss you, my girl, you too, my
+son-in-law, and the little one on both cheeks. I am, with best
+compliments, your loving father.
+
+“Theodore Rouault.”
+
+She held the coarse paper in her fingers for some minutes. The spelling
+mistakes were interwoven one with the other, and Emma followed the
+kindly thought that cackled right through it like a hen half hidden
+in the hedge of thorns. The writing had been dried with ashes from
+the hearth, for a little grey powder slipped from the letter on to her
+dress, and she almost thought she saw her father bending over the hearth
+to take up the tongs. How long since she had been with him, sitting on
+the footstool in the chimney-corner, where she used to burn the end of
+a bit of wood in the great flame of the sea-sedges! She remembered the
+summer evenings all full of sunshine. The colts neighed when anyone
+passed by, and galloped, galloped. Under her window there was a beehive,
+and sometimes the bees wheeling round in the light struck against her
+window like rebounding balls of gold. What happiness there had been
+at that time, what freedom, what hope! What an abundance of illusions!
+Nothing was left of them now. She had got rid of them all in her soul’s
+life, in all her successive conditions of life, maidenhood, her marriage,
+and her love--thus constantly losing them all her life through, like
+a traveller who leaves something of his wealth at every inn along his
+road.
+
+But what then, made her so unhappy? What was the extraordinary
+catastrophe that had transformed her? And she raised her head, looking
+round as if to seek the cause of that which made her suffer.
+
+An April ray was dancing on the china of the whatnot; the fire burned;
+beneath her slippers she felt the softness of the carpet; the day was
+bright, the air warm, and she heard her child shouting with laughter.
+
+In fact, the little girl was just then rolling on the lawn in the midst
+of the grass that was being turned. She was lying flat on her stomach
+at the top of a rick. The servant was holding her by her skirt.
+Lestiboudois was raking by her side, and every time he came near she
+lent forward, beating the air with both her arms.
+
+“Bring her to me,” said her mother, rushing to embrace her. “How I love
+you, my poor child! How I love you!”
+
+Then noticing that the tips of her ears were rather dirty, she rang at
+once for warm water, and washed her, changed her linen, her stockings,
+her shoes, asked a thousand questions about her health, as if on the
+return from a long journey, and finally, kissing her again and crying
+a little, she gave her back to the servant, who stood quite
+thunderstricken at this excess of tenderness.
+
+That evening Rodolphe found her more serious than usual.
+
+“That will pass over,” he concluded; “it’s a whim:”
+
+And he missed three rendezvous running. When he did come, she showed
+herself cold and almost contemptuous.
+
+“Ah! you’re losing your time, my lady!”
+
+And he pretended not to notice her melancholy sighs, nor the
+handkerchief she took out.
+
+Then Emma repented. She even asked herself why she detested Charles; if
+it had not been better to have been able to love him? But he gave her
+no opportunities for such a revival of sentiment, so that she was much
+embarrassed by her desire for sacrifice, when the druggist came just in
+time to provide her with an opportunity.
+
+
+
+Chapter Eleven
+
+He had recently read a eulogy on a new method for curing club-foot, and
+as he was a partisan of progress, he conceived the patriotic idea that
+Yonville, in order to keep to the fore, ought to have some operations
+for strephopody or club-foot.
+
+“For,” said he to Emma, “what risk is there? See--” (and he enumerated
+on his fingers the advantages of the attempt), “success, almost certain
+relief and beautifying of the patient, celebrity acquired by the
+operator. Why, for example, should not your husband relieve poor
+Hippolyte of the ‘Lion d’Or’? Note that he would not fail to tell about
+his cure to all the travellers, and then” (Homais lowered his voice and
+looked round him) “who is to prevent me from sending a short paragraph
+on the subject to the paper? Eh! goodness me! an article gets about; it
+is talked of; it ends by making a snowball! And who knows? who knows?”
+
+In fact, Bovary might succeed. Nothing proved to Emma that he was not
+clever; and what a satisfaction for her to have urged him to a step by
+which his reputation and fortune would be increased! She only wished to
+lean on something more solid than love.
+
+Charles, urged by the druggist and by her, allowed himself to be
+persuaded. He sent to Rouen for Dr. Duval’s volume, and every evening,
+holding his head between both hands, plunged into the reading of it.
+
+While he was studying equinus, varus, and valgus, that is to say,
+katastrephopody, endostrephopody, and exostrephopody (or better, the
+various turnings of the foot downwards, inwards, and outwards, with the
+hypostrephopody and anastrephopody), otherwise torsion downwards and
+upwards, Monsier Homais, with all sorts of arguments, was exhorting the
+lad at the inn to submit to the operation.
+
+“You will scarcely feel, probably, a slight pain; it is a simple prick,
+like a little blood-letting, less than the extraction of certain corns.”
+
+Hippolyte, reflecting, rolled his stupid eyes.
+
+“However,” continued the chemist, “it doesn’t concern me. It’s for your
+sake, for pure humanity! I should like to see you, my friend, rid of
+your hideous caudication, together with that waddling of the lumbar
+regions which, whatever you say, must considerably interfere with you in
+the exercise of your calling.”
+
+Then Homais represented to him how much jollier and brisker he would
+feel afterwards, and even gave him to understand that he would be more
+likely to please the women; and the stable-boy began to smile heavily.
+Then he attacked him through his vanity:
+
+“Aren’t you a man? Hang it! what would you have done if you had had to
+go into the army, to go and fight beneath the standard? Ah! Hippolyte!”
+
+And Homais retired, declaring that he could not understand this
+obstinacy, this blindness in refusing the benefactions of science.
+
+The poor fellow gave way, for it was like a conspiracy. Binet, who never
+interfered with other people’s business, Madame Lefrancois, Artemise,
+the neighbours, even the mayor, Monsieur Tuvache--everyone persuaded
+him, lectured him, shamed him; but what finally decided him was that it
+would cost him nothing. Bovary even undertook to provide the machine
+for the operation. This generosity was an idea of Emma’s, and Charles
+consented to it, thinking in his heart of hearts that his wife was an
+angel.
+
+So by the advice of the chemist, and after three fresh starts, he had a
+kind of box made by the carpenter, with the aid of the locksmith,
+that weighed about eight pounds, and in which iron, wood, sheer-iron,
+leather, screws, and nuts had not been spared.
+
+But to know which of Hippolyte’s tendons to cut, it was necessary first
+of all to find out what kind of club-foot he had.
+
+He had a foot forming almost a straight line with the leg, which,
+however, did not prevent it from being turned in, so that it was an
+equinus together with something of a varus, or else a slight varus with
+a strong tendency to equinus. But with this equinus, wide in foot like
+a horse’s hoof, with rugose skin, dry tendons, and large toes, on which
+the black nails looked as if made of iron, the clubfoot ran about like
+a deer from morn till night. He was constantly to be seen on the Place,
+jumping round the carts, thrusting his limping foot forwards. He seemed
+even stronger on that leg than the other. By dint of hard service it had
+acquired, as it were, moral qualities of patience and energy; and
+when he was given some heavy work, he stood on it in preference to its
+fellow.
+
+Now, as it was an equinus, it was necessary to cut the tendon of
+Achilles, and, if need were, the anterior tibial muscle could be seen to
+afterwards for getting rid of the varus; for the doctor did not dare to
+risk both operations at once; he was even trembling already for fear of
+injuring some important region that he did not know.
+
+Neither Ambrose Pare, applying for the first time since Celsus, after an
+interval of fifteen centuries, a ligature to an artery, nor Dupuytren,
+about to open an abscess in the brain, nor Gensoul when he first took
+away the superior maxilla, had hearts that trembled, hands that shook,
+minds so strained as Monsieur Bovary when he approached Hippolyte, his
+tenotome between his fingers. And as at hospitals, near by on a table
+lay a heap of lint, with waxed thread, many bandages--a pyramid of
+bandages--every bandage to be found at the druggist’s. It was Monsieur
+Homais who since morning had been organising all these preparations,
+as much to dazzle the multitude as to keep up his illusions. Charles
+pierced the skin; a dry crackling was heard. The tendon was cut, the
+operation over. Hippolyte could not get over his surprise, but bent over
+Bovary’s hands to cover them with kisses.
+
+“Come, be calm,” said the druggist; “later on you will show your
+gratitude to your benefactor.”
+
+And he went down to tell the result to five or six inquirers who were
+waiting in the yard, and who fancied that Hippolyte would reappear
+walking properly. Then Charles, having buckled his patient into the
+machine, went home, where Emma, all anxiety, awaited him at the door.
+She threw herself on his neck; they sat down to table; he ate much,
+and at dessert he even wanted to take a cup of coffee, a luxury he only
+permitted himself on Sundays when there was company.
+
+The evening was charming, full of prattle, of dreams together. They
+talked about their future fortune, of the improvements to be made in
+their house; he saw people’s estimation of him growing, his comforts
+increasing, his wife always loving him; and she was happy to refresh
+herself with a new sentiment, healthier, better, to feel at last some
+tenderness for this poor fellow who adored her. The thought of Rodolphe
+for one moment passed through her mind, but her eyes turned again to
+Charles; she even noticed with surprise that he had not bad teeth.
+
+They were in bed when Monsieur Homais, in spite of the servant, suddenly
+entered the room, holding in his hand a sheet of paper just written. It
+was the paragraph he intended for the “Fanal de Rouen.” He brought it
+for them to read.
+
+“Read it yourself,” said Bovary.
+
+He read--
+
+“‘Despite the prejudices that still invest a part of the face of Europe
+like a net, the light nevertheless begins to penetrate our country
+places. Thus on Tuesday our little town of Yonville found itself the
+scene of a surgical operation which is at the same time an act of
+loftiest philanthropy. Monsieur Bovary, one of our most distinguished
+practitioners--’”
+
+“Oh, that is too much! too much!” said Charles, choking with emotion.
+
+“No, no! not at all! What next!”
+
+“‘--Performed an operation on a club-footed man.’ I have not used the
+scientific term, because you know in a newspaper everyone would not
+perhaps understand. The masses must--’”
+
+“No doubt,” said Bovary; “go on!”
+
+“I proceed,” said the chemist. “‘Monsieur Bovary, one of our most
+distinguished practitioners, performed an operation on a club-footed man
+called Hippolyte Tautain, stableman for the last twenty-five years at
+the hotel of the “Lion d’Or,” kept by Widow Lefrancois, at the Place
+d’Armes. The novelty of the attempt, and the interest incident to the
+subject, had attracted such a concourse of persons that there was
+a veritable obstruction on the threshold of the establishment. The
+operation, moreover, was performed as if by magic, and barely a
+few drops of blood appeared on the skin, as though to say that the
+rebellious tendon had at last given way beneath the efforts of art. The
+patient, strangely enough--we affirm it as an eye-witness--complained
+of no pain. His condition up to the present time leaves nothing to be
+desired. Everything tends to show that his convelescence will be brief;
+and who knows even if at our next village festivity we shall not see our
+good Hippolyte figuring in the bacchic dance in the midst of a chorus
+of joyous boon-companions, and thus proving to all eyes by his verve
+and his capers his complete cure? Honour, then, to the generous savants!
+Honour to those indefatigable spirits who consecrate their vigils to the
+amelioration or to the alleviation of their kind! Honour, thrice honour!
+Is it not time to cry that the blind shall see, the deaf hear, the lame
+walk? But that which fanaticism formerly promised to its elect, science
+now accomplishes for all men. We shall keep our readers informed as to
+the successive phases of this remarkable cure.’”
+
+This did not prevent Mere Lefrancois, from coming five days after,
+scared, and crying out--
+
+“Help! he is dying! I am going crazy!”
+
+Charles rushed to the “Lion d’Or,” and the chemist, who caught sight
+of him passing along the Place hatless, abandoned his shop. He appeared
+himself breathless, red, anxious, and asking everyone who was going up
+the stairs--
+
+“Why, what’s the matter with our interesting strephopode?”
+
+The strephopode was writhing in hideous convulsions, so that the machine
+in which his leg was enclosed was knocked against the wall enough to
+break it.
+
+With many precautions, in order not to disturb the position of the limb,
+the box was removed, and an awful sight presented itself. The outlines
+of the foot disappeared in such a swelling that the entire skin seemed
+about to burst, and it was covered with ecchymosis, caused by the famous
+machine. Hippolyte had already complained of suffering from it. No
+attention had been paid to him; they had to acknowledge that he had not
+been altogether wrong, and he was freed for a few hours. But, hardly had
+the oedema gone down to some extent, than the two savants thought fit
+to put back the limb in the apparatus, strapping it tighter to hasten
+matters. At last, three days after, Hippolyte being unable to endure it
+any longer, they once more removed the machine, and were much surprised
+at the result they saw. The livid tumefaction spread over the leg, with
+blisters here and there, whence there oozed a black liquid. Matters
+were taking a serious turn. Hippolyte began to worry himself, and Mere
+Lefrancois, had him installed in the little room near the kitchen, so
+that he might at least have some distraction.
+
+But the tax-collector, who dined there every day, complained bitterly of
+such companionship. Then Hippolyte was removed to the billiard-room.
+He lay there moaning under his heavy coverings, pale with long beard,
+sunken eyes, and from time to time turning his perspiring head on the
+dirty pillow, where the flies alighted. Madame Bovary went to see him.
+She brought him linen for his poultices; she comforted, and encouraged
+him. Besides, he did not want for company, especially on market-days,
+when the peasants were knocking about the billiard-balls round him,
+fenced with the cues, smoked, drank, sang, and brawled.
+
+“How are you?” they said, clapping him on the shoulder. “Ah! you’re not
+up to much, it seems, but it’s your own fault. You should do this! do
+that!” And then they told him stories of people who had all been cured
+by other remedies than his. Then by way of consolation they added--
+
+“You give way too much! Get up! You coddle yourself like a king! All the
+same, old chap, you don’t smell nice!”
+
+Gangrene, in fact, was spreading more and more. Bovary himself turned
+sick at it. He came every hour, every moment. Hippolyte looked at him
+with eyes full of terror, sobbing--
+
+“When shall I get well? Oh, save me! How unfortunate I am! How
+unfortunate I am!”
+
+And the doctor left, always recommending him to diet himself.
+
+“Don’t listen to him, my lad,” said Mere Lefrancois, “Haven’t they
+tortured you enough already? You’ll grow still weaker. Here! swallow
+this.”
+
+And she gave him some good beef-tea, a slice of mutton, a piece of
+bacon, and sometimes small glasses of brandy, that he had not the
+strength to put to his lips.
+
+Abbe Bournisien, hearing that he was growing worse, asked to see him.
+He began by pitying his sufferings, declaring at the same time that he
+ought to rejoice at them since it was the will of the Lord, and take
+advantage of the occasion to reconcile himself to Heaven.
+
+“For,” said the ecclesiastic in a paternal tone, “you rather neglected
+your duties; you were rarely seen at divine worship. How many years is
+it since you approached the holy table? I understand that your work,
+that the whirl of the world may have kept you from care for your
+salvation. But now is the time to reflect. Yet don’t despair. I have
+known great sinners, who, about to appear before God (you are not yet
+at this point I know), had implored His mercy, and who certainly died in
+the best frame of mind. Let us hope that, like them, you will set us a
+good example. Thus, as a precaution, what is to prevent you from saying
+morning and evening a ‘Hail Mary, full of grace,’ and ‘Our Father which
+art in heaven’? Yes, do that, for my sake, to oblige me. That won’t cost
+you anything. Will you promise me?”
+
+The poor devil promised. The cure came back day after day. He chatted
+with the landlady; and even told anecdotes interspersed with jokes and
+puns that Hippolyte did not understand. Then, as soon as he could, he
+fell back upon matters of religion, putting on an appropriate expression
+of face.
+
+His zeal seemed successful, for the club-foot soon manifested a desire
+to go on a pilgrimage to Bon-Secours if he were cured; to which Monsieur
+Bournisien replied that he saw no objection; two precautions were better
+than one; it was no risk anyhow.
+
+The druggist was indignant at what he called the manoeuvres of the
+priest; they were prejudicial, he said, to Hippolyte’s convalescence,
+and he kept repeating to Madame Lefrancois, “Leave him alone! leave him
+alone! You perturb his morals with your mysticism.” But the good woman
+would no longer listen to him; he was the cause of it all. From a spirit
+of contradiction she hung up near the bedside of the patient a basin
+filled with holy-water and a branch of box.
+
+Religion, however, seemed no more able to succour him than surgery, and
+the invincible gangrene still spread from the extremities towards
+the stomach. It was all very well to vary the potions and change the
+poultices; the muscles each day rotted more and more; and at last
+Charles replied by an affirmative nod of the head when Mere Lefrancois,
+asked him if she could not, as a forlorn hope, send for Monsieur Canivet
+of Neufchatel, who was a celebrity.
+
+A doctor of medicine, fifty years of age, enjoying a good position
+and self-possessed, Charles’s colleague did not refrain from laughing
+disdainfully when he had uncovered the leg, mortified to the knee. Then
+having flatly declared that it must be amputated, he went off to the
+chemist’s to rail at the asses who could have reduced a poor man to such
+a state. Shaking Monsieur Homais by the button of his coat, he shouted
+out in the shop--
+
+“These are the inventions of Paris! These are the ideas of those gentry
+of the capital! It is like strabismus, chloroform, lithotrity, a heap of
+monstrosities that the Government ought to prohibit. But they want to do
+the clever, and they cram you with remedies without, troubling about
+the consequences. We are not so clever, not we! We are not savants,
+coxcombs, fops! We are practitioners; we cure people, and we should
+not dream of operating on anyone who is in perfect health. Straighten
+club-feet! As if one could straighten club-feet! It is as if one wished,
+for example, to make a hunchback straight!”
+
+Homais suffered as he listened to this discourse, and he concealed his
+discomfort beneath a courtier’s smile; for he needed to humour Monsier
+Canivet, whose prescriptions sometimes came as far as Yonville. So he
+did not take up the defence of Bovary; he did not even make a single
+remark, and, renouncing his principles, he sacrificed his dignity to the
+more serious interests of his business.
+
+This amputation of the thigh by Doctor Canivet was a great event in the
+village. On that day all the inhabitants got up earlier, and the Grande
+Rue, although full of people, had something lugubrious about it, as
+if an execution had been expected. At the grocer’s they discussed
+Hippolyte’s illness; the shops did no business, and Madame Tuvache, the
+mayor’s wife, did not stir from her window, such was her impatience to
+see the operator arrive.
+
+He came in his gig, which he drove himself. But the springs of the right
+side having at length given way beneath the weight of his corpulence, it
+happened that the carriage as it rolled along leaned over a little, and
+on the other cushion near him could be seen a large box covered in red
+sheep-leather, whose three brass clasps shone grandly.
+
+After he had entered like a whirlwind the porch of the “Lion d’Or,” the
+doctor, shouting very loud, ordered them to unharness his horse. Then he
+went into the stable to see that she was eating her oats all right; for
+on arriving at a patient’s he first of all looked after his mare and his
+gig. People even said about this--
+
+“Ah! Monsieur Canivet’s a character!”
+
+And he was the more esteemed for this imperturbable coolness. The
+universe to the last man might have died, and he would not have missed
+the smallest of his habits.
+
+Homais presented himself.
+
+“I count on you,” said the doctor. “Are we ready? Come along!”
+
+But the druggist, turning red, confessed that he was too sensitive to
+assist at such an operation.
+
+“When one is a simple spectator,” he said, “the imagination, you know,
+is impressed. And then I have such a nervous system!”
+
+“Pshaw!” interrupted Canivet; “on the contrary, you seem to me inclined
+to apoplexy. Besides, that doesn’t astonish me, for you chemist fellows
+are always poking about your kitchens, which must end by spoiling your
+constitutions. Now just look at me. I get up every day at four o’clock;
+I shave with cold water (and am never cold). I don’t wear flannels, and
+I never catch cold; my carcass is good enough! I live now in one way,
+now in another, like a philosopher, taking pot-luck; that is why I
+am not squeamish like you, and it is as indifferent to me to carve a
+Christian as the first fowl that turns up. Then, perhaps, you will say,
+habit! habit!”
+
+Then, without any consideration for Hippolyte, who was sweating with
+agony between his sheets, these gentlemen entered into a conversation,
+in which the druggist compared the coolness of a surgeon to that of a
+general; and this comparison was pleasing to Canivet, who launched out
+on the exigencies of his art. He looked upon, it as a sacred office,
+although the ordinary practitioners dishonoured it. At last, coming back
+to the patient, he examined the bandages brought by Homais, the same
+that had appeared for the club-foot, and asked for someone to hold the
+limb for him. Lestiboudois was sent for, and Monsieur Canivet having
+turned up his sleeves, passed into the billiard-room, while the druggist
+stayed with Artemise and the landlady, both whiter than their aprons,
+and with ears strained towards the door.
+
+Bovary during this time did not dare to stir from his house.
+
+He kept downstairs in the sitting-room by the side of the fireless
+chimney, his chin on his breast, his hands clasped, his eyes staring.
+“What a mishap!” he thought, “what a mishap!” Perhaps, after all, he had
+made some slip. He thought it over, but could hit upon nothing. But the
+most famous surgeons also made mistakes; and that is what no one would
+ever believe! People, on the contrary, would laugh, jeer! It would
+spread as far as Forges, as Neufchatel, as Rouen, everywhere! Who could
+say if his colleagues would not write against him. Polemics would ensue;
+he would have to answer in the papers. Hippolyte might even prosecute
+him. He saw himself dishonoured, ruined, lost; and his imagination,
+assailed by a world of hypotheses, tossed amongst them like an empty
+cask borne by the sea and floating upon the waves.
+
+Emma, opposite, watched him; she did not share his humiliation; she felt
+another--that of having supposed such a man was worth anything. As if
+twenty times already she had not sufficiently perceived his mediocrity.
+
+Charles was walking up and down the room; his boots creaked on the
+floor.
+
+“Sit down,” she said; “you fidget me.”
+
+He sat down again.
+
+How was it that she--she, who was so intelligent--could have allowed
+herself to be deceived again? and through what deplorable madness had
+she thus ruined her life by continual sacrifices? She recalled all her
+instincts of luxury, all the privations of her soul, the sordidness of
+marriage, of the household, her dream sinking into the mire like wounded
+swallows; all that she had longed for, all that she had denied herself,
+all that she might have had! And for what? for what?
+
+In the midst of the silence that hung over the village a heart-rending
+cry rose on the air. Bovary turned white to fainting. She knit her
+brows with a nervous gesture, then went on. And it was for him, for this
+creature, for this man, who understood nothing, who felt nothing! For he
+was there quite quiet, not even suspecting that the ridicule of his name
+would henceforth sully hers as well as his. She had made efforts to love
+him, and she had repented with tears for having yielded to another!
+
+“But it was perhaps a valgus!” suddenly exclaimed Bovary, who was
+meditating.
+
+At the unexpected shock of this phrase falling on her thought like a
+leaden bullet on a silver plate, Emma, shuddering, raised her head in
+order to find out what he meant to say; and they looked at the other in
+silence, almost amazed to see each other, so far sundered were they
+by their inner thoughts. Charles gazed at her with the dull look of
+a drunken man, while he listened motionless to the last cries of the
+sufferer, that followed each other in long-drawn modulations, broken by
+sharp spasms like the far-off howling of some beast being slaughtered.
+Emma bit her wan lips, and rolling between her fingers a piece of coral
+that she had broken, fixed on Charles the burning glance of her eyes
+like two arrows of fire about to dart forth. Everything in him irritated
+her now; his face, his dress, what he did not say, his whole person, his
+existence, in fine. She repented of her past virtue as of a crime, and
+what still remained of it rumbled away beneath the furious blows of her
+pride. She revelled in all the evil ironies of triumphant adultery.
+The memory of her lover came back to her with dazzling attractions; she
+threw her whole soul into it, borne away towards this image with a fresh
+enthusiasm; and Charles seemed to her as much removed from her life, as
+absent forever, as impossible and annihilated, as if he had been about
+to die and were passing under her eyes.
+
+There was a sound of steps on the pavement. Charles looked up, and
+through the lowered blinds he saw at the corner of the market in
+the broad sunshine Dr. Canivet, who was wiping his brow with his
+handkerchief. Homais, behind him, was carrying a large red box in his
+hand, and both were going towards the chemist’s.
+
+Then with a feeling of sudden tenderness and discouragement Charles
+turned to his wife saying to her--
+
+“Oh, kiss me, my own!”
+
+“Leave me!” she said, red with anger.
+
+“What is the matter?” he asked, stupefied. “Be calm; compose yourself.
+You know well enough that I love you. Come!”
+
+“Enough!” she cried with a terrible look.
+
+And escaping from the room, Emma closed the door so violently that the
+barometer fell from the wall and smashed on the floor.
+
+Charles sank back into his arm-chair overwhelmed, trying to discover
+what could be wrong with her, fancying some nervous illness, weeping,
+and vaguely feeling something fatal and incomprehensible whirling round
+him.
+
+When Rodolphe came to the garden that evening, he found his mistress
+waiting for him at the foot of the steps on the lowest stair. They threw
+their arms round one another, and all their rancour melted like snow
+beneath the warmth of that kiss.
+
+
+
+Chapter Twelve
+
+They began to love one another again. Often, even in the middle of the
+day, Emma suddenly wrote to him, then from the window made a sign to
+Justin, who, taking his apron off, quickly ran to La Huchette. Rodolphe
+would come; she had sent for him to tell him that she was bored, that
+her husband was odious, her life frightful.
+
+“But what can I do?” he cried one day impatiently.
+
+“Ah! if you would--”
+
+She was sitting on the floor between his knees, her hair loose, her look
+lost.
+
+“Why, what?” said Rodolphe.
+
+She sighed.
+
+“We would go and live elsewhere--somewhere!”
+
+“You are really mad!” he said laughing. “How could that be possible?”
+
+She returned to the subject; he pretended not to understand, and turned
+the conversation.
+
+What he did not understand was all this worry about so simple an affair
+as love. She had a motive, a reason, and, as it were, a pendant to her
+affection.
+
+Her tenderness, in fact, grew each day with her repulsion to her
+husband. The more she gave up herself to the one, the more she loathed
+the other. Never had Charles seemed to her so disagreeable, to have
+such stodgy fingers, such vulgar ways, to be so dull as when they found
+themselves together after her meeting with Rodolphe. Then, while playing
+the spouse and virtue, she was burning at the thought of that head whose
+black hair fell in a curl over the sunburnt brow, of that form at once
+so strong and elegant, of that man, in a word, who had such experience
+in his reasoning, such passion in his desires. It was for him that she
+filed her nails with the care of a chaser, and that there was never
+enough cold-cream for her skin, nor of patchouli for her handkerchiefs.
+She loaded herself with bracelets, rings, and necklaces. When he
+was coming she filled the two large blue glass vases with roses, and
+prepared her room and her person like a courtesan expecting a prince.
+The servant had to be constantly washing linen, and all day Felicite
+did not stir from the kitchen, where little Justin, who often kept her
+company, watched her at work.
+
+With his elbows on the long board on which she was ironing, he
+greedily watched all these women’s clothes spread about him, the dimity
+petticoats, the fichus, the collars, and the drawers with running
+strings, wide at the hips and growing narrower below.
+
+“What is that for?” asked the young fellow, passing his hand over the
+crinoline or the hooks and eyes.
+
+“Why, haven’t you ever seen anything?” Felicite answered laughing. “As
+if your mistress, Madame Homais, didn’t wear the same.”
+
+“Oh, I daresay! Madame Homais!” And he added with a meditative air, “As
+if she were a lady like madame!”
+
+But Felicite grew impatient of seeing him hanging round her. She was six
+years older than he, and Theodore, Monsieur Guillaumin’s servant, was
+beginning to pay court to her.
+
+“Let me alone,” she said, moving her pot of starch. “You’d better be
+off and pound almonds; you are always dangling about women. Before you
+meddle with such things, bad boy, wait till you’ve got a beard to your
+chin.”
+
+“Oh, don’t be cross! I’ll go and clean her boots.”
+
+And he at once took down from the shelf Emma’s boots, all coated with
+mud, the mud of the rendezvous, that crumbled into powder beneath his
+fingers, and that he watched as it gently rose in a ray of sunlight.
+
+“How afraid you are of spoiling them!” said the servant, who wasn’t so
+particular when she cleaned them herself, because as soon as the stuff
+of the boots was no longer fresh madame handed them over to her.
+
+Emma had a number in her cupboard that she squandered one after the
+other, without Charles allowing himself the slightest observation. So
+also he disbursed three hundred francs for a wooden leg that she thought
+proper to make a present of to Hippolyte. Its top was covered with cork,
+and it had spring joints, a complicated mechanism, covered over by black
+trousers ending in a patent-leather boot. But Hippolyte, not daring
+to use such a handsome leg every day, begged Madame Bovary to get him
+another more convenient one. The doctor, of course, had again to defray
+the expense of this purchase.
+
+So little by little the stable-man took up his work again. One saw him
+running about the village as before, and when Charles heard from afar
+the sharp noise of the wooden leg, he at once went in another direction.
+
+It was Monsieur Lheureux, the shopkeeper, who had undertaken the order;
+this provided him with an excuse for visiting Emma. He chatted with her
+about the new goods from Paris, about a thousand feminine trifles, made
+himself very obliging, and never asked for his money. Emma yielded to
+this lazy mode of satisfying all her caprices. Thus she wanted to have
+a very handsome ridding-whip that was at an umbrella-maker’s at Rouen
+to give to Rodolphe. The week after Monsieur Lheureux placed it on her
+table.
+
+But the next day he called on her with a bill for two hundred and
+seventy francs, not counting the centimes. Emma was much embarrassed;
+all the drawers of the writing-table were empty; they owed over a
+fortnight’s wages to Lestiboudois, two quarters to the servant, for any
+quantity of other things, and Bovary was impatiently expecting Monsieur
+Derozeray’s account, which he was in the habit of paying every year
+about Midsummer.
+
+She succeeded at first in putting off Lheureux. At last he lost
+patience; he was being sued; his capital was out, and unless he got some
+in he should be forced to take back all the goods she had received.
+
+“Oh, very well, take them!” said Emma.
+
+“I was only joking,” he replied; “the only thing I regret is the whip.
+My word! I’ll ask monsieur to return it to me.”
+
+“No, no!” she said.
+
+“Ah! I’ve got you!” thought Lheureux.
+
+And, certain of his discovery, he went out repeating to himself in an
+undertone, and with his usual low whistle--
+
+“Good! we shall see! we shall see!”
+
+She was thinking how to get out of this when the servant coming in
+put on the mantelpiece a small roll of blue paper “from Monsieur
+Derozeray’s.” Emma pounced upon and opened it. It contained fifteen
+napoleons; it was the account. She heard Charles on the stairs; threw
+the gold to the back of her drawer, and took out the key.
+
+Three days after Lheureux reappeared.
+
+“I have an arrangement to suggest to you,” he said. “If, instead of the
+sum agreed on, you would take--”
+
+“Here it is,” she said placing fourteen napoleons in his hand.
+
+The tradesman was dumfounded. Then, to conceal his disappointment, he
+was profuse in apologies and proffers of service, all of which Emma
+declined; then she remained a few moments fingering in the pocket of
+her apron the two five-franc pieces that he had given her in change.
+She promised herself she would economise in order to pay back later on.
+“Pshaw!” she thought, “he won’t think about it again.”
+
+Besides the riding-whip with its silver-gilt handle, Rodolphe had
+received a seal with the motto Amor nel cor* furthermore, a scarf for
+a muffler, and, finally, a cigar-case exactly like the Viscount’s, that
+Charles had formerly picked up in the road, and that Emma had kept.
+These presents, however, humiliated him; he refused several; she
+insisted, and he ended by obeying, thinking her tyrannical and
+overexacting.
+
+     *A loving heart.
+
+Then she had strange ideas.
+
+“When midnight strikes,” she said, “you must think of me.”
+
+And if he confessed that he had not thought of her, there were floods of
+reproaches that always ended with the eternal question--
+
+“Do you love me?”
+
+“Why, of course I love you,” he answered.
+
+“A great deal?”
+
+“Certainly!”
+
+“You haven’t loved any others?”
+
+“Did you think you’d got a virgin?” he exclaimed laughing.
+
+Emma cried, and he tried to console her, adorning his protestations with
+puns.
+
+“Oh,” she went on, “I love you! I love you so that I could not live
+without you, do you see? There are times when I long to see you again,
+when I am torn by all the anger of love. I ask myself, Where is
+he? Perhaps he is talking to other women. They smile upon him; he
+approaches. Oh no; no one else pleases you. There are some more
+beautiful, but I love you best. I know how to love best. I am your
+servant, your concubine! You are my king, my idol! You are good, you are
+beautiful, you are clever, you are strong!”
+
+He had so often heard these things said that they did not strike him as
+original. Emma was like all his mistresses; and the charm of novelty,
+gradually falling away like a garment, laid bare the eternal monotony
+of passion, that has always the same forms and the same language. He
+did not distinguish, this man of so much experience, the difference of
+sentiment beneath the sameness of expression. Because lips libertine
+and venal had murmured such words to him, he believed but little in the
+candour of hers; exaggerated speeches hiding mediocre affections must be
+discounted; as if the fullness of the soul did not sometimes overflow in
+the emptiest metaphors, since no one can ever give the exact measure of
+his needs, nor of his conceptions, nor of his sorrows; and since human
+speech is like a cracked tin kettle, on which we hammer out tunes to
+make bears dance when we long to move the stars.
+
+But with that superior critical judgment that belongs to him who, in no
+matter what circumstance, holds back, Rodolphe saw other delights to be
+got out of this love. He thought all modesty in the way. He treated her
+quite sans facon.* He made of her something supple and corrupt. Hers
+was an idiotic sort of attachment, full of admiration for him, of
+voluptuousness for her, a beatitude that benumbed her; her soul sank
+into this drunkenness, shrivelled up, drowned in it, like Clarence in
+his butt of Malmsey.
+
+     *Off-handedly.
+
+
+By the mere effect of her love Madame Bovary’s manners changed.
+Her looks grew bolder, her speech more free; she even committed the
+impropriety of walking out with Monsieur Rodolphe, a cigarette in her
+mouth, “as if to defy the people.” At last, those who still doubted
+doubted no longer when one day they saw her getting out of the
+“Hirondelle,” her waist squeezed into a waistcoat like a man; and Madame
+Bovary senior, who, after a fearful scene with her husband, had taken
+refuge at her son’s, was not the least scandalised of the women-folk.
+Many other things displeased her. First, Charles had not attended to
+her advice about the forbidding of novels; then the “ways of the house”
+ annoyed her; she allowed herself to make some remarks, and there were
+quarrels, especially one on account of Felicite.
+
+Madame Bovary senior, the evening before, passing along the passage,
+had surprised her in company of a man--a man with a brown collar, about
+forty years old, who, at the sound of her step, had quickly escaped
+through the kitchen. Then Emma began to laugh, but the good lady grew
+angry, declaring that unless morals were to be laughed at one ought to
+look after those of one’s servants.
+
+“Where were you brought up?” asked the daughter-in-law, with so
+impertinent a look that Madame Bovary asked her if she were not perhaps
+defending her own case.
+
+“Leave the room!” said the young woman, springing up with a bound.
+
+“Emma! Mamma!” cried Charles, trying to reconcile them.
+
+But both had fled in their exasperation. Emma was stamping her feet as
+she repeated--
+
+“Oh! what manners! What a peasant!”
+
+He ran to his mother; she was beside herself. She stammered
+
+“She is an insolent, giddy-headed thing, or perhaps worse!”
+
+And she was for leaving at once if the other did not apologise. So
+Charles went back again to his wife and implored her to give way; he
+knelt to her; she ended by saying--
+
+“Very well! I’ll go to her.”
+
+And in fact she held out her hand to her mother-in-law with the dignity
+of a marchioness as she said--
+
+“Excuse me, madame.”
+
+Then, having gone up again to her room, she threw herself flat on her
+bed and cried there like a child, her face buried in the pillow.
+
+She and Rodolphe had agreed that in the event of anything extraordinary
+occurring, she should fasten a small piece of white paper to the blind,
+so that if by chance he happened to be in Yonville, he could hurry to
+the lane behind the house. Emma made the signal; she had been waiting
+three-quarters of an hour when she suddenly caught sight of Rodolphe at
+the corner of the market. She felt tempted to open the window and call
+him, but he had already disappeared. She fell back in despair.
+
+Soon, however, it seemed to her that someone was walking on the
+pavement. It was he, no doubt. She went downstairs, crossed the yard. He
+was there outside. She threw herself into his arms.
+
+“Do take care!” he said.
+
+“Ah! if you knew!” she replied.
+
+And she began telling him everything, hurriedly, disjointedly,
+exaggerating the facts, inventing many, and so prodigal of parentheses
+that he understood nothing of it.
+
+“Come, my poor angel, courage! Be comforted! be patient!”
+
+“But I have been patient; I have suffered for four years. A love like
+ours ought to show itself in the face of heaven. They torture me! I can
+bear it no longer! Save me!”
+
+She clung to Rodolphe. Her eyes, full of tears, flashed like flames
+beneath a wave; her breast heaved; he had never loved her so much, so
+that he lost his head and said “What is, it? What do you wish?”
+
+“Take me away,” she cried, “carry me off! Oh, I pray you!”
+
+And she threw herself upon his mouth, as if to seize there the
+unexpected consent if breathed forth in a kiss.
+
+“But--” Rodolphe resumed.
+
+“What?”
+
+“Your little girl!”
+
+She reflected a few moments, then replied--
+
+“We will take her! It can’t be helped!”
+
+“What a woman!” he said to himself, watching her as she went. For she
+had run into the garden. Someone was calling her.
+
+On the following days Madame Bovary senior was much surprised at the
+change in her daughter-in-law. Emma, in fact, was showing herself more
+docile, and even carried her deference so far as to ask for a recipe for
+pickling gherkins.
+
+Was it the better to deceive them both? Or did she wish by a sort of
+voluptuous stoicism to feel the more profoundly the bitterness of the
+things she was about to leave?
+
+But she paid no heed to them; on the contrary, she lived as lost in the
+anticipated delight of her coming happiness.
+
+It was an eternal subject for conversation with Rodolphe. She leant on
+his shoulder murmuring--
+
+“Ah! when we are in the mail-coach! Do you think about it? Can it be? It
+seems to me that the moment I feel the carriage start, it will be as if
+we were rising in a balloon, as if we were setting out for the clouds.
+Do you know that I count the hours? And you?”
+
+Never had Madame Bovary been so beautiful as at this period; she had
+that indefinable beauty that results from joy, from enthusiasm, from
+success, and that is only the harmony of temperament with circumstances.
+Her desires, her sorrows, the experience of pleasure, and her ever-young
+illusions, that had, as soil and rain and winds and the sun make flowers
+grow, gradually developed her, and she at length blossomed forth in all
+the plenitude of her nature. Her eyelids seemed chiselled expressly for
+her long amorous looks in which the pupil disappeared, while a strong
+inspiration expanded her delicate nostrils and raised the fleshy corner
+of her lips, shaded in the light by a little black down. One would have
+thought that an artist apt in conception had arranged the curls of hair
+upon her neck; they fell in a thick mass, negligently, and with the
+changing chances of their adultery, that unbound them every day. Her
+voice now took more mellow infections, her figure also; something subtle
+and penetrating escaped even from the folds of her gown and from the
+line of her foot. Charles, as when they were first married, thought her
+delicious and quite irresistible.
+
+When he came home in the middle of the night, he did not dare to wake
+her. The porcelain night-light threw a round trembling gleam upon the
+ceiling, and the drawn curtains of the little cot formed as it were a
+white hut standing out in the shade, and by the bedside Charles looked
+at them. He seemed to hear the light breathing of his child. She would
+grow big now; every season would bring rapid progress. He already saw
+her coming from school as the day drew in, laughing, with ink-stains on
+her jacket, and carrying her basket on her arm. Then she would have to
+be sent to the boarding-school; that would cost much; how was it to
+be done? Then he reflected. He thought of hiring a small farm in the
+neighbourhood, that he would superintend every morning on his way to his
+patients. He would save up what he brought in; he would put it in the
+savings-bank. Then he would buy shares somewhere, no matter where;
+besides, his practice would increase; he counted upon that, for he
+wanted Berthe to be well-educated, to be accomplished, to learn to play
+the piano. Ah! how pretty she would be later on when she was fifteen,
+when, resembling her mother, she would, like her, wear large straw hats
+in the summer-time; from a distance they would be taken for two sisters.
+He pictured her to himself working in the evening by their side beneath
+the light of the lamp; she would embroider him slippers; she would look
+after the house; she would fill all the home with her charm and her
+gaiety. At last, they would think of her marriage; they would find her
+some good young fellow with a steady business; he would make her happy;
+this would last for ever.
+
+Emma was not asleep; she pretended to be; and while he dozed off by her
+side she awakened to other dreams.
+
+To the gallop of four horses she was carried away for a week towards a
+new land, whence they would return no more. They went on and on, their
+arms entwined, without a word. Often from the top of a mountain there
+suddenly glimpsed some splendid city with domes, and bridges, and
+ships, forests of citron trees, and cathedrals of white marble, on whose
+pointed steeples were storks’ nests. They went at a walking-pace because
+of the great flag-stones, and on the ground there were bouquets of
+flowers, offered you by women dressed in red bodices. They heard the
+chiming of bells, the neighing of mules, together with the murmur of
+guitars and the noise of fountains, whose rising spray refreshed heaps
+of fruit arranged like a pyramid at the foot of pale statues that smiled
+beneath playing waters. And then, one night they came to a fishing
+village, where brown nets were drying in the wind along the cliffs and
+in front of the huts. It was there that they would stay; they would live
+in a low, flat-roofed house, shaded by a palm-tree, in the heart of a
+gulf, by the sea. They would row in gondolas, swing in hammocks, and
+their existence would be easy and large as their silk gowns, warm and
+star-spangled as the nights they would contemplate. However, in the
+immensity of this future that she conjured up, nothing special stood
+forth; the days, all magnificent, resembled each other like waves; and
+it swayed in the horizon, infinite, harmonised, azure, and bathed in
+sunshine. But the child began to cough in her cot or Bovary snored
+more loudly, and Emma did not fall asleep till morning, when the dawn
+whitened the windows, and when little Justin was already in the square
+taking down the shutters of the chemist’s shop.
+
+She had sent for Monsieur Lheureux, and had said to him--
+
+“I want a cloak--a large lined cloak with a deep collar.”
+
+“You are going on a journey?” he asked.
+
+“No; but--never mind. I may count on you, may I not, and quickly?”
+
+He bowed.
+
+“Besides, I shall want,” she went on, “a trunk--not too heavy--handy.”
+
+“Yes, yes, I understand. About three feet by a foot and a half, as they
+are being made just now.”
+
+“And a travelling bag.”
+
+“Decidedly,” thought Lheureux, “there’s a row on here.”
+
+“And,” said Madame Bovary, taking her watch from her belt, “take this;
+you can pay yourself out of it.”
+
+But the tradesman cried out that she was wrong; they knew one another;
+did he doubt her? What childishness!
+
+She insisted, however, on his taking at least the chain, and Lheureux
+had already put it in his pocket and was going, when she called him
+back.
+
+“You will leave everything at your place. As to the cloak”--she seemed
+to be reflecting--“do not bring it either; you can give me the maker’s
+address, and tell him to have it ready for me.”
+
+It was the next month that they were to run away. She was to leave
+Yonville as if she was going on some business to Rouen. Rodolphe would
+have booked the seats, procured the passports, and even have written to
+Paris in order to have the whole mail-coach reserved for them as far as
+Marseilles, where they would buy a carriage, and go on thence without
+stopping to Genoa. She would take care to send her luggage to Lheureux
+whence it would be taken direct to the “Hirondelle,” so that no one
+would have any suspicion. And in all this there never was any allusion
+to the child. Rodolphe avoided speaking of her; perhaps he no longer
+thought about it.
+
+He wished to have two more weeks before him to arrange some affairs;
+then at the end of a week he wanted two more; then he said he was ill;
+next he went on a journey. The month of August passed, and, after all
+these delays, they decided that it was to be irrevocably fixed for the
+4th September--a Monday.
+
+At length the Saturday before arrived.
+
+Rodolphe came in the evening earlier than usual.
+
+“Everything is ready?” she asked him.
+
+“Yes.”
+
+Then they walked round a garden-bed, and went to sit down near the
+terrace on the kerb-stone of the wall.
+
+“You are sad,” said Emma.
+
+“No; why?”
+
+And yet he looked at her strangely in a tender fashion.
+
+“It is because you are going away?” she went on; “because you are
+leaving what is dear to you--your life? Ah! I understand. I have nothing
+in the world! you are all to me; so shall I be to you. I will be your
+people, your country; I will tend, I will love you!”
+
+“How sweet you are!” he said, seizing her in his arms.
+
+“Really!” she said with a voluptuous laugh. “Do you love me? Swear it
+then!”
+
+“Do I love you--love you? I adore you, my love.”
+
+The moon, full and purple-coloured, was rising right out of the earth
+at the end of the meadow. She rose quickly between the branches of the
+poplars, that hid her here and there like a black curtain pierced with
+holes. Then she appeared dazzling with whiteness in the empty heavens
+that she lit up, and now sailing more slowly along, let fall upon the
+river a great stain that broke up into an infinity of stars; and the
+silver sheen seemed to writhe through the very depths like a heedless
+serpent covered with luminous scales; it also resembled some monster
+candelabra all along which sparkled drops of diamonds running together.
+The soft night was about them; masses of shadow filled the branches.
+Emma, her eyes half closed, breathed in with deep sighs the fresh wind
+that was blowing. They did not speak, lost as they were in the rush of
+their reverie. The tenderness of the old days came back to their hearts,
+full and silent as the flowing river, with the softness of the perfume
+of the syringas, and threw across their memories shadows more immense
+and more sombre than those of the still willows that lengthened out over
+the grass. Often some night-animal, hedgehog or weasel, setting out on
+the hunt, disturbed the lovers, or sometimes they heard a ripe peach
+falling all alone from the espalier.
+
+“Ah! what a lovely night!” said Rodolphe.
+
+“We shall have others,” replied Emma; and, as if speaking to herself:
+“Yet, it will be good to travel. And yet, why should my heart be
+so heavy? Is it dread of the unknown? The effect of habits left? Or
+rather--? No; it is the excess of happiness. How weak I am, am I not?
+Forgive me!”
+
+“There is still time!” he cried. “Reflect! perhaps you may repent!”
+
+“Never!” she cried impetuously. And coming closer to him: “What ill
+could come to me? There is no desert, no precipice, no ocean I would not
+traverse with you. The longer we live together the more it will be like
+an embrace, every day closer, more heart to heart. There will be
+nothing to trouble us, no cares, no obstacle. We shall be alone, all to
+ourselves eternally. Oh, speak! Answer me!”
+
+At regular intervals he answered, “Yes--Yes--” She had passed her hands
+through his hair, and she repeated in a childlike voice, despite the big
+tears which were falling, “Rodolphe! Rodolphe! Ah! Rodolphe! dear little
+Rodolphe!”
+
+Midnight struck.
+
+“Midnight!” said she. “Come, it is to-morrow. One day more!”
+
+He rose to go; and as if the movement he made had been the signal for
+their flight, Emma said, suddenly assuming a gay air--
+
+“You have the passports?”
+
+“Yes.”
+
+“You are forgetting nothing?”
+
+“No.”
+
+“Are you sure?”
+
+“Certainly.”
+
+“It is at the Hotel de Provence, is it not, that you will wait for me at
+midday?”
+
+He nodded.
+
+“Till to-morrow then!” said Emma in a last caress; and she watched him
+go.
+
+He did not turn round. She ran after him, and, leaning over the water’s
+edge between the bulrushes--
+
+“To-morrow!” she cried.
+
+He was already on the other side of the river and walking fast across
+the meadow.
+
+After a few moments Rodolphe stopped; and when he saw her with her white
+gown gradually fade away in the shade like a ghost, he was seized with
+such a beating of the heart that he leant against a tree lest he should
+fall.
+
+“What an imbecile I am!” he said with a fearful oath. “No matter! She
+was a pretty mistress!”
+
+And immediately Emma’s beauty, with all the pleasures of their love,
+came back to him. For a moment he softened; then he rebelled against
+her.
+
+“For, after all,” he exclaimed, gesticulating, “I can’t exile
+myself--have a child on my hands.”
+
+He was saying these things to give himself firmness.
+
+“And besides, the worry, the expense! Ah! no, no, no, no! a thousand
+times no! That would be too stupid.”
+
+
+
+Chapter Thirteen
+
+No sooner was Rodolphe at home than he sat down quickly at his bureau
+under the stag’s head that hung as a trophy on the wall. But when he had
+the pen between his fingers, he could think of nothing, so that, resting
+on his elbows, he began to reflect. Emma seemed to him to have receded
+into a far-off past, as if the resolution he had taken had suddenly
+placed a distance between them.
+
+To get back something of her, he fetched from the cupboard at the
+bedside an old Rheims biscuit-box, in which he usually kept his letters
+from women, and from it came an odour of dry dust and withered
+roses. First he saw a handkerchief with pale little spots. It was a
+handkerchief of hers. Once when they were walking her nose had bled; he
+had forgotten it. Near it, chipped at all the corners, was a miniature
+given him by Emma: her toilette seemed to him pretentious, and her
+languishing look in the worst possible taste. Then, from looking at this
+image and recalling the memory of its original, Emma’s features little
+by little grew confused in his remembrance, as if the living and the
+painted face, rubbing one against the other, had effaced each other.
+Finally, he read some of her letters; they were full of explanations
+relating to their journey, short, technical, and urgent, like business
+notes. He wanted to see the long ones again, those of old times. In
+order to find them at the bottom of the box, Rodolphe disturbed all the
+others, and mechanically began rummaging amidst this mass of papers and
+things, finding pell-mell bouquets, garters, a black mask, pins, and
+hair--hair! dark and fair, some even, catching in the hinges of the box,
+broke when it was opened.
+
+Thus dallying with his souvenirs, he examined the writing and the style
+of the letters, as varied as their orthography. They were tender or
+jovial, facetious, melancholy; there were some that asked for love,
+others that asked for money. A word recalled faces to him, certain
+gestures, the sound of a voice; sometimes, however, he remembered
+nothing at all.
+
+In fact, these women, rushing at once into his thoughts, cramped each
+other and lessened, as reduced to a uniform level of love that equalised
+them all. So taking handfuls of the mixed-up letters, he amused himself
+for some moments with letting them fall in cascades from his right into
+his left hand. At last, bored and weary, Rodolphe took back the box to
+the cupboard, saying to himself, “What a lot of rubbish!” Which summed
+up his opinion; for pleasures, like schoolboys in a school courtyard,
+had so trampled upon his heart that no green thing grew there, and that
+which passed through it, more heedless than children, did not even, like
+them, leave a name carved upon the wall.
+
+“Come,” said he, “let’s begin.”
+
+He wrote--
+
+“Courage, Emma! courage! I would not bring misery into your life.”
+
+“After all, that’s true,” thought Rodolphe. “I am acting in her
+interest; I am honest.”
+
+“Have you carefully weighed your resolution? Do you know to what an
+abyss I was dragging you, poor angel? No, you do not, do you? You were
+coming confident and fearless, believing in happiness in the future. Ah!
+unhappy that we are--insensate!”
+
+Rodolphe stopped here to think of some good excuse.
+
+“If I told her all my fortune is lost? No! Besides, that would stop
+nothing. It would all have to be begun over again later on. As if one
+could make women like that listen to reason!” He reflected, then went
+on--
+
+“I shall not forget you, oh believe it; and I shall ever have a profound
+devotion for you; but some day, sooner or later, this ardour (such is
+the fate of human things) would have grown less, no doubt. Lassitude
+would have come to us, and who knows if I should not even have had the
+atrocious pain of witnessing your remorse, of sharing it myself, since
+I should have been its cause? The mere idea of the grief that would come
+to you tortures me, Emma. Forget me! Why did I ever know you? Why were
+you so beautiful? Is it my fault? O my God! No, no! Accuse only fate.”
+
+“That’s a word that always tells,” he said to himself.
+
+“Ah, if you had been one of those frivolous women that one sees,
+certainly I might, through egotism, have tried an experiment, in that
+case without danger for you. But that delicious exaltation, at once your
+charm and your torment, has prevented you from understanding, adorable
+woman that you are, the falseness of our future position. Nor had I
+reflected upon this at first, and I rested in the shade of that ideal
+happiness as beneath that of the manchineel tree, without foreseeing the
+consequences.”
+
+“Perhaps she’ll think I’m giving it up from avarice. Ah, well! so much
+the worse; it must be stopped!”
+
+“The world is cruel, Emma. Wherever we might have gone, it would have
+persecuted us. You would have had to put up with indiscreet questions,
+calumny, contempt, insult perhaps. Insult to you! Oh! And I, who would
+place you on a throne! I who bear with me your memory as a talisman! For
+I am going to punish myself by exile for all the ill I have done you.
+I am going away. Whither I know not. I am mad. Adieu! Be good always.
+Preserve the memory of the unfortunate who has lost you. Teach my name
+to your child; let her repeat it in her prayers.”
+
+The wicks of the candles flickered. Rodolphe got up to, shut the window,
+and when he had sat down again--
+
+“I think it’s all right. Ah! and this for fear she should come and hunt
+me up.”
+
+“I shall be far away when you read these sad lines, for I have wished to
+flee as quickly as possible to shun the temptation of seeing you again.
+No weakness! I shall return, and perhaps later on we shall talk together
+very coldly of our old love. Adieu!”
+
+And there was a last “adieu” divided into two words! “A Dieu!” which he
+thought in very excellent taste.
+
+“Now how am I to sign?” he said to himself. “‘Yours devotedly?’ No!
+‘Your friend?’ Yes, that’s it.”
+
+“Your friend.”
+
+He re-read his letter. He considered it very good.
+
+“Poor little woman!” he thought with emotion. “She’ll think me harder
+than a rock. There ought to have been some tears on this; but I can’t
+cry; it isn’t my fault.” Then, having emptied some water into a glass,
+Rodolphe dipped his finger into it, and let a big drop fall on the
+paper, that made a pale stain on the ink. Then looking for a seal, he
+came upon the one “Amor nel cor.”
+
+“That doesn’t at all fit in with the circumstances. Pshaw! never mind!”
+
+After which he smoked three pipes and went to bed.
+
+The next day when he was up (at about two o’clock--he had slept late),
+Rodolphe had a basket of apricots picked. He put his letter at
+the bottom under some vine leaves, and at once ordered Girard, his
+ploughman, to take it with care to Madame Bovary. He made use of this
+means for corresponding with her, sending according to the season fruits
+or game.
+
+“If she asks after me,” he said, “you will tell her that I have gone on
+a journey. You must give the basket to her herself, into her own hands.
+Get along and take care!”
+
+Girard put on his new blouse, knotted his handkerchief round the
+apricots, and walking with great heavy steps in his thick iron-bound
+galoshes, made his way to Yonville.
+
+Madame Bovary, when he got to her house, was arranging a bundle of linen
+on the kitchen-table with Felicite.
+
+“Here,” said the ploughboy, “is something for you--from the master.”
+
+She was seized with apprehension, and as she sought in her pocket for
+some coppers, she looked at the peasant with haggard eyes, while he
+himself looked at her with amazement, not understanding how such a
+present could so move anyone. At last he went out. Felicite remained.
+She could bear it no longer; she ran into the sitting room as if to take
+the apricots there, overturned the basket, tore away the leaves, found
+the letter, opened it, and, as if some fearful fire were behind her,
+Emma flew to her room terrified.
+
+Charles was there; she saw him; he spoke to her; she heard nothing, and
+she went on quickly up the stairs, breathless, distraught, dumb, and
+ever holding this horrible piece of paper, that crackled between her
+fingers like a plate of sheet-iron. On the second floor she stopped
+before the attic door, which was closed.
+
+Then she tried to calm herself; she recalled the letter; she must finish
+it; she did not dare to. And where? How? She would be seen! “Ah, no!
+here,” she thought, “I shall be all right.”
+
+Emma pushed open the door and went in.
+
+The slates threw straight down a heavy heat that gripped her temples,
+stifled her; she dragged herself to the closed garret-window. She drew
+back the bolt, and the dazzling light burst in with a leap.
+
+Opposite, beyond the roofs, stretched the open country till it was lost
+to sight. Down below, underneath her, the village square was empty; the
+stones of the pavement glittered, the weathercocks on the houses were
+motionless. At the corner of the street, from a lower storey, rose a
+kind of humming with strident modulations. It was Binet turning.
+
+She leant against the embrasure of the window, and reread the letter
+with angry sneers. But the more she fixed her attention upon it, the
+more confused were her ideas. She saw him again, heard him, encircled
+him with her arms, and throbs of her heart, that beat against her breast
+like blows of a sledge-hammer, grew faster and faster, with uneven
+intervals. She looked about her with the wish that the earth might
+crumble into pieces. Why not end it all? What restrained her? She was
+free. She advanced, looking at the paving-stones, saying to herself,
+“Come! come!”
+
+The luminous ray that came straight up from below drew the weight of
+her body towards the abyss. It seemed to her that the ground of the
+oscillating square went up the walls and that the floor dipped on
+end like a tossing boat. She was right at the edge, almost hanging,
+surrounded by vast space. The blue of the heavens suffused her, the air
+was whirling in her hollow head; she had but to yield, to let herself
+be taken; and the humming of the lathe never ceased, like an angry voice
+calling her.
+
+“Emma! Emma!” cried Charles.
+
+She stopped.
+
+“Wherever are you? Come!”
+
+The thought that she had just escaped from death almost made her faint
+with terror. She closed her eyes; then she shivered at the touch of a
+hand on her sleeve; it was Felicite.
+
+“Master is waiting for you, madame; the soup is on the table.”
+
+And she had to go down to sit at table.
+
+She tried to eat. The food choked her. Then she unfolded her napkin as
+if to examine the darns, and she really thought of applying herself to
+this work, counting the threads in the linen. Suddenly the remembrance
+of the letter returned to her. How had she lost it? Where could she find
+it? But she felt such weariness of spirit that she could not even invent
+a pretext for leaving the table. Then she became a coward; she was
+afraid of Charles; he knew all, that was certain! Indeed he pronounced
+these words in a strange manner:
+
+“We are not likely to see Monsieur Rodolphe soon again, it seems.”
+
+“Who told you?” she said, shuddering.
+
+“Who told me!” he replied, rather astonished at her abrupt tone. “Why,
+Girard, whom I met just now at the door of the Cafe Francais. He has
+gone on a journey, or is to go.”
+
+She gave a sob.
+
+“What surprises you in that? He absents himself like that from time
+to time for a change, and, ma foi, I think he’s right, when one has a
+fortune and is a bachelor. Besides, he has jolly times, has our friend.
+He’s a bit of a rake. Monsieur Langlois told me--”
+
+He stopped for propriety’s sake because the servant came in. She put
+back into the basket the apricots scattered on the sideboard. Charles,
+without noticing his wife’s colour, had them brought to him, took one,
+and bit into it.
+
+“Ah! perfect!” said he; “just taste!”
+
+And he handed her the basket, which she put away from her gently.
+
+“Do just smell! What an odour!” he remarked, passing it under her nose
+several times.
+
+“I am choking,” she cried, leaping up. But by an effort of will the
+spasm passed; then--
+
+“It is nothing,” she said, “it is nothing! It is nervousness. Sit down
+and go on eating.” For she dreaded lest he should begin questioning her,
+attending to her, that she should not be left alone.
+
+Charles, to obey her, sat down again, and he spat the stones of the
+apricots into his hands, afterwards putting them on his plate.
+
+Suddenly a blue tilbury passed across the square at a rapid trot. Emma
+uttered a cry and fell back rigid to the ground.
+
+In fact, Rodolphe, after many reflections, had decided to set out for
+Rouen. Now, as from La Huchette to Buchy there is no other way than by
+Yonville, he had to go through the village, and Emma had recognised him
+by the rays of the lanterns, which like lightning flashed through the
+twilight.
+
+The chemist, at the tumult which broke out in the house ran thither. The
+table with all the plates was upset; sauce, meat, knives, the salt, and
+cruet-stand were strewn over the room; Charles was calling for help;
+Berthe, scared, was crying; and Felicite, whose hands trembled, was
+unlacing her mistress, whose whole body shivered convulsively.
+
+“I’ll run to my laboratory for some aromatic vinegar,” said the
+druggist.
+
+Then as she opened her eyes on smelling the bottle--
+
+“I was sure of it,” he remarked; “that would wake any dead person for
+you!”
+
+“Speak to us,” said Charles; “collect yourself; it is your Charles, who
+loves you. Do you know me? See! here is your little girl! Oh, kiss her!”
+
+The child stretched out her arms to her mother to cling to her neck. But
+turning away her head, Emma said in a broken voice “No, no! no one!”
+
+She fainted again. They carried her to her bed. She lay there stretched
+at full length, her lips apart, her eyelids closed, her hands open,
+motionless, and white as a waxen image. Two streams of tears flowed from
+her eyes and fell slowly upon the pillow.
+
+Charles, standing up, was at the back of the alcove, and the chemist,
+near him, maintained that meditative silence that is becoming on the
+serious occasions of life.
+
+“Do not be uneasy,” he said, touching his elbow; “I think the paroxysm
+is past.”
+
+“Yes, she is resting a little now,” answered Charles, watching her
+sleep. “Poor girl! poor girl! She had gone off now!”
+
+Then Homais asked how the accident had come about. Charles answered that
+she had been taken ill suddenly while she was eating some apricots.
+
+“Extraordinary!” continued the chemist. “But it might be that the
+apricots had brought on the syncope. Some natures are so sensitive to
+certain smells; and it would even be a very fine question to study both
+in its pathological and physiological relation. The priests know the
+importance of it, they who have introduced aromatics into all their
+ceremonies. It is to stupefy the senses and to bring on ecstasies--a
+thing, moreover, very easy in persons of the weaker sex, who are more
+delicate than the other. Some are cited who faint at the smell of burnt
+hartshorn, of new bread--”
+
+“Take care; you’ll wake her!” said Bovary in a low voice.
+
+“And not only,” the druggist went on, “are human beings subject to such
+anomalies, but animals also. Thus you are not ignorant of the singularly
+aphrodisiac effect produced by the Nepeta cataria, vulgarly called
+catmint, on the feline race; and, on the other hand, to quote an example
+whose authenticity I can answer for. Bridaux (one of my old comrades, at
+present established in the Rue Malpalu) possesses a dog that falls into
+convulsions as soon as you hold out a snuff-box to him. He often even
+makes the experiment before his friends at his summer-house at Guillaume
+Wood. Would anyone believe that a simple sternutation could produce such
+ravages on a quadrupedal organism? It is extremely curious, is it not?”
+
+“Yes,” said Charles, who was not listening to him.
+
+“This shows us,” went on the other, smiling with benign
+self-sufficiency, “the innumerable irregularities of the nervous system.
+With regard to madame, she has always seemed to me, I confess, very
+susceptible. And so I should by no means recommend to you, my dear
+friend, any of those so-called remedies that, under the pretence
+of attacking the symptoms, attack the constitution. No; no useless
+physicking! Diet, that is all; sedatives, emollients, dulcification.
+Then, don’t you think that perhaps her imagination should be worked
+upon?”
+
+“In what way? How?” said Bovary.
+
+“Ah! that is it. Such is indeed the question. ‘That is the question,’ as
+I lately read in a newspaper.”
+
+But Emma, awaking, cried out--
+
+“The letter! the letter!”
+
+They thought she was delirious; and she was by midnight. Brain-fever had
+set in.
+
+For forty-three days Charles did not leave her. He gave up all his
+patients; he no longer went to bed; he was constantly feeling her pulse,
+putting on sinapisms and cold-water compresses. He sent Justin as far as
+Neufchatel for ice; the ice melted on the way; he sent him back again.
+He called Monsieur Canivet into consultation; he sent for Dr. Lariviere,
+his old master, from Rouen; he was in despair. What alarmed him most was
+Emma’s prostration, for she did not speak, did not listen, did not even
+seem to suffer, as if her body and soul were both resting together after
+all their troubles.
+
+About the middle of October she could sit up in bed supported by
+pillows. Charles wept when he saw her eat her first bread-and-jelly. Her
+strength returned to her; she got up for a few hours of an afternoon,
+and one day, when she felt better, he tried to take her, leaning on his
+arm, for a walk round the garden. The sand of the paths was disappearing
+beneath the dead leaves; she walked slowly, dragging along her slippers,
+and leaning against Charles’s shoulder. She smiled all the time.
+
+They went thus to the bottom of the garden near the terrace. She drew
+herself up slowly, shading her eyes with her hand to look. She looked
+far off, as far as she could, but on the horizon were only great
+bonfires of grass smoking on the hills.
+
+“You will tire yourself, my darling!” said Bovary. And, pushing her
+gently to make her go into the arbour, “Sit down on this seat; you’ll be
+comfortable.”
+
+“Oh! no; not there!” she said in a faltering voice.
+
+She was seized with giddiness, and from that evening her illness
+recommenced, with a more uncertain character, it is true, and more
+complex symptoms. Now she suffered in her heart, then in the chest, the
+head, the limbs; she had vomitings, in which Charles thought he saw the
+first signs of cancer.
+
+And besides this, the poor fellow was worried about money matters.
+
+
+
+Chapter Fourteen
+
+To begin with, he did not know how he could pay Monsieur Homais for all
+the physic supplied by him, and though, as a medical man, he was not
+obliged to pay for it, he nevertheless blushed a little at such an
+obligation. Then the expenses of the household, now that the servant was
+mistress, became terrible. Bills rained in upon the house; the tradesmen
+grumbled; Monsieur Lheureux especially harassed him. In fact, at
+the height of Emma’s illness, the latter, taking advantage of the
+circumstances to make his bill larger, had hurriedly brought the cloak,
+the travelling-bag, two trunks instead of one, and a number of other
+things. It was very well for Charles to say he did not want them. The
+tradesman answered arrogantly that these articles had been ordered, and
+that he would not take them back; besides, it would vex madame in her
+convalescence; the doctor had better think it over; in short, he was
+resolved to sue him rather than give up his rights and take back his
+goods. Charles subsequently ordered them to be sent back to the shop.
+Felicite forgot; he had other things to attend to; then thought no more
+about them. Monsieur Lheureux returned to the charge, and, by turns
+threatening and whining, so managed that Bovary ended by signing a
+bill at six months. But hardly had he signed this bill than a bold idea
+occurred to him: it was to borrow a thousand francs from Lheureux.
+So, with an embarrassed air, he asked if it were possible to get them,
+adding that it would be for a year, at any interest he wished. Lheureux
+ran off to his shop, brought back the money, and dictated another bill,
+by which Bovary undertook to pay to his order on the 1st of September
+next the sum of one thousand and seventy francs, which, with the hundred
+and eighty already agreed to, made just twelve hundred and fifty, thus
+lending at six per cent in addition to one-fourth for commission: and
+the things bringing him in a good third at the least, this ought in
+twelve months to give him a profit of a hundred and thirty francs. He
+hoped that the business would not stop there; that the bills would not
+be paid; that they would be renewed; and that his poor little money,
+having thriven at the doctor’s as at a hospital, would come back to him
+one day considerably more plump, and fat enough to burst his bag.
+
+Everything, moreover, succeeded with him. He was adjudicator for a
+supply of cider to the hospital at Neufchatel; Monsieur Guillaumin
+promised him some shares in the turf-pits of Gaumesnil, and he dreamt of
+establishing a new diligence service between Arcueil and Rouen, which
+no doubt would not be long in ruining the ramshackle van of the “Lion
+d’Or,” and that, travelling faster, at a cheaper rate, and carrying more
+luggage, would thus put into his hands the whole commerce of Yonville.
+
+Charles several times asked himself by what means he should next year be
+able to pay back so much money. He reflected, imagined expedients, such
+as applying to his father or selling something. But his father would be
+deaf, and he--he had nothing to sell. Then he foresaw such worries that
+he quickly dismissed so disagreeable a subject of meditation from
+his mind. He reproached himself with forgetting Emma, as if, all his
+thoughts belonging to this woman, it was robbing her of something not to
+be constantly thinking of her.
+
+The winter was severe, Madame Bovary’s convalescence slow. When it
+was fine they wheeled her arm-chair to the window that overlooked the
+square, for she now had an antipathy to the garden, and the blinds on
+that side were always down. She wished the horse to be sold; what she
+formerly liked now displeased her. All her ideas seemed to be limited to
+the care of herself. She stayed in bed taking little meals, rang for the
+servant to inquire about her gruel or to chat with her. The snow on
+the market-roof threw a white, still light into the room; then the rain
+began to fall; and Emma waited daily with a mind full of eagerness for
+the inevitable return of some trifling events which nevertheless had no
+relation to her. The most important was the arrival of the “Hirondelle”
+ in the evening. Then the landlady shouted out, and other voices
+answered, while Hippolyte’s lantern, as he fetched the boxes from the
+boot, was like a star in the darkness. At mid-day Charles came in;
+then he went out again; next she took some beef-tea, and towards five
+o’clock, as the day drew in, the children coming back from school,
+dragging their wooden shoes along the pavement, knocked the clapper of
+the shutters with their rulers one after the other.
+
+It was at this hour that Monsieur Bournisien came to see her. He
+inquired after her health, gave her news, exhorted her to religion, in a
+coaxing little prattle that was not without its charm. The mere thought
+of his cassock comforted her.
+
+One day, when at the height of her illness, she had thought herself
+dying, and had asked for the communion; and, while they were making the
+preparations in her room for the sacrament, while they were turning the
+night table covered with syrups into an altar, and while Felicite was
+strewing dahlia flowers on the floor, Emma felt some power passing
+over her that freed her from her pains, from all perception, from
+all feeling. Her body, relieved, no longer thought; another life was
+beginning; it seemed to her that her being, mounting toward God, would
+be annihilated in that love like a burning incense that melts into
+vapour. The bed-clothes were sprinkled with holy water, the priest drew
+from the holy pyx the white wafer; and it was fainting with a celestial
+joy that she put out her lips to accept the body of the Saviour
+presented to her. The curtains of the alcove floated gently round her
+like clouds, and the rays of the two tapers burning on the night-table
+seemed to shine like dazzling halos. Then she let her head fall back,
+fancying she heard in space the music of seraphic harps, and perceived
+in an azure sky, on a golden throne in the midst of saints holding green
+palms, God the Father, resplendent with majesty, who with a sign sent to
+earth angels with wings of fire to carry her away in their arms.
+
+This splendid vision dwelt in her memory as the most beautiful thing
+that it was possible to dream, so that now she strove to recall her
+sensation. That still lasted, however, but in a less exclusive fashion
+and with a deeper sweetness. Her soul, tortured by pride, at length
+found rest in Christian humility, and, tasting the joy of weakness, she
+saw within herself the destruction of her will, that must have left a
+wide entrance for the inroads of heavenly grace. There existed, then,
+in the place of happiness, still greater joys--another love beyond all
+loves, without pause and without end, one that would grow eternally! She
+saw amid the illusions of her hope a state of purity floating above the
+earth mingling with heaven, to which she aspired. She wanted to become
+a saint. She bought chaplets and wore amulets; she wished to have in her
+room, by the side of her bed, a reliquary set in emeralds that she might
+kiss it every evening.
+
+The cure marvelled at this humour, although Emma’s religion, he thought,
+might, from its fervour, end by touching on heresy, extravagance. But
+not being much versed in these matters, as soon as they went beyond a
+certain limit he wrote to Monsieur Boulard, bookseller to Monsignor,
+to send him “something good for a lady who was very clever.” The
+bookseller, with as much indifference as if he had been sending off
+hardware to niggers, packed up, pellmell, everything that was then the
+fashion in the pious book trade. There were little manuals in questions
+and answers, pamphlets of aggressive tone after the manner of Monsieur
+de Maistre, and certain novels in rose-coloured bindings and with
+a honied style, manufactured by troubadour seminarists or penitent
+blue-stockings. There were the “Think of it; the Man of the World at
+Mary’s Feet, by Monsieur de ***, decorated with many Orders”; “The
+Errors of Voltaire, for the Use of the Young,” etc.
+
+Madame Bovary’s mind was not yet sufficiently clear to apply herself
+seriously to anything; moreover, she began this reading in too much
+hurry. She grew provoked at the doctrines of religion; the arrogance
+of the polemic writings displeased her by their inveteracy in attacking
+people she did not know; and the secular stories, relieved with
+religion, seemed to her written in such ignorance of the world, that
+they insensibly estranged her from the truths for whose proof she was
+looking. Nevertheless, she persevered; and when the volume slipped
+from her hands, she fancied herself seized with the finest Catholic
+melancholy that an ethereal soul could conceive.
+
+As for the memory of Rodolphe, she had thrust it back to the bottom of
+her heart, and it remained there more solemn and more motionless than
+a king’s mummy in a catacomb. An exhalation escaped from this embalmed
+love, that, penetrating through everything, perfumed with tenderness the
+immaculate atmosphere in which she longed to live. When she knelt on her
+Gothic prie-Dieu, she addressed to the Lord the same suave words that
+she had murmured formerly to her lover in the outpourings of adultery.
+It was to make faith come; but no delights descended from the heavens,
+and she arose with tired limbs and with a vague feeling of a gigantic
+dupery.
+
+This searching after faith, she thought, was only one merit the more,
+and in the pride of her devoutness Emma compared herself to those grand
+ladies of long ago whose glory she had dreamed of over a portrait of La
+Valliere, and who, trailing with so much majesty the lace-trimmed trains
+of their long gowns, retired into solitudes to shed at the feet of
+Christ all the tears of hearts that life had wounded.
+
+Then she gave herself up to excessive charity. She sewed clothes for the
+poor, she sent wood to women in childbed; and Charles one day, on coming
+home, found three good-for-nothings in the kitchen seated at the table
+eating soup. She had her little girl, whom during her illness her
+husband had sent back to the nurse, brought home. She wanted to teach
+her to read; even when Berthe cried, she was not vexed. She had made
+up her mind to resignation, to universal indulgence. Her language about
+everything was full of ideal expressions. She said to her child, “Is
+your stomach-ache better, my angel?”
+
+Madame Bovary senior found nothing to censure except perhaps this mania
+of knitting jackets for orphans instead of mending her own house-linen;
+but, harassed with domestic quarrels, the good woman took pleasure in
+this quiet house, and she even stayed there till after Easter, to escape
+the sarcasms of old Bovary, who never failed on Good Friday to order
+chitterlings.
+
+Besides the companionship of her mother-in-law, who strengthened her a
+little by the rectitude of her judgment and her grave ways, Emma almost
+every day had other visitors. These were Madame Langlois, Madame Caron,
+Madame Dubreuil, Madame Tuvache, and regularly from two to five o’clock
+the excellent Madame Homais, who, for her part, had never believed any
+of the tittle-tattle about her neighbour. The little Homais also came to
+see her; Justin accompanied them. He went up with them to her bedroom,
+and remained standing near the door, motionless and mute. Often even
+Madame Bovary; taking no heed of him, began her toilette. She began by
+taking out her comb, shaking her head with a quick movement, and when
+he for the first time saw all this mass of hair that fell to her knees
+unrolling in black ringlets, it was to him, poor child! like a sudden
+entrance into something new and strange, whose splendour terrified him.
+
+Emma, no doubt, did not notice his silent attentions or his timidity.
+She had no suspicion that the love vanished from her life was there,
+palpitating by her side, beneath that coarse holland shirt, in that
+youthful heart open to the emanations of her beauty. Besides, she
+now enveloped all things with such indifference, she had words so
+affectionate with looks so haughty, such contradictory ways, that one
+could no longer distinguish egotism from charity, or corruption from
+virtue. One evening, for example, she was angry with the servant, who
+had asked to go out, and stammered as she tried to find some pretext.
+Then suddenly--
+
+“So you love him?” she said.
+
+And without waiting for any answer from Felicite, who was blushing, she
+added, “There! run along; enjoy yourself!”
+
+In the beginning of spring she had the garden turned up from end to end,
+despite Bovary’s remonstrances. However, he was glad to see her at last
+manifest a wish of any kind. As she grew stronger she displayed more
+wilfulness. First, she found occasion to expel Mere Rollet, the nurse,
+who during her convalescence had contracted the habit of coming too
+often to the kitchen with her two nurslings and her boarder, better
+off for teeth than a cannibal. Then she got rid of the Homais family,
+successively dismissed all the other visitors, and even frequented
+church less assiduously, to the great approval of the druggist, who said
+to her in a friendly way--
+
+“You were going in a bit for the cassock!”
+
+As formerly, Monsieur Bournisien dropped in every day when he came out
+after catechism class. He preferred staying out of doors to taking the
+air “in the grove,” as he called the arbour. This was the time when
+Charles came home. They were hot; some sweet cider was brought out, and
+they drank together to madame’s complete restoration.
+
+Binet was there; that is to say, a little lower down against the terrace
+wall, fishing for crayfish. Bovary invited him to have a drink, and he
+thoroughly understood the uncorking of the stone bottles.
+
+“You must,” he said, throwing a satisfied glance all round him, even to
+the very extremity of the landscape, “hold the bottle perpendicularly on
+the table, and after the strings are cut, press up the cork with
+little thrusts, gently, gently, as indeed they do seltzer-water at
+restaurants.”
+
+But during his demonstration the cider often spurted right into their
+faces, and then the ecclesiastic, with a thick laugh, never missed this
+joke--
+
+“Its goodness strikes the eye!”
+
+He was, in fact, a good fellow and one day he was not even scandalised
+at the chemist, who advised Charles to give madame some distraction
+by taking her to the theatre at Rouen to hear the illustrious tenor,
+Lagardy. Homais, surprised at this silence, wanted to know his opinion,
+and the priest declared that he considered music less dangerous for
+morals than literature.
+
+But the chemist took up the defence of letters. The theatre, he
+contended, served for railing at prejudices, and, beneath a mask of
+pleasure, taught virtue.
+
+“‘Castigat ridendo mores,’ * Monsieur Bournisien! Thus consider the
+greater part of Voltaire’s tragedies; they are cleverly strewn with
+philosophical reflections, that made them a vast school of morals and
+diplomacy for the people.”
+
+     *It corrects customs through laughter.
+
+
+“I,” said Binet, “once saw a piece called the ‘Gamin de Paris,’ in which
+there was the character of an old general that is really hit off to a
+T. He sets down a young swell who had seduced a working girl, who at the
+ending--”
+
+“Certainly,” continued Homais, “there is bad literature as there is bad
+pharmacy, but to condemn in a lump the most important of the fine arts
+seems to me a stupidity, a Gothic idea, worthy of the abominable times
+that imprisoned Galileo.”
+
+“I know very well,” objected the cure, “that there are good works,
+good authors. However, if it were only those persons of different sexes
+united in a bewitching apartment, decorated rouge, those lights, those
+effeminate voices, all this must, in the long-run, engender a
+certain mental libertinage, give rise to immodest thoughts and impure
+temptations. Such, at any rate, is the opinion of all the Fathers.
+Finally,” he added, suddenly assuming a mystic tone of voice while
+he rolled a pinch of snuff between his fingers, “if the Church has
+condemned the theatre, she must be right; we must submit to her
+decrees.”
+
+“Why,” asked the druggist, “should she excommunicate actors? For
+formerly they openly took part in religious ceremonies. Yes, in the
+middle of the chancel they acted; they performed a kind of farce called
+‘Mysteries,’ which often offended against the laws of decency.”
+
+The ecclesiastic contented himself with uttering a groan, and the
+chemist went on--
+
+“It’s like it is in the Bible; there there are, you know, more than one
+piquant detail, matters really libidinous!”
+
+And on a gesture of irritation from Monsieur Bournisien--
+
+“Ah! you’ll admit that it is not a book to place in the hands of a young
+girl, and I should be sorry if Athalie--”
+
+“But it is the Protestants, and not we,” cried the other impatiently,
+“who recommend the Bible.”
+
+“No matter,” said Homais. “I am surprised that in our days, in this
+century of enlightenment, anyone should still persist in proscribing an
+intellectual relaxation that is inoffensive, moralising, and sometimes
+even hygienic; is it not, doctor?”
+
+“No doubt,” replied the doctor carelessly, either because, sharing the
+same ideas, he wished to offend no one, or else because he had not any
+ideas.
+
+The conversation seemed at an end when the chemist thought fit to shoot
+a Parthian arrow.
+
+“I’ve known priests who put on ordinary clothes to go and see dancers
+kicking about.”
+
+“Come, come!” said the cure.
+
+“Ah! I’ve known some!” And separating the words of his sentence, Homais
+repeated, “I--have--known--some!”
+
+“Well, they were wrong,” said Bournisien, resigned to anything.
+
+“By Jove! they go in for more than that,” exclaimed the druggist.
+
+“Sir!” replied the ecclesiastic, with such angry eyes that the druggist
+was intimidated by them.
+
+“I only mean to say,” he replied in less brutal a tone, “that toleration
+is the surest way to draw people to religion.”
+
+“That is true! that is true!” agreed the good fellow, sitting down again
+on his chair. But he stayed only a few moments.
+
+Then, as soon as he had gone, Monsieur Homais said to the doctor--
+
+“That’s what I call a cock-fight. I beat him, did you see, in a
+way!--Now take my advice. Take madame to the theatre, if it were only
+for once in your life, to enrage one of these ravens, hang it! If anyone
+could take my place, I would accompany you myself. Be quick about it.
+Lagardy is only going to give one performance; he’s engaged to go to
+England at a high salary. From what I hear, he’s a regular dog; he’s
+rolling in money; he’s taking three mistresses and a cook along with
+him. All these great artists burn the candle at both ends; they require
+a dissolute life, that suits the imagination to some extent. But they
+die at the hospital, because they haven’t the sense when young to lay
+by. Well, a pleasant dinner! Goodbye till to-morrow.”
+
+The idea of the theatre quickly germinated in Bovary’s head, for he at
+once communicated it to his wife, who at first refused, alleging the
+fatigue, the worry, the expense; but, for a wonder, Charles did not give
+in, so sure was he that this recreation would be good for her. He saw
+nothing to prevent it: his mother had sent them three hundred francs
+which he had no longer expected; the current debts were not very large,
+and the falling in of Lheureux’s bills was still so far off that
+there was no need to think about them. Besides, imagining that she
+was refusing from delicacy, he insisted the more; so that by dint of
+worrying her she at last made up her mind, and the next day at eight
+o’clock they set out in the “Hirondelle.”
+
+The druggist, whom nothing whatever kept at Yonville, but who thought
+himself bound not to budge from it, sighed as he saw them go.
+
+“Well, a pleasant journey!” he said to them; “happy mortals that you
+are!”
+
+Then addressing himself to Emma, who was wearing a blue silk gown with
+four flounces--
+
+“You are as lovely as a Venus. You’ll cut a figure at Rouen.”
+
+The diligence stopped at the “Croix-Rouge” in the Place Beauvoisine. It
+was the inn that is in every provincial faubourg, with large stables
+and small bedrooms, where one sees in the middle of the court chickens
+pilfering the oats under the muddy gigs of the commercial travellers--a
+good old house, with worm-eaten balconies that creak in the wind on
+winter nights, always full of people, noise, and feeding, whose black
+tables are sticky with coffee and brandy, the thick windows made yellow
+by the flies, the damp napkins stained with cheap wine, and that always
+smells of the village, like ploughboys dressed in Sundayclothes, has
+a cafe on the street, and towards the countryside a kitchen-garden.
+Charles at once set out. He muddled up the stage-boxes with the gallery,
+the pit with the boxes; asked for explanations, did not understand them;
+was sent from the box-office to the acting-manager; came back to the
+inn, returned to the theatre, and thus several times traversed the whole
+length of the town from the theatre to the boulevard.
+
+Madame Bovary bought a bonnet, gloves, and a bouquet. The doctor was
+much afraid of missing the beginning, and, without having had time to
+swallow a plate of soup, they presented themselves at the doors of the
+theatre, which were still closed.
+
+
+
+
+Chapter Fifteen
+
+The crowd was waiting against the wall, symmetrically enclosed between
+the balustrades. At the corner of the neighbouring streets huge bills
+repeated in quaint letters “Lucie de Lammermoor-Lagardy-Opera-etc.” The
+weather was fine, the people were hot, perspiration trickled amid the
+curls, and handkerchiefs taken from pockets were mopping red foreheads;
+and now and then a warm wind that blew from the river gently stirred the
+border of the tick awnings hanging from the doors of the public-houses.
+A little lower down, however, one was refreshed by a current of icy air
+that smelt of tallow, leather, and oil. This was an exhalation from
+the Rue des Charrettes, full of large black warehouses where they made
+casks.
+
+For fear of seeming ridiculous, Emma before going in wished to have a
+little stroll in the harbour, and Bovary prudently kept his tickets in
+his hand, in the pocket of his trousers, which he pressed against his
+stomach.
+
+Her heart began to beat as soon as she reached the vestibule. She
+involuntarily smiled with vanity on seeing the crowd rushing to the
+right by the other corridor while she went up the staircase to the
+reserved seats. She was as pleased as a child to push with her finger
+the large tapestried door. She breathed in with all her might the
+dusty smell of the lobbies, and when she was seated in her box she bent
+forward with the air of a duchess.
+
+The theatre was beginning to fill; opera-glasses were taken from their
+cases, and the subscribers, catching sight of one another, were bowing.
+They came to seek relaxation in the fine arts after the anxieties of
+business; but “business” was not forgotten; they still talked cottons,
+spirits of wine, or indigo. The heads of old men were to be seen,
+inexpressive and peaceful, with their hair and complexions looking like
+silver medals tarnished by steam of lead. The young beaux were strutting
+about in the pit, showing in the opening of their waistcoats their pink
+or applegreen cravats, and Madame Bovary from above admired them leaning
+on their canes with golden knobs in the open palm of their yellow
+gloves.
+
+Now the lights of the orchestra were lit, the lustre, let down from the
+ceiling, throwing by the glimmering of its facets a sudden gaiety over
+the theatre; then the musicians came in one after the other; and
+first there was the protracted hubbub of the basses grumbling, violins
+squeaking, cornets trumpeting, flutes and flageolets fifing. But three
+knocks were heard on the stage, a rolling of drums began, the brass
+instruments played some chords, and the curtain rising, discovered a
+country-scene.
+
+It was the cross-roads of a wood, with a fountain shaded by an oak to
+the left. Peasants and lords with plaids on their shoulders were singing
+a hunting-song together; then a captain suddenly came on, who evoked
+the spirit of evil by lifting both his arms to heaven. Another appeared;
+they went away, and the hunters started afresh. She felt herself
+transported to the reading of her youth, into the midst of Walter Scott.
+She seemed to hear through the mist the sound of the Scotch bagpipes
+re-echoing over the heather. Then her remembrance of the novel helping
+her to understand the libretto, she followed the story phrase by phrase,
+while vague thoughts that came back to her dispersed at once again with
+the bursts of music. She gave herself up to the lullaby of the melodies,
+and felt all her being vibrate as if the violin bows were drawn over her
+nerves. She had not eyes enough to look at the costumes, the scenery,
+the actors, the painted trees that shook when anyone walked, and the
+velvet caps, cloaks, swords--all those imaginary things that floated
+amid the harmony as in the atmosphere of another world. But a young
+woman stepped forward, throwing a purse to a squire in green. She was
+left alone, and the flute was heard like the murmur of a fountain or the
+warbling of birds. Lucie attacked her cavatina in G major bravely. She
+plained of love; she longed for wings. Emma, too, fleeing from life,
+would have liked to fly away in an embrace. Suddenly Edgar-Lagardy
+appeared.
+
+He had that splendid pallor that gives something of the majesty of
+marble to the ardent races of the South. His vigorous form was tightly
+clad in a brown-coloured doublet; a small chiselled poniard hung against
+his left thigh, and he cast round laughing looks showing his white
+teeth. They said that a Polish princess having heard him sing one night
+on the beach at Biarritz, where he mended boats, had fallen in love
+with him. She had ruined herself for him. He had deserted her for
+other women, and this sentimental celebrity did not fail to enhance his
+artistic reputation. The diplomatic mummer took care always to slip into
+his advertisements some poetic phrase on the fascination of his
+person and the susceptibility of his soul. A fine organ, imperturbable
+coolness, more temperament than intelligence, more power of emphasis
+than of real singing, made up the charm of this admirable charlatan
+nature, in which there was something of the hairdresser and the
+toreador.
+
+From the first scene he evoked enthusiasm. He pressed Lucy in his arms,
+he left her, he came back, he seemed desperate; he had outbursts of
+rage, then elegiac gurglings of infinite sweetness, and the notes
+escaped from his bare neck full of sobs and kisses. Emma leant forward
+to see him, clutching the velvet of the box with her nails. She was
+filling her heart with these melodious lamentations that were drawn
+out to the accompaniment of the double-basses, like the cries of the
+drowning in the tumult of a tempest. She recognised all the intoxication
+and the anguish that had almost killed her. The voice of a prima donna
+seemed to her to be but echoes of her conscience, and this illusion that
+charmed her as some very thing of her own life. But no one on earth had
+loved her with such love. He had not wept like Edgar that last moonlit
+night when they said, “To-morrow! to-morrow!” The theatre rang with
+cheers; they recommenced the entire movement; the lovers spoke of
+the flowers on their tomb, of vows, exile, fate, hopes; and when they
+uttered the final adieu, Emma gave a sharp cry that mingled with the
+vibrations of the last chords.
+
+“But why,” asked Bovary, “does that gentleman persecute her?”
+
+“No, no!” she answered; “he is her lover!”
+
+“Yet he vows vengeance on her family, while the other one who came on
+before said, ‘I love Lucie and she loves me!’ Besides, he went off with
+her father arm in arm. For he certainly is her father, isn’t he--the
+ugly little man with a cock’s feather in his hat?”
+
+Despite Emma’s explanations, as soon as the recitative duet began
+in which Gilbert lays bare his abominable machinations to his master
+Ashton, Charles, seeing the false troth-ring that is to deceive Lucie,
+thought it was a love-gift sent by Edgar. He confessed, moreover, that
+he did not understand the story because of the music, which interfered
+very much with the words.
+
+“What does it matter?” said Emma. “Do be quiet!”
+
+“Yes, but you know,” he went on, leaning against her shoulder, “I like
+to understand things.”
+
+“Be quiet! be quiet!” she cried impatiently.
+
+Lucie advanced, half supported by her women, a wreath of orange blossoms
+in her hair, and paler than the white satin of her gown. Emma dreamed
+of her marriage day; she saw herself at home again amid the corn in the
+little path as they walked to the church. Oh, why had not she, like
+this woman, resisted, implored? She, on the contrary, had been joyous,
+without seeing the abyss into which she was throwing herself. Ah! if
+in the freshness of her beauty, before the soiling of marriage and the
+disillusions of adultery, she could have anchored her life upon some
+great, strong heart, then virtue, tenderness, voluptuousness, and duty
+blending, she would never have fallen from so high a happiness. But that
+happiness, no doubt, was a lie invented for the despair of all desire.
+She now knew the smallness of the passions that art exaggerated. So,
+striving to divert her thoughts, Emma determined now to see in this
+reproduction of her sorrows only a plastic fantasy, well enough to
+please the eye, and she even smiled internally with disdainful pity when
+at the back of the stage under the velvet hangings a man appeared in a
+black cloak.
+
+His large Spanish hat fell at a gesture he made, and immediately the
+instruments and the singers began the sextet. Edgar, flashing with fury,
+dominated all the others with his clearer voice; Ashton hurled homicidal
+provocations at him in deep notes; Lucie uttered her shrill plaint,
+Arthur at one side, his modulated tones in the middle register, and the
+bass of the minister pealed forth like an organ, while the voices of the
+women repeating his words took them up in chorus delightfully. They were
+all in a row gesticulating, and anger, vengeance, jealousy, terror, and
+stupefaction breathed forth at once from their half-opened mouths. The
+outraged lover brandished his naked sword; his guipure ruffle rose with
+jerks to the movements of his chest, and he walked from right to left
+with long strides, clanking against the boards the silver-gilt spurs of
+his soft boots, widening out at the ankles. He, she thought must have an
+inexhaustible love to lavish it upon the crowd with such effusion.
+All her small fault-findings faded before the poetry of the part
+that absorbed her; and, drawn towards this man by the illusion of the
+character, she tried to imagine to herself his life--that life resonant,
+extraordinary, splendid, and that might have been hers if fate had
+willed it. They would have known one another, loved one another. With
+him, through all the kingdoms of Europe she would have travelled from
+capital to capital, sharing his fatigues and his pride, picking up the
+flowers thrown to him, herself embroidering his costumes. Then each
+evening, at the back of a box, behind the golden trellis-work she would
+have drunk in eagerly the expansions of this soul that would have sung
+for her alone; from the stage, even as he acted, he would have looked
+at her. But the mad idea seized her that he was looking at her; it was
+certain. She longed to run to his arms, to take refuge in his strength,
+as in the incarnation of love itself, and to say to him, to cry out,
+“Take me away! carry me with you! let us go! Thine, thine! all my ardour
+and all my dreams!”
+
+The curtain fell.
+
+The smell of the gas mingled with that of the breaths, the waving of the
+fans, made the air more suffocating. Emma wanted to go out; the
+crowd filled the corridors, and she fell back in her arm-chair with
+palpitations that choked her. Charles, fearing that she would faint, ran
+to the refreshment-room to get a glass of barley-water.
+
+He had great difficulty in getting back to his seat, for his elbows were
+jerked at every step because of the glass he held in his hands, and
+he even spilt three-fourths on the shoulders of a Rouen lady in short
+sleeves, who feeling the cold liquid running down to her loins, uttered
+cries like a peacock, as if she were being assassinated. Her husband,
+who was a millowner, railed at the clumsy fellow, and while she was with
+her handkerchief wiping up the stains from her handsome cherry-coloured
+taffeta gown, he angrily muttered about indemnity, costs, reimbursement.
+At last Charles reached his wife, saying to her, quite out of breath--
+
+“Ma foi! I thought I should have had to stay there. There is such a
+crowd--SUCH a crowd!”
+
+He added--
+
+“Just guess whom I met up there! Monsieur Leon!”
+
+“Leon?”
+
+“Himself! He’s coming along to pay his respects.” And as he finished
+these words the ex-clerk of Yonville entered the box.
+
+He held out his hand with the ease of a gentleman; and Madame Bovary
+extended hers, without doubt obeying the attraction of a stronger will.
+She had not felt it since that spring evening when the rain fell upon
+the green leaves, and they had said good-bye standing at the window.
+But soon recalling herself to the necessities of the situation, with an
+effort she shook off the torpor of her memories, and began stammering a
+few hurried words.
+
+“Ah, good-day! What! you here?”
+
+“Silence!” cried a voice from the pit, for the third act was beginning.
+
+“So you are at Rouen?”
+
+“Yes.”
+
+“And since when?”
+
+“Turn them out! turn them out!” People were looking at them. They were
+silent.
+
+But from that moment she listened no more; and the chorus of the guests,
+the scene between Ashton and his servant, the grand duet in D major, all
+were for her as far off as if the instruments had grown less sonorous
+and the characters more remote. She remembered the games at cards at the
+druggist’s, and the walk to the nurse’s, the reading in the arbour,
+the tete-a-tete by the fireside--all that poor love, so calm and so
+protracted, so discreet, so tender, and that she had nevertheless
+forgotten. And why had he come back? What combination of circumstances
+had brought him back into her life? He was standing behind her, leaning
+with his shoulder against the wall of the box; now and again she felt
+herself shuddering beneath the hot breath from his nostrils falling upon
+her hair.
+
+“Does this amuse you?” said he, bending over her so closely that the end
+of his moustache brushed her cheek. She replied carelessly--
+
+“Oh, dear me, no, not much.”
+
+Then he proposed that they should leave the theatre and go and take an
+ice somewhere.
+
+“Oh, not yet; let us stay,” said Bovary. “Her hair’s undone; this is
+going to be tragic.”
+
+But the mad scene did not at all interest Emma, and the acting of the
+singer seemed to her exaggerated.
+
+“She screams too loud,” said she, turning to Charles, who was listening.
+
+“Yes--a little,” he replied, undecided between the frankness of his
+pleasure and his respect for his wife’s opinion.
+
+Then with a sigh Leon said--
+
+“The heat is--”
+
+“Unbearable! Yes!”
+
+“Do you feel unwell?” asked Bovary.
+
+“Yes, I am stifling; let us go.”
+
+Monsieur Leon put her long lace shawl carefully about her shoulders, and
+all three went off to sit down in the harbour, in the open air, outside
+the windows of a cafe.
+
+First they spoke of her illness, although Emma interrupted Charles
+from time to time, for fear, she said, of boring Monsieur Leon; and the
+latter told them that he had come to spend two years at Rouen in a large
+office, in order to get practice in his profession, which was different
+in Normandy and Paris. Then he inquired after Berthe, the Homais, Mere
+Lefrancois, and as they had, in the husband’s presence, nothing more to
+say to one another, the conversation soon came to an end.
+
+People coming out of the theatre passed along the pavement, humming or
+shouting at the top of their voices, “O bel ange, ma Lucie!*” Then Leon,
+playing the dilettante, began to talk music. He had seen Tambourini,
+Rubini, Persiani, Grisi, and, compared with them, Lagardy, despite his
+grand outbursts, was nowhere.
+
+     *Oh beautiful angel, my Lucie.
+
+
+“Yet,” interrupted Charles, who was slowly sipping his rum-sherbet,
+“they say that he is quite admirable in the last act. I regret leaving
+before the end, because it was beginning to amuse me.”
+
+“Why,” said the clerk, “he will soon give another performance.”
+
+But Charles replied that they were going back next day. “Unless,” he
+added, turning to his wife, “you would like to stay alone, kitten?”
+
+And changing his tactics at this unexpected opportunity that presented
+itself to his hopes, the young man sang the praises of Lagardy in the
+last number. It was really superb, sublime. Then Charles insisted--
+
+“You would get back on Sunday. Come, make up your mind. You are wrong if
+you feel that this is doing you the least good.”
+
+The tables round them, however, were emptying; a waiter came and stood
+discreetly near them. Charles, who understood, took out his purse; the
+clerk held back his arm, and did not forget to leave two more pieces of
+silver that he made chink on the marble.
+
+“I am really sorry,” said Bovary, “about the money which you are--”
+
+The other made a careless gesture full of cordiality, and taking his hat
+said--
+
+“It is settled, isn’t it? To-morrow at six o’clock?”
+
+Charles explained once more that he could not absent himself longer, but
+that nothing prevented Emma--
+
+“But,” she stammered, with a strange smile, “I am not sure--”
+
+“Well, you must think it over. We’ll see. Night brings counsel.” Then to
+Leon, who was walking along with them, “Now that you are in our part of
+the world, I hope you’ll come and ask us for some dinner now and then.”
+
+The clerk declared he would not fail to do so, being obliged, moreover,
+to go to Yonville on some business for his office. And they parted
+before the Saint-Herbland Passage just as the clock in the cathedral
+struck half-past eleven.
+
+
+
+
+Part III
+
+
+
+Chapter One
+
+Monsieur Leon, while studying law, had gone pretty often to the
+dancing-rooms, where he was even a great success amongst the grisettes,
+who thought he had a distinguished air. He was the best-mannered of the
+students; he wore his hair neither too long nor too short, didn’t spend
+all his quarter’s money on the first day of the month, and kept on good
+terms with his professors. As for excesses, he had always abstained from
+them, as much from cowardice as from refinement.
+
+Often when he stayed in his room to read, or else when sitting of an
+evening under the lime-trees of the Luxembourg, he let his Code fall to
+the ground, and the memory of Emma came back to him. But gradually this
+feeling grew weaker, and other desires gathered over it, although it
+still persisted through them all. For Leon did not lose all hope; there
+was for him, as it were, a vague promise floating in the future, like a
+golden fruit suspended from some fantastic tree.
+
+Then, seeing her again after three years of absence his passion
+reawakened. He must, he thought, at last make up his mind to possess
+her. Moreover, his timidity had worn off by contact with his gay
+companions, and he returned to the provinces despising everyone who had
+not with varnished shoes trodden the asphalt of the boulevards. By
+the side of a Parisienne in her laces, in the drawing-room of some
+illustrious physician, a person driving his carriage and wearing many
+orders, the poor clerk would no doubt have trembled like a child; but
+here, at Rouen, on the harbour, with the wife of this small doctor
+he felt at his ease, sure beforehand he would shine. Self-possession
+depends on its environment. We don’t speak on the first floor as on the
+fourth; and the wealthy woman seems to have, about her, to guard her
+virtue, all her banknotes, like a cuirass in the lining of her corset.
+
+On leaving the Bovarys the night before, Leon had followed them
+through the streets at a distance; then having seen them stop at the
+“Croix-Rouge,” he turned on his heel, and spent the night meditating a
+plan.
+
+So the next day about five o’clock he walked into the kitchen of the
+inn, with a choking sensation in his throat, pale cheeks, and that
+resolution of cowards that stops at nothing.
+
+“The gentleman isn’t in,” answered a servant.
+
+This seemed to him a good omen. He went upstairs.
+
+She was not disturbed at his approach; on the contrary, she apologised
+for having neglected to tell him where they were staying.
+
+“Oh, I divined it!” said Leon.
+
+He pretended he had been guided towards her by chance, by, instinct. She
+began to smile; and at once, to repair his folly, Leon told her that he
+had spent his morning in looking for her in all the hotels in the town
+one after the other.
+
+“So you have made up your mind to stay?” he added.
+
+“Yes,” she said, “and I am wrong. One ought not to accustom oneself to
+impossible pleasures when there are a thousand demands upon one.”
+
+“Oh, I can imagine!”
+
+“Ah! no; for you, you are a man!”
+
+But men too had had their trials, and the conversation went off into
+certain philosophical reflections. Emma expatiated much on the misery of
+earthly affections, and the eternal isolation in which the heart remains
+entombed.
+
+To show off, or from a naive imitation of this melancholy which called
+forth his, the young man declared that he had been awfully bored during
+the whole course of his studies. The law irritated him, other vocations
+attracted him, and his mother never ceased worrying him in every one
+of her letters. As they talked they explained more and more fully the
+motives of their sadness, working themselves up in their progressive
+confidence. But they sometimes stopped short of the complete exposition
+of their thought, and then sought to invent a phrase that might express
+it all the same. She did not confess her passion for another; he did not
+say that he had forgotten her.
+
+Perhaps he no longer remembered his suppers with girls after masked
+balls; and no doubt she did not recollect the rendezvous of old when she
+ran across the fields in the morning to her lover’s house. The noises
+of the town hardly reached them, and the room seemed small, as if
+on purpose to hem in their solitude more closely. Emma, in a dimity
+dressing-gown, leant her head against the back of the old arm-chair; the
+yellow wall-paper formed, as it were, a golden background behind her,
+and her bare head was mirrored in the glass with the white parting in
+the middle, and the tip of her ears peeping out from the folds of her
+hair.
+
+“But pardon me!” she said. “It is wrong of me. I weary you with my
+eternal complaints.”
+
+“No, never, never!”
+
+“If you knew,” she went on, raising to the ceiling her beautiful eyes,
+in which a tear was trembling, “all that I had dreamed!”
+
+“And I! Oh, I too have suffered! Often I went out; I went away. I
+dragged myself along the quays, seeking distraction amid the din of the
+crowd without being able to banish the heaviness that weighed upon me.
+In an engraver’s shop on the boulevard there is an Italian print of one
+of the Muses. She is draped in a tunic, and she is looking at the
+moon, with forget-me-nots in her flowing hair. Something drove me there
+continually; I stayed there hours together.” Then in a trembling voice,
+“She resembled you a little.”
+
+Madame Bovary turned away her head that he might not see the
+irrepressible smile she felt rising to her lips.
+
+“Often,” he went on, “I wrote you letters that I tore up.”
+
+She did not answer. He continued--
+
+“I sometimes fancied that some chance would bring you. I thought I
+recognised you at street-corners, and I ran after all the carriages
+through whose windows I saw a shawl fluttering, a veil like yours.”
+
+She seemed resolved to let him go on speaking without interruption.
+Crossing her arms and bending down her face, she looked at the rosettes
+on her slippers, and at intervals made little movements inside the satin
+of them with her toes.
+
+At last she sighed.
+
+“But the most wretched thing, is it not--is to drag out, as I do, a
+useless existence. If our pains were only of some use to someone, we
+should find consolation in the thought of the sacrifice.”
+
+He started off in praise of virtue, duty, and silent immolation, having
+himself an incredible longing for self-sacrifice that he could not
+satisfy.
+
+“I should much like,” she said, “to be a nurse at a hospital.”
+
+“Alas! men have none of these holy missions, and I see nowhere any
+calling--unless perhaps that of a doctor.”
+
+With a slight shrug of her shoulders, Emma interrupted him to speak of
+her illness, which had almost killed her. What a pity! She should not be
+suffering now! Leon at once envied the calm of the tomb, and one evening
+he had even made his will, asking to be buried in that beautiful rug
+with velvet stripes he had received from her. For this was how they
+would have wished to be, each setting up an ideal to which they were now
+adapting their past life. Besides, speech is a rolling-mill that always
+thins out the sentiment.
+
+But at this invention of the rug she asked, “But why?”
+
+“Why?” He hesitated. “Because I loved you so!” And congratulating
+himself at having surmounted the difficulty, Leon watched her face out
+of the corner of his eyes.
+
+It was like the sky when a gust of wind drives the clouds across. The
+mass of sad thoughts that darkened them seemed to be lifted from her
+blue eyes; her whole face shone. He waited. At last she replied--
+
+“I always suspected it.”
+
+Then they went over all the trifling events of that far-off existence,
+whose joys and sorrows they had just summed up in one word. They
+recalled the arbour with clematis, the dresses she had worn, the
+furniture of her room, the whole of her house.
+
+“And our poor cactuses, where are they?”
+
+“The cold killed them this winter.”
+
+“Ah! how I have thought of them, do you know? I often saw them again as
+of yore, when on the summer mornings the sun beat down upon your blinds,
+and I saw your two bare arms passing out amongst the flowers.”
+
+“Poor friend!” she said, holding out her hand to him.
+
+Leon swiftly pressed his lips to it. Then, when he had taken a deep
+breath--
+
+“At that time you were to me I know not what incomprehensible force that
+took captive my life. Once, for instance, I went to see you; but you, no
+doubt, do not remember it.”
+
+“I do,” she said; “go on.”
+
+“You were downstairs in the ante-room, ready to go out, standing on
+the last stair; you were wearing a bonnet with small blue flowers; and
+without any invitation from you, in spite of myself, I went with you.
+Every moment, however, I grew more and more conscious of my folly, and
+I went on walking by you, not daring to follow you completely, and
+unwilling to leave you. When you went into a shop, I waited in the
+street, and I watched you through the window taking off your gloves and
+counting the change on the counter. Then you rang at Madame Tuvache’s;
+you were let in, and I stood like an idiot in front of the great heavy
+door that had closed after you.”
+
+Madame Bovary, as she listened to him, wondered that she was so old. All
+these things reappearing before her seemed to widen out her life; it was
+like some sentimental immensity to which she returned; and from time to
+time she said in a low voice, her eyes half closed--
+
+“Yes, it is true--true--true!”
+
+They heard eight strike on the different clocks of the Beauvoisine
+quarter, which is full of schools, churches, and large empty hotels.
+They no longer spoke, but they felt as they looked upon each other a
+buzzing in their heads, as if something sonorous had escaped from the
+fixed eyes of each of them. They were hand in hand now, and the past,
+the future, reminiscences and dreams, all were confounded in the
+sweetness of this ecstasy. Night was darkening over the walls, on which
+still shone, half hidden in the shade, the coarse colours of four bills
+representing four scenes from the “Tour de Nesle,” with a motto in
+Spanish and French at the bottom. Through the sash-window a patch of
+dark sky was seen between the pointed roofs.
+
+She rose to light two wax-candles on the drawers, then she sat down
+again.
+
+“Well!” said Leon.
+
+“Well!” she replied.
+
+He was thinking how to resume the interrupted conversation, when she
+said to him--
+
+“How is it that no one until now has ever expressed such sentiments to
+me?”
+
+The clerk said that ideal natures were difficult to understand. He from
+the first moment had loved her, and he despaired when he thought of the
+happiness that would have been theirs, if thanks to fortune, meeting her
+earlier, they had been indissolubly bound to one another.
+
+“I have sometimes thought of it,” she went on.
+
+“What a dream!” murmured Leon. And fingering gently the blue binding of
+her long white sash, he added, “And who prevents us from beginning now?”
+
+“No, my friend,” she replied; “I am too old; you are too young. Forget
+me! Others will love you; you will love them.”
+
+“Not as you!” he cried.
+
+“What a child you are! Come, let us be sensible. I wish it.”
+
+She showed him the impossibility of their love, and that they must
+remain, as formerly, on the simple terms of a fraternal friendship.
+
+Was she speaking thus seriously? No doubt Emma did not herself know,
+quite absorbed as she was by the charm of the seduction, and the
+necessity of defending herself from it; and contemplating the young
+man with a moved look, she gently repulsed the timid caresses that his
+trembling hands attempted.
+
+“Ah! forgive me!” he cried, drawing back.
+
+Emma was seized with a vague fear at this shyness, more dangerous to her
+than the boldness of Rodolphe when he advanced to her open-armed. No man
+had ever seemed to her so beautiful. An exquisite candour emanated from
+his being. He lowered his long fine eyelashes, that curled upwards.
+His cheek, with the soft skin reddened, she thought, with desire of her
+person, and Emma felt an invincible longing to press her lips to it.
+Then, leaning towards the clock as if to see the time--
+
+“Ah! how late it is!” she said; “how we do chatter!”
+
+He understood the hint and took up his hat.
+
+“It has even made me forget the theatre. And poor Bovary has left me
+here especially for that. Monsieur Lormeaux, of the Rue Grand-Pont, was
+to take me and his wife.”
+
+And the opportunity was lost, as she was to leave the next day.
+
+“Really!” said Leon.
+
+“Yes.”
+
+“But I must see you again,” he went on. “I wanted to tell you--”
+
+“What?”
+
+“Something--important--serious. Oh, no! Besides, you will not go; it is
+impossible. If you should--listen to me. Then you have not understood
+me; you have not guessed--”
+
+“Yet you speak plainly,” said Emma.
+
+“Ah! you can jest. Enough! enough! Oh, for pity’s sake, let me see you
+once--only once!”
+
+“Well--” She stopped; then, as if thinking better of it, “Oh, not here!”
+
+“Where you will.”
+
+“Will you--” She seemed to reflect; then abruptly, “To-morrow at eleven
+o’clock in the cathedral.”
+
+“I shall be there,” he cried, seizing her hands, which she disengaged.
+
+And as they were both standing up, he behind her, and Emma with her head
+bent, he stooped over her and pressed long kisses on her neck.
+
+“You are mad! Ah! you are mad!” she said, with sounding little laughs,
+while the kisses multiplied.
+
+Then bending his head over her shoulder, he seemed to beg the consent of
+her eyes. They fell upon him full of an icy dignity.
+
+Leon stepped back to go out. He stopped on the threshold; then he
+whispered with a trembling voice, “Tomorrow!”
+
+She answered with a nod, and disappeared like a bird into the next room.
+
+In the evening Emma wrote the clerk an interminable letter, in which she
+cancelled the rendezvous; all was over; they must not, for the sake of
+their happiness, meet again. But when the letter was finished, as she
+did not know Leon’s address, she was puzzled.
+
+“I’ll give it to him myself,” she said; “he will come.”
+
+The next morning, at the open window, and humming on his balcony, Leon
+himself varnished his pumps with several coatings. He put on white
+trousers, fine socks, a green coat, emptied all the scent he had into
+his handkerchief, then having had his hair curled, he uncurled it again,
+in order to give it a more natural elegance.
+
+“It is still too early,” he thought, looking at the hairdresser’s
+cuckoo-clock, that pointed to the hour of nine. He read an old fashion
+journal, went out, smoked a cigar, walked up three streets, thought it
+was time, and went slowly towards the porch of Notre Dame.
+
+It was a beautiful summer morning. Silver plate sparkled in the
+jeweller’s windows, and the light falling obliquely on the cathedral
+made mirrors of the corners of the grey stones; a flock of birds
+fluttered in the grey sky round the trefoil bell-turrets; the square,
+resounding with cries, was fragrant with the flowers that bordered its
+pavement, roses, jasmines, pinks, narcissi, and tube-roses, unevenly
+spaced out between moist grasses, catmint, and chickweed for the birds;
+the fountains gurgled in the centre, and under large umbrellas, amidst
+melons, piled up in heaps, flower-women, bare-headed, were twisting
+paper round bunches of violets.
+
+The young man took one. It was the first time that he had bought flowers
+for a woman, and his breast, as he smelt them, swelled with pride, as if
+this homage that he meant for another had recoiled upon himself.
+
+But he was afraid of being seen; he resolutely entered the church. The
+beadle, who was just then standing on the threshold in the middle of the
+left doorway, under the “Dancing Marianne,” with feather cap, and rapier
+dangling against his calves, came in, more majestic than a cardinal, and
+as shining as a saint on a holy pyx.
+
+He came towards Leon, and, with that smile of wheedling benignity
+assumed by ecclesiastics when they question children--
+
+“The gentleman, no doubt, does not belong to these parts? The gentleman
+would like to see the curiosities of the church?”
+
+“No!” said the other.
+
+And he first went round the lower aisles. Then he went out to look at
+the Place. Emma was not coming yet. He went up again to the choir.
+
+The nave was reflected in the full fonts with the beginning of the
+arches and some portions of the glass windows. But the reflections of
+the paintings, broken by the marble rim, were continued farther on upon
+the flag-stones, like a many-coloured carpet. The broad daylight from
+without streamed into the church in three enormous rays from the three
+opened portals. From time to time at the upper end a sacristan passed,
+making the oblique genuflexion of devout persons in a hurry. The crystal
+lustres hung motionless. In the choir a silver lamp was burning, and
+from the side chapels and dark places of the church sometimes rose
+sounds like sighs, with the clang of a closing grating, its echo
+reverberating under the lofty vault.
+
+Leon with solemn steps walked along by the walls. Life had never seemed
+so good to him. She would come directly, charming, agitated, looking
+back at the glances that followed her, and with her flounced dress, her
+gold eyeglass, her thin shoes, with all sorts of elegant trifles that he
+had never enjoyed, and with the ineffable seduction of yielding virtue.
+The church like a huge boudoir spread around her; the arches bent down
+to gather in the shade the confession of her love; the windows shone
+resplendent to illumine her face, and the censers would burn that she
+might appear like an angel amid the fumes of the sweet-smelling odours.
+
+But she did not come. He sat down on a chair, and his eyes fell upon a
+blue stained window representing boatmen carrying baskets. He looked at
+it long, attentively, and he counted the scales of the fishes and the
+button-holes of the doublets, while his thoughts wandered off towards
+Emma.
+
+The beadle, standing aloof, was inwardly angry at this individual who
+took the liberty of admiring the cathedral by himself. He seemed to him
+to be conducting himself in a monstrous fashion, to be robbing him in a
+sort, and almost committing sacrilege.
+
+But a rustle of silk on the flags, the tip of a bonnet, a lined
+cloak--it was she! Leon rose and ran to meet her.
+
+Emma was pale. She walked fast.
+
+“Read!” she said, holding out a paper to him. “Oh, no!”
+
+And she abruptly withdrew her hand to enter the chapel of the Virgin,
+where, kneeling on a chair, she began to pray.
+
+The young man was irritated at this bigot fancy; then he nevertheless
+experienced a certain charm in seeing her, in the middle of a
+rendezvous, thus lost in her devotions, like an Andalusian marchioness;
+then he grew bored, for she seemed never coming to an end.
+
+Emma prayed, or rather strove to pray, hoping that some sudden
+resolution might descend to her from heaven; and to draw down divine
+aid she filled full her eyes with the splendours of the tabernacle. She
+breathed in the perfumes of the full-blown flowers in the large vases,
+and listened to the stillness of the church, that only heightened the
+tumult of her heart.
+
+She rose, and they were about to leave, when the beadle came forward,
+hurriedly saying--
+
+“Madame, no doubt, does not belong to these parts? Madame would like to
+see the curiosities of the church?”
+
+“Oh, no!” cried the clerk.
+
+“Why not?” said she. For she clung with her expiring virtue to the
+Virgin, the sculptures, the tombs--anything.
+
+Then, in order to proceed “by rule,” the beadle conducted them right to
+the entrance near the square, where, pointing out with his cane a large
+circle of block-stones without inscription or carving--
+
+“This,” he said majestically, “is the circumference of the beautiful
+bell of Ambroise. It weighed forty thousand pounds. There was not its
+equal in all Europe. The workman who cast it died of the joy--”
+
+“Let us go on,” said Leon.
+
+The old fellow started off again; then, having got back to the chapel of
+the Virgin, he stretched forth his arm with an all-embracing gesture
+of demonstration, and, prouder than a country squire showing you his
+espaliers, went on--
+
+“This simple stone covers Pierre de Breze, lord of Varenne and of
+Brissac, grand marshal of Poitou, and governor of Normandy, who died at
+the battle of Montlhery on the 16th of July, 1465.”
+
+Leon bit his lips, fuming.
+
+“And on the right, this gentleman all encased in iron, on the
+prancing horse, is his grandson, Louis de Breze, lord of Breval and of
+Montchauvet, Count de Maulevrier, Baron de Mauny, chamberlain to the
+king, Knight of the Order, and also governor of Normandy; died on the
+23rd of July, 1531--a Sunday, as the inscription specifies; and below,
+this figure, about to descend into the tomb, portrays the same person.
+It is not possible, is it, to see a more perfect representation of
+annihilation?”
+
+Madame Bovary put up her eyeglasses. Leon, motionless, looked at her,
+no longer even attempting to speak a single word, to make a gesture,
+so discouraged was he at this two-fold obstinacy of gossip and
+indifference.
+
+The everlasting guide went on--
+
+“Near him, this kneeling woman who weeps is his spouse, Diane de
+Poitiers, Countess de Breze, Duchess de Valentinois, born in 1499, died
+in 1566, and to the left, the one with the child is the Holy Virgin. Now
+turn to this side; here are the tombs of the Ambroise. They were both
+cardinals and archbishops of Rouen. That one was minister under Louis
+XII. He did a great deal for the cathedral. In his will he left thirty
+thousand gold crowns for the poor.”
+
+And without stopping, still talking, he pushed them into a chapel
+full of balustrades, some put away, and disclosed a kind of block that
+certainly might once have been an ill-made statue.
+
+“Truly,” he said with a groan, “it adorned the tomb of Richard Coeur de
+Lion, King of England and Duke of Normandy. It was the Calvinists, sir,
+who reduced it to this condition. They had buried it for spite in the
+earth, under the episcopal seat of Monsignor. See! this is the door by
+which Monsignor passes to his house. Let us pass on quickly to see the
+gargoyle windows.”
+
+But Leon hastily took some silver from his pocket and seized Emma’s
+arm. The beadle stood dumfounded, not able to understand this untimely
+munificence when there were still so many things for the stranger to
+see. So calling him back, he cried--
+
+“Sir! sir! The steeple! the steeple!”
+
+“No, thank you!” said Leon.
+
+“You are wrong, sir! It is four hundred and forty feet high, nine less
+than the great pyramid of Egypt. It is all cast; it--”
+
+Leon was fleeing, for it seemed to him that his love, that for nearly
+two hours now had become petrified in the church like the stones, would
+vanish like a vapour through that sort of truncated funnel, of oblong
+cage, of open chimney that rises so grotesquely from the cathedral like
+the extravagant attempt of some fantastic brazier.
+
+“But where are we going?” she said.
+
+Making no answer, he walked on with a rapid step; and Madame Bovary
+was already, dipping her finger in the holy water when behind them they
+heard a panting breath interrupted by the regular sound of a cane. Leon
+turned back.
+
+“Sir!”
+
+“What is it?”
+
+And he recognised the beadle, holding under his arms and balancing
+against his stomach some twenty large sewn volumes. They were works
+“which treated of the cathedral.”
+
+“Idiot!” growled Leon, rushing out of the church.
+
+A lad was playing about the close.
+
+“Go and get me a cab!”
+
+The child bounded off like a ball by the Rue Quatre-Vents; then they
+were alone a few minutes, face to face, and a little embarrassed.
+
+“Ah! Leon! Really--I don’t know--if I ought,” she whispered. Then with a
+more serious air, “Do you know, it is very improper--”
+
+“How so?” replied the clerk. “It is done at Paris.”
+
+And that, as an irresistible argument, decided her.
+
+Still the cab did not come. Leon was afraid she might go back into the
+church. At last the cab appeared.
+
+“At all events, go out by the north porch,” cried the beadle, who was
+left alone on the threshold, “so as to see the Resurrection, the Last
+Judgment, Paradise, King David, and the Condemned in Hell-flames.”
+
+“Where to, sir?” asked the coachman.
+
+“Where you like,” said Leon, forcing Emma into the cab.
+
+And the lumbering machine set out. It went down the Rue Grand-Pont,
+crossed the Place des Arts, the Quai Napoleon, the Pont Neuf, and
+stopped short before the statue of Pierre Corneille.
+
+“Go on,” cried a voice that came from within.
+
+The cab went on again, and as soon as it reached the Carrefour
+Lafayette, set off down-hill, and entered the station at a gallop.
+
+“No, straight on!” cried the same voice.
+
+The cab came out by the gate, and soon having reached the Cours, trotted
+quietly beneath the elm-trees. The coachman wiped his brow, put his
+leather hat between his knees, and drove his carriage beyond the side
+alley by the meadow to the margin of the waters.
+
+It went along by the river, along the towing-path paved with sharp
+pebbles, and for a long while in the direction of Oyssel, beyond the
+isles.
+
+But suddenly it turned with a dash across Quatremares, Sotteville, La
+Grande-Chaussee, the Rue d’Elbeuf, and made its third halt in front of
+the Jardin des Plantes.
+
+“Get on, will you?” cried the voice more furiously.
+
+And at once resuming its course, it passed by Saint-Sever, by the
+Quai’des Curandiers, the Quai aux Meules, once more over the bridge, by
+the Place du Champ de Mars, and behind the hospital gardens, where old
+men in black coats were walking in the sun along the terrace all green
+with ivy. It went up the Boulevard Bouvreuil, along the Boulevard
+Cauchoise, then the whole of Mont-Riboudet to the Deville hills.
+
+It came back; and then, without any fixed plan or direction, wandered
+about at hazard. The cab was seen at Saint-Pol, at Lescure, at Mont
+Gargan, at La Rougue-Marc and Place du Gaillardbois; in the Rue
+Maladrerie, Rue Dinanderie, before Saint-Romain, Saint-Vivien,
+Saint-Maclou, Saint-Nicaise--in front of the Customs, at the “Vieille
+Tour,” the “Trois Pipes,” and the Monumental Cemetery. From time to time
+the coachman, on his box cast despairing eyes at the public-houses.
+He could not understand what furious desire for locomotion urged these
+individuals never to wish to stop. He tried to now and then, and at
+once exclamations of anger burst forth behind him. Then he lashed his
+perspiring jades afresh, but indifferent to their jolting, running up
+against things here and there, not caring if he did, demoralised, and
+almost weeping with thirst, fatigue, and depression.
+
+And on the harbour, in the midst of the drays and casks, and in the
+streets, at the corners, the good folk opened large wonder-stricken
+eyes at this sight, so extraordinary in the provinces, a cab with blinds
+drawn, and which appeared thus constantly shut more closely than a tomb,
+and tossing about like a vessel.
+
+Once in the middle of the day, in the open country, just as the sun
+beat most fiercely against the old plated lanterns, a bared hand passed
+beneath the small blinds of yellow canvas, and threw out some scraps
+of paper that scattered in the wind, and farther off lighted like white
+butterflies on a field of red clover all in bloom.
+
+At about six o’clock the carriage stopped in a back street of the
+Beauvoisine Quarter, and a woman got out, who walked with her veil down,
+and without turning her head.
+
+
+
+Chapter Two
+
+On reaching the inn, Madame Bovary was surprised not to see the
+diligence. Hivert, who had waited for her fifty-three minutes, had at
+last started.
+
+Yet nothing forced her to go; but she had given her word that she would
+return that same evening. Moreover, Charles expected her, and in her
+heart she felt already that cowardly docility that is for some women at
+once the chastisement and atonement of adultery.
+
+She packed her box quickly, paid her bill, took a cab in the yard,
+hurrying on the driver, urging him on, every moment inquiring about
+the time and the miles traversed. He succeeded in catching up the
+“Hirondelle” as it neared the first houses of Quincampoix.
+
+Hardly was she seated in her corner than she closed her eyes, and opened
+them at the foot of the hill, when from afar she recognised Felicite,
+who was on the lookout in front of the farrier’s shop. Hivert pulled
+in his horses and, the servant, climbing up to the window, said
+mysteriously--
+
+“Madame, you must go at once to Monsieur Homais. It’s for something
+important.”
+
+The village was silent as usual. At the corner of the streets were small
+pink heaps that smoked in the air, for this was the time for jam-making,
+and everyone at Yonville prepared his supply on the same day. But in
+front of the chemist’s shop one might admire a far larger heap, and that
+surpassed the others with the superiority that a laboratory must have
+over ordinary stores, a general need over individual fancy.
+
+She went in. The large arm-chair was upset, and even the “Fanal de
+Rouen” lay on the ground, outspread between two pestles. She pushed open
+the lobby door, and in the middle of the kitchen, amid brown jars full
+of picked currants, of powdered sugar and lump sugar, of the scales on
+the table, and of the pans on the fire, she saw all the Homais, small
+and large, with aprons reaching to their chins, and with forks in their
+hands. Justin was standing up with bowed head, and the chemist was
+screaming--
+
+“Who told you to go and fetch it in the Capharnaum.”
+
+“What is it? What is the matter?”
+
+“What is it?” replied the druggist. “We are making preserves; they are
+simmering; but they were about to boil over, because there is too
+much juice, and I ordered another pan. Then he, from indolence, from
+laziness, went and took, hanging on its nail in my laboratory, the key
+of the Capharnaum.”
+
+It was thus the druggist called a small room under the leads, full of
+the utensils and the goods of his trade. He often spent long hours there
+alone, labelling, decanting, and doing up again; and he looked upon
+it not as a simple store, but as a veritable sanctuary, whence there
+afterwards issued, elaborated by his hands, all sorts of pills, boluses,
+infusions, lotions, and potions, that would bear far and wide his
+celebrity. No one in the world set foot there, and he respected it so,
+that he swept it himself. Finally, if the pharmacy, open to all comers,
+was the spot where he displayed his pride, the Capharnaum was the refuge
+where, egoistically concentrating himself, Homais delighted in the
+exercise of his predilections, so that Justin’s thoughtlessness seemed
+to him a monstrous piece of irreverence, and, redder than the currants,
+he repeated--
+
+“Yes, from the Capharnaum! The key that locks up the acids and caustic
+alkalies! To go and get a spare pan! a pan with a lid! and that I
+shall perhaps never use! Everything is of importance in the delicate
+operations of our art! But, devil take it! one must make distinctions,
+and not employ for almost domestic purposes that which is meant for
+pharmaceutical! It is as if one were to carve a fowl with a scalpel; as
+if a magistrate--”
+
+“Now be calm,” said Madame Homais.
+
+And Athalie, pulling at his coat, cried “Papa! papa!”
+
+“No, let me alone,” went on the druggist “let me alone, hang it! My
+word! One might as well set up for a grocer. That’s it! go it! respect
+nothing! break, smash, let loose the leeches, burn the mallow-paste,
+pickle the gherkins in the window jars, tear up the bandages!”
+
+“I thought you had--” said Emma.
+
+“Presently! Do you know to what you exposed yourself? Didn’t you see
+anything in the corner, on the left, on the third shelf? Speak, answer,
+articulate something.”
+
+“I--don’t--know,” stammered the young fellow.
+
+“Ah! you don’t know! Well, then, I do know! You saw a bottle of blue
+glass, sealed with yellow wax, that contains a white powder, on which I
+have even written ‘Dangerous!’ And do you know what is in it? Arsenic!
+And you go and touch it! You take a pan that was next to it!”
+
+“Next to it!” cried Madame Homais, clasping her hands. “Arsenic! You
+might have poisoned us all.”
+
+And the children began howling as if they already had frightful pains in
+their entrails.
+
+“Or poison a patient!” continued the druggist. “Do you want to see me
+in the prisoner’s dock with criminals, in a court of justice? To see
+me dragged to the scaffold? Don’t you know what care I take in managing
+things, although I am so thoroughly used to it? Often I am horrified
+myself when I think of my responsibility; for the Government persecutes
+us, and the absurd legislation that rules us is a veritable Damocles’
+sword over our heads.”
+
+Emma no longer dreamed of asking what they wanted her for, and the
+druggist went on in breathless phrases--
+
+“That is your return for all the kindness we have shown you! That is how
+you recompense me for the really paternal care that I lavish on you! For
+without me where would you be? What would you be doing? Who provides
+you with food, education, clothes, and all the means of figuring one day
+with honour in the ranks of society? But you must pull hard at the oar
+if you’re to do that, and get, as, people say, callosities upon your
+hands. Fabricando fit faber, age quod agis.*”
+
+     * The worker lives by working, do what he will.
+
+
+He was so exasperated he quoted Latin. He would have quoted Chinese
+or Greenlandish had he known those two languages, for he was in one
+of those crises in which the whole soul shows indistinctly what it
+contains, like the ocean, which, in the storm, opens itself from the
+seaweeds on its shores down to the sands of its abysses.
+
+And he went on--
+
+“I am beginning to repent terribly of having taken you up! I should
+certainly have done better to have left you to rot in your poverty and
+the dirt in which you were born. Oh, you’ll never be fit for anything
+but to herd animals with horns! You have no aptitude for science! You
+hardly know how to stick on a label! And there you are, dwelling with me
+snug as a parson, living in clover, taking your ease!”
+
+But Emma, turning to Madame Homais, “I was told to come here--”
+
+“Oh, dear me!” interrupted the good woman, with a sad air, “how am I to
+tell you? It is a misfortune!”
+
+She could not finish, the druggist was thundering--“Empty it! Clean it!
+Take it back! Be quick!”
+
+And seizing Justin by the collar of his blouse, he shook a book out of
+his pocket. The lad stooped, but Homais was the quicker, and, having
+picked up the volume, contemplated it with staring eyes and open mouth.
+
+“CONJUGAL--LOVE!” he said, slowly separating the two words. “Ah! very
+good! very good! very pretty! And illustrations! Oh, this is too much!”
+
+Madame Homais came forward.
+
+“No, do not touch it!”
+
+The children wanted to look at the pictures.
+
+“Leave the room,” he said imperiously; and they went out.
+
+First he walked up and down with the open volume in his hand, rolling
+his eyes, choking, tumid, apoplectic. Then he came straight to his
+pupil, and, planting himself in front of him with crossed arms--
+
+“Have you every vice, then, little wretch? Take care! you are on a
+downward path. Did not you reflect that this infamous book might fall
+in the hands of my children, kindle a spark in their minds, tarnish the
+purity of Athalie, corrupt Napoleon. He is already formed like a man.
+Are you quite sure, anyhow, that they have not read it? Can you certify
+to me--”
+
+“But really, sir,” said Emma, “you wished to tell me--”
+
+“Ah, yes! madame. Your father-in-law is dead.”
+
+In fact, Monsieur Bovary senior had expired the evening before suddenly
+from an attack of apoplexy as he got up from table, and by way of
+greater precaution, on account of Emma’s sensibility, Charles had begged
+Homais to break the horrible news to her gradually. Homais had thought
+over his speech; he had rounded, polished it, made it rhythmical; it was
+a masterpiece of prudence and transitions, of subtle turns and delicacy;
+but anger had got the better of rhetoric.
+
+Emma, giving up all chance of hearing any details, left the pharmacy;
+for Monsieur Homais had taken up the thread of his vituperations.
+However, he was growing calmer, and was now grumbling in a paternal tone
+whilst he fanned himself with his skull-cap.
+
+“It is not that I entirely disapprove of the work. Its author was a
+doctor! There are certain scientific points in it that it is not ill a
+man should know, and I would even venture to say that a man must know.
+But later--later! At any rate, not till you are man yourself and your
+temperament is formed.”
+
+When Emma knocked at the door. Charles, who was waiting for her, came
+forward with open arms and said to her with tears in his voice--
+
+“Ah! my dear!”
+
+And he bent over her gently to kiss her. But at the contact of his lips
+the memory of the other seized her, and she passed her hand over her
+face shuddering.
+
+But she made answer, “Yes, I know, I know!”
+
+He showed her the letter in which his mother told the event without any
+sentimental hypocrisy. She only regretted her husband had not received
+the consolations of religion, as he had died at Daudeville, in the
+street, at the door of a cafe after a patriotic dinner with some
+ex-officers.
+
+Emma gave him back the letter; then at dinner, for appearance’s sake,
+she affected a certain repugnance. But as he urged her to try, she
+resolutely began eating, while Charles opposite her sat motionless in a
+dejected attitude.
+
+Now and then he raised his head and gave her a long look full of
+distress. Once he sighed, “I should have liked to see him again!”
+
+She was silent. At last, understanding that she must say something, “How
+old was your father?” she asked.
+
+“Fifty-eight.”
+
+“Ah!”
+
+And that was all.
+
+A quarter of an hour after he added, “My poor mother! what will become
+of her now?”
+
+She made a gesture that signified she did not know. Seeing her so
+taciturn, Charles imagined her much affected, and forced himself to say
+nothing, not to reawaken this sorrow which moved him. And, shaking off
+his own--
+
+“Did you enjoy yourself yesterday?” he asked.
+
+“Yes.”
+
+When the cloth was removed, Bovary did not rise, nor did Emma; and as
+she looked at him, the monotony of the spectacle drove little by little
+all pity from her heart. He seemed to her paltry, weak, a cipher--in
+a word, a poor thing in every way. How to get rid of him? What an
+interminable evening! Something stupefying like the fumes of opium
+seized her.
+
+They heard in the passage the sharp noise of a wooden leg on the boards.
+It was Hippolyte bringing back Emma’s luggage. In order to put it down
+he described painfully a quarter of a circle with his stump.
+
+“He doesn’t even remember any more about it,” she thought, looking at
+the poor devil, whose coarse red hair was wet with perspiration.
+
+Bovary was searching at the bottom of his purse for a centime, and
+without appearing to understand all there was of humiliation for him
+in the mere presence of this man, who stood there like a personified
+reproach to his incurable incapacity.
+
+“Hallo! you’ve a pretty bouquet,” he said, noticing Leon’s violets on
+the chimney.
+
+“Yes,” she replied indifferently; “it’s a bouquet I bought just now from
+a beggar.”
+
+Charles picked up the flowers, and freshening his eyes, red with tears,
+against them, smelt them delicately.
+
+She took them quickly from his hand and put them in a glass of water.
+
+The next day Madame Bovary senior arrived. She and her son wept much.
+Emma, on the pretext of giving orders, disappeared. The following day
+they had a talk over the mourning. They went and sat down with their
+workboxes by the waterside under the arbour.
+
+Charles was thinking of his father, and was surprised to feel so much
+affection for this man, whom till then he had thought he cared little
+about. Madame Bovary senior was thinking of her husband. The worst
+days of the past seemed enviable to her. All was forgotten beneath the
+instinctive regret of such a long habit, and from time to time whilst
+she sewed, a big tear rolled along her nose and hung suspended there a
+moment. Emma was thinking that it was scarcely forty-eight hours since
+they had been together, far from the world, all in a frenzy of joy, and
+not having eyes enough to gaze upon each other. She tried to recall the
+slightest details of that past day. But the presence of her husband and
+mother-in-law worried her. She would have liked to hear nothing, to see
+nothing, so as not to disturb the meditation on her love, that, do what
+she would, became lost in external sensations.
+
+She was unpicking the lining of a dress, and the strips were scattered
+around her. Madame Bovary senior was plying her scissor without looking
+up, and Charles, in his list slippers and his old brown surtout that he
+used as a dressing-gown, sat with both hands in his pockets, and did not
+speak either; near them Berthe, in a little white pinafore, was raking
+sand in the walks with her spade. Suddenly she saw Monsieur Lheureux,
+the linendraper, come in through the gate.
+
+He came to offer his services “under the sad circumstances.” Emma
+answered that she thought she could do without. The shopkeeper was not
+to be beaten.
+
+“I beg your pardon,” he said, “but I should like to have a private talk
+with you.” Then in a low voice, “It’s about that affair--you know.”
+
+Charles crimsoned to his ears. “Oh, yes! certainly.” And in his
+confusion, turning to his wife, “Couldn’t you, my darling?”
+
+She seemed to understand him, for she rose; and Charles said to his
+mother, “It is nothing particular. No doubt, some household trifle.” He
+did not want her to know the story of the bill, fearing her reproaches.
+
+As soon as they were alone, Monsieur Lheureux in sufficiently clear
+terms began to congratulate Emma on the inheritance, then to talk of
+indifferent matters, of the espaliers, of the harvest, and of his own
+health, which was always so-so, always having ups and downs. In fact, he
+had to work devilish hard, although he didn’t make enough, in spite of
+all people said, to find butter for his bread.
+
+Emma let him talk on. She had bored herself so prodigiously the last two
+days.
+
+“And so you’re quite well again?” he went on. “Ma foi! I saw your
+husband in a sad state. He’s a good fellow, though we did have a little
+misunderstanding.”
+
+She asked what misunderstanding, for Charles had said nothing of the
+dispute about the goods supplied to her.
+
+“Why, you know well enough,” cried Lheureux. “It was about your little
+fancies--the travelling trunks.”
+
+He had drawn his hat over his eyes, and, with his hands behind his
+back, smiling and whistling, he looked straight at her in an unbearable
+manner. Did he suspect anything?
+
+She was lost in all kinds of apprehensions. At last, however, he went
+on--
+
+“We made it up, all the same, and I’ve come again to propose another
+arrangement.”
+
+This was to renew the bill Bovary had signed. The doctor, of course,
+would do as he pleased; he was not to trouble himself, especially just
+now, when he would have a lot of worry. “And he would do better to give
+it over to someone else--to you, for example. With a power of attorney
+it could be easily managed, and then we (you and I) would have our
+little business transactions together.”
+
+She did not understand. He was silent. Then, passing to his trade,
+Lheureux declared that madame must require something. He would send her
+a black barege, twelve yards, just enough to make a gown.
+
+“The one you’ve on is good enough for the house, but you want another
+for calls. I saw that the very moment that I came in. I’ve the eye of an
+American!”
+
+He did not send the stuff; he brought it. Then he came again to measure
+it; he came again on other pretexts, always trying to make himself
+agreeable, useful, “enfeoffing himself,” as Homais would have said, and
+always dropping some hint to Emma about the power of attorney. He never
+mentioned the bill; she did not think of it. Charles, at the beginning
+of her convalescence, had certainly said something about it to her,
+but so many emotions had passed through her head that she no longer
+remembered it. Besides, she took care not to talk of any money
+questions. Madame Bovary seemed surprised at this, and attributed the
+change in her ways to the religious sentiments she had contracted during
+her illness.
+
+But as soon as she was gone, Emma greatly astounded Bovary by her
+practical good sense. It would be necessary to make inquiries, to look
+into mortgages, and see if there were any occasion for a sale by auction
+or a liquidation. She quoted technical terms casually, pronounced the
+grand words of order, the future, foresight, and constantly exaggerated
+the difficulties of settling his father’s affairs so much, that at last
+one day she showed him the rough draft of a power of attorney to manage
+and administer his business, arrange all loans, sign and endorse all
+bills, pay all sums, etc. She had profited by Lheureux’s lessons.
+Charles naively asked her where this paper came from.
+
+“Monsieur Guillaumin”; and with the utmost coolness she added, “I don’t
+trust him overmuch. Notaries have such a bad reputation. Perhaps we
+ought to consult--we only know--no one.”
+
+“Unless Leon--” replied Charles, who was reflecting. But it was
+difficult to explain matters by letter. Then she offered to make the
+journey, but he thanked her. She insisted. It was quite a contest of
+mutual consideration. At last she cried with affected waywardness--
+
+“No, I will go!”
+
+“How good you are!” he said, kissing her forehead.
+
+The next morning she set out in the “Hirondelle” to go to Rouen to
+consult Monsieur Leon, and she stayed there three days.
+
+
+
+Chapter Three
+
+They were three full, exquisite days--a true honeymoon. They were at
+the Hotel-de-Boulogne, on the harbour; and they lived there, with drawn
+blinds and closed doors, with flowers on the floor, and iced syrups were
+brought them early in the morning.
+
+Towards evening they took a covered boat and went to dine on one of the
+islands. It was the time when one hears by the side of the dockyard the
+caulking-mallets sounding against the hull of vessels. The smoke of
+the tar rose up between the trees; there were large fatty drops on the
+water, undulating in the purple colour of the sun, like floating plaques
+of Florentine bronze.
+
+They rowed down in the midst of moored boats, whose long oblique cables
+grazed lightly against the bottom of the boat. The din of the town
+gradually grew distant; the rolling of carriages, the tumult of voices,
+the yelping of dogs on the decks of vessels. She took off her bonnet,
+and they landed on their island.
+
+They sat down in the low-ceilinged room of a tavern, at whose door hung
+black nets. They ate fried smelts, cream and cherries. They lay down
+upon the grass; they kissed behind the poplars; and they would fain,
+like two Robinsons, have lived for ever in this little place, which
+seemed to them in their beatitude the most magnificent on earth. It was
+not the first time that they had seen trees, a blue sky, meadows; that
+they had heard the water flowing and the wind blowing in the leaves;
+but, no doubt, they had never admired all this, as if Nature had
+not existed before, or had only begun to be beautiful since the
+gratification of their desires.
+
+At night they returned. The boat glided along the shores of the islands.
+They sat at the bottom, both hidden by the shade, in silence. The square
+oars rang in the iron thwarts, and, in the stillness, seemed to mark
+time, like the beating of a metronome, while at the stern the rudder
+that trailed behind never ceased its gentle splash against the water.
+
+Once the moon rose; they did not fail to make fine phrases, finding the
+orb melancholy and full of poetry. She even began to sing--
+
+“One night, do you remember, we were sailing,” etc.
+
+Her musical but weak voice died away along the waves, and the winds
+carried off the trills that Leon heard pass like the flapping of wings
+about him.
+
+She was opposite him, leaning against the partition of the shallop,
+through one of whose raised blinds the moon streamed in. Her black
+dress, whose drapery spread out like a fan, made her seem more slender,
+taller. Her head was raised, her hands clasped, her eyes turned towards
+heaven. At times the shadow of the willows hid her completely; then she
+reappeared suddenly, like a vision in the moonlight.
+
+Leon, on the floor by her side, found under his hand a ribbon of scarlet
+silk. The boatman looked at it, and at last said--
+
+“Perhaps it belongs to the party I took out the other day. A lot
+of jolly folk, gentlemen and ladies, with cakes, champagne,
+cornets--everything in style! There was one especially, a tall handsome
+man with small moustaches, who was that funny! And they all kept saying,
+‘Now tell us something, Adolphe--Dolpe,’ I think.”
+
+She shivered.
+
+“You are in pain?” asked Leon, coming closer to her.
+
+“Oh, it’s nothing! No doubt, it is only the night air.”
+
+“And who doesn’t want for women, either,” softly added the sailor,
+thinking he was paying the stranger a compliment.
+
+Then, spitting on his hands, he took the oars again.
+
+Yet they had to part. The adieux were sad. He was to send his letters to
+Mere Rollet, and she gave him such precise instructions about a double
+envelope that he admired greatly her amorous astuteness.
+
+“So you can assure me it is all right?” she said with her last kiss.
+
+“Yes, certainly.”
+
+“But why,” he thought afterwards as he came back through the streets
+alone, “is she so very anxious to get this power of attorney?”
+
+
+
+Chapter Four
+
+Leon soon put on an air of superiority before his comrades, avoided
+their company, and completely neglected his work.
+
+He waited for her letters; he re-read them; he wrote to her. He called
+her to mind with all the strength of his desires and of his memories.
+Instead of lessening with absence, this longing to see her again grew,
+so that at last on Saturday morning he escaped from his office.
+
+When, from the summit of the hill, he saw in the valley below the
+church-spire with its tin flag swinging in the wind, he felt that
+delight mingled with triumphant vanity and egoistic tenderness that
+millionaires must experience when they come back to their native
+village.
+
+He went rambling round her house. A light was burning in the kitchen. He
+watched for her shadow behind the curtains, but nothing appeared.
+
+Mere Lefrancois, when she saw him, uttered many exclamations. She
+thought he “had grown and was thinner,” while Artemise, on the contrary,
+thought him stouter and darker.
+
+He dined in the little room as of yore, but alone, without the
+tax-gatherer; for Binet, tired of waiting for the “Hirondelle,” had
+definitely put forward his meal one hour, and now he dined punctually at
+five, and yet he declared usually the rickety old concern “was late.”
+
+Leon, however, made up his mind, and knocked at the doctor’s door.
+Madame was in her room, and did not come down for a quarter of an hour.
+The doctor seemed delighted to see him, but he never stirred out that
+evening, nor all the next day.
+
+He saw her alone in the evening, very late, behind the garden in the
+lane; in the lane, as she had the other one! It was a stormy night, and
+they talked under an umbrella by lightning flashes.
+
+Their separation was becoming intolerable. “I would rather die!” said
+Emma. She was writhing in his arms, weeping. “Adieu! adieu! When shall I
+see you again?”
+
+They came back again to embrace once more, and it was then that
+she promised him to find soon, by no matter what means, a regular
+opportunity for seeing one another in freedom at least once a week. Emma
+never doubted she should be able to do this. Besides, she was full of
+hope. Some money was coming to her.
+
+On the strength of it she bought a pair of yellow curtains with large
+stripes for her room, whose cheapness Monsieur Lheureux had commended;
+she dreamed of getting a carpet, and Lheureux, declaring that it wasn’t
+“drinking the sea,” politely undertook to supply her with one. She could
+no longer do without his services. Twenty times a day she sent for him,
+and he at once put by his business without a murmur. People could not
+understand either why Mere Rollet breakfasted with her every day, and
+even paid her private visits.
+
+It was about this time, that is to say, the beginning of winter, that
+she seemed seized with great musical fervour.
+
+One evening when Charles was listening to her, she began the same piece
+four times over, each time with much vexation, while he, not noticing
+any difference, cried--
+
+“Bravo! very goodl You are wrong to stop. Go on!”
+
+“Oh, no; it is execrable! My fingers are quite rusty.”
+
+The next day he begged her to play him something again.
+
+“Very well; to please you!”
+
+And Charles confessed she had gone off a little. She played wrong notes
+and blundered; then, stopping short--
+
+“Ah! it is no use. I ought to take some lessons; but--” She bit her lips
+and added, “Twenty francs a lesson, that’s too dear!”
+
+“Yes, so it is--rather,” said Charles, giggling stupidly. “But it seems
+to me that one might be able to do it for less; for there are artists of
+no reputation, and who are often better than the celebrities.”
+
+“Find them!” said Emma.
+
+The next day when he came home he looked at her shyly, and at last could
+no longer keep back the words.
+
+“How obstinate you are sometimes! I went to Barfucheres to-day. Well,
+Madame Liegard assured me that her three young ladies who are at
+La Misericorde have lessons at fifty sous apiece, and that from an
+excellent mistress!”
+
+She shrugged her shoulders and did not open her piano again. But when
+she passed by it (if Bovary were there), she sighed--
+
+“Ah! my poor piano!”
+
+And when anyone came to see her, she did not fail to inform them she
+had given up music, and could not begin again now for important reasons.
+Then people commiserated her--
+
+“What a pity! she had so much talent!”
+
+They even spoke to Bovary about it. They put him to shame, and
+especially the chemist.
+
+“You are wrong. One should never let any of the faculties of nature lie
+fallow. Besides, just think, my good friend, that by inducing madame to
+study; you are economising on the subsequent musical education of
+your child. For my own part, I think that mothers ought themselves to
+instruct their children. That is an idea of Rousseau’s, still rather
+new perhaps, but that will end by triumphing, I am certain of it, like
+mothers nursing their own children and vaccination.”
+
+So Charles returned once more to this question of the piano. Emma
+replied bitterly that it would be better to sell it. This poor piano,
+that had given her vanity so much satisfaction--to see it go was to
+Bovary like the indefinable suicide of a part of herself.
+
+“If you liked,” he said, “a lesson from time to time, that wouldn’t
+after all be very ruinous.”
+
+“But lessons,” she replied, “are only of use when followed up.”
+
+And thus it was she set about obtaining her husband’s permission to go
+to town once a week to see her lover. At the end of a month she was even
+considered to have made considerable progress.
+
+
+
+Chapter Five
+
+She went on Thursdays. She got up and dressed silently, in order not to
+awaken Charles, who would have made remarks about her getting ready too
+early. Next she walked up and down, went to the windows, and looked out
+at the Place. The early dawn was broadening between the pillars of the
+market, and the chemist’s shop, with the shutters still up, showed in
+the pale light of the dawn the large letters of his signboard.
+
+When the clock pointed to a quarter past seven, she went off to the
+“Lion d’Or,” whose door Artemise opened yawning. The girl then made
+up the coals covered by the cinders, and Emma remained alone in the
+kitchen. Now and again she went out. Hivert was leisurely harnessing his
+horses, listening, moreover, to Mere Lefrancois, who, passing her head
+and nightcap through a grating, was charging him with commissions and
+giving him explanations that would have confused anyone else. Emma kept
+beating the soles of her boots against the pavement of the yard.
+
+At last, when he had eaten his soup, put on his cloak, lighted his pipe,
+and grasped his whip, he calmly installed himself on his seat.
+
+The “Hirondelle” started at a slow trot, and for about a mile stopped
+here and there to pick up passengers who waited for it, standing at the
+border of the road, in front of their yard gates.
+
+Those who had secured seats the evening before kept it waiting; some
+even were still in bed in their houses. Hivert called, shouted, swore;
+then he got down from his seat and went and knocked loudly at the doors.
+The wind blew through the cracked windows.
+
+The four seats, however, filled up. The carriage rolled off; rows of
+apple-trees followed one upon another, and the road between its two long
+ditches, full of yellow water, rose, constantly narrowing towards the
+horizon.
+
+Emma knew it from end to end; she knew that after a meadow there was
+a sign-post, next an elm, a barn, or the hut of a lime-kiln tender.
+Sometimes even, in the hope of getting some surprise, she shut her eyes,
+but she never lost the clear perception of the distance to be traversed.
+
+At last the brick houses began to follow one another more closely, the
+earth resounded beneath the wheels, the “Hirondelle” glided between the
+gardens, where through an opening one saw statues, a periwinkle plant,
+clipped yews, and a swing. Then on a sudden the town appeared. Sloping
+down like an amphitheatre, and drowned in the fog, it widened out
+beyond the bridges confusedly. Then the open country spread away with
+a monotonous movement till it touched in the distance the vague line of
+the pale sky. Seen thus from above, the whole landscape looked immovable
+as a picture; the anchored ships were massed in one corner, the river
+curved round the foot of the green hills, and the isles, oblique in
+shape, lay on the water, like large, motionless, black fishes. The
+factory chimneys belched forth immense brown fumes that were blown away
+at the top. One heard the rumbling of the foundries, together with the
+clear chimes of the churches that stood out in the mist. The leafless
+trees on the boulevards made violet thickets in the midst of the
+houses, and the roofs, all shining with the rain, threw back unequal
+reflections, according to the height of the quarters in which they were.
+Sometimes a gust of wind drove the clouds towards the Saint Catherine
+hills, like aerial waves that broke silently against a cliff.
+
+A giddiness seemed to her to detach itself from this mass of existence,
+and her heart swelled as if the hundred and twenty thousand souls that
+palpitated there had all at once sent into it the vapour of the passions
+she fancied theirs. Her love grew in the presence of this vastness, and
+expanded with tumult to the vague murmurings that rose towards her. She
+poured it out upon the square, on the walks, on the streets, and the
+old Norman city outspread before her eyes as an enormous capital, as a
+Babylon into which she was entering. She leant with both hands against
+the window, drinking in the breeze; the three horses galloped, the
+stones grated in the mud, the diligence rocked, and Hivert, from afar,
+hailed the carts on the road, while the bourgeois who had spent the
+night at the Guillaume woods came quietly down the hill in their little
+family carriages.
+
+They stopped at the barrier; Emma undid her overshoes, put on other
+gloves, rearranged her shawl, and some twenty paces farther she got down
+from the “Hirondelle.”
+
+The town was then awakening. Shop-boys in caps were cleaning up the
+shop-fronts, and women with baskets against their hips, at intervals
+uttered sonorous cries at the corners of streets. She walked with
+downcast eyes, close to the walls, and smiling with pleasure under her
+lowered black veil.
+
+For fear of being seen, she did not usually take the most direct road.
+She plunged into dark alleys, and, all perspiring, reached the bottom
+of the Rue Nationale, near the fountain that stands there. It is the
+quarter for theatres, public-houses, and whores. Often a cart would
+pass near her, bearing some shaking scenery. Waiters in aprons were
+sprinkling sand on the flagstones between green shrubs. It all smelt of
+absinthe, cigars, and oysters.
+
+She turned down a street; she recognised him by his curling hair that
+escaped from beneath his hat.
+
+Leon walked along the pavement. She followed him to the hotel. He went
+up, opened the door, entered--What an embrace!
+
+Then, after the kisses, the words gushed forth. They told each other the
+sorrows of the week, the presentiments, the anxiety for the letters; but
+now everything was forgotten; they gazed into each other’s faces with
+voluptuous laughs, and tender names.
+
+The bed was large, of mahogany, in the shape of a boat. The curtains
+were in red levantine, that hung from the ceiling and bulged out too
+much towards the bell-shaped bedside; and nothing in the world was so
+lovely as her brown head and white skin standing out against this purple
+colour, when, with a movement of shame, she crossed her bare arms,
+hiding her face in her hands.
+
+The warm room, with its discreet carpet, its gay ornaments, and its
+calm light, seemed made for the intimacies of passion. The curtain-rods,
+ending in arrows, their brass pegs, and the great balls of the fire-dogs
+shone suddenly when the sun came in. On the chimney between the
+candelabra there were two of those pink shells in which one hears the
+murmur of the sea if one holds them to the ear.
+
+How they loved that dear room, so full of gaiety, despite its rather
+faded splendour! They always found the furniture in the same place, and
+sometimes hairpins, that she had forgotten the Thursday before, under
+the pedestal of the clock. They lunched by the fireside on a little
+round table, inlaid with rosewood. Emma carved, put bits on his plate
+with all sorts of coquettish ways, and she laughed with a sonorous and
+libertine laugh when the froth of the champagne ran over from the
+glass to the rings on her fingers. They were so completely lost in
+the possession of each other that they thought themselves in their
+own house, and that they would live there till death, like two spouses
+eternally young. They said “our room,” “our carpet,” she even said “my
+slippers,” a gift of Leon’s, a whim she had had. They were pink satin,
+bordered with swansdown. When she sat on his knees, her leg, then too
+short, hung in the air, and the dainty shoe, that had no back to it, was
+held only by the toes to her bare foot.
+
+He for the first time enjoyed the inexpressible delicacy of feminine
+refinements. He had never met this grace of language, this reserve of
+clothing, these poses of the weary dove. He admired the exaltation of
+her soul and the lace on her petticoat. Besides, was she not “a lady”
+ and a married woman--a real mistress, in fine?
+
+By the diversity of her humour, in turn mystical or mirthful, talkative,
+taciturn, passionate, careless, she awakened in him a thousand desires,
+called up instincts or memories. She was the mistress of all the novels,
+the heroine of all the dramas, the vague “she” of all the volumes
+of verse. He found again on her shoulder the amber colouring of the
+“Odalisque Bathing”; she had the long waist of feudal chatelaines, and
+she resembled the “Pale Woman of Barcelona.” But above all she was the
+Angel!
+
+Often looking at her, it seemed to him that his soul, escaping towards
+her, spread like a wave about the outline of her head, and descended
+drawn down into the whiteness of her breast. He knelt on the ground
+before her, and with both elbows on her knees looked at her with a
+smile, his face upturned.
+
+She bent over him, and murmured, as if choking with intoxication--
+
+“Oh, do not move! do not speak! look at me! Something so sweet comes
+from your eyes that helps me so much!”
+
+She called him “child.” “Child, do you love me?”
+
+And she did not listen for his answer in the haste of her lips that
+fastened to his mouth.
+
+On the clock there was a bronze cupid, who smirked as he bent his arm
+beneath a golden garland. They had laughed at it many a time, but when
+they had to part everything seemed serious to them.
+
+Motionless in front of each other, they kept repeating, “Till Thursday,
+till Thursday.”
+
+Suddenly she seized his head between her hands, kissed him hurriedly on
+the forehead, crying, “Adieu!” and rushed down the stairs.
+
+She went to a hairdresser’s in the Rue de la Comedie to have her hair
+arranged. Night fell; the gas was lighted in the shop. She heard the
+bell at the theatre calling the mummers to the performance, and she saw,
+passing opposite, men with white faces and women in faded gowns going in
+at the stage-door.
+
+It was hot in the room, small, and too low where the stove was hissing
+in the midst of wigs and pomades. The smell of the tongs, together with
+the greasy hands that handled her head, soon stunned her, and she dozed
+a little in her wrapper. Often, as he did her hair, the man offered her
+tickets for a masked ball.
+
+Then she went away. She went up the streets; reached the Croix-Rouge,
+put on her overshoes, that she had hidden in the morning under the seat,
+and sank into her place among the impatient passengers. Some got out
+at the foot of the hill. She remained alone in the carriage. At every
+turning all the lights of the town were seen more and more completely,
+making a great luminous vapour about the dim houses. Emma knelt on the
+cushions and her eyes wandered over the dazzling light. She sobbed;
+called on Leon, sent him tender words and kisses lost in the wind.
+
+On the hillside a poor devil wandered about with his stick in the midst
+of the diligences. A mass of rags covered his shoulders, and an old
+staved-in beaver, turned out like a basin, hid his face; but when he
+took it off he discovered in the place of eyelids empty and bloody
+orbits. The flesh hung in red shreds, and there flowed from it liquids
+that congealed into green scale down to the nose, whose black nostrils
+sniffed convulsively. To speak to you he threw back his head with an
+idiotic laugh; then his bluish eyeballs, rolling constantly, at the
+temples beat against the edge of the open wound. He sang a little song
+as he followed the carriages--
+
+“Maids an the warmth of a summer day Dream of love, and of love always”
+
+And all the rest was about birds and sunshine and green leaves.
+
+Sometimes he appeared suddenly behind Emma, bareheaded, and she drew
+back with a cry. Hivert made fun of him. He would advise him to get a
+booth at the Saint Romain fair, or else ask him, laughing, how his young
+woman was.
+
+Often they had started when, with a sudden movement, his hat entered the
+diligence through the small window, while he clung with his other arm
+to the footboard, between the wheels splashing mud. His voice, feeble
+at first and quavering, grew sharp; it resounded in the night like the
+indistinct moan of a vague distress; and through the ringing of the
+bells, the murmur of the trees, and the rumbling of the empty vehicle,
+it had a far-off sound that disturbed Emma. It went to the bottom of
+her soul, like a whirlwind in an abyss, and carried her away into the
+distances of a boundless melancholy. But Hivert, noticing a weight
+behind, gave the blind man sharp cuts with his whip. The thong lashed
+his wounds, and he fell back into the mud with a yell. Then the
+passengers in the “Hirondelle” ended by falling asleep, some with open
+mouths, others with lowered chins, leaning against their neighbour’s
+shoulder, or with their arm passed through the strap, oscillating
+regularly with the jolting of the carriage; and the reflection of the
+lantern swinging without, on the crupper of the wheeler; penetrating
+into the interior through the chocolate calico curtains, threw
+sanguineous shadows over all these motionless people. Emma, drunk with
+grief, shivered in her clothes, feeling her feet grow colder and colder,
+and death in her soul.
+
+Charles at home was waiting for her; the “Hirondelle” was always late
+on Thursdays. Madame arrived at last, and scarcely kissed the child. The
+dinner was not ready. No matter! She excused the servant. This girl now
+seemed allowed to do just as she liked.
+
+Often her husband, noting her pallor, asked if she were unwell.
+
+“No,” said Emma.
+
+“But,” he replied, “you seem so strange this evening.”
+
+“Oh, it’s nothing! nothing!”
+
+There were even days when she had no sooner come in than she went up to
+her room; and Justin, happening to be there, moved about noiselessly,
+quicker at helping her than the best of maids. He put the matches
+ready, the candlestick, a book, arranged her nightgown, turned back the
+bedclothes.
+
+“Come!” said she, “that will do. Now you can go.”
+
+For he stood there, his hands hanging down and his eyes wide open, as if
+enmeshed in the innumerable threads of a sudden reverie.
+
+The following day was frightful, and those that came after still more
+unbearable, because of her impatience to once again seize her happiness;
+an ardent lust, inflamed by the images of past experience, and that
+burst forth freely on the seventh day beneath Leon’s caresses. His
+ardours were hidden beneath outbursts of wonder and gratitude. Emma
+tasted this love in a discreet, absorbed fashion, maintained it by all
+the artifices of her tenderness, and trembled a little lest it should be
+lost later on.
+
+She often said to him, with her sweet, melancholy voice--
+
+“Ah! you too, you will leave me! You will marry! You will be like all
+the others.”
+
+He asked, “What others?”
+
+“Why, like all men,” she replied. Then added, repulsing him with a
+languid movement--
+
+“You are all evil!”
+
+One day, as they were talking philosophically of earthly disillusions,
+to experiment on his jealousy, or yielding, perhaps, to an over-strong
+need to pour out her heart, she told him that formerly, before him, she
+had loved someone.
+
+“Not like you,” she went on quickly, protesting by the head of her child
+that “nothing had passed between them.”
+
+The young man believed her, but none the less questioned her to find out
+what he was.
+
+“He was a ship’s captain, my dear.”
+
+Was this not preventing any inquiry, and, at the same time, assuming a
+higher ground through this pretended fascination exercised over a man
+who must have been of warlike nature and accustomed to receive homage?
+
+The clerk then felt the lowliness of his position; he longed for
+epaulettes, crosses, titles. All that would please her--he gathered that
+from her spendthrift habits.
+
+Emma nevertheless concealed many of these extravagant fancies, such as
+her wish to have a blue tilbury to drive into Rouen, drawn by an English
+horse and driven by a groom in top-boots. It was Justin who had inspired
+her with this whim, by begging her to take him into her service as
+valet-de-chambre*, and if the privation of it did not lessen the
+pleasure of her arrival at each rendezvous, it certainly augmented the
+bitterness of the return.
+
+     * Manservant.
+
+
+Often, when they talked together of Paris, she ended by murmuring, “Ah!
+how happy we should be there!”
+
+“Are we not happy?” gently answered the young man passing his hands over
+her hair.
+
+“Yes, that is true,” she said. “I am mad. Kiss me!”
+
+To her husband she was more charming than ever. She made him
+pistachio-creams, and played him waltzes after dinner. So he thought
+himself the most fortunate of men and Emma was without uneasiness, when,
+one evening suddenly he said--
+
+“It is Mademoiselle Lempereur, isn’t it, who gives you lessons?”
+
+“Yes.”
+
+“Well, I saw her just now,” Charles went on, “at Madame Liegeard’s. I
+spoke to her about you, and she doesn’t know you.”
+
+This was like a thunderclap. However, she replied quite naturally--
+
+“Ah! no doubt she forgot my name.”
+
+“But perhaps,” said the doctor, “there are several Demoiselles Lempereur
+at Rouen who are music-mistresses.”
+
+“Possibly!” Then quickly--“But I have my receipts here. See!”
+
+And she went to the writing-table, ransacked all the drawers, rummaged
+the papers, and at last lost her head so completely that Charles
+earnestly begged her not to take so much trouble about those wretched
+receipts.
+
+“Oh, I will find them,” she said.
+
+And, in fact, on the following Friday, as Charles was putting on one
+of his boots in the dark cabinet where his clothes were kept, he felt
+a piece of paper between the leather and his sock. He took it out and
+read--
+
+“Received, for three months’ lessons and several pieces of music, the
+sum of sixty-three francs.--Felicie Lempereur, professor of music.”
+
+“How the devil did it get into my boots?”
+
+“It must,” she replied, “have fallen from the old box of bills that is
+on the edge of the shelf.”
+
+From that moment her existence was but one long tissue of lies, in which
+she enveloped her love as in veils to hide it. It was a want, a mania,
+a pleasure carried to such an extent that if she said she had the day
+before walked on the right side of a road, one might know she had taken
+the left.
+
+One morning, when she had gone, as usual, rather lightly clothed, it
+suddenly began to snow, and as Charles was watching the weather from the
+window, he caught sight of Monsieur Bournisien in the chaise of Monsieur
+Tuvache, who was driving him to Rouen. Then he went down to give the
+priest a thick shawl that he was to hand over to Emma as soon as he
+reached the “Croix-Rouge.” When he got to the inn, Monsieur Bournisien
+asked for the wife of the Yonville doctor. The landlady replied that
+she very rarely came to her establishment. So that evening, when he
+recognised Madame Bovary in the “Hirondelle,” the cure told her his
+dilemma, without, however, appearing to attach much importance to it,
+for he began praising a preacher who was doing wonders at the Cathedral,
+and whom all the ladies were rushing to hear.
+
+Still, if he did not ask for any explanation, others, later on, might
+prove less discreet. So she thought well to get down each time at the
+“Croix-Rouge,” so that the good folk of her village who saw her on the
+stairs should suspect nothing.
+
+One day, however, Monsieur Lheureux met her coming out of the Hotel
+de Boulogne on Leon’s arm; and she was frightened, thinking he would
+gossip. He was not such a fool. But three days after he came to her
+room, shut the door, and said, “I must have some money.”
+
+She declared she could not give him any. Lheureux burst into
+lamentations and reminded her of all the kindnesses he had shown her.
+
+In fact, of the two bills signed by Charles, Emma up to the present had
+paid only one. As to the second, the shopkeeper, at her request, had
+consented to replace it by another, which again had been renewed for a
+long date. Then he drew from his pocket a list of goods not paid for; to
+wit, the curtains, the carpet, the material for the armchairs, several
+dresses, and divers articles of dress, the bills for which amounted to
+about two thousand francs.
+
+She bowed her head. He went on--
+
+“But if you haven’t any ready money, you have an estate.” And he
+reminded her of a miserable little hovel situated at Barneville, near
+Aumale, that brought in almost nothing. It had formerly been part of a
+small farm sold by Monsieur Bovary senior; for Lheureux knew everything,
+even to the number of acres and the names of the neighbours.
+
+“If I were in your place,” he said, “I should clear myself of my debts,
+and have money left over.”
+
+She pointed out the difficulty of getting a purchaser. He held out the
+hope of finding one; but she asked him how she should manage to sell it.
+
+“Haven’t you your power of attorney?” he replied.
+
+The phrase came to her like a breath of fresh air. “Leave me the bill,”
+ said Emma.
+
+“Oh, it isn’t worth while,” answered Lheureux.
+
+He came back the following week and boasted of having, after much
+trouble, at last discovered a certain Langlois, who, for a long time,
+had had an eye on the property, but without mentioning his price.
+
+“Never mind the price!” she cried.
+
+But they would, on the contrary, have to wait, to sound the fellow.
+The thing was worth a journey, and, as she could not undertake it, he
+offered to go to the place to have an interview with Langlois. On his
+return he announced that the purchaser proposed four thousand francs.
+
+Emma was radiant at this news.
+
+“Frankly,” he added, “that’s a good price.”
+
+She drew half the sum at once, and when she was about to pay her account
+the shopkeeper said--
+
+“It really grieves me, on my word! to see you depriving yourself all at
+once of such a big sum as that.”
+
+Then she looked at the bank-notes, and dreaming of the unlimited number
+of rendezvous represented by those two thousand francs, she stammered--
+
+“What! what!”
+
+“Oh!” he went on, laughing good-naturedly, “one puts anything one likes
+on receipts. Don’t you think I know what household affairs are?” And he
+looked at her fixedly, while in his hand he held two long papers that he
+slid between his nails. At last, opening his pocket-book, he spread out
+on the table four bills to order, each for a thousand francs.
+
+“Sign these,” he said, “and keep it all!”
+
+She cried out, scandalised.
+
+“But if I give you the surplus,” replied Monsieur Lheureux impudently,
+“is that not helping you?”
+
+And taking a pen he wrote at the bottom of the account, “Received of
+Madame Bovary four thousand francs.”
+
+“Now who can trouble you, since in six months you’ll draw the arrears
+for your cottage, and I don’t make the last bill due till after you’ve
+been paid?”
+
+Emma grew rather confused in her calculations, and her ears tingled
+as if gold pieces, bursting from their bags, rang all round her on
+the floor. At last Lheureux explained that he had a very good friend,
+Vincart, a broker at Rouen, who would discount these four bills. Then
+he himself would hand over to madame the remainder after the actual debt
+was paid.
+
+But instead of two thousand francs he brought only eighteen hundred, for
+the friend Vincart (which was only fair) had deducted two hundred francs
+for commission and discount. Then he carelessly asked for a receipt.
+
+“You understand--in business--sometimes. And with the date, if you
+please, with the date.”
+
+A horizon of realisable whims opened out before Emma. She was prudent
+enough to lay by a thousand crowns, with which the first three bills
+were paid when they fell due; but the fourth, by chance, came to the
+house on a Thursday, and Charles, quite upset, patiently awaited his
+wife’s return for an explanation.
+
+If she had not told him about this bill, it was only to spare him such
+domestic worries; she sat on his knees, caressed him, cooed to him, gave
+him a long enumeration of all the indispensable things that had been got
+on credit.
+
+“Really, you must confess, considering the quantity, it isn’t too dear.”
+
+Charles, at his wit’s end, soon had recourse to the eternal Lheureux,
+who swore he would arrange matters if the doctor would sign him two
+bills, one of which was for seven hundred francs, payable in three
+months. In order to arrange for this he wrote his mother a pathetic
+letter. Instead of sending a reply she came herself; and when Emma
+wanted to know whether he had got anything out of her, “Yes,” he
+replied; “but she wants to see the account.” The next morning at
+daybreak Emma ran to Lheureux to beg him to make out another account for
+not more than a thousand francs, for to show the one for four thousand
+it would be necessary to say that she had paid two-thirds, and confess,
+consequently, the sale of the estate--a negotiation admirably carried
+out by the shopkeeper, and which, in fact, was only actually known later
+on.
+
+Despite the low price of each article, Madame Bovary senior, of course,
+thought the expenditure extravagant.
+
+“Couldn’t you do without a carpet? Why have recovered the arm-chairs? In
+my time there was a single arm-chair in a house, for elderly persons--at
+any rate it was so at my mother’s, who was a good woman, I can tell you.
+Everybody can’t be rich! No fortune can hold out against waste! I should
+be ashamed to coddle myself as you do! And yet I am old. I need looking
+after. And there! there! fitting up gowns! fallals! What! silk for
+lining at two francs, when you can get jaconet for ten sous, or even for
+eight, that would do well enough!”
+
+Emma, lying on a lounge, replied as quietly as possible--“Ah! Madame,
+enough! enough!”
+
+The other went on lecturing her, predicting they would end in the
+workhouse. But it was Bovary’s fault. Luckily he had promised to destroy
+that power of attorney.
+
+“What?”
+
+“Ah! he swore he would,” went on the good woman.
+
+Emma opened the window, called Charles, and the poor fellow was obliged
+to confess the promise torn from him by his mother.
+
+Emma disappeared, then came back quickly, and majestically handed her a
+thick piece of paper.
+
+“Thank you,” said the old woman. And she threw the power of attorney
+into the fire.
+
+Emma began to laugh, a strident, piercing, continuous laugh; she had an
+attack of hysterics.
+
+“Oh, my God!” cried Charles. “Ah! you really are wrong! You come here
+and make scenes with her!”
+
+His mother, shrugging her shoulders, declared it was “all put on.”
+
+But Charles, rebelling for the first time, took his wife’s part, so that
+Madame Bovary, senior, said she would leave. She went the very next day,
+and on the threshold, as he was trying to detain her, she replied--
+
+“No, no! You love her better than me, and you are right. It is natural.
+For the rest, so much the worse! You will see. Good day--for I am not
+likely to come soon again, as you say, to make scenes.”
+
+Charles nevertheless was very crestfallen before Emma, who did not hide
+the resentment she still felt at his want of confidence, and it needed
+many prayers before she would consent to have another power of attorney.
+He even accompanied her to Monsieur Guillaumin to have a second one,
+just like the other, drawn up.
+
+“I understand,” said the notary; “a man of science can’t be worried with
+the practical details of life.”
+
+And Charles felt relieved by this comfortable reflection, which gave his
+weakness the flattering appearance of higher pre-occupation.
+
+And what an outburst the next Thursday at the hotel in their room with
+Leon! She laughed, cried, sang, sent for sherbets, wanted to smoke
+cigarettes, seemed to him wild and extravagant, but adorable, superb.
+
+He did not know what recreation of her whole being drove her more and
+more to plunge into the pleasures of life. She was becoming irritable,
+greedy, voluptuous; and she walked about the streets with him carrying
+her head high, without fear, so she said, of compromising herself.
+At times, however, Emma shuddered at the sudden thought of meeting
+Rodolphe, for it seemed to her that, although they were separated
+forever, she was not completely free from her subjugation to him.
+
+One night she did not return to Yonville at all. Charles lost his head
+with anxiety, and little Berthe would not go to bed without her mamma,
+and sobbed enough to break her heart. Justin had gone out searching the
+road at random. Monsieur Homais even had left his pharmacy.
+
+At last, at eleven o’clock, able to bear it no longer, Charles
+harnessed his chaise, jumped in, whipped up his horse, and reached the
+“Croix-Rouge” about two o’clock in the morning. No one there! He thought
+that the clerk had perhaps seen her; but where did he live? Happily,
+Charles remembered his employer’s address, and rushed off there.
+
+Day was breaking, and he could distinguish the escutcheons over the
+door, and knocked. Someone, without opening the door, shouted out the
+required information, adding a few insults to those who disturb people
+in the middle of the night.
+
+The house inhabited by the clerk had neither bell, knocker, nor porter.
+Charles knocked loudly at the shutters with his hands. A policeman
+happened to pass by. Then he was frightened, and went away.
+
+“I am mad,” he said; “no doubt they kept her to dinner at Monsieur
+Lormeaux’.” But the Lormeaux no longer lived at Rouen.
+
+“She probably stayed to look after Madame Dubreuil. Why, Madame Dubreuil
+has been dead these ten months! Where can she be?”
+
+An idea occurred to him. At a cafe he asked for a Directory, and
+hurriedly looked for the name of Mademoiselle Lempereur, who lived at
+No. 74 Rue de la Renelle-des-Maroquiniers.
+
+As he was turning into the street, Emma herself appeared at the other
+end of it. He threw himself upon her rather than embraced her, crying--
+
+“What kept you yesterday?”
+
+“I was not well.”
+
+“What was it? Where? How?”
+
+She passed her hand over her forehead and answered, “At Mademoiselle
+Lempereur’s.”
+
+“I was sure of it! I was going there.”
+
+“Oh, it isn’t worth while,” said Emma. “She went out just now; but for
+the future don’t worry. I do not feel free, you see, if I know that the
+least delay upsets you like this.”
+
+This was a sort of permission that she gave herself, so as to get
+perfect freedom in her escapades. And she profited by it freely, fully.
+When she was seized with the desire to see Leon, she set out upon any
+pretext; and as he was not expecting her on that day, she went to fetch
+him at his office.
+
+It was a great delight at first, but soon he no longer concealed the
+truth, which was, that his master complained very much about these
+interruptions.
+
+“Pshaw! come along,” she said.
+
+And he slipped out.
+
+She wanted him to dress all in black, and grow a pointed beard, to
+look like the portraits of Louis XIII. She wanted to see his lodgings;
+thought them poor. He blushed at them, but she did not notice this, then
+advised him to buy some curtains like hers, and as he objected to the
+expense--
+
+“Ah! ah! you care for your money,” she said laughing.
+
+Each time Leon had to tell her everything that he had done since their
+last meeting. She asked him for some verses--some verses “for herself,”
+ a “love poem” in honour of her. But he never succeeded in getting a
+rhyme for the second verse; and at last ended by copying a sonnet in
+a “Keepsake.” This was less from vanity than from the one desire of
+pleasing her. He did not question her ideas; he accepted all her tastes;
+he was rather becoming her mistress than she his. She had tender words
+and kisses that thrilled his soul. Where could she have learnt this
+corruption almost incorporeal in the strength of its profanity and
+dissimulation?
+
+
+
+Chapter Six
+
+During the journeys he made to see her, Leon had often dined at the
+chemist’s, and he felt obliged from politeness to invite him in turn.
+
+“With pleasure!” Monsieur Homais replied; “besides, I must invigorate
+my mind, for I am getting rusty here. We’ll go to the theatre, to the
+restaurant; we’ll make a night of it.”
+
+“Oh, my dear!” tenderly murmured Madame Homais, alarmed at the vague
+perils he was preparing to brave.
+
+“Well, what? Do you think I’m not sufficiently ruining my health living
+here amid the continual emanations of the pharmacy? But there! that is
+the way with women! They are jealous of science, and then are opposed to
+our taking the most legitimate distractions. No matter! Count upon
+me. One of these days I shall turn up at Rouen, and we’ll go the pace
+together.”
+
+The druggist would formerly have taken good care not to use such an
+expression, but he was cultivating a gay Parisian style, which he
+thought in the best taste; and, like his neighbour, Madame Bovary, he
+questioned the clerk curiously about the customs of the capital; he
+even talked slang to dazzle the bourgeois, saying bender, crummy, dandy,
+macaroni, the cheese, cut my stick and “I’ll hook it,” for “I am going.”
+
+So one Thursday Emma was surprised to meet Monsieur Homais in the
+kitchen of the “Lion d’Or,” wearing a traveller’s costume, that is to
+say, wrapped in an old cloak which no one knew he had, while he carried
+a valise in one hand and the foot-warmer of his establishment in the
+other. He had confided his intentions to no one, for fear of causing the
+public anxiety by his absence.
+
+The idea of seeing again the place where his youth had been spent no
+doubt excited him, for during the whole journey he never ceased talking,
+and as soon as he had arrived, he jumped quickly out of the diligence
+to go in search of Leon. In vain the clerk tried to get rid of him.
+Monsieur Homais dragged him off to the large Cafe de la Normandie,
+which he entered majestically, not raising his hat, thinking it very
+provincial to uncover in any public place.
+
+Emma waited for Leon three quarters of an hour. At last she ran to
+his office; and, lost in all sorts of conjectures, accusing him of
+indifference, and reproaching herself for her weakness, she spent the
+afternoon, her face pressed against the window-panes.
+
+At two o’clock they were still at a table opposite each other. The large
+room was emptying; the stove-pipe, in the shape of a palm-tree, spread
+its gilt leaves over the white ceiling, and near them, outside the
+window, in the bright sunshine, a little fountain gurgled in a white
+basin, where; in the midst of watercress and asparagus, three torpid
+lobsters stretched across to some quails that lay heaped up in a pile on
+their sides.
+
+Homais was enjoying himself. Although he was even more intoxicated with
+the luxury than the rich fare, the Pommard wine all the same rather
+excited his faculties; and when the omelette au rhum* appeared, he began
+propounding immoral theories about women. What seduced him above all
+else was chic. He admired an elegant toilette in a well-furnished
+apartment, and as to bodily qualities, he didn’t dislike a young girl.
+
+     * In rum.
+
+
+Leon watched the clock in despair. The druggist went on drinking,
+eating, and talking.
+
+“You must be very lonely,” he said suddenly, “here at Rouen. To be sure
+your lady-love doesn’t live far away.”
+
+And the other blushed--
+
+“Come now, be frank. Can you deny that at Yonville--”
+
+The young man stammered something.
+
+“At Madame Bovary’s, you’re not making love to--”
+
+“To whom?”
+
+“The servant!”
+
+He was not joking; but vanity getting the better of all prudence, Leon,
+in spite of himself protested. Besides, he only liked dark women.
+
+“I approve of that,” said the chemist; “they have more passion.”
+
+And whispering into his friend’s ear, he pointed out the symptoms by
+which one could find out if a woman had passion. He even launched into
+an ethnographic digression: the German was vapourish, the French woman
+licentious, the Italian passionate.
+
+“And negresses?” asked the clerk.
+
+“They are an artistic taste!” said Homais. “Waiter! two cups of coffee!”
+
+“Are we going?” at last asked Leon impatiently.
+
+“Ja!”
+
+But before leaving he wanted to see the proprietor of the establishment
+and made him a few compliments. Then the young man, to be alone, alleged
+he had some business engagement.
+
+“Ah! I will escort you,” said Homais.
+
+And all the while he was walking through the streets with him he talked
+of his wife, his children; of their future, and of his business; told
+him in what a decayed condition it had formerly been, and to what a
+degree of perfection he had raised it.
+
+Arrived in front of the Hotel de Boulogne, Leon left him abruptly, ran
+up the stairs, and found his mistress in great excitement. At mention of
+the chemist she flew into a passion. He, however, piled up good reasons;
+it wasn’t his fault; didn’t she know Homais--did she believe that he
+would prefer his company? But she turned away; he drew her back, and,
+sinking on his knees, clasped her waist with his arms in a languorous
+pose, full of concupiscence and supplication.
+
+She was standing up, her large flashing eyes looked at him seriously,
+almost terribly. Then tears obscured them, her red eyelids were lowered,
+she gave him her hands, and Leon was pressing them to his lips when a
+servant appeared to tell the gentleman that he was wanted.
+
+“You will come back?” she said.
+
+“Yes.”
+
+“But when?”
+
+“Immediately.”
+
+“It’s a trick,” said the chemist, when he saw Leon. “I wanted to
+interrupt this visit, that seemed to me to annoy you. Let’s go and have
+a glass of garus at Bridoux’.”
+
+Leon vowed that he must get back to his office. Then the druggist joked
+him about quill-drivers and the law.
+
+“Leave Cujas and Barthole alone a bit. Who the devil prevents you? Be a
+man! Let’s go to Bridoux’. You’ll see his dog. It’s very interesting.”
+
+And as the clerk still insisted--
+
+“I’ll go with you. I’ll read a paper while I wait for you, or turn over
+the leaves of a ‘Code.’”
+
+Leon, bewildered by Emma’s anger, Monsieur Homais’ chatter, and,
+perhaps, by the heaviness of the luncheon, was undecided, and, as it
+were, fascinated by the chemist, who kept repeating--
+
+“Let’s go to Bridoux’. It’s just by here, in the Rue Malpalu.”
+
+Then, through cowardice, through stupidity, through that indefinable
+feeling that drags us into the most distasteful acts, he allowed
+himself to be led off to Bridoux’, whom they found in his small yard,
+superintending three workmen, who panted as they turned the large
+wheel of a machine for making seltzer-water. Homais gave them some good
+advice. He embraced Bridoux; they took some garus. Twenty times Leon
+tried to escape, but the other seized him by the arm saying--
+
+“Presently! I’m coming! We’ll go to the ‘Fanal de Rouen’ to see the
+fellows there. I’ll introduce you to Thornassin.”
+
+At last he managed to get rid of him, and rushed straight to the hotel.
+Emma was no longer there. She had just gone in a fit of anger. She
+detested him now. This failing to keep their rendezvous seemed to her an
+insult, and she tried to rake up other reasons to separate herself from
+him. He was incapable of heroism, weak, banal, more spiritless than a
+woman, avaricious too, and cowardly.
+
+Then, growing calmer, she at length discovered that she had, no doubt,
+calumniated him. But the disparaging of those we love always alienates
+us from them to some extent. We must not touch our idols; the gilt
+sticks to our fingers.
+
+They gradually came to talking more frequently of matters outside their
+love, and in the letters that Emma wrote him she spoke of flowers,
+verses, the moon and the stars, naive resources of a waning passion
+striving to keep itself alive by all external aids. She was constantly
+promising herself a profound felicity on her next journey. Then
+she confessed to herself that she felt nothing extraordinary. This
+disappointment quickly gave way to a new hope, and Emma returned to him
+more inflamed, more eager than ever. She undressed brutally, tearing off
+the thin laces of her corset that nestled around her hips like a gliding
+snake. She went on tiptoe, barefooted, to see once more that the
+door was closed, then, pale, serious, and, without speaking, with one
+movement, she threw herself upon his breast with a long shudder.
+
+Yet there was upon that brow covered with cold drops, on those quivering
+lips, in those wild eyes, in the strain of those arms, something vague
+and dreary that seemed to Leon to glide between them subtly as if to
+separate them.
+
+He did not dare to question her; but, seeing her so skilled, she must
+have passed, he thought, through every experience of suffering and of
+pleasure. What had once charmed now frightened him a little. Besides, he
+rebelled against his absorption, daily more marked, by her personality.
+He begrudged Emma this constant victory. He even strove not to love her;
+then, when he heard the creaking of her boots, he turned coward, like
+drunkards at the sight of strong drinks.
+
+She did not fail, in truth, to lavish all sorts of attentions upon him,
+from the delicacies of food to the coquettries of dress and languishing
+looks. She brought roses to her breast from Yonville, which she threw
+into his face; was anxious about his health, gave him advice as to his
+conduct; and, in order the more surely to keep her hold on him, hoping
+perhaps that heaven would take her part, she tied a medal of the
+Virgin round his neck. She inquired like a virtuous mother about his
+companions. She said to him--
+
+“Don’t see them; don’t go out; think only of ourselves; love me!”
+
+She would have liked to be able to watch over his life; and the idea
+occurred to her of having him followed in the streets. Near the hotel
+there was always a kind of loafer who accosted travellers, and who would
+not refuse. But her pride revolted at this.
+
+“Bah! so much the worse. Let him deceive me! What does it matter to me?
+As If I cared for him!”
+
+One day, when they had parted early and she was returning alone along
+the boulevard, she saw the walls of her convent; then she sat down on a
+form in the shade of the elm-trees. How calm that time had been! How she
+longed for the ineffable sentiments of love that she had tried to figure
+to herself out of books! The first month of her marriage, her rides in
+the wood, the viscount that waltzed, and Lagardy singing, all repassed
+before her eyes. And Leon suddenly appeared to her as far off as the
+others.
+
+“Yet I love him,” she said to herself.
+
+No matter! She was not happy--she never had been. Whence came this
+insufficiency in life--this instantaneous turning to decay of everything
+on which she leant? But if there were somewhere a being strong and
+beautiful, a valiant nature, full at once of exaltation and refinement,
+a poet’s heart in an angel’s form, a lyre with sounding chords ringing
+out elegiac epithalamia to heaven, why, perchance, should she not find
+him? Ah! how impossible! Besides, nothing was worth the trouble of
+seeking it; everything was a lie. Every smile hid a yawn of boredom,
+every joy a curse, all pleasure satiety, and the sweetest kisses left
+upon your lips only the unattainable desire for a greater delight.
+
+A metallic clang droned through the air, and four strokes were heard
+from the convent-clock. Four o’clock! And it seemed to her that she had
+been there on that form an eternity. But an infinity of passions may be
+contained in a minute, like a crowd in a small space.
+
+Emma lived all absorbed in hers, and troubled no more about money
+matters than an archduchess.
+
+Once, however, a wretched-looking man, rubicund and bald, came to her
+house, saying he had been sent by Monsieur Vincart of Rouen. He took out
+the pins that held together the side-pockets of his long green overcoat,
+stuck them into his sleeve, and politely handed her a paper.
+
+It was a bill for seven hundred francs, signed by her, and which
+Lheureux, in spite of all his professions, had paid away to Vincart. She
+sent her servant for him. He could not come. Then the stranger, who
+had remained standing, casting right and left curious glances, that his
+thick, fair eyebrows hid, asked with a naive air--
+
+“What answer am I to take Monsieur Vincart?”
+
+“Oh,” said Emma, “tell him that I haven’t it. I will send next week; he
+must wait; yes, till next week.”
+
+And the fellow went without another word.
+
+But the next day at twelve o’clock she received a summons, and the sight
+of the stamped paper, on which appeared several times in large letters,
+“Maitre Hareng, bailiff at Buchy,” so frightened her that she rushed in
+hot haste to the linendraper’s. She found him in his shop, doing up a
+parcel.
+
+“Your obedient!” he said; “I am at your service.”
+
+But Lheureux, all the same, went on with his work, helped by a young
+girl of about thirteen, somewhat hunch-backed, who was at once his clerk
+and his servant.
+
+Then, his clogs clattering on the shop-boards, he went up in front
+of Madame Bovary to the first door, and introduced her into a narrow
+closet, where, in a large bureau in sapon-wood, lay some ledgers,
+protected by a horizontal padlocked iron bar. Against the wall, under
+some remnants of calico, one glimpsed a safe, but of such dimensions
+that it must contain something besides bills and money. Monsieur
+Lheureux, in fact, went in for pawnbroking, and it was there that he had
+put Madame Bovary’s gold chain, together with the earrings of poor old
+Tellier, who, at last forced to sell out, had bought a meagre store
+of grocery at Quincampoix, where he was dying of catarrh amongst his
+candles, that were less yellow than his face.
+
+Lheureux sat down in a large cane arm-chair, saying: “What news?”
+
+“See!”
+
+And she showed him the paper.
+
+“Well how can I help it?”
+
+Then she grew angry, reminding him of the promise he had given not to
+pay away her bills. He acknowledged it.
+
+“But I was pressed myself; the knife was at my own throat.”
+
+“And what will happen now?” she went on.
+
+“Oh, it’s very simple; a judgment and then a distraint--that’s about
+it!”
+
+Emma kept down a desire to strike him, and asked gently if there was no
+way of quieting Monsieur Vincart.
+
+“I dare say! Quiet Vincart! You don’t know him; he’s more ferocious than
+an Arab!”
+
+Still Monsieur Lheureux must interfere.
+
+“Well, listen. It seems to me so far I’ve been very good to you.” And
+opening one of his ledgers, “See,” he said. Then running up the page
+with his finger, “Let’s see! let’s see! August 3d, two hundred francs;
+June 17th, a hundred and fifty; March 23d, forty-six. In April--”
+
+He stopped, as if afraid of making some mistake.
+
+“Not to speak of the bills signed by Monsieur Bovary, one for seven
+hundred francs, and another for three hundred. As to your little
+installments, with the interest, why, there’s no end to ‘em; one gets
+quite muddled over ‘em. I’ll have nothing more to do with it.”
+
+She wept; she even called him “her good Monsieur Lheureux.” But he
+always fell back upon “that rascal Vincart.” Besides, he hadn’t a brass
+farthing; no one was paying him now-a-days; they were eating his coat
+off his back; a poor shopkeeper like him couldn’t advance money.
+
+Emma was silent, and Monsieur Lheureux, who was biting the feathers of a
+quill, no doubt became uneasy at her silence, for he went on--
+
+“Unless one of these days I have something coming in, I might--”
+
+“Besides,” said she, “as soon as the balance of Barneville--”
+
+“What!”
+
+And on hearing that Langlois had not yet paid he seemed much surprised.
+Then in a honied voice--
+
+“And we agree, you say?”
+
+“Oh! to anything you like.”
+
+On this he closed his eyes to reflect, wrote down a few figures, and
+declaring it would be very difficult for him, that the affair was shady,
+and that he was being bled, he wrote out four bills for two hundred and
+fifty francs each, to fall due month by month.
+
+“Provided that Vincart will listen to me! However, it’s settled. I don’t
+play the fool; I’m straight enough.”
+
+Next he carelessly showed her several new goods, not one of which,
+however, was in his opinion worthy of madame.
+
+“When I think that there’s a dress at threepence-halfpenny a yard, and
+warranted fast colours! And yet they actually swallow it! Of course you
+understand one doesn’t tell them what it really is!” He hoped by this
+confession of dishonesty to others to quite convince her of his probity
+to her.
+
+Then he called her back to show her three yards of guipure that he had
+lately picked up “at a sale.”
+
+“Isn’t it lovely?” said Lheureux. “It is very much used now for the
+backs of arm-chairs. It’s quite the rage.”
+
+And, more ready than a juggler, he wrapped up the guipure in some blue
+paper and put it in Emma’s hands.
+
+“But at least let me know--”
+
+“Yes, another time,” he replied, turning on his heel.
+
+That same evening she urged Bovary to write to his mother, to ask her
+to send as quickly as possible the whole of the balance due from the
+father’s estate. The mother-in-law replied that she had nothing more,
+the winding up was over, and there was due to them besides Barneville an
+income of six hundred francs, that she would pay them punctually.
+
+Then Madame Bovary sent in accounts to two or three patients, and she
+made large use of this method, which was very successful. She was always
+careful to add a postscript: “Do not mention this to my husband; you
+know how proud he is. Excuse me. Yours obediently.” There were some
+complaints; she intercepted them.
+
+To get money she began selling her old gloves, her old hats, the old
+odds and ends, and she bargained rapaciously, her peasant blood standing
+her in good stead. Then on her journey to town she picked up nick-nacks
+secondhand, that, in default of anyone else, Monsieur Lheureux would
+certainly take off her hands. She bought ostrich feathers, Chinese
+porcelain, and trunks; she borrowed from Felicite, from Madame
+Lefrancois, from the landlady at the Croix-Rouge, from everybody, no
+matter where.
+
+With the money she at last received from Barneville she paid two bills;
+the other fifteen hundred francs fell due. She renewed the bills, and
+thus it was continually.
+
+Sometimes, it is true, she tried to make a calculation, but she
+discovered things so exorbitant that she could not believe them
+possible. Then she recommenced, soon got confused, gave it all up, and
+thought no more about it.
+
+The house was very dreary now. Tradesmen were seen leaving it with angry
+faces. Handkerchiefs were lying about on the stoves, and little Berthe,
+to the great scandal of Madame Homais, wore stockings with holes in
+them. If Charles timidly ventured a remark, she answered roughly that it
+wasn’t her fault.
+
+What was the meaning of all these fits of temper? He explained
+everything through her old nervous illness, and reproaching himself with
+having taken her infirmities for faults, accused himself of egotism, and
+longed to go and take her in his arms.
+
+“Ah, no!” he said to himself; “I should worry her.”
+
+And he did not stir.
+
+After dinner he walked about alone in the garden; he took little Berthe
+on his knees, and unfolding his medical journal, tried to teach her
+to read. But the child, who never had any lessons, soon looked up with
+large, sad eyes and began to cry. Then he comforted her; went to fetch
+water in her can to make rivers on the sand path, or broke off branches
+from the privet hedges to plant trees in the beds. This did not spoil
+the garden much, all choked now with long weeds. They owed Lestiboudois
+for so many days. Then the child grew cold and asked for her mother.
+
+“Call the servant,” said Charles. “You know, dearie, that mamma does not
+like to be disturbed.”
+
+Autumn was setting in, and the leaves were already falling, as they did
+two years ago when she was ill. Where would it all end? And he walked up
+and down, his hands behind his back.
+
+Madame was in her room, which no one entered. She stayed there all
+day long, torpid, half dressed, and from time to time burning Turkish
+pastilles which she had bought at Rouen in an Algerian’s shop. In order
+not to have at night this sleeping man stretched at her side, by dint of
+manoeuvring, she at last succeeded in banishing him to the second floor,
+while she read till morning extravagant books, full of pictures of
+orgies and thrilling situations. Often, seized with fear, she cried out,
+and Charles hurried to her.
+
+“Oh, go away!” she would say.
+
+Or at other times, consumed more ardently than ever by that inner flame
+to which adultery added fuel, panting, tremulous, all desire, she threw
+open her window, breathed in the cold air, shook loose in the wind her
+masses of hair, too heavy, and, gazing upon the stars, longed for some
+princely love. She thought of him, of Leon. She would then have given
+anything for a single one of those meetings that surfeited her.
+
+These were her gala days. She wanted them to be sumptuous, and when he
+alone could not pay the expenses, she made up the deficit liberally,
+which happened pretty well every time. He tried to make her understand
+that they would be quite as comfortable somewhere else, in a smaller
+hotel, but she always found some objection.
+
+One day she drew six small silver-gilt spoons from her bag (they were
+old Roualt’s wedding present), begging him to pawn them at once for her,
+and Leon obeyed, though the proceeding annoyed him. He was afraid of
+compromising himself.
+
+Then, on, reflection, he began to think his mistress’s ways were growing
+odd, and that they were perhaps not wrong in wishing to separate him
+from her.
+
+In fact someone had sent his mother a long anonymous letter to warn her
+that he was “ruining himself with a married woman,” and the good lady at
+once conjuring up the eternal bugbear of families, the vague pernicious
+creature, the siren, the monster, who dwells fantastically in depths of
+love, wrote to Lawyer Dubocage, his employer, who behaved perfectly in
+the affair. He kept him for three quarters of an hour trying to open
+his eyes, to warn him of the abyss into which he was falling. Such
+an intrigue would damage him later on, when he set up for himself. He
+implored him to break with her, and, if he would not make this sacrifice
+in his own interest, to do it at least for his, Dubocage’s sake.
+
+At last Leon swore he would not see Emma again, and he reproached
+himself with not having kept his word, considering all the worry and
+lectures this woman might still draw down upon him, without reckoning
+the jokes made by his companions as they sat round the stove in the
+morning. Besides, he was soon to be head clerk; it was time to settle
+down. So he gave up his flute, exalted sentiments, and poetry; for every
+bourgeois in the flush of his youth, were it but for a day, a moment,
+has believed himself capable of immense passions, of lofty enterprises.
+The most mediocre libertine has dreamed of sultanas; every notary bears
+within him the debris of a poet.
+
+He was bored now when Emma suddenly began to sob on his breast, and his
+heart, like the people who can only stand a certain amount of music,
+dozed to the sound of a love whose delicacies he no longer noted.
+
+They knew one another too well for any of those surprises of possession
+that increase its joys a hundred-fold. She was as sick of him as he
+was weary of her. Emma found again in adultery all the platitudes of
+marriage.
+
+But how to get rid of him? Then, though she might feel humiliated at
+the baseness of such enjoyment, she clung to it from habit or from
+corruption, and each day she hungered after them the more, exhausting
+all felicity in wishing for too much of it. She accused Leon of her
+baffled hopes, as if he had betrayed her; and she even longed for some
+catastrophe that would bring about their separation, since she had not
+the courage to make up her mind to it herself.
+
+She none the less went on writing him love letters, in virtue of the
+notion that a woman must write to her lover.
+
+But whilst she wrote it was another man she saw, a phantom fashioned out
+of her most ardent memories, of her finest reading, her strongest
+lusts, and at last he became so real, so tangible, that she palpitated
+wondering, without, however, the power to imagine him clearly, so lost
+was he, like a god, beneath the abundance of his attributes. He dwelt in
+that azure land where silk ladders hang from balconies under the breath
+of flowers, in the light of the moon. She felt him near her; he was
+coming, and would carry her right away in a kiss.
+
+Then she fell back exhausted, for these transports of vague love wearied
+her more than great debauchery.
+
+She now felt constant ache all over her. Often she even received
+summonses, stamped paper that she barely looked at. She would have liked
+not to be alive, or to be always asleep.
+
+On Mid-Lent she did not return to Yonville, but in the evening went to
+a masked ball. She wore velvet breeches, red stockings, a club wig, and
+three-cornered hat cocked on one side. She danced all night to the wild
+tones of the trombones; people gathered round her, and in the morning
+she found herself on the steps of the theatre together with five or six
+masks, debardeuses* and sailors, Leon’s comrades, who were talking about
+having supper.
+
+     * People dressed as longshoremen.
+
+
+The neighbouring cafes were full. They caught sight of one on the
+harbour, a very indifferent restaurant, whose proprietor showed them to
+a little room on the fourth floor.
+
+The men were whispering in a corner, no doubt consorting about expenses.
+There were a clerk, two medical students, and a shopman--what company
+for her! As to the women, Emma soon perceived from the tone of their
+voices that they must almost belong to the lowest class. Then she was
+frightened, pushed back her chair, and cast down her eyes.
+
+The others began to eat; she ate nothing. Her head was on fire, her eyes
+smarted, and her skin was ice-cold. In her head she seemed to feel the
+floor of the ball-room rebounding again beneath the rhythmical pulsation
+of the thousands of dancing feet. And now the smell of the punch, the
+smoke of the cigars, made her giddy. She fainted, and they carried her
+to the window.
+
+Day was breaking, and a great stain of purple colour broadened out
+in the pale horizon over the St. Catherine hills. The livid river was
+shivering in the wind; there was no one on the bridges; the street lamps
+were going out.
+
+She revived, and began thinking of Berthe asleep yonder in the servant’s
+room. Then a cart filled with long strips of iron passed by, and made a
+deafening metallic vibration against the walls of the houses.
+
+She slipped away suddenly, threw off her costume, told Leon she must get
+back, and at last was alone at the Hotel de Boulogne. Everything, even
+herself, was now unbearable to her. She wished that, taking wing like a
+bird, she could fly somewhere, far away to regions of purity, and there
+grow young again.
+
+She went out, crossed the Boulevard, the Place Cauchoise, and the
+Faubourg, as far as an open street that overlooked some gardens. She
+walked rapidly; the fresh air calming her; and, little by little, the
+faces of the crowd, the masks, the quadrilles, the lights, the supper,
+those women, all disappeared like mists fading away. Then, reaching the
+“Croix-Rouge,” she threw herself on the bed in her little room on the
+second floor, where there were pictures of the “Tour de Nesle.” At four
+o’clock Hivert awoke her.
+
+When she got home, Felicite showed her behind the clock a grey paper.
+She read--
+
+“In virtue of the seizure in execution of a judgment.”
+
+What judgment? As a matter of fact, the evening before another paper
+had been brought that she had not yet seen, and she was stunned by these
+words--
+
+“By order of the king, law, and justice, to Madame Bovary.” Then,
+skipping several lines, she read, “Within twenty-four hours, without
+fail--” But what? “To pay the sum of eight thousand francs.” And there
+was even at the bottom, “She will be constrained thereto by every
+form of law, and notably by a writ of distraint on her furniture and
+effects.”
+
+What was to be done? In twenty-four hours--tomorrow. Lheureux, she
+thought, wanted to frighten her again; for she saw through all his
+devices, the object of his kindnesses. What reassured her was the very
+magnitude of the sum.
+
+However, by dint of buying and not paying, of borrowing, signing bills,
+and renewing these bills that grew at each new falling-in, she had ended
+by preparing a capital for Monsieur Lheureux which he was impatiently
+awaiting for his speculations.
+
+She presented herself at his place with an offhand air.
+
+“You know what has happened to me? No doubt it’s a joke!”
+
+“How so?”
+
+He turned away slowly, and, folding his arms, said to her--
+
+“My good lady, did you think I should go on to all eternity being your
+purveyor and banker, for the love of God? Now be just. I must get back
+what I’ve laid out. Now be just.”
+
+She cried out against the debt.
+
+“Ah! so much the worse. The court has admitted it. There’s a judgment.
+It’s been notified to you. Besides, it isn’t my fault. It’s Vincart’s.”
+
+“Could you not--?”
+
+“Oh, nothing whatever.”
+
+“But still, now talk it over.”
+
+And she began beating about the bush; she had known nothing about it; it
+was a surprise.
+
+“Whose fault is that?” said Lheureux, bowing ironically. “While I’m
+slaving like a nigger, you go gallivanting about.”
+
+“Ah! no lecturing.”
+
+“It never does any harm,” he replied.
+
+She turned coward; she implored him; she even pressed her pretty white
+and slender hand against the shopkeeper’s knee.
+
+“There, that’ll do! Anyone’d think you wanted to seduce me!”
+
+“You are a wretch!” she cried.
+
+“Oh, oh! go it! go it!”
+
+“I will show you up. I shall tell my husband.”
+
+“All right! I too. I’ll show your husband something.”
+
+And Lheureux drew from his strong box the receipt for eighteen hundred
+francs that she had given him when Vincart had discounted the bills.
+
+“Do you think,” he added, “that he’ll not understand your little theft,
+the poor dear man?”
+
+She collapsed, more overcome than if felled by the blow of a pole-axe.
+He was walking up and down from the window to the bureau, repeating all
+the while--
+
+“Ah! I’ll show him! I’ll show him!” Then he approached her, and in a
+soft voice said--
+
+“It isn’t pleasant, I know; but, after all, no bones are broken, and,
+since that is the only way that is left for you paying back my money--”
+
+“But where am I to get any?” said Emma, wringing her hands.
+
+“Bah! when one has friends like you!”
+
+And he looked at her in so keen, so terrible a fashion, that she
+shuddered to her very heart.
+
+“I promise you,” she said, “to sign--”
+
+“I’ve enough of your signatures.”
+
+“I will sell something.”
+
+“Get along!” he said, shrugging his shoulders; “you’ve not got
+anything.”
+
+And he called through the peep-hole that looked down into the shop--
+
+“Annette, don’t forget the three coupons of No. 14.”
+
+The servant appeared. Emma understood, and asked how much money would be
+wanted to put a stop to the proceedings.
+
+“It is too late.”
+
+“But if I brought you several thousand francs--a quarter of the sum--a
+third--perhaps the whole?”
+
+“No; it’s no use!”
+
+And he pushed her gently towards the staircase.
+
+“I implore you, Monsieur Lheureux, just a few days more!” She was
+sobbing.
+
+“There! tears now!”
+
+“You are driving me to despair!”
+
+“What do I care?” said he, shutting the door.
+
+
+
+Chapter Seven
+
+She was stoical the next day when Maitre Hareng, the bailiff, with two
+assistants, presented himself at her house to draw up the inventory for
+the distraint.
+
+They began with Bovary’s consulting-room, and did not write down
+the phrenological head, which was considered an “instrument of his
+profession”; but in the kitchen they counted the plates; the saucepans,
+the chairs, the candlesticks, and in the bedroom all the nick-nacks on
+the whatnot. They examined her dresses, the linen, the dressing-room;
+and her whole existence to its most intimate details, was, like a corpse
+on whom a post-mortem is made, outspread before the eyes of these three
+men.
+
+Maitre Hareng, buttoned up in his thin black coat, wearing a white
+choker and very tight foot-straps, repeated from time to time--“Allow
+me, madame. You allow me?” Often he uttered exclamations. “Charming!
+very pretty.” Then he began writing again, dipping his pen into the horn
+inkstand in his left hand.
+
+When they had done with the rooms they went up to the attic. She kept a
+desk there in which Rodolphe’s letters were locked. It had to be opened.
+
+“Ah! a correspondence,” said Maitre Hareng, with a discreet smile. “But
+allow me, for I must make sure the box contains nothing else.” And he
+tipped up the papers lightly, as if to shake out napoleons. Then she
+grew angered to see this coarse hand, with fingers red and pulpy like
+slugs, touching these pages against which her heart had beaten.
+
+They went at last. Felicite came back. Emma had sent her out to watch
+for Bovary in order to keep him off, and they hurriedly installed the
+man in possession under the roof, where he swore he would remain.
+
+During the evening Charles seemed to her careworn. Emma watched him with
+a look of anguish, fancying she saw an accusation in every line of his
+face. Then, when her eyes wandered over the chimney-piece ornamented
+with Chinese screens, over the large curtains, the armchairs, all
+those things, in a word, that had, softened the bitterness of her life,
+remorse seized her or rather an immense regret, that, far from crushing,
+irritated her passion. Charles placidly poked the fire, both his feet on
+the fire-dogs.
+
+Once the man, no doubt bored in his hiding-place, made a slight noise.
+
+“Is anyone walking upstairs?” said Charles.
+
+“No,” she replied; “it is a window that has been left open, and is
+rattling in the wind.”
+
+The next day, Sunday, she went to Rouen to call on all the brokers whose
+names she knew. They were at their country-places or on journeys. She
+was not discouraged; and those whom she did manage to see she asked for
+money, declaring she must have some, and that she would pay it back.
+Some laughed in her face; all refused.
+
+At two o’clock she hurried to Leon, and knocked at the door. No one
+answered. At length he appeared.
+
+“What brings you here?”
+
+“Do I disturb you?”
+
+“No; but--” And he admitted that his landlord didn’t like his having
+“women” there.
+
+“I must speak to you,” she went on.
+
+Then he took down the key, but she stopped him.
+
+“No, no! Down there, in our home!”
+
+And they went to their room at the Hotel de Boulogne.
+
+On arriving she drank off a large glass of water. She was very pale. She
+said to him--
+
+“Leon, you will do me a service?”
+
+And, shaking him by both hands that she grasped tightly, she added--
+
+“Listen, I want eight thousand francs.”
+
+“But you are mad!”
+
+“Not yet.”
+
+And thereupon, telling him the story of the distraint, she explained
+her distress to him; for Charles knew nothing of it; her mother-in-law
+detested her; old Rouault could do nothing; but he, Leon, he would set
+about finding this indispensable sum.
+
+“How on earth can I?”
+
+“What a coward you are!” she cried.
+
+Then he said stupidly, “You are exaggerating the difficulty. Perhaps,
+with a thousand crowns or so the fellow could be stopped.”
+
+All the greater reason to try and do something; it was impossible that
+they could not find three thousand francs. Besides, Leon, could be
+security instead of her.
+
+“Go, try, try! I will love you so!”
+
+He went out, and came back at the end of an hour, saying, with solemn
+face--
+
+“I have been to three people with no success.”
+
+Then they remained sitting face to face at the two chimney corners,
+motionless, in silence. Emma shrugged her shoulders as she stamped her
+feet. He heard her murmuring--
+
+“If I were in your place _I_ should soon get some.”
+
+“But where?”
+
+“At your office.” And she looked at him.
+
+An infernal boldness looked out from her burning eyes, and their lids
+drew close together with a lascivious and encouraging look, so that the
+young man felt himself growing weak beneath the mute will of this woman
+who was urging him to a crime. Then he was afraid, and to avoid any
+explanation he smote his forehead, crying--
+
+“Morel is to come back to-night; he will not refuse me, I hope” (this
+was one of his friends, the son of a very rich merchant); “and I will
+bring it you to-morrow,” he added.
+
+Emma did not seem to welcome this hope with all the joy he had expected.
+Did she suspect the lie? He went on, blushing--
+
+“However, if you don’t see me by three o’clock do not wait for me, my
+darling. I must be off now; forgive me! Goodbye!”
+
+He pressed her hand, but it felt quite lifeless. Emma had no strength
+left for any sentiment.
+
+Four o’clock struck, and she rose to return to Yonville, mechanically
+obeying the force of old habits.
+
+The weather was fine. It was one of those March days, clear and sharp,
+when the sun shines in a perfectly white sky. The Rouen folk, in
+Sunday-clothes, were walking about with happy looks. She reached the
+Place du Parvis. People were coming out after vespers; the crowd flowed
+out through the three doors like a stream through the three arches of
+a bridge, and in the middle one, more motionless than a rock, stood the
+beadle.
+
+Then she remembered the day when, all anxious and full of hope, she had
+entered beneath this large nave, that had opened out before her, less
+profound than her love; and she walked on weeping beneath her veil,
+giddy, staggering, almost fainting.
+
+“Take care!” cried a voice issuing from the gate of a courtyard that was
+thrown open.
+
+She stopped to let pass a black horse, pawing the ground between the
+shafts of a tilbury, driven by a gentleman in sable furs. Who was it?
+She knew him. The carriage darted by and disappeared.
+
+Why, it was he--the Viscount. She turned away; the street was empty. She
+was so overwhelmed, so sad, that she had to lean against a wall to keep
+herself from falling.
+
+Then she thought she had been mistaken. Anyhow, she did not know. All
+within her and around her was abandoning her. She felt lost, sinking
+at random into indefinable abysses, and it was almost with joy that, on
+reaching the “Croix-Rouge,” she saw the good Homais, who was watching
+a large box full of pharmaceutical stores being hoisted on to the
+“Hirondelle.” In his hand he held tied in a silk handkerchief six
+cheminots for his wife.
+
+Madame Homais was very fond of these small, heavy turban-shaped loaves,
+that are eaten in Lent with salt butter; a last vestige of Gothic food
+that goes back, perhaps, to the time of the Crusades, and with which
+the robust Normans gorged themselves of yore, fancying they saw on the
+table, in the light of the yellow torches, between tankards of hippocras
+and huge boars’ heads, the heads of Saracens to be devoured. The
+druggist’s wife crunched them up as they had done--heroically, despite
+her wretched teeth. And so whenever Homais journeyed to town, he never
+failed to bring her home some that he bought at the great baker’s in the
+Rue Massacre.
+
+“Charmed to see you,” he said, offering Emma a hand to help her into the
+“Hirondelle.” Then he hung up his cheminots to the cords of the netting,
+and remained bare-headed in an attitude pensive and Napoleonic.
+
+But when the blind man appeared as usual at the foot of the hill he
+exclaimed--
+
+“I can’t understand why the authorities tolerate such culpable
+industries. Such unfortunates should be locked up and forced to work.
+Progress, my word! creeps at a snail’s pace. We are floundering about in
+mere barbarism.”
+
+The blind man held out his hat, that flapped about at the door, as if it
+were a bag in the lining that had come unnailed.
+
+“This,” said the chemist, “is a scrofulous affection.”
+
+And though he knew the poor devil, he pretended to see him for the first
+time, murmured something about “cornea,” “opaque cornea,” “sclerotic,”
+ “facies,” then asked him in a paternal tone--
+
+“My friend, have you long had this terrible infirmity? Instead of
+getting drunk at the public, you’d do better to die yourself.”
+
+He advised him to take good wine, good beer, and good joints. The blind
+man went on with his song; he seemed, moreover, almost idiotic. At last
+Monsieur Homais opened his purse--
+
+“Now there’s a sou; give me back two lairds, and don’t forget my advice:
+you’ll be the better for it.”
+
+Hivert openly cast some doubt on the efficacy of it. But the druggist
+said that he would cure himself with an antiphlogistic pomade of his own
+composition, and he gave his address--“Monsieur Homais, near the market,
+pretty well known.”
+
+“Now,” said Hivert, “for all this trouble you’ll give us your
+performance.”
+
+The blind man sank down on his haunches, with his head thrown back,
+whilst he rolled his greenish eyes, lolled out his tongue, and rubbed
+his stomach with both hands as he uttered a kind of hollow yell like a
+famished dog. Emma, filled with disgust, threw him over her shoulder
+a five-franc piece. It was all her fortune. It seemed to her very fine
+thus to throw it away.
+
+The coach had gone on again when suddenly Monsieur Homais leant out
+through the window, crying--
+
+“No farinaceous or milk food, wear wool next the skin, and expose the
+diseased parts to the smoke of juniper berries.”
+
+The sight of the well-known objects that defiled before her eyes
+gradually diverted Emma from her present trouble. An intolerable fatigue
+overwhelmed her, and she reached her home stupefied, discouraged, almost
+asleep.
+
+“Come what may come!” she said to herself. “And then, who knows? Why, at
+any moment could not some extraordinary event occur? Lheureux even might
+die!”
+
+At nine o’clock in the morning she was awakened by the sound of voices
+in the Place. There was a crowd round the market reading a large bill
+fixed to one of the posts, and she saw Justin, who was climbing on to
+a stone and tearing down the bill. But at this moment the rural guard
+seized him by the collar. Monsieur Homais came out of his shop, and Mere
+Lefrangois, in the midst of the crowd, seemed to be perorating.
+
+“Madame! madame!” cried Felicite, running in, “it’s abominable!”
+
+And the poor girl, deeply moved, handed her a yellow paper that she had
+just torn off the door. Emma read with a glance that all her furniture
+was for sale.
+
+Then they looked at one another silently. The servant and mistress had
+no secret one from the other. At last Felicite sighed--
+
+“If I were you, madame, I should go to Monsieur Guillaumin.”
+
+“Do you think--”
+
+And this question meant to say--
+
+“You who know the house through the servant, has the master spoken
+sometimes of me?”
+
+“Yes, you’d do well to go there.”
+
+She dressed, put on her black gown, and her hood with jet beads, and
+that she might not be seen (there was still a crowd on the Place), she
+took the path by the river, outside the village.
+
+She reached the notary’s gate quite breathless. The sky was sombre, and
+a little snow was falling. At the sound of the bell, Theodore in a
+red waistcoat appeared on the steps; he came to open the door almost
+familiarly, as to an acquaintance, and showed her into the dining-room.
+
+A large porcelain stove crackled beneath a cactus that filled up the
+niche in the wall, and in black wood frames against the oak-stained
+paper hung Steuben’s “Esmeralda” and Schopin’s “Potiphar.” The
+ready-laid table, the two silver chafing-dishes, the crystal door-knobs,
+the parquet and the furniture, all shone with a scrupulous, English
+cleanliness; the windows were ornamented at each corner with stained
+glass.
+
+“Now this,” thought Emma, “is the dining-room I ought to have.”
+
+The notary came in pressing his palm-leaf dressing-gown to his breast
+with his left arm, while with the other hand he raised and quickly put
+on again his brown velvet cap, pretentiously cocked on the right side,
+whence looked out the ends of three fair curls drawn from the back of
+the head, following the line of his bald skull.
+
+After he had offered her a seat he sat down to breakfast, apologising
+profusely for his rudeness.
+
+“I have come,” she said, “to beg you, sir--”
+
+“What, madame? I am listening.”
+
+And she began explaining her position to him. Monsieur Guillaumin knew
+it, being secretly associated with the linendraper, from whom he always
+got capital for the loans on mortgages that he was asked to make.
+
+So he knew (and better than she herself) the long story of the bills,
+small at first, bearing different names as endorsers, made out at long
+dates, and constantly renewed up to the day, when, gathering together
+all the protested bills, the shopkeeper had bidden his friend Vincart
+take in his own name all the necessary proceedings, not wishing to pass
+for a tiger with his fellow-citizens.
+
+She mingled her story with recriminations against Lheureux, to which the
+notary replied from time to time with some insignificant word. Eating
+his cutlet and drinking his tea, he buried his chin in his sky-blue
+cravat, into which were thrust two diamond pins, held together by a
+small gold chain; and he smiled a singular smile, in a sugary, ambiguous
+fashion. But noticing that her feet were damp, he said--
+
+“Do get closer to the stove; put your feet up against the porcelain.”
+
+She was afraid of dirtying it. The notary replied in a gallant tone--
+
+“Beautiful things spoil nothing.”
+
+Then she tried to move him, and, growing moved herself, she began
+telling him about the poorness of her home, her worries, her wants.
+He could understand that; an elegant woman! and, without leaving off
+eating, he had turned completely round towards her, so that his knee
+brushed against her boot, whose sole curled round as it smoked against
+the stove.
+
+But when she asked for a thousand sous, he closed his lips, and declared
+he was very sorry he had not had the management of her fortune before,
+for there were hundreds of ways very convenient, even for a lady, of
+turning her money to account. They might, either in the turf-peats
+of Grumesnil or building-ground at Havre, almost without risk, have
+ventured on some excellent speculations; and he let her consume herself
+with rage at the thought of the fabulous sums that she would certainly
+have made.
+
+“How was it,” he went on, “that you didn’t come to me?”
+
+“I hardly know,” she said.
+
+“Why, hey? Did I frighten you so much? It is I, on the contrary, who
+ought to complain. We hardly know one another; yet I am very devoted to
+you. You do not doubt that, I hope?”
+
+He held out his hand, took hers, covered it with a greedy kiss, then
+held it on his knee; and he played delicately with her fingers whilst
+he murmured a thousand blandishments. His insipid voice murmured like a
+running brook; a light shone in his eyes through the glimmering of his
+spectacles, and his hand was advancing up Emma’s sleeve to press her
+arm. She felt against her cheek his panting breath. This man oppressed
+her horribly.
+
+She sprang up and said to him--
+
+“Sir, I am waiting.”
+
+“For what?” said the notary, who suddenly became very pale.
+
+“This money.”
+
+“But--” Then, yielding to the outburst of too powerful a desire, “Well,
+yes!”
+
+He dragged himself towards her on his knees, regardless of his
+dressing-gown.
+
+“For pity’s sake, stay. I love you!”
+
+He seized her by her waist. Madame Bovary’s face flushed purple. She
+recoiled with a terrible look, crying--
+
+“You are taking a shameless advantage of my distress, sir! I am to be
+pitied--not to be sold.”
+
+And she went out.
+
+The notary remained quite stupefied, his eyes fixed on his fine
+embroidered slippers. They were a love gift, and the sight of them at
+last consoled him. Besides, he reflected that such an adventure might
+have carried him too far.
+
+“What a wretch! what a scoundrel! what an infamy!” she said to herself,
+as she fled with nervous steps beneath the aspens of the path. The
+disappointment of her failure increased the indignation of her outraged
+modesty; it seemed to her that Providence pursued her implacably, and,
+strengthening herself in her pride, she had never felt so much esteem
+for herself nor so much contempt for others. A spirit of warfare
+transformed her. She would have liked to strike all men, to spit in
+their faces, to crush them, and she walked rapidly straight on, pale,
+quivering, maddened, searching the empty horizon with tear-dimmed eyes,
+and as it were rejoicing in the hate that was choking her.
+
+When she saw her house a numbness came over her. She could not go on;
+and yet she must. Besides, whither could she flee?
+
+Felicite was waiting for her at the door. “Well?”
+
+“No!” said Emma.
+
+And for a quarter of an hour the two of them went over the various
+persons in Yonville who might perhaps be inclined to help her. But each
+time that Felicite named someone Emma replied--
+
+“Impossible! they will not!”
+
+“And the master’ll soon be in.”
+
+“I know that well enough. Leave me alone.”
+
+She had tried everything; there was nothing more to be done now; and
+when Charles came in she would have to say to him--
+
+“Go away! This carpet on which you are walking is no longer ours. In
+your own house you do not possess a chair, a pin, a straw, and it is I,
+poor man, who have ruined you.”
+
+Then there would be a great sob; next he would weep abundantly, and at
+last, the surprise past, he would forgive her.
+
+“Yes,” she murmured, grinding her teeth, “he will forgive me, he who
+would give a million if I would forgive him for having known me! Never!
+never!”
+
+This thought of Bovary’s superiority to her exasperated her. Then,
+whether she confessed or did not confess, presently, immediately,
+to-morrow, he would know the catastrophe all the same; so she must wait
+for this horrible scene, and bear the weight of his magnanimity. The
+desire to return to Lheureux’s seized her--what would be the use? To
+write to her father--it was too late; and perhaps, she began to repent
+now that she had not yielded to that other, when she heard the trot of
+a horse in the alley. It was he; he was opening the gate; he was whiter
+than the plaster wall. Rushing to the stairs, she ran out quickly to the
+square; and the wife of the mayor, who was talking to Lestiboudois in
+front of the church, saw her go in to the tax-collector’s.
+
+She hurried off to tell Madame Caron, and the two ladies went up to
+the attic, and, hidden by some linen spread across props, stationed
+themselves comfortably for overlooking the whole of Binet’s room.
+
+He was alone in his garret, busy imitating in wood one of those
+indescribable bits of ivory, composed of crescents, of spheres hollowed
+out one within the other, the whole as straight as an obelisk, and of no
+use whatever; and he was beginning on the last piece--he was nearing his
+goal. In the twilight of the workshop the white dust was flying from his
+tools like a shower of sparks under the hoofs of a galloping horse; the
+two wheels were turning, droning; Binet smiled, his chin lowered, his
+nostrils distended, and, in a word, seemed lost in one of those complete
+happinesses that, no doubt, belong only to commonplace occupations,
+which amuse the mind with facile difficulties, and satisfy by a
+realisation of that beyond which such minds have not a dream.
+
+“Ah! there she is!” exclaimed Madame Tuvache.
+
+But it was impossible because of the lathe to hear what she was saying.
+
+At last these ladies thought they made out the word “francs,” and Madame
+Tuvache whispered in a low voice--
+
+“She is begging him to give her time for paying her taxes.”
+
+“Apparently!” replied the other.
+
+They saw her walking up and down, examining the napkin-rings, the
+candlesticks, the banister rails against the walls, while Binet stroked
+his beard with satisfaction.
+
+“Do you think she wants to order something of him?” said Madame Tuvache.
+
+“Why, he doesn’t sell anything,” objected her neighbour.
+
+The tax-collector seemed to be listening with wide-open eyes, as if he
+did not understand. She went on in a tender, suppliant manner. She came
+nearer to him, her breast heaving; they no longer spoke.
+
+“Is she making him advances?” said Madame Tuvache. Binet was scarlet to
+his very ears. She took hold of his hands.
+
+“Oh, it’s too much!”
+
+And no doubt she was suggesting something abominable to him; for the
+tax-collector--yet he was brave, had fought at Bautzen and at Lutzen,
+had been through the French campaign, and had even been recommended for
+the cross--suddenly, as at the sight of a serpent, recoiled as far as he
+could from her, crying--
+
+“Madame! what do you mean?”
+
+“Women like that ought to be whipped,” said Madame Tuvache.
+
+“But where is she?” continued Madame Caron, for she had disappeared
+whilst they spoke; then catching sight of her going up the Grande Rue,
+and turning to the right as if making for the cemetery, they were lost
+in conjectures.
+
+“Nurse Rollet,” she said on reaching the nurse’s, “I am choking; unlace
+me!” She fell on the bed sobbing. Nurse Rollet covered her with a
+petticoat and remained standing by her side. Then, as she did not
+answer, the good woman withdrew, took her wheel and began spinning flax.
+
+“Oh, leave off!” she murmured, fancying she heard Binet’s lathe.
+
+“What’s bothering her?” said the nurse to herself. “Why has she come
+here?”
+
+She had rushed thither; impelled by a kind of horror that drove her from
+her home.
+
+Lying on her back, motionless, and with staring eyes, she saw things but
+vaguely, although she tried to with idiotic persistence. She looked
+at the scales on the walls, two brands smoking end to end, and a long
+spider crawling over her head in a rent in the beam. At last she began
+to collect her thoughts. She remembered--one day--Leon--Oh! how long
+ago that was--the sun was shining on the river, and the clematis were
+perfuming the air. Then, carried away as by a rushing torrent, she soon
+began to recall the day before.
+
+“What time is it?” she asked.
+
+Mere Rollet went out, raised the fingers of her right hand to that side
+of the sky that was brightest, and came back slowly, saying--
+
+“Nearly three.”
+
+“Ah! thanks, thanks!”
+
+For he would come; he would have found some money. But he would,
+perhaps, go down yonder, not guessing she was here, and she told the
+nurse to run to her house to fetch him.
+
+“Be quick!”
+
+“But, my dear lady, I’m going, I’m going!”
+
+She wondered now that she had not thought of him from the first.
+Yesterday he had given his word; he would not break it. And she already
+saw herself at Lheureux’s spreading out her three bank-notes on his
+bureau. Then she would have to invent some story to explain matters to
+Bovary. What should it be?
+
+The nurse, however, was a long while gone. But, as there was no clock
+in the cot, Emma feared she was perhaps exaggerating the length of time.
+She began walking round the garden, step by step; she went into the path
+by the hedge, and returned quickly, hoping that the woman would have
+come back by another road. At last, weary of waiting, assailed by fears
+that she thrust from her, no longer conscious whether she had been here
+a century or a moment, she sat down in a corner, closed her eyes, and
+stopped her ears. The gate grated; she sprang up. Before she had spoken
+Mere Rollet said to her--
+
+“There is no one at your house!”
+
+“What?”
+
+“Oh, no one! And the doctor is crying. He is calling for you; they’re
+looking for you.”
+
+Emma answered nothing. She gasped as she turned her eyes about
+her, while the peasant woman, frightened at her face, drew back
+instinctively, thinking her mad. Suddenly she struck her brow and
+uttered a cry; for the thought of Rodolphe, like a flash of lightning in
+a dark night, had passed into her soul. He was so good, so delicate, so
+generous! And besides, should he hesitate to do her this service, she
+would know well enough how to constrain him to it by re-waking, in a
+single moment, their lost love. So she set out towards La Huchette, not
+seeing that she was hastening to offer herself to that which but a while
+ago had so angered her, not in the least conscious of her prostitution.
+
+
+
+Chapter Eight
+
+She asked herself as she walked along, “What am I going to say? How
+shall I begin?” And as she went on she recognised the thickets,
+the trees, the sea-rushes on the hill, the chateau yonder. All the
+sensations of her first tenderness came back to her, and her poor aching
+heart opened out amorously. A warm wind blew in her face; the melting
+snow fell drop by drop from the buds to the grass.
+
+She entered, as she used to, through the small park-gate. She reached
+the avenue bordered by a double row of dense lime-trees. They were
+swaying their long whispering branches to and fro. The dogs in their
+kennels all barked, and the noise of their voices resounded, but brought
+out no one.
+
+She went up the large straight staircase with wooden balusters that led
+to the corridor paved with dusty flags, into which several doors in a
+row opened, as in a monastery or an inn. His was at the top, right
+at the end, on the left. When she placed her fingers on the lock her
+strength suddenly deserted her. She was afraid, almost wished he
+would not be there, though this was her only hope, her last chance of
+salvation. She collected her thoughts for one moment, and, strengthening
+herself by the feeling of present necessity, went in.
+
+He was in front of the fire, both his feet on the mantelpiece, smoking a
+pipe.
+
+“What! it is you!” he said, getting up hurriedly.
+
+“Yes, it is I, Rodolphe. I should like to ask your advice.”
+
+And, despite all her efforts, it was impossible for her to open her
+lips.
+
+“You have not changed; you are charming as ever!”
+
+“Oh,” she replied bitterly, “they are poor charms since you disdained
+them.”
+
+Then he began a long explanation of his conduct, excusing himself in
+vague terms, in default of being able to invent better.
+
+She yielded to his words, still more to his voice and the sight of him,
+so that, she pretended to believe, or perhaps believed; in the pretext
+he gave for their rupture; this was a secret on which depended the
+honour, the very life of a third person.
+
+“No matter!” she said, looking at him sadly. “I have suffered much.”
+
+He replied philosophically--
+
+“Such is life!”
+
+“Has life,” Emma went on, “been good to you at least, since our
+separation?”
+
+“Oh, neither good nor bad.”
+
+“Perhaps it would have been better never to have parted.”
+
+“Yes, perhaps.”
+
+“You think so?” she said, drawing nearer, and she sighed. “Oh, Rodolphe!
+if you but knew! I loved you so!”
+
+It was then that she took his hand, and they remained some time, their
+fingers intertwined, like that first day at the Show. With a gesture of
+pride he struggled against this emotion. But sinking upon his breast she
+said to him--
+
+“How did you think I could live without you? One cannot lose the habit
+of happiness. I was desolate. I thought I should die. I will tell you
+about all that and you will see. And you--you fled from me!”
+
+For, all the three years, he had carefully avoided her in consequence
+of that natural cowardice that characterises the stronger sex. Emma went
+on, with dainty little nods, more coaxing than an amorous kitten--
+
+“You love others, confess it! Oh, I understand them, dear! I excuse
+them. You probably seduced them as you seduced me. You are indeed a man;
+you have everything to make one love you. But we’ll begin again, won’t
+we? We will love one another. See! I am laughing; I am happy! Oh,
+speak!”
+
+And she was charming to see, with her eyes, in which trembled a tear,
+like the rain of a storm in a blue corolla.
+
+He had drawn her upon his knees, and with the back of his hand was
+caressing her smooth hair, where in the twilight was mirrored like a
+golden arrow one last ray of the sun. She bent down her brow; at last he
+kissed her on the eyelids quite gently with the tips of his lips.
+
+“Why, you have been crying! What for?”
+
+She burst into tears. Rodolphe thought this was an outburst of her
+love. As she did not speak, he took this silence for a last remnant of
+resistance, and then he cried out--
+
+“Oh, forgive me! You are the only one who pleases me. I was imbecile and
+cruel. I love you. I will love you always. What is it. Tell me!” He was
+kneeling by her.
+
+“Well, I am ruined, Rodolphe! You must lend me three thousand francs.”
+
+“But--but--” said he, getting up slowly, while his face assumed a grave
+expression.
+
+“You know,” she went on quickly, “that my husband had placed his whole
+fortune at a notary’s. He ran away. So we borrowed; the patients don’t
+pay us. Moreover, the settling of the estate is not yet done; we shall
+have the money later on. But to-day, for want of three thousand francs,
+we are to be sold up. It is to be at once, this very moment, and,
+counting upon your friendship, I have come to you.”
+
+“Ah!” thought Rodolphe, turning very pale, “that was what she came for.”
+ At last he said with a calm air--
+
+“Dear madame, I have not got them.”
+
+He did not lie. If he had had them, he would, no doubt, have given them,
+although it is generally disagreeable to do such fine things: a demand
+for money being, of all the winds that blow upon love, the coldest and
+most destructive.
+
+First she looked at him for some moments.
+
+“You have not got them!” she repeated several times. “You have not got
+them! I ought to have spared myself this last shame. You never loved me.
+You are no better than the others.”
+
+She was betraying, ruining herself.
+
+Rodolphe interrupted her, declaring he was “hard up” himself.
+
+“Ah! I pity you,” said Emma. “Yes--very much.”
+
+And fixing her eyes upon an embossed carabine, that shone against its
+panoply, “But when one is so poor one doesn’t have silver on the butt of
+one’s gun. One doesn’t buy a clock inlaid with tortoise shell,” she went
+on, pointing to a buhl timepiece, “nor silver-gilt whistles for one’s
+whips,” and she touched them, “nor charms for one’s watch. Oh, he wants
+for nothing! even to a liqueur-stand in his room! For you love yourself;
+you live well. You have a chateau, farms, woods; you go hunting; you
+travel to Paris. Why, if it were but that,” she cried, taking up two
+studs from the mantelpiece, “but the least of these trifles, one can get
+money for them. Oh, I do not want them, keep them!”
+
+And she threw the two links away from her, their gold chain breaking as
+it struck against the wall.
+
+“But I! I would have given you everything. I would have sold all, worked
+for you with my hands, I would have begged on the highroads for a smile,
+for a look, to hear you say ‘Thanks!’ And you sit there quietly in your
+arm-chair, as if you had not made me suffer enough already! But for you,
+and you know it, I might have lived happily. What made you do it? Was
+it a bet? Yet you loved me--you said so. And but a moment since--Ah!
+it would have been better to have driven me away. My hands are hot with
+your kisses, and there is the spot on the carpet where at my knees you
+swore an eternity of love! You made me believe you; for two years you
+held me in the most magnificent, the sweetest dream! Eh! Our plans for
+the journey, do you remember? Oh, your letter! your letter! it tore my
+heart! And then when I come back to him--to him, rich, happy, free--to
+implore the help the first stranger would give, a suppliant, and
+bringing back to him all my tenderness, he repulses me because it would
+cost him three thousand francs!”
+
+“I haven’t got them,” replied Rodolphe, with that perfect calm with
+which resigned rage covers itself as with a shield.
+
+She went out. The walls trembled, the ceiling was crushing her, and she
+passed back through the long alley, stumbling against the heaps of dead
+leaves scattered by the wind. At last she reached the ha-ha hedge in
+front of the gate; she broke her nails against the lock in her haste to
+open it. Then a hundred steps farther on, breathless, almost falling,
+she stopped. And now turning round, she once more saw the impassive
+chateau, with the park, the gardens, the three courts, and all the
+windows of the facade.
+
+She remained lost in stupor, and having no more consciousness of herself
+than through the beating of her arteries, that she seemed to hear
+bursting forth like a deafening music filling all the fields. The earth
+beneath her feet was more yielding than the sea, and the furrows seemed
+to her immense brown waves breaking into foam. Everything in her
+head, of memories, ideas, went off at once like a thousand pieces of
+fireworks. She saw her father, Lheureux’s closet, their room at home,
+another landscape. Madness was coming upon her; she grew afraid, and
+managed to recover herself, in a confused way, it is true, for she did
+not in the least remember the cause of the terrible condition she was
+in, that is to say, the question of money. She suffered only in her
+love, and felt her soul passing from her in this memory; as wounded men,
+dying, feel their life ebb from their bleeding wounds.
+
+Night was falling, crows were flying about.
+
+Suddenly it seemed to her that fiery spheres were exploding in the air
+like fulminating balls when they strike, and were whirling, whirling,
+to melt at last upon the snow between the branches of the trees. In the
+midst of each of them appeared the face of Rodolphe. They multiplied and
+drew near her, penetrating, her. It all disappeared; she recognised the
+lights of the houses that shone through the fog.
+
+Now her situation, like an abyss, rose up before her. She was panting as
+if her heart would burst. Then in an ecstasy of heroism, that made
+her almost joyous, she ran down the hill, crossed the cow-plank, the
+foot-path, the alley, the market, and reached the chemist’s shop. She
+was about to enter, but at the sound of the bell someone might come, and
+slipping in by the gate, holding her breath, feeling her way along the
+walls, she went as far as the door of the kitchen, where a candle stuck
+on the stove was burning. Justin in his shirt-sleeves was carrying out a
+dish.
+
+“Ah! they are dining; I will wait.”
+
+He returned; she tapped at the window. He went out.
+
+“The key! the one for upstairs where he keeps the--”
+
+“What?”
+
+And he looked at her, astonished at the pallor of her face, that stood
+out white against the black background of the night. She seemed to
+him extraordinarily beautiful and majestic as a phantom. Without
+understanding what she wanted, he had the presentiment of something
+terrible.
+
+But she went on quickly in a love voice; in a sweet, melting voice, “I
+want it; give it to me.”
+
+As the partition wall was thin, they could hear the clatter of the forks
+on the plates in the dining-room.
+
+She pretended that she wanted to kill the rats that kept her from
+sleeping.
+
+“I must tell master.”
+
+“No, stay!” Then with an indifferent air, “Oh, it’s not worth while;
+I’ll tell him presently. Come, light me upstairs.”
+
+She entered the corridor into which the laboratory door opened. Against
+the wall was a key labelled Capharnaum.
+
+“Justin!” called the druggist impatiently.
+
+“Let us go up.”
+
+And he followed her. The key turned in the lock, and she went straight
+to the third shelf, so well did her memory guide her, seized the blue
+jar, tore out the cork, plunged in her hand, and withdrawing it full of
+a white powder, she began eating it.
+
+“Stop!” he cried, rushing at her.
+
+“Hush! someone will come.”
+
+He was in despair, was calling out.
+
+“Say nothing, or all the blame will fall on your master.”
+
+Then she went home, suddenly calmed, and with something of the serenity
+of one that had performed a duty.
+
+When Charles, distracted by the news of the distraint, returned home,
+Emma had just gone out. He cried aloud, wept, fainted, but she did not
+return. Where could she be? He sent Felicite to Homais, to Monsieur
+Tuvache, to Lheureux, to the “Lion d’Or,” everywhere, and in the
+intervals of his agony he saw his reputation destroyed, their fortune
+lost, Berthe’s future ruined. By what?--Not a word! He waited till six
+in the evening. At last, unable to bear it any longer, and fancying she
+had gone to Rouen, he set out along the highroad, walked a mile, met no
+one, again waited, and returned home. She had come back.
+
+“What was the matter? Why? Explain to me.”
+
+She sat down at her writing-table and wrote a letter, which she sealed
+slowly, adding the date and the hour. Then she said in a solemn tone:
+
+“You are to read it to-morrow; till then, I pray you, do not ask me a
+single question. No, not one!”
+
+“But--”
+
+“Oh, leave me!”
+
+She lay down full length on her bed. A bitter taste that she felt in her
+mouth awakened her. She saw Charles, and again closed her eyes.
+
+She was studying herself curiously, to see if she were not suffering.
+But no! nothing as yet. She heard the ticking of the clock, the
+crackling of the fire, and Charles breathing as he stood upright by her
+bed.
+
+“Ah! it is but a little thing, death!” she thought. “I shall fall asleep
+and all will be over.”
+
+She drank a mouthful of water and turned to the wall. The frightful
+taste of ink continued.
+
+“I am thirsty; oh! so thirsty,” she sighed.
+
+“What is it?” said Charles, who was handing her a glass.
+
+“It is nothing! Open the window; I am choking.”
+
+She was seized with a sickness so sudden that she had hardly time to
+draw out her handkerchief from under the pillow.
+
+“Take it away,” she said quickly; “throw it away.”
+
+He spoke to her; she did not answer. She lay motionless, afraid that
+the slightest movement might make her vomit. But she felt an icy cold
+creeping from her feet to her heart.
+
+“Ah! it is beginning,” she murmured.
+
+“What did you say?”
+
+She turned her head from side to side with a gentle movement full of
+agony, while constantly opening her mouth as if something very heavy
+were weighing upon her tongue. At eight o’clock the vomiting began
+again.
+
+Charles noticed that at the bottom of the basin there was a sort of
+white sediment sticking to the sides of the porcelain.
+
+“This is extraordinary--very singular,” he repeated.
+
+But she said in a firm voice, “No, you are mistaken.”
+
+Then gently, and almost as caressing her, he passed his hand over her
+stomach. She uttered a sharp cry. He fell back terror-stricken.
+
+Then she began to groan, faintly at first. Her shoulders were shaken by
+a strong shuddering, and she was growing paler than the sheets in which
+her clenched fingers buried themselves. Her unequal pulse was now almost
+imperceptible.
+
+Drops of sweat oozed from her bluish face, that seemed as if rigid in
+the exhalations of a metallic vapour. Her teeth chattered, her dilated
+eyes looked vaguely about her, and to all questions she replied only
+with a shake of the head; she even smiled once or twice. Gradually, her
+moaning grew louder; a hollow shriek burst from her; she pretended she
+was better and that she would get up presently. But she was seized with
+convulsions and cried out--
+
+“Ah! my God! It is horrible!”
+
+He threw himself on his knees by her bed.
+
+“Tell me! what have you eaten? Answer, for heaven’s sake!”
+
+And he looked at her with a tenderness in his eyes such as she had never
+seen.
+
+“Well, there--there!” she said in a faint voice. He flew to the
+writing-table, tore open the seal, and read aloud: “Accuse no one.” He
+stopped, passed his hands across his eyes, and read it over again.
+
+“What! help--help!”
+
+He could only keep repeating the word: “Poisoned! poisoned!” Felicite
+ran to Homais, who proclaimed it in the market-place; Madame Lefrancois
+heard it at the “Lion d’Or”; some got up to go and tell their
+neighbours, and all night the village was on the alert.
+
+Distraught, faltering, reeling, Charles wandered about the room. He
+knocked against the furniture, tore his hair, and the chemist had never
+believed that there could be so terrible a sight.
+
+He went home to write to Monsieur Canivet and to Doctor Lariviere. He
+lost his head, and made more than fifteen rough copies. Hippolyte went
+to Neufchatel, and Justin so spurred Bovary’s horse that he left it
+foundered and three parts dead by the hill at Bois-Guillaume.
+
+Charles tried to look up his medical dictionary, but could not read it;
+the lines were dancing.
+
+“Be calm,” said the druggist; “we have only to administer a powerful
+antidote. What is the poison?”
+
+Charles showed him the letter. It was arsenic.
+
+“Very well,” said Homais, “we must make an analysis.”
+
+For he knew that in cases of poisoning an analysis must be made; and the
+other, who did not understand, answered--
+
+“Oh, do anything! save her!”
+
+Then going back to her, he sank upon the carpet, and lay there with his
+head leaning against the edge of her bed, sobbing.
+
+“Don’t cry,” she said to him. “Soon I shall not trouble you any more.”
+
+“Why was it? Who drove you to it?”
+
+She replied. “It had to be, my dear!”
+
+“Weren’t you happy? Is it my fault? I did all I could!”
+
+“Yes, that is true--you are good--you.”
+
+And she passed her hand slowly over his hair. The sweetness of this
+sensation deepened his sadness; he felt his whole being dissolving
+in despair at the thought that he must lose her, just when she was
+confessing more love for him than ever. And he could think of nothing;
+he did not know, he did not dare; the urgent need for some immediate
+resolution gave the finishing stroke to the turmoil of his mind.
+
+So she had done, she thought, with all the treachery; and meanness,
+and numberless desires that had tortured her. She hated no one now; a
+twilight dimness was settling upon her thoughts, and, of all earthly
+noises, Emma heard none but the intermittent lamentations of this poor
+heart, sweet and indistinct like the echo of a symphony dying away.
+
+“Bring me the child,” she said, raising herself on her elbow.
+
+“You are not worse, are you?” asked Charles.
+
+“No, no!”
+
+The child, serious, and still half-asleep, was carried in on the
+servant’s arm in her long white nightgown, from which her bare
+feet peeped out. She looked wonderingly at the disordered room, and
+half-closed her eyes, dazzled by the candles burning on the table. They
+reminded her, no doubt, of the morning of New Year’s day and Mid-Lent,
+when thus awakened early by candle-light she came to her mother’s bed to
+fetch her presents, for she began saying--
+
+“But where is it, mamma?” And as everybody was silent, “But I can’t see
+my little stocking.”
+
+Felicite held her over the bed while she still kept looking towards the
+mantelpiece.
+
+“Has nurse taken it?” she asked.
+
+And at this name, that carried her back to the memory of her adulteries
+and her calamities, Madame Bovary turned away her head, as at the
+loathing of another bitterer poison that rose to her mouth. But Berthe
+remained perched on the bed.
+
+“Oh, how big your eyes are, mamma! How pale you are! how hot you are!”
+
+Her mother looked at her. “I am frightened!” cried the child, recoiling.
+
+Emma took her hand to kiss it; the child struggled.
+
+“That will do. Take her away,” cried Charles, who was sobbing in the
+alcove.
+
+Then the symptoms ceased for a moment; she seemed less agitated; and at
+every insignificant word, at every respiration a little more easy, he
+regained hope. At last, when Canivet came in, he threw himself into his
+arms.
+
+“Ah! it is you. Thanks! You are good! But she is better. See! look at
+her.”
+
+His colleague was by no means of this opinion, and, as he said of
+himself, “never beating about the bush,” he prescribed, an emetic in
+order to empty the stomach completely.
+
+She soon began vomiting blood. Her lips became drawn. Her limbs were
+convulsed, her whole body covered with brown spots, and her pulse
+slipped beneath the fingers like a stretched thread, like a harp-string
+nearly breaking.
+
+After this she began to scream horribly. She cursed the poison, railed
+at it, and implored it to be quick, and thrust away with her stiffened
+arms everything that Charles, in more agony than herself, tried to make
+her drink. He stood up, his handkerchief to his lips, with a rattling
+sound in his throat, weeping, and choked by sobs that shook his whole
+body. Felicite was running hither and thither in the room. Homais,
+motionless, uttered great sighs; and Monsieur Canivet, always retaining
+his self-command, nevertheless began to feel uneasy.
+
+“The devil! yet she has been purged, and from the moment that the cause
+ceases--”
+
+“The effect must cease,” said Homais, “that is evident.”
+
+“Oh, save her!” cried Bovary.
+
+And, without listening to the chemist, who was still venturing the
+hypothesis, “It is perhaps a salutary paroxysm,” Canivet was about to
+administer some theriac, when they heard the cracking of a whip; all the
+windows rattled, and a post-chaise drawn by three horses abreast, up to
+their ears in mud, drove at a gallop round the corner of the market. It
+was Doctor Lariviere.
+
+The apparition of a god would not have caused more commotion. Bovary
+raised his hands; Canivet stopped short; and Homais pulled off his
+skull-cap long before the doctor had come in.
+
+He belonged to that great school of surgery begotten of Bichat, to that
+generation, now extinct, of philosophical practitioners, who, loving
+their art with a fanatical love, exercised it with enthusiasm and
+wisdom. Everyone in his hospital trembled when he was angry; and his
+students so revered him that they tried, as soon as they were themselves
+in practice, to imitate him as much as possible. So that in all the
+towns about they were found wearing his long wadded merino overcoat
+and black frock-coat, whose buttoned cuffs slightly covered his brawny
+hands--very beautiful hands, and that never knew gloves, as though to be
+more ready to plunge into suffering. Disdainful of honours, of titles,
+and of academies, like one of the old Knight-Hospitallers, generous,
+fatherly to the poor, and practising virtue without believing in it, he
+would almost have passed for a saint if the keenness of his intellect
+had not caused him to be feared as a demon. His glance, more penetrating
+than his bistouries, looked straight into your soul, and dissected every
+lie athwart all assertions and all reticences. And thus he went along,
+full of that debonair majesty that is given by the consciousness
+of great talent, of fortune, and of forty years of a labourious and
+irreproachable life.
+
+He frowned as soon as he had passed the door when he saw the cadaverous
+face of Emma stretched out on her back with her mouth open. Then, while
+apparently listening to Canivet, he rubbed his fingers up and down
+beneath his nostrils, and repeated--
+
+“Good! good!”
+
+But he made a slow gesture with his shoulders. Bovary watched him; they
+looked at one another; and this man, accustomed as he was to the sight
+of pain, could not keep back a tear that fell on his shirt-frill.
+
+He tried to take Canivet into the next room. Charles followed him.
+
+“She is very ill, isn’t she? If we put on sinapisms? Anything! Oh, think
+of something, you who have saved so many!”
+
+Charles caught him in both his arms, and gazed at him wildly,
+imploringly, half-fainting against his breast.
+
+“Come, my poor fellow, courage! There is nothing more to be done.”
+
+And Doctor Lariviere turned away.
+
+“You are going?”
+
+“I will come back.”
+
+He went out only to give an order to the coachman, with Monsieur
+Canivet, who did not care either to have Emma die under his hands.
+
+The chemist rejoined them on the Place. He could not by temperament keep
+away from celebrities, so he begged Monsieur Lariviere to do him the
+signal honour of accepting some breakfast.
+
+He sent quickly to the “Lion d’Or” for some pigeons; to the butcher’s
+for all the cutlets that were to be had; to Tuvache for cream; and
+to Lestiboudois for eggs; and the druggist himself aided in the
+preparations, while Madame Homais was saying as she pulled together the
+strings of her jacket--
+
+“You must excuse us, sir, for in this poor place, when one hasn’t been
+told the night before--”
+
+“Wine glasses!” whispered Homais.
+
+“If only we were in town, we could fall back upon stuffed trotters.”
+
+“Be quiet! Sit down, doctor!”
+
+He thought fit, after the first few mouthfuls, to give some details as
+to the catastrophe.
+
+“We first had a feeling of siccity in the pharynx, then intolerable
+pains at the epigastrium, super purgation, coma.”
+
+“But how did she poison herself?”
+
+“I don’t know, doctor, and I don’t even know where she can have procured
+the arsenious acid.”
+
+Justin, who was just bringing in a pile of plates, began to tremble.
+
+“What’s the matter?” said the chemist.
+
+At this question the young man dropped the whole lot on the ground with
+a crash.
+
+“Imbecile!” cried Homais, “awkward lout! block-head! confounded ass!”
+
+But suddenly controlling himself--
+
+“I wished, doctor, to make an analysis, and primo I delicately
+introduced a tube--”
+
+“You would have done better,” said the physician, “to introduce your
+fingers into her throat.”
+
+His colleague was silent, having just before privately received a severe
+lecture about his emetic, so that this good Canivet, so arrogant and so
+verbose at the time of the clubfoot, was to-day very modest. He smiled
+without ceasing in an approving manner.
+
+Homais dilated in Amphytrionic pride, and the affecting thought of
+Bovary vaguely contributed to his pleasure by a kind of egotistic
+reflex upon himself. Then the presence of the doctor transported him.
+He displayed his erudition, cited pell-mell cantharides, upas, the
+manchineel, vipers.
+
+“I have even read that various persons have found themselves
+under toxicological symptoms, and, as it were, thunderstricken by
+black-pudding that had been subjected to a too vehement fumigation.
+At least, this was stated in a very fine report drawn up by one of our
+pharmaceutical chiefs, one of our masters, the illustrious Cadet de
+Gassicourt!”
+
+Madame Homais reappeared, carrying one of those shaky machines that
+are heated with spirits of wine; for Homais liked to make his coffee
+at table, having, moreover, torrefied it, pulverised it, and mixed it
+himself.
+
+“Saccharum, doctor?” said he, offering the sugar.
+
+Then he had all his children brought down, anxious to have the
+physician’s opinion on their constitutions.
+
+At last Monsieur Lariviere was about to leave, when Madame Homais asked
+for a consultation about her husband. He was making his blood too thick
+by going to sleep every evening after dinner.
+
+“Oh, it isn’t his blood that’s too thick,” said the physician.
+
+And, smiling a little at his unnoticed joke, the doctor opened the
+door. But the chemist’s shop was full of people; he had the greatest
+difficulty in getting rid of Monsieur Tuvache, who feared his spouse
+would get inflammation of the lungs, because she was in the habit of
+spitting on the ashes; then of Monsieur Binet, who sometimes experienced
+sudden attacks of great hunger; and of Madame Caron, who suffered
+from tinglings; of Lheureux, who had vertigo; of Lestiboudois, who had
+rheumatism; and of Madame Lefrancois, who had heartburn. At last the
+three horses started; and it was the general opinion that he had not
+shown himself at all obliging.
+
+Public attention was distracted by the appearance of Monsieur
+Bournisien, who was going across the market with the holy oil.
+
+Homais, as was due to his principles, compared priests to ravens
+attracted by the odour of death. The sight of an ecclesiastic was
+personally disagreeable to him, for the cassock made him think of the
+shroud, and he detested the one from some fear of the other.
+
+Nevertheless, not shrinking from what he called his mission, he returned
+to Bovary’s in company with Canivet whom Monsieur Lariviere, before
+leaving, had strongly urged to make this visit; and he would, but for
+his wife’s objections, have taken his two sons with him, in order
+to accustom them to great occasions; that this might be a lesson, an
+example, a solemn picture, that should remain in their heads later on.
+
+The room when they went in was full of mournful solemnity. On the
+work-table, covered over with a white cloth, there were five or six
+small balls of cotton in a silver dish, near a large crucifix between
+two lighted candles.
+
+Emma, her chin sunken upon her breast, had her eyes inordinately wide
+open, and her poor hands wandered over the sheets with that hideous
+and soft movement of the dying, that seems as if they wanted already to
+cover themselves with the shroud. Pale as a statue and with eyes red as
+fire, Charles, not weeping, stood opposite her at the foot of the bed,
+while the priest, bending one knee, was muttering words in a low voice.
+
+She turned her face slowly, and seemed filled with joy on seeing
+suddenly the violet stole, no doubt finding again, in the midst of
+a temporary lull in her pain, the lost voluptuousness of her first
+mystical transports, with the visions of eternal beatitude that were
+beginning.
+
+The priest rose to take the crucifix; then she stretched forward her
+neck as one who is athirst, and glueing her lips to the body of the
+Man-God, she pressed upon it with all her expiring strength the fullest
+kiss of love that she had ever given. Then he recited the Misereatur and
+the Indulgentiam, dipped his right thumb in the oil, and began to give
+extreme unction. First upon the eyes, that had so coveted all worldly
+pomp; then upon the nostrils, that had been greedy of the warm breeze
+and amorous odours; then upon the mouth, that had uttered lies, that had
+curled with pride and cried out in lewdness; then upon the hands that
+had delighted in sensual touches; and finally upon the soles of the
+feet, so swift of yore, when she was running to satisfy her desires, and
+that would now walk no more.
+
+The cure wiped his fingers, threw the bit of cotton dipped in oil into
+the fire, and came and sat down by the dying woman, to tell her that
+she must now blend her sufferings with those of Jesus Christ and abandon
+herself to the divine mercy.
+
+Finishing his exhortations, he tried to place in her hand a blessed
+candle, symbol of the celestial glory with which she was soon to be
+surrounded. Emma, too weak, could not close her fingers, and the taper,
+but for Monsieur Bournisien would have fallen to the ground.
+
+However, she was not quite so pale, and her face had an expression of
+serenity as if the sacrament had cured her.
+
+The priest did not fail to point this out; he even explained to Bovary
+that the Lord sometimes prolonged the life of persons when he thought it
+meet for their salvation; and Charles remembered the day when, so near
+death, she had received the communion. Perhaps there was no need to
+despair, he thought.
+
+In fact, she looked around her slowly, as one awakening from a dream;
+then in a distinct voice she asked for her looking-glass, and remained
+some time bending over it, until the big tears fell from her eyes. Then
+she turned away her head with a sigh and fell back upon the pillows.
+
+Her chest soon began panting rapidly; the whole of her tongue protruded
+from her mouth; her eyes, as they rolled, grew paler, like the two
+globes of a lamp that is going out, so that one might have thought
+her already dead but for the fearful labouring of her ribs, shaken
+by violent breathing, as if the soul were struggling to free itself.
+Felicite knelt down before the crucifix, and the druggist himself
+slightly bent his knees, while Monsieur Canivet looked out vaguely at
+the Place. Bournisien had again begun to pray, his face bowed against
+the edge of the bed, his long black cassock trailing behind him in the
+room. Charles was on the other side, on his knees, his arms outstretched
+towards Emma. He had taken her hands and pressed them, shuddering at
+every beat of her heart, as at the shaking of a falling ruin. As the
+death-rattle became stronger the priest prayed faster; his prayers
+mingled with the stifled sobs of Bovary, and sometimes all seemed lost
+in the muffled murmur of the Latin syllables that tolled like a passing
+bell.
+
+Suddenly on the pavement was heard a loud noise of clogs and the
+clattering of a stick; and a voice rose--a raucous voice--that sang--
+
+“Maids in the warmth of a summer day Dream of love and of love always”
+
+Emma raised herself like a galvanised corpse, her hair undone, her eyes
+fixed, staring.
+
+“Where the sickle blades have been, Nannette, gathering ears of corn,
+Passes bending down, my queen, To the earth where they were born.”
+
+“The blind man!” she cried. And Emma began to laugh, an atrocious,
+frantic, despairing laugh, thinking she saw the hideous face of the poor
+wretch that stood out against the eternal night like a menace.
+
+“The wind is strong this summer day, Her petticoat has flown away.”
+
+She fell back upon the mattress in a convulsion. They all drew near. She
+was dead.
+
+
+
+Chapter Nine
+
+There is always after the death of anyone a kind of stupefaction;
+so difficult is it to grasp this advent of nothingness and to resign
+ourselves to believe in it. But still, when he saw that she did not
+move, Charles threw himself upon her, crying--
+
+“Farewell! farewell!”
+
+Homais and Canivet dragged him from the room.
+
+“Restrain yourself!”
+
+“Yes.” said he, struggling, “I’ll be quiet. I’ll not do anything. But
+leave me alone. I want to see her. She is my wife!”
+
+And he wept.
+
+“Cry,” said the chemist; “let nature take her course; that will solace
+you.”
+
+Weaker than a child, Charles let himself be led downstairs into the
+sitting-room, and Monsieur Homais soon went home. On the Place he
+was accosted by the blind man, who, having dragged himself as far as
+Yonville, in the hope of getting the antiphlogistic pomade, was asking
+every passer-by where the druggist lived.
+
+“There now! as if I hadn’t got other fish to fry. Well, so much the
+worse; you must come later on.”
+
+And he entered the shop hurriedly.
+
+He had to write two letters, to prepare a soothing potion for Bovary, to
+invent some lie that would conceal the poisoning, and work it up into an
+article for the “Fanal,” without counting the people who were waiting to
+get the news from him; and when the Yonvillers had all heard his story
+of the arsenic that she had mistaken for sugar in making a vanilla
+cream. Homais once more returned to Bovary’s.
+
+He found him alone (Monsieur Canivet had left), sitting in an arm-chair
+near the window, staring with an idiotic look at the flags of the floor.
+
+“Now,” said the chemist, “you ought yourself to fix the hour for the
+ceremony.”
+
+“Why? What ceremony?” Then, in a stammering, frightened voice, “Oh, no!
+not that. No! I want to see her here.”
+
+Homais, to keep himself in countenance, took up a water-bottle on the
+whatnot to water the geraniums.
+
+“Ah! thanks,” said Charles; “you are good.”
+
+But he did not finish, choking beneath the crowd of memories that this
+action of the druggist recalled to him.
+
+Then to distract him, Homais thought fit to talk a little horticulture:
+plants wanted humidity. Charles bowed his head in sign of approbation.
+
+“Besides, the fine days will soon be here again.”
+
+“Ah!” said Bovary.
+
+The druggist, at his wit’s end, began softly to draw aside the small
+window-curtain.
+
+“Hallo! there’s Monsieur Tuvache passing.”
+
+Charles repeated like a machine---
+
+“Monsieur Tuvache passing!”
+
+Homais did not dare to speak to him again about the funeral
+arrangements; it was the priest who succeeded in reconciling him to
+them.
+
+He shut himself up in his consulting-room, took a pen, and after sobbing
+for some time, wrote--
+
+“I wish her to be buried in her wedding-dress, with white shoes, and a
+wreath. Her hair is to be spread out over her shoulders. Three coffins,
+one of oak, one of mahogany, one of lead. Let no one say anything to me.
+I shall have strength. Over all there is to be placed a large piece of
+green velvet. This is my wish; see that it is done.”
+
+The two men were much surprised at Bovary’s romantic ideas. The chemist
+at once went to him and said--
+
+“This velvet seems to me a superfetation. Besides, the expense--”
+
+“What’s that to you?” cried Charles. “Leave me! You did not love her.
+Go!”
+
+The priest took him by the arm for a turn in the garden. He discoursed
+on the vanity of earthly things. God was very great, was very good: one
+must submit to his decrees without a murmur; nay, must even thank him.
+
+Charles burst out into blasphemies: “I hate your God!”
+
+“The spirit of rebellion is still upon you,” sighed the ecclesiastic.
+
+Bovary was far away. He was walking with great strides along by the
+wall, near the espalier, and he ground his teeth; he raised to heaven
+looks of malediction, but not so much as a leaf stirred.
+
+A fine rain was falling: Charles, whose chest was bare, at last began to
+shiver; he went in and sat down in the kitchen.
+
+At six o’clock a noise like a clatter of old iron was heard on the
+Place; it was the “Hirondelle” coming in, and he remained with his
+forehead against the windowpane, watching all the passengers get
+out, one after the other. Felicite put down a mattress for him in the
+drawing-room. He threw himself upon it and fell asleep.
+
+Although a philosopher, Monsieur Homais respected the dead. So bearing
+no grudge to poor Charles, he came back again in the evening to sit up
+with the body; bringing with him three volumes and a pocket-book for
+taking notes.
+
+Monsieur Bournisien was there, and two large candles were burning at the
+head of the bed, that had been taken out of the alcove. The druggist, on
+whom the silence weighed, was not long before he began formulating some
+regrets about this “unfortunate young woman.” and the priest replied
+that there was nothing to do now but pray for her.
+
+“Yet,” Homais went on, “one of two things; either she died in a state of
+grace (as the Church has it), and then she has no need of our prayers;
+or else she departed impertinent (that is, I believe, the ecclesiastical
+expression), and then--”
+
+Bournisien interrupted him, replying testily that it was none the less
+necessary to pray.
+
+“But,” objected the chemist, “since God knows all our needs, what can be
+the good of prayer?”
+
+“What!” cried the ecclesiastic, “prayer! Why, aren’t you a Christian?”
+
+“Excuse me,” said Homais; “I admire Christianity. To begin with, it
+enfranchised the slaves, introduced into the world a morality--”
+
+“That isn’t the question. All the texts-”
+
+“Oh! oh! As to texts, look at history; it, is known that all the texts
+have been falsified by the Jesuits.”
+
+Charles came in, and advancing towards the bed, slowly drew the
+curtains.
+
+Emma’s head was turned towards her right shoulder, the corner of her
+mouth, which was open, seemed like a black hole at the lower part of her
+face; her two thumbs were bent into the palms of her hands; a kind
+of white dust besprinkled her lashes, and her eyes were beginning to
+disappear in that viscous pallor that looks like a thin web, as if
+spiders had spun it over. The sheet sunk in from her breast to her
+knees, and then rose at the tips of her toes, and it seemed to Charles
+that infinite masses, an enormous load, were weighing upon her.
+
+The church clock struck two. They could hear the loud murmur of the
+river flowing in the darkness at the foot of the terrace. Monsieur
+Bournisien from time to time blew his nose noisily, and Homais’ pen was
+scratching over the paper.
+
+“Come, my good friend,” he said, “withdraw; this spectacle is tearing
+you to pieces.”
+
+Charles once gone, the chemist and the cure recommenced their
+discussions.
+
+“Read Voltaire,” said the one, “read D’Holbach, read the
+‘Encyclopaedia’!”
+
+“Read the ‘Letters of some Portuguese Jews,’” said the other; “read ‘The
+Meaning of Christianity,’ by Nicolas, formerly a magistrate.”
+
+They grew warm, they grew red, they both talked at once without
+listening to each other. Bournisien was scandalized at such audacity;
+Homais marvelled at such stupidity; and they were on the point of
+insulting one another when Charles suddenly reappeared. A fascination
+drew him. He was continually coming upstairs.
+
+He stood opposite her, the better to see her, and he lost himself in a
+contemplation so deep that it was no longer painful.
+
+He recalled stories of catalepsy, the marvels of magnetism, and he
+said to himself that by willing it with all his force he might perhaps
+succeed in reviving her. Once he even bent towards he, and cried in a
+low voice, “Emma! Emma!” His strong breathing made the flames of the
+candles tremble against the wall.
+
+At daybreak Madame Bovary senior arrived. Charles as he embraced her
+burst into another flood of tears. She tried, as the chemist had done,
+to make some remarks to him on the expenses of the funeral. He became so
+angry that she was silent, and he even commissioned her to go to town at
+once and buy what was necessary.
+
+Charles remained alone the whole afternoon; they had taken Berthe
+to Madame Homais’; Felicite was in the room upstairs with Madame
+Lefrancois.
+
+In the evening he had some visitors. He rose, pressed their hands,
+unable to speak. Then they sat down near one another, and formed a large
+semicircle in front of the fire. With lowered faces, and swinging one
+leg crossed over the other knee, they uttered deep sighs at intervals;
+each one was inordinately bored, and yet none would be the first to go.
+
+Homais, when he returned at nine o’clock (for the last two days only
+Homais seemed to have been on the Place), was laden with a stock of
+camphor, of benzine, and aromatic herbs. He also carried a large jar
+full of chlorine water, to keep off all miasmata. Just then the servant,
+Madame Lefrancois, and Madame Bovary senior were busy about Emma,
+finishing dressing her, and they were drawing down the long stiff veil
+that covered her to her satin shoes.
+
+Felicite was sobbing--“Ah! my poor mistress! my poor mistress!”
+
+“Look at her,” said the landlady, sighing; “how pretty she still is!
+Now, couldn’t you swear she was going to get up in a minute?”
+
+Then they bent over her to put on her wreath. They had to raise the head
+a little, and a rush of black liquid issued, as if she were vomiting,
+from her mouth.
+
+“Oh, goodness! The dress; take care!” cried Madame Lefrancois. “Now,
+just come and help,” she said to the chemist. “Perhaps you’re afraid?”
+
+“I afraid?” replied he, shrugging his shoulders. “I dare say! I’ve seen
+all sorts of things at the hospital when I was studying pharmacy. We
+used to make punch in the dissecting room! Nothingness does not terrify
+a philosopher; and, as I often say, I even intend to leave my body to
+the hospitals, in order, later on, to serve science.”
+
+The cure on his arrival inquired how Monsieur Bovary was, and, on
+the reply of the druggist, went on--“The blow, you see, is still too
+recent.”
+
+Then Homais congratulated him on not being exposed, like other people,
+to the loss of a beloved companion; whence there followed a discussion
+on the celibacy of priests.
+
+“For,” said the chemist, “it is unnatural that a man should do without
+women! There have been crimes--”
+
+“But, good heaven!” cried the ecclesiastic, “how do you expect an
+individual who is married to keep the secrets of the confessional, for
+example?”
+
+Homais fell foul of the confessional. Bournisien defended it; he
+enlarged on the acts of restitution that it brought about. He cited
+various anecdotes about thieves who had suddenly become honest. Military
+men on approaching the tribunal of penitence had felt the scales fall
+from their eyes. At Fribourg there was a minister--
+
+His companion was asleep. Then he felt somewhat stifled by the
+over-heavy atmosphere of the room; he opened the window; this awoke the
+chemist.
+
+“Come, take a pinch of snuff,” he said to him. “Take it; it’ll relieve
+you.”
+
+A continual barking was heard in the distance. “Do you hear that dog
+howling?” said the chemist.
+
+“They smell the dead,” replied the priest. “It’s like bees; they leave
+their hives on the decease of any person.”
+
+Homais made no remark upon these prejudices, for he had again dropped
+asleep. Monsieur Bournisien, stronger than he, went on moving his lips
+gently for some time, then insensibly his chin sank down, he let fall
+his big black boot, and began to snore.
+
+They sat opposite one another, with protruding stomachs, puffed-up
+faces, and frowning looks, after so much disagreement uniting at last in
+the same human weakness, and they moved no more than the corpse by their
+side, that seemed to be sleeping.
+
+Charles coming in did not wake them. It was the last time; he came to
+bid her farewell.
+
+The aromatic herbs were still smoking, and spirals of bluish vapour
+blended at the window-sash with the fog that was coming in. There were
+few stars, and the night was warm. The wax of the candles fell in great
+drops upon the sheets of the bed. Charles watched them burn, tiring his
+eyes against the glare of their yellow flame.
+
+The watering on the satin gown shimmered white as moonlight. Emma was
+lost beneath it; and it seemed to him that, spreading beyond her own
+self, she blended confusedly with everything around her--the silence,
+the night, the passing wind, the damp odours rising from the ground.
+
+Then suddenly he saw her in the garden at Tostes, on a bench against the
+thorn hedge, or else at Rouen in the streets, on the threshold of their
+house, in the yard at Bertaux. He again heard the laughter of the happy
+boys beneath the apple-trees: the room was filled with the perfume
+of her hair; and her dress rustled in his arms with a noise like
+electricity. The dress was still the same.
+
+For a long while he thus recalled all his lost joys, her attitudes,
+her movements, the sound of her voice. Upon one fit of despair followed
+another, and even others, inexhaustible as the waves of an overflowing
+sea.
+
+A terrible curiosity seized him. Slowly, with the tips of his fingers,
+palpitating, he lifted her veil. But he uttered a cry of horror that
+awoke the other two.
+
+They dragged him down into the sitting-room. Then Felicite came up to
+say that he wanted some of her hair.
+
+“Cut some off,” replied the druggist.
+
+And as she did not dare to, he himself stepped forward, scissors in
+hand. He trembled so that he pierced the skin of the temple in several
+places. At last, stiffening himself against emotion, Homais gave two
+or three great cuts at random that left white patches amongst that
+beautiful black hair.
+
+The chemist and the cure plunged anew into their occupations, not
+without sleeping from time to time, of which they accused each other
+reciprocally at each fresh awakening. Then Monsieur Bournisien sprinkled
+the room with holy water and Homais threw a little chlorine water on the
+floor.
+
+Felicite had taken care to put on the chest of drawers, for each
+of them, a bottle of brandy, some cheese, and a large roll. And the
+druggist, who could not hold out any longer, about four in the morning
+sighed--
+
+“My word! I should like to take some sustenance.”
+
+The priest did not need any persuading; he went out to go and say mass,
+came back, and then they ate and hobnobbed, giggling a little without
+knowing why, stimulated by that vague gaiety that comes upon us after
+times of sadness, and at the last glass the priest said to the druggist,
+as he clapped him on the shoulder--
+
+“We shall end by understanding one another.”
+
+In the passage downstairs they met the undertaker’s men, who were coming
+in. Then Charles for two hours had to suffer the torture of hearing the
+hammer resound against the wood. Next day they lowered her into her
+oak coffin, that was fitted into the other two; but as the bier was
+too large, they had to fill up the gaps with the wool of a mattress. At
+last, when the three lids had been planed down, nailed, soldered, it was
+placed outside in front of the door; the house was thrown open, and the
+people of Yonville began to flock round.
+
+Old Rouault arrived, and fainted on the Place when he saw the black
+cloth!
+
+
+
+Chapter Ten
+
+He had only received the chemist’s letter thirty-six hours after the
+event; and, from consideration for his feelings, Homais had so worded it
+that it was impossible to make out what it was all about.
+
+First, the old fellow had fallen as if struck by apoplexy. Next, he
+understood that she was not dead, but she might be. At last, he had put
+on his blouse, taken his hat, fastened his spurs to his boots, and set
+out at full speed; and the whole of the way old Rouault, panting, was
+torn by anguish. Once even he was obliged to dismount. He was dizzy; he
+heard voices round about him; he felt himself going mad.
+
+Day broke. He saw three black hens asleep in a tree. He shuddered,
+horrified at this omen. Then he promised the Holy Virgin three chasubles
+for the church, and that he would go barefooted from the cemetery at
+Bertaux to the chapel of Vassonville.
+
+He entered Maromme shouting for the people of the inn, burst open the
+door with a thrust of his shoulder, made for a sack of oats, emptied a
+bottle of sweet cider into the manger, and again mounted his nag, whose
+feet struck fire as it dashed along.
+
+He said to himself that no doubt they would save her; the doctors would
+discover some remedy surely. He remembered all the miraculous cures
+he had been told about. Then she appeared to him dead. She was there;
+before his eyes, lying on her back in the middle of the road. He reined
+up, and the hallucination disappeared.
+
+At Quincampoix, to give himself heart, he drank three cups of coffee
+one after the other. He fancied they had made a mistake in the name in
+writing. He looked for the letter in his pocket, felt it there, but did
+not dare to open it.
+
+At last he began to think it was all a joke; someone’s spite, the jest
+of some wag; and besides, if she were dead, one would have known it. But
+no! There was nothing extraordinary about the country; the sky was blue,
+the trees swayed; a flock of sheep passed. He saw the village; he was
+seen coming bending forward upon his horse, belabouring it with great
+blows, the girths dripping with blood.
+
+When he had recovered consciousness, he fell, weeping, into Bovary’s
+arms: “My girl! Emma! my child! tell me--”
+
+The other replied, sobbing, “I don’t know! I don’t know! It’s a curse!”
+
+The druggist separated them. “These horrible details are useless. I will
+tell this gentleman all about it. Here are the people coming. Dignity!
+Come now! Philosophy!”
+
+The poor fellow tried to show himself brave, and repeated several times.
+“Yes! courage!”
+
+“Oh,” cried the old man, “so I will have, by God! I’ll go along o’ her
+to the end!”
+
+The bell began tolling. All was ready; they had to start. And seated in
+a stall of the choir, side by side, they saw pass and repass in front of
+them continually the three chanting choristers.
+
+The serpent-player was blowing with all his might. Monsieur Bournisien,
+in full vestments, was singing in a shrill voice. He bowed before the
+tabernacle, raising his hands, stretched out his arms. Lestiboudois
+went about the church with his whalebone stick. The bier stood near the
+lectern, between four rows of candles. Charles felt inclined to get up
+and put them out.
+
+Yet he tried to stir himself to a feeling of devotion, to throw himself
+into the hope of a future life in which he should see her again. He
+imagined to himself she had gone on a long journey, far away, for a long
+time. But when he thought of her lying there, and that all was over,
+that they would lay her in the earth, he was seized with a fierce,
+gloomy, despairful rage. At times he thought he felt nothing more, and
+he enjoyed this lull in his pain, whilst at the same time he reproached
+himself for being a wretch.
+
+The sharp noise of an iron-ferruled stick was heard on the stones,
+striking them at irregular intervals. It came from the end of the
+church, and stopped short at the lower aisles. A man in a coarse brown
+jacket knelt down painfully. It was Hippolyte, the stable-boy at the
+“Lion d’Or.” He had put on his new leg.
+
+One of the choristers went round the nave making a collection, and the
+coppers chinked one after the other on the silver plate.
+
+“Oh, make haste! I am in pain!” cried Bovary, angrily throwing him a
+five-franc piece. The churchman thanked him with a deep bow.
+
+They sang, they knelt, they stood up; it was endless! He remembered that
+once, in the early times, they had been to mass together, and they had
+sat down on the other side, on the right, by the wall. The bell began
+again. There was a great moving of chairs; the bearers slipped their
+three staves under the coffin, and everyone left the church.
+
+Then Justin appeared at the door of the shop. He suddenly went in again,
+pale, staggering.
+
+People were at the windows to see the procession pass. Charles at the
+head walked erect. He affected a brave air, and saluted with a nod those
+who, coming out from the lanes or from their doors, stood amidst the
+crowd.
+
+The six men, three on either side, walked slowly, panting a little.
+The priests, the choristers, and the two choirboys recited the De
+profundis*, and their voices echoed over the fields, rising and falling
+with their undulations. Sometimes they disappeared in the windings of
+the path; but the great silver cross rose always before the trees.
+
+     *Psalm CXXX.
+
+
+The women followed in black cloaks with turned-down hoods; each of them
+carried in her hands a large lighted candle, and Charles felt himself
+growing weaker at this continual repetition of prayers and torches,
+beneath this oppressive odour of wax and of cassocks. A fresh breeze was
+blowing; the rye and colza were sprouting, little dewdrops trembled at
+the roadsides and on the hawthorn hedges. All sorts of joyous sounds
+filled the air; the jolting of a cart rolling afar off in the ruts, the
+crowing of a cock, repeated again and again, or the gambling of a foal
+running away under the apple-trees: The pure sky was fretted with rosy
+clouds; a bluish haze rested upon the cots covered with iris. Charles as
+he passed recognised each courtyard. He remembered mornings like this,
+when, after visiting some patient, he came out from one and returned to
+her.
+
+The black cloth bestrewn with white beads blew up from time to time,
+laying bare the coffin. The tired bearers walked more slowly, and it
+advanced with constant jerks, like a boat that pitches with every wave.
+
+They reached the cemetery. The men went right down to a place in the
+grass where a grave was dug. They ranged themselves all round; and while
+the priest spoke, the red soil thrown up at the sides kept noiselessly
+slipping down at the corners.
+
+Then when the four ropes were arranged the coffin was placed upon them.
+He watched it descend; it seemed descending for ever. At last a thud was
+heard; the ropes creaked as they were drawn up. Then Bournisien took
+the spade handed to him by Lestiboudois; with his left hand all the
+time sprinkling water, with the right he vigorously threw in a large
+spadeful; and the wood of the coffin, struck by the pebbles, gave forth
+that dread sound that seems to us the reverberation of eternity.
+
+The ecclesiastic passed the holy water sprinkler to his neighbour. This
+was Homais. He swung it gravely, then handed it to Charles, who sank to
+his knees in the earth and threw in handfuls of it, crying, “Adieu!” He
+sent her kisses; he dragged himself towards the grave, to engulf himself
+with her. They led him away, and he soon grew calmer, feeling perhaps,
+like the others, a vague satisfaction that it was all over.
+
+Old Rouault on his way back began quietly smoking a pipe, which Homais
+in his innermost conscience thought not quite the thing. He also noticed
+that Monsieur Binet had not been present, and that Tuvache had “made
+off” after mass, and that Theodore, the notary’s servant wore a blue
+coat, “as if one could not have got a black coat, since that is the
+custom, by Jove!” And to share his observations with others he went from
+group to group. They were deploring Emma’s death, especially Lheureux,
+who had not failed to come to the funeral.
+
+“Poor little woman! What a trouble for her husband!”
+
+The druggist continued, “Do you know that but for me he would have
+committed some fatal attempt upon himself?”
+
+“Such a good woman! To think that I saw her only last Saturday in my
+shop.”
+
+“I haven’t had leisure,” said Homais, “to prepare a few words that I
+would have cast upon her tomb.”
+
+Charles on getting home undressed, and old Rouault put on his blue
+blouse. It was a new one, and as he had often during the journey wiped
+his eyes on the sleeves, the dye had stained his face, and the traces of
+tears made lines in the layer of dust that covered it.
+
+Madame Bovary senior was with them. All three were silent. At last the
+old fellow sighed--
+
+“Do you remember, my friend, that I went to Tostes once when you had
+just lost your first deceased? I consoled you at that time. I thought of
+something to say then, but now--” Then, with a loud groan that shook his
+whole chest, “Ah! this is the end for me, do you see! I saw my wife go,
+then my son, and now to-day it’s my daughter.”
+
+He wanted to go back at once to Bertaux, saying that he could not sleep
+in this house. He even refused to see his granddaughter.
+
+“No, no! It would grieve me too much. Only you’ll kiss her many times
+for me. Good-bye! you’re a good fellow! And then I shall never forget
+that,” he said, slapping his thigh. “Never fear, you shall always have
+your turkey.”
+
+But when he reached the top of the hill he turned back, as he had turned
+once before on the road of Saint-Victor when he had parted from her. The
+windows of the village were all on fire beneath the slanting rays of the
+sun sinking behind the field. He put his hand over his eyes, and saw
+in the horizon an enclosure of walls, where trees here and there formed
+black clusters between white stones; then he went on his way at a gentle
+trot, for his nag had gone lame.
+
+Despite their fatigue, Charles and his mother stayed very long that
+evening talking together. They spoke of the days of the past and of the
+future. She would come to live at Yonville; she would keep house for
+him; they would never part again. She was ingenious and caressing,
+rejoicing in her heart at gaining once more an affection that had
+wandered from her for so many years. Midnight struck. The village as
+usual was silent, and Charles, awake, thought always of her.
+
+Rodolphe, who, to distract himself, had been rambling about the wood all
+day, was sleeping quietly in his chateau, and Leon, down yonder, always
+slept.
+
+There was another who at that hour was not asleep.
+
+On the grave between the pine-trees a child was on his knees weeping,
+and his heart, rent by sobs, was beating in the shadow beneath the load
+of an immense regret, sweeter than the moon and fathomless as the night.
+The gate suddenly grated. It was Lestiboudois; he came to fetch his
+spade, that he had forgotten. He recognised Justin climbing over the
+wall, and at last knew who was the culprit who stole his potatoes.
+
+
+
+Chapter Eleven
+
+The next day Charles had the child brought back. She asked for her
+mamma. They told her she was away; that she would bring her back some
+playthings. Berthe spoke of her again several times, then at last
+thought no more of her. The child’s gaiety broke Bovary’s heart, and he
+had to bear besides the intolerable consolations of the chemist.
+
+Money troubles soon began again, Monsieur Lheureux urging on anew his
+friend Vincart, and Charles pledged himself for exorbitant sums; for he
+would never consent to let the smallest of the things that had belonged
+to HER be sold. His mother was exasperated with him; he grew even more
+angry than she did. He had altogether changed. She left the house.
+
+Then everyone began “taking advantage” of him. Mademoiselle Lempereur
+presented a bill for six months’ teaching, although Emma had never taken
+a lesson (despite the receipted bill she had shown Bovary); it was an
+arrangement between the two women. The man at the circulating library
+demanded three years’ subscriptions; Mere Rollet claimed the postage due
+for some twenty letters, and when Charles asked for an explanation, she
+had the delicacy to reply--
+
+“Oh, I don’t know. It was for her business affairs.”
+
+With every debt he paid Charles thought he had come to the end of them.
+But others followed ceaselessly. He sent in accounts for professional
+attendance. He was shown the letters his wife had written. Then he had
+to apologise.
+
+Felicite now wore Madame Bovary’s gowns; not all, for he had kept some
+of them, and he went to look at them in her dressing-room, locking
+himself up there; she was about her height, and often Charles, seeing
+her from behind, was seized with an illusion, and cried out--
+
+“Oh, stay, stay!”
+
+But at Whitsuntide she ran away from Yonville, carried off by Theodore,
+stealing all that was left of the wardrobe.
+
+It was about this time that the widow Dupuis had the honour to inform
+him of the “marriage of Monsieur Leon Dupuis her son, notary at Yvetot,
+to Mademoiselle Leocadie Leboeuf of Bondeville.” Charles, among the
+other congratulations he sent him, wrote this sentence--
+
+“How glad my poor wife would have been!”
+
+One day when, wandering aimlessly about the house, he had gone up to the
+attic, he felt a pellet of fine paper under his slipper. He opened it
+and read: “Courage, Emma, courage. I would not bring misery into your
+life.” It was Rodolphe’s letter, fallen to the ground between the boxes,
+where it had remained, and that the wind from the dormer window had just
+blown towards the door. And Charles stood, motionless and staring, in
+the very same place where, long ago, Emma, in despair, and paler even
+than he, had thought of dying. At last he discovered a small R at the
+bottom of the second page. What did this mean? He remembered Rodolphe’s
+attentions, his sudden, disappearance, his constrained air when they
+had met two or three times since. But the respectful tone of the letter
+deceived him.
+
+“Perhaps they loved one another platonically,” he said to himself.
+
+Besides, Charles was not of those who go to the bottom of things; he
+shrank from the proofs, and his vague jealousy was lost in the immensity
+of his woe.
+
+Everyone, he thought, must have adored her; all men assuredly must have
+coveted her. She seemed but the more beautiful to him for this; he
+was seized with a lasting, furious desire for her, that inflamed his
+despair, and that was boundless, because it was now unrealisable.
+
+To please her, as if she were still living, he adopted her
+predilections, her ideas; he bought patent leather boots and took to
+wearing white cravats. He put cosmetics on his moustache, and, like her,
+signed notes of hand. She corrupted him from beyond the grave.
+
+He was obliged to sell his silver piece by piece; next he sold the
+drawing-room furniture. All the rooms were stripped; but the bedroom,
+her own room, remained as before. After his dinner Charles went up
+there. He pushed the round table in front of the fire, and drew up her
+armchair. He sat down opposite it. A candle burnt in one of the gilt
+candlesticks. Berthe by his side was painting prints.
+
+He suffered, poor man, at seeing her so badly dressed, with laceless
+boots, and the arm-holes of her pinafore torn down to the hips; for the
+charwoman took no care of her. But she was so sweet, so pretty, and her
+little head bent forward so gracefully, letting the dear fair hair fall
+over her rosy cheeks, that an infinite joy came upon him, a happiness
+mingled with bitterness, like those ill-made wines that taste of
+resin. He mended her toys, made her puppets from cardboard, or sewed up
+half-torn dolls. Then, if his eyes fell upon the workbox, a ribbon lying
+about, or even a pin left in a crack of the table, he began to dream,
+and looked so sad that she became as sad as he.
+
+No one now came to see them, for Justin had run away to Rouen, where he
+was a grocer’s assistant, and the druggist’s children saw less and less
+of the child, Monsieur Homais not caring, seeing the difference of their
+social position, to continue the intimacy.
+
+The blind man, whom he had not been able to cure with the pomade, had
+gone back to the hill of Bois-Guillaume, where he told the travellers of
+the vain attempt of the druggist, to such an extent, that Homais when
+he went to town hid himself behind the curtains of the “Hirondelle” to
+avoid meeting him. He detested him, and wishing, in the interests of his
+own reputation, to get rid of him at all costs, he directed against
+him a secret battery, that betrayed the depth of his intellect and the
+baseness of his vanity. Thus, for six consecutive months, one could read
+in the “Fanal de Rouen” editorials such as these--
+
+“All who bend their steps towards the fertile plains of Picardy have, no
+doubt, remarked, by the Bois-Guillaume hill, a wretch suffering from
+a horrible facial wound. He importunes, persecutes one, and levies a
+regular tax on all travellers. Are we still living in the monstrous
+times of the Middle Ages, when vagabonds were permitted to display in
+our public places leprosy and scrofulas they had brought back from the
+Crusades?”
+
+Or--
+
+“In spite of the laws against vagabondage, the approaches to our great
+towns continue to be infected by bands of beggars. Some are seen going
+about alone, and these are not, perhaps, the least dangerous. What are
+our ediles about?”
+
+Then Homais invented anecdotes--
+
+“Yesterday, by the Bois-Guillaume hill, a skittish horse--” And then
+followed the story of an accident caused by the presence of the blind
+man.
+
+He managed so well that the fellow was locked up. But he was released.
+He began again, and Homais began again. It was a struggle. Homais won
+it, for his foe was condemned to life-long confinement in an asylum.
+
+This success emboldened him, and henceforth there was no longer a dog
+run over, a barn burnt down, a woman beaten in the parish, of which
+he did not immediately inform the public, guided always by the love of
+progress and the hate of priests. He instituted comparisons between the
+elementary and clerical schools to the detriment of the latter; called
+to mind the massacre of St. Bartholomew a propos of a grant of one
+hundred francs to the church, and denounced abuses, aired new views.
+That was his phrase. Homais was digging and delving; he was becoming
+dangerous.
+
+However, he was stifling in the narrow limits of journalism, and soon a
+book, a work was necessary to him. Then he composed “General Statistics
+of the Canton of Yonville, followed by Climatological Remarks.” The
+statistics drove him to philosophy. He busied himself with great
+questions: the social problem, moralisation of the poorer classes,
+pisciculture, caoutchouc, railways, etc. He even began to blush at being
+a bourgeois. He affected the artistic style, he smoked. He bought two
+chic Pompadour statuettes to adorn his drawing-room.
+
+He by no means gave up his shop. On the contrary, he kept well abreast
+of new discoveries. He followed the great movement of chocolates; he
+was the first to introduce “cocoa” and “revalenta” into the
+Seine-Inferieure. He was enthusiastic about the hydro-electric
+Pulvermacher chains; he wore one himself, and when at night he took off
+his flannel vest, Madame Homais stood quite dazzled before the golden
+spiral beneath which he was hidden, and felt her ardour redouble for
+this man more bandaged than a Scythian, and splendid as one of the Magi.
+
+He had fine ideas about Emma’s tomb. First he proposed a broken column
+with some drapery, next a pyramid, then a Temple of Vesta, a sort of
+rotunda, or else a “mass of ruins.” And in all his plans Homais always
+stuck to the weeping willow, which he looked upon as the indispensable
+symbol of sorrow.
+
+Charles and he made a journey to Rouen together to look at some tombs
+at a funeral furnisher’s, accompanied by an artist, one Vaufrylard, a
+friend of Bridoux’s, who made puns all the time. At last, after having
+examined some hundred designs, having ordered an estimate and made
+another journey to Rouen, Charles decided in favour of a mausoleum,
+which on the two principal sides was to have a “spirit bearing an
+extinguished torch.”
+
+As to the inscription, Homais could think of nothing so fine as Sta
+viator*, and he got no further; he racked his brain, he constantly
+repeated Sta viator. At last he hit upon Amabilen conjugem calcas**,
+which was adopted.
+
+     * Rest traveler.
+
+     ** Tread upon a loving wife.
+
+A strange thing was that Bovary, while continually thinking of Emma, was
+forgetting her. He grew desperate as he felt this image fading from his
+memory in spite of all efforts to retain it. Yet every night he dreamt
+of her; it was always the same dream. He drew near her, but when he was
+about to clasp her she fell into decay in his arms.
+
+For a week he was seen going to church in the evening. Monsieur
+Bournisien even paid him two or three visits, then gave him up.
+Moreover, the old fellow was growing intolerant, fanatic, said Homais.
+He thundered against the spirit of the age, and never failed, every
+other week, in his sermon, to recount the death agony of Voltaire, who
+died devouring his excrements, as everyone knows.
+
+In spite of the economy with which Bovary lived, he was far from being
+able to pay off his old debts. Lheureux refused to renew any more
+bills. A distraint became imminent. Then he appealed to his mother, who
+consented to let him take a mortgage on her property, but with a great
+many recriminations against Emma; and in return for her sacrifice she
+asked for a shawl that had escaped the depredations of Felicite. Charles
+refused to give it her; they quarrelled.
+
+She made the first overtures of reconciliation by offering to have the
+little girl, who could help her in the house, to live with her. Charles
+consented to this, but when the time for parting came, all his courage
+failed him. Then there was a final, complete rupture.
+
+As his affections vanished, he clung more closely to the love of his
+child. She made him anxious, however, for she coughed sometimes, and had
+red spots on her cheeks.
+
+Opposite his house, flourishing and merry, was the family of the
+chemist, with whom everything was prospering. Napoleon helped him in the
+laboratory, Athalie embroidered him a skullcap, Irma cut out rounds of
+paper to cover the preserves, and Franklin recited Pythagoras’ table in
+a breath. He was the happiest of fathers, the most fortunate of men.
+
+Not so! A secret ambition devoured him. Homais hankered after the cross
+of the Legion of Honour. He had plenty of claims to it.
+
+“First, having at the time of the cholera distinguished myself by a
+boundless devotion; second, by having published, at my expense,
+various works of public utility, such as” (and he recalled his pamphlet
+entitled, “Cider, its manufacture and effects,” besides observation
+on the lanigerous plant-louse, sent to the Academy; his volume of
+statistics, and down to his pharmaceutical thesis); “without counting
+that I am a member of several learned societies” (he was member of a
+single one).
+
+“In short!” he cried, making a pirouette, “if it were only for
+distinguishing myself at fires!”
+
+Then Homais inclined towards the Government. He secretly did the
+prefect great service during the elections. He sold himself--in a word,
+prostituted himself. He even addressed a petition to the sovereign
+in which he implored him to “do him justice”; he called him “our good
+king,” and compared him to Henri IV.
+
+And every morning the druggist rushed for the paper to see if his
+nomination were in it. It was never there. At last, unable to bear it
+any longer, he had a grass plot in his garden designed to represent the
+Star of the Cross of Honour with two little strips of grass running from
+the top to imitate the ribband. He walked round it with folded arms,
+meditating on the folly of the Government and the ingratitude of men.
+
+From respect, or from a sort of sensuality that made him carry on his
+investigations slowly, Charles had not yet opened the secret drawer of
+a rosewood desk which Emma had generally used. One day, however, he
+sat down before it, turned the key, and pressed the spring. All Leon’s
+letters were there. There could be no doubt this time. He devoured them
+to the very last, ransacked every corner, all the furniture, all the
+drawers, behind the walls, sobbing, crying aloud, distraught, mad. He
+found a box and broke it open with a kick. Rodolphe’s portrait flew full
+in his face in the midst of the overturned love-letters.
+
+People wondered at his despondency. He never went out, saw no one,
+refused even to visit his patients. Then they said “he shut himself up
+to drink.”
+
+Sometimes, however, some curious person climbed on to the garden hedge,
+and saw with amazement this long-bearded, shabbily clothed, wild man,
+who wept aloud as he walked up and down.
+
+In the evening in summer he took his little girl with him and led her to
+the cemetery. They came back at nightfall, when the only light left in
+the Place was that in Binet’s window.
+
+The voluptuousness of his grief was, however, incomplete, for he had no
+one near him to share it, and he paid visits to Madame Lefrancois to be
+able to speak of her.
+
+But the landlady only listened with half an ear, having troubles
+like himself. For Lheureux had at last established the “Favorites du
+Commerce,” and Hivert, who enjoyed a great reputation for doing errands,
+insisted on a rise of wages, and was threatening to go over “to the
+opposition shop.”
+
+One day when he had gone to the market at Argueil to sell his horse--his
+last resource--he met Rodolphe.
+
+They both turned pale when they caught sight of one another. Rodolphe,
+who had only sent his card, first stammered some apologies, then grew
+bolder, and even pushed his assurance (it was in the month of August and
+very hot) to the length of inviting him to have a bottle of beer at the
+public-house.
+
+Leaning on the table opposite him, he chewed his cigar as he talked, and
+Charles was lost in reverie at this face that she had loved. He seemed
+to see again something of her in it. It was a marvel to him. He would
+have liked to have been this man.
+
+The other went on talking agriculture, cattle, pasturage, filling out
+with banal phrases all the gaps where an allusion might slip in. Charles
+was not listening to him; Rodolphe noticed it, and he followed the
+succession of memories that crossed his face. This gradually grew
+redder; the nostrils throbbed fast, the lips quivered. There was at
+last a moment when Charles, full of a sombre fury, fixed his eyes on
+Rodolphe, who, in something of fear, stopped talking. But soon the same
+look of weary lassitude came back to his face.
+
+“I don’t blame you,” he said.
+
+Rodolphe was dumb. And Charles, his head in his hands, went on in a
+broken voice, and with the resigned accent of infinite sorrow--
+
+“No, I don’t blame you now.”
+
+He even added a fine phrase, the only one he ever made--
+
+“It is the fault of fatality!”
+
+Rodolphe, who had managed the fatality, thought the remark very offhand
+from a man in his position, comic even, and a little mean.
+
+The next day Charles went to sit down on the seat in the arbour. Rays
+of light were straying through the trellis, the vine leaves threw their
+shadows on the sand, the jasmines perfumed the air, the heavens were
+blue, Spanish flies buzzed round the lilies in bloom, and Charles was
+suffocating like a youth beneath the vague love influences that filled
+his aching heart.
+
+At seven o’clock little Berthe, who had not seen him all the afternoon,
+went to fetch him to dinner.
+
+His head was thrown back against the wall, his eyes closed, his mouth
+open, and in his hand was a long tress of black hair.
+
+“Come along, papa,” she said.
+
+And thinking he wanted to play; she pushed him gently. He fell to the
+ground. He was dead.
+
+Thirty-six hours after, at the druggist’s request, Monsieur Canivet came
+thither. He made a post-mortem and found nothing.
+
+When everything had been sold, twelve francs seventy-five centimes
+remained, that served to pay for Mademoiselle Bovary’s going to
+her grandmother. The good woman died the same year; old Rouault was
+paralysed, and it was an aunt who took charge of her. She is poor, and
+sends her to a cotton-factory to earn a living.
+
+Since Bovary’s death three doctors have followed one another at Yonville
+without any success, so severely did Homais attack them. He has an
+enormous practice; the authorities treat him with consideration, and
+public opinion protects him.
+
+He has just received the cross of the Legion of Honour.
+
+
+
+
+
+End of the Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+*** END OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+***** This file should be named 2413-0.txt or 2413-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/4/1/2413/
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/odyssey.txt
+++ b/jet/hadoop/src/main/resources/books/odyssey.txt
@@ -1,0 +1,11984 @@
+﻿The Project Gutenberg EBook of The Odyssey, by Homer
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Odyssey
+
+Author: Homer
+
+Translator: Samuel Butler
+
+
+Release Date: April, 1999 [EBook #1727]
+Last Updated: April 9, 2013
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+
+
+
+Produced by Jim Tinsley
+
+
+
+
+
+
+
+
+
+THE ODYSSEY
+
+
+  rendered into English
+  prose for the use of
+  those who cannot
+  read the original
+
+
+By Samuel Butler
+
+
+
+
+PREFACE TO FIRST EDITION
+
+This translation is intended to supplement a work entitled "The
+Authoress of the Odyssey", which I published in 1897. I could not give
+the whole "Odyssey" in that book without making it unwieldy, I therefore
+epitomised my translation, which was already completed and which I now
+publish in full.
+
+I shall not here argue the two main points dealt with in the work just
+mentioned; I have nothing either to add to, or to withdraw from, what I
+have there written. The points in question are:
+
+(1) that the "Odyssey" was written entirely at, and drawn entirely
+from, the place now called Trapani on the West Coast of Sicily, alike
+as regards the Phaeacian and the Ithaca scenes; while the voyages of
+Ulysses, when once he is within easy reach of Sicily, solve themselves
+into a periplus of the island, practically from Trapani back to Trapani,
+via the Lipari islands, the Straits of Messina, and the island of
+Pantellaria.
+
+(2) That the poem was entirely written by a very young woman, who lived
+at the place now called Trapani, and introduced herself into her work
+under the name of Nausicaa.
+
+The main arguments on which I base the first of these somewhat startling
+contentions, have been prominently and repeatedly before the English
+and Italian public ever since they appeared (without rejoinder) in the
+"Athenaeum" for January 30 and February 20, 1892. Both contentions were
+urged (also without rejoinder) in the Johnian "Eagle" for the Lent and
+October terms of the same year. Nothing to which I should reply
+has reached me from any quarter, and knowing how anxiously I have
+endeavoured to learn the existence of any flaws in my argument, I begin
+to feel some confidence that, did such flaws exist, I should have heard,
+at any rate about some of them, before now. Without, therefore, for
+a moment pretending to think that scholars generally acquiesce in my
+conclusions, I shall act as thinking them little likely so to gainsay me
+as that it will be incumbent upon me to reply, and shall confine myself
+to translating the "Odyssey" for English readers, with such notes as
+I think will be found useful. Among these I would especially call
+attention to one on xxii. 465-473 which Lord Grimthorpe has kindly
+allowed me to make public.
+
+I have repeated several of the illustrations used in "The Authoress of
+the Odyssey", and have added two which I hope may bring the outer court
+of Ulysses' house more vividly before the reader. I should like to
+explain that the presence of a man and a dog in one illustration is
+accidental, and was not observed by me till I developed the negative. In
+an appendix I have also reprinted the paragraphs explanatory of the
+plan of Ulysses' house, together with the plan itself. The reader is
+recommended to study this plan with some attention.
+
+In the preface to my translation of the "Iliad" I have given my views as
+to the main principles by which a translator should be guided, and need
+not repeat them here, beyond pointing out that the initial liberty of
+translating poetry into prose involves the continual taking of more
+or less liberty throughout the translation; for much that is right in
+poetry is wrong in prose, and the exigencies of readable prose are the
+first things to be considered in a prose translation. That the reader,
+however, may see how far I have departed from strict construe, I will
+print here Messrs. Butcher and Lang's translation of the sixty lines or
+so of the "Odyssey." Their translation runs:
+
+  Tell me, Muse, of that man, so ready at need, who wandered
+  far and wide, after he had sacked the sacred citadel of
+  Troy, and many were the men whose towns he saw and whose
+  mind he learnt, yea, and many the woes he suffered in his
+  heart on the deep, striving to win his own life and the
+  return of his company. Nay, but even so he saved not his
+  company, though he desired it sore. For through the
+  blindness of their own hearts they perished, fools, who
+  devoured the oxen of Helios Hyperion: but the god took from
+  them their day of returning. Of these things, goddess,
+  daughter of Zeus, whencesoever thou hast heard thereof,
+  declare thou even unto us.
+
+  Now all the rest, as many as fled from sheer destruction,
+  were at home, and had escaped both war and sea, but
+  Odysseus only, craving for his wife and for his homeward
+  path, the lady nymph Calypso held, that fair goddess, in her
+  hollow caves, longing to have him for her lord. But when
+  now the year had come in the courses of the seasons,
+  wherein the gods had ordained that he should return home to
+  Ithaca, not even there was he quit of labours, not even
+  among his own; but all the gods had pity on him save
+  Poseidon, who raged continually against godlike Odysseus,
+  till he came to his own country. Howbeit Poseidon had now
+  departed for the distant Ethiopians, the Ethiopians that are
+  sundered in twain, the uttermost of men, abiding some where
+  Hyperion sinks and some where he rises. There he looked to
+  receive his hecatomb of bulls and rams, there he made merry
+  sitting at the feast, but the other gods were gathered in
+  the halls of Olympian Zeus. Then among them the father of
+  men and gods began to speak, for he bethought him in his
+  heart of noble Aegisthus, whom the son of Agamemnon,
+  far-famed Orestes, slew. Thinking upon him he spake out among
+  the Immortals:
+
+  'Lo you now, how vainly mortal men do blame the gods! For of
+  us they say comes evil, whereas they even of themselves,
+  through the blindness of their own hearts, have sorrows
+  beyond that which is ordained. Even as of late Aegisthus,
+  beyond that which was ordained, took to him the wedded wife
+  of the son of Atreus, and killed her lord on his return,
+  and that with sheer doom before his eyes, since we had
+  warned him by the embassy of Hermes the keen-sighted, the
+  slayer of Argos, that he should neither kill the man, nor
+  woo his wife. For the son of Atreus shall be avenged at the
+  hand of Orestes, so soon as he shall come to man's estate
+  and long for his own country. So spake Hermes, yet he
+  prevailed not on the heart of Aegisthus, for all his good
+  will; but now hath he paid one price for all.'
+
+  And the goddess, grey-eyed Athene, answered him, saying: 'O
+  father, our father Cronides, throned in the highest; that
+  man assuredly lies in a death that is his due; so perish
+  likewise all who work such deeds! But my heart is rent for
+  wise Odysseus, the hapless one, who far from his friends
+  this long while suffereth affliction in a sea-girt isle,
+  where is the navel of the sea, a woodland isle, and
+  therein a goddess hath her habitation, the daughter of the
+  wizard Atlas, who knows the depths of every sea, and
+  himself upholds the tall pillars which keep earth and sky
+  asunder. His daughter it is that holds the hapless man in
+  sorrow: and ever with soft and guileful tales she is
+  wooing him to forgetfulness of Ithaca. But Odysseus
+  yearning to see if it were but the smoke leap upwards from
+  his own land, hath a desire to die. As for thee, thine
+  heart regardeth it not at all, Olympian! What! Did not
+  Odysseus by the ships of the Argives make thee free
+  offering of sacrifice in the wide Trojan land? Wherefore
+  wast thou then so wroth with him, O Zeus?'
+
+The "Odyssey" (as every one knows) abounds in passages borrowed from the
+"Iliad"; I had wished to print these in a slightly different type, with
+marginal references to the "Iliad," and had marked them to this end in
+my MS. I found, however, that the translation would be thus hopelessly
+scholasticised, and abandoned my intention. I would nevertheless urge on
+those who have the management of our University presses, that they would
+render a great service to students if they would publish a Greek text of
+the "Odyssey" with the Iliadic passages printed in a different type, and
+with marginal references. I have given the British Museum a copy of the
+"Odyssey" with the Iliadic passages underlined and referred to in MS.;
+I have also given an "Iliad" marked with all the Odyssean passages, and
+their references; but copies of both the "Iliad" and "Odyssey" so marked
+ought to be within easy reach of all students.
+
+Any one who at the present day discusses the questions that have arisen
+round the "Iliad" since Wolf's time, without keeping it well before
+his reader's mind that the "Odyssey" was demonstrably written from one
+single neighbourhood, and hence (even though nothing else pointed to
+this conclusion) presumably by one person only--that it was written
+certainly before 750, and in all probability before 1000 B.C.--that
+the writer of this very early poem was demonstrably familiar with the
+"Iliad" as we now have it, borrowing as freely from those books whose
+genuineness has been most impugned, as from those which are admitted to
+be by Homer--any one who fails to keep these points before his readers,
+is hardly dealing equitably by them. Any one on the other hand, who will
+mark his "Iliad" and his "Odyssey" from the copies in the British Museum
+above referred to, and who will draw the only inference that common
+sense can draw from the presence of so many identical passages in both
+poems, will, I believe, find no difficulty in assigning their proper
+value to a large number of books here and on the Continent that at
+present enjoy considerable reputations. Furthermore, and this perhaps
+is an advantage better worth securing, he will find that many puzzles of
+the "Odyssey" cease to puzzle him on the discovery that they arise from
+over-saturation with the "Iliad."
+
+Other difficulties will also disappear as soon as the development of the
+poem in the writer's mind is understood. I have dealt with this at some
+length in pp. 251-261 of "The Authoress of the Odyssey". Briefly, the
+"Odyssey" consists of two distinct poems: (1) The Return of Ulysses,
+which alone the Muse is asked to sing in the opening lines of the poem.
+This poem includes the Phaeacian episode, and the account of Ulysses'
+adventures as told by himself in Books ix.-xii. It consists of lines
+1-79 (roughly) of Book i., of line 28 of Book v., and thence without
+intermission to the middle of line 187 of Book xiii., at which point the
+original scheme was abandoned.
+
+(2) The story of Penelope and the suitors, with the episode of
+Telemachus' voyage to Pylos. This poem begins with line 80 (roughly)
+of Book i., is continued to the end of Book iv., and not resumed till
+Ulysses wakes in the middle of line 187, Book xiii., from whence it
+continues to the end of Book xxiv.
+
+In "The Authoress of the Odyssey", I wrote:
+
+   the introduction of lines xi., 115-137 and of line ix.,
+   535, with the writing a new council of the gods at the
+   beginning of Book v., to take the place of the one that was
+   removed to Book i., 1-79, were the only things that were
+   done to give even a semblance of unity to the old scheme
+   and the new, and to conceal the fact that the Muse, after
+   being asked to sing of one subject, spend two-thirds of her
+   time in singing a very different one, with a climax for
+   which no-one has asked her. For roughly the Return occupies
+   eight Books, and Penelope and the Suitors sixteen.
+
+I believe this to be substantially correct.
+
+Lastly, to deal with a very unimportant point, I observe that the
+Leipsic Teubner edition of 894 makes Books ii. and iii. end with a
+comma. Stops are things of such far more recent date than the "Odyssey,"
+that there does not seem much use in adhering to the text in so small a
+matter; still, from a spirit of mere conservatism, I have preferred
+to do so. Why [Greek] at the beginnings of Books ii. and viii., and
+[Greek], at the beginning of Book vii. should have initial capitals in
+an edition far too careful to admit a supposition of inadvertence, when
+[Greek] at the beginning of Books vi. and xiii., and [Greek] at the
+beginning of Book xvii. have no initial capitals, I cannot determine.
+No other Books of the "Odyssey" have initial capitals except the three
+mentioned unless the first word of the Book is a proper name.
+
+S. BUTLER.
+
+July 25, 1900.
+
+
+
+
+PREFACE TO SECOND EDITION
+
+Butler's Translation of the "Odyssey" appeared originally in 1900, and
+The Authoress of the Odyssey in 1897. In the preface to the new edition
+of "The Authoress", which is published simultaneously with this new
+edition of the Translation, I have given some account of the genesis of
+the two books.
+
+The size of the original page has been reduced so as to make both
+books uniform with Butler's other works; and, fortunately, it has been
+possible, by using a smaller type, to get the same number of words into
+each page, so that the references remain good, and, with the exception
+of a few minor alterations and rearrangements now to be enumerated
+so far as they affect the Translation, the new editions are faithful
+reprints of the original editions, with misprints and obvious errors
+corrected--no attempt having been made to edit them or to bring them up
+to date.
+
+(a) The Index has been revised.
+
+(b) Owing to the reduction in the size of the page it has been necessary
+to shorten some of the headlines, and here advantage has been taken of
+various corrections of and additions to the headlines and shoulder-notes
+made by Butler in his own copies of the two books.
+
+(c) For the most part each of the illustrations now occupies a page,
+whereas in the original editions they generally appeared two on the
+page. It has been necessary to reduce the plan of the House of Ulysses.
+
+On page 153 of "The Authoress" Butler says: "No great poet would compare
+his hero to a paunch full of blood and fat, cooking before the fire
+(xx, 24-28)." This passage is not given in the abridged Story of the
+"Odyssey" at the beginning of the book, but in the Translation it occurs
+in these words:
+
+"Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side then on the other, that he
+may get it cooked as soon as possible; even so did he turn himself about
+from side to side, thinking all the time how, single-handed as he
+was, he should contrive to kill so large a body of men as the wicked
+suitors."
+
+It looks as though in the interval between the publication of "The
+Authoress" (1897) and of the Translation (1900) Butler had changed his
+mind; for in the first case the comparison is between Ulysses and a
+paunch full, etc., and in the second it is between Ulysses and a man who
+turns a paunch full, etc. The second comparison is perhaps one which a
+great poet might make.
+
+In seeing the works through the press I have had the invaluable
+assistance of Mr. A. T. Bartholomew of the University Library,
+Cambridge, and of Mr. Donald S. Robertson, Fellow of Trinity College,
+Cambridge. To both these friends I give my most cordial thanks for the
+care and skill exercised by them. Mr. Robertson has found time for the
+labour of checking and correcting all the quotations from and references
+to the "Iliad" and "Odyssey," and I believe that it could not have been
+better performed. It was, I know, a pleasure for him; and it would have
+been a pleasure also for Butler if he could have known that his work was
+being shepherded by the son of his old friend, Mr. H. R. Robertson, who
+more than half a century ago was a fellow-student with him at Cary's
+School of Art in Streatham Street, Bloomsbury.
+
+HENRY FESTING JONES.
+
+120 MAIDA VALE, W.9.
+
+4th December, 1921.
+
+
+
+
+THE ODYSSEY
+
+
+Book I
+
+THE GODS IN COUNCIL--MINERVA'S VISIT TO ITHACA--THE CHALLENGE FROM
+TELEMACHUS TO THE SUITORS.
+
+Tell me, O Muse, of that ingenious hero who travelled far and wide after
+he had sacked the famous town of Troy. Many cities did he visit, and
+many were the nations with whose manners and customs he was acquainted;
+moreover he suffered much by sea while trying to save his own life and
+bring his men safely home; but do what he might he could not save his
+men, for they perished through their own sheer folly in eating the
+cattle of the Sun-god Hyperion; so the god prevented them from ever
+reaching home. Tell me, too, about all these things, oh daughter of
+Jove, from whatsoever source you may know them.
+
+So now all who escaped death in battle or by shipwreck had got safely
+home except Ulysses, and he, though he was longing to return to his wife
+and country, was detained by the goddess Calypso, who had got him into
+a large cave and wanted to marry him. But as years went by, there came a
+time when the gods settled that he should go back to Ithaca; even then,
+however, when he was among his own people, his troubles were not
+yet over; nevertheless all the gods had now begun to pity him except
+Neptune, who still persecuted him without ceasing and would not let him
+get home.
+
+Now Neptune had gone off to the Ethiopians, who are at the world's end,
+and lie in two halves, the one looking West and the other East. {1} He
+had gone there to accept a hecatomb of sheep and oxen, and was enjoying
+himself at his festival; but the other gods met in the house of Olympian
+Jove, and the sire of gods and men spoke first. At that moment he was
+thinking of Aegisthus, who had been killed by Agamemnon's son Orestes;
+so he said to the other gods:
+
+"See now, how men lay blame upon us gods for what is after all nothing
+but their own folly. Look at Aegisthus; he must needs make love to
+Agamemnon's wife unrighteously and then kill Agamemnon, though he knew
+it would be the death of him; for I sent Mercury to warn him not to do
+either of these things, inasmuch as Orestes would be sure to take his
+revenge when he grew up and wanted to return home. Mercury told him
+this in all good will but he would not listen, and now he has paid for
+everything in full."
+
+Then Minerva said, "Father, son of Saturn, King of kings, it served
+Aegisthus right, and so it would any one else who does as he did; but
+Aegisthus is neither here nor there; it is for Ulysses that my heart
+bleeds, when I think of his sufferings in that lonely sea-girt island,
+far away, poor man, from all his friends. It is an island covered
+with forest, in the very middle of the sea, and a goddess lives there,
+daughter of the magician Atlas, who looks after the bottom of the ocean,
+and carries the great columns that keep heaven and earth asunder. This
+daughter of Atlas has got hold of poor unhappy Ulysses, and keeps trying
+by every kind of blandishment to make him forget his home, so that he
+is tired of life, and thinks of nothing but how he may once more see the
+smoke of his own chimneys. You, sir, take no heed of this, and yet when
+Ulysses was before Troy did he not propitiate you with many a burnt
+sacrifice? Why then should you keep on being so angry with him?"
+
+And Jove said, "My child, what are you talking about? How can I forget
+Ulysses than whom there is no more capable man on earth, nor more
+liberal in his offerings to the immortal gods that live in heaven? Bear
+in mind, however, that Neptune is still furious with Ulysses for having
+blinded an eye of Polyphemus king of the Cyclopes. Polyphemus is son to
+Neptune by the nymph Thoosa, daughter to the sea-king Phorcys; therefore
+though he will not kill Ulysses outright, he torments him by preventing
+him from getting home. Still, let us lay our heads together and see how
+we can help him to return; Neptune will then be pacified, for if we are
+all of a mind he can hardly stand out against us."
+
+And Minerva said, "Father, son of Saturn, King of kings, if, then, the
+gods now mean that Ulysses should get home, we should first send Mercury
+to the Ogygian island to tell Calypso that we have made up our minds and
+that he is to return. In the meantime I will go to Ithaca, to put heart
+into Ulysses' son Telemachus; I will embolden him to call the Achaeans
+in assembly, and speak out to the suitors of his mother Penelope, who
+persist in eating up any number of his sheep and oxen; I will also
+conduct him to Sparta and to Pylos, to see if he can hear anything about
+the return of his dear father--for this will make people speak well of
+him."
+
+So saying she bound on her glittering golden sandals, imperishable,
+with which she can fly like the wind over land or sea; she grasped the
+redoubtable bronze-shod spear, so stout and sturdy and strong, wherewith
+she quells the ranks of heroes who have displeased her, and down she
+darted from the topmost summits of Olympus, whereon forthwith she was
+in Ithaca, at the gateway of Ulysses' house, disguised as a visitor,
+Mentes, chief of the Taphians, and she held a bronze spear in her hand.
+There she found the lordly suitors seated on hides of the oxen which
+they had killed and eaten, and playing draughts in front of the house.
+Men-servants and pages were bustling about to wait upon them, some
+mixing wine with water in the mixing-bowls, some cleaning down the
+tables with wet sponges and laying them out again, and some cutting up
+great quantities of meat.
+
+Telemachus saw her long before any one else did. He was sitting moodily
+among the suitors thinking about his brave father, and how he would send
+them flying out of the house, if he were to come to his own again and
+be honoured as in days gone by. Thus brooding as he sat among them, he
+caught sight of Minerva and went straight to the gate, for he was vexed
+that a stranger should be kept waiting for admittance. He took her right
+hand in his own, and bade her give him her spear. "Welcome," said he,
+"to our house, and when you have partaken of food you shall tell us what
+you have come for."
+
+He led the way as he spoke, and Minerva followed him. When they were
+within he took her spear and set it in the spear-stand against a strong
+bearing-post along with the many other spears of his unhappy father, and
+he conducted her to a richly decorated seat under which he threw a
+cloth of damask. There was a footstool also for her feet,{2} and he set
+another seat near her for himself, away from the suitors, that she might
+not be annoyed while eating by their noise and insolence, and that he
+might ask her more freely about his father.
+
+A maid servant then brought them water in a beautiful golden ewer and
+poured it into a silver basin for them to wash their hands, and she
+drew a clean table beside them. An upper servant brought them bread, and
+offered them many good things of what there was in the house, the carver
+fetched them plates of all manner of meats and set cups of gold by their
+side, and a manservant brought them wine and poured it out for them.
+
+Then the suitors came in and took their places on the benches and seats.
+{3} Forthwith men servants poured water over their hands, maids went
+round with the bread-baskets, pages filled the mixing-bowls with wine
+and water, and they laid their hands upon the good things that were
+before them. As soon as they had had enough to eat and drink they wanted
+music and dancing, which are the crowning embellishments of a banquet,
+so a servant brought a lyre to Phemius, whom they compelled perforce
+to sing to them. As soon as he touched his lyre and began to sing
+Telemachus spoke low to Minerva, with his head close to hers that no man
+might hear.
+
+"I hope, sir," said he, "that you will not be offended with what I am
+going to say. Singing comes cheap to those who do not pay for it, and
+all this is done at the cost of one whose bones lie rotting in some
+wilderness or grinding to powder in the surf. If these men were to see
+my father come back to Ithaca they would pray for longer legs rather
+than a longer purse, for money would not serve them; but he, alas, has
+fallen on an ill fate, and even when people do sometimes say that he is
+coming, we no longer heed them; we shall never see him again. And now,
+sir, tell me and tell me true, who you are and where you come from. Tell
+me of your town and parents, what manner of ship you came in, how your
+crew brought you to Ithaca, and of what nation they declared themselves
+to be--for you cannot have come by land. Tell me also truly, for I want
+to know, are you a stranger to this house, or have you been here in my
+father's time? In the old days we had many visitors for my father went
+about much himself."
+
+And Minerva answered, "I will tell you truly and particularly all about
+it. I am Mentes, son of Anchialus, and I am King of the Taphians. I have
+come here with my ship and crew, on a voyage to men of a foreign tongue
+being bound for Temesa {4} with a cargo of iron, and I shall bring back
+copper. As for my ship, it lies over yonder off the open country away
+from the town, in the harbour Rheithron {5} under the wooded mountain
+Neritum. {6} Our fathers were friends before us, as old Laertes will
+tell you, if you will go and ask him. They say, however, that he never
+comes to town now, and lives by himself in the country, faring hardly,
+with an old woman to look after him and get his dinner for him, when
+he comes in tired from pottering about his vineyard. They told me your
+father was at home again, and that was why I came, but it seems the gods
+are still keeping him back, for he is not dead yet not on the mainland.
+It is more likely he is on some sea-girt island in mid ocean, or a
+prisoner among savages who are detaining him against his will. I am no
+prophet, and know very little about omens, but I speak as it is borne
+in upon me from heaven, and assure you that he will not be away much
+longer; for he is a man of such resource that even though he were in
+chains of iron he would find some means of getting home again. But tell
+me, and tell me true, can Ulysses really have such a fine looking fellow
+for a son? You are indeed wonderfully like him about the head and eyes,
+for we were close friends before he set sail for Troy where the flower
+of all the Argives went also. Since that time we have never either of us
+seen the other."
+
+"My mother," answered Telemachus, "tells me I am son to Ulysses, but it
+is a wise child that knows his own father. Would that I were son to one
+who had grown old upon his own estates, for, since you ask me, there
+is no more ill-starred man under heaven than he who they tell me is my
+father."
+
+And Minerva said, "There is no fear of your race dying out yet, while
+Penelope has such a fine son as you are. But tell me, and tell me true,
+what is the meaning of all this feasting, and who are these people? What
+is it all about? Have you some banquet, or is there a wedding in the
+family--for no one seems to be bringing any provisions of his own? And
+the guests--how atrociously they are behaving; what riot they make over
+the whole house; it is enough to disgust any respectable person who
+comes near them."
+
+"Sir," said Telemachus, "as regards your question, so long as my father
+was here it was well with us and with the house, but the gods in their
+displeasure have willed it otherwise, and have hidden him away more
+closely than mortal man was ever yet hidden. I could have borne it
+better even though he were dead, if he had fallen with his men before
+Troy, or had died with friends around him when the days of his fighting
+were done; for then the Achaeans would have built a mound over his
+ashes, and I should myself have been heir to his renown; but now the
+storm-winds have spirited him away we know not whither; he is gone
+without leaving so much as a trace behind him, and I inherit nothing
+but dismay. Nor does the matter end simply with grief for the loss of
+my father; heaven has laid sorrows upon me of yet another kind; for the
+chiefs from all our islands, Dulichium, Same, and the woodland island of
+Zacynthus, as also all the principal men of Ithaca itself, are eating up
+my house under the pretext of paying their court to my mother, who
+will neither point blank say that she will not marry, {7} nor yet bring
+matters to an end; so they are making havoc of my estate, and before
+long will do so also with myself."
+
+"Is that so?" exclaimed Minerva, "then you do indeed want Ulysses home
+again. Give him his helmet, shield, and a couple of lances, and if he is
+the man he was when I first knew him in our house, drinking and making
+merry, he would soon lay his hands about these rascally suitors, were
+he to stand once more upon his own threshold. He was then coming from
+Ephyra, where he had been to beg poison for his arrows from Ilus, son of
+Mermerus. Ilus feared the ever-living gods and would not give him any,
+but my father let him have some, for he was very fond of him. If Ulysses
+is the man he then was these suitors will have a short shrift and a
+sorry wedding.
+
+"But there! It rests with heaven to determine whether he is to return,
+and take his revenge in his own house or no; I would, however, urge you
+to set about trying to get rid of these suitors at once. Take my advice,
+call the Achaean heroes in assembly to-morrow morning--lay your case
+before them, and call heaven to bear you witness. Bid the suitors take
+themselves off, each to his own place, and if your mother's mind is set
+on marrying again, let her go back to her father, who will find her
+a husband and provide her with all the marriage gifts that so dear a
+daughter may expect. As for yourself, let me prevail upon you to take
+the best ship you can get, with a crew of twenty men, and go in quest
+of your father who has so long been missing. Some one may tell
+you something, or (and people often hear things in this way) some
+heaven-sent message may direct you. First go to Pylos and ask Nestor;
+thence go on to Sparta and visit Menelaus, for he got home last of all
+the Achaeans; if you hear that your father is alive and on his way home,
+you can put up with the waste these suitors will make for yet another
+twelve months. If on the other hand you hear of his death, come home at
+once, celebrate his funeral rites with all due pomp, build a barrow
+to his memory, and make your mother marry again. Then, having done all
+this, think it well over in your mind how, by fair means or foul, you
+may kill these suitors in your own house. You are too old to plead
+infancy any longer; have you not heard how people are singing Orestes'
+praises for having killed his father's murderer Aegisthus? You are a
+fine, smart looking fellow; show your mettle, then, and make yourself a
+name in story. Now, however, I must go back to my ship and to my crew,
+who will be impatient if I keep them waiting longer; think the matter
+over for yourself, and remember what I have said to you."
+
+"Sir," answered Telemachus, "it has been very kind of you to talk to me
+in this way, as though I were your own son, and I will do all you tell
+me; I know you want to be getting on with your voyage, but stay a little
+longer till you have taken a bath and refreshed yourself. I will then
+give you a present, and you shall go on your way rejoicing; I will give
+you one of great beauty and value--a keepsake such as only dear friends
+give to one another."
+
+Minerva answered, "Do not try to keep me, for I would be on my way at
+once. As for any present you may be disposed to make me, keep it till
+I come again, and I will take it home with me. You shall give me a very
+good one, and I will give you one of no less value in return."
+
+With these words she flew away like a bird into the air, but she had
+given Telemachus courage, and had made him think more than ever about
+his father. He felt the change, wondered at it, and knew that the
+stranger had been a god, so he went straight to where the suitors were
+sitting.
+
+Phemius was still singing, and his hearers sat rapt in silence as he
+told the sad tale of the return from Troy, and the ills Minerva had laid
+upon the Achaeans. Penelope, daughter of Icarius, heard his song from
+her room upstairs, and came down by the great staircase, not alone, but
+attended by two of her handmaids. When she reached the suitors she stood
+by one of the bearing posts that supported the roof of the cloisters {8}
+with a staid maiden on either side of her. She held a veil, moreover,
+before her face, and was weeping bitterly.
+
+"Phemius," she cried, "you know many another feat of gods and heroes,
+such as poets love to celebrate. Sing the suitors some one of these, and
+let them drink their wine in silence, but cease this sad tale, for it
+breaks my sorrowful heart, and reminds me of my lost husband whom I
+mourn ever without ceasing, and whose name was great over all Hellas and
+middle Argos." {9}
+
+"Mother," answered Telemachus, "let the bard sing what he has a mind to;
+bards do not make the ills they sing of; it is Jove, not they, who makes
+them, and who sends weal or woe upon mankind according to his own good
+pleasure. This fellow means no harm by singing the ill-fated return of
+the Danaans, for people always applaud the latest songs most warmly.
+Make up your mind to it and bear it; Ulysses is not the only man who
+never came back from Troy, but many another went down as well as he. Go,
+then, within the house and busy yourself with your daily duties, your
+loom, your distaff, and the ordering of your servants; for speech is
+man's matter, and mine above all others {10}--for it is I who am master
+here."
+
+She went wondering back into the house, and laid her son's saying in
+her heart. Then, going upstairs with her handmaids into her room, she
+mourned her dear husband till Minerva shed sweet sleep over her eyes.
+But the suitors were clamorous throughout the covered cloisters {11},
+and prayed each one that he might be her bed fellow.
+
+Then Telemachus spoke, "Shameless," he cried, "and insolent suitors, let
+us feast at our pleasure now, and let there be no brawling, for it is a
+rare thing to hear a man with such a divine voice as Phemius has; but in
+the morning meet me in full assembly that I may give you formal notice
+to depart, and feast at one another's houses, turn and turn about, at
+your own cost. If on the other hand you choose to persist in spunging
+upon one man, heaven help me, but Jove shall reckon with you in full,
+and when you fall in my father's house there shall be no man to avenge
+you."
+
+The suitors bit their lips as they heard him, and marvelled at the
+boldness of his speech. Then, Antinous, son of Eupeithes, said, "The
+gods seem to have given you lessons in bluster and tall talking; may
+Jove never grant you to be chief in Ithaca as your father was before
+you."
+
+Telemachus answered, "Antinous, do not chide with me, but, god willing,
+I will be chief too if I can. Is this the worst fate you can think of
+for me? It is no bad thing to be a chief, for it brings both riches
+and honour. Still, now that Ulysses is dead there are many great men in
+Ithaca both old and young, and some other may take the lead among them;
+nevertheless I will be chief in my own house, and will rule those whom
+Ulysses has won for me."
+
+Then Eurymachus, son of Polybus, answered, "It rests with heaven to
+decide who shall be chief among us, but you shall be master in your
+own house and over your own possessions; no one while there is a man
+in Ithaca shall do you violence nor rob you. And now, my good fellow,
+I want to know about this stranger. What country does he come from?
+Of what family is he, and where is his estate? Has he brought you news
+about the return of your father, or was he on business of his own? He
+seemed a well to do man, but he hurried off so suddenly that he was gone
+in a moment before we could get to know him."
+
+"My father is dead and gone," answered Telemachus, "and even if some
+rumour reaches me I put no more faith in it now. My mother does indeed
+sometimes send for a soothsayer and question him, but I give his
+prophecyings no heed. As for the stranger, he was Mentes, son of
+Anchialus, chief of the Taphians, an old friend of my father's." But in
+his heart he knew that it had been the goddess.
+
+The suitors then returned to their singing and dancing until the
+evening; but when night fell upon their pleasuring they went home to
+bed each in his own abode. {12} Telemachus's room was high up in a tower
+{13} that looked on to the outer court; hither, then, he hied, brooding
+and full of thought. A good old woman, Euryclea, daughter of Ops,
+the son of Pisenor, went before him with a couple of blazing torches.
+Laertes had bought her with his own money when she was quite young; he
+gave the worth of twenty oxen for her, and shewed as much respect to her
+in his household as he did to his own wedded wife, but he did not take
+her to his bed for he feared his wife's resentment. {14} She it was who
+now lighted Telemachus to his room, and she loved him better than any of
+the other women in the house did, for she had nursed him when he was a
+baby. He opened the door of his bed room and sat down upon the bed; as
+he took off his shirt {15} he gave it to the good old woman, who folded
+it tidily up, and hung it for him over a peg by his bed side, after
+which she went out, pulled the door to by a silver catch, and drew the
+bolt home by means of the strap. {16} But Telemachus as he lay covered
+with a woollen fleece kept thinking all night through of his intended
+voyage and of the counsel that Minerva had given him.
+
+
+Book II
+
+ASSEMBLY OF THE PEOPLE OF ITHACA--SPEECHES OF TELEMACHUS AND OF THE
+SUITORS--TELEMACHUS MAKES HIS PREPARATIONS AND STARTS FOR PYLOS WITH
+MINERVA DISGUISED AS MENTOR.
+
+Now when the child of morning, rosy-fingered Dawn, appeared Telemachus
+rose and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulder, and left his room looking like an
+immortal god. He at once sent the criers round to call the people in
+assembly, so they called them and the people gathered thereon; then,
+when they were got together, he went to the place of assembly spear in
+hand--not alone, for his two hounds went with him. Minerva endowed him
+with a presence of such divine comeliness that all marvelled at him as
+he went by, and when he took his place in his father's seat even the
+oldest councillors made way for him.
+
+Aegyptius, a man bent double with age, and of infinite experience, was
+the first to speak. His son Antiphus had gone with Ulysses to Ilius,
+land of noble steeds, but the savage Cyclops had killed him when they
+were all shut up in the cave, and had cooked his last dinner for him.
+{17} He had three sons left, of whom two still worked on their father's
+land, while the third, Eurynomus, was one of the suitors; nevertheless
+their father could not get over the loss of Antiphus, and was still
+weeping for him when he began his speech.
+
+"Men of Ithaca," he said, "hear my words. From the day Ulysses left us
+there has been no meeting of our councillors until now; who then can it
+be, whether old or young, that finds it so necessary to convene us? Has
+he got wind of some host approaching, and does he wish to warn us, or
+would he speak upon some other matter of public moment? I am sure he is
+an excellent person, and I hope Jove will grant him his heart's desire."
+
+Telemachus took this speech as of good omen and rose at once, for he was
+bursting with what he had to say. He stood in the middle of the assembly
+and the good herald Pisenor brought him his staff. Then, turning to
+Aegyptius, "Sir," said he, "it is I, as you will shortly learn, who have
+convened you, for it is I who am the most aggrieved. I have not got wind
+of any host approaching about which I would warn you, nor is there any
+matter of public moment on which I would speak. My grievance is purely
+personal, and turns on two great misfortunes which have fallen upon my
+house. The first of these is the loss of my excellent father, who was
+chief among all you here present, and was like a father to every one
+of you; the second is much more serious, and ere long will be the utter
+ruin of my estate. The sons of all the chief men among you are pestering
+my mother to marry them against her will. They are afraid to go to
+her father Icarius, asking him to choose the one he likes best, and
+to provide marriage gifts for his daughter, but day by day they keep
+hanging about my father's house, sacrificing our oxen, sheep, and fat
+goats for their banquets, and never giving so much as a thought to the
+quantity of wine they drink. No estate can stand such recklessness; we
+have now no Ulysses to ward off harm from our doors, and I cannot hold
+my own against them. I shall never all my days be as good a man as he
+was, still I would indeed defend myself if I had power to do so, for I
+cannot stand such treatment any longer; my house is being disgraced and
+ruined. Have respect, therefore, to your own consciences and to public
+opinion. Fear, too, the wrath of heaven, lest the gods should be
+displeased and turn upon you. I pray you by Jove and Themis, who is the
+beginning and the end of councils, [do not] hold back, my friends, and
+leave me singlehanded {18}--unless it be that my brave father Ulysses
+did some wrong to the Achaeans which you would now avenge on me, by
+aiding and abetting these suitors. Moreover, if I am to be eaten out of
+house and home at all, I had rather you did the eating yourselves, for
+I could then take action against you to some purpose, and serve you with
+notices from house to house till I got paid in full, whereas now I have
+no remedy." {19}
+
+With this Telemachus dashed his staff to the ground and burst into
+tears. Every one was very sorry for him, but they all sat still and no
+one ventured to make him an angry answer, save only Antinous, who spoke
+thus:
+
+"Telemachus, insolent braggart that you are, how dare you try to throw
+the blame upon us suitors? It is your mother's fault not ours, for she
+is a very artful woman. This three years past, and close on four, she
+had been driving us out of our minds, by encouraging each one of us, and
+sending him messages without meaning one word of what she says. And then
+there was that other trick she played us. She set up a great tambour
+frame in her room, and began to work on an enormous piece of fine
+needlework. 'Sweet hearts,' said she, 'Ulysses is indeed dead, still
+do not press me to marry again immediately, wait--for I would not have
+skill in needlework perish unrecorded--till I have completed a pall for
+the hero Laertes, to be in readiness against the time when death shall
+take him. He is very rich, and the women of the place will talk if he is
+laid out without a pall.'
+
+"This was what she said, and we assented; whereon we could see her
+working on her great web all day long, but at night she would unpick the
+stitches again by torchlight. She fooled us in this way for three years
+and we never found her out, but as time wore on and she was now in her
+fourth year, one of her maids who knew what she was doing told us, and
+we caught her in the act of undoing her work, so she had to finish it
+whether she would or no. The suitors, therefore, make you this answer,
+that both you and the Achaeans may understand-'Send your mother away,
+and bid her marry the man of her own and of her father's choice'; for I
+do not know what will happen if she goes on plaguing us much longer with
+the airs she gives herself on the score of the accomplishments Minerva
+has taught her, and because she is so clever. We never yet heard of such
+a woman; we know all about Tyro, Alcmena, Mycene, and the famous women
+of old, but they were nothing to your mother any one of them. It was not
+fair of her to treat us in that way, and as long as she continues in
+the mind with which heaven has now endowed her, so long shall we go on
+eating up your estate; and I do not see why she should change, for she
+gets all the honour and glory, and it is you who pay for it, not she.
+Understand, then, that we will not go back to our lands, neither here
+nor elsewhere, till she has made her choice and married some one or
+other of us."
+
+Telemachus answered, "Antinous, how can I drive the mother who bore me
+from my father's house? My father is abroad and we do not know whether
+he is alive or dead. It will be hard on me if I have to pay Icarius the
+large sum which I must give him if I insist on sending his daughter back
+to him. Not only will he deal rigorously with me, but heaven will also
+punish me; for my mother when she leaves the house will call on the
+Erinyes to avenge her; besides, it would not be a creditable thing to
+do, and I will have nothing to say to it. If you choose to take offence
+at this, leave the house and feast elsewhere at one another's houses at
+your own cost turn and turn about. If, on the other hand, you elect to
+persist in spunging upon one man, heaven help me, but Jove shall reckon
+with you in full, and when you fall in my father's house there shall be
+no man to avenge you."
+
+As he spoke Jove sent two eagles from the top of the mountain, and they
+flew on and on with the wind, sailing side by side in their own lordly
+flight. When they were right over the middle of the assembly they
+wheeled and circled about, beating the air with their wings and glaring
+death into the eyes of them that were below; then, fighting fiercely and
+tearing at one another, they flew off towards the right over the town.
+The people wondered as they saw them, and asked each other what all this
+might be; whereon Halitherses, who was the best prophet and reader of
+omens among them, spoke to them plainly and in all honesty, saying:
+
+"Hear me, men of Ithaca, and I speak more particularly to the suitors,
+for I see mischief brewing for them. Ulysses is not going to be
+away much longer; indeed he is close at hand to deal out death and
+destruction, not on them alone, but on many another of us who live in
+Ithaca. Let us then be wise in time, and put a stop to this wickedness
+before he comes. Let the suitors do so of their own accord; it will
+be better for them, for I am not prophesying without due knowledge;
+everything has happened to Ulysses as I foretold when the Argives set
+out for Troy, and he with them. I said that after going through much
+hardship and losing all his men he should come home again in the
+twentieth year and that no one would know him; and now all this is
+coming true."
+
+Eurymachus son of Polybus then said, "Go home, old man, and prophesy to
+your own children, or it may be worse for them. I can read these omens
+myself much better than you can; birds are always flying about in the
+sunshine somewhere or other, but they seldom mean anything. Ulysses has
+died in a far country, and it is a pity you are not dead along with
+him, instead of prating here about omens and adding fuel to the anger of
+Telemachus which is fierce enough as it is. I suppose you think he will
+give you something for your family, but I tell you--and it shall surely
+be--when an old man like you, who should know better, talks a young one
+over till he becomes troublesome, in the first place his young friend
+will only fare so much the worse--he will take nothing by it, for the
+suitors will prevent this--and in the next, we will lay a heavier fine,
+sir, upon yourself than you will at all like paying, for it will bear
+hardly upon you. As for Telemachus, I warn him in the presence of you
+all to send his mother back to her father, who will find her a husband
+and provide her with all the marriage gifts so dear a daughter may
+expect. Till then we shall go on harassing him with our suit; for we
+fear no man, and care neither for him, with all his fine speeches, nor
+for any fortune-telling of yours. You may preach as much as you please,
+but we shall only hate you the more. We shall go back and continue to
+eat up Telemachus's estate without paying him, till such time as his
+mother leaves off tormenting us by keeping us day after day on the
+tiptoe of expectation, each vying with the other in his suit for a prize
+of such rare perfection. Besides we cannot go after the other women whom
+we should marry in due course, but for the way in which she treats us."
+
+Then Telemachus said, "Eurymachus, and you other suitors, I shall say no
+more, and entreat you no further, for the gods and the people of Ithaca
+now know my story. Give me, then, a ship and a crew of twenty men to
+take me hither and thither, and I will go to Sparta and to Pylos in
+quest of my father who has so long been missing. Some one may tell
+me something, or (and people often hear things in this way) some
+heaven-sent message may direct me. If I can hear of him as alive and on
+his way home I will put up with the waste you suitors will make for yet
+another twelve months. If on the other hand I hear of his death, I will
+return at once, celebrate his funeral rites with all due pomp, build a
+barrow to his memory, and make my mother marry again."
+
+With these words he sat down, and Mentor {20} who had been a friend of
+Ulysses, and had been left in charge of everything with full authority
+over the servants, rose to speak. He, then, plainly and in all honesty
+addressed them thus:
+
+"Hear me, men of Ithaca, I hope that you may never have a kind and
+well-disposed ruler any more, nor one who will govern you equitably;
+I hope that all your chiefs henceforward may be cruel and unjust, for
+there is not one of you but has forgotten Ulysses, who ruled you as
+though he were your father. I am not half so angry with the suitors, for
+if they choose to do violence in the naughtiness of their hearts, and
+wager their heads that Ulysses will not return, they can take the high
+hand and eat up his estate, but as for you others I am shocked at
+the way in which you all sit still without even trying to stop such
+scandalous goings on--which you could do if you chose, for you are many
+and they are few."
+
+Leiocritus, son of Evenor, answered him saying, "Mentor, what folly is
+all this, that you should set the people to stay us? It is a hard thing
+for one man to fight with many about his victuals. Even though Ulysses
+himself were to set upon us while we are feasting in his house, and do
+his best to oust us, his wife, who wants him back so very badly, would
+have small cause for rejoicing, and his blood would be upon his own head
+if he fought against such great odds. There is no sense in what you have
+been saying. Now, therefore, do you people go about your business, and
+let his father's old friends, Mentor and Halitherses, speed this boy on
+his journey, if he goes at all--which I do not think he will, for he
+is more likely to stay where he is till some one comes and tells him
+something."
+
+On this he broke up the assembly, and every man went back to his own
+abode, while the suitors returned to the house of Ulysses.
+
+Then Telemachus went all alone by the sea side, washed his hands in the
+grey waves, and prayed to Minerva.
+
+"Hear me," he cried, "you god who visited me yesterday, and bade me sail
+the seas in search of my father who has so long been missing. I would
+obey you, but the Achaeans, and more particularly the wicked suitors,
+are hindering me that I cannot do so."
+
+As he thus prayed, Minerva came close up to him in the likeness and with
+the voice of Mentor. "Telemachus," said she, "if you are made of
+the same stuff as your father you will be neither fool nor coward
+henceforward, for Ulysses never broke his word nor left his work half
+done. If, then, you take after him, your voyage will not be fruitless,
+but unless you have the blood of Ulysses and of Penelope in your veins
+I see no likelihood of your succeeding. Sons are seldom as good men as
+their fathers; they are generally worse, not better; still, as you are
+not going to be either fool or coward henceforward, and are not entirely
+without some share of your father's wise discernment, I look with hope
+upon your undertaking. But mind you never make common cause with any of
+those foolish suitors, for they have neither sense nor virtue, and give
+no thought to death and to the doom that will shortly fall on one and
+all of them, so that they shall perish on the same day. As for your
+voyage, it shall not be long delayed; your father was such an old friend
+of mine that I will find you a ship, and will come with you myself.
+Now, however, return home, and go about among the suitors; begin getting
+provisions ready for your voyage; see everything well stowed, the wine
+in jars, and the barley meal, which is the staff of life, in leathern
+bags, while I go round the town and beat up volunteers at once. There
+are many ships in Ithaca both old and new; I will run my eye over them
+for you and will choose the best; we will get her ready and will put out
+to sea without delay."
+
+Thus spoke Minerva daughter of Jove, and Telemachus lost no time in
+doing as the goddess told him. He went moodily home, and found the
+suitors flaying goats and singeing pigs in the outer court. Antinous
+came up to him at once and laughed as he took his hand in his own,
+saying, "Telemachus, my fine fire-eater, bear no more ill blood neither
+in word nor deed, but eat and drink with us as you used to do. The
+Achaeans will find you in everything--a ship and a picked crew to
+boot--so that you can set sail for Pylos at once and get news of your
+noble father."
+
+"Antinous," answered Telemachus, "I cannot eat in peace, nor take
+pleasure of any kind with such men as you are. Was it not enough that
+you should waste so much good property of mine while I was yet a boy?
+Now that I am older and know more about it, I am also stronger, and
+whether here among this people, or by going to Pylos, I will do you all
+the harm I can. I shall go, and my going will not be in vain--though,
+thanks to you suitors, I have neither ship nor crew of my own, and must
+be passenger not captain."
+
+As he spoke he snatched his hand from that of Antinous. Meanwhile the
+others went on getting dinner ready about the buildings, {21} jeering at
+him tauntingly as they did so.
+
+"Telemachus," said one youngster, "means to be the death of us; I
+suppose he thinks he can bring friends to help him from Pylos, or again
+from Sparta, where he seems bent on going. Or will he go to Ephyra as
+well, for poison to put in our wine and kill us?"
+
+Another said, "Perhaps if Telemachus goes on board ship, he will be like
+his father and perish far from his friends. In this case we should have
+plenty to do, for we could then divide up his property amongst us: as
+for the house we can let his mother and the man who marries her have
+that."
+
+This was how they talked. But Telemachus went down into the lofty and
+spacious store-room where his father's treasure of gold and bronze lay
+heaped up upon the floor, and where the linen and spare clothes were
+kept in open chests. Here, too, there was a store of fragrant olive oil,
+while casks of old, well-ripened wine, unblended and fit for a god to
+drink, were ranged against the wall in case Ulysses should come home
+again after all. The room was closed with well-made doors opening in the
+middle; moreover the faithful old house-keeper Euryclea, daughter of
+Ops the son of Pisenor, was in charge of everything both night and day.
+Telemachus called her to the store-room and said:
+
+"Nurse, draw me off some of the best wine you have, after what you
+are keeping for my father's own drinking, in case, poor man, he should
+escape death, and find his way home again after all. Let me have twelve
+jars, and see that they all have lids; also fill me some well-sewn
+leathern bags with barley meal--about twenty measures in all. Get these
+things put together at once, and say nothing about it. I will take
+everything away this evening as soon as my mother has gone upstairs
+for the night. I am going to Sparta and to Pylos to see if I can hear
+anything about the return of my dear father."
+
+When Euryclea heard this she began to cry, and spoke fondly to him,
+saying, "My dear child, what ever can have put such notion as that into
+your head? Where in the world do you want to go to--you, who are the
+one hope of the house? Your poor father is dead and gone in some foreign
+country nobody knows where, and as soon as your back is turned these
+wicked ones here will be scheming to get you put out of the way, and
+will share all your possessions among themselves; stay where you are
+among your own people, and do not go wandering and worrying your life
+out on the barren ocean."
+
+"Fear not, nurse," answered Telemachus, "my scheme is not without
+heaven's sanction; but swear that you will say nothing about all this
+to my mother, till I have been away some ten or twelve days, unless she
+hears of my having gone, and asks you; for I do not want her to spoil
+her beauty by crying."
+
+The old woman swore most solemnly that she would not, and when she
+had completed her oath, she began drawing off the wine into jars, and
+getting the barley meal into the bags, while Telemachus went back to the
+suitors.
+
+Then Minerva bethought her of another matter. She took his shape, and
+went round the town to each one of the crew, telling them to meet at the
+ship by sundown. She went also to Noemon son of Phronius, and asked him
+to let her have a ship--which he was very ready to do. When the sun had
+set and darkness was over all the land, she got the ship into the
+water, put all the tackle on board her that ships generally carry, and
+stationed her at the end of the harbour. Presently the crew came up, and
+the goddess spoke encouragingly to each of them.
+
+Furthermore she went to the house of Ulysses, and threw the suitors into
+a deep slumber. She caused their drink to fuddle them, and made them
+drop their cups from their hands, so that instead of sitting over their
+wine, they went back into the town to sleep, with their eyes heavy and
+full of drowsiness. Then she took the form and voice of Mentor, and
+called Telemachus to come outside.
+
+"Telemachus," said she, "the men are on board and at their oars, waiting
+for you to give your orders, so make haste and let us be off."
+
+On this she led the way, while Telemachus followed in her steps. When
+they got to the ship they found the crew waiting by the water side, and
+Telemachus said, "Now my men, help me to get the stores on board;
+they are all put together in the cloister, and my mother does not know
+anything about it, nor any of the maid servants except one."
+
+With these words he led the way and the others followed after. When
+they had brought the things as he told them, Telemachus went on board,
+Minerva going before him and taking her seat in the stern of the vessel,
+while Telemachus sat beside her. Then the men loosed the hawsers and
+took their places on the benches. Minerva sent them a fair wind from
+the West, {22} that whistled over the deep blue waves {23} whereon
+Telemachus told them to catch hold of the ropes and hoist sail, and they
+did as he told them. They set the mast in its socket in the cross plank,
+raised it, and made it fast with the forestays; then they hoisted their
+white sails aloft with ropes of twisted ox hide. As the sail bellied out
+with the wind, the ship flew through the deep blue water, and the foam
+hissed against her bows as she sped onward. Then they made all fast
+throughout the ship, filled the mixing bowls to the brim, and made
+drink offerings to the immortal gods that are from everlasting, but more
+particularly to the grey-eyed daughter of Jove.
+
+Thus, then, the ship sped on her way through the watches of the night
+from dark till dawn,
+
+
+Book III
+
+TELEMACHUS VISITS NESTOR AT PYLOS.
+
+but as the sun was rising from the fair sea {24} into the firmament of
+heaven to shed light on mortals and immortals, they reached Pylos the
+city of Neleus. Now the people of Pylos were gathered on the sea shore
+to offer sacrifice of black bulls to Neptune lord of the Earthquake.
+There were nine guilds with five hundred men in each, and there were
+nine bulls to each guild. As they were eating the inward meats {25}
+and burning the thigh bones [on the embers] in the name of Neptune,
+Telemachus and his crew arrived, furled their sails, brought their ship
+to anchor, and went ashore.
+
+Minerva led the way and Telemachus followed her. Presently she said,
+"Telemachus, you must not be in the least shy or nervous; you have taken
+this voyage to try and find out where your father is buried and how he
+came by his end; so go straight up to Nestor that we may see what he has
+got to tell us. Beg of him to speak the truth, and he will tell no lies,
+for he is an excellent person."
+
+"But how, Mentor," replied Telemachus, "dare I go up to Nestor, and
+how am I to address him? I have never yet been used to holding long
+conversations with people, and am ashamed to begin questioning one who
+is so much older than myself."
+
+"Some things, Telemachus," answered Minerva, "will be suggested to
+you by your own instinct, and heaven will prompt you further; for I am
+assured that the gods have been with you from the time of your birth
+until now."
+
+She then went quickly on, and Telemachus followed in her steps till they
+reached the place where the guilds of the Pylian people were assembled.
+There they found Nestor sitting with his sons, while his company round
+him were busy getting dinner ready, and putting pieces of meat on to the
+spits {26} while other pieces were cooking. When they saw the strangers
+they crowded round them, took them by the hand and bade them take their
+places. Nestor's son Pisistratus at once offered his hand to each of
+them, and seated them on some soft sheepskins that were lying on the
+sands near his father and his brother Thrasymedes. Then he gave them
+their portions of the inward meats and poured wine for them into a
+golden cup, handing it to Minerva first, and saluting her at the same
+time.
+
+"Offer a prayer, sir," said he, "to King Neptune, for it is his feast
+that you are joining; when you have duly prayed and made your drink
+offering, pass the cup to your friend that he may do so also. I doubt
+not that he too lifts his hands in prayer, for man cannot live without
+God in the world. Still he is younger than you are, and is much of an
+age with myself, so I will give you the precedence."
+
+As he spoke he handed her the cup. Minerva thought it very right and
+proper of him to have given it to herself first; {27} she accordingly
+began praying heartily to Neptune. "O thou," she cried, "that encirclest
+the earth, vouchsafe to grant the prayers of thy servants that call upon
+thee. More especially we pray thee send down thy grace on Nestor and
+on his sons; thereafter also make the rest of the Pylian people some
+handsome return for the goodly hecatomb they are offering you. Lastly,
+grant Telemachus and myself a happy issue, in respect of the matter that
+has brought us in our ship to Pylos."
+
+When she had thus made an end of praying, she handed the cup to
+Telemachus and he prayed likewise. By and by, when the outer meats were
+roasted and had been taken off the spits, the carvers gave every man his
+portion and they all made an excellent dinner. As soon as they had had
+enough to eat and drink, Nestor, knight of Gerene, began to speak.
+
+"Now," said he, "that our guests have done their dinner, it will be best
+to ask them who they are. Who, then, sir strangers, are you, and from
+what port have you sailed? Are you traders? or do you sail the seas as
+rovers with your hand against every man, and every man's hand against
+you?"
+
+Telemachus answered boldly, for Minerva had given him courage to ask
+about his father and get himself a good name.
+
+"Nestor," said he, "son of Neleus, honour to the Achaean name, you ask
+whence we come, and I will tell you. We come from Ithaca under Neritum,
+{28} and the matter about which I would speak is of private not public
+import. I seek news of my unhappy father Ulysses, who is said to have
+sacked the town of Troy in company with yourself. We know what fate
+befell each one of the other heroes who fought at Troy, but as regards
+Ulysses heaven has hidden from us the knowledge even that he is dead
+at all, for no one can certify us in what place he perished, nor say
+whether he fell in battle on the mainland, or was lost at sea amid the
+waves of Amphitrite. Therefore I am suppliant at your knees, if haply
+you may be pleased to tell me of his melancholy end, whether you saw it
+with your own eyes, or heard it from some other traveller, for he was
+a man born to trouble. Do not soften things out of any pity for me,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service, either by word or deed, when you
+Achaeans were harassed among the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+"My friend," answered Nestor, "you recall a time of much sorrow to
+my mind, for the brave Achaeans suffered much both at sea, while
+privateering under Achilles, and when fighting before the great city
+of king Priam. Our best men all of them fell there--Ajax, Achilles,
+Patroclus peer of gods in counsel, and my own dear son Antilochus, a man
+singularly fleet of foot and in fight valiant. But we suffered much more
+than this; what mortal tongue indeed could tell the whole story? Though
+you were to stay here and question me for five years, or even six, I
+could not tell you all that the Achaeans suffered, and you would turn
+homeward weary of my tale before it ended. Nine long years did we try
+every kind of stratagem, but the hand of heaven was against us; during
+all this time there was no one who could compare with your father in
+subtlety--if indeed you are his son--I can hardly believe my eyes--and
+you talk just like him too--no one would say that people of such
+different ages could speak so much alike. He and I never had any kind
+of difference from first to last neither in camp nor council, but in
+singleness of heart and purpose we advised the Argives how all might be
+ordered for the best.
+
+"When, however, we had sacked the city of Priam, and were setting sail
+in our ships as heaven had dispersed us, then Jove saw fit to vex the
+Argives on their homeward voyage; for they had not all been either
+wise or understanding, and hence many came to a bad end through the
+displeasure of Jove's daughter Minerva, who brought about a quarrel
+between the two sons of Atreus.
+
+"The sons of Atreus called a meeting which was not as it should be, for
+it was sunset and the Achaeans were heavy with wine. When they explained
+why they had called the people together, it seemed that Menelaus was
+for sailing homeward at once, and this displeased Agamemnon, who thought
+that we should wait till we had offered hecatombs to appease the anger
+of Minerva. Fool that he was, he might have known that he would not
+prevail with her, for when the gods have made up their minds they do not
+change them lightly. So the two stood bandying hard words, whereon the
+Achaeans sprang to their feet with a cry that rent the air, and were of
+two minds as to what they should do.
+
+"That night we rested and nursed our anger, for Jove was hatching
+mischief against us. But in the morning some of us drew our ships into
+the water and put our goods with our women on board, while the rest,
+about half in number, stayed behind with Agamemnon. We--the other
+half--embarked and sailed; and the ships went well, for heaven had
+smoothed the sea. When we reached Tenedos we offered sacrifices to the
+gods, for we were longing to get home; cruel Jove, however, did not yet
+mean that we should do so, and raised a second quarrel in the course of
+which some among us turned their ships back again, and sailed away under
+Ulysses to make their peace with Agamemnon; but I, and all the ships
+that were with me pressed forward, for I saw that mischief was brewing.
+The son of Tydeus went on also with me, and his crews with him. Later on
+Menelaus joined us at Lesbos, and found us making up our minds about our
+course--for we did not know whether to go outside Chios by the island
+of Psyra, keeping this to our left, or inside Chios, over against the
+stormy headland of Mimas. So we asked heaven for a sign, and were shown
+one to the effect that we should be soonest out of danger if we headed
+our ships across the open sea to Euboea. This we therefore did, and a
+fair wind sprang up which gave us a quick passage during the night to
+Geraestus, {29} where we offered many sacrifices to Neptune for
+having helped us so far on our way. Four days later Diomed and his men
+stationed their ships in Argos, but I held on for Pylos, and the wind
+never fell light from the day when heaven first made it fair for me.
+
+"Therefore, my dear young friend, I returned without hearing anything
+about the others. I know neither who got home safely nor who were lost
+but, as in duty bound, I will give you without reserve the reports that
+have reached me since I have been here in my own house. They say the
+Myrmidons returned home safely under Achilles' son Neoptolemus; so also
+did the valiant son of Poias, Philoctetes. Idomeneus, again, lost no men
+at sea, and all his followers who escaped death in the field got safe
+home with him to Crete. No matter how far out of the world you live, you
+will have heard of Agamemnon and the bad end he came to at the hands of
+Aegisthus--and a fearful reckoning did Aegisthus presently pay. See what
+a good thing it is for a man to leave a son behind him to do as Orestes
+did, who killed false Aegisthus the murderer of his noble father. You
+too, then--for you are a tall smart-looking fellow--show your mettle and
+make yourself a name in story."
+
+"Nestor son of Neleus," answered Telemachus, "honour to the Achaean
+name, the Achaeans applaud Orestes and his name will live through all
+time for he has avenged his father nobly. Would that heaven might grant
+me to do like vengeance on the insolence of the wicked suitors, who
+are ill treating me and plotting my ruin; but the gods have no such
+happiness in store for me and for my father, so we must bear it as best
+we may."
+
+"My friend," said Nestor, "now that you remind me, I remember to have
+heard that your mother has many suitors, who are ill disposed towards
+you and are making havoc of your estate. Do you submit to this tamely,
+or are public feeling and the voice of heaven against you? Who knows but
+what Ulysses may come back after all, and pay these scoundrels in full,
+either single-handed or with a force of Achaeans behind him? If Minerva
+were to take as great a liking to you as she did to Ulysses when we were
+fighting before Troy (for I never yet saw the gods so openly fond of any
+one as Minerva then was of your father), if she would take as good care
+of you as she did of him, these wooers would soon some of them forget
+their wooing."
+
+Telemachus answered, "I can expect nothing of the kind; it would be far
+too much to hope for. I dare not let myself think of it. Even though the
+gods themselves willed it no such good fortune could befall me."
+
+On this Minerva said, "Telemachus, what are you talking about? Heaven
+has a long arm if it is minded to save a man; and if it were me, I
+should not care how much I suffered before getting home, provided I
+could be safe when I was once there. I would rather this, than get home
+quickly, and then be killed in my own house as Agamemnon was by the
+treachery of Aegisthus and his wife. Still, death is certain, and when
+a man's hour is come, not even the gods can save him, no matter how fond
+they are of him."
+
+"Mentor," answered Telemachus, "do not let us talk about it any more.
+There is no chance of my father's ever coming back; the gods have long
+since counselled his destruction. There is something else, however,
+about which I should like to ask Nestor, for he knows much more than any
+one else does. They say he has reigned for three generations so that it
+is like talking to an immortal. Tell me, therefore, Nestor, and tell
+me true; how did Agamemnon come to die in that way? What was Menelaus
+doing? And how came false Aegisthus to kill so far better a man than
+himself? Was Menelaus away from Achaean Argos, voyaging elsewhither
+among mankind, that Aegisthus took heart and killed Agamemnon?"
+
+"I will tell you truly," answered Nestor, "and indeed you have yourself
+divined how it all happened. If Menelaus when he got back from Troy
+had found Aegisthus still alive in his house, there would have been no
+barrow heaped up for him, not even when he was dead, but he would have
+been thrown outside the city to dogs and vultures, and not a woman would
+have mourned him, for he had done a deed of great wickedness; but we
+were over there, fighting hard at Troy, and Aegisthus, who was taking
+his ease quietly in the heart of Argos, cajoled Agamemnon's wife
+Clytemnestra with incessant flattery.
+
+"At first she would have nothing to do with his wicked scheme, for she
+was of a good natural disposition; {30} moreover there was a bard with
+her, to whom Agamemnon had given strict orders on setting out for Troy,
+that he was to keep guard over his wife; but when heaven had counselled
+her destruction, Aegisthus carried this bard off to a desert island and
+left him there for crows and seagulls to batten upon--after which she
+went willingly enough to the house of Aegisthus. Then he offered many
+burnt sacrifices to the gods, and decorated many temples with tapestries
+and gilding, for he had succeeded far beyond his expectations.
+
+"Meanwhile Menelaus and I were on our way home from Troy, on good terms
+with one another. When we got to Sunium, which is the point of Athens,
+Apollo with his painless shafts killed Phrontis the steersman of
+Menelaus' ship (and never man knew better how to handle a vessel in
+rough weather) so that he died then and there with the helm in his hand,
+and Menelaus, though very anxious to press forward, had to wait in order
+to bury his comrade and give him his due funeral rites. Presently, when
+he too could put to sea again, and had sailed on as far as the Malean
+heads, Jove counselled evil against him and made it blow hard till the
+waves ran mountains high. Here he divided his fleet and took the one
+half towards Crete where the Cydonians dwell round about the waters of
+the river Iardanus. There is a high headland hereabouts stretching out
+into the sea from a place called Gortyn, and all along this part of the
+coast as far as Phaestus the sea runs high when there is a south wind
+blowing, but after Phaestus the coast is more protected, for a small
+headland can make a great shelter. Here this part of the fleet was
+driven on to the rocks and wrecked; but the crews just managed to save
+themselves. As for the other five ships, they were taken by winds and
+seas to Egypt, where Menelaus gathered much gold and substance among
+people of an alien speech. Meanwhile Aegisthus here at home plotted his
+evil deed. For seven years after he had killed Agamemnon he ruled in
+Mycene, and the people were obedient under him, but in the eighth year
+Orestes came back from Athens to be his bane, and killed the murderer
+of his father. Then he celebrated the funeral rites of his mother and
+of false Aegisthus by a banquet to the people of Argos, and on that very
+day Menelaus came home, {31} with as much treasure as his ships could
+carry.
+
+"Take my advice then, and do not go travelling about for long so far
+from home, nor leave your property with such dangerous people in your
+house; they will eat up everything you have among them, and you will
+have been on a fool's errand. Still, I should advise you by all means
+to go and visit Menelaus, who has lately come off a voyage among such
+distant peoples as no man could ever hope to get back from, when the
+winds had once carried him so far out of his reckoning; even birds
+cannot fly the distance in a twelve-month, so vast and terrible are the
+seas that they must cross. Go to him, therefore, by sea, and take your
+own men with you; or if you would rather travel by land you can have a
+chariot, you can have horses, and here are my sons who can escort you to
+Lacedaemon where Menelaus lives. Beg of him to speak the truth, and he
+will tell you no lies, for he is an excellent person."
+
+As he spoke the sun set and it came on dark, whereon Minerva said, "Sir,
+all that you have said is well; now, however, order the tongues of the
+victims to be cut, and mix wine that we may make drink-offerings to
+Neptune, and the other immortals, and then go to bed, for it is bed
+time. People should go away early and not keep late hours at a religious
+festival."
+
+Thus spoke the daughter of Jove, and they obeyed her saying. Men
+servants poured water over the hands of the guests, while pages filled
+the mixing-bowls with wine and water, and handed it round after giving
+every man his drink offering; then they threw the tongues of the victims
+into the fire, and stood up to make their drink offerings. When they
+had made their offerings and had drunk each as much as he was minded,
+Minerva and Telemachus were for going on board their ship, but Nestor
+caught them up at once and stayed them.
+
+"Heaven and the immortal gods," he exclaimed, "forbid that you should
+leave my house to go on board of a ship. Do you think I am so poor and
+short of clothes, or that I have so few cloaks and as to be unable to
+find comfortable beds both for myself and for my guests? Let me tell you
+I have store both of rugs and cloaks, and shall not permit the son of
+my old friend Ulysses to camp down on the deck of a ship--not while I
+live--nor yet will my sons after me, but they will keep open house as I
+have done."
+
+Then Minerva answered, "Sir, you have spoken well, and it will be much
+better that Telemachus should do as you have said; he, therefore, shall
+return with you and sleep at your house, but I must go back to give
+orders to my crew, and keep them in good heart. I am the only older
+person among them; the rest are all young men of Telemachus' own age,
+who have taken this voyage out of friendship; so I must return to the
+ship and sleep there. Moreover to-morrow I must go to the Cauconians
+where I have a large sum of money long owing to me. As for Telemachus,
+now that he is your guest, send him to Lacedaemon in a chariot, and let
+one of your sons go with him. Be pleased to also provide him with your
+best and fleetest horses."
+
+When she had thus spoken, she flew away in the form of an eagle, and all
+marvelled as they beheld it. Nestor was astonished, and took Telemachus
+by the hand. "My friend," said he, "I see that you are going to be a
+great hero some day, since the gods wait upon you thus while you are
+still so young. This can have been none other of those who dwell in
+heaven than Jove's redoubtable daughter, the Trito-born, who shewed
+such favour towards your brave father among the Argives. Holy queen," he
+continued, "vouchsafe to send down thy grace upon myself, my good wife,
+and my children. In return, I will offer you in sacrifice a broad-browed
+heifer of a year old, unbroken, and never yet brought by man under the
+yoke. I will gild her horns, and will offer her up to you in sacrifice."
+
+Thus did he pray, and Minerva heard his prayer. He then led the way to
+his own house, followed by his sons and sons in law. When they had got
+there and had taken their places on the benches and seats, he mixed them
+a bowl of sweet wine that was eleven years old when the housekeeper took
+the lid off the jar that held it. As he mixed the wine, he prayed much
+and made drink offerings to Minerva, daughter of Aegis-bearing Jove.
+Then, when they had made their drink offerings and had drunk each as
+much as he was minded, the others went home to bed each in his own
+abode; but Nestor put Telemachus to sleep in the room that was over the
+gateway along with Pisistratus, who was the only unmarried son now left
+him. As for himself, he slept in an inner room of the house, with the
+queen his wife by his side.
+
+Now when the child of morning rosy-fingered Dawn appeared, Nestor left
+his couch and took his seat on the benches of white and polished marble
+that stood in front of his house. Here aforetime sat Neleus, peer of
+gods in counsel, but he was now dead, and had gone to the house of
+Hades; so Nestor sat in his seat sceptre in hand, as guardian of the
+public weal. His sons as they left their rooms gathered round him,
+Echephron, Stratius, Perseus, Aretus, and Thrasymedes; the sixth son
+was Pisistratus, and when Telemachus joined them they made him sit with
+them. Nestor then addressed them.
+
+"My sons," said he, "make haste to do as I shall bid you. I wish first
+and foremost to propitiate the great goddess Minerva, who manifested
+herself visibly to me during yesterday's festivities. Go, then, one or
+other of you to the plain, tell the stockman to look me out a heifer,
+and come on here with it at once. Another must go to Telemachus' ship,
+and invite all the crew, leaving two men only in charge of the vessel.
+Some one else will run and fetch Laerceus the goldsmith to gild the
+horns of the heifer. The rest, stay all of you where you are; tell the
+maids in the house to prepare an excellent dinner, and to fetch seats,
+and logs of wood for a burnt offering. Tell them also to bring me some
+clear spring water."
+
+On this they hurried off on their several errands. The heifer was
+brought in from the plain, and Telemachus's crew came from the ship; the
+goldsmith brought the anvil, hammer, and tongs, with which he worked his
+gold, and Minerva herself came to accept the sacrifice. Nestor gave out
+the gold, and the smith gilded the horns of the heifer that the goddess
+might have pleasure in their beauty. Then Stratius and Echephron brought
+her in by the horns; Aretus fetched water from the house in a ewer that
+had a flower pattern on it, and in his other hand he held a basket of
+barley meal; sturdy Thrasymedes stood by with a sharp axe, ready to
+strike the heifer, while Perseus held a bucket. Then Nestor began with
+washing his hands and sprinkling the barley meal, and he offered many
+a prayer to Minerva as he threw a lock from the heifer's head upon the
+fire.
+
+When they had done praying and sprinkling the barley meal {32}
+Thrasymedes dealt his blow, and brought the heifer down with a stroke
+that cut through the tendons at the base of her neck, whereon the
+daughters and daughters in law of Nestor, and his venerable wife
+Eurydice (she was eldest daughter to Clymenus) screamed with delight.
+Then they lifted the heifer's head from off the ground, and Pisistratus
+cut her throat. When she had done bleeding and was quite dead, they cut
+her up. They cut out the thigh bones all in due course, wrapped them
+round in two layers of fat, and set some pieces of raw meat on the top
+of them; then Nestor laid them upon the wood fire and poured wine over
+them, while the young men stood near him with five-pronged spits in
+their hands. When the thighs were burned and they had tasted the inward
+meats, they cut the rest of the meat up small, put the pieces on the
+spits and toasted them over the fire.
+
+Meanwhile lovely Polycaste, Nestor's youngest daughter, washed
+Telemachus. When she had washed him and anointed him with oil, she
+brought him a fair mantle and shirt, {33} and he looked like a god as
+he came from the bath and took his seat by the side of Nestor. When
+the outer meats were done they drew them off the spits and sat down to
+dinner where they were waited upon by some worthy henchmen, who kept
+pouring them out their wine in cups of gold. As soon as they had had
+enough to eat and drink Nestor said, "Sons, put Telemachus's horses to
+the chariot that he may start at once."
+
+Thus did he speak, and they did even as he had said, and yoked the fleet
+horses to the chariot. The housekeeper packed them up a provision
+of bread, wine, and sweet meats fit for the sons of princes. Then
+Telemachus got into the chariot, while Pisistratus gathered up the reins
+and took his seat beside him. He lashed the horses on and they flew
+forward nothing loth into the open country, leaving the high citadel of
+Pylos behind them. All that day did they travel, swaying the yoke upon
+their necks till the sun went down and darkness was over all the land.
+Then they reached Pherae where Diocles lived, who was son to Ortilochus
+and grandson to Alpheus. Here they passed the night and Diocles
+entertained them hospitably. When the child of morning, rosy-fingered
+Dawn, appeared, they again yoked their horses and drove out through the
+gateway under the echoing gatehouse. {34} Pisistratus lashed the horses
+on and they flew forward nothing loth; presently they came to the corn
+lands of the open country, and in the course of time completed their
+journey, so well did their steeds take them. {35}
+
+Now when the sun had set and darkness was over the land,
+
+
+Book IV
+
+THE VISIT TO KING MENELAUS, WHO TELLS HIS STORY--MEANWHILE THE SUITORS
+IN ITHACA PLOT AGAINST TELEMACHUS.
+
+they reached the low lying city of Lacedaemon, where they drove straight
+to the abode of Menelaus {36} [and found him in his own house, feasting
+with his many clansmen in honour of the wedding of his son, and also of
+his daughter, whom he was marrying to the son of that valiant warrior
+Achilles. He had given his consent and promised her to him while he was
+still at Troy, and now the gods were bringing the marriage about; so he
+was sending her with chariots and horses to the city of the Myrmidons
+over whom Achilles' son was reigning. For his only son he had found a
+bride from Sparta, {37} the daughter of Alector. This son, Megapenthes,
+was born to him of a bondwoman, for heaven vouchsafed Helen no more
+children after she had borne Hermione, who was fair as golden Venus
+herself.
+
+So the neighbours and kinsmen of Menelaus were feasting and making merry
+in his house. There was a bard also to sing to them and play his lyre,
+while two tumblers went about performing in the midst of them when the
+man struck up with his tune.] {38}
+
+Telemachus and the son of Nestor stayed their horses at the gate,
+whereon Eteoneus servant to Menelaus came out, and as soon as he saw
+them ran hurrying back into the house to tell his Master. He went close
+up to him and said, "Menelaus, there are some strangers come here, two
+men, who look like sons of Jove. What are we to do? Shall we take their
+horses out, or tell them to find friends elsewhere as they best can?"
+
+Menelaus was very angry and said, "Eteoneus, son of Boethous, you never
+used to be a fool, but now you talk like a simpleton. Take their horses
+out, of course, and show the strangers in that they may have supper;
+you and I have staid often enough at other people's houses before we got
+back here, where heaven grant that we may rest in peace henceforward."
+
+So Eteoneus bustled back and bade the other servants come with him. They
+took their sweating steeds from under the yoke, made them fast to the
+mangers, and gave them a feed of oats and barley mixed. Then they leaned
+the chariot against the end wall of the courtyard, and led the way into
+the house. Telemachus and Pisistratus were astonished when they saw it,
+for its splendour was as that of the sun and moon; then, when they had
+admired everything to their heart's content, they went into the bath
+room and washed themselves.
+
+When the servants had washed them and anointed them with oil, they
+brought them woollen cloaks and shirts, and the two took their seats by
+the side of Menelaus. A maid-servant brought them water in a beautiful
+golden ewer, and poured it into a silver basin for them to wash their
+hands; and she drew a clean table beside them. An upper servant brought
+them bread, and offered them many good things of what there was in the
+house, while the carver fetched them plates of all manner of meats and
+set cups of gold by their side.
+
+Menelaus then greeted them saying, "Fall to, and welcome; when you have
+done supper I shall ask who you are, for the lineage of such men as
+you cannot have been lost. You must be descended from a line of
+sceptre-bearing kings, for poor people do not have such sons as you
+are."
+
+On this he handed them {39} a piece of fat roast loin, which had been
+set near him as being a prime part, and they laid their hands on the
+good things that were before them; as soon as they had had enough to eat
+and drink, Telemachus said to the son of Nestor, with his head so close
+that no one might hear, "Look, Pisistratus, man after my own heart,
+see the gleam of bronze and gold--of amber, {40} ivory, and silver.
+Everything is so splendid that it is like seeing the palace of Olympian
+Jove. I am lost in admiration."
+
+Menelaus overheard him and said, "No one, my sons, can hold his own
+with Jove, for his house and everything about him is immortal; but among
+mortal men--well, there may be another who has as much wealth as I
+have, or there may not; but at all events I have travelled much and have
+undergone much hardship, for it was nearly eight years before I could
+get home with my fleet. I went to Cyprus, Phoenicia and the Egyptians;
+I went also to the Ethiopians, the Sidonians, and the Erembians, and to
+Libya where the lambs have horns as soon as they are born, and the sheep
+lamb down three times a year. Every one in that country, whether master
+or man, has plenty of cheese, meat, and good milk, for the ewes yield
+all the year round. But while I was travelling and getting great riches
+among these people, my brother was secretly and shockingly murdered
+through the perfidy of his wicked wife, so that I have no pleasure in
+being lord of all this wealth. Whoever your parents may be they must
+have told you about all this, and of my heavy loss in the ruin {41} of a
+stately mansion fully and magnificently furnished. Would that I had only
+a third of what I now have so that I had stayed at home, and all those
+were living who perished on the plain of Troy, far from Argos. I often
+grieve, as I sit here in my house, for one and all of them. At times
+I cry aloud for sorrow, but presently I leave off again, for crying is
+cold comfort and one soon tires of it. Yet grieve for these as I may,
+I do so for one man more than for them all. I cannot even think of him
+without loathing both food and sleep, so miserable does he make me, for
+no one of all the Achaeans worked so hard or risked so much as he did.
+He took nothing by it, and has left a legacy of sorrow to myself, for he
+has been gone a long time, and we know not whether he is alive or
+dead. His old father, his long-suffering wife Penelope, and his son
+Telemachus, whom he left behind him an infant in arms, are plunged in
+grief on his account."
+
+Thus spoke Menelaus, and the heart of Telemachus yearned as he bethought
+him of his father. Tears fell from his eyes as he heard him thus
+mentioned, so that he held his cloak before his face with both hands.
+When Menelaus saw this he doubted whether to let him choose his own time
+for speaking, or to ask him at once and find what it was all about.
+
+While he was thus in two minds Helen came down from her high vaulted and
+perfumed room, looking as lovely as Diana herself. Adraste brought her
+a seat, Alcippe a soft woollen rug while Phylo fetched her the silver
+work-box which Alcandra wife of Polybus had given her. Polybus lived in
+Egyptian Thebes, which is the richest city in the whole world; he gave
+Menelaus two baths, both of pure silver, two tripods, and ten talents of
+gold; besides all this, his wife gave Helen some beautiful presents, to
+wit, a golden distaff, and a silver work box that ran on wheels, with a
+gold band round the top of it. Phylo now placed this by her side, full
+of fine spun yarn, and a distaff charged with violet coloured wool was
+laid upon the top of it. Then Helen took her seat, put her feet upon the
+footstool, and began to question her husband. {42}
+
+"Do we know, Menelaus," said she, "the names of these strangers who
+have come to visit us? Shall I guess right or wrong?--but I cannot help
+saying what I think. Never yet have I seen either man or woman so like
+somebody else (indeed when I look at him I hardly know what to think)
+as this young man is like Telemachus, whom Ulysses left as a baby behind
+him, when you Achaeans went to Troy with battle in your hearts, on
+account of my most shameless self."
+
+"My dear wife," replied Menelaus, "I see the likeness just as you do.
+His hands and feet are just like Ulysses; so is his hair, with the shape
+of his head and the expression of his eyes. Moreover, when I was talking
+about Ulysses, and saying how much he had suffered on my account, tears
+fell from his eyes, and he hid his face in his mantle."
+
+Then Pisistratus said, "Menelaus, son of Atreus, you are right in
+thinking that this young man is Telemachus, but he is very modest, and
+is ashamed to come here and begin opening up discourse with one whose
+conversation is so divinely interesting as your own. My father, Nestor,
+sent me to escort him hither, for he wanted to know whether you could
+give him any counsel or suggestion. A son has always trouble at home
+when his father has gone away leaving him without supporters; and this
+is how Telemachus is now placed, for his father is absent, and there is
+no one among his own people to stand by him."
+
+"Bless my heart," replied Menelaus, "then I am receiving a visit from
+the son of a very dear friend, who suffered much hardship for my sake.
+I had always hoped to entertain him with most marked distinction when
+heaven had granted us a safe return from beyond the seas. I should have
+founded a city for him in Argos, and built him a house. I should have
+made him leave Ithaca with his goods, his son, and all his people, and
+should have sacked for them some one of the neighbouring cities that
+are subject to me. We should thus have seen one another continually,
+and nothing but death could have interrupted so close and happy an
+intercourse. I suppose, however, that heaven grudged us such great good
+fortune, for it has prevented the poor fellow from ever getting home at
+all."
+
+Thus did he speak, and his words set them all a weeping. Helen wept,
+Telemachus wept, and so did Menelaus, nor could Pisistratus keep his
+eyes from filling, when he remembered his dear brother Antilochus whom
+the son of bright Dawn had killed. Thereon he said to Menelaus,
+
+"Sir, my father Nestor, when we used to talk about you at home, told me
+you were a person of rare and excellent understanding. If, then, it be
+possible, do as I would urge you. I am not fond of crying while I am
+getting my supper. Morning will come in due course, and in the forenoon
+I care not how much I cry for those that are dead and gone. This is all
+we can do for the poor things. We can only shave our heads for them and
+wring the tears from our cheeks. I had a brother who died at Troy; he
+was by no means the worst man there; you are sure to have known him--his
+name was Antilochus; I never set eyes upon him myself, but they say that
+he was singularly fleet of foot and in fight valiant."
+
+"Your discretion, my friend," answered Menelaus, "is beyond your years.
+It is plain you take after your father. One can soon see when a man
+is son to one whom heaven has blessed both as regards wife and
+offspring--and it has blessed Nestor from first to last all his days,
+giving him a green old age in his own house, with sons about him who are
+both well disposed and valiant. We will put an end therefore to all this
+weeping, and attend to our supper again. Let water be poured over our
+hands. Telemachus and I can talk with one another fully in the morning."
+
+On this Asphalion, one of the servants, poured water over their hands
+and they laid their hands on the good things that were before them.
+
+Then Jove's daughter Helen bethought her of another matter. She drugged
+the wine with an herb that banishes all care, sorrow, and ill humour.
+Whoever drinks wine thus drugged cannot shed a single tear all the rest
+of the day, not even though his father and mother both of them drop down
+dead, or he sees a brother or a son hewn in pieces before his very eyes.
+This drug, of such sovereign power and virtue, had been given to Helen
+by Polydamna wife of Thon, a woman of Egypt, where there grow all sorts
+of herbs, some good to put into the mixing bowl and others poisonous.
+Moreover, every one in the whole country is a skilled physician, for
+they are of the race of Paeeon. When Helen had put this drug in the
+bowl, and had told the servants to serve the wine round, she said:
+
+"Menelaus, son of Atreus, and you my good friends, sons of honourable
+men (which is as Jove wills, for he is the giver both of good and evil,
+and can do what he chooses), feast here as you will, and listen while I
+tell you a tale in season. I cannot indeed name every single one of the
+exploits of Ulysses, but I can say what he did when he was before Troy,
+and you Achaeans were in all sorts of difficulties. He covered himself
+with wounds and bruises, dressed himself all in rags, and entered the
+enemy's city looking like a menial or a beggar, and quite different
+from what he did when he was among his own people. In this disguise
+he entered the city of Troy, and no one said anything to him. I alone
+recognised him and began to question him, but he was too cunning for me.
+When, however, I had washed and anointed him and had given him clothes,
+and after I had sworn a solemn oath not to betray him to the Trojans
+till he had got safely back to his own camp and to the ships, he told me
+all that the Achaeans meant to do. He killed many Trojans and got much
+information before he reached the Argive camp, for all which things the
+Trojan women made lamentation, but for my own part I was glad, for my
+heart was beginning to yearn after my home, and I was unhappy about
+the wrong that Venus had done me in taking me over there, away from
+my country, my girl, and my lawful wedded husband, who is indeed by no
+means deficient either in person or understanding."
+
+Then Menelaus said, "All that you have been saying, my dear wife, is
+true. I have travelled much, and have had much to do with heroes, but
+I have never seen such another man as Ulysses. What endurance too,
+and what courage he displayed within the wooden horse, wherein all the
+bravest of the Argives were lying in wait to bring death and destruction
+upon the Trojans. {43} At that moment you came up to us; some god
+who wished well to the Trojans must have set you on to it and you had
+Deiphobus with you. Three times did you go all round our hiding place
+and pat it; you called our chiefs each by his own name, and mimicked
+all our wives--Diomed, Ulysses, and I from our seats inside heard what
+a noise you made. Diomed and I could not make up our minds whether to
+spring out then and there, or to answer you from inside, but Ulysses
+held us all in check, so we sat quite still, all except Anticlus, who
+was beginning to answer you, when Ulysses clapped his two brawny hands
+over his mouth, and kept them there. It was this that saved us all, for
+he muzzled Anticlus till Minerva took you away again."
+
+"How sad," exclaimed Telemachus, "that all this was of no avail to save
+him, nor yet his own iron courage. But now, sir, be pleased to send us
+all to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+On this Helen told the maid servants to set beds in the room that was in
+the gatehouse, and to make them with good red rugs, and spread coverlets
+on the top of them with woollen cloaks for the guests to wear. So
+the maids went out, carrying a torch, and made the beds, to which
+a man-servant presently conducted the strangers. Thus, then, did
+Telemachus and Pisistratus sleep there in the forecourt, while the son
+of Atreus lay in an inner room with lovely Helen by his side.
+
+When the child of morning, rosy-fingered Dawn appeared, Menelaus rose
+and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulders, and left his room looking like an
+immortal god. Then, taking a seat near Telemachus he said:
+
+"And what, Telemachus, has led you to take this long sea voyage to
+Lacedaemon? Are you on public, or private business? Tell me all about
+it."
+
+"I have come, sir," replied Telemachus, "to see if you can tell me
+anything about my father. I am being eaten out of house and home; my
+fair estate is being wasted, and my house is full of miscreants who keep
+killing great numbers of my sheep and oxen, on the pretence of paying
+their addresses to my mother. Therefore, I am suppliant at your knees if
+haply you may tell me about my father's melancholy end, whether you saw
+it with your own eyes, or heard it from some other traveller; for he was
+a man born to trouble. Do not soften things out of any pity for myself,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service either by word or deed, when you
+Achaeans were harassed by the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+Menelaus on hearing this was very much shocked. "So," he exclaimed,
+"these cowards would usurp a brave man's bed? A hind might as well lay
+her new born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell: the lion when he comes back to his lair
+will make short work with the pair of them--and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Achaeans cheered him--if he is still
+such and were to come near these suitors, they would have a short shrift
+and a sorry wedding. As regards your questions, however, I will not
+prevaricate nor deceive you, but will tell you without concealment all
+that the old man of the sea told me.
+
+"I was trying to come on here, but the gods detained me in Egypt, for
+my hecatombs had not given them full satisfaction, and the gods are very
+strict about having their dues. Now off Egypt, about as far as a ship
+can sail in a day with a good stiff breeze behind her, there is an
+island called Pharos--it has a good harbour from which vessels can
+get out into open sea when they have taken in water--and here the gods
+becalmed me twenty days without so much as a breath of fair wind to help
+me forward. We should have run clean out of provisions and my men would
+have starved, if a goddess had not taken pity upon me and saved me in
+the person of Idothea, daughter to Proteus, the old man of the sea, for
+she had taken a great fancy to me.
+
+"She came to me one day when I was by myself, as I often was, for the
+men used to go with their barbed hooks, all over the island in the
+hope of catching a fish or two to save them from the pangs of hunger.
+'Stranger,' said she, 'it seems to me that you like starving in this
+way--at any rate it does not greatly trouble you, for you stick here day
+after day, without even trying to get away though your men are dying by
+inches.'
+
+"'Let me tell you,' said I, 'whichever of the goddesses you may happen
+to be, that I am not staying here of my own accord, but must have
+offended the gods that live in heaven. Tell me, therefore, for the gods
+know everything, which of the immortals it is that is hindering me in
+this way, and tell me also how I may sail the sea so as to reach my
+home.'
+
+"'Stranger,' replied she, 'I will make it all quite clear to you. There
+is an old immortal who lives under the sea hereabouts and whose name
+is Proteus. He is an Egyptian, and people say he is my father; he is
+Neptune's head man and knows every inch of ground all over the bottom of
+the sea. If you can snare him and hold him tight, he will tell you about
+your voyage, what courses you are to take, and how you are to sail the
+sea so as to reach your home. He will also tell you, if you so will, all
+that has been going on at your house both good and bad, while you have
+been away on your long and dangerous journey.'
+
+"'Can you show me,' said I, 'some stratagem by means of which I may
+catch this old god without his suspecting it and finding me out? For a
+god is not easily caught--not by a mortal man.'
+
+"'Stranger,' said she, 'I will make it all quite clear to you. About the
+time when the sun shall have reached mid heaven, the old man of the sea
+comes up from under the waves, heralded by the West wind that furs the
+water over his head. As soon as he has come up he lies down, and goes to
+sleep in a great sea cave, where the seals--Halosydne's chickens as they
+call them--come up also from the grey sea, and go to sleep in shoals
+all round him; and a very strong and fish-like smell do they bring with
+them. {44} Early to-morrow morning I will take you to this place and
+will lay you in ambush. Pick out, therefore, the three best men you have
+in your fleet, and I will tell you all the tricks that the old man will
+play you.
+
+"'First he will look over all his seals, and count them; then, when he
+has seen them and tallied them on his five fingers, he will go to sleep
+among them, as a shepherd among his sheep. The moment you see that he is
+asleep seize him; put forth all your strength and hold him fast, for he
+will do his very utmost to get away from you. He will turn himself into
+every kind of creature that goes upon the earth, and will become also
+both fire and water; but you must hold him fast and grip him tighter
+and tighter, till he begins to talk to you and comes back to what he was
+when you saw him go to sleep; then you may slacken your hold and let him
+go; and you can ask him which of the gods it is that is angry with you,
+and what you must do to reach your home over the seas.'
+
+"Having so said she dived under the waves, whereon I turned back to
+the place where my ships were ranged upon the shore; and my heart was
+clouded with care as I went along. When I reached my ship we got supper
+ready, for night was falling, and camped down upon the beach.
+
+"When the child of morning rosy-fingered Dawn appeared, I took the three
+men on whose prowess of all kinds I could most rely, and went along by
+the sea-side, praying heartily to heaven. Meanwhile the goddess fetched
+me up four seal skins from the bottom of the sea, all of them just
+skinned, for she meant playing a trick upon her father. Then she dug
+four pits for us to lie in, and sat down to wait till we should come up.
+When we were close to her, she made us lie down in the pits one after
+the other, and threw a seal skin over each of us. Our ambuscade would
+have been intolerable, for the stench of the fishy seals was most
+distressing {45}--who would go to bed with a sea monster if he could
+help it?--but here, too, the goddess helped us, and thought of something
+that gave us great relief, for she put some ambrosia under each man's
+nostrils, which was so fragrant that it killed the smell of the seals.
+{46}
+
+"We waited the whole morning and made the best of it, watching the seals
+come up in hundreds to bask upon the sea shore, till at noon the old man
+of the sea came up too, and when he had found his fat seals he went over
+them and counted them. We were among the first he counted, and he never
+suspected any guile, but laid himself down to sleep as soon as he had
+done counting. Then we rushed upon him with a shout and seized him; on
+which he began at once with his old tricks, and changed himself first
+into a lion with a great mane; then all of a sudden he became a dragon,
+a leopard, a wild boar; the next moment he was running water, and then
+again directly he was a tree, but we stuck to him and never lost hold,
+till at last the cunning old creature became distressed, and said,
+'Which of the gods was it, Son of Atreus, that hatched this plot with
+you for snaring me and seizing me against my will? What do you want?'
+
+"'You know that yourself, old man,' I answered, 'you will gain nothing
+by trying to put me off. It is because I have been kept so long in this
+island, and see no sign of my being able to get away. I am losing
+all heart; tell me, then, for you gods know everything, which of the
+immortals it is that is hindering me, and tell me also how I may sail
+the sea so as to reach my home?'
+
+"Then,' he said, 'if you would finish your voyage and get home quickly,
+you must offer sacrifices to Jove and to the rest of the gods before
+embarking; for it is decreed that you shall not get back to your
+friends, and to your own house, till you have returned to the heaven-fed
+stream of Egypt, and offered holy hecatombs to the immortal gods that
+reign in heaven. When you have done this they will let you finish your
+voyage.'
+
+"I was broken hearted when I heard that I must go back all that long and
+terrible voyage to Egypt; {47} nevertheless, I answered, 'I will do all,
+old man, that you have laid upon me; but now tell me, and tell me true,
+whether all the Achaeans whom Nestor and I left behind us when we set
+sail from Troy have got home safely, or whether any one of them came
+to a bad end either on board his own ship or among his friends when the
+days of his fighting were done.'
+
+"'Son of Atreus,' he answered, 'why ask me? You had better not know what
+I can tell you, for your eyes will surely fill when you have heard my
+story. Many of those about whom you ask are dead and gone, but many
+still remain, and only two of the chief men among the Achaeans
+perished during their return home. As for what happened on the field of
+battle--you were there yourself. A third Achaean leader is still at sea,
+alive, but hindered from returning. Ajax was wrecked, for Neptune drove
+him on to the great rocks of Gyrae; nevertheless, he let him get safe
+out of the water, and in spite of all Minerva's hatred he would have
+escaped death, if he had not ruined himself by boasting. He said the
+gods could not drown him even though they had tried to do so, and when
+Neptune heard this large talk, he seized his trident in his two brawny
+hands, and split the rock of Gyrae in two pieces. The base remained
+where it was, but the part on which Ajax was sitting fell headlong
+into the sea and carried Ajax with it; so he drank salt water and was
+drowned.
+
+"'Your brother and his ships escaped, for Juno protected him, but when
+he was just about to reach the high promontory of Malea, he was caught
+by a heavy gale which carried him out to sea again sorely against his
+will, and drove him to the foreland where Thyestes used to dwell, but
+where Aegisthus was then living. By and by, however, it seemed as though
+he was to return safely after all, for the gods backed the wind into its
+old quarter and they reached home; whereon Agamemnon kissed his native
+soil, and shed tears of joy at finding himself in his own country.
+
+"'Now there was a watchman whom Aegisthus kept always on the watch, and
+to whom he had promised two talents of gold. This man had been looking
+out for a whole year to make sure that Agamemnon did not give him the
+slip and prepare war; when, therefore, this man saw Agamemnon go by,
+he went and told Aegisthus, who at once began to lay a plot for him. He
+picked twenty of his bravest warriors and placed them in ambuscade on
+one side the cloister, while on the opposite side he prepared a banquet.
+Then he sent his chariots and horsemen to Agamemnon, and invited him to
+the feast, but he meant foul play. He got him there, all unsuspicious of
+the doom that was awaiting him, and killed him when the banquet was
+over as though he were butchering an ox in the shambles; not one of
+Agamemnon's followers was left alive, nor yet one of Aegisthus', but
+they were all killed there in the cloisters.'
+
+"Thus spoke Proteus, and I was broken hearted as I heard him. I sat down
+upon the sands and wept; I felt as though I could no longer bear to live
+nor look upon the light of the sun. Presently, when I had had my fill of
+weeping and writhing upon the ground, the old man of the sea said, 'Son
+of Atreus, do not waste any more time in crying so bitterly; it can
+do no manner of good; find your way home as fast as ever you can,
+for Aegisthus may be still alive, and even though Orestes has been
+beforehand with you in killing him, you may yet come in for his
+funeral.'
+
+"On this I took comfort in spite of all my sorrow, and said, 'I know,
+then, about these two; tell me, therefore, about the third man of whom
+you spoke; is he still alive, but at sea, and unable to get home? or is
+he dead? Tell me, no matter how much it may grieve me.'
+
+"'The third man,' he answered, 'is Ulysses who dwells in Ithaca. I
+can see him in an island sorrowing bitterly in the house of the nymph
+Calypso, who is keeping him prisoner, and he cannot reach his home for
+he has no ships nor sailors to take him over the sea. As for your own
+end, Menelaus, you shall not die in Argos, but the gods will take you to
+the Elysian plain, which is at the ends of the world. There fair-haired
+Rhadamanthus reigns, and men lead an easier life than any where else in
+the world, for in Elysium there falls not rain, nor hail, nor snow, but
+Oceanus breathes ever with a West wind that sings softly from the sea,
+and gives fresh life to all men. This will happen to you because you
+have married Helen, and are Jove's son-in-law.'
+
+"As he spoke he dived under the waves, whereon I turned back to the
+ships with my companions, and my heart was clouded with care as I went
+along. When we reached the ships we got supper ready, for night was
+falling, and camped down upon the beach. When the child of morning,
+rosy-fingered Dawn appeared, we drew our ships into the water, and put
+our masts and sails within them; then we went on board ourselves, took
+our seats on the benches, and smote the grey sea with our oars. I
+again stationed my ships in the heaven-fed stream of Egypt, and offered
+hecatombs that were full and sufficient. When I had thus appeased
+heaven's anger, I raised a barrow to the memory of Agamemnon that his
+name might live for ever, after which I had a quick passage home, for
+the gods sent me a fair wind.
+
+"And now for yourself--stay here some ten or twelve days longer, and I
+will then speed you on your way. I will make you a noble present of a
+chariot and three horses. I will also give you a beautiful chalice
+that so long as you live you may think of me whenever you make a
+drink-offering to the immortal gods."
+
+"Son of Atreus," replied Telemachus, "do not press me to stay longer; I
+should be contented to remain with you for another twelve months; I find
+your conversation so delightful that I should never once wish myself at
+home with my parents; but my crew whom I have left at Pylos are already
+impatient, and you are detaining me from them. As for any present you
+may be disposed to make me, I had rather that it should be a piece of
+plate. I will take no horses back with me to Ithaca, but will leave them
+to adorn your own stables, for you have much flat ground in your kingdom
+where lotus thrives, as also meadow-sweet and wheat and barley, and oats
+with their white and spreading ears; whereas in Ithaca we have neither
+open fields nor racecourses, and the country is more fit for goats than
+horses, and I like it the better for that. {48} None of our islands have
+much level ground, suitable for horses, and Ithaca least of all."
+
+Menelaus smiled and took Telemachus's hand within his own. "What you
+say," said he, "shows that you come of good family. I both can, and
+will, make this exchange for you, by giving you the finest and most
+precious piece of plate in all my house. It is a mixing bowl by Vulcan's
+own hand, of pure silver, except the rim, which is inlaid with gold.
+Phaedimus, king of the Sidonians, gave it me in the course of a visit
+which I paid him when I returned thither on my homeward journey. I will
+make you a present of it."
+
+Thus did they converse [and guests kept coming to the king's house. They
+brought sheep and wine, while their wives had put up bread for them to
+take with them; so they were busy cooking their dinners in the courts].
+{49}
+
+Meanwhile the suitors were throwing discs or aiming with spears at
+a mark on the levelled ground in front of Ulysses' house, and were
+behaving with all their old insolence. Antinous and Eurymachus, who were
+their ringleaders and much the foremost among them all, were sitting
+together when Noemon son of Phronius came up and said to Antinous,
+
+"Have we any idea, Antinous, on what day Telemachus returns from Pylos?
+He has a ship of mine, and I want it, to cross over to Elis: I have
+twelve brood mares there with yearling mule foals by their side not yet
+broken in, and I want to bring one of them over here and break him."
+
+They were astounded when they heard this, for they had made sure that
+Telemachus had not gone to the city of Neleus. They thought he was
+only away somewhere on the farms, and was with the sheep, or with the
+swineherd; so Antinous said, "When did he go? Tell me truly, and
+what young men did he take with him? Were they freemen or his own
+bondsmen--for he might manage that too? Tell me also, did you let him
+have the ship of your own free will because he asked you, or did he take
+it without your leave?"
+
+"I lent it him," answered Noemon, "what else could I do when a man of
+his position said he was in a difficulty, and asked me to oblige him? I
+could not possibly refuse. As for those who went with him they were the
+best young men we have, and I saw Mentor go on board as captain--or some
+god who was exactly like him. I cannot understand it, for I saw Mentor
+here myself yesterday morning, and yet he was then setting out for
+Pylos."
+
+Noemon then went back to his father's house, but Antinous and Eurymachus
+were very angry. They told the others to leave off playing, and to come
+and sit down along with themselves. When they came, Antinous son of
+Eupeithes spoke in anger. His heart was black with rage, and his eyes
+flashed fire as he said:
+
+"Good heavens, this voyage of Telemachus is a very serious matter; we
+had made sure that it would come to nothing, but the young fellow has
+got away in spite of us, and with a picked crew too. He will be giving
+us trouble presently; may Jove take him before he is full grown. Find me
+a ship, therefore, with a crew of twenty men, and I will lie in wait for
+him in the straits between Ithaca and Samos; he will then rue the day
+that he set out to try and get news of his father."
+
+Thus did he speak, and the others applauded his saying; they then all of
+them went inside the buildings.
+
+It was not long ere Penelope came to know what the suitors were
+plotting; for a man servant, Medon, overheard them from outside the
+outer court as they were laying their schemes within, and went to tell
+his mistress. As he crossed the threshold of her room Penelope said:
+"Medon, what have the suitors sent you here for? Is it to tell the maids
+to leave their master's business and cook dinner for them? I wish they
+may neither woo nor dine henceforward, neither here nor anywhere else,
+but let this be the very last time, for the waste you all make of my
+son's estate. Did not your fathers tell you when you were children, how
+good Ulysses had been to them--never doing anything high-handed, nor
+speaking harshly to anybody? Kings may say things sometimes, and they
+may take a fancy to one man and dislike another, but Ulysses never did
+an unjust thing by anybody--which shows what bad hearts you have, and
+that there is no such thing as gratitude left in this world."
+
+Then Medon said, "I wish, Madam, that this were all; but they are
+plotting something much more dreadful now--may heaven frustrate their
+design. They are going to try and murder Telemachus as he is coming home
+from Pylos and Lacedaemon, where he has been to get news of his father."
+
+Then Penelope's heart sank within her, and for a long time she was
+speechless; her eyes filled with tears, and she could find no utterance.
+At last, however, she said, "Why did my son leave me? What business had
+he to go sailing off in ships that make long voyages over the ocean like
+sea-horses? Does he want to die without leaving any one behind him to
+keep up his name?"
+
+"I do not know," answered Medon, "whether some god set him on to it, or
+whether he went on his own impulse to see if he could find out if his
+father was dead, or alive and on his way home."
+
+Then he went downstairs again, leaving Penelope in an agony of grief.
+There were plenty of seats in the house, but she had no heart for
+sitting on any one of them; she could only fling herself on the floor of
+her own room and cry; whereon all the maids in the house, both old
+and young, gathered round her and began to cry too, till at last in a
+transport of sorrow she exclaimed,
+
+"My dears, heaven has been pleased to try me with more affliction
+than any other woman of my age and country. First I lost my brave and
+lion-hearted husband, who had every good quality under heaven, and whose
+name was great over all Hellas and middle Argos, and now my darling son
+is at the mercy of the winds and waves, without my having heard one word
+about his leaving home. You hussies, there was not one of you would so
+much as think of giving me a call out of my bed, though you all of you
+very well knew when he was starting. If I had known he meant taking this
+voyage, he would have had to give it up, no matter how much he was bent
+upon it, or leave me a corpse behind him--one or other. Now, however,
+go some of you and call old Dolius, who was given me by my father on my
+marriage, and who is my gardener. Bid him go at once and tell everything
+to Laertes, who may be able to hit on some plan for enlisting public
+sympathy on our side, as against those who are trying to exterminate his
+own race and that of Ulysses."
+
+Then the dear old nurse Euryclea said, "You may kill me, Madam, or let
+me live on in your house, whichever you please, but I will tell you the
+real truth. I knew all about it, and gave him everything he wanted in
+the way of bread and wine, but he made me take my solemn oath that I
+would not tell you anything for some ten or twelve days, unless you
+asked or happened to hear of his having gone, for he did not want you to
+spoil your beauty by crying. And now, Madam, wash your face, change
+your dress, and go upstairs with your maids to offer prayers to Minerva,
+daughter of Aegis-bearing Jove, for she can save him even though he
+be in the jaws of death. Do not trouble Laertes: he has trouble enough
+already. Besides, I cannot think that the gods hate the race of the son
+of Arceisius so much, but there will be a son left to come up after him,
+and inherit both the house and the fair fields that lie far all round
+it."
+
+With these words she made her mistress leave off crying, and dried the
+tears from her eyes. Penelope washed her face, changed her dress, and
+went upstairs with her maids. She then put some bruised barley into a
+basket and began praying to Minerva.
+
+"Hear me," she cried, "Daughter of Aegis-bearing Jove, unweariable. If
+ever Ulysses while he was here burned you fat thigh bones of sheep or
+heifer, bear it in mind now as in my favour, and save my darling son
+from the villainy of the suitors."
+
+She cried aloud as she spoke, and the goddess heard her prayer;
+meanwhile the suitors were clamorous throughout the covered cloister,
+and one of them said:
+
+"The queen is preparing for her marriage with one or other of us. Little
+does she dream that her son has now been doomed to die."
+
+This was what they said, but they did not know what was going to happen.
+Then Antinous said, "Comrades, let there be no loud talking, lest some
+of it get carried inside. Let us be up and do that in silence, about
+which we are all of a mind."
+
+He then chose twenty men, and they went down to their ship and to the
+sea side; they drew the vessel into the water and got her mast and sails
+inside her; they bound the oars to the thole-pins with twisted thongs
+of leather, all in due course, and spread the white sails aloft, while
+their fine servants brought them their armour. Then they made the ship
+fast a little way out, came on shore again, got their suppers, and
+waited till night should fall.
+
+But Penelope lay in her own room upstairs unable to eat or drink, and
+wondering whether her brave son would escape, or be overpowered by the
+wicked suitors. Like a lioness caught in the toils with huntsmen hemming
+her in on every side she thought and thought till she sank into a
+slumber, and lay on her bed bereft of thought and motion.
+
+Then Minerva bethought her of another matter, and made a vision in
+the likeness of Penelope's sister Iphthime daughter of Icarius who had
+married Eumelus and lived in Pherae. She told the vision to go to the
+house of Ulysses, and to make Penelope leave off crying, so it came into
+her room by the hole through which the thong went for pulling the door
+to, and hovered over her head saying,
+
+"You are asleep, Penelope: the gods who live at ease will not suffer you
+to weep and be so sad. Your son has done them no wrong, so he will yet
+come back to you."
+
+Penelope, who was sleeping sweetly at the gates of dreamland, answered,
+"Sister, why have you come here? You do not come very often, but I
+suppose that is because you live such a long way off. Am I, then, to
+leave off crying and refrain from all the sad thoughts that torture me?
+I, who have lost my brave and lion-hearted husband, who had every good
+quality under heaven, and whose name was great over all Hellas and
+middle Argos; and now my darling son has gone off on board of a ship--a
+foolish fellow who has never been used to roughing it, nor to going
+about among gatherings of men. I am even more anxious about him than
+about my husband; I am all in a tremble when I think of him, lest
+something should happen to him, either from the people among whom he has
+gone, or by sea, for he has many enemies who are plotting against him,
+and are bent on killing him before he can return home."
+
+Then the vision said, "Take heart, and be not so much dismayed. There is
+one gone with him whom many a man would be glad enough to have stand by
+his side, I mean Minerva; it is she who has compassion upon you, and who
+has sent me to bear you this message."
+
+"Then," said Penelope, "if you are a god or have been sent here by
+divine commission, tell me also about that other unhappy one--is he
+still alive, or is he already dead and in the house of Hades?"
+
+And the vision said, "I shall not tell you for certain whether he is
+alive or dead, and there is no use in idle conversation."
+
+Then it vanished through the thong-hole of the door and was dissipated
+into thin air; but Penelope rose from her sleep refreshed and comforted,
+so vivid had been her dream.
+
+Meantime the suitors went on board and sailed their ways over the
+sea, intent on murdering Telemachus. Now there is a rocky islet called
+Asteris, of no great size, in mid channel between Ithaca and Samos, and
+there is a harbour on either side of it where a ship can lie. Here then
+the Achaeans placed themselves in ambush.
+
+
+Book V
+
+CALYPSO--ULYSSES REACHES SCHERIA ON A RAFT.
+
+And now, as Dawn rose from her couch beside Tithonus--harbinger of light
+alike to mortals and immortals--the gods met in council and with them,
+Jove the lord of thunder, who is their king. Thereon Minerva began to
+tell them of the many sufferings of Ulysses, for she pitied him away
+there in the house of the nymph Calypso.
+
+"Father Jove," said she, "and all you other gods that live in
+everlasting bliss, I hope there may never be such a thing as a kind and
+well-disposed ruler any more, nor one who will govern equitably. I hope
+they will be all henceforth cruel and unjust, for there is not one of
+his subjects but has forgotten Ulysses, who ruled them as though he were
+their father. There he is, lying in great pain in an island where dwells
+the nymph Calypso, who will not let him go; and he cannot get back to
+his own country, for he can find neither ships nor sailors to take him
+over the sea. Furthermore, wicked people are now trying to murder his
+only son Telemachus, who is coming home from Pylos and Lacedaemon, where
+he has been to see if he can get news of his father."
+
+"What, my dear, are you talking about?" replied her father, "did you not
+send him there yourself, because you thought it would help Ulysses to
+get home and punish the suitors? Besides, you are perfectly able to
+protect Telemachus, and to see him safely home again, while the suitors
+have to come hurry-skurrying back without having killed him."
+
+When he had thus spoken, he said to his son Mercury, "Mercury, you are
+our messenger, go therefore and tell Calypso we have decreed that poor
+Ulysses is to return home. He is to be convoyed neither by gods nor men,
+but after a perilous voyage of twenty days upon a raft he is to reach
+fertile Scheria, {50} the land of the Phaeacians, who are near of kin to
+the gods, and will honour him as though he were one of ourselves. They
+will send him in a ship to his own country, and will give him more
+bronze and gold and raiment than he would have brought back from Troy,
+if he had had all his prize money and had got home without disaster.
+This is how we have settled that he shall return to his country and his
+friends."
+
+Thus he spoke, and Mercury, guide and guardian, slayer of Argus, did as
+he was told. Forthwith he bound on his glittering golden sandals with
+which he could fly like the wind over land and sea. He took the wand
+with which he seals men's eyes in sleep or wakes them just as he
+pleases, and flew holding it in his hand over Pieria; then he swooped
+down through the firmament till he reached the level of the sea, whose
+waves he skimmed like a cormorant that flies fishing every hole and
+corner of the ocean, and drenching its thick plumage in the spray. He
+flew and flew over many a weary wave, but when at last he got to the
+island which was his journey's end, he left the sea and went on by land
+till he came to the cave where the nymph Calypso lived.
+
+He found her at home. There was a large fire burning on the hearth, and
+one could smell from far the fragrant reek of burning cedar and sandal
+wood. As for herself, she was busy at her loom, shooting her golden
+shuttle through the warp and singing beautifully. Round her cave there
+was a thick wood of alder, poplar, and sweet smelling cypress trees,
+wherein all kinds of great birds had built their nests--owls, hawks, and
+chattering sea-crows that occupy their business in the waters. A vine
+loaded with grapes was trained and grew luxuriantly about the mouth of
+the cave; there were also four running rills of water in channels cut
+pretty close together, and turned hither and thither so as to irrigate
+the beds of violets and luscious herbage over which they flowed. {51}
+Even a god could not help being charmed with such a lovely spot,
+so Mercury stood still and looked at it; but when he had admired it
+sufficiently he went inside the cave.
+
+Calypso knew him at once--for the gods all know each other, no matter
+how far they live from one another--but Ulysses was not within; he was
+on the sea-shore as usual, looking out upon the barren ocean with tears
+in his eyes, groaning and breaking his heart for sorrow. Calypso
+gave Mercury a seat and said: "Why have you come to see me,
+Mercury--honoured, and ever welcome--for you do not visit me often? Say
+what you want; I will do it for you at once if I can, and if it can be
+done at all; but come inside, and let me set refreshment before you."
+
+As she spoke she drew a table loaded with ambrosia beside him and mixed
+him some red nectar, so Mercury ate and drank till he had had enough,
+and then said:
+
+"We are speaking god and goddess to one another, and you ask me why I
+have come here, and I will tell you truly as you would have me do. Jove
+sent me; it was no doing of mine; who could possibly want to come all
+this way over the sea where there are no cities full of people to offer
+me sacrifices or choice hecatombs? Nevertheless I had to come, for none
+of us other gods can cross Jove, nor transgress his orders. He says that
+you have here the most ill-starred of all those who fought nine years
+before the city of King Priam and sailed home in the tenth year after
+having sacked it. On their way home they sinned against Minerva, {52}
+who raised both wind and waves against them, so that all his brave
+companions perished, and he alone was carried hither by wind and tide.
+Jove says that you are to let this man go at once, for it is decreed
+that he shall not perish here, far from his own people, but shall return
+to his house and country and see his friends again."
+
+Calypso trembled with rage when she heard this, "You gods," she
+exclaimed, "ought to be ashamed of yourselves. You are always jealous
+and hate seeing a goddess take a fancy to a mortal man, and live with
+him in open matrimony. So when rosy-fingered Dawn made love to Orion,
+you precious gods were all of you furious till Diana went and killed him
+in Ortygia. So again when Ceres fell in love with Iasion, and yielded to
+him in a thrice-ploughed fallow field, Jove came to hear of it before so
+very long and killed Iasion with his thunderbolts. And now you are angry
+with me too because I have a man here. I found the poor creature sitting
+all alone astride of a keel, for Jove had struck his ship with lightning
+and sunk it in mid ocean, so that all his crew were drowned, while he
+himself was driven by wind and waves on to my island. I got fond of him
+and cherished him, and had set my heart on making him immortal, so that
+he should never grow old all his days; still I cannot cross Jove, nor
+bring his counsels to nothing; therefore, if he insists upon it, let the
+man go beyond the seas again; but I cannot send him anywhere myself
+for I have neither ships nor men who can take him. Nevertheless I will
+readily give him such advice, in all good faith, as will be likely to
+bring him safely to his own country."
+
+"Then send him away," said Mercury, "or Jove will be angry with you and
+punish you".
+
+On this he took his leave, and Calypso went out to look for Ulysses, for
+she had heard Jove's message. She found him sitting upon the beach with
+his eyes ever filled with tears, and dying of sheer home sickness; for
+he had got tired of Calypso, and though he was forced to sleep with her
+in the cave by night, it was she, not he, that would have it so. As for
+the day time, he spent it on the rocks and on the sea shore, weeping,
+crying aloud for his despair, and always looking out upon the sea.
+Calypso then went close up to him said:
+
+"My poor fellow, you shall not stay here grieving and fretting your life
+out any longer. I am going to send you away of my own free will; so go,
+cut some beams of wood, and make yourself a large raft with an upper
+deck that it may carry you safely over the sea. I will put bread, wine,
+and water on board to save you from starving. I will also give you
+clothes, and will send you a fair wind to take you home, if the gods in
+heaven so will it--for they know more about these things, and can settle
+them better than I can."
+
+Ulysses shuddered as he heard her. "Now goddess," he answered, "there is
+something behind all this; you cannot be really meaning to help me home
+when you bid me do such a dreadful thing as put to sea on a raft. Not
+even a well found ship with a fair wind could venture on such a distant
+voyage: nothing that you can say or do shall make me go on board a raft
+unless you first solemnly swear that you mean me no mischief."
+
+Calypso smiled at this and caressed him with her hand: "You know a great
+deal," said she, "but you are quite wrong here. May heaven above and
+earth below be my witnesses, with the waters of the river Styx--and this
+is the most solemn oath which a blessed god can take--that I mean you
+no sort of harm, and am only advising you to do exactly what I should do
+myself in your place. I am dealing with you quite straightforwardly; my
+heart is not made of iron, and I am very sorry for you."
+
+When she had thus spoken she led the way rapidly before him, and Ulysses
+followed in her steps; so the pair, goddess and man, went on and on till
+they came to Calypso's cave, where Ulysses took the seat that Mercury
+had just left. Calypso set meat and drink before him of the food that
+mortals eat; but her maids brought ambrosia and nectar for herself, and
+they laid their hands on the good things that were before them. When
+they had satisfied themselves with meat and drink, Calypso spoke,
+saying:
+
+"Ulysses, noble son of Laertes, so you would start home to your own
+land at once? Good luck go with you, but if you could only know how much
+suffering is in store for you before you get back to your own country,
+you would stay where you are, keep house along with me, and let me
+make you immortal, no matter how anxious you may be to see this wife
+of yours, of whom you are thinking all the time day after day; yet I
+flatter myself that I am no whit less tall or well-looking than she
+is, for it is not to be expected that a mortal woman should compare in
+beauty with an immortal."
+
+"Goddess," replied Ulysses, "do not be angry with me about this. I
+am quite aware that my wife Penelope is nothing like so tall or so
+beautiful as yourself. She is only a woman, whereas you are an immortal.
+Nevertheless, I want to get home, and can think of nothing else. If some
+god wrecks me when I am on the sea, I will bear it and make the best
+of it. I have had infinite trouble both by land and sea already, so let
+this go with the rest."
+
+Presently the sun set and it became dark, whereon the pair retired into
+the inner part of the cave and went to bed.
+
+When the child of morning rosy-fingered Dawn appeared, Ulysses put on
+his shirt and cloak, while the goddess wore a dress of a light gossamer
+fabric, very fine and graceful, with a beautiful golden girdle about her
+waist and a veil to cover her head. She at once set herself to think how
+she could speed Ulysses on his way. So she gave him a great bronze
+axe that suited his hands; it was sharpened on both sides, and had a
+beautiful olive-wood handle fitted firmly on to it. She also gave him a
+sharp adze, and then led the way to the far end of the island where the
+largest trees grew--alder, poplar and pine, that reached the sky--very
+dry and well seasoned, so as to sail light for him in the water. {53}
+Then, when she had shown him where the best trees grew, Calypso went
+home, leaving him to cut them, which he soon finished doing. He cut down
+twenty trees in all and adzed them smooth, squaring them by rule in good
+workmanlike fashion. Meanwhile Calypso came back with some augers, so
+he bored holes with them and fitted the timbers together with bolts and
+rivets. He made the raft as broad as a skilled shipwright makes the beam
+of a large vessel, and he fixed a deck on top of the ribs, and ran a
+gunwale all round it. He also made a mast with a yard arm, and a rudder
+to steer with. He fenced the raft all round with wicker hurdles as a
+protection against the waves, and then he threw on a quantity of wood.
+By and by Calypso brought him some linen to make the sails, and he made
+these too, excellently, making them fast with braces and sheets. Last of
+all, with the help of levers, he drew the raft down into the water.
+
+In four days he had completed the whole work, and on the fifth Calypso
+sent him from the island after washing him and giving him some clean
+clothes. She gave him a goat skin full of black wine, and another larger
+one of water; she also gave him a wallet full of provisions, and found
+him in much good meat. Moreover, she made the wind fair and warm for
+him, and gladly did Ulysses spread his sail before it, while he sat and
+guided the raft skilfully by means of the rudder. He never closed his
+eyes, but kept them fixed on the Pleiads, on late-setting Bootes, and on
+the Bear--which men also call the wain, and which turns round and round
+where it is, facing Orion, and alone never dipping into the stream of
+Oceanus--for Calypso had told him to keep this to his left. Days seven
+and ten did he sail over the sea, and on the eighteenth the dim outlines
+of the mountains on the nearest part of the Phaeacian coast appeared,
+rising like a shield on the horizon.
+
+But King Neptune, who was returning from the Ethiopians, caught sight of
+Ulysses a long way off, from the mountains of the Solymi. He could see
+him sailing upon the sea, and it made him very angry, so he wagged his
+head and muttered to himself, saying, "Good heavens, so the gods have
+been changing their minds about Ulysses while I was away in Ethiopia,
+and now he is close to the land of the Phaeacians, where it is decreed
+that he shall escape from the calamities that have befallen him. Still,
+he shall have plenty of hardship yet before he has done with it."
+
+Thereon he gathered his clouds together, grasped his trident, stirred
+it round in the sea, and roused the rage of every wind that blows till
+earth, sea, and sky were hidden in cloud, and night sprang forth out of
+the heavens. Winds from East, South, North, and West fell upon him all
+at the same time, and a tremendous sea got up, so that Ulysses' heart
+began to fail him. "Alas," he said to himself in his dismay, "what ever
+will become of me? I am afraid Calypso was right when she said I should
+have trouble by sea before I got back home. It is all coming true. How
+black is Jove making heaven with his clouds, and what a sea the winds
+are raising from every quarter at once. I am now safe to perish. Blest
+and thrice blest were those Danaans who fell before Troy in the cause
+of the sons of Atreus. Would that I had been killed on the day when the
+Trojans were pressing me so sorely about the dead body of Achilles, for
+then I should have had due burial and the Achaeans would have honoured
+my name; but now it seems that I shall come to a most pitiable end."
+
+As he spoke a sea broke over him with such terrific fury that the raft
+reeled again, and he was carried overboard a long way off. He let go the
+helm, and the force of the hurricane was so great that it broke the mast
+half way up, and both sail and yard went over into the sea. For a long
+time Ulysses was under water, and it was all he could do to rise to the
+surface again, for the clothes Calypso had given him weighed him down;
+but at last he got his head above water and spat out the bitter brine
+that was running down his face in streams. In spite of all this,
+however, he did not lose sight of his raft, but swam as fast as he could
+towards it, got hold of it, and climbed on board again so as to escape
+drowning. The sea took the raft and tossed it about as Autumn winds
+whirl thistledown round and round upon a road. It was as though the
+South, North, East, and West winds were all playing battledore and
+shuttlecock with it at once.
+
+When he was in this plight, Ino daughter of Cadmus, also called
+Leucothea, saw him. She had formerly been a mere mortal, but had been
+since raised to the rank of a marine goddess. Seeing in what great
+distress Ulysses now was, she had compassion upon him, and, rising like
+a sea-gull from the waves, took her seat upon the raft.
+
+"My poor good man," said she, "why is Neptune so furiously angry with
+you? He is giving you a great deal of trouble, but for all his bluster
+he will not kill you. You seem to be a sensible person, do then as I bid
+you; strip, leave your raft to drive before the wind, and swim to the
+Phaeacian coast where better luck awaits you. And here, take my veil and
+put it round your chest; it is enchanted, and you can come to no harm
+so long as you wear it. As soon as you touch land take it off, throw it
+back as far as you can into the sea, and then go away again." With these
+words she took off her veil and gave it him. Then she dived down again
+like a sea-gull and vanished beneath the dark blue waters.
+
+But Ulysses did not know what to think. "Alas," he said to himself in
+his dismay, "this is only some one or other of the gods who is luring me
+to ruin by advising me to quit my raft. At any rate I will not do so at
+present, for the land where she said I should be quit of all troubles
+seemed to be still a good way off. I know what I will do--I am sure it
+will be best--no matter what happens I will stick to the raft as long
+as her timbers hold together, but when the sea breaks her up I will swim
+for it; I do not see how I can do any better than this."
+
+While he was thus in two minds, Neptune sent a terrible great wave that
+seemed to rear itself above his head till it broke right over the raft,
+which then went to pieces as though it were a heap of dry chaff tossed
+about by a whirlwind. Ulysses got astride of one plank and rode upon
+it as if he were on horseback; he then took off the clothes Calypso
+had given him, bound Ino's veil under his arms, and plunged into the
+sea--meaning to swim on shore. King Neptune watched him as he did so,
+and wagged his head, muttering to himself and saying, "There now, swim
+up and down as you best can till you fall in with well-to-do people.
+I do not think you will be able to say that I have let you off too
+lightly." On this he lashed his horses and drove to Aegae where his
+palace is.
+
+But Minerva resolved to help Ulysses, so she bound the ways of all the
+winds except one, and made them lie quite still; but she roused a good
+stiff breeze from the North that should lay the waters till Ulysses
+reached the land of the Phaeacians where he would be safe.
+
+Thereon he floated about for two nights and two days in the water, with
+a heavy swell on the sea and death staring him in the face; but when the
+third day broke, the wind fell and there was a dead calm without so much
+as a breath of air stirring. As he rose on the swell he looked eagerly
+ahead, and could see land quite near. Then, as children rejoice when
+their dear father begins to get better after having for a long time
+borne sore affliction sent him by some angry spirit, but the gods
+deliver him from evil, so was Ulysses thankful when he again saw land
+and trees, and swam on with all his strength that he might once more set
+foot upon dry ground. When, however, he got within earshot, he began to
+hear the surf thundering up against the rocks, for the swell still broke
+against them with a terrific roar. Everything was enveloped in spray;
+there were no harbours where a ship might ride, nor shelter of any kind,
+but only headlands, low-lying rocks, and mountain tops.
+
+Ulysses' heart now began to fail him, and he said despairingly to
+himself, "Alas, Jove has let me see land after swimming so far that I
+had given up all hope, but I can find no landing place, for the coast is
+rocky and surf-beaten, the rocks are smooth and rise sheer from the sea,
+with deep water close under them so that I cannot climb out for want of
+foot hold. I am afraid some great wave will lift me off my legs and dash
+me against the rocks as I leave the water--which would give me a
+sorry landing. If, on the other hand, I swim further in search of some
+shelving beach or harbour, a hurricane may carry me out to sea again
+sorely against my will, or heaven may send some great monster of the
+deep to attack me; for Amphitrite breeds many such, and I know that
+Neptune is very angry with me."
+
+While he was thus in two minds a wave caught him and took him with such
+force against the rocks that he would have been smashed and torn to
+pieces if Minerva had not shown him what to do. He caught hold of the
+rock with both hands and clung to it groaning with pain till the wave
+retired, so he was saved that time; but presently the wave came on again
+and carried him back with it far into the sea--tearing his hands as the
+suckers of a polypus are torn when some one plucks it from its bed, and
+the stones come up along with it--even so did the rocks tear the skin
+from his strong hands, and then the wave drew him deep down under the
+water.
+
+Here poor Ulysses would have certainly perished even in spite of his own
+destiny, if Minerva had not helped him to keep his wits about him. He
+swam seaward again, beyond reach of the surf that was beating against
+the land, and at the same time he kept looking towards the shore to
+see if he could find some haven, or a spit that should take the waves
+aslant. By and by, as he swam on, he came to the mouth of a river, and
+here he thought would be the best place, for there were no rocks, and it
+afforded shelter from the wind. He felt that there was a current, so he
+prayed inwardly and said:
+
+"Hear me, O King, whoever you may be, and save me from the anger of the
+sea-god Neptune, for I approach you prayerfully. Any one who has lost
+his way has at all times a claim even upon the gods, wherefore in my
+distress I draw near to your stream, and cling to the knees of your
+riverhood. Have mercy upon me, O king, for I declare myself your
+suppliant."
+
+Then the god staid his stream and stilled the waves, making all calm
+before him, and bringing him safely into the mouth of the river. Here
+at last Ulysses' knees and strong hands failed him, for the sea had
+completely broken him. His body was all swollen, and his mouth and
+nostrils ran down like a river with sea-water, so that he could neither
+breathe nor speak, and lay swooning from sheer exhaustion; presently,
+when he had got his breath and came to himself again, he took off the
+scarf that Ino had given him and threw it back into the salt {54} stream
+of the river, whereon Ino received it into her hands from the wave that
+bore it towards her. Then he left the river, laid himself down among the
+rushes, and kissed the bounteous earth.
+
+"Alas," he cried to himself in his dismay, "what ever will become of me,
+and how is it all to end? If I stay here upon the river bed through the
+long watches of the night, I am so exhausted that the bitter cold and
+damp may make an end of me--for towards sunrise there will be a keen
+wind blowing from off the river. If, on the other hand, I climb the hill
+side, find shelter in the woods, and sleep in some thicket, I may escape
+the cold and have a good night's rest, but some savage beast may take
+advantage of me and devour me."
+
+In the end he deemed it best to take to the woods, and he found one
+upon some high ground not far from the water. There he crept beneath
+two shoots of olive that grew from a single stock--the one an ungrafted
+sucker, while the other had been grafted. No wind, however squally,
+could break through the cover they afforded, nor could the sun's rays
+pierce them, nor the rain get through them, so closely did they grow
+into one another. Ulysses crept under these and began to make himself
+a bed to lie on, for there was a great litter of dead leaves lying
+about--enough to make a covering for two or three men even in hard
+winter weather. He was glad enough to see this, so he laid himself down
+and heaped the leaves all round him. Then, as one who lives alone in the
+country, far from any neighbor, hides a brand as fire-seed in the
+ashes to save himself from having to get a light elsewhere, even so did
+Ulysses cover himself up with leaves; and Minerva shed a sweet sleep
+upon his eyes, closed his eyelids, and made him lose all memories of his
+sorrows.
+
+
+Book VI
+
+THE MEETING BETWEEN NAUSICAA AND ULYSSES.
+
+So here Ulysses slept, overcome by sleep and toil; but Minerva went off
+to the country and city of the Phaeacians--a people who used to live in
+the fair town of Hypereia, near the lawless Cyclopes. Now the Cyclopes
+were stronger than they and plundered them, so their king Nausithous
+moved them thence and settled them in Scheria, far from all other
+people. He surrounded the city with a wall, built houses and temples,
+and divided the lands among his people; but he was dead and gone to
+the house of Hades, and King Alcinous, whose counsels were inspired
+of heaven, was now reigning. To his house, then, did Minerva hie in
+furtherance of the return of Ulysses.
+
+She went straight to the beautifully decorated bedroom in which there
+slept a girl who was as lovely as a goddess, Nausicaa, daughter to King
+Alcinous. Two maid servants were sleeping near her, both very pretty,
+one on either side of the doorway, which was closed with well made
+folding doors. Minerva took the form of the famous sea captain Dymas's
+daughter, who was a bosom friend of Nausicaa and just her own age; then,
+coming up to the girl's bedside like a breath of wind, she hovered over
+her head and said:
+
+"Nausicaa, what can your mother have been about, to have such a lazy
+daughter? Here are your clothes all lying in disorder, yet you are going
+to be married almost immediately, and should not only be well dressed
+yourself, but should find good clothes for those who attend you. This is
+the way to get yourself a good name, and to make your father and mother
+proud of you. Suppose, then, that we make tomorrow a washing day,
+and start at daybreak. I will come and help you so that you may have
+everything ready as soon as possible, for all the best young men among
+your own people are courting you, and you are not going to remain a
+maid much longer. Ask your father, therefore, to have a waggon and mules
+ready for us at daybreak, to take the rugs, robes, and girdles, and you
+can ride, too, which will be much pleasanter for you than walking, for
+the washing-cisterns are some way from the town."
+
+When she had said this Minerva went away to Olympus, which they say
+is the everlasting home of the gods. Here no wind beats roughly, and
+neither rain nor snow can fall; but it abides in everlasting sunshine
+and in a great peacefulness of light, wherein the blessed gods are
+illumined for ever and ever. This was the place to which the goddess
+went when she had given instructions to the girl.
+
+By and by morning came and woke Nausicaa, who began wondering about
+her dream; she therefore went to the other end of the house to tell her
+father and mother all about it, and found them in their own room. Her
+mother was sitting by the fireside spinning her purple yarn with her
+maids around her, and she happened to catch her father just as he was
+going out to attend a meeting of the town council, which the Phaeacian
+aldermen had convened. She stopped him and said:
+
+"Papa dear, could you manage to let me have a good big waggon? I want to
+take all our dirty clothes to the river and wash them. You are the chief
+man here, so it is only right that you should have a clean shirt when
+you attend meetings of the council. Moreover, you have five sons at
+home, two of them married, while the other three are good looking
+bachelors; you know they always like to have clean linen when they go to
+a dance, and I have been thinking about all this."
+
+She did not say a word about her own wedding, for she did not like to,
+but her father knew and said, "You shall have the mules, my love, and
+whatever else you have a mind for. Be off with you, and the men shall
+get you a good strong waggon with a body to it that will hold all your
+clothes."
+
+On this he gave his orders to the servants, who got the waggon out,
+harnessed the mules, and put them to, while the girl brought the clothes
+down from the linen room and placed them on the waggon. Her mother
+prepared her a basket of provisions with all sorts of good things, and a
+goat skin full of wine; the girl now got into the waggon, and her mother
+gave her also a golden cruse of oil, that she and her women might anoint
+themselves. Then she took the whip and reins and lashed the mules on,
+whereon they set off, and their hoofs clattered on the road. They pulled
+without flagging, and carried not only Nausicaa and her wash of clothes,
+but the maids also who were with her.
+
+When they reached the water side they went to the washing cisterns,
+through which there ran at all times enough pure water to wash any
+quantity of linen, no matter how dirty. Here they unharnessed the mules
+and turned them out to feed on the sweet juicy herbage that grew by the
+water side. They took the clothes out of the waggon, put them in the
+water, and vied with one another in treading them in the pits to get the
+dirt out. After they had washed them and got them quite clean, they laid
+them out by the sea side, where the waves had raised a high beach of
+shingle, and set about washing themselves and anointing themselves with
+olive oil. Then they got their dinner by the side of the stream, and
+waited for the sun to finish drying the clothes. When they had done
+dinner they threw off the veils that covered their heads and began to
+play at ball, while Nausicaa sang for them. As the huntress Diana goes
+forth upon the mountains of Taygetus or Erymanthus to hunt wild boars or
+deer, and the wood nymphs, daughters of Aegis-bearing Jove, take their
+sport along with her (then is Leto proud at seeing her daughter stand a
+full head taller than the others, and eclipse the loveliest amid a whole
+bevy of beauties), even so did the girl outshine her handmaids.
+
+When it was time for them to start home, and they were folding the
+clothes and putting them into the waggon, Minerva began to consider how
+Ulysses should wake up and see the handsome girl who was to conduct him
+to the city of the Phaeacians. The girl, therefore, threw a ball at one
+of the maids, which missed her and fell into deep water. On this they
+all shouted, and the noise they made woke Ulysses, who sat up in his bed
+of leaves and began to wonder what it might all be.
+
+"Alas," said he to himself, "what kind of people have I come amongst?
+Are they cruel, savage, and uncivilised, or hospitable and humane? I
+seem to hear the voices of young women, and they sound like those of
+the nymphs that haunt mountain tops, or springs of rivers and meadows of
+green grass. At any rate I am among a race of men and women. Let me try
+if I cannot manage to get a look at them."
+
+As he said this he crept from under his bush, and broke off a bough
+covered with thick leaves to hide his nakedness. He looked like some
+lion of the wilderness that stalks about exulting in his strength and
+defying both wind and rain; his eyes glare as he prowls in quest of
+oxen, sheep, or deer, for he is famished, and will dare break even
+into a well fenced homestead, trying to get at the sheep--even such did
+Ulysses seem to the young women, as he drew near to them all naked as he
+was, for he was in great want. On seeing one so unkempt and so begrimed
+with salt water, the others scampered off along the spits that jutted
+out into the sea, but the daughter of Alcinous stood firm, for Minerva
+put courage into her heart and took away all fear from her. She stood
+right in front of Ulysses, and he doubted whether he should go up to
+her, throw himself at her feet, and embrace her knees as a suppliant, or
+stay where he was and entreat her to give him some clothes and show him
+the way to the town. In the end he deemed it best to entreat her from a
+distance in case the girl should take offence at his coming near enough
+to clasp her knees, so he addressed her in honeyed and persuasive
+language.
+
+"O queen," he said, "I implore your aid--but tell me, are you a goddess
+or are you a mortal woman? If you are a goddess and dwell in heaven, I
+can only conjecture that you are Jove's daughter Diana, for your face
+and figure resemble none but hers; if on the other hand you are a mortal
+and live on earth, thrice happy are your father and mother--thrice
+happy, too, are your brothers and sisters; how proud and delighted
+they must feel when they see so fair a scion as yourself going out to a
+dance; most happy, however, of all will he be whose wedding gifts have
+been the richest, and who takes you to his own home. I never yet saw any
+one so beautiful, neither man nor woman, and am lost in admiration as I
+behold you. I can only compare you to a young palm tree which I saw when
+I was at Delos growing near the altar of Apollo--for I was there, too,
+with much people after me, when I was on that journey which has been the
+source of all my troubles. Never yet did such a young plant shoot out
+of the ground as that was, and I admired and wondered at it exactly as I
+now admire and wonder at yourself. I dare not clasp your knees, but I
+am in great distress; yesterday made the twentieth day that I had been
+tossing about upon the sea. The winds and waves have taken me all the
+way from the Ogygian island, {55} and now fate has flung me upon this
+coast that I may endure still further suffering; for I do not think that
+I have yet come to the end of it, but rather that heaven has still much
+evil in store for me.
+
+"And now, O queen, have pity upon me, for you are the first person I
+have met, and I know no one else in this country. Show me the way to
+your town, and let me have anything that you may have brought hither to
+wrap your clothes in. May heaven grant you in all things your heart's
+desire--husband, house, and a happy, peaceful home; for there is nothing
+better in this world than that man and wife should be of one mind in a
+house. It discomfits their enemies, makes the hearts of their friends
+glad, and they themselves know more about it than any one."
+
+To this Nausicaa answered, "Stranger, you appear to be a sensible,
+well-disposed person. There is no accounting for luck; Jove gives
+prosperity to rich and poor just as he chooses, so you must take what
+he has seen fit to send you, and make the best of it. Now, however, that
+you have come to this our country, you shall not want for clothes nor
+for anything else that a foreigner in distress may reasonably look for.
+I will show you the way to the town, and will tell you the name of our
+people; we are called Phaeacians, and I am daughter to Alcinous, in whom
+the whole power of the state is vested."
+
+Then she called her maids and said, "Stay where you are, you girls. Can
+you not see a man without running away from him? Do you take him for a
+robber or a murderer? Neither he nor any one else can come here to do
+us Phaeacians any harm, for we are dear to the gods, and live apart on a
+land's end that juts into the sounding sea, and have nothing to do with
+any other people. This is only some poor man who has lost his way, and
+we must be kind to him, for strangers and foreigners in distress
+are under Jove's protection, and will take what they can get and be
+thankful; so, girls, give the poor fellow something to eat and drink,
+and wash him in the stream at some place that is sheltered from the
+wind."
+
+On this the maids left off running away and began calling one another
+back. They made Ulysses sit down in the shelter as Nausicaa had told
+them, and brought him a shirt and cloak. They also brought him the
+little golden cruse of oil, and told him to go and wash in the stream.
+But Ulysses said, "Young women, please to stand a little on one side
+that I may wash the brine from my shoulders and anoint myself with oil,
+for it is long enough since my skin has had a drop of oil upon it. I
+cannot wash as long as you all keep standing there. I am ashamed to
+strip {56} before a number of good looking young women."
+
+Then they stood on one side and went to tell the girl, while Ulysses
+washed himself in the stream and scrubbed the brine from his back and
+from his broad shoulders. When he had thoroughly washed himself, and had
+got the brine out of his hair, he anointed himself with oil, and put
+on the clothes which the girl had given him; Minerva then made him look
+taller and stronger than before, she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders as a skilful workman who has
+studied art of all kinds under Vulcan and Minerva enriches a piece of
+silver plate by gilding it--and his work is full of beauty. Then he went
+and sat down a little way off upon the beach, looking quite young and
+handsome, and the girl gazed on him with admiration; then she said to
+her maids:
+
+"Hush, my dears, for I want to say something. I believe the gods who
+live in heaven have sent this man to the Phaeacians. When I first saw
+him I thought him plain, but now his appearance is like that of the gods
+who dwell in heaven. I should like my future husband to be just such
+another as he is, if he would only stay here and not want to go away.
+However, give him something to eat and drink."
+
+They did as they were told, and set food before Ulysses, who ate and
+drank ravenously, for it was long since he had had food of any kind.
+Meanwhile, Nausicaa bethought her of another matter. She got the linen
+folded and placed in the waggon, she then yoked the mules, and, as she
+took her seat, she called Ulysses:
+
+"Stranger," said she, "rise and let us be going back to the town; I will
+introduce you at the house of my excellent father, where I can tell you
+that you will meet all the best people among the Phaeacians. But be sure
+and do as I bid you, for you seem to be a sensible person. As long as
+we are going past the fields and farm lands, follow briskly behind the
+waggon along with the maids and I will lead the way myself. Presently,
+however, we shall come to the town, where you will find a high wall
+running all round it, and a good harbour on either side with a narrow
+entrance into the city, and the ships will be drawn up by the road side,
+for every one has a place where his own ship can lie. You will see the
+market place with a temple of Neptune in the middle of it, and paved
+with large stones bedded in the earth. Here people deal in ship's gear
+of all kinds, such as cables and sails, and here, too, are the places
+where oars are made, for the Phaeacians are not a nation of archers;
+they know nothing about bows and arrows, but are a sea-faring folk, and
+pride themselves on their masts, oars, and ships, with which they travel
+far over the sea.
+
+"I am afraid of the gossip and scandal that may be set on foot against
+me later on; for the people here are very ill-natured, and some low
+fellow, if he met us, might say, 'Who is this fine-looking stranger that
+is going about with Nausicaa? Where did she find him? I suppose she is
+going to marry him. Perhaps he is a vagabond sailor whom she has taken
+from some foreign vessel, for we have no neighbours; or some god has at
+last come down from heaven in answer to her prayers, and she is going to
+live with him all the rest of her life. It would be a good thing if she
+would take herself off and find a husband somewhere else, for she will
+not look at one of the many excellent young Phaeacians who are in love
+with her.' This is the kind of disparaging remark that would be made
+about me, and I could not complain, for I should myself be scandalised
+at seeing any other girl do the like, and go about with men in spite
+of everybody, while her father and mother were still alive, and without
+having been married in the face of all the world.
+
+"If, therefore, you want my father to give you an escort and to help you
+home, do as I bid you; you will see a beautiful grove of poplars by the
+road side dedicated to Minerva; it has a well in it and a meadow all
+round it. Here my father has a field of rich garden ground, about as far
+from the town as a man's voice will carry. Sit down there and wait for
+a while till the rest of us can get into the town and reach my father's
+house. Then, when you think we must have done this, come into the town
+and ask the way to the house of my father Alcinous. You will have no
+difficulty in finding it; any child will point it out to you, for no one
+else in the whole town has anything like such a fine house as he has.
+When you have got past the gates and through the outer court, go right
+across the inner court till you come to my mother. You will find her
+sitting by the fire and spinning her purple wool by firelight. It is a
+fine sight to see her as she leans back against one of the bearing-posts
+with her maids all ranged behind her. Close to her seat stands that of
+my father, on which he sits and topes like an immortal god. Never mind
+him, but go up to my mother, and lay your hands upon her knees if you
+would get home quickly. If you can gain her over, you may hope to see
+your own country again, no matter how distant it may be."
+
+So saying she lashed the mules with her whip and they left the river.
+The mules drew well, and their hoofs went up and down upon the road.
+She was careful not to go too fast for Ulysses and the maids who were
+following on foot along with the waggon, so she plied her whip with
+judgement. As the sun was going down they came to the sacred grove of
+Minerva, and there Ulysses sat down and prayed to the mighty daughter of
+Jove.
+
+"Hear me," he cried, "daughter of Aegis-bearing Jove, unweariable, hear
+me now, for you gave no heed to my prayers when Neptune was wrecking me.
+Now, therefore, have pity upon me and grant that I may find friends and
+be hospitably received by the Phaeacians."
+
+Thus did he pray, and Minerva heard his prayer, but she would not show
+herself to him openly, for she was afraid of her uncle Neptune, who was
+still furious in his endeavors to prevent Ulysses from getting home.
+
+
+Book VII
+
+RECEPTION OF ULYSSES AT THE PALACE OF KING ALCINOUS.
+
+Thus, then, did Ulysses wait and pray; but the girl drove on to the
+town. When she reached her father's house she drew up at the gateway,
+and her brothers--comely as the gods--gathered round her, took the mules
+out of the waggon, and carried the clothes into the house, while she
+went to her own room, where an old servant, Eurymedusa of Apeira, lit
+the fire for her. This old woman had been brought by sea from Apeira,
+and had been chosen as a prize for Alcinous because he was king over the
+Phaeacians, and the people obeyed him as though he were a god. {57}
+She had been nurse to Nausicaa, and had now lit the fire for her, and
+brought her supper for her into her own room.
+
+Presently Ulysses got up to go towards the town; and Minerva shed a
+thick mist all round him to hide him in case any of the proud Phaeacians
+who met him should be rude to him, or ask him who he was. Then, as he
+was just entering the town, she came towards him in the likeness of a
+little girl carrying a pitcher. She stood right in front of him, and
+Ulysses said:
+
+"My dear, will you be so kind as to show me the house of king Alcinous?
+I am an unfortunate foreigner in distress, and do not know one in your
+town and country."
+
+Then Minerva said, "Yes, father stranger, I will show you the house you
+want, for Alcinous lives quite close to my own father. I will go before
+you and show the way, but say not a word as you go, and do not look
+at any man, nor ask him questions; for the people here cannot abide
+strangers, and do not like men who come from some other place. They are
+a sea-faring folk, and sail the seas by the grace of Neptune in ships
+that glide along like thought, or as a bird in the air."
+
+On this she led the way, and Ulysses followed in her steps; but not one
+of the Phaeacians could see him as he passed through the city in the
+midst of them; for the great goddess Minerva in her good will towards
+him had hidden him in a thick cloud of darkness. He admired their
+harbours, ships, places of assembly, and the lofty walls of the city,
+which, with the palisade on top of them, were very striking, and when
+they reached the king's house Minerva said:
+
+"This is the house, father stranger, which you would have me show you.
+You will find a number of great people sitting at table, but do not be
+afraid; go straight in, for the bolder a man is the more likely he is to
+carry his point, even though he is a stranger. First find the queen. Her
+name is Arete, and she comes of the same family as her husband Alcinous.
+They both descend originally from Neptune, who was father to Nausithous
+by Periboea, a woman of great beauty. Periboea was the youngest daughter
+of Eurymedon, who at one time reigned over the giants, but he ruined his
+ill-fated people and lost his own life to boot.
+
+"Neptune, however, lay with his daughter, and she had a son by him, the
+great Nausithous, who reigned over the Phaeacians. Nausithous had two
+sons Rhexenor and Alcinous; {58} Apollo killed the first of them while
+he was still a bridegroom and without male issue; but he left a daughter
+Arete, whom Alcinous married, and honours as no other woman is honoured
+of all those that keep house along with their husbands.
+
+"Thus she both was, and still is, respected beyond measure by her
+children, by Alcinous himself, and by the whole people, who look upon
+her as a goddess, and greet her whenever she goes about the city, for
+she is a thoroughly good woman both in head and heart, and when any
+women are friends of hers, she will help their husbands also to settle
+their disputes. If you can gain her good will, you may have every hope
+of seeing your friends again, and getting safely back to your home and
+country."
+
+Then Minerva left Scheria and went away over the sea. She went to
+Marathon {59} and to the spacious streets of Athens, where she entered
+the abode of Erechtheus; but Ulysses went on to the house of Alcinous,
+and he pondered much as he paused a while before reaching the threshold
+of bronze, for the splendour of the palace was like that of the sun or
+moon. The walls on either side were of bronze from end to end, and the
+cornice was of blue enamel. The doors were gold, and hung on pillars of
+silver that rose from a floor of bronze, while the lintel was silver and
+the hook of the door was of gold.
+
+On either side there stood gold and silver mastiffs which Vulcan, with
+his consummate skill, had fashioned expressly to keep watch over the
+palace of king Alcinous; so they were immortal and could never grow old.
+Seats were ranged all along the wall, here and there from one end to the
+other, with coverings of fine woven work which the women of the house
+had made. Here the chief persons of the Phaeacians used to sit and eat
+and drink, for there was abundance at all seasons; and there were golden
+figures of young men with lighted torches in their hands, raised on
+pedestals, to give light by night to those who were at table. There are
+{60} fifty maid servants in the house, some of whom are always grinding
+rich yellow grain at the mill, while others work at the loom, or sit and
+spin, and their shuttles go backwards and forwards like the fluttering
+of aspen leaves, while the linen is so closely woven that it will turn
+oil. As the Phaeacians are the best sailors in the world, so their women
+excel all others in weaving, for Minerva has taught them all manner of
+useful arts, and they are very intelligent.
+
+Outside the gate of the outer court there is a large garden of
+about four acres with a wall all round it. It is full of beautiful
+trees--pears, pomegranates, and the most delicious apples. There are
+luscious figs also, and olives in full growth. The fruits never rot nor
+fail all the year round, neither winter nor summer, for the air is so
+soft that a new crop ripens before the old has dropped. Pear grows on
+pear, apple on apple, and fig on fig, and so also with the grapes, for
+there is an excellent vineyard: on the level ground of a part of this,
+the grapes are being made into raisins; in another part they are being
+gathered; some are being trodden in the wine tubs, others further on
+have shed their blossom and are beginning to show fruit, others again
+are just changing colour. In the furthest part of the ground there are
+beautifully arranged beds of flowers that are in bloom all the year
+round. Two streams go through it, the one turned in ducts throughout the
+whole garden, while the other is carried under the ground of the outer
+court to the house itself, and the town's people draw water from it.
+Such, then, were the splendours with which the gods had endowed the
+house of king Alcinous.
+
+So here Ulysses stood for a while and looked about him, but when he
+had looked long enough he crossed the threshold and went within the
+precincts of the house. There he found all the chief people among the
+Phaeacians making their drink offerings to Mercury, which they always
+did the last thing before going away for the night. {61} He went
+straight through the court, still hidden by the cloak of darkness
+in which Minerva had enveloped him, till he reached Arete and King
+Alcinous; then he laid his hands upon the knees of the queen, and at
+that moment the miraculous darkness fell away from him and he became
+visible. Every one was speechless with surprise at seeing a man there,
+but Ulysses began at once with his petition.
+
+"Queen Arete," he exclaimed, "daughter of great Rhexenor, in my distress
+I humbly pray you, as also your husband and these your guests (whom may
+heaven prosper with long life and happiness, and may they leave their
+possessions to their children, and all the honours conferred upon them
+by the state) to help me home to my own country as soon as possible; for
+I have been long in trouble and away from my friends."
+
+Then he sat down on the hearth among the ashes and they all held their
+peace, till presently the old hero Echeneus, who was an excellent
+speaker and an elder among the Phaeacians, plainly and in all honesty
+addressed them thus:
+
+"Alcinous," said he, "it is not creditable to you that a stranger should
+be seen sitting among the ashes of your hearth; every one is waiting to
+hear what you are about to say; tell him, then, to rise and take a seat
+on a stool inlaid with silver, and bid your servants mix some wine and
+water that we may make a drink offering to Jove the lord of thunder,
+who takes all well disposed suppliants under his protection; and let
+the housekeeper give him some supper, of whatever there may be in the
+house."
+
+When Alcinous heard this he took Ulysses by the hand, raised him from
+the hearth, and bade him take the seat of Laodamas, who had been sitting
+beside him, and was his favourite son. A maid servant then brought him
+water in a beautiful golden ewer and poured it into a silver basin for
+him to wash his hands, and she drew a clean table beside him; an upper
+servant brought him bread and offered him many good things of what there
+was in the house, and Ulysses ate and drank. Then Alcinous said to one
+of the servants, "Pontonous, mix a cup of wine and hand it round that
+we may make drink-offerings to Jove the lord of thunder, who is the
+protector of all well-disposed suppliants."
+
+Pontonous then mixed wine and water, and handed it round after giving
+every man his drink-offering. When they had made their offerings, and
+had drunk each as much as he was minded, Alcinous said:
+
+"Aldermen and town councillors of the Phaeacians, hear my words. You
+have had your supper, so now go home to bed. To-morrow morning I shall
+invite a still larger number of aldermen, and will give a sacrificial
+banquet in honour of our guest; we can then discuss the question of his
+escort, and consider how we may at once send him back rejoicing to his
+own country without trouble or inconvenience to himself, no matter how
+distant it may be. We must see that he comes to no harm while on his
+homeward journey, but when he is once at home he will have to take
+the luck he was born with for better or worse like other people. It is
+possible, however, that the stranger is one of the immortals who
+has come down from heaven to visit us; but in this case the gods
+are departing from their usual practice, for hitherto they have made
+themselves perfectly clear to us when we have been offering them
+hecatombs. They come and sit at our feasts just like one of our selves,
+and if any solitary wayfarer happens to stumble upon some one or other
+of them, they affect no concealment, for we are as near of kin to the
+gods as the Cyclopes and the savage giants are." {62}
+
+Then Ulysses said: "Pray, Alcinous, do not take any such notion into
+your head. I have nothing of the immortal about me, neither in body
+nor mind, and most resemble those among you who are the most afflicted.
+Indeed, were I to tell you all that heaven has seen fit to lay upon me,
+you would say that I was still worse off than they are. Nevertheless,
+let me sup in spite of sorrow, for an empty stomach is a very
+importunate thing, and thrusts itself on a man's notice no matter how
+dire is his distress. I am in great trouble, yet it insists that I shall
+eat and drink, bids me lay aside all memory of my sorrows and dwell only
+on the due replenishing of itself. As for yourselves, do as you propose,
+and at break of day set about helping me to get home. I shall be content
+to die if I may first once more behold my property, my bondsmen, and all
+the greatness of my house." {63}
+
+Thus did he speak. Every one approved his saying, and agreed that he
+should have his escort inasmuch as he had spoken reasonably. Then when
+they had made their drink offerings, and had drunk each as much as he
+was minded they went home to bed every man in his own abode, leaving
+Ulysses in the cloister with Arete and Alcinous while the servants were
+taking the things away after supper. Arete was the first to speak,
+for she recognised the shirt, cloak, and good clothes that Ulysses
+was wearing, as the work of herself and of her maids; so she said,
+"Stranger, before we go any further, there is a question I should like
+to ask you. Who, and whence are you, and who gave you those clothes? Did
+you not say you had come here from beyond the sea?"
+
+And Ulysses answered, "It would be a long story Madam, were I to relate
+in full the tale of my misfortunes, for the hand of heaven has been laid
+heavy upon me; but as regards your question, there is an island far away
+in the sea which is called 'the Ogygian.' Here dwells the cunning and
+powerful goddess Calypso, daughter of Atlas. She lives by herself far
+from all neighbours human or divine. Fortune, however, brought me to
+her hearth all desolate and alone, for Jove struck my ship with his
+thunderbolts, and broke it up in mid-ocean. My brave comrades were
+drowned every man of them, but I stuck to the keel and was carried
+hither and thither for the space of nine days, till at last during the
+darkness of the tenth night the gods brought me to the Ogygian island
+where the great goddess Calypso lives. She took me in and treated me
+with the utmost kindness; indeed she wanted to make me immortal that I
+might never grow old, but she could not persuade me to let her do so.
+
+"I stayed with Calypso seven years straight on end, and watered the good
+clothes she gave me with my tears during the whole time; but at last
+when the eighth year came round she bade me depart of her own free will,
+either because Jove had told her she must, or because she had changed
+her mind. She sent me from her island on a raft, which she provisioned
+with abundance of bread and wine. Moreover she gave me good stout
+clothing, and sent me a wind that blew both warm and fair. Days seven
+and ten did I sail over the sea, and on the eighteenth I caught sight of
+the first outlines of the mountains upon your coast--and glad indeed was
+I to set eyes upon them. Nevertheless there was still much trouble in
+store for me, for at this point Neptune would let me go no further, and
+raised a great storm against me; the sea was so terribly high that I
+could no longer keep to my raft, which went to pieces under the fury of
+the gale, and I had to swim for it, till wind and current brought me to
+your shores.
+
+"There I tried to land, but could not, for it was a bad place and the
+waves dashed me against the rocks, so I again took to the sea and swam
+on till I came to a river that seemed the most likely landing place, for
+there were no rocks and it was sheltered from the wind. Here, then, I
+got out of the water and gathered my senses together again. Night was
+coming on, so I left the river, and went into a thicket, where I covered
+myself all over with leaves, and presently heaven sent me off into a
+very deep sleep. Sick and sorry as I was I slept among the leaves all
+night, and through the next day till afternoon, when I woke as the sun
+was westering, and saw your daughter's maid servants playing upon the
+beach, and your daughter among them looking like a goddess. I besought
+her aid, and she proved to be of an excellent disposition, much more so
+than could be expected from so young a person--for young people are apt
+to be thoughtless. She gave me plenty of bread and wine, and when she
+had had me washed in the river she also gave me the clothes in which you
+see me. Now, therefore, though it has pained me to do so, I have told
+you the whole truth."
+
+Then Alcinous said, "Stranger, it was very wrong of my daughter not to
+bring you on at once to my house along with the maids, seeing that she
+was the first person whose aid you asked."
+
+"Pray do not scold her," replied Ulysses; "she is not to blame. She did
+tell me to follow along with the maids, but I was ashamed and afraid,
+for I thought you might perhaps be displeased if you saw me. Every human
+being is sometimes a little suspicious and irritable."
+
+"Stranger," replied Alcinous, "I am not the kind of man to get angry
+about nothing; it is always better to be reasonable; but by Father Jove,
+Minerva, and Apollo, now that I see what kind of person you are, and how
+much you think as I do, I wish you would stay here, marry my daughter,
+and become my son-in-law. If you will stay I will give you a house and
+an estate, but no one (heaven forbid) shall keep you here against your
+own wish, and that you may be sure of this I will attend tomorrow to the
+matter of your escort. You can sleep {64} during the whole voyage if you
+like, and the men shall sail you over smooth waters either to your own
+home, or wherever you please, even though it be a long way further
+off than Euboea, which those of my people who saw it when they took
+yellow-haired Rhadamanthus to see Tityus the son of Gaia, tell me is the
+furthest of any place--and yet they did the whole voyage in a single day
+without distressing themselves, and came back again afterwards. You
+will thus see how much my ships excel all others, and what magnificent
+oarsmen my sailors are."
+
+Then was Ulysses glad and prayed aloud saying, "Father Jove, grant that
+Alcinous may do all as he has said, for so he will win an imperishable
+name among mankind, and at the same time I shall return to my country."
+
+Thus did they converse. Then Arete told her maids to set a bed in the
+room that was in the gatehouse, and make it with good red rugs, and to
+spread coverlets on the top of them with woollen cloaks for Ulysses to
+wear. The maids thereon went out with torches in their hands, and when
+they had made the bed they came up to Ulysses and said, "Rise, sir
+stranger, and come with us for your bed is ready," and glad indeed was
+he to go to his rest.
+
+So Ulysses slept in a bed placed in a room over the echoing gateway; but
+Alcinous lay in the inner part of the house, with the queen his wife by
+his side.
+
+
+Book VIII
+
+BANQUET IN THE HOUSE OF ALCINOUS--THE GAMES.
+
+Now when the child of morning, rosy-fingered Dawn, appeared, Alcinous
+and Ulysses both rose, and Alcinous led the way to the Phaeacian place
+of assembly, which was near the ships. When they got there they sat down
+side by side on a seat of polished stone, while Minerva took the form
+of one of Alcinous' servants, and went round the town in order to help
+Ulysses to get home. She went up to the citizens, man by man, and said,
+"Aldermen and town councillors of the Phaeacians, come to the assembly
+all of you and listen to the stranger who has just come off a long
+voyage to the house of King Alcinous; he looks like an immortal god."
+
+With these words she made them all want to come, and they flocked to the
+assembly till seats and standing room were alike crowded. Every one was
+struck with the appearance of Ulysses, for Minerva had beautified him
+about the head and shoulders, making him look taller and stouter than he
+really was, that he might impress the Phaeacians favourably as being a
+very remarkable man, and might come off well in the many trials of skill
+to which they would challenge him. Then, when they were got together,
+Alcinous spoke:
+
+"Hear me," said he, "aldermen and town councillors of the Phaeacians,
+that I may speak even as I am minded. This stranger, whoever he may be,
+has found his way to my house from somewhere or other either East or
+West. He wants an escort and wishes to have the matter settled. Let
+us then get one ready for him, as we have done for others before him;
+indeed, no one who ever yet came to my house has been able to complain
+of me for not speeding on his way soon enough. Let us draw a ship into
+the sea--one that has never yet made a voyage--and man her with two and
+fifty of our smartest young sailors. Then when you have made fast
+your oars each by his own seat, leave the ship and come to my house to
+prepare a feast. {65} I will find you in everything. I am giving these
+instructions to the young men who will form the crew, for as regards
+you aldermen and town councillors, you will join me in entertaining
+our guest in the cloisters. I can take no excuses, and we will have
+Demodocus to sing to us; for there is no bard like him whatever he may
+choose to sing about."
+
+Alcinous then led the way, and the others followed after, while a
+servant went to fetch Demodocus. The fifty-two picked oarsmen went to
+the sea shore as they had been told, and when they got there they drew
+the ship into the water, got her mast and sails inside her, bound
+the oars to the thole-pins with twisted thongs of leather, all in due
+course, and spread the white sails aloft. They moored the vessel a
+little way out from land, and then came on shore and went to the house
+of King Alcinous. The out houses, {66} yards, and all the precincts were
+filled with crowds of men in great multitudes both old and young; and
+Alcinous killed them a dozen sheep, eight full grown pigs, and two oxen.
+These they skinned and dressed so as to provide a magnificent banquet.
+
+A servant presently led in the famous bard Demodocus, whom the muse had
+dearly loved, but to whom she had given both good and evil, for though
+she had endowed him with a divine gift of song, she had robbed him of
+his eyesight. Pontonous set a seat for him among the guests, leaning it
+up against a bearing-post. He hung the lyre for him on a peg over his
+head, and showed him where he was to feel for it with his hands. He also
+set a fair table with a basket of victuals by his side, and a cup of
+wine from which he might drink whenever he was so disposed.
+
+The company then laid their hands upon the good things that were before
+them, but as soon as they had had enough to eat and drink, the muse
+inspired Demodocus to sing the feats of heroes, and more especially
+a matter that was then in the mouths of all men, to wit, the quarrel
+between Ulysses and Achilles, and the fierce words that they heaped on
+one another as they sat together at a banquet. But Agamemnon was glad
+when he heard his chieftains quarrelling with one another, for Apollo
+had foretold him this at Pytho when he crossed the stone floor to
+consult the oracle. Here was the beginning of the evil that by the will
+of Jove fell both upon Danaans and Trojans.
+
+Thus sang the bard, but Ulysses drew his purple mantle over his head and
+covered his face, for he was ashamed to let the Phaeacians see that he
+was weeping. When the bard left off singing he wiped the tears from his
+eyes, uncovered his face, and, taking his cup, made a drink-offering to
+the gods; but when the Phaeacians pressed Demodocus to sing further, for
+they delighted in his lays, then Ulysses again drew his mantle over his
+head and wept bitterly. No one noticed his distress except Alcinous, who
+was sitting near him, and heard the heavy sighs that he was heaving. So
+he at once said, "Aldermen and town councillors of the Phaeacians, we
+have had enough now, both of the feast, and of the minstrelsy that is
+its due accompaniment; let us proceed therefore to the athletic sports,
+so that our guest on his return home may be able to tell his friends
+how much we surpass all other nations as boxers, wrestlers, jumpers, and
+runners."
+
+With these words he led the way, and the others followed after. A
+servant hung Demodocus's lyre on its peg for him, led him out of the
+cloister, and set him on the same way as that along which all the chief
+men of the Phaeacians were going to see the sports; a crowd of several
+thousands of people followed them, and there were many excellent
+competitors for all the prizes. Acroneos, Ocyalus, Elatreus, Nauteus,
+Prymneus, Anchialus, Eretmeus, Ponteus, Proreus, Thoon, Anabesineus, and
+Amphialus son of Polyneus son of Tecton. There was also Euryalus son of
+Naubolus, who was like Mars himself, and was the best looking man
+among the Phaeacians except Laodamas. Three sons of Alcinous, Laodamas,
+Halios, and Clytoneus, competed also.
+
+The foot races came first. The course was set out for them from the
+starting post, and they raised a dust upon the plain as they all flew
+forward at the same moment. Clytoneus came in first by a long way; he
+left every one else behind him by the length of the furrow that a couple
+of mules can plough in a fallow field. {67} They then turned to the
+painful art of wrestling, and here Euryalus proved to be the best man.
+Amphialus excelled all the others in jumping, while at throwing the disc
+there was no one who could approach Elatreus. Alcinous's son Laodamas
+was the best boxer, and he it was who presently said, when they had all
+been diverted with the games, "Let us ask the stranger whether he excels
+in any of these sports; he seems very powerfully built; his thighs,
+calves, hands, and neck are of prodigious strength, nor is he at all
+old, but he has suffered much lately, and there is nothing like the sea
+for making havoc with a man, no matter how strong he is."
+
+"You are quite right, Laodamas," replied Euryalus, "go up to your guest
+and speak to him about it yourself."
+
+When Laodamas heard this he made his way into the middle of the crowd
+and said to Ulysses, "I hope, Sir, that you will enter yourself for some
+one or other of our competitions if you are skilled in any of them--and
+you must have gone in for many a one before now. There is nothing that
+does any one so much credit all his life long as the showing himself a
+proper man with his hands and feet. Have a try therefore at something,
+and banish all sorrow from your mind. Your return home will not be long
+delayed, for the ship is already drawn into the water, and the crew is
+found."
+
+Ulysses answered, "Laodamas, why do you taunt me in this way? my mind is
+set rather on cares than contests; I have been through infinite trouble,
+and am come among you now as a suppliant, praying your king and people
+to further me on my return home."
+
+Then Euryalus reviled him outright and said, "I gather, then, that you
+are unskilled in any of the many sports that men generally delight in. I
+suppose you are one of those grasping traders that go about in ships
+as captains or merchants, and who think of nothing but of their outward
+freights and homeward cargoes. There does not seem to be much of the
+athlete about you."
+
+"For shame, Sir," answered Ulysses, fiercely, "you are an insolent
+fellow--so true is it that the gods do not grace all men alike in
+speech, person, and understanding. One man may be of weak presence, but
+heaven has adorned this with such a good conversation that he charms
+every one who sees him; his honeyed moderation carries his hearers with
+him so that he is leader in all assemblies of his fellows, and wherever
+he goes he is looked up to. Another may be as handsome as a god, but his
+good looks are not crowned with discretion. This is your case. No god
+could make a finer looking fellow than you are, but you are a fool. Your
+ill-judged remarks have made me exceedingly angry, and you are quite
+mistaken, for I excel in a great many athletic exercises; indeed, so
+long as I had youth and strength, I was among the first athletes of the
+age. Now, however, I am worn out by labour and sorrow, for I have gone
+through much both on the field of battle and by the waves of the weary
+sea; still, in spite of all this I will compete, for your taunts have
+stung me to the quick."
+
+So he hurried up without even taking his cloak off, and seized a disc,
+larger, more massive and much heavier than those used by the Phaeacians
+when disc-throwing among themselves. {68} Then, swinging it back, he
+threw it from his brawny hand, and it made a humming sound in the air as
+he did so. The Phaeacians quailed beneath the rushing of its flight as
+it sped gracefully from his hand, and flew beyond any mark that had been
+made yet. Minerva, in the form of a man, came and marked the place where
+it had fallen. "A blind man, Sir," said she, "could easily tell your
+mark by groping for it--it is so far ahead of any other. You may make
+your mind easy about this contest, for no Phaeacian can come near to
+such a throw as yours."
+
+Ulysses was glad when he found he had a friend among the lookers-on,
+so he began to speak more pleasantly. "Young men," said he, "come up to
+that throw if you can, and I will throw another disc as heavy or even
+heavier. If anyone wants to have a bout with me let him come on, for I
+am exceedingly angry; I will box, wrestle, or run, I do not care what it
+is, with any man of you all except Laodamas, but not with him because I
+am his guest, and one cannot compete with one's own personal friend.
+At least I do not think it a prudent or a sensible thing for a guest
+to challenge his host's family at any game, especially when he is in a
+foreign country. He will cut the ground from under his own feet if he
+does; but I make no exception as regards any one else, for I want to
+have the matter out and know which is the best man. I am a good hand
+at every kind of athletic sport known among mankind. I am an excellent
+archer. In battle I am always the first to bring a man down with my
+arrow, no matter how many more are taking aim at him alongside of me.
+Philoctetes was the only man who could shoot better than I could when we
+Achaeans were before Troy and in practice. I far excel every one else
+in the whole world, of those who still eat bread upon the face of the
+earth, but I should not like to shoot against the mighty dead, such as
+Hercules, or Eurytus the Oechalian--men who could shoot against the gods
+themselves. This in fact was how Eurytus came prematurely by his end,
+for Apollo was angry with him and killed him because he challenged him
+as an archer. I can throw a dart farther than any one else can shoot an
+arrow. Running is the only point in respect of which I am afraid some of
+the Phaeacians might beat me, for I have been brought down very low at
+sea; my provisions ran short, and therefore I am still weak."
+
+They all held their peace except King Alcinous, who began, "Sir, we have
+had much pleasure in hearing all that you have told us, from which I
+understand that you are willing to show your prowess, as having been
+displeased with some insolent remarks that have been made to you by one
+of our athletes, and which could never have been uttered by any one who
+knows how to talk with propriety. I hope you will apprehend my meaning,
+and will explain to any one of your chief men who may be dining with
+yourself and your family when you get home, that we have an hereditary
+aptitude for accomplishments of all kinds. We are not particularly
+remarkable for our boxing, nor yet as wrestlers, but we are singularly
+fleet of foot and are excellent sailors. We are extremely fond of good
+dinners, music, and dancing; we also like frequent changes of linen,
+warm baths, and good beds, so now, please, some of you who are the best
+dancers set about dancing, that our guest on his return home may be able
+to tell his friends how much we surpass all other nations as sailors,
+runners, dancers, and minstrels. Demodocus has left his lyre at my
+house, so run some one or other of you and fetch it for him."
+
+On this a servant hurried off to bring the lyre from the king's house,
+and the nine men who had been chosen as stewards stood forward. It was
+their business to manage everything connected with the sports, so
+they made the ground smooth and marked a wide space for the dancers.
+Presently the servant came back with Demodocus's lyre, and he took his
+place in the midst of them, whereon the best young dancers in the town
+began to foot and trip it so nimbly that Ulysses was delighted with the
+merry twinkling of their feet.
+
+Meanwhile the bard began to sing the loves of Mars and Venus, and how
+they first began their intrigue in the house of Vulcan. Mars made Venus
+many presents, and defiled King Vulcan's marriage bed, so the sun, who
+saw what they were about, told Vulcan. Vulcan was very angry when he
+heard such dreadful news, so he went to his smithy brooding mischief,
+got his great anvil into its place, and began to forge some chains which
+none could either unloose or break, so that they might stay there in
+that place. {69} When he had finished his snare he went into his bedroom
+and festooned the bed-posts all over with chains like cobwebs; he also
+let many hang down from the great beam of the ceiling. Not even a god
+could see them so fine and subtle were they. As soon as he had spread
+the chains all over the bed, he made as though he were setting out for
+the fair state of Lemnos, which of all places in the world was the one
+he was most fond of. But Mars kept no blind look out, and as soon as he
+saw him start, hurried off to his house, burning with love for Venus.
+
+Now Venus was just come in from a visit to her father Jove, and was
+about sitting down when Mars came inside the house, and said as he took
+her hand in his own, "Let us go to the couch of Vulcan: he is not at
+home, but is gone off to Lemnos among the Sintians, whose speech is
+barbarous."
+
+She was nothing loth, so they went to the couch to take their rest,
+whereon they were caught in the toils which cunning Vulcan had spread
+for them, and could neither get up nor stir hand or foot, but found too
+late that they were in a trap. Then Vulcan came up to them, for he had
+turned back before reaching Lemnos, when his scout the sun told him what
+was going on. He was in a furious passion, and stood in the vestibule
+making a dreadful noise as he shouted to all the gods.
+
+"Father Jove," he cried, "and all you other blessed gods who live for
+ever, come here and see the ridiculous and disgraceful sight that I will
+show you. Jove's daughter Venus is always dishonouring me because I am
+lame. She is in love with Mars, who is handsome and clean built, whereas
+I am a cripple--but my parents are to blame for that, not I; they ought
+never to have begotten me. Come and see the pair together asleep on
+my bed. It makes me furious to look at them. They are very fond of one
+another, but I do not think they will lie there longer than they can
+help, nor do I think that they will sleep much; there, however, they
+shall stay till her father has repaid me the sum I gave him for his
+baggage of a daughter, who is fair but not honest."
+
+On this the gods gathered to the house of Vulcan. Earth-encircling
+Neptune came, and Mercury the bringer of luck, and King Apollo, but the
+goddesses staid at home all of them for shame. Then the givers of all
+good things stood in the doorway, and the blessed gods roared with
+inextinguishable laughter, as they saw how cunning Vulcan had been,
+whereon one would turn towards his neighbour saying:
+
+"Ill deeds do not prosper, and the weak confound the strong. See how
+limping Vulcan, lame as he is, has caught Mars who is the fleetest god
+in heaven; and now Mars will be cast in heavy damages."
+
+Thus did they converse, but King Apollo said to Mercury, "Messenger
+Mercury, giver of good things, you would not care how strong the chains
+were, would you, if you could sleep with Venus?"
+
+"King Apollo," answered Mercury, "I only wish I might get the chance,
+though there were three times as many chains--and you might look on, all
+of you, gods and goddesses, but I would sleep with her if I could."
+
+The immortal gods burst out laughing as they heard him, but Neptune took
+it all seriously, and kept on imploring Vulcan to set Mars free again.
+"Let him go," he cried, "and I will undertake, as you require, that
+he shall pay you all the damages that are held reasonable among the
+immortal gods."
+
+"Do not," replied Vulcan, "ask me to do this; a bad man's bond is bad
+security; what remedy could I enforce against you if Mars should go away
+and leave his debts behind him along with his chains?"
+
+"Vulcan," said Neptune, "if Mars goes away without paying his damages,
+I will pay you myself." So Vulcan answered, "In this case I cannot and
+must not refuse you."
+
+Thereon he loosed the bonds that bound them, and as soon as they were
+free they scampered off, Mars to Thrace and laughter-loving Venus to
+Cyprus and to Paphos, where is her grove and her altar fragrant with
+burnt offerings. Here the Graces bathed her, and anointed her with oil
+of ambrosia such as the immortal gods make use of, and they clothed her
+in raiment of the most enchanting beauty.
+
+Thus sang the bard, and both Ulysses and the seafaring Phaeacians were
+charmed as they heard him.
+
+Then Alcinous told Laodamas and Halius to dance alone, for there was no
+one to compete with them. So they took a red ball which Polybus had made
+for them, and one of them bent himself backwards and threw it up towards
+the clouds, while the other jumped from off the ground and caught it
+with ease before it came down again. When they had done throwing the
+ball straight up into the air they began to dance, and at the same time
+kept on throwing it backwards and forwards to one another, while all
+the young men in the ring applauded and made a great stamping with their
+feet. Then Ulysses said:
+
+"King Alcinous, you said your people were the nimblest dancers in the
+world, and indeed they have proved themselves to be so. I was astonished
+as I saw them."
+
+The king was delighted at this, and exclaimed to the Phaeacians,
+"Aldermen and town councillors, our guest seems to be a person of
+singular judgement; let us give him such proof of our hospitality as
+he may reasonably expect. There are twelve chief men among you, and
+counting myself there are thirteen; contribute, each of you, a clean
+cloak, a shirt, and a talent of fine gold; let us give him all this in
+a lump down at once, so that when he gets his supper he may do so with a
+light heart. As for Euryalus he will have to make a formal apology and a
+present too, for he has been rude."
+
+Thus did he speak. The others all of them applauded his saying, and
+sent their servants to fetch the presents. Then Euryalus said, "King
+Alcinous, I will give the stranger all the satisfaction you require. He
+shall have my sword, which is of bronze, all but the hilt, which is of
+silver. I will also give him the scabbard of newly sawn ivory into which
+it fits. It will be worth a great deal to him."
+
+As he spoke he placed the sword in the hands of Ulysses and said, "Good
+luck to you, father stranger; if anything has been said amiss may the
+winds blow it away with them, and may heaven grant you a safe return,
+for I understand you have been long away from home, and have gone
+through much hardship."
+
+To which Ulysses answered, "Good luck to you too my friend, and may the
+gods grant you every happiness. I hope you will not miss the sword you
+have given me along with your apology."
+
+With these words he girded the sword about his shoulders and towards
+sundown the presents began to make their appearance, as the servants of
+the donors kept bringing them to the house of King Alcinous; here his
+sons received them, and placed them under their mother's charge. Then
+Alcinous led the way to the house and bade his guests take their seats.
+
+"Wife," said he, turning to Queen Arete, "Go, fetch the best chest we
+have, and put a clean cloak and shirt in it. Also, set a copper on the
+fire and heat some water; our guest will take a warm bath; see also to
+the careful packing of the presents that the noble Phaeacians have made
+him; he will thus better enjoy both his supper and the singing that
+will follow. I shall myself give him this golden goblet--which is of
+exquisite workmanship--that he may be reminded of me for the rest of his
+life whenever he makes a drink offering to Jove, or to any of the gods."
+{70}
+
+Then Arete told her maids to set a large tripod upon the fire as fast as
+they could, whereon they set a tripod full of bath water on to a clear
+fire; they threw on sticks to make it blaze, and the water became hot
+as the flame played about the belly of the tripod. {71} Meanwhile Arete
+brought a magnificent chest from her own room, and inside it she packed
+all the beautiful presents of gold and raiment which the Phaeacians had
+brought. Lastly she added a cloak and a good shirt from Alcinous, and
+said to Ulysses:
+
+"See to the lid yourself, and have the whole bound round at once, for
+fear any one should rob you by the way when you are asleep in your
+ship." {72}
+
+When Ulysses heard this he put the lid on the chest and made it fast
+with a bond that Circe had taught him. He had done so before an upper
+servant told him to come to the bath and wash himself. He was very glad
+of a warm bath, for he had had no one to wait upon him ever since he
+left the house of Calypso, who as long as he remained with her had taken
+as good care of him as though he had been a god. When the servants had
+done washing and anointing him with oil, and had given him a clean cloak
+and shirt, he left the bath room and joined the guests who were sitting
+over their wine. Lovely Nausicaa stood by one of the bearing-posts
+supporting the roof of the cloister, and admired him as she saw him
+pass. "Farewell stranger," said she, "do not forget me when you are safe
+at home again, for it is to me first that you owe a ransom for having
+saved your life."
+
+And Ulysses said, "Nausicaa, daughter of great Alcinous, may Jove the
+mighty husband of Juno, grant that I may reach my home; so shall I bless
+you as my guardian angel all my days, for it was you who saved me."
+
+When he had said this, he seated himself beside Alcinous. Supper was
+then served, and the wine was mixed for drinking. A servant led in the
+favourite bard Demodocus, and set him in the midst of the company, near
+one of the bearing-posts supporting the cloister, that he might lean
+against it. Then Ulysses cut off a piece of roast pork with plenty of
+fat (for there was abundance left on the joint) and said to a servant,
+"Take this piece of pork over to Demodocus and tell him to eat it; for
+all the pain his lays may cause me I will salute him none the less;
+bards are honoured and respected throughout the world, for the muse
+teaches them their songs and loves them."
+
+The servant carried the pork in his fingers over to Demodocus, who took
+it and was very much pleased. They then laid their hands on the good
+things that were before them, and as soon as they had had to eat and
+drink, Ulysses said to Demodocus, "Demodocus, there is no one in the
+world whom I admire more than I do you. You must have studied under the
+Muse, Jove's daughter, and under Apollo, so accurately do you sing the
+return of the Achaeans with all their sufferings and adventures. If you
+were not there yourself, you must have heard it all from some one who
+was. Now, however, change your song and tell us of the wooden horse
+which Epeus made with the assistance of Minerva, and which Ulysses got
+by stratagem into the fort of Troy after freighting it with the men who
+afterwards sacked the city. If you will sing this tale aright I will
+tell all the world how magnificently heaven has endowed you."
+
+The bard inspired of heaven took up the story at the point where some of
+the Argives set fire to their tents and sailed away while others, hidden
+within the horse, {73} were waiting with Ulysses in the Trojan place
+of assembly. For the Trojans themselves had drawn the horse into their
+fortress, and it stood there while they sat in council round it, and
+were in three minds as to what they should do. Some were for breaking it
+up then and there; others would have it dragged to the top of the rock
+on which the fortress stood, and then thrown down the precipice; while
+yet others were for letting it remain as an offering and propitiation
+for the gods. And this was how they settled it in the end, for the city
+was doomed when it took in that horse, within which were all the bravest
+of the Argives waiting to bring death and destruction on the Trojans.
+Anon he sang how the sons of the Achaeans issued from the horse, and
+sacked the town, breaking out from their ambuscade. He sang how they
+overran the city hither and thither and ravaged it, and how Ulysses went
+raging like Mars along with Menelaus to the house of Deiphobus. It was
+there that the fight raged most furiously, nevertheless by Minerva's
+help he was victorious.
+
+All this he told, but Ulysses was overcome as he heard him, and his
+cheeks were wet with tears. He wept as a woman weeps when she throws
+herself on the body of her husband who has fallen before his own city
+and people, fighting bravely in defence of his home and children. She
+screams aloud and flings her arms about him as he lies gasping for
+breath and dying, but her enemies beat her from behind about the back
+and shoulders, and carry her off into slavery, to a life of labour and
+sorrow, and the beauty fades from her cheeks--even so piteously did
+Ulysses weep, but none of those present perceived his tears except
+Alcinous, who was sitting near him, and could hear the sobs and sighs
+that he was heaving. The king, therefore, at once rose and said:
+
+"Aldermen and town councillors of the Phaeacians, let Demodocus cease
+his song, for there are those present who do not seem to like it. From
+the moment that we had done supper and Demodocus began to sing, our
+guest has been all the time groaning and lamenting. He is evidently
+in great trouble, so let the bard leave off, that we may all enjoy
+ourselves, hosts and guest alike. This will be much more as it should
+be, for all these festivities, with the escort and the presents that we
+are making with so much good will are wholly in his honour, and any
+one with even a moderate amount of right feeling knows that he ought to
+treat a guest and a suppliant as though he were his own brother.
+
+"Therefore, Sir, do you on your part affect no more concealment nor
+reserve in the matter about which I shall ask you; it will be more
+polite in you to give me a plain answer; tell me the name by which your
+father and mother over yonder used to call you, and by which you were
+known among your neighbours and fellow-citizens. There is no one,
+neither rich nor poor, who is absolutely without any name whatever, for
+people's fathers and mothers give them names as soon as they are born.
+Tell me also your country, nation, and city, that our ships may shape
+their purpose accordingly and take you there. For the Phaeacians have
+no pilots; their vessels have no rudders as those of other nations have,
+but the ships themselves understand what it is that we are thinking
+about and want; they know all the cities and countries in the whole
+world, and can traverse the sea just as well even when it is covered
+with mist and cloud, so that there is no danger of being wrecked or
+coming to any harm. Still I do remember hearing my father say that
+Neptune was angry with us for being too easy-going in the matter of
+giving people escorts. He said that one of these days he should wreck a
+ship of ours as it was returning from having escorted some one, {74} and
+bury our city under a high mountain. This is what my father used to say,
+but whether the god will carry out his threat or no is a matter which he
+will decide for himself.
+
+"And now, tell me and tell me true. Where have you been wandering, and
+in what countries have you travelled? Tell us of the peoples themselves,
+and of their cities--who were hostile, savage and uncivilised, and who,
+on the other hand, hospitable and humane. Tell us also why you are made
+so unhappy on hearing about the return of the Argive Danaans from Troy.
+The gods arranged all this, and sent them their misfortunes in order
+that future generations might have something to sing about. Did you
+lose some brave kinsman of your wife's when you were before Troy? a
+son-in-law or father-in-law--which are the nearest relations a man has
+outside his own flesh and blood? or was it some brave and kindly-natured
+comrade--for a good friend is as dear to a man as his own brother?"
+
+
+Book IX
+
+ULYSSES DECLARES HIMSELF AND BEGINS HIS STORY---THE CICONS, LOTOPHAGI,
+AND CYCLOPES.
+
+
+And Ulysses answered, "King Alcinous, it is a good thing to hear a bard
+with such a divine voice as this man has. There is nothing better or
+more delightful than when a whole people make merry together, with the
+guests sitting orderly to listen, while the table is loaded with bread
+and meats, and the cup-bearer draws wine and fills his cup for every
+man. This is indeed as fair a sight as a man can see. Now, however,
+since you are inclined to ask the story of my sorrows, and rekindle my
+own sad memories in respect of them, I do not know how to begin, nor yet
+how to continue and conclude my tale, for the hand of heaven has been
+laid heavily upon me.
+
+"Firstly, then, I will tell you my name that you too may know it, and
+one day, if I outlive this time of sorrow, may become my guests though I
+live so far away from all of you. I am Ulysses son of Laertes, renowned
+among mankind for all manner of subtlety, so that my fame ascends to
+heaven. I live in Ithaca, where there is a high mountain called Neritum,
+covered with forests; and not far from it there is a group of islands
+very near to one another--Dulichium, Same, and the wooded island of
+Zacynthus. It lies squat on the horizon, all highest up in the sea
+towards the sunset, while the others lie away from it towards dawn. {75}
+It is a rugged island, but it breeds brave men, and my eyes know none
+that they better love to look upon. The goddess Calypso kept me with her
+in her cave, and wanted me to marry her, as did also the cunning Aeaean
+goddess Circe; but they could neither of them persuade me, for there
+is nothing dearer to a man than his own country and his parents, and
+however splendid a home he may have in a foreign country, if it be far
+from father or mother, he does not care about it. Now, however, I will
+tell you of the many hazardous adventures which by Jove's will I met
+with on my return from Troy.
+
+"When I had set sail thence the wind took me first to Ismarus, which is
+the city of the Cicons. There I sacked the town and put the people to
+the sword. We took their wives and also much booty, which we divided
+equitably amongst us, so that none might have reason to complain. I
+then said that we had better make off at once, but my men very foolishly
+would not obey me, so they staid there drinking much wine and killing
+great numbers of sheep and oxen on the sea shore. Meanwhile the Cicons
+cried out for help to other Cicons who lived inland. These were more in
+number, and stronger, and they were more skilled in the art of war,
+for they could fight, either from chariots or on foot as the occasion
+served; in the morning, therefore, they came as thick as leaves and
+bloom in summer, and the hand of heaven was against us, so that we were
+hard pressed. They set the battle in array near the ships, and the hosts
+aimed their bronze-shod spears at one another. {76} So long as the day
+waxed and it was still morning, we held our own against them, though
+they were more in number than we; but as the sun went down, towards the
+time when men loose their oxen, the Cicons got the better of us, and we
+lost half a dozen men from every ship we had; so we got away with those
+that were left.
+
+"Thence we sailed onward with sorrow in our hearts, but glad to have
+escaped death though we had lost our comrades, nor did we leave till we
+had thrice invoked each one of the poor fellows who had perished by the
+hands of the Cicons. Then Jove raised the North wind against us till it
+blew a hurricane, so that land and sky were hidden in thick clouds, and
+night sprang forth out of the heavens. We let the ships run before the
+gale, but the force of the wind tore our sails to tatters, so we took
+them down for fear of shipwreck, and rowed our hardest towards the land.
+There we lay two days and two nights suffering much alike from toil and
+distress of mind, but on the morning of the third day we again raised
+our masts, set sail, and took our places, letting the wind and steersmen
+direct our ship. I should have got home at that time unharmed had not
+the North wind and the currents been against me as I was doubling Cape
+Malea, and set me off my course hard by the island of Cythera.
+
+"I was driven thence by foul winds for a space of nine days upon the
+sea, but on the tenth day we reached the land of the Lotus-eaters, who
+live on a food that comes from a kind of flower. Here we landed to take
+in fresh water, and our crews got their mid-day meal on the shore near
+the ships. When they had eaten and drunk I sent two of my company to
+see what manner of men the people of the place might be, and they had
+a third man under them. They started at once, and went about among the
+Lotus-eaters, who did them no hurt, but gave them to eat of the lotus,
+which was so delicious that those who ate of it left off caring about
+home, and did not even want to go back and say what had happened to
+them, but were for staying and munching lotus {77} with the Lotus-eaters
+without thinking further of their return; nevertheless, though they wept
+bitterly I forced them back to the ships and made them fast under the
+benches. Then I told the rest to go on board at once, lest any of them
+should taste of the lotus and leave off wanting to get home, so they
+took their places and smote the grey sea with their oars.
+
+"We sailed hence, always in much distress, till we came to the land of
+the lawless and inhuman Cyclopes. Now the Cyclopes neither plant nor
+plough, but trust in providence, and live on such wheat, barley, and
+grapes as grow wild without any kind of tillage, and their wild grapes
+yield them wine as the sun and the rain may grow them. They have no
+laws nor assemblies of the people, but live in caves on the tops of
+high mountains; each is lord and master in his family, and they take no
+account of their neighbours.
+
+"Now off their harbour there lies a wooded and fertile island not quite
+close to the land of the Cyclopes, but still not far. It is over-run
+with wild goats, that breed there in great numbers and are never
+disturbed by foot of man; for sportsmen--who as a rule will suffer so
+much hardship in forest or among mountain precipices--do not go there,
+nor yet again is it ever ploughed or fed down, but it lies a wilderness
+untilled and unsown from year to year, and has no living thing upon it
+but only goats. For the Cyclopes have no ships, nor yet shipwrights who
+could make ships for them; they cannot therefore go from city to city,
+or sail over the sea to one another's country as people who have ships
+can do; if they had had these they would have colonised the island, {78}
+for it is a very good one, and would yield everything in due season.
+There are meadows that in some places come right down to the sea
+shore, well watered and full of luscious grass; grapes would do there
+excellently; there is level land for ploughing, and it would always
+yield heavily at harvest time, for the soil is deep. There is a good
+harbour where no cables are wanted, nor yet anchors, nor need a ship be
+moored, but all one has to do is to beach one's vessel and stay there
+till the wind becomes fair for putting out to sea again. At the head of
+the harbour there is a spring of clear water coming out of a cave, and
+there are poplars growing all round it.
+
+"Here we entered, but so dark was the night that some god must have
+brought us in, for there was nothing whatever to be seen. A thick mist
+hung all round our ships; {79} the moon was hidden behind a mass of
+clouds so that no one could have seen the island if he had looked for
+it, nor were there any breakers to tell us we were close in shore before
+we found ourselves upon the land itself; when, however, we had beached
+the ships, we took down the sails, went ashore and camped upon the beach
+till daybreak.
+
+"When the child of morning, rosy-fingered Dawn appeared, we admired
+the island and wandered all over it, while the nymphs Jove's daughters
+roused the wild goats that we might get some meat for our dinner. On
+this we fetched our spears and bows and arrows from the ships, and
+dividing ourselves into three bands began to shoot the goats. Heaven
+sent us excellent sport; I had twelve ships with me, and each ship got
+nine goats, while my own ship had ten; thus through the livelong day to
+the going down of the sun we ate and drank our fill, and we had plenty
+of wine left, for each one of us had taken many jars full when we sacked
+the city of the Cicons, and this had not yet run out. While we were
+feasting we kept turning our eyes towards the land of the Cyclopes,
+which was hard by, and saw the smoke of their stubble fires. We could
+almost fancy we heard their voices and the bleating of their sheep and
+goats, but when the sun went down and it came on dark, we camped down
+upon the beach, and next morning I called a council.
+
+"'Stay here, my brave fellows,' said I, 'all the rest of you, while I go
+with my ship and exploit these people myself: I want to see if they are
+uncivilised savages, or a hospitable and humane race.'
+
+"I went on board, bidding my men to do so also and loose the hawsers; so
+they took their places and smote the grey sea with their oars. When we
+got to the land, which was not far, there, on the face of a cliff near
+the sea, we saw a great cave overhung with laurels. It was a station for
+a great many sheep and goats, and outside there was a large yard, with
+a high wall round it made of stones built into the ground and of trees
+both pine and oak. This was the abode of a huge monster who was then
+away from home shepherding his flocks. He would have nothing to do with
+other people, but led the life of an outlaw. He was a horrid creature,
+not like a human being at all, but resembling rather some crag that
+stands out boldly against the sky on the top of a high mountain.
+
+"I told my men to draw the ship ashore, and stay where they were, all
+but the twelve best among them, who were to go along with myself. I also
+took a goatskin of sweet black wine which had been given me by Maron,
+son of Euanthes, who was priest of Apollo the patron god of Ismarus, and
+lived within the wooded precincts of the temple. When we were sacking
+the city we respected him, and spared his life, as also his wife and
+child; so he made me some presents of great value--seven talents of fine
+gold, and a bowl of silver, with twelve jars of sweet wine, unblended,
+and of the most exquisite flavour. Not a man nor maid in the house knew
+about it, but only himself, his wife, and one housekeeper: when he drank
+it he mixed twenty parts of water to one of wine, and yet the fragrance
+from the mixing-bowl was so exquisite that it was impossible to refrain
+from drinking. I filled a large skin with this wine, and took a wallet
+full of provisions with me, for my mind misgave me that I might have to
+deal with some savage who would be of great strength, and would respect
+neither right nor law.
+
+"We soon reached his cave, but he was out shepherding, so we went inside
+and took stock of all that we could see. His cheese-racks were loaded
+with cheeses, and he had more lambs and kids than his pens could hold.
+They were kept in separate flocks; first there were the hoggets, then
+the oldest of the younger lambs and lastly the very young ones {80} all
+kept apart from one another; as for his dairy, all the vessels, bowls,
+and milk pails into which he milked, were swimming with whey. When they
+saw all this, my men begged me to let them first steal some cheeses, and
+make off with them to the ship; they would then return, drive down the
+lambs and kids, put them on board and sail away with them. It would have
+been indeed better if we had done so but I would not listen to them, for
+I wanted to see the owner himself, in the hope that he might give me
+a present. When, however, we saw him my poor men found him ill to deal
+with.
+
+"We lit a fire, offered some of the cheeses in sacrifice, ate others
+of them, and then sat waiting till the Cyclops should come in with his
+sheep. When he came, he brought in with him a huge load of dry firewood
+to light the fire for his supper, and this he flung with such a noise on
+to the floor of his cave that we hid ourselves for fear at the far end
+of the cavern. Meanwhile he drove all the ewes inside, as well as the
+she-goats that he was going to milk, leaving the males, both rams and
+he-goats, outside in the yards. Then he rolled a huge stone to the mouth
+of the cave--so huge that two and twenty strong four-wheeled waggons
+would not be enough to draw it from its place against the doorway. When
+he had so done he sat down and milked his ewes and goats, all in due
+course, and then let each of them have her own young. He curdled half
+the milk and set it aside in wicker strainers, but the other half he
+poured into bowls that he might drink it for his supper. When he had got
+through with all his work, he lit the fire, and then caught sight of us,
+whereon he said:
+
+"'Strangers, who are you? Where do sail from? Are you traders, or do
+you sail the sea as rovers, with your hands against every man, and every
+man's hand against you?'
+
+"We were frightened out of our senses by his loud voice and monstrous
+form, but I managed to say, 'We are Achaeans on our way home from Troy,
+but by the will of Jove, and stress of weather, we have been driven far
+out of our course. We are the people of Agamemnon, son of Atreus, who
+has won infinite renown throughout the whole world, by sacking so great
+a city and killing so many people. We therefore humbly pray you to show
+us some hospitality, and otherwise make us such presents as visitors may
+reasonably expect. May your excellency fear the wrath of heaven, for we
+are your suppliants, and Jove takes all respectable travellers under his
+protection, for he is the avenger of all suppliants and foreigners in
+distress.'
+
+"To this he gave me but a pitiless answer, 'Stranger,' said he, 'you are
+a fool, or else you know nothing of this country. Talk to me, indeed,
+about fearing the gods or shunning their anger? We Cyclopes do not care
+about Jove or any of your blessed gods, for we are ever so much stronger
+than they. I shall not spare either yourself or your companions out of
+any regard for Jove, unless I am in the humour for doing so. And now
+tell me where you made your ship fast when you came on shore. Was it
+round the point, or is she lying straight off the land?'
+
+"He said this to draw me out, but I was too cunning to be caught in that
+way, so I answered with a lie; 'Neptune,' said I, 'sent my ship on to
+the rocks at the far end of your country, and wrecked it. We were driven
+on to them from the open sea, but I and those who are with me escaped
+the jaws of death.'
+
+"The cruel wretch vouchsafed me not one word of answer, but with a
+sudden clutch he gripped up two of my men at once and dashed them down
+upon the ground as though they had been puppies. Their brains were shed
+upon the ground, and the earth was wet with their blood. Then he tore
+them limb from limb and supped upon them. He gobbled them up like a lion
+in the wilderness, flesh, bones, marrow, and entrails, without leaving
+anything uneaten. As for us, we wept and lifted up our hands to heaven
+on seeing such a horrid sight, for we did not know what else to do; but
+when the Cyclops had filled his huge paunch, and had washed down his
+meal of human flesh with a drink of neat milk, he stretched himself
+full length upon the ground among his sheep, and went to sleep. I was at
+first inclined to seize my sword, draw it, and drive it into his vitals,
+but I reflected that if I did we should all certainly be lost, for we
+should never be able to shift the stone which the monster had put in
+front of the door. So we stayed sobbing and sighing where we were till
+morning came.
+
+"When the child of morning, rosy-fingered dawn, appeared, he again lit
+his fire, milked his goats and ewes, all quite rightly, and then let
+each have her own young one; as soon as he had got through with all his
+work, he clutched up two more of my men, and began eating them for his
+morning's meal. Presently, with the utmost ease, he rolled the stone
+away from the door and drove out his sheep, but he at once put it back
+again--as easily as though he were merely clapping the lid on to a
+quiver full of arrows. As soon as he had done so he shouted, and cried
+'Shoo, shoo,' after his sheep to drive them on to the mountain; so I was
+left to scheme some way of taking my revenge and covering myself with
+glory.
+
+"In the end I deemed it would be the best plan to do as follows: The
+Cyclops had a great club which was lying near one of the sheep pens;
+it was of green olive wood, and he had cut it intending to use it for
+a staff as soon as it should be dry. It was so huge that we could
+only compare it to the mast of a twenty-oared merchant vessel of large
+burden, and able to venture out into open sea. I went up to this club
+and cut off about six feet of it; I then gave this piece to the men and
+told them to fine it evenly off at one end, which they proceeded to do,
+and lastly I brought it to a point myself, charring the end in the fire
+to make it harder. When I had done this I hid it under dung, which was
+lying about all over the cave, and told the men to cast lots which of
+them should venture along with myself to lift it and bore it into the
+monster's eye while he was asleep. The lot fell upon the very four whom
+I should have chosen, and I myself made five. In the evening the wretch
+came back from shepherding, and drove his flocks into the cave--this
+time driving them all inside, and not leaving any in the yards; I
+suppose some fancy must have taken him, or a god must have prompted him
+to do so. As soon as he had put the stone back to its place against the
+door, he sat down, milked his ewes and his goats all quite rightly, and
+then let each have her own young one; when he had got through with all
+this work, he gripped up two more of my men, and made his supper off
+them. So I went up to him with an ivy-wood bowl of black wine in my
+hands:
+
+"'Look here, Cyclops,' said I, you have been eating a great deal of
+man's flesh, so take this and drink some wine, that you may see what
+kind of liquor we had on board my ship. I was bringing it to you as a
+drink-offering, in the hope that you would take compassion upon me and
+further me on my way home, whereas all you do is to go on ramping and
+raving most intolerably. You ought to be ashamed of yourself; how can
+you expect people to come see you any more if you treat them in this
+way?'
+
+"He then took the cup and drank. He was so delighted with the taste of
+the wine that he begged me for another bowl full. 'Be so kind,' he said,
+'as to give me some more, and tell me your name at once. I want to make
+you a present that you will be glad to have. We have wine even in this
+country, for our soil grows grapes and the sun ripens them, but this
+drinks like Nectar and Ambrosia all in one.'
+
+"I then gave him some more; three times did I fill the bowl for him, and
+three times did he drain it without thought or heed; then, when I saw
+that the wine had got into his head, I said to him as plausibly as
+I could: 'Cyclops, you ask my name and I will tell it you; give me,
+therefore, the present you promised me; my name is Noman; this is what
+my father and mother and my friends have always called me.'
+
+"But the cruel wretch said, 'Then I will eat all Noman's comrades before
+Noman himself, and will keep Noman for the last. This is the present
+that I will make him.'
+
+"As he spoke he reeled, and fell sprawling face upwards on the ground.
+His great neck hung heavily backwards and a deep sleep took hold upon
+him. Presently he turned sick, and threw up both wine and the gobbets of
+human flesh on which he had been gorging, for he was very drunk. Then I
+thrust the beam of wood far into the embers to heat it, and encouraged
+my men lest any of them should turn faint-hearted. When the wood, green
+though it was, was about to blaze, I drew it out of the fire glowing
+with heat, and my men gathered round me, for heaven had filled their
+hearts with courage. We drove the sharp end of the beam into the
+monster's eye, and bearing upon it with all my weight I kept turning it
+round and round as though I were boring a hole in a ship's plank with an
+auger, which two men with a wheel and strap can keep on turning as long
+as they choose. Even thus did we bore the red hot beam into his eye,
+till the boiling blood bubbled all over it as we worked it round and
+round, so that the steam from the burning eyeball scalded his eyelids
+and eyebrows, and the roots of the eye sputtered in the fire. As a
+blacksmith plunges an axe or hatchet into cold water to temper it--for
+it is this that gives strength to the iron--and it makes a great hiss as
+he does so, even thus did the Cyclops' eye hiss round the beam of olive
+wood, and his hideous yells made the cave ring again. We ran away in a
+fright, but he plucked the beam all besmirched with gore from his eye,
+and hurled it from him in a frenzy of rage and pain, shouting as he did
+so to the other Cyclopes who lived on the bleak headlands near him;
+so they gathered from all quarters round his cave when they heard him
+crying, and asked what was the matter with him.
+
+"'What ails you, Polyphemus,' said they, 'that you make such a noise,
+breaking the stillness of the night, and preventing us from being able
+to sleep? Surely no man is carrying off your sheep? Surely no man is
+trying to kill you either by fraud or by force?'
+
+"But Polyphemus shouted to them from inside the cave, 'Noman is killing
+me by fraud; no man is killing me by force.'
+
+"'Then,' said they, 'if no man is attacking you, you must be ill; when
+Jove makes people ill, there is no help for it, and you had better pray
+to your father Neptune.'
+
+"Then they went away, and I laughed inwardly at the success of my clever
+stratagem, but the Cyclops, groaning and in an agony of pain, felt about
+with his hands till he found the stone and took it from the door; then
+he sat in the doorway and stretched his hands in front of it to catch
+anyone going out with the sheep, for he thought I might be foolish
+enough to attempt this.
+
+"As for myself I kept on puzzling to think how I could best save my own
+life and those of my companions; I schemed and schemed, as one who knows
+that his life depends upon it, for the danger was very great. In the
+end I deemed that this plan would be the best; the male sheep were well
+grown, and carried a heavy black fleece, so I bound them noiselessly in
+threes together, with some of the withies on which the wicked monster
+used to sleep. There was to be a man under the middle sheep, and the two
+on either side were to cover him, so that there were three sheep to each
+man. As for myself there was a ram finer than any of the others, so I
+caught hold of him by the back, esconced myself in the thick wool under
+his belly, and hung on patiently to his fleece, face upwards, keeping a
+firm hold on it all the time.
+
+"Thus, then, did we wait in great fear of mind till morning came, but
+when the child of morning, rosy-fingered Dawn, appeared, the male sheep
+hurried out to feed, while the ewes remained bleating about the pens
+waiting to be milked, for their udders were full to bursting; but their
+master in spite of all his pain felt the backs of all the sheep as they
+stood upright, without being sharp enough to find out that the men were
+underneath their bellies. As the ram was going out, last of all, heavy
+with its fleece and with the weight of my crafty self, Polyphemus laid
+hold of it and said:
+
+"'My good ram, what is it that makes you the last to leave my cave this
+morning? You are not wont to let the ewes go before you, but lead the
+mob with a run whether to flowery mead or bubbling fountain, and are the
+first to come home again at night; but now you lag last of all. Is it
+because you know your master has lost his eye, and are sorry because
+that wicked Noman and his horrid crew has got him down in his drink and
+blinded him? But I will have his life yet. If you could understand and
+talk, you would tell me where the wretch is hiding, and I would dash his
+brains upon the ground till they flew all over the cave. I should thus
+have some satisfaction for the harm this no-good Noman has done me.'
+
+"As he spoke he drove the ram outside, but when we were a little way
+out from the cave and yards, I first got from under the ram's belly,
+and then freed my comrades; as for the sheep, which were very fat, by
+constantly heading them in the right direction we managed to drive them
+down to the ship. The crew rejoiced greatly at seeing those of us who
+had escaped death, but wept for the others whom the Cyclops had killed.
+However, I made signs to them by nodding and frowning that they were to
+hush their crying, and told them to get all the sheep on board at once
+and put out to sea; so they went aboard, took their places, and smote
+the grey sea with their oars. Then, when I had got as far out as my
+voice would reach, I began to jeer at the Cyclops.
+
+"'Cyclops,' said I, 'you should have taken better measure of your man
+before eating up his comrades in your cave. You wretch, eat up your
+visitors in your own house? You might have known that your sin would
+find you out, and now Jove and the other gods have punished you.'
+
+"He got more and more furious as he heard me, so he tore the top from
+off a high mountain, and flung it just in front of my ship so that
+it was within a little of hitting the end of the rudder. {81} The sea
+quaked as the rock fell into it, and the wash of the wave it raised
+carried us back towards the mainland, and forced us towards the shore.
+But I snatched up a long pole and kept the ship off, making signs to my
+men by nodding my head, that they must row for their lives, whereon they
+laid out with a will. When we had got twice as far as we were before, I
+was for jeering at the Cyclops again, but the men begged and prayed of
+me to hold my tongue.
+
+"'Do not,' they exclaimed, 'be mad enough to provoke this savage
+creature further; he has thrown one rock at us already which drove us
+back again to the mainland, and we made sure it had been the death
+of us; if he had then heard any further sound of voices he would have
+pounded our heads and our ship's timbers into a jelly with the rugged
+rocks he would have heaved at us, for he can throw them a long way.'
+
+"But I would not listen to them, and shouted out to him in my rage,
+'Cyclops, if any one asks you who it was that put your eye out and
+spoiled your beauty, say it was the valiant warrior Ulysses, son of
+Laertes, who lives in Ithaca.'
+
+"On this he groaned, and cried out, 'Alas, alas, then the old prophecy
+about me is coming true. There was a prophet here, at one time, a man
+both brave and of great stature, Telemus son of Eurymus, who was an
+excellent seer, and did all the prophesying for the Cyclopes till he
+grew old; he told me that all this would happen to me some day, and said
+I should lose my sight by the hand of Ulysses. I have been all along
+expecting some one of imposing presence and superhuman strength, whereas
+he turns out to be a little insignificant weakling, who has managed to
+blind my eye by taking advantage of me in my drink; come here, then,
+Ulysses, that I may make you presents to show my hospitality, and urge
+Neptune to help you forward on your journey--for Neptune and I are
+father and son. He, if he so will, shall heal me, which no one else
+neither god nor man can do.'
+
+"Then I said, 'I wish I could be as sure of killing you outright and
+sending you down to the house of Hades, as I am that it will take more
+than Neptune to cure that eye of yours.'
+
+"On this he lifted up his hands to the firmament of heaven and prayed,
+saying, 'Hear me, great Neptune; if I am indeed your own true begotten
+son, grant that Ulysses may never reach his home alive; or if he must
+get back to his friends at last, let him do so late and in sore plight
+after losing all his men [let him reach his home in another man's ship
+and find trouble in his house.'] {82}
+
+"Thus did he pray, and Neptune heard his prayer. Then he picked up
+a rock much larger than the first, swung it aloft and hurled it with
+prodigious force. It fell just short of the ship, but was within a
+little of hitting the end of the rudder. The sea quaked as the rock fell
+into it, and the wash of the wave it raised drove us onwards on our way
+towards the shore of the island.
+
+"When at last we got to the island where we had left the rest of our
+ships, we found our comrades lamenting us, and anxiously awaiting our
+return. We ran our vessel upon the sands and got out of her on to the
+sea shore; we also landed the Cyclops' sheep, and divided them equitably
+amongst us so that none might have reason to complain. As for the ram,
+my companions agreed that I should have it as an extra share; so I
+sacrificed it on the sea shore, and burned its thigh bones to Jove, who
+is the lord of all. But he heeded not my sacrifice, and only thought how
+he might destroy both my ships and my comrades.
+
+"Thus through the livelong day to the going down of the sun we feasted
+our fill on meat and drink, but when the sun went down and it came on
+dark, we camped upon the beach. When the child of morning rosy-fingered
+Dawn appeared, I bade my men on board and loose the hawsers. Then they
+took their places and smote the grey sea with their oars; so we sailed
+on with sorrow in our hearts, but glad to have escaped death though we
+had lost our comrades.
+
+
+Book X
+
+AEOLUS, THE LAESTRYGONES, CIRCE.
+
+"Thence we went on to the Aeolian island where lives Aeolus son of
+Hippotas, dear to the immortal gods. It is an island that floats (as
+it were) upon the sea, {83} iron bound with a wall that girds it. Now,
+Aeolus has six daughters and six lusty sons, so he made the sons marry
+the daughters, and they all live with their dear father and mother,
+feasting and enjoying every conceivable kind of luxury. All day long the
+atmosphere of the house is loaded with the savour of roasting meats till
+it groans again, yard and all; but by night they sleep on their well
+made bedsteads, each with his own wife between the blankets. These were
+the people among whom we had now come.
+
+"Aeolus entertained me for a whole month asking me questions all the
+time about Troy, the Argive fleet, and the return of the Achaeans. I
+told him exactly how everything had happened, and when I said I must go,
+and asked him to further me on my way, he made no sort of difficulty,
+but set about doing so at once. Moreover, he flayed me a prime ox-hide
+to hold the ways of the roaring winds, which he shut up in the hide as
+in a sack--for Jove had made him captain over the winds, and he could
+stir or still each one of them according to his own pleasure. He put
+the sack in the ship and bound the mouth so tightly with a silver thread
+that not even a breath of a side-wind could blow from any quarter. The
+West wind which was fair for us did he alone let blow as it chose; but
+it all came to nothing, for we were lost through our own folly.
+
+"Nine days and nine nights did we sail, and on the tenth day our native
+land showed on the horizon. We got so close in that we could see the
+stubble fires burning, and I, being then dead beat, fell into a light
+sleep, for I had never let the rudder out of my own hands, that we might
+get home the faster. On this the men fell to talking among themselves,
+and said I was bringing back gold and silver in the sack that Aeolus
+had given me. 'Bless my heart,' would one turn to his neighbour, saying,
+'how this man gets honoured and makes friends to whatever city or
+country he may go. See what fine prizes he is taking home from Troy,
+while we, who have travelled just as far as he has, come back with hands
+as empty as we set out with--and now Aeolus has given him ever so much
+more. Quick--let us see what it all is, and how much gold and silver
+there is in the sack he gave him.'
+
+"Thus they talked and evil counsels prevailed. They loosed the sack,
+whereupon the wind flew howling forth and raised a storm that carried us
+weeping out to sea and away from our own country. Then I awoke, and knew
+not whether to throw myself into the sea or to live on and make the best
+of it; but I bore it, covered myself up, and lay down in the ship, while
+the men lamented bitterly as the fierce winds bore our fleet back to the
+Aeolian island.
+
+"When we reached it we went ashore to take in water, and dined hard by
+the ships. Immediately after dinner I took a herald and one of my men
+and went straight to the house of Aeolus, where I found him feasting
+with his wife and family; so we sat down as suppliants on the threshold.
+They were astounded when they saw us and said, 'Ulysses, what brings you
+here? What god has been ill-treating you? We took great pains to further
+you on your way home to Ithaca, or wherever it was that you wanted to go
+to.'
+
+"Thus did they speak, but I answered sorrowfully, 'My men have undone
+me; they, and cruel sleep, have ruined me. My friends, mend me this
+mischief, for you can if you will.'
+
+"I spoke as movingly as I could, but they said nothing, till their
+father answered, 'Vilest of mankind, get you gone at once out of the
+island; him whom heaven hates will I in no wise help. Be off, for you
+come here as one abhorred of heaven.' And with these words he sent me
+sorrowing from his door.
+
+"Thence we sailed sadly on till the men were worn out with long and
+fruitless rowing, for there was no longer any wind to help them. Six
+days, night and day did we toil, and on the seventh day we reached the
+rocky stronghold of Lamus--Telepylus, the city of the Laestrygonians,
+where the shepherd who is driving in his sheep and goats [to be milked]
+salutes him who is driving out his flock [to feed] and this last answers
+the salute. In that country a man who could do without sleep might earn
+double wages, one as a herdsman of cattle, and another as a shepherd,
+for they work much the same by night as they do by day. {84}
+
+"When we reached the harbour we found it land-locked under steep cliffs,
+with a narrow entrance between two headlands. My captains took all their
+ships inside, and made them fast close to one another, for there was
+never so much as a breath of wind inside, but it was always dead calm. I
+kept my own ship outside, and moored it to a rock at the very end of the
+point; then I climbed a high rock to reconnoitre, but could see no sign
+neither of man nor cattle, only some smoke rising from the ground. So I
+sent two of my company with an attendant to find out what sort of people
+the inhabitants were.
+
+"The men when they got on shore followed a level road by which the
+people draw their firewood from the mountains into the town, till
+presently they met a young woman who had come outside to fetch water,
+and who was daughter to a Laestrygonian named Antiphates. She was going
+to the fountain Artacia from which the people bring in their water, and
+when my men had come close up to her, they asked her who the king of
+that country might be, and over what kind of people he ruled; so she
+directed them to her father's house, but when they got there they found
+his wife to be a giantess as huge as a mountain, and they were horrified
+at the sight of her.
+
+"She at once called her husband Antiphates from the place of assembly,
+and forthwith he set about killing my men. He snatched up one of them,
+and began to make his dinner off him then and there, whereon the other
+two ran back to the ships as fast as ever they could. But Antiphates
+raised a hue-and-cry after them, and thousands of sturdy Laestrygonians
+sprang up from every quarter--ogres, not men. They threw vast rocks at
+us from the cliffs as though they had been mere stones, and I heard
+the horrid sound of the ships crunching up against one another, and the
+death cries of my men, as the Laestrygonians speared them like fishes
+and took them home to eat them. While they were thus killing my men
+within the harbour I drew my sword, cut the cable of my own ship, and
+told my men to row with all their might if they too would not fare like
+the rest; so they laid out for their lives, and we were thankful enough
+when we got into open water out of reach of the rocks they hurled at us.
+As for the others there was not one of them left.
+
+"Thence we sailed sadly on, glad to have escaped death, though we had
+lost our comrades, and came to the Aeaean island, where Circe lives--a
+great and cunning goddess who is own sister to the magician Aeetes--for
+they are both children of the sun by Perse, who is daughter to Oceanus.
+We brought our ship into a safe harbour without a word, for some god
+guided us thither, and having landed we lay there for two days and two
+nights, worn out in body and mind. When the morning of the third day
+came I took my spear and my sword, and went away from the ship to
+reconnoitre, and see if I could discover signs of human handiwork,
+or hear the sound of voices. Climbing to the top of a high look-out I
+espied the smoke of Circe's house rising upwards amid a dense forest of
+trees, and when I saw this I doubted whether, having seen the smoke, I
+would not go on at once and find out more, but in the end I deemed it
+best to go back to the ship, give the men their dinners, and send some
+of them instead of going myself.
+
+"When I had nearly got back to the ship some god took pity upon my
+solitude, and sent a fine antlered stag right into the middle of my
+path. He was coming down his pasture in the forest to drink of the
+river, for the heat of the sun drove him, and as he passed I struck
+him in the middle of the back; the bronze point of the spear went clean
+through him, and he lay groaning in the dust until the life went out of
+him. Then I set my foot upon him, drew my spear from the wound, and laid
+it down; I also gathered rough grass and rushes and twisted them into a
+fathom or so of good stout rope, with which I bound the four feet of
+the noble creature together; having so done I hung him round my neck and
+walked back to the ship leaning upon my spear, for the stag was much too
+big for me to be able to carry him on my shoulder, steadying him with
+one hand. As I threw him down in front of the ship, I called the men
+and spoke cheeringly man by man to each of them. 'Look here my friends,'
+said I, 'we are not going to die so much before our time after all, and
+at any rate we will not starve so long as we have got something to eat
+and drink on board.' On this they uncovered their heads upon the sea
+shore and admired the stag, for he was indeed a splendid fellow. Then,
+when they had feasted their eyes upon him sufficiently, they washed
+their hands and began to cook him for dinner.
+
+"Thus through the livelong day to the going down of the sun we stayed
+there eating and drinking our fill, but when the sun went down and it
+came on dark, we camped upon the sea shore. When the child of morning,
+rosy-fingered Dawn, appeared, I called a council and said, 'My friends,
+we are in very great difficulties; listen therefore to me. We have no
+idea where the sun either sets or rises, {85} so that we do not even
+know East from West. I see no way out of it; nevertheless, we must try
+and find one. We are certainly on an island, for I went as high as
+I could this morning, and saw the sea reaching all round it to the
+horizon; it lies low, but towards the middle I saw smoke rising from out
+of a thick forest of trees.'
+
+"Their hearts sank as they heard me, for they remembered how they had
+been treated by the Laestrygonian Antiphates, and by the savage ogre
+Polyphemus. They wept bitterly in their dismay, but there was nothing to
+be got by crying, so I divided them into two companies and set a captain
+over each; I gave one company to Eurylochus, while I took command of
+the other myself. Then we cast lots in a helmet, and the lot fell upon
+Eurylochus; so he set out with his twenty-two men, and they wept, as
+also did we who were left behind.
+
+"When they reached Circe's house they found it built of cut stones, on
+a site that could be seen from far, in the middle of the forest.
+There were wild mountain wolves and lions prowling all round it--poor
+bewitched creatures whom she had tamed by her enchantments and drugged
+into subjection. They did not attack my men, but wagged their great
+tails, fawned upon them, and rubbed their noses lovingly against them.
+{86} As hounds crowd round their master when they see him coming from
+dinner--for they know he will bring them something--even so did these
+wolves and lions with their great claws fawn upon my men, but the men
+were terribly frightened at seeing such strange creatures. Presently
+they reached the gates of the goddess's house, and as they stood there
+they could hear Circe within, singing most beautifully as she worked at
+her loom, making a web so fine, so soft, and of such dazzling colours
+as no one but a goddess could weave. On this Polites, whom I valued and
+trusted more than any other of my men, said, 'There is some one inside
+working at a loom and singing most beautifully; the whole place resounds
+with it, let us call her and see whether she is woman or goddess.'
+
+"They called her and she came down, unfastened the door, and bade them
+enter. They, thinking no evil, followed her, all except Eurylochus, who
+suspected mischief and staid outside. When she had got them into her
+house, she set them upon benches and seats and mixed them a mess with
+cheese, honey, meal, and Pramnian wine, but she drugged it with wicked
+poisons to make them forget their homes, and when they had drunk she
+turned them into pigs by a stroke of her wand, and shut them up in her
+pig-styes. They were like pigs--head, hair, and all, and they grunted
+just as pigs do; but their senses were the same as before, and they
+remembered everything.
+
+"Thus then were they shut up squealing, and Circe threw them some acorns
+and beech masts such as pigs eat, but Eurylochus hurried back to tell me
+about the sad fate of our comrades. He was so overcome with dismay
+that though he tried to speak he could find no words to do so; his eyes
+filled with tears and he could only sob and sigh, till at last we forced
+his story out of him, and he told us what had happened to the others.
+
+"'We went,' said he, 'as you told us, through the forest, and in the
+middle of it there was a fine house built with cut stones in a place
+that could be seen from far. There we found a woman, or else she was a
+goddess, working at her loom and singing sweetly; so the men shouted to
+her and called her, whereon she at once came down, opened the door, and
+invited us in. The others did not suspect any mischief so they followed
+her into the house, but I staid where I was, for I thought there might
+be some treachery. From that moment I saw them no more, for not one of
+them ever came out, though I sat a long time watching for them.'
+
+"Then I took my sword of bronze and slung it over my shoulders; I also
+took my bow, and told Eurylochus to come back with me and shew me the
+way. But he laid hold of me with both his hands and spoke piteously,
+saying, 'Sir, do not force me to go with you, but let me stay here, for
+I know you will not bring one of them back with you, nor even return
+alive yourself; let us rather see if we cannot escape at any rate with
+the few that are left us, for we may still save our lives.'
+
+"'Stay where you are, then,' answered I, 'eating and drinking at the
+ship, but I must go, for I am most urgently bound to do so.'
+
+"With this I left the ship and went up inland. When I got through the
+charmed grove, and was near the great house of the enchantress Circe,
+I met Mercury with his golden wand, disguised as a young man in the
+hey-day of his youth and beauty with the down just coming upon his
+face. He came up to me and took my hand within his own, saying, 'My poor
+unhappy man, whither are you going over this mountain top, alone and
+without knowing the way? Your men are shut up in Circe's pigstyes, like
+so many wild boars in their lairs. You surely do not fancy that you can
+set them free? I can tell you that you will never get back and will have
+to stay there with the rest of them. But never mind, I will protect
+you and get you out of your difficulty. Take this herb, which is one
+of great virtue, and keep it about you when you go to Circe's house, it
+will be a talisman to you against every kind of mischief.
+
+"'And I will tell you of all the wicked witchcraft that Circe will try
+to practice upon you. She will mix a mess for you to drink, and she will
+drug the meal with which she makes it, but she will not be able to charm
+you, for the virtue of the herb that I shall give you will prevent her
+spells from working. I will tell you all about it. When Circe strikes
+you with her wand, draw your sword and spring upon her as though you
+were going to kill her. She will then be frightened, and will desire you
+to go to bed with her; on this you must not point blank refuse her, for
+you want her to set your companions free, and to take good care also of
+yourself, but you must make her swear solemnly by all the blessed gods
+that she will plot no further mischief against you, or else when she has
+got you naked she will unman you and make you fit for nothing.'
+
+"As he spoke he pulled the herb out of the ground and shewed me what it
+was like. The root was black, while the flower was as white as milk; the
+gods call it Moly, and mortal men cannot uproot it, but the gods can do
+whatever they like.
+
+"Then Mercury went back to high Olympus passing over the wooded island;
+but I fared onward to the house of Circe, and my heart was clouded with
+care as I walked along. When I got to the gates I stood there and called
+the goddess, and as soon as she heard me she came down, opened the door,
+and asked me to come in; so I followed her--much troubled in my mind.
+She set me on a richly decorated seat inlaid with silver, there was a
+footstool also under my feet, and she mixed a mess in a golden goblet
+for me to drink; but she drugged it, for she meant me mischief. When she
+had given it me, and I had drunk it without its charming me, she struck
+me with her wand. 'There now,' she cried, 'be off to the pigstye, and
+make your lair with the rest of them.'
+
+"But I rushed at her with my sword drawn as though I would kill her,
+whereon she fell with a loud scream, clasped my knees, and spoke
+piteously, saying, 'Who and whence are you? from what place and people
+have you come? How can it be that my drugs have no power to charm you?
+Never yet was any man able to stand so much as a taste of the herb I
+gave you; you must be spell-proof; surely you can be none other than the
+bold hero Ulysses, who Mercury always said would come here some day with
+his ship while on his way home from Troy; so be it then; sheathe your
+sword and let us go to bed, that we may make friends and learn to trust
+each other.'
+
+"And I answered, 'Circe, how can you expect me to be friendly with you
+when you have just been turning all my men into pigs? And now that you
+have got me here myself, you mean me mischief when you ask me to go to
+bed with you, and will unman me and make me fit for nothing. I shall
+certainly not consent to go to bed with you unless you will first take
+your solemn oath to plot no further harm against me.'
+
+"So she swore at once as I had told her, and when she had completed her
+oath then I went to bed with her.
+
+"Meanwhile her four servants, who are her housemaids, set about their
+work. They are the children of the groves and fountains, and of the
+holy waters that run down into the sea. One of them spread a fair purple
+cloth over a seat, and laid a carpet underneath it. Another brought
+tables of silver up to the seats, and set them with baskets of gold. A
+third mixed some sweet wine with water in a silver bowl and put golden
+cups upon the tables, while the fourth brought in water and set it to
+boil in a large cauldron over a good fire which she had lighted. When
+the water in the cauldron was boiling, {87} she poured cold into it
+till it was just as I liked it, and then she set me in a bath and began
+washing me from the cauldron about the head and shoulders, to take the
+tire and stiffness out of my limbs. As soon as she had done washing me
+and anointing me with oil, she arrayed me in a good cloak and shirt
+and led me to a richly decorated seat inlaid with silver; there was a
+footstool also under my feet. A maid servant then brought me water in a
+beautiful golden ewer and poured it into a silver basin for me to wash
+my hands, and she drew a clean table beside me; an upper servant brought
+me bread and offered me many things of what there was in the house, and
+then Circe bade me eat, but I would not, and sat without heeding what
+was before me, still moody and suspicious.
+
+"When Circe saw me sitting there without eating, and in great grief, she
+came to me and said, 'Ulysses, why do you sit like that as though you
+were dumb, gnawing at your own heart, and refusing both meat and drink?
+Is it that you are still suspicious? You ought not to be, for I have
+already sworn solemnly that I will not hurt you.'
+
+"And I said, 'Circe, no man with any sense of what is right can think of
+either eating or drinking in your house until you have set his friends
+free and let him see them. If you want me to eat and drink, you must
+free my men and bring them to me that I may see them with my own eyes.'
+
+"When I had said this she went straight through the court with her wand
+in her hand and opened the pigstye doors. My men came out like so many
+prime hogs and stood looking at her, but she went about among them and
+anointed each with a second drug, whereon the bristles that the bad drug
+had given them fell off, and they became men again, younger than they
+were before, and much taller and better looking. They knew me at once,
+seized me each of them by the hand, and wept for joy till the whole
+house was filled with the sound of their halloa-ballooing, and Circe
+herself was so sorry for them that she came up to me and said, 'Ulysses,
+noble son of Laertes, go back at once to the sea where you have left
+your ship, and first draw it on to the land. Then, hide all your ship's
+gear and property in some cave, and come back here with your men.'
+
+"I agreed to this, so I went back to the sea shore, and found the men at
+the ship weeping and wailing most piteously. When they saw me the silly
+blubbering fellows began frisking round me as calves break out and
+gambol round their mothers, when they see them coming home to be milked
+after they have been feeding all day, and the homestead resounds with
+their lowing. They seemed as glad to see me as though they had got back
+to their own rugged Ithaca, where they had been born and bred. 'Sir,'
+said the affectionate creatures, 'we are as glad to see you back as
+though we had got safe home to Ithaca; but tell us all about the fate of
+our comrades.'
+
+"I spoke comfortingly to them and said, 'We must draw our ship on to the
+land, and hide the ship's gear with all our property in some cave; then
+come with me all of you as fast as you can to Circe's house, where
+you will find your comrades eating and drinking in the midst of great
+abundance.'
+
+"On this the men would have come with me at once, but Eurylochus tried
+to hold them back and said, 'Alas, poor wretches that we are, what will
+become of us? Rush not on your ruin by going to the house of Circe, who
+will turn us all into pigs or wolves or lions, and we shall have to
+keep guard over her house. Remember how the Cyclops treated us when our
+comrades went inside his cave, and Ulysses with them. It was all through
+his sheer folly that those men lost their lives.'
+
+"When I heard him I was in two minds whether or no to draw the keen
+blade that hung by my sturdy thigh and cut his head off in spite of
+his being a near relation of my own; but the men interceded for him
+and said, 'Sir, if it may so be, let this fellow stay here and mind the
+ship, but take the rest of us with you to Circe's house.'
+
+"On this we all went inland, and Eurylochus was not left behind after
+all, but came on too, for he was frightened by the severe reprimand that
+I had given him.
+
+"Meanwhile Circe had been seeing that the men who had been left behind
+were washed and anointed with olive oil; she had also given them woollen
+cloaks and shirts, and when we came we found them all comfortably at
+dinner in her house. As soon as the men saw each other face to face
+and knew one another, they wept for joy and cried aloud till the whole
+palace rang again. Thereon Circe came up to me and said, 'Ulysses, noble
+son of Laertes, tell your men to leave off crying; I know how much you
+have all of you suffered at sea, and how ill you have fared among cruel
+savages on the mainland, but that is over now, so stay here, and eat and
+drink till you are once more as strong and hearty as you were when you
+left Ithaca; for at present you are weakened both in body and mind; you
+keep all the time thinking of the hardships you have suffered during
+your travels, so that you have no more cheerfulness left in you.'
+
+"Thus did she speak and we assented. We stayed with Circe for a whole
+twelvemonth feasting upon an untold quantity both of meat and wine. But
+when the year had passed in the waning of moons and the long days had
+come round, my men called me apart and said, 'Sir, it is time you began
+to think about going home, if so be you are to be spared to see your
+house and native country at all.'
+
+"Thus did they speak and I assented. Thereon through the livelong day to
+the going down of the sun we feasted our fill on meat and wine, but when
+the sun went down and it came on dark the men laid themselves down to
+sleep in the covered cloisters. I, however, after I had got into bed
+with Circe, besought her by her knees, and the goddess listened to what
+I had got to say. 'Circe,' said I, 'please to keep the promise you made
+me about furthering me on my homeward voyage. I want to get back and so
+do my men, they are always pestering me with their complaints as soon as
+ever your back is turned.'
+
+"And the goddess answered, 'Ulysses, noble son of Laertes, you shall
+none of you stay here any longer if you do not want to, but there
+is another journey which you have got to take before you can sail
+homewards. You must go to the house of Hades and of dread Proserpine to
+consult the ghost of the blind Theban prophet Teiresias, whose reason is
+still unshaken. To him alone has Proserpine left his understanding even
+in death, but the other ghosts flit about aimlessly.'
+
+"I was dismayed when I heard this. I sat up in bed and wept, and would
+gladly have lived no longer to see the light of the sun, but presently
+when I was tired of weeping and tossing myself about, I said, 'And who
+shall guide me upon this voyage--for the house of Hades is a port that
+no ship can reach.'
+
+"'You will want no guide,' she answered; 'raise your mast, set your
+white sails, sit quite still, and the North Wind will blow you there
+of itself. When your ship has traversed the waters of Oceanus, you will
+reach the fertile shore of Proserpine's country with its groves of tall
+poplars and willows that shed their fruit untimely; here beach your
+ship upon the shore of Oceanus, and go straight on to the dark abode of
+Hades. You will find it near the place where the rivers Pyriphlegethon
+and Cocytus (which is a branch of the river Styx) flow into Acheron, and
+you will see a rock near it, just where the two roaring rivers run into
+one another.
+
+"'When you have reached this spot, as I now tell you, dig a trench
+a cubit or so in length, breadth, and depth, and pour into it as a
+drink-offering to all the dead, first, honey mixed with milk, then wine,
+and in the third place water--sprinkling white barley meal over the
+whole. Moreover you must offer many prayers to the poor feeble ghosts,
+and promise them that when you get back to Ithaca you will sacrifice a
+barren heifer to them, the best you have, and will load the pyre with
+good things. More particularly you must promise that Teiresias shall
+have a black sheep all to himself, the finest in all your flocks.
+
+"'When you shall have thus besought the ghosts with your prayers, offer
+them a ram and a black ewe, bending their heads towards Erebus; but
+yourself turn away from them as though you would make towards the river.
+On this, many dead men's ghosts will come to you, and you must tell your
+men to skin the two sheep that you have just killed, and offer them as a
+burnt sacrifice with prayers to Hades and to Proserpine. Then draw your
+sword and sit there, so as to prevent any other poor ghost from
+coming near the spilt blood before Teiresias shall have answered your
+questions. The seer will presently come to you, and will tell you about
+your voyage--what stages you are to make, and how you are to sail the
+sea so as to reach your home.'
+
+"It was day-break by the time she had done speaking, so she dressed
+me in my shirt and cloak. As for herself she threw a beautiful light
+gossamer fabric over her shoulders, fastening it with a golden girdle
+round her waist, and she covered her head with a mantle. Then I went
+about among the men everywhere all over the house, and spoke kindly to
+each of them man by man: 'You must not lie sleeping here any longer,'
+said I to them, 'we must be going, for Circe has told me all about it.'
+And on this they did as I bade them.
+
+"Even so, however, I did not get them away without misadventure. We had
+with us a certain youth named Elpenor, not very remarkable for sense or
+courage, who had got drunk and was lying on the house-top away from the
+rest of the men, to sleep off his liquor in the cool. When he heard the
+noise of the men bustling about, he jumped up on a sudden and forgot
+all about coming down by the main staircase, so he tumbled right off the
+roof and broke his neck, and his soul went down to the house of Hades.
+
+"When I had got the men together I said to them, 'You think you are
+about to start home again, but Circe has explained to me that instead of
+this, we have got to go to the house of Hades and Proserpine to consult
+the ghost of the Theban prophet Teiresias.'
+
+"The men were broken-hearted as they heard me, and threw themselves
+on the ground groaning and tearing their hair, but they did not mend
+matters by crying. When we reached the sea shore, weeping and lamenting
+our fate, Circe brought the ram and the ewe, and we made them fast hard
+by the ship. She passed through the midst of us without our knowing it,
+for who can see the comings and goings of a god, if the god does not
+wish to be seen?
+
+
+Book XI
+
+THE VISIT TO THE DEAD. {88}
+
+"Then, when we had got down to the sea shore we drew our ship into the
+water and got her mast and sails into her; we also put the sheep on
+board and took our places, weeping and in great distress of mind. Circe,
+that great and cunning goddess, sent us a fair wind that blew dead aft
+and staid steadily with us keeping our sails all the time well filled;
+so we did whatever wanted doing to the ship's gear and let her go as the
+wind and helmsman headed her. All day long her sails were full as she
+held her course over the sea, but when the sun went down and darkness
+was over all the earth, we got into the deep waters of the river
+Oceanus, where lie the land and city of the Cimmerians who live
+enshrouded in mist and darkness which the rays of the sun never pierce
+neither at his rising nor as he goes down again out of the heavens, but
+the poor wretches live in one long melancholy night. When we got there
+we beached the ship, took the sheep out of her, and went along by the
+waters of Oceanus till we came to the place of which Circe had told us.
+
+"Here Perimedes and Eurylochus held the victims, while I drew my sword
+and dug the trench a cubit each way. I made a drink-offering to all the
+dead, first with honey and milk, then with wine, and thirdly with water,
+and I sprinkled white barley meal over the whole, praying earnestly to
+the poor feckless ghosts, and promising them that when I got back to
+Ithaca I would sacrifice a barren heifer for them, the best I had, and
+would load the pyre with good things. I also particularly promised
+that Teiresias should have a black sheep to himself, the best in all my
+flocks. When I had prayed sufficiently to the dead, I cut the throats of
+the two sheep and let the blood run into the trench, whereon the ghosts
+came trooping up from Erebus--brides, {89} young bachelors, old men worn
+out with toil, maids who had been crossed in love, and brave men who had
+been killed in battle, with their armour still smirched with blood; they
+came from every quarter and flitted round the trench with a strange kind
+of screaming sound that made me turn pale with fear. When I saw them
+coming I told the men to be quick and flay the carcasses of the two dead
+sheep and make burnt offerings of them, and at the same time to repeat
+prayers to Hades and to Proserpine; but I sat where I was with my sword
+drawn and would not let the poor feckless ghosts come near the blood
+till Teiresias should have answered my questions.
+
+"The first ghost that came was that of my comrade Elpenor, for he had
+not yet been laid beneath the earth. We had left his body unwaked and
+unburied in Circe's house, for we had had too much else to do. I was
+very sorry for him, and cried when I saw him: 'Elpenor,' said I, 'how
+did you come down here into this gloom and darkness? You have got here
+on foot quicker than I have with my ship.'
+
+"'Sir,' he answered with a groan, 'it was all bad luck, and my own
+unspeakable drunkenness. I was lying asleep on the top of Circe's house,
+and never thought of coming down again by the great staircase but fell
+right off the roof and broke my neck, so my soul came down to the house
+of Hades. And now I beseech you by all those whom you have left behind
+you, though they are not here, by your wife, by the father who brought
+you up when you were a child, and by Telemachus who is the one hope of
+your house, do what I shall now ask you. I know that when you leave this
+limbo you will again hold your ship for the Aeaean island. Do not
+go thence leaving me unwaked and unburied behind you, or I may bring
+heaven's anger upon you; but burn me with whatever armour I have, build
+a barrow for me on the sea shore, that may tell people in days to come
+what a poor unlucky fellow I was, and plant over my grave the oar I used
+to row with when I was yet alive and with my messmates.' And I said, 'My
+poor fellow, I will do all that you have asked of me.'
+
+"Thus, then, did we sit and hold sad talk with one another, I on the one
+side of the trench with my sword held over the blood, and the ghost
+of my comrade saying all this to me from the other side. Then came the
+ghost of my dead mother Anticlea, daughter to Autolycus. I had left her
+alive when I set out for Troy and was moved to tears when I saw her, but
+even so, for all my sorrow I would not let her come near the blood till
+I had asked my questions of Teiresias.
+
+"Then came also the ghost of Theban Teiresias, with his golden sceptre
+in his hand. He knew me and said, 'Ulysses, noble son of Laertes, why,
+poor man, have you left the light of day and come down to visit the dead
+in this sad place? Stand back from the trench and withdraw your sword
+that I may drink of the blood and answer your questions truly.'
+
+"So I drew back, and sheathed my sword, whereon when he had drank of the
+blood he began with his prophecy.
+
+"'You want to know,' said he, 'about your return home, but heaven will
+make this hard for you. I do not think that you will escape the eye
+of Neptune, who still nurses his bitter grudge against you for having
+blinded his son. Still, after much suffering you may get home if you
+can restrain yourself and your companions when your ship reaches the
+Thrinacian island, where you will find the sheep and cattle belonging to
+the sun, who sees and gives ear to everything. If you leave these flocks
+unharmed and think of nothing but of getting home, you may yet after
+much hardship reach Ithaca; but if you harm them, then I forewarn you of
+the destruction both of your ship and of your men. Even though you may
+yourself escape, you will return in bad plight after losing all your
+men, [in another man's ship, and you will find trouble in your house,
+which will be overrun by high-handed people, who are devouring your
+substance under the pretext of paying court and making presents to your
+wife.
+
+"'When you get home you will take your revenge on these suitors; and
+after you have killed them by force or fraud in your own house, you must
+take a well made oar and carry it on and on, till you come to a country
+where the people have never heard of the sea and do not even mix salt
+with their food, nor do they know anything about ships, and oars that
+are as the wings of a ship. I will give you this certain token which
+cannot escape your notice. A wayfarer will meet you and will say it must
+be a winnowing shovel that you have got upon your shoulder; on this you
+must fix the oar in the ground and sacrifice a ram, a bull, and a boar
+to Neptune. {90} Then go home and offer hecatombs to all the gods in
+heaven one after the other. As for yourself, death shall come to you
+from the sea, and your life shall ebb away very gently when you are full
+of years and peace of mind, and your people shall bless you. All that I
+have said will come true].' {91}
+
+"'This,' I answered, 'must be as it may please heaven, but tell me and
+tell me and tell me true, I see my poor mother's ghost close by us; she
+is sitting by the blood without saying a word, and though I am her own
+son she does not remember me and speak to me; tell me, Sir, how I can
+make her know me.'
+
+"'That,' said he, 'I can soon do. Any ghost that you let taste of the
+blood will talk with you like a reasonable being, but if you do not let
+them have any blood they will go away again.'
+
+"On this the ghost of Teiresias went back to the house of Hades, for his
+prophecyings had now been spoken, but I sat still where I was until my
+mother came up and tasted the blood. Then she knew me at once and spoke
+fondly to me, saying, 'My son, how did you come down to this abode of
+darkness while you are still alive? It is a hard thing for the living to
+see these places, for between us and them there are great and terrible
+waters, and there is Oceanus, which no man can cross on foot, but he
+must have a good ship to take him. Are you all this time trying to find
+your way home from Troy, and have you never yet got back to Ithaca nor
+seen your wife in your own house?'
+
+"'Mother,' said I, 'I was forced to come here to consult the ghost of
+the Theban prophet Teiresias. I have never yet been near the Achaean
+land nor set foot on my native country, and I have had nothing but one
+long series of misfortunes from the very first day that I set out with
+Agamemnon for Ilius, the land of noble steeds, to fight the Trojans. But
+tell me, and tell me true, in what way did you die? Did you have a long
+illness, or did heaven vouchsafe you a gentle easy passage to eternity?
+Tell me also about my father, and the son whom I left behind me, is my
+property still in their hands, or has some one else got hold of it, who
+thinks that I shall not return to claim it? Tell me again what my wife
+intends doing, and in what mind she is; does she live with my son and
+guard my estate securely, or has she made the best match she could and
+married again?'
+
+"My mother answered, 'Your wife still remains in your house, but she is
+in great distress of mind and spends her whole time in tears both night
+and day. No one as yet has got possession of your fine property, and
+Telemachus still holds your lands undisturbed. He has to entertain
+largely, as of course he must, considering his position as a magistrate,
+{92} and how every one invites him; your father remains at his old place
+in the country and never goes near the town. He has no comfortable bed
+nor bedding; in the winter he sleeps on the floor in front of the fire
+with the men and goes about all in rags, but in summer, when the warm
+weather comes on again, he lies out in the vineyard on a bed of vine
+leaves thrown any how upon the ground. He grieves continually about your
+never having come home, and suffers more and more as he grows older. As
+for my own end it was in this wise: heaven did not take me swiftly and
+painlessly in my own house, nor was I attacked by any illness such as
+those that generally wear people out and kill them, but my longing to
+know what you were doing and the force of my affection for you--this it
+was that was the death of me.' {93}
+
+"Then I tried to find some way of embracing my poor mother's ghost.
+Thrice I sprang towards her and tried to clasp her in my arms, but each
+time she flitted from my embrace as it were a dream or phantom, and
+being touched to the quick I said to her, 'Mother, why do you not stay
+still when I would embrace you? If we could throw our arms around one
+another we might find sad comfort in the sharing of our sorrows even in
+the house of Hades; does Proserpine want to lay a still further load of
+grief upon me by mocking me with a phantom only?'
+
+"'My son,' she answered, 'most ill-fated of all mankind, it is not
+Proserpine that is beguiling you, but all people are like this when they
+are dead. The sinews no longer hold the flesh and bones together; these
+perish in the fierceness of consuming fire as soon as life has left the
+body, and the soul flits away as though it were a dream. Now, however,
+go back to the light of day as soon as you can, and note all these
+things that you may tell them to your wife hereafter.'
+
+"Thus did we converse, and anon Proserpine sent up the ghosts of the
+wives and daughters of all the most famous men. They gathered in crowds
+about the blood, and I considered how I might question them severally.
+In the end I deemed that it would be best to draw the keen blade that
+hung by my sturdy thigh, and keep them from all drinking the blood at
+once. So they came up one after the other, and each one as I questioned
+her told me her race and lineage.
+
+"The first I saw was Tyro. She was daughter of Salmoneus and wife of
+Cretheus the son of Aeolus. {94} She fell in love with the river Enipeus
+who is much the most beautiful river in the whole world. Once when she
+was taking a walk by his side as usual, Neptune, disguised as her lover,
+lay with her at the mouth of the river, and a huge blue wave arched
+itself like a mountain over them to hide both woman and god, whereon he
+loosed her virgin girdle and laid her in a deep slumber. When the god
+had accomplished the deed of love, he took her hand in his own and
+said, 'Tyro, rejoice in all good will; the embraces of the gods are not
+fruitless, and you will have fine twins about this time twelve months.
+Take great care of them. I am Neptune, so now go home, but hold your
+tongue and do not tell any one.'
+
+"Then he dived under the sea, and she in due course bore Pelias and
+Neleus, who both of them served Jove with all their might. Pelias was
+a great breeder of sheep and lived in Iolcus, but the other lived in
+Pylos. The rest of her children were by Cretheus, namely, Aeson, Pheres,
+and Amythaon, who was a mighty warrior and charioteer.
+
+"Next to her I saw Antiope, daughter to Asopus, who could boast of
+having slept in the arms of even Jove himself, and who bore him two sons
+Amphion and Zethus. These founded Thebes with its seven gates, and built
+a wall all round it; for strong though they were they could not hold
+Thebes till they had walled it.
+
+"Then I saw Alcmena, the wife of Amphitryon, who also bore to Jove
+indomitable Hercules; and Megara who was daughter to great King Creon,
+and married the redoubtable son of Amphitryon.
+
+"I also saw fair Epicaste mother of king Oedipodes whose awful lot it
+was to marry her own son without suspecting it. He married her after
+having killed his father, but the gods proclaimed the whole story to the
+world; whereon he remained king of Thebes, in great grief for the spite
+the gods had borne him; but Epicaste went to the house of the mighty
+jailor Hades, having hanged herself for grief, and the avenging spirits
+haunted him as for an outraged mother--to his ruing bitterly thereafter.
+
+"Then I saw Chloris, whom Neleus married for her beauty, having given
+priceless presents for her. She was youngest daughter to Amphion son of
+Iasus and king of Minyan Orchomenus, and was Queen in Pylos. She bore
+Nestor, Chromius, and Periclymenus, and she also bore that marvellously
+lovely woman Pero, who was wooed by all the country round; but Neleus
+would only give her to him who should raid the cattle of Iphicles from
+the grazing grounds of Phylace, and this was a hard task. The only man
+who would undertake to raid them was a certain excellent seer, {95} but
+the will of heaven was against him, for the rangers of the cattle caught
+him and put him in prison; nevertheless when a full year had passed and
+the same season came round again, Iphicles set him at liberty, after
+he had expounded all the oracles of heaven. Thus, then, was the will of
+Jove accomplished.
+
+"And I saw Leda the wife of Tyndarus, who bore him two famous sons,
+Castor breaker of horses, and Pollux the mighty boxer. Both these heroes
+are lying under the earth, though they are still alive, for by a special
+dispensation of Jove, they die and come to life again, each one of them
+every other day throughout all time, and they have the rank of gods.
+
+"After her I saw Iphimedeia wife of Aloeus who boasted the embrace
+of Neptune. She bore two sons Otus and Ephialtes, but both were short
+lived. They were the finest children that were ever born in this world,
+and the best looking, Orion only excepted; for at nine years old they
+were nine fathoms high, and measured nine cubits round the chest. They
+threatened to make war with the gods in Olympus, and tried to set Mount
+Ossa on the top of Mount Olympus, and Mount Pelion on the top of Ossa,
+that they might scale heaven itself, and they would have done it too if
+they had been grown up, but Apollo, son of Leto, killed both of them,
+before they had got so much as a sign of hair upon their cheeks or chin.
+
+"Then I saw Phaedra, and Procris, and fair Ariadne daughter of the
+magician Minos, whom Theseus was carrying off from Crete to Athens, but
+he did not enjoy her, for before he could do so Diana killed her in the
+island of Dia on account of what Bacchus had said against her.
+
+"I also saw Maera and Clymene and hateful Eriphyle, who sold her own
+husband for gold. But it would take me all night if I were to name every
+single one of the wives and daughters of heroes whom I saw, and it is
+time for me to go to bed, either on board ship with my crew, or here. As
+for my escort, heaven and yourselves will see to it."
+
+Here he ended, and the guests sat all of them enthralled and speechless
+throughout the covered cloister. Then Arete said to them:--
+
+"What do you think of this man, O Phaeacians? Is he not tall and good
+looking, and is he not clever? True, he is my own guest, but all of you
+share in the distinction. Do not be in a hurry to send him away, nor
+niggardly in the presents you make to one who is in such great need, for
+heaven has blessed all of you with great abundance."
+
+Then spoke the aged hero Echeneus who was one of the oldest men among
+them, "My friends," said he, "what our august queen has just said to us
+is both reasonable and to the purpose, therefore be persuaded by it;
+but the decision whether in word or deed rests ultimately with King
+Alcinous."
+
+"The thing shall be done," exclaimed Alcinous, "as surely as I still
+live and reign over the Phaeacians. Our guest is indeed very anxious to
+get home, still we must persuade him to remain with us until to-morrow,
+by which time I shall be able to get together the whole sum that I mean
+to give him. As regards his escort it will be a matter for you all, and
+mine above all others as the chief person among you."
+
+And Ulysses answered, "King Alcinous, if you were to bid me to stay here
+for a whole twelve months, and then speed me on my way, loaded with your
+noble gifts, I should obey you gladly and it would redound greatly to
+my advantage, for I should return fuller-handed to my own people, and
+should thus be more respected and beloved by all who see me when I get
+back to Ithaca."
+
+"Ulysses," replied Alcinous, "not one of us who sees you has any idea
+that you are a charlatan or a swindler. I know there are many people
+going about who tell such plausible stories that it is very hard to see
+through them, but there is a style about your language which assures me
+of your good disposition. Moreover you have told the story of your own
+misfortunes, and those of the Argives, as though you were a practiced
+bard; but tell me, and tell me true, whether you saw any of the mighty
+heroes who went to Troy at the same time with yourself, and perished
+there. The evenings are still at their longest, and it is not yet bed
+time--go on, therefore, with your divine story, for I could stay here
+listening till tomorrow morning, so long as you will continue to tell us
+of your adventures."
+
+"Alcinous," answered Ulysses, "there is a time for making speeches, and
+a time for going to bed; nevertheless, since you so desire, I will not
+refrain from telling you the still sadder tale of those of my comrades
+who did not fall fighting with the Trojans, but perished on their
+return, through the treachery of a wicked woman.
+
+"When Proserpine had dismissed the female ghosts in all directions,
+the ghost of Agamemnon son of Atreus came sadly up to me, surrounded by
+those who had perished with him in the house of Aegisthus. As soon as he
+had tasted the blood, he knew me, and weeping bitterly stretched out his
+arms towards me to embrace me; but he had no strength nor substance any
+more, and I too wept and pitied him as I beheld him. 'How did you come
+by your death,' said I, 'King Agamemnon? Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the main land when you were cattle-lifting or sheep-stealing,
+or while they were fighting in defence of their wives and city?'
+
+"'Ulysses,' he answered, 'noble son of Laertes, I was not lost at sea
+in any storm of Neptune's raising, nor did my foes despatch me upon the
+mainland, but Aegisthus and my wicked wife were the death of me between
+them. He asked me to his house, feasted me, and then butchered me most
+miserably as though I were a fat beast in a slaughter house, while all
+around me my comrades were slain like sheep or pigs for the wedding
+breakfast, or picnic, or gorgeous banquet of some great nobleman. You
+must have seen numbers of men killed either in a general engagement, or
+in single combat, but you never saw anything so truly pitiable as the
+way in which we fell in that cloister, with the mixing bowl and the
+loaded tables lying all about, and the ground reeking with our blood. I
+heard Priam's daughter Cassandra scream as Clytemnestra killed her close
+beside me. I lay dying upon the earth with the sword in my body, and
+raised my hands to kill the slut of a murderess, but she slipped away
+from me; she would not even close my lips nor my eyes when I was dying,
+for there is nothing in this world so cruel and so shameless as a woman
+when she has fallen into such guilt as hers was. Fancy murdering her own
+husband! I thought I was going to be welcomed home by my children and my
+servants, but her abominable crime has brought disgrace on herself and
+all women who shall come after--even on the good ones.'
+
+"And I said, 'In truth Jove has hated the house of Atreus from first to
+last in the matter of their women's counsels. See how many of us fell
+for Helen's sake, and now it seems that Clytemnestra hatched mischief
+against you too during your absence.'
+
+"'Be sure, therefore,' continued Agamemnon, 'and not be too friendly
+even with your own wife. Do not tell her all that you know perfectly
+well yourself. Tell her a part only, and keep your own counsel about the
+rest. Not that your wife, Ulysses, is likely to murder you, for Penelope
+is a very admirable woman, and has an excellent nature. We left her a
+young bride with an infant at her breast when we set out for Troy. This
+child no doubt is now grown up happily to man's estate, {96} and he and
+his father will have a joyful meeting and embrace one another as it is
+right they should do, whereas my wicked wife did not even allow me
+the happiness of looking upon my son, but killed me ere I could do so.
+Furthermore I say--and lay my saying to your heart--do not tell people
+when you are bringing your ship to Ithaca, but steal a march upon them,
+for after all this there is no trusting women. But now tell me, and
+tell me true, can you give me any news of my son Orestes? Is he in
+Orchomenus, or at Pylos, or is he at Sparta with Menelaus--for I presume
+that he is still living.'
+
+"And I said, 'Agamemnon, why do you ask me? I do not know whether your
+son is alive or dead, and it is not right to talk when one does not
+know.'
+
+"As we two sat weeping and talking thus sadly with one another the ghost
+of Achilles came up to us with Patroclus, Antilochus, and Ajax who was
+the finest and goodliest man of all the Danaans after the son of Peleus.
+The fleet descendant of Aeacus knew me and spoke piteously, saying,
+'Ulysses, noble son of Laertes, what deed of daring will you undertake
+next, that you venture down to the house of Hades among us silly dead,
+who are but the ghosts of them that can labour no more?'
+
+"And I said, 'Achilles, son of Peleus, foremost champion of the
+Achaeans, I came to consult Teiresias, and see if he could advise me
+about my return home to Ithaca, for I have never yet been able to get
+near the Achaean land, nor to set foot in my own country, but have been
+in trouble all the time. As for you, Achilles, no one was ever yet so
+fortunate as you have been, nor ever will be, for you were adored by all
+us Argives as long as you were alive, and now that you are here you are
+a great prince among the dead. Do not, therefore, take it so much to
+heart even if you are dead.'
+
+"'Say not a word,' he answered, 'in death's favour; I would rather be
+a paid servant in a poor man's house and be above ground than king of
+kings among the dead. But give me news about my son; is he gone to the
+wars and will he be a great soldier, or is this not so? Tell me also if
+you have heard anything about my father Peleus--does he still rule among
+the Myrmidons, or do they show him no respect throughout Hellas and
+Phthia now that he is old and his limbs fail him? Could I but stand by
+his side, in the light of day, with the same strength that I had when I
+killed the bravest of our foes upon the plain of Troy--could I but be
+as I then was and go even for a short time to my father's house, any one
+who tried to do him violence or supersede him would soon rue it.'
+
+"'I have heard nothing,' I answered, 'of Peleus, but I can tell you all
+about your son Neoptolemus, for I took him in my own ship from Scyros
+with the Achaeans. In our councils of war before Troy he was always
+first to speak, and his judgement was unerring. Nestor and I were the
+only two who could surpass him; and when it came to fighting on the
+plain of Troy, he would never remain with the body of his men, but would
+dash on far in front, foremost of them all in valour. Many a man did
+he kill in battle--I cannot name every single one of those whom he slew
+while fighting on the side of the Argives, but will only say how
+he killed that valiant hero Eurypylus son of Telephus, who was the
+handsomest man I ever saw except Memnon; many others also of the
+Ceteians fell around him by reason of a woman's bribes. Moreover, when
+all the bravest of the Argives went inside the horse that Epeus had
+made, and it was left to me to settle when we should either open the
+door of our ambuscade, or close it, though all the other leaders and
+chief men among the Danaans were drying their eyes and quaking in every
+limb, I never once saw him turn pale nor wipe a tear from his cheek;
+he was all the time urging me to break out from the horse--grasping
+the handle of his sword and his bronze-shod spear, and breathing fury
+against the foe. Yet when we had sacked the city of Priam he got his
+handsome share of the prize money and went on board (such is the fortune
+of war) without a wound upon him, neither from a thrown spear nor in
+close combat, for the rage of Mars is a matter of great chance.'
+
+"When I had told him this, the ghost of Achilles strode off across a
+meadow full of asphodel, exulting over what I had said concerning the
+prowess of his son.
+
+"The ghosts of other dead men stood near me and told me each his own
+melancholy tale; but that of Ajax son of Telamon alone held aloof--still
+angry with me for having won the cause in our dispute about the armour
+of Achilles. Thetis had offered it as a prize, but the Trojan prisoners
+and Minerva were the judges. Would that I had never gained the day in
+such a contest, for it cost the life of Ajax, who was foremost of all
+the Danaans after the son of Peleus, alike in stature and prowess.
+
+"When I saw him I tried to pacify him and said, 'Ajax, will you not
+forget and forgive even in death, but must the judgement about that
+hateful armour still rankle with you? It cost us Argives dear enough to
+lose such a tower of strength as you were to us. We mourned you as much
+as we mourned Achilles son of Peleus himself, nor can the blame be laid
+on anything but on the spite which Jove bore against the Danaans, for it
+was this that made him counsel your destruction--come hither, therefore,
+bring your proud spirit into subjection, and hear what I can tell you.'
+
+"He would not answer, but turned away to Erebus and to the other ghosts;
+nevertheless, I should have made him talk to me in spite of his being
+so angry, or I should have gone on talking to him, {97} only that there
+were still others among the dead whom I desired to see.
+
+"Then I saw Minos son of Jove with his golden sceptre in his hand
+sitting in judgement on the dead, and the ghosts were gathered sitting
+and standing round him in the spacious house of Hades, to learn his
+sentences upon them.
+
+"After him I saw huge Orion in a meadow full of asphodel driving the
+ghosts of the wild beasts that he had killed upon the mountains, and he
+had a great bronze club in his hand, unbreakable for ever and ever.
+
+"And I saw Tityus son of Gaia stretched upon the plain and covering some
+nine acres of ground. Two vultures on either side of him were digging
+their beaks into his liver, and he kept on trying to beat them off with
+his hands, but could not; for he had violated Jove's mistress Leto as
+she was going through Panopeus on her way to Pytho.
+
+"I saw also the dreadful fate of Tantalus, who stood in a lake that
+reached his chin; he was dying to quench his thirst, but could never
+reach the water, for whenever the poor creature stooped to drink, it
+dried up and vanished, so that there was nothing but dry ground--parched
+by the spite of heaven. There were tall trees, moreover, that shed their
+fruit over his head--pears, pomegranates, apples, sweet figs and juicy
+olives, but whenever the poor creature stretched out his hand to take
+some, the wind tossed the branches back again to the clouds.
+
+"And I saw Sisyphus at his endless task raising his prodigious stone
+with both his hands. With hands and feet he tried to roll it up to the
+top of the hill, but always, just before he could roll it over on to the
+other side, its weight would be too much for him, and the pitiless stone
+{98} would come thundering down again on to the plain. Then he would
+begin trying to push it up hill again, and the sweat ran off him and the
+steam rose after him.
+
+"After him I saw mighty Hercules, but it was his phantom only, for he is
+feasting ever with the immortal gods, and has lovely Hebe to wife, who
+is daughter of Jove and Juno. The ghosts were screaming round him like
+scared birds flying all whithers. He looked black as night with his bare
+bow in his hands and his arrow on the string, glaring around as though
+ever on the point of taking aim. About his breast there was a wondrous
+golden belt adorned in the most marvellous fashion with bears, wild
+boars, and lions with gleaming eyes; there was also war, battle, and
+death. The man who made that belt, do what he might, would never be able
+to make another like it. Hercules knew me at once when he saw me, and
+spoke piteously, saying, 'My poor Ulysses, noble son of Laertes, are
+you too leading the same sorry kind of life that I did when I was above
+ground? I was son of Jove, but I went through an infinity of suffering,
+for I became bondsman to one who was far beneath me--a low fellow
+who set me all manner of labours. He once sent me here to fetch the
+hell-hound--for he did not think he could find anything harder for me
+than this, but I got the hound out of Hades and brought him to him, for
+Mercury and Minerva helped me.'
+
+"On this Hercules went down again into the house of Hades, but I stayed
+where I was in case some other of the mighty dead should come to me.
+And I should have seen still other of them that are gone before, whom
+I would fain have seen--Theseus and Pirithous--glorious children of the
+gods, but so many thousands of ghosts came round me and uttered such
+appalling cries, that I was panic stricken lest Proserpine should send
+up from the house of Hades the head of that awful monster Gorgon. On
+this I hastened back to my ship and ordered my men to go on board at
+once and loose the hawsers; so they embarked and took their places,
+whereon the ship went down the stream of the river Oceanus. We had to
+row at first, but presently a fair wind sprang up.
+
+
+Book XII
+
+THE SIRENS, SCYLLA AND CHARYBDIS, THE CATTLE OF THE SUN.
+
+"After we were clear of the river Oceanus, and had got out into the open
+sea, we went on till we reached the Aeaean island where there is dawn
+and sun-rise as in other places. We then drew our ship on to the sands
+and got out of her on to the shore, where we went to sleep and waited
+till day should break.
+
+"Then, when the child of morning, rosy-fingered Dawn, appeared, I sent
+some men to Circe's house to fetch the body of Elpenor. We cut firewood
+from a wood where the headland jutted out into the sea, and after we had
+wept over him and lamented him we performed his funeral rites. When his
+body and armour had been burned to ashes, we raised a cairn, set a stone
+over it, and at the top of the cairn we fixed the oar that he had been
+used to row with.
+
+"While we were doing all this, Circe, who knew that we had got back from
+the house of Hades, dressed herself and came to us as fast as she could;
+and her maid servants came with her bringing us bread, meat, and wine.
+Then she stood in the midst of us and said, 'You have done a bold thing
+in going down alive to the house of Hades, and you will have died twice,
+to other people's once; now, then, stay here for the rest of the
+day, feast your fill, and go on with your voyage at daybreak tomorrow
+morning. In the meantime I will tell Ulysses about your course, and
+will explain everything to him so as to prevent your suffering from
+misadventure either by land or sea.'
+
+"We agreed to do as she had said, and feasted through the livelong day
+to the going down of the sun, but when the sun had set and it came on
+dark, the men laid themselves down to sleep by the stern cables of the
+ship. Then Circe took me by the hand and bade me be seated away from
+the others, while she reclined by my side and asked me all about our
+adventures.
+
+"'So far so good,' said she, when I had ended my story, 'and now pay
+attention to what I am about to tell you--heaven itself, indeed, will
+recall it to your recollection. First you will come to the Sirens who
+enchant all who come near them. If any one unwarily draws in too close
+and hears the singing of the Sirens, his wife and children will never
+welcome him home again, for they sit in a green field and warble him to
+death with the sweetness of their song. There is a great heap of dead
+men's bones lying all around, with the flesh still rotting off them.
+Therefore pass these Sirens by, and stop your men's ears with wax that
+none of them may hear; but if you like you can listen yourself, for you
+may get the men to bind you as you stand upright on a cross piece half
+way up the mast, {99} and they must lash the rope's ends to the mast
+itself, that you may have the pleasure of listening. If you beg and pray
+the men to unloose you, then they must bind you faster.
+
+"'When your crew have taken you past these Sirens, I cannot give you
+coherent directions {100} as to which of two courses you are to take; I
+will lay the two alternatives before you, and you must consider them for
+yourself. On the one hand there are some overhanging rocks against which
+the deep blue waves of Amphitrite beat with terrific fury; the blessed
+gods call these rocks the Wanderers. Here not even a bird may pass, no,
+not even the timid doves that bring ambrosia to Father Jove, but the
+sheer rock always carries off one of them, and Father Jove has to send
+another to make up their number; no ship that ever yet came to these
+rocks has got away again, but the waves and whirlwinds of fire are
+freighted with wreckage and with the bodies of dead men. The only vessel
+that ever sailed and got through, was the famous Argo on her way from
+the house of Aetes, and she too would have gone against these great
+rocks, only that Juno piloted her past them for the love she bore to
+Jason.
+
+"'Of these two rocks the one reaches heaven and its peak is lost in a
+dark cloud. This never leaves it, so that the top is never clear not
+even in summer and early autumn. No man though he had twenty hands and
+twenty feet could get a foothold on it and climb it, for it runs sheer
+up, as smooth as though it had been polished. In the middle of it there
+is a large cavern, looking West and turned towards Erebus; you must
+take your ship this way, but the cave is so high up that not even the
+stoutest archer could send an arrow into it. Inside it Scylla sits and
+yelps with a voice that you might take to be that of a young hound, but
+in truth she is a dreadful monster and no one--not even a god--could
+face her without being terror-struck. She has twelve mis-shapen feet,
+and six necks of the most prodigious length; and at the end of each neck
+she has a frightful head with three rows of teeth in each, all set very
+close together, so that they would crunch any one to death in a moment,
+and she sits deep within her shady cell thrusting out her heads and
+peering all round the rock, fishing for dolphins or dogfish or
+any larger monster that she can catch, of the thousands with which
+Amphitrite teems. No ship ever yet got past her without losing some men,
+for she shoots out all her heads at once, and carries off a man in each
+mouth.
+
+"'You will find the other rock lie lower, but they are so close together
+that there is not more than a bow-shot between them. [A large fig
+tree in full leaf {101} grows upon it], and under it lies the sucking
+whirlpool of Charybdis. Three times in the day does she vomit forth her
+waters, and three times she sucks them down again; see that you be not
+there when she is sucking, for if you are, Neptune himself could not
+save you; you must hug the Scylla side and drive ship by as fast as you
+can, for you had better lose six men than your whole crew.'
+
+"'Is there no way,' said I, 'of escaping Charybdis, and at the same time
+keeping Scylla off when she is trying to harm my men?'
+
+"'You dare devil,' replied the goddess, 'you are always wanting to fight
+somebody or something; you will not let yourself be beaten even by the
+immortals. For Scylla is not mortal; moreover she is savage, extreme,
+rude, cruel and invincible. There is no help for it; your best chance
+will be to get by her as fast as ever you can, for if you dawdle about
+her rock while you are putting on your armour, she may catch you with
+a second cast of her six heads, and snap up another half dozen of your
+men; so drive your ship past her at full speed, and roar out lustily to
+Crataiis who is Scylla's dam, bad luck to her; she will then stop her
+from making a second raid upon you.'
+
+"'You will now come to the Thrinacian island, and here you will see
+many herds of cattle and flocks of sheep belonging to the sun-god--seven
+herds of cattle and seven flocks of sheep, with fifty head in each
+flock. They do not breed, nor do they become fewer in number, and they
+are tended by the goddesses Phaethusa and Lampetie, who are children of
+the sun-god Hyperion by Neaera. Their mother when she had borne them and
+had done suckling them sent them to the Thrinacian island, which was
+a long way off, to live there and look after their father's flocks and
+herds. If you leave these flocks unharmed, and think of nothing but
+getting home, you may yet after much hardship reach Ithaca; but if you
+harm them, then I forewarn you of the destruction both of your ship
+and of your comrades; and even though you may yourself escape, you will
+return late, in bad plight, after losing all your men.'
+
+"Here she ended, and dawn enthroned in gold began to show in heaven,
+whereon she returned inland. I then went on board and told my men to
+loose the ship from her moorings; so they at once got into her, took
+their places, and began to smite the grey sea with their oars. Presently
+the great and cunning goddess Circe befriended us with a fair wind
+that blew dead aft, and staid steadily with us, keeping our sails well
+filled, so we did whatever wanted doing to the ship's gear, and let her
+go as wind and helmsman headed her.
+
+"Then, being much troubled in mind, I said to my men, 'My friends, it
+is not right that one or two of us alone should know the prophecies that
+Circe has made me, I will therefore tell you about them, so that whether
+we live or die we may do so with our eyes open. First she said we were
+to keep clear of the Sirens, who sit and sing most beautifully in a
+field of flowers; but she said I might hear them myself so long as no
+one else did. Therefore, take me and bind me to the crosspiece half
+way up the mast; bind me as I stand upright, with a bond so fast that I
+cannot possibly break away, and lash the rope's ends to the mast itself.
+If I beg and pray you to set me free, then bind me more tightly still.'
+
+"I had hardly finished telling everything to the men before we
+reached the island of the two Sirens, {102} for the wind had been very
+favourable. Then all of a sudden it fell dead calm; there was not a
+breath of wind nor a ripple upon the water, so the men furled the sails
+and stowed them; then taking to their oars they whitened the water with
+the foam they raised in rowing. Meanwhile I look a large wheel of wax
+and cut it up small with my sword. Then I kneaded the wax in my strong
+hands till it became soft, which it soon did between the kneading and
+the rays of the sun-god son of Hyperion. Then I stopped the ears of all
+my men, and they bound me hands and feet to the mast as I stood upright
+on the cross piece; but they went on rowing themselves. When we had got
+within earshot of the land, and the ship was going at a good rate, the
+Sirens saw that we were getting in shore and began with their singing.
+
+"'Come here,' they sang, 'renowned Ulysses, honour to the Achaean name,
+and listen to our two voices. No one ever sailed past us without staying
+to hear the enchanting sweetness of our song--and he who listens will
+go on his way not only charmed, but wiser, for we know all the ills that
+the gods laid upon the Argives and Trojans before Troy, and can tell you
+everything that is going to happen over the whole world.'
+
+"They sang these words most musically, and as I longed to hear them
+further I made signs by frowning to my men that they should set me free;
+but they quickened their stroke, and Eurylochus and Perimedes bound me
+with still stronger bonds till we had got out of hearing of the Sirens'
+voices. Then my men took the wax from their ears and unbound me.
+
+"Immediately after we had got past the island I saw a great wave from
+which spray was rising, and I heard a loud roaring sound. The men were
+so frightened that they loosed hold of their oars, for the whole sea
+resounded with the rushing of the waters, {103} but the ship stayed
+where it was, for the men had left off rowing. I went round, therefore,
+and exhorted them man by man not to lose heart.
+
+"'My friends,' said I, 'this is not the first time that we have been
+in danger, and we are in nothing like so bad a case as when the Cyclops
+shut us up in his cave; nevertheless, my courage and wise counsel
+saved us then, and we shall live to look back on all this as well. Now,
+therefore, let us all do as I say, trust in Jove and row on with might
+and main. As for you, coxswain, these are your orders; attend to them,
+for the ship is in your hands; turn her head away from these steaming
+rapids and hug the rock, or she will give you the slip and be over
+yonder before you know where you are, and you will be the death of us.'
+
+"So they did as I told them; but I said nothing about the awful monster
+Scylla, for I knew the men would not go on rowing if I did, but would
+huddle together in the hold. In one thing only did I disobey Circe's
+strict instructions--I put on my armour. Then seizing two strong spears
+I took my stand on the ship's bows, for it was there that I expected
+first to see the monster of the rock, who was to do my men so much harm;
+but I could not make her out anywhere, though I strained my eyes with
+looking the gloomy rock all over and over.
+
+"Then we entered the Straits in great fear of mind, for on the one hand
+was Scylla, and on the other dread Charybdis kept sucking up the salt
+water. As she vomited it up, it was like the water in a cauldron when it
+is boiling over upon a great fire, and the spray reached the top of the
+rocks on either side. When she began to suck again, we could see the
+water all inside whirling round and round, and it made a deafening sound
+as it broke against the rocks. We could see the bottom of the whirlpool
+all black with sand and mud, and the men were at their wits ends for
+fear. While we were taken up with this, and were expecting each moment
+to be our last, Scylla pounced down suddenly upon us and snatched up my
+six best men. I was looking at once after both ship and men, and in a
+moment I saw their hands and feet ever so high above me, struggling in
+the air as Scylla was carrying them off, and I heard them call out my
+name in one last despairing cry. As a fisherman, seated, spear in hand,
+upon some jutting rock {104} throws bait into the water to deceive the
+poor little fishes, and spears them with the ox's horn with which his
+spear is shod, throwing them gasping on to the land as he catches them
+one by one--even so did Scylla land these panting creatures on her
+rock and munch them up at the mouth of her den, while they screamed and
+stretched out their hands to me in their mortal agony. This was the most
+sickening sight that I saw throughout all my voyages.
+
+"When we had passed the [Wandering] rocks, with Scylla and terrible
+Charybdis, we reached the noble island of the sun-god, where were the
+goodly cattle and sheep belonging to the sun Hyperion. While still at
+sea in my ship I could bear the cattle lowing as they came home to the
+yards, and the sheep bleating. Then I remembered what the blind Theban
+prophet Teiresias had told me, and how carefully Aeaean Circe had warned
+me to shun the island of the blessed sun-god. So being much troubled I
+said to the men, 'My men, I know you are hard pressed, but listen while
+I tell you the prophecy that Teiresias made me, and how carefully Aeaean
+Circe warned me to shun the island of the blessed sun-god, for it
+was here, she said, that our worst danger would lie. Head the ship,
+therefore, away from the island.'
+
+"The men were in despair at this, and Eurylochus at once gave me an
+insolent answer. 'Ulysses,' said he, 'you are cruel; you are very strong
+yourself and never get worn out; you seem to be made of iron, and now,
+though your men are exhausted with toil and want of sleep, you will not
+let them land and cook themselves a good supper upon this island, but
+bid them put out to sea and go faring fruitlessly on through the watches
+of the flying night. It is by night that the winds blow hardest and do
+so much damage; how can we escape should one of those sudden squalls
+spring up from South West or West, which so often wreck a vessel when
+our lords the gods are unpropitious? Now, therefore, let us obey the
+behests of night and prepare our supper here hard by the ship; to-morrow
+morning we will go on board again and put out to sea.'
+
+"Thus spoke Eurylochus, and the men approved his words. I saw that
+heaven meant us a mischief and said, 'You force me to yield, for you are
+many against one, but at any rate each one of you must take his solemn
+oath that if he meet with a herd of cattle or a large flock of sheep,
+he will not be so mad as to kill a single head of either, but will be
+satisfied with the food that Circe has given us.'
+
+"They all swore as I bade them, and when they had completed their oath
+we made the ship fast in a harbour that was near a stream of fresh
+water, and the men went ashore and cooked their suppers. As soon as they
+had had enough to eat and drink, they began talking about their poor
+comrades whom Scylla had snatched up and eaten; this set them weeping
+and they went on crying till they fell off into a sound sleep.
+
+"In the third watch of the night when the stars had shifted their
+places, Jove raised a great gale of wind that flew a hurricane so that
+land and sea were covered with thick clouds, and night sprang forth out
+of the heavens. When the child of morning, rosy-fingered Dawn, appeared,
+we brought the ship to land and drew her into a cave wherein the
+sea-nymphs hold their courts and dances, and I called the men together
+in council.
+
+"'My friends,' said I, 'we have meat and drink in the ship, let us mind,
+therefore, and not touch the cattle, or we shall suffer for it; for
+these cattle and sheep belong to the mighty sun, who sees and gives ear
+to everything.' And again they promised that they would obey.
+
+"For a whole month the wind blew steadily from the South, and there was
+no other wind, but only South and East. {105} As long as corn and wine
+held out the men did not touch the cattle when they were hungry; when,
+however, they had eaten all there was in the ship, they were forced
+to go further afield, with hook and line, catching birds, and taking
+whatever they could lay their hands on; for they were starving. One day,
+therefore, I went up inland that I might pray heaven to show me some
+means of getting away. When I had gone far enough to be clear of all
+my men, and had found a place that was well sheltered from the wind,
+I washed my hands and prayed to all the gods in Olympus till by and by
+they sent me off into a sweet sleep.
+
+"Meanwhile Eurylochus had been giving evil counsel to the men, 'Listen
+to me,' said he, 'my poor comrades. All deaths are bad enough but there
+is none so bad as famine. Why should not we drive in the best of these
+cows and offer them in sacrifice to the immortal gods? If we ever get
+back to Ithaca, we can build a fine temple to the sun-god and enrich it
+with every kind of ornament; if, however, he is determined to sink our
+ship out of revenge for these homed cattle, and the other gods are of
+the same mind, I for one would rather drink salt water once for all and
+have done with it, than be starved to death by inches in such a desert
+island as this is.'
+
+"Thus spoke Eurylochus, and the men approved his words. Now the cattle,
+so fair and goodly, were feeding not far from the ship; the men,
+therefore, drove in the best of them, and they all stood round them
+saying their prayers, and using young oak-shoots instead of barley-meal,
+for there was no barley left. When they had done praying they killed the
+cows and dressed their carcasses; they cut out the thigh bones, wrapped
+them round in two layers of fat, and set some pieces of raw meat on top
+of them. They had no wine with which to make drink-offerings over the
+sacrifice while it was cooking, so they kept pouring on a little water
+from time to time while the inward meats were being grilled; then, when
+the thigh bones were burned and they had tasted the inward meats, they
+cut the rest up small and put the pieces upon the spits.
+
+"By this time my deep sleep had left me, and I turned back to the ship
+and to the sea shore. As I drew near I began to smell hot roast meat, so
+I groaned out a prayer to the immortal gods. 'Father Jove,' I exclaimed,
+'and all you other gods who live in everlasting bliss, you have done me
+a cruel mischief by the sleep into which you have sent me; see what fine
+work these men of mine have been making in my absence.'
+
+"Meanwhile Lampetie went straight off to the sun and told him we had
+been killing his cows, whereon he flew into a great rage, and said
+to the immortals, 'Father Jove, and all you other gods who live in
+everlasting bliss, I must have vengeance on the crew of Ulysses' ship:
+they have had the insolence to kill my cows, which were the one thing I
+loved to look upon, whether I was going up heaven or down again. If they
+do not square accounts with me about my cows, I will go down to Hades
+and shine there among the dead.'
+
+"'Sun,' said Jove, 'go on shining upon us gods and upon mankind over the
+fruitful earth. I will shiver their ship into little pieces with a bolt
+of white lightning as soon as they get out to sea.'
+
+"I was told all this by Calypso, who said she had heard it from the
+mouth of Mercury.
+
+"As soon as I got down to my ship and to the sea shore I rebuked each
+one of the men separately, but we could see no way out of it, for the
+cows were dead already. And indeed the gods began at once to show signs
+and wonders among us, for the hides of the cattle crawled about, and
+the joints upon the spits began to low like cows, and the meat, whether
+cooked or raw, kept on making a noise just as cows do.
+
+"For six days my men kept driving in the best cows and feasting upon
+them, but when Jove the son of Saturn had added a seventh day, the fury
+of the gale abated; we therefore went on board, raised our masts, spread
+sail, and put out to sea. As soon as we were well away from the island,
+and could see nothing but sky and sea, the son of Saturn raised a black
+cloud over our ship, and the sea grew dark beneath it. We did not get on
+much further, for in another moment we were caught by a terrific squall
+from the West that snapped the forestays of the mast so that it fell
+aft, while all the ship's gear tumbled about at the bottom of the
+vessel. The mast fell upon the head of the helmsman in the ship's
+stern, so that the bones of his head were crushed to pieces, and he fell
+overboard as though he were diving, with no more life left in him.
+
+"Then Jove let fly with his thunderbolts, and the ship went round and
+round, and was filled with fire and brimstone as the lightning struck
+it. The men all fell into the sea; they were carried about in the water
+round the ship, looking like so many sea-gulls, but the god presently
+deprived them of all chance of getting home again.
+
+"I stuck to the ship till the sea knocked her sides from her keel (which
+drifted about by itself) and struck the mast out of her in the direction
+of the keel; but there was a backstay of stout ox-thong still hanging
+about it, and with this I lashed the mast and keel together, and getting
+astride of them was carried wherever the winds chose to take me.
+
+"[The gale from the West had now spent its force, and the wind got into
+the South again, which frightened me lest I should be taken back to the
+terrible whirlpool of Charybdis. This indeed was what actually happened,
+for I was borne along by the waves all night, and by sunrise had reached
+the rock of Scylla, and the whirlpool. She was then sucking down the
+salt sea water, {106} but I was carried aloft toward the fig tree, which
+I caught hold of and clung on to like a bat. I could not plant my feet
+anywhere so as to stand securely, for the roots were a long way off and
+the boughs that overshadowed the whole pool were too high, too vast, and
+too far apart for me to reach them; so I hung patiently on, waiting till
+the pool should discharge my mast and raft again--and a very long while
+it seemed. A jury-man is not more glad to get home to supper, after
+having been long detained in court by troublesome cases, than I was to
+see my raft beginning to work its way out of the whirlpool again. At
+last I let go with my hands and feet, and fell heavily into the sea,
+hard by my raft on to which I then got, and began to row with my hands.
+As for Scylla, the father of gods and men would not let her get further
+sight of me--otherwise I should have certainly been lost.] {107}
+
+"Hence I was carried along for nine days till on the tenth night the
+gods stranded me on the Ogygian island, where dwells the great and
+powerful goddess Calypso. She took me in and was kind to me, but I need
+say no more about this, for I told you and your noble wife all about it
+yesterday, and I hate saying the same thing over and over again."
+
+
+Book XIII
+
+ULYSSES LEAVES SCHERIA AND RETURNS TO ITHACA.
+
+Thus did he speak, and they all held their peace throughout the covered
+cloister, enthralled by the charm of his story, till presently Alcinous
+began to speak.
+
+"Ulysses," said he, "now that you have reached my house I doubt not you
+will get home without further misadventure no matter how much you have
+suffered in the past. To you others, however, who come here night after
+night to drink my choicest wine and listen to my bard, I would insist
+as follows. Our guest has already packed up the clothes, wrought gold,
+{108} and other valuables which you have brought for his acceptance;
+let us now, therefore, present him further, each one of us, with a large
+tripod and a cauldron. We will recoup ourselves by the levy of a general
+rate; for private individuals cannot be expected to bear the burden of
+such a handsome present."
+
+Every one approved of this, and then they went home to bed each in his
+own abode. When the child of morning, rosy-fingered Dawn, appeared they
+hurried down to the ship and brought their cauldrons with them. Alcinous
+went on board and saw everything so securely stowed under the ship's
+benches that nothing could break adrift and injure the rowers. Then they
+went to the house of Alcinous to get dinner, and he sacrificed a bull
+for them in honour of Jove who is the lord of all. They set the steaks
+to grill and made an excellent dinner, after which the inspired bard,
+Demodocus, who was a favourite with every one, sang to them; but Ulysses
+kept on turning his eyes towards the sun, as though to hasten his
+setting, for he was longing to be on his way. As one who has been all
+day ploughing a fallow field with a couple of oxen keeps thinking about
+his supper and is glad when night comes that he may go and get it, for
+it is all his legs can do to carry him, even so did Ulysses rejoice when
+the sun went down, and he at once said to the Phaeacians, addressing
+himself more particularly to King Alcinous:
+
+"Sir, and all of you, farewell. Make your drink-offerings and send me on
+my way rejoicing, for you have fulfilled my heart's desire by giving me
+an escort, and making me presents, which heaven grant that I may turn
+to good account; may I find my admirable wife living in peace among
+friends, {109} and may you whom I leave behind me give satisfaction
+to your wives and children; {110} may heaven vouchsafe you every good
+grace, and may no evil thing come among your people."
+
+Thus did he speak. His hearers all of them approved his saying and
+agreed that he should have his escort inasmuch as he had spoken
+reasonably. Alcinous therefore said to his servant, "Pontonous, mix
+some wine and hand it round to everybody, that we may offer a prayer to
+father Jove, and speed our guest upon his way."
+
+Pontonous mixed the wine and handed it to every one in turn; the others
+each from his own seat made a drink-offering to the blessed gods that
+live in heaven, but Ulysses rose and placed the double cup in the hands
+of queen Arete.
+
+"Farewell, queen," said he, "henceforward and for ever, till age and
+death, the common lot of mankind, lay their hands upon you. I now take
+my leave; be happy in this house with your children, your people, and
+with king Alcinous."
+
+As he spoke he crossed the threshold, and Alcinous sent a man to conduct
+him to his ship and to the sea shore. Arete also sent some maidservants
+with him--one with a clean shirt and cloak, another to carry his strong
+box, and a third with corn and wine. When they got to the water side
+the crew took these things and put them on board, with all the meat and
+drink; but for Ulysses they spread a rug and a linen sheet on deck that
+he might sleep soundly in the stern of the ship. Then he too went on
+board and lay down without a word, but the crew took every man his place
+and loosed the hawser from the pierced stone to which it had been bound.
+Thereon, when they began rowing out to sea, Ulysses fell into a deep,
+sweet, and almost deathlike slumber. {111}
+
+The ship bounded forward on her way as a four in hand chariot flies over
+the course when the horses feel the whip. Her prow curvetted as it were
+the neck of a stallion, and a great wave of dark blue water seethed in
+her wake. She held steadily on her course, and even a falcon, swiftest
+of all birds, could not have kept pace with her. Thus, then, she cut her
+way through the water, carrying one who was as cunning as the gods, but
+who was now sleeping peacefully, forgetful of all that he had suffered
+both on the field of battle and by the waves of the weary sea.
+
+When the bright star that heralds the approach of dawn began to show,
+the ship drew near to land. {112} Now there is in Ithaca a haven of the
+old merman Phorcys, which lies between two points that break the line
+of the sea and shut the harbour in. These shelter it from the storms of
+wind and sea that rage outside, so that, when once within it, a ship may
+lie without being even moored. At the head of this harbour there is a
+large olive tree, and at no great distance a fine overarching cavern
+sacred to the nymphs who are called Naiads. {113} There are mixing bowls
+within it and wine-jars of stone, and the bees hive there. Moreover,
+there are great looms of stone on which the nymphs weave their robes of
+sea purple--very curious to see--and at all times there is water within
+it. It has two entrances, one facing North by which mortals can go
+down into the cave, while the other comes from the South and is more
+mysterious; mortals cannot possibly get in by it, it is the way taken by
+the gods.
+
+Into this harbour, then, they took their ship, for they knew the place.
+{114} She had so much way upon her that she ran half her own length on
+to the shore; {115} when, however, they had landed, the first thing they
+did was to lift Ulysses with his rug and linen sheet out of the ship,
+and lay him down upon the sand still fast asleep. Then they took out the
+presents which Minerva had persuaded the Phaeacians to give him when he
+was setting out on his voyage homewards. They put these all together by
+the root of the olive tree, away from the road, for fear some passer by
+{116} might come and steal them before Ulysses awoke; and then they made
+the best of their way home again.
+
+But Neptune did not forget the threats with which he had already
+threatened Ulysses, so he took counsel with Jove. "Father Jove," said
+he, "I shall no longer be held in any sort of respect among you gods, if
+mortals like the Phaeacians, who are my own flesh and blood, show such
+small regard for me. I said I would let Ulysses get home when he had
+suffered sufficiently. I did not say that he should never get home at
+all, for I knew you had already nodded your head about it, and promised
+that he should do so; but now they have brought him in a ship fast
+asleep and have landed him in Ithaca after loading him with more
+magnificent presents of bronze, gold, and raiment than he would ever
+have brought back from Troy, if he had had his share of the spoil and
+got home without misadventure."
+
+And Jove answered, "What, O Lord of the Earthquake, are you talking
+about? The gods are by no means wanting in respect for you. It would
+be monstrous were they to insult one so old and honoured as you are. As
+regards mortals, however, if any of them is indulging in insolence and
+treating you disrespectfully, it will always rest with yourself to deal
+with him as you may think proper, so do just as you please."
+
+"I should have done so at once," replied Neptune, "if I were not anxious
+to avoid anything that might displease you; now, therefore, I should
+like to wreck the Phaeacian ship as it is returning from its escort.
+This will stop them from escorting people in future; and I should also
+like to bury their city under a huge mountain."
+
+"My good friend," answered Jove, "I should recommend you at the very
+moment when the people from the city are watching the ship on her way,
+to turn it into a rock near the land and looking like a ship. This
+will astonish everybody, and you can then bury their city under the
+mountain."
+
+When earth-encircling Neptune heard this he went to Scheria where the
+Phaeacians live, and stayed there till the ship, which was making rapid
+way, had got close in. Then he went up to it, turned it into stone, and
+drove it down with the flat of his hand so as to root it in the ground.
+After this he went away.
+
+The Phaeacians then began talking among themselves, and one would turn
+towards his neighbour, saying, "Bless my heart, who is it that can have
+rooted the ship in the sea just as she was getting into port? We could
+see the whole of her only a moment ago."
+
+This was how they talked, but they knew nothing about it; and Alcinous
+said, "I remember now the old prophecy of my father. He said that
+Neptune would be angry with us for taking every one so safely over the
+sea, and would one day wreck a Phaeacian ship as it was returning from
+an escort, and bury our city under a high mountain. This was what my old
+father used to say, and now it is all coming true. {117} Now therefore
+let us all do as I say; in the first place we must leave off giving
+people escorts when they come here, and in the next let us sacrifice
+twelve picked bulls to Neptune that he may have mercy upon us, and not
+bury our city under the high mountain." When the people heard this they
+were afraid and got ready the bulls.
+
+Thus did the chiefs and rulers of the Phaeacians pray to king Neptune,
+standing round his altar; and at the same time {118} Ulysses woke up
+once more upon his own soil. He had been so long away that he did not
+know it again; moreover, Jove's daughter Minerva had made it a foggy
+day, so that people might not know of his having come, and that she
+might tell him everything without either his wife or his fellow citizens
+and friends recognising him {119} until he had taken his revenge upon
+the wicked suitors. Everything, therefore, seemed quite different to
+him--the long straight tracks, the harbours, the precipices, and the
+goodly trees, appeared all changed as he started up and looked upon his
+native land. So he smote his thighs with the flat of his hands and cried
+aloud despairingly.
+
+"Alas," he exclaimed, "among what manner of people am I fallen? Are they
+savage and uncivilised or hospitable and humane? Where shall I put all
+this treasure, and which way shall I go? I wish I had staid over there
+with the Phaeacians; or I could have gone to some other great chief who
+would have been good to me and given me an escort. As it is I do not
+know where to put my treasure, and I cannot leave it here for fear
+somebody else should get hold of it. In good truth the chiefs and rulers
+of the Phaeacians have not been dealing fairly by me, and have left me
+in the wrong country; they said they would take me back to Ithaca and
+they have not done so: may Jove the protector of suppliants chastise
+them, for he watches over everybody and punishes those who do wrong.
+Still, I suppose I must count my goods and see if the crew have gone off
+with any of them."
+
+He counted his goodly coppers and cauldrons, his gold and all his
+clothes, but there was nothing missing; still he kept grieving about not
+being in his own country, and wandered up and down by the shore of
+the sounding sea bewailing his hard fate. Then Minerva came up to him
+disguised as a young shepherd of delicate and princely mien, with a good
+cloak folded double about her shoulders; she had sandals on her comely
+feet and held a javelin in her hand. Ulysses was glad when he saw her,
+and went straight up to her.
+
+"My friend," said he, "you are the first person whom I have met with in
+this country; I salute you, therefore, and beg you to be well disposed
+towards me. Protect these my goods, and myself too, for I embrace your
+knees and pray to you as though you were a god. Tell me, then, and tell
+me truly, what land and country is this? Who are its inhabitants? Am I
+on an island, or is this the sea board of some continent?"
+
+Minerva answered, "Stranger, you must be very simple, or must have come
+from somewhere a long way off, not to know what country this is. It is
+a very celebrated place, and everybody knows it East and West. It is
+rugged and not a good driving country, but it is by no means a bad
+island for what there is of it. It grows any quantity of corn and also
+wine, for it is watered both by rain and dew; it breeds cattle also
+and goats; all kinds of timber grow here, and there are watering places
+where the water never runs dry; so, sir, the name of Ithaca is known
+even as far as Troy, which I understand to be a long way off from this
+Achaean country."
+
+Ulysses was glad at finding himself, as Minerva told him, in his own
+country, and he began to answer, but he did not speak the truth, and
+made up a lying story in the instinctive wiliness of his heart.
+
+"I heard of Ithaca," said he, "when I was in Crete beyond the seas, and
+now it seems I have reached it with all these treasures. I have left
+as much more behind me for my children, but am flying because I killed
+Orsilochus son of Idomeneus, the fleetest runner in Crete. I killed him
+because he wanted to rob me of the spoils I had got from Troy with so
+much trouble and danger both on the field of battle and by the waves of
+the weary sea; he said I had not served his father loyally at Troy as
+vassal, but had set myself up as an independent ruler, so I lay in wait
+for him with one of my followers by the road side, and speared him as
+he was coming into town from the country. It was a very dark night and
+nobody saw us; it was not known, therefore, that I had killed him, but
+as soon as I had done so I went to a ship and besought the owners, who
+were Phoenicians, to take me on board and set me in Pylos or in Elis
+where the Epeans rule, giving them as much spoil as satisfied them. They
+meant no guile, but the wind drove them off their course, and we sailed
+on till we came hither by night. It was all we could do to get inside
+the harbour, and none of us said a word about supper though we wanted it
+badly, but we all went on shore and lay down just as we were. I was very
+tired and fell asleep directly, so they took my goods out of the ship,
+and placed them beside me where I was lying upon the sand. Then they
+sailed away to Sidonia, and I was left here in great distress of mind."
+
+Such was his story, but Minerva smiled and caressed him with her hand.
+Then she took the form of a woman, fair, stately, and wise, "He must be
+indeed a shifty lying fellow," said she, "who could surpass you in all
+manner of craft even though you had a god for your antagonist. Dare
+devil that you are, full of guile, unwearying in deceit, can you not
+drop your tricks and your instinctive falsehood, even now that you are
+in your own country again? We will say no more, however, about this, for
+we can both of us deceive upon occasion--you are the most accomplished
+counsellor and orator among all mankind, while I for diplomacy and
+subtlety have no equal among the gods. Did you not know Jove's daughter
+Minerva--me, who have been ever with you, who kept watch over you in
+all your troubles, and who made the Phaeacians take so great a liking
+to you? And now, again, I am come here to talk things over with you, and
+help you to hide the treasure I made the Phaeacians give you; I want to
+tell you about the troubles that await you in your own house; you have
+got to face them, but tell no one, neither man nor woman, that you have
+come home again. Bear everything, and put up with every man's insolence,
+without a word."
+
+And Ulysses answered, "A man, goddess, may know a great deal, but you
+are so constantly changing your appearance that when he meets you it
+is a hard matter for him to know whether it is you or not. This much,
+however, I know exceedingly well; you were very kind to me as long as we
+Achaeans were fighting before Troy, but from the day on which we went on
+board ship after having sacked the city of Priam, and heaven dispersed
+us--from that day, Minerva, I saw no more of you, and cannot ever
+remember your coming to my ship to help me in a difficulty; I had to
+wander on sick and sorry till the gods delivered me from evil and I
+reached the city of the Phaeacians, where you encouraged me and took me
+into the town. {120} And now, I beseech you in your father's name, tell
+me the truth, for I do not believe I am really back in Ithaca. I am in
+some other country and you are mocking me and deceiving me in all you
+have been saying. Tell me then truly, have I really got back to my own
+country?"
+
+"You are always taking something of that sort in your head," replied
+Minerva, "and that is why I cannot desert you in your afflictions; you
+are so plausible, shrewd and shifty. Any one but yourself on returning
+from so long a voyage would at once have gone home to see his wife and
+children, but you do not seem to care about asking after them or hearing
+any news about them till you have exploited your wife, who remains at
+home vainly grieving for you, and having no peace night or day for the
+tears she sheds on your behalf. As for my not coming near you, I was
+never uneasy about you, for I was certain you would get back safely
+though you would lose all your men, and I did not wish to quarrel with
+my uncle Neptune, who never forgave you for having blinded his son.
+{121} I will now, however, point out to you the lie of the land, and
+you will then perhaps believe me. This is the haven of the old merman
+Phorcys, and here is the olive tree that grows at the head of it; [near
+it is the cave sacred to the Naiads;] {122} here too is the overarching
+cavern in which you have offered many an acceptable hecatomb to the
+nymphs, and this is the wooded mountain Neritum."
+
+As she spoke the goddess dispersed the mist and the land appeared. Then
+Ulysses rejoiced at finding himself again in his own land, and kissed
+the bounteous soil; he lifted up his hands and prayed to the nymphs,
+saying, "Naiad nymphs, daughters of Jove, I made sure that I was never
+again to see you, now therefore I greet you with all loving salutations,
+and I will bring you offerings as in the old days, if Jove's redoubtable
+daughter will grant me life, and bring my son to manhood."
+
+"Take heart, and do not trouble yourself about that," rejoined Minerva,
+"let us rather set about stowing your things at once in the cave, where
+they will be quite safe. Let us see how we can best manage it all."
+
+Therewith she went down into the cave to look for the safest hiding
+places, while Ulysses brought up all the treasure of gold, bronze, and
+good clothing which the Phaeacians had given him. They stowed everything
+carefully away, and Minerva set a stone against the door of the cave.
+Then the two sat down by the root of the great olive, and consulted how
+to compass the destruction of the wicked suitors.
+
+"Ulysses," said Minerva, "noble son of Laertes, think how you can lay
+hands on these disreputable people who have been lording it in your
+house these three years, courting your wife and making wedding presents
+to her, while she does nothing but lament your absence, giving hope and
+sending encouraging messages {123} to every one of them, but meaning the
+very opposite of all she says."
+
+And Ulysses answered, "In good truth, goddess, it seems I should have
+come to much the same bad end in my own house as Agamemnon did, if you
+had not given me such timely information. Advise me how I shall best
+avenge myself. Stand by my side and put your courage into my heart as on
+the day when we loosed Troy's fair diadem from her brow. Help me now as
+you did then, and I will fight three hundred men, if you, goddess, will
+be with me."
+
+"Trust me for that," said she, "I will not lose sight of you when once
+we set about it, and I imagine that some of those who are devouring your
+substance will then bespatter the pavement with their blood and brains.
+I will begin by disguising you so that no human being shall know you; I
+will cover your body with wrinkles; you shall lose all your yellow
+hair; I will clothe you in a garment that shall fill all who see it with
+loathing; I will blear your fine eyes for you, and make you an unseemly
+object in the sight of the suitors, of your wife, and of the son whom
+you left behind you. Then go at once to the swineherd who is in charge
+of your pigs; he has been always well affected towards you, and is
+devoted to Penelope and your son; you will find him feeding his pigs
+near the rock that is called Raven {124} by the fountain Arethusa, where
+they are fattening on beechmast and spring water after their manner.
+Stay with him and find out how things are going, while I proceed to
+Sparta and see your son, who is with Menelaus at Lacedaemon, where he
+has gone to try and find out whether you are still alive." {125}
+
+"But why," said Ulysses, "did you not tell him, for you knew all about
+it? Did you want him too to go sailing about amid all kinds of hardship
+while others are eating up his estate?"
+
+Minerva answered, "Never mind about him, I sent him that he might be
+well spoken of for having gone. He is in no sort of difficulty, but
+is staying quite comfortably with Menelaus, and is surrounded with
+abundance of every kind. The suitors have put out to sea and are lying
+in wait for him, for they mean to kill him before he can get home. I do
+not much think they will succeed, but rather that some of those who are
+now eating up your estate will first find a grave themselves."
+
+As she spoke Minerva touched him with her wand and covered him with
+wrinkles, took away all his yellow hair, and withered the flesh over his
+whole body; she bleared his eyes, which were naturally very fine ones;
+she changed his clothes and threw an old rag of a wrap about him, and a
+tunic, tattered, filthy, and begrimed with smoke; she also gave him an
+undressed deer skin as an outer garment, and furnished him with a staff
+and a wallet all in holes, with a twisted thong for him to sling it over
+his shoulder.
+
+When the pair had thus laid their plans they parted, and the goddess
+went straight to Lacedaemon to fetch Telemachus.
+
+
+Book XIV
+
+ULYSSES IN THE HUT WITH EUMAEUS.
+
+Ulysses now left the haven, and took the rough track up through the
+wooded country and over the crest of the mountain till he reached the
+place where Minerva had said that he would find the swineherd, who was
+the most thrifty servant he had. He found him sitting in front of his
+hut, which was by the yards that he had built on a site which could be
+seen from far. He had made them spacious {126} and fair to see, with
+a free run for the pigs all round them; he had built them during his
+master's absence, of stones which he had gathered out of the ground,
+without saying anything to Penelope or Laertes, and he had fenced them
+on top with thorn bushes. Outside the yard he had run a strong fence of
+oaken posts, split, and set pretty close together, while inside he had
+built twelve styes near one another for the sows to lie in. There were
+fifty pigs wallowing in each stye, all of them breeding sows; but the
+boars slept outside and were much fewer in number, for the suitors
+kept on eating them, and the swineherd had to send them the best he
+had continually. There were three hundred and sixty boar pigs, and the
+herdsman's four hounds, which were as fierce as wolves, slept always
+with them. The swineherd was at that moment cutting out a pair of
+sandals {127} from a good stout ox hide. Three of his men were out
+herding the pigs in one place or another, and he had sent the fourth to
+town with a boar that he had been forced to send the suitors that they
+might sacrifice it and have their fill of meat.
+
+When the hounds saw Ulysses they set up a furious barking and flew at
+him, but Ulysses was cunning enough to sit down and loose his hold of
+the stick that he had in his hand: still, he would have been torn by
+them in his own homestead had not the swineherd dropped his ox hide,
+rushed full speed through the gate of the yard and driven the dogs off
+by shouting and throwing stones at them. Then he said to Ulysses, "Old
+man, the dogs were likely to have made short work of you, and then you
+would have got me into trouble. The gods have given me quite enough
+worries without that, for I have lost the best of masters, and am in
+continual grief on his account. I have to attend swine for other people
+to eat, while he, if he yet lives to see the light of day, is starving
+in some distant land. But come inside, and when you have had your fill
+of bread and wine, tell me where you come from, and all about your
+misfortunes."
+
+On this the swineherd led the way into the hut and bade him sit down.
+He strewed a good thick bed of rushes upon the floor, and on the top of
+this he threw the shaggy chamois skin--a great thick one--on which he
+used to sleep by night. Ulysses was pleased at being made thus welcome,
+and said "May Jove, sir, and the rest of the gods grant you your heart's
+desire in return for the kind way in which you have received me."
+
+To this you answered, O swineherd Eumaeus, "Stranger, though a still
+poorer man should come here, it would not be right for me to insult him,
+for all strangers and beggars are from Jove. You must take what you
+can get and be thankful, for servants live in fear when they have young
+lords for their masters; and this is my misfortune now, for heaven has
+hindered the return of him who would have been always good to me and
+given me something of my own--a house, a piece of land, a good looking
+wife, and all else that a liberal master allows a servant who has worked
+hard for him, and whose labour the gods have prospered as they have mine
+in the situation which I hold. If my master had grown old here he would
+have done great things by me, but he is gone, and I wish that Helen's
+whole race were utterly destroyed, for she has been the death of many a
+good man. It was this matter that took my master to Ilius, the land of
+noble steeds, to fight the Trojans in the cause of king Agamemnon."
+
+As he spoke he bound his girdle round him and went to the styes where
+the young sucking pigs were penned. He picked out two which he brought
+back with him and sacrificed. He singed them, cut them up, and spitted
+them; when the meat was cooked he brought it all in and set it before
+Ulysses, hot and still on the spit, whereon Ulysses sprinkled it over
+with white barley meal. The swineherd then mixed wine in a bowl of
+ivy-wood, and taking a seat opposite Ulysses told him to begin.
+
+"Fall to, stranger," said he, "on a dish of servant's pork. The fat pigs
+have to go to the suitors, who eat them up without shame or scruple; but
+the blessed gods love not such shameful doings, and respect those who do
+what is lawful and right. Even the fierce freebooters who go raiding on
+other people's land, and Jove gives them their spoil--even they,
+when they have filled their ships and got home again live
+conscience-stricken, and look fearfully for judgement; but some god
+seems to have told these people that Ulysses is dead and gone; they
+will not, therefore, go back to their own homes and make their offers of
+marriage in the usual way, but waste his estate by force, without fear
+or stint. Not a day or night comes out of heaven, but they sacrifice not
+one victim nor two only, and they take the run of his wine, for he was
+exceedingly rich. No other great man either in Ithaca or on the mainland
+is as rich as he was; he had as much as twenty men put together. I will
+tell you what he had. There are twelve herds of cattle upon the main
+land, and as many flocks of sheep, there are also twelve droves of pigs,
+while his own men and hired strangers feed him twelve widely spreading
+herds of goats. Here in Ithaca he runs even large flocks of goats on
+the far end of the island, and they are in the charge of excellent goat
+herds. Each one of these sends the suitors the best goat in the flock
+every day. As for myself, I am in charge of the pigs that you see here,
+and I have to keep picking out the best I have and sending it to them."
+
+This was his story, but Ulysses went on eating and drinking ravenously
+without a word, brooding his revenge. When he had eaten enough and was
+satisfied, the swineherd took the bowl from which he usually drank,
+filled it with wine, and gave it to Ulysses, who was pleased, and said
+as he took it in his hands, "My friend, who was this master of yours
+that bought you and paid for you, so rich and so powerful as you tell
+me? You say he perished in the cause of King Agamemnon; tell me who he
+was, in case I may have met with such a person. Jove and the other gods
+know, but I may be able to give you news of him, for I have travelled
+much."
+
+Eumaeus answered, "Old man, no traveller who comes here with news will
+get Ulysses' wife and son to believe his story. Nevertheless, tramps in
+want of a lodging keep coming with their mouths full of lies, and not a
+word of truth; every one who finds his way to Ithaca goes to my mistress
+and tells her falsehoods, whereon she takes them in, makes much of them,
+and asks them all manner of questions, crying all the time as women will
+when they have lost their husbands. And you too, old man, for a shirt
+and a cloak would doubtless make up a very pretty story. But the wolves
+and birds of prey have long since torn Ulysses to pieces, or the fishes
+of the sea have eaten him, and his bones are lying buried deep in sand
+upon some foreign shore; he is dead and gone, and a bad business it is
+for all his friends--for me especially; go where I may I shall never
+find so good a master, not even if I were to go home to my mother and
+father where I was bred and born. I do not so much care, however, about
+my parents now, though I should dearly like to see them again in my own
+country; it is the loss of Ulysses that grieves me most; I cannot speak
+of him without reverence though he is here no longer, for he was very
+fond of me, and took such care of me that wherever he may be I shall
+always honour his memory."
+
+"My friend," replied Ulysses, "you are very positive, and very hard of
+belief about your master's coming home again, nevertheless I will not
+merely say, but will swear, that he is coming. Do not give me anything
+for my news till he has actually come, you may then give me a shirt and
+cloak of good wear if you will. I am in great want, but I will not take
+anything at all till then, for I hate a man, even as I hate hell fire,
+who lets his poverty tempt him into lying. I swear by king Jove, by the
+rites of hospitality, and by that hearth of Ulysses to which I have now
+come, that all will surely happen as I have said it will. Ulysses
+will return in this self same year; with the end of this moon and the
+beginning of the next he will be here to do vengeance on all those who
+are ill treating his wife and son."
+
+To this you answered, O swineherd Eumaeus, "Old man, you will neither
+get paid for bringing good news, nor will Ulysses ever come home; drink
+your wine in peace, and let us talk about something else. Do not keep on
+reminding me of all this; it always pains me when any one speaks about
+my honoured master. As for your oath we will let it alone, but I only
+wish he may come, as do Penelope, his old father Laertes, and his son
+Telemachus. I am terribly unhappy too about this same boy of his; he was
+running up fast into manhood, and bade fare to be no worse man, face
+and figure, than his father, but some one, either god or man, has been
+unsettling his mind, so he has gone off to Pylos to try and get news of
+his father, and the suitors are lying in wait for him as he is coming
+home, in the hope of leaving the house of Arceisius without a name in
+Ithaca. But let us say no more about him, and leave him to be taken, or
+else to escape if the son of Saturn holds his hand over him to protect
+him. And now, old man, tell me your own story; tell me also, for I want
+to know, who you are and where you come from. Tell me of your town
+and parents, what manner of ship you came in, how crew brought you to
+Ithaca, and from what country they professed to come--for you cannot
+have come by land."
+
+And Ulysses answered, "I will tell you all about it. If there were meat
+and wine enough, and we could stay here in the hut with nothing to do
+but to eat and drink while the others go to their work, I could easily
+talk on for a whole twelve months without ever finishing the story of
+the sorrows with which it has pleased heaven to visit me.
+
+"I am by birth a Cretan; my father was a well to do man, who had many
+sons born in marriage, whereas I was the son of a slave whom he had
+purchased for a concubine; nevertheless, my father Castor son of Hylax
+(whose lineage I claim, and who was held in the highest honour among the
+Cretans for his wealth, prosperity, and the valour of his sons) put me
+on the same level with my brothers who had been born in wedlock. When,
+however, death took him to the house of Hades, his sons divided his
+estate and cast lots for their shares, but to me they gave a holding
+and little else; nevertheless, my valour enabled me to marry into a rich
+family, for I was not given to bragging, or shirking on the field of
+battle. It is all over now; still, if you look at the straw you can see
+what the ear was, for I have had trouble enough and to spare. Mars and
+Minerva made me doughty in war; when I had picked my men to surprise the
+enemy with an ambuscade I never gave death so much as a thought, but was
+the first to leap forward and spear all whom I could overtake. Such was
+I in battle, but I did not care about farm work, nor the frugal home
+life of those who would bring up children. My delight was in ships,
+fighting, javelins, and arrows--things that most men shudder to think
+of; but one man likes one thing and another another, and this was what
+I was most naturally inclined to. Before the Achaeans went to Troy,
+nine times was I in command of men and ships on foreign service, and I
+amassed much wealth. I had my pick of the spoil in the first instance,
+and much more was allotted to me later on.
+
+"My house grew apace and I became a great man among the Cretans,
+but when Jove counselled that terrible expedition, in which so many
+perished, the people required me and Idomeneus to lead their ships to
+Troy, and there was no way out of it, for they insisted on our doing
+so. There we fought for nine whole years, but in the tenth we sacked the
+city of Priam and sailed home again as heaven dispersed us. Then it was
+that Jove devised evil against me. I spent but one month happily with my
+children, wife, and property, and then I conceived the idea of making a
+descent on Egypt, so I fitted out a fine fleet and manned it. I had nine
+ships, and the people flocked to fill them. For six days I and my men
+made feast, and I found them many victims both for sacrifice to the gods
+and for themselves, but on the seventh day we went on board and set sail
+from Crete with a fair North wind behind us though we were going down a
+river. Nothing went ill with any of our ships, and we had no sickness
+on board, but sat where we were and let the ships go as the wind and
+steersmen took them. On the fifth day we reached the river Aegyptus;
+there I stationed my ships in the river, bidding my men stay by them and
+keep guard over them while I sent out scouts to reconnoitre from every
+point of vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captive. The alarm was soon carried to the city, and when they
+heard the war cry, the people came out at daybreak till the plain was
+filled with horsemen and foot soldiers and with the gleam of armour.
+Then Jove spread panic among my men, and they would no longer face the
+enemy, for they found themselves surrounded. The Egyptians killed many
+of us, and took the rest alive to do forced labour for them. Jove,
+however, put it in my mind to do thus--and I wish I had died then and
+there in Egypt instead, for there was much sorrow in store for me--I
+took off my helmet and shield and dropped my spear from my hand; then
+I went straight up to the king's chariot, clasped his knees and kissed
+them, whereon he spared my life, bade me get into his chariot, and took
+me weeping to his own home. Many made at me with their ashen spears and
+tried to kill me in their fury, but the king protected me, for he feared
+the wrath of Jove the protector of strangers, who punishes those who do
+evil.
+
+"I stayed there for seven years and got together much money among the
+Egyptians, for they all gave me something; but when it was now going on
+for eight years there came a certain Phoenician, a cunning rascal, who
+had already committed all sorts of villainy, and this man talked me over
+into going with him to Phoenicia, where his house and his possessions
+lay. I stayed there for a whole twelve months, but at the end of that
+time when months and days had gone by till the same season had come
+round again, he set me on board a ship bound for Libya, on a pretence
+that I was to take a cargo along with him to that place, but really that
+he might sell me as a slave and take the money I fetched. I suspected
+his intention, but went on board with him, for I could not help it.
+
+"The ship ran before a fresh North wind till we had reached the sea
+that lies between Crete and Libya; there, however, Jove counselled their
+destruction, for as soon as we were well out from Crete and could see
+nothing but sea and sky, he raised a black cloud over our ship and the
+sea grew dark beneath it. Then Jove let fly with his thunderbolts and
+the ship went round and round and was filled with fire and brimstone
+as the lightning struck it. The men fell all into the sea; they
+were carried about in the water round the ship looking like so many
+sea-gulls, but the god presently deprived them of all chance of getting
+home again. I was all dismayed. Jove, however, sent the ship's mast
+within my reach, which saved my life, for I clung to it, and drifted
+before the fury of the gale. Nine days did I drift but in the darkness
+of the tenth night a great wave bore me on to the Thesprotian coast.
+There Pheidon king of the Thesprotians entertained me hospitably without
+charging me anything at all--for his son found me when I was nearly dead
+with cold and fatigue, whereon he raised me by the hand, took me to his
+father's house and gave me clothes to wear.
+
+"There it was that I heard news of Ulysses, for the king told me he
+had entertained him, and shown him much hospitality while he was on his
+homeward journey. He showed me also the treasure of gold, and wrought
+iron that Ulysses had got together. There was enough to keep his family
+for ten generations, so much had he left in the house of king Pheidon.
+But the king said Ulysses had gone to Dodona that he might learn Jove's
+mind from the god's high oak tree, and know whether after so long an
+absence he should return to Ithaca openly, or in secret. Moreover the
+king swore in my presence, making drink-offerings in his own house as
+he did so, that the ship was by the water side, and the crew found,
+that should take him to his own country. He sent me off however before
+Ulysses returned, for there happened to be a Thesprotian ship sailing
+for the wheat-growing island of Dulichium, and he told those in charge
+of her to be sure and take me safely to King Acastus.
+
+"These men hatched a plot against me that would have reduced me to the
+very extreme of misery, for when the ship had got some way out from land
+they resolved on selling me as a slave. They stripped me of the shirt
+and cloak that I was wearing, and gave me instead the tattered old
+clouts in which you now see me; then, towards nightfall, they reached
+the tilled lands of Ithaca, and there they bound me with a strong rope
+fast in the ship, while they went on shore to get supper by the sea
+side. But the gods soon undid my bonds for me, and having drawn my rags
+over my head I slid down the rudder into the sea, where I struck out and
+swam till I was well clear of them, and came ashore near a thick wood
+in which I lay concealed. They were very angry at my having escaped and
+went searching about for me, till at last they thought it was no further
+use and went back to their ship. The gods, having hidden me thus easily,
+then took me to a good man's door--for it seems that I am not to die yet
+awhile."
+
+To this you answered, O swineherd Eumaeus, "Poor unhappy stranger, I
+have found the story of your misfortunes extremely interesting, but that
+part about Ulysses is not right; and you will never get me to believe
+it. Why should a man like you go about telling lies in this way? I know
+all about the return of my master. The gods one and all of them detest
+him, or they would have taken him before Troy, or let him die with
+friends around him when the days of his fighting were done; for then the
+Achaeans would have built a mound over his ashes and his son would have
+been heir to his renown, but now the storm winds have spirited him away
+we know not whither.
+
+"As for me I live out of the way here with the pigs, and never go to the
+town unless when Penelope sends for me on the arrival of some news
+about Ulysses. Then they all sit round and ask questions, both those who
+grieve over the king's absence, and those who rejoice at it because they
+can eat up his property without paying for it. For my own part I have
+never cared about asking anyone else since the time when I was taken in
+by an Aetolian, who had killed a man and come a long way till at last
+he reached my station, and I was very kind to him. He said he had seen
+Ulysses with Idomeneus among the Cretans, refitting his ships which had
+been damaged in a gale. He said Ulysses would return in the following
+summer or autumn with his men, and that he would bring back much wealth.
+And now you, you unfortunate old man, since fate has brought you to my
+door, do not try to flatter me in this way with vain hopes. It is not
+for any such reason that I shall treat you kindly, but only out of
+respect for Jove the god of hospitality, as fearing him and pitying
+you."
+
+Ulysses answered, "I see that you are of an unbelieving mind; I have
+given you my oath, and yet you will not credit me; let us then make a
+bargain, and call all the gods in heaven to witness it. If your master
+comes home, give me a cloak and shirt of good wear, and send me to
+Dulichium where I want to go; but if he does not come as I say he will,
+set your men on to me, and tell them to throw me from yonder precipice,
+as a warning to tramps not to go about the country telling lies."
+
+"And a pretty figure I should cut then," replied Eumaeus, "both now and
+hereafter, if I were to kill you after receiving you into my hut and
+showing you hospitality. I should have to say my prayers in good earnest
+if I did; but it is just supper time and I hope my men will come in
+directly, that we may cook something savoury for supper."
+
+Thus did they converse, and presently the swineherds came up with
+the pigs, which were then shut up for the night in their styes, and a
+tremendous squealing they made as they were being driven into them. But
+Eumaeus called to his men and said, "Bring in the best pig you have,
+that I may sacrifice him for this stranger, and we will take toll of him
+ourselves. We have had trouble enough this long time feeding pigs, while
+others reap the fruit of our labour."
+
+On this he began chopping firewood, while the others brought in a fine
+fat five year old boar pig, and set it at the altar. Eumaeus did not
+forget the gods, for he was a man of good principles, so the first thing
+he did was to cut bristles from the pig's face and throw them into the
+fire, praying to all the gods as he did so that Ulysses might return
+home again. Then he clubbed the pig with a billet of oak which he had
+kept back when he was chopping the firewood, and stunned it, while the
+others slaughtered and singed it. Then they cut it up, and Eumaeus began
+by putting raw pieces from each joint on to some of the fat; these he
+sprinkled with barley meal, and laid upon the embers; they cut the rest
+of the meat up small, put the pieces upon the spits and roasted them
+till they were done; when they had taken them off the spits they
+threw them on to the dresser in a heap. The swineherd, who was a most
+equitable man, then stood up to give every one his share. He made seven
+portions; one of these he set apart for Mercury the son of Maia and the
+nymphs, praying to them as he did so; the others he dealt out to the men
+man by man. He gave Ulysses some slices cut lengthways down the loin
+as a mark of especial honour, and Ulysses was much pleased. "I hope,
+Eumaeus," said he, "that Jove will be as well disposed towards you as I
+am, for the respect you are showing to an outcast like myself."
+
+To this you answered, O swineherd Eumaeus, "Eat, my good fellow, and
+enjoy your supper, such as it is. God grants this, and withholds that,
+just as he thinks right, for he can do whatever he chooses."
+
+As he spoke he cut off the first piece and offered it as a burnt
+sacrifice to the immortal gods; then he made them a drink-offering,
+put the cup in the hands of Ulysses, and sat down to his own portion.
+Mesaulius brought them their bread; the swineherd had brought this man
+on his own account from among the Taphians during his master's absence,
+and had paid for him with his own money without saying anything either
+to his mistress or Laertes. They then laid their hands upon the good
+things that were before them, and when they had had enough to eat and
+drink, Mesaulius took away what was left of the bread, and they all went
+to bed after having made a hearty supper.
+
+Now the night came on stormy and very dark, for there was no moon. It
+poured without ceasing, and the wind blew strong from the West, which is
+a wet quarter, so Ulysses thought he would see whether Eumaeus, in the
+excellent care he took of him, would take off his own cloak and give
+it him, or make one of his men give him one. "Listen to me," said he,
+"Eumaeus and the rest of you; when I have said a prayer I will tell you
+something. It is the wine that makes me talk in this way; wine will make
+even a wise man fall to singing; it will make him chuckle and dance
+and say many a word that he had better leave unspoken; still, as I have
+begun, I will go on. Would that I were still young and strong as when we
+got up an ambuscade before Troy. Menelaus and Ulysses were the leaders,
+but I was in command also, for the other two would have it so. When we
+had come up to the wall of the city we crouched down beneath our armour
+and lay there under cover of the reeds and thick brushwood that grew
+about the swamp. It came on to freeze with a North wind blowing; the
+snow fell small and fine like hoar frost, and our shields were coated
+thick with rime. The others had all got cloaks and shirts, and slept
+comfortably enough with their shields about their shoulders, but I had
+carelessly left my cloak behind me, not thinking that I should be too
+cold, and had gone off in nothing but my shirt and shield. When the
+night was two-thirds through and the stars had shifted their places, I
+nudged Ulysses who was close to me with my elbow, and he at once gave me
+his ear.
+
+"'Ulysses,' said I, 'this cold will be the death of me, for I have no
+cloak; some god fooled me into setting off with nothing on but my shirt,
+and I do not know what to do.'
+
+"Ulysses, who was as crafty as he was valiant, hit upon the following
+plan:
+
+"'Keep still,' said he in a low voice, 'or the others will hear you.'
+Then he raised his head on his elbow.
+
+"'My friends,' said he, 'I have had a dream from heaven in my sleep. We
+are a long way from the ships; I wish some one would go down and tell
+Agamemnon to send us up more men at once.'
+
+"On this Thoas son of Andraemon threw off his cloak and set out running
+to the ships, whereon I took the cloak and lay in it comfortably enough
+till morning. Would that I were still young and strong as I was in those
+days, for then some one of you swineherds would give me a cloak both out
+of good will and for the respect due to a brave soldier; but now people
+look down upon me because my clothes are shabby."
+
+And Eumaeus answered, "Old man, you have told us an excellent story,
+and have said nothing so far but what is quite satisfactory; for the
+present, therefore, you shall want neither clothing nor anything else
+that a stranger in distress may reasonably expect, but to-morrow morning
+you have to shake your own old rags about your body again, for we have
+not many spare cloaks nor shirts up here, but every man has only one.
+When Ulysses' son comes home again he will give you both cloak and
+shirt, and send you wherever you may want to go."
+
+With this he got up and made a bed for Ulysses by throwing some
+goatskins and sheepskins on the ground in front of the fire. Here
+Ulysses lay down, and Eumaeus covered him over with a great heavy cloak
+that he kept for a change in case of extraordinarily bad weather.
+
+Thus did Ulysses sleep, and the young men slept beside him. But the
+swineherd did not like sleeping away from his pigs, so he got ready
+to go outside, and Ulysses was glad to see that he looked after his
+property during his master's absence. First he slung his sword over his
+brawny shoulders and put on a thick cloak to keep out the wind. He also
+took the skin of a large and well fed goat, and a javelin in case of
+attack from men or dogs. Thus equipped he went to his rest where the
+pigs were camping under an overhanging rock that gave them shelter from
+the North wind.
+
+
+Book XV
+
+MINERVA SUMMONS TELEMACHUS FROM LACEDAEMON--HE MEETS WITH THEOCLYMENUS
+AT PYLOS AND BRINGS HIM TO ITHACA--ON LANDING HE GOES TO THE HUT OF
+EUMAEUS.
+
+But Minerva went to the fair city of Lacedaemon to tell Ulysses' son
+that he was to return at once. She found him and Pisistratus sleeping
+in the forecourt of Menelaus's house; Pisistratus was fast asleep,
+but Telemachus could get no rest all night for thinking of his unhappy
+father, so Minerva went close up to him and said:
+
+"Telemachus, you should not remain so far away from home any longer, nor
+leave your property with such dangerous people in your house; they
+will eat up everything you have among them, and you will have been on a
+fool's errand. Ask Menelaus to send you home at once if you wish to
+find your excellent mother still there when you get back. Her father and
+brothers are already urging her to marry Eurymachus, who has given her
+more than any of the others, and has been greatly increasing his wedding
+presents. I hope nothing valuable may have been taken from the house in
+spite of you, but you know what women are--they always want to do the
+best they can for the man who marries them, and never give another
+thought to the children of their first husband, nor to their father
+either when he is dead and done with. Go home, therefore, and put
+everything in charge of the most respectable woman servant that you
+have, until it shall please heaven to send you a wife of your own. Let
+me tell you also of another matter which you had better attend to. The
+chief men among the suitors are lying in wait for you in the Strait
+{128} between Ithaca and Samos, and they mean to kill you before you
+can reach home. I do not much think they will succeed; it is more likely
+that some of those who are now eating up your property will find a grave
+themselves. Sail night and day, and keep your ship well away from the
+islands; the god who watches over you and protects you will send you a
+fair wind. As soon as you get to Ithaca send your ship and men on to the
+town, but yourself go straight to the swineherd who has charge of your
+pigs; he is well disposed towards you, stay with him, therefore, for the
+night, and then send him to Penelope to tell her that you have got back
+safe from Pylos."
+
+Then she went back to Olympus; but Telemachus stirred Pisistratus with
+his heel to rouse him, and said, "Wake up Pisistratus, and yoke the
+horses to the chariot, for we must set off home." {129}
+
+But Pisistratus said, "No matter what hurry we are in we cannot drive
+in the dark. It will be morning soon; wait till Menelaus has brought his
+presents and put them in the chariot for us; and let him say good bye to
+us in the usual way. So long as he lives a guest should never forget a
+host who has shown him kindness."
+
+As he spoke day began to break, and Menelaus, who had already risen,
+leaving Helen in bed, came towards them. When Telemachus saw him he
+put on his shirt as fast as he could, threw a great cloak over his
+shoulders, and went out to meet him. "Menelaus," said he, "let me go
+back now to my own country, for I want to get home."
+
+And Menelaus answered, "Telemachus, if you insist on going I will not
+detain you. I do not like to see a host either too fond of his guest or
+too rude to him. Moderation is best in all things, and not letting a
+man go when he wants to do so is as bad as telling him to go if he would
+like to stay. One should treat a guest well as long as he is in the
+house and speed him when he wants to leave it. Wait, then, till I
+can get your beautiful presents into your chariot, and till you have
+yourself seen them. I will tell the women to prepare a sufficient dinner
+for you of what there may be in the house; it will be at once more
+proper and cheaper for you to get your dinner before setting out on
+such a long journey. If, moreover, you have a fancy for making a tour
+in Hellas or in the Peloponnese, I will yoke my horses, and will conduct
+you myself through all our principal cities. No one will send us away
+empty handed; every one will give us something--a bronze tripod, a
+couple of mules, or a gold cup."
+
+"Menelaus," replied Telemachus, "I want to go home at once, for when
+I came away I left my property without protection, and fear that
+while looking for my father I shall come to ruin myself, or find that
+something valuable has been stolen during my absence."
+
+When Menelaus heard this he immediately told his wife and servants to
+prepare a sufficient dinner from what there might be in the house. At
+this moment Eteoneus joined him, for he lived close by and had just got
+up; so Menelaus told him to light the fire and cook some meat, which he
+at once did. Then Menelaus went down into his fragrant store room, {130}
+not alone, but Helen went too, with Megapenthes. When he reached the
+place where the treasures of his house were kept, he selected a double
+cup, and told his son Megapenthes to bring also a silver mixing bowl.
+Meanwhile Helen went to the chest where she kept the lovely dresses
+which she had made with her own hands, and took out one that was largest
+and most beautifully enriched with embroidery; it glittered like a star,
+and lay at the very bottom of the chest. {131} Then they all came back
+through the house again till they got to Telemachus, and Menelaus said,
+"Telemachus, may Jove, the mighty husband of Juno, bring you safely home
+according to your desire. I will now present you with the finest and
+most precious piece of plate in all my house. It is a mixing bowl of
+pure silver, except the rim, which is inlaid with gold, and it is the
+work of Vulcan. Phaedimus king of the Sidonians made me a present of it
+in the course of a visit that I paid him while I was on my return home.
+I should like to give it to you."
+
+With these words he placed the double cup in the hands of Telemachus,
+while Megapenthes brought the beautiful mixing bowl and set it before
+him. Hard by stood lovely Helen with the robe ready in her hand.
+
+"I too, my son," said she, "have something for you as a keepsake from
+the hand of Helen; it is for your bride to wear upon her wedding day.
+Till then, get your dear mother to keep it for you; thus may you go back
+rejoicing to your own country and to your home."
+
+So saying she gave the robe over to him and he received it gladly. Then
+Pisistratus put the presents into the chariot, and admired them all as
+he did so. Presently Menelaus took Telemachus and Pisistratus into the
+house, and they both of them sat down to table. A maid servant brought
+them water in a beautiful golden ewer, and poured it into a silver basin
+for them to wash their hands, and she drew a clean table beside them;
+an upper servant brought them bread and offered them many good things of
+what there was in the house. Eteoneus carved the meat and gave them each
+their portions, while Megapenthes poured out the wine. Then they laid
+their hands upon the good things that were before them, but as soon as
+they had had enough to eat and drink Telemachus and Pisistratus yoked
+the horses, and took their places in the chariot. They drove out through
+the inner gateway and under the echoing gatehouse of the outer court,
+and Menelaus came after them with a golden goblet of wine in his right
+hand that they might make a drink-offering before they set out. He stood
+in front of the horses and pledged them, saying, "Farewell to both of
+you; see that you tell Nestor how I have treated you, for he was as
+kind to me as any father could be while we Achaeans were fighting before
+Troy."
+
+"We will be sure, sir," answered Telemachus, "to tell him everything as
+soon as we see him. I wish I were as certain of finding Ulysses returned
+when I get back to Ithaca, that I might tell him of the very great
+kindness you have shown me and of the many beautiful presents I am
+taking with me."
+
+As he was thus speaking a bird flew on his right hand--an eagle with a
+great white goose in its talons which it had carried off from the farm
+yard--and all the men and women were running after it and shouting. It
+came quite close up to them and flew away on their right hands in front
+of the horses. When they saw it they were glad, and their hearts took
+comfort within them, whereon Pisistratus said, "Tell me, Menelaus, has
+heaven sent this omen for us or for you?"
+
+Menelaus was thinking what would be the most proper answer for him to
+make, but Helen was too quick for him and said, "I will read this matter
+as heaven has put it in my heart, and as I doubt not that it will come
+to pass. The eagle came from the mountain where it was bred and has
+its nest, and in like manner Ulysses, after having travelled far and
+suffered much, will return to take his revenge--if indeed he is not back
+already and hatching mischief for the suitors."
+
+"May Jove so grant it," replied Telemachus, "if it should prove to be
+so, I will make vows to you as though you were a god, even when I am at
+home."
+
+As he spoke he lashed his horses and they started off at full speed
+through the town towards the open country. They swayed the yoke upon
+their necks and travelled the whole day long till the sun set and
+darkness was over all the land. Then they reached Pherae, where Diocles
+lived who was son of Ortilochus, the son of Alpheus. There they passed
+the night and were treated hospitably. When the child of morning,
+rosy-fingered Dawn, appeared, they again yoked their horses and their
+places in the chariot. They drove out through the inner gateway and
+under the echoing gatehouse of the outer court. Then Pisistratus lashed
+his horses on and they flew forward nothing loath; ere long they came to
+Pylos, and then Telemachus said:
+
+"Pisistratus, I hope you will promise to do what I am going to ask you.
+You know our fathers were old friends before us; moreover, we are both
+of an age, and this journey has brought us together still more closely;
+do not, therefore, take me past my ship, but leave me there, for if I go
+to your father's house he will try to keep me in the warmth of his good
+will towards me, and I must go home at once."
+
+Pisistratus thought how he should do as he was asked, and in the end he
+deemed it best to turn his horses towards the ship, and put Menelaus's
+beautiful presents of gold and raiment in the stern of the vessel. Then
+he said, "Go on board at once and tell your men to do so also before
+I can reach home to tell my father. I know how obstinate he is, and am
+sure he will not let you go; he will come down here to fetch you, and he
+will not go back without you. But he will be very angry."
+
+With this he drove his goodly steeds back to the city of the Pylians and
+soon reached his home, but Telemachus called the men together and gave
+his orders. "Now, my men," said he, "get everything in order on board
+the ship, and let us set out home."
+
+Thus did he speak, and they went on board even as he had said. But as
+Telemachus was thus busied, praying also and sacrificing to Minerva
+in the ship's stern, there came to him a man from a distant country,
+a seer, who was flying from Argos because he had killed a man. He was
+descended from Melampus, who used to live in Pylos, the land of sheep;
+he was rich and owned a great house, but he was driven into exile by the
+great and powerful king Neleus. Neleus seized his goods and held them
+for a whole year, during which he was a close prisoner in the house
+of king Phylacus, and in much distress of mind both on account of the
+daughter of Neleus and because he was haunted by a great sorrow that
+dread Erinys had laid upon him. In the end, however, he escaped with his
+life, drove the cattle from Phylace to Pylos, avenged the wrong that had
+been done him, and gave the daughter of Neleus to his brother. Then he
+left the country and went to Argos, where it was ordained that he should
+reign over much people. There he married, established himself, and had
+two famous sons Antiphates and Mantius. Antiphates became father of
+Oicleus, and Oicleus of Amphiaraus, who was dearly loved both by Jove
+and by Apollo, but he did not live to old age, for he was killed
+in Thebes by reason of a woman's gifts. His sons were Alcmaeon
+and Amphilochus. Mantius, the other son of Melampus, was father to
+Polypheides and Cleitus. Aurora, throned in gold, carried off Cleitus
+for his beauty's sake, that he might dwell among the immortals, but
+Apollo made Polypheides the greatest seer in the whole world now that
+Amphiaraus was dead. He quarrelled with his father and went to live in
+Hyperesia, where he remained and prophesied for all men.
+
+His son, Theoclymenus, it was who now came up to Telemachus as he was
+making drink-offerings and praying in his ship. "Friend," said he,
+"now that I find you sacrificing in this place, I beseech you by your
+sacrifices themselves, and by the god to whom you make them, I pray you
+also by your own head and by those of your followers tell me the truth
+and nothing but the truth. Who and whence are you? Tell me also of your
+town and parents."
+
+Telemachus said, "I will answer you quite truly. I am from Ithaca, and
+my father is Ulysses, as surely as that he ever lived. But he has come
+to some miserable end. Therefore I have taken this ship and got my crew
+together to see if I can hear any news of him, for he has been away a
+long time."
+
+"I too," answered Theoclymenus, "am an exile, for I have killed a man
+of my own race. He has many brothers and kinsmen in Argos, and they
+have great power among the Argives. I am flying to escape death at their
+hands, and am thus doomed to be a wanderer on the face of the earth. I
+am your suppliant; take me, therefore, on board your ship that they may
+not kill me, for I know they are in pursuit."
+
+"I will not refuse you," replied Telemachus, "if you wish to join us.
+Come, therefore, and in Ithaca we will treat you hospitably according to
+what we have."
+
+On this he received Theoclymenus' spear and laid it down on the deck of
+the ship. He went on board and sat in the stern, bidding Theoclymenus
+sit beside him; then the men let go the hawsers. Telemachus told them to
+catch hold of the ropes, and they made all haste to do so. They set the
+mast in its socket in the cross plank, raised it and made it fast with
+the forestays, and they hoisted their white sails with sheets of twisted
+ox hide. Minerva sent them a fair wind that blew fresh and strong to
+take the ship on her course as fast as possible. Thus then they passed
+by Crouni and Chalcis.
+
+Presently the sun set and darkness was over all the land. The vessel
+made a quick passage to Pheae and thence on to Elis, where the Epeans
+rule. Telemachus then headed her for the flying islands, {132} wondering
+within himself whether he should escape death or should be taken
+prisoner.
+
+Meanwhile Ulysses and the swineherd were eating their supper in the hut,
+and the men supped with them. As soon as they had had to eat and drink,
+Ulysses began trying to prove the swineherd and see whether he would
+continue to treat him kindly, and ask him to stay on at the station or
+pack him off to the city; so he said:
+
+"Eumaeus, and all of you, to-morrow I want to go away and begin begging
+about the town, so as to be no more trouble to you or to your men. Give
+me your advice therefore, and let me have a good guide to go with me
+and show me the way. I will go the round of the city begging as I needs
+must, to see if any one will give me a drink and a piece of bread. I
+should like also to go to the house of Ulysses and bring news of her
+husband to Queen Penelope. I could then go about among the suitors and
+see if out of all their abundance they will give me a dinner. I should
+soon make them an excellent servant in all sorts of ways. Listen and
+believe when I tell you that by the blessing of Mercury who gives grace
+and good name to the works of all men, there is no one living who would
+make a more handy servant than I should--to put fresh wood on the fire,
+chop fuel, carve, cook, pour out wine, and do all those services that
+poor men have to do for their betters."
+
+The swineherd was very much disturbed when he heard this. "Heaven help
+me," he exclaimed, "what ever can have put such a notion as that into
+your head? If you go near the suitors you will be undone to a certainty,
+for their pride and insolence reach the very heavens. They would never
+think of taking a man like you for a servant. Their servants are all
+young men, well dressed, wearing good cloaks and shirts, with well
+looking faces and their hair always tidy, the tables are kept quite
+clean and are loaded with bread, meat, and wine. Stay where you are,
+then; you are not in anybody's way; I do not mind your being here, no
+more do any of the others, and when Telemachus comes home he will give
+you a shirt and cloak and will send you wherever you want to go."
+
+Ulysses answered, "I hope you may be as dear to the gods as you are to
+me, for having saved me from going about and getting into trouble; there
+is nothing worse than being always on the tramp; still, when men have
+once got low down in the world they will go through a great deal on
+behalf of their miserable bellies. Since, however, you press me to stay
+here and await the return of Telemachus, tell me about Ulysses' mother,
+and his father whom he left on the threshold of old age when he set
+out for Troy. Are they still living or are they already dead and in the
+house of Hades?"
+
+"I will tell you all about them," replied Eumaeus, "Laertes is still
+living and prays heaven to let him depart peacefully in his own house,
+for he is terribly distressed about the absence of his son, and also
+about the death of his wife, which grieved him greatly and aged him more
+than anything else did. She came to an unhappy end {133} through sorrow
+for her son: may no friend or neighbour who has dealt kindly by me come
+to such an end as she did. As long as she was still living, though she
+was always grieving, I used to like seeing her and asking her how she
+did, for she brought me up along with her daughter Ctimene, the youngest
+of her children; we were boy and girl together, and she made little
+difference between us. When, however, we both grew up, they sent Ctimene
+to Same and received a splendid dowry for her. As for me, my mistress
+gave me a good shirt and cloak with a pair of sandals for my feet, and
+sent me off into the country, but she was just as fond of me as ever.
+This is all over now. Still it has pleased heaven to prosper my work in
+the situation which I now hold. I have enough to eat and drink, and can
+find something for any respectable stranger who comes here; but there
+is no getting a kind word or deed out of my mistress, for the house has
+fallen into the hands of wicked people. Servants want sometimes to see
+their mistress and have a talk with her; they like to have something
+to eat and drink at the house, and something too to take back with them
+into the country. This is what will keep servants in a good humour."
+
+Ulysses answered, "Then you must have been a very little fellow,
+Eumaeus, when you were taken so far away from your home and parents.
+Tell me, and tell me true, was the city in which your father and mother
+lived sacked and pillaged, or did some enemies carry you off when you
+were alone tending sheep or cattle, ship you off here, and sell you for
+whatever your master gave them?"
+
+"Stranger," replied Eumaeus, "as regards your question: sit still, make
+yourself comfortable, drink your wine, and listen to me. The nights
+are now at their longest; there is plenty of time both for sleeping and
+sitting up talking together; you ought not to go to bed till bed time,
+too much sleep is as bad as too little; if any one of the others wishes
+to go to bed let him leave us and do so; he can then take my master's
+pigs out when he has done breakfast in the morning. We too will sit here
+eating and drinking in the hut, and telling one another stories about
+our misfortunes; for when a man has suffered much, and been buffeted
+about in the world, he takes pleasure in recalling the memory of sorrows
+that have long gone by. As regards your question, then, my tale is as
+follows:
+
+"You may have heard of an island called Syra that lies over above
+Ortygia, {134} where the land begins to turn round and look in another
+direction. {135} It is not very thickly peopled, but the soil is good,
+with much pasture fit for cattle and sheep, and it abounds with wine
+and wheat. Dearth never comes there, nor are the people plagued by any
+sickness, but when they grow old Apollo comes with Diana and kills them
+with his painless shafts. It contains two communities, and the whole
+country is divided between these two. My father Ctesius son of Ormenus,
+a man comparable to the gods, reigned over both.
+
+"Now to this place there came some cunning traders from Phoenicia (for
+the Phoenicians are great mariners) in a ship which they had freighted
+with gewgaws of all kinds. There happened to be a Phoenician woman in
+my father's house, very tall and comely, and an excellent servant; these
+scoundrels got hold of her one day when she was washing near their ship,
+seduced her, and cajoled her in ways that no woman can resist, no matter
+how good she may be by nature. The man who had seduced her asked her who
+she was and where she came from, and on this she told him her father's
+name. 'I come from Sidon,' said she, 'and am daughter to Arybas, a
+man rolling in wealth. One day as I was coming into the town from the
+country, some Taphian pirates seized me and took me here over the sea,
+where they sold me to the man who owns this house, and he gave them
+their price for me.'
+
+"The man who had seduced her then said, 'Would you like to come along
+with us to see the house of your parents and your parents themselves?
+They are both alive and are said to be well off.'
+
+"'I will do so gladly,' answered she, 'if you men will first swear me a
+solemn oath that you will do me no harm by the way.'
+
+"They all swore as she told them, and when they had completed their oath
+the woman said, 'Hush; and if any of your men meets me in the street or
+at the well, do not let him speak to me, for fear some one should go and
+tell my master, in which case he would suspect something. He would put
+me in prison, and would have all of you murdered; keep your own counsel
+therefore; buy your merchandise as fast as you can, and send me word
+when you have done loading. I will bring as much gold as I can lay my
+hands on, and there is something else also that I can do towards paying
+my fare. I am nurse to the son of the good man of the house, a funny
+little fellow just able to run about. I will carry him off in your ship,
+and you will get a great deal of money for him if you take him and sell
+him in foreign parts.'
+
+"On this she went back to the house. The Phoenicians stayed a whole
+year till they had loaded their ship with much precious merchandise,
+and then, when they had got freight enough, they sent to tell the
+woman. Their messenger, a very cunning fellow, came to my father's house
+bringing a necklace of gold with amber beads strung among it; and
+while my mother and the servants had it in their hands admiring it and
+bargaining about it, he made a sign quietly to the woman and then went
+back to the ship, whereon she took me by the hand and led me out of the
+house. In the fore part of the house she saw the tables set with
+the cups of guests who had been feasting with my father, as being in
+attendance on him; these were now all gone to a meeting of the public
+assembly, so she snatched up three cups and carried them off in the
+bosom of her dress, while I followed her, for I knew no better. The sun
+was now set, and darkness was over all the land, so we hurried on as
+fast as we could till we reached the harbour, where the Phoenician ship
+was lying. When they had got on board they sailed their ways over the
+sea, taking us with them, and Jove sent then a fair wind; six days did
+we sail both night and day, but on the seventh day Diana struck the
+woman and she fell heavily down into the ship's hold as though she were
+a sea gull alighting on the water; so they threw her overboard to the
+seals and fishes, and I was left all sorrowful and alone. Presently the
+winds and waves took the ship to Ithaca, where Laertes gave sundry of
+his chattels for me, and thus it was that ever I came to set eyes upon
+this country."
+
+Ulysses answered, "Eumaeus, I have heard the story of your misfortunes
+with the most lively interest and pity, but Jove has given you good as
+well as evil, for in spite of everything you have a good master, who
+sees that you always have enough to eat and drink; and you lead a good
+life, whereas I am still going about begging my way from city to city."
+
+Thus did they converse, and they had only a very little time left for
+sleep, for it was soon daybreak. In the mean time Telemachus and his
+crew were nearing land, so they loosed the sails, took down the mast,
+and rowed the ship into the harbour. {136} They cast out their mooring
+stones and made fast the hawsers; they then got out upon the sea shore,
+mixed their wine, and got dinner ready. As soon as they had had enough
+to eat and drink Telemachus said, "Take the ship on to the town, but
+leave me here, for I want to look after the herdsmen on one of my farms.
+In the evening, when I have seen all I want, I will come down to the
+city, and to-morrow morning in return for your trouble I will give you
+all a good dinner with meat and wine." {137}
+
+Then Theoclymenus said, "And what, my dear young friend, is to become of
+me? To whose house, among all your chief men, am I to repair? or shall I
+go straight to your own house and to your mother?"
+
+"At any other time," replied Telemachus, "I should have bidden you go to
+my own house, for you would find no want of hospitality; at the present
+moment, however, you would not be comfortable there, for I shall be
+away, and my mother will not see you; she does not often show herself
+even to the suitors, but sits at her loom weaving in an upper chamber,
+out of their way; but I can tell you a man whose house you can go
+to--I mean Eurymachus the son of Polybus, who is held in the highest
+estimation by every one in Ithaca. He is much the best man and the most
+persistent wooer, of all those who are paying court to my mother and
+trying to take Ulysses' place. Jove, however, in heaven alone knows
+whether or no they will come to a bad end before the marriage takes
+place."
+
+As he was speaking a bird flew by upon his right hand--a hawk, Apollo's
+messenger. It held a dove in its talons, and the feathers, as it tore
+them off, {138} fell to the ground midway between Telemachus and the
+ship. On this Theoclymenus called him apart and caught him by the hand.
+"Telemachus," said he, "that bird did not fly on your right hand without
+having been sent there by some god. As soon as I saw it I knew it was an
+omen; it means that you will remain powerful and that there will be no
+house in Ithaca more royal than your own."
+
+"I wish it may prove so," answered Telemachus. "If it does, I will show
+you so much good will and give you so many presents that all who meet
+you will congratulate you."
+
+Then he said to his friend Piraeus, "Piraeus, son of Clytius, you have
+throughout shown yourself the most willing to serve me of all those who
+have accompanied me to Pylos; I wish you would take this stranger to
+your own house and entertain him hospitably till I can come for him."
+
+And Piraeus answered, "Telemachus, you may stay away as long as you
+please, but I will look after him for you, and he shall find no lack of
+hospitality."
+
+As he spoke he went on board, and bade the others do so also and loose
+the hawsers, so they took their places in the ship. But Telemachus
+bound on his sandals, and took a long and doughty spear with a head
+of sharpened bronze from the deck of the ship. Then they loosed the
+hawsers, thrust the ship off from land, and made on towards the city
+as they had been told to do, while Telemachus strode on as fast as he
+could, till he reached the homestead where his countless herds of
+swine were feeding, and where dwelt the excellent swineherd, who was so
+devoted a servant to his master.
+
+
+Book XVI
+
+ULYSSES REVEALS HIMSELF TO TELEMACHUS.
+
+Meanwhile Ulysses and the swineherd had lit a fire in the hut and were
+were getting breakfast ready at daybreak, for they had sent the men out
+with the pigs. When Telemachus came up, the dogs did not bark but fawned
+upon him, so Ulysses, hearing the sound of feet and noticing that the
+dogs did not bark, said to Eumaeus:
+
+"Eumaeus, I hear footsteps; I suppose one of your men or some one of
+your acquaintance is coming here, for the dogs are fawning upon him and
+not barking."
+
+The words were hardly out of his mouth before his son stood at the door.
+Eumaeus sprang to his feet, and the bowls in which he was mixing wine
+fell from his hands, as he made towards his master. He kissed his head
+and both his beautiful eyes, and wept for joy. A father could not be
+more delighted at the return of an only son, the child of his old age,
+after ten years' absence in a foreign country and after having gone
+through much hardship. He embraced him, kissed him all over as though he
+had come back from the dead, and spoke fondly to him saying:
+
+"So you are come, Telemachus, light of my eyes that you are. When I
+heard you had gone to Pylos I made sure I was never going to see you any
+more. Come in, my dear child, and sit down, that I may have a good look
+at you now you are home again; it is not very often you come into
+the country to see us herdsmen; you stick pretty close to the town
+generally. I suppose you think it better to keep an eye on what the
+suitors are doing."
+
+"So be it, old friend," answered Telemachus, "but I am come now because
+I want to see you, and to learn whether my mother is still at her
+old home or whether some one else has married her, so that the bed of
+Ulysses is without bedding and covered with cobwebs."
+
+"She is still at the house," replied Eumaeus, "grieving and breaking her
+heart, and doing nothing but weep, both night and day continually."
+
+As he spoke he took Telemachus' spear, whereon he crossed the stone
+threshold and came inside. Ulysses rose from his seat to give him place
+as he entered, but Telemachus checked him; "Sit down, stranger," said
+he, "I can easily find another seat, and there is one here who will lay
+it for me."
+
+Ulysses went back to his own place, and Eumaeus strewed some green
+brushwood on the floor and threw a sheepskin on top of it for Telemachus
+to sit upon. Then the swineherd brought them platters of cold meat, the
+remains from what they had eaten the day before, and he filled the bread
+baskets with bread as fast as he could. He mixed wine also in bowls of
+ivy-wood, and took his seat facing Ulysses. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Telemachus said to Eumaeus, "Old friend, where
+does this stranger come from? How did his crew bring him to Ithaca, and
+who were they?--for assuredly he did not come here by land."
+
+To this you answered, O swineherd Eumaeus, "My son, I will tell you
+the real truth. He says he is a Cretan, and that he has been a great
+traveller. At this moment he is running away from a Thesprotian ship,
+and has taken refuge at my station, so I will put him into your hands.
+Do whatever you like with him, only remember that he is your suppliant."
+
+"I am very much distressed," said Telemachus, "by what you have just
+told me. How can I take this stranger into my house? I am as yet young,
+and am not strong enough to hold my own if any man attacks me. My mother
+cannot make up her mind whether to stay where she is and look after the
+house out of respect for public opinion and the memory of her husband,
+or whether the time is now come for her to take the best man of those
+who are wooing her, and the one who will make her the most advantageous
+offer; still, as the stranger has come to your station I will find him
+a cloak and shirt of good wear, with a sword and sandals, and will send
+him wherever he wants to go. Or if you like you can keep him here at the
+station, and I will send him clothes and food that he may be no burden
+on you and on your men; but I will not have him go near the suitors,
+for they are very insolent, and are sure to ill treat him in a way that
+would greatly grieve me; no matter how valiant a man may be he can do
+nothing against numbers, for they will be too strong for him."
+
+Then Ulysses said, "Sir, it is right that I should say something myself.
+I am much shocked about what you have said about the insolent way in
+which the suitors are behaving in despite of such a man as you are. Tell
+me, do you submit to such treatment tamely, or has some god set your
+people against you? May you not complain of your brothers--for it is to
+these that a man may look for support, however great his quarrel may be?
+I wish I were as young as you are and in my present mind; if I were son
+to Ulysses, or, indeed, Ulysses himself, I would rather some one came
+and cut my head off, but I would go to the house and be the bane of
+every one of these men. {139} If they were too many for me--I being
+single-handed--I would rather die fighting in my own house than see such
+disgraceful sights day after day, strangers grossly maltreated, and men
+dragging the women servants about the house in an unseemly way, wine
+drawn recklessly, and bread wasted all to no purpose for an end that
+shall never be accomplished."
+
+And Telemachus answered, "I will tell you truly everything. There is no
+enmity between me and my people, nor can I complain of brothers, to whom
+a man may look for support however great his quarrel may be. Jove has
+made us a race of only sons. Laertes was the only son of Arceisius, and
+Ulysses only son of Laertes. I am myself the only son of Ulysses who
+left me behind him when he went away, so that I have never been of any
+use to him. Hence it comes that my house is in the hands of numberless
+marauders; for the chiefs from all the neighbouring islands, Dulichium,
+Same, Zacynthus, as also all the principal men of Ithaca itself, are
+eating up my house under the pretext of paying court to my mother, who
+will neither say point blank that she will not marry, nor yet bring
+matters to an end, so they are making havoc of my estate, and before
+long will do so with myself into the bargain. The issue, however,
+rests with heaven. But do you, old friend Eumaeus, go at once and tell
+Penelope that I am safe and have returned from Pylos. Tell it to herself
+alone, and then come back here without letting any one else know, for
+there are many who are plotting mischief against me."
+
+"I understand and heed you," replied Eumaeus; "you need instruct me no
+further, only as I am going that way say whether I had not better let
+poor Laertes know that you are returned. He used to superintend the work
+on his farm in spite of his bitter sorrow about Ulysses, and he would
+eat and drink at will along with his servants; but they tell me that
+from the day on which you set out for Pylos he has neither eaten nor
+drunk as he ought to do, nor does he look after his farm, but sits
+weeping and wasting the flesh from off his bones."
+
+"More's the pity," answered Telemachus, "I am sorry for him, but we must
+leave him to himself just now. If people could have everything their own
+way, the first thing I should choose would be the return of my father;
+but go, and give your message; then make haste back again, and do not
+turn out of your way to tell Laertes. Tell my mother to send one of her
+women secretly with the news at once, and let him hear it from her."
+
+Thus did he urge the swineherd; Eumaeus, therefore, took his sandals,
+bound them to his feet, and started for the town. Minerva watched
+him well off the station, and then came up to it in the form of a
+woman--fair, stately, and wise. She stood against the side of the entry,
+and revealed herself to Ulysses, but Telemachus could not see her, and
+knew not that she was there, for the gods do not let themselves be seen
+by everybody. Ulysses saw her, and so did the dogs, for they did not
+bark, but went scared and whining off to the other side of the yards.
+She nodded her head and motioned to Ulysses with her eyebrows; whereon
+he left the hut and stood before her outside the main wall of the yards.
+Then she said to him:
+
+"Ulysses, noble son of Laertes, it is now time for you to tell your
+son: do not keep him in the dark any longer, but lay your plans for the
+destruction of the suitors, and then make for the town. I will not be
+long in joining you, for I too am eager for the fray."
+
+As she spoke she touched him with her golden wand. First she threw
+a fair clean shirt and cloak about his shoulders; then she made him
+younger and of more imposing presence; she gave him back his colour,
+filled out his cheeks, and let his beard become dark again. Then she
+went away and Ulysses came back inside the hut. His son was astounded
+when he saw him, and turned his eyes away for fear he might be looking
+upon a god.
+
+"Stranger," said he, "how suddenly you have changed from what you were
+a moment or two ago. You are dressed differently and your colour is not
+the same. Are you some one or other of the gods that live in heaven? If
+so, be propitious to me till I can make you due sacrifice and offerings
+of wrought gold. Have mercy upon me."
+
+And Ulysses said, "I am no god, why should you take me for one? I am
+your father, on whose account you grieve and suffer so much at the hands
+of lawless men."
+
+As he spoke he kissed his son, and a tear fell from his cheek on to the
+ground, for he had restrained all tears till now. But Telemachus could
+not yet believe that it was his father, and said:
+
+"You are not my father, but some god is flattering me with vain hopes
+that I may grieve the more hereafter; no mortal man could of himself
+contrive to do as you have been doing, and make yourself old and young
+at a moment's notice, unless a god were with him. A second ago you
+were old and all in rags, and now you are like some god come down from
+heaven."
+
+Ulysses answered, "Telemachus, you ought not to be so immeasurably
+astonished at my being really here. There is no other Ulysses who will
+come hereafter. Such as I am, it is I, who after long wandering and much
+hardship have got home in the twentieth year to my own country. What you
+wonder at is the work of the redoubtable goddess Minerva, who does with
+me whatever she will, for she can do what she pleases. At one moment she
+makes me like a beggar, and the next I am a young man with good clothes
+on my back; it is an easy matter for the gods who live in heaven to make
+any man look either rich or poor."
+
+As he spoke he sat down, and Telemachus threw his arms about his father
+and wept. They were both so much moved that they cried aloud like eagles
+or vultures with crooked talons that have been robbed of their half
+fledged young by peasants. Thus piteously did they weep, and the sun
+would have gone down upon their mourning if Telemachus had not suddenly
+said, "In what ship, my dear father, did your crew bring you to Ithaca?
+Of what nation did they declare themselves to be--for you cannot have
+come by land?"
+
+"I will tell you the truth, my son," replied Ulysses. "It was the
+Phaeacians who brought me here. They are great sailors, and are in the
+habit of giving escorts to any one who reaches their coasts. They took
+me over the sea while I was fast asleep, and landed me in Ithaca, after
+giving me many presents in bronze, gold, and raiment. These things by
+heaven's mercy are lying concealed in a cave, and I am now come here on
+the suggestion of Minerva that we may consult about killing our enemies.
+First, therefore, give me a list of the suitors, with their number, that
+I may learn who, and how many, they are. I can then turn the matter
+over in my mind, and see whether we two can fight the whole body of them
+ourselves, or whether we must find others to help us."
+
+To this Telemachus answered, "Father, I have always heard of your renown
+both in the field and in council, but the task you talk of is a very
+great one: I am awed at the mere thought of it; two men cannot stand
+against many and brave ones. There are not ten suitors only, nor twice
+ten, but ten many times over; you shall learn their number at once.
+There are fifty-two chosen youths from Dulichium, and they have six
+servants; from Same there are twenty-four; twenty young Achaeans from
+Zacynthus, and twelve from Ithaca itself, all of them well born. They
+have with them a servant Medon, a bard, and two men who can carve at
+table. If we face such numbers as this, you may have bitter cause to rue
+your coming, and your revenge. See whether you cannot think of some one
+who would be willing to come and help us."
+
+"Listen to me," replied Ulysses, "and think whether Minerva and her
+father Jove may seem sufficient, or whether I am to try and find some
+one else as well."
+
+"Those whom you have named," answered Telemachus, "are a couple of good
+allies, for though they dwell high up among the clouds they have power
+over both gods and men."
+
+"These two," continued Ulysses, "will not keep long out of the fray,
+when the suitors and we join fight in my house. Now, therefore, return
+home early to-morrow morning, and go about among the suitors as
+before. Later on the swineherd will bring me to the city disguised as a
+miserable old beggar. If you see them ill treating me, steel your heart
+against my sufferings; even though they drag me feet foremost out of
+the house, or throw things at me, look on and do nothing beyond gently
+trying to make them behave more reasonably; but they will not listen to
+you, for the day of their reckoning is at hand. Furthermore I say, and
+lay my saying to your heart; when Minerva shall put it in my mind, I
+will nod my head to you, and on seeing me do this you must collect all
+the armour that is in the house and hide it in the strong store room.
+Make some excuse when the suitors ask you why you are removing it; say
+that you have taken it to be out of the way of the smoke, inasmuch as it
+is no longer what it was when Ulysses went away, but has become soiled
+and begrimed with soot. Add to this more particularly that you are
+afraid Jove may set them on to quarrel over their wine, and that they
+may do each other some harm which may disgrace both banquet and wooing,
+for the sight of arms sometimes tempts people to use them. But leave
+a sword and a spear apiece for yourself and me, and a couple of oxhide
+shields so that we can snatch them up at any moment; Jove and Minerva
+will then soon quiet these people. There is also another matter; if you
+are indeed my son and my blood runs in your veins, let no one know that
+Ulysses is within the house--neither Laertes, nor yet the swineherd, nor
+any of the servants, nor even Penelope herself. Let you and me exploit
+the women alone, and let us also make trial of some other of the men
+servants, to see who is on our side and whose hand is against us."
+
+"Father," replied Telemachus, "you will come to know me by and by, and
+when you do you will find that I can keep your counsel. I do not think,
+however, the plan you propose will turn out well for either of us. Think
+it over. It will take us a long time to go the round of the farms and
+exploit the men, and all the time the suitors will be wasting your
+estate with impunity and without compunction. Prove the women by all
+means, to see who are disloyal and who guiltless, but I am not in favour
+of going round and trying the men. We can attend to that later on, if
+you really have some sign from Jove that he will support you."
+
+Thus did they converse, and meanwhile the ship which had brought
+Telemachus and his crew from Pylos had reached the town of Ithaca. When
+they had come inside the harbour they drew the ship on to the land;
+their servants came and took their armour from them, and they left all
+the presents at the house of Clytius. Then they sent a servant to tell
+Penelope that Telemachus had gone into the country, but had sent the
+ship to the town to prevent her from being alarmed and made unhappy.
+This servant and Eumaeus happened to meet when they were both on the
+same errand of going to tell Penelope. When they reached the House, the
+servant stood up and said to the queen in the presence of the waiting
+women, "Your son, Madam, is now returned from Pylos"; but Eumaeus went
+close up to Penelope, and said privately all that her son had bidden
+him tell her. When he had given his message he left the house with its
+outbuildings and went back to his pigs again.
+
+The suitors were surprised and angry at what had happened, so they
+went outside the great wall that ran round the outer court, and held
+a council near the main entrance. Eurymachus, son of Polybus, was the
+first to speak.
+
+"My friends," said he, "this voyage of Telemachus's is a very serious
+matter; we had made sure that it would come to nothing. Now, however,
+let us draw a ship into the water, and get a crew together to send after
+the others and tell them to come back as fast as they can."
+
+He had hardly done speaking when Amphinomus turned in his place and
+saw the ship inside the harbour, with the crew lowering her sails, and
+putting by their oars; so he laughed, and said to the others, "We need
+not send them any message, for they are here. Some god must have told
+them, or else they saw the ship go by, and could not overtake her."
+
+On this they rose and went to the water side. The crew then drew the
+ship on shore; their servants took their armour from them, and they went
+up in a body to the place of assembly, but they would not let any one
+old or young sit along with them, and Antinous, son of Eupeithes, spoke
+first.
+
+"Good heavens," said he, "see how the gods have saved this man from
+destruction. We kept a succession of scouts upon the headlands all day
+long, and when the sun was down we never went on shore to sleep, but
+waited in the ship all night till morning in the hope of capturing and
+killing him; but some god has conveyed him home in spite of us. Let
+us consider how we can make an end of him. He must not escape us; our
+affair is never likely to come off while he is alive, for he is very
+shrewd, and public feeling is by no means all on our side. We must make
+haste before he can call the Achaeans in assembly; he will lose no time
+in doing so, for he will be furious with us, and will tell all the world
+how we plotted to kill him, but failed to take him. The people will not
+like this when they come to know of it; we must see that they do us no
+hurt, nor drive us from our own country into exile. Let us try and
+lay hold of him either on his farm away from the town, or on the road
+hither. Then we can divide up his property amongst us, and let his
+mother and the man who marries her have the house. If this does not
+please you, and you wish Telemachus to live on and hold his father's
+property, then we must not gather here and eat up his goods in this way,
+but must make our offers to Penelope each from his own house, and she
+can marry the man who will give the most for her, and whose lot it is to
+win her."
+
+They all held their peace until Amphinomus rose to speak. He was the son
+of Nisus, who was son to king Aretias, and he was foremost among all the
+suitors from the wheat-growing and well grassed island of Dulichium; his
+conversation, moreover, was more agreeable to Penelope than that of any
+of the other suitors, for he was a man of good natural disposition. "My
+friends," said he, speaking to them plainly and in all honestly, "I am
+not in favour of killing Telemachus. It is a heinous thing to kill one
+who is of noble blood. Let us first take counsel of the gods, and if the
+oracles of Jove advise it, I will both help to kill him myself, and will
+urge everyone else to do so; but if they dissuade us, I would have you
+hold your hands."
+
+Thus did he speak, and his words pleased them well, so they rose
+forthwith and went to the house of Ulysses, where they took their
+accustomed seats.
+
+Then Penelope resolved that she would show herself to the suitors. She
+knew of the plot against Telemachus, for the servant Medon had overheard
+their counsels and had told her; she went down therefore to the court
+attended by her maidens, and when she reached the suitors she stood by
+one of the bearing-posts supporting the roof of the cloister holding a
+veil before her face, and rebuked Antinous saying:
+
+"Antinous, insolent and wicked schemer, they say you are the best
+speaker and counsellor of any man your own age in Ithaca, but you are
+nothing of the kind. Madman, why should you try to compass the death
+of Telemachus, and take no heed of suppliants, whose witness is Jove
+himself? It is not right for you to plot thus against one another.
+Do you not remember how your father fled to this house in fear of the
+people, who were enraged against him for having gone with some Taphian
+pirates and plundered the Thesprotians who were at peace with us? They
+wanted to tear him in pieces and eat up everything he had, but Ulysses
+stayed their hands although they were infuriated, and now you devour his
+property without paying for it, and break my heart by wooing his wife
+and trying to kill his son. Leave off doing so, and stop the others
+also."
+
+To this Eurymachus son of Polybus answered, "Take heart, Queen Penelope
+daughter of Icarius, and do not trouble yourself about these matters.
+The man is not yet born, nor never will be, who shall lay hands upon
+your son Telemachus, while I yet live to look upon the face of the
+earth. I say--and it shall surely be--that my spear shall be reddened
+with his blood; for many a time has Ulysses taken me on his knees,
+held wine up to my lips to drink, and put pieces of meat into my hands.
+Therefore Telemachus is much the dearest friend I have, and has nothing
+to fear from the hands of us suitors. Of course, if death comes to him
+from the gods, he cannot escape it." He said this to quiet her, but in
+reality he was plotting against Telemachus.
+
+Then Penelope went upstairs again and mourned her husband till Minerva
+shed sleep over her eyes. In the evening Eumaeus got back to Ulysses
+and his son, who had just sacrificed a young pig of a year old and were
+helping one another to get supper ready; Minerva therefore came up to
+Ulysses, turned him into an old man with a stroke of her wand, and
+clad him in his old clothes again, for fear that the swineherd might
+recognise him and not keep the secret, but go and tell Penelope.
+
+Telemachus was the first to speak. "So you have got back, Eumaeus," said
+he. "What is the news of the town? Have the suitors returned, or are
+they still waiting over yonder, to take me on my way home?"
+
+"I did not think of asking about that," replied Eumaeus, "when I was in
+the town. I thought I would give my message and come back as soon as I
+could. I met a man sent by those who had gone with you to Pylos, and he
+was the first to tell the news to your mother, but I can say what I saw
+with my own eyes; I had just got on to the crest of the hill of Mercury
+above the town when I saw a ship coming into harbour with a number of
+men in her. They had many shields and spears, and I thought it was the
+suitors, but I cannot be sure."
+
+On hearing this Telemachus smiled to his father, but so that Eumaeus
+could not see him.
+
+Then, when they had finished their work and the meal was ready, they ate
+it, and every man had his full share so that all were satisfied. As
+soon as they had had enough to eat and drink, they laid down to rest and
+enjoyed the boon of sleep.
+
+
+Book XVII
+
+TELEMACHUS AND HIS MOTHER MEET--ULYSSES AND EUMAEUS COME DOWN TO THE
+TOWN, AND ULYSSES IS INSULTED BY MELANTHIUS--HE IS RECOGNISED BY THE
+DOG ARGOS--HE IS INSULTED AND PRESENTLY STRUCK BY ANTINOUS WITH A
+STOOL--PENELOPE DESIRES THAT HE SHALL BE SENT TO HER.
+
+When the child of morning, rosy-fingered Dawn, appeared, Telemachus
+bound on his sandals and took a strong spear that suited his hands, for
+he wanted to go into the city. "Old friend," said he to the swineherd,
+"I will now go to the town and show myself to my mother, for she will
+never leave off grieving till she has seen me. As for this unfortunate
+stranger, take him to the town and let him beg there of any one who will
+give him a drink and a piece of bread. I have trouble enough of my own,
+and cannot be burdened with other people. If this makes him angry so
+much the worse for him, but I like to say what I mean."
+
+Then Ulysses said, "Sir, I do not want to stay here; a beggar can always
+do better in town than country, for any one who likes can give him
+something. I am too old to care about remaining here at the beck and
+call of a master. Therefore let this man do as you have just told him,
+and take me to the town as soon as I have had a warm by the fire, and
+the day has got a little heat in it. My clothes are wretchedly thin, and
+this frosty morning I shall be perished with cold, for you say the city
+is some way off."
+
+On this Telemachus strode off through the yards, brooding his revenge
+upon the suitors. When he reached home he stood his spear against a
+bearing-post of the cloister, crossed the stone floor of the cloister
+itself, and went inside.
+
+Nurse Euryclea saw him long before any one else did. She was putting the
+fleeces on to the seats, and she burst out crying as she ran up to him;
+all the other maids came up too, and covered his head and shoulders with
+their kisses. Penelope came out of her room looking like Diana or Venus,
+and wept as she flung her arms about her son. She kissed his forehead
+and both his beautiful eyes, "Light of my eyes," she cried as she spoke
+fondly to him, "so you are come home again; I made sure I was never
+going to see you any more. To think of your having gone off to Pylos
+without saying anything about it or obtaining my consent. But come, tell
+me what you saw."
+
+"Do not scold me, mother," answered Telemachus, "nor vex me, seeing what
+a narrow escape I have had, but wash your face, change your dress, go
+upstairs with your maids, and promise full and sufficient hecatombs to
+all the gods if Jove will only grant us our revenge upon the suitors. I
+must now go to the place of assembly to invite a stranger who has come
+back with me from Pylos. I sent him on with my crew, and told Piraeus to
+take him home and look after him till I could come for him myself."
+
+She heeded her son's words, washed her face, changed her dress, and
+vowed full and sufficient hecatombs to all the gods if they would only
+vouchsafe her revenge upon the suitors.
+
+Telemachus went through, and out of, the cloisters spear in hand--not
+alone, for his two fleet dogs went with him. Minerva endowed him with a
+presence of such divine comeliness that all marvelled at him as he went
+by, and the suitors gathered round him with fair words in their mouths
+and malice in their hearts; but he avoided them, and went to sit with
+Mentor, Antiphus, and Halitherses, old friends of his father's house,
+and they made him tell them all that had happened to him. Then Piraeus
+came up with Theoclymenus, whom he had escorted through the town to the
+place of assembly, whereon Telemachus at once joined them. Piraeus was
+first to speak: "Telemachus," said he, "I wish you would send some of
+your women to my house to take away the presents Menelaus gave you."
+
+"We do not know, Piraeus," answered Telemachus, "what may happen. If
+the suitors kill me in my own house and divide my property among them,
+I would rather you had the presents than that any of those people should
+get hold of them. If on the other hand I managed to kill them, I shall
+be much obliged if you will kindly bring me my presents."
+
+With these words he took Theoclymenus to his own house. When they got
+there they laid their cloaks on the benches and seats, went into the
+baths, and washed themselves. When the maids had washed and anointed
+them, and had given them cloaks and shirts, they took their seats at
+table. A maid servant then brought them water in a beautiful golden
+ewer, and poured it into a silver basin for them to wash their hands;
+and she drew a clean table beside them. An upper servant brought them
+bread and offered them many good things of what there was in the
+house. Opposite them sat Penelope, reclining on a couch by one of the
+bearing-posts of the cloister, and spinning. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Penelope said:
+
+"Telemachus, I shall go upstairs and lie down on that sad couch, which I
+have not ceased to water with my tears, from the day Ulysses set out for
+Troy with the sons of Atreus. You failed, however, to make it clear to
+me before the suitors came back to the house, whether or no you had been
+able to hear anything about the return of your father."
+
+"I will tell you then truth," replied her son. "We went to Pylos and saw
+Nestor, who took me to his house and treated me as hospitably as though
+I were a son of his own who had just returned after a long absence; so
+also did his sons; but he said he had not heard a word from any
+human being about Ulysses, whether he was alive or dead. He sent me,
+therefore, with a chariot and horses to Menelaus. There I saw Helen, for
+whose sake so many, both Argives and Trojans, were in heaven's wisdom
+doomed to suffer. Menelaus asked me what it was that had brought me to
+Lacedaemon, and I told him the whole truth, whereon he said, 'So, then,
+these cowards would usurp a brave man's bed? A hind might as well lay
+her new-born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell. The lion, when he comes back to his lair,
+will make short work with the pair of them, and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Greeks cheered him--if he is still
+such, and were to come near these suitors, they would have a short
+shrift and a sorry wedding. As regards your question, however, I will
+not prevaricate nor deceive you, but what the old man of the sea told
+me, so much will I tell you in full. He said he could see Ulysses on
+an island sorrowing bitterly in the house of the nymph Calypso, who was
+keeping him prisoner, and he could not reach his home, for he had no
+ships nor sailors to take him over the sea.' This was what Menelaus told
+me, and when I had heard his story I came away; the gods then gave me a
+fair wind and soon brought me safe home again."
+
+With these words he moved the heart of Penelope. Then Theoclymenus said
+to her:
+
+"Madam, wife of Ulysses, Telemachus does not understand these things;
+listen therefore to me, for I can divine them surely, and will hide
+nothing from you. May Jove the king of heaven be my witness, and the
+rites of hospitality, with that hearth of Ulysses to which I now come,
+that Ulysses himself is even now in Ithaca, and, either going about the
+country or staying in one place, is enquiring into all these evil deeds
+and preparing a day of reckoning for the suitors. I saw an omen when I
+was on the ship which meant this, and I told Telemachus about it."
+
+"May it be even so," answered Penelope; "if your words come true, you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you."
+
+Thus did they converse. Meanwhile the suitors were throwing discs, or
+aiming with spears at a mark on the levelled ground in front of the
+house, and behaving with all their old insolence. But when it was now
+time for dinner, and the flock of sheep and goats had come into the town
+from all the country round, {140} with their shepherds as usual, then
+Medon, who was their favourite servant, and who waited upon them at
+table, said, "Now then, my young masters, you have had enough sport, so
+come inside that we may get dinner ready. Dinner is not a bad thing, at
+dinner time."
+
+They left their sports as he told them, and when they were within the
+house, they laid their cloaks on the benches and seats inside, and then
+sacrificed some sheep, goats, pigs, and a heifer, all of them fat and
+well grown. {141} Thus they made ready for their meal. In the meantime
+Ulysses and the swineherd were about starting for the town, and the
+swineherd said, "Stranger, I suppose you still want to go to town
+to-day, as my master said you were to do; for my own part I should have
+liked you to stay here as a station hand, but I must do as my master
+tells me, or he will scold me later on, and a scolding from one's master
+is a very serious thing. Let us then be off, for it is now broad day; it
+will be night again directly and then you will find it colder." {142}
+
+"I know, and understand you," replied Ulysses; "you need say no more.
+Let us be going, but if you have a stick ready cut, let me have it to
+walk with, for you say the road is a very rough one."
+
+As he spoke he threw his shabby old tattered wallet over his shoulders,
+by the cord from which it hung, and Eumaeus gave him a stick to his
+liking. The two then started, leaving the station in charge of the dogs
+and herdsmen who remained behind; the swineherd led the way and his
+master followed after, looking like some broken down old tramp as he
+leaned upon his staff, and his clothes were all in rags. When they had
+got over the rough steep ground and were nearing the city, they reached
+the fountain from which the citizens drew their water. This had
+been made by Ithacus, Neritus, and Polyctor. There was a grove of
+water-loving poplars planted in a circle all round it, and the clear
+cold water came down to it from a rock high up, {143} while above the
+fountain there was an altar to the nymphs, at which all wayfarers used
+to sacrifice. Here Melanthius son of Dolius overtook them as he was
+driving down some goats, the best in his flock, for the suitors' dinner,
+and there were two shepherds with him. When he saw Eumaeus and Ulysses
+he reviled them with outrageous and unseemly language, which made
+Ulysses very angry.
+
+"There you go," cried he, "and a precious pair you are. See how heaven
+brings birds of the same feather to one another. Where, pray, master
+swineherd, are you taking this poor miserable object? It would make any
+one sick to see such a creature at table. A fellow like this never won a
+prize for anything in his life, but will go about rubbing his shoulders
+against every man's door post, and begging, not for swords and cauldrons
+{144} like a man, but only for a few scraps not worth begging for. If
+you would give him to me for a hand on my station, he might do to clean
+out the folds, or bring a bit of sweet feed to the kids, and he could
+fatten his thighs as much as he pleased on whey; but he has taken to bad
+ways and will not go about any kind of work; he will do nothing but
+beg victuals all the town over, to feed his insatiable belly. I say,
+therefore--and it shall surely be--if he goes near Ulysses' house he
+will get his head broken by the stools they will fling at him, till they
+turn him out."
+
+On this, as he passed, he gave Ulysses a kick on the hip out of pure
+wantonness, but Ulysses stood firm, and did not budge from the path. For
+a moment he doubted whether or no to fly at Melanthius and kill him
+with his staff, or fling him to the ground and beat his brains out;
+he resolved, however, to endure it and keep himself in check, but the
+swineherd looked straight at Melanthius and rebuked him, lifting up his
+hands and praying to heaven as he did so.
+
+"Fountain nymphs," he cried, "children of Jove, if ever Ulysses burned
+you thigh bones covered with fat whether of lambs or kids, grant my
+prayer that heaven may send him home. He would soon put an end to
+the swaggering threats with which such men as you go about insulting
+people--gadding all over the town while your flocks are going to ruin
+through bad shepherding."
+
+Then Melanthius the goatherd answered, "You ill conditioned cur, what
+are you talking about? Some day or other I will put you on board ship
+and take you to a foreign country, where I can sell you and pocket the
+money you will fetch. I wish I were as sure that Apollo would strike
+Telemachus dead this very day, or that the suitors would kill him, as I
+am that Ulysses will never come home again."
+
+With this he left them to come on at their leisure, while he went
+quickly forward and soon reached the house of his master. When he
+got there he went in and took his seat among the suitors opposite
+Eurymachus, who liked him better than any of the others. The servants
+brought him a portion of meat, and an upper woman servant set bread
+before him that he might eat. Presently Ulysses and the swineherd came
+up to the house and stood by it, amid a sound of music, for Phemius was
+just beginning to sing to the suitors. Then Ulysses took hold of the
+swineherd's hand, and said:
+
+"Eumaeus, this house of Ulysses is a very fine place. No matter how far
+you go, you will find few like it. One building keeps following on after
+another. The outer court has a wall with battlements all round it; the
+doors are double folding, and of good workmanship; it would be a hard
+matter to take it by force of arms. I perceive, too, that there are many
+people banqueting within it, for there is a smell of roast meat, and
+I hear a sound of music, which the gods have made to go along with
+feasting."
+
+Then Eumaeus said, "You have perceived aright, as indeed you generally
+do; but let us think what will be our best course. Will you go inside
+first and join the suitors, leaving me here behind you, or will you wait
+here and let me go in first? But do not wait long, or some one may see
+you loitering about outside, and throw something at you. Consider this
+matter I pray you."
+
+And Ulysses answered, "I understand and heed. Go in first and leave
+me here where I am. I am quite used to being beaten and having things
+thrown at me. I have been so much buffeted about in war and by sea that
+I am case-hardened, and this too may go with the rest. But a man cannot
+hide away the cravings of a hungry belly; this is an enemy which gives
+much trouble to all men; it is because of this that ships are fitted out
+to sail the seas, and to make war upon other people."
+
+As they were thus talking, a dog that had been lying asleep raised his
+head and pricked up his ears. This was Argos, whom Ulysses had bred
+before setting out for Troy, but he had never had any work out of him.
+In the old days he used to be taken out by the young men when they went
+hunting wild goats, or deer, or hares, but now that his master was gone
+he was lying neglected on the heaps of mule and cow dung that lay in
+front of the stable doors till the men should come and draw it away
+to manure the great close; and he was full of fleas. As soon as he saw
+Ulysses standing there, he dropped his ears and wagged his tail, but he
+could not get close up to his master. When Ulysses saw the dog on the
+other side of the yard, he dashed a tear from his eyes without Eumaeus
+seeing it, and said:
+
+"Eumaeus, what a noble hound that is over yonder on the manure heap: his
+build is splendid; is he as fine a fellow as he looks, or is he only one
+of those dogs that come begging about a table, and are kept merely for
+show?"
+
+"This hound," answered Eumaeus, "belonged to him who has died in a far
+country. If he were what he was when Ulysses left for Troy, he would
+soon show you what he could do. There was not a wild beast in the forest
+that could get away from him when he was once on its tracks. But now he
+has fallen on evil times, for his master is dead and gone, and the women
+take no care of him. Servants never do their work when their master's
+hand is no longer over them, for Jove takes half the goodness out of a
+man when he makes a slave of him."
+
+As he spoke he went inside the buildings to the cloister where the
+suitors were, but Argos died as soon as he had recognised his master.
+
+Telemachus saw Eumaeus long before any one else did, and beckoned him
+to come and sit beside him; so he looked about and saw a seat lying
+near where the carver sat serving out their portions to the suitors; he
+picked it up, brought it to Telemachus's table, and sat down opposite
+him. Then the servant brought him his portion, and gave him bread from
+the bread-basket.
+
+Immediately afterwards Ulysses came inside, looking like a poor
+miserable old beggar, leaning on his staff and with his clothes all in
+rags. He sat down upon the threshold of ash-wood just inside the doors
+leading from the outer to the inner court, and against a bearing-post of
+cypress-wood which the carpenter had skilfully planed, and had made to
+join truly with rule and line. Telemachus took a whole loaf from the
+bread-basket, with as much meat as he could hold in his two hands, and
+said to Eumaeus, "Take this to the stranger, and tell him to go
+the round of the suitors, and beg from them; a beggar must not be
+shamefaced."
+
+So Eumaeus went up to him and said, "Stranger, Telemachus sends you
+this, and says you are to go the round of the suitors begging, for
+beggars must not be shamefaced."
+
+Ulysses answered, "May King Jove grant all happiness to Telemachus, and
+fulfil the desire of his heart."
+
+Then with both hands he took what Telemachus had sent him, and laid it
+on the dirty old wallet at his feet. He went on eating it while the
+bard was singing, and had just finished his dinner as he left off.
+The suitors applauded the bard, whereon Minerva went up to Ulysses and
+prompted him to beg pieces of bread from each one of the suitors, that
+he might see what kind of people they were, and tell the good from the
+bad; but come what might she was not going to save a single one of them.
+Ulysses, therefore, went on his round, going from left to right, and
+stretched out his hands to beg as though he were a real beggar. Some of
+them pitied him, and were curious about him, asking one another who
+he was and where he came from; whereon the goatherd Melanthius said,
+"Suitors of my noble mistress, I can tell you something about him, for I
+have seen him before. The swineherd brought him here, but I know nothing
+about the man himself, nor where he comes from."
+
+On this Antinous began to abuse the swineherd. "You precious idiot," he
+cried, "what have you brought this man to town for? Have we not tramps
+and beggars enough already to pester us as we sit at meat? Do you think
+it a small thing that such people gather here to waste your master's
+property--and must you needs bring this man as well?"
+
+And Eumaeus answered, "Antinous, your birth is good but your words evil.
+It was no doing of mine that he came here. Who is likely to invite a
+stranger from a foreign country, unless it be one of those who can do
+public service as a seer, a healer of hurts, a carpenter, or a bard who
+can charm us with his singing? Such men are welcome all the world over,
+but no one is likely to ask a beggar who will only worry him. You are
+always harder on Ulysses' servants than any of the other suitors
+are, and above all on me, but I do not care so long as Telemachus and
+Penelope are alive and here."
+
+But Telemachus said, "Hush, do not answer him; Antinous has the
+bitterest tongue of all the suitors, and he makes the others worse."
+
+Then turning to Antinous he said, "Antinous, you take as much care of
+my interests as though I were your son. Why should you want to see this
+stranger turned out of the house? Heaven forbid; take something and give
+it him yourself; I do not grudge it; I bid you take it. Never mind my
+mother, nor any of the other servants in the house; but I know you will
+not do what I say, for you are more fond of eating things yourself than
+of giving them to other people."
+
+"What do you mean, Telemachus," replied Antinous, "by this swaggering
+talk? If all the suitors were to give him as much as I will, he would
+not come here again for another three months."
+
+As he spoke he drew the stool on which he rested his dainty feet from
+under the table, and made as though he would throw it at Ulysses, but
+the other suitors all gave him something, and filled his wallet with
+bread and meat; he was about, therefore, to go back to the threshold and
+eat what the suitors had given him, but he first went up to Antinous and
+said:
+
+"Sir, give me something; you are not, surely, the poorest man here; you
+seem to be a chief, foremost among them all; therefore you should be the
+better giver, and I will tell far and wide of your bounty. I too was a
+rich man once, and had a fine house of my own; in those days I gave to
+many a tramp such as I now am, no matter who he might be nor what he
+wanted. I had any number of servants, and all the other things which
+people have who live well and are accounted wealthy, but it pleased Jove
+to take all away from me. He sent me with a band of roving robbers to
+Egypt; it was a long voyage and I was undone by it. I stationed my ships
+in the river Aegyptus, and bade my men stay by them and keep guard
+over them, while I sent out scouts to reconnoitre from every point of
+vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captives. The alarm was soon carried to the city, and when they
+heard the war-cry, the people came out at daybreak till the plain was
+filled with soldiers horse and foot, and with the gleam of armour. Then
+Jove spread panic among my men, and they would no longer face the enemy,
+for they found themselves surrounded. The Egyptians killed many of us,
+and took the rest alive to do forced labour for them; as for myself,
+they gave me to a friend who met them, to take to Cyprus, Dmetor by
+name, son of Iasus, who was a great man in Cyprus. Thence I am come
+hither in a state of great misery."
+
+Then Antinous said, "What god can have sent such a pestilence to plague
+us during our dinner? Get out, into the open part of the court, {145}
+or I will give you Egypt and Cyprus over again for your insolence and
+importunity; you have begged of all the others, and they have given you
+lavishly, for they have abundance round them, and it is easy to be free
+with other people's property when there is plenty of it."
+
+On this Ulysses began to move off, and said, "Your looks, my fine sir,
+are better than your breeding; if you were in your own house you would
+not spare a poor man so much as a pinch of salt, for though you are in
+another man's, and surrounded with abundance, you cannot find it in you
+to give him even a piece of bread."
+
+This made Antinous very angry, and he scowled at him saying, "You shall
+pay for this before you get clear of the court." With these words he
+threw a footstool at him, and hit him on the right shoulder blade near
+the top of his back. Ulysses stood firm as a rock and the blow did not
+even stagger him, but he shook his head in silence as he brooded on his
+revenge. Then he went back to the threshold and sat down there, laying
+his well filled wallet at his feet.
+
+"Listen to me," he cried, "you suitors of Queen Penelope, that I may
+speak even as I am minded. A man knows neither ache nor pain if he gets
+hit while fighting for his money, or for his sheep or his cattle; and
+even so Antinous has hit me while in the service of my miserable belly,
+which is always getting people into trouble. Still, if the poor have
+gods and avenging deities at all, I pray them that Antinous may come to
+a bad end before his marriage."
+
+"Sit where you are, and eat your victuals in silence, or be off
+elsewhere," shouted Antinous. "If you say more I will have you dragged
+hand and foot through the courts, and the servants shall flay you
+alive."
+
+The other suitors were much displeased at this, and one of the young men
+said, "Antinous, you did ill in striking that poor wretch of a tramp: it
+will be worse for you if he should turn out to be some god--and we know
+the gods go about disguised in all sorts of ways as people from foreign
+countries, and travel about the world to see who do amiss and who
+righteously." {146}
+
+Thus said the suitors, but Antinous paid them no heed. Meanwhile
+Telemachus was furious about the blow that had been given to his father,
+and though no tear fell from him, he shook his head in silence and
+brooded on his revenge.
+
+Now when Penelope heard that the beggar had been struck in the
+banqueting-cloister, she said before her maids, "Would that Apollo would
+so strike you, Antinous," and her waiting woman Eurynome answered, "If
+our prayers were answered not one of the suitors would ever again see
+the sun rise." Then Penelope said, "Nurse, {147} I hate every single one
+of them, for they mean nothing but mischief, but I hate Antinous like
+the darkness of death itself. A poor unfortunate tramp has come begging
+about the house for sheer want. Every one else has given him
+something to put in his wallet, but Antinous has hit him on the right
+shoulder-blade with a footstool."
+
+Thus did she talk with her maids as she sat in her own room, and in
+the meantime Ulysses was getting his dinner. Then she called for the
+swineherd and said, "Eumaeus, go and tell the stranger to come here, I
+want to see him and ask him some questions. He seems to have travelled
+much, and he may have seen or heard something of my unhappy husband."
+
+To this you answered, O swineherd Eumaeus, "If these Achaeans, Madam,
+would only keep quiet, you would be charmed with the history of his
+adventures. I had him three days and three nights with me in my hut,
+which was the first place he reached after running away from his ship,
+and he has not yet completed the story of his misfortunes. If he had
+been the most heaven-taught minstrel in the whole world, on whose lips
+all hearers hang entranced, I could not have been more charmed as I
+sat in my hut and listened to him. He says there is an old friendship
+between his house and that of Ulysses, and that he comes from Crete
+where the descendants of Minos live, after having been driven hither and
+thither by every kind of misfortune; he also declares that he has heard
+of Ulysses as being alive and near at hand among the Thesprotians, and
+that he is bringing great wealth home with him."
+
+"Call him here, then," said Penelope, "that I too may hear his story.
+As for the suitors, let them take their pleasure indoors or out as they
+will, for they have nothing to fret about. Their corn and wine remain
+unwasted in their houses with none but servants to consume them, while
+they keep hanging about our house day after day sacrificing our oxen,
+sheep, and fat goats for their banquets, and never giving so much as
+a thought to the quantity of wine they drink. No estate can stand such
+recklessness, for we have now no Ulysses to protect us. If he were to
+come again, he and his son would soon have their revenge."
+
+As she spoke Telemachus sneezed so loudly that the whole house resounded
+with it. Penelope laughed when she heard this, and said to Eumaeus, "Go
+and call the stranger; did you not hear how my son sneezed just as I
+was speaking? This can only mean that all the suitors are going to be
+killed, and that not one of them shall escape. Furthermore I say, and
+lay my saying to your heart: if I am satisfied that the stranger is
+speaking the truth I shall give him a shirt and cloak of good wear."
+
+When Eumaeus heard this he went straight to Ulysses and said, "Father
+stranger, my mistress Penelope, mother of Telemachus, has sent for you;
+she is in great grief, but she wishes to hear anything you can tell her
+about her husband, and if she is satisfied that you are speaking the
+truth, she will give you a shirt and cloak, which are the very things
+that you are most in want of. As for bread, you can get enough of that
+to fill your belly, by begging about the town, and letting those give
+that will."
+
+"I will tell Penelope," answered Ulysses, "nothing but what is strictly
+true. I know all about her husband, and have been partner with him
+in affliction, but I am afraid of passing through this crowd of cruel
+suitors, for their pride and insolence reach heaven. Just now, moreover,
+as I was going about the house without doing any harm, a man gave me
+a blow that hurt me very much, but neither Telemachus nor any one else
+defended me. Tell Penelope, therefore, to be patient and wait till
+sundown. Let her give me a seat close up to the fire, for my clothes are
+worn very thin--you know they are, for you have seen them ever since I
+first asked you to help me--she can then ask me about the return of her
+husband."
+
+The swineherd went back when he heard this, and Penelope said as she saw
+him cross the threshold, "Why do you not bring him here, Eumaeus? Is he
+afraid that some one will ill-treat him, or is he shy of coming inside
+the house at all? Beggars should not be shamefaced."
+
+To this you answered, O swineherd Eumaeus, "The stranger is quite
+reasonable. He is avoiding the suitors, and is only doing what any one
+else would do. He asks you to wait till sundown, and it will be much
+better, madam, that you should have him all to yourself, when you can
+hear him and talk to him as you will."
+
+"The man is no fool," answered Penelope, "it would very likely be as
+he says, for there are no such abominable people in the whole world as
+these men are."
+
+When she had done speaking Eumaeus went back to the suitors, for he had
+explained everything. Then he went up to Telemachus and said in his ear
+so that none could overhear him, "My dear sir, I will now go back to the
+pigs, to see after your property and my own business. You will look to
+what is going on here, but above all be careful to keep out of danger,
+for there are many who bear you ill will. May Jove bring them to a bad
+end before they do us a mischief."
+
+"Very well," replied Telemachus, "go home when you have had your dinner,
+and in the morning come here with the victims we are to sacrifice for
+the day. Leave the rest to heaven and me."
+
+On this Eumaeus took his seat again, and when he had finished his dinner
+he left the courts and the cloister with the men at table, and went
+back to his pigs. As for the suitors, they presently began to amuse
+themselves with singing and dancing, for it was now getting on towards
+evening.
+
+
+Book XVIII
+
+THE FIGHT WITH IRUS--ULYSSES WARNS AMPHINOMUS--PENELOPE GETS PRESENTS
+FROM THE SUITORS--THE BRAZIERS--ULYSSES REBUKES EURYMACHUS.
+
+Now there came a certain common tramp who used to go begging all over
+the city of Ithaca, and was notorious as an incorrigible glutton and
+drunkard. This man had no strength nor stay in him, but he was a great
+hulking fellow to look at; his real name, the one his mother gave him,
+was Arnaeus, but the young men of the place called him Irus, {148}
+because he used to run errands for any one who would send him. As soon
+as he came he began to insult Ulysses, and to try and drive him out of
+his own house.
+
+"Be off, old man," he cried, "from the doorway, or you shall be dragged
+out neck and heels. Do you not see that they are all giving me the wink,
+and wanting me to turn you out by force, only I do not like to do so?
+Get up then, and go of yourself, or we shall come to blows."
+
+Ulysses frowned on him and said, "My friend, I do you no manner of harm;
+people give you a great deal, but I am not jealous. There is room enough
+in this doorway for the pair of us, and you need not grudge me things
+that are not yours to give. You seem to be just such another tramp as
+myself, but perhaps the gods will give us better luck by and by. Do not,
+however, talk too much about fighting or you will incense me, and old
+though I am, I shall cover your mouth and chest with blood. I shall
+have more peace tomorrow if I do, for you will not come to the house of
+Ulysses any more."
+
+Irus was very angry and answered, "You filthy glutton, you run on
+trippingly like an old fish-fag. I have a good mind to lay both hands
+about you, and knock your teeth out of your head like so many boar's
+tusks. Get ready, therefore, and let these people here stand by and
+look on. You will never be able to fight one who is so much younger than
+yourself."
+
+Thus roundly did they rate one another on the smooth pavement in front
+of the doorway, {149} and when Antinous saw what was going on he laughed
+heartily and said to the others, "This is the finest sport that you
+ever saw; heaven never yet sent anything like it into this house. The
+stranger and Irus have quarreled and are going to fight, let us set them
+on to do so at once."
+
+The suitors all came up laughing, and gathered round the two ragged
+tramps. "Listen to me," said Antinous, "there are some goats' paunches
+down at the fire, which we have filled with blood and fat, and set aside
+for supper; he who is victorious and proves himself to be the better
+man shall have his pick of the lot; he shall be free of our table and we
+will not allow any other beggar about the house at all."
+
+The others all agreed, but Ulysses, to throw them off the scent, said,
+"Sirs, an old man like myself, worn out with suffering, cannot hold his
+own against a young one; but my irrepressible belly urges me on, though
+I know it can only end in my getting a drubbing. You must swear, however
+that none of you will give me a foul blow to favour Irus and secure him
+the victory."
+
+They swore as he told them, and when they had completed their oath
+Telemachus put in a word and said, "Stranger, if you have a mind to
+settle with this fellow, you need not be afraid of any one here. Whoever
+strikes you will have to fight more than one. I am host, and the other
+chiefs, Antinous and Eurymachus, both of them men of understanding, are
+of the same mind as I am."
+
+Every one assented, and Ulysses girded his old rags about his loins,
+thus baring his stalwart thighs, his broad chest and shoulders, and his
+mighty arms; but Minerva came up to him and made his limbs even stronger
+still. The suitors were beyond measure astonished, and one would turn
+towards his neighbour saying, "The stranger has brought such a thigh out
+of his old rags that there will soon be nothing left of Irus."
+
+Irus began to be very uneasy as he heard them, but the servants girded
+him by force, and brought him [into the open part of the court] in such
+a fright that his limbs were all of a tremble. Antinous scolded him and
+said, "You swaggering bully, you ought never to have been born at all if
+you are afraid of such an old broken down creature as this tramp is.
+I say, therefore--and it shall surely be--if he beats you and proves
+himself the better man, I shall pack you off on board ship to the
+mainland and send you to king Echetus, who kills every one that comes
+near him. He will cut off your nose and ears, and draw out your entrails
+for the dogs to eat."
+
+This frightened Irus still more, but they brought him into the middle
+of the court, and the two men raised their hands to fight. Then Ulysses
+considered whether he should let drive so hard at him as to make an end
+of him then and there, or whether he should give him a lighter blow that
+should only knock him down; in the end he deemed it best to give the
+lighter blow for fear the Achaeans should begin to suspect who he was.
+Then they began to fight, and Irus hit Ulysses on the right shoulder;
+but Ulysses gave Irus a blow on the neck under the ear that broke in the
+bones of his skull, and the blood came gushing out of his mouth; he fell
+groaning in the dust, gnashing his teeth and kicking on the ground, but
+the suitors threw up their hands and nearly died of laughter, as Ulysses
+caught hold of him by the foot and dragged him into the outer court as
+far as the gate-house. There he propped him up against the wall and put
+his staff in his hands. "Sit here," said he, "and keep the dogs and pigs
+off; you are a pitiful creature, and if you try to make yourself king of
+the beggars any more you shall fare still worse."
+
+Then he threw his dirty old wallet, all tattered and torn over his
+shoulder with the cord by which it hung, and went back to sit down upon
+the threshold; but the suitors went within the cloisters, laughing and
+saluting him, "May Jove, and all the other gods," said they, "grant
+you whatever you want for having put an end to the importunity of this
+insatiable tramp. We will take him over to the mainland presently, to
+king Echetus, who kills every one that comes near him."
+
+Ulysses hailed this as of good omen, and Antinous set a great goat's
+paunch before him filled with blood and fat. Amphinomus took two loaves
+out of the bread-basket and brought them to him, pledging him as he
+did so in a golden goblet of wine. "Good luck to you," he said, "father
+stranger, you are very badly off at present, but I hope you will have
+better times by and by."
+
+To this Ulysses answered, "Amphinomus, you seem to be a man of good
+understanding, as indeed you may well be, seeing whose son you are. I
+have heard your father well spoken of; he is Nisus of Dulichium, a man
+both brave and wealthy. They tell me you are his son, and you appear to
+be a considerable person; listen, therefore, and take heed to what I am
+saying. Man is the vainest of all creatures that have their being upon
+earth. As long as heaven vouchsafes him health and strength, he thinks
+that he shall come to no harm hereafter, and even when the blessed gods
+bring sorrow upon him, he bears it as he needs must, and makes the best
+of it; for God almighty gives men their daily minds day by day. I know
+all about it, for I was a rich man once, and did much wrong in the
+stubbornness of my pride, and in the confidence that my father and my
+brothers would support me; therefore let a man fear God in all things
+always, and take the good that heaven may see fit to send him without
+vain glory. Consider the infamy of what these suitors are doing; see how
+they are wasting the estate, and doing dishonour to the wife, of one who
+is certain to return some day, and that, too, not long hence. Nay, he
+will be here soon; may heaven send you home quietly first that you may
+not meet with him in the day of his coming, for once he is here the
+suitors and he will not part bloodlessly."
+
+With these words he made a drink-offering, and when he had drunk he put
+the gold cup again into the hands of Amphinomus, who walked away serious
+and bowing his head, for he foreboded evil. But even so he did not
+escape destruction, for Minerva had doomed him to fall by the hand of
+Telemachus. So he took his seat again at the place from which he had
+come.
+
+Then Minerva put it into the mind of Penelope to show herself to the
+suitors, that she might make them still more enamoured of her, and win
+still further honour from her son and husband. So she feigned a mocking
+laugh and said, "Eurynome, I have changed my mind, and have a fancy to
+show myself to the suitors although I detest them. I should like also to
+give my son a hint that he had better not have anything more to do with
+them. They speak fairly enough but they mean mischief."
+
+"My dear child," answered Eurynome, "all that you have said is true,
+go and tell your son about it, but first wash yourself and anoint your
+face. Do not go about with your cheeks all covered with tears; it is not
+right that you should grieve so incessantly; for Telemachus, whom you
+always prayed that you might live to see with a beard, is already grown
+up."
+
+"I know, Eurynome," replied Penelope, "that you mean well, but do not
+try and persuade me to wash and to anoint myself, for heaven robbed
+me of all my beauty on the day my husband sailed; nevertheless, tell
+Autonoe and Hippodamia that I want them. They must be with me when I
+am in the cloister; I am not going among the men alone; it would not be
+proper for me to do so."
+
+On this the old woman {150} went out of the room to bid the maids go to
+their mistress. In the meantime Minerva bethought her of another matter,
+and sent Penelope off into a sweet slumber; so she lay down on her couch
+and her limbs became heavy with sleep. Then the goddess shed grace and
+beauty over her that all the Achaeans might admire her. She washed
+her face with the ambrosial loveliness that Venus wears when she goes
+dancing with the Graces; she made her taller and of a more commanding
+figure, while as for her complexion it was whiter than sawn ivory. When
+Minerva had done all this she went away, whereon the maids came in from
+the women's room and woke Penelope with the sound of their talking.
+
+"What an exquisitely delicious sleep I have been having," said she, as
+she passed her hands over her face, "in spite of all my misery. I wish
+Diana would let me die so sweetly now at this very moment, that I
+might no longer waste in despair for the loss of my dear husband, who
+possessed every kind of good quality and was the most distinguished man
+among the Achaeans."
+
+With these words she came down from her upper room, not alone but
+attended by two of her maidens, and when she reached the suitors she
+stood by one of the bearing-posts supporting the roof of the cloister,
+holding a veil before her face, and with a staid maid servant on either
+side of her. As they beheld her the suitors were so overpowered and
+became so desperately enamoured of her, that each one prayed he might
+win her for his own bed fellow.
+
+"Telemachus," said she, addressing her son, "I fear you are no longer so
+discreet and well conducted as you used to be. When you were younger you
+had a greater sense of propriety; now, however, that you are grown up,
+though a stranger to look at you would take you for the son of a well to
+do father as far as size and good looks go, your conduct is by no means
+what it should be. What is all this disturbance that has been going on,
+and how came you to allow a stranger to be so disgracefully ill-treated?
+What would have happened if he had suffered serious injury while a
+suppliant in our house? Surely this would have been very discreditable
+to you."
+
+"I am not surprised, my dear mother, at your displeasure," replied
+Telemachus, "I understand all about it and know when things are not
+as they should be, which I could not do when I was younger; I cannot,
+however, behave with perfect propriety at all times. First one and then
+another of these wicked people here keeps driving me out of my mind,
+and I have no one to stand by me. After all, however, this fight between
+Irus and the stranger did not turn out as the suitors meant it to do,
+for the stranger got the best of it. I wish Father Jove, Minerva, and
+Apollo would break the neck of every one of these wooers of yours, some
+inside the house and some out; and I wish they might all be as limp as
+Irus is over yonder in the gate of the outer court. See how he nods
+his head like a drunken man; he has had such a thrashing that he cannot
+stand on his feet nor get back to his home, wherever that may be, for he
+has no strength left in him."
+
+Thus did they converse. Eurymachus then came up and said, "Queen
+Penelope, daughter of Icarius, if all the Achaeans in Iasian Argos could
+see you at this moment, you would have still more suitors in your house
+by tomorrow morning, for you are the most admirable woman in the whole
+world both as regards personal beauty and strength of understanding."
+
+To this Penelope replied, "Eurymachus, heaven robbed me of all my beauty
+whether of face or figure when the Argives set sail for Troy and my dear
+husband with them. If he were to return and look after my affairs, I
+should both be more respected and show a better presence to the world.
+As it is, I am oppressed with care, and with the afflictions which
+heaven has seen fit to heap upon me. My husband foresaw it all, and when
+he was leaving home he took my right wrist in his hand--'Wife,' he said,
+'we shall not all of us come safe home from Troy, for the Trojans fight
+well both with bow and spear. They are excellent also at fighting from
+chariots, and nothing decides the issue of a fight sooner than this. I
+know not, therefore, whether heaven will send me back to you, or whether
+I may not fall over there at Troy. In the meantime do you look after
+things here. Take care of my father and mother as at present, and even
+more so during my absence, but when you see our son growing a beard,
+then marry whom you will, and leave this your present home.' This is
+what he said and now it is all coming true. A night will come when I
+shall have to yield myself to a marriage which I detest, for Jove has
+taken from me all hope of happiness. This further grief, moreover, cuts
+me to the very heart. You suitors are not wooing me after the custom of
+my country. When men are courting a woman who they think will be a good
+wife to them and who is of noble birth, and when they are each trying
+to win her for himself, they usually bring oxen and sheep to feast the
+friends of the lady, and they make her magnificent presents, instead of
+eating up other people's property without paying for it."
+
+This was what she said, and Ulysses was glad when he heard her trying
+to get presents out of the suitors, and flattering them with fair words
+which he knew she did not mean.
+
+Then Antinous said, "Queen Penelope, daughter of Icarius, take as many
+presents as you please from any one who will give them to you; it is not
+well to refuse a present; but we will not go about our business nor stir
+from where we are, till you have married the best man among us whoever
+he may be."
+
+The others applauded what Antinous had said, and each one sent his
+servant to bring his present. Antinous's man returned with a large and
+lovely dress most exquisitely embroidered. It had twelve beautifully
+made brooch pins of pure gold with which to fasten it. Eurymachus
+immediately brought her a magnificent chain of gold and amber beads that
+gleamed like sunlight. Eurydamas's two men returned with some
+earrings fashioned into three brilliant pendants which glistened most
+beautifully; while king Pisander son of Polyctor gave her a necklace
+of the rarest workmanship, and every one else brought her a beautiful
+present of some kind.
+
+Then the queen went back to her room upstairs, and her maids brought the
+presents after her. Meanwhile the suitors took to singing and dancing,
+and stayed till evening came. They danced and sang till it grew dark;
+they then brought in three braziers {151} to give light, and piled them
+up with chopped firewood very old and dry, and they lit torches from
+them, which the maids held up turn and turn about. Then Ulysses said:
+
+"Maids, servants of Ulysses who has so long been absent, go to the queen
+inside the house; sit with her and amuse her, or spin, and pick wool.
+I will hold the light for all these people. They may stay till morning,
+but shall not beat me, for I can stand a great deal."
+
+The maids looked at one another and laughed, while pretty Melantho began
+to gibe at him contemptuously. She was daughter to Dolius, but had been
+brought up by Penelope, who used to give her toys to play with, and
+looked after her when she was a child; but in spite of all this she
+showed no consideration for the sorrows of her mistress, and used to
+misconduct herself with Eurymachus, with whom she was in love.
+
+"Poor wretch," said she, "are you gone clean out of your mind? Go and
+sleep in some smithy, or place of public gossips, instead of chattering
+here. Are you not ashamed of opening your mouth before your betters--so
+many of them too? Has the wine been getting into your head, or do you
+always babble in this way? You seem to have lost your wits because you
+beat the tramp Irus; take care that a better man than he does not come
+and cudgel you about the head till he pack you bleeding out of the
+house."
+
+"Vixen," replied Ulysses, scowling at her, "I will go and tell
+Telemachus what you have been saying, and he will have you torn limb
+from limb."
+
+With these words he scared the women, and they went off into the body
+of the house. They trembled all over, for they thought he would do as he
+said. But Ulysses took his stand near the burning braziers, holding up
+torches and looking at the people--brooding the while on things that
+should surely come to pass.
+
+But Minerva would not let the suitors for one moment cease their
+insolence, for she wanted Ulysses to become even more bitter against
+them; she therefore set Eurymachus son of Polybus on to gibe at him,
+which made the others laugh. "Listen to me," said he, "you suitors of
+Queen Penelope, that I may speak even as I am minded. It is not for
+nothing that this man has come to the house of Ulysses; I believe the
+light has not been coming from the torches, but from his own head--for
+his hair is all gone, every bit of it."
+
+Then turning to Ulysses he said, "Stranger, will you work as a servant,
+if I send you to the wolds and see that you are well paid? Can you build
+a stone fence, or plant trees? I will have you fed all the year round,
+and will find you in shoes and clothing. Will you go, then? Not you; for
+you have got into bad ways, and do not want to work; you had rather fill
+your belly by going round the country begging."
+
+"Eurymachus," answered Ulysses, "if you and I were to work one against
+the other in early summer when the days are at their longest--give me a
+good scythe, and take another yourself, and let us see which will last
+the longer or mow the stronger, from dawn till dark when the mowing
+grass is about. Or if you will plough against me, let us each take a
+yoke of tawny oxen, well-mated and of great strength and endurance:
+turn me into a four acre field, and see whether you or I can drive the
+straighter furrow. If, again, war were to break out this day, give me
+a shield, a couple of spears and a helmet fitting well upon my
+temples--you would find me foremost in the fray, and would cease your
+gibes about my belly. You are insolent and cruel, and think yourself
+a great man because you live in a little world, and that a bad one. If
+Ulysses comes to his own again, the doors of his house are wide, but you
+will find them narrow when you try to fly through them."
+
+Eurymachus was furious at all this. He scowled at him and cried, "You
+wretch, I will soon pay you out for daring to say such things to me, and
+in public too. Has the wine been getting into your head or do you always
+babble in this way? You seem to have lost your wits because you beat the
+tramp Irus." With this he caught hold of a footstool, but Ulysses sought
+protection at the knees of Amphinomus of Dulichium, for he was afraid.
+The stool hit the cupbearer on his right hand and knocked him down: the
+man fell with a cry flat on his back, and his wine-jug fell ringing to
+the ground. The suitors in the covered cloister were now in an uproar,
+and one would turn towards his neighbour, saying, "I wish the stranger
+had gone somewhere else, bad luck to him, for all the trouble he gives
+us. We cannot permit such disturbance about a beggar; if such ill
+counsels are to prevail we shall have no more pleasure at our banquet."
+
+On this Telemachus came forward and said, "Sirs, are you mad? Can you
+not carry your meat and your liquor decently? Some evil spirit has
+possessed you. I do not wish to drive any of you away, but you have had
+your suppers, and the sooner you all go home to bed the better."
+
+The suitors bit their lips and marvelled at the boldness of his speech;
+but Amphinomus the son of Nisus, who was son to Aretias, said, "Do not
+let us take offence; it is reasonable, so let us make no answer. Neither
+let us do violence to the stranger nor to any of Ulysses' servants. Let
+the cupbearer go round with the drink-offerings, that we may make them
+and go home to our rest. As for the stranger, let us leave Telemachus to
+deal with him, for it is to his house that he has come."
+
+Thus did he speak, and his saying pleased them well, so Mulius of
+Dulichium, servant to Amphinomus, mixed them a bowl of wine and water
+and handed it round to each of them man by man, whereon they made their
+drink-offerings to the blessed gods: Then, when they had made their
+drink-offerings and had drunk each one as he was minded, they took their
+several ways each of them to his own abode.
+
+
+Book XIX
+
+TELEMACHUS AND ULYSSES REMOVE THE ARMOUR--ULYSSES INTERVIEWS
+PENELOPE--EURYCLEA WASHES HIS FEET AND RECOGNISES THE SCAR ON HIS
+LEG--PENELOPE TELLS HER DREAM TO ULYSSES.
+
+Ulysses was left in the cloister, pondering on the means whereby with
+Minerva's help he might be able to kill the suitors. Presently he said
+to Telemachus, "Telemachus, we must get the armour together and take
+it down inside. Make some excuse when the suitors ask you why you have
+removed it. Say that you have taken it to be out of the way of the
+smoke, inasmuch as it is no longer what it was when Ulysses went
+away, but has become soiled and begrimed with soot. Add to this more
+particularly that you are afraid Jove may set them on to quarrel over
+their wine, and that they may do each other some harm which may disgrace
+both banquet and wooing, for the sight of arms sometimes tempts people
+to use them."
+
+Telemachus approved of what his father had said, so he called nurse
+Euryclea and said, "Nurse, shut the women up in their room, while I take
+the armour that my father left behind him down into the store room. No
+one looks after it now my father is gone, and it has got all smirched
+with soot during my own boyhood. I want to take it down where the smoke
+cannot reach it."
+
+"I wish, child," answered Euryclea, "that you would take the management
+of the house into your own hands altogether, and look after all the
+property yourself. But who is to go with you and light you to the
+store-room? The maids would have done so, but you would not let them."
+
+"The stranger," said Telemachus, "shall show me a light; when people eat
+my bread they must earn it, no matter where they come from."
+
+Euryclea did as she was told, and bolted the women inside their room.
+Then Ulysses and his son made all haste to take the helmets, shields,
+and spears inside; and Minerva went before them with a gold lamp in her
+hand that shed a soft and brilliant radiance, whereon Telemachus said,
+"Father, my eyes behold a great marvel: the walls, with the rafters,
+crossbeams, and the supports on which they rest are all aglow as with
+a flaming fire. Surely there is some god here who has come down from
+heaven."
+
+"Hush," answered Ulysses, "hold your peace and ask no questions, for
+this is the manner of the gods. Get you to your bed, and leave me here
+to talk with your mother and the maids. Your mother in her grief will
+ask me all sorts of questions."
+
+On this Telemachus went by torch-light to the other side of the inner
+court, to the room in which he always slept. There he lay in his bed
+till morning, while Ulysses was left in the cloister pondering on the
+means whereby with Minerva's help he might be able to kill the suitors.
+
+Then Penelope came down from her room looking like Venus or Diana, and
+they set her a seat inlaid with scrolls of silver and ivory near the
+fire in her accustomed place. It had been made by Icmalius and had a
+footstool all in one piece with the seat itself; and it was covered with
+a thick fleece: on this she now sat, and the maids came from the women's
+room to join her. They set about removing the tables at which the wicked
+suitors had been dining, and took away the bread that was left, with
+the cups from which they had drunk. They emptied the embers out of the
+braziers, and heaped much wood upon them to give both light and heat;
+but Melantho began to rail at Ulysses a second time and said, "Stranger,
+do you mean to plague us by hanging about the house all night and spying
+upon the women? Be off, you wretch, outside, and eat your supper there,
+or you shall be driven out with a firebrand."
+
+Ulysses scowled at her and answered, "My good woman, why should you be
+so angry with me? Is it because I am not clean, and my clothes are all
+in rags, and because I am obliged to go begging about after the manner
+of tramps and beggars generally? I too was a rich man once, and had a
+fine house of my own; in those days I gave to many a tramp such as I now
+am, no matter who he might be nor what he wanted. I had any number of
+servants, and all the other things which people have who live well and
+are accounted wealthy, but it pleased Jove to take all away from me;
+therefore, woman, beware lest you too come to lose that pride and place
+in which you now wanton above your fellows; have a care lest you get
+out of favour with your mistress, and lest Ulysses should come home, for
+there is still a chance that he may do so. Moreover, though he be dead
+as you think he is, yet by Apollo's will he has left a son behind him,
+Telemachus, who will note anything done amiss by the maids in the house,
+for he is now no longer in his boyhood."
+
+Penelope heard what he was saying and scolded the maid, "Impudent
+baggage," said she, "I see how abominably you are behaving, and you
+shall smart for it. You knew perfectly well, for I told you myself, that
+I was going to see the stranger and ask him about my husband, for whose
+sake I am in such continual sorrow."
+
+Then she said to her head waiting woman Eurynome, "Bring a seat with a
+fleece upon it, for the stranger to sit upon while he tells his story,
+and listens to what I have to say. I wish to ask him some questions."
+
+Eurynome brought the seat at once and set a fleece upon it, and as soon
+as Ulysses had sat down Penelope began by saying, "Stranger, I shall
+first ask you who and whence are you? Tell me of your town and parents."
+
+"Madam," answered Ulysses, "who on the face of the whole earth can dare
+to chide with you? Your fame reaches the firmament of heaven itself; you
+are like some blameless king, who upholds righteousness, as the monarch
+over a great and valiant nation: the earth yields its wheat and barley,
+the trees are loaded with fruit, the ewes bring forth lambs, and the sea
+abounds with fish by reason of his virtues, and his people do good deeds
+under him. Nevertheless, as I sit here in your house, ask me some other
+question and do not seek to know my race and family, or you will recall
+memories that will yet more increase my sorrow. I am full of heaviness,
+but I ought not to sit weeping and wailing in another person's house,
+nor is it well to be thus grieving continually. I shall have one of the
+servants or even yourself complaining of me, and saying that my eyes
+swim with tears because I am heavy with wine."
+
+Then Penelope answered, "Stranger, heaven robbed me of all beauty,
+whether of face or figure, when the Argives set sail for Troy and my
+dear husband with them. If he were to return and look after my affairs
+I should be both more respected and should show a better presence to
+the world. As it is, I am oppressed with care, and with the afflictions
+which heaven has seen fit to heap upon me. The chiefs from all our
+islands--Dulichium, Same, and Zacynthus, as also from Ithaca itself,
+are wooing me against my will and are wasting my estate. I can therefore
+show no attention to strangers, nor suppliants, nor to people who say
+that they are skilled artisans, but am all the time broken-hearted
+about Ulysses. They want me to marry again at once, and I have to invent
+stratagems in order to deceive them. In the first place heaven put it in
+my mind to set up a great tambour-frame in my room, and to begin
+working upon an enormous piece of fine needlework. Then I said to them,
+'Sweethearts, Ulysses is indeed dead, still, do not press me to marry
+again immediately; wait--for I would not have my skill in needlework
+perish unrecorded--till I have finished making a pall for the hero
+Laertes, to be ready against the time when death shall take him. He
+is very rich, and the women of the place will talk if he is laid out
+without a pall.' This was what I said, and they assented; whereon I
+used to keep working at my great web all day long, but at night I would
+unpick the stitches again by torch light. I fooled them in this way for
+three years without their finding it out, but as time wore on and I was
+now in my fourth year, in the waning of moons, and many days had been
+accomplished, those good for nothing hussies my maids betrayed me to the
+suitors, who broke in upon me and caught me; they were very angry with
+me, so I was forced to finish my work whether I would or no. And now
+I do not see how I can find any further shift for getting out of this
+marriage. My parents are putting great pressure upon me, and my son
+chafes at the ravages the suitors are making upon his estate, for he is
+now old enough to understand all about it and is perfectly able to look
+after his own affairs, for heaven has blessed him with an excellent
+disposition. Still, notwithstanding all this, tell me who you are and
+where you come from--for you must have had father and mother of some
+sort; you cannot be the son of an oak or of a rock."
+
+Then Ulysses answered, "Madam, wife of Ulysses, since you persist in
+asking me about my family, I will answer, no matter what it costs me:
+people must expect to be pained when they have been exiles as long as
+I have, and suffered as much among as many peoples. Nevertheless, as
+regards your question I will tell you all you ask. There is a fair and
+fruitful island in mid-ocean called Crete; it is thickly peopled and
+there are ninety cities in it: the people speak many different languages
+which overlap one another, for there are Achaeans, brave Eteocretans,
+Dorians of three-fold race, and noble Pelasgi. There is a great
+town there, Cnossus, where Minos reigned who every nine years had a
+conference with Jove himself. {152} Minos was father to Deucalion, whose
+son I am, for Deucalion had two sons Idomeneus and myself. Idomeneus
+sailed for Troy, and I, who am the younger, am called Aethon; my
+brother, however, was at once the older and the more valiant of the two;
+hence it was in Crete that I saw Ulysses and showed him hospitality, for
+the winds took him there as he was on his way to Troy, carrying him out
+of his course from cape Malea and leaving him in Amnisus off the cave of
+Ilithuia, where the harbours are difficult to enter and he could hardly
+find shelter from the winds that were then raging. As soon as he got
+there he went into the town and asked for Idomeneus, claiming to be his
+old and valued friend, but Idomeneus had already set sail for Troy some
+ten or twelve days earlier, so I took him to my own house and showed him
+every kind of hospitality, for I had abundance of everything. Moreover,
+I fed the men who were with him with barley meal from the public store,
+and got subscriptions of wine and oxen for them to sacrifice to their
+heart's content. They stayed with me twelve days, for there was a gale
+blowing from the North so strong that one could hardly keep one's feet
+on land. I suppose some unfriendly god had raised it for them, but on
+the thirteenth day the wind dropped, and they got away."
+
+Many a plausible tale did Ulysses further tell her, and Penelope wept
+as she listened, for her heart was melted. As the snow wastes upon the
+mountain tops when the winds from South East and West have breathed upon
+it and thawed it till the rivers run bank full with water, even so did
+her cheeks overflow with tears for the husband who was all the time
+sitting by her side. Ulysses felt for her and was sorry for her, but he
+kept his eyes as hard as horn or iron without letting them so much
+as quiver, so cunningly did he restrain his tears. Then, when she had
+relieved herself by weeping, she turned to him again and said: "Now,
+stranger, I shall put you to the test and see whether or no you really
+did entertain my husband and his men, as you say you did. Tell me, then,
+how he was dressed, what kind of a man he was to look at, and so also
+with his companions."
+
+"Madam," answered Ulysses, "it is such a long time ago that I can hardly
+say. Twenty years are come and gone since he left my home, and went
+elsewhither; but I will tell you as well as I can recollect. Ulysses
+wore a mantle of purple wool, double lined, and it was fastened by a
+gold brooch with two catches for the pin. On the face of this there was
+a device that shewed a dog holding a spotted fawn between his fore paws,
+and watching it as it lay panting upon the ground. Every one marvelled
+at the way in which these things had been done in gold, the dog
+looking at the fawn, and strangling it, while the fawn was struggling
+convulsively to escape. {153} As for the shirt that he wore next his
+skin, it was so soft that it fitted him like the skin of an onion, and
+glistened in the sunlight to the admiration of all the women who beheld
+it. Furthermore I say, and lay my saying to your heart, that I do not
+know whether Ulysses wore these clothes when he left home, or whether
+one of his companions had given them to him while he was on his voyage;
+or possibly some one at whose house he was staying made him a present
+of them, for he was a man of many friends and had few equals among the
+Achaeans. I myself gave him a sword of bronze and a beautiful purple
+mantle, double lined, with a shirt that went down to his feet, and I
+sent him on board his ship with every mark of honour. He had a servant
+with him, a little older than himself, and I can tell you what he was
+like; his shoulders were hunched, {154} he was dark, and he had thick
+curly hair. His name was Eurybates, and Ulysses treated him with greater
+familiarity than he did any of the others, as being the most like-minded
+with himself."
+
+Penelope was moved still more deeply as she heard the indisputable
+proofs that Ulysses laid before her; and when she had again found relief
+in tears she said to him, "Stranger, I was already disposed to pity you,
+but henceforth you shall be honoured and made welcome in my house. It
+was I who gave Ulysses the clothes you speak of. I took them out of
+the store room and folded them up myself, and I gave him also the gold
+brooch to wear as an ornament. Alas! I shall never welcome him home
+again. It was by an ill fate that he ever set out for that detested city
+whose very name I cannot bring myself even to mention."
+
+Then Ulysses answered, "Madam, wife of Ulysses, do not disfigure
+yourself further by grieving thus bitterly for your loss, though I can
+hardly blame you for doing so. A woman who has loved her husband and
+borne him children, would naturally be grieved at losing him, even
+though he were a worse man than Ulysses, who they say was like a god.
+Still, cease your tears and listen to what I can tell you. I will hide
+nothing from you, and can say with perfect truth that I have lately
+heard of Ulysses as being alive and on his way home; he is among the
+Thesprotians, and is bringing back much valuable treasure that he has
+begged from one and another of them; but his ship and all his crew
+were lost as they were leaving the Thrinacian island, for Jove and
+the sun-god were angry with him because his men had slaughtered the
+sun-god's cattle, and they were all drowned to a man. But Ulysses
+stuck to the keel of the ship and was drifted on to the land of the
+Phaeacians, who are near of kin to the immortals, and who treated him
+as though he had been a god, giving him many presents, and wishing to
+escort him home safe and sound. In fact Ulysses would have been here
+long ago, had he not thought better to go from land to land gathering
+wealth; for there is no man living who is so wily as he is; there is no
+one can compare with him. Pheidon king of the Thesprotians told me all
+this, and he swore to me--making drink-offerings in his house as he did
+so--that the ship was by the water side and the crew found who would
+take Ulysses to his own country. He sent me off first, for there
+happened to be a Thesprotian ship sailing for the wheat-growing
+island of Dulichium, but he showed me all the treasure Ulysses had got
+together, and he had enough lying in the house of king Pheidon to keep
+his family for ten generations; but the king said Ulysses had gone to
+Dodona that he might learn Jove's mind from the high oak tree, and know
+whether after so long an absence he should return to Ithaca openly or in
+secret. So you may know he is safe and will be here shortly; he is close
+at hand and cannot remain away from home much longer; nevertheless I
+will confirm my words with an oath, and call Jove who is the first and
+mightiest of all gods to witness, as also that hearth of Ulysses to
+which I have now come, that all I have spoken shall surely come to pass.
+Ulysses will return in this self same year; with the end of this moon
+and the beginning of the next he will be here."
+
+"May it be even so," answered Penelope; "if your words come true you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you; but I know very well how it will be. Ulysses
+will not return, neither will you get your escort hence, for so surely
+as that Ulysses ever was, there are now no longer any such masters in
+the house as he was, to receive honourable strangers or to further them
+on their way home. And now, you maids, wash his feet for him, and make
+him a bed on a couch with rugs and blankets, that he may be warm and
+quiet till morning. Then, at day break wash him and anoint him again,
+that he may sit in the cloister and take his meals with Telemachus. It
+shall be the worse for any one of these hateful people who is uncivil to
+him; like it or not, he shall have no more to do in this house. For how,
+sir, shall you be able to learn whether or no I am superior to others of
+my sex both in goodness of heart and understanding, if I let you dine in
+my cloisters squalid and ill clad? Men live but for a little season; if
+they are hard, and deal hardly, people wish them ill so long as they are
+alive, and speak contemptuously of them when they are dead, but he that
+is righteous and deals righteously, the people tell of his praise among
+all lands, and many shall call him blessed."
+
+Ulysses answered, "Madam, I have foresworn rugs and blankets from the
+day that I left the snowy ranges of Crete to go on shipboard. I will
+lie as I have lain on many a sleepless night hitherto. Night after night
+have I passed in any rough sleeping place, and waited for morning. Nor,
+again, do I like having my feet washed; I shall not let any of the young
+hussies about your house touch my feet; but, if you have any old and
+respectable woman who has gone through as much trouble as I have, I will
+allow her to wash them."
+
+To this Penelope said, "My dear sir, of all the guests who ever yet
+came to my house there never was one who spoke in all things with such
+admirable propriety as you do. There happens to be in the house a most
+respectable old woman--the same who received my poor dear husband in
+her arms the night he was born, and nursed him in infancy. She is
+very feeble now, but she shall wash your feet." "Come here," said she,
+"Euryclea, and wash your master's age-mate; I suppose Ulysses' hands and
+feet are very much the same now as his are, for trouble ages all of us
+dreadfully fast."
+
+On these words the old woman covered her face with her hands; she began
+to weep and made lamentation saying, "My dear child, I cannot think
+whatever I am to do with you. I am certain no one was ever more
+god-fearing than yourself, and yet Jove hates you. No one in the whole
+world ever burned him more thigh bones, nor gave him finer hecatombs
+when you prayed you might come to a green old age yourself and see your
+son grow up to take after you: yet see how he has prevented you alone
+from ever getting back to your own home. I have no doubt the women in
+some foreign palace which Ulysses has got to are gibing at him as all
+these sluts here have been gibing at you. I do not wonder at your
+not choosing to let them wash you after the manner in which they have
+insulted you; I will wash your feet myself gladly enough, as Penelope
+has said that I am to do so; I will wash them both for Penelope's
+sake and for your own, for you have raised the most lively feelings of
+compassion in my mind; and let me say this moreover, which pray attend
+to; we have had all kinds of strangers in distress come here before now,
+but I make bold to say that no one ever yet came who was so like Ulysses
+in figure, voice, and feet as you are."
+
+"Those who have seen us both," answered Ulysses, "have always said we
+were wonderfully like each other, and now you have noticed it too."
+
+Then the old woman took the cauldron in which she was going to wash his
+feet, and poured plenty of cold water into it, adding hot till the bath
+was warm enough. Ulysses sat by the fire, but ere long he turned away
+from the light, for it occurred to him that when the old woman had hold
+of his leg she would recognise a certain scar which it bore, whereon the
+whole truth would come out. And indeed as soon as she began washing her
+master, she at once knew the scar as one that had been given him by
+a wild boar when he was hunting on Mt. Parnassus with his excellent
+grandfather Autolycus--who was the most accomplished thief and perjurer
+in the whole world--and with the sons of Autolycus. Mercury himself had
+endowed him with this gift, for he used to burn the thigh bones of goats
+and kids to him, so he took pleasure in his companionship. It happened
+once that Autolycus had gone to Ithaca and had found the child of his
+daughter just born. As soon as he had done supper Euryclea set the
+infant upon his knees and said, "Autolycus, you must find a name for
+your grandson; you greatly wished that you might have one."
+
+"Son-in-law and daughter," replied Autolycus, "call the child thus: I
+am highly displeased with a large number of people in one place and
+another, both men and women; so name the child 'Ulysses,' or the child
+of anger. When he grows up and comes to visit his mother's family on Mt.
+Parnassus, where my possessions lie, I will make him a present and will
+send him on his way rejoicing."
+
+Ulysses, therefore, went to Parnassus to get the presents from
+Autolycus, who with his sons shook hands with him and gave him welcome.
+His grandmother Amphithea threw her arms about him, and kissed his head,
+and both his beautiful eyes, while Autolycus desired his sons to get
+dinner ready, and they did as he told them. They brought in a five year
+old bull, flayed it, made it ready and divided it into joints; these
+they then cut carefully up into smaller pieces and spitted them; they
+roasted them sufficiently and served the portions round. Thus through
+the livelong day to the going down of the sun they feasted, and every
+man had his full share so that all were satisfied; but when the sun set
+and it came on dark, they went to bed and enjoyed the boon of sleep.
+
+When the child of morning, rosy-fingered Dawn, appeared, the sons of
+Autolycus went out with their hounds hunting, and Ulysses went too.
+They climbed the wooded slopes of Parnassus and soon reached its breezy
+upland valleys; but as the sun was beginning to beat upon the fields,
+fresh-risen from the slow still currents of Oceanus, they came to a
+mountain dell. The dogs were in front searching for the tracks of the
+beast they were chasing, and after them came the sons of Autolycus,
+among whom was Ulysses, close behind the dogs, and he had a long
+spear in his hand. Here was the lair of a huge boar among some thick
+brushwood, so dense that the wind and rain could not get through it, nor
+could the sun's rays pierce it, and the ground underneath lay thick
+with fallen leaves. The boar heard the noise of the men's feet, and the
+hounds baying on every side as the huntsmen came up to him, so he rushed
+from his lair, raised the bristles on his neck, and stood at bay with
+fire flashing from his eyes. Ulysses was the first to raise his spear
+and try to drive it into the brute, but the boar was too quick for him,
+and charged him sideways, ripping him above the knee with a gash that
+tore deep though it did not reach the bone. As for the boar, Ulysses hit
+him on the right shoulder, and the point of the spear went right through
+him, so that he fell groaning in the dust until the life went out of
+him. The sons of Autolycus busied themselves with the carcass of the
+boar, and bound Ulysses' wound; then, after saying a spell to stop the
+bleeding, they went home as fast as they could. But when Autolycus and
+his sons had thoroughly healed Ulysses, they made him some splendid
+presents, and sent him back to Ithaca with much mutual good will. When
+he got back, his father and mother were rejoiced to see him, and asked
+him all about it, and how he had hurt himself to get the scar; so he
+told them how the boar had ripped him when he was out hunting with
+Autolycus and his sons on Mt. Parnassus.
+
+As soon as Euryclea had got the scarred limb in her hands and had well
+hold of it, she recognised it and dropped the foot at once. The leg fell
+into the bath, which rang out and was overturned, so that all the water
+was spilt on the ground; Euryclea's eyes between her joy and her grief
+filled with tears, and she could not speak, but she caught Ulysses
+by the beard and said, "My dear child, I am sure you must be Ulysses
+himself, only I did not know you till I had actually touched and handled
+you."
+
+As she spoke she looked towards Penelope, as though wanting to tell her
+that her dear husband was in the house, but Penelope was unable to
+look in that direction and observe what was going on, for Minerva had
+diverted her attention; so Ulysses caught Euryclea by the throat with
+his right hand and with his left drew her close to him, and said,
+"Nurse, do you wish to be the ruin of me, you who nursed me at your own
+breast, now that after twenty years of wandering I am at last come to
+my own home again? Since it has been borne in upon you by heaven to
+recognise me, hold your tongue, and do not say a word about it to any
+one else in the house, for if you do I tell you--and it shall surely
+be--that if heaven grants me to take the lives of these suitors, I will
+not spare you, though you are my own nurse, when I am killing the other
+women."
+
+"My child," answered Euryclea, "what are you talking about? You know
+very well that nothing can either bend or break me. I will hold my
+tongue like a stone or a piece of iron; furthermore let me say, and lay
+my saying to your heart, when heaven has delivered the suitors into your
+hand, I will give you a list of the women in the house who have been
+ill-behaved, and of those who are guiltless."
+
+And Ulysses answered, "Nurse, you ought not to speak in that way; I am
+well able to form my own opinion about one and all of them; hold your
+tongue and leave everything to heaven."
+
+As he said this Euryclea left the cloister to fetch some more water, for
+the first had been all spilt; and when she had washed him and anointed
+him with oil, Ulysses drew his seat nearer to the fire to warm himself,
+and hid the scar under his rags. Then Penelope began talking to him and
+said:
+
+"Stranger, I should like to speak with you briefly about another matter.
+It is indeed nearly bed time--for those, at least, who can sleep in
+spite of sorrow. As for myself, heaven has given me a life of such
+unmeasurable woe, that even by day when I am attending to my duties and
+looking after the servants, I am still weeping and lamenting during the
+whole time; then, when night comes, and we all of us go to bed, I lie
+awake thinking, and my heart becomes a prey to the most incessant and
+cruel tortures. As the dun nightingale, daughter of Pandareus, sings in
+the early spring from her seat in shadiest covert hid, and with many
+a plaintive trill pours out the tale how by mishap she killed her own
+child Itylus, son of king Zethus, even so does my mind toss and turn in
+its uncertainty whether I ought to stay with my son here, and safeguard
+my substance, my bondsmen, and the greatness of my house, out of regard
+to public opinion and the memory of my late husband, or whether it is
+not now time for me to go with the best of these suitors who are wooing
+me and making me such magnificent presents. As long as my son was still
+young, and unable to understand, he would not hear of my leaving my
+husband's house, but now that he is full grown he begs and prays me to
+do so, being incensed at the way in which the suitors are eating up his
+property. Listen, then, to a dream that I have had and interpret it for
+me if you can. I have twenty geese about the house that eat mash out
+of a trough, {155} and of which I am exceedingly fond. I dreamed that a
+great eagle came swooping down from a mountain, and dug his curved beak
+into the neck of each of them till he had killed them all. Presently
+he soared off into the sky, and left them lying dead about the yard;
+whereon I wept in my dream till all my maids gathered round me, so
+piteously was I grieving because the eagle had killed my geese. Then he
+came back again, and perching on a projecting rafter spoke to me with
+human voice, and told me to leave off crying. 'Be of good courage,' he
+said, 'daughter of Icarius; this is no dream, but a vision of good omen
+that shall surely come to pass. The geese are the suitors, and I am no
+longer an eagle, but your own husband, who am come back to you, and who
+will bring these suitors to a disgraceful end.' On this I woke, and when
+I looked out I saw my geese at the trough eating their mash as usual."
+
+"This dream, Madam," replied Ulysses, "can admit but of one
+interpretation, for had not Ulysses himself told you how it shall be
+fulfilled? The death of the suitors is portended, and not one single one
+of them will escape."
+
+And Penelope answered, "Stranger, dreams are very curious and
+unaccountable things, and they do not by any means invariably come true.
+There are two gates through which these unsubstantial fancies proceed;
+the one is of horn, and the other ivory. Those that come through
+the gate of ivory are fatuous, but those from the gate of horn mean
+something to those that see them. I do not think, however, that my own
+dream came through the gate of horn, though I and my son should be most
+thankful if it proves to have done so. Furthermore I say--and lay my
+saying to your heart--the coming dawn will usher in the ill-omened day
+that is to sever me from the house of Ulysses, for I am about to hold a
+tournament of axes. My husband used to set up twelve axes in the court,
+one in front of the other, like the stays upon which a ship is built;
+he would then go back from them and shoot an arrow through the whole
+twelve. I shall make the suitors try to do the same thing, and whichever
+of them can string the bow most easily, and send his arrow through all
+the twelve axes, him will I follow, and quit this house of my lawful
+husband, so goodly and so abounding in wealth. But even so, I doubt not
+that I shall remember it in my dreams."
+
+Then Ulysses answered, "Madam, wife of Ulysses, you need not defer your
+tournament, for Ulysses will return ere ever they can string the bow,
+handle it how they will, and send their arrows through the iron."
+
+To this Penelope said, "As long, sir, as you will sit here and talk
+to me, I can have no desire to go to bed. Still, people cannot do
+permanently without sleep, and heaven has appointed us dwellers on earth
+a time for all things. I will therefore go upstairs and recline upon
+that couch which I have never ceased to flood with my tears from the day
+Ulysses set out for the city with a hateful name."
+
+She then went upstairs to her own room, not alone, but attended by her
+maidens, and when there, she lamented her dear husband till Minerva shed
+sweet sleep over her eyelids.
+
+
+Book XX
+
+ULYSSES CANNOT SLEEP--PENELOPE'S PRAYER TO DIANA--THE TWO SIGNS FROM
+HEAVEN--EUMAEUS AND PHILOETIUS ARRIVE--THE SUITORS DINE--CTESIPPUS
+THROWS AN OX'S FOOT AT ULYSSES--THEOCLYMENUS FORETELLS DISASTER AND
+LEAVES THE HOUSE.
+
+Ulysses slept in the cloister upon an undressed bullock's hide, on the
+top of which he threw several skins of the sheep the suitors had eaten,
+and Eurynome {156} threw a cloak over him after he had laid himself
+down. There, then, Ulysses lay wakefully brooding upon the way in which
+he should kill the suitors; and by and by, the women who had been in the
+habit of misconducting themselves with them, left the house giggling and
+laughing with one another. This made Ulysses very angry, and he doubted
+whether to get up and kill every single one of them then and there, or
+to let them sleep one more and last time with the suitors. His heart
+growled within him, and as a bitch with puppies growls and shows her
+teeth when she sees a stranger, so did his heart growl with anger at
+the evil deeds that were being done: but he beat his breast and said,
+"Heart, be still, you had worse than this to bear on the day when the
+terrible Cyclops ate your brave companions; yet you bore it in silence
+till your cunning got you safe out of the cave, though you made sure of
+being killed."
+
+Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side and then on the other, that he
+may get it cooked as soon as possible, even so did he turn himself about
+from side to side, thinking all the time how, single handed as he was,
+he should contrive to kill so large a body of men as the wicked suitors.
+But by and by Minerva came down from heaven in the likeness of a woman,
+and hovered over his head saying, "My poor unhappy man, why do you lie
+awake in this way? This is your house: your wife is safe inside it, and
+so is your son who is just such a young man as any father may be proud
+of."
+
+"Goddess," answered Ulysses, "all that you have said is true, but I am
+in some doubt as to how I shall be able to kill these wicked suitors
+single handed, seeing what a number of them there always are. And there
+is this further difficulty, which is still more considerable. Supposing
+that with Jove's and your assistance I succeed in killing them, I must
+ask you to consider where I am to escape to from their avengers when it
+is all over."
+
+"For shame," replied Minerva, "why, any one else would trust a worse
+ally than myself, even though that ally were only a mortal and less wise
+than I am. Am I not a goddess, and have I not protected you throughout
+in all your troubles? I tell you plainly that even though there were
+fifty bands of men surrounding us and eager to kill us, you should take
+all their sheep and cattle, and drive them away with you. But go to
+sleep; it is a very bad thing to lie awake all night, and you shall be
+out of your troubles before long."
+
+As she spoke she shed sleep over his eyes, and then went back to
+Olympus.
+
+While Ulysses was thus yielding himself to a very deep slumber that
+eased the burden of his sorrows, his admirable wife awoke, and sitting
+up in her bed began to cry. When she had relieved herself by weeping she
+prayed to Diana saying, "Great Goddess Diana, daughter of Jove, drive an
+arrow into my heart and slay me; or let some whirlwind snatch me up and
+bear me through paths of darkness till it drop me into the mouths
+of over-flowing Oceanus, as it did the daughters of Pandareus. The
+daughters of Pandareus lost their father and mother, for the gods killed
+them, so they were left orphans. But Venus took care of them, and fed
+them on cheese, honey, and sweet wine. Juno taught them to excel all
+women in beauty of form and understanding; Diana gave them an imposing
+presence, and Minerva endowed them with every kind of accomplishment;
+but one day when Venus had gone up to Olympus to see Jove about getting
+them married (for well does he know both what shall happen and what
+not happen to every one) the storm winds came and spirited them away to
+become handmaids to the dread Erinyes. Even so I wish that the gods who
+live in heaven would hide me from mortal sight, or that fair Diana might
+strike me, for I would fain go even beneath the sad earth if I might
+do so still looking towards Ulysses only, and without having to yield
+myself to a worse man than he was. Besides, no matter how much people
+may grieve by day, they can put up with it so long as they can sleep at
+night, for when the eyes are closed in slumber people forget good and
+ill alike; whereas my misery haunts me even in my dreams. This very
+night methought there was one lying by my side who was like Ulysses as
+he was when he went away with his host, and I rejoiced, for I believed
+that it was no dream, but the very truth itself."
+
+On this the day broke, but Ulysses heard the sound of her weeping, and
+it puzzled him, for it seemed as though she already knew him and was by
+his side. Then he gathered up the cloak and the fleeces on which he had
+lain, and set them on a seat in the cloister, but he took the bullock's
+hide out into the open. He lifted up his hands to heaven, and prayed,
+saying "Father Jove, since you have seen fit to bring me over land and
+sea to my own home after all the afflictions you have laid upon me, give
+me a sign out of the mouth of some one or other of those who are now
+waking within the house, and let me have another sign of some kind from
+outside."
+
+Thus did he pray. Jove heard his prayer and forthwith thundered high
+up among the clouds from the splendour of Olympus, and Ulysses was glad
+when he heard it. At the same time within the house, a miller-woman from
+hard by in the mill room lifted up her voice and gave him another sign.
+There were twelve miller-women whose business it was to grind wheat and
+barley which are the staff of life. The others had ground their task and
+had gone to take their rest, but this one had not yet finished, for
+she was not so strong as they were, and when she heard the thunder she
+stopped grinding and gave the sign to her master. "Father Jove," said
+she, "you, who rule over heaven and earth, you have thundered from a
+clear sky without so much as a cloud in it, and this means something for
+somebody; grant the prayer, then, of me your poor servant who calls
+upon you, and let this be the very last day that the suitors dine in the
+house of Ulysses. They have worn me out with labour of grinding meal for
+them, and I hope they may never have another dinner anywhere at all."
+
+Ulysses was glad when he heard the omens conveyed to him by the woman's
+speech, and by the thunder, for he knew they meant that he should avenge
+himself on the suitors.
+
+Then the other maids in the house rose and lit the fire on the hearth;
+Telemachus also rose and put on his clothes. He girded his sword about
+his shoulder, bound his sandals on to his comely feet, and took a
+doughty spear with a point of sharpened bronze; then he went to the
+threshold of the cloister and said to Euryclea, "Nurse, did you make the
+stranger comfortable both as regards bed and board, or did you let him
+shift for himself?--for my mother, good woman though she is, has a
+way of paying great attention to second-rate people, and of neglecting
+others who are in reality much better men."
+
+"Do not find fault child," said Euryclea, "when there is no one to find
+fault with. The stranger sat and drank his wine as long as he liked:
+your mother did ask him if he would take any more bread and he said he
+would not. When he wanted to go to bed she told the servants to make one
+for him, but he said he was such a wretched outcast that he would not
+sleep on a bed and under blankets; he insisted on having an undressed
+bullock's hide and some sheepskins put for him in the cloister and I
+threw a cloak over him myself." {157}
+
+Then Telemachus went out of the court to the place where the Achaeans
+were meeting in assembly; he had his spear in his hand, and he was not
+alone, for his two dogs went with him. But Euryclea called the maids and
+said, "Come, wake up; set about sweeping the cloisters and sprinkling
+them with water to lay the dust; put the covers on the seats; wipe down
+the tables, some of you, with a wet sponge; clean out the mixing-jugs
+and the cups, and go for water from the fountain at once; the suitors
+will be here directly; they will be here early, for it is a feast day."
+
+Thus did she speak, and they did even as she had said: twenty of them
+went to the fountain for water, and the others set themselves busily to
+work about the house. The men who were in attendance on the suitors also
+came up and began chopping firewood. By and by the women returned from
+the fountain, and the swineherd came after them with the three best pigs
+he could pick out. These he let feed about the premises, and then he
+said good-humouredly to Ulysses, "Stranger, are the suitors treating you
+any better now, or are they as insolent as ever?"
+
+"May heaven," answered Ulysses, "requite to them the wickedness with
+which they deal high-handedly in another man's house without any sense
+of shame."
+
+Thus did they converse; meanwhile Melanthius the goatherd came up, for
+he too was bringing in his best goats for the suitors' dinner; and he
+had two shepherds with him. They tied the goats up under the gatehouse,
+and then Melanthius began gibing at Ulysses. "Are you still here,
+stranger," said he, "to pester people by begging about the house? Why
+can you not go elsewhere? You and I shall not come to an understanding
+before we have given each other a taste of our fists. You beg without
+any sense of decency: are there not feasts elsewhere among the Achaeans,
+as well as here?"
+
+Ulysses made no answer, but bowed his head and brooded. Then a third
+man, Philoetius, joined them, who was bringing in a barren heifer and
+some goats. These were brought over by the boatmen who are there to take
+people over when any one comes to them. So Philoetius made his heifer
+and his goats secure under the gatehouse, and then went up to the
+swineherd. "Who, Swineherd," said he, "is this stranger that is lately
+come here? Is he one of your men? What is his family? Where does he come
+from? Poor fellow, he looks as if he had been some great man, but the
+gods give sorrow to whom they will--even to kings if it so pleases
+them."
+
+As he spoke he went up to Ulysses and saluted him with his right hand;
+"Good day to you, father stranger," said he, "you seem to be very poorly
+off now, but I hope you will have better times by and by. Father Jove,
+of all gods you are the most malicious. We are your own children, yet
+you show us no mercy in all our misery and afflictions. A sweat came
+over me when I saw this man, and my eyes filled with tears, for he
+reminds me of Ulysses, who I fear is going about in just such rags as
+this man's are, if indeed he is still among the living. If he is already
+dead and in the house of Hades, then, alas! for my good master, who made
+me his stockman when I was quite young among the Cephallenians, and now
+his cattle are countless; no one could have done better with them than I
+have, for they have bred like ears of corn; nevertheless I have to keep
+bringing them in for others to eat, who take no heed to his son though
+he is in the house, and fear not the wrath of heaven, but are already
+eager to divide Ulysses' property among them because he has been away so
+long. I have often thought--only it would not be right while his son
+is living--of going off with the cattle to some foreign country; bad as
+this would be, it is still harder to stay here and be ill-treated about
+other people's herds. My position is intolerable, and I should long
+since have run away and put myself under the protection of some other
+chief, only that I believe my poor master will yet return, and send all
+these suitors flying out of the house."
+
+"Stockman," answered Ulysses, "you seem to be a very well-disposed
+person, and I can see that you are a man of sense. Therefore I will tell
+you, and will confirm my words with an oath. By Jove, the chief of all
+gods, and by that hearth of Ulysses to which I am now come, Ulysses
+shall return before you leave this place, and if you are so minded you
+shall see him killing the suitors who are now masters here."
+
+"If Jove were to bring this to pass," replied the stockman, "you should
+see how I would do my very utmost to help him."
+
+And in like manner Eumaeus prayed that Ulysses might return home.
+
+Thus did they converse. Meanwhile the suitors were hatching a plot to
+murder Telemachus: but a bird flew near them on their left hand--an
+eagle with a dove in its talons. On this Amphinomus said, "My friends,
+this plot of ours to murder Telemachus will not succeed; let us go to
+dinner instead."
+
+The others assented, so they went inside and laid their cloaks on the
+benches and seats. They sacrificed the sheep, goats, pigs, and the
+heifer, and when the inward meats were cooked they served them round.
+They mixed the wine in the mixing-bowls, and the swineherd gave every
+man his cup, while Philoetius handed round the bread in the bread
+baskets, and Melanthius poured them out their wine. Then they laid their
+hands upon the good things that were before them.
+
+Telemachus purposely made Ulysses sit in the part of the cloister that
+was paved with stone; {158} he gave him a shabby looking seat at a
+little table to himself, and had his portion of the inward meats brought
+to him, with his wine in a gold cup. "Sit there," said he, "and drink
+your wine among the great people. I will put a stop to the gibes and
+blows of the suitors, for this is no public house, but belongs to
+Ulysses, and has passed from him to me. Therefore, suitors, keep your
+hands and your tongues to yourselves, or there will be mischief."
+
+The suitors bit their lips, and marvelled at the boldness of his speech;
+then Antinous said, "We do not like such language but we will put up
+with it, for Telemachus is threatening us in good earnest. If Jove had
+let us we should have put a stop to his brave talk ere now."
+
+Thus spoke Antinous, but Telemachus heeded him not. Meanwhile the
+heralds were bringing the holy hecatomb through the city, and the
+Achaeans gathered under the shady grove of Apollo.
+
+Then they roasted the outer meat, drew it off the spits, gave every man
+his portion, and feasted to their heart's content; those who waited
+at table gave Ulysses exactly the same portion as the others had, for
+Telemachus had told them to do so.
+
+But Minerva would not let the suitors for one moment drop their
+insolence, for she wanted Ulysses to become still more bitter against
+them. Now there happened to be among them a ribald fellow, whose name
+was Ctesippus, and who came from Same. This man, confident in his
+great wealth, was paying court to the wife of Ulysses, and said to the
+suitors, "Hear what I have to say. The stranger has already had as
+large a portion as any one else; this is well, for it is not right nor
+reasonable to ill-treat any guest of Telemachus who comes here. I
+will, however, make him a present on my own account, that he may have
+something to give to the bath-woman, or to some other of Ulysses'
+servants."
+
+As he spoke he picked up a heifer's foot from the meat-basket in which
+it lay, and threw it at Ulysses, but Ulysses turned his head a little
+aside, and avoided it, smiling grimly Sardinian fashion {159} as he did
+so, and it hit the wall, not him. On this Telemachus spoke fiercely to
+Ctesippus, "It is a good thing for you," said he, "that the stranger
+turned his head so that you missed him. If you had hit him I should have
+run you through with my spear, and your father would have had to see
+about getting you buried rather than married in this house. So let me
+have no more unseemly behaviour from any of you, for I am grown up
+now to the knowledge of good and evil and understand what is going on,
+instead of being the child that I have been heretofore. I have long seen
+you killing my sheep and making free with my corn and wine: I have put
+up with this, for one man is no match for many, but do me no further
+violence. Still, if you wish to kill me, kill me; I would far rather die
+than see such disgraceful scenes day after day--guests insulted, and men
+dragging the women servants about the house in an unseemly way."
+
+They all held their peace till at last Agelaus son of Damastor said, "No
+one should take offence at what has just been said, nor gainsay it, for
+it is quite reasonable. Leave off, therefore, ill-treating the stranger,
+or any one else of the servants who are about the house; I would say,
+however, a friendly word to Telemachus and his mother, which I trust may
+commend itself to both. 'As long,' I would say, 'as you had ground for
+hoping that Ulysses would one day come home, no one could complain of
+your waiting and suffering {160} the suitors to be in your house. It
+would have been better that he should have returned, but it is now
+sufficiently clear that he will never do so; therefore talk all this
+quietly over with your mother, and tell her to marry the best man,
+and the one who makes her the most advantageous offer. Thus you will
+yourself be able to manage your own inheritance, and to eat and drink
+in peace, while your mother will look after some other man's house, not
+yours.'"
+
+To this Telemachus answered, "By Jove, Agelaus, and by the sorrows of my
+unhappy father, who has either perished far from Ithaca, or is wandering
+in some distant land, I throw no obstacles in the way of my mother's
+marriage; on the contrary I urge her to choose whomsoever she will, and
+I will give her numberless gifts into the bargain, but I dare not insist
+point blank that she shall leave the house against her own wishes.
+Heaven forbid that I should do this."
+
+Minerva now made the suitors fall to laughing immoderately, and set
+their wits wandering; but they were laughing with a forced laughter.
+Their meat became smeared with blood; their eyes filled with tears,
+and their hearts were heavy with forebodings. Theoclymenus saw this
+and said, "Unhappy men, what is it that ails you? There is a shroud
+of darkness drawn over you from head to foot, your cheeks are wet with
+tears; the air is alive with wailing voices; the walls and roof-beams
+drip blood; the gate of the cloisters and the court beyond them are full
+of ghosts trooping down into the night of hell; the sun is blotted out
+of heaven, and a blighting gloom is over all the land."
+
+Thus did he speak, and they all of them laughed heartily. Eurymachus
+then said, "This stranger who has lately come here has lost his senses.
+Servants, turn him out into the streets, since he finds it so dark
+here."
+
+But Theoclymenus said, "Eurymachus, you need not send any one with me.
+I have eyes, ears, and a pair of feet of my own, to say nothing of an
+understanding mind. I will take these out of the house with me, for
+I see mischief overhanging you, from which not one of you men who are
+insulting people and plotting ill deeds in the house of Ulysses will be
+able to escape."
+
+He left the house as he spoke, and went back to Piraeus who gave him
+welcome, but the suitors kept looking at one another and provoking
+Telemachus by laughing at the strangers. One insolent fellow said to
+him, "Telemachus, you are not happy in your guests; first you have this
+importunate tramp, who comes begging bread and wine and has no skill
+for work or for hard fighting, but is perfectly useless, and now here is
+another fellow who is setting himself up as a prophet. Let me persuade
+you, for it will be much better to put them on board ship and send them
+off to the Sicels to sell for what they will bring."
+
+Telemachus gave him no heed, but sate silently watching his father,
+expecting every moment that he would begin his attack upon the suitors.
+
+Meanwhile the daughter of Icarius, wise Penelope, had had a rich seat
+placed for her facing the court and cloisters, so that she could hear
+what every one was saying. The dinner indeed had been prepared amid much
+merriment; it had been both good and abundant, for they had sacrificed
+many victims; but the supper was yet to come, and nothing can be
+conceived more gruesome than the meal which a goddess and a brave man
+were soon to lay before them--for they had brought their doom upon
+themselves.
+
+
+Book XXI
+
+THE TRIAL OF THE AXES, DURING WHICH ULYSSES REVEALS HIMSELF TO EUMAEUS
+AND PHILOETIUS
+
+Minerva now put it in Penelope's mind to make the suitors try their
+skill with the bow and with the iron axes, in contest among themselves,
+as a means of bringing about their destruction. She went upstairs and
+got the store-room key, which was made of bronze and had a handle of
+ivory; she then went with her maidens into the store-room at the end of
+the house, where her husband's treasures of gold, bronze, and wrought
+iron were kept, and where was also his bow, and the quiver full of
+deadly arrows that had been given him by a friend whom he had met in
+Lacedaemon--Iphitus the son of Eurytus. The two fell in with one another
+in Messene at the house of Ortilochus, where Ulysses was staying in
+order to recover a debt that was owing from the whole people; for the
+Messenians had carried off three hundred sheep from Ithaca, and had
+sailed away with them and with their shepherds. In quest of these
+Ulysses took a long journey while still quite young, for his father and
+the other chieftains sent him on a mission to recover them. Iphitus had
+gone there also to try and get back twelve brood mares that he had lost,
+and the mule foals that were running with them. These mares were the
+death of him in the end, for when he went to the house of Jove's son,
+mighty Hercules, who performed such prodigies of valour, Hercules to his
+shame killed him, though he was his guest, for he feared not heaven's
+vengeance, nor yet respected his own table which he had set before
+Iphitus, but killed him in spite of everything, and kept the mares
+himself. It was when claiming these that Iphitus met Ulysses, and gave
+him the bow which mighty Eurytus had been used to carry, and which on
+his death had been left by him to his son. Ulysses gave him in return
+a sword and a spear, and this was the beginning of a fast friendship,
+although they never visited at one another's houses, for Jove's son
+Hercules killed Iphitus ere they could do so. This bow, then, given him
+by Iphitus, had not been taken with him by Ulysses when he sailed for
+Troy; he had used it so long as he had been at home, but had left it
+behind as having been a keepsake from a valued friend.
+
+Penelope presently reached the oak threshold of the store-room; the
+carpenter had planed this duly, and had drawn a line on it so as to get
+it quite straight; he had then set the door posts into it and hung the
+doors. She loosed the strap from the handle of the door, put in the key,
+and drove it straight home to shoot back the bolts that held the doors;
+{161} these flew open with a noise like a bull bellowing in a meadow,
+and Penelope stepped upon the raised platform, where the chests stood in
+which the fair linen and clothes were laid by along with fragrant herbs:
+reaching thence, she took down the bow with its bow case from the peg
+on which it hung. She sat down with it on her knees, weeping bitterly as
+she took the bow out of its case, and when her tears had relieved her,
+she went to the cloister where the suitors were, carrying the bow and
+the quiver, with the many deadly arrows that were inside it. Along
+with her came her maidens, bearing a chest that contained much iron
+and bronze which her husband had won as prizes. When she reached the
+suitors, she stood by one of the bearing-posts supporting the roof of
+the cloister, holding a veil before her face, and with a maid on either
+side of her. Then she said:
+
+"Listen to me you suitors, who persist in abusing the hospitality of
+this house because its owner has been long absent, and without other
+pretext than that you want to marry me; this, then, being the prize that
+you are contending for, I will bring out the mighty bow of Ulysses, and
+whomsoever of you shall string it most easily and send his arrow through
+each one of twelve axes, him will I follow and quit this house of my
+lawful husband, so goodly, and so abounding in wealth. But even so I
+doubt not that I shall remember it in my dreams."
+
+As she spoke, she told Eumaeus to set the bow and the pieces of iron
+before the suitors, and Eumaeus wept as he took them to do as she had
+bidden him. Hard by, the stockman wept also when he saw his master's
+bow, but Antinous scolded them. "You country louts," said he, "silly
+simpletons; why should you add to the sorrows of your mistress by crying
+in this way? She has enough to grieve her in the loss of her husband;
+sit still, therefore, and eat your dinners in silence, or go outside if
+you want to cry, and leave the bow behind you. We suitors shall have to
+contend for it with might and main, for we shall find it no light matter
+to string such a bow as this is. There is not a man of us all who is
+such another as Ulysses; for I have seen him and remember him, though I
+was then only a child."
+
+This was what he said, but all the time he was expecting to be able to
+string the bow and shoot through the iron, whereas in fact he was to
+be the first that should taste of the arrows from the hands of Ulysses,
+whom he was dishonouring in his own house--egging the others on to do so
+also.
+
+Then Telemachus spoke. "Great heavens!" he exclaimed, "Jove must have
+robbed me of my senses. Here is my dear and excellent mother saying she
+will quit this house and marry again, yet I am laughing and enjoying
+myself as though there were nothing happening. But, suitors, as the
+contest has been agreed upon, let it go forward. It is for a woman whose
+peer is not to be found in Pylos, Argos, or Mycene, nor yet in Ithaca
+nor on the mainland. You know this as well as I do; what need have I to
+speak in praise of my mother? Come on, then, make no excuses for delay,
+but let us see whether you can string the bow or no. I too will make
+trial of it, for if I can string it and shoot through the iron, I shall
+not suffer my mother to quit this house with a stranger, not if I can
+win the prizes which my father won before me."
+
+As he spoke he sprang from his seat, threw his crimson cloak from him,
+and took his sword from his shoulder. First he set the axes in a row, in
+a long groove which he had dug for them, and had made straight by line.
+{162} Then he stamped the earth tight round them, and everyone was
+surprised when they saw him set them up so orderly, though he had never
+seen anything of the kind before. This done, he went on to the pavement
+to make trial of the bow; thrice did he tug at it, trying with all his
+might to draw the string, and thrice he had to leave off, though he had
+hoped to string the bow and shoot through the iron. He was trying for
+the fourth time, and would have strung it had not Ulysses made a sign to
+check him in spite of all his eagerness. So he said:
+
+"Alas! I shall either be always feeble and of no prowess, or I am too
+young, and have not yet reached my full strength so as to be able
+to hold my own if any one attacks me. You others, therefore, who are
+stronger than I, make trial of the bow and get this contest settled."
+
+On this he put the bow down, letting it lean against the door [that led
+into the house] with the arrow standing against the top of the bow. Then
+he sat down on the seat from which he had risen, and Antinous said:
+
+"Come on each of you in his turn, going towards the right from the place
+at which the cupbearer begins when he is handing round the wine."
+
+The rest agreed, and Leiodes son of Oenops was the first to rise. He
+was sacrificial priest to the suitors, and sat in the corner near the
+mixing-bowl. {163} He was the only man who hated their evil deeds and
+was indignant with the others. He was now the first to take the bow and
+arrow, so he went on to the pavement to make his trial, but he could not
+string the bow, for his hands were weak and unused to hard work, they
+therefore soon grew tired, and he said to the suitors, "My friends, I
+cannot string it; let another have it, this bow shall take the life and
+soul out of many a chief among us, for it is better to die than to live
+after having missed the prize that we have so long striven for, and
+which has brought us so long together. Some one of us is even now hoping
+and praying that he may marry Penelope, but when he has seen this bow
+and tried it, let him woo and make bridal offerings to some other woman,
+and let Penelope marry whoever makes her the best offer and whose lot it
+is to win her."
+
+On this he put the bow down, letting it lean against the door, {164}
+with the arrow standing against the tip of the bow. Then he took his
+seat again on the seat from which he had risen; and Antinous rebuked him
+saying:
+
+"Leiodes, what are you talking about? Your words are monstrous and
+intolerable; it makes me angry to listen to you. Shall, then, this bow
+take the life of many a chief among us, merely because you cannot bend
+it yourself? True, you were not born to be an archer, but there are
+others who will soon string it."
+
+Then he said to Melanthius the goatherd, "Look sharp, light a fire in
+the court, and set a seat hard by with a sheep skin on it; bring us also
+a large ball of lard, from what they have in the house. Let us warm the
+bow and grease it--we will then make trial of it again, and bring the
+contest to an end."
+
+Melanthius lit the fire, and set a seat covered with sheep skins beside
+it. He also brought a great ball of lard from what they had in the
+house, and the suitors warmed the bow and again made trial of it, but
+they were none of them nearly strong enough to string it. Nevertheless
+there still remained Antinous and Eurymachus, who were the ringleaders
+among the suitors and much the foremost among them all.
+
+Then the swineherd and the stockman left the cloisters together, and
+Ulysses followed them. When they had got outside the gates and the outer
+yard, Ulysses said to them quietly:
+
+"Stockman, and you swineherd, I have something in my mind which I am in
+doubt whether to say or no; but I think I will say it. What manner of
+men would you be to stand by Ulysses, if some god should bring him back
+here all of a sudden? Say which you are disposed to do--to side with the
+suitors, or with Ulysses?"
+
+"Father Jove," answered the stockman, "would indeed that you might so
+ordain it. If some god were but to bring Ulysses back, you should see
+with what might and main I would fight for him."
+
+In like words Eumaeus prayed to all the gods that Ulysses might return;
+when, therefore, he saw for certain what mind they were of, Ulysses
+said, "It is I, Ulysses, who am here. I have suffered much, but at last,
+in the twentieth year, I am come back to my own country. I find that you
+two alone of all my servants are glad that I should do so, for I
+have not heard any of the others praying for my return. To you two,
+therefore, will I unfold the truth as it shall be. If heaven shall
+deliver the suitors into my hands, I will find wives for both of you,
+will give you house and holding close to my own, and you shall be to me
+as though you were brothers and friends of Telemachus. I will now give
+you convincing proofs that you may know me and be assured. See, here is
+the scar from the boar's tooth that ripped me when I was out hunting on
+Mt. Parnassus with the sons of Autolycus."
+
+As he spoke he drew his rags aside from the great scar, and when they
+had examined it thoroughly, they both of them wept about Ulysses, threw
+their arms round him, and kissed his head and shoulders, while Ulysses
+kissed their hands and faces in return. The sun would have gone down
+upon their mourning if Ulysses had not checked them and said:
+
+"Cease your weeping, lest some one should come outside and see us, and
+tell those who are within. When you go in, do so separately, not both
+together; I will go first, and do you follow afterwards; let this
+moreover be the token between us; the suitors will all of them try to
+prevent me from getting hold of the bow and quiver; do you, therefore,
+Eumaeus, place it in my hands when you are carrying it about, and
+tell the women to close the doors of their apartment. If they hear any
+groaning or uproar as of men fighting about the house, they must not
+come out; they must keep quiet, and stay where they are at their work.
+And I charge you, Philoetius, to make fast the doors of the outer court,
+and to bind them securely at once."
+
+When he had thus spoken, he went back to the house and took the seat
+that he had left. Presently, his two servants followed him inside.
+
+At this moment the bow was in the hands of Eurymachus, who was warming
+it by the fire, but even so he could not string it, and he was greatly
+grieved. He heaved a deep sigh and said, "I grieve for myself and for us
+all; I grieve that I shall have to forgo the marriage, but I do not care
+nearly so much about this, for there are plenty of other women in Ithaca
+and elsewhere; what I feel most is the fact of our being so inferior to
+Ulysses in strength that we cannot string his bow. This will disgrace us
+in the eyes of those who are yet unborn."
+
+"It shall not be so, Eurymachus," said Antinous, "and you know it
+yourself. Today is the feast of Apollo throughout all the land; who can
+string a bow on such a day as this? Put it on one side--as for the axes
+they can stay where they are, for no one is likely to come to the house
+and take them away: let the cupbearer go round with his cups, that we
+may make our drink-offerings and drop this matter of the bow; we will
+tell Melanthius to bring us in some goats tomorrow--the best he has; we
+can then offer thigh bones to Apollo the mighty archer, and again make
+trial of the bow, so as to bring the contest to an end."
+
+The rest approved his words, and thereon men servants poured water over
+the hands of the guests, while pages filled the mixing-bowls with wine
+and water and handed it round after giving every man his drink-offering.
+Then, when they had made their offerings and had drunk each as much as
+he desired, Ulysses craftily said:--
+
+"Suitors of the illustrious queen, listen that I may speak even as I am
+minded. I appeal more especially to Eurymachus, and to Antinous who
+has just spoken with so much reason. Cease shooting for the present and
+leave the matter to the gods, but in the morning let heaven give victory
+to whom it will. For the moment, however, give me the bow that I may
+prove the power of my hands among you all, and see whether I still have
+as much strength as I used to have, or whether travel and neglect have
+made an end of it."
+
+This made them all very angry, for they feared he might string the bow,
+Antinous therefore rebuked him fiercely saying, "Wretched creature, you
+have not so much as a grain of sense in your whole body; you ought
+to think yourself lucky in being allowed to dine unharmed among your
+betters, without having any smaller portion served you than we others
+have had, and in being allowed to hear our conversation. No other beggar
+or stranger has been allowed to hear what we say among ourselves; the
+wine must have been doing you a mischief, as it does with all those who
+drink immoderately. It was wine that inflamed the Centaur Eurytion when
+he was staying with Peirithous among the Lapithae. When the wine had
+got into his head, he went mad and did ill deeds about the house of
+Peirithous; this angered the heroes who were there assembled, so they
+rushed at him and cut off his ears and nostrils; then they dragged him
+through the doorway out of the house, so he went away crazed, and bore
+the burden of his crime, bereft of understanding. Henceforth, therefore,
+there was war between mankind and the centaurs, but he brought it upon
+himself through his own drunkenness. In like manner I can tell you that
+it will go hardly with you if you string the bow: you will find no mercy
+from any one here, for we shall at once ship you off to king Echetus,
+who kills every one that comes near him: you will never get away alive,
+so drink and keep quiet without getting into a quarrel with men younger
+than yourself."
+
+Penelope then spoke to him. "Antinous," said she, "it is not right that
+you should ill-treat any guest of Telemachus who comes to this house.
+If the stranger should prove strong enough to string the mighty bow of
+Ulysses, can you suppose that he would take me home with him and make me
+his wife? Even the man himself can have no such idea in his mind:
+none of you need let that disturb his feasting; it would be out of all
+reason."
+
+"Queen Penelope," answered Eurymachus, "we do not suppose that this man
+will take you away with him; it is impossible; but we are afraid lest
+some of the baser sort, men or women among the Achaeans, should go
+gossiping about and say, 'These suitors are a feeble folk; they are
+paying court to the wife of a brave man whose bow not one of them was
+able to string, and yet a beggarly tramp who came to the house strung it
+at once and sent an arrow through the iron.' This is what will be said,
+and it will be a scandal against us."
+
+"Eurymachus," Penelope answered, "people who persist in eating up the
+estate of a great chieftain and dishonouring his house must not expect
+others to think well of them. Why then should you mind if men talk as
+you think they will? This stranger is strong and well-built, he says
+moreover that he is of noble birth. Give him the bow, and let us see
+whether he can string it or no. I say--and it shall surely be--that if
+Apollo vouchsafes him the glory of stringing it, I will give him a cloak
+and shirt of good wear, with a javelin to keep off dogs and robbers,
+and a sharp sword. I will also give him sandals, and will see him sent
+safely wherever he wants to go."
+
+Then Telemachus said, "Mother, I am the only man either in Ithaca or in
+the islands that are over against Elis who has the right to let any
+one have the bow or to refuse it. No one shall force me one way or the
+other, not even though I choose to make the stranger a present of the
+bow outright, and let him take it away with him. Go, then, within the
+house and busy yourself with your daily duties, your loom, your distaff,
+and the ordering of your servants. This bow is a man's matter, and mine
+above all others, for it is I who am master here."
+
+She went wondering back into the house, and laid her son's saying in her
+heart. Then going upstairs with her handmaids into her room, she mourned
+her dear husband till Minerva sent sweet sleep over her eyelids.
+
+The swineherd now took up the bow and was for taking it to Ulysses, but
+the suitors clamoured at him from all parts of the cloisters, and one of
+them said, "You idiot, where are you taking the bow to? Are you out of
+your wits? If Apollo and the other gods will grant our prayer, your own
+boarhounds shall get you into some quiet little place, and worry you to
+death."
+
+Eumaeus was frightened at the outcry they all raised, so he put the bow
+down then and there, but Telemachus shouted out at him from the other
+side of the cloisters, and threatened him saying, "Father Eumaeus,
+bring the bow on in spite of them, or young as I am I will pelt you with
+stones back to the country, for I am the better man of the two. I wish
+I was as much stronger than all the other suitors in the house as I am
+than you, I would soon send some of them off sick and sorry, for they
+mean mischief."
+
+Thus did he speak, and they all of them laughed heartily, which put them
+in a better humour with Telemachus; so Eumaeus brought the bow on and
+placed it in the hands of Ulysses. When he had done this, he called
+Euryclea apart and said to her, "Euryclea, Telemachus says you are to
+close the doors of the women's apartments. If they hear any groaning or
+uproar as of men fighting about the house, they are not to come out, but
+are to keep quiet and stay where they are at their work."
+
+Euryclea did as she was told and closed the doors of the women's
+apartments.
+
+Meanwhile Philoetius slipped quietly out and made fast the gates of
+the outer court. There was a ship's cable of byblus fibre lying in the
+gatehouse, so he made the gates fast with it and then came in again,
+resuming the seat that he had left, and keeping an eye on Ulysses, who
+had now got the bow in his hands, and was turning it every way about,
+and proving it all over to see whether the worms had been eating into
+its two horns during his absence. Then would one turn towards his
+neighbour saying, "This is some tricky old bow-fancier; either he has
+got one like it at home, or he wants to make one, in such workmanlike
+style does the old vagabond handle it."
+
+Another said, "I hope he may be no more successful in other things than
+he is likely to be in stringing this bow."
+
+But Ulysses, when he had taken it up and examined it all over, strung it
+as easily as a skilled bard strings a new peg of his lyre and makes
+the twisted gut fast at both ends. Then he took it in his right hand
+to prove the string, and it sang sweetly under his touch like the
+twittering of a swallow. The suitors were dismayed, and turned colour
+as they heard it; at that moment, moreover, Jove thundered loudly as a
+sign, and the heart of Ulysses rejoiced as he heard the omen that the
+son of scheming Saturn had sent him.
+
+He took an arrow that was lying upon the table {165}--for those
+which the Achaeans were so shortly about to taste were all inside the
+quiver--he laid it on the centre-piece of the bow, and drew the notch of
+the arrow and the string toward him, still seated on his seat. When
+he had taken aim he let fly, and his arrow pierced every one of the
+handle-holes of the axes from the first onwards till it had gone right
+through them, and into the outer courtyard. Then he said to Telemachus:
+
+"Your guest has not disgraced you, Telemachus. I did not miss what I
+aimed at, and I was not long in stringing my bow. I am still strong, and
+not as the suitors twit me with being. Now, however, it is time for
+the Achaeans to prepare supper while there is still daylight, and
+then otherwise to disport themselves with song and dance which are the
+crowning ornaments of a banquet."
+
+As he spoke he made a sign with his eyebrows, and Telemachus girded on
+his sword, grasped his spear, and stood armed beside his father's seat.
+
+
+Book XXII
+
+THE KILLING OF THE SUITORS--THE MAIDS WHO HAVE MISCONDUCTED THEMSELVES
+ARE MADE TO CLEANSE THE CLOISTERS AND ARE THEN HANGED.
+
+Then Ulysses tore off his rags, and sprang on to the broad pavement
+with his bow and his quiver full of arrows. He shed the arrows on to the
+ground at his feet and said, "The mighty contest is at an end. I will
+now see whether Apollo will vouchsafe it to me to hit another mark which
+no man has yet hit."
+
+On this he aimed a deadly arrow at Antinous, who was about to take up a
+two-handled gold cup to drink his wine and already had it in his hands.
+He had no thought of death--who amongst all the revellers would think
+that one man, however brave, would stand alone among so many and kill
+him? The arrow struck Antinous in the throat, and the point went clean
+through his neck, so that he fell over and the cup dropped from his
+hand, while a thick stream of blood gushed from his nostrils. He kicked
+the table from him and upset the things on it, so that the bread and
+roasted meats were all soiled as they fell over on to the ground. {166}
+The suitors were in an uproar when they saw that a man had been hit;
+they sprang in dismay one and all of them from their seats and looked
+everywhere towards the walls, but there was neither shield nor spear,
+and they rebuked Ulysses very angrily. "Stranger," said they, "you shall
+pay for shooting people in this way: you shall see no other contest;
+you are a doomed man; he whom you have slain was the foremost youth in
+Ithaca, and the vultures shall devour you for having killed him."
+
+Thus they spoke, for they thought that he had killed Antinous by
+mistake, and did not perceive that death was hanging over the head of
+every one of them. But Ulysses glared at them and said:
+
+"Dogs, did you think that I should not come back from Troy? You have
+wasted my substance, {167} have forced my women servants to lie with
+you, and have wooed my wife while I was still living. You have feared
+neither God nor man, and now you shall die."
+
+They turned pale with fear as he spoke, and every man looked round about
+to see whither he might fly for safety, but Eurymachus alone spoke.
+
+"If you are Ulysses," said he, "then what you have said is just. We have
+done much wrong on your lands and in your house. But Antinous who was
+the head and front of the offending lies low already. It was all his
+doing. It was not that he wanted to marry Penelope; he did not so much
+care about that; what he wanted was something quite different, and Jove
+has not vouchsafed it to him; he wanted to kill your son and to be chief
+man in Ithaca. Now, therefore, that he has met the death which was his
+due, spare the lives of your people. We will make everything good among
+ourselves, and pay you in full for all that we have eaten and drunk.
+Each one of us shall pay you a fine worth twenty oxen, and we will keep
+on giving you gold and bronze till your heart is softened. Until we have
+done this no one can complain of your being enraged against us."
+
+Ulysses again glared at him and said, "Though you should give me all
+that you have in the world both now and all that you ever shall have,
+I will not stay my hand till I have paid all of you in full. You must
+fight, or fly for your lives; and fly, not a man of you shall."
+
+Their hearts sank as they heard him, but Eurymachus again spoke saying:
+
+"My friends, this man will give us no quarter. He will stand where he
+is and shoot us down till he has killed every man among us. Let us then
+show fight; draw your swords, and hold up the tables to shield you
+from his arrows. Let us have at him with a rush, to drive him from the
+pavement and doorway: we can then get through into the town, and raise
+such an alarm as shall soon stay his shooting."
+
+As he spoke he drew his keen blade of bronze, sharpened on both sides,
+and with a loud cry sprang towards Ulysses, but Ulysses instantly shot
+an arrow into his breast that caught him by the nipple and fixed itself
+in his liver. He dropped his sword and fell doubled up over his table.
+The cup and all the meats went over on to the ground as he smote the
+earth with his forehead in the agonies of death, and he kicked the stool
+with his feet until his eyes were closed in darkness.
+
+Then Amphinomus drew his sword and made straight at Ulysses to try and
+get him away from the door; but Telemachus was too quick for him, and
+struck him from behind; the spear caught him between the shoulders and
+went right through his chest, so that he fell heavily to the ground and
+struck the earth with his forehead. Then Telemachus sprang away from
+him, leaving his spear still in the body, for he feared that if he
+stayed to draw it out, some one of the Achaeans might come up and hack
+at him with his sword, or knock him down, so he set off at a run, and
+immediately was at his father's side. Then he said:
+
+"Father, let me bring you a shield, two spears, and a brass helmet for
+your temples. I will arm myself as well, and will bring other armour for
+the swineherd and the stockman, for we had better be armed."
+
+"Run and fetch them," answered Ulysses, "while my arrows hold out, or
+when I am alone they may get me away from the door."
+
+Telemachus did as his father said, and went off to the store room where
+the armour was kept. He chose four shields, eight spears, and four brass
+helmets with horse-hair plumes. He brought them with all speed to his
+father, and armed himself first, while the stockman and the swineherd
+also put on their armour, and took their places near Ulysses. Meanwhile
+Ulysses, as long as his arrows lasted, had been shooting the suitors one
+by one, and they fell thick on one another: when his arrows gave out, he
+set the bow to stand against the end wall of the house by the door post,
+and hung a shield four hides thick about his shoulders; on his comely
+head he set his helmet, well wrought with a crest of horse-hair that
+nodded menacingly above it, {168} and he grasped two redoubtable
+bronze-shod spears.
+
+Now there was a trap door {169} on the wall, while at one end of the
+pavement {170} there was an exit leading to a narrow passage, and this
+exit was closed by a well-made door. Ulysses told Philoetius to stand by
+this door and guard it, for only one person could attack it at a time.
+But Agelaus shouted out, "Cannot some one go up to the trap door and
+tell the people what is going on? Help would come at once, and we should
+soon make an end of this man and his shooting."
+
+"This may not be, Agelaus," answered Melanthius, "the mouth of the
+narrow passage is dangerously near the entrance to the outer court. One
+brave man could prevent any number from getting in. But I know what I
+will do, I will bring you arms from the store-room, for I am sure it is
+there that Ulysses and his son have put them."
+
+On this the goatherd Melanthius went by back passages to the store-room
+of Ulysses' house. There he chose twelve shields, with as many helmets
+and spears, and brought them back as fast as he could to give them to
+the suitors. Ulysses' heart began to fail him when he saw the suitors
+{171} putting on their armour and brandishing their spears. He saw the
+greatness of the danger, and said to Telemachus, "Some one of the women
+inside is helping the suitors against us, or it may be Melanthius."
+
+Telemachus answered, "The fault, father, is mine, and mine only; I left
+the store room door open, and they have kept a sharper look out than
+I have. Go, Eumaeus, put the door to, and see whether it is one of the
+women who is doing this, or whether, as I suspect, it is Melanthius the
+son of Dolius."
+
+Thus did they converse. Meanwhile Melanthius was again going to the
+store room to fetch more armour, but the swineherd saw him and said to
+Ulysses who was beside him, "Ulysses, noble son of Laertes, it is that
+scoundrel Melanthius, just as we suspected, who is going to the store
+room. Say, shall I kill him, if I can get the better of him, or shall
+I bring him here that you may take your own revenge for all the many
+wrongs that he has done in your house?"
+
+Ulysses answered, "Telemachus and I will hold these suitors in check, no
+matter what they do; go back both of you and bind Melanthius' hands and
+feet behind him. Throw him into the store room and make the door fast
+behind you; then fasten a noose about his body, and string him close up
+to the rafters from a high bearing-post, {172} that he may linger on in
+an agony."
+
+Thus did he speak, and they did even as he had said; they went to the
+store room, which they entered before Melanthius saw them, for he was
+busy searching for arms in the innermost part of the room, so the
+two took their stand on either side of the door and waited. By and by
+Melanthius came out with a helmet in one hand, and an old dry-rotted
+shield in the other, which had been borne by Laertes when he was young,
+but which had been long since thrown aside, and the straps had become
+unsewn; on this the two seized him, dragged him back by the hair, and
+threw him struggling to the ground. They bent his hands and feet well
+behind his back, and bound them tight with a painful bond as Ulysses had
+told them; then they fastened a noose about his body and strung him up
+from a high pillar till he was close up to the rafters, and over him did
+you then vaunt, O swineherd Eumaeus saying, "Melanthius, you will pass
+the night on a soft bed as you deserve. You will know very well when
+morning comes from the streams of Oceanus, and it is time for you to be
+driving in your goats for the suitors to feast on."
+
+There, then, they left him in very cruel bondage, and having put on
+their armour they closed the door behind them and went back to take
+their places by the side of Ulysses; whereon the four men stood in the
+cloister, fierce and full of fury; nevertheless, those who were in the
+body of the court were still both brave and many. Then Jove's daughter
+Minerva came up to them, having assumed the voice and form of Mentor.
+Ulysses was glad when he saw her and said, "Mentor, lend me your help,
+and forget not your old comrade, nor the many good turns he has done
+you. Besides, you are my age-mate."
+
+But all the time he felt sure it was Minerva, and the suitors from the
+other side raised an uproar when they saw her. Agelaus was the first to
+reproach her. "Mentor," he cried, "do not let Ulysses beguile you into
+siding with him and fighting the suitors. This is what we will do: when
+we have killed these people, father and son, we will kill you too. You
+shall pay for it with your head, and when we have killed you, we will
+take all you have, in doors or out, and bring it into hotch-pot with
+Ulysses' property; we will not let your sons live in your house, nor
+your daughters, nor shall your widow continue to live in the city of
+Ithaca."
+
+This made Minerva still more furious, so she scolded Ulysses very
+angrily. {173} "Ulysses," said she, "your strength and prowess are no
+longer what they were when you fought for nine long years among the
+Trojans about the noble lady Helen. You killed many a man in those days,
+and it was through your stratagem that Priam's city was taken. How comes
+it that you are so lamentably less valiant now that you are on your own
+ground, face to face with the suitors in your own house? Come on, my
+good fellow, stand by my side and see how Mentor, son of Alcimus shall
+fight your foes and requite your kindnesses conferred upon him."
+
+But she would not give him full victory as yet, for she wished still
+further to prove his own prowess and that of his brave son, so she flew
+up to one of the rafters in the roof of the cloister and sat upon it in
+the form of a swallow.
+
+Meanwhile Agelaus son of Damastor, Eurynomus, Amphimedon, Demoptolemus,
+Pisander, and Polybus son of Polyctor bore the brunt of the fight upon
+the suitors' side; of all those who were still fighting for their lives
+they were by far the most valiant, for the others had already fallen
+under the arrows of Ulysses. Agelaus shouted to them and said, "My
+friends, he will soon have to leave off, for Mentor has gone away after
+having done nothing for him but brag. They are standing at the doors
+unsupported. Do not aim at him all at once, but six of you throw your
+spears first, and see if you cannot cover yourselves with glory by
+killing him. When he has fallen we need not be uneasy about the others."
+
+They threw their spears as he bade them, but Minerva made them all of
+no effect. One hit the door post; another went against the door; the
+pointed shaft of another struck the wall; and as soon as they had
+avoided all the spears of the suitors Ulysses said to his own men, "My
+friends, I should say we too had better let drive into the middle of
+them, or they will crown all the harm they have done us by killing us
+outright."
+
+They therefore aimed straight in front of them and threw their spears.
+Ulysses killed Demoptolemus, Telemachus Euryades, Eumaeus Elatus, while
+the stockman killed Pisander. These all bit the dust, and as the others
+drew back into a corner Ulysses and his men rushed forward and regained
+their spears by drawing them from the bodies of the dead.
+
+The suitors now aimed a second time, but again Minerva made their
+weapons for the most part without effect. One hit a bearing-post of
+the cloister; another went against the door; while the pointed shaft of
+another struck the wall. Still, Amphimedon just took a piece of the
+top skin from off Telemachus's wrist, and Ctesippus managed to graze
+Eumaeus's shoulder above his shield; but the spear went on and fell
+to the ground. Then Ulysses and his men let drive into the crowd of
+suitors. Ulysses hit Eurydamas, Telemachus Amphimedon, and Eumaeus
+Polybus. After this the stockman hit Ctesippus in the breast, and
+taunted him saying, "Foul-mouthed son of Polytherses, do not be so
+foolish as to talk wickedly another time, but let heaven direct your
+speech, for the gods are far stronger than men. I make you a present of
+this advice to repay you for the foot which you gave Ulysses when he was
+begging about in his own house."
+
+Thus spoke the stockman, and Ulysses struck the son of Damastor with a
+spear in close fight, while Telemachus hit Leocritus son of Evenor in
+the belly, and the dart went clean through him, so that he fell forward
+full on his face upon the ground. Then Minerva from her seat on the
+rafter held up her deadly aegis, and the hearts of the suitors quailed.
+They fled to the other end of the court like a herd of cattle maddened
+by the gadfly in early summer when the days are at their longest. As
+eagle-beaked, crook-taloned vultures from the mountains swoop down on
+the smaller birds that cower in flocks upon the ground, and kill
+them, for they cannot either fight or fly, and lookers on enjoy the
+sport--even so did Ulysses and his men fall upon the suitors and smite
+them on every side. They made a horrible groaning as their brains were
+being battered in, and the ground seethed with their blood.
+
+Leiodes then caught the knees of Ulysses and said, "Ulysses I beseech
+you have mercy upon me and spare me. I never wronged any of the women in
+your house either in word or deed, and I tried to stop the others. I
+saw them, but they would not listen, and now they are paying for their
+folly. I was their sacrificing priest; if you kill me, I shall die
+without having done anything to deserve it, and shall have got no thanks
+for all the good that I did."
+
+Ulysses looked sternly at him and answered, "If you were their
+sacrificing priest, you must have prayed many a time that it might be
+long before I got home again, and that you might marry my wife and have
+children by her. Therefore you shall die."
+
+With these words he picked up the sword that Agelaus had dropped when
+he was being killed, and which was lying upon the ground. Then he struck
+Leiodes on the back of his neck, so that his head fell rolling in the
+dust while he was yet speaking.
+
+The minstrel Phemius son of Terpes--he who had been forced by the
+suitors to sing to them--now tried to save his life. He was standing
+near towards the trap door, {174} and held his lyre in his hand. He did
+not know whether to fly out of the cloister and sit down by the altar of
+Jove that was in the outer court, and on which both Laertes and Ulysses
+had offered up the thigh bones of many an ox, or whether to go straight
+up to Ulysses and embrace his knees, but in the end he deemed it best
+to embrace Ulysses' knees. So he laid his lyre on the ground between the
+mixing bowl {175} and the silver-studded seat; then going up to Ulysses
+he caught hold of his knees and said, "Ulysses, I beseech you have mercy
+on me and spare me. You will be sorry for it afterwards if you kill a
+bard who can sing both for gods and men as I can. I make all my lays
+myself, and heaven visits me with every kind of inspiration. I would
+sing to you as though you were a god, do not therefore be in such a
+hurry to cut my head off. Your own son Telemachus will tell you that I
+did not want to frequent your house and sing to the suitors after their
+meals, but they were too many and too strong for me, so they made me."
+
+Telemachus heard him, and at once went up to his father. "Hold!" he
+cried, "the man is guiltless, do him no hurt; and we will spare Medon
+too, who was always good to me when I was a boy, unless Philoetius or
+Eumaeus has already killed him, or he has fallen in your way when you
+were raging about the court."
+
+Medon caught these words of Telemachus, for he was crouching under a
+seat beneath which he had hidden by covering himself up with a freshly
+flayed heifer's hide, so he threw off the hide, went up to Telemachus,
+and laid hold of his knees.
+
+"Here I am, my dear sir," said he, "stay your hand therefore, and tell
+your father, or he will kill me in his rage against the suitors for
+having wasted his substance and been so foolishly disrespectful to
+yourself."
+
+Ulysses smiled at him and answered, "Fear not; Telemachus has saved your
+life, that you may know in future, and tell other people, how greatly
+better good deeds prosper than evil ones. Go, therefore, outside
+the cloisters into the outer court, and be out of the way of the
+slaughter--you and the bard--while I finish my work here inside."
+
+The pair went into the outer court as fast as they could, and sat down
+by Jove's great altar, looking fearfully round, and still expecting that
+they would be killed. Then Ulysses searched the whole court carefully
+over, to see if anyone had managed to hide himself and was still living,
+but he found them all lying in the dust and weltering in their blood.
+They were like fishes which fishermen have netted out of the sea, and
+thrown upon the beach to lie gasping for water till the heat of the sun
+makes an end of them. Even so were the suitors lying all huddled up one
+against the other.
+
+Then Ulysses said to Telemachus, "Call nurse Euryclea; I have something
+to say to her."
+
+Telemachus went and knocked at the door of the women's room. "Make
+haste," said he, "you old woman who have been set over all the other
+women in the house. Come outside; my father wishes to speak to you."
+
+When Euryclea heard this she unfastened the door of the women's room
+and came out, following Telemachus. She found Ulysses among the
+corpses bespattered with blood and filth like a lion that has just been
+devouring an ox, and his breast and both his cheeks are all bloody, so
+that he is a fearful sight; even so was Ulysses besmirched from head
+to foot with gore. When she saw all the corpses and such a quantity of
+blood, she was beginning to cry out for joy, for she saw that a great
+deed had been done; but Ulysses checked her, "Old woman," said he,
+"rejoice in silence; restrain yourself, and do not make any noise about
+it; it is an unholy thing to vaunt over dead men. Heaven's doom and
+their own evil deeds have brought these men to destruction, for they
+respected no man in the whole world, neither rich nor poor, who came
+near them, and they have come to a bad end as a punishment for their
+wickedness and folly. Now, however, tell me which of the women in the
+house have misconducted themselves, and who are innocent." {176}
+
+"I will tell you the truth, my son," answered Euryclea. "There are fifty
+women in the house whom we teach to do things, such as carding wool,
+and all kinds of household work. Of these, twelve in all {177} have
+misbehaved, and have been wanting in respect to me, and also to
+Penelope. They showed no disrespect to Telemachus, for he has only
+lately grown and his mother never permitted him to give orders to the
+female servants; but let me go upstairs and tell your wife all that has
+happened, for some god has been sending her to sleep."
+
+"Do not wake her yet," answered Ulysses, "but tell the women who have
+misconducted themselves to come to me."
+
+Euryclea left the cloister to tell the women, and make them come to
+Ulysses; in the meantime he called Telemachus, the stockman, and the
+swineherd. "Begin," said he, "to remove the dead, and make the women
+help you. Then, get sponges and clean water to swill down the tables and
+seats. When you have thoroughly cleansed the whole cloisters, take the
+women into the space between the domed room and the wall of the outer
+court, and run them through with your swords till they are quite dead,
+and have forgotten all about love and the way in which they used to lie
+in secret with the suitors."
+
+On this the women came down in a body, weeping and wailing bitterly.
+First they carried the dead bodies out, and propped them up against one
+another in the gatehouse. Ulysses ordered them about and made them do
+their work quickly, so they had to carry the bodies out. When they had
+done this, they cleaned all the tables and seats with sponges and water,
+while Telemachus and the two others shovelled up the blood and dirt from
+the ground, and the women carried it all away and put it out of doors.
+Then when they had made the whole place quite clean and orderly, they
+took the women out and hemmed them in the narrow space between the wall
+of the domed room and that of the yard, so that they could not get away:
+and Telemachus said to the other two, "I shall not let these women die
+a clean death, for they were insolent to me and my mother, and used to
+sleep with the suitors."
+
+So saying he made a ship's cable fast to one of the bearing-posts that
+supported the roof of the domed room, and secured it all around the
+building, at a good height, lest any of the women's feet should touch
+the ground; and as thrushes or doves beat against a net that has been
+set for them in a thicket just as they were getting to their nest, and a
+terrible fate awaits them, even so did the women have to put their heads
+in nooses one after the other and die most miserably. {178} Their feet
+moved convulsively for a while, but not for very long.
+
+As for Melanthius, they took him through the cloister into the inner
+court. There they cut off his nose and his ears; they drew out his
+vitals and gave them to the dogs raw, and then in their fury they cut
+off his hands and his feet.
+
+When they had done this they washed their hands and feet and went back
+into the house, for all was now over; and Ulysses said to the dear old
+nurse Euryclea, "Bring me sulphur, which cleanses all pollution, and
+fetch fire also that I may burn it, and purify the cloisters. Go,
+moreover, and tell Penelope to come here with her attendants, and also
+all the maidservants that are in the house."
+
+"All that you have said is true," answered Euryclea, "but let me bring
+you some clean clothes--a shirt and cloak. Do not keep these rags on
+your back any longer. It is not right."
+
+"First light me a fire," replied Ulysses.
+
+She brought the fire and sulphur, as he had bidden her, and Ulysses
+thoroughly purified the cloisters and both the inner and outer courts.
+Then she went inside to call the women and tell them what had happened;
+whereon they came from their apartment with torches in their hands, and
+pressed round Ulysses to embrace him, kissing his head and shoulders and
+taking hold of his hands. It made him feel as if he should like to weep,
+for he remembered every one of them. {179}
+
+
+Book XXIII
+
+PENELOPE EVENTUALLY RECOGNISES HER HUSBAND--EARLY IN THE MORNING
+ULYSSES, TELEMACHUS, EUMAEUS, AND PHILOETIUS LEAVE THE TOWN.
+
+Euryclea now went upstairs laughing to tell her mistress that her dear
+husband had come home. Her aged knees became young again and her feet
+were nimble for joy as she went up to her mistress and bent over her
+head to speak to her. "Wake up Penelope, my dear child," she exclaimed,
+"and see with your own eyes something that you have been wanting this
+long time past. Ulysses has at last indeed come home again, and has
+killed the suitors who were giving so much trouble in his house, eating
+up his estate and ill treating his son."
+
+"My good nurse," answered Penelope, "you must be mad. The gods sometimes
+send some very sensible people out of their minds, and make foolish
+people become sensible. This is what they must have been doing to you;
+for you always used to be a reasonable person. Why should you thus mock
+me when I have trouble enough already--talking such nonsense, and waking
+me up out of a sweet sleep that had taken possession of my eyes and
+closed them? I have never slept so soundly from the day my poor husband
+went to that city with the ill-omened name. Go back again into the
+women's room; if it had been any one else who had woke me up to bring me
+such absurd news I should have sent her away with a severe scolding. As
+it is your age shall protect you."
+
+"My dear child," answered Euryclea, "I am not mocking you. It is quite
+true as I tell you that Ulysses is come home again. He was the stranger
+whom they all kept on treating so badly in the cloister. Telemachus knew
+all the time that he was come back, but kept his father's secret that he
+might have his revenge on all these wicked people."
+
+Then Penelope sprang up from her couch, threw her arms round Euryclea,
+and wept for joy. "But my dear nurse," said she, "explain this to me;
+if he has really come home as you say, how did he manage to overcome the
+wicked suitors single handed, seeing what a number of them there always
+were?"
+
+"I was not there," answered Euryclea, "and do not know; I only heard
+them groaning while they were being killed. We sat crouching and huddled
+up in a corner of the women's room with the doors closed, till your
+son came to fetch me because his father sent him. Then I found Ulysses
+standing over the corpses that were lying on the ground all round him,
+one on top of the other. You would have enjoyed it if you could have
+seen him standing there all bespattered with blood and filth, and
+looking just like a lion. But the corpses are now all piled up in the
+gatehouse that is in the outer court, and Ulysses has lit a great fire
+to purify the house with sulphur. He has sent me to call you, so come
+with me that you may both be happy together after all; for now at last
+the desire of your heart has been fulfilled; your husband is come home
+to find both wife and son alive and well, and to take his revenge in his
+own house on the suitors who behaved so badly to him."
+
+"My dear nurse," said Penelope, "do not exult too confidently over all
+this. You know how delighted every one would be to see Ulysses come
+home--more particularly myself, and the son who has been born to both
+of us; but what you tell me cannot be really true. It is some god who is
+angry with the suitors for their great wickedness, and has made an end
+of them; for they respected no man in the whole world, neither rich nor
+poor, who came near them, and they have come to a bad end in consequence
+of their iniquity; Ulysses is dead far away from the Achaean land; he
+will never return home again."
+
+Then nurse Euryclea said, "My child, what are you talking about? but you
+were all hard of belief and have made up your mind that your husband is
+never coming, although he is in the house and by his own fire side
+at this very moment. Besides I can give you another proof; when I was
+washing him I perceived the scar which the wild boar gave him, and I
+wanted to tell you about it, but in his wisdom he would not let me, and
+clapped his hands over my mouth; so come with me and I will make this
+bargain with you--if I am deceiving you, you may have me killed by the
+most cruel death you can think of."
+
+"My dear nurse," said Penelope, "however wise you may be you can hardly
+fathom the counsels of the gods. Nevertheless, we will go in search of
+my son, that I may see the corpses of the suitors, and the man who has
+killed them."
+
+On this she came down from her upper room, and while doing so she
+considered whether she should keep at a distance from her husband and
+question him, or whether she should at once go up to him and embrace
+him. When, however, she had crossed the stone floor of the cloister, she
+sat down opposite Ulysses by the fire, against the wall at right angles
+{180} [to that by which she had entered], while Ulysses sat near one of
+the bearing-posts, looking upon the ground, and waiting to see what his
+brave wife would say to him when she saw him. For a long time she sat
+silent and as one lost in amazement. At one moment she looked him full
+in the face, but then again directly, she was misled by his shabby
+clothes and failed to recognise him, {181} till Telemachus began to
+reproach her and said:
+
+"Mother--but you are so hard that I cannot call you by such a name--why
+do you keep away from my father in this way? Why do you not sit by his
+side and begin talking to him and asking him questions? No other woman
+could bear to keep away from her husband when he had come back to her
+after twenty years of absence, and after having gone through so much;
+but your heart always was as hard as a stone."
+
+Penelope answered, "My son, I am so lost in astonishment that I can find
+no words in which either to ask questions or to answer them. I cannot
+even look him straight in the face. Still, if he really is Ulysses
+come back to his own home again, we shall get to understand one another
+better by and by, for there are tokens with which we two are alone
+acquainted, and which are hidden from all others."
+
+Ulysses smiled at this, and said to Telemachus, "Let your mother put me
+to any proof she likes; she will make up her mind about it presently.
+She rejects me for the moment and believes me to be somebody else,
+because I am covered with dirt and have such bad clothes on; let us,
+however, consider what we had better do next. When one man has killed
+another--even though he was not one who would leave many friends to take
+up his quarrel--the man who has killed him must still say good bye to
+his friends and fly the country; whereas we have been killing the stay
+of a whole town, and all the picked youth of Ithaca. I would have you
+consider this matter."
+
+"Look to it yourself, father," answered Telemachus, "for they say you
+are the wisest counsellor in the world, and that there is no other
+mortal man who can compare with you. We will follow you with right good
+will, nor shall you find us fail you in so far as our strength holds
+out."
+
+"I will say what I think will be best," answered Ulysses. "First wash
+and put your shirts on; tell the maids also to go to their own room and
+dress; Phemius shall then strike up a dance tune on his lyre, so that if
+people outside hear, or any of the neighbours, or some one going along
+the street happens to notice it, they may think there is a wedding in
+the house, and no rumours about the death of the suitors will get about
+in the town, before we can escape to the woods upon my own land. Once
+there, we will settle which of the courses heaven vouchsafes us shall
+seem wisest."
+
+Thus did he speak, and they did even as he had said. First they washed
+and put their shirts on, while the women got ready. Then Phemius took
+his lyre and set them all longing for sweet song and stately dance. The
+house re-echoed with the sound of men and women dancing, and the people
+outside said, "I suppose the queen has been getting married at last.
+She ought to be ashamed of herself for not continuing to protect her
+husband's property until he comes home." {182}
+
+This was what they said, but they did not know what it was that had been
+happening. The upper servant Eurynome washed and anointed Ulysses in his
+own house and gave him a shirt and cloak, while Minerva made him look
+taller and stronger than before; she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders just as a skilful workman who
+has studied art of all kinds under Vulcan or Minerva--and his work is
+full of beauty--enriches a piece of silver plate by gilding it. He came
+from the bath looking like one of the immortals, and sat down opposite
+his wife on the seat he had left. "My dear," said he, "heaven has
+endowed you with a heart more unyielding than woman ever yet had. No
+other woman could bear to keep away from her husband when he had come
+back to her after twenty years of absence, and after having gone through
+so much. But come, nurse, get a bed ready for me; I will sleep alone,
+for this woman has a heart as hard as iron."
+
+"My dear," answered Penelope, "I have no wish to set myself up, nor to
+depreciate you; but I am not struck by your appearance, for I very well
+remember what kind of a man you were when you set sail from Ithaca.
+Nevertheless, Euryclea, take his bed outside the bed chamber that he
+himself built. Bring the bed outside this room, and put bedding upon it
+with fleeces, good coverlets, and blankets."
+
+She said this to try him, but Ulysses was very angry and said, "Wife,
+I am much displeased at what you have just been saying. Who has been
+taking my bed from the place in which I left it? He must have found it a
+hard task, no matter how skilled a workman he was, unless some god came
+and helped him to shift it. There is no man living, however strong and
+in his prime, who could move it from its place, for it is a marvellous
+curiosity which I made with my very own hands. There was a young olive
+growing within the precincts of the house, in full vigour, and about as
+thick as a bearing-post. I built my room round this with strong walls
+of stone and a roof to cover them, and I made the doors strong and
+well-fitting. Then I cut off the top boughs of the olive tree and left
+the stump standing. This I dressed roughly from the root upwards and
+then worked with carpenter's tools well and skilfully, straightening
+my work by drawing a line on the wood, and making it into a bed-prop.
+I then bored a hole down the middle, and made it the centre-post of my
+bed, at which I worked till I had finished it, inlaying it with gold and
+silver; after this I stretched a hide of crimson leather from one side
+of it to the other. So you see I know all about it, and I desire to
+learn whether it is still there, or whether any one has been removing it
+by cutting down the olive tree at its roots."
+
+When she heard the sure proofs Ulysses now gave her, she fairly broke
+down. She flew weeping to his side, flung her arms about his neck, and
+kissed him. "Do not be angry with me Ulysses," she cried, "you, who are
+the wisest of mankind. We have suffered, both of us. Heaven has denied
+us the happiness of spending our youth, and of growing old, together; do
+not then be aggrieved or take it amiss that I did not embrace you thus
+as soon as I saw you. I have been shuddering all the time through fear
+that someone might come here and deceive me with a lying story; for
+there are many very wicked people going about. Jove's daughter Helen
+would never have yielded herself to a man from a foreign country, if she
+had known that the sons of Achaeans would come after her and bring her
+back. Heaven put it in her heart to do wrong, and she gave no thought
+to that sin, which has been the source of all our sorrows. Now, however,
+that you have convinced me by showing that you know all about our
+bed (which no human being has ever seen but you and I and a single
+maidservant, the daughter of Actor, who was given me by my father on my
+marriage, and who keeps the doors of our room) hard of belief though I
+have been I can mistrust no longer."
+
+Then Ulysses in his turn melted, and wept as he clasped his dear and
+faithful wife to his bosom. As the sight of land is welcome to men who
+are swimming towards the shore, when Neptune has wrecked their ship with
+the fury of his winds and waves; a few alone reach the land, and these,
+covered with brine, are thankful when they find themselves on firm
+ground and out of danger--even so was her husband welcome to her as she
+looked upon him, and she could not tear her two fair arms from about
+his neck. Indeed they would have gone on indulging their sorrow till
+rosy-fingered morn appeared, had not Minerva determined otherwise, and
+held night back in the far west, while she would not suffer Dawn to
+leave Oceanus, nor to yoke the two steeds Lampus and Phaethon that bear
+her onward to break the day upon mankind.
+
+At last, however, Ulysses said, "Wife, we have not yet reached the end
+of our troubles. I have an unknown amount of toil still to undergo. It
+is long and difficult, but I must go through with it, for thus the shade
+of Teiresias prophesied concerning me, on the day when I went down into
+Hades to ask about my return and that of my companions. But now let us
+go to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+"You shall go to bed as soon as you please," replied Penelope, "now that
+the gods have sent you home to your own good house and to your country.
+But as heaven has put it in your mind to speak of it, tell me about the
+task that lies before you. I shall have to hear about it later, so it is
+better that I should be told at once."
+
+"My dear," answered Ulysses, "why should you press me to tell you?
+Still, I will not conceal it from you, though you will not like it. I do
+not like it myself, for Teiresias bade me travel far and wide, carrying
+an oar, till I came to a country where the people have never heard of
+the sea, and do not even mix salt with their food. They know nothing
+about ships, nor oars that are as the wings of a ship. He gave me this
+certain token which I will not hide from you. He said that a wayfarer
+should meet me and ask me whether it was a winnowing shovel that I had
+on my shoulder. On this, I was to fix my oar in the ground and sacrifice
+a ram, a bull, and a boar to Neptune; after which I was to go home and
+offer hecatombs to all the gods in heaven, one after the other. As for
+myself, he said that death should come to me from the sea, and that my
+life should ebb away very gently when I was full of years and peace of
+mind, and my people should bless me. All this, he said, should surely
+come to pass."
+
+And Penelope said, "If the gods are going to vouchsafe you a happier
+time in your old age, you may hope then to have some respite from
+misfortune."
+
+Thus did they converse. Meanwhile Eurynome and the nurse took torches
+and made the bed ready with soft coverlets; as soon as they had laid
+them, the nurse went back into the house to go to her rest, leaving the
+bed chamber woman Eurynome {183} to show Ulysses and Penelope to bed by
+torch light. When she had conducted them to their room she went
+back, and they then came joyfully to the rites of their own old bed.
+Telemachus, Philoetius, and the swineherd now left off dancing, and made
+the women leave off also. They then laid themselves down to sleep in the
+cloisters.
+
+When Ulysses and Penelope had had their fill of love they fell talking
+with one another. She told him how much she had had to bear in seeing
+the house filled with a crowd of wicked suitors who had killed so many
+sheep and oxen on her account, and had drunk so many casks of wine.
+Ulysses in his turn told her what he had suffered, and how much trouble
+he had himself given to other people. He told her everything, and she
+was so delighted to listen that she never went to sleep till he had
+ended his whole story.
+
+He began with his victory over the Cicons, and how he thence reached the
+fertile land of the Lotus-eaters. He told her all about the Cyclops
+and how he had punished him for having so ruthlessly eaten his brave
+comrades; how he then went on to Aeolus, who received him hospitably and
+furthered him on his way, but even so he was not to reach home, for to
+his great grief a hurricane carried him out to sea again; how he went on
+to the Laestrygonian city Telepylos, where the people destroyed all his
+ships with their crews, save himself and his own ship only. Then he told
+of cunning Circe and her craft, and how he sailed to the chill house of
+Hades, to consult the ghost of the Theban prophet Teiresias, and how he
+saw his old comrades in arms, and his mother who bore him and brought
+him up when he was a child; how he then heard the wondrous singing of
+the Sirens, and went on to the wandering rocks and terrible Charybdis
+and to Scylla, whom no man had ever yet passed in safety; how his men
+then ate the cattle of the sun-god, and how Jove therefore struck the
+ship with his thunderbolts, so that all his men perished together,
+himself alone being left alive; how at last he reached the Ogygian
+island and the nymph Calypso, who kept him there in a cave, and fed
+him, and wanted him to marry her, in which case she intended making him
+immortal so that he should never grow old, but she could not persuade
+him to let her do so; and how after much suffering he had found his way
+to the Phaeacians, who had treated him as though he had been a god, and
+sent him back in a ship to his own country after having given him gold,
+bronze, and raiment in great abundance. This was the last thing about
+which he told her, for here a deep sleep took hold upon him and eased
+the burden of his sorrows.
+
+Then Minerva bethought her of another matter. When she deemed that
+Ulysses had had both of his wife and of repose, she bade gold-enthroned
+Dawn rise out of Oceanus that she might shed light upon mankind. On
+this, Ulysses rose from his comfortable bed and said to Penelope,
+"Wife, we have both of us had our full share of troubles, you, here, in
+lamenting my absence, and I in being prevented from getting home though
+I was longing all the time to do so. Now, however, that we have at last
+come together, take care of the property that is in the house. As for
+the sheep and goats which the wicked suitors have eaten, I will take
+many myself by force from other people, and will compel the Achaeans to
+make good the rest till they shall have filled all my yards. I am now
+going to the wooded lands out in the country to see my father who has
+so long been grieved on my account, and to yourself I will give these
+instructions, though you have little need of them. At sunrise it will
+at once get abroad that I have been killing the suitors; go upstairs,
+therefore, {184} and stay there with your women. See nobody and ask no
+questions." {185}
+
+As he spoke he girded on his armour. Then he roused Telemachus,
+Philoetius, and Eumaeus, and told them all to put on their armour also.
+This they did, and armed themselves. When they had done so, they
+opened the gates and sallied forth, Ulysses leading the way. It was now
+daylight, but Minerva nevertheless concealed them in darkness and led
+them quickly out of the town.
+
+
+Book XXIV
+
+THE GHOSTS OF THE SUITORS IN HADES--ULYSSES AND HIS MEN GO TO THE HOUSE
+OF LAERTES--THE PEOPLE OF ITHACA COME OUT TO ATTACK ULYSSES, BUT MINERVA
+CONCLUDES A PEACE.
+
+Then Mercury of Cyllene summoned the ghosts of the suitors, and in his
+hand he held the fair golden wand with which he seals men's eyes in
+sleep or wakes them just as he pleases; with this he roused the ghosts
+and led them, while they followed whining and gibbering behind him. As
+bats fly squealing in the hollow of some great cave, when one of them
+has fallen out of the cluster in which they hang, even so did the ghosts
+whine and squeal as Mercury the healer of sorrow led them down into the
+dark abode of death. When they had passed the waters of Oceanus and the
+rock Leucas, they came to the gates of the sun and the land of dreams,
+whereon they reached the meadow of asphodel where dwell the souls and
+shadows of them that can labour no more.
+
+Here they found the ghost of Achilles son of Peleus, with those of
+Patroclus, Antilochus, and Ajax, who was the finest and handsomest man
+of all the Danaans after the son of Peleus himself.
+
+They gathered round the ghost of the son of Peleus, and the ghost of
+Agamemnon joined them, sorrowing bitterly. Round him were gathered also
+the ghosts of those who had perished with him in the house of Aegisthus;
+and the ghost of Achilles spoke first.
+
+"Son of Atreus," it said, "we used to say that Jove had loved you better
+from first to last than any other hero, for you were captain over many
+and brave men, when we were all fighting together before Troy; yet the
+hand of death, which no mortal can escape, was laid upon you all too
+early. Better for you had you fallen at Troy in the hey-day of your
+renown, for the Achaeans would have built a mound over your ashes, and
+your son would have been heir to your good name, whereas it has now been
+your lot to come to a most miserable end."
+
+"Happy son of Peleus," answered the ghost of Agamemnon, "for having
+died at Troy far from Argos, while the bravest of the Trojans and the
+Achaeans fell round you fighting for your body. There you lay in the
+whirling clouds of dust, all huge and hugely, heedless now of your
+chivalry. We fought the whole of the livelong day, nor should we ever
+have left off if Jove had not sent a hurricane to stay us. Then, when we
+had borne you to the ships out of the fray, we laid you on your bed and
+cleansed your fair skin with warm water and with ointments. The Danaans
+tore their hair and wept bitterly round about you. Your mother, when she
+heard, came with her immortal nymphs from out of the sea, and the sound
+of a great wailing went forth over the waters so that the Achaeans
+quaked for fear. They would have fled panic-stricken to their ships had
+not wise old Nestor whose counsel was ever truest checked them saying,
+'Hold, Argives, fly not sons of the Achaeans, this is his mother coming
+from the sea with her immortal nymphs to view the body of her son.'
+
+"Thus he spoke, and the Achaeans feared no more. The daughters of the
+old man of the sea stood round you weeping bitterly, and clothed you
+in immortal raiment. The nine muses also came and lifted up their sweet
+voices in lament--calling and answering one another; there was not an
+Argive but wept for pity of the dirge they chaunted. Days and nights
+seven and ten we mourned you, mortals and immortals, but on the
+eighteenth day we gave you to the flames, and many a fat sheep with many
+an ox did we slay in sacrifice around you. You were burnt in raiment of
+the gods, with rich resins and with honey, while heroes, horse and foot,
+clashed their armour round the pile as you were burning, with the tramp
+as of a great multitude. But when the flames of heaven had done
+their work, we gathered your white bones at daybreak and laid them in
+ointments and in pure wine. Your mother brought us a golden vase to hold
+them--gift of Bacchus, and work of Vulcan himself; in this we mingled
+your bleached bones with those of Patroclus who had gone before you, and
+separate we enclosed also those of Antilochus, who had been closer to
+you than any other of your comrades now that Patroclus was no more.
+
+"Over these the host of the Argives built a noble tomb, on a point
+jutting out over the open Hellespont, that it might be seen from far
+out upon the sea by those now living and by them that shall be born
+hereafter. Your mother begged prizes from the gods, and offered them
+to be contended for by the noblest of the Achaeans. You must have
+been present at the funeral of many a hero, when the young men gird
+themselves and make ready to contend for prizes on the death of some
+great chieftain, but you never saw such prizes as silver-footed Thetis
+offered in your honour; for the gods loved you well. Thus even in death
+your fame, Achilles, has not been lost, and your name lives evermore
+among all mankind. But as for me, what solace had I when the days of my
+fighting were done? For Jove willed my destruction on my return, by the
+hands of Aegisthus and those of my wicked wife."
+
+Thus did they converse, and presently Mercury came up to them with the
+ghosts of the suitors who had been killed by Ulysses. The ghosts of
+Agamemnon and Achilles were astonished at seeing them, and went up
+to them at once. The ghost of Agamemnon recognised Amphimedon son of
+Melaneus, who lived in Ithaca and had been his host, so it began to talk
+to him.
+
+"Amphimedon," it said, "what has happened to all you fine young men--all
+of an age too--that you are come down here under the ground? One could
+pick no finer body of men from any city. Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the mainland when you were cattle-lifting or sheep-stealing,
+or while fighting in defence of their wives and city? Answer my
+question, for I have been your guest. Do you not remember how I came to
+your house with Menelaus, to persuade Ulysses to join us with his ships
+against Troy? It was a whole month ere we could resume our voyage, for
+we had hard work to persuade Ulysses to come with us."
+
+And the ghost of Amphimedon answered, "Agamemnon, son of Atreus, king of
+men, I remember everything that you have said, and will tell you fully
+and accurately about the way in which our end was brought about. Ulysses
+had been long gone, and we were courting his wife, who did not say point
+blank that she would not marry, nor yet bring matters to an end, for she
+meant to compass our destruction: this, then, was the trick she played
+us. She set up a great tambour frame in her room and began to work on an
+enormous piece of fine needlework. 'Sweethearts,' said she, 'Ulysses
+is indeed dead, still, do not press me to marry again immediately;
+wait--for I would not have my skill in needlework perish
+unrecorded--till I have completed a pall for the hero Laertes, against
+the time when death shall take him. He is very rich, and the women of
+the place will talk if he is laid out without a pall.' This is what she
+said, and we assented; whereupon we could see her working upon her great
+web all day long, but at night she would unpick the stitches again
+by torchlight. She fooled us in this way for three years without our
+finding it out, but as time wore on and she was now in her fourth year,
+in the waning of moons and many days had been accomplished, one of her
+maids who knew what she was doing told us, and we caught her in the act
+of undoing her work, so she had to finish it whether she would or no;
+and when she showed us the robe she had made, after she had had it
+washed, {186} its splendour was as that of the sun or moon.
+
+"Then some malicious god conveyed Ulysses to the upland farm where his
+swineherd lives. Thither presently came also his son, returning from
+a voyage to Pylos, and the two came to the town when they had hatched
+their plot for our destruction. Telemachus came first, and then after
+him, accompanied by the swineherd, came Ulysses, clad in rags and
+leaning on a staff as though he were some miserable old beggar. He came
+so unexpectedly that none of us knew him, not even the older ones among
+us, and we reviled him and threw things at him. He endured both being
+struck and insulted without a word, though he was in his own house; but
+when the will of Aegis-bearing Jove inspired him, he and Telemachus
+took the armour and hid it in an inner chamber, bolting the doors behind
+them. Then he cunningly made his wife offer his bow and a quantity
+of iron to be contended for by us ill-fated suitors; and this was the
+beginning of our end, for not one of us could string the bow--nor nearly
+do so. When it was about to reach the hands of Ulysses, we all of us
+shouted out that it should not be given him, no matter what he might
+say, but Telemachus insisted on his having it. When he had got it in his
+hands he strung it with ease and sent his arrow through the iron. Then
+he stood on the floor of the cloister and poured his arrows on the
+ground, glaring fiercely about him. First he killed Antinous, and then,
+aiming straight before him, he let fly his deadly darts and they fell
+thick on one another. It was plain that some one of the gods was
+helping them, for they fell upon us with might and main throughout the
+cloisters, and there was a hideous sound of groaning as our brains
+were being battered in, and the ground seethed with our blood. This,
+Agamemnon, is how we came by our end, and our bodies are lying still
+uncared for in the house of Ulysses, for our friends at home do not
+yet know what has happened, so that they cannot lay us out and wash
+the black blood from our wounds, making moan over us according to the
+offices due to the departed."
+
+"Happy Ulysses, son of Laertes," replied the ghost of Agamemnon, "you
+are indeed blessed in the possession of a wife endowed with such rare
+excellence of understanding, and so faithful to her wedded lord as
+Penelope the daughter of Icarius. The fame, therefore, of her virtue
+shall never die, and the immortals shall compose a song that shall be
+welcome to all mankind in honour of the constancy of Penelope. How far
+otherwise was the wickedness of the daughter of Tyndareus who killed her
+lawful husband; her song shall be hateful among men, for she has brought
+disgrace on all womankind even on the good ones."
+
+Thus did they converse in the house of Hades deep down within the bowels
+of the earth. Meanwhile Ulysses and the others passed out of the town
+and soon reached the fair and well-tilled farm of Laertes, which he
+had reclaimed with infinite labour. Here was his house, with a lean-to
+running all round it, where the slaves who worked for him slept and sat
+and ate, while inside the house there was an old Sicel woman, who looked
+after him in this his country-farm. When Ulysses got there, he said to
+his son and to the other two:
+
+"Go to the house, and kill the best pig that you can find for dinner.
+Meanwhile I want to see whether my father will know me, or fail to
+recognise me after so long an absence."
+
+He then took off his armour and gave it to Eumaeus and Philoetius, who
+went straight on to the house, while he turned off into the vineyard to
+make trial of his father. As he went down into the great orchard, he did
+not see Dolius, nor any of his sons nor of the other bondsmen, for they
+were all gathering thorns to make a fence for the vineyard, at the place
+where the old man had told them; he therefore found his father alone,
+hoeing a vine. He had on a dirty old shirt, patched and very shabby;
+his legs were bound round with thongs of oxhide to save him from the
+brambles, and he also wore sleeves of leather; he had a goat skin cap on
+his head, and was looking very woe-begone. When Ulysses saw him so worn,
+so old and full of sorrow, he stood still under a tall pear tree and
+began to weep. He doubted whether to embrace him, kiss him, and tell him
+all about his having come home, or whether he should first question him
+and see what he would say. In the end he deemed it best to be crafty
+with him, so in this mind he went up to his father, who was bending down
+and digging about a plant.
+
+"I see, sir," said Ulysses, "that you are an excellent gardener--what
+pains you take with it, to be sure. There is not a single plant, not a
+fig tree, vine, olive, pear, nor flower bed, but bears the trace of your
+attention. I trust, however, that you will not be offended if I say
+that you take better care of your garden than of yourself. You are old,
+unsavoury, and very meanly clad. It cannot be because you are idle that
+your master takes such poor care of you, indeed your face and figure
+have nothing of the slave about them, and proclaim you of noble birth.
+I should have said that you were one of those who should wash well, eat
+well, and lie soft at night as old men have a right to do; but tell me,
+and tell me true, whose bondman are you, and in whose garden are you
+working? Tell me also about another matter. Is this place that I have
+come to really Ithaca? I met a man just now who said so, but he was a
+dull fellow, and had not the patience to hear my story out when I was
+asking him about an old friend of mine, whether he was still living, or
+was already dead and in the house of Hades. Believe me when I tell you
+that this man came to my house once when I was in my own country and
+never yet did any stranger come to me whom I liked better. He said that
+his family came from Ithaca and that his father was Laertes, son of
+Arceisius. I received him hospitably, making him welcome to all the
+abundance of my house, and when he went away I gave him all customary
+presents. I gave him seven talents of fine gold, and a cup of solid
+silver with flowers chased upon it. I gave him twelve light cloaks,
+and as many pieces of tapestry; I also gave him twelve cloaks of single
+fold, twelve rugs, twelve fair mantles, and an equal number of shirts.
+To all this I added four good looking women skilled in all useful arts,
+and I let him take his choice."
+
+His father shed tears and answered, "Sir, you have indeed come to the
+country that you have named, but it is fallen into the hands of wicked
+people. All this wealth of presents has been given to no purpose. If
+you could have found your friend here alive in Ithaca, he would have
+entertained you hospitably and would have requited your presents amply
+when you left him--as would have been only right considering what you
+had already given him. But tell me, and tell me true, how many years is
+it since you entertained this guest--my unhappy son, as ever was? Alas!
+He has perished far from his own country; the fishes of the sea have
+eaten him, or he has fallen a prey to the birds and wild beasts of some
+continent. Neither his mother, nor I his father, who were his parents,
+could throw our arms about him and wrap him in his shroud, nor could
+his excellent and richly dowered wife Penelope bewail her husband as was
+natural upon his death bed, and close his eyes according to the offices
+due to the departed. But now, tell me truly for I want to know. Who
+and whence are you--tell me of your town and parents? Where is the
+ship lying that has brought you and your men to Ithaca? Or were you a
+passenger on some other man's ship, and those who brought you here have
+gone on their way and left you?"
+
+"I will tell you everything," answered Ulysses, "quite truly. I come
+from Alybas, where I have a fine house. I am son of king Apheidas, who
+is the son of Polypemon. My own name is Eperitus; heaven drove me off my
+course as I was leaving Sicania, and I have been carried here against
+my will. As for my ship it is lying over yonder, off the open country
+outside the town, and this is the fifth year since Ulysses left my
+country. Poor fellow, yet the omens were good for him when he left me.
+The birds all flew on our right hands, and both he and I rejoiced to
+see them as we parted, for we had every hope that we should have another
+friendly meeting and exchange presents."
+
+A dark cloud of sorrow fell upon Laertes as he listened. He filled both
+hands with the dust from off the ground and poured it over his grey
+head, groaning heavily as he did so. The heart of Ulysses was touched,
+and his nostrils quivered as he looked upon his father; then he sprang
+towards him, flung his arms about him and kissed him, saying, "I am he,
+father, about whom you are asking--I have returned after having been
+away for twenty years. But cease your sighing and lamentation--we have
+no time to lose, for I should tell you that I have been killing the
+suitors in my house, to punish them for their insolence and crimes."
+
+"If you really are my son Ulysses," replied Laertes, "and have come back
+again, you must give me such manifest proof of your identity as shall
+convince me."
+
+"First observe this scar," answered Ulysses, "which I got from a boar's
+tusk when I was hunting on Mt. Parnassus. You and my mother had sent me
+to Autolycus, my mother's father, to receive the presents which when he
+was over here he had promised to give me. Furthermore I will point out
+to you the trees in the vineyard which you gave me, and I asked you all
+about them as I followed you round the garden. We went over them all,
+and you told me their names and what they all were. You gave me thirteen
+pear trees, ten apple trees, and forty fig trees; you also said you
+would give me fifty rows of vines; there was corn planted between each
+row, and they yield grapes of every kind when the heat of heaven has
+been laid heavy upon them."
+
+Laertes' strength failed him when he heard the convincing proofs which
+his son had given him. He threw his arms about him, and Ulysses had to
+support him, or he would have gone off into a swoon; but as soon as he
+came to, and was beginning to recover his senses, he said, "O father
+Jove, then you gods are still in Olympus after all, if the suitors have
+really been punished for their insolence and folly. Nevertheless, I
+am much afraid that I shall have all the townspeople of Ithaca up here
+directly, and they will be sending messengers everywhere throughout the
+cities of the Cephallenians."
+
+Ulysses answered, "Take heart and do not trouble yourself about that,
+but let us go into the house hard by your garden. I have already told
+Telemachus, Philoetius, and Eumaeus to go on there and get dinner ready
+as soon as possible."
+
+Thus conversing the two made their way towards the house. When they got
+there they found Telemachus with the stockman and the swineherd cutting
+up meat and mixing wine with water. Then the old Sicel woman took
+Laertes inside and washed him and anointed him with oil. She put him on
+a good cloak, and Minerva came up to him and gave him a more imposing
+presence, making him taller and stouter than before. When he came back
+his son was surprised to see him looking so like an immortal, and said
+to him, "My dear father, some one of the gods has been making you much
+taller and better-looking."
+
+Laertes answered, "Would, by Father Jove, Minerva, and Apollo, that
+I were the man I was when I ruled among the Cephallenians, and took
+Nericum, that strong fortress on the foreland. If I were still what I
+then was and had been in our house yesterday with my armour on, I should
+have been able to stand by you and help you against the suitors. I
+should have killed a great many of them, and you would have rejoiced to
+see it."
+
+Thus did they converse; but the others, when they had finished their
+work and the feast was ready, left off working, and took each his proper
+place on the benches and seats. Then they began eating; by and by old
+Dolius and his sons left their work and came up, for their mother, the
+Sicel woman who looked after Laertes now that he was growing old, had
+been to fetch them. When they saw Ulysses and were certain it was he,
+they stood there lost in astonishment; but Ulysses scolded them good
+naturedly and said, "Sit down to your dinner, old man, and never mind
+about your surprise; we have been wanting to begin for some time and
+have been waiting for you."
+
+Then Dolius put out both his hands and went up to Ulysses. "Sir," said
+he, seizing his master's hand and kissing it at the wrist, "we have long
+been wishing you home: and now heaven has restored you to us after we
+had given up hoping. All hail, therefore, and may the gods prosper you.
+{187} But tell me, does Penelope already know of your return, or shall
+we send some one to tell her?"
+
+"Old man," answered Ulysses, "she knows already, so you need not trouble
+about that." On this he took his seat, and the sons of Dolius gathered
+round Ulysses to give him greeting and embrace him one after the other;
+then they took their seats in due order near Dolius their father.
+
+While they were thus busy getting their dinner ready, Rumour went round
+the town, and noised abroad the terrible fate that had befallen the
+suitors; as soon, therefore, as the people heard of it they gathered
+from every quarter, groaning and hooting before the house of Ulysses.
+They took the dead away, buried every man his own, and put the bodies
+of those who came from elsewhere on board the fishing vessels, for the
+fishermen to take each of them to his own place. They then met angrily
+in the place of assembly, and when they were got together Eupeithes
+rose to speak. He was overwhelmed with grief for the death of his son
+Antinous, who had been the first man killed by Ulysses, so he said,
+weeping bitterly, "My friends, this man has done the Achaeans great
+wrong. He took many of our best men away with him in his fleet, and he
+has lost both ships and men; now, moreover, on his return he has been
+killing all the foremost men among the Cephallenians. Let us be up and
+doing before he can get away to Pylos or to Elis where the Epeans rule,
+or we shall be ashamed of ourselves for ever afterwards. It will be an
+everlasting disgrace to us if we do not avenge the murder of our sons
+and brothers. For my own part I should have no more pleasure in life,
+but had rather die at once. Let us be up, then, and after them, before
+they can cross over to the main land."
+
+He wept as he spoke and every one pitied him. But Medon and the bard
+Phemius had now woke up, and came to them from the house of Ulysses.
+Every one was astonished at seeing them, but they stood in the middle of
+the assembly, and Medon said, "Hear me, men of Ithaca. Ulysses did not
+do these things against the will of heaven. I myself saw an immortal god
+take the form of Mentor and stand beside him. This god appeared, now in
+front of him encouraging him, and now going furiously about the court
+and attacking the suitors whereon they fell thick on one another."
+
+On this pale fear laid hold of them, and old Halitherses, son of Mastor,
+rose to speak, for he was the only man among them who knew both past and
+future; so he spoke to them plainly and in all honesty, saying,
+
+"Men of Ithaca, it is all your own fault that things have turned out as
+they have; you would not listen to me, nor yet to Mentor, when we
+bade you check the folly of your sons who were doing much wrong in the
+wantonness of their hearts--wasting the substance and dishonouring the
+wife of a chieftain who they thought would not return. Now, however, let
+it be as I say, and do as I tell you. Do not go out against Ulysses, or
+you may find that you have been drawing down evil on your own heads."
+
+This was what he said, and more than half raised a loud shout, and at
+once left the assembly. But the rest stayed where they were, for the
+speech of Halitherses displeased them, and they sided with Eupeithes;
+they therefore hurried off for their armour, and when they had armed
+themselves, they met together in front of the city, and Eupeithes led
+them on in their folly. He thought he was going to avenge the murder
+of his son, whereas in truth he was never to return, but was himself to
+perish in his attempt.
+
+Then Minerva said to Jove, "Father, son of Saturn, king of kings, answer
+me this question--What do you propose to do? Will you set them fighting
+still further, or will you make peace between them?"
+
+And Jove answered, "My child, why should you ask me? Was it not by your
+own arrangement that Ulysses came home and took his revenge upon the
+suitors? Do whatever you like, but I will tell you what I think will
+be most reasonable arrangement. Now that Ulysses is revenged, let them
+swear to a solemn covenant, in virtue of which he shall continue to
+rule, while we cause the others to forgive and forget the massacre of
+their sons and brothers. Let them then all become friends as heretofore,
+and let peace and plenty reign."
+
+This was what Minerva was already eager to bring about, so down she
+darted from off the topmost summits of Olympus.
+
+Now when Laertes and the others had done dinner, Ulysses began by
+saying, "Some of you go out and see if they are not getting close up
+to us." So one of Dolius's sons went as he was bid. Standing on the
+threshold he could see them all quite near, and said to Ulysses, "Here
+they are, let us put on our armour at once."
+
+They put on their armour as fast as they could--that is to say Ulysses,
+his three men, and the six sons of Dolius. Laertes also and Dolius did
+the same--warriors by necessity in spite of their grey hair. When they
+had all put on their armour, they opened the gate and sallied forth,
+Ulysses leading the way.
+
+Then Jove's daughter Minerva came up to them, having assumed the form
+and voice of Mentor. Ulysses was glad when he saw her, and said to
+his son Telemachus, "Telemachus, now that you are about to fight in an
+engagement, which will show every man's mettle, be sure not to disgrace
+your ancestors, who were eminent for their strength and courage all the
+world over."
+
+"You say truly, my dear father," answered Telemachus, "and you shall
+see, if you will, that I am in no mind to disgrace your family."
+
+Laertes was delighted when he heard this. "Good heavens," he exclaimed,
+"what a day I am enjoying: I do indeed rejoice at it. My son and
+grandson are vying with one another in the matter of valour."
+
+On this Minerva came close up to him and said, "Son of Arceisius---best
+friend I have in the world--pray to the blue-eyed damsel, and to Jove
+her father; then poise your spear and hurl it."
+
+As she spoke she infused fresh vigour into him, and when he had prayed
+to her he poised his spear and hurled it. He hit Eupeithes' helmet, and
+the spear went right through it, for the helmet stayed it not, and
+his armour rang rattling round him as he fell heavily to the ground.
+Meantime Ulysses and his son fell upon the front line of the foe and
+smote them with their swords and spears; indeed, they would have killed
+every one of them, and prevented them from ever getting home again,
+only Minerva raised her voice aloud, and made every one pause. "Men of
+Ithaca," she cried, "cease this dreadful war, and settle the matter at
+once without further bloodshed."
+
+On this pale fear seized every one; they were so frightened that their
+arms dropped from their hands and fell upon the ground at the sound of
+the goddess' voice, and they fled back to the city for their lives. But
+Ulysses gave a great cry, and gathering himself together swooped down
+like a soaring eagle. Then the son of Saturn sent a thunderbolt of fire
+that fell just in front of Minerva, so she said to Ulysses, "Ulysses,
+noble son of Laertes, stop this warful strife, or Jove will be angry
+with you."
+
+Thus spoke Minerva, and Ulysses obeyed her gladly. Then Minerva assumed
+the form and voice of Mentor, and presently made a covenant of peace
+between the two contending parties.
+
+
+
+                        FOOTNOTES
+
+{1} Black races are evidently known to the writer as stretching all
+across Africa, one half looking West on to the Atlantic, and the other
+East on to the Indian Ocean.
+
+{2} The original use of the footstool was probably less to rest the feet
+than to keep them (especially when bare) from a floor which was often
+wet and dirty.
+
+{3} The [Greek] or seat, is occasionally called "high," as being higher
+than the [Greek] or low footstool. It was probably no higher than an
+ordinary chair is now, and seems to have had no back.
+
+{4} Temesa was on the West Coast of the toe of Italy, in what is now the
+gulf of Sta Eufemia. It was famous in remote times for its copper mines,
+which, however, were worked out when Strabo wrote.
+
+{5} i.e. "with a current in it"--see illustrations and map near the end
+of bks. v. and vi. respectively.
+
+{6} Reading [Greek] for [Greek], cf. "Od." iii. 81 where the same
+mistake is made, and xiii. 351 where the mountain is called Neritum, the
+same place being intended both here and in book xiii.
+
+{7} It is never plausibly explained why Penelope cannot do this, and
+from bk. ii. it is clear that she kept on deliberately encouraging the
+suitors, though we are asked to believe that she was only fooling them.
+
+{8} See note on "Od." i. 365.
+
+{9} Middle Argos means the Peleponnese which, however, is never so
+called in the "Iliad". I presume "middle" means "middle between the two
+Greek-speaking countries of Asia Minor and Sicily, with South Italy";
+for that parts of Sicily and also large parts, though not the whole of
+South Italy, were inhabited by Greek-speaking races centuries before the
+Dorian colonisations can hardly be doubted. The Sicians, and also the
+Sicels, both of them probably spoke Greek.
+
+{10} cf. "Il." vi. 490-495. In the "Iliad" it is "war," not "speech,"
+that is a man's matter. It argues a certain hardness, or at any rate
+dislike of the "Iliad" on the part of the writer of the "Odyssey,"
+that she should have adopted Hector's farewell to Andromache here, as
+elsewhere in the poem, for a scene of such inferior pathos.
+
+{11} [Greek] The whole open court with the covered cloister running
+round it was called [Greek], or [Greek], but the covered part was
+distinguished by being called "shady" or "shadow-giving". It was in this
+part that the tables for the suitors were laid. The Fountain Court at
+Hampton Court may serve as an illustration (save as regards the use of
+arches instead of wooden supports and rafters) and the arrangement
+is still common in Sicily. The usual translation "shadowy" or "dusky"
+halls, gives a false idea of the scene.
+
+{12} The reader will note the extreme care which the writer takes to
+make it clear that none of the suitors were allowed to sleep in Ulysses'
+house.
+
+{13} See Appendix; g, in plan of Ulysses' house.
+
+{14} I imagine this passage to be a rejoinder to "Il." xxiii. 702-705 in
+which a tripod is valued at twelve oxen, and a good useful maid of
+all work at only four. The scrupulous regard of Laertes for his wife's
+feelings is of a piece with the extreme jealousy for the honour of
+woman, which is manifest throughout the "Odyssey".
+
+{15} [Greek] "The [Greek], or tunica, was a shirt or shift, and served
+as the chief under garment of the Greeks and Romans, whether men
+or women." Smith's Dictionary of Greek and Roman Antiquities, under
+"Tunica".
+
+{16} Doors fastened to all intents and purposes as here described may be
+seen in the older houses at Trapani. There is a slot on the outer side
+of the door by means of which a person who has left the room can shoot
+the bolt. My bedroom at the Albergo Centrale was fastened in this way.
+
+{17} [Greek] So we vulgarly say "had cooked his goose," or "had settled
+his hash." Aegyptus cannot of course know of the fate Antiphus had met
+with, for there had as yet been no news of or from Ulysses.
+
+{18} "Il." xxii. 416. [Greek] The authoress has bungled by borrowing
+these words verbatim from the "Iliad", without prefixing the necessary
+"do not," which I have supplied.
+
+{19} i.e. you have money, and could pay when I got judgment, whereas the
+suitors are men of straw.
+
+{20} cf. "Il." ii. 76. [Greek]. The Odyssean passage runs [Greek]. Is
+it possible not to suspect that the name Mentor was coined upon that of
+Nestor?
+
+{21} i.e. in the outer court, and in the uncovered part of the inner
+house.
+
+{22} This would be fair from Sicily, which was doing duty for Ithaca in
+the mind of the writer, but a North wind would have been preferable for
+a voyage from the real Ithaca to Pylos.
+
+{23} [Greek] The wind does not whistle over waves. It only whistles
+through rigging or some other obstacle that cuts it.
+
+{24} cf. "Il." v.20. [Greek] The Odyssean line is [Greek]. There can
+be no doubt that the Odyssean line was suggested by the Iliadic, but
+nothing can explain why Idaeus jumping from his chariot should suggest
+to the writer of the "Odyssey" the sun jumping from the sea. The
+probability is that she never gave the matter a thought, but took the
+line in question as an effect of saturation with the "Iliad," and of
+unconscious cerebration. The "Odyssey" contains many such examples.
+
+{25} The heart, liver, lights, kidneys, etc. were taken out from the
+inside and eaten first as being more readily cooked; the [Greek], or
+bone meat, was cooking while the [Greek] or inward parts were being
+eaten. I imagine that the thigh bones made a kind of gridiron, while at
+the same time the marrow inside them got cooked.
+
+{26} i.e. skewers, either single, double, or even five pronged. The meat
+would be pierced with the skewer, and laid over the ashes to grill--the
+two ends of the skewer being supported in whatever way convenient. Meat
+so cooking may be seen in any eating house in Smyrna, or any Eastern
+town. When I rode across the Troad from the Dardanelles to Hissarlik and
+Mount Ida, I noticed that my dragoman and his men did all our outdoor
+cooking exactly in the Odyssean and Iliadic fashion.
+
+{27} cf. "Il." xvii. 567. [Greek] The Odyssean lines are--[Greek]
+
+{28} Reading [Greek] for [Greek], cf. "Od." i.186.
+
+{29} The geography of the Aegean as above described is correct, but is
+probably taken from the lost poem, the Nosti, the existence of which is
+referred to "Od." i.326,327 and 350, etc. A glance at the map will show
+that heaven advised its supplicants quite correctly.
+
+{30} The writer--ever jealous for the honour of women--extenuates
+Clytemnestra's guilt as far as possible, and explains it as due to her
+having been left unprotected, and fallen into the hands of a wicked man.
+
+{31} The Greek is [Greek] cf. "Iliad" ii. 408 [Greek] Surely the [Greek]
+of the Odyssean passage was due to the [Greek] of the "Iliad." No other
+reason suggests itself for the making Menelaus return on the very day of
+the feast given by Orestes. The fact that in the "Iliad" Menelaus came
+to a banquet without waiting for an invitation, determines the writer
+of the "Odyssey" to make him come to a banquet, also uninvited, but
+as circumstances did not permit of his having been invited, his coming
+uninvited is shown to have been due to chance. I do not think the
+authoress thought all this out, but attribute the strangeness of the
+coincidence to unconscious cerebration and saturation.
+
+{32} cf. "Il." i.458, ii. 421. The writer here interrupts an Iliadic
+passage (to which she returns immediately) for the double purpose of
+dwelling upon the slaughter of the heifer, and of letting Nestor's wife
+and daughter enjoy it also. A male writer, if he was borrowing from the
+"Iliad," would have stuck to his borrowing.
+
+{33} cf. "Il." xxiv. 587,588 where the lines refer to the washing the
+dead body of Hector.
+
+{34} See illustration on opposite page. The yard is typical of many that
+may be seen in Sicily. The existing ground-plan is probably unmodified
+from Odyssean, and indeed long pre-Odyssean times, but the earlier
+buildings would have no arches, and would, one would suppose, be mainly
+timber. The Odyssean [Greek] were the sheds that ran round the yard
+as the arches do now. The [Greek] was the one through which the main
+entrance passed, and which was hence "noisy," or reverberating. It had
+an upper story in which visitors were often lodged.
+
+{35} This journey is an impossible one. Telemachus and Pisistratus would
+have been obliged to drive over the Taygetus range, over which there has
+never yet been a road for wheeled vehicles. It is plain therefore that
+the audience for whom the "Odyssey" was written was one that would be
+unlikely to know anything about the topography of the Peloponnese, so
+that the writer might take what liberties she chose.
+
+{36} The lines which I have enclosed in brackets are evidently an
+afterthought--added probably by the writer herself--for they evince
+the same instinctively greater interest in anything that may concern a
+woman, which is so noticeable throughout the poem. There is no further
+sign of any special festivities nor of any other guests than Telemachus
+and Pisistratus, until lines 621-624 (ordinarily enclosed in brackets)
+are abruptly introduced, probably with a view of trying to carry off the
+introduction of the lines now in question.
+
+The addition was, I imagine, suggested by a desire to excuse and explain
+the non-appearance of Hermione in bk. xv., as also of both Hermione and
+Megapenthes in the rest of bk. iv. Megapenthes in bk. xv. seems to be
+still a bachelor: the presumption therefore is that bk. xv. was written
+before the story of his marriage here given. I take it he is only
+married here because his sister is being married. She having been
+properly attended to, Megapenthes might as well be married at the same
+time. Hermione could not now be less than thirty.
+
+I have dealt with this passage somewhat more fully in my "Authoress of
+the Odyssey", p.136-138. See also p. 256 of the same book.
+
+{37} Sparta and Lacedaemon are here treated as two different places,
+though in other parts of the poem it is clear that the writer
+understands them as one. The catalogue in the "Iliad," which the writer
+is here presumably following, makes the same mistake ("Il." ii. 581,582)
+
+{38} These last three lines are identical with "Il." vxiii. 604-606.
+
+{39} From the Greek [Greek] it is plain that Menelaus took up the piece
+of meat with his fingers.
+
+{40} Amber is never mentioned in the "Iliad." Sicily, where I suppose
+the "Odyssey" to have been written, has always been, and still is, one
+of the principal amber producing countries. It was probably the only one
+known in the Odyssean age. See "The Authoress of the Odyssey", p260.
+
+{41} This no doubt refers to the story told in the last poem of the
+Cypria about Paris and Helen robbing Menelaus of the greater part of his
+treasures, when they sailed together for Troy.
+
+{42} It is inconceivable that Helen should enter thus, in the middle of
+supper, intending to work with her distaff, if great festivities were
+going on. Telemachus and Pisistratus are evidently dining en famille.
+
+{43} In the Italian insurrection of 1848, eight young men who were being
+hotly pursued by the Austrian police hid themselves inside Donatello's
+colossal wooden horse in the Salone at Padua, and remained there for
+a week being fed by their confederates. In 1898 the last survivor was
+carried round Padua in triumph.
+
+{44} The Greek is [Greek]. Is it unfair to argue that the writer is a
+person of somewhat delicate sensibility, to whom a strong smell of fish
+is distasteful?
+
+{45} The Greek is [Greek]. I believe this to be a hit at the writer's
+own countrymen who were of Phocaean descent, and the next following line
+to be a rejoinder to complaints made against her in bk. vi. 273-288, to
+the effect that she gave herself airs and would marry none of her own
+people. For that the writer of the "Odyssey" was the person who has
+been introduced into the poem under the name of Nausicaa, I cannot bring
+myself to question. I may remind English readers that [Greek] (i.e.
+phoca) means "seal." Seals almost always appear on Phocaean coins.
+
+{46} Surely here again we are in the hands of a writer of delicate
+sensibility. It is not as though the seals were stale; they had only
+just been killed. The writer, however is obviously laughing at her own
+countrymen, and insulting them as openly as she dares.
+
+{47} We were told above (lines 357,357) that it was only one day's sail.
+
+{48} I give the usual translation, but I do not believe the Greek will
+warrant it. The Greek reads [Greek].
+
+This is usually held to mean that Ithaca is an island fit for breeding
+goats, and on that account more delectable to the speaker than it would
+have been if it were fit for breeding horses. I find little authority
+for such a translation; the most equitable translation of the text as it
+stands is, "Ithaca is an island fit for breeding goats, and delectable
+rather than fit for breeding horses; for not one of the islands is good
+driving ground, nor well meadowed." Surely the writer does not mean that
+a pleasant or delectable island would not be fit for breeding horses?
+The most equitable translation, therefore, of the present text being
+thus halt and impotent, we may suspect corruption, and I hazard the
+following emendation, though I have not adopted it in my translation, as
+fearing that it would be deemed too fanciful. I would read:--[Greek].
+
+As far as scanning goes the [Greek] is not necessary; [Greek] iv. 72,
+[Greek] iv. 233, to go no further afield than earlier lines of the same
+book, give sufficient authority for [Greek], but the [Greek] would not
+be redundant; it would emphasise the surprise of the contrast, and I
+should prefer to have it, though it is not very important either way.
+This reading of course should be translated "Ithaca is an island fit for
+breeding goats, and (by your leave) itself a horseman rather than
+fit for breeding horses--for not one of the islands is good and well
+meadowed ground."
+
+This would be sure to baffle the Alexandrian editors. "How," they would
+ask themselves, "could an island be a horseman?" and they would cast
+about for an emendation. A visit to the top of Mt. Eryx might perhaps
+make the meaning intelligible, and suggest my proposed restoration of
+the text to the reader as readily as it did to myself.
+
+I have elsewhere stated my conviction that the writer of the "Odyssey"
+was familiar with the old Sican city at the top of Mt. Eryx, and that
+the Aegadean islands which are so striking when seen thence did duty
+with her for the Ionian islands--Marettimo, the highest and most
+westerly of the group, standing for Ithaca. When seen from the top of
+Mt. Eryx Marettimo shows as it should do according to "Od." ix. 25,26,
+"on the horizon, all highest up in the sea towards the West," while
+the other islands lie "some way off it to the East." As we descend
+to Trapani, Marettimo appears to sink on to the top of the island of
+Levanzo, behind which it disappears. My friend, the late Signor E.
+Biaggini, pointed to it once as it was just standing on the top of
+Levanzo, and said to me "Come cavalca bene" ("How well it rides"), and
+this immediately suggested my emendation to me. Later on I found in
+the hymn to the Pythian Apollo (which abounds with tags taken from the
+"Odyssey") a line ending [Greek] which strengthened my suspicion that
+this was the original ending of the second of the two lines above under
+consideration.
+
+{49} See note on line 3 of this book. The reader will observe that
+the writer has been unable to keep the women out of an interpolation
+consisting only of four lines.
+
+{50} Scheria means a piece of land jutting out into the sea. In my
+"Authoress of the Odyssey" I thought "Jutland" would be a suitable
+translation, but it has been pointed out to me that "Jutland" only means
+the land of the Jutes.
+
+{51} Irrigation as here described is common in gardens near Trapani. The
+water that supplies the ducts is drawn from wells by a mule who turns a
+wheel with buckets on it.
+
+{52} There is not a word here about the cattle of the sun-god.
+
+{53} The writer evidently thought that green, growing wood might also be
+well seasoned.
+
+{54} The reader will note that the river was flowing with salt water
+i.e. that it was tidal.
+
+{55} Then the Ogygian island was not so far off, but that Nausicaa might
+be assumed to know where it was.
+
+{56} Greek [Greek]
+
+{57} I suspect a family joke, or sly allusion to some thing of which
+we know nothing, in this story of Eurymedusa's having been brought from
+Apeira. The Greek word "apeiros" means "inexperienced," "ignorant." Is
+it possible that Eurymedusa was notoriously incompetent?
+
+{58} Polyphemus was also son to Neptune, see "Od." ix. 412,529. he was
+therefore half brother to Nausithous, half uncle to King Alcinous, and
+half great uncle to Nausicaa.
+
+{59} It would seem as though the writer thought that Marathon was close
+to Athens.
+
+{60} Here the writer, knowing that she is drawing (with embellishments)
+from things actually existing, becomes impatient of past tenses and
+slides into the present.
+
+{61} This is hidden malice, implying that the Phaeacian magnates were
+no better than they should be. The final drink-offering should have been
+made to Jove or Neptune, not to the god of thievishness and rascality
+of all kinds. In line 164 we do indeed find Echeneus proposing that
+a drink-offering should be made to Jove, but Mercury is evidently,
+according to our authoress, the god who was most likely to be of use to
+them.
+
+{62} The fact of Alcinous knowing anything about the Cyclopes suggests
+that in the writer's mind Scheria and the country of the Cyclopes were
+not very far from one another. I take the Cyclopes and the giants to be
+one and the same people.
+
+{63} "My property, etc." The authoress is here adopting an Iliadic line
+(xix. 333), and this must account for the absence of all reference
+to Penelope. If she had happened to remember "Il." v.213, she would
+doubtless have appropriated it by preference, for that line reads "my
+country, my wife, and all the greatness of my house."
+
+{64} The at first inexplicable sleep of Ulysses (bk. xiii. 79, etc.)
+is here, as also in viii. 445, being obviously prepared. The writer
+evidently attached the utmost importance to it. Those who know that the
+harbour which did duty with the writer of the "Odyssey" for the one in
+which Ulysses landed in Ithaca, was only about 2 miles from the place
+in which Ulysses is now talking with Alcinous, will understand why the
+sleep was so necessary.
+
+{65} There were two classes--the lower who were found in provisions
+which they had to cook for themselves in the yards and outer precincts,
+where they would also eat--and the upper who would eat in the cloisters
+of the inner court, and have their cooking done for them.
+
+{66} Translation very dubious. I suppose the [Greek] here to be the
+covered sheds that ran round the outer courtyard. See illustrations at
+the end of bk. iii.
+
+{67} The writer apparently deems that the words "as compared with what
+oxen can plough in the same time" go without saying. Not so the writer
+of the "Iliad" from which the Odyssean passage is probably taken. He
+explains that mules can plough quicker than oxen ("Il." x.351-353)
+
+{68} It was very fortunate that such a disc happened to be there, seeing
+that none like it were in common use.
+
+{69} "Il." xiii. 37. Here, as so often elsewhere in the "Odyssey," the
+appropriation of an Iliadic line which is not quite appropriate puzzles
+the reader. The "they" is not the chains, nor yet Mars and Venus. It is
+an overflow from the Iliadic passage in which Neptune hobbles his horses
+in bonds "which none could either unloose or break so that they might
+stay there in that place." If the line would have scanned without the
+addition of the words "so that they might stay there in that place,"
+they would have been omitted in the "Odyssey."
+
+{70} The reader will note that Alcinous never goes beyond saying that
+he is going to give the goblet; he never gives it. Elsewhere in both
+"Iliad" and "Odyssey" the offer of a present is immediately followed by
+the statement that it was given and received gladly--Alcinous actually
+does give a chest and a cloak and shirt--probably also some of the corn
+and wine for the long two-mile voyage was provided by him--but it is
+quite plain that he gave no talent and no cup.
+
+{71} "Il." xviii, 344-349. These lines in the "Iliad" tell of the
+preparation for washing the body of Patroclus, and I am not pleased that
+the writer of the "Odyssey" should have adopted them here.
+
+{72} see note {64}
+
+{73} see note {43}
+
+{74} The reader will find this threat fulfilled in bk. xiii
+
+{75} If the other islands lay some distance away from Ithaca (which
+the word [Greek] suggests), what becomes of the [Greek] or gut between
+Ithaca and Samos which we hear of in Bks. iv. and xv.? I suspect that
+the authoress in her mind makes Telemachus come back from Pylos to the
+Lilybaean promontory and thence to Trapani through the strait between
+the Isola Grande and the mainland--the island of Asteria being the one
+on which Motya afterwards stood.
+
+{76} "Il." xviii. 533-534. The sudden lapse into the third person here
+for a couple of lines is due to the fact that the two Iliadic lines
+taken are in the third person.
+
+{77} cf. "Il." ii. 776. The words in both "Iliad" and "Odyssey" are
+[Greek]. In the "Iliad" they are used of the horses of Achilles'
+followers as they stood idle, "champing lotus."
+
+{78} I take all this passage about the Cyclopes having no ships to
+be sarcastic--meaning, "You people of Drepanum have no excuse for not
+colonising the island of Favognana, which you could easily do, for you
+have plenty of ships, and the island is a very good one." For that
+the island so fully described here is the Aegadean or "goat" island of
+Favognana, and that the Cyclopes are the old Sican inhabitants of Mt.
+Eryx should not be doubted.
+
+{79} For the reasons why it was necessary that the night should be so
+exceptionally dark see "The Authoress of the Odyssey" pp. 188-189.
+
+{80} None but such lambs as would suck if they were with their mothers
+would be left in the yard. The older lambs should have been out feeding.
+The authoress has got it all wrong, but it does not matter. See "The
+Authoress of the Odyssey" p.148.
+
+{81} This line is enclosed in brackets in the received text, and is
+omitted (with note) by Messrs. Butcher & Lang. But lines enclosed in
+brackets are almost always genuine; all that brackets mean is that the
+bracketed passage puzzled some early editor, who nevertheless found
+it too well established in the text to venture on omitting it. In the
+present case the line bracketed is the very last which a full-grown male
+editor would be likely to interpolate. It is safer to infer that the
+writer, a young woman, not knowing or caring at which end of the ship
+the rudder should be, determined to make sure by placing it at both
+ends, which we shall find she presently does by repeating it (line 340)
+at the stern of the ship. As for the two rocks thrown, the first I take
+to be the Asinelli, see map facing p.80. The second I see as the two
+contiguous islands of the Formiche, which are treated as one, see map
+facing p.108. The Asinelli is an island shaped like a boat, and pointing
+to the island of Favognana. I think the authoress's compatriots, who
+probably did not like her much better that she did them, jeered at the
+absurdity of Ulysses' conduct, and saw the Asinelli or "donkeys," not as
+the rock thrown by Polyphemus, but as the boat itself containing Ulysses
+and his men.
+
+{82} This line exists in the text here but not in the corresponding
+passage xii. 141. I am inclined to think it is interpolated (probably
+by the poetess herself) from the first of lines xi. 115-137, which I can
+hardly doubt were added by the writer when the scheme of the work was
+enlarged and altered. See "The Authoress of the Odyssey" pp. 254-255.
+
+{83} "Floating" ([Greek]) is not to be taken literally. The island
+itself, as apart from its inhabitants, was quite normal. There is no
+indication of its moving during the month that Ulysses stayed with
+Aeolus, and on his return from his unfortunate voyage, he seems to
+have found it in the same place. The [Greek] in fact should no more be
+pressed than [Greek] as applied to islands, "Odyssey" xv. 299--where
+they are called "flying" because the ship would fly past them. So also
+the "Wanderers," as explained by Buttmann; see note on "Odyssey" xii.
+57.
+
+{84} Literally "for the ways of the night and of the day are near." I
+have seen what Mr. Andrew Lang says ("Homer and the Epic," p.236, and
+"Longman's Magazine" for January, 1898, p.277) about the "amber route"
+and the "Sacred Way" in this connection; but until he gives his grounds
+for holding that the Mediterranean peoples in the Odyssean age used to
+go far North for their amber instead of getting it in Sicily, where it
+is still found in considerable quantities, I do not know what weight I
+ought to attach to his opinion. I have been unable to find grounds
+for asserting that B.C. 1000 there was any commerce between the
+Mediterranean and the "Far North," but I shall be very ready to learn
+if Mr. Lang will enlighten me. See "The Authoress of the Odyssey" pp.
+185-186.
+
+{85} One would have thought that when the sun was driving the stag down
+to the water, Ulysses might have observed its whereabouts.
+
+{86} See Hobbes of Malmesbury's translation.
+
+{87} "Il." vxiii. 349. Again the writer draws from the washing the body
+of Patroclus--which offends.
+
+{88} This visit is wholly without topographical significance.
+
+{89} Brides presented themselves instinctively to the imagination of the
+writer, as the phase of humanity which she found most interesting.
+
+{90} Ulysses was, in fact, to become a missionary and preach Neptune to
+people who knew not his name. I was fortunate enough to meet in Sicily
+a woman carrying one of these winnowing shovels; it was not much shorter
+than an oar, and I was able at once to see what the writer of the
+"Odyssey" intended.
+
+{91} I suppose the lines I have enclosed in brackets to have been added
+by the author when she enlarged her original scheme by the addition of
+books i.-iv. and xiii. (from line 187)-xxiv. The reader will observe
+that in the corresponding passage (xii. 137-141) the prophecy ends with
+"after losing all your comrades," and that there is no allusion to the
+suitors. For fuller explanation see "The Authoress of the Odyssey" pp.
+254-255.
+
+{92} The reader will remember that we are in the first year of Ulysses'
+wanderings, Telemachus therefore was only eleven years old. The same
+anachronism is made later on in this book. See "The Authoress of the
+Odyssey" pp. 132-133.
+
+{93} Tradition says that she had hanged herself. Cf. "Odyssey" xv. 355,
+etc.
+
+{94} Not to be confounded with Aeolus king of the winds.
+
+{95} Melampus, vide book xv. 223, etc.
+
+{96} I have already said in a note on bk. xi. 186 that at this point of
+Ulysses' voyage Telemachus could only be between eleven and twelve years
+old.
+
+{97} Is the writer a man or a woman?
+
+{98} Cf. "Il." iv. 521, [Greek]. The Odyssean line reads, [Greek]. The
+famous dactylism, therefore, of the Odyssean line was probably suggested
+by that of the Ileadic rather than by a desire to accommodate sound to
+sense. At any rate the double coincidence of a dactylic line, and an
+ending [Greek], seems conclusive as to the familiarity of the writer of
+the "Odyssey" with the Iliadic line.
+
+{99} Off the coast of Sicily and South Italy, in the month of May, I
+have seen men fastened half way up a boat's mast with their feet resting
+on a crosspiece, just large enough to support them. From this point
+of vantage they spear sword-fish. When I saw men thus employed I could
+hardly doubt that the writer of the "Odyssey" had seen others like them,
+and had them in her mind when describing the binding of Ulysses. I have
+therefore with some diffidence ventured to depart from the received
+translation of [Greek] (cf. Alcaeus frag. 18, where, however, it is
+very hard to say what [Greek] means). In Sophocles' Lexicon I find a
+reference to Chrysostom (l, 242, A. Ed. Benedictine Paris 1834-1839)
+for the word [Greek], which is probably the same as [Greek], but I have
+looked for the passage in vain.
+
+{100} The writer is at fault here and tries to put it off on Circe. When
+Ulysses comes to take the route prescribed by Circe, he ought to pass
+either the Wanderers or some other difficulty of which we are not told,
+but he does not do so. The Planctae, or Wanderers, merge into Scylla and
+Charybdis, and the alternative between them and something untold
+merges into the alternative whether Ulysses had better choose Scylla or
+Charybdis. Yet from line 260, it seems we are to consider the Wanderers
+as having been passed by Ulysses; this appears even more plainly from
+xxiii. 327, in which Ulysses expressly mentions the Wandering rocks as
+having been between the Sirens and Scylla and Charybdis. The writer,
+however, is evidently unaware that she does not quite understand her own
+story; her difficulty was perhaps due to the fact that though Trapanese
+sailors had given her a fair idea as to where all her other localities
+really were, no one in those days more than in our own could localise
+the Planctae, which in fact, as Buttmann has argued, were derived not
+from any particular spot, but from sailors' tales about the difficulties
+of navigating the group of the Aeolian islands as a whole (see note on
+"Od." x. 3). Still the matter of the poor doves caught her fancy, so she
+would not forgo them. The whirlwinds of fire and the smoke that hangs on
+Scylla suggests allusion to Stromboli and perhaps even Etna. Scylla is
+on the Italian side, and therefore may be said to look West. It is about
+8 miles thence to the Sicilian coast, so Ulysses may be perfectly well
+told that after passing Scylla he will come to the Thrinacian island or
+Sicily. Charybdis is transposed to a site some few miles to the north of
+its actual position.
+
+{101} I suppose this line to have been intercalated by the author when
+lines 426-446 were added.
+
+{102} For the reasons which enable us to identify the island of the two
+Sirens with the Lipari island now Salinas--the ancient Didyme, or "twin"
+island--see The Authoress of the Odyssey, pp. 195, 196. The two
+Sirens doubtless were, as their name suggests, the whistling gusts, or
+avalanches of air that at times descend without a moment's warning from
+the two lofty mountains of Salinas--as also from all high points in the
+neighbourhood.
+
+{103} See Admiral Smyth on the currents in the Straits of Messina,
+quoted in "The Authoress of the Odyssey," p. 197.
+
+{104} In the islands of Favognana and Marettimo off Trapani I have seen
+men fish exactly as here described. They chew bread into a paste and
+throw it into the sea to attract the fish, which they then spear. No
+line is used.
+
+{105} The writer evidently regards Ulysses as on a coast that looked
+East at no great distance south of the Straits of Messina somewhere,
+say, near Tauromenium, now Taormina.
+
+{106} Surely there must be a line missing here to tell us that the keel
+and mast were carried down into Charybdis. Besides, the aorist [Greek]
+in its present surrounding is perplexing. I have translated it as though
+it were an imperfect; I see Messrs. Butcher and Lang translate it as
+a pluperfect, but surely Charybdis was in the act of sucking down the
+water when Ulysses arrived.
+
+{107} I suppose the passage within brackets to have been an afterthought
+but to have been written by the same hand as the rest of the poem. I
+suppose xii. 103 to have been also added by the writer when she decided
+on sending Ulysses back to Charybdis. The simile suggests the hand of
+the wife or daughter of a magistrate who had often seen her father come
+in cross and tired.
+
+{108} Gr. [Greek]. This puts coined money out of the question, but
+nevertheless implies that the gold had been worked into ornaments of
+some kind.
+
+{109} I suppose Teiresias' prophecy of bk. xi. 114-120 had made no
+impression on Ulysses. More probably the prophecy was an afterthought,
+intercalated, as I have already said, by the authoress when she changed
+her scheme.
+
+{110} A male writer would have made Ulysses say, not "may you give
+satisfaction to your wives," but "may your wives give satisfaction to
+you."
+
+{111} See note {64}.
+
+{112} The land was in reality the shallow inlet, now the salt works of
+S. Cusumano--the neighbourhood of Trapani and Mt. Eryx being made to do
+double duty, both as Scheria and Ithaca. Hence the necessity for making
+Ulysses set out after dark, fall instantly into a profound sleep, and
+wake up on a morning so foggy that he could not see anything till the
+interviews between Neptune and Jove and between Ulysses and Minerva
+should have given the audience time to accept the situation. See
+illustrations and map near the end of bks. v. and vi. respectively.
+
+{113} This cave, which is identifiable with singular completeness, is
+now called the "grotta del toro," probably a corruption of "tesoro," for
+it is held to contain a treasure. See The Authoress of the Odyssey, pp.
+167-170.
+
+{114} Probably they would.
+
+{115} Then it had a shallow shelving bottom.
+
+{116} Doubtless the road would pass the harbour in Odyssean times as it
+passes the salt works now; indeed, if there is to be a road at all there
+is no other level ground which it could take. See map above referred to.
+
+{117} The rock at the end of the Northern harbour of Trapani, to which
+I suppose the writer of the "Odyssey" to be here referring, still bears
+the name Malconsiglio--"the rock of evil counsel." There is a legend
+that it was a ship of Turkish pirates who were intending to attack
+Trapani, but the "Madonna di Trapani" crushed them under this rock just
+as they were coming into port. My friend Cavaliere Giannitrapani of
+Trapani told me that his father used to tell him when he was a boy that
+if he would drop exactly three drops of oil on to the water near the
+rock, he would see the ship still at the bottom. The legend is evidently
+a Christianised version of the Odyssean story, while the name supplies
+the additional detail that the disaster happened in consequence of an
+evil counsel.
+
+{118} It would seem then that the ship had got all the way back from
+Ithaca in about a quarter of an hour.
+
+{119} And may we not add "and also to prevent his recognising that he
+was only in the place where he had met Nausicaa two days earlier."
+
+{120} All this is to excuse the entire absence of Minerva from books
+ix.-xii., which I suppose had been written already, before the authoress
+had determined on making Minerva so prominent a character.
+
+{121} We have met with this somewhat lame attempt to cover the writer's
+change of scheme at the end of bk. vi.
+
+{122} I take the following from The Authoress of the Odyssey, p. 167.
+"It is clear from the text that there were two [caves] not one, but some
+one has enclosed in brackets the two lines in which the second cave is
+mentioned, I presume because he found himself puzzled by having a second
+cave sprung upon him when up to this point he had only been told of one.
+
+"I venture to think that if he had known the ground he would not have
+been puzzled, for there are two caves, distant about 80 or 100 yards
+from one another." The cave in which Ulysses hid his treasure is, as I
+have already said, identifiable with singular completeness. The other
+cave presents no special features, neither in the poem nor in nature.
+
+{123} There is no attempt to disguise the fact that Penelope had long
+given encouragement to the suitors. The only defence set up is that she
+did not really mean to encourage them. Would it not have been wiser to
+have tried a little discouragement?
+
+{124} See map near the end of bk. vi. Ruccazzu dei corvi of course means
+"the rock of the ravens." Both name and ravens still exist.
+
+{125} See The Authoress of the Odyssey, pp. 140, 141. The real reason
+for sending Telemachus to Pylos and Lacedaemon was that the authoress
+might get Helen of Troy into her poem. He was sent at the only point in
+the story at which he could be sent, so he must have gone then or not at
+all.
+
+{126} The site I assign to Eumaeus's hut, close to the Ruccazzu dei
+Corvi, is about 2,000 feet above the sea, and commands an extensive
+view.
+
+{127} Sandals such as Eumaeus was making are still worn in the Abruzzi
+and elsewhere. An oblong piece of leather forms the sole: holes are cut
+at the four corners, and through these holes leathern straps are passed,
+which are bound round the foot and cross-gartered up the calf.
+
+{128} See note {75}
+
+{129} Telemachus like many another good young man seems to expect every
+one to fetch and carry for him.
+
+{130} "Il." vi. 288. The store room was fragrant because it was made of
+cedar wood. See "Il." xxiv. 192.
+
+{131} cf. "Il." vi. 289 and 293-296. The dress was kept at the bottom
+of the chest as one that would only be wanted on the greatest occasions;
+but surely the marriage of Hermione and of Megapenthes (bk, iv. ad
+init.) might have induced Helen to wear it on the preceding evening,
+in which case it could hardly have got back. We find no hint here of
+Megapenthes' recent marriage.
+
+{132} See note {83}.
+
+{133} cf. "Od." xi. 196, etc.
+
+{134} The names Syra and Ortygia, on which island a great part of the
+Doric Syracuse was originally built, suggest that even in Odyssean times
+there was a prehistoric Syracuse, the existence of which was known to
+the writer of the poem.
+
+{135} Literally "where are the turnings of the sun." Assuming, as we may
+safely do, that the Syra and Ortygia of the "Odyssey" refer to Syracuse,
+it is the fact that not far to the South of these places the land turns
+sharply round, so that mariners following the coast would find the
+sun upon the other side of their ship to that on which they'd had it
+hitherto.
+
+Mr. A. S. Griffith has kindly called my attention to Herod iv. 42,
+where, speaking of the circumnavigation of Africa by Phoenician mariners
+under Necos, he writes:
+
+"On their return they declared--I for my part do not believe them, but
+perhaps others may--that in sailing round Libya [i.e. Africa] they had
+the sun upon their right hand. In this way was the extent of Libya first
+discovered.
+
+"I take it that Eumaeus was made to have come from Syracuse because
+the writer thought she rather ought to have made something happen at
+Syracuse during her account of the voyages of Ulysses. She could
+not, however, break his long drift from Charybdis to the island of
+Pantellaria; she therefore resolved to make it up to Syracuse in another
+way."
+
+{135} Modern excavations establish the existence of two and only two
+pre-Dorian communities at Syracuse; they were, so Dr. Orsi informed me,
+at Plemmirio and Cozzo Pantano. See The Authoress of the Odyssey, pp.
+211-213.
+
+{136} This harbour is again evidently the harbour in which Ulysses had
+landed, i.e. the harbour that is now the salt works of S. Cusumano.
+
+{137} This never can have been anything but very niggardly pay for some
+eight or nine days' service. I suppose the crew were to consider the
+pleasure of having had a trip to Pylos as a set off. There is no trace
+of the dinner as having been actually given, either on the following or
+any other morning.
+
+{138} No hawk can tear its prey while it is on the wing.
+
+{139} The text is here apparently corrupt, and will not make sense as it
+stands. I follow Messrs. Butcher and Lang in omitting line 101.
+
+{140} i.e. to be milked, as in South Italian and Sicilian towns at the
+present day.
+
+{141} The butchering and making ready the carcases took place partly in
+the outer yard and partly in the open part of the inner court.
+
+{142} These words cannot mean that it would be afternoon soon after they
+were spoken. Ulysses and Eumaeus reached the town which was "some way
+off" (xvii. 25) in time for the suitor's early meal (xvii. 170 and 176)
+say at ten or eleven o' clock. The context of the rest of the book shows
+this. Eumaeus and Ulysses, therefore, cannot have started later than
+eight or nine, and Eumaeus's words must be taken as an exaggeration for
+the purpose of making Ulysses bestir himself.
+
+{143} I imagine the fountain to have been somewhere about where the
+church of the Madonna di Trapani now stands, and to have been fed with
+water from what is now called the Fontana Diffali on Mt. Eryx.
+
+{144} From this and other passages in the "Odyssey" it appears that
+we are in an age anterior to the use of coined money--an age when
+cauldrons, tripods, swords, cattle, chattels of all kinds, measures
+of corn, wine, or oil, etc. etc., not to say pieces of gold, silver,
+bronze, or even iron, wrought more or less, but unstamped, were the
+nearest approach to a currency that had as yet been reached.
+
+{145} Gr. is [Greek]
+
+{146} I correct these proofs abroad and am not within reach of Hesiod,
+but surely this passage suggests acquaintance with the Works and Ways,
+though it by no means compels it.
+
+{147} It would seem as though Eurynome and Euryclea were the same
+person. See note {156}
+
+{148} It is plain, therefore, that Iris was commonly accepted as the
+messenger of the gods, though our authoress will never permit her to
+fetch or carry for any one.
+
+{149} i.e. the doorway leading from the inner to the outer court.
+
+{150} Surely in this scene, again, Eurynome is in reality Euryclea. See
+note {156}
+
+{151} These, I imagine, must have been in the open part of the inner
+courtyard, where the maids also stood, and threw the light of their
+torches into the covered cloister that ran all round it. The smoke would
+otherwise have been intolerable.
+
+{152} Translation very uncertain; vide Liddell and Scott, under [Greek]
+
+{153} See photo on opposite page.
+
+{154} cf. "Il." ii. 184, and 217, 218. An additional and well-marked
+feature being wanted to convince Penelope, the writer has taken the
+hunched shoulders of Thersites (who is mentioned immediately after
+Eurybates in the "Iliad") and put them on to Eurybates' back.
+
+{155} This is how geese are now fed in Sicily, at any rate in summer,
+when the grass is all burnt up. I have never seen them grazing.
+
+{156} Lower down (line 143) Euryclea says it was herself that had thrown
+the cloak over Ulysses--for the plural should not be taken as implying
+more than one person. The writer is evidently still fluctuating between
+Euryclea and Eurynome as the name for the old nurse. She probably
+originally meant to call her Euryclea, but finding it not immediately
+easy to make Euryclea scan in xvii. 495, she hastily called her
+Eurynome, intending either to alter this name later or to change the
+earlier Euryclea's into Eurynome. She then drifted in to Eurynome
+as convenience further directed, still nevertheless hankering after
+Euryclea, till at last she found that the path of least resistance
+would lie in the direction of making Eurynome and Euryclea two persons.
+Therefore in xxiii. 289-292 both Eurynome and "the nurse" (who can be
+none other than Euryclea) come on together. I do not say that this is
+feminine, but it is not unfeminine.
+
+{157} See note {156}
+
+{158} This, I take it, was immediately in front of the main entrance of
+the inner courtyard into the body of the house.
+
+{159} This is the only allusion to Sardinia in either "Iliad" or
+"Odyssey."
+
+{160} The normal translation of the Greek word would be "holding back,"
+"curbing," "restraining," but I cannot think that the writer meant
+this--she must have been using the word in its other sense of "having,"
+"holding," "keeping," "maintaining."
+
+{161} I have vainly tried to realise the construction of the fastening
+here described.
+
+{162} See plan of Ulysses' house in the appendix. It is evident that the
+open part of the court had no flooring but the natural soil.
+
+{163} See plan of Ulysses' house, and note {175}.
+
+{164} i.e. the door that led into the body of the house.
+
+{165} This was, no doubt, the little table that was set for Ulysses,
+"Od." xx. 259.
+
+Surely the difficulty of this passage has been overrated. I suppose
+the iron part of the axe to have been wedged into the handle, or bound
+securely to it--the handle being half buried in the ground. The axe
+would be placed edgeways towards the archer, and he would have to shoot
+his arrow through the hole into which the handle was fitted when the axe
+was in use. Twelve axes were placed in a row all at the same height,
+all exactly in front of one another, all edgeways to Ulysses whose arrow
+passed through all the holes from the first onward. I cannot see how the
+Greek can bear any other interpretation, the words being, [Greek]
+
+"He did not miss a single hole from the first onwards." [Greek]
+according to Liddell and Scott being "the hole for the handle of an
+axe, etc.," while [Greek] ("Od." v. 236) is, according to the same
+authorities, the handle itself. The feat is absurdly impossible, but our
+authoress sometimes has a soul above impossibilities.
+
+{166} The reader will note how the spoiling of good food distresses the
+writer even in such a supreme moment as this.
+
+{167} Here we have it again. Waste of substance comes first.
+
+{168} cf. "Il." iii. 337 and three other places. It is strange that
+the author of the "Iliad" should find a little horse-hair so alarming.
+Possibly enough she was merely borrowing a common form line from some
+earlier poet--or poetess--for this is a woman's line rather than a
+man's.
+
+{169} Or perhaps simply "window." See plan in the appendix.
+
+{170} i.e. the pavement on which Ulysses was standing.
+
+{171} The interpretation of lines 126-143 is most dubious, and at best
+we are in a region of melodrama: cf., however, i.425, etc. from which it
+appears that there was a tower in the outer court, and that Telemachus
+used to sleep in it. The [Greek] I take to be a door, or trap door,
+leading on to the roof above Telemachus's bed room, which we are told
+was in a place that could be seen from all round--or it might be simply
+a window in Telemachus's room looking out into the street. From the
+top of the tower the outer world was to be told what was going on, but
+people could not get in by the [Greek]: they would have to come in by
+the main entrance, and Melanthius explains that the mouth of the narrow
+passage (which was in the lands of Ulysses and his friends) commanded
+the only entrance by which help could come, so that there would be
+nothing gained by raising an alarm. As for the [Greek] of line 143,
+no commentator ancient or modern has been able to say what was
+intended--but whatever they were, Melanthius could never carry twelve
+shields, twelve helmets, and twelve spears. Moreover, where he could
+go the others could go also. If a dozen suitors had followed Melanthius
+into the house they could have attacked Ulysses in the rear, in which
+case, unless Minerva had intervened promptly, the "Odyssey" would have
+had a different ending. But throughout the scene we are in a region of
+extravagance rather than of true fiction--it cannot be taken seriously
+by any but the very serious, until we come to the episode of Phemius and
+Medon, where the writer begins to be at home again.
+
+{172} I presume it was intended that there should be a hook driven into
+the bearing-post.
+
+{173} What for?
+
+{174} Gr: [Greek]. This is not [Greek].
+
+{175} From lines 333 and 341 of this book, and lines 145 and 146 of bk.
+xxi we can locate the approach to the [Greek] with some certainty.
+
+{176} But in xix. 500-502 Ulysses scolded Euryclea for offering
+information on this very point, and declared himself quite able to
+settle it for himself.
+
+{177} There were a hundred and eight Suitors.
+
+{178} Lord Grimthorpe, whose understanding does not lend itself to easy
+imposition, has been good enough to write to me about my conviction that
+the "Odyssey" was written by a woman, and to send me remarks upon the
+gross absurdity of the incident here recorded. It is plain that all
+the authoress cared about was that the women should be hanged: as for
+attempting to realise, or to make her readers realise, how the hanging
+was done, this was of no consequence. The reader must take her word for
+it and ask no questions. Lord Grimthorpe wrote:
+
+"I had better send you my ideas about Nausicaa's hanging of the
+maids (not 'maidens,' of whom Froude wrote so well in his 'Science of
+History') before I forget it all. Luckily for me Liddell & Scott have
+specially translated most of the doubtful words, referring to this very
+place.
+
+"A ship's cable. I don't know how big a ship she meant, but it must have
+been a very small one indeed if its 'cable' could be used to tie tightly
+round a woman's neck, and still more round a dozen of them 'in a row,'
+besides being strong enough to hold them and pull them all up.
+
+"A dozen average women would need the weight and strength of more than
+a dozen strong heavy men even over the best pulley hung to the roof
+over them; and the idea of pulling them up by a rope hung anyhow round a
+pillar [Greek] is absurdly impossible; and how a dozen of them could be
+hung dangling round one post is a problem which a senior wrangler would
+be puzzled to answer... She had better have let Telemachus use his sword
+as he had intended till she changed his mind for him."
+
+{179} Then they had all been in Ulysses' service over twenty years;
+perhaps the twelve guilty ones had been engaged more recently.
+
+{180} Translation very doubtful--cf. "It." xxiv. 598.
+
+{181} But why could she not at once ask to see the scar, of which
+Euryclea had told her, or why could not Ulysses have shown it to her?
+
+{182} The people of Ithaca seem to have been as fond of carping as the
+Phaeacians were in vi. 273, etc.
+
+{183} See note {156}. Ulysses's bed room does not appear to have been
+upstairs, nor yet quite within the house. Is it possible that it was
+"the domed room" round the outside of which the erring maids were, for
+aught we have heard to the contrary, still hanging?
+
+{184} Ulysses bedroom in the mind of the writer is here too apparently
+down stairs.
+
+{185} Penelope having been now sufficiently whitewashed, disappears from
+the poem.
+
+{186} So practised a washerwoman as our authoress doubtless knew that by
+this time the web must have become such a wreck that it would have gone
+to pieces in the wash.
+
+A lady points out to me, just as these sheets are leaving my hands, that
+no really good needlewoman--no one, indeed, whose work or character was
+worth consideration--could have endured, no matter for what reason, the
+unpicking of her day's work, day after day for between three and four
+years.
+
+{187} We must suppose Dolius not yet to know that his son Melanthius
+had been tortured, mutilated, and left to die by Ulysses' orders on the
+preceding day, and that his daughter Melantho had been hanged. Dolius
+was probably exceptionally simple-minded, and his name was ironical.
+So on Mt. Eryx I was shown a man who was always called Sonza Malizia or
+"Guileless"--he being held exceptionally cunning.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Odyssey, by Homer
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+***** This file should be named 1727.txt or 1727.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/2/1727/
+
+Produced by Jim Tinsley
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License available with this file or online at
+  www.gutenberg.org/license.
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation information page at www.gutenberg.org
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at 809
+North 1500 West, Salt Lake City, UT 84116, (801) 596-1887.  Email
+contact links and up to date contact information can be found at the
+Foundation's web site and official page at www.gutenberg.org/contact
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit:  www.gutenberg.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart was the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For forty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/peter-pan.txt
+++ b/jet/hadoop/src/main/resources/books/peter-pan.txt
@@ -1,0 +1,6649 @@
+﻿The Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+** This is a COPYRIGHTED Project Gutenberg eBook, Details Below **
+**     Please follow the copyright guidelines in this file.     **
+
+Title: Peter Pan
+       Peter Pan and Wendy
+
+Author: James M. Barrie
+
+Posting Date: June 25, 2008 [EBook #16]
+Release Date: July, 1991
+Last Updated: October 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+
+
+
+
+
+
+
+
+
+PETER PAN
+
+[PETER AND WENDY]
+
+By J. M. Barrie [James Matthew Barrie]
+
+A Millennium Fulcrum Edition (c)1991 by Duncan Research
+
+
+
+
+Contents:
+
+Chapter 1 PETER BREAKS THROUGH
+
+Chapter 2 THE SHADOW
+
+Chapter 3 COME AWAY, COME AWAY!
+
+Chapter 4 THE FLIGHT
+
+Chapter 5 THE ISLAND COME TRUE
+
+Chapter 6 THE LITTLE HOUSE
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+Chapter 8 THE MERMAID’S LAGOON
+
+Chapter 9 THE NEVER BIRD
+
+Chapter 10 THE HAPPY HOME
+
+Chapter 11 WENDY’S STORY
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+Chapter 14 THE PIRATE SHIP
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Chapter 16 THE RETURN HOME
+
+Chapter 17 WHEN WENDY GREW UP
+
+
+
+
+Chapter 1 PETER BREAKS THROUGH
+
+All children, except one, grow up. They soon know that they will grow
+up, and the way Wendy knew was this. One day when she was two years old
+she was playing in a garden, and she plucked another flower and ran with
+it to her mother. I suppose she must have looked rather delightful, for
+Mrs. Darling put her hand to her heart and cried, “Oh, why can’t you
+remain like this for ever!” This was all that passed between them on
+the subject, but henceforth Wendy knew that she must grow up. You always
+know after you are two. Two is the beginning of the end.
+
+Of course they lived at 14 [their house number on their street], and
+until Wendy came her mother was the chief one. She was a lovely lady,
+with a romantic mind and such a sweet mocking mouth. Her romantic
+mind was like the tiny boxes, one within the other, that come from the
+puzzling East, however many you discover there is always one more; and
+her sweet mocking mouth had one kiss on it that Wendy could never get,
+though there it was, perfectly conspicuous in the right-hand corner.
+
+The way Mr. Darling won her was this: the many gentlemen who had been
+boys when she was a girl discovered simultaneously that they loved her,
+and they all ran to her house to propose to her except Mr. Darling, who
+took a cab and nipped in first, and so he got her. He got all of her,
+except the innermost box and the kiss. He never knew about the box, and
+in time he gave up trying for the kiss. Wendy thought Napoleon could
+have got it, but I can picture him trying, and then going off in a
+passion, slamming the door.
+
+Mr. Darling used to boast to Wendy that her mother not only loved him
+but respected him. He was one of those deep ones who know about stocks
+and shares. Of course no one really knows, but he quite seemed to know,
+and he often said stocks were up and shares were down in a way that
+would have made any woman respect him.
+
+Mrs. Darling was married in white, and at first she kept the books
+perfectly, almost gleefully, as if it were a game, not so much as a
+Brussels sprout was missing; but by and by whole cauliflowers dropped
+out, and instead of them there were pictures of babies without faces.
+She drew them when she should have been totting up. They were Mrs.
+Darling’s guesses.
+
+Wendy came first, then John, then Michael.
+
+For a week or two after Wendy came it was doubtful whether they would
+be able to keep her, as she was another mouth to feed. Mr. Darling was
+frightfully proud of her, but he was very honourable, and he sat on the
+edge of Mrs. Darling’s bed, holding her hand and calculating expenses,
+while she looked at him imploringly. She wanted to risk it, come what
+might, but that was not his way; his way was with a pencil and a piece
+of paper, and if she confused him with suggestions he had to begin at
+the beginning again.
+
+“Now don’t interrupt,” he would beg of her.
+
+“I have one pound seventeen here, and two and six at the office; I can
+cut off my coffee at the office, say ten shillings, making two nine
+and six, with your eighteen and three makes three nine seven, with five
+naught naught in my cheque-book makes eight nine seven--who is that
+moving?--eight nine seven, dot and carry seven--don’t speak, my own--and
+the pound you lent to that man who came to the door--quiet, child--dot
+and carry child--there, you’ve done it!--did I say nine nine seven? yes,
+I said nine nine seven; the question is, can we try it for a year on
+nine nine seven?”
+
+“Of course we can, George,” she cried. But she was prejudiced in Wendy’s
+favour, and he was really the grander character of the two.
+
+“Remember mumps,” he warned her almost threateningly, and off he went
+again. “Mumps one pound, that is what I have put down, but I daresay
+it will be more like thirty shillings--don’t speak--measles one five,
+German measles half a guinea, makes two fifteen six--don’t waggle your
+finger--whooping-cough, say fifteen shillings”--and so on it went, and
+it added up differently each time; but at last Wendy just got through,
+with mumps reduced to twelve six, and the two kinds of measles treated
+as one.
+
+There was the same excitement over John, and Michael had even a narrower
+squeak; but both were kept, and soon, you might have seen the three of
+them going in a row to Miss Fulsom’s Kindergarten school, accompanied by
+their nurse.
+
+Mrs. Darling loved to have everything just so, and Mr. Darling had a
+passion for being exactly like his neighbours; so, of course, they had
+a nurse. As they were poor, owing to the amount of milk the children
+drank, this nurse was a prim Newfoundland dog, called Nana, who had
+belonged to no one in particular until the Darlings engaged her. She had
+always thought children important, however, and the Darlings had become
+acquainted with her in Kensington Gardens, where she spent most of her
+spare time peeping into perambulators, and was much hated by careless
+nursemaids, whom she followed to their homes and complained of to their
+mistresses. She proved to be quite a treasure of a nurse. How thorough
+she was at bath-time, and up at any moment of the night if one of her
+charges made the slightest cry. Of course her kennel was in the nursery.
+She had a genius for knowing when a cough is a thing to have no patience
+with and when it needs stocking around your throat. She believed to her
+last day in old-fashioned remedies like rhubarb leaf, and made sounds of
+contempt over all this new-fangled talk about germs, and so on. It was a
+lesson in propriety to see her escorting the children to school, walking
+sedately by their side when they were well behaved, and butting them
+back into line if they strayed. On John’s footer [in England soccer
+was called football, “footer” for short] days she never once forgot his
+sweater, and she usually carried an umbrella in her mouth in case of
+rain. There is a room in the basement of Miss Fulsom’s school where the
+nurses wait. They sat on forms, while Nana lay on the floor, but that
+was the only difference. They affected to ignore her as of an inferior
+social status to themselves, and she despised their light talk. She
+resented visits to the nursery from Mrs. Darling’s friends, but if they
+did come she first whipped off Michael’s pinafore and put him into the
+one with blue braiding, and smoothed out Wendy and made a dash at John’s
+hair.
+
+No nursery could possibly have been conducted more correctly, and
+Mr. Darling knew it, yet he sometimes wondered uneasily whether the
+neighbours talked.
+
+He had his position in the city to consider.
+
+Nana also troubled him in another way. He had sometimes a feeling that
+she did not admire him. “I know she admires you tremendously, George,”
+ Mrs. Darling would assure him, and then she would sign to the children
+to be specially nice to father. Lovely dances followed, in which the
+only other servant, Liza, was sometimes allowed to join. Such a midget
+she looked in her long skirt and maid’s cap, though she had sworn, when
+engaged, that she would never see ten again. The gaiety of those romps!
+And gayest of all was Mrs. Darling, who would pirouette so wildly that
+all you could see of her was the kiss, and then if you had dashed at her
+you might have got it. There never was a simpler happier family until
+the coming of Peter Pan.
+
+Mrs. Darling first heard of Peter when she was tidying up her children’s
+minds. It is the nightly custom of every good mother after her children
+are asleep to rummage in their minds and put things straight for next
+morning, repacking into their proper places the many articles that have
+wandered during the day. If you could keep awake (but of course you
+can’t) you would see your own mother doing this, and you would find it
+very interesting to watch her. It is quite like tidying up drawers. You
+would see her on her knees, I expect, lingering humorously over some of
+your contents, wondering where on earth you had picked this thing up,
+making discoveries sweet and not so sweet, pressing this to her cheek as
+if it were as nice as a kitten, and hurriedly stowing that out of sight.
+When you wake in the morning, the naughtiness and evil passions with
+which you went to bed have been folded up small and placed at the bottom
+of your mind and on the top, beautifully aired, are spread out your
+prettier thoughts, ready for you to put on.
+
+I don’t know whether you have ever seen a map of a person’s mind.
+Doctors sometimes draw maps of other parts of you, and your own map can
+become intensely interesting, but catch them trying to draw a map of a
+child’s mind, which is not only confused, but keeps going round all
+the time. There are zigzag lines on it, just like your temperature on a
+card, and these are probably roads in the island, for the Neverland is
+always more or less an island, with astonishing splashes of colour here
+and there, and coral reefs and rakish-looking craft in the offing, and
+savages and lonely lairs, and gnomes who are mostly tailors, and caves
+through which a river runs, and princes with six elder brothers, and a
+hut fast going to decay, and one very small old lady with a hooked nose.
+It would be an easy map if that were all, but there is also first day
+at school, religion, fathers, the round pond, needle-work, murders,
+hangings, verbs that take the dative, chocolate pudding day, getting
+into braces, say ninety-nine, three-pence for pulling out your tooth
+yourself, and so on, and either these are part of the island or they are
+another map showing through, and it is all rather confusing, especially
+as nothing will stand still.
+
+Of course the Neverlands vary a good deal. John’s, for instance, had a
+lagoon with flamingoes flying over it at which John was shooting, while
+Michael, who was very small, had a flamingo with lagoons flying over
+it. John lived in a boat turned upside down on the sands, Michael in
+a wigwam, Wendy in a house of leaves deftly sewn together. John had no
+friends, Michael had friends at night, Wendy had a pet wolf forsaken by
+its parents, but on the whole the Neverlands have a family resemblance,
+and if they stood still in a row you could say of them that they have
+each other’s nose, and so forth. On these magic shores children at play
+are for ever beaching their coracles [simple boat]. We too have been
+there; we can still hear the sound of the surf, though we shall land no
+more.
+
+Of all delectable islands the Neverland is the snuggest and most
+compact, not large and sprawly, you know, with tedious distances between
+one adventure and another, but nicely crammed. When you play at it by
+day with the chairs and table-cloth, it is not in the least alarming,
+but in the two minutes before you go to sleep it becomes very real. That
+is why there are night-lights.
+
+Occasionally in her travels through her children’s minds Mrs. Darling
+found things she could not understand, and of these quite the most
+perplexing was the word Peter. She knew of no Peter, and yet he was
+here and there in John and Michael’s minds, while Wendy’s began to be
+scrawled all over with him. The name stood out in bolder letters than
+any of the other words, and as Mrs. Darling gazed she felt that it had
+an oddly cocky appearance.
+
+“Yes, he is rather cocky,” Wendy admitted with regret. Her mother had
+been questioning her.
+
+“But who is he, my pet?”
+
+“He is Peter Pan, you know, mother.”
+
+At first Mrs. Darling did not know, but after thinking back into her
+childhood she just remembered a Peter Pan who was said to live with the
+fairies. There were odd stories about him, as that when children died he
+went part of the way with them, so that they should not be frightened.
+She had believed in him at the time, but now that she was married and
+full of sense she quite doubted whether there was any such person.
+
+“Besides,” she said to Wendy, “he would be grown up by this time.”
+
+“Oh no, he isn’t grown up,” Wendy assured her confidently, “and he is
+just my size.” She meant that he was her size in both mind and body; she
+didn’t know how she knew, she just knew it.
+
+Mrs. Darling consulted Mr. Darling, but he smiled pooh-pooh. “Mark my
+words,” he said, “it is some nonsense Nana has been putting into their
+heads; just the sort of idea a dog would have. Leave it alone, and it
+will blow over.”
+
+But it would not blow over and soon the troublesome boy gave Mrs.
+Darling quite a shock.
+
+Children have the strangest adventures without being troubled by them.
+For instance, they may remember to mention, a week after the event
+happened, that when they were in the wood they had met their dead
+father and had a game with him. It was in this casual way that Wendy one
+morning made a disquieting revelation. Some leaves of a tree had been
+found on the nursery floor, which certainly were not there when the
+children went to bed, and Mrs. Darling was puzzling over them when Wendy
+said with a tolerant smile:
+
+“I do believe it is that Peter again!”
+
+“Whatever do you mean, Wendy?”
+
+“It is so naughty of him not to wipe his feet,” Wendy said, sighing. She
+was a tidy child.
+
+She explained in quite a matter-of-fact way that she thought Peter
+sometimes came to the nursery in the night and sat on the foot of her
+bed and played on his pipes to her. Unfortunately she never woke, so she
+didn’t know how she knew, she just knew.
+
+“What nonsense you talk, precious. No one can get into the house without
+knocking.”
+
+“I think he comes in by the window,” she said.
+
+“My love, it is three floors up.”
+
+“Were not the leaves at the foot of the window, mother?”
+
+It was quite true; the leaves had been found very near the window.
+
+Mrs. Darling did not know what to think, for it all seemed so natural to
+Wendy that you could not dismiss it by saying she had been dreaming.
+
+“My child,” the mother cried, “why did you not tell me of this before?”
+
+“I forgot,” said Wendy lightly. She was in a hurry to get her breakfast.
+
+Oh, surely she must have been dreaming.
+
+But, on the other hand, there were the leaves. Mrs. Darling examined
+them very carefully; they were skeleton leaves, but she was sure they
+did not come from any tree that grew in England. She crawled about the
+floor, peering at it with a candle for marks of a strange foot. She
+rattled the poker up the chimney and tapped the walls. She let down a
+tape from the window to the pavement, and it was a sheer drop of thirty
+feet, without so much as a spout to climb up by.
+
+Certainly Wendy had been dreaming.
+
+But Wendy had not been dreaming, as the very next night showed, the
+night on which the extraordinary adventures of these children may be
+said to have begun.
+
+On the night we speak of all the children were once more in bed. It
+happened to be Nana’s evening off, and Mrs. Darling had bathed them and
+sung to them till one by one they had let go her hand and slid away into
+the land of sleep.
+
+All were looking so safe and cosy that she smiled at her fears now and
+sat down tranquilly by the fire to sew.
+
+It was something for Michael, who on his birthday was getting into
+shirts. The fire was warm, however, and the nursery dimly lit by three
+night-lights, and presently the sewing lay on Mrs. Darling’s lap. Then
+her head nodded, oh, so gracefully. She was asleep. Look at the four of
+them, Wendy and Michael over there, John here, and Mrs. Darling by the
+fire. There should have been a fourth night-light.
+
+While she slept she had a dream. She dreamt that the Neverland had come
+too near and that a strange boy had broken through from it. He did not
+alarm her, for she thought she had seen him before in the faces of many
+women who have no children. Perhaps he is to be found in the faces of
+some mothers also. But in her dream he had rent the film that obscures
+the Neverland, and she saw Wendy and John and Michael peeping through
+the gap.
+
+The dream by itself would have been a trifle, but while she was dreaming
+the window of the nursery blew open, and a boy did drop on the floor.
+He was accompanied by a strange light, no bigger than your fist, which
+darted about the room like a living thing and I think it must have been
+this light that wakened Mrs. Darling.
+
+She started up with a cry, and saw the boy, and somehow she knew at once
+that he was Peter Pan. If you or I or Wendy had been there we should
+have seen that he was very like Mrs. Darling’s kiss. He was a lovely
+boy, clad in skeleton leaves and the juices that ooze out of trees but
+the most entrancing thing about him was that he had all his first teeth.
+When he saw she was a grown-up, he gnashed the little pearls at her.
+
+
+
+
+Chapter 2 THE SHADOW
+
+Mrs. Darling screamed, and, as if in answer to a bell, the door opened,
+and Nana entered, returned from her evening out. She growled and sprang
+at the boy, who leapt lightly through the window. Again Mrs. Darling
+screamed, this time in distress for him, for she thought he was killed,
+and she ran down into the street to look for his little body, but it
+was not there; and she looked up, and in the black night she could see
+nothing but what she thought was a shooting star.
+
+She returned to the nursery, and found Nana with something in her mouth,
+which proved to be the boy’s shadow. As he leapt at the window Nana had
+closed it quickly, too late to catch him, but his shadow had not had
+time to get out; slam went the window and snapped it off.
+
+You may be sure Mrs. Darling examined the shadow carefully, but it was
+quite the ordinary kind.
+
+Nana had no doubt of what was the best thing to do with this shadow. She
+hung it out at the window, meaning “He is sure to come back for it; let
+us put it where he can get it easily without disturbing the children.”
+
+But unfortunately Mrs. Darling could not leave it hanging out at the
+window, it looked so like the washing and lowered the whole tone of the
+house. She thought of showing it to Mr. Darling, but he was totting up
+winter great-coats for John and Michael, with a wet towel around his
+head to keep his brain clear, and it seemed a shame to trouble him;
+besides, she knew exactly what he would say: “It all comes of having a
+dog for a nurse.”
+
+She decided to roll the shadow up and put it away carefully in a drawer,
+until a fitting opportunity came for telling her husband. Ah me!
+
+The opportunity came a week later, on that never-to-be-forgotten Friday.
+Of course it was a Friday.
+
+“I ought to have been specially careful on a Friday,” she used to say
+afterwards to her husband, while perhaps Nana was on the other side of
+her, holding her hand.
+
+“No, no,” Mr. Darling always said, “I am responsible for it all. I,
+George Darling, did it. MEA CULPA, MEA CULPA.” He had had a classical
+education.
+
+They sat thus night after night recalling that fatal Friday, till every
+detail of it was stamped on their brains and came through on the other
+side like the faces on a bad coinage.
+
+“If only I had not accepted that invitation to dine at 27,” Mrs. Darling
+said.
+
+“If only I had not poured my medicine into Nana’s bowl,” said Mr.
+Darling.
+
+“If only I had pretended to like the medicine,” was what Nana’s wet eyes
+said.
+
+“My liking for parties, George.”
+
+“My fatal gift of humour, dearest.”
+
+“My touchiness about trifles, dear master and mistress.”
+
+Then one or more of them would break down altogether; Nana at the
+thought, “It’s true, it’s true, they ought not to have had a dog for
+a nurse.” Many a time it was Mr. Darling who put the handkerchief to
+Nana’s eyes.
+
+“That fiend!” Mr. Darling would cry, and Nana’s bark was the echo of
+it, but Mrs. Darling never upbraided Peter; there was something in the
+right-hand corner of her mouth that wanted her not to call Peter names.
+
+They would sit there in the empty nursery, recalling fondly every
+smallest detail of that dreadful evening. It had begun so uneventfully,
+so precisely like a hundred other evenings, with Nana putting on the
+water for Michael’s bath and carrying him to it on her back.
+
+“I won’t go to bed,” he had shouted, like one who still believed that he
+had the last word on the subject, “I won’t, I won’t. Nana, it isn’t six
+o’clock yet. Oh dear, oh dear, I shan’t love you any more, Nana. I tell
+you I won’t be bathed, I won’t, I won’t!”
+
+Then Mrs. Darling had come in, wearing her white evening-gown. She had
+dressed early because Wendy so loved to see her in her evening-gown,
+with the necklace George had given her. She was wearing Wendy’s bracelet
+on her arm; she had asked for the loan of it. Wendy loved to lend her
+bracelet to her mother.
+
+She had found her two older children playing at being herself and father
+on the occasion of Wendy’s birth, and John was saying:
+
+“I am happy to inform you, Mrs. Darling, that you are now a mother,”
+ in just such a tone as Mr. Darling himself may have used on the real
+occasion.
+
+Wendy had danced with joy, just as the real Mrs. Darling must have done.
+
+Then John was born, with the extra pomp that he conceived due to the
+birth of a male, and Michael came from his bath to ask to be born also,
+but John said brutally that they did not want any more.
+
+Michael had nearly cried. “Nobody wants me,” he said, and of course the
+lady in the evening-dress could not stand that.
+
+“I do,” she said, “I so want a third child.”
+
+“Boy or girl?” asked Michael, not too hopefully.
+
+“Boy.”
+
+Then he had leapt into her arms. Such a little thing for Mr. and Mrs.
+Darling and Nana to recall now, but not so little if that was to be
+Michael’s last night in the nursery.
+
+They go on with their recollections.
+
+“It was then that I rushed in like a tornado, wasn’t it?” Mr. Darling
+would say, scorning himself; and indeed he had been like a tornado.
+
+Perhaps there was some excuse for him. He, too, had been dressing for
+the party, and all had gone well with him until he came to his tie. It
+is an astounding thing to have to tell, but this man, though he knew
+about stocks and shares, had no real mastery of his tie. Sometimes the
+thing yielded to him without a contest, but there were occasions when it
+would have been better for the house if he had swallowed his pride and
+used a made-up tie.
+
+This was such an occasion. He came rushing into the nursery with the
+crumpled little brute of a tie in his hand.
+
+“Why, what is the matter, father dear?”
+
+“Matter!” he yelled; he really yelled. “This tie, it will not tie.” He
+became dangerously sarcastic. “Not round my neck! Round the bed-post!
+Oh yes, twenty times have I made it up round the bed-post, but round my
+neck, no! Oh dear no! begs to be excused!”
+
+He thought Mrs. Darling was not sufficiently impressed, and he went on
+sternly, “I warn you of this, mother, that unless this tie is round my
+neck we don’t go out to dinner to-night, and if I don’t go out to dinner
+to-night, I never go to the office again, and if I don’t go to the
+office again, you and I starve, and our children will be flung into the
+streets.”
+
+Even then Mrs. Darling was placid. “Let me try, dear,” she said, and
+indeed that was what he had come to ask her to do, and with her nice
+cool hands she tied his tie for him, while the children stood around to
+see their fate decided. Some men would have resented her being able to
+do it so easily, but Mr. Darling had far too fine a nature for that; he
+thanked her carelessly, at once forgot his rage, and in another moment
+was dancing round the room with Michael on his back.
+
+“How wildly we romped!” says Mrs. Darling now, recalling it.
+
+“Our last romp!” Mr. Darling groaned.
+
+“O George, do you remember Michael suddenly said to me, ‘How did you get
+to know me, mother?’”
+
+“I remember!”
+
+“They were rather sweet, don’t you think, George?”
+
+“And they were ours, ours! and now they are gone.”
+
+The romp had ended with the appearance of Nana, and most unluckily Mr.
+Darling collided against her, covering his trousers with hairs. They
+were not only new trousers, but they were the first he had ever had
+with braid on them, and he had had to bite his lip to prevent the tears
+coming. Of course Mrs. Darling brushed him, but he began to talk again
+about its being a mistake to have a dog for a nurse.
+
+“George, Nana is a treasure.”
+
+“No doubt, but I have an uneasy feeling at times that she looks upon the
+children as puppies.”
+
+“Oh no, dear one, I feel sure she knows they have souls.”
+
+“I wonder,” Mr. Darling said thoughtfully, “I wonder.” It was an
+opportunity, his wife felt, for telling him about the boy. At first he
+pooh-poohed the story, but he became thoughtful when she showed him the
+shadow.
+
+“It is nobody I know,” he said, examining it carefully, “but it does
+look a scoundrel.”
+
+“We were still discussing it, you remember,” says Mr. Darling, “when
+Nana came in with Michael’s medicine. You will never carry the bottle in
+your mouth again, Nana, and it is all my fault.”
+
+Strong man though he was, there is no doubt that he had behaved rather
+foolishly over the medicine. If he had a weakness, it was for thinking
+that all his life he had taken medicine boldly, and so now, when Michael
+dodged the spoon in Nana’s mouth, he had said reprovingly, “Be a man,
+Michael.”
+
+“Won’t; won’t!” Michael cried naughtily. Mrs. Darling left the room to
+get a chocolate for him, and Mr. Darling thought this showed want of
+firmness.
+
+“Mother, don’t pamper him,” he called after her. “Michael, when I was
+your age I took medicine without a murmur. I said, ‘Thank you, kind
+parents, for giving me bottles to make me well.’”
+
+He really thought this was true, and Wendy, who was now in her
+night-gown, believed it also, and she said, to encourage Michael, “That
+medicine you sometimes take, father, is much nastier, isn’t it?”
+
+“Ever so much nastier,” Mr. Darling said bravely, “and I would take it
+now as an example to you, Michael, if I hadn’t lost the bottle.”
+
+He had not exactly lost it; he had climbed in the dead of night to the
+top of the wardrobe and hidden it there. What he did not know was that
+the faithful Liza had found it, and put it back on his wash-stand.
+
+“I know where it is, father,” Wendy cried, always glad to be of service.
+“I’ll bring it,” and she was off before he could stop her. Immediately
+his spirits sank in the strangest way.
+
+“John,” he said, shuddering, “it’s most beastly stuff. It’s that nasty,
+sticky, sweet kind.”
+
+“It will soon be over, father,” John said cheerily, and then in rushed
+Wendy with the medicine in a glass.
+
+“I have been as quick as I could,” she panted.
+
+“You have been wonderfully quick,” her father retorted, with a
+vindictive politeness that was quite thrown away upon her. “Michael
+first,” he said doggedly.
+
+“Father first,” said Michael, who was of a suspicious nature.
+
+“I shall be sick, you know,” Mr. Darling said threateningly.
+
+“Come on, father,” said John.
+
+“Hold your tongue, John,” his father rapped out.
+
+Wendy was quite puzzled. “I thought you took it quite easily, father.”
+
+“That is not the point,” he retorted. “The point is, that there is
+more in my glass than in Michael’s spoon.” His proud heart was nearly
+bursting. “And it isn’t fair: I would say it though it were with my last
+breath; it isn’t fair.”
+
+“Father, I am waiting,” said Michael coldly.
+
+“It’s all very well to say you are waiting; so am I waiting.”
+
+“Father’s a cowardly custard.”
+
+“So are you a cowardly custard.”
+
+“I’m not frightened.”
+
+“Neither am I frightened.”
+
+“Well, then, take it.”
+
+“Well, then, you take it.”
+
+Wendy had a splendid idea. “Why not both take it at the same time?”
+
+“Certainly,” said Mr. Darling. “Are you ready, Michael?”
+
+Wendy gave the words, one, two, three, and Michael took his medicine,
+but Mr. Darling slipped his behind his back.
+
+There was a yell of rage from Michael, and “O father!” Wendy exclaimed.
+
+“What do you mean by ‘O father’?” Mr. Darling demanded. “Stop that row,
+Michael. I meant to take mine, but I--I missed it.”
+
+It was dreadful the way all the three were looking at him, just as if
+they did not admire him. “Look here, all of you,” he said entreatingly,
+as soon as Nana had gone into the bathroom. “I have just thought of a
+splendid joke. I shall pour my medicine into Nana’s bowl, and she will
+drink it, thinking it is milk!”
+
+It was the colour of milk; but the children did not have their father’s
+sense of humour, and they looked at him reproachfully as he poured the
+medicine into Nana’s bowl. “What fun!” he said doubtfully, and they did
+not dare expose him when Mrs. Darling and Nana returned.
+
+“Nana, good dog,” he said, patting her, “I have put a little milk into
+your bowl, Nana.”
+
+Nana wagged her tail, ran to the medicine, and began lapping it. Then
+she gave Mr. Darling such a look, not an angry look: she showed him the
+great red tear that makes us so sorry for noble dogs, and crept into her
+kennel.
+
+Mr. Darling was frightfully ashamed of himself, but he would not give
+in. In a horrid silence Mrs. Darling smelt the bowl. “O George,” she
+said, “it’s your medicine!”
+
+“It was only a joke,” he roared, while she comforted her boys, and Wendy
+hugged Nana. “Much good,” he said bitterly, “my wearing myself to the
+bone trying to be funny in this house.”
+
+And still Wendy hugged Nana. “That’s right,” he shouted. “Coddle her!
+Nobody coddles me. Oh dear no! I am only the breadwinner, why should I
+be coddled--why, why, why!”
+
+“George,” Mrs. Darling entreated him, “not so loud; the servants
+will hear you.” Somehow they had got into the way of calling Liza the
+servants.
+
+“Let them!” he answered recklessly. “Bring in the whole world. But I
+refuse to allow that dog to lord it in my nursery for an hour longer.”
+
+The children wept, and Nana ran to him beseechingly, but he waved her
+back. He felt he was a strong man again. “In vain, in vain,” he cried;
+“the proper place for you is the yard, and there you go to be tied up
+this instant.”
+
+“George, George,” Mrs. Darling whispered, “remember what I told you
+about that boy.”
+
+Alas, he would not listen. He was determined to show who was master in
+that house, and when commands would not draw Nana from the kennel, he
+lured her out of it with honeyed words, and seizing her roughly, dragged
+her from the nursery. He was ashamed of himself, and yet he did it.
+It was all owing to his too affectionate nature, which craved for
+admiration. When he had tied her up in the back-yard, the wretched
+father went and sat in the passage, with his knuckles to his eyes.
+
+In the meantime Mrs. Darling had put the children to bed in unwonted
+silence and lit their night-lights. They could hear Nana barking, and
+John whimpered, “It is because he is chaining her up in the yard,” but
+Wendy was wiser.
+
+“That is not Nana’s unhappy bark,” she said, little guessing what was
+about to happen; “that is her bark when she smells danger.”
+
+Danger!
+
+“Are you sure, Wendy?”
+
+“Oh, yes.”
+
+Mrs. Darling quivered and went to the window. It was securely fastened.
+She looked out, and the night was peppered with stars. They were
+crowding round the house, as if curious to see what was to take place
+there, but she did not notice this, nor that one or two of the smaller
+ones winked at her. Yet a nameless fear clutched at her heart and made
+her cry, “Oh, how I wish that I wasn’t going to a party to-night!”
+
+Even Michael, already half asleep, knew that she was perturbed, and he
+asked, “Can anything harm us, mother, after the night-lights are lit?”
+
+“Nothing, precious,” she said; “they are the eyes a mother leaves behind
+her to guard her children.”
+
+She went from bed to bed singing enchantments over them, and little
+Michael flung his arms round her. “Mother,” he cried, “I’m glad of you.”
+ They were the last words she was to hear from him for a long time.
+
+No. 27 was only a few yards distant, but there had been a slight fall of
+snow, and Father and Mother Darling picked their way over it deftly not
+to soil their shoes. They were already the only persons in the street,
+and all the stars were watching them. Stars are beautiful, but they may
+not take an active part in anything, they must just look on for ever. It
+is a punishment put on them for something they did so long ago that no
+star now knows what it was. So the older ones have become glassy-eyed
+and seldom speak (winking is the star language), but the little
+ones still wonder. They are not really friendly to Peter, who had a
+mischievous way of stealing up behind them and trying to blow them out;
+but they are so fond of fun that they were on his side to-night, and
+anxious to get the grown-ups out of the way. So as soon as the door
+of 27 closed on Mr. and Mrs. Darling there was a commotion in the
+firmament, and the smallest of all the stars in the Milky Way screamed
+out:
+
+“Now, Peter!”
+
+
+
+
+Chapter 3 COME AWAY, COME AWAY!
+
+For a moment after Mr. and Mrs. Darling left the house the night-lights
+by the beds of the three children continued to burn clearly. They were
+awfully nice little night-lights, and one cannot help wishing that they
+could have kept awake to see Peter; but Wendy’s light blinked and gave
+such a yawn that the other two yawned also, and before they could close
+their mouths all the three went out.
+
+There was another light in the room now, a thousand times brighter than
+the night-lights, and in the time we have taken to say this, it had been
+in all the drawers in the nursery, looking for Peter’s shadow, rummaged
+the wardrobe and turned every pocket inside out. It was not really a
+light; it made this light by flashing about so quickly, but when it came
+to rest for a second you saw it was a fairy, no longer than your hand,
+but still growing. It was a girl called Tinker Bell exquisitely gowned
+in a skeleton leaf, cut low and square, through which her figure could
+be seen to the best advantage. She was slightly inclined to EMBONPOINT.
+[plump hourglass figure]
+
+A moment after the fairy’s entrance the window was blown open by the
+breathing of the little stars, and Peter dropped in. He had carried
+Tinker Bell part of the way, and his hand was still messy with the fairy
+dust.
+
+“Tinker Bell,” he called softly, after making sure that the children
+were asleep, “Tink, where are you?” She was in a jug for the moment, and
+liking it extremely; she had never been in a jug before.
+
+“Oh, do come out of that jug, and tell me, do you know where they put my
+shadow?”
+
+The loveliest tinkle as of golden bells answered him. It is the fairy
+language. You ordinary children can never hear it, but if you were to
+hear it you would know that you had heard it once before.
+
+Tink said that the shadow was in the big box. She meant the chest of
+drawers, and Peter jumped at the drawers, scattering their contents to
+the floor with both hands, as kings toss ha’pence to the crowd. In a
+moment he had recovered his shadow, and in his delight he forgot that he
+had shut Tinker Bell up in the drawer.
+
+If he thought at all, but I don’t believe he ever thought, it was that
+he and his shadow, when brought near each other, would join like drops
+of water, and when they did not he was appalled. He tried to stick it
+on with soap from the bathroom, but that also failed. A shudder passed
+through Peter, and he sat on the floor and cried.
+
+His sobs woke Wendy, and she sat up in bed. She was not alarmed to see
+a stranger crying on the nursery floor; she was only pleasantly
+interested.
+
+“Boy,” she said courteously, “why are you crying?”
+
+Peter could be exceeding polite also, having learned the grand manner at
+fairy ceremonies, and he rose and bowed to her beautifully. She was much
+pleased, and bowed beautifully to him from the bed.
+
+“What’s your name?” he asked.
+
+“Wendy Moira Angela Darling,” she replied with some satisfaction. “What
+is your name?”
+
+“Peter Pan.”
+
+She was already sure that he must be Peter, but it did seem a
+comparatively short name.
+
+“Is that all?”
+
+“Yes,” he said rather sharply. He felt for the first time that it was a
+shortish name.
+
+“I’m so sorry,” said Wendy Moira Angela.
+
+“It doesn’t matter,” Peter gulped.
+
+She asked where he lived.
+
+“Second to the right,” said Peter, “and then straight on till morning.”
+
+“What a funny address!”
+
+Peter had a sinking. For the first time he felt that perhaps it was a
+funny address.
+
+“No, it isn’t,” he said.
+
+“I mean,” Wendy said nicely, remembering that she was hostess, “is that
+what they put on the letters?”
+
+He wished she had not mentioned letters.
+
+“Don’t get any letters,” he said contemptuously.
+
+“But your mother gets letters?”
+
+“Don’t have a mother,” he said. Not only had he no mother, but he had
+not the slightest desire to have one. He thought them very over-rated
+persons. Wendy, however, felt at once that she was in the presence of a
+tragedy.
+
+“O Peter, no wonder you were crying,” she said, and got out of bed and
+ran to him.
+
+“I wasn’t crying about mothers,” he said rather indignantly. “I was
+crying because I can’t get my shadow to stick on. Besides, I wasn’t
+crying.”
+
+“It has come off?”
+
+“Yes.”
+
+Then Wendy saw the shadow on the floor, looking so draggled, and she was
+frightfully sorry for Peter. “How awful!” she said, but she could not
+help smiling when she saw that he had been trying to stick it on with
+soap. How exactly like a boy!
+
+Fortunately she knew at once what to do. “It must be sewn on,” she said,
+just a little patronisingly.
+
+“What’s sewn?” he asked.
+
+“You’re dreadfully ignorant.”
+
+“No, I’m not.”
+
+But she was exulting in his ignorance. “I shall sew it on for you, my
+little man,” she said, though he was tall as herself, and she got out
+her housewife [sewing bag], and sewed the shadow on to Peter’s foot.
+
+“I daresay it will hurt a little,” she warned him.
+
+“Oh, I shan’t cry,” said Peter, who was already of the opinion that he
+had never cried in his life. And he clenched his teeth and did not
+cry, and soon his shadow was behaving properly, though still a little
+creased.
+
+“Perhaps I should have ironed it,” Wendy said thoughtfully, but Peter,
+boylike, was indifferent to appearances, and he was now jumping about in
+the wildest glee. Alas, he had already forgotten that he owed his bliss
+to Wendy. He thought he had attached the shadow himself. “How clever I
+am!” he crowed rapturously, “oh, the cleverness of me!”
+
+It is humiliating to have to confess that this conceit of Peter was
+one of his most fascinating qualities. To put it with brutal frankness,
+there never was a cockier boy.
+
+But for the moment Wendy was shocked. “You conceit [braggart],” she
+exclaimed, with frightful sarcasm; “of course I did nothing!”
+
+“You did a little,” Peter said carelessly, and continued to dance.
+
+“A little!” she replied with hauteur [pride]; “if I am no use I can at
+least withdraw,” and she sprang in the most dignified way into bed and
+covered her face with the blankets.
+
+To induce her to look up he pretended to be going away, and when this
+failed he sat on the end of the bed and tapped her gently with his foot.
+“Wendy,” he said, “don’t withdraw. I can’t help crowing, Wendy, when
+I’m pleased with myself.” Still she would not look up, though she was
+listening eagerly. “Wendy,” he continued, in a voice that no woman has
+ever yet been able to resist, “Wendy, one girl is more use than twenty
+boys.”
+
+Now Wendy was every inch a woman, though there were not very many
+inches, and she peeped out of the bed-clothes.
+
+“Do you really think so, Peter?”
+
+“Yes, I do.”
+
+“I think it’s perfectly sweet of you,” she declared, “and I’ll get up
+again,” and she sat with him on the side of the bed. She also said
+she would give him a kiss if he liked, but Peter did not know what she
+meant, and he held out his hand expectantly.
+
+“Surely you know what a kiss is?” she asked, aghast.
+
+“I shall know when you give it to me,” he replied stiffly, and not to
+hurt his feeling she gave him a thimble.
+
+“Now,” said he, “shall I give you a kiss?” and she replied with a slight
+primness, “If you please.” She made herself rather cheap by inclining
+her face toward him, but he merely dropped an acorn button into her
+hand, so she slowly returned her face to where it had been before, and
+said nicely that she would wear his kiss on the chain around her neck.
+It was lucky that she did put it on that chain, for it was afterwards to
+save her life.
+
+When people in our set are introduced, it is customary for them to
+ask each other’s age, and so Wendy, who always liked to do the correct
+thing, asked Peter how old he was. It was not really a happy question to
+ask him; it was like an examination paper that asks grammar, when what
+you want to be asked is Kings of England.
+
+“I don’t know,” he replied uneasily, “but I am quite young.” He really
+knew nothing about it, he had merely suspicions, but he said at a
+venture, “Wendy, I ran away the day I was born.”
+
+Wendy was quite surprised, but interested; and she indicated in the
+charming drawing-room manner, by a touch on her night-gown, that he
+could sit nearer her.
+
+“It was because I heard father and mother,” he explained in a low
+voice, “talking about what I was to be when I became a man.” He was
+extraordinarily agitated now. “I don’t want ever to be a man,” he said
+with passion. “I want always to be a little boy and to have fun. So
+I ran away to Kensington Gardens and lived a long long time among the
+fairies.”
+
+She gave him a look of the most intense admiration, and he thought it
+was because he had run away, but it was really because he knew fairies.
+Wendy had lived such a home life that to know fairies struck her as
+quite delightful. She poured out questions about them, to his surprise,
+for they were rather a nuisance to him, getting in his way and so on,
+and indeed he sometimes had to give them a hiding [spanking]. Still, he
+liked them on the whole, and he told her about the beginning of fairies.
+
+“You see, Wendy, when the first baby laughed for the first time, its
+laugh broke into a thousand pieces, and they all went skipping about,
+and that was the beginning of fairies.”
+
+Tedious talk this, but being a stay-at-home she liked it.
+
+“And so,” he went on good-naturedly, “there ought to be one fairy for
+every boy and girl.”
+
+“Ought to be? Isn’t there?”
+
+“No. You see children know such a lot now, they soon don’t believe in
+fairies, and every time a child says, ‘I don’t believe in fairies,’
+there is a fairy somewhere that falls down dead.”
+
+Really, he thought they had now talked enough about fairies, and it
+struck him that Tinker Bell was keeping very quiet. “I can’t think where
+she has gone to,” he said, rising, and he called Tink by name. Wendy’s
+heart went flutter with a sudden thrill.
+
+“Peter,” she cried, clutching him, “you don’t mean to tell me that there
+is a fairy in this room!”
+
+“She was here just now,” he said a little impatiently. “You don’t hear
+her, do you?” and they both listened.
+
+“The only sound I hear,” said Wendy, “is like a tinkle of bells.”
+
+“Well, that’s Tink, that’s the fairy language. I think I hear her too.”
+
+The sound came from the chest of drawers, and Peter made a merry face.
+No one could ever look quite so merry as Peter, and the loveliest of
+gurgles was his laugh. He had his first laugh still.
+
+“Wendy,” he whispered gleefully, “I do believe I shut her up in the
+drawer!”
+
+He let poor Tink out of the drawer, and she flew about the nursery
+screaming with fury. “You shouldn’t say such things,” Peter retorted.
+“Of course I’m very sorry, but how could I know you were in the drawer?”
+
+Wendy was not listening to him. “O Peter,” she cried, “if she would only
+stand still and let me see her!”
+
+“They hardly ever stand still,” he said, but for one moment Wendy saw
+the romantic figure come to rest on the cuckoo clock. “O the lovely!”
+ she cried, though Tink’s face was still distorted with passion.
+
+“Tink,” said Peter amiably, “this lady says she wishes you were her
+fairy.”
+
+Tinker Bell answered insolently.
+
+“What does she say, Peter?”
+
+He had to translate. “She is not very polite. She says you are a great
+[huge] ugly girl, and that she is my fairy.”
+
+He tried to argue with Tink. “You know you can’t be my fairy, Tink,
+because I am an gentleman and you are a lady.”
+
+To this Tink replied in these words, “You silly ass,” and disappeared
+into the bathroom. “She is quite a common fairy,” Peter explained
+apologetically, “she is called Tinker Bell because she mends the pots
+and kettles [tinker = tin worker].” [Similar to “cinder” plus “elle” to
+get Cinderella]
+
+They were together in the armchair by this time, and Wendy plied him
+with more questions.
+
+“If you don’t live in Kensington Gardens now--”
+
+“Sometimes I do still.”
+
+“But where do you live mostly now?”
+
+“With the lost boys.”
+
+“Who are they?”
+
+“They are the children who fall out of their perambulators when the
+nurse is looking the other way. If they are not claimed in seven
+days they are sent far away to the Neverland to defray expenses. I’m
+captain.”
+
+“What fun it must be!”
+
+“Yes,” said cunning Peter, “but we are rather lonely. You see we have no
+female companionship.”
+
+“Are none of the others girls?”
+
+“Oh, no; girls, you know, are much too clever to fall out of their
+prams.”
+
+This flattered Wendy immensely. “I think,” she said, “it is perfectly
+lovely the way you talk about girls; John there just despises us.”
+
+For reply Peter rose and kicked John out of bed, blankets and all; one
+kick. This seemed to Wendy rather forward for a first meeting, and she
+told him with spirit that he was not captain in her house. However,
+John continued to sleep so placidly on the floor that she allowed him
+to remain there. “And I know you meant to be kind,” she said, relenting,
+“so you may give me a kiss.”
+
+For the moment she had forgotten his ignorance about kisses. “I thought
+you would want it back,” he said a little bitterly, and offered to
+return her the thimble.
+
+“Oh dear,” said the nice Wendy, “I don’t mean a kiss, I mean a thimble.”
+
+“What’s that?”
+
+“It’s like this.” She kissed him.
+
+“Funny!” said Peter gravely. “Now shall I give you a thimble?”
+
+“If you wish to,” said Wendy, keeping her head erect this time.
+
+Peter thimbled her, and almost immediately she screeched. “What is it,
+Wendy?”
+
+“It was exactly as if someone were pulling my hair.”
+
+“That must have been Tink. I never knew her so naughty before.”
+
+And indeed Tink was darting about again, using offensive language.
+
+“She says she will do that to you, Wendy, every time I give you a
+thimble.”
+
+“But why?”
+
+“Why, Tink?”
+
+Again Tink replied, “You silly ass.” Peter could not understand why,
+but Wendy understood, and she was just slightly disappointed when he
+admitted that he came to the nursery window not to see her but to listen
+to stories.
+
+“You see, I don’t know any stories. None of the lost boys knows any
+stories.”
+
+“How perfectly awful,” Wendy said.
+
+“Do you know,” Peter asked “why swallows build in the eaves of houses?
+It is to listen to the stories. O Wendy, your mother was telling you
+such a lovely story.”
+
+“Which story was it?”
+
+“About the prince who couldn’t find the lady who wore the glass
+slipper.”
+
+“Peter,” said Wendy excitedly, “that was Cinderella, and he found her,
+and they lived happily ever after.”
+
+Peter was so glad that he rose from the floor, where they had been
+sitting, and hurried to the window.
+
+“Where are you going?” she cried with misgiving.
+
+“To tell the other boys.”
+
+“Don’t go Peter,” she entreated, “I know such lots of stories.”
+
+Those were her precise words, so there can be no denying that it was she
+who first tempted him.
+
+He came back, and there was a greedy look in his eyes now which ought to
+have alarmed her, but did not.
+
+“Oh, the stories I could tell to the boys!” she cried, and then Peter
+gripped her and began to draw her toward the window.
+
+“Let me go!” she ordered him.
+
+“Wendy, do come with me and tell the other boys.”
+
+Of course she was very pleased to be asked, but she said, “Oh dear, I
+can’t. Think of mummy! Besides, I can’t fly.”
+
+“I’ll teach you.”
+
+“Oh, how lovely to fly.”
+
+“I’ll teach you how to jump on the wind’s back, and then away we go.”
+
+“Oo!” she exclaimed rapturously.
+
+“Wendy, Wendy, when you are sleeping in your silly bed you might be
+flying about with me saying funny things to the stars.”
+
+“Oo!”
+
+“And, Wendy, there are mermaids.”
+
+“Mermaids! With tails?”
+
+“Such long tails.”
+
+“Oh,” cried Wendy, “to see a mermaid!”
+
+He had become frightfully cunning. “Wendy,” he said, “how we should all
+respect you.”
+
+She was wriggling her body in distress. It was quite as if she were
+trying to remain on the nursery floor.
+
+But he had no pity for her.
+
+“Wendy,” he said, the sly one, “you could tuck us in at night.”
+
+“Oo!”
+
+“None of us has ever been tucked in at night.”
+
+“Oo,” and her arms went out to him.
+
+“And you could darn our clothes, and make pockets for us. None of us has
+any pockets.”
+
+How could she resist. “Of course it’s awfully fascinating!” she cried.
+“Peter, would you teach John and Michael to fly too?”
+
+“If you like,” he said indifferently, and she ran to John and Michael
+and shook them. “Wake up,” she cried, “Peter Pan has come and he is to
+teach us to fly.”
+
+John rubbed his eyes. “Then I shall get up,” he said. Of course he was
+on the floor already. “Hallo,” he said, “I am up!”
+
+Michael was up by this time also, looking as sharp as a knife with six
+blades and a saw, but Peter suddenly signed silence. Their faces assumed
+the awful craftiness of children listening for sounds from the grown-up
+world. All was as still as salt. Then everything was right. No, stop!
+Everything was wrong. Nana, who had been barking distressfully all the
+evening, was quiet now. It was her silence they had heard.
+
+“Out with the light! Hide! Quick!” cried John, taking command for the
+only time throughout the whole adventure. And thus when Liza entered,
+holding Nana, the nursery seemed quite its old self, very dark, and
+you would have sworn you heard its three wicked inmates breathing
+angelically as they slept. They were really doing it artfully from
+behind the window curtains.
+
+Liza was in a bad temper, for she was mixing the Christmas puddings in
+the kitchen, and had been drawn from them, with a raisin still on her
+cheek, by Nana’s absurd suspicions. She thought the best way of getting
+a little quiet was to take Nana to the nursery for a moment, but in
+custody of course.
+
+“There, you suspicious brute,” she said, not sorry that Nana was in
+disgrace. “They are perfectly safe, aren’t they? Every one of the little
+angels sound asleep in bed. Listen to their gentle breathing.”
+
+Here Michael, encouraged by his success, breathed so loudly that they
+were nearly detected. Nana knew that kind of breathing, and she tried to
+drag herself out of Liza’s clutches.
+
+But Liza was dense. “No more of it, Nana,” she said sternly, pulling
+her out of the room. “I warn you if you bark again I shall go straight
+for master and missus and bring them home from the party, and then, oh,
+won’t master whip you, just.”
+
+She tied the unhappy dog up again, but do you think Nana ceased to bark?
+Bring master and missus home from the party! Why, that was just what she
+wanted. Do you think she cared whether she was whipped so long as her
+charges were safe? Unfortunately Liza returned to her puddings, and
+Nana, seeing that no help would come from her, strained and strained at
+the chain until at last she broke it. In another moment she had burst
+into the dining-room of 27 and flung up her paws to heaven, her most
+expressive way of making a communication. Mr. and Mrs. Darling knew at
+once that something terrible was happening in their nursery, and without
+a good-bye to their hostess they rushed into the street.
+
+But it was now ten minutes since three scoundrels had been breathing
+behind the curtains, and Peter Pan can do a great deal in ten minutes.
+
+We now return to the nursery.
+
+“It’s all right,” John announced, emerging from his hiding-place. “I
+say, Peter, can you really fly?”
+
+Instead of troubling to answer him Peter flew around the room, taking
+the mantelpiece on the way.
+
+“How topping!” said John and Michael.
+
+“How sweet!” cried Wendy.
+
+“Yes, I’m sweet, oh, I am sweet!” said Peter, forgetting his manners
+again.
+
+It looked delightfully easy, and they tried it first from the floor and
+then from the beds, but they always went down instead of up.
+
+“I say, how do you do it?” asked John, rubbing his knee. He was quite a
+practical boy.
+
+“You just think lovely wonderful thoughts,” Peter explained, “and they
+lift you up in the air.”
+
+He showed them again.
+
+“You’re so nippy at it,” John said, “couldn’t you do it very slowly
+once?”
+
+Peter did it both slowly and quickly. “I’ve got it now, Wendy!” cried
+John, but soon he found he had not. Not one of them could fly an inch,
+though even Michael was in words of two syllables, and Peter did not
+know A from Z.
+
+Of course Peter had been trifling with them, for no one can fly unless
+the fairy dust has been blown on him. Fortunately, as we have mentioned,
+one of his hands was messy with it, and he blew some on each of them,
+with the most superb results.
+
+“Now just wiggle your shoulders this way,” he said, “and let go.”
+
+They were all on their beds, and gallant Michael let go first. He did
+not quite mean to let go, but he did it, and immediately he was borne
+across the room.
+
+“I flewed!” he screamed while still in mid-air.
+
+John let go and met Wendy near the bathroom.
+
+“Oh, lovely!”
+
+“Oh, ripping!”
+
+“Look at me!”
+
+“Look at me!”
+
+“Look at me!”
+
+They were not nearly so elegant as Peter, they could not help kicking a
+little, but their heads were bobbing against the ceiling, and there is
+almost nothing so delicious as that. Peter gave Wendy a hand at first,
+but had to desist, Tink was so indignant.
+
+Up and down they went, and round and round. Heavenly was Wendy’s word.
+
+“I say,” cried John, “why shouldn’t we all go out?”
+
+Of course it was to this that Peter had been luring them.
+
+Michael was ready: he wanted to see how long it took him to do a billion
+miles. But Wendy hesitated.
+
+“Mermaids!” said Peter again.
+
+“Oo!”
+
+“And there are pirates.”
+
+“Pirates,” cried John, seizing his Sunday hat, “let us go at once.”
+
+It was just at this moment that Mr. and Mrs. Darling hurried with Nana
+out of 27. They ran into the middle of the street to look up at the
+nursery window; and, yes, it was still shut, but the room was ablaze
+with light, and most heart-gripping sight of all, they could see in
+shadow on the curtain three little figures in night attire circling
+round and round, not on the floor but in the air.
+
+Not three figures, four!
+
+In a tremble they opened the street door. Mr. Darling would have rushed
+upstairs, but Mrs. Darling signed him to go softly. She even tried to
+make her heart go softly.
+
+Will they reach the nursery in time? If so, how delightful for them, and
+we shall all breathe a sigh of relief, but there will be no story. On
+the other hand, if they are not in time, I solemnly promise that it will
+all come right in the end.
+
+They would have reached the nursery in time had it not been that the
+little stars were watching them. Once again the stars blew the window
+open, and that smallest star of all called out:
+
+“Cave, Peter!”
+
+Then Peter knew that there was not a moment to lose. “Come,” he cried
+imperiously, and soared out at once into the night, followed by John and
+Michael and Wendy.
+
+Mr. and Mrs. Darling and Nana rushed into the nursery too late. The
+birds were flown.
+
+
+
+
+Chapter 4 THE FLIGHT
+
+“Second to the right, and straight on till morning.”
+
+That, Peter had told Wendy, was the way to the Neverland; but even
+birds, carrying maps and consulting them at windy corners, could not
+have sighted it with these instructions. Peter, you see, just said
+anything that came into his head.
+
+At first his companions trusted him implicitly, and so great were the
+delights of flying that they wasted time circling round church spires or
+any other tall objects on the way that took their fancy.
+
+John and Michael raced, Michael getting a start.
+
+They recalled with contempt that not so long ago they had thought
+themselves fine fellows for being able to fly round a room.
+
+Not long ago. But how long ago? They were flying over the sea before
+this thought began to disturb Wendy seriously. John thought it was their
+second sea and their third night.
+
+Sometimes it was dark and sometimes light, and now they were very cold
+and again too warm. Did they really feel hungry at times, or were they
+merely pretending, because Peter had such a jolly new way of feeding
+them? His way was to pursue birds who had food in their mouths suitable
+for humans and snatch it from them; then the birds would follow and
+snatch it back; and they would all go chasing each other gaily for
+miles, parting at last with mutual expressions of good-will. But Wendy
+noticed with gentle concern that Peter did not seem to know that this
+was rather an odd way of getting your bread and butter, nor even that
+there are other ways.
+
+Certainly they did not pretend to be sleepy, they were sleepy; and that
+was a danger, for the moment they popped off, down they fell. The awful
+thing was that Peter thought this funny.
+
+“There he goes again!” he would cry gleefully, as Michael suddenly
+dropped like a stone.
+
+“Save him, save him!” cried Wendy, looking with horror at the cruel
+sea far below. Eventually Peter would dive through the air, and catch
+Michael just before he could strike the sea, and it was lovely the way
+he did it; but he always waited till the last moment, and you felt it
+was his cleverness that interested him and not the saving of human life.
+Also he was fond of variety, and the sport that engrossed him one moment
+would suddenly cease to engage him, so there was always the possibility
+that the next time you fell he would let you go.
+
+He could sleep in the air without falling, by merely lying on his back
+and floating, but this was, partly at least, because he was so light
+that if you got behind him and blew he went faster.
+
+“Do be more polite to him,” Wendy whispered to John, when they were
+playing “Follow my Leader.”
+
+“Then tell him to stop showing off,” said John.
+
+When playing Follow my Leader, Peter would fly close to the water and
+touch each shark’s tail in passing, just as in the street you may run
+your finger along an iron railing. They could not follow him in this
+with much success, so perhaps it was rather like showing off, especially
+as he kept looking behind to see how many tails they missed.
+
+“You must be nice to him,” Wendy impressed on her brothers. “What could
+we do if he were to leave us!”
+
+“We could go back,” Michael said.
+
+“How could we ever find our way back without him?”
+
+“Well, then, we could go on,” said John.
+
+“That is the awful thing, John. We should have to go on, for we don’t
+know how to stop.”
+
+This was true, Peter had forgotten to show them how to stop.
+
+John said that if the worst came to the worst, all they had to do was to
+go straight on, for the world was round, and so in time they must come
+back to their own window.
+
+“And who is to get food for us, John?”
+
+“I nipped a bit out of that eagle’s mouth pretty neatly, Wendy.”
+
+“After the twentieth try,” Wendy reminded him. “And even though we
+became good at picking up food, see how we bump against clouds and things
+if he is not near to give us a hand.”
+
+Indeed they were constantly bumping. They could now fly strongly, though
+they still kicked far too much; but if they saw a cloud in front of
+them, the more they tried to avoid it, the more certainly did they bump
+into it. If Nana had been with them, she would have had a bandage round
+Michael’s forehead by this time.
+
+Peter was not with them for the moment, and they felt rather lonely up
+there by themselves. He could go so much faster than they that he would
+suddenly shoot out of sight, to have some adventure in which they had no
+share. He would come down laughing over something fearfully funny he had
+been saying to a star, but he had already forgotten what it was, or he
+would come up with mermaid scales still sticking to him, and yet not be
+able to say for certain what had been happening. It was really rather
+irritating to children who had never seen a mermaid.
+
+“And if he forgets them so quickly,” Wendy argued, “how can we expect
+that he will go on remembering us?”
+
+Indeed, sometimes when he returned he did not remember them, at least
+not well. Wendy was sure of it. She saw recognition come into his eyes
+as he was about to pass them the time of day and go on; once even she
+had to call him by name.
+
+“I’m Wendy,” she said agitatedly.
+
+He was very sorry. “I say, Wendy,” he whispered to her, “always if you
+see me forgetting you, just keep on saying ‘I’m Wendy,’ and then I’ll
+remember.”
+
+Of course this was rather unsatisfactory. However, to make amends he
+showed them how to lie out flat on a strong wind that was going their
+way, and this was such a pleasant change that they tried it several
+times and found that they could sleep thus with security. Indeed they
+would have slept longer, but Peter tired quickly of sleeping, and soon
+he would cry in his captain voice, “We get off here.” So with occasional
+tiffs, but on the whole rollicking, they drew near the Neverland; for
+after many moons they did reach it, and, what is more, they had been
+going pretty straight all the time, not perhaps so much owing to the
+guidance of Peter or Tink as because the island was looking for them. It
+is only thus that any one may sight those magic shores.
+
+“There it is,” said Peter calmly.
+
+“Where, where?”
+
+“Where all the arrows are pointing.”
+
+Indeed a million golden arrows were pointing it out to the children, all
+directed by their friend the sun, who wanted them to be sure of their
+way before leaving them for the night.
+
+Wendy and John and Michael stood on tip-toe in the air to get their
+first sight of the island. Strange to say, they all recognized it at
+once, and until fear fell upon them they hailed it, not as something
+long dreamt of and seen at last, but as a familiar friend to whom they
+were returning home for the holidays.
+
+“John, there’s the lagoon.”
+
+“Wendy, look at the turtles burying their eggs in the sand.”
+
+“I say, John, I see your flamingo with the broken leg!”
+
+“Look, Michael, there’s your cave!”
+
+“John, what’s that in the brushwood?”
+
+“It’s a wolf with her whelps. Wendy, I do believe that’s your little
+whelp!”
+
+“There’s my boat, John, with her sides stove in!”
+
+“No, it isn’t. Why, we burned your boat.”
+
+“That’s her, at any rate. I say, John, I see the smoke of the redskin
+camp!”
+
+“Where? Show me, and I’ll tell you by the way smoke curls whether they
+are on the war-path.”
+
+“There, just across the Mysterious River.”
+
+“I see now. Yes, they are on the war-path right enough.”
+
+Peter was a little annoyed with them for knowing so much, but if he
+wanted to lord it over them his triumph was at hand, for have I not told
+you that anon fear fell upon them?
+
+It came as the arrows went, leaving the island in gloom.
+
+In the old days at home the Neverland had always begun to look a little
+dark and threatening by bedtime. Then unexplored patches arose in it
+and spread, black shadows moved about in them, the roar of the beasts of
+prey was quite different now, and above all, you lost the certainty that
+you would win. You were quite glad that the night-lights were on. You
+even liked Nana to say that this was just the mantelpiece over here, and
+that the Neverland was all make-believe.
+
+Of course the Neverland had been make-believe in those days, but it
+was real now, and there were no night-lights, and it was getting darker
+every moment, and where was Nana?
+
+They had been flying apart, but they huddled close to Peter now. His
+careless manner had gone at last, his eyes were sparkling, and a tingle
+went through them every time they touched his body. They were now over
+the fearsome island, flying so low that sometimes a tree grazed their
+feet. Nothing horrid was visible in the air, yet their progress had
+become slow and laboured, exactly as if they were pushing their way
+through hostile forces. Sometimes they hung in the air until Peter had
+beaten on it with his fists.
+
+“They don’t want us to land,” he explained.
+
+“Who are they?” Wendy whispered, shuddering.
+
+But he could not or would not say. Tinker Bell had been asleep on his
+shoulder, but now he wakened her and sent her on in front.
+
+Sometimes he poised himself in the air, listening intently, with his
+hand to his ear, and again he would stare down with eyes so bright that
+they seemed to bore two holes to earth. Having done these things, he
+went on again.
+
+His courage was almost appalling. “Would you like an adventure now,” he
+said casually to John, “or would you like to have your tea first?”
+
+Wendy said “tea first” quickly, and Michael pressed her hand in
+gratitude, but the braver John hesitated.
+
+“What kind of adventure?” he asked cautiously.
+
+“There’s a pirate asleep in the pampas just beneath us,” Peter told him.
+“If you like, we’ll go down and kill him.”
+
+“I don’t see him,” John said after a long pause.
+
+“I do.”
+
+“Suppose,” John said, a little huskily, “he were to wake up.”
+
+Peter spoke indignantly. “You don’t think I would kill him while he was
+sleeping! I would wake him first, and then kill him. That’s the way I
+always do.”
+
+“I say! Do you kill many?”
+
+“Tons.”
+
+John said “How ripping,” but decided to have tea first. He asked if
+there were many pirates on the island just now, and Peter said he had
+never known so many.
+
+“Who is captain now?”
+
+“Hook,” answered Peter, and his face became very stern as he said that
+hated word.
+
+“Jas. Hook?”
+
+“Ay.”
+
+Then indeed Michael began to cry, and even John could speak in gulps
+only, for they knew Hook’s reputation.
+
+“He was Blackbeard’s bo’sun,” John whispered huskily. “He is the worst
+of them all. He is the only man of whom Barbecue was afraid.”
+
+“That’s him,” said Peter.
+
+“What is he like? Is he big?”
+
+“He is not so big as he was.”
+
+“How do you mean?”
+
+“I cut off a bit of him.”
+
+“You!”
+
+“Yes, me,” said Peter sharply.
+
+“I wasn’t meaning to be disrespectful.”
+
+“Oh, all right.”
+
+“But, I say, what bit?”
+
+“His right hand.”
+
+“Then he can’t fight now?”
+
+“Oh, can’t he just!”
+
+“Left-hander?”
+
+“He has an iron hook instead of a right hand, and he claws with it.”
+
+“Claws!”
+
+“I say, John,” said Peter.
+
+“Yes.”
+
+“Say, ‘Ay, ay, sir.’”
+
+“Ay, ay, sir.”
+
+“There is one thing,” Peter continued, “that every boy who serves under
+me has to promise, and so must you.”
+
+John paled.
+
+“It is this, if we meet Hook in open fight, you must leave him to me.”
+
+“I promise,” John said loyally.
+
+For the moment they were feeling less eerie, because Tink was flying
+with them, and in her light they could distinguish each other.
+Unfortunately she could not fly so slowly as they, and so she had to go
+round and round them in a circle in which they moved as in a halo. Wendy
+quite liked it, until Peter pointed out the drawbacks.
+
+“She tells me,” he said, “that the pirates sighted us before the
+darkness came, and got Long Tom out.”
+
+“The big gun?”
+
+“Yes. And of course they must see her light, and if they guess we are
+near it they are sure to let fly.”
+
+“Wendy!”
+
+“John!”
+
+“Michael!”
+
+“Tell her to go away at once, Peter,” the three cried simultaneously,
+but he refused.
+
+“She thinks we have lost the way,” he replied stiffly, “and she is
+rather frightened. You don’t think I would send her away all by herself
+when she is frightened!”
+
+For a moment the circle of light was broken, and something gave Peter a
+loving little pinch.
+
+“Then tell her,” Wendy begged, “to put out her light.”
+
+“She can’t put it out. That is about the only thing fairies can’t do. It
+just goes out of itself when she falls asleep, same as the stars.”
+
+“Then tell her to sleep at once,” John almost ordered.
+
+“She can’t sleep except when she’s sleepy. It is the only other thing
+fairies can’t do.”
+
+“Seems to me,” growled John, “these are the only two things worth
+doing.”
+
+Here he got a pinch, but not a loving one.
+
+“If only one of us had a pocket,” Peter said, “we could carry her in
+it.” However, they had set off in such a hurry that there was not a
+pocket between the four of them.
+
+He had a happy idea. John’s hat!
+
+Tink agreed to travel by hat if it was carried in the hand. John carried
+it, though she had hoped to be carried by Peter. Presently Wendy took
+the hat, because John said it struck against his knee as he flew; and
+this, as we shall see, led to mischief, for Tinker Bell hated to be
+under an obligation to Wendy.
+
+In the black topper the light was completely hidden, and they flew on in
+silence. It was the stillest silence they had ever known, broken once by
+a distant lapping, which Peter explained was the wild beasts drinking at
+the ford, and again by a rasping sound that might have been the branches
+of trees rubbing together, but he said it was the redskins sharpening
+their knives.
+
+Even these noises ceased. To Michael the loneliness was dreadful. “If
+only something would make a sound!” he cried.
+
+As if in answer to his request, the air was rent by the most tremendous
+crash he had ever heard. The pirates had fired Long Tom at them.
+
+The roar of it echoed through the mountains, and the echoes seemed to
+cry savagely, “Where are they, where are they, where are they?”
+
+Thus sharply did the terrified three learn the difference between an
+island of make-believe and the same island come true.
+
+When at last the heavens were steady again, John and Michael
+found themselves alone in the darkness. John was treading the air
+mechanically, and Michael without knowing how to float was floating.
+
+“Are you shot?” John whispered tremulously.
+
+“I haven’t tried [myself out] yet,” Michael whispered back.
+
+We know now that no one had been hit. Peter, however, had been carried
+by the wind of the shot far out to sea, while Wendy was blown upwards
+with no companion but Tinker Bell.
+
+It would have been well for Wendy if at that moment she had dropped the
+hat.
+
+I don’t know whether the idea came suddenly to Tink, or whether she had
+planned it on the way, but she at once popped out of the hat and began
+to lure Wendy to her destruction.
+
+Tink was not all bad; or, rather, she was all bad just now, but, on the
+other hand, sometimes she was all good. Fairies have to be one thing or
+the other, because being so small they unfortunately have room for one
+feeling only at a time. They are, however, allowed to change, only it
+must be a complete change. At present she was full of jealousy of Wendy.
+What she said in her lovely tinkle Wendy could not of course understand,
+and I believe some of it was bad words, but it sounded kind, and she
+flew back and forward, plainly meaning “Follow me, and all will be
+well.”
+
+What else could poor Wendy do? She called to Peter and John and Michael,
+and got only mocking echoes in reply. She did not yet know that Tink
+hated her with the fierce hatred of a very woman. And so, bewildered,
+and now staggering in her flight, she followed Tink to her doom.
+
+
+
+
+Chapter 5 THE ISLAND COME TRUE
+
+Feeling that Peter was on his way back, the Neverland had again woke
+into life. We ought to use the pluperfect and say wakened, but woke is
+better and was always used by Peter.
+
+In his absence things are usually quiet on the island. The fairies take
+an hour longer in the morning, the beasts attend to their young, the
+redskins feed heavily for six days and nights, and when pirates and
+lost boys meet they merely bite their thumbs at each other. But with the
+coming of Peter, who hates lethargy, they are under way again: if you
+put your ear to the ground now, you would hear the whole island seething
+with life.
+
+On this evening the chief forces of the island were disposed as follows.
+The lost boys were out looking for Peter, the pirates were out looking
+for the lost boys, the redskins were out looking for the pirates, and
+the beasts were out looking for the redskins. They were going round and
+round the island, but they did not meet because all were going at the
+same rate.
+
+All wanted blood except the boys, who liked it as a rule, but to-night
+were out to greet their captain. The boys on the island vary, of course,
+in numbers, according as they get killed and so on; and when they seem
+to be growing up, which is against the rules, Peter thins them out; but
+at this time there were six of them, counting the twins as two. Let us
+pretend to lie here among the sugar-cane and watch them as they steal by
+in single file, each with his hand on his dagger.
+
+They are forbidden by Peter to look in the least like him, and they wear
+the skins of the bears slain by themselves, in which they are so round
+and furry that when they fall they roll. They have therefore become very
+sure-footed.
+
+The first to pass is Tootles, not the least brave but the most
+unfortunate of all that gallant band. He had been in fewer adventures
+than any of them, because the big things constantly happened just when
+he had stepped round the corner; all would be quiet, he would take the
+opportunity of going off to gather a few sticks for firewood, and
+then when he returned the others would be sweeping up the blood. This
+ill-luck had given a gentle melancholy to his countenance, but instead
+of souring his nature had sweetened it, so that he was quite the
+humblest of the boys. Poor kind Tootles, there is danger in the air for
+you to-night. Take care lest an adventure is now offered you, which, if
+accepted, will plunge you in deepest woe. Tootles, the fairy Tink, who
+is bent on mischief this night is looking for a tool [for doing her
+mischief], and she thinks you are the most easily tricked of the boys.
+‘Ware Tinker Bell.
+
+Would that he could hear us, but we are not really on the island, and he
+passes by, biting his knuckles.
+
+Next comes Nibs, the gay and debonair, followed by Slightly, who cuts
+whistles out of the trees and dances ecstatically to his own tunes.
+Slightly is the most conceited of the boys. He thinks he remembers the
+days before he was lost, with their manners and customs, and this has
+given his nose an offensive tilt. Curly is fourth; he is a pickle, [a
+person who gets in pickles-predicaments] and so often has he had to
+deliver up his person when Peter said sternly, “Stand forth the one who
+did this thing,” that now at the command he stands forth automatically
+whether he has done it or not. Last come the Twins, who cannot be
+described because we should be sure to be describing the wrong one.
+Peter never quite knew what twins were, and his band were not allowed
+to know anything he did not know, so these two were always vague about
+themselves, and did their best to give satisfaction by keeping close
+together in an apologetic sort of way.
+
+The boys vanish in the gloom, and after a pause, but not a long pause,
+for things go briskly on the island, come the pirates on their track. We
+hear them before they are seen, and it is always the same dreadful song:
+
+     “Avast belay, yo ho, heave to,
+     A-pirating we go,
+     And if we’re parted by a shot
+     We’re sure to meet below!”
+
+A more villainous-looking lot never hung in a row on Execution dock.
+Here, a little in advance, ever and again with his head to the
+ground listening, his great arms bare, pieces of eight in his ears as
+ornaments, is the handsome Italian Cecco, who cut his name in letters
+of blood on the back of the governor of the prison at Gao. That gigantic
+black behind him has had many names since he dropped the one with
+which dusky mothers still terrify their children on the banks of the
+Guadjo-mo. Here is Bill Jukes, every inch of him tattooed, the same Bill
+Jukes who got six dozen on the WALRUS from Flint before he would drop
+the bag of moidores [Portuguese gold pieces]; and Cookson, said to
+be Black Murphy’s brother (but this was never proved), and Gentleman
+Starkey, once an usher in a public school and still dainty in his ways
+of killing; and Skylights (Morgan’s Skylights); and the Irish bo’sun
+Smee, an oddly genial man who stabbed, so to speak, without offence,
+and was the only Non-conformist in Hook’s crew; and Noodler, whose
+hands were fixed on backwards; and Robt. Mullins and Alf Mason and many
+another ruffian long known and feared on the Spanish Main.
+
+In the midst of them, the blackest and largest in that dark setting,
+reclined James Hook, or as he wrote himself, Jas. Hook, of whom it is
+said he was the only man that the Sea-Cook feared. He lay at his ease in
+a rough chariot drawn and propelled by his men, and instead of a right
+hand he had the iron hook with which ever and anon he encouraged them
+to increase their pace. As dogs this terrible man treated and addressed
+them, and as dogs they obeyed him. In person he was cadaverous [dead
+looking] and blackavized [dark faced], and his hair was dressed in long
+curls, which at a little distance looked like black candles, and gave a
+singularly threatening expression to his handsome countenance. His eyes
+were of the blue of the forget-me-not, and of a profound melancholy,
+save when he was plunging his hook into you, at which time two red spots
+appeared in them and lit them up horribly. In manner, something of the
+grand seigneur still clung to him, so that he even ripped you up with
+an air, and I have been told that he was a RACONTEUR [storyteller] of
+repute. He was never more sinister than when he was most polite,
+which is probably the truest test of breeding; and the elegance of his
+diction, even when he was swearing, no less than the distinction of his
+demeanour, showed him one of a different cast from his crew. A man of
+indomitable courage, it was said that the only thing he shied at was
+the sight of his own blood, which was thick and of an unusual colour.
+In dress he somewhat aped the attire associated with the name of Charles
+II, having heard it said in some earlier period of his career that he
+bore a strange resemblance to the ill-fated Stuarts; and in his mouth
+he had a holder of his own contrivance which enabled him to smoke two
+cigars at once. But undoubtedly the grimmest part of him was his iron
+claw.
+
+Let us now kill a pirate, to show Hook’s method. Skylights will do. As
+they pass, Skylights lurches clumsily against him, ruffling his lace
+collar; the hook shoots forth, there is a tearing sound and one screech,
+then the body is kicked aside, and the pirates pass on. He has not even
+taken the cigars from his mouth.
+
+Such is the terrible man against whom Peter Pan is pitted. Which will
+win?
+
+On the trail of the pirates, stealing noiselessly down the war-path,
+which is not visible to inexperienced eyes, come the redskins, every one
+of them with his eyes peeled. They carry tomahawks and knives, and their
+naked bodies gleam with paint and oil. Strung around them are scalps, of
+boys as well as of pirates, for these are the Piccaninny tribe, and not
+to be confused with the softer-hearted Delawares or the Hurons. In
+the van, on all fours, is Great Big Little Panther, a brave of so many
+scalps that in his present position they somewhat impede his progress.
+Bringing up the rear, the place of greatest danger, comes Tiger Lily,
+proudly erect, a princess in her own right. She is the most beautiful
+of dusky Dianas [Diana = goddess of the woods] and the belle of the
+Piccaninnies, coquettish [flirting], cold and amorous [loving] by turns;
+there is not a brave who would not have the wayward thing to wife, but
+she staves off the altar with a hatchet. Observe how they pass over
+fallen twigs without making the slightest noise. The only sound to be
+heard is their somewhat heavy breathing. The fact is that they are all a
+little fat just now after the heavy gorging, but in time they will work
+this off. For the moment, however, it constitutes their chief danger.
+
+The redskins disappear as they have come like shadows, and soon their
+place is taken by the beasts, a great and motley procession: lions,
+tigers, bears, and the innumerable smaller savage things that flee
+from them, for every kind of beast, and, more particularly, all the
+man-eaters, live cheek by jowl on the favoured island. Their tongues are
+hanging out, they are hungry to-night.
+
+When they have passed, comes the last figure of all, a gigantic
+crocodile. We shall see for whom she is looking presently.
+
+The crocodile passes, but soon the boys appear again, for the procession
+must continue indefinitely until one of the parties stops or changes its
+pace. Then quickly they will be on top of each other.
+
+All are keeping a sharp look-out in front, but none suspects that the
+danger may be creeping up from behind. This shows how real the island
+was.
+
+The first to fall out of the moving circle was the boys. They flung
+themselves down on the sward [turf], close to their underground home.
+
+“I do wish Peter would come back,” every one of them said nervously,
+though in height and still more in breadth they were all larger than
+their captain.
+
+“I am the only one who is not afraid of the pirates,” Slightly said, in
+the tone that prevented his being a general favourite; but perhaps some
+distant sound disturbed him, for he added hastily, “but I wish he
+would come back, and tell us whether he has heard anything more about
+Cinderella.”
+
+They talked of Cinderella, and Tootles was confident that his mother
+must have been very like her.
+
+It was only in Peter’s absence that they could speak of mothers, the
+subject being forbidden by him as silly.
+
+“All I remember about my mother,” Nibs told them, “is that she often
+said to my father, ‘Oh, how I wish I had a cheque-book of my own!’ I
+don’t know what a cheque-book is, but I should just love to give my
+mother one.”
+
+While they talked they heard a distant sound. You or I, not being wild
+things of the woods, would have heard nothing, but they heard it, and it
+was the grim song:
+
+     “Yo ho, yo ho, the pirate life,
+     The flag o’ skull and bones,
+     A merry hour, a hempen rope,
+     And hey for Davy Jones.”
+
+At once the lost boys--but where are they? They are no longer there.
+Rabbits could not have disappeared more quickly.
+
+I will tell you where they are. With the exception of Nibs, who has
+darted away to reconnoitre [look around], they are already in their home
+under the ground, a very delightful residence of which we shall see
+a good deal presently. But how have they reached it? for there is no
+entrance to be seen, not so much as a large stone, which if rolled away,
+would disclose the mouth of a cave. Look closely, however, and you may
+note that there are here seven large trees, each with a hole in its
+hollow trunk as large as a boy. These are the seven entrances to the
+home under the ground, for which Hook has been searching in vain these
+many moons. Will he find it tonight?
+
+As the pirates advanced, the quick eye of Starkey sighted Nibs
+disappearing through the wood, and at once his pistol flashed out. But
+an iron claw gripped his shoulder.
+
+“Captain, let go!” he cried, writhing.
+
+Now for the first time we hear the voice of Hook. It was a black voice.
+“Put back that pistol first,” it said threateningly.
+
+“It was one of those boys you hate. I could have shot him dead.”
+
+“Ay, and the sound would have brought Tiger Lily’s redskins upon us. Do
+you want to lose your scalp?”
+
+“Shall I after him, Captain,” asked pathetic Smee, “and tickle him
+with Johnny Corkscrew?” Smee had pleasant names for everything, and his
+cutlass was Johnny Corkscrew, because he wiggled it in the wound. One
+could mention many lovable traits in Smee. For instance, after killing,
+it was his spectacles he wiped instead of his weapon.
+
+“Johnny’s a silent fellow,” he reminded Hook.
+
+“Not now, Smee,” Hook said darkly. “He is only one, and I want to
+mischief all the seven. Scatter and look for them.”
+
+The pirates disappeared among the trees, and in a moment their Captain
+and Smee were alone. Hook heaved a heavy sigh, and I know not why it
+was, perhaps it was because of the soft beauty of the evening, but there
+came over him a desire to confide to his faithful bo’sun the story of
+his life. He spoke long and earnestly, but what it was all about Smee,
+who was rather stupid, did not know in the least.
+
+Anon [later] he caught the word Peter.
+
+“Most of all,” Hook was saying passionately, “I want their captain,
+Peter Pan. ‘Twas he cut off my arm.” He brandished the hook
+threateningly. “I’ve waited long to shake his hand with this. Oh, I’ll
+tear him!”
+
+“And yet,” said Smee, “I have often heard you say that hook was worth a
+score of hands, for combing the hair and other homely uses.”
+
+“Ay,” the captain answered, “if I was a mother I would pray to have my
+children born with this instead of that,” and he cast a look of pride
+upon his iron hand and one of scorn upon the other. Then again he
+frowned.
+
+“Peter flung my arm,” he said, wincing, “to a crocodile that happened to
+be passing by.”
+
+“I have often,” said Smee, “noticed your strange dread of crocodiles.”
+
+“Not of crocodiles,” Hook corrected him, “but of that one crocodile.” He
+lowered his voice. “It liked my arm so much, Smee, that it has followed
+me ever since, from sea to sea and from land to land, licking its lips
+for the rest of me.”
+
+“In a way,” said Smee, “it’s sort of a compliment.”
+
+“I want no such compliments,” Hook barked petulantly. “I want Peter Pan,
+who first gave the brute its taste for me.”
+
+He sat down on a large mushroom, and now there was a quiver in his
+voice. “Smee,” he said huskily, “that crocodile would have had me before
+this, but by a lucky chance it swallowed a clock which goes tick tick
+inside it, and so before it can reach me I hear the tick and bolt.” He
+laughed, but in a hollow way.
+
+“Some day,” said Smee, “the clock will run down, and then he’ll get
+you.”
+
+Hook wetted his dry lips. “Ay,” he said, “that’s the fear that haunts
+me.”
+
+Since sitting down he had felt curiously warm. “Smee,” he said, “this
+seat is hot.” He jumped up. “Odds bobs, hammer and tongs I’m burning.”
+
+They examined the mushroom, which was of a size and solidity unknown
+on the mainland; they tried to pull it up, and it came away at once in
+their hands, for it had no root. Stranger still, smoke began at once
+to ascend. The pirates looked at each other. “A chimney!” they both
+exclaimed.
+
+They had indeed discovered the chimney of the home under the ground. It
+was the custom of the boys to stop it with a mushroom when enemies were
+in the neighbourhood.
+
+Not only smoke came out of it. There came also children’s voices, for
+so safe did the boys feel in their hiding-place that they were gaily
+chattering. The pirates listened grimly, and then replaced the mushroom.
+They looked around them and noted the holes in the seven trees.
+
+“Did you hear them say Peter Pan’s from home?” Smee whispered, fidgeting
+with Johnny Corkscrew.
+
+Hook nodded. He stood for a long time lost in thought, and at last a
+curdling smile lit up his swarthy face. Smee had been waiting for it.
+“Unrip your plan, captain,” he cried eagerly.
+
+“To return to the ship,” Hook replied slowly through his teeth, “and
+cook a large rich cake of a jolly thickness with green sugar on it.
+There can be but one room below, for there is but one chimney. The silly
+moles had not the sense to see that they did not need a door apiece.
+That shows they have no mother. We will leave the cake on the shore
+of the Mermaids’ Lagoon. These boys are always swimming about there,
+playing with the mermaids. They will find the cake and they will gobble
+it up, because, having no mother, they don’t know how dangerous ‘tis to
+eat rich damp cake.” He burst into laughter, not hollow laughter now,
+but honest laughter. “Aha, they will die.”
+
+Smee had listened with growing admiration.
+
+“It’s the wickedest, prettiest policy ever I heard of!” he cried, and in
+their exultation they danced and sang:
+
+     “Avast, belay, when I appear,
+     By fear they’re overtook;
+     Nought’s left upon your bones when you
+     Have shaken claws with Hook.”
+
+They began the verse, but they never finished it, for another sound
+broke in and stilled them. There was at first such a tiny sound that a
+leaf might have fallen on it and smothered it, but as it came nearer it
+was more distinct.
+
+Tick tick tick tick!
+
+Hook stood shuddering, one foot in the air.
+
+“The crocodile!” he gasped, and bounded away, followed by his bo’sun.
+
+It was indeed the crocodile. It had passed the redskins, who were now on
+the trail of the other pirates. It oozed on after Hook.
+
+Once more the boys emerged into the open; but the dangers of the night
+were not yet over, for presently Nibs rushed breathless into their
+midst, pursued by a pack of wolves. The tongues of the pursuers were
+hanging out; the baying of them was horrible.
+
+“Save me, save me!” cried Nibs, falling on the ground.
+
+“But what can we do, what can we do?”
+
+It was a high compliment to Peter that at that dire moment their
+thoughts turned to him.
+
+“What would Peter do?” they cried simultaneously.
+
+Almost in the same breath they cried, “Peter would look at them through
+his legs.”
+
+And then, “Let us do what Peter would do.”
+
+It is quite the most successful way of defying wolves, and as one boy
+they bent and looked through their legs. The next moment is the long
+one, but victory came quickly, for as the boys advanced upon them in the
+terrible attitude, the wolves dropped their tails and fled.
+
+Now Nibs rose from the ground, and the others thought that his staring
+eyes still saw the wolves. But it was not wolves he saw.
+
+“I have seen a wonderfuller thing,” he cried, as they gathered round him
+eagerly. “A great white bird. It is flying this way.”
+
+“What kind of a bird, do you think?”
+
+“I don’t know,” Nibs said, awestruck, “but it looks so weary, and as it
+flies it moans, ‘Poor Wendy.’”
+
+“Poor Wendy?”
+
+“I remember,” said Slightly instantly, “there are birds called Wendies.”
+
+“See, it comes!” cried Curly, pointing to Wendy in the heavens.
+
+Wendy was now almost overhead, and they could hear her plaintive cry.
+But more distinct came the shrill voice of Tinker Bell. The jealous
+fairy had now cast off all disguise of friendship, and was darting
+at her victim from every direction, pinching savagely each time she
+touched.
+
+“Hullo, Tink,” cried the wondering boys.
+
+Tink’s reply rang out: “Peter wants you to shoot the Wendy.”
+
+It was not in their nature to question when Peter ordered. “Let us do
+what Peter wishes!” cried the simple boys. “Quick, bows and arrows!”
+
+All but Tootles popped down their trees. He had a bow and arrow with
+him, and Tink noted it, and rubbed her little hands.
+
+“Quick, Tootles, quick,” she screamed. “Peter will be so pleased.”
+
+Tootles excitedly fitted the arrow to his bow. “Out of the way, Tink,”
+ he shouted, and then he fired, and Wendy fluttered to the ground with an
+arrow in her breast.
+
+
+
+
+Chapter 6 THE LITTLE HOUSE
+
+Foolish Tootles was standing like a conqueror over Wendy’s body when the
+other boys sprang, armed, from their trees.
+
+“You are too late,” he cried proudly, “I have shot the Wendy. Peter will
+be so pleased with me.”
+
+Overhead Tinker Bell shouted “Silly ass!” and darted into hiding. The
+others did not hear her. They had crowded round Wendy, and as they
+looked a terrible silence fell upon the wood. If Wendy’s heart had been
+beating they would all have heard it.
+
+Slightly was the first to speak. “This is no bird,” he said in a scared
+voice. “I think this must be a lady.”
+
+“A lady?” said Tootles, and fell a-trembling.
+
+“And we have killed her,” Nibs said hoarsely.
+
+They all whipped off their caps.
+
+“Now I see,” Curly said: “Peter was bringing her to us.” He threw
+himself sorrowfully on the ground.
+
+“A lady to take care of us at last,” said one of the twins, “and you
+have killed her!”
+
+They were sorry for him, but sorrier for themselves, and when he took a
+step nearer them they turned from him.
+
+Tootles’ face was very white, but there was a dignity about him now that
+had never been there before.
+
+“I did it,” he said, reflecting. “When ladies used to come to me in
+dreams, I said, ‘Pretty mother, pretty mother.’ But when at last she
+really came, I shot her.”
+
+He moved slowly away.
+
+“Don’t go,” they called in pity.
+
+“I must,” he answered, shaking; “I am so afraid of Peter.”
+
+It was at this tragic moment that they heard a sound which made the
+heart of every one of them rise to his mouth. They heard Peter crow.
+
+“Peter!” they cried, for it was always thus that he signalled his
+return.
+
+“Hide her,” they whispered, and gathered hastily around Wendy. But
+Tootles stood aloof.
+
+Again came that ringing crow, and Peter dropped in front of them.
+“Greetings, boys,” he cried, and mechanically they saluted, and then
+again was silence.
+
+He frowned.
+
+“I am back,” he said hotly, “why do you not cheer?”
+
+They opened their mouths, but the cheers would not come. He overlooked
+it in his haste to tell the glorious tidings.
+
+“Great news, boys,” he cried, “I have brought at last a mother for you
+all.”
+
+Still no sound, except a little thud from Tootles as he dropped on his
+knees.
+
+“Have you not seen her?” asked Peter, becoming troubled. “She flew this
+way.”
+
+“Ah me!” one voice said, and another said, “Oh, mournful day.”
+
+Tootles rose. “Peter,” he said quietly, “I will show her to you,” and
+when the others would still have hidden her he said, “Back, twins, let
+Peter see.”
+
+So they all stood back, and let him see, and after he had looked for a
+little time he did not know what to do next.
+
+“She is dead,” he said uncomfortably. “Perhaps she is frightened at
+being dead.”
+
+He thought of hopping off in a comic sort of way till he was out of
+sight of her, and then never going near the spot any more. They would
+all have been glad to follow if he had done this.
+
+But there was the arrow. He took it from her heart and faced his band.
+
+“Whose arrow?” he demanded sternly.
+
+“Mine, Peter,” said Tootles on his knees.
+
+“Oh, dastard hand,” Peter said, and he raised the arrow to use it as a
+dagger.
+
+Tootles did not flinch. He bared his breast. “Strike, Peter,” he said
+firmly, “strike true.”
+
+Twice did Peter raise the arrow, and twice did his hand fall. “I cannot
+strike,” he said with awe, “there is something stays my hand.”
+
+All looked at him in wonder, save Nibs, who fortunately looked at Wendy.
+
+“It is she,” he cried, “the Wendy lady, see, her arm!”
+
+Wonderful to relate [tell], Wendy had raised her arm. Nibs bent over
+her and listened reverently. “I think she said, ‘Poor Tootles,’” he
+whispered.
+
+“She lives,” Peter said briefly.
+
+Slightly cried instantly, “The Wendy lady lives.”
+
+Then Peter knelt beside her and found his button. You remember she had
+put it on a chain that she wore round her neck.
+
+“See,” he said, “the arrow struck against this. It is the kiss I gave
+her. It has saved her life.”
+
+“I remember kisses,” Slightly interposed quickly, “let me see it. Ay,
+that’s a kiss.”
+
+Peter did not hear him. He was begging Wendy to get better quickly, so
+that he could show her the mermaids. Of course she could not answer yet,
+being still in a frightful faint; but from overhead came a wailing note.
+
+“Listen to Tink,” said Curly, “she is crying because the Wendy lives.”
+
+Then they had to tell Peter of Tink’s crime, and almost never had they
+seen him look so stern.
+
+“Listen, Tinker Bell,” he cried, “I am your friend no more. Begone from
+me for ever.”
+
+She flew on to his shoulder and pleaded, but he brushed her off. Not
+until Wendy again raised her arm did he relent sufficiently to say,
+“Well, not for ever, but for a whole week.”
+
+Do you think Tinker Bell was grateful to Wendy for raising her arm? Oh
+dear no, never wanted to pinch her so much. Fairies indeed are strange,
+and Peter, who understood them best, often cuffed [slapped] them.
+
+But what to do with Wendy in her present delicate state of health?
+
+“Let us carry her down into the house,” Curly suggested.
+
+“Ay,” said Slightly, “that is what one does with ladies.”
+
+“No, no,” Peter said, “you must not touch her. It would not be
+sufficiently respectful.”
+
+“That,” said Slightly, “is what I was thinking.”
+
+“But if she lies there,” Tootles said, “she will die.”
+
+“Ay, she will die,” Slightly admitted, “but there is no way out.”
+
+“Yes, there is,” cried Peter. “Let us build a little house round her.”
+
+They were all delighted. “Quick,” he ordered them, “bring me each of you
+the best of what we have. Gut our house. Be sharp.”
+
+In a moment they were as busy as tailors the night before a wedding.
+They skurried this way and that, down for bedding, up for firewood, and
+while they were at it, who should appear but John and Michael. As they
+dragged along the ground they fell asleep standing, stopped, woke up,
+moved another step and slept again.
+
+“John, John,” Michael would cry, “wake up! Where is Nana, John, and
+mother?”
+
+And then John would rub his eyes and mutter, “It is true, we did fly.”
+
+You may be sure they were very relieved to find Peter.
+
+“Hullo, Peter,” they said.
+
+“Hullo,” replied Peter amicably, though he had quite forgotten them.
+He was very busy at the moment measuring Wendy with his feet to see
+how large a house she would need. Of course he meant to leave room for
+chairs and a table. John and Michael watched him.
+
+“Is Wendy asleep?” they asked.
+
+“Yes.”
+
+“John,” Michael proposed, “let us wake her and get her to make supper
+for us,” but as he said it some of the other boys rushed on carrying
+branches for the building of the house. “Look at them!” he cried.
+
+“Curly,” said Peter in his most captainy voice, “see that these boys
+help in the building of the house.”
+
+“Ay, ay, sir.”
+
+“Build a house?” exclaimed John.
+
+“For the Wendy,” said Curly.
+
+“For Wendy?” John said, aghast. “Why, she is only a girl!”
+
+“That,” explained Curly, “is why we are her servants.”
+
+“You? Wendy’s servants!”
+
+“Yes,” said Peter, “and you also. Away with them.”
+
+The astounded brothers were dragged away to hack and hew and carry.
+“Chairs and a fender [fireplace] first,” Peter ordered. “Then we shall
+build a house round them.”
+
+“Ay,” said Slightly, “that is how a house is built; it all comes back to
+me.”
+
+Peter thought of everything. “Slightly,” he cried, “fetch a doctor.”
+
+“Ay, ay,” said Slightly at once, and disappeared, scratching his head.
+But he knew Peter must be obeyed, and he returned in a moment, wearing
+John’s hat and looking solemn.
+
+“Please, sir,” said Peter, going to him, “are you a doctor?”
+
+The difference between him and the other boys at such a time was that
+they knew it was make-believe, while to him make-believe and true were
+exactly the same thing. This sometimes troubled them, as when they had
+to make-believe that they had had their dinners.
+
+If they broke down in their make-believe he rapped them on the knuckles.
+
+“Yes, my little man,” Slightly anxiously replied, who had chapped
+knuckles.
+
+“Please, sir,” Peter explained, “a lady lies very ill.”
+
+She was lying at their feet, but Slightly had the sense not to see her.
+
+“Tut, tut, tut,” he said, “where does she lie?”
+
+“In yonder glade.”
+
+“I will put a glass thing in her mouth,” said Slightly, and he
+made-believe to do it, while Peter waited. It was an anxious moment when
+the glass thing was withdrawn.
+
+“How is she?” inquired Peter.
+
+“Tut, tut, tut,” said Slightly, “this has cured her.”
+
+“I am glad!” Peter cried.
+
+“I will call again in the evening,” Slightly said; “give her beef tea
+out of a cup with a spout to it;” but after he had returned the hat
+to John he blew big breaths, which was his habit on escaping from a
+difficulty.
+
+In the meantime the wood had been alive with the sound of axes; almost
+everything needed for a cosy dwelling already lay at Wendy’s feet.
+
+“If only we knew,” said one, “the kind of house she likes best.”
+
+“Peter,” shouted another, “she is moving in her sleep.”
+
+“Her mouth opens,” cried a third, looking respectfully into it. “Oh,
+lovely!”
+
+“Perhaps she is going to sing in her sleep,” said Peter. “Wendy, sing
+the kind of house you would like to have.”
+
+Immediately, without opening her eyes, Wendy began to sing:
+
+     “I wish I had a pretty house,
+     The littlest ever seen,
+     With funny little red walls
+     And roof of mossy green.”
+
+They gurgled with joy at this, for by the greatest good luck the
+branches they had brought were sticky with red sap, and all the ground
+was carpeted with moss. As they rattled up the little house they broke
+into song themselves:
+
+     “We’ve built the little walls and roof
+     And made a lovely door,
+     So tell us, mother Wendy,
+     What are you wanting more?”
+
+To this she answered greedily:
+
+     “Oh, really next I think I’ll have
+     Gay windows all about,
+     With roses peeping in, you know,
+     And babies peeping out.”
+
+With a blow of their fists they made windows, and large yellow leaves
+were the blinds. But roses--?
+
+“Roses,” cried Peter sternly.
+
+Quickly they made-believe to grow the loveliest roses up the walls.
+
+Babies?
+
+To prevent Peter ordering babies they hurried into song again:
+
+     “We’ve made the roses peeping out,
+     The babes are at the door,
+     We cannot make ourselves, you know,
+     ‘cos we’ve been made before.”
+
+Peter, seeing this to be a good idea, at once pretended that it was his
+own. The house was quite beautiful, and no doubt Wendy was very cosy
+within, though, of course, they could no longer see her. Peter strode
+up and down, ordering finishing touches. Nothing escaped his eagle eyes.
+Just when it seemed absolutely finished:
+
+“There’s no knocker on the door,” he said.
+
+They were very ashamed, but Tootles gave the sole of his shoe, and it
+made an excellent knocker.
+
+Absolutely finished now, they thought.
+
+Not of bit of it. “There’s no chimney,” Peter said; “we must have a
+chimney.”
+
+“It certainly does need a chimney,” said John importantly. This gave
+Peter an idea. He snatched the hat off John’s head, knocked out the
+bottom [top], and put the hat on the roof. The little house was so
+pleased to have such a capital chimney that, as if to say thank you,
+smoke immediately began to come out of the hat.
+
+Now really and truly it was finished. Nothing remained to do but to
+knock.
+
+“All look your best,” Peter warned them; “first impressions are awfully
+important.”
+
+He was glad no one asked him what first impressions are; they were all
+too busy looking their best.
+
+He knocked politely, and now the wood was as still as the children, not
+a sound to be heard except from Tinker Bell, who was watching from a
+branch and openly sneering.
+
+What the boys were wondering was, would any one answer the knock? If a
+lady, what would she be like?
+
+The door opened and a lady came out. It was Wendy. They all whipped off
+their hats.
+
+She looked properly surprised, and this was just how they had hoped she
+would look.
+
+“Where am I?” she said.
+
+Of course Slightly was the first to get his word in. “Wendy lady,” he
+said rapidly, “for you we built this house.”
+
+“Oh, say you’re pleased,” cried Nibs.
+
+“Lovely, darling house,” Wendy said, and they were the very words they
+had hoped she would say.
+
+“And we are your children,” cried the twins.
+
+Then all went on their knees, and holding out their arms cried, “O Wendy
+lady, be our mother.”
+
+“Ought I?” Wendy said, all shining. “Of course it’s frightfully
+fascinating, but you see I am only a little girl. I have no real
+experience.”
+
+“That doesn’t matter,” said Peter, as if he were the only person present
+who knew all about it, though he was really the one who knew least.
+“What we need is just a nice motherly person.”
+
+“Oh dear!” Wendy said, “you see, I feel that is exactly what I am.”
+
+“It is, it is,” they all cried; “we saw it at once.”
+
+“Very well,” she said, “I will do my best. Come inside at once, you
+naughty children; I am sure your feet are damp. And before I put you to
+bed I have just time to finish the story of Cinderella.”
+
+In they went; I don’t know how there was room for them, but you can
+squeeze very tight in the Neverland. And that was the first of the many
+joyous evenings they had with Wendy. By and by she tucked them up in the
+great bed in the home under the trees, but she herself slept that night
+in the little house, and Peter kept watch outside with drawn sword, for
+the pirates could be heard carousing far away and the wolves were on the
+prowl. The little house looked so cosy and safe in the darkness, with
+a bright light showing through its blinds, and the chimney smoking
+beautifully, and Peter standing on guard. After a time he fell asleep,
+and some unsteady fairies had to climb over him on their way home from
+an orgy. Any of the other boys obstructing the fairy path at night they
+would have mischiefed, but they just tweaked Peter’s nose and passed on.
+
+
+
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+One of the first things Peter did next day was to measure Wendy and John
+and Michael for hollow trees. Hook, you remember, had sneered at the
+boys for thinking they needed a tree apiece, but this was ignorance, for
+unless your tree fitted you it was difficult to go up and down, and no
+two of the boys were quite the same size. Once you fitted, you drew in
+[let out] your breath at the top, and down you went at exactly the
+right speed, while to ascend you drew in and let out alternately, and so
+wriggled up. Of course, when you have mastered the action you are able
+to do these things without thinking of them, and nothing can be more
+graceful.
+
+But you simply must fit, and Peter measures you for your tree as
+carefully as for a suit of clothes: the only difference being that the
+clothes are made to fit you, while you have to be made to fit the tree.
+Usually it is done quite easily, as by your wearing too many garments
+or too few, but if you are bumpy in awkward places or the only available
+tree is an odd shape, Peter does some things to you, and after that you
+fit. Once you fit, great care must be taken to go on fitting, and this,
+as Wendy was to discover to her delight, keeps a whole family in perfect
+condition.
+
+Wendy and Michael fitted their trees at the first try, but John had to
+be altered a little.
+
+After a few days’ practice they could go up and down as gaily as buckets
+in a well. And how ardently they grew to love their home under the
+ground; especially Wendy. It consisted of one large room, as all houses
+should do, with a floor in which you could dig [for worms] if you wanted
+to go fishing, and in this floor grew stout mushrooms of a charming
+colour, which were used as stools. A Never tree tried hard to grow in
+the centre of the room, but every morning they sawed the trunk through,
+level with the floor. By tea-time it was always about two feet high, and
+then they put a door on top of it, the whole thus becoming a table;
+as soon as they cleared away, they sawed off the trunk again, and thus
+there was more room to play. There was an enormous fireplace which was
+in almost any part of the room where you cared to light it, and across
+this Wendy stretched strings, made of fibre, from which she suspended
+her washing. The bed was tilted against the wall by day, and let down at
+6:30, when it filled nearly half the room; and all the boys slept in it,
+except Michael, lying like sardines in a tin. There was a strict rule
+against turning round until one gave the signal, when all turned at
+once. Michael should have used it also, but Wendy would have [desired]
+a baby, and he was the littlest, and you know what women are, and the
+short and long of it is that he was hung up in a basket.
+
+It was rough and simple, and not unlike what baby bears would have made
+of an underground house in the same circumstances. But there was one
+recess in the wall, no larger than a bird-cage, which was the private
+apartment of Tinker Bell. It could be shut off from the rest of
+the house by a tiny curtain, which Tink, who was most fastidious
+[particular], always kept drawn when dressing or undressing. No woman,
+however large, could have had a more exquisite boudoir [dressing room]
+and bed-chamber combined. The couch, as she always called it, was
+a genuine Queen Mab, with club legs; and she varied the bedspreads
+according to what fruit-blossom was in season. Her mirror was a
+Puss-in-Boots, of which there are now only three, unchipped, known to
+fairy dealers; the washstand was Pie-crust and reversible, the chest
+of drawers an authentic Charming the Sixth, and the carpet and rugs the
+best (the early) period of Margery and Robin. There was a chandelier
+from Tiddlywinks for the look of the thing, but of course she lit the
+residence herself. Tink was very contemptuous of the rest of the house,
+as indeed was perhaps inevitable, and her chamber, though beautiful,
+looked rather conceited, having the appearance of a nose permanently
+turned up.
+
+I suppose it was all especially entrancing to Wendy, because those
+rampagious boys of hers gave her so much to do. Really there were whole
+weeks when, except perhaps with a stocking in the evening, she was never
+above ground. The cooking, I can tell you, kept her nose to the pot, and
+even if there was nothing in it, even if there was no pot, she had to
+keep watching that it came aboil just the same. You never exactly
+knew whether there would be a real meal or just a make-believe, it all
+depended upon Peter’s whim: he could eat, really eat, if it was part of
+a game, but he could not stodge [cram down the food] just to feel
+stodgy [stuffed with food], which is what most children like better than
+anything else; the next best thing being to talk about it. Make-believe
+was so real to him that during a meal of it you could see him getting
+rounder. Of course it was trying, but you simply had to follow his lead,
+and if you could prove to him that you were getting loose for your tree
+he let you stodge.
+
+Wendy’s favourite time for sewing and darning was after they had all
+gone to bed. Then, as she expressed it, she had a breathing time for
+herself; and she occupied it in making new things for them, and putting
+double pieces on the knees, for they were all most frightfully hard on
+their knees.
+
+When she sat down to a basketful of their stockings, every heel with a
+hole in it, she would fling up her arms and exclaim, “Oh dear, I am sure
+I sometimes think spinsters are to be envied!”
+
+Her face beamed when she exclaimed this.
+
+You remember about her pet wolf. Well, it very soon discovered that she
+had come to the island and it found her out, and they just ran into each
+other’s arms. After that it followed her about everywhere.
+
+As time wore on did she think much about the beloved parents she had
+left behind her? This is a difficult question, because it is quite
+impossible to say how time does wear on in the Neverland, where it is
+calculated by moons and suns, and there are ever so many more of them
+than on the mainland. But I am afraid that Wendy did not really worry
+about her father and mother; she was absolutely confident that they
+would always keep the window open for her to fly back by, and this gave
+her complete ease of mind. What did disturb her at times was that John
+remembered his parents vaguely only, as people he had once known, while
+Michael was quite willing to believe that she was really his mother.
+These things scared her a little, and nobly anxious to do her duty, she
+tried to fix the old life in their minds by setting them examination
+papers on it, as like as possible to the ones she used to do at school.
+The other boys thought this awfully interesting, and insisted on
+joining, and they made slates for themselves, and sat round the table,
+writing and thinking hard about the questions she had written on another
+slate and passed round. They were the most ordinary questions--“What
+was the colour of Mother’s eyes? Which was taller, Father or Mother? Was
+Mother blonde or brunette? Answer all three questions if possible.”
+ “(A) Write an essay of not less than 40 words on How I spent my last
+Holidays, or The Characters of Father and Mother compared. Only one of
+these to be attempted.” Or “(1) Describe Mother’s laugh; (2) Describe
+Father’s laugh; (3) Describe Mother’s Party Dress; (4) Describe the
+Kennel and its Inmate.”
+
+They were just everyday questions like these, and when you could not
+answer them you were told to make a cross; and it was really dreadful
+what a number of crosses even John made. Of course the only boy who
+replied to every question was Slightly, and no one could have been more
+hopeful of coming out first, but his answers were perfectly ridiculous,
+and he really came out last: a melancholy thing.
+
+Peter did not compete. For one thing he despised all mothers except
+Wendy, and for another he was the only boy on the island who could
+neither write nor spell; not the smallest word. He was above all that
+sort of thing.
+
+By the way, the questions were all written in the past tense. What
+was the colour of Mother’s eyes, and so on. Wendy, you see, had been
+forgetting, too.
+
+Adventures, of course, as we shall see, were of daily occurrence; but
+about this time Peter invented, with Wendy’s help, a new game that
+fascinated him enormously, until he suddenly had no more interest in it,
+which, as you have been told, was what always happened with his games.
+It consisted in pretending not to have adventures, in doing the sort of
+thing John and Michael had been doing all their lives, sitting on stools
+flinging balls in the air, pushing each other, going out for walks and
+coming back without having killed so much as a grizzly. To see Peter
+doing nothing on a stool was a great sight; he could not help looking
+solemn at such times, to sit still seemed to him such a comic thing to
+do. He boasted that he had gone walking for the good of his health. For
+several suns these were the most novel of all adventures to him; and
+John and Michael had to pretend to be delighted also; otherwise he would
+have treated them severely.
+
+He often went out alone, and when he came back you were never absolutely
+certain whether he had had an adventure or not. He might have forgotten
+it so completely that he said nothing about it; and then when you went
+out you found the body; and, on the other hand, he might say a great
+deal about it, and yet you could not find the body. Sometimes he came
+home with his head bandaged, and then Wendy cooed over him and bathed
+it in lukewarm water, while he told a dazzling tale. But she was never
+quite sure, you know. There were, however, many adventures which she
+knew to be true because she was in them herself, and there were still
+more that were at least partly true, for the other boys were in them and
+said they were wholly true. To describe them all would require a book as
+large as an English-Latin, Latin-English Dictionary, and the most we can
+do is to give one as a specimen of an average hour on the island. The
+difficulty is which one to choose. Should we take the brush with the
+redskins at Slightly Gulch? It was a sanguinary affair, and
+especially interesting as showing one of Peter’s peculiarities, which
+was that in the middle of a fight he would suddenly change sides. At the
+Gulch, when victory was still in the balance, sometimes leaning this way
+and sometimes that, he called out, “I’m redskin to-day; what are you,
+Tootles?” And Tootles answered, “Redskin; what are you, Nibs?” and
+Nibs said, “Redskin; what are you Twin?” and so on; and they were all
+redskins; and of course this would have ended the fight had not the real
+redskins fascinated by Peter’s methods, agreed to be lost boys for that
+once, and so at it they all went again, more fiercely than ever.
+
+The extraordinary upshot of this adventure was--but we have not decided
+yet that this is the adventure we are to narrate. Perhaps a better one
+would be the night attack by the redskins on the house under the ground,
+when several of them stuck in the hollow trees and had to be pulled out
+like corks. Or we might tell how Peter saved Tiger Lily’s life in the
+Mermaids’ Lagoon, and so made her his ally.
+
+Or we could tell of that cake the pirates cooked so that the boys might
+eat it and perish; and how they placed it in one cunning spot after
+another; but always Wendy snatched it from the hands of her children, so
+that in time it lost its succulence, and became as hard as a stone, and
+was used as a missile, and Hook fell over it in the dark.
+
+Or suppose we tell of the birds that were Peter’s friends, particularly
+of the Never bird that built in a tree overhanging the lagoon, and how
+the nest fell into the water, and still the bird sat on her eggs, and
+Peter gave orders that she was not to be disturbed. That is a pretty
+story, and the end shows how grateful a bird can be; but if we tell
+it we must also tell the whole adventure of the lagoon, which would
+of course be telling two adventures rather than just one. A shorter
+adventure, and quite as exciting, was Tinker Bell’s attempt, with the
+help of some street fairies, to have the sleeping Wendy conveyed on a
+great floating leaf to the mainland. Fortunately the leaf gave way and
+Wendy woke, thinking it was bath-time, and swam back. Or again, we might
+choose Peter’s defiance of the lions, when he drew a circle round him
+on the ground with an arrow and dared them to cross it; and though he
+waited for hours, with the other boys and Wendy looking on breathlessly
+from trees, not one of them dared to accept his challenge.
+
+Which of these adventures shall we choose? The best way will be to toss
+for it.
+
+I have tossed, and the lagoon has won. This almost makes one wish that
+the gulch or the cake or Tink’s leaf had won. Of course I could do it
+again, and make it best out of three; however, perhaps fairest to stick
+to the lagoon.
+
+
+
+
+Chapter 8 THE MERMAIDS’ LAGOON
+
+If you shut your eyes and are a lucky one, you may see at times a
+shapeless pool of lovely pale colours suspended in the darkness; then
+if you squeeze your eyes tighter, the pool begins to take shape, and the
+colours become so vivid that with another squeeze they must go on fire.
+But just before they go on fire you see the lagoon. This is the nearest
+you ever get to it on the mainland, just one heavenly moment; if there
+could be two moments you might see the surf and hear the mermaids
+singing.
+
+The children often spent long summer days on this lagoon, swimming or
+floating most of the time, playing the mermaid games in the water,
+and so forth. You must not think from this that the mermaids were on
+friendly terms with them: on the contrary, it was among Wendy’s lasting
+regrets that all the time she was on the island she never had a civil
+word from one of them. When she stole softly to the edge of the lagoon
+she might see them by the score, especially on Marooners’ Rock, where
+they loved to bask, combing out their hair in a lazy way that quite
+irritated her; or she might even swim, on tiptoe as it were, to within
+a yard of them, but then they saw her and dived, probably splashing her
+with their tails, not by accident, but intentionally.
+
+They treated all the boys in the same way, except of course Peter, who
+chatted with them on Marooners’ Rock by the hour, and sat on their tails
+when they got cheeky. He gave Wendy one of their combs.
+
+The most haunting time at which to see them is at the turn of the moon,
+when they utter strange wailing cries; but the lagoon is dangerous for
+mortals then, and until the evening of which we have now to tell, Wendy
+had never seen the lagoon by moonlight, less from fear, for of course
+Peter would have accompanied her, than because she had strict rules
+about every one being in bed by seven. She was often at the lagoon,
+however, on sunny days after rain, when the mermaids come up in
+extraordinary numbers to play with their bubbles. The bubbles of many
+colours made in rainbow water they treat as balls, hitting them gaily
+from one to another with their tails, and trying to keep them in the
+rainbow till they burst. The goals are at each end of the rainbow, and
+the keepers only are allowed to use their hands. Sometimes a dozen of
+these games will be going on in the lagoon at a time, and it is quite a
+pretty sight.
+
+But the moment the children tried to join in they had to play by
+themselves, for the mermaids immediately disappeared. Nevertheless we
+have proof that they secretly watched the interlopers, and were not
+above taking an idea from them; for John introduced a new way of hitting
+the bubble, with the head instead of the hand, and the mermaids adopted
+it. This is the one mark that John has left on the Neverland.
+
+It must also have been rather pretty to see the children resting on a
+rock for half an hour after their mid-day meal. Wendy insisted on
+their doing this, and it had to be a real rest even though the meal was
+make-believe. So they lay there in the sun, and their bodies glistened
+in it, while she sat beside them and looked important.
+
+It was one such day, and they were all on Marooners’ Rock. The rock was
+not much larger than their great bed, but of course they all knew how
+not to take up much room, and they were dozing, or at least lying with
+their eyes shut, and pinching occasionally when they thought Wendy was
+not looking. She was very busy, stitching.
+
+While she stitched a change came to the lagoon. Little shivers ran over
+it, and the sun went away and shadows stole across the water, turning
+it cold. Wendy could no longer see to thread her needle, and when she
+looked up, the lagoon that had always hitherto been such a laughing
+place seemed formidable and unfriendly.
+
+It was not, she knew, that night had come, but something as dark as
+night had come. No, worse than that. It had not come, but it had sent
+that shiver through the sea to say that it was coming. What was it?
+
+There crowded upon her all the stories she had been told of Marooners’
+Rock, so called because evil captains put sailors on it and leave
+them there to drown. They drown when the tide rises, for then it is
+submerged.
+
+Of course she should have roused the children at once; not merely
+because of the unknown that was stalking toward them, but because it was
+no longer good for them to sleep on a rock grown chilly. But she was
+a young mother and she did not know this; she thought you simply must
+stick to your rule about half an hour after the mid-day meal. So, though
+fear was upon her, and she longed to hear male voices, she would not
+waken them. Even when she heard the sound of muffled oars, though her
+heart was in her mouth, she did not waken them. She stood over them to
+let them have their sleep out. Was it not brave of Wendy?
+
+It was well for those boys then that there was one among them who could
+sniff danger even in his sleep. Peter sprang erect, as wide awake at
+once as a dog, and with one warning cry he roused the others.
+
+He stood motionless, one hand to his ear.
+
+“Pirates!” he cried. The others came closer to him. A strange smile was
+playing about his face, and Wendy saw it and shuddered. While that smile
+was on his face no one dared address him; all they could do was to stand
+ready to obey. The order came sharp and incisive.
+
+“Dive!”
+
+There was a gleam of legs, and instantly the lagoon seemed deserted.
+Marooners’ Rock stood alone in the forbidding waters as if it were
+itself marooned.
+
+The boat drew nearer. It was the pirate dinghy, with three figures in
+her, Smee and Starkey, and the third a captive, no other than Tiger
+Lily. Her hands and ankles were tied, and she knew what was to be her
+fate. She was to be left on the rock to perish, an end to one of her
+race more terrible than death by fire or torture, for is it not written
+in the book of the tribe that there is no path through water to the
+happy hunting-ground? Yet her face was impassive; she was the daughter
+of a chief, she must die as a chief’s daughter, it is enough.
+
+They had caught her boarding the pirate ship with a knife in her mouth.
+No watch was kept on the ship, it being Hook’s boast that the wind of
+his name guarded the ship for a mile around. Now her fate would help to
+guard it also. One more wail would go the round in that wind by night.
+
+In the gloom that they brought with them the two pirates did not see the
+rock till they crashed into it.
+
+“Luff, you lubber,” cried an Irish voice that was Smee’s; “here’s the
+rock. Now, then, what we have to do is to hoist the redskin on to it and
+leave her here to drown.”
+
+It was the work of one brutal moment to land the beautiful girl on the
+rock; she was too proud to offer a vain resistance.
+
+Quite near the rock, but out of sight, two heads were bobbing up and
+down, Peter’s and Wendy’s. Wendy was crying, for it was the first
+tragedy she had seen. Peter had seen many tragedies, but he had
+forgotten them all. He was less sorry than Wendy for Tiger Lily: it was
+two against one that angered him, and he meant to save her. An easy way
+would have been to wait until the pirates had gone, but he was never one
+to choose the easy way.
+
+There was almost nothing he could not do, and he now imitated the voice
+of Hook.
+
+“Ahoy there, you lubbers!” he called. It was a marvellous imitation.
+
+“The captain!” said the pirates, staring at each other in surprise.
+
+“He must be swimming out to us,” Starkey said, when they had looked for
+him in vain.
+
+“We are putting the redskin on the rock,” Smee called out.
+
+“Set her free,” came the astonishing answer.
+
+“Free!”
+
+“Yes, cut her bonds and let her go.”
+
+“But, captain--”
+
+“At once, d’ye hear,” cried Peter, “or I’ll plunge my hook in you.”
+
+“This is queer!” Smee gasped.
+
+“Better do what the captain orders,” said Starkey nervously.
+
+“Ay, ay,” Smee said, and he cut Tiger Lily’s cords. At once like an eel
+she slid between Starkey’s legs into the water.
+
+Of course Wendy was very elated over Peter’s cleverness; but she knew
+that he would be elated also and very likely crow and thus betray
+himself, so at once her hand went out to cover his mouth. But it was
+stayed even in the act, for “Boat ahoy!” rang over the lagoon in Hook’s
+voice, and this time it was not Peter who had spoken.
+
+Peter may have been about to crow, but his face puckered in a whistle of
+surprise instead.
+
+“Boat ahoy!” again came the voice.
+
+Now Wendy understood. The real Hook was also in the water.
+
+He was swimming to the boat, and as his men showed a light to guide him
+he had soon reached them. In the light of the lantern Wendy saw his hook
+grip the boat’s side; she saw his evil swarthy face as he rose dripping
+from the water, and, quaking, she would have liked to swim away, but
+Peter would not budge. He was tingling with life and also top-heavy with
+conceit. “Am I not a wonder, oh, I am a wonder!” he whispered to her,
+and though she thought so also, she was really glad for the sake of his
+reputation that no one heard him except herself.
+
+He signed to her to listen.
+
+The two pirates were very curious to know what had brought their captain
+to them, but he sat with his head on his hook in a position of profound
+melancholy.
+
+“Captain, is all well?” they asked timidly, but he answered with a
+hollow moan.
+
+“He sighs,” said Smee.
+
+“He sighs again,” said Starkey.
+
+“And yet a third time he sighs,” said Smee.
+
+Then at last he spoke passionately.
+
+“The game’s up,” he cried, “those boys have found a mother.”
+
+Affrighted though she was, Wendy swelled with pride.
+
+“O evil day!” cried Starkey.
+
+“What’s a mother?” asked the ignorant Smee.
+
+Wendy was so shocked that she exclaimed. “He doesn’t know!” and always
+after this she felt that if you could have a pet pirate Smee would be
+her one.
+
+Peter pulled her beneath the water, for Hook had started up, crying,
+“What was that?”
+
+“I heard nothing,” said Starkey, raising the lantern over the waters,
+and as the pirates looked they saw a strange sight. It was the nest I
+have told you of, floating on the lagoon, and the Never bird was sitting
+on it.
+
+“See,” said Hook in answer to Smee’s question, “that is a mother. What
+a lesson! The nest must have fallen into the water, but would the mother
+desert her eggs? No.”
+
+There was a break in his voice, as if for a moment he recalled innocent
+days when--but he brushed away this weakness with his hook.
+
+Smee, much impressed, gazed at the bird as the nest was borne past, but
+the more suspicious Starkey said, “If she is a mother, perhaps she is
+hanging about here to help Peter.”
+
+Hook winced. “Ay,” he said, “that is the fear that haunts me.”
+
+He was roused from this dejection by Smee’s eager voice.
+
+“Captain,” said Smee, “could we not kidnap these boys’ mother and make
+her our mother?”
+
+“It is a princely scheme,” cried Hook, and at once it took practical
+shape in his great brain. “We will seize the children and carry them to
+the boat: the boys we will make walk the plank, and Wendy shall be our
+mother.”
+
+Again Wendy forgot herself.
+
+“Never!” she cried, and bobbed.
+
+“What was that?”
+
+But they could see nothing. They thought it must have been a leaf in the
+wind. “Do you agree, my bullies?” asked Hook.
+
+“There is my hand on it,” they both said.
+
+“And there is my hook. Swear.”
+
+They all swore. By this time they were on the rock, and suddenly Hook
+remembered Tiger Lily.
+
+“Where is the redskin?” he demanded abruptly.
+
+He had a playful humour at moments, and they thought this was one of the
+moments.
+
+“That is all right, captain,” Smee answered complacently; “we let her
+go.”
+
+“Let her go!” cried Hook.
+
+“‘Twas your own orders,” the bo’sun faltered.
+
+“You called over the water to us to let her go,” said Starkey.
+
+“Brimstone and gall,” thundered Hook, “what cozening [cheating] is
+going on here!” His face had gone black with rage, but he saw that they
+believed their words, and he was startled. “Lads,” he said, shaking a
+little, “I gave no such order.”
+
+“It is passing queer,” Smee said, and they all fidgeted uncomfortably.
+Hook raised his voice, but there was a quiver in it.
+
+“Spirit that haunts this dark lagoon to-night,” he cried, “dost hear
+me?”
+
+Of course Peter should have kept quiet, but of course he did not. He
+immediately answered in Hook’s voice:
+
+“Odds, bobs, hammer and tongs, I hear you.”
+
+In that supreme moment Hook did not blanch, even at the gills, but Smee
+and Starkey clung to each other in terror.
+
+“Who are you, stranger? Speak!” Hook demanded.
+
+“I am James Hook,” replied the voice, “captain of the JOLLY ROGER.”
+
+“You are not; you are not,” Hook cried hoarsely.
+
+“Brimstone and gall,” the voice retorted, “say that again, and I’ll cast
+anchor in you.”
+
+Hook tried a more ingratiating manner. “If you are Hook,” he said almost
+humbly, “come tell me, who am I?”
+
+“A codfish,” replied the voice, “only a codfish.”
+
+“A codfish!” Hook echoed blankly, and it was then, but not till then,
+that his proud spirit broke. He saw his men draw back from him.
+
+“Have we been captained all this time by a codfish!” they muttered. “It
+is lowering to our pride.”
+
+They were his dogs snapping at him, but, tragic figure though he had
+become, he scarcely heeded them. Against such fearful evidence it was
+not their belief in him that he needed, it was his own. He felt his ego
+slipping from him. “Don’t desert me, bully,” he whispered hoarsely to
+it.
+
+In his dark nature there was a touch of the feminine, as in all the
+great pirates, and it sometimes gave him intuitions. Suddenly he tried
+the guessing game.
+
+“Hook,” he called, “have you another voice?”
+
+Now Peter could never resist a game, and he answered blithely in his own
+voice, “I have.”
+
+“And another name?”
+
+“Ay, ay.”
+
+“Vegetable?” asked Hook.
+
+“No.”
+
+“Mineral?”
+
+“No.”
+
+“Animal?”
+
+“Yes.”
+
+“Man?”
+
+“No!” This answer rang out scornfully.
+
+“Boy?”
+
+“Yes.”
+
+“Ordinary boy?”
+
+“No!”
+
+“Wonderful boy?”
+
+To Wendy’s pain the answer that rang out this time was “Yes.”
+
+“Are you in England?”
+
+“No.”
+
+“Are you here?”
+
+“Yes.”
+
+Hook was completely puzzled. “You ask him some questions,” he said to
+the others, wiping his damp brow.
+
+Smee reflected. “I can’t think of a thing,” he said regretfully.
+
+“Can’t guess, can’t guess!” crowed Peter. “Do you give it up?”
+
+Of course in his pride he was carrying the game too far, and the
+miscreants [villains] saw their chance.
+
+“Yes, yes,” they answered eagerly.
+
+“Well, then,” he cried, “I am Peter Pan.”
+
+Pan!
+
+In a moment Hook was himself again, and Smee and Starkey were his
+faithful henchmen.
+
+“Now we have him,” Hook shouted. “Into the water, Smee. Starkey, mind
+the boat. Take him dead or alive!”
+
+He leaped as he spoke, and simultaneously came the gay voice of Peter.
+
+“Are you ready, boys?”
+
+“Ay, ay,” from various parts of the lagoon.
+
+“Then lam into the pirates.”
+
+The fight was short and sharp. First to draw blood was John, who
+gallantly climbed into the boat and held Starkey. There was fierce
+struggle, in which the cutlass was torn from the pirate’s grasp. He
+wriggled overboard and John leapt after him. The dinghy drifted away.
+
+Here and there a head bobbed up in the water, and there was a flash
+of steel followed by a cry or a whoop. In the confusion some struck at
+their own side. The corkscrew of Smee got Tootles in the fourth rib, but
+he was himself pinked [nicked] in turn by Curly. Farther from the rock
+Starkey was pressing Slightly and the twins hard.
+
+Where all this time was Peter? He was seeking bigger game.
+
+The others were all brave boys, and they must not be blamed for backing
+from the pirate captain. His iron claw made a circle of dead water round
+him, from which they fled like affrighted fishes.
+
+But there was one who did not fear him: there was one prepared to enter
+that circle.
+
+Strangely, it was not in the water that they met. Hook rose to the rock
+to breathe, and at the same moment Peter scaled it on the opposite
+side. The rock was slippery as a ball, and they had to crawl rather than
+climb. Neither knew that the other was coming. Each feeling for a grip
+met the other’s arm: in surprise they raised their heads; their faces
+were almost touching; so they met.
+
+Some of the greatest heroes have confessed that just before they fell to
+[began combat] they had a sinking [feeling in the stomach]. Had it been
+so with Peter at that moment I would admit it. After all, he was the
+only man that the Sea-Cook had feared. But Peter had no sinking, he had
+one feeling only, gladness; and he gnashed his pretty teeth with joy.
+Quick as thought he snatched a knife from Hook’s belt and was about to
+drive it home, when he saw that he was higher up the rock than his foe.
+It would not have been fighting fair. He gave the pirate a hand to help
+him up.
+
+It was then that Hook bit him.
+
+Not the pain of this but its unfairness was what dazed Peter. It made
+him quite helpless. He could only stare, horrified. Every child is
+affected thus the first time he is treated unfairly. All he thinks he
+has a right to when he comes to you to be yours is fairness. After
+you have been unfair to him he will love you again, but will never
+afterwards be quite the same boy. No one ever gets over the first
+unfairness; no one except Peter. He often met it, but he always forgot
+it. I suppose that was the real difference between him and all the rest.
+
+So when he met it now it was like the first time; and he could just
+stare, helpless. Twice the iron hand clawed him.
+
+A few moments afterwards the other boys saw Hook in the water striking
+wildly for the ship; no elation on the pestilent face now, only white
+fear, for the crocodile was in dogged pursuit of him. On ordinary
+occasions the boys would have swum alongside cheering; but now they were
+uneasy, for they had lost both Peter and Wendy, and were scouring the
+lagoon for them, calling them by name. They found the dinghy and went
+home in it, shouting “Peter, Wendy” as they went, but no answer came
+save mocking laughter from the mermaids. “They must be swimming back or
+flying,” the boys concluded. They were not very anxious, because they
+had such faith in Peter. They chuckled, boylike, because they would be
+late for bed; and it was all mother Wendy’s fault!
+
+When their voices died away there came cold silence over the lagoon, and
+then a feeble cry.
+
+“Help, help!”
+
+Two small figures were beating against the rock; the girl had fainted
+and lay on the boy’s arm. With a last effort Peter pulled her up the
+rock and then lay down beside her. Even as he also fainted he saw that
+the water was rising. He knew that they would soon be drowned, but he
+could do no more.
+
+As they lay side by side a mermaid caught Wendy by the feet, and began
+pulling her softly into the water. Peter, feeling her slip from him,
+woke with a start, and was just in time to draw her back. But he had to
+tell her the truth.
+
+“We are on the rock, Wendy,” he said, “but it is growing smaller. Soon
+the water will be over it.”
+
+She did not understand even now.
+
+“We must go,” she said, almost brightly.
+
+“Yes,” he answered faintly.
+
+“Shall we swim or fly, Peter?”
+
+He had to tell her.
+
+“Do you think you could swim or fly as far as the island, Wendy, without
+my help?”
+
+She had to admit that she was too tired.
+
+He moaned.
+
+“What is it?” she asked, anxious about him at once.
+
+“I can’t help you, Wendy. Hook wounded me. I can neither fly nor swim.”
+
+“Do you mean we shall both be drowned?”
+
+“Look how the water is rising.”
+
+They put their hands over their eyes to shut out the sight. They thought
+they would soon be no more. As they sat thus something brushed against
+Peter as light as a kiss, and stayed there, as if saying timidly, “Can I
+be of any use?”
+
+It was the tail of a kite, which Michael had made some days before. It
+had torn itself out of his hand and floated away.
+
+“Michael’s kite,” Peter said without interest, but next moment he had
+seized the tail, and was pulling the kite toward him.
+
+“It lifted Michael off the ground,” he cried; “why should it not carry
+you?”
+
+“Both of us!”
+
+“It can’t lift two; Michael and Curly tried.”
+
+“Let us draw lots,” Wendy said bravely.
+
+“And you a lady; never.” Already he had tied the tail round her. She
+clung to him; she refused to go without him; but with a “Good-bye,
+Wendy,” he pushed her from the rock; and in a few minutes she was borne
+out of his sight. Peter was alone on the lagoon.
+
+The rock was very small now; soon it would be submerged. Pale rays of
+light tiptoed across the waters; and by and by there was to be heard a
+sound at once the most musical and the most melancholy in the world: the
+mermaids calling to the moon.
+
+Peter was not quite like other boys; but he was afraid at last. A
+tremour ran through him, like a shudder passing over the sea; but on
+the sea one shudder follows another till there are hundreds of them, and
+Peter felt just the one. Next moment he was standing erect on the rock
+again, with that smile on his face and a drum beating within him. It was
+saying, “To die will be an awfully big adventure.”
+
+
+
+
+Chapter 9 THE NEVER BIRD
+
+The last sound Peter heard before he was quite alone were the mermaids
+retiring one by one to their bedchambers under the sea. He was too far
+away to hear their doors shut; but every door in the coral caves where
+they live rings a tiny bell when it opens or closes (as in all the
+nicest houses on the mainland), and he heard the bells.
+
+Steadily the waters rose till they were nibbling at his feet; and to
+pass the time until they made their final gulp, he watched the only
+thing on the lagoon. He thought it was a piece of floating paper,
+perhaps part of the kite, and wondered idly how long it would take to
+drift ashore.
+
+Presently he noticed as an odd thing that it was undoubtedly out upon
+the lagoon with some definite purpose, for it was fighting the tide,
+and sometimes winning; and when it won, Peter, always sympathetic to
+the weaker side, could not help clapping; it was such a gallant piece of
+paper.
+
+It was not really a piece of paper; it was the Never bird, making
+desperate efforts to reach Peter on the nest. By working her wings, in a
+way she had learned since the nest fell into the water, she was able to
+some extent to guide her strange craft, but by the time Peter recognised
+her she was very exhausted. She had come to save him, to give him her
+nest, though there were eggs in it. I rather wonder at the bird, for
+though he had been nice to her, he had also sometimes tormented her. I
+can suppose only that, like Mrs. Darling and the rest of them, she was
+melted because he had all his first teeth.
+
+She called out to him what she had come for, and he called out to her
+what she was doing there; but of course neither of them understood
+the other’s language. In fanciful stories people can talk to the birds
+freely, and I wish for the moment I could pretend that this were such a
+story, and say that Peter replied intelligently to the Never bird; but
+truth is best, and I want to tell you only what really happened. Well,
+not only could they not understand each other, but they forgot their
+manners.
+
+“I--want--you--to--get--into--the--nest,” the bird called, speaking as
+slowly and distinctly as possible, “and--then--you--can--drift--ashore,
+but--I--am--too--tired--to--bring--it--any--nearer--so--you--must--try
+to--swim--to--it.”
+
+“What are you quacking about?” Peter answered. “Why don’t you let the
+nest drift as usual?”
+
+“I--want--you--” the bird said, and repeated it all over.
+
+Then Peter tried slow and distinct.
+
+“What--are--you--quacking--about?” and so on.
+
+The Never bird became irritated; they have very short tempers.
+
+“You dunderheaded little jay!” she screamed, “Why don’t you do as I tell
+you?”
+
+Peter felt that she was calling him names, and at a venture he retorted
+hotly:
+
+“So are you!”
+
+Then rather curiously they both snapped out the same remark:
+
+“Shut up!”
+
+“Shut up!”
+
+Nevertheless the bird was determined to save him if she could, and by
+one last mighty effort she propelled the nest against the rock. Then up
+she flew; deserting her eggs, so as to make her meaning clear.
+
+Then at last he understood, and clutched the nest and waved his thanks
+to the bird as she fluttered overhead. It was not to receive his thanks,
+however, that she hung there in the sky; it was not even to watch him
+get into the nest; it was to see what he did with her eggs.
+
+There were two large white eggs, and Peter lifted them up and reflected.
+The bird covered her face with her wings, so as not to see the last of
+them; but she could not help peeping between the feathers.
+
+I forget whether I have told you that there was a stave on the rock,
+driven into it by some buccaneers of long ago to mark the site of buried
+treasure. The children had discovered the glittering hoard, and when in
+a mischievous mood used to fling showers of moidores, diamonds, pearls
+and pieces of eight to the gulls, who pounced upon them for food, and
+then flew away, raging at the scurvy trick that had been played upon
+them. The stave was still there, and on it Starkey had hung his hat, a
+deep tarpaulin, watertight, with a broad brim. Peter put the eggs into
+this hat and set it on the lagoon. It floated beautifully.
+
+The Never bird saw at once what he was up to, and screamed her
+admiration of him; and, alas, Peter crowed his agreement with her. Then
+he got into the nest, reared the stave in it as a mast, and hung up his
+shirt for a sail. At the same moment the bird fluttered down upon the
+hat and once more sat snugly on her eggs. She drifted in one direction,
+and he was borne off in another, both cheering.
+
+Of course when Peter landed he beached his barque [small ship, actually
+the Never Bird’s nest in this particular case in point] in a place where
+the bird would easily find it; but the hat was such a great success that
+she abandoned the nest. It drifted about till it went to pieces, and
+often Starkey came to the shore of the lagoon, and with many bitter
+feelings watched the bird sitting on his hat. As we shall not see her
+again, it may be worth mentioning here that all Never birds now build
+in that shape of nest, with a broad brim on which the youngsters take an
+airing.
+
+Great were the rejoicings when Peter reached the home under the ground
+almost as soon as Wendy, who had been carried hither and thither by
+the kite. Every boy had adventures to tell; but perhaps the biggest
+adventure of all was that they were several hours late for bed. This so
+inflated them that they did various dodgy things to get staying up still
+longer, such as demanding bandages; but Wendy, though glorying in having
+them all home again safe and sound, was scandalised by the lateness of
+the hour, and cried, “To bed, to bed,” in a voice that had to be obeyed.
+Next day, however, she was awfully tender, and gave out bandages to
+every one, and they played till bed-time at limping about and carrying
+their arms in slings.
+
+
+
+
+Chapter 10 THE HAPPY HOME
+
+One important result of the brush [with the pirates] on the lagoon was
+that it made the redskins their friends. Peter had saved Tiger Lily from
+a dreadful fate, and now there was nothing she and her braves would not
+do for him. All night they sat above, keeping watch over the home under
+the ground and awaiting the big attack by the pirates which obviously
+could not be much longer delayed. Even by day they hung about, smoking
+the pipe of peace, and looking almost as if they wanted tit-bits to eat.
+
+They called Peter the Great White Father, prostrating themselves [lying
+down] before him; and he liked this tremendously, so that it was not
+really good for him.
+
+“The great white father,” he would say to them in a very lordly manner,
+as they grovelled at his feet, “is glad to see the Piccaninny warriors
+protecting his wigwam from the pirates.”
+
+“Me Tiger Lily,” that lovely creature would reply. “Peter Pan save me,
+me his velly nice friend. Me no let pirates hurt him.”
+
+She was far too pretty to cringe in this way, but Peter thought it his
+due, and he would answer condescendingly, “It is good. Peter Pan has
+spoken.”
+
+Always when he said, “Peter Pan has spoken,” it meant that they must now
+shut up, and they accepted it humbly in that spirit; but they were by
+no means so respectful to the other boys, whom they looked upon as just
+ordinary braves. They said “How-do?” to them, and things like that; and
+what annoyed the boys was that Peter seemed to think this all right.
+
+Secretly Wendy sympathised with them a little, but she was far too loyal
+a housewife to listen to any complaints against father. “Father knows
+best,” she always said, whatever her private opinion must be. Her
+private opinion was that the redskins should not call her a squaw.
+
+We have now reached the evening that was to be known among them as the
+Night of Nights, because of its adventures and their upshot. The day, as
+if quietly gathering its forces, had been almost uneventful, and now the
+redskins in their blankets were at their posts above, while, below, the
+children were having their evening meal; all except Peter, who had gone
+out to get the time. The way you got the time on the island was to find
+the crocodile, and then stay near him till the clock struck.
+
+The meal happened to be a make-believe tea, and they sat around the
+board, guzzling in their greed; and really, what with their chatter and
+recriminations, the noise, as Wendy said, was positively deafening.
+To be sure, she did not mind noise, but she simply would not have them
+grabbing things, and then excusing themselves by saying that Tootles had
+pushed their elbow. There was a fixed rule that they must never hit back
+at meals, but should refer the matter of dispute to Wendy by raising
+the right arm politely and saying, “I complain of so-and-so;” but what
+usually happened was that they forgot to do this or did it too much.
+
+“Silence,” cried Wendy when for the twentieth time she had told them
+that they were not all to speak at once. “Is your mug empty, Slightly
+darling?”
+
+“Not quite empty, mummy,” Slightly said, after looking into an imaginary
+mug.
+
+“He hasn’t even begun to drink his milk,” Nibs interposed.
+
+This was telling, and Slightly seized his chance.
+
+“I complain of Nibs,” he cried promptly.
+
+John, however, had held up his hand first.
+
+“Well, John?”
+
+“May I sit in Peter’s chair, as he is not here?”
+
+“Sit in father’s chair, John!” Wendy was scandalised. “Certainly not.”
+
+“He is not really our father,” John answered. “He didn’t even know how a
+father does till I showed him.”
+
+This was grumbling. “We complain of John,” cried the twins.
+
+Tootles held up his hand. He was so much the humblest of them, indeed he
+was the only humble one, that Wendy was specially gentle with him.
+
+“I don’t suppose,” Tootles said diffidently [bashfully or timidly],
+“that I could be father.”
+
+“No, Tootles.”
+
+Once Tootles began, which was not very often, he had a silly way of
+going on.
+
+“As I can’t be father,” he said heavily, “I don’t suppose, Michael, you
+would let me be baby?”
+
+“No, I won’t,” Michael rapped out. He was already in his basket.
+
+“As I can’t be baby,” Tootles said, getting heavier and heavier and
+heavier, “do you think I could be a twin?”
+
+“No, indeed,” replied the twins; “it’s awfully difficult to be a twin.”
+
+“As I can’t be anything important,” said Tootles, “would any of you like
+to see me do a trick?”
+
+“No,” they all replied.
+
+Then at last he stopped. “I hadn’t really any hope,” he said.
+
+The hateful telling broke out again.
+
+“Slightly is coughing on the table.”
+
+“The twins began with cheese-cakes.”
+
+“Curly is taking both butter and honey.”
+
+“Nibs is speaking with his mouth full.”
+
+“I complain of the twins.”
+
+“I complain of Curly.”
+
+“I complain of Nibs.”
+
+“Oh dear, oh dear,” cried Wendy, “I’m sure I sometimes think that
+spinsters are to be envied.”
+
+She told them to clear away, and sat down to her work-basket, a heavy
+load of stockings and every knee with a hole in it as usual.
+
+“Wendy,” remonstrated [scolded] Michael, “I’m too big for a cradle.”
+
+“I must have somebody in a cradle,” she said almost tartly, “and you
+are the littlest. A cradle is such a nice homely thing to have about a
+house.”
+
+While she sewed they played around her; such a group of happy faces
+and dancing limbs lit up by that romantic fire. It had become a very
+familiar scene, this, in the home under the ground, but we are looking
+on it for the last time.
+
+There was a step above, and Wendy, you may be sure, was the first to
+recognize it.
+
+“Children, I hear your father’s step. He likes you to meet him at the
+door.”
+
+Above, the redskins crouched before Peter.
+
+“Watch well, braves. I have spoken.”
+
+And then, as so often before, the gay children dragged him from his
+tree. As so often before, but never again.
+
+He had brought nuts for the boys as well as the correct time for Wendy.
+
+“Peter, you just spoil them, you know,” Wendy simpered [exaggerated a
+smile].
+
+“Ah, old lady,” said Peter, hanging up his gun.
+
+“It was me told him mothers are called old lady,” Michael whispered to
+Curly.
+
+“I complain of Michael,” said Curly instantly.
+
+The first twin came to Peter. “Father, we want to dance.”
+
+“Dance away, my little man,” said Peter, who was in high good humour.
+
+“But we want you to dance.”
+
+Peter was really the best dancer among them, but he pretended to be
+scandalised.
+
+“Me! My old bones would rattle!”
+
+“And mummy too.”
+
+“What,” cried Wendy, “the mother of such an armful, dance!”
+
+“But on a Saturday night,” Slightly insinuated.
+
+It was not really Saturday night, at least it may have been, for
+they had long lost count of the days; but always if they wanted to do
+anything special they said this was Saturday night, and then they did
+it.
+
+“Of course it is Saturday night, Peter,” Wendy said, relenting.
+
+“People of our figure, Wendy!”
+
+“But it is only among our own progeny [children].”
+
+“True, true.”
+
+So they were told they could dance, but they must put on their nighties
+first.
+
+“Ah, old lady,” Peter said aside to Wendy, warming himself by the fire
+and looking down at her as she sat turning a heel, “there is nothing
+more pleasant of an evening for you and me when the day’s toil is over
+than to rest by the fire with the little ones near by.”
+
+“It is sweet, Peter, isn’t it?” Wendy said, frightfully gratified.
+“Peter, I think Curly has your nose.”
+
+“Michael takes after you.”
+
+She went to him and put her hand on his shoulder.
+
+“Dear Peter,” she said, “with such a large family, of course, I have now
+passed my best, but you don’t want to [ex]change me, do you?”
+
+“No, Wendy.”
+
+Certainly he did not want a change, but he looked at her uncomfortably,
+blinking, you know, like one not sure whether he was awake or asleep.
+
+“Peter, what is it?”
+
+“I was just thinking,” he said, a little scared. “It is only
+make-believe, isn’t it, that I am their father?”
+
+“Oh yes,” Wendy said primly [formally and properly].
+
+“You see,” he continued apologetically, “it would make me seem so old to
+be their real father.”
+
+“But they are ours, Peter, yours and mine.”
+
+“But not really, Wendy?” he asked anxiously.
+
+“Not if you don’t wish it,” she replied; and she distinctly heard his
+sigh of relief. “Peter,” she asked, trying to speak firmly, “what are
+your exact feelings to [about] me?”
+
+“Those of a devoted son, Wendy.”
+
+“I thought so,” she said, and went and sat by herself at the extreme end
+of the room.
+
+“You are so queer,” he said, frankly puzzled, “and Tiger Lily is just
+the same. There is something she wants to be to me, but she says it is
+not my mother.”
+
+“No, indeed, it is not,” Wendy replied with frightful emphasis. Now we
+know why she was prejudiced against the redskins.
+
+“Then what is it?”
+
+“It isn’t for a lady to tell.”
+
+“Oh, very well,” Peter said, a little nettled. “Perhaps Tinker Bell will
+tell me.”
+
+“Oh yes, Tinker Bell will tell you,” Wendy retorted scornfully. “She is
+an abandoned little creature.”
+
+Here Tink, who was in her bedroom, eavesdropping, squeaked out something
+impudent.
+
+“She says she glories in being abandoned,” Peter interpreted.
+
+He had a sudden idea. “Perhaps Tink wants to be my mother?”
+
+“You silly ass!” cried Tinker Bell in a passion.
+
+She had said it so often that Wendy needed no translation.
+
+“I almost agree with her,” Wendy snapped. Fancy Wendy snapping! But she
+had been much tried, and she little knew what was to happen before the
+night was out. If she had known she would not have snapped.
+
+None of them knew. Perhaps it was best not to know. Their ignorance
+gave them one more glad hour; and as it was to be their last hour on the
+island, let us rejoice that there were sixty glad minutes in it. They
+sang and danced in their night-gowns. Such a deliciously creepy song
+it was, in which they pretended to be frightened at their own shadows,
+little witting that so soon shadows would close in upon them, from whom
+they would shrink in real fear. So uproariously gay was the dance, and
+how they buffeted each other on the bed and out of it! It was a pillow
+fight rather than a dance, and when it was finished, the pillows
+insisted on one bout more, like partners who know that they may never
+meet again. The stories they told, before it was time for Wendy’s
+good-night story! Even Slightly tried to tell a story that night, but
+the beginning was so fearfully dull that it appalled not only the others
+but himself, and he said happily:
+
+“Yes, it is a dull beginning. I say, let us pretend that it is the end.”
+
+And then at last they all got into bed for Wendy’s story, the story they
+loved best, the story Peter hated. Usually when she began to tell this
+story he left the room or put his hands over his ears; and possibly if
+he had done either of those things this time they might all still be on
+the island. But to-night he remained on his stool; and we shall see what
+happened.
+
+
+
+
+Chapter 11 WENDY’S STORY
+
+“Listen, then,” said Wendy, settling down to her story, with Michael at
+her feet and seven boys in the bed. “There was once a gentleman--”
+
+“I had rather he had been a lady,” Curly said.
+
+“I wish he had been a white rat,” said Nibs.
+
+“Quiet,” their mother admonished [cautioned] them. “There was a lady
+also, and--”
+
+“Oh, mummy,” cried the first twin, “you mean that there is a lady also,
+don’t you? She is not dead, is she?”
+
+“Oh, no.”
+
+“I am awfully glad she isn’t dead,” said Tootles. “Are you glad, John?”
+
+“Of course I am.”
+
+“Are you glad, Nibs?”
+
+“Rather.”
+
+“Are you glad, Twins?”
+
+“We are glad.”
+
+“Oh dear,” sighed Wendy.
+
+“Little less noise there,” Peter called out, determined that she should
+have fair play, however beastly a story it might be in his opinion.
+
+“The gentleman’s name,” Wendy continued, “was Mr. Darling, and her name
+was Mrs. Darling.”
+
+“I knew them,” John said, to annoy the others.
+
+“I think I knew them,” said Michael rather doubtfully.
+
+“They were married, you know,” explained Wendy, “and what do you think
+they had?”
+
+“White rats,” cried Nibs, inspired.
+
+“No.”
+
+“It’s awfully puzzling,” said Tootles, who knew the story by heart.
+
+“Quiet, Tootles. They had three descendants.”
+
+“What is descendants?”
+
+“Well, you are one, Twin.”
+
+“Did you hear that, John? I am a descendant.”
+
+“Descendants are only children,” said John.
+
+“Oh dear, oh dear,” sighed Wendy. “Now these three children had a
+faithful nurse called Nana; but Mr. Darling was angry with her and
+chained her up in the yard, and so all the children flew away.”
+
+“It’s an awfully good story,” said Nibs.
+
+“They flew away,” Wendy continued, “to the Neverland, where the lost
+children are.”
+
+“I just thought they did,” Curly broke in excitedly. “I don’t know how
+it is, but I just thought they did!”
+
+“O Wendy,” cried Tootles, “was one of the lost children called Tootles?”
+
+“Yes, he was.”
+
+“I am in a story. Hurrah, I am in a story, Nibs.”
+
+“Hush. Now I want you to consider the feelings of the unhappy parents
+with all their children flown away.”
+
+“Oo!” they all moaned, though they were not really considering the
+feelings of the unhappy parents one jot.
+
+“Think of the empty beds!”
+
+“Oo!”
+
+“It’s awfully sad,” the first twin said cheerfully.
+
+“I don’t see how it can have a happy ending,” said the second twin. “Do
+you, Nibs?”
+
+“I’m frightfully anxious.”
+
+“If you knew how great is a mother’s love,” Wendy told them
+triumphantly, “you would have no fear.” She had now come to the part
+that Peter hated.
+
+“I do like a mother’s love,” said Tootles, hitting Nibs with a pillow.
+“Do you like a mother’s love, Nibs?”
+
+“I do just,” said Nibs, hitting back.
+
+“You see,” Wendy said complacently, “our heroine knew that the mother
+would always leave the window open for her children to fly back by; so
+they stayed away for years and had a lovely time.”
+
+“Did they ever go back?”
+
+“Let us now,” said Wendy, bracing herself up for her finest effort,
+“take a peep into the future;” and they all gave themselves the twist
+that makes peeps into the future easier. “Years have rolled by, and who
+is this elegant lady of uncertain age alighting at London Station?”
+
+“O Wendy, who is she?” cried Nibs, every bit as excited as if he didn’t
+know.
+
+“Can it be--yes--no--it is--the fair Wendy!”
+
+“Oh!”
+
+“And who are the two noble portly figures accompanying her, now grown to
+man’s estate? Can they be John and Michael? They are!”
+
+“Oh!”
+
+“‘See, dear brothers,’ says Wendy pointing upwards, ‘there is the window
+still standing open. Ah, now we are rewarded for our sublime faith in a
+mother’s love.’ So up they flew to their mummy and daddy, and pen cannot
+describe the happy scene, over which we draw a veil.”
+
+That was the story, and they were as pleased with it as the fair
+narrator herself. Everything just as it should be, you see. Off we skip
+like the most heartless things in the world, which is what children are,
+but so attractive; and we have an entirely selfish time, and then when
+we have need of special attention we nobly return for it, confident that
+we shall be rewarded instead of smacked.
+
+So great indeed was their faith in a mother’s love that they felt they
+could afford to be callous for a bit longer.
+
+But there was one there who knew better, and when Wendy finished he
+uttered a hollow groan.
+
+“What is it, Peter?” she cried, running to him, thinking he was ill. She
+felt him solicitously, lower down than his chest. “Where is it, Peter?”
+
+“It isn’t that kind of pain,” Peter replied darkly.
+
+“Then what kind is it?”
+
+“Wendy, you are wrong about mothers.”
+
+They all gathered round him in affright, so alarming was his agitation;
+and with a fine candour he told them what he had hitherto concealed.
+
+“Long ago,” he said, “I thought like you that my mother would always
+keep the window open for me, so I stayed away for moons and moons and
+moons, and then flew back; but the window was barred, for mother had
+forgotten all about me, and there was another little boy sleeping in my
+bed.”
+
+I am not sure that this was true, but Peter thought it was true; and it
+scared them.
+
+“Are you sure mothers are like that?”
+
+“Yes.”
+
+So this was the truth about mothers. The toads!
+
+Still it is best to be careful; and no one knows so quickly as a child
+when he should give in. “Wendy, let us [let’s] go home,” cried John and
+Michael together.
+
+“Yes,” she said, clutching them.
+
+“Not to-night?” asked the lost boys bewildered. They knew in what they
+called their hearts that one can get on quite well without a mother, and
+that it is only the mothers who think you can’t.
+
+“At once,” Wendy replied resolutely, for the horrible thought had come
+to her: “Perhaps mother is in half mourning by this time.”
+
+This dread made her forgetful of what must be Peter’s feelings, and
+she said to him rather sharply, “Peter, will you make the necessary
+arrangements?”
+
+“If you wish it,” he replied, as coolly as if she had asked him to pass
+the nuts.
+
+Not so much as a sorry-to-lose-you between them! If she did not mind the
+parting, he was going to show her, was Peter, that neither did he.
+
+But of course he cared very much; and he was so full of wrath against
+grown-ups, who, as usual, were spoiling everything, that as soon as he
+got inside his tree he breathed intentionally quick short breaths at the
+rate of about five to a second. He did this because there is a saying in
+the Neverland that, every time you breathe, a grown-up dies; and Peter
+was killing them off vindictively as fast as possible.
+
+Then having given the necessary instructions to the redskins he returned
+to the home, where an unworthy scene had been enacted in his absence.
+Panic-stricken at the thought of losing Wendy the lost boys had advanced
+upon her threateningly.
+
+“It will be worse than before she came,” they cried.
+
+“We shan’t let her go.”
+
+“Let’s keep her prisoner.”
+
+“Ay, chain her up.”
+
+In her extremity an instinct told her to which of them to turn.
+
+“Tootles,” she cried, “I appeal to you.”
+
+Was it not strange? She appealed to Tootles, quite the silliest one.
+
+Grandly, however, did Tootles respond. For that one moment he dropped
+his silliness and spoke with dignity.
+
+“I am just Tootles,” he said, “and nobody minds me. But the first who
+does not behave to Wendy like an English gentleman I will blood him
+severely.”
+
+He drew back his hanger; and for that instant his sun was at noon. The
+others held back uneasily. Then Peter returned, and they saw at once
+that they would get no support from him. He would keep no girl in the
+Neverland against her will.
+
+“Wendy,” he said, striding up and down, “I have asked the redskins to
+guide you through the wood, as flying tires you so.”
+
+“Thank you, Peter.”
+
+“Then,” he continued, in the short sharp voice of one accustomed to be
+obeyed, “Tinker Bell will take you across the sea. Wake her, Nibs.”
+
+Nibs had to knock twice before he got an answer, though Tink had really
+been sitting up in bed listening for some time.
+
+“Who are you? How dare you? Go away,” she cried.
+
+“You are to get up, Tink,” Nibs called, “and take Wendy on a journey.”
+
+Of course Tink had been delighted to hear that Wendy was going; but
+she was jolly well determined not to be her courier, and she said so in
+still more offensive language. Then she pretended to be asleep again.
+
+“She says she won’t!” Nibs exclaimed, aghast at such insubordination,
+whereupon Peter went sternly toward the young lady’s chamber.
+
+“Tink,” he rapped out, “if you don’t get up and dress at once I will
+open the curtains, and then we shall all see you in your negligee
+[nightgown].”
+
+This made her leap to the floor. “Who said I wasn’t getting up?” she
+cried.
+
+In the meantime the boys were gazing very forlornly at Wendy, now
+equipped with John and Michael for the journey. By this time they were
+dejected, not merely because they were about to lose her, but also
+because they felt that she was going off to something nice to which they
+had not been invited. Novelty was beckoning to them as usual.
+
+Crediting them with a nobler feeling Wendy melted.
+
+“Dear ones,” she said, “if you will all come with me I feel almost sure
+I can get my father and mother to adopt you.”
+
+The invitation was meant specially for Peter, but each of the boys was
+thinking exclusively of himself, and at once they jumped with joy.
+
+“But won’t they think us rather a handful?” Nibs asked in the middle of
+his jump.
+
+“Oh no,” said Wendy, rapidly thinking it out, “it will only mean having
+a few beds in the drawing-room; they can be hidden behind the screens on
+first Thursdays.”
+
+“Peter, can we go?” they all cried imploringly. They took it for granted
+that if they went he would go also, but really they scarcely cared. Thus
+children are ever ready, when novelty knocks, to desert their dearest
+ones.
+
+“All right,” Peter replied with a bitter smile, and immediately they
+rushed to get their things.
+
+“And now, Peter,” Wendy said, thinking she had put everything right,
+“I am going to give you your medicine before you go.” She loved to give
+them medicine, and undoubtedly gave them too much. Of course it was only
+water, but it was out of a bottle, and she always shook the bottle and
+counted the drops, which gave it a certain medicinal quality. On this
+occasion, however, she did not give Peter his draught [portion], for
+just as she had prepared it, she saw a look on his face that made her
+heart sink.
+
+“Get your things, Peter,” she cried, shaking.
+
+“No,” he answered, pretending indifference, “I am not going with you,
+Wendy.”
+
+“Yes, Peter.”
+
+“No.”
+
+To show that her departure would leave him unmoved, he skipped up and
+down the room, playing gaily on his heartless pipes. She had to run
+about after him, though it was rather undignified.
+
+“To find your mother,” she coaxed.
+
+Now, if Peter had ever quite had a mother, he no longer missed her. He
+could do very well without one. He had thought them out, and remembered
+only their bad points.
+
+“No, no,” he told Wendy decisively; “perhaps she would say I was old,
+and I just want always to be a little boy and to have fun.”
+
+“But, Peter--”
+
+“No.”
+
+And so the others had to be told.
+
+“Peter isn’t coming.”
+
+Peter not coming! They gazed blankly at him, their sticks over their
+backs, and on each stick a bundle. Their first thought was that if Peter
+was not going he had probably changed his mind about letting them go.
+
+But he was far too proud for that. “If you find your mothers,” he said
+darkly, “I hope you will like them.”
+
+The awful cynicism of this made an uncomfortable impression, and most
+of them began to look rather doubtful. After all, their faces said, were
+they not noodles to want to go?
+
+“Now then,” cried Peter, “no fuss, no blubbering; good-bye, Wendy;” and
+he held out his hand cheerily, quite as if they must really go now, for
+he had something important to do.
+
+She had to take his hand, and there was no indication that he would
+prefer a thimble.
+
+“You will remember about changing your flannels, Peter?” she said,
+lingering over him. She was always so particular about their flannels.
+
+“Yes.”
+
+“And you will take your medicine?”
+
+“Yes.”
+
+That seemed to be everything, and an awkward pause followed. Peter,
+however, was not the kind that breaks down before other people. “Are you
+ready, Tinker Bell?” he called out.
+
+“Ay, ay.”
+
+“Then lead the way.”
+
+Tink darted up the nearest tree; but no one followed her, for it was
+at this moment that the pirates made their dreadful attack upon the
+redskins. Above, where all had been so still, the air was rent with
+shrieks and the clash of steel. Below, there was dead silence. Mouths
+opened and remained open. Wendy fell on her knees, but her arms were
+extended toward Peter. All arms were extended to him, as if suddenly
+blown in his direction; they were beseeching him mutely not to desert
+them. As for Peter, he seized his sword, the same he thought he had
+slain Barbecue with, and the lust of battle was in his eye.
+
+
+
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+The pirate attack had been a complete surprise: a sure proof that the
+unscrupulous Hook had conducted it improperly, for to surprise redskins
+fairly is beyond the wit of the white man.
+
+By all the unwritten laws of savage warfare it is always the redskin who
+attacks, and with the wiliness of his race he does it just before the
+dawn, at which time he knows the courage of the whites to be at its
+lowest ebb. The white men have in the meantime made a rude stockade on
+the summit of yonder undulating ground, at the foot of which a stream
+runs, for it is destruction to be too far from water. There they await
+the onslaught, the inexperienced ones clutching their revolvers and
+treading on twigs, but the old hands sleeping tranquilly until just
+before the dawn. Through the long black night the savage scouts wriggle,
+snake-like, among the grass without stirring a blade. The brushwood
+closes behind them, as silently as sand into which a mole has dived.
+Not a sound is to be heard, save when they give vent to a wonderful
+imitation of the lonely call of the coyote. The cry is answered by other
+braves; and some of them do it even better than the coyotes, who are not
+very good at it. So the chill hours wear on, and the long suspense is
+horribly trying to the paleface who has to live through it for the first
+time; but to the trained hand those ghastly calls and still ghastlier
+silences are but an intimation of how the night is marching.
+
+That this was the usual procedure was so well known to Hook that in
+disregarding it he cannot be excused on the plea of ignorance.
+
+The Piccaninnies, on their part, trusted implicitly to his honour, and
+their whole action of the night stands out in marked contrast to his.
+They left nothing undone that was consistent with the reputation of
+their tribe. With that alertness of the senses which is at once the
+marvel and despair of civilised peoples, they knew that the pirates were
+on the island from the moment one of them trod on a dry stick; and in
+an incredibly short space of time the coyote cries began. Every foot of
+ground between the spot where Hook had landed his forces and the
+home under the trees was stealthily examined by braves wearing their
+mocassins with the heels in front. They found only one hillock with a
+stream at its base, so that Hook had no choice; here he must establish
+himself and wait for just before the dawn. Everything being thus mapped
+out with almost diabolical cunning, the main body of the redskins folded
+their blankets around them, and in the phlegmatic manner that is to
+them, the pearl of manhood squatted above the children’s home, awaiting
+the cold moment when they should deal pale death.
+
+Here dreaming, though wide-awake, of the exquisite tortures to which
+they were to put him at break of day, those confiding savages were found
+by the treacherous Hook. From the accounts afterwards supplied by such
+of the scouts as escaped the carnage, he does not seem even to have
+paused at the rising ground, though it is certain that in that grey
+light he must have seen it: no thought of waiting to be attacked appears
+from first to last to have visited his subtle mind; he would not even
+hold off till the night was nearly spent; on he pounded with no policy
+but to fall to [get into combat]. What could the bewildered scouts do,
+masters as they were of every war-like artifice save this one, but trot
+helplessly after him, exposing themselves fatally to view, while they
+gave pathetic utterance to the coyote cry.
+
+Around the brave Tiger Lily were a dozen of her stoutest warriors, and
+they suddenly saw the perfidious pirates bearing down upon them. Fell
+from their eyes then the film through which they had looked at
+victory. No more would they torture at the stake. For them the happy
+hunting-grounds was now. They knew it; but as their father’s sons they
+acquitted themselves. Even then they had time to gather in a phalanx
+[dense formation] that would have been hard to break had they risen
+quickly, but this they were forbidden to do by the traditions of their
+race. It is written that the noble savage must never express surprise in
+the presence of the white. Thus terrible as the sudden appearance of the
+pirates must have been to them, they remained stationary for a moment,
+not a muscle moving; as if the foe had come by invitation. Then, indeed,
+the tradition gallantly upheld, they seized their weapons, and the air
+was torn with the war-cry; but it was now too late.
+
+It is no part of ours to describe what was a massacre rather than a
+fight. Thus perished many of the flower of the Piccaninny tribe. Not all
+unavenged did they die, for with Lean Wolf fell Alf Mason, to disturb
+the Spanish Main no more, and among others who bit the dust were Geo.
+Scourie, Chas. Turley, and the Alsatian Foggerty. Turley fell to the
+tomahawk of the terrible Panther, who ultimately cut a way through the
+pirates with Tiger Lily and a small remnant of the tribe.
+
+To what extent Hook is to blame for his tactics on this occasion is for
+the historian to decide. Had he waited on the rising ground till the
+proper hour he and his men would probably have been butchered; and in
+judging him it is only fair to take this into account. What he should
+perhaps have done was to acquaint his opponents that he proposed to
+follow a new method. On the other hand, this, as destroying the element
+of surprise, would have made his strategy of no avail, so that the whole
+question is beset with difficulties. One cannot at least withhold a
+reluctant admiration for the wit that had conceived so bold a scheme,
+and the fell [deadly] genius with which it was carried out.
+
+What were his own feelings about himself at that triumphant moment?
+Fain [gladly] would his dogs have known, as breathing heavily and wiping
+their cutlasses, they gathered at a discreet distance from his hook, and
+squinted through their ferret eyes at this extraordinary man. Elation
+must have been in his heart, but his face did not reflect it: ever a
+dark and solitary enigma, he stood aloof from his followers in spirit as
+in substance.
+
+The night’s work was not yet over, for it was not the redskins he had
+come out to destroy; they were but the bees to be smoked, so that he
+should get at the honey. It was Pan he wanted, Pan and Wendy and their
+band, but chiefly Pan.
+
+Peter was such a small boy that one tends to wonder at the man’s hatred
+of him. True he had flung Hook’s arm to the crocodile, but even this
+and the increased insecurity of life to which it led, owing to
+the crocodile’s pertinacity [persistance], hardly account for a
+vindictiveness so relentless and malignant. The truth is that there was
+a something about Peter which goaded the pirate captain to frenzy. It
+was not his courage, it was not his engaging appearance, it was not--.
+There is no beating about the bush, for we know quite well what it was,
+and have got to tell. It was Peter’s cockiness.
+
+This had got on Hook’s nerves; it made his iron claw twitch, and at
+night it disturbed him like an insect. While Peter lived, the tortured
+man felt that he was a lion in a cage into which a sparrow had come.
+
+The question now was how to get down the trees, or how to get his dogs
+down? He ran his greedy eyes over them, searching for the thinnest
+ones. They wriggled uncomfortably, for they knew he would not scruple
+[hesitate] to ram them down with poles.
+
+In the meantime, what of the boys? We have seen them at the first clang
+of the weapons, turned as it were into stone figures, open-mouthed,
+all appealing with outstretched arms to Peter; and we return to them as
+their mouths close, and their arms fall to their sides. The pandemonium
+above has ceased almost as suddenly as it arose, passed like a fierce
+gust of wind; but they know that in the passing it has determined their
+fate.
+
+Which side had won?
+
+The pirates, listening avidly at the mouths of the trees, heard the
+question put by every boy, and alas, they also heard Peter’s answer.
+
+“If the redskins have won,” he said, “they will beat the tom-tom; it is
+always their sign of victory.”
+
+Now Smee had found the tom-tom, and was at that moment sitting on it.
+“You will never hear the tom-tom again,” he muttered, but inaudibly of
+course, for strict silence had been enjoined [urged]. To his amazement
+Hook signed him to beat the tom-tom, and slowly there came to Smee an
+understanding of the dreadful wickedness of the order. Never, probably,
+had this simple man admired Hook so much.
+
+Twice Smee beat upon the instrument, and then stopped to listen
+gleefully.
+
+“The tom-tom,” the miscreants heard Peter cry; “an Indian victory!”
+
+The doomed children answered with a cheer that was music to the black
+hearts above, and almost immediately they repeated their good-byes
+to Peter. This puzzled the pirates, but all their other feelings were
+swallowed by a base delight that the enemy were about to come up the
+trees. They smirked at each other and rubbed their hands. Rapidly and
+silently Hook gave his orders: one man to each tree, and the others to
+arrange themselves in a line two yards apart.
+
+
+
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+The more quickly this horror is disposed of the better. The first to
+emerge from his tree was Curly. He rose out of it into the arms of
+Cecco, who flung him to Smee, who flung him to Starkey, who flung him to
+Bill Jukes, who flung him to Noodler, and so he was tossed from one to
+another till he fell at the feet of the black pirate. All the boys were
+plucked from their trees in this ruthless manner; and several of them
+were in the air at a time, like bales of goods flung from hand to hand.
+
+A different treatment was accorded to Wendy, who came last. With
+ironical politeness Hook raised his hat to her, and, offering her his
+arm, escorted her to the spot where the others were being gagged. He
+did it with such an air, he was so frightfully DISTINGUE [imposingly
+distinguished], that she was too fascinated to cry out. She was only a
+little girl.
+
+Perhaps it is tell-tale to divulge that for a moment Hook entranced her,
+and we tell on her only because her slip led to strange results. Had she
+haughtily unhanded him (and we should have loved to write it of her),
+she would have been hurled through the air like the others, and then
+Hook would probably not have been present at the tying of the children;
+and had he not been at the tying he would not have discovered Slightly’s
+secret, and without the secret he could not presently have made his foul
+attempt on Peter’s life.
+
+They were tied to prevent their flying away, doubled up with their knees
+close to their ears; and for the trussing of them the black pirate had
+cut a rope into nine equal pieces. All went well until Slightly’s turn
+came, when he was found to be like those irritating parcels that use up
+all the string in going round and leave no tags [ends] with which to
+tie a knot. The pirates kicked him in their rage, just as you kick the
+parcel (though in fairness you should kick the string); and strange
+to say it was Hook who told them to belay their violence. His lip was
+curled with malicious triumph. While his dogs were merely sweating
+because every time they tried to pack the unhappy lad tight in one
+part he bulged out in another, Hook’s master mind had gone far beneath
+Slightly’s surface, probing not for effects but for causes; and his
+exultation showed that he had found them. Slightly, white to the gills,
+knew that Hook had surprised [discovered] his secret, which was this,
+that no boy so blown out could use a tree wherein an average man need
+stick. Poor Slightly, most wretched of all the children now, for he
+was in a panic about Peter, bitterly regretted what he had done. Madly
+addicted to the drinking of water when he was hot, he had swelled in
+consequence to his present girth, and instead of reducing himself to fit
+his tree he had, unknown to the others, whittled his tree to make it fit
+him.
+
+Sufficient of this Hook guessed to persuade him that Peter at last lay
+at his mercy, but no word of the dark design that now formed in the
+subterranean caverns of his mind crossed his lips; he merely signed
+that the captives were to be conveyed to the ship, and that he would be
+alone.
+
+How to convey them? Hunched up in their ropes they might indeed be
+rolled down hill like barrels, but most of the way lay through a morass.
+Again Hook’s genius surmounted difficulties. He indicated that the
+little house must be used as a conveyance. The children were flung into
+it, four stout pirates raised it on their shoulders, the others fell in
+behind, and singing the hateful pirate chorus the strange procession
+set off through the wood. I don’t know whether any of the children were
+crying; if so, the singing drowned the sound; but as the little house
+disappeared in the forest, a brave though tiny jet of smoke issued from
+its chimney as if defying Hook.
+
+Hook saw it, and it did Peter a bad service. It dried up any trickle of
+pity for him that may have remained in the pirate’s infuriated breast.
+
+The first thing he did on finding himself alone in the fast falling
+night was to tiptoe to Slightly’s tree, and make sure that it provided
+him with a passage. Then for long he remained brooding; his hat of ill
+omen on the sward, so that any gentle breeze which had arisen might play
+refreshingly through his hair. Dark as were his thoughts his blue eyes
+were as soft as the periwinkle. Intently he listened for any sound from
+the nether world, but all was as silent below as above; the house under
+the ground seemed to be but one more empty tenement in the void. Was
+that boy asleep, or did he stand waiting at the foot of Slightly’s tree,
+with his dagger in his hand?
+
+There was no way of knowing, save by going down. Hook let his cloak slip
+softly to the ground, and then biting his lips till a lewd blood stood
+on them, he stepped into the tree. He was a brave man, but for a moment
+he had to stop there and wipe his brow, which was dripping like a
+candle. Then, silently, he let himself go into the unknown.
+
+He arrived unmolested at the foot of the shaft, and stood still again,
+biting at his breath, which had almost left him. As his eyes became
+accustomed to the dim light various objects in the home under the trees
+took shape; but the only one on which his greedy gaze rested, long
+sought for and found at last, was the great bed. On the bed lay Peter
+fast asleep.
+
+Unaware of the tragedy being enacted above, Peter had continued, for
+a little time after the children left, to play gaily on his pipes: no
+doubt rather a forlorn attempt to prove to himself that he did not care.
+Then he decided not to take his medicine, so as to grieve Wendy. Then he
+lay down on the bed outside the coverlet, to vex her still more; for she
+had always tucked them inside it, because you never know that you may
+not grow chilly at the turn of the night. Then he nearly cried; but
+it struck him how indignant she would be if he laughed instead; so he
+laughed a haughty laugh and fell asleep in the middle of it.
+
+Sometimes, though not often, he had dreams, and they were more painful
+than the dreams of other boys. For hours he could not be separated from
+these dreams, though he wailed piteously in them. They had to do, I
+think, with the riddle of his existence. At such times it had been
+Wendy’s custom to take him out of bed and sit with him on her lap,
+soothing him in dear ways of her own invention, and when he grew calmer
+to put him back to bed before he quite woke up, so that he should
+not know of the indignity to which she had subjected him. But on this
+occasion he had fallen at once into a dreamless sleep. One arm dropped
+over the edge of the bed, one leg was arched, and the unfinished part of
+his laugh was stranded on his mouth, which was open, showing the little
+pearls.
+
+Thus defenceless Hook found him. He stood silent at the foot of the tree
+looking across the chamber at his enemy. Did no feeling of compassion
+disturb his sombre breast? The man was not wholly evil; he loved flowers
+(I have been told) and sweet music (he was himself no mean performer on
+the harpsichord); and, let it be frankly admitted, the idyllic nature of
+the scene stirred him profoundly. Mastered by his better self he would
+have returned reluctantly up the tree, but for one thing.
+
+What stayed him was Peter’s impertinent appearance as he slept. The
+open mouth, the drooping arm, the arched knee: they were such a
+personification of cockiness as, taken together, will never again, one
+may hope, be presented to eyes so sensitive to their offensiveness. They
+steeled Hook’s heart. If his rage had broken him into a hundred pieces
+every one of them would have disregarded the incident, and leapt at the
+sleeper.
+
+Though a light from the one lamp shone dimly on the bed, Hook stood in
+darkness himself, and at the first stealthy step forward he discovered
+an obstacle, the door of Slightly’s tree. It did not entirely fill the
+aperture, and he had been looking over it. Feeling for the catch,
+he found to his fury that it was low down, beyond his reach. To his
+disordered brain it seemed then that the irritating quality in Peter’s
+face and figure visibly increased, and he rattled the door and flung
+himself against it. Was his enemy to escape him after all?
+
+But what was that? The red in his eye had caught sight of Peter’s
+medicine standing on a ledge within easy reach. He fathomed what it was
+straightaway, and immediately knew that the sleeper was in his power.
+
+Lest he should be taken alive, Hook always carried about his person a
+dreadful drug, blended by himself of all the death-dealing rings that
+had come into his possession. These he had boiled down into a yellow
+liquid quite unknown to science, which was probably the most virulent
+poison in existence.
+
+Five drops of this he now added to Peter’s cup. His hand shook, but it
+was in exultation rather than in shame. As he did it he avoided glancing
+at the sleeper, but not lest pity should unnerve him; merely to avoid
+spilling. Then one long gloating look he cast upon his victim, and
+turning, wormed his way with difficulty up the tree. As he emerged
+at the top he looked the very spirit of evil breaking from its hole.
+Donning his hat at its most rakish angle, he wound his cloak around him,
+holding one end in front as if to conceal his person from the night,
+of which it was the blackest part, and muttering strangely to himself,
+stole away through the trees.
+
+Peter slept on. The light guttered [burned to edges] and went out,
+leaving the tenement in darkness; but still he slept. It must have been
+not less than ten o’clock by the crocodile, when he suddenly sat up in
+his bed, wakened by he knew not what. It was a soft cautious tapping on
+the door of his tree.
+
+Soft and cautious, but in that stillness it was sinister. Peter felt for
+his dagger till his hand gripped it. Then he spoke.
+
+“Who is that?”
+
+For long there was no answer: then again the knock.
+
+“Who are you?”
+
+No answer.
+
+He was thrilled, and he loved being thrilled. In two strides he reached
+the door. Unlike Slightly’s door, it filled the aperture [opening], so
+that he could not see beyond it, nor could the one knocking see him.
+
+“I won’t open unless you speak,” Peter cried.
+
+Then at last the visitor spoke, in a lovely bell-like voice.
+
+“Let me in, Peter.”
+
+It was Tink, and quickly he unbarred to her. She flew in excitedly, her
+face flushed and her dress stained with mud.
+
+“What is it?”
+
+“Oh, you could never guess!” she cried, and offered him three guesses.
+“Out with it!” he shouted, and in one ungrammatical sentence, as long as
+the ribbons that conjurers [magicians] pull from their mouths, she told
+of the capture of Wendy and the boys.
+
+Peter’s heart bobbed up and down as he listened. Wendy bound, and on the
+pirate ship; she who loved everything to be just so!
+
+“I’ll rescue her!” he cried, leaping at his weapons. As he leapt he
+thought of something he could do to please her. He could take his
+medicine.
+
+His hand closed on the fatal draught.
+
+“No!” shrieked Tinker Bell, who had heard Hook mutter about his deed as
+he sped through the forest.
+
+“Why not?”
+
+“It is poisoned.”
+
+“Poisoned? Who could have poisoned it?”
+
+“Hook.”
+
+“Don’t be silly. How could Hook have got down here?”
+
+Alas, Tinker Bell could not explain this, for even she did not know the
+dark secret of Slightly’s tree. Nevertheless Hook’s words had left no
+room for doubt. The cup was poisoned.
+
+“Besides,” said Peter, quite believing himself, “I never fell asleep.”
+
+He raised the cup. No time for words now; time for deeds; and with one
+of her lightning movements Tink got between his lips and the draught,
+and drained it to the dregs.
+
+“Why, Tink, how dare you drink my medicine?”
+
+But she did not answer. Already she was reeling in the air.
+
+“What is the matter with you?” cried Peter, suddenly afraid.
+
+“It was poisoned, Peter,” she told him softly; “and now I am going to be
+dead.”
+
+“O Tink, did you drink it to save me?”
+
+“Yes.”
+
+“But why, Tink?”
+
+Her wings would scarcely carry her now, but in reply she alighted on his
+shoulder and gave his nose a loving bite. She whispered in his ear “You
+silly ass,” and then, tottering to her chamber, lay down on the bed.
+
+His head almost filled the fourth wall of her little room as he knelt
+near her in distress. Every moment her light was growing fainter; and
+he knew that if it went out she would be no more. She liked his tears so
+much that she put out her beautiful finger and let them run over it.
+
+Her voice was so low that at first he could not make out what she said.
+Then he made it out. She was saying that she thought she could get well
+again if children believed in fairies.
+
+Peter flung out his arms. There were no children there, and it was night
+time; but he addressed all who might be dreaming of the Neverland, and
+who were therefore nearer to him than you think: boys and girls in their
+nighties, and naked papooses in their baskets hung from trees.
+
+“Do you believe?” he cried.
+
+Tink sat up in bed almost briskly to listen to her fate.
+
+She fancied she heard answers in the affirmative, and then again she
+wasn’t sure.
+
+“What do you think?” she asked Peter.
+
+“If you believe,” he shouted to them, “clap your hands; don’t let Tink
+die.”
+
+Many clapped.
+
+Some didn’t.
+
+A few beasts hissed.
+
+The clapping stopped suddenly; as if countless mothers had rushed to
+their nurseries to see what on earth was happening; but already Tink was
+saved. First her voice grew strong, then she popped out of bed, then
+she was flashing through the room more merry and impudent than ever. She
+never thought of thanking those who believed, but she would have liked to
+get at the ones who had hissed.
+
+“And now to rescue Wendy!”
+
+The moon was riding in a cloudy heaven when Peter rose from his tree,
+begirt [belted] with weapons and wearing little else, to set out upon
+his perilous quest. It was not such a night as he would have chosen.
+He had hoped to fly, keeping not far from the ground so that nothing
+unwonted should escape his eyes; but in that fitful light to have
+flown low would have meant trailing his shadow through the trees, thus
+disturbing birds and acquainting a watchful foe that he was astir.
+
+He regretted now that he had given the birds of the island such strange
+names that they are very wild and difficult of approach.
+
+There was no other course but to press forward in redskin fashion, at
+which happily he was an adept [expert]. But in what direction, for he
+could not be sure that the children had been taken to the ship? A
+light fall of snow had obliterated all footmarks; and a deathly silence
+pervaded the island, as if for a space Nature stood still in horror of
+the recent carnage. He had taught the children something of the forest
+lore that he had himself learned from Tiger Lily and Tinker Bell,
+and knew that in their dire hour they were not likely to forget it.
+Slightly, if he had an opportunity, would blaze [cut a mark in] the
+trees, for instance, Curly would drop seeds, and Wendy would leave her
+handkerchief at some important place. The morning was needed to search
+for such guidance, and he could not wait. The upper world had called
+him, but would give no help.
+
+The crocodile passed him, but not another living thing, not a sound, not
+a movement; and yet he knew well that sudden death might be at the next
+tree, or stalking him from behind.
+
+He swore this terrible oath: “Hook or me this time.”
+
+Now he crawled forward like a snake, and again erect, he darted across
+a space on which the moonlight played, one finger on his lip and his
+dagger at the ready. He was frightfully happy.
+
+
+
+
+Chapter 14 THE PIRATE SHIP
+
+One green light squinting over Kidd’s Creek, which is near the mouth of
+the pirate river, marked where the brig, the JOLLY ROGER, lay, low in
+the water; a rakish-looking [speedy-looking] craft foul to the hull,
+every beam in her detestable, like ground strewn with mangled feathers.
+She was the cannibal of the seas, and scarce needed that watchful eye,
+for she floated immune in the horror of her name.
+
+She was wrapped in the blanket of night, through which no sound from her
+could have reached the shore. There was little sound, and none agreeable
+save the whir of the ship’s sewing machine at which Smee sat, ever
+industrious and obliging, the essence of the commonplace, pathetic Smee.
+I know not why he was so infinitely pathetic, unless it were because
+he was so pathetically unaware of it; but even strong men had to turn
+hastily from looking at him, and more than once on summer evenings he
+had touched the fount of Hook’s tears and made it flow. Of this, as of
+almost everything else, Smee was quite unconscious.
+
+A few of the pirates leant over the bulwarks, drinking in the miasma
+[putrid mist] of the night; others sprawled by barrels over games of
+dice and cards; and the exhausted four who had carried the little house
+lay prone on the deck, where even in their sleep they rolled skillfully
+to this side or that out of Hook’s reach, lest he should claw them
+mechanically in passing.
+
+Hook trod the deck in thought. O man unfathomable. It was his hour of
+triumph. Peter had been removed for ever from his path, and all the
+other boys were in the brig, about to walk the plank. It was his
+grimmest deed since the days when he had brought Barbecue to heel; and
+knowing as we do how vain a tabernacle is man, could we be surprised
+had he now paced the deck unsteadily, bellied out by the winds of his
+success?
+
+But there was no elation in his gait, which kept pace with the action of
+his sombre mind. Hook was profoundly dejected.
+
+He was often thus when communing with himself on board ship in the
+quietude of the night. It was because he was so terribly alone. This
+inscrutable man never felt more alone than when surrounded by his dogs.
+They were socially inferior to him.
+
+Hook was not his true name. To reveal who he really was would even at
+this date set the country in a blaze; but as those who read between the
+lines must already have guessed, he had been at a famous public school;
+and its traditions still clung to him like garments, with which indeed
+they are largely concerned. Thus it was offensive to him even now to
+board a ship in the same dress in which he grappled [attacked] her, and
+he still adhered in his walk to the school’s distinguished slouch. But
+above all he retained the passion for good form.
+
+Good form! However much he may have degenerated, he still knew that this
+is all that really matters.
+
+From far within him he heard a creaking as of rusty portals, and through
+them came a stern tap-tap-tap, like hammering in the night when one
+cannot sleep. “Have you been good form to-day?” was their eternal
+question.
+
+“Fame, fame, that glittering bauble, it is mine,” he cried.
+
+“Is it quite good form to be distinguished at anything?” the tap-tap
+from his school replied.
+
+“I am the only man whom Barbecue feared,” he urged, “and Flint feared
+Barbecue.”
+
+“Barbecue, Flint--what house?” came the cutting retort.
+
+Most disquieting reflection of all, was it not bad form to think about
+good form?
+
+His vitals were tortured by this problem. It was a claw within him
+sharper than the iron one; and as it tore him, the perspiration dripped
+down his tallow [waxy] countenance and streaked his doublet. Ofttimes he
+drew his sleeve across his face, but there was no damming that trickle.
+
+Ah, envy not Hook.
+
+There came to him a presentiment of his early dissolution [death]. It
+was as if Peter’s terrible oath had boarded the ship. Hook felt a gloomy
+desire to make his dying speech, lest presently there should be no time
+for it.
+
+“Better for Hook,” he cried, “if he had had less ambition!” It was in
+his darkest hours only that he referred to himself in the third person.
+
+“No little children to love me!”
+
+Strange that he should think of this, which had never troubled him
+before; perhaps the sewing machine brought it to his mind. For long he
+muttered to himself, staring at Smee, who was hemming placidly, under
+the conviction that all children feared him.
+
+Feared him! Feared Smee! There was not a child on board the brig that
+night who did not already love him. He had said horrid things to them
+and hit them with the palm of his hand, because he could not hit with
+his fist, but they had only clung to him the more. Michael had tried on
+his spectacles.
+
+To tell poor Smee that they thought him lovable! Hook itched to do it,
+but it seemed too brutal. Instead, he revolved this mystery in his
+mind: why do they find Smee lovable? He pursued the problem like the
+sleuth-hound that he was. If Smee was lovable, what was it that made him
+so? A terrible answer suddenly presented itself--“Good form?”
+
+Had the bo’sun good form without knowing it, which is the best form of
+all?
+
+He remembered that you have to prove you don’t know you have it before
+you are eligible for Pop [an elite social club at Eton].
+
+With a cry of rage he raised his iron hand over Smee’s head; but he did
+not tear. What arrested him was this reflection:
+
+“To claw a man because he is good form, what would that be?”
+
+“Bad form!”
+
+The unhappy Hook was as impotent [powerless] as he was damp, and he fell
+forward like a cut flower.
+
+His dogs thinking him out of the way for a time, discipline instantly
+relaxed; and they broke into a bacchanalian [drunken] dance, which
+brought him to his feet at once, all traces of human weakness gone, as
+if a bucket of water had passed over him.
+
+“Quiet, you scugs,” he cried, “or I’ll cast anchor in you;” and at once
+the din was hushed. “Are all the children chained, so that they cannot
+fly away?”
+
+“Ay, ay.”
+
+“Then hoist them up.”
+
+The wretched prisoners were dragged from the hold, all except Wendy,
+and ranged in line in front of him. For a time he seemed unconscious
+of their presence. He lolled at his ease, humming, not unmelodiously,
+snatches of a rude song, and fingering a pack of cards. Ever and anon
+the light from his cigar gave a touch of colour to his face.
+
+“Now then, bullies,” he said briskly, “six of you walk the plank
+to-night, but I have room for two cabin boys. Which of you is it to be?”
+
+“Don’t irritate him unnecessarily,” had been Wendy’s instructions in
+the hold; so Tootles stepped forward politely. Tootles hated the idea
+of signing under such a man, but an instinct told him that it would
+be prudent to lay the responsibility on an absent person; and though a
+somewhat silly boy, he knew that mothers alone are always willing to be
+the buffer. All children know this about mothers, and despise them for
+it, but make constant use of it.
+
+So Tootles explained prudently, “You see, sir, I don’t think my mother
+would like me to be a pirate. Would your mother like you to be a pirate,
+Slightly?”
+
+He winked at Slightly, who said mournfully, “I don’t think so,” as if
+he wished things had been otherwise. “Would your mother like you to be a
+pirate, Twin?”
+
+“I don’t think so,” said the first twin, as clever as the others. “Nibs,
+would--”
+
+“Stow this gab,” roared Hook, and the spokesmen were dragged back. “You,
+boy,” he said, addressing John, “you look as if you had a little pluck
+in you. Didst never want to be a pirate, my hearty?”
+
+Now John had sometimes experienced this hankering at maths. prep.; and
+he was struck by Hook’s picking him out.
+
+“I once thought of calling myself Red-handed Jack,” he said diffidently.
+
+“And a good name too. We’ll call you that here, bully, if you join.”
+
+“What do you think, Michael?” asked John.
+
+“What would you call me if I join?” Michael demanded.
+
+“Blackbeard Joe.”
+
+Michael was naturally impressed. “What do you think, John?” He wanted
+John to decide, and John wanted him to decide.
+
+“Shall we still be respectful subjects of the King?” John inquired.
+
+Through Hook’s teeth came the answer: “You would have to swear, ‘Down
+with the King.’”
+
+Perhaps John had not behaved very well so far, but he shone out now.
+
+“Then I refuse,” he cried, banging the barrel in front of Hook.
+
+“And I refuse,” cried Michael.
+
+“Rule Britannia!” squeaked Curly.
+
+The infuriated pirates buffeted them in the mouth; and Hook roared out,
+“That seals your doom. Bring up their mother. Get the plank ready.”
+
+They were only boys, and they went white as they saw Jukes and Cecco
+preparing the fatal plank. But they tried to look brave when Wendy was
+brought up.
+
+No words of mine can tell you how Wendy despised those pirates. To the
+boys there was at least some glamour in the pirate calling; but all that
+she saw was that the ship had not been tidied for years. There was not
+a porthole on the grimy glass of which you might not have written with
+your finger “Dirty pig”; and she had already written it on several. But
+as the boys gathered round her she had no thought, of course, save for
+them.
+
+“So, my beauty,” said Hook, as if he spoke in syrup, “you are to see
+your children walk the plank.”
+
+Fine gentlemen though he was, the intensity of his communings had soiled
+his ruff, and suddenly he knew that she was gazing at it. With a hasty
+gesture he tried to hide it, but he was too late.
+
+“Are they to die?” asked Wendy, with a look of such frightful contempt
+that he nearly fainted.
+
+“They are,” he snarled. “Silence all,” he called gloatingly, “for a
+mother’s last words to her children.”
+
+At this moment Wendy was grand. “These are my last words, dear boys,”
+ she said firmly. “I feel that I have a message to you from your real
+mothers, and it is this: ‘We hope our sons will die like English
+gentlemen.’”
+
+Even the pirates were awed, and Tootles cried out hysterically, “I am
+going to do what my mother hopes. What are you to do, Nibs?”
+
+“What my mother hopes. What are you to do, Twin?”
+
+“What my mother hopes. John, what are--”
+
+But Hook had found his voice again.
+
+“Tie her up!” he shouted.
+
+It was Smee who tied her to the mast. “See here, honey,” he whispered,
+“I’ll save you if you promise to be my mother.”
+
+But not even for Smee would she make such a promise. “I would almost
+rather have no children at all,” she said disdainfully [scornfully].
+
+It is sad to know that not a boy was looking at her as Smee tied her to
+the mast; the eyes of all were on the plank: that last little walk they
+were about to take. They were no longer able to hope that they would
+walk it manfully, for the capacity to think had gone from them; they
+could stare and shiver only.
+
+Hook smiled on them with his teeth closed, and took a step toward Wendy.
+His intention was to turn her face so that she should see the boys
+walking the plank one by one. But he never reached her, he never heard
+the cry of anguish he hoped to wring from her. He heard something else
+instead.
+
+It was the terrible tick-tick of the crocodile.
+
+They all heard it--pirates, boys, Wendy; and immediately every head was
+blown in one direction; not to the water whence the sound proceeded, but
+toward Hook. All knew that what was about to happen concerned him alone,
+and that from being actors they were suddenly become spectators.
+
+Very frightful was it to see the change that came over him. It was as if
+he had been clipped at every joint. He fell in a little heap.
+
+The sound came steadily nearer; and in advance of it came this ghastly
+thought, “The crocodile is about to board the ship!”
+
+Even the iron claw hung inactive; as if knowing that it was no intrinsic
+part of what the attacking force wanted. Left so fearfully alone, any
+other man would have lain with his eyes shut where he fell: but the
+gigantic brain of Hook was still working, and under its guidance he
+crawled on the knees along the deck as far from the sound as he could
+go. The pirates respectfully cleared a passage for him, and it was only
+when he brought up against the bulwarks that he spoke.
+
+“Hide me!” he cried hoarsely.
+
+They gathered round him, all eyes averted from the thing that was coming
+aboard. They had no thought of fighting it. It was Fate.
+
+Only when Hook was hidden from them did curiosity loosen the limbs of
+the boys so that they could rush to the ship’s side to see the crocodile
+climbing it. Then they got the strangest surprise of the Night of
+Nights; for it was no crocodile that was coming to their aid. It was
+Peter.
+
+He signed to them not to give vent to any cry of admiration that might
+rouse suspicion. Then he went on ticking.
+
+
+
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Odd things happen to all of us on our way through life without our
+noticing for a time that they have happened. Thus, to take an instance,
+we suddenly discover that we have been deaf in one ear for we don’t know
+how long, but, say, half an hour. Now such an experience had come that
+night to Peter. When last we saw him he was stealing across the island
+with one finger to his lips and his dagger at the ready. He had seen the
+crocodile pass by without noticing anything peculiar about it, but by
+and by he remembered that it had not been ticking. At first he thought
+this eerie, but soon concluded rightly that the clock had run down.
+
+Without giving a thought to what might be the feelings of a
+fellow-creature thus abruptly deprived of its closest companion, Peter
+began to consider how he could turn the catastrophe to his own use;
+and he decided to tick, so that wild beasts should believe he was the
+crocodile and let him pass unmolested. He ticked superbly, but with one
+unforeseen result. The crocodile was among those who heard the sound,
+and it followed him, though whether with the purpose of regaining what
+it had lost, or merely as a friend under the belief that it was again
+ticking itself, will never be certainly known, for, like slaves to a
+fixed idea, it was a stupid beast.
+
+Peter reached the shore without mishap, and went straight on, his legs
+encountering the water as if quite unaware that they had entered a new
+element. Thus many animals pass from land to water, but no other human
+of whom I know. As he swam he had but one thought: “Hook or me this
+time.” He had ticked so long that he now went on ticking without knowing
+that he was doing it. Had he known he would have stopped, for to board
+the brig by help of the tick, though an ingenious idea, had not occurred
+to him.
+
+On the contrary, he thought he had scaled her side as noiseless as a
+mouse; and he was amazed to see the pirates cowering from him, with Hook
+in their midst as abject as if he had heard the crocodile.
+
+The crocodile! No sooner did Peter remember it than he heard the
+ticking. At first he thought the sound did come from the crocodile,
+and he looked behind him swiftly. Then he realised that he was doing it
+himself, and in a flash he understood the situation. “How clever of me!”
+ he thought at once, and signed to the boys not to burst into applause.
+
+It was at this moment that Ed Teynte the quartermaster emerged from the
+forecastle and came along the deck. Now, reader, time what happened by
+your watch. Peter struck true and deep. John clapped his hands on the
+ill-fated pirate’s mouth to stifle the dying groan. He fell forward.
+Four boys caught him to prevent the thud. Peter gave the signal, and the
+carrion was cast overboard. There was a splash, and then silence. How
+long has it taken?
+
+“One!” (Slightly had begun to count.)
+
+None too soon, Peter, every inch of him on tiptoe, vanished into the
+cabin; for more than one pirate was screwing up his courage to look
+round. They could hear each other’s distressed breathing now, which
+showed them that the more terrible sound had passed.
+
+“It’s gone, captain,” Smee said, wiping off his spectacles. “All’s still
+again.”
+
+Slowly Hook let his head emerge from his ruff, and listened so intently
+that he could have caught the echo of the tick. There was not a sound,
+and he drew himself up firmly to his full height.
+
+“Then here’s to Johnny Plank!” he cried brazenly, hating the boys more
+than ever because they had seen him unbend. He broke into the villainous
+ditty:
+
+     “Yo ho, yo ho, the frisky plank,
+     You walks along it so,
+     Till it goes down and you goes down
+     To Davy Jones below!”
+
+To terrorize the prisoners the more, though with a certain loss of
+dignity, he danced along an imaginary plank, grimacing at them as he
+sang; and when he finished he cried, “Do you want a touch of the cat [o’
+nine tails] before you walk the plank?”
+
+At that they fell on their knees. “No, no!” they cried so piteously that
+every pirate smiled.
+
+“Fetch the cat, Jukes,” said Hook; “it’s in the cabin.”
+
+The cabin! Peter was in the cabin! The children gazed at each other.
+
+“Ay, ay,” said Jukes blithely, and he strode into the cabin. They
+followed him with their eyes; they scarce knew that Hook had resumed his
+song, his dogs joining in with him:
+
+     “Yo ho, yo ho, the scratching cat,
+     Its tails are nine, you know,
+     And when they’re writ upon your back--”
+
+What was the last line will never be known, for of a sudden the song was
+stayed by a dreadful screech from the cabin. It wailed through the ship,
+and died away. Then was heard a crowing sound which was well understood
+by the boys, but to the pirates was almost more eerie than the screech.
+
+“What was that?” cried Hook.
+
+“Two,” said Slightly solemnly.
+
+The Italian Cecco hesitated for a moment and then swung into the cabin.
+He tottered out, haggard.
+
+“What’s the matter with Bill Jukes, you dog?” hissed Hook, towering over
+him.
+
+“The matter wi’ him is he’s dead, stabbed,” replied Cecco in a hollow
+voice.
+
+“Bill Jukes dead!” cried the startled pirates.
+
+“The cabin’s as black as a pit,” Cecco said, almost gibbering, “but
+there is something terrible in there: the thing you heard crowing.”
+
+The exultation of the boys, the lowering looks of the pirates, both were
+seen by Hook.
+
+“Cecco,” he said in his most steely voice, “go back and fetch me out
+that doodle-doo.”
+
+Cecco, bravest of the brave, cowered before his captain, crying “No,
+no”; but Hook was purring to his claw.
+
+“Did you say you would go, Cecco?” he said musingly.
+
+Cecco went, first flinging his arms despairingly. There was no more
+singing, all listened now; and again came a death-screech and again a
+crow.
+
+No one spoke except Slightly. “Three,” he said.
+
+Hook rallied his dogs with a gesture. “‘S’death and odds fish,” he
+thundered, “who is to bring me that doodle-doo?”
+
+“Wait till Cecco comes out,” growled Starkey, and the others took up the
+cry.
+
+“I think I heard you volunteer, Starkey,” said Hook, purring again.
+
+“No, by thunder!” Starkey cried.
+
+“My hook thinks you did,” said Hook, crossing to him. “I wonder if it
+would not be advisable, Starkey, to humour the hook?”
+
+“I’ll swing before I go in there,” replied Starkey doggedly, and again
+he had the support of the crew.
+
+“Is this mutiny?” asked Hook more pleasantly than ever. “Starkey’s
+ringleader!”
+
+“Captain, mercy!” Starkey whimpered, all of a tremble now.
+
+“Shake hands, Starkey,” said Hook, proffering his claw.
+
+Starkey looked round for help, but all deserted him. As he backed up
+Hook advanced, and now the red spark was in his eye. With a despairing
+scream the pirate leapt upon Long Tom and precipitated himself into the
+sea.
+
+“Four,” said Slightly.
+
+“And now,” Hook said courteously, “did any other gentlemen say mutiny?”
+ Seizing a lantern and raising his claw with a menacing gesture, “I’ll
+bring out that doodle-doo myself,” he said, and sped into the cabin.
+
+“Five.” How Slightly longed to say it. He wetted his lips to be ready,
+but Hook came staggering out, without his lantern.
+
+“Something blew out the light,” he said a little unsteadily.
+
+“Something!” echoed Mullins.
+
+“What of Cecco?” demanded Noodler.
+
+“He’s as dead as Jukes,” said Hook shortly.
+
+His reluctance to return to the cabin impressed them all unfavourably,
+and the mutinous sounds again broke forth. All pirates are
+superstitious, and Cookson cried, “They do say the surest sign a ship’s
+accurst is when there’s one on board more than can be accounted for.”
+
+“I’ve heard,” muttered Mullins, “he always boards the pirate craft last.
+Had he a tail, captain?”
+
+“They say,” said another, looking viciously at Hook, “that when he comes
+it’s in the likeness of the wickedest man aboard.”
+
+“Had he a hook, captain?” asked Cookson insolently; and one after
+another took up the cry, “The ship’s doomed!” At this the children could
+not resist raising a cheer. Hook had well-nigh forgotten his prisoners,
+but as he swung round on them now his face lit up again.
+
+“Lads,” he cried to his crew, “now here’s a notion. Open the cabin door
+and drive them in. Let them fight the doodle-doo for their lives. If
+they kill him, we’re so much the better; if he kills them, we’re none
+the worse.”
+
+For the last time his dogs admired Hook, and devotedly they did his
+bidding. The boys, pretending to struggle, were pushed into the cabin
+and the door was closed on them.
+
+“Now, listen!” cried Hook, and all listened. But not one dared to face
+the door. Yes, one, Wendy, who all this time had been bound to the mast.
+It was for neither a scream nor a crow that she was watching, it was for
+the reappearance of Peter.
+
+She had not long to wait. In the cabin he had found the thing for which
+he had gone in search: the key that would free the children of their
+manacles, and now they all stole forth, armed with such weapons as they
+could find. First signing them to hide, Peter cut Wendy’s bonds,
+and then nothing could have been easier than for them all to fly off
+together; but one thing barred the way, an oath, “Hook or me this time.”
+ So when he had freed Wendy, he whispered for her to conceal herself with
+the others, and himself took her place by the mast, her cloak around him
+so that he should pass for her. Then he took a great breath and crowed.
+
+To the pirates it was a voice crying that all the boys lay slain in the
+cabin; and they were panic-stricken. Hook tried to hearten them; but
+like the dogs he had made them they showed him their fangs, and he knew
+that if he took his eyes off them now they would leap at him.
+
+“Lads,” he said, ready to cajole or strike as need be, but never
+quailing for an instant, “I’ve thought it out. There’s a Jonah aboard.”
+
+“Ay,” they snarled, “a man wi’ a hook.”
+
+“No, lads, no, it’s the girl. Never was luck on a pirate ship wi’ a
+woman on board. We’ll right the ship when she’s gone.”
+
+Some of them remembered that this had been a saying of Flint’s. “It’s
+worth trying,” they said doubtfully.
+
+“Fling the girl overboard,” cried Hook; and they made a rush at the
+figure in the cloak.
+
+“There’s none can save you now, missy,” Mullins hissed jeeringly.
+
+“There’s one,” replied the figure.
+
+“Who’s that?”
+
+“Peter Pan the avenger!” came the terrible answer; and as he spoke Peter
+flung off his cloak. Then they all knew who ‘twas that had been undoing
+them in the cabin, and twice Hook essayed to speak and twice he failed.
+In that frightful moment I think his fierce heart broke.
+
+At last he cried, “Cleave him to the brisket!” but without conviction.
+
+“Down, boys, and at them!” Peter’s voice rang out; and in another moment
+the clash of arms was resounding through the ship. Had the pirates kept
+together it is certain that they would have won; but the onset came
+when they were still unstrung, and they ran hither and thither, striking
+wildly, each thinking himself the last survivor of the crew. Man to man
+they were the stronger; but they fought on the defensive only, which
+enabled the boys to hunt in pairs and choose their quarry. Some of the
+miscreants leapt into the sea; others hid in dark recesses, where they
+were found by Slightly, who did not fight, but ran about with a lantern
+which he flashed in their faces, so that they were half blinded and
+fell as an easy prey to the reeking swords of the other boys. There was
+little sound to be heard but the clang of weapons, an occasional
+screech or splash, and Slightly monotonously counting--five--six--seven
+eight--nine--ten--eleven.
+
+I think all were gone when a group of savage boys surrounded Hook, who
+seemed to have a charmed life, as he kept them at bay in that circle
+of fire. They had done for his dogs, but this man alone seemed to be a
+match for them all. Again and again they closed upon him, and again and
+again he hewed a clear space. He had lifted up one boy with his hook,
+and was using him as a buckler [shield], when another, who had just
+passed his sword through Mullins, sprang into the fray.
+
+“Put up your swords, boys,” cried the newcomer, “this man is mine.”
+
+Thus suddenly Hook found himself face to face with Peter. The others
+drew back and formed a ring around them.
+
+For long the two enemies looked at one another, Hook shuddering
+slightly, and Peter with the strange smile upon his face.
+
+“So, Pan,” said Hook at last, “this is all your doing.”
+
+“Ay, James Hook,” came the stern answer, “it is all my doing.”
+
+“Proud and insolent youth,” said Hook, “prepare to meet thy doom.”
+
+“Dark and sinister man,” Peter answered, “have at thee.”
+
+Without more words they fell to, and for a space there was no advantage
+to either blade. Peter was a superb swordsman, and parried with dazzling
+rapidity; ever and anon he followed up a feint with a lunge that got
+past his foe’s defence, but his shorter reach stood him in ill stead,
+and he could not drive the steel home. Hook, scarcely his inferior in
+brilliancy, but not quite so nimble in wrist play, forced him back by
+the weight of his onset, hoping suddenly to end all with a favourite
+thrust, taught him long ago by Barbecue at Rio; but to his astonishment
+he found this thrust turned aside again and again. Then he sought to
+close and give the quietus with his iron hook, which all this time had
+been pawing the air; but Peter doubled under it and, lunging fiercely,
+pierced him in the ribs. At the sight of his own blood, whose peculiar
+colour, you remember, was offensive to him, the sword fell from Hook’s
+hand, and he was at Peter’s mercy.
+
+“Now!” cried all the boys, but with a magnificent gesture Peter invited
+his opponent to pick up his sword. Hook did so instantly, but with a
+tragic feeling that Peter was showing good form.
+
+Hitherto he had thought it was some fiend fighting him, but darker
+suspicions assailed him now.
+
+“Pan, who and what art thou?” he cried huskily.
+
+“I’m youth, I’m joy,” Peter answered at a venture, “I’m a little bird
+that has broken out of the egg.”
+
+This, of course, was nonsense; but it was proof to the unhappy Hook that
+Peter did not know in the least who or what he was, which is the very
+pinnacle of good form.
+
+“To’t again,” he cried despairingly.
+
+He fought now like a human flail, and every sweep of that terrible sword
+would have severed in twain any man or boy who obstructed it; but Peter
+fluttered round him as if the very wind it made blew him out of the
+danger zone. And again and again he darted in and pricked.
+
+Hook was fighting now without hope. That passionate breast no longer
+asked for life; but for one boon it craved: to see Peter show bad form
+before it was cold forever.
+
+Abandoning the fight he rushed into the powder magazine and fired it.
+
+“In two minutes,” he cried, “the ship will be blown to pieces.”
+
+Now, now, he thought, true form will show.
+
+But Peter issued from the powder magazine with the shell in his hands,
+and calmly flung it overboard.
+
+What sort of form was Hook himself showing? Misguided man though he was,
+we may be glad, without sympathising with him, that in the end he was
+true to the traditions of his race. The other boys were flying around
+him now, flouting, scornful; and he staggered about the deck striking up
+at them impotently, his mind was no longer with them; it was slouching
+in the playing fields of long ago, or being sent up [to the headmaster]
+for good, or watching the wall-game from a famous wall. And his shoes
+were right, and his waistcoat was right, and his tie was right, and his
+socks were right.
+
+James Hook, thou not wholly unheroic figure, farewell.
+
+For we have come to his last moment.
+
+Seeing Peter slowly advancing upon him through the air with dagger
+poised, he sprang upon the bulwarks to cast himself into the sea. He
+did not know that the crocodile was waiting for him; for we purposely
+stopped the clock that this knowledge might be spared him: a little mark
+of respect from us at the end.
+
+He had one last triumph, which I think we need not grudge him. As he
+stood on the bulwark looking over his shoulder at Peter gliding through
+the air, he invited him with a gesture to use his foot. It made Peter
+kick instead of stab.
+
+At last Hook had got the boon for which he craved.
+
+“Bad form,” he cried jeeringly, and went content to the crocodile.
+
+Thus perished James Hook.
+
+“Seventeen,” Slightly sang out; but he was not quite correct in his
+figures. Fifteen paid the penalty for their crimes that night; but two
+reached the shore: Starkey to be captured by the redskins, who made him
+nurse for all their papooses, a melancholy come-down for a pirate; and
+Smee, who henceforth wandered about the world in his spectacles, making
+a precarious living by saying he was the only man that Jas. Hook had
+feared.
+
+Wendy, of course, had stood by taking no part in the fight, though
+watching Peter with glistening eyes; but now that all was over she
+became prominent again. She praised them equally, and shuddered
+delightfully when Michael showed her the place where he had killed one;
+and then she took them into Hook’s cabin and pointed to his watch which
+was hanging on a nail. It said “half-past one!”
+
+The lateness of the hour was almost the biggest thing of all. She got
+them to bed in the pirates’ bunks pretty quickly, you may be sure; all
+but Peter, who strutted up and down on the deck, until at last he fell
+asleep by the side of Long Tom. He had one of his dreams that night, and
+cried in his sleep for a long time, and Wendy held him tightly.
+
+
+
+
+Chapter 16 THE RETURN HOME
+
+By three bells that morning they were all stirring their stumps [legs];
+for there was a big sea running; and Tootles, the bo’sun, was among
+them, with a rope’s end in his hand and chewing tobacco. They all donned
+pirate clothes cut off at the knee, shaved smartly, and tumbled up, with
+the true nautical roll and hitching their trousers.
+
+It need not be said who was the captain. Nibs and John were first and
+second mate. There was a woman aboard. The rest were tars [sailors]
+before the mast, and lived in the fo’c’sle. Peter had already lashed
+himself to the wheel; but he piped all hands and delivered a short
+address to them; said he hoped they would do their duty like gallant
+hearties, but that he knew they were the scum of Rio and the Gold Coast,
+and if they snapped at him he would tear them. The bluff strident words
+struck the note sailors understood, and they cheered him lustily. Then
+a few sharp orders were given, and they turned the ship round, and nosed
+her for the mainland.
+
+Captain Pan calculated, after consulting the ship’s chart, that if this
+weather lasted they should strike the Azores about the 21st of June,
+after which it would save time to fly.
+
+Some of them wanted it to be an honest ship and others were in favour
+of keeping it a pirate; but the captain treated them as dogs, and they
+dared not express their wishes to him even in a round robin [one person
+after another, as they had to Cpt. Hook]. Instant obedience was the only
+safe thing. Slightly got a dozen for looking perplexed when told to take
+soundings. The general feeling was that Peter was honest just now to
+lull Wendy’s suspicions, but that there might be a change when the new
+suit was ready, which, against her will, she was making for him out of
+some of Hook’s wickedest garments. It was afterwards whispered among
+them that on the first night he wore this suit he sat long in the cabin
+with Hook’s cigar-holder in his mouth and one hand clenched, all but for
+the forefinger, which he bent and held threateningly aloft like a hook.
+
+Instead of watching the ship, however, we must now return to that
+desolate home from which three of our characters had taken heartless
+flight so long ago. It seems a shame to have neglected No. 14 all this
+time; and yet we may be sure that Mrs. Darling does not blame us. If we
+had returned sooner to look with sorrowful sympathy at her, she would
+probably have cried, “Don’t be silly; what do I matter? Do go back and
+keep an eye on the children.” So long as mothers are like this their
+children will take advantage of them; and they may lay to [bet on] that.
+
+Even now we venture into that familiar nursery only because its lawful
+occupants are on their way home; we are merely hurrying on in advance
+of them to see that their beds are properly aired and that Mr. and Mrs.
+Darling do not go out for the evening. We are no more than servants. Why
+on earth should their beds be properly aired, seeing that they left them
+in such a thankless hurry? Would it not serve them jolly well right if
+they came back and found that their parents were spending the week-end
+in the country? It would be the moral lesson they have been in need
+of ever since we met them; but if we contrived things in this way Mrs.
+Darling would never forgive us.
+
+One thing I should like to do immensely, and that is to tell her, in the
+way authors have, that the children are coming back, that indeed they
+will be here on Thursday week. This would spoil so completely the
+surprise to which Wendy and John and Michael are looking forward. They
+have been planning it out on the ship: mother’s rapture, father’s shout
+of joy, Nana’s leap through the air to embrace them first, when what
+they ought to be prepared for is a good hiding. How delicious to spoil
+it all by breaking the news in advance; so that when they enter grandly
+Mrs. Darling may not even offer Wendy her mouth, and Mr. Darling may
+exclaim pettishly, “Dash it all, here are those boys again.” However,
+we should get no thanks even for this. We are beginning to know Mrs.
+Darling by this time, and may be sure that she would upbraid us for
+depriving the children of their little pleasure.
+
+“But, my dear madam, it is ten days till Thursday week; so that by
+telling you what’s what, we can save you ten days of unhappiness.”
+
+“Yes, but at what a cost! By depriving the children of ten minutes of
+delight.”
+
+“Oh, if you look at it in that way!”
+
+“What other way is there in which to look at it?”
+
+You see, the woman had no proper spirit. I had meant to say
+extraordinarily nice things about her; but I despise her, and not one of
+them will I say now. She does not really need to be told to have things
+ready, for they are ready. All the beds are aired, and she never leaves
+the house, and observe, the window is open. For all the use we are to
+her, we might well go back to the ship. However, as we are here we may
+as well stay and look on. That is all we are, lookers-on. Nobody really
+wants us. So let us watch and say jaggy things, in the hope that some of
+them will hurt.
+
+The only change to be seen in the night-nursery is that between nine
+and six the kennel is no longer there. When the children flew away, Mr.
+Darling felt in his bones that all the blame was his for having chained
+Nana up, and that from first to last she had been wiser than he. Of
+course, as we have seen, he was quite a simple man; indeed he might have
+passed for a boy again if he had been able to take his baldness off;
+but he had also a noble sense of justice and a lion’s courage to do what
+seemed right to him; and having thought the matter out with anxious care
+after the flight of the children, he went down on all fours and crawled
+into the kennel. To all Mrs. Darling’s dear invitations to him to come
+out he replied sadly but firmly:
+
+“No, my own one, this is the place for me.”
+
+In the bitterness of his remorse he swore that he would never leave
+the kennel until his children came back. Of course this was a pity; but
+whatever Mr. Darling did he had to do in excess, otherwise he soon gave
+up doing it. And there never was a more humble man than the once proud
+George Darling, as he sat in the kennel of an evening talking with his
+wife of their children and all their pretty ways.
+
+Very touching was his deference to Nana. He would not let her come into
+the kennel, but on all other matters he followed her wishes implicitly.
+
+Every morning the kennel was carried with Mr. Darling in it to a cab,
+which conveyed him to his office, and he returned home in the same way
+at six. Something of the strength of character of the man will be seen
+if we remember how sensitive he was to the opinion of neighbours: this
+man whose every movement now attracted surprised attention. Inwardly he
+must have suffered torture; but he preserved a calm exterior even when
+the young criticised his little home, and he always lifted his hat
+courteously to any lady who looked inside.
+
+It may have been Quixotic, but it was magnificent. Soon the inward
+meaning of it leaked out, and the great heart of the public was touched.
+Crowds followed the cab, cheering it lustily; charming girls scaled it
+to get his autograph; interviews appeared in the better class of papers,
+and society invited him to dinner and added, “Do come in the kennel.”
+
+On that eventful Thursday week, Mrs. Darling was in the night-nursery
+awaiting George’s return home; a very sad-eyed woman. Now that we look
+at her closely and remember the gaiety of her in the old days, all gone
+now just because she has lost her babes, I find I won’t be able to say
+nasty things about her after all. If she was too fond of her rubbishy
+children, she couldn’t help it. Look at her in her chair, where she has
+fallen asleep. The corner of her mouth, where one looks first, is almost
+withered up. Her hand moves restlessly on her breast as if she had a
+pain there. Some like Peter best, and some like Wendy best, but I like
+her best. Suppose, to make her happy, we whisper to her in her sleep
+that the brats are coming back. They are really within two miles of the
+window now, and flying strong, but all we need whisper is that they are
+on the way. Let’s.
+
+It is a pity we did it, for she has started up, calling their names; and
+there is no one in the room but Nana.
+
+“O Nana, I dreamt my dear ones had come back.”
+
+Nana had filmy eyes, but all she could do was put her paw gently on her
+mistress’s lap; and they were sitting together thus when the kennel was
+brought back. As Mr. Darling puts his head out to kiss his wife, we see
+that his face is more worn than of yore, but has a softer expression.
+
+He gave his hat to Liza, who took it scornfully; for she had no
+imagination, and was quite incapable of understanding the motives of
+such a man. Outside, the crowd who had accompanied the cab home were
+still cheering, and he was naturally not unmoved.
+
+“Listen to them,” he said; “it is very gratifying.”
+
+“Lots of little boys,” sneered Liza.
+
+“There were several adults to-day,” he assured her with a faint flush;
+but when she tossed her head he had not a word of reproof for her.
+Social success had not spoilt him; it had made him sweeter. For some
+time he sat with his head out of the kennel, talking with Mrs. Darling
+of this success, and pressing her hand reassuringly when she said she
+hoped his head would not be turned by it.
+
+“But if I had been a weak man,” he said. “Good heavens, if I had been a
+weak man!”
+
+“And, George,” she said timidly, “you are as full of remorse as ever,
+aren’t you?”
+
+“Full of remorse as ever, dearest! See my punishment: living in a
+kennel.”
+
+“But it is punishment, isn’t it, George? You are sure you are not
+enjoying it?”
+
+“My love!”
+
+You may be sure she begged his pardon; and then, feeling drowsy, he
+curled round in the kennel.
+
+“Won’t you play me to sleep,” he asked, “on the nursery piano?” and as
+she was crossing to the day-nursery he added thoughtlessly, “And shut
+that window. I feel a draught.”
+
+“O George, never ask me to do that. The window must always be left open
+for them, always, always.”
+
+Now it was his turn to beg her pardon; and she went into the day-nursery
+and played, and soon he was asleep; and while he slept, Wendy and John
+and Michael flew into the room.
+
+Oh no. We have written it so, because that was the charming arrangement
+planned by them before we left the ship; but something must have
+happened since then, for it is not they who have flown in, it is Peter
+and Tinker Bell.
+
+Peter’s first words tell all.
+
+“Quick Tink,” he whispered, “close the window; bar it! That’s right. Now
+you and I must get away by the door; and when Wendy comes she will think
+her mother has barred her out; and she will have to go back with me.”
+
+Now I understand what had hitherto puzzled me, why when Peter had
+exterminated the pirates he did not return to the island and leave Tink
+to escort the children to the mainland. This trick had been in his head
+all the time.
+
+Instead of feeling that he was behaving badly he danced with glee; then
+he peeped into the day-nursery to see who was playing. He whispered to
+Tink, “It’s Wendy’s mother! She is a pretty lady, but not so pretty as
+my mother. Her mouth is full of thimbles, but not so full as my mother’s
+was.”
+
+Of course he knew nothing whatever about his mother; but he sometimes
+bragged about her.
+
+He did not know the tune, which was “Home, Sweet Home,” but he knew it
+was saying, “Come back, Wendy, Wendy, Wendy”; and he cried exultantly,
+“You will never see Wendy again, lady, for the window is barred!”
+
+He peeped in again to see why the music had stopped, and now he saw
+that Mrs. Darling had laid her head on the box, and that two tears were
+sitting on her eyes.
+
+“She wants me to unbar the window,” thought Peter, “but I won’t, not I!”
+
+He peeped again, and the tears were still there, or another two had
+taken their place.
+
+“She’s awfully fond of Wendy,” he said to himself. He was angry with her
+now for not seeing why she could not have Wendy.
+
+The reason was so simple: “I’m fond of her too. We can’t both have her,
+lady.”
+
+But the lady would not make the best of it, and he was unhappy. He
+ceased to look at her, but even then she would not let go of him. He
+skipped about and made funny faces, but when he stopped it was just as
+if she were inside him, knocking.
+
+“Oh, all right,” he said at last, and gulped. Then he unbarred the
+window. “Come on, Tink,” he cried, with a frightful sneer at the laws of
+nature; “we don’t want any silly mothers;” and he flew away.
+
+Thus Wendy and John and Michael found the window open for them after
+all, which of course was more than they deserved. They alighted on the
+floor, quite unashamed of themselves, and the youngest one had already
+forgotten his home.
+
+“John,” he said, looking around him doubtfully, “I think I have been
+here before.”
+
+“Of course you have, you silly. There is your old bed.”
+
+“So it is,” Michael said, but not with much conviction.
+
+“I say,” cried John, “the kennel!” and he dashed across to look into it.
+
+“Perhaps Nana is inside it,” Wendy said.
+
+But John whistled. “Hullo,” he said, “there’s a man inside it.”
+
+“It’s father!” exclaimed Wendy.
+
+“Let me see father,” Michael begged eagerly, and he took a good look.
+“He is not so big as the pirate I killed,” he said with such frank
+disappointment that I am glad Mr. Darling was asleep; it would have been
+sad if those had been the first words he heard his little Michael say.
+
+Wendy and John had been taken aback somewhat at finding their father in
+the kennel.
+
+“Surely,” said John, like one who had lost faith in his memory, “he used
+not to sleep in the kennel?”
+
+“John,” Wendy said falteringly, “perhaps we don’t remember the old life
+as well as we thought we did.”
+
+A chill fell upon them; and serve them right.
+
+“It is very careless of mother,” said that young scoundrel John, “not to
+be here when we come back.”
+
+It was then that Mrs. Darling began playing again.
+
+“It’s mother!” cried Wendy, peeping.
+
+“So it is!” said John.
+
+“Then are you not really our mother, Wendy?” asked Michael, who was
+surely sleepy.
+
+“Oh dear!” exclaimed Wendy, with her first real twinge of remorse [for
+having gone], “it was quite time we came back.”
+
+“Let us creep in,” John suggested, “and put our hands over her eyes.”
+
+But Wendy, who saw that they must break the joyous news more gently, had
+a better plan.
+
+“Let us all slip into our beds, and be there when she comes in, just as
+if we had never been away.”
+
+And so when Mrs. Darling went back to the night-nursery to see if her
+husband was asleep, all the beds were occupied. The children waited
+for her cry of joy, but it did not come. She saw them, but she did not
+believe they were there. You see, she saw them in their beds so often in
+her dreams that she thought this was just the dream hanging around her
+still.
+
+She sat down in the chair by the fire, where in the old days she had
+nursed them.
+
+They could not understand this, and a cold fear fell upon all the three
+of them.
+
+“Mother!” Wendy cried.
+
+“That’s Wendy,” she said, but still she was sure it was the dream.
+
+“Mother!”
+
+“That’s John,” she said.
+
+“Mother!” cried Michael. He knew her now.
+
+“That’s Michael,” she said, and she stretched out her arms for the three
+little selfish children they would never envelop again. Yes, they did,
+they went round Wendy and John and Michael, who had slipped out of bed
+and run to her.
+
+“George, George!” she cried when she could speak; and Mr. Darling woke
+to share her bliss, and Nana came rushing in. There could not have been
+a lovelier sight; but there was none to see it except a little boy who
+was staring in at the window. He had had ecstasies innumerable that
+other children can never know; but he was looking through the window at
+the one joy from which he must be for ever barred.
+
+
+
+
+Chapter 17 WHEN WENDY GREW UP
+
+I hope you want to know what became of the other boys. They were waiting
+below to give Wendy time to explain about them; and when they had
+counted five hundred they went up. They went up by the stair, because
+they thought this would make a better impression. They stood in a row
+in front of Mrs. Darling, with their hats off, and wishing they were not
+wearing their pirate clothes. They said nothing, but their eyes asked
+her to have them. They ought to have looked at Mr. Darling also, but
+they forgot about him.
+
+Of course Mrs. Darling said at once that she would have them; but Mr.
+Darling was curiously depressed, and they saw that he considered six a
+rather large number.
+
+“I must say,” he said to Wendy, “that you don’t do things by halves,” a
+grudging remark which the twins thought was pointed at them.
+
+The first twin was the proud one, and he asked, flushing, “Do you think
+we should be too much of a handful, sir? Because, if so, we can go
+away.”
+
+“Father!” Wendy cried, shocked; but still the cloud was on him. He knew
+he was behaving unworthily, but he could not help it.
+
+“We could lie doubled up,” said Nibs.
+
+“I always cut their hair myself,” said Wendy.
+
+“George!” Mrs. Darling exclaimed, pained to see her dear one showing
+himself in such an unfavourable light.
+
+Then he burst into tears, and the truth came out. He was as glad to
+have them as she was, he said, but he thought they should have asked his
+consent as well as hers, instead of treating him as a cypher [zero] in
+his own house.
+
+“I don’t think he is a cypher,” Tootles cried instantly. “Do you think
+he is a cypher, Curly?”
+
+“No, I don’t. Do you think he is a cypher, Slightly?”
+
+“Rather not. Twin, what do you think?”
+
+It turned out that not one of them thought him a cypher; and he was
+absurdly gratified, and said he would find space for them all in the
+drawing-room if they fitted in.
+
+“We’ll fit in, sir,” they assured him.
+
+“Then follow the leader,” he cried gaily. “Mind you, I am not sure that
+we have a drawing-room, but we pretend we have, and it’s all the same.
+Hoop la!”
+
+He went off dancing through the house, and they all cried “Hoop la!” and
+danced after him, searching for the drawing-room; and I forget whether
+they found it, but at any rate they found corners, and they all fitted
+in.
+
+As for Peter, he saw Wendy once again before he flew away. He did not
+exactly come to the window, but he brushed against it in passing so that
+she could open it if she liked and call to him. That is what she did.
+
+“Hullo, Wendy, good-bye,” he said.
+
+“Oh dear, are you going away?”
+
+“Yes.”
+
+“You don’t feel, Peter,” she said falteringly, “that you would like to
+say anything to my parents about a very sweet subject?”
+
+“No.”
+
+“About me, Peter?”
+
+“No.”
+
+Mrs. Darling came to the window, for at present she was keeping a sharp
+eye on Wendy. She told Peter that she had adopted all the other boys,
+and would like to adopt him also.
+
+“Would you send me to school?” he inquired craftily.
+
+“Yes.”
+
+“And then to an office?”
+
+“I suppose so.”
+
+“Soon I would be a man?”
+
+“Very soon.”
+
+“I don’t want to go to school and learn solemn things,” he told her
+passionately. “I don’t want to be a man. O Wendy’s mother, if I was to
+wake up and feel there was a beard!”
+
+“Peter,” said Wendy the comforter, “I should love you in a beard;” and
+Mrs. Darling stretched out her arms to him, but he repulsed her.
+
+“Keep back, lady, no one is going to catch me and make me a man.”
+
+“But where are you going to live?”
+
+“With Tink in the house we built for Wendy. The fairies are to put it
+high up among the tree tops where they sleep at nights.”
+
+“How lovely,” cried Wendy so longingly that Mrs. Darling tightened her
+grip.
+
+“I thought all the fairies were dead,” Mrs. Darling said.
+
+“There are always a lot of young ones,” explained Wendy, who was now
+quite an authority, “because you see when a new baby laughs for the
+first time a new fairy is born, and as there are always new babies there
+are always new fairies. They live in nests on the tops of trees; and the
+mauve ones are boys and the white ones are girls, and the blue ones are
+just little sillies who are not sure what they are.”
+
+“I shall have such fun,” said Peter, with eye on Wendy.
+
+“It will be rather lonely in the evening,” she said, “sitting by the
+fire.”
+
+“I shall have Tink.”
+
+“Tink can’t go a twentieth part of the way round,” she reminded him a
+little tartly.
+
+“Sneaky tell-tale!” Tink called out from somewhere round the corner.
+
+“It doesn’t matter,” Peter said.
+
+“O Peter, you know it matters.”
+
+“Well, then, come with me to the little house.”
+
+“May I, mummy?”
+
+“Certainly not. I have got you home again, and I mean to keep you.”
+
+“But he does so need a mother.”
+
+“So do you, my love.”
+
+“Oh, all right,” Peter said, as if he had asked her from politeness
+merely; but Mrs. Darling saw his mouth twitch, and she made this
+handsome offer: to let Wendy go to him for a week every year to do
+his spring cleaning. Wendy would have preferred a more permanent
+arrangement; and it seemed to her that spring would be long in coming;
+but this promise sent Peter away quite gay again. He had no sense of
+time, and was so full of adventures that all I have told you about him
+is only a halfpenny-worth of them. I suppose it was because Wendy knew
+this that her last words to him were these rather plaintive ones:
+
+“You won’t forget me, Peter, will you, before spring cleaning time
+comes?”
+
+Of course Peter promised; and then he flew away. He took Mrs. Darling’s
+kiss with him. The kiss that had been for no one else, Peter took quite
+easily. Funny. But she seemed satisfied.
+
+Of course all the boys went to school; and most of them got into Class
+III, but Slightly was put first into Class IV and then into Class V.
+Class I is the top class. Before they had attended school a week they
+saw what goats they had been not to remain on the island; but it was too
+late now, and soon they settled down to being as ordinary as you or me
+or Jenkins minor [the younger Jenkins]. It is sad to have to say that
+the power to fly gradually left them. At first Nana tied their feet to
+the bed-posts so that they should not fly away in the night; and one of
+their diversions by day was to pretend to fall off buses [the English
+double-deckers]; but by and by they ceased to tug at their bonds in bed,
+and found that they hurt themselves when they let go of the bus. In time
+they could not even fly after their hats. Want of practice, they called
+it; but what it really meant was that they no longer believed.
+
+Michael believed longer than the other boys, though they jeered at him;
+so he was with Wendy when Peter came for her at the end of the first
+year. She flew away with Peter in the frock she had woven from leaves
+and berries in the Neverland, and her one fear was that he might notice
+how short it had become; but he never noticed, he had so much to say
+about himself.
+
+She had looked forward to thrilling talks with him about old times, but
+new adventures had crowded the old ones from his mind.
+
+“Who is Captain Hook?” he asked with interest when she spoke of the arch
+enemy.
+
+“Don’t you remember,” she asked, amazed, “how you killed him and saved
+all our lives?”
+
+“I forget them after I kill them,” he replied carelessly.
+
+When she expressed a doubtful hope that Tinker Bell would be glad to see
+her he said, “Who is Tinker Bell?”
+
+“O Peter,” she said, shocked; but even when she explained he could not
+remember.
+
+“There are such a lot of them,” he said. “I expect she is no more.”
+
+I expect he was right, for fairies don’t live long, but they are so
+little that a short time seems a good while to them.
+
+Wendy was pained too to find that the past year was but as yesterday
+to Peter; it had seemed such a long year of waiting to her. But he was
+exactly as fascinating as ever, and they had a lovely spring cleaning in
+the little house on the tree tops.
+
+Next year he did not come for her. She waited in a new frock because the
+old one simply would not meet; but he never came.
+
+“Perhaps he is ill,” Michael said.
+
+“You know he is never ill.”
+
+Michael came close to her and whispered, with a shiver, “Perhaps there
+is no such person, Wendy!” and then Wendy would have cried if Michael
+had not been crying.
+
+Peter came next spring cleaning; and the strange thing was that he never
+knew he had missed a year.
+
+That was the last time the girl Wendy ever saw him. For a little longer
+she tried for his sake not to have growing pains; and she felt she was
+untrue to him when she got a prize for general knowledge. But the years
+came and went without bringing the careless boy; and when they met again
+Wendy was a married woman, and Peter was no more to her than a little
+dust in the box in which she had kept her toys. Wendy was grown up. You
+need not be sorry for her. She was one of the kind that likes to grow
+up. In the end she grew up of her own free will a day quicker than other
+girls.
+
+All the boys were grown up and done for by this time; so it is scarcely
+worth while saying anything more about them. You may see the twins and
+Nibs and Curly any day going to an office, each carrying a little bag
+and an umbrella. Michael is an engine-driver [train engineer]. Slightly
+married a lady of title, and so he became a lord. You see that judge in
+a wig coming out at the iron door? That used to be Tootles. The bearded
+man who doesn’t know any story to tell his children was once John.
+
+Wendy was married in white with a pink sash. It is strange to think
+that Peter did not alight in the church and forbid the banns [formal
+announcement of a marriage].
+
+Years rolled on again, and Wendy had a daughter. This ought not to be
+written in ink but in a golden splash.
+
+She was called Jane, and always had an odd inquiring look, as if from
+the moment she arrived on the mainland she wanted to ask questions. When
+she was old enough to ask them they were mostly about Peter Pan. She
+loved to hear of Peter, and Wendy told her all she could remember in the
+very nursery from which the famous flight had taken place. It was
+Jane’s nursery now, for her father had bought it at the three per cents
+[mortgage rate] from Wendy’s father, who was no longer fond of stairs.
+Mrs. Darling was now dead and forgotten.
+
+There were only two beds in the nursery now, Jane’s and her nurse’s; and
+there was no kennel, for Nana also had passed away. She died of old age,
+and at the end she had been rather difficult to get on with; being very
+firmly convinced that no one knew how to look after children except
+herself.
+
+Once a week Jane’s nurse had her evening off; and then it was Wendy’s
+part to put Jane to bed. That was the time for stories. It was Jane’s
+invention to raise the sheet over her mother’s head and her own, thus
+making a tent, and in the awful darkness to whisper:
+
+“What do we see now?”
+
+“I don’t think I see anything to-night,” says Wendy, with a feeling that
+if Nana were here she would object to further conversation.
+
+“Yes, you do,” says Jane, “you see when you were a little girl.”
+
+“That is a long time ago, sweetheart,” says Wendy. “Ah me, how time
+flies!”
+
+“Does it fly,” asks the artful child, “the way you flew when you were a
+little girl?”
+
+“The way I flew? Do you know, Jane, I sometimes wonder whether I ever
+did really fly.”
+
+“Yes, you did.”
+
+“The dear old days when I could fly!”
+
+“Why can’t you fly now, mother?”
+
+“Because I am grown up, dearest. When people grow up they forget the
+way.”
+
+“Why do they forget the way?”
+
+“Because they are no longer gay and innocent and heartless. It is only
+the gay and innocent and heartless who can fly.”
+
+“What is gay and innocent and heartless? I do wish I were gay and
+innocent and heartless.”
+
+Or perhaps Wendy admits she does see something.
+
+“I do believe,” she says, “that it is this nursery.”
+
+“I do believe it is,” says Jane. “Go on.”
+
+They are now embarked on the great adventure of the night when Peter
+flew in looking for his shadow.
+
+“The foolish fellow,” says Wendy, “tried to stick it on with soap, and
+when he could not he cried, and that woke me, and I sewed it on for
+him.”
+
+“You have missed a bit,” interrupts Jane, who now knows the story better
+than her mother. “When you saw him sitting on the floor crying, what did
+you say?”
+
+“I sat up in bed and I said, ‘Boy, why are you crying?’”
+
+“Yes, that was it,” says Jane, with a big breath.
+
+“And then he flew us all away to the Neverland and the fairies and the
+pirates and the redskins and the mermaids’ lagoon, and the home under
+the ground, and the little house.”
+
+“Yes! which did you like best of all?”
+
+“I think I liked the home under the ground best of all.”
+
+“Yes, so do I. What was the last thing Peter ever said to you?”
+
+“The last thing he ever said to me was, ‘Just always be waiting for me,
+and then some night you will hear me crowing.’”
+
+“Yes.”
+
+“But, alas, he forgot all about me,” Wendy said it with a smile. She was
+as grown up as that.
+
+“What did his crow sound like?” Jane asked one evening.
+
+“It was like this,” Wendy said, trying to imitate Peter’s crow.
+
+“No, it wasn’t,” Jane said gravely, “it was like this;” and she did it
+ever so much better than her mother.
+
+Wendy was a little startled. “My darling, how can you know?”
+
+“I often hear it when I am sleeping,” Jane said.
+
+“Ah yes, many girls hear it when they are sleeping, but I was the only
+one who heard it awake.”
+
+“Lucky you,” said Jane.
+
+And then one night came the tragedy. It was the spring of the year, and
+the story had been told for the night, and Jane was now asleep in her
+bed. Wendy was sitting on the floor, very close to the fire, so as to
+see to darn, for there was no other light in the nursery; and while she
+sat darning she heard a crow. Then the window blew open as of old, and
+Peter dropped in on the floor.
+
+He was exactly the same as ever, and Wendy saw at once that he still had
+all his first teeth.
+
+He was a little boy, and she was grown up. She huddled by the fire not
+daring to move, helpless and guilty, a big woman.
+
+“Hullo, Wendy,” he said, not noticing any difference, for he was
+thinking chiefly of himself; and in the dim light her white dress might
+have been the nightgown in which he had seen her first.
+
+“Hullo, Peter,” she replied faintly, squeezing herself as small as
+possible. Something inside her was crying “Woman, Woman, let go of me.”
+
+“Hullo, where is John?” he asked, suddenly missing the third bed.
+
+“John is not here now,” she gasped.
+
+“Is Michael asleep?” he asked, with a careless glance at Jane.
+
+“Yes,” she answered; and now she felt that she was untrue to Jane as
+well as to Peter.
+
+“That is not Michael,” she said quickly, lest a judgment should fall on
+her.
+
+Peter looked. “Hullo, is it a new one?”
+
+“Yes.”
+
+“Boy or girl?”
+
+“Girl.”
+
+Now surely he would understand; but not a bit of it.
+
+“Peter,” she said, faltering, “are you expecting me to fly away with
+you?”
+
+“Of course; that is why I have come.” He added a little sternly, “Have
+you forgotten that this is spring cleaning time?”
+
+She knew it was useless to say that he had let many spring cleaning
+times pass.
+
+“I can’t come,” she said apologetically, “I have forgotten how to fly.”
+
+“I’ll soon teach you again.”
+
+“O Peter, don’t waste the fairy dust on me.”
+
+She had risen; and now at last a fear assailed him. “What is it?” he
+cried, shrinking.
+
+“I will turn up the light,” she said, “and then you can see for
+yourself.”
+
+For almost the only time in his life that I know of, Peter was afraid.
+“Don’t turn up the light,” he cried.
+
+She let her hands play in the hair of the tragic boy. She was not a
+little girl heart-broken about him; she was a grown woman smiling at it
+all, but they were wet-eyed smiles.
+
+Then she turned up the light, and Peter saw. He gave a cry of pain; and
+when the tall beautiful creature stooped to lift him in her arms he drew
+back sharply.
+
+“What is it?” he cried again.
+
+She had to tell him.
+
+“I am old, Peter. I am ever so much more than twenty. I grew up long
+ago.”
+
+“You promised not to!”
+
+“I couldn’t help it. I am a married woman, Peter.”
+
+“No, you’re not.”
+
+“Yes, and the little girl in the bed is my baby.”
+
+“No, she’s not.”
+
+But he supposed she was; and he took a step towards the sleeping child
+with his dagger upraised. Of course he did not strike. He sat down on
+the floor instead and sobbed; and Wendy did not know how to comfort him,
+though she could have done it so easily once. She was only a woman now,
+and she ran out of the room to try to think.
+
+Peter continued to cry, and soon his sobs woke Jane. She sat up in bed,
+and was interested at once.
+
+“Boy,” she said, “why are you crying?”
+
+Peter rose and bowed to her, and she bowed to him from the bed.
+
+“Hullo,” he said.
+
+“Hullo,” said Jane.
+
+“My name is Peter Pan,” he told her.
+
+“Yes, I know.”
+
+“I came back for my mother,” he explained, “to take her to the
+Neverland.”
+
+“Yes, I know,” Jane said, “I have been waiting for you.”
+
+When Wendy returned diffidently she found Peter sitting on the bed-post
+crowing gloriously, while Jane in her nighty was flying round the room
+in solemn ecstasy.
+
+“She is my mother,” Peter explained; and Jane descended and stood by his
+side, with the look in her face that he liked to see on ladies when they
+gazed at him.
+
+“He does so need a mother,” Jane said.
+
+“Yes, I know,” Wendy admitted rather forlornly; “no one knows it so well
+as I.”
+
+“Good-bye,” said Peter to Wendy; and he rose in the air, and the
+shameless Jane rose with him; it was already her easiest way of moving
+about.
+
+Wendy rushed to the window.
+
+“No, no,” she cried.
+
+“It is just for spring cleaning time,” Jane said, “he wants me always to
+do his spring cleaning.”
+
+“If only I could go with you,” Wendy sighed.
+
+“You see you can’t fly,” said Jane.
+
+Of course in the end Wendy let them fly away together. Our last glimpse
+of her shows her at the window, watching them receding into the sky
+until they were as small as stars.
+
+As you look at Wendy, you may see her hair becoming white, and her
+figure little again, for all this happened long ago. Jane is now a
+common grown-up, with a daughter called Margaret; and every spring
+cleaning time, except when he forgets, Peter comes for Margaret and
+takes her to the Neverland, where she tells him stories about himself,
+to which he listens eagerly. When Margaret grows up she will have a
+daughter, who is to be Peter’s mother in turn; and thus it will go on,
+so long as children are gay and innocent and heartless.
+
+
+THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+***** This file should be named 16-0.txt or 16-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/16/
+
+
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in the
+General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You may
+use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://www.gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+This particular work is one of the few copyrighted individual works
+included with the permission of the copyright holder.  Information on
+the copyright owner for this particular work and the terms of use
+imposed by the copyright holder on this work are set forth at the
+beginning of this work.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS,’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Each eBook is in a subdirectory of the same number as the eBook’s
+eBook number, often in several formats including plain vanilla ASCII,
+compressed (zipped), HTML and others.
+
+Corrected EDITIONS of our eBooks replace the old file and take over
+the old filename and etext number.  The replaced older file is renamed.
+VERSIONS based on separate sources are treated as new eBooks receiving
+new filenames and etext numbers.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+EBooks posted prior to November 2003, with eBook numbers BELOW #10000,
+are filed in directories based on their release date.  If you want to
+download any of these eBooks directly, rather than using the regular
+search system you may utilize the following addresses and just
+download by the etext year.
+
+http://www.ibiblio.org/gutenberg/etext06
+
+    (Or /etext 05, 04, 03, 02, 01, 00, 99,
+     98, 97, 96, 95, 94, 93, 92, 92, 91 or 90)
+
+EBooks posted since November 2003, with etext numbers OVER #10000, are
+filed in a different way.  The year of a release date is no longer part
+of the directory path.  The path is based on the etext number (which is
+identical to the filename).  The path to the file is made up of single
+digits corresponding to all but the last digit in the filename.  For
+example an eBook of filename 10234 would be found at:
+
+http://www.gutenberg.org/1/0/2/3/10234
+
+or filename 24689 would be found at:
+http://www.gutenberg.org/2/4/6/8/24689
+
+An alternative method of locating eBooks:
+http://www.gutenberg.org/GUTINDEX.ALL
+
+*** END: FULL LICENSE ***

--- a/jet/hadoop/src/main/resources/books/pride-and-prejudice.txt
+++ b/jet/hadoop/src/main/resources/books/pride-and-prejudice.txt
@@ -1,0 +1,13427 @@
+﻿The Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Pride and Prejudice
+
+Author: Jane Austen
+
+Posting Date: August 26, 2008 [EBook #1342]
+Release Date: June, 1998
+Last Updated: October 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+
+
+
+Produced by Anonymous Volunteers
+
+
+
+
+
+PRIDE AND PREJUDICE
+
+By Jane Austen
+
+
+
+Chapter 1
+
+
+It is a truth universally acknowledged, that a single man in possession
+of a good fortune, must be in want of a wife.
+
+However little known the feelings or views of such a man may be on his
+first entering a neighbourhood, this truth is so well fixed in the minds
+of the surrounding families, that he is considered the rightful property
+of some one or other of their daughters.
+
+“My dear Mr. Bennet,” said his lady to him one day, “have you heard that
+Netherfield Park is let at last?”
+
+Mr. Bennet replied that he had not.
+
+“But it is,” returned she; “for Mrs. Long has just been here, and she
+told me all about it.”
+
+Mr. Bennet made no answer.
+
+“Do you not want to know who has taken it?” cried his wife impatiently.
+
+“_You_ want to tell me, and I have no objection to hearing it.”
+
+This was invitation enough.
+
+“Why, my dear, you must know, Mrs. Long says that Netherfield is taken
+by a young man of large fortune from the north of England; that he came
+down on Monday in a chaise and four to see the place, and was so much
+delighted with it, that he agreed with Mr. Morris immediately; that he
+is to take possession before Michaelmas, and some of his servants are to
+be in the house by the end of next week.”
+
+“What is his name?”
+
+“Bingley.”
+
+“Is he married or single?”
+
+“Oh! Single, my dear, to be sure! A single man of large fortune; four or
+five thousand a year. What a fine thing for our girls!”
+
+“How so? How can it affect them?”
+
+“My dear Mr. Bennet,” replied his wife, “how can you be so tiresome! You
+must know that I am thinking of his marrying one of them.”
+
+“Is that his design in settling here?”
+
+“Design! Nonsense, how can you talk so! But it is very likely that he
+_may_ fall in love with one of them, and therefore you must visit him as
+soon as he comes.”
+
+“I see no occasion for that. You and the girls may go, or you may send
+them by themselves, which perhaps will be still better, for as you are
+as handsome as any of them, Mr. Bingley may like you the best of the
+party.”
+
+“My dear, you flatter me. I certainly _have_ had my share of beauty, but
+I do not pretend to be anything extraordinary now. When a woman has five
+grown-up daughters, she ought to give over thinking of her own beauty.”
+
+“In such cases, a woman has not often much beauty to think of.”
+
+“But, my dear, you must indeed go and see Mr. Bingley when he comes into
+the neighbourhood.”
+
+“It is more than I engage for, I assure you.”
+
+“But consider your daughters. Only think what an establishment it would
+be for one of them. Sir William and Lady Lucas are determined to
+go, merely on that account, for in general, you know, they visit no
+newcomers. Indeed you must go, for it will be impossible for _us_ to
+visit him if you do not.”
+
+“You are over-scrupulous, surely. I dare say Mr. Bingley will be very
+glad to see you; and I will send a few lines by you to assure him of my
+hearty consent to his marrying whichever he chooses of the girls; though
+I must throw in a good word for my little Lizzy.”
+
+“I desire you will do no such thing. Lizzy is not a bit better than the
+others; and I am sure she is not half so handsome as Jane, nor half so
+good-humoured as Lydia. But you are always giving _her_ the preference.”
+
+“They have none of them much to recommend them,” replied he; “they are
+all silly and ignorant like other girls; but Lizzy has something more of
+quickness than her sisters.”
+
+“Mr. Bennet, how _can_ you abuse your own children in such a way? You
+take delight in vexing me. You have no compassion for my poor nerves.”
+
+“You mistake me, my dear. I have a high respect for your nerves. They
+are my old friends. I have heard you mention them with consideration
+these last twenty years at least.”
+
+“Ah, you do not know what I suffer.”
+
+“But I hope you will get over it, and live to see many young men of four
+thousand a year come into the neighbourhood.”
+
+“It will be no use to us, if twenty such should come, since you will not
+visit them.”
+
+“Depend upon it, my dear, that when there are twenty, I will visit them
+all.”
+
+Mr. Bennet was so odd a mixture of quick parts, sarcastic humour,
+reserve, and caprice, that the experience of three-and-twenty years had
+been insufficient to make his wife understand his character. _Her_ mind
+was less difficult to develop. She was a woman of mean understanding,
+little information, and uncertain temper. When she was discontented,
+she fancied herself nervous. The business of her life was to get her
+daughters married; its solace was visiting and news.
+
+
+
+Chapter 2
+
+
+Mr. Bennet was among the earliest of those who waited on Mr. Bingley. He
+had always intended to visit him, though to the last always assuring
+his wife that he should not go; and till the evening after the visit was
+paid she had no knowledge of it. It was then disclosed in the following
+manner. Observing his second daughter employed in trimming a hat, he
+suddenly addressed her with:
+
+“I hope Mr. Bingley will like it, Lizzy.”
+
+“We are not in a way to know _what_ Mr. Bingley likes,” said her mother
+resentfully, “since we are not to visit.”
+
+“But you forget, mamma,” said Elizabeth, “that we shall meet him at the
+assemblies, and that Mrs. Long promised to introduce him.”
+
+“I do not believe Mrs. Long will do any such thing. She has two nieces
+of her own. She is a selfish, hypocritical woman, and I have no opinion
+of her.”
+
+“No more have I,” said Mr. Bennet; “and I am glad to find that you do
+not depend on her serving you.”
+
+Mrs. Bennet deigned not to make any reply, but, unable to contain
+herself, began scolding one of her daughters.
+
+“Don’t keep coughing so, Kitty, for Heaven’s sake! Have a little
+compassion on my nerves. You tear them to pieces.”
+
+“Kitty has no discretion in her coughs,” said her father; “she times
+them ill.”
+
+“I do not cough for my own amusement,” replied Kitty fretfully. “When is
+your next ball to be, Lizzy?”
+
+“To-morrow fortnight.”
+
+“Aye, so it is,” cried her mother, “and Mrs. Long does not come back
+till the day before; so it will be impossible for her to introduce him,
+for she will not know him herself.”
+
+“Then, my dear, you may have the advantage of your friend, and introduce
+Mr. Bingley to _her_.”
+
+“Impossible, Mr. Bennet, impossible, when I am not acquainted with him
+myself; how can you be so teasing?”
+
+“I honour your circumspection. A fortnight’s acquaintance is certainly
+very little. One cannot know what a man really is by the end of a
+fortnight. But if _we_ do not venture somebody else will; and after all,
+Mrs. Long and her neices must stand their chance; and, therefore, as
+she will think it an act of kindness, if you decline the office, I will
+take it on myself.”
+
+The girls stared at their father. Mrs. Bennet said only, “Nonsense,
+nonsense!”
+
+“What can be the meaning of that emphatic exclamation?” cried he. “Do
+you consider the forms of introduction, and the stress that is laid on
+them, as nonsense? I cannot quite agree with you _there_. What say you,
+Mary? For you are a young lady of deep reflection, I know, and read
+great books and make extracts.”
+
+Mary wished to say something sensible, but knew not how.
+
+“While Mary is adjusting her ideas,” he continued, “let us return to Mr.
+Bingley.”
+
+“I am sick of Mr. Bingley,” cried his wife.
+
+“I am sorry to hear _that_; but why did not you tell me that before? If
+I had known as much this morning I certainly would not have called
+on him. It is very unlucky; but as I have actually paid the visit, we
+cannot escape the acquaintance now.”
+
+The astonishment of the ladies was just what he wished; that of Mrs.
+Bennet perhaps surpassing the rest; though, when the first tumult of joy
+was over, she began to declare that it was what she had expected all the
+while.
+
+“How good it was in you, my dear Mr. Bennet! But I knew I should
+persuade you at last. I was sure you loved your girls too well to
+neglect such an acquaintance. Well, how pleased I am! and it is such a
+good joke, too, that you should have gone this morning and never said a
+word about it till now.”
+
+“Now, Kitty, you may cough as much as you choose,” said Mr. Bennet; and,
+as he spoke, he left the room, fatigued with the raptures of his wife.
+
+“What an excellent father you have, girls!” said she, when the door was
+shut. “I do not know how you will ever make him amends for his kindness;
+or me, either, for that matter. At our time of life it is not so
+pleasant, I can tell you, to be making new acquaintances every day; but
+for your sakes, we would do anything. Lydia, my love, though you _are_
+the youngest, I dare say Mr. Bingley will dance with you at the next
+ball.”
+
+“Oh!” said Lydia stoutly, “I am not afraid; for though I _am_ the
+youngest, I’m the tallest.”
+
+The rest of the evening was spent in conjecturing how soon he would
+return Mr. Bennet’s visit, and determining when they should ask him to
+dinner.
+
+
+
+Chapter 3
+
+
+Not all that Mrs. Bennet, however, with the assistance of her five
+daughters, could ask on the subject, was sufficient to draw from her
+husband any satisfactory description of Mr. Bingley. They attacked him
+in various ways--with barefaced questions, ingenious suppositions, and
+distant surmises; but he eluded the skill of them all, and they were at
+last obliged to accept the second-hand intelligence of their neighbour,
+Lady Lucas. Her report was highly favourable. Sir William had been
+delighted with him. He was quite young, wonderfully handsome, extremely
+agreeable, and, to crown the whole, he meant to be at the next assembly
+with a large party. Nothing could be more delightful! To be fond of
+dancing was a certain step towards falling in love; and very lively
+hopes of Mr. Bingley’s heart were entertained.
+
+“If I can but see one of my daughters happily settled at Netherfield,”
+ said Mrs. Bennet to her husband, “and all the others equally well
+married, I shall have nothing to wish for.”
+
+In a few days Mr. Bingley returned Mr. Bennet’s visit, and sat about
+ten minutes with him in his library. He had entertained hopes of being
+admitted to a sight of the young ladies, of whose beauty he had
+heard much; but he saw only the father. The ladies were somewhat more
+fortunate, for they had the advantage of ascertaining from an upper
+window that he wore a blue coat, and rode a black horse.
+
+An invitation to dinner was soon afterwards dispatched; and already
+had Mrs. Bennet planned the courses that were to do credit to her
+housekeeping, when an answer arrived which deferred it all. Mr. Bingley
+was obliged to be in town the following day, and, consequently, unable
+to accept the honour of their invitation, etc. Mrs. Bennet was quite
+disconcerted. She could not imagine what business he could have in town
+so soon after his arrival in Hertfordshire; and she began to fear that
+he might be always flying about from one place to another, and never
+settled at Netherfield as he ought to be. Lady Lucas quieted her fears
+a little by starting the idea of his being gone to London only to get
+a large party for the ball; and a report soon followed that Mr. Bingley
+was to bring twelve ladies and seven gentlemen with him to the assembly.
+The girls grieved over such a number of ladies, but were comforted the
+day before the ball by hearing, that instead of twelve he brought only
+six with him from London--his five sisters and a cousin. And when
+the party entered the assembly room it consisted of only five
+altogether--Mr. Bingley, his two sisters, the husband of the eldest, and
+another young man.
+
+Mr. Bingley was good-looking and gentlemanlike; he had a pleasant
+countenance, and easy, unaffected manners. His sisters were fine women,
+with an air of decided fashion. His brother-in-law, Mr. Hurst, merely
+looked the gentleman; but his friend Mr. Darcy soon drew the attention
+of the room by his fine, tall person, handsome features, noble mien, and
+the report which was in general circulation within five minutes
+after his entrance, of his having ten thousand a year. The gentlemen
+pronounced him to be a fine figure of a man, the ladies declared he
+was much handsomer than Mr. Bingley, and he was looked at with great
+admiration for about half the evening, till his manners gave a disgust
+which turned the tide of his popularity; for he was discovered to be
+proud; to be above his company, and above being pleased; and not all
+his large estate in Derbyshire could then save him from having a most
+forbidding, disagreeable countenance, and being unworthy to be compared
+with his friend.
+
+Mr. Bingley had soon made himself acquainted with all the principal
+people in the room; he was lively and unreserved, danced every dance,
+was angry that the ball closed so early, and talked of giving
+one himself at Netherfield. Such amiable qualities must speak for
+themselves. What a contrast between him and his friend! Mr. Darcy danced
+only once with Mrs. Hurst and once with Miss Bingley, declined being
+introduced to any other lady, and spent the rest of the evening in
+walking about the room, speaking occasionally to one of his own party.
+His character was decided. He was the proudest, most disagreeable man
+in the world, and everybody hoped that he would never come there again.
+Amongst the most violent against him was Mrs. Bennet, whose dislike of
+his general behaviour was sharpened into particular resentment by his
+having slighted one of her daughters.
+
+Elizabeth Bennet had been obliged, by the scarcity of gentlemen, to sit
+down for two dances; and during part of that time, Mr. Darcy had been
+standing near enough for her to hear a conversation between him and Mr.
+Bingley, who came from the dance for a few minutes, to press his friend
+to join it.
+
+“Come, Darcy,” said he, “I must have you dance. I hate to see you
+standing about by yourself in this stupid manner. You had much better
+dance.”
+
+“I certainly shall not. You know how I detest it, unless I am
+particularly acquainted with my partner. At such an assembly as this
+it would be insupportable. Your sisters are engaged, and there is not
+another woman in the room whom it would not be a punishment to me to
+stand up with.”
+
+“I would not be so fastidious as you are,” cried Mr. Bingley, “for a
+kingdom! Upon my honour, I never met with so many pleasant girls in
+my life as I have this evening; and there are several of them you see
+uncommonly pretty.”
+
+“_You_ are dancing with the only handsome girl in the room,” said Mr.
+Darcy, looking at the eldest Miss Bennet.
+
+“Oh! She is the most beautiful creature I ever beheld! But there is one
+of her sisters sitting down just behind you, who is very pretty, and I
+dare say very agreeable. Do let me ask my partner to introduce you.”
+
+“Which do you mean?” and turning round he looked for a moment at
+Elizabeth, till catching her eye, he withdrew his own and coldly said:
+“She is tolerable, but not handsome enough to tempt _me_; I am in no
+humour at present to give consequence to young ladies who are slighted
+by other men. You had better return to your partner and enjoy her
+smiles, for you are wasting your time with me.”
+
+Mr. Bingley followed his advice. Mr. Darcy walked off; and Elizabeth
+remained with no very cordial feelings toward him. She told the story,
+however, with great spirit among her friends; for she had a lively,
+playful disposition, which delighted in anything ridiculous.
+
+The evening altogether passed off pleasantly to the whole family. Mrs.
+Bennet had seen her eldest daughter much admired by the Netherfield
+party. Mr. Bingley had danced with her twice, and she had been
+distinguished by his sisters. Jane was as much gratified by this as
+her mother could be, though in a quieter way. Elizabeth felt Jane’s
+pleasure. Mary had heard herself mentioned to Miss Bingley as the most
+accomplished girl in the neighbourhood; and Catherine and Lydia had been
+fortunate enough never to be without partners, which was all that they
+had yet learnt to care for at a ball. They returned, therefore, in good
+spirits to Longbourn, the village where they lived, and of which they
+were the principal inhabitants. They found Mr. Bennet still up. With
+a book he was regardless of time; and on the present occasion he had a
+good deal of curiosity as to the event of an evening which had raised
+such splendid expectations. He had rather hoped that his wife’s views on
+the stranger would be disappointed; but he soon found out that he had a
+different story to hear.
+
+“Oh! my dear Mr. Bennet,” as she entered the room, “we have had a most
+delightful evening, a most excellent ball. I wish you had been there.
+Jane was so admired, nothing could be like it. Everybody said how well
+she looked; and Mr. Bingley thought her quite beautiful, and danced with
+her twice! Only think of _that_, my dear; he actually danced with her
+twice! and she was the only creature in the room that he asked a second
+time. First of all, he asked Miss Lucas. I was so vexed to see him stand
+up with her! But, however, he did not admire her at all; indeed, nobody
+can, you know; and he seemed quite struck with Jane as she was going
+down the dance. So he inquired who she was, and got introduced, and
+asked her for the two next. Then the two third he danced with Miss King,
+and the two fourth with Maria Lucas, and the two fifth with Jane again,
+and the two sixth with Lizzy, and the _Boulanger_--”
+
+“If he had had any compassion for _me_,” cried her husband impatiently,
+“he would not have danced half so much! For God’s sake, say no more of
+his partners. Oh that he had sprained his ankle in the first dance!”
+
+“Oh! my dear, I am quite delighted with him. He is so excessively
+handsome! And his sisters are charming women. I never in my life saw
+anything more elegant than their dresses. I dare say the lace upon Mrs.
+Hurst’s gown--”
+
+Here she was interrupted again. Mr. Bennet protested against any
+description of finery. She was therefore obliged to seek another branch
+of the subject, and related, with much bitterness of spirit and some
+exaggeration, the shocking rudeness of Mr. Darcy.
+
+“But I can assure you,” she added, “that Lizzy does not lose much by not
+suiting _his_ fancy; for he is a most disagreeable, horrid man, not at
+all worth pleasing. So high and so conceited that there was no enduring
+him! He walked here, and he walked there, fancying himself so very
+great! Not handsome enough to dance with! I wish you had been there, my
+dear, to have given him one of your set-downs. I quite detest the man.”
+
+
+
+Chapter 4
+
+
+When Jane and Elizabeth were alone, the former, who had been cautious in
+her praise of Mr. Bingley before, expressed to her sister just how very
+much she admired him.
+
+“He is just what a young man ought to be,” said she, “sensible,
+good-humoured, lively; and I never saw such happy manners!--so much
+ease, with such perfect good breeding!”
+
+“He is also handsome,” replied Elizabeth, “which a young man ought
+likewise to be, if he possibly can. His character is thereby complete.”
+
+“I was very much flattered by his asking me to dance a second time. I
+did not expect such a compliment.”
+
+“Did not you? I did for you. But that is one great difference between
+us. Compliments always take _you_ by surprise, and _me_ never. What
+could be more natural than his asking you again? He could not help
+seeing that you were about five times as pretty as every other woman
+in the room. No thanks to his gallantry for that. Well, he certainly is
+very agreeable, and I give you leave to like him. You have liked many a
+stupider person.”
+
+“Dear Lizzy!”
+
+“Oh! you are a great deal too apt, you know, to like people in general.
+You never see a fault in anybody. All the world are good and agreeable
+in your eyes. I never heard you speak ill of a human being in your
+life.”
+
+“I would not wish to be hasty in censuring anyone; but I always speak
+what I think.”
+
+“I know you do; and it is _that_ which makes the wonder. With _your_
+good sense, to be so honestly blind to the follies and nonsense of
+others! Affectation of candour is common enough--one meets with it
+everywhere. But to be candid without ostentation or design--to take the
+good of everybody’s character and make it still better, and say nothing
+of the bad--belongs to you alone. And so you like this man’s sisters,
+too, do you? Their manners are not equal to his.”
+
+“Certainly not--at first. But they are very pleasing women when you
+converse with them. Miss Bingley is to live with her brother, and keep
+his house; and I am much mistaken if we shall not find a very charming
+neighbour in her.”
+
+Elizabeth listened in silence, but was not convinced; their behaviour at
+the assembly had not been calculated to please in general; and with more
+quickness of observation and less pliancy of temper than her sister,
+and with a judgement too unassailed by any attention to herself, she
+was very little disposed to approve them. They were in fact very fine
+ladies; not deficient in good humour when they were pleased, nor in the
+power of making themselves agreeable when they chose it, but proud and
+conceited. They were rather handsome, had been educated in one of the
+first private seminaries in town, had a fortune of twenty thousand
+pounds, were in the habit of spending more than they ought, and of
+associating with people of rank, and were therefore in every respect
+entitled to think well of themselves, and meanly of others. They were of
+a respectable family in the north of England; a circumstance more deeply
+impressed on their memories than that their brother’s fortune and their
+own had been acquired by trade.
+
+Mr. Bingley inherited property to the amount of nearly a hundred
+thousand pounds from his father, who had intended to purchase an
+estate, but did not live to do it. Mr. Bingley intended it likewise, and
+sometimes made choice of his county; but as he was now provided with a
+good house and the liberty of a manor, it was doubtful to many of those
+who best knew the easiness of his temper, whether he might not spend the
+remainder of his days at Netherfield, and leave the next generation to
+purchase.
+
+His sisters were anxious for his having an estate of his own; but,
+though he was now only established as a tenant, Miss Bingley was by no
+means unwilling to preside at his table--nor was Mrs. Hurst, who had
+married a man of more fashion than fortune, less disposed to consider
+his house as her home when it suited her. Mr. Bingley had not been of
+age two years, when he was tempted by an accidental recommendation
+to look at Netherfield House. He did look at it, and into it for
+half-an-hour--was pleased with the situation and the principal
+rooms, satisfied with what the owner said in its praise, and took it
+immediately.
+
+Between him and Darcy there was a very steady friendship, in spite of
+great opposition of character. Bingley was endeared to Darcy by the
+easiness, openness, and ductility of his temper, though no disposition
+could offer a greater contrast to his own, and though with his own he
+never appeared dissatisfied. On the strength of Darcy’s regard, Bingley
+had the firmest reliance, and of his judgement the highest opinion.
+In understanding, Darcy was the superior. Bingley was by no means
+deficient, but Darcy was clever. He was at the same time haughty,
+reserved, and fastidious, and his manners, though well-bred, were not
+inviting. In that respect his friend had greatly the advantage. Bingley
+was sure of being liked wherever he appeared, Darcy was continually
+giving offense.
+
+The manner in which they spoke of the Meryton assembly was sufficiently
+characteristic. Bingley had never met with more pleasant people or
+prettier girls in his life; everybody had been most kind and attentive
+to him; there had been no formality, no stiffness; he had soon felt
+acquainted with all the room; and, as to Miss Bennet, he could not
+conceive an angel more beautiful. Darcy, on the contrary, had seen a
+collection of people in whom there was little beauty and no fashion, for
+none of whom he had felt the smallest interest, and from none received
+either attention or pleasure. Miss Bennet he acknowledged to be pretty,
+but she smiled too much.
+
+Mrs. Hurst and her sister allowed it to be so--but still they admired
+her and liked her, and pronounced her to be a sweet girl, and one
+whom they would not object to know more of. Miss Bennet was therefore
+established as a sweet girl, and their brother felt authorized by such
+commendation to think of her as he chose.
+
+
+
+Chapter 5
+
+
+Within a short walk of Longbourn lived a family with whom the Bennets
+were particularly intimate. Sir William Lucas had been formerly in trade
+in Meryton, where he had made a tolerable fortune, and risen to the
+honour of knighthood by an address to the king during his mayoralty.
+The distinction had perhaps been felt too strongly. It had given him a
+disgust to his business, and to his residence in a small market town;
+and, in quitting them both, he had removed with his family to a house
+about a mile from Meryton, denominated from that period Lucas Lodge,
+where he could think with pleasure of his own importance, and,
+unshackled by business, occupy himself solely in being civil to all
+the world. For, though elated by his rank, it did not render him
+supercilious; on the contrary, he was all attention to everybody. By
+nature inoffensive, friendly, and obliging, his presentation at St.
+James’s had made him courteous.
+
+Lady Lucas was a very good kind of woman, not too clever to be a
+valuable neighbour to Mrs. Bennet. They had several children. The eldest
+of them, a sensible, intelligent young woman, about twenty-seven, was
+Elizabeth’s intimate friend.
+
+That the Miss Lucases and the Miss Bennets should meet to talk over
+a ball was absolutely necessary; and the morning after the assembly
+brought the former to Longbourn to hear and to communicate.
+
+“_You_ began the evening well, Charlotte,” said Mrs. Bennet with civil
+self-command to Miss Lucas. “_You_ were Mr. Bingley’s first choice.”
+
+“Yes; but he seemed to like his second better.”
+
+“Oh! you mean Jane, I suppose, because he danced with her twice. To be
+sure that _did_ seem as if he admired her--indeed I rather believe he
+_did_--I heard something about it--but I hardly know what--something
+about Mr. Robinson.”
+
+“Perhaps you mean what I overheard between him and Mr. Robinson; did not
+I mention it to you? Mr. Robinson’s asking him how he liked our Meryton
+assemblies, and whether he did not think there were a great many
+pretty women in the room, and _which_ he thought the prettiest? and his
+answering immediately to the last question: ‘Oh! the eldest Miss Bennet,
+beyond a doubt; there cannot be two opinions on that point.’”
+
+“Upon my word! Well, that is very decided indeed--that does seem as
+if--but, however, it may all come to nothing, you know.”
+
+“_My_ overhearings were more to the purpose than _yours_, Eliza,” said
+Charlotte. “Mr. Darcy is not so well worth listening to as his friend,
+is he?--poor Eliza!--to be only just _tolerable_.”
+
+“I beg you would not put it into Lizzy’s head to be vexed by his
+ill-treatment, for he is such a disagreeable man, that it would be quite
+a misfortune to be liked by him. Mrs. Long told me last night that he
+sat close to her for half-an-hour without once opening his lips.”
+
+“Are you quite sure, ma’am?--is not there a little mistake?” said Jane.
+“I certainly saw Mr. Darcy speaking to her.”
+
+“Aye--because she asked him at last how he liked Netherfield, and he
+could not help answering her; but she said he seemed quite angry at
+being spoke to.”
+
+“Miss Bingley told me,” said Jane, “that he never speaks much,
+unless among his intimate acquaintances. With _them_ he is remarkably
+agreeable.”
+
+“I do not believe a word of it, my dear. If he had been so very
+agreeable, he would have talked to Mrs. Long. But I can guess how it
+was; everybody says that he is eat up with pride, and I dare say he had
+heard somehow that Mrs. Long does not keep a carriage, and had come to
+the ball in a hack chaise.”
+
+“I do not mind his not talking to Mrs. Long,” said Miss Lucas, “but I
+wish he had danced with Eliza.”
+
+“Another time, Lizzy,” said her mother, “I would not dance with _him_,
+if I were you.”
+
+“I believe, ma’am, I may safely promise you _never_ to dance with him.”
+
+“His pride,” said Miss Lucas, “does not offend _me_ so much as pride
+often does, because there is an excuse for it. One cannot wonder that so
+very fine a young man, with family, fortune, everything in his favour,
+should think highly of himself. If I may so express it, he has a _right_
+to be proud.”
+
+“That is very true,” replied Elizabeth, “and I could easily forgive
+_his_ pride, if he had not mortified _mine_.”
+
+“Pride,” observed Mary, who piqued herself upon the solidity of her
+reflections, “is a very common failing, I believe. By all that I have
+ever read, I am convinced that it is very common indeed; that human
+nature is particularly prone to it, and that there are very few of us
+who do not cherish a feeling of self-complacency on the score of some
+quality or other, real or imaginary. Vanity and pride are different
+things, though the words are often used synonymously. A person may
+be proud without being vain. Pride relates more to our opinion of
+ourselves, vanity to what we would have others think of us.”
+
+“If I were as rich as Mr. Darcy,” cried a young Lucas, who came with
+his sisters, “I should not care how proud I was. I would keep a pack of
+foxhounds, and drink a bottle of wine a day.”
+
+“Then you would drink a great deal more than you ought,” said Mrs.
+Bennet; “and if I were to see you at it, I should take away your bottle
+directly.”
+
+The boy protested that she should not; she continued to declare that she
+would, and the argument ended only with the visit.
+
+
+
+Chapter 6
+
+
+The ladies of Longbourn soon waited on those of Netherfield. The visit
+was soon returned in due form. Miss Bennet’s pleasing manners grew on
+the goodwill of Mrs. Hurst and Miss Bingley; and though the mother was
+found to be intolerable, and the younger sisters not worth speaking to,
+a wish of being better acquainted with _them_ was expressed towards
+the two eldest. By Jane, this attention was received with the greatest
+pleasure, but Elizabeth still saw superciliousness in their treatment
+of everybody, hardly excepting even her sister, and could not like them;
+though their kindness to Jane, such as it was, had a value as arising in
+all probability from the influence of their brother’s admiration. It
+was generally evident whenever they met, that he _did_ admire her and
+to _her_ it was equally evident that Jane was yielding to the preference
+which she had begun to entertain for him from the first, and was in a
+way to be very much in love; but she considered with pleasure that it
+was not likely to be discovered by the world in general, since Jane
+united, with great strength of feeling, a composure of temper and a
+uniform cheerfulness of manner which would guard her from the suspicions
+of the impertinent. She mentioned this to her friend Miss Lucas.
+
+“It may perhaps be pleasant,” replied Charlotte, “to be able to impose
+on the public in such a case; but it is sometimes a disadvantage to be
+so very guarded. If a woman conceals her affection with the same skill
+from the object of it, she may lose the opportunity of fixing him; and
+it will then be but poor consolation to believe the world equally in
+the dark. There is so much of gratitude or vanity in almost every
+attachment, that it is not safe to leave any to itself. We can all
+_begin_ freely--a slight preference is natural enough; but there are
+very few of us who have heart enough to be really in love without
+encouragement. In nine cases out of ten a women had better show _more_
+affection than she feels. Bingley likes your sister undoubtedly; but he
+may never do more than like her, if she does not help him on.”
+
+“But she does help him on, as much as her nature will allow. If I can
+perceive her regard for him, he must be a simpleton, indeed, not to
+discover it too.”
+
+“Remember, Eliza, that he does not know Jane’s disposition as you do.”
+
+“But if a woman is partial to a man, and does not endeavour to conceal
+it, he must find it out.”
+
+“Perhaps he must, if he sees enough of her. But, though Bingley and Jane
+meet tolerably often, it is never for many hours together; and, as they
+always see each other in large mixed parties, it is impossible that
+every moment should be employed in conversing together. Jane should
+therefore make the most of every half-hour in which she can command his
+attention. When she is secure of him, there will be more leisure for
+falling in love as much as she chooses.”
+
+“Your plan is a good one,” replied Elizabeth, “where nothing is in
+question but the desire of being well married, and if I were determined
+to get a rich husband, or any husband, I dare say I should adopt it. But
+these are not Jane’s feelings; she is not acting by design. As yet,
+she cannot even be certain of the degree of her own regard nor of its
+reasonableness. She has known him only a fortnight. She danced four
+dances with him at Meryton; she saw him one morning at his own house,
+and has since dined with him in company four times. This is not quite
+enough to make her understand his character.”
+
+“Not as you represent it. Had she merely _dined_ with him, she might
+only have discovered whether he had a good appetite; but you must
+remember that four evenings have also been spent together--and four
+evenings may do a great deal.”
+
+“Yes; these four evenings have enabled them to ascertain that they
+both like Vingt-un better than Commerce; but with respect to any other
+leading characteristic, I do not imagine that much has been unfolded.”
+
+“Well,” said Charlotte, “I wish Jane success with all my heart; and
+if she were married to him to-morrow, I should think she had as good a
+chance of happiness as if she were to be studying his character for a
+twelvemonth. Happiness in marriage is entirely a matter of chance. If
+the dispositions of the parties are ever so well known to each other or
+ever so similar beforehand, it does not advance their felicity in the
+least. They always continue to grow sufficiently unlike afterwards to
+have their share of vexation; and it is better to know as little as
+possible of the defects of the person with whom you are to pass your
+life.”
+
+“You make me laugh, Charlotte; but it is not sound. You know it is not
+sound, and that you would never act in this way yourself.”
+
+Occupied in observing Mr. Bingley’s attentions to her sister, Elizabeth
+was far from suspecting that she was herself becoming an object of some
+interest in the eyes of his friend. Mr. Darcy had at first scarcely
+allowed her to be pretty; he had looked at her without admiration at the
+ball; and when they next met, he looked at her only to criticise. But no
+sooner had he made it clear to himself and his friends that she hardly
+had a good feature in her face, than he began to find it was rendered
+uncommonly intelligent by the beautiful expression of her dark eyes. To
+this discovery succeeded some others equally mortifying. Though he had
+detected with a critical eye more than one failure of perfect symmetry
+in her form, he was forced to acknowledge her figure to be light and
+pleasing; and in spite of his asserting that her manners were not those
+of the fashionable world, he was caught by their easy playfulness. Of
+this she was perfectly unaware; to her he was only the man who made
+himself agreeable nowhere, and who had not thought her handsome enough
+to dance with.
+
+He began to wish to know more of her, and as a step towards conversing
+with her himself, attended to her conversation with others. His doing so
+drew her notice. It was at Sir William Lucas’s, where a large party were
+assembled.
+
+“What does Mr. Darcy mean,” said she to Charlotte, “by listening to my
+conversation with Colonel Forster?”
+
+“That is a question which Mr. Darcy only can answer.”
+
+“But if he does it any more I shall certainly let him know that I see
+what he is about. He has a very satirical eye, and if I do not begin by
+being impertinent myself, I shall soon grow afraid of him.”
+
+On his approaching them soon afterwards, though without seeming to have
+any intention of speaking, Miss Lucas defied her friend to mention such
+a subject to him; which immediately provoking Elizabeth to do it, she
+turned to him and said:
+
+“Did you not think, Mr. Darcy, that I expressed myself uncommonly
+well just now, when I was teasing Colonel Forster to give us a ball at
+Meryton?”
+
+“With great energy; but it is always a subject which makes a lady
+energetic.”
+
+“You are severe on us.”
+
+“It will be _her_ turn soon to be teased,” said Miss Lucas. “I am going
+to open the instrument, Eliza, and you know what follows.”
+
+“You are a very strange creature by way of a friend!--always wanting me
+to play and sing before anybody and everybody! If my vanity had taken
+a musical turn, you would have been invaluable; but as it is, I would
+really rather not sit down before those who must be in the habit of
+hearing the very best performers.” On Miss Lucas’s persevering, however,
+she added, “Very well, if it must be so, it must.” And gravely glancing
+at Mr. Darcy, “There is a fine old saying, which everybody here is of
+course familiar with: ‘Keep your breath to cool your porridge’; and I
+shall keep mine to swell my song.”
+
+Her performance was pleasing, though by no means capital. After a song
+or two, and before she could reply to the entreaties of several that
+she would sing again, she was eagerly succeeded at the instrument by her
+sister Mary, who having, in consequence of being the only plain one in
+the family, worked hard for knowledge and accomplishments, was always
+impatient for display.
+
+Mary had neither genius nor taste; and though vanity had given her
+application, it had given her likewise a pedantic air and conceited
+manner, which would have injured a higher degree of excellence than she
+had reached. Elizabeth, easy and unaffected, had been listened to with
+much more pleasure, though not playing half so well; and Mary, at the
+end of a long concerto, was glad to purchase praise and gratitude by
+Scotch and Irish airs, at the request of her younger sisters, who,
+with some of the Lucases, and two or three officers, joined eagerly in
+dancing at one end of the room.
+
+Mr. Darcy stood near them in silent indignation at such a mode of
+passing the evening, to the exclusion of all conversation, and was too
+much engrossed by his thoughts to perceive that Sir William Lucas was
+his neighbour, till Sir William thus began:
+
+“What a charming amusement for young people this is, Mr. Darcy! There
+is nothing like dancing after all. I consider it as one of the first
+refinements of polished society.”
+
+“Certainly, sir; and it has the advantage also of being in vogue amongst
+the less polished societies of the world. Every savage can dance.”
+
+Sir William only smiled. “Your friend performs delightfully,” he
+continued after a pause, on seeing Bingley join the group; “and I doubt
+not that you are an adept in the science yourself, Mr. Darcy.”
+
+“You saw me dance at Meryton, I believe, sir.”
+
+“Yes, indeed, and received no inconsiderable pleasure from the sight. Do
+you often dance at St. James’s?”
+
+“Never, sir.”
+
+“Do you not think it would be a proper compliment to the place?”
+
+“It is a compliment which I never pay to any place if I can avoid it.”
+
+“You have a house in town, I conclude?”
+
+Mr. Darcy bowed.
+
+“I had once had some thought of fixing in town myself--for I am fond
+of superior society; but I did not feel quite certain that the air of
+London would agree with Lady Lucas.”
+
+He paused in hopes of an answer; but his companion was not disposed
+to make any; and Elizabeth at that instant moving towards them, he was
+struck with the action of doing a very gallant thing, and called out to
+her:
+
+“My dear Miss Eliza, why are you not dancing? Mr. Darcy, you must allow
+me to present this young lady to you as a very desirable partner. You
+cannot refuse to dance, I am sure when so much beauty is before you.”
+ And, taking her hand, he would have given it to Mr. Darcy who, though
+extremely surprised, was not unwilling to receive it, when she instantly
+drew back, and said with some discomposure to Sir William:
+
+“Indeed, sir, I have not the least intention of dancing. I entreat you
+not to suppose that I moved this way in order to beg for a partner.”
+
+Mr. Darcy, with grave propriety, requested to be allowed the honour of
+her hand, but in vain. Elizabeth was determined; nor did Sir William at
+all shake her purpose by his attempt at persuasion.
+
+“You excel so much in the dance, Miss Eliza, that it is cruel to deny
+me the happiness of seeing you; and though this gentleman dislikes the
+amusement in general, he can have no objection, I am sure, to oblige us
+for one half-hour.”
+
+“Mr. Darcy is all politeness,” said Elizabeth, smiling.
+
+“He is, indeed; but, considering the inducement, my dear Miss Eliza,
+we cannot wonder at his complaisance--for who would object to such a
+partner?”
+
+Elizabeth looked archly, and turned away. Her resistance had not
+injured her with the gentleman, and he was thinking of her with some
+complacency, when thus accosted by Miss Bingley:
+
+“I can guess the subject of your reverie.”
+
+“I should imagine not.”
+
+“You are considering how insupportable it would be to pass many evenings
+in this manner--in such society; and indeed I am quite of your opinion.
+I was never more annoyed! The insipidity, and yet the noise--the
+nothingness, and yet the self-importance of all those people! What would
+I give to hear your strictures on them!”
+
+“Your conjecture is totally wrong, I assure you. My mind was more
+agreeably engaged. I have been meditating on the very great pleasure
+which a pair of fine eyes in the face of a pretty woman can bestow.”
+
+Miss Bingley immediately fixed her eyes on his face, and desired he
+would tell her what lady had the credit of inspiring such reflections.
+Mr. Darcy replied with great intrepidity:
+
+“Miss Elizabeth Bennet.”
+
+“Miss Elizabeth Bennet!” repeated Miss Bingley. “I am all astonishment.
+How long has she been such a favourite?--and pray, when am I to wish you
+joy?”
+
+“That is exactly the question which I expected you to ask. A lady’s
+imagination is very rapid; it jumps from admiration to love, from love
+to matrimony, in a moment. I knew you would be wishing me joy.”
+
+“Nay, if you are serious about it, I shall consider the matter is
+absolutely settled. You will be having a charming mother-in-law, indeed;
+and, of course, she will always be at Pemberley with you.”
+
+He listened to her with perfect indifference while she chose to
+entertain herself in this manner; and as his composure convinced her
+that all was safe, her wit flowed long.
+
+
+
+Chapter 7
+
+
+Mr. Bennet’s property consisted almost entirely in an estate of two
+thousand a year, which, unfortunately for his daughters, was entailed,
+in default of heirs male, on a distant relation; and their mother’s
+fortune, though ample for her situation in life, could but ill supply
+the deficiency of his. Her father had been an attorney in Meryton, and
+had left her four thousand pounds.
+
+She had a sister married to a Mr. Phillips, who had been a clerk to
+their father and succeeded him in the business, and a brother settled in
+London in a respectable line of trade.
+
+The village of Longbourn was only one mile from Meryton; a most
+convenient distance for the young ladies, who were usually tempted
+thither three or four times a week, to pay their duty to their aunt and
+to a milliner’s shop just over the way. The two youngest of the family,
+Catherine and Lydia, were particularly frequent in these attentions;
+their minds were more vacant than their sisters’, and when nothing
+better offered, a walk to Meryton was necessary to amuse their morning
+hours and furnish conversation for the evening; and however bare of news
+the country in general might be, they always contrived to learn some
+from their aunt. At present, indeed, they were well supplied both with
+news and happiness by the recent arrival of a militia regiment in the
+neighbourhood; it was to remain the whole winter, and Meryton was the
+headquarters.
+
+Their visits to Mrs. Phillips were now productive of the most
+interesting intelligence. Every day added something to their knowledge
+of the officers’ names and connections. Their lodgings were not long a
+secret, and at length they began to know the officers themselves. Mr.
+Phillips visited them all, and this opened to his nieces a store of
+felicity unknown before. They could talk of nothing but officers; and
+Mr. Bingley’s large fortune, the mention of which gave animation
+to their mother, was worthless in their eyes when opposed to the
+regimentals of an ensign.
+
+After listening one morning to their effusions on this subject, Mr.
+Bennet coolly observed:
+
+“From all that I can collect by your manner of talking, you must be two
+of the silliest girls in the country. I have suspected it some time, but
+I am now convinced.”
+
+Catherine was disconcerted, and made no answer; but Lydia, with perfect
+indifference, continued to express her admiration of Captain Carter,
+and her hope of seeing him in the course of the day, as he was going the
+next morning to London.
+
+“I am astonished, my dear,” said Mrs. Bennet, “that you should be so
+ready to think your own children silly. If I wished to think slightingly
+of anybody’s children, it should not be of my own, however.”
+
+“If my children are silly, I must hope to be always sensible of it.”
+
+“Yes--but as it happens, they are all of them very clever.”
+
+“This is the only point, I flatter myself, on which we do not agree. I
+had hoped that our sentiments coincided in every particular, but I must
+so far differ from you as to think our two youngest daughters uncommonly
+foolish.”
+
+“My dear Mr. Bennet, you must not expect such girls to have the sense of
+their father and mother. When they get to our age, I dare say they will
+not think about officers any more than we do. I remember the time when
+I liked a red coat myself very well--and, indeed, so I do still at my
+heart; and if a smart young colonel, with five or six thousand a year,
+should want one of my girls I shall not say nay to him; and I thought
+Colonel Forster looked very becoming the other night at Sir William’s in
+his regimentals.”
+
+“Mamma,” cried Lydia, “my aunt says that Colonel Forster and Captain
+Carter do not go so often to Miss Watson’s as they did when they first
+came; she sees them now very often standing in Clarke’s library.”
+
+Mrs. Bennet was prevented replying by the entrance of the footman with
+a note for Miss Bennet; it came from Netherfield, and the servant waited
+for an answer. Mrs. Bennet’s eyes sparkled with pleasure, and she was
+eagerly calling out, while her daughter read,
+
+“Well, Jane, who is it from? What is it about? What does he say? Well,
+Jane, make haste and tell us; make haste, my love.”
+
+“It is from Miss Bingley,” said Jane, and then read it aloud.
+
+“MY DEAR FRIEND,--
+
+“If you are not so compassionate as to dine to-day with Louisa and me,
+we shall be in danger of hating each other for the rest of our lives,
+for a whole day’s tete-a-tete between two women can never end without a
+quarrel. Come as soon as you can on receipt of this. My brother and the
+gentlemen are to dine with the officers.--Yours ever,
+
+“CAROLINE BINGLEY”
+
+“With the officers!” cried Lydia. “I wonder my aunt did not tell us of
+_that_.”
+
+“Dining out,” said Mrs. Bennet, “that is very unlucky.”
+
+“Can I have the carriage?” said Jane.
+
+“No, my dear, you had better go on horseback, because it seems likely to
+rain; and then you must stay all night.”
+
+“That would be a good scheme,” said Elizabeth, “if you were sure that
+they would not offer to send her home.”
+
+“Oh! but the gentlemen will have Mr. Bingley’s chaise to go to Meryton,
+and the Hursts have no horses to theirs.”
+
+“I had much rather go in the coach.”
+
+“But, my dear, your father cannot spare the horses, I am sure. They are
+wanted in the farm, Mr. Bennet, are they not?”
+
+“They are wanted in the farm much oftener than I can get them.”
+
+“But if you have got them to-day,” said Elizabeth, “my mother’s purpose
+will be answered.”
+
+She did at last extort from her father an acknowledgment that the horses
+were engaged. Jane was therefore obliged to go on horseback, and her
+mother attended her to the door with many cheerful prognostics of a
+bad day. Her hopes were answered; Jane had not been gone long before
+it rained hard. Her sisters were uneasy for her, but her mother was
+delighted. The rain continued the whole evening without intermission;
+Jane certainly could not come back.
+
+“This was a lucky idea of mine, indeed!” said Mrs. Bennet more than
+once, as if the credit of making it rain were all her own. Till the
+next morning, however, she was not aware of all the felicity of her
+contrivance. Breakfast was scarcely over when a servant from Netherfield
+brought the following note for Elizabeth:
+
+“MY DEAREST LIZZY,--
+
+“I find myself very unwell this morning, which, I suppose, is to be
+imputed to my getting wet through yesterday. My kind friends will not
+hear of my returning till I am better. They insist also on my seeing Mr.
+Jones--therefore do not be alarmed if you should hear of his having been
+to me--and, excepting a sore throat and headache, there is not much the
+matter with me.--Yours, etc.”
+
+“Well, my dear,” said Mr. Bennet, when Elizabeth had read the note
+aloud, “if your daughter should have a dangerous fit of illness--if she
+should die, it would be a comfort to know that it was all in pursuit of
+Mr. Bingley, and under your orders.”
+
+“Oh! I am not afraid of her dying. People do not die of little trifling
+colds. She will be taken good care of. As long as she stays there, it is
+all very well. I would go and see her if I could have the carriage.”
+
+Elizabeth, feeling really anxious, was determined to go to her, though
+the carriage was not to be had; and as she was no horsewoman, walking
+was her only alternative. She declared her resolution.
+
+“How can you be so silly,” cried her mother, “as to think of such a
+thing, in all this dirt! You will not be fit to be seen when you get
+there.”
+
+“I shall be very fit to see Jane--which is all I want.”
+
+“Is this a hint to me, Lizzy,” said her father, “to send for the
+horses?”
+
+“No, indeed, I do not wish to avoid the walk. The distance is nothing
+when one has a motive; only three miles. I shall be back by dinner.”
+
+“I admire the activity of your benevolence,” observed Mary, “but every
+impulse of feeling should be guided by reason; and, in my opinion,
+exertion should always be in proportion to what is required.”
+
+“We will go as far as Meryton with you,” said Catherine and Lydia.
+Elizabeth accepted their company, and the three young ladies set off
+together.
+
+“If we make haste,” said Lydia, as they walked along, “perhaps we may
+see something of Captain Carter before he goes.”
+
+In Meryton they parted; the two youngest repaired to the lodgings of one
+of the officers’ wives, and Elizabeth continued her walk alone, crossing
+field after field at a quick pace, jumping over stiles and springing
+over puddles with impatient activity, and finding herself at last
+within view of the house, with weary ankles, dirty stockings, and a face
+glowing with the warmth of exercise.
+
+She was shown into the breakfast-parlour, where all but Jane were
+assembled, and where her appearance created a great deal of surprise.
+That she should have walked three miles so early in the day, in such
+dirty weather, and by herself, was almost incredible to Mrs. Hurst and
+Miss Bingley; and Elizabeth was convinced that they held her in contempt
+for it. She was received, however, very politely by them; and in their
+brother’s manners there was something better than politeness; there
+was good humour and kindness. Mr. Darcy said very little, and Mr.
+Hurst nothing at all. The former was divided between admiration of the
+brilliancy which exercise had given to her complexion, and doubt as
+to the occasion’s justifying her coming so far alone. The latter was
+thinking only of his breakfast.
+
+Her inquiries after her sister were not very favourably answered. Miss
+Bennet had slept ill, and though up, was very feverish, and not
+well enough to leave her room. Elizabeth was glad to be taken to her
+immediately; and Jane, who had only been withheld by the fear of giving
+alarm or inconvenience from expressing in her note how much she longed
+for such a visit, was delighted at her entrance. She was not equal,
+however, to much conversation, and when Miss Bingley left them
+together, could attempt little besides expressions of gratitude for the
+extraordinary kindness she was treated with. Elizabeth silently attended
+her.
+
+When breakfast was over they were joined by the sisters; and Elizabeth
+began to like them herself, when she saw how much affection and
+solicitude they showed for Jane. The apothecary came, and having
+examined his patient, said, as might be supposed, that she had caught
+a violent cold, and that they must endeavour to get the better of it;
+advised her to return to bed, and promised her some draughts. The advice
+was followed readily, for the feverish symptoms increased, and her head
+ached acutely. Elizabeth did not quit her room for a moment; nor were
+the other ladies often absent; the gentlemen being out, they had, in
+fact, nothing to do elsewhere.
+
+When the clock struck three, Elizabeth felt that she must go, and very
+unwillingly said so. Miss Bingley offered her the carriage, and she only
+wanted a little pressing to accept it, when Jane testified such concern
+in parting with her, that Miss Bingley was obliged to convert the offer
+of the chaise to an invitation to remain at Netherfield for the present.
+Elizabeth most thankfully consented, and a servant was dispatched to
+Longbourn to acquaint the family with her stay and bring back a supply
+of clothes.
+
+
+
+Chapter 8
+
+
+At five o’clock the two ladies retired to dress, and at half-past six
+Elizabeth was summoned to dinner. To the civil inquiries which then
+poured in, and amongst which she had the pleasure of distinguishing the
+much superior solicitude of Mr. Bingley’s, she could not make a very
+favourable answer. Jane was by no means better. The sisters, on hearing
+this, repeated three or four times how much they were grieved, how
+shocking it was to have a bad cold, and how excessively they disliked
+being ill themselves; and then thought no more of the matter: and their
+indifference towards Jane when not immediately before them restored
+Elizabeth to the enjoyment of all her former dislike.
+
+Their brother, indeed, was the only one of the party whom she could
+regard with any complacency. His anxiety for Jane was evident, and his
+attentions to herself most pleasing, and they prevented her feeling
+herself so much an intruder as she believed she was considered by the
+others. She had very little notice from any but him. Miss Bingley was
+engrossed by Mr. Darcy, her sister scarcely less so; and as for Mr.
+Hurst, by whom Elizabeth sat, he was an indolent man, who lived only to
+eat, drink, and play at cards; who, when he found her to prefer a plain
+dish to a ragout, had nothing to say to her.
+
+When dinner was over, she returned directly to Jane, and Miss Bingley
+began abusing her as soon as she was out of the room. Her manners were
+pronounced to be very bad indeed, a mixture of pride and impertinence;
+she had no conversation, no style, no beauty. Mrs. Hurst thought the
+same, and added:
+
+“She has nothing, in short, to recommend her, but being an excellent
+walker. I shall never forget her appearance this morning. She really
+looked almost wild.”
+
+“She did, indeed, Louisa. I could hardly keep my countenance. Very
+nonsensical to come at all! Why must _she_ be scampering about the
+country, because her sister had a cold? Her hair, so untidy, so blowsy!”
+
+“Yes, and her petticoat; I hope you saw her petticoat, six inches deep
+in mud, I am absolutely certain; and the gown which had been let down to
+hide it not doing its office.”
+
+“Your picture may be very exact, Louisa,” said Bingley; “but this was
+all lost upon me. I thought Miss Elizabeth Bennet looked remarkably
+well when she came into the room this morning. Her dirty petticoat quite
+escaped my notice.”
+
+“_You_ observed it, Mr. Darcy, I am sure,” said Miss Bingley; “and I am
+inclined to think that you would not wish to see _your_ sister make such
+an exhibition.”
+
+“Certainly not.”
+
+“To walk three miles, or four miles, or five miles, or whatever it is,
+above her ankles in dirt, and alone, quite alone! What could she mean by
+it? It seems to me to show an abominable sort of conceited independence,
+a most country-town indifference to decorum.”
+
+“It shows an affection for her sister that is very pleasing,” said
+Bingley.
+
+“I am afraid, Mr. Darcy,” observed Miss Bingley in a half whisper, “that
+this adventure has rather affected your admiration of her fine eyes.”
+
+“Not at all,” he replied; “they were brightened by the exercise.” A
+short pause followed this speech, and Mrs. Hurst began again:
+
+“I have an excessive regard for Miss Jane Bennet, she is really a very
+sweet girl, and I wish with all my heart she were well settled. But with
+such a father and mother, and such low connections, I am afraid there is
+no chance of it.”
+
+“I think I have heard you say that their uncle is an attorney in
+Meryton.”
+
+“Yes; and they have another, who lives somewhere near Cheapside.”
+
+“That is capital,” added her sister, and they both laughed heartily.
+
+“If they had uncles enough to fill _all_ Cheapside,” cried Bingley, “it
+would not make them one jot less agreeable.”
+
+“But it must very materially lessen their chance of marrying men of any
+consideration in the world,” replied Darcy.
+
+To this speech Bingley made no answer; but his sisters gave it their
+hearty assent, and indulged their mirth for some time at the expense of
+their dear friend’s vulgar relations.
+
+With a renewal of tenderness, however, they returned to her room on
+leaving the dining-parlour, and sat with her till summoned to coffee.
+She was still very poorly, and Elizabeth would not quit her at all, till
+late in the evening, when she had the comfort of seeing her sleep, and
+when it seemed to her rather right than pleasant that she should go
+downstairs herself. On entering the drawing-room she found the whole
+party at loo, and was immediately invited to join them; but suspecting
+them to be playing high she declined it, and making her sister the
+excuse, said she would amuse herself for the short time she could stay
+below, with a book. Mr. Hurst looked at her with astonishment.
+
+“Do you prefer reading to cards?” said he; “that is rather singular.”
+
+“Miss Eliza Bennet,” said Miss Bingley, “despises cards. She is a great
+reader, and has no pleasure in anything else.”
+
+“I deserve neither such praise nor such censure,” cried Elizabeth; “I am
+_not_ a great reader, and I have pleasure in many things.”
+
+“In nursing your sister I am sure you have pleasure,” said Bingley; “and
+I hope it will be soon increased by seeing her quite well.”
+
+Elizabeth thanked him from her heart, and then walked towards the
+table where a few books were lying. He immediately offered to fetch her
+others--all that his library afforded.
+
+“And I wish my collection were larger for your benefit and my own
+credit; but I am an idle fellow, and though I have not many, I have more
+than I ever looked into.”
+
+Elizabeth assured him that she could suit herself perfectly with those
+in the room.
+
+“I am astonished,” said Miss Bingley, “that my father should have left
+so small a collection of books. What a delightful library you have at
+Pemberley, Mr. Darcy!”
+
+“It ought to be good,” he replied, “it has been the work of many
+generations.”
+
+“And then you have added so much to it yourself, you are always buying
+books.”
+
+“I cannot comprehend the neglect of a family library in such days as
+these.”
+
+“Neglect! I am sure you neglect nothing that can add to the beauties of
+that noble place. Charles, when you build _your_ house, I wish it may be
+half as delightful as Pemberley.”
+
+“I wish it may.”
+
+“But I would really advise you to make your purchase in that
+neighbourhood, and take Pemberley for a kind of model. There is not a
+finer county in England than Derbyshire.”
+
+“With all my heart; I will buy Pemberley itself if Darcy will sell it.”
+
+“I am talking of possibilities, Charles.”
+
+“Upon my word, Caroline, I should think it more possible to get
+Pemberley by purchase than by imitation.”
+
+Elizabeth was so much caught with what passed, as to leave her very
+little attention for her book; and soon laying it wholly aside, she drew
+near the card-table, and stationed herself between Mr. Bingley and his
+eldest sister, to observe the game.
+
+“Is Miss Darcy much grown since the spring?” said Miss Bingley; “will
+she be as tall as I am?”
+
+“I think she will. She is now about Miss Elizabeth Bennet’s height, or
+rather taller.”
+
+“How I long to see her again! I never met with anybody who delighted me
+so much. Such a countenance, such manners! And so extremely accomplished
+for her age! Her performance on the pianoforte is exquisite.”
+
+“It is amazing to me,” said Bingley, “how young ladies can have patience
+to be so very accomplished as they all are.”
+
+“All young ladies accomplished! My dear Charles, what do you mean?”
+
+“Yes, all of them, I think. They all paint tables, cover screens, and
+net purses. I scarcely know anyone who cannot do all this, and I am sure
+I never heard a young lady spoken of for the first time, without being
+informed that she was very accomplished.”
+
+“Your list of the common extent of accomplishments,” said Darcy, “has
+too much truth. The word is applied to many a woman who deserves it no
+otherwise than by netting a purse or covering a screen. But I am very
+far from agreeing with you in your estimation of ladies in general. I
+cannot boast of knowing more than half-a-dozen, in the whole range of my
+acquaintance, that are really accomplished.”
+
+“Nor I, I am sure,” said Miss Bingley.
+
+“Then,” observed Elizabeth, “you must comprehend a great deal in your
+idea of an accomplished woman.”
+
+“Yes, I do comprehend a great deal in it.”
+
+“Oh! certainly,” cried his faithful assistant, “no one can be really
+esteemed accomplished who does not greatly surpass what is usually met
+with. A woman must have a thorough knowledge of music, singing, drawing,
+dancing, and the modern languages, to deserve the word; and besides
+all this, she must possess a certain something in her air and manner of
+walking, the tone of her voice, her address and expressions, or the word
+will be but half-deserved.”
+
+“All this she must possess,” added Darcy, “and to all this she must
+yet add something more substantial, in the improvement of her mind by
+extensive reading.”
+
+“I am no longer surprised at your knowing _only_ six accomplished women.
+I rather wonder now at your knowing _any_.”
+
+“Are you so severe upon your own sex as to doubt the possibility of all
+this?”
+
+“I never saw such a woman. I never saw such capacity, and taste, and
+application, and elegance, as you describe united.”
+
+Mrs. Hurst and Miss Bingley both cried out against the injustice of her
+implied doubt, and were both protesting that they knew many women who
+answered this description, when Mr. Hurst called them to order, with
+bitter complaints of their inattention to what was going forward. As all
+conversation was thereby at an end, Elizabeth soon afterwards left the
+room.
+
+“Elizabeth Bennet,” said Miss Bingley, when the door was closed on her,
+“is one of those young ladies who seek to recommend themselves to the
+other sex by undervaluing their own; and with many men, I dare say, it
+succeeds. But, in my opinion, it is a paltry device, a very mean art.”
+
+“Undoubtedly,” replied Darcy, to whom this remark was chiefly addressed,
+“there is a meanness in _all_ the arts which ladies sometimes condescend
+to employ for captivation. Whatever bears affinity to cunning is
+despicable.”
+
+Miss Bingley was not so entirely satisfied with this reply as to
+continue the subject.
+
+Elizabeth joined them again only to say that her sister was worse, and
+that she could not leave her. Bingley urged Mr. Jones being sent for
+immediately; while his sisters, convinced that no country advice could
+be of any service, recommended an express to town for one of the most
+eminent physicians. This she would not hear of; but she was not so
+unwilling to comply with their brother’s proposal; and it was settled
+that Mr. Jones should be sent for early in the morning, if Miss Bennet
+were not decidedly better. Bingley was quite uncomfortable; his sisters
+declared that they were miserable. They solaced their wretchedness,
+however, by duets after supper, while he could find no better relief
+to his feelings than by giving his housekeeper directions that every
+attention might be paid to the sick lady and her sister.
+
+
+
+Chapter 9
+
+
+Elizabeth passed the chief of the night in her sister’s room, and in the
+morning had the pleasure of being able to send a tolerable answer to the
+inquiries which she very early received from Mr. Bingley by a housemaid,
+and some time afterwards from the two elegant ladies who waited on his
+sisters. In spite of this amendment, however, she requested to have a
+note sent to Longbourn, desiring her mother to visit Jane, and form her
+own judgement of her situation. The note was immediately dispatched, and
+its contents as quickly complied with. Mrs. Bennet, accompanied by her
+two youngest girls, reached Netherfield soon after the family breakfast.
+
+Had she found Jane in any apparent danger, Mrs. Bennet would have been
+very miserable; but being satisfied on seeing her that her illness was
+not alarming, she had no wish of her recovering immediately, as her
+restoration to health would probably remove her from Netherfield. She
+would not listen, therefore, to her daughter’s proposal of being carried
+home; neither did the apothecary, who arrived about the same time, think
+it at all advisable. After sitting a little while with Jane, on Miss
+Bingley’s appearance and invitation, the mother and three daughters all
+attended her into the breakfast parlour. Bingley met them with hopes
+that Mrs. Bennet had not found Miss Bennet worse than she expected.
+
+“Indeed I have, sir,” was her answer. “She is a great deal too ill to be
+moved. Mr. Jones says we must not think of moving her. We must trespass
+a little longer on your kindness.”
+
+“Removed!” cried Bingley. “It must not be thought of. My sister, I am
+sure, will not hear of her removal.”
+
+“You may depend upon it, Madam,” said Miss Bingley, with cold civility,
+“that Miss Bennet will receive every possible attention while she
+remains with us.”
+
+Mrs. Bennet was profuse in her acknowledgments.
+
+“I am sure,” she added, “if it was not for such good friends I do not
+know what would become of her, for she is very ill indeed, and suffers
+a vast deal, though with the greatest patience in the world, which is
+always the way with her, for she has, without exception, the sweetest
+temper I have ever met with. I often tell my other girls they are
+nothing to _her_. You have a sweet room here, Mr. Bingley, and a
+charming prospect over the gravel walk. I do not know a place in the
+country that is equal to Netherfield. You will not think of quitting it
+in a hurry, I hope, though you have but a short lease.”
+
+“Whatever I do is done in a hurry,” replied he; “and therefore if I
+should resolve to quit Netherfield, I should probably be off in five
+minutes. At present, however, I consider myself as quite fixed here.”
+
+“That is exactly what I should have supposed of you,” said Elizabeth.
+
+“You begin to comprehend me, do you?” cried he, turning towards her.
+
+“Oh! yes--I understand you perfectly.”
+
+“I wish I might take this for a compliment; but to be so easily seen
+through I am afraid is pitiful.”
+
+“That is as it happens. It does not follow that a deep, intricate
+character is more or less estimable than such a one as yours.”
+
+“Lizzy,” cried her mother, “remember where you are, and do not run on in
+the wild manner that you are suffered to do at home.”
+
+“I did not know before,” continued Bingley immediately, “that you were a
+studier of character. It must be an amusing study.”
+
+“Yes, but intricate characters are the _most_ amusing. They have at
+least that advantage.”
+
+“The country,” said Darcy, “can in general supply but a few subjects for
+such a study. In a country neighbourhood you move in a very confined and
+unvarying society.”
+
+“But people themselves alter so much, that there is something new to be
+observed in them for ever.”
+
+“Yes, indeed,” cried Mrs. Bennet, offended by his manner of mentioning
+a country neighbourhood. “I assure you there is quite as much of _that_
+going on in the country as in town.”
+
+Everybody was surprised, and Darcy, after looking at her for a moment,
+turned silently away. Mrs. Bennet, who fancied she had gained a complete
+victory over him, continued her triumph.
+
+“I cannot see that London has any great advantage over the country, for
+my part, except the shops and public places. The country is a vast deal
+pleasanter, is it not, Mr. Bingley?”
+
+“When I am in the country,” he replied, “I never wish to leave it;
+and when I am in town it is pretty much the same. They have each their
+advantages, and I can be equally happy in either.”
+
+“Aye--that is because you have the right disposition. But that
+gentleman,” looking at Darcy, “seemed to think the country was nothing
+at all.”
+
+“Indeed, Mamma, you are mistaken,” said Elizabeth, blushing for her
+mother. “You quite mistook Mr. Darcy. He only meant that there was not
+such a variety of people to be met with in the country as in the town,
+which you must acknowledge to be true.”
+
+“Certainly, my dear, nobody said there were; but as to not meeting
+with many people in this neighbourhood, I believe there are few
+neighbourhoods larger. I know we dine with four-and-twenty families.”
+
+Nothing but concern for Elizabeth could enable Bingley to keep his
+countenance. His sister was less delicate, and directed her eyes towards
+Mr. Darcy with a very expressive smile. Elizabeth, for the sake of
+saying something that might turn her mother’s thoughts, now asked her if
+Charlotte Lucas had been at Longbourn since _her_ coming away.
+
+“Yes, she called yesterday with her father. What an agreeable man Sir
+William is, Mr. Bingley, is not he? So much the man of fashion! So
+genteel and easy! He has always something to say to everybody. _That_
+is my idea of good breeding; and those persons who fancy themselves very
+important, and never open their mouths, quite mistake the matter.”
+
+“Did Charlotte dine with you?”
+
+“No, she would go home. I fancy she was wanted about the mince-pies. For
+my part, Mr. Bingley, I always keep servants that can do their own work;
+_my_ daughters are brought up very differently. But everybody is to
+judge for themselves, and the Lucases are a very good sort of girls,
+I assure you. It is a pity they are not handsome! Not that I think
+Charlotte so _very_ plain--but then she is our particular friend.”
+
+“She seems a very pleasant young woman.”
+
+“Oh! dear, yes; but you must own she is very plain. Lady Lucas herself
+has often said so, and envied me Jane’s beauty. I do not like to boast
+of my own child, but to be sure, Jane--one does not often see anybody
+better looking. It is what everybody says. I do not trust my own
+partiality. When she was only fifteen, there was a man at my brother
+Gardiner’s in town so much in love with her that my sister-in-law was
+sure he would make her an offer before we came away. But, however, he
+did not. Perhaps he thought her too young. However, he wrote some verses
+on her, and very pretty they were.”
+
+“And so ended his affection,” said Elizabeth impatiently. “There has
+been many a one, I fancy, overcome in the same way. I wonder who first
+discovered the efficacy of poetry in driving away love!”
+
+“I have been used to consider poetry as the _food_ of love,” said Darcy.
+
+“Of a fine, stout, healthy love it may. Everything nourishes what is
+strong already. But if it be only a slight, thin sort of inclination, I
+am convinced that one good sonnet will starve it entirely away.”
+
+Darcy only smiled; and the general pause which ensued made Elizabeth
+tremble lest her mother should be exposing herself again. She longed to
+speak, but could think of nothing to say; and after a short silence Mrs.
+Bennet began repeating her thanks to Mr. Bingley for his kindness to
+Jane, with an apology for troubling him also with Lizzy. Mr. Bingley was
+unaffectedly civil in his answer, and forced his younger sister to be
+civil also, and say what the occasion required. She performed her part
+indeed without much graciousness, but Mrs. Bennet was satisfied, and
+soon afterwards ordered her carriage. Upon this signal, the youngest of
+her daughters put herself forward. The two girls had been whispering to
+each other during the whole visit, and the result of it was, that the
+youngest should tax Mr. Bingley with having promised on his first coming
+into the country to give a ball at Netherfield.
+
+Lydia was a stout, well-grown girl of fifteen, with a fine complexion
+and good-humoured countenance; a favourite with her mother, whose
+affection had brought her into public at an early age. She had high
+animal spirits, and a sort of natural self-consequence, which the
+attention of the officers, to whom her uncle’s good dinners, and her own
+easy manners recommended her, had increased into assurance. She was very
+equal, therefore, to address Mr. Bingley on the subject of the ball, and
+abruptly reminded him of his promise; adding, that it would be the most
+shameful thing in the world if he did not keep it. His answer to this
+sudden attack was delightful to their mother’s ear:
+
+“I am perfectly ready, I assure you, to keep my engagement; and when
+your sister is recovered, you shall, if you please, name the very day of
+the ball. But you would not wish to be dancing when she is ill.”
+
+Lydia declared herself satisfied. “Oh! yes--it would be much better to
+wait till Jane was well, and by that time most likely Captain Carter
+would be at Meryton again. And when you have given _your_ ball,” she
+added, “I shall insist on their giving one also. I shall tell Colonel
+Forster it will be quite a shame if he does not.”
+
+Mrs. Bennet and her daughters then departed, and Elizabeth returned
+instantly to Jane, leaving her own and her relations’ behaviour to the
+remarks of the two ladies and Mr. Darcy; the latter of whom, however,
+could not be prevailed on to join in their censure of _her_, in spite of
+all Miss Bingley’s witticisms on _fine eyes_.
+
+
+
+Chapter 10
+
+
+The day passed much as the day before had done. Mrs. Hurst and Miss
+Bingley had spent some hours of the morning with the invalid, who
+continued, though slowly, to mend; and in the evening Elizabeth joined
+their party in the drawing-room. The loo-table, however, did not appear.
+Mr. Darcy was writing, and Miss Bingley, seated near him, was watching
+the progress of his letter and repeatedly calling off his attention by
+messages to his sister. Mr. Hurst and Mr. Bingley were at piquet, and
+Mrs. Hurst was observing their game.
+
+Elizabeth took up some needlework, and was sufficiently amused in
+attending to what passed between Darcy and his companion. The perpetual
+commendations of the lady, either on his handwriting, or on the evenness
+of his lines, or on the length of his letter, with the perfect unconcern
+with which her praises were received, formed a curious dialogue, and was
+exactly in union with her opinion of each.
+
+“How delighted Miss Darcy will be to receive such a letter!”
+
+He made no answer.
+
+“You write uncommonly fast.”
+
+“You are mistaken. I write rather slowly.”
+
+“How many letters you must have occasion to write in the course of a
+year! Letters of business, too! How odious I should think them!”
+
+“It is fortunate, then, that they fall to my lot instead of yours.”
+
+“Pray tell your sister that I long to see her.”
+
+“I have already told her so once, by your desire.”
+
+“I am afraid you do not like your pen. Let me mend it for you. I mend
+pens remarkably well.”
+
+“Thank you--but I always mend my own.”
+
+“How can you contrive to write so even?”
+
+He was silent.
+
+“Tell your sister I am delighted to hear of her improvement on the harp;
+and pray let her know that I am quite in raptures with her beautiful
+little design for a table, and I think it infinitely superior to Miss
+Grantley’s.”
+
+“Will you give me leave to defer your raptures till I write again? At
+present I have not room to do them justice.”
+
+“Oh! it is of no consequence. I shall see her in January. But do you
+always write such charming long letters to her, Mr. Darcy?”
+
+“They are generally long; but whether always charming it is not for me
+to determine.”
+
+“It is a rule with me, that a person who can write a long letter with
+ease, cannot write ill.”
+
+“That will not do for a compliment to Darcy, Caroline,” cried her
+brother, “because he does _not_ write with ease. He studies too much for
+words of four syllables. Do not you, Darcy?”
+
+“My style of writing is very different from yours.”
+
+“Oh!” cried Miss Bingley, “Charles writes in the most careless way
+imaginable. He leaves out half his words, and blots the rest.”
+
+“My ideas flow so rapidly that I have not time to express them--by which
+means my letters sometimes convey no ideas at all to my correspondents.”
+
+“Your humility, Mr. Bingley,” said Elizabeth, “must disarm reproof.”
+
+“Nothing is more deceitful,” said Darcy, “than the appearance of
+humility. It is often only carelessness of opinion, and sometimes an
+indirect boast.”
+
+“And which of the two do you call _my_ little recent piece of modesty?”
+
+“The indirect boast; for you are really proud of your defects in
+writing, because you consider them as proceeding from a rapidity of
+thought and carelessness of execution, which, if not estimable, you
+think at least highly interesting. The power of doing anything with
+quickness is always prized much by the possessor, and often without any
+attention to the imperfection of the performance. When you told Mrs.
+Bennet this morning that if you ever resolved upon quitting Netherfield
+you should be gone in five minutes, you meant it to be a sort of
+panegyric, of compliment to yourself--and yet what is there so very
+laudable in a precipitance which must leave very necessary business
+undone, and can be of no real advantage to yourself or anyone else?”
+
+“Nay,” cried Bingley, “this is too much, to remember at night all the
+foolish things that were said in the morning. And yet, upon my honour,
+I believe what I said of myself to be true, and I believe it at this
+moment. At least, therefore, I did not assume the character of needless
+precipitance merely to show off before the ladies.”
+
+“I dare say you believed it; but I am by no means convinced that
+you would be gone with such celerity. Your conduct would be quite as
+dependent on chance as that of any man I know; and if, as you were
+mounting your horse, a friend were to say, ‘Bingley, you had better
+stay till next week,’ you would probably do it, you would probably not
+go--and at another word, might stay a month.”
+
+“You have only proved by this,” cried Elizabeth, “that Mr. Bingley did
+not do justice to his own disposition. You have shown him off now much
+more than he did himself.”
+
+“I am exceedingly gratified,” said Bingley, “by your converting what my
+friend says into a compliment on the sweetness of my temper. But I am
+afraid you are giving it a turn which that gentleman did by no means
+intend; for he would certainly think better of me, if under such a
+circumstance I were to give a flat denial, and ride off as fast as I
+could.”
+
+“Would Mr. Darcy then consider the rashness of your original intentions
+as atoned for by your obstinacy in adhering to it?”
+
+“Upon my word, I cannot exactly explain the matter; Darcy must speak for
+himself.”
+
+“You expect me to account for opinions which you choose to call mine,
+but which I have never acknowledged. Allowing the case, however, to
+stand according to your representation, you must remember, Miss Bennet,
+that the friend who is supposed to desire his return to the house, and
+the delay of his plan, has merely desired it, asked it without offering
+one argument in favour of its propriety.”
+
+“To yield readily--easily--to the _persuasion_ of a friend is no merit
+with you.”
+
+“To yield without conviction is no compliment to the understanding of
+either.”
+
+“You appear to me, Mr. Darcy, to allow nothing for the influence of
+friendship and affection. A regard for the requester would often make
+one readily yield to a request, without waiting for arguments to reason
+one into it. I am not particularly speaking of such a case as you have
+supposed about Mr. Bingley. We may as well wait, perhaps, till the
+circumstance occurs before we discuss the discretion of his behaviour
+thereupon. But in general and ordinary cases between friend and friend,
+where one of them is desired by the other to change a resolution of no
+very great moment, should you think ill of that person for complying
+with the desire, without waiting to be argued into it?”
+
+“Will it not be advisable, before we proceed on this subject, to
+arrange with rather more precision the degree of importance which is to
+appertain to this request, as well as the degree of intimacy subsisting
+between the parties?”
+
+“By all means,” cried Bingley; “let us hear all the particulars, not
+forgetting their comparative height and size; for that will have more
+weight in the argument, Miss Bennet, than you may be aware of. I assure
+you, that if Darcy were not such a great tall fellow, in comparison with
+myself, I should not pay him half so much deference. I declare I do not
+know a more awful object than Darcy, on particular occasions, and in
+particular places; at his own house especially, and of a Sunday evening,
+when he has nothing to do.”
+
+Mr. Darcy smiled; but Elizabeth thought she could perceive that he was
+rather offended, and therefore checked her laugh. Miss Bingley warmly
+resented the indignity he had received, in an expostulation with her
+brother for talking such nonsense.
+
+“I see your design, Bingley,” said his friend. “You dislike an argument,
+and want to silence this.”
+
+“Perhaps I do. Arguments are too much like disputes. If you and Miss
+Bennet will defer yours till I am out of the room, I shall be very
+thankful; and then you may say whatever you like of me.”
+
+“What you ask,” said Elizabeth, “is no sacrifice on my side; and Mr.
+Darcy had much better finish his letter.”
+
+Mr. Darcy took her advice, and did finish his letter.
+
+When that business was over, he applied to Miss Bingley and Elizabeth
+for an indulgence of some music. Miss Bingley moved with some alacrity
+to the pianoforte; and, after a polite request that Elizabeth would lead
+the way which the other as politely and more earnestly negatived, she
+seated herself.
+
+Mrs. Hurst sang with her sister, and while they were thus employed,
+Elizabeth could not help observing, as she turned over some music-books
+that lay on the instrument, how frequently Mr. Darcy’s eyes were fixed
+on her. She hardly knew how to suppose that she could be an object of
+admiration to so great a man; and yet that he should look at her
+because he disliked her, was still more strange. She could only imagine,
+however, at last that she drew his notice because there was something
+more wrong and reprehensible, according to his ideas of right, than in
+any other person present. The supposition did not pain her. She liked
+him too little to care for his approbation.
+
+After playing some Italian songs, Miss Bingley varied the charm by
+a lively Scotch air; and soon afterwards Mr. Darcy, drawing near
+Elizabeth, said to her:
+
+“Do not you feel a great inclination, Miss Bennet, to seize such an
+opportunity of dancing a reel?”
+
+She smiled, but made no answer. He repeated the question, with some
+surprise at her silence.
+
+“Oh!” said she, “I heard you before, but I could not immediately
+determine what to say in reply. You wanted me, I know, to say ‘Yes,’
+that you might have the pleasure of despising my taste; but I always
+delight in overthrowing those kind of schemes, and cheating a person of
+their premeditated contempt. I have, therefore, made up my mind to tell
+you, that I do not want to dance a reel at all--and now despise me if
+you dare.”
+
+“Indeed I do not dare.”
+
+Elizabeth, having rather expected to affront him, was amazed at his
+gallantry; but there was a mixture of sweetness and archness in her
+manner which made it difficult for her to affront anybody; and Darcy
+had never been so bewitched by any woman as he was by her. He really
+believed, that were it not for the inferiority of her connections, he
+should be in some danger.
+
+Miss Bingley saw, or suspected enough to be jealous; and her great
+anxiety for the recovery of her dear friend Jane received some
+assistance from her desire of getting rid of Elizabeth.
+
+She often tried to provoke Darcy into disliking her guest, by talking of
+their supposed marriage, and planning his happiness in such an alliance.
+
+“I hope,” said she, as they were walking together in the shrubbery
+the next day, “you will give your mother-in-law a few hints, when this
+desirable event takes place, as to the advantage of holding her tongue;
+and if you can compass it, do cure the younger girls of running after
+officers. And, if I may mention so delicate a subject, endeavour to
+check that little something, bordering on conceit and impertinence,
+which your lady possesses.”
+
+“Have you anything else to propose for my domestic felicity?”
+
+“Oh! yes. Do let the portraits of your uncle and aunt Phillips be placed
+in the gallery at Pemberley. Put them next to your great-uncle the
+judge. They are in the same profession, you know, only in different
+lines. As for your Elizabeth’s picture, you must not have it taken, for
+what painter could do justice to those beautiful eyes?”
+
+“It would not be easy, indeed, to catch their expression, but their
+colour and shape, and the eyelashes, so remarkably fine, might be
+copied.”
+
+At that moment they were met from another walk by Mrs. Hurst and
+Elizabeth herself.
+
+“I did not know that you intended to walk,” said Miss Bingley, in some
+confusion, lest they had been overheard.
+
+“You used us abominably ill,” answered Mrs. Hurst, “running away without
+telling us that you were coming out.”
+
+Then taking the disengaged arm of Mr. Darcy, she left Elizabeth to walk
+by herself. The path just admitted three. Mr. Darcy felt their rudeness,
+and immediately said:
+
+“This walk is not wide enough for our party. We had better go into the
+avenue.”
+
+But Elizabeth, who had not the least inclination to remain with them,
+laughingly answered:
+
+“No, no; stay where you are. You are charmingly grouped, and appear
+to uncommon advantage. The picturesque would be spoilt by admitting a
+fourth. Good-bye.”
+
+She then ran gaily off, rejoicing as she rambled about, in the hope of
+being at home again in a day or two. Jane was already so much recovered
+as to intend leaving her room for a couple of hours that evening.
+
+
+
+Chapter 11
+
+
+When the ladies removed after dinner, Elizabeth ran up to her
+sister, and seeing her well guarded from cold, attended her into the
+drawing-room, where she was welcomed by her two friends with many
+professions of pleasure; and Elizabeth had never seen them so agreeable
+as they were during the hour which passed before the gentlemen appeared.
+Their powers of conversation were considerable. They could describe an
+entertainment with accuracy, relate an anecdote with humour, and laugh
+at their acquaintance with spirit.
+
+But when the gentlemen entered, Jane was no longer the first object;
+Miss Bingley’s eyes were instantly turned toward Darcy, and she had
+something to say to him before he had advanced many steps. He addressed
+himself to Miss Bennet, with a polite congratulation; Mr. Hurst also
+made her a slight bow, and said he was “very glad;” but diffuseness
+and warmth remained for Bingley’s salutation. He was full of joy and
+attention. The first half-hour was spent in piling up the fire, lest she
+should suffer from the change of room; and she removed at his desire
+to the other side of the fireplace, that she might be further from
+the door. He then sat down by her, and talked scarcely to anyone
+else. Elizabeth, at work in the opposite corner, saw it all with great
+delight.
+
+When tea was over, Mr. Hurst reminded his sister-in-law of the
+card-table--but in vain. She had obtained private intelligence that Mr.
+Darcy did not wish for cards; and Mr. Hurst soon found even his open
+petition rejected. She assured him that no one intended to play, and
+the silence of the whole party on the subject seemed to justify her. Mr.
+Hurst had therefore nothing to do, but to stretch himself on one of the
+sofas and go to sleep. Darcy took up a book; Miss Bingley did the same;
+and Mrs. Hurst, principally occupied in playing with her bracelets
+and rings, joined now and then in her brother’s conversation with Miss
+Bennet.
+
+Miss Bingley’s attention was quite as much engaged in watching Mr.
+Darcy’s progress through _his_ book, as in reading her own; and she
+was perpetually either making some inquiry, or looking at his page. She
+could not win him, however, to any conversation; he merely answered her
+question, and read on. At length, quite exhausted by the attempt to be
+amused with her own book, which she had only chosen because it was the
+second volume of his, she gave a great yawn and said, “How pleasant
+it is to spend an evening in this way! I declare after all there is no
+enjoyment like reading! How much sooner one tires of anything than of a
+book! When I have a house of my own, I shall be miserable if I have not
+an excellent library.”
+
+No one made any reply. She then yawned again, threw aside her book, and
+cast her eyes round the room in quest for some amusement; when hearing
+her brother mentioning a ball to Miss Bennet, she turned suddenly
+towards him and said:
+
+“By the bye, Charles, are you really serious in meditating a dance at
+Netherfield? I would advise you, before you determine on it, to consult
+the wishes of the present party; I am much mistaken if there are
+not some among us to whom a ball would be rather a punishment than a
+pleasure.”
+
+“If you mean Darcy,” cried her brother, “he may go to bed, if he
+chooses, before it begins--but as for the ball, it is quite a settled
+thing; and as soon as Nicholls has made white soup enough, I shall send
+round my cards.”
+
+“I should like balls infinitely better,” she replied, “if they were
+carried on in a different manner; but there is something insufferably
+tedious in the usual process of such a meeting. It would surely be much
+more rational if conversation instead of dancing were made the order of
+the day.”
+
+“Much more rational, my dear Caroline, I dare say, but it would not be
+near so much like a ball.”
+
+Miss Bingley made no answer, and soon afterwards she got up and walked
+about the room. Her figure was elegant, and she walked well; but
+Darcy, at whom it was all aimed, was still inflexibly studious. In
+the desperation of her feelings, she resolved on one effort more, and,
+turning to Elizabeth, said:
+
+“Miss Eliza Bennet, let me persuade you to follow my example, and take a
+turn about the room. I assure you it is very refreshing after sitting so
+long in one attitude.”
+
+Elizabeth was surprised, but agreed to it immediately. Miss Bingley
+succeeded no less in the real object of her civility; Mr. Darcy looked
+up. He was as much awake to the novelty of attention in that quarter as
+Elizabeth herself could be, and unconsciously closed his book. He was
+directly invited to join their party, but he declined it, observing that
+he could imagine but two motives for their choosing to walk up and down
+the room together, with either of which motives his joining them would
+interfere. “What could he mean? She was dying to know what could be his
+meaning?”--and asked Elizabeth whether she could at all understand him?
+
+“Not at all,” was her answer; “but depend upon it, he means to be severe
+on us, and our surest way of disappointing him will be to ask nothing
+about it.”
+
+Miss Bingley, however, was incapable of disappointing Mr. Darcy in
+anything, and persevered therefore in requiring an explanation of his
+two motives.
+
+“I have not the smallest objection to explaining them,” said he, as soon
+as she allowed him to speak. “You either choose this method of passing
+the evening because you are in each other’s confidence, and have secret
+affairs to discuss, or because you are conscious that your figures
+appear to the greatest advantage in walking; if the first, I would be
+completely in your way, and if the second, I can admire you much better
+as I sit by the fire.”
+
+“Oh! shocking!” cried Miss Bingley. “I never heard anything so
+abominable. How shall we punish him for such a speech?”
+
+“Nothing so easy, if you have but the inclination,” said Elizabeth. “We
+can all plague and punish one another. Tease him--laugh at him. Intimate
+as you are, you must know how it is to be done.”
+
+“But upon my honour, I do _not_. I do assure you that my intimacy has
+not yet taught me _that_. Tease calmness of manner and presence of
+mind! No, no; I feel he may defy us there. And as to laughter, we will
+not expose ourselves, if you please, by attempting to laugh without a
+subject. Mr. Darcy may hug himself.”
+
+“Mr. Darcy is not to be laughed at!” cried Elizabeth. “That is an
+uncommon advantage, and uncommon I hope it will continue, for it would
+be a great loss to _me_ to have many such acquaintances. I dearly love a
+laugh.”
+
+“Miss Bingley,” said he, “has given me more credit than can be.
+The wisest and the best of men--nay, the wisest and best of their
+actions--may be rendered ridiculous by a person whose first object in
+life is a joke.”
+
+“Certainly,” replied Elizabeth--“there are such people, but I hope I
+am not one of _them_. I hope I never ridicule what is wise and good.
+Follies and nonsense, whims and inconsistencies, _do_ divert me, I own,
+and I laugh at them whenever I can. But these, I suppose, are precisely
+what you are without.”
+
+“Perhaps that is not possible for anyone. But it has been the study
+of my life to avoid those weaknesses which often expose a strong
+understanding to ridicule.”
+
+“Such as vanity and pride.”
+
+“Yes, vanity is a weakness indeed. But pride--where there is a real
+superiority of mind, pride will be always under good regulation.”
+
+Elizabeth turned away to hide a smile.
+
+“Your examination of Mr. Darcy is over, I presume,” said Miss Bingley;
+“and pray what is the result?”
+
+“I am perfectly convinced by it that Mr. Darcy has no defect. He owns it
+himself without disguise.”
+
+“No,” said Darcy, “I have made no such pretension. I have faults enough,
+but they are not, I hope, of understanding. My temper I dare not vouch
+for. It is, I believe, too little yielding--certainly too little for the
+convenience of the world. I cannot forget the follies and vices of others
+so soon as I ought, nor their offenses against myself. My feelings
+are not puffed about with every attempt to move them. My temper
+would perhaps be called resentful. My good opinion once lost, is lost
+forever.”
+
+“_That_ is a failing indeed!” cried Elizabeth. “Implacable resentment
+_is_ a shade in a character. But you have chosen your fault well. I
+really cannot _laugh_ at it. You are safe from me.”
+
+“There is, I believe, in every disposition a tendency to some particular
+evil--a natural defect, which not even the best education can overcome.”
+
+“And _your_ defect is to hate everybody.”
+
+“And yours,” he replied with a smile, “is willfully to misunderstand
+them.”
+
+“Do let us have a little music,” cried Miss Bingley, tired of a
+conversation in which she had no share. “Louisa, you will not mind my
+waking Mr. Hurst?”
+
+Her sister had not the smallest objection, and the pianoforte was
+opened; and Darcy, after a few moments’ recollection, was not sorry for
+it. He began to feel the danger of paying Elizabeth too much attention.
+
+
+
+Chapter 12
+
+
+In consequence of an agreement between the sisters, Elizabeth wrote the
+next morning to their mother, to beg that the carriage might be sent for
+them in the course of the day. But Mrs. Bennet, who had calculated on
+her daughters remaining at Netherfield till the following Tuesday, which
+would exactly finish Jane’s week, could not bring herself to receive
+them with pleasure before. Her answer, therefore, was not propitious, at
+least not to Elizabeth’s wishes, for she was impatient to get home. Mrs.
+Bennet sent them word that they could not possibly have the carriage
+before Tuesday; and in her postscript it was added, that if Mr. Bingley
+and his sister pressed them to stay longer, she could spare them
+very well. Against staying longer, however, Elizabeth was positively
+resolved--nor did she much expect it would be asked; and fearful, on the
+contrary, as being considered as intruding themselves needlessly long,
+she urged Jane to borrow Mr. Bingley’s carriage immediately, and at
+length it was settled that their original design of leaving Netherfield
+that morning should be mentioned, and the request made.
+
+The communication excited many professions of concern; and enough was
+said of wishing them to stay at least till the following day to work
+on Jane; and till the morrow their going was deferred. Miss Bingley was
+then sorry that she had proposed the delay, for her jealousy and dislike
+of one sister much exceeded her affection for the other.
+
+The master of the house heard with real sorrow that they were to go so
+soon, and repeatedly tried to persuade Miss Bennet that it would not be
+safe for her--that she was not enough recovered; but Jane was firm where
+she felt herself to be right.
+
+To Mr. Darcy it was welcome intelligence--Elizabeth had been at
+Netherfield long enough. She attracted him more than he liked--and Miss
+Bingley was uncivil to _her_, and more teasing than usual to himself.
+He wisely resolved to be particularly careful that no sign of admiration
+should _now_ escape him, nothing that could elevate her with the hope
+of influencing his felicity; sensible that if such an idea had been
+suggested, his behaviour during the last day must have material weight
+in confirming or crushing it. Steady to his purpose, he scarcely spoke
+ten words to her through the whole of Saturday, and though they were
+at one time left by themselves for half-an-hour, he adhered most
+conscientiously to his book, and would not even look at her.
+
+On Sunday, after morning service, the separation, so agreeable to almost
+all, took place. Miss Bingley’s civility to Elizabeth increased at last
+very rapidly, as well as her affection for Jane; and when they parted,
+after assuring the latter of the pleasure it would always give her
+to see her either at Longbourn or Netherfield, and embracing her most
+tenderly, she even shook hands with the former. Elizabeth took leave of
+the whole party in the liveliest of spirits.
+
+They were not welcomed home very cordially by their mother. Mrs. Bennet
+wondered at their coming, and thought them very wrong to give so much
+trouble, and was sure Jane would have caught cold again. But their
+father, though very laconic in his expressions of pleasure, was really
+glad to see them; he had felt their importance in the family circle. The
+evening conversation, when they were all assembled, had lost much of
+its animation, and almost all its sense by the absence of Jane and
+Elizabeth.
+
+They found Mary, as usual, deep in the study of thorough-bass and human
+nature; and had some extracts to admire, and some new observations of
+threadbare morality to listen to. Catherine and Lydia had information
+for them of a different sort. Much had been done and much had been said
+in the regiment since the preceding Wednesday; several of the officers
+had dined lately with their uncle, a private had been flogged, and it
+had actually been hinted that Colonel Forster was going to be married.
+
+
+
+Chapter 13
+
+
+“I hope, my dear,” said Mr. Bennet to his wife, as they were at
+breakfast the next morning, “that you have ordered a good dinner to-day,
+because I have reason to expect an addition to our family party.”
+
+“Who do you mean, my dear? I know of nobody that is coming, I am sure,
+unless Charlotte Lucas should happen to call in--and I hope _my_ dinners
+are good enough for her. I do not believe she often sees such at home.”
+
+“The person of whom I speak is a gentleman, and a stranger.”
+
+Mrs. Bennet’s eyes sparkled. “A gentleman and a stranger! It is Mr.
+Bingley, I am sure! Well, I am sure I shall be extremely glad to see Mr.
+Bingley. But--good Lord! how unlucky! There is not a bit of fish to be
+got to-day. Lydia, my love, ring the bell--I must speak to Hill this
+moment.”
+
+“It is _not_ Mr. Bingley,” said her husband; “it is a person whom I
+never saw in the whole course of my life.”
+
+This roused a general astonishment; and he had the pleasure of being
+eagerly questioned by his wife and his five daughters at once.
+
+After amusing himself some time with their curiosity, he thus explained:
+
+“About a month ago I received this letter; and about a fortnight ago
+I answered it, for I thought it a case of some delicacy, and requiring
+early attention. It is from my cousin, Mr. Collins, who, when I am dead,
+may turn you all out of this house as soon as he pleases.”
+
+“Oh! my dear,” cried his wife, “I cannot bear to hear that mentioned.
+Pray do not talk of that odious man. I do think it is the hardest thing
+in the world, that your estate should be entailed away from your own
+children; and I am sure, if I had been you, I should have tried long ago
+to do something or other about it.”
+
+Jane and Elizabeth tried to explain to her the nature of an entail. They
+had often attempted to do it before, but it was a subject on which
+Mrs. Bennet was beyond the reach of reason, and she continued to rail
+bitterly against the cruelty of settling an estate away from a family of
+five daughters, in favour of a man whom nobody cared anything about.
+
+“It certainly is a most iniquitous affair,” said Mr. Bennet, “and
+nothing can clear Mr. Collins from the guilt of inheriting Longbourn.
+But if you will listen to his letter, you may perhaps be a little
+softened by his manner of expressing himself.”
+
+“No, that I am sure I shall not; and I think it is very impertinent of
+him to write to you at all, and very hypocritical. I hate such false
+friends. Why could he not keep on quarreling with you, as his father did
+before him?”
+
+“Why, indeed; he does seem to have had some filial scruples on that
+head, as you will hear.”
+
+“Hunsford, near Westerham, Kent, 15th October.
+
+“Dear Sir,--
+
+“The disagreement subsisting between yourself and my late honoured
+father always gave me much uneasiness, and since I have had the
+misfortune to lose him, I have frequently wished to heal the breach; but
+for some time I was kept back by my own doubts, fearing lest it might
+seem disrespectful to his memory for me to be on good terms with anyone
+with whom it had always pleased him to be at variance.--‘There, Mrs.
+Bennet.’--My mind, however, is now made up on the subject, for having
+received ordination at Easter, I have been so fortunate as to be
+distinguished by the patronage of the Right Honourable Lady Catherine de
+Bourgh, widow of Sir Lewis de Bourgh, whose bounty and beneficence has
+preferred me to the valuable rectory of this parish, where it shall be
+my earnest endeavour to demean myself with grateful respect towards her
+ladyship, and be ever ready to perform those rites and ceremonies which
+are instituted by the Church of England. As a clergyman, moreover, I
+feel it my duty to promote and establish the blessing of peace in
+all families within the reach of my influence; and on these grounds I
+flatter myself that my present overtures are highly commendable, and
+that the circumstance of my being next in the entail of Longbourn estate
+will be kindly overlooked on your side, and not lead you to reject the
+offered olive-branch. I cannot be otherwise than concerned at being the
+means of injuring your amiable daughters, and beg leave to apologise for
+it, as well as to assure you of my readiness to make them every possible
+amends--but of this hereafter. If you should have no objection to
+receive me into your house, I propose myself the satisfaction of waiting
+on you and your family, Monday, November 18th, by four o’clock, and
+shall probably trespass on your hospitality till the Saturday se’ennight
+following, which I can do without any inconvenience, as Lady Catherine
+is far from objecting to my occasional absence on a Sunday, provided
+that some other clergyman is engaged to do the duty of the day.--I
+remain, dear sir, with respectful compliments to your lady and
+daughters, your well-wisher and friend,
+
+“WILLIAM COLLINS”
+
+“At four o’clock, therefore, we may expect this peace-making gentleman,”
+ said Mr. Bennet, as he folded up the letter. “He seems to be a most
+conscientious and polite young man, upon my word, and I doubt not will
+prove a valuable acquaintance, especially if Lady Catherine should be so
+indulgent as to let him come to us again.”
+
+“There is some sense in what he says about the girls, however, and if
+he is disposed to make them any amends, I shall not be the person to
+discourage him.”
+
+“Though it is difficult,” said Jane, “to guess in what way he can mean
+to make us the atonement he thinks our due, the wish is certainly to his
+credit.”
+
+Elizabeth was chiefly struck by his extraordinary deference for Lady
+Catherine, and his kind intention of christening, marrying, and burying
+his parishioners whenever it were required.
+
+“He must be an oddity, I think,” said she. “I cannot make him
+out.--There is something very pompous in his style.--And what can he
+mean by apologising for being next in the entail?--We cannot suppose he
+would help it if he could.--Could he be a sensible man, sir?”
+
+“No, my dear, I think not. I have great hopes of finding him quite the
+reverse. There is a mixture of servility and self-importance in his
+letter, which promises well. I am impatient to see him.”
+
+“In point of composition,” said Mary, “the letter does not seem
+defective. The idea of the olive-branch perhaps is not wholly new, yet I
+think it is well expressed.”
+
+To Catherine and Lydia, neither the letter nor its writer were in any
+degree interesting. It was next to impossible that their cousin should
+come in a scarlet coat, and it was now some weeks since they had
+received pleasure from the society of a man in any other colour. As for
+their mother, Mr. Collins’s letter had done away much of her ill-will,
+and she was preparing to see him with a degree of composure which
+astonished her husband and daughters.
+
+Mr. Collins was punctual to his time, and was received with great
+politeness by the whole family. Mr. Bennet indeed said little; but the
+ladies were ready enough to talk, and Mr. Collins seemed neither in
+need of encouragement, nor inclined to be silent himself. He was a
+tall, heavy-looking young man of five-and-twenty. His air was grave and
+stately, and his manners were very formal. He had not been long seated
+before he complimented Mrs. Bennet on having so fine a family of
+daughters; said he had heard much of their beauty, but that in this
+instance fame had fallen short of the truth; and added, that he did
+not doubt her seeing them all in due time disposed of in marriage. This
+gallantry was not much to the taste of some of his hearers; but Mrs.
+Bennet, who quarreled with no compliments, answered most readily.
+
+“You are very kind, I am sure; and I wish with all my heart it may
+prove so, for else they will be destitute enough. Things are settled so
+oddly.”
+
+“You allude, perhaps, to the entail of this estate.”
+
+“Ah! sir, I do indeed. It is a grievous affair to my poor girls, you
+must confess. Not that I mean to find fault with _you_, for such things
+I know are all chance in this world. There is no knowing how estates
+will go when once they come to be entailed.”
+
+“I am very sensible, madam, of the hardship to my fair cousins, and
+could say much on the subject, but that I am cautious of appearing
+forward and precipitate. But I can assure the young ladies that I come
+prepared to admire them. At present I will not say more; but, perhaps,
+when we are better acquainted--”
+
+He was interrupted by a summons to dinner; and the girls smiled on each
+other. They were not the only objects of Mr. Collins’s admiration. The
+hall, the dining-room, and all its furniture, were examined and praised;
+and his commendation of everything would have touched Mrs. Bennet’s
+heart, but for the mortifying supposition of his viewing it all as his
+own future property. The dinner too in its turn was highly admired; and
+he begged to know to which of his fair cousins the excellency of its
+cooking was owing. But he was set right there by Mrs. Bennet, who
+assured him with some asperity that they were very well able to keep a
+good cook, and that her daughters had nothing to do in the kitchen. He
+begged pardon for having displeased her. In a softened tone she declared
+herself not at all offended; but he continued to apologise for about a
+quarter of an hour.
+
+
+
+Chapter 14
+
+
+During dinner, Mr. Bennet scarcely spoke at all; but when the servants
+were withdrawn, he thought it time to have some conversation with his
+guest, and therefore started a subject in which he expected him to
+shine, by observing that he seemed very fortunate in his patroness. Lady
+Catherine de Bourgh’s attention to his wishes, and consideration for
+his comfort, appeared very remarkable. Mr. Bennet could not have chosen
+better. Mr. Collins was eloquent in her praise. The subject elevated him
+to more than usual solemnity of manner, and with a most important aspect
+he protested that “he had never in his life witnessed such behaviour in
+a person of rank--such affability and condescension, as he had himself
+experienced from Lady Catherine. She had been graciously pleased to
+approve of both of the discourses which he had already had the honour of
+preaching before her. She had also asked him twice to dine at Rosings,
+and had sent for him only the Saturday before, to make up her pool of
+quadrille in the evening. Lady Catherine was reckoned proud by many
+people he knew, but _he_ had never seen anything but affability in her.
+She had always spoken to him as she would to any other gentleman; she
+made not the smallest objection to his joining in the society of the
+neighbourhood nor to his leaving the parish occasionally for a week or
+two, to visit his relations. She had even condescended to advise him to
+marry as soon as he could, provided he chose with discretion; and had
+once paid him a visit in his humble parsonage, where she had perfectly
+approved all the alterations he had been making, and had even vouchsafed
+to suggest some herself--some shelves in the closet up stairs.”
+
+“That is all very proper and civil, I am sure,” said Mrs. Bennet, “and
+I dare say she is a very agreeable woman. It is a pity that great ladies
+in general are not more like her. Does she live near you, sir?”
+
+“The garden in which stands my humble abode is separated only by a lane
+from Rosings Park, her ladyship’s residence.”
+
+“I think you said she was a widow, sir? Has she any family?”
+
+“She has only one daughter, the heiress of Rosings, and of very
+extensive property.”
+
+“Ah!” said Mrs. Bennet, shaking her head, “then she is better off than
+many girls. And what sort of young lady is she? Is she handsome?”
+
+“She is a most charming young lady indeed. Lady Catherine herself says
+that, in point of true beauty, Miss de Bourgh is far superior to the
+handsomest of her sex, because there is that in her features which marks
+the young lady of distinguished birth. She is unfortunately of a sickly
+constitution, which has prevented her from making that progress in many
+accomplishments which she could not have otherwise failed of, as I am
+informed by the lady who superintended her education, and who still
+resides with them. But she is perfectly amiable, and often condescends
+to drive by my humble abode in her little phaeton and ponies.”
+
+“Has she been presented? I do not remember her name among the ladies at
+court.”
+
+“Her indifferent state of health unhappily prevents her being in town;
+and by that means, as I told Lady Catherine one day, has deprived the
+British court of its brightest ornament. Her ladyship seemed pleased
+with the idea; and you may imagine that I am happy on every occasion to
+offer those little delicate compliments which are always acceptable
+to ladies. I have more than once observed to Lady Catherine, that
+her charming daughter seemed born to be a duchess, and that the most
+elevated rank, instead of giving her consequence, would be adorned by
+her. These are the kind of little things which please her ladyship, and
+it is a sort of attention which I conceive myself peculiarly bound to
+pay.”
+
+“You judge very properly,” said Mr. Bennet, “and it is happy for you
+that you possess the talent of flattering with delicacy. May I ask
+whether these pleasing attentions proceed from the impulse of the
+moment, or are the result of previous study?”
+
+“They arise chiefly from what is passing at the time, and though I
+sometimes amuse myself with suggesting and arranging such little elegant
+compliments as may be adapted to ordinary occasions, I always wish to
+give them as unstudied an air as possible.”
+
+Mr. Bennet’s expectations were fully answered. His cousin was as absurd
+as he had hoped, and he listened to him with the keenest enjoyment,
+maintaining at the same time the most resolute composure of countenance,
+and, except in an occasional glance at Elizabeth, requiring no partner
+in his pleasure.
+
+By tea-time, however, the dose had been enough, and Mr. Bennet was glad
+to take his guest into the drawing-room again, and, when tea was over,
+glad to invite him to read aloud to the ladies. Mr. Collins readily
+assented, and a book was produced; but, on beholding it (for everything
+announced it to be from a circulating library), he started back, and
+begging pardon, protested that he never read novels. Kitty stared at
+him, and Lydia exclaimed. Other books were produced, and after some
+deliberation he chose Fordyce’s Sermons. Lydia gaped as he opened the
+volume, and before he had, with very monotonous solemnity, read three
+pages, she interrupted him with:
+
+“Do you know, mamma, that my uncle Phillips talks of turning away
+Richard; and if he does, Colonel Forster will hire him. My aunt told me
+so herself on Saturday. I shall walk to Meryton to-morrow to hear more
+about it, and to ask when Mr. Denny comes back from town.”
+
+Lydia was bid by her two eldest sisters to hold her tongue; but Mr.
+Collins, much offended, laid aside his book, and said:
+
+“I have often observed how little young ladies are interested by books
+of a serious stamp, though written solely for their benefit. It amazes
+me, I confess; for, certainly, there can be nothing so advantageous to
+them as instruction. But I will no longer importune my young cousin.”
+
+Then turning to Mr. Bennet, he offered himself as his antagonist at
+backgammon. Mr. Bennet accepted the challenge, observing that he acted
+very wisely in leaving the girls to their own trifling amusements.
+Mrs. Bennet and her daughters apologised most civilly for Lydia’s
+interruption, and promised that it should not occur again, if he would
+resume his book; but Mr. Collins, after assuring them that he bore his
+young cousin no ill-will, and should never resent her behaviour as any
+affront, seated himself at another table with Mr. Bennet, and prepared
+for backgammon.
+
+
+
+Chapter 15
+
+
+Mr. Collins was not a sensible man, and the deficiency of nature had
+been but little assisted by education or society; the greatest part
+of his life having been spent under the guidance of an illiterate and
+miserly father; and though he belonged to one of the universities, he
+had merely kept the necessary terms, without forming at it any useful
+acquaintance. The subjection in which his father had brought him up had
+given him originally great humility of manner; but it was now a
+good deal counteracted by the self-conceit of a weak head, living in
+retirement, and the consequential feelings of early and unexpected
+prosperity. A fortunate chance had recommended him to Lady Catherine de
+Bourgh when the living of Hunsford was vacant; and the respect which
+he felt for her high rank, and his veneration for her as his patroness,
+mingling with a very good opinion of himself, of his authority as a
+clergyman, and his right as a rector, made him altogether a mixture of
+pride and obsequiousness, self-importance and humility.
+
+Having now a good house and a very sufficient income, he intended to
+marry; and in seeking a reconciliation with the Longbourn family he had
+a wife in view, as he meant to choose one of the daughters, if he found
+them as handsome and amiable as they were represented by common report.
+This was his plan of amends--of atonement--for inheriting their father’s
+estate; and he thought it an excellent one, full of eligibility and
+suitableness, and excessively generous and disinterested on his own
+part.
+
+His plan did not vary on seeing them. Miss Bennet’s lovely face
+confirmed his views, and established all his strictest notions of what
+was due to seniority; and for the first evening _she_ was his settled
+choice. The next morning, however, made an alteration; for in a
+quarter of an hour’s tete-a-tete with Mrs. Bennet before breakfast, a
+conversation beginning with his parsonage-house, and leading naturally
+to the avowal of his hopes, that a mistress might be found for it at
+Longbourn, produced from her, amid very complaisant smiles and general
+encouragement, a caution against the very Jane he had fixed on. “As to
+her _younger_ daughters, she could not take upon her to say--she could
+not positively answer--but she did not _know_ of any prepossession; her
+_eldest_ daughter, she must just mention--she felt it incumbent on her
+to hint, was likely to be very soon engaged.”
+
+Mr. Collins had only to change from Jane to Elizabeth--and it was soon
+done--done while Mrs. Bennet was stirring the fire. Elizabeth, equally
+next to Jane in birth and beauty, succeeded her of course.
+
+Mrs. Bennet treasured up the hint, and trusted that she might soon have
+two daughters married; and the man whom she could not bear to speak of
+the day before was now high in her good graces.
+
+Lydia’s intention of walking to Meryton was not forgotten; every sister
+except Mary agreed to go with her; and Mr. Collins was to attend them,
+at the request of Mr. Bennet, who was most anxious to get rid of him,
+and have his library to himself; for thither Mr. Collins had followed
+him after breakfast; and there he would continue, nominally engaged with
+one of the largest folios in the collection, but really talking to Mr.
+Bennet, with little cessation, of his house and garden at Hunsford. Such
+doings discomposed Mr. Bennet exceedingly. In his library he had been
+always sure of leisure and tranquillity; and though prepared, as he told
+Elizabeth, to meet with folly and conceit in every other room of the
+house, he was used to be free from them there; his civility, therefore,
+was most prompt in inviting Mr. Collins to join his daughters in their
+walk; and Mr. Collins, being in fact much better fitted for a walker
+than a reader, was extremely pleased to close his large book, and go.
+
+In pompous nothings on his side, and civil assents on that of his
+cousins, their time passed till they entered Meryton. The attention of
+the younger ones was then no longer to be gained by him. Their eyes were
+immediately wandering up in the street in quest of the officers, and
+nothing less than a very smart bonnet indeed, or a really new muslin in
+a shop window, could recall them.
+
+But the attention of every lady was soon caught by a young man, whom
+they had never seen before, of most gentlemanlike appearance, walking
+with another officer on the other side of the way. The officer was
+the very Mr. Denny concerning whose return from London Lydia came
+to inquire, and he bowed as they passed. All were struck with the
+stranger’s air, all wondered who he could be; and Kitty and Lydia,
+determined if possible to find out, led the way across the street, under
+pretense of wanting something in an opposite shop, and fortunately
+had just gained the pavement when the two gentlemen, turning back, had
+reached the same spot. Mr. Denny addressed them directly, and entreated
+permission to introduce his friend, Mr. Wickham, who had returned with
+him the day before from town, and he was happy to say had accepted a
+commission in their corps. This was exactly as it should be; for the
+young man wanted only regimentals to make him completely charming.
+His appearance was greatly in his favour; he had all the best part of
+beauty, a fine countenance, a good figure, and very pleasing address.
+The introduction was followed up on his side by a happy readiness
+of conversation--a readiness at the same time perfectly correct and
+unassuming; and the whole party were still standing and talking together
+very agreeably, when the sound of horses drew their notice, and Darcy
+and Bingley were seen riding down the street. On distinguishing the
+ladies of the group, the two gentlemen came directly towards them, and
+began the usual civilities. Bingley was the principal spokesman, and
+Miss Bennet the principal object. He was then, he said, on his way to
+Longbourn on purpose to inquire after her. Mr. Darcy corroborated
+it with a bow, and was beginning to determine not to fix his eyes
+on Elizabeth, when they were suddenly arrested by the sight of the
+stranger, and Elizabeth happening to see the countenance of both as they
+looked at each other, was all astonishment at the effect of the meeting.
+Both changed colour, one looked white, the other red. Mr. Wickham,
+after a few moments, touched his hat--a salutation which Mr. Darcy just
+deigned to return. What could be the meaning of it? It was impossible to
+imagine; it was impossible not to long to know.
+
+In another minute, Mr. Bingley, but without seeming to have noticed what
+passed, took leave and rode on with his friend.
+
+Mr. Denny and Mr. Wickham walked with the young ladies to the door of
+Mr. Phillip’s house, and then made their bows, in spite of Miss Lydia’s
+pressing entreaties that they should come in, and even in spite of
+Mrs. Phillips’s throwing up the parlour window and loudly seconding the
+invitation.
+
+Mrs. Phillips was always glad to see her nieces; and the two eldest,
+from their recent absence, were particularly welcome, and she was
+eagerly expressing her surprise at their sudden return home, which, as
+their own carriage had not fetched them, she should have known nothing
+about, if she had not happened to see Mr. Jones’s shop-boy in the
+street, who had told her that they were not to send any more draughts to
+Netherfield because the Miss Bennets were come away, when her civility
+was claimed towards Mr. Collins by Jane’s introduction of him. She
+received him with her very best politeness, which he returned with
+as much more, apologising for his intrusion, without any previous
+acquaintance with her, which he could not help flattering himself,
+however, might be justified by his relationship to the young ladies who
+introduced him to her notice. Mrs. Phillips was quite awed by such an
+excess of good breeding; but her contemplation of one stranger was soon
+put to an end by exclamations and inquiries about the other; of whom,
+however, she could only tell her nieces what they already knew, that
+Mr. Denny had brought him from London, and that he was to have a
+lieutenant’s commission in the ----shire. She had been watching him the
+last hour, she said, as he walked up and down the street, and had Mr.
+Wickham appeared, Kitty and Lydia would certainly have continued the
+occupation, but unluckily no one passed windows now except a few of the
+officers, who, in comparison with the stranger, were become “stupid,
+disagreeable fellows.” Some of them were to dine with the Phillipses
+the next day, and their aunt promised to make her husband call on Mr.
+Wickham, and give him an invitation also, if the family from Longbourn
+would come in the evening. This was agreed to, and Mrs. Phillips
+protested that they would have a nice comfortable noisy game of lottery
+tickets, and a little bit of hot supper afterwards. The prospect of such
+delights was very cheering, and they parted in mutual good spirits. Mr.
+Collins repeated his apologies in quitting the room, and was assured
+with unwearying civility that they were perfectly needless.
+
+As they walked home, Elizabeth related to Jane what she had seen pass
+between the two gentlemen; but though Jane would have defended either
+or both, had they appeared to be in the wrong, she could no more explain
+such behaviour than her sister.
+
+Mr. Collins on his return highly gratified Mrs. Bennet by admiring
+Mrs. Phillips’s manners and politeness. He protested that, except Lady
+Catherine and her daughter, he had never seen a more elegant woman;
+for she had not only received him with the utmost civility, but even
+pointedly included him in her invitation for the next evening, although
+utterly unknown to her before. Something, he supposed, might be
+attributed to his connection with them, but yet he had never met with so
+much attention in the whole course of his life.
+
+
+
+Chapter 16
+
+
+As no objection was made to the young people’s engagement with their
+aunt, and all Mr. Collins’s scruples of leaving Mr. and Mrs. Bennet for
+a single evening during his visit were most steadily resisted, the coach
+conveyed him and his five cousins at a suitable hour to Meryton; and
+the girls had the pleasure of hearing, as they entered the drawing-room,
+that Mr. Wickham had accepted their uncle’s invitation, and was then in
+the house.
+
+When this information was given, and they had all taken their seats, Mr.
+Collins was at leisure to look around him and admire, and he was so much
+struck with the size and furniture of the apartment, that he declared he
+might almost have supposed himself in the small summer breakfast
+parlour at Rosings; a comparison that did not at first convey much
+gratification; but when Mrs. Phillips understood from him what
+Rosings was, and who was its proprietor--when she had listened to the
+description of only one of Lady Catherine’s drawing-rooms, and found
+that the chimney-piece alone had cost eight hundred pounds, she felt all
+the force of the compliment, and would hardly have resented a comparison
+with the housekeeper’s room.
+
+In describing to her all the grandeur of Lady Catherine and her mansion,
+with occasional digressions in praise of his own humble abode, and
+the improvements it was receiving, he was happily employed until the
+gentlemen joined them; and he found in Mrs. Phillips a very attentive
+listener, whose opinion of his consequence increased with what she
+heard, and who was resolving to retail it all among her neighbours as
+soon as she could. To the girls, who could not listen to their cousin,
+and who had nothing to do but to wish for an instrument, and examine
+their own indifferent imitations of china on the mantelpiece, the
+interval of waiting appeared very long. It was over at last, however.
+The gentlemen did approach, and when Mr. Wickham walked into the room,
+Elizabeth felt that she had neither been seeing him before, nor thinking
+of him since, with the smallest degree of unreasonable admiration.
+The officers of the ----shire were in general a very creditable,
+gentlemanlike set, and the best of them were of the present party; but
+Mr. Wickham was as far beyond them all in person, countenance, air, and
+walk, as _they_ were superior to the broad-faced, stuffy uncle Phillips,
+breathing port wine, who followed them into the room.
+
+Mr. Wickham was the happy man towards whom almost every female eye was
+turned, and Elizabeth was the happy woman by whom he finally seated
+himself; and the agreeable manner in which he immediately fell into
+conversation, though it was only on its being a wet night, made her feel
+that the commonest, dullest, most threadbare topic might be rendered
+interesting by the skill of the speaker.
+
+With such rivals for the notice of the fair as Mr. Wickham and the
+officers, Mr. Collins seemed to sink into insignificance; to the young
+ladies he certainly was nothing; but he had still at intervals a kind
+listener in Mrs. Phillips, and was by her watchfulness, most abundantly
+supplied with coffee and muffin. When the card-tables were placed, he
+had the opportunity of obliging her in turn, by sitting down to whist.
+
+“I know little of the game at present,” said he, “but I shall be glad
+to improve myself, for in my situation in life--” Mrs. Phillips was very
+glad for his compliance, but could not wait for his reason.
+
+Mr. Wickham did not play at whist, and with ready delight was he
+received at the other table between Elizabeth and Lydia. At first there
+seemed danger of Lydia’s engrossing him entirely, for she was a most
+determined talker; but being likewise extremely fond of lottery tickets,
+she soon grew too much interested in the game, too eager in making bets
+and exclaiming after prizes to have attention for anyone in particular.
+Allowing for the common demands of the game, Mr. Wickham was therefore
+at leisure to talk to Elizabeth, and she was very willing to hear
+him, though what she chiefly wished to hear she could not hope to be
+told--the history of his acquaintance with Mr. Darcy. She dared not
+even mention that gentleman. Her curiosity, however, was unexpectedly
+relieved. Mr. Wickham began the subject himself. He inquired how far
+Netherfield was from Meryton; and, after receiving her answer, asked in
+a hesitating manner how long Mr. Darcy had been staying there.
+
+“About a month,” said Elizabeth; and then, unwilling to let the subject
+drop, added, “He is a man of very large property in Derbyshire, I
+understand.”
+
+“Yes,” replied Mr. Wickham; “his estate there is a noble one. A clear
+ten thousand per annum. You could not have met with a person more
+capable of giving you certain information on that head than myself, for
+I have been connected with his family in a particular manner from my
+infancy.”
+
+Elizabeth could not but look surprised.
+
+“You may well be surprised, Miss Bennet, at such an assertion, after
+seeing, as you probably might, the very cold manner of our meeting
+yesterday. Are you much acquainted with Mr. Darcy?”
+
+“As much as I ever wish to be,” cried Elizabeth very warmly. “I have
+spent four days in the same house with him, and I think him very
+disagreeable.”
+
+“I have no right to give _my_ opinion,” said Wickham, “as to his being
+agreeable or otherwise. I am not qualified to form one. I have known him
+too long and too well to be a fair judge. It is impossible for _me_
+to be impartial. But I believe your opinion of him would in general
+astonish--and perhaps you would not express it quite so strongly
+anywhere else. Here you are in your own family.”
+
+“Upon my word, I say no more _here_ than I might say in any house in
+the neighbourhood, except Netherfield. He is not at all liked in
+Hertfordshire. Everybody is disgusted with his pride. You will not find
+him more favourably spoken of by anyone.”
+
+“I cannot pretend to be sorry,” said Wickham, after a short
+interruption, “that he or that any man should not be estimated beyond
+their deserts; but with _him_ I believe it does not often happen. The
+world is blinded by his fortune and consequence, or frightened by his
+high and imposing manners, and sees him only as he chooses to be seen.”
+
+“I should take him, even on _my_ slight acquaintance, to be an
+ill-tempered man.” Wickham only shook his head.
+
+“I wonder,” said he, at the next opportunity of speaking, “whether he is
+likely to be in this country much longer.”
+
+“I do not at all know; but I _heard_ nothing of his going away when I
+was at Netherfield. I hope your plans in favour of the ----shire will
+not be affected by his being in the neighbourhood.”
+
+“Oh! no--it is not for _me_ to be driven away by Mr. Darcy. If _he_
+wishes to avoid seeing _me_, he must go. We are not on friendly terms,
+and it always gives me pain to meet him, but I have no reason for
+avoiding _him_ but what I might proclaim before all the world, a sense
+of very great ill-usage, and most painful regrets at his being what he
+is. His father, Miss Bennet, the late Mr. Darcy, was one of the best men
+that ever breathed, and the truest friend I ever had; and I can never
+be in company with this Mr. Darcy without being grieved to the soul by
+a thousand tender recollections. His behaviour to myself has been
+scandalous; but I verily believe I could forgive him anything and
+everything, rather than his disappointing the hopes and disgracing the
+memory of his father.”
+
+Elizabeth found the interest of the subject increase, and listened with
+all her heart; but the delicacy of it prevented further inquiry.
+
+Mr. Wickham began to speak on more general topics, Meryton, the
+neighbourhood, the society, appearing highly pleased with all that
+he had yet seen, and speaking of the latter with gentle but very
+intelligible gallantry.
+
+“It was the prospect of constant society, and good society,” he added,
+“which was my chief inducement to enter the ----shire. I knew it to be
+a most respectable, agreeable corps, and my friend Denny tempted me
+further by his account of their present quarters, and the very great
+attentions and excellent acquaintances Meryton had procured them.
+Society, I own, is necessary to me. I have been a disappointed man, and
+my spirits will not bear solitude. I _must_ have employment and society.
+A military life is not what I was intended for, but circumstances have
+now made it eligible. The church _ought_ to have been my profession--I
+was brought up for the church, and I should at this time have been in
+possession of a most valuable living, had it pleased the gentleman we
+were speaking of just now.”
+
+“Indeed!”
+
+“Yes--the late Mr. Darcy bequeathed me the next presentation of the best
+living in his gift. He was my godfather, and excessively attached to me.
+I cannot do justice to his kindness. He meant to provide for me amply,
+and thought he had done it; but when the living fell, it was given
+elsewhere.”
+
+“Good heavens!” cried Elizabeth; “but how could _that_ be? How could his
+will be disregarded? Why did you not seek legal redress?”
+
+“There was just such an informality in the terms of the bequest as to
+give me no hope from law. A man of honour could not have doubted the
+intention, but Mr. Darcy chose to doubt it--or to treat it as a merely
+conditional recommendation, and to assert that I had forfeited all claim
+to it by extravagance, imprudence--in short anything or nothing. Certain
+it is, that the living became vacant two years ago, exactly as I was
+of an age to hold it, and that it was given to another man; and no
+less certain is it, that I cannot accuse myself of having really done
+anything to deserve to lose it. I have a warm, unguarded temper, and
+I may have spoken my opinion _of_ him, and _to_ him, too freely. I can
+recall nothing worse. But the fact is, that we are very different sort
+of men, and that he hates me.”
+
+“This is quite shocking! He deserves to be publicly disgraced.”
+
+“Some time or other he _will_ be--but it shall not be by _me_. Till I
+can forget his father, I can never defy or expose _him_.”
+
+Elizabeth honoured him for such feelings, and thought him handsomer than
+ever as he expressed them.
+
+“But what,” said she, after a pause, “can have been his motive? What can
+have induced him to behave so cruelly?”
+
+“A thorough, determined dislike of me--a dislike which I cannot but
+attribute in some measure to jealousy. Had the late Mr. Darcy liked me
+less, his son might have borne with me better; but his father’s uncommon
+attachment to me irritated him, I believe, very early in life. He had
+not a temper to bear the sort of competition in which we stood--the sort
+of preference which was often given me.”
+
+“I had not thought Mr. Darcy so bad as this--though I have never liked
+him. I had not thought so very ill of him. I had supposed him to be
+despising his fellow-creatures in general, but did not suspect him of
+descending to such malicious revenge, such injustice, such inhumanity as
+this.”
+
+After a few minutes’ reflection, however, she continued, “I _do_
+remember his boasting one day, at Netherfield, of the implacability of
+his resentments, of his having an unforgiving temper. His disposition
+must be dreadful.”
+
+“I will not trust myself on the subject,” replied Wickham; “I can hardly
+be just to him.”
+
+Elizabeth was again deep in thought, and after a time exclaimed, “To
+treat in such a manner the godson, the friend, the favourite of his
+father!” She could have added, “A young man, too, like _you_, whose very
+countenance may vouch for your being amiable”--but she contented herself
+with, “and one, too, who had probably been his companion from childhood,
+connected together, as I think you said, in the closest manner!”
+
+“We were born in the same parish, within the same park; the greatest
+part of our youth was passed together; inmates of the same house,
+sharing the same amusements, objects of the same parental care. _My_
+father began life in the profession which your uncle, Mr. Phillips,
+appears to do so much credit to--but he gave up everything to be of
+use to the late Mr. Darcy and devoted all his time to the care of the
+Pemberley property. He was most highly esteemed by Mr. Darcy, a most
+intimate, confidential friend. Mr. Darcy often acknowledged himself to
+be under the greatest obligations to my father’s active superintendence,
+and when, immediately before my father’s death, Mr. Darcy gave him a
+voluntary promise of providing for me, I am convinced that he felt it to
+be as much a debt of gratitude to _him_, as of his affection to myself.”
+
+“How strange!” cried Elizabeth. “How abominable! I wonder that the very
+pride of this Mr. Darcy has not made him just to you! If from no better
+motive, that he should not have been too proud to be dishonest--for
+dishonesty I must call it.”
+
+“It _is_ wonderful,” replied Wickham, “for almost all his actions may
+be traced to pride; and pride had often been his best friend. It has
+connected him nearer with virtue than with any other feeling. But we are
+none of us consistent, and in his behaviour to me there were stronger
+impulses even than pride.”
+
+“Can such abominable pride as his have ever done him good?”
+
+“Yes. It has often led him to be liberal and generous, to give his money
+freely, to display hospitality, to assist his tenants, and relieve the
+poor. Family pride, and _filial_ pride--for he is very proud of what
+his father was--have done this. Not to appear to disgrace his family,
+to degenerate from the popular qualities, or lose the influence of the
+Pemberley House, is a powerful motive. He has also _brotherly_ pride,
+which, with _some_ brotherly affection, makes him a very kind and
+careful guardian of his sister, and you will hear him generally cried up
+as the most attentive and best of brothers.”
+
+“What sort of girl is Miss Darcy?”
+
+He shook his head. “I wish I could call her amiable. It gives me pain to
+speak ill of a Darcy. But she is too much like her brother--very, very
+proud. As a child, she was affectionate and pleasing, and extremely fond
+of me; and I have devoted hours and hours to her amusement. But she is
+nothing to me now. She is a handsome girl, about fifteen or sixteen,
+and, I understand, highly accomplished. Since her father’s death, her
+home has been London, where a lady lives with her, and superintends her
+education.”
+
+After many pauses and many trials of other subjects, Elizabeth could not
+help reverting once more to the first, and saying:
+
+“I am astonished at his intimacy with Mr. Bingley! How can Mr. Bingley,
+who seems good humour itself, and is, I really believe, truly amiable,
+be in friendship with such a man? How can they suit each other? Do you
+know Mr. Bingley?”
+
+“Not at all.”
+
+“He is a sweet-tempered, amiable, charming man. He cannot know what Mr.
+Darcy is.”
+
+“Probably not; but Mr. Darcy can please where he chooses. He does not
+want abilities. He can be a conversible companion if he thinks it worth
+his while. Among those who are at all his equals in consequence, he is
+a very different man from what he is to the less prosperous. His
+pride never deserts him; but with the rich he is liberal-minded, just,
+sincere, rational, honourable, and perhaps agreeable--allowing something
+for fortune and figure.”
+
+The whist party soon afterwards breaking up, the players gathered round
+the other table and Mr. Collins took his station between his cousin
+Elizabeth and Mrs. Phillips. The usual inquiries as to his success were
+made by the latter. It had not been very great; he had lost every
+point; but when Mrs. Phillips began to express her concern thereupon,
+he assured her with much earnest gravity that it was not of the least
+importance, that he considered the money as a mere trifle, and begged
+that she would not make herself uneasy.
+
+“I know very well, madam,” said he, “that when persons sit down to a
+card-table, they must take their chances of these things, and happily I
+am not in such circumstances as to make five shillings any object. There
+are undoubtedly many who could not say the same, but thanks to Lady
+Catherine de Bourgh, I am removed far beyond the necessity of regarding
+little matters.”
+
+Mr. Wickham’s attention was caught; and after observing Mr. Collins for
+a few moments, he asked Elizabeth in a low voice whether her relation
+was very intimately acquainted with the family of de Bourgh.
+
+“Lady Catherine de Bourgh,” she replied, “has very lately given him
+a living. I hardly know how Mr. Collins was first introduced to her
+notice, but he certainly has not known her long.”
+
+“You know of course that Lady Catherine de Bourgh and Lady Anne Darcy
+were sisters; consequently that she is aunt to the present Mr. Darcy.”
+
+“No, indeed, I did not. I knew nothing at all of Lady Catherine’s
+connections. I never heard of her existence till the day before
+yesterday.”
+
+“Her daughter, Miss de Bourgh, will have a very large fortune, and it is
+believed that she and her cousin will unite the two estates.”
+
+This information made Elizabeth smile, as she thought of poor Miss
+Bingley. Vain indeed must be all her attentions, vain and useless her
+affection for his sister and her praise of himself, if he were already
+self-destined for another.
+
+“Mr. Collins,” said she, “speaks highly both of Lady Catherine and her
+daughter; but from some particulars that he has related of her ladyship,
+I suspect his gratitude misleads him, and that in spite of her being his
+patroness, she is an arrogant, conceited woman.”
+
+“I believe her to be both in a great degree,” replied Wickham; “I have
+not seen her for many years, but I very well remember that I never liked
+her, and that her manners were dictatorial and insolent. She has the
+reputation of being remarkably sensible and clever; but I rather believe
+she derives part of her abilities from her rank and fortune, part from
+her authoritative manner, and the rest from the pride for her
+nephew, who chooses that everyone connected with him should have an
+understanding of the first class.”
+
+Elizabeth allowed that he had given a very rational account of it, and
+they continued talking together, with mutual satisfaction till supper
+put an end to cards, and gave the rest of the ladies their share of Mr.
+Wickham’s attentions. There could be no conversation in the noise
+of Mrs. Phillips’s supper party, but his manners recommended him to
+everybody. Whatever he said, was said well; and whatever he did, done
+gracefully. Elizabeth went away with her head full of him. She could
+think of nothing but of Mr. Wickham, and of what he had told her, all
+the way home; but there was not time for her even to mention his name
+as they went, for neither Lydia nor Mr. Collins were once silent. Lydia
+talked incessantly of lottery tickets, of the fish she had lost and the
+fish she had won; and Mr. Collins in describing the civility of Mr. and
+Mrs. Phillips, protesting that he did not in the least regard his losses
+at whist, enumerating all the dishes at supper, and repeatedly fearing
+that he crowded his cousins, had more to say than he could well manage
+before the carriage stopped at Longbourn House.
+
+
+
+Chapter 17
+
+
+Elizabeth related to Jane the next day what had passed between Mr.
+Wickham and herself. Jane listened with astonishment and concern; she
+knew not how to believe that Mr. Darcy could be so unworthy of Mr.
+Bingley’s regard; and yet, it was not in her nature to question the
+veracity of a young man of such amiable appearance as Wickham. The
+possibility of his having endured such unkindness, was enough to
+interest all her tender feelings; and nothing remained therefore to be
+done, but to think well of them both, to defend the conduct of each,
+and throw into the account of accident or mistake whatever could not be
+otherwise explained.
+
+“They have both,” said she, “been deceived, I dare say, in some way
+or other, of which we can form no idea. Interested people have perhaps
+misrepresented each to the other. It is, in short, impossible for us to
+conjecture the causes or circumstances which may have alienated them,
+without actual blame on either side.”
+
+“Very true, indeed; and now, my dear Jane, what have you got to say on
+behalf of the interested people who have probably been concerned in the
+business? Do clear _them_ too, or we shall be obliged to think ill of
+somebody.”
+
+“Laugh as much as you choose, but you will not laugh me out of my
+opinion. My dearest Lizzy, do but consider in what a disgraceful light
+it places Mr. Darcy, to be treating his father’s favourite in such
+a manner, one whom his father had promised to provide for. It is
+impossible. No man of common humanity, no man who had any value for his
+character, could be capable of it. Can his most intimate friends be so
+excessively deceived in him? Oh! no.”
+
+“I can much more easily believe Mr. Bingley’s being imposed on, than
+that Mr. Wickham should invent such a history of himself as he gave me
+last night; names, facts, everything mentioned without ceremony. If it
+be not so, let Mr. Darcy contradict it. Besides, there was truth in his
+looks.”
+
+“It is difficult indeed--it is distressing. One does not know what to
+think.”
+
+“I beg your pardon; one knows exactly what to think.”
+
+But Jane could think with certainty on only one point--that Mr. Bingley,
+if he _had_ been imposed on, would have much to suffer when the affair
+became public.
+
+The two young ladies were summoned from the shrubbery, where this
+conversation passed, by the arrival of the very persons of whom they had
+been speaking; Mr. Bingley and his sisters came to give their personal
+invitation for the long-expected ball at Netherfield, which was fixed
+for the following Tuesday. The two ladies were delighted to see their
+dear friend again, called it an age since they had met, and repeatedly
+asked what she had been doing with herself since their separation. To
+the rest of the family they paid little attention; avoiding Mrs. Bennet
+as much as possible, saying not much to Elizabeth, and nothing at all to
+the others. They were soon gone again, rising from their seats with an
+activity which took their brother by surprise, and hurrying off as if
+eager to escape from Mrs. Bennet’s civilities.
+
+The prospect of the Netherfield ball was extremely agreeable to every
+female of the family. Mrs. Bennet chose to consider it as given in
+compliment to her eldest daughter, and was particularly flattered
+by receiving the invitation from Mr. Bingley himself, instead of a
+ceremonious card. Jane pictured to herself a happy evening in the
+society of her two friends, and the attentions of their brother; and
+Elizabeth thought with pleasure of dancing a great deal with Mr.
+Wickham, and of seeing a confirmation of everything in Mr. Darcy’s look
+and behaviour. The happiness anticipated by Catherine and Lydia depended
+less on any single event, or any particular person, for though they
+each, like Elizabeth, meant to dance half the evening with Mr. Wickham,
+he was by no means the only partner who could satisfy them, and a ball
+was, at any rate, a ball. And even Mary could assure her family that she
+had no disinclination for it.
+
+“While I can have my mornings to myself,” said she, “it is enough--I
+think it is no sacrifice to join occasionally in evening engagements.
+Society has claims on us all; and I profess myself one of those
+who consider intervals of recreation and amusement as desirable for
+everybody.”
+
+Elizabeth’s spirits were so high on this occasion, that though she did
+not often speak unnecessarily to Mr. Collins, she could not help asking
+him whether he intended to accept Mr. Bingley’s invitation, and if
+he did, whether he would think it proper to join in the evening’s
+amusement; and she was rather surprised to find that he entertained no
+scruple whatever on that head, and was very far from dreading a rebuke
+either from the Archbishop, or Lady Catherine de Bourgh, by venturing to
+dance.
+
+“I am by no means of the opinion, I assure you,” said he, “that a ball
+of this kind, given by a young man of character, to respectable people,
+can have any evil tendency; and I am so far from objecting to dancing
+myself, that I shall hope to be honoured with the hands of all my fair
+cousins in the course of the evening; and I take this opportunity of
+soliciting yours, Miss Elizabeth, for the two first dances especially,
+a preference which I trust my cousin Jane will attribute to the right
+cause, and not to any disrespect for her.”
+
+Elizabeth felt herself completely taken in. She had fully proposed being
+engaged by Mr. Wickham for those very dances; and to have Mr. Collins
+instead! her liveliness had never been worse timed. There was no help
+for it, however. Mr. Wickham’s happiness and her own were perforce
+delayed a little longer, and Mr. Collins’s proposal accepted with as
+good a grace as she could. She was not the better pleased with his
+gallantry from the idea it suggested of something more. It now first
+struck her, that _she_ was selected from among her sisters as worthy
+of being mistress of Hunsford Parsonage, and of assisting to form a
+quadrille table at Rosings, in the absence of more eligible visitors.
+The idea soon reached to conviction, as she observed his increasing
+civilities toward herself, and heard his frequent attempt at a
+compliment on her wit and vivacity; and though more astonished than
+gratified herself by this effect of her charms, it was not long before
+her mother gave her to understand that the probability of their marriage
+was extremely agreeable to _her_. Elizabeth, however, did not choose
+to take the hint, being well aware that a serious dispute must be the
+consequence of any reply. Mr. Collins might never make the offer, and
+till he did, it was useless to quarrel about him.
+
+If there had not been a Netherfield ball to prepare for and talk of, the
+younger Miss Bennets would have been in a very pitiable state at this
+time, for from the day of the invitation, to the day of the ball, there
+was such a succession of rain as prevented their walking to Meryton
+once. No aunt, no officers, no news could be sought after--the very
+shoe-roses for Netherfield were got by proxy. Even Elizabeth might have
+found some trial of her patience in weather which totally suspended the
+improvement of her acquaintance with Mr. Wickham; and nothing less than
+a dance on Tuesday, could have made such a Friday, Saturday, Sunday, and
+Monday endurable to Kitty and Lydia.
+
+
+
+Chapter 18
+
+
+Till Elizabeth entered the drawing-room at Netherfield, and looked in
+vain for Mr. Wickham among the cluster of red coats there assembled, a
+doubt of his being present had never occurred to her. The certainty
+of meeting him had not been checked by any of those recollections that
+might not unreasonably have alarmed her. She had dressed with more than
+usual care, and prepared in the highest spirits for the conquest of all
+that remained unsubdued of his heart, trusting that it was not more than
+might be won in the course of the evening. But in an instant arose
+the dreadful suspicion of his being purposely omitted for Mr. Darcy’s
+pleasure in the Bingleys’ invitation to the officers; and though
+this was not exactly the case, the absolute fact of his absence was
+pronounced by his friend Denny, to whom Lydia eagerly applied, and who
+told them that Wickham had been obliged to go to town on business the
+day before, and was not yet returned; adding, with a significant smile,
+“I do not imagine his business would have called him away just now, if
+he had not wanted to avoid a certain gentleman here.”
+
+This part of his intelligence, though unheard by Lydia, was caught by
+Elizabeth, and, as it assured her that Darcy was not less answerable for
+Wickham’s absence than if her first surmise had been just, every
+feeling of displeasure against the former was so sharpened by immediate
+disappointment, that she could hardly reply with tolerable civility to
+the polite inquiries which he directly afterwards approached to make.
+Attendance, forbearance, patience with Darcy, was injury to Wickham. She
+was resolved against any sort of conversation with him, and turned away
+with a degree of ill-humour which she could not wholly surmount even in
+speaking to Mr. Bingley, whose blind partiality provoked her.
+
+But Elizabeth was not formed for ill-humour; and though every prospect
+of her own was destroyed for the evening, it could not dwell long on her
+spirits; and having told all her griefs to Charlotte Lucas, whom she had
+not seen for a week, she was soon able to make a voluntary transition
+to the oddities of her cousin, and to point him out to her particular
+notice. The first two dances, however, brought a return of distress;
+they were dances of mortification. Mr. Collins, awkward and solemn,
+apologising instead of attending, and often moving wrong without being
+aware of it, gave her all the shame and misery which a disagreeable
+partner for a couple of dances can give. The moment of her release from
+him was ecstasy.
+
+She danced next with an officer, and had the refreshment of talking of
+Wickham, and of hearing that he was universally liked. When those dances
+were over, she returned to Charlotte Lucas, and was in conversation with
+her, when she found herself suddenly addressed by Mr. Darcy who took
+her so much by surprise in his application for her hand, that,
+without knowing what she did, she accepted him. He walked away again
+immediately, and she was left to fret over her own want of presence of
+mind; Charlotte tried to console her:
+
+“I dare say you will find him very agreeable.”
+
+“Heaven forbid! _That_ would be the greatest misfortune of all! To find
+a man agreeable whom one is determined to hate! Do not wish me such an
+evil.”
+
+When the dancing recommenced, however, and Darcy approached to claim her
+hand, Charlotte could not help cautioning her in a whisper, not to be a
+simpleton, and allow her fancy for Wickham to make her appear unpleasant
+in the eyes of a man ten times his consequence. Elizabeth made no
+answer, and took her place in the set, amazed at the dignity to which
+she was arrived in being allowed to stand opposite to Mr. Darcy, and
+reading in her neighbours’ looks, their equal amazement in beholding
+it. They stood for some time without speaking a word; and she began to
+imagine that their silence was to last through the two dances, and at
+first was resolved not to break it; till suddenly fancying that it would
+be the greater punishment to her partner to oblige him to talk, she made
+some slight observation on the dance. He replied, and was again
+silent. After a pause of some minutes, she addressed him a second time
+with:--“It is _your_ turn to say something now, Mr. Darcy. I talked
+about the dance, and _you_ ought to make some sort of remark on the size
+of the room, or the number of couples.”
+
+He smiled, and assured her that whatever she wished him to say should be
+said.
+
+“Very well. That reply will do for the present. Perhaps by and by I may
+observe that private balls are much pleasanter than public ones. But
+_now_ we may be silent.”
+
+“Do you talk by rule, then, while you are dancing?”
+
+“Sometimes. One must speak a little, you know. It would look odd to be
+entirely silent for half an hour together; and yet for the advantage of
+_some_, conversation ought to be so arranged, as that they may have the
+trouble of saying as little as possible.”
+
+“Are you consulting your own feelings in the present case, or do you
+imagine that you are gratifying mine?”
+
+“Both,” replied Elizabeth archly; “for I have always seen a great
+similarity in the turn of our minds. We are each of an unsocial,
+taciturn disposition, unwilling to speak, unless we expect to say
+something that will amaze the whole room, and be handed down to
+posterity with all the eclat of a proverb.”
+
+“This is no very striking resemblance of your own character, I am sure,”
+ said he. “How near it may be to _mine_, I cannot pretend to say. _You_
+think it a faithful portrait undoubtedly.”
+
+“I must not decide on my own performance.”
+
+He made no answer, and they were again silent till they had gone down
+the dance, when he asked her if she and her sisters did not very often
+walk to Meryton. She answered in the affirmative, and, unable to resist
+the temptation, added, “When you met us there the other day, we had just
+been forming a new acquaintance.”
+
+The effect was immediate. A deeper shade of _hauteur_ overspread his
+features, but he said not a word, and Elizabeth, though blaming herself
+for her own weakness, could not go on. At length Darcy spoke, and in a
+constrained manner said, “Mr. Wickham is blessed with such happy manners
+as may ensure his _making_ friends--whether he may be equally capable of
+_retaining_ them, is less certain.”
+
+“He has been so unlucky as to lose _your_ friendship,” replied Elizabeth
+with emphasis, “and in a manner which he is likely to suffer from all
+his life.”
+
+Darcy made no answer, and seemed desirous of changing the subject. At
+that moment, Sir William Lucas appeared close to them, meaning to pass
+through the set to the other side of the room; but on perceiving Mr.
+Darcy, he stopped with a bow of superior courtesy to compliment him on
+his dancing and his partner.
+
+“I have been most highly gratified indeed, my dear sir. Such very
+superior dancing is not often seen. It is evident that you belong to the
+first circles. Allow me to say, however, that your fair partner does not
+disgrace you, and that I must hope to have this pleasure often repeated,
+especially when a certain desirable event, my dear Eliza (glancing at
+her sister and Bingley) shall take place. What congratulations will then
+flow in! I appeal to Mr. Darcy:--but let me not interrupt you, sir. You
+will not thank me for detaining you from the bewitching converse of that
+young lady, whose bright eyes are also upbraiding me.”
+
+The latter part of this address was scarcely heard by Darcy; but Sir
+William’s allusion to his friend seemed to strike him forcibly, and his
+eyes were directed with a very serious expression towards Bingley and
+Jane, who were dancing together. Recovering himself, however, shortly,
+he turned to his partner, and said, “Sir William’s interruption has made
+me forget what we were talking of.”
+
+“I do not think we were speaking at all. Sir William could not have
+interrupted two people in the room who had less to say for themselves.
+We have tried two or three subjects already without success, and what we
+are to talk of next I cannot imagine.”
+
+“What think you of books?” said he, smiling.
+
+“Books--oh! no. I am sure we never read the same, or not with the same
+feelings.”
+
+“I am sorry you think so; but if that be the case, there can at least be
+no want of subject. We may compare our different opinions.”
+
+“No--I cannot talk of books in a ball-room; my head is always full of
+something else.”
+
+“The _present_ always occupies you in such scenes--does it?” said he,
+with a look of doubt.
+
+“Yes, always,” she replied, without knowing what she said, for her
+thoughts had wandered far from the subject, as soon afterwards appeared
+by her suddenly exclaiming, “I remember hearing you once say, Mr. Darcy,
+that you hardly ever forgave, that your resentment once created was
+unappeasable. You are very cautious, I suppose, as to its _being
+created_.”
+
+“I am,” said he, with a firm voice.
+
+“And never allow yourself to be blinded by prejudice?”
+
+“I hope not.”
+
+“It is particularly incumbent on those who never change their opinion,
+to be secure of judging properly at first.”
+
+“May I ask to what these questions tend?”
+
+“Merely to the illustration of _your_ character,” said she, endeavouring
+to shake off her gravity. “I am trying to make it out.”
+
+“And what is your success?”
+
+She shook her head. “I do not get on at all. I hear such different
+accounts of you as puzzle me exceedingly.”
+
+“I can readily believe,” answered he gravely, “that reports may vary
+greatly with respect to me; and I could wish, Miss Bennet, that you were
+not to sketch my character at the present moment, as there is reason to
+fear that the performance would reflect no credit on either.”
+
+“But if I do not take your likeness now, I may never have another
+opportunity.”
+
+“I would by no means suspend any pleasure of yours,” he coldly replied.
+She said no more, and they went down the other dance and parted in
+silence; and on each side dissatisfied, though not to an equal degree,
+for in Darcy’s breast there was a tolerably powerful feeling towards
+her, which soon procured her pardon, and directed all his anger against
+another.
+
+They had not long separated, when Miss Bingley came towards her, and
+with an expression of civil disdain accosted her:
+
+“So, Miss Eliza, I hear you are quite delighted with George Wickham!
+Your sister has been talking to me about him, and asking me a thousand
+questions; and I find that the young man quite forgot to tell you, among
+his other communication, that he was the son of old Wickham, the late
+Mr. Darcy’s steward. Let me recommend you, however, as a friend, not to
+give implicit confidence to all his assertions; for as to Mr. Darcy’s
+using him ill, it is perfectly false; for, on the contrary, he has
+always been remarkably kind to him, though George Wickham has treated
+Mr. Darcy in a most infamous manner. I do not know the particulars, but
+I know very well that Mr. Darcy is not in the least to blame, that he
+cannot bear to hear George Wickham mentioned, and that though my brother
+thought that he could not well avoid including him in his invitation to
+the officers, he was excessively glad to find that he had taken himself
+out of the way. His coming into the country at all is a most insolent
+thing, indeed, and I wonder how he could presume to do it. I pity you,
+Miss Eliza, for this discovery of your favourite’s guilt; but really,
+considering his descent, one could not expect much better.”
+
+“His guilt and his descent appear by your account to be the same,” said
+Elizabeth angrily; “for I have heard you accuse him of nothing worse
+than of being the son of Mr. Darcy’s steward, and of _that_, I can
+assure you, he informed me himself.”
+
+“I beg your pardon,” replied Miss Bingley, turning away with a sneer.
+“Excuse my interference--it was kindly meant.”
+
+“Insolent girl!” said Elizabeth to herself. “You are much mistaken
+if you expect to influence me by such a paltry attack as this. I see
+nothing in it but your own wilful ignorance and the malice of Mr.
+Darcy.” She then sought her eldest sister, who had undertaken to make
+inquiries on the same subject of Bingley. Jane met her with a smile of
+such sweet complacency, a glow of such happy expression, as sufficiently
+marked how well she was satisfied with the occurrences of the evening.
+Elizabeth instantly read her feelings, and at that moment solicitude for
+Wickham, resentment against his enemies, and everything else, gave way
+before the hope of Jane’s being in the fairest way for happiness.
+
+“I want to know,” said she, with a countenance no less smiling than her
+sister’s, “what you have learnt about Mr. Wickham. But perhaps you have
+been too pleasantly engaged to think of any third person; in which case
+you may be sure of my pardon.”
+
+“No,” replied Jane, “I have not forgotten him; but I have nothing
+satisfactory to tell you. Mr. Bingley does not know the whole of
+his history, and is quite ignorant of the circumstances which have
+principally offended Mr. Darcy; but he will vouch for the good conduct,
+the probity, and honour of his friend, and is perfectly convinced that
+Mr. Wickham has deserved much less attention from Mr. Darcy than he has
+received; and I am sorry to say by his account as well as his sister’s,
+Mr. Wickham is by no means a respectable young man. I am afraid he has
+been very imprudent, and has deserved to lose Mr. Darcy’s regard.”
+
+“Mr. Bingley does not know Mr. Wickham himself?”
+
+“No; he never saw him till the other morning at Meryton.”
+
+“This account then is what he has received from Mr. Darcy. I am
+satisfied. But what does he say of the living?”
+
+“He does not exactly recollect the circumstances, though he has heard
+them from Mr. Darcy more than once, but he believes that it was left to
+him _conditionally_ only.”
+
+“I have not a doubt of Mr. Bingley’s sincerity,” said Elizabeth warmly;
+“but you must excuse my not being convinced by assurances only. Mr.
+Bingley’s defense of his friend was a very able one, I dare say; but
+since he is unacquainted with several parts of the story, and has learnt
+the rest from that friend himself, I shall venture to still think of
+both gentlemen as I did before.”
+
+She then changed the discourse to one more gratifying to each, and on
+which there could be no difference of sentiment. Elizabeth listened with
+delight to the happy, though modest hopes which Jane entertained of Mr.
+Bingley’s regard, and said all in her power to heighten her confidence
+in it. On their being joined by Mr. Bingley himself, Elizabeth withdrew
+to Miss Lucas; to whose inquiry after the pleasantness of her last
+partner she had scarcely replied, before Mr. Collins came up to them,
+and told her with great exultation that he had just been so fortunate as
+to make a most important discovery.
+
+“I have found out,” said he, “by a singular accident, that there is now
+in the room a near relation of my patroness. I happened to overhear the
+gentleman himself mentioning to the young lady who does the honours of
+the house the names of his cousin Miss de Bourgh, and of her mother Lady
+Catherine. How wonderfully these sort of things occur! Who would have
+thought of my meeting with, perhaps, a nephew of Lady Catherine de
+Bourgh in this assembly! I am most thankful that the discovery is made
+in time for me to pay my respects to him, which I am now going to
+do, and trust he will excuse my not having done it before. My total
+ignorance of the connection must plead my apology.”
+
+“You are not going to introduce yourself to Mr. Darcy!”
+
+“Indeed I am. I shall entreat his pardon for not having done it earlier.
+I believe him to be Lady Catherine’s _nephew_. It will be in my power to
+assure him that her ladyship was quite well yesterday se’nnight.”
+
+Elizabeth tried hard to dissuade him from such a scheme, assuring him
+that Mr. Darcy would consider his addressing him without introduction
+as an impertinent freedom, rather than a compliment to his aunt; that
+it was not in the least necessary there should be any notice on either
+side; and that if it were, it must belong to Mr. Darcy, the superior in
+consequence, to begin the acquaintance. Mr. Collins listened to her
+with the determined air of following his own inclination, and, when she
+ceased speaking, replied thus:
+
+“My dear Miss Elizabeth, I have the highest opinion in the world in
+your excellent judgement in all matters within the scope of your
+understanding; but permit me to say, that there must be a wide
+difference between the established forms of ceremony amongst the laity,
+and those which regulate the clergy; for, give me leave to observe that
+I consider the clerical office as equal in point of dignity with
+the highest rank in the kingdom--provided that a proper humility of
+behaviour is at the same time maintained. You must therefore allow me to
+follow the dictates of my conscience on this occasion, which leads me to
+perform what I look on as a point of duty. Pardon me for neglecting to
+profit by your advice, which on every other subject shall be my constant
+guide, though in the case before us I consider myself more fitted by
+education and habitual study to decide on what is right than a young
+lady like yourself.” And with a low bow he left her to attack Mr.
+Darcy, whose reception of his advances she eagerly watched, and whose
+astonishment at being so addressed was very evident. Her cousin prefaced
+his speech with a solemn bow and though she could not hear a word of
+it, she felt as if hearing it all, and saw in the motion of his lips the
+words “apology,” “Hunsford,” and “Lady Catherine de Bourgh.” It vexed
+her to see him expose himself to such a man. Mr. Darcy was eyeing him
+with unrestrained wonder, and when at last Mr. Collins allowed him time
+to speak, replied with an air of distant civility. Mr. Collins, however,
+was not discouraged from speaking again, and Mr. Darcy’s contempt seemed
+abundantly increasing with the length of his second speech, and at the
+end of it he only made him a slight bow, and moved another way. Mr.
+Collins then returned to Elizabeth.
+
+“I have no reason, I assure you,” said he, “to be dissatisfied with my
+reception. Mr. Darcy seemed much pleased with the attention. He answered
+me with the utmost civility, and even paid me the compliment of saying
+that he was so well convinced of Lady Catherine’s discernment as to be
+certain she could never bestow a favour unworthily. It was really a very
+handsome thought. Upon the whole, I am much pleased with him.”
+
+As Elizabeth had no longer any interest of her own to pursue, she turned
+her attention almost entirely on her sister and Mr. Bingley; and the
+train of agreeable reflections which her observations gave birth to,
+made her perhaps almost as happy as Jane. She saw her in idea settled in
+that very house, in all the felicity which a marriage of true affection
+could bestow; and she felt capable, under such circumstances, of
+endeavouring even to like Bingley’s two sisters. Her mother’s thoughts
+she plainly saw were bent the same way, and she determined not to
+venture near her, lest she might hear too much. When they sat down to
+supper, therefore, she considered it a most unlucky perverseness which
+placed them within one of each other; and deeply was she vexed to find
+that her mother was talking to that one person (Lady Lucas) freely,
+openly, and of nothing else but her expectation that Jane would soon
+be married to Mr. Bingley. It was an animating subject, and Mrs. Bennet
+seemed incapable of fatigue while enumerating the advantages of the
+match. His being such a charming young man, and so rich, and living but
+three miles from them, were the first points of self-gratulation; and
+then it was such a comfort to think how fond the two sisters were of
+Jane, and to be certain that they must desire the connection as much as
+she could do. It was, moreover, such a promising thing for her younger
+daughters, as Jane’s marrying so greatly must throw them in the way of
+other rich men; and lastly, it was so pleasant at her time of life to be
+able to consign her single daughters to the care of their sister, that
+she might not be obliged to go into company more than she liked. It was
+necessary to make this circumstance a matter of pleasure, because on
+such occasions it is the etiquette; but no one was less likely than Mrs.
+Bennet to find comfort in staying home at any period of her life. She
+concluded with many good wishes that Lady Lucas might soon be equally
+fortunate, though evidently and triumphantly believing there was no
+chance of it.
+
+In vain did Elizabeth endeavour to check the rapidity of her mother’s
+words, or persuade her to describe her felicity in a less audible
+whisper; for, to her inexpressible vexation, she could perceive that the
+chief of it was overheard by Mr. Darcy, who sat opposite to them. Her
+mother only scolded her for being nonsensical.
+
+“What is Mr. Darcy to me, pray, that I should be afraid of him? I am
+sure we owe him no such particular civility as to be obliged to say
+nothing _he_ may not like to hear.”
+
+“For heaven’s sake, madam, speak lower. What advantage can it be for you
+to offend Mr. Darcy? You will never recommend yourself to his friend by
+so doing!”
+
+Nothing that she could say, however, had any influence. Her mother would
+talk of her views in the same intelligible tone. Elizabeth blushed and
+blushed again with shame and vexation. She could not help frequently
+glancing her eye at Mr. Darcy, though every glance convinced her of what
+she dreaded; for though he was not always looking at her mother, she was
+convinced that his attention was invariably fixed by her. The expression
+of his face changed gradually from indignant contempt to a composed and
+steady gravity.
+
+At length, however, Mrs. Bennet had no more to say; and Lady Lucas, who
+had been long yawning at the repetition of delights which she saw no
+likelihood of sharing, was left to the comforts of cold ham and
+chicken. Elizabeth now began to revive. But not long was the interval of
+tranquillity; for, when supper was over, singing was talked of, and
+she had the mortification of seeing Mary, after very little entreaty,
+preparing to oblige the company. By many significant looks and silent
+entreaties, did she endeavour to prevent such a proof of complaisance,
+but in vain; Mary would not understand them; such an opportunity of
+exhibiting was delightful to her, and she began her song. Elizabeth’s
+eyes were fixed on her with most painful sensations, and she watched her
+progress through the several stanzas with an impatience which was very
+ill rewarded at their close; for Mary, on receiving, amongst the thanks
+of the table, the hint of a hope that she might be prevailed on to
+favour them again, after the pause of half a minute began another.
+Mary’s powers were by no means fitted for such a display; her voice was
+weak, and her manner affected. Elizabeth was in agonies. She looked at
+Jane, to see how she bore it; but Jane was very composedly talking to
+Bingley. She looked at his two sisters, and saw them making signs
+of derision at each other, and at Darcy, who continued, however,
+imperturbably grave. She looked at her father to entreat his
+interference, lest Mary should be singing all night. He took the hint,
+and when Mary had finished her second song, said aloud, “That will do
+extremely well, child. You have delighted us long enough. Let the other
+young ladies have time to exhibit.”
+
+Mary, though pretending not to hear, was somewhat disconcerted; and
+Elizabeth, sorry for her, and sorry for her father’s speech, was afraid
+her anxiety had done no good. Others of the party were now applied to.
+
+“If I,” said Mr. Collins, “were so fortunate as to be able to sing, I
+should have great pleasure, I am sure, in obliging the company with an
+air; for I consider music as a very innocent diversion, and perfectly
+compatible with the profession of a clergyman. I do not mean, however,
+to assert that we can be justified in devoting too much of our time
+to music, for there are certainly other things to be attended to. The
+rector of a parish has much to do. In the first place, he must make
+such an agreement for tithes as may be beneficial to himself and not
+offensive to his patron. He must write his own sermons; and the time
+that remains will not be too much for his parish duties, and the care
+and improvement of his dwelling, which he cannot be excused from making
+as comfortable as possible. And I do not think it of light importance
+that he should have attentive and conciliatory manners towards everybody,
+especially towards those to whom he owes his preferment. I cannot acquit
+him of that duty; nor could I think well of the man who should omit an
+occasion of testifying his respect towards anybody connected with the
+family.” And with a bow to Mr. Darcy, he concluded his speech, which had
+been spoken so loud as to be heard by half the room. Many stared--many
+smiled; but no one looked more amused than Mr. Bennet himself, while his
+wife seriously commended Mr. Collins for having spoken so sensibly,
+and observed in a half-whisper to Lady Lucas, that he was a remarkably
+clever, good kind of young man.
+
+To Elizabeth it appeared that, had her family made an agreement to
+expose themselves as much as they could during the evening, it would
+have been impossible for them to play their parts with more spirit or
+finer success; and happy did she think it for Bingley and her sister
+that some of the exhibition had escaped his notice, and that his
+feelings were not of a sort to be much distressed by the folly which he
+must have witnessed. That his two sisters and Mr. Darcy, however, should
+have such an opportunity of ridiculing her relations, was bad enough,
+and she could not determine whether the silent contempt of the
+gentleman, or the insolent smiles of the ladies, were more intolerable.
+
+The rest of the evening brought her little amusement. She was teased by
+Mr. Collins, who continued most perseveringly by her side, and though
+he could not prevail on her to dance with him again, put it out of her
+power to dance with others. In vain did she entreat him to stand up with
+somebody else, and offer to introduce him to any young lady in the room.
+He assured her, that as to dancing, he was perfectly indifferent to it;
+that his chief object was by delicate attentions to recommend himself to
+her and that he should therefore make a point of remaining close to her
+the whole evening. There was no arguing upon such a project. She owed
+her greatest relief to her friend Miss Lucas, who often joined them, and
+good-naturedly engaged Mr. Collins’s conversation to herself.
+
+She was at least free from the offense of Mr. Darcy’s further notice;
+though often standing within a very short distance of her, quite
+disengaged, he never came near enough to speak. She felt it to be the
+probable consequence of her allusions to Mr. Wickham, and rejoiced in
+it.
+
+The Longbourn party were the last of all the company to depart, and, by
+a manoeuvre of Mrs. Bennet, had to wait for their carriage a quarter of
+an hour after everybody else was gone, which gave them time to see how
+heartily they were wished away by some of the family. Mrs. Hurst and her
+sister scarcely opened their mouths, except to complain of fatigue, and
+were evidently impatient to have the house to themselves. They repulsed
+every attempt of Mrs. Bennet at conversation, and by so doing threw a
+languor over the whole party, which was very little relieved by the
+long speeches of Mr. Collins, who was complimenting Mr. Bingley and his
+sisters on the elegance of their entertainment, and the hospitality and
+politeness which had marked their behaviour to their guests. Darcy said
+nothing at all. Mr. Bennet, in equal silence, was enjoying the scene.
+Mr. Bingley and Jane were standing together, a little detached from the
+rest, and talked only to each other. Elizabeth preserved as steady a
+silence as either Mrs. Hurst or Miss Bingley; and even Lydia was too
+much fatigued to utter more than the occasional exclamation of “Lord,
+how tired I am!” accompanied by a violent yawn.
+
+When at length they arose to take leave, Mrs. Bennet was most pressingly
+civil in her hope of seeing the whole family soon at Longbourn, and
+addressed herself especially to Mr. Bingley, to assure him how happy he
+would make them by eating a family dinner with them at any time, without
+the ceremony of a formal invitation. Bingley was all grateful pleasure,
+and he readily engaged for taking the earliest opportunity of waiting on
+her, after his return from London, whither he was obliged to go the next
+day for a short time.
+
+Mrs. Bennet was perfectly satisfied, and quitted the house under the
+delightful persuasion that, allowing for the necessary preparations of
+settlements, new carriages, and wedding clothes, she should undoubtedly
+see her daughter settled at Netherfield in the course of three or four
+months. Of having another daughter married to Mr. Collins, she thought
+with equal certainty, and with considerable, though not equal, pleasure.
+Elizabeth was the least dear to her of all her children; and though the
+man and the match were quite good enough for _her_, the worth of each
+was eclipsed by Mr. Bingley and Netherfield.
+
+
+
+Chapter 19
+
+
+The next day opened a new scene at Longbourn. Mr. Collins made his
+declaration in form. Having resolved to do it without loss of time, as
+his leave of absence extended only to the following Saturday, and having
+no feelings of diffidence to make it distressing to himself even at
+the moment, he set about it in a very orderly manner, with all the
+observances, which he supposed a regular part of the business. On
+finding Mrs. Bennet, Elizabeth, and one of the younger girls together,
+soon after breakfast, he addressed the mother in these words:
+
+“May I hope, madam, for your interest with your fair daughter Elizabeth,
+when I solicit for the honour of a private audience with her in the
+course of this morning?”
+
+Before Elizabeth had time for anything but a blush of surprise, Mrs.
+Bennet answered instantly, “Oh dear!--yes--certainly. I am sure Lizzy
+will be very happy--I am sure she can have no objection. Come, Kitty, I
+want you up stairs.” And, gathering her work together, she was hastening
+away, when Elizabeth called out:
+
+“Dear madam, do not go. I beg you will not go. Mr. Collins must excuse
+me. He can have nothing to say to me that anybody need not hear. I am
+going away myself.”
+
+“No, no, nonsense, Lizzy. I desire you to stay where you are.” And upon
+Elizabeth’s seeming really, with vexed and embarrassed looks, about to
+escape, she added: “Lizzy, I _insist_ upon your staying and hearing Mr.
+Collins.”
+
+Elizabeth would not oppose such an injunction--and a moment’s
+consideration making her also sensible that it would be wisest to get it
+over as soon and as quietly as possible, she sat down again and tried to
+conceal, by incessant employment the feelings which were divided between
+distress and diversion. Mrs. Bennet and Kitty walked off, and as soon as
+they were gone, Mr. Collins began.
+
+“Believe me, my dear Miss Elizabeth, that your modesty, so far from
+doing you any disservice, rather adds to your other perfections. You
+would have been less amiable in my eyes had there _not_ been this little
+unwillingness; but allow me to assure you, that I have your respected
+mother’s permission for this address. You can hardly doubt the
+purport of my discourse, however your natural delicacy may lead you to
+dissemble; my attentions have been too marked to be mistaken. Almost as
+soon as I entered the house, I singled you out as the companion of
+my future life. But before I am run away with by my feelings on this
+subject, perhaps it would be advisable for me to state my reasons for
+marrying--and, moreover, for coming into Hertfordshire with the design
+of selecting a wife, as I certainly did.”
+
+The idea of Mr. Collins, with all his solemn composure, being run away
+with by his feelings, made Elizabeth so near laughing, that she could
+not use the short pause he allowed in any attempt to stop him further,
+and he continued:
+
+“My reasons for marrying are, first, that I think it a right thing for
+every clergyman in easy circumstances (like myself) to set the example
+of matrimony in his parish; secondly, that I am convinced that it will
+add very greatly to my happiness; and thirdly--which perhaps I ought
+to have mentioned earlier, that it is the particular advice and
+recommendation of the very noble lady whom I have the honour of calling
+patroness. Twice has she condescended to give me her opinion (unasked
+too!) on this subject; and it was but the very Saturday night before I
+left Hunsford--between our pools at quadrille, while Mrs. Jenkinson was
+arranging Miss de Bourgh’s footstool, that she said, ‘Mr. Collins, you
+must marry. A clergyman like you must marry. Choose properly, choose
+a gentlewoman for _my_ sake; and for your _own_, let her be an active,
+useful sort of person, not brought up high, but able to make a small
+income go a good way. This is my advice. Find such a woman as soon as
+you can, bring her to Hunsford, and I will visit her.’ Allow me, by the
+way, to observe, my fair cousin, that I do not reckon the notice
+and kindness of Lady Catherine de Bourgh as among the least of the
+advantages in my power to offer. You will find her manners beyond
+anything I can describe; and your wit and vivacity, I think, must be
+acceptable to her, especially when tempered with the silence and
+respect which her rank will inevitably excite. Thus much for my general
+intention in favour of matrimony; it remains to be told why my views
+were directed towards Longbourn instead of my own neighbourhood, where I
+can assure you there are many amiable young women. But the fact is, that
+being, as I am, to inherit this estate after the death of your honoured
+father (who, however, may live many years longer), I could not satisfy
+myself without resolving to choose a wife from among his daughters, that
+the loss to them might be as little as possible, when the melancholy
+event takes place--which, however, as I have already said, may not
+be for several years. This has been my motive, my fair cousin, and
+I flatter myself it will not sink me in your esteem. And now nothing
+remains for me but to assure you in the most animated language of the
+violence of my affection. To fortune I am perfectly indifferent, and
+shall make no demand of that nature on your father, since I am well
+aware that it could not be complied with; and that one thousand pounds
+in the four per cents, which will not be yours till after your mother’s
+decease, is all that you may ever be entitled to. On that head,
+therefore, I shall be uniformly silent; and you may assure yourself that
+no ungenerous reproach shall ever pass my lips when we are married.”
+
+It was absolutely necessary to interrupt him now.
+
+“You are too hasty, sir,” she cried. “You forget that I have made no
+answer. Let me do it without further loss of time. Accept my thanks for
+the compliment you are paying me. I am very sensible of the honour of
+your proposals, but it is impossible for me to do otherwise than to
+decline them.”
+
+“I am not now to learn,” replied Mr. Collins, with a formal wave of the
+hand, “that it is usual with young ladies to reject the addresses of the
+man whom they secretly mean to accept, when he first applies for their
+favour; and that sometimes the refusal is repeated a second, or even a
+third time. I am therefore by no means discouraged by what you have just
+said, and shall hope to lead you to the altar ere long.”
+
+“Upon my word, sir,” cried Elizabeth, “your hope is a rather
+extraordinary one after my declaration. I do assure you that I am not
+one of those young ladies (if such young ladies there are) who are so
+daring as to risk their happiness on the chance of being asked a second
+time. I am perfectly serious in my refusal. You could not make _me_
+happy, and I am convinced that I am the last woman in the world who
+could make you so. Nay, were your friend Lady Catherine to know me, I
+am persuaded she would find me in every respect ill qualified for the
+situation.”
+
+“Were it certain that Lady Catherine would think so,” said Mr. Collins
+very gravely--“but I cannot imagine that her ladyship would at all
+disapprove of you. And you may be certain when I have the honour of
+seeing her again, I shall speak in the very highest terms of your
+modesty, economy, and other amiable qualification.”
+
+“Indeed, Mr. Collins, all praise of me will be unnecessary. You
+must give me leave to judge for myself, and pay me the compliment
+of believing what I say. I wish you very happy and very rich, and by
+refusing your hand, do all in my power to prevent your being otherwise.
+In making me the offer, you must have satisfied the delicacy of your
+feelings with regard to my family, and may take possession of Longbourn
+estate whenever it falls, without any self-reproach. This matter may
+be considered, therefore, as finally settled.” And rising as she
+thus spoke, she would have quitted the room, had Mr. Collins not thus
+addressed her:
+
+“When I do myself the honour of speaking to you next on the subject, I
+shall hope to receive a more favourable answer than you have now given
+me; though I am far from accusing you of cruelty at present, because I
+know it to be the established custom of your sex to reject a man on
+the first application, and perhaps you have even now said as much to
+encourage my suit as would be consistent with the true delicacy of the
+female character.”
+
+“Really, Mr. Collins,” cried Elizabeth with some warmth, “you puzzle me
+exceedingly. If what I have hitherto said can appear to you in the form
+of encouragement, I know not how to express my refusal in such a way as
+to convince you of its being one.”
+
+“You must give me leave to flatter myself, my dear cousin, that your
+refusal of my addresses is merely words of course. My reasons for
+believing it are briefly these: It does not appear to me that my hand is
+unworthy of your acceptance, or that the establishment I can offer would
+be any other than highly desirable. My situation in life, my connections
+with the family of de Bourgh, and my relationship to your own, are
+circumstances highly in my favour; and you should take it into further
+consideration, that in spite of your manifold attractions, it is by no
+means certain that another offer of marriage may ever be made you. Your
+portion is unhappily so small that it will in all likelihood undo
+the effects of your loveliness and amiable qualifications. As I must
+therefore conclude that you are not serious in your rejection of me,
+I shall choose to attribute it to your wish of increasing my love by
+suspense, according to the usual practice of elegant females.”
+
+“I do assure you, sir, that I have no pretensions whatever to that kind
+of elegance which consists in tormenting a respectable man. I would
+rather be paid the compliment of being believed sincere. I thank you
+again and again for the honour you have done me in your proposals, but
+to accept them is absolutely impossible. My feelings in every respect
+forbid it. Can I speak plainer? Do not consider me now as an elegant
+female, intending to plague you, but as a rational creature, speaking
+the truth from her heart.”
+
+“You are uniformly charming!” cried he, with an air of awkward
+gallantry; “and I am persuaded that when sanctioned by the express
+authority of both your excellent parents, my proposals will not fail of
+being acceptable.”
+
+To such perseverance in wilful self-deception Elizabeth would make
+no reply, and immediately and in silence withdrew; determined, if
+he persisted in considering her repeated refusals as flattering
+encouragement, to apply to her father, whose negative might be uttered
+in such a manner as to be decisive, and whose behaviour at least could
+not be mistaken for the affectation and coquetry of an elegant female.
+
+
+
+Chapter 20
+
+
+Mr. Collins was not left long to the silent contemplation of his
+successful love; for Mrs. Bennet, having dawdled about in the vestibule
+to watch for the end of the conference, no sooner saw Elizabeth open
+the door and with quick step pass her towards the staircase, than she
+entered the breakfast-room, and congratulated both him and herself in
+warm terms on the happy prospect of their nearer connection. Mr. Collins
+received and returned these felicitations with equal pleasure, and then
+proceeded to relate the particulars of their interview, with the result
+of which he trusted he had every reason to be satisfied, since the
+refusal which his cousin had steadfastly given him would naturally flow
+from her bashful modesty and the genuine delicacy of her character.
+
+This information, however, startled Mrs. Bennet; she would have been
+glad to be equally satisfied that her daughter had meant to encourage
+him by protesting against his proposals, but she dared not believe it,
+and could not help saying so.
+
+“But, depend upon it, Mr. Collins,” she added, “that Lizzy shall be
+brought to reason. I will speak to her about it directly. She is a very
+headstrong, foolish girl, and does not know her own interest but I will
+_make_ her know it.”
+
+“Pardon me for interrupting you, madam,” cried Mr. Collins; “but if
+she is really headstrong and foolish, I know not whether she would
+altogether be a very desirable wife to a man in my situation, who
+naturally looks for happiness in the marriage state. If therefore she
+actually persists in rejecting my suit, perhaps it were better not
+to force her into accepting me, because if liable to such defects of
+temper, she could not contribute much to my felicity.”
+
+“Sir, you quite misunderstand me,” said Mrs. Bennet, alarmed. “Lizzy is
+only headstrong in such matters as these. In everything else she is as
+good-natured a girl as ever lived. I will go directly to Mr. Bennet, and
+we shall very soon settle it with her, I am sure.”
+
+She would not give him time to reply, but hurrying instantly to her
+husband, called out as she entered the library, “Oh! Mr. Bennet, you
+are wanted immediately; we are all in an uproar. You must come and make
+Lizzy marry Mr. Collins, for she vows she will not have him, and if you
+do not make haste he will change his mind and not have _her_.”
+
+Mr. Bennet raised his eyes from his book as she entered, and fixed them
+on her face with a calm unconcern which was not in the least altered by
+her communication.
+
+“I have not the pleasure of understanding you,” said he, when she had
+finished her speech. “Of what are you talking?”
+
+“Of Mr. Collins and Lizzy. Lizzy declares she will not have Mr. Collins,
+and Mr. Collins begins to say that he will not have Lizzy.”
+
+“And what am I to do on the occasion? It seems an hopeless business.”
+
+“Speak to Lizzy about it yourself. Tell her that you insist upon her
+marrying him.”
+
+“Let her be called down. She shall hear my opinion.”
+
+Mrs. Bennet rang the bell, and Miss Elizabeth was summoned to the
+library.
+
+“Come here, child,” cried her father as she appeared. “I have sent for
+you on an affair of importance. I understand that Mr. Collins has made
+you an offer of marriage. Is it true?” Elizabeth replied that it was.
+“Very well--and this offer of marriage you have refused?”
+
+“I have, sir.”
+
+“Very well. We now come to the point. Your mother insists upon your
+accepting it. Is it not so, Mrs. Bennet?”
+
+“Yes, or I will never see her again.”
+
+“An unhappy alternative is before you, Elizabeth. From this day you must
+be a stranger to one of your parents. Your mother will never see you
+again if you do _not_ marry Mr. Collins, and I will never see you again
+if you _do_.”
+
+Elizabeth could not but smile at such a conclusion of such a beginning,
+but Mrs. Bennet, who had persuaded herself that her husband regarded the
+affair as she wished, was excessively disappointed.
+
+“What do you mean, Mr. Bennet, in talking this way? You promised me to
+_insist_ upon her marrying him.”
+
+“My dear,” replied her husband, “I have two small favours to request.
+First, that you will allow me the free use of my understanding on the
+present occasion; and secondly, of my room. I shall be glad to have the
+library to myself as soon as may be.”
+
+Not yet, however, in spite of her disappointment in her husband, did
+Mrs. Bennet give up the point. She talked to Elizabeth again and again;
+coaxed and threatened her by turns. She endeavoured to secure Jane
+in her interest; but Jane, with all possible mildness, declined
+interfering; and Elizabeth, sometimes with real earnestness, and
+sometimes with playful gaiety, replied to her attacks. Though her manner
+varied, however, her determination never did.
+
+Mr. Collins, meanwhile, was meditating in solitude on what had passed.
+He thought too well of himself to comprehend on what motives his cousin
+could refuse him; and though his pride was hurt, he suffered in no other
+way. His regard for her was quite imaginary; and the possibility of her
+deserving her mother’s reproach prevented his feeling any regret.
+
+While the family were in this confusion, Charlotte Lucas came to spend
+the day with them. She was met in the vestibule by Lydia, who, flying to
+her, cried in a half whisper, “I am glad you are come, for there is such
+fun here! What do you think has happened this morning? Mr. Collins has
+made an offer to Lizzy, and she will not have him.”
+
+Charlotte hardly had time to answer, before they were joined by Kitty,
+who came to tell the same news; and no sooner had they entered the
+breakfast-room, where Mrs. Bennet was alone, than she likewise began on
+the subject, calling on Miss Lucas for her compassion, and entreating
+her to persuade her friend Lizzy to comply with the wishes of all her
+family. “Pray do, my dear Miss Lucas,” she added in a melancholy tone,
+“for nobody is on my side, nobody takes part with me. I am cruelly used,
+nobody feels for my poor nerves.”
+
+Charlotte’s reply was spared by the entrance of Jane and Elizabeth.
+
+“Aye, there she comes,” continued Mrs. Bennet, “looking as unconcerned
+as may be, and caring no more for us than if we were at York, provided
+she can have her own way. But I tell you, Miss Lizzy--if you take it
+into your head to go on refusing every offer of marriage in this way,
+you will never get a husband at all--and I am sure I do not know who is
+to maintain you when your father is dead. I shall not be able to keep
+you--and so I warn you. I have done with you from this very day. I told
+you in the library, you know, that I should never speak to you again,
+and you will find me as good as my word. I have no pleasure in talking
+to undutiful children. Not that I have much pleasure, indeed, in talking
+to anybody. People who suffer as I do from nervous complaints can have
+no great inclination for talking. Nobody can tell what I suffer! But it
+is always so. Those who do not complain are never pitied.”
+
+Her daughters listened in silence to this effusion, sensible that
+any attempt to reason with her or soothe her would only increase the
+irritation. She talked on, therefore, without interruption from any of
+them, till they were joined by Mr. Collins, who entered the room with
+an air more stately than usual, and on perceiving whom, she said to
+the girls, “Now, I do insist upon it, that you, all of you, hold
+your tongues, and let me and Mr. Collins have a little conversation
+together.”
+
+Elizabeth passed quietly out of the room, Jane and Kitty followed, but
+Lydia stood her ground, determined to hear all she could; and Charlotte,
+detained first by the civility of Mr. Collins, whose inquiries after
+herself and all her family were very minute, and then by a little
+curiosity, satisfied herself with walking to the window and pretending
+not to hear. In a doleful voice Mrs. Bennet began the projected
+conversation: “Oh! Mr. Collins!”
+
+“My dear madam,” replied he, “let us be for ever silent on this point.
+Far be it from me,” he presently continued, in a voice that marked his
+displeasure, “to resent the behaviour of your daughter. Resignation
+to inevitable evils is the duty of us all; the peculiar duty of a
+young man who has been so fortunate as I have been in early preferment;
+and I trust I am resigned. Perhaps not the less so from feeling a doubt
+of my positive happiness had my fair cousin honoured me with her hand;
+for I have often observed that resignation is never so perfect as
+when the blessing denied begins to lose somewhat of its value in our
+estimation. You will not, I hope, consider me as showing any disrespect
+to your family, my dear madam, by thus withdrawing my pretensions to
+your daughter’s favour, without having paid yourself and Mr. Bennet the
+compliment of requesting you to interpose your authority in my
+behalf. My conduct may, I fear, be objectionable in having accepted my
+dismission from your daughter’s lips instead of your own. But we are all
+liable to error. I have certainly meant well through the whole affair.
+My object has been to secure an amiable companion for myself, with due
+consideration for the advantage of all your family, and if my _manner_
+has been at all reprehensible, I here beg leave to apologise.”
+
+
+
+Chapter 21
+
+
+The discussion of Mr. Collins’s offer was now nearly at an end, and
+Elizabeth had only to suffer from the uncomfortable feelings necessarily
+attending it, and occasionally from some peevish allusions of her
+mother. As for the gentleman himself, _his_ feelings were chiefly
+expressed, not by embarrassment or dejection, or by trying to avoid her,
+but by stiffness of manner and resentful silence. He scarcely ever spoke
+to her, and the assiduous attentions which he had been so sensible of
+himself were transferred for the rest of the day to Miss Lucas, whose
+civility in listening to him was a seasonable relief to them all, and
+especially to her friend.
+
+The morrow produced no abatement of Mrs. Bennet’s ill-humour or ill
+health. Mr. Collins was also in the same state of angry pride. Elizabeth
+had hoped that his resentment might shorten his visit, but his plan did
+not appear in the least affected by it. He was always to have gone on
+Saturday, and to Saturday he meant to stay.
+
+After breakfast, the girls walked to Meryton to inquire if Mr. Wickham
+were returned, and to lament over his absence from the Netherfield ball.
+He joined them on their entering the town, and attended them to their
+aunt’s where his regret and vexation, and the concern of everybody, was
+well talked over. To Elizabeth, however, he voluntarily acknowledged
+that the necessity of his absence _had_ been self-imposed.
+
+“I found,” said he, “as the time drew near that I had better not meet
+Mr. Darcy; that to be in the same room, the same party with him for so
+many hours together, might be more than I could bear, and that scenes
+might arise unpleasant to more than myself.”
+
+She highly approved his forbearance, and they had leisure for a full
+discussion of it, and for all the commendation which they civilly
+bestowed on each other, as Wickham and another officer walked back with
+them to Longbourn, and during the walk he particularly attended to
+her. His accompanying them was a double advantage; she felt all the
+compliment it offered to herself, and it was most acceptable as an
+occasion of introducing him to her father and mother.
+
+Soon after their return, a letter was delivered to Miss Bennet; it came
+from Netherfield. The envelope contained a sheet of elegant, little,
+hot-pressed paper, well covered with a lady’s fair, flowing hand; and
+Elizabeth saw her sister’s countenance change as she read it, and saw
+her dwelling intently on some particular passages. Jane recollected
+herself soon, and putting the letter away, tried to join with her usual
+cheerfulness in the general conversation; but Elizabeth felt an anxiety
+on the subject which drew off her attention even from Wickham; and no
+sooner had he and his companion taken leave, than a glance from Jane
+invited her to follow her up stairs. When they had gained their own room,
+Jane, taking out the letter, said:
+
+“This is from Caroline Bingley; what it contains has surprised me a good
+deal. The whole party have left Netherfield by this time, and are on
+their way to town--and without any intention of coming back again. You
+shall hear what she says.”
+
+She then read the first sentence aloud, which comprised the information
+of their having just resolved to follow their brother to town directly,
+and of their meaning to dine in Grosvenor Street, where Mr. Hurst had a
+house. The next was in these words: “I do not pretend to regret anything
+I shall leave in Hertfordshire, except your society, my dearest friend;
+but we will hope, at some future period, to enjoy many returns of that
+delightful intercourse we have known, and in the meanwhile may
+lessen the pain of separation by a very frequent and most unreserved
+correspondence. I depend on you for that.” To these highflown
+expressions Elizabeth listened with all the insensibility of distrust;
+and though the suddenness of their removal surprised her, she saw
+nothing in it really to lament; it was not to be supposed that their
+absence from Netherfield would prevent Mr. Bingley’s being there; and as
+to the loss of their society, she was persuaded that Jane must cease to
+regard it, in the enjoyment of his.
+
+“It is unlucky,” said she, after a short pause, “that you should not be
+able to see your friends before they leave the country. But may we not
+hope that the period of future happiness to which Miss Bingley looks
+forward may arrive earlier than she is aware, and that the delightful
+intercourse you have known as friends will be renewed with yet greater
+satisfaction as sisters? Mr. Bingley will not be detained in London by
+them.”
+
+“Caroline decidedly says that none of the party will return into
+Hertfordshire this winter. I will read it to you:”
+
+“When my brother left us yesterday, he imagined that the business which
+took him to London might be concluded in three or four days; but as we
+are certain it cannot be so, and at the same time convinced that when
+Charles gets to town he will be in no hurry to leave it again, we have
+determined on following him thither, that he may not be obliged to spend
+his vacant hours in a comfortless hotel. Many of my acquaintances are
+already there for the winter; I wish that I could hear that you, my
+dearest friend, had any intention of making one of the crowd--but of
+that I despair. I sincerely hope your Christmas in Hertfordshire may
+abound in the gaieties which that season generally brings, and that your
+beaux will be so numerous as to prevent your feeling the loss of the
+three of whom we shall deprive you.”
+
+“It is evident by this,” added Jane, “that he comes back no more this
+winter.”
+
+“It is only evident that Miss Bingley does not mean that he _should_.”
+
+“Why will you think so? It must be his own doing. He is his own
+master. But you do not know _all_. I _will_ read you the passage which
+particularly hurts me. I will have no reserves from _you_.”
+
+“Mr. Darcy is impatient to see his sister; and, to confess the truth,
+_we_ are scarcely less eager to meet her again. I really do not think
+Georgiana Darcy has her equal for beauty, elegance, and accomplishments;
+and the affection she inspires in Louisa and myself is heightened into
+something still more interesting, from the hope we dare entertain of
+her being hereafter our sister. I do not know whether I ever before
+mentioned to you my feelings on this subject; but I will not leave the
+country without confiding them, and I trust you will not esteem them
+unreasonable. My brother admires her greatly already; he will have
+frequent opportunity now of seeing her on the most intimate footing;
+her relations all wish the connection as much as his own; and a sister’s
+partiality is not misleading me, I think, when I call Charles most
+capable of engaging any woman’s heart. With all these circumstances to
+favour an attachment, and nothing to prevent it, am I wrong, my dearest
+Jane, in indulging the hope of an event which will secure the happiness
+of so many?”
+
+“What do you think of _this_ sentence, my dear Lizzy?” said Jane as she
+finished it. “Is it not clear enough? Does it not expressly declare that
+Caroline neither expects nor wishes me to be her sister; that she is
+perfectly convinced of her brother’s indifference; and that if she
+suspects the nature of my feelings for him, she means (most kindly!) to
+put me on my guard? Can there be any other opinion on the subject?”
+
+“Yes, there can; for mine is totally different. Will you hear it?”
+
+“Most willingly.”
+
+“You shall have it in a few words. Miss Bingley sees that her brother is
+in love with you, and wants him to marry Miss Darcy. She follows him
+to town in hope of keeping him there, and tries to persuade you that he
+does not care about you.”
+
+Jane shook her head.
+
+“Indeed, Jane, you ought to believe me. No one who has ever seen you
+together can doubt his affection. Miss Bingley, I am sure, cannot. She
+is not such a simpleton. Could she have seen half as much love in Mr.
+Darcy for herself, she would have ordered her wedding clothes. But the
+case is this: We are not rich enough or grand enough for them; and she
+is the more anxious to get Miss Darcy for her brother, from the notion
+that when there has been _one_ intermarriage, she may have less trouble
+in achieving a second; in which there is certainly some ingenuity, and
+I dare say it would succeed, if Miss de Bourgh were out of the way. But,
+my dearest Jane, you cannot seriously imagine that because Miss Bingley
+tells you her brother greatly admires Miss Darcy, he is in the smallest
+degree less sensible of _your_ merit than when he took leave of you on
+Tuesday, or that it will be in her power to persuade him that, instead
+of being in love with you, he is very much in love with her friend.”
+
+“If we thought alike of Miss Bingley,” replied Jane, “your
+representation of all this might make me quite easy. But I know the
+foundation is unjust. Caroline is incapable of wilfully deceiving
+anyone; and all that I can hope in this case is that she is deceiving
+herself.”
+
+“That is right. You could not have started a more happy idea, since you
+will not take comfort in mine. Believe her to be deceived, by all means.
+You have now done your duty by her, and must fret no longer.”
+
+“But, my dear sister, can I be happy, even supposing the best, in
+accepting a man whose sisters and friends are all wishing him to marry
+elsewhere?”
+
+“You must decide for yourself,” said Elizabeth; “and if, upon mature
+deliberation, you find that the misery of disobliging his two sisters is
+more than equivalent to the happiness of being his wife, I advise you by
+all means to refuse him.”
+
+“How can you talk so?” said Jane, faintly smiling. “You must know that
+though I should be exceedingly grieved at their disapprobation, I could
+not hesitate.”
+
+“I did not think you would; and that being the case, I cannot consider
+your situation with much compassion.”
+
+“But if he returns no more this winter, my choice will never be
+required. A thousand things may arise in six months!”
+
+The idea of his returning no more Elizabeth treated with the utmost
+contempt. It appeared to her merely the suggestion of Caroline’s
+interested wishes, and she could not for a moment suppose that those
+wishes, however openly or artfully spoken, could influence a young man
+so totally independent of everyone.
+
+She represented to her sister as forcibly as possible what she felt
+on the subject, and had soon the pleasure of seeing its happy effect.
+Jane’s temper was not desponding, and she was gradually led to hope,
+though the diffidence of affection sometimes overcame the hope, that
+Bingley would return to Netherfield and answer every wish of her heart.
+
+They agreed that Mrs. Bennet should only hear of the departure of the
+family, without being alarmed on the score of the gentleman’s conduct;
+but even this partial communication gave her a great deal of concern,
+and she bewailed it as exceedingly unlucky that the ladies should happen
+to go away just as they were all getting so intimate together. After
+lamenting it, however, at some length, she had the consolation that Mr.
+Bingley would be soon down again and soon dining at Longbourn, and the
+conclusion of all was the comfortable declaration, that though he had
+been invited only to a family dinner, she would take care to have two
+full courses.
+
+
+
+Chapter 22
+
+
+The Bennets were engaged to dine with the Lucases and again during the
+chief of the day was Miss Lucas so kind as to listen to Mr. Collins.
+Elizabeth took an opportunity of thanking her. “It keeps him in good
+humour,” said she, “and I am more obliged to you than I can express.”
+ Charlotte assured her friend of her satisfaction in being useful, and
+that it amply repaid her for the little sacrifice of her time. This was
+very amiable, but Charlotte’s kindness extended farther than Elizabeth
+had any conception of; its object was nothing else than to secure her
+from any return of Mr. Collins’s addresses, by engaging them towards
+herself. Such was Miss Lucas’s scheme; and appearances were so
+favourable, that when they parted at night, she would have felt almost
+secure of success if he had not been to leave Hertfordshire so very
+soon. But here she did injustice to the fire and independence of his
+character, for it led him to escape out of Longbourn House the next
+morning with admirable slyness, and hasten to Lucas Lodge to throw
+himself at her feet. He was anxious to avoid the notice of his cousins,
+from a conviction that if they saw him depart, they could not fail to
+conjecture his design, and he was not willing to have the attempt known
+till its success might be known likewise; for though feeling almost
+secure, and with reason, for Charlotte had been tolerably encouraging,
+he was comparatively diffident since the adventure of Wednesday.
+His reception, however, was of the most flattering kind. Miss Lucas
+perceived him from an upper window as he walked towards the house, and
+instantly set out to meet him accidentally in the lane. But little had
+she dared to hope that so much love and eloquence awaited her there.
+
+In as short a time as Mr. Collins’s long speeches would allow,
+everything was settled between them to the satisfaction of both; and as
+they entered the house he earnestly entreated her to name the day that
+was to make him the happiest of men; and though such a solicitation must
+be waived for the present, the lady felt no inclination to trifle with
+his happiness. The stupidity with which he was favoured by nature must
+guard his courtship from any charm that could make a woman wish for its
+continuance; and Miss Lucas, who accepted him solely from the pure
+and disinterested desire of an establishment, cared not how soon that
+establishment were gained.
+
+Sir William and Lady Lucas were speedily applied to for their consent;
+and it was bestowed with a most joyful alacrity. Mr. Collins’s present
+circumstances made it a most eligible match for their daughter, to whom
+they could give little fortune; and his prospects of future wealth were
+exceedingly fair. Lady Lucas began directly to calculate, with more
+interest than the matter had ever excited before, how many years longer
+Mr. Bennet was likely to live; and Sir William gave it as his decided
+opinion, that whenever Mr. Collins should be in possession of the
+Longbourn estate, it would be highly expedient that both he and his wife
+should make their appearance at St. James’s. The whole family, in short,
+were properly overjoyed on the occasion. The younger girls formed hopes
+of _coming out_ a year or two sooner than they might otherwise have
+done; and the boys were relieved from their apprehension of Charlotte’s
+dying an old maid. Charlotte herself was tolerably composed. She had
+gained her point, and had time to consider of it. Her reflections were
+in general satisfactory. Mr. Collins, to be sure, was neither sensible
+nor agreeable; his society was irksome, and his attachment to her must
+be imaginary. But still he would be her husband. Without thinking highly
+either of men or matrimony, marriage had always been her object; it was
+the only provision for well-educated young women of small fortune,
+and however uncertain of giving happiness, must be their pleasantest
+preservative from want. This preservative she had now obtained; and at
+the age of twenty-seven, without having ever been handsome, she felt all
+the good luck of it. The least agreeable circumstance in the business
+was the surprise it must occasion to Elizabeth Bennet, whose friendship
+she valued beyond that of any other person. Elizabeth would wonder,
+and probably would blame her; and though her resolution was not to be
+shaken, her feelings must be hurt by such a disapprobation. She resolved
+to give her the information herself, and therefore charged Mr. Collins,
+when he returned to Longbourn to dinner, to drop no hint of what had
+passed before any of the family. A promise of secrecy was of course very
+dutifully given, but it could not be kept without difficulty; for the
+curiosity excited by his long absence burst forth in such very direct
+questions on his return as required some ingenuity to evade, and he was
+at the same time exercising great self-denial, for he was longing to
+publish his prosperous love.
+
+As he was to begin his journey too early on the morrow to see any of the
+family, the ceremony of leave-taking was performed when the ladies moved
+for the night; and Mrs. Bennet, with great politeness and cordiality,
+said how happy they should be to see him at Longbourn again, whenever
+his engagements might allow him to visit them.
+
+“My dear madam,” he replied, “this invitation is particularly
+gratifying, because it is what I have been hoping to receive; and
+you may be very certain that I shall avail myself of it as soon as
+possible.”
+
+They were all astonished; and Mr. Bennet, who could by no means wish for
+so speedy a return, immediately said:
+
+“But is there not danger of Lady Catherine’s disapprobation here, my
+good sir? You had better neglect your relations than run the risk of
+offending your patroness.”
+
+“My dear sir,” replied Mr. Collins, “I am particularly obliged to you
+for this friendly caution, and you may depend upon my not taking so
+material a step without her ladyship’s concurrence.”
+
+“You cannot be too much upon your guard. Risk anything rather than her
+displeasure; and if you find it likely to be raised by your coming to us
+again, which I should think exceedingly probable, stay quietly at home,
+and be satisfied that _we_ shall take no offence.”
+
+“Believe me, my dear sir, my gratitude is warmly excited by such
+affectionate attention; and depend upon it, you will speedily receive
+from me a letter of thanks for this, and for every other mark of your
+regard during my stay in Hertfordshire. As for my fair cousins, though
+my absence may not be long enough to render it necessary, I shall now
+take the liberty of wishing them health and happiness, not excepting my
+cousin Elizabeth.”
+
+With proper civilities the ladies then withdrew; all of them equally
+surprised that he meditated a quick return. Mrs. Bennet wished to
+understand by it that he thought of paying his addresses to one of her
+younger girls, and Mary might have been prevailed on to accept him.
+She rated his abilities much higher than any of the others; there was
+a solidity in his reflections which often struck her, and though by no
+means so clever as herself, she thought that if encouraged to read
+and improve himself by such an example as hers, he might become a very
+agreeable companion. But on the following morning, every hope of this
+kind was done away. Miss Lucas called soon after breakfast, and in a
+private conference with Elizabeth related the event of the day before.
+
+The possibility of Mr. Collins’s fancying himself in love with her
+friend had once occurred to Elizabeth within the last day or two; but
+that Charlotte could encourage him seemed almost as far from
+possibility as she could encourage him herself, and her astonishment was
+consequently so great as to overcome at first the bounds of decorum, and
+she could not help crying out:
+
+“Engaged to Mr. Collins! My dear Charlotte--impossible!”
+
+The steady countenance which Miss Lucas had commanded in telling her
+story, gave way to a momentary confusion here on receiving so direct a
+reproach; though, as it was no more than she expected, she soon regained
+her composure, and calmly replied:
+
+“Why should you be surprised, my dear Eliza? Do you think it incredible
+that Mr. Collins should be able to procure any woman’s good opinion,
+because he was not so happy as to succeed with you?”
+
+But Elizabeth had now recollected herself, and making a strong effort
+for it, was able to assure with tolerable firmness that the prospect of
+their relationship was highly grateful to her, and that she wished her
+all imaginable happiness.
+
+“I see what you are feeling,” replied Charlotte. “You must be surprised,
+very much surprised--so lately as Mr. Collins was wishing to marry
+you. But when you have had time to think it over, I hope you will be
+satisfied with what I have done. I am not romantic, you know; I never
+was. I ask only a comfortable home; and considering Mr. Collins’s
+character, connection, and situation in life, I am convinced that my
+chance of happiness with him is as fair as most people can boast on
+entering the marriage state.”
+
+Elizabeth quietly answered “Undoubtedly;” and after an awkward pause,
+they returned to the rest of the family. Charlotte did not stay much
+longer, and Elizabeth was then left to reflect on what she had heard.
+It was a long time before she became at all reconciled to the idea of so
+unsuitable a match. The strangeness of Mr. Collins’s making two offers
+of marriage within three days was nothing in comparison of his being now
+accepted. She had always felt that Charlotte’s opinion of matrimony was
+not exactly like her own, but she had not supposed it to be possible
+that, when called into action, she would have sacrificed every better
+feeling to worldly advantage. Charlotte the wife of Mr. Collins was a
+most humiliating picture! And to the pang of a friend disgracing herself
+and sunk in her esteem, was added the distressing conviction that it
+was impossible for that friend to be tolerably happy in the lot she had
+chosen.
+
+
+
+Chapter 23
+
+
+Elizabeth was sitting with her mother and sisters, reflecting on what
+she had heard, and doubting whether she was authorised to mention
+it, when Sir William Lucas himself appeared, sent by his daughter, to
+announce her engagement to the family. With many compliments to them,
+and much self-gratulation on the prospect of a connection between the
+houses, he unfolded the matter--to an audience not merely wondering, but
+incredulous; for Mrs. Bennet, with more perseverance than politeness,
+protested he must be entirely mistaken; and Lydia, always unguarded and
+often uncivil, boisterously exclaimed:
+
+“Good Lord! Sir William, how can you tell such a story? Do not you know
+that Mr. Collins wants to marry Lizzy?”
+
+Nothing less than the complaisance of a courtier could have borne
+without anger such treatment; but Sir William’s good breeding carried
+him through it all; and though he begged leave to be positive as to the
+truth of his information, he listened to all their impertinence with the
+most forbearing courtesy.
+
+Elizabeth, feeling it incumbent on her to relieve him from so unpleasant
+a situation, now put herself forward to confirm his account, by
+mentioning her prior knowledge of it from Charlotte herself; and
+endeavoured to put a stop to the exclamations of her mother and sisters
+by the earnestness of her congratulations to Sir William, in which she
+was readily joined by Jane, and by making a variety of remarks on the
+happiness that might be expected from the match, the excellent character
+of Mr. Collins, and the convenient distance of Hunsford from London.
+
+Mrs. Bennet was in fact too much overpowered to say a great deal while
+Sir William remained; but no sooner had he left them than her feelings
+found a rapid vent. In the first place, she persisted in disbelieving
+the whole of the matter; secondly, she was very sure that Mr. Collins
+had been taken in; thirdly, she trusted that they would never be
+happy together; and fourthly, that the match might be broken off. Two
+inferences, however, were plainly deduced from the whole: one, that
+Elizabeth was the real cause of the mischief; and the other that she
+herself had been barbarously misused by them all; and on these two
+points she principally dwelt during the rest of the day. Nothing could
+console and nothing could appease her. Nor did that day wear out her
+resentment. A week elapsed before she could see Elizabeth without
+scolding her, a month passed away before she could speak to Sir William
+or Lady Lucas without being rude, and many months were gone before she
+could at all forgive their daughter.
+
+Mr. Bennet’s emotions were much more tranquil on the occasion, and such
+as he did experience he pronounced to be of a most agreeable sort; for
+it gratified him, he said, to discover that Charlotte Lucas, whom he had
+been used to think tolerably sensible, was as foolish as his wife, and
+more foolish than his daughter!
+
+Jane confessed herself a little surprised at the match; but she said
+less of her astonishment than of her earnest desire for their happiness;
+nor could Elizabeth persuade her to consider it as improbable. Kitty
+and Lydia were far from envying Miss Lucas, for Mr. Collins was only a
+clergyman; and it affected them in no other way than as a piece of news
+to spread at Meryton.
+
+Lady Lucas could not be insensible of triumph on being able to retort
+on Mrs. Bennet the comfort of having a daughter well married; and she
+called at Longbourn rather oftener than usual to say how happy she was,
+though Mrs. Bennet’s sour looks and ill-natured remarks might have been
+enough to drive happiness away.
+
+Between Elizabeth and Charlotte there was a restraint which kept them
+mutually silent on the subject; and Elizabeth felt persuaded that
+no real confidence could ever subsist between them again. Her
+disappointment in Charlotte made her turn with fonder regard to her
+sister, of whose rectitude and delicacy she was sure her opinion could
+never be shaken, and for whose happiness she grew daily more anxious,
+as Bingley had now been gone a week and nothing more was heard of his
+return.
+
+Jane had sent Caroline an early answer to her letter, and was counting
+the days till she might reasonably hope to hear again. The promised
+letter of thanks from Mr. Collins arrived on Tuesday, addressed to
+their father, and written with all the solemnity of gratitude which a
+twelvemonth’s abode in the family might have prompted. After discharging
+his conscience on that head, he proceeded to inform them, with many
+rapturous expressions, of his happiness in having obtained the affection
+of their amiable neighbour, Miss Lucas, and then explained that it was
+merely with the view of enjoying her society that he had been so ready
+to close with their kind wish of seeing him again at Longbourn, whither
+he hoped to be able to return on Monday fortnight; for Lady Catherine,
+he added, so heartily approved his marriage, that she wished it to take
+place as soon as possible, which he trusted would be an unanswerable
+argument with his amiable Charlotte to name an early day for making him
+the happiest of men.
+
+Mr. Collins’s return into Hertfordshire was no longer a matter of
+pleasure to Mrs. Bennet. On the contrary, she was as much disposed to
+complain of it as her husband. It was very strange that he should come
+to Longbourn instead of to Lucas Lodge; it was also very inconvenient
+and exceedingly troublesome. She hated having visitors in the house
+while her health was so indifferent, and lovers were of all people the
+most disagreeable. Such were the gentle murmurs of Mrs. Bennet, and
+they gave way only to the greater distress of Mr. Bingley’s continued
+absence.
+
+Neither Jane nor Elizabeth were comfortable on this subject. Day after
+day passed away without bringing any other tidings of him than the
+report which shortly prevailed in Meryton of his coming no more to
+Netherfield the whole winter; a report which highly incensed Mrs.
+Bennet, and which she never failed to contradict as a most scandalous
+falsehood.
+
+Even Elizabeth began to fear--not that Bingley was indifferent--but that
+his sisters would be successful in keeping him away. Unwilling as
+she was to admit an idea so destructive of Jane’s happiness, and so
+dishonorable to the stability of her lover, she could not prevent its
+frequently occurring. The united efforts of his two unfeeling sisters
+and of his overpowering friend, assisted by the attractions of Miss
+Darcy and the amusements of London might be too much, she feared, for
+the strength of his attachment.
+
+As for Jane, _her_ anxiety under this suspense was, of course, more
+painful than Elizabeth’s, but whatever she felt she was desirous of
+concealing, and between herself and Elizabeth, therefore, the subject
+was never alluded to. But as no such delicacy restrained her mother,
+an hour seldom passed in which she did not talk of Bingley, express her
+impatience for his arrival, or even require Jane to confess that if he
+did not come back she would think herself very ill used. It needed
+all Jane’s steady mildness to bear these attacks with tolerable
+tranquillity.
+
+Mr. Collins returned most punctually on Monday fortnight, but his
+reception at Longbourn was not quite so gracious as it had been on his
+first introduction. He was too happy, however, to need much attention;
+and luckily for the others, the business of love-making relieved them
+from a great deal of his company. The chief of every day was spent by
+him at Lucas Lodge, and he sometimes returned to Longbourn only in time
+to make an apology for his absence before the family went to bed.
+
+Mrs. Bennet was really in a most pitiable state. The very mention of
+anything concerning the match threw her into an agony of ill-humour,
+and wherever she went she was sure of hearing it talked of. The sight
+of Miss Lucas was odious to her. As her successor in that house, she
+regarded her with jealous abhorrence. Whenever Charlotte came to see
+them, she concluded her to be anticipating the hour of possession; and
+whenever she spoke in a low voice to Mr. Collins, was convinced that
+they were talking of the Longbourn estate, and resolving to turn herself
+and her daughters out of the house, as soon as Mr. Bennet were dead. She
+complained bitterly of all this to her husband.
+
+“Indeed, Mr. Bennet,” said she, “it is very hard to think that Charlotte
+Lucas should ever be mistress of this house, that I should be forced to
+make way for _her_, and live to see her take her place in it!”
+
+“My dear, do not give way to such gloomy thoughts. Let us hope for
+better things. Let us flatter ourselves that I may be the survivor.”
+
+This was not very consoling to Mrs. Bennet, and therefore, instead of
+making any answer, she went on as before.
+
+“I cannot bear to think that they should have all this estate. If it was
+not for the entail, I should not mind it.”
+
+“What should not you mind?”
+
+“I should not mind anything at all.”
+
+“Let us be thankful that you are preserved from a state of such
+insensibility.”
+
+“I never can be thankful, Mr. Bennet, for anything about the entail. How
+anyone could have the conscience to entail away an estate from one’s own
+daughters, I cannot understand; and all for the sake of Mr. Collins too!
+Why should _he_ have it more than anybody else?”
+
+“I leave it to yourself to determine,” said Mr. Bennet.
+
+
+
+Chapter 24
+
+
+Miss Bingley’s letter arrived, and put an end to doubt. The very first
+sentence conveyed the assurance of their being all settled in London for
+the winter, and concluded with her brother’s regret at not having had
+time to pay his respects to his friends in Hertfordshire before he left
+the country.
+
+Hope was over, entirely over; and when Jane could attend to the rest
+of the letter, she found little, except the professed affection of the
+writer, that could give her any comfort. Miss Darcy’s praise occupied
+the chief of it. Her many attractions were again dwelt on, and Caroline
+boasted joyfully of their increasing intimacy, and ventured to predict
+the accomplishment of the wishes which had been unfolded in her former
+letter. She wrote also with great pleasure of her brother’s being an
+inmate of Mr. Darcy’s house, and mentioned with raptures some plans of
+the latter with regard to new furniture.
+
+Elizabeth, to whom Jane very soon communicated the chief of all this,
+heard it in silent indignation. Her heart was divided between concern
+for her sister, and resentment against all others. To Caroline’s
+assertion of her brother’s being partial to Miss Darcy she paid no
+credit. That he was really fond of Jane, she doubted no more than she
+had ever done; and much as she had always been disposed to like him, she
+could not think without anger, hardly without contempt, on that easiness
+of temper, that want of proper resolution, which now made him the slave
+of his designing friends, and led him to sacrifice of his own happiness
+to the caprice of their inclination. Had his own happiness, however,
+been the only sacrifice, he might have been allowed to sport with it in
+whatever manner he thought best, but her sister’s was involved in it, as
+she thought he must be sensible himself. It was a subject, in short,
+on which reflection would be long indulged, and must be unavailing. She
+could think of nothing else; and yet whether Bingley’s regard had really
+died away, or were suppressed by his friends’ interference; whether
+he had been aware of Jane’s attachment, or whether it had escaped his
+observation; whatever were the case, though her opinion of him must be
+materially affected by the difference, her sister’s situation remained
+the same, her peace equally wounded.
+
+A day or two passed before Jane had courage to speak of her feelings to
+Elizabeth; but at last, on Mrs. Bennet’s leaving them together, after a
+longer irritation than usual about Netherfield and its master, she could
+not help saying:
+
+“Oh, that my dear mother had more command over herself! She can have no
+idea of the pain she gives me by her continual reflections on him. But
+I will not repine. It cannot last long. He will be forgot, and we shall
+all be as we were before.”
+
+Elizabeth looked at her sister with incredulous solicitude, but said
+nothing.
+
+“You doubt me,” cried Jane, slightly colouring; “indeed, you have
+no reason. He may live in my memory as the most amiable man of my
+acquaintance, but that is all. I have nothing either to hope or fear,
+and nothing to reproach him with. Thank God! I have not _that_ pain. A
+little time, therefore--I shall certainly try to get the better.”
+
+With a stronger voice she soon added, “I have this comfort immediately,
+that it has not been more than an error of fancy on my side, and that it
+has done no harm to anyone but myself.”
+
+“My dear Jane!” exclaimed Elizabeth, “you are too good. Your sweetness
+and disinterestedness are really angelic; I do not know what to say
+to you. I feel as if I had never done you justice, or loved you as you
+deserve.”
+
+Miss Bennet eagerly disclaimed all extraordinary merit, and threw back
+the praise on her sister’s warm affection.
+
+“Nay,” said Elizabeth, “this is not fair. _You_ wish to think all the
+world respectable, and are hurt if I speak ill of anybody. I only want
+to think _you_ perfect, and you set yourself against it. Do not
+be afraid of my running into any excess, of my encroaching on your
+privilege of universal good-will. You need not. There are few people
+whom I really love, and still fewer of whom I think well. The more I see
+of the world, the more am I dissatisfied with it; and every day confirms
+my belief of the inconsistency of all human characters, and of the
+little dependence that can be placed on the appearance of merit or
+sense. I have met with two instances lately, one I will not mention; the
+other is Charlotte’s marriage. It is unaccountable! In every view it is
+unaccountable!”
+
+“My dear Lizzy, do not give way to such feelings as these. They will
+ruin your happiness. You do not make allowance enough for difference
+of situation and temper. Consider Mr. Collins’s respectability, and
+Charlotte’s steady, prudent character. Remember that she is one of a
+large family; that as to fortune, it is a most eligible match; and be
+ready to believe, for everybody’s sake, that she may feel something like
+regard and esteem for our cousin.”
+
+“To oblige you, I would try to believe almost anything, but no one else
+could be benefited by such a belief as this; for were I persuaded that
+Charlotte had any regard for him, I should only think worse of her
+understanding than I now do of her heart. My dear Jane, Mr. Collins is a
+conceited, pompous, narrow-minded, silly man; you know he is, as well as
+I do; and you must feel, as well as I do, that the woman who married him
+cannot have a proper way of thinking. You shall not defend her, though
+it is Charlotte Lucas. You shall not, for the sake of one individual,
+change the meaning of principle and integrity, nor endeavour to persuade
+yourself or me, that selfishness is prudence, and insensibility of
+danger security for happiness.”
+
+“I must think your language too strong in speaking of both,” replied
+Jane; “and I hope you will be convinced of it by seeing them happy
+together. But enough of this. You alluded to something else. You
+mentioned _two_ instances. I cannot misunderstand you, but I entreat
+you, dear Lizzy, not to pain me by thinking _that person_ to blame, and
+saying your opinion of him is sunk. We must not be so ready to fancy
+ourselves intentionally injured. We must not expect a lively young man
+to be always so guarded and circumspect. It is very often nothing but
+our own vanity that deceives us. Women fancy admiration means more than
+it does.”
+
+“And men take care that they should.”
+
+“If it is designedly done, they cannot be justified; but I have no idea
+of there being so much design in the world as some persons imagine.”
+
+“I am far from attributing any part of Mr. Bingley’s conduct to design,”
+ said Elizabeth; “but without scheming to do wrong, or to make others
+unhappy, there may be error, and there may be misery. Thoughtlessness,
+want of attention to other people’s feelings, and want of resolution,
+will do the business.”
+
+“And do you impute it to either of those?”
+
+“Yes; to the last. But if I go on, I shall displease you by saying what
+I think of persons you esteem. Stop me whilst you can.”
+
+“You persist, then, in supposing his sisters influence him?”
+
+“Yes, in conjunction with his friend.”
+
+“I cannot believe it. Why should they try to influence him? They can
+only wish his happiness; and if he is attached to me, no other woman can
+secure it.”
+
+“Your first position is false. They may wish many things besides his
+happiness; they may wish his increase of wealth and consequence; they
+may wish him to marry a girl who has all the importance of money, great
+connections, and pride.”
+
+“Beyond a doubt, they _do_ wish him to choose Miss Darcy,” replied Jane;
+“but this may be from better feelings than you are supposing. They have
+known her much longer than they have known me; no wonder if they love
+her better. But, whatever may be their own wishes, it is very unlikely
+they should have opposed their brother’s. What sister would think
+herself at liberty to do it, unless there were something very
+objectionable? If they believed him attached to me, they would not try
+to part us; if he were so, they could not succeed. By supposing such an
+affection, you make everybody acting unnaturally and wrong, and me most
+unhappy. Do not distress me by the idea. I am not ashamed of having been
+mistaken--or, at least, it is light, it is nothing in comparison of what
+I should feel in thinking ill of him or his sisters. Let me take it in
+the best light, in the light in which it may be understood.”
+
+Elizabeth could not oppose such a wish; and from this time Mr. Bingley’s
+name was scarcely ever mentioned between them.
+
+Mrs. Bennet still continued to wonder and repine at his returning no
+more, and though a day seldom passed in which Elizabeth did not account
+for it clearly, there was little chance of her ever considering it with
+less perplexity. Her daughter endeavoured to convince her of what she
+did not believe herself, that his attentions to Jane had been merely the
+effect of a common and transient liking, which ceased when he saw her
+no more; but though the probability of the statement was admitted at
+the time, she had the same story to repeat every day. Mrs. Bennet’s best
+comfort was that Mr. Bingley must be down again in the summer.
+
+Mr. Bennet treated the matter differently. “So, Lizzy,” said he one day,
+“your sister is crossed in love, I find. I congratulate her. Next to
+being married, a girl likes to be crossed a little in love now and then.
+It is something to think of, and it gives her a sort of distinction
+among her companions. When is your turn to come? You will hardly bear to
+be long outdone by Jane. Now is your time. Here are officers enough in
+Meryton to disappoint all the young ladies in the country. Let Wickham
+be _your_ man. He is a pleasant fellow, and would jilt you creditably.”
+
+“Thank you, sir, but a less agreeable man would satisfy me. We must not
+all expect Jane’s good fortune.”
+
+“True,” said Mr. Bennet, “but it is a comfort to think that whatever of
+that kind may befall you, you have an affectionate mother who will make
+the most of it.”
+
+Mr. Wickham’s society was of material service in dispelling the gloom
+which the late perverse occurrences had thrown on many of the Longbourn
+family. They saw him often, and to his other recommendations was now
+added that of general unreserve. The whole of what Elizabeth had already
+heard, his claims on Mr. Darcy, and all that he had suffered from him,
+was now openly acknowledged and publicly canvassed; and everybody was
+pleased to know how much they had always disliked Mr. Darcy before they
+had known anything of the matter.
+
+Miss Bennet was the only creature who could suppose there might be
+any extenuating circumstances in the case, unknown to the society
+of Hertfordshire; her mild and steady candour always pleaded for
+allowances, and urged the possibility of mistakes--but by everybody else
+Mr. Darcy was condemned as the worst of men.
+
+
+
+Chapter 25
+
+
+After a week spent in professions of love and schemes of felicity,
+Mr. Collins was called from his amiable Charlotte by the arrival of
+Saturday. The pain of separation, however, might be alleviated on his
+side, by preparations for the reception of his bride; as he had reason
+to hope, that shortly after his return into Hertfordshire, the day would
+be fixed that was to make him the happiest of men. He took leave of his
+relations at Longbourn with as much solemnity as before; wished his fair
+cousins health and happiness again, and promised their father another
+letter of thanks.
+
+On the following Monday, Mrs. Bennet had the pleasure of receiving
+her brother and his wife, who came as usual to spend the Christmas
+at Longbourn. Mr. Gardiner was a sensible, gentlemanlike man, greatly
+superior to his sister, as well by nature as education. The Netherfield
+ladies would have had difficulty in believing that a man who lived
+by trade, and within view of his own warehouses, could have been so
+well-bred and agreeable. Mrs. Gardiner, who was several years younger
+than Mrs. Bennet and Mrs. Phillips, was an amiable, intelligent, elegant
+woman, and a great favourite with all her Longbourn nieces. Between the
+two eldest and herself especially, there subsisted a particular regard.
+They had frequently been staying with her in town.
+
+The first part of Mrs. Gardiner’s business on her arrival was to
+distribute her presents and describe the newest fashions. When this was
+done she had a less active part to play. It became her turn to listen.
+Mrs. Bennet had many grievances to relate, and much to complain of. They
+had all been very ill-used since she last saw her sister. Two of her
+girls had been upon the point of marriage, and after all there was
+nothing in it.
+
+“I do not blame Jane,” she continued, “for Jane would have got Mr.
+Bingley if she could. But Lizzy! Oh, sister! It is very hard to think
+that she might have been Mr. Collins’s wife by this time, had it not
+been for her own perverseness. He made her an offer in this very room,
+and she refused him. The consequence of it is, that Lady Lucas will have
+a daughter married before I have, and that the Longbourn estate is just
+as much entailed as ever. The Lucases are very artful people indeed,
+sister. They are all for what they can get. I am sorry to say it of
+them, but so it is. It makes me very nervous and poorly, to be thwarted
+so in my own family, and to have neighbours who think of themselves
+before anybody else. However, your coming just at this time is the
+greatest of comforts, and I am very glad to hear what you tell us, of
+long sleeves.”
+
+Mrs. Gardiner, to whom the chief of this news had been given before,
+in the course of Jane and Elizabeth’s correspondence with her, made her
+sister a slight answer, and, in compassion to her nieces, turned the
+conversation.
+
+When alone with Elizabeth afterwards, she spoke more on the subject. “It
+seems likely to have been a desirable match for Jane,” said she. “I am
+sorry it went off. But these things happen so often! A young man, such
+as you describe Mr. Bingley, so easily falls in love with a pretty girl
+for a few weeks, and when accident separates them, so easily forgets
+her, that these sort of inconsistencies are very frequent.”
+
+“An excellent consolation in its way,” said Elizabeth, “but it will not
+do for _us_. We do not suffer by _accident_. It does not often
+happen that the interference of friends will persuade a young man of
+independent fortune to think no more of a girl whom he was violently in
+love with only a few days before.”
+
+“But that expression of ‘violently in love’ is so hackneyed, so
+doubtful, so indefinite, that it gives me very little idea. It is as
+often applied to feelings which arise from a half-hour’s acquaintance,
+as to a real, strong attachment. Pray, how _violent was_ Mr. Bingley’s
+love?”
+
+“I never saw a more promising inclination; he was growing quite
+inattentive to other people, and wholly engrossed by her. Every time
+they met, it was more decided and remarkable. At his own ball he
+offended two or three young ladies, by not asking them to dance; and I
+spoke to him twice myself, without receiving an answer. Could there be
+finer symptoms? Is not general incivility the very essence of love?”
+
+“Oh, yes!--of that kind of love which I suppose him to have felt. Poor
+Jane! I am sorry for her, because, with her disposition, she may not get
+over it immediately. It had better have happened to _you_, Lizzy; you
+would have laughed yourself out of it sooner. But do you think she
+would be prevailed upon to go back with us? Change of scene might be
+of service--and perhaps a little relief from home may be as useful as
+anything.”
+
+Elizabeth was exceedingly pleased with this proposal, and felt persuaded
+of her sister’s ready acquiescence.
+
+“I hope,” added Mrs. Gardiner, “that no consideration with regard to
+this young man will influence her. We live in so different a part of
+town, all our connections are so different, and, as you well know, we go
+out so little, that it is very improbable that they should meet at all,
+unless he really comes to see her.”
+
+“And _that_ is quite impossible; for he is now in the custody of his
+friend, and Mr. Darcy would no more suffer him to call on Jane in such
+a part of London! My dear aunt, how could you think of it? Mr. Darcy may
+perhaps have _heard_ of such a place as Gracechurch Street, but he
+would hardly think a month’s ablution enough to cleanse him from its
+impurities, were he once to enter it; and depend upon it, Mr. Bingley
+never stirs without him.”
+
+“So much the better. I hope they will not meet at all. But does not Jane
+correspond with his sister? _She_ will not be able to help calling.”
+
+“She will drop the acquaintance entirely.”
+
+But in spite of the certainty in which Elizabeth affected to place this
+point, as well as the still more interesting one of Bingley’s being
+withheld from seeing Jane, she felt a solicitude on the subject which
+convinced her, on examination, that she did not consider it entirely
+hopeless. It was possible, and sometimes she thought it probable, that
+his affection might be reanimated, and the influence of his friends
+successfully combated by the more natural influence of Jane’s
+attractions.
+
+Miss Bennet accepted her aunt’s invitation with pleasure; and the
+Bingleys were no otherwise in her thoughts at the same time, than as she
+hoped by Caroline’s not living in the same house with her brother,
+she might occasionally spend a morning with her, without any danger of
+seeing him.
+
+The Gardiners stayed a week at Longbourn; and what with the Phillipses,
+the Lucases, and the officers, there was not a day without its
+engagement. Mrs. Bennet had so carefully provided for the entertainment
+of her brother and sister, that they did not once sit down to a family
+dinner. When the engagement was for home, some of the officers always
+made part of it--of which officers Mr. Wickham was sure to be one; and
+on these occasions, Mrs. Gardiner, rendered suspicious by Elizabeth’s
+warm commendation, narrowly observed them both. Without supposing them,
+from what she saw, to be very seriously in love, their preference
+of each other was plain enough to make her a little uneasy; and
+she resolved to speak to Elizabeth on the subject before she left
+Hertfordshire, and represent to her the imprudence of encouraging such
+an attachment.
+
+To Mrs. Gardiner, Wickham had one means of affording pleasure,
+unconnected with his general powers. About ten or a dozen years ago,
+before her marriage, she had spent a considerable time in that very
+part of Derbyshire to which he belonged. They had, therefore, many
+acquaintances in common; and though Wickham had been little there since
+the death of Darcy’s father, it was yet in his power to give her fresher
+intelligence of her former friends than she had been in the way of
+procuring.
+
+Mrs. Gardiner had seen Pemberley, and known the late Mr. Darcy by
+character perfectly well. Here consequently was an inexhaustible subject
+of discourse. In comparing her recollection of Pemberley with the minute
+description which Wickham could give, and in bestowing her tribute of
+praise on the character of its late possessor, she was delighting both
+him and herself. On being made acquainted with the present Mr. Darcy’s
+treatment of him, she tried to remember some of that gentleman’s
+reputed disposition when quite a lad which might agree with it, and
+was confident at last that she recollected having heard Mr. Fitzwilliam
+Darcy formerly spoken of as a very proud, ill-natured boy.
+
+
+
+Chapter 26
+
+
+Mrs. Gardiner’s caution to Elizabeth was punctually and kindly given
+on the first favourable opportunity of speaking to her alone; after
+honestly telling her what she thought, she thus went on:
+
+“You are too sensible a girl, Lizzy, to fall in love merely because
+you are warned against it; and, therefore, I am not afraid of speaking
+openly. Seriously, I would have you be on your guard. Do not involve
+yourself or endeavour to involve him in an affection which the want
+of fortune would make so very imprudent. I have nothing to say against
+_him_; he is a most interesting young man; and if he had the fortune he
+ought to have, I should think you could not do better. But as it is, you
+must not let your fancy run away with you. You have sense, and we all
+expect you to use it. Your father would depend on _your_ resolution and
+good conduct, I am sure. You must not disappoint your father.”
+
+“My dear aunt, this is being serious indeed.”
+
+“Yes, and I hope to engage you to be serious likewise.”
+
+“Well, then, you need not be under any alarm. I will take care of
+myself, and of Mr. Wickham too. He shall not be in love with me, if I
+can prevent it.”
+
+“Elizabeth, you are not serious now.”
+
+“I beg your pardon, I will try again. At present I am not in love with
+Mr. Wickham; no, I certainly am not. But he is, beyond all comparison,
+the most agreeable man I ever saw--and if he becomes really attached to
+me--I believe it will be better that he should not. I see the imprudence
+of it. Oh! _that_ abominable Mr. Darcy! My father’s opinion of me does
+me the greatest honour, and I should be miserable to forfeit it. My
+father, however, is partial to Mr. Wickham. In short, my dear aunt, I
+should be very sorry to be the means of making any of you unhappy; but
+since we see every day that where there is affection, young people
+are seldom withheld by immediate want of fortune from entering into
+engagements with each other, how can I promise to be wiser than so many
+of my fellow-creatures if I am tempted, or how am I even to know that it
+would be wisdom to resist? All that I can promise you, therefore, is not
+to be in a hurry. I will not be in a hurry to believe myself his first
+object. When I am in company with him, I will not be wishing. In short,
+I will do my best.”
+
+“Perhaps it will be as well if you discourage his coming here so very
+often. At least, you should not _remind_ your mother of inviting him.”
+
+“As I did the other day,” said Elizabeth with a conscious smile: “very
+true, it will be wise in me to refrain from _that_. But do not imagine
+that he is always here so often. It is on your account that he has been
+so frequently invited this week. You know my mother’s ideas as to the
+necessity of constant company for her friends. But really, and upon my
+honour, I will try to do what I think to be the wisest; and now I hope
+you are satisfied.”
+
+Her aunt assured her that she was, and Elizabeth having thanked her for
+the kindness of her hints, they parted; a wonderful instance of advice
+being given on such a point, without being resented.
+
+Mr. Collins returned into Hertfordshire soon after it had been quitted
+by the Gardiners and Jane; but as he took up his abode with the Lucases,
+his arrival was no great inconvenience to Mrs. Bennet. His marriage was
+now fast approaching, and she was at length so far resigned as to think
+it inevitable, and even repeatedly to say, in an ill-natured tone, that
+she “_wished_ they might be happy.” Thursday was to be the wedding day,
+and on Wednesday Miss Lucas paid her farewell visit; and when she
+rose to take leave, Elizabeth, ashamed of her mother’s ungracious and
+reluctant good wishes, and sincerely affected herself, accompanied her
+out of the room. As they went downstairs together, Charlotte said:
+
+“I shall depend on hearing from you very often, Eliza.”
+
+“_That_ you certainly shall.”
+
+“And I have another favour to ask you. Will you come and see me?”
+
+“We shall often meet, I hope, in Hertfordshire.”
+
+“I am not likely to leave Kent for some time. Promise me, therefore, to
+come to Hunsford.”
+
+Elizabeth could not refuse, though she foresaw little pleasure in the
+visit.
+
+“My father and Maria are coming to me in March,” added Charlotte, “and I
+hope you will consent to be of the party. Indeed, Eliza, you will be as
+welcome as either of them.”
+
+The wedding took place; the bride and bridegroom set off for Kent from
+the church door, and everybody had as much to say, or to hear, on
+the subject as usual. Elizabeth soon heard from her friend; and their
+correspondence was as regular and frequent as it had ever been; that
+it should be equally unreserved was impossible. Elizabeth could never
+address her without feeling that all the comfort of intimacy was over,
+and though determined not to slacken as a correspondent, it was for the
+sake of what had been, rather than what was. Charlotte’s first letters
+were received with a good deal of eagerness; there could not but be
+curiosity to know how she would speak of her new home, how she would
+like Lady Catherine, and how happy she would dare pronounce herself to
+be; though, when the letters were read, Elizabeth felt that Charlotte
+expressed herself on every point exactly as she might have foreseen. She
+wrote cheerfully, seemed surrounded with comforts, and mentioned nothing
+which she could not praise. The house, furniture, neighbourhood, and
+roads, were all to her taste, and Lady Catherine’s behaviour was most
+friendly and obliging. It was Mr. Collins’s picture of Hunsford and
+Rosings rationally softened; and Elizabeth perceived that she must wait
+for her own visit there to know the rest.
+
+Jane had already written a few lines to her sister to announce their
+safe arrival in London; and when she wrote again, Elizabeth hoped it
+would be in her power to say something of the Bingleys.
+
+Her impatience for this second letter was as well rewarded as impatience
+generally is. Jane had been a week in town without either seeing or
+hearing from Caroline. She accounted for it, however, by supposing that
+her last letter to her friend from Longbourn had by some accident been
+lost.
+
+“My aunt,” she continued, “is going to-morrow into that part of the
+town, and I shall take the opportunity of calling in Grosvenor Street.”
+
+She wrote again when the visit was paid, and she had seen Miss Bingley.
+“I did not think Caroline in spirits,” were her words, “but she was very
+glad to see me, and reproached me for giving her no notice of my coming
+to London. I was right, therefore, my last letter had never reached
+her. I inquired after their brother, of course. He was well, but so much
+engaged with Mr. Darcy that they scarcely ever saw him. I found that
+Miss Darcy was expected to dinner. I wish I could see her. My visit was
+not long, as Caroline and Mrs. Hurst were going out. I dare say I shall
+see them soon here.”
+
+Elizabeth shook her head over this letter. It convinced her that
+accident only could discover to Mr. Bingley her sister’s being in town.
+
+Four weeks passed away, and Jane saw nothing of him. She endeavoured to
+persuade herself that she did not regret it; but she could no longer be
+blind to Miss Bingley’s inattention. After waiting at home every morning
+for a fortnight, and inventing every evening a fresh excuse for her, the
+visitor did at last appear; but the shortness of her stay, and yet more,
+the alteration of her manner would allow Jane to deceive herself no
+longer. The letter which she wrote on this occasion to her sister will
+prove what she felt.
+
+“My dearest Lizzy will, I am sure, be incapable of triumphing in her
+better judgement, at my expense, when I confess myself to have been
+entirely deceived in Miss Bingley’s regard for me. But, my dear sister,
+though the event has proved you right, do not think me obstinate if I
+still assert that, considering what her behaviour was, my confidence was
+as natural as your suspicion. I do not at all comprehend her reason for
+wishing to be intimate with me; but if the same circumstances were to
+happen again, I am sure I should be deceived again. Caroline did not
+return my visit till yesterday; and not a note, not a line, did I
+receive in the meantime. When she did come, it was very evident that
+she had no pleasure in it; she made a slight, formal apology, for not
+calling before, said not a word of wishing to see me again, and was
+in every respect so altered a creature, that when she went away I was
+perfectly resolved to continue the acquaintance no longer. I pity,
+though I cannot help blaming her. She was very wrong in singling me out
+as she did; I can safely say that every advance to intimacy began on
+her side. But I pity her, because she must feel that she has been acting
+wrong, and because I am very sure that anxiety for her brother is the
+cause of it. I need not explain myself farther; and though _we_ know
+this anxiety to be quite needless, yet if she feels it, it will easily
+account for her behaviour to me; and so deservedly dear as he is to
+his sister, whatever anxiety she must feel on his behalf is natural and
+amiable. I cannot but wonder, however, at her having any such fears now,
+because, if he had at all cared about me, we must have met, long ago.
+He knows of my being in town, I am certain, from something she said
+herself; and yet it would seem, by her manner of talking, as if she
+wanted to persuade herself that he is really partial to Miss Darcy. I
+cannot understand it. If I were not afraid of judging harshly, I should
+be almost tempted to say that there is a strong appearance of duplicity
+in all this. But I will endeavour to banish every painful thought,
+and think only of what will make me happy--your affection, and the
+invariable kindness of my dear uncle and aunt. Let me hear from you very
+soon. Miss Bingley said something of his never returning to Netherfield
+again, of giving up the house, but not with any certainty. We had better
+not mention it. I am extremely glad that you have such pleasant accounts
+from our friends at Hunsford. Pray go to see them, with Sir William and
+Maria. I am sure you will be very comfortable there.--Yours, etc.”
+
+This letter gave Elizabeth some pain; but her spirits returned as she
+considered that Jane would no longer be duped, by the sister at least.
+All expectation from the brother was now absolutely over. She would not
+even wish for a renewal of his attentions. His character sunk on
+every review of it; and as a punishment for him, as well as a possible
+advantage to Jane, she seriously hoped he might really soon marry Mr.
+Darcy’s sister, as by Wickham’s account, she would make him abundantly
+regret what he had thrown away.
+
+Mrs. Gardiner about this time reminded Elizabeth of her promise
+concerning that gentleman, and required information; and Elizabeth
+had such to send as might rather give contentment to her aunt than to
+herself. His apparent partiality had subsided, his attentions were over,
+he was the admirer of some one else. Elizabeth was watchful enough to
+see it all, but she could see it and write of it without material pain.
+Her heart had been but slightly touched, and her vanity was satisfied
+with believing that _she_ would have been his only choice, had fortune
+permitted it. The sudden acquisition of ten thousand pounds was the most
+remarkable charm of the young lady to whom he was now rendering himself
+agreeable; but Elizabeth, less clear-sighted perhaps in this case than
+in Charlotte’s, did not quarrel with him for his wish of independence.
+Nothing, on the contrary, could be more natural; and while able to
+suppose that it cost him a few struggles to relinquish her, she was
+ready to allow it a wise and desirable measure for both, and could very
+sincerely wish him happy.
+
+All this was acknowledged to Mrs. Gardiner; and after relating the
+circumstances, she thus went on: “I am now convinced, my dear aunt, that
+I have never been much in love; for had I really experienced that pure
+and elevating passion, I should at present detest his very name, and
+wish him all manner of evil. But my feelings are not only cordial
+towards _him_; they are even impartial towards Miss King. I cannot find
+out that I hate her at all, or that I am in the least unwilling to
+think her a very good sort of girl. There can be no love in all this. My
+watchfulness has been effectual; and though I certainly should be a more
+interesting object to all my acquaintances were I distractedly in love
+with him, I cannot say that I regret my comparative insignificance.
+Importance may sometimes be purchased too dearly. Kitty and Lydia take
+his defection much more to heart than I do. They are young in the
+ways of the world, and not yet open to the mortifying conviction that
+handsome young men must have something to live on as well as the plain.”
+
+
+
+Chapter 27
+
+
+With no greater events than these in the Longbourn family, and otherwise
+diversified by little beyond the walks to Meryton, sometimes dirty and
+sometimes cold, did January and February pass away. March was to take
+Elizabeth to Hunsford. She had not at first thought very seriously of
+going thither; but Charlotte, she soon found, was depending on the plan
+and she gradually learned to consider it herself with greater pleasure
+as well as greater certainty. Absence had increased her desire of seeing
+Charlotte again, and weakened her disgust of Mr. Collins. There
+was novelty in the scheme, and as, with such a mother and such
+uncompanionable sisters, home could not be faultless, a little change
+was not unwelcome for its own sake. The journey would moreover give her
+a peep at Jane; and, in short, as the time drew near, she would have
+been very sorry for any delay. Everything, however, went on smoothly,
+and was finally settled according to Charlotte’s first sketch. She was
+to accompany Sir William and his second daughter. The improvement
+of spending a night in London was added in time, and the plan became
+perfect as plan could be.
+
+The only pain was in leaving her father, who would certainly miss her,
+and who, when it came to the point, so little liked her going, that he
+told her to write to him, and almost promised to answer her letter.
+
+The farewell between herself and Mr. Wickham was perfectly friendly; on
+his side even more. His present pursuit could not make him forget that
+Elizabeth had been the first to excite and to deserve his attention, the
+first to listen and to pity, the first to be admired; and in his manner
+of bidding her adieu, wishing her every enjoyment, reminding her of
+what she was to expect in Lady Catherine de Bourgh, and trusting their
+opinion of her--their opinion of everybody--would always coincide, there
+was a solicitude, an interest which she felt must ever attach her to
+him with a most sincere regard; and she parted from him convinced that,
+whether married or single, he must always be her model of the amiable
+and pleasing.
+
+Her fellow-travellers the next day were not of a kind to make her
+think him less agreeable. Sir William Lucas, and his daughter Maria, a
+good-humoured girl, but as empty-headed as himself, had nothing to say
+that could be worth hearing, and were listened to with about as much
+delight as the rattle of the chaise. Elizabeth loved absurdities, but
+she had known Sir William’s too long. He could tell her nothing new of
+the wonders of his presentation and knighthood; and his civilities were
+worn out, like his information.
+
+It was a journey of only twenty-four miles, and they began it so early
+as to be in Gracechurch Street by noon. As they drove to Mr. Gardiner’s
+door, Jane was at a drawing-room window watching their arrival; when
+they entered the passage she was there to welcome them, and Elizabeth,
+looking earnestly in her face, was pleased to see it healthful and
+lovely as ever. On the stairs were a troop of little boys and girls,
+whose eagerness for their cousin’s appearance would not allow them to
+wait in the drawing-room, and whose shyness, as they had not seen
+her for a twelvemonth, prevented their coming lower. All was joy and
+kindness. The day passed most pleasantly away; the morning in bustle and
+shopping, and the evening at one of the theatres.
+
+Elizabeth then contrived to sit by her aunt. Their first object was her
+sister; and she was more grieved than astonished to hear, in reply to
+her minute inquiries, that though Jane always struggled to support her
+spirits, there were periods of dejection. It was reasonable, however,
+to hope that they would not continue long. Mrs. Gardiner gave her the
+particulars also of Miss Bingley’s visit in Gracechurch Street, and
+repeated conversations occurring at different times between Jane and
+herself, which proved that the former had, from her heart, given up the
+acquaintance.
+
+Mrs. Gardiner then rallied her niece on Wickham’s desertion, and
+complimented her on bearing it so well.
+
+“But my dear Elizabeth,” she added, “what sort of girl is Miss King? I
+should be sorry to think our friend mercenary.”
+
+“Pray, my dear aunt, what is the difference in matrimonial affairs,
+between the mercenary and the prudent motive? Where does discretion end,
+and avarice begin? Last Christmas you were afraid of his marrying me,
+because it would be imprudent; and now, because he is trying to get
+a girl with only ten thousand pounds, you want to find out that he is
+mercenary.”
+
+“If you will only tell me what sort of girl Miss King is, I shall know
+what to think.”
+
+“She is a very good kind of girl, I believe. I know no harm of her.”
+
+“But he paid her not the smallest attention till her grandfather’s death
+made her mistress of this fortune.”
+
+“No--why should he? If it were not allowable for him to gain _my_
+affections because I had no money, what occasion could there be for
+making love to a girl whom he did not care about, and who was equally
+poor?”
+
+“But there seems an indelicacy in directing his attentions towards her
+so soon after this event.”
+
+“A man in distressed circumstances has not time for all those elegant
+decorums which other people may observe. If _she_ does not object to it,
+why should _we_?”
+
+“_Her_ not objecting does not justify _him_. It only shows her being
+deficient in something herself--sense or feeling.”
+
+“Well,” cried Elizabeth, “have it as you choose. _He_ shall be
+mercenary, and _she_ shall be foolish.”
+
+“No, Lizzy, that is what I do _not_ choose. I should be sorry, you know,
+to think ill of a young man who has lived so long in Derbyshire.”
+
+“Oh! if that is all, I have a very poor opinion of young men who live in
+Derbyshire; and their intimate friends who live in Hertfordshire are not
+much better. I am sick of them all. Thank Heaven! I am going to-morrow
+where I shall find a man who has not one agreeable quality, who has
+neither manner nor sense to recommend him. Stupid men are the only ones
+worth knowing, after all.”
+
+“Take care, Lizzy; that speech savours strongly of disappointment.”
+
+Before they were separated by the conclusion of the play, she had the
+unexpected happiness of an invitation to accompany her uncle and aunt in
+a tour of pleasure which they proposed taking in the summer.
+
+“We have not determined how far it shall carry us,” said Mrs. Gardiner,
+“but, perhaps, to the Lakes.”
+
+No scheme could have been more agreeable to Elizabeth, and her
+acceptance of the invitation was most ready and grateful. “Oh, my dear,
+dear aunt,” she rapturously cried, “what delight! what felicity! You
+give me fresh life and vigour. Adieu to disappointment and spleen. What
+are young men to rocks and mountains? Oh! what hours of transport
+we shall spend! And when we _do_ return, it shall not be like other
+travellers, without being able to give one accurate idea of anything. We
+_will_ know where we have gone--we _will_ recollect what we have seen.
+Lakes, mountains, and rivers shall not be jumbled together in our
+imaginations; nor when we attempt to describe any particular scene,
+will we begin quarreling about its relative situation. Let _our_
+first effusions be less insupportable than those of the generality of
+travellers.”
+
+
+
+Chapter 28
+
+
+Every object in the next day’s journey was new and interesting to
+Elizabeth; and her spirits were in a state of enjoyment; for she had
+seen her sister looking so well as to banish all fear for her health,
+and the prospect of her northern tour was a constant source of delight.
+
+When they left the high road for the lane to Hunsford, every eye was in
+search of the Parsonage, and every turning expected to bring it in view.
+The palings of Rosings Park was their boundary on one side. Elizabeth
+smiled at the recollection of all that she had heard of its inhabitants.
+
+At length the Parsonage was discernible. The garden sloping to the
+road, the house standing in it, the green pales, and the laurel hedge,
+everything declared they were arriving. Mr. Collins and Charlotte
+appeared at the door, and the carriage stopped at the small gate which
+led by a short gravel walk to the house, amidst the nods and smiles of
+the whole party. In a moment they were all out of the chaise, rejoicing
+at the sight of each other. Mrs. Collins welcomed her friend with the
+liveliest pleasure, and Elizabeth was more and more satisfied with
+coming when she found herself so affectionately received. She saw
+instantly that her cousin’s manners were not altered by his marriage;
+his formal civility was just what it had been, and he detained her some
+minutes at the gate to hear and satisfy his inquiries after all her
+family. They were then, with no other delay than his pointing out the
+neatness of the entrance, taken into the house; and as soon as they
+were in the parlour, he welcomed them a second time, with ostentatious
+formality to his humble abode, and punctually repeated all his wife’s
+offers of refreshment.
+
+Elizabeth was prepared to see him in his glory; and she could not help
+in fancying that in displaying the good proportion of the room, its
+aspect and its furniture, he addressed himself particularly to her,
+as if wishing to make her feel what she had lost in refusing him. But
+though everything seemed neat and comfortable, she was not able to
+gratify him by any sigh of repentance, and rather looked with wonder at
+her friend that she could have so cheerful an air with such a companion.
+When Mr. Collins said anything of which his wife might reasonably be
+ashamed, which certainly was not unseldom, she involuntarily turned her
+eye on Charlotte. Once or twice she could discern a faint blush; but
+in general Charlotte wisely did not hear. After sitting long enough to
+admire every article of furniture in the room, from the sideboard to
+the fender, to give an account of their journey, and of all that had
+happened in London, Mr. Collins invited them to take a stroll in the
+garden, which was large and well laid out, and to the cultivation of
+which he attended himself. To work in this garden was one of his most
+respectable pleasures; and Elizabeth admired the command of countenance
+with which Charlotte talked of the healthfulness of the exercise, and
+owned she encouraged it as much as possible. Here, leading the way
+through every walk and cross walk, and scarcely allowing them an
+interval to utter the praises he asked for, every view was pointed out
+with a minuteness which left beauty entirely behind. He could number the
+fields in every direction, and could tell how many trees there were in
+the most distant clump. But of all the views which his garden, or which
+the country or kingdom could boast, none were to be compared with the
+prospect of Rosings, afforded by an opening in the trees that bordered
+the park nearly opposite the front of his house. It was a handsome
+modern building, well situated on rising ground.
+
+From his garden, Mr. Collins would have led them round his two meadows;
+but the ladies, not having shoes to encounter the remains of a white
+frost, turned back; and while Sir William accompanied him, Charlotte
+took her sister and friend over the house, extremely well pleased,
+probably, to have the opportunity of showing it without her husband’s
+help. It was rather small, but well built and convenient; and everything
+was fitted up and arranged with a neatness and consistency of which
+Elizabeth gave Charlotte all the credit. When Mr. Collins could be
+forgotten, there was really an air of great comfort throughout, and by
+Charlotte’s evident enjoyment of it, Elizabeth supposed he must be often
+forgotten.
+
+She had already learnt that Lady Catherine was still in the country. It
+was spoken of again while they were at dinner, when Mr. Collins joining
+in, observed:
+
+“Yes, Miss Elizabeth, you will have the honour of seeing Lady Catherine
+de Bourgh on the ensuing Sunday at church, and I need not say you will
+be delighted with her. She is all affability and condescension, and I
+doubt not but you will be honoured with some portion of her notice
+when service is over. I have scarcely any hesitation in saying she
+will include you and my sister Maria in every invitation with which she
+honours us during your stay here. Her behaviour to my dear Charlotte is
+charming. We dine at Rosings twice every week, and are never allowed
+to walk home. Her ladyship’s carriage is regularly ordered for us. I
+_should_ say, one of her ladyship’s carriages, for she has several.”
+
+“Lady Catherine is a very respectable, sensible woman indeed,” added
+Charlotte, “and a most attentive neighbour.”
+
+“Very true, my dear, that is exactly what I say. She is the sort of
+woman whom one cannot regard with too much deference.”
+
+The evening was spent chiefly in talking over Hertfordshire news,
+and telling again what had already been written; and when it closed,
+Elizabeth, in the solitude of her chamber, had to meditate upon
+Charlotte’s degree of contentment, to understand her address in guiding,
+and composure in bearing with, her husband, and to acknowledge that it
+was all done very well. She had also to anticipate how her visit
+would pass, the quiet tenor of their usual employments, the vexatious
+interruptions of Mr. Collins, and the gaieties of their intercourse with
+Rosings. A lively imagination soon settled it all.
+
+About the middle of the next day, as she was in her room getting ready
+for a walk, a sudden noise below seemed to speak the whole house in
+confusion; and, after listening a moment, she heard somebody running
+up stairs in a violent hurry, and calling loudly after her. She opened
+the door and met Maria in the landing place, who, breathless with
+agitation, cried out--
+
+“Oh, my dear Eliza! pray make haste and come into the dining-room, for
+there is such a sight to be seen! I will not tell you what it is. Make
+haste, and come down this moment.”
+
+Elizabeth asked questions in vain; Maria would tell her nothing more,
+and down they ran into the dining-room, which fronted the lane, in
+quest of this wonder; It was two ladies stopping in a low phaeton at the
+garden gate.
+
+“And is this all?” cried Elizabeth. “I expected at least that the pigs
+were got into the garden, and here is nothing but Lady Catherine and her
+daughter.”
+
+“La! my dear,” said Maria, quite shocked at the mistake, “it is not
+Lady Catherine. The old lady is Mrs. Jenkinson, who lives with them;
+the other is Miss de Bourgh. Only look at her. She is quite a little
+creature. Who would have thought that she could be so thin and small?”
+
+“She is abominably rude to keep Charlotte out of doors in all this wind.
+Why does she not come in?”
+
+“Oh, Charlotte says she hardly ever does. It is the greatest of favours
+when Miss de Bourgh comes in.”
+
+“I like her appearance,” said Elizabeth, struck with other ideas. “She
+looks sickly and cross. Yes, she will do for him very well. She will
+make him a very proper wife.”
+
+Mr. Collins and Charlotte were both standing at the gate in conversation
+with the ladies; and Sir William, to Elizabeth’s high diversion, was
+stationed in the doorway, in earnest contemplation of the greatness
+before him, and constantly bowing whenever Miss de Bourgh looked that
+way.
+
+At length there was nothing more to be said; the ladies drove on, and
+the others returned into the house. Mr. Collins no sooner saw the two
+girls than he began to congratulate them on their good fortune, which
+Charlotte explained by letting them know that the whole party was asked
+to dine at Rosings the next day.
+
+
+
+Chapter 29
+
+
+Mr. Collins’s triumph, in consequence of this invitation, was complete.
+The power of displaying the grandeur of his patroness to his wondering
+visitors, and of letting them see her civility towards himself and his
+wife, was exactly what he had wished for; and that an opportunity
+of doing it should be given so soon, was such an instance of Lady
+Catherine’s condescension, as he knew not how to admire enough.
+
+“I confess,” said he, “that I should not have been at all surprised by
+her ladyship’s asking us on Sunday to drink tea and spend the evening at
+Rosings. I rather expected, from my knowledge of her affability, that it
+would happen. But who could have foreseen such an attention as this? Who
+could have imagined that we should receive an invitation to dine there
+(an invitation, moreover, including the whole party) so immediately
+after your arrival!”
+
+“I am the less surprised at what has happened,” replied Sir William,
+“from that knowledge of what the manners of the great really are, which
+my situation in life has allowed me to acquire. About the court, such
+instances of elegant breeding are not uncommon.”
+
+Scarcely anything was talked of the whole day or next morning but their
+visit to Rosings. Mr. Collins was carefully instructing them in what
+they were to expect, that the sight of such rooms, so many servants, and
+so splendid a dinner, might not wholly overpower them.
+
+When the ladies were separating for the toilette, he said to Elizabeth--
+
+“Do not make yourself uneasy, my dear cousin, about your apparel. Lady
+Catherine is far from requiring that elegance of dress in us which
+becomes herself and her daughter. I would advise you merely to put on
+whatever of your clothes is superior to the rest--there is no occasion
+for anything more. Lady Catherine will not think the worse of you
+for being simply dressed. She likes to have the distinction of rank
+preserved.”
+
+While they were dressing, he came two or three times to their different
+doors, to recommend their being quick, as Lady Catherine very much
+objected to be kept waiting for her dinner. Such formidable accounts of
+her ladyship, and her manner of living, quite frightened Maria Lucas
+who had been little used to company, and she looked forward to her
+introduction at Rosings with as much apprehension as her father had done
+to his presentation at St. James’s.
+
+As the weather was fine, they had a pleasant walk of about half a
+mile across the park. Every park has its beauty and its prospects; and
+Elizabeth saw much to be pleased with, though she could not be in such
+raptures as Mr. Collins expected the scene to inspire, and was but
+slightly affected by his enumeration of the windows in front of the
+house, and his relation of what the glazing altogether had originally
+cost Sir Lewis de Bourgh.
+
+When they ascended the steps to the hall, Maria’s alarm was every
+moment increasing, and even Sir William did not look perfectly calm.
+Elizabeth’s courage did not fail her. She had heard nothing of Lady
+Catherine that spoke her awful from any extraordinary talents or
+miraculous virtue, and the mere stateliness of money or rank she thought
+she could witness without trepidation.
+
+From the entrance-hall, of which Mr. Collins pointed out, with a
+rapturous air, the fine proportion and the finished ornaments, they
+followed the servants through an ante-chamber, to the room where Lady
+Catherine, her daughter, and Mrs. Jenkinson were sitting. Her ladyship,
+with great condescension, arose to receive them; and as Mrs. Collins had
+settled it with her husband that the office of introduction should
+be hers, it was performed in a proper manner, without any of those
+apologies and thanks which he would have thought necessary.
+
+In spite of having been at St. James’s, Sir William was so completely
+awed by the grandeur surrounding him, that he had but just courage
+enough to make a very low bow, and take his seat without saying a word;
+and his daughter, frightened almost out of her senses, sat on the edge
+of her chair, not knowing which way to look. Elizabeth found herself
+quite equal to the scene, and could observe the three ladies before her
+composedly. Lady Catherine was a tall, large woman, with strongly-marked
+features, which might once have been handsome. Her air was not
+conciliating, nor was her manner of receiving them such as to make her
+visitors forget their inferior rank. She was not rendered formidable by
+silence; but whatever she said was spoken in so authoritative a tone,
+as marked her self-importance, and brought Mr. Wickham immediately to
+Elizabeth’s mind; and from the observation of the day altogether, she
+believed Lady Catherine to be exactly what he represented.
+
+When, after examining the mother, in whose countenance and deportment
+she soon found some resemblance of Mr. Darcy, she turned her eyes on the
+daughter, she could almost have joined in Maria’s astonishment at her
+being so thin and so small. There was neither in figure nor face any
+likeness between the ladies. Miss de Bourgh was pale and sickly; her
+features, though not plain, were insignificant; and she spoke very
+little, except in a low voice, to Mrs. Jenkinson, in whose appearance
+there was nothing remarkable, and who was entirely engaged in listening
+to what she said, and placing a screen in the proper direction before
+her eyes.
+
+After sitting a few minutes, they were all sent to one of the windows to
+admire the view, Mr. Collins attending them to point out its beauties,
+and Lady Catherine kindly informing them that it was much better worth
+looking at in the summer.
+
+The dinner was exceedingly handsome, and there were all the servants and
+all the articles of plate which Mr. Collins had promised; and, as he had
+likewise foretold, he took his seat at the bottom of the table, by her
+ladyship’s desire, and looked as if he felt that life could furnish
+nothing greater. He carved, and ate, and praised with delighted
+alacrity; and every dish was commended, first by him and then by Sir
+William, who was now enough recovered to echo whatever his son-in-law
+said, in a manner which Elizabeth wondered Lady Catherine could bear.
+But Lady Catherine seemed gratified by their excessive admiration, and
+gave most gracious smiles, especially when any dish on the table proved
+a novelty to them. The party did not supply much conversation. Elizabeth
+was ready to speak whenever there was an opening, but she was seated
+between Charlotte and Miss de Bourgh--the former of whom was engaged in
+listening to Lady Catherine, and the latter said not a word to her all
+dinner-time. Mrs. Jenkinson was chiefly employed in watching how little
+Miss de Bourgh ate, pressing her to try some other dish, and fearing
+she was indisposed. Maria thought speaking out of the question, and the
+gentlemen did nothing but eat and admire.
+
+When the ladies returned to the drawing-room, there was little to
+be done but to hear Lady Catherine talk, which she did without any
+intermission till coffee came in, delivering her opinion on every
+subject in so decisive a manner, as proved that she was not used to
+have her judgement controverted. She inquired into Charlotte’s domestic
+concerns familiarly and minutely, gave her a great deal of advice as
+to the management of them all; told her how everything ought to be
+regulated in so small a family as hers, and instructed her as to the
+care of her cows and her poultry. Elizabeth found that nothing was
+beneath this great lady’s attention, which could furnish her with an
+occasion of dictating to others. In the intervals of her discourse
+with Mrs. Collins, she addressed a variety of questions to Maria and
+Elizabeth, but especially to the latter, of whose connections she knew
+the least, and who she observed to Mrs. Collins was a very genteel,
+pretty kind of girl. She asked her, at different times, how many sisters
+she had, whether they were older or younger than herself, whether any of
+them were likely to be married, whether they were handsome, where they
+had been educated, what carriage her father kept, and what had been
+her mother’s maiden name? Elizabeth felt all the impertinence of
+her questions but answered them very composedly. Lady Catherine then
+observed,
+
+“Your father’s estate is entailed on Mr. Collins, I think. For your
+sake,” turning to Charlotte, “I am glad of it; but otherwise I see no
+occasion for entailing estates from the female line. It was not thought
+necessary in Sir Lewis de Bourgh’s family. Do you play and sing, Miss
+Bennet?”
+
+“A little.”
+
+“Oh! then--some time or other we shall be happy to hear you. Our
+instrument is a capital one, probably superior to----You shall try it
+some day. Do your sisters play and sing?”
+
+“One of them does.”
+
+“Why did not you all learn? You ought all to have learned. The Miss
+Webbs all play, and their father has not so good an income as yours. Do
+you draw?”
+
+“No, not at all.”
+
+“What, none of you?”
+
+“Not one.”
+
+“That is very strange. But I suppose you had no opportunity. Your mother
+should have taken you to town every spring for the benefit of masters.”
+
+“My mother would have had no objection, but my father hates London.”
+
+“Has your governess left you?”
+
+“We never had any governess.”
+
+“No governess! How was that possible? Five daughters brought up at home
+without a governess! I never heard of such a thing. Your mother must
+have been quite a slave to your education.”
+
+Elizabeth could hardly help smiling as she assured her that had not been
+the case.
+
+“Then, who taught you? who attended to you? Without a governess, you
+must have been neglected.”
+
+“Compared with some families, I believe we were; but such of us as
+wished to learn never wanted the means. We were always encouraged to
+read, and had all the masters that were necessary. Those who chose to be
+idle, certainly might.”
+
+“Aye, no doubt; but that is what a governess will prevent, and if I had
+known your mother, I should have advised her most strenuously to engage
+one. I always say that nothing is to be done in education without steady
+and regular instruction, and nobody but a governess can give it. It is
+wonderful how many families I have been the means of supplying in that
+way. I am always glad to get a young person well placed out. Four nieces
+of Mrs. Jenkinson are most delightfully situated through my means; and
+it was but the other day that I recommended another young person,
+who was merely accidentally mentioned to me, and the family are quite
+delighted with her. Mrs. Collins, did I tell you of Lady Metcalf’s
+calling yesterday to thank me? She finds Miss Pope a treasure. ‘Lady
+Catherine,’ said she, ‘you have given me a treasure.’ Are any of your
+younger sisters out, Miss Bennet?”
+
+“Yes, ma’am, all.”
+
+“All! What, all five out at once? Very odd! And you only the second. The
+younger ones out before the elder ones are married! Your younger sisters
+must be very young?”
+
+“Yes, my youngest is not sixteen. Perhaps _she_ is full young to be
+much in company. But really, ma’am, I think it would be very hard upon
+younger sisters, that they should not have their share of society and
+amusement, because the elder may not have the means or inclination to
+marry early. The last-born has as good a right to the pleasures of youth
+as the first. And to be kept back on _such_ a motive! I think it would
+not be very likely to promote sisterly affection or delicacy of mind.”
+
+“Upon my word,” said her ladyship, “you give your opinion very decidedly
+for so young a person. Pray, what is your age?”
+
+“With three younger sisters grown up,” replied Elizabeth, smiling, “your
+ladyship can hardly expect me to own it.”
+
+Lady Catherine seemed quite astonished at not receiving a direct answer;
+and Elizabeth suspected herself to be the first creature who had ever
+dared to trifle with so much dignified impertinence.
+
+“You cannot be more than twenty, I am sure, therefore you need not
+conceal your age.”
+
+“I am not one-and-twenty.”
+
+When the gentlemen had joined them, and tea was over, the card-tables
+were placed. Lady Catherine, Sir William, and Mr. and Mrs. Collins sat
+down to quadrille; and as Miss de Bourgh chose to play at cassino, the
+two girls had the honour of assisting Mrs. Jenkinson to make up her
+party. Their table was superlatively stupid. Scarcely a syllable was
+uttered that did not relate to the game, except when Mrs. Jenkinson
+expressed her fears of Miss de Bourgh’s being too hot or too cold, or
+having too much or too little light. A great deal more passed at the
+other table. Lady Catherine was generally speaking--stating the mistakes
+of the three others, or relating some anecdote of herself. Mr. Collins
+was employed in agreeing to everything her ladyship said, thanking her
+for every fish he won, and apologising if he thought he won too many.
+Sir William did not say much. He was storing his memory with anecdotes
+and noble names.
+
+When Lady Catherine and her daughter had played as long as they chose,
+the tables were broken up, the carriage was offered to Mrs. Collins,
+gratefully accepted and immediately ordered. The party then gathered
+round the fire to hear Lady Catherine determine what weather they were
+to have on the morrow. From these instructions they were summoned by
+the arrival of the coach; and with many speeches of thankfulness on Mr.
+Collins’s side and as many bows on Sir William’s they departed. As soon
+as they had driven from the door, Elizabeth was called on by her cousin
+to give her opinion of all that she had seen at Rosings, which, for
+Charlotte’s sake, she made more favourable than it really was. But her
+commendation, though costing her some trouble, could by no means satisfy
+Mr. Collins, and he was very soon obliged to take her ladyship’s praise
+into his own hands.
+
+
+
+Chapter 30
+
+
+Sir William stayed only a week at Hunsford, but his visit was long
+enough to convince him of his daughter’s being most comfortably settled,
+and of her possessing such a husband and such a neighbour as were not
+often met with. While Sir William was with them, Mr. Collins devoted his
+morning to driving him out in his gig, and showing him the country; but
+when he went away, the whole family returned to their usual employments,
+and Elizabeth was thankful to find that they did not see more of her
+cousin by the alteration, for the chief of the time between breakfast
+and dinner was now passed by him either at work in the garden or in
+reading and writing, and looking out of the window in his own book-room,
+which fronted the road. The room in which the ladies sat was backwards.
+Elizabeth had at first rather wondered that Charlotte should not prefer
+the dining-parlour for common use; it was a better sized room, and had a
+more pleasant aspect; but she soon saw that her friend had an excellent
+reason for what she did, for Mr. Collins would undoubtedly have been
+much less in his own apartment, had they sat in one equally lively; and
+she gave Charlotte credit for the arrangement.
+
+From the drawing-room they could distinguish nothing in the lane, and
+were indebted to Mr. Collins for the knowledge of what carriages went
+along, and how often especially Miss de Bourgh drove by in her phaeton,
+which he never failed coming to inform them of, though it happened
+almost every day. She not unfrequently stopped at the Parsonage, and
+had a few minutes’ conversation with Charlotte, but was scarcely ever
+prevailed upon to get out.
+
+Very few days passed in which Mr. Collins did not walk to Rosings, and
+not many in which his wife did not think it necessary to go likewise;
+and till Elizabeth recollected that there might be other family livings
+to be disposed of, she could not understand the sacrifice of so many
+hours. Now and then they were honoured with a call from her ladyship,
+and nothing escaped her observation that was passing in the room during
+these visits. She examined into their employments, looked at their work,
+and advised them to do it differently; found fault with the arrangement
+of the furniture; or detected the housemaid in negligence; and if she
+accepted any refreshment, seemed to do it only for the sake of finding
+out that Mrs. Collins’s joints of meat were too large for her family.
+
+Elizabeth soon perceived, that though this great lady was not in
+commission of the peace of the county, she was a most active magistrate
+in her own parish, the minutest concerns of which were carried to her
+by Mr. Collins; and whenever any of the cottagers were disposed to
+be quarrelsome, discontented, or too poor, she sallied forth into the
+village to settle their differences, silence their complaints, and scold
+them into harmony and plenty.
+
+The entertainment of dining at Rosings was repeated about twice a week;
+and, allowing for the loss of Sir William, and there being only one
+card-table in the evening, every such entertainment was the counterpart
+of the first. Their other engagements were few, as the style of living
+in the neighbourhood in general was beyond Mr. Collins’s reach. This,
+however, was no evil to Elizabeth, and upon the whole she spent her time
+comfortably enough; there were half-hours of pleasant conversation with
+Charlotte, and the weather was so fine for the time of year that she had
+often great enjoyment out of doors. Her favourite walk, and where she
+frequently went while the others were calling on Lady Catherine, was
+along the open grove which edged that side of the park, where there was
+a nice sheltered path, which no one seemed to value but herself, and
+where she felt beyond the reach of Lady Catherine’s curiosity.
+
+In this quiet way, the first fortnight of her visit soon passed away.
+Easter was approaching, and the week preceding it was to bring an
+addition to the family at Rosings, which in so small a circle must be
+important. Elizabeth had heard soon after her arrival that Mr. Darcy was
+expected there in the course of a few weeks, and though there were not
+many of her acquaintances whom she did not prefer, his coming would
+furnish one comparatively new to look at in their Rosings parties, and
+she might be amused in seeing how hopeless Miss Bingley’s designs on him
+were, by his behaviour to his cousin, for whom he was evidently
+destined by Lady Catherine, who talked of his coming with the greatest
+satisfaction, spoke of him in terms of the highest admiration, and
+seemed almost angry to find that he had already been frequently seen by
+Miss Lucas and herself.
+
+His arrival was soon known at the Parsonage; for Mr. Collins was walking
+the whole morning within view of the lodges opening into Hunsford Lane,
+in order to have the earliest assurance of it, and after making his
+bow as the carriage turned into the Park, hurried home with the great
+intelligence. On the following morning he hastened to Rosings to pay his
+respects. There were two nephews of Lady Catherine to require them, for
+Mr. Darcy had brought with him a Colonel Fitzwilliam, the younger son of
+his uncle Lord ----, and, to the great surprise of all the party, when
+Mr. Collins returned, the gentlemen accompanied him. Charlotte had seen
+them from her husband’s room, crossing the road, and immediately running
+into the other, told the girls what an honour they might expect, adding:
+
+“I may thank you, Eliza, for this piece of civility. Mr. Darcy would
+never have come so soon to wait upon me.”
+
+Elizabeth had scarcely time to disclaim all right to the compliment,
+before their approach was announced by the door-bell, and shortly
+afterwards the three gentlemen entered the room. Colonel Fitzwilliam,
+who led the way, was about thirty, not handsome, but in person and
+address most truly the gentleman. Mr. Darcy looked just as he had been
+used to look in Hertfordshire--paid his compliments, with his usual
+reserve, to Mrs. Collins, and whatever might be his feelings toward her
+friend, met her with every appearance of composure. Elizabeth merely
+curtseyed to him without saying a word.
+
+Colonel Fitzwilliam entered into conversation directly with the
+readiness and ease of a well-bred man, and talked very pleasantly; but
+his cousin, after having addressed a slight observation on the house and
+garden to Mrs. Collins, sat for some time without speaking to anybody.
+At length, however, his civility was so far awakened as to inquire of
+Elizabeth after the health of her family. She answered him in the usual
+way, and after a moment’s pause, added:
+
+“My eldest sister has been in town these three months. Have you never
+happened to see her there?”
+
+She was perfectly sensible that he never had; but she wished to see
+whether he would betray any consciousness of what had passed between
+the Bingleys and Jane, and she thought he looked a little confused as he
+answered that he had never been so fortunate as to meet Miss Bennet. The
+subject was pursued no farther, and the gentlemen soon afterwards went
+away.
+
+
+
+Chapter 31
+
+
+Colonel Fitzwilliam’s manners were very much admired at the Parsonage,
+and the ladies all felt that he must add considerably to the pleasures
+of their engagements at Rosings. It was some days, however, before they
+received any invitation thither--for while there were visitors in the
+house, they could not be necessary; and it was not till Easter-day,
+almost a week after the gentlemen’s arrival, that they were honoured by
+such an attention, and then they were merely asked on leaving church to
+come there in the evening. For the last week they had seen very little
+of Lady Catherine or her daughter. Colonel Fitzwilliam had called at the
+Parsonage more than once during the time, but Mr. Darcy they had seen
+only at church.
+
+The invitation was accepted of course, and at a proper hour they joined
+the party in Lady Catherine’s drawing-room. Her ladyship received
+them civilly, but it was plain that their company was by no means so
+acceptable as when she could get nobody else; and she was, in fact,
+almost engrossed by her nephews, speaking to them, especially to Darcy,
+much more than to any other person in the room.
+
+Colonel Fitzwilliam seemed really glad to see them; anything was a
+welcome relief to him at Rosings; and Mrs. Collins’s pretty friend had
+moreover caught his fancy very much. He now seated himself by her, and
+talked so agreeably of Kent and Hertfordshire, of travelling and staying
+at home, of new books and music, that Elizabeth had never been half so
+well entertained in that room before; and they conversed with so much
+spirit and flow, as to draw the attention of Lady Catherine herself,
+as well as of Mr. Darcy. _His_ eyes had been soon and repeatedly turned
+towards them with a look of curiosity; and that her ladyship, after a
+while, shared the feeling, was more openly acknowledged, for she did not
+scruple to call out:
+
+“What is that you are saying, Fitzwilliam? What is it you are talking
+of? What are you telling Miss Bennet? Let me hear what it is.”
+
+“We are speaking of music, madam,” said he, when no longer able to avoid
+a reply.
+
+“Of music! Then pray speak aloud. It is of all subjects my delight. I
+must have my share in the conversation if you are speaking of music.
+There are few people in England, I suppose, who have more true enjoyment
+of music than myself, or a better natural taste. If I had ever learnt,
+I should have been a great proficient. And so would Anne, if her health
+had allowed her to apply. I am confident that she would have performed
+delightfully. How does Georgiana get on, Darcy?”
+
+Mr. Darcy spoke with affectionate praise of his sister’s proficiency.
+
+“I am very glad to hear such a good account of her,” said Lady
+Catherine; “and pray tell her from me, that she cannot expect to excel
+if she does not practice a good deal.”
+
+“I assure you, madam,” he replied, “that she does not need such advice.
+She practises very constantly.”
+
+“So much the better. It cannot be done too much; and when I next write
+to her, I shall charge her not to neglect it on any account. I often
+tell young ladies that no excellence in music is to be acquired without
+constant practice. I have told Miss Bennet several times, that she
+will never play really well unless she practises more; and though Mrs.
+Collins has no instrument, she is very welcome, as I have often told
+her, to come to Rosings every day, and play on the pianoforte in Mrs.
+Jenkinson’s room. She would be in nobody’s way, you know, in that part
+of the house.”
+
+Mr. Darcy looked a little ashamed of his aunt’s ill-breeding, and made
+no answer.
+
+When coffee was over, Colonel Fitzwilliam reminded Elizabeth of having
+promised to play to him; and she sat down directly to the instrument. He
+drew a chair near her. Lady Catherine listened to half a song, and then
+talked, as before, to her other nephew; till the latter walked away
+from her, and making with his usual deliberation towards the pianoforte
+stationed himself so as to command a full view of the fair performer’s
+countenance. Elizabeth saw what he was doing, and at the first
+convenient pause, turned to him with an arch smile, and said:
+
+“You mean to frighten me, Mr. Darcy, by coming in all this state to hear
+me? I will not be alarmed though your sister _does_ play so well. There
+is a stubbornness about me that never can bear to be frightened at the
+will of others. My courage always rises at every attempt to intimidate
+me.”
+
+“I shall not say you are mistaken,” he replied, “because you could not
+really believe me to entertain any design of alarming you; and I have
+had the pleasure of your acquaintance long enough to know that you find
+great enjoyment in occasionally professing opinions which in fact are
+not your own.”
+
+Elizabeth laughed heartily at this picture of herself, and said to
+Colonel Fitzwilliam, “Your cousin will give you a very pretty notion of
+me, and teach you not to believe a word I say. I am particularly unlucky
+in meeting with a person so able to expose my real character, in a part
+of the world where I had hoped to pass myself off with some degree of
+credit. Indeed, Mr. Darcy, it is very ungenerous in you to mention all
+that you knew to my disadvantage in Hertfordshire--and, give me leave to
+say, very impolitic too--for it is provoking me to retaliate, and such
+things may come out as will shock your relations to hear.”
+
+“I am not afraid of you,” said he, smilingly.
+
+“Pray let me hear what you have to accuse him of,” cried Colonel
+Fitzwilliam. “I should like to know how he behaves among strangers.”
+
+“You shall hear then--but prepare yourself for something very dreadful.
+The first time of my ever seeing him in Hertfordshire, you must know,
+was at a ball--and at this ball, what do you think he did? He danced
+only four dances, though gentlemen were scarce; and, to my certain
+knowledge, more than one young lady was sitting down in want of a
+partner. Mr. Darcy, you cannot deny the fact.”
+
+“I had not at that time the honour of knowing any lady in the assembly
+beyond my own party.”
+
+“True; and nobody can ever be introduced in a ball-room. Well, Colonel
+Fitzwilliam, what do I play next? My fingers wait your orders.”
+
+“Perhaps,” said Darcy, “I should have judged better, had I sought an
+introduction; but I am ill-qualified to recommend myself to strangers.”
+
+“Shall we ask your cousin the reason of this?” said Elizabeth, still
+addressing Colonel Fitzwilliam. “Shall we ask him why a man of sense and
+education, and who has lived in the world, is ill qualified to recommend
+himself to strangers?”
+
+“I can answer your question,” said Fitzwilliam, “without applying to
+him. It is because he will not give himself the trouble.”
+
+“I certainly have not the talent which some people possess,” said Darcy,
+“of conversing easily with those I have never seen before. I cannot
+catch their tone of conversation, or appear interested in their
+concerns, as I often see done.”
+
+“My fingers,” said Elizabeth, “do not move over this instrument in the
+masterly manner which I see so many women’s do. They have not the same
+force or rapidity, and do not produce the same expression. But then I
+have always supposed it to be my own fault--because I will not take the
+trouble of practising. It is not that I do not believe _my_ fingers as
+capable as any other woman’s of superior execution.”
+
+Darcy smiled and said, “You are perfectly right. You have employed your
+time much better. No one admitted to the privilege of hearing you can
+think anything wanting. We neither of us perform to strangers.”
+
+Here they were interrupted by Lady Catherine, who called out to know
+what they were talking of. Elizabeth immediately began playing again.
+Lady Catherine approached, and, after listening for a few minutes, said
+to Darcy:
+
+“Miss Bennet would not play at all amiss if she practised more, and
+could have the advantage of a London master. She has a very good notion
+of fingering, though her taste is not equal to Anne’s. Anne would have
+been a delightful performer, had her health allowed her to learn.”
+
+Elizabeth looked at Darcy to see how cordially he assented to his
+cousin’s praise; but neither at that moment nor at any other could she
+discern any symptom of love; and from the whole of his behaviour to Miss
+de Bourgh she derived this comfort for Miss Bingley, that he might have
+been just as likely to marry _her_, had she been his relation.
+
+Lady Catherine continued her remarks on Elizabeth’s performance, mixing
+with them many instructions on execution and taste. Elizabeth received
+them with all the forbearance of civility, and, at the request of the
+gentlemen, remained at the instrument till her ladyship’s carriage was
+ready to take them all home.
+
+
+
+Chapter 32
+
+
+Elizabeth was sitting by herself the next morning, and writing to Jane
+while Mrs. Collins and Maria were gone on business into the village,
+when she was startled by a ring at the door, the certain signal of a
+visitor. As she had heard no carriage, she thought it not unlikely to
+be Lady Catherine, and under that apprehension was putting away her
+half-finished letter that she might escape all impertinent questions,
+when the door opened, and, to her very great surprise, Mr. Darcy, and
+Mr. Darcy only, entered the room.
+
+He seemed astonished too on finding her alone, and apologised for his
+intrusion by letting her know that he had understood all the ladies were
+to be within.
+
+They then sat down, and when her inquiries after Rosings were made,
+seemed in danger of sinking into total silence. It was absolutely
+necessary, therefore, to think of something, and in this emergence
+recollecting _when_ she had seen him last in Hertfordshire, and
+feeling curious to know what he would say on the subject of their hasty
+departure, she observed:
+
+“How very suddenly you all quitted Netherfield last November, Mr. Darcy!
+It must have been a most agreeable surprise to Mr. Bingley to see you
+all after him so soon; for, if I recollect right, he went but the day
+before. He and his sisters were well, I hope, when you left London?”
+
+“Perfectly so, I thank you.”
+
+She found that she was to receive no other answer, and, after a short
+pause added:
+
+“I think I have understood that Mr. Bingley has not much idea of ever
+returning to Netherfield again?”
+
+“I have never heard him say so; but it is probable that he may spend
+very little of his time there in the future. He has many friends, and
+is at a time of life when friends and engagements are continually
+increasing.”
+
+“If he means to be but little at Netherfield, it would be better for
+the neighbourhood that he should give up the place entirely, for then we
+might possibly get a settled family there. But, perhaps, Mr. Bingley did
+not take the house so much for the convenience of the neighbourhood as
+for his own, and we must expect him to keep it or quit it on the same
+principle.”
+
+“I should not be surprised,” said Darcy, “if he were to give it up as
+soon as any eligible purchase offers.”
+
+Elizabeth made no answer. She was afraid of talking longer of his
+friend; and, having nothing else to say, was now determined to leave the
+trouble of finding a subject to him.
+
+He took the hint, and soon began with, “This seems a very comfortable
+house. Lady Catherine, I believe, did a great deal to it when Mr.
+Collins first came to Hunsford.”
+
+“I believe she did--and I am sure she could not have bestowed her
+kindness on a more grateful object.”
+
+“Mr. Collins appears to be very fortunate in his choice of a wife.”
+
+“Yes, indeed, his friends may well rejoice in his having met with one
+of the very few sensible women who would have accepted him, or have made
+him happy if they had. My friend has an excellent understanding--though
+I am not certain that I consider her marrying Mr. Collins as the
+wisest thing she ever did. She seems perfectly happy, however, and in a
+prudential light it is certainly a very good match for her.”
+
+“It must be very agreeable for her to be settled within so easy a
+distance of her own family and friends.”
+
+“An easy distance, do you call it? It is nearly fifty miles.”
+
+“And what is fifty miles of good road? Little more than half a day’s
+journey. Yes, I call it a _very_ easy distance.”
+
+“I should never have considered the distance as one of the _advantages_
+of the match,” cried Elizabeth. “I should never have said Mrs. Collins
+was settled _near_ her family.”
+
+“It is a proof of your own attachment to Hertfordshire. Anything beyond
+the very neighbourhood of Longbourn, I suppose, would appear far.”
+
+As he spoke there was a sort of smile which Elizabeth fancied she
+understood; he must be supposing her to be thinking of Jane and
+Netherfield, and she blushed as she answered:
+
+“I do not mean to say that a woman may not be settled too near her
+family. The far and the near must be relative, and depend on many
+varying circumstances. Where there is fortune to make the expenses of
+travelling unimportant, distance becomes no evil. But that is not the
+case _here_. Mr. and Mrs. Collins have a comfortable income, but not
+such a one as will allow of frequent journeys--and I am persuaded my
+friend would not call herself _near_ her family under less than _half_
+the present distance.”
+
+Mr. Darcy drew his chair a little towards her, and said, “_You_ cannot
+have a right to such very strong local attachment. _You_ cannot have
+been always at Longbourn.”
+
+Elizabeth looked surprised. The gentleman experienced some change of
+feeling; he drew back his chair, took a newspaper from the table, and
+glancing over it, said, in a colder voice:
+
+“Are you pleased with Kent?”
+
+A short dialogue on the subject of the country ensued, on either side
+calm and concise--and soon put an end to by the entrance of Charlotte
+and her sister, just returned from her walk. The tete-a-tete surprised
+them. Mr. Darcy related the mistake which had occasioned his intruding
+on Miss Bennet, and after sitting a few minutes longer without saying
+much to anybody, went away.
+
+“What can be the meaning of this?” said Charlotte, as soon as he was
+gone. “My dear, Eliza, he must be in love with you, or he would never
+have called us in this familiar way.”
+
+But when Elizabeth told of his silence, it did not seem very likely,
+even to Charlotte’s wishes, to be the case; and after various
+conjectures, they could at last only suppose his visit to proceed from
+the difficulty of finding anything to do, which was the more probable
+from the time of year. All field sports were over. Within doors there
+was Lady Catherine, books, and a billiard-table, but gentlemen cannot
+always be within doors; and in the nearness of the Parsonage, or the
+pleasantness of the walk to it, or of the people who lived in it, the
+two cousins found a temptation from this period of walking thither
+almost every day. They called at various times of the morning, sometimes
+separately, sometimes together, and now and then accompanied by their
+aunt. It was plain to them all that Colonel Fitzwilliam came because he
+had pleasure in their society, a persuasion which of course recommended
+him still more; and Elizabeth was reminded by her own satisfaction in
+being with him, as well as by his evident admiration of her, of her
+former favourite George Wickham; and though, in comparing them, she saw
+there was less captivating softness in Colonel Fitzwilliam’s manners,
+she believed he might have the best informed mind.
+
+But why Mr. Darcy came so often to the Parsonage, it was more difficult
+to understand. It could not be for society, as he frequently sat there
+ten minutes together without opening his lips; and when he did speak,
+it seemed the effect of necessity rather than of choice--a sacrifice
+to propriety, not a pleasure to himself. He seldom appeared really
+animated. Mrs. Collins knew not what to make of him. Colonel
+Fitzwilliam’s occasionally laughing at his stupidity, proved that he was
+generally different, which her own knowledge of him could not have told
+her; and as she would liked to have believed this change the effect
+of love, and the object of that love her friend Eliza, she set herself
+seriously to work to find it out. She watched him whenever they were at
+Rosings, and whenever he came to Hunsford; but without much success. He
+certainly looked at her friend a great deal, but the expression of that
+look was disputable. It was an earnest, steadfast gaze, but she often
+doubted whether there were much admiration in it, and sometimes it
+seemed nothing but absence of mind.
+
+She had once or twice suggested to Elizabeth the possibility of his
+being partial to her, but Elizabeth always laughed at the idea; and Mrs.
+Collins did not think it right to press the subject, from the danger of
+raising expectations which might only end in disappointment; for in her
+opinion it admitted not of a doubt, that all her friend’s dislike would
+vanish, if she could suppose him to be in her power.
+
+
+In her kind schemes for Elizabeth, she sometimes planned her marrying
+Colonel Fitzwilliam. He was beyond comparison the most pleasant man; he
+certainly admired her, and his situation in life was most eligible; but,
+to counterbalance these advantages, Mr. Darcy had considerable patronage
+in the church, and his cousin could have none at all.
+
+
+
+Chapter 33
+
+
+More than once did Elizabeth, in her ramble within the park,
+unexpectedly meet Mr. Darcy. She felt all the perverseness of the
+mischance that should bring him where no one else was brought, and, to
+prevent its ever happening again, took care to inform him at first that
+it was a favourite haunt of hers. How it could occur a second time,
+therefore, was very odd! Yet it did, and even a third. It seemed like
+wilful ill-nature, or a voluntary penance, for on these occasions it was
+not merely a few formal inquiries and an awkward pause and then away,
+but he actually thought it necessary to turn back and walk with her. He
+never said a great deal, nor did she give herself the trouble of talking
+or of listening much; but it struck her in the course of their third
+rencontre that he was asking some odd unconnected questions--about
+her pleasure in being at Hunsford, her love of solitary walks, and her
+opinion of Mr. and Mrs. Collins’s happiness; and that in speaking of
+Rosings and her not perfectly understanding the house, he seemed to
+expect that whenever she came into Kent again she would be staying
+_there_ too. His words seemed to imply it. Could he have Colonel
+Fitzwilliam in his thoughts? She supposed, if he meant anything, he must
+mean an allusion to what might arise in that quarter. It distressed
+her a little, and she was quite glad to find herself at the gate in the
+pales opposite the Parsonage.
+
+She was engaged one day as she walked, in perusing Jane’s last letter,
+and dwelling on some passages which proved that Jane had not written in
+spirits, when, instead of being again surprised by Mr. Darcy, she saw
+on looking up that Colonel Fitzwilliam was meeting her. Putting away the
+letter immediately and forcing a smile, she said:
+
+“I did not know before that you ever walked this way.”
+
+“I have been making the tour of the park,” he replied, “as I generally
+do every year, and intend to close it with a call at the Parsonage. Are
+you going much farther?”
+
+“No, I should have turned in a moment.”
+
+And accordingly she did turn, and they walked towards the Parsonage
+together.
+
+“Do you certainly leave Kent on Saturday?” said she.
+
+“Yes--if Darcy does not put it off again. But I am at his disposal. He
+arranges the business just as he pleases.”
+
+“And if not able to please himself in the arrangement, he has at least
+pleasure in the great power of choice. I do not know anybody who seems
+more to enjoy the power of doing what he likes than Mr. Darcy.”
+
+“He likes to have his own way very well,” replied Colonel Fitzwilliam.
+“But so we all do. It is only that he has better means of having it
+than many others, because he is rich, and many others are poor. I speak
+feelingly. A younger son, you know, must be inured to self-denial and
+dependence.”
+
+“In my opinion, the younger son of an earl can know very little of
+either. Now seriously, what have you ever known of self-denial and
+dependence? When have you been prevented by want of money from going
+wherever you chose, or procuring anything you had a fancy for?”
+
+“These are home questions--and perhaps I cannot say that I have
+experienced many hardships of that nature. But in matters of greater
+weight, I may suffer from want of money. Younger sons cannot marry where
+they like.”
+
+“Unless where they like women of fortune, which I think they very often
+do.”
+
+“Our habits of expense make us too dependent, and there are not many
+in my rank of life who can afford to marry without some attention to
+money.”
+
+“Is this,” thought Elizabeth, “meant for me?” and she coloured at the
+idea; but, recovering herself, said in a lively tone, “And pray, what
+is the usual price of an earl’s younger son? Unless the elder brother is
+very sickly, I suppose you would not ask above fifty thousand pounds.”
+
+He answered her in the same style, and the subject dropped. To interrupt
+a silence which might make him fancy her affected with what had passed,
+she soon afterwards said:
+
+“I imagine your cousin brought you down with him chiefly for the sake of
+having someone at his disposal. I wonder he does not marry, to secure a
+lasting convenience of that kind. But, perhaps, his sister does as well
+for the present, and, as she is under his sole care, he may do what he
+likes with her.”
+
+“No,” said Colonel Fitzwilliam, “that is an advantage which he must
+divide with me. I am joined with him in the guardianship of Miss Darcy.”
+
+“Are you indeed? And pray what sort of guardians do you make? Does your
+charge give you much trouble? Young ladies of her age are sometimes a
+little difficult to manage, and if she has the true Darcy spirit, she
+may like to have her own way.”
+
+As she spoke she observed him looking at her earnestly; and the manner
+in which he immediately asked her why she supposed Miss Darcy likely to
+give them any uneasiness, convinced her that she had somehow or other
+got pretty near the truth. She directly replied:
+
+“You need not be frightened. I never heard any harm of her; and I dare
+say she is one of the most tractable creatures in the world. She is a
+very great favourite with some ladies of my acquaintance, Mrs. Hurst and
+Miss Bingley. I think I have heard you say that you know them.”
+
+“I know them a little. Their brother is a pleasant gentlemanlike man--he
+is a great friend of Darcy’s.”
+
+“Oh! yes,” said Elizabeth drily; “Mr. Darcy is uncommonly kind to Mr.
+Bingley, and takes a prodigious deal of care of him.”
+
+“Care of him! Yes, I really believe Darcy _does_ take care of him in
+those points where he most wants care. From something that he told me in
+our journey hither, I have reason to think Bingley very much indebted to
+him. But I ought to beg his pardon, for I have no right to suppose that
+Bingley was the person meant. It was all conjecture.”
+
+“What is it you mean?”
+
+“It is a circumstance which Darcy could not wish to be generally known,
+because if it were to get round to the lady’s family, it would be an
+unpleasant thing.”
+
+“You may depend upon my not mentioning it.”
+
+“And remember that I have not much reason for supposing it to be
+Bingley. What he told me was merely this: that he congratulated himself
+on having lately saved a friend from the inconveniences of a most
+imprudent marriage, but without mentioning names or any other
+particulars, and I only suspected it to be Bingley from believing
+him the kind of young man to get into a scrape of that sort, and from
+knowing them to have been together the whole of last summer.”
+
+“Did Mr. Darcy give you reasons for this interference?”
+
+“I understood that there were some very strong objections against the
+lady.”
+
+“And what arts did he use to separate them?”
+
+“He did not talk to me of his own arts,” said Fitzwilliam, smiling. “He
+only told me what I have now told you.”
+
+Elizabeth made no answer, and walked on, her heart swelling with
+indignation. After watching her a little, Fitzwilliam asked her why she
+was so thoughtful.
+
+“I am thinking of what you have been telling me,” said she. “Your
+cousin’s conduct does not suit my feelings. Why was he to be the judge?”
+
+“You are rather disposed to call his interference officious?”
+
+“I do not see what right Mr. Darcy had to decide on the propriety of his
+friend’s inclination, or why, upon his own judgement alone, he was to
+determine and direct in what manner his friend was to be happy.
+But,” she continued, recollecting herself, “as we know none of the
+particulars, it is not fair to condemn him. It is not to be supposed
+that there was much affection in the case.”
+
+“That is not an unnatural surmise,” said Fitzwilliam, “but it is a
+lessening of the honour of my cousin’s triumph very sadly.”
+
+This was spoken jestingly; but it appeared to her so just a picture
+of Mr. Darcy, that she would not trust herself with an answer, and
+therefore, abruptly changing the conversation talked on indifferent
+matters until they reached the Parsonage. There, shut into her own room,
+as soon as their visitor left them, she could think without interruption
+of all that she had heard. It was not to be supposed that any other
+people could be meant than those with whom she was connected. There
+could not exist in the world _two_ men over whom Mr. Darcy could have
+such boundless influence. That he had been concerned in the measures
+taken to separate Bingley and Jane she had never doubted; but she had
+always attributed to Miss Bingley the principal design and arrangement
+of them. If his own vanity, however, did not mislead him, _he_ was
+the cause, his pride and caprice were the cause, of all that Jane had
+suffered, and still continued to suffer. He had ruined for a while
+every hope of happiness for the most affectionate, generous heart in the
+world; and no one could say how lasting an evil he might have inflicted.
+
+“There were some very strong objections against the lady,” were Colonel
+Fitzwilliam’s words; and those strong objections probably were, her
+having one uncle who was a country attorney, and another who was in
+business in London.
+
+“To Jane herself,” she exclaimed, “there could be no possibility of
+objection; all loveliness and goodness as she is!--her understanding
+excellent, her mind improved, and her manners captivating. Neither
+could anything be urged against my father, who, though with some
+peculiarities, has abilities Mr. Darcy himself need not disdain, and
+respectability which he will probably never reach.” When she thought of
+her mother, her confidence gave way a little; but she would not allow
+that any objections _there_ had material weight with Mr. Darcy, whose
+pride, she was convinced, would receive a deeper wound from the want of
+importance in his friend’s connections, than from their want of sense;
+and she was quite decided, at last, that he had been partly governed
+by this worst kind of pride, and partly by the wish of retaining Mr.
+Bingley for his sister.
+
+The agitation and tears which the subject occasioned, brought on a
+headache; and it grew so much worse towards the evening, that, added to
+her unwillingness to see Mr. Darcy, it determined her not to attend her
+cousins to Rosings, where they were engaged to drink tea. Mrs. Collins,
+seeing that she was really unwell, did not press her to go and as much
+as possible prevented her husband from pressing her; but Mr. Collins
+could not conceal his apprehension of Lady Catherine’s being rather
+displeased by her staying at home.
+
+
+
+Chapter 34
+
+
+When they were gone, Elizabeth, as if intending to exasperate herself
+as much as possible against Mr. Darcy, chose for her employment the
+examination of all the letters which Jane had written to her since her
+being in Kent. They contained no actual complaint, nor was there any
+revival of past occurrences, or any communication of present suffering.
+But in all, and in almost every line of each, there was a want of that
+cheerfulness which had been used to characterise her style, and which,
+proceeding from the serenity of a mind at ease with itself and kindly
+disposed towards everyone, had been scarcely ever clouded. Elizabeth
+noticed every sentence conveying the idea of uneasiness, with an
+attention which it had hardly received on the first perusal. Mr. Darcy’s
+shameful boast of what misery he had been able to inflict, gave her
+a keener sense of her sister’s sufferings. It was some consolation
+to think that his visit to Rosings was to end on the day after the
+next--and, a still greater, that in less than a fortnight she should
+herself be with Jane again, and enabled to contribute to the recovery of
+her spirits, by all that affection could do.
+
+She could not think of Darcy’s leaving Kent without remembering that
+his cousin was to go with him; but Colonel Fitzwilliam had made it clear
+that he had no intentions at all, and agreeable as he was, she did not
+mean to be unhappy about him.
+
+While settling this point, she was suddenly roused by the sound of the
+door-bell, and her spirits were a little fluttered by the idea of its
+being Colonel Fitzwilliam himself, who had once before called late in
+the evening, and might now come to inquire particularly after her.
+But this idea was soon banished, and her spirits were very differently
+affected, when, to her utter amazement, she saw Mr. Darcy walk into the
+room. In an hurried manner he immediately began an inquiry after her
+health, imputing his visit to a wish of hearing that she were better.
+She answered him with cold civility. He sat down for a few moments, and
+then getting up, walked about the room. Elizabeth was surprised, but
+said not a word. After a silence of several minutes, he came towards her
+in an agitated manner, and thus began:
+
+“In vain I have struggled. It will not do. My feelings will not be
+repressed. You must allow me to tell you how ardently I admire and love
+you.”
+
+Elizabeth’s astonishment was beyond expression. She stared, coloured,
+doubted, and was silent. This he considered sufficient encouragement;
+and the avowal of all that he felt, and had long felt for her,
+immediately followed. He spoke well; but there were feelings besides
+those of the heart to be detailed; and he was not more eloquent on the
+subject of tenderness than of pride. His sense of her inferiority--of
+its being a degradation--of the family obstacles which had always
+opposed to inclination, were dwelt on with a warmth which seemed due to
+the consequence he was wounding, but was very unlikely to recommend his
+suit.
+
+In spite of her deeply-rooted dislike, she could not be insensible to
+the compliment of such a man’s affection, and though her intentions did
+not vary for an instant, she was at first sorry for the pain he was to
+receive; till, roused to resentment by his subsequent language, she
+lost all compassion in anger. She tried, however, to compose herself to
+answer him with patience, when he should have done. He concluded with
+representing to her the strength of that attachment which, in spite
+of all his endeavours, he had found impossible to conquer; and with
+expressing his hope that it would now be rewarded by her acceptance of
+his hand. As he said this, she could easily see that he had no doubt
+of a favourable answer. He _spoke_ of apprehension and anxiety, but
+his countenance expressed real security. Such a circumstance could
+only exasperate farther, and, when he ceased, the colour rose into her
+cheeks, and she said:
+
+“In such cases as this, it is, I believe, the established mode to
+express a sense of obligation for the sentiments avowed, however
+unequally they may be returned. It is natural that obligation should
+be felt, and if I could _feel_ gratitude, I would now thank you. But I
+cannot--I have never desired your good opinion, and you have certainly
+bestowed it most unwillingly. I am sorry to have occasioned pain to
+anyone. It has been most unconsciously done, however, and I hope will be
+of short duration. The feelings which, you tell me, have long prevented
+the acknowledgment of your regard, can have little difficulty in
+overcoming it after this explanation.”
+
+Mr. Darcy, who was leaning against the mantelpiece with his eyes fixed
+on her face, seemed to catch her words with no less resentment than
+surprise. His complexion became pale with anger, and the disturbance
+of his mind was visible in every feature. He was struggling for the
+appearance of composure, and would not open his lips till he believed
+himself to have attained it. The pause was to Elizabeth’s feelings
+dreadful. At length, with a voice of forced calmness, he said:
+
+“And this is all the reply which I am to have the honour of expecting!
+I might, perhaps, wish to be informed why, with so little _endeavour_ at
+civility, I am thus rejected. But it is of small importance.”
+
+“I might as well inquire,” replied she, “why with so evident a desire
+of offending and insulting me, you chose to tell me that you liked me
+against your will, against your reason, and even against your character?
+Was not this some excuse for incivility, if I _was_ uncivil? But I have
+other provocations. You know I have. Had not my feelings decided against
+you--had they been indifferent, or had they even been favourable, do you
+think that any consideration would tempt me to accept the man who has
+been the means of ruining, perhaps for ever, the happiness of a most
+beloved sister?”
+
+As she pronounced these words, Mr. Darcy changed colour; but the emotion
+was short, and he listened without attempting to interrupt her while she
+continued:
+
+“I have every reason in the world to think ill of you. No motive can
+excuse the unjust and ungenerous part you acted _there_. You dare not,
+you cannot deny, that you have been the principal, if not the only means
+of dividing them from each other--of exposing one to the censure of the
+world for caprice and instability, and the other to its derision for
+disappointed hopes, and involving them both in misery of the acutest
+kind.”
+
+She paused, and saw with no slight indignation that he was listening
+with an air which proved him wholly unmoved by any feeling of remorse.
+He even looked at her with a smile of affected incredulity.
+
+“Can you deny that you have done it?” she repeated.
+
+With assumed tranquillity he then replied: “I have no wish of denying
+that I did everything in my power to separate my friend from your
+sister, or that I rejoice in my success. Towards _him_ I have been
+kinder than towards myself.”
+
+Elizabeth disdained the appearance of noticing this civil reflection,
+but its meaning did not escape, nor was it likely to conciliate her.
+
+“But it is not merely this affair,” she continued, “on which my dislike
+is founded. Long before it had taken place my opinion of you was
+decided. Your character was unfolded in the recital which I received
+many months ago from Mr. Wickham. On this subject, what can you have to
+say? In what imaginary act of friendship can you here defend yourself?
+or under what misrepresentation can you here impose upon others?”
+
+“You take an eager interest in that gentleman’s concerns,” said Darcy,
+in a less tranquil tone, and with a heightened colour.
+
+“Who that knows what his misfortunes have been, can help feeling an
+interest in him?”
+
+“His misfortunes!” repeated Darcy contemptuously; “yes, his misfortunes
+have been great indeed.”
+
+“And of your infliction,” cried Elizabeth with energy. “You have reduced
+him to his present state of poverty--comparative poverty. You have
+withheld the advantages which you must know to have been designed for
+him. You have deprived the best years of his life of that independence
+which was no less his due than his desert. You have done all this!
+and yet you can treat the mention of his misfortune with contempt and
+ridicule.”
+
+“And this,” cried Darcy, as he walked with quick steps across the room,
+“is your opinion of me! This is the estimation in which you hold me!
+I thank you for explaining it so fully. My faults, according to this
+calculation, are heavy indeed! But perhaps,” added he, stopping in
+his walk, and turning towards her, “these offenses might have been
+overlooked, had not your pride been hurt by my honest confession of the
+scruples that had long prevented my forming any serious design. These
+bitter accusations might have been suppressed, had I, with greater
+policy, concealed my struggles, and flattered you into the belief of
+my being impelled by unqualified, unalloyed inclination; by reason, by
+reflection, by everything. But disguise of every sort is my abhorrence.
+Nor am I ashamed of the feelings I related. They were natural and
+just. Could you expect me to rejoice in the inferiority of your
+connections?--to congratulate myself on the hope of relations, whose
+condition in life is so decidedly beneath my own?”
+
+Elizabeth felt herself growing more angry every moment; yet she tried to
+the utmost to speak with composure when she said:
+
+“You are mistaken, Mr. Darcy, if you suppose that the mode of your
+declaration affected me in any other way, than as it spared me the concern
+which I might have felt in refusing you, had you behaved in a more
+gentlemanlike manner.”
+
+She saw him start at this, but he said nothing, and she continued:
+
+“You could not have made the offer of your hand in any possible way that
+would have tempted me to accept it.”
+
+Again his astonishment was obvious; and he looked at her with an
+expression of mingled incredulity and mortification. She went on:
+
+“From the very beginning--from the first moment, I may almost say--of
+my acquaintance with you, your manners, impressing me with the fullest
+belief of your arrogance, your conceit, and your selfish disdain of
+the feelings of others, were such as to form the groundwork of
+disapprobation on which succeeding events have built so immovable a
+dislike; and I had not known you a month before I felt that you were the
+last man in the world whom I could ever be prevailed on to marry.”
+
+“You have said quite enough, madam. I perfectly comprehend your
+feelings, and have now only to be ashamed of what my own have been.
+Forgive me for having taken up so much of your time, and accept my best
+wishes for your health and happiness.”
+
+And with these words he hastily left the room, and Elizabeth heard him
+the next moment open the front door and quit the house.
+
+The tumult of her mind, was now painfully great. She knew not how
+to support herself, and from actual weakness sat down and cried for
+half-an-hour. Her astonishment, as she reflected on what had passed,
+was increased by every review of it. That she should receive an offer of
+marriage from Mr. Darcy! That he should have been in love with her for
+so many months! So much in love as to wish to marry her in spite of
+all the objections which had made him prevent his friend’s marrying
+her sister, and which must appear at least with equal force in his
+own case--was almost incredible! It was gratifying to have inspired
+unconsciously so strong an affection. But his pride, his abominable
+pride--his shameless avowal of what he had done with respect to
+Jane--his unpardonable assurance in acknowledging, though he could
+not justify it, and the unfeeling manner in which he had mentioned Mr.
+Wickham, his cruelty towards whom he had not attempted to deny, soon
+overcame the pity which the consideration of his attachment had for
+a moment excited. She continued in very agitated reflections till the
+sound of Lady Catherine’s carriage made her feel how unequal she was to
+encounter Charlotte’s observation, and hurried her away to her room.
+
+
+
+Chapter 35
+
+
+Elizabeth awoke the next morning to the same thoughts and meditations
+which had at length closed her eyes. She could not yet recover from the
+surprise of what had happened; it was impossible to think of anything
+else; and, totally indisposed for employment, she resolved, soon after
+breakfast, to indulge herself in air and exercise. She was proceeding
+directly to her favourite walk, when the recollection of Mr. Darcy’s
+sometimes coming there stopped her, and instead of entering the park,
+she turned up the lane, which led farther from the turnpike-road. The
+park paling was still the boundary on one side, and she soon passed one
+of the gates into the ground.
+
+After walking two or three times along that part of the lane, she was
+tempted, by the pleasantness of the morning, to stop at the gates and
+look into the park. The five weeks which she had now passed in Kent had
+made a great difference in the country, and every day was adding to the
+verdure of the early trees. She was on the point of continuing her walk,
+when she caught a glimpse of a gentleman within the sort of grove which
+edged the park; he was moving that way; and, fearful of its being Mr.
+Darcy, she was directly retreating. But the person who advanced was now
+near enough to see her, and stepping forward with eagerness, pronounced
+her name. She had turned away; but on hearing herself called, though
+in a voice which proved it to be Mr. Darcy, she moved again towards the
+gate. He had by that time reached it also, and, holding out a letter,
+which she instinctively took, said, with a look of haughty composure,
+“I have been walking in the grove some time in the hope of meeting you.
+Will you do me the honour of reading that letter?” And then, with a
+slight bow, turned again into the plantation, and was soon out of sight.
+
+With no expectation of pleasure, but with the strongest curiosity,
+Elizabeth opened the letter, and, to her still increasing wonder,
+perceived an envelope containing two sheets of letter-paper, written
+quite through, in a very close hand. The envelope itself was likewise
+full. Pursuing her way along the lane, she then began it. It was dated
+from Rosings, at eight o’clock in the morning, and was as follows:--
+
+“Be not alarmed, madam, on receiving this letter, by the apprehension
+of its containing any repetition of those sentiments or renewal of those
+offers which were last night so disgusting to you. I write without any
+intention of paining you, or humbling myself, by dwelling on wishes
+which, for the happiness of both, cannot be too soon forgotten; and the
+effort which the formation and the perusal of this letter must occasion,
+should have been spared, had not my character required it to be written
+and read. You must, therefore, pardon the freedom with which I demand
+your attention; your feelings, I know, will bestow it unwillingly, but I
+demand it of your justice.
+
+“Two offenses of a very different nature, and by no means of equal
+magnitude, you last night laid to my charge. The first mentioned was,
+that, regardless of the sentiments of either, I had detached Mr. Bingley
+from your sister, and the other, that I had, in defiance of various
+claims, in defiance of honour and humanity, ruined the immediate
+prosperity and blasted the prospects of Mr. Wickham. Wilfully and
+wantonly to have thrown off the companion of my youth, the acknowledged
+favourite of my father, a young man who had scarcely any other
+dependence than on our patronage, and who had been brought up to expect
+its exertion, would be a depravity, to which the separation of two young
+persons, whose affection could be the growth of only a few weeks, could
+bear no comparison. But from the severity of that blame which was last
+night so liberally bestowed, respecting each circumstance, I shall hope
+to be in the future secured, when the following account of my actions
+and their motives has been read. If, in the explanation of them, which
+is due to myself, I am under the necessity of relating feelings which
+may be offensive to yours, I can only say that I am sorry. The necessity
+must be obeyed, and further apology would be absurd.
+
+“I had not been long in Hertfordshire, before I saw, in common with
+others, that Bingley preferred your elder sister to any other young
+woman in the country. But it was not till the evening of the dance
+at Netherfield that I had any apprehension of his feeling a serious
+attachment. I had often seen him in love before. At that ball, while I
+had the honour of dancing with you, I was first made acquainted, by Sir
+William Lucas’s accidental information, that Bingley’s attentions to
+your sister had given rise to a general expectation of their marriage.
+He spoke of it as a certain event, of which the time alone could
+be undecided. From that moment I observed my friend’s behaviour
+attentively; and I could then perceive that his partiality for Miss
+Bennet was beyond what I had ever witnessed in him. Your sister I also
+watched. Her look and manners were open, cheerful, and engaging as ever,
+but without any symptom of peculiar regard, and I remained convinced
+from the evening’s scrutiny, that though she received his attentions
+with pleasure, she did not invite them by any participation of
+sentiment. If _you_ have not been mistaken here, _I_ must have been
+in error. Your superior knowledge of your sister must make the latter
+probable. If it be so, if I have been misled by such error to inflict
+pain on her, your resentment has not been unreasonable. But I shall not
+scruple to assert, that the serenity of your sister’s countenance and
+air was such as might have given the most acute observer a conviction
+that, however amiable her temper, her heart was not likely to be
+easily touched. That I was desirous of believing her indifferent is
+certain--but I will venture to say that my investigation and decisions
+are not usually influenced by my hopes or fears. I did not believe
+her to be indifferent because I wished it; I believed it on impartial
+conviction, as truly as I wished it in reason. My objections to the
+marriage were not merely those which I last night acknowledged to have
+the utmost force of passion to put aside, in my own case; the want of
+connection could not be so great an evil to my friend as to me. But
+there were other causes of repugnance; causes which, though still
+existing, and existing to an equal degree in both instances, I had
+myself endeavoured to forget, because they were not immediately before
+me. These causes must be stated, though briefly. The situation of your
+mother’s family, though objectionable, was nothing in comparison to that
+total want of propriety so frequently, so almost uniformly betrayed by
+herself, by your three younger sisters, and occasionally even by your
+father. Pardon me. It pains me to offend you. But amidst your concern
+for the defects of your nearest relations, and your displeasure at this
+representation of them, let it give you consolation to consider that, to
+have conducted yourselves so as to avoid any share of the like censure,
+is praise no less generally bestowed on you and your elder sister, than
+it is honourable to the sense and disposition of both. I will only say
+farther that from what passed that evening, my opinion of all parties
+was confirmed, and every inducement heightened which could have led
+me before, to preserve my friend from what I esteemed a most unhappy
+connection. He left Netherfield for London, on the day following, as
+you, I am certain, remember, with the design of soon returning.
+
+“The part which I acted is now to be explained. His sisters’ uneasiness
+had been equally excited with my own; our coincidence of feeling was
+soon discovered, and, alike sensible that no time was to be lost in
+detaching their brother, we shortly resolved on joining him directly in
+London. We accordingly went--and there I readily engaged in the office
+of pointing out to my friend the certain evils of such a choice. I
+described, and enforced them earnestly. But, however this remonstrance
+might have staggered or delayed his determination, I do not suppose
+that it would ultimately have prevented the marriage, had it not been
+seconded by the assurance that I hesitated not in giving, of your
+sister’s indifference. He had before believed her to return his
+affection with sincere, if not with equal regard. But Bingley has great
+natural modesty, with a stronger dependence on my judgement than on his
+own. To convince him, therefore, that he had deceived himself, was
+no very difficult point. To persuade him against returning into
+Hertfordshire, when that conviction had been given, was scarcely the
+work of a moment. I cannot blame myself for having done thus much. There
+is but one part of my conduct in the whole affair on which I do not
+reflect with satisfaction; it is that I condescended to adopt the
+measures of art so far as to conceal from him your sister’s being in
+town. I knew it myself, as it was known to Miss Bingley; but her
+brother is even yet ignorant of it. That they might have met without
+ill consequence is perhaps probable; but his regard did not appear to me
+enough extinguished for him to see her without some danger. Perhaps this
+concealment, this disguise was beneath me; it is done, however, and it
+was done for the best. On this subject I have nothing more to say, no
+other apology to offer. If I have wounded your sister’s feelings, it
+was unknowingly done and though the motives which governed me may to
+you very naturally appear insufficient, I have not yet learnt to condemn
+them.
+
+“With respect to that other, more weighty accusation, of having injured
+Mr. Wickham, I can only refute it by laying before you the whole of his
+connection with my family. Of what he has _particularly_ accused me I
+am ignorant; but of the truth of what I shall relate, I can summon more
+than one witness of undoubted veracity.
+
+“Mr. Wickham is the son of a very respectable man, who had for many
+years the management of all the Pemberley estates, and whose good
+conduct in the discharge of his trust naturally inclined my father to
+be of service to him; and on George Wickham, who was his godson, his
+kindness was therefore liberally bestowed. My father supported him at
+school, and afterwards at Cambridge--most important assistance, as his
+own father, always poor from the extravagance of his wife, would have
+been unable to give him a gentleman’s education. My father was not only
+fond of this young man’s society, whose manners were always engaging; he
+had also the highest opinion of him, and hoping the church would be
+his profession, intended to provide for him in it. As for myself, it is
+many, many years since I first began to think of him in a very different
+manner. The vicious propensities--the want of principle, which he was
+careful to guard from the knowledge of his best friend, could not escape
+the observation of a young man of nearly the same age with himself,
+and who had opportunities of seeing him in unguarded moments, which Mr.
+Darcy could not have. Here again I shall give you pain--to what degree
+you only can tell. But whatever may be the sentiments which Mr. Wickham
+has created, a suspicion of their nature shall not prevent me from
+unfolding his real character--it adds even another motive.
+
+“My excellent father died about five years ago; and his attachment to
+Mr. Wickham was to the last so steady, that in his will he particularly
+recommended it to me, to promote his advancement in the best manner
+that his profession might allow--and if he took orders, desired that a
+valuable family living might be his as soon as it became vacant. There
+was also a legacy of one thousand pounds. His own father did not long
+survive mine, and within half a year from these events, Mr. Wickham
+wrote to inform me that, having finally resolved against taking orders,
+he hoped I should not think it unreasonable for him to expect some more
+immediate pecuniary advantage, in lieu of the preferment, by which he
+could not be benefited. He had some intention, he added, of studying
+law, and I must be aware that the interest of one thousand pounds would
+be a very insufficient support therein. I rather wished, than believed
+him to be sincere; but, at any rate, was perfectly ready to accede to
+his proposal. I knew that Mr. Wickham ought not to be a clergyman; the
+business was therefore soon settled--he resigned all claim to assistance
+in the church, were it possible that he could ever be in a situation to
+receive it, and accepted in return three thousand pounds. All connection
+between us seemed now dissolved. I thought too ill of him to invite him
+to Pemberley, or admit his society in town. In town I believe he chiefly
+lived, but his studying the law was a mere pretence, and being now free
+from all restraint, his life was a life of idleness and dissipation.
+For about three years I heard little of him; but on the decease of the
+incumbent of the living which had been designed for him, he applied to
+me again by letter for the presentation. His circumstances, he assured
+me, and I had no difficulty in believing it, were exceedingly bad. He
+had found the law a most unprofitable study, and was now absolutely
+resolved on being ordained, if I would present him to the living in
+question--of which he trusted there could be little doubt, as he was
+well assured that I had no other person to provide for, and I could not
+have forgotten my revered father’s intentions. You will hardly blame
+me for refusing to comply with this entreaty, or for resisting every
+repetition to it. His resentment was in proportion to the distress of
+his circumstances--and he was doubtless as violent in his abuse of me
+to others as in his reproaches to myself. After this period every
+appearance of acquaintance was dropped. How he lived I know not. But
+last summer he was again most painfully obtruded on my notice.
+
+“I must now mention a circumstance which I would wish to forget myself,
+and which no obligation less than the present should induce me to unfold
+to any human being. Having said thus much, I feel no doubt of your
+secrecy. My sister, who is more than ten years my junior, was left to
+the guardianship of my mother’s nephew, Colonel Fitzwilliam, and myself.
+About a year ago, she was taken from school, and an establishment formed
+for her in London; and last summer she went with the lady who presided
+over it, to Ramsgate; and thither also went Mr. Wickham, undoubtedly by
+design; for there proved to have been a prior acquaintance between him
+and Mrs. Younge, in whose character we were most unhappily deceived; and
+by her connivance and aid, he so far recommended himself to Georgiana,
+whose affectionate heart retained a strong impression of his kindness to
+her as a child, that she was persuaded to believe herself in love, and
+to consent to an elopement. She was then but fifteen, which must be her
+excuse; and after stating her imprudence, I am happy to add, that I owed
+the knowledge of it to herself. I joined them unexpectedly a day or two
+before the intended elopement, and then Georgiana, unable to support the
+idea of grieving and offending a brother whom she almost looked up to as
+a father, acknowledged the whole to me. You may imagine what I felt and
+how I acted. Regard for my sister’s credit and feelings prevented
+any public exposure; but I wrote to Mr. Wickham, who left the place
+immediately, and Mrs. Younge was of course removed from her charge. Mr.
+Wickham’s chief object was unquestionably my sister’s fortune, which
+is thirty thousand pounds; but I cannot help supposing that the hope of
+revenging himself on me was a strong inducement. His revenge would have
+been complete indeed.
+
+“This, madam, is a faithful narrative of every event in which we have
+been concerned together; and if you do not absolutely reject it as
+false, you will, I hope, acquit me henceforth of cruelty towards Mr.
+Wickham. I know not in what manner, under what form of falsehood he
+had imposed on you; but his success is not perhaps to be wondered
+at. Ignorant as you previously were of everything concerning either,
+detection could not be in your power, and suspicion certainly not in
+your inclination.
+
+“You may possibly wonder why all this was not told you last night; but
+I was not then master enough of myself to know what could or ought to
+be revealed. For the truth of everything here related, I can appeal more
+particularly to the testimony of Colonel Fitzwilliam, who, from our
+near relationship and constant intimacy, and, still more, as one of
+the executors of my father’s will, has been unavoidably acquainted
+with every particular of these transactions. If your abhorrence of _me_
+should make _my_ assertions valueless, you cannot be prevented by
+the same cause from confiding in my cousin; and that there may be
+the possibility of consulting him, I shall endeavour to find some
+opportunity of putting this letter in your hands in the course of the
+morning. I will only add, God bless you.
+
+“FITZWILLIAM DARCY”
+
+
+
+Chapter 36
+
+
+If Elizabeth, when Mr. Darcy gave her the letter, did not expect it to
+contain a renewal of his offers, she had formed no expectation at all of
+its contents. But such as they were, it may well be supposed how eagerly
+she went through them, and what a contrariety of emotion they excited.
+Her feelings as she read were scarcely to be defined. With amazement did
+she first understand that he believed any apology to be in his power;
+and steadfastly was she persuaded, that he could have no explanation
+to give, which a just sense of shame would not conceal. With a strong
+prejudice against everything he might say, she began his account of what
+had happened at Netherfield. She read with an eagerness which hardly
+left her power of comprehension, and from impatience of knowing what the
+next sentence might bring, was incapable of attending to the sense of
+the one before her eyes. His belief of her sister’s insensibility she
+instantly resolved to be false; and his account of the real, the worst
+objections to the match, made her too angry to have any wish of doing
+him justice. He expressed no regret for what he had done which satisfied
+her; his style was not penitent, but haughty. It was all pride and
+insolence.
+
+But when this subject was succeeded by his account of Mr. Wickham--when
+she read with somewhat clearer attention a relation of events which,
+if true, must overthrow every cherished opinion of his worth, and which
+bore so alarming an affinity to his own history of himself--her
+feelings were yet more acutely painful and more difficult of definition.
+Astonishment, apprehension, and even horror, oppressed her. She wished
+to discredit it entirely, repeatedly exclaiming, “This must be false!
+This cannot be! This must be the grossest falsehood!”--and when she had
+gone through the whole letter, though scarcely knowing anything of the
+last page or two, put it hastily away, protesting that she would not
+regard it, that she would never look in it again.
+
+In this perturbed state of mind, with thoughts that could rest on
+nothing, she walked on; but it would not do; in half a minute the letter
+was unfolded again, and collecting herself as well as she could, she
+again began the mortifying perusal of all that related to Wickham, and
+commanded herself so far as to examine the meaning of every sentence.
+The account of his connection with the Pemberley family was exactly what
+he had related himself; and the kindness of the late Mr. Darcy, though
+she had not before known its extent, agreed equally well with his own
+words. So far each recital confirmed the other; but when she came to the
+will, the difference was great. What Wickham had said of the living
+was fresh in her memory, and as she recalled his very words, it was
+impossible not to feel that there was gross duplicity on one side or the
+other; and, for a few moments, she flattered herself that her wishes did
+not err. But when she read and re-read with the closest attention, the
+particulars immediately following of Wickham’s resigning all pretensions
+to the living, of his receiving in lieu so considerable a sum as three
+thousand pounds, again was she forced to hesitate. She put down
+the letter, weighed every circumstance with what she meant to be
+impartiality--deliberated on the probability of each statement--but with
+little success. On both sides it was only assertion. Again she read
+on; but every line proved more clearly that the affair, which she had
+believed it impossible that any contrivance could so represent as to
+render Mr. Darcy’s conduct in it less than infamous, was capable of a
+turn which must make him entirely blameless throughout the whole.
+
+The extravagance and general profligacy which he scrupled not to lay at
+Mr. Wickham’s charge, exceedingly shocked her; the more so, as she could
+bring no proof of its injustice. She had never heard of him before his
+entrance into the ----shire Militia, in which he had engaged at the
+persuasion of the young man who, on meeting him accidentally in town,
+had there renewed a slight acquaintance. Of his former way of life
+nothing had been known in Hertfordshire but what he told himself. As
+to his real character, had information been in her power, she had
+never felt a wish of inquiring. His countenance, voice, and manner had
+established him at once in the possession of every virtue. She tried
+to recollect some instance of goodness, some distinguished trait of
+integrity or benevolence, that might rescue him from the attacks of
+Mr. Darcy; or at least, by the predominance of virtue, atone for those
+casual errors under which she would endeavour to class what Mr. Darcy
+had described as the idleness and vice of many years’ continuance. But
+no such recollection befriended her. She could see him instantly before
+her, in every charm of air and address; but she could remember no more
+substantial good than the general approbation of the neighbourhood, and
+the regard which his social powers had gained him in the mess. After
+pausing on this point a considerable while, she once more continued to
+read. But, alas! the story which followed, of his designs on Miss
+Darcy, received some confirmation from what had passed between Colonel
+Fitzwilliam and herself only the morning before; and at last she was
+referred for the truth of every particular to Colonel Fitzwilliam
+himself--from whom she had previously received the information of his
+near concern in all his cousin’s affairs, and whose character she had no
+reason to question. At one time she had almost resolved on applying to
+him, but the idea was checked by the awkwardness of the application, and
+at length wholly banished by the conviction that Mr. Darcy would never
+have hazarded such a proposal, if he had not been well assured of his
+cousin’s corroboration.
+
+She perfectly remembered everything that had passed in conversation
+between Wickham and herself, in their first evening at Mr. Phillips’s.
+Many of his expressions were still fresh in her memory. She was _now_
+struck with the impropriety of such communications to a stranger, and
+wondered it had escaped her before. She saw the indelicacy of putting
+himself forward as he had done, and the inconsistency of his professions
+with his conduct. She remembered that he had boasted of having no fear
+of seeing Mr. Darcy--that Mr. Darcy might leave the country, but that
+_he_ should stand his ground; yet he had avoided the Netherfield ball
+the very next week. She remembered also that, till the Netherfield
+family had quitted the country, he had told his story to no one but
+herself; but that after their removal it had been everywhere discussed;
+that he had then no reserves, no scruples in sinking Mr. Darcy’s
+character, though he had assured her that respect for the father would
+always prevent his exposing the son.
+
+How differently did everything now appear in which he was concerned!
+His attentions to Miss King were now the consequence of views solely and
+hatefully mercenary; and the mediocrity of her fortune proved no longer
+the moderation of his wishes, but his eagerness to grasp at anything.
+His behaviour to herself could now have had no tolerable motive; he had
+either been deceived with regard to her fortune, or had been gratifying
+his vanity by encouraging the preference which she believed she had most
+incautiously shown. Every lingering struggle in his favour grew fainter
+and fainter; and in farther justification of Mr. Darcy, she could not
+but allow that Mr. Bingley, when questioned by Jane, had long ago
+asserted his blamelessness in the affair; that proud and repulsive as
+were his manners, she had never, in the whole course of their
+acquaintance--an acquaintance which had latterly brought them much
+together, and given her a sort of intimacy with his ways--seen anything
+that betrayed him to be unprincipled or unjust--anything that spoke him
+of irreligious or immoral habits; that among his own connections he was
+esteemed and valued--that even Wickham had allowed him merit as a
+brother, and that she had often heard him speak so affectionately of his
+sister as to prove him capable of _some_ amiable feeling; that had his
+actions been what Mr. Wickham represented them, so gross a violation of
+everything right could hardly have been concealed from the world; and
+that friendship between a person capable of it, and such an amiable man
+as Mr. Bingley, was incomprehensible.
+
+She grew absolutely ashamed of herself. Of neither Darcy nor Wickham
+could she think without feeling she had been blind, partial, prejudiced,
+absurd.
+
+“How despicably I have acted!” she cried; “I, who have prided myself
+on my discernment! I, who have valued myself on my abilities! who have
+often disdained the generous candour of my sister, and gratified
+my vanity in useless or blameable mistrust! How humiliating is this
+discovery! Yet, how just a humiliation! Had I been in love, I could
+not have been more wretchedly blind! But vanity, not love, has been my
+folly. Pleased with the preference of one, and offended by the neglect
+of the other, on the very beginning of our acquaintance, I have courted
+prepossession and ignorance, and driven reason away, where either were
+concerned. Till this moment I never knew myself.”
+
+From herself to Jane--from Jane to Bingley, her thoughts were in a line
+which soon brought to her recollection that Mr. Darcy’s explanation
+_there_ had appeared very insufficient, and she read it again. Widely
+different was the effect of a second perusal. How could she deny that
+credit to his assertions in one instance, which she had been obliged to
+give in the other? He declared himself to be totally unsuspicious of her
+sister’s attachment; and she could not help remembering what Charlotte’s
+opinion had always been. Neither could she deny the justice of his
+description of Jane. She felt that Jane’s feelings, though fervent, were
+little displayed, and that there was a constant complacency in her air
+and manner not often united with great sensibility.
+
+When she came to that part of the letter in which her family were
+mentioned in terms of such mortifying, yet merited reproach, her sense
+of shame was severe. The justice of the charge struck her too forcibly
+for denial, and the circumstances to which he particularly alluded as
+having passed at the Netherfield ball, and as confirming all his first
+disapprobation, could not have made a stronger impression on his mind
+than on hers.
+
+The compliment to herself and her sister was not unfelt. It soothed,
+but it could not console her for the contempt which had thus been
+self-attracted by the rest of her family; and as she considered
+that Jane’s disappointment had in fact been the work of her nearest
+relations, and reflected how materially the credit of both must be hurt
+by such impropriety of conduct, she felt depressed beyond anything she
+had ever known before.
+
+After wandering along the lane for two hours, giving way to every
+variety of thought--re-considering events, determining probabilities,
+and reconciling herself, as well as she could, to a change so sudden and
+so important, fatigue, and a recollection of her long absence, made
+her at length return home; and she entered the house with the wish
+of appearing cheerful as usual, and the resolution of repressing such
+reflections as must make her unfit for conversation.
+
+She was immediately told that the two gentlemen from Rosings had each
+called during her absence; Mr. Darcy, only for a few minutes, to take
+leave--but that Colonel Fitzwilliam had been sitting with them at least
+an hour, hoping for her return, and almost resolving to walk after her
+till she could be found. Elizabeth could but just _affect_ concern
+in missing him; she really rejoiced at it. Colonel Fitzwilliam was no
+longer an object; she could think only of her letter.
+
+
+
+Chapter 37
+
+
+The two gentlemen left Rosings the next morning, and Mr. Collins having
+been in waiting near the lodges, to make them his parting obeisance, was
+able to bring home the pleasing intelligence, of their appearing in very
+good health, and in as tolerable spirits as could be expected, after the
+melancholy scene so lately gone through at Rosings. To Rosings he then
+hastened, to console Lady Catherine and her daughter; and on his return
+brought back, with great satisfaction, a message from her ladyship,
+importing that she felt herself so dull as to make her very desirous of
+having them all to dine with her.
+
+Elizabeth could not see Lady Catherine without recollecting that, had
+she chosen it, she might by this time have been presented to her as
+her future niece; nor could she think, without a smile, of what her
+ladyship’s indignation would have been. “What would she have said? how
+would she have behaved?” were questions with which she amused herself.
+
+Their first subject was the diminution of the Rosings party. “I assure
+you, I feel it exceedingly,” said Lady Catherine; “I believe no one
+feels the loss of friends so much as I do. But I am particularly
+attached to these young men, and know them to be so much attached to
+me! They were excessively sorry to go! But so they always are. The
+dear Colonel rallied his spirits tolerably till just at last; but Darcy
+seemed to feel it most acutely, more, I think, than last year. His
+attachment to Rosings certainly increases.”
+
+Mr. Collins had a compliment, and an allusion to throw in here, which
+were kindly smiled on by the mother and daughter.
+
+Lady Catherine observed, after dinner, that Miss Bennet seemed out of
+spirits, and immediately accounting for it by herself, by supposing that
+she did not like to go home again so soon, she added:
+
+“But if that is the case, you must write to your mother and beg that
+you may stay a little longer. Mrs. Collins will be very glad of your
+company, I am sure.”
+
+“I am much obliged to your ladyship for your kind invitation,” replied
+Elizabeth, “but it is not in my power to accept it. I must be in town
+next Saturday.”
+
+“Why, at that rate, you will have been here only six weeks. I expected
+you to stay two months. I told Mrs. Collins so before you came. There
+can be no occasion for your going so soon. Mrs. Bennet could certainly
+spare you for another fortnight.”
+
+“But my father cannot. He wrote last week to hurry my return.”
+
+“Oh! your father of course may spare you, if your mother can. Daughters
+are never of so much consequence to a father. And if you will stay
+another _month_ complete, it will be in my power to take one of you as
+far as London, for I am going there early in June, for a week; and as
+Dawson does not object to the barouche-box, there will be very good room
+for one of you--and indeed, if the weather should happen to be cool, I
+should not object to taking you both, as you are neither of you large.”
+
+“You are all kindness, madam; but I believe we must abide by our
+original plan.”
+
+Lady Catherine seemed resigned. “Mrs. Collins, you must send a servant
+with them. You know I always speak my mind, and I cannot bear the idea
+of two young women travelling post by themselves. It is highly improper.
+You must contrive to send somebody. I have the greatest dislike in
+the world to that sort of thing. Young women should always be properly
+guarded and attended, according to their situation in life. When my
+niece Georgiana went to Ramsgate last summer, I made a point of her
+having two men-servants go with her. Miss Darcy, the daughter of
+Mr. Darcy, of Pemberley, and Lady Anne, could not have appeared with
+propriety in a different manner. I am excessively attentive to all those
+things. You must send John with the young ladies, Mrs. Collins. I
+am glad it occurred to me to mention it; for it would really be
+discreditable to _you_ to let them go alone.”
+
+“My uncle is to send a servant for us.”
+
+“Oh! Your uncle! He keeps a man-servant, does he? I am very glad you
+have somebody who thinks of these things. Where shall you change horses?
+Oh! Bromley, of course. If you mention my name at the Bell, you will be
+attended to.”
+
+Lady Catherine had many other questions to ask respecting their journey,
+and as she did not answer them all herself, attention was necessary,
+which Elizabeth believed to be lucky for her; or, with a mind so
+occupied, she might have forgotten where she was. Reflection must be
+reserved for solitary hours; whenever she was alone, she gave way to it
+as the greatest relief; and not a day went by without a solitary
+walk, in which she might indulge in all the delight of unpleasant
+recollections.
+
+Mr. Darcy’s letter she was in a fair way of soon knowing by heart. She
+studied every sentence; and her feelings towards its writer were at
+times widely different. When she remembered the style of his address,
+she was still full of indignation; but when she considered how unjustly
+she had condemned and upbraided him, her anger was turned against
+herself; and his disappointed feelings became the object of compassion.
+His attachment excited gratitude, his general character respect; but she
+could not approve him; nor could she for a moment repent her refusal,
+or feel the slightest inclination ever to see him again. In her own past
+behaviour, there was a constant source of vexation and regret; and in
+the unhappy defects of her family, a subject of yet heavier chagrin.
+They were hopeless of remedy. Her father, contented with laughing at
+them, would never exert himself to restrain the wild giddiness of his
+youngest daughters; and her mother, with manners so far from right
+herself, was entirely insensible of the evil. Elizabeth had frequently
+united with Jane in an endeavour to check the imprudence of Catherine
+and Lydia; but while they were supported by their mother’s indulgence,
+what chance could there be of improvement? Catherine, weak-spirited,
+irritable, and completely under Lydia’s guidance, had been always
+affronted by their advice; and Lydia, self-willed and careless, would
+scarcely give them a hearing. They were ignorant, idle, and vain. While
+there was an officer in Meryton, they would flirt with him; and while
+Meryton was within a walk of Longbourn, they would be going there
+forever.
+
+Anxiety on Jane’s behalf was another prevailing concern; and Mr. Darcy’s
+explanation, by restoring Bingley to all her former good opinion,
+heightened the sense of what Jane had lost. His affection was proved
+to have been sincere, and his conduct cleared of all blame, unless any
+could attach to the implicitness of his confidence in his friend. How
+grievous then was the thought that, of a situation so desirable in every
+respect, so replete with advantage, so promising for happiness, Jane had
+been deprived, by the folly and indecorum of her own family!
+
+When to these recollections was added the development of Wickham’s
+character, it may be easily believed that the happy spirits which had
+seldom been depressed before, were now so much affected as to make it
+almost impossible for her to appear tolerably cheerful.
+
+Their engagements at Rosings were as frequent during the last week of
+her stay as they had been at first. The very last evening was spent
+there; and her ladyship again inquired minutely into the particulars of
+their journey, gave them directions as to the best method of packing,
+and was so urgent on the necessity of placing gowns in the only right
+way, that Maria thought herself obliged, on her return, to undo all the
+work of the morning, and pack her trunk afresh.
+
+When they parted, Lady Catherine, with great condescension, wished them
+a good journey, and invited them to come to Hunsford again next year;
+and Miss de Bourgh exerted herself so far as to curtsey and hold out her
+hand to both.
+
+
+
+Chapter 38
+
+
+On Saturday morning Elizabeth and Mr. Collins met for breakfast a few
+minutes before the others appeared; and he took the opportunity of
+paying the parting civilities which he deemed indispensably necessary.
+
+“I know not, Miss Elizabeth,” said he, “whether Mrs. Collins has yet
+expressed her sense of your kindness in coming to us; but I am very
+certain you will not leave the house without receiving her thanks for
+it. The favour of your company has been much felt, I assure you. We
+know how little there is to tempt anyone to our humble abode. Our plain
+manner of living, our small rooms and few domestics, and the little we
+see of the world, must make Hunsford extremely dull to a young lady like
+yourself; but I hope you will believe us grateful for the condescension,
+and that we have done everything in our power to prevent your spending
+your time unpleasantly.”
+
+Elizabeth was eager with her thanks and assurances of happiness. She
+had spent six weeks with great enjoyment; and the pleasure of being with
+Charlotte, and the kind attentions she had received, must make _her_
+feel the obliged. Mr. Collins was gratified, and with a more smiling
+solemnity replied:
+
+“It gives me great pleasure to hear that you have passed your time not
+disagreeably. We have certainly done our best; and most fortunately
+having it in our power to introduce you to very superior society, and,
+from our connection with Rosings, the frequent means of varying the
+humble home scene, I think we may flatter ourselves that your Hunsford
+visit cannot have been entirely irksome. Our situation with regard to
+Lady Catherine’s family is indeed the sort of extraordinary advantage
+and blessing which few can boast. You see on what a footing we are. You
+see how continually we are engaged there. In truth I must acknowledge
+that, with all the disadvantages of this humble parsonage, I should
+not think anyone abiding in it an object of compassion, while they are
+sharers of our intimacy at Rosings.”
+
+Words were insufficient for the elevation of his feelings; and he was
+obliged to walk about the room, while Elizabeth tried to unite civility
+and truth in a few short sentences.
+
+“You may, in fact, carry a very favourable report of us into
+Hertfordshire, my dear cousin. I flatter myself at least that you will
+be able to do so. Lady Catherine’s great attentions to Mrs. Collins you
+have been a daily witness of; and altogether I trust it does not appear
+that your friend has drawn an unfortunate--but on this point it will be
+as well to be silent. Only let me assure you, my dear Miss Elizabeth,
+that I can from my heart most cordially wish you equal felicity in
+marriage. My dear Charlotte and I have but one mind and one way of
+thinking. There is in everything a most remarkable resemblance of
+character and ideas between us. We seem to have been designed for each
+other.”
+
+Elizabeth could safely say that it was a great happiness where that was
+the case, and with equal sincerity could add, that she firmly believed
+and rejoiced in his domestic comforts. She was not sorry, however, to
+have the recital of them interrupted by the lady from whom they sprang.
+Poor Charlotte! it was melancholy to leave her to such society! But she
+had chosen it with her eyes open; and though evidently regretting that
+her visitors were to go, she did not seem to ask for compassion. Her
+home and her housekeeping, her parish and her poultry, and all their
+dependent concerns, had not yet lost their charms.
+
+At length the chaise arrived, the trunks were fastened on, the parcels
+placed within, and it was pronounced to be ready. After an affectionate
+parting between the friends, Elizabeth was attended to the carriage by
+Mr. Collins, and as they walked down the garden he was commissioning her
+with his best respects to all her family, not forgetting his thanks
+for the kindness he had received at Longbourn in the winter, and his
+compliments to Mr. and Mrs. Gardiner, though unknown. He then handed her
+in, Maria followed, and the door was on the point of being closed,
+when he suddenly reminded them, with some consternation, that they had
+hitherto forgotten to leave any message for the ladies at Rosings.
+
+“But,” he added, “you will of course wish to have your humble respects
+delivered to them, with your grateful thanks for their kindness to you
+while you have been here.”
+
+Elizabeth made no objection; the door was then allowed to be shut, and
+the carriage drove off.
+
+“Good gracious!” cried Maria, after a few minutes’ silence, “it seems
+but a day or two since we first came! and yet how many things have
+happened!”
+
+“A great many indeed,” said her companion with a sigh.
+
+“We have dined nine times at Rosings, besides drinking tea there twice!
+How much I shall have to tell!”
+
+Elizabeth added privately, “And how much I shall have to conceal!”
+
+Their journey was performed without much conversation, or any alarm; and
+within four hours of their leaving Hunsford they reached Mr. Gardiner’s
+house, where they were to remain a few days.
+
+Jane looked well, and Elizabeth had little opportunity of studying her
+spirits, amidst the various engagements which the kindness of her
+aunt had reserved for them. But Jane was to go home with her, and at
+Longbourn there would be leisure enough for observation.
+
+It was not without an effort, meanwhile, that she could wait even for
+Longbourn, before she told her sister of Mr. Darcy’s proposals. To know
+that she had the power of revealing what would so exceedingly astonish
+Jane, and must, at the same time, so highly gratify whatever of her own
+vanity she had not yet been able to reason away, was such a temptation
+to openness as nothing could have conquered but the state of indecision
+in which she remained as to the extent of what she should communicate;
+and her fear, if she once entered on the subject, of being hurried
+into repeating something of Bingley which might only grieve her sister
+further.
+
+
+
+Chapter 39
+
+
+It was the second week in May, in which the three young ladies set out
+together from Gracechurch Street for the town of ----, in Hertfordshire;
+and, as they drew near the appointed inn where Mr. Bennet’s carriage
+was to meet them, they quickly perceived, in token of the coachman’s
+punctuality, both Kitty and Lydia looking out of a dining-room up stairs.
+These two girls had been above an hour in the place, happily employed
+in visiting an opposite milliner, watching the sentinel on guard, and
+dressing a salad and cucumber.
+
+After welcoming their sisters, they triumphantly displayed a table set
+out with such cold meat as an inn larder usually affords, exclaiming,
+“Is not this nice? Is not this an agreeable surprise?”
+
+“And we mean to treat you all,” added Lydia, “but you must lend us the
+money, for we have just spent ours at the shop out there.” Then, showing
+her purchases--“Look here, I have bought this bonnet. I do not think
+it is very pretty; but I thought I might as well buy it as not. I shall
+pull it to pieces as soon as I get home, and see if I can make it up any
+better.”
+
+And when her sisters abused it as ugly, she added, with perfect
+unconcern, “Oh! but there were two or three much uglier in the shop; and
+when I have bought some prettier-coloured satin to trim it with fresh, I
+think it will be very tolerable. Besides, it will not much signify what
+one wears this summer, after the ----shire have left Meryton, and they
+are going in a fortnight.”
+
+“Are they indeed!” cried Elizabeth, with the greatest satisfaction.
+
+“They are going to be encamped near Brighton; and I do so want papa to
+take us all there for the summer! It would be such a delicious scheme;
+and I dare say would hardly cost anything at all. Mamma would like to
+go too of all things! Only think what a miserable summer else we shall
+have!”
+
+“Yes,” thought Elizabeth, “_that_ would be a delightful scheme indeed,
+and completely do for us at once. Good Heaven! Brighton, and a whole
+campful of soldiers, to us, who have been overset already by one poor
+regiment of militia, and the monthly balls of Meryton!”
+
+“Now I have got some news for you,” said Lydia, as they sat down at
+table. “What do you think? It is excellent news--capital news--and about
+a certain person we all like!”
+
+Jane and Elizabeth looked at each other, and the waiter was told he need
+not stay. Lydia laughed, and said:
+
+“Aye, that is just like your formality and discretion. You thought the
+waiter must not hear, as if he cared! I dare say he often hears worse
+things said than I am going to say. But he is an ugly fellow! I am glad
+he is gone. I never saw such a long chin in my life. Well, but now for
+my news; it is about dear Wickham; too good for the waiter, is it not?
+There is no danger of Wickham’s marrying Mary King. There’s for you! She
+is gone down to her uncle at Liverpool: gone to stay. Wickham is safe.”
+
+“And Mary King is safe!” added Elizabeth; “safe from a connection
+imprudent as to fortune.”
+
+“She is a great fool for going away, if she liked him.”
+
+“But I hope there is no strong attachment on either side,” said Jane.
+
+“I am sure there is not on _his_. I will answer for it, he never cared
+three straws about her--who could about such a nasty little freckled
+thing?”
+
+Elizabeth was shocked to think that, however incapable of such
+coarseness of _expression_ herself, the coarseness of the _sentiment_
+was little other than her own breast had harboured and fancied liberal!
+
+As soon as all had ate, and the elder ones paid, the carriage was
+ordered; and after some contrivance, the whole party, with all their
+boxes, work-bags, and parcels, and the unwelcome addition of Kitty’s and
+Lydia’s purchases, were seated in it.
+
+“How nicely we are all crammed in,” cried Lydia. “I am glad I bought my
+bonnet, if it is only for the fun of having another bandbox! Well, now
+let us be quite comfortable and snug, and talk and laugh all the way
+home. And in the first place, let us hear what has happened to you all
+since you went away. Have you seen any pleasant men? Have you had any
+flirting? I was in great hopes that one of you would have got a husband
+before you came back. Jane will be quite an old maid soon, I declare.
+She is almost three-and-twenty! Lord, how ashamed I should be of not
+being married before three-and-twenty! My aunt Phillips wants you so to
+get husbands, you can’t think. She says Lizzy had better have taken Mr.
+Collins; but _I_ do not think there would have been any fun in it. Lord!
+how I should like to be married before any of you; and then I would
+chaperon you about to all the balls. Dear me! we had such a good piece
+of fun the other day at Colonel Forster’s. Kitty and me were to spend
+the day there, and Mrs. Forster promised to have a little dance in the
+evening; (by the bye, Mrs. Forster and me are _such_ friends!) and so
+she asked the two Harringtons to come, but Harriet was ill, and so Pen
+was forced to come by herself; and then, what do you think we did? We
+dressed up Chamberlayne in woman’s clothes on purpose to pass for a
+lady, only think what fun! Not a soul knew of it, but Colonel and Mrs.
+Forster, and Kitty and me, except my aunt, for we were forced to borrow
+one of her gowns; and you cannot imagine how well he looked! When Denny,
+and Wickham, and Pratt, and two or three more of the men came in, they
+did not know him in the least. Lord! how I laughed! and so did Mrs.
+Forster. I thought I should have died. And _that_ made the men suspect
+something, and then they soon found out what was the matter.”
+
+With such kinds of histories of their parties and good jokes, did
+Lydia, assisted by Kitty’s hints and additions, endeavour to amuse her
+companions all the way to Longbourn. Elizabeth listened as little as she
+could, but there was no escaping the frequent mention of Wickham’s name.
+
+Their reception at home was most kind. Mrs. Bennet rejoiced to see Jane
+in undiminished beauty; and more than once during dinner did Mr. Bennet
+say voluntarily to Elizabeth:
+
+“I am glad you are come back, Lizzy.”
+
+Their party in the dining-room was large, for almost all the Lucases
+came to meet Maria and hear the news; and various were the subjects that
+occupied them: Lady Lucas was inquiring of Maria, after the welfare and
+poultry of her eldest daughter; Mrs. Bennet was doubly engaged, on one
+hand collecting an account of the present fashions from Jane, who sat
+some way below her, and, on the other, retailing them all to the younger
+Lucases; and Lydia, in a voice rather louder than any other person’s,
+was enumerating the various pleasures of the morning to anybody who
+would hear her.
+
+“Oh! Mary,” said she, “I wish you had gone with us, for we had such fun!
+As we went along, Kitty and I drew up the blinds, and pretended there
+was nobody in the coach; and I should have gone so all the way, if Kitty
+had not been sick; and when we got to the George, I do think we behaved
+very handsomely, for we treated the other three with the nicest cold
+luncheon in the world, and if you would have gone, we would have treated
+you too. And then when we came away it was such fun! I thought we never
+should have got into the coach. I was ready to die of laughter. And then
+we were so merry all the way home! we talked and laughed so loud, that
+anybody might have heard us ten miles off!”
+
+To this Mary very gravely replied, “Far be it from me, my dear sister,
+to depreciate such pleasures! They would doubtless be congenial with the
+generality of female minds. But I confess they would have no charms for
+_me_--I should infinitely prefer a book.”
+
+But of this answer Lydia heard not a word. She seldom listened to
+anybody for more than half a minute, and never attended to Mary at all.
+
+In the afternoon Lydia was urgent with the rest of the girls to walk
+to Meryton, and to see how everybody went on; but Elizabeth steadily
+opposed the scheme. It should not be said that the Miss Bennets could
+not be at home half a day before they were in pursuit of the officers.
+There was another reason too for her opposition. She dreaded seeing Mr.
+Wickham again, and was resolved to avoid it as long as possible. The
+comfort to _her_ of the regiment’s approaching removal was indeed beyond
+expression. In a fortnight they were to go--and once gone, she hoped
+there could be nothing more to plague her on his account.
+
+She had not been many hours at home before she found that the Brighton
+scheme, of which Lydia had given them a hint at the inn, was under
+frequent discussion between her parents. Elizabeth saw directly that her
+father had not the smallest intention of yielding; but his answers were
+at the same time so vague and equivocal, that her mother, though often
+disheartened, had never yet despaired of succeeding at last.
+
+
+
+Chapter 40
+
+
+Elizabeth’s impatience to acquaint Jane with what had happened could
+no longer be overcome; and at length, resolving to suppress every
+particular in which her sister was concerned, and preparing her to be
+surprised, she related to her the next morning the chief of the scene
+between Mr. Darcy and herself.
+
+Miss Bennet’s astonishment was soon lessened by the strong sisterly
+partiality which made any admiration of Elizabeth appear perfectly
+natural; and all surprise was shortly lost in other feelings. She was
+sorry that Mr. Darcy should have delivered his sentiments in a manner so
+little suited to recommend them; but still more was she grieved for the
+unhappiness which her sister’s refusal must have given him.
+
+“His being so sure of succeeding was wrong,” said she, “and certainly
+ought not to have appeared; but consider how much it must increase his
+disappointment!”
+
+“Indeed,” replied Elizabeth, “I am heartily sorry for him; but he has
+other feelings, which will probably soon drive away his regard for me.
+You do not blame me, however, for refusing him?”
+
+“Blame you! Oh, no.”
+
+“But you blame me for having spoken so warmly of Wickham?”
+
+“No--I do not know that you were wrong in saying what you did.”
+
+“But you _will_ know it, when I tell you what happened the very next
+day.”
+
+She then spoke of the letter, repeating the whole of its contents as far
+as they concerned George Wickham. What a stroke was this for poor Jane!
+who would willingly have gone through the world without believing that
+so much wickedness existed in the whole race of mankind, as was here
+collected in one individual. Nor was Darcy’s vindication, though
+grateful to her feelings, capable of consoling her for such discovery.
+Most earnestly did she labour to prove the probability of error, and
+seek to clear the one without involving the other.
+
+“This will not do,” said Elizabeth; “you never will be able to make both
+of them good for anything. Take your choice, but you must be satisfied
+with only one. There is but such a quantity of merit between them; just
+enough to make one good sort of man; and of late it has been shifting
+about pretty much. For my part, I am inclined to believe it all Darcy’s;
+but you shall do as you choose.”
+
+It was some time, however, before a smile could be extorted from Jane.
+
+“I do not know when I have been more shocked,” said she. “Wickham so
+very bad! It is almost past belief. And poor Mr. Darcy! Dear Lizzy, only
+consider what he must have suffered. Such a disappointment! and with the
+knowledge of your ill opinion, too! and having to relate such a thing
+of his sister! It is really too distressing. I am sure you must feel it
+so.”
+
+“Oh! no, my regret and compassion are all done away by seeing you so
+full of both. I know you will do him such ample justice, that I am
+growing every moment more unconcerned and indifferent. Your profusion
+makes me saving; and if you lament over him much longer, my heart will
+be as light as a feather.”
+
+“Poor Wickham! there is such an expression of goodness in his
+countenance! such an openness and gentleness in his manner!”
+
+“There certainly was some great mismanagement in the education of those
+two young men. One has got all the goodness, and the other all the
+appearance of it.”
+
+“I never thought Mr. Darcy so deficient in the _appearance_ of it as you
+used to do.”
+
+“And yet I meant to be uncommonly clever in taking so decided a dislike
+to him, without any reason. It is such a spur to one’s genius, such an
+opening for wit, to have a dislike of that kind. One may be continually
+abusive without saying anything just; but one cannot always be laughing
+at a man without now and then stumbling on something witty.”
+
+“Lizzy, when you first read that letter, I am sure you could not treat
+the matter as you do now.”
+
+“Indeed, I could not. I was uncomfortable enough, I may say unhappy. And
+with no one to speak to about what I felt, no Jane to comfort me and say
+that I had not been so very weak and vain and nonsensical as I knew I
+had! Oh! how I wanted you!”
+
+“How unfortunate that you should have used such very strong expressions
+in speaking of Wickham to Mr. Darcy, for now they _do_ appear wholly
+undeserved.”
+
+“Certainly. But the misfortune of speaking with bitterness is a most
+natural consequence of the prejudices I had been encouraging. There
+is one point on which I want your advice. I want to be told whether I
+ought, or ought not, to make our acquaintances in general understand
+Wickham’s character.”
+
+Miss Bennet paused a little, and then replied, “Surely there can be no
+occasion for exposing him so dreadfully. What is your opinion?”
+
+“That it ought not to be attempted. Mr. Darcy has not authorised me
+to make his communication public. On the contrary, every particular
+relative to his sister was meant to be kept as much as possible to
+myself; and if I endeavour to undeceive people as to the rest of his
+conduct, who will believe me? The general prejudice against Mr. Darcy
+is so violent, that it would be the death of half the good people in
+Meryton to attempt to place him in an amiable light. I am not equal
+to it. Wickham will soon be gone; and therefore it will not signify to
+anyone here what he really is. Some time hence it will be all found out,
+and then we may laugh at their stupidity in not knowing it before. At
+present I will say nothing about it.”
+
+“You are quite right. To have his errors made public might ruin him for
+ever. He is now, perhaps, sorry for what he has done, and anxious to
+re-establish a character. We must not make him desperate.”
+
+The tumult of Elizabeth’s mind was allayed by this conversation. She had
+got rid of two of the secrets which had weighed on her for a fortnight,
+and was certain of a willing listener in Jane, whenever she might wish
+to talk again of either. But there was still something lurking behind,
+of which prudence forbade the disclosure. She dared not relate the other
+half of Mr. Darcy’s letter, nor explain to her sister how sincerely she
+had been valued by her friend. Here was knowledge in which no one
+could partake; and she was sensible that nothing less than a perfect
+understanding between the parties could justify her in throwing off
+this last encumbrance of mystery. “And then,” said she, “if that very
+improbable event should ever take place, I shall merely be able to
+tell what Bingley may tell in a much more agreeable manner himself. The
+liberty of communication cannot be mine till it has lost all its value!”
+
+She was now, on being settled at home, at leisure to observe the real
+state of her sister’s spirits. Jane was not happy. She still cherished a
+very tender affection for Bingley. Having never even fancied herself
+in love before, her regard had all the warmth of first attachment,
+and, from her age and disposition, greater steadiness than most first
+attachments often boast; and so fervently did she value his remembrance,
+and prefer him to every other man, that all her good sense, and all her
+attention to the feelings of her friends, were requisite to check the
+indulgence of those regrets which must have been injurious to her own
+health and their tranquillity.
+
+“Well, Lizzy,” said Mrs. Bennet one day, “what is your opinion _now_ of
+this sad business of Jane’s? For my part, I am determined never to speak
+of it again to anybody. I told my sister Phillips so the other day. But
+I cannot find out that Jane saw anything of him in London. Well, he is
+a very undeserving young man--and I do not suppose there’s the least
+chance in the world of her ever getting him now. There is no talk of
+his coming to Netherfield again in the summer; and I have inquired of
+everybody, too, who is likely to know.”
+
+“I do not believe he will ever live at Netherfield any more.”
+
+“Oh well! it is just as he chooses. Nobody wants him to come. Though I
+shall always say he used my daughter extremely ill; and if I was her, I
+would not have put up with it. Well, my comfort is, I am sure Jane will
+die of a broken heart; and then he will be sorry for what he has done.”
+
+But as Elizabeth could not receive comfort from any such expectation,
+she made no answer.
+
+“Well, Lizzy,” continued her mother, soon afterwards, “and so the
+Collinses live very comfortable, do they? Well, well, I only hope
+it will last. And what sort of table do they keep? Charlotte is an
+excellent manager, I dare say. If she is half as sharp as her
+mother, she is saving enough. There is nothing extravagant in _their_
+housekeeping, I dare say.”
+
+“No, nothing at all.”
+
+“A great deal of good management, depend upon it. Yes, yes, _they_ will
+take care not to outrun their income. _They_ will never be distressed
+for money. Well, much good may it do them! And so, I suppose, they often
+talk of having Longbourn when your father is dead. They look upon it as
+quite their own, I dare say, whenever that happens.”
+
+“It was a subject which they could not mention before me.”
+
+“No; it would have been strange if they had; but I make no doubt they
+often talk of it between themselves. Well, if they can be easy with an
+estate that is not lawfully their own, so much the better. I should be
+ashamed of having one that was only entailed on me.”
+
+
+
+Chapter 41
+
+
+The first week of their return was soon gone. The second began. It was
+the last of the regiment’s stay in Meryton, and all the young ladies
+in the neighbourhood were drooping apace. The dejection was almost
+universal. The elder Miss Bennets alone were still able to eat, drink,
+and sleep, and pursue the usual course of their employments. Very
+frequently were they reproached for this insensibility by Kitty and
+Lydia, whose own misery was extreme, and who could not comprehend such
+hard-heartedness in any of the family.
+
+“Good Heaven! what is to become of us? What are we to do?” would they
+often exclaim in the bitterness of woe. “How can you be smiling so,
+Lizzy?”
+
+Their affectionate mother shared all their grief; she remembered what
+she had herself endured on a similar occasion, five-and-twenty years
+ago.
+
+“I am sure,” said she, “I cried for two days together when Colonel
+Miller’s regiment went away. I thought I should have broken my heart.”
+
+“I am sure I shall break _mine_,” said Lydia.
+
+“If one could but go to Brighton!” observed Mrs. Bennet.
+
+“Oh, yes!--if one could but go to Brighton! But papa is so
+disagreeable.”
+
+“A little sea-bathing would set me up forever.”
+
+“And my aunt Phillips is sure it would do _me_ a great deal of good,”
+ added Kitty.
+
+Such were the kind of lamentations resounding perpetually through
+Longbourn House. Elizabeth tried to be diverted by them; but all sense
+of pleasure was lost in shame. She felt anew the justice of Mr. Darcy’s
+objections; and never had she been so much disposed to pardon his
+interference in the views of his friend.
+
+But the gloom of Lydia’s prospect was shortly cleared away; for she
+received an invitation from Mrs. Forster, the wife of the colonel of
+the regiment, to accompany her to Brighton. This invaluable friend was a
+very young woman, and very lately married. A resemblance in good humour
+and good spirits had recommended her and Lydia to each other, and out of
+their _three_ months’ acquaintance they had been intimate _two_.
+
+The rapture of Lydia on this occasion, her adoration of Mrs. Forster,
+the delight of Mrs. Bennet, and the mortification of Kitty, are scarcely
+to be described. Wholly inattentive to her sister’s feelings, Lydia
+flew about the house in restless ecstasy, calling for everyone’s
+congratulations, and laughing and talking with more violence than ever;
+whilst the luckless Kitty continued in the parlour repined at her fate
+in terms as unreasonable as her accent was peevish.
+
+“I cannot see why Mrs. Forster should not ask _me_ as well as Lydia,”
+ said she, “Though I am _not_ her particular friend. I have just as much
+right to be asked as she has, and more too, for I am two years older.”
+
+In vain did Elizabeth attempt to make her reasonable, and Jane to make
+her resigned. As for Elizabeth herself, this invitation was so far from
+exciting in her the same feelings as in her mother and Lydia, that she
+considered it as the death warrant of all possibility of common sense
+for the latter; and detestable as such a step must make her were it
+known, she could not help secretly advising her father not to let her
+go. She represented to him all the improprieties of Lydia’s general
+behaviour, the little advantage she could derive from the friendship of
+such a woman as Mrs. Forster, and the probability of her being yet more
+imprudent with such a companion at Brighton, where the temptations must
+be greater than at home. He heard her attentively, and then said:
+
+“Lydia will never be easy until she has exposed herself in some public
+place or other, and we can never expect her to do it with so
+little expense or inconvenience to her family as under the present
+circumstances.”
+
+“If you were aware,” said Elizabeth, “of the very great disadvantage to
+us all which must arise from the public notice of Lydia’s unguarded and
+imprudent manner--nay, which has already arisen from it, I am sure you
+would judge differently in the affair.”
+
+“Already arisen?” repeated Mr. Bennet. “What, has she frightened away
+some of your lovers? Poor little Lizzy! But do not be cast down. Such
+squeamish youths as cannot bear to be connected with a little absurdity
+are not worth a regret. Come, let me see the list of pitiful fellows who
+have been kept aloof by Lydia’s folly.”
+
+“Indeed you are mistaken. I have no such injuries to resent. It is not
+of particular, but of general evils, which I am now complaining. Our
+importance, our respectability in the world must be affected by the
+wild volatility, the assurance and disdain of all restraint which mark
+Lydia’s character. Excuse me, for I must speak plainly. If you, my dear
+father, will not take the trouble of checking her exuberant spirits, and
+of teaching her that her present pursuits are not to be the business of
+her life, she will soon be beyond the reach of amendment. Her character
+will be fixed, and she will, at sixteen, be the most determined flirt
+that ever made herself or her family ridiculous; a flirt, too, in the
+worst and meanest degree of flirtation; without any attraction beyond
+youth and a tolerable person; and, from the ignorance and emptiness
+of her mind, wholly unable to ward off any portion of that universal
+contempt which her rage for admiration will excite. In this danger
+Kitty also is comprehended. She will follow wherever Lydia leads. Vain,
+ignorant, idle, and absolutely uncontrolled! Oh! my dear father, can you
+suppose it possible that they will not be censured and despised wherever
+they are known, and that their sisters will not be often involved in the
+disgrace?”
+
+Mr. Bennet saw that her whole heart was in the subject, and
+affectionately taking her hand said in reply:
+
+“Do not make yourself uneasy, my love. Wherever you and Jane are known
+you must be respected and valued; and you will not appear to less
+advantage for having a couple of--or I may say, three--very silly
+sisters. We shall have no peace at Longbourn if Lydia does not go to
+Brighton. Let her go, then. Colonel Forster is a sensible man, and will
+keep her out of any real mischief; and she is luckily too poor to be an
+object of prey to anybody. At Brighton she will be of less importance
+even as a common flirt than she has been here. The officers will find
+women better worth their notice. Let us hope, therefore, that her being
+there may teach her her own insignificance. At any rate, she cannot grow
+many degrees worse, without authorising us to lock her up for the rest
+of her life.”
+
+With this answer Elizabeth was forced to be content; but her own opinion
+continued the same, and she left him disappointed and sorry. It was not
+in her nature, however, to increase her vexations by dwelling on
+them. She was confident of having performed her duty, and to fret
+over unavoidable evils, or augment them by anxiety, was no part of her
+disposition.
+
+Had Lydia and her mother known the substance of her conference with her
+father, their indignation would hardly have found expression in their
+united volubility. In Lydia’s imagination, a visit to Brighton comprised
+every possibility of earthly happiness. She saw, with the creative eye
+of fancy, the streets of that gay bathing-place covered with officers.
+She saw herself the object of attention, to tens and to scores of them
+at present unknown. She saw all the glories of the camp--its tents
+stretched forth in beauteous uniformity of lines, crowded with the young
+and the gay, and dazzling with scarlet; and, to complete the view, she
+saw herself seated beneath a tent, tenderly flirting with at least six
+officers at once.
+
+Had she known her sister sought to tear her from such prospects and such
+realities as these, what would have been her sensations? They could have
+been understood only by her mother, who might have felt nearly the same.
+Lydia’s going to Brighton was all that consoled her for her melancholy
+conviction of her husband’s never intending to go there himself.
+
+But they were entirely ignorant of what had passed; and their raptures
+continued, with little intermission, to the very day of Lydia’s leaving
+home.
+
+Elizabeth was now to see Mr. Wickham for the last time. Having been
+frequently in company with him since her return, agitation was pretty
+well over; the agitations of former partiality entirely so. She had even
+learnt to detect, in the very gentleness which had first delighted
+her, an affectation and a sameness to disgust and weary. In his present
+behaviour to herself, moreover, she had a fresh source of displeasure,
+for the inclination he soon testified of renewing those intentions which
+had marked the early part of their acquaintance could only serve, after
+what had since passed, to provoke her. She lost all concern for him in
+finding herself thus selected as the object of such idle and frivolous
+gallantry; and while she steadily repressed it, could not but feel the
+reproof contained in his believing, that however long, and for whatever
+cause, his attentions had been withdrawn, her vanity would be gratified,
+and her preference secured at any time by their renewal.
+
+On the very last day of the regiment’s remaining at Meryton, he dined,
+with other of the officers, at Longbourn; and so little was Elizabeth
+disposed to part from him in good humour, that on his making some
+inquiry as to the manner in which her time had passed at Hunsford, she
+mentioned Colonel Fitzwilliam’s and Mr. Darcy’s having both spent three
+weeks at Rosings, and asked him, if he was acquainted with the former.
+
+He looked surprised, displeased, alarmed; but with a moment’s
+recollection and a returning smile, replied, that he had formerly seen
+him often; and, after observing that he was a very gentlemanlike man,
+asked her how she had liked him. Her answer was warmly in his favour.
+With an air of indifference he soon afterwards added:
+
+“How long did you say he was at Rosings?”
+
+“Nearly three weeks.”
+
+“And you saw him frequently?”
+
+“Yes, almost every day.”
+
+“His manners are very different from his cousin’s.”
+
+“Yes, very different. But I think Mr. Darcy improves upon acquaintance.”
+
+“Indeed!” cried Mr. Wickham with a look which did not escape her. “And
+pray, may I ask?--” But checking himself, he added, in a gayer tone, “Is
+it in address that he improves? Has he deigned to add aught of civility
+to his ordinary style?--for I dare not hope,” he continued in a lower
+and more serious tone, “that he is improved in essentials.”
+
+“Oh, no!” said Elizabeth. “In essentials, I believe, he is very much
+what he ever was.”
+
+While she spoke, Wickham looked as if scarcely knowing whether to
+rejoice over her words, or to distrust their meaning. There was a
+something in her countenance which made him listen with an apprehensive
+and anxious attention, while she added:
+
+“When I said that he improved on acquaintance, I did not mean that
+his mind or his manners were in a state of improvement, but that, from
+knowing him better, his disposition was better understood.”
+
+Wickham’s alarm now appeared in a heightened complexion and agitated
+look; for a few minutes he was silent, till, shaking off his
+embarrassment, he turned to her again, and said in the gentlest of
+accents:
+
+“You, who so well know my feeling towards Mr. Darcy, will readily
+comprehend how sincerely I must rejoice that he is wise enough to assume
+even the _appearance_ of what is right. His pride, in that direction,
+may be of service, if not to himself, to many others, for it must only
+deter him from such foul misconduct as I have suffered by. I only
+fear that the sort of cautiousness to which you, I imagine, have been
+alluding, is merely adopted on his visits to his aunt, of whose good
+opinion and judgement he stands much in awe. His fear of her has always
+operated, I know, when they were together; and a good deal is to be
+imputed to his wish of forwarding the match with Miss de Bourgh, which I
+am certain he has very much at heart.”
+
+Elizabeth could not repress a smile at this, but she answered only by a
+slight inclination of the head. She saw that he wanted to engage her on
+the old subject of his grievances, and she was in no humour to indulge
+him. The rest of the evening passed with the _appearance_, on his
+side, of usual cheerfulness, but with no further attempt to distinguish
+Elizabeth; and they parted at last with mutual civility, and possibly a
+mutual desire of never meeting again.
+
+When the party broke up, Lydia returned with Mrs. Forster to Meryton,
+from whence they were to set out early the next morning. The separation
+between her and her family was rather noisy than pathetic. Kitty was the
+only one who shed tears; but she did weep from vexation and envy. Mrs.
+Bennet was diffuse in her good wishes for the felicity of her daughter,
+and impressive in her injunctions that she should not miss the
+opportunity of enjoying herself as much as possible--advice which
+there was every reason to believe would be well attended to; and in
+the clamorous happiness of Lydia herself in bidding farewell, the more
+gentle adieus of her sisters were uttered without being heard.
+
+
+
+Chapter 42
+
+
+Had Elizabeth’s opinion been all drawn from her own family, she could
+not have formed a very pleasing opinion of conjugal felicity or domestic
+comfort. Her father, captivated by youth and beauty, and that appearance
+of good humour which youth and beauty generally give, had married a
+woman whose weak understanding and illiberal mind had very early in
+their marriage put an end to all real affection for her. Respect,
+esteem, and confidence had vanished for ever; and all his views
+of domestic happiness were overthrown. But Mr. Bennet was not of
+a disposition to seek comfort for the disappointment which his own
+imprudence had brought on, in any of those pleasures which too often
+console the unfortunate for their folly or their vice. He was fond of
+the country and of books; and from these tastes had arisen his principal
+enjoyments. To his wife he was very little otherwise indebted, than as
+her ignorance and folly had contributed to his amusement. This is not
+the sort of happiness which a man would in general wish to owe to his
+wife; but where other powers of entertainment are wanting, the true
+philosopher will derive benefit from such as are given.
+
+Elizabeth, however, had never been blind to the impropriety of her
+father’s behaviour as a husband. She had always seen it with pain; but
+respecting his abilities, and grateful for his affectionate treatment of
+herself, she endeavoured to forget what she could not overlook, and to
+banish from her thoughts that continual breach of conjugal obligation
+and decorum which, in exposing his wife to the contempt of her own
+children, was so highly reprehensible. But she had never felt so
+strongly as now the disadvantages which must attend the children of so
+unsuitable a marriage, nor ever been so fully aware of the evils arising
+from so ill-judged a direction of talents; talents, which, rightly used,
+might at least have preserved the respectability of his daughters, even
+if incapable of enlarging the mind of his wife.
+
+When Elizabeth had rejoiced over Wickham’s departure she found little
+other cause for satisfaction in the loss of the regiment. Their parties
+abroad were less varied than before, and at home she had a mother and
+sister whose constant repinings at the dullness of everything around
+them threw a real gloom over their domestic circle; and, though Kitty
+might in time regain her natural degree of sense, since the disturbers
+of her brain were removed, her other sister, from whose disposition
+greater evil might be apprehended, was likely to be hardened in all
+her folly and assurance by a situation of such double danger as a
+watering-place and a camp. Upon the whole, therefore, she found, what
+has been sometimes found before, that an event to which she had been
+looking with impatient desire did not, in taking place, bring all the
+satisfaction she had promised herself. It was consequently necessary to
+name some other period for the commencement of actual felicity--to have
+some other point on which her wishes and hopes might be fixed, and by
+again enjoying the pleasure of anticipation, console herself for the
+present, and prepare for another disappointment. Her tour to the Lakes
+was now the object of her happiest thoughts; it was her best consolation
+for all the uncomfortable hours which the discontentedness of her mother
+and Kitty made inevitable; and could she have included Jane in the
+scheme, every part of it would have been perfect.
+
+“But it is fortunate,” thought she, “that I have something to wish for.
+Were the whole arrangement complete, my disappointment would be certain.
+But here, by carrying with me one ceaseless source of regret in my
+sister’s absence, I may reasonably hope to have all my expectations of
+pleasure realised. A scheme of which every part promises delight can
+never be successful; and general disappointment is only warded off by
+the defence of some little peculiar vexation.”
+
+When Lydia went away she promised to write very often and very minutely
+to her mother and Kitty; but her letters were always long expected, and
+always very short. Those to her mother contained little else than that
+they were just returned from the library, where such and such officers
+had attended them, and where she had seen such beautiful ornaments as
+made her quite wild; that she had a new gown, or a new parasol, which
+she would have described more fully, but was obliged to leave off in a
+violent hurry, as Mrs. Forster called her, and they were going off to
+the camp; and from her correspondence with her sister, there was still
+less to be learnt--for her letters to Kitty, though rather longer, were
+much too full of lines under the words to be made public.
+
+After the first fortnight or three weeks of her absence, health, good
+humour, and cheerfulness began to reappear at Longbourn. Everything wore
+a happier aspect. The families who had been in town for the winter came
+back again, and summer finery and summer engagements arose. Mrs. Bennet
+was restored to her usual querulous serenity; and, by the middle of
+June, Kitty was so much recovered as to be able to enter Meryton without
+tears; an event of such happy promise as to make Elizabeth hope that by
+the following Christmas she might be so tolerably reasonable as not to
+mention an officer above once a day, unless, by some cruel and malicious
+arrangement at the War Office, another regiment should be quartered in
+Meryton.
+
+The time fixed for the beginning of their northern tour was now fast
+approaching, and a fortnight only was wanting of it, when a letter
+arrived from Mrs. Gardiner, which at once delayed its commencement and
+curtailed its extent. Mr. Gardiner would be prevented by business from
+setting out till a fortnight later in July, and must be in London again
+within a month, and as that left too short a period for them to go so
+far, and see so much as they had proposed, or at least to see it with
+the leisure and comfort they had built on, they were obliged to give up
+the Lakes, and substitute a more contracted tour, and, according to the
+present plan, were to go no farther northwards than Derbyshire. In that
+county there was enough to be seen to occupy the chief of their three
+weeks; and to Mrs. Gardiner it had a peculiarly strong attraction. The
+town where she had formerly passed some years of her life, and where
+they were now to spend a few days, was probably as great an object of
+her curiosity as all the celebrated beauties of Matlock, Chatsworth,
+Dovedale, or the Peak.
+
+Elizabeth was excessively disappointed; she had set her heart on seeing
+the Lakes, and still thought there might have been time enough. But it
+was her business to be satisfied--and certainly her temper to be happy;
+and all was soon right again.
+
+With the mention of Derbyshire there were many ideas connected. It was
+impossible for her to see the word without thinking of Pemberley and its
+owner. “But surely,” said she, “I may enter his county with impunity,
+and rob it of a few petrified spars without his perceiving me.”
+
+The period of expectation was now doubled. Four weeks were to pass away
+before her uncle and aunt’s arrival. But they did pass away, and Mr.
+and Mrs. Gardiner, with their four children, did at length appear at
+Longbourn. The children, two girls of six and eight years old, and two
+younger boys, were to be left under the particular care of their
+cousin Jane, who was the general favourite, and whose steady sense and
+sweetness of temper exactly adapted her for attending to them in every
+way--teaching them, playing with them, and loving them.
+
+The Gardiners stayed only one night at Longbourn, and set off the
+next morning with Elizabeth in pursuit of novelty and amusement.
+One enjoyment was certain--that of suitableness of companions;
+a suitableness which comprehended health and temper to bear
+inconveniences--cheerfulness to enhance every pleasure--and affection
+and intelligence, which might supply it among themselves if there were
+disappointments abroad.
+
+It is not the object of this work to give a description of Derbyshire,
+nor of any of the remarkable places through which their route thither
+lay; Oxford, Blenheim, Warwick, Kenilworth, Birmingham, etc. are
+sufficiently known. A small part of Derbyshire is all the present
+concern. To the little town of Lambton, the scene of Mrs. Gardiner’s
+former residence, and where she had lately learned some acquaintance
+still remained, they bent their steps, after having seen all the
+principal wonders of the country; and within five miles of Lambton,
+Elizabeth found from her aunt that Pemberley was situated. It was not
+in their direct road, nor more than a mile or two out of it. In
+talking over their route the evening before, Mrs. Gardiner expressed
+an inclination to see the place again. Mr. Gardiner declared his
+willingness, and Elizabeth was applied to for her approbation.
+
+“My love, should not you like to see a place of which you have heard
+so much?” said her aunt; “a place, too, with which so many of your
+acquaintances are connected. Wickham passed all his youth there, you
+know.”
+
+Elizabeth was distressed. She felt that she had no business at
+Pemberley, and was obliged to assume a disinclination for seeing it. She
+must own that she was tired of seeing great houses; after going over so
+many, she really had no pleasure in fine carpets or satin curtains.
+
+Mrs. Gardiner abused her stupidity. “If it were merely a fine house
+richly furnished,” said she, “I should not care about it myself; but
+the grounds are delightful. They have some of the finest woods in the
+country.”
+
+Elizabeth said no more--but her mind could not acquiesce. The
+possibility of meeting Mr. Darcy, while viewing the place, instantly
+occurred. It would be dreadful! She blushed at the very idea, and
+thought it would be better to speak openly to her aunt than to run such
+a risk. But against this there were objections; and she finally resolved
+that it could be the last resource, if her private inquiries to the
+absence of the family were unfavourably answered.
+
+Accordingly, when she retired at night, she asked the chambermaid
+whether Pemberley were not a very fine place? what was the name of its
+proprietor? and, with no little alarm, whether the family were down for
+the summer? A most welcome negative followed the last question--and her
+alarms now being removed, she was at leisure to feel a great deal of
+curiosity to see the house herself; and when the subject was revived the
+next morning, and she was again applied to, could readily answer, and
+with a proper air of indifference, that she had not really any dislike
+to the scheme. To Pemberley, therefore, they were to go.
+
+
+
+Chapter 43
+
+
+Elizabeth, as they drove along, watched for the first appearance of
+Pemberley Woods with some perturbation; and when at length they turned
+in at the lodge, her spirits were in a high flutter.
+
+The park was very large, and contained great variety of ground. They
+entered it in one of its lowest points, and drove for some time through
+a beautiful wood stretching over a wide extent.
+
+Elizabeth’s mind was too full for conversation, but she saw and admired
+every remarkable spot and point of view. They gradually ascended for
+half-a-mile, and then found themselves at the top of a considerable
+eminence, where the wood ceased, and the eye was instantly caught by
+Pemberley House, situated on the opposite side of a valley, into which
+the road with some abruptness wound. It was a large, handsome stone
+building, standing well on rising ground, and backed by a ridge of
+high woody hills; and in front, a stream of some natural importance was
+swelled into greater, but without any artificial appearance. Its banks
+were neither formal nor falsely adorned. Elizabeth was delighted. She
+had never seen a place for which nature had done more, or where natural
+beauty had been so little counteracted by an awkward taste. They were
+all of them warm in their admiration; and at that moment she felt that
+to be mistress of Pemberley might be something!
+
+They descended the hill, crossed the bridge, and drove to the door; and,
+while examining the nearer aspect of the house, all her apprehension of
+meeting its owner returned. She dreaded lest the chambermaid had been
+mistaken. On applying to see the place, they were admitted into the
+hall; and Elizabeth, as they waited for the housekeeper, had leisure to
+wonder at her being where she was.
+
+The housekeeper came; a respectable-looking elderly woman, much less
+fine, and more civil, than she had any notion of finding her. They
+followed her into the dining-parlour. It was a large, well proportioned
+room, handsomely fitted up. Elizabeth, after slightly surveying it, went
+to a window to enjoy its prospect. The hill, crowned with wood, which
+they had descended, receiving increased abruptness from the distance,
+was a beautiful object. Every disposition of the ground was good; and
+she looked on the whole scene, the river, the trees scattered on its
+banks and the winding of the valley, as far as she could trace it,
+with delight. As they passed into other rooms these objects were taking
+different positions; but from every window there were beauties to be
+seen. The rooms were lofty and handsome, and their furniture suitable to
+the fortune of its proprietor; but Elizabeth saw, with admiration of
+his taste, that it was neither gaudy nor uselessly fine; with less of
+splendour, and more real elegance, than the furniture of Rosings.
+
+“And of this place,” thought she, “I might have been mistress! With
+these rooms I might now have been familiarly acquainted! Instead of
+viewing them as a stranger, I might have rejoiced in them as my own, and
+welcomed to them as visitors my uncle and aunt. But no,”--recollecting
+herself--“that could never be; my uncle and aunt would have been lost to
+me; I should not have been allowed to invite them.”
+
+This was a lucky recollection--it saved her from something very like
+regret.
+
+She longed to inquire of the housekeeper whether her master was really
+absent, but had not the courage for it. At length however, the question
+was asked by her uncle; and she turned away with alarm, while Mrs.
+Reynolds replied that he was, adding, “But we expect him to-morrow, with
+a large party of friends.” How rejoiced was Elizabeth that their own
+journey had not by any circumstance been delayed a day!
+
+Her aunt now called her to look at a picture. She approached and saw the
+likeness of Mr. Wickham, suspended, amongst several other miniatures,
+over the mantelpiece. Her aunt asked her, smilingly, how she liked it.
+The housekeeper came forward, and told them it was a picture of a young
+gentleman, the son of her late master’s steward, who had been brought
+up by him at his own expense. “He is now gone into the army,” she added;
+“but I am afraid he has turned out very wild.”
+
+Mrs. Gardiner looked at her niece with a smile, but Elizabeth could not
+return it.
+
+“And that,” said Mrs. Reynolds, pointing to another of the miniatures,
+“is my master--and very like him. It was drawn at the same time as the
+other--about eight years ago.”
+
+“I have heard much of your master’s fine person,” said Mrs. Gardiner,
+looking at the picture; “it is a handsome face. But, Lizzy, you can tell
+us whether it is like or not.”
+
+Mrs. Reynolds respect for Elizabeth seemed to increase on this
+intimation of her knowing her master.
+
+“Does that young lady know Mr. Darcy?”
+
+Elizabeth coloured, and said: “A little.”
+
+“And do not you think him a very handsome gentleman, ma’am?”
+
+“Yes, very handsome.”
+
+“I am sure I know none so handsome; but in the gallery up stairs you
+will see a finer, larger picture of him than this. This room was my late
+master’s favourite room, and these miniatures are just as they used to
+be then. He was very fond of them.”
+
+This accounted to Elizabeth for Mr. Wickham’s being among them.
+
+Mrs. Reynolds then directed their attention to one of Miss Darcy, drawn
+when she was only eight years old.
+
+“And is Miss Darcy as handsome as her brother?” said Mrs. Gardiner.
+
+“Oh! yes--the handsomest young lady that ever was seen; and so
+accomplished!--She plays and sings all day long. In the next room is
+a new instrument just come down for her--a present from my master; she
+comes here to-morrow with him.”
+
+Mr. Gardiner, whose manners were very easy and pleasant, encouraged her
+communicativeness by his questions and remarks; Mrs. Reynolds, either
+by pride or attachment, had evidently great pleasure in talking of her
+master and his sister.
+
+“Is your master much at Pemberley in the course of the year?”
+
+“Not so much as I could wish, sir; but I dare say he may spend half his
+time here; and Miss Darcy is always down for the summer months.”
+
+“Except,” thought Elizabeth, “when she goes to Ramsgate.”
+
+“If your master would marry, you might see more of him.”
+
+“Yes, sir; but I do not know when _that_ will be. I do not know who is
+good enough for him.”
+
+Mr. and Mrs. Gardiner smiled. Elizabeth could not help saying, “It is
+very much to his credit, I am sure, that you should think so.”
+
+“I say no more than the truth, and everybody will say that knows him,”
+ replied the other. Elizabeth thought this was going pretty far; and she
+listened with increasing astonishment as the housekeeper added, “I have
+never known a cross word from him in my life, and I have known him ever
+since he was four years old.”
+
+This was praise, of all others most extraordinary, most opposite to her
+ideas. That he was not a good-tempered man had been her firmest opinion.
+Her keenest attention was awakened; she longed to hear more, and was
+grateful to her uncle for saying:
+
+“There are very few people of whom so much can be said. You are lucky in
+having such a master.”
+
+“Yes, sir, I know I am. If I were to go through the world, I could
+not meet with a better. But I have always observed, that they who are
+good-natured when children, are good-natured when they grow up; and
+he was always the sweetest-tempered, most generous-hearted boy in the
+world.”
+
+Elizabeth almost stared at her. “Can this be Mr. Darcy?” thought she.
+
+“His father was an excellent man,” said Mrs. Gardiner.
+
+“Yes, ma’am, that he was indeed; and his son will be just like him--just
+as affable to the poor.”
+
+Elizabeth listened, wondered, doubted, and was impatient for more. Mrs.
+Reynolds could interest her on no other point. She related the subjects
+of the pictures, the dimensions of the rooms, and the price of the
+furniture, in vain. Mr. Gardiner, highly amused by the kind of family
+prejudice to which he attributed her excessive commendation of her
+master, soon led again to the subject; and she dwelt with energy on his
+many merits as they proceeded together up the great staircase.
+
+“He is the best landlord, and the best master,” said she, “that ever
+lived; not like the wild young men nowadays, who think of nothing but
+themselves. There is not one of his tenants or servants but will give
+him a good name. Some people call him proud; but I am sure I never saw
+anything of it. To my fancy, it is only because he does not rattle away
+like other young men.”
+
+“In what an amiable light does this place him!” thought Elizabeth.
+
+“This fine account of him,” whispered her aunt as they walked, “is not
+quite consistent with his behaviour to our poor friend.”
+
+“Perhaps we might be deceived.”
+
+“That is not very likely; our authority was too good.”
+
+On reaching the spacious lobby above they were shown into a very pretty
+sitting-room, lately fitted up with greater elegance and lightness than
+the apartments below; and were informed that it was but just done to
+give pleasure to Miss Darcy, who had taken a liking to the room when
+last at Pemberley.
+
+“He is certainly a good brother,” said Elizabeth, as she walked towards
+one of the windows.
+
+Mrs. Reynolds anticipated Miss Darcy’s delight, when she should enter
+the room. “And this is always the way with him,” she added. “Whatever
+can give his sister any pleasure is sure to be done in a moment. There
+is nothing he would not do for her.”
+
+The picture-gallery, and two or three of the principal bedrooms, were
+all that remained to be shown. In the former were many good paintings;
+but Elizabeth knew nothing of the art; and from such as had been already
+visible below, she had willingly turned to look at some drawings of Miss
+Darcy’s, in crayons, whose subjects were usually more interesting, and
+also more intelligible.
+
+In the gallery there were many family portraits, but they could have
+little to fix the attention of a stranger. Elizabeth walked in quest of
+the only face whose features would be known to her. At last it arrested
+her--and she beheld a striking resemblance to Mr. Darcy, with such a
+smile over the face as she remembered to have sometimes seen when he
+looked at her. She stood several minutes before the picture, in earnest
+contemplation, and returned to it again before they quitted the gallery.
+Mrs. Reynolds informed them that it had been taken in his father’s
+lifetime.
+
+There was certainly at this moment, in Elizabeth’s mind, a more gentle
+sensation towards the original than she had ever felt at the height of
+their acquaintance. The commendation bestowed on him by Mrs. Reynolds
+was of no trifling nature. What praise is more valuable than the praise
+of an intelligent servant? As a brother, a landlord, a master, she
+considered how many people’s happiness were in his guardianship!--how
+much of pleasure or pain was it in his power to bestow!--how much of
+good or evil must be done by him! Every idea that had been brought
+forward by the housekeeper was favourable to his character, and as she
+stood before the canvas on which he was represented, and fixed his
+eyes upon herself, she thought of his regard with a deeper sentiment of
+gratitude than it had ever raised before; she remembered its warmth, and
+softened its impropriety of expression.
+
+When all of the house that was open to general inspection had been seen,
+they returned downstairs, and, taking leave of the housekeeper, were
+consigned over to the gardener, who met them at the hall-door.
+
+As they walked across the hall towards the river, Elizabeth turned back
+to look again; her uncle and aunt stopped also, and while the former
+was conjecturing as to the date of the building, the owner of it himself
+suddenly came forward from the road, which led behind it to the stables.
+
+They were within twenty yards of each other, and so abrupt was his
+appearance, that it was impossible to avoid his sight. Their eyes
+instantly met, and the cheeks of both were overspread with the deepest
+blush. He absolutely started, and for a moment seemed immovable from
+surprise; but shortly recovering himself, advanced towards the party,
+and spoke to Elizabeth, if not in terms of perfect composure, at least
+of perfect civility.
+
+She had instinctively turned away; but stopping on his approach,
+received his compliments with an embarrassment impossible to be
+overcome. Had his first appearance, or his resemblance to the picture
+they had just been examining, been insufficient to assure the other two
+that they now saw Mr. Darcy, the gardener’s expression of surprise, on
+beholding his master, must immediately have told it. They stood a little
+aloof while he was talking to their niece, who, astonished and confused,
+scarcely dared lift her eyes to his face, and knew not what answer
+she returned to his civil inquiries after her family. Amazed at the
+alteration of his manner since they last parted, every sentence that
+he uttered was increasing her embarrassment; and every idea of the
+impropriety of her being found there recurring to her mind, the few
+minutes in which they continued were some of the most uncomfortable in
+her life. Nor did he seem much more at ease; when he spoke, his accent
+had none of its usual sedateness; and he repeated his inquiries as
+to the time of her having left Longbourn, and of her having stayed in
+Derbyshire, so often, and in so hurried a way, as plainly spoke the
+distraction of his thoughts.
+
+At length every idea seemed to fail him; and, after standing a few
+moments without saying a word, he suddenly recollected himself, and took
+leave.
+
+The others then joined her, and expressed admiration of his figure; but
+Elizabeth heard not a word, and wholly engrossed by her own feelings,
+followed them in silence. She was overpowered by shame and vexation. Her
+coming there was the most unfortunate, the most ill-judged thing in the
+world! How strange it must appear to him! In what a disgraceful light
+might it not strike so vain a man! It might seem as if she had purposely
+thrown herself in his way again! Oh! why did she come? Or, why did he
+thus come a day before he was expected? Had they been only ten minutes
+sooner, they should have been beyond the reach of his discrimination;
+for it was plain that he was that moment arrived--that moment alighted
+from his horse or his carriage. She blushed again and again over
+the perverseness of the meeting. And his behaviour, so strikingly
+altered--what could it mean? That he should even speak to her was
+amazing!--but to speak with such civility, to inquire after her family!
+Never in her life had she seen his manners so little dignified, never
+had he spoken with such gentleness as on this unexpected meeting. What
+a contrast did it offer to his last address in Rosings Park, when he put
+his letter into her hand! She knew not what to think, or how to account
+for it.
+
+They had now entered a beautiful walk by the side of the water, and
+every step was bringing forward a nobler fall of ground, or a finer
+reach of the woods to which they were approaching; but it was some time
+before Elizabeth was sensible of any of it; and, though she answered
+mechanically to the repeated appeals of her uncle and aunt, and
+seemed to direct her eyes to such objects as they pointed out, she
+distinguished no part of the scene. Her thoughts were all fixed on that
+one spot of Pemberley House, whichever it might be, where Mr. Darcy then
+was. She longed to know what at the moment was passing in his mind--in
+what manner he thought of her, and whether, in defiance of everything,
+she was still dear to him. Perhaps he had been civil only because he
+felt himself at ease; yet there had been _that_ in his voice which was
+not like ease. Whether he had felt more of pain or of pleasure in
+seeing her she could not tell, but he certainly had not seen her with
+composure.
+
+At length, however, the remarks of her companions on her absence of mind
+aroused her, and she felt the necessity of appearing more like herself.
+
+They entered the woods, and bidding adieu to the river for a while,
+ascended some of the higher grounds; when, in spots where the opening of
+the trees gave the eye power to wander, were many charming views of the
+valley, the opposite hills, with the long range of woods overspreading
+many, and occasionally part of the stream. Mr. Gardiner expressed a wish
+of going round the whole park, but feared it might be beyond a walk.
+With a triumphant smile they were told that it was ten miles round.
+It settled the matter; and they pursued the accustomed circuit; which
+brought them again, after some time, in a descent among hanging woods,
+to the edge of the water, and one of its narrowest parts. They crossed
+it by a simple bridge, in character with the general air of the scene;
+it was a spot less adorned than any they had yet visited; and the
+valley, here contracted into a glen, allowed room only for the stream,
+and a narrow walk amidst the rough coppice-wood which bordered it.
+Elizabeth longed to explore its windings; but when they had crossed the
+bridge, and perceived their distance from the house, Mrs. Gardiner,
+who was not a great walker, could go no farther, and thought only
+of returning to the carriage as quickly as possible. Her niece was,
+therefore, obliged to submit, and they took their way towards the house
+on the opposite side of the river, in the nearest direction; but their
+progress was slow, for Mr. Gardiner, though seldom able to indulge the
+taste, was very fond of fishing, and was so much engaged in watching the
+occasional appearance of some trout in the water, and talking to the
+man about them, that he advanced but little. Whilst wandering on in this
+slow manner, they were again surprised, and Elizabeth’s astonishment
+was quite equal to what it had been at first, by the sight of Mr. Darcy
+approaching them, and at no great distance. The walk being here
+less sheltered than on the other side, allowed them to see him before
+they met. Elizabeth, however astonished, was at least more prepared
+for an interview than before, and resolved to appear and to speak with
+calmness, if he really intended to meet them. For a few moments, indeed,
+she felt that he would probably strike into some other path. The idea
+lasted while a turning in the walk concealed him from their view; the
+turning past, he was immediately before them. With a glance, she saw
+that he had lost none of his recent civility; and, to imitate his
+politeness, she began, as they met, to admire the beauty of the place;
+but she had not got beyond the words “delightful,” and “charming,” when
+some unlucky recollections obtruded, and she fancied that praise of
+Pemberley from her might be mischievously construed. Her colour changed,
+and she said no more.
+
+Mrs. Gardiner was standing a little behind; and on her pausing, he asked
+her if she would do him the honour of introducing him to her friends.
+This was a stroke of civility for which she was quite unprepared;
+and she could hardly suppress a smile at his being now seeking the
+acquaintance of some of those very people against whom his pride had
+revolted in his offer to herself. “What will be his surprise,” thought
+she, “when he knows who they are? He takes them now for people of
+fashion.”
+
+The introduction, however, was immediately made; and as she named their
+relationship to herself, she stole a sly look at him, to see how he bore
+it, and was not without the expectation of his decamping as fast as he
+could from such disgraceful companions. That he was _surprised_ by the
+connection was evident; he sustained it, however, with fortitude, and
+so far from going away, turned back with them, and entered into
+conversation with Mr. Gardiner. Elizabeth could not but be pleased,
+could not but triumph. It was consoling that he should know she had
+some relations for whom there was no need to blush. She listened most
+attentively to all that passed between them, and gloried in every
+expression, every sentence of her uncle, which marked his intelligence,
+his taste, or his good manners.
+
+The conversation soon turned upon fishing; and she heard Mr. Darcy
+invite him, with the greatest civility, to fish there as often as he
+chose while he continued in the neighbourhood, offering at the same time
+to supply him with fishing tackle, and pointing out those parts of
+the stream where there was usually most sport. Mrs. Gardiner, who was
+walking arm-in-arm with Elizabeth, gave her a look expressive of wonder.
+Elizabeth said nothing, but it gratified her exceedingly; the compliment
+must be all for herself. Her astonishment, however, was extreme, and
+continually was she repeating, “Why is he so altered? From what can
+it proceed? It cannot be for _me_--it cannot be for _my_ sake that his
+manners are thus softened. My reproofs at Hunsford could not work such a
+change as this. It is impossible that he should still love me.”
+
+After walking some time in this way, the two ladies in front, the two
+gentlemen behind, on resuming their places, after descending to
+the brink of the river for the better inspection of some curious
+water-plant, there chanced to be a little alteration. It originated
+in Mrs. Gardiner, who, fatigued by the exercise of the morning, found
+Elizabeth’s arm inadequate to her support, and consequently preferred
+her husband’s. Mr. Darcy took her place by her niece, and they walked on
+together. After a short silence, the lady first spoke. She wished him
+to know that she had been assured of his absence before she came to the
+place, and accordingly began by observing, that his arrival had been
+very unexpected--“for your housekeeper,” she added, “informed us that
+you would certainly not be here till to-morrow; and indeed, before we
+left Bakewell, we understood that you were not immediately expected
+in the country.” He acknowledged the truth of it all, and said that
+business with his steward had occasioned his coming forward a few hours
+before the rest of the party with whom he had been travelling. “They
+will join me early to-morrow,” he continued, “and among them are some
+who will claim an acquaintance with you--Mr. Bingley and his sisters.”
+
+Elizabeth answered only by a slight bow. Her thoughts were instantly
+driven back to the time when Mr. Bingley’s name had been the last
+mentioned between them; and, if she might judge by his complexion, _his_
+mind was not very differently engaged.
+
+“There is also one other person in the party,” he continued after a
+pause, “who more particularly wishes to be known to you. Will you allow
+me, or do I ask too much, to introduce my sister to your acquaintance
+during your stay at Lambton?”
+
+The surprise of such an application was great indeed; it was too great
+for her to know in what manner she acceded to it. She immediately felt
+that whatever desire Miss Darcy might have of being acquainted with her
+must be the work of her brother, and, without looking farther, it was
+satisfactory; it was gratifying to know that his resentment had not made
+him think really ill of her.
+
+They now walked on in silence, each of them deep in thought. Elizabeth
+was not comfortable; that was impossible; but she was flattered and
+pleased. His wish of introducing his sister to her was a compliment of
+the highest kind. They soon outstripped the others, and when they had
+reached the carriage, Mr. and Mrs. Gardiner were half a quarter of a
+mile behind.
+
+He then asked her to walk into the house--but she declared herself not
+tired, and they stood together on the lawn. At such a time much might
+have been said, and silence was very awkward. She wanted to talk, but
+there seemed to be an embargo on every subject. At last she recollected
+that she had been travelling, and they talked of Matlock and Dove Dale
+with great perseverance. Yet time and her aunt moved slowly--and her
+patience and her ideas were nearly worn out before the tete-a-tete was
+over. On Mr. and Mrs. Gardiner’s coming up they were all pressed to go
+into the house and take some refreshment; but this was declined, and
+they parted on each side with utmost politeness. Mr. Darcy handed the
+ladies into the carriage; and when it drove off, Elizabeth saw him
+walking slowly towards the house.
+
+The observations of her uncle and aunt now began; and each of them
+pronounced him to be infinitely superior to anything they had expected.
+“He is perfectly well behaved, polite, and unassuming,” said her uncle.
+
+“There _is_ something a little stately in him, to be sure,” replied her
+aunt, “but it is confined to his air, and is not unbecoming. I can now
+say with the housekeeper, that though some people may call him proud, I
+have seen nothing of it.”
+
+“I was never more surprised than by his behaviour to us. It was more
+than civil; it was really attentive; and there was no necessity for such
+attention. His acquaintance with Elizabeth was very trifling.”
+
+“To be sure, Lizzy,” said her aunt, “he is not so handsome as Wickham;
+or, rather, he has not Wickham’s countenance, for his features
+are perfectly good. But how came you to tell me that he was so
+disagreeable?”
+
+Elizabeth excused herself as well as she could; said that she had liked
+him better when they had met in Kent than before, and that she had never
+seen him so pleasant as this morning.
+
+“But perhaps he may be a little whimsical in his civilities,” replied
+her uncle. “Your great men often are; and therefore I shall not take him
+at his word, as he might change his mind another day, and warn me off
+his grounds.”
+
+Elizabeth felt that they had entirely misunderstood his character, but
+said nothing.
+
+“From what we have seen of him,” continued Mrs. Gardiner, “I really
+should not have thought that he could have behaved in so cruel a way by
+anybody as he has done by poor Wickham. He has not an ill-natured look.
+On the contrary, there is something pleasing about his mouth when he
+speaks. And there is something of dignity in his countenance that would
+not give one an unfavourable idea of his heart. But, to be sure, the
+good lady who showed us his house did give him a most flaming character!
+I could hardly help laughing aloud sometimes. But he is a liberal
+master, I suppose, and _that_ in the eye of a servant comprehends every
+virtue.”
+
+Elizabeth here felt herself called on to say something in vindication of
+his behaviour to Wickham; and therefore gave them to understand, in
+as guarded a manner as she could, that by what she had heard from
+his relations in Kent, his actions were capable of a very different
+construction; and that his character was by no means so faulty, nor
+Wickham’s so amiable, as they had been considered in Hertfordshire. In
+confirmation of this, she related the particulars of all the pecuniary
+transactions in which they had been connected, without actually naming
+her authority, but stating it to be such as might be relied on.
+
+Mrs. Gardiner was surprised and concerned; but as they were now
+approaching the scene of her former pleasures, every idea gave way to
+the charm of recollection; and she was too much engaged in pointing out
+to her husband all the interesting spots in its environs to think of
+anything else. Fatigued as she had been by the morning’s walk they
+had no sooner dined than she set off again in quest of her former
+acquaintance, and the evening was spent in the satisfactions of a
+intercourse renewed after many years’ discontinuance.
+
+The occurrences of the day were too full of interest to leave Elizabeth
+much attention for any of these new friends; and she could do nothing
+but think, and think with wonder, of Mr. Darcy’s civility, and, above
+all, of his wishing her to be acquainted with his sister.
+
+
+
+Chapter 44
+
+
+Elizabeth had settled it that Mr. Darcy would bring his sister to visit
+her the very day after her reaching Pemberley; and was consequently
+resolved not to be out of sight of the inn the whole of that morning.
+But her conclusion was false; for on the very morning after their
+arrival at Lambton, these visitors came. They had been walking about the
+place with some of their new friends, and were just returning to the inn
+to dress themselves for dining with the same family, when the sound of a
+carriage drew them to a window, and they saw a gentleman and a lady in
+a curricle driving up the street. Elizabeth immediately recognizing
+the livery, guessed what it meant, and imparted no small degree of her
+surprise to her relations by acquainting them with the honour which she
+expected. Her uncle and aunt were all amazement; and the embarrassment
+of her manner as she spoke, joined to the circumstance itself, and many
+of the circumstances of the preceding day, opened to them a new idea on
+the business. Nothing had ever suggested it before, but they felt that
+there was no other way of accounting for such attentions from such a
+quarter than by supposing a partiality for their niece. While these
+newly-born notions were passing in their heads, the perturbation of
+Elizabeth’s feelings was at every moment increasing. She was quite
+amazed at her own discomposure; but amongst other causes of disquiet,
+she dreaded lest the partiality of the brother should have said too much
+in her favour; and, more than commonly anxious to please, she naturally
+suspected that every power of pleasing would fail her.
+
+She retreated from the window, fearful of being seen; and as she walked
+up and down the room, endeavouring to compose herself, saw such looks of
+inquiring surprise in her uncle and aunt as made everything worse.
+
+Miss Darcy and her brother appeared, and this formidable introduction
+took place. With astonishment did Elizabeth see that her new
+acquaintance was at least as much embarrassed as herself. Since her
+being at Lambton, she had heard that Miss Darcy was exceedingly proud;
+but the observation of a very few minutes convinced her that she was
+only exceedingly shy. She found it difficult to obtain even a word from
+her beyond a monosyllable.
+
+Miss Darcy was tall, and on a larger scale than Elizabeth; and, though
+little more than sixteen, her figure was formed, and her appearance
+womanly and graceful. She was less handsome than her brother; but there
+was sense and good humour in her face, and her manners were perfectly
+unassuming and gentle. Elizabeth, who had expected to find in her as
+acute and unembarrassed an observer as ever Mr. Darcy had been, was much
+relieved by discerning such different feelings.
+
+They had not long been together before Mr. Darcy told her that Bingley
+was also coming to wait on her; and she had barely time to express her
+satisfaction, and prepare for such a visitor, when Bingley’s quick
+step was heard on the stairs, and in a moment he entered the room. All
+Elizabeth’s anger against him had been long done away; but had she still
+felt any, it could hardly have stood its ground against the unaffected
+cordiality with which he expressed himself on seeing her again. He
+inquired in a friendly, though general way, after her family, and looked
+and spoke with the same good-humoured ease that he had ever done.
+
+To Mr. and Mrs. Gardiner he was scarcely a less interesting personage
+than to herself. They had long wished to see him. The whole party before
+them, indeed, excited a lively attention. The suspicions which had just
+arisen of Mr. Darcy and their niece directed their observation towards
+each with an earnest though guarded inquiry; and they soon drew from
+those inquiries the full conviction that one of them at least knew
+what it was to love. Of the lady’s sensations they remained a little
+in doubt; but that the gentleman was overflowing with admiration was
+evident enough.
+
+Elizabeth, on her side, had much to do. She wanted to ascertain the
+feelings of each of her visitors; she wanted to compose her own, and
+to make herself agreeable to all; and in the latter object, where she
+feared most to fail, she was most sure of success, for those to whom she
+endeavoured to give pleasure were prepossessed in her favour. Bingley
+was ready, Georgiana was eager, and Darcy determined, to be pleased.
+
+In seeing Bingley, her thoughts naturally flew to her sister; and, oh!
+how ardently did she long to know whether any of his were directed in
+a like manner. Sometimes she could fancy that he talked less than on
+former occasions, and once or twice pleased herself with the notion
+that, as he looked at her, he was trying to trace a resemblance. But,
+though this might be imaginary, she could not be deceived as to his
+behaviour to Miss Darcy, who had been set up as a rival to Jane. No look
+appeared on either side that spoke particular regard. Nothing occurred
+between them that could justify the hopes of his sister. On this point
+she was soon satisfied; and two or three little circumstances occurred
+ere they parted, which, in her anxious interpretation, denoted a
+recollection of Jane not untinctured by tenderness, and a wish of saying
+more that might lead to the mention of her, had he dared. He observed
+to her, at a moment when the others were talking together, and in a tone
+which had something of real regret, that it “was a very long time since
+he had had the pleasure of seeing her;” and, before she could reply,
+he added, “It is above eight months. We have not met since the 26th of
+November, when we were all dancing together at Netherfield.”
+
+Elizabeth was pleased to find his memory so exact; and he afterwards
+took occasion to ask her, when unattended to by any of the rest, whether
+_all_ her sisters were at Longbourn. There was not much in the question,
+nor in the preceding remark; but there was a look and a manner which
+gave them meaning.
+
+It was not often that she could turn her eyes on Mr. Darcy himself;
+but, whenever she did catch a glimpse, she saw an expression of general
+complaisance, and in all that he said she heard an accent so removed
+from _hauteur_ or disdain of his companions, as convinced her that
+the improvement of manners which she had yesterday witnessed however
+temporary its existence might prove, had at least outlived one day. When
+she saw him thus seeking the acquaintance and courting the good opinion
+of people with whom any intercourse a few months ago would have been a
+disgrace--when she saw him thus civil, not only to herself, but to the
+very relations whom he had openly disdained, and recollected their last
+lively scene in Hunsford Parsonage--the difference, the change was
+so great, and struck so forcibly on her mind, that she could hardly
+restrain her astonishment from being visible. Never, even in the company
+of his dear friends at Netherfield, or his dignified relations
+at Rosings, had she seen him so desirous to please, so free from
+self-consequence or unbending reserve, as now, when no importance
+could result from the success of his endeavours, and when even the
+acquaintance of those to whom his attentions were addressed would draw
+down the ridicule and censure of the ladies both of Netherfield and
+Rosings.
+
+Their visitors stayed with them above half-an-hour; and when they arose
+to depart, Mr. Darcy called on his sister to join him in expressing
+their wish of seeing Mr. and Mrs. Gardiner, and Miss Bennet, to dinner
+at Pemberley, before they left the country. Miss Darcy, though with a
+diffidence which marked her little in the habit of giving invitations,
+readily obeyed. Mrs. Gardiner looked at her niece, desirous of knowing
+how _she_, whom the invitation most concerned, felt disposed as to its
+acceptance, but Elizabeth had turned away her head. Presuming however,
+that this studied avoidance spoke rather a momentary embarrassment than
+any dislike of the proposal, and seeing in her husband, who was fond of
+society, a perfect willingness to accept it, she ventured to engage for
+her attendance, and the day after the next was fixed on.
+
+Bingley expressed great pleasure in the certainty of seeing Elizabeth
+again, having still a great deal to say to her, and many inquiries to
+make after all their Hertfordshire friends. Elizabeth, construing all
+this into a wish of hearing her speak of her sister, was pleased, and on
+this account, as well as some others, found herself, when their
+visitors left them, capable of considering the last half-hour with some
+satisfaction, though while it was passing, the enjoyment of it had been
+little. Eager to be alone, and fearful of inquiries or hints from her
+uncle and aunt, she stayed with them only long enough to hear their
+favourable opinion of Bingley, and then hurried away to dress.
+
+But she had no reason to fear Mr. and Mrs. Gardiner’s curiosity; it was
+not their wish to force her communication. It was evident that she was
+much better acquainted with Mr. Darcy than they had before any idea of;
+it was evident that he was very much in love with her. They saw much to
+interest, but nothing to justify inquiry.
+
+Of Mr. Darcy it was now a matter of anxiety to think well; and, as far
+as their acquaintance reached, there was no fault to find. They could
+not be untouched by his politeness; and had they drawn his character
+from their own feelings and his servant’s report, without any reference
+to any other account, the circle in Hertfordshire to which he was known
+would not have recognized it for Mr. Darcy. There was now an interest,
+however, in believing the housekeeper; and they soon became sensible
+that the authority of a servant who had known him since he was four
+years old, and whose own manners indicated respectability, was not to be
+hastily rejected. Neither had anything occurred in the intelligence of
+their Lambton friends that could materially lessen its weight. They had
+nothing to accuse him of but pride; pride he probably had, and if not,
+it would certainly be imputed by the inhabitants of a small market-town
+where the family did not visit. It was acknowledged, however, that he
+was a liberal man, and did much good among the poor.
+
+With respect to Wickham, the travellers soon found that he was not held
+there in much estimation; for though the chief of his concerns with the
+son of his patron were imperfectly understood, it was yet a well-known
+fact that, on his quitting Derbyshire, he had left many debts behind
+him, which Mr. Darcy afterwards discharged.
+
+As for Elizabeth, her thoughts were at Pemberley this evening more than
+the last; and the evening, though as it passed it seemed long, was not
+long enough to determine her feelings towards _one_ in that mansion;
+and she lay awake two whole hours endeavouring to make them out. She
+certainly did not hate him. No; hatred had vanished long ago, and she
+had almost as long been ashamed of ever feeling a dislike against him,
+that could be so called. The respect created by the conviction of his
+valuable qualities, though at first unwillingly admitted, had for some
+time ceased to be repugnant to her feeling; and it was now heightened
+into somewhat of a friendlier nature, by the testimony so highly in
+his favour, and bringing forward his disposition in so amiable a light,
+which yesterday had produced. But above all, above respect and esteem,
+there was a motive within her of goodwill which could not be overlooked.
+It was gratitude; gratitude, not merely for having once loved her,
+but for loving her still well enough to forgive all the petulance and
+acrimony of her manner in rejecting him, and all the unjust accusations
+accompanying her rejection. He who, she had been persuaded, would avoid
+her as his greatest enemy, seemed, on this accidental meeting, most
+eager to preserve the acquaintance, and without any indelicate display
+of regard, or any peculiarity of manner, where their two selves only
+were concerned, was soliciting the good opinion of her friends, and bent
+on making her known to his sister. Such a change in a man of so much
+pride exciting not only astonishment but gratitude--for to love, ardent
+love, it must be attributed; and as such its impression on her was of a
+sort to be encouraged, as by no means unpleasing, though it could not be
+exactly defined. She respected, she esteemed, she was grateful to him,
+she felt a real interest in his welfare; and she only wanted to know how
+far she wished that welfare to depend upon herself, and how far it would
+be for the happiness of both that she should employ the power, which her
+fancy told her she still possessed, of bringing on her the renewal of
+his addresses.
+
+It had been settled in the evening between the aunt and the niece, that
+such a striking civility as Miss Darcy’s in coming to see them on the
+very day of her arrival at Pemberley, for she had reached it only to a
+late breakfast, ought to be imitated, though it could not be equalled,
+by some exertion of politeness on their side; and, consequently, that
+it would be highly expedient to wait on her at Pemberley the following
+morning. They were, therefore, to go. Elizabeth was pleased; though when
+she asked herself the reason, she had very little to say in reply.
+
+Mr. Gardiner left them soon after breakfast. The fishing scheme had been
+renewed the day before, and a positive engagement made of his meeting
+some of the gentlemen at Pemberley before noon.
+
+
+
+Chapter 45
+
+
+Convinced as Elizabeth now was that Miss Bingley’s dislike of her had
+originated in jealousy, she could not help feeling how unwelcome her
+appearance at Pemberley must be to her, and was curious to know with how
+much civility on that lady’s side the acquaintance would now be renewed.
+
+On reaching the house, they were shown through the hall into the saloon,
+whose northern aspect rendered it delightful for summer. Its windows
+opening to the ground, admitted a most refreshing view of the high woody
+hills behind the house, and of the beautiful oaks and Spanish chestnuts
+which were scattered over the intermediate lawn.
+
+In this house they were received by Miss Darcy, who was sitting there
+with Mrs. Hurst and Miss Bingley, and the lady with whom she lived in
+London. Georgiana’s reception of them was very civil, but attended with
+all the embarrassment which, though proceeding from shyness and the fear
+of doing wrong, would easily give to those who felt themselves inferior
+the belief of her being proud and reserved. Mrs. Gardiner and her niece,
+however, did her justice, and pitied her.
+
+By Mrs. Hurst and Miss Bingley they were noticed only by a curtsey; and,
+on their being seated, a pause, awkward as such pauses must always be,
+succeeded for a few moments. It was first broken by Mrs. Annesley, a
+genteel, agreeable-looking woman, whose endeavour to introduce some kind
+of discourse proved her to be more truly well-bred than either of the
+others; and between her and Mrs. Gardiner, with occasional help from
+Elizabeth, the conversation was carried on. Miss Darcy looked as if she
+wished for courage enough to join in it; and sometimes did venture a
+short sentence when there was least danger of its being heard.
+
+Elizabeth soon saw that she was herself closely watched by Miss Bingley,
+and that she could not speak a word, especially to Miss Darcy, without
+calling her attention. This observation would not have prevented her
+from trying to talk to the latter, had they not been seated at an
+inconvenient distance; but she was not sorry to be spared the necessity
+of saying much. Her own thoughts were employing her. She expected every
+moment that some of the gentlemen would enter the room. She wished, she
+feared that the master of the house might be amongst them; and whether
+she wished or feared it most, she could scarcely determine. After
+sitting in this manner a quarter of an hour without hearing Miss
+Bingley’s voice, Elizabeth was roused by receiving from her a cold
+inquiry after the health of her family. She answered with equal
+indifference and brevity, and the other said no more.
+
+The next variation which their visit afforded was produced by the
+entrance of servants with cold meat, cake, and a variety of all the
+finest fruits in season; but this did not take place till after many
+a significant look and smile from Mrs. Annesley to Miss Darcy had been
+given, to remind her of her post. There was now employment for the whole
+party--for though they could not all talk, they could all eat; and the
+beautiful pyramids of grapes, nectarines, and peaches soon collected
+them round the table.
+
+While thus engaged, Elizabeth had a fair opportunity of deciding whether
+she most feared or wished for the appearance of Mr. Darcy, by the
+feelings which prevailed on his entering the room; and then, though but
+a moment before she had believed her wishes to predominate, she began to
+regret that he came.
+
+He had been some time with Mr. Gardiner, who, with two or three other
+gentlemen from the house, was engaged by the river, and had left him
+only on learning that the ladies of the family intended a visit to
+Georgiana that morning. No sooner did he appear than Elizabeth wisely
+resolved to be perfectly easy and unembarrassed; a resolution the more
+necessary to be made, but perhaps not the more easily kept, because she
+saw that the suspicions of the whole party were awakened against them,
+and that there was scarcely an eye which did not watch his behaviour
+when he first came into the room. In no countenance was attentive
+curiosity so strongly marked as in Miss Bingley’s, in spite of the
+smiles which overspread her face whenever she spoke to one of its
+objects; for jealousy had not yet made her desperate, and her attentions
+to Mr. Darcy were by no means over. Miss Darcy, on her brother’s
+entrance, exerted herself much more to talk, and Elizabeth saw that he
+was anxious for his sister and herself to get acquainted, and forwarded
+as much as possible, every attempt at conversation on either side. Miss
+Bingley saw all this likewise; and, in the imprudence of anger, took the
+first opportunity of saying, with sneering civility:
+
+“Pray, Miss Eliza, are not the ----shire Militia removed from Meryton?
+They must be a great loss to _your_ family.”
+
+In Darcy’s presence she dared not mention Wickham’s name; but Elizabeth
+instantly comprehended that he was uppermost in her thoughts; and the
+various recollections connected with him gave her a moment’s distress;
+but exerting herself vigorously to repel the ill-natured attack, she
+presently answered the question in a tolerably detached tone. While
+she spoke, an involuntary glance showed her Darcy, with a heightened
+complexion, earnestly looking at her, and his sister overcome with
+confusion, and unable to lift up her eyes. Had Miss Bingley known what
+pain she was then giving her beloved friend, she undoubtedly would
+have refrained from the hint; but she had merely intended to discompose
+Elizabeth by bringing forward the idea of a man to whom she believed
+her partial, to make her betray a sensibility which might injure her in
+Darcy’s opinion, and, perhaps, to remind the latter of all the follies
+and absurdities by which some part of her family were connected
+with that corps. Not a syllable had ever reached her of Miss Darcy’s
+meditated elopement. To no creature had it been revealed, where secrecy
+was possible, except to Elizabeth; and from all Bingley’s connections
+her brother was particularly anxious to conceal it, from the very
+wish which Elizabeth had long ago attributed to him, of their becoming
+hereafter her own. He had certainly formed such a plan, and without
+meaning that it should affect his endeavour to separate him from Miss
+Bennet, it is probable that it might add something to his lively concern
+for the welfare of his friend.
+
+Elizabeth’s collected behaviour, however, soon quieted his emotion; and
+as Miss Bingley, vexed and disappointed, dared not approach nearer to
+Wickham, Georgiana also recovered in time, though not enough to be able
+to speak any more. Her brother, whose eye she feared to meet, scarcely
+recollected her interest in the affair, and the very circumstance which
+had been designed to turn his thoughts from Elizabeth seemed to have
+fixed them on her more and more cheerfully.
+
+Their visit did not continue long after the question and answer above
+mentioned; and while Mr. Darcy was attending them to their carriage Miss
+Bingley was venting her feelings in criticisms on Elizabeth’s person,
+behaviour, and dress. But Georgiana would not join her. Her brother’s
+recommendation was enough to ensure her favour; his judgement could not
+err. And he had spoken in such terms of Elizabeth as to leave Georgiana
+without the power of finding her otherwise than lovely and amiable. When
+Darcy returned to the saloon, Miss Bingley could not help repeating to
+him some part of what she had been saying to his sister.
+
+“How very ill Miss Eliza Bennet looks this morning, Mr. Darcy,” she
+cried; “I never in my life saw anyone so much altered as she is since
+the winter. She is grown so brown and coarse! Louisa and I were agreeing
+that we should not have known her again.”
+
+However little Mr. Darcy might have liked such an address, he contented
+himself with coolly replying that he perceived no other alteration than
+her being rather tanned, no miraculous consequence of travelling in the
+summer.
+
+“For my own part,” she rejoined, “I must confess that I never could
+see any beauty in her. Her face is too thin; her complexion has no
+brilliancy; and her features are not at all handsome. Her nose
+wants character--there is nothing marked in its lines. Her teeth are
+tolerable, but not out of the common way; and as for her eyes,
+which have sometimes been called so fine, I could never see anything
+extraordinary in them. They have a sharp, shrewish look, which I do
+not like at all; and in her air altogether there is a self-sufficiency
+without fashion, which is intolerable.”
+
+Persuaded as Miss Bingley was that Darcy admired Elizabeth, this was not
+the best method of recommending herself; but angry people are not always
+wise; and in seeing him at last look somewhat nettled, she had all the
+success she expected. He was resolutely silent, however, and, from a
+determination of making him speak, she continued:
+
+“I remember, when we first knew her in Hertfordshire, how amazed we all
+were to find that she was a reputed beauty; and I particularly recollect
+your saying one night, after they had been dining at Netherfield, ‘_She_
+a beauty!--I should as soon call her mother a wit.’ But afterwards she
+seemed to improve on you, and I believe you thought her rather pretty at
+one time.”
+
+“Yes,” replied Darcy, who could contain himself no longer, “but _that_
+was only when I first saw her, for it is many months since I have
+considered her as one of the handsomest women of my acquaintance.”
+
+He then went away, and Miss Bingley was left to all the satisfaction of
+having forced him to say what gave no one any pain but herself.
+
+Mrs. Gardiner and Elizabeth talked of all that had occurred during their
+visit, as they returned, except what had particularly interested them
+both. The look and behaviour of everybody they had seen were discussed,
+except of the person who had mostly engaged their attention. They talked
+of his sister, his friends, his house, his fruit--of everything but
+himself; yet Elizabeth was longing to know what Mrs. Gardiner thought of
+him, and Mrs. Gardiner would have been highly gratified by her niece’s
+beginning the subject.
+
+
+
+Chapter 46
+
+
+Elizabeth had been a good deal disappointed in not finding a letter from
+Jane on their first arrival at Lambton; and this disappointment had been
+renewed on each of the mornings that had now been spent there; but
+on the third her repining was over, and her sister justified, by the
+receipt of two letters from her at once, on one of which was marked that
+it had been missent elsewhere. Elizabeth was not surprised at it, as
+Jane had written the direction remarkably ill.
+
+They had just been preparing to walk as the letters came in; and
+her uncle and aunt, leaving her to enjoy them in quiet, set off by
+themselves. The one missent must first be attended to; it had been
+written five days ago. The beginning contained an account of all their
+little parties and engagements, with such news as the country afforded;
+but the latter half, which was dated a day later, and written in evident
+agitation, gave more important intelligence. It was to this effect:
+
+“Since writing the above, dearest Lizzy, something has occurred of a
+most unexpected and serious nature; but I am afraid of alarming you--be
+assured that we are all well. What I have to say relates to poor Lydia.
+An express came at twelve last night, just as we were all gone to bed,
+from Colonel Forster, to inform us that she was gone off to Scotland
+with one of his officers; to own the truth, with Wickham! Imagine our
+surprise. To Kitty, however, it does not seem so wholly unexpected. I am
+very, very sorry. So imprudent a match on both sides! But I am willing
+to hope the best, and that his character has been misunderstood.
+Thoughtless and indiscreet I can easily believe him, but this step
+(and let us rejoice over it) marks nothing bad at heart. His choice is
+disinterested at least, for he must know my father can give her nothing.
+Our poor mother is sadly grieved. My father bears it better. How
+thankful am I that we never let them know what has been said against
+him; we must forget it ourselves. They were off Saturday night about
+twelve, as is conjectured, but were not missed till yesterday morning at
+eight. The express was sent off directly. My dear Lizzy, they must have
+passed within ten miles of us. Colonel Forster gives us reason to expect
+him here soon. Lydia left a few lines for his wife, informing her of
+their intention. I must conclude, for I cannot be long from my poor
+mother. I am afraid you will not be able to make it out, but I hardly
+know what I have written.”
+
+Without allowing herself time for consideration, and scarcely knowing
+what she felt, Elizabeth on finishing this letter instantly seized the
+other, and opening it with the utmost impatience, read as follows: it
+had been written a day later than the conclusion of the first.
+
+“By this time, my dearest sister, you have received my hurried letter; I
+wish this may be more intelligible, but though not confined for time, my
+head is so bewildered that I cannot answer for being coherent. Dearest
+Lizzy, I hardly know what I would write, but I have bad news for you,
+and it cannot be delayed. Imprudent as the marriage between Mr. Wickham
+and our poor Lydia would be, we are now anxious to be assured it has
+taken place, for there is but too much reason to fear they are not gone
+to Scotland. Colonel Forster came yesterday, having left Brighton the
+day before, not many hours after the express. Though Lydia’s short
+letter to Mrs. F. gave them to understand that they were going to Gretna
+Green, something was dropped by Denny expressing his belief that W.
+never intended to go there, or to marry Lydia at all, which was
+repeated to Colonel F., who, instantly taking the alarm, set off from B.
+intending to trace their route. He did trace them easily to Clapham,
+but no further; for on entering that place, they removed into a hackney
+coach, and dismissed the chaise that brought them from Epsom. All that
+is known after this is, that they were seen to continue the London road.
+I know not what to think. After making every possible inquiry on that
+side London, Colonel F. came on into Hertfordshire, anxiously renewing
+them at all the turnpikes, and at the inns in Barnet and Hatfield, but
+without any success--no such people had been seen to pass through. With
+the kindest concern he came on to Longbourn, and broke his apprehensions
+to us in a manner most creditable to his heart. I am sincerely grieved
+for him and Mrs. F., but no one can throw any blame on them. Our
+distress, my dear Lizzy, is very great. My father and mother believe the
+worst, but I cannot think so ill of him. Many circumstances might make
+it more eligible for them to be married privately in town than to pursue
+their first plan; and even if _he_ could form such a design against a
+young woman of Lydia’s connections, which is not likely, can I suppose
+her so lost to everything? Impossible! I grieve to find, however, that
+Colonel F. is not disposed to depend upon their marriage; he shook his
+head when I expressed my hopes, and said he feared W. was not a man to
+be trusted. My poor mother is really ill, and keeps her room. Could she
+exert herself, it would be better; but this is not to be expected. And
+as to my father, I never in my life saw him so affected. Poor Kitty has
+anger for having concealed their attachment; but as it was a matter of
+confidence, one cannot wonder. I am truly glad, dearest Lizzy, that you
+have been spared something of these distressing scenes; but now, as the
+first shock is over, shall I own that I long for your return? I am not
+so selfish, however, as to press for it, if inconvenient. Adieu! I
+take up my pen again to do what I have just told you I would not; but
+circumstances are such that I cannot help earnestly begging you all to
+come here as soon as possible. I know my dear uncle and aunt so well,
+that I am not afraid of requesting it, though I have still something
+more to ask of the former. My father is going to London with Colonel
+Forster instantly, to try to discover her. What he means to do I am sure
+I know not; but his excessive distress will not allow him to pursue any
+measure in the best and safest way, and Colonel Forster is obliged to
+be at Brighton again to-morrow evening. In such an exigence, my
+uncle’s advice and assistance would be everything in the world; he will
+immediately comprehend what I must feel, and I rely upon his goodness.”
+
+“Oh! where, where is my uncle?” cried Elizabeth, darting from her seat
+as she finished the letter, in eagerness to follow him, without losing
+a moment of the time so precious; but as she reached the door it was
+opened by a servant, and Mr. Darcy appeared. Her pale face and impetuous
+manner made him start, and before he could recover himself to speak,
+she, in whose mind every idea was superseded by Lydia’s situation,
+hastily exclaimed, “I beg your pardon, but I must leave you. I must find
+Mr. Gardiner this moment, on business that cannot be delayed; I have not
+an instant to lose.”
+
+“Good God! what is the matter?” cried he, with more feeling than
+politeness; then recollecting himself, “I will not detain you a minute;
+but let me, or let the servant go after Mr. and Mrs. Gardiner. You are
+not well enough; you cannot go yourself.”
+
+Elizabeth hesitated, but her knees trembled under her and she felt how
+little would be gained by her attempting to pursue them. Calling back
+the servant, therefore, she commissioned him, though in so breathless
+an accent as made her almost unintelligible, to fetch his master and
+mistress home instantly.
+
+On his quitting the room she sat down, unable to support herself, and
+looking so miserably ill, that it was impossible for Darcy to leave her,
+or to refrain from saying, in a tone of gentleness and commiseration,
+“Let me call your maid. Is there nothing you could take to give you
+present relief? A glass of wine; shall I get you one? You are very ill.”
+
+“No, I thank you,” she replied, endeavouring to recover herself. “There
+is nothing the matter with me. I am quite well; I am only distressed by
+some dreadful news which I have just received from Longbourn.”
+
+She burst into tears as she alluded to it, and for a few minutes could
+not speak another word. Darcy, in wretched suspense, could only say
+something indistinctly of his concern, and observe her in compassionate
+silence. At length she spoke again. “I have just had a letter from Jane,
+with such dreadful news. It cannot be concealed from anyone. My younger
+sister has left all her friends--has eloped; has thrown herself into
+the power of--of Mr. Wickham. They are gone off together from Brighton.
+_You_ know him too well to doubt the rest. She has no money, no
+connections, nothing that can tempt him to--she is lost for ever.”
+
+Darcy was fixed in astonishment. “When I consider,” she added in a yet
+more agitated voice, “that I might have prevented it! I, who knew what
+he was. Had I but explained some part of it only--some part of what I
+learnt, to my own family! Had his character been known, this could not
+have happened. But it is all--all too late now.”
+
+“I am grieved indeed,” cried Darcy; “grieved--shocked. But is it
+certain--absolutely certain?”
+
+“Oh, yes! They left Brighton together on Sunday night, and were traced
+almost to London, but not beyond; they are certainly not gone to
+Scotland.”
+
+“And what has been done, what has been attempted, to recover her?”
+
+“My father is gone to London, and Jane has written to beg my uncle’s
+immediate assistance; and we shall be off, I hope, in half-an-hour. But
+nothing can be done--I know very well that nothing can be done. How is
+such a man to be worked on? How are they even to be discovered? I have
+not the smallest hope. It is every way horrible!”
+
+Darcy shook his head in silent acquiescence.
+
+“When _my_ eyes were opened to his real character--Oh! had I known what
+I ought, what I dared to do! But I knew not--I was afraid of doing too
+much. Wretched, wretched mistake!”
+
+Darcy made no answer. He seemed scarcely to hear her, and was walking
+up and down the room in earnest meditation, his brow contracted, his air
+gloomy. Elizabeth soon observed, and instantly understood it. Her
+power was sinking; everything _must_ sink under such a proof of family
+weakness, such an assurance of the deepest disgrace. She could neither
+wonder nor condemn, but the belief of his self-conquest brought nothing
+consolatory to her bosom, afforded no palliation of her distress. It
+was, on the contrary, exactly calculated to make her understand her own
+wishes; and never had she so honestly felt that she could have loved
+him, as now, when all love must be vain.
+
+But self, though it would intrude, could not engross her. Lydia--the
+humiliation, the misery she was bringing on them all, soon swallowed
+up every private care; and covering her face with her handkerchief,
+Elizabeth was soon lost to everything else; and, after a pause of
+several minutes, was only recalled to a sense of her situation by
+the voice of her companion, who, in a manner which, though it spoke
+compassion, spoke likewise restraint, said, “I am afraid you have been
+long desiring my absence, nor have I anything to plead in excuse of my
+stay, but real, though unavailing concern. Would to Heaven that anything
+could be either said or done on my part that might offer consolation to
+such distress! But I will not torment you with vain wishes, which may
+seem purposely to ask for your thanks. This unfortunate affair will, I
+fear, prevent my sister’s having the pleasure of seeing you at Pemberley
+to-day.”
+
+“Oh, yes. Be so kind as to apologise for us to Miss Darcy. Say that
+urgent business calls us home immediately. Conceal the unhappy truth as
+long as it is possible, I know it cannot be long.”
+
+He readily assured her of his secrecy; again expressed his sorrow for
+her distress, wished it a happier conclusion than there was at present
+reason to hope, and leaving his compliments for her relations, with only
+one serious, parting look, went away.
+
+As he quitted the room, Elizabeth felt how improbable it was that they
+should ever see each other again on such terms of cordiality as
+had marked their several meetings in Derbyshire; and as she threw a
+retrospective glance over the whole of their acquaintance, so full
+of contradictions and varieties, sighed at the perverseness of those
+feelings which would now have promoted its continuance, and would
+formerly have rejoiced in its termination.
+
+If gratitude and esteem are good foundations of affection, Elizabeth’s
+change of sentiment will be neither improbable nor faulty. But if
+otherwise--if regard springing from such sources is unreasonable or
+unnatural, in comparison of what is so often described as arising on
+a first interview with its object, and even before two words have been
+exchanged, nothing can be said in her defence, except that she had given
+somewhat of a trial to the latter method in her partiality for Wickham,
+and that its ill success might, perhaps, authorise her to seek the other
+less interesting mode of attachment. Be that as it may, she saw him
+go with regret; and in this early example of what Lydia’s infamy must
+produce, found additional anguish as she reflected on that wretched
+business. Never, since reading Jane’s second letter, had she entertained
+a hope of Wickham’s meaning to marry her. No one but Jane, she thought,
+could flatter herself with such an expectation. Surprise was the least
+of her feelings on this development. While the contents of the first
+letter remained in her mind, she was all surprise--all astonishment that
+Wickham should marry a girl whom it was impossible he could marry
+for money; and how Lydia could ever have attached him had appeared
+incomprehensible. But now it was all too natural. For such an attachment
+as this she might have sufficient charms; and though she did not suppose
+Lydia to be deliberately engaging in an elopement without the intention
+of marriage, she had no difficulty in believing that neither her virtue
+nor her understanding would preserve her from falling an easy prey.
+
+She had never perceived, while the regiment was in Hertfordshire, that
+Lydia had any partiality for him; but she was convinced that Lydia
+wanted only encouragement to attach herself to anybody. Sometimes one
+officer, sometimes another, had been her favourite, as their attentions
+raised them in her opinion. Her affections had continually been
+fluctuating but never without an object. The mischief of neglect and
+mistaken indulgence towards such a girl--oh! how acutely did she now
+feel it!
+
+She was wild to be at home--to hear, to see, to be upon the spot to
+share with Jane in the cares that must now fall wholly upon her, in a
+family so deranged, a father absent, a mother incapable of exertion, and
+requiring constant attendance; and though almost persuaded that nothing
+could be done for Lydia, her uncle’s interference seemed of the utmost
+importance, and till he entered the room her impatience was severe. Mr.
+and Mrs. Gardiner had hurried back in alarm, supposing by the servant’s
+account that their niece was taken suddenly ill; but satisfying them
+instantly on that head, she eagerly communicated the cause of their
+summons, reading the two letters aloud, and dwelling on the postscript
+of the last with trembling energy.--Though Lydia had never been a
+favourite with them, Mr. and Mrs. Gardiner could not but be deeply
+afflicted. Not Lydia only, but all were concerned in it; and after the
+first exclamations of surprise and horror, Mr. Gardiner promised every
+assistance in his power. Elizabeth, though expecting no less, thanked
+him with tears of gratitude; and all three being actuated by one spirit,
+everything relating to their journey was speedily settled. They were to
+be off as soon as possible. “But what is to be done about Pemberley?”
+ cried Mrs. Gardiner. “John told us Mr. Darcy was here when you sent for
+us; was it so?”
+
+“Yes; and I told him we should not be able to keep our engagement.
+_That_ is all settled.”
+
+“What is all settled?” repeated the other, as she ran into her room to
+prepare. “And are they upon such terms as for her to disclose the real
+truth? Oh, that I knew how it was!”
+
+But wishes were vain, or at least could only serve to amuse her in the
+hurry and confusion of the following hour. Had Elizabeth been at leisure
+to be idle, she would have remained certain that all employment was
+impossible to one so wretched as herself; but she had her share of
+business as well as her aunt, and amongst the rest there were notes to
+be written to all their friends at Lambton, with false excuses for their
+sudden departure. An hour, however, saw the whole completed; and Mr.
+Gardiner meanwhile having settled his account at the inn, nothing
+remained to be done but to go; and Elizabeth, after all the misery of
+the morning, found herself, in a shorter space of time than she could
+have supposed, seated in the carriage, and on the road to Longbourn.
+
+
+
+Chapter 47
+
+
+“I have been thinking it over again, Elizabeth,” said her uncle, as they
+drove from the town; “and really, upon serious consideration, I am much
+more inclined than I was to judge as your eldest sister does on the
+matter. It appears to me so very unlikely that any young man should
+form such a design against a girl who is by no means unprotected or
+friendless, and who was actually staying in his colonel’s family, that I
+am strongly inclined to hope the best. Could he expect that her friends
+would not step forward? Could he expect to be noticed again by the
+regiment, after such an affront to Colonel Forster? His temptation is
+not adequate to the risk!”
+
+“Do you really think so?” cried Elizabeth, brightening up for a moment.
+
+“Upon my word,” said Mrs. Gardiner, “I begin to be of your uncle’s
+opinion. It is really too great a violation of decency, honour, and
+interest, for him to be guilty of. I cannot think so very ill of
+Wickham. Can you yourself, Lizzy, so wholly give him up, as to believe
+him capable of it?”
+
+“Not, perhaps, of neglecting his own interest; but of every other
+neglect I can believe him capable. If, indeed, it should be so! But I
+dare not hope it. Why should they not go on to Scotland if that had been
+the case?”
+
+“In the first place,” replied Mr. Gardiner, “there is no absolute proof
+that they are not gone to Scotland.”
+
+“Oh! but their removing from the chaise into a hackney coach is such
+a presumption! And, besides, no traces of them were to be found on the
+Barnet road.”
+
+“Well, then--supposing them to be in London. They may be there, though
+for the purpose of concealment, for no more exceptional purpose. It is
+not likely that money should be very abundant on either side; and it
+might strike them that they could be more economically, though less
+expeditiously, married in London than in Scotland.”
+
+“But why all this secrecy? Why any fear of detection? Why must their
+marriage be private? Oh, no, no--this is not likely. His most particular
+friend, you see by Jane’s account, was persuaded of his never intending
+to marry her. Wickham will never marry a woman without some money. He
+cannot afford it. And what claims has Lydia--what attraction has she
+beyond youth, health, and good humour that could make him, for her sake,
+forego every chance of benefiting himself by marrying well? As to what
+restraint the apprehensions of disgrace in the corps might throw on a
+dishonourable elopement with her, I am not able to judge; for I know
+nothing of the effects that such a step might produce. But as to your
+other objection, I am afraid it will hardly hold good. Lydia has
+no brothers to step forward; and he might imagine, from my father’s
+behaviour, from his indolence and the little attention he has ever
+seemed to give to what was going forward in his family, that _he_ would
+do as little, and think as little about it, as any father could do, in
+such a matter.”
+
+“But can you think that Lydia is so lost to everything but love of him
+as to consent to live with him on any terms other than marriage?”
+
+“It does seem, and it is most shocking indeed,” replied Elizabeth, with
+tears in her eyes, “that a sister’s sense of decency and virtue in such
+a point should admit of doubt. But, really, I know not what to say.
+Perhaps I am not doing her justice. But she is very young; she has never
+been taught to think on serious subjects; and for the last half-year,
+nay, for a twelvemonth--she has been given up to nothing but amusement
+and vanity. She has been allowed to dispose of her time in the most idle
+and frivolous manner, and to adopt any opinions that came in her way.
+Since the ----shire were first quartered in Meryton, nothing but love,
+flirtation, and officers have been in her head. She has been doing
+everything in her power by thinking and talking on the subject, to give
+greater--what shall I call it? susceptibility to her feelings; which are
+naturally lively enough. And we all know that Wickham has every charm of
+person and address that can captivate a woman.”
+
+“But you see that Jane,” said her aunt, “does not think so very ill of
+Wickham as to believe him capable of the attempt.”
+
+“Of whom does Jane ever think ill? And who is there, whatever might be
+their former conduct, that she would think capable of such an attempt,
+till it were proved against them? But Jane knows, as well as I do, what
+Wickham really is. We both know that he has been profligate in every
+sense of the word; that he has neither integrity nor honour; that he is
+as false and deceitful as he is insinuating.”
+
+“And do you really know all this?” cried Mrs. Gardiner, whose curiosity
+as to the mode of her intelligence was all alive.
+
+“I do indeed,” replied Elizabeth, colouring. “I told you, the other day,
+of his infamous behaviour to Mr. Darcy; and you yourself, when last at
+Longbourn, heard in what manner he spoke of the man who had behaved
+with such forbearance and liberality towards him. And there are other
+circumstances which I am not at liberty--which it is not worth while to
+relate; but his lies about the whole Pemberley family are endless. From
+what he said of Miss Darcy I was thoroughly prepared to see a proud,
+reserved, disagreeable girl. Yet he knew to the contrary himself. He
+must know that she was as amiable and unpretending as we have found
+her.”
+
+“But does Lydia know nothing of this? can she be ignorant of what you
+and Jane seem so well to understand?”
+
+“Oh, yes!--that, that is the worst of all. Till I was in Kent, and saw
+so much both of Mr. Darcy and his relation Colonel Fitzwilliam, I was
+ignorant of the truth myself. And when I returned home, the ----shire
+was to leave Meryton in a week or fortnight’s time. As that was the
+case, neither Jane, to whom I related the whole, nor I, thought it
+necessary to make our knowledge public; for of what use could
+it apparently be to any one, that the good opinion which all the
+neighbourhood had of him should then be overthrown? And even when it was
+settled that Lydia should go with Mrs. Forster, the necessity of opening
+her eyes to his character never occurred to me. That _she_ could be
+in any danger from the deception never entered my head. That such a
+consequence as _this_ could ensue, you may easily believe, was far
+enough from my thoughts.”
+
+“When they all removed to Brighton, therefore, you had no reason, I
+suppose, to believe them fond of each other?”
+
+“Not the slightest. I can remember no symptom of affection on either
+side; and had anything of the kind been perceptible, you must be aware
+that ours is not a family on which it could be thrown away. When first
+he entered the corps, she was ready enough to admire him; but so we all
+were. Every girl in or near Meryton was out of her senses about him for
+the first two months; but he never distinguished _her_ by any particular
+attention; and, consequently, after a moderate period of extravagant and
+wild admiration, her fancy for him gave way, and others of the regiment,
+who treated her with more distinction, again became her favourites.”
+
+                          * * * * *
+
+It may be easily believed, that however little of novelty could be added
+to their fears, hopes, and conjectures, on this interesting subject, by
+its repeated discussion, no other could detain them from it long, during
+the whole of the journey. From Elizabeth’s thoughts it was never absent.
+Fixed there by the keenest of all anguish, self-reproach, she could find
+no interval of ease or forgetfulness.
+
+They travelled as expeditiously as possible, and, sleeping one night
+on the road, reached Longbourn by dinner time the next day. It was a
+comfort to Elizabeth to consider that Jane could not have been wearied
+by long expectations.
+
+The little Gardiners, attracted by the sight of a chaise, were standing
+on the steps of the house as they entered the paddock; and, when the
+carriage drove up to the door, the joyful surprise that lighted up their
+faces, and displayed itself over their whole bodies, in a variety of
+capers and frisks, was the first pleasing earnest of their welcome.
+
+Elizabeth jumped out; and, after giving each of them a hasty kiss,
+hurried into the vestibule, where Jane, who came running down from her
+mother’s apartment, immediately met her.
+
+Elizabeth, as she affectionately embraced her, whilst tears filled the
+eyes of both, lost not a moment in asking whether anything had been
+heard of the fugitives.
+
+“Not yet,” replied Jane. “But now that my dear uncle is come, I hope
+everything will be well.”
+
+“Is my father in town?”
+
+“Yes, he went on Tuesday, as I wrote you word.”
+
+“And have you heard from him often?”
+
+“We have heard only twice. He wrote me a few lines on Wednesday to say
+that he had arrived in safety, and to give me his directions, which I
+particularly begged him to do. He merely added that he should not write
+again till he had something of importance to mention.”
+
+“And my mother--how is she? How are you all?”
+
+“My mother is tolerably well, I trust; though her spirits are greatly
+shaken. She is up stairs and will have great satisfaction in seeing you
+all. She does not yet leave her dressing-room. Mary and Kitty, thank
+Heaven, are quite well.”
+
+“But you--how are you?” cried Elizabeth. “You look pale. How much you
+must have gone through!”
+
+Her sister, however, assured her of her being perfectly well; and their
+conversation, which had been passing while Mr. and Mrs. Gardiner were
+engaged with their children, was now put an end to by the approach
+of the whole party. Jane ran to her uncle and aunt, and welcomed and
+thanked them both, with alternate smiles and tears.
+
+When they were all in the drawing-room, the questions which Elizabeth
+had already asked were of course repeated by the others, and they soon
+found that Jane had no intelligence to give. The sanguine hope of
+good, however, which the benevolence of her heart suggested had not yet
+deserted her; she still expected that it would all end well, and that
+every morning would bring some letter, either from Lydia or her father,
+to explain their proceedings, and, perhaps, announce their marriage.
+
+Mrs. Bennet, to whose apartment they all repaired, after a few minutes’
+conversation together, received them exactly as might be expected; with
+tears and lamentations of regret, invectives against the villainous
+conduct of Wickham, and complaints of her own sufferings and ill-usage;
+blaming everybody but the person to whose ill-judging indulgence the
+errors of her daughter must principally be owing.
+
+“If I had been able,” said she, “to carry my point in going to Brighton,
+with all my family, _this_ would not have happened; but poor dear Lydia
+had nobody to take care of her. Why did the Forsters ever let her go out
+of their sight? I am sure there was some great neglect or other on their
+side, for she is not the kind of girl to do such a thing if she had been
+well looked after. I always thought they were very unfit to have the
+charge of her; but I was overruled, as I always am. Poor dear child!
+And now here’s Mr. Bennet gone away, and I know he will fight Wickham,
+wherever he meets him and then he will be killed, and what is to become
+of us all? The Collinses will turn us out before he is cold in his
+grave, and if you are not kind to us, brother, I do not know what we
+shall do.”
+
+They all exclaimed against such terrific ideas; and Mr. Gardiner, after
+general assurances of his affection for her and all her family, told her
+that he meant to be in London the very next day, and would assist Mr.
+Bennet in every endeavour for recovering Lydia.
+
+“Do not give way to useless alarm,” added he; “though it is right to be
+prepared for the worst, there is no occasion to look on it as certain.
+It is not quite a week since they left Brighton. In a few days more we
+may gain some news of them; and till we know that they are not married,
+and have no design of marrying, do not let us give the matter over as
+lost. As soon as I get to town I shall go to my brother, and make
+him come home with me to Gracechurch Street; and then we may consult
+together as to what is to be done.”
+
+“Oh! my dear brother,” replied Mrs. Bennet, “that is exactly what I
+could most wish for. And now do, when you get to town, find them out,
+wherever they may be; and if they are not married already, _make_ them
+marry. And as for wedding clothes, do not let them wait for that, but
+tell Lydia she shall have as much money as she chooses to buy them,
+after they are married. And, above all, keep Mr. Bennet from fighting.
+Tell him what a dreadful state I am in, that I am frighted out of my
+wits--and have such tremblings, such flutterings, all over me--such
+spasms in my side and pains in my head, and such beatings at heart, that
+I can get no rest by night nor by day. And tell my dear Lydia not to
+give any directions about her clothes till she has seen me, for she does
+not know which are the best warehouses. Oh, brother, how kind you are! I
+know you will contrive it all.”
+
+But Mr. Gardiner, though he assured her again of his earnest endeavours
+in the cause, could not avoid recommending moderation to her, as well
+in her hopes as her fear; and after talking with her in this manner till
+dinner was on the table, they all left her to vent all her feelings on
+the housekeeper, who attended in the absence of her daughters.
+
+Though her brother and sister were persuaded that there was no real
+occasion for such a seclusion from the family, they did not attempt to
+oppose it, for they knew that she had not prudence enough to hold her
+tongue before the servants, while they waited at table, and judged it
+better that _one_ only of the household, and the one whom they could
+most trust should comprehend all her fears and solicitude on the
+subject.
+
+In the dining-room they were soon joined by Mary and Kitty, who had been
+too busily engaged in their separate apartments to make their appearance
+before. One came from her books, and the other from her toilette. The
+faces of both, however, were tolerably calm; and no change was visible
+in either, except that the loss of her favourite sister, or the anger
+which she had herself incurred in this business, had given more of
+fretfulness than usual to the accents of Kitty. As for Mary, she was
+mistress enough of herself to whisper to Elizabeth, with a countenance
+of grave reflection, soon after they were seated at table:
+
+“This is a most unfortunate affair, and will probably be much talked of.
+But we must stem the tide of malice, and pour into the wounded bosoms of
+each other the balm of sisterly consolation.”
+
+Then, perceiving in Elizabeth no inclination of replying, she added,
+“Unhappy as the event must be for Lydia, we may draw from it this useful
+lesson: that loss of virtue in a female is irretrievable; that one
+false step involves her in endless ruin; that her reputation is no less
+brittle than it is beautiful; and that she cannot be too much guarded in
+her behaviour towards the undeserving of the other sex.”
+
+Elizabeth lifted up her eyes in amazement, but was too much oppressed
+to make any reply. Mary, however, continued to console herself with such
+kind of moral extractions from the evil before them.
+
+In the afternoon, the two elder Miss Bennets were able to be for
+half-an-hour by themselves; and Elizabeth instantly availed herself of
+the opportunity of making any inquiries, which Jane was equally eager to
+satisfy. After joining in general lamentations over the dreadful sequel
+of this event, which Elizabeth considered as all but certain, and Miss
+Bennet could not assert to be wholly impossible, the former continued
+the subject, by saying, “But tell me all and everything about it which
+I have not already heard. Give me further particulars. What did Colonel
+Forster say? Had they no apprehension of anything before the elopement
+took place? They must have seen them together for ever.”
+
+“Colonel Forster did own that he had often suspected some partiality,
+especially on Lydia’s side, but nothing to give him any alarm. I am so
+grieved for him! His behaviour was attentive and kind to the utmost. He
+_was_ coming to us, in order to assure us of his concern, before he had
+any idea of their not being gone to Scotland: when that apprehension
+first got abroad, it hastened his journey.”
+
+“And was Denny convinced that Wickham would not marry? Did he know of
+their intending to go off? Had Colonel Forster seen Denny himself?”
+
+“Yes; but, when questioned by _him_, Denny denied knowing anything of
+their plans, and would not give his real opinion about it. He did not
+repeat his persuasion of their not marrying--and from _that_, I am
+inclined to hope, he might have been misunderstood before.”
+
+“And till Colonel Forster came himself, not one of you entertained a
+doubt, I suppose, of their being really married?”
+
+“How was it possible that such an idea should enter our brains? I felt
+a little uneasy--a little fearful of my sister’s happiness with him
+in marriage, because I knew that his conduct had not been always quite
+right. My father and mother knew nothing of that; they only felt how
+imprudent a match it must be. Kitty then owned, with a very natural
+triumph on knowing more than the rest of us, that in Lydia’s last letter
+she had prepared her for such a step. She had known, it seems, of their
+being in love with each other, many weeks.”
+
+“But not before they went to Brighton?”
+
+“No, I believe not.”
+
+“And did Colonel Forster appear to think well of Wickham himself? Does
+he know his real character?”
+
+“I must confess that he did not speak so well of Wickham as he formerly
+did. He believed him to be imprudent and extravagant. And since this sad
+affair has taken place, it is said that he left Meryton greatly in debt;
+but I hope this may be false.”
+
+“Oh, Jane, had we been less secret, had we told what we knew of him,
+this could not have happened!”
+
+“Perhaps it would have been better,” replied her sister. “But to expose
+the former faults of any person without knowing what their present
+feelings were, seemed unjustifiable. We acted with the best intentions.”
+
+“Could Colonel Forster repeat the particulars of Lydia’s note to his
+wife?”
+
+“He brought it with him for us to see.”
+
+Jane then took it from her pocket-book, and gave it to Elizabeth. These
+were the contents:
+
+“MY DEAR HARRIET,
+
+“You will laugh when you know where I am gone, and I cannot help
+laughing myself at your surprise to-morrow morning, as soon as I am
+missed. I am going to Gretna Green, and if you cannot guess with who,
+I shall think you a simpleton, for there is but one man in the world I
+love, and he is an angel. I should never be happy without him, so think
+it no harm to be off. You need not send them word at Longbourn of my
+going, if you do not like it, for it will make the surprise the greater,
+when I write to them and sign my name ‘Lydia Wickham.’ What a good joke
+it will be! I can hardly write for laughing. Pray make my excuses to
+Pratt for not keeping my engagement, and dancing with him to-night.
+Tell him I hope he will excuse me when he knows all; and tell him I will
+dance with him at the next ball we meet, with great pleasure. I shall
+send for my clothes when I get to Longbourn; but I wish you would tell
+Sally to mend a great slit in my worked muslin gown before they are
+packed up. Good-bye. Give my love to Colonel Forster. I hope you will
+drink to our good journey.
+
+“Your affectionate friend,
+
+“LYDIA BENNET.”
+
+“Oh! thoughtless, thoughtless Lydia!” cried Elizabeth when she had
+finished it. “What a letter is this, to be written at such a moment!
+But at least it shows that _she_ was serious on the subject of their
+journey. Whatever he might afterwards persuade her to, it was not on her
+side a _scheme_ of infamy. My poor father! how he must have felt it!”
+
+“I never saw anyone so shocked. He could not speak a word for full ten
+minutes. My mother was taken ill immediately, and the whole house in
+such confusion!”
+
+“Oh! Jane,” cried Elizabeth, “was there a servant belonging to it who
+did not know the whole story before the end of the day?”
+
+“I do not know. I hope there was. But to be guarded at such a time is
+very difficult. My mother was in hysterics, and though I endeavoured to
+give her every assistance in my power, I am afraid I did not do so
+much as I might have done! But the horror of what might possibly happen
+almost took from me my faculties.”
+
+“Your attendance upon her has been too much for you. You do not look
+well. Oh that I had been with you! you have had every care and anxiety
+upon yourself alone.”
+
+“Mary and Kitty have been very kind, and would have shared in every
+fatigue, I am sure; but I did not think it right for either of them.
+Kitty is slight and delicate; and Mary studies so much, that her hours
+of repose should not be broken in on. My aunt Phillips came to Longbourn
+on Tuesday, after my father went away; and was so good as to stay till
+Thursday with me. She was of great use and comfort to us all. And
+Lady Lucas has been very kind; she walked here on Wednesday morning to
+condole with us, and offered her services, or any of her daughters’, if
+they should be of use to us.”
+
+“She had better have stayed at home,” cried Elizabeth; “perhaps she
+_meant_ well, but, under such a misfortune as this, one cannot see
+too little of one’s neighbours. Assistance is impossible; condolence
+insufferable. Let them triumph over us at a distance, and be satisfied.”
+
+She then proceeded to inquire into the measures which her father had
+intended to pursue, while in town, for the recovery of his daughter.
+
+“He meant I believe,” replied Jane, “to go to Epsom, the place where
+they last changed horses, see the postilions and try if anything could
+be made out from them. His principal object must be to discover the
+number of the hackney coach which took them from Clapham. It had come
+with a fare from London; and as he thought that the circumstance of a
+gentleman and lady’s removing from one carriage into another might
+be remarked he meant to make inquiries at Clapham. If he could anyhow
+discover at what house the coachman had before set down his fare, he
+determined to make inquiries there, and hoped it might not be impossible
+to find out the stand and number of the coach. I do not know of any
+other designs that he had formed; but he was in such a hurry to be gone,
+and his spirits so greatly discomposed, that I had difficulty in finding
+out even so much as this.”
+
+
+
+Chapter 48
+
+
+The whole party were in hopes of a letter from Mr. Bennet the next
+morning, but the post came in without bringing a single line from him.
+His family knew him to be, on all common occasions, a most negligent and
+dilatory correspondent; but at such a time they had hoped for exertion.
+They were forced to conclude that he had no pleasing intelligence to
+send; but even of _that_ they would have been glad to be certain. Mr.
+Gardiner had waited only for the letters before he set off.
+
+When he was gone, they were certain at least of receiving constant
+information of what was going on, and their uncle promised, at parting,
+to prevail on Mr. Bennet to return to Longbourn, as soon as he could,
+to the great consolation of his sister, who considered it as the only
+security for her husband’s not being killed in a duel.
+
+Mrs. Gardiner and the children were to remain in Hertfordshire a few
+days longer, as the former thought her presence might be serviceable
+to her nieces. She shared in their attendance on Mrs. Bennet, and was a
+great comfort to them in their hours of freedom. Their other aunt also
+visited them frequently, and always, as she said, with the design of
+cheering and heartening them up--though, as she never came without
+reporting some fresh instance of Wickham’s extravagance or irregularity,
+she seldom went away without leaving them more dispirited than she found
+them.
+
+All Meryton seemed striving to blacken the man who, but three months
+before, had been almost an angel of light. He was declared to be in debt
+to every tradesman in the place, and his intrigues, all honoured with
+the title of seduction, had been extended into every tradesman’s family.
+Everybody declared that he was the wickedest young man in the world;
+and everybody began to find out that they had always distrusted the
+appearance of his goodness. Elizabeth, though she did not credit above
+half of what was said, believed enough to make her former assurance of
+her sister’s ruin more certain; and even Jane, who believed still less
+of it, became almost hopeless, more especially as the time was now come
+when, if they had gone to Scotland, which she had never before entirely
+despaired of, they must in all probability have gained some news of
+them.
+
+Mr. Gardiner left Longbourn on Sunday; on Tuesday his wife received a
+letter from him; it told them that, on his arrival, he had immediately
+found out his brother, and persuaded him to come to Gracechurch Street;
+that Mr. Bennet had been to Epsom and Clapham, before his arrival,
+but without gaining any satisfactory information; and that he was now
+determined to inquire at all the principal hotels in town, as Mr. Bennet
+thought it possible they might have gone to one of them, on their first
+coming to London, before they procured lodgings. Mr. Gardiner himself
+did not expect any success from this measure, but as his brother was
+eager in it, he meant to assist him in pursuing it. He added that Mr.
+Bennet seemed wholly disinclined at present to leave London and promised
+to write again very soon. There was also a postscript to this effect:
+
+“I have written to Colonel Forster to desire him to find out, if
+possible, from some of the young man’s intimates in the regiment,
+whether Wickham has any relations or connections who would be likely to
+know in what part of town he has now concealed himself. If there were
+anyone that one could apply to with a probability of gaining such a
+clue as that, it might be of essential consequence. At present we have
+nothing to guide us. Colonel Forster will, I dare say, do everything in
+his power to satisfy us on this head. But, on second thoughts, perhaps,
+Lizzy could tell us what relations he has now living, better than any
+other person.”
+
+Elizabeth was at no loss to understand from whence this deference to her
+authority proceeded; but it was not in her power to give any information
+of so satisfactory a nature as the compliment deserved. She had never
+heard of his having had any relations, except a father and mother, both
+of whom had been dead many years. It was possible, however, that some of
+his companions in the ----shire might be able to give more information;
+and though she was not very sanguine in expecting it, the application
+was a something to look forward to.
+
+Every day at Longbourn was now a day of anxiety; but the most anxious
+part of each was when the post was expected. The arrival of letters
+was the grand object of every morning’s impatience. Through letters,
+whatever of good or bad was to be told would be communicated, and every
+succeeding day was expected to bring some news of importance.
+
+But before they heard again from Mr. Gardiner, a letter arrived for
+their father, from a different quarter, from Mr. Collins; which, as Jane
+had received directions to open all that came for him in his absence,
+she accordingly read; and Elizabeth, who knew what curiosities his
+letters always were, looked over her, and read it likewise. It was as
+follows:
+
+“MY DEAR SIR,
+
+“I feel myself called upon, by our relationship, and my situation
+in life, to condole with you on the grievous affliction you are now
+suffering under, of which we were yesterday informed by a letter from
+Hertfordshire. Be assured, my dear sir, that Mrs. Collins and myself
+sincerely sympathise with you and all your respectable family, in
+your present distress, which must be of the bitterest kind, because
+proceeding from a cause which no time can remove. No arguments shall be
+wanting on my part that can alleviate so severe a misfortune--or that
+may comfort you, under a circumstance that must be of all others the
+most afflicting to a parent’s mind. The death of your daughter would
+have been a blessing in comparison of this. And it is the more to
+be lamented, because there is reason to suppose as my dear Charlotte
+informs me, that this licentiousness of behaviour in your daughter has
+proceeded from a faulty degree of indulgence; though, at the same time,
+for the consolation of yourself and Mrs. Bennet, I am inclined to think
+that her own disposition must be naturally bad, or she could not be
+guilty of such an enormity, at so early an age. Howsoever that may be,
+you are grievously to be pitied; in which opinion I am not only joined
+by Mrs. Collins, but likewise by Lady Catherine and her daughter, to
+whom I have related the affair. They agree with me in apprehending that
+this false step in one daughter will be injurious to the fortunes of
+all the others; for who, as Lady Catherine herself condescendingly says,
+will connect themselves with such a family? And this consideration leads
+me moreover to reflect, with augmented satisfaction, on a certain event
+of last November; for had it been otherwise, I must have been involved
+in all your sorrow and disgrace. Let me then advise you, dear sir, to
+console yourself as much as possible, to throw off your unworthy child
+from your affection for ever, and leave her to reap the fruits of her
+own heinous offense.
+
+“I am, dear sir, etc., etc.”
+
+Mr. Gardiner did not write again till he had received an answer from
+Colonel Forster; and then he had nothing of a pleasant nature to send.
+It was not known that Wickham had a single relationship with whom he
+kept up any connection, and it was certain that he had no near one
+living. His former acquaintances had been numerous; but since he
+had been in the militia, it did not appear that he was on terms of
+particular friendship with any of them. There was no one, therefore,
+who could be pointed out as likely to give any news of him. And in the
+wretched state of his own finances, there was a very powerful motive for
+secrecy, in addition to his fear of discovery by Lydia’s relations, for
+it had just transpired that he had left gaming debts behind him to a
+very considerable amount. Colonel Forster believed that more than a
+thousand pounds would be necessary to clear his expenses at Brighton.
+He owed a good deal in town, but his debts of honour were still more
+formidable. Mr. Gardiner did not attempt to conceal these particulars
+from the Longbourn family. Jane heard them with horror. “A gamester!”
+ she cried. “This is wholly unexpected. I had not an idea of it.”
+
+Mr. Gardiner added in his letter, that they might expect to see their
+father at home on the following day, which was Saturday. Rendered
+spiritless by the ill-success of all their endeavours, he had yielded
+to his brother-in-law’s entreaty that he would return to his family, and
+leave it to him to do whatever occasion might suggest to be advisable
+for continuing their pursuit. When Mrs. Bennet was told of this, she did
+not express so much satisfaction as her children expected, considering
+what her anxiety for his life had been before.
+
+“What, is he coming home, and without poor Lydia?” she cried. “Sure he
+will not leave London before he has found them. Who is to fight Wickham,
+and make him marry her, if he comes away?”
+
+As Mrs. Gardiner began to wish to be at home, it was settled that she
+and the children should go to London, at the same time that Mr. Bennet
+came from it. The coach, therefore, took them the first stage of their
+journey, and brought its master back to Longbourn.
+
+Mrs. Gardiner went away in all the perplexity about Elizabeth and her
+Derbyshire friend that had attended her from that part of the world. His
+name had never been voluntarily mentioned before them by her niece; and
+the kind of half-expectation which Mrs. Gardiner had formed, of their
+being followed by a letter from him, had ended in nothing. Elizabeth had
+received none since her return that could come from Pemberley.
+
+The present unhappy state of the family rendered any other excuse for
+the lowness of her spirits unnecessary; nothing, therefore, could be
+fairly conjectured from _that_, though Elizabeth, who was by this time
+tolerably well acquainted with her own feelings, was perfectly aware
+that, had she known nothing of Darcy, she could have borne the dread of
+Lydia’s infamy somewhat better. It would have spared her, she thought,
+one sleepless night out of two.
+
+When Mr. Bennet arrived, he had all the appearance of his usual
+philosophic composure. He said as little as he had ever been in the
+habit of saying; made no mention of the business that had taken him
+away, and it was some time before his daughters had courage to speak of
+it.
+
+It was not till the afternoon, when he had joined them at tea, that
+Elizabeth ventured to introduce the subject; and then, on her briefly
+expressing her sorrow for what he must have endured, he replied, “Say
+nothing of that. Who should suffer but myself? It has been my own doing,
+and I ought to feel it.”
+
+“You must not be too severe upon yourself,” replied Elizabeth.
+
+“You may well warn me against such an evil. Human nature is so prone
+to fall into it! No, Lizzy, let me once in my life feel how much I have
+been to blame. I am not afraid of being overpowered by the impression.
+It will pass away soon enough.”
+
+“Do you suppose them to be in London?”
+
+“Yes; where else can they be so well concealed?”
+
+“And Lydia used to want to go to London,” added Kitty.
+
+“She is happy then,” said her father drily; “and her residence there
+will probably be of some duration.”
+
+Then after a short silence he continued:
+
+“Lizzy, I bear you no ill-will for being justified in your advice to me
+last May, which, considering the event, shows some greatness of mind.”
+
+They were interrupted by Miss Bennet, who came to fetch her mother’s
+tea.
+
+“This is a parade,” he cried, “which does one good; it gives such an
+elegance to misfortune! Another day I will do the same; I will sit in my
+library, in my nightcap and powdering gown, and give as much trouble as
+I can; or, perhaps, I may defer it till Kitty runs away.”
+
+“I am not going to run away, papa,” said Kitty fretfully. “If I should
+ever go to Brighton, I would behave better than Lydia.”
+
+“_You_ go to Brighton. I would not trust you so near it as Eastbourne
+for fifty pounds! No, Kitty, I have at last learnt to be cautious, and
+you will feel the effects of it. No officer is ever to enter into
+my house again, nor even to pass through the village. Balls will be
+absolutely prohibited, unless you stand up with one of your sisters.
+And you are never to stir out of doors till you can prove that you have
+spent ten minutes of every day in a rational manner.”
+
+Kitty, who took all these threats in a serious light, began to cry.
+
+“Well, well,” said he, “do not make yourself unhappy. If you are a good
+girl for the next ten years, I will take you to a review at the end of
+them.”
+
+
+
+Chapter 49
+
+
+Two days after Mr. Bennet’s return, as Jane and Elizabeth were walking
+together in the shrubbery behind the house, they saw the housekeeper
+coming towards them, and, concluding that she came to call them to their
+mother, went forward to meet her; but, instead of the expected summons,
+when they approached her, she said to Miss Bennet, “I beg your pardon,
+madam, for interrupting you, but I was in hopes you might have got some
+good news from town, so I took the liberty of coming to ask.”
+
+“What do you mean, Hill? We have heard nothing from town.”
+
+“Dear madam,” cried Mrs. Hill, in great astonishment, “don’t you know
+there is an express come for master from Mr. Gardiner? He has been here
+this half-hour, and master has had a letter.”
+
+Away ran the girls, too eager to get in to have time for speech. They
+ran through the vestibule into the breakfast-room; from thence to the
+library; their father was in neither; and they were on the point of
+seeking him up stairs with their mother, when they were met by the
+butler, who said:
+
+“If you are looking for my master, ma’am, he is walking towards the
+little copse.”
+
+Upon this information, they instantly passed through the hall once
+more, and ran across the lawn after their father, who was deliberately
+pursuing his way towards a small wood on one side of the paddock.
+
+Jane, who was not so light nor so much in the habit of running as
+Elizabeth, soon lagged behind, while her sister, panting for breath,
+came up with him, and eagerly cried out:
+
+“Oh, papa, what news--what news? Have you heard from my uncle?”
+
+“Yes I have had a letter from him by express.”
+
+“Well, and what news does it bring--good or bad?”
+
+“What is there of good to be expected?” said he, taking the letter from
+his pocket. “But perhaps you would like to read it.”
+
+Elizabeth impatiently caught it from his hand. Jane now came up.
+
+“Read it aloud,” said their father, “for I hardly know myself what it is
+about.”
+
+“Gracechurch Street, Monday, August 2.
+
+“MY DEAR BROTHER,
+
+“At last I am able to send you some tidings of my niece, and such as,
+upon the whole, I hope it will give you satisfaction. Soon after you
+left me on Saturday, I was fortunate enough to find out in what part of
+London they were. The particulars I reserve till we meet; it is enough
+to know they are discovered. I have seen them both--”
+
+“Then it is as I always hoped,” cried Jane; “they are married!”
+
+Elizabeth read on:
+
+“I have seen them both. They are not married, nor can I find there
+was any intention of being so; but if you are willing to perform the
+engagements which I have ventured to make on your side, I hope it will
+not be long before they are. All that is required of you is, to assure
+to your daughter, by settlement, her equal share of the five thousand
+pounds secured among your children after the decease of yourself and
+my sister; and, moreover, to enter into an engagement of allowing her,
+during your life, one hundred pounds per annum. These are conditions
+which, considering everything, I had no hesitation in complying with,
+as far as I thought myself privileged, for you. I shall send this by
+express, that no time may be lost in bringing me your answer. You
+will easily comprehend, from these particulars, that Mr. Wickham’s
+circumstances are not so hopeless as they are generally believed to be.
+The world has been deceived in that respect; and I am happy to say there
+will be some little money, even when all his debts are discharged, to
+settle on my niece, in addition to her own fortune. If, as I conclude
+will be the case, you send me full powers to act in your name throughout
+the whole of this business, I will immediately give directions to
+Haggerston for preparing a proper settlement. There will not be the
+smallest occasion for your coming to town again; therefore stay quiet at
+Longbourn, and depend on my diligence and care. Send back your answer as
+fast as you can, and be careful to write explicitly. We have judged it
+best that my niece should be married from this house, of which I hope
+you will approve. She comes to us to-day. I shall write again as soon as
+anything more is determined on. Yours, etc.,
+
+“EDW. GARDINER.”
+
+“Is it possible?” cried Elizabeth, when she had finished. “Can it be
+possible that he will marry her?”
+
+“Wickham is not so undeserving, then, as we thought him,” said her
+sister. “My dear father, I congratulate you.”
+
+“And have you answered the letter?” cried Elizabeth.
+
+“No; but it must be done soon.”
+
+Most earnestly did she then entreat him to lose no more time before he
+wrote.
+
+“Oh! my dear father,” she cried, “come back and write immediately.
+Consider how important every moment is in such a case.”
+
+“Let me write for you,” said Jane, “if you dislike the trouble
+yourself.”
+
+“I dislike it very much,” he replied; “but it must be done.”
+
+And so saying, he turned back with them, and walked towards the house.
+
+“And may I ask--” said Elizabeth; “but the terms, I suppose, must be
+complied with.”
+
+“Complied with! I am only ashamed of his asking so little.”
+
+“And they _must_ marry! Yet he is _such_ a man!”
+
+“Yes, yes, they must marry. There is nothing else to be done. But there
+are two things that I want very much to know; one is, how much money
+your uncle has laid down to bring it about; and the other, how am I ever
+to pay him.”
+
+“Money! My uncle!” cried Jane, “what do you mean, sir?”
+
+“I mean, that no man in his senses would marry Lydia on so slight a
+temptation as one hundred a year during my life, and fifty after I am
+gone.”
+
+“That is very true,” said Elizabeth; “though it had not occurred to me
+before. His debts to be discharged, and something still to remain! Oh!
+it must be my uncle’s doings! Generous, good man, I am afraid he has
+distressed himself. A small sum could not do all this.”
+
+“No,” said her father; “Wickham’s a fool if he takes her with a farthing
+less than ten thousand pounds. I should be sorry to think so ill of him,
+in the very beginning of our relationship.”
+
+“Ten thousand pounds! Heaven forbid! How is half such a sum to be
+repaid?”
+
+Mr. Bennet made no answer, and each of them, deep in thought, continued
+silent till they reached the house. Their father then went on to the
+library to write, and the girls walked into the breakfast-room.
+
+“And they are really to be married!” cried Elizabeth, as soon as they
+were by themselves. “How strange this is! And for _this_ we are to be
+thankful. That they should marry, small as is their chance of happiness,
+and wretched as is his character, we are forced to rejoice. Oh, Lydia!”
+
+“I comfort myself with thinking,” replied Jane, “that he certainly would
+not marry Lydia if he had not a real regard for her. Though our kind
+uncle has done something towards clearing him, I cannot believe that ten
+thousand pounds, or anything like it, has been advanced. He has children
+of his own, and may have more. How could he spare half ten thousand
+pounds?”
+
+“If he were ever able to learn what Wickham’s debts have been,” said
+Elizabeth, “and how much is settled on his side on our sister, we shall
+exactly know what Mr. Gardiner has done for them, because Wickham has
+not sixpence of his own. The kindness of my uncle and aunt can never
+be requited. Their taking her home, and affording her their personal
+protection and countenance, is such a sacrifice to her advantage as
+years of gratitude cannot enough acknowledge. By this time she is
+actually with them! If such goodness does not make her miserable now,
+she will never deserve to be happy! What a meeting for her, when she
+first sees my aunt!”
+
+“We must endeavour to forget all that has passed on either side,” said
+Jane: “I hope and trust they will yet be happy. His consenting to
+marry her is a proof, I will believe, that he is come to a right way of
+thinking. Their mutual affection will steady them; and I flatter myself
+they will settle so quietly, and live in so rational a manner, as may in
+time make their past imprudence forgotten.”
+
+“Their conduct has been such,” replied Elizabeth, “as neither you, nor
+I, nor anybody can ever forget. It is useless to talk of it.”
+
+It now occurred to the girls that their mother was in all likelihood
+perfectly ignorant of what had happened. They went to the library,
+therefore, and asked their father whether he would not wish them to make
+it known to her. He was writing and, without raising his head, coolly
+replied:
+
+“Just as you please.”
+
+“May we take my uncle’s letter to read to her?”
+
+“Take whatever you like, and get away.”
+
+Elizabeth took the letter from his writing-table, and they went up stairs
+together. Mary and Kitty were both with Mrs. Bennet: one communication
+would, therefore, do for all. After a slight preparation for good news,
+the letter was read aloud. Mrs. Bennet could hardly contain herself. As
+soon as Jane had read Mr. Gardiner’s hope of Lydia’s being soon
+married, her joy burst forth, and every following sentence added to its
+exuberance. She was now in an irritation as violent from delight, as she
+had ever been fidgety from alarm and vexation. To know that her daughter
+would be married was enough. She was disturbed by no fear for her
+felicity, nor humbled by any remembrance of her misconduct.
+
+“My dear, dear Lydia!” she cried. “This is delightful indeed! She will
+be married! I shall see her again! She will be married at sixteen!
+My good, kind brother! I knew how it would be. I knew he would manage
+everything! How I long to see her! and to see dear Wickham too! But the
+clothes, the wedding clothes! I will write to my sister Gardiner about
+them directly. Lizzy, my dear, run down to your father, and ask him
+how much he will give her. Stay, stay, I will go myself. Ring the bell,
+Kitty, for Hill. I will put on my things in a moment. My dear, dear
+Lydia! How merry we shall be together when we meet!”
+
+Her eldest daughter endeavoured to give some relief to the violence of
+these transports, by leading her thoughts to the obligations which Mr.
+Gardiner’s behaviour laid them all under.
+
+“For we must attribute this happy conclusion,” she added, “in a great
+measure to his kindness. We are persuaded that he has pledged himself to
+assist Mr. Wickham with money.”
+
+“Well,” cried her mother, “it is all very right; who should do it but
+her own uncle? If he had not had a family of his own, I and my children
+must have had all his money, you know; and it is the first time we have
+ever had anything from him, except a few presents. Well! I am so happy!
+In a short time I shall have a daughter married. Mrs. Wickham! How well
+it sounds! And she was only sixteen last June. My dear Jane, I am in
+such a flutter, that I am sure I can’t write; so I will dictate, and
+you write for me. We will settle with your father about the money
+afterwards; but the things should be ordered immediately.”
+
+She was then proceeding to all the particulars of calico, muslin, and
+cambric, and would shortly have dictated some very plentiful orders, had
+not Jane, though with some difficulty, persuaded her to wait till her
+father was at leisure to be consulted. One day’s delay, she observed,
+would be of small importance; and her mother was too happy to be quite
+so obstinate as usual. Other schemes, too, came into her head.
+
+“I will go to Meryton,” said she, “as soon as I am dressed, and tell the
+good, good news to my sister Philips. And as I come back, I can call
+on Lady Lucas and Mrs. Long. Kitty, run down and order the carriage.
+An airing would do me a great deal of good, I am sure. Girls, can I do
+anything for you in Meryton? Oh! Here comes Hill! My dear Hill, have you
+heard the good news? Miss Lydia is going to be married; and you shall
+all have a bowl of punch to make merry at her wedding.”
+
+Mrs. Hill began instantly to express her joy. Elizabeth received her
+congratulations amongst the rest, and then, sick of this folly, took
+refuge in her own room, that she might think with freedom.
+
+Poor Lydia’s situation must, at best, be bad enough; but that it was
+no worse, she had need to be thankful. She felt it so; and though, in
+looking forward, neither rational happiness nor worldly prosperity could
+be justly expected for her sister, in looking back to what they had
+feared, only two hours ago, she felt all the advantages of what they had
+gained.
+
+
+
+Chapter 50
+
+
+Mr. Bennet had very often wished before this period of his life that,
+instead of spending his whole income, he had laid by an annual sum for
+the better provision of his children, and of his wife, if she survived
+him. He now wished it more than ever. Had he done his duty in that
+respect, Lydia need not have been indebted to her uncle for whatever
+of honour or credit could now be purchased for her. The satisfaction of
+prevailing on one of the most worthless young men in Great Britain to be
+her husband might then have rested in its proper place.
+
+He was seriously concerned that a cause of so little advantage to anyone
+should be forwarded at the sole expense of his brother-in-law, and he
+was determined, if possible, to find out the extent of his assistance,
+and to discharge the obligation as soon as he could.
+
+When first Mr. Bennet had married, economy was held to be perfectly
+useless, for, of course, they were to have a son. The son was to join
+in cutting off the entail, as soon as he should be of age, and the widow
+and younger children would by that means be provided for. Five daughters
+successively entered the world, but yet the son was to come; and Mrs.
+Bennet, for many years after Lydia’s birth, had been certain that he
+would. This event had at last been despaired of, but it was then
+too late to be saving. Mrs. Bennet had no turn for economy, and her
+husband’s love of independence had alone prevented their exceeding their
+income.
+
+Five thousand pounds was settled by marriage articles on Mrs. Bennet and
+the children. But in what proportions it should be divided amongst the
+latter depended on the will of the parents. This was one point, with
+regard to Lydia, at least, which was now to be settled, and Mr. Bennet
+could have no hesitation in acceding to the proposal before him. In
+terms of grateful acknowledgment for the kindness of his brother,
+though expressed most concisely, he then delivered on paper his perfect
+approbation of all that was done, and his willingness to fulfil the
+engagements that had been made for him. He had never before supposed
+that, could Wickham be prevailed on to marry his daughter, it would
+be done with so little inconvenience to himself as by the present
+arrangement. He would scarcely be ten pounds a year the loser by the
+hundred that was to be paid them; for, what with her board and pocket
+allowance, and the continual presents in money which passed to her
+through her mother’s hands, Lydia’s expenses had been very little within
+that sum.
+
+That it would be done with such trifling exertion on his side, too, was
+another very welcome surprise; for his wish at present was to have as
+little trouble in the business as possible. When the first transports
+of rage which had produced his activity in seeking her were over, he
+naturally returned to all his former indolence. His letter was soon
+dispatched; for, though dilatory in undertaking business, he was quick
+in its execution. He begged to know further particulars of what he
+was indebted to his brother, but was too angry with Lydia to send any
+message to her.
+
+The good news spread quickly through the house, and with proportionate
+speed through the neighbourhood. It was borne in the latter with decent
+philosophy. To be sure, it would have been more for the advantage
+of conversation had Miss Lydia Bennet come upon the town; or, as the
+happiest alternative, been secluded from the world, in some distant
+farmhouse. But there was much to be talked of in marrying her; and the
+good-natured wishes for her well-doing which had proceeded before from
+all the spiteful old ladies in Meryton lost but a little of their spirit
+in this change of circumstances, because with such an husband her misery
+was considered certain.
+
+It was a fortnight since Mrs. Bennet had been downstairs; but on this
+happy day she again took her seat at the head of her table, and in
+spirits oppressively high. No sentiment of shame gave a damp to her
+triumph. The marriage of a daughter, which had been the first object
+of her wishes since Jane was sixteen, was now on the point of
+accomplishment, and her thoughts and her words ran wholly on those
+attendants of elegant nuptials, fine muslins, new carriages, and
+servants. She was busily searching through the neighbourhood for a
+proper situation for her daughter, and, without knowing or considering
+what their income might be, rejected many as deficient in size and
+importance.
+
+“Haye Park might do,” said she, “if the Gouldings could quit it--or the
+great house at Stoke, if the drawing-room were larger; but Ashworth is
+too far off! I could not bear to have her ten miles from me; and as for
+Pulvis Lodge, the attics are dreadful.”
+
+Her husband allowed her to talk on without interruption while the
+servants remained. But when they had withdrawn, he said to her: “Mrs.
+Bennet, before you take any or all of these houses for your son and
+daughter, let us come to a right understanding. Into _one_ house in this
+neighbourhood they shall never have admittance. I will not encourage the
+impudence of either, by receiving them at Longbourn.”
+
+A long dispute followed this declaration; but Mr. Bennet was firm. It
+soon led to another; and Mrs. Bennet found, with amazement and horror,
+that her husband would not advance a guinea to buy clothes for his
+daughter. He protested that she should receive from him no mark of
+affection whatever on the occasion. Mrs. Bennet could hardly comprehend
+it. That his anger could be carried to such a point of inconceivable
+resentment as to refuse his daughter a privilege without which her
+marriage would scarcely seem valid, exceeded all she could believe
+possible. She was more alive to the disgrace which her want of new
+clothes must reflect on her daughter’s nuptials, than to any sense of
+shame at her eloping and living with Wickham a fortnight before they
+took place.
+
+Elizabeth was now most heartily sorry that she had, from the distress of
+the moment, been led to make Mr. Darcy acquainted with their fears for
+her sister; for since her marriage would so shortly give the
+proper termination to the elopement, they might hope to conceal its
+unfavourable beginning from all those who were not immediately on the
+spot.
+
+She had no fear of its spreading farther through his means. There were
+few people on whose secrecy she would have more confidently depended;
+but, at the same time, there was no one whose knowledge of a sister’s
+frailty would have mortified her so much--not, however, from any fear
+of disadvantage from it individually to herself, for, at any rate,
+there seemed a gulf impassable between them. Had Lydia’s marriage been
+concluded on the most honourable terms, it was not to be supposed that
+Mr. Darcy would connect himself with a family where, to every other
+objection, would now be added an alliance and relationship of the
+nearest kind with a man whom he so justly scorned.
+
+From such a connection she could not wonder that he would shrink. The
+wish of procuring her regard, which she had assured herself of his
+feeling in Derbyshire, could not in rational expectation survive such a
+blow as this. She was humbled, she was grieved; she repented, though she
+hardly knew of what. She became jealous of his esteem, when she could no
+longer hope to be benefited by it. She wanted to hear of him, when there
+seemed the least chance of gaining intelligence. She was convinced that
+she could have been happy with him, when it was no longer likely they
+should meet.
+
+What a triumph for him, as she often thought, could he know that the
+proposals which she had proudly spurned only four months ago, would now
+have been most gladly and gratefully received! He was as generous, she
+doubted not, as the most generous of his sex; but while he was mortal,
+there must be a triumph.
+
+She began now to comprehend that he was exactly the man who, in
+disposition and talents, would most suit her. His understanding and
+temper, though unlike her own, would have answered all her wishes. It
+was an union that must have been to the advantage of both; by her ease
+and liveliness, his mind might have been softened, his manners improved;
+and from his judgement, information, and knowledge of the world, she
+must have received benefit of greater importance.
+
+But no such happy marriage could now teach the admiring multitude what
+connubial felicity really was. An union of a different tendency, and
+precluding the possibility of the other, was soon to be formed in their
+family.
+
+How Wickham and Lydia were to be supported in tolerable independence,
+she could not imagine. But how little of permanent happiness could
+belong to a couple who were only brought together because their passions
+were stronger than their virtue, she could easily conjecture.
+
+                          * * * * *
+
+Mr. Gardiner soon wrote again to his brother. To Mr. Bennet’s
+acknowledgments he briefly replied, with assurance of his eagerness to
+promote the welfare of any of his family; and concluded with entreaties
+that the subject might never be mentioned to him again. The principal
+purport of his letter was to inform them that Mr. Wickham had resolved
+on quitting the militia.
+
+“It was greatly my wish that he should do so,” he added, “as soon as
+his marriage was fixed on. And I think you will agree with me, in
+considering the removal from that corps as highly advisable, both on
+his account and my niece’s. It is Mr. Wickham’s intention to go into
+the regulars; and among his former friends, there are still some who
+are able and willing to assist him in the army. He has the promise of an
+ensigncy in General ----‘s regiment, now quartered in the North. It
+is an advantage to have it so far from this part of the kingdom. He
+promises fairly; and I hope among different people, where they may each
+have a character to preserve, they will both be more prudent. I have
+written to Colonel Forster, to inform him of our present arrangements,
+and to request that he will satisfy the various creditors of Mr. Wickham
+in and near Brighton, with assurances of speedy payment, for which I
+have pledged myself. And will you give yourself the trouble of carrying
+similar assurances to his creditors in Meryton, of whom I shall subjoin
+a list according to his information? He has given in all his debts; I
+hope at least he has not deceived us. Haggerston has our directions,
+and all will be completed in a week. They will then join his regiment,
+unless they are first invited to Longbourn; and I understand from Mrs.
+Gardiner, that my niece is very desirous of seeing you all before she
+leaves the South. She is well, and begs to be dutifully remembered to
+you and her mother.--Yours, etc.,
+
+“E. GARDINER.”
+
+Mr. Bennet and his daughters saw all the advantages of Wickham’s removal
+from the ----shire as clearly as Mr. Gardiner could do. But Mrs. Bennet
+was not so well pleased with it. Lydia’s being settled in the North,
+just when she had expected most pleasure and pride in her company,
+for she had by no means given up her plan of their residing in
+Hertfordshire, was a severe disappointment; and, besides, it was such a
+pity that Lydia should be taken from a regiment where she was acquainted
+with everybody, and had so many favourites.
+
+“She is so fond of Mrs. Forster,” said she, “it will be quite shocking
+to send her away! And there are several of the young men, too, that she
+likes very much. The officers may not be so pleasant in General ----‘s
+regiment.”
+
+His daughter’s request, for such it might be considered, of being
+admitted into her family again before she set off for the North,
+received at first an absolute negative. But Jane and Elizabeth,
+who agreed in wishing, for the sake of their sister’s feelings and
+consequence, that she should be noticed on her marriage by her parents,
+urged him so earnestly yet so rationally and so mildly, to receive her
+and her husband at Longbourn, as soon as they were married, that he was
+prevailed on to think as they thought, and act as they wished. And their
+mother had the satisfaction of knowing that she would be able to show
+her married daughter in the neighbourhood before she was banished to the
+North. When Mr. Bennet wrote again to his brother, therefore, he sent
+his permission for them to come; and it was settled, that as soon as
+the ceremony was over, they should proceed to Longbourn. Elizabeth was
+surprised, however, that Wickham should consent to such a scheme, and
+had she consulted only her own inclination, any meeting with him would
+have been the last object of her wishes.
+
+
+
+Chapter 51
+
+
+Their sister’s wedding day arrived; and Jane and Elizabeth felt for her
+probably more than she felt for herself. The carriage was sent to
+meet them at ----, and they were to return in it by dinner-time. Their
+arrival was dreaded by the elder Miss Bennets, and Jane more especially,
+who gave Lydia the feelings which would have attended herself, had she
+been the culprit, and was wretched in the thought of what her sister
+must endure.
+
+They came. The family were assembled in the breakfast room to receive
+them. Smiles decked the face of Mrs. Bennet as the carriage drove up to
+the door; her husband looked impenetrably grave; her daughters, alarmed,
+anxious, uneasy.
+
+Lydia’s voice was heard in the vestibule; the door was thrown open, and
+she ran into the room. Her mother stepped forwards, embraced her, and
+welcomed her with rapture; gave her hand, with an affectionate smile,
+to Wickham, who followed his lady; and wished them both joy with an
+alacrity which shewed no doubt of their happiness.
+
+Their reception from Mr. Bennet, to whom they then turned, was not quite
+so cordial. His countenance rather gained in austerity; and he scarcely
+opened his lips. The easy assurance of the young couple, indeed, was
+enough to provoke him. Elizabeth was disgusted, and even Miss Bennet
+was shocked. Lydia was Lydia still; untamed, unabashed, wild, noisy,
+and fearless. She turned from sister to sister, demanding their
+congratulations; and when at length they all sat down, looked eagerly
+round the room, took notice of some little alteration in it, and
+observed, with a laugh, that it was a great while since she had been
+there.
+
+Wickham was not at all more distressed than herself, but his manners
+were always so pleasing, that had his character and his marriage been
+exactly what they ought, his smiles and his easy address, while he
+claimed their relationship, would have delighted them all. Elizabeth had
+not before believed him quite equal to such assurance; but she sat down,
+resolving within herself to draw no limits in future to the impudence
+of an impudent man. She blushed, and Jane blushed; but the cheeks of the
+two who caused their confusion suffered no variation of colour.
+
+There was no want of discourse. The bride and her mother could neither
+of them talk fast enough; and Wickham, who happened to sit near
+Elizabeth, began inquiring after his acquaintance in that neighbourhood,
+with a good humoured ease which she felt very unable to equal in her
+replies. They seemed each of them to have the happiest memories in the
+world. Nothing of the past was recollected with pain; and Lydia led
+voluntarily to subjects which her sisters would not have alluded to for
+the world.
+
+“Only think of its being three months,” she cried, “since I went away;
+it seems but a fortnight I declare; and yet there have been things
+enough happened in the time. Good gracious! when I went away, I am sure
+I had no more idea of being married till I came back again! though I
+thought it would be very good fun if I was.”
+
+Her father lifted up his eyes. Jane was distressed. Elizabeth looked
+expressively at Lydia; but she, who never heard nor saw anything of
+which she chose to be insensible, gaily continued, “Oh! mamma, do the
+people hereabouts know I am married to-day? I was afraid they might not;
+and we overtook William Goulding in his curricle, so I was determined he
+should know it, and so I let down the side-glass next to him, and took
+off my glove, and let my hand just rest upon the window frame, so that
+he might see the ring, and then I bowed and smiled like anything.”
+
+Elizabeth could bear it no longer. She got up, and ran out of the room;
+and returned no more, till she heard them passing through the hall to
+the dining parlour. She then joined them soon enough to see Lydia, with
+anxious parade, walk up to her mother’s right hand, and hear her say
+to her eldest sister, “Ah! Jane, I take your place now, and you must go
+lower, because I am a married woman.”
+
+It was not to be supposed that time would give Lydia that embarrassment
+from which she had been so wholly free at first. Her ease and good
+spirits increased. She longed to see Mrs. Phillips, the Lucases, and
+all their other neighbours, and to hear herself called “Mrs. Wickham”
+ by each of them; and in the mean time, she went after dinner to show her
+ring, and boast of being married, to Mrs. Hill and the two housemaids.
+
+“Well, mamma,” said she, when they were all returned to the breakfast
+room, “and what do you think of my husband? Is not he a charming man? I
+am sure my sisters must all envy me. I only hope they may have half
+my good luck. They must all go to Brighton. That is the place to get
+husbands. What a pity it is, mamma, we did not all go.”
+
+“Very true; and if I had my will, we should. But my dear Lydia, I don’t
+at all like your going such a way off. Must it be so?”
+
+“Oh, lord! yes;--there is nothing in that. I shall like it of all
+things. You and papa, and my sisters, must come down and see us. We
+shall be at Newcastle all the winter, and I dare say there will be some
+balls, and I will take care to get good partners for them all.”
+
+“I should like it beyond anything!” said her mother.
+
+“And then when you go away, you may leave one or two of my sisters
+behind you; and I dare say I shall get husbands for them before the
+winter is over.”
+
+“I thank you for my share of the favour,” said Elizabeth; “but I do not
+particularly like your way of getting husbands.”
+
+Their visitors were not to remain above ten days with them. Mr. Wickham
+had received his commission before he left London, and he was to join
+his regiment at the end of a fortnight.
+
+No one but Mrs. Bennet regretted that their stay would be so short; and
+she made the most of the time by visiting about with her daughter, and
+having very frequent parties at home. These parties were acceptable to
+all; to avoid a family circle was even more desirable to such as did
+think, than such as did not.
+
+Wickham’s affection for Lydia was just what Elizabeth had expected
+to find it; not equal to Lydia’s for him. She had scarcely needed her
+present observation to be satisfied, from the reason of things, that
+their elopement had been brought on by the strength of her love, rather
+than by his; and she would have wondered why, without violently caring
+for her, he chose to elope with her at all, had she not felt certain
+that his flight was rendered necessary by distress of circumstances; and
+if that were the case, he was not the young man to resist an opportunity
+of having a companion.
+
+Lydia was exceedingly fond of him. He was her dear Wickham on every
+occasion; no one was to be put in competition with him. He did every
+thing best in the world; and she was sure he would kill more birds on
+the first of September, than any body else in the country.
+
+One morning, soon after their arrival, as she was sitting with her two
+elder sisters, she said to Elizabeth:
+
+“Lizzy, I never gave _you_ an account of my wedding, I believe. You
+were not by, when I told mamma and the others all about it. Are not you
+curious to hear how it was managed?”
+
+“No really,” replied Elizabeth; “I think there cannot be too little said
+on the subject.”
+
+“La! You are so strange! But I must tell you how it went off. We were
+married, you know, at St. Clement’s, because Wickham’s lodgings were in
+that parish. And it was settled that we should all be there by eleven
+o’clock. My uncle and aunt and I were to go together; and the others
+were to meet us at the church. Well, Monday morning came, and I was in
+such a fuss! I was so afraid, you know, that something would happen to
+put it off, and then I should have gone quite distracted. And there was
+my aunt, all the time I was dressing, preaching and talking away just as
+if she was reading a sermon. However, I did not hear above one word in
+ten, for I was thinking, you may suppose, of my dear Wickham. I longed
+to know whether he would be married in his blue coat.”
+
+“Well, and so we breakfasted at ten as usual; I thought it would never
+be over; for, by the bye, you are to understand, that my uncle and aunt
+were horrid unpleasant all the time I was with them. If you’ll believe
+me, I did not once put my foot out of doors, though I was there a
+fortnight. Not one party, or scheme, or anything. To be sure London was
+rather thin, but, however, the Little Theatre was open. Well, and so
+just as the carriage came to the door, my uncle was called away upon
+business to that horrid man Mr. Stone. And then, you know, when once
+they get together, there is no end of it. Well, I was so frightened I
+did not know what to do, for my uncle was to give me away; and if we
+were beyond the hour, we could not be married all day. But, luckily, he
+came back again in ten minutes’ time, and then we all set out. However,
+I recollected afterwards that if he had been prevented going, the
+wedding need not be put off, for Mr. Darcy might have done as well.”
+
+“Mr. Darcy!” repeated Elizabeth, in utter amazement.
+
+“Oh, yes!--he was to come there with Wickham, you know. But gracious
+me! I quite forgot! I ought not to have said a word about it. I promised
+them so faithfully! What will Wickham say? It was to be such a secret!”
+
+“If it was to be secret,” said Jane, “say not another word on the
+subject. You may depend upon my seeking no further.”
+
+“Oh! certainly,” said Elizabeth, though burning with curiosity; “we will
+ask you no questions.”
+
+“Thank you,” said Lydia, “for if you did, I should certainly tell you
+all, and then Wickham would be angry.”
+
+On such encouragement to ask, Elizabeth was forced to put it out of her
+power, by running away.
+
+But to live in ignorance on such a point was impossible; or at least
+it was impossible not to try for information. Mr. Darcy had been at
+her sister’s wedding. It was exactly a scene, and exactly among people,
+where he had apparently least to do, and least temptation to go.
+Conjectures as to the meaning of it, rapid and wild, hurried into her
+brain; but she was satisfied with none. Those that best pleased her, as
+placing his conduct in the noblest light, seemed most improbable. She
+could not bear such suspense; and hastily seizing a sheet of paper,
+wrote a short letter to her aunt, to request an explanation of what
+Lydia had dropt, if it were compatible with the secrecy which had been
+intended.
+
+“You may readily comprehend,” she added, “what my curiosity must be
+to know how a person unconnected with any of us, and (comparatively
+speaking) a stranger to our family, should have been amongst you at such
+a time. Pray write instantly, and let me understand it--unless it is,
+for very cogent reasons, to remain in the secrecy which Lydia seems
+to think necessary; and then I must endeavour to be satisfied with
+ignorance.”
+
+“Not that I _shall_, though,” she added to herself, as she finished
+the letter; “and my dear aunt, if you do not tell me in an honourable
+manner, I shall certainly be reduced to tricks and stratagems to find it
+out.”
+
+Jane’s delicate sense of honour would not allow her to speak to
+Elizabeth privately of what Lydia had let fall; Elizabeth was glad
+of it;--till it appeared whether her inquiries would receive any
+satisfaction, she had rather be without a confidante.
+
+
+
+Chapter 52
+
+
+Elizabeth had the satisfaction of receiving an answer to her letter as
+soon as she possibly could. She was no sooner in possession of it
+than, hurrying into the little copse, where she was least likely to
+be interrupted, she sat down on one of the benches and prepared to
+be happy; for the length of the letter convinced her that it did not
+contain a denial.
+
+“Gracechurch street, Sept. 6.
+
+“MY DEAR NIECE,
+
+“I have just received your letter, and shall devote this whole morning
+to answering it, as I foresee that a _little_ writing will not comprise
+what I have to tell you. I must confess myself surprised by your
+application; I did not expect it from _you_. Don’t think me angry,
+however, for I only mean to let you know that I had not imagined such
+inquiries to be necessary on _your_ side. If you do not choose to
+understand me, forgive my impertinence. Your uncle is as much surprised
+as I am--and nothing but the belief of your being a party concerned
+would have allowed him to act as he has done. But if you are really
+innocent and ignorant, I must be more explicit.
+
+“On the very day of my coming home from Longbourn, your uncle had a most
+unexpected visitor. Mr. Darcy called, and was shut up with him several
+hours. It was all over before I arrived; so my curiosity was not so
+dreadfully racked as _yours_ seems to have been. He came to tell Mr.
+Gardiner that he had found out where your sister and Mr. Wickham were,
+and that he had seen and talked with them both; Wickham repeatedly,
+Lydia once. From what I can collect, he left Derbyshire only one day
+after ourselves, and came to town with the resolution of hunting for
+them. The motive professed was his conviction of its being owing to
+himself that Wickham’s worthlessness had not been so well known as to
+make it impossible for any young woman of character to love or confide
+in him. He generously imputed the whole to his mistaken pride, and
+confessed that he had before thought it beneath him to lay his private
+actions open to the world. His character was to speak for itself. He
+called it, therefore, his duty to step forward, and endeavour to remedy
+an evil which had been brought on by himself. If he _had another_
+motive, I am sure it would never disgrace him. He had been some days
+in town, before he was able to discover them; but he had something to
+direct his search, which was more than _we_ had; and the consciousness
+of this was another reason for his resolving to follow us.
+
+“There is a lady, it seems, a Mrs. Younge, who was some time ago
+governess to Miss Darcy, and was dismissed from her charge on some cause
+of disapprobation, though he did not say what. She then took a large
+house in Edward-street, and has since maintained herself by letting
+lodgings. This Mrs. Younge was, he knew, intimately acquainted with
+Wickham; and he went to her for intelligence of him as soon as he got to
+town. But it was two or three days before he could get from her what he
+wanted. She would not betray her trust, I suppose, without bribery and
+corruption, for she really did know where her friend was to be found.
+Wickham indeed had gone to her on their first arrival in London, and had
+she been able to receive them into her house, they would have taken up
+their abode with her. At length, however, our kind friend procured the
+wished-for direction. They were in ---- street. He saw Wickham, and
+afterwards insisted on seeing Lydia. His first object with her, he
+acknowledged, had been to persuade her to quit her present disgraceful
+situation, and return to her friends as soon as they could be prevailed
+on to receive her, offering his assistance, as far as it would go. But
+he found Lydia absolutely resolved on remaining where she was. She cared
+for none of her friends; she wanted no help of his; she would not hear
+of leaving Wickham. She was sure they should be married some time or
+other, and it did not much signify when. Since such were her feelings,
+it only remained, he thought, to secure and expedite a marriage, which,
+in his very first conversation with Wickham, he easily learnt had never
+been _his_ design. He confessed himself obliged to leave the regiment,
+on account of some debts of honour, which were very pressing; and
+scrupled not to lay all the ill-consequences of Lydia’s flight on her
+own folly alone. He meant to resign his commission immediately; and as
+to his future situation, he could conjecture very little about it. He
+must go somewhere, but he did not know where, and he knew he should have
+nothing to live on.
+
+“Mr. Darcy asked him why he had not married your sister at once. Though
+Mr. Bennet was not imagined to be very rich, he would have been able
+to do something for him, and his situation must have been benefited by
+marriage. But he found, in reply to this question, that Wickham still
+cherished the hope of more effectually making his fortune by marriage in
+some other country. Under such circumstances, however, he was not likely
+to be proof against the temptation of immediate relief.
+
+“They met several times, for there was much to be discussed. Wickham of
+course wanted more than he could get; but at length was reduced to be
+reasonable.
+
+“Every thing being settled between _them_, Mr. Darcy’s next step was to
+make your uncle acquainted with it, and he first called in Gracechurch
+street the evening before I came home. But Mr. Gardiner could not be
+seen, and Mr. Darcy found, on further inquiry, that your father was
+still with him, but would quit town the next morning. He did not judge
+your father to be a person whom he could so properly consult as your
+uncle, and therefore readily postponed seeing him till after the
+departure of the former. He did not leave his name, and till the next
+day it was only known that a gentleman had called on business.
+
+“On Saturday he came again. Your father was gone, your uncle at home,
+and, as I said before, they had a great deal of talk together.
+
+“They met again on Sunday, and then _I_ saw him too. It was not all
+settled before Monday: as soon as it was, the express was sent off to
+Longbourn. But our visitor was very obstinate. I fancy, Lizzy, that
+obstinacy is the real defect of his character, after all. He has been
+accused of many faults at different times, but _this_ is the true one.
+Nothing was to be done that he did not do himself; though I am sure (and
+I do not speak it to be thanked, therefore say nothing about it), your
+uncle would most readily have settled the whole.
+
+“They battled it together for a long time, which was more than either
+the gentleman or lady concerned in it deserved. But at last your uncle
+was forced to yield, and instead of being allowed to be of use to his
+niece, was forced to put up with only having the probable credit of it,
+which went sorely against the grain; and I really believe your letter
+this morning gave him great pleasure, because it required an explanation
+that would rob him of his borrowed feathers, and give the praise where
+it was due. But, Lizzy, this must go no farther than yourself, or Jane
+at most.
+
+“You know pretty well, I suppose, what has been done for the young
+people. His debts are to be paid, amounting, I believe, to considerably
+more than a thousand pounds, another thousand in addition to her own
+settled upon _her_, and his commission purchased. The reason why all
+this was to be done by him alone, was such as I have given above. It
+was owing to him, to his reserve and want of proper consideration, that
+Wickham’s character had been so misunderstood, and consequently that he
+had been received and noticed as he was. Perhaps there was some truth
+in _this_; though I doubt whether _his_ reserve, or _anybody’s_ reserve,
+can be answerable for the event. But in spite of all this fine talking,
+my dear Lizzy, you may rest perfectly assured that your uncle would
+never have yielded, if we had not given him credit for _another
+interest_ in the affair.
+
+“When all this was resolved on, he returned again to his friends, who
+were still staying at Pemberley; but it was agreed that he should be in
+London once more when the wedding took place, and all money matters were
+then to receive the last finish.
+
+“I believe I have now told you every thing. It is a relation which
+you tell me is to give you great surprise; I hope at least it will not
+afford you any displeasure. Lydia came to us; and Wickham had constant
+admission to the house. _He_ was exactly what he had been, when I
+knew him in Hertfordshire; but I would not tell you how little I was
+satisfied with her behaviour while she staid with us, if I had not
+perceived, by Jane’s letter last Wednesday, that her conduct on coming
+home was exactly of a piece with it, and therefore what I now tell
+you can give you no fresh pain. I talked to her repeatedly in the most
+serious manner, representing to her all the wickedness of what she had
+done, and all the unhappiness she had brought on her family. If she
+heard me, it was by good luck, for I am sure she did not listen. I was
+sometimes quite provoked, but then I recollected my dear Elizabeth and
+Jane, and for their sakes had patience with her.
+
+“Mr. Darcy was punctual in his return, and as Lydia informed you,
+attended the wedding. He dined with us the next day, and was to leave
+town again on Wednesday or Thursday. Will you be very angry with me, my
+dear Lizzy, if I take this opportunity of saying (what I was never bold
+enough to say before) how much I like him. His behaviour to us has,
+in every respect, been as pleasing as when we were in Derbyshire. His
+understanding and opinions all please me; he wants nothing but a little
+more liveliness, and _that_, if he marry _prudently_, his wife may teach
+him. I thought him very sly;--he hardly ever mentioned your name. But
+slyness seems the fashion.
+
+“Pray forgive me if I have been very presuming, or at least do not
+punish me so far as to exclude me from P. I shall never be quite happy
+till I have been all round the park. A low phaeton, with a nice little
+pair of ponies, would be the very thing.
+
+“But I must write no more. The children have been wanting me this half
+hour.
+
+“Yours, very sincerely,
+
+“M. GARDINER.”
+
+The contents of this letter threw Elizabeth into a flutter of spirits,
+in which it was difficult to determine whether pleasure or pain bore the
+greatest share. The vague and unsettled suspicions which uncertainty had
+produced of what Mr. Darcy might have been doing to forward her sister’s
+match, which she had feared to encourage as an exertion of goodness too
+great to be probable, and at the same time dreaded to be just, from the
+pain of obligation, were proved beyond their greatest extent to be true!
+He had followed them purposely to town, he had taken on himself all
+the trouble and mortification attendant on such a research; in which
+supplication had been necessary to a woman whom he must abominate and
+despise, and where he was reduced to meet, frequently meet, reason
+with, persuade, and finally bribe, the man whom he always most wished to
+avoid, and whose very name it was punishment to him to pronounce. He had
+done all this for a girl whom he could neither regard nor esteem. Her
+heart did whisper that he had done it for her. But it was a hope shortly
+checked by other considerations, and she soon felt that even her vanity
+was insufficient, when required to depend on his affection for her--for
+a woman who had already refused him--as able to overcome a sentiment so
+natural as abhorrence against relationship with Wickham. Brother-in-law
+of Wickham! Every kind of pride must revolt from the connection. He had,
+to be sure, done much. She was ashamed to think how much. But he had
+given a reason for his interference, which asked no extraordinary
+stretch of belief. It was reasonable that he should feel he had been
+wrong; he had liberality, and he had the means of exercising it; and
+though she would not place herself as his principal inducement, she
+could, perhaps, believe that remaining partiality for her might assist
+his endeavours in a cause where her peace of mind must be materially
+concerned. It was painful, exceedingly painful, to know that they were
+under obligations to a person who could never receive a return. They
+owed the restoration of Lydia, her character, every thing, to him. Oh!
+how heartily did she grieve over every ungracious sensation she had ever
+encouraged, every saucy speech she had ever directed towards him. For
+herself she was humbled; but she was proud of him. Proud that in a cause
+of compassion and honour, he had been able to get the better of himself.
+She read over her aunt’s commendation of him again and again. It
+was hardly enough; but it pleased her. She was even sensible of some
+pleasure, though mixed with regret, on finding how steadfastly both she
+and her uncle had been persuaded that affection and confidence subsisted
+between Mr. Darcy and herself.
+
+She was roused from her seat, and her reflections, by some one’s
+approach; and before she could strike into another path, she was
+overtaken by Wickham.
+
+“I am afraid I interrupt your solitary ramble, my dear sister?” said he,
+as he joined her.
+
+“You certainly do,” she replied with a smile; “but it does not follow
+that the interruption must be unwelcome.”
+
+“I should be sorry indeed, if it were. We were always good friends; and
+now we are better.”
+
+“True. Are the others coming out?”
+
+“I do not know. Mrs. Bennet and Lydia are going in the carriage to
+Meryton. And so, my dear sister, I find, from our uncle and aunt, that
+you have actually seen Pemberley.”
+
+She replied in the affirmative.
+
+“I almost envy you the pleasure, and yet I believe it would be too much
+for me, or else I could take it in my way to Newcastle. And you saw the
+old housekeeper, I suppose? Poor Reynolds, she was always very fond of
+me. But of course she did not mention my name to you.”
+
+“Yes, she did.”
+
+“And what did she say?”
+
+“That you were gone into the army, and she was afraid had--not turned
+out well. At such a distance as _that_, you know, things are strangely
+misrepresented.”
+
+“Certainly,” he replied, biting his lips. Elizabeth hoped she had
+silenced him; but he soon afterwards said:
+
+“I was surprised to see Darcy in town last month. We passed each other
+several times. I wonder what he can be doing there.”
+
+“Perhaps preparing for his marriage with Miss de Bourgh,” said
+Elizabeth. “It must be something particular, to take him there at this
+time of year.”
+
+“Undoubtedly. Did you see him while you were at Lambton? I thought I
+understood from the Gardiners that you had.”
+
+“Yes; he introduced us to his sister.”
+
+“And do you like her?”
+
+“Very much.”
+
+“I have heard, indeed, that she is uncommonly improved within this year
+or two. When I last saw her, she was not very promising. I am very glad
+you liked her. I hope she will turn out well.”
+
+“I dare say she will; she has got over the most trying age.”
+
+“Did you go by the village of Kympton?”
+
+“I do not recollect that we did.”
+
+“I mention it, because it is the living which I ought to have had. A
+most delightful place!--Excellent Parsonage House! It would have suited
+me in every respect.”
+
+“How should you have liked making sermons?”
+
+“Exceedingly well. I should have considered it as part of my duty,
+and the exertion would soon have been nothing. One ought not to
+repine;--but, to be sure, it would have been such a thing for me! The
+quiet, the retirement of such a life would have answered all my ideas
+of happiness! But it was not to be. Did you ever hear Darcy mention the
+circumstance, when you were in Kent?”
+
+“I have heard from authority, which I thought _as good_, that it was
+left you conditionally only, and at the will of the present patron.”
+
+“You have. Yes, there was something in _that_; I told you so from the
+first, you may remember.”
+
+“I _did_ hear, too, that there was a time, when sermon-making was not
+so palatable to you as it seems to be at present; that you actually
+declared your resolution of never taking orders, and that the business
+had been compromised accordingly.”
+
+“You did! and it was not wholly without foundation. You may remember
+what I told you on that point, when first we talked of it.”
+
+They were now almost at the door of the house, for she had walked fast
+to get rid of him; and unwilling, for her sister’s sake, to provoke him,
+she only said in reply, with a good-humoured smile:
+
+“Come, Mr. Wickham, we are brother and sister, you know. Do not let
+us quarrel about the past. In future, I hope we shall be always of one
+mind.”
+
+She held out her hand; he kissed it with affectionate gallantry, though
+he hardly knew how to look, and they entered the house.
+
+
+
+Chapter 53
+
+
+Mr. Wickham was so perfectly satisfied with this conversation that he
+never again distressed himself, or provoked his dear sister Elizabeth,
+by introducing the subject of it; and she was pleased to find that she
+had said enough to keep him quiet.
+
+The day of his and Lydia’s departure soon came, and Mrs. Bennet was
+forced to submit to a separation, which, as her husband by no means
+entered into her scheme of their all going to Newcastle, was likely to
+continue at least a twelvemonth.
+
+“Oh! my dear Lydia,” she cried, “when shall we meet again?”
+
+“Oh, lord! I don’t know. Not these two or three years, perhaps.”
+
+“Write to me very often, my dear.”
+
+“As often as I can. But you know married women have never much time for
+writing. My sisters may write to _me_. They will have nothing else to
+do.”
+
+Mr. Wickham’s adieus were much more affectionate than his wife’s. He
+smiled, looked handsome, and said many pretty things.
+
+“He is as fine a fellow,” said Mr. Bennet, as soon as they were out of
+the house, “as ever I saw. He simpers, and smirks, and makes love to
+us all. I am prodigiously proud of him. I defy even Sir William Lucas
+himself to produce a more valuable son-in-law.”
+
+The loss of her daughter made Mrs. Bennet very dull for several days.
+
+“I often think,” said she, “that there is nothing so bad as parting with
+one’s friends. One seems so forlorn without them.”
+
+“This is the consequence, you see, Madam, of marrying a daughter,” said
+Elizabeth. “It must make you better satisfied that your other four are
+single.”
+
+“It is no such thing. Lydia does not leave me because she is married,
+but only because her husband’s regiment happens to be so far off. If
+that had been nearer, she would not have gone so soon.”
+
+But the spiritless condition which this event threw her into was shortly
+relieved, and her mind opened again to the agitation of hope, by an
+article of news which then began to be in circulation. The housekeeper
+at Netherfield had received orders to prepare for the arrival of her
+master, who was coming down in a day or two, to shoot there for several
+weeks. Mrs. Bennet was quite in the fidgets. She looked at Jane, and
+smiled and shook her head by turns.
+
+“Well, well, and so Mr. Bingley is coming down, sister,” (for Mrs.
+Phillips first brought her the news). “Well, so much the better. Not
+that I care about it, though. He is nothing to us, you know, and I am
+sure _I_ never want to see him again. But, however, he is very welcome
+to come to Netherfield, if he likes it. And who knows what _may_ happen?
+But that is nothing to us. You know, sister, we agreed long ago never to
+mention a word about it. And so, is it quite certain he is coming?”
+
+“You may depend on it,” replied the other, “for Mrs. Nicholls was in
+Meryton last night; I saw her passing by, and went out myself on purpose
+to know the truth of it; and she told me that it was certain true. He
+comes down on Thursday at the latest, very likely on Wednesday. She was
+going to the butcher’s, she told me, on purpose to order in some meat on
+Wednesday, and she has got three couple of ducks just fit to be killed.”
+
+Miss Bennet had not been able to hear of his coming without changing
+colour. It was many months since she had mentioned his name to
+Elizabeth; but now, as soon as they were alone together, she said:
+
+“I saw you look at me to-day, Lizzy, when my aunt told us of the present
+report; and I know I appeared distressed. But don’t imagine it was from
+any silly cause. I was only confused for the moment, because I felt that
+I _should_ be looked at. I do assure you that the news does not affect
+me either with pleasure or pain. I am glad of one thing, that he comes
+alone; because we shall see the less of him. Not that I am afraid of
+_myself_, but I dread other people’s remarks.”
+
+Elizabeth did not know what to make of it. Had she not seen him in
+Derbyshire, she might have supposed him capable of coming there with no
+other view than what was acknowledged; but she still thought him partial
+to Jane, and she wavered as to the greater probability of his coming
+there _with_ his friend’s permission, or being bold enough to come
+without it.
+
+“Yet it is hard,” she sometimes thought, “that this poor man cannot
+come to a house which he has legally hired, without raising all this
+speculation! I _will_ leave him to himself.”
+
+In spite of what her sister declared, and really believed to be her
+feelings in the expectation of his arrival, Elizabeth could easily
+perceive that her spirits were affected by it. They were more disturbed,
+more unequal, than she had often seen them.
+
+The subject which had been so warmly canvassed between their parents,
+about a twelvemonth ago, was now brought forward again.
+
+“As soon as ever Mr. Bingley comes, my dear,” said Mrs. Bennet, “you
+will wait on him of course.”
+
+“No, no. You forced me into visiting him last year, and promised, if I
+went to see him, he should marry one of my daughters. But it ended in
+nothing, and I will not be sent on a fool’s errand again.”
+
+His wife represented to him how absolutely necessary such an attention
+would be from all the neighbouring gentlemen, on his returning to
+Netherfield.
+
+“‘Tis an etiquette I despise,” said he. “If he wants our society,
+let him seek it. He knows where we live. I will not spend my hours
+in running after my neighbours every time they go away and come back
+again.”
+
+“Well, all I know is, that it will be abominably rude if you do not wait
+on him. But, however, that shan’t prevent my asking him to dine here, I
+am determined. We must have Mrs. Long and the Gouldings soon. That will
+make thirteen with ourselves, so there will be just room at table for
+him.”
+
+Consoled by this resolution, she was the better able to bear her
+husband’s incivility; though it was very mortifying to know that her
+neighbours might all see Mr. Bingley, in consequence of it, before
+_they_ did. As the day of his arrival drew near,--
+
+“I begin to be sorry that he comes at all,” said Jane to her sister. “It
+would be nothing; I could see him with perfect indifference, but I can
+hardly bear to hear it thus perpetually talked of. My mother means well;
+but she does not know, no one can know, how much I suffer from what she
+says. Happy shall I be, when his stay at Netherfield is over!”
+
+“I wish I could say anything to comfort you,” replied Elizabeth; “but it
+is wholly out of my power. You must feel it; and the usual satisfaction
+of preaching patience to a sufferer is denied me, because you have
+always so much.”
+
+Mr. Bingley arrived. Mrs. Bennet, through the assistance of servants,
+contrived to have the earliest tidings of it, that the period of anxiety
+and fretfulness on her side might be as long as it could. She counted
+the days that must intervene before their invitation could be sent;
+hopeless of seeing him before. But on the third morning after his
+arrival in Hertfordshire, she saw him, from her dressing-room window,
+enter the paddock and ride towards the house.
+
+Her daughters were eagerly called to partake of her joy. Jane resolutely
+kept her place at the table; but Elizabeth, to satisfy her mother, went
+to the window--she looked,--she saw Mr. Darcy with him, and sat down
+again by her sister.
+
+“There is a gentleman with him, mamma,” said Kitty; “who can it be?”
+
+“Some acquaintance or other, my dear, I suppose; I am sure I do not
+know.”
+
+“La!” replied Kitty, “it looks just like that man that used to be with
+him before. Mr. what’s-his-name. That tall, proud man.”
+
+“Good gracious! Mr. Darcy!--and so it does, I vow. Well, any friend of
+Mr. Bingley’s will always be welcome here, to be sure; but else I must
+say that I hate the very sight of him.”
+
+Jane looked at Elizabeth with surprise and concern. She knew but little
+of their meeting in Derbyshire, and therefore felt for the awkwardness
+which must attend her sister, in seeing him almost for the first time
+after receiving his explanatory letter. Both sisters were uncomfortable
+enough. Each felt for the other, and of course for themselves; and their
+mother talked on, of her dislike of Mr. Darcy, and her resolution to be
+civil to him only as Mr. Bingley’s friend, without being heard by either
+of them. But Elizabeth had sources of uneasiness which could not be
+suspected by Jane, to whom she had never yet had courage to shew Mrs.
+Gardiner’s letter, or to relate her own change of sentiment towards him.
+To Jane, he could be only a man whose proposals she had refused,
+and whose merit she had undervalued; but to her own more extensive
+information, he was the person to whom the whole family were indebted
+for the first of benefits, and whom she regarded herself with an
+interest, if not quite so tender, at least as reasonable and just as
+what Jane felt for Bingley. Her astonishment at his coming--at his
+coming to Netherfield, to Longbourn, and voluntarily seeking her again,
+was almost equal to what she had known on first witnessing his altered
+behaviour in Derbyshire.
+
+The colour which had been driven from her face, returned for half a
+minute with an additional glow, and a smile of delight added lustre to
+her eyes, as she thought for that space of time that his affection and
+wishes must still be unshaken. But she would not be secure.
+
+“Let me first see how he behaves,” said she; “it will then be early
+enough for expectation.”
+
+She sat intently at work, striving to be composed, and without daring to
+lift up her eyes, till anxious curiosity carried them to the face of
+her sister as the servant was approaching the door. Jane looked a little
+paler than usual, but more sedate than Elizabeth had expected. On the
+gentlemen’s appearing, her colour increased; yet she received them with
+tolerable ease, and with a propriety of behaviour equally free from any
+symptom of resentment or any unnecessary complaisance.
+
+Elizabeth said as little to either as civility would allow, and sat down
+again to her work, with an eagerness which it did not often command. She
+had ventured only one glance at Darcy. He looked serious, as usual; and,
+she thought, more as he had been used to look in Hertfordshire, than as
+she had seen him at Pemberley. But, perhaps he could not in her mother’s
+presence be what he was before her uncle and aunt. It was a painful, but
+not an improbable, conjecture.
+
+Bingley, she had likewise seen for an instant, and in that short period
+saw him looking both pleased and embarrassed. He was received by Mrs.
+Bennet with a degree of civility which made her two daughters ashamed,
+especially when contrasted with the cold and ceremonious politeness of
+her curtsey and address to his friend.
+
+Elizabeth, particularly, who knew that her mother owed to the latter
+the preservation of her favourite daughter from irremediable infamy,
+was hurt and distressed to a most painful degree by a distinction so ill
+applied.
+
+Darcy, after inquiring of her how Mr. and Mrs. Gardiner did, a question
+which she could not answer without confusion, said scarcely anything. He
+was not seated by her; perhaps that was the reason of his silence; but
+it had not been so in Derbyshire. There he had talked to her friends,
+when he could not to herself. But now several minutes elapsed without
+bringing the sound of his voice; and when occasionally, unable to resist
+the impulse of curiosity, she raised her eyes to his face, she as often
+found him looking at Jane as at herself, and frequently on no object but
+the ground. More thoughtfulness and less anxiety to please, than when
+they last met, were plainly expressed. She was disappointed, and angry
+with herself for being so.
+
+“Could I expect it to be otherwise!” said she. “Yet why did he come?”
+
+She was in no humour for conversation with anyone but himself; and to
+him she had hardly courage to speak.
+
+She inquired after his sister, but could do no more.
+
+“It is a long time, Mr. Bingley, since you went away,” said Mrs. Bennet.
+
+He readily agreed to it.
+
+“I began to be afraid you would never come back again. People _did_ say
+you meant to quit the place entirely at Michaelmas; but, however, I hope
+it is not true. A great many changes have happened in the neighbourhood,
+since you went away. Miss Lucas is married and settled. And one of my
+own daughters. I suppose you have heard of it; indeed, you must have
+seen it in the papers. It was in The Times and The Courier, I know;
+though it was not put in as it ought to be. It was only said, ‘Lately,
+George Wickham, Esq. to Miss Lydia Bennet,’ without there being a
+syllable said of her father, or the place where she lived, or anything.
+It was my brother Gardiner’s drawing up too, and I wonder how he came to
+make such an awkward business of it. Did you see it?”
+
+Bingley replied that he did, and made his congratulations. Elizabeth
+dared not lift up her eyes. How Mr. Darcy looked, therefore, she could
+not tell.
+
+“It is a delightful thing, to be sure, to have a daughter well married,”
+ continued her mother, “but at the same time, Mr. Bingley, it is very
+hard to have her taken such a way from me. They are gone down to
+Newcastle, a place quite northward, it seems, and there they are to stay
+I do not know how long. His regiment is there; for I suppose you have
+heard of his leaving the ----shire, and of his being gone into the
+regulars. Thank Heaven! he has _some_ friends, though perhaps not so
+many as he deserves.”
+
+Elizabeth, who knew this to be levelled at Mr. Darcy, was in such
+misery of shame, that she could hardly keep her seat. It drew from her,
+however, the exertion of speaking, which nothing else had so effectually
+done before; and she asked Bingley whether he meant to make any stay in
+the country at present. A few weeks, he believed.
+
+“When you have killed all your own birds, Mr. Bingley,” said her mother,
+“I beg you will come here, and shoot as many as you please on Mr.
+Bennet’s manor. I am sure he will be vastly happy to oblige you, and
+will save all the best of the covies for you.”
+
+Elizabeth’s misery increased, at such unnecessary, such officious
+attention! Were the same fair prospect to arise at present as had
+flattered them a year ago, every thing, she was persuaded, would be
+hastening to the same vexatious conclusion. At that instant, she felt
+that years of happiness could not make Jane or herself amends for
+moments of such painful confusion.
+
+“The first wish of my heart,” said she to herself, “is never more to
+be in company with either of them. Their society can afford no pleasure
+that will atone for such wretchedness as this! Let me never see either
+one or the other again!”
+
+Yet the misery, for which years of happiness were to offer no
+compensation, received soon afterwards material relief, from observing
+how much the beauty of her sister re-kindled the admiration of her
+former lover. When first he came in, he had spoken to her but little;
+but every five minutes seemed to be giving her more of his attention. He
+found her as handsome as she had been last year; as good natured, and
+as unaffected, though not quite so chatty. Jane was anxious that no
+difference should be perceived in her at all, and was really persuaded
+that she talked as much as ever. But her mind was so busily engaged,
+that she did not always know when she was silent.
+
+When the gentlemen rose to go away, Mrs. Bennet was mindful of her
+intended civility, and they were invited and engaged to dine at
+Longbourn in a few days time.
+
+“You are quite a visit in my debt, Mr. Bingley,” she added, “for when
+you went to town last winter, you promised to take a family dinner with
+us, as soon as you returned. I have not forgot, you see; and I assure
+you, I was very much disappointed that you did not come back and keep
+your engagement.”
+
+Bingley looked a little silly at this reflection, and said something of
+his concern at having been prevented by business. They then went away.
+
+Mrs. Bennet had been strongly inclined to ask them to stay and dine
+there that day; but, though she always kept a very good table, she did
+not think anything less than two courses could be good enough for a man
+on whom she had such anxious designs, or satisfy the appetite and pride
+of one who had ten thousand a year.
+
+
+
+Chapter 54
+
+
+As soon as they were gone, Elizabeth walked out to recover her spirits;
+or in other words, to dwell without interruption on those subjects that
+must deaden them more. Mr. Darcy’s behaviour astonished and vexed her.
+
+“Why, if he came only to be silent, grave, and indifferent,” said she,
+“did he come at all?”
+
+She could settle it in no way that gave her pleasure.
+
+“He could be still amiable, still pleasing, to my uncle and aunt, when
+he was in town; and why not to me? If he fears me, why come hither? If
+he no longer cares for me, why silent? Teasing, teasing, man! I will
+think no more about him.”
+
+Her resolution was for a short time involuntarily kept by the approach
+of her sister, who joined her with a cheerful look, which showed her
+better satisfied with their visitors, than Elizabeth.
+
+“Now,” said she, “that this first meeting is over, I feel perfectly
+easy. I know my own strength, and I shall never be embarrassed again by
+his coming. I am glad he dines here on Tuesday. It will then be publicly
+seen that, on both sides, we meet only as common and indifferent
+acquaintance.”
+
+“Yes, very indifferent indeed,” said Elizabeth, laughingly. “Oh, Jane,
+take care.”
+
+“My dear Lizzy, you cannot think me so weak, as to be in danger now?”
+
+“I think you are in very great danger of making him as much in love with
+you as ever.”
+
+                          * * * * *
+
+They did not see the gentlemen again till Tuesday; and Mrs. Bennet, in
+the meanwhile, was giving way to all the happy schemes, which the good
+humour and common politeness of Bingley, in half an hour’s visit, had
+revived.
+
+On Tuesday there was a large party assembled at Longbourn; and the two
+who were most anxiously expected, to the credit of their punctuality
+as sportsmen, were in very good time. When they repaired to the
+dining-room, Elizabeth eagerly watched to see whether Bingley would take
+the place, which, in all their former parties, had belonged to him, by
+her sister. Her prudent mother, occupied by the same ideas, forbore
+to invite him to sit by herself. On entering the room, he seemed to
+hesitate; but Jane happened to look round, and happened to smile: it was
+decided. He placed himself by her.
+
+Elizabeth, with a triumphant sensation, looked towards his friend.
+He bore it with noble indifference, and she would have imagined that
+Bingley had received his sanction to be happy, had she not seen his eyes
+likewise turned towards Mr. Darcy, with an expression of half-laughing
+alarm.
+
+His behaviour to her sister was such, during dinner time, as showed an
+admiration of her, which, though more guarded than formerly, persuaded
+Elizabeth, that if left wholly to himself, Jane’s happiness, and his
+own, would be speedily secured. Though she dared not depend upon the
+consequence, she yet received pleasure from observing his behaviour. It
+gave her all the animation that her spirits could boast; for she was in
+no cheerful humour. Mr. Darcy was almost as far from her as the table
+could divide them. He was on one side of her mother. She knew how little
+such a situation would give pleasure to either, or make either appear to
+advantage. She was not near enough to hear any of their discourse, but
+she could see how seldom they spoke to each other, and how formal and
+cold was their manner whenever they did. Her mother’s ungraciousness,
+made the sense of what they owed him more painful to Elizabeth’s mind;
+and she would, at times, have given anything to be privileged to tell
+him that his kindness was neither unknown nor unfelt by the whole of the
+family.
+
+She was in hopes that the evening would afford some opportunity of
+bringing them together; that the whole of the visit would not pass away
+without enabling them to enter into something more of conversation than
+the mere ceremonious salutation attending his entrance. Anxious
+and uneasy, the period which passed in the drawing-room, before the
+gentlemen came, was wearisome and dull to a degree that almost made her
+uncivil. She looked forward to their entrance as the point on which all
+her chance of pleasure for the evening must depend.
+
+“If he does not come to me, _then_,” said she, “I shall give him up for
+ever.”
+
+The gentlemen came; and she thought he looked as if he would have
+answered her hopes; but, alas! the ladies had crowded round the table,
+where Miss Bennet was making tea, and Elizabeth pouring out the coffee,
+in so close a confederacy that there was not a single vacancy near her
+which would admit of a chair. And on the gentlemen’s approaching, one of
+the girls moved closer to her than ever, and said, in a whisper:
+
+“The men shan’t come and part us, I am determined. We want none of them;
+do we?”
+
+Darcy had walked away to another part of the room. She followed him with
+her eyes, envied everyone to whom he spoke, had scarcely patience enough
+to help anybody to coffee; and then was enraged against herself for
+being so silly!
+
+“A man who has once been refused! How could I ever be foolish enough to
+expect a renewal of his love? Is there one among the sex, who would not
+protest against such a weakness as a second proposal to the same woman?
+There is no indignity so abhorrent to their feelings!”
+
+She was a little revived, however, by his bringing back his coffee cup
+himself; and she seized the opportunity of saying:
+
+“Is your sister at Pemberley still?”
+
+“Yes, she will remain there till Christmas.”
+
+“And quite alone? Have all her friends left her?”
+
+“Mrs. Annesley is with her. The others have been gone on to Scarborough,
+these three weeks.”
+
+She could think of nothing more to say; but if he wished to converse
+with her, he might have better success. He stood by her, however, for
+some minutes, in silence; and, at last, on the young lady’s whispering
+to Elizabeth again, he walked away.
+
+When the tea-things were removed, and the card-tables placed, the ladies
+all rose, and Elizabeth was then hoping to be soon joined by him,
+when all her views were overthrown by seeing him fall a victim to her
+mother’s rapacity for whist players, and in a few moments after seated
+with the rest of the party. She now lost every expectation of pleasure.
+They were confined for the evening at different tables, and she had
+nothing to hope, but that his eyes were so often turned towards her side
+of the room, as to make him play as unsuccessfully as herself.
+
+Mrs. Bennet had designed to keep the two Netherfield gentlemen to
+supper; but their carriage was unluckily ordered before any of the
+others, and she had no opportunity of detaining them.
+
+“Well girls,” said she, as soon as they were left to themselves, “What
+say you to the day? I think every thing has passed off uncommonly well,
+I assure you. The dinner was as well dressed as any I ever saw. The
+venison was roasted to a turn--and everybody said they never saw so
+fat a haunch. The soup was fifty times better than what we had at the
+Lucases’ last week; and even Mr. Darcy acknowledged, that the partridges
+were remarkably well done; and I suppose he has two or three French
+cooks at least. And, my dear Jane, I never saw you look in greater
+beauty. Mrs. Long said so too, for I asked her whether you did not. And
+what do you think she said besides? ‘Ah! Mrs. Bennet, we shall have her
+at Netherfield at last.’ She did indeed. I do think Mrs. Long is as good
+a creature as ever lived--and her nieces are very pretty behaved girls,
+and not at all handsome: I like them prodigiously.”
+
+Mrs. Bennet, in short, was in very great spirits; she had seen enough of
+Bingley’s behaviour to Jane, to be convinced that she would get him at
+last; and her expectations of advantage to her family, when in a happy
+humour, were so far beyond reason, that she was quite disappointed at
+not seeing him there again the next day, to make his proposals.
+
+“It has been a very agreeable day,” said Miss Bennet to Elizabeth. “The
+party seemed so well selected, so suitable one with the other. I hope we
+may often meet again.”
+
+Elizabeth smiled.
+
+“Lizzy, you must not do so. You must not suspect me. It mortifies me.
+I assure you that I have now learnt to enjoy his conversation as an
+agreeable and sensible young man, without having a wish beyond it. I am
+perfectly satisfied, from what his manners now are, that he never had
+any design of engaging my affection. It is only that he is blessed
+with greater sweetness of address, and a stronger desire of generally
+pleasing, than any other man.”
+
+“You are very cruel,” said her sister, “you will not let me smile, and
+are provoking me to it every moment.”
+
+“How hard it is in some cases to be believed!”
+
+“And how impossible in others!”
+
+“But why should you wish to persuade me that I feel more than I
+acknowledge?”
+
+“That is a question which I hardly know how to answer. We all love to
+instruct, though we can teach only what is not worth knowing. Forgive
+me; and if you persist in indifference, do not make me your confidante.”
+
+
+
+Chapter 55
+
+
+A few days after this visit, Mr. Bingley called again, and alone. His
+friend had left him that morning for London, but was to return home in
+ten days time. He sat with them above an hour, and was in remarkably
+good spirits. Mrs. Bennet invited him to dine with them; but, with many
+expressions of concern, he confessed himself engaged elsewhere.
+
+“Next time you call,” said she, “I hope we shall be more lucky.”
+
+He should be particularly happy at any time, etc. etc.; and if she would
+give him leave, would take an early opportunity of waiting on them.
+
+“Can you come to-morrow?”
+
+Yes, he had no engagement at all for to-morrow; and her invitation was
+accepted with alacrity.
+
+He came, and in such very good time that the ladies were none of them
+dressed. In ran Mrs. Bennet to her daughter’s room, in her dressing
+gown, and with her hair half finished, crying out:
+
+“My dear Jane, make haste and hurry down. He is come--Mr. Bingley is
+come. He is, indeed. Make haste, make haste. Here, Sarah, come to Miss
+Bennet this moment, and help her on with her gown. Never mind Miss
+Lizzy’s hair.”
+
+“We will be down as soon as we can,” said Jane; “but I dare say Kitty is
+forwarder than either of us, for she went up stairs half an hour ago.”
+
+“Oh! hang Kitty! what has she to do with it? Come be quick, be quick!
+Where is your sash, my dear?”
+
+But when her mother was gone, Jane would not be prevailed on to go down
+without one of her sisters.
+
+The same anxiety to get them by themselves was visible again in the
+evening. After tea, Mr. Bennet retired to the library, as was his
+custom, and Mary went up stairs to her instrument. Two obstacles of
+the five being thus removed, Mrs. Bennet sat looking and winking at
+Elizabeth and Catherine for a considerable time, without making any
+impression on them. Elizabeth would not observe her; and when at last
+Kitty did, she very innocently said, “What is the matter mamma? What do
+you keep winking at me for? What am I to do?”
+
+“Nothing child, nothing. I did not wink at you.” She then sat still
+five minutes longer; but unable to waste such a precious occasion, she
+suddenly got up, and saying to Kitty, “Come here, my love, I want to
+speak to you,” took her out of the room. Jane instantly gave a look
+at Elizabeth which spoke her distress at such premeditation, and her
+entreaty that _she_ would not give in to it. In a few minutes, Mrs.
+Bennet half-opened the door and called out:
+
+“Lizzy, my dear, I want to speak with you.”
+
+Elizabeth was forced to go.
+
+“We may as well leave them by themselves you know;” said her mother, as
+soon as she was in the hall. “Kitty and I are going up stairs to sit in
+my dressing-room.”
+
+Elizabeth made no attempt to reason with her mother, but remained
+quietly in the hall, till she and Kitty were out of sight, then returned
+into the drawing-room.
+
+Mrs. Bennet’s schemes for this day were ineffectual. Bingley was every
+thing that was charming, except the professed lover of her daughter. His
+ease and cheerfulness rendered him a most agreeable addition to their
+evening party; and he bore with the ill-judged officiousness of the
+mother, and heard all her silly remarks with a forbearance and command
+of countenance particularly grateful to the daughter.
+
+He scarcely needed an invitation to stay supper; and before he went
+away, an engagement was formed, chiefly through his own and Mrs.
+Bennet’s means, for his coming next morning to shoot with her husband.
+
+After this day, Jane said no more of her indifference. Not a word passed
+between the sisters concerning Bingley; but Elizabeth went to bed in
+the happy belief that all must speedily be concluded, unless Mr. Darcy
+returned within the stated time. Seriously, however, she felt tolerably
+persuaded that all this must have taken place with that gentleman’s
+concurrence.
+
+Bingley was punctual to his appointment; and he and Mr. Bennet spent
+the morning together, as had been agreed on. The latter was much more
+agreeable than his companion expected. There was nothing of presumption
+or folly in Bingley that could provoke his ridicule, or disgust him into
+silence; and he was more communicative, and less eccentric, than the
+other had ever seen him. Bingley of course returned with him to dinner;
+and in the evening Mrs. Bennet’s invention was again at work to get
+every body away from him and her daughter. Elizabeth, who had a letter
+to write, went into the breakfast room for that purpose soon after tea;
+for as the others were all going to sit down to cards, she could not be
+wanted to counteract her mother’s schemes.
+
+But on returning to the drawing-room, when her letter was finished, she
+saw, to her infinite surprise, there was reason to fear that her mother
+had been too ingenious for her. On opening the door, she perceived her
+sister and Bingley standing together over the hearth, as if engaged in
+earnest conversation; and had this led to no suspicion, the faces of
+both, as they hastily turned round and moved away from each other, would
+have told it all. Their situation was awkward enough; but _hers_ she
+thought was still worse. Not a syllable was uttered by either; and
+Elizabeth was on the point of going away again, when Bingley, who as
+well as the other had sat down, suddenly rose, and whispering a few
+words to her sister, ran out of the room.
+
+Jane could have no reserves from Elizabeth, where confidence would give
+pleasure; and instantly embracing her, acknowledged, with the liveliest
+emotion, that she was the happiest creature in the world.
+
+“‘Tis too much!” she added, “by far too much. I do not deserve it. Oh!
+why is not everybody as happy?”
+
+Elizabeth’s congratulations were given with a sincerity, a warmth,
+a delight, which words could but poorly express. Every sentence of
+kindness was a fresh source of happiness to Jane. But she would not
+allow herself to stay with her sister, or say half that remained to be
+said for the present.
+
+“I must go instantly to my mother;” she cried. “I would not on any
+account trifle with her affectionate solicitude; or allow her to hear it
+from anyone but myself. He is gone to my father already. Oh! Lizzy, to
+know that what I have to relate will give such pleasure to all my dear
+family! how shall I bear so much happiness!”
+
+She then hastened away to her mother, who had purposely broken up the
+card party, and was sitting up stairs with Kitty.
+
+Elizabeth, who was left by herself, now smiled at the rapidity and ease
+with which an affair was finally settled, that had given them so many
+previous months of suspense and vexation.
+
+“And this,” said she, “is the end of all his friend’s anxious
+circumspection! of all his sister’s falsehood and contrivance! the
+happiest, wisest, most reasonable end!”
+
+In a few minutes she was joined by Bingley, whose conference with her
+father had been short and to the purpose.
+
+“Where is your sister?” said he hastily, as he opened the door.
+
+“With my mother up stairs. She will be down in a moment, I dare say.”
+
+He then shut the door, and, coming up to her, claimed the good wishes
+and affection of a sister. Elizabeth honestly and heartily expressed
+her delight in the prospect of their relationship. They shook hands with
+great cordiality; and then, till her sister came down, she had to listen
+to all he had to say of his own happiness, and of Jane’s perfections;
+and in spite of his being a lover, Elizabeth really believed all his
+expectations of felicity to be rationally founded, because they had for
+basis the excellent understanding, and super-excellent disposition of
+Jane, and a general similarity of feeling and taste between her and
+himself.
+
+It was an evening of no common delight to them all; the satisfaction of
+Miss Bennet’s mind gave a glow of such sweet animation to her face, as
+made her look handsomer than ever. Kitty simpered and smiled, and hoped
+her turn was coming soon. Mrs. Bennet could not give her consent or
+speak her approbation in terms warm enough to satisfy her feelings,
+though she talked to Bingley of nothing else for half an hour; and when
+Mr. Bennet joined them at supper, his voice and manner plainly showed
+how really happy he was.
+
+Not a word, however, passed his lips in allusion to it, till their
+visitor took his leave for the night; but as soon as he was gone, he
+turned to his daughter, and said:
+
+“Jane, I congratulate you. You will be a very happy woman.”
+
+Jane went to him instantly, kissed him, and thanked him for his
+goodness.
+
+“You are a good girl;” he replied, “and I have great pleasure in
+thinking you will be so happily settled. I have not a doubt of your
+doing very well together. Your tempers are by no means unlike. You are
+each of you so complying, that nothing will ever be resolved on; so
+easy, that every servant will cheat you; and so generous, that you will
+always exceed your income.”
+
+“I hope not so. Imprudence or thoughtlessness in money matters would be
+unpardonable in me.”
+
+“Exceed their income! My dear Mr. Bennet,” cried his wife, “what are you
+talking of? Why, he has four or five thousand a year, and very likely
+more.” Then addressing her daughter, “Oh! my dear, dear Jane, I am so
+happy! I am sure I shan’t get a wink of sleep all night. I knew how it
+would be. I always said it must be so, at last. I was sure you could not
+be so beautiful for nothing! I remember, as soon as ever I saw him, when
+he first came into Hertfordshire last year, I thought how likely it was
+that you should come together. Oh! he is the handsomest young man that
+ever was seen!”
+
+Wickham, Lydia, were all forgotten. Jane was beyond competition her
+favourite child. At that moment, she cared for no other. Her younger
+sisters soon began to make interest with her for objects of happiness
+which she might in future be able to dispense.
+
+Mary petitioned for the use of the library at Netherfield; and Kitty
+begged very hard for a few balls there every winter.
+
+Bingley, from this time, was of course a daily visitor at Longbourn;
+coming frequently before breakfast, and always remaining till after
+supper; unless when some barbarous neighbour, who could not be enough
+detested, had given him an invitation to dinner which he thought himself
+obliged to accept.
+
+Elizabeth had now but little time for conversation with her sister; for
+while he was present, Jane had no attention to bestow on anyone else;
+but she found herself considerably useful to both of them in those hours
+of separation that must sometimes occur. In the absence of Jane, he
+always attached himself to Elizabeth, for the pleasure of talking of
+her; and when Bingley was gone, Jane constantly sought the same means of
+relief.
+
+“He has made me so happy,” said she, one evening, “by telling me that he
+was totally ignorant of my being in town last spring! I had not believed
+it possible.”
+
+“I suspected as much,” replied Elizabeth. “But how did he account for
+it?”
+
+“It must have been his sister’s doing. They were certainly no friends to
+his acquaintance with me, which I cannot wonder at, since he might have
+chosen so much more advantageously in many respects. But when they see,
+as I trust they will, that their brother is happy with me, they will
+learn to be contented, and we shall be on good terms again; though we
+can never be what we once were to each other.”
+
+“That is the most unforgiving speech,” said Elizabeth, “that I ever
+heard you utter. Good girl! It would vex me, indeed, to see you again
+the dupe of Miss Bingley’s pretended regard.”
+
+“Would you believe it, Lizzy, that when he went to town last November,
+he really loved me, and nothing but a persuasion of _my_ being
+indifferent would have prevented his coming down again!”
+
+“He made a little mistake to be sure; but it is to the credit of his
+modesty.”
+
+This naturally introduced a panegyric from Jane on his diffidence, and
+the little value he put on his own good qualities. Elizabeth was pleased
+to find that he had not betrayed the interference of his friend; for,
+though Jane had the most generous and forgiving heart in the world, she
+knew it was a circumstance which must prejudice her against him.
+
+“I am certainly the most fortunate creature that ever existed!” cried
+Jane. “Oh! Lizzy, why am I thus singled from my family, and blessed
+above them all! If I could but see _you_ as happy! If there _were_ but
+such another man for you!”
+
+“If you were to give me forty such men, I never could be so happy as
+you. Till I have your disposition, your goodness, I never can have your
+happiness. No, no, let me shift for myself; and, perhaps, if I have very
+good luck, I may meet with another Mr. Collins in time.”
+
+The situation of affairs in the Longbourn family could not be long a
+secret. Mrs. Bennet was privileged to whisper it to Mrs. Phillips,
+and she ventured, without any permission, to do the same by all her
+neighbours in Meryton.
+
+The Bennets were speedily pronounced to be the luckiest family in the
+world, though only a few weeks before, when Lydia had first run away,
+they had been generally proved to be marked out for misfortune.
+
+
+
+Chapter 56
+
+
+One morning, about a week after Bingley’s engagement with Jane had been
+formed, as he and the females of the family were sitting together in the
+dining-room, their attention was suddenly drawn to the window, by the
+sound of a carriage; and they perceived a chaise and four driving up
+the lawn. It was too early in the morning for visitors, and besides, the
+equipage did not answer to that of any of their neighbours. The horses
+were post; and neither the carriage, nor the livery of the servant who
+preceded it, were familiar to them. As it was certain, however, that
+somebody was coming, Bingley instantly prevailed on Miss Bennet to avoid
+the confinement of such an intrusion, and walk away with him into the
+shrubbery. They both set off, and the conjectures of the remaining three
+continued, though with little satisfaction, till the door was thrown
+open and their visitor entered. It was Lady Catherine de Bourgh.
+
+They were of course all intending to be surprised; but their
+astonishment was beyond their expectation; and on the part of Mrs.
+Bennet and Kitty, though she was perfectly unknown to them, even
+inferior to what Elizabeth felt.
+
+She entered the room with an air more than usually ungracious, made no
+other reply to Elizabeth’s salutation than a slight inclination of the
+head, and sat down without saying a word. Elizabeth had mentioned her
+name to her mother on her ladyship’s entrance, though no request of
+introduction had been made.
+
+Mrs. Bennet, all amazement, though flattered by having a guest of such
+high importance, received her with the utmost politeness. After sitting
+for a moment in silence, she said very stiffly to Elizabeth,
+
+“I hope you are well, Miss Bennet. That lady, I suppose, is your
+mother.”
+
+Elizabeth replied very concisely that she was.
+
+“And _that_ I suppose is one of your sisters.”
+
+“Yes, madam,” said Mrs. Bennet, delighted to speak to Lady Catherine.
+“She is my youngest girl but one. My youngest of all is lately married,
+and my eldest is somewhere about the grounds, walking with a young man
+who, I believe, will soon become a part of the family.”
+
+“You have a very small park here,” returned Lady Catherine after a short
+silence.
+
+“It is nothing in comparison of Rosings, my lady, I dare say; but I
+assure you it is much larger than Sir William Lucas’s.”
+
+“This must be a most inconvenient sitting room for the evening, in
+summer; the windows are full west.”
+
+Mrs. Bennet assured her that they never sat there after dinner, and then
+added:
+
+“May I take the liberty of asking your ladyship whether you left Mr. and
+Mrs. Collins well.”
+
+“Yes, very well. I saw them the night before last.”
+
+Elizabeth now expected that she would produce a letter for her from
+Charlotte, as it seemed the only probable motive for her calling. But no
+letter appeared, and she was completely puzzled.
+
+Mrs. Bennet, with great civility, begged her ladyship to take some
+refreshment; but Lady Catherine very resolutely, and not very politely,
+declined eating anything; and then, rising up, said to Elizabeth,
+
+“Miss Bennet, there seemed to be a prettyish kind of a little wilderness
+on one side of your lawn. I should be glad to take a turn in it, if you
+will favour me with your company.”
+
+“Go, my dear,” cried her mother, “and show her ladyship about the
+different walks. I think she will be pleased with the hermitage.”
+
+Elizabeth obeyed, and running into her own room for her parasol,
+attended her noble guest downstairs. As they passed through the
+hall, Lady Catherine opened the doors into the dining-parlour and
+drawing-room, and pronouncing them, after a short survey, to be decent
+looking rooms, walked on.
+
+Her carriage remained at the door, and Elizabeth saw that her
+waiting-woman was in it. They proceeded in silence along the gravel walk
+that led to the copse; Elizabeth was determined to make no effort for
+conversation with a woman who was now more than usually insolent and
+disagreeable.
+
+“How could I ever think her like her nephew?” said she, as she looked in
+her face.
+
+As soon as they entered the copse, Lady Catherine began in the following
+manner:--
+
+“You can be at no loss, Miss Bennet, to understand the reason of my
+journey hither. Your own heart, your own conscience, must tell you why I
+come.”
+
+Elizabeth looked with unaffected astonishment.
+
+“Indeed, you are mistaken, Madam. I have not been at all able to account
+for the honour of seeing you here.”
+
+“Miss Bennet,” replied her ladyship, in an angry tone, “you ought to
+know, that I am not to be trifled with. But however insincere _you_ may
+choose to be, you shall not find _me_ so. My character has ever been
+celebrated for its sincerity and frankness, and in a cause of such
+moment as this, I shall certainly not depart from it. A report of a most
+alarming nature reached me two days ago. I was told that not only your
+sister was on the point of being most advantageously married, but that
+you, that Miss Elizabeth Bennet, would, in all likelihood, be soon
+afterwards united to my nephew, my own nephew, Mr. Darcy. Though I
+_know_ it must be a scandalous falsehood, though I would not injure him
+so much as to suppose the truth of it possible, I instantly resolved
+on setting off for this place, that I might make my sentiments known to
+you.”
+
+“If you believed it impossible to be true,” said Elizabeth, colouring
+with astonishment and disdain, “I wonder you took the trouble of coming
+so far. What could your ladyship propose by it?”
+
+“At once to insist upon having such a report universally contradicted.”
+
+“Your coming to Longbourn, to see me and my family,” said Elizabeth
+coolly, “will be rather a confirmation of it; if, indeed, such a report
+is in existence.”
+
+“If! Do you then pretend to be ignorant of it? Has it not been
+industriously circulated by yourselves? Do you not know that such a
+report is spread abroad?”
+
+“I never heard that it was.”
+
+“And can you likewise declare, that there is no foundation for it?”
+
+“I do not pretend to possess equal frankness with your ladyship. You may
+ask questions which I shall not choose to answer.”
+
+“This is not to be borne. Miss Bennet, I insist on being satisfied. Has
+he, has my nephew, made you an offer of marriage?”
+
+“Your ladyship has declared it to be impossible.”
+
+“It ought to be so; it must be so, while he retains the use of his
+reason. But your arts and allurements may, in a moment of infatuation,
+have made him forget what he owes to himself and to all his family. You
+may have drawn him in.”
+
+“If I have, I shall be the last person to confess it.”
+
+“Miss Bennet, do you know who I am? I have not been accustomed to such
+language as this. I am almost the nearest relation he has in the world,
+and am entitled to know all his dearest concerns.”
+
+“But you are not entitled to know mine; nor will such behaviour as this,
+ever induce me to be explicit.”
+
+“Let me be rightly understood. This match, to which you have the
+presumption to aspire, can never take place. No, never. Mr. Darcy is
+engaged to my daughter. Now what have you to say?”
+
+“Only this; that if he is so, you can have no reason to suppose he will
+make an offer to me.”
+
+Lady Catherine hesitated for a moment, and then replied:
+
+“The engagement between them is of a peculiar kind. From their infancy,
+they have been intended for each other. It was the favourite wish of
+_his_ mother, as well as of hers. While in their cradles, we planned
+the union: and now, at the moment when the wishes of both sisters would
+be accomplished in their marriage, to be prevented by a young woman of
+inferior birth, of no importance in the world, and wholly unallied to
+the family! Do you pay no regard to the wishes of his friends? To his
+tacit engagement with Miss de Bourgh? Are you lost to every feeling of
+propriety and delicacy? Have you not heard me say that from his earliest
+hours he was destined for his cousin?”
+
+“Yes, and I had heard it before. But what is that to me? If there is
+no other objection to my marrying your nephew, I shall certainly not
+be kept from it by knowing that his mother and aunt wished him to
+marry Miss de Bourgh. You both did as much as you could in planning the
+marriage. Its completion depended on others. If Mr. Darcy is neither
+by honour nor inclination confined to his cousin, why is not he to make
+another choice? And if I am that choice, why may not I accept him?”
+
+“Because honour, decorum, prudence, nay, interest, forbid it. Yes,
+Miss Bennet, interest; for do not expect to be noticed by his family or
+friends, if you wilfully act against the inclinations of all. You will
+be censured, slighted, and despised, by everyone connected with him.
+Your alliance will be a disgrace; your name will never even be mentioned
+by any of us.”
+
+“These are heavy misfortunes,” replied Elizabeth. “But the wife of Mr.
+Darcy must have such extraordinary sources of happiness necessarily
+attached to her situation, that she could, upon the whole, have no cause
+to repine.”
+
+“Obstinate, headstrong girl! I am ashamed of you! Is this your gratitude
+for my attentions to you last spring? Is nothing due to me on that
+score? Let us sit down. You are to understand, Miss Bennet, that I came
+here with the determined resolution of carrying my purpose; nor will
+I be dissuaded from it. I have not been used to submit to any person’s
+whims. I have not been in the habit of brooking disappointment.”
+
+“_That_ will make your ladyship’s situation at present more pitiable;
+but it will have no effect on me.”
+
+“I will not be interrupted. Hear me in silence. My daughter and my
+nephew are formed for each other. They are descended, on the maternal
+side, from the same noble line; and, on the father’s, from respectable,
+honourable, and ancient--though untitled--families. Their fortune on
+both sides is splendid. They are destined for each other by the voice of
+every member of their respective houses; and what is to divide them?
+The upstart pretensions of a young woman without family, connections,
+or fortune. Is this to be endured! But it must not, shall not be. If you
+were sensible of your own good, you would not wish to quit the sphere in
+which you have been brought up.”
+
+“In marrying your nephew, I should not consider myself as quitting that
+sphere. He is a gentleman; I am a gentleman’s daughter; so far we are
+equal.”
+
+“True. You _are_ a gentleman’s daughter. But who was your mother?
+Who are your uncles and aunts? Do not imagine me ignorant of their
+condition.”
+
+“Whatever my connections may be,” said Elizabeth, “if your nephew does
+not object to them, they can be nothing to _you_.”
+
+“Tell me once for all, are you engaged to him?”
+
+Though Elizabeth would not, for the mere purpose of obliging Lady
+Catherine, have answered this question, she could not but say, after a
+moment’s deliberation:
+
+“I am not.”
+
+Lady Catherine seemed pleased.
+
+“And will you promise me, never to enter into such an engagement?”
+
+“I will make no promise of the kind.”
+
+“Miss Bennet I am shocked and astonished. I expected to find a more
+reasonable young woman. But do not deceive yourself into a belief that
+I will ever recede. I shall not go away till you have given me the
+assurance I require.”
+
+“And I certainly _never_ shall give it. I am not to be intimidated into
+anything so wholly unreasonable. Your ladyship wants Mr. Darcy to marry
+your daughter; but would my giving you the wished-for promise make their
+marriage at all more probable? Supposing him to be attached to me, would
+my refusing to accept his hand make him wish to bestow it on his cousin?
+Allow me to say, Lady Catherine, that the arguments with which you have
+supported this extraordinary application have been as frivolous as the
+application was ill-judged. You have widely mistaken my character, if
+you think I can be worked on by such persuasions as these. How far your
+nephew might approve of your interference in his affairs, I cannot tell;
+but you have certainly no right to concern yourself in mine. I must beg,
+therefore, to be importuned no farther on the subject.”
+
+“Not so hasty, if you please. I have by no means done. To all the
+objections I have already urged, I have still another to add. I am
+no stranger to the particulars of your youngest sister’s infamous
+elopement. I know it all; that the young man’s marrying her was a
+patched-up business, at the expence of your father and uncles. And is
+such a girl to be my nephew’s sister? Is her husband, is the son of his
+late father’s steward, to be his brother? Heaven and earth!--of what are
+you thinking? Are the shades of Pemberley to be thus polluted?”
+
+“You can now have nothing further to say,” she resentfully answered.
+“You have insulted me in every possible method. I must beg to return to
+the house.”
+
+And she rose as she spoke. Lady Catherine rose also, and they turned
+back. Her ladyship was highly incensed.
+
+“You have no regard, then, for the honour and credit of my nephew!
+Unfeeling, selfish girl! Do you not consider that a connection with you
+must disgrace him in the eyes of everybody?”
+
+“Lady Catherine, I have nothing further to say. You know my sentiments.”
+
+“You are then resolved to have him?”
+
+“I have said no such thing. I am only resolved to act in that manner,
+which will, in my own opinion, constitute my happiness, without
+reference to _you_, or to any person so wholly unconnected with me.”
+
+“It is well. You refuse, then, to oblige me. You refuse to obey the
+claims of duty, honour, and gratitude. You are determined to ruin him in
+the opinion of all his friends, and make him the contempt of the world.”
+
+“Neither duty, nor honour, nor gratitude,” replied Elizabeth, “have any
+possible claim on me, in the present instance. No principle of either
+would be violated by my marriage with Mr. Darcy. And with regard to the
+resentment of his family, or the indignation of the world, if the former
+_were_ excited by his marrying me, it would not give me one moment’s
+concern--and the world in general would have too much sense to join in
+the scorn.”
+
+“And this is your real opinion! This is your final resolve! Very well.
+I shall now know how to act. Do not imagine, Miss Bennet, that your
+ambition will ever be gratified. I came to try you. I hoped to find you
+reasonable; but, depend upon it, I will carry my point.”
+
+In this manner Lady Catherine talked on, till they were at the door of
+the carriage, when, turning hastily round, she added, “I take no leave
+of you, Miss Bennet. I send no compliments to your mother. You deserve
+no such attention. I am most seriously displeased.”
+
+Elizabeth made no answer; and without attempting to persuade her
+ladyship to return into the house, walked quietly into it herself. She
+heard the carriage drive away as she proceeded up stairs. Her mother
+impatiently met her at the door of the dressing-room, to ask why Lady
+Catherine would not come in again and rest herself.
+
+“She did not choose it,” said her daughter, “she would go.”
+
+“She is a very fine-looking woman! and her calling here was prodigiously
+civil! for she only came, I suppose, to tell us the Collinses were
+well. She is on her road somewhere, I dare say, and so, passing through
+Meryton, thought she might as well call on you. I suppose she had
+nothing particular to say to you, Lizzy?”
+
+Elizabeth was forced to give into a little falsehood here; for to
+acknowledge the substance of their conversation was impossible.
+
+
+
+Chapter 57
+
+
+The discomposure of spirits which this extraordinary visit threw
+Elizabeth into, could not be easily overcome; nor could she, for many
+hours, learn to think of it less than incessantly. Lady Catherine, it
+appeared, had actually taken the trouble of this journey from Rosings,
+for the sole purpose of breaking off her supposed engagement with Mr.
+Darcy. It was a rational scheme, to be sure! but from what the report
+of their engagement could originate, Elizabeth was at a loss to imagine;
+till she recollected that _his_ being the intimate friend of Bingley,
+and _her_ being the sister of Jane, was enough, at a time when the
+expectation of one wedding made everybody eager for another, to supply
+the idea. She had not herself forgotten to feel that the marriage of her
+sister must bring them more frequently together. And her neighbours
+at Lucas Lodge, therefore (for through their communication with the
+Collinses, the report, she concluded, had reached Lady Catherine), had
+only set that down as almost certain and immediate, which she had looked
+forward to as possible at some future time.
+
+In revolving Lady Catherine’s expressions, however, she could not help
+feeling some uneasiness as to the possible consequence of her persisting
+in this interference. From what she had said of her resolution to
+prevent their marriage, it occurred to Elizabeth that she must meditate
+an application to her nephew; and how _he_ might take a similar
+representation of the evils attached to a connection with her, she dared
+not pronounce. She knew not the exact degree of his affection for his
+aunt, or his dependence on her judgment, but it was natural to suppose
+that he thought much higher of her ladyship than _she_ could do; and it
+was certain that, in enumerating the miseries of a marriage with _one_,
+whose immediate connections were so unequal to his own, his aunt would
+address him on his weakest side. With his notions of dignity, he would
+probably feel that the arguments, which to Elizabeth had appeared weak
+and ridiculous, contained much good sense and solid reasoning.
+
+If he had been wavering before as to what he should do, which had often
+seemed likely, the advice and entreaty of so near a relation might
+settle every doubt, and determine him at once to be as happy as dignity
+unblemished could make him. In that case he would return no more. Lady
+Catherine might see him in her way through town; and his engagement to
+Bingley of coming again to Netherfield must give way.
+
+“If, therefore, an excuse for not keeping his promise should come to his
+friend within a few days,” she added, “I shall know how to understand
+it. I shall then give over every expectation, every wish of his
+constancy. If he is satisfied with only regretting me, when he might
+have obtained my affections and hand, I shall soon cease to regret him
+at all.”
+
+                          * * * * *
+
+The surprise of the rest of the family, on hearing who their visitor had
+been, was very great; but they obligingly satisfied it, with the same
+kind of supposition which had appeased Mrs. Bennet’s curiosity; and
+Elizabeth was spared from much teasing on the subject.
+
+The next morning, as she was going downstairs, she was met by her
+father, who came out of his library with a letter in his hand.
+
+“Lizzy,” said he, “I was going to look for you; come into my room.”
+
+She followed him thither; and her curiosity to know what he had to
+tell her was heightened by the supposition of its being in some manner
+connected with the letter he held. It suddenly struck her that it
+might be from Lady Catherine; and she anticipated with dismay all the
+consequent explanations.
+
+She followed her father to the fire place, and they both sat down. He
+then said,
+
+“I have received a letter this morning that has astonished me
+exceedingly. As it principally concerns yourself, you ought to know its
+contents. I did not know before, that I had two daughters on the brink
+of matrimony. Let me congratulate you on a very important conquest.”
+
+The colour now rushed into Elizabeth’s cheeks in the instantaneous
+conviction of its being a letter from the nephew, instead of the aunt;
+and she was undetermined whether most to be pleased that he explained
+himself at all, or offended that his letter was not rather addressed to
+herself; when her father continued:
+
+“You look conscious. Young ladies have great penetration in such matters
+as these; but I think I may defy even _your_ sagacity, to discover the
+name of your admirer. This letter is from Mr. Collins.”
+
+“From Mr. Collins! and what can _he_ have to say?”
+
+“Something very much to the purpose of course. He begins with
+congratulations on the approaching nuptials of my eldest daughter, of
+which, it seems, he has been told by some of the good-natured, gossiping
+Lucases. I shall not sport with your impatience, by reading what he says
+on that point. What relates to yourself, is as follows: ‘Having thus
+offered you the sincere congratulations of Mrs. Collins and myself on
+this happy event, let me now add a short hint on the subject of another;
+of which we have been advertised by the same authority. Your daughter
+Elizabeth, it is presumed, will not long bear the name of Bennet, after
+her elder sister has resigned it, and the chosen partner of her fate may
+be reasonably looked up to as one of the most illustrious personages in
+this land.’
+
+“Can you possibly guess, Lizzy, who is meant by this? ‘This young
+gentleman is blessed, in a peculiar way, with every thing the heart of
+mortal can most desire,--splendid property, noble kindred, and extensive
+patronage. Yet in spite of all these temptations, let me warn my cousin
+Elizabeth, and yourself, of what evils you may incur by a precipitate
+closure with this gentleman’s proposals, which, of course, you will be
+inclined to take immediate advantage of.’
+
+“Have you any idea, Lizzy, who this gentleman is? But now it comes out:
+
+“‘My motive for cautioning you is as follows. We have reason to imagine
+that his aunt, Lady Catherine de Bourgh, does not look on the match with
+a friendly eye.’
+
+“_Mr. Darcy_, you see, is the man! Now, Lizzy, I think I _have_
+surprised you. Could he, or the Lucases, have pitched on any man within
+the circle of our acquaintance, whose name would have given the lie
+more effectually to what they related? Mr. Darcy, who never looks at any
+woman but to see a blemish, and who probably never looked at you in his
+life! It is admirable!”
+
+Elizabeth tried to join in her father’s pleasantry, but could only force
+one most reluctant smile. Never had his wit been directed in a manner so
+little agreeable to her.
+
+“Are you not diverted?”
+
+“Oh! yes. Pray read on.”
+
+“‘After mentioning the likelihood of this marriage to her ladyship last
+night, she immediately, with her usual condescension, expressed what she
+felt on the occasion; when it became apparent, that on the score of some
+family objections on the part of my cousin, she would never give her
+consent to what she termed so disgraceful a match. I thought it my duty
+to give the speediest intelligence of this to my cousin, that she and
+her noble admirer may be aware of what they are about, and not run
+hastily into a marriage which has not been properly sanctioned.’ Mr.
+Collins moreover adds, ‘I am truly rejoiced that my cousin Lydia’s sad
+business has been so well hushed up, and am only concerned that their
+living together before the marriage took place should be so generally
+known. I must not, however, neglect the duties of my station, or refrain
+from declaring my amazement at hearing that you received the young
+couple into your house as soon as they were married. It was an
+encouragement of vice; and had I been the rector of Longbourn, I should
+very strenuously have opposed it. You ought certainly to forgive them,
+as a Christian, but never to admit them in your sight, or allow their
+names to be mentioned in your hearing.’ That is his notion of Christian
+forgiveness! The rest of his letter is only about his dear Charlotte’s
+situation, and his expectation of a young olive-branch. But, Lizzy, you
+look as if you did not enjoy it. You are not going to be _missish_,
+I hope, and pretend to be affronted at an idle report. For what do we
+live, but to make sport for our neighbours, and laugh at them in our
+turn?”
+
+“Oh!” cried Elizabeth, “I am excessively diverted. But it is so
+strange!”
+
+“Yes--_that_ is what makes it amusing. Had they fixed on any other man
+it would have been nothing; but _his_ perfect indifference, and _your_
+pointed dislike, make it so delightfully absurd! Much as I abominate
+writing, I would not give up Mr. Collins’s correspondence for any
+consideration. Nay, when I read a letter of his, I cannot help giving
+him the preference even over Wickham, much as I value the impudence and
+hypocrisy of my son-in-law. And pray, Lizzy, what said Lady Catherine
+about this report? Did she call to refuse her consent?”
+
+To this question his daughter replied only with a laugh; and as it had
+been asked without the least suspicion, she was not distressed by
+his repeating it. Elizabeth had never been more at a loss to make her
+feelings appear what they were not. It was necessary to laugh, when she
+would rather have cried. Her father had most cruelly mortified her, by
+what he said of Mr. Darcy’s indifference, and she could do nothing but
+wonder at such a want of penetration, or fear that perhaps, instead of
+his seeing too little, she might have fancied too much.
+
+
+
+Chapter 58
+
+
+Instead of receiving any such letter of excuse from his friend, as
+Elizabeth half expected Mr. Bingley to do, he was able to bring Darcy
+with him to Longbourn before many days had passed after Lady Catherine’s
+visit. The gentlemen arrived early; and, before Mrs. Bennet had time
+to tell him of their having seen his aunt, of which her daughter sat
+in momentary dread, Bingley, who wanted to be alone with Jane, proposed
+their all walking out. It was agreed to. Mrs. Bennet was not in the
+habit of walking; Mary could never spare time; but the remaining five
+set off together. Bingley and Jane, however, soon allowed the others
+to outstrip them. They lagged behind, while Elizabeth, Kitty, and Darcy
+were to entertain each other. Very little was said by either; Kitty
+was too much afraid of him to talk; Elizabeth was secretly forming a
+desperate resolution; and perhaps he might be doing the same.
+
+They walked towards the Lucases, because Kitty wished to call upon
+Maria; and as Elizabeth saw no occasion for making it a general concern,
+when Kitty left them she went boldly on with him alone. Now was the
+moment for her resolution to be executed, and, while her courage was
+high, she immediately said:
+
+“Mr. Darcy, I am a very selfish creature; and, for the sake of giving
+relief to my own feelings, care not how much I may be wounding yours. I
+can no longer help thanking you for your unexampled kindness to my
+poor sister. Ever since I have known it, I have been most anxious to
+acknowledge to you how gratefully I feel it. Were it known to the rest
+of my family, I should not have merely my own gratitude to express.”
+
+“I am sorry, exceedingly sorry,” replied Darcy, in a tone of surprise
+and emotion, “that you have ever been informed of what may, in a
+mistaken light, have given you uneasiness. I did not think Mrs. Gardiner
+was so little to be trusted.”
+
+“You must not blame my aunt. Lydia’s thoughtlessness first betrayed to
+me that you had been concerned in the matter; and, of course, I could
+not rest till I knew the particulars. Let me thank you again and again,
+in the name of all my family, for that generous compassion which induced
+you to take so much trouble, and bear so many mortifications, for the
+sake of discovering them.”
+
+“If you _will_ thank me,” he replied, “let it be for yourself alone.
+That the wish of giving happiness to you might add force to the other
+inducements which led me on, I shall not attempt to deny. But your
+_family_ owe me nothing. Much as I respect them, I believe I thought
+only of _you_.”
+
+Elizabeth was too much embarrassed to say a word. After a short pause,
+her companion added, “You are too generous to trifle with me. If your
+feelings are still what they were last April, tell me so at once. _My_
+affections and wishes are unchanged, but one word from you will silence
+me on this subject for ever.”
+
+Elizabeth, feeling all the more than common awkwardness and anxiety of
+his situation, now forced herself to speak; and immediately, though not
+very fluently, gave him to understand that her sentiments had undergone
+so material a change, since the period to which he alluded, as to make
+her receive with gratitude and pleasure his present assurances. The
+happiness which this reply produced, was such as he had probably never
+felt before; and he expressed himself on the occasion as sensibly and as
+warmly as a man violently in love can be supposed to do. Had Elizabeth
+been able to encounter his eye, she might have seen how well the
+expression of heartfelt delight, diffused over his face, became him;
+but, though she could not look, she could listen, and he told her of
+feelings, which, in proving of what importance she was to him, made his
+affection every moment more valuable.
+
+They walked on, without knowing in what direction. There was too much to
+be thought, and felt, and said, for attention to any other objects. She
+soon learnt that they were indebted for their present good understanding
+to the efforts of his aunt, who did call on him in her return through
+London, and there relate her journey to Longbourn, its motive, and the
+substance of her conversation with Elizabeth; dwelling emphatically on
+every expression of the latter which, in her ladyship’s apprehension,
+peculiarly denoted her perverseness and assurance; in the belief that
+such a relation must assist her endeavours to obtain that promise
+from her nephew which she had refused to give. But, unluckily for her
+ladyship, its effect had been exactly contrariwise.
+
+“It taught me to hope,” said he, “as I had scarcely ever allowed myself
+to hope before. I knew enough of your disposition to be certain that,
+had you been absolutely, irrevocably decided against me, you would have
+acknowledged it to Lady Catherine, frankly and openly.”
+
+Elizabeth coloured and laughed as she replied, “Yes, you know enough
+of my frankness to believe me capable of _that_. After abusing you so
+abominably to your face, I could have no scruple in abusing you to all
+your relations.”
+
+“What did you say of me, that I did not deserve? For, though your
+accusations were ill-founded, formed on mistaken premises, my
+behaviour to you at the time had merited the severest reproof. It was
+unpardonable. I cannot think of it without abhorrence.”
+
+“We will not quarrel for the greater share of blame annexed to that
+evening,” said Elizabeth. “The conduct of neither, if strictly examined,
+will be irreproachable; but since then, we have both, I hope, improved
+in civility.”
+
+“I cannot be so easily reconciled to myself. The recollection of what I
+then said, of my conduct, my manners, my expressions during the whole of
+it, is now, and has been many months, inexpressibly painful to me. Your
+reproof, so well applied, I shall never forget: ‘had you behaved in a
+more gentlemanlike manner.’ Those were your words. You know not, you can
+scarcely conceive, how they have tortured me;--though it was some time,
+I confess, before I was reasonable enough to allow their justice.”
+
+“I was certainly very far from expecting them to make so strong an
+impression. I had not the smallest idea of their being ever felt in such
+a way.”
+
+“I can easily believe it. You thought me then devoid of every proper
+feeling, I am sure you did. The turn of your countenance I shall never
+forget, as you said that I could not have addressed you in any possible
+way that would induce you to accept me.”
+
+“Oh! do not repeat what I then said. These recollections will not do at
+all. I assure you that I have long been most heartily ashamed of it.”
+
+Darcy mentioned his letter. “Did it,” said he, “did it soon make you
+think better of me? Did you, on reading it, give any credit to its
+contents?”
+
+She explained what its effect on her had been, and how gradually all her
+former prejudices had been removed.
+
+“I knew,” said he, “that what I wrote must give you pain, but it was
+necessary. I hope you have destroyed the letter. There was one part
+especially, the opening of it, which I should dread your having the
+power of reading again. I can remember some expressions which might
+justly make you hate me.”
+
+“The letter shall certainly be burnt, if you believe it essential to the
+preservation of my regard; but, though we have both reason to think my
+opinions not entirely unalterable, they are not, I hope, quite so easily
+changed as that implies.”
+
+“When I wrote that letter,” replied Darcy, “I believed myself perfectly
+calm and cool, but I am since convinced that it was written in a
+dreadful bitterness of spirit.”
+
+“The letter, perhaps, began in bitterness, but it did not end so. The
+adieu is charity itself. But think no more of the letter. The feelings
+of the person who wrote, and the person who received it, are now
+so widely different from what they were then, that every unpleasant
+circumstance attending it ought to be forgotten. You must learn some
+of my philosophy. Think only of the past as its remembrance gives you
+pleasure.”
+
+“I cannot give you credit for any philosophy of the kind. Your
+retrospections must be so totally void of reproach, that the contentment
+arising from them is not of philosophy, but, what is much better, of
+innocence. But with me, it is not so. Painful recollections will intrude
+which cannot, which ought not, to be repelled. I have been a selfish
+being all my life, in practice, though not in principle. As a child I
+was taught what was right, but I was not taught to correct my temper. I
+was given good principles, but left to follow them in pride and conceit.
+Unfortunately an only son (for many years an only child), I was spoilt
+by my parents, who, though good themselves (my father, particularly, all
+that was benevolent and amiable), allowed, encouraged, almost taught
+me to be selfish and overbearing; to care for none beyond my own family
+circle; to think meanly of all the rest of the world; to wish at least
+to think meanly of their sense and worth compared with my own. Such I
+was, from eight to eight and twenty; and such I might still have been
+but for you, dearest, loveliest Elizabeth! What do I not owe you! You
+taught me a lesson, hard indeed at first, but most advantageous. By you,
+I was properly humbled. I came to you without a doubt of my reception.
+You showed me how insufficient were all my pretensions to please a woman
+worthy of being pleased.”
+
+“Had you then persuaded yourself that I should?”
+
+“Indeed I had. What will you think of my vanity? I believed you to be
+wishing, expecting my addresses.”
+
+“My manners must have been in fault, but not intentionally, I assure
+you. I never meant to deceive you, but my spirits might often lead me
+wrong. How you must have hated me after _that_ evening?”
+
+“Hate you! I was angry perhaps at first, but my anger soon began to take
+a proper direction.”
+
+“I am almost afraid of asking what you thought of me, when we met at
+Pemberley. You blamed me for coming?”
+
+“No indeed; I felt nothing but surprise.”
+
+“Your surprise could not be greater than _mine_ in being noticed by you.
+My conscience told me that I deserved no extraordinary politeness, and I
+confess that I did not expect to receive _more_ than my due.”
+
+“My object then,” replied Darcy, “was to show you, by every civility in
+my power, that I was not so mean as to resent the past; and I hoped to
+obtain your forgiveness, to lessen your ill opinion, by letting you
+see that your reproofs had been attended to. How soon any other wishes
+introduced themselves I can hardly tell, but I believe in about half an
+hour after I had seen you.”
+
+He then told her of Georgiana’s delight in her acquaintance, and of her
+disappointment at its sudden interruption; which naturally leading to
+the cause of that interruption, she soon learnt that his resolution of
+following her from Derbyshire in quest of her sister had been formed
+before he quitted the inn, and that his gravity and thoughtfulness
+there had arisen from no other struggles than what such a purpose must
+comprehend.
+
+She expressed her gratitude again, but it was too painful a subject to
+each, to be dwelt on farther.
+
+After walking several miles in a leisurely manner, and too busy to know
+anything about it, they found at last, on examining their watches, that
+it was time to be at home.
+
+“What could become of Mr. Bingley and Jane!” was a wonder which
+introduced the discussion of their affairs. Darcy was delighted with
+their engagement; his friend had given him the earliest information of
+it.
+
+“I must ask whether you were surprised?” said Elizabeth.
+
+“Not at all. When I went away, I felt that it would soon happen.”
+
+“That is to say, you had given your permission. I guessed as much.” And
+though he exclaimed at the term, she found that it had been pretty much
+the case.
+
+“On the evening before my going to London,” said he, “I made a
+confession to him, which I believe I ought to have made long ago. I
+told him of all that had occurred to make my former interference in his
+affairs absurd and impertinent. His surprise was great. He had never had
+the slightest suspicion. I told him, moreover, that I believed myself
+mistaken in supposing, as I had done, that your sister was indifferent
+to him; and as I could easily perceive that his attachment to her was
+unabated, I felt no doubt of their happiness together.”
+
+Elizabeth could not help smiling at his easy manner of directing his
+friend.
+
+“Did you speak from your own observation,” said she, “when you told him
+that my sister loved him, or merely from my information last spring?”
+
+“From the former. I had narrowly observed her during the two visits
+which I had lately made here; and I was convinced of her affection.”
+
+“And your assurance of it, I suppose, carried immediate conviction to
+him.”
+
+“It did. Bingley is most unaffectedly modest. His diffidence had
+prevented his depending on his own judgment in so anxious a case, but
+his reliance on mine made every thing easy. I was obliged to confess
+one thing, which for a time, and not unjustly, offended him. I could not
+allow myself to conceal that your sister had been in town three months
+last winter, that I had known it, and purposely kept it from him. He was
+angry. But his anger, I am persuaded, lasted no longer than he remained
+in any doubt of your sister’s sentiments. He has heartily forgiven me
+now.”
+
+Elizabeth longed to observe that Mr. Bingley had been a most delightful
+friend; so easily guided that his worth was invaluable; but she checked
+herself. She remembered that he had yet to learn to be laughed at,
+and it was rather too early to begin. In anticipating the happiness
+of Bingley, which of course was to be inferior only to his own, he
+continued the conversation till they reached the house. In the hall they
+parted.
+
+
+
+Chapter 59
+
+
+“My dear Lizzy, where can you have been walking to?” was a question
+which Elizabeth received from Jane as soon as she entered their room,
+and from all the others when they sat down to table. She had only to
+say in reply, that they had wandered about, till she was beyond her own
+knowledge. She coloured as she spoke; but neither that, nor anything
+else, awakened a suspicion of the truth.
+
+The evening passed quietly, unmarked by anything extraordinary. The
+acknowledged lovers talked and laughed, the unacknowledged were silent.
+Darcy was not of a disposition in which happiness overflows in mirth;
+and Elizabeth, agitated and confused, rather _knew_ that she was happy
+than _felt_ herself to be so; for, besides the immediate embarrassment,
+there were other evils before her. She anticipated what would be felt
+in the family when her situation became known; she was aware that no
+one liked him but Jane; and even feared that with the others it was a
+dislike which not all his fortune and consequence might do away.
+
+At night she opened her heart to Jane. Though suspicion was very far
+from Miss Bennet’s general habits, she was absolutely incredulous here.
+
+“You are joking, Lizzy. This cannot be!--engaged to Mr. Darcy! No, no,
+you shall not deceive me. I know it to be impossible.”
+
+“This is a wretched beginning indeed! My sole dependence was on you; and
+I am sure nobody else will believe me, if you do not. Yet, indeed, I am
+in earnest. I speak nothing but the truth. He still loves me, and we are
+engaged.”
+
+Jane looked at her doubtingly. “Oh, Lizzy! it cannot be. I know how much
+you dislike him.”
+
+“You know nothing of the matter. _That_ is all to be forgot. Perhaps I
+did not always love him so well as I do now. But in such cases as
+these, a good memory is unpardonable. This is the last time I shall ever
+remember it myself.”
+
+Miss Bennet still looked all amazement. Elizabeth again, and more
+seriously assured her of its truth.
+
+“Good Heaven! can it be really so! Yet now I must believe you,” cried
+Jane. “My dear, dear Lizzy, I would--I do congratulate you--but are you
+certain? forgive the question--are you quite certain that you can be
+happy with him?”
+
+“There can be no doubt of that. It is settled between us already, that
+we are to be the happiest couple in the world. But are you pleased,
+Jane? Shall you like to have such a brother?”
+
+“Very, very much. Nothing could give either Bingley or myself more
+delight. But we considered it, we talked of it as impossible. And do you
+really love him quite well enough? Oh, Lizzy! do anything rather than
+marry without affection. Are you quite sure that you feel what you ought
+to do?”
+
+“Oh, yes! You will only think I feel _more_ than I ought to do, when I
+tell you all.”
+
+“What do you mean?”
+
+“Why, I must confess that I love him better than I do Bingley. I am
+afraid you will be angry.”
+
+“My dearest sister, now _be_ serious. I want to talk very seriously. Let
+me know every thing that I am to know, without delay. Will you tell me
+how long you have loved him?”
+
+“It has been coming on so gradually, that I hardly know when it began.
+But I believe I must date it from my first seeing his beautiful grounds
+at Pemberley.”
+
+Another entreaty that she would be serious, however, produced the
+desired effect; and she soon satisfied Jane by her solemn assurances
+of attachment. When convinced on that article, Miss Bennet had nothing
+further to wish.
+
+“Now I am quite happy,” said she, “for you will be as happy as myself.
+I always had a value for him. Were it for nothing but his love of you,
+I must always have esteemed him; but now, as Bingley’s friend and your
+husband, there can be only Bingley and yourself more dear to me. But
+Lizzy, you have been very sly, very reserved with me. How little did you
+tell me of what passed at Pemberley and Lambton! I owe all that I know
+of it to another, not to you.”
+
+Elizabeth told her the motives of her secrecy. She had been unwilling
+to mention Bingley; and the unsettled state of her own feelings had made
+her equally avoid the name of his friend. But now she would no longer
+conceal from her his share in Lydia’s marriage. All was acknowledged,
+and half the night spent in conversation.
+
+                          * * * * *
+
+“Good gracious!” cried Mrs. Bennet, as she stood at a window the next
+morning, “if that disagreeable Mr. Darcy is not coming here again with
+our dear Bingley! What can he mean by being so tiresome as to be always
+coming here? I had no notion but he would go a-shooting, or something or
+other, and not disturb us with his company. What shall we do with him?
+Lizzy, you must walk out with him again, that he may not be in Bingley’s
+way.”
+
+Elizabeth could hardly help laughing at so convenient a proposal; yet
+was really vexed that her mother should be always giving him such an
+epithet.
+
+As soon as they entered, Bingley looked at her so expressively, and
+shook hands with such warmth, as left no doubt of his good information;
+and he soon afterwards said aloud, “Mrs. Bennet, have you no more lanes
+hereabouts in which Lizzy may lose her way again to-day?”
+
+“I advise Mr. Darcy, and Lizzy, and Kitty,” said Mrs. Bennet, “to walk
+to Oakham Mount this morning. It is a nice long walk, and Mr. Darcy has
+never seen the view.”
+
+“It may do very well for the others,” replied Mr. Bingley; “but I am
+sure it will be too much for Kitty. Won’t it, Kitty?” Kitty owned that
+she had rather stay at home. Darcy professed a great curiosity to see
+the view from the Mount, and Elizabeth silently consented. As she went
+up stairs to get ready, Mrs. Bennet followed her, saying:
+
+“I am quite sorry, Lizzy, that you should be forced to have that
+disagreeable man all to yourself. But I hope you will not mind it: it is
+all for Jane’s sake, you know; and there is no occasion for talking
+to him, except just now and then. So, do not put yourself to
+inconvenience.”
+
+During their walk, it was resolved that Mr. Bennet’s consent should be
+asked in the course of the evening. Elizabeth reserved to herself the
+application for her mother’s. She could not determine how her mother
+would take it; sometimes doubting whether all his wealth and grandeur
+would be enough to overcome her abhorrence of the man. But whether she
+were violently set against the match, or violently delighted with it, it
+was certain that her manner would be equally ill adapted to do credit
+to her sense; and she could no more bear that Mr. Darcy should hear
+the first raptures of her joy, than the first vehemence of her
+disapprobation.
+
+                          * * * * *
+
+In the evening, soon after Mr. Bennet withdrew to the library, she saw
+Mr. Darcy rise also and follow him, and her agitation on seeing it was
+extreme. She did not fear her father’s opposition, but he was going to
+be made unhappy; and that it should be through her means--that _she_,
+his favourite child, should be distressing him by her choice, should be
+filling him with fears and regrets in disposing of her--was a wretched
+reflection, and she sat in misery till Mr. Darcy appeared again, when,
+looking at him, she was a little relieved by his smile. In a few minutes
+he approached the table where she was sitting with Kitty; and, while
+pretending to admire her work said in a whisper, “Go to your father, he
+wants you in the library.” She was gone directly.
+
+Her father was walking about the room, looking grave and anxious.
+“Lizzy,” said he, “what are you doing? Are you out of your senses, to be
+accepting this man? Have not you always hated him?”
+
+How earnestly did she then wish that her former opinions had been more
+reasonable, her expressions more moderate! It would have spared her from
+explanations and professions which it was exceedingly awkward to give;
+but they were now necessary, and she assured him, with some confusion,
+of her attachment to Mr. Darcy.
+
+“Or, in other words, you are determined to have him. He is rich, to be
+sure, and you may have more fine clothes and fine carriages than Jane.
+But will they make you happy?”
+
+“Have you any other objection,” said Elizabeth, “than your belief of my
+indifference?”
+
+“None at all. We all know him to be a proud, unpleasant sort of man; but
+this would be nothing if you really liked him.”
+
+“I do, I do like him,” she replied, with tears in her eyes, “I love him.
+Indeed he has no improper pride. He is perfectly amiable. You do not
+know what he really is; then pray do not pain me by speaking of him in
+such terms.”
+
+“Lizzy,” said her father, “I have given him my consent. He is the kind
+of man, indeed, to whom I should never dare refuse anything, which he
+condescended to ask. I now give it to _you_, if you are resolved on
+having him. But let me advise you to think better of it. I know
+your disposition, Lizzy. I know that you could be neither happy nor
+respectable, unless you truly esteemed your husband; unless you looked
+up to him as a superior. Your lively talents would place you in the
+greatest danger in an unequal marriage. You could scarcely escape
+discredit and misery. My child, let me not have the grief of seeing
+_you_ unable to respect your partner in life. You know not what you are
+about.”
+
+Elizabeth, still more affected, was earnest and solemn in her reply; and
+at length, by repeated assurances that Mr. Darcy was really the object
+of her choice, by explaining the gradual change which her estimation of
+him had undergone, relating her absolute certainty that his affection
+was not the work of a day, but had stood the test of many months’
+suspense, and enumerating with energy all his good qualities, she did
+conquer her father’s incredulity, and reconcile him to the match.
+
+“Well, my dear,” said he, when she ceased speaking, “I have no more to
+say. If this be the case, he deserves you. I could not have parted with
+you, my Lizzy, to anyone less worthy.”
+
+To complete the favourable impression, she then told him what Mr. Darcy
+had voluntarily done for Lydia. He heard her with astonishment.
+
+“This is an evening of wonders, indeed! And so, Darcy did every thing;
+made up the match, gave the money, paid the fellow’s debts, and got him
+his commission! So much the better. It will save me a world of trouble
+and economy. Had it been your uncle’s doing, I must and _would_ have
+paid him; but these violent young lovers carry every thing their own
+way. I shall offer to pay him to-morrow; he will rant and storm about
+his love for you, and there will be an end of the matter.”
+
+He then recollected her embarrassment a few days before, on his reading
+Mr. Collins’s letter; and after laughing at her some time, allowed her
+at last to go--saying, as she quitted the room, “If any young men come
+for Mary or Kitty, send them in, for I am quite at leisure.”
+
+Elizabeth’s mind was now relieved from a very heavy weight; and, after
+half an hour’s quiet reflection in her own room, she was able to join
+the others with tolerable composure. Every thing was too recent for
+gaiety, but the evening passed tranquilly away; there was no longer
+anything material to be dreaded, and the comfort of ease and familiarity
+would come in time.
+
+When her mother went up to her dressing-room at night, she followed her,
+and made the important communication. Its effect was most extraordinary;
+for on first hearing it, Mrs. Bennet sat quite still, and unable to
+utter a syllable. Nor was it under many, many minutes that she could
+comprehend what she heard; though not in general backward to credit
+what was for the advantage of her family, or that came in the shape of a
+lover to any of them. She began at length to recover, to fidget about in
+her chair, get up, sit down again, wonder, and bless herself.
+
+“Good gracious! Lord bless me! only think! dear me! Mr. Darcy! Who would
+have thought it! And is it really true? Oh! my sweetest Lizzy! how rich
+and how great you will be! What pin-money, what jewels, what carriages
+you will have! Jane’s is nothing to it--nothing at all. I am so
+pleased--so happy. Such a charming man!--so handsome! so tall!--Oh, my
+dear Lizzy! pray apologise for my having disliked him so much before. I
+hope he will overlook it. Dear, dear Lizzy. A house in town! Every thing
+that is charming! Three daughters married! Ten thousand a year! Oh,
+Lord! What will become of me. I shall go distracted.”
+
+This was enough to prove that her approbation need not be doubted: and
+Elizabeth, rejoicing that such an effusion was heard only by herself,
+soon went away. But before she had been three minutes in her own room,
+her mother followed her.
+
+“My dearest child,” she cried, “I can think of nothing else! Ten
+thousand a year, and very likely more! ‘Tis as good as a Lord! And a
+special licence. You must and shall be married by a special licence. But
+my dearest love, tell me what dish Mr. Darcy is particularly fond of,
+that I may have it to-morrow.”
+
+This was a sad omen of what her mother’s behaviour to the gentleman
+himself might be; and Elizabeth found that, though in the certain
+possession of his warmest affection, and secure of her relations’
+consent, there was still something to be wished for. But the morrow
+passed off much better than she expected; for Mrs. Bennet luckily stood
+in such awe of her intended son-in-law that she ventured not to speak to
+him, unless it was in her power to offer him any attention, or mark her
+deference for his opinion.
+
+Elizabeth had the satisfaction of seeing her father taking pains to get
+acquainted with him; and Mr. Bennet soon assured her that he was rising
+every hour in his esteem.
+
+“I admire all my three sons-in-law highly,” said he. “Wickham, perhaps,
+is my favourite; but I think I shall like _your_ husband quite as well
+as Jane’s.”
+
+
+
+Chapter 60
+
+
+Elizabeth’s spirits soon rising to playfulness again, she wanted Mr.
+Darcy to account for his having ever fallen in love with her. “How could
+you begin?” said she. “I can comprehend your going on charmingly, when
+you had once made a beginning; but what could set you off in the first
+place?”
+
+“I cannot fix on the hour, or the spot, or the look, or the words, which
+laid the foundation. It is too long ago. I was in the middle before I
+knew that I _had_ begun.”
+
+“My beauty you had early withstood, and as for my manners--my behaviour
+to _you_ was at least always bordering on the uncivil, and I never spoke
+to you without rather wishing to give you pain than not. Now be sincere;
+did you admire me for my impertinence?”
+
+“For the liveliness of your mind, I did.”
+
+“You may as well call it impertinence at once. It was very little less.
+The fact is, that you were sick of civility, of deference, of officious
+attention. You were disgusted with the women who were always speaking,
+and looking, and thinking for _your_ approbation alone. I roused, and
+interested you, because I was so unlike _them_. Had you not been really
+amiable, you would have hated me for it; but in spite of the pains you
+took to disguise yourself, your feelings were always noble and just; and
+in your heart, you thoroughly despised the persons who so assiduously
+courted you. There--I have saved you the trouble of accounting for
+it; and really, all things considered, I begin to think it perfectly
+reasonable. To be sure, you knew no actual good of me--but nobody thinks
+of _that_ when they fall in love.”
+
+“Was there no good in your affectionate behaviour to Jane while she was
+ill at Netherfield?”
+
+“Dearest Jane! who could have done less for her? But make a virtue of it
+by all means. My good qualities are under your protection, and you are
+to exaggerate them as much as possible; and, in return, it belongs to me
+to find occasions for teasing and quarrelling with you as often as may
+be; and I shall begin directly by asking you what made you so unwilling
+to come to the point at last. What made you so shy of me, when you first
+called, and afterwards dined here? Why, especially, when you called, did
+you look as if you did not care about me?”
+
+“Because you were grave and silent, and gave me no encouragement.”
+
+“But I was embarrassed.”
+
+“And so was I.”
+
+“You might have talked to me more when you came to dinner.”
+
+“A man who had felt less, might.”
+
+“How unlucky that you should have a reasonable answer to give, and that
+I should be so reasonable as to admit it! But I wonder how long you
+_would_ have gone on, if you had been left to yourself. I wonder when
+you _would_ have spoken, if I had not asked you! My resolution of
+thanking you for your kindness to Lydia had certainly great effect.
+_Too much_, I am afraid; for what becomes of the moral, if our comfort
+springs from a breach of promise? for I ought not to have mentioned the
+subject. This will never do.”
+
+“You need not distress yourself. The moral will be perfectly fair. Lady
+Catherine’s unjustifiable endeavours to separate us were the means of
+removing all my doubts. I am not indebted for my present happiness to
+your eager desire of expressing your gratitude. I was not in a humour
+to wait for any opening of yours. My aunt’s intelligence had given me
+hope, and I was determined at once to know every thing.”
+
+“Lady Catherine has been of infinite use, which ought to make her happy,
+for she loves to be of use. But tell me, what did you come down to
+Netherfield for? Was it merely to ride to Longbourn and be embarrassed?
+or had you intended any more serious consequence?”
+
+“My real purpose was to see _you_, and to judge, if I could, whether I
+might ever hope to make you love me. My avowed one, or what I avowed to
+myself, was to see whether your sister were still partial to Bingley,
+and if she were, to make the confession to him which I have since made.”
+
+“Shall you ever have courage to announce to Lady Catherine what is to
+befall her?”
+
+“I am more likely to want more time than courage, Elizabeth. But it
+ought to be done, and if you will give me a sheet of paper, it shall be
+done directly.”
+
+“And if I had not a letter to write myself, I might sit by you and
+admire the evenness of your writing, as another young lady once did. But
+I have an aunt, too, who must not be longer neglected.”
+
+From an unwillingness to confess how much her intimacy with Mr. Darcy
+had been over-rated, Elizabeth had never yet answered Mrs. Gardiner’s
+long letter; but now, having _that_ to communicate which she knew would
+be most welcome, she was almost ashamed to find that her uncle and
+aunt had already lost three days of happiness, and immediately wrote as
+follows:
+
+“I would have thanked you before, my dear aunt, as I ought to have done,
+for your long, kind, satisfactory, detail of particulars; but to say the
+truth, I was too cross to write. You supposed more than really existed.
+But _now_ suppose as much as you choose; give a loose rein to your
+fancy, indulge your imagination in every possible flight which the
+subject will afford, and unless you believe me actually married, you
+cannot greatly err. You must write again very soon, and praise him a
+great deal more than you did in your last. I thank you, again and again,
+for not going to the Lakes. How could I be so silly as to wish it! Your
+idea of the ponies is delightful. We will go round the Park every day. I
+am the happiest creature in the world. Perhaps other people have said so
+before, but not one with such justice. I am happier even than Jane; she
+only smiles, I laugh. Mr. Darcy sends you all the love in the world that
+he can spare from me. You are all to come to Pemberley at Christmas.
+Yours, etc.”
+
+Mr. Darcy’s letter to Lady Catherine was in a different style; and still
+different from either was what Mr. Bennet sent to Mr. Collins, in reply
+to his last.
+
+“DEAR SIR,
+
+“I must trouble you once more for congratulations. Elizabeth will soon
+be the wife of Mr. Darcy. Console Lady Catherine as well as you can.
+But, if I were you, I would stand by the nephew. He has more to give.
+
+“Yours sincerely, etc.”
+
+Miss Bingley’s congratulations to her brother, on his approaching
+marriage, were all that was affectionate and insincere. She wrote even
+to Jane on the occasion, to express her delight, and repeat all her
+former professions of regard. Jane was not deceived, but she was
+affected; and though feeling no reliance on her, could not help writing
+her a much kinder answer than she knew was deserved.
+
+The joy which Miss Darcy expressed on receiving similar information,
+was as sincere as her brother’s in sending it. Four sides of paper were
+insufficient to contain all her delight, and all her earnest desire of
+being loved by her sister.
+
+Before any answer could arrive from Mr. Collins, or any congratulations
+to Elizabeth from his wife, the Longbourn family heard that the
+Collinses were come themselves to Lucas Lodge. The reason of this
+sudden removal was soon evident. Lady Catherine had been rendered
+so exceedingly angry by the contents of her nephew’s letter, that
+Charlotte, really rejoicing in the match, was anxious to get away till
+the storm was blown over. At such a moment, the arrival of her friend
+was a sincere pleasure to Elizabeth, though in the course of their
+meetings she must sometimes think the pleasure dearly bought, when she
+saw Mr. Darcy exposed to all the parading and obsequious civility of
+her husband. He bore it, however, with admirable calmness. He could even
+listen to Sir William Lucas, when he complimented him on carrying away
+the brightest jewel of the country, and expressed his hopes of their all
+meeting frequently at St. James’s, with very decent composure. If he did
+shrug his shoulders, it was not till Sir William was out of sight.
+
+Mrs. Phillips’s vulgarity was another, and perhaps a greater, tax on his
+forbearance; and though Mrs. Phillips, as well as her sister, stood in
+too much awe of him to speak with the familiarity which Bingley’s good
+humour encouraged, yet, whenever she _did_ speak, she must be vulgar.
+Nor was her respect for him, though it made her more quiet, at all
+likely to make her more elegant. Elizabeth did all she could to shield
+him from the frequent notice of either, and was ever anxious to keep
+him to herself, and to those of her family with whom he might converse
+without mortification; and though the uncomfortable feelings arising
+from all this took from the season of courtship much of its pleasure, it
+added to the hope of the future; and she looked forward with delight to
+the time when they should be removed from society so little pleasing
+to either, to all the comfort and elegance of their family party at
+Pemberley.
+
+
+
+Chapter 61
+
+
+Happy for all her maternal feelings was the day on which Mrs. Bennet got
+rid of her two most deserving daughters. With what delighted pride
+she afterwards visited Mrs. Bingley, and talked of Mrs. Darcy, may
+be guessed. I wish I could say, for the sake of her family, that the
+accomplishment of her earnest desire in the establishment of so many
+of her children produced so happy an effect as to make her a sensible,
+amiable, well-informed woman for the rest of her life; though perhaps it
+was lucky for her husband, who might not have relished domestic felicity
+in so unusual a form, that she still was occasionally nervous and
+invariably silly.
+
+Mr. Bennet missed his second daughter exceedingly; his affection for her
+drew him oftener from home than anything else could do. He delighted in
+going to Pemberley, especially when he was least expected.
+
+Mr. Bingley and Jane remained at Netherfield only a twelvemonth. So near
+a vicinity to her mother and Meryton relations was not desirable even to
+_his_ easy temper, or _her_ affectionate heart. The darling wish of his
+sisters was then gratified; he bought an estate in a neighbouring county
+to Derbyshire, and Jane and Elizabeth, in addition to every other source
+of happiness, were within thirty miles of each other.
+
+Kitty, to her very material advantage, spent the chief of her time with
+her two elder sisters. In society so superior to what she had generally
+known, her improvement was great. She was not of so ungovernable a
+temper as Lydia; and, removed from the influence of Lydia’s example,
+she became, by proper attention and management, less irritable, less
+ignorant, and less insipid. From the further disadvantage of Lydia’s
+society she was of course carefully kept, and though Mrs. Wickham
+frequently invited her to come and stay with her, with the promise of
+balls and young men, her father would never consent to her going.
+
+Mary was the only daughter who remained at home; and she was necessarily
+drawn from the pursuit of accomplishments by Mrs. Bennet’s being quite
+unable to sit alone. Mary was obliged to mix more with the world, but
+she could still moralize over every morning visit; and as she was no
+longer mortified by comparisons between her sisters’ beauty and her own,
+it was suspected by her father that she submitted to the change without
+much reluctance.
+
+As for Wickham and Lydia, their characters suffered no revolution from
+the marriage of her sisters. He bore with philosophy the conviction that
+Elizabeth must now become acquainted with whatever of his ingratitude
+and falsehood had before been unknown to her; and in spite of every
+thing, was not wholly without hope that Darcy might yet be prevailed on
+to make his fortune. The congratulatory letter which Elizabeth received
+from Lydia on her marriage, explained to her that, by his wife at least,
+if not by himself, such a hope was cherished. The letter was to this
+effect:
+
+“MY DEAR LIZZY,
+
+“I wish you joy. If you love Mr. Darcy half as well as I do my dear
+Wickham, you must be very happy. It is a great comfort to have you so
+rich, and when you have nothing else to do, I hope you will think of us.
+I am sure Wickham would like a place at court very much, and I do not
+think we shall have quite money enough to live upon without some help.
+Any place would do, of about three or four hundred a year; but however,
+do not speak to Mr. Darcy about it, if you had rather not.
+
+“Yours, etc.”
+
+As it happened that Elizabeth had _much_ rather not, she endeavoured in
+her answer to put an end to every entreaty and expectation of the kind.
+Such relief, however, as it was in her power to afford, by the practice
+of what might be called economy in her own private expences, she
+frequently sent them. It had always been evident to her that such an
+income as theirs, under the direction of two persons so extravagant in
+their wants, and heedless of the future, must be very insufficient to
+their support; and whenever they changed their quarters, either Jane or
+herself were sure of being applied to for some little assistance
+towards discharging their bills. Their manner of living, even when the
+restoration of peace dismissed them to a home, was unsettled in the
+extreme. They were always moving from place to place in quest of a cheap
+situation, and always spending more than they ought. His affection for
+her soon sunk into indifference; hers lasted a little longer; and
+in spite of her youth and her manners, she retained all the claims to
+reputation which her marriage had given her.
+
+Though Darcy could never receive _him_ at Pemberley, yet, for
+Elizabeth’s sake, he assisted him further in his profession. Lydia was
+occasionally a visitor there, when her husband was gone to enjoy himself
+in London or Bath; and with the Bingleys they both of them frequently
+staid so long, that even Bingley’s good humour was overcome, and he
+proceeded so far as to talk of giving them a hint to be gone.
+
+Miss Bingley was very deeply mortified by Darcy’s marriage; but as she
+thought it advisable to retain the right of visiting at Pemberley, she
+dropt all her resentment; was fonder than ever of Georgiana, almost as
+attentive to Darcy as heretofore, and paid off every arrear of civility
+to Elizabeth.
+
+Pemberley was now Georgiana’s home; and the attachment of the sisters
+was exactly what Darcy had hoped to see. They were able to love each
+other even as well as they intended. Georgiana had the highest opinion
+in the world of Elizabeth; though at first she often listened with
+an astonishment bordering on alarm at her lively, sportive, manner of
+talking to her brother. He, who had always inspired in herself a respect
+which almost overcame her affection, she now saw the object of open
+pleasantry. Her mind received knowledge which had never before fallen
+in her way. By Elizabeth’s instructions, she began to comprehend that
+a woman may take liberties with her husband which a brother will not
+always allow in a sister more than ten years younger than himself.
+
+Lady Catherine was extremely indignant on the marriage of her nephew;
+and as she gave way to all the genuine frankness of her character in
+her reply to the letter which announced its arrangement, she sent him
+language so very abusive, especially of Elizabeth, that for some time
+all intercourse was at an end. But at length, by Elizabeth’s persuasion,
+he was prevailed on to overlook the offence, and seek a reconciliation;
+and, after a little further resistance on the part of his aunt, her
+resentment gave way, either to her affection for him, or her curiosity
+to see how his wife conducted herself; and she condescended to wait
+on them at Pemberley, in spite of that pollution which its woods had
+received, not merely from the presence of such a mistress, but the
+visits of her uncle and aunt from the city.
+
+With the Gardiners, they were always on the most intimate terms.
+Darcy, as well as Elizabeth, really loved them; and they were both ever
+sensible of the warmest gratitude towards the persons who, by bringing
+her into Derbyshire, had been the means of uniting them.
+
+
+
+
+
+End of the Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+***** This file should be named 1342-0.txt or 1342-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/3/4/1342/
+
+Produced by Anonymous Volunteers
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/relativity-special-and-general-theory.txt
+++ b/jet/hadoop/src/main/resources/books/relativity-special-and-general-theory.txt
@@ -1,0 +1,4063 @@
+﻿The Project Gutenberg EBook of Relativity: The Special and General Theory
+by Albert Einstein
+(#1 in our series by Albert Einstein)
+
+Note: 58 image files are part of this eBook.  They include tables,
+equations and figures that could not be represented well as plain text.
+
+Copyright laws are changing all over the world. Be sure to check the
+copyright laws for your country before downloading or redistributing
+this or any other Project Gutenberg eBook.
+
+This header should be the first thing seen when viewing this Project
+Gutenberg file.  Please do not remove it.  Do not change or edit the
+header without written permission.
+
+Please read the "legal small print," and other information about the
+eBook and Project Gutenberg at the bottom of this file.  Included is
+important information about your specific rights and restrictions in
+how the file may be used.  You can also find out about how to make a
+donation to Project Gutenberg, and how to get involved.
+
+
+**Welcome To The World of Free Plain Vanilla Electronic Texts**
+
+**eBooks Readable By Both Humans and By Computers, Since 1971**
+
+*****These eBooks Were Prepared By Thousands of Volunteers!*****
+
+
+Title: Relativity: The Special and General Theory
+
+Author: Albert Einstein
+
+Release Date: February, 2004  [EBook #5001]
+[Yes, we are more than one year ahead of schedule]
+[This file was first posted on April 1, 2002]
+
+Edition: 10
+
+Language: English
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+
+
+
+ALBERT EINSTEIN REFERENCE ARCHIVE
+
+RELATIVITY: THE SPECIAL AND GENERAL THEORY
+
+BY ALBERT EINSTEIN
+
+
+Written: 1916 (this revised edition: 1924)
+Source: Relativity: The Special and General Theory (1920)
+Publisher: Methuen & Co Ltd
+First Published: December, 1916
+Translated: Robert W. Lawson (Authorised translation)
+Transcription/Markup: Brian Basgen <brian@marxists.org>
+Transcription to text: Gregory B. Newby <gbnewby@petascale.org>
+Thanks to: Einstein Reference Archive (marxists.org)
+The Einstein Reference Archive is online at:
+http://www.marxists.org/reference/archive/einstein/index.htm
+
+Transcriber note: This file is a plain text rendition of HTML.
+Because many equations cannot be presented effectively in plain text,
+images are supplied for many equations and for all figures and tables.
+
+
+CONTENTS
+
+Preface
+
+Part I: The Special Theory of Relativity
+
+01. Physical Meaning of Geometrical Propositions
+02. The System of Co-ordinates
+03. Space and Time in Classical Mechanics
+04. The Galileian System of Co-ordinates
+05. The Principle of Relativity (in the Restricted Sense)
+06. The Theorem of the Addition of Velocities employed in
+Classical Mechanics
+07. The Apparent Incompatability of the Law of Propagation of
+Light with the Principle of Relativity
+08. On the Idea of Time in Physics
+09. The Relativity of Simultaneity
+10. On the Relativity of the Conception of Distance
+11. The Lorentz Transformation
+12. The Behaviour of Measuring-Rods and Clocks in Motion
+13. Theorem of the Addition of Velocities. The Experiment of Fizeau
+14. The Hueristic Value of the Theory of Relativity
+15. General Results of the Theory
+16. Expereince and the Special Theory of Relativity
+17. Minkowski's Four-dimensial Space
+
+
+Part II: The General Theory of Relativity
+
+18. Special and General Principle of Relativity
+19. The Gravitational Field
+20. The Equality of Inertial and Gravitational Mass as an Argument
+for the General Postulate of Relativity
+21. In What Respects are the Foundations of Classical Mechanics
+and of the Special Theory of Relativity Unsatisfactory?
+22. A Few Inferences from the General Principle of Relativity
+23. Behaviour of Clocks and Measuring-Rods on a Rotating Body of
+Reference
+24. Euclidean and non-Euclidean Continuum
+25. Gaussian Co-ordinates
+26. The Space-Time Continuum of the Speical Theory of Relativity
+Considered as a Euclidean Continuum
+27. The Space-Time Continuum of the General Theory of Relativity
+is Not a Eculidean Continuum
+28. Exact Formulation of the General Principle of Relativity
+29. The Solution of the Problem of Gravitation on the Basis of the
+General Principle of Relativity
+
+
+Part III: Considerations on the Universe as a Whole
+
+30. Cosmological Difficulties of Netwon's Theory
+31. The Possibility of a "Finite" and yet "Unbounded" Universe
+32. The Structure of Space According to the General Theory of
+Relativity
+
+
+Appendices:
+
+01. Simple Derivation of the Lorentz Transformation (sup. ch. 11)
+02. Minkowski's Four-Dimensional Space ("World") (sup. ch 17)
+03. The Experimental Confirmation of the General Theory of Relativity
+04. The Structure of Space According to the General Theory of
+Relativity (sup. ch 32)
+05. Relativity and the Problem of Space
+
+Note: The fifth Appendix was added by Einstein at the time of the
+fifteenth re-printing of this book; and as a result is still under
+copyright restrictions so cannot be added without the permission of
+the publisher.
+
+
+
+PREFACE
+
+ (December, 1916)
+
+The present book is intended, as far as possible, to give an exact
+insight into the theory of Relativity to those readers who, from a
+general scientific and philosophical point of view, are interested in
+the theory, but who are not conversant with the mathematical apparatus
+of theoretical physics. The work presumes a standard of education
+corresponding to that of a university matriculation examination, and,
+despite the shortness of the book, a fair amount of patience and force
+of will on the part of the reader. The author has spared himself no
+pains in his endeavour to present the main ideas in the simplest and
+most intelligible form, and on the whole, in the sequence and
+connection in which they actually originated. In the interest of
+clearness, it appeared to me inevitable that I should repeat myself
+frequently, without paying the slightest attention to the elegance of
+the presentation. I adhered scrupulously to the precept of that
+brilliant theoretical physicist L. Boltzmann, according to whom
+matters of elegance ought to be left to the tailor and to the cobbler.
+I make no pretence of having withheld from the reader difficulties
+which are inherent to the subject. On the other hand, I have purposely
+treated the empirical physical foundations of the theory in a
+"step-motherly" fashion, so that readers unfamiliar with physics may
+not feel like the wanderer who was unable to see the forest for the
+trees. May the book bring some one a few happy hours of suggestive
+thought!
+
+December, 1916
+A. EINSTEIN
+
+
+
+PART I
+
+THE SPECIAL THEORY OF RELATIVITY
+
+PHYSICAL MEANING OF GEOMETRICAL PROPOSITIONS
+
+
+In your schooldays most of you who read this book made acquaintance
+with the noble building of Euclid's geometry, and you remember --
+perhaps with more respect than love -- the magnificent structure, on
+the lofty staircase of which you were chased about for uncounted hours
+by conscientious teachers. By reason of our past experience, you would
+certainly regard everyone with disdain who should pronounce even the
+most out-of-the-way proposition of this science to be untrue. But
+perhaps this feeling of proud certainty would leave you immediately if
+some one were to ask you: "What, then, do you mean by the assertion
+that these propositions are true?" Let us proceed to give this
+question a little consideration.
+
+Geometry sets out form certain conceptions such as "plane," "point,"
+and "straight line," with which we are able to associate more or less
+definite ideas, and from certain simple propositions (axioms) which,
+in virtue of these ideas, we are inclined to accept as "true." Then,
+on the basis of a logical process, the justification of which we feel
+ourselves compelled to admit, all remaining propositions are shown to
+follow from those axioms, i.e. they are proven. A proposition is then
+correct ("true") when it has been derived in the recognised manner
+from the axioms. The question of "truth" of the individual geometrical
+propositions is thus reduced to one of the "truth" of the axioms. Now
+it has long been known that the last question is not only unanswerable
+by the methods of geometry, but that it is in itself entirely without
+meaning. We cannot ask whether it is true that only one straight line
+goes through two points. We can only say that Euclidean geometry deals
+with things called "straight lines," to each of which is ascribed the
+property of being uniquely determined by two points situated on it.
+The concept "true" does not tally with the assertions of pure
+geometry, because by the word "true" we are eventually in the habit of
+designating always the correspondence with a "real" object; geometry,
+however, is not concerned with the relation of the ideas involved in
+it to objects of experience, but only with the logical connection of
+these ideas among themselves.
+
+It is not difficult to understand why, in spite of this, we feel
+constrained to call the propositions of geometry "true." Geometrical
+ideas correspond to more or less exact objects in nature, and these
+last are undoubtedly the exclusive cause of the genesis of those
+ideas. Geometry ought to refrain from such a course, in order to give
+to its structure the largest possible logical unity. The practice, for
+example, of seeing in a "distance" two marked positions on a
+practically rigid body is something which is lodged deeply in our
+habit of thought. We are accustomed further to regard three points as
+being situated on a straight line, if their apparent positions can be
+made to coincide for observation with one eye, under suitable choice
+of our place of observation.
+
+If, in pursuance of our habit of thought, we now supplement the
+propositions of Euclidean geometry by the single proposition that two
+points on a practically rigid body always correspond to the same
+distance (line-interval), independently of any changes in position to
+which we may subject the body, the propositions of Euclidean geometry
+then resolve themselves into propositions on the possible relative
+position of practically rigid bodies.* Geometry which has been
+supplemented in this way is then to be treated as a branch of physics.
+We can now legitimately ask as to the "truth" of geometrical
+propositions interpreted in this way, since we are justified in asking
+whether these propositions are satisfied for those real things we have
+associated with the geometrical ideas. In less exact terms we can
+express this by saying that by the "truth" of a geometrical
+proposition in this sense we understand its validity for a
+construction with rule and compasses.
+
+Of course the conviction of the "truth" of geometrical propositions in
+this sense is founded exclusively on rather incomplete experience. For
+the present we shall assume the "truth" of the geometrical
+propositions, then at a later stage (in the general theory of
+relativity) we shall see that this "truth" is limited, and we shall
+consider the extent of its limitation.
+
+
+  Notes
+
+*) It follows that a natural object is associated also with a
+straight line. Three points A, B and C on a rigid body thus lie in a
+straight line when the points A and C being given, B is chosen such
+that the sum of the distances AB and BC is as short as possible. This
+incomplete suggestion will suffice for the present purpose.
+
+
+
+THE SYSTEM OF CO-ORDINATES
+
+
+On the basis of the physical interpretation of distance which has been
+indicated, we are also in a position to establish the distance between
+two points on a rigid body by means of measurements. For this purpose
+we require a " distance " (rod S) which is to be used once and for
+all, and which we employ as a standard measure. If, now, A and B are
+two points on a rigid body, we can construct the line joining them
+according to the rules of geometry ; then, starting from A, we can
+mark off the distance S time after time until we reach B. The number
+of these operations required is the numerical measure of the distance
+AB. This is the basis of all measurement of length. *
+
+Every description of the scene of an event or of the position of an
+object in space is based on the specification of the point on a rigid
+body (body of reference) with which that event or object coincides.
+This applies not only to scientific description, but also to everyday
+life. If I analyse the place specification " Times Square, New York,"
+**A I arrive at the following result. The earth is the rigid body
+to which the specification of place refers; " Times Square, New York,"
+is a well-defined point, to which a name has been assigned, and with
+which the event coincides in space.**B
+
+This primitive method of place specification deals only with places on
+the surface of rigid bodies, and is dependent on the existence of
+points on this surface which are distinguishable from each other. But
+we can free ourselves from both of these limitations without altering
+the nature of our specification of position. If, for instance, a cloud
+is hovering over Times Square, then we can determine its position
+relative to the surface of the earth by erecting a pole
+perpendicularly on the Square, so that it reaches the cloud. The
+length of the pole measured with the standard measuring-rod, combined
+with the specification of the position of the foot of the pole,
+supplies us with a complete place specification. On the basis of this
+illustration, we are able to see the manner in which a refinement of
+the conception of position has been developed.
+
+(a) We imagine the rigid body, to which the place specification is
+referred, supplemented in such a manner that the object whose position
+we require is reached by. the completed rigid body.
+
+(b) In locating the position of the object, we make use of a number
+(here the length of the pole measured with the measuring-rod) instead
+of designated points of reference.
+
+(c) We speak of the height of the cloud even when the pole which
+reaches the cloud has not been erected. By means of optical
+observations of the cloud from different positions on the ground, and
+taking into account the properties of the propagation of light, we
+determine the length of the pole we should have required in order to
+reach the cloud.
+
+From this consideration we see that it will be advantageous if, in the
+description of position, it should be possible by means of numerical
+measures to make ourselves independent of the existence of marked
+positions (possessing names) on the rigid body of reference. In the
+physics of measurement this is attained by the application of the
+Cartesian system of co-ordinates.
+
+This consists of three plane surfaces perpendicular to each other and
+rigidly attached to a rigid body. Referred to a system of
+co-ordinates, the scene of any event will be determined (for the main
+part) by the specification of the lengths of the three perpendiculars
+or co-ordinates (x, y, z) which can be dropped from the scene of the
+event to those three plane surfaces. The lengths of these three
+perpendiculars can be determined by a series of manipulations with
+rigid measuring-rods performed according to the rules and methods laid
+down by Euclidean geometry.
+
+In practice, the rigid surfaces which constitute the system of
+co-ordinates are generally not available ; furthermore, the magnitudes
+of the co-ordinates are not actually determined by constructions with
+rigid rods, but by indirect means. If the results of physics and
+astronomy are to maintain their clearness, the physical meaning of
+specifications of position must always be sought in accordance with
+the above considerations. ***
+
+We thus obtain the following result: Every description of events in
+space involves the use of a rigid body to which such events have to be
+referred. The resulting relationship takes for granted that the laws
+of Euclidean geometry hold for "distances;" the "distance" being
+represented physically by means of the convention of two marks on a
+rigid body.
+
+
+  Notes
+
+* Here we have assumed that there is nothing left over i.e. that
+the measurement gives a whole number. This difficulty is got over by
+the use of divided measuring-rods, the introduction of which does not
+demand any fundamentally new method.
+
+**A Einstein used "Potsdamer Platz, Berlin" in the original text.
+In the authorised translation this was supplemented with "Tranfalgar
+Square, London". We have changed this to "Times Square, New York", as
+this is the most well known/identifiable location to English speakers
+in the present day. [Note by the janitor.]
+
+**B It is not necessary here to investigate further the significance
+of the expression "coincidence in space." This conception is
+sufficiently obvious to ensure that differences of opinion are
+scarcely likely to arise as to its applicability in practice.
+
+*** A refinement and modification of these views does not become
+necessary until we come to deal with the general theory of relativity,
+treated in the second part of this book.
+
+
+
+SPACE AND TIME IN CLASSICAL MECHANICS
+
+
+The purpose of mechanics is to describe how bodies change their
+position in space with "time." I should load my conscience with grave
+sins against the sacred spirit of lucidity were I to formulate the
+aims of mechanics in this way, without serious reflection and detailed
+explanations. Let us proceed to disclose these sins.
+
+It is not clear what is to be understood here by "position" and
+"space." I stand at the window of a railway carriage which is
+travelling uniformly, and drop a stone on the embankment, without
+throwing it. Then, disregarding the influence of the air resistance, I
+see the stone descend in a straight line. A pedestrian who observes
+the misdeed from the footpath notices that the stone falls to earth in
+a parabolic curve. I now ask: Do the "positions" traversed by the
+stone lie "in reality" on a straight line or on a parabola? Moreover,
+what is meant here by motion "in space" ? From the considerations of
+the previous section the answer is self-evident. In the first place we
+entirely shun the vague word "space," of which, we must honestly
+acknowledge, we cannot form the slightest conception, and we replace
+it by "motion relative to a practically rigid body of reference." The
+positions relative to the body of reference (railway carriage or
+embankment) have already been defined in detail in the preceding
+section. If instead of " body of reference " we insert " system of
+co-ordinates," which is a useful idea for mathematical description, we
+are in a position to say : The stone traverses a straight line
+relative to a system of co-ordinates rigidly attached to the carriage,
+but relative to a system of co-ordinates rigidly attached to the
+ground (embankment) it describes a parabola. With the aid of this
+example it is clearly seen that there is no such thing as an
+independently existing trajectory (lit. "path-curve"*), but only
+a trajectory relative to a particular body of reference.
+
+In order to have a complete description of the motion, we must specify
+how the body alters its position with time ; i.e. for every point on
+the trajectory it must be stated at what time the body is situated
+there. These data must be supplemented by such a definition of time
+that, in virtue of this definition, these time-values can be regarded
+essentially as magnitudes (results of measurements) capable of
+observation. If we take our stand on the ground of classical
+mechanics, we can satisfy this requirement for our illustration in the
+following manner. We imagine two clocks of identical construction ;
+the man at the railway-carriage window is holding one of them, and the
+man on the footpath the other. Each of the observers determines the
+position on his own reference-body occupied by the stone at each tick
+of the clock he is holding in his hand. In this connection we have not
+taken account of the inaccuracy involved by the finiteness of the
+velocity of propagation of light. With this and with a second
+difficulty prevailing here we shall have to deal in detail later.
+
+
+  Notes
+
+*) That is, a curve along which the body moves.
+
+
+
+THE GALILEIAN SYSTEM OF CO-ORDINATES
+
+
+As is well known, the fundamental law of the mechanics of
+Galilei-Newton, which is known as the law of inertia, can be stated
+thus: A body removed sufficiently far from other bodies continues in a
+state of rest or of uniform motion in a straight line. This law not
+only says something about the motion of the bodies, but it also
+indicates the reference-bodies or systems of coordinates, permissible
+in mechanics, which can be used in mechanical description. The visible
+fixed stars are bodies for which the law of inertia certainly holds to
+a high degree of approximation. Now if we use a system of co-ordinates
+which is rigidly attached to the earth, then, relative to this system,
+every fixed star describes a circle of immense radius in the course of
+an astronomical day, a result which is opposed to the statement of the
+law of inertia. So that if we adhere to this law we must refer these
+motions only to systems of coordinates relative to which the fixed
+stars do not move in a circle. A system of co-ordinates of which the
+state of motion is such that the law of inertia holds relative to it
+is called a " Galileian system of co-ordinates." The laws of the
+mechanics of Galflei-Newton can be regarded as valid only for a
+Galileian system of co-ordinates.
+
+
+
+THE PRINCIPLE OF RELATIVITY
+(IN THE RESTRICTED SENSE)
+
+
+In order to attain the greatest possible clearness, let us return to
+our example of the railway carriage supposed to be travelling
+uniformly. We call its motion a uniform translation ("uniform" because
+it is of constant velocity and direction, " translation " because
+although the carriage changes its position relative to the embankment
+yet it does not rotate in so doing). Let us imagine a raven flying
+through the air in such a manner that its motion, as observed from the
+embankment, is uniform and in a straight line. If we were to observe
+the flying raven from the moving railway carriage. we should find that
+the motion of the raven would be one of different velocity and
+direction, but that it would still be uniform and in a straight line.
+Expressed in an abstract manner we may say : If a mass m is moving
+uniformly in a straight line with respect to a co-ordinate system K,
+then it will also be moving uniformly and in a straight line relative
+to a second co-ordinate system K1 provided that the latter is
+executing a uniform translatory motion with respect to K. In
+accordance with the discussion contained in the preceding section, it
+follows that:
+
+If K is a Galileian co-ordinate system. then every other co-ordinate
+system K' is a Galileian one, when, in relation to K, it is in a
+condition of uniform motion of translation. Relative to K1 the
+mechanical laws of Galilei-Newton hold good exactly as they do with
+respect to K.
+
+We advance a step farther in our generalisation when we express the
+tenet thus: If, relative to K, K1 is a uniformly moving co-ordinate
+system devoid of rotation, then natural phenomena run their course
+with respect to K1 according to exactly the same general laws as with
+respect to K. This statement is called the principle of relativity (in
+the restricted sense).
+
+As long as one was convinced that all natural phenomena were capable
+of representation with the help of classical mechanics, there was no
+need to doubt the validity of this principle of relativity. But in
+view of the more recent development of electrodynamics and optics it
+became more and more evident that classical mechanics affords an
+insufficient foundation for the physical description of all natural
+phenomena. At this juncture the question of the validity of the
+principle of relativity became ripe for discussion, and it did not
+appear impossible that the answer to this question might be in the
+negative.
+
+Nevertheless, there are two general facts which at the outset speak
+very much in favour of the validity of the principle of relativity.
+Even though classical mechanics does not supply us with a sufficiently
+broad basis for the theoretical presentation of all physical
+phenomena, still we must grant it a considerable measure of " truth,"
+since it supplies us with the actual motions of the heavenly bodies
+with a delicacy of detail little short of wonderful. The principle of
+relativity must therefore apply with great accuracy in the domain of
+mechanics. But that a principle of such broad generality should hold
+with such exactness in one domain of phenomena, and yet should be
+invalid for another, is a priori not very probable.
+
+We now proceed to the second argument, to which, moreover, we shall
+return later. If the principle of relativity (in the restricted sense)
+does not hold, then the Galileian co-ordinate systems K, K1, K2, etc.,
+which are moving uniformly relative to each other, will not be
+equivalent for the description of natural phenomena. In this case we
+should be constrained to believe that natural laws are capable of
+being formulated in a particularly simple manner, and of course only
+on condition that, from amongst all possible Galileian co-ordinate
+systems, we should have chosen one (K[0]) of a particular state of
+motion as our body of reference. We should then be justified (because
+of its merits for the description of natural phenomena) in calling
+this system " absolutely at rest," and all other Galileian systems K "
+in motion." If, for instance, our embankment were the system K[0] then
+our railway carriage would be a system K, relative to which less
+simple laws would hold than with respect to K[0]. This diminished
+simplicity would be due to the fact that the carriage K would be in
+motion (i.e."really")with respect to K[0]. In the general laws of
+nature which have been formulated with reference to K, the magnitude
+and direction of the velocity of the carriage would necessarily play a
+part. We should expect, for instance, that the note emitted by an
+organpipe placed with its axis parallel to the direction of travel
+would be different from that emitted if the axis of the pipe were
+placed perpendicular to this direction.
+
+Now in virtue of its motion in an orbit round the sun, our earth is
+comparable with a railway carriage travelling with a velocity of about
+30 kilometres per second. If the principle of relativity were not
+valid we should therefore expect that the direction of motion of the
+earth at any moment would enter into the laws of nature, and also that
+physical systems in their behaviour would be dependent on the
+orientation in space with respect to the earth. For owing to the
+alteration in direction of the velocity of revolution of the earth in
+the course of a year, the earth cannot be at rest relative to the
+hypothetical system K[0] throughout the whole year. However, the most
+careful observations have never revealed such anisotropic properties
+in terrestrial physical space, i.e. a physical non-equivalence of
+different directions. This is very powerful argument in favour of the
+principle of relativity.
+
+
+
+THE THEOREM OF THE
+ADDITION OF VELOCITIES
+EMPLOYED IN CLASSICAL MECHANICS
+
+
+Let us suppose our old friend the railway carriage to be travelling
+along the rails with a constant velocity v, and that a man traverses
+the length of the carriage in the direction of travel with a velocity
+w. How quickly or, in other words, with what velocity W does the man
+advance relative to the embankment during the process ? The only
+possible answer seems to result from the following consideration: If
+the man were to stand still for a second, he would advance relative to
+the embankment through a distance v equal numerically to the velocity
+of the carriage. As a consequence of his walking, however, he
+traverses an additional distance w relative to the carriage, and hence
+also relative to the embankment, in this second, the distance w being
+numerically equal to the velocity with which he is walking. Thus in
+total be covers the distance W=v+w relative to the embankment in the
+second considered. We shall see later that this result, which
+expresses the theorem of the addition of velocities employed in
+classical mechanics, cannot be maintained ; in other words, the law
+that we have just written down does not hold in reality. For the time
+being, however, we shall assume its correctness.
+
+
+
+THE APPARENT INCOMPATIBILITY OF THE
+LAW OF PROPAGATION OF LIGHT WITH THE
+PRINCIPLE OF RELATIVITY
+
+
+There is hardly a simpler law in physics than that according to which
+light is propagated in empty space. Every child at school knows, or
+believes he knows, that this propagation takes place in straight lines
+with a velocity c= 300,000 km./sec. At all events we know with great
+exactness that this velocity is the same for all colours, because if
+this were not the case, the minimum of emission would not be observed
+simultaneously for different colours during the eclipse of a fixed
+star by its dark neighbour. By means of similar considerations based
+on observa- tions of double stars, the Dutch astronomer De Sitter was
+also able to show that the velocity of propagation of light cannot
+depend on the velocity of motion of the body emitting the light. The
+assumption that this velocity of propagation is dependent on the
+direction "in space" is in itself improbable.
+
+In short, let us assume that the simple law of the constancy of the
+velocity of light c (in vacuum) is justifiably believed by the child
+at school. Who would imagine that this simple law has plunged the
+conscientiously thoughtful physicist into the greatest intellectual
+difficulties? Let us consider how these difficulties arise.
+
+Of course we must refer the process of the propagation of light (and
+indeed every other process) to a rigid reference-body (co-ordinate
+system). As such a system let us again choose our embankment. We shall
+imagine the air above it to have been removed. If a ray of light be
+sent along the embankment, we see from the above that the tip of the
+ray will be transmitted with the velocity c relative to the
+embankment. Now let us suppose that our railway carriage is again
+travelling along the railway lines with the velocity v, and that its
+direction is the same as that of the ray of light, but its velocity of
+course much less. Let us inquire about the velocity of propagation of
+the ray of light relative to the carriage. It is obvious that we can
+here apply the consideration of the previous section, since the ray of
+light plays the part of the man walking along relatively to the
+carriage. The velocity w of the man relative to the embankment is here
+replaced by the velocity of light relative to the embankment. w is the
+required velocity of light with respect to the carriage, and we have
+
+                               w = c-v.
+
+The velocity of propagation ot a ray of light relative to the carriage
+thus comes cut smaller than c.
+
+But this result comes into conflict with the principle of relativity
+set forth in Section V. For, like every other general law of
+nature, the law of the transmission of light in vacuo [in vacuum]
+must, according to the principle of relativity, be the same for the
+railway carriage as reference-body as when the rails are the body of
+reference. But, from our above consideration, this would appear to be
+impossible. If every ray of light is propagated relative to the
+embankment with the velocity c, then for this reason it would appear
+that another law of propagation of light must necessarily hold with
+respect to the carriage -- a result contradictory to the principle of
+relativity.
+
+In view of this dilemma there appears to be nothing else for it than
+to abandon either the principle of relativity or the simple law of the
+propagation of light in vacuo. Those of you who have carefully
+followed the preceding discussion are almost sure to expect that we
+should retain the principle of relativity, which appeals so
+convincingly to the intellect because it is so natural and simple. The
+law of the propagation of light in vacuo would then have to be
+replaced by a more complicated law conformable to the principle of
+relativity. The development of theoretical physics shows, however,
+that we cannot pursue this course. The epoch-making theoretical
+investigations of H. A. Lorentz on the electrodynamical and optical
+phenomena connected with moving bodies show that experience in this
+domain leads conclusively to a theory of electromagnetic phenomena, of
+which the law of the constancy of the velocity of light in vacuo is a
+necessary consequence. Prominent theoretical physicists were theref
+ore more inclined to reject the principle of relativity, in spite of
+the fact that no empirical data had been found which were
+contradictory to this principle.
+
+At this juncture the theory of relativity entered the arena. As a
+result of an analysis of the physical conceptions of time and space,
+it became evident that in realily there is not the least
+incompatibilitiy between the principle of relativity and the law of
+propagation of light, and that by systematically holding fast to both
+these laws a logically rigid theory could be arrived at. This theory
+has been called the special theory of relativity to distinguish it
+from the extended theory, with which we shall deal later. In the
+following pages we shall present the fundamental ideas of the special
+theory of relativity.
+
+
+
+ON THE IDEA OF TIME IN PHYSICS
+
+
+Lightning has struck the rails on our railway embankment at two places
+A and B far distant from each other. I make the additional assertion
+that these two lightning flashes occurred simultaneously. If I ask you
+whether there is sense in this statement, you will answer my question
+with a decided "Yes." But if I now approach you with the request to
+explain to me the sense of the statement more precisely, you find
+after some consideration that the answer to this question is not so
+easy as it appears at first sight.
+
+After some time perhaps the following answer would occur to you: "The
+significance of the statement is clear in itself and needs no further
+explanation; of course it would require some consideration if I were
+to be commissioned to determine by observations whether in the actual
+case the two events took place simultaneously or not." I cannot be
+satisfied with this answer for the following reason. Supposing that as
+a result of ingenious considerations an able meteorologist were to
+discover that the lightning must always strike the places A and B
+simultaneously, then we should be faced with the task of testing
+whether or not this theoretical result is in accordance with the
+reality. We encounter the same difficulty with all physical statements
+in which the conception " simultaneous " plays a part. The concept
+does not exist for the physicist until he has the possibility of
+discovering whether or not it is fulfilled in an actual case. We thus
+require a definition of simultaneity such that this definition
+supplies us with the method by means of which, in the present case, he
+can decide by experiment whether or not both the lightning strokes
+occurred simultaneously. As long as this requirement is not satisfied,
+I allow myself to be deceived as a physicist (and of course the same
+applies if I am not a physicist), when I imagine that I am able to
+attach a meaning to the statement of simultaneity. (I would ask the
+reader not to proceed farther until he is fully convinced on this
+point.)
+
+After thinking the matter over for some time you then offer the
+following suggestion with which to test simultaneity. By measuring
+along the rails, the connecting line AB should be measured up and an
+observer placed at the mid-point M of the distance AB. This observer
+should be supplied with an arrangement (e.g. two mirrors inclined at
+90^0) which allows him visually to observe both places A and B at the
+same time. If the observer perceives the two flashes of lightning at
+the same time, then they are simultaneous.
+
+I am very pleased with this suggestion, but for all that I cannot
+regard the matter as quite settled, because I feel constrained to
+raise the following objection:
+
+"Your definition would certainly be right, if only I knew that the
+light by means of which the observer at M perceives the lightning
+flashes travels along the length A arrow M with the same velocity as
+along the length B arrow M. But an examination of this supposition
+would only be possible if we already had at our disposal the means of
+measuring time. It would thus appear as though we were moving here in
+a logical circle."
+
+After further consideration you cast a somewhat disdainful glance at
+me -- and rightly so -- and you declare:
+
+"I maintain my previous definition nevertheless, because in reality it
+assumes absolutely nothing about light. There is only one demand to be
+made of the definition of simultaneity, namely, that in every real
+case it must supply us with an empirical decision as to whether or not
+the conception that has to be defined is fulfilled. That my definition
+satisfies this demand is indisputable. That light requires the same
+time to traverse the path A arrow M as for the path B arrow M is in
+reality neither a supposition nor a hypothesis about the physical
+nature of light, but a stipulation which I can make of my own freewill
+in order to arrive at a definition of simultaneity."
+
+It is clear that this definition can be used to give an exact meaning
+not only to two events, but to as many events as we care to choose,
+and independently of the positions of the scenes of the events with
+respect to the body of reference * (here the railway embankment).
+We are thus led also to a definition of " time " in physics. For this
+purpose we suppose that clocks of identical construction are placed at
+the points A, B and C of the railway line (co-ordinate system) and
+that they are set in such a manner that the positions of their
+pointers are simultaneously (in the above sense) the same. Under these
+conditions we understand by the " time " of an event the reading
+(position of the hands) of that one of these clocks which is in the
+immediate vicinity (in space) of the event. In this manner a
+time-value is associated with every event which is essentially capable
+of observation.
+
+This stipulation contains a further physical hypothesis, the validity
+of which will hardly be doubted without empirical evidence to the
+contrary. It has been assumed that all these clocks go at the same
+rate if they are of identical construction. Stated more exactly: When
+two clocks arranged at rest in different places of a reference-body
+are set in such a manner that a particular position of the pointers of
+the one clock is simultaneous (in the above sense) with the same
+position, of the pointers of the other clock, then identical "
+settings " are always simultaneous (in the sense of the above
+definition).
+
+
+  Notes
+
+*) We suppose further, that, when three events A, B and C occur in
+different places in such a manner that A is simultaneous with B and B
+is simultaneous with C (simultaneous in the sense of the above
+definition), then the criterion for the simultaneity of the pair of
+events A, C is also satisfied. This assumption is a physical
+hypothesis about the the of propagation of light: it must certainly be
+fulfilled if we are to maintain the law of the constancy of the
+velocity of light in vacuo.
+
+
+
+THE RELATIVITY OF SIMULATNEITY
+
+
+Up to now our considerations have been referred to a particular body
+of reference, which we have styled a " railway embankment." We suppose
+a very long train travelling along the rails with the constant
+velocity v and in the direction indicated in Fig 1. People travelling
+in this train will with a vantage view the train as a rigid
+reference-body (co-ordinate system); they regard all events in
+
+                       Fig. 01: file fig01.gif
+
+
+reference to the train. Then every event which takes place along the
+line also takes place at a particular point of the train. Also the
+definition of simultaneity can be given relative to the train in
+exactly the same way as with respect to the embankment. As a natural
+consequence, however, the following question arises :
+
+Are two events (e.g. the two strokes of lightning A and B) which are
+simultaneous with reference to the railway embankment also
+simultaneous relatively to the train? We shall show directly that the
+answer must be in the negative.
+
+When we say that the lightning strokes A and B are simultaneous with
+respect to be embankment, we mean: the rays of light emitted at the
+places A and B, where the lightning occurs, meet each other at the
+mid-point M of the length A arrow B of the embankment. But the events
+A and B also correspond to positions A and B on the train. Let M1 be
+the mid-point of the distance A arrow B on the travelling train. Just
+when the flashes (as judged from the embankment) of lightning occur,
+this point M1 naturally coincides with the point M but it moves
+towards the right in the diagram with the velocity v of the train. If
+an observer sitting in the position M1 in the train did not possess
+this velocity, then he would remain permanently at M, and the light
+rays emitted by the flashes of lightning A and B would reach him
+simultaneously, i.e. they would meet just where he is situated. Now in
+reality (considered with reference to the railway embankment) he is
+hastening towards the beam of light coming from B, whilst he is riding
+on ahead of the beam of light coming from A. Hence the observer will
+see the beam of light emitted from B earlier than he will see that
+emitted from A. Observers who take the railway train as their
+reference-body must therefore come to the conclusion that the
+lightning flash B took place earlier than the lightning flash A. We
+thus arrive at the important result:
+
+Events which are simultaneous with reference to the embankment are not
+simultaneous with respect to the train, and vice versa (relativity of
+simultaneity). Every reference-body (co-ordinate system) has its own
+particular time ; unless we are told the reference-body to which the
+statement of time refers, there is no meaning in a statement of the
+time of an event.
+
+Now before the advent of the theory of relativity it had always
+tacitly been assumed in physics that the statement of time had an
+absolute significance, i.e. that it is independent of the state of
+motion of the body of reference. But we have just seen that this
+assumption is incompatible with the most natural definition of
+simultaneity; if we discard this assumption, then the conflict between
+the law of the propagation of light in vacuo and the principle of
+relativity (developed in Section 7) disappears.
+
+We were led to that conflict by the considerations of Section 6,
+which are now no longer tenable. In that section we concluded that the
+man in the carriage, who traverses the distance w per second relative
+to the carriage, traverses the same distance also with respect to the
+embankment in each second of time. But, according to the foregoing
+considerations, the time required by a particular occurrence with
+respect to the carriage must not be considered equal to the duration
+of the same occurrence as judged from the embankment (as
+reference-body). Hence it cannot be contended that the man in walking
+travels the distance w relative to the railway line in a time which is
+equal to one second as judged from the embankment.
+
+Moreover, the considerations of Section 6 are based on yet a second
+assumption, which, in the light of a strict consideration, appears to
+be arbitrary, although it was always tacitly made even before the
+introduction of the theory of relativity.
+
+
+
+ON THE RELATIVITY OF THE CONCEPTION OF DISTANCE
+
+
+Let us consider two particular points on the train * travelling
+along the embankment with the velocity v, and inquire as to their
+distance apart. We already know that it is necessary to have a body of
+reference for the measurement of a distance, with respect to which
+body the distance can be measured up. It is the simplest plan to use
+the train itself as reference-body (co-ordinate system). An observer
+in the train measures the interval by marking off his measuring-rod in
+a straight line (e.g. along the floor of the carriage) as many times
+as is necessary to take him from the one marked point to the other.
+Then the number which tells us how often the rod has to be laid down
+is the required distance.
+
+It is a different matter when the distance has to be judged from the
+railway line. Here the following method suggests itself. If we call
+A^1 and B^1 the two points on the train whose distance apart is
+required, then both of these points are moving with the velocity v
+along the embankment. In the first place we require to determine the
+points A and B of the embankment which are just being passed by the
+two points A^1 and B^1 at a particular time t -- judged from the
+embankment. These points A and B of the embankment can be determined
+by applying the definition of time given in Section 8. The distance
+between these points A and B is then measured by repeated application
+of thee measuring-rod along the embankment.
+
+A priori it is by no means certain that this last measurement will
+supply us with the same result as the first. Thus the length of the
+train as measured from the embankment may be different from that
+obtained by measuring in the train itself. This circumstance leads us
+to a second objection which must be raised against the apparently
+obvious consideration of Section 6. Namely, if the man in the
+carriage covers the distance w in a unit of time -- measured from the
+train, -- then this distance -- as measured from the embankment -- is
+not necessarily also equal to w.
+
+
+  Notes
+
+*) e.g. the middle of the first and of the hundredth carriage.
+
+
+
+THE LORENTZ TRANSFORMATION
+
+
+The results of the last three sections show that the apparent
+incompatibility of the law of propagation of light with the principle
+of relativity (Section 7) has been derived by means of a
+consideration which borrowed two unjustifiable hypotheses from
+classical mechanics; these are as follows:
+
+(1) The time-interval (time) between two events is independent of the
+condition of motion of the body of reference.
+
+(2) The space-interval (distance) between two points of a rigid body
+is independent of the condition of motion of the body of reference.
+
+If we drop these hypotheses, then the dilemma of Section 7
+disappears, because the theorem of the addition of velocities derived
+in Section 6 becomes invalid. The possibility presents itself that
+the law of the propagation of light in vacuo may be compatible with
+the principle of relativity, and the question arises: How have we to
+modify the considerations of Section 6 in order to remove the
+apparent disagreement between these two fundamental results of
+experience? This question leads to a general one. In the discussion of
+Section 6 we have to do with places and times relative both to the
+train and to the embankment. How are we to find the place and time of
+an event in relation to the train, when we know the place and time of
+the event with respect to the railway embankment ? Is there a
+thinkable answer to this question of such a nature that the law of
+transmission of light in vacuo does not contradict the principle of
+relativity ? In other words : Can we conceive of a relation between
+place and time of the individual events relative to both
+reference-bodies, such that every ray of light possesses the velocity
+of transmission c relative to the embankment and relative to the train
+? This question leads to a quite definite positive answer, and to a
+perfectly definite transformation law for the space-time magnitudes of
+an event when changing over from one body of reference to another.
+
+Before we deal with this, we shall introduce the following incidental
+consideration. Up to the present we have only considered events taking
+place along the embankment, which had mathematically to assume the
+function of a straight line. In the manner indicated in Section 2
+we can imagine this reference-body supplemented laterally and in a
+vertical direction by means of a framework of rods, so that an event
+which takes place anywhere can be localised with reference to this
+framework. Fig. 2 Similarly, we can imagine the train travelling with
+the velocity v to be continued across the whole of space, so that
+every event, no matter how far off it may be, could also be localised
+with respect to the second framework. Without committing any
+fundamental error, we can disregard the fact that in reality these
+frameworks would continually interfere with each other, owing to the
+impenetrability of solid bodies. In every such framework we imagine
+three surfaces perpendicular to each other marked out, and designated
+as " co-ordinate planes " (" co-ordinate system "). A co-ordinate
+system K then corresponds to the embankment, and a co-ordinate system
+K' to the train. An event, wherever it may have taken place, would be
+fixed in space with respect to K by the three perpendiculars x, y, z
+on the co-ordinate planes, and with regard to time by a time value t.
+Relative to K1, the same event would be fixed in respect of space and
+time by corresponding values x1, y1, z1, t1, which of course are not
+identical with x, y, z, t. It has already been set forth in detail how
+these magnitudes are to be regarded as results of physical
+measurements.
+
+Obviously our problem can be exactly formulated in the following
+manner. What are the values x1, y1, z1, t1, of an event with respect
+to K1, when the magnitudes x, y, z, t, of the same event with respect
+to K are given ? The relations must be so chosen that the law of the
+transmission of light in vacuo is satisfied for one and the same ray
+of light (and of course for every ray) with respect to K and K1. For
+the relative orientation in space of the co-ordinate systems indicated
+in the diagram ([7]Fig. 2), this problem is solved by means of the
+equations :
+
+                         eq. 1: file eq01.gif
+
+                                y1 = y
+                                z1 = z
+
+                         eq. 2: file eq02.gif
+
+This system of equations is known as the " Lorentz transformation." *
+
+If in place of the law of transmission of light we had taken as our
+basis the tacit assumptions of the older mechanics as to the absolute
+character of times and lengths, then instead of the above we should
+have obtained the following equations:
+
+                             x1 = x - vt
+                                y1 = y
+                                z1 = z
+                                t1 = t
+
+This system of equations is often termed the " Galilei
+transformation." The Galilei transformation can be obtained from the
+Lorentz transformation by substituting an infinitely large value for
+the velocity of light c in the latter transformation.
+
+Aided by the following illustration, we can readily see that, in
+accordance with the Lorentz transformation, the law of the
+transmission of light in vacuo is satisfied both for the
+reference-body K and for the reference-body K1. A light-signal is sent
+along the positive x-axis, and this light-stimulus advances in
+accordance with the equation
+
+                               x = ct,
+
+i.e. with the velocity c. According to the equations of the Lorentz
+transformation, this simple relation between x and t involves a
+relation between x1 and t1. In point of fact, if we substitute for x
+the value ct in the first and fourth equations of the Lorentz
+transformation, we obtain:
+
+                         eq. 3: file eq03.gif
+
+
+                         eq. 4: file eq04.gif
+
+from which, by division, the expression
+
+                               x1 = ct1
+
+immediately follows. If referred to the system K1, the propagation of
+light takes place according to this equation. We thus see that the
+velocity of transmission relative to the reference-body K1 is also
+equal to c. The same result is obtained for rays of light advancing in
+any other direction whatsoever. Of cause this is not surprising, since
+the equations of the Lorentz transformation were derived conformably
+to this point of view.
+
+
+  Notes
+
+*) A simple derivation of the Lorentz transformation is given in
+Appendix I.
+
+
+
+THE BEHAVIOUR OF MEASURING-RODS AND CLOCKS IN MOTION
+
+
+Place a metre-rod in the x1-axis of K1 in such a manner that one end
+(the beginning) coincides with the point x1=0 whilst the other end
+(the end of the rod) coincides with the point x1=I. What is the length
+of the metre-rod relatively to the system K? In order to learn this,
+we need only ask where the beginning of the rod and the end of the rod
+lie with respect to K at a particular time t of the system K. By means
+of the first equation of the Lorentz transformation the values of
+these two points at the time t = 0 can be shown to be
+
+                       eq. 05a: file eq05a.gif
+
+
+                       eq. 05b: file eq05b.gif
+
+
+the distance between the points being eq. 06 .
+
+But the metre-rod is moving with the velocity v relative to K. It
+therefore follows that the length of a rigid metre-rod moving in the
+direction of its length with a velocity v is eq. 06 of a metre.
+
+The rigid rod is thus shorter when in motion than when at rest, and
+the more quickly it is moving, the shorter is the rod. For the
+velocity v=c we should have eq. 06a ,
+
+and for stiII greater velocities the square-root becomes imaginary.
+From this we conclude that in the theory of relativity the velocity c
+plays the part of a limiting velocity, which can neither be reached
+nor exceeded by any real body.
+
+Of course this feature of the velocity c as a limiting velocity also
+clearly follows from the equations of the Lorentz transformation, for
+these became meaningless if we choose values of v greater than c.
+
+If, on the contrary, we had considered a metre-rod at rest in the
+x-axis with respect to K, then we should have found that the length of
+the rod as judged from K1 would have been eq. 06 ;
+
+this is quite in accordance with the principle of relativity which
+forms the basis of our considerations.
+
+A Priori it is quite clear that we must be able to learn something
+about the physical behaviour of measuring-rods and clocks from the
+equations of transformation, for the magnitudes z, y, x, t, are
+nothing more nor less than the results of measurements obtainable by
+means of measuring-rods and clocks. If we had based our considerations
+on the Galileian transformation we should not have obtained a
+contraction of the rod as a consequence of its motion.
+
+Let us now consider a seconds-clock which is permanently situated at
+the origin (x1=0) of K1. t1=0 and t1=I are two successive ticks of
+this clock. The first and fourth equations of the Lorentz
+transformation give for these two ticks :
+
+                                t = 0
+
+and
+
+                        eq. 07: file eq07.gif
+
+As judged from K, the clock is moving with the velocity v; as judged
+from this reference-body, the time which elapses between two strokes
+of the clock is not one second, but
+
+                        eq. 08: file eq08.gif
+
+seconds, i.e. a somewhat larger time. As a consequence of its motion
+the clock goes more slowly than when at rest. Here also the velocity c
+plays the part of an unattainable limiting velocity.
+
+
+
+THEOREM OF THE ADDITION OF VELOCITIES.
+THE EXPERIMENT OF FIZEAU
+
+
+Now in practice we can move clocks and measuring-rods only with
+velocities that are small compared with the velocity of light; hence
+we shall hardly be able to compare the results of the previous section
+directly with the reality. But, on the other hand, these results must
+strike you as being very singular, and for that reason I shall now
+draw another conclusion from the theory, one which can easily be
+derived from the foregoing considerations, and which has been most
+elegantly confirmed by experiment.
+
+In Section 6 we derived the theorem of the addition of velocities
+in one direction in the form which also results from the hypotheses of
+classical mechanics- This theorem can also be deduced readily horn the
+Galilei transformation (Section 11). In place of the man walking
+inside the carriage, we introduce a point moving relatively to the
+co-ordinate system K1 in accordance with the equation
+
+                               x1 = wt1
+
+By means of the first and fourth equations of the Galilei
+transformation we can express x1 and t1 in terms of x and t, and we
+then obtain
+
+                             x = (v + w)t
+
+This equation expresses nothing else than the law of motion of the
+point with reference to the system K (of the man with reference to the
+embankment). We denote this velocity by the symbol W, and we then
+obtain, as in Section 6,
+
+                           W=v+w         A)
+
+But we can carry out this consideration just as well on the basis of
+the theory of relativity. In the equation
+
+                         x1 = wt1         B)
+
+we must then express x1and t1 in terms of x and t, making use of the
+first and fourth equations of the Lorentz transformation. Instead of
+the equation (A) we then obtain the equation
+
+                        eq. 09: file eq09.gif
+
+
+which corresponds to the theorem of addition for velocities in one
+direction according to the theory of relativity. The question now
+arises as to which of these two theorems is the better in accord with
+experience. On this point we axe enlightened by a most important
+experiment which the brilliant physicist Fizeau performed more than
+half a century ago, and which has been repeated since then by some of
+the best experimental physicists, so that there can be no doubt about
+its result. The experiment is concerned with the following question.
+Light travels in a motionless liquid with a particular velocity w. How
+quickly does it travel in the direction of the arrow in the tube T
+(see the accompanying diagram, Fig. 3) when the liquid above
+mentioned is flowing through the tube with a velocity v ?
+
+In accordance with the principle of relativity we shall certainly have
+to take for granted that the propagation of light always takes place
+with the same velocity w with respect to the liquid, whether the
+latter is in motion with reference to other bodies or not. The
+velocity of light relative to the liquid and the velocity of the
+latter relative to the tube are thus known, and we require the
+velocity of light relative to the tube.
+
+It is clear that we have the problem of Section 6 again before us. The
+tube plays the part of the railway embankment or of the co-ordinate
+system K, the liquid plays the part of the carriage or of the
+co-ordinate system K1, and finally, the light plays the part of the
+
+                      Figure 03: file fig03.gif
+
+
+man walking along the carriage, or of the moving point in the present
+section. If we denote the velocity of the light relative to the tube
+by W, then this is given by the equation (A) or (B), according as the
+Galilei transformation or the Lorentz transformation corresponds to
+the facts. Experiment * decides in favour of equation (B) derived
+from the theory of relativity, and the agreement is, indeed, very
+exact. According to recent and most excellent measurements by Zeeman,
+the influence of the velocity of flow v on the propagation of light is
+represented by formula (B) to within one per cent.
+
+Nevertheless we must now draw attention to the fact that a theory of
+this phenomenon was given by H. A. Lorentz long before the statement
+of the theory of relativity. This theory was of a purely
+electrodynamical nature, and was obtained by the use of particular
+hypotheses as to the electromagnetic structure of matter. This
+circumstance, however, does not in the least diminish the
+conclusiveness of the experiment as a crucial test in favour of the
+theory of relativity, for the electrodynamics of Maxwell-Lorentz, on
+which the original theory was based, in no way opposes the theory of
+relativity. Rather has the latter been developed trom electrodynamics
+as an astoundingly simple combination and generalisation of the
+hypotheses, formerly independent of each other, on which
+electrodynamics was built.
+
+
+  Notes
+
+*) Fizeau found eq. 10 , where eq. 11
+
+is the index of refraction of the liquid. On the other hand, owing to
+the smallness of eq. 12 as compared with I,
+
+we can replace (B) in the first place by eq. 13 , or to the same order
+of approximation by
+
+eq. 14 , which agrees with Fizeau's result.
+
+
+
+THE HEURISTIC VALUE OF THE THEORY OF RELATIVITY
+
+
+Our train of thought in the foregoing pages can be epitomised in the
+following manner. Experience has led to the conviction that, on the
+one hand, the principle of relativity holds true and that on the other
+hand the velocity of transmission of light in vacuo has to be
+considered equal to a constant c. By uniting these two postulates we
+obtained the law of transformation for the rectangular co-ordinates x,
+y, z and the time t of the events which constitute the processes of
+nature. In this connection we did not obtain the Galilei
+transformation, but, differing from classical mechanics, the Lorentz
+transformation.
+
+The law of transmission of light, the acceptance of which is justified
+by our actual knowledge, played an important part in this process of
+thought. Once in possession of the Lorentz transformation, however, we
+can combine this with the principle of relativity, and sum up the
+theory thus:
+
+Every general law of nature must be so constituted that it is
+transformed into a law of exactly the same form when, instead of the
+space-time variables x, y, z, t of the original coordinate system K,
+we introduce new space-time variables x1, y1, z1, t1 of a co-ordinate
+system K1. In this connection the relation between the ordinary and
+the accented magnitudes is given by the Lorentz transformation. Or in
+brief : General laws of nature are co-variant with respect to Lorentz
+transformations.
+
+This is a definite mathematical condition that the theory of
+relativity demands of a natural law, and in virtue of this, the theory
+becomes a valuable heuristic aid in the search for general laws of
+nature. If a general law of nature were to be found which did not
+satisfy this condition, then at least one of the two fundamental
+assumptions of the theory would have been disproved. Let us now
+examine what general results the latter theory has hitherto evinced.
+
+
+
+GENERAL RESULTS OF THE THEORY
+
+
+It is clear from our previous considerations that the (special) theory
+of relativity has grown out of electrodynamics and optics. In these
+fields it has not appreciably altered the predictions of theory, but
+it has considerably simplified the theoretical structure, i.e. the
+derivation of laws, and -- what is incomparably more important -- it
+has considerably reduced the number of independent hypothese forming
+the basis of theory. The special theory of relativity has rendered the
+Maxwell-Lorentz theory so plausible, that the latter would have been
+generally accepted by physicists even if experiment had decided less
+unequivocally in its favour.
+
+Classical mechanics required to be modified before it could come into
+line with the demands of the special theory of relativity. For the
+main part, however, this modification affects only the laws for rapid
+motions, in which the velocities of matter v are not very small as
+compared with the velocity of light. We have experience of such rapid
+motions only in the case of electrons and ions; for other motions the
+variations from the laws of classical mechanics are too small to make
+themselves evident in practice. We shall not consider the motion of
+stars until we come to speak of the general theory of relativity. In
+accordance with the theory of relativity the kinetic energy of a
+material point of mass m is no longer given by the well-known
+expression
+
+                        eq. 15: file eq15.gif
+
+but by the expression
+
+                        eq. 16: file eq16.gif
+
+
+This expression approaches infinity as the velocity v approaches the
+velocity of light c. The velocity must therefore always remain less
+than c, however great may be the energies used to produce the
+acceleration. If we develop the expression for the kinetic energy in
+the form of a series, we obtain
+
+                        eq. 17: file eq17.gif
+
+
+When eq. 18 is small compared with unity, the third of these terms is
+always small in comparison with the second,
+
+which last is alone considered in classical mechanics. The first term
+mc^2 does not contain the velocity, and requires no consideration if
+we are only dealing with the question as to how the energy of a
+point-mass; depends on the velocity. We shall speak of its essential
+significance later.
+
+The most important result of a general character to which the special
+theory of relativity has led is concerned with the conception of mass.
+Before the advent of relativity, physics recognised two conservation
+laws of fundamental importance, namely, the law of the canservation of
+energy and the law of the conservation of mass these two fundamental
+laws appeared to be quite independent of each other. By means of the
+theory of relativity they have been united into one law. We shall now
+briefly consider how this unification came about, and what meaning is
+to be attached to it.
+
+The principle of relativity requires that the law of the concervation
+of energy should hold not only with reference to a co-ordinate system
+K, but also with respect to every co-ordinate system K1 which is in a
+state of uniform motion of translation relative to K, or, briefly,
+relative to every " Galileian " system of co-ordinates. In contrast to
+classical mechanics; the Lorentz transformation is the deciding factor
+in the transition from one such system to another.
+
+By means of comparatively simple considerations we are led to draw the
+following conclusion from these premises, in conjunction with the
+fundamental equations of the electrodynamics of Maxwell: A body moving
+with the velocity v, which absorbs * an amount of energy E[0] in
+the form of radiation without suffering an alteration in velocity in
+the process, has, as a consequence, its energy increased by an amount
+
+                        eq. 19: file eq19.gif
+
+In consideration of the expression given above for the kinetic energy
+of the body, the required energy of the body comes out to be
+
+                        eq. 20: file eq20.gif
+
+
+Thus the body has the same energy as a body of mass
+
+                         eq.21: file eq21.gif
+
+moving with the velocity v. Hence we can say: If a body takes up an
+amount of energy E[0], then its inertial mass increases by an amount
+
+                        eq. 22: file eq22.gif
+
+
+the inertial mass of a body is not a constant but varies according to
+the change in the energy of the body. The inertial mass of a system of
+bodies can even be regarded as a measure of its energy. The law of the
+conservation of the mass of a system becomes identical with the law of
+the conservation of energy, and is only valid provided that the system
+neither takes up nor sends out energy. Writing the expression for the
+energy in the form
+
+                        eq. 23: file eq23.gif
+
+we see that the term mc^2, which has hitherto attracted our attention,
+is nothing else than the energy possessed by the body ** before it
+absorbed the energy E[0].
+
+A direct comparison of this relation with experiment is not possible
+at the present time (1920; see *** Note, p. 48), owing to the fact that
+the changes in energy E[0] to which we can Subject a system are not
+large enough to make themselves perceptible as a change in the
+inertial mass of the system.
+
+                                eq. 22: file eq22.gif
+
+
+is too small in comparison with the mass m, which was present before
+the alteration of the energy. It is owing to this circumstance that
+classical mechanics was able to establish successfully the
+conservation of mass as a law of independent validity.
+
+Let me add a final remark of a fundamental nature. The success of the
+Faraday-Maxwell interpretation of electromagnetic action at a distance
+resulted in physicists becoming convinced that there are no such
+things as instantaneous actions at a distance (not involving an
+intermediary medium) of the type of Newton's law of gravitation.
+According to the theory of relativity, action at a distance with the
+velocity of light always takes the place of instantaneous action at a
+distance or of action at a distance with an infinite velocity of
+transmission. This is connected with the fact that the velocity c
+plays a fundamental role in this theory. In Part II we shall see in
+what way this result becomes modified in the general theory of
+relativity.
+
+
+  Notes
+
+*) E[0] is the energy taken up, as judged from a co-ordinate system
+moving with the body.
+
+**) As judged from a co-ordinate system moving with the body.
+
+***[Note] The equation E = mc^2 has been thoroughly proved time and
+again since this time.
+
+
+
+EXPERIENCE AND THE SPECIAL THEORY OF RELATIVITY
+
+
+To what extent is the special theory of relativity supported by
+experience?  This question is not easily answered for the reason
+already mentioned in connection with the fundamental experiment of
+Fizeau. The special theory of relativity has crystallised out from the
+Maxwell-Lorentz theory of electromagnetic phenomena. Thus all facts of
+experience which support the electromagnetic theory also support the
+theory of relativity. As being of particular importance, I mention
+here the fact that the theory of relativity enables us to predict the
+effects produced on the light reaching us from the fixed stars. These
+results are obtained in an exceedingly simple manner, and the effects
+indicated, which are due to the relative motion of the earth with
+reference to those fixed stars are found to be in accord with
+experience. We refer to the yearly movement of the apparent position
+of the fixed stars resulting from the motion of the earth round the
+sun (aberration), and to the influence of the radial components of the
+relative motions of the fixed stars with respect to the earth on the
+colour of the light reaching us from them. The latter effect manifests
+itself in a slight displacement of the spectral lines of the light
+transmitted to us from a fixed star, as compared with the position of
+the same spectral lines when they are produced by a terrestrial source
+of light (Doppler principle). The experimental arguments in favour of
+the Maxwell-Lorentz theory, which are at the same time arguments in
+favour of the theory of relativity, are too numerous to be set forth
+here. In reality they limit the theoretical possibilities to such an
+extent, that no other theory than that of Maxwell and Lorentz has been
+able to hold its own when tested by experience.
+
+But there are two classes of experimental facts hitherto obtained
+which can be represented in the Maxwell-Lorentz theory only by the
+introduction of an auxiliary hypothesis, which in itself -- i.e.
+without making use of the theory of relativity -- appears extraneous.
+
+It is known that cathode rays and the so-called b-rays emitted by
+radioactive substances consist of negatively electrified particles
+(electrons) of very small inertia and large velocity. By examining the
+deflection of these rays under the influence of electric and magnetic
+fields, we can study the law of motion of these particles very
+exactly.
+
+In the theoretical treatment of these electrons, we are faced with the
+difficulty that electrodynamic theory of itself is unable to give an
+account of their nature. For since electrical masses of one sign repel
+each other, the negative electrical masses constituting the electron
+would necessarily be scattered under the influence of their mutual
+repulsions, unless there are forces of another kind operating between
+them, the nature of which has hitherto remained obscure to us.*   If
+we now assume that the relative distances between the electrical
+masses constituting the electron remain unchanged during the motion of
+the electron (rigid connection in the sense of classical mechanics),
+we arrive at a law of motion of the electron which does not agree with
+experience. Guided by purely formal points of view, H. A. Lorentz was
+the first to introduce the hypothesis that the form of the electron
+experiences a contraction in the direction of motion in consequence of
+that motion. the contracted length being proportional to the
+expression
+
+                        eq. 05: file eq05.gif
+
+This, hypothesis, which is not justifiable by any electrodynamical
+facts, supplies us then with that particular law of motion which has
+been confirmed with great precision in recent years.
+
+The theory of relativity leads to the same law of motion, without
+requiring any special hypothesis whatsoever as to the structure and
+the behaviour of the electron. We arrived at a similar conclusion in
+Section 13 in connection with the experiment of Fizeau, the result
+of which is foretold by the theory of relativity without the necessity
+of drawing on hypotheses as to the physical nature of the liquid.
+
+The second class of facts to which we have alluded has reference to
+the question whether or not the motion of the earth in space can be
+made perceptible in terrestrial experiments. We have already remarked
+in Section 5 that all attempts of this nature led to a negative
+result. Before the theory of relativity was put forward, it was
+difficult to become reconciled to this negative result, for reasons
+now to be discussed. The inherited prejudices about time and space did
+not allow any doubt to arise as to the prime importance of the
+Galileian transformation for changing over from one body of reference
+to another. Now assuming that the Maxwell-Lorentz equations hold for a
+reference-body K, we then find that they do not hold for a
+reference-body K1 moving uniformly with respect to K, if we assume
+that the relations of the Galileian transformstion exist between the
+co-ordinates of K and K1. It thus appears that, of all Galileian
+co-ordinate systems, one (K) corresponding to a particular state of
+motion is physically unique. This result was interpreted physically by
+regarding K as at rest with respect to a hypothetical ćther of space.
+On the other hand, all coordinate systems K1 moving relatively to K
+were to be regarded as in motion with respect to the ćther. To this
+motion of K1 against the ćther ("ćther-drift " relative to K1) were
+attributed the more complicated laws which were supposed to hold
+relative to K1. Strictly speaking, such an ćther-drift ought also to
+be assumed relative to the earth, and for a long time the efforts of
+physicists were devoted to attempts to detect the existence of an
+ćther-drift at the earth's surface.
+
+In one of the most notable of these attempts Michelson devised a
+method which appears as though it must be decisive. Imagine two
+mirrors so arranged on a rigid body that the reflecting surfaces face
+each other. A ray of light requires a perfectly definite time T to
+pass from one mirror to the other and back again, if the whole system
+be at rest with respect to the ćther. It is found by calculation,
+however, that a slightly different time T1 is required for this
+process, if the body, together with the mirrors, be moving relatively
+to the ćther. And yet another point: it is shown by calculation that
+for a given velocity v with reference to the ćther, this time T1 is
+different when the body is moving perpendicularly to the planes of the
+mirrors from that resulting when the motion is parallel to these
+planes. Although the estimated difference between these two times is
+exceedingly small, Michelson and Morley performed an experiment
+involving interference in which this difference should have been
+clearly detectable. But the experiment gave a negative result -- a
+fact very perplexing to physicists. Lorentz and FitzGerald rescued the
+theory from this difficulty by assuming that the motion of the body
+relative to the ćther produces a contraction of the body in the
+direction of motion, the amount of contraction being just sufficient
+to compensate for the differeace in time mentioned above. Comparison
+with the discussion in Section 11 shows that also from the
+standpoint of the theory of relativity this solution of the difficulty
+was the right one. But on the basis of the theory of relativity the
+method of interpretation is incomparably more satisfactory. According
+to this theory there is no such thing as a " specially favoured "
+(unique) co-ordinate system to occasion the introduction of the
+ćther-idea, and hence there can be no ćther-drift, nor any experiment
+with which to demonstrate it. Here the contraction of moving bodies
+follows from the two fundamental principles of the theory, without the
+introduction of particular hypotheses ; and as the prime factor
+involved in this contraction we find, not the motion in itself, to
+which we cannot attach any meaning, but the motion with respect to the
+body of reference chosen in the particular case in point. Thus for a
+co-ordinate system moving with the earth the mirror system of
+Michelson and Morley is not shortened, but it is shortened for a
+co-ordinate system which is at rest relatively to the sun.
+
+
+  Notes
+
+*) The general theory of relativity renders it likely that the
+electrical masses of an electron are held together by gravitational
+forces.
+
+
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE
+
+
+The non-mathematician is seized by a mysterious shuddering when he
+hears of "four-dimensional" things, by a feeling not unlike that
+awakened by thoughts of the occult. And yet there is no more
+common-place statement than that the world in which we live is a
+four-dimensional space-time continuum.
+
+Space is a three-dimensional continuum. By this we mean that it is
+possible to describe the position of a point (at rest) by means of
+three numbers (co-ordinales) x, y, z, and that there is an indefinite
+number of points in the neighbourhood of this one, the position of
+which can be described by co-ordinates such as x[1], y[1], z[1], which
+may be as near as we choose to the respective values of the
+co-ordinates x, y, z, of the first point. In virtue of the latter
+property we speak of a " continuum," and owing to the fact that there
+are three co-ordinates we speak of it as being " three-dimensional."
+
+Similarly, the world of physical phenomena which was briefly called "
+world " by Minkowski is naturally four dimensional in the space-time
+sense. For it is composed of individual events, each of which is
+described by four numbers, namely, three space co-ordinates x, y, z,
+and a time co-ordinate, the time value t. The" world" is in this sense
+also a continuum; for to every event there are as many "neighbouring"
+events (realised or at least thinkable) as we care to choose, the
+co-ordinates x[1], y[1], z[1], t[1] of which differ by an indefinitely
+small amount from those of the event x, y, z, t originally considered.
+That we have not been accustomed to regard the world in this sense as
+a four-dimensional continuum is due to the fact that in physics,
+before the advent of the theory of relativity, time played a different
+and more independent role, as compared with the space coordinates. It
+is for this reason that we have been in the habit of treating time as
+an independent continuum. As a matter of fact, according to classical
+mechanics, time is absolute, i.e. it is independent of the position
+and the condition of motion of the system of co-ordinates. We see this
+expressed in the last equation of the Galileian transformation (t1 =
+t)
+
+The four-dimensional mode of consideration of the "world" is natural
+on the theory of relativity, since according to this theory time is
+robbed of its independence. This is shown by the fourth equation of
+the Lorentz transformation:
+
+                        eq. 24: file eq24.gif
+
+
+Moreover, according to this equation the time difference Dt1 of two
+events with respect to K1 does not in general vanish, even when the
+time difference Dt1 of the same events with reference to K vanishes.
+Pure " space-distance " of two events with respect to K results in "
+time-distance " of the same events with respect to K. But the
+discovery of Minkowski, which was of importance for the formal
+development of the theory of relativity, does not lie here. It is to
+be found rather in the fact of his recognition that the
+four-dimensional space-time continuum of the theory of relativity, in
+its most essential formal properties, shows a pronounced relationship
+to the three-dimensional continuum of Euclidean geometrical
+space.*  In order to give due prominence to this relationship,
+however, we must replace the usual time co-ordinate t by an imaginary
+magnitude eq. 25 proportional to it. Under these conditions, the
+natural laws satisfying the demands of the (special) theory of
+relativity assume mathematical forms, in which the time co-ordinate
+plays exactly the same role as the three space co-ordinates. Formally,
+these four co-ordinates correspond exactly to the three space
+co-ordinates in Euclidean geometry. It must be clear even to the
+non-mathematician that, as a consequence of this purely formal
+addition to our knowledge, the theory perforce gained clearness in no
+mean measure.
+
+These inadequate remarks can give the reader only a vague notion of
+the important idea contributed by Minkowski. Without it the general
+theory of relativity, of which the fundamental ideas are developed in
+the following pages, would perhaps have got no farther than its long
+clothes. Minkowski's work is doubtless difficult of access to anyone
+inexperienced in mathematics, but since it is not necessary to have a
+very exact grasp of this work in order to understand the fundamental
+ideas of either the special or the general theory of relativity, I
+shall leave it here at present, and revert to it only towards the end
+of Part 2.
+
+
+  Notes
+
+*) Cf. the somewhat more detailed discussion in Appendix II.
+
+
+
+
+PART II
+
+THE GENERAL THEORY OF RELATIVITY
+
+
+SPECIAL AND GENERAL PRINCIPLE OF RELATIVITY
+
+
+The basal principle, which was the pivot of all our previous
+considerations, was the special principle of relativity, i.e. the
+principle of the physical relativity of all uniform motion. Let as
+once more analyse its meaning carefully.
+
+It was at all times clear that, from the point of view of the idea it
+conveys to us, every motion must be considered only as a relative
+motion. Returning to the illustration we have frequently used of the
+embankment and the railway carriage, we can express the fact of the
+motion here taking place in the following two forms, both of which are
+equally justifiable :
+
+(a) The carriage is in motion relative to the embankment,
+(b) The embankment is in motion relative to the carriage.
+
+In (a) the embankment, in (b) the carriage, serves as the body of
+reference in our statement of the motion taking place. If it is simply
+a question of detecting or of describing the motion involved, it is in
+principle immaterial to what reference-body we refer the motion. As
+already mentioned, this is self-evident, but it must not be confused
+with the much more comprehensive statement called "the principle of
+relativity," which we have taken as the basis of our investigations.
+
+The principle we have made use of not only maintains that we may
+equally well choose the carriage or the embankment as our
+reference-body for the description of any event (for this, too, is
+self-evident). Our principle rather asserts what follows : If we
+formulate the general laws of nature as they are obtained from
+experience, by making use of
+
+(a) the embankment as reference-body,
+(b) the railway carriage as reference-body,
+
+then these general laws of nature (e.g. the laws of mechanics or the
+law of the propagation of light in vacuo) have exactly the same form
+in both cases. This can also be expressed as follows : For the
+physical description of natural processes, neither of the reference
+bodies K, K1 is unique (lit. " specially marked out ") as compared
+with the other. Unlike the first, this latter statement need not of
+necessity hold a priori; it is not contained in the conceptions of "
+motion" and " reference-body " and derivable from them; only
+experience can decide as to its correctness or incorrectness.
+
+Up to the present, however, we have by no means maintained the
+equivalence of all bodies of reference K in connection with the
+formulation of natural laws. Our course was more on the following
+Iines. In the first place, we started out from the assumption that
+there exists a reference-body K, whose condition of motion is such
+that the Galileian law holds with respect to it : A particle left to
+itself and sufficiently far removed from all other particles moves
+uniformly in a straight line. With reference to K (Galileian
+reference-body) the laws of nature were to be as simple as possible.
+But in addition to K, all bodies of reference K1 should be given
+preference in this sense, and they should be exactly equivalent to K
+for the formulation of natural laws, provided that they are in a state
+of uniform rectilinear and non-rotary motion with respect to K ; all
+these bodies of reference are to be regarded as Galileian
+reference-bodies. The validity of the principle of relativity was
+assumed only for these reference-bodies, but not for others (e.g.
+those possessing motion of a different kind). In this sense we speak
+of the special principle of relativity, or special theory of
+relativity.
+
+In contrast to this we wish to understand by the "general principle of
+relativity" the following statement : All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion. But before proceeding farther, it ought to be pointed
+out that this formulation must be replaced later by a more abstract
+one, for reasons which will become evident at a later stage.
+
+Since the introduction of the special principle of relativity has been
+justified, every intellect which strives after generalisation must
+feel the temptation to venture the step towards the general principle
+of relativity. But a simple and apparently quite reliable
+consideration seems to suggest that, for the present at any rate,
+there is little hope of success in such an attempt; Let us imagine
+ourselves transferred to our old friend the railway carriage, which is
+travelling at a uniform rate. As long as it is moving unifromly, the
+occupant of the carriage is not sensible of its motion, and it is for
+this reason that he can without reluctance interpret the facts of the
+case as indicating that the carriage is at rest, but the embankment in
+motion. Moreover, according to the special principle of relativity,
+this interpretation is quite justified also from a physical point of
+view.
+
+If the motion of the carriage is now changed into a non-uniform
+motion, as for instance by a powerful application of the brakes, then
+the occupant of the carriage experiences a correspondingly powerful
+jerk forwards. The retarded motion is manifested in the mechanical
+behaviour of bodies relative to the person in the railway carriage.
+The mechanical behaviour is different from that of the case previously
+considered, and for this reason it would appear to be impossible that
+the same mechanical laws hold relatively to the non-uniformly moving
+carriage, as hold with reference to the carriage when at rest or in
+uniform motion. At all events it is clear that the Galileian law does
+not hold with respect to the non-uniformly moving carriage. Because of
+this, we feel compelled at the present juncture to grant a kind of
+absolute physical reality to non-uniform motion, in opposition to the
+general principle of relatvity. But in what follows we shall soon see
+that this conclusion cannot be maintained.
+
+
+
+THE GRAVITATIONAL FIELD
+
+
+"If we pick up a stone and then let it go, why does it fall to the
+ground ?" The usual answer to this question is: "Because it is
+attracted by the earth." Modern physics formulates the answer rather
+differently for the following reason. As a result of the more careful
+study of electromagnetic phenomena, we have come to regard action at a
+distance as a process impossible without the intervention of some
+intermediary medium. If, for instance, a magnet attracts a piece of
+iron, we cannot be content to regard this as meaning that the magnet
+acts directly on the iron through the intermediate empty space, but we
+are constrained to imagine -- after the manner of Faraday -- that the
+magnet always calls into being something physically real in the space
+around it, that something being what we call a "magnetic field." In
+its turn this magnetic field operates on the piece of iron, so that
+the latter strives to move towards the magnet. We shall not discuss
+here the justification for this incidental conception, which is indeed
+a somewhat arbitrary one. We shall only mention that with its aid
+electromagnetic phenomena can be theoretically represented much more
+satisfactorily than without it, and this applies particularly to the
+transmission of electromagnetic waves. The effects of gravitation also
+are regarded in an analogous manner.
+
+The action of the earth on the stone takes place indirectly. The earth
+produces in its surrounding a gravitational field, which acts on the
+stone and produces its motion of fall. As we know from experience, the
+intensity of the action on a body dimishes according to a quite
+definite law, as we proceed farther and farther away from the earth.
+From our point of view this means : The law governing the properties
+of the gravitational field in space must be a perfectly definite one,
+in order correctly to represent the diminution of gravitational action
+with the distance from operative bodies. It is something like this:
+The body (e.g. the earth) produces a field in its immediate
+neighbourhood directly; the intensity and direction of the field at
+points farther removed from the body are thence determined by the law
+which governs the properties in space of the gravitational fields
+themselves.
+
+In contrast to electric and magnetic fields, the gravitational field
+exhibits a most remarkable property, which is of fundamental
+importance for what follows. Bodies which are moving under the sole
+influence of a gravitational field receive an acceleration, which does
+not in the least depend either on the material or on the physical
+state of the body. For instance, a piece of lead and a piece of wood
+fall in exactly the same manner in a gravitational field (in vacuo),
+when they start off from rest or with the same initial velocity. This
+law, which holds most accurately, can be expressed in a different form
+in the light of the following consideration.
+
+According to Newton's law of motion, we have
+
+(Force) = (inertial mass) x (acceleration),
+
+where the "inertial mass" is a characteristic constant of the
+accelerated body. If now gravitation is the cause of the acceleration,
+we then have
+
+(Force) = (gravitational mass) x (intensity of the gravitational
+field),
+
+where the "gravitational mass" is likewise a characteristic constant
+for the body. From these two relations follows:
+
+                                eq. 26: file eq26.gif
+
+
+If now, as we find from experience, the acceleration is to be
+independent of the nature and the condition of the body and always the
+same for a given gravitational field, then the ratio of the
+gravitational to the inertial mass must likewise be the same for all
+bodies. By a suitable choice of units we can thus make this ratio
+equal to unity. We then have the following law: The gravitational mass
+of a body is equal to its inertial law.
+
+It is true that this important law had hitherto been recorded in
+mechanics, but it had not been interpreted. A satisfactory
+interpretation can be obtained only if we recognise the following fact
+: The same quality of a body manifests itself according to
+circumstances as " inertia " or as " weight " (lit. " heaviness '). In
+the following section we shall show to what extent this is actually
+the case, and how this question is connected with the general
+postulate of relativity.
+
+
+
+
+THE EQUALITY OF INERTIAL AND GRAVITATIONAL MASS
+AS AN ARGUMENT FOR THE GENERAL POSTULE OF RELATIVITY
+
+
+We imagine a large portion of empty space, so far removed from stars
+and other appreciable masses, that we have before us approximately the
+conditions required by the fundamental law of Galilei. It is then
+possible to choose a Galileian reference-body for this part of space
+(world), relative to which points at rest remain at rest and points in
+motion continue permanently in uniform rectilinear motion. As
+reference-body let us imagine a spacious chest resembling a room with
+an observer inside who is equipped with apparatus. Gravitation
+naturally does not exist for this observer. He must fasten himself
+with strings to the floor, otherwise the slightest impact against the
+floor will cause him to rise slowly towards the ceiling of the room.
+
+To the middle of the lid of the chest is fixed externally a hook with
+rope attached, and now a " being " (what kind of a being is immaterial
+to us) begins pulling at this with a constant force. The chest
+together with the observer then begin to move "upwards" with a
+uniformly accelerated motion. In course of time their velocity will
+reach unheard-of values -- provided that we are viewing all this from
+another reference-body which is not being pulled with a rope.
+
+But how does the man in the chest regard the Process ? The
+acceleration of the chest will be transmitted to him by the reaction
+of the floor of the chest. He must therefore take up this pressure by
+means of his legs if he does not wish to be laid out full length on
+the floor. He is then standing in the chest in exactly the same way as
+anyone stands in a room of a home on our earth. If he releases a body
+which he previously had in his land, the accelertion of the chest will
+no longer be transmitted to this body, and for this reason the body
+will approach the floor of the chest with an accelerated relative
+motion. The observer will further convince himself that the
+acceleration of the body towards the floor of the chest is always of
+the same magnitude, whatever kind of body he may happen to use for the
+experiment.
+
+Relying on his knowledge of the gravitational field (as it was
+discussed in the preceding section), the man in the chest will thus
+come to the conclusion that he and the chest are in a gravitational
+field which is constant with regard to time. Of course he will be
+puzzled for a moment as to why the chest does not fall in this
+gravitational field. just then, however, he discovers the hook in the
+middle of the lid of the chest and the rope which is attached to it,
+and he consequently comes to the conclusion that the chest is
+suspended at rest in the gravitational field.
+
+Ought we to smile at the man and say that he errs in his conclusion ?
+I do not believe we ought to if we wish to remain consistent ; we must
+rather admit that his mode of grasping the situation violates neither
+reason nor known mechanical laws. Even though it is being accelerated
+with respect to the "Galileian space" first considered, we can
+nevertheless regard the chest as being at rest. We have thus good
+grounds for extending the principle of relativity to include bodies of
+reference which are accelerated with respect to each other, and as a
+result we have gained a powerful argument for a generalised postulate
+of relativity.
+
+We must note carefully that the possibility of this mode of
+interpretation rests on the fundamental property of the gravitational
+field of giving all bodies the same acceleration, or, what comes to
+the same thing, on the law of the equality of inertial and
+gravitational mass. If this natural law did not exist, the man in the
+accelerated chest would not be able to interpret the behaviour of the
+bodies around him on the supposition of a gravitational field, and he
+would not be justified on the grounds of experience in supposing his
+reference-body to be " at rest."
+
+Suppose that the man in the chest fixes a rope to the inner side of
+the lid, and that he attaches a body to the free end of the rope. The
+result of this will be to strech the rope so that it will hang "
+vertically " downwards. If we ask for an opinion of the cause of
+tension in the rope, the man in the chest will say: "The suspended
+body experiences a downward force in the gravitational field, and this
+is neutralised by the tension of the rope ; what determines the
+magnitude of the tension of the rope is the gravitational mass of the
+suspended body." On the other hand, an observer who is poised freely
+in space will interpret the condition of things thus : " The rope must
+perforce take part in the accelerated motion of the chest, and it
+transmits this motion to the body attached to it. The tension of the
+rope is just large enough to effect the acceleration of the body. That
+which determines the magnitude of the tension of the rope is the
+inertial mass of the body." Guided by this example, we see that our
+extension of the principle of relativity implies the necessity of the
+law of the equality of inertial and gravitational mass. Thus we have
+obtained a physical interpretation of this law.
+
+From our consideration of the accelerated chest we see that a general
+theory of relativity must yield important results on the laws of
+gravitation. In point of fact, the systematic pursuit of the general
+idea of relativity has supplied the laws satisfied by the
+gravitational field. Before proceeding farther, however, I must warn
+the reader against a misconception suggested by these considerations.
+A gravitational field exists for the man in the chest, despite the
+fact that there was no such field for the co-ordinate system first
+chosen. Now we might easily suppose that the existence of a
+gravitational field is always only an apparent one. We might also
+think that, regardless of the kind of gravitational field which may be
+present, we could always choose another reference-body such that no
+gravitational field exists with reference to it. This is by no means
+true for all gravitational fields, but only for those of quite special
+form. It is, for instance, impossible to choose a body of reference
+such that, as judged from it, the gravitational field of the earth (in
+its entirety) vanishes.
+
+We can now appreciate why that argument is not convincing, which we
+brought forward against the general principle of relativity at theend
+of Section 18. It is certainly true that the observer in the
+railway carriage experiences a jerk forwards as a result of the
+application of the brake, and that he recognises, in this the
+non-uniformity of motion (retardation) of the carriage. But he is
+compelled by nobody to refer this jerk to a " real " acceleration
+(retardation) of the carriage. He might also interpret his experience
+thus: " My body of reference (the carriage) remains permanently at
+rest. With reference to it, however, there exists (during the period
+of application of the brakes) a gravitational field which is directed
+forwards and which is variable with respect to time. Under the
+influence of this field, the embankment together with the earth moves
+non-uniformly in such a manner that their original velocity in the
+backwards direction is continuously reduced."
+
+
+
+IN WHAT RESPECTS ARE THE FOUNDATIONS OF CLASSICAL MECHANICS AND OF THE
+SPECIAL THEORY OF RELATIVITY UNSATISFACTORY?
+
+
+We have already stated several times that classical mechanics starts
+out from the following law: Material particles sufficiently far
+removed from other material particles continue to move uniformly in a
+straight line or continue in a state of rest. We have also repeatedly
+emphasised that this fundamental law can only be valid for bodies of
+reference K which possess certain unique states of motion, and which
+are in uniform translational motion relative to each other. Relative
+to other reference-bodies K the law is not valid. Both in classical
+mechanics and in the special theory of relativity we therefore
+differentiate between reference-bodies K relative to which the
+recognised " laws of nature " can be said to hold, and
+reference-bodies K relative to which these laws do not hold.
+
+But no person whose mode of thought is logical can rest satisfied with
+this condition of things. He asks : " How does it come that certain
+reference-bodies (or their states of motion) are given priority over
+other reference-bodies (or their states of motion) ? What is the
+reason for this Preference? In order to show clearly what I mean by
+this question, I shall make use of a comparison.
+
+I am standing in front of a gas range. Standing alongside of each
+other on the range are two pans so much alike that one may be mistaken
+for the other. Both are half full of water. I notice that steam is
+being emitted continuously from the one pan, but not from the other. I
+am surprised at this, even if I have never seen either a gas range or
+a pan before. But if I now notice a luminous something of bluish
+colour under the first pan but not under the other, I cease to be
+astonished, even if I have never before seen a gas flame. For I can
+only say that this bluish something will cause the emission of the
+steam, or at least possibly it may do so. If, however, I notice the
+bluish something in neither case, and if I observe that the one
+continuously emits steam whilst the other does not, then I shall
+remain astonished and dissatisfied until I have discovered some
+circumstance to which I can attribute the different behaviour of the
+two pans.
+
+Analogously, I seek in vain for a real something in classical
+mechanics (or in the special theory of relativity) to which I can
+attribute the different behaviour of bodies considered with respect to
+the reference systems K and K1.*  Newton saw this objection and
+attempted to invalidate it, but without success. But E. Mach recognsed
+it most clearly of all, and because of this objection he claimed that
+mechanics must be placed on a new basis. It can only be got rid of by
+means of a physics which is conformable to the general principle of
+relativity, since the equations of such a theory hold for every body
+of reference, whatever may be its state of motion.
+
+
+  Notes
+
+*) The objection is of importance more especially when the state of
+motion of the reference-body is of such a nature that it does not
+require any external agency for its maintenance, e.g. in the case when
+the reference-body is rotating uniformly.
+
+
+
+A FEW INFERENCES FROM THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+The considerations of Section 20 show that the general principle of
+relativity puts us in a position to derive properties of the
+gravitational field in a purely theoretical manner. Let us suppose,
+for instance, that we know the space-time " course " for any natural
+process whatsoever, as regards the manner in which it takes place in
+the Galileian domain relative to a Galileian body of reference K. By
+means of purely theoretical operations (i.e. simply by calculation) we
+are then able to find how this known natural process appears, as seen
+from a reference-body K1 which is accelerated relatively to K. But
+since a gravitational field exists with respect to this new body of
+reference K1, our consideration also teaches us how the gravitational
+field influences the process studied.
+
+For example, we learn that a body which is in a state of uniform
+rectilinear motion with respect to K (in accordance with the law of
+Galilei) is executing an accelerated and in general curvilinear motion
+with respect to the accelerated reference-body K1 (chest). This
+acceleration or curvature corresponds to the influence on the moving
+body of the gravitational field prevailing relatively to K. It is
+known that a gravitational field influences the movement of bodies in
+this way, so that our consideration supplies us with nothing
+essentially new.
+
+However, we obtain a new result of fundamental importance when we
+carry out the analogous consideration for a ray of light. With respect
+to the Galileian reference-body K, such a ray of light is transmitted
+rectilinearly with the velocity c. It can easily be shown that the
+path of the same ray of light is no longer a straight line when we
+consider it with reference to the accelerated chest (reference-body
+K1). From this we conclude, that, in general, rays of light are
+propagated curvilinearly in gravitational fields. In two respects this
+result is of great importance.
+
+In the first place, it can be compared with the reality. Although a
+detailed examination of the question shows that the curvature of light
+rays required by the general theory of relativity is only exceedingly
+small for the gravitational fields at our disposal in practice, its
+estimated magnitude for light rays passing the sun at grazing
+incidence is nevertheless 1.7 seconds of arc. This ought to manifest
+itself in the following way. As seen from the earth, certain fixed
+stars appear to be in the neighbourhood of the sun, and are thus
+capable of observation during a total eclipse of the sun. At such
+times, these stars ought to appear to be displaced outwards from the
+sun by an amount indicated above, as compared with their apparent
+position in the sky when the sun is situated at another part of the
+heavens. The examination of the correctness or otherwise of this
+deduction is a problem of the greatest importance, the early solution
+of which is to be expected of astronomers.[2]*
+
+In the second place our result shows that, according to the general
+theory of relativity, the law of the constancy of the velocity of
+light in vacuo, which constitutes one of the two fundamental
+assumptions in the special theory of relativity and to which we have
+already frequently referred, cannot claim any unlimited validity. A
+curvature of rays of light can only take place when the velocity of
+propagation of light varies with position. Now we might think that as
+a consequence of this, the special theory of relativity and with it
+the whole theory of relativity would be laid in the dust. But in
+reality this is not the case. We can only conclude that the special
+theory of relativity cannot claim an unlinlited domain of validity ;
+its results hold only so long as we are able to disregard the
+influences of gravitational fields on the phenomena (e.g. of light).
+
+Since it has often been contended by opponents of the theory of
+relativity that the special theory of relativity is overthrown by the
+general theory of relativity, it is perhaps advisable to make the
+facts of the case clearer by means of an appropriate comparison.
+Before the development of electrodynamics the laws of electrostatics
+were looked upon as the laws of electricity. At the present time we
+know that electric fields can be derived correctly from electrostatic
+considerations only for the case, which is never strictly realised, in
+which the electrical masses are quite at rest relatively to each
+other, and to the co-ordinate system. Should we be justified in saying
+that for this reason electrostatics is overthrown by the
+field-equations of Maxwell in electrodynamics ? Not in the least.
+Electrostatics is contained in electrodynamics as a limiting case ;
+the laws of the latter lead directly to those of the former for the
+case in which the fields are invariable with regard to time. No fairer
+destiny could be allotted to any physical theory, than that it should
+of itself point out the way to the introduction of a more
+comprehensive theory, in which it lives on as a limiting case.
+
+In the example of the transmission of light just dealt with, we have
+seen that the general theory of relativity enables us to derive
+theoretically the influence of a gravitational field on the course of
+natural processes, the Iaws of which are already known when a
+gravitational field is absent. But the most attractive problem, to the
+solution of which the general theory of relativity supplies the key,
+concerns the investigation of the laws satisfied by the gravitational
+field itself. Let us consider this for a moment.
+
+We are acquainted with space-time domains which behave (approximately)
+in a " Galileian " fashion under suitable choice of reference-body,
+i.e. domains in which gravitational fields are absent. If we now refer
+such a domain to a reference-body K1 possessing any kind of motion,
+then relative to K1 there exists a gravitational field which is
+variable with respect to space and time.[3]**  The character of this
+field will of course depend on the motion chosen for K1. According to
+the general theory of relativity, the general law of the gravitational
+field must be satisfied for all gravitational fields obtainable in
+this way. Even though by no means all gravitationial fields can be
+produced in this way, yet we may entertain the hope that the general
+law of gravitation will be derivable from such gravitational fields of
+a special kind. This hope has been realised in the most beautiful
+manner. But between the clear vision of this goal and its actual
+realisation it was necessary to surmount a serious difficulty, and as
+this lies deep at the root of things, I dare not withhold it from the
+reader. We require to extend our ideas of the space-time continuum
+still farther.
+
+
+  Notes
+
+*) By means of the star photographs of two expeditions equipped by
+a Joint Committee of the Royal and Royal Astronomical Societies, the
+existence of the deflection of light demanded by theory was first
+confirmed during the solar eclipse of 29th May, 1919. (Cf. Appendix
+III.)
+
+**) This follows from a generalisation of the discussion in
+Section 20
+
+
+
+BEHAVIOUR OF CLOCKS AND MEASURING-RODS ON A ROTATING BODY OF REFERENCE
+
+
+Hitherto I have purposely refrained from speaking about the physical
+interpretation of space- and time-data in the case of the general
+theory of relativity. As a consequence, I am guilty of a certain
+slovenliness of treatment, which, as we know from the special theory
+of relativity, is far from being unimportant and pardonable. It is now
+high time that we remedy this defect; but I would mention at the
+outset, that this matter lays no small claims on the patience and on
+the power of abstraction of the reader.
+
+We start off again from quite special cases, which we have frequently
+used before. Let us consider a space time domain in which no
+gravitational field exists relative to a reference-body K whose state
+of motion has been suitably chosen. K is then a Galileian
+reference-body as regards the domain considered, and the results of
+the special theory of relativity hold relative to K. Let us supposse
+the same domain referred to a second body of reference K1, which is
+rotating uniformly with respect to K. In order to fix our ideas, we
+shall imagine K1 to be in the form of a plane circular disc, which
+rotates uniformly in its own plane about its centre. An observer who
+is sitting eccentrically on the disc K1 is sensible of a force which
+acts outwards in a radial direction, and which would be interpreted as
+an effect of inertia (centrifugal force) by an observer who was at
+rest with respect to the original reference-body K. But the observer
+on the disc may regard his disc as a reference-body which is " at rest
+" ; on the basis of the general principle of relativity he is
+justified in doing this. The force acting on himself, and in fact on
+all other bodies which are at rest relative to the disc, he regards as
+the effect of a gravitational field. Nevertheless, the
+space-distribution of this gravitational field is of a kind that would
+not be possible on Newton's theory of gravitation.* But since the
+observer believes in the general theory of relativity, this does not
+disturb him; he is quite in the right when he believes that a general
+law of gravitation can be formulated- a law which not only explains
+the motion of the stars correctly, but also the field of force
+experienced by himself.
+
+The observer performs experiments on his circular disc with clocks and
+measuring-rods. In doing so, it is his intention to arrive at exact
+definitions for the signification of time- and space-data with
+reference to the circular disc K1, these definitions being based on
+his observations. What will be his experience in this enterprise ?
+
+To start with, he places one of two identically constructed clocks at
+the centre of the circular disc, and the other on the edge of the
+disc, so that they are at rest relative to it. We now ask ourselves
+whether both clocks go at the same rate from the standpoint of the
+non-rotating Galileian reference-body K. As judged from this body, the
+clock at the centre of the disc has no velocity, whereas the clock at
+the edge of the disc is in motion relative to K in consequence of the
+rotation. According to a result obtained in Section 12, it follows
+that the latter clock goes at a rate permanently slower than that of
+the clock at the centre of the circular disc, i.e. as observed from K.
+It is obvious that the same effect would be noted by an observer whom
+we will imagine sitting alongside his clock at the centre of the
+circular disc. Thus on our circular disc, or, to make the case more
+general, in every gravitational field, a clock will go more quickly or
+less quickly, according to the position in which the clock is situated
+(at rest). For this reason it is not possible to obtain a reasonable
+definition of time with the aid of clocks which are arranged at rest
+with respect to the body of reference. A similar difficulty presents
+itself when we attempt to apply our earlier definition of simultaneity
+in such a case, but I do not wish to go any farther into this
+question.
+
+Moreover, at this stage the definition of the space co-ordinates also
+presents insurmountable difficulties. If the observer applies his
+standard measuring-rod (a rod which is short as compared with the
+radius of the disc) tangentially to the edge of the disc, then, as
+judged from the Galileian system, the length of this rod will be less
+than I, since, according to Section 12, moving bodies suffer a
+shortening in the direction of the motion. On the other hand, the
+measaring-rod will not experience a shortening in length, as judged
+from K, if it is applied to the disc in the direction of the radius.
+If, then, the observer first measures the circumference of the disc
+with his measuring-rod and then the diameter of the disc, on dividing
+the one by the other, he will not obtain as quotient the familiar
+number p = 3.14 . . ., but a larger number,[4]** whereas of course,
+for a disc which is at rest with respect to K, this operation would
+yield p exactly. This proves that the propositions of Euclidean
+geometry cannot hold exactly on the rotating disc, nor in general in a
+gravitational field, at least if we attribute the length I to the rod
+in all positions and in every orientation. Hence the idea of a
+straight line also loses its meaning. We are therefore not in a
+position to define exactly the co-ordinates x, y, z relative to the
+disc by means of the method used in discussing the special theory, and
+as long as the co- ordinates and times of events have not been
+defined, we cannot assign an exact meaning to the natural laws in
+which these occur.
+
+Thus all our previous conclusions based on general relativity would
+appear to be called in question. In reality we must make a subtle
+detour in order to be able to apply the postulate of general
+relativity exactly. I shall prepare the reader for this in the
+following paragraphs.
+
+
+  Notes
+
+*) The field disappears at the centre of the disc and increases
+proportionally to the distance from the centre as we proceed outwards.
+
+**) Throughout this consideration we have to use the Galileian
+(non-rotating) system K as reference-body, since we may only assume
+the validity of the results of the special theory of relativity
+relative to K (relative to K1 a gravitational field prevails).
+
+
+
+EUCLIDEAN AND NON-EUCLIDEAN CONTINUUM
+
+
+The surface of a marble table is spread out in front of me. I can get
+from any one point on this table to any other point by passing
+continuously from one point to a " neighbouring " one, and repeating
+this process a (large) number of times, or, in other words, by going
+from point to point without executing "jumps." I am sure the reader
+will appreciate with sufficient clearness what I mean here by "
+neighbouring " and by " jumps " (if he is not too pedantic). We
+express this property of the surface by describing the latter as a
+continuum.
+
+Let us now imagine that a large number of little rods of equal length
+have been made, their lengths being small compared with the dimensions
+of the marble slab. When I say they are of equal length, I mean that
+one can be laid on any other without the ends overlapping. We next lay
+four of these little rods on the marble slab so that they constitute a
+quadrilateral figure (a square), the diagonals of which are equally
+long. To ensure the equality of the diagonals, we make use of a little
+testing-rod. To this square we add similar ones, each of which has one
+rod in common with the first. We proceed in like manner with each of
+these squares until finally the whole marble slab is laid out with
+squares. The arrangement is such, that each side of a square belongs
+to two squares and each corner to four squares.
+
+It is a veritable wonder that we can carry out this business without
+getting into the greatest difficulties. We only need to think of the
+following. If at any moment three squares meet at a corner, then two
+sides of the fourth square are already laid, and, as a consequence,
+the arrangement of the remaining two sides of the square is already
+completely determined. But I am now no longer able to adjust the
+quadrilateral so that its diagonals may be equal. If they are equal of
+their own accord, then this is an especial favour of the marble slab
+and of the little rods, about which I can only be thankfully
+surprised. We must experience many such surprises if the construction
+is to be successful.
+
+If everything has really gone smoothly, then I say that the points of
+the marble slab constitute a Euclidean continuum with respect to the
+little rod, which has been used as a " distance " (line-interval). By
+choosing one corner of a square as " origin" I can characterise every
+other corner of a square with reference to this origin by means of two
+numbers. I only need state how many rods I must pass over when,
+starting from the origin, I proceed towards the " right " and then "
+upwards," in order to arrive at the corner of the square under
+consideration. These two numbers are then the " Cartesian co-ordinates
+" of this corner with reference to the " Cartesian co-ordinate system"
+which is determined by the arrangement of little rods.
+
+By making use of the following modification of this abstract
+experiment, we recognise that there must also be cases in which the
+experiment would be unsuccessful. We shall suppose that the rods "
+expand " by in amount proportional to the increase of temperature. We
+heat the central part of the marble slab, but not the periphery, in
+which case two of our little rods can still be brought into
+coincidence at every position on the table. But our construction of
+squares must necessarily come into disorder during the heating,
+because the little rods on the central region of the table expand,
+whereas those on the outer part do not.
+
+With reference to our little rods -- defined as unit lengths -- the
+marble slab is no longer a Euclidean continuum, and we are also no
+longer in the position of defining Cartesian co-ordinates directly
+with their aid, since the above construction can no longer be carried
+out. But since there are other things which are not influenced in a
+similar manner to the little rods (or perhaps not at all) by the
+temperature of the table, it is possible quite naturally to maintain
+the point of view that the marble slab is a " Euclidean continuum."
+This can be done in a satisfactory manner by making a more subtle
+stipulation about the measurement or the comparison of lengths.
+
+But if rods of every kind (i.e. of every material) were to behave in
+the same way as regards the influence of temperature when they are on
+the variably heated marble slab, and if we had no other means of
+detecting the effect of temperature than the geometrical behaviour of
+our rods in experiments analogous to the one described above, then our
+best plan would be to assign the distance one to two points on the
+slab, provided that the ends of one of our rods could be made to
+coincide with these two points ; for how else should we define the
+distance without our proceeding being in the highest measure grossly
+arbitrary ? The method of Cartesian coordinates must then be
+discarded, and replaced by another which does not assume the validity
+of Euclidean geometry for rigid bodies.*  The reader will notice
+that the situation depicted here corresponds to the one brought about
+by the general postitlate of relativity (Section 23).
+
+
+  Notes
+
+*) Mathematicians have been confronted with our problem in the
+following form. If we are given a surface (e.g. an ellipsoid) in
+Euclidean three-dimensional space, then there exists for this surface
+a two-dimensional geometry, just as much as for a plane surface. Gauss
+undertook the task of treating this two-dimensional geometry from
+first principles, without making use of the fact that the surface
+belongs to a Euclidean continuum of three dimensions. If we imagine
+constructions to be made with rigid rods in the surface (similar to
+that above with the marble slab), we should find that different laws
+hold for these from those resulting on the basis of Euclidean plane
+geometry. The surface is not a Euclidean continuum with respect to the
+rods, and we cannot define Cartesian co-ordinates in the surface.
+Gauss indicated the principles according to which we can treat the
+geometrical relationships in the surface, and thus pointed out the way
+to the method of Riemman of treating multi-dimensional, non-Euclidean
+continuum. Thus it is that mathematicians long ago solved the formal
+problems to which we are led by the general postulate of relativity.
+
+
+
+GAUSSIAN CO-ORDINATES
+
+
+According to Gauss, this combined analytical and geometrical mode of
+handling the problem can be arrived at in the following way. We
+imagine a system of arbitrary curves (see Fig. 4) drawn on the surface
+of the table. These we designate as u-curves, and we indicate each of
+them by means of a number. The Curves u= 1, u= 2 and u= 3 are drawn in
+the diagram. Between the curves u= 1 and u= 2 we must imagine an
+infinitely large number to be drawn, all of which correspond to real
+numbers lying between 1 and 2. fig. 04 We have then a system of
+u-curves, and this "infinitely dense" system covers the whole surface
+of the table. These u-curves must not intersect each other, and
+through each point of the surface one and only one curve must pass.
+Thus a perfectly definite value of u belongs to every point on the
+surface of the marble slab. In like manner we imagine a system of
+v-curves drawn on the surface. These satisfy the same conditions as
+the u-curves, they are provided with numbers in a corresponding
+manner, and they may likewise be of arbitrary shape. It follows that a
+value of u and a value of v belong to every point on the surface of
+the table. We call these two numbers the co-ordinates of the surface
+of the table (Gaussian co-ordinates). For example, the point P in the
+diagram has the Gaussian co-ordinates u= 3, v= 1. Two neighbouring
+points P and P1 on the surface then correspond to the co-ordinates
+
+                       P:       u,v
+
+                       P1:     u + du, v + dv,
+
+where du and dv signify very small numbers. In a similar manner we may
+indicate the distance (line-interval) between P and P1, as measured
+with a little rod, by means of the very small number ds. Then
+according to Gauss we have
+
+                ds2 = g[11]du2 + 2g[12]dudv = g[22]dv2
+
+where g[11], g[12], g[22], are magnitudes which depend in a perfectly
+definite way on u and v. The magnitudes g[11], g[12] and g[22],
+determine the behaviour of the rods relative to the u-curves and
+v-curves, and thus also relative to the surface of the table. For the
+case in which the points of the surface considered form a Euclidean
+continuum with reference to the measuring-rods, but only in this case,
+it is possible to draw the u-curves and v-curves and to attach numbers
+to them, in such a manner, that we simply have :
+
+                           ds2 = du2 + dv2
+
+Under these conditions, the u-curves and v-curves are straight lines
+in the sense of Euclidean geometry, and they are perpendicular to each
+other. Here the Gaussian coordinates are samply Cartesian ones. It is
+clear that Gauss co-ordinates are nothing more than an association of
+two sets of numbers with the points of the surface considered, of such
+a nature that numerical values differing very slightly from each other
+are associated with neighbouring points " in space."
+
+So far, these considerations hold for a continuum of two dimensions.
+But the Gaussian method can be applied also to a continuum of three,
+four or more dimensions. If, for instance, a continuum of four
+dimensions be supposed available, we may represent it in the following
+way. With every point of the continuum, we associate arbitrarily four
+numbers, x[1], x[2], x[3], x[4], which are known as " co-ordinates."
+Adjacent points correspond to adjacent values of the coordinates. If a
+distance ds is associated with the adjacent points P and P1, this
+distance being measurable and well defined from a physical point of
+view, then the following formula holds:
+
+ds2 = g[11]dx[1]^2 + 2g[12]dx[1]dx[2] . . . . g[44]dx[4]^2,
+
+where the magnitudes g[11], etc., have values which vary with the
+position in the continuum. Only when the continuum is a Euclidean one
+is it possible to associate the co-ordinates x[1] . . x[4]. with the
+points of the continuum so that we have simply
+
+ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+In this case relations hold in the four-dimensional continuum which
+are analogous to those holding in our three-dimensional measurements.
+
+However, the Gauss treatment for ds2 which we have given above is not
+always possible. It is only possible when sufficiently small regions
+of the continuum under consideration may be regarded as Euclidean
+continua. For example, this obviously holds in the case of the marble
+slab of the table and local variation of temperature. The temperature
+is practically constant for a small part of the slab, and thus the
+geometrical behaviour of the rods is almost as it ought to be
+according to the rules of Euclidean geometry. Hence the imperfections
+of the construction of squares in the previous section do not show
+themselves clearly until this construction is extended over a
+considerable portion of the surface of the table.
+
+We can sum this up as follows: Gauss invented a method for the
+mathematical treatment of continua in general, in which "
+size-relations " (" distances " between neighbouring points) are
+defined. To every point of a continuum are assigned as many numbers
+(Gaussian coordinates) as the continuum has dimensions. This is done
+in such a way, that only one meaning can be attached to the
+assignment, and that numbers (Gaussian coordinates) which differ by an
+indefinitely small amount are assigned to adjacent points. The
+Gaussian coordinate system is a logical generalisation of the
+Cartesian co-ordinate system. It is also applicable to non-Euclidean
+continua, but only when, with respect to the defined "size" or
+"distance," small parts of the continuum under consideration behave
+more nearly like a Euclidean system, the smaller the part of the
+continuum under our notice.
+
+
+
+THE SPACE-TIME CONTINUUM OF THE SPEICAL THEORY OF RELATIVITY CONSIDERED AS A
+EUCLIDEAN CONTINUUM
+
+
+We are now in a position to formulate more exactly the idea of
+Minkowski, which was only vaguely indicated in Section 17. In
+accordance with the special theory of relativity, certain co-ordinate
+systems are given preference for the description of the
+four-dimensional, space-time continuum. We called these " Galileian
+co-ordinate systems." For these systems, the four co-ordinates x, y,
+z, t, which determine an event or -- in other words, a point of the
+four-dimensional continuum -- are defined physically in a simple
+manner, as set forth in detail in the first part of this book. For the
+transition from one Galileian system to another, which is moving
+uniformly with reference to the first, the equations of the Lorentz
+transformation are valid. These last form the basis for the derivation
+of deductions from the special theory of relativity, and in themselves
+they are nothing more than the expression of the universal validity of
+the law of transmission of light for all Galileian systems of
+reference.
+
+Minkowski found that the Lorentz transformations satisfy the following
+simple conditions. Let us consider two neighbouring events, the
+relative position of which in the four-dimensional continuum is given
+with respect to a Galileian reference-body K by the space co-ordinate
+differences dx, dy, dz and the time-difference dt. With reference to a
+second Galileian system we shall suppose that the corresponding
+differences for these two events are dx1, dy1, dz1, dt1. Then these
+magnitudes always fulfil the condition*
+
+     dx2 + dy2 + dz2 - c^2dt2 = dx1 2 + dy1 2 + dz1 2 - c^2dt1 2.
+
+The validity of the Lorentz transformation follows from this
+condition. We can express this as follows: The magnitude
+
+                   ds2 = dx2 + dy2 + dz2 - c^2dt2,
+
+which belongs to two adjacent points of the four-dimensional
+space-time continuum, has the same value for all selected (Galileian)
+reference-bodies. If we replace x, y, z, sq. rt. -I . ct , by x[1],
+x[2], x[3], x[4], we also obtaill the result that
+
+             ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+is independent of the choice of the body of reference. We call the
+magnitude ds the " distance " apart of the two events or
+four-dimensional points.
+
+Thus, if we choose as time-variable the imaginary variable sq. rt. -I
+. ct instead of the real quantity t, we can regard the space-time
+contintium -- accordance with the special theory of relativity -- as a
+", Euclidean " four-dimensional continuum, a result which follows from
+the considerations of the preceding section.
+
+
+  Notes
+
+*) Cf. Appendixes I and 2. The relations which are derived
+there for the co-ordlnates themselves are valid also for co-ordinate
+differences, and thus also for co-ordinate differentials (indefinitely
+small differences).
+
+
+
+THE SPACE-TIME CONTINUUM OF THE GENERAL THEORY OF REALTIIVTY IS NOT A
+ECULIDEAN CONTINUUM
+
+
+In the first part of this book we were able to make use of space-time
+co-ordinates which allowed of a simple and direct physical
+interpretation, and which, according to Section 26, can be regarded
+as four-dimensional Cartesian co-ordinates. This was possible on the
+basis of the law of the constancy of the velocity of tight. But
+according to Section 21 the general theory of relativity cannot
+retain this law. On the contrary, we arrived at the result that
+according to this latter theory the velocity of light must always
+depend on the co-ordinates when a gravitational field is present. In
+connection with a specific illustration in Section 23, we found
+that the presence of a gravitational field invalidates the definition
+of the coordinates and the ifine, which led us to our objective in the
+special theory of relativity.
+
+In view of the resuIts of these considerations we are led to the
+conviction that, according to the general principle of relativity, the
+space-time continuum cannot be regarded as a Euclidean one, but that
+here we have the general case, corresponding to the marble slab with
+local variations of temperature, and with which we made acquaintance
+as an example of a two-dimensional continuum. Just as it was there
+impossible to construct a Cartesian co-ordinate system from equal
+rods, so here it is impossible to build up a system (reference-body)
+from rigid bodies and clocks, which shall be of such a nature that
+measuring-rods and clocks, arranged rigidly with respect to one
+another, shaIll indicate position and time directly. Such was the
+essence of the difficulty with which we were confronted in Section
+23.
+
+But the considerations of Sections 25 and 26 show us the way to
+surmount this difficulty. We refer the fourdimensional space-time
+continuum in an arbitrary manner to Gauss co-ordinates. We assign to
+every point of the continuum (event) four numbers, x[1], x[2], x[3],
+x[4] (co-ordinates), which have not the least direct physical
+significance, but only serve the purpose of numbering the points of
+the continuum in a definite but arbitrary manner. This arrangement
+does not even need to be of such a kind that we must regard x[1],
+x[2], x[3], as "space" co-ordinates and x[4], as a " time "
+co-ordinate.
+
+The reader may think that such a description of the world would be
+quite inadequate. What does it mean to assign to an event the
+particular co-ordinates x[1], x[2], x[3], x[4], if in themselves these
+co-ordinates have no significance ? More careful consideration shows,
+however, that this anxiety is unfounded. Let us consider, for
+instance, a material point with any kind of motion. If this point had
+only a momentary existence without duration, then it would to
+described in space-time by a single system of values x[1], x[2], x[3],
+x[4]. Thus its permanent existence must be characterised by an
+infinitely large number of such systems of values, the co-ordinate
+values of which are so close together as to give continuity;
+corresponding to the material point, we thus have a (uni-dimensional)
+line in the four-dimensional continuum. In the same way, any such
+lines in our continuum correspond to many points in motion. The only
+statements having regard to these points which can claim a physical
+existence are in reality the statements about their encounters. In our
+mathematical treatment, such an encounter is expressed in the fact
+that the two lines which represent the motions of the points in
+question have a particular system of co-ordinate values, x[1], x[2],
+x[3], x[4], in common. After mature consideration the reader will
+doubtless admit that in reality such encounters constitute the only
+actual evidence of a time-space nature with which we meet in physical
+statements.
+
+When we were describing the motion of a material point relative to a
+body of reference, we stated nothing more than the encounters of this
+point with particular points of the reference-body. We can also
+determine the corresponding values of the time by the observation of
+encounters of the body with clocks, in conjunction with the
+observation of the encounter of the hands of clocks with particular
+points on the dials. It is just the same in the case of
+space-measurements by means of measuring-rods, as a litttle
+consideration will show.
+
+The following statements hold generally : Every physical description
+resolves itself into a number of statements, each of which refers to
+the space-time coincidence of two events A and B. In terms of Gaussian
+co-ordinates, every such statement is expressed by the agreement of
+their four co-ordinates x[1], x[2], x[3], x[4]. Thus in reality, the
+description of the time-space continuum by means of Gauss co-ordinates
+completely replaces the description with the aid of a body of
+reference, without suffering from the defects of the latter mode of
+description; it is not tied down to the Euclidean character of the
+continuum which has to be represented.
+
+
+
+EXACT FORMULATION OF THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+We are now in a position to replace the pro. visional formulation of
+the general principle of relativity given in Section 18 by an exact
+formulation. The form there used, "All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion," cannot be maintained, because the use of rigid
+reference-bodies, in the sense of the method followed in the special
+theory of relativity, is in general not possible in space-time
+description. The Gauss co-ordinate system has to take the place of the
+body of reference. The following statement corresponds to the
+fundamental idea of the general principle of relativity: "All Gaussian
+co-ordinate systems are essentially equivalent for the formulation of
+the general laws of nature."
+
+We can state this general principle of relativity in still another
+form, which renders it yet more clearly intelligible than it is when
+in the form of the natural extension of the special principle of
+relativity. According to the special theory of relativity, the
+equations which express the general laws of nature pass over into
+equations of the same form when, by making use of the Lorentz
+transformation, we replace the space-time variables x, y, z, t, of a
+(Galileian) reference-body K by the space-time variables x1, y1, z1,
+t1, of a new reference-body K1. According to the general theory of
+relativity, on the other hand, by application of arbitrary
+substitutions of the Gauss variables x[1], x[2], x[3], x[4], the
+equations must pass over into equations of the same form; for every
+transformation (not only the Lorentz transformation) corresponds to
+the transition of one Gauss co-ordinate system into another.
+
+If we desire to adhere to our "old-time" three-dimensional view of
+things, then we can characterise the development which is being
+undergone by the fundamental idea of the general theory of relativity
+as follows : The special theory of relativity has reference to
+Galileian domains, i.e. to those in which no gravitational field
+exists. In this connection a Galileian reference-body serves as body
+of reference, i.e. a rigid body the state of motion of which is so
+chosen that the Galileian law of the uniform rectilinear motion of
+"isolated" material points holds relatively to it.
+
+Certain considerations suggest that we should refer the same Galileian
+domains to non-Galileian reference-bodies also. A gravitational field
+of a special kind is then present with respect to these bodies (cf.
+Sections 20 and 23).
+
+In gravitational fields there are no such things as rigid bodies with
+Euclidean properties; thus the fictitious rigid body of reference is
+of no avail in the general theory of relativity. The motion of clocks
+is also influenced by gravitational fields, and in such a way that a
+physical definition of time which is made directly with the aid of
+clocks has by no means the same degree of plausibility as in the
+special theory of relativity.
+
+For this reason non-rigid reference-bodies are used, which are as a
+whole not only moving in any way whatsoever, but which also suffer
+alterations in form ad lib. during their motion. Clocks, for which the
+law of motion is of any kind, however irregular, serve for the
+definition of time. We have to imagine each of these clocks fixed at a
+point on the non-rigid reference-body. These clocks satisfy only the
+one condition, that the "readings" which are observed simultaneously
+on adjacent clocks (in space) differ from each other by an
+indefinitely small amount. This non-rigid reference-body, which might
+appropriately be termed a "reference-mollusc", is in the main
+equivalent to a Gaussian four-dimensional co-ordinate system chosen
+arbitrarily. That which gives the "mollusc" a certain
+comprehensibility as compared with the Gauss co-ordinate system is the
+(really unjustified) formal retention of the separate existence of the
+space co-ordinates as opposed to the time co-ordinate. Every point on
+the mollusc is treated as a space-point, and every material point
+which is at rest relatively to it as at rest, so long as the mollusc
+is considered as reference-body. The general principle of relativity
+requires that all these molluscs can be used as reference-bodies with
+equal right and equal success in the formulation of the general laws
+of nature; the laws themselves must be quite independent of the choice
+of mollusc.
+
+The great power possessed by the general principle of relativity lies
+in the comprehensive limitation which is imposed on the laws of nature
+in consequence of what we have seen above.
+
+
+
+THE SOLUTION OF THE PROBLEM OF GRAVITATION ON THE BASIS OF THE GENERAL
+PRINCIPLE OF RELATIVITY
+
+
+If the reader has followed all our previous considerations, he will
+have no further difficulty in understanding the methods leading to the
+solution of the problem of gravitation.
+
+We start off on a consideration of a Galileian domain, i.e. a domain
+in which there is no gravitational field relative to the Galileian
+reference-body K. The behaviour of measuring-rods and clocks with
+reference to K is known from the special theory of relativity,
+likewise the behaviour of "isolated" material points; the latter move
+uniformly and in straight lines.
+
+Now let us refer this domain to a random Gauss coordinate system or to
+a "mollusc" as reference-body K1. Then with respect to K1 there is a
+gravitational field G (of a particular kind). We learn the behaviour
+of measuring-rods and clocks and also of freely-moving material points
+with reference to K1 simply by mathematical transformation. We
+interpret this behaviour as the behaviour of measuring-rods, docks and
+material points tinder the influence of the gravitational field G.
+Hereupon we introduce a hypothesis: that the influence of the
+gravitational field on measuringrods, clocks and freely-moving
+material points continues to take place according to the same laws,
+even in the case where the prevailing gravitational field is not
+derivable from the Galfleian special care, simply by means of a
+transformation of co-ordinates.
+
+The next step is to investigate the space-time behaviour of the
+gravitational field G, which was derived from the Galileian special
+case simply by transformation of the coordinates. This behaviour is
+formulated in a law, which is always valid, no matter how the
+reference-body (mollusc) used in the description may be chosen.
+
+This law is not yet the general law of the gravitational field, since
+the gravitational field under consideration is of a special kind. In
+order to find out the general law-of-field of gravitation we still
+require to obtain a generalisation of the law as found above. This can
+be obtained without caprice, however, by taking into consideration the
+following demands:
+
+(a) The required generalisation must likewise satisfy the general
+postulate of relativity.
+
+(b) If there is any matter in the domain under consideration, only its
+inertial mass, and thus according to Section 15 only its energy is
+of importance for its etfect in exciting a field.
+
+(c) Gravitational field and matter together must satisfy the law of
+the conservation of energy (and of impulse).
+
+Finally, the general principle of relativity permits us to determine
+the influence of the gravitational field on the course of all those
+processes which take place according to known laws when a
+gravitational field is absent i.e. which have already been fitted into
+the frame of the special theory of relativity. In this connection we
+proceed in principle according to the method which has already been
+explained for measuring-rods, clocks and freely moving material
+points.
+
+The theory of gravitation derived in this way from the general
+postulate of relativity excels not only in its beauty ; nor in
+removing the defect attaching to classical mechanics which was brought
+to light in Section 21; nor in interpreting the empirical law of
+the equality of inertial and gravitational mass ; but it has also
+already explained a result of observation in astronomy, against which
+classical mechanics is powerless.
+
+If we confine the application of the theory to the case where the
+gravitational fields can be regarded as being weak, and in which all
+masses move with respect to the coordinate system with velocities
+which are small compared with the velocity of light, we then obtain as
+a first approximation the Newtonian theory. Thus the latter theory is
+obtained here without any particular assumption, whereas Newton had to
+introduce the hypothesis that the force of attraction between mutually
+attracting material points is inversely proportional to the square of
+the distance between them. If we increase the accuracy of the
+calculation, deviations from the theory of Newton make their
+appearance, practically all of which must nevertheless escape the test
+of observation owing to their smallness.
+
+We must draw attention here to one of these deviations. According to
+Newton's theory, a planet moves round the sun in an ellipse, which
+would permanently maintain its position with respect to the fixed
+stars, if we could disregard the motion of the fixed stars themselves
+and the action of the other planets under consideration. Thus, if we
+correct the observed motion of the planets for these two influences,
+and if Newton's theory be strictly correct, we ought to obtain for the
+orbit of the planet an ellipse, which is fixed with reference to the
+fixed stars. This deduction, which can be tested with great accuracy,
+has been confirmed for all the planets save one, with the precision
+that is capable of being obtained by the delicacy of observation
+attainable at the present time. The sole exception is Mercury, the
+planet which lies nearest the sun. Since the time of Leverrier, it has
+been known that the ellipse corresponding to the orbit of Mercury,
+after it has been corrected for the influences mentioned above, is not
+stationary with respect to the fixed stars, but that it rotates
+exceedingly slowly in the plane of the orbit and in the sense of the
+orbital motion. The value obtained for this rotary movement of the
+orbital ellipse was 43 seconds of arc per century, an amount ensured
+to be correct to within a few seconds of arc. This effect can be
+explained by means of classical mechanics only on the assumption of
+hypotheses which have little probability, and which were devised
+solely for this purponse.
+
+On the basis of the general theory of relativity, it is found that the
+ellipse of every planet round the sun must necessarily rotate in the
+manner indicated above ; that for all the planets, with the exception
+of Mercury, this rotation is too small to be detected with the
+delicacy of observation possible at the present time ; but that in the
+case of Mercury it must amount to 43 seconds of arc per century, a
+result which is strictly in agreement with observation.
+
+Apart from this one, it has hitherto been possible to make only two
+deductions from the theory which admit of being tested by observation,
+to wit, the curvature of light rays by the gravitational field of the
+sun,*x and a displacement of the spectral lines of light reaching
+us from large stars, as compared with the corresponding lines for
+light produced in an analogous manner terrestrially (i.e. by the same
+kind of atom).**  These two deductions from the theory have both
+been confirmed.
+
+
+  Notes
+
+*) First observed by Eddington and others in 1919. (Cf. Appendix
+III, pp. 126-129).
+
+**) Established by Adams in 1924. (Cf. p. 132)
+
+
+
+
+PART III
+
+CONSIDERATIONS ON THE UNIVERSE AS A WHOLE
+
+
+COSMOLOGICAL DIFFICULTIES OF NEWTON'S THEORY
+
+
+Part from the difficulty discussed in Section 21, there is a second
+fundamental difficulty attending classical celestial mechanics, which,
+to the best of my knowledge, was first discussed in detail by the
+astronomer Seeliger. If we ponder over the question as to how the
+universe, considered as a whole, is to be regarded, the first answer
+that suggests itself to us is surely this: As regards space (and time)
+the universe is infinite. There are stars everywhere, so that the
+density of matter, although very variable in detail, is nevertheless
+on the average everywhere the same. In other words: However far we
+might travel through space, we should find everywhere an attenuated
+swarm of fixed stars of approrimately the same kind and density.
+
+This view is not in harmony with the theory of Newton. The latter
+theory rather requires that the universe should have a kind of centre
+in which the density of the stars is a maximum, and that as we proceed
+outwards from this centre the group-density of the stars should
+diminish, until finally, at great distances, it is succeeded by an
+infinite region of emptiness. The stellar universe ought to be a
+finite island in the infinite ocean of space.*
+
+This conception is in itself not very satisfactory. It is still less
+satisfactory because it leads to the result that the light emitted by
+the stars and also individual stars of the stellar system are
+perpetually passing out into infinite space, never to return, and
+without ever again coming into interaction with other objects of
+nature. Such a finite material universe would be destined to become
+gradually but systematically impoverished.
+
+In order to escape this dilemma, Seeliger suggested a modification of
+Newton's law, in which he assumes that for great distances the force
+of attraction between two masses diminishes more rapidly than would
+result from the inverse square law. In this way it is possible for the
+mean density of matter to be constant everywhere, even to infinity,
+without infinitely large gravitational fields being produced. We thus
+free ourselves from the distasteful conception that the material
+universe ought to possess something of the nature of a centre. Of
+course we purchase our emancipation from the fundamental difficulties
+mentioned, at the cost of a modification and complication of Newton's
+law which has neither empirical nor theoretical foundation. We can
+imagine innumerable laws which would serve the same purpose, without
+our being able to state a reason why one of them is to be preferred to
+the others ; for any one of these laws would be founded just as little
+on more general theoretical principles as is the law of Newton.
+
+
+  Notes
+
+*) Proof -- According to the theory of Newton, the number of "lines
+of force" which come from infinity and terminate in a mass m is
+proportional to the mass m. If, on the average, the Mass density p[0]
+is constant throughout tithe universe, then a sphere of volume V will
+enclose the average man p[0]V. Thus the number of lines of force
+passing through the surface F of the sphere into its interior is
+proportional to p[0] V. For unit area of the surface of the sphere the
+number of lines of force which enters the sphere is thus proportional
+to p[0] V/F or to p[0]R. Hence the intensity of the field at the
+surface would ultimately become infinite with increasing radius R of
+the sphere, which is impossible.
+
+
+
+THE POSSIBILITY OF A "FINITE" AND YET "UNBOUNDED" UNIVERSE
+
+
+But speculations on the structure of the universe also move in quite
+another direction. The development of non-Euclidean geometry led to
+the recognition of the fact, that we can cast doubt on the
+infiniteness of our space without coming into conflict with the laws
+of thought or with experience (Riemann, Helmholtz). These questions
+have already been treated in detail and with unsurpassable lucidity by
+Helmholtz and Poincaré, whereas I can only touch on them briefly here.
+
+In the first place, we imagine an existence in two dimensional space.
+Flat beings with flat implements, and in particular flat rigid
+measuring-rods, are free to move in a plane. For them nothing exists
+outside of this plane: that which they observe to happen to themselves
+and to their flat " things " is the all-inclusive reality of their
+plane. In particular, the constructions of plane Euclidean geometry
+can be carried out by means of the rods e.g. the lattice construction,
+considered in Section 24. In contrast to ours, the universe of
+these beings is two-dimensional; but, like ours, it extends to
+infinity. In their universe there is room for an infinite number of
+identical squares made up of rods, i.e. its volume (surface) is
+infinite. If these beings say their universe is " plane," there is
+sense in the statement, because they mean that they can perform the
+constructions of plane Euclidean geometry with their rods. In this
+connection the individual rods always represent the same distance,
+independently of their position.
+
+Let us consider now a second two-dimensional existence, but this time
+on a spherical surface instead of on a plane. The flat beings with
+their measuring-rods and other objects fit exactly on this surface and
+they are unable to leave it. Their whole universe of observation
+extends exclusively over the surface of the sphere. Are these beings
+able to regard the geometry of their universe as being plane geometry
+and their rods withal as the realisation of " distance " ? They cannot
+do this. For if they attempt to realise a straight line, they will
+obtain a curve, which we " three-dimensional beings " designate as a
+great circle, i.e. a self-contained line of definite finite length,
+which can be measured up by means of a measuring-rod. Similarly, this
+universe has a finite area that can be compared with the area, of a
+square constructed with rods. The great charm resulting from this
+consideration lies in the recognition of the fact that the universe of
+these beings is finite and yet has no limits.
+
+But the spherical-surface beings do not need to go on a world-tour in
+order to perceive that they are not living in a Euclidean universe.
+They can convince themselves of this on every part of their " world,"
+provided they do not use too small a piece of it. Starting from a
+point, they draw " straight lines " (arcs of circles as judged in
+three dimensional space) of equal length in all directions. They will
+call the line joining the free ends of these lines a " circle." For a
+plane surface, the ratio of the circumference of a circle to its
+diameter, both lengths being measured with the same rod, is, according
+to Euclidean geometry of the plane, equal to a constant value p, which
+is independent of the diameter of the circle. On their spherical
+surface our flat beings would find for this ratio the value
+
+                        eq. 27: file eq27.gif
+
+i.e. a smaller value than p, the difference being the more
+considerable, the greater is the radius of the circle in comparison
+with the radius R of the " world-sphere." By means of this relation
+the spherical beings can determine the radius of their universe ("
+world "), even when only a relatively small part of their worldsphere
+is available for their measurements. But if this part is very small
+indeed, they will no longer be able to demonstrate that they are on a
+spherical " world " and not on a Euclidean plane, for a small part of
+a spherical surface differs only slightly from a piece of a plane of
+the same size.
+
+Thus if the spherical surface beings are living on a planet of which
+the solar system occupies only a negligibly small part of the
+spherical universe, they have no means of determining whether they are
+living in a finite or in an infinite universe, because the " piece of
+universe " to which they have access is in both cases practically
+plane, or Euclidean. It follows directly from this discussion, that
+for our sphere-beings the circumference of a circle first increases
+with the radius until the " circumference of the universe " is
+reached, and that it thenceforward gradually decreases to zero for
+still further increasing values of the radius. During this process the
+area of the circle continues to increase more and more, until finally
+it becomes equal to the total area of the whole " world-sphere."
+
+Perhaps the reader will wonder why we have placed our " beings " on a
+sphere rather than on another closed surface. But this choice has its
+justification in the fact that, of all closed surfaces, the sphere is
+unique in possessing the property that all points on it are
+equivalent. I admit that the ratio of the circumference c of a circle
+to its radius r depends on r, but for a given value of r it is the
+same for all points of the " worldsphere "; in other words, the "
+world-sphere " is a " surface of constant curvature."
+
+To this two-dimensional sphere-universe there is a three-dimensional
+analogy, namely, the three-dimensional spherical space which was
+discovered by Riemann. its points are likewise all equivalent. It
+possesses a finite volume, which is determined by its "radius"
+(2p2R3). Is it possible to imagine a spherical space? To imagine a
+space means nothing else than that we imagine an epitome of our "
+space " experience, i.e. of experience that we can have in the
+movement of " rigid " bodies. In this sense we can imagine a spherical
+space.
+
+Suppose we draw lines or stretch strings in all directions from a
+point, and mark off from each of these the distance r with a
+measuring-rod. All the free end-points of these lengths lie on a
+spherical surface. We can specially measure up the area (F) of this
+surface by means of a square made up of measuring-rods. If the
+universe is Euclidean, then F = 4pR2 ; if it is spherical, then F is
+always less than 4pR2. With increasing values of r, F increases from
+zero up to a maximum value which is determined by the " world-radius,"
+but for still further increasing values of r, the area gradually
+diminishes to zero. At first, the straight lines which radiate from
+the starting point diverge farther and farther from one another, but
+later they approach each other, and finally they run together again at
+a "counter-point" to the starting point. Under such conditions they
+have traversed the whole spherical space. It is easily seen that the
+three-dimensional spherical space is quite analogous to the
+two-dimensional spherical surface. It is finite (i.e. of finite
+volume), and has no bounds.
+
+It may be mentioned that there is yet another kind of curved space: "
+elliptical space." It can be regarded as a curved space in which the
+two " counter-points " are identical (indistinguishable from each
+other). An elliptical universe can thus be considered to some extent
+as a curved universe possessing central symmetry.
+
+It follows from what has been said, that closed spaces without limits
+are conceivable. From amongst these, the spherical space (and the
+elliptical) excels in its simplicity, since all points on it are
+equivalent. As a result of this discussion, a most interesting
+question arises for astronomers and physicists, and that is whether
+the universe in which we live is infinite, or whether it is finite in
+the manner of the spherical universe. Our experience is far from being
+sufficient to enable us to answer this question. But the general
+theory of relativity permits of our answering it with a moduate degree
+of certainty, and in this connection the difficulty mentioned in
+Section 30 finds its solution.
+
+
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+
+
+According to the general theory of relativity, the geometrical
+properties of space are not independent, but they are determined by
+matter. Thus we can draw conclusions about the geometrical structure
+of the universe only if we base our considerations on the state of the
+matter as being something that is known. We know from experience that,
+for a suitably chosen co-ordinate system, the velocities of the stars
+are small as compared with the velocity of transmission of light. We
+can thus as a rough approximation arrive at a conclusion as to the
+nature of the universe as a whole, if we treat the matter as being at
+rest.
+
+We already know from our previous discussion that the behaviour of
+measuring-rods and clocks is influenced by gravitational fields, i.e.
+by the distribution of matter. This in itself is sufficient to exclude
+the possibility of the exact validity of Euclidean geometry in our
+universe. But it is conceivable that our universe differs only
+slightly from a Euclidean one, and this notion seems all the more
+probable, since calculations show that the metrics of surrounding
+space is influenced only to an exceedingly small extent by masses even
+of the magnitude of our sun. We might imagine that, as regards
+geometry, our universe behaves analogously to a surface which is
+irregularly curved in its individual parts, but which nowhere departs
+appreciably from a plane: something like the rippled surface of a
+lake. Such a universe might fittingly be called a quasi-Euclidean
+universe. As regards its space it would be infinite. But calculation
+shows that in a quasi-Euclidean universe the average density of matter
+would necessarily be nil. Thus such a universe could not be inhabited
+by matter everywhere ; it would present to us that unsatisfactory
+picture which we portrayed in Section 30.
+
+If we are to have in the universe an average density of matter which
+differs from zero, however small may be that difference, then the
+universe cannot be quasi-Euclidean. On the contrary, the results of
+calculation indicate that if matter be distributed uniformly, the
+universe would necessarily be spherical (or elliptical). Since in
+reality the detailed distribution of matter is not uniform, the real
+universe will deviate in individual parts from the spherical, i.e. the
+universe will be quasi-spherical. But it will be necessarily finite.
+In fact, the theory supplies us with a simple connection *  between
+the space-expanse of the universe and the average density of matter in
+it.
+
+
+  Notes
+
+*) For the radius R of the universe we obtain the equation
+
+                        eq. 28: file eq28.gif
+
+The use of the C.G.S. system in this equation gives 2/k = 1^.08.10^27;
+p is the average density of the matter and k is a constant connected
+with the Newtonian constant of gravitation.
+
+
+
+APPENDIX I
+
+SIMPLE DERIVATION OF THE LORENTZ TRANSFORMATION
+(SUPPLEMENTARY TO SECTION 11)
+
+
+For the relative orientation of the co-ordinate systems indicated in
+Fig. 2, the x-axes of both systems pernumently coincide. In the
+present case we can divide the problem into parts by considering first
+only events which are localised on the x-axis. Any such event is
+represented with respect to the co-ordinate system K by the abscissa x
+and the time t, and with respect to the system K1 by the abscissa x'
+and the time t'. We require to find x' and t' when x and t are given.
+
+A light-signal, which is proceeding along the positive axis of x, is
+transmitted according to the equation
+
+                                x = ct
+
+or
+
+                 x - ct = 0     .     .     .    (1).
+
+Since the same light-signal has to be transmitted relative to K1 with
+the velocity c, the propagation relative to the system K1 will be
+represented by the analogous formula
+
+                x' - ct' = O     .     .     .    (2)
+
+Those space-time points (events) which satisfy (x) must also satisfy
+(2). Obviously this will be the case when the relation
+
+          (x' - ct') = l (x - ct)     .     .     .    (3).
+
+is fulfilled in general, where l indicates a constant ; for, according
+to (3), the disappearance of (x - ct) involves the disappearance of
+(x' - ct').
+
+If we apply quite similar considerations to light rays which are being
+transmitted along the negative x-axis, we obtain the condition
+
+           (x' + ct') = ľ(x + ct)    .     .     .    (4).
+
+By adding (or subtracting) equations (3) and (4), and introducing for
+convenience the constants a and b in place of the constants l and ľ,
+where
+
+                        eq. 29: file eq29.gif
+
+and
+
+                        eq. 30: file eq30.gif
+
+we obtain the equations
+
+                        eq. 31: file eq31.gif
+
+We should thus have the solution of our problem, if the constants a
+and b were known. These result from the following discussion.
+
+For the origin of K1 we have permanently x' = 0, and hence according
+to the first of the equations (5)
+
+                        eq. 32: file eq32.gif
+
+If we call v the velocity with which the origin of K1 is moving
+relative to K, we then have
+
+                        eq. 33: file eq33.gif
+
+The same value v can be obtained from equations (5), if we calculate
+the velocity of another point of K1 relative to K, or the velocity
+(directed towards the negative x-axis) of a point of K with respect to
+K'. In short, we can designate v as the relative velocity of the two
+systems.
+
+Furthermore, the principle of relativity teaches us that, as judged
+from K, the length of a unit measuring-rod which is at rest with
+reference to K1 must be exactly the same as the length, as judged from
+K', of a unit measuring-rod which is at rest relative to K. In order
+to see how the points of the x-axis appear as viewed from K, we only
+require to take a " snapshot " of K1 from K; this means that we have
+to insert a particular value of t (time of K), e.g. t = 0. For this
+value of t we then obtain from the first of the equations (5)
+
+                               x' = ax
+
+Two points of the x'-axis which are separated by the distance Dx' = I
+when measured in the K1 system are thus separated in our instantaneous
+photograph by the distance
+
+                        eq. 34: file eq34.gif
+
+But if the snapshot be taken from K'(t' = 0), and if we eliminate t
+from the equations (5), taking into account the expression (6), we
+obtain
+
+                        eq. 35: file eq35.gif
+
+From this we conclude that two points on the x-axis separated by the
+distance I (relative to K) will be represented on our snapshot by the
+distance
+
+                        eq. 36: file eq36.gif
+
+But from what has been said, the two snapshots must be identical;
+hence Dx in (7) must be equal to Dx' in (7a), so that we obtain
+
+                        eq. 37: file eq37.gif
+
+The equations (6) and (7b) determine the constants a and b. By
+inserting the values of these constants in (5), we obtain the first
+and the fourth of the equations given in Section 11.
+
+                        eq. 38: file eq38.gif
+
+Thus we have obtained the Lorentz transformation for events on the
+x-axis. It satisfies the condition
+
+         x'2 - c^2t'2 = x2 - c^2t2    .     .     .    (8a).
+
+The extension of this result, to include events which take place
+outside the x-axis, is obtained by retaining equations (8) and
+supplementing them by the relations
+
+                        eq. 39: file eq39.gif
+
+In this way we satisfy the postulate of the constancy of the velocity
+of light in vacuo for rays of light of arbitrary direction, both for
+the system K and for the system K'. This may be shown in the following
+manner.
+
+We suppose a light-signal sent out from the origin of K at the time t
+= 0. It will be propagated according to the equation
+
+                        eq. 40: file eq40.gif
+
+or, if we square this equation, according to the equation
+
+          x2 + y2 + z2 = c^2t2 = 0    .     .     .    (10).
+
+It is required by the law of propagation of light, in conjunction with
+the postulate of relativity, that the transmission of the signal in
+question should take place -- as judged from K1 -- in accordance with
+the corresponding formula
+
+                               r' = ct'
+
+or,
+
+       x'2 + y'2 + z'2 - c^2t'2 = 0    .     .     .    (10a).
+
+In order that equation (10a) may be a consequence of equation (10), we
+must have
+
+   x'2 + y'2 + z'2 - c^2t'2 = s (x2 + y2 + z2 - c^2t2)       (11).
+
+Since equation (8a) must hold for points on the x-axis, we thus have s
+= I. It is easily seen that the Lorentz transformation really
+satisfies equation (11) for s = I; for (11) is a consequence of (8a)
+and (9), and hence also of (8) and (9). We have thus derived the
+Lorentz transformation.
+
+The Lorentz transformation represented by (8) and (9) still requires
+to be generalised. Obviously it is immaterial whether the axes of K1
+be chosen so that they are spatially parallel to those of K. It is
+also not essential that the velocity of translation of K1 with respect
+to K should be in the direction of the x-axis. A simple consideration
+shows that we are able to construct the Lorentz transformation in this
+general sense from two kinds of transformations, viz. from Lorentz
+transformations in the special sense and from purely spatial
+transformations. which corresponds to the replacement of the
+rectangular co-ordinate system by a new system with its axes pointing
+in other directions.
+
+Mathematically, we can characterise the generalised Lorentz
+transformation thus :
+
+It expresses x', y', x', t', in terms of linear homogeneous functions
+of x, y, x, t, of such a kind that the relation
+
+     x'2 + y'2 + z'2 - c^2t'2 = x2 + y2 + z2 - c^2t2       (11a).
+
+is satisficd identically. That is to say: If we substitute their
+expressions in x, y, x, t, in place of x', y', x', t', on the
+left-hand side, then the left-hand side of (11a) agrees with the
+right-hand side.
+
+
+
+APPENDIX II
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE ("WORLD")
+(SUPPLEMENTARY TO SECTION 17)
+
+
+We can characterise the Lorentz transformation still more simply if we
+introduce the imaginary eq. 25 in place of t, as time-variable. If, in
+accordance with this, we insert
+
+                              x[1] = x
+                              x[2] = y
+                              x[3] = z
+                              x[4] = eq. 25
+
+and similarly for the accented system K1, then the condition which is
+identically satisfied by the transformation can be expressed thus :
+
+x[1]'2 + x[2]'2 + x[3]'2 + x[4]'2 = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    (12).
+
+That is, by the afore-mentioned choice of " coordinates," (11a) [see
+the end of Appendix II] is transformed into this equation.
+
+We see from (12) that the imaginary time co-ordinate x[4], enters into
+the condition of transformation in exactly the same way as the space
+co-ordinates x[1], x[2], x[3]. It is due to this fact that, according
+to the theory of relativity, the " time "x[4], enters into natural
+laws in the same form as the space co ordinates x[1], x[2], x[3].
+
+A four-dimensional continuum described by the "co-ordinates" x[1],
+x[2], x[3], x[4], was called "world" by Minkowski, who also termed a
+point-event a " world-point." From a "happening" in three-dimensional
+space, physics becomes, as it were, an " existence " in the
+four-dimensional " world."
+
+This four-dimensional " world " bears a close similarity to the
+three-dimensional " space " of (Euclidean) analytical geometry. If we
+introduce into the latter a new Cartesian co-ordinate system (x'[1],
+x'[2], x'[3]) with the same origin, then x'[1], x'[2], x'[3], are
+linear homogeneous functions of x[1], x[2], x[3] which identically
+satisfy the equation
+
+        x'[1]^2 + x'[2]^2 + x'[3]^2 = x[1]^2 + x[2]^2 + x[3]^2
+
+The analogy with (12) is a complete one. We can regard Minkowski's "
+world " in a formal manner as a four-dimensional Euclidean space (with
+an imaginary time coordinate) ; the Lorentz transformation corresponds
+to a " rotation " of the co-ordinate system in the fourdimensional "
+world."
+
+
+
+APPENDIX III
+
+THE EXPERIMENTAL CONFIRMATION OF THE GENERAL THEORY OF RELATIVITY
+
+
+From a systematic theoretical point of view, we may imagine the
+process of evolution of an empirical science to be a continuous
+process of induction. Theories are evolved and are expressed in short
+compass as statements of a large number of individual observations in
+the form of empirical laws, from which the general laws can be
+ascertained by comparison. Regarded in this way, the development of a
+science bears some resemblance to the compilation of a classified
+catalogue. It is, as it were, a purely empirical enterprise.
+
+But this point of view by no means embraces the whole of the actual
+process ; for it slurs over the important part played by intuition and
+deductive thought in the development of an exact science. As soon as a
+science has emerged from its initial stages, theoretical advances are
+no longer achieved merely by a process of arrangement. Guided by
+empirical data, the investigator rather develops a system of thought
+which, in general, is built up logically from a small number of
+fundamental assumptions, the so-called axioms. We call such a system
+of thought a theory. The theory finds the justification for its
+existence in the fact that it correlates a large number of single
+observations, and it is just here that the " truth " of the theory
+lies.
+
+Corresponding to the same complex of empirical data, there may be
+several theories, which differ from one another to a considerable
+extent. But as regards the deductions from the theories which are
+capable of being tested, the agreement between the theories may be so
+complete that it becomes difficult to find any deductions in which the
+two theories differ from each other. As an example, a case of general
+interest is available in the province of biology, in the Darwinian
+theory of the development of species by selection in the struggle for
+existence, and in the theory of development which is based on the
+hypothesis of the hereditary transmission of acquired characters.
+
+We have another instance of far-reaching agreement between the
+deductions from two theories in Newtonian mechanics on the one hand,
+and the general theory of relativity on the other. This agreement goes
+so far, that up to the preseat we have been able to find only a few
+deductions from the general theory of relativity which are capable of
+investigation, and to which the physics of pre-relativity days does
+not also lead, and this despite the profound difference in the
+fundamental assumptions of the two theories. In what follows, we shall
+again consider these important deductions, and we shall also discuss
+the empirical evidence appertaining to them which has hitherto been
+obtained.
+
+ (a) Motion of the Perihelion of Mercury
+
+According to Newtonian mechanics and Newton's law of gravitation, a
+planet which is revolving round the sun would describe an ellipse
+round the latter, or, more correctly, round the common centre of
+gravity of the sun and the planet. In such a system, the sun, or the
+common centre of gravity, lies in one of the foci of the orbital
+ellipse in such a manner that, in the course of a planet-year, the
+distance sun-planet grows from a minimum to a maximum, and then
+decreases again to a minimum. If instead of Newton's law we insert a
+somewhat different law of attraction into the calculation, we find
+that, according to this new law, the motion would still take place in
+such a manner that the distance sun-planet exhibits periodic
+variations; but in this case the angle described by the line joining
+sun and planet during such a period (from perihelion--closest
+proximity to the sun--to perihelion) would differ from 360^0. The line
+of the orbit would not then be a closed one but in the course of time
+it would fill up an annular part of the orbital plane, viz. between
+the circle of least and the circle of greatest distance of the planet
+from the sun.
+
+According also to the general theory of relativity, which differs of
+course from the theory of Newton, a small variation from the
+Newton-Kepler motion of a planet in its orbit should take place, and
+in such away, that the angle described by the radius sun-planet
+between one perhelion and the next should exceed that corresponding to
+one complete revolution by an amount given by
+
+                        eq. 41: file eq41.gif
+
+(N.B. -- One complete revolution corresponds to the angle 2p in the
+absolute angular measure customary in physics, and the above
+expression giver the amount by which the radius sun-planet exceeds
+this angle during the interval between one perihelion and the next.)
+In this expression a represents the major semi-axis of the ellipse, e
+its eccentricity, c the velocity of light, and T the period of
+revolution of the planet. Our result may also be stated as follows :
+According to the general theory of relativity, the major axis of the
+ellipse rotates round the sun in the same sense as the orbital motion
+of the planet. Theory requires that this rotation should amount to 43
+seconds of arc per century for the planet Mercury, but for the other
+Planets of our solar system its magnitude should be so small that it
+would necessarily escape detection. *
+
+In point of fact, astronomers have found that the theory of Newton
+does not suffice to calculate the observed motion of Mercury with an
+exactness corresponding to that of the delicacy of observation
+attainable at the present time. After taking account of all the
+disturbing influences exerted on Mercury by the remaining planets, it
+was found (Leverrier: 1859; and Newcomb: 1895) that an unexplained
+perihelial movement of the orbit of Mercury remained over, the amount
+of which does not differ sensibly from the above mentioned +43 seconds
+of arc per century. The uncertainty of the empirical result amounts to
+a few seconds only.
+
+ (b) Deflection of Light by a Gravitational Field
+
+In Section 22 it has been already mentioned that according to the
+general theory of relativity, a ray of light will experience a
+curvature of its path when passing through a gravitational field, this
+curvature being similar to that experienced by the path of a body
+which is projected through a gravitational field. As a result of this
+theory, we should expect that a ray of light which is passing close to
+a heavenly body would be deviated towards the latter. For a ray of
+light which passes the sun at a distance of D sun-radii from its
+centre, the angle of deflection (a) should amount to
+
+                        eq. 42: file eq42.gif
+
+It may be added that, according to the theory, half of Figure 05 this
+deflection is produced by the Newtonian field of attraction of the
+sun, and the other half by the geometrical modification (" curvature
+") of space caused by the sun.
+
+This result admits of an experimental test by means of the
+photographic registration of stars during a total eclipse of the sun.
+The only reason why we must wait for a total eclipse is because at
+every other time the atmosphere is so strongly illuminated by the
+light from the sun that the stars situated near the sun's disc are
+invisible. The predicted effect can be seen clearly from the
+accompanying diagram. If the sun (S) were not present, a star which is
+practically infinitely distant would be seen in the direction D[1], as
+observed front the earth. But as a consequence of the deflection of
+light from the star by the sun, the star will be seen in the direction
+D[2], i.e. at a somewhat greater distance from the centre of the sun
+than corresponds to its real position.
+
+In practice, the question is tested in the following way. The stars in
+the neighbourhood of the sun are photographed during a solar eclipse.
+In addition, a second photograph of the same stars is taken when the
+sun is situated at another position in the sky, i.e. a few months
+earlier or later. As compared whh the standard photograph, the
+positions of the stars on the eclipse-photograph ought to appear
+displaced radially outwards (away from the centre of the sun) by an
+amount corresponding to the angle a.
+
+We are indebted to the [British] Royal Society and to the Royal
+Astronomical Society for the investigation of this important
+deduction. Undaunted by the [first world] war and by difficulties of
+both a material and a psychological nature aroused by the war, these
+societies equipped two expeditions -- to Sobral (Brazil), and to the
+island of Principe (West Africa) -- and sent several of Britain's most
+celebrated astronomers (Eddington, Cottingham, Crommelin, Davidson),
+in order to obtain photographs of the solar eclipse of 29th May, 1919.
+The relative discrepancies to be expected between the stellar
+photographs obtained during the eclipse and the comparison photographs
+amounted to a few hundredths of a millimetre only. Thus great accuracy
+was necessary in making the adjustments required for the taking of the
+photographs, and in their subsequent measurement.
+
+The results of the measurements confirmed the theory in a thoroughly
+satisfactory manner. The rectangular components of the observed and of
+the calculated deviations of the stars (in seconds of arc) are set
+forth in the following table of results :
+
+                      Table 01: file table01.gif
+
+ (c) Displacement of Spectral Lines Towards the Red
+
+In Section 23 it has been shown that in a system K1 which is in
+rotation with regard to a Galileian system K, clocks of identical
+construction, and which are considered at rest with respect to the
+rotating reference-body, go at rates which are dependent on the
+positions of the clocks. We shall now examine this dependence
+quantitatively. A clock, which is situated at a distance r from the
+centre of the disc, has a velocity relative to K which is given by
+
+                                V = wr
+
+where w represents the angular velocity of rotation of the disc K1
+with respect to K. If v[0], represents the number of ticks of the
+clock per unit time (" rate " of the clock) relative to K when the
+clock is at rest, then the " rate " of the clock (v) when it is moving
+relative to K with a velocity V, but at rest with respect to the disc,
+will, in accordance with Section 12, be given by
+
+                        eq. 43: file eq43.gif
+
+or with sufficient accuracy by
+
+                        eq. 44: file eq44.gif
+
+This expression may also be stated in the following form:
+
+                        eq. 45: file eq45.gif
+
+If we represent the difference of potential of the centrifugal force
+between the position of the clock and the centre of the disc by f,
+i.e. the work, considered negatively, which must be performed on the
+unit of mass against the centrifugal force in order to transport it
+from the position of the clock on the rotating disc to the centre of
+the disc, then we have
+
+                        eq. 46: file eq46.gif
+
+From this it follows that
+
+                        eq. 47: file eq47.gif
+
+In the first place, we see from this expression that two clocks of
+identical construction will go at different rates when situated at
+different distances from the centre of the disc. This result is aiso
+valid from the standpoint of an observer who is rotating with the
+disc.
+
+Now, as judged from the disc, the latter is in a gravititional field
+of potential f, hence the result we have obtained will hold quite
+generally for gravitational fields. Furthermore, we can regard an atom
+which is emitting spectral lines as a clock, so that the following
+statement will hold:
+
+An atom absorbs or emits light of a frequency which is dependent on
+the potential of the gravitational field in which it is situated.
+
+The frequency of an atom situated on the surface of a heavenly body
+will be somewhat less than the frequency of an atom of the same
+element which is situated in free space (or on the surface of a
+smaller celestial body).
+
+Now f = - K (M/r), where K is Newton's constant of gravitation, and M
+is the mass of the heavenly body. Thus a displacement towards the red
+ought to take place for spectral lines produced at the surface of
+stars as compared with the spectral lines of the same element produced
+at the surface of the earth, the amount of this displacement being
+
+                        eq. 48: file eq48.gif
+
+For the sun, the displacement towards the red predicted by theory
+amounts to about two millionths of the wave-length. A trustworthy
+calculation is not possible in the case of the stars, because in
+general neither the mass M nor the radius r are known.
+
+It is an open question whether or not this effect exists, and at the
+present time (1920) astronomers are working with great zeal towards
+the solution. Owing to the smallness of the effect in the case of the
+sun, it is difficult to form an opinion as to its existence. Whereas
+Grebe and Bachem (Bonn), as a result of their own measurements and
+those of Evershed and Schwarzschild on the cyanogen bands, have placed
+the existence of the effect almost beyond doubt, while other
+investigators, particularly St. John, have been led to the opposite
+opinion in consequence of their measurements.
+
+Mean displacements of lines towards the less refrangible end of the
+spectrum are certainly revealed by statistical investigations of the
+fixed stars ; but up to the present the examination of the available
+data does not allow of any definite decision being arrived at, as to
+whether or not these displacements are to be referred in reality to
+the effect of gravitation. The results of observation have been
+collected together, and discussed in detail from the standpoint of the
+question which has been engaging our attention here, in a paper by E.
+Freundlich entitled "Zur Prüfung der allgemeinen
+Relativit&umlaut;ts-Theorie" (Die Naturwissenschaften, 1919, No. 35,
+p. 520: Julius Springer, Berlin).
+
+At all events, a definite decision will be reached during the next few
+years. If the displacement of spectral lines towards the red by the
+gravitational potential does not exist, then the general theory of
+relativity will be untenable. On the other hand, if the cause of the
+displacement of spectral lines be definitely traced to the
+gravitational potential, then the study of this displacement will
+furnish us with important information as to the mass of the heavenly
+bodies. [5][A]
+
+
+  Notes
+
+*) Especially since the next planet Venus has an orbit that is
+almost an exact circle, which makes it more difficult to locate the
+perihelion with precision.
+
+The displacentent of spectral lines towards the red end of the
+spectrum was definitely established by Adams in 1924, by observations
+on the dense companion of Sirius, for which the effect is about thirty
+times greater than for the Sun. R.W.L. -- translator
+
+
+
+APPENDIX IV
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+(SUPPLEMENTARY TO SECTION 32)
+
+
+Since the publication of the first edition of this little book, our
+knowledge about the structure of space in the large (" cosmological
+problem ") has had an important development, which ought to be
+mentioned even in a popular presentation of the subject.
+
+My original considerations on the subject were based on two
+hypotheses:
+
+(1) There exists an average density of matter in the whole of space
+which is everywhere the same and different from zero.
+
+(2) The magnitude (" radius ") of space is independent of time.
+
+Both these hypotheses proved to be consistent, according to the
+general theory of relativity, but only after a hypothetical term was
+added to the field equations, a term which was not required by the
+theory as such nor did it seem natural from a theoretical point of
+view (" cosmological term of the field equations ").
+
+Hypothesis (2) appeared unavoidable to me at the time, since I thought
+that one would get into bottomless speculations if one departed from
+it.
+
+However, already in the 'twenties, the Russian mathematician Friedman
+showed that a different hypothesis was natural from a purely
+theoretical point of view. He realized that it was possible to
+preserve hypothesis (1) without introducing the less natural
+cosmological term into the field equations of gravitation, if one was
+ready to drop hypothesis (2). Namely, the original field equations
+admit a solution in which the " world radius " depends on time
+(expanding space). In that sense one can say, according to Friedman,
+that the theory demands an expansion of space.
+
+A few years later Hubble showed, by a special investigation of the
+extra-galactic nebulae (" milky ways "), that the spectral lines
+emitted showed a red shift which increased regularly with the distance
+of the nebulae. This can be interpreted in regard to our present
+knowledge only in the sense of Doppler's principle, as an expansive
+motion of the system of stars in the large -- as required, according
+to Friedman, by the field equations of gravitation. Hubble's discovery
+can, therefore, be considered to some extent as a confirmation of the
+theory.
+
+There does arise, however, a strange difficulty. The interpretation of
+the galactic line-shift discovered by Hubble as an expansion (which
+can hardly be doubted from a theoretical point of view), leads to an
+origin of this expansion which lies " only " about 10^9 years ago,
+while physical astronomy makes it appear likely that the development
+of individual stars and systems of stars takes considerably longer. It
+is in no way known how this incongruity is to be overcome.
+
+I further want to rernark that the theory of expanding space, together
+with the empirical data of astronomy, permit no decision to be reached
+about the finite or infinite character of (three-dimensional) space,
+while the original " static " hypothesis of space yielded the closure
+(finiteness) of space.
+
+
+K = co-ordinate system
+x, y = two-dimensional co-ordinates
+x, y, z = three-dimensional co-ordinates
+x, y, z, t = four-dimensional co-ordinates
+
+t = time
+I = distance
+v = velocity
+
+F = force
+G = gravitational field
+
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+This file should be named 5001.zip and contains numerous
+image files for equations.
+
+Project Gutenberg eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the US
+unless a copyright notice is included.  Thus, we usually do not
+keep eBooks in compliance with any particular paper edition.
+
+We are now trying to release all our eBooks one year in advance
+of the official release dates, leaving time for better editing.
+Please be encouraged to tell us about any error or corrections,
+even years after the official publication date.
+
+Please note neither this listing nor its contents are final til
+midnight of the last day of the month of any such announcement.
+The official release date of all Project Gutenberg eBooks is at
+Midnight, Central Time, of the last day of the stated month.  A
+preliminary version may often be posted for suggestion, comment
+and editing by those who wish to do so.
+
+Most people start at our Web sites at:
+http://gutenberg.net or
+http://promo.net/pg
+
+These Web sites include award-winning information about Project
+Gutenberg, including how to donate, how to help produce our new
+eBooks, and how to subscribe to our email newsletter (free!).
+
+
+Those of you who want to download any eBook before announcement
+can get to them as follows, and just download by date.  This is
+also a good way to get them instantly upon announcement, as the
+indexes our cataloguers produce obviously take a while after an
+announcement goes out in the Project Gutenberg Newsletter.
+
+http://www.ibiblio.org/gutenberg/etext03 or
+ftp://ftp.ibiblio.org/pub/docs/books/gutenberg/etext03
+
+Or /etext02, 01, 00, 99, 98, 97, 96, 95, 94, 93, 92, 92, 91 or 90
+
+Just search by the first five letters of the filename you want,
+as it appears in our Newsletters.
+
+
+Information about Project Gutenberg (one page)
+
+We produce about two million dollars for each hour we work.  The
+time it takes us, a rather conservative estimate, is fifty hours
+to get any eBook selected, entered, proofread, edited, copyright
+searched and analyzed, the copyright letters written, etc.   Our
+projected audience is one hundred million readers.  If the value
+per text is nominally estimated at one dollar then we produce $2
+million dollars per hour in 2002 as we release over 100 new text
+files per month:  1240 more eBooks in 2001 for a total of 4000+
+We are already on our way to trying for 2000 more eBooks in 2002
+If they reach just 1-2% of the world's population then the total
+will reach over half a trillion eBooks given away by year's end.
+
+The Goal of Project Gutenberg is to Give Away 1 Trillion eBooks!
+This is ten thousand titles each to one hundred million readers,
+which is only about 4% of the present number of computer users.
+
+Here is the briefest record of our progress (* means estimated):
+
+eBooks Year Month
+
+    1  1971 July
+   10  1991 January
+  100  1994 January
+ 1000  1997 August
+ 1500  1998 October
+ 2000  1999 December
+ 2500  2000 December
+ 3000  2001 November
+ 4000  2001 October/November
+ 6000  2002 December*
+ 9000  2003 November*
+10000  2004 January*
+
+
+The Project Gutenberg Literary Archive Foundation has been created
+to secure a future for Project Gutenberg into the next millennium.
+
+We need your donations more than ever!
+
+As of February, 2002, contributions are being solicited from people
+and organizations in: Alabama, Alaska, Arkansas, Connecticut,
+Delaware, District of Columbia, Florida, Georgia, Hawaii, Illinois,
+Indiana, Iowa, Kansas, Kentucky, Louisiana, Maine, Massachusetts,
+Michigan, Mississippi, Missouri, Montana, Nebraska, Nevada, New
+Hampshire, New Jersey, New Mexico, New York, North Carolina, Ohio,
+Oklahoma, Oregon, Pennsylvania, Rhode Island, South Carolina, South
+Dakota, Tennessee, Texas, Utah, Vermont, Virginia, Washington, West
+Virginia, Wisconsin, and Wyoming.
+
+We have filed in all 50 states now, but these are the only ones
+that have responded.
+
+As the requirements for other states are met, additions to this list
+will be made and fund raising will begin in the additional states.
+Please feel free to ask to check the status of your state.
+
+In answer to various questions we have received on this:
+
+We are constantly working on finishing the paperwork to legally
+request donations in all 50 states.  If your state is not listed and
+you would like to know if we have added it since the list you have,
+just ask.
+
+While we cannot solicit donations from people in states where we are
+not yet registered, we know of no prohibition against accepting
+donations from donors in these states who approach us with an offer to
+donate.
+
+International donations are accepted, but we don't know ANYTHING about
+how to make them tax-deductible, or even if they CAN be made
+deductible, and don't have the staff to handle it even if there are
+ways.
+
+Donations by check or money order may be sent to:
+
+Project Gutenberg Literary Archive Foundation
+PMB 113
+1739 University Ave.
+Oxford, MS 38655-4109
+
+Contact us if you want to arrange for a wire transfer or payment
+method other than by check or money order.
+
+The Project Gutenberg Literary Archive Foundation has been approved by
+the US Internal Revenue Service as a 501(c)(3) organization with EIN
+[Employee Identification Number] 64-622154.  Donations are
+tax-deductible to the maximum extent permitted by law.  As fund-raising
+requirements for other states are met, additions to this list will be
+made and fund-raising will begin in the additional states.
+
+We need your donations more than ever!
+
+You can get up to date donation information online at:
+
+http://www.gutenberg.net/donation.html
+
+
+***
+
+If you can't reach Project Gutenberg,
+you can always email directly to:
+
+Michael S. Hart <hart@pobox.com>
+
+Prof. Hart will answer or forward your message.
+
+We would prefer to send you information by email.
+
+
+**The Legal Small Print**
+
+
+(Three Pages)
+
+***START**THE SMALL PRINT!**FOR PUBLIC DOMAIN EBOOKS**START***
+Why is this "Small Print!" statement here? You know: lawyers.
+They tell us you might sue us if there is something wrong with
+your copy of this eBook, even if you got it for free from
+someone other than us, and even if what's wrong is not our
+fault. So, among other things, this "Small Print!" statement
+disclaims most of our liability to you. It also tells you how
+you may distribute copies of this eBook if you want to.
+
+*BEFORE!* YOU USE OR READ THIS EBOOK
+By using or reading any part of this PROJECT GUTENBERG-tm
+eBook, you indicate that you understand, agree to and accept
+this "Small Print!" statement. If you do not, you can receive
+a refund of the money (if any) you paid for this eBook by
+sending a request within 30 days of receiving it to the person
+you got it from. If you received this eBook on a physical
+medium (such as a disk), you must return it with your request.
+
+ABOUT PROJECT GUTENBERG-TM EBOOKS
+This PROJECT GUTENBERG-tm eBook, like most PROJECT GUTENBERG-tm eBooks,
+is a "public domain" work distributed by Professor Michael S. Hart
+through the Project Gutenberg Association (the "Project").
+Among other things, this means that no one owns a United States copyright
+on or for this work, so the Project (and you!) can copy and
+distribute it in the United States without permission and
+without paying copyright royalties. Special rules, set forth
+below, apply if you wish to copy and distribute this eBook
+under the "PROJECT GUTENBERG" trademark.
+
+Please do not use the "PROJECT GUTENBERG" trademark to market
+any commercial products without permission.
+
+To create these eBooks, the Project expends considerable
+efforts to identify, transcribe and proofread public domain
+works. Despite these efforts, the Project's eBooks and any
+medium they may be on may contain "Defects". Among other
+things, Defects may take the form of incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged
+disk or other eBook medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+LIMITED WARRANTY; DISCLAIMER OF DAMAGES
+But for the "Right of Replacement or Refund" described below,
+[1] Michael Hart and the Foundation (and any other party you may
+receive this eBook from as a PROJECT GUTENBERG-tm eBook) disclaims
+all liability to you for damages, costs and expenses, including
+legal fees, and [2] YOU HAVE NO REMEDIES FOR NEGLIGENCE OR
+UNDER STRICT LIABILITY, OR FOR BREACH OF WARRANTY OR CONTRACT,
+INCLUDING BUT NOT LIMITED TO INDIRECT, CONSEQUENTIAL, PUNITIVE
+OR INCIDENTAL DAMAGES, EVEN IF YOU GIVE NOTICE OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+If you discover a Defect in this eBook within 90 days of
+receiving it, you can receive a refund of the money (if any)
+you paid for it by sending an explanatory note within that
+time to the person you received it from. If you received it
+on a physical medium, you must return it with your note, and
+such person may choose to alternatively give you a replacement
+copy. If you received it electronically, such person may
+choose to alternatively give you a second opportunity to
+receive it electronically.
+
+THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS". NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, ARE MADE TO YOU AS
+TO THE EBOOK OR ANY MEDIUM IT MAY BE ON, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+Some states do not allow disclaimers of implied warranties or
+the exclusion or limitation of consequential damages, so the
+above disclaimers and exclusions may not apply to you, and you
+may have other legal rights.
+
+INDEMNITY
+You will indemnify and hold Michael Hart, the Foundation,
+and its trustees and agents, and any volunteers associated
+with the production and distribution of Project Gutenberg-tm
+texts harmless, from all liability, cost and expense, including
+legal fees, that arise directly or indirectly from any of the
+following that you do or cause:  [1] distribution of this eBook,
+[2] alteration, modification, or addition to the eBook,
+or [3] any Defect.
+
+DISTRIBUTION UNDER "PROJECT GUTENBERG-tm"
+You may distribute copies of this eBook electronically, or by
+disk, book or any other medium if you either delete this
+"Small Print!" and all other references to Project Gutenberg,
+or:
+
+[1]  Only give exact copies of it.  Among other things, this
+     requires that you do not remove, alter or modify the
+     eBook or this "small print!" statement.  You may however,
+     if you wish, distribute this eBook in machine readable
+     binary, compressed, mark-up, or proprietary form,
+     including any form resulting from conversion by word
+     processing or hypertext software, but only so long as
+     *EITHER*:
+
+     [*]  The eBook, when displayed, is clearly readable, and
+          does *not* contain characters other than those
+          intended by the author of the work, although tilde
+          (~), asterisk (*) and underline (_) characters may
+          be used to convey punctuation intended by the
+          author, and additional characters may be used to
+          indicate hypertext links; OR
+
+     [*]  The eBook may be readily converted by the reader at
+          no expense into plain ASCII, EBCDIC or equivalent
+          form by the program that displays the eBook (as is
+          the case, for instance, with most word processors);
+          OR
+
+     [*]  You provide, or agree to also provide on request at
+          no additional cost, fee or expense, a copy of the
+          eBook in its original plain ASCII form (or in EBCDIC
+          or other equivalent proprietary form).
+
+[2]  Honor the eBook refund and replacement provisions of this
+     "Small Print!" statement.
+
+[3]  Pay a trademark license fee to the Foundation of 20% of the
+     gross profits you derive calculated using the method you
+     already use to calculate your applicable taxes.  If you
+     don't derive profits, no royalty is due.  Royalties are
+     payable to "Project Gutenberg Literary Archive Foundation"
+     the 60 days following each date you prepare (or were
+     legally required to prepare) your annual (or equivalent
+     periodic) tax return.  Please contact us beforehand to
+     let us know your plans and to work out the details.
+
+WHAT IF YOU *WANT* TO SEND MONEY EVEN IF YOU DON'T HAVE TO?
+Project Gutenberg is dedicated to increasing the number of
+public domain and licensed works that can be freely distributed
+in machine readable form.
+
+The Project gratefully accepts contributions of money, time,
+public domain materials, or royalty free copyright licenses.
+Money should be paid to the:
+"Project Gutenberg Literary Archive Foundation."
+
+If you are interested in contributing scanning equipment or
+software or other items, please contact Michael Hart at:
+hart@pobox.com
+
+[Portions of this eBook's header and trailer may be reprinted only
+when distributed free of all fees.  Copyright (C) 2001, 2002 by
+Michael S. Hart.  Project Gutenberg is a TradeMark and may not be
+used in any sales of Project Gutenberg eBooks or other materials be
+they hardware or software or any other related product without
+express permission.]
+
+*END THE SMALL PRINT! FOR PUBLIC DOMAIN EBOOKS*Ver.02/11/02*END*

--- a/jet/hadoop/src/main/resources/books/through-the-looking-glass.txt
+++ b/jet/hadoop/src/main/resources/books/through-the-looking-glass.txt
@@ -1,0 +1,4306 @@
+﻿The Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson                         AKA Lewis Carroll
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Through the Looking-Glass
+
+Author: Charles Dodgson, AKA Lewis Carroll
+
+Posting Date: June 25, 2008 [EBook #12]
+Release Date: February, 1991
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+
+
+
+
+
+
+
+
+
+THROUGH THE LOOKING-GLASS
+
+By Lewis Carroll
+
+
+The Millennium Fulcrum Edition 1.7
+
+
+
+
+CHAPTER I. Looking-Glass house
+
+One thing was certain, that the WHITE kitten had had nothing to do with
+it:--it was the black kitten’s fault entirely. For the white kitten had
+been having its face washed by the old cat for the last quarter of
+an hour (and bearing it pretty well, considering); so you see that it
+COULDN’T have had any hand in the mischief.
+
+The way Dinah washed her children’s faces was this: first she held the
+poor thing down by its ear with one paw, and then with the other paw she
+rubbed its face all over, the wrong way, beginning at the nose: and
+just now, as I said, she was hard at work on the white kitten, which was
+lying quite still and trying to purr--no doubt feeling that it was all
+meant for its good.
+
+But the black kitten had been finished with earlier in the afternoon,
+and so, while Alice was sitting curled up in a corner of the great
+arm-chair, half talking to herself and half asleep, the kitten had been
+having a grand game of romps with the ball of worsted Alice had been
+trying to wind up, and had been rolling it up and down till it had all
+come undone again; and there it was, spread over the hearth-rug, all
+knots and tangles, with the kitten running after its own tail in the
+middle.
+
+‘Oh, you wicked little thing!’ cried Alice, catching up the kitten, and
+giving it a little kiss to make it understand that it was in disgrace.
+‘Really, Dinah ought to have taught you better manners! You OUGHT,
+Dinah, you know you ought!’ she added, looking reproachfully at the old
+cat, and speaking in as cross a voice as she could manage--and then she
+scrambled back into the arm-chair, taking the kitten and the worsted
+with her, and began winding up the ball again. But she didn’t get on
+very fast, as she was talking all the time, sometimes to the kitten, and
+sometimes to herself. Kitty sat very demurely on her knee, pretending to
+watch the progress of the winding, and now and then putting out one
+paw and gently touching the ball, as if it would be glad to help, if it
+might.
+
+‘Do you know what to-morrow is, Kitty?’ Alice began. ‘You’d have guessed
+if you’d been up in the window with me--only Dinah was making you tidy,
+so you couldn’t. I was watching the boys getting in sticks for the
+bonfire--and it wants plenty of sticks, Kitty! Only it got so cold, and
+it snowed so, they had to leave off. Never mind, Kitty, we’ll go and
+see the bonfire to-morrow.’ Here Alice wound two or three turns of the
+worsted round the kitten’s neck, just to see how it would look: this led
+to a scramble, in which the ball rolled down upon the floor, and yards
+and yards of it got unwound again.
+
+‘Do you know, I was so angry, Kitty,’ Alice went on as soon as they were
+comfortably settled again, ‘when I saw all the mischief you had been
+doing, I was very nearly opening the window, and putting you out into
+the snow! And you’d have deserved it, you little mischievous darling!
+What have you got to say for yourself? Now don’t interrupt me!’ she
+went on, holding up one finger. ‘I’m going to tell you all your faults.
+Number one: you squeaked twice while Dinah was washing your face this
+morning. Now you can’t deny it, Kitty: I heard you! What’s that you
+say?’ (pretending that the kitten was speaking.) ‘Her paw went into your
+eye? Well, that’s YOUR fault, for keeping your eyes open--if you’d
+shut them tight up, it wouldn’t have happened. Now don’t make any more
+excuses, but listen! Number two: you pulled Snowdrop away by the tail
+just as I had put down the saucer of milk before her! What, you were
+thirsty, were you? How do you know she wasn’t thirsty too? Now for
+number three: you unwound every bit of the worsted while I wasn’t
+looking!
+
+‘That’s three faults, Kitty, and you’ve not been punished for any of
+them yet. You know I’m saving up all your punishments for Wednesday
+week--Suppose they had saved up all MY punishments!’ she went on,
+talking more to herself than the kitten. ‘What WOULD they do at the end
+of a year? I should be sent to prison, I suppose, when the day came.
+Or--let me see--suppose each punishment was to be going without a
+dinner: then, when the miserable day came, I should have to go without
+fifty dinners at once! Well, I shouldn’t mind THAT much! I’d far rather
+go without them than eat them!
+
+‘Do you hear the snow against the window-panes, Kitty? How nice and soft
+it sounds! Just as if some one was kissing the window all over outside.
+I wonder if the snow LOVES the trees and fields, that it kisses them so
+gently? And then it covers them up snug, you know, with a white quilt;
+and perhaps it says, “Go to sleep, darlings, till the summer comes
+again.” And when they wake up in the summer, Kitty, they dress
+themselves all in green, and dance about--whenever the wind blows--oh,
+that’s very pretty!’ cried Alice, dropping the ball of worsted to clap
+her hands. ‘And I do so WISH it was true! I’m sure the woods look sleepy
+in the autumn, when the leaves are getting brown.
+
+‘Kitty, can you play chess? Now, don’t smile, my dear, I’m asking it
+seriously. Because, when we were playing just now, you watched just as
+if you understood it: and when I said “Check!” you purred! Well, it WAS
+a nice check, Kitty, and really I might have won, if it hadn’t been for
+that nasty Knight, that came wiggling down among my pieces. Kitty, dear,
+let’s pretend--’ And here I wish I could tell you half the things Alice
+used to say, beginning with her favourite phrase ‘Let’s pretend.’ She
+had had quite a long argument with her sister only the day before--all
+because Alice had begun with ‘Let’s pretend we’re kings and queens;’ and
+her sister, who liked being very exact, had argued that they couldn’t,
+because there were only two of them, and Alice had been reduced at last
+to say, ‘Well, YOU can be one of them then, and I’LL be all the rest.’
+And once she had really frightened her old nurse by shouting suddenly in
+her ear, ‘Nurse! Do let’s pretend that I’m a hungry hyaena, and you’re a
+bone.’
+
+But this is taking us away from Alice’s speech to the kitten. ‘Let’s
+pretend that you’re the Red Queen, Kitty! Do you know, I think if you
+sat up and folded your arms, you’d look exactly like her. Now do try,
+there’s a dear!’ And Alice got the Red Queen off the table, and set it
+up before the kitten as a model for it to imitate: however, the thing
+didn’t succeed, principally, Alice said, because the kitten wouldn’t
+fold its arms properly. So, to punish it, she held it up to the
+Looking-glass, that it might see how sulky it was--‘and if you’re not
+good directly,’ she added, ‘I’ll put you through into Looking-glass
+House. How would you like THAT?’
+
+‘Now, if you’ll only attend, Kitty, and not talk so much, I’ll tell you
+all my ideas about Looking-glass House. First, there’s the room you can
+see through the glass--that’s just the same as our drawing room, only
+the things go the other way. I can see all of it when I get upon a
+chair--all but the bit behind the fireplace. Oh! I do so wish I could
+see THAT bit! I want so much to know whether they’ve a fire in the
+winter: you never CAN tell, you know, unless our fire smokes, and then
+smoke comes up in that room too--but that may be only pretence, just to
+make it look as if they had a fire. Well then, the books are something
+like our books, only the words go the wrong way; I know that, because
+I’ve held up one of our books to the glass, and then they hold up one in
+the other room.
+
+‘How would you like to live in Looking-glass House, Kitty? I wonder if
+they’d give you milk in there? Perhaps Looking-glass milk isn’t good
+to drink--But oh, Kitty! now we come to the passage. You can just see a
+little PEEP of the passage in Looking-glass House, if you leave the door
+of our drawing-room wide open: and it’s very like our passage as far
+as you can see, only you know it may be quite different on beyond.
+Oh, Kitty! how nice it would be if we could only get through into
+Looking-glass House! I’m sure it’s got, oh! such beautiful things in it!
+Let’s pretend there’s a way of getting through into it, somehow, Kitty.
+Let’s pretend the glass has got all soft like gauze, so that we can get
+through. Why, it’s turning into a sort of mist now, I declare! It’ll be
+easy enough to get through--’ She was up on the chimney-piece while she
+said this, though she hardly knew how she had got there. And certainly
+the glass WAS beginning to melt away, just like a bright silvery mist.
+
+In another moment Alice was through the glass, and had jumped lightly
+down into the Looking-glass room. The very first thing she did was
+to look whether there was a fire in the fireplace, and she was quite
+pleased to find that there was a real one, blazing away as brightly as
+the one she had left behind. ‘So I shall be as warm here as I was in the
+old room,’ thought Alice: ‘warmer, in fact, because there’ll be no one
+here to scold me away from the fire. Oh, what fun it’ll be, when they
+see me through the glass in here, and can’t get at me!’
+
+Then she began looking about, and noticed that what could be seen from
+the old room was quite common and uninteresting, but that all the rest
+was as different as possible. For instance, the pictures on the
+wall next the fire seemed to be all alive, and the very clock on
+the chimney-piece (you know you can only see the back of it in the
+Looking-glass) had got the face of a little old man, and grinned at her.
+
+‘They don’t keep this room so tidy as the other,’ Alice thought to
+herself, as she noticed several of the chessmen down in the hearth among
+the cinders: but in another moment, with a little ‘Oh!’ of surprise, she
+was down on her hands and knees watching them. The chessmen were walking
+about, two and two!
+
+‘Here are the Red King and the Red Queen,’ Alice said (in a whisper, for
+fear of frightening them), ‘and there are the White King and the White
+Queen sitting on the edge of the shovel--and here are two castles
+walking arm in arm--I don’t think they can hear me,’ she went on, as she
+put her head closer down, ‘and I’m nearly sure they can’t see me. I feel
+somehow as if I were invisible--’
+
+Here something began squeaking on the table behind Alice, and made her
+turn her head just in time to see one of the White Pawns roll over and
+begin kicking: she watched it with great curiosity to see what would
+happen next.
+
+‘It is the voice of my child!’ the White Queen cried out as she rushed
+past the King, so violently that she knocked him over among the cinders.
+‘My precious Lily! My imperial kitten!’ and she began scrambling wildly
+up the side of the fender.
+
+‘Imperial fiddlestick!’ said the King, rubbing his nose, which had been
+hurt by the fall. He had a right to be a LITTLE annoyed with the Queen,
+for he was covered with ashes from head to foot.
+
+Alice was very anxious to be of use, and, as the poor little Lily was
+nearly screaming herself into a fit, she hastily picked up the Queen and
+set her on the table by the side of her noisy little daughter.
+
+The Queen gasped, and sat down: the rapid journey through the air had
+quite taken away her breath and for a minute or two she could do nothing
+but hug the little Lily in silence. As soon as she had recovered her
+breath a little, she called out to the White King, who was sitting
+sulkily among the ashes, ‘Mind the volcano!’
+
+‘What volcano?’ said the King, looking up anxiously into the fire, as if
+he thought that was the most likely place to find one.
+
+‘Blew--me--up,’ panted the Queen, who was still a little out of breath.
+‘Mind you come up--the regular way--don’t get blown up!’
+
+Alice watched the White King as he slowly struggled up from bar to bar,
+till at last she said, ‘Why, you’ll be hours and hours getting to the
+table, at that rate. I’d far better help you, hadn’t I?’ But the King
+took no notice of the question: it was quite clear that he could neither
+hear her nor see her.
+
+So Alice picked him up very gently, and lifted him across more slowly
+than she had lifted the Queen, that she mightn’t take his breath away:
+but, before she put him on the table, she thought she might as well dust
+him a little, he was so covered with ashes.
+
+She said afterwards that she had never seen in all her life such a face
+as the King made, when he found himself held in the air by an invisible
+hand, and being dusted: he was far too much astonished to cry out, but
+his eyes and his mouth went on getting larger and larger, and rounder
+and rounder, till her hand shook so with laughing that she nearly let
+him drop upon the floor.
+
+‘Oh! PLEASE don’t make such faces, my dear!’ she cried out, quite
+forgetting that the King couldn’t hear her. ‘You make me laugh so that
+I can hardly hold you! And don’t keep your mouth so wide open! All the
+ashes will get into it--there, now I think you’re tidy enough!’ she
+added, as she smoothed his hair, and set him upon the table near the
+Queen.
+
+The King immediately fell flat on his back, and lay perfectly still: and
+Alice was a little alarmed at what she had done, and went round the room
+to see if she could find any water to throw over him. However, she could
+find nothing but a bottle of ink, and when she got back with it she
+found he had recovered, and he and the Queen were talking together in a
+frightened whisper--so low, that Alice could hardly hear what they said.
+
+The King was saying, ‘I assure, you my dear, I turned cold to the very
+ends of my whiskers!’
+
+To which the Queen replied, ‘You haven’t got any whiskers.’
+
+‘The horror of that moment,’ the King went on, ‘I shall never, NEVER
+forget!’
+
+‘You will, though,’ the Queen said, ‘if you don’t make a memorandum of
+it.’
+
+Alice looked on with great interest as the King took an enormous
+memorandum-book out of his pocket, and began writing. A sudden thought
+struck her, and she took hold of the end of the pencil, which came some
+way over his shoulder, and began writing for him.
+
+The poor King looked puzzled and unhappy, and struggled with the pencil
+for some time without saying anything; but Alice was too strong for him,
+and at last he panted out, ‘My dear! I really MUST get a thinner pencil.
+I can’t manage this one a bit; it writes all manner of things that I
+don’t intend--’
+
+‘What manner of things?’ said the Queen, looking over the book (in which
+Alice had put ‘THE WHITE KNIGHT IS SLIDING DOWN THE POKER. HE BALANCES
+VERY BADLY’) ‘That’s not a memorandum of YOUR feelings!’
+
+There was a book lying near Alice on the table, and while she sat
+watching the White King (for she was still a little anxious about him,
+and had the ink all ready to throw over him, in case he fainted again),
+she turned over the leaves, to find some part that she could read,
+‘--for it’s all in some language I don’t know,’ she said to herself.
+
+It was like this.
+
+
+             YKCOWREBBAJ
+
+     sevot yhtils eht dna,gillirb sawT’
+      ebaw eht ni elbmig dna eryg diD
+        ,sevogorob eht erew ysmim llA
+       .ebargtuo shtar emom eht dnA
+
+
+She puzzled over this for some time, but at last a bright thought struck
+her. ‘Why, it’s a Looking-glass book, of course! And if I hold it up to
+a glass, the words will all go the right way again.’
+
+This was the poem that Alice read.
+
+
+             JABBERWOCKY
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+     ‘Beware the Jabberwock, my son!
+      The jaws that bite, the claws that catch!
+     Beware the Jubjub bird, and shun
+      The frumious Bandersnatch!’
+
+     He took his vorpal sword in hand:
+      Long time the manxome foe he sought--
+     So rested he by the Tumtum tree,
+      And stood awhile in thought.
+
+     And as in uffish thought he stood,
+      The Jabberwock, with eyes of flame,
+     Came whiffling through the tulgey wood,
+      And burbled as it came!
+
+     One, two! One, two! And through and through
+      The vorpal blade went snicker-snack!
+     He left it dead, and with its head
+      He went galumphing back.
+
+     ‘And hast thou slain the Jabberwock?
+      Come to my arms, my beamish boy!
+     O frabjous day! Callooh! Callay!’
+      He chortled in his joy.
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+
+‘It seems very pretty,’ she said when she had finished it, ‘but it’s
+RATHER hard to understand!’ (You see she didn’t like to confess, even
+to herself, that she couldn’t make it out at all.) ‘Somehow it seems
+to fill my head with ideas--only I don’t exactly know what they are!
+However, SOMEBODY killed SOMETHING: that’s clear, at any rate--’
+
+‘But oh!’ thought Alice, suddenly jumping up, ‘if I don’t make haste I
+shall have to go back through the Looking-glass, before I’ve seen what
+the rest of the house is like! Let’s have a look at the garden first!’
+She was out of the room in a moment, and ran down stairs--or, at least,
+it wasn’t exactly running, but a new invention of hers for getting down
+stairs quickly and easily, as Alice said to herself. She just kept the
+tips of her fingers on the hand-rail, and floated gently down without
+even touching the stairs with her feet; then she floated on through the
+hall, and would have gone straight out at the door in the same way, if
+she hadn’t caught hold of the door-post. She was getting a little giddy
+with so much floating in the air, and was rather glad to find herself
+walking again in the natural way.
+
+
+
+
+CHAPTER II. The Garden of Live Flowers
+
+‘I should see the garden far better,’ said Alice to herself, ‘if I could
+get to the top of that hill: and here’s a path that leads straight to
+it--at least, no, it doesn’t do that--’ (after going a few yards along
+the path, and turning several sharp corners), ‘but I suppose it will
+at last. But how curiously it twists! It’s more like a corkscrew than a
+path! Well, THIS turn goes to the hill, I suppose--no, it doesn’t! This
+goes straight back to the house! Well then, I’ll try it the other way.’
+
+And so she did: wandering up and down, and trying turn after turn, but
+always coming back to the house, do what she would. Indeed, once, when
+she turned a corner rather more quickly than usual, she ran against it
+before she could stop herself.
+
+‘It’s no use talking about it,’ Alice said, looking up at the house and
+pretending it was arguing with her. ‘I’m NOT going in again yet. I know
+I should have to get through the Looking-glass again--back into the old
+room--and there’d be an end of all my adventures!’
+
+So, resolutely turning her back upon the house, she set out once more
+down the path, determined to keep straight on till she got to the hill.
+For a few minutes all went on well, and she was just saying, ‘I really
+SHALL do it this time--’ when the path gave a sudden twist and shook
+itself (as she described it afterwards), and the next moment she found
+herself actually walking in at the door.
+
+‘Oh, it’s too bad!’ she cried. ‘I never saw such a house for getting in
+the way! Never!’
+
+However, there was the hill full in sight, so there was nothing to be
+done but start again. This time she came upon a large flower-bed, with a
+border of daisies, and a willow-tree growing in the middle.
+
+‘O Tiger-lily,’ said Alice, addressing herself to one that was waving
+gracefully about in the wind, ‘I WISH you could talk!’
+
+‘We CAN talk,’ said the Tiger-lily: ‘when there’s anybody worth talking
+to.’
+
+Alice was so astonished that she could not speak for a minute: it quite
+seemed to take her breath away. At length, as the Tiger-lily only went
+on waving about, she spoke again, in a timid voice--almost in a whisper.
+‘And can ALL the flowers talk?’
+
+‘As well as YOU can,’ said the Tiger-lily. ‘And a great deal louder.’
+
+‘It isn’t manners for us to begin, you know,’ said the Rose, ‘and I
+really was wondering when you’d speak! Said I to myself, “Her face has
+got SOME sense in it, though it’s not a clever one!” Still, you’re the
+right colour, and that goes a long way.’
+
+‘I don’t care about the colour,’ the Tiger-lily remarked. ‘If only her
+petals curled up a little more, she’d be all right.’
+
+Alice didn’t like being criticised, so she began asking questions.
+‘Aren’t you sometimes frightened at being planted out here, with nobody
+to take care of you?’
+
+‘There’s the tree in the middle,’ said the Rose: ‘what else is it good
+for?’
+
+‘But what could it do, if any danger came?’ Alice asked.
+
+‘It says “Bough-wough!”’ cried a Daisy: ‘that’s why its branches are
+called boughs!’
+
+‘Didn’t you know THAT?’ cried another Daisy, and here they all began
+shouting together, till the air seemed quite full of little shrill
+voices. ‘Silence, every one of you!’ cried the Tiger-lily, waving itself
+passionately from side to side, and trembling with excitement. ‘They
+know I can’t get at them!’ it panted, bending its quivering head towards
+Alice, ‘or they wouldn’t dare to do it!’
+
+‘Never mind!’ Alice said in a soothing tone, and stooping down to the
+daisies, who were just beginning again, she whispered, ‘If you don’t
+hold your tongues, I’ll pick you!’
+
+There was silence in a moment, and several of the pink daisies turned
+white.
+
+‘That’s right!’ said the Tiger-lily. ‘The daisies are worst of all. When
+one speaks, they all begin together, and it’s enough to make one wither
+to hear the way they go on!’
+
+‘How is it you can all talk so nicely?’ Alice said, hoping to get it
+into a better temper by a compliment. ‘I’ve been in many gardens before,
+but none of the flowers could talk.’
+
+‘Put your hand down, and feel the ground,’ said the Tiger-lily. ‘Then
+you’ll know why.’
+
+Alice did so. ‘It’s very hard,’ she said, ‘but I don’t see what that has
+to do with it.’
+
+‘In most gardens,’ the Tiger-lily said, ‘they make the beds too soft--so
+that the flowers are always asleep.’
+
+This sounded a very good reason, and Alice was quite pleased to know it.
+‘I never thought of that before!’ she said.
+
+‘It’s MY opinion that you never think AT ALL,’ the Rose said in a rather
+severe tone.
+
+‘I never saw anybody that looked stupider,’ a Violet said, so suddenly,
+that Alice quite jumped; for it hadn’t spoken before.
+
+‘Hold YOUR tongue!’ cried the Tiger-lily. ‘As if YOU ever saw anybody!
+You keep your head under the leaves, and snore away there, till you know
+no more what’s going on in the world, than if you were a bud!’
+
+‘Are there any more people in the garden besides me?’ Alice said, not
+choosing to notice the Rose’s last remark.
+
+‘There’s one other flower in the garden that can move about like you,’
+said the Rose. ‘I wonder how you do it--’ (‘You’re always wondering,’
+said the Tiger-lily), ‘but she’s more bushy than you are.’
+
+‘Is she like me?’ Alice asked eagerly, for the thought crossed her mind,
+‘There’s another little girl in the garden, somewhere!’
+
+‘Well, she has the same awkward shape as you,’ the Rose said, ‘but she’s
+redder--and her petals are shorter, I think.’
+
+‘Her petals are done up close, almost like a dahlia,’ the Tiger-lily
+interrupted: ‘not tumbled about anyhow, like yours.’
+
+‘But that’s not YOUR fault,’ the Rose added kindly: ‘you’re beginning
+to fade, you know--and then one can’t help one’s petals getting a little
+untidy.’
+
+Alice didn’t like this idea at all: so, to change the subject, she asked
+‘Does she ever come out here?’
+
+‘I daresay you’ll see her soon,’ said the Rose. ‘She’s one of the thorny
+kind.’
+
+‘Where does she wear the thorns?’ Alice asked with some curiosity.
+
+‘Why all round her head, of course,’ the Rose replied. ‘I was wondering
+YOU hadn’t got some too. I thought it was the regular rule.’
+
+‘She’s coming!’ cried the Larkspur. ‘I hear her footstep, thump, thump,
+thump, along the gravel-walk!’
+
+Alice looked round eagerly, and found that it was the Red Queen. ‘She’s
+grown a good deal!’ was her first remark. She had indeed: when Alice
+first found her in the ashes, she had been only three inches high--and
+here she was, half a head taller than Alice herself!
+
+‘It’s the fresh air that does it,’ said the Rose: ‘wonderfully fine air
+it is, out here.’
+
+‘I think I’ll go and meet her,’ said Alice, for, though the flowers were
+interesting enough, she felt that it would be far grander to have a talk
+with a real Queen.
+
+‘You can’t possibly do that,’ said the Rose: ‘_I_ should advise you to
+walk the other way.’
+
+This sounded nonsense to Alice, so she said nothing, but set off at
+once towards the Red Queen. To her surprise, she lost sight of her in a
+moment, and found herself walking in at the front-door again.
+
+A little provoked, she drew back, and after looking everywhere for the
+queen (whom she spied out at last, a long way off), she thought she
+would try the plan, this time, of walking in the opposite direction.
+
+It succeeded beautifully. She had not been walking a minute before she
+found herself face to face with the Red Queen, and full in sight of the
+hill she had been so long aiming at.
+
+‘Where do you come from?’ said the Red Queen. ‘And where are you going?
+Look up, speak nicely, and don’t twiddle your fingers all the time.’
+
+Alice attended to all these directions, and explained, as well as she
+could, that she had lost her way.
+
+‘I don’t know what you mean by YOUR way,’ said the Queen: ‘all the ways
+about here belong to ME--but why did you come out here at all?’ she
+added in a kinder tone. ‘Curtsey while you’re thinking what to say, it
+saves time.’
+
+Alice wondered a little at this, but she was too much in awe of the
+Queen to disbelieve it. ‘I’ll try it when I go home,’ she thought to
+herself, ‘the next time I’m a little late for dinner.’
+
+‘It’s time for you to answer now,’ the Queen said, looking at her watch:
+‘open your mouth a LITTLE wider when you speak, and always say “your
+Majesty.”’
+
+‘I only wanted to see what the garden was like, your Majesty--’
+
+‘That’s right,’ said the Queen, patting her on the head, which Alice
+didn’t like at all, ‘though, when you say “garden,”--I’VE seen gardens,
+compared with which this would be a wilderness.’
+
+Alice didn’t dare to argue the point, but went on: ‘--and I thought I’d
+try and find my way to the top of that hill--’
+
+‘When you say “hill,”’ the Queen interrupted, ‘_I_ could show you hills,
+in comparison with which you’d call that a valley.’
+
+‘No, I shouldn’t,’ said Alice, surprised into contradicting her at last:
+‘a hill CAN’T be a valley, you know. That would be nonsense--’
+
+The Red Queen shook her head, ‘You may call it “nonsense” if you like,’
+she said, ‘but I’VE heard nonsense, compared with which that would be as
+sensible as a dictionary!’
+
+Alice curtseyed again, as she was afraid from the Queen’s tone that she
+was a LITTLE offended: and they walked on in silence till they got to
+the top of the little hill.
+
+For some minutes Alice stood without speaking, looking out in all
+directions over the country--and a most curious country it was. There
+were a number of tiny little brooks running straight across it from side
+to side, and the ground between was divided up into squares by a number
+of little green hedges, that reached from brook to brook.
+
+‘I declare it’s marked out just like a large chessboard!’ Alice said at
+last. ‘There ought to be some men moving about somewhere--and so there
+are!’ She added in a tone of delight, and her heart began to beat quick
+with excitement as she went on. ‘It’s a great huge game of chess that’s
+being played--all over the world--if this IS the world at all, you know.
+Oh, what fun it is! How I WISH I was one of them! I wouldn’t mind being
+a Pawn, if only I might join--though of course I should LIKE to be a
+Queen, best.’
+
+She glanced rather shyly at the real Queen as she said this, but her
+companion only smiled pleasantly, and said, ‘That’s easily managed. You
+can be the White Queen’s Pawn, if you like, as Lily’s too young to
+play; and you’re in the Second Square to begin with: when you get to
+the Eighth Square you’ll be a Queen--’ Just at this moment, somehow or
+other, they began to run.
+
+Alice never could quite make out, in thinking it over afterwards, how it
+was that they began: all she remembers is, that they were running hand
+in hand, and the Queen went so fast that it was all she could do to keep
+up with her: and still the Queen kept crying ‘Faster! Faster!’ but Alice
+felt she COULD NOT go faster, though she had not breath left to say so.
+
+The most curious part of the thing was, that the trees and the other
+things round them never changed their places at all: however fast they
+went, they never seemed to pass anything. ‘I wonder if all the things
+move along with us?’ thought poor puzzled Alice. And the Queen seemed to
+guess her thoughts, for she cried, ‘Faster! Don’t try to talk!’
+
+Not that Alice had any idea of doing THAT. She felt as if she would
+never be able to talk again, she was getting so much out of breath: and
+still the Queen cried ‘Faster! Faster!’ and dragged her along. ‘Are we
+nearly there?’ Alice managed to pant out at last.
+
+‘Nearly there!’ the Queen repeated. ‘Why, we passed it ten minutes ago!
+Faster!’ And they ran on for a time in silence, with the wind whistling
+in Alice’s ears, and almost blowing her hair off her head, she fancied.
+
+‘Now! Now!’ cried the Queen. ‘Faster! Faster!’ And they went so fast
+that at last they seemed to skim through the air, hardly touching the
+ground with their feet, till suddenly, just as Alice was getting quite
+exhausted, they stopped, and she found herself sitting on the ground,
+breathless and giddy.
+
+The Queen propped her up against a tree, and said kindly, ‘You may rest
+a little now.’
+
+Alice looked round her in great surprise. ‘Why, I do believe we’ve been
+under this tree the whole time! Everything’s just as it was!’
+
+‘Of course it is,’ said the Queen, ‘what would you have it?’
+
+‘Well, in OUR country,’ said Alice, still panting a little, ‘you’d
+generally get to somewhere else--if you ran very fast for a long time,
+as we’ve been doing.’
+
+‘A slow sort of country!’ said the Queen. ‘Now, HERE, you see, it takes
+all the running YOU can do, to keep in the same place. If you want to
+get somewhere else, you must run at least twice as fast as that!’
+
+‘I’d rather not try, please!’ said Alice. ‘I’m quite content to stay
+here--only I AM so hot and thirsty!’
+
+‘I know what YOU’D like!’ the Queen said good-naturedly, taking a little
+box out of her pocket. ‘Have a biscuit?’
+
+Alice thought it would not be civil to say ‘No,’ though it wasn’t at all
+what she wanted. So she took it, and ate it as well as she could: and it
+was VERY dry; and she thought she had never been so nearly choked in all
+her life.
+
+‘While you’re refreshing yourself,’ said the Queen, ‘I’ll just take
+the measurements.’ And she took a ribbon out of her pocket, marked in
+inches, and began measuring the ground, and sticking little pegs in here
+and there.
+
+‘At the end of two yards,’ she said, putting in a peg to mark the
+distance, ‘I shall give you your directions--have another biscuit?’
+
+‘No, thank you,’ said Alice: ‘one’s QUITE enough!’
+
+‘Thirst quenched, I hope?’ said the Queen.
+
+Alice did not know what to say to this, but luckily the Queen did not
+wait for an answer, but went on. ‘At the end of THREE yards I shall
+repeat them--for fear of your forgetting them. At the end of FOUR, I
+shall say good-bye. And at the end of FIVE, I shall go!’
+
+She had got all the pegs put in by this time, and Alice looked on
+with great interest as she returned to the tree, and then began slowly
+walking down the row.
+
+At the two-yard peg she faced round, and said, ‘A pawn goes two squares
+in its first move, you know. So you’ll go VERY quickly through the Third
+Square--by railway, I should think--and you’ll find yourself in the
+Fourth Square in no time. Well, THAT square belongs to Tweedledum and
+Tweedledee--the Fifth is mostly water--the Sixth belongs to Humpty
+Dumpty--But you make no remark?’
+
+‘I--I didn’t know I had to make one--just then,’ Alice faltered out.
+
+‘You SHOULD have said, “It’s extremely kind of you to tell me all
+this”--however, we’ll suppose it said--the Seventh Square is all
+forest--however, one of the Knights will show you the way--and in the
+Eighth Square we shall be Queens together, and it’s all feasting and
+fun!’ Alice got up and curtseyed, and sat down again.
+
+At the next peg the Queen turned again, and this time she said, ‘Speak
+in French when you can’t think of the English for a thing--turn out your
+toes as you walk--and remember who you are!’ She did not wait for Alice
+to curtsey this time, but walked on quickly to the next peg, where she
+turned for a moment to say ‘good-bye,’ and then hurried on to the last.
+
+How it happened, Alice never knew, but exactly as she came to the last
+peg, she was gone. Whether she vanished into the air, or whether she
+ran quickly into the wood (‘and she CAN run very fast!’ thought Alice),
+there was no way of guessing, but she was gone, and Alice began to
+remember that she was a Pawn, and that it would soon be time for her to
+move.
+
+
+
+
+CHAPTER III. Looking-Glass Insects
+
+Of course the first thing to do was to make a grand survey of the
+country she was going to travel through. ‘It’s something very like
+learning geography,’ thought Alice, as she stood on tiptoe in hopes of
+being able to see a little further. ‘Principal rivers--there ARE none.
+Principal mountains--I’m on the only one, but I don’t think it’s got any
+name. Principal towns--why, what ARE those creatures, making honey down
+there? They can’t be bees--nobody ever saw bees a mile off, you know--’
+and for some time she stood silent, watching one of them that was
+bustling about among the flowers, poking its proboscis into them, ‘just
+as if it was a regular bee,’ thought Alice.
+
+However, this was anything but a regular bee: in fact it was an
+elephant--as Alice soon found out, though the idea quite took her breath
+away at first. ‘And what enormous flowers they must be!’ was her next
+idea. ‘Something like cottages with the roofs taken off, and stalks put
+to them--and what quantities of honey they must make! I think I’ll go
+down and--no, I won’t JUST yet,’ she went on, checking herself just as
+she was beginning to run down the hill, and trying to find some excuse
+for turning shy so suddenly. ‘It’ll never do to go down among them
+without a good long branch to brush them away--and what fun it’ll be
+when they ask me how I like my walk. I shall say--“Oh, I like it well
+enough--“’ (here came the favourite little toss of the head), ‘“only it
+was so dusty and hot, and the elephants did tease so!”’
+
+‘I think I’ll go down the other way,’ she said after a pause: ‘and
+perhaps I may visit the elephants later on. Besides, I do so want to get
+into the Third Square!’
+
+So with this excuse she ran down the hill and jumped over the first of
+the six little brooks.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Tickets, please!’ said the Guard, putting his head in at the window.
+In a moment everybody was holding out a ticket: they were about the same
+size as the people, and quite seemed to fill the carriage.
+
+‘Now then! Show your ticket, child!’ the Guard went on, looking angrily
+at Alice. And a great many voices all said together (‘like the chorus of
+a song,’ thought Alice), ‘Don’t keep him waiting, child! Why, his time
+is worth a thousand pounds a minute!’
+
+‘I’m afraid I haven’t got one,’ Alice said in a frightened tone: ‘there
+wasn’t a ticket-office where I came from.’ And again the chorus of
+voices went on. ‘There wasn’t room for one where she came from. The land
+there is worth a thousand pounds an inch!’
+
+‘Don’t make excuses,’ said the Guard: ‘you should have bought one from
+the engine-driver.’ And once more the chorus of voices went on with ‘The
+man that drives the engine. Why, the smoke alone is worth a thousand
+pounds a puff!’
+
+Alice thought to herself, ‘Then there’s no use in speaking.’ The
+voices didn’t join in this time, as she hadn’t spoken, but to her
+great surprise, they all THOUGHT in chorus (I hope you understand what
+THINKING IN CHORUS means--for I must confess that _I_ don’t), ‘Better
+say nothing at all. Language is worth a thousand pounds a word!’
+
+‘I shall dream about a thousand pounds tonight, I know I shall!’ thought
+Alice.
+
+All this time the Guard was looking at her, first through a telescope,
+then through a microscope, and then through an opera-glass. At last he
+said, ‘You’re travelling the wrong way,’ and shut up the window and went
+away.
+
+‘So young a child,’ said the gentleman sitting opposite to her (he was
+dressed in white paper), ‘ought to know which way she’s going, even if
+she doesn’t know her own name!’
+
+A Goat, that was sitting next to the gentleman in white, shut his
+eyes and said in a loud voice, ‘She ought to know her way to the
+ticket-office, even if she doesn’t know her alphabet!’
+
+There was a Beetle sitting next to the Goat (it was a very queer
+carriage-full of passengers altogether), and, as the rule seemed to be
+that they should all speak in turn, HE went on with ‘She’ll have to go
+back from here as luggage!’
+
+Alice couldn’t see who was sitting beyond the Beetle, but a hoarse voice
+spoke next. ‘Change engines--’ it said, and was obliged to leave off.
+
+‘It sounds like a horse,’ Alice thought to herself. And an extremely
+small voice, close to her ear, said, ‘You might make a joke on
+that--something about “horse” and “hoarse,” you know.’
+
+Then a very gentle voice in the distance said, ‘She must be labelled
+“Lass, with care,” you know--’
+
+And after that other voices went on (‘What a number of people there are
+in the carriage!’ thought Alice), saying, ‘She must go by post, as she’s
+got a head on her--’ ‘She must be sent as a message by the telegraph--’
+‘She must draw the train herself the rest of the way--’ and so on.
+
+But the gentleman dressed in white paper leaned forwards and whispered
+in her ear, ‘Never mind what they all say, my dear, but take a
+return-ticket every time the train stops.’
+
+‘Indeed I shan’t!’ Alice said rather impatiently. ‘I don’t belong to
+this railway journey at all--I was in a wood just now--and I wish I
+could get back there.’
+
+‘You might make a joke on THAT,’ said the little voice close to her ear:
+‘something about “you WOULD if you could,” you know.’
+
+‘Don’t tease so,’ said Alice, looking about in vain to see where the
+voice came from; ‘if you’re so anxious to have a joke made, why don’t
+you make one yourself?’
+
+The little voice sighed deeply: it was VERY unhappy, evidently, and
+Alice would have said something pitying to comfort it, ‘If it would only
+sigh like other people!’ she thought. But this was such a wonderfully
+small sigh, that she wouldn’t have heard it at all, if it hadn’t come
+QUITE close to her ear. The consequence of this was that it tickled her
+ear very much, and quite took off her thoughts from the unhappiness of
+the poor little creature.
+
+‘I know you are a friend,’ the little voice went on; ‘a dear friend, and
+an old friend. And you won’t hurt me, though I AM an insect.’
+
+‘What kind of insect?’ Alice inquired a little anxiously. What she
+really wanted to know was, whether it could sting or not, but she
+thought this wouldn’t be quite a civil question to ask.
+
+‘What, then you don’t--’ the little voice began, when it was drowned by
+a shrill scream from the engine, and everybody jumped up in alarm, Alice
+among the rest.
+
+The Horse, who had put his head out of the window, quietly drew it in
+and said, ‘It’s only a brook we have to jump over.’ Everybody seemed
+satisfied with this, though Alice felt a little nervous at the idea of
+trains jumping at all. ‘However, it’ll take us into the Fourth Square,
+that’s some comfort!’ she said to herself. In another moment she felt
+the carriage rise straight up into the air, and in her fright she caught
+at the thing nearest to her hand, which happened to be the Goat’s beard.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+But the beard seemed to melt away as she touched it, and she found
+herself sitting quietly under a tree--while the Gnat (for that was the
+insect she had been talking to) was balancing itself on a twig just over
+her head, and fanning her with its wings.
+
+It certainly was a VERY large Gnat: ‘about the size of a chicken,’ Alice
+thought. Still, she couldn’t feel nervous with it, after they had been
+talking together so long.
+
+‘--then you don’t like all insects?’ the Gnat went on, as quietly as if
+nothing had happened.
+
+‘I like them when they can talk,’ Alice said. ‘None of them ever talk,
+where _I_ come from.’
+
+‘What sort of insects do you rejoice in, where YOU come from?’ the Gnat
+inquired.
+
+‘I don’t REJOICE in insects at all,’ Alice explained, ‘because I’m
+rather afraid of them--at least the large kinds. But I can tell you the
+names of some of them.’
+
+‘Of course they answer to their names?’ the Gnat remarked carelessly.
+
+‘I never knew them to do it.’
+
+‘What’s the use of their having names,’ the Gnat said, ‘if they won’t
+answer to them?’
+
+‘No use to THEM,’ said Alice; ‘but it’s useful to the people who name
+them, I suppose. If not, why do things have names at all?’
+
+‘I can’t say,’ the Gnat replied. ‘Further on, in the wood down there,
+they’ve got no names--however, go on with your list of insects: you’re
+wasting time.’
+
+‘Well, there’s the Horse-fly,’ Alice began, counting off the names on
+her fingers.
+
+‘All right,’ said the Gnat: ‘half way up that bush, you’ll see a
+Rocking-horse-fly, if you look. It’s made entirely of wood, and gets
+about by swinging itself from branch to branch.’
+
+‘What does it live on?’ Alice asked, with great curiosity.
+
+‘Sap and sawdust,’ said the Gnat. ‘Go on with the list.’
+
+Alice looked up at the Rocking-horse-fly with great interest, and made
+up her mind that it must have been just repainted, it looked so bright
+and sticky; and then she went on.
+
+‘And there’s the Dragon-fly.’
+
+‘Look on the branch above your head,’ said the Gnat, ‘and there you’ll
+find a snap-dragon-fly. Its body is made of plum-pudding, its wings of
+holly-leaves, and its head is a raisin burning in brandy.’
+
+‘And what does it live on?’
+
+‘Frumenty and mince pie,’ the Gnat replied; ‘and it makes its nest in a
+Christmas box.’
+
+‘And then there’s the Butterfly,’ Alice went on, after she had taken
+a good look at the insect with its head on fire, and had thought to
+herself, ‘I wonder if that’s the reason insects are so fond of flying
+into candles--because they want to turn into Snap-dragon-flies!’
+
+‘Crawling at your feet,’ said the Gnat (Alice drew her feet back in
+some alarm), ‘you may observe a Bread-and-Butterfly. Its wings are thin
+slices of Bread-and-butter, its body is a crust, and its head is a lump
+of sugar.’
+
+‘And what does IT live on?’
+
+‘Weak tea with cream in it.’
+
+A new difficulty came into Alice’s head. ‘Supposing it couldn’t find
+any?’ she suggested.
+
+‘Then it would die, of course.’
+
+‘But that must happen very often,’ Alice remarked thoughtfully.
+
+‘It always happens,’ said the Gnat.
+
+After this, Alice was silent for a minute or two, pondering. The Gnat
+amused itself meanwhile by humming round and round her head: at last
+it settled again and remarked, ‘I suppose you don’t want to lose your
+name?’
+
+‘No, indeed,’ Alice said, a little anxiously.
+
+‘And yet I don’t know,’ the Gnat went on in a careless tone: ‘only think
+how convenient it would be if you could manage to go home without it!
+For instance, if the governess wanted to call you to your lessons, she
+would call out “come here--,” and there she would have to leave off,
+because there wouldn’t be any name for her to call, and of course you
+wouldn’t have to go, you know.’
+
+‘That would never do, I’m sure,’ said Alice: ‘the governess would never
+think of excusing me lessons for that. If she couldn’t remember my name,
+she’d call me “Miss!” as the servants do.’
+
+‘Well, if she said “Miss,” and didn’t say anything more,’ the Gnat
+remarked, ‘of course you’d miss your lessons. That’s a joke. I wish YOU
+had made it.’
+
+‘Why do you wish _I_ had made it?’ Alice asked. ‘It’s a very bad one.’
+
+But the Gnat only sighed deeply, while two large tears came rolling down
+its cheeks.
+
+‘You shouldn’t make jokes,’ Alice said, ‘if it makes you so unhappy.’
+
+Then came another of those melancholy little sighs, and this time the
+poor Gnat really seemed to have sighed itself away, for, when Alice
+looked up, there was nothing whatever to be seen on the twig, and, as
+she was getting quite chilly with sitting still so long, she got up and
+walked on.
+
+She very soon came to an open field, with a wood on the other side of
+it: it looked much darker than the last wood, and Alice felt a LITTLE
+timid about going into it. However, on second thoughts, she made up her
+mind to go on: ‘for I certainly won’t go BACK,’ she thought to herself,
+and this was the only way to the Eighth Square.
+
+‘This must be the wood,’ she said thoughtfully to herself, ‘where
+things have no names. I wonder what’ll become of MY name when I go in?
+I shouldn’t like to lose it at all--because they’d have to give me
+another, and it would be almost certain to be an ugly one. But then
+the fun would be trying to find the creature that had got my old
+name! That’s just like the advertisements, you know, when people lose
+dogs--“ANSWERS TO THE NAME OF ‘DASH:’ HAD ON A BRASS COLLAR”--just fancy
+calling everything you met “Alice,” till one of them answered! Only they
+wouldn’t answer at all, if they were wise.’
+
+She was rambling on in this way when she reached the wood: it looked
+very cool and shady. ‘Well, at any rate it’s a great comfort,’ she
+said as she stepped under the trees, ‘after being so hot, to get into
+the--into WHAT?’ she went on, rather surprised at not being able to
+think of the word. ‘I mean to get under the--under the--under THIS, you
+know!’ putting her hand on the trunk of the tree. ‘What DOES it call
+itself, I wonder? I do believe it’s got no name--why, to be sure it
+hasn’t!’
+
+She stood silent for a minute, thinking: then she suddenly began again.
+‘Then it really HAS happened, after all! And now, who am I? I WILL
+remember, if I can! I’m determined to do it!’ But being determined
+didn’t help much, and all she could say, after a great deal of puzzling,
+was, ‘L, I KNOW it begins with L!’
+
+Just then a Fawn came wandering by: it looked at Alice with its large
+gentle eyes, but didn’t seem at all frightened. ‘Here then! Here then!’
+Alice said, as she held out her hand and tried to stroke it; but it only
+started back a little, and then stood looking at her again.
+
+‘What do you call yourself?’ the Fawn said at last. Such a soft sweet
+voice it had!
+
+‘I wish I knew!’ thought poor Alice. She answered, rather sadly,
+‘Nothing, just now.’
+
+‘Think again,’ it said: ‘that won’t do.’
+
+Alice thought, but nothing came of it. ‘Please, would you tell me
+what YOU call yourself?’ she said timidly. ‘I think that might help a
+little.’
+
+‘I’ll tell you, if you’ll move a little further on,’ the Fawn said. ‘I
+can’t remember here.’
+
+So they walked on together though the wood, Alice with her arms clasped
+lovingly round the soft neck of the Fawn, till they came out into
+another open field, and here the Fawn gave a sudden bound into the air,
+and shook itself free from Alice’s arms. ‘I’m a Fawn!’ it cried out in a
+voice of delight, ‘and, dear me! you’re a human child!’ A sudden look of
+alarm came into its beautiful brown eyes, and in another moment it had
+darted away at full speed.
+
+Alice stood looking after it, almost ready to cry with vexation at
+having lost her dear little fellow-traveller so suddenly. ‘However, I
+know my name now.’ she said, ‘that’s SOME comfort. Alice--Alice--I won’t
+forget it again. And now, which of these finger-posts ought I to follow,
+I wonder?’
+
+It was not a very difficult question to answer, as there was only one
+road through the wood, and the two finger-posts both pointed along it.
+‘I’ll settle it,’ Alice said to herself, ‘when the road divides and they
+point different ways.’
+
+But this did not seem likely to happen. She went on and on, a long way,
+but wherever the road divided there were sure to be two finger-posts
+pointing the same way, one marked ‘TO TWEEDLEDUM’S HOUSE’ and the other
+‘TO THE HOUSE OF TWEEDLEDEE.’
+
+‘I do believe,’ said Alice at last, ‘that they live in the same house! I
+wonder I never thought of that before--But I can’t stay there long. I’ll
+just call and say “how d’you do?” and ask them the way out of the wood.
+If I could only get to the Eighth Square before it gets dark!’ So she
+wandered on, talking to herself as she went, till, on turning a sharp
+corner, she came upon two fat little men, so suddenly that she could not
+help starting back, but in another moment she recovered herself, feeling
+sure that they must be.
+
+
+
+
+CHAPTER IV. Tweedledum And Tweedledee
+
+They were standing under a tree, each with an arm round the other’s
+neck, and Alice knew which was which in a moment, because one of them
+had ‘DUM’ embroidered on his collar, and the other ‘DEE.’ ‘I suppose
+they’ve each got “TWEEDLE” round at the back of the collar,’ she said to
+herself.
+
+They stood so still that she quite forgot they were alive, and she was
+just looking round to see if the word “TWEEDLE” was written at the back
+of each collar, when she was startled by a voice coming from the one
+marked ‘DUM.’
+
+‘If you think we’re wax-works,’ he said, ‘you ought to pay, you know.
+Wax-works weren’t made to be looked at for nothing, nohow!’
+
+‘Contrariwise,’ added the one marked ‘DEE,’ ‘if you think we’re alive,
+you ought to speak.’
+
+‘I’m sure I’m very sorry,’ was all Alice could say; for the words of the
+old song kept ringing through her head like the ticking of a clock, and
+she could hardly help saying them out loud:--
+
+
+     ‘Tweedledum and Tweedledee
+      Agreed to have a battle;
+     For Tweedledum said Tweedledee
+      Had spoiled his nice new rattle.
+
+     Just then flew down a monstrous crow,
+      As black as a tar-barrel;
+     Which frightened both the heroes so,
+      They quite forgot their quarrel.’
+
+‘I know what you’re thinking about,’ said Tweedledum: ‘but it isn’t so,
+nohow.’
+
+‘Contrariwise,’ continued Tweedledee, ‘if it was so, it might be; and if
+it were so, it would be; but as it isn’t, it ain’t. That’s logic.’
+
+‘I was thinking,’ Alice said very politely, ‘which is the best way out
+of this wood: it’s getting so dark. Would you tell me, please?’
+
+But the little men only looked at each other and grinned.
+
+They looked so exactly like a couple of great schoolboys, that Alice
+couldn’t help pointing her finger at Tweedledum, and saying ‘First Boy!’
+
+‘Nohow!’ Tweedledum cried out briskly, and shut his mouth up again with
+a snap.
+
+‘Next Boy!’ said Alice, passing on to Tweedledee, though she felt quite
+certain he would only shout out ‘Contrariwise!’ and so he did.
+
+‘You’ve been wrong!’ cried Tweedledum. ‘The first thing in a visit is to
+say “How d’ye do?” and shake hands!’ And here the two brothers gave each
+other a hug, and then they held out the two hands that were free, to
+shake hands with her.
+
+Alice did not like shaking hands with either of them first, for fear
+of hurting the other one’s feelings; so, as the best way out of the
+difficulty, she took hold of both hands at once: the next moment they
+were dancing round in a ring. This seemed quite natural (she remembered
+afterwards), and she was not even surprised to hear music playing: it
+seemed to come from the tree under which they were dancing, and it was
+done (as well as she could make it out) by the branches rubbing one
+across the other, like fiddles and fiddle-sticks.
+
+‘But it certainly WAS funny,’ (Alice said afterwards, when she was
+telling her sister the history of all this,) ‘to find myself singing
+“HERE WE GO ROUND THE MULBERRY BUSH.” I don’t know when I began it, but
+somehow I felt as if I’d been singing it a long long time!’
+
+The other two dancers were fat, and very soon out of breath. ‘Four times
+round is enough for one dance,’ Tweedledum panted out, and they left
+off dancing as suddenly as they had begun: the music stopped at the same
+moment.
+
+Then they let go of Alice’s hands, and stood looking at her for a
+minute: there was a rather awkward pause, as Alice didn’t know how to
+begin a conversation with people she had just been dancing with. ‘It
+would never do to say “How d’ye do?” NOW,’ she said to herself: ‘we seem
+to have got beyond that, somehow!’
+
+‘I hope you’re not much tired?’ she said at last.
+
+‘Nohow. And thank you VERY much for asking,’ said Tweedledum.
+
+‘So much obliged!’ added Tweedledee. ‘You like poetry?’
+
+‘Ye-es, pretty well--SOME poetry,’ Alice said doubtfully. ‘Would you
+tell me which road leads out of the wood?’
+
+‘What shall I repeat to her?’ said Tweedledee, looking round at
+Tweedledum with great solemn eyes, and not noticing Alice’s question.
+
+‘“THE WALRUS AND THE CARPENTER” is the longest,’ Tweedledum replied,
+giving his brother an affectionate hug.
+
+Tweedledee began instantly:
+
+       ‘The sun was shining--’
+
+Here Alice ventured to interrupt him. ‘If it’s VERY long,’ she said, as
+politely as she could, ‘would you please tell me first which road--’
+
+Tweedledee smiled gently, and began again:
+
+     ‘The sun was shining on the sea,
+      Shining with all his might:
+     He did his very best to make
+      The billows smooth and bright--
+     And this was odd, because it was
+      The middle of the night.
+
+     The moon was shining sulkily,
+      Because she thought the sun
+     Had got no business to be there
+      After the day was done--
+     “It’s very rude of him,” she said,
+      “To come and spoil the fun!”
+
+     The sea was wet as wet could be,
+      The sands were dry as dry.
+     You could not see a cloud, because
+      No cloud was in the sky:
+     No birds were flying over head--
+      There were no birds to fly.
+
+     The Walrus and the Carpenter
+      Were walking close at hand;
+     They wept like anything to see
+      Such quantities of sand:
+     “If this were only cleared away,”
+       They said, “it WOULD be grand!”
+
+     “If seven maids with seven mops
+      Swept it for half a year,
+     Do you suppose,” the Walrus said,
+      “That they could get it clear?”
+      “I doubt it,” said the Carpenter,
+      And shed a bitter tear.
+
+     “O Oysters, come and walk with us!”
+       The Walrus did beseech.
+     “A pleasant walk, a pleasant talk,
+      Along the briny beach:
+     We cannot do with more than four,
+      To give a hand to each.”
+
+     The eldest Oyster looked at him.
+      But never a word he said:
+     The eldest Oyster winked his eye,
+      And shook his heavy head--
+     Meaning to say he did not choose
+      To leave the oyster-bed.
+
+     But four young oysters hurried up,
+      All eager for the treat:
+     Their coats were brushed, their faces washed,
+      Their shoes were clean and neat--
+     And this was odd, because, you know,
+      They hadn’t any feet.
+
+     Four other Oysters followed them,
+      And yet another four;
+     And thick and fast they came at last,
+      And more, and more, and more--
+     All hopping through the frothy waves,
+      And scrambling to the shore.
+
+     The Walrus and the Carpenter
+      Walked on a mile or so,
+     And then they rested on a rock
+      Conveniently low:
+     And all the little Oysters stood
+      And waited in a row.
+
+     “The time has come,” the Walrus said,
+      “To talk of many things:
+     Of shoes--and ships--and sealing-wax--
+      Of cabbages--and kings--
+     And why the sea is boiling hot--
+      And whether pigs have wings.”
+
+     “But wait a bit,” the Oysters cried,
+      “Before we have our chat;
+     For some of us are out of breath,
+      And all of us are fat!”
+      “No hurry!” said the Carpenter.
+      They thanked him much for that.
+
+     “A loaf of bread,” the Walrus said,
+      “Is what we chiefly need:
+     Pepper and vinegar besides
+      Are very good indeed--
+     Now if you’re ready Oysters dear,
+      We can begin to feed.”
+
+     “But not on us!” the Oysters cried,
+      Turning a little blue,
+     “After such kindness, that would be
+      A dismal thing to do!”
+      “The night is fine,” the Walrus said
+      “Do you admire the view?
+
+     “It was so kind of you to come!
+      And you are very nice!”
+      The Carpenter said nothing but
+      “Cut us another slice:
+     I wish you were not quite so deaf--
+      I’ve had to ask you twice!”
+
+     “It seems a shame,” the Walrus said,
+      “To play them such a trick,
+     After we’ve brought them out so far,
+      And made them trot so quick!”
+      The Carpenter said nothing but
+      “The butter’s spread too thick!”
+
+     “I weep for you,” the Walrus said.
+      “I deeply sympathize.”
+      With sobs and tears he sorted out
+      Those of the largest size.
+     Holding his pocket handkerchief
+      Before his streaming eyes.
+
+     “O Oysters,” said the Carpenter.
+      “You’ve had a pleasant run!
+     Shall we be trotting home again?”
+       But answer came there none--
+     And that was scarcely odd, because
+      They’d eaten every one.’
+
+‘I like the Walrus best,’ said Alice: ‘because you see he was a LITTLE
+sorry for the poor oysters.’
+
+‘He ate more than the Carpenter, though,’ said Tweedledee. ‘You see he
+held his handkerchief in front, so that the Carpenter couldn’t count how
+many he took: contrariwise.’
+
+‘That was mean!’ Alice said indignantly. ‘Then I like the Carpenter
+best--if he didn’t eat so many as the Walrus.’
+
+‘But he ate as many as he could get,’ said Tweedledum.
+
+This was a puzzler. After a pause, Alice began, ‘Well! They were BOTH
+very unpleasant characters--’ Here she checked herself in some alarm,
+at hearing something that sounded to her like the puffing of a large
+steam-engine in the wood near them, though she feared it was more likely
+to be a wild beast. ‘Are there any lions or tigers about here?’ she
+asked timidly.
+
+‘It’s only the Red King snoring,’ said Tweedledee.
+
+‘Come and look at him!’ the brothers cried, and they each took one of
+Alice’s hands, and led her up to where the King was sleeping.
+
+‘Isn’t he a LOVELY sight?’ said Tweedledum.
+
+Alice couldn’t say honestly that he was. He had a tall red night-cap on,
+with a tassel, and he was lying crumpled up into a sort of untidy heap,
+and snoring loud--‘fit to snore his head off!’ as Tweedledum remarked.
+
+‘I’m afraid he’ll catch cold with lying on the damp grass,’ said Alice,
+who was a very thoughtful little girl.
+
+‘He’s dreaming now,’ said Tweedledee: ‘and what do you think he’s
+dreaming about?’
+
+Alice said ‘Nobody can guess that.’
+
+‘Why, about YOU!’ Tweedledee exclaimed, clapping his hands triumphantly.
+‘And if he left off dreaming about you, where do you suppose you’d be?’
+
+‘Where I am now, of course,’ said Alice.
+
+‘Not you!’ Tweedledee retorted contemptuously. ‘You’d be nowhere. Why,
+you’re only a sort of thing in his dream!’
+
+‘If that there King was to wake,’ added Tweedledum, ‘you’d go
+out--bang!--just like a candle!’
+
+‘I shouldn’t!’ Alice exclaimed indignantly. ‘Besides, if I’M only a sort
+of thing in his dream, what are YOU, I should like to know?’
+
+‘Ditto’ said Tweedledum.
+
+‘Ditto, ditto’ cried Tweedledee.
+
+He shouted this so loud that Alice couldn’t help saying, ‘Hush! You’ll
+be waking him, I’m afraid, if you make so much noise.’
+
+‘Well, it no use YOUR talking about waking him,’ said Tweedledum, ‘when
+you’re only one of the things in his dream. You know very well you’re
+not real.’
+
+‘I AM real!’ said Alice and began to cry.
+
+‘You won’t make yourself a bit realler by crying,’ Tweedledee remarked:
+‘there’s nothing to cry about.’
+
+‘If I wasn’t real,’ Alice said--half-laughing through her tears, it all
+seemed so ridiculous--‘I shouldn’t be able to cry.’
+
+‘I hope you don’t suppose those are real tears?’ Tweedledum interrupted
+in a tone of great contempt.
+
+‘I know they’re talking nonsense,’ Alice thought to herself: ‘and it’s
+foolish to cry about it.’ So she brushed away her tears, and went on as
+cheerfully as she could. ‘At any rate I’d better be getting out of the
+wood, for really it’s coming on very dark. Do you think it’s going to
+rain?’
+
+Tweedledum spread a large umbrella over himself and his brother, and
+looked up into it. ‘No, I don’t think it is,’ he said: ‘at least--not
+under HERE. Nohow.’
+
+‘But it may rain OUTSIDE?’
+
+‘It may--if it chooses,’ said Tweedledee: ‘we’ve no objection.
+Contrariwise.’
+
+‘Selfish things!’ thought Alice, and she was just going to say
+‘Good-night’ and leave them, when Tweedledum sprang out from under the
+umbrella and seized her by the wrist.
+
+‘Do you see THAT?’ he said, in a voice choking with passion, and
+his eyes grew large and yellow all in a moment, as he pointed with a
+trembling finger at a small white thing lying under the tree.
+
+‘It’s only a rattle,’ Alice said, after a careful examination of the
+little white thing. ‘Not a rattleSNAKE, you know,’ she added hastily,
+thinking that he was frightened: ‘only an old rattle--quite old and
+broken.’
+
+‘I knew it was!’ cried Tweedledum, beginning to stamp about wildly and
+tear his hair. ‘It’s spoilt, of course!’ Here he looked at Tweedledee,
+who immediately sat down on the ground, and tried to hide himself under
+the umbrella.
+
+Alice laid her hand upon his arm, and said in a soothing tone, ‘You
+needn’t be so angry about an old rattle.’
+
+‘But it isn’t old!’ Tweedledum cried, in a greater fury than ever. ‘It’s
+new, I tell you--I bought it yesterday--my nice new RATTLE!’ and his
+voice rose to a perfect scream.
+
+All this time Tweedledee was trying his best to fold up the umbrella,
+with himself in it: which was such an extraordinary thing to do, that it
+quite took off Alice’s attention from the angry brother. But he couldn’t
+quite succeed, and it ended in his rolling over, bundled up in the
+umbrella, with only his head out: and there he lay, opening and shutting
+his mouth and his large eyes--‘looking more like a fish than anything
+else,’ Alice thought.
+
+‘Of course you agree to have a battle?’ Tweedledum said in a calmer
+tone.
+
+‘I suppose so,’ the other sulkily replied, as he crawled out of the
+umbrella: ‘only SHE must help us to dress up, you know.’
+
+So the two brothers went off hand-in-hand into the wood, and returned
+in a minute with their arms full of things--such as bolsters, blankets,
+hearth-rugs, table-cloths, dish-covers and coal-scuttles. ‘I hope you’re
+a good hand at pinning and tying strings?’ Tweedledum remarked. ‘Every
+one of these things has got to go on, somehow or other.’
+
+Alice said afterwards she had never seen such a fuss made about anything
+in all her life--the way those two bustled about--and the quantity of
+things they put on--and the trouble they gave her in tying strings and
+fastening buttons--‘Really they’ll be more like bundles of old clothes
+than anything else, by the time they’re ready!’ she said to herself, as
+she arranged a bolster round the neck of Tweedledee, ‘to keep his head
+from being cut off,’ as he said.
+
+‘You know,’ he added very gravely, ‘it’s one of the most serious things
+that can possibly happen to one in a battle--to get one’s head cut off.’
+
+Alice laughed aloud: but she managed to turn it into a cough, for fear
+of hurting his feelings.
+
+‘Do I look very pale?’ said Tweedledum, coming up to have his helmet
+tied on. (He CALLED it a helmet, though it certainly looked much more
+like a saucepan.)
+
+‘Well--yes--a LITTLE,’ Alice replied gently.
+
+‘I’m very brave generally,’ he went on in a low voice: ‘only to-day I
+happen to have a headache.’
+
+‘And I’VE got a toothache!’ said Tweedledee, who had overheard the
+remark. ‘I’m far worse off than you!’
+
+‘Then you’d better not fight to-day,’ said Alice, thinking it a good
+opportunity to make peace.
+
+‘We MUST have a bit of a fight, but I don’t care about going on long,’
+said Tweedledum. ‘What’s the time now?’
+
+Tweedledee looked at his watch, and said ‘Half-past four.’
+
+‘Let’s fight till six, and then have dinner,’ said Tweedledum.
+
+‘Very well,’ the other said, rather sadly: ‘and SHE can watch us--only
+you’d better not come VERY close,’ he added: ‘I generally hit everything
+I can see--when I get really excited.’
+
+‘And _I_ hit everything within reach,’ cried Tweedledum, ‘whether I can
+see it or not!’
+
+Alice laughed. ‘You must hit the TREES pretty often, I should think,’
+she said.
+
+Tweedledum looked round him with a satisfied smile. ‘I don’t suppose,’
+he said, ‘there’ll be a tree left standing, for ever so far round, by
+the time we’ve finished!’
+
+‘And all about a rattle!’ said Alice, still hoping to make them a LITTLE
+ashamed of fighting for such a trifle.
+
+‘I shouldn’t have minded it so much,’ said Tweedledum, ‘if it hadn’t
+been a new one.’
+
+‘I wish the monstrous crow would come!’ thought Alice.
+
+‘There’s only one sword, you know,’ Tweedledum said to his brother:
+‘but you can have the umbrella--it’s quite as sharp. Only we must begin
+quick. It’s getting as dark as it can.’
+
+‘And darker,’ said Tweedledee.
+
+It was getting dark so suddenly that Alice thought there must be a
+thunderstorm coming on. ‘What a thick black cloud that is!’ she said.
+‘And how fast it comes! Why, I do believe it’s got wings!’
+
+‘It’s the crow!’ Tweedledum cried out in a shrill voice of alarm: and
+the two brothers took to their heels and were out of sight in a moment.
+
+Alice ran a little way into the wood, and stopped under a large tree.
+‘It can never get at me HERE,’ she thought: ‘it’s far too large to
+squeeze itself in among the trees. But I wish it wouldn’t flap its wings
+so--it makes quite a hurricane in the wood--here’s somebody’s shawl
+being blown away!’
+
+
+
+
+CHAPTER V. Wool and Water
+
+She caught the shawl as she spoke, and looked about for the owner: in
+another moment the White Queen came running wildly through the wood,
+with both arms stretched out wide, as if she were flying, and Alice very
+civilly went to meet her with the shawl.
+
+‘I’m very glad I happened to be in the way,’ Alice said, as she helped
+her to put on her shawl again.
+
+The White Queen only looked at her in a helpless frightened sort of way,
+and kept repeating something in a whisper to herself that sounded like
+‘bread-and-butter, bread-and-butter,’ and Alice felt that if there was
+to be any conversation at all, she must manage it herself. So she began
+rather timidly: ‘Am I addressing the White Queen?’
+
+‘Well, yes, if you call that a-dressing,’ The Queen said. ‘It isn’t MY
+notion of the thing, at all.’
+
+Alice thought it would never do to have an argument at the very
+beginning of their conversation, so she smiled and said, ‘If your
+Majesty will only tell me the right way to begin, I’ll do it as well as
+I can.’
+
+‘But I don’t want it done at all!’ groaned the poor Queen. ‘I’ve been
+a-dressing myself for the last two hours.’
+
+It would have been all the better, as it seemed to Alice, if she had got
+some one else to dress her, she was so dreadfully untidy. ‘Every
+single thing’s crooked,’ Alice thought to herself, ‘and she’s all over
+pins!--may I put your shawl straight for you?’ she added aloud.
+
+‘I don’t know what’s the matter with it!’ the Queen said, in a
+melancholy voice. ‘It’s out of temper, I think. I’ve pinned it here, and
+I’ve pinned it there, but there’s no pleasing it!’
+
+‘It CAN’T go straight, you know, if you pin it all on one side,’ Alice
+said, as she gently put it right for her; ‘and, dear me, what a state
+your hair is in!’
+
+‘The brush has got entangled in it!’ the Queen said with a sigh. ‘And I
+lost the comb yesterday.’
+
+Alice carefully released the brush, and did her best to get the hair
+into order. ‘Come, you look rather better now!’ she said, after altering
+most of the pins. ‘But really you should have a lady’s maid!’
+
+‘I’m sure I’ll take you with pleasure!’ the Queen said. ‘Twopence a
+week, and jam every other day.’
+
+Alice couldn’t help laughing, as she said, ‘I don’t want you to hire
+ME--and I don’t care for jam.’
+
+‘It’s very good jam,’ said the Queen.
+
+‘Well, I don’t want any TO-DAY, at any rate.’
+
+‘You couldn’t have it if you DID want it,’ the Queen said. ‘The rule is,
+jam to-morrow and jam yesterday--but never jam to-day.’
+
+‘It MUST come sometimes to “jam to-day,”’ Alice objected.
+
+‘No, it can’t,’ said the Queen. ‘It’s jam every OTHER day: to-day isn’t
+any OTHER day, you know.’
+
+‘I don’t understand you,’ said Alice. ‘It’s dreadfully confusing!’
+
+‘That’s the effect of living backwards,’ the Queen said kindly: ‘it
+always makes one a little giddy at first--’
+
+‘Living backwards!’ Alice repeated in great astonishment. ‘I never heard
+of such a thing!’
+
+‘--but there’s one great advantage in it, that one’s memory works both
+ways.’
+
+‘I’m sure MINE only works one way,’ Alice remarked. ‘I can’t remember
+things before they happen.’
+
+‘It’s a poor sort of memory that only works backwards,’ the Queen
+remarked.
+
+‘What sort of things do YOU remember best?’ Alice ventured to ask.
+
+‘Oh, things that happened the week after next,’ the Queen replied in a
+careless tone. ‘For instance, now,’ she went on, sticking a large piece
+of plaster on her finger as she spoke, ‘there’s the King’s
+Messenger. He’s in prison now, being punished: and the trial doesn’t
+even begin till next Wednesday: and of course the crime comes last of
+all.’
+
+‘Suppose he never commits the crime?’ said Alice.
+
+‘That would be all the better, wouldn’t it?’ the Queen said, as she
+bound the plaster round her finger with a bit of ribbon.
+
+Alice felt there was no denying THAT. ‘Of course it would be all
+the better,’ she said: ‘but it wouldn’t be all the better his being
+punished.’
+
+‘You’re wrong THERE, at any rate,’ said the Queen: ‘were YOU ever
+punished?’
+
+‘Only for faults,’ said Alice.
+
+‘And you were all the better for it, I know!’ the Queen said
+triumphantly.
+
+‘Yes, but then I HAD done the things I was punished for,’ said Alice:
+‘that makes all the difference.’
+
+‘But if you HADN’T done them,’ the Queen said, ‘that would have been
+better still; better, and better, and better!’ Her voice went higher
+with each ‘better,’ till it got quite to a squeak at last.
+
+Alice was just beginning to say ‘There’s a mistake somewhere--,’ when
+the Queen began screaming so loud that she had to leave the sentence
+unfinished. ‘Oh, oh, oh!’ shouted the Queen, shaking her hand about as
+if she wanted to shake it off. ‘My finger’s bleeding! Oh, oh, oh, oh!’
+
+Her screams were so exactly like the whistle of a steam-engine, that
+Alice had to hold both her hands over her ears.
+
+‘What IS the matter?’ she said, as soon as there was a chance of making
+herself heard. ‘Have you pricked your finger?’
+
+‘I haven’t pricked it YET,’ the Queen said, ‘but I soon shall--oh, oh,
+oh!’
+
+‘When do you expect to do it?’ Alice asked, feeling very much inclined
+to laugh.
+
+‘When I fasten my shawl again,’ the poor Queen groaned out: ‘the brooch
+will come undone directly. Oh, oh!’ As she said the words the brooch
+flew open, and the Queen clutched wildly at it, and tried to clasp it
+again.
+
+‘Take care!’ cried Alice. ‘You’re holding it all crooked!’ And she
+caught at the brooch; but it was too late: the pin had slipped, and the
+Queen had pricked her finger.
+
+‘That accounts for the bleeding, you see,’ she said to Alice with a
+smile. ‘Now you understand the way things happen here.’
+
+‘But why don’t you scream now?’ Alice asked, holding her hands ready to
+put over her ears again.
+
+‘Why, I’ve done all the screaming already,’ said the Queen. ‘What would
+be the good of having it all over again?’
+
+By this time it was getting light. ‘The crow must have flown away, I
+think,’ said Alice: ‘I’m so glad it’s gone. I thought it was the night
+coming on.’
+
+‘I wish _I_ could manage to be glad!’ the Queen said. ‘Only I never
+can remember the rule. You must be very happy, living in this wood, and
+being glad whenever you like!’
+
+‘Only it is so VERY lonely here!’ Alice said in a melancholy voice; and
+at the thought of her loneliness two large tears came rolling down her
+cheeks.
+
+‘Oh, don’t go on like that!’ cried the poor Queen, wringing her hands in
+despair. ‘Consider what a great girl you are. Consider what a long way
+you’ve come to-day. Consider what o’clock it is. Consider anything, only
+don’t cry!’
+
+Alice could not help laughing at this, even in the midst of her tears.
+‘Can YOU keep from crying by considering things?’ she asked.
+
+‘That’s the way it’s done,’ the Queen said with great decision: ‘nobody
+can do two things at once, you know. Let’s consider your age to begin
+with--how old are you?’
+
+‘I’m seven and a half exactly.’
+
+‘You needn’t say “exactually,”’ the Queen remarked: ‘I can believe
+it without that. Now I’ll give YOU something to believe. I’m just one
+hundred and one, five months and a day.’
+
+‘I can’t believe THAT!’ said Alice.
+
+‘Can’t you?’ the Queen said in a pitying tone. ‘Try again: draw a long
+breath, and shut your eyes.’
+
+Alice laughed. ‘There’s no use trying,’ she said: ‘one CAN’T believe
+impossible things.’
+
+‘I daresay you haven’t had much practice,’ said the Queen. ‘When I was
+your age, I always did it for half-an-hour a day. Why, sometimes I’ve
+believed as many as six impossible things before breakfast. There goes
+the shawl again!’
+
+The brooch had come undone as she spoke, and a sudden gust of wind blew
+the Queen’s shawl across a little brook. The Queen spread out her arms
+again, and went flying after it, and this time she succeeded in catching
+it for herself. ‘I’ve got it!’ she cried in a triumphant tone. ‘Now you
+shall see me pin it on again, all by myself!’
+
+‘Then I hope your finger is better now?’ Alice said very politely, as
+she crossed the little brook after the Queen.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Oh, much better!’ cried the Queen, her voice rising to a squeak as she
+went on. ‘Much be-etter! Be-etter! Be-e-e-etter! Be-e-ehh!’ The last
+word ended in a long bleat, so like a sheep that Alice quite started.
+
+She looked at the Queen, who seemed to have suddenly wrapped herself up
+in wool. Alice rubbed her eyes, and looked again. She couldn’t make out
+what had happened at all. Was she in a shop? And was that really--was it
+really a SHEEP that was sitting on the other side of the counter? Rub as
+she could, she could make nothing more of it: she was in a little dark
+shop, leaning with her elbows on the counter, and opposite to her was
+an old Sheep, sitting in an arm-chair knitting, and every now and then
+leaving off to look at her through a great pair of spectacles.
+
+‘What is it you want to buy?’ the Sheep said at last, looking up for a
+moment from her knitting.
+
+‘I don’t QUITE know yet,’ Alice said, very gently. ‘I should like to
+look all round me first, if I might.’
+
+‘You may look in front of you, and on both sides, if you like,’ said the
+Sheep: ‘but you can’t look ALL round you--unless you’ve got eyes at the
+back of your head.’
+
+But these, as it happened, Alice had NOT got: so she contented herself
+with turning round, looking at the shelves as she came to them.
+
+The shop seemed to be full of all manner of curious things--but the
+oddest part of it all was, that whenever she looked hard at any shelf,
+to make out exactly what it had on it, that particular shelf was always
+quite empty: though the others round it were crowded as full as they
+could hold.
+
+‘Things flow about so here!’ she said at last in a plaintive tone, after
+she had spent a minute or so in vainly pursuing a large bright thing,
+that looked sometimes like a doll and sometimes like a work-box, and was
+always in the shelf next above the one she was looking at. ‘And this one
+is the most provoking of all--but I’ll tell you what--’ she added, as a
+sudden thought struck her, ‘I’ll follow it up to the very top shelf of
+all. It’ll puzzle it to go through the ceiling, I expect!’
+
+But even this plan failed: the ‘thing’ went through the ceiling as
+quietly as possible, as if it were quite used to it.
+
+‘Are you a child or a teetotum?’ the Sheep said, as she took up another
+pair of needles. ‘You’ll make me giddy soon, if you go on turning round
+like that.’ She was now working with fourteen pairs at once, and Alice
+couldn’t help looking at her in great astonishment.
+
+‘How CAN she knit with so many?’ the puzzled child thought to herself.
+‘She gets more and more like a porcupine every minute!’
+
+‘Can you row?’ the Sheep asked, handing her a pair of knitting-needles
+as she spoke.
+
+‘Yes, a little--but not on land--and not with needles--’ Alice was
+beginning to say, when suddenly the needles turned into oars in her
+hands, and she found they were in a little boat, gliding along between
+banks: so there was nothing for it but to do her best.
+
+‘Feather!’ cried the Sheep, as she took up another pair of needles.
+
+This didn’t sound like a remark that needed any answer, so Alice said
+nothing, but pulled away. There was something very queer about the
+water, she thought, as every now and then the oars got fast in it, and
+would hardly come out again.
+
+‘Feather! Feather!’ the Sheep cried again, taking more needles. ‘You’ll
+be catching a crab directly.’
+
+‘A dear little crab!’ thought Alice. ‘I should like that.’
+
+‘Didn’t you hear me say “Feather”?’ the Sheep cried angrily, taking up
+quite a bunch of needles.
+
+‘Indeed I did,’ said Alice: ‘you’ve said it very often--and very loud.
+Please, where ARE the crabs?’
+
+‘In the water, of course!’ said the Sheep, sticking some of the needles
+into her hair, as her hands were full. ‘Feather, I say!’
+
+‘WHY do you say “feather” so often?’ Alice asked at last, rather vexed.
+‘I’m not a bird!’
+
+‘You are,’ said the Sheep: ‘you’re a little goose.’
+
+This offended Alice a little, so there was no more conversation for a
+minute or two, while the boat glided gently on, sometimes among beds of
+weeds (which made the oars stick fast in the water, worse then ever),
+and sometimes under trees, but always with the same tall river-banks
+frowning over their heads.
+
+‘Oh, please! There are some scented rushes!’ Alice cried in a sudden
+transport of delight. ‘There really are--and SUCH beauties!’
+
+‘You needn’t say “please” to ME about ‘em,’ the Sheep said, without
+looking up from her knitting: ‘I didn’t put ‘em there, and I’m not going
+to take ‘em away.’
+
+‘No, but I meant--please, may we wait and pick some?’ Alice pleaded. ‘If
+you don’t mind stopping the boat for a minute.’
+
+‘How am _I_ to stop it?’ said the Sheep. ‘If you leave off rowing, it’ll
+stop of itself.’
+
+So the boat was left to drift down the stream as it would, till it
+glided gently in among the waving rushes. And then the little sleeves
+were carefully rolled up, and the little arms were plunged in elbow-deep
+to get the rushes a good long way down before breaking them off--and for
+a while Alice forgot all about the Sheep and the knitting, as she
+bent over the side of the boat, with just the ends of her tangled hair
+dipping into the water--while with bright eager eyes she caught at one
+bunch after another of the darling scented rushes.
+
+‘I only hope the boat won’t tipple over!’ she said to herself. ‘Oh, WHAT
+a lovely one! Only I couldn’t quite reach it.’ ‘And it certainly DID
+seem a little provoking (‘almost as if it happened on purpose,’ she
+thought) that, though she managed to pick plenty of beautiful rushes as
+the boat glided by, there was always a more lovely one that she couldn’t
+reach.
+
+‘The prettiest are always further!’ she said at last, with a sigh at the
+obstinacy of the rushes in growing so far off, as, with flushed cheeks
+and dripping hair and hands, she scrambled back into her place, and
+began to arrange her new-found treasures.
+
+What mattered it to her just then that the rushes had begun to fade, and
+to lose all their scent and beauty, from the very moment that she
+picked them? Even real scented rushes, you know, last only a very little
+while--and these, being dream-rushes, melted away almost like snow, as
+they lay in heaps at her feet--but Alice hardly noticed this, there were
+so many other curious things to think about.
+
+They hadn’t gone much farther before the blade of one of the oars got
+fast in the water and WOULDN’T come out again (so Alice explained it
+afterwards), and the consequence was that the handle of it caught her
+under the chin, and, in spite of a series of little shrieks of ‘Oh, oh,
+oh!’ from poor Alice, it swept her straight off the seat, and down among
+the heap of rushes.
+
+However, she wasn’t hurt, and was soon up again: the Sheep went on with
+her knitting all the while, just as if nothing had happened. ‘That was
+a nice crab you caught!’ she remarked, as Alice got back into her place,
+very much relieved to find herself still in the boat.
+
+‘Was it? I didn’t see it,’ Said Alice, peeping cautiously over the side
+of the boat into the dark water. ‘I wish it hadn’t let go--I should
+so like to see a little crab to take home with me!’ But the Sheep only
+laughed scornfully, and went on with her knitting.
+
+‘Are there many crabs here?’ said Alice.
+
+‘Crabs, and all sorts of things,’ said the Sheep: ‘plenty of choice,
+only make up your mind. Now, what DO you want to buy?’
+
+‘To buy!’ Alice echoed in a tone that was half astonished and half
+frightened--for the oars, and the boat, and the river, had vanished all
+in a moment, and she was back again in the little dark shop.
+
+‘I should like to buy an egg, please,’ she said timidly. ‘How do you
+sell them?’
+
+‘Fivepence farthing for one--Twopence for two,’ the Sheep replied.
+
+‘Then two are cheaper than one?’ Alice said in a surprised tone, taking
+out her purse.
+
+‘Only you MUST eat them both, if you buy two,’ said the Sheep.
+
+‘Then I’ll have ONE, please,’ said Alice, as she put the money down on
+the counter. For she thought to herself, ‘They mightn’t be at all nice,
+you know.’
+
+The Sheep took the money, and put it away in a box: then she said ‘I
+never put things into people’s hands--that would never do--you must get
+it for yourself.’ And so saying, she went off to the other end of the
+shop, and set the egg upright on a shelf.
+
+‘I wonder WHY it wouldn’t do?’ thought Alice, as she groped her way
+among the tables and chairs, for the shop was very dark towards the end.
+‘The egg seems to get further away the more I walk towards it. Let me
+see, is this a chair? Why, it’s got branches, I declare! How very odd to
+find trees growing here! And actually here’s a little brook! Well, this
+is the very queerest shop I ever saw!’
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+
+So she went on, wondering more and more at every step, as everything
+turned into a tree the moment she came up to it, and she quite expected
+the egg to do the same.
+
+
+
+
+CHAPTER VI. Humpty Dumpty
+
+However, the egg only got larger and larger, and more and more human:
+when she had come within a few yards of it, she saw that it had eyes
+and a nose and mouth; and when she had come close to it, she saw clearly
+that it was HUMPTY DUMPTY himself. ‘It can’t be anybody else!’ she said
+to herself. ‘I’m as certain of it, as if his name were written all over
+his face.’
+
+It might have been written a hundred times, easily, on that enormous
+face. Humpty Dumpty was sitting with his legs crossed, like a Turk, on
+the top of a high wall--such a narrow one that Alice quite wondered how
+he could keep his balance--and, as his eyes were steadily fixed in the
+opposite direction, and he didn’t take the least notice of her, she
+thought he must be a stuffed figure after all.
+
+‘And how exactly like an egg he is!’ she said aloud, standing with her
+hands ready to catch him, for she was every moment expecting him to
+fall.
+
+‘It’s VERY provoking,’ Humpty Dumpty said after a long silence, looking
+away from Alice as he spoke, ‘to be called an egg--VERY!’
+
+‘I said you LOOKED like an egg, Sir,’ Alice gently explained. ‘And some
+eggs are very pretty, you know’ she added, hoping to turn her remark
+into a sort of a compliment.
+
+‘Some people,’ said Humpty Dumpty, looking away from her as usual, ‘have
+no more sense than a baby!’
+
+Alice didn’t know what to say to this: it wasn’t at all like
+conversation, she thought, as he never said anything to HER; in fact,
+his last remark was evidently addressed to a tree--so she stood and
+softly repeated to herself:--
+
+
+     ‘Humpty Dumpty sat on a wall:
+     Humpty Dumpty had a great fall.
+     All the King’s horses and all the King’s men
+     Couldn’t put Humpty Dumpty in his place again.’
+
+
+‘That last line is much too long for the poetry,’ she added, almost out
+loud, forgetting that Humpty Dumpty would hear her.
+
+‘Don’t stand there chattering to yourself like that,’ Humpty Dumpty
+said, looking at her for the first time, ‘but tell me your name and your
+business.’
+
+‘My NAME is Alice, but--’
+
+‘It’s a stupid enough name!’ Humpty Dumpty interrupted impatiently.
+‘What does it mean?’
+
+‘MUST a name mean something?’ Alice asked doubtfully.
+
+‘Of course it must,’ Humpty Dumpty said with a short laugh: ‘MY name
+means the shape I am--and a good handsome shape it is, too. With a name
+like yours, you might be any shape, almost.’
+
+‘Why do you sit out here all alone?’ said Alice, not wishing to begin an
+argument.
+
+‘Why, because there’s nobody with me!’ cried Humpty Dumpty. ‘Did you
+think I didn’t know the answer to THAT? Ask another.’
+
+‘Don’t you think you’d be safer down on the ground?’ Alice went on, not
+with any idea of making another riddle, but simply in her good-natured
+anxiety for the queer creature. ‘That wall is so VERY narrow!’
+
+‘What tremendously easy riddles you ask!’ Humpty Dumpty growled out. ‘Of
+course I don’t think so! Why, if ever I DID fall off--which there’s no
+chance of--but IF I did--’ Here he pursed up his lips and looked so solemn
+and grand that Alice could hardly help laughing. ‘IF I did fall,’ he
+went on, ‘THE KING HAS PROMISED ME--ah, you may turn pale, if you like!
+You didn’t think I was going to say that, did you? THE KING HAS PROMISED ME--
+WITH HIS VERY OWN MOUTH--to--to--’
+
+‘To send all his horses and all his men,’ Alice interrupted, rather
+unwisely.
+
+‘Now I declare that’s too bad!’ Humpty Dumpty cried, breaking into a
+sudden passion. ‘You’ve been listening at doors--and behind trees--and
+down chimneys--or you couldn’t have known it!’
+
+‘I haven’t, indeed!’ Alice said very gently. ‘It’s in a book.’
+
+‘Ah, well! They may write such things in a BOOK,’ Humpty Dumpty said in
+a calmer tone. ‘That’s what you call a History of England, that is.
+Now, take a good look at me! I’m one that has spoken to a King, _I_ am:
+mayhap you’ll never see such another: and to show you I’m not proud, you
+may shake hands with me!’ And he grinned almost from ear to ear, as he
+leant forwards (and as nearly as possible fell off the wall in doing so)
+and offered Alice his hand. She watched him a little anxiously as she
+took it. ‘If he smiled much more, the ends of his mouth might meet
+behind,’ she thought: ‘and then I don’t know what would happen to his
+head! I’m afraid it would come off!’
+
+‘Yes, all his horses and all his men,’ Humpty Dumpty went on. ‘They’d
+pick me up again in a minute, THEY would! However, this conversation is
+going on a little too fast: let’s go back to the last remark but one.’
+
+‘I’m afraid I can’t quite remember it,’ Alice said very politely.
+
+‘In that case we start fresh,’ said Humpty Dumpty, ‘and it’s my turn
+to choose a subject--’ (‘He talks about it just as if it was a game!’
+thought Alice.) ‘So here’s a question for you. How old did you say you
+were?’
+
+Alice made a short calculation, and said ‘Seven years and six months.’
+
+‘Wrong!’ Humpty Dumpty exclaimed triumphantly. ‘You never said a word
+like it!’
+
+‘I though you meant “How old ARE you?”’ Alice explained.
+
+‘If I’d meant that, I’d have said it,’ said Humpty Dumpty.
+
+Alice didn’t want to begin another argument, so she said nothing.
+
+‘Seven years and six months!’ Humpty Dumpty repeated thoughtfully. ‘An
+uncomfortable sort of age. Now if you’d asked MY advice, I’d have said
+“Leave off at seven”--but it’s too late now.’
+
+‘I never ask advice about growing,’ Alice said indignantly.
+
+‘Too proud?’ the other inquired.
+
+Alice felt even more indignant at this suggestion. ‘I mean,’ she said,
+‘that one can’t help growing older.’
+
+‘ONE can’t, perhaps,’ said Humpty Dumpty, ‘but TWO can. With proper
+assistance, you might have left off at seven.’
+
+‘What a beautiful belt you’ve got on!’ Alice suddenly remarked.
+
+(They had had quite enough of the subject of age, she thought: and if
+they really were to take turns in choosing subjects, it was her turn
+now.) ‘At least,’ she corrected herself on second thoughts, ‘a beautiful
+cravat, I should have said--no, a belt, I mean--I beg your pardon!’ she
+added in dismay, for Humpty Dumpty looked thoroughly offended, and she
+began to wish she hadn’t chosen that subject. ‘If I only knew,’ she
+thought to herself, ‘which was neck and which was waist!’
+
+Evidently Humpty Dumpty was very angry, though he said nothing for a
+minute or two. When he DID speak again, it was in a deep growl.
+
+‘It is a--MOST--PROVOKING--thing,’ he said at last, ‘when a person
+doesn’t know a cravat from a belt!’
+
+‘I know it’s very ignorant of me,’ Alice said, in so humble a tone that
+Humpty Dumpty relented.
+
+‘It’s a cravat, child, and a beautiful one, as you say. It’s a present
+from the White King and Queen. There now!’
+
+‘Is it really?’ said Alice, quite pleased to find that she HAD chosen a
+good subject, after all.
+
+‘They gave it me,’ Humpty Dumpty continued thoughtfully, as he crossed
+one knee over the other and clasped his hands round it, ‘they gave it
+me--for an un-birthday present.’
+
+‘I beg your pardon?’ Alice said with a puzzled air.
+
+‘I’m not offended,’ said Humpty Dumpty.
+
+‘I mean, what IS an un-birthday present?’
+
+‘A present given when it isn’t your birthday, of course.’
+
+Alice considered a little. ‘I like birthday presents best,’ she said at
+last.
+
+‘You don’t know what you’re talking about!’ cried Humpty Dumpty. ‘How
+many days are there in a year?’
+
+‘Three hundred and sixty-five,’ said Alice.
+
+‘And how many birthdays have you?’
+
+‘One.’
+
+‘And if you take one from three hundred and sixty-five, what remains?’
+
+‘Three hundred and sixty-four, of course.’
+
+Humpty Dumpty looked doubtful. ‘I’d rather see that done on paper,’ he
+said.
+
+Alice couldn’t help smiling as she took out her memorandum-book, and
+worked the sum for him:
+
+
+               365
+                1
+               ____
+
+               364
+               ___
+
+Humpty Dumpty took the book, and looked at it carefully. ‘That seems to
+be done right--’ he began.
+
+‘You’re holding it upside down!’ Alice interrupted.
+
+‘To be sure I was!’ Humpty Dumpty said gaily, as she turned it round for
+him. ‘I thought it looked a little queer. As I was saying, that SEEMS
+to be done right--though I haven’t time to look it over thoroughly just
+now--and that shows that there are three hundred and sixty-four days
+when you might get un-birthday presents--’
+
+‘Certainly,’ said Alice.
+
+‘And only ONE for birthday presents, you know. There’s glory for you!’
+
+‘I don’t know what you mean by “glory,”’ Alice said.
+
+Humpty Dumpty smiled contemptuously. ‘Of course you don’t--till I tell
+you. I meant “there’s a nice knock-down argument for you!”’
+
+‘But “glory” doesn’t mean “a nice knock-down argument,”’ Alice objected.
+
+‘When _I_ use a word,’ Humpty Dumpty said in rather a scornful tone, ‘it
+means just what I choose it to mean--neither more nor less.’
+
+‘The question is,’ said Alice, ‘whether you CAN make words mean so many
+different things.’
+
+‘The question is,’ said Humpty Dumpty, ‘which is to be master--that’s
+all.’
+
+Alice was too much puzzled to say anything, so after a minute Humpty
+Dumpty began again. ‘They’ve a temper, some of them--particularly verbs,
+they’re the proudest--adjectives you can do anything with, but not
+verbs--however, _I_ can manage the whole lot of them! Impenetrability!
+That’s what _I_ say!’
+
+‘Would you tell me, please,’ said Alice ‘what that means?’
+
+‘Now you talk like a reasonable child,’ said Humpty Dumpty, looking very
+much pleased. ‘I meant by “impenetrability” that we’ve had enough of
+that subject, and it would be just as well if you’d mention what you
+mean to do next, as I suppose you don’t mean to stop here all the rest
+of your life.’
+
+‘That’s a great deal to make one word mean,’ Alice said in a thoughtful
+tone.
+
+‘When I make a word do a lot of work like that,’ said Humpty Dumpty, ‘I
+always pay it extra.’
+
+‘Oh!’ said Alice. She was too much puzzled to make any other remark.
+
+‘Ah, you should see ‘em come round me of a Saturday night,’ Humpty
+Dumpty went on, wagging his head gravely from side to side: ‘for to get
+their wages, you know.’
+
+(Alice didn’t venture to ask what he paid them with; and so you see I
+can’t tell YOU.)
+
+‘You seem very clever at explaining words, Sir,’ said Alice. ‘Would you
+kindly tell me the meaning of the poem called “Jabberwocky”?’
+
+‘Let’s hear it,’ said Humpty Dumpty. ‘I can explain all the poems that
+were ever invented--and a good many that haven’t been invented just
+yet.’
+
+This sounded very hopeful, so Alice repeated the first verse:
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+‘That’s enough to begin with,’ Humpty Dumpty interrupted: ‘there
+are plenty of hard words there. “BRILLIG” means four o’clock in the
+afternoon--the time when you begin BROILING things for dinner.’
+
+‘That’ll do very well,’ said Alice: ‘and “SLITHY”?’
+
+‘Well, “SLITHY” means “lithe and slimy.” “Lithe” is the same as
+“active.” You see it’s like a portmanteau--there are two meanings packed
+up into one word.’
+
+‘I see it now,’ Alice remarked thoughtfully: ‘and what are “TOVES”?’
+
+‘Well, “TOVES” are something like badgers--they’re something like
+lizards--and they’re something like corkscrews.’
+
+‘They must be very curious looking creatures.’
+
+‘They are that,’ said Humpty Dumpty: ‘also they make their nests under
+sun-dials--also they live on cheese.’
+
+‘And what’s the “GYRE” and to “GIMBLE”?’
+
+‘To “GYRE” is to go round and round like a gyroscope. To “GIMBLE” is to
+make holes like a gimlet.’
+
+‘And “THE WABE” is the grass-plot round a sun-dial, I suppose?’ said
+Alice, surprised at her own ingenuity.
+
+‘Of course it is. It’s called “WABE,” you know, because it goes a long
+way before it, and a long way behind it--’
+
+‘And a long way beyond it on each side,’ Alice added.
+
+‘Exactly so. Well, then, “MIMSY” is “flimsy and miserable” (there’s
+another portmanteau for you). And a “BOROGOVE” is a thin shabby-looking
+bird with its feathers sticking out all round--something like a live
+mop.’
+
+‘And then “MOME RATHS”?’ said Alice. ‘I’m afraid I’m giving you a great
+deal of trouble.’
+
+‘Well, a “RATH” is a sort of green pig: but “MOME” I’m not certain
+about. I think it’s short for “from home”--meaning that they’d lost
+their way, you know.’
+
+‘And what does “OUTGRABE” mean?’
+
+‘Well, “OUTGRABING” is something between bellowing and whistling, with a
+kind of sneeze in the middle: however, you’ll hear it done, maybe--down
+in the wood yonder--and when you’ve once heard it you’ll be QUITE
+content. Who’s been repeating all that hard stuff to you?’
+
+‘I read it in a book,’ said Alice. ‘But I had some poetry repeated to
+me, much easier than that, by--Tweedledee, I think it was.’
+
+‘As to poetry, you know,’ said Humpty Dumpty, stretching out one of his
+great hands, ‘_I_ can repeat poetry as well as other folk, if it comes
+to that--’
+
+‘Oh, it needn’t come to that!’ Alice hastily said, hoping to keep him
+from beginning.
+
+‘The piece I’m going to repeat,’ he went on without noticing her remark,
+‘was written entirely for your amusement.’
+
+Alice felt that in that case she really OUGHT to listen to it, so she
+sat down, and said ‘Thank you’ rather sadly.
+
+
+     ‘In winter, when the fields are white,
+     I sing this song for your delight--
+
+
+only I don’t sing it,’ he added, as an explanation.
+
+‘I see you don’t,’ said Alice.
+
+‘If you can SEE whether I’m singing or not, you’ve sharper eyes than
+most.’ Humpty Dumpty remarked severely. Alice was silent.
+
+
+     ‘In spring, when woods are getting green,
+     I’ll try and tell you what I mean.’
+
+
+‘Thank you very much,’ said Alice.
+
+
+     ‘In summer, when the days are long,
+     Perhaps you’ll understand the song:
+     In autumn, when the leaves are brown,
+     Take pen and ink, and write it down.’
+
+
+‘I will, if I can remember it so long,’ said Alice.
+
+‘You needn’t go on making remarks like that,’ Humpty Dumpty said:
+‘they’re not sensible, and they put me out.’
+
+     ‘I sent a message to the fish:
+     I told them “This is what I wish.”
+
+     The little fishes of the sea,
+     They sent an answer back to me.
+
+     The little fishes’ answer was
+     “We cannot do it, Sir, because--“’
+
+
+‘I’m afraid I don’t quite understand,’ said Alice.
+
+‘It gets easier further on,’ Humpty Dumpty replied.
+
+
+     ‘I sent to them again to say
+     “It will be better to obey.”
+
+     The fishes answered with a grin,
+     “Why, what a temper you are in!”
+
+     I told them once, I told them twice:
+     They would not listen to advice.
+
+     I took a kettle large and new,
+     Fit for the deed I had to do.
+
+     My heart went hop, my heart went thump;
+     I filled the kettle at the pump.
+
+     Then some one came to me and said,
+     “The little fishes are in bed.”
+
+     I said to him, I said it plain,
+     “Then you must wake them up again.”
+
+     I said it very loud and clear;
+     I went and shouted in his ear.’
+
+
+Humpty Dumpty raised his voice almost to a scream as he repeated this
+verse, and Alice thought with a shudder, ‘I wouldn’t have been the
+messenger for ANYTHING!’
+
+
+     ‘But he was very stiff and proud;
+     He said “You needn’t shout so loud!”
+
+     And he was very proud and stiff;
+     He said “I’d go and wake them, if--”
+
+     I took a corkscrew from the shelf:
+     I went to wake them up myself.
+
+     And when I found the door was locked,
+     I pulled and pushed and kicked and knocked.
+
+     And when I found the door was shut,
+     I tried to turn the handle, but--’
+
+
+There was a long pause.
+
+‘Is that all?’ Alice timidly asked.
+
+‘That’s all,’ said Humpty Dumpty. ‘Good-bye.’
+
+This was rather sudden, Alice thought: but, after such a VERY strong
+hint that she ought to be going, she felt that it would hardly be civil
+to stay. So she got up, and held out her hand. ‘Good-bye, till we meet
+again!’ she said as cheerfully as she could.
+
+‘I shouldn’t know you again if we DID meet,’ Humpty Dumpty replied in
+a discontented tone, giving her one of his fingers to shake; ‘you’re so
+exactly like other people.’
+
+‘The face is what one goes by, generally,’ Alice remarked in a
+thoughtful tone.
+
+‘That’s just what I complain of,’ said Humpty Dumpty. ‘Your face is the
+same as everybody has--the two eyes, so--’ (marking their places in the
+air with this thumb) ‘nose in the middle, mouth under. It’s always the
+same. Now if you had the two eyes on the same side of the nose, for
+instance--or the mouth at the top--that would be SOME help.’
+
+‘It wouldn’t look nice,’ Alice objected. But Humpty Dumpty only shut his
+eyes and said ‘Wait till you’ve tried.’
+
+Alice waited a minute to see if he would speak again, but as he never
+opened his eyes or took any further notice of her, she said ‘Good-bye!’
+once more, and, getting no answer to this, she quietly walked away:
+but she couldn’t help saying to herself as she went, ‘Of all the
+unsatisfactory--’ (she repeated this aloud, as it was a great comfort to
+have such a long word to say) ‘of all the unsatisfactory people I EVER
+met--’ She never finished the sentence, for at this moment a heavy crash
+shook the forest from end to end.
+
+
+
+
+CHAPTER VII. The Lion and the Unicorn
+
+The next moment soldiers came running through the wood, at first in twos
+and threes, then ten or twenty together, and at last in such crowds that
+they seemed to fill the whole forest. Alice got behind a tree, for fear
+of being run over, and watched them go by.
+
+She thought that in all her life she had never seen soldiers so
+uncertain on their feet: they were always tripping over something or
+other, and whenever one went down, several more always fell over him, so
+that the ground was soon covered with little heaps of men.
+
+Then came the horses. Having four feet, these managed rather better than
+the foot-soldiers: but even THEY stumbled now and then; and it seemed
+to be a regular rule that, whenever a horse stumbled the rider fell off
+instantly. The confusion got worse every moment, and Alice was very glad
+to get out of the wood into an open place, where she found the White
+King seated on the ground, busily writing in his memorandum-book.
+
+‘I’ve sent them all!’ the King cried in a tone of delight, on seeing
+Alice. ‘Did you happen to meet any soldiers, my dear, as you came
+through the wood?’
+
+‘Yes, I did,’ said Alice: ‘several thousand, I should think.’
+
+‘Four thousand two hundred and seven, that’s the exact number,’ the King
+said, referring to his book. ‘I couldn’t send all the horses, you know,
+because two of them are wanted in the game. And I haven’t sent the two
+Messengers, either. They’re both gone to the town. Just look along the
+road, and tell me if you can see either of them.’
+
+‘I see nobody on the road,’ said Alice.
+
+‘I only wish _I_ had such eyes,’ the King remarked in a fretful tone.
+‘To be able to see Nobody! And at that distance, too! Why, it’s as much
+as _I_ can do to see real people, by this light!’
+
+All this was lost on Alice, who was still looking intently along
+the road, shading her eyes with one hand. ‘I see somebody now!’ she
+exclaimed at last. ‘But he’s coming very slowly--and what curious
+attitudes he goes into!’ (For the messenger kept skipping up and down,
+and wriggling like an eel, as he came along, with his great hands spread
+out like fans on each side.)
+
+‘Not at all,’ said the King. ‘He’s an Anglo-Saxon Messenger--and those
+are Anglo-Saxon attitudes. He only does them when he’s happy. His name
+is Haigha.’ (He pronounced it so as to rhyme with ‘mayor.’)
+
+‘I love my love with an H,’ Alice couldn’t help beginning, ‘because
+he is Happy. I hate him with an H, because he is Hideous. I fed him
+with--with--with Ham-sandwiches and Hay. His name is Haigha, and he
+lives--’
+
+‘He lives on the Hill,’ the King remarked simply, without the least idea
+that he was joining in the game, while Alice was still hesitating for
+the name of a town beginning with H. ‘The other Messenger’s called
+Hatta. I must have TWO, you know--to come and go. One to come, and one
+to go.’
+
+‘I beg your pardon?’ said Alice.
+
+‘It isn’t respectable to beg,’ said the King.
+
+‘I only meant that I didn’t understand,’ said Alice. ‘Why one to come
+and one to go?’
+
+‘Didn’t I tell you?’ the King repeated impatiently. ‘I must have Two--to
+fetch and carry. One to fetch, and one to carry.’
+
+At this moment the Messenger arrived: he was far too much out of breath
+to say a word, and could only wave his hands about, and make the most
+fearful faces at the poor King.
+
+‘This young lady loves you with an H,’ the King said, introducing Alice
+in the hope of turning off the Messenger’s attention from himself--but
+it was no use--the Anglo-Saxon attitudes only got more extraordinary
+every moment, while the great eyes rolled wildly from side to side.
+
+‘You alarm me!’ said the King. ‘I feel faint--Give me a ham sandwich!’
+
+On which the Messenger, to Alice’s great amusement, opened a bag that
+hung round his neck, and handed a sandwich to the King, who devoured it
+greedily.
+
+‘Another sandwich!’ said the King.
+
+‘There’s nothing but hay left now,’ the Messenger said, peeping into the
+bag.
+
+‘Hay, then,’ the King murmured in a faint whisper.
+
+Alice was glad to see that it revived him a good deal. ‘There’s nothing
+like eating hay when you’re faint,’ he remarked to her, as he munched
+away.
+
+‘I should think throwing cold water over you would be better,’ Alice
+suggested: ‘or some sal-volatile.’
+
+‘I didn’t say there was nothing BETTER,’ the King replied. ‘I said there
+was nothing LIKE it.’ Which Alice did not venture to deny.
+
+‘Who did you pass on the road?’ the King went on, holding out his hand
+to the Messenger for some more hay.
+
+‘Nobody,’ said the Messenger.
+
+‘Quite right,’ said the King: ‘this young lady saw him too. So of course
+Nobody walks slower than you.’
+
+‘I do my best,’ the Messenger said in a sulky tone. ‘I’m sure nobody
+walks much faster than I do!’
+
+‘He can’t do that,’ said the King, ‘or else he’d have been here first.
+However, now you’ve got your breath, you may tell us what’s happened in
+the town.’
+
+‘I’ll whisper it,’ said the Messenger, putting his hands to his mouth
+in the shape of a trumpet, and stooping so as to get close to the King’s
+ear. Alice was sorry for this, as she wanted to hear the news too.
+However, instead of whispering, he simply shouted at the top of his
+voice ‘They’re at it again!’
+
+‘Do you call THAT a whisper?’ cried the poor King, jumping up and
+shaking himself. ‘If you do such a thing again, I’ll have you buttered!
+It went through and through my head like an earthquake!’
+
+‘It would have to be a very tiny earthquake!’ thought Alice. ‘Who are at
+it again?’ she ventured to ask.
+
+‘Why the Lion and the Unicorn, of course,’ said the King.
+
+‘Fighting for the crown?’
+
+‘Yes, to be sure,’ said the King: ‘and the best of the joke is, that
+it’s MY crown all the while! Let’s run and see them.’ And they trotted
+off, Alice repeating to herself, as she ran, the words of the old
+song:--
+
+
+   ‘The Lion and the Unicorn were fighting for the crown:
+   The Lion beat the Unicorn all round the town.
+   Some gave them white bread, some gave them brown;
+   Some gave them plum-cake and drummed them out of town.’
+
+
+‘Does--the one--that wins--get the crown?’ she asked, as well as she
+could, for the run was putting her quite out of breath.
+
+‘Dear me, no!’ said the King. ‘What an idea!’
+
+‘Would you--be good enough,’ Alice panted out, after running a little
+further, ‘to stop a minute--just to get--one’s breath again?’
+
+‘I’m GOOD enough,’ the King said, ‘only I’m not strong enough. You see,
+a minute goes by so fearfully quick. You might as well try to stop a
+Bandersnatch!’
+
+Alice had no more breath for talking, so they trotted on in silence,
+till they came in sight of a great crowd, in the middle of which the
+Lion and Unicorn were fighting. They were in such a cloud of dust, that
+at first Alice could not make out which was which: but she soon managed
+to distinguish the Unicorn by his horn.
+
+They placed themselves close to where Hatta, the other messenger, was
+standing watching the fight, with a cup of tea in one hand and a piece
+of bread-and-butter in the other.
+
+‘He’s only just out of prison, and he hadn’t finished his tea when
+he was sent in,’ Haigha whispered to Alice: ‘and they only give them
+oyster-shells in there--so you see he’s very hungry and thirsty. How
+are you, dear child?’ he went on, putting his arm affectionately round
+Hatta’s neck.
+
+Hatta looked round and nodded, and went on with his bread and butter.
+
+‘Were you happy in prison, dear child?’ said Haigha.
+
+Hatta looked round once more, and this time a tear or two trickled down
+his cheek: but not a word would he say.
+
+‘Speak, can’t you!’ Haigha cried impatiently. But Hatta only munched
+away, and drank some more tea.
+
+‘Speak, won’t you!’ cried the King. ‘How are they getting on with the
+fight?’
+
+Hatta made a desperate effort, and swallowed a large piece of
+bread-and-butter. ‘They’re getting on very well,’ he said in a choking
+voice: ‘each of them has been down about eighty-seven times.’
+
+‘Then I suppose they’ll soon bring the white bread and the brown?’ Alice
+ventured to remark.
+
+‘It’s waiting for ‘em now,’ said Hatta: ‘this is a bit of it as I’m
+eating.’
+
+There was a pause in the fight just then, and the Lion and the Unicorn
+sat down, panting, while the King called out ‘Ten minutes allowed for
+refreshments!’ Haigha and Hatta set to work at once, carrying rough
+trays of white and brown bread. Alice took a piece to taste, but it was
+VERY dry.
+
+‘I don’t think they’ll fight any more to-day,’ the King said to Hatta:
+‘go and order the drums to begin.’ And Hatta went bounding away like a
+grasshopper.
+
+For a minute or two Alice stood silent, watching him. Suddenly she
+brightened up. ‘Look, look!’ she cried, pointing eagerly. ‘There’s the
+White Queen running across the country! She came flying out of the wood
+over yonder--How fast those Queens CAN run!’
+
+‘There’s some enemy after her, no doubt,’ the King said, without even
+looking round. ‘That wood’s full of them.’
+
+‘But aren’t you going to run and help her?’ Alice asked, very much
+surprised at his taking it so quietly.
+
+‘No use, no use!’ said the King. ‘She runs so fearfully quick. You might
+as well try to catch a Bandersnatch! But I’ll make a memorandum about
+her, if you like--She’s a dear good creature,’ he repeated softly to
+himself, as he opened his memorandum-book. ‘Do you spell “creature” with
+a double “e”?’
+
+At this moment the Unicorn sauntered by them, with his hands in his
+pockets. ‘I had the best of it this time?’ he said to the King, just
+glancing at him as he passed.
+
+‘A little--a little,’ the King replied, rather nervously. ‘You shouldn’t
+have run him through with your horn, you know.’
+
+‘It didn’t hurt him,’ the Unicorn said carelessly, and he was going
+on, when his eye happened to fall upon Alice: he turned round rather
+instantly, and stood for some time looking at her with an air of the
+deepest disgust.
+
+‘What--is--this?’ he said at last.
+
+‘This is a child!’ Haigha replied eagerly, coming in front of Alice
+to introduce her, and spreading out both his hands towards her in an
+Anglo-Saxon attitude. ‘We only found it to-day. It’s as large as life,
+and twice as natural!’
+
+‘I always thought they were fabulous monsters!’ said the Unicorn. ‘Is it
+alive?’
+
+‘It can talk,’ said Haigha, solemnly.
+
+The Unicorn looked dreamily at Alice, and said ‘Talk, child.’
+
+Alice could not help her lips curling up into a smile as she began: ‘Do
+you know, I always thought Unicorns were fabulous monsters, too! I never
+saw one alive before!’
+
+‘Well, now that we HAVE seen each other,’ said the Unicorn, ‘if you’ll
+believe in me, I’ll believe in you. Is that a bargain?’
+
+‘Yes, if you like,’ said Alice.
+
+‘Come, fetch out the plum-cake, old man!’ the Unicorn went on, turning
+from her to the King. ‘None of your brown bread for me!’
+
+‘Certainly--certainly!’ the King muttered, and beckoned to Haigha. ‘Open
+the bag!’ he whispered. ‘Quick! Not that one--that’s full of hay!’
+
+Haigha took a large cake out of the bag, and gave it to Alice to hold,
+while he got out a dish and carving-knife. How they all came out of it
+Alice couldn’t guess. It was just like a conjuring-trick, she thought.
+
+The Lion had joined them while this was going on: he looked very
+tired and sleepy, and his eyes were half shut. ‘What’s this!’ he said,
+blinking lazily at Alice, and speaking in a deep hollow tone that
+sounded like the tolling of a great bell.
+
+‘Ah, what IS it, now?’ the Unicorn cried eagerly. ‘You’ll never guess!
+_I_ couldn’t.’
+
+The Lion looked at Alice wearily. ‘Are you animal--vegetable--or
+mineral?’ he said, yawning at every other word.
+
+‘It’s a fabulous monster!’ the Unicorn cried out, before Alice could
+reply.
+
+‘Then hand round the plum-cake, Monster,’ the Lion said, lying down and
+putting his chin on his paws. ‘And sit down, both of you,’ (to the King
+and the Unicorn): ‘fair play with the cake, you know!’
+
+The King was evidently very uncomfortable at having to sit down between
+the two great creatures; but there was no other place for him.
+
+‘What a fight we might have for the crown, NOW!’ the Unicorn said,
+looking slyly up at the crown, which the poor King was nearly shaking
+off his head, he trembled so much.
+
+‘I should win easy,’ said the Lion.
+
+‘I’m not so sure of that,’ said the Unicorn.
+
+‘Why, I beat you all round the town, you chicken!’ the Lion replied
+angrily, half getting up as he spoke.
+
+Here the King interrupted, to prevent the quarrel going on: he was very
+nervous, and his voice quite quivered. ‘All round the town?’ he
+said. ‘That’s a good long way. Did you go by the old bridge, or the
+market-place? You get the best view by the old bridge.’
+
+‘I’m sure I don’t know,’ the Lion growled out as he lay down again.
+‘There was too much dust to see anything. What a time the Monster is,
+cutting up that cake!’
+
+Alice had seated herself on the bank of a little brook, with the great
+dish on her knees, and was sawing away diligently with the knife. ‘It’s
+very provoking!’ she said, in reply to the Lion (she was getting quite
+used to being called ‘the Monster’). ‘I’ve cut several slices already,
+but they always join on again!’
+
+‘You don’t know how to manage Looking-glass cakes,’ the Unicorn
+remarked. ‘Hand it round first, and cut it afterwards.’
+
+This sounded nonsense, but Alice very obediently got up, and carried the
+dish round, and the cake divided itself into three pieces as she did so.
+‘NOW cut it up,’ said the Lion, as she returned to her place with the
+empty dish.
+
+‘I say, this isn’t fair!’ cried the Unicorn, as Alice sat with the knife
+in her hand, very much puzzled how to begin. ‘The Monster has given the
+Lion twice as much as me!’
+
+‘She’s kept none for herself, anyhow,’ said the Lion. ‘Do you like
+plum-cake, Monster?’
+
+But before Alice could answer him, the drums began.
+
+Where the noise came from, she couldn’t make out: the air seemed full
+of it, and it rang through and through her head till she felt quite
+deafened. She started to her feet and sprang across the little brook in
+her terror,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and had just time to see the Lion and the Unicorn rise to their feet,
+with angry looks at being interrupted in their feast, before she dropped
+to her knees, and put her hands over her ears, vainly trying to shut out
+the dreadful uproar.
+
+‘If THAT doesn’t “drum them out of town,”’ she thought to herself,
+‘nothing ever will!’
+
+
+
+
+CHAPTER VIII. ‘It’s my own Invention’
+
+After a while the noise seemed gradually to die away, till all was dead
+silence, and Alice lifted up her head in some alarm. There was no one
+to be seen, and her first thought was that she must have been dreaming
+about the Lion and the Unicorn and those queer Anglo-Saxon Messengers.
+However, there was the great dish still lying at her feet, on which she
+had tried to cut the plum-cake, ‘So I wasn’t dreaming, after all,’ she
+said to herself, ‘unless--unless we’re all part of the same dream. Only
+I do hope it’s MY dream, and not the Red King’s! I don’t like belonging
+to another person’s dream,’ she went on in a rather complaining tone:
+‘I’ve a great mind to go and wake him, and see what happens!’
+
+At this moment her thoughts were interrupted by a loud shouting of
+‘Ahoy! Ahoy! Check!’ and a Knight dressed in crimson armour came
+galloping down upon her, brandishing a great club. Just as he reached
+her, the horse stopped suddenly: ‘You’re my prisoner!’ the Knight cried,
+as he tumbled off his horse.
+
+Startled as she was, Alice was more frightened for him than for herself
+at the moment, and watched him with some anxiety as he mounted again.
+As soon as he was comfortably in the saddle, he began once more ‘You’re
+my--’ but here another voice broke in ‘Ahoy! Ahoy! Check!’ and Alice
+looked round in some surprise for the new enemy.
+
+This time it was a White Knight. He drew up at Alice’s side, and tumbled
+off his horse just as the Red Knight had done: then he got on again,
+and the two Knights sat and looked at each other for some time without
+speaking. Alice looked from one to the other in some bewilderment.
+
+‘She’s MY prisoner, you know!’ the Red Knight said at last.
+
+‘Yes, but then _I_ came and rescued her!’ the White Knight replied.
+
+‘Well, we must fight for her, then,’ said the Red Knight, as he took up
+his helmet (which hung from the saddle, and was something the shape of a
+horse’s head), and put it on.
+
+‘You will observe the Rules of Battle, of course?’ the White Knight
+remarked, putting on his helmet too.
+
+‘I always do,’ said the Red Knight, and they began banging away at each
+other with such fury that Alice got behind a tree to be out of the way
+of the blows.
+
+‘I wonder, now, what the Rules of Battle are,’ she said to herself, as
+she watched the fight, timidly peeping out from her hiding-place: ‘one
+Rule seems to be, that if one Knight hits the other, he knocks him off
+his horse, and if he misses, he tumbles off himself--and another Rule
+seems to be that they hold their clubs with their arms, as if they were
+Punch and Judy--What a noise they make when they tumble! Just like
+a whole set of fire-irons falling into the fender! And how quiet the
+horses are! They let them get on and off them just as if they were
+tables!’
+
+Another Rule of Battle, that Alice had not noticed, seemed to be that
+they always fell on their heads, and the battle ended with their both
+falling off in this way, side by side: when they got up again, they
+shook hands, and then the Red Knight mounted and galloped off.
+
+‘It was a glorious victory, wasn’t it?’ said the White Knight, as he
+came up panting.
+
+‘I don’t know,’ Alice said doubtfully. ‘I don’t want to be anybody’s
+prisoner. I want to be a Queen.’
+
+‘So you will, when you’ve crossed the next brook,’ said the White
+Knight. ‘I’ll see you safe to the end of the wood--and then I must go
+back, you know. That’s the end of my move.’
+
+‘Thank you very much,’ said Alice. ‘May I help you off with your
+helmet?’ It was evidently more than he could manage by himself; however,
+she managed to shake him out of it at last.
+
+‘Now one can breathe more easily,’ said the Knight, putting back his
+shaggy hair with both hands, and turning his gentle face and large mild
+eyes to Alice. She thought she had never seen such a strange-looking
+soldier in all her life.
+
+He was dressed in tin armour, which seemed to fit him very badly, and
+he had a queer-shaped little deal box fastened across his shoulder,
+upside-down, and with the lid hanging open. Alice looked at it with
+great curiosity.
+
+‘I see you’re admiring my little box.’ the Knight said in a friendly
+tone. ‘It’s my own invention--to keep clothes and sandwiches in. You see
+I carry it upside-down, so that the rain can’t get in.’
+
+‘But the things can get OUT,’ Alice gently remarked. ‘Do you know the
+lid’s open?’
+
+‘I didn’t know it,’ the Knight said, a shade of vexation passing over
+his face. ‘Then all the things must have fallen out! And the box is no
+use without them.’ He unfastened it as he spoke, and was just going to
+throw it into the bushes, when a sudden thought seemed to strike him,
+and he hung it carefully on a tree. ‘Can you guess why I did that?’ he
+said to Alice.
+
+Alice shook her head.
+
+‘In hopes some bees may make a nest in it--then I should get the honey.’
+
+‘But you’ve got a bee-hive--or something like one--fastened to the
+saddle,’ said Alice.
+
+‘Yes, it’s a very good bee-hive,’ the Knight said in a discontented
+tone, ‘one of the best kind. But not a single bee has come near it yet.
+And the other thing is a mouse-trap. I suppose the mice keep the bees
+out--or the bees keep the mice out, I don’t know which.’
+
+‘I was wondering what the mouse-trap was for,’ said Alice. ‘It isn’t
+very likely there would be any mice on the horse’s back.’
+
+‘Not very likely, perhaps,’ said the Knight: ‘but if they DO come, I
+don’t choose to have them running all about.’
+
+‘You see,’ he went on after a pause, ‘it’s as well to be provided for
+EVERYTHING. That’s the reason the horse has all those anklets round his
+feet.’
+
+‘But what are they for?’ Alice asked in a tone of great curiosity.
+
+‘To guard against the bites of sharks,’ the Knight replied. ‘It’s an
+invention of my own. And now help me on. I’ll go with you to the end of
+the wood--What’s the dish for?’
+
+‘It’s meant for plum-cake,’ said Alice.
+
+‘We’d better take it with us,’ the Knight said. ‘It’ll come in handy if
+we find any plum-cake. Help me to get it into this bag.’
+
+This took a very long time to manage, though Alice held the bag open
+very carefully, because the Knight was so VERY awkward in putting in
+the dish: the first two or three times that he tried he fell in himself
+instead. ‘It’s rather a tight fit, you see,’ he said, as they got it in
+a last; ‘There are so many candlesticks in the bag.’ And he hung it
+to the saddle, which was already loaded with bunches of carrots, and
+fire-irons, and many other things.
+
+‘I hope you’ve got your hair well fastened on?’ he continued, as they
+set off.
+
+‘Only in the usual way,’ Alice said, smiling.
+
+‘That’s hardly enough,’ he said, anxiously. ‘You see the wind is so VERY
+strong here. It’s as strong as soup.’
+
+‘Have you invented a plan for keeping the hair from being blown off?’
+Alice enquired.
+
+‘Not yet,’ said the Knight. ‘But I’ve got a plan for keeping it from
+FALLING off.’
+
+‘I should like to hear it, very much.’
+
+‘First you take an upright stick,’ said the Knight. ‘Then you make your
+hair creep up it, like a fruit-tree. Now the reason hair falls off is
+because it hangs DOWN--things never fall UPWARDS, you know. It’s a plan
+of my own invention. You may try it if you like.’
+
+It didn’t sound a comfortable plan, Alice thought, and for a few minutes
+she walked on in silence, puzzling over the idea, and every now and then
+stopping to help the poor Knight, who certainly was NOT a good rider.
+
+Whenever the horse stopped (which it did very often), he fell off in
+front; and whenever it went on again (which it generally did rather
+suddenly), he fell off behind. Otherwise he kept on pretty well, except
+that he had a habit of now and then falling off sideways; and as he
+generally did this on the side on which Alice was walking, she soon
+found that it was the best plan not to walk QUITE close to the horse.
+
+‘I’m afraid you’ve not had much practice in riding,’ she ventured to
+say, as she was helping him up from his fifth tumble.
+
+The Knight looked very much surprised, and a little offended at the
+remark. ‘What makes you say that?’ he asked, as he scrambled back into
+the saddle, keeping hold of Alice’s hair with one hand, to save himself
+from falling over on the other side.
+
+‘Because people don’t fall off quite so often, when they’ve had much
+practice.’
+
+‘I’ve had plenty of practice,’ the Knight said very gravely: ‘plenty of
+practice!’
+
+Alice could think of nothing better to say than ‘Indeed?’ but she said
+it as heartily as she could. They went on a little way in silence after
+this, the Knight with his eyes shut, muttering to himself, and Alice
+watching anxiously for the next tumble.
+
+‘The great art of riding,’ the Knight suddenly began in a loud voice,
+waving his right arm as he spoke, ‘is to keep--’ Here the sentence ended
+as suddenly as it had begun, as the Knight fell heavily on the top of
+his head exactly in the path where Alice was walking. She was quite
+frightened this time, and said in an anxious tone, as she picked him up,
+‘I hope no bones are broken?’
+
+‘None to speak of,’ the Knight said, as if he didn’t mind breaking two
+or three of them. ‘The great art of riding, as I was saying, is--to keep
+your balance properly. Like this, you know--’
+
+He let go the bridle, and stretched out both his arms to show Alice
+what he meant, and this time he fell flat on his back, right under the
+horse’s feet.
+
+‘Plenty of practice!’ he went on repeating, all the time that Alice was
+getting him on his feet again. ‘Plenty of practice!’
+
+‘It’s too ridiculous!’ cried Alice, losing all her patience this time.
+‘You ought to have a wooden horse on wheels, that you ought!’
+
+‘Does that kind go smoothly?’ the Knight asked in a tone of great
+interest, clasping his arms round the horse’s neck as he spoke, just in
+time to save himself from tumbling off again.
+
+‘Much more smoothly than a live horse,’ Alice said, with a little scream
+of laughter, in spite of all she could do to prevent it.
+
+‘I’ll get one,’ the Knight said thoughtfully to himself. ‘One or
+two--several.’
+
+There was a short silence after this, and then the Knight went on again.
+‘I’m a great hand at inventing things. Now, I daresay you noticed, that
+last time you picked me up, that I was looking rather thoughtful?’
+
+‘You WERE a little grave,’ said Alice.
+
+‘Well, just then I was inventing a new way of getting over a gate--would
+you like to hear it?’
+
+‘Very much indeed,’ Alice said politely.
+
+‘I’ll tell you how I came to think of it,’ said the Knight. ‘You see, I
+said to myself, “The only difficulty is with the feet: the HEAD is high
+enough already.” Now, first I put my head on the top of the gate--then I
+stand on my head--then the feet are high enough, you see--then I’m over,
+you see.’
+
+‘Yes, I suppose you’d be over when that was done,’ Alice said
+thoughtfully: ‘but don’t you think it would be rather hard?’
+
+‘I haven’t tried it yet,’ the Knight said, gravely: ‘so I can’t tell for
+certain--but I’m afraid it WOULD be a little hard.’
+
+He looked so vexed at the idea, that Alice changed the subject hastily.
+‘What a curious helmet you’ve got!’ she said cheerfully. ‘Is that your
+invention too?’
+
+The Knight looked down proudly at his helmet, which hung from the
+saddle. ‘Yes,’ he said, ‘but I’ve invented a better one than that--like
+a sugar loaf. When I used to wear it, if I fell off the horse, it always
+touched the ground directly. So I had a VERY little way to fall, you
+see--But there WAS the danger of falling INTO it, to be sure. That
+happened to me once--and the worst of it was, before I could get out
+again, the other White Knight came and put it on. He thought it was his
+own helmet.’
+
+The knight looked so solemn about it that Alice did not dare to laugh.
+‘I’m afraid you must have hurt him,’ she said in a trembling voice,
+‘being on the top of his head.’
+
+‘I had to kick him, of course,’ the Knight said, very seriously. ‘And
+then he took the helmet off again--but it took hours and hours to get me
+out. I was as fast as--as lightning, you know.’
+
+‘But that’s a different kind of fastness,’ Alice objected.
+
+The Knight shook his head. ‘It was all kinds of fastness with me, I can
+assure you!’ he said. He raised his hands in some excitement as he said
+this, and instantly rolled out of the saddle, and fell headlong into a
+deep ditch.
+
+Alice ran to the side of the ditch to look for him. She was rather
+startled by the fall, as for some time he had kept on very well, and she
+was afraid that he really WAS hurt this time. However, though she could
+see nothing but the soles of his feet, she was much relieved to hear
+that he was talking on in his usual tone. ‘All kinds of fastness,’
+he repeated: ‘but it was careless of him to put another man’s helmet
+on--with the man in it, too.’
+
+‘How CAN you go on talking so quietly, head downwards?’ Alice asked, as
+she dragged him out by the feet, and laid him in a heap on the bank.
+
+The Knight looked surprised at the question. ‘What does it matter where
+my body happens to be?’ he said. ‘My mind goes on working all the same.
+In fact, the more head downwards I am, the more I keep inventing new
+things.’
+
+‘Now the cleverest thing of the sort that I ever did,’ he went on after
+a pause, ‘was inventing a new pudding during the meat-course.’
+
+‘In time to have it cooked for the next course?’ said Alice. ‘Well,
+not the NEXT course,’ the Knight said in a slow thoughtful tone: ‘no,
+certainly not the next COURSE.’
+
+‘Then it would have to be the next day. I suppose you wouldn’t have two
+pudding-courses in one dinner?’
+
+‘Well, not the NEXT day,’ the Knight repeated as before: ‘not the next
+DAY. In fact,’ he went on, holding his head down, and his voice getting
+lower and lower, ‘I don’t believe that pudding ever WAS cooked! In fact,
+I don’t believe that pudding ever WILL be cooked! And yet it was a very
+clever pudding to invent.’
+
+‘What did you mean it to be made of?’ Alice asked, hoping to cheer him
+up, for the poor Knight seemed quite low-spirited about it.
+
+‘It began with blotting paper,’ the Knight answered with a groan.
+
+‘That wouldn’t be very nice, I’m afraid--’
+
+‘Not very nice ALONE,’ he interrupted, quite eagerly: ‘but you’ve no
+idea what a difference it makes mixing it with other things--such as
+gunpowder and sealing-wax. And here I must leave you.’ They had just
+come to the end of the wood.
+
+Alice could only look puzzled: she was thinking of the pudding.
+
+‘You are sad,’ the Knight said in an anxious tone: ‘let me sing you a
+song to comfort you.’
+
+‘Is it very long?’ Alice asked, for she had heard a good deal of poetry
+that day.
+
+‘It’s long,’ said the Knight, ‘but very, VERY beautiful. Everybody that
+hears me sing it--either it brings the TEARS into their eyes, or else--’
+
+‘Or else what?’ said Alice, for the Knight had made a sudden pause.
+
+‘Or else it doesn’t, you know. The name of the song is called “HADDOCKS’
+EYES.”’
+
+‘Oh, that’s the name of the song, is it?’ Alice said, trying to feel
+interested.
+
+‘No, you don’t understand,’ the Knight said, looking a little vexed.
+‘That’s what the name is CALLED. The name really IS “THE AGED AGED
+MAN.”’
+
+‘Then I ought to have said “That’s what the SONG is called”?’ Alice
+corrected herself.
+
+‘No, you oughtn’t: that’s quite another thing! The SONG is called “WAYS
+AND MEANS”: but that’s only what it’s CALLED, you know!’
+
+‘Well, what IS the song, then?’ said Alice, who was by this time
+completely bewildered.
+
+‘I was coming to that,’ the Knight said. ‘The song really IS “A-SITTING
+ON A GATE”: and the tune’s my own invention.’
+
+So saying, he stopped his horse and let the reins fall on its neck:
+then, slowly beating time with one hand, and with a faint smile lighting
+up his gentle foolish face, as if he enjoyed the music of his song, he
+began.
+
+Of all the strange things that Alice saw in her journey Through The
+Looking-Glass, this was the one that she always remembered most clearly.
+Years afterwards she could bring the whole scene back again, as if it
+had been only yesterday--the mild blue eyes and kindly smile of the
+Knight--the setting sun gleaming through his hair, and shining on his
+armour in a blaze of light that quite dazzled her--the horse quietly
+moving about, with the reins hanging loose on his neck, cropping the
+grass at her feet--and the black shadows of the forest behind--all this
+she took in like a picture, as, with one hand shading her eyes, she
+leant against a tree, watching the strange pair, and listening, in a
+half dream, to the melancholy music of the song.
+
+‘But the tune ISN’T his own invention,’ she said to herself: ‘it’s “I
+GIVE THEE ALL, I CAN NO MORE.”’ She stood and listened very attentively,
+but no tears came into her eyes.
+
+
+     ‘I’ll tell thee everything I can;
+      There’s little to relate.
+     I saw an aged aged man,
+      A-sitting on a gate.
+     “Who are you, aged man?” I said,
+      “and how is it you live?”
+      And his answer trickled through my head
+      Like water through a sieve.
+
+     He said “I look for butterflies
+      That sleep among the wheat:
+     I make them into mutton-pies,
+      And sell them in the street.
+     I sell them unto men,” he said,
+      “Who sail on stormy seas;
+     And that’s the way I get my bread--
+      A trifle, if you please.”
+
+     But I was thinking of a plan
+      To dye one’s whiskers green,
+     And always use so large a fan
+      That they could not be seen.
+     So, having no reply to give
+      To what the old man said,
+     I cried, “Come, tell me how you live!”
+       And thumped him on the head.
+
+     His accents mild took up the tale:
+      He said “I go my ways,
+     And when I find a mountain-rill,
+      I set it in a blaze;
+     And thence they make a stuff they call
+      Rolands’ Macassar Oil--
+     Yet twopence-halfpenny is all
+      They give me for my toil.”
+
+     But I was thinking of a way
+      To feed oneself on batter,
+     And so go on from day to day
+      Getting a little fatter.
+     I shook him well from side to side,
+      Until his face was blue:
+     “Come, tell me how you live,” I cried,
+      “And what it is you do!”
+
+     He said “I hunt for haddocks’ eyes
+      Among the heather bright,
+     And work them into waistcoat-buttons
+      In the silent night.
+     And these I do not sell for gold
+      Or coin of silvery shine
+     But for a copper halfpenny,
+      And that will purchase nine.
+
+     “I sometimes dig for buttered rolls,
+      Or set limed twigs for crabs;
+     I sometimes search the grassy knolls
+      For wheels of Hansom-cabs.
+     And that’s the way” (he gave a wink)
+      “By which I get my wealth--
+     And very gladly will I drink
+      Your Honour’s noble health.”
+
+     I heard him then, for I had just
+      Completed my design
+     To keep the Menai bridge from rust
+      By boiling it in wine.
+     I thanked him much for telling me
+      The way he got his wealth,
+     But chiefly for his wish that he
+      Might drink my noble health.
+
+     And now, if e’er by chance I put
+      My fingers into glue
+     Or madly squeeze a right-hand foot
+      Into a left-hand shoe,
+     Or if I drop upon my toe
+      A very heavy weight,
+     I weep, for it reminds me so,
+      Of that old man I used to know--
+
+     Whose look was mild, whose speech was slow,
+     Whose hair was whiter than the snow,
+     Whose face was very like a crow,
+     With eyes, like cinders, all aglow,
+     Who seemed distracted with his woe,
+     Who rocked his body to and fro,
+     And muttered mumblingly and low,
+     As if his mouth were full of dough,
+     Who snorted like a buffalo--
+     That summer evening, long ago,
+      A-sitting on a gate.’
+
+
+As the Knight sang the last words of the ballad, he gathered up the
+reins, and turned his horse’s head along the road by which they had
+come. ‘You’ve only a few yards to go,’ he said, ‘down the hill and over
+that little brook, and then you’ll be a Queen--But you’ll stay and
+see me off first?’ he added as Alice turned with an eager look in the
+direction to which he pointed. ‘I shan’t be long. You’ll wait and wave
+your handkerchief when I get to that turn in the road? I think it’ll
+encourage me, you see.’
+
+‘Of course I’ll wait,’ said Alice: ‘and thank you very much for coming
+so far--and for the song--I liked it very much.’
+
+‘I hope so,’ the Knight said doubtfully: ‘but you didn’t cry so much as
+I thought you would.’
+
+So they shook hands, and then the Knight rode slowly away into the
+forest. ‘It won’t take long to see him OFF, I expect,’ Alice said to
+herself, as she stood watching him. ‘There he goes! Right on his head as
+usual! However, he gets on again pretty easily--that comes of having so
+many things hung round the horse--’ So she went on talking to herself,
+as she watched the horse walking leisurely along the road, and the
+Knight tumbling off, first on one side and then on the other. After
+the fourth or fifth tumble he reached the turn, and then she waved her
+handkerchief to him, and waited till he was out of sight.
+
+‘I hope it encouraged him,’ she said, as she turned to run down the
+hill: ‘and now for the last brook, and to be a Queen! How grand it
+sounds!’ A very few steps brought her to the edge of the brook. ‘The
+Eighth Square at last!’ she cried as she bounded across,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and threw herself down to rest on a lawn as soft as moss, with little
+flower-beds dotted about it here and there. ‘Oh, how glad I am to get
+here! And what IS this on my head?’ she exclaimed in a tone of dismay,
+as she put her hands up to something very heavy, and fitted tight all
+round her head.
+
+‘But how CAN it have got there without my knowing it?’ she said to
+herself, as she lifted it off, and set it on her lap to make out what it
+could possibly be.
+
+It was a golden crown.
+
+
+
+
+CHAPTER IX. Queen Alice
+
+‘Well, this IS grand!’ said Alice. ‘I never expected I should be a Queen
+so soon--and I’ll tell you what it is, your majesty,’ she went on in
+a severe tone (she was always rather fond of scolding herself), ‘it’ll
+never do for you to be lolling about on the grass like that! Queens have
+to be dignified, you know!’
+
+So she got up and walked about--rather stiffly just at first, as she was
+afraid that the crown might come off: but she comforted herself with the
+thought that there was nobody to see her, ‘and if I really am a Queen,’
+she said as she sat down again, ‘I shall be able to manage it quite well
+in time.’
+
+Everything was happening so oddly that she didn’t feel a bit surprised
+at finding the Red Queen and the White Queen sitting close to her, one
+on each side: she would have liked very much to ask them how they came
+there, but she feared it would not be quite civil. However, there would
+be no harm, she thought, in asking if the game was over. ‘Please, would
+you tell me--’ she began, looking timidly at the Red Queen.
+
+‘Speak when you’re spoken to!’ The Queen sharply interrupted her.
+
+‘But if everybody obeyed that rule,’ said Alice, who was always ready
+for a little argument, ‘and if you only spoke when you were spoken to,
+and the other person always waited for YOU to begin, you see nobody
+would ever say anything, so that--’
+
+‘Ridiculous!’ cried the Queen. ‘Why, don’t you see, child--’ here she
+broke off with a frown, and, after thinking for a minute, suddenly
+changed the subject of the conversation. ‘What do you mean by “If you
+really are a Queen”? What right have you to call yourself so? You can’t
+be a Queen, you know, till you’ve passed the proper examination. And the
+sooner we begin it, the better.’
+
+‘I only said “if”!’ poor Alice pleaded in a piteous tone.
+
+The two Queens looked at each other, and the Red Queen remarked, with a
+little shudder, ‘She SAYS she only said “if”--’
+
+‘But she said a great deal more than that!’ the White Queen moaned,
+wringing her hands. ‘Oh, ever so much more than that!’
+
+‘So you did, you know,’ the Red Queen said to Alice. ‘Always speak the
+truth--think before you speak--and write it down afterwards.’
+
+‘I’m sure I didn’t mean--’ Alice was beginning, but the Red Queen
+interrupted her impatiently.
+
+‘That’s just what I complain of! You SHOULD have meant! What do you
+suppose is the use of child without any meaning? Even a joke should
+have some meaning--and a child’s more important than a joke, I hope. You
+couldn’t deny that, even if you tried with both hands.’
+
+‘I don’t deny things with my HANDS,’ Alice objected.
+
+‘Nobody said you did,’ said the Red Queen. ‘I said you couldn’t if you
+tried.’
+
+‘She’s in that state of mind,’ said the White Queen, ‘that she wants to
+deny SOMETHING--only she doesn’t know what to deny!’
+
+‘A nasty, vicious temper,’ the Red Queen remarked; and then there was an
+uncomfortable silence for a minute or two.
+
+The Red Queen broke the silence by saying to the White Queen, ‘I invite
+you to Alice’s dinner-party this afternoon.’
+
+The White Queen smiled feebly, and said ‘And I invite YOU.’
+
+‘I didn’t know I was to have a party at all,’ said Alice; ‘but if there
+is to be one, I think _I_ ought to invite the guests.’
+
+‘We gave you the opportunity of doing it,’ the Red Queen remarked: ‘but
+I daresay you’ve not had many lessons in manners yet?’
+
+‘Manners are not taught in lessons,’ said Alice. ‘Lessons teach you to
+do sums, and things of that sort.’
+
+‘And you do Addition?’ the White Queen asked. ‘What’s one and one and
+one and one and one and one and one and one and one and one?’
+
+‘I don’t know,’ said Alice. ‘I lost count.’
+
+‘She can’t do Addition,’ the Red Queen interrupted. ‘Can you do
+Subtraction? Take nine from eight.’
+
+‘Nine from eight I can’t, you know,’ Alice replied very readily: ‘but--’
+
+‘She can’t do Subtraction,’ said the White Queen. ‘Can you do Division?
+Divide a loaf by a knife--what’s the answer to that?’
+
+‘I suppose--’ Alice was beginning, but the Red Queen answered for her.
+‘Bread-and-butter, of course. Try another Subtraction sum. Take a bone
+from a dog: what remains?’
+
+Alice considered. ‘The bone wouldn’t remain, of course, if I took
+it--and the dog wouldn’t remain; it would come to bite me--and I’m sure
+I shouldn’t remain!’
+
+‘Then you think nothing would remain?’ said the Red Queen.
+
+‘I think that’s the answer.’
+
+‘Wrong, as usual,’ said the Red Queen: ‘the dog’s temper would remain.’
+
+‘But I don’t see how--’
+
+‘Why, look here!’ the Red Queen cried. ‘The dog would lose its temper,
+wouldn’t it?’
+
+‘Perhaps it would,’ Alice replied cautiously.
+
+‘Then if the dog went away, its temper would remain!’ the Queen
+exclaimed triumphantly.
+
+Alice said, as gravely as she could, ‘They might go different ways.’ But
+she couldn’t help thinking to herself, ‘What dreadful nonsense we ARE
+talking!’
+
+‘She can’t do sums a BIT!’ the Queens said together, with great
+emphasis.
+
+‘Can YOU do sums?’ Alice said, turning suddenly on the White Queen, for
+she didn’t like being found fault with so much.
+
+The Queen gasped and shut her eyes. ‘I can do Addition, if you give me
+time--but I can’t do Subtraction, under ANY circumstances!’
+
+‘Of course you know your A B C?’ said the Red Queen.
+
+‘To be sure I do.’ said Alice.
+
+‘So do I,’ the White Queen whispered: ‘we’ll often say it over together,
+dear. And I’ll tell you a secret--I can read words of one letter! Isn’t
+THAT grand! However, don’t be discouraged. You’ll come to it in time.’
+
+Here the Red Queen began again. ‘Can you answer useful questions?’ she
+said. ‘How is bread made?’
+
+‘I know THAT!’ Alice cried eagerly. ‘You take some flour--’
+
+‘Where do you pick the flower?’ the White Queen asked. ‘In a garden, or
+in the hedges?’
+
+‘Well, it isn’t PICKED at all,’ Alice explained: ‘it’s GROUND--’
+
+‘How many acres of ground?’ said the White Queen. ‘You mustn’t leave out
+so many things.’
+
+‘Fan her head!’ the Red Queen anxiously interrupted. ‘She’ll be feverish
+after so much thinking.’ So they set to work and fanned her with bunches
+of leaves, till she had to beg them to leave off, it blew her hair about
+so.
+
+‘She’s all right again now,’ said the Red Queen. ‘Do you know Languages?
+What’s the French for fiddle-de-dee?’
+
+‘Fiddle-de-dee’s not English,’ Alice replied gravely.
+
+‘Who ever said it was?’ said the Red Queen.
+
+Alice thought she saw a way out of the difficulty this time. ‘If you’ll
+tell me what language “fiddle-de-dee” is, I’ll tell you the French for
+it!’ she exclaimed triumphantly.
+
+But the Red Queen drew herself up rather stiffly, and said ‘Queens never
+make bargains.’
+
+‘I wish Queens never asked questions,’ Alice thought to herself.
+
+‘Don’t let us quarrel,’ the White Queen said in an anxious tone. ‘What
+is the cause of lightning?’
+
+‘The cause of lightning,’ Alice said very decidedly, for she felt quite
+certain about this, ‘is the thunder--no, no!’ she hastily corrected
+herself. ‘I meant the other way.’
+
+‘It’s too late to correct it,’ said the Red Queen: ‘when you’ve once
+said a thing, that fixes it, and you must take the consequences.’
+
+‘Which reminds me--’ the White Queen said, looking down and nervously
+clasping and unclasping her hands, ‘we had SUCH a thunderstorm last
+Tuesday--I mean one of the last set of Tuesdays, you know.’
+
+Alice was puzzled. ‘In OUR country,’ she remarked, ‘there’s only one day
+at a time.’
+
+The Red Queen said, ‘That’s a poor thin way of doing things. Now HERE,
+we mostly have days and nights two or three at a time, and sometimes
+in the winter we take as many as five nights together--for warmth, you
+know.’
+
+‘Are five nights warmer than one night, then?’ Alice ventured to ask.
+
+‘Five times as warm, of course.’
+
+‘But they should be five times as COLD, by the same rule--’
+
+‘Just so!’ cried the Red Queen. ‘Five times as warm, AND five times
+as cold--just as I’m five times as rich as you are, AND five times as
+clever!’
+
+Alice sighed and gave it up. ‘It’s exactly like a riddle with no
+answer!’ she thought.
+
+‘Humpty Dumpty saw it too,’ the White Queen went on in a low voice, more
+as if she were talking to herself. ‘He came to the door with a corkscrew
+in his hand--’
+
+‘What did he want?’ said the Red Queen.
+
+‘He said he WOULD come in,’ the White Queen went on, ‘because he was
+looking for a hippopotamus. Now, as it happened, there wasn’t such a
+thing in the house, that morning.’
+
+‘Is there generally?’ Alice asked in an astonished tone.
+
+‘Well, only on Thursdays,’ said the Queen.
+
+‘I know what he came for,’ said Alice: ‘he wanted to punish the fish,
+because--’
+
+Here the White Queen began again. ‘It was SUCH a thunderstorm, you can’t
+think!’ (‘She NEVER could, you know,’ said the Red Queen.) ‘And part of
+the roof came off, and ever so much thunder got in--and it went
+rolling round the room in great lumps--and knocking over the tables and
+things--till I was so frightened, I couldn’t remember my own name!’
+
+Alice thought to herself, ‘I never should TRY to remember my name in the
+middle of an accident! Where would be the use of it?’ but she did not
+say this aloud, for fear of hurting the poor Queen’s feeling.
+
+‘Your Majesty must excuse her,’ the Red Queen said to Alice, taking
+one of the White Queen’s hands in her own, and gently stroking it:
+‘she means well, but she can’t help saying foolish things, as a general
+rule.’
+
+The White Queen looked timidly at Alice, who felt she OUGHT to say
+something kind, but really couldn’t think of anything at the moment.
+
+‘She never was really well brought up,’ the Red Queen went on: ‘but
+it’s amazing how good-tempered she is! Pat her on the head, and see how
+pleased she’ll be!’ But this was more than Alice had courage to do.
+
+‘A little kindness--and putting her hair in papers--would do wonders
+with her--’
+
+The White Queen gave a deep sigh, and laid her head on Alice’s shoulder.
+‘I AM so sleepy?’ she moaned.
+
+‘She’s tired, poor thing!’ said the Red Queen. ‘Smooth her hair--lend
+her your nightcap--and sing her a soothing lullaby.’
+
+‘I haven’t got a nightcap with me,’ said Alice, as she tried to obey the
+first direction: ‘and I don’t know any soothing lullabies.’
+
+‘I must do it myself, then,’ said the Red Queen, and she began:
+
+
+   ‘Hush-a-by lady, in Alice’s lap!
+   Till the feast’s ready, we’ve time for a nap:
+   When the feast’s over, we’ll go to the ball--
+   Red Queen, and White Queen, and Alice, and all!
+
+
+‘And now you know the words,’ she added, as she put her head down on
+Alice’s other shoulder, ‘just sing it through to ME. I’m getting sleepy,
+too.’ In another moment both Queens were fast asleep, and snoring loud.
+
+‘What AM I to do?’ exclaimed Alice, looking about in great perplexity,
+as first one round head, and then the other, rolled down from her
+shoulder, and lay like a heavy lump in her lap. ‘I don’t think it EVER
+happened before, that any one had to take care of two Queens asleep
+at once! No, not in all the History of England--it couldn’t, you know,
+because there never was more than one Queen at a time. Do wake up, you
+heavy things!’ she went on in an impatient tone; but there was no answer
+but a gentle snoring.
+
+The snoring got more distinct every minute, and sounded more like a
+tune: at last she could even make out the words, and she listened so
+eagerly that, when the two great heads vanished from her lap, she hardly
+missed them.
+
+She was standing before an arched doorway over which were the words
+QUEEN ALICE in large letters, and on each side of the arch there was a
+bell-handle; one was marked ‘Visitors’ Bell,’ and the other ‘Servants’
+Bell.’
+
+‘I’ll wait till the song’s over,’ thought Alice, ‘and then I’ll
+ring--the--WHICH bell must I ring?’ she went on, very much puzzled by
+the names. ‘I’m not a visitor, and I’m not a servant. There OUGHT to be
+one marked “Queen,” you know--’
+
+Just then the door opened a little way, and a creature with a long beak
+put its head out for a moment and said ‘No admittance till the week
+after next!’ and shut the door again with a bang.
+
+Alice knocked and rang in vain for a long time, but at last, a very old
+Frog, who was sitting under a tree, got up and hobbled slowly towards
+her: he was dressed in bright yellow, and had enormous boots on.
+
+‘What is it, now?’ the Frog said in a deep hoarse whisper.
+
+Alice turned round, ready to find fault with anybody. ‘Where’s the
+servant whose business it is to answer the door?’ she began angrily.
+
+‘Which door?’ said the Frog.
+
+Alice almost stamped with irritation at the slow drawl in which he
+spoke. ‘THIS door, of course!’
+
+The Frog looked at the door with his large dull eyes for a minute:
+then he went nearer and rubbed it with his thumb, as if he were trying
+whether the paint would come off; then he looked at Alice.
+
+‘To answer the door?’ he said. ‘What’s it been asking of?’ He was so
+hoarse that Alice could scarcely hear him.
+
+‘I don’t know what you mean,’ she said.
+
+‘I talks English, doesn’t I?’ the Frog went on. ‘Or are you deaf? What
+did it ask you?’
+
+‘Nothing!’ Alice said impatiently. ‘I’ve been knocking at it!’
+
+‘Shouldn’t do that--shouldn’t do that--’ the Frog muttered. ‘Vexes it,
+you know.’ Then he went up and gave the door a kick with one of his
+great feet. ‘You let IT alone,’ he panted out, as he hobbled back to his
+tree, ‘and it’ll let YOU alone, you know.’
+
+At this moment the door was flung open, and a shrill voice was heard
+singing:
+
+
+   ‘To the Looking-Glass world it was Alice that said,
+   “I’ve a sceptre in hand, I’ve a crown on my head;
+   Let the Looking-Glass creatures, whatever they be,
+   Come and dine with the Red Queen, the White Queen, and me.”’
+
+
+And hundreds of voices joined in the chorus:
+
+
+  ‘Then fill up the glasses as quick as you can,
+  And sprinkle the table with buttons and bran:
+  Put cats in the coffee, and mice in the tea--
+  And welcome Queen Alice with thirty-times-three!’
+
+
+Then followed a confused noise of cheering, and Alice thought to
+herself, ‘Thirty times three makes ninety. I wonder if any one’s
+counting?’ In a minute there was silence again, and the same shrill
+voice sang another verse;
+
+
+  ‘“O Looking-Glass creatures,” quoth Alice, “draw near!
+  ‘Tis an honour to see me, a favour to hear:
+  ‘Tis a privilege high to have dinner and tea
+  Along with the Red Queen, the White Queen, and me!”’
+
+
+Then came the chorus again:--
+
+
+  ‘Then fill up the glasses with treacle and ink,
+  Or anything else that is pleasant to drink:
+  Mix sand with the cider, and wool with the wine--
+  And welcome Queen Alice with ninety-times-nine!’
+
+
+‘Ninety times nine!’ Alice repeated in despair, ‘Oh, that’ll never
+be done! I’d better go in at once--’ and there was a dead silence the
+moment she appeared.
+
+Alice glanced nervously along the table, as she walked up the large
+hall, and noticed that there were about fifty guests, of all kinds: some
+were animals, some birds, and there were even a few flowers among them.
+‘I’m glad they’ve come without waiting to be asked,’ she thought: ‘I
+should never have known who were the right people to invite!’
+
+There were three chairs at the head of the table; the Red and White
+Queens had already taken two of them, but the middle one was empty.
+Alice sat down in it, rather uncomfortable in the silence, and longing
+for some one to speak.
+
+At last the Red Queen began. ‘You’ve missed the soup and fish,’ she
+said. ‘Put on the joint!’ And the waiters set a leg of mutton before
+Alice, who looked at it rather anxiously, as she had never had to carve
+a joint before.
+
+‘You look a little shy; let me introduce you to that leg of mutton,’
+said the Red Queen. ‘Alice--Mutton; Mutton--Alice.’ The leg of mutton
+got up in the dish and made a little bow to Alice; and Alice returned
+the bow, not knowing whether to be frightened or amused.
+
+‘May I give you a slice?’ she said, taking up the knife and fork, and
+looking from one Queen to the other.
+
+‘Certainly not,’ the Red Queen said, very decidedly: ‘it isn’t etiquette
+to cut any one you’ve been introduced to. Remove the joint!’ And the
+waiters carried it off, and brought a large plum-pudding in its place.
+
+‘I won’t be introduced to the pudding, please,’ Alice said rather
+hastily, ‘or we shall get no dinner at all. May I give you some?’
+
+But the Red Queen looked sulky, and growled ‘Pudding--Alice;
+Alice--Pudding. Remove the pudding!’ and the waiters took it away so
+quickly that Alice couldn’t return its bow.
+
+However, she didn’t see why the Red Queen should be the only one to give
+orders, so, as an experiment, she called out ‘Waiter! Bring back the
+pudding!’ and there it was again in a moment like a conjuring-trick. It
+was so large that she couldn’t help feeling a LITTLE shy with it, as she
+had been with the mutton; however, she conquered her shyness by a great
+effort and cut a slice and handed it to the Red Queen.
+
+‘What impertinence!’ said the Pudding. ‘I wonder how you’d like it, if I
+were to cut a slice out of YOU, you creature!’
+
+It spoke in a thick, suety sort of voice, and Alice hadn’t a word to say
+in reply: she could only sit and look at it and gasp.
+
+‘Make a remark,’ said the Red Queen: ‘it’s ridiculous to leave all the
+conversation to the pudding!’
+
+‘Do you know, I’ve had such a quantity of poetry repeated to me to-day,’
+Alice began, a little frightened at finding that, the moment she opened
+her lips, there was dead silence, and all eyes were fixed upon her; ‘and
+it’s a very curious thing, I think--every poem was about fishes in some
+way. Do you know why they’re so fond of fishes, all about here?’
+
+She spoke to the Red Queen, whose answer was a little wide of the mark.
+‘As to fishes,’ she said, very slowly and solemnly, putting her mouth
+close to Alice’s ear, ‘her White Majesty knows a lovely riddle--all in
+poetry--all about fishes. Shall she repeat it?’
+
+‘Her Red Majesty’s very kind to mention it,’ the White Queen murmured
+into Alice’s other ear, in a voice like the cooing of a pigeon. ‘It
+would be SUCH a treat! May I?’
+
+‘Please do,’ Alice said very politely.
+
+The White Queen laughed with delight, and stroked Alice’s cheek. Then
+she began:
+
+
+    ‘“First, the fish must be caught.”
+   That is easy: a baby, I think, could have caught it.
+    “Next, the fish must be bought.”
+   That is easy: a penny, I think, would have bought it.
+
+    “Now cook me the fish!”
+   That is easy, and will not take more than a minute.
+    “Let it lie in a dish!”
+   That is easy, because it already is in it.
+
+    “Bring it here! Let me sup!”
+   It is easy to set such a dish on the table.
+    “Take the dish-cover up!”
+   Ah, THAT is so hard that I fear I’m unable!
+
+    For it holds it like glue--
+  Holds the lid to the dish, while it lies in the middle:
+    Which is easiest to do,
+  Un-dish-cover the fish, or dishcover the riddle?’
+
+
+‘Take a minute to think about it, and then guess,’ said the Red Queen.
+‘Meanwhile, we’ll drink your health--Queen Alice’s health!’ she screamed
+at the top of her voice, and all the guests began drinking it directly,
+and very queerly they managed it: some of them put their glasses upon
+their heads like extinguishers, and drank all that trickled down their
+faces--others upset the decanters, and drank the wine as it ran off
+the edges of the table--and three of them (who looked like kangaroos)
+scrambled into the dish of roast mutton, and began eagerly lapping up
+the gravy, ‘just like pigs in a trough!’ thought Alice.
+
+‘You ought to return thanks in a neat speech,’ the Red Queen said,
+frowning at Alice as she spoke.
+
+‘We must support you, you know,’ the White Queen whispered, as Alice got
+up to do it, very obediently, but a little frightened.
+
+‘Thank you very much,’ she whispered in reply, ‘but I can do quite well
+without.’
+
+‘That wouldn’t be at all the thing,’ the Red Queen said very decidedly:
+so Alice tried to submit to it with a good grace.
+
+(‘And they DID push so!’ she said afterwards, when she was telling her
+sister the history of the feast. ‘You would have thought they wanted to
+squeeze me flat!’)
+
+In fact it was rather difficult for her to keep in her place while she
+made her speech: the two Queens pushed her so, one on each side, that
+they nearly lifted her up into the air: ‘I rise to return thanks--’
+Alice began: and she really DID rise as she spoke, several inches; but
+she got hold of the edge of the table, and managed to pull herself down
+again.
+
+‘Take care of yourself!’ screamed the White Queen, seizing Alice’s hair
+with both her hands. ‘Something’s going to happen!’
+
+And then (as Alice afterwards described it) all sorts of things happened
+in a moment. The candles all grew up to the ceiling, looking something
+like a bed of rushes with fireworks at the top. As to the bottles, they
+each took a pair of plates, which they hastily fitted on as wings, and
+so, with forks for legs, went fluttering about in all directions: ‘and
+very like birds they look,’ Alice thought to herself, as well as she
+could in the dreadful confusion that was beginning.
+
+At this moment she heard a hoarse laugh at her side, and turned to see
+what was the matter with the White Queen; but, instead of the Queen,
+there was the leg of mutton sitting in the chair. ‘Here I am!’ cried a
+voice from the soup tureen, and Alice turned again, just in time to see
+the Queen’s broad good-natured face grinning at her for a moment over
+the edge of the tureen, before she disappeared into the soup.
+
+There was not a moment to be lost. Already several of the guests were
+lying down in the dishes, and the soup ladle was walking up the table
+towards Alice’s chair, and beckoning to her impatiently to get out of
+its way.
+
+‘I can’t stand this any longer!’ she cried as she jumped up and seized
+the table-cloth with both hands: one good pull, and plates, dishes,
+guests, and candles came crashing down together in a heap on the floor.
+
+‘And as for YOU,’ she went on, turning fiercely upon the Red Queen, whom
+she considered as the cause of all the mischief--but the Queen was no
+longer at her side--she had suddenly dwindled down to the size of a
+little doll, and was now on the table, merrily running round and round
+after her own shawl, which was trailing behind her.
+
+At any other time, Alice would have felt surprised at this, but she was
+far too much excited to be surprised at anything NOW. ‘As for YOU,’
+she repeated, catching hold of the little creature in the very act of
+jumping over a bottle which had just lighted upon the table, ‘I’ll shake
+you into a kitten, that I will!’
+
+
+
+
+CHAPTER X. Shaking
+
+She took her off the table as she spoke, and shook her backwards and
+forwards with all her might.
+
+The Red Queen made no resistance whatever; only her face grew very
+small, and her eyes got large and green: and still, as Alice went on
+shaking her, she kept on growing shorter--and fatter--and softer--and
+rounder--and--
+
+
+
+
+CHAPTER XI. Waking
+
+--and it really WAS a kitten, after all.
+
+
+
+
+CHAPTER XII. Which Dreamed it?
+
+‘Your majesty shouldn’t purr so loud,’ Alice said, rubbing her eyes, and
+addressing the kitten, respectfully, yet with some severity. ‘You
+woke me out of oh! such a nice dream! And you’ve been along with me,
+Kitty--all through the Looking-Glass world. Did you know it, dear?’
+
+It is a very inconvenient habit of kittens (Alice had once made the
+remark) that, whatever you say to them, they ALWAYS purr. ‘If they would
+only purr for “yes” and mew for “no,” or any rule of that sort,’ she had
+said, ‘so that one could keep up a conversation! But how CAN you talk
+with a person if they always say the same thing?’
+
+On this occasion the kitten only purred: and it was impossible to guess
+whether it meant ‘yes’ or ‘no.’
+
+So Alice hunted among the chessmen on the table till she had found the
+Red Queen: then she went down on her knees on the hearth-rug, and put
+the kitten and the Queen to look at each other. ‘Now, Kitty!’ she cried,
+clapping her hands triumphantly. ‘Confess that was what you turned
+into!’
+
+(‘But it wouldn’t look at it,’ she said, when she was explaining the
+thing afterwards to her sister: ‘it turned away its head, and pretended
+not to see it: but it looked a LITTLE ashamed of itself, so I think it
+MUST have been the Red Queen.’)
+
+‘Sit up a little more stiffly, dear!’ Alice cried with a merry laugh.
+‘And curtsey while you’re thinking what to--what to purr. It saves time,
+remember!’ And she caught it up and gave it one little kiss, ‘just in
+honour of having been a Red Queen.’
+
+‘Snowdrop, my pet!’ she went on, looking over her shoulder at the White
+Kitten, which was still patiently undergoing its toilet, ‘when WILL
+Dinah have finished with your White Majesty, I wonder? That must be the
+reason you were so untidy in my dream--Dinah! do you know that you’re
+scrubbing a White Queen? Really, it’s most disrespectful of you!
+
+‘And what did DINAH turn to, I wonder?’ she prattled on, as she settled
+comfortably down, with one elbow in the rug, and her chin in her hand,
+to watch the kittens. ‘Tell me, Dinah, did you turn to Humpty Dumpty? I
+THINK you did--however, you’d better not mention it to your friends just
+yet, for I’m not sure.
+
+‘By the way, Kitty, if only you’d been really with me in my dream, there
+was one thing you WOULD have enjoyed--I had such a quantity of poetry
+said to me, all about fishes! To-morrow morning you shall have a real
+treat. All the time you’re eating your breakfast, I’ll repeat “The
+Walrus and the Carpenter” to you; and then you can make believe it’s
+oysters, dear!
+
+‘Now, Kitty, let’s consider who it was that dreamed it all. This is a
+serious question, my dear, and you should NOT go on licking your paw
+like that--as if Dinah hadn’t washed you this morning! You see, Kitty,
+it MUST have been either me or the Red King. He was part of my dream,
+of course--but then I was part of his dream, too! WAS it the Red King,
+Kitty? You were his wife, my dear, so you ought to know--Oh, Kitty, DO
+help to settle it! I’m sure your paw can wait!’ But the provoking kitten
+only began on the other paw, and pretended it hadn’t heard the question.
+
+Which do YOU think it was?
+
+
+              ----
+
+
+         A boat beneath a sunny sky,
+         Lingering onward dreamily
+         In an evening of July--
+
+         Children three that nestle near,
+         Eager eye and willing ear,
+         Pleased a simple tale to hear--
+
+         Long has paled that sunny sky:
+         Echoes fade and memories die.
+         Autumn frosts have slain July.
+
+         Still she haunts me, phantomwise,
+         Alice moving under skies
+         Never seen by waking eyes.
+
+         Children yet, the tale to hear,
+         Eager eye and willing ear,
+         Lovingly shall nestle near.
+
+         In a Wonderland they lie,
+         Dreaming as the days go by,
+         Dreaming as the summers die:
+
+         Ever drifting down the stream--
+         Lingering in the golden gleam--
+         Life, what is it but a dream?
+
+
+              THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson, AKA Lewis Carroll
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+***** This file should be named 12-0.txt or 12-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/12/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/time-machine.txt
+++ b/jet/hadoop/src/main/resources/books/time-machine.txt
@@ -1,0 +1,3617 @@
+﻿Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Time Machine
+
+Author: H. G. (Herbert George) Wells
+
+Release Date: October 2, 2004 [EBook #35]
+[Last updated: October 3, 2014]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+
+
+
+
+
+
+
+
+
+
+
+The Time Machine, by H. G. Wells [1898]
+
+
+
+
+I
+
+
+The Time Traveller (for so it will be convenient to speak of him)
+was expounding a recondite matter to us. His grey eyes shone and
+twinkled, and his usually pale face was flushed and animated. The
+fire burned brightly, and the soft radiance of the incandescent
+lights in the lilies of silver caught the bubbles that flashed and
+passed in our glasses. Our chairs, being his patents, embraced and
+caressed us rather than submitted to be sat upon, and there was that
+luxurious after-dinner atmosphere when thought roams gracefully
+free of the trammels of precision. And he put it to us in this
+way--marking the points with a lean forefinger--as we sat and lazily
+admired his earnestness over this new paradox (as we thought it)
+and his fecundity.
+
+'You must follow me carefully. I shall have to controvert one or two
+ideas that are almost universally accepted. The geometry, for
+instance, they taught you at school is founded on a misconception.'
+
+'Is not that rather a large thing to expect us to begin upon?'
+said Filby, an argumentative person with red hair.
+
+'I do not mean to ask you to accept anything without reasonable
+ground for it. You will soon admit as much as I need from you. You
+know of course that a mathematical line, a line of thickness _nil_,
+has no real existence. They taught you that? Neither has a
+mathematical plane. These things are mere abstractions.'
+
+'That is all right,' said the Psychologist.
+
+'Nor, having only length, breadth, and thickness, can a cube have a
+real existence.'
+
+'There I object,' said Filby. 'Of course a solid body may exist. All
+real things--'
+
+'So most people think. But wait a moment. Can an _instantaneous_
+cube exist?'
+
+'Don't follow you,' said Filby.
+
+'Can a cube that does not last for any time at all, have a real
+existence?'
+
+Filby became pensive. 'Clearly,' the Time Traveller proceeded, 'any
+real body must have extension in _four_ directions: it must have
+Length, Breadth, Thickness, and--Duration. But through a natural
+infirmity of the flesh, which I will explain to you in a moment, we
+incline to overlook this fact. There are really four dimensions,
+three which we call the three planes of Space, and a fourth, Time.
+There is, however, a tendency to draw an unreal distinction between
+the former three dimensions and the latter, because it happens that
+our consciousness moves intermittently in one direction along the
+latter from the beginning to the end of our lives.'
+
+'That,' said a very young man, making spasmodic efforts to relight
+his cigar over the lamp; 'that ... very clear indeed.'
+
+'Now, it is very remarkable that this is so extensively overlooked,'
+continued the Time Traveller, with a slight accession of
+cheerfulness. 'Really this is what is meant by the Fourth Dimension,
+though some people who talk about the Fourth Dimension do not know
+they mean it. It is only another way of looking at Time. _There is
+no difference between Time and any of the three dimensions of Space
+except that our consciousness moves along it_. But some foolish
+people have got hold of the wrong side of that idea. You have all
+heard what they have to say about this Fourth Dimension?'
+
+'_I_ have not,' said the Provincial Mayor.
+
+'It is simply this. That Space, as our mathematicians have it, is
+spoken of as having three dimensions, which one may call Length,
+Breadth, and Thickness, and is always definable by reference to
+three planes, each at right angles to the others. But some
+philosophical people have been asking why _three_ dimensions
+particularly--why not another direction at right angles to the other
+three?--and have even tried to construct a Four-Dimension geometry.
+Professor Simon Newcomb was expounding this to the New York
+Mathematical Society only a month or so ago. You know how on a flat
+surface, which has only two dimensions, we can represent a figure of
+a three-dimensional solid, and similarly they think that by models
+of three dimensions they could represent one of four--if they could
+master the perspective of the thing. See?'
+
+'I think so,' murmured the Provincial Mayor; and, knitting his
+brows, he lapsed into an introspective state, his lips moving as one
+who repeats mystic words. 'Yes, I think I see it now,' he said after
+some time, brightening in a quite transitory manner.
+
+'Well, I do not mind telling you I have been at work upon this
+geometry of Four Dimensions for some time. Some of my results
+are curious. For instance, here is a portrait of a man at eight
+years old, another at fifteen, another at seventeen, another at
+twenty-three, and so on. All these are evidently sections, as it
+were, Three-Dimensional representations of his Four-Dimensioned
+being, which is a fixed and unalterable thing.
+
+'Scientific people,' proceeded the Time Traveller, after the pause
+required for the proper assimilation of this, 'know very well that
+Time is only a kind of Space. Here is a popular scientific diagram,
+a weather record. This line I trace with my finger shows the
+movement of the barometer. Yesterday it was so high, yesterday night
+it fell, then this morning it rose again, and so gently upward to
+here. Surely the mercury did not trace this line in any of the
+dimensions of Space generally recognized? But certainly it traced
+such a line, and that line, therefore, we must conclude was along
+the Time-Dimension.'
+
+'But,' said the Medical Man, staring hard at a coal in the fire, 'if
+Time is really only a fourth dimension of Space, why is it, and why
+has it always been, regarded as something different? And why cannot
+we move in Time as we move about in the other dimensions of Space?'
+
+The Time Traveller smiled. 'Are you sure we can move freely in
+Space? Right and left we can go, backward and forward freely enough,
+and men always have done so. I admit we move freely in two
+dimensions. But how about up and down? Gravitation limits us there.'
+
+'Not exactly,' said the Medical Man. 'There are balloons.'
+
+'But before the balloons, save for spasmodic jumping and the
+inequalities of the surface, man had no freedom of vertical
+movement.'
+
+'Still they could move a little up and down,' said the Medical Man.
+
+'Easier, far easier down than up.'
+
+'And you cannot move at all in Time, you cannot get away from the
+present moment.'
+
+'My dear sir, that is just where you are wrong. That is just where
+the whole world has gone wrong. We are always getting away from the
+present moment. Our mental existences, which are immaterial and have
+no dimensions, are passing along the Time-Dimension with a uniform
+velocity from the cradle to the grave. Just as we should travel _down_
+if we began our existence fifty miles above the earth's surface.'
+
+'But the great difficulty is this,' interrupted the Psychologist.
+'You _can_ move about in all directions of Space, but you cannot
+move about in Time.'
+
+'That is the germ of my great discovery. But you are wrong to say
+that we cannot move about in Time. For instance, if I am recalling
+an incident very vividly I go back to the instant of its occurrence:
+I become absent-minded, as you say. I jump back for a moment. Of
+course we have no means of staying back for any length of Time, any
+more than a savage or an animal has of staying six feet above the
+ground. But a civilized man is better off than the savage in this
+respect. He can go up against gravitation in a balloon, and why
+should he not hope that ultimately he may be able to stop or
+accelerate his drift along the Time-Dimension, or even turn about
+and travel the other way?'
+
+'Oh, _this_,' began Filby, 'is all--'
+
+'Why not?' said the Time Traveller.
+
+'It's against reason,' said Filby.
+
+'What reason?' said the Time Traveller.
+
+'You can show black is white by argument,' said Filby, 'but you will
+never convince me.'
+
+'Possibly not,' said the Time Traveller. 'But now you begin to see
+the object of my investigations into the geometry of Four
+Dimensions. Long ago I had a vague inkling of a machine--'
+
+'To travel through Time!' exclaimed the Very Young Man.
+
+'That shall travel indifferently in any direction of Space and Time,
+as the driver determines.'
+
+Filby contented himself with laughter.
+
+'But I have experimental verification,' said the Time Traveller.
+
+'It would be remarkably convenient for the historian,' the
+Psychologist suggested. 'One might travel back and verify the
+accepted account of the Battle of Hastings, for instance!'
+
+'Don't you think you would attract attention?' said the Medical Man.
+'Our ancestors had no great tolerance for anachronisms.'
+
+'One might get one's Greek from the very lips of Homer and Plato,'
+the Very Young Man thought.
+
+'In which case they would certainly plough you for the Little-go.
+The German scholars have improved Greek so much.'
+
+'Then there is the future,' said the Very Young Man. 'Just think!
+One might invest all one's money, leave it to accumulate at
+interest, and hurry on ahead!'
+
+'To discover a society,' said I, 'erected on a strictly communistic
+basis.'
+
+'Of all the wild extravagant theories!' began the Psychologist.
+
+'Yes, so it seemed to me, and so I never talked of it until--'
+
+'Experimental verification!' cried I. 'You are going to verify
+_that_?'
+
+'The experiment!' cried Filby, who was getting brain-weary.
+
+'Let's see your experiment anyhow,' said the Psychologist, 'though
+it's all humbug, you know.'
+
+The Time Traveller smiled round at us. Then, still smiling faintly,
+and with his hands deep in his trousers pockets, he walked slowly
+out of the room, and we heard his slippers shuffling down the long
+passage to his laboratory.
+
+The Psychologist looked at us. 'I wonder what he's got?'
+
+'Some sleight-of-hand trick or other,' said the Medical Man, and
+Filby tried to tell us about a conjurer he had seen at Burslem; but
+before he had finished his preface the Time Traveller came back, and
+Filby's anecdote collapsed.
+
+The thing the Time Traveller held in his hand was a glittering
+metallic framework, scarcely larger than a small clock, and very
+delicately made. There was ivory in it, and some transparent
+crystalline substance. And now I must be explicit, for this that
+follows--unless his explanation is to be accepted--is an absolutely
+unaccountable thing. He took one of the small octagonal tables that
+were scattered about the room, and set it in front of the fire, with
+two legs on the hearthrug. On this table he placed the mechanism.
+Then he drew up a chair, and sat down. The only other object on the
+table was a small shaded lamp, the bright light of which fell upon
+the model. There were also perhaps a dozen candles about, two in
+brass candlesticks upon the mantel and several in sconces, so that
+the room was brilliantly illuminated. I sat in a low arm-chair
+nearest the fire, and I drew this forward so as to be almost between
+the Time Traveller and the fireplace. Filby sat behind him, looking
+over his shoulder. The Medical Man and the Provincial Mayor watched
+him in profile from the right, the Psychologist from the left. The
+Very Young Man stood behind the Psychologist. We were all on the
+alert. It appears incredible to me that any kind of trick, however
+subtly conceived and however adroitly done, could have been played
+upon us under these conditions.
+
+The Time Traveller looked at us, and then at the mechanism. 'Well?'
+said the Psychologist.
+
+'This little affair,' said the Time Traveller, resting his elbows
+upon the table and pressing his hands together above the apparatus,
+'is only a model. It is my plan for a machine to travel through
+time. You will notice that it looks singularly askew, and that there
+is an odd twinkling appearance about this bar, as though it was in
+some way unreal.' He pointed to the part with his finger. 'Also,
+here is one little white lever, and here is another.'
+
+The Medical Man got up out of his chair and peered into the thing.
+'It's beautifully made,' he said.
+
+'It took two years to make,' retorted the Time Traveller. Then, when
+we had all imitated the action of the Medical Man, he said: 'Now I
+want you clearly to understand that this lever, being pressed over,
+sends the machine gliding into the future, and this other reverses
+the motion. This saddle represents the seat of a time traveller.
+Presently I am going to press the lever, and off the machine will
+go. It will vanish, pass into future Time, and disappear. Have a
+good look at the thing. Look at the table too, and satisfy
+yourselves there is no trickery. I don't want to waste this model,
+and then be told I'm a quack.'
+
+There was a minute's pause perhaps. The Psychologist seemed about to
+speak to me, but changed his mind. Then the Time Traveller put forth
+his finger towards the lever. 'No,' he said suddenly. 'Lend me your
+hand.' And turning to the Psychologist, he took that individual's
+hand in his own and told him to put out his forefinger. So that it
+was the Psychologist himself who sent forth the model Time Machine
+on its interminable voyage. We all saw the lever turn. I am
+absolutely certain there was no trickery. There was a breath of
+wind, and the lamp flame jumped. One of the candles on the mantel
+was blown out, and the little machine suddenly swung round, became
+indistinct, was seen as a ghost for a second perhaps, as an eddy of
+faintly glittering brass and ivory; and it was gone--vanished! Save
+for the lamp the table was bare.
+
+Everyone was silent for a minute. Then Filby said he was damned.
+
+The Psychologist recovered from his stupor, and suddenly looked
+under the table. At that the Time Traveller laughed cheerfully.
+'Well?' he said, with a reminiscence of the Psychologist. Then,
+getting up, he went to the tobacco jar on the mantel, and with his
+back to us began to fill his pipe.
+
+We stared at each other. 'Look here,' said the Medical Man, 'are you
+in earnest about this? Do you seriously believe that that machine
+has travelled into time?'
+
+'Certainly,' said the Time Traveller, stooping to light a spill at
+the fire. Then he turned, lighting his pipe, to look at the
+Psychologist's face. (The Psychologist, to show that he was not
+unhinged, helped himself to a cigar and tried to light it uncut.)
+'What is more, I have a big machine nearly finished in there'--he
+indicated the laboratory--'and when that is put together I mean to
+have a journey on my own account.'
+
+'You mean to say that that machine has travelled into the future?'
+said Filby.
+
+'Into the future or the past--I don't, for certain, know which.'
+
+After an interval the Psychologist had an inspiration. 'It must have
+gone into the past if it has gone anywhere,' he said.
+
+'Why?' said the Time Traveller.
+
+'Because I presume that it has not moved in space, and if it
+travelled into the future it would still be here all this time,
+since it must have travelled through this time.'
+
+'But,' I said, 'If it travelled into the past it would have been
+visible when we came first into this room; and last Thursday when we
+were here; and the Thursday before that; and so forth!'
+
+'Serious objections,' remarked the Provincial Mayor, with an air of
+impartiality, turning towards the Time Traveller.
+
+'Not a bit,' said the Time Traveller, and, to the Psychologist: 'You
+think. You can explain that. It's presentation below the threshold,
+you know, diluted presentation.'
+
+'Of course,' said the Psychologist, and reassured us. 'That's a
+simple point of psychology. I should have thought of it. It's plain
+enough, and helps the paradox delightfully. We cannot see it, nor
+can we appreciate this machine, any more than we can the spoke of
+a wheel spinning, or a bullet flying through the air. If it is
+travelling through time fifty times or a hundred times faster than
+we are, if it gets through a minute while we get through a second,
+the impression it creates will of course be only one-fiftieth or
+one-hundredth of what it would make if it were not travelling in
+time. That's plain enough.' He passed his hand through the space in
+which the machine had been. 'You see?' he said, laughing.
+
+We sat and stared at the vacant table for a minute or so. Then the
+Time Traveller asked us what we thought of it all.
+
+'It sounds plausible enough to-night,' said the Medical Man; 'but
+wait until to-morrow. Wait for the common sense of the morning.'
+
+'Would you like to see the Time Machine itself?' asked the Time
+Traveller. And therewith, taking the lamp in his hand, he led the
+way down the long, draughty corridor to his laboratory. I remember
+vividly the flickering light, his queer, broad head in silhouette,
+the dance of the shadows, how we all followed him, puzzled but
+incredulous, and how there in the laboratory we beheld a larger
+edition of the little mechanism which we had seen vanish from before
+our eyes. Parts were of nickel, parts of ivory, parts had certainly
+been filed or sawn out of rock crystal. The thing was generally
+complete, but the twisted crystalline bars lay unfinished upon the
+bench beside some sheets of drawings, and I took one up for a better
+look at it. Quartz it seemed to be.
+
+'Look here,' said the Medical Man, 'are you perfectly serious?
+Or is this a trick--like that ghost you showed us last Christmas?'
+
+'Upon that machine,' said the Time Traveller, holding the lamp
+aloft, 'I intend to explore time. Is that plain? I was never more
+serious in my life.'
+
+None of us quite knew how to take it.
+
+I caught Filby's eye over the shoulder of the Medical Man, and he
+winked at me solemnly.
+
+
+
+
+II
+
+
+I think that at that time none of us quite believed in the Time
+Machine. The fact is, the Time Traveller was one of those men who
+are too clever to be believed: you never felt that you saw all round
+him; you always suspected some subtle reserve, some ingenuity in
+ambush, behind his lucid frankness. Had Filby shown the model and
+explained the matter in the Time Traveller's words, we should have
+shown _him_ far less scepticism. For we should have perceived his
+motives; a pork butcher could understand Filby. But the Time
+Traveller had more than a touch of whim among his elements, and we
+distrusted him. Things that would have made the frame of a less
+clever man seemed tricks in his hands. It is a mistake to do things
+too easily. The serious people who took him seriously never felt
+quite sure of his deportment; they were somehow aware that trusting
+their reputations for judgment with him was like furnishing a
+nursery with egg-shell china. So I don't think any of us said very
+much about time travelling in the interval between that Thursday and
+the next, though its odd potentialities ran, no doubt, in most of
+our minds: its plausibility, that is, its practical incredibleness,
+the curious possibilities of anachronism and of utter confusion it
+suggested. For my own part, I was particularly preoccupied with the
+trick of the model. That I remember discussing with the Medical Man,
+whom I met on Friday at the Linnaean. He said he had seen a similar
+thing at Tubingen, and laid considerable stress on the blowing out
+of the candle. But how the trick was done he could not explain.
+
+The next Thursday I went again to Richmond--I suppose I was one of
+the Time Traveller's most constant guests--and, arriving late, found
+four or five men already assembled in his drawing-room. The Medical
+Man was standing before the fire with a sheet of paper in one hand
+and his watch in the other. I looked round for the Time Traveller,
+and--'It's half-past seven now,' said the Medical Man. 'I suppose
+we'd better have dinner?'
+
+'Where's----?' said I, naming our host.
+
+'You've just come? It's rather odd. He's unavoidably detained. He
+asks me in this note to lead off with dinner at seven if he's not
+back. Says he'll explain when he comes.'
+
+'It seems a pity to let the dinner spoil,' said the Editor of a
+well-known daily paper; and thereupon the Doctor rang the bell.
+
+The Psychologist was the only person besides the Doctor and myself
+who had attended the previous dinner. The other men were Blank, the
+Editor aforementioned, a certain journalist, and another--a quiet,
+shy man with a beard--whom I didn't know, and who, as far as my
+observation went, never opened his mouth all the evening. There was
+some speculation at the dinner-table about the Time Traveller's
+absence, and I suggested time travelling, in a half-jocular spirit.
+The Editor wanted that explained to him, and the Psychologist
+volunteered a wooden account of the 'ingenious paradox and trick' we
+had witnessed that day week. He was in the midst of his exposition
+when the door from the corridor opened slowly and without noise. I
+was facing the door, and saw it first. 'Hallo!' I said. 'At last!'
+And the door opened wider, and the Time Traveller stood before us.
+I gave a cry of surprise. 'Good heavens! man, what's the matter?'
+cried the Medical Man, who saw him next. And the whole tableful
+turned towards the door.
+
+He was in an amazing plight. His coat was dusty and dirty, and
+smeared with green down the sleeves; his hair disordered, and as it
+seemed to me greyer--either with dust and dirt or because its colour
+had actually faded. His face was ghastly pale; his chin had a brown
+cut on it--a cut half healed; his expression was haggard and drawn,
+as by intense suffering. For a moment he hesitated in the doorway,
+as if he had been dazzled by the light. Then he came into the room.
+He walked with just such a limp as I have seen in footsore tramps.
+We stared at him in silence, expecting him to speak.
+
+He said not a word, but came painfully to the table, and made a
+motion towards the wine. The Editor filled a glass of champagne, and
+pushed it towards him. He drained it, and it seemed to do him good:
+for he looked round the table, and the ghost of his old smile
+flickered across his face. 'What on earth have you been up to, man?'
+said the Doctor. The Time Traveller did not seem to hear. 'Don't let
+me disturb you,' he said, with a certain faltering articulation.
+'I'm all right.' He stopped, held out his glass for more, and took
+it off at a draught. 'That's good,' he said. His eyes grew brighter,
+and a faint colour came into his cheeks. His glance flickered over
+our faces with a certain dull approval, and then went round the warm
+and comfortable room. Then he spoke again, still as it were feeling
+his way among his words. 'I'm going to wash and dress, and then I'll
+come down and explain things ... Save me some of that mutton. I'm
+starving for a bit of meat.'
+
+He looked across at the Editor, who was a rare visitor, and hoped he
+was all right. The Editor began a question. 'Tell you presently,'
+said the Time Traveller. 'I'm--funny! Be all right in a minute.'
+
+He put down his glass, and walked towards the staircase door. Again
+I remarked his lameness and the soft padding sound of his footfall,
+and standing up in my place, I saw his feet as he went out. He had
+nothing on them but a pair of tattered, blood-stained socks. Then the
+door closed upon him. I had half a mind to follow, till I remembered
+how he detested any fuss about himself. For a minute, perhaps, my
+mind was wool-gathering. Then, 'Remarkable Behaviour of an Eminent
+Scientist,' I heard the Editor say, thinking (after his wont) in
+headlines. And this brought my attention back to the bright
+dinner-table.
+
+'What's the game?' said the Journalist. 'Has he been doing the
+Amateur Cadger? I don't follow.' I met the eye of the Psychologist,
+and read my own interpretation in his face. I thought of the Time
+Traveller limping painfully upstairs. I don't think any one else had
+noticed his lameness.
+
+The first to recover completely from this surprise was the Medical
+Man, who rang the bell--the Time Traveller hated to have servants
+waiting at dinner--for a hot plate. At that the Editor turned to his
+knife and fork with a grunt, and the Silent Man followed suit. The
+dinner was resumed. Conversation was exclamatory for a little while,
+with gaps of wonderment; and then the Editor got fervent in his
+curiosity. 'Does our friend eke out his modest income with a
+crossing? or has he his Nebuchadnezzar phases?' he inquired. 'I feel
+assured it's this business of the Time Machine,' I said, and took up
+the Psychologist's account of our previous meeting. The new guests
+were frankly incredulous. The Editor raised objections. 'What _was_
+this time travelling? A man couldn't cover himself with dust by
+rolling in a paradox, could he?' And then, as the idea came home to
+him, he resorted to caricature. Hadn't they any clothes-brushes in
+the Future? The Journalist too, would not believe at any price, and
+joined the Editor in the easy work of heaping ridicule on the whole
+thing. They were both the new kind of journalist--very joyous,
+irreverent young men. 'Our Special Correspondent in the Day
+after To-morrow reports,' the Journalist was saying--or rather
+shouting--when the Time Traveller came back. He was dressed in
+ordinary evening clothes, and nothing save his haggard look remained
+of the change that had startled me.
+
+'I say,' said the Editor hilariously, 'these chaps here say you have
+been travelling into the middle of next week! Tell us all about
+little Rosebery, will you? What will you take for the lot?'
+
+The Time Traveller came to the place reserved for him without a
+word. He smiled quietly, in his old way. 'Where's my mutton?' he
+said. 'What a treat it is to stick a fork into meat again!'
+
+'Story!' cried the Editor.
+
+'Story be damned!' said the Time Traveller. 'I want something to
+eat. I won't say a word until I get some peptone into my arteries.
+Thanks. And the salt.'
+
+'One word,' said I. 'Have you been time travelling?'
+
+'Yes,' said the Time Traveller, with his mouth full, nodding his
+head.
+
+'I'd give a shilling a line for a verbatim note,' said the Editor.
+The Time Traveller pushed his glass towards the Silent Man and rang
+it with his fingernail; at which the Silent Man, who had been
+staring at his face, started convulsively, and poured him wine.
+The rest of the dinner was uncomfortable. For my own part, sudden
+questions kept on rising to my lips, and I dare say it was the same
+with the others. The Journalist tried to relieve the tension by
+telling anecdotes of Hettie Potter. The Time Traveller devoted his
+attention to his dinner, and displayed the appetite of a tramp.
+The Medical Man smoked a cigarette, and watched the Time Traveller
+through his eyelashes. The Silent Man seemed even more clumsy than
+usual, and drank champagne with regularity and determination out of
+sheer nervousness. At last the Time Traveller pushed his plate away,
+and looked round us. 'I suppose I must apologize,' he said. 'I was
+simply starving. I've had a most amazing time.' He reached out his
+hand for a cigar, and cut the end. 'But come into the smoking-room.
+It's too long a story to tell over greasy plates.' And ringing the
+bell in passing, he led the way into the adjoining room.
+
+'You have told Blank, and Dash, and Chose about the machine?' he
+said to me, leaning back in his easy-chair and naming the three new
+guests.
+
+'But the thing's a mere paradox,' said the Editor.
+
+'I can't argue to-night. I don't mind telling you the story, but
+I can't argue. I will,' he went on, 'tell you the story of what
+has happened to me, if you like, but you must refrain from
+interruptions. I want to tell it. Badly. Most of it will sound like
+lying. So be it! It's true--every word of it, all the same. I was in
+my laboratory at four o'clock, and since then ... I've lived eight
+days ... such days as no human being ever lived before! I'm nearly
+worn out, but I shan't sleep till I've told this thing over to you.
+Then I shall go to bed. But no interruptions! Is it agreed?'
+
+'Agreed,' said the Editor, and the rest of us echoed 'Agreed.' And
+with that the Time Traveller began his story as I have set it forth.
+He sat back in his chair at first, and spoke like a weary man.
+Afterwards he got more animated. In writing it down I feel with only
+too much keenness the inadequacy of pen and ink--and, above all, my
+own inadequacy--to express its quality. You read, I will suppose,
+attentively enough; but you cannot see the speaker's white,
+sincere face in the bright circle of the little lamp, nor hear the
+intonation of his voice. You cannot know how his expression followed
+the turns of his story! Most of us hearers were in shadow, for the
+candles in the smoking-room had not been lighted, and only the face
+of the Journalist and the legs of the Silent Man from the knees
+downward were illuminated. At first we glanced now and again at each
+other. After a time we ceased to do that, and looked only at the
+Time Traveller's face.
+
+
+
+
+III
+
+
+'I told some of you last Thursday of the principles of the Time
+Machine, and showed you the actual thing itself, incomplete in the
+workshop. There it is now, a little travel-worn, truly; and one of
+the ivory bars is cracked, and a brass rail bent; but the rest of
+it's sound enough. I expected to finish it on Friday, but on Friday,
+when the putting together was nearly done, I found that one of the
+nickel bars was exactly one inch too short, and this I had to get
+remade; so that the thing was not complete until this morning. It
+was at ten o'clock to-day that the first of all Time Machines began
+its career. I gave it a last tap, tried all the screws again, put
+one more drop of oil on the quartz rod, and sat myself in the
+saddle. I suppose a suicide who holds a pistol to his skull feels
+much the same wonder at what will come next as I felt then. I took
+the starting lever in one hand and the stopping one in the other,
+pressed the first, and almost immediately the second. I seemed to
+reel; I felt a nightmare sensation of falling; and, looking round,
+I saw the laboratory exactly as before. Had anything happened? For
+a moment I suspected that my intellect had tricked me. Then I noted
+the clock. A moment before, as it seemed, it had stood at a minute
+or so past ten; now it was nearly half-past three!
+
+'I drew a breath, set my teeth, gripped the starting lever with both
+hands, and went off with a thud. The laboratory got hazy and went
+dark. Mrs. Watchett came in and walked, apparently without seeing
+me, towards the garden door. I suppose it took her a minute or so to
+traverse the place, but to me she seemed to shoot across the room
+like a rocket. I pressed the lever over to its extreme position. The
+night came like the turning out of a lamp, and in another moment
+came to-morrow. The laboratory grew faint and hazy, then fainter
+and ever fainter. To-morrow night came black, then day again, night
+again, day again, faster and faster still. An eddying murmur filled
+my ears, and a strange, dumb confusedness descended on my mind.
+
+'I am afraid I cannot convey the peculiar sensations of time
+travelling. They are excessively unpleasant. There is a feeling
+exactly like that one has upon a switchback--of a helpless headlong
+motion! I felt the same horrible anticipation, too, of an imminent
+smash. As I put on pace, night followed day like the flapping of a
+black wing. The dim suggestion of the laboratory seemed presently to
+fall away from me, and I saw the sun hopping swiftly across the sky,
+leaping it every minute, and every minute marking a day. I supposed
+the laboratory had been destroyed and I had come into the open air.
+I had a dim impression of scaffolding, but I was already going too
+fast to be conscious of any moving things. The slowest snail that
+ever crawled dashed by too fast for me. The twinkling succession of
+darkness and light was excessively painful to the eye. Then, in the
+intermittent darknesses, I saw the moon spinning swiftly through her
+quarters from new to full, and had a faint glimpse of the circling
+stars. Presently, as I went on, still gaining velocity, the
+palpitation of night and day merged into one continuous greyness;
+the sky took on a wonderful deepness of blue, a splendid luminous
+color like that of early twilight; the jerking sun became a streak
+of fire, a brilliant arch, in space; the moon a fainter fluctuating
+band; and I could see nothing of the stars, save now and then a
+brighter circle flickering in the blue.
+
+'The landscape was misty and vague. I was still on the hill-side
+upon which this house now stands, and the shoulder rose above me
+grey and dim. I saw trees growing and changing like puffs of vapour,
+now brown, now green; they grew, spread, shivered, and passed away.
+I saw huge buildings rise up faint and fair, and pass like dreams.
+The whole surface of the earth seemed changed--melting and flowing
+under my eyes. The little hands upon the dials that registered my
+speed raced round faster and faster. Presently I noted that the sun
+belt swayed up and down, from solstice to solstice, in a minute or
+less, and that consequently my pace was over a year a minute; and
+minute by minute the white snow flashed across the world, and
+vanished, and was followed by the bright, brief green of spring.
+
+'The unpleasant sensations of the start were less poignant now. They
+merged at last into a kind of hysterical exhilaration. I remarked
+indeed a clumsy swaying of the machine, for which I was unable to
+account. But my mind was too confused to attend to it, so with a
+kind of madness growing upon me, I flung myself into futurity. At
+first I scarce thought of stopping, scarce thought of anything but
+these new sensations. But presently a fresh series of impressions
+grew up in my mind--a certain curiosity and therewith a certain
+dread--until at last they took complete possession of me. What
+strange developments of humanity, what wonderful advances upon our
+rudimentary civilization, I thought, might not appear when I came to
+look nearly into the dim elusive world that raced and fluctuated
+before my eyes! I saw great and splendid architecture rising about
+me, more massive than any buildings of our own time, and yet, as it
+seemed, built of glimmer and mist. I saw a richer green flow up the
+hill-side, and remain there, without any wintry intermission. Even
+through the veil of my confusion the earth seemed very fair. And so
+my mind came round to the business of stopping.
+
+'The peculiar risk lay in the possibility of my finding some
+substance in the space which I, or the machine, occupied. So long
+as I travelled at a high velocity through time, this scarcely
+mattered; I was, so to speak, attenuated--was slipping like a vapour
+through the interstices of intervening substances! But to come to
+a stop involved the jamming of myself, molecule by molecule, into
+whatever lay in my way; meant bringing my atoms into such intimate
+contact with those of the obstacle that a profound chemical
+reaction--possibly a far-reaching explosion--would result, and blow
+myself and my apparatus out of all possible dimensions--into the
+Unknown. This possibility had occurred to me again and again while I
+was making the machine; but then I had cheerfully accepted it as an
+unavoidable risk--one of the risks a man has got to take! Now the
+risk was inevitable, I no longer saw it in the same cheerful light.
+The fact is that, insensibly, the absolute strangeness of everything,
+the sickly jarring and swaying of the machine, above all, the
+feeling of prolonged falling, had absolutely upset my nerve. I told
+myself that I could never stop, and with a gust of petulance I
+resolved to stop forthwith. Like an impatient fool, I lugged over
+the lever, and incontinently the thing went reeling over, and I was
+flung headlong through the air.
+
+'There was the sound of a clap of thunder in my ears. I may have
+been stunned for a moment. A pitiless hail was hissing round me,
+and I was sitting on soft turf in front of the overset machine.
+Everything still seemed grey, but presently I remarked that the
+confusion in my ears was gone. I looked round me. I was on what
+seemed to be a little lawn in a garden, surrounded by rhododendron
+bushes, and I noticed that their mauve and purple blossoms were
+dropping in a shower under the beating of the hail-stones. The
+rebounding, dancing hail hung in a cloud over the machine, and drove
+along the ground like smoke. In a moment I was wet to the skin.
+"Fine hospitality," said I, "to a man who has travelled innumerable
+years to see you."
+
+'Presently I thought what a fool I was to get wet. I stood up and
+looked round me. A colossal figure, carved apparently in some white
+stone, loomed indistinctly beyond the rhododendrons through the hazy
+downpour. But all else of the world was invisible.
+
+'My sensations would be hard to describe. As the columns of hail
+grew thinner, I saw the white figure more distinctly. It was very
+large, for a silver birch-tree touched its shoulder. It was of white
+marble, in shape something like a winged sphinx, but the wings,
+instead of being carried vertically at the sides, were spread so
+that it seemed to hover. The pedestal, it appeared to me, was of
+bronze, and was thick with verdigris. It chanced that the face was
+towards me; the sightless eyes seemed to watch me; there was the
+faint shadow of a smile on the lips. It was greatly weather-worn,
+and that imparted an unpleasant suggestion of disease. I stood
+looking at it for a little space--half a minute, perhaps, or half an
+hour. It seemed to advance and to recede as the hail drove before it
+denser or thinner. At last I tore my eyes from it for a moment and
+saw that the hail curtain had worn threadbare, and that the sky was
+lightening with the promise of the sun.
+
+'I looked up again at the crouching white shape, and the full
+temerity of my voyage came suddenly upon me. What might appear when
+that hazy curtain was altogether withdrawn? What might not have
+happened to men? What if cruelty had grown into a common passion?
+What if in this interval the race had lost its manliness and had
+developed into something inhuman, unsympathetic, and overwhelmingly
+powerful? I might seem some old-world savage animal, only the more
+dreadful and disgusting for our common likeness--a foul creature to
+be incontinently slain.
+
+'Already I saw other vast shapes--huge buildings with intricate
+parapets and tall columns, with a wooded hill-side dimly creeping
+in upon me through the lessening storm. I was seized with a panic
+fear. I turned frantically to the Time Machine, and strove hard to
+readjust it. As I did so the shafts of the sun smote through the
+thunderstorm. The grey downpour was swept aside and vanished like
+the trailing garments of a ghost. Above me, in the intense blue
+of the summer sky, some faint brown shreds of cloud whirled into
+nothingness. The great buildings about me stood out clear and
+distinct, shining with the wet of the thunderstorm, and picked out
+in white by the unmelted hailstones piled along their courses. I
+felt naked in a strange world. I felt as perhaps a bird may feel in
+the clear air, knowing the hawk wings above and will swoop. My fear
+grew to frenzy. I took a breathing space, set my teeth, and again
+grappled fiercely, wrist and knee, with the machine. It gave under
+my desperate onset and turned over. It struck my chin violently. One
+hand on the saddle, the other on the lever, I stood panting heavily
+in attitude to mount again.
+
+'But with this recovery of a prompt retreat my courage recovered. I
+looked more curiously and less fearfully at this world of the remote
+future. In a circular opening, high up in the wall of the nearer
+house, I saw a group of figures clad in rich soft robes. They had
+seen me, and their faces were directed towards me.
+
+'Then I heard voices approaching me. Coming through the bushes by
+the White Sphinx were the heads and shoulders of men running. One of
+these emerged in a pathway leading straight to the little lawn upon
+which I stood with my machine. He was a slight creature--perhaps
+four feet high--clad in a purple tunic, girdled at the waist with a
+leather belt. Sandals or buskins--I could not clearly distinguish
+which--were on his feet; his legs were bare to the knees, and his
+head was bare. Noticing that, I noticed for the first time how warm
+the air was.
+
+'He struck me as being a very beautiful and graceful creature, but
+indescribably frail. His flushed face reminded me of the more
+beautiful kind of consumptive--that hectic beauty of which we used
+to hear so much. At the sight of him I suddenly regained confidence.
+I took my hands from the machine.
+
+
+
+
+IV
+
+
+'In another moment we were standing face to face, I and this fragile
+thing out of futurity. He came straight up to me and laughed into my
+eyes. The absence from his bearing of any sign of fear struck me at
+once. Then he turned to the two others who were following him and
+spoke to them in a strange and very sweet and liquid tongue.
+
+'There were others coming, and presently a little group of perhaps
+eight or ten of these exquisite creatures were about me. One of them
+addressed me. It came into my head, oddly enough, that my voice was
+too harsh and deep for them. So I shook my head, and, pointing to my
+ears, shook it again. He came a step forward, hesitated, and then
+touched my hand. Then I felt other soft little tentacles upon my
+back and shoulders. They wanted to make sure I was real. There was
+nothing in this at all alarming. Indeed, there was something in
+these pretty little people that inspired confidence--a graceful
+gentleness, a certain childlike ease. And besides, they looked so
+frail that I could fancy myself flinging the whole dozen of them
+about like nine-pins. But I made a sudden motion to warn them when I
+saw their little pink hands feeling at the Time Machine. Happily
+then, when it was not too late, I thought of a danger I had hitherto
+forgotten, and reaching over the bars of the machine I unscrewed the
+little levers that would set it in motion, and put these in my
+pocket. Then I turned again to see what I could do in the way of
+communication.
+
+'And then, looking more nearly into their features, I saw some
+further peculiarities in their Dresden-china type of prettiness.
+Their hair, which was uniformly curly, came to a sharp end at the
+neck and cheek; there was not the faintest suggestion of it on the
+face, and their ears were singularly minute. The mouths were small,
+with bright red, rather thin lips, and the little chins ran to a
+point. The eyes were large and mild; and--this may seem egotism on
+my part--I fancied even that there was a certain lack of the
+interest I might have expected in them.
+
+'As they made no effort to communicate with me, but simply stood
+round me smiling and speaking in soft cooing notes to each other, I
+began the conversation. I pointed to the Time Machine and to myself.
+Then hesitating for a moment how to express time, I pointed to the
+sun. At once a quaintly pretty little figure in chequered purple and
+white followed my gesture, and then astonished me by imitating the
+sound of thunder.
+
+'For a moment I was staggered, though the import of his gesture was
+plain enough. The question had come into my mind abruptly: were
+these creatures fools? You may hardly understand how it took me.
+You see I had always anticipated that the people of the year Eight
+Hundred and Two Thousand odd would be incredibly in front of us in
+knowledge, art, everything. Then one of them suddenly asked me a
+question that showed him to be on the intellectual level of one of
+our five-year-old children--asked me, in fact, if I had come from
+the sun in a thunderstorm! It let loose the judgment I had suspended
+upon their clothes, their frail light limbs, and fragile features.
+A flow of disappointment rushed across my mind. For a moment I felt
+that I had built the Time Machine in vain.
+
+'I nodded, pointed to the sun, and gave them such a vivid rendering
+of a thunderclap as startled them. They all withdrew a pace or so
+and bowed. Then came one laughing towards me, carrying a chain of
+beautiful flowers altogether new to me, and put it about my neck.
+The idea was received with melodious applause; and presently they
+were all running to and fro for flowers, and laughingly flinging
+them upon me until I was almost smothered with blossom. You who
+have never seen the like can scarcely imagine what delicate and
+wonderful flowers countless years of culture had created. Then
+someone suggested that their plaything should be exhibited in the
+nearest building, and so I was led past the sphinx of white marble,
+which had seemed to watch me all the while with a smile at my
+astonishment, towards a vast grey edifice of fretted stone. As I
+went with them the memory of my confident anticipations of a
+profoundly grave and intellectual posterity came, with irresistible
+merriment, to my mind.
+
+'The building had a huge entry, and was altogether of colossal
+dimensions. I was naturally most occupied with the growing crowd of
+little people, and with the big open portals that yawned before me
+shadowy and mysterious. My general impression of the world I saw
+over their heads was a tangled waste of beautiful bushes and
+flowers, a long neglected and yet weedless garden. I saw a number
+of tall spikes of strange white flowers, measuring a foot perhaps
+across the spread of the waxen petals. They grew scattered, as if
+wild, among the variegated shrubs, but, as I say, I did not examine
+them closely at this time. The Time Machine was left deserted on the
+turf among the rhododendrons.
+
+'The arch of the doorway was richly carved, but naturally I did
+not observe the carving very narrowly, though I fancied I saw
+suggestions of old Phoenician decorations as I passed through, and
+it struck me that they were very badly broken and weather-worn.
+Several more brightly clad people met me in the doorway, and so we
+entered, I, dressed in dingy nineteenth-century garments, looking
+grotesque enough, garlanded with flowers, and surrounded by an
+eddying mass of bright, soft-colored robes and shining white limbs,
+in a melodious whirl of laughter and laughing speech.
+
+'The big doorway opened into a proportionately great hall hung with
+brown. The roof was in shadow, and the windows, partially glazed
+with coloured glass and partially unglazed, admitted a tempered
+light. The floor was made up of huge blocks of some very hard white
+metal, not plates nor slabs--blocks, and it was so much worn, as I
+judged by the going to and fro of past generations, as to be deeply
+channelled along the more frequented ways. Transverse to the length
+were innumerable tables made of slabs of polished stone, raised
+perhaps a foot from the floor, and upon these were heaps of fruits.
+Some I recognized as a kind of hypertrophied raspberry and orange,
+but for the most part they were strange.
+
+'Between the tables was scattered a great number of cushions.
+Upon these my conductors seated themselves, signing for me to do
+likewise. With a pretty absence of ceremony they began to eat the
+fruit with their hands, flinging peel and stalks, and so forth, into
+the round openings in the sides of the tables. I was not loath to
+follow their example, for I felt thirsty and hungry. As I did so I
+surveyed the hall at my leisure.
+
+'And perhaps the thing that struck me most was its dilapidated look.
+The stained-glass windows, which displayed only a geometrical
+pattern, were broken in many places, and the curtains that hung
+across the lower end were thick with dust. And it caught my eye that
+the corner of the marble table near me was fractured. Nevertheless,
+the general effect was extremely rich and picturesque. There were,
+perhaps, a couple of hundred people dining in the hall, and most of
+them, seated as near to me as they could come, were watching me with
+interest, their little eyes shining over the fruit they were eating.
+All were clad in the same soft and yet strong, silky material.
+
+'Fruit, by the by, was all their diet. These people of the remote
+future were strict vegetarians, and while I was with them, in spite
+of some carnal cravings, I had to be frugivorous also. Indeed, I
+found afterwards that horses, cattle, sheep, dogs, had followed the
+Ichthyosaurus into extinction. But the fruits were very delightful;
+one, in particular, that seemed to be in season all the time I was
+there--a floury thing in a three-sided husk--was especially good,
+and I made it my staple. At first I was puzzled by all these strange
+fruits, and by the strange flowers I saw, but later I began to
+perceive their import.
+
+'However, I am telling you of my fruit dinner in the distant future
+now. So soon as my appetite was a little checked, I determined to
+make a resolute attempt to learn the speech of these new men of
+mine. Clearly that was the next thing to do. The fruits seemed a
+convenient thing to begin upon, and holding one of these up I began
+a series of interrogative sounds and gestures. I had some
+considerable difficulty in conveying my meaning. At first my efforts
+met with a stare of surprise or inextinguishable laughter, but
+presently a fair-haired little creature seemed to grasp my intention
+and repeated a name. They had to chatter and explain the business
+at great length to each other, and my first attempts to make the
+exquisite little sounds of their language caused an immense amount
+of amusement. However, I felt like a schoolmaster amidst children,
+and persisted, and presently I had a score of noun substantives at
+least at my command; and then I got to demonstrative pronouns, and
+even the verb "to eat." But it was slow work, and the little people
+soon tired and wanted to get away from my interrogations, so I
+determined, rather of necessity, to let them give their lessons in
+little doses when they felt inclined. And very little doses I found
+they were before long, for I never met people more indolent or more
+easily fatigued.
+
+'A queer thing I soon discovered about my little hosts, and that was
+their lack of interest. They would come to me with eager cries of
+astonishment, like children, but like children they would soon stop
+examining me and wander away after some other toy. The dinner and my
+conversational beginnings ended, I noted for the first time that
+almost all those who had surrounded me at first were gone. It is
+odd, too, how speedily I came to disregard these little people. I
+went out through the portal into the sunlit world again as soon as
+my hunger was satisfied. I was continually meeting more of these men
+of the future, who would follow me a little distance, chatter and
+laugh about me, and, having smiled and gesticulated in a friendly
+way, leave me again to my own devices.
+
+'The calm of evening was upon the world as I emerged from the great
+hall, and the scene was lit by the warm glow of the setting sun.
+At first things were very confusing. Everything was so entirely
+different from the world I had known--even the flowers. The big
+building I had left was situated on the slope of a broad river
+valley, but the Thames had shifted perhaps a mile from its present
+position. I resolved to mount to the summit of a crest, perhaps a
+mile and a half away, from which I could get a wider view of this
+our planet in the year Eight Hundred and Two Thousand Seven Hundred
+and One A.D. For that, I should explain, was the date the little
+dials of my machine recorded.
+
+'As I walked I was watching for every impression that could possibly
+help to explain the condition of ruinous splendour in which I
+found the world--for ruinous it was. A little way up the hill, for
+instance, was a great heap of granite, bound together by masses of
+aluminium, a vast labyrinth of precipitous walls and crumpled
+heaps, amidst which were thick heaps of very beautiful pagoda-like
+plants--nettles possibly--but wonderfully tinted with brown about
+the leaves, and incapable of stinging. It was evidently the derelict
+remains of some vast structure, to what end built I could not
+determine. It was here that I was destined, at a later date, to have
+a very strange experience--the first intimation of a still stranger
+discovery--but of that I will speak in its proper place.
+
+'Looking round with a sudden thought, from a terrace on which I
+rested for a while, I realized that there were no small houses to be
+seen. Apparently the single house, and possibly even the household,
+had vanished. Here and there among the greenery were palace-like
+buildings, but the house and the cottage, which form such
+characteristic features of our own English landscape, had
+disappeared.
+
+'"Communism," said I to myself.
+
+'And on the heels of that came another thought. I looked at the
+half-dozen little figures that were following me. Then, in a flash,
+I perceived that all had the same form of costume, the same soft
+hairless visage, and the same girlish rotundity of limb. It may seem
+strange, perhaps, that I had not noticed this before. But everything
+was so strange. Now, I saw the fact plainly enough. In costume, and
+in all the differences of texture and bearing that now mark off the
+sexes from each other, these people of the future were alike. And
+the children seemed to my eyes to be but the miniatures of their
+parents. I judged, then, that the children of that time were
+extremely precocious, physically at least, and I found afterwards
+abundant verification of my opinion.
+
+'Seeing the ease and security in which these people were living, I
+felt that this close resemblance of the sexes was after all what
+one would expect; for the strength of a man and the softness of a
+woman, the institution of the family, and the differentiation of
+occupations are mere militant necessities of an age of physical
+force; where population is balanced and abundant, much childbearing
+becomes an evil rather than a blessing to the State; where
+violence comes but rarely and off-spring are secure, there is less
+necessity--indeed there is no necessity--for an efficient family,
+and the specialization of the sexes with reference to their
+children's needs disappears. We see some beginnings of this even
+in our own time, and in this future age it was complete. This, I
+must remind you, was my speculation at the time. Later, I was to
+appreciate how far it fell short of the reality.
+
+'While I was musing upon these things, my attention was attracted by
+a pretty little structure, like a well under a cupola. I thought in
+a transitory way of the oddness of wells still existing, and then
+resumed the thread of my speculations. There were no large buildings
+towards the top of the hill, and as my walking powers were evidently
+miraculous, I was presently left alone for the first time. With a
+strange sense of freedom and adventure I pushed on up to the crest.
+
+'There I found a seat of some yellow metal that I did not recognize,
+corroded in places with a kind of pinkish rust and half smothered
+in soft moss, the arm-rests cast and filed into the resemblance of
+griffins' heads. I sat down on it, and I surveyed the broad view of
+our old world under the sunset of that long day. It was as sweet and
+fair a view as I have ever seen. The sun had already gone below the
+horizon and the west was flaming gold, touched with some horizontal
+bars of purple and crimson. Below was the valley of the Thames, in
+which the river lay like a band of burnished steel. I have already
+spoken of the great palaces dotted about among the variegated
+greenery, some in ruins and some still occupied. Here and there rose
+a white or silvery figure in the waste garden of the earth, here and
+there came the sharp vertical line of some cupola or obelisk. There
+were no hedges, no signs of proprietary rights, no evidences of
+agriculture; the whole earth had become a garden.
+
+'So watching, I began to put my interpretation upon the things I had
+seen, and as it shaped itself to me that evening, my interpretation
+was something in this way. (Afterwards I found I had got only a
+half-truth--or only a glimpse of one facet of the truth.)
+
+'It seemed to me that I had happened upon humanity upon the wane.
+The ruddy sunset set me thinking of the sunset of mankind. For the
+first time I began to realize an odd consequence of the social
+effort in which we are at present engaged. And yet, come to think,
+it is a logical consequence enough. Strength is the outcome of need;
+security sets a premium on feebleness. The work of ameliorating the
+conditions of life--the true civilizing process that makes life more
+and more secure--had gone steadily on to a climax. One triumph of a
+united humanity over Nature had followed another. Things that are
+now mere dreams had become projects deliberately put in hand and
+carried forward. And the harvest was what I saw!
+
+'After all, the sanitation and the agriculture of to-day are still
+in the rudimentary stage. The science of our time has attacked but
+a little department of the field of human disease, but even so,
+it spreads its operations very steadily and persistently. Our
+agriculture and horticulture destroy a weed just here and there and
+cultivate perhaps a score or so of wholesome plants, leaving the
+greater number to fight out a balance as they can. We improve our
+favourite plants and animals--and how few they are--gradually by
+selective breeding; now a new and better peach, now a seedless
+grape, now a sweeter and larger flower, now a more convenient breed
+of cattle. We improve them gradually, because our ideals are vague
+and tentative, and our knowledge is very limited; because Nature,
+too, is shy and slow in our clumsy hands. Some day all this will
+be better organized, and still better. That is the drift of the
+current in spite of the eddies. The whole world will be intelligent,
+educated, and co-operating; things will move faster and faster
+towards the subjugation of Nature. In the end, wisely and carefully
+we shall readjust the balance of animal and vegetable life to suit
+our human needs.
+
+'This adjustment, I say, must have been done, and done well; done
+indeed for all Time, in the space of Time across which my machine
+had leaped. The air was free from gnats, the earth from weeds or
+fungi; everywhere were fruits and sweet and delightful flowers;
+brilliant butterflies flew hither and thither. The ideal of
+preventive medicine was attained. Diseases had been stamped out. I
+saw no evidence of any contagious diseases during all my stay. And I
+shall have to tell you later that even the processes of putrefaction
+and decay had been profoundly affected by these changes.
+
+'Social triumphs, too, had been effected. I saw mankind housed in
+splendid shelters, gloriously clothed, and as yet I had found them
+engaged in no toil. There were no signs of struggle, neither social
+nor economical struggle. The shop, the advertisement, traffic, all
+that commerce which constitutes the body of our world, was gone. It
+was natural on that golden evening that I should jump at the idea of
+a social paradise. The difficulty of increasing population had been
+met, I guessed, and population had ceased to increase.
+
+'But with this change in condition comes inevitably adaptations to
+the change. What, unless biological science is a mass of errors, is
+the cause of human intelligence and vigour? Hardship and freedom:
+conditions under which the active, strong, and subtle survive and
+the weaker go to the wall; conditions that put a premium upon the
+loyal alliance of capable men, upon self-restraint, patience, and
+decision. And the institution of the family, and the emotions that
+arise therein, the fierce jealousy, the tenderness for offspring,
+parental self-devotion, all found their justification and support in
+the imminent dangers of the young. _Now_, where are these imminent
+dangers? There is a sentiment arising, and it will grow, against
+connubial jealousy, against fierce maternity, against passion
+of all sorts; unnecessary things now, and things that make us
+uncomfortable, savage survivals, discords in a refined and pleasant
+life.
+
+'I thought of the physical slightness of the people, their lack of
+intelligence, and those big abundant ruins, and it strengthened my
+belief in a perfect conquest of Nature. For after the battle comes
+Quiet. Humanity had been strong, energetic, and intelligent, and had
+used all its abundant vitality to alter the conditions under which
+it lived. And now came the reaction of the altered conditions.
+
+'Under the new conditions of perfect comfort and security, that
+restless energy, that with us is strength, would become weakness.
+Even in our own time certain tendencies and desires, once necessary
+to survival, are a constant source of failure. Physical courage and
+the love of battle, for instance, are no great help--may even be
+hindrances--to a civilized man. And in a state of physical balance
+and security, power, intellectual as well as physical, would be out
+of place. For countless years I judged there had been no danger of
+war or solitary violence, no danger from wild beasts, no wasting
+disease to require strength of constitution, no need of toil. For
+such a life, what we should call the weak are as well equipped as
+the strong, are indeed no longer weak. Better equipped indeed they
+are, for the strong would be fretted by an energy for which there
+was no outlet. No doubt the exquisite beauty of the buildings I saw
+was the outcome of the last surgings of the now purposeless energy
+of mankind before it settled down into perfect harmony with the
+conditions under which it lived--the flourish of that triumph which
+began the last great peace. This has ever been the fate of energy in
+security; it takes to art and to eroticism, and then come languor
+and decay.
+
+'Even this artistic impetus would at last die away--had almost died
+in the Time I saw. To adorn themselves with flowers, to dance, to
+sing in the sunlight: so much was left of the artistic spirit, and
+no more. Even that would fade in the end into a contented
+inactivity. We are kept keen on the grindstone of pain and
+necessity, and, it seemed to me, that here was that hateful
+grindstone broken at last!
+
+'As I stood there in the gathering dark I thought that in this
+simple explanation I had mastered the problem of the world--mastered
+the whole secret of these delicious people. Possibly the checks they
+had devised for the increase of population had succeeded too well,
+and their numbers had rather diminished than kept stationary.
+That would account for the abandoned ruins. Very simple was my
+explanation, and plausible enough--as most wrong theories are!
+
+
+
+
+V
+
+
+'As I stood there musing over this too perfect triumph of man, the
+full moon, yellow and gibbous, came up out of an overflow of silver
+light in the north-east. The bright little figures ceased to move
+about below, a noiseless owl flitted by, and I shivered with the
+chill of the night. I determined to descend and find where I could
+sleep.
+
+'I looked for the building I knew. Then my eye travelled along to
+the figure of the White Sphinx upon the pedestal of bronze, growing
+distinct as the light of the rising moon grew brighter. I could see
+the silver birch against it. There was the tangle of rhododendron
+bushes, black in the pale light, and there was the little lawn.
+I looked at the lawn again. A queer doubt chilled my complacency.
+"No," said I stoutly to myself, "that was not the lawn."
+
+'But it _was_ the lawn. For the white leprous face of the sphinx was
+towards it. Can you imagine what I felt as this conviction came
+home to me? But you cannot. The Time Machine was gone!
+
+'At once, like a lash across the face, came the possibility of
+losing my own age, of being left helpless in this strange new world.
+The bare thought of it was an actual physical sensation. I could
+feel it grip me at the throat and stop my breathing. In another
+moment I was in a passion of fear and running with great leaping
+strides down the slope. Once I fell headlong and cut my face; I lost
+no time in stanching the blood, but jumped up and ran on, with a
+warm trickle down my cheek and chin. All the time I ran I was saying
+to myself: "They have moved it a little, pushed it under the bushes
+out of the way." Nevertheless, I ran with all my might. All the
+time, with the certainty that sometimes comes with excessive dread,
+I knew that such assurance was folly, knew instinctively that the
+machine was removed out of my reach. My breath came with pain. I
+suppose I covered the whole distance from the hill crest to the
+little lawn, two miles perhaps, in ten minutes. And I am not a young
+man. I cursed aloud, as I ran, at my confident folly in leaving the
+machine, wasting good breath thereby. I cried aloud, and none
+answered. Not a creature seemed to be stirring in that moonlit
+world.
+
+'When I reached the lawn my worst fears were realized. Not a trace
+of the thing was to be seen. I felt faint and cold when I faced the
+empty space among the black tangle of bushes. I ran round it
+furiously, as if the thing might be hidden in a corner, and then
+stopped abruptly, with my hands clutching my hair. Above me towered
+the sphinx, upon the bronze pedestal, white, shining, leprous, in
+the light of the rising moon. It seemed to smile in mockery of my
+dismay.
+
+'I might have consoled myself by imagining the little people had put
+the mechanism in some shelter for me, had I not felt assured of
+their physical and intellectual inadequacy. That is what dismayed
+me: the sense of some hitherto unsuspected power, through whose
+intervention my invention had vanished. Yet, for one thing I felt
+assured: unless some other age had produced its exact duplicate,
+the machine could not have moved in time. The attachment of the
+levers--I will show you the method later--prevented any one from
+tampering with it in that way when they were removed. It had moved,
+and was hid, only in space. But then, where could it be?
+
+'I think I must have had a kind of frenzy. I remember running
+violently in and out among the moonlit bushes all round the sphinx,
+and startling some white animal that, in the dim light, I took for a
+small deer. I remember, too, late that night, beating the bushes
+with my clenched fist until my knuckles were gashed and bleeding
+from the broken twigs. Then, sobbing and raving in my anguish of
+mind, I went down to the great building of stone. The big hall was
+dark, silent, and deserted. I slipped on the uneven floor, and fell
+over one of the malachite tables, almost breaking my shin. I lit a
+match and went on past the dusty curtains, of which I have told you.
+
+'There I found a second great hall covered with cushions, upon
+which, perhaps, a score or so of the little people were sleeping. I
+have no doubt they found my second appearance strange enough, coming
+suddenly out of the quiet darkness with inarticulate noises and the
+splutter and flare of a match. For they had forgotten about matches.
+"Where is my Time Machine?" I began, bawling like an angry child,
+laying hands upon them and shaking them up together. It must have
+been very queer to them. Some laughed, most of them looked sorely
+frightened. When I saw them standing round me, it came into my head
+that I was doing as foolish a thing as it was possible for me to do
+under the circumstances, in trying to revive the sensation of fear.
+For, reasoning from their daylight behaviour, I thought that fear
+must be forgotten.
+
+'Abruptly, I dashed down the match, and, knocking one of the people
+over in my course, went blundering across the big dining-hall again,
+out under the moonlight. I heard cries of terror and their little
+feet running and stumbling this way and that. I do not remember all
+I did as the moon crept up the sky. I suppose it was the unexpected
+nature of my loss that maddened me. I felt hopelessly cut off from
+my own kind--a strange animal in an unknown world. I must have raved
+to and fro, screaming and crying upon God and Fate. I have a memory
+of horrible fatigue, as the long night of despair wore away; of
+looking in this impossible place and that; of groping among moon-lit
+ruins and touching strange creatures in the black shadows; at last,
+of lying on the ground near the sphinx and weeping with absolute
+wretchedness. I had nothing left but misery. Then I slept, and when
+I woke again it was full day, and a couple of sparrows were hopping
+round me on the turf within reach of my arm.
+
+'I sat up in the freshness of the morning, trying to remember how
+I had got there, and why I had such a profound sense of desertion
+and despair. Then things came clear in my mind. With the plain,
+reasonable daylight, I could look my circumstances fairly in the
+face. I saw the wild folly of my frenzy overnight, and I could
+reason with myself. "Suppose the worst?" I said. "Suppose the
+machine altogether lost--perhaps destroyed? It behoves me to be
+calm and patient, to learn the way of the people, to get a clear
+idea of the method of my loss, and the means of getting materials
+and tools; so that in the end, perhaps, I may make another." That
+would be my only hope, perhaps, but better than despair. And, after
+all, it was a beautiful and curious world.
+
+'But probably, the machine had only been taken away. Still, I must
+be calm and patient, find its hiding-place, and recover it by force
+or cunning. And with that I scrambled to my feet and looked about
+me, wondering where I could bathe. I felt weary, stiff, and
+travel-soiled. The freshness of the morning made me desire an equal
+freshness. I had exhausted my emotion. Indeed, as I went about
+my business, I found myself wondering at my intense excitement
+overnight. I made a careful examination of the ground about the
+little lawn. I wasted some time in futile questionings, conveyed, as
+well as I was able, to such of the little people as came by. They
+all failed to understand my gestures; some were simply stolid, some
+thought it was a jest and laughed at me. I had the hardest task in
+the world to keep my hands off their pretty laughing faces. It was
+a foolish impulse, but the devil begotten of fear and blind anger
+was ill curbed and still eager to take advantage of my perplexity.
+The turf gave better counsel. I found a groove ripped in it, about
+midway between the pedestal of the sphinx and the marks of my feet
+where, on arrival, I had struggled with the overturned machine.
+There were other signs of removal about, with queer narrow
+footprints like those I could imagine made by a sloth. This directed
+my closer attention to the pedestal. It was, as I think I have said,
+of bronze. It was not a mere block, but highly decorated with deep
+framed panels on either side. I went and rapped at these. The
+pedestal was hollow. Examining the panels with care I found them
+discontinuous with the frames. There were no handles or keyholes,
+but possibly the panels, if they were doors, as I supposed, opened
+from within. One thing was clear enough to my mind. It took no very
+great mental effort to infer that my Time Machine was inside that
+pedestal. But how it got there was a different problem.
+
+'I saw the heads of two orange-clad people coming through the bushes
+and under some blossom-covered apple-trees towards me. I turned
+smiling to them and beckoned them to me. They came, and then,
+pointing to the bronze pedestal, I tried to intimate my wish to open
+it. But at my first gesture towards this they behaved very oddly. I
+don't know how to convey their expression to you. Suppose you were
+to use a grossly improper gesture to a delicate-minded woman--it is
+how she would look. They went off as if they had received the last
+possible insult. I tried a sweet-looking little chap in white next,
+with exactly the same result. Somehow, his manner made me feel
+ashamed of myself. But, as you know, I wanted the Time Machine, and
+I tried him once more. As he turned off, like the others, my temper
+got the better of me. In three strides I was after him, had him by
+the loose part of his robe round the neck, and began dragging him
+towards the sphinx. Then I saw the horror and repugnance of his
+face, and all of a sudden I let him go.
+
+'But I was not beaten yet. I banged with my fist at the bronze
+panels. I thought I heard something stir inside--to be explicit,
+I thought I heard a sound like a chuckle--but I must have been
+mistaken. Then I got a big pebble from the river, and came and
+hammered till I had flattened a coil in the decorations, and the
+verdigris came off in powdery flakes. The delicate little people
+must have heard me hammering in gusty outbreaks a mile away on
+either hand, but nothing came of it. I saw a crowd of them upon the
+slopes, looking furtively at me. At last, hot and tired, I sat down
+to watch the place. But I was too restless to watch long; I am too
+Occidental for a long vigil. I could work at a problem for years,
+but to wait inactive for twenty-four hours--that is another matter.
+
+'I got up after a time, and began walking aimlessly through the
+bushes towards the hill again. "Patience," said I to myself. "If you
+want your machine again you must leave that sphinx alone. If they
+mean to take your machine away, it's little good your wrecking their
+bronze panels, and if they don't, you will get it back as soon as
+you can ask for it. To sit among all those unknown things before a
+puzzle like that is hopeless. That way lies monomania. Face this
+world. Learn its ways, watch it, be careful of too hasty guesses
+at its meaning. In the end you will find clues to it all." Then
+suddenly the humour of the situation came into my mind: the thought
+of the years I had spent in study and toil to get into the future
+age, and now my passion of anxiety to get out of it. I had made
+myself the most complicated and the most hopeless trap that ever a
+man devised. Although it was at my own expense, I could not help
+myself. I laughed aloud.
+
+'Going through the big palace, it seemed to me that the little
+people avoided me. It may have been my fancy, or it may have had
+something to do with my hammering at the gates of bronze. Yet I felt
+tolerably sure of the avoidance. I was careful, however, to show no
+concern and to abstain from any pursuit of them, and in the course
+of a day or two things got back to the old footing. I made what
+progress I could in the language, and in addition I pushed my
+explorations here and there. Either I missed some subtle point or
+their language was excessively simple--almost exclusively composed
+of concrete substantives and verbs. There seemed to be few, if any,
+abstract terms, or little use of figurative language. Their
+sentences were usually simple and of two words, and I failed to
+convey or understand any but the simplest propositions. I determined
+to put the thought of my Time Machine and the mystery of the bronze
+doors under the sphinx as much as possible in a corner of memory,
+until my growing knowledge would lead me back to them in a natural
+way. Yet a certain feeling, you may understand, tethered me in a
+circle of a few miles round the point of my arrival.
+
+'So far as I could see, all the world displayed the same exuberant
+richness as the Thames valley. From every hill I climbed I saw the
+same abundance of splendid buildings, endlessly varied in material
+and style, the same clustering thickets of evergreens, the same
+blossom-laden trees and tree-ferns. Here and there water shone like
+silver, and beyond, the land rose into blue undulating hills, and
+so faded into the serenity of the sky. A peculiar feature, which
+presently attracted my attention, was the presence of certain
+circular wells, several, as it seemed to me, of a very great depth.
+One lay by the path up the hill, which I had followed during my
+first walk. Like the others, it was rimmed with bronze, curiously
+wrought, and protected by a little cupola from the rain. Sitting by
+the side of these wells, and peering down into the shafted darkness,
+I could see no gleam of water, nor could I start any reflection
+with a lighted match. But in all of them I heard a certain sound:
+a thud--thud--thud, like the beating of some big engine; and I
+discovered, from the flaring of my matches, that a steady current of
+air set down the shafts. Further, I threw a scrap of paper into the
+throat of one, and, instead of fluttering slowly down, it was at
+once sucked swiftly out of sight.
+
+'After a time, too, I came to connect these wells with tall towers
+standing here and there upon the slopes; for above them there was
+often just such a flicker in the air as one sees on a hot day above
+a sun-scorched beach. Putting things together, I reached a strong
+suggestion of an extensive system of subterranean ventilation, whose
+true import it was difficult to imagine. I was at first inclined to
+associate it with the sanitary apparatus of these people. It was an
+obvious conclusion, but it was absolutely wrong.
+
+'And here I must admit that I learned very little of drains and
+bells and modes of conveyance, and the like conveniences, during my
+time in this real future. In some of these visions of Utopias and
+coming times which I have read, there is a vast amount of detail
+about building, and social arrangements, and so forth. But while
+such details are easy enough to obtain when the whole world is
+contained in one's imagination, they are altogether inaccessible to
+a real traveller amid such realities as I found here. Conceive the
+tale of London which a negro, fresh from Central Africa, would take
+back to his tribe! What would he know of railway companies, of
+social movements, of telephone and telegraph wires, of the Parcels
+Delivery Company, and postal orders and the like? Yet we, at least,
+should be willing enough to explain these things to him! And even of
+what he knew, how much could he make his untravelled friend either
+apprehend or believe? Then, think how narrow the gap between a negro
+and a white man of our own times, and how wide the interval between
+myself and these of the Golden Age! I was sensible of much which was
+unseen, and which contributed to my comfort; but save for a general
+impression of automatic organization, I fear I can convey very
+little of the difference to your mind.
+
+'In the matter of sepulture, for instance, I could see no signs of
+crematoria nor anything suggestive of tombs. But it occurred to me
+that, possibly, there might be cemeteries (or crematoria) somewhere
+beyond the range of my explorings. This, again, was a question I
+deliberately put to myself, and my curiosity was at first entirely
+defeated upon the point. The thing puzzled me, and I was led to make
+a further remark, which puzzled me still more: that aged and infirm
+among this people there were none.
+
+'I must confess that my satisfaction with my first theories of an
+automatic civilization and a decadent humanity did not long endure.
+Yet I could think of no other. Let me put my difficulties. The
+several big palaces I had explored were mere living places, great
+dining-halls and sleeping apartments. I could find no machinery, no
+appliances of any kind. Yet these people were clothed in pleasant
+fabrics that must at times need renewal, and their sandals, though
+undecorated, were fairly complex specimens of metalwork. Somehow
+such things must be made. And the little people displayed no vestige
+of a creative tendency. There were no shops, no workshops, no sign
+of importations among them. They spent all their time in playing
+gently, in bathing in the river, in making love in a half-playful
+fashion, in eating fruit and sleeping. I could not see how things
+were kept going.
+
+'Then, again, about the Time Machine: something, I knew not what,
+had taken it into the hollow pedestal of the White Sphinx. Why? For
+the life of me I could not imagine. Those waterless wells, too,
+those flickering pillars. I felt I lacked a clue. I felt--how shall
+I put it? Suppose you found an inscription, with sentences here and
+there in excellent plain English, and interpolated therewith, others
+made up of words, of letters even, absolutely unknown to you? Well,
+on the third day of my visit, that was how the world of Eight
+Hundred and Two Thousand Seven Hundred and One presented itself to
+me!
+
+'That day, too, I made a friend--of a sort. It happened that, as I
+was watching some of the little people bathing in a shallow, one of
+them was seized with cramp and began drifting downstream. The main
+current ran rather swiftly, but not too strongly for even a moderate
+swimmer. It will give you an idea, therefore, of the strange
+deficiency in these creatures, when I tell you that none made the
+slightest attempt to rescue the weakly crying little thing which
+was drowning before their eyes. When I realized this, I hurriedly
+slipped off my clothes, and, wading in at a point lower down, I
+caught the poor mite and drew her safe to land. A little rubbing of
+the limbs soon brought her round, and I had the satisfaction of
+seeing she was all right before I left her. I had got to such a low
+estimate of her kind that I did not expect any gratitude from her.
+In that, however, I was wrong.
+
+'This happened in the morning. In the afternoon I met my little
+woman, as I believe it was, as I was returning towards my centre
+from an exploration, and she received me with cries of delight and
+presented me with a big garland of flowers--evidently made for me
+and me alone. The thing took my imagination. Very possibly I had
+been feeling desolate. At any rate I did my best to display my
+appreciation of the gift. We were soon seated together in a little
+stone arbour, engaged in conversation, chiefly of smiles. The
+creature's friendliness affected me exactly as a child's might have
+done. We passed each other flowers, and she kissed my hands. I did
+the same to hers. Then I tried talk, and found that her name was
+Weena, which, though I don't know what it meant, somehow seemed
+appropriate enough. That was the beginning of a queer friendship
+which lasted a week, and ended--as I will tell you!
+
+'She was exactly like a child. She wanted to be with me always. She
+tried to follow me everywhere, and on my next journey out and about
+it went to my heart to tire her down, and leave her at last,
+exhausted and calling after me rather plaintively. But the problems
+of the world had to be mastered. I had not, I said to myself, come
+into the future to carry on a miniature flirtation. Yet her distress
+when I left her was very great, her expostulations at the parting
+were sometimes frantic, and I think, altogether, I had as much
+trouble as comfort from her devotion. Nevertheless she was, somehow,
+a very great comfort. I thought it was mere childish affection that
+made her cling to me. Until it was too late, I did not clearly know
+what I had inflicted upon her when I left her. Nor until it was too
+late did I clearly understand what she was to me. For, by merely
+seeming fond of me, and showing in her weak, futile way that she
+cared for me, the little doll of a creature presently gave my return
+to the neighbourhood of the White Sphinx almost the feeling of
+coming home; and I would watch for her tiny figure of white and gold
+so soon as I came over the hill.
+
+'It was from her, too, that I learned that fear had not yet left the
+world. She was fearless enough in the daylight, and she had the
+oddest confidence in me; for once, in a foolish moment, I made
+threatening grimaces at her, and she simply laughed at them. But she
+dreaded the dark, dreaded shadows, dreaded black things. Darkness
+to her was the one thing dreadful. It was a singularly passionate
+emotion, and it set me thinking and observing. I discovered then,
+among other things, that these little people gathered into the great
+houses after dark, and slept in droves. To enter upon them without a
+light was to put them into a tumult of apprehension. I never found
+one out of doors, or one sleeping alone within doors, after dark.
+Yet I was still such a blockhead that I missed the lesson of that
+fear, and in spite of Weena's distress I insisted upon sleeping away
+from these slumbering multitudes.
+
+'It troubled her greatly, but in the end her odd affection for me
+triumphed, and for five of the nights of our acquaintance, including
+the last night of all, she slept with her head pillowed on my arm.
+But my story slips away from me as I speak of her. It must have been
+the night before her rescue that I was awakened about dawn. I had
+been restless, dreaming most disagreeably that I was drowned, and
+that sea anemones were feeling over my face with their soft palps.
+I woke with a start, and with an odd fancy that some greyish animal
+had just rushed out of the chamber. I tried to get to sleep again,
+but I felt restless and uncomfortable. It was that dim grey hour
+when things are just creeping out of darkness, when everything is
+colourless and clear cut, and yet unreal. I got up, and went down
+into the great hall, and so out upon the flagstones in front of the
+palace. I thought I would make a virtue of necessity, and see the
+sunrise.
+
+'The moon was setting, and the dying moonlight and the first pallor
+of dawn were mingled in a ghastly half-light. The bushes were inky
+black, the ground a sombre grey, the sky colourless and cheerless.
+And up the hill I thought I could see ghosts. There several times,
+as I scanned the slope, I saw white figures. Twice I fancied I saw
+a solitary white, ape-like creature running rather quickly up the
+hill, and once near the ruins I saw a leash of them carrying some
+dark body. They moved hastily. I did not see what became of them.
+It seemed that they vanished among the bushes. The dawn was still
+indistinct, you must understand. I was feeling that chill,
+uncertain, early-morning feeling you may have known. I doubted
+my eyes.
+
+'As the eastern sky grew brighter, and the light of the day came on
+and its vivid colouring returned upon the world once more, I scanned
+the view keenly. But I saw no vestige of my white figures. They were
+mere creatures of the half light. "They must have been ghosts," I
+said; "I wonder whence they dated." For a queer notion of Grant
+Allen's came into my head, and amused me. If each generation die and
+leave ghosts, he argued, the world at last will get overcrowded with
+them. On that theory they would have grown innumerable some Eight
+Hundred Thousand Years hence, and it was no great wonder to see four
+at once. But the jest was unsatisfying, and I was thinking of these
+figures all the morning, until Weena's rescue drove them out of my
+head. I associated them in some indefinite way with the white animal
+I had startled in my first passionate search for the Time Machine.
+But Weena was a pleasant substitute. Yet all the same, they were
+soon destined to take far deadlier possession of my mind.
+
+'I think I have said how much hotter than our own was the weather
+of this Golden Age. I cannot account for it. It may be that the sun
+was hotter, or the earth nearer the sun. It is usual to assume that
+the sun will go on cooling steadily in the future. But people,
+unfamiliar with such speculations as those of the younger Darwin,
+forget that the planets must ultimately fall back one by one into
+the parent body. As these catastrophes occur, the sun will blaze
+with renewed energy; and it may be that some inner planet had
+suffered this fate. Whatever the reason, the fact remains that the
+sun was very much hotter than we know it.
+
+'Well, one very hot morning--my fourth, I think--as I was seeking
+shelter from the heat and glare in a colossal ruin near the great
+house where I slept and fed, there happened this strange thing:
+Clambering among these heaps of masonry, I found a narrow gallery,
+whose end and side windows were blocked by fallen masses of stone.
+By contrast with the brilliancy outside, it seemed at first
+impenetrably dark to me. I entered it groping, for the change from
+light to blackness made spots of colour swim before me. Suddenly I
+halted spellbound. A pair of eyes, luminous by reflection against
+the daylight without, was watching me out of the darkness.
+
+'The old instinctive dread of wild beasts came upon me. I clenched
+my hands and steadfastly looked into the glaring eyeballs. I was
+afraid to turn. Then the thought of the absolute security in which
+humanity appeared to be living came to my mind. And then I
+remembered that strange terror of the dark. Overcoming my fear to
+some extent, I advanced a step and spoke. I will admit that my
+voice was harsh and ill-controlled. I put out my hand and touched
+something soft. At once the eyes darted sideways, and something
+white ran past me. I turned with my heart in my mouth, and saw a
+queer little ape-like figure, its head held down in a peculiar
+manner, running across the sunlit space behind me. It blundered
+against a block of granite, staggered aside, and in a moment was
+hidden in a black shadow beneath another pile of ruined masonry.
+
+'My impression of it is, of course, imperfect; but I know it was a
+dull white, and had strange large greyish-red eyes; also that there
+was flaxen hair on its head and down its back. But, as I say, it
+went too fast for me to see distinctly. I cannot even say whether it
+ran on all-fours, or only with its forearms held very low. After an
+instant's pause I followed it into the second heap of ruins. I could
+not find it at first; but, after a time in the profound obscurity, I
+came upon one of those round well-like openings of which I have told
+you, half closed by a fallen pillar. A sudden thought came to me.
+Could this Thing have vanished down the shaft? I lit a match, and,
+looking down, I saw a small, white, moving creature, with large
+bright eyes which regarded me steadfastly as it retreated. It made
+me shudder. It was so like a human spider! It was clambering down
+the wall, and now I saw for the first time a number of metal foot
+and hand rests forming a kind of ladder down the shaft. Then the
+light burned my fingers and fell out of my hand, going out as it
+dropped, and when I had lit another the little monster had
+disappeared.
+
+'I do not know how long I sat peering down that well. It was not for
+some time that I could succeed in persuading myself that the thing I
+had seen was human. But, gradually, the truth dawned on me: that
+Man had not remained one species, but had differentiated into two
+distinct animals: that my graceful children of the Upper-world were
+not the sole descendants of our generation, but that this bleached,
+obscene, nocturnal Thing, which had flashed before me, was also heir
+to all the ages.
+
+'I thought of the flickering pillars and of my theory of an
+underground ventilation. I began to suspect their true import. And
+what, I wondered, was this Lemur doing in my scheme of a perfectly
+balanced organization? How was it related to the indolent serenity
+of the beautiful Upper-worlders? And what was hidden down there,
+at the foot of that shaft? I sat upon the edge of the well telling
+myself that, at any rate, there was nothing to fear, and that there
+I must descend for the solution of my difficulties. And withal I
+was absolutely afraid to go! As I hesitated, two of the beautiful
+Upper-world people came running in their amorous sport across the
+daylight in the shadow. The male pursued the female, flinging
+flowers at her as he ran.
+
+'They seemed distressed to find me, my arm against the overturned
+pillar, peering down the well. Apparently it was considered bad form
+to remark these apertures; for when I pointed to this one, and tried
+to frame a question about it in their tongue, they were still more
+visibly distressed and turned away. But they were interested by my
+matches, and I struck some to amuse them. I tried them again about
+the well, and again I failed. So presently I left them, meaning to
+go back to Weena, and see what I could get from her. But my mind was
+already in revolution; my guesses and impressions were slipping and
+sliding to a new adjustment. I had now a clue to the import of these
+wells, to the ventilating towers, to the mystery of the ghosts; to
+say nothing of a hint at the meaning of the bronze gates and the
+fate of the Time Machine! And very vaguely there came a suggestion
+towards the solution of the economic problem that had puzzled me.
+
+'Here was the new view. Plainly, this second species of Man was
+subterranean. There were three circumstances in particular which
+made me think that its rare emergence above ground was the outcome
+of a long-continued underground habit. In the first place, there was
+the bleached look common in most animals that live largely in the
+dark--the white fish of the Kentucky caves, for instance. Then,
+those large eyes, with that capacity for reflecting light, are
+common features of nocturnal things--witness the owl and the cat.
+And last of all, that evident confusion in the sunshine, that hasty
+yet fumbling awkward flight towards dark shadow, and that peculiar
+carriage of the head while in the light--all reinforced the theory
+of an extreme sensitiveness of the retina.
+
+'Beneath my feet, then, the earth must be tunnelled enormously, and
+these tunnellings were the habitat of the new race. The presence of
+ventilating shafts and wells along the hill slopes--everywhere, in
+fact, except along the river valley--showed how universal were its
+ramifications. What so natural, then, as to assume that it was in
+this artificial Underworld that such work as was necessary to the
+comfort of the daylight race was done? The notion was so plausible
+that I at once accepted it, and went on to assume the _how_ of this
+splitting of the human species. I dare say you will anticipate the
+shape of my theory; though, for myself, I very soon felt that it
+fell far short of the truth.
+
+'At first, proceeding from the problems of our own age, it seemed
+clear as daylight to me that the gradual widening of the present
+merely temporary and social difference between the Capitalist and
+the Labourer, was the key to the whole position. No doubt it will
+seem grotesque enough to you--and wildly incredible!--and yet even
+now there are existing circumstances to point that way. There is
+a tendency to utilize underground space for the less ornamental
+purposes of civilization; there is the Metropolitan Railway in
+London, for instance, there are new electric railways, there are
+subways, there are underground workrooms and restaurants, and they
+increase and multiply. Evidently, I thought, this tendency had
+increased till Industry had gradually lost its birthright in the
+sky. I mean that it had gone deeper and deeper into larger and ever
+larger underground factories, spending a still-increasing amount of
+its time therein, till, in the end--! Even now, does not an East-end
+worker live in such artificial conditions as practically to be cut
+off from the natural surface of the earth?
+
+'Again, the exclusive tendency of richer people--due, no doubt, to
+the increasing refinement of their education, and the widening gulf
+between them and the rude violence of the poor--is already leading
+to the closing, in their interest, of considerable portions of the
+surface of the land. About London, for instance, perhaps half the
+prettier country is shut in against intrusion. And this same
+widening gulf--which is due to the length and expense of the higher
+educational process and the increased facilities for and temptations
+towards refined habits on the part of the rich--will make that
+exchange between class and class, that promotion by intermarriage
+which at present retards the splitting of our species along lines
+of social stratification, less and less frequent. So, in the end,
+above ground you must have the Haves, pursuing pleasure and comfort
+and beauty, and below ground the Have-nots, the Workers getting
+continually adapted to the conditions of their labour. Once they
+were there, they would no doubt have to pay rent, and not a little
+of it, for the ventilation of their caverns; and if they refused,
+they would starve or be suffocated for arrears. Such of them as were
+so constituted as to be miserable and rebellious would die; and, in
+the end, the balance being permanent, the survivors would become as
+well adapted to the conditions of underground life, and as happy in
+their way, as the Upper-world people were to theirs. As it seemed to
+me, the refined beauty and the etiolated pallor followed naturally
+enough.
+
+'The great triumph of Humanity I had dreamed of took a different
+shape in my mind. It had been no such triumph of moral education and
+general co-operation as I had imagined. Instead, I saw a real
+aristocracy, armed with a perfected science and working to a logical
+conclusion the industrial system of to-day. Its triumph had not been
+simply a triumph over Nature, but a triumph over Nature and the
+fellow-man. This, I must warn you, was my theory at the time. I had
+no convenient cicerone in the pattern of the Utopian books. My
+explanation may be absolutely wrong. I still think it is the
+most plausible one. But even on this supposition the balanced
+civilization that was at last attained must have long since passed
+its zenith, and was now far fallen into decay. The too-perfect
+security of the Upper-worlders had led them to a slow movement of
+degeneration, to a general dwindling in size, strength, and
+intelligence. That I could see clearly enough already. What had
+happened to the Under-grounders I did not yet suspect; but from what
+I had seen of the Morlocks--that, by the by, was the name by which
+these creatures were called--I could imagine that the modification
+of the human type was even far more profound than among the "Eloi,"
+the beautiful race that I already knew.
+
+'Then came troublesome doubts. Why had the Morlocks taken my Time
+Machine? For I felt sure it was they who had taken it. Why, too, if
+the Eloi were masters, could they not restore the machine to me? And
+why were they so terribly afraid of the dark? I proceeded, as I have
+said, to question Weena about this Under-world, but here again I was
+disappointed. At first she would not understand my questions, and
+presently she refused to answer them. She shivered as though the
+topic was unendurable. And when I pressed her, perhaps a little
+harshly, she burst into tears. They were the only tears, except my
+own, I ever saw in that Golden Age. When I saw them I ceased
+abruptly to trouble about the Morlocks, and was only concerned in
+banishing these signs of the human inheritance from Weena's eyes.
+And very soon she was smiling and clapping her hands, while I
+solemnly burned a match.
+
+
+
+
+VI
+
+
+'It may seem odd to you, but it was two days before I could follow
+up the new-found clue in what was manifestly the proper way. I felt
+a peculiar shrinking from those pallid bodies. They were just the
+half-bleached colour of the worms and things one sees preserved in
+spirit in a zoological museum. And they were filthily cold to the
+touch. Probably my shrinking was largely due to the sympathetic
+influence of the Eloi, whose disgust of the Morlocks I now began
+to appreciate.
+
+'The next night I did not sleep well. Probably my health was a
+little disordered. I was oppressed with perplexity and doubt. Once
+or twice I had a feeling of intense fear for which I could perceive
+no definite reason. I remember creeping noiselessly into the great
+hall where the little people were sleeping in the moonlight--that
+night Weena was among them--and feeling reassured by their presence.
+It occurred to me even then, that in the course of a few days the
+moon must pass through its last quarter, and the nights grow dark,
+when the appearances of these unpleasant creatures from below, these
+whitened Lemurs, this new vermin that had replaced the old, might be
+more abundant. And on both these days I had the restless feeling of
+one who shirks an inevitable duty. I felt assured that the Time
+Machine was only to be recovered by boldly penetrating these
+underground mysteries. Yet I could not face the mystery. If only I
+had had a companion it would have been different. But I was so
+horribly alone, and even to clamber down into the darkness of the
+well appalled me. I don't know if you will understand my feeling,
+but I never felt quite safe at my back.
+
+'It was this restlessness, this insecurity, perhaps, that drove me
+further and further afield in my exploring expeditions. Going to the
+south-westward towards the rising country that is now called Combe
+Wood, I observed far off, in the direction of nineteenth-century
+Banstead, a vast green structure, different in character from any
+I had hitherto seen. It was larger than the largest of the palaces
+or ruins I knew, and the facade had an Oriental look: the face
+of it having the lustre, as well as the pale-green tint, a kind
+of bluish-green, of a certain type of Chinese porcelain. This
+difference in aspect suggested a difference in use, and I was minded
+to push on and explore. But the day was growing late, and I had come
+upon the sight of the place after a long and tiring circuit; so I
+resolved to hold over the adventure for the following day, and I
+returned to the welcome and the caresses of little Weena. But next
+morning I perceived clearly enough that my curiosity regarding the
+Palace of Green Porcelain was a piece of self-deception, to enable
+me to shirk, by another day, an experience I dreaded. I resolved I
+would make the descent without further waste of time, and started
+out in the early morning towards a well near the ruins of granite
+and aluminium.
+
+'Little Weena ran with me. She danced beside me to the well, but
+when she saw me lean over the mouth and look downward, she seemed
+strangely disconcerted. "Good-bye, little Weena," I said, kissing
+her; and then putting her down, I began to feel over the parapet
+for the climbing hooks. Rather hastily, I may as well confess, for
+I feared my courage might leak away! At first she watched me in
+amazement. Then she gave a most piteous cry, and running to me, she
+began to pull at me with her little hands. I think her opposition
+nerved me rather to proceed. I shook her off, perhaps a little
+roughly, and in another moment I was in the throat of the well. I
+saw her agonized face over the parapet, and smiled to reassure her.
+Then I had to look down at the unstable hooks to which I clung.
+
+'I had to clamber down a shaft of perhaps two hundred yards. The
+descent was effected by means of metallic bars projecting from
+the sides of the well, and these being adapted to the needs of
+a creature much smaller and lighter than myself, I was speedily
+cramped and fatigued by the descent. And not simply fatigued! One of
+the bars bent suddenly under my weight, and almost swung me off into
+the blackness beneath. For a moment I hung by one hand, and after
+that experience I did not dare to rest again. Though my arms and
+back were presently acutely painful, I went on clambering down the
+sheer descent with as quick a motion as possible. Glancing upward,
+I saw the aperture, a small blue disk, in which a star was visible,
+while little Weena's head showed as a round black projection. The
+thudding sound of a machine below grew louder and more oppressive.
+Everything save that little disk above was profoundly dark, and when
+I looked up again Weena had disappeared.
+
+'I was in an agony of discomfort. I had some thought of trying to go
+up the shaft again, and leave the Under-world alone. But even while
+I turned this over in my mind I continued to descend. At last, with
+intense relief, I saw dimly coming up, a foot to the right of me, a
+slender loophole in the wall. Swinging myself in, I found it was the
+aperture of a narrow horizontal tunnel in which I could lie down and
+rest. It was not too soon. My arms ached, my back was cramped, and I
+was trembling with the prolonged terror of a fall. Besides this, the
+unbroken darkness had had a distressing effect upon my eyes. The air
+was full of the throb and hum of machinery pumping air down the
+shaft.
+
+'I do not know how long I lay. I was roused by a soft hand touching
+my face. Starting up in the darkness I snatched at my matches and,
+hastily striking one, I saw three stooping white creatures similar
+to the one I had seen above ground in the ruin, hastily retreating
+before the light. Living, as they did, in what appeared to me
+impenetrable darkness, their eyes were abnormally large and
+sensitive, just as are the pupils of the abysmal fishes, and they
+reflected the light in the same way. I have no doubt they could see
+me in that rayless obscurity, and they did not seem to have any fear
+of me apart from the light. But, so soon as I struck a match in
+order to see them, they fled incontinently, vanishing into dark
+gutters and tunnels, from which their eyes glared at me in the
+strangest fashion.
+
+'I tried to call to them, but the language they had was apparently
+different from that of the Over-world people; so that I was needs
+left to my own unaided efforts, and the thought of flight before
+exploration was even then in my mind. But I said to myself, "You are
+in for it now," and, feeling my way along the tunnel, I found the
+noise of machinery grow louder. Presently the walls fell away from
+me, and I came to a large open space, and striking another match,
+saw that I had entered a vast arched cavern, which stretched into
+utter darkness beyond the range of my light. The view I had of it
+was as much as one could see in the burning of a match.
+
+'Necessarily my memory is vague. Great shapes like big machines rose
+out of the dimness, and cast grotesque black shadows, in which dim
+spectral Morlocks sheltered from the glare. The place, by the by,
+was very stuffy and oppressive, and the faint halitus of freshly
+shed blood was in the air. Some way down the central vista was a
+little table of white metal, laid with what seemed a meal. The
+Morlocks at any rate were carnivorous! Even at the time, I remember
+wondering what large animal could have survived to furnish the red
+joint I saw. It was all very indistinct: the heavy smell, the big
+unmeaning shapes, the obscene figures lurking in the shadows, and
+only waiting for the darkness to come at me again! Then the match
+burned down, and stung my fingers, and fell, a wriggling red spot
+in the blackness.
+
+'I have thought since how particularly ill-equipped I was for such
+an experience. When I had started with the Time Machine, I had
+started with the absurd assumption that the men of the Future would
+certainly be infinitely ahead of ourselves in all their appliances.
+I had come without arms, without medicine, without anything to
+smoke--at times I missed tobacco frightfully--even without enough
+matches. If only I had thought of a Kodak! I could have flashed that
+glimpse of the Underworld in a second, and examined it at leisure.
+But, as it was, I stood there with only the weapons and the powers
+that Nature had endowed me with--hands, feet, and teeth; these, and
+four safety-matches that still remained to me.
+
+'I was afraid to push my way in among all this machinery in the
+dark, and it was only with my last glimpse of light I discovered
+that my store of matches had run low. It had never occurred to me
+until that moment that there was any need to economize them, and I
+had wasted almost half the box in astonishing the Upper-worlders, to
+whom fire was a novelty. Now, as I say, I had four left, and while I
+stood in the dark, a hand touched mine, lank fingers came feeling
+over my face, and I was sensible of a peculiar unpleasant odour. I
+fancied I heard the breathing of a crowd of those dreadful little
+beings about me. I felt the box of matches in my hand being gently
+disengaged, and other hands behind me plucking at my clothing. The
+sense of these unseen creatures examining me was indescribably
+unpleasant. The sudden realization of my ignorance of their ways of
+thinking and doing came home to me very vividly in the darkness. I
+shouted at them as loudly as I could. They started away, and then
+I could feel them approaching me again. They clutched at me more
+boldly, whispering odd sounds to each other. I shivered violently,
+and shouted again--rather discordantly. This time they were not so
+seriously alarmed, and they made a queer laughing noise as they came
+back at me. I will confess I was horribly frightened. I determined
+to strike another match and escape under the protection of its
+glare. I did so, and eking out the flicker with a scrap of paper
+from my pocket, I made good my retreat to the narrow tunnel. But I
+had scarce entered this when my light was blown out and in the
+blackness I could hear the Morlocks rustling like wind among leaves,
+and pattering like the rain, as they hurried after me.
+
+'In a moment I was clutched by several hands, and there was no
+mistaking that they were trying to haul me back. I struck another
+light, and waved it in their dazzled faces. You can scarce imagine
+how nauseatingly inhuman they looked--those pale, chinless faces
+and great, lidless, pinkish-grey eyes!--as they stared in their
+blindness and bewilderment. But I did not stay to look, I promise
+you: I retreated again, and when my second match had ended, I struck
+my third. It had almost burned through when I reached the opening
+into the shaft. I lay down on the edge, for the throb of the great
+pump below made me giddy. Then I felt sideways for the projecting
+hooks, and, as I did so, my feet were grasped from behind, and I
+was violently tugged backward. I lit my last match ... and it
+incontinently went out. But I had my hand on the climbing bars now,
+and, kicking violently, I disengaged myself from the clutches of the
+Morlocks and was speedily clambering up the shaft, while they stayed
+peering and blinking up at me: all but one little wretch who
+followed me for some way, and well-nigh secured my boot as a trophy.
+
+'That climb seemed interminable to me. With the last twenty or
+thirty feet of it a deadly nausea came upon me. I had the greatest
+difficulty in keeping my hold. The last few yards was a frightful
+struggle against this faintness. Several times my head swam, and I
+felt all the sensations of falling. At last, however, I got over the
+well-mouth somehow, and staggered out of the ruin into the blinding
+sunlight. I fell upon my face. Even the soil smelt sweet and clean.
+Then I remember Weena kissing my hands and ears, and the voices of
+others among the Eloi. Then, for a time, I was insensible.
+
+
+
+
+VII
+
+
+'Now, indeed, I seemed in a worse case than before. Hitherto,
+except during my night's anguish at the loss of the Time Machine,
+I had felt a sustaining hope of ultimate escape, but that hope was
+staggered by these new discoveries. Hitherto I had merely thought
+myself impeded by the childish simplicity of the little people, and
+by some unknown forces which I had only to understand to overcome;
+but there was an altogether new element in the sickening quality of
+the Morlocks--a something inhuman and malign. Instinctively I
+loathed them. Before, I had felt as a man might feel who had fallen
+into a pit: my concern was with the pit and how to get out of it.
+Now I felt like a beast in a trap, whose enemy would come upon him
+soon.
+
+'The enemy I dreaded may surprise you. It was the darkness of the
+new moon. Weena had put this into my head by some at first
+incomprehensible remarks about the Dark Nights. It was not now
+such a very difficult problem to guess what the coming Dark Nights
+might mean. The moon was on the wane: each night there was a longer
+interval of darkness. And I now understood to some slight degree at
+least the reason of the fear of the little Upper-world people for
+the dark. I wondered vaguely what foul villainy it might be that
+the Morlocks did under the new moon. I felt pretty sure now that
+my second hypothesis was all wrong. The Upper-world people might
+once have been the favoured aristocracy, and the Morlocks their
+mechanical servants: but that had long since passed away. The two
+species that had resulted from the evolution of man were sliding
+down towards, or had already arrived at, an altogether new
+relationship. The Eloi, like the Carolingian kings, had decayed
+to a mere beautiful futility. They still possessed the earth on
+sufferance: since the Morlocks, subterranean for innumerable
+generations, had come at last to find the daylit surface
+intolerable. And the Morlocks made their garments, I inferred, and
+maintained them in their habitual needs, perhaps through the
+survival of an old habit of service. They did it as a standing horse
+paws with his foot, or as a man enjoys killing animals in sport:
+because ancient and departed necessities had impressed it on the
+organism. But, clearly, the old order was already in part reversed.
+The Nemesis of the delicate ones was creeping on apace. Ages ago,
+thousands of generations ago, man had thrust his brother man out of
+the ease and the sunshine. And now that brother was coming back
+changed! Already the Eloi had begun to learn one old lesson anew.
+They were becoming reacquainted with Fear. And suddenly there came
+into my head the memory of the meat I had seen in the Under-world.
+It seemed odd how it floated into my mind: not stirred up as it
+were by the current of my meditations, but coming in almost like a
+question from outside. I tried to recall the form of it. I had a
+vague sense of something familiar, but I could not tell what it was
+at the time.
+
+'Still, however helpless the little people in the presence of their
+mysterious Fear, I was differently constituted. I came out of this
+age of ours, this ripe prime of the human race, when Fear does not
+paralyse and mystery has lost its terrors. I at least would defend
+myself. Without further delay I determined to make myself arms and a
+fastness where I might sleep. With that refuge as a base, I could
+face this strange world with some of that confidence I had lost in
+realizing to what creatures night by night I lay exposed. I felt
+I could never sleep again until my bed was secure from them. I
+shuddered with horror to think how they must already have examined
+me.
+
+'I wandered during the afternoon along the valley of the Thames, but
+found nothing that commended itself to my mind as inaccessible. All
+the buildings and trees seemed easily practicable to such dexterous
+climbers as the Morlocks, to judge by their wells, must be. Then the
+tall pinnacles of the Palace of Green Porcelain and the polished
+gleam of its walls came back to my memory; and in the evening,
+taking Weena like a child upon my shoulder, I went up the hills
+towards the south-west. The distance, I had reckoned, was seven or
+eight miles, but it must have been nearer eighteen. I had first seen
+the place on a moist afternoon when distances are deceptively
+diminished. In addition, the heel of one of my shoes was loose, and
+a nail was working through the sole--they were comfortable old shoes
+I wore about indoors--so that I was lame. And it was already long
+past sunset when I came in sight of the palace, silhouetted black
+against the pale yellow of the sky.
+
+'Weena had been hugely delighted when I began to carry her, but
+after a while she desired me to let her down, and ran along by the
+side of me, occasionally darting off on either hand to pick flowers
+to stick in my pockets. My pockets had always puzzled Weena, but at
+the last she had concluded that they were an eccentric kind of vase
+for floral decoration. At least she utilized them for that purpose.
+And that reminds me! In changing my jacket I found...'
+
+The Time Traveller paused, put his hand into his pocket, and
+silently placed two withered flowers, not unlike very large white
+mallows, upon the little table. Then he resumed his narrative.
+
+'As the hush of evening crept over the world and we proceeded over
+the hill crest towards Wimbledon, Weena grew tired and wanted to
+return to the house of grey stone. But I pointed out the distant
+pinnacles of the Palace of Green Porcelain to her, and contrived to
+make her understand that we were seeking a refuge there from her
+Fear. You know that great pause that comes upon things before the
+dusk? Even the breeze stops in the trees. To me there is always an
+air of expectation about that evening stillness. The sky was clear,
+remote, and empty save for a few horizontal bars far down in the
+sunset. Well, that night the expectation took the colour of my
+fears. In that darkling calm my senses seemed preternaturally
+sharpened. I fancied I could even feel the hollowness of the ground
+beneath my feet: could, indeed, almost see through it the Morlocks
+on their ant-hill going hither and thither and waiting for the dark.
+In my excitement I fancied that they would receive my invasion of
+their burrows as a declaration of war. And why had they taken my
+Time Machine?
+
+'So we went on in the quiet, and the twilight deepened into night.
+The clear blue of the distance faded, and one star after another
+came out. The ground grew dim and the trees black. Weena's fears and
+her fatigue grew upon her. I took her in my arms and talked to her
+and caressed her. Then, as the darkness grew deeper, she put her
+arms round my neck, and, closing her eyes, tightly pressed her face
+against my shoulder. So we went down a long slope into a valley, and
+there in the dimness I almost walked into a little river. This I
+waded, and went up the opposite side of the valley, past a number
+of sleeping houses, and by a statue--a Faun, or some such figure,
+_minus_ the head. Here too were acacias. So far I had seen nothing of
+the Morlocks, but it was yet early in the night, and the darker hours
+before the old moon rose were still to come.
+
+'From the brow of the next hill I saw a thick wood spreading wide
+and black before me. I hesitated at this. I could see no end to
+it, either to the right or the left. Feeling tired--my feet, in
+particular, were very sore--I carefully lowered Weena from my
+shoulder as I halted, and sat down upon the turf. I could no
+longer see the Palace of Green Porcelain, and I was in doubt of my
+direction. I looked into the thickness of the wood and thought of
+what it might hide. Under that dense tangle of branches one would
+be out of sight of the stars. Even were there no other lurking
+danger--a danger I did not care to let my imagination loose
+upon--there would still be all the roots to stumble over and the
+tree-boles to strike against.
+
+'I was very tired, too, after the excitements of the day; so I
+decided that I would not face it, but would pass the night upon the
+open hill.
+
+'Weena, I was glad to find, was fast asleep. I carefully wrapped her
+in my jacket, and sat down beside her to wait for the moonrise. The
+hill-side was quiet and deserted, but from the black of the wood
+there came now and then a stir of living things. Above me shone the
+stars, for the night was very clear. I felt a certain sense of
+friendly comfort in their twinkling. All the old constellations
+had gone from the sky, however: that slow movement which is
+imperceptible in a hundred human lifetimes, had long since
+rearranged them in unfamiliar groupings. But the Milky Way, it
+seemed to me, was still the same tattered streamer of star-dust as
+of yore. Southward (as I judged it) was a very bright red star that
+was new to me; it was even more splendid than our own green Sirius.
+And amid all these scintillating points of light one bright planet
+shone kindly and steadily like the face of an old friend.
+
+'Looking at these stars suddenly dwarfed my own troubles and all
+the gravities of terrestrial life. I thought of their unfathomable
+distance, and the slow inevitable drift of their movements out of
+the unknown past into the unknown future. I thought of the great
+precessional cycle that the pole of the earth describes. Only forty
+times had that silent revolution occurred during all the years that
+I had traversed. And during these few revolutions all the activity,
+all the traditions, the complex organizations, the nations,
+languages, literatures, aspirations, even the mere memory of Man as
+I knew him, had been swept out of existence. Instead were these
+frail creatures who had forgotten their high ancestry, and the white
+Things of which I went in terror. Then I thought of the Great Fear
+that was between the two species, and for the first time, with a
+sudden shiver, came the clear knowledge of what the meat I had seen
+might be. Yet it was too horrible! I looked at little Weena sleeping
+beside me, her face white and starlike under the stars, and
+forthwith dismissed the thought.
+
+'Through that long night I held my mind off the Morlocks as well as
+I could, and whiled away the time by trying to fancy I could find
+signs of the old constellations in the new confusion. The sky kept
+very clear, except for a hazy cloud or so. No doubt I dozed at
+times. Then, as my vigil wore on, came a faintness in the eastward
+sky, like the reflection of some colourless fire, and the old moon
+rose, thin and peaked and white. And close behind, and overtaking
+it, and overflowing it, the dawn came, pale at first, and then
+growing pink and warm. No Morlocks had approached us. Indeed, I had
+seen none upon the hill that night. And in the confidence of renewed
+day it almost seemed to me that my fear had been unreasonable. I
+stood up and found my foot with the loose heel swollen at the ankle
+and painful under the heel; so I sat down again, took off my shoes,
+and flung them away.
+
+'I awakened Weena, and we went down into the wood, now green and
+pleasant instead of black and forbidding. We found some fruit
+wherewith to break our fast. We soon met others of the dainty ones,
+laughing and dancing in the sunlight as though there was no such
+thing in nature as the night. And then I thought once more of the
+meat that I had seen. I felt assured now of what it was, and from
+the bottom of my heart I pitied this last feeble rill from the great
+flood of humanity. Clearly, at some time in the Long-Ago of human
+decay the Morlocks' food had run short. Possibly they had lived on
+rats and such-like vermin. Even now man is far less discriminating
+and exclusive in his food than he was--far less than any monkey. His
+prejudice against human flesh is no deep-seated instinct. And so
+these inhuman sons of men----! I tried to look at the thing in a
+scientific spirit. After all, they were less human and more remote
+than our cannibal ancestors of three or four thousand years ago.
+And the intelligence that would have made this state of things a
+torment had gone. Why should I trouble myself? These Eloi were mere
+fatted cattle, which the ant-like Morlocks preserved and preyed
+upon--probably saw to the breeding of. And there was Weena dancing
+at my side!
+
+'Then I tried to preserve myself from the horror that was coming
+upon me, by regarding it as a rigorous punishment of human
+selfishness. Man had been content to live in ease and delight upon
+the labours of his fellow-man, had taken Necessity as his watchword
+and excuse, and in the fullness of time Necessity had come home to
+him. I even tried a Carlyle-like scorn of this wretched aristocracy
+in decay. But this attitude of mind was impossible. However great
+their intellectual degradation, the Eloi had kept too much of the
+human form not to claim my sympathy, and to make me perforce a
+sharer in their degradation and their Fear.
+
+'I had at that time very vague ideas as to the course I should
+pursue. My first was to secure some safe place of refuge, and to
+make myself such arms of metal or stone as I could contrive. That
+necessity was immediate. In the next place, I hoped to procure some
+means of fire, so that I should have the weapon of a torch at hand,
+for nothing, I knew, would be more efficient against these Morlocks.
+Then I wanted to arrange some contrivance to break open the doors of
+bronze under the White Sphinx. I had in mind a battering ram. I had
+a persuasion that if I could enter those doors and carry a blaze of
+light before me I should discover the Time Machine and escape. I
+could not imagine the Morlocks were strong enough to move it far
+away. Weena I had resolved to bring with me to our own time. And
+turning such schemes over in my mind I pursued our way towards the
+building which my fancy had chosen as our dwelling.
+
+
+
+
+VIII
+
+
+'I found the Palace of Green Porcelain, when we approached it about
+noon, deserted and falling into ruin. Only ragged vestiges of glass
+remained in its windows, and great sheets of the green facing had
+fallen away from the corroded metallic framework. It lay very high
+upon a turfy down, and looking north-eastward before I entered it, I
+was surprised to see a large estuary, or even creek, where I judged
+Wandsworth and Battersea must once have been. I thought then--though
+I never followed up the thought--of what might have happened, or
+might be happening, to the living things in the sea.
+
+'The material of the Palace proved on examination to be indeed
+porcelain, and along the face of it I saw an inscription in some
+unknown character. I thought, rather foolishly, that Weena might
+help me to interpret this, but I only learned that the bare idea of
+writing had never entered her head. She always seemed to me, I
+fancy, more human than she was, perhaps because her affection was so
+human.
+
+'Within the big valves of the door--which were open and broken--we
+found, instead of the customary hall, a long gallery lit by many
+side windows. At the first glance I was reminded of a museum.
+The tiled floor was thick with dust, and a remarkable array of
+miscellaneous objects was shrouded in the same grey covering. Then
+I perceived, standing strange and gaunt in the centre of the hall,
+what was clearly the lower part of a huge skeleton. I recognized
+by the oblique feet that it was some extinct creature after the
+fashion of the Megatherium. The skull and the upper bones lay
+beside it in the thick dust, and in one place, where rain-water had
+dropped through a leak in the roof, the thing itself had been worn
+away. Further in the gallery was the huge skeleton barrel of a
+Brontosaurus. My museum hypothesis was confirmed. Going towards the
+side I found what appeared to be sloping shelves, and clearing away
+the thick dust, I found the old familiar glass cases of our own
+time. But they must have been air-tight to judge from the fair
+preservation of some of their contents.
+
+'Clearly we stood among the ruins of some latter-day South
+Kensington! Here, apparently, was the Palaeontological Section,
+and a very splendid array of fossils it must have been, though the
+inevitable process of decay that had been staved off for a time, and
+had, through the extinction of bacteria and fungi, lost ninety-nine
+hundredths of its force, was nevertheless, with extreme sureness if
+with extreme slowness at work again upon all its treasures. Here and
+there I found traces of the little people in the shape of rare
+fossils broken to pieces or threaded in strings upon reeds. And the
+cases had in some instances been bodily removed--by the Morlocks as
+I judged. The place was very silent. The thick dust deadened our
+footsteps. Weena, who had been rolling a sea urchin down the sloping
+glass of a case, presently came, as I stared about me, and very
+quietly took my hand and stood beside me.
+
+'And at first I was so much surprised by this ancient monument of an
+intellectual age, that I gave no thought to the possibilities it
+presented. Even my preoccupation about the Time Machine receded a
+little from my mind.
+
+'To judge from the size of the place, this Palace of Green Porcelain
+had a great deal more in it than a Gallery of Palaeontology;
+possibly historical galleries; it might be, even a library! To me,
+at least in my present circumstances, these would be vastly more
+interesting than this spectacle of oldtime geology in decay.
+Exploring, I found another short gallery running transversely to the
+first. This appeared to be devoted to minerals, and the sight of a
+block of sulphur set my mind running on gunpowder. But I could find
+no saltpeter; indeed, no nitrates of any kind. Doubtless they had
+deliquesced ages ago. Yet the sulphur hung in my mind, and set up a
+train of thinking. As for the rest of the contents of that gallery,
+though on the whole they were the best preserved of all I saw, I had
+little interest. I am no specialist in mineralogy, and I went on
+down a very ruinous aisle running parallel to the first hall I had
+entered. Apparently this section had been devoted to natural
+history, but everything had long since passed out of recognition. A
+few shrivelled and blackened vestiges of what had once been stuffed
+animals, desiccated mummies in jars that had once held spirit, a
+brown dust of departed plants: that was all! I was sorry for that,
+because I should have been glad to trace the patent readjustments by
+which the conquest of animated nature had been attained. Then we
+came to a gallery of simply colossal proportions, but singularly
+ill-lit, the floor of it running downward at a slight angle from the
+end at which I entered. At intervals white globes hung from the
+ceiling--many of them cracked and smashed--which suggested that
+originally the place had been artificially lit. Here I was more in
+my element, for rising on either side of me were the huge bulks of
+big machines, all greatly corroded and many broken down, but some
+still fairly complete. You know I have a certain weakness for
+mechanism, and I was inclined to linger among these; the more so as
+for the most part they had the interest of puzzles, and I could make
+only the vaguest guesses at what they were for. I fancied that if
+I could solve their puzzles I should find myself in possession of
+powers that might be of use against the Morlocks.
+
+'Suddenly Weena came very close to my side. So suddenly that she
+startled me. Had it not been for her I do not think I should have
+noticed that the floor of the gallery sloped at all. [Footnote: It
+may be, of course, that the floor did not slope, but that the museum
+was built into the side of a hill.--ED.] The end I had come in at
+was quite above ground, and was lit by rare slit-like windows. As
+you went down the length, the ground came up against these windows,
+until at last there was a pit like the "area" of a London house
+before each, and only a narrow line of daylight at the top. I went
+slowly along, puzzling about the machines, and had been too intent
+upon them to notice the gradual diminution of the light, until
+Weena's increasing apprehensions drew my attention. Then I saw that
+the gallery ran down at last into a thick darkness. I hesitated, and
+then, as I looked round me, I saw that the dust was less abundant
+and its surface less even. Further away towards the dimness, it
+appeared to be broken by a number of small narrow footprints. My
+sense of the immediate presence of the Morlocks revived at that.
+I felt that I was wasting my time in the academic examination of
+machinery. I called to mind that it was already far advanced in the
+afternoon, and that I had still no weapon, no refuge, and no means
+of making a fire. And then down in the remote blackness of the
+gallery I heard a peculiar pattering, and the same odd noises I had
+heard down the well.
+
+'I took Weena's hand. Then, struck with a sudden idea, I left her
+and turned to a machine from which projected a lever not unlike
+those in a signal-box. Clambering upon the stand, and grasping this
+lever in my hands, I put all my weight upon it sideways. Suddenly
+Weena, deserted in the central aisle, began to whimper. I had judged
+the strength of the lever pretty correctly, for it snapped after a
+minute's strain, and I rejoined her with a mace in my hand more than
+sufficient, I judged, for any Morlock skull I might encounter. And I
+longed very much to kill a Morlock or so. Very inhuman, you may
+think, to want to go killing one's own descendants! But it was
+impossible, somehow, to feel any humanity in the things. Only my
+disinclination to leave Weena, and a persuasion that if I began to
+slake my thirst for murder my Time Machine might suffer, restrained
+me from going straight down the gallery and killing the brutes I
+heard.
+
+'Well, mace in one hand and Weena in the other, I went out of that
+gallery and into another and still larger one, which at the first
+glance reminded me of a military chapel hung with tattered flags.
+The brown and charred rags that hung from the sides of it, I
+presently recognized as the decaying vestiges of books. They had
+long since dropped to pieces, and every semblance of print had left
+them. But here and there were warped boards and cracked metallic
+clasps that told the tale well enough. Had I been a literary man I
+might, perhaps, have moralized upon the futility of all ambition.
+But as it was, the thing that struck me with keenest force was the
+enormous waste of labour to which this sombre wilderness of rotting
+paper testified. At the time I will confess that I thought chiefly
+of the _Philosophical Transactions_ and my own seventeen papers upon
+physical optics.
+
+'Then, going up a broad staircase, we came to what may once have
+been a gallery of technical chemistry. And here I had not a little
+hope of useful discoveries. Except at one end where the roof had
+collapsed, this gallery was well preserved. I went eagerly to every
+unbroken case. And at last, in one of the really air-tight cases,
+I found a box of matches. Very eagerly I tried them. They were
+perfectly good. They were not even damp. I turned to Weena. "Dance,"
+I cried to her in her own tongue. For now I had a weapon indeed
+against the horrible creatures we feared. And so, in that derelict
+museum, upon the thick soft carpeting of dust, to Weena's huge
+delight, I solemnly performed a kind of composite dance, whistling
+_The Land of the Leal_ as cheerfully as I could. In part it was a
+modest _cancan_, in part a step dance, in part a skirt-dance (so far
+as my tail-coat permitted), and in part original. For I am naturally
+inventive, as you know.
+
+'Now, I still think that for this box of matches to have escaped
+the wear of time for immemorial years was a most strange, as for
+me it was a most fortunate thing. Yet, oddly enough, I found a far
+unlikelier substance, and that was camphor. I found it in a sealed
+jar, that by chance, I suppose, had been really hermetically sealed.
+I fancied at first that it was paraffin wax, and smashed the glass
+accordingly. But the odour of camphor was unmistakable. In the
+universal decay this volatile substance had chanced to survive,
+perhaps through many thousands of centuries. It reminded me of a
+sepia painting I had once seen done from the ink of a fossil
+Belemnite that must have perished and become fossilized millions
+of years ago. I was about to throw it away, but I remembered that
+it was inflammable and burned with a good bright flame--was, in
+fact, an excellent candle--and I put it in my pocket. I found no
+explosives, however, nor any means of breaking down the bronze
+doors. As yet my iron crowbar was the most helpful thing I had
+chanced upon. Nevertheless I left that gallery greatly elated.
+
+'I cannot tell you all the story of that long afternoon. It would
+require a great effort of memory to recall my explorations in at all
+the proper order. I remember a long gallery of rusting stands of
+arms, and how I hesitated between my crowbar and a hatchet or a
+sword. I could not carry both, however, and my bar of iron promised
+best against the bronze gates. There were numbers of guns, pistols,
+and rifles. The most were masses of rust, but many were of some
+new metal, and still fairly sound. But any cartridges or powder
+there may once have been had rotted into dust. One corner I saw was
+charred and shattered; perhaps, I thought, by an explosion among the
+specimens. In another place was a vast array of idols--Polynesian,
+Mexican, Grecian, Phoenician, every country on earth I should think.
+And here, yielding to an irresistible impulse, I wrote my name upon
+the nose of a steatite monster from South America that particularly
+took my fancy.
+
+'As the evening drew on, my interest waned. I went through gallery
+after gallery, dusty, silent, often ruinous, the exhibits sometimes
+mere heaps of rust and lignite, sometimes fresher. In one place I
+suddenly found myself near the model of a tin-mine, and then by the
+merest accident I discovered, in an air-tight case, two dynamite
+cartridges! I shouted "Eureka!" and smashed the case with joy. Then
+came a doubt. I hesitated. Then, selecting a little side gallery,
+I made my essay. I never felt such a disappointment as I did in
+waiting five, ten, fifteen minutes for an explosion that never came.
+Of course the things were dummies, as I might have guessed from
+their presence. I really believe that had they not been so, I should
+have rushed off incontinently and blown Sphinx, bronze doors, and
+(as it proved) my chances of finding the Time Machine, all together
+into non-existence.
+
+'It was after that, I think, that we came to a little open court
+within the palace. It was turfed, and had three fruit-trees. So we
+rested and refreshed ourselves. Towards sunset I began to consider
+our position. Night was creeping upon us, and my inaccessible
+hiding-place had still to be found. But that troubled me very little
+now. I had in my possession a thing that was, perhaps, the best of
+all defences against the Morlocks--I had matches! I had the camphor
+in my pocket, too, if a blaze were needed. It seemed to me that
+the best thing we could do would be to pass the night in the open,
+protected by a fire. In the morning there was the getting of the
+Time Machine. Towards that, as yet, I had only my iron mace. But
+now, with my growing knowledge, I felt very differently towards
+those bronze doors. Up to this, I had refrained from forcing them,
+largely because of the mystery on the other side. They had never
+impressed me as being very strong, and I hoped to find my bar of
+iron not altogether inadequate for the work.
+
+
+
+
+IX
+
+
+'We emerged from the palace while the sun was still in part above
+the horizon. I was determined to reach the White Sphinx early the
+next morning, and ere the dusk I purposed pushing through the woods
+that had stopped me on the previous journey. My plan was to go as
+far as possible that night, and then, building a fire, to sleep
+in the protection of its glare. Accordingly, as we went along I
+gathered any sticks or dried grass I saw, and presently had my arms
+full of such litter. Thus loaded, our progress was slower than I had
+anticipated, and besides Weena was tired. And I began to suffer from
+sleepiness too; so that it was full night before we reached the
+wood. Upon the shrubby hill of its edge Weena would have stopped,
+fearing the darkness before us; but a singular sense of impending
+calamity, that should indeed have served me as a warning, drove me
+onward. I had been without sleep for a night and two days, and I was
+feverish and irritable. I felt sleep coming upon me, and the
+Morlocks with it.
+
+'While we hesitated, among the black bushes behind us, and dim
+against their blackness, I saw three crouching figures. There was
+scrub and long grass all about us, and I did not feel safe from
+their insidious approach. The forest, I calculated, was rather
+less than a mile across. If we could get through it to the bare
+hill-side, there, as it seemed to me, was an altogether safer
+resting-place; I thought that with my matches and my camphor I could
+contrive to keep my path illuminated through the woods. Yet it was
+evident that if I was to flourish matches with my hands I should
+have to abandon my firewood; so, rather reluctantly, I put it down.
+And then it came into my head that I would amaze our friends behind
+by lighting it. I was to discover the atrocious folly of this
+proceeding, but it came to my mind as an ingenious move for covering
+our retreat.
+
+'I don't know if you have ever thought what a rare thing flame must
+be in the absence of man and in a temperate climate. The sun's
+heat is rarely strong enough to burn, even when it is focused by
+dewdrops, as is sometimes the case in more tropical districts.
+Lightning may blast and blacken, but it rarely gives rise to
+widespread fire. Decaying vegetation may occasionally smoulder with
+the heat of its fermentation, but this rarely results in flame. In
+this decadence, too, the art of fire-making had been forgotten on
+the earth. The red tongues that went licking up my heap of wood were
+an altogether new and strange thing to Weena.
+
+'She wanted to run to it and play with it. I believe she would have
+cast herself into it had I not restrained her. But I caught her up,
+and in spite of her struggles, plunged boldly before me into the
+wood. For a little way the glare of my fire lit the path. Looking
+back presently, I could see, through the crowded stems, that from my
+heap of sticks the blaze had spread to some bushes adjacent, and a
+curved line of fire was creeping up the grass of the hill. I laughed
+at that, and turned again to the dark trees before me. It was very
+black, and Weena clung to me convulsively, but there was still, as
+my eyes grew accustomed to the darkness, sufficient light for me to
+avoid the stems. Overhead it was simply black, except where a gap of
+remote blue sky shone down upon us here and there. I struck none of
+my matches because I had no hand free. Upon my left arm I carried my
+little one, in my right hand I had my iron bar.
+
+'For some way I heard nothing but the crackling twigs under my feet,
+the faint rustle of the breeze above, and my own breathing and the
+throb of the blood-vessels in my ears. Then I seemed to know of a
+pattering about me. I pushed on grimly. The pattering grew more
+distinct, and then I caught the same queer sound and voices I had
+heard in the Under-world. There were evidently several of the
+Morlocks, and they were closing in upon me. Indeed, in another
+minute I felt a tug at my coat, then something at my arm. And Weena
+shivered violently, and became quite still.
+
+'It was time for a match. But to get one I must put her down. I did
+so, and, as I fumbled with my pocket, a struggle began in the
+darkness about my knees, perfectly silent on her part and with the
+same peculiar cooing sounds from the Morlocks. Soft little hands,
+too, were creeping over my coat and back, touching even my neck.
+Then the match scratched and fizzed. I held it flaring, and saw the
+white backs of the Morlocks in flight amid the trees. I hastily took
+a lump of camphor from my pocket, and prepared to light it as soon
+as the match should wane. Then I looked at Weena. She was lying
+clutching my feet and quite motionless, with her face to the ground.
+With a sudden fright I stooped to her. She seemed scarcely to
+breathe. I lit the block of camphor and flung it to the ground,
+and as it split and flared up and drove back the Morlocks and the
+shadows, I knelt down and lifted her. The wood behind seemed full of
+the stir and murmur of a great company!
+
+'She seemed to have fainted. I put her carefully upon my shoulder
+and rose to push on, and then there came a horrible realization. In
+manoeuvring with my matches and Weena, I had turned myself about
+several times, and now I had not the faintest idea in what direction
+lay my path. For all I knew, I might be facing back towards the
+Palace of Green Porcelain. I found myself in a cold sweat. I had to
+think rapidly what to do. I determined to build a fire and encamp
+where we were. I put Weena, still motionless, down upon a turfy
+bole, and very hastily, as my first lump of camphor waned, I began
+collecting sticks and leaves. Here and there out of the darkness
+round me the Morlocks' eyes shone like carbuncles.
+
+'The camphor flickered and went out. I lit a match, and as I did so,
+two white forms that had been approaching Weena dashed hastily away.
+One was so blinded by the light that he came straight for me, and I
+felt his bones grind under the blow of my fist. He gave a whoop of
+dismay, staggered a little way, and fell down. I lit another piece
+of camphor, and went on gathering my bonfire. Presently I noticed
+how dry was some of the foliage above me, for since my arrival
+on the Time Machine, a matter of a week, no rain had fallen. So,
+instead of casting about among the trees for fallen twigs, I began
+leaping up and dragging down branches. Very soon I had a choking
+smoky fire of green wood and dry sticks, and could economize my
+camphor. Then I turned to where Weena lay beside my iron mace. I
+tried what I could to revive her, but she lay like one dead. I could
+not even satisfy myself whether or not she breathed.
+
+'Now, the smoke of the fire beat over towards me, and it must have
+made me heavy of a sudden. Moreover, the vapour of camphor was in
+the air. My fire would not need replenishing for an hour or so. I
+felt very weary after my exertion, and sat down. The wood, too, was
+full of a slumbrous murmur that I did not understand. I seemed just
+to nod and open my eyes. But all was dark, and the Morlocks had
+their hands upon me. Flinging off their clinging fingers I hastily
+felt in my pocket for the match-box, and--it had gone! Then they
+gripped and closed with me again. In a moment I knew what had
+happened. I had slept, and my fire had gone out, and the bitterness
+of death came over my soul. The forest seemed full of the smell of
+burning wood. I was caught by the neck, by the hair, by the arms,
+and pulled down. It was indescribably horrible in the darkness to
+feel all these soft creatures heaped upon me. I felt as if I was in
+a monstrous spider's web. I was overpowered, and went down. I felt
+little teeth nipping at my neck. I rolled over, and as I did so my
+hand came against my iron lever. It gave me strength. I struggled
+up, shaking the human rats from me, and, holding the bar short,
+I thrust where I judged their faces might be. I could feel the
+succulent giving of flesh and bone under my blows, and for a moment
+I was free.
+
+'The strange exultation that so often seems to accompany hard
+fighting came upon me. I knew that both I and Weena were lost, but I
+determined to make the Morlocks pay for their meat. I stood with my
+back to a tree, swinging the iron bar before me. The whole wood was
+full of the stir and cries of them. A minute passed. Their voices
+seemed to rise to a higher pitch of excitement, and their movements
+grew faster. Yet none came within reach. I stood glaring at the
+blackness. Then suddenly came hope. What if the Morlocks were
+afraid? And close on the heels of that came a strange thing. The
+darkness seemed to grow luminous. Very dimly I began to see the
+Morlocks about me--three battered at my feet--and then I recognized,
+with incredulous surprise, that the others were running, in an
+incessant stream, as it seemed, from behind me, and away through the
+wood in front. And their backs seemed no longer white, but reddish.
+As I stood agape, I saw a little red spark go drifting across a gap
+of starlight between the branches, and vanish. And at that I
+understood the smell of burning wood, the slumbrous murmur that was
+growing now into a gusty roar, the red glow, and the Morlocks'
+flight.
+
+'Stepping out from behind my tree and looking back, I saw, through
+the black pillars of the nearer trees, the flames of the burning
+forest. It was my first fire coming after me. With that I looked for
+Weena, but she was gone. The hissing and crackling behind me, the
+explosive thud as each fresh tree burst into flame, left little
+time for reflection. My iron bar still gripped, I followed in the
+Morlocks' path. It was a close race. Once the flames crept forward
+so swiftly on my right as I ran that I was outflanked and had to
+strike off to the left. But at last I emerged upon a small open
+space, and as I did so, a Morlock came blundering towards me, and
+past me, and went on straight into the fire!
+
+'And now I was to see the most weird and horrible thing, I think, of
+all that I beheld in that future age. This whole space was as bright
+as day with the reflection of the fire. In the centre was a hillock
+or tumulus, surmounted by a scorched hawthorn. Beyond this was
+another arm of the burning forest, with yellow tongues already
+writhing from it, completely encircling the space with a fence of
+fire. Upon the hill-side were some thirty or forty Morlocks, dazzled
+by the light and heat, and blundering hither and thither against
+each other in their bewilderment. At first I did not realize their
+blindness, and struck furiously at them with my bar, in a frenzy of
+fear, as they approached me, killing one and crippling several more.
+But when I had watched the gestures of one of them groping under the
+hawthorn against the red sky, and heard their moans, I was assured
+of their absolute helplessness and misery in the glare, and I struck
+no more of them.
+
+'Yet every now and then one would come straight towards me, setting
+loose a quivering horror that made me quick to elude him. At one
+time the flames died down somewhat, and I feared the foul creatures
+would presently be able to see me. I was thinking of beginning the
+fight by killing some of them before this should happen; but the
+fire burst out again brightly, and I stayed my hand. I walked about
+the hill among them and avoided them, looking for some trace of
+Weena. But Weena was gone.
+
+'At last I sat down on the summit of the hillock, and watched this
+strange incredible company of blind things groping to and fro, and
+making uncanny noises to each other, as the glare of the fire beat
+on them. The coiling uprush of smoke streamed across the sky, and
+through the rare tatters of that red canopy, remote as though they
+belonged to another universe, shone the little stars. Two or three
+Morlocks came blundering into me, and I drove them off with blows
+of my fists, trembling as I did so.
+
+'For the most part of that night I was persuaded it was a nightmare.
+I bit myself and screamed in a passionate desire to awake. I beat
+the ground with my hands, and got up and sat down again, and
+wandered here and there, and again sat down. Then I would fall to
+rubbing my eyes and calling upon God to let me awake. Thrice I saw
+Morlocks put their heads down in a kind of agony and rush into the
+flames. But, at last, above the subsiding red of the fire, above the
+streaming masses of black smoke and the whitening and blackening
+tree stumps, and the diminishing numbers of these dim creatures,
+came the white light of the day.
+
+'I searched again for traces of Weena, but there were none. It was
+plain that they had left her poor little body in the forest. I
+cannot describe how it relieved me to think that it had escaped the
+awful fate to which it seemed destined. As I thought of that, I was
+almost moved to begin a massacre of the helpless abominations about
+me, but I contained myself. The hillock, as I have said, was a kind
+of island in the forest. From its summit I could now make out
+through a haze of smoke the Palace of Green Porcelain, and from that
+I could get my bearings for the White Sphinx. And so, leaving the
+remnant of these damned souls still going hither and thither and
+moaning, as the day grew clearer, I tied some grass about my feet
+and limped on across smoking ashes and among black stems, that still
+pulsated internally with fire, towards the hiding-place of the Time
+Machine. I walked slowly, for I was almost exhausted, as well as
+lame, and I felt the intensest wretchedness for the horrible death
+of little Weena. It seemed an overwhelming calamity. Now, in this
+old familiar room, it is more like the sorrow of a dream than an
+actual loss. But that morning it left me absolutely lonely
+again--terribly alone. I began to think of this house of mine, of
+this fireside, of some of you, and with such thoughts came a longing
+that was pain.
+
+'But as I walked over the smoking ashes under the bright morning
+sky, I made a discovery. In my trouser pocket were still some loose
+matches. The box must have leaked before it was lost.
+
+
+
+
+X
+
+
+'About eight or nine in the morning I came to the same seat of
+yellow metal from which I had viewed the world upon the evening of
+my arrival. I thought of my hasty conclusions upon that evening and
+could not refrain from laughing bitterly at my confidence. Here
+was the same beautiful scene, the same abundant foliage, the same
+splendid palaces and magnificent ruins, the same silver river
+running between its fertile banks. The gay robes of the beautiful
+people moved hither and thither among the trees. Some were bathing
+in exactly the place where I had saved Weena, and that suddenly gave
+me a keen stab of pain. And like blots upon the landscape rose the
+cupolas above the ways to the Under-world. I understood now what all
+the beauty of the Over-world people covered. Very pleasant was their
+day, as pleasant as the day of the cattle in the field. Like the
+cattle, they knew of no enemies and provided against no needs. And
+their end was the same.
+
+'I grieved to think how brief the dream of the human intellect had
+been. It had committed suicide. It had set itself steadfastly
+towards comfort and ease, a balanced society with security and
+permanency as its watchword, it had attained its hopes--to come
+to this at last. Once, life and property must have reached almost
+absolute safety. The rich had been assured of his wealth and
+comfort, the toiler assured of his life and work. No doubt in that
+perfect world there had been no unemployed problem, no social
+question left unsolved. And a great quiet had followed.
+
+'It is a law of nature we overlook, that intellectual versatility
+is the compensation for change, danger, and trouble. An animal
+perfectly in harmony with its environment is a perfect mechanism.
+Nature never appeals to intelligence until habit and instinct are
+useless. There is no intelligence where there is no change and no
+need of change. Only those animals partake of intelligence that have
+to meet a huge variety of needs and dangers.
+
+'So, as I see it, the Upper-world man had drifted towards his
+feeble prettiness, and the Under-world to mere mechanical industry.
+But that perfect state had lacked one thing even for mechanical
+perfection--absolute permanency. Apparently as time went on, the
+feeding of the Under-world, however it was effected, had become
+disjointed. Mother Necessity, who had been staved off for a
+few thousand years, came back again, and she began below. The
+Under-world being in contact with machinery, which, however perfect,
+still needs some little thought outside habit, had probably retained
+perforce rather more initiative, if less of every other human
+character, than the Upper. And when other meat failed them, they
+turned to what old habit had hitherto forbidden. So I say I saw it
+in my last view of the world of Eight Hundred and Two Thousand Seven
+Hundred and One. It may be as wrong an explanation as mortal wit
+could invent. It is how the thing shaped itself to me, and as that I
+give it to you.
+
+'After the fatigues, excitements, and terrors of the past days, and
+in spite of my grief, this seat and the tranquil view and the warm
+sunlight were very pleasant. I was very tired and sleepy, and soon
+my theorizing passed into dozing. Catching myself at that, I took my
+own hint, and spreading myself out upon the turf I had a long and
+refreshing sleep.
+
+'I awoke a little before sunsetting. I now felt safe against being
+caught napping by the Morlocks, and, stretching myself, I came on
+down the hill towards the White Sphinx. I had my crowbar in one
+hand, and the other hand played with the matches in my pocket.
+
+'And now came a most unexpected thing. As I approached the pedestal
+of the sphinx I found the bronze valves were open. They had slid
+down into grooves.
+
+'At that I stopped short before them, hesitating to enter.
+
+'Within was a small apartment, and on a raised place in the corner
+of this was the Time Machine. I had the small levers in my pocket.
+So here, after all my elaborate preparations for the siege of the
+White Sphinx, was a meek surrender. I threw my iron bar away, almost
+sorry not to use it.
+
+'A sudden thought came into my head as I stooped towards the portal.
+For once, at least, I grasped the mental operations of the Morlocks.
+Suppressing a strong inclination to laugh, I stepped through the
+bronze frame and up to the Time Machine. I was surprised to find it
+had been carefully oiled and cleaned. I have suspected since that
+the Morlocks had even partially taken it to pieces while trying in
+their dim way to grasp its purpose.
+
+'Now as I stood and examined it, finding a pleasure in the mere
+touch of the contrivance, the thing I had expected happened. The
+bronze panels suddenly slid up and struck the frame with a clang.
+I was in the dark--trapped. So the Morlocks thought. At that I
+chuckled gleefully.
+
+'I could already hear their murmuring laughter as they came towards
+me. Very calmly I tried to strike the match. I had only to fix on
+the levers and depart then like a ghost. But I had overlooked one
+little thing. The matches were of that abominable kind that light
+only on the box.
+
+'You may imagine how all my calm vanished. The little brutes were
+close upon me. One touched me. I made a sweeping blow in the dark at
+them with the levers, and began to scramble into the saddle of the
+machine. Then came one hand upon me and then another. Then I had
+simply to fight against their persistent fingers for my levers, and
+at the same time feel for the studs over which these fitted. One,
+indeed, they almost got away from me. As it slipped from my hand,
+I had to butt in the dark with my head--I could hear the Morlock's
+skull ring--to recover it. It was a nearer thing than the fight in
+the forest, I think, this last scramble.
+
+'But at last the lever was fitted and pulled over. The clinging
+hands slipped from me. The darkness presently fell from my eyes.
+I found myself in the same grey light and tumult I have already
+described.
+
+
+
+
+XI
+
+
+'I have already told you of the sickness and confusion that comes
+with time travelling. And this time I was not seated properly in the
+saddle, but sideways and in an unstable fashion. For an indefinite
+time I clung to the machine as it swayed and vibrated, quite
+unheeding how I went, and when I brought myself to look at the dials
+again I was amazed to find where I had arrived. One dial records
+days, and another thousands of days, another millions of days, and
+another thousands of millions. Now, instead of reversing the levers,
+I had pulled them over so as to go forward with them, and when I
+came to look at these indicators I found that the thousands hand was
+sweeping round as fast as the seconds hand of a watch--into
+futurity.
+
+'As I drove on, a peculiar change crept over the appearance of
+things. The palpitating greyness grew darker; then--though I was
+still travelling with prodigious velocity--the blinking succession
+of day and night, which was usually indicative of a slower pace,
+returned, and grew more and more marked. This puzzled me very much
+at first. The alternations of night and day grew slower and slower,
+and so did the passage of the sun across the sky, until they seemed
+to stretch through centuries. At last a steady twilight brooded over
+the earth, a twilight only broken now and then when a comet glared
+across the darkling sky. The band of light that had indicated the
+sun had long since disappeared; for the sun had ceased to set--it
+simply rose and fell in the west, and grew ever broader and more
+red. All trace of the moon had vanished. The circling of the stars,
+growing slower and slower, had given place to creeping points of
+light. At last, some time before I stopped, the sun, red and very
+large, halted motionless upon the horizon, a vast dome glowing with
+a dull heat, and now and then suffering a momentary extinction. At
+one time it had for a little while glowed more brilliantly again,
+but it speedily reverted to its sullen red heat. I perceived by this
+slowing down of its rising and setting that the work of the tidal
+drag was done. The earth had come to rest with one face to the sun,
+even as in our own time the moon faces the earth. Very cautiously,
+for I remembered my former headlong fall, I began to reverse
+my motion. Slower and slower went the circling hands until the
+thousands one seemed motionless and the daily one was no longer a
+mere mist upon its scale. Still slower, until the dim outlines of a
+desolate beach grew visible.
+
+'I stopped very gently and sat upon the Time Machine, looking round.
+The sky was no longer blue. North-eastward it was inky black,
+and out of the blackness shone brightly and steadily the pale
+white stars. Overhead it was a deep Indian red and starless, and
+south-eastward it grew brighter to a glowing scarlet where, cut by
+the horizon, lay the huge hull of the sun, red and motionless. The
+rocks about me were of a harsh reddish colour, and all the trace of
+life that I could see at first was the intensely green vegetation
+that covered every projecting point on their south-eastern face. It
+was the same rich green that one sees on forest moss or on the
+lichen in caves: plants which like these grow in a perpetual
+twilight.
+
+'The machine was standing on a sloping beach. The sea stretched away
+to the south-west, to rise into a sharp bright horizon against the
+wan sky. There were no breakers and no waves, for not a breath of
+wind was stirring. Only a slight oily swell rose and fell like a
+gentle breathing, and showed that the eternal sea was still moving
+and living. And along the margin where the water sometimes broke was
+a thick incrustation of salt--pink under the lurid sky. There was a
+sense of oppression in my head, and I noticed that I was breathing
+very fast. The sensation reminded me of my only experience of
+mountaineering, and from that I judged the air to be more rarefied
+than it is now.
+
+'Far away up the desolate slope I heard a harsh scream, and saw a
+thing like a huge white butterfly go slanting and fluttering up into
+the sky and, circling, disappear over some low hillocks beyond. The
+sound of its voice was so dismal that I shivered and seated myself
+more firmly upon the machine. Looking round me again, I saw that,
+quite near, what I had taken to be a reddish mass of rock was moving
+slowly towards me. Then I saw the thing was really a monstrous
+crab-like creature. Can you imagine a crab as large as yonder table,
+with its many legs moving slowly and uncertainly, its big claws
+swaying, its long antennae, like carters' whips, waving and feeling,
+and its stalked eyes gleaming at you on either side of its metallic
+front? Its back was corrugated and ornamented with ungainly bosses,
+and a greenish incrustation blotched it here and there. I could see
+the many palps of its complicated mouth flickering and feeling as it
+moved.
+
+'As I stared at this sinister apparition crawling towards me, I felt
+a tickling on my cheek as though a fly had lighted there. I tried to
+brush it away with my hand, but in a moment it returned, and almost
+immediately came another by my ear. I struck at this, and caught
+something threadlike. It was drawn swiftly out of my hand. With a
+frightful qualm, I turned, and I saw that I had grasped the antenna
+of another monster crab that stood just behind me. Its evil eyes
+were wriggling on their stalks, its mouth was all alive with
+appetite, and its vast ungainly claws, smeared with an algal slime,
+were descending upon me. In a moment my hand was on the lever, and
+I had placed a month between myself and these monsters. But I was
+still on the same beach, and I saw them distinctly now as soon as I
+stopped. Dozens of them seemed to be crawling here and there, in the
+sombre light, among the foliated sheets of intense green.
+
+'I cannot convey the sense of abominable desolation that hung over
+the world. The red eastern sky, the northward blackness, the salt
+Dead Sea, the stony beach crawling with these foul, slow-stirring
+monsters, the uniform poisonous-looking green of the lichenous
+plants, the thin air that hurts one's lungs: all contributed to an
+appalling effect. I moved on a hundred years, and there was the same
+red sun--a little larger, a little duller--the same dying sea, the
+same chill air, and the same crowd of earthy crustacea creeping in
+and out among the green weed and the red rocks. And in the westward
+sky, I saw a curved pale line like a vast new moon.
+
+'So I travelled, stopping ever and again, in great strides of a
+thousand years or more, drawn on by the mystery of the earth's fate,
+watching with a strange fascination the sun grow larger and duller
+in the westward sky, and the life of the old earth ebb away. At
+last, more than thirty million years hence, the huge red-hot dome of
+the sun had come to obscure nearly a tenth part of the darkling
+heavens. Then I stopped once more, for the crawling multitude of
+crabs had disappeared, and the red beach, save for its livid green
+liverworts and lichens, seemed lifeless. And now it was flecked with
+white. A bitter cold assailed me. Rare white flakes ever and again
+came eddying down. To the north-eastward, the glare of snow lay
+under the starlight of the sable sky and I could see an undulating
+crest of hillocks pinkish white. There were fringes of ice along the
+sea margin, with drifting masses further out; but the main expanse
+of that salt ocean, all bloody under the eternal sunset, was still
+unfrozen.
+
+'I looked about me to see if any traces of animal life remained. A
+certain indefinable apprehension still kept me in the saddle of the
+machine. But I saw nothing moving, in earth or sky or sea. The green
+slime on the rocks alone testified that life was not extinct. A
+shallow sandbank had appeared in the sea and the water had receded
+from the beach. I fancied I saw some black object flopping about
+upon this bank, but it became motionless as I looked at it, and I
+judged that my eye had been deceived, and that the black object was
+merely a rock. The stars in the sky were intensely bright and seemed
+to me to twinkle very little.
+
+'Suddenly I noticed that the circular westward outline of the sun
+had changed; that a concavity, a bay, had appeared in the curve. I
+saw this grow larger. For a minute perhaps I stared aghast at this
+blackness that was creeping over the day, and then I realized that
+an eclipse was beginning. Either the moon or the planet Mercury was
+passing across the sun's disk. Naturally, at first I took it to be
+the moon, but there is much to incline me to believe that what I
+really saw was the transit of an inner planet passing very near to
+the earth.
+
+'The darkness grew apace; a cold wind began to blow in freshening
+gusts from the east, and the showering white flakes in the air
+increased in number. From the edge of the sea came a ripple and
+whisper. Beyond these lifeless sounds the world was silent. Silent?
+It would be hard to convey the stillness of it. All the sounds of
+man, the bleating of sheep, the cries of birds, the hum of insects,
+the stir that makes the background of our lives--all that was over.
+As the darkness thickened, the eddying flakes grew more abundant,
+dancing before my eyes; and the cold of the air more intense. At
+last, one by one, swiftly, one after the other, the white peaks of
+the distant hills vanished into blackness. The breeze rose to a
+moaning wind. I saw the black central shadow of the eclipse sweeping
+towards me. In another moment the pale stars alone were visible. All
+else was rayless obscurity. The sky was absolutely black.
+
+'A horror of this great darkness came on me. The cold, that smote
+to my marrow, and the pain I felt in breathing, overcame me. I
+shivered, and a deadly nausea seized me. Then like a red-hot bow
+in the sky appeared the edge of the sun. I got off the machine to
+recover myself. I felt giddy and incapable of facing the return
+journey. As I stood sick and confused I saw again the moving thing
+upon the shoal--there was no mistake now that it was a moving
+thing--against the red water of the sea. It was a round thing, the
+size of a football perhaps, or, it may be, bigger, and tentacles
+trailed down from it; it seemed black against the weltering
+blood-red water, and it was hopping fitfully about. Then I felt I
+was fainting. But a terrible dread of lying helpless in that remote
+and awful twilight sustained me while I clambered upon the saddle.
+
+
+
+
+XII
+
+
+'So I came back. For a long time I must have been insensible upon
+the machine. The blinking succession of the days and nights was
+resumed, the sun got golden again, the sky blue. I breathed with
+greater freedom. The fluctuating contours of the land ebbed and
+flowed. The hands spun backward upon the dials. At last I saw again
+the dim shadows of houses, the evidences of decadent humanity.
+These, too, changed and passed, and others came. Presently, when the
+million dial was at zero, I slackened speed. I began to recognize
+our own pretty and familiar architecture, the thousands hand ran back
+to the starting-point, the night and day flapped slower and slower.
+Then the old walls of the laboratory came round me. Very gently,
+now, I slowed the mechanism down.
+
+'I saw one little thing that seemed odd to me. I think I have told
+you that when I set out, before my velocity became very high, Mrs.
+Watchett had walked across the room, travelling, as it seemed to me,
+like a rocket. As I returned, I passed again across that minute when
+she traversed the laboratory. But now her every motion appeared to
+be the exact inversion of her previous ones. The door at the lower
+end opened, and she glided quietly up the laboratory, back foremost,
+and disappeared behind the door by which she had previously entered.
+Just before that I seemed to see Hillyer for a moment; but he passed
+like a flash.
+
+'Then I stopped the machine, and saw about me again the old familiar
+laboratory, my tools, my appliances just as I had left them. I got
+off the thing very shakily, and sat down upon my bench. For several
+minutes I trembled violently. Then I became calmer. Around me was
+my old workshop again, exactly as it had been. I might have slept
+there, and the whole thing have been a dream.
+
+'And yet, not exactly! The thing had started from the south-east
+corner of the laboratory. It had come to rest again in the
+north-west, against the wall where you saw it. That gives you the
+exact distance from my little lawn to the pedestal of the White
+Sphinx, into which the Morlocks had carried my machine.
+
+'For a time my brain went stagnant. Presently I got up and came
+through the passage here, limping, because my heel was still
+painful, and feeling sorely begrimed. I saw the _Pall Mall Gazette_
+on the table by the door. I found the date was indeed to-day, and
+looking at the timepiece, saw the hour was almost eight o'clock. I
+heard your voices and the clatter of plates. I hesitated--I felt so
+sick and weak. Then I sniffed good wholesome meat, and opened the
+door on you. You know the rest. I washed, and dined, and now I am
+telling you the story.
+
+'I know,' he said, after a pause, 'that all this will be absolutely
+incredible to you. To me the one incredible thing is that I am here
+to-night in this old familiar room looking into your friendly faces
+and telling you these strange adventures.'
+
+He looked at the Medical Man. 'No. I cannot expect you to believe
+it. Take it as a lie--or a prophecy. Say I dreamed it in the
+workshop. Consider I have been speculating upon the destinies of our
+race until I have hatched this fiction. Treat my assertion of its
+truth as a mere stroke of art to enhance its interest. And taking
+it as a story, what do you think of it?'
+
+He took up his pipe, and began, in his old accustomed manner, to tap
+with it nervously upon the bars of the grate. There was a momentary
+stillness. Then chairs began to creak and shoes to scrape upon the
+carpet. I took my eyes off the Time Traveller's face, and looked
+round at his audience. They were in the dark, and little spots of
+colour swam before them. The Medical Man seemed absorbed in the
+contemplation of our host. The Editor was looking hard at the end
+of his cigar--the sixth. The Journalist fumbled for his watch. The
+others, as far as I remember, were motionless.
+
+The Editor stood up with a sigh. 'What a pity it is you're not
+a writer of stories!' he said, putting his hand on the Time
+Traveller's shoulder.
+
+'You don't believe it?'
+
+'Well----'
+
+'I thought not.'
+
+The Time Traveller turned to us. 'Where are the matches?' he said.
+He lit one and spoke over his pipe, puffing. 'To tell you the truth
+... I hardly believe it myself.... And yet...'
+
+His eye fell with a mute inquiry upon the withered white flowers
+upon the little table. Then he turned over the hand holding his
+pipe, and I saw he was looking at some half-healed scars on his
+knuckles.
+
+The Medical Man rose, came to the lamp, and examined the flowers.
+'The gynaeceum's odd,' he said. The Psychologist leant forward to
+see, holding out his hand for a specimen.
+
+'I'm hanged if it isn't a quarter to one,' said the Journalist.
+'How shall we get home?'
+
+'Plenty of cabs at the station,' said the Psychologist.
+
+'It's a curious thing,' said the Medical Man; 'but I certainly don't
+know the natural order of these flowers. May I have them?'
+
+The Time Traveller hesitated. Then suddenly: 'Certainly not.'
+
+'Where did you really get them?' said the Medical Man.
+
+The Time Traveller put his hand to his head. He spoke like one who
+was trying to keep hold of an idea that eluded him. 'They were put
+into my pocket by Weena, when I travelled into Time.' He stared
+round the room. 'I'm damned if it isn't all going. This room and you
+and the atmosphere of every day is too much for my memory. Did I
+ever make a Time Machine, or a model of a Time Machine? Or is it all
+only a dream? They say life is a dream, a precious poor dream at
+times--but I can't stand another that won't fit. It's madness. And
+where did the dream come from? ... I must look at that machine. If
+there is one!'
+
+He caught up the lamp swiftly, and carried it, flaring red, through
+the door into the corridor. We followed him. There in the flickering
+light of the lamp was the machine sure enough, squat, ugly, and
+askew; a thing of brass, ebony, ivory, and translucent glimmering
+quartz. Solid to the touch--for I put out my hand and felt the rail
+of it--and with brown spots and smears upon the ivory, and bits of
+grass and moss upon the lower parts, and one rail bent awry.
+
+The Time Traveller put the lamp down on the bench, and ran his hand
+along the damaged rail. 'It's all right now,' he said. 'The story I
+told you was true. I'm sorry to have brought you out here in the
+cold.' He took up the lamp, and, in an absolute silence, we
+returned to the smoking-room.
+
+He came into the hall with us and helped the Editor on with his
+coat. The Medical Man looked into his face and, with a certain
+hesitation, told him he was suffering from overwork, at which he
+laughed hugely. I remember him standing in the open doorway, bawling
+good night.
+
+I shared a cab with the Editor. He thought the tale a 'gaudy lie.'
+For my own part I was unable to come to a conclusion. The story was
+so fantastic and incredible, the telling so credible and sober. I
+lay awake most of the night thinking about it. I determined to go
+next day and see the Time Traveller again. I was told he was in the
+laboratory, and being on easy terms in the house, I went up to him.
+The laboratory, however, was empty. I stared for a minute at the
+Time Machine and put out my hand and touched the lever. At that the
+squat substantial-looking mass swayed like a bough shaken by the
+wind. Its instability startled me extremely, and I had a queer
+reminiscence of the childish days when I used to be forbidden to
+meddle. I came back through the corridor. The Time Traveller met me
+in the smoking-room. He was coming from the house. He had a small
+camera under one arm and a knapsack under the other. He laughed when
+he saw me, and gave me an elbow to shake. 'I'm frightfully busy,'
+said he, 'with that thing in there.'
+
+'But is it not some hoax?' I said. 'Do you really travel through
+time?'
+
+'Really and truly I do.' And he looked frankly into my eyes. He
+hesitated. His eye wandered about the room. 'I only want half an
+hour,' he said. 'I know why you came, and it's awfully good of you.
+There's some magazines here. If you'll stop to lunch I'll prove you
+this time travelling up to the hilt, specimen and all. If you'll
+forgive my leaving you now?'
+
+I consented, hardly comprehending then the full import of his words,
+and he nodded and went on down the corridor. I heard the door of
+the laboratory slam, seated myself in a chair, and took up a daily
+paper. What was he going to do before lunch-time? Then suddenly
+I was reminded by an advertisement that I had promised to meet
+Richardson, the publisher, at two. I looked at my watch, and saw
+that I could barely save that engagement. I got up and went down the
+passage to tell the Time Traveller.
+
+As I took hold of the handle of the door I heard an exclamation,
+oddly truncated at the end, and a click and a thud. A gust of air
+whirled round me as I opened the door, and from within came the
+sound of broken glass falling on the floor. The Time Traveller was
+not there. I seemed to see a ghostly, indistinct figure sitting in
+a whirling mass of black and brass for a moment--a figure so
+transparent that the bench behind with its sheets of drawings was
+absolutely distinct; but this phantasm vanished as I rubbed my eyes.
+The Time Machine had gone. Save for a subsiding stir of dust, the
+further end of the laboratory was empty. A pane of the skylight had,
+apparently, just been blown in.
+
+I felt an unreasonable amazement. I knew that something strange had
+happened, and for the moment could not distinguish what the strange
+thing might be. As I stood staring, the door into the garden opened,
+and the man-servant appeared.
+
+We looked at each other. Then ideas began to come. 'Has Mr. ----
+gone out that way?' said I.
+
+'No, sir. No one has come out this way. I was expecting to find him
+here.'
+
+At that I understood. At the risk of disappointing Richardson I
+stayed on, waiting for the Time Traveller; waiting for the second,
+perhaps still stranger story, and the specimens and photographs he
+would bring with him. But I am beginning now to fear that I must
+wait a lifetime. The Time Traveller vanished three years ago. And,
+as everybody knows now, he has never returned.
+
+
+
+
+EPILOGUE
+
+
+One cannot choose but wonder. Will he ever return? It may be that he
+swept back into the past, and fell among the blood-drinking, hairy
+savages of the Age of Unpolished Stone; into the abysses of the
+Cretaceous Sea; or among the grotesque saurians, the huge reptilian
+brutes of the Jurassic times. He may even now--if I may use the
+phrase--be wandering on some plesiosaurus-haunted Oolitic coral
+reef, or beside the lonely saline lakes of the Triassic Age. Or did
+he go forward, into one of the nearer ages, in which men are still
+men, but with the riddles of our own time answered and its wearisome
+problems solved? Into the manhood of the race: for I, for my own
+part, cannot think that these latter days of weak experiment,
+fragmentary theory, and mutual discord are indeed man's culminating
+time! I say, for my own part. He, I know--for the question had been
+discussed among us long before the Time Machine was made--thought
+but cheerlessly of the Advancement of Mankind, and saw in the
+growing pile of civilization only a foolish heaping that must
+inevitably fall back upon and destroy its makers in the end. If that
+is so, it remains for us to live as though it were not so. But to me
+the future is still black and blank--is a vast ignorance, lit at a
+few casual places by the memory of his story. And I have by me, for
+my comfort, two strange white flowers--shrivelled now, and brown and
+flat and brittle--to witness that even when mind and strength had
+gone, gratitude and a mutual tenderness still lived on in the heart
+of man.
+
+
+
+
+
+
+
+End of Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+***** This file should be named 35.txt or 35.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/35/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/hadoop/src/main/resources/books/tom-sawyer.txt
+++ b/jet/hadoop/src/main/resources/books/tom-sawyer.txt
@@ -1,0 +1,9209 @@
+
+The Project Gutenberg EBook of The Adventures of Tom Sawyer, Complete by
+Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: The Adventures of Tom Sawyer, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #74]
+Last updated: August 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+Produced by David Widger
+
+
+
+
+
+THE ADVENTURES OF TOM SAWYER
+
+By Mark Twain
+
+(Samuel Langhorne Clemens)
+
+
+
+
+CONTENTS
+
+CHAPTER I. Y-o-u-u Tom-Aunt Polly Decides Upon her Duty--Tom Practices
+Music--The Challenge--A Private Entrance
+
+CHAPTER II. Strong Temptations--Strategic Movements--The Innocents
+Beguiled
+
+CHAPTER III. Tom as a General--Triumph and Reward--Dismal
+Felicity--Commission and Omission
+
+CHAPTER IV. Mental Acrobatics--Attending Sunday--School--The
+Superintendent--“Showing off”--Tom Lionized
+
+CHAPTER V. A Useful Minister--In Church--The Climax
+
+CHAPTER VI. Self-Examination--Dentistry--The Midnight Charm--Witches and
+Devils--Cautious Approaches--Happy Hours
+
+CHAPTER VII. A Treaty Entered Into--Early Lessons--A Mistake Made
+
+CHAPTER VIII. Tom Decides on his Course--Old Scenes Re-enacted
+
+CHAPTER IX. A Solemn Situation--Grave Subjects Introduced--Injun Joe
+Explains
+
+CHAPTER X. The Solemn Oath--Terror Brings Repentance--Mental Punishment
+
+CHAPTER XI. Muff Potter Comes Himself--Tom’s Conscience at Work
+
+CHAPTER XII. Tom Shows his Generosity--Aunt Polly Weakens
+
+CHAPTER XIII. The Young Pirates--Going to the Rendezvous--The Camp--Fire
+Talk
+
+CHAPTER XIV. Camp-Life--A Sensation--Tom Steals Away from Camp
+
+CHAPTER XV. Tom Reconnoiters--Learns the Situation--Reports at Camp
+
+CHAPTER XVI. A Day’s Amusements--Tom Reveals a Secret--The Pirates take a
+Lesson--A Night Surprise--An Indian War
+
+CHAPTER XVII. Memories of the Lost Heroes--The Point in Tom’s Secret
+
+CHAPTER XVIII. Tom’s Feelings Investigated--Wonderful Dream--Becky
+Thatcher Overshadowed--Tom Becomes Jealous--Black Revenge
+
+CHAPTER XIX. Tom Tells the Truth
+
+CHAPTER XX. Becky in a Dilemma--Tom’s Nobility Asserts Itself
+
+CHAPTER XXI. Youthful Eloquence--Compositions by the Young Ladies--A
+Lengthy Vision--The Boy’s Vengeance Satisfied
+
+CHAPTER XXII. Tom’s Confidence Betrayed--Expects Signal Punishment
+
+CHAPTER XXIII. Old Muff’s Friends--Muff Potter in Court--Muff Potter
+Saved
+
+CHAPTER XXIV. Tom as the Village Hero--Days of Splendor and Nights of
+Horror--Pursuit of Injun Joe
+
+CHAPTER XXV. About Kings and Diamonds--Search for the Treasure--Dead
+People and Ghosts
+
+CHAPTER XXVI. The Haunted House--Sleepy Ghosts--A Box of Gold--Bitter Luck
+
+CHAPTER XXVII. Doubts to be Settled--The Young Detectives
+
+CHAPTER XXVIII. An Attempt at No. Two--Huck Mounts Guard
+
+CHAPTER XXIX. The Pic-nic--Huck on Injun Joe’s Track--The “Revenge”
+ Job--Aid for the Widow
+
+CHAPTER XXX. The Welchman Reports--Huck Under Fire--The Story Circulated
+--A New Sensation--Hope Giving Way to Despair
+
+CHAPTER XXXI. An Exploring Expedition--Trouble Commences--Lost in the
+Cave--Total Darkness--Found but not Saved
+
+CHAPTER XXXII. Tom tells the Story of their Escape--Tom’s Enemy in Safe
+Quarters
+
+CHAPTER XXXIII. The Fate of Injun Joe--Huck and Tom Compare Notes
+--An Expedition to the Cave--Protection Against Ghosts--“An Awful Snug
+Place”--A Reception at the Widow Douglas’s
+
+CHAPTER XXXIV. Springing a Secret--Mr. Jones’ Surprise a Failure
+
+CHAPTER XXXV. A New Order of Things--Poor Huck--New Adventures Planned
+
+
+
+
+ILLUSTRATIONS
+
+Tom Sawyer
+
+Tom at Home
+
+Aunt Polly Beguiled
+
+A Good Opportunity
+
+Who’s Afraid
+
+Late Home
+
+Jim
+
+‘Tendin’ to Business
+
+Ain’t that Work?
+
+Cat and Toys
+
+Amusement
+
+Becky Thatcher
+
+Paying Off
+
+After the Battle
+
+“Showing Off”
+
+Not Amiss
+
+Mary
+
+Tom Contemplating
+
+Dampened Ardor
+
+Youth
+
+Boyhood
+
+Using the “Barlow”
+
+The Church
+
+Necessities
+
+Tom as a Sunday-School Hero    
+
+The Prize
+
+At Church
+
+The Model Boy
+
+The Church Choir
+
+A Side Show
+
+Result of Playing in Church
+
+The Pinch-Bug
+
+Sid
+
+Dentistry
+
+Huckleberry Finn
+
+Mother Hopkins
+
+Result of Tom’s Truthfulness
+
+Tom as an Artist
+
+Interrupted Courtship
+
+The Master
+
+Vain Pleading
+
+Tail Piece
+
+The Grave in the Woods
+
+Tom Meditates
+
+Robin Hood and his Foe
+
+Death of Robin Hood
+
+Midnight
+
+Tom’s Mode of Egress
+
+Tom’s Effort at Prayer
+
+Muff Potter Outwitted
+
+The Graveyard
+
+Forewarnings
+
+Disturbing Muff’s Sleep
+
+Tom’s Talk with his Aunt
+
+Muff Potter
+
+A Suspicious Incident
+
+Injun Joe’s two Victims
+
+In the Coils
+
+Peter
+
+Aunt Polly seeks Information
+
+A General Good Time
+
+Demoralized
+
+Joe Harper
+
+On Board Their First Prize
+
+The Pirates Ashore
+
+Wild Life
+
+The Pirate’s Bath
+
+The Pleasant Stroll
+
+The Search for the Drowned
+
+The Mysterious Writing
+
+River View
+
+What Tom Saw
+
+Tom Swims the River
+
+Taking Lessons
+
+The Pirates’ Egg Market
+
+Tom Looking for Joe’s Knife    
+
+The Thunder Storm
+
+Terrible Slaughter
+
+The Mourner
+
+Tom’s Proudest Moment
+
+Amy Lawrence
+
+Tom tries to Remember
+
+The Hero
+
+A Flirtation
+
+Becky Retaliates
+
+A Sudden Frost
+
+Counter-irritation
+
+Aunt Polly
+
+Tom justified
+
+The Discovery
+
+Caught in the Act
+
+Tom Astonishes the School
+
+Literature
+
+Tom Declaims
+
+Examination Evening
+
+On Exhibition
+
+Prize Authors
+
+The Master’s Dilemma
+
+The School House
+
+The Cadet
+
+Happy for Two Days
+
+Enjoying the Vacation
+
+The Stolen Melons
+
+The Judge
+
+Visiting the Prisoner
+
+Tom Swears
+
+The Court Room
+
+The Detective
+
+Tom Dreams
+
+The Treasure
+
+The Private Conference
+
+A King; Poor Fellow!
+
+Business
+
+The Ha’nted House
+
+Injun Joe
+
+The Greatest and Best
+
+Hidden Treasures Unearthed
+
+The Boy’s Salvation
+
+Room No. 2
+
+The Next Day’s Conference
+
+Treasures
+
+Uncle Jake
+
+Buck at Home
+
+The Haunted Room
+
+“Run for Your Life”
+
+McDougal’s Cave
+
+Inside the Cave
+
+Huck on Duty
+
+A Rousing Act
+
+Tail Piece
+
+The Welchman
+
+Result of a Sneeze
+
+Cornered
+
+Alarming Discoveries
+
+Tom and Becky stir up the Town
+
+Tom’s Marks
+
+Huck Questions the Widow
+
+Vampires
+
+Wonders of the Cave
+
+Attacked by Natives
+
+Despair
+
+The Wedding Cake
+
+A New Terror
+
+Daylight
+
+“Turn Out” to Receive Tom and Becky
+
+The Escape from the Cave
+
+Fate of the Ragged Man
+
+The Treasures Found
+
+Caught at Last
+
+Drop after Drop
+
+Having a Good Time
+
+A Business Trip
+
+“Got it at Last!”
+
+Tail Piece
+
+Widow Douglas
+
+Tom Backs his Statement
+
+Tail Piece
+
+Huck Transformed
+
+Comfortable Once More
+
+High up in Society
+
+Contentment
+
+
+
+
+PREFACE
+
+Most of the adventures recorded in this book really occurred; one or two
+were experiences of my own, the rest those of boys who were schoolmates
+of mine. Huck Finn is drawn from life; Tom Sawyer also, but not from an
+individual--he is a combination of the characteristics of three boys whom
+I knew, and therefore belongs to the composite order of architecture.
+
+The odd superstitions touched upon were all prevalent among children and
+slaves in the West at the period of this story--that is to say, thirty or
+forty years ago.
+
+Although my book is intended mainly for the entertainment of boys and
+girls, I hope it will not be shunned by men and women on that account,
+for part of my plan has been to try to pleasantly remind adults of what
+they once were themselves, and of how they felt and thought and talked,
+and what queer enterprises they sometimes engaged in.
+
+THE AUTHOR.
+
+HARTFORD, 1876.
+
+
+
+
+CHAPTER I
+
+“TOM!”
+
+No answer.
+
+“TOM!”
+
+No answer.
+
+“What’s gone with that boy,  I wonder? You TOM!”
+
+No answer.
+
+The old lady pulled her spectacles down and looked over them about the
+room; then she put them up and looked out under them. She seldom or
+never looked _through_ them for so small a thing as a boy; they were
+her state pair, the pride of her heart, and were built for “style,” not
+service--she could have seen through a pair of stove-lids just as well.
+She looked perplexed for a moment, and then said, not fiercely, but
+still loud enough for the furniture to hear:
+
+“Well, I lay if I get hold of you I’ll--”
+
+She did not finish, for by this time she was bending down and punching
+under the bed with the broom, and so she needed breath to punctuate the
+punches with. She resurrected nothing but the cat.
+
+“I never did see the beat of that boy!”
+
+She went to the open door and stood in it and looked out among the
+tomato vines and “jimpson” weeds that constituted the garden. No Tom. So
+she lifted up her voice at an angle calculated for distance and shouted:
+
+“Y-o-u-u TOM!”
+
+There was a slight noise behind her and she turned just in time to seize
+a small boy by the slack of his roundabout and arrest his flight.
+
+“There! I might ‘a’ thought of that closet. What you been doing in
+there?”
+
+“Nothing.”
+
+“Nothing! Look at your hands. And look at your mouth. What _is_ that
+truck?”
+
+“I don’t know, aunt.”
+
+“Well, I know. It’s jam--that’s what it is. Forty times I’ve said if you
+didn’t let that jam alone I’d skin you. Hand me that switch.”
+
+The switch hovered in the air--the peril was desperate--
+
+“My! Look behind you, aunt!”
+
+The old lady whirled round, and snatched her skirts out of danger.
+The lad fled on the instant, scrambled up the high board-fence, and
+disappeared over it.
+
+His aunt Polly stood surprised a moment, and then broke into a gentle
+laugh.
+
+“Hang the boy, can’t I never learn anything? Ain’t he played me tricks
+enough like that for me to be looking out for him by this time? But old
+fools is the biggest fools there is. Can’t learn an old dog new tricks,
+as the saying is. But my goodness, he never plays them alike, two days,
+and how is a body to know what’s coming? He ‘pears to know just how long
+he can torment me before I get my dander up, and he knows if he can make
+out to put me off for a minute or make me laugh, it’s all down again and
+I can’t hit him a lick. I ain’t doing my duty by that boy, and that’s
+the Lord’s truth, goodness knows. Spare the rod and spile the child,
+as the Good Book says. I’m a laying up sin and suffering for us both,
+I know. He’s full of the Old Scratch, but laws-a-me! he’s my own
+dead sister’s boy, poor thing, and I ain’t got the heart to lash him,
+somehow. Every time I let him off, my conscience does hurt me so, and
+every time I hit him my old heart most breaks. Well-a-well, man that is
+born of woman is of few days and full of trouble, as the Scripture
+says, and I reckon it’s so. He’ll play hookey this evening, * and [*
+Southwestern for “afternoon”] I’ll just be obleeged to make him work,
+tomorrow, to punish him. It’s mighty hard to make him work Saturdays,
+when all the boys is having holiday, but he hates work more than he
+hates anything else, and I’ve _got_ to do some of my duty by him, or
+I’ll be the ruination of the child.”
+
+Tom did play hookey, and he had a very good time. He got back home
+barely in season to help Jim, the small colored boy, saw next-day’s wood
+and split the kindlings before supper--at least he was there in time
+to tell his adventures to Jim while Jim did three-fourths of the work.
+Tom’s younger brother (or rather half-brother) Sid was already through
+with his part of the work (picking up chips), for he was a quiet boy,
+and had no adventurous, trouble-some ways.
+
+While Tom was eating his supper, and stealing sugar as opportunity
+offered, Aunt Polly asked him questions that were full of guile, and
+very deep--for she wanted to trap him into damaging revealments. Like
+many other simple-hearted souls, it was her pet vanity to believe she
+was endowed with a talent for dark and mysterious diplomacy, and she
+loved to contemplate her most transparent devices as marvels of low
+cunning. Said she:
+
+“Tom, it was middling warm in school, warn’t it?”
+
+“Yes’m.”
+
+“Powerful warm, warn’t it?”
+
+“Yes’m.”
+
+“Didn’t you want to go in a-swimming, Tom?”
+
+A bit of a scare shot through Tom--a touch of uncomfortable suspicion. He
+searched Aunt Polly’s face, but it told him nothing. So he said:
+
+“No’m--well, not very much.”
+
+The old lady reached out her hand and felt Tom’s shirt, and said:
+
+“But you ain’t too warm now, though.” And it flattered her to reflect
+that she had discovered that the shirt was dry without anybody knowing
+that that was what she had in her mind. But in spite of her, Tom knew
+where the wind lay, now. So he forestalled what might be the next move:
+
+“Some of us pumped on our heads--mine’s damp yet. See?”
+
+Aunt Polly was vexed to think she had overlooked that bit of
+circumstantial evidence, and missed a trick. Then she had a new
+inspiration:
+
+“Tom, you didn’t have to undo your shirt collar where I sewed it, to
+pump on your head, did you? Unbutton your jacket!”
+
+The trouble vanished out of Tom’s face. He opened his jacket. His shirt
+collar was securely sewed.
+
+“Bother! Well, go ‘long with you. I’d made sure you’d played hookey
+and been a-swimming. But I forgive ye, Tom. I reckon you’re a kind of a
+singed cat, as the saying is--better’n you look. _This_ time.”
+
+She was half sorry her sagacity had miscarried, and half glad that Tom
+had stumbled into obedient conduct for once.
+
+But Sidney said:
+
+“Well, now, if I didn’t think you sewed his collar with white thread,
+but it’s black.”
+
+“Why, I did sew it with white! Tom!”
+
+But Tom did not wait for the rest. As he went out at the door he said:
+
+“Siddy, I’ll lick you for that.”
+
+In a safe place Tom examined two large needles which were thrust into
+the lapels of his jacket, and had thread bound about them--one needle
+carried white thread and the other black. He said:
+
+“She’d never noticed if it hadn’t been for Sid. Confound it! sometimes
+she sews it with white, and sometimes she sews it with black. I wish to
+gee-miny she’d stick to one or t’other--I can’t keep the run of ‘em. But
+I bet you I’ll lam Sid for that. I’ll learn him!”
+
+He was not the Model Boy of the village. He knew the model boy very well
+though--and loathed him.
+
+Within two minutes, or even less, he had forgotten all his troubles. Not
+because his troubles were one whit less heavy and bitter to him than a
+man’s are to a man, but because a new and powerful interest bore
+them down and drove them out of his mind for the time--just as men’s
+misfortunes are forgotten in the excitement of new enterprises. This new
+interest was a valued novelty in whistling, which he had just acquired
+from a negro, and he was suffering to practise it un-disturbed. It
+consisted in a peculiar bird-like turn, a sort of liquid warble,
+produced by touching the tongue to the roof of the mouth at short
+intervals in the midst of the music--the reader probably remembers how to
+do it, if he has ever been a boy. Diligence and attention soon gave him
+the knack of it, and he strode down the street with his mouth full of
+harmony and his soul full of gratitude. He felt much as an astronomer
+feels who has discovered a new planet--no doubt, as far as strong, deep,
+unalloyed pleasure is concerned, the advantage was with the boy, not the
+astronomer.
+
+The summer evenings were long. It was not dark, yet. Presently Tom
+checked his whistle. A stranger was before him--a boy a shade larger
+than himself. A new-comer of any age or either sex was an im-pressive
+curiosity in the poor little shabby village of St. Petersburg. This boy
+was well dressed, too--well dressed on a week-day. This was simply as
+astounding. His cap was a dainty thing, his close-buttoned blue cloth
+roundabout was new and natty, and so were his pantaloons. He had shoes
+on--and it was only Friday. He even wore a necktie, a bright bit of
+ribbon. He had a citified air about him that ate into Tom’s vitals. The
+more Tom stared at the splendid marvel, the higher he turned up his nose
+at his finery and the shabbier and shabbier his own outfit seemed to
+him to grow. Neither boy spoke. If one moved, the other moved--but only
+sidewise, in a circle; they kept face to face and eye to eye all the
+time. Finally Tom said:
+
+“I can lick you!”
+
+“I’d like to see you try it.”
+
+“Well, I can do it.”
+
+“No you can’t, either.”
+
+“Yes I can.”
+
+“No you can’t.”
+
+“I can.”
+
+“You can’t.”
+
+“Can!”
+
+“Can’t!”
+
+An uncomfortable pause. Then Tom said:
+
+“What’s your name?”
+
+“‘Tisn’t any of your business, maybe.”
+
+“Well I ‘low I’ll _make_ it my business.”
+
+“Well why don’t you?”
+
+“If you say much, I will.”
+
+“Much--much--_much_. There now.”
+
+“Oh, you think you’re mighty smart, _don’t_ you? I could lick you with
+one hand tied behind me, if I wanted to.”
+
+“Well why don’t you _do_ it? You _say_ you can do it.”
+
+“Well I _will_, if you fool with me.”
+
+“Oh yes--I’ve seen whole families in the same fix.”
+
+“Smarty! You think you’re _some_, now, _don’t_ you? Oh, what a hat!”
+
+“You can lump that hat if you don’t like it. I dare you to knock it
+off--and anybody that’ll take a dare will suck eggs.”
+
+“You’re a liar!”
+
+“You’re another.”
+
+“You’re a fighting liar and dasn’t take it up.”
+
+“Aw--take a walk!”
+
+“Say--if you give me much more of your sass I’ll take and bounce a rock
+off’n your head.”
+
+“Oh, of _course_ you will.”
+
+“Well I _will_.”
+
+“Well why don’t you _do_ it then? What do you keep _saying_ you will
+for? Why don’t you _do_ it? It’s because you’re afraid.”
+
+“I _ain’t_ afraid.”
+
+“You are.”
+
+“I ain’t.”
+
+“You are.”
+
+Another pause, and more eying and sidling around each other. Presently
+they were shoulder to shoulder. Tom said:
+
+“Get away from here!”
+
+“Go away yourself!”
+
+“I won’t.”
+
+“I won’t either.”
+
+So they stood, each with a foot placed at an angle as a brace, and both
+shoving with might and main, and glowering at each other with hate. But
+neither could get an advantage. After struggling till both were hot and
+flushed, each relaxed his strain with watchful caution, and Tom said:
+
+“You’re a coward and a pup. I’ll tell my big brother on you, and he can
+thrash you with his little finger, and I’ll make him do it, too.”
+
+“What do I care for your big brother? I’ve got a brother that’s bigger
+than he is--and what’s more, he can throw him over that fence, too.”
+ [Both brothers were imaginary.]
+
+“That’s a lie.”
+
+“_Your_ saying so don’t make it so.”
+
+Tom drew a line in the dust with his big toe, and said:
+
+“I dare you to step over that, and I’ll lick you till you can’t stand
+up. Anybody that’ll take a dare will steal sheep.”
+
+The new boy stepped over promptly, and said:
+
+“Now you said you’d do it, now let’s see you do it.”
+
+“Don’t you crowd me now; you better look out.”
+
+“Well, you _said_ you’d do it--why don’t you do it?”
+
+“By jingo! for two cents I _will_ do it.”
+
+The new boy took two broad coppers out of his pocket and held them out
+with derision. Tom struck them to the ground. In an instant both boys
+were rolling and tumbling in the dirt, gripped together like cats; and
+for the space of a minute they tugged and tore at each other’s hair and
+clothes, punched and scratched each other’s nose, and covered themselves
+with dust and glory. Presently the confusion took form, and through the
+fog of battle Tom appeared, seated astride the new boy, and pounding him
+with his fists. “Holler ‘nuff!” said he.
+
+The boy only struggled to free himself. He was crying--mainly from rage.
+
+“Holler ‘nuff!”--and the pounding went on.
+
+At last the stranger got out a smothered “‘Nuff!” and Tom let him up and
+said:
+
+“Now that’ll learn you. Better look out who you’re fooling with next
+time.”
+
+The new boy went off brushing the dust from his clothes, sobbing,
+snuffling, and occasionally looking back and shaking his head and
+threatening what he would do to Tom the “next time he caught him out.”
+ To which Tom responded with jeers, and started off in high feather, and
+as soon as his back was turned the new boy snatched up a stone, threw it
+and hit him between the shoulders and then turned tail and ran like
+an antelope. Tom chased the traitor home, and thus found out where he
+lived. He then held a position at the gate for some time, daring the
+enemy to come outside, but the enemy only made faces at him through the
+window and declined. At last the enemy’s mother appeared, and called Tom
+a bad, vicious, vulgar child, and ordered him away. So he went away; but
+he said he “‘lowed” to “lay” for that boy.
+
+He got home pretty late that night, and when he climbed cautiously in
+at the window, he uncovered an ambuscade, in the person of his aunt; and
+when she saw the state his clothes were in her resolution to turn his
+Saturday holiday into captivity at hard labor became adamantine in its
+firmness.
+
+
+
+
+CHAPTER II
+
+SATURDAY morning was come, and all the summer world was bright and
+fresh, and brimming with life. There was a song in every heart; and if
+the heart was young the music issued at the lips. There was cheer in
+every face and a spring in every step. The locust-trees were in bloom
+and the fragrance of the blossoms filled the air. Cardiff Hill, beyond
+the village and above it, was green with vegetation and it lay just far
+enough away to seem a Delectable Land, dreamy, reposeful, and inviting.
+
+Tom appeared on the sidewalk with a bucket of whitewash and a
+long-handled brush. He surveyed the fence, and all gladness left him and
+a deep melancholy settled down upon his spirit. Thirty yards of board
+fence nine feet high. Life to him seemed hollow, and existence but a
+burden. Sighing, he dipped his brush and passed it along the topmost
+plank; repeated the operation; did it again; compared the insignificant
+whitewashed streak with the far-reaching continent of unwhitewashed
+fence, and sat down on a tree-box discouraged. Jim came skipping out at
+the gate with a tin pail, and singing Buffalo Gals. Bringing water from
+the town pump had always been hateful work in Tom’s eyes, before, but
+now it did not strike him so. He remembered that there was company at
+the pump. White, mulatto, and negro boys and girls were always there
+waiting their turns, resting, trading playthings, quarrelling, fighting,
+skylarking. And he remembered that although the pump was only a hundred
+and fifty yards off, Jim never got back with a bucket of water under an
+hour--and even then somebody generally had to go after him. Tom said:
+
+“Say, Jim, I’ll fetch the water if you’ll whitewash some.”
+
+Jim shook his head and said:
+
+“Can’t, Mars Tom. Ole missis, she tole me I got to go an’ git dis water
+an’ not stop foolin’ roun’ wid anybody. She say she spec’ Mars Tom gwine
+to ax me to whitewash, an’ so she tole me go ‘long an’ ‘tend to my own
+business--she ‘lowed _she’d_ ‘tend to de whitewashin’.”
+
+“Oh, never you mind what she said, Jim. That’s the way she always talks.
+Gimme the bucket--I won’t be gone only a a minute. _She_ won’t ever
+know.”
+
+“Oh, I dasn’t, Mars Tom. Ole missis she’d take an’ tar de head off’n me.
+‘Deed she would.”
+
+“_She_! She never licks anybody--whacks ‘em over the head with her
+thimble--and who cares for that, I’d like to know. She talks awful, but
+talk don’t hurt--anyways it don’t if she don’t cry. Jim, I’ll give you a
+marvel. I’ll give you a white alley!”
+
+Jim began to waver.
+
+“White alley, Jim! And it’s a bully taw.”
+
+“My! Dat’s a mighty gay marvel, I tell you! But Mars Tom I’s powerful
+‘fraid ole missis--”
+
+“And besides, if you will I’ll show you my sore toe.”
+
+Jim was only human--this attraction was too much for him. He put down
+his pail, took the white alley, and bent over the toe with absorbing
+interest while the bandage was being unwound. In another moment he
+was flying down the street with his pail and a tingling rear, Tom was
+whitewashing with vigor, and Aunt Polly was retiring from the field with
+a slipper in her hand and triumph in her eye.
+
+But Tom’s energy did not last. He began to think of the fun he had
+planned for this day, and his sorrows multiplied. Soon the free boys
+would come tripping along on all sorts of delicious expeditions, and
+they would make a world of fun of him for having to work--the very
+thought of it burnt him like fire. He got out his worldly wealth and
+examined it--bits of toys, marbles, and trash; enough to buy an exchange
+of _work_, maybe, but not half enough to buy so much as half an hour
+of pure freedom. So he returned his straitened means to his pocket, and
+gave up the idea of trying to buy the boys. At this dark and hopeless
+moment an inspiration burst upon him! Nothing less than a great,
+magnificent inspiration.
+
+He took up his brush and went tranquilly to work. Ben Rogers hove in
+sight presently--the very boy, of all boys, whose ridicule he had been
+dreading. Ben’s gait was the hop-skip-and-jump--proof enough that his
+heart was light and his anticipations high. He was eating an apple, and
+giving a long, melodious whoop, at intervals, followed by a deep-toned
+ding-dong-dong, ding-dong-dong, for he was personating a steamboat. As
+he drew near, he slackened speed, took the middle of the street, leaned
+far over to starboard and rounded to ponderously and with laborious pomp
+and circumstance--for he was personating the Big Missouri, and considered
+himself to be drawing nine feet of water. He was boat and captain and
+engine-bells combined, so he had to imagine himself standing on his own
+hurricane-deck giving the orders and executing them:
+
+“Stop her, sir! Ting-a-ling-ling!” The headway ran almost out, and he
+drew up slowly toward the sidewalk.
+
+“Ship up to back! Ting-a-ling-ling!” His arms straightened and stiffened
+down his sides.
+
+“Set her back on the stabboard! Ting-a-ling-ling! Chow! ch-chow-wow!
+Chow!” His right hand, mean-time, describing stately circles--for it was
+representing a forty-foot wheel.
+
+“Let her go back on the labboard! Ting-a-ling-ling! Chow-ch-chow-chow!”
+ The left hand began to describe circles.
+
+“Stop the stabboard! Ting-a-ling-ling! Stop the labboard! Come ahead on
+the stabboard! Stop her! Let your outside turn over slow! Ting-a-ling-ling!
+Chow-ow-ow! Get out that head-line! _lively_ now! Come--out with
+your spring-line--what’re you about there! Take a turn round that stump
+with the bight of it! Stand by that stage, now--let her go! Done with
+the engines, sir! Ting-a-ling-ling! SH’T! S’H’T! SH’T!” (trying the
+gauge-cocks).
+
+Tom went on whitewashing--paid no attention to the steamboat. Ben stared
+a moment and then said: “_Hi-Yi! You’re_ up a stump, ain’t you!”
+
+No answer. Tom surveyed his last touch with the eye of an artist, then
+he gave his brush another gentle sweep and surveyed the result, as
+before. Ben ranged up alongside of him. Tom’s mouth watered for the
+apple, but he stuck to his work. Ben said:
+
+“Hello, old chap, you got to work, hey?”
+
+Tom wheeled suddenly and said:
+
+“Why, it’s you, Ben! I warn’t noticing.”
+
+“Say--I’m going in a-swimming, I am. Don’t you wish you could? But of
+course you’d druther _work_--wouldn’t you? Course you would!”
+
+Tom contemplated the boy a bit, and said:
+
+“What do you call work?”
+
+“Why, ain’t _that_ work?”
+
+Tom resumed his whitewashing, and answered carelessly:
+
+“Well, maybe it is, and maybe it ain’t. All I know, is, it suits Tom
+Sawyer.”
+
+“Oh come, now, you don’t mean to let on that you _like_ it?”
+
+The brush continued to move.
+
+“Like it? Well, I don’t see why I oughtn’t to like it. Does a boy get a
+chance to whitewash a fence every day?”
+
+That put the thing in a new light. Ben stopped nibbling his apple.
+Tom swept his brush daintily back and forth--stepped back to note the
+effect--added a touch here and there--criticised the effect again--Ben
+watching every move and getting more and more interested, more and more
+absorbed. Presently he said:
+
+“Say, Tom, let _me_ whitewash a little.”
+
+Tom considered, was about to consent; but he altered his mind:
+
+“No--no--I reckon it wouldn’t hardly do, Ben. You see, Aunt Polly’s awful
+particular about this fence--right here on the street, you know--but if it
+was the back fence I wouldn’t mind and _she_ wouldn’t. Yes, she’s awful
+particular about this fence; it’s got to be done very careful; I reckon
+there ain’t one boy in a thousand, maybe two thousand, that can do it
+the way it’s got to be done.”
+
+“No--is that so? Oh come, now--lemme just try. Only just a little--I’d let
+_you_, if you was me, Tom.”
+
+“Ben, I’d like to, honest injun; but Aunt Polly--well, Jim wanted to do
+it, but she wouldn’t let him; Sid wanted to do it, and she wouldn’t let
+Sid. Now don’t you see how I’m fixed? If you was to tackle this fence
+and anything was to happen to it--”
+
+“Oh, shucks, I’ll be just as careful. Now lemme try. Say--I’ll give you
+the core of my apple.”
+
+“Well, here--No, Ben, now don’t. I’m afeard--”
+
+“I’ll give you _all_ of it!”
+
+Tom gave up the brush with reluctance in his face, but alacrity in his
+heart. And while the late steamer Big Missouri worked and sweated in the
+sun, the retired artist sat on a barrel in the shade close by,
+dangled his legs, munched his apple, and planned the slaughter of more
+innocents. There was no lack of material; boys happened along every
+little while; they came to jeer, but remained to whitewash. By the time
+Ben was fagged out, Tom had traded the next chance to Billy Fisher for
+a kite, in good repair; and when he played out, Johnny Miller bought in
+for a dead rat and a string to swing it with--and so on, and so on, hour
+after hour. And when the middle of the afternoon came, from being a
+poor poverty-stricken boy in the morning, Tom was literally rolling in
+wealth. He had besides the things before mentioned, twelve marbles, part
+of a jews-harp, a piece of blue bottle-glass to look through, a spool
+cannon, a key that wouldn’t unlock anything, a fragment of chalk, a
+glass stopper of a decanter, a tin soldier, a couple of tadpoles,
+six fire-crackers, a kitten with only one eye, a brass door-knob, a
+dog-collar--but no dog--the handle of a knife, four pieces of orange-peel,
+and a dilapidated old window sash.
+
+He had had a nice, good, idle time all the while--plenty of company--and
+the fence had three coats of whitewash on it! If he hadn’t run out of
+whitewash he would have bankrupted every boy in the village.
+
+Tom said to himself that it was not such a hollow world, after all. He
+had discovered a great law of human action, without knowing it--namely,
+that in order to make a man or a boy covet a thing, it is only necessary
+to make the thing difficult to attain. If he had been a great and
+wise philosopher, like the writer of this book, he would now have
+comprehended that Work consists of whatever a body is _obliged_ to do,
+and that Play consists of whatever a body is not obliged to do. And
+this would help him to understand why constructing artificial flowers or
+performing on a tread-mill is work, while rolling ten-pins or climbing
+Mont Blanc is only amusement. There are wealthy gentlemen in England
+who drive four-horse passenger-coaches twenty or thirty miles on a
+daily line, in the summer, because the privilege costs them considerable
+money; but if they were offered wages for the service, that would turn
+it into work and then they would resign.
+
+The boy mused awhile over the substantial change which had taken place
+in his worldly circumstances, and then wended toward headquarters to
+report.
+
+
+
+
+CHAPTER III
+
+TOM presented himself before Aunt Polly, who was sitting by an
+open window in a pleasant rearward apartment, which was bedroom,
+breakfast-room, dining-room, and library, combined. The balmy summer
+air, the restful quiet, the odor of the flowers, and the drowsing
+murmur of the bees had had their effect, and she was nodding over her
+knitting--for she had no company but the cat, and it was asleep in her
+lap. Her spectacles were propped up on her gray head for safety. She had
+thought that of course Tom had deserted long ago, and she wondered at
+seeing him place himself in her power again in this intrepid way. He
+said: “Mayn’t I go and play now, aunt?”
+
+“What, a’ready? How much have you done?”
+
+“It’s all done, aunt.”
+
+“Tom, don’t lie to me--I can’t bear it.”
+
+“I ain’t, aunt; it _is_ all done.”
+
+Aunt Polly placed small trust in such evidence. She went out to see for
+herself; and she would have been content to find twenty per cent. of
+Tom’s statement true. When she found the entire fence white-washed, and
+not only whitewashed but elaborately coated and recoated, and even a
+streak added to the ground, her astonishment was almost unspeakable. She
+said:
+
+“Well, I never! There’s no getting round it, you can work when you’re a
+mind to, Tom.” And then she diluted the compliment by adding, “But it’s
+powerful seldom you’re a mind to, I’m bound to say. Well, go ‘long and
+play; but mind you get back some time in a week, or I’ll tan you.”
+
+She was so overcome by the splendor of his achievement that she took
+him into the closet and selected a choice apple and delivered it to him,
+along with an improving lecture upon the added value and flavor a treat
+took to itself when it came without sin through virtuous effort.
+And while she closed with a happy Scriptural flourish, he “hooked” a
+doughnut.
+
+Then he skipped out, and saw Sid just starting up the outside stairway
+that led to the back rooms on the second floor. Clods were handy and
+the air was full of them in a twinkling. They raged around Sid like a
+hail-storm; and before Aunt Polly could collect her surprised faculties
+and sally to the rescue, six or seven clods had taken personal effect,
+and Tom was over the fence and gone. There was a gate, but as a general
+thing he was too crowded for time to make use of it. His soul was at
+peace, now that he had settled with Sid for calling attention to his
+black thread and getting him into trouble.
+
+Tom skirted the block, and came round into a muddy alley that led by the
+back of his aunt’s cow-stable. He presently got safely beyond the reach
+of capture and punishment, and hastened toward the public square of the
+village, where two “military” companies of boys had met for conflict,
+according to previous appointment. Tom was General of one of these
+armies, Joe Harper (a bosom friend) General of the other. These two
+great commanders did not condescend to fight in person--that being better
+suited to the still smaller fry--but sat together on an eminence
+and conducted the field operations by orders delivered through
+aides-de-camp. Tom’s army won a great victory, after a long and
+hard-fought battle. Then the dead were counted, prisoners exchanged,
+the terms of the next disagreement agreed upon, and the day for the
+necessary battle appointed; after which the armies fell into line and
+marched away, and Tom turned homeward alone.
+
+As he was passing by the house where Jeff Thatcher lived, he saw a new
+girl in the garden--a lovely little blue-eyed creature with yellow
+hair plaited into two long-tails, white summer frock and embroidered
+pan-talettes. The fresh-crowned hero fell without firing a shot. A
+certain Amy Lawrence vanished out of his heart and left not even a
+memory of herself behind. He had thought he loved her to distraction;
+he had regarded his passion as adoration; and behold it was only a poor
+little evanescent partiality. He had been months winning her; she had
+confessed hardly a week ago; he had been the happiest and the proudest
+boy in the world only seven short days, and here in one instant of time
+she had gone out of his heart like a casual stranger whose visit is
+done.
+
+He worshipped this new angel with furtive eye, till he saw that she had
+discovered him; then he pretended he did not know she was present, and
+began to “show off” in all sorts of absurd boyish ways, in order to win
+her admiration. He kept up this grotesque foolishness for some time;
+but by-and-by, while he was in the midst of some dangerous gymnastic
+performances, he glanced aside and saw that the little girl was wending
+her way toward the house. Tom came up to the fence and leaned on it,
+grieving, and hoping she would tarry yet awhile longer. She halted a
+moment on the steps and then moved toward the door. Tom heaved a great
+sigh as she put her foot on the threshold. But his face lit up,
+right away, for she tossed a pansy over the fence a moment before she
+disappeared.
+
+The boy ran around and stopped within a foot or two of the flower, and
+then shaded his eyes with his hand and began to look down street as
+if he had discovered something of interest going on in that direction.
+Presently he picked up a straw and began trying to balance it on his
+nose, with his head tilted far back; and as he moved from side to side,
+in his efforts, he edged nearer and nearer toward the pansy; finally his
+bare foot rested upon it, his pliant toes closed upon it, and he hopped
+away with the treasure and disappeared round the corner. But only for a
+minute--only while he could button the flower inside his jacket, next
+his heart--or next his stomach, possibly, for he was not much posted in
+anatomy, and not hypercritical, anyway.
+
+He returned, now, and hung about the fence till nightfall, “showing
+off,” as before; but the girl never exhibited herself again, though Tom
+comforted himself a little with the hope that she had been near some
+window, meantime, and been aware of his attentions. Finally he strode
+home reluctantly, with his poor head full of visions.
+
+All through supper his spirits were so high that his aunt wondered “what
+had got into the child.” He took a good scolding about clodding Sid, and
+did not seem to mind it in the least. He tried to steal sugar under his
+aunt’s very nose, and got his knuckles rapped for it. He said:
+
+“Aunt, you don’t whack Sid when he takes it.”
+
+“Well, Sid don’t torment a body the way you do. You’d be always into
+that sugar if I warn’t watching you.”
+
+Presently she stepped into the kitchen, and Sid, happy in his immunity,
+reached for the sugar-bowl--a sort of glorying over Tom which was
+wellnigh unbearable. But Sid’s fingers slipped and the bowl dropped and
+broke. Tom was in ecstasies. In such ecstasies that he even controlled
+his tongue and was silent. He said to himself that he would not speak a
+word, even when his aunt came in, but would sit perfectly still till she
+asked who did the mischief; and then he would tell, and there would be
+nothing so good in the world as to see that pet model “catch it.” He was
+so brimful of exultation that he could hardly hold himself when the old
+lady came back and stood above the wreck discharging lightnings of wrath
+from over her spectacles. He said to himself, “Now it’s coming!” And the
+next instant he was sprawling on the floor! The potent palm was uplifted
+to strike again when Tom cried out:
+
+“Hold on, now, what ‘er you belting _me_ for?--Sid broke it!”
+
+Aunt Polly paused, perplexed, and Tom looked for healing pity. But when
+she got her tongue again, she only said:
+
+“Umf! Well, you didn’t get a lick amiss, I reckon. You been into some
+other audacious mischief when I wasn’t around, like enough.”
+
+Then her conscience reproached her, and she yearned to say something
+kind and loving; but she judged that this would be construed into a
+confession that she had been in the wrong, and discipline forbade that.
+So she kept silence, and went about her affairs with a troubled heart.
+Tom sulked in a corner and exalted his woes. He knew that in her heart
+his aunt was on her knees to him, and he was morosely gratified by the
+consciousness of it. He would hang out no signals, he would take notice
+of none. He knew that a yearning glance fell upon him, now and then,
+through a film of tears, but he refused recognition of it. He pictured
+himself lying sick unto death and his aunt bending over him beseeching
+one little forgiving word, but he would turn his face to the wall, and
+die with that word unsaid. Ah, how would she feel then? And he pictured
+himself brought home from the river, dead, with his curls all wet, and
+his sore heart at rest. How she would throw herself upon him, and how
+her tears would fall like rain, and her lips pray God to give her back
+her boy and she would never, never abuse him any more! But he would
+lie there cold and white and make no sign--a poor little sufferer, whose
+griefs were at an end. He so worked upon his feelings with the pathos of
+these dreams, that he had to keep swallowing, he was so like to choke;
+and his eyes swam in a blur of water, which overflowed when he winked,
+and ran down and trickled from the end of his nose. And such a luxury to
+him was this petting of his sorrows, that he could not bear to have any
+worldly cheeriness or any grating delight intrude upon it; it was too
+sacred for such contact; and so, presently, when his cousin Mary danced
+in, all alive with the joy of seeing home again after an age-long visit
+of one week to the country, he got up and moved in clouds and darkness
+out at one door as she brought song and sunshine in at the other.
+
+He wandered far from the accustomed haunts of boys, and sought desolate
+places that were in harmony with his spirit. A log raft in the river
+invited him, and he seated himself on its outer edge and contemplated
+the dreary vastness of the stream, wishing, the while, that he could
+only be drowned, all at once and unconsciously, without undergoing the
+uncomfortable routine devised by nature. Then he thought of his flower.
+He got it out, rumpled and wilted, and it mightily increased his dismal
+felicity. He wondered if she would pity him if she knew? Would she
+cry, and wish that she had a right to put her arms around his neck and
+comfort him? Or would she turn coldly away like all the hollow world?
+This picture brought such an agony of pleasurable suffering that he
+worked it over and over again in his mind and set it up in new and
+varied lights, till he wore it threadbare. At last he rose up sighing
+and departed in the darkness.
+
+About half-past nine or ten o’clock he came along the deserted street to
+where the Adored Unknown lived; he paused a moment; no sound fell upon
+his listening ear; a candle was casting a dull glow upon the curtain
+of a second-story window. Was the sacred presence there? He climbed the
+fence, threaded his stealthy way through the plants, till he stood under
+that window; he looked up at it long, and with emotion; then he laid him
+down on the ground under it, disposing himself upon his back, with his
+hands clasped upon his breast and holding his poor wilted flower.
+And thus he would die--out in the cold world, with no shelter over his
+homeless head, no friendly hand to wipe the death-damps from his brow,
+no loving face to bend pityingly over him when the great agony came. And
+thus _she_ would see him when she looked out upon the glad morning, and
+oh! would she drop one little tear upon his poor, lifeless form, would
+she heave one little sigh to see a bright young life so rudely blighted,
+so untimely cut down?
+
+The window went up, a maid-servant’s discordant voice profaned the holy
+calm, and a deluge of water drenched the prone martyr’s remains!
+
+The strangling hero sprang up with a relieving snort. There was a whiz
+as of a missile in the air, mingled with the murmur of a curse, a sound
+as of shivering glass followed, and a small, vague form went over the
+fence and shot away in the gloom.
+
+Not long after, as Tom, all undressed for bed, was surveying his
+drenched garments by the light of a tallow dip, Sid woke up; but if he
+had any dim idea of making any “references to allusions,” he thought
+better of it and held his peace, for there was danger in Tom’s eye.
+
+Tom turned in without the added vexation of prayers, and Sid made mental
+note of the omission.
+
+
+
+
+CHAPTER IV
+
+THE sun rose upon a tranquil world, and beamed down upon the peaceful
+village like a benediction. Breakfast over, Aunt Polly had family
+worship: it began with a prayer built from the ground up of solid
+courses of Scriptural quotations, welded together with a thin mortar of
+originality; and from the summit of this she delivered a grim chapter of
+the Mosaic Law, as from Sinai.
+
+Then Tom girded up his loins, so to speak, and went to work to “get
+his verses.” Sid had learned his lesson days before. Tom bent all his
+energies to the memorizing of five verses, and he chose part of the
+Sermon on the Mount, because he could find no verses that were shorter.
+At the end of half an hour Tom had a vague general idea of his lesson,
+but no more, for his mind was traversing the whole field of human
+thought, and his hands were busy with distracting recreations. Mary took
+his book to hear him recite, and he tried to find his way through the
+fog:
+
+“Blessed are the--a--a--”
+
+“Poor”--
+
+“Yes--poor; blessed are the poor--a--a--”
+
+“In spirit--”
+
+“In spirit; blessed are the poor in spirit, for they--they--”
+
+“_Theirs_--”
+
+“For _theirs_. Blessed are the poor in spirit, for theirs is the kingdom
+of heaven. Blessed are they that mourn, for they--they--”
+
+“Sh--”
+
+“For they--a--”
+
+“S, H, A--”
+
+“For they S, H--Oh, I don’t know what it is!”
+
+“_Shall_!”
+
+“Oh, _shall_! for they shall--for they shall--a--a--shall mourn--a--a--blessed
+are they that shall--they that--a--they that shall mourn, for they
+shall--a--shall _what_? Why don’t you tell me, Mary?--what do you want to
+be so mean for?”
+
+“Oh, Tom, you poor thick-headed thing, I’m not teasing you. I wouldn’t
+do that. You must go and learn it again. Don’t you be discouraged, Tom,
+you’ll manage it--and if you do, I’ll give you something ever so nice.
+There, now, that’s a good boy.”
+
+“All right! What is it, Mary, tell me what it is.”
+
+“Never you mind, Tom. You know if I say it’s nice, it is nice.”
+
+“You bet you that’s so, Mary. All right, I’ll tackle it again.”
+
+And he did “tackle it again”--and under the double pressure of curiosity
+and prospective gain he did it with such spirit that he accomplished a
+shining success. Mary gave him a brand-new “Barlow” knife worth twelve
+and a half cents; and the convulsion of delight that swept his system
+shook him to his foundations. True, the knife would not cut anything,
+but it was a “sure-enough” Barlow, and there was inconceivable grandeur
+in that--though where the Western boys ever got the idea that such a
+weapon could possibly be counterfeited to its injury is an imposing
+mystery and will always remain so, perhaps. Tom contrived to scarify the
+cupboard with it, and was arranging to begin on the bureau, when he was
+called off to dress for Sunday-school.
+
+Mary gave him a tin basin of water and a piece of soap, and he went
+outside the door and set the basin on a little bench there; then he
+dipped the soap in the water and laid it down; turned up his sleeves;
+poured out the water on the ground, gently, and then entered the kitchen
+and began to wipe his face diligently on the towel behind the door. But
+Mary removed the towel and said:
+
+“Now ain’t you ashamed, Tom. You mustn’t be so bad. Water won’t hurt
+you.”
+
+Tom was a trifle disconcerted. The basin was refilled, and this time he
+stood over it a little while, gathering resolution; took in a big breath
+and began. When he entered the kitchen presently, with both eyes shut
+and groping for the towel with his hands, an honorable testimony of
+suds and water was dripping from his face. But when he emerged from
+the towel, he was not yet satisfactory, for the clean territory stopped
+short at his chin and his jaws, like a mask; below and beyond this line
+there was a dark expanse of unirrigated soil that spread downward in
+front and backward around his neck. Mary took him in hand, and when she
+was done with him he was a man and a brother, without distinction of
+color, and his saturated hair was neatly brushed, and its short curls
+wrought into a dainty and symmetrical general effect. [He privately
+smoothed out the curls, with labor and difficulty, and plastered his
+hair close down to his head; for he held curls to be effeminate, and his
+own filled his life with bitterness.] Then Mary got out a suit of his
+clothing that had been used only on Sundays during two years--they were
+simply called his “other clothes”--and so by that we know the size of his
+wardrobe. The girl “put him to rights” after he had dressed himself;
+she buttoned his neat roundabout up to his chin, turned his vast shirt
+collar down over his shoulders, brushed him off and crowned him with
+his speckled straw hat. He now looked exceedingly improved and
+uncomfortable. He was fully as uncomfortable as he looked; for there
+was a restraint about whole clothes and cleanliness that galled him. He
+hoped that Mary would forget his shoes, but the hope was blighted; she
+coated them thoroughly with tallow, as was the custom, and brought
+them out. He lost his temper and said he was always being made to do
+everything he didn’t want to do. But Mary said, persuasively:
+
+“Please, Tom--that’s a good boy.”
+
+So he got into the shoes snarling. Mary was soon ready, and the three
+children set out for Sunday-school--a place that Tom hated with his whole
+heart; but Sid and Mary were fond of it.
+
+Sabbath-school hours were from nine to half-past ten; and then church
+service. Two of the children always remained for the sermon voluntarily,
+and the other always remained too--for stronger reasons. The church’s
+high-backed, uncushioned pews would seat about three hundred persons;
+the edifice was but a small, plain affair, with a sort of pine board
+tree-box on top of it for a steeple. At the door Tom dropped back a step
+and accosted a Sunday-dressed comrade:
+
+“Say, Billy, got a yaller ticket?”
+
+“Yes.”
+
+“What’ll you take for her?”
+
+“What’ll you give?”
+
+“Piece of lickrish and a fish-hook.”
+
+“Less see ‘em.”
+
+Tom exhibited. They were satisfactory, and the property changed hands.
+Then Tom traded a couple of white alleys for three red tickets, and some
+small trifle or other for a couple of blue ones. He waylaid other
+boys as they came, and went on buying tickets of various colors ten
+or fifteen minutes longer. He entered the church, now, with a swarm
+of clean and noisy boys and girls, proceeded to his seat and started
+a quarrel with the first boy that came handy. The teacher, a grave,
+elderly man, interfered; then turned his back a moment and Tom pulled a
+boy’s hair in the next bench, and was absorbed in his book when the boy
+turned around; stuck a pin in another boy, presently, in order to hear
+him say “Ouch!” and got a new reprimand from his teacher. Tom’s whole
+class were of a pattern--restless, noisy, and troublesome. When they came
+to recite their lessons, not one of them knew his verses perfectly, but
+had to be prompted all along. However, they worried through, and each
+got his reward--in small blue tickets, each with a passage of Scripture
+on it; each blue ticket was pay for two verses of the recitation. Ten
+blue tickets equalled a red one, and could be exchanged for it; ten red
+tickets equalled a yellow one; for ten yellow tickets the superintendent
+gave a very plainly bound Bible (worth forty cents in those easy
+times) to the pupil. How many of my readers would have the industry and
+application to memorize two thousand verses, even for a Dore Bible? And
+yet Mary had acquired two Bibles in this way--it was the patient work of
+two years--and a boy of German parentage had won four or five. He once
+recited three thousand verses without stopping; but the strain upon his
+mental faculties was too great, and he was little better than an idiot
+from that day forth--a grievous misfortune for the school, for on great
+occasions, before company, the superintendent (as Tom expressed it)
+had always made this boy come out and “spread himself.” Only the older
+pupils managed to keep their tickets and stick to their tedious work
+long enough to get a Bible, and so the delivery of one of these prizes
+was a rare and noteworthy circumstance; the successful pupil was so
+great and conspicuous for that day that on the spot every scholar’s
+heart was fired with a fresh ambition that often lasted a couple
+of weeks. It is possible that Tom’s mental stomach had never really
+hungered for one of those prizes, but unquestionably his entire being
+had for many a day longed for the glory and the eclat that came with it.
+
+In due course the superintendent stood up in front of the pulpit, with
+a closed hymn-book in his hand and his forefinger inserted between its
+leaves, and commanded attention. When a Sunday-school superintendent
+makes his customary little speech, a hymn-book in the hand is as
+necessary as is the inevitable sheet of music in the hand of a singer
+who stands forward on the platform and sings a solo at a concert--though
+why, is a mystery: for neither the hymn-book nor the sheet of music
+is ever referred to by the sufferer. This superintendent was a slim
+creature of thirty-five, with a sandy goatee and short sandy hair; he
+wore a stiff standing-collar whose upper edge almost reached his ears
+and whose sharp points curved forward abreast the corners of his mouth--a
+fence that compelled a straight lookout ahead, and a turning of the
+whole body when a side view was required; his chin was propped on a
+spreading cravat which was as broad and as long as a bank-note, and had
+fringed ends; his boot toes were turned sharply up, in the fashion
+of the day, like sleigh-runners--an effect patiently and laboriously
+produced by the young men by sitting with their toes pressed against a
+wall for hours together. Mr. Walters was very earnest of mien, and very
+sincere and honest at heart; and he held sacred things and places
+in such reverence, and so separated them from worldly matters, that
+unconsciously to himself his Sunday-school voice had acquired a peculiar
+intonation which was wholly absent on week-days. He began after this
+fashion:
+
+“Now, children, I want you all to sit up just as straight and pretty as
+you can and give me all your attention for a minute or two. There--that
+is it. That is the way good little boys and girls should do. I see one
+little girl who is looking out of the window--I am afraid she thinks I
+am out there somewhere--perhaps up in one of the trees making a speech
+to the little birds. [Applausive titter.] I want to tell you how good it
+makes me feel to see so many bright, clean little faces assembled in a
+place like this, learning to do right and be good.” And so forth and so
+on. It is not necessary to set down the rest of the oration. It was of a
+pattern which does not vary, and so it is familiar to us all.
+
+The latter third of the speech was marred by the resumption of fights
+and other recreations among certain of the bad boys, and by fidgetings
+and whisperings that extended far and wide, washing even to the bases of
+isolated and incorruptible rocks like Sid and Mary. But now every sound
+ceased suddenly, with the subsidence of Mr. Walters’ voice, and the
+conclusion of the speech was received with a burst of silent gratitude.
+
+A good part of the whispering had been occasioned by an event which was
+more or less rare--the entrance of visitors: lawyer Thatcher, accompanied
+by a very feeble and aged man; a fine, portly, middle-aged gentleman
+with iron-gray hair; and a dignified lady who was doubtless the latter’s
+wife. The lady was leading a child. Tom had been restless and full of
+chafings and repinings; conscience-smitten, too--he could not meet Amy
+Lawrence’s eye, he could not brook her loving gaze. But when he saw this
+small newcomer his soul was all ablaze with bliss in a moment. The next
+moment he was “showing off” with all his might--cuffing boys, pulling
+hair, making faces--in a word, using every art that seemed likely to
+fascinate a girl and win her applause. His exaltation had but one
+alloy--the memory of his humiliation in this angel’s garden--and that
+record in sand was fast washing out, under the waves of happiness that
+were sweeping over it now.
+
+The visitors were given the highest seat of honor, and as soon as Mr.
+Walters’ speech was finished, he introduced them to the school. The
+middle-aged man turned out to be a prodigious personage--no less a one
+than the county judge--altogether the most august creation these children
+had ever looked upon--and they wondered what kind of material he was made
+of--and they half wanted to hear him roar, and were half afraid he might,
+too. He was from Constantinople, twelve miles away--so he had travelled,
+and seen the world--these very eyes had looked upon the county
+court-house--which was said to have a tin roof. The awe which these
+reflections inspired was attested by the impressive silence and the
+ranks of staring eyes. This was the great Judge Thatcher, brother of
+their own lawyer. Jeff Thatcher immediately went forward, to be familiar
+with the great man and be envied by the school. It would have been music
+to his soul to hear the whisperings:
+
+“Look at him, Jim! He’s a going up there. Say--look! he’s a going to
+shake hands with him--he _is_ shaking hands with him! By jings, don’t you
+wish you was Jeff?”
+
+Mr. Walters fell to “showing off,” with all sorts of official bustlings
+and activities, giving orders, delivering judgments, discharging
+directions here, there, everywhere that he could find a target. The
+librarian “showed off”--running hither and thither with his arms full of
+books and making a deal of the splutter and fuss that insect authority
+delights in. The young lady teachers “showed off”--bending sweetly over
+pupils that were lately being boxed, lifting pretty warning fingers
+at bad little boys and patting good ones lovingly. The young gentlemen
+teachers “showed off” with small scoldings and other little displays of
+authority and fine attention to discipline--and most of the teachers, of
+both sexes, found business up at the library, by the pulpit; and it was
+business that frequently had to be done over again two or three times
+(with much seeming vexation). The little girls “showed off” in various
+ways, and the little boys “showed off” with such diligence that the air
+was thick with paper wads and the murmur of scufflings. And above it
+all the great man sat and beamed a majestic judicial smile upon all
+the house, and warmed himself in the sun of his own grandeur--for he was
+“showing off,” too.
+
+There was only one thing wanting to make Mr. Walters’ ecstasy complete,
+and that was a chance to deliver a Bible-prize and exhibit a prodigy.
+Several pupils had a few yellow tickets, but none had enough--he had been
+around among the star pupils inquiring. He would have given worlds, now,
+to have that German lad back again with a sound mind.
+
+And now at this moment, when hope was dead, Tom Sawyer came forward with
+nine yellow tickets, nine red tickets, and ten blue ones, and demanded
+a Bible. This was a thunderbolt out of a clear sky. Walters was not
+expecting an application from this source for the next ten years. But
+there was no getting around it--here were the certified checks, and they
+were good for their face. Tom was therefore elevated to a place with
+the Judge and the other elect, and the great news was announced from
+headquarters. It was the most stunning surprise of the decade, and
+so profound was the sensation that it lifted the new hero up to the
+judicial one’s altitude, and the school had two marvels to gaze upon
+in place of one. The boys were all eaten up with envy--but those that
+suffered the bitterest pangs were those who perceived too late that they
+themselves had contributed to this hated splendor by trading tickets to
+Tom for the wealth he had amassed in selling whitewashing privileges.
+These despised themselves, as being the dupes of a wily fraud, a
+guileful snake in the grass.
+
+The prize was delivered to Tom with as much effusion as the
+superintendent could pump up under the circumstances; but it lacked
+somewhat of the true gush, for the poor fellow’s instinct taught him
+that there was a mystery here that could not well bear the light,
+perhaps; it was simply preposterous that this boy had warehoused two
+thousand sheaves of Scriptural wisdom on his premises--a dozen would
+strain his capacity, without a doubt.
+
+Amy Lawrence was proud and glad, and she tried to make Tom see it in
+her face--but he wouldn’t look. She wondered; then she was just a grain
+troubled; next a dim suspicion came and went--came again; she watched;
+a furtive glance told her worlds--and then her heart broke, and she was
+jealous, and angry, and the tears came and she hated everybody. Tom most
+of all (she thought).
+
+Tom was introduced to the Judge; but his tongue was tied, his breath
+would hardly come, his heart quaked--partly because of the awful
+greatness of the man, but mainly because he was her parent. He would
+have liked to fall down and worship him, if it were in the dark. The
+Judge put his hand on Tom’s head and called him a fine little man, and
+asked him what his name was. The boy stammered, gasped, and got it out:
+
+“Tom.”
+
+“Oh, no, not Tom--it is--”
+
+“Thomas.”
+
+“Ah, that’s it. I thought there was more to it, maybe. That’s very well.
+But you’ve another one I daresay, and you’ll tell it to me, won’t you?”
+
+“Tell the gentleman your other name, Thomas,” said Walters, “and say
+sir. You mustn’t forget your manners.”
+
+“Thomas Sawyer--sir.”
+
+“That’s it! That’s a good boy. Fine boy. Fine, manly little fellow. Two
+thousand verses is a great many--very, very great many. And you never can
+be sorry for the trouble you took to learn them; for knowledge is worth
+more than anything there is in the world; it’s what makes great men
+and good men; you’ll be a great man and a good man yourself, some
+day, Thomas, and then you’ll look back and say, It’s all owing to the
+precious Sunday-school privileges of my boyhood--it’s all owing to
+my dear teachers that taught me to learn--it’s all owing to the good
+superintendent, who encouraged me, and watched over me, and gave me a
+beautiful Bible--a splendid elegant Bible--to keep and have it all for my
+own, always--it’s all owing to right bringing up! That is what you will
+say, Thomas--and you wouldn’t take any money for those two thousand
+verses--no indeed you wouldn’t. And now you wouldn’t mind telling me and
+this lady some of the things you’ve learned--no, I know you wouldn’t--for
+we are proud of little boys that learn. Now, no doubt you know the names
+of all the twelve disciples. Won’t you tell us the names of the first
+two that were appointed?”
+
+Tom was tugging at a button-hole and looking sheepish. He blushed,
+now, and his eyes fell. Mr. Walters’ heart sank within him. He said
+to himself, it is not possible that the boy can answer the simplest
+question--why _did_ the Judge ask him? Yet he felt obliged to speak up
+and say:
+
+“Answer the gentleman, Thomas--don’t be afraid.”
+
+Tom still hung fire.
+
+“Now I know you’ll tell me,” said the lady. “The names of the first two
+disciples were--”
+
+“_David And Goliah!_”
+
+Let us draw the curtain of charity over the rest of the scene.
+
+
+
+
+CHAPTER V
+
+ABOUT half-past ten the cracked bell of the small church began to ring,
+and presently the people began to gather for the morning sermon. The
+Sunday-school children distributed themselves about the house and
+occupied pews with their parents, so as to be under supervision. Aunt
+Polly came, and Tom and Sid and Mary sat with her--Tom being placed next
+the aisle, in order that he might be as far away from the open window
+and the seductive outside summer scenes as possible. The crowd filed up
+the aisles: the aged and needy postmaster, who had seen better days;
+the mayor and his wife--for they had a mayor there, among other
+unnecessaries; the justice of the peace; the widow Douglass, fair,
+smart, and forty, a generous, good-hearted soul and well-to-do, her hill
+mansion the only palace in the town, and the most hospitable and much
+the most lavish in the matter of festivities that St. Petersburg could
+boast; the bent and venerable Major and Mrs. Ward; lawyer Riverson, the
+new notable from a distance; next the belle of the village, followed by
+a troop of lawn-clad and ribbon-decked young heart-breakers; then all
+the young clerks in town in a body--for they had stood in the vestibule
+sucking their cane-heads, a circling wall of oiled and simpering
+admirers, till the last girl had run their gantlet; and last of all came
+the Model Boy, Willie Mufferson, taking as heedful care of his mother as
+if she were cut glass. He always brought his mother to church, and was
+the pride of all the matrons. The boys all hated him, he was so
+good. And besides, he had been “thrown up to them” so much. His
+white handkerchief was hanging out of his pocket behind, as usual on
+Sundays--accidentally. Tom had no handkerchief, and he looked upon boys
+who had as snobs.
+
+The congregation being fully assembled, now, the bell rang once more,
+to warn laggards and stragglers, and then a solemn hush fell upon the
+church which was only broken by the tittering and whispering of the
+choir in the gallery. The choir always tittered and whispered all
+through service. There was once a church choir that was not ill-bred,
+but I have forgotten where it was, now. It was a great many years ago,
+and I can scarcely remember anything about it, but I think it was in
+some foreign country.
+
+The minister gave out the hymn, and read it through with a relish, in a
+peculiar style which was much admired in that part of the country. His
+voice began on a medium key and climbed steadily up till it reached a
+certain point, where it bore with strong emphasis upon the topmost word
+and then plunged down as if from a spring-board:
+
+Shall I be car-ri-ed toe the skies, on flow’ry _beds_ of ease,
+
+Whilst others fight to win the prize, and sail thro’ _blood_-y seas?
+
+He was regarded as a wonderful reader. At church “sociables” he was
+always called upon to read poetry; and when he was through, the ladies
+would lift up their hands and let them fall helplessly in their laps,
+and “wall” their eyes, and shake their heads, as much as to say, “Words
+cannot express it; it is too beautiful, TOO beautiful for this mortal
+earth.”
+
+After the hymn had been sung, the Rev. Mr. Sprague turned himself into
+a bulletin-board, and read off “notices” of meetings and societies and
+things till it seemed that the list would stretch out to the crack of
+doom--a queer custom which is still kept up in America, even in cities,
+away here in this age of abundant newspapers. Often, the less there is
+to justify a traditional custom, the harder it is to get rid of it.
+
+And now the minister prayed. A good, generous prayer it was, and went
+into details: it pleaded for the church, and the little children of the
+church; for the other churches of the village; for the village itself;
+for the county; for the State; for the State officers; for the United
+States; for the churches of the United States; for Congress; for the
+President; for the officers of the Government; for poor sailors, tossed
+by stormy seas; for the oppressed millions groaning under the heel of
+European monarchies and Oriental despotisms; for such as have the light
+and the good tidings, and yet have not eyes to see nor ears to hear
+withal; for the heathen in the far islands of the sea; and closed with
+a supplication that the words he was about to speak might find grace
+and favor, and be as seed sown in fertile ground, yielding in time a
+grateful harvest of good. Amen.
+
+There was a rustling of dresses, and the standing congregation sat down.
+The boy whose history this book relates did not enjoy the prayer, he
+only endured it--if he even did that much. He was restive all through it;
+he kept tally of the details of the prayer, unconsciously--for he was not
+listening, but he knew the ground of old, and the clergyman’s regular
+route over it--and when a little trifle of new matter was interlarded,
+his ear detected it and his whole nature resented it; he considered
+additions unfair, and scoundrelly. In the midst of the prayer a fly had
+lit on the back of the pew in front of him and tortured his spirit by
+calmly rubbing its hands together, embracing its head with its arms, and
+polishing it so vigorously that it seemed to almost part company with
+the body, and the slender thread of a neck was exposed to view; scraping
+its wings with its hind legs and smoothing them to its body as if they
+had been coat-tails; going through its whole toilet as tranquilly as if
+it knew it was perfectly safe. As indeed it was; for as sorely as Tom’s
+hands itched to grab for it they did not dare--he believed his soul would
+be instantly destroyed if he did such a thing while the prayer was going
+on. But with the closing sentence his hand began to curve and steal
+forward; and the instant the “Amen” was out the fly was a prisoner of
+war. His aunt detected the act and made him let it go.
+
+The minister gave out his text and droned along monotonously through an
+argument that was so prosy that many a head by and by began to nod--and
+yet it was an argument that dealt in limitless fire and brimstone and
+thinned the predestined elect down to a company so small as to be hardly
+worth the saving. Tom counted the pages of the sermon; after church he
+always knew how many pages there had been, but he seldom knew anything
+else about the discourse. However, this time he was really interested
+for a little while. The minister made a grand and moving picture of the
+assembling together of the world’s hosts at the millennium when the lion
+and the lamb should lie down together and a little child should lead
+them. But the pathos, the lesson, the moral of the great spectacle
+were lost upon the boy; he only thought of the conspicuousness of the
+principal character before the on-looking nations; his face lit with the
+thought, and he said to himself that he wished he could be that child,
+if it was a tame lion.
+
+Now he lapsed into suffering again, as the dry argument was resumed.
+Presently he bethought him of a treasure he had and got it out. It was
+a large black beetle with formidable jaws--a “pinchbug,” he called it. It
+was in a percussion-cap box. The first thing the beetle did was to
+take him by the finger. A natural fillip followed, the beetle went
+floundering into the aisle and lit on its back, and the hurt finger went
+into the boy’s mouth. The beetle lay there working its helpless legs,
+unable to turn over. Tom eyed it, and longed for it; but it was safe out
+of his reach. Other people uninterested in the sermon found relief in
+the beetle, and they eyed it too. Presently a vagrant poodle dog came
+idling along, sad at heart, lazy with the summer softness and the
+quiet, weary of captivity, sighing for change. He spied the beetle; the
+drooping tail lifted and wagged. He surveyed the prize; walked around
+it; smelt at it from a safe distance; walked around it again; grew
+bolder, and took a closer smell; then lifted his lip and made a gingerly
+snatch at it, just missing it; made another, and another; began to enjoy
+the diversion; subsided to his stomach with the beetle between his paws,
+and continued his experiments; grew weary at last, and then indifferent
+and absent-minded. His head nodded, and little by little his chin
+descended and touched the enemy, who seized it. There was a sharp yelp,
+a flirt of the poodle’s head, and the beetle fell a couple of yards
+away, and lit on its back once more. The neighboring spectators
+shook with a gentle inward joy, several faces went behind fans and
+hand-kerchiefs, and Tom was entirely happy. The dog looked foolish,
+and probably felt so; but there was resentment in his heart, too, and a
+craving for revenge. So he went to the beetle and began a wary attack on
+it again; jumping at it from every point of a circle, lighting with his
+fore-paws within an inch of the creature, making even closer snatches at
+it with his teeth, and jerking his head till his ears flapped again. But
+he grew tired once more, after a while; tried to amuse himself with a
+fly but found no relief; followed an ant around, with his nose close
+to the floor, and quickly wearied of that; yawned, sighed, forgot the
+beetle entirely, and sat down on it. Then there was a wild yelp of agony
+and the poodle went sailing up the aisle; the yelps continued, and so
+did the dog; he crossed the house in front of the altar; he flew
+down the other aisle; he crossed before the doors; he clamored up the
+home-stretch; his anguish grew with his progress, till presently he was
+but a woolly comet moving in its orbit with the gleam and the speed of
+light. At last the frantic sufferer sheered from its course, and sprang
+into its master’s lap; he flung it out of the window, and the voice of
+distress quickly thinned away and died in the distance.
+
+By this time the whole church was red-faced and suffocating with
+suppressed laughter, and the sermon had come to a dead standstill.
+The discourse was resumed presently, but it went lame and halting, all
+possibility of impressiveness being at an end; for even the gravest
+sentiments were constantly being received with a smothered burst of
+unholy mirth, under cover of some remote pew-back, as if the poor parson
+had said a rarely facetious thing. It was a genuine relief to the whole
+congregation when the ordeal was over and the benediction pronounced.
+
+Tom Sawyer went home quite cheerful, thinking to himself that there was
+some satisfaction about divine service when there was a bit of variety
+in it. He had but one marring thought; he was willing that the dog
+should play with his pinchbug, but he did not think it was upright in
+him to carry it off.
+
+
+
+
+CHAPTER VI
+
+MONDAY morning found Tom Sawyer miserable. Monday morning always found
+him so--because it began another week’s slow suffering in school. He
+generally began that day with wishing he had had no intervening holiday,
+it made the going into captivity and fetters again so much more odious.
+
+Tom lay thinking. Presently it occurred to him that he wished he was
+sick; then he could stay home from school. Here was a vague possibility.
+He canvassed his system. No ailment was found, and he investigated
+again. This time he thought he could detect colicky symptoms, and he
+began to encourage them with considerable hope. But they soon grew
+feeble, and presently died wholly away. He reflected further. Suddenly
+he discovered something. One of his upper front teeth was loose. This
+was lucky; he was about to begin to groan, as a “starter,” as he
+called it, when it occurred to him that if he came into court with that
+argument, his aunt would pull it out, and that would hurt. So he thought
+he would hold the tooth in reserve for the present, and seek further.
+Nothing offered for some little time, and then he remembered hearing
+the doctor tell about a certain thing that laid up a patient for two or
+three weeks and threatened to make him lose a finger. So the boy eagerly
+drew his sore toe from under the sheet and held it up for inspection.
+But now he did not know the necessary symptoms. However, it seemed
+well worth while to chance it, so he fell to groaning with considerable
+spirit.
+
+But Sid slept on unconscious.
+
+Tom groaned louder, and fancied that he began to feel pain in the toe.
+
+No result from Sid.
+
+Tom was panting with his exertions by this time. He took a rest and then
+swelled himself up and fetched a succession of admirable groans.
+
+Sid snored on.
+
+Tom was aggravated. He said, “Sid, Sid!” and shook him. This course
+worked well, and Tom began to groan again. Sid yawned, stretched, then
+brought himself up on his elbow with a snort, and began to stare at Tom.
+Tom went on groaning. Sid said:
+
+“Tom! Say, Tom!” [No response.] “Here, Tom! TOM! What is the matter,
+Tom?” And he shook him and looked in his face anxiously.
+
+Tom moaned out:
+
+“Oh, don’t, Sid. Don’t joggle me.”
+
+“Why, what’s the matter, Tom? I must call auntie.”
+
+“No--never mind. It’ll be over by and by, maybe. Don’t call anybody.”
+
+“But I must! _Don’t_ groan so, Tom, it’s awful. How long you been this
+way?”
+
+“Hours. Ouch! Oh, don’t stir so, Sid, you’ll kill me.”
+
+“Tom, why didn’t you wake me sooner? Oh, Tom, _don’t!_ It makes my flesh
+crawl to hear you. Tom, what is the matter?”
+
+“I forgive you everything, Sid. [Groan.] Everything you’ve ever done to
+me. When I’m gone--”
+
+“Oh, Tom, you ain’t dying, are you? Don’t, Tom--oh, don’t. Maybe--”
+
+“I forgive everybody, Sid. [Groan.] Tell ‘em so, Sid. And Sid, you give
+my window-sash and my cat with one eye to that new girl that’s come to
+town, and tell her--”
+
+But Sid had snatched his clothes and gone. Tom was suffering in reality,
+now, so handsomely was his imagination working, and so his groans had
+gathered quite a genuine tone.
+
+Sid flew downstairs and said:
+
+“Oh, Aunt Polly, come! Tom’s dying!”
+
+“Dying!”
+
+“Yes’m. Don’t wait--come quick!”
+
+“Rubbage! I don’t believe it!”
+
+But she fled upstairs, nevertheless, with Sid and Mary at her heels.
+And her face grew white, too, and her lip trembled. When she reached the
+bedside she gasped out:
+
+“You, Tom! Tom, what’s the matter with you?”
+
+“Oh, auntie, I’m--”
+
+“What’s the matter with you--what is the matter with you, child?”
+
+“Oh, auntie, my sore toe’s mortified!”
+
+The old lady sank down into a chair and laughed a little, then cried a
+little, then did both together. This restored her and she said:
+
+“Tom, what a turn you did give me. Now you shut up that nonsense and
+climb out of this.”
+
+The groans ceased and the pain vanished from the toe. The boy felt a
+little foolish, and he said:
+
+“Aunt Polly, it _seemed_ mortified, and it hurt so I never minded my
+tooth at all.”
+
+“Your tooth, indeed! What’s the matter with your tooth?”
+
+“One of them’s loose, and it aches perfectly awful.”
+
+“There, there, now, don’t begin that groaning again. Open your mouth.
+Well--your tooth _is_ loose, but you’re not going to die about that.
+Mary, get me a silk thread, and a chunk of fire out of the kitchen.”
+
+Tom said:
+
+“Oh, please, auntie, don’t pull it out. It don’t hurt any more. I wish
+I may never stir if it does. Please don’t, auntie. I don’t want to stay
+home from school.”
+
+“Oh, you don’t, don’t you? So all this row was because you thought you’d
+get to stay home from school and go a-fishing? Tom, Tom, I love you so,
+and you seem to try every way you can to break my old heart with your
+outrageousness.” By this time the dental instruments were ready. The old
+lady made one end of the silk thread fast to Tom’s tooth with a loop
+and tied the other to the bedpost. Then she seized the chunk of fire and
+suddenly thrust it almost into the boy’s face. The tooth hung dangling
+by the bedpost, now.
+
+But all trials bring their compensations. As Tom wended to school after
+breakfast, he was the envy of every boy he met because the gap in his
+upper row of teeth enabled him to expectorate in a new and admirable
+way. He gathered quite a following of lads interested in the exhibition;
+and one that had cut his finger and had been a centre of fascination and
+homage up to this time, now found himself suddenly without an adherent,
+and shorn of his glory. His heart was heavy, and he said with a disdain
+which he did not feel that it wasn’t anything to spit like Tom Sawyer;
+but another boy said, “Sour grapes!” and he wandered away a dismantled
+hero.
+
+Shortly Tom came upon the juvenile pariah of the village, Huckleberry
+Finn, son of the town drunkard. Huckleberry was cordially hated and
+dreaded by all the mothers of the town, because he was idle and lawless
+and vulgar and bad--and because all their children admired him so, and
+delighted in his forbidden society, and wished they dared to be like
+him. Tom was like the rest of the respectable boys, in that he envied
+Huckleberry his gaudy outcast condition, and was under strict orders
+not to play with him. So he played with him every time he got a chance.
+Huckleberry was always dressed in the cast-off clothes of full-grown
+men, and they were in perennial bloom and fluttering with rags. His hat
+was a vast ruin with a wide crescent lopped out of its brim; his coat,
+when he wore one, hung nearly to his heels and had the rearward buttons
+far down the back; but one suspender supported his trousers; the seat of
+the trousers bagged low and contained nothing, the fringed legs dragged
+in the dirt when not rolled up.
+
+Huckleberry came and went, at his own free will. He slept on doorsteps
+in fine weather and in empty hogsheads in wet; he did not have to go to
+school or to church, or call any being master or obey anybody; he could
+go fishing or swimming when and where he chose, and stay as long as it
+suited him; nobody forbade him to fight; he could sit up as late as he
+pleased; he was always the first boy that went barefoot in the spring
+and the last to resume leather in the fall; he never had to wash, nor
+put on clean clothes; he could swear wonderfully. In a word, everything
+that goes to make life precious that boy had. So thought every harassed,
+hampered, respectable boy in St. Petersburg.
+
+Tom hailed the romantic outcast:
+
+“Hello, Huckleberry!”
+
+“Hello yourself, and see how you like it.”
+
+“What’s that you got?”
+
+“Dead cat.”
+
+“Lemme see him, Huck. My, he’s pretty stiff. Where’d you get him?”
+
+“Bought him off’n a boy.”
+
+“What did you give?”
+
+“I give a blue ticket and a bladder that I got at the slaughter-house.”
+
+“Where’d you get the blue ticket?”
+
+“Bought it off’n Ben Rogers two weeks ago for a hoop-stick.”
+
+“Say--what is dead cats good for, Huck?”
+
+“Good for? Cure warts with.”
+
+“No! Is that so? I know something that’s better.”
+
+“I bet you don’t. What is it?”
+
+“Why, spunk-water.”
+
+“Spunk-water! I wouldn’t give a dern for spunk-water.”
+
+“You wouldn’t, wouldn’t you? D’you ever try it?”
+
+“No, I hain’t. But Bob Tanner did.”
+
+“Who told you so!”
+
+“Why, he told Jeff Thatcher, and Jeff told Johnny Baker, and Johnny
+told Jim Hollis, and Jim told Ben Rogers, and Ben told a nigger, and the
+nigger told me. There now!”
+
+“Well, what of it? They’ll all lie. Leastways all but the nigger. I
+don’t know _him_. But I never see a nigger that _wouldn’t_ lie. Shucks!
+Now you tell me how Bob Tanner done it, Huck.”
+
+“Why, he took and dipped his hand in a rotten stump where the rain-water
+was.”
+
+“In the daytime?”
+
+“Certainly.”
+
+“With his face to the stump?”
+
+“Yes. Least I reckon so.”
+
+“Did he say anything?”
+
+“I don’t reckon he did. I don’t know.”
+
+“Aha! Talk about trying to cure warts with spunk-water such a blame fool
+way as that! Why, that ain’t a-going to do any good. You got to go all
+by yourself, to the middle of the woods, where you know there’s a
+spunk-water stump, and just as it’s midnight you back up against the stump
+and jam your hand in and say:
+
+‘Barley-corn, barley-corn, injun-meal shorts, Spunk-water, spunk-water,
+swaller these warts,’
+
+and then walk away quick, eleven steps, with your eyes shut, and then
+turn around three times and walk home without speaking to anybody.
+Because if you speak the charm’s busted.”
+
+“Well, that sounds like a good way; but that ain’t the way Bob Tanner
+done.”
+
+“No, sir, you can bet he didn’t, becuz he’s the wartiest boy in this
+town; and he wouldn’t have a wart on him if he’d knowed how to work
+spunk-water. I’ve took off thousands of warts off of my hands that way,
+Huck. I play with frogs so much that I’ve always got considerable many
+warts. Sometimes I take ‘em off with a bean.”
+
+“Yes, bean’s good. I’ve done that.”
+
+“Have you? What’s your way?”
+
+“You take and split the bean, and cut the wart so as to get some blood,
+and then you put the blood on one piece of the bean and take and dig
+a hole and bury it ‘bout midnight at the crossroads in the dark of the
+moon, and then you burn up the rest of the bean. You see that piece
+that’s got the blood on it will keep drawing and drawing, trying to
+fetch the other piece to it, and so that helps the blood to draw the
+wart, and pretty soon off she comes.”
+
+“Yes, that’s it, Huck--that’s it; though when you’re burying it if you
+say ‘Down bean; off wart; come no more to bother me!’ it’s better.
+That’s the way Joe Harper does, and he’s been nearly to Coonville and
+most everywheres. But say--how do you cure ‘em with dead cats?”
+
+“Why, you take your cat and go and get in the grave-yard ‘long about
+midnight when somebody that was wicked has been buried; and when it’s
+midnight a devil will come, or maybe two or three, but you can’t see
+‘em, you can only hear something like the wind, or maybe hear ‘em talk;
+and when they’re taking that feller away, you heave your cat after ‘em
+and say, ‘Devil follow corpse, cat follow devil, warts follow cat, I’m
+done with ye!’ That’ll fetch _any_ wart.”
+
+“Sounds right. D’you ever try it, Huck?”
+
+“No, but old Mother Hopkins told me.”
+
+“Well, I reckon it’s so, then. Becuz they say she’s a witch.”
+
+“Say! Why, Tom, I _know_ she is. She witched pap. Pap says so his own
+self. He come along one day, and he see she was a-witching him, so he
+took up a rock, and if she hadn’t dodged, he’d a got her. Well, that
+very night he rolled off’n a shed wher’ he was a layin drunk, and broke
+his arm.”
+
+“Why, that’s awful. How did he know she was a-witching him?”
+
+“Lord, pap can tell, easy. Pap says when they keep looking at you right
+stiddy, they’re a-witching you. Specially if they mumble. Becuz when
+they mumble they’re saying the Lord’s Prayer backards.”
+
+“Say, Hucky, when you going to try the cat?”
+
+“To-night. I reckon they’ll come after old Hoss Williams to-night.”
+
+“But they buried him Saturday. Didn’t they get him Saturday night?”
+
+“Why, how you talk! How could their charms work till midnight?--and
+_then_ it’s Sunday. Devils don’t slosh around much of a Sunday, I don’t
+reckon.”
+
+“I never thought of that. That’s so. Lemme go with you?”
+
+“Of course--if you ain’t afeard.”
+
+“Afeard! ‘Tain’t likely. Will you meow?”
+
+“Yes--and you meow back, if you get a chance. Last time, you kep’ me
+a-meowing around till old Hays went to throwing rocks at me and says
+‘Dern that cat!’ and so I hove a brick through his window--but don’t you
+tell.”
+
+“I won’t. I couldn’t meow that night, becuz auntie was watching me, but
+I’ll meow this time. Say--what’s that?”
+
+“Nothing but a tick.”
+
+“Where’d you get him?”
+
+“Out in the woods.”
+
+“What’ll you take for him?”
+
+“I don’t know. I don’t want to sell him.”
+
+“All right. It’s a mighty small tick, anyway.”
+
+“Oh, anybody can run a tick down that don’t belong to them. I’m
+satisfied with it. It’s a good enough tick for me.”
+
+“Sho, there’s ticks a plenty. I could have a thousand of ‘em if I wanted
+to.”
+
+“Well, why don’t you? Becuz you know mighty well you can’t. This is a
+pretty early tick, I reckon. It’s the first one I’ve seen this year.”
+
+“Say, Huck--I’ll give you my tooth for him.”
+
+“Less see it.”
+
+Tom got out a bit of paper and carefully unrolled it. Huckleberry viewed
+it wistfully. The temptation was very strong. At last he said:
+
+“Is it genuwyne?”
+
+Tom lifted his lip and showed the vacancy.
+
+“Well, all right,” said Huckleberry, “it’s a trade.”
+
+Tom enclosed the tick in the percussion-cap box that had lately been the
+pinchbug’s prison, and the boys separated, each feeling wealthier than
+before.
+
+When Tom reached the little isolated frame school-house, he strode in
+briskly, with the manner of one who had come with all honest speed. He
+hung his hat on a peg and flung himself into his seat with business-like
+alacrity. The master, throned on high in his great splint-bottom
+arm-chair, was dozing, lulled by the drowsy hum of study. The
+interruption roused him.
+
+“Thomas Sawyer!”
+
+Tom knew that when his name was pronounced in full, it meant trouble.
+
+“Sir!”
+
+“Come up here. Now, sir, why are you late again, as usual?”
+
+Tom was about to take refuge in a lie, when he saw two long tails of
+yellow hair hanging down a back that he recognized by the electric
+sympathy of love; and by that form was _the only vacant place_ on the
+girls’ side of the school-house. He instantly said:
+
+“_I stopped to talk with Huckleberry Finn!_”
+
+The master’s pulse stood still, and he stared helplessly. The buzz of
+study ceased. The pupils wondered if this foolhardy boy had lost his
+mind. The master said:
+
+“You--you did what?”
+
+“Stopped to talk with Huckleberry Finn.”
+
+There was no mistaking the words.
+
+“Thomas Sawyer, this is the most astounding confession I have ever
+listened to. No mere ferule will answer for this offence. Take off your
+jacket.”
+
+The master’s arm performed until it was tired and the stock of switches
+notably diminished. Then the order followed:
+
+“Now, sir, go and sit with the girls! And let this be a warning to you.”
+
+The titter that rippled around the room appeared to abash the boy, but
+in reality that result was caused rather more by his worshipful awe
+of his unknown idol and the dread pleasure that lay in his high good
+fortune. He sat down upon the end of the pine bench and the girl hitched
+herself away from him with a toss of her head. Nudges and winks and
+whispers traversed the room, but Tom sat still, with his arms upon the
+long, low desk before him, and seemed to study his book.
+
+By and by attention ceased from him, and the accustomed school murmur
+rose upon the dull air once more. Presently the boy began to steal
+furtive glances at the girl. She observed it, “made a mouth” at him
+and gave him the back of her head for the space of a minute. When she
+cautiously faced around again, a peach lay before her. She thrust it
+away. Tom gently put it back. She thrust it away again, but with less
+animosity. Tom patiently returned it to its place. Then she let it
+remain. Tom scrawled on his slate, “Please take it--I got more.” The
+girl glanced at the words, but made no sign. Now the boy began to draw
+something on the slate, hiding his work with his left hand. For a time
+the girl refused to notice; but her human curiosity presently began
+to manifest itself by hardly perceptible signs. The boy worked on,
+apparently unconscious. The girl made a sort of non-committal attempt
+to see, but the boy did not betray that he was aware of it. At last she
+gave in and hesitatingly whispered:
+
+“Let me see it.”
+
+Tom partly uncovered a dismal caricature of a house with two gable ends
+to it and a corkscrew of smoke issuing from the chimney. Then the girl’s
+interest began to fasten itself upon the work and she forgot everything
+else. When it was finished, she gazed a moment, then whispered:
+
+“It’s nice--make a man.”
+
+The artist erected a man in the front yard, that resembled a derrick. He
+could have stepped over the house; but the girl was not hypercritical;
+she was satisfied with the monster, and whispered:
+
+“It’s a beautiful man--now make me coming along.”
+
+Tom drew an hour-glass with a full moon and straw limbs to it and armed
+the spreading fingers with a portentous fan. The girl said:
+
+“It’s ever so nice--I wish I could draw.”
+
+“It’s easy,” whispered Tom, “I’ll learn you.”
+
+“Oh, will you? When?”
+
+“At noon. Do you go home to dinner?”
+
+“I’ll stay if you will.”
+
+“Good--that’s a whack. What’s your name?”
+
+“Becky Thatcher. What’s yours? Oh, I know. It’s Thomas Sawyer.”
+
+“That’s the name they lick me by. I’m Tom when I’m good. You call me
+Tom, will you?”
+
+“Yes.”
+
+Now Tom began to scrawl something on the slate, hiding the words from
+the girl. But she was not backward this time. She begged to see. Tom
+said:
+
+“Oh, it ain’t anything.”
+
+“Yes it is.”
+
+“No it ain’t. You don’t want to see.”
+
+“Yes I do, indeed I do. Please let me.”
+
+“You’ll tell.”
+
+“No I won’t--deed and deed and double deed won’t.”
+
+“You won’t tell anybody at all? Ever, as long as you live?”
+
+“No, I won’t ever tell _any_body. Now let me.”
+
+“Oh, _you_ don’t want to see!”
+
+“Now that you treat me so, I _will_ see.” And she put her small hand
+upon his and a little scuffle ensued, Tom pretending to resist in
+earnest but letting his hand slip by degrees till these words were
+revealed: “_I love you_.”
+
+“Oh, you bad thing!” And she hit his hand a smart rap, but reddened and
+looked pleased, nevertheless.
+
+Just at this juncture the boy felt a slow, fateful grip closing on his
+ear, and a steady lifting impulse. In that wise he was borne across the
+house and deposited in his own seat, under a peppering fire of giggles
+from the whole school. Then the master stood over him during a few awful
+moments, and finally moved away to his throne without saying a word. But
+although Tom’s ear tingled, his heart was jubilant.
+
+As the school quieted down Tom made an honest effort to study, but
+the turmoil within him was too great. In turn he took his place in the
+reading class and made a botch of it; then in the geography class and
+turned lakes into mountains, mountains into rivers, and rivers into
+continents, till chaos was come again; then in the spelling class, and
+got “turned down,” by a succession of mere baby words, till he brought
+up at the foot and yielded up the pewter medal which he had worn with
+ostentation for months.
+
+
+
+
+CHAPTER VII
+
+THE harder Tom tried to fasten his mind on his book, the more his ideas
+wandered. So at last, with a sigh and a yawn, he gave it up. It seemed
+to him that the noon recess would never come. The air was utterly dead.
+There was not a breath stirring. It was the sleepiest of sleepy days.
+The drowsing murmur of the five and twenty studying scholars soothed
+the soul like the spell that is in the murmur of bees. Away off in the
+flaming sunshine, Cardiff Hill lifted its soft green sides through a
+shimmering veil of heat, tinted with the purple of distance; a few birds
+floated on lazy wing high in the air; no other living thing was visible
+but some cows, and they were asleep. Tom’s heart ached to be free, or
+else to have something of interest to do to pass the dreary time.
+His hand wandered into his pocket and his face lit up with a glow of
+gratitude that was prayer, though he did not know it. Then furtively
+the percussion-cap box came out. He released the tick and put him on
+the long flat desk. The creature probably glowed with a gratitude that
+amounted to prayer, too, at this moment, but it was premature: for when
+he started thankfully to travel off, Tom turned him aside with a pin and
+made him take a new direction.
+
+Tom’s bosom friend sat next him, suffering just as Tom had been, and
+now he was deeply and gratefully interested in this entertainment in
+an instant. This bosom friend was Joe Harper. The two boys were sworn
+friends all the week, and embattled enemies on Saturdays. Joe took a
+pin out of his lapel and began to assist in exercising the prisoner.
+The sport grew in interest momently. Soon Tom said that they were
+interfering with each other, and neither getting the fullest benefit
+of the tick. So he put Joe’s slate on the desk and drew a line down the
+middle of it from top to bottom.
+
+“Now,” said he, “as long as he is on your side you can stir him up and
+I’ll let him alone; but if you let him get away and get on my side,
+you’re to leave him alone as long as I can keep him from crossing over.”
+
+“All right, go ahead; start him up.”
+
+The tick escaped from Tom, presently, and crossed the equator. Joe
+harassed him awhile, and then he got away and crossed back again. This
+change of base occurred often. While one boy was worrying the tick with
+absorbing interest, the other would look on with interest as strong, the
+two heads bowed together over the slate, and the two souls dead to all
+things else. At last luck seemed to settle and abide with Joe. The
+tick tried this, that, and the other course, and got as excited and as
+anxious as the boys themselves, but time and again just as he would
+have victory in his very grasp, so to speak, and Tom’s fingers would
+be twitching to begin, Joe’s pin would deftly head him off, and keep
+possession. At last Tom could stand it no longer. The temptation was too
+strong. So he reached out and lent a hand with his pin. Joe was angry in
+a moment. Said he:
+
+“Tom, you let him alone.”
+
+“I only just want to stir him up a little, Joe.”
+
+“No, sir, it ain’t fair; you just let him alone.”
+
+“Blame it, I ain’t going to stir him much.”
+
+“Let him alone, I tell you.”
+
+“I won’t!”
+
+“You shall--he’s on my side of the line.”
+
+“Look here, Joe Harper, whose is that tick?”
+
+“I don’t care whose tick he is--he’s on my side of the line, and you
+sha’n’t touch him.”
+
+“Well, I’ll just bet I will, though. He’s my tick and I’ll do what I
+blame please with him, or die!”
+
+A tremendous whack came down on Tom’s shoulders, and its duplicate on
+Joe’s; and for the space of two minutes the dust continued to fly from
+the two jackets and the whole school to enjoy it. The boys had been
+too absorbed to notice the hush that had stolen upon the school awhile
+before when the master came tiptoeing down the room and stood over them.
+He had contemplated a good part of the performance before he contributed
+his bit of variety to it.
+
+When school broke up at noon, Tom flew to Becky Thatcher, and whispered
+in her ear:
+
+“Put on your bonnet and let on you’re going home; and when you get to
+the corner, give the rest of ‘em the slip, and turn down through the
+lane and come back. I’ll go the other way and come it over ‘em the same
+way.”
+
+So the one went off with one group of scholars, and the other with
+another. In a little while the two met at the bottom of the lane, and
+when they reached the school they had it all to themselves. Then they
+sat together, with a slate before them, and Tom gave Becky the pencil
+and held her hand in his, guiding it, and so created another surprising
+house. When the interest in art began to wane, the two fell to talking.
+Tom was swimming in bliss. He said:
+
+“Do you love rats?”
+
+“No! I hate them!”
+
+“Well, I do, too--_live_ ones. But I mean dead ones, to swing round your
+head with a string.”
+
+“No, I don’t care for rats much, anyway. What I like is chewing-gum.”
+
+“Oh, I should say so! I wish I had some now.”
+
+“Do you? I’ve got some. I’ll let you chew it awhile, but you must give
+it back to me.”
+
+That was agreeable, so they chewed it turn about, and dangled their legs
+against the bench in excess of contentment.
+
+“Was you ever at a circus?” said Tom.
+
+“Yes, and my pa’s going to take me again some time, if I’m good.”
+
+“I been to the circus three or four times--lots of times. Church ain’t
+shucks to a circus. There’s things going on at a circus all the time.
+I’m going to be a clown in a circus when I grow up.”
+
+“Oh, are you! That will be nice. They’re so lovely, all spotted up.”
+
+“Yes, that’s so. And they get slathers of money--most a dollar a day, Ben
+Rogers says. Say, Becky, was you ever engaged?”
+
+“What’s that?”
+
+“Why, engaged to be married.”
+
+“No.”
+
+“Would you like to?”
+
+“I reckon so. I don’t know. What is it like?”
+
+“Like? Why it ain’t like anything. You only just tell a boy you won’t
+ever have anybody but him, ever ever ever, and then you kiss and that’s
+all. Anybody can do it.”
+
+“Kiss? What do you kiss for?”
+
+“Why, that, you know, is to--well, they always do that.”
+
+“Everybody?”
+
+“Why, yes, everybody that’s in love with each other. Do you remember
+what I wrote on the slate?”
+
+“Ye--yes.”
+
+“What was it?”
+
+“I sha’n’t tell you.”
+
+“Shall I tell _you_?”
+
+“Ye--yes--but some other time.”
+
+“No, now.”
+
+“No, not now--to-morrow.”
+
+“Oh, no, _now_. Please, Becky--I’ll whisper it, I’ll whisper it ever so
+easy.”
+
+Becky hesitating, Tom took silence for consent, and passed his arm about
+her waist and whispered the tale ever so softly, with his mouth close to
+her ear. And then he added:
+
+“Now you whisper it to me--just the same.”
+
+She resisted, for a while, and then said:
+
+“You turn your face away so you can’t see, and then I will. But you
+mustn’t ever tell anybody--_will_ you, Tom? Now you won’t, _will_ you?”
+
+“No, indeed, indeed I won’t. Now, Becky.”
+
+He turned his face away. She bent timidly around till her breath stirred
+his curls and whispered, “I--love--you!”
+
+Then she sprang away and ran around and around the desks and benches,
+with Tom after her, and took refuge in a corner at last, with her little
+white apron to her face. Tom clasped her about her neck and pleaded:
+
+“Now, Becky, it’s all done--all over but the kiss. Don’t you be afraid
+of that--it ain’t anything at all. Please, Becky.” And he tugged at her
+apron and the hands.
+
+By and by she gave up, and let her hands drop; her face, all glowing
+with the struggle, came up and submitted. Tom kissed the red lips and
+said:
+
+“Now it’s all done, Becky. And always after this, you know, you ain’t
+ever to love anybody but me, and you ain’t ever to marry anybody but me,
+ever never and forever. Will you?”
+
+“No, I’ll never love anybody but you, Tom, and I’ll never marry anybody
+but you--and you ain’t to ever marry anybody but me, either.”
+
+“Certainly. Of course. That’s _part_ of it. And always coming to school
+or when we’re going home, you’re to walk with me, when there ain’t
+anybody looking--and you choose me and I choose you at parties, because
+that’s the way you do when you’re engaged.”
+
+“It’s so nice. I never heard of it before.”
+
+“Oh, it’s ever so gay! Why, me and Amy Lawrence--”
+
+The big eyes told Tom his blunder and he stopped, confused.
+
+“Oh, Tom! Then I ain’t the first you’ve ever been engaged to!”
+
+The child began to cry. Tom said:
+
+“Oh, don’t cry, Becky, I don’t care for her any more.”
+
+“Yes, you do, Tom--you know you do.”
+
+Tom tried to put his arm about her neck, but she pushed him away and
+turned her face to the wall, and went on crying. Tom tried again, with
+soothing words in his mouth, and was repulsed again. Then his pride was
+up, and he strode away and went outside. He stood about, restless and
+uneasy, for a while, glancing at the door, every now and then, hoping
+she would repent and come to find him. But she did not. Then he began
+to feel badly and fear that he was in the wrong. It was a hard struggle
+with him to make new advances, now, but he nerved himself to it and
+entered. She was still standing back there in the corner, sobbing, with
+her face to the wall. Tom’s heart smote him. He went to her and stood a
+moment, not knowing exactly how to proceed. Then he said hesitatingly:
+
+“Becky, I--I don’t care for anybody but you.”
+
+No reply--but sobs.
+
+“Becky”--pleadingly. “Becky, won’t you say something?”
+
+More sobs.
+
+Tom got out his chiefest jewel, a brass knob from the top of an andiron,
+and passed it around her so that she could see it, and said:
+
+“Please, Becky, won’t you take it?”
+
+She struck it to the floor. Then Tom marched out of the house and over
+the hills and far away, to return to school no more that day. Presently
+Becky began to suspect. She ran to the door; he was not in sight; she
+flew around to the play-yard; he was not there. Then she called:
+
+“Tom! Come back, Tom!”
+
+She listened intently, but there was no answer. She had no companions
+but silence and loneliness. So she sat down to cry again and upbraid
+herself; and by this time the scholars began to gather again, and she
+had to hide her griefs and still her broken heart and take up the cross
+of a long, dreary, aching afternoon, with none among the strangers about
+her to exchange sorrows with.
+
+
+
+
+CHAPTER VIII
+
+TOM dodged hither and thither through lanes until he was well out of the
+track of returning scholars, and then fell into a moody jog. He crossed
+a small “branch” two or three times, because of a prevailing juvenile
+superstition that to cross water baffled pursuit. Half an hour later
+he was disappearing behind the Douglas mansion on the summit of Cardiff
+Hill, and the school-house was hardly distinguishable away off in the
+valley behind him. He entered a dense wood, picked his pathless way to
+the centre of it, and sat down on a mossy spot under a spreading oak.
+There was not even a zephyr stirring; the dead noonday heat had even
+stilled the songs of the birds; nature lay in a trance that was broken
+by no sound but the occasional far-off hammering of a wood-pecker, and
+this seemed to render the pervading silence and sense of loneliness the
+more profound. The boy’s soul was steeped in melancholy; his feelings
+were in happy accord with his surroundings. He sat long with his elbows
+on his knees and his chin in his hands, meditating. It seemed to him
+that life was but a trouble, at best, and he more than half envied Jimmy
+Hodges, so lately released; it must be very peaceful, he thought, to lie
+and slumber and dream forever and ever, with the wind whispering through
+the trees and caressing the grass and the flowers over the grave, and
+nothing to bother and grieve about, ever any more. If he only had a
+clean Sunday-school record he could be willing to go, and be done with
+it all. Now as to this girl. What had he done? Nothing. He had meant
+the best in the world, and been treated like a dog--like a very dog. She
+would be sorry some day--maybe when it was too late. Ah, if he could only
+die _temporarily_!
+
+But the elastic heart of youth cannot be compressed into one constrained
+shape long at a time. Tom presently began to drift insensibly back into
+the concerns of this life again. What if he turned his back, now, and
+disappeared mysteriously? What if he went away--ever so far away, into
+unknown countries beyond the seas--and never came back any more! How
+would she feel then! The idea of being a clown recurred to him now, only
+to fill him with disgust. For frivolity and jokes and spotted tights
+were an offense, when they intruded themselves upon a spirit that was
+exalted into the vague august realm of the romantic. No, he would be
+a soldier, and return after long years, all war-worn and illustrious.
+No--better still, he would join the Indians, and hunt buffaloes and go on
+the warpath in the mountain ranges and the trackless great plains of the
+Far West, and away in the future come back a great chief, bristling with
+feathers, hideous with paint, and prance into Sunday-school, some drowsy
+summer morning, with a blood-curdling war-whoop, and sear the eyeballs
+of all his companions with unappeasable envy. But no, there was
+something gaudier even than this. He would be a pirate! That was it!
+_now_ his future lay plain before him, and glowing with unimaginable
+splendor. How his name would fill the world, and make people shudder!
+How gloriously he would go plowing the dancing seas, in his long, low,
+black-hulled racer, the Spirit of the Storm, with his grisly flag flying
+at the fore! And at the zenith of his fame, how he would suddenly appear
+at the old village and stalk into church, brown and weather-beaten, in
+his black velvet doublet and trunks, his great jack-boots, his crimson
+sash, his belt bristling with horse-pistols, his crime-rusted cutlass
+at his side, his slouch hat with waving plumes, his black flag unfurled,
+with the skull and crossbones on it, and hear with swelling ecstasy
+the whisperings, “It’s Tom Sawyer the Pirate!--the Black Avenger of the
+Spanish Main!”
+
+Yes, it was settled; his career was determined. He would run away from
+home and enter upon it. He would start the very next morning. Therefore
+he must now begin to get ready. He would collect his resources together.
+He went to a rotten log near at hand and began to dig under one end of
+it with his Barlow knife. He soon struck wood that sounded hollow. He
+put his hand there and uttered this incantation impressively:
+
+“What hasn’t come here, come! What’s here, stay here!”
+
+Then he scraped away the dirt, and exposed a pine shingle. He took it
+up and disclosed a shapely little treasure-house whose bottom and sides
+were of shingles. In it lay a marble. Tom’s astonishment was bound-less!
+He scratched his head with a perplexed air, and said:
+
+“Well, that beats anything!”
+
+Then he tossed the marble away pettishly, and stood cogitating. The
+truth was, that a superstition of his had failed, here, which he and
+all his comrades had always looked upon as infallible. If you buried
+a marble with certain necessary incantations, and left it alone a
+fortnight, and then opened the place with the incantation he had just
+used, you would find that all the marbles you had ever lost had gathered
+themselves together there, meantime, no matter how widely they had been
+separated. But now, this thing had actually and unquestionably failed.
+Tom’s whole structure of faith was shaken to its foundations. He had
+many a time heard of this thing succeeding but never of its failing
+before. It did not occur to him that he had tried it several times
+before, himself, but could never find the hiding-places afterward. He
+puzzled over the matter some time, and finally decided that some witch
+had interfered and broken the charm. He thought he would satisfy himself
+on that point; so he searched around till he found a small sandy spot
+with a little funnel-shaped depression in it. He laid himself down and
+put his mouth close to this depression and called--
+
+“Doodle-bug, doodle-bug, tell me what I want to know! Doodle-bug,
+doodle-bug, tell me what I want to know!”
+
+The sand began to work, and presently a small black bug appeared for a
+second and then darted under again in a fright.
+
+“He dasn’t tell! So it _was_ a witch that done it. I just knowed it.”
+
+He well knew the futility of trying to contend against witches, so he
+gave up discouraged. But it occurred to him that he might as well have
+the marble he had just thrown away, and therefore he went and made a
+patient search for it. But he could not find it. Now he went back to his
+treasure-house and carefully placed himself just as he had been standing
+when he tossed the marble away; then he took another marble from his
+pocket and tossed it in the same way, saying:
+
+“Brother, go find your brother!”
+
+He watched where it stopped, and went there and looked. But it must
+have fallen short or gone too far; so he tried twice more. The last
+repetition was successful. The two marbles lay within a foot of each
+other.
+
+Just here the blast of a toy tin trumpet came faintly down the green
+aisles of the forest. Tom flung off his jacket and trousers, turned
+a suspender into a belt, raked away some brush behind the rotten log,
+disclosing a rude bow and arrow, a lath sword and a tin trumpet, and
+in a moment had seized these things and bounded away, barelegged,
+with fluttering shirt. He presently halted under a great elm, blew an
+answering blast, and then began to tiptoe and look warily out, this way
+and that. He said cautiously--to an imaginary company:
+
+“Hold, my merry men! Keep hid till I blow.”
+
+Now appeared Joe Harper, as airily clad and elaborately armed as Tom.
+Tom called:
+
+“Hold! Who comes here into Sherwood Forest without my pass?”
+
+“Guy of Guisborne wants no man’s pass. Who art thou that--that--”
+
+“Dares to hold such language,” said Tom, prompting--for they talked “by
+the book,” from memory.
+
+“Who art thou that dares to hold such language?”
+
+“I, indeed! I am Robin Hood, as thy caitiff carcase soon shall know.”
+
+“Then art thou indeed that famous outlaw? Right gladly will I dispute
+with thee the passes of the merry wood. Have at thee!”
+
+They took their lath swords, dumped their other traps on the ground,
+struck a fencing attitude, foot to foot, and began a grave, careful
+combat, “two up and two down.” Presently Tom said:
+
+“Now, if you’ve got the hang, go it lively!”
+
+So they “went it lively,” panting and perspiring with the work. By and
+by Tom shouted:
+
+“Fall! fall! Why don’t you fall?”
+
+“I sha’n’t! Why don’t you fall yourself? You’re getting the worst of
+it.”
+
+“Why, that ain’t anything. I can’t fall; that ain’t the way it is in the
+book. The book says, ‘Then with one back-handed stroke he slew poor Guy
+of Guisborne.’ You’re to turn around and let me hit you in the back.”
+
+There was no getting around the authorities, so Joe turned, received the
+whack and fell.
+
+“Now,” said Joe, getting up, “you got to let me kill _you_. That’s
+fair.”
+
+“Why, I can’t do that, it ain’t in the book.”
+
+“Well, it’s blamed mean--that’s all.”
+
+“Well, say, Joe, you can be Friar Tuck or Much the miller’s son, and lam
+me with a quarter-staff; or I’ll be the Sheriff of Nottingham and you be
+Robin Hood a little while and kill me.”
+
+This was satisfactory, and so these adventures were carried out. Then
+Tom became Robin Hood again, and was allowed by the treacherous nun to
+bleed his strength away through his neglected wound. And at last Joe,
+representing a whole tribe of weeping outlaws, dragged him sadly forth,
+gave his bow into his feeble hands, and Tom said, “Where this arrow
+falls, there bury poor Robin Hood under the greenwood tree.” Then he
+shot the arrow and fell back and would have died, but he lit on a nettle
+and sprang up too gaily for a corpse.
+
+The boys dressed themselves, hid their accoutrements, and went off
+grieving that there were no outlaws any more, and wondering what modern
+civilization could claim to have done to compensate for their loss.
+They said they would rather be outlaws a year in Sherwood Forest than
+President of the United States forever.
+
+
+
+
+CHAPTER IX
+
+AT half-past nine, that night, Tom and Sid were sent to bed, as usual.
+They said their prayers, and Sid was soon asleep. Tom lay awake and
+waited, in restless impatience. When it seemed to him that it must be
+nearly daylight, he heard the clock strike ten! This was despair. He
+would have tossed and fidgeted, as his nerves demanded, but he was
+afraid he might wake Sid. So he lay still, and stared up into the dark.
+Everything was dismally still. By and by, out of the stillness, little,
+scarcely perceptible noises began to emphasize themselves. The ticking
+of the clock began to bring itself into notice. Old beams began to crack
+mysteriously. The stairs creaked faintly. Evidently spirits were abroad.
+A measured, muffled snore issued from Aunt Polly’s chamber. And now the
+tiresome chirping of a cricket that no human ingenuity could locate,
+began. Next the ghastly ticking of a death-watch in the wall at the
+bed’s head made Tom shudder--it meant that somebody’s days were numbered.
+Then the howl of a far-off dog rose on the night air, and was answered
+by a fainter howl from a remoter distance. Tom was in an agony. At last
+he was satisfied that time had ceased and eternity begun; he began to
+doze, in spite of himself; the clock chimed eleven, but he did not hear
+it. And then there came, mingling with his half-formed dreams, a most
+melancholy caterwauling. The raising of a neighboring window disturbed
+him. A cry of “Scat! you devil!” and the crash of an empty bottle
+against the back of his aunt’s woodshed brought him wide awake, and a
+single minute later he was dressed and out of the window and creeping
+along the roof of the “ell” on all fours. He “meow’d” with caution once
+or twice, as he went; then jumped to the roof of the woodshed and thence
+to the ground. Huckleberry Finn was there, with his dead cat. The boys
+moved off and disappeared in the gloom. At the end of half an hour they
+were wading through the tall grass of the graveyard.
+
+It was a graveyard of the old-fashioned Western kind. It was on a hill,
+about a mile and a half from the village. It had a crazy board fence
+around it, which leaned inward in places, and outward the rest of the
+time, but stood upright nowhere. Grass and weeds grew rank over the
+whole cemetery. All the old graves were sunken in, there was not a
+tombstone on the place; round-topped, worm-eaten boards staggered over
+the graves, leaning for support and finding none. “Sacred to the memory
+of” So-and-So had been painted on them once, but it could no longer have
+been read, on the most of them, now, even if there had been light.
+
+A faint wind moaned through the trees, and Tom feared it might be the
+spirits of the dead, complaining at being disturbed. The boys talked
+little, and only under their breath, for the time and the place and the
+pervading solemnity and silence oppressed their spirits. They found the
+sharp new heap they were seeking, and ensconced themselves within the
+protection of three great elms that grew in a bunch within a few feet of
+the grave.
+
+Then they waited in silence for what seemed a long time. The hooting of
+a distant owl was all the sound that troubled the dead stillness. Tom’s
+reflections grew oppressive. He must force some talk. So he said in a
+whisper:
+
+“Hucky, do you believe the dead people like it for us to be here?”
+
+Huckleberry whispered:
+
+“I wisht I knowed. It’s awful solemn like, _ain’t_ it?”
+
+“I bet it is.”
+
+There was a considerable pause, while the boys canvassed this matter
+inwardly. Then Tom whispered:
+
+“Say, Hucky--do you reckon Hoss Williams hears us talking?”
+
+“O’ course he does. Least his sperrit does.”
+
+Tom, after a pause:
+
+“I wish I’d said Mister Williams. But I never meant any harm. Everybody
+calls him Hoss.”
+
+“A body can’t be too partic’lar how they talk ‘bout these-yer dead
+people, Tom.”
+
+This was a damper, and conversation died again.
+
+Presently Tom seized his comrade’s arm and said:
+
+“Sh!”
+
+“What is it, Tom?” And the two clung together with beating hearts.
+
+“Sh! There ‘tis again! Didn’t you hear it?”
+
+“I--”
+
+“There! Now you hear it.”
+
+“Lord, Tom, they’re coming! They’re coming, sure. What’ll we do?”
+
+“I dono. Think they’ll see us?”
+
+“Oh, Tom, they can see in the dark, same as cats. I wisht I hadn’t
+come.”
+
+“Oh, don’t be afeard. I don’t believe they’ll bother us. We ain’t doing
+any harm. If we keep perfectly still, maybe they won’t notice us at
+all.”
+
+“I’ll try to, Tom, but, Lord, I’m all of a shiver.”
+
+“Listen!”
+
+The boys bent their heads together and scarcely breathed. A muffled
+sound of voices floated up from the far end of the graveyard.
+
+“Look! See there!” whispered Tom. “What is it?”
+
+“It’s devil-fire. Oh, Tom, this is awful.”
+
+Some vague figures approached through the gloom, swinging an
+old-fashioned tin lantern that freckled the ground with innumerable
+little spangles of light. Presently Huckleberry whispered with a
+shudder:
+
+“It’s the devils sure enough. Three of ‘em! Lordy, Tom, we’re goners!
+Can you pray?”
+
+“I’ll try, but don’t you be afeard. They ain’t going to hurt us. ‘Now I
+lay me down to sleep, I--’”
+
+“Sh!”
+
+“What is it, Huck?”
+
+“They’re _humans_! One of ‘em is, anyway. One of ‘em’s old Muff Potter’s
+voice.”
+
+“No--‘tain’t so, is it?”
+
+“I bet I know it. Don’t you stir nor budge. He ain’t sharp enough to
+notice us. Drunk, the same as usual, likely--blamed old rip!”
+
+“All right, I’ll keep still. Now they’re stuck. Can’t find it. Here they
+come again. Now they’re hot. Cold again. Hot again. Red hot! They’re
+p’inted right, this time. Say, Huck, I know another o’ them voices; it’s
+Injun Joe.”
+
+“That’s so--that murderin’ half-breed! I’d druther they was devils a dern
+sight. What kin they be up to?”
+
+The whisper died wholly out, now, for the three men had reached the
+grave and stood within a few feet of the boys’ hiding-place.
+
+“Here it is,” said the third voice; and the owner of it held the lantern
+up and revealed the face of young Doctor Robinson.
+
+Potter and Injun Joe were carrying a handbarrow with a rope and a couple
+of shovels on it. They cast down their load and began to open the grave.
+The doctor put the lantern at the head of the grave and came and sat
+down with his back against one of the elm trees. He was so close the
+boys could have touched him.
+
+“Hurry, men!” he said, in a low voice; “the moon might come out at any
+moment.”
+
+They growled a response and went on digging. For some time there was no
+noise but the grating sound of the spades discharging their freight of
+mould and gravel. It was very monotonous. Finally a spade struck upon
+the coffin with a dull woody accent, and within another minute or two
+the men had hoisted it out on the ground. They pried off the lid with
+their shovels, got out the body and dumped it rudely on the ground. The
+moon drifted from behind the clouds and exposed the pallid face.
+The barrow was got ready and the corpse placed on it, covered with a
+blanket, and bound to its place with the rope. Potter took out a large
+spring-knife and cut off the dangling end of the rope and then said:
+
+“Now the cussed thing’s ready, Sawbones, and you’ll just out with
+another five, or here she stays.”
+
+“That’s the talk!” said Injun Joe.
+
+“Look here, what does this mean?” said the doctor. “You required your
+pay in advance, and I’ve paid you.”
+
+“Yes, and you done more than that,” said Injun Joe, approaching the
+doctor, who was now standing. “Five years ago you drove me away from
+your father’s kitchen one night, when I come to ask for something to
+eat, and you said I warn’t there for any good; and when I swore I’d get
+even with you if it took a hundred years, your father had me jailed for
+a vagrant. Did you think I’d forget? The Injun blood ain’t in me for
+nothing. And now I’ve _got_ you, and you got to _settle_, you know!”
+
+He was threatening the doctor, with his fist in his face, by this time.
+The doctor struck out suddenly and stretched the ruffian on the ground.
+Potter dropped his knife, and exclaimed:
+
+“Here, now, don’t you hit my pard!” and the next moment he had grappled
+with the doctor and the two were struggling with might and main,
+trampling the grass and tearing the ground with their heels. Injun Joe
+sprang to his feet, his eyes flaming with passion, snatched up Potter’s
+knife, and went creeping, catlike and stooping, round and round about
+the combatants, seeking an opportunity. All at once the doctor flung
+himself free, seized the heavy headboard of Williams’ grave and felled
+Potter to the earth with it--and in the same instant the half-breed saw
+his chance and drove the knife to the hilt in the young man’s breast. He
+reeled and fell partly upon Potter, flooding him with his blood, and in
+the same moment the clouds blotted out the dreadful spectacle and the
+two frightened boys went speeding away in the dark.
+
+Presently, when the moon emerged again, Injun Joe was standing over the
+two forms, contemplating them. The doctor murmured inarticulately, gave
+a long gasp or two and was still. The half-breed muttered:
+
+“_That_ score is settled--damn you.”
+
+Then he robbed the body. After which he put the fatal knife in Potter’s
+open right hand, and sat down on the dismantled coffin. Three--four--five
+minutes passed, and then Potter began to stir and moan. His hand closed
+upon the knife; he raised it, glanced at it, and let it fall, with a
+shudder. Then he sat up, pushing the body from him, and gazed at it, and
+then around him, confusedly. His eyes met Joe’s.
+
+“Lord, how is this, Joe?” he said.
+
+“It’s a dirty business,” said Joe, without moving.
+
+“What did you do it for?”
+
+“I! I never done it!”
+
+“Look here! That kind of talk won’t wash.”
+
+Potter trembled and grew white.
+
+“I thought I’d got sober. I’d no business to drink to-night. But it’s
+in my head yet--worse’n when we started here. I’m all in a muddle;
+can’t recollect anything of it, hardly. Tell me, Joe--_honest_, now,
+old feller--did I do it? Joe, I never meant to--‘pon my soul and honor, I
+never meant to, Joe. Tell me how it was, Joe. Oh, it’s awful--and him so
+young and promising.”
+
+“Why, you two was scuffling, and he fetched you one with the headboard
+and you fell flat; and then up you come, all reeling and staggering
+like, and snatched the knife and jammed it into him, just as he fetched
+you another awful clip--and here you’ve laid, as dead as a wedge til
+now.”
+
+“Oh, I didn’t know what I was a-doing. I wish I may die this minute if I
+did. It was all on account of the whiskey and the excitement, I reckon.
+I never used a weepon in my life before, Joe. I’ve fought, but never
+with weepons. They’ll all say that. Joe, don’t tell! Say you won’t tell,
+Joe--that’s a good feller. I always liked you, Joe, and stood up for you,
+too. Don’t you remember? You _won’t_ tell, _will_ you, Joe?” And the
+poor creature dropped on his knees before the stolid murderer, and
+clasped his appealing hands.
+
+“No, you’ve always been fair and square with me, Muff Potter, and I
+won’t go back on you. There, now, that’s as fair as a man can say.”
+
+“Oh, Joe, you’re an angel. I’ll bless you for this the longest day I
+live.” And Potter began to cry.
+
+“Come, now, that’s enough of that. This ain’t any time for blubbering.
+You be off yonder way and I’ll go this. Move, now, and don’t leave any
+tracks behind you.”
+
+Potter started on a trot that quickly increased to a run. The half-breed
+stood looking after him. He muttered:
+
+“If he’s as much stunned with the lick and fuddled with the rum as he
+had the look of being, he won’t think of the knife till he’s gone so
+far he’ll be afraid to come back after it to such a place by
+himself--chicken-heart!”
+
+Two or three minutes later the murdered man, the blanketed corpse, the
+lidless coffin, and the open grave were under no inspection but the
+moon’s. The stillness was complete again, too.
+
+
+
+
+CHAPTER X
+
+THE two boys flew on and on, toward the village, speechless with
+horror. They glanced backward over their shoulders from time to time,
+apprehensively, as if they feared they might be followed. Every stump
+that started up in their path seemed a man and an enemy, and made them
+catch their breath; and as they sped by some outlying cottages that lay
+near the village, the barking of the aroused watch-dogs seemed to give
+wings to their feet.
+
+“If we can only get to the old tannery before we break down!” whispered
+Tom, in short catches between breaths. “I can’t stand it much longer.”
+
+Huckleberry’s hard pantings were his only reply, and the boys fixed
+their eyes on the goal of their hopes and bent to their work to win it.
+They gained steadily on it, and at last, breast to breast, they burst
+through the open door and fell grateful and exhausted in the sheltering
+shadows beyond. By and by their pulses slowed down, and Tom whispered:
+
+“Huckleberry, what do you reckon’ll come of this?”
+
+“If Doctor Robinson dies, I reckon hanging’ll come of it.”
+
+“Do you though?”
+
+“Why, I _know_ it, Tom.”
+
+Tom thought a while, then he said:
+
+“Who’ll tell? We?”
+
+“What are you talking about? S’pose something happened and Injun Joe
+_didn’t_ hang? Why, he’d kill us some time or other, just as dead sure
+as we’re a laying here.”
+
+“That’s just what I was thinking to myself, Huck.”
+
+“If anybody tells, let Muff Potter do it, if he’s fool enough. He’s
+generally drunk enough.”
+
+Tom said nothing--went on thinking. Presently he whispered:
+
+“Huck, Muff Potter don’t know it. How can he tell?”
+
+“What’s the reason he don’t know it?”
+
+“Because he’d just got that whack when Injun Joe done it. D’you reckon
+he could see anything? D’you reckon he knowed anything?”
+
+“By hokey, that’s so, Tom!”
+
+“And besides, look-a-here--maybe that whack done for _him_!”
+
+“No, ‘taint likely, Tom. He had liquor in him; I could see that; and
+besides, he always has. Well, when pap’s full, you might take and belt
+him over the head with a church and you couldn’t phase him. He says so,
+his own self. So it’s the same with Muff Potter, of course. But if a man
+was dead sober, I reckon maybe that whack might fetch him; I dono.”
+
+After another reflective silence, Tom said:
+
+“Hucky, you sure you can keep mum?”
+
+“Tom, we _got_ to keep mum. You know that. That Injun devil wouldn’t
+make any more of drownding us than a couple of cats, if we was to squeak
+‘bout this and they didn’t hang him. Now, look-a-here, Tom, less take
+and swear to one another--that’s what we got to do--swear to keep mum.”
+
+“I’m agreed. It’s the best thing. Would you just hold hands and swear
+that we--”
+
+“Oh no, that wouldn’t do for this. That’s good enough for little
+rubbishy common things--specially with gals, cuz _they_ go back on you
+anyway, and blab if they get in a huff--but there orter be writing ‘bout
+a big thing like this. And blood.”
+
+Tom’s whole being applauded this idea. It was deep, and dark, and awful;
+the hour, the circumstances, the surroundings, were in keeping with it.
+He picked up a clean pine shingle that lay in the moon-light, took a
+little fragment of “red keel” out of his pocket, got the moon on
+his work, and painfully scrawled these lines, emphasizing each slow
+down-stroke by clamping his tongue between his teeth, and letting up the
+pressure on the up-strokes. [See next page.]
+
+“Huck Finn and Tom Sawyer swears they will keep mum about This and They
+wish They may Drop down dead in Their Tracks if They ever Tell and Rot.”
+
+Huckleberry was filled with admiration of Tom’s facility in writing, and
+the sublimity of his language. He at once took a pin from his lapel and
+was going to prick his flesh, but Tom said:
+
+“Hold on! Don’t do that. A pin’s brass. It might have verdigrease on
+it.”
+
+“What’s verdigrease?”
+
+“It’s p’ison. That’s what it is. You just swaller some of it once--you’ll
+see.”
+
+So Tom unwound the thread from one of his needles, and each boy pricked
+the ball of his thumb and squeezed out a drop of blood. In time, after
+many squeezes, Tom managed to sign his initials, using the ball of his
+little finger for a pen. Then he showed Huckleberry how to make an H and
+an F, and the oath was complete. They buried the shingle close to the
+wall, with some dismal ceremonies and incantations, and the fetters
+that bound their tongues were considered to be locked and the key thrown
+away.
+
+A figure crept stealthily through a break in the other end of the ruined
+building, now, but they did not notice it.
+
+“Tom,” whispered Huckleberry, “does this keep us from _ever_
+telling--_always_?”
+
+“Of course it does. It don’t make any difference _what_ happens, we got
+to keep mum. We’d drop down dead--don’t _you_ know that?”
+
+“Yes, I reckon that’s so.”
+
+They continued to whisper for some little time. Presently a dog set up
+a long, lugubrious howl just outside--within ten feet of them. The boys
+clasped each other suddenly, in an agony of fright.
+
+“Which of us does he mean?” gasped Huckleberry.
+
+“I dono--peep through the crack. Quick!”
+
+“No, _you_, Tom!”
+
+“I can’t--I can’t _do_ it, Huck!”
+
+“Please, Tom. There ‘tis again!”
+
+“Oh, lordy, I’m thankful!” whispered Tom. “I know his voice. It’s Bull
+Harbison.” *
+
+[* If Mr. Harbison owned a slave named Bull, Tom would have spoken of
+him as “Harbison’s Bull,” but a son or a dog of that name was “Bull
+Harbison.”]
+
+“Oh, that’s good--I tell you, Tom, I was most scared to death; I’d a bet
+anything it was a _stray_ dog.”
+
+The dog howled again. The boys’ hearts sank once more.
+
+“Oh, my! that ain’t no Bull Harbison!” whispered Huckleberry. “_Do_,
+Tom!”
+
+Tom, quaking with fear, yielded, and put his eye to the crack. His
+whisper was hardly audible when he said:
+
+“Oh, Huck, _its a stray dog_!”
+
+“Quick, Tom, quick! Who does he mean?”
+
+“Huck, he must mean us both--we’re right together.”
+
+“Oh, Tom, I reckon we’re goners. I reckon there ain’t no mistake ‘bout
+where _I’ll_ go to. I been so wicked.”
+
+“Dad fetch it! This comes of playing hookey and doing everything a
+feller’s told _not_ to do. I might a been good, like Sid, if I’d a
+tried--but no, I wouldn’t, of course. But if ever I get off this time,
+I lay I’ll just _waller_ in Sunday-schools!” And Tom began to snuffle a
+little.
+
+“_You_ bad!” and Huckleberry began to snuffle too. “Consound it, Tom
+Sawyer, you’re just old pie, ‘long-side o’ what I am. Oh, _lordy_,
+lordy, lordy, I wisht I only had half your chance.”
+
+Tom choked off and whispered:
+
+“Look, Hucky, look! He’s got his _back_ to us!”
+
+Hucky looked, with joy in his heart.
+
+“Well, he has, by jingoes! Did he before?”
+
+“Yes, he did. But I, like a fool, never thought. Oh, this is bully, you
+know. _Now_ who can he mean?”
+
+The howling stopped. Tom pricked up his ears.
+
+“Sh! What’s that?” he whispered.
+
+“Sounds like--like hogs grunting. No--it’s somebody snoring, Tom.”
+
+“That _is_ it! Where ‘bouts is it, Huck?”
+
+“I bleeve it’s down at ‘tother end. Sounds so, anyway. Pap used to sleep
+there, sometimes, ‘long with the hogs, but laws bless you, he just lifts
+things when _he_ snores. Besides, I reckon he ain’t ever coming back to
+this town any more.”
+
+The spirit of adventure rose in the boys’ souls once more.
+
+“Hucky, do you das’t to go if I lead?”
+
+“I don’t like to, much. Tom, s’pose it’s Injun Joe!”
+
+Tom quailed. But presently the temptation rose up strong again and the
+boys agreed to try, with the understanding that they would take to their
+heels if the snoring stopped. So they went tiptoeing stealthily down,
+the one behind the other. When they had got to within five steps of the
+snorer, Tom stepped on a stick, and it broke with a sharp snap. The man
+moaned, writhed a little, and his face came into the moonlight. It was
+Muff Potter. The boys’ hearts had stood still, and their hopes too,
+when the man moved, but their fears passed away now. They tip-toed out,
+through the broken weather-boarding, and stopped at a little distance
+to exchange a parting word. That long, lugubrious howl rose on the night
+air again! They turned and saw the strange dog standing within a few
+feet of where Potter was lying, and _facing_ Potter, with his nose
+pointing heavenward.
+
+“Oh, geeminy, it’s _him_!” exclaimed both boys, in a breath.
+
+“Say, Tom--they say a stray dog come howling around Johnny Miller’s
+house, ‘bout midnight, as much as two weeks ago; and a whippoorwill come
+in and lit on the banisters and sung, the very same evening; and there
+ain’t anybody dead there yet.”
+
+“Well, I know that. And suppose there ain’t. Didn’t Gracie Miller fall
+in the kitchen fire and burn herself terrible the very next Saturday?”
+
+“Yes, but she ain’t _dead_. And what’s more, she’s getting better, too.”
+
+“All right, you wait and see. She’s a goner, just as dead sure as Muff
+Potter’s a goner. That’s what the niggers say, and they know all about
+these kind of things, Huck.”
+
+Then they separated, cogitating. When Tom crept in at his bedroom window
+the night was almost spent. He undressed with excessive caution, and
+fell asleep congratulating himself that nobody knew of his escapade. He
+was not aware that the gently-snoring Sid was awake, and had been so for
+an hour.
+
+When Tom awoke, Sid was dressed and gone. There was a late look in the
+light, a late sense in the atmosphere. He was startled. Why had he not
+been called--persecuted till he was up, as usual? The thought filled
+him with bodings. Within five minutes he was dressed and down-stairs,
+feeling sore and drowsy. The family were still at table, but they had
+finished breakfast. There was no voice of rebuke; but there were averted
+eyes; there was a silence and an air of solemnity that struck a chill
+to the culprit’s heart. He sat down and tried to seem gay, but it
+was up-hill work; it roused no smile, no response, and he lapsed into
+silence and let his heart sink down to the depths.
+
+After breakfast his aunt took him aside, and Tom almost brightened in
+the hope that he was going to be flogged; but it was not so. His aunt
+wept over him and asked him how he could go and break her old heart so;
+and finally told him to go on, and ruin himself and bring her gray hairs
+with sorrow to the grave, for it was no use for her to try any more.
+This was worse than a thousand whippings, and Tom’s heart was sorer now
+than his body. He cried, he pleaded for forgiveness, promised to reform
+over and over again, and then received his dismissal, feeling that
+he had won but an imperfect forgiveness and established but a feeble
+confidence.
+
+He left the presence too miserable to even feel revengeful toward
+Sid; and so the latter’s prompt retreat through the back gate was
+unnecessary. He moped to school gloomy and sad, and took his flogging,
+along with Joe Harper, for playing hookey the day before, with the
+air of one whose heart was busy with heavier woes and wholly dead to
+trifles. Then he betook himself to his seat, rested his elbows on his
+desk and his jaws in his hands, and stared at the wall with the stony
+stare of suffering that has reached the limit and can no further go.
+His elbow was pressing against some hard substance. After a long time
+he slowly and sadly changed his position, and took up this object with
+a sigh. It was in a paper. He unrolled it. A long, lingering, colossal
+sigh followed, and his heart broke. It was his brass andiron knob!
+
+This final feather broke the camel’s back.
+
+
+
+
+CHAPTER XI
+
+CLOSE upon the hour of noon the whole village was suddenly electrified
+with the ghastly news. No need of the as yet un-dreamed-of telegraph;
+the tale flew from man to man, from group to group, from house to house,
+with little less than telegraphic speed. Of course the schoolmaster gave
+holi-day for that afternoon; the town would have thought strangely of
+him if he had not.
+
+A gory knife had been found close to the murdered man, and it had been
+recognized by somebody as belonging to Muff Potter--so the story ran. And
+it was said that a belated citizen had come upon Potter washing himself
+in the “branch” about one or two o’clock in the morning, and that Potter
+had at once sneaked off--suspicious circumstances, especially the washing
+which was not a habit with Potter. It was also said that the town had
+been ransacked for this “murderer” (the public are not slow in the
+matter of sifting evidence and arriving at a verdict), but that he
+could not be found. Horsemen had departed down all the roads in every
+direction, and the Sheriff “was confident” that he would be captured
+before night.
+
+All the town was drifting toward the graveyard. Tom’s heartbreak
+vanished and he joined the procession, not because he would not
+a thousand times rather go anywhere else, but because an awful,
+unaccountable fascination drew him on. Arrived at the dreadful place, he
+wormed his small body through the crowd and saw the dismal spectacle.
+It seemed to him an age since he was there before. Somebody pinched
+his arm. He turned, and his eyes met Huckleberry’s. Then both looked
+elsewhere at once, and wondered if anybody had noticed anything in their
+mutual glance. But everybody was talking, and intent upon the grisly
+spectacle before them.
+
+“Poor fellow!” “Poor young fellow!” “This ought to be a lesson to grave
+robbers!” “Muff Potter’ll hang for this if they catch him!” This was the
+drift of remark; and the minister said, “It was a judgment; His hand is
+here.”
+
+Now Tom shivered from head to heel; for his eye fell upon the stolid
+face of Injun Joe. At this moment the crowd began to sway and struggle,
+and voices shouted, “It’s him! it’s him! he’s coming himself!”
+
+“Who? Who?” from twenty voices.
+
+“Muff Potter!”
+
+“Hallo, he’s stopped!--Look out, he’s turning! Don’t let him get away!”
+
+People in the branches of the trees over Tom’s head said he wasn’t
+trying to get away--he only looked doubtful and perplexed.
+
+“Infernal impudence!” said a bystander; “wanted to come and take a quiet
+look at his work, I reckon--didn’t expect any company.”
+
+The crowd fell apart, now, and the Sheriff came through, ostentatiously
+leading Potter by the arm. The poor fellow’s face was haggard, and
+his eyes showed the fear that was upon him. When he stood before the
+murdered man, he shook as with a palsy, and he put his face in his hands
+and burst into tears.
+
+“I didn’t do it, friends,” he sobbed; “‘pon my word and honor I never
+done it.”
+
+“Who’s accused you?” shouted a voice.
+
+This shot seemed to carry home. Potter lifted his face and looked around
+him with a pathetic hopelessness in his eyes. He saw Injun Joe, and
+exclaimed:
+
+“Oh, Injun Joe, you promised me you’d never--”
+
+“Is that your knife?” and it was thrust before him by the Sheriff.
+
+Potter would have fallen if they had not caught him and eased him to the
+ground. Then he said:
+
+“Something told me ‘t if I didn’t come back and get--” He shuddered; then
+waved his nerveless hand with a vanquished gesture and said, “Tell ‘em,
+Joe, tell ‘em--it ain’t any use any more.”
+
+Then Huckleberry and Tom stood dumb and staring, and heard the
+stony-hearted liar reel off his serene statement, they expecting every
+moment that the clear sky would deliver God’s lightnings upon his head,
+and wondering to see how long the stroke was delayed. And when he had
+finished and still stood alive and whole, their wavering impulse to
+break their oath and save the poor betrayed prisoner’s life faded and
+vanished away, for plainly this miscreant had sold himself to Satan and
+it would be fatal to meddle with the property of such a power as that.
+
+“Why didn’t you leave? What did you want to come here for?” somebody
+said.
+
+“I couldn’t help it--I couldn’t help it,” Potter moaned. “I wanted to
+run away, but I couldn’t seem to come anywhere but here.” And he fell to
+sobbing again.
+
+Injun Joe repeated his statement, just as calmly, a few minutes
+afterward on the inquest, under oath; and the boys, seeing that the
+lightnings were still withheld, were confirmed in their belief that
+Joe had sold himself to the devil. He was now become, to them, the most
+balefully interesting object they had ever looked upon, and they could
+not take their fascinated eyes from his face.
+
+They inwardly resolved to watch him nights, when opportunity should
+offer, in the hope of getting a glimpse of his dread master.
+
+Injun Joe helped to raise the body of the murdered man and put it in
+a wagon for removal; and it was whispered through the shuddering
+crowd that the wound bled a little! The boys thought that this happy
+circumstance would turn suspicion in the right direction; but they were
+disappointed, for more than one villager remarked:
+
+“It was within three feet of Muff Potter when it done it.”
+
+Tom’s fearful secret and gnawing conscience disturbed his sleep for as
+much as a week after this; and at breakfast one morning Sid said:
+
+“Tom, you pitch around and talk in your sleep so much that you keep me
+awake half the time.”
+
+Tom blanched and dropped his eyes.
+
+“It’s a bad sign,” said Aunt Polly, gravely. “What you got on your mind,
+Tom?”
+
+“Nothing. Nothing ‘t I know of.” But the boy’s hand shook so that he
+spilled his coffee.
+
+“And you do talk such stuff,” Sid said. “Last night you said, ‘It’s
+blood, it’s blood, that’s what it is!’ You said that over and over.
+And you said, ‘Don’t torment me so--I’ll tell!’ Tell _what_? What is it
+you’ll tell?”
+
+Everything was swimming before Tom. There is no telling what might have
+happened, now, but luckily the concern passed out of Aunt Polly’s face
+and she came to Tom’s relief without knowing it. She said:
+
+“Sho! It’s that dreadful murder. I dream about it most every night
+myself. Sometimes I dream it’s me that done it.”
+
+Mary said she had been affected much the same way. Sid seemed satisfied.
+Tom got out of the presence as quick as he plausibly could, and after
+that he complained of toothache for a week, and tied up his jaws every
+night. He never knew that Sid lay nightly watching, and frequently
+slipped the bandage free and then leaned on his elbow listening a good
+while at a time, and afterward slipped the bandage back to its place
+again. Tom’s distress of mind wore off gradually and the toothache grew
+irksome and was discarded. If Sid really managed to make anything out of
+Tom’s disjointed mutterings, he kept it to himself.
+
+It seemed to Tom that his schoolmates never would get done holding
+inquests on dead cats, and thus keeping his trouble present to his mind.
+Sid noticed that Tom never was coroner at one of these inquiries,
+though it had been his habit to take the lead in all new enterprises;
+he noticed, too, that Tom never acted as a witness--and that was strange;
+and Sid did not overlook the fact that Tom even showed a marked aversion
+to these inquests, and always avoided them when he could. Sid marvelled,
+but said nothing. However, even inquests went out of vogue at last, and
+ceased to torture Tom’s conscience.
+
+Every day or two, during this time of sorrow, Tom watched his
+opportunity and went to the little grated jail-window and smuggled such
+small comforts through to the “murderer” as he could get hold of. The
+jail was a trifling little brick den that stood in a marsh at the edge
+of the village, and no guards were afforded for it; indeed, it
+was seldom occupied. These offerings greatly helped to ease Tom’s
+conscience.
+
+The villagers had a strong desire to tar-and-feather Injun Joe and ride
+him on a rail, for body-snatching, but so formidable was his character
+that nobody could be found who was willing to take the lead in the
+matter, so it was dropped. He had been careful to begin both of his
+inquest-statements with the fight, without confessing the grave-robbery
+that preceded it; therefore it was deemed wisest not to try the case in
+the courts at present.
+
+
+
+
+CHAPTER XII
+
+ONE of the reasons why Tom’s mind had drifted away from its secret
+troubles was, that it had found a new and weighty matter to interest
+itself about. Becky Thatcher had stopped coming to school. Tom had
+struggled with his pride a few days, and tried to “whistle her down the
+wind,” but failed. He began to find himself hanging around her father’s
+house, nights, and feeling very miserable. She was ill. What if she
+should die! There was distraction in the thought. He no longer took an
+interest in war, nor even in piracy. The charm of life was gone; there
+was nothing but dreariness left. He put his hoop away, and his bat;
+there was no joy in them any more. His aunt was concerned. She began to
+try all manner of remedies on him. She was one of those people who
+are infatuated with patent medicines and all new-fangled methods of
+producing health or mending it. She was an inveterate experimenter in
+these things. When something fresh in this line came out she was in a
+fever, right away, to try it; not on herself, for she was never ailing,
+but on anybody else that came handy. She was a subscriber for all the
+“Health” periodicals and phrenological frauds; and the solemn ignorance
+they were inflated with was breath to her nostrils. All the “rot” they
+contained about ventilation, and how to go to bed, and how to get up,
+and what to eat, and what to drink, and how much exercise to take, and
+what frame of mind to keep one’s self in, and what sort of clothing
+to wear, was all gospel to her, and she never observed that her
+health-journals of the current month customarily upset everything they
+had recommended the month before. She was as simple-hearted and honest
+as the day was long, and so she was an easy victim. She gathered
+together her quack periodicals and her quack medicines, and thus armed
+with death, went about on her pale horse, metaphorically speaking, with
+“hell following after.” But she never suspected that she was not an
+angel of healing and the balm of Gilead in disguise, to the suffering
+neighbors.
+
+The water treatment was new, now, and Tom’s low condition was a windfall
+to her. She had him out at daylight every morning, stood him up in the
+wood-shed and drowned him with a deluge of cold water; then she scrubbed
+him down with a towel like a file, and so brought him to; then she
+rolled him up in a wet sheet and put him away under blankets till she
+sweated his soul clean and “the yellow stains of it came through his
+pores”--as Tom said.
+
+Yet notwithstanding all this, the boy grew more and more melancholy and
+pale and dejected. She added hot baths, sitz baths, shower baths, and
+plunges. The boy remained as dismal as a hearse. She began to assist the
+water with a slim oatmeal diet and blister-plasters. She calculated his
+capacity as she would a jug’s, and filled him up every day with quack
+cure-alls.
+
+Tom had become indifferent to persecution by this time. This phase
+filled the old lady’s heart with consternation. This indifference must
+be broken up at any cost. Now she heard of Pain-killer for the first
+time. She ordered a lot at once. She tasted it and was filled with
+gratitude. It was simply fire in a liquid form. She dropped the water
+treatment and everything else, and pinned her faith to Pain-killer.
+She gave Tom a teaspoonful and watched with the deepest anxiety for the
+result. Her troubles were instantly at rest, her soul at peace again;
+for the “indifference” was broken up. The boy could not have shown a
+wilder, heartier interest, if she had built a fire under him.
+
+Tom felt that it was time to wake up; this sort of life might be
+romantic enough, in his blighted condition, but it was getting to have
+too little sentiment and too much distracting variety about it. So he
+thought over various plans for relief, and finally hit upon that of
+professing to be fond of Pain-killer. He asked for it so often that he
+became a nuisance, and his aunt ended by telling him to help himself and
+quit bothering her. If it had been Sid, she would have had no misgivings
+to alloy her delight; but since it was Tom, she watched the bottle
+clandestinely. She found that the medicine did really diminish, but it
+did not occur to her that the boy was mending the health of a crack in
+the sitting-room floor with it.
+
+One day Tom was in the act of dosing the crack when his aunt’s yellow
+cat came along, purring, eyeing the teaspoon avariciously, and begging
+for a taste. Tom said:
+
+“Don’t ask for it unless you want it, Peter.”
+
+But Peter signified that he did want it.
+
+“You better make sure.”
+
+Peter was sure.
+
+“Now you’ve asked for it, and I’ll give it to you, because there ain’t
+anything mean about me; but if you find you don’t like it, you mustn’t
+blame anybody but your own self.”
+
+Peter was agreeable. So Tom pried his mouth open and poured down
+the Pain-killer. Peter sprang a couple of yards in the air, and then
+delivered a war-whoop and set off round and round the room, banging
+against furniture, upsetting flower-pots, and making general havoc. Next
+he rose on his hind feet and pranced around, in a frenzy of enjoyment,
+with his head over his shoulder and his voice proclaiming his
+unappeasable happiness. Then he went tearing around the house again
+spreading chaos and destruction in his path. Aunt Polly entered in time
+to see him throw a few double summersets, deliver a final mighty hurrah,
+and sail through the open window, carrying the rest of the flower-pots
+with him. The old lady stood petrified with astonishment, peering over
+her glasses; Tom lay on the floor expiring with laughter.
+
+“Tom, what on earth ails that cat?”
+
+“I don’t know, aunt,” gasped the boy.
+
+“Why, I never see anything like it. What did make him act so?”
+
+“Deed I don’t know, Aunt Polly; cats always act so when they’re having a
+good time.”
+
+“They do, do they?” There was something in the tone that made Tom
+apprehensive.
+
+“Yes’m. That is, I believe they do.”
+
+“You _do_?”
+
+“Yes’m.”
+
+The old lady was bending down, Tom watching, with interest emphasized
+by anxiety. Too late he divined her “drift.” The handle of the telltale
+tea-spoon was visible under the bed-valance. Aunt Polly took it, held it
+up. Tom winced, and dropped his eyes. Aunt Polly raised him by the usual
+handle--his ear--and cracked his head soundly with her thimble.
+
+“Now, sir, what did you want to treat that poor dumb beast so, for?”
+
+“I done it out of pity for him--because he hadn’t any aunt.”
+
+“Hadn’t any aunt!--you numskull. What has that got to do with it?”
+
+“Heaps. Because if he’d had one she’d a burnt him out herself! She’d a
+roasted his bowels out of him ‘thout any more feeling than if he was a
+human!”
+
+Aunt Polly felt a sudden pang of remorse. This was putting the thing in
+a new light; what was cruelty to a cat _might_ be cruelty to a boy, too.
+She began to soften; she felt sorry. Her eyes watered a little, and she
+put her hand on Tom’s head and said gently:
+
+“I was meaning for the best, Tom. And, Tom, it _did_ do you good.”
+
+Tom looked up in her face with just a perceptible twinkle peeping
+through his gravity.
+
+“I know you was meaning for the best, aunty, and so was I with Peter. It
+done _him_ good, too. I never see him get around so since--”
+
+“Oh, go ‘long with you, Tom, before you aggravate me again. And you try
+and see if you can’t be a good boy, for once, and you needn’t take any
+more medicine.”
+
+Tom reached school ahead of time. It was noticed that this strange thing
+had been occurring every day latterly. And now, as usual of late,
+he hung about the gate of the schoolyard instead of playing with his
+comrades. He was sick, he said, and he looked it. He tried to seem to
+be looking everywhere but whither he really was looking--down the road.
+Presently Jeff Thatcher hove in sight, and Tom’s face lighted; he gazed
+a moment, and then turned sorrowfully away. When Jeff arrived, Tom
+accosted him; and “led up” warily to opportunities for remark about
+Becky, but the giddy lad never could see the bait. Tom watched and
+watched, hoping whenever a frisking frock came in sight, and hating the
+owner of it as soon as he saw she was not the right one. At last frocks
+ceased to appear, and he dropped hopelessly into the dumps; he entered
+the empty schoolhouse and sat down to suffer. Then one more frock passed
+in at the gate, and Tom’s heart gave a great bound. The next instant he
+was out, and “going on” like an Indian; yelling, laughing, chasing boys,
+jumping over the fence at risk of life and limb, throwing handsprings,
+standing on his head--doing all the heroic things he could conceive of,
+and keeping a furtive eye out, all the while, to see if Becky Thatcher
+was noticing. But she seemed to be unconscious of it all; she never
+looked. Could it be possible that she was not aware that he was there?
+He carried his exploits to her immediate vicinity; came war-whooping
+around, snatched a boy’s cap, hurled it to the roof of the schoolhouse,
+broke through a group of boys, tumbling them in every direction, and
+fell sprawling, himself, under Becky’s nose, almost upsetting her--and
+she turned, with her nose in the air, and he heard her say: “Mf! some
+people think they’re mighty smart--always showing off!”
+
+Tom’s cheeks burned. He gathered himself up and sneaked off, crushed and
+crestfallen.
+
+
+
+
+CHAPTER XIII
+
+TOM’S mind was made up now. He was gloomy and desperate. He was a
+forsaken, friendless boy, he said; nobody loved him; when they found out
+what they had driven him to, perhaps they would be sorry; he had tried
+to do right and get along, but they would not let him; since nothing
+would do them but to be rid of him, let it be so; and let them blame
+_him_ for the consequences--why shouldn’t they? What right had the
+friendless to complain? Yes, they had forced him to it at last: he would
+lead a life of crime. There was no choice.
+
+By this time he was far down Meadow Lane, and the bell for school to
+“take up” tinkled faintly upon his ear. He sobbed, now, to think he
+should never, never hear that old familiar sound any more--it was very
+hard, but it was forced on him; since he was driven out into the cold
+world, he must submit--but he forgave them. Then the sobs came thick and
+fast.
+
+Just at this point he met his soul’s sworn comrade, Joe
+Harper--hard-eyed, and with evidently a great and dismal purpose in his
+heart. Plainly here were “two souls with but a single thought.” Tom,
+wiping his eyes with his sleeve, began to blubber out something about
+a resolution to escape from hard usage and lack of sympathy at home by
+roaming abroad into the great world never to return; and ended by hoping
+that Joe would not forget him.
+
+But it transpired that this was a request which Joe had just been going
+to make of Tom, and had come to hunt him up for that purpose. His mother
+had whipped him for drinking some cream which he had never tasted and
+knew nothing about; it was plain that she was tired of him and wished
+him to go; if she felt that way, there was nothing for him to do but
+succumb; he hoped she would be happy, and never regret having driven her
+poor boy out into the unfeeling world to suffer and die.
+
+As the two boys walked sorrowing along, they made a new compact to stand
+by each other and be brothers and never separate till death relieved
+them of their troubles. Then they began to lay their plans. Joe was for
+being a hermit, and living on crusts in a remote cave, and dying,
+some time, of cold and want and grief; but after listening to Tom, he
+conceded that there were some conspicuous advantages about a life of
+crime, and so he consented to be a pirate.
+
+Three miles below St. Petersburg, at a point where the Mississippi River
+was a trifle over a mile wide, there was a long, narrow, wooded island,
+with a shallow bar at the head of it, and this offered well as a
+rendezvous. It was not inhabited; it lay far over toward the further
+shore, abreast a dense and almost wholly unpeopled forest. So Jackson’s
+Island was chosen. Who were to be the subjects of their piracies was a
+matter that did not occur to them. Then they hunted up Huckleberry Finn,
+and he joined them promptly, for all careers were one to him; he was
+indifferent. They presently separated to meet at a lonely spot on the
+river-bank two miles above the village at the favorite hour--which was
+midnight. There was a small log raft there which they meant to capture.
+Each would bring hooks and lines, and such provision as he could steal
+in the most dark and mysterious way--as became outlaws. And before the
+afternoon was done, they had all managed to enjoy the sweet glory of
+spreading the fact that pretty soon the town would “hear something.” All
+who got this vague hint were cautioned to “be mum and wait.”
+
+About midnight Tom arrived with a boiled ham and a few trifles,
+and stopped in a dense undergrowth on a small bluff overlooking the
+meeting-place. It was starlight, and very still. The mighty river lay
+like an ocean at rest. Tom listened a moment, but no sound disturbed the
+quiet. Then he gave a low, distinct whistle. It was answered from under
+the bluff. Tom whistled twice more; these signals were answered in the
+same way. Then a guarded voice said:
+
+“Who goes there?”
+
+“Tom Sawyer, the Black Avenger of the Spanish Main. Name your names.”
+
+“Huck Finn the Red-Handed, and Joe Harper the Terror of the Seas.” Tom
+had furnished these titles, from his favorite literature.
+
+“‘Tis well. Give the countersign.”
+
+Two hoarse whispers delivered the same awful word simultaneously to the
+brooding night:
+
+“_Blood_!”
+
+Then Tom tumbled his ham over the bluff and let himself down after it,
+tearing both skin and clothes to some extent in the effort. There was
+an easy, comfortable path along the shore under the bluff, but it lacked
+the advantages of difficulty and danger so valued by a pirate.
+
+The Terror of the Seas had brought a side of bacon, and had about worn
+himself out with getting it there. Finn the Red-Handed had stolen a
+skillet and a quantity of half-cured leaf tobacco, and had also brought
+a few corn-cobs to make pipes with. But none of the pirates smoked or
+“chewed” but himself. The Black Avenger of the Spanish Main said it
+would never do to start without some fire. That was a wise thought;
+matches were hardly known there in that day. They saw a fire smouldering
+upon a great raft a hundred yards above, and they went stealthily
+thither and helped themselves to a chunk. They made an imposing
+adventure of it, saying, “Hist!” every now and then, and suddenly
+halting with finger on lip; moving with hands on imaginary dagger-hilts;
+and giving orders in dismal whispers that if “the foe” stirred, to “let
+him have it to the hilt,” because “dead men tell no tales.” They knew
+well enough that the raftsmen were all down at the village laying
+in stores or having a spree, but still that was no excuse for their
+conducting this thing in an unpiratical way.
+
+They shoved off, presently, Tom in command, Huck at the after oar and
+Joe at the forward. Tom stood amidships, gloomy-browed, and with folded
+arms, and gave his orders in a low, stern whisper:
+
+“Luff, and bring her to the wind!”
+
+“Aye-aye, sir!”
+
+“Steady, steady-y-y-y!”
+
+“Steady it is, sir!”
+
+“Let her go off a point!”
+
+“Point it is, sir!”
+
+As the boys steadily and monotonously drove the raft toward mid-stream
+it was no doubt understood that these orders were given only for
+“style,” and were not intended to mean anything in particular.
+
+“What sail’s she carrying?”
+
+“Courses, tops’ls, and flying-jib, sir.”
+
+“Send the r’yals up! Lay out aloft, there, half a dozen of
+ye--foretopmaststuns’l! Lively, now!”
+
+“Aye-aye, sir!”
+
+“Shake out that maintogalans’l! Sheets and braces! _now_ my hearties!”
+
+“Aye-aye, sir!”
+
+“Hellum-a-lee--hard a port! Stand by to meet her when she comes! Port,
+port! _Now_, men! With a will! Stead-y-y-y!”
+
+“Steady it is, sir!”
+
+The raft drew beyond the middle of the river; the boys pointed her head
+right, and then lay on their oars. The river was not high, so there was
+not more than a two or three mile current. Hardly a word was said during
+the next three-quarters of an hour. Now the raft was passing before
+the distant town. Two or three glimmering lights showed where it lay,
+peacefully sleeping, beyond the vague vast sweep of star-gemmed water,
+unconscious of the tremendous event that was happening. The Black
+Avenger stood still with folded arms, “looking his last” upon the scene
+of his former joys and his later sufferings, and wishing “she” could see
+him now, abroad on the wild sea, facing peril and death with dauntless
+heart, going to his doom with a grim smile on his lips. It was but
+a small strain on his imagination to remove Jackson’s Island beyond
+eye-shot of the village, and so he “looked his last” with a broken and
+satisfied heart. The other pirates were looking their last, too; and
+they all looked so long that they came near letting the current drift
+them out of the range of the island. But they discovered the danger in
+time, and made shift to avert it. About two o’clock in the morning the
+raft grounded on the bar two hundred yards above the head of the island,
+and they waded back and forth until they had landed their freight. Part
+of the little raft’s belongings consisted of an old sail, and this they
+spread over a nook in the bushes for a tent to shelter their provisions;
+but they themselves would sleep in the open air in good weather, as
+became outlaws.
+
+They built a fire against the side of a great log twenty or thirty steps
+within the sombre depths of the forest, and then cooked some bacon in
+the frying-pan for supper, and used up half of the corn “pone” stock
+they had brought. It seemed glorious sport to be feasting in that wild,
+free way in the virgin forest of an unexplored and uninhabited island,
+far from the haunts of men, and they said they never would return to
+civilization. The climbing fire lit up their faces and threw its ruddy
+glare upon the pillared tree-trunks of their forest temple, and upon the
+varnished foliage and festooning vines.
+
+When the last crisp slice of bacon was gone, and the last allowance
+of corn pone devoured, the boys stretched themselves out on the grass,
+filled with contentment. They could have found a cooler place, but
+they would not deny themselves such a romantic feature as the roasting
+campfire.
+
+“_Ain’t_ it gay?” said Joe.
+
+“It’s _nuts_!” said Tom. “What would the boys say if they could see us?”
+
+“Say? Well, they’d just die to be here--hey, Hucky!”
+
+“I reckon so,” said Huckleberry; “anyways, I’m suited. I don’t want
+nothing better’n this. I don’t ever get enough to eat, gen’ally--and here
+they can’t come and pick at a feller and bullyrag him so.”
+
+“It’s just the life for me,” said Tom. “You don’t have to get up,
+mornings, and you don’t have to go to school, and wash, and all that
+blame foolishness. You see a pirate don’t have to do _anything_, Joe,
+when he’s ashore, but a hermit _he_ has to be praying considerable, and
+then he don’t have any fun, anyway, all by himself that way.”
+
+“Oh yes, that’s so,” said Joe, “but I hadn’t thought much about it, you
+know. I’d a good deal rather be a pirate, now that I’ve tried it.”
+
+“You see,” said Tom, “people don’t go much on hermits, nowadays, like
+they used to in old times, but a pirate’s always respected. And
+a hermit’s got to sleep on the hardest place he can find, and put
+sackcloth and ashes on his head, and stand out in the rain, and--”
+
+“What does he put sackcloth and ashes on his head for?” inquired Huck.
+
+“I dono. But they’ve _got_ to do it. Hermits always do. You’d have to do
+that if you was a hermit.”
+
+“Dern’d if I would,” said Huck.
+
+“Well, what would you do?”
+
+“I dono. But I wouldn’t do that.”
+
+“Why, Huck, you’d _have_ to. How’d you get around it?”
+
+“Why, I just wouldn’t stand it. I’d run away.”
+
+“Run away! Well, you _would_ be a nice old slouch of a hermit. You’d be
+a disgrace.”
+
+The Red-Handed made no response, being better employed. He had finished
+gouging out a cob, and now he fitted a weed stem to it, loaded it with
+tobacco, and was pressing a coal to the charge and blowing a cloud of
+fragrant smoke--he was in the full bloom of luxurious contentment. The
+other pirates envied him this majestic vice, and secretly resolved to
+acquire it shortly. Presently Huck said:
+
+“What does pirates have to do?”
+
+Tom said:
+
+“Oh, they have just a bully time--take ships and burn them, and get the
+money and bury it in awful places in their island where there’s ghosts
+and things to watch it, and kill everybody in the ships--make ‘em walk a
+plank.”
+
+“And they carry the women to the island,” said Joe; “they don’t kill the
+women.”
+
+“No,” assented Tom, “they don’t kill the women--they’re too noble. And
+the women’s always beautiful, too.
+
+“And don’t they wear the bulliest clothes! Oh no! All gold and silver
+and di’monds,” said Joe, with enthusiasm.
+
+“Who?” said Huck.
+
+“Why, the pirates.”
+
+Huck scanned his own clothing forlornly.
+
+“I reckon I ain’t dressed fitten for a pirate,” said he, with a
+regretful pathos in his voice; “but I ain’t got none but these.”
+
+But the other boys told him the fine clothes would come fast enough,
+after they should have begun their adventures. They made him understand
+that his poor rags would do to begin with, though it was customary for
+wealthy pirates to start with a proper wardrobe.
+
+Gradually their talk died out and drowsiness began to steal upon the
+eyelids of the little waifs. The pipe dropped from the fingers of the
+Red-Handed, and he slept the sleep of the conscience-free and the weary.
+The Terror of the Seas and the Black Avenger of the Spanish Main had
+more difficulty in getting to sleep. They said their prayers inwardly,
+and lying down, since there was nobody there with authority to make them
+kneel and recite aloud; in truth, they had a mind not to say them at
+all, but they were afraid to proceed to such lengths as that, lest they
+might call down a sudden and special thunderbolt from heaven. Then at
+once they reached and hovered upon the imminent verge of sleep--but an
+intruder came, now, that would not “down.” It was conscience. They began
+to feel a vague fear that they had been doing wrong to run away; and
+next they thought of the stolen meat, and then the real torture came.
+They tried to argue it away by reminding conscience that they had
+purloined sweetmeats and apples scores of times; but conscience was not
+to be appeased by such thin plausibilities; it seemed to them, in the
+end, that there was no getting around the stubborn fact that taking
+sweetmeats was only “hooking,” while taking bacon and hams and such
+valuables was plain simple stealing--and there was a command against that
+in the Bible. So they inwardly resolved that so long as they remained in
+the business, their piracies should not again be sullied with the
+crime of stealing. Then conscience granted a truce, and these curiously
+inconsistent pirates fell peacefully to sleep.
+
+
+
+
+CHAPTER XIV
+
+WHEN Tom awoke in the morning, he wondered where he was. He sat up and
+rubbed his eyes and looked around. Then he comprehended. It was the cool
+gray dawn, and there was a delicious sense of repose and peace in the
+deep pervading calm and silence of the woods. Not a leaf stirred; not
+a sound obtruded upon great Nature’s meditation. Beaded dewdrops stood
+upon the leaves and grasses. A white layer of ashes covered the fire,
+and a thin blue breath of smoke rose straight into the air. Joe and Huck
+still slept.
+
+Now, far away in the woods a bird called; another answered; presently
+the hammering of a woodpecker was heard. Gradually the cool dim gray
+of the morning whitened, and as gradually sounds multiplied and life
+manifested itself. The marvel of Nature shaking off sleep and going
+to work unfolded itself to the musing boy. A little green worm came
+crawling over a dewy leaf, lifting two-thirds of his body into the air
+from time to time and “sniffing around,” then proceeding again--for he
+was measuring, Tom said; and when the worm approached him, of its own
+accord, he sat as still as a stone, with his hopes rising and falling,
+by turns, as the creature still came toward him or seemed inclined to
+go elsewhere; and when at last it considered a painful moment with its
+curved body in the air and then came decisively down upon Tom’s leg and
+began a journey over him, his whole heart was glad--for that meant that
+he was going to have a new suit of clothes--without the shadow of a
+doubt a gaudy piratical uniform. Now a procession of ants appeared,
+from nowhere in particular, and went about their labors; one struggled
+manfully by with a dead spider five times as big as itself in its arms,
+and lugged it straight up a tree-trunk. A brown spotted lady-bug climbed
+the dizzy height of a grass blade, and Tom bent down close to it and
+said, “Lady-bug, lady-bug, fly away home, your house is on fire, your
+children’s alone,” and she took wing and went off to see about it--which
+did not surprise the boy, for he knew of old that this insect was
+credulous about conflagrations, and he had practised upon its simplicity
+more than once. A tumblebug came next, heaving sturdily at its ball, and
+Tom touched the creature, to see it shut its legs against its body
+and pretend to be dead. The birds were fairly rioting by this time. A
+catbird, the Northern mocker, lit in a tree over Tom’s head, and trilled
+out her imitations of her neighbors in a rapture of enjoyment; then
+a shrill jay swept down, a flash of blue flame, and stopped on a twig
+almost within the boy’s reach, cocked his head to one side and eyed the
+strangers with a consuming curiosity; a gray squirrel and a big fellow
+of the “fox” kind came skurrying along, sitting up at intervals to
+inspect and chatter at the boys, for the wild things had probably never
+seen a human being before and scarcely knew whether to be afraid or not.
+All Nature was wide awake and stirring, now; long lances of sunlight
+pierced down through the dense foliage far and near, and a few
+butterflies came fluttering upon the scene.
+
+Tom stirred up the other pirates and they all clattered away with
+a shout, and in a minute or two were stripped and chasing after and
+tumbling over each other in the shallow limpid water of the white
+sandbar. They felt no longing for the little village sleeping in the
+distance beyond the majestic waste of water. A vagrant current or a
+slight rise in the river had carried off their raft, but this only
+gratified them, since its going was something like burning the bridge
+between them and civilization.
+
+They came back to camp wonderfully refreshed, glad-hearted, and
+ravenous; and they soon had the camp-fire blazing up again. Huck found a
+spring of clear cold water close by, and the boys made cups of broad oak
+or hickory leaves, and felt that water, sweetened with such a wildwood
+charm as that, would be a good enough substitute for coffee. While Joe
+was slicing bacon for breakfast, Tom and Huck asked him to hold on a
+minute; they stepped to a promising nook in the river-bank and threw in
+their lines; almost immediately they had reward. Joe had not had time
+to get impatient before they were back again with some handsome bass,
+a couple of sun-perch and a small catfish--provisions enough for quite a
+family. They fried the fish with the bacon, and were astonished; for
+no fish had ever seemed so delicious before. They did not know that the
+quicker a fresh-water fish is on the fire after he is caught the better
+he is; and they reflected little upon what a sauce open-air sleeping,
+open-air exercise, bathing, and a large ingredient of hunger make, too.
+
+They lay around in the shade, after breakfast, while Huck had a smoke,
+and then went off through the woods on an exploring expedition. They
+tramped gayly along, over decaying logs, through tangled underbrush,
+among solemn monarchs of the forest, hung from their crowns to the
+ground with a drooping regalia of grape-vines. Now and then they came
+upon snug nooks carpeted with grass and jeweled with flowers.
+
+They found plenty of things to be delighted with, but nothing to be
+astonished at. They discovered that the island was about three miles
+long and a quarter of a mile wide, and that the shore it lay closest to
+was only separated from it by a narrow channel hardly two hundred yards
+wide. They took a swim about every hour, so it was close upon the middle
+of the afternoon when they got back to camp. They were too hungry to
+stop to fish, but they fared sumptuously upon cold ham, and then threw
+themselves down in the shade to talk. But the talk soon began to drag,
+and then died. The stillness, the solemnity that brooded in the woods,
+and the sense of loneliness, began to tell upon the spirits of the boys.
+They fell to thinking. A sort of undefined longing crept upon them. This
+took dim shape, presently--it was budding homesickness. Even Finn the
+Red-Handed was dreaming of his doorsteps and empty hogsheads. But they
+were all ashamed of their weakness, and none was brave enough to speak
+his thought.
+
+For some time, now, the boys had been dully conscious of a peculiar
+sound in the distance, just as one sometimes is of the ticking of a
+clock which he takes no distinct note of. But now this mysterious sound
+became more pronounced, and forced a recognition. The boys started,
+glanced at each other, and then each assumed a listening attitude. There
+was a long silence, profound and unbroken; then a deep, sullen boom came
+floating down out of the distance.
+
+“What is it!” exclaimed Joe, under his breath.
+
+“I wonder,” said Tom in a whisper.
+
+“‘Tain’t thunder,” said Huckleberry, in an awed tone, “becuz thunder--”
+
+“Hark!” said Tom. “Listen--don’t talk.”
+
+They waited a time that seemed an age, and then the same muffled boom
+troubled the solemn hush.
+
+“Let’s go and see.”
+
+They sprang to their feet and hurried to the shore toward the town. They
+parted the bushes on the bank and peered out over the water. The little
+steam ferry-boat was about a mile below the village, drifting with the
+current. Her broad deck seemed crowded with people. There were a great
+many skiffs rowing about or floating with the stream in the neighborhood
+of the ferryboat, but the boys could not determine what the men in
+them were doing. Presently a great jet of white smoke burst from the
+ferryboat’s side, and as it expanded and rose in a lazy cloud, that same
+dull throb of sound was borne to the listeners again.
+
+“I know now!” exclaimed Tom; “somebody’s drownded!”
+
+“That’s it!” said Huck; “they done that last summer, when Bill Turner
+got drownded; they shoot a cannon over the water, and that makes
+him come up to the top. Yes, and they take loaves of bread and put
+quicksilver in ‘em and set ‘em afloat, and wherever there’s anybody
+that’s drownded, they’ll float right there and stop.”
+
+“Yes, I’ve heard about that,” said Joe. “I wonder what makes the bread
+do that.”
+
+“Oh, it ain’t the bread, so much,” said Tom; “I reckon it’s mostly what
+they _say_ over it before they start it out.”
+
+“But they don’t say anything over it,” said Huck. “I’ve seen ‘em and
+they don’t.”
+
+“Well, that’s funny,” said Tom. “But maybe they say it to themselves. Of
+_course_ they do. Anybody might know that.”
+
+The other boys agreed that there was reason in what Tom said, because
+an ignorant lump of bread, uninstructed by an incantation, could not
+be expected to act very intelligently when set upon an errand of such
+gravity.
+
+“By jings, I wish I was over there, now,” said Joe.
+
+“I do too” said Huck “I’d give heaps to know who it is.”
+
+The boys still listened and watched. Presently a revealing thought
+flashed through Tom’s mind, and he exclaimed:
+
+“Boys, I know who’s drownded--it’s us!”
+
+They felt like heroes in an instant. Here was a gorgeous triumph; they
+were missed; they were mourned; hearts were breaking on their account;
+tears were being shed; accusing memories of unkindness to these poor
+lost lads were rising up, and unavailing regrets and remorse were being
+indulged; and best of all, the departed were the talk of the whole town,
+and the envy of all the boys, as far as this dazzling notoriety was
+concerned. This was fine. It was worth while to be a pirate, after all.
+
+As twilight drew on, the ferryboat went back to her accustomed business
+and the skiffs disappeared. The pirates returned to camp. They were
+jubilant with vanity over their new grandeur and the illustrious trouble
+they were making. They caught fish, cooked supper and ate it, and then
+fell to guessing at what the village was thinking and saying about them;
+and the pictures they drew of the public distress on their account were
+gratifying to look upon--from their point of view. But when the shadows
+of night closed them in, they gradually ceased to talk, and sat gazing
+into the fire, with their minds evidently wandering elsewhere. The
+excitement was gone, now, and Tom and Joe could not keep back thoughts
+of certain persons at home who were not enjoying this fine frolic as
+much as they were. Misgivings came; they grew troubled and unhappy; a
+sigh or two escaped, unawares. By and by Joe timidly ventured upon a
+roundabout “feeler” as to how the others might look upon a return to
+civilization--not right now, but--
+
+Tom withered him with derision! Huck, being uncommitted as yet, joined
+in with Tom, and the waverer quickly “explained,” and was glad to get
+out of the scrape with as little taint of chicken-hearted home-sickness
+clinging to his garments as he could. Mutiny was effectually laid to
+rest for the moment.
+
+As the night deepened, Huck began to nod, and presently to snore.
+Joe followed next. Tom lay upon his elbow motionless, for some time,
+watching the two intently. At last he got up cautiously, on his knees,
+and went searching among the grass and the flickering reflections flung
+by the campfire. He picked up and inspected several large semi-cylinders
+of the thin white bark of a sycamore, and finally chose two which seemed
+to suit him. Then he knelt by the fire and painfully wrote something
+upon each of these with his “red keel”; one he rolled up and put in his
+jacket pocket, and the other he put in Joe’s hat and removed it to a
+little distance from the owner. And he also put into the hat certain
+schoolboy treasures of almost inestimable value--among them a lump of
+chalk, an India-rubber ball, three fishhooks, and one of that kind
+of marbles known as a “sure ‘nough crystal.” Then he tiptoed his way
+cautiously among the trees till he felt that he was out of hearing, and
+straightway broke into a keen run in the direction of the sandbar.
+
+
+
+
+CHAPTER XV
+
+A few minutes later Tom was in the shoal water of the bar, wading toward
+the Illinois shore. Before the depth reached his middle he was halfway
+over; the current would permit no more wading, now, so he struck out
+confidently to swim the remaining hundred yards. He swam quartering
+upstream, but still was swept downward rather faster than he had
+expected. However, he reached the shore finally, and drifted along till
+he found a low place and drew himself out. He put his hand on his jacket
+pocket, found his piece of bark safe, and then struck through the woods,
+following the shore, with streaming garments. Shortly before ten
+o’clock he came out into an open place opposite the village, and saw the
+ferryboat lying in the shadow of the trees and the high bank. Everything
+was quiet under the blinking stars. He crept down the bank, watching
+with all his eyes, slipped into the water, swam three or four strokes
+and climbed into the skiff that did “yawl” duty at the boat’s stern. He
+laid himself down under the thwarts and waited, panting.
+
+Presently the cracked bell tapped and a voice gave the order to “cast
+off.” A minute or two later the skiff’s head was standing high up,
+against the boat’s swell, and the voyage was begun. Tom felt happy in
+his success, for he knew it was the boat’s last trip for the night. At
+the end of a long twelve or fifteen minutes the wheels stopped, and
+Tom slipped overboard and swam ashore in the dusk, landing fifty yards
+downstream, out of danger of possible stragglers.
+
+He flew along unfrequented alleys, and shortly found himself at his
+aunt’s back fence. He climbed over, approached the “ell,” and looked
+in at the sitting-room window, for a light was burning there. There
+sat Aunt Polly, Sid, Mary, and Joe Harper’s mother, grouped together,
+talking. They were by the bed, and the bed was between them and the
+door. Tom went to the door and began to softly lift the latch; then
+he pressed gently and the door yielded a crack; he continued pushing
+cautiously, and quaking every time it creaked, till he judged he might
+squeeze through on his knees; so he put his head through and began,
+warily.
+
+“What makes the candle blow so?” said Aunt Polly. Tom hurried up. “Why,
+that door’s open, I believe. Why, of course it is. No end of strange
+things now. Go ‘long and shut it, Sid.”
+
+Tom disappeared under the bed just in time. He lay and “breathed”
+ himself for a time, and then crept to where he could almost touch his
+aunt’s foot.
+
+“But as I was saying,” said Aunt Polly, “he warn’t _bad_, so to say--only
+misch_ee_vous. Only just giddy, and harum-scarum, you know. He warn’t
+any more responsible than a colt. _He_ never meant any harm, and he was
+the best-hearted boy that ever was”--and she began to cry.
+
+“It was just so with my Joe--always full of his devilment, and up to
+every kind of mischief, but he was just as unselfish and kind as he
+could be--and laws bless me, to think I went and whipped him for taking
+that cream, never once recollecting that I throwed it out myself because
+it was sour, and I never to see him again in this world, never, never,
+never, poor abused boy!” And Mrs. Harper sobbed as if her heart would
+break.
+
+“I hope Tom’s better off where he is,” said Sid, “but if he’d been
+better in some ways--”
+
+“_Sid!_” Tom felt the glare of the old lady’s eye, though he could not
+see it. “Not a word against my Tom, now that he’s gone! God’ll take care
+of _him_--never you trouble _your_self, sir! Oh, Mrs. Harper, I don’t
+know how to give him up! I don’t know how to give him up! He was such a
+comfort to me, although he tormented my old heart out of me, ‘most.”
+
+“The Lord giveth and the Lord hath taken away--Blessed be the name of
+the Lord! But it’s so hard--Oh, it’s so hard! Only last Saturday my Joe
+busted a firecracker right under my nose and I knocked him sprawling.
+Little did I know then, how soon--Oh, if it was to do over again I’d hug
+him and bless him for it.”
+
+“Yes, yes, yes, I know just how you feel, Mrs. Harper, I know just
+exactly how you feel. No longer ago than yesterday noon, my Tom took
+and filled the cat full of Pain-killer, and I did think the cretur would
+tear the house down. And God forgive me, I cracked Tom’s head with my
+thimble, poor boy, poor dead boy. But he’s out of all his troubles now.
+And the last words I ever heard him say was to reproach--”
+
+But this memory was too much for the old lady, and she broke entirely
+down. Tom was snuffling, now, himself--and more in pity of himself than
+anybody else. He could hear Mary crying, and putting in a kindly word
+for him from time to time. He began to have a nobler opinion of himself
+than ever before. Still, he was sufficiently touched by his aunt’s grief
+to long to rush out from under the bed and overwhelm her with joy--and
+the theatrical gorgeousness of the thing appealed strongly to his
+nature, too, but he resisted and lay still.
+
+He went on listening, and gathered by odds and ends that it was
+conjectured at first that the boys had got drowned while taking a swim;
+then the small raft had been missed; next, certain boys said the missing
+lads had promised that the village should “hear something” soon; the
+wise-heads had “put this and that together” and decided that the lads
+had gone off on that raft and would turn up at the next town below,
+presently; but toward noon the raft had been found, lodged against the
+Missouri shore some five or six miles below the village--and then hope
+perished; they must be drowned, else hunger would have driven them home
+by nightfall if not sooner. It was believed that the search for the
+bodies had been a fruitless effort merely because the drowning must
+have occurred in mid-channel, since the boys, being good swimmers, would
+otherwise have escaped to shore. This was Wednesday night. If the bodies
+continued missing until Sunday, all hope would be given over, and the
+funerals would be preached on that morning. Tom shuddered.
+
+Mrs. Harper gave a sobbing goodnight and turned to go. Then with a
+mutual impulse the two bereaved women flung themselves into each other’s
+arms and had a good, consoling cry, and then parted. Aunt Polly was
+tender far beyond her wont, in her goodnight to Sid and Mary. Sid
+snuffled a bit and Mary went off crying with all her heart.
+
+Aunt Polly knelt down and prayed for Tom so touchingly, so appealingly,
+and with such measureless love in her words and her old trembling voice,
+that he was weltering in tears again, long before she was through.
+
+He had to keep still long after she went to bed, for she kept making
+broken-hearted ejaculations from time to time, tossing unrestfully, and
+turning over. But at last she was still, only moaning a little in her
+sleep. Now the boy stole out, rose gradually by the bedside, shaded the
+candle-light with his hand, and stood regarding her. His heart was full
+of pity for her. He took out his sycamore scroll and placed it by the
+candle. But something occurred to him, and he lingered considering.
+His face lighted with a happy solution of his thought; he put the bark
+hastily in his pocket. Then he bent over and kissed the faded lips, and
+straightway made his stealthy exit, latching the door behind him.
+
+He threaded his way back to the ferry landing, found nobody at large
+there, and walked boldly on board the boat, for he knew she was
+tenantless except that there was a watchman, who always turned in and
+slept like a graven image. He untied the skiff at the stern, slipped
+into it, and was soon rowing cautiously upstream. When he had pulled a
+mile above the village, he started quartering across and bent himself
+stoutly to his work. He hit the landing on the other side neatly, for
+this was a familiar bit of work to him. He was moved to capture
+the skiff, arguing that it might be considered a ship and therefore
+legitimate prey for a pirate, but he knew a thorough search would be
+made for it and that might end in revelations. So he stepped ashore and
+entered the woods.
+
+He sat down and took a long rest, torturing himself meanwhile to keep
+awake, and then started warily down the home-stretch. The night was far
+spent. It was broad daylight before he found himself fairly abreast the
+island bar. He rested again until the sun was well up and gilding the
+great river with its splendor, and then he plunged into the stream. A
+little later he paused, dripping, upon the threshold of the camp, and
+heard Joe say:
+
+“No, Tom’s true-blue, Huck, and he’ll come back. He won’t desert. He
+knows that would be a disgrace to a pirate, and Tom’s too proud for that
+sort of thing. He’s up to something or other. Now I wonder what?”
+
+“Well, the things is ours, anyway, ain’t they?”
+
+“Pretty near, but not yet, Huck. The writing says they are if he ain’t
+back here to breakfast.”
+
+“Which he is!” exclaimed Tom, with fine dramatic effect, stepping
+grandly into camp.
+
+A sumptuous breakfast of bacon and fish was shortly provided, and as the
+boys set to work upon it, Tom recounted (and adorned) his adventures.
+They were a vain and boastful company of heroes when the tale was done.
+Then Tom hid himself away in a shady nook to sleep till noon, and the
+other pirates got ready to fish and explore.
+
+
+
+
+CHAPTER XVI
+
+AFTER dinner all the gang turned out to hunt for turtle eggs on the bar.
+They went about poking sticks into the sand, and when they found a soft
+place they went down on their knees and dug with their hands. Sometimes
+they would take fifty or sixty eggs out of one hole. They were perfectly
+round white things a trifle smaller than an English walnut. They had a
+famous fried-egg feast that night, and another on Friday morning.
+
+After breakfast they went whooping and prancing out on the bar, and
+chased each other round and round, shedding clothes as they went, until
+they were naked, and then continued the frolic far away up the shoal
+water of the bar, against the stiff current, which latter tripped their
+legs from under them from time to time and greatly increased the fun.
+And now and then they stooped in a group and splashed water in each
+other’s faces with their palms, gradually approaching each other, with
+averted faces to avoid the strangling sprays, and finally gripping and
+struggling till the best man ducked his neighbor, and then they all
+went under in a tangle of white legs and arms and came up blowing,
+sputtering, laughing, and gasping for breath at one and the same time.
+
+When they were well exhausted, they would run out and sprawl on the dry,
+hot sand, and lie there and cover themselves up with it, and by and by
+break for the water again and go through the original performance once
+more. Finally it occurred to them that their naked skin represented
+flesh-colored “tights” very fairly; so they drew a ring in the sand and
+had a circus--with three clowns in it, for none would yield this proudest
+post to his neighbor.
+
+Next they got their marbles and played “knucks” and “ringtaw” and
+“keeps” till that amusement grew stale. Then Joe and Huck had another
+swim, but Tom would not venture, because he found that in kicking off
+his trousers he had kicked his string of rattlesnake rattles off his
+ankle, and he wondered how he had escaped cramp so long without the
+protection of this mysterious charm. He did not venture again until he
+had found it, and by that time the other boys were tired and ready to
+rest. They gradually wandered apart, dropped into the “dumps,” and
+fell to gazing longingly across the wide river to where the village lay
+drowsing in the sun. Tom found himself writing “BECKY” in the sand with
+his big toe; he scratched it out, and was angry with himself for his
+weakness. But he wrote it again, nevertheless; he could not help it. He
+erased it once more and then took himself out of temptation by driving
+the other boys together and joining them.
+
+But Joe’s spirits had gone down almost beyond resurrection. He was so
+homesick that he could hardly endure the misery of it. The tears lay
+very near the surface. Huck was melancholy, too. Tom was downhearted,
+but tried hard not to show it. He had a secret which he was not ready
+to tell, yet, but if this mutinous depression was not broken up soon, he
+would have to bring it out. He said, with a great show of cheerfulness:
+
+“I bet there’s been pirates on this island before, boys. We’ll explore
+it again. They’ve hid treasures here somewhere. How’d you feel to light
+on a rotten chest full of gold and silver--hey?”
+
+But it roused only faint enthusiasm, which faded out, with no reply.
+Tom tried one or two other seductions; but they failed, too. It was
+discouraging work. Joe sat poking up the sand with a stick and looking
+very gloomy. Finally he said:
+
+“Oh, boys, let’s give it up. I want to go home. It’s so lonesome.”
+
+“Oh no, Joe, you’ll feel better by and by,” said Tom. “Just think of the
+fishing that’s here.”
+
+“I don’t care for fishing. I want to go home.”
+
+“But, Joe, there ain’t such another swimming-place anywhere.”
+
+“Swimming’s no good. I don’t seem to care for it, somehow, when there
+ain’t anybody to say I sha’n’t go in. I mean to go home.”
+
+“Oh, shucks! Baby! You want to see your mother, I reckon.”
+
+“Yes, I _do_ want to see my mother--and you would, too, if you had one. I
+ain’t any more baby than you are.” And Joe snuffled a little.
+
+“Well, we’ll let the crybaby go home to his mother, won’t we, Huck? Poor
+thing--does it want to see its mother? And so it shall. You like it here,
+don’t you, Huck? We’ll stay, won’t we?”
+
+Huck said, “Y-e-s”--without any heart in it.
+
+“I’ll never speak to you again as long as I live,” said Joe, rising.
+“There now!” And he moved moodily away and began to dress himself.
+
+“Who cares!” said Tom. “Nobody wants you to. Go ‘long home and get
+laughed at. Oh, you’re a nice pirate. Huck and me ain’t crybabies. We’ll
+stay, won’t we, Huck? Let him go if he wants to. I reckon we can get
+along without him, per’aps.”
+
+But Tom was uneasy, nevertheless, and was alarmed to see Joe go sullenly
+on with his dressing. And then it was discomforting to see Huck eying
+Joe’s preparations so wistfully, and keeping up such an ominous silence.
+Presently, without a parting word, Joe began to wade off toward the
+Illinois shore. Tom’s heart began to sink. He glanced at Huck. Huck
+could not bear the look, and dropped his eyes. Then he said:
+
+“I want to go, too, Tom. It was getting so lonesome anyway, and now
+it’ll be worse. Let’s us go, too, Tom.”
+
+“I won’t! You can all go, if you want to. I mean to stay.”
+
+“Tom, I better go.”
+
+“Well, go ‘long--who’s hendering you.”
+
+Huck began to pick up his scattered clothes. He said:
+
+“Tom, I wisht you’d come, too. Now you think it over. We’ll wait for you
+when we get to shore.”
+
+“Well, you’ll wait a blame long time, that’s all.”
+
+Huck started sorrowfully away, and Tom stood looking after him, with a
+strong desire tugging at his heart to yield his pride and go along
+too. He hoped the boys would stop, but they still waded slowly on. It
+suddenly dawned on Tom that it was become very lonely and still. He made
+one final struggle with his pride, and then darted after his comrades,
+yelling:
+
+“Wait! Wait! I want to tell you something!”
+
+They presently stopped and turned around. When he got to where they
+were, he began unfolding his secret, and they listened moodily till
+at last they saw the “point” he was driving at, and then they set up a
+warwhoop of applause and said it was “splendid!” and said if he had
+told them at first, they wouldn’t have started away. He made a plausible
+excuse; but his real reason had been the fear that not even the secret
+would keep them with him any very great length of time, and so he had
+meant to hold it in reserve as a last seduction.
+
+The lads came gayly back and went at their sports again with a will,
+chattering all the time about Tom’s stupendous plan and admiring the
+genius of it. After a dainty egg and fish dinner, Tom said he wanted to
+learn to smoke, now. Joe caught at the idea and said he would like to
+try, too. So Huck made pipes and filled them. These novices had never
+smoked anything before but cigars made of grapevine, and they “bit” the
+tongue, and were not considered manly anyway.
+
+Now they stretched themselves out on their elbows and began to puff,
+charily, and with slender confidence. The smoke had an unpleasant taste,
+and they gagged a little, but Tom said:
+
+“Why, it’s just as easy! If I’d a knowed this was all, I’d a learnt long
+ago.”
+
+“So would I,” said Joe. “It’s just nothing.”
+
+“Why, many a time I’ve looked at people smoking, and thought well I wish
+I could do that; but I never thought I could,” said Tom.
+
+“That’s just the way with me, hain’t it, Huck? You’ve heard me talk just
+that way--haven’t you, Huck? I’ll leave it to Huck if I haven’t.”
+
+“Yes--heaps of times,” said Huck.
+
+“Well, I have too,” said Tom; “oh, hundreds of times. Once down by the
+slaughter-house. Don’t you remember, Huck? Bob Tanner was there, and
+Johnny Miller, and Jeff Thatcher, when I said it. Don’t you remember,
+Huck, ‘bout me saying that?”
+
+“Yes, that’s so,” said Huck. “That was the day after I lost a white
+alley. No, ‘twas the day before.”
+
+“There--I told you so,” said Tom. “Huck recollects it.”
+
+“I bleeve I could smoke this pipe all day,” said Joe. “I don’t feel
+sick.”
+
+“Neither do I,” said Tom. “I could smoke it all day. But I bet you Jeff
+Thatcher couldn’t.”
+
+“Jeff Thatcher! Why, he’d keel over just with two draws. Just let him
+try it once. _He’d_ see!”
+
+“I bet he would. And Johnny Miller--I wish could see Johnny Miller tackle
+it once.”
+
+“Oh, don’t I!” said Joe. “Why, I bet you Johnny Miller couldn’t any more
+do this than nothing. Just one little snifter would fetch _him_.”
+
+“‘Deed it would, Joe. Say--I wish the boys could see us now.”
+
+“So do I.”
+
+“Say--boys, don’t say anything about it, and some time when they’re
+around, I’ll come up to you and say, ‘Joe, got a pipe? I want a smoke.’
+And you’ll say, kind of careless like, as if it warn’t anything, you’ll
+say, ‘Yes, I got my _old_ pipe, and another one, but my tobacker ain’t
+very good.’ And I’ll say, ‘Oh, that’s all right, if it’s _strong_
+enough.’ And then you’ll out with the pipes, and we’ll light up just as
+ca’m, and then just see ‘em look!”
+
+“By jings, that’ll be gay, Tom! I wish it was _now_!”
+
+“So do I! And when we tell ‘em we learned when we was off pirating,
+won’t they wish they’d been along?”
+
+“Oh, I reckon not! I’ll just _bet_ they will!”
+
+So the talk ran on. But presently it began to flag a trifle, and
+grow disjointed. The silences widened; the expectoration marvellously
+increased. Every pore inside the boys’ cheeks became a spouting
+fountain; they could scarcely bail out the cellars under their tongues
+fast enough to prevent an inundation; little overflowings down their
+throats occurred in spite of all they could do, and sudden retchings
+followed every time. Both boys were looking very pale and miserable,
+now. Joe’s pipe dropped from his nerveless fingers. Tom’s followed. Both
+fountains were going furiously and both pumps bailing with might and
+main. Joe said feebly:
+
+“I’ve lost my knife. I reckon I better go and find it.”
+
+Tom said, with quivering lips and halting utterance:
+
+“I’ll help you. You go over that way and I’ll hunt around by the spring.
+No, you needn’t come, Huck--we can find it.”
+
+So Huck sat down again, and waited an hour. Then he found it lonesome,
+and went to find his comrades. They were wide apart in the woods, both
+very pale, both fast asleep. But something informed him that if they had
+had any trouble they had got rid of it.
+
+They were not talkative at supper that night. They had a humble look,
+and when Huck prepared his pipe after the meal and was going to prepare
+theirs, they said no, they were not feeling very well--something they ate
+at dinner had disagreed with them.
+
+About midnight Joe awoke, and called the boys. There was a brooding
+oppressiveness in the air that seemed to bode something. The boys
+huddled themselves together and sought the friendly companionship of
+the fire, though the dull dead heat of the breathless atmosphere was
+stifling. They sat still, intent and waiting. The solemn hush continued.
+Beyond the light of the fire everything was swallowed up in the
+blackness of darkness. Presently there came a quivering glow that
+vaguely revealed the foliage for a moment and then vanished. By and by
+another came, a little stronger. Then another. Then a faint moan came
+sighing through the branches of the forest and the boys felt a fleeting
+breath upon their cheeks, and shuddered with the fancy that the Spirit
+of the Night had gone by. There was a pause. Now a weird flash turned
+night into day and showed every little grassblade, separate and
+distinct, that grew about their feet. And it showed three white,
+startled faces, too. A deep peal of thunder went rolling and tumbling
+down the heavens and lost itself in sullen rumblings in the distance. A
+sweep of chilly air passed by, rustling all the leaves and snowing the
+flaky ashes broadcast about the fire. Another fierce glare lit up the
+forest and an instant crash followed that seemed to rend the treetops
+right over the boys’ heads. They clung together in terror, in the thick
+gloom that followed. A few big raindrops fell pattering upon the leaves.
+
+“Quick! boys, go for the tent!” exclaimed Tom.
+
+They sprang away, stumbling over roots and among vines in the dark, no
+two plunging in the same direction. A furious blast roared through
+the trees, making everything sing as it went. One blinding flash after
+another came, and peal on peal of deafening thunder. And now a drenching
+rain poured down and the rising hurricane drove it in sheets along the
+ground. The boys cried out to each other, but the roaring wind and the
+booming thunderblasts drowned their voices utterly. However, one by one
+they straggled in at last and took shelter under the tent, cold, scared,
+and streaming with water; but to have company in misery seemed something
+to be grateful for. They could not talk, the old sail flapped so
+furiously, even if the other noises would have allowed them. The tempest
+rose higher and higher, and presently the sail tore loose from its
+fastenings and went winging away on the blast. The boys seized each
+others’ hands and fled, with many tumblings and bruises, to the shelter
+of a great oak that stood upon the riverbank. Now the battle was at its
+highest. Under the ceaseless conflagration of lightning that flamed
+in the skies, everything below stood out in cleancut and shadowless
+distinctness: the bending trees, the billowy river, white with foam, the
+driving spray of spumeflakes, the dim outlines of the high bluffs on
+the other side, glimpsed through the drifting cloudrack and the slanting
+veil of rain. Every little while some giant tree yielded the fight
+and fell crashing through the younger growth; and the unflagging
+thunderpeals came now in ear-splitting explosive bursts, keen and sharp,
+and unspeakably appalling. The storm culminated in one matchless effort
+that seemed likely to tear the island to pieces, burn it up, drown it to
+the treetops, blow it away, and deafen every creature in it, all at one
+and the same moment. It was a wild night for homeless young heads to be
+out in.
+
+But at last the battle was done, and the forces retired with weaker and
+weaker threatenings and grumblings, and peace resumed her sway. The
+boys went back to camp, a good deal awed; but they found there was still
+something to be thankful for, because the great sycamore, the shelter
+of their beds, was a ruin, now, blasted by the lightnings, and they were
+not under it when the catastrophe happened.
+
+Everything in camp was drenched, the campfire as well; for they were but
+heedless lads, like their generation, and had made no provision against
+rain. Here was matter for dismay, for they were soaked through and
+chilled. They were eloquent in their distress; but they presently
+discovered that the fire had eaten so far up under the great log it had
+been built against (where it curved upward and separated itself from
+the ground), that a handbreadth or so of it had escaped wetting; so they
+patiently wrought until, with shreds and bark gathered from the under
+sides of sheltered logs, they coaxed the fire to burn again. Then they
+piled on great dead boughs till they had a roaring furnace, and were
+gladhearted once more. They dried their boiled ham and had a feast,
+and after that they sat by the fire and expanded and glorified their
+midnight adventure until morning, for there was not a dry spot to sleep
+on, anywhere around.
+
+As the sun began to steal in upon the boys, drowsiness came over
+them, and they went out on the sandbar and lay down to sleep. They got
+scorched out by and by, and drearily set about getting breakfast. After
+the meal they felt rusty, and stiff-jointed, and a little homesick once
+more. Tom saw the signs, and fell to cheering up the pirates as well as
+he could. But they cared nothing for marbles, or circus, or swimming, or
+anything. He reminded them of the imposing secret, and raised a ray of
+cheer. While it lasted, he got them interested in a new device. This was
+to knock off being pirates, for a while, and be Indians for a change.
+They were attracted by this idea; so it was not long before they were
+stripped, and striped from head to heel with black mud, like so many
+zebras--all of them chiefs, of course--and then they went tearing through
+the woods to attack an English settlement.
+
+By and by they separated into three hostile tribes, and darted upon each
+other from ambush with dreadful warwhoops, and killed and scalped each
+other by thousands. It was a gory day. Consequently it was an extremely
+satisfactory one.
+
+They assembled in camp toward suppertime, hungry and happy; but now
+a difficulty arose--hostile Indians could not break the bread of
+hospitality together without first making peace, and this was a simple
+impossibility without smoking a pipe of peace. There was no other
+process that ever they had heard of. Two of the savages almost wished
+they had remained pirates. However, there was no other way; so with such
+show of cheerfulness as they could muster they called for the pipe and
+took their whiff as it passed, in due form.
+
+And behold, they were glad they had gone into savagery, for they had
+gained something; they found that they could now smoke a little without
+having to go and hunt for a lost knife; they did not get sick enough to
+be seriously uncomfortable. They were not likely to fool away this high
+promise for lack of effort. No, they practised cautiously, after supper,
+with right fair success, and so they spent a jubilant evening. They were
+prouder and happier in their new acquirement than they would have been
+in the scalping and skinning of the Six Nations. We will leave them to
+smoke and chatter and brag, since we have no further use for them at
+present.
+
+
+
+
+CHAPTER XVII
+
+BUT there was no hilarity in the little town that same tranquil Saturday
+afternoon. The Harpers, and Aunt Polly’s family, were being put into
+mourning, with great grief and many tears. An unusual quiet possessed
+the village, although it was ordinarily quiet enough, in all conscience.
+The villagers conducted their concerns with an absent air, and talked
+little; but they sighed often. The Saturday holiday seemed a burden to
+the children. They had no heart in their sports, and gradually gave them
+up.
+
+In the afternoon Becky Thatcher found herself moping about the deserted
+schoolhouse yard, and feeling very melancholy. But she found nothing
+there to comfort her. She soliloquized:
+
+“Oh, if I only had a brass andiron-knob again! But I haven’t got
+anything now to remember him by.” And she choked back a little sob.
+
+Presently she stopped, and said to herself:
+
+“It was right here. Oh, if it was to do over again, I wouldn’t say
+that--I wouldn’t say it for the whole world. But he’s gone now; I’ll
+never, never, never see him any more.”
+
+This thought broke her down, and she wandered away, with tears rolling
+down her cheeks. Then quite a group of boys and girls--playmates of Tom’s
+and Joe’s--came by, and stood looking over the paling fence and talking
+in reverent tones of how Tom did so-and-so the last time they saw
+him, and how Joe said this and that small trifle (pregnant with awful
+prophecy, as they could easily see now!)--and each speaker pointed out
+the exact spot where the lost lads stood at the time, and then added
+something like “and I was a-standing just so--just as I am now, and as if
+you was him--I was as close as that--and he smiled, just this way--and then
+something seemed to go all over me, like--awful, you know--and I never
+thought what it meant, of course, but I can see now!”
+
+Then there was a dispute about who saw the dead boys last in life, and
+many claimed that dismal distinction, and offered evidences, more or
+less tampered with by the witness; and when it was ultimately decided
+who _did_ see the departed last, and exchanged the last words with them,
+the lucky parties took upon themselves a sort of sacred importance,
+and were gaped at and envied by all the rest. One poor chap, who had
+no other grandeur to offer, said with tolerably manifest pride in the
+remembrance:
+
+“Well, Tom Sawyer he licked me once.”
+
+But that bid for glory was a failure. Most of the boys could say that,
+and so that cheapened the distinction too much. The group loitered away,
+still recalling memories of the lost heroes, in awed voices.
+
+When the Sunday-school hour was finished, the next morning, the bell
+began to toll, instead of ringing in the usual way. It was a very still
+Sabbath, and the mournful sound seemed in keeping with the musing hush
+that lay upon nature. The villagers began to gather, loitering a moment
+in the vestibule to converse in whispers about the sad event. But there
+was no whispering in the house; only the funereal rustling of dresses
+as the women gathered to their seats disturbed the silence there. None
+could remember when the little church had been so full before. There
+was finally a waiting pause, an expectant dumbness, and then Aunt Polly
+entered, followed by Sid and Mary, and they by the Harper family, all in
+deep black, and the whole congregation, the old minister as well, rose
+reverently and stood until the mourners were seated in the front pew.
+There was another communing silence, broken at intervals by muffled
+sobs, and then the minister spread his hands abroad and prayed. A moving
+hymn was sung, and the text followed: “I am the Resurrection and the
+Life.”
+
+As the service proceeded, the clergyman drew such pictures of the
+graces, the winning ways, and the rare promise of the lost lads that
+every soul there, thinking he recognized these pictures, felt a pang
+in remembering that he had persistently blinded himself to them always
+before, and had as persistently seen only faults and flaws in the poor
+boys. The minister related many a touching incident in the lives of the
+departed, too, which illustrated their sweet, generous natures, and the
+people could easily see, now, how noble and beautiful those episodes
+were, and remembered with grief that at the time they occurred they had
+seemed rank rascalities, well deserving of the cowhide. The congregation
+became more and more moved, as the pathetic tale went on, till at last
+the whole company broke down and joined the weeping mourners in a chorus
+of anguished sobs, the preacher himself giving way to his feelings, and
+crying in the pulpit.
+
+There was a rustle in the gallery, which nobody noticed; a moment later
+the church door creaked; the minister raised his streaming eyes above
+his handkerchief, and stood transfixed! First one and then another pair
+of eyes followed the minister’s, and then almost with one impulse the
+congregation rose and stared while the three dead boys came marching up
+the aisle, Tom in the lead, Joe next, and Huck, a ruin of drooping rags,
+sneaking sheepishly in the rear! They had been hid in the unused gallery
+listening to their own funeral sermon!
+
+Aunt Polly, Mary, and the Harpers threw themselves upon their restored
+ones, smothered them with kisses and poured out thanksgivings, while
+poor Huck stood abashed and uncomfortable, not knowing exactly what
+to do or where to hide from so many unwelcoming eyes. He wavered, and
+started to slink away, but Tom seized him and said:
+
+“Aunt Polly, it ain’t fair. Somebody’s got to be glad to see Huck.”
+
+“And so they shall. I’m glad to see him, poor motherless thing!” And
+the loving attentions Aunt Polly lavished upon him were the one thing
+capable of making him more uncomfortable than he was before.
+
+Suddenly the minister shouted at the top of his voice: “Praise God from
+whom all blessings flow--_sing_!--and put your hearts in it!”
+
+And they did. Old Hundred swelled up with a triumphant burst, and
+while it shook the rafters Tom Sawyer the Pirate looked around upon the
+envying juveniles about him and confessed in his heart that this was the
+proudest moment of his life.
+
+As the “sold” congregation trooped out they said they would almost be
+willing to be made ridiculous again to hear Old Hundred sung like that
+once more.
+
+Tom got more cuffs and kisses that day--according to Aunt Polly’s varying
+moods--than he had earned before in a year; and he hardly knew which
+expressed the most gratefulness to God and affection for himself.
+
+
+
+
+CHAPTER XVIII
+
+THAT was Tom’s great secret--the scheme to return home with his brother
+pirates and attend their own funerals. They had paddled over to the
+Missouri shore on a log, at dusk on Saturday, landing five or six miles
+below the village; they had slept in the woods at the edge of the town
+till nearly daylight, and had then crept through back lanes and alleys
+and finished their sleep in the gallery of the church among a chaos of
+invalided benches.
+
+At breakfast, Monday morning, Aunt Polly and Mary were very loving to
+Tom, and very attentive to his wants. There was an unusual amount of
+talk. In the course of it Aunt Polly said:
+
+“Well, I don’t say it wasn’t a fine joke, Tom, to keep everybody
+suffering ‘most a week so you boys had a good time, but it is a pity you
+could be so hard-hearted as to let me suffer so. If you could come over
+on a log to go to your funeral, you could have come over and give me a
+hint some way that you warn’t dead, but only run off.”
+
+“Yes, you could have done that, Tom,” said Mary; “and I believe you
+would if you had thought of it.”
+
+“Would you, Tom?” said Aunt Polly, her face lighting wistfully. “Say,
+now, would you, if you’d thought of it?”
+
+“I--well, I don’t know. ‘Twould ‘a’ spoiled everything.”
+
+“Tom, I hoped you loved me that much,” said Aunt Polly, with a grieved
+tone that discomforted the boy. “It would have been something if you’d
+cared enough to _think_ of it, even if you didn’t _do_ it.”
+
+“Now, auntie, that ain’t any harm,” pleaded Mary; “it’s only Tom’s giddy
+way--he is always in such a rush that he never thinks of anything.”
+
+“More’s the pity. Sid would have thought. And Sid would have come and
+_done_ it, too. Tom, you’ll look back, some day, when it’s too late,
+and wish you’d cared a little more for me when it would have cost you so
+little.”
+
+“Now, auntie, you know I do care for you,” said Tom.
+
+“I’d know it better if you acted more like it.”
+
+“I wish now I’d thought,” said Tom, with a repentant tone; “but I dreamt
+about you, anyway. That’s something, ain’t it?”
+
+“It ain’t much--a cat does that much--but it’s better than nothing. What
+did you dream?”
+
+“Why, Wednesday night I dreamt that you was sitting over there by the
+bed, and Sid was sitting by the woodbox, and Mary next to him.”
+
+“Well, so we did. So we always do. I’m glad your dreams could take even
+that much trouble about us.”
+
+“And I dreamt that Joe Harper’s mother was here.”
+
+“Why, she was here! Did you dream any more?”
+
+“Oh, lots. But it’s so dim, now.”
+
+“Well, try to recollect--can’t you?”
+
+“Somehow it seems to me that the wind--the wind blowed the--the--”
+
+“Try harder, Tom! The wind did blow something. Come!”
+
+Tom pressed his fingers on his forehead an anxious minute, and then
+said:
+
+“I’ve got it now! I’ve got it now! It blowed the candle!”
+
+“Mercy on us! Go on, Tom--go on!”
+
+“And it seems to me that you said, ‘Why, I believe that that door--’”
+
+“Go _on_, Tom!”
+
+“Just let me study a moment--just a moment. Oh, yes--you said you believed
+the door was open.”
+
+“As I’m sitting here, I did! Didn’t I, Mary! Go on!”
+
+“And then--and then--well I won’t be certain, but it seems like as if you
+made Sid go and--and--”
+
+“Well? Well? What did I make him do, Tom? What did I make him do?”
+
+“You made him--you--Oh, you made him shut it.”
+
+“Well, for the land’s sake! I never heard the beat of that in all my
+days! Don’t tell _me_ there ain’t anything in dreams, any more. Sereny
+Harper shall know of this before I’m an hour older. I’d like to see her
+get around _this_ with her rubbage ‘bout superstition. Go on, Tom!”
+
+“Oh, it’s all getting just as bright as day, now. Next you said I warn’t
+_bad_, only mischeevous and harum-scarum, and not any more responsible
+than--than--I think it was a colt, or something.”
+
+“And so it was! Well, goodness gracious! Go on, Tom!”
+
+“And then you began to cry.”
+
+“So I did. So I did. Not the first time, neither. And then--”
+
+“Then Mrs. Harper she began to cry, and said Joe was just the same, and
+she wished she hadn’t whipped him for taking cream when she’d throwed it
+out her own self--”
+
+“Tom! The sperrit was upon you! You was a prophesying--that’s what you
+was doing! Land alive, go on, Tom!”
+
+“Then Sid he said--he said--”
+
+“I don’t think I said anything,” said Sid.
+
+“Yes you did, Sid,” said Mary.
+
+“Shut your heads and let Tom go on! What did he say, Tom?”
+
+“He said--I _think_ he said he hoped I was better off where I was gone
+to, but if I’d been better sometimes--”
+
+“_There_, d’you hear that! It was his very words!”
+
+“And you shut him up sharp.”
+
+“I lay I did! There must ‘a’ been an angel there. There _was_ an angel
+there, somewheres!”
+
+“And Mrs. Harper told about Joe scaring her with a firecracker, and you
+told about Peter and the Pain-killer--”
+
+“Just as true as I live!”
+
+“And then there was a whole lot of talk ‘bout dragging the river for us,
+and ‘bout having the funeral Sunday, and then you and old Miss Harper
+hugged and cried, and she went.”
+
+“It happened just so! It happened just so, as sure as I’m a-sitting in
+these very tracks. Tom, you couldn’t told it more like if you’d ‘a’ seen
+it! And then what? Go on, Tom!”
+
+“Then I thought you prayed for me--and I could see you and hear every
+word you said. And you went to bed, and I was so sorry that I took and
+wrote on a piece of sycamore bark, ‘We ain’t dead--we are only off being
+pirates,’ and put it on the table by the candle; and then you looked
+so good, laying there asleep, that I thought I went and leaned over and
+kissed you on the lips.”
+
+“Did you, Tom, _did_ you! I just forgive you everything for that!” And
+she seized the boy in a crushing embrace that made him feel like the
+guiltiest of villains.
+
+“It was very kind, even though it was only a--dream,” Sid soliloquized
+just audibly.
+
+“Shut up, Sid! A body does just the same in a dream as he’d do if he was
+awake. Here’s a big Milum apple I’ve been saving for you, Tom, if you
+was ever found again--now go ‘long to school. I’m thankful to the good
+God and Father of us all I’ve got you back, that’s long-suffering and
+merciful to them that believe on Him and keep His word, though goodness
+knows I’m unworthy of it, but if only the worthy ones got His blessings
+and had His hand to help them over the rough places, there’s few enough
+would smile here or ever enter into His rest when the long night comes.
+Go ‘long Sid, Mary, Tom--take yourselves off--you’ve hendered me long
+enough.”
+
+The children left for school, and the old lady to call on Mrs. Harper
+and vanquish her realism with Tom’s marvellous dream. Sid had better
+judgment than to utter the thought that was in his mind as he left the
+house. It was this: “Pretty thin--as long a dream as that, without any
+mistakes in it!”
+
+What a hero Tom was become, now! He did not go skipping and prancing,
+but moved with a dignified swagger as became a pirate who felt that the
+public eye was on him. And indeed it was; he tried not to seem to see
+the looks or hear the remarks as he passed along, but they were food and
+drink to him. Smaller boys than himself flocked at his heels, as proud
+to be seen with him, and tolerated by him, as if he had been the drummer
+at the head of a procession or the elephant leading a menagerie into
+town. Boys of his own size pretended not to know he had been away at
+all; but they were consuming with envy, nevertheless. They would have
+given anything to have that swarthy sun-tanned skin of his, and his
+glittering notoriety; and Tom would not have parted with either for a
+circus.
+
+At school the children made so much of him and of Joe, and delivered
+such eloquent admiration from their eyes, that the two heroes were
+not long in becoming insufferably “stuck-up.” They began to tell their
+adventures to hungry listeners--but they only began; it was not a
+thing likely to have an end, with imaginations like theirs to furnish
+material. And finally, when they got out their pipes and went serenely
+puffing around, the very summit of glory was reached.
+
+Tom decided that he could be independent of Becky Thatcher now. Glory
+was sufficient. He would live for glory. Now that he was distinguished,
+maybe she would be wanting to “make up.” Well, let her--she should see
+that he could be as indifferent as some other people. Presently she
+arrived. Tom pretended not to see her. He moved away and joined a group
+of boys and girls and began to talk. Soon he observed that she was
+tripping gayly back and forth with flushed face and dancing eyes,
+pretending to be busy chasing schoolmates, and screaming with laughter
+when she made a capture; but he noticed that she always made her
+captures in his vicinity, and that she seemed to cast a conscious eye
+in his direction at such times, too. It gratified all the vicious vanity
+that was in him; and so, instead of winning him, it only “set him up”
+ the more and made him the more diligent to avoid betraying that he
+knew she was about. Presently she gave over skylarking, and moved
+irresolutely about, sighing once or twice and glancing furtively and
+wistfully toward Tom. Then she observed that now Tom was talking more
+particularly to Amy Lawrence than to any one else. She felt a sharp pang
+and grew disturbed and uneasy at once. She tried to go away, but her
+feet were treacherous, and carried her to the group instead. She said to
+a girl almost at Tom’s elbow--with sham vivacity:
+
+“Why, Mary Austin! you bad girl, why didn’t you come to Sunday-school?”
+
+“I did come--didn’t you see me?”
+
+“Why, no! Did you? Where did you sit?”
+
+“I was in Miss Peters’ class, where I always go. I saw _you_.”
+
+“Did you? Why, it’s funny I didn’t see you. I wanted to tell you about
+the picnic.”
+
+“Oh, that’s jolly. Who’s going to give it?”
+
+“My ma’s going to let me have one.”
+
+“Oh, goody; I hope she’ll let _me_ come.”
+
+“Well, she will. The picnic’s for me. She’ll let anybody come that I
+want, and I want you.”
+
+“That’s ever so nice. When is it going to be?”
+
+“By and by. Maybe about vacation.”
+
+“Oh, won’t it be fun! You going to have all the girls and boys?”
+
+“Yes, every one that’s friends to me--or wants to be”; and she glanced
+ever so furtively at Tom, but he talked right along to Amy Lawrence
+about the terrible storm on the island, and how the lightning tore the
+great sycamore tree “all to flinders” while he was “standing within
+three feet of it.”
+
+“Oh, may I come?” said Grace Miller.
+
+“Yes.”
+
+“And me?” said Sally Rogers.
+
+“Yes.”
+
+“And me, too?” said Susy Harper. “And Joe?”
+
+“Yes.”
+
+And so on, with clapping of joyful hands till all the group had begged
+for invitations but Tom and Amy. Then Tom turned coolly away, still
+talking, and took Amy with him. Becky’s lips trembled and the tears
+came to her eyes; she hid these signs with a forced gayety and went on
+chattering, but the life had gone out of the picnic, now, and out of
+everything else; she got away as soon as she could and hid herself and
+had what her sex call “a good cry.” Then she sat moody, with wounded
+pride, till the bell rang. She roused up, now, with a vindictive cast
+in her eye, and gave her plaited tails a shake and said she knew what
+_she’d_ do.
+
+At recess Tom continued his flirtation with Amy with jubilant
+self-satisfaction. And he kept drifting about to find Becky and lacerate
+her with the performance. At last he spied her, but there was a sudden
+falling of his mercury. She was sitting cosily on a little bench behind
+the schoolhouse looking at a picture-book with Alfred Temple--and so
+absorbed were they, and their heads so close together over the book,
+that they did not seem to be conscious of anything in the world besides.
+Jealousy ran red-hot through Tom’s veins. He began to hate himself for
+throwing away the chance Becky had offered for a reconciliation. He
+called himself a fool, and all the hard names he could think of. He
+wanted to cry with vexation. Amy chatted happily along, as they walked,
+for her heart was singing, but Tom’s tongue had lost its function. He
+did not hear what Amy was saying, and whenever she paused expectantly
+he could only stammer an awkward assent, which was as often misplaced
+as otherwise. He kept drifting to the rear of the schoolhouse, again and
+again, to sear his eyeballs with the hateful spectacle there. He could
+not help it. And it maddened him to see, as he thought he saw, that
+Becky Thatcher never once suspected that he was even in the land of the
+living. But she did see, nevertheless; and she knew she was winning her
+fight, too, and was glad to see him suffer as she had suffered.
+
+Amy’s happy prattle became intolerable. Tom hinted at things he had
+to attend to; things that must be done; and time was fleeting. But in
+vain--the girl chirped on. Tom thought, “Oh, hang her, ain’t I ever going
+to get rid of her?” At last he must be attending to those things--and she
+said artlessly that she would be “around” when school let out. And he
+hastened away, hating her for it.
+
+“Any other boy!” Tom thought, grating his teeth. “Any boy in the whole
+town but that Saint Louis smarty that thinks he dresses so fine and is
+aristocracy! Oh, all right, I licked you the first day you ever saw this
+town, mister, and I’ll lick you again! You just wait till I catch you
+out! I’ll just take and--”
+
+And he went through the motions of thrashing an imaginary boy--pummelling
+the air, and kicking and gouging. “Oh, you do, do you? You holler
+‘nough, do you? Now, then, let that learn you!” And so the imaginary
+flogging was finished to his satisfaction.
+
+Tom fled home at noon. His conscience could not endure any more of Amy’s
+grateful happiness, and his jealousy could bear no more of the other
+distress. Becky resumed her picture inspections with Alfred, but as the
+minutes dragged along and no Tom came to suffer, her triumph began to
+cloud and she lost interest; gravity and absentmindedness followed,
+and then melancholy; two or three times she pricked up her ear at
+a footstep, but it was a false hope; no Tom came. At last she grew
+entirely miserable and wished she hadn’t carried it so far. When
+poor Alfred, seeing that he was losing her, he did not know how, kept
+exclaiming: “Oh, here’s a jolly one! look at this!” she lost patience at
+last, and said, “Oh, don’t bother me! I don’t care for them!” and burst
+into tears, and got up and walked away.
+
+Alfred dropped alongside and was going to try to comfort her, but she
+said:
+
+“Go away and leave me alone, can’t you! I hate you!”
+
+So the boy halted, wondering what he could have done--for she had said
+she would look at pictures all through the nooning--and she walked on,
+crying. Then Alfred went musing into the deserted schoolhouse. He was
+humiliated and angry. He easily guessed his way to the truth--the girl
+had simply made a convenience of him to vent her spite upon Tom Sawyer.
+He was far from hating Tom the less when this thought occurred to him.
+He wished there was some way to get that boy into trouble without much
+risk to himself. Tom’s spelling-book fell under his eye. Here was his
+opportunity. He gratefully opened to the lesson for the afternoon and
+poured ink upon the page.
+
+Becky, glancing in at a window behind him at the moment, saw the act,
+and moved on, without discovering herself. She started homeward, now,
+intending to find Tom and tell him; Tom would be thankful and their
+troubles would be healed. Before she was half way home, however, she
+had changed her mind. The thought of Tom’s treatment of her when she was
+talking about her picnic came scorching back and filled her with shame.
+She resolved to let him get whipped on the damaged spelling-book’s
+account, and to hate him forever, into the bargain.
+
+
+
+
+CHAPTER XIX
+
+TOM arrived at home in a dreary mood, and the first thing his aunt said
+to him showed him that he had brought his sorrows to an unpromising
+market:
+
+“Tom, I’ve a notion to skin you alive!”
+
+“Auntie, what have I done?”
+
+“Well, you’ve done enough. Here I go over to Sereny Harper, like an old
+softy, expecting I’m going to make her believe all that rubbage about
+that dream, when lo and behold you she’d found out from Joe that you was
+over here and heard all the talk we had that night. Tom, I don’t know
+what is to become of a boy that will act like that. It makes me feel so
+bad to think you could let me go to Sereny Harper and make such a fool
+of myself and never say a word.”
+
+This was a new aspect of the thing. His smartness of the morning had
+seemed to Tom a good joke before, and very ingenious. It merely looked
+mean and shabby now. He hung his head and could not think of anything to
+say for a moment. Then he said:
+
+“Auntie, I wish I hadn’t done it--but I didn’t think.”
+
+“Oh, child, you never think. You never think of anything but your
+own selfishness. You could think to come all the way over here from
+Jackson’s Island in the night to laugh at our troubles, and you could
+think to fool me with a lie about a dream; but you couldn’t ever think
+to pity us and save us from sorrow.”
+
+“Auntie, I know now it was mean, but I didn’t mean to be mean. I didn’t,
+honest. And besides, I didn’t come over here to laugh at you that
+night.”
+
+“What did you come for, then?”
+
+“It was to tell you not to be uneasy about us, because we hadn’t got
+drownded.”
+
+“Tom, Tom, I would be the thankfullest soul in this world if I could
+believe you ever had as good a thought as that, but you know you never
+did--and I know it, Tom.”
+
+“Indeed and ‘deed I did, auntie--I wish I may never stir if I didn’t.”
+
+“Oh, Tom, don’t lie--don’t do it. It only makes things a hundred times
+worse.”
+
+“It ain’t a lie, auntie; it’s the truth. I wanted to keep you from
+grieving--that was all that made me come.”
+
+“I’d give the whole world to believe that--it would cover up a power
+of sins, Tom. I’d ‘most be glad you’d run off and acted so bad. But it
+ain’t reasonable; because, why didn’t you tell me, child?”
+
+“Why, you see, when you got to talking about the funeral, I just got all
+full of the idea of our coming and hiding in the church, and I couldn’t
+somehow bear to spoil it. So I just put the bark back in my pocket and
+kept mum.”
+
+“What bark?”
+
+“The bark I had wrote on to tell you we’d gone pirating. I wish, now,
+you’d waked up when I kissed you--I do, honest.”
+
+The hard lines in his aunt’s face relaxed and a sudden tenderness dawned
+in her eyes.
+
+“_Did_ you kiss me, Tom?”
+
+“Why, yes, I did.”
+
+“Are you sure you did, Tom?”
+
+“Why, yes, I did, auntie--certain sure.”
+
+“What did you kiss me for, Tom?”
+
+“Because I loved you so, and you laid there moaning and I was so sorry.”
+
+The words sounded like truth. The old lady could not hide a tremor in
+her voice when she said:
+
+“Kiss me again, Tom!--and be off with you to school, now, and don’t
+bother me any more.”
+
+The moment he was gone, she ran to a closet and got out the ruin of a
+jacket which Tom had gone pirating in. Then she stopped, with it in her
+hand, and said to herself:
+
+“No, I don’t dare. Poor boy, I reckon he’s lied about it--but it’s a
+blessed, blessed lie, there’s such a comfort come from it. I hope
+the Lord--I _know_ the Lord will forgive him, because it was such
+good-heartedness in him to tell it. But I don’t want to find out it’s a
+lie. I won’t look.”
+
+She put the jacket away, and stood by musing a minute. Twice she put out
+her hand to take the garment again, and twice she refrained. Once more
+she ventured, and this time she fortified herself with the thought:
+“It’s a good lie--it’s a good lie--I won’t let it grieve me.” So she
+sought the jacket pocket. A moment later she was reading Tom’s piece of
+bark through flowing tears and saying: “I could forgive the boy, now, if
+he’d committed a million sins!”
+
+
+
+
+CHAPTER XX
+
+THERE was something about Aunt Polly’s manner, when she kissed Tom, that
+swept away his low spirits and made him lighthearted and happy again. He
+started to school and had the luck of coming upon Becky Thatcher at the
+head of Meadow Lane. His mood always determined his manner. Without a
+moment’s hesitation he ran to her and said:
+
+“I acted mighty mean today, Becky, and I’m so sorry. I won’t ever, ever
+do that way again, as long as ever I live--please make up, won’t you?”
+
+The girl stopped and looked him scornfully in the face:
+
+“I’ll thank you to keep yourself _to_ yourself, Mr. Thomas Sawyer. I’ll
+never speak to you again.”
+
+She tossed her head and passed on. Tom was so stunned that he had not
+even presence of mind enough to say “Who cares, Miss Smarty?” until the
+right time to say it had gone by. So he said nothing. But he was in a
+fine rage, nevertheless. He moped into the schoolyard wishing she were
+a boy, and imagining how he would trounce her if she were. He presently
+encountered her and delivered a stinging remark as he passed. She hurled
+one in return, and the angry breach was complete. It seemed to Becky, in
+her hot resentment, that she could hardly wait for school to “take in,”
+ she was so impatient to see Tom flogged for the injured spelling-book.
+If she had had any lingering notion of exposing Alfred Temple, Tom’s
+offensive fling had driven it entirely away.
+
+Poor girl, she did not know how fast she was nearing trouble herself.
+The master, Mr. Dobbins, had reached middle age with an unsatisfied
+ambition. The darling of his desires was, to be a doctor, but
+poverty had decreed that he should be nothing higher than a village
+schoolmaster. Every day he took a mysterious book out of his desk and
+absorbed himself in it at times when no classes were reciting. He kept
+that book under lock and key. There was not an urchin in school but was
+perishing to have a glimpse of it, but the chance never came. Every boy
+and girl had a theory about the nature of that book; but no two theories
+were alike, and there was no way of getting at the facts in the case.
+Now, as Becky was passing by the desk, which stood near the door, she
+noticed that the key was in the lock! It was a precious moment. She
+glanced around; found herself alone, and the next instant she had the
+book in her hands. The titlepage--Professor Somebody’s _Anatomy_--carried
+no information to her mind; so she began to turn the leaves. She came at
+once upon a handsomely engraved and colored frontispiece--a human figure,
+stark naked. At that moment a shadow fell on the page and Tom Sawyer
+stepped in at the door and caught a glimpse of the picture. Becky
+snatched at the book to close it, and had the hard luck to tear the
+pictured page half down the middle. She thrust the volume into the desk,
+turned the key, and burst out crying with shame and vexation.
+
+“Tom Sawyer, you are just as mean as you can be, to sneak up on a person
+and look at what they’re looking at.”
+
+“How could I know you was looking at anything?”
+
+“You ought to be ashamed of yourself, Tom Sawyer; you know you’re
+going to tell on me, and oh, what shall I do, what shall I do! I’ll be
+whipped, and I never was whipped in school.”
+
+Then she stamped her little foot and said:
+
+“_Be_ so mean if you want to! I know something that’s going to happen.
+You just wait and you’ll see! Hateful, hateful, hateful!”--and she flung
+out of the house with a new explosion of crying.
+
+Tom stood still, rather flustered by this onslaught. Presently he said
+to himself:
+
+“What a curious kind of a fool a girl is! Never been licked in
+school! Shucks! What’s a licking! That’s just like a girl--they’re so
+thin-skinned and chicken-hearted. Well, of course I ain’t going to tell
+old Dobbins on this little fool, because there’s other ways of getting
+even on her, that ain’t so mean; but what of it? Old Dobbins will ask
+who it was tore his book. Nobody’ll answer. Then he’ll do just the way
+he always does--ask first one and then t’other, and when he comes to the
+right girl he’ll know it, without any telling. Girls’ faces always tell
+on them. They ain’t got any backbone. She’ll get licked. Well, it’s a
+kind of a tight place for Becky Thatcher, because there ain’t any way
+out of it.” Tom conned the thing a moment longer, and then added: “All
+right, though; she’d like to see me in just such a fix--let her sweat it
+out!”
+
+Tom joined the mob of skylarking scholars outside. In a few moments the
+master arrived and school “took in.” Tom did not feel a strong interest
+in his studies. Every time he stole a glance at the girls’ side of the
+room Becky’s face troubled him. Considering all things, he did not want
+to pity her, and yet it was all he could do to help it. He could get
+up no exultation that was really worthy the name. Presently the
+spelling-book discovery was made, and Tom’s mind was entirely full
+of his own matters for a while after that. Becky roused up from her
+lethargy of distress and showed good interest in the proceedings. She
+did not expect that Tom could get out of his trouble by denying that he
+spilt the ink on the book himself; and she was right. The denial only
+seemed to make the thing worse for Tom. Becky supposed she would be glad
+of that, and she tried to believe she was glad of it, but she found she
+was not certain. When the worst came to the worst, she had an impulse
+to get up and tell on Alfred Temple, but she made an effort and forced
+herself to keep still--because, said she to herself, “he’ll tell about me
+tearing the picture sure. I wouldn’t say a word, not to save his life!”
+
+Tom took his whipping and went back to his seat not at all
+broken-hearted, for he thought it was possible that he had unknowingly
+upset the ink on the spelling-book himself, in some skylarking bout--he
+had denied it for form’s sake and because it was custom, and had stuck
+to the denial from principle.
+
+A whole hour drifted by, the master sat nodding in his throne, the air
+was drowsy with the hum of study. By and by, Mr. Dobbins straightened
+himself up, yawned, then unlocked his desk, and reached for his book,
+but seemed undecided whether to take it out or leave it. Most of the
+pupils glanced up languidly, but there were two among them that watched
+his movements with intent eyes. Mr. Dobbins fingered his book absently
+for a while, then took it out and settled himself in his chair to read!
+Tom shot a glance at Becky. He had seen a hunted and helpless rabbit
+look as she did, with a gun levelled at its head. Instantly he forgot
+his quarrel with her. Quick--something must be done! done in a flash,
+too! But the very imminence of the emergency paralyzed his invention.
+Good!--he had an inspiration! He would run and snatch the book, spring
+through the door and fly. But his resolution shook for one little
+instant, and the chance was lost--the master opened the volume. If Tom
+only had the wasted opportunity back again! Too late. There was no help
+for Becky now, he said. The next moment the master faced the school.
+Every eye sank under his gaze. There was that in it which smote even
+the innocent with fear. There was silence while one might count ten--the
+master was gathering his wrath. Then he spoke: “Who tore this book?”
+
+There was not a sound. One could have heard a pin drop. The stillness
+continued; the master searched face after face for signs of guilt.
+
+“Benjamin Rogers, did you tear this book?”
+
+A denial. Another pause.
+
+“Joseph Harper, did you?”
+
+Another denial. Tom’s uneasiness grew more and more intense under the
+slow torture of these proceedings. The master scanned the ranks of
+boys--considered a while, then turned to the girls:
+
+“Amy Lawrence?”
+
+A shake of the head.
+
+“Gracie Miller?”
+
+The same sign.
+
+“Susan Harper, did you do this?”
+
+Another negative. The next girl was Becky Thatcher. Tom was trembling
+from head to foot with excitement and a sense of the hopelessness of the
+situation.
+
+“Rebecca Thatcher” [Tom glanced at her face--it was white with
+terror]--“did you tear--no, look me in the face” [her hands rose in
+appeal]--“did you tear this book?”
+
+A thought shot like lightning through Tom’s brain. He sprang to his feet
+and shouted--“I done it!”
+
+The school stared in perplexity at this incredible folly. Tom stood a
+moment, to gather his dismembered faculties; and when he stepped forward
+to go to his punishment the surprise, the gratitude, the adoration that
+shone upon him out of poor Becky’s eyes seemed pay enough for a hundred
+floggings. Inspired by the splendor of his own act, he took without
+an outcry the most merciless flaying that even Mr. Dobbins had ever
+administered; and also received with indifference the added cruelty of a
+command to remain two hours after school should be dismissed--for he
+knew who would wait for him outside till his captivity was done, and not
+count the tedious time as loss, either.
+
+Tom went to bed that night planning vengeance against Alfred Temple; for
+with shame and repentance Becky had told him all, not forgetting her own
+treachery; but even the longing for vengeance had to give way, soon, to
+pleasanter musings, and he fell asleep at last with Becky’s latest words
+lingering dreamily in his ear--
+
+“Tom, how _could_ you be so noble!”
+
+
+
+
+CHAPTER XXI
+
+VACATION was approaching. The schoolmaster, always severe, grew severer
+and more exacting than ever, for he wanted the school to make a good
+showing on “Examination” day. His rod and his ferule were seldom idle
+now--at least among the smaller pupils. Only the biggest boys, and young
+ladies of eighteen and twenty, escaped lashing. Mr. Dobbins’ lashings
+were very vigorous ones, too; for although he carried, under his wig, a
+perfectly bald and shiny head, he had only reached middle age, and there
+was no sign of feebleness in his muscle. As the great day approached,
+all the tyranny that was in him came to the surface; he seemed to take a
+vindictive pleasure in punishing the least shortcomings. The consequence
+was, that the smaller boys spent their days in terror and suffering and
+their nights in plotting revenge. They threw away no opportunity to do
+the master a mischief. But he kept ahead all the time. The retribution
+that followed every vengeful success was so sweeping and majestic that
+the boys always retired from the field badly worsted. At last they
+conspired together and hit upon a plan that promised a dazzling victory.
+They swore in the signpainter’s boy, told him the scheme, and asked his
+help. He had his own reasons for being delighted, for the master boarded
+in his father’s family and had given the boy ample cause to hate him.
+The master’s wife would go on a visit to the country in a few days, and
+there would be nothing to interfere with the plan; the master always
+prepared himself for great occasions by getting pretty well fuddled, and
+the signpainter’s boy said that when the dominie had reached the proper
+condition on Examination Evening he would “manage the thing” while he
+napped in his chair; then he would have him awakened at the right time
+and hurried away to school.
+
+In the fulness of time the interesting occasion arrived. At eight in
+the evening the schoolhouse was brilliantly lighted, and adorned with
+wreaths and festoons of foliage and flowers. The master sat throned in
+his great chair upon a raised platform, with his blackboard behind him.
+He was looking tolerably mellow. Three rows of benches on each side and
+six rows in front of him were occupied by the dignitaries of the town
+and by the parents of the pupils. To his left, back of the rows of
+citizens, was a spacious temporary platform upon which were seated the
+scholars who were to take part in the exercises of the evening; rows of
+small boys, washed and dressed to an intolerable state of discomfort;
+rows of gawky big boys; snowbanks of girls and young ladies clad in
+lawn and muslin and conspicuously conscious of their bare arms, their
+grandmothers’ ancient trinkets, their bits of pink and blue ribbon and
+the flowers in their hair. All the rest of the house was filled with
+non-participating scholars.
+
+The exercises began. A very little boy stood up and sheepishly recited,
+“You’d scarce expect one of my age to speak in public on the stage,”
+ etc.--accompanying himself with the painfully exact and spasmodic
+gestures which a machine might have used--supposing the machine to be a
+trifle out of order. But he got through safely, though cruelly scared,
+and got a fine round of applause when he made his manufactured bow and
+retired.
+
+A little shamefaced girl lisped, “Mary had a little lamb,” etc.,
+performed a compassion-inspiring curtsy, got her meed of applause, and
+sat down flushed and happy.
+
+Tom Sawyer stepped forward with conceited confidence and soared into
+the unquenchable and indestructible “Give me liberty or give me death”
+ speech, with fine fury and frantic gesticulation, and broke down in the
+middle of it. A ghastly stage-fright seized him, his legs quaked under
+him and he was like to choke. True, he had the manifest sympathy of the
+house but he had the house’s silence, too, which was even worse than
+its sympathy. The master frowned, and this completed the disaster. Tom
+struggled awhile and then retired, utterly defeated. There was a weak
+attempt at applause, but it died early.
+
+“The Boy Stood on the Burning Deck” followed; also “The Assyrian Came
+Down,” and other declamatory gems. Then there were reading exercises,
+and a spelling fight. The meagre Latin class recited with honor. The
+prime feature of the evening was in order, now--original “compositions”
+ by the young ladies. Each in her turn stepped forward to the edge of the
+platform, cleared her throat, held up her manuscript (tied with dainty
+ribbon), and proceeded to read, with labored attention to “expression”
+ and punctuation. The themes were the same that had been illuminated upon
+similar occasions by their mothers before them, their grandmothers,
+and doubtless all their ancestors in the female line clear back to the
+Crusades. “Friendship” was one; “Memories of Other Days”; “Religion in
+History”; “Dream Land”; “The Advantages of Culture”; “Forms of Political
+Government Compared and Contrasted”; “Melancholy”; “Filial Love”; “Heart
+Longings,” etc., etc.
+
+A prevalent feature in these compositions was a nursed and petted
+melancholy; another was a wasteful and opulent gush of “fine language”;
+another was a tendency to lug in by the ears particularly prized words
+and phrases until they were worn entirely out; and a peculiarity that
+conspicuously marked and marred them was the inveterate and intolerable
+sermon that wagged its crippled tail at the end of each and every one
+of them. No matter what the subject might be, a brainracking effort was
+made to squirm it into some aspect or other that the moral and religious
+mind could contemplate with edification. The glaring insincerity of
+these sermons was not sufficient to compass the banishment of the
+fashion from the schools, and it is not sufficient today; it never will
+be sufficient while the world stands, perhaps. There is no school in
+all our land where the young ladies do not feel obliged to close their
+compositions with a sermon; and you will find that the sermon of the
+most frivolous and the least religious girl in the school is always
+the longest and the most relentlessly pious. But enough of this. Homely
+truth is unpalatable.
+
+Let us return to the “Examination.” The first composition that was read
+was one entitled “Is this, then, Life?” Perhaps the reader can endure an
+extract from it:
+
+“In the common walks of life, with what delightful emotions does the
+youthful mind look forward to some anticipated scene of festivity!
+Imagination is busy sketching rose-tinted pictures of joy. In fancy, the
+voluptuous votary of fashion sees herself amid the festive throng, ‘the
+observed of all observers.’ Her graceful form, arrayed in snowy robes,
+is whirling through the mazes of the joyous dance; her eye is brightest,
+her step is lightest in the gay assembly.
+
+“In such delicious fancies time quickly glides by, and the welcome hour
+arrives for her entrance into the Elysian world, of which she has
+had such bright dreams. How fairy-like does everything appear to her
+enchanted vision! Each new scene is more charming than the last. But
+after a while she finds that beneath this goodly exterior, all is
+vanity, the flattery which once charmed her soul, now grates harshly
+upon her ear; the ballroom has lost its charms; and with wasted health
+and imbittered heart, she turns away with the conviction that earthly
+pleasures cannot satisfy the longings of the soul!”
+
+And so forth and so on. There was a buzz of gratification from time to
+time during the reading, accompanied by whispered ejaculations of “How
+sweet!” “How eloquent!” “So true!” etc., and after the thing had closed
+with a peculiarly afflicting sermon the applause was enthusiastic.
+
+Then arose a slim, melancholy girl, whose face had the “interesting”
+ paleness that comes of pills and indigestion, and read a “poem.” Two
+stanzas of it will do:
+
+“A MISSOURI MAIDEN’S FAREWELL TO ALABAMA
+
+“Alabama, goodbye! I love thee well! But yet for a while do I leave thee
+now! Sad, yes, sad thoughts of thee my heart doth swell, And burning
+recollections throng my brow! For I have wandered through thy flowery
+woods; Have roamed and read near Tallapoosa’s stream; Have listened to
+Tallassee’s warring floods, And wooed on Coosa’s side Aurora’s beam.
+
+“Yet shame I not to bear an o’erfull heart, Nor blush to turn behind
+my tearful eyes; ‘Tis from no stranger land I now must part, ‘Tis to no
+strangers left I yield these sighs. Welcome and home were mine within
+this State, Whose vales I leave--whose spires fade fast from me And cold
+must be mine eyes, and heart, and tete, When, dear Alabama! they turn
+cold on thee!” There were very few there who knew what “tete” meant, but
+the poem was very satisfactory, nevertheless.
+
+Next appeared a dark-complexioned, black-eyed, black-haired young lady,
+who paused an impressive moment, assumed a tragic expression, and began
+to read in a measured, solemn tone:
+
+“A VISION
+
+“Dark and tempestuous was night. Around the throne on high not a single
+star quivered; but the deep intonations of the heavy thunder constantly
+vibrated upon the ear; whilst the terrific lightning revelled in angry
+mood through the cloudy chambers of heaven, seeming to scorn the power
+exerted over its terror by the illustrious Franklin! Even the boisterous
+winds unanimously came forth from their mystic homes, and blustered
+about as if to enhance by their aid the wildness of the scene.
+
+“At such a time, so dark, so dreary, for human sympathy my very spirit
+sighed; but instead thereof,
+
+“‘My dearest friend, my counsellor, my comforter and guide--My joy in
+grief, my second bliss in joy,’ came to my side. She moved like one of
+those bright beings pictured in the sunny walks of fancy’s Eden by
+the romantic and young, a queen of beauty unadorned save by her own
+transcendent loveliness. So soft was her step, it failed to make even a
+sound, and but for the magical thrill imparted by her genial touch,
+as other unobtrusive beauties, she would have glided away
+unperceived--unsought. A strange sadness rested upon her features, like
+icy tears upon the robe of December, as she pointed to the contending
+elements without, and bade me contemplate the two beings presented.”
+
+This nightmare occupied some ten pages of manuscript and wound up with a
+sermon so destructive of all hope to non-Presbyterians that it took
+the first prize. This composition was considered to be the very finest
+effort of the evening. The mayor of the village, in delivering the prize
+to the author of it, made a warm speech in which he said that it was by
+far the most “eloquent” thing he had ever listened to, and that Daniel
+Webster himself might well be proud of it.
+
+It may be remarked, in passing, that the number of compositions in which
+the word “beauteous” was over-fondled, and human experience referred to
+as “life’s page,” was up to the usual average.
+
+Now the master, mellow almost to the verge of geniality, put his chair
+aside, turned his back to the audience, and began to draw a map of
+America on the blackboard, to exercise the geography class upon. But he
+made a sad business of it with his unsteady hand, and a smothered titter
+rippled over the house. He knew what the matter was, and set himself to
+right it. He sponged out lines and remade them; but he only distorted
+them more than ever, and the tittering was more pronounced. He threw his
+entire attention upon his work, now, as if determined not to be put down
+by the mirth. He felt that all eyes were fastened upon him; he imagined
+he was succeeding, and yet the tittering continued; it even manifestly
+increased. And well it might. There was a garret above, pierced with
+a scuttle over his head; and down through this scuttle came a cat,
+suspended around the haunches by a string; she had a rag tied about
+her head and jaws to keep her from mewing; as she slowly descended she
+curved upward and clawed at the string, she swung downward and clawed
+at the intangible air. The tittering rose higher and higher--the cat was
+within six inches of the absorbed teacher’s head--down, down, a little
+lower, and she grabbed his wig with her desperate claws, clung to it,
+and was snatched up into the garret in an instant with her trophy still
+in her possession! And how the light did blaze abroad from the master’s
+bald pate--for the signpainter’s boy had _gilded_ it!
+
+That broke up the meeting. The boys were avenged. Vacation had come.
+
+NOTE:--The pretended “compositions” quoted in this chapter are taken
+without alteration from a volume entitled “Prose and Poetry, by a
+Western Lady”--but they are exactly and precisely after the schoolgirl
+pattern, and hence are much happier than any mere imitations could be.
+
+
+
+
+CHAPTER XXII
+
+TOM joined the new order of Cadets of Temperance, being attracted by the
+showy character of their “regalia.” He promised to abstain from smoking,
+chewing, and profanity as long as he remained a member. Now he found out
+a new thing--namely, that to promise not to do a thing is the surest way
+in the world to make a body want to go and do that very thing. Tom soon
+found himself tormented with a desire to drink and swear; the desire
+grew to be so intense that nothing but the hope of a chance to display
+himself in his red sash kept him from withdrawing from the order. Fourth
+of July was coming; but he soon gave that up--gave it up before he had
+worn his shackles over forty-eight hours--and fixed his hopes upon old
+Judge Frazer, justice of the peace, who was apparently on his deathbed
+and would have a big public funeral, since he was so high an official.
+During three days Tom was deeply concerned about the Judge’s condition
+and hungry for news of it. Sometimes his hopes ran high--so high that
+he would venture to get out his regalia and practise before the
+looking-glass. But the Judge had a most discouraging way of fluctuating.
+At last he was pronounced upon the mend--and then convalescent. Tom was
+disgusted; and felt a sense of injury, too. He handed in his resignation
+at once--and that night the Judge suffered a relapse and died. Tom
+resolved that he would never trust a man like that again.
+
+The funeral was a fine thing. The Cadets paraded in a style calculated
+to kill the late member with envy. Tom was a free boy again,
+however--there was something in that. He could drink and swear, now--but
+found to his surprise that he did not want to. The simple fact that he
+could, took the desire away, and the charm of it.
+
+Tom presently wondered to find that his coveted vacation was beginning
+to hang a little heavily on his hands.
+
+He attempted a diary--but nothing happened during three days, and so he
+abandoned it.
+
+The first of all the negro minstrel shows came to town, and made a
+sensation. Tom and Joe Harper got up a band of performers and were happy
+for two days.
+
+Even the Glorious Fourth was in some sense a failure, for it rained
+hard, there was no procession in consequence, and the greatest man
+in the world (as Tom supposed), Mr. Benton, an actual United States
+Senator, proved an overwhelming disappointment--for he was not
+twenty-five feet high, nor even anywhere in the neighborhood of it.
+
+A circus came. The boys played circus for three days afterward in tents
+made of rag carpeting--admission, three pins for boys, two for girls--and
+then circusing was abandoned.
+
+A phrenologist and a mesmerizer came--and went again and left the village
+duller and drearier than ever.
+
+There were some boys-and-girls’ parties, but they were so few and so
+delightful that they only made the aching voids between ache the harder.
+
+Becky Thatcher was gone to her Constantinople home to stay with her
+parents during vacation--so there was no bright side to life anywhere.
+
+The dreadful secret of the murder was a chronic misery. It was a very
+cancer for permanency and pain.
+
+Then came the measles.
+
+During two long weeks Tom lay a prisoner, dead to the world and its
+happenings. He was very ill, he was interested in nothing. When he got
+upon his feet at last and moved feebly downtown, a melancholy change had
+come over everything and every creature. There had been a “revival,” and
+everybody had “got religion,” not only the adults, but even the boys and
+girls. Tom went about, hoping against hope for the sight of one blessed
+sinful face, but disappointment crossed him everywhere. He found Joe
+Harper studying a Testament, and turned sadly away from the depressing
+spectacle. He sought Ben Rogers, and found him visiting the poor with a
+basket of tracts. He hunted up Jim Hollis, who called his attention to
+the precious blessing of his late measles as a warning. Every boy
+he encountered added another ton to his depression; and when, in
+desperation, he flew for refuge at last to the bosom of Huckleberry Finn
+and was received with a Scriptural quotation, his heart broke and he
+crept home and to bed realizing that he alone of all the town was lost,
+forever and forever.
+
+And that night there came on a terrific storm, with driving rain, awful
+claps of thunder and blinding sheets of lightning. He covered his head
+with the bedclothes and waited in a horror of suspense for his doom; for
+he had not the shadow of a doubt that all this hubbub was about him.
+He believed he had taxed the forbearance of the powers above to the
+extremity of endurance and that this was the result. It might have
+seemed to him a waste of pomp and ammunition to kill a bug with a
+battery of artillery, but there seemed nothing incongruous about the
+getting up such an expensive thunderstorm as this to knock the turf from
+under an insect like himself.
+
+By and by the tempest spent itself and died without accomplishing its
+object. The boy’s first impulse was to be grateful, and reform. His
+second was to wait--for there might not be any more storms.
+
+The next day the doctors were back; Tom had relapsed. The three weeks he
+spent on his back this time seemed an entire age. When he got abroad
+at last he was hardly grateful that he had been spared, remembering how
+lonely was his estate, how companionless and forlorn he was. He drifted
+listlessly down the street and found Jim Hollis acting as judge in a
+juvenile court that was trying a cat for murder, in the presence of her
+victim, a bird. He found Joe Harper and Huck Finn up an alley eating a
+stolen melon. Poor lads! they--like Tom--had suffered a relapse.
+
+
+
+
+CHAPTER XXIII
+
+AT last the sleepy atmosphere was stirred--and vigorously: the murder
+trial came on in the court. It became the absorbing topic of village
+talk immediately. Tom could not get away from it. Every reference to
+the murder sent a shudder to his heart, for his troubled conscience
+and fears almost persuaded him that these remarks were put forth in
+his hearing as “feelers”; he did not see how he could be suspected of
+knowing anything about the murder, but still he could not be comfortable
+in the midst of this gossip. It kept him in a cold shiver all the time.
+He took Huck to a lonely place to have a talk with him. It would be some
+relief to unseal his tongue for a little while; to divide his burden of
+distress with another sufferer. Moreover, he wanted to assure himself
+that Huck had remained discreet.
+
+“Huck, have you ever told anybody about--that?”
+
+“‘Bout what?”
+
+“You know what.”
+
+“Oh--‘course I haven’t.”
+
+“Never a word?”
+
+“Never a solitary word, so help me. What makes you ask?”
+
+“Well, I was afeard.”
+
+“Why, Tom Sawyer, we wouldn’t be alive two days if that got found out.
+_You_ know that.”
+
+Tom felt more comfortable. After a pause:
+
+“Huck, they couldn’t anybody get you to tell, could they?”
+
+“Get me to tell? Why, if I wanted that halfbreed devil to drownd me they
+could get me to tell. They ain’t no different way.”
+
+“Well, that’s all right, then. I reckon we’re safe as long as we keep
+mum. But let’s swear again, anyway. It’s more surer.”
+
+“I’m agreed.”
+
+So they swore again with dread solemnities.
+
+“What is the talk around, Huck? I’ve heard a power of it.”
+
+“Talk? Well, it’s just Muff Potter, Muff Potter, Muff Potter all the
+time. It keeps me in a sweat, constant, so’s I want to hide som’ers.”
+
+“That’s just the same way they go on round me. I reckon he’s a goner.
+Don’t you feel sorry for him, sometimes?”
+
+“Most always--most always. He ain’t no account; but then he hain’t ever
+done anything to hurt anybody. Just fishes a little, to get money to
+get drunk on--and loafs around considerable; but lord, we all do
+that--leastways most of us--preachers and such like. But he’s kind of
+good--he give me half a fish, once, when there warn’t enough for two; and
+lots of times he’s kind of stood by me when I was out of luck.”
+
+“Well, he’s mended kites for me, Huck, and knitted hooks on to my line.
+I wish we could get him out of there.”
+
+“My! we couldn’t get him out, Tom. And besides, ‘twouldn’t do any good;
+they’d ketch him again.”
+
+“Yes--so they would. But I hate to hear ‘em abuse him so like the dickens
+when he never done--that.”
+
+“I do too, Tom. Lord, I hear ‘em say he’s the bloodiest looking villain
+in this country, and they wonder he wasn’t ever hung before.”
+
+“Yes, they talk like that, all the time. I’ve heard ‘em say that if he
+was to get free they’d lynch him.”
+
+“And they’d do it, too.”
+
+The boys had a long talk, but it brought them little comfort. As the
+twilight drew on, they found themselves hanging about the neighborhood
+of the little isolated jail, perhaps with an undefined hope that
+something would happen that might clear away their difficulties. But
+nothing happened; there seemed to be no angels or fairies interested in
+this luckless captive.
+
+The boys did as they had often done before--went to the cell grating and
+gave Potter some tobacco and matches. He was on the ground floor and
+there were no guards.
+
+His gratitude for their gifts had always smote their consciences
+before--it cut deeper than ever, this time. They felt cowardly and
+treacherous to the last degree when Potter said:
+
+“You’ve been mighty good to me, boys--better’n anybody else in this town.
+And I don’t forget it, I don’t. Often I says to myself, says I, ‘I used
+to mend all the boys’ kites and things, and show ‘em where the good
+fishin’ places was, and befriend ‘em what I could, and now they’ve
+all forgot old Muff when he’s in trouble; but Tom don’t, and Huck
+don’t--_they_ don’t forget him, says I, ‘and I don’t forget them.’ Well,
+boys, I done an awful thing--drunk and crazy at the time--that’s the only
+way I account for it--and now I got to swing for it, and it’s right.
+Right, and _best_, too, I reckon--hope so, anyway. Well, we won’t talk
+about that. I don’t want to make _you_ feel bad; you’ve befriended me.
+But what I want to say, is, don’t _you_ ever get drunk--then you won’t
+ever get here. Stand a litter furder west--so--that’s it; it’s a prime
+comfort to see faces that’s friendly when a body’s in such a muck
+of trouble, and there don’t none come here but yourn. Good friendly
+faces--good friendly faces. Git up on one another’s backs and let me
+touch ‘em. That’s it. Shake hands--yourn’ll come through the bars, but
+mine’s too big. Little hands, and weak--but they’ve helped Muff Potter a
+power, and they’d help him more if they could.”
+
+Tom went home miserable, and his dreams that night were full of horrors.
+The next day and the day after, he hung about the courtroom, drawn by an
+almost irresistible impulse to go in, but forcing himself to stay out.
+Huck was having the same experience. They studiously avoided each other.
+Each wandered away, from time to time, but the same dismal fascination
+always brought them back presently. Tom kept his ears open when idlers
+sauntered out of the courtroom, but invariably heard distressing
+news--the toils were closing more and more relentlessly around poor
+Potter. At the end of the second day the village talk was to the effect
+that Injun Joe’s evidence stood firm and unshaken, and that there was
+not the slightest question as to what the jury’s verdict would be.
+
+Tom was out late, that night, and came to bed through the window. He
+was in a tremendous state of excitement. It was hours before he got to
+sleep. All the village flocked to the courthouse the next morning, for
+this was to be the great day. Both sexes were about equally represented
+in the packed audience. After a long wait the jury filed in and took
+their places; shortly afterward, Potter, pale and haggard, timid and
+hopeless, was brought in, with chains upon him, and seated where all
+the curious eyes could stare at him; no less conspicuous was Injun Joe,
+stolid as ever. There was another pause, and then the judge arrived and
+the sheriff proclaimed the opening of the court. The usual whisperings
+among the lawyers and gathering together of papers followed. These
+details and accompanying delays worked up an atmosphere of preparation
+that was as impressive as it was fascinating.
+
+Now a witness was called who testified that he found Muff Potter washing
+in the brook, at an early hour of the morning that the murder was
+discovered, and that he immediately sneaked away. After some further
+questioning, counsel for the prosecution said:
+
+“Take the witness.”
+
+The prisoner raised his eyes for a moment, but dropped them again when
+his own counsel said:
+
+“I have no questions to ask him.”
+
+The next witness proved the finding of the knife near the corpse.
+Counsel for the prosecution said:
+
+“Take the witness.”
+
+“I have no questions to ask him,” Potter’s lawyer replied.
+
+A third witness swore he had often seen the knife in Potter’s
+possession.
+
+“Take the witness.”
+
+Counsel for Potter declined to question him. The faces of the audience
+began to betray annoyance. Did this attorney mean to throw away his
+client’s life without an effort?
+
+Several witnesses deposed concerning Potter’s guilty behavior when
+brought to the scene of the murder. They were allowed to leave the stand
+without being cross-questioned.
+
+Every detail of the damaging circumstances that occurred in the
+graveyard upon that morning which all present remembered so well was
+brought out by credible witnesses, but none of them were cross-examined
+by Potter’s lawyer. The perplexity and dissatisfaction of the house
+expressed itself in murmurs and provoked a reproof from the bench.
+Counsel for the prosecution now said:
+
+“By the oaths of citizens whose simple word is above suspicion, we have
+fastened this awful crime, beyond all possibility of question, upon the
+unhappy prisoner at the bar. We rest our case here.”
+
+A groan escaped from poor Potter, and he put his face in his hands and
+rocked his body softly to and fro, while a painful silence reigned
+in the courtroom. Many men were moved, and many women’s compassion
+testified itself in tears. Counsel for the defence rose and said:
+
+“Your honor, in our remarks at the opening of this trial, we
+foreshadowed our purpose to prove that our client did this fearful deed
+while under the influence of a blind and irresponsible delirium produced
+by drink. We have changed our mind. We shall not offer that plea.” [Then
+to the clerk:] “Call Thomas Sawyer!”
+
+A puzzled amazement awoke in every face in the house, not even excepting
+Potter’s. Every eye fastened itself with wondering interest upon Tom as
+he rose and took his place upon the stand. The boy looked wild enough,
+for he was badly scared. The oath was administered.
+
+“Thomas Sawyer, where were you on the seventeenth of June, about the
+hour of midnight?”
+
+Tom glanced at Injun Joe’s iron face and his tongue failed him. The
+audience listened breathless, but the words refused to come. After a few
+moments, however, the boy got a little of his strength back, and managed
+to put enough of it into his voice to make part of the house hear:
+
+“In the graveyard!”
+
+“A little bit louder, please. Don’t be afraid. You were--”
+
+“In the graveyard.”
+
+A contemptuous smile flitted across Injun Joe’s face.
+
+“Were you anywhere near Horse Williams’ grave?”
+
+“Yes, sir.”
+
+“Speak up--just a trifle louder. How near were you?”
+
+“Near as I am to you.”
+
+“Were you hidden, or not?”
+
+“I was hid.”
+
+“Where?”
+
+“Behind the elms that’s on the edge of the grave.”
+
+Injun Joe gave a barely perceptible start.
+
+“Any one with you?”
+
+“Yes, sir. I went there with--”
+
+“Wait--wait a moment. Never mind mentioning your companion’s name. We
+will produce him at the proper time. Did you carry anything there with
+you.”
+
+Tom hesitated and looked confused.
+
+“Speak out, my boy--don’t be diffident. The truth is always respectable.
+What did you take there?”
+
+“Only a--a--dead cat.”
+
+There was a ripple of mirth, which the court checked.
+
+“We will produce the skeleton of that cat. Now, my boy, tell us
+everything that occurred--tell it in your own way--don’t skip anything,
+and don’t be afraid.”
+
+Tom began--hesitatingly at first, but as he warmed to his subject his
+words flowed more and more easily; in a little while every sound ceased
+but his own voice; every eye fixed itself upon him; with parted lips and
+bated breath the audience hung upon his words, taking no note of time,
+rapt in the ghastly fascinations of the tale. The strain upon pent
+emotion reached its climax when the boy said:
+
+“--and as the doctor fetched the board around and Muff Potter fell, Injun
+Joe jumped with the knife and--”
+
+Crash! Quick as lightning the halfbreed sprang for a window, tore his
+way through all opposers, and was gone!
+
+
+
+
+CHAPTER XXIV
+
+TOM was a glittering hero once more--the pet of the old, the envy of the
+young. His name even went into immortal print, for the village paper
+magnified him. There were some that believed he would be President, yet,
+if he escaped hanging.
+
+As usual, the fickle, unreasoning world took Muff Potter to its bosom
+and fondled him as lavishly as it had abused him before. But that sort
+of conduct is to the world’s credit; therefore it is not well to find
+fault with it.
+
+Tom’s days were days of splendor and exultation to him, but his nights
+were seasons of horror. Injun Joe infested all his dreams, and always
+with doom in his eye. Hardly any temptation could persuade the boy
+to stir abroad after nightfall. Poor Huck was in the same state of
+wretchedness and terror, for Tom had told the whole story to the lawyer
+the night before the great day of the trial, and Huck was sore afraid
+that his share in the business might leak out, yet, notwithstanding
+Injun Joe’s flight had saved him the suffering of testifying in court.
+The poor fellow had got the attorney to promise secrecy, but what of
+that? Since Tom’s harassed conscience had managed to drive him to the
+lawyer’s house by night and wring a dread tale from lips that had
+been sealed with the dismalest and most formidable of oaths, Huck’s
+confidence in the human race was wellnigh obliterated.
+
+Daily Muff Potter’s gratitude made Tom glad he had spoken; but nightly
+he wished he had sealed up his tongue.
+
+Half the time Tom was afraid Injun Joe would never be captured; the
+other half he was afraid he would be. He felt sure he never could draw a
+safe breath again until that man was dead and he had seen the corpse.
+
+Rewards had been offered, the country had been scoured, but no Injun
+Joe was found. One of those omniscient and aweinspiring marvels, a
+detective, came up from St. Louis, moused around, shook his head, looked
+wise, and made that sort of astounding success which members of that
+craft usually achieve. That is to say, he “found a clew.” But you can’t
+hang a “clew” for murder, and so after that detective had got through
+and gone home, Tom felt just as insecure as he was before.
+
+The slow days drifted on, and each left behind it a slightly lightened
+weight of apprehension.
+
+
+
+
+CHAPTER XXV
+
+THERE comes a time in every rightly-constructed boy’s life when he has
+a raging desire to go somewhere and dig for hidden treasure. This desire
+suddenly came upon Tom one day. He sallied out to find Joe Harper,
+but failed of success. Next he sought Ben Rogers; he had gone fishing.
+Presently he stumbled upon Huck Finn the Red-Handed. Huck would
+answer. Tom took him to a private place and opened the matter to him
+confidentially. Huck was willing. Huck was always willing to take a hand
+in any enterprise that offered entertainment and required no capital,
+for he had a troublesome superabundance of that sort of time which is
+not money. “Where’ll we dig?” said Huck.
+
+“Oh, most anywhere.”
+
+“Why, is it hid all around?”
+
+“No, indeed it ain’t. It’s hid in mighty particular places,
+Huck--sometimes on islands, sometimes in rotten chests under the end of
+a limb of an old dead tree, just where the shadow falls at midnight; but
+mostly under the floor in ha’nted houses.”
+
+“Who hides it?”
+
+“Why, robbers, of course--who’d you reckon? Sunday-school
+sup’rintendents?”
+
+“I don’t know. If ‘twas mine I wouldn’t hide it; I’d spend it and have a
+good time.”
+
+“So would I. But robbers don’t do that way. They always hide it and
+leave it there.”
+
+“Don’t they come after it any more?”
+
+“No, they think they will, but they generally forget the marks, or else
+they die. Anyway, it lays there a long time and gets rusty; and by and
+by somebody finds an old yellow paper that tells how to find the marks--a
+paper that’s got to be ciphered over about a week because it’s mostly
+signs and hy’roglyphics.”
+
+“Hyro--which?”
+
+“Hy’roglyphics--pictures and things, you know, that don’t seem to mean
+anything.”
+
+“Have you got one of them papers, Tom?”
+
+“No.”
+
+“Well then, how you going to find the marks?”
+
+“I don’t want any marks. They always bury it under a ha’nted house or on
+an island, or under a dead tree that’s got one limb sticking out. Well,
+we’ve tried Jackson’s Island a little, and we can try it again some
+time; and there’s the old ha’nted house up the Still-House branch, and
+there’s lots of dead-limb trees--dead loads of ‘em.”
+
+“Is it under all of them?”
+
+“How you talk! No!”
+
+“Then how you going to know which one to go for?”
+
+“Go for all of ‘em!”
+
+“Why, Tom, it’ll take all summer.”
+
+“Well, what of that? Suppose you find a brass pot with a hundred dollars
+in it, all rusty and gray, or rotten chest full of di’monds. How’s
+that?”
+
+Huck’s eyes glowed.
+
+“That’s bully. Plenty bully enough for me. Just you gimme the hundred
+dollars and I don’t want no di’monds.”
+
+“All right. But I bet you I ain’t going to throw off on di’monds. Some
+of ‘em’s worth twenty dollars apiece--there ain’t any, hardly, but’s
+worth six bits or a dollar.”
+
+“No! Is that so?”
+
+“Cert’nly--anybody’ll tell you so. Hain’t you ever seen one, Huck?”
+
+“Not as I remember.”
+
+“Oh, kings have slathers of them.”
+
+“Well, I don’ know no kings, Tom.”
+
+“I reckon you don’t. But if you was to go to Europe you’d see a raft of
+‘em hopping around.”
+
+“Do they hop?”
+
+“Hop?--your granny! No!”
+
+“Well, what did you say they did, for?”
+
+“Shucks, I only meant you’d _see_ ‘em--not hopping, of course--what do
+they want to hop for?--but I mean you’d just see ‘em--scattered around,
+you know, in a kind of a general way. Like that old humpbacked Richard.”
+
+“Richard? What’s his other name?”
+
+“He didn’t have any other name. Kings don’t have any but a given name.”
+
+“No?”
+
+“But they don’t.”
+
+“Well, if they like it, Tom, all right; but I don’t want to be a king
+and have only just a given name, like a nigger. But say--where you going
+to dig first?”
+
+“Well, I don’t know. S’pose we tackle that old dead-limb tree on the
+hill t’other side of Still-House branch?”
+
+“I’m agreed.”
+
+So they got a crippled pick and a shovel, and set out on their
+three-mile tramp. They arrived hot and panting, and threw themselves
+down in the shade of a neighboring elm to rest and have a smoke.
+
+“I like this,” said Tom.
+
+“So do I.”
+
+“Say, Huck, if we find a treasure here, what you going to do with your
+share?”
+
+“Well, I’ll have pie and a glass of soda every day, and I’ll go to every
+circus that comes along. I bet I’ll have a gay time.”
+
+“Well, ain’t you going to save any of it?”
+
+“Save it? What for?”
+
+“Why, so as to have something to live on, by and by.”
+
+“Oh, that ain’t any use. Pap would come back to thish-yer town some day
+and get his claws on it if I didn’t hurry up, and I tell you he’d clean
+it out pretty quick. What you going to do with yourn, Tom?”
+
+“I’m going to buy a new drum, and a sure’nough sword, and a red necktie
+and a bull pup, and get married.”
+
+“Married!”
+
+“That’s it.”
+
+“Tom, you--why, you ain’t in your right mind.”
+
+“Wait--you’ll see.”
+
+“Well, that’s the foolishest thing you could do. Look at pap and my
+mother. Fight! Why, they used to fight all the time. I remember, mighty
+well.”
+
+“That ain’t anything. The girl I’m going to marry won’t fight.”
+
+“Tom, I reckon they’re all alike. They’ll all comb a body. Now you
+better think ‘bout this awhile. I tell you you better. What’s the name
+of the gal?”
+
+“It ain’t a gal at all--it’s a girl.”
+
+“It’s all the same, I reckon; some says gal, some says girl--both’s
+right, like enough. Anyway, what’s her name, Tom?”
+
+“I’ll tell you some time--not now.”
+
+“All right--that’ll do. Only if you get married I’ll be more lonesomer
+than ever.”
+
+“No you won’t. You’ll come and live with me. Now stir out of this and
+we’ll go to digging.”
+
+They worked and sweated for half an hour. No result. They toiled another
+halfhour. Still no result. Huck said:
+
+“Do they always bury it as deep as this?”
+
+“Sometimes--not always. Not generally. I reckon we haven’t got the right
+place.”
+
+So they chose a new spot and began again. The labor dragged a little,
+but still they made progress. They pegged away in silence for some time.
+Finally Huck leaned on his shovel, swabbed the beaded drops from his
+brow with his sleeve, and said:
+
+“Where you going to dig next, after we get this one?”
+
+“I reckon maybe we’ll tackle the old tree that’s over yonder on Cardiff
+Hill back of the widow’s.”
+
+“I reckon that’ll be a good one. But won’t the widow take it away from
+us, Tom? It’s on her land.”
+
+“_She_ take it away! Maybe she’d like to try it once. Whoever finds one
+of these hid treasures, it belongs to him. It don’t make any difference
+whose land it’s on.”
+
+That was satisfactory. The work went on. By and by Huck said:
+
+“Blame it, we must be in the wrong place again. What do you think?”
+
+“It is mighty curious, Huck. I don’t understand it. Sometimes witches
+interfere. I reckon maybe that’s what’s the trouble now.”
+
+“Shucks! Witches ain’t got no power in the daytime.”
+
+“Well, that’s so. I didn’t think of that. Oh, I know what the matter is!
+What a blamed lot of fools we are! You got to find out where the shadow
+of the limb falls at midnight, and that’s where you dig!”
+
+“Then consound it, we’ve fooled away all this work for nothing. Now hang
+it all, we got to come back in the night. It’s an awful long way. Can
+you get out?”
+
+“I bet I will. We’ve got to do it tonight, too, because if somebody sees
+these holes they’ll know in a minute what’s here and they’ll go for it.”
+
+“Well, I’ll come around and maow tonight.”
+
+“All right. Let’s hide the tools in the bushes.”
+
+The boys were there that night, about the appointed time. They sat in
+the shadow waiting. It was a lonely place, and an hour made solemn by
+old traditions. Spirits whispered in the rustling leaves, ghosts lurked
+in the murky nooks, the deep baying of a hound floated up out of the
+distance, an owl answered with his sepulchral note. The boys were
+subdued by these solemnities, and talked little. By and by they judged
+that twelve had come; they marked where the shadow fell, and began to
+dig. Their hopes commenced to rise. Their interest grew stronger, and
+their industry kept pace with it. The hole deepened and still deepened,
+but every time their hearts jumped to hear the pick strike upon
+something, they only suffered a new disappointment. It was only a stone
+or a chunk. At last Tom said:
+
+“It ain’t any use, Huck, we’re wrong again.”
+
+“Well, but we _can’t_ be wrong. We spotted the shadder to a dot.”
+
+“I know it, but then there’s another thing.”
+
+“What’s that?”.
+
+“Why, we only guessed at the time. Like enough it was too late or too
+early.”
+
+Huck dropped his shovel.
+
+“That’s it,” said he. “That’s the very trouble. We got to give this one
+up. We can’t ever tell the right time, and besides this kind of thing’s
+too awful, here this time of night with witches and ghosts a-fluttering
+around so. I feel as if something’s behind me all the time;  and I’m
+afeard to turn around, becuz maybe there’s others in front a-waiting for
+a chance. I been creeping all over, ever since I got here.”
+
+“Well, I’ve been pretty much so, too, Huck. They most always put in a
+dead man when they bury a treasure under a tree, to look out for it.”
+
+“Lordy!”
+
+“Yes, they do. I’ve always heard that.”
+
+“Tom, I don’t like to fool around much where there’s dead people. A
+body’s bound to get into trouble with ‘em, sure.”
+
+“I don’t like to stir ‘em up, either. S’pose this one here was to stick
+his skull out and say something!”
+
+“Don’t Tom! It’s awful.”
+
+“Well, it just is. Huck, I don’t feel comfortable a bit.”
+
+“Say, Tom, let’s give this place up, and try somewheres else.”
+
+“All right, I reckon we better.”
+
+“What’ll it be?”
+
+Tom considered awhile; and then said:
+
+“The ha’nted house. That’s it!”
+
+“Blame it, I don’t like ha’nted houses, Tom. Why, they’re a dern sight
+worse’n dead people. Dead people might talk, maybe, but they don’t come
+sliding around in a shroud, when you ain’t noticing, and peep over your
+shoulder all of a sudden and grit their teeth, the way a ghost does. I
+couldn’t stand such a thing as that, Tom--nobody could.”
+
+“Yes, but, Huck, ghosts don’t travel around only at night. They won’t
+hender us from digging there in the daytime.”
+
+“Well, that’s so. But you know mighty well people don’t go about that
+ha’nted house in the day nor the night.”
+
+“Well, that’s mostly because they don’t like to go where a man’s been
+murdered, anyway--but nothing’s ever been seen around that house except
+in the night--just some blue lights slipping by the windows--no regular
+ghosts.”
+
+“Well, where you see one of them blue lights flickering around, Tom,
+you can bet there’s a ghost mighty close behind it. It stands to reason.
+Becuz you know that they don’t anybody but ghosts use ‘em.”
+
+“Yes, that’s so. But anyway they don’t come around in the daytime, so
+what’s the use of our being afeard?”
+
+“Well, all right. We’ll tackle the ha’nted house if you say so--but I
+reckon it’s taking chances.”
+
+They had started down the hill by this time. There in the middle of the
+moonlit valley below them stood the “ha’nted” house, utterly isolated,
+its fences gone long ago, rank weeds smothering the very doorsteps, the
+chimney crumbled to ruin, the window-sashes vacant, a corner of the roof
+caved in. The boys gazed awhile, half expecting to see a blue light flit
+past a window; then talking in a low tone, as befitted the time and the
+circumstances, they struck far off to the right, to give the haunted
+house a wide berth, and took their way homeward through the woods that
+adorned the rearward side of Cardiff Hill.
+
+
+
+
+CHAPTER XVI
+
+ABOUT noon the next day the boys arrived at the dead tree; they had come
+for their tools. Tom was impatient to go to the haunted house; Huck was
+measurably so, also--but suddenly said:
+
+“Lookyhere, Tom, do you know what day it is?”
+
+Tom mentally ran over the days of the week, and then quickly lifted his
+eyes with a startled look in them--
+
+“My! I never once thought of it, Huck!”
+
+“Well, I didn’t neither, but all at once it popped onto me that it was
+Friday.”
+
+“Blame it, a body can’t be too careful, Huck. We might ‘a’ got into an
+awful scrape, tackling such a thing on a Friday.”
+
+“_Might_! Better say we _would_! There’s some lucky days, maybe, but
+Friday ain’t.”
+
+“Any fool knows that. I don’t reckon _you_ was the first that found it
+out, Huck.”
+
+“Well, I never said I was, did I? And Friday ain’t all, neither. I had a
+rotten bad dream last night--dreampt about rats.”
+
+“No! Sure sign of trouble. Did they fight?”
+
+“No.”
+
+“Well, that’s good, Huck. When they don’t fight it’s only a sign that
+there’s trouble around, you know. All we got to do is to look mighty
+sharp and keep out of it. We’ll drop this thing for today, and play. Do
+you know Robin Hood, Huck?”
+
+“No. Who’s Robin Hood?”
+
+“Why, he was one of the greatest men that was ever in England--and the
+best. He was a robber.”
+
+“Cracky, I wisht I was. Who did he rob?”
+
+“Only sheriffs and bishops and rich people and kings, and such like. But
+he never bothered the poor. He loved ‘em. He always divided up with ‘em
+perfectly square.”
+
+“Well, he must ‘a’ been a brick.”
+
+“I bet you he was, Huck. Oh, he was the noblest man that ever was.
+They ain’t any such men now, I can tell you. He could lick any man in
+England, with one hand tied behind him; and he could take his yew bow
+and plug a ten-cent piece every time, a mile and a half.”
+
+“What’s a _yew_ bow?”
+
+“I don’t know. It’s some kind of a bow, of course. And if he hit that
+dime only on the edge he would set down and cry--and curse. But we’ll
+play Robin Hood--it’s nobby fun. I’ll learn you.”
+
+“I’m agreed.”
+
+So they played Robin Hood all the afternoon, now and then casting a
+yearning eye down upon the haunted house and passing a remark about the
+morrow’s prospects and possibilities there. As the sun began to sink
+into the west they took their way homeward athwart the long shadows
+of the trees and soon were buried from sight in the forests of Cardiff
+Hill.
+
+On Saturday, shortly after noon, the boys were at the dead tree again.
+They had a smoke and a chat in the shade, and then dug a little in their
+last hole, not with great hope, but merely because Tom said there were
+so many cases where people had given up a treasure after getting down
+within six inches of it, and then somebody else had come along and
+turned it up with a single thrust of a shovel. The thing failed this
+time, however, so the boys shouldered their tools and went away feeling
+that they had not trifled with fortune, but had fulfilled all the
+requirements that belong to the business of treasure-hunting.
+
+When they reached the haunted house there was something so weird and
+grisly about the dead silence that reigned there under the baking sun,
+and something so depressing about the loneliness and desolation of the
+place, that they were afraid, for a moment, to venture in. Then they
+crept to the door and took a trembling peep. They saw a weedgrown,
+floorless room, unplastered, an ancient fireplace, vacant windows,
+a ruinous staircase; and here, there, and everywhere hung ragged and
+abandoned cobwebs. They presently entered, softly, with quickened
+pulses, talking in whispers, ears alert to catch the slightest sound,
+and muscles tense and ready for instant retreat.
+
+In a little while familiarity modified their fears and they gave the
+place a critical and interested examination, rather admiring their own
+boldness, and wondering at it, too. Next they wanted to look upstairs.
+This was something like cutting off retreat, but they got to daring
+each other, and of course there could be but one result--they threw their
+tools into a corner and made the ascent. Up there were the same signs of
+decay. In one corner they found a closet that promised mystery, but the
+promise was a fraud--there was nothing in it. Their courage was up now
+and well in hand. They were about to go down and begin work when--
+
+“Sh!” said Tom.
+
+“What is it?” whispered Huck, blanching with fright.
+
+“Sh!... There!... Hear it?”
+
+“Yes!... Oh, my! Let’s run!”
+
+“Keep still! Don’t you budge! They’re coming right toward the door.”
+
+The boys stretched themselves upon the floor with their eyes to
+knotholes in the planking, and lay waiting, in a misery of fear.
+
+“They’ve stopped.... No--coming.... Here they are. Don’t whisper another
+word, Huck. My goodness, I wish I was out of this!”
+
+Two men entered. Each boy said to himself: “There’s the old deaf and
+dumb Spaniard that’s been about town once or twice lately--never saw
+t’other man before.”
+
+“T’other” was a ragged, unkempt creature, with nothing very pleasant
+in his face. The Spaniard was wrapped in a serape; he had bushy white
+whiskers; long white hair flowed from under his sombrero, and he wore
+green goggles. When they came in, “t’other” was talking in a low voice;
+they sat down on the ground, facing the door, with their backs to the
+wall, and the speaker continued his remarks. His manner became less
+guarded and his words more distinct as he proceeded:
+
+“No,” said he, “I’ve thought it all over, and I don’t like it. It’s
+dangerous.”
+
+“Dangerous!” grunted the “deaf and dumb” Spaniard--to the vast surprise
+of the boys. “Milksop!”
+
+This voice made the boys gasp and quake. It was Injun Joe’s! There was
+silence for some time. Then Joe said:
+
+“What’s any more dangerous than that job up yonder--but nothing’s come of
+it.”
+
+“That’s different. Away up the river so, and not another house about.
+‘Twon’t ever be known that we tried, anyway, long as we didn’t succeed.”
+
+“Well, what’s more dangerous than coming here in the daytime!--anybody
+would suspicion us that saw us.”
+
+“I know that. But there warn’t any other place as handy after that fool
+of a job. I want to quit this shanty. I wanted to yesterday, only it
+warn’t any use trying to stir out of here, with those infernal boys
+playing over there on the hill right in full view.”
+
+“Those infernal boys” quaked again under the inspiration of this remark,
+and thought how lucky it was that they had remembered it was Friday and
+concluded to wait a day. They wished in their hearts they had waited a
+year.
+
+The two men got out some food and made a luncheon. After a long and
+thoughtful silence, Injun Joe said:
+
+“Look here, lad--you go back up the river where you belong. Wait there
+till you hear from me. I’ll take the chances on dropping into this town
+just once more, for a look. We’ll do that ‘dangerous’ job after I’ve
+spied around a little and think things look well for it. Then for Texas!
+We’ll leg it together!”
+
+This was satisfactory. Both men presently fell to yawning, and Injun Joe
+said:
+
+“I’m dead for sleep! It’s your turn to watch.”
+
+He curled down in the weeds and soon began to snore. His comrade stirred
+him once or twice and he became quiet. Presently the watcher began to
+nod; his head drooped lower and lower, both men began to snore now.
+
+The boys drew a long, grateful breath. Tom whispered:
+
+“Now’s our chance--come!”
+
+Huck said:
+
+“I can’t--I’d die if they was to wake.”
+
+Tom urged--Huck held back. At last Tom rose slowly and softly, and
+started alone. But the first step he made wrung such a hideous creak
+from the crazy floor that he sank down almost dead with fright. He never
+made a second attempt. The boys lay there counting the dragging moments
+till it seemed to them that time must be done and eternity growing gray;
+and then they were grateful to note that at last the sun was setting.
+
+Now one snore ceased. Injun Joe sat up, stared around--smiled grimly upon
+his comrade, whose head was drooping upon his knees--stirred him up with
+his foot and said:
+
+“Here! _You’re_ a watchman, ain’t you! All right, though--nothing’s
+happened.”
+
+“My! have I been asleep?”
+
+“Oh, partly, partly. Nearly time for us to be moving, pard. What’ll we
+do with what little swag we’ve got left?”
+
+“I don’t know--leave it here as we’ve always done, I reckon. No use to
+take it away till we start south. Six hundred and fifty in silver’s
+something to carry.”
+
+“Well--all right--it won’t matter to come here once more.”
+
+“No--but I’d say come in the night as we used to do--it’s better.”
+
+“Yes: but look here; it may be a good while before I get the right
+chance at that job; accidents might happen; ‘tain’t in such a very good
+place; we’ll just regularly bury it--and bury it deep.”
+
+“Good idea,” said the comrade, who walked across the room, knelt down,
+raised one of the rearward hearth-stones and took out a bag that jingled
+pleasantly. He subtracted from it twenty or thirty dollars for himself
+and as much for Injun Joe, and passed the bag to the latter, who was on
+his knees in the corner, now, digging with his bowie-knife.
+
+The boys forgot all their fears, all their miseries in an instant. With
+gloating eyes they watched every movement. Luck!--the splendor of it was
+beyond all imagination! Six hundred dollars was money enough to make
+half a dozen boys rich! Here was treasure-hunting under the happiest
+auspices--there would not be any bothersome uncertainty as to where to
+dig. They nudged each other every moment--eloquent nudges and easily
+understood, for they simply meant--“Oh, but ain’t you glad _now_ we’re
+here!”
+
+Joe’s knife struck upon something.
+
+“Hello!” said he.
+
+“What is it?” said his comrade.
+
+“Half-rotten plank--no, it’s a box, I believe. Here--bear a hand and we’ll
+see what it’s here for. Never mind, I’ve broke a hole.”
+
+He reached his hand in and drew it out--
+
+“Man, it’s money!”
+
+The two men examined the handful of coins. They were gold. The boys
+above were as excited as themselves, and as delighted.
+
+Joe’s comrade said:
+
+“We’ll make quick work of this. There’s an old rusty pick over amongst
+the weeds in the corner the other side of the fireplace--I saw it a
+minute ago.”
+
+He ran and brought the boys’ pick and shovel. Injun Joe took the
+pick, looked it over critically, shook his head, muttered something to
+himself, and then began to use it. The box was soon unearthed. It was
+not very large; it was iron bound and had been very strong before the
+slow years had injured it. The men contemplated the treasure awhile in
+blissful silence.
+
+“Pard, there’s thousands of dollars here,” said Injun Joe.
+
+“‘Twas always said that Murrel’s gang used to be around here one
+summer,” the stranger observed.
+
+“I know it,” said Injun Joe; “and this looks like it, I should say.”
+
+“Now you won’t need to do that job.”
+
+The halfbreed frowned. Said he:
+
+“You don’t know me. Least you don’t know all about that thing. ‘Tain’t
+robbery altogether--it’s _revenge_!” and a wicked light flamed in his
+eyes. “I’ll need your help in it. When it’s finished--then Texas. Go home
+to your Nance and your kids, and stand by till you hear from me.”
+
+“Well--if you say so; what’ll we do with this--bury it again?”
+
+“Yes. [Ravishing delight overhead.] _No_! by the great Sachem, no!
+[Profound distress overhead.] I’d nearly forgot. That pick had fresh
+earth on it! [The boys were sick with terror in a moment.] What business
+has a pick and a shovel here? What business with fresh earth on
+them? Who brought them here--and where are they gone? Have you heard
+anybody?--seen anybody? What! bury it again and leave them to come and
+see the ground disturbed? Not exactly--not exactly. We’ll take it to my
+den.”
+
+“Why, of course! Might have thought of that before. You mean Number
+One?”
+
+“No--Number Two--under the cross. The other place is bad--too common.”
+
+“All right. It’s nearly dark enough to start.”
+
+Injun Joe got up and went about from window to window cautiously peeping
+out. Presently he said:
+
+“Who could have brought those tools here? Do you reckon they can be
+upstairs?”
+
+The boys’ breath forsook them. Injun Joe put his hand on his knife,
+halted a moment, undecided, and then turned toward the stairway. The
+boys thought of the closet, but their strength was gone. The steps came
+creaking up the stairs--the intolerable distress of the situation woke
+the stricken resolution of the lads--they were about to spring for the
+closet, when there was a crash of rotten timbers and Injun Joe landed on
+the ground amid the debris of the ruined stairway. He gathered himself
+up cursing, and his comrade said:
+
+“Now what’s the use of all that? If it’s anybody, and they’re up there,
+let them _stay_ there--who cares? If they want to jump down, now, and get
+into trouble, who objects? It will be dark in fifteen minutes--and then
+let them follow us if they want to. I’m willing. In my opinion, whoever
+hove those things in here caught a sight of us and took us for ghosts or
+devils or something. I’ll bet they’re running yet.”
+
+Joe grumbled awhile; then he agreed with his friend that what daylight
+was left ought to be economized in getting things ready for leaving.
+Shortly afterward they slipped out of the house in the deepening
+twilight, and moved toward the river with their precious box.
+
+Tom and Huck rose up, weak but vastly relieved, and stared after them
+through the chinks between the logs of the house. Follow? Not they. They
+were content to reach ground again without broken necks, and take the
+townward track over the hill. They did not talk much. They were too much
+absorbed in hating themselves--hating the ill luck that made them take
+the spade and the pick there. But for that, Injun Joe never would have
+suspected. He would have hidden the silver with the gold to wait
+there till his “revenge” was satisfied, and then he would have had the
+misfortune to find that money turn up missing. Bitter, bitter luck that
+the tools were ever brought there!
+
+They resolved to keep a lookout for that Spaniard when he should come to
+town spying out for chances to do his revengeful job, and follow him to
+“Number Two,” wherever that might be. Then a ghastly thought occurred to
+Tom.
+
+“Revenge? What if he means _us_, Huck!”
+
+“Oh, don’t!” said Huck, nearly fainting.
+
+They talked it all over, and as they entered town they agreed to believe
+that he might possibly mean somebody else--at least that he might at
+least mean nobody but Tom, since only Tom had testified.
+
+Very, very small comfort it was to Tom to be alone in danger! Company
+would be a palpable improvement, he thought.
+
+
+
+
+CHAPTER XXVII
+
+THE adventure of the day mightily tormented Tom’s dreams that night.
+Four times he had his hands on that rich treasure and four times
+it wasted to nothingness in his fingers as sleep forsook him and
+wakefulness brought back the hard reality of his misfortune. As he lay
+in the early morning recalling the incidents of his great adventure, he
+noticed that they seemed curiously subdued and far away--somewhat as if
+they had happened in another world, or in a time long gone by. Then it
+occurred to him that the great adventure itself must be a dream! There
+was one very strong argument in favor of this idea--namely, that the
+quantity of coin he had seen was too vast to be real. He had never seen
+as much as fifty dollars in one mass before, and he was like all boys of
+his age and station in life, in that he imagined that all references to
+“hundreds” and “thousands” were mere fanciful forms of speech, and that
+no such sums really existed in the world. He never had supposed for
+a moment that so large a sum as a hundred dollars was to be found in
+actual money in any one’s possession. If his notions of hidden treasure
+had been analyzed, they would have been found to consist of a handful of
+real dimes and a bushel of vague, splendid, ungraspable dollars.
+
+But the incidents of his adventure grew sensibly sharper and clearer
+under the attrition of thinking them over, and so he presently found
+himself leaning to the impression that the thing might not have been a
+dream, after all. This uncertainty must be swept away. He would snatch a
+hurried breakfast and go and find Huck. Huck was sitting on the gunwale
+of a flatboat, listlessly dangling his feet in the water and looking
+very melancholy. Tom concluded to let Huck lead up to the subject. If
+he did not do it, then the adventure would be proved to have been only a
+dream.
+
+“Hello, Huck!”
+
+“Hello, yourself.”
+
+Silence, for a minute.
+
+“Tom, if we’d ‘a’ left the blame tools at the dead tree, we’d ‘a’ got
+the money. Oh, ain’t it awful!”
+
+“‘Tain’t a dream, then, ‘tain’t a dream! Somehow I most wish it was.
+Dog’d if I don’t, Huck.”
+
+“What ain’t a dream?”
+
+“Oh, that thing yesterday. I been half thinking it was.”
+
+“Dream! If them stairs hadn’t broke down you’d ‘a’ seen how much dream
+it was! I’ve had dreams enough all night--with that patch-eyed Spanish
+devil going for me all through ‘em--rot him!”
+
+“No, not rot him. _Find_ him! Track the money!”
+
+“Tom, we’ll never find him. A feller don’t have only one chance for such
+a pile--and that one’s lost. I’d feel mighty shaky if I was to see him,
+anyway.”
+
+“Well, so’d I; but I’d like to see him, anyway--and track him out--to his
+Number Two.”
+
+“Number Two--yes, that’s it. I been thinking ‘bout that. But I can’t make
+nothing out of it. What do you reckon it is?”
+
+“I dono. It’s too deep. Say, Huck--maybe it’s the number of a house!”
+
+“Goody!... No, Tom, that ain’t it. If it is, it ain’t in this one-horse
+town. They ain’t no numbers here.”
+
+“Well, that’s so. Lemme think a minute. Here--it’s the number of a
+room--in a tavern, you know!”
+
+“Oh, that’s the trick! They ain’t only two taverns. We can find out
+quick.”
+
+“You stay here, Huck, till I come.”
+
+Tom was off at once. He did not care to have Huck’s company in public
+places. He was gone half an hour. He found that in the best tavern, No.
+2 had long been occupied by a young lawyer, and was still so occupied.
+In the less ostentatious house, No. 2 was a mystery. The tavern-keeper’s
+young son said it was kept locked all the time, and he never saw anybody
+go into it or come out of it except at night; he did not know any
+particular reason for this state of things; had had some little
+curiosity, but it was rather feeble; had made the most of the mystery
+by entertaining himself with the idea that that room was “ha’nted”; had
+noticed that there was a light in there the night before.
+
+“That’s what I’ve found out, Huck. I reckon that’s the very No. 2 we’re
+after.”
+
+“I reckon it is, Tom. Now what you going to do?”
+
+“Lemme think.”
+
+Tom thought a long time. Then he said:
+
+“I’ll tell you. The back door of that No. 2 is the door that comes out
+into that little close alley between the tavern and the old rattle trap
+of a brick store. Now you get hold of all the doorkeys you can find, and
+I’ll nip all of auntie’s, and the first dark night we’ll go there and
+try ‘em. And mind you, keep a lookout for Injun Joe, because he said he
+was going to drop into town and spy around once more for a chance to get
+his revenge. If you see him, you just follow him; and if he don’t go to
+that No. 2, that ain’t the place.”
+
+“Lordy, I don’t want to foller him by myself!”
+
+“Why, it’ll be night, sure. He mightn’t ever see you--and if he did,
+maybe he’d never think anything.”
+
+“Well, if it’s pretty dark I reckon I’ll track him. I dono--I dono. I’ll
+try.”
+
+“You bet I’ll follow him, if it’s dark, Huck. Why, he might ‘a’ found
+out he couldn’t get his revenge, and be going right after that money.”
+
+“It’s so, Tom, it’s so. I’ll foller him; I will, by jingoes!”
+
+“Now you’re _talking_! Don’t you ever weaken, Huck, and I won’t.”
+
+
+
+
+CHAPTER XXVIII
+
+THAT night Tom and Huck were ready for their adventure. They hung about
+the neighborhood of the tavern until after nine, one watching the alley
+at a distance and the other the tavern door. Nobody entered the alley or
+left it; nobody resembling the Spaniard entered or left the tavern
+door. The night promised to be a fair one; so Tom went home with the
+understanding that if a considerable degree of darkness came on, Huck
+was to come and “maow,” whereupon he would slip out and try the keys.
+But the night remained clear, and Huck closed his watch and retired to
+bed in an empty sugar hogshead about twelve.
+
+Tuesday the boys had the same ill luck. Also Wednesday. But Thursday
+night promised better. Tom slipped out in good season with his aunt’s
+old tin lantern, and a large towel to blindfold it with. He hid the
+lantern in Huck’s sugar hogshead and the watch began. An hour before
+midnight the tavern closed up and its lights (the only ones thereabouts)
+were put out. No Spaniard had been seen. Nobody had entered or left the
+alley. Everything was auspicious. The blackness of darkness reigned,
+the perfect stillness was interrupted only by occasional mutterings of
+distant thunder.
+
+Tom got his lantern, lit it in the hogshead, wrapped it closely in the
+towel, and the two adventurers crept in the gloom toward the tavern.
+Huck stood sentry and Tom felt his way into the alley. Then there was
+a season of waiting anxiety that weighed upon Huck’s spirits like a
+mountain. He began to wish he could see a flash from the lantern--it
+would frighten him, but it would at least tell him that Tom was alive
+yet. It seemed hours since Tom had disappeared. Surely he must have
+fainted; maybe he was dead; maybe his heart had burst under terror and
+excitement. In his uneasiness Huck found himself drawing closer
+and closer to the alley; fearing all sorts of dreadful things, and
+momentarily expecting some catastrophe to happen that would take away
+his breath. There was not much to take away, for he seemed only able to
+inhale it by thimblefuls, and his heart would soon wear itself out, the
+way it was beating. Suddenly there was a flash of light and Tom came
+tearing by him: “Run!” said he; “run, for your life!”
+
+He needn’t have repeated it; once was enough; Huck was making thirty or
+forty miles an hour before the repetition was uttered. The boys never
+stopped till they reached the shed of a deserted slaughter-house at the
+lower end of the village. Just as they got within its shelter the storm
+burst and the rain poured down. As soon as Tom got his breath he said:
+
+“Huck, it was awful! I tried two of the keys, just as soft as I could;
+but they seemed to make such a power of racket that I couldn’t hardly
+get my breath I was so scared. They wouldn’t turn in the lock, either.
+Well, without noticing what I was doing, I took hold of the knob, and
+open comes the door! It warn’t locked! I hopped in, and shook off the
+towel, and, _Great Caesar’s Ghost!_”
+
+“What!--what’d you see, Tom?”
+
+“Huck, I most stepped onto Injun Joe’s hand!”
+
+“No!”
+
+“Yes! He was lying there, sound asleep on the floor, with his old patch
+on his eye and his arms spread out.”
+
+“Lordy, what did you do? Did he wake up?”
+
+“No, never budged. Drunk, I reckon. I just grabbed that towel and
+started!”
+
+“I’d never ‘a’ thought of the towel, I bet!”
+
+“Well, I would. My aunt would make me mighty sick if I lost it.”
+
+“Say, Tom, did you see that box?”
+
+“Huck, I didn’t wait to look around. I didn’t see the box, I didn’t see
+the cross. I didn’t see anything but a bottle and a tin cup on the floor
+by Injun Joe; yes, I saw two barrels and lots more bottles in the room.
+Don’t you see, now, what’s the matter with that ha’nted room?”
+
+“How?”
+
+“Why, it’s ha’nted with whiskey! Maybe _all_ the Temperance Taverns have
+got a ha’nted room, hey, Huck?”
+
+“Well, I reckon maybe that’s so. Who’d ‘a’ thought such a thing? But
+say, Tom, now’s a mighty good time to get that box, if Injun Joe’s
+drunk.”
+
+“It is, that! You try it!”
+
+Huck shuddered.
+
+“Well, no--I reckon not.”
+
+“And I reckon not, Huck. Only one bottle alongside of Injun Joe ain’t
+enough. If there’d been three, he’d be drunk enough and I’d do it.”
+
+There was a long pause for reflection, and then Tom said:
+
+“Lookyhere, Huck, less not try that thing any more till we know Injun
+Joe’s not in there. It’s too scary. Now, if we watch every night, we’ll
+be dead sure to see him go out, some time or other, and then we’ll
+snatch that box quicker’n lightning.”
+
+“Well, I’m agreed. I’ll watch the whole night long, and I’ll do it every
+night, too, if you’ll do the other part of the job.”
+
+“All right, I will. All you got to do is to trot up Hooper Street a
+block and maow--and if I’m asleep, you throw some gravel at the window
+and that’ll fetch me.”
+
+“Agreed, and good as wheat!”
+
+“Now, Huck, the storm’s over, and I’ll go home. It’ll begin to be
+daylight in a couple of hours. You go back and watch that long, will
+you?”
+
+“I said I would, Tom, and I will. I’ll ha’nt that tavern every night for
+a year! I’ll sleep all day and I’ll stand watch all night.”
+
+“That’s all right. Now, where you going to sleep?”
+
+“In Ben Rogers’ hayloft. He lets me, and so does his pap’s nigger man,
+Uncle Jake. I tote water for Uncle Jake whenever he wants me to, and any
+time I ask him he gives me a little something to eat if he can spare it.
+That’s a mighty good nigger, Tom. He likes me, becuz I don’t ever act as
+if I was above him. Sometime I’ve set right down and eat _with_ him. But
+you needn’t tell that. A body’s got to do things when he’s awful hungry
+he wouldn’t want to do as a steady thing.”
+
+“Well, if I don’t want you in the daytime, I’ll let you sleep. I won’t
+come bothering around. Any time you see something’s up, in the night,
+just skip right around and maow.”
+
+
+
+
+CHAPTER XXIX
+
+THE first thing Tom heard on Friday morning was a glad piece of
+news--Judge Thatcher’s family had come back to town the night before.
+Both Injun Joe and the treasure sunk into secondary importance for a
+moment, and Becky took the chief place in the boy’s interest. He saw her
+and they had an exhausting good time playing “hispy” and “gully-keeper”
+ with a crowd of their schoolmates. The day was completed and crowned in
+a peculiarly satisfactory way: Becky teased her mother to appoint
+the next day for the long-promised and long-delayed picnic, and she
+consented. The child’s delight was boundless; and Tom’s not more
+moderate. The invitations were sent out before sunset, and straightway
+the young folks of the village were thrown into a fever of preparation
+and pleasurable anticipation. Tom’s excitement enabled him to keep
+awake until a pretty late hour, and he had good hopes of hearing Huck’s
+“maow,” and of having his treasure to astonish Becky and the picnickers
+with, next day; but he was disappointed. No signal came that night.
+
+Morning came, eventually, and by ten or eleven o’clock a giddy and
+rollicking company were gathered at Judge Thatcher’s, and everything was
+ready for a start. It was not the custom for elderly people to mar the
+picnics with their presence. The children were considered safe enough
+under the wings of a few young ladies of eighteen and a few young
+gentlemen of twenty-three or thereabouts. The old steam ferry-boat was
+chartered for the occasion; presently the gay throng filed up the main
+street laden with provision-baskets. Sid was sick and had to miss
+the fun; Mary remained at home to entertain him. The last thing Mrs.
+Thatcher said to Becky, was:
+
+“You’ll not get back till late. Perhaps you’d better stay all night with
+some of the girls that live near the ferry-landing, child.”
+
+“Then I’ll stay with Susy Harper, mamma.”
+
+“Very well. And mind and behave yourself and don’t be any trouble.”
+
+Presently, as they tripped along, Tom said to Becky:
+
+“Say--I’ll tell you what we’ll do. ‘Stead of going to Joe Harper’s we’ll
+climb right up the hill and stop at the Widow Douglas’. She’ll have
+ice-cream! She has it most every day--dead loads of it. And she’ll be
+awful glad to have us.”
+
+“Oh, that will be fun!”
+
+Then Becky reflected a moment and said:
+
+“But what will mamma say?”
+
+“How’ll she ever know?”
+
+The girl turned the idea over in her mind, and said reluctantly:
+
+“I reckon it’s wrong--but--”
+
+“But shucks! Your mother won’t know, and so what’s the harm? All she
+wants is that you’ll be safe; and I bet you she’d ‘a’ said go there if
+she’d ‘a’ thought of it. I know she would!”
+
+The Widow Douglas’ splendid hospitality was a tempting bait. It and
+Tom’s persuasions presently carried the day. So it was decided to say
+nothing to anybody about the night’s programme. Presently it occurred to
+Tom that maybe Huck might come this very night and give the signal. The
+thought took a deal of the spirit out of his anticipations. Still he
+could not bear to give up the fun at Widow Douglas’. And why should he
+give it up, he reasoned--the signal did not come the night before, so
+why should it be any more likely to come tonight? The sure fun of the
+evening outweighed the uncertain treasure; and, boy-like, he determined
+to yield to the stronger inclination and not allow himself to think of
+the box of money another time that day.
+
+Three miles below town the ferryboat stopped at the mouth of a woody
+hollow and tied up. The crowd swarmed ashore and soon the forest
+distances and craggy heights echoed far and near with shoutings and
+laughter. All the different ways of getting hot and tired were gone
+through with, and by-and-by the rovers straggled back to camp fortified
+with responsible appetites, and then the destruction of the good things
+began. After the feast there was a refreshing season of rest and chat in
+the shade of spreading oaks. By-and-by somebody shouted:
+
+“Who’s ready for the cave?”
+
+Everybody was. Bundles of candles were procured, and straightway there
+was a general scamper up the hill. The mouth of the cave was up the
+hillside--an opening shaped like a letter A. Its massive oaken door stood
+unbarred. Within was a small chamber, chilly as an icehouse, and walled
+by Nature with solid limestone that was dewy with a cold sweat. It was
+romantic and mysterious to stand here in the deep gloom and look out
+upon the green valley shining in the sun. But the impressiveness of the
+situation quickly wore off, and the romping began again. The moment
+a candle was lighted there was a general rush upon the owner of it; a
+struggle and a gallant defence followed, but the candle was soon knocked
+down or blown out, and then there was a glad clamor of laughter and a
+new chase. But all things have an end. By-and-by the procession went
+filing down the steep descent of the main avenue, the flickering rank of
+lights dimly revealing the lofty walls of rock almost to their point of
+junction sixty feet overhead. This main avenue was not more than
+eight or ten feet wide. Every few steps other lofty and still narrower
+crevices branched from it on either hand--for McDougal’s cave was but a
+vast labyrinth of crooked aisles that ran into each other and out again
+and led nowhere. It was said that one might wander days and nights
+together through its intricate tangle of rifts and chasms, and never
+find the end of the cave; and that he might go down, and down, and
+still down, into the earth, and it was just the same--labyrinth under
+labyrinth, and no end to any of them. No man “knew” the cave. That was
+an impossible thing. Most of the young men knew a portion of it, and it
+was not customary to venture much beyond this known portion. Tom Sawyer
+knew as much of the cave as any one.
+
+The procession moved along the main avenue some three-quarters of
+a mile, and then groups and couples began to slip aside into branch
+avenues, fly along the dismal corridors, and take each other by surprise
+at points where the corridors joined again. Parties were able to elude
+each other for the space of half an hour without going beyond the
+“known” ground.
+
+By-and-by, one group after another came straggling back to the mouth
+of the cave, panting, hilarious, smeared from head to foot with tallow
+drippings, daubed with clay, and entirely delighted with the success of
+the day. Then they were astonished to find that they had been taking
+no note of time and that night was about at hand. The clanging bell had
+been calling for half an hour. However, this sort of close to the day’s
+adventures was romantic and therefore satisfactory. When the ferryboat
+with her wild freight pushed into the stream, nobody cared sixpence for
+the wasted time but the captain of the craft.
+
+Huck was already upon his watch when the ferryboat’s lights went
+glinting past the wharf. He heard no noise on board, for the young
+people were as subdued and still as people usually are who are nearly
+tired to death. He wondered what boat it was, and why she did not
+stop at the wharf--and then he dropped her out of his mind and put his
+attention upon his business. The night was growing cloudy and dark. Ten
+o’clock came, and the noise of vehicles ceased, scattered lights began
+to wink out, all straggling foot-passengers disappeared, the village
+betook itself to its slumbers and left the small watcher alone with the
+silence and the ghosts. Eleven o’clock came, and the tavern lights were
+put out; darkness everywhere, now. Huck waited what seemed a weary long
+time, but nothing happened. His faith was weakening. Was there any use?
+Was there really any use? Why not give it up and turn in?
+
+A noise fell upon his ear. He was all attention in an instant. The alley
+door closed softly. He sprang to the corner of the brick store. The next
+moment two men brushed by him, and one seemed to have something under
+his arm. It must be that box! So they were going to remove the treasure.
+Why call Tom now? It would be absurd--the men would get away with the box
+and never be found again. No, he would stick to their wake and follow
+them; he would trust to the darkness for security from discovery. So
+communing with himself, Huck stepped out and glided along behind the
+men, cat-like, with bare feet, allowing them to keep just far enough
+ahead not to be invisible.
+
+They moved up the river street three blocks, then turned to the left up
+a crossstreet. They went straight ahead, then, until they came to the
+path that led up Cardiff Hill; this they took. They passed by the old
+Welshman’s house, halfway up the hill, without hesitating, and still
+climbed upward. Good, thought Huck, they will bury it in the old quarry.
+But they never stopped at the quarry. They passed on, up the summit.
+They plunged into the narrow path between the tall sumach bushes, and
+were at once hidden in the gloom. Huck closed up and shortened his
+distance, now, for they would never be able to see him. He trotted along
+awhile; then slackened his pace, fearing he was gaining too fast; moved
+on a piece, then stopped altogether; listened; no sound; none, save that
+he seemed to hear the beating of his own heart. The hooting of an
+owl came over the hill--ominous sound! But no footsteps. Heavens, was
+everything lost! He was about to spring with winged feet, when a man
+cleared his throat not four feet from him! Huck’s heart shot into his
+throat, but he swallowed it again; and then he stood there shaking as
+if a dozen agues had taken charge of him at once, and so weak that he
+thought he must surely fall to the ground. He knew where he was. He
+knew he was within five steps of the stile leading into Widow Douglas’
+grounds. Very well, he thought, let them bury it there; it won’t be hard
+to find.
+
+Now there was a voice--a very low voice--Injun Joe’s:
+
+“Damn her, maybe she’s got company--there’s lights, late as it is.”
+
+“I can’t see any.”
+
+This was that stranger’s voice--the stranger of the haunted house. A
+deadly chill went to Huck’s heart--this, then, was the “revenge” job! His
+thought was, to fly. Then he remembered that the Widow Douglas had been
+kind to him more than once, and maybe these men were going to murder
+her. He wished he dared venture to warn her; but he knew he didn’t
+dare--they might come and catch him. He thought all this and more in
+the moment that elapsed between the stranger’s remark and Injun Joe’s
+next--which was--
+
+“Because the bush is in your way. Now--this way--now you see, don’t you?”
+
+“Yes. Well, there _is_ company there, I reckon. Better give it up.”
+
+“Give it up, and I just leaving this country forever! Give it up and
+maybe never have another chance. I tell you again, as I’ve told you
+before, I don’t care for her swag--you may have it. But her husband was
+rough on me--many times he was rough on me--and mainly he was the justice
+of the peace that jugged me for a vagrant. And that ain’t all. It ain’t
+a millionth part of it! He had me _horsewhipped_!--horsewhipped in
+front of the jail, like a nigger!--with all the town looking on!
+_Horsewhipped_!--do you understand? He took advantage of me and died. But
+I’ll take it out of _her_.”
+
+“Oh, don’t kill her! Don’t do that!”
+
+“Kill? Who said anything about killing? I would kill _him_ if he was
+here; but not her. When you want to get revenge on a woman you don’t
+kill her--bosh! you go for her looks. You slit her nostrils--you notch her
+ears like a sow!”
+
+“By God, that’s--”
+
+“Keep your opinion to yourself! It will be safest for you. I’ll tie her
+to the bed. If she bleeds to death, is that my fault? I’ll not cry, if
+she does. My friend, you’ll help me in this thing--for _my_ sake--that’s
+why you’re here--I mightn’t be able alone. If you flinch, I’ll kill you.
+Do you understand that? And if I have to kill you, I’ll kill her--and
+then I reckon nobody’ll ever know much about who done this business.”
+
+“Well, if it’s got to be done, let’s get at it. The quicker the
+better--I’m all in a shiver.”
+
+“Do it _now_? And company there? Look here--I’ll get suspicious of you,
+first thing you know. No--we’ll wait till the lights are out--there’s no
+hurry.”
+
+Huck felt that a silence was going to ensue--a thing still more awful
+than any amount of murderous talk; so he held his breath and stepped
+gingerly back; planted his foot carefully and firmly, after balancing,
+one-legged, in a precarious way and almost toppling over, first on one
+side and then on the other. He took another step back, with the same
+elaboration and the same risks; then another and another, and--a twig
+snapped under his foot! His breath stopped and he listened. There was no
+sound--the stillness was perfect. His gratitude was measureless. Now he
+turned in his tracks, between the walls of sumach bushes--turned
+himself as carefully as if he were a ship--and then stepped quickly but
+cautiously along. When he emerged at the quarry he felt secure, and
+so he picked up his nimble heels and flew. Down, down he sped, till he
+reached the Welshman’s. He banged at the door, and presently the heads
+of the old man and his two stalwart sons were thrust from windows.
+
+“What’s the row there? Who’s banging? What do you want?”
+
+“Let me in--quick! I’ll tell everything.”
+
+“Why, who are you?”
+
+“Huckleberry Finn--quick, let me in!”
+
+“Huckleberry Finn, indeed! It ain’t a name to open many doors, I judge!
+But let him in, lads, and let’s see what’s the trouble.”
+
+“Please don’t ever tell I told you,” were Huck’s first words when he got
+in. “Please don’t--I’d be killed, sure--but the widow’s been good friends
+to me sometimes, and I want to tell--I _will_ tell if you’ll promise you
+won’t ever say it was me.”
+
+“By George, he _has_ got something to tell, or he wouldn’t act so!”
+ exclaimed the old man; “out with it and nobody here’ll ever tell, lad.”
+
+Three minutes later the old man and his sons, well armed, were up the
+hill, and just entering the sumach path on tiptoe, their weapons in
+their hands. Huck accompanied them no further. He hid behind a great
+bowlder and fell to listening. There was a lagging, anxious silence, and
+then all of a sudden there was an explosion of firearms and a cry.
+
+Huck waited for no particulars. He sprang away and sped down the hill as
+fast as his legs could carry him.
+
+
+
+
+CHAPTER XXX
+
+AS the earliest suspicion of dawn appeared on Sunday morning, Huck came
+groping up the hill and rapped gently at the old Welshman’s door. The
+inmates were asleep, but it was a sleep that was set on a hair-trigger,
+on account of the exciting episode of the night. A call came from a
+window:
+
+“Who’s there!”
+
+Huck’s scared voice answered in a low tone:
+
+“Please let me in! It’s only Huck Finn!”
+
+“It’s a name that can open this door night or day, lad!--and welcome!”
+
+These were strange words to the vagabond boy’s ears, and the pleasantest
+he had ever heard. He could not recollect that the closing word had ever
+been applied in his case before. The door was quickly unlocked, and he
+entered. Huck was given a seat and the old man and his brace of tall
+sons speedily dressed themselves.
+
+“Now, my boy, I hope you’re good and hungry, because breakfast will be
+ready as soon as the sun’s up, and we’ll have a piping hot one, too--make
+yourself easy about that! I and the boys hoped you’d turn up and stop
+here last night.”
+
+“I was awful scared,” said Huck, “and I run. I took out when the pistols
+went off, and I didn’t stop for three mile. I’ve come now becuz I wanted
+to know about it, you know; and I come before daylight becuz I didn’t
+want to run across them devils, even if they was dead.”
+
+“Well, poor chap, you do look as if you’d had a hard night of it--but
+there’s a bed here for you when you’ve had your breakfast. No, they
+ain’t dead, lad--we are sorry enough for that. You see we knew right
+where to put our hands on them, by your description; so we crept along
+on tiptoe till we got within fifteen feet of them--dark as a cellar that
+sumach path was--and just then I found I was going to sneeze. It was the
+meanest kind of luck! I tried to keep it back, but no use--‘twas bound to
+come, and it did come! I was in the lead with my pistol raised, and when
+the sneeze started those scoundrels a-rustling to get out of the path,
+I sung out, ‘Fire boys!’ and blazed away at the place where the rustling
+was. So did the boys. But they were off in a jiffy, those villains, and
+we after them, down through the woods. I judge we never touched them.
+They fired a shot apiece as they started, but their bullets whizzed by
+and didn’t do us any harm. As soon as we lost the sound of their feet
+we quit chasing, and went down and stirred up the constables. They got a
+posse together, and went off to guard the river bank, and as soon as it
+is light the sheriff and a gang are going to beat up the woods. My boys
+will be with them presently. I wish we had some sort of description of
+those rascals--‘twould help a good deal. But you couldn’t see what they
+were like, in the dark, lad, I suppose?”
+
+“Oh yes; I saw them downtown and follered them.”
+
+“Splendid! Describe them--describe them, my boy!”
+
+“One’s the old deaf and dumb Spaniard that’s ben around here once or
+twice, and t’other’s a mean-looking, ragged--”
+
+“That’s enough, lad, we know the men! Happened on them in the woods back
+of the widow’s one day, and they slunk away. Off with you, boys, and
+tell the sheriff--get your breakfast tomorrow morning!”
+
+The Welshman’s sons departed at once. As they were leaving the room Huck
+sprang up and exclaimed:
+
+“Oh, please don’t tell _any_body it was me that blowed on them! Oh,
+please!”
+
+“All right if you say it, Huck, but you ought to have the credit of what
+you did.”
+
+“Oh no, no! Please don’t tell!”
+
+When the young men were gone, the old Welshman said:
+
+“They won’t tell--and I won’t. But why don’t you want it known?”
+
+Huck would not explain, further than to say that he already knew too
+much about one of those men and would not have the man know that he knew
+anything against him for the whole world--he would be killed for knowing
+it, sure.
+
+The old man promised secrecy once more, and said:
+
+“How did you come to follow these fellows, lad? Were they looking
+suspicious?”
+
+Huck was silent while he framed a duly cautious reply. Then he said:
+
+“Well, you see, I’m a kind of a hard lot,--least everybody says so, and
+I don’t see nothing agin it--and sometimes I can’t sleep much, on account
+of thinking about it and sort of trying to strike out a new way of
+doing. That was the way of it last night. I couldn’t sleep, and so I
+come along upstreet ‘bout midnight, a-turning it all over, and when I
+got to that old shackly brick store by the Temperance Tavern, I backed
+up agin the wall to have another think. Well, just then along comes
+these two chaps slipping along close by me, with something under their
+arm, and I reckoned they’d stole it. One was a-smoking, and t’other one
+wanted a light; so they stopped right before me and the cigars lit up
+their faces and I see that the big one was the deaf and dumb Spaniard,
+by his white whiskers and the patch on his eye, and t’other one was a
+rusty, ragged-looking devil.”
+
+“Could you see the rags by the light of the cigars?”
+
+This staggered Huck for a moment. Then he said:
+
+“Well, I don’t know--but somehow it seems as if I did.”
+
+“Then they went on, and you--”
+
+“Follered ‘em--yes. That was it. I wanted to see what was up--they sneaked
+along so. I dogged ‘em to the widder’s stile, and stood in the dark and
+heard the ragged one beg for the widder, and the Spaniard swear he’d
+spile her looks just as I told you and your two--”
+
+“What! The _deaf and dumb_ man said all that!”
+
+Huck had made another terrible mistake! He was trying his best to keep
+the old man from getting the faintest hint of who the Spaniard might be,
+and yet his tongue seemed determined to get him into trouble in spite of
+all he could do. He made several efforts to creep out of his scrape,
+but the old man’s eye was upon him and he made blunder after blunder.
+Presently the Welshman said:
+
+“My boy, don’t be afraid of me. I wouldn’t hurt a hair of your head for
+all the world. No--I’d protect you--I’d protect you. This Spaniard is
+not deaf and dumb; you’ve let that slip without intending it; you can’t
+cover that up now. You know something about that Spaniard that you want
+to keep dark. Now trust me--tell me what it is, and trust me--I won’t
+betray you.”
+
+Huck looked into the old man’s honest eyes a moment, then bent over and
+whispered in his ear:
+
+“‘Tain’t a Spaniard--it’s Injun Joe!”
+
+The Welshman almost jumped out of his chair. In a moment he said:
+
+“It’s all plain enough, now. When you talked about notching ears and
+slitting noses I judged that that was your own embellishment, because
+white men don’t take that sort of revenge. But an Injun! That’s a
+different matter altogether.”
+
+During breakfast the talk went on, and in the course of it the old man
+said that the last thing which he and his sons had done, before going
+to bed, was to get a lantern and examine the stile and its vicinity for
+marks of blood. They found none, but captured a bulky bundle of--
+
+“Of _what_?”
+
+If the words had been lightning they could not have leaped with a more
+stunning suddenness from Huck’s blanched lips. His eyes were staring
+wide, now, and his breath suspended--waiting for the answer. The Welshman
+started--stared in return--three seconds--five seconds--ten--then replied:
+
+“Of burglar’s tools. Why, what’s the _matter_ with you?”
+
+Huck sank back, panting gently, but deeply, unutterably grateful. The
+Welshman eyed him gravely, curiously--and presently said:
+
+“Yes, burglar’s tools. That appears to relieve you a good deal. But what
+did give you that turn? What were _you_ expecting we’d found?”
+
+Huck was in a close place--the inquiring eye was upon him--he would have
+given anything for material for a plausible answer--nothing suggested
+itself--the inquiring eye was boring deeper and deeper--a senseless
+reply offered--there was no time to weigh it, so at a venture he uttered
+it--feebly:
+
+“Sunday-school books, maybe.”
+
+Poor Huck was too distressed to smile, but the old man laughed loud and
+joyously, shook up the details of his anatomy from head to foot, and
+ended by saying that such a laugh was money in a-man’s pocket, because
+it cut down the doctor’s bill like everything. Then he added:
+
+“Poor old chap, you’re white and jaded--you ain’t well a bit--no wonder
+you’re a little flighty and off your balance. But you’ll come out of it.
+Rest and sleep will fetch you out all right, I hope.”
+
+Huck was irritated to think he had been such a goose and betrayed such
+a suspicious excitement, for he had dropped the idea that the parcel
+brought from the tavern was the treasure, as soon as he had heard the
+talk at the widow’s stile. He had only thought it was not the treasure,
+however--he had not known that it wasn’t--and so the suggestion of a
+captured bundle was too much for his self-possession. But on the whole
+he felt glad the little episode had happened, for now he knew beyond all
+question that that bundle was not _the_ bundle, and so his mind was
+at rest and exceedingly comfortable. In fact, everything seemed to be
+drifting just in the right direction, now; the treasure must be still
+in No. 2, the men would be captured and jailed that day, and he and
+Tom could seize the gold that night without any trouble or any fear of
+interruption.
+
+Just as breakfast was completed there was a knock at the door. Huck
+jumped for a hiding-place, for he had no mind to be connected even
+remotely with the late event. The Welshman admitted several ladies and
+gentlemen, among them the Widow Douglas, and noticed that groups of
+citizens were climbing up the hill--to stare at the stile. So the news
+had spread. The Welshman had to tell the story of the night to the
+visitors. The widow’s gratitude for her preservation was outspoken.
+
+“Don’t say a word about it, madam. There’s another that you’re more
+beholden to than you are to me and my boys, maybe, but he don’t allow me
+to tell his name. We wouldn’t have been there but for him.”
+
+Of course this excited a curiosity so vast that it almost belittled the
+main matter--but the Welshman allowed it to eat into the vitals of his
+visitors, and through them be transmitted to the whole town, for he
+refused to part with his secret. When all else had been learned, the
+widow said:
+
+“I went to sleep reading in bed and slept straight through all that
+noise. Why didn’t you come and wake me?”
+
+“We judged it warn’t worth while. Those fellows warn’t likely to come
+again--they hadn’t any tools left to work with, and what was the use of
+waking you up and scaring you to death? My three negro men stood guard
+at your house all the rest of the night. They’ve just come back.”
+
+More visitors came, and the story had to be told and retold for a couple
+of hours more.
+
+There was no Sabbath-school during day-school vacation, but everybody
+was early at church. The stirring event was well canvassed. News came
+that not a sign of the two villains had been yet discovered. When the
+sermon was finished, Judge Thatcher’s wife dropped alongside of Mrs.
+Harper as she moved down the aisle with the crowd and said:
+
+“Is my Becky going to sleep all day? I just expected she would be tired
+to death.”
+
+“Your Becky?”
+
+“Yes,” with a startled look--“didn’t she stay with you last night?”
+
+“Why, no.”
+
+Mrs. Thatcher turned pale, and sank into a pew, just as Aunt Polly,
+talking briskly with a friend, passed by. Aunt Polly said:
+
+“Goodmorning, Mrs. Thatcher. Goodmorning, Mrs. Harper. I’ve got a boy
+that’s turned up missing. I reckon my Tom stayed at your house last
+night--one of you. And now he’s afraid to come to church. I’ve got to
+settle with him.”
+
+Mrs. Thatcher shook her head feebly and turned paler than ever.
+
+“He didn’t stay with us,” said Mrs. Harper, beginning to look uneasy. A
+marked anxiety came into Aunt Polly’s face.
+
+“Joe Harper, have you seen my Tom this morning?”
+
+“No’m.”
+
+“When did you see him last?”
+
+Joe tried to remember, but was not sure he could say. The people had
+stopped moving out of church. Whispers passed along, and a boding
+uneasiness took possession of every countenance. Children were anxiously
+questioned, and young teachers. They all said they had not noticed
+whether Tom and Becky were on board the ferryboat on the homeward trip;
+it was dark; no one thought of inquiring if any one was missing. One
+young man finally blurted out his fear that they were still in the cave!
+Mrs. Thatcher swooned away. Aunt Polly fell to crying and wringing her
+hands.
+
+The alarm swept from lip to lip, from group to group, from street to
+street, and within five minutes the bells were wildly clanging and
+the whole town was up! The Cardiff Hill episode sank into instant
+insignificance, the burglars were forgotten, horses were saddled, skiffs
+were manned, the ferryboat ordered out, and before the horror was half
+an hour old, two hundred men were pouring down highroad and river toward
+the cave.
+
+All the long afternoon the village seemed empty and dead. Many women
+visited Aunt Polly and Mrs. Thatcher and tried to comfort them. They
+cried with them, too, and that was still better than words. All the
+tedious night the town waited for news; but when the morning dawned at
+last, all the word that came was, “Send more candles--and send food.”
+ Mrs. Thatcher was almost crazed; and Aunt Polly, also. Judge Thatcher
+sent messages of hope and encouragement from the cave, but they conveyed
+no real cheer.
+
+The old Welshman came home toward daylight, spattered with
+candle-grease, smeared with clay, and almost worn out. He found Huck
+still in the bed that had been provided for him, and delirious with
+fever. The physicians were all at the cave, so the Widow Douglas came
+and took charge of the patient. She said she would do her best by him,
+because, whether he was good, bad, or indifferent, he was the Lord’s,
+and nothing that was the Lord’s was a thing to be neglected. The
+Welshman said Huck had good spots in him, and the widow said:
+
+“You can depend on it. That’s the Lord’s mark. He don’t leave it off.
+He never does. Puts it somewhere on every creature that comes from his
+hands.”
+
+Early in the forenoon parties of jaded men began to straggle into the
+village, but the strongest of the citizens continued searching. All the
+news that could be gained was that remotenesses of the cavern were being
+ransacked that had never been visited before; that every corner and
+crevice was going to be thoroughly searched; that wherever one wandered
+through the maze of passages, lights were to be seen flitting hither
+and thither in the distance, and shoutings and pistol-shots sent their
+hollow reverberations to the ear down the sombre aisles. In one place,
+far from the section usually traversed by tourists, the names “BECKY &
+TOM” had been found traced upon the rocky wall with candle-smoke, and
+near at hand a grease-soiled bit of ribbon. Mrs. Thatcher recognized the
+ribbon and cried over it. She said it was the last relic she should ever
+have of her child; and that no other memorial of her could ever be so
+precious, because this one parted latest from the living body before the
+awful death came. Some said that now and then, in the cave, a far-away
+speck of light would glimmer, and then a glorious shout would burst
+forth and a score of men go trooping down the echoing aisle--and then a
+sickening disappointment always followed; the children were not there;
+it was only a searcher’s light.
+
+Three dreadful days and nights dragged their tedious hours along, and
+the village sank into a hopeless stupor. No one had heart for anything.
+The accidental discovery, just made, that the proprietor of the
+Temperance Tavern kept liquor on his premises, scarcely fluttered the
+public pulse, tremendous as the fact was. In a lucid interval, Huck
+feebly led up to the subject of taverns, and finally asked--dimly
+dreading the worst--if anything had been discovered at the Temperance
+Tavern since he had been ill.
+
+“Yes,” said the widow.
+
+Huck started up in bed, wildeyed:
+
+“What? What was it?”
+
+“Liquor!--and the place has been shut up. Lie down, child--what a turn you
+did give me!”
+
+“Only tell me just one thing--only just one--please! Was it Tom Sawyer
+that found it?”
+
+The widow burst into tears. “Hush, hush, child, hush! I’ve told you
+before, you must _not_ talk. You are very, very sick!”
+
+Then nothing but liquor had been found; there would have been a great
+powwow if it had been the gold. So the treasure was gone forever--gone
+forever! But what could she be crying about? Curious that she should
+cry.
+
+These thoughts worked their dim way through Huck’s mind, and under the
+weariness they gave him he fell asleep. The widow said to herself:
+
+“There--he’s asleep, poor wreck. Tom Sawyer find it! Pity but somebody
+could find Tom Sawyer! Ah, there ain’t many left, now, that’s got hope
+enough, or strength enough, either, to go on searching.”
+
+
+
+
+CHAPTER XXXI
+
+NOW to return to Tom and Becky’s share in the picnic. They tripped along
+the murky aisles with the rest of the company, visiting the familiar
+wonders of the cave--wonders dubbed with rather over-descriptive names,
+such as “The Drawing-Room,” “The Cathedral,” “Aladdin’s Palace,” and
+so on. Presently the hide-and-seek frolicking began, and Tom and Becky
+engaged in it with zeal until the exertion began to grow a trifle
+wearisome; then they wandered down a sinuous avenue holding their
+candles aloft and reading the tangled webwork of names, dates,
+postoffice addresses, and mottoes with which the rocky walls had been
+frescoed (in candle-smoke). Still drifting along and talking, they
+scarcely noticed that they were now in a part of the cave whose walls
+were not frescoed. They smoked their own names under an overhanging
+shelf and moved on. Presently they came to a place where a little stream
+of water, trickling over a ledge and carrying a limestone sediment with
+it, had, in the slow-dragging ages, formed a laced and ruffled Niagara
+in gleaming and imperishable stone. Tom squeezed his small body behind
+it in order to illuminate it for Becky’s gratification. He found that
+it curtained a sort of steep natural stairway which was enclosed between
+narrow walls, and at once the ambition to be a discoverer seized him.
+
+Becky responded to his call, and they made a smoke-mark for future
+guidance, and started upon their quest. They wound this way and that,
+far down into the secret depths of the cave, made another mark, and
+branched off in search of novelties to tell the upper world about. In
+one place they found a spacious cavern, from whose ceiling depended a
+multitude of shining stalactites of the length and circumference of
+a man’s leg; they walked all about it, wondering and admiring, and
+presently left it by one of the numerous passages that opened into
+it. This shortly brought them to a bewitching spring, whose basin was
+incrusted with a frostwork of glittering crystals; it was in the midst
+of a cavern whose walls were supported by many fantastic pillars which
+had been formed by the joining of great stalactites and stalagmites
+together, the result of the ceaseless water-drip of centuries. Under the
+roof vast knots of bats had packed themselves together, thousands in a
+bunch; the lights disturbed the creatures and they came flocking down by
+hundreds, squeaking and darting furiously at the candles. Tom knew their
+ways and the danger of this sort of conduct. He seized Becky’s hand and
+hurried her into the first corridor that offered; and none too soon, for
+a bat struck Becky’s light out with its wing while she was passing out
+of the cavern. The bats chased the children a good distance; but the
+fugitives plunged into every new passage that offered, and at last got
+rid of the perilous things. Tom found a subterranean lake, shortly,
+which stretched its dim length away until its shape was lost in the
+shadows. He wanted to explore its borders, but concluded that it would
+be best to sit down and rest awhile, first. Now, for the first time, the
+deep stillness of the place laid a clammy hand upon the spirits of the
+children. Becky said:
+
+“Why, I didn’t notice, but it seems ever so long since I heard any of
+the others.”
+
+“Come to think, Becky, we are away down below them--and I don’t know how
+far away north, or south, or east, or whichever it is. We couldn’t hear
+them here.”
+
+Becky grew apprehensive.
+
+“I wonder how long we’ve been down here, Tom? We better start back.”
+
+“Yes, I reckon we better. P’raps we better.”
+
+“Can you find the way, Tom? It’s all a mixed-up crookedness to me.”
+
+“I reckon I could find it--but then the bats. If they put our candles
+out it will be an awful fix. Let’s try some other way, so as not to go
+through there.”
+
+“Well. But I hope we won’t get lost. It would be so awful!” and the girl
+shuddered at the thought of the dreadful possibilities.
+
+They started through a corridor, and traversed it in silence a long
+way, glancing at each new opening, to see if there was anything familiar
+about the look of it; but they were all strange. Every time Tom made an
+examination, Becky would watch his face for an encouraging sign, and he
+would say cheerily:
+
+“Oh, it’s all right. This ain’t the one, but we’ll come to it right
+away!”
+
+But he felt less and less hopeful with each failure, and presently began
+to turn off into diverging avenues at sheer random, in desperate hope of
+finding the one that was wanted. He still said it was “all right,” but
+there was such a leaden dread at his heart that the words had lost their
+ring and sounded just as if he had said, “All is lost!” Becky clung to
+his side in an anguish of fear, and tried hard to keep back the tears,
+but they would come. At last she said:
+
+“Oh, Tom, never mind the bats, let’s go back that way! We seem to get
+worse and worse off all the time.”
+
+“Listen!” said he.
+
+Profound silence; silence so deep that even their breathings were
+conspicuous in the hush. Tom shouted. The call went echoing down
+the empty aisles and died out in the distance in a faint sound that
+resembled a ripple of mocking laughter.
+
+“Oh, don’t do it again, Tom, it is too horrid,” said Becky.
+
+“It is horrid, but I better, Becky; they might hear us, you know,” and
+he shouted again.
+
+The “might” was even a chillier horror than the ghostly laughter, it so
+confessed a perishing hope. The children stood still and listened; but
+there was no result. Tom turned upon the back track at once, and hurried
+his steps. It was but a little while before a certain indecision in his
+manner revealed another fearful fact to Becky--he could not find his way
+back!
+
+“Oh, Tom, you didn’t make any marks!”
+
+“Becky, I was such a fool! Such a fool! I never thought we might want to
+come back! No--I can’t find the way. It’s all mixed up.”
+
+“Tom, Tom, we’re lost! we’re lost! We never can get out of this awful
+place! Oh, why _did_ we ever leave the others!”
+
+She sank to the ground and burst into such a frenzy of crying that Tom
+was appalled with the idea that she might die, or lose her reason. He
+sat down by her and put his arms around her; she buried her face in
+his bosom, she clung to him, she poured out her terrors, her unavailing
+regrets, and the far echoes turned them all to jeering laughter. Tom
+begged her to pluck up hope again, and she said she could not. He fell
+to blaming and abusing himself for getting her into this miserable
+situation; this had a better effect. She said she would try to hope
+again, she would get up and follow wherever he might lead if only he
+would not talk like that any more. For he was no more to blame than she,
+she said.
+
+So they moved on again--aimlessly--simply at random--all they could do
+was to move, keep moving. For a little while, hope made a show of
+reviving--not with any reason to back it, but only because it is its
+nature to revive when the spring has not been taken out of it by age and
+familiarity with failure.
+
+By-and-by Tom took Becky’s candle and blew it out. This economy meant so
+much! Words were not needed. Becky understood, and her hope died again.
+She knew that Tom had a whole candle and three or four pieces in his
+pockets--yet he must economize.
+
+By-and-by, fatigue began to assert its claims; the children tried to pay
+attention, for it was dreadful to think of sitting down when time was
+grown to be so precious, moving, in some direction, in any direction,
+was at least progress and might bear fruit; but to sit down was to
+invite death and shorten its pursuit.
+
+At last Becky’s frail limbs refused to carry her farther. She sat down.
+Tom rested with her, and they talked of home, and the friends there,
+and the comfortable beds and, above all, the light! Becky cried, and Tom
+tried to think of some way of comforting her, but all his encouragements
+were grown thread-bare with use, and sounded like sarcasms. Fatigue bore
+so heavily upon Becky that she drowsed off to sleep. Tom was grateful.
+He sat looking into her drawn face and saw it grow smooth and natural
+under the influence of pleasant dreams; and by-and-by a smile dawned and
+rested there. The peaceful face reflected somewhat of peace and healing
+into his own spirit, and his thoughts wandered away to bygone times and
+dreamy memories. While he was deep in his musings, Becky woke up with a
+breezy little laugh--but it was stricken dead upon her lips, and a groan
+followed it.
+
+“Oh, how _could_ I sleep! I wish I never, never had waked! No! No, I
+don’t, Tom! Don’t look so! I won’t say it again.”
+
+“I’m glad you’ve slept, Becky; you’ll feel rested, now, and we’ll find
+the way out.”
+
+“We can try, Tom; but I’ve seen such a beautiful country in my dream. I
+reckon we are going there.”
+
+“Maybe not, maybe not. Cheer up, Becky, and let’s go on trying.”
+
+They rose up and wandered along, hand in hand and hopeless. They tried
+to estimate how long they had been in the cave, but all they knew was
+that it seemed days and weeks, and yet it was plain that this could not
+be, for their candles were not gone yet. A long time after this--they
+could not tell how long--Tom said they must go softly and listen for
+dripping water--they must find a spring. They found one presently, and
+Tom said it was time to rest again. Both were cruelly tired, yet Becky
+said she thought she could go a little farther. She was surprised to
+hear Tom dissent. She could not understand it. They sat down, and Tom
+fastened his candle to the wall in front of them with some clay. Thought
+was soon busy; nothing was said for some time. Then Becky broke the
+silence:
+
+“Tom, I am so hungry!”
+
+Tom took something out of his pocket.
+
+“Do you remember this?” said he.
+
+Becky almost smiled.
+
+“It’s our wedding-cake, Tom.”
+
+“Yes--I wish it was as big as a barrel, for it’s all we’ve got.”
+
+“I saved it from the picnic for us to dream on, Tom, the way grownup
+people do with wedding-cake--but it’ll be our--”
+
+She dropped the sentence where it was. Tom divided the cake and Becky
+ate with good appetite, while Tom nibbled at his moiety. There was
+abundance of cold water to finish the feast with. By-and-by Becky
+suggested that they move on again. Tom was silent a moment. Then he
+said:
+
+“Becky, can you bear it if I tell you something?”
+
+Becky’s face paled, but she thought she could.
+
+“Well, then, Becky, we must stay here, where there’s water to drink.
+That little piece is our last candle!”
+
+Becky gave loose to tears and wailings. Tom did what he could to comfort
+her, but with little effect. At length Becky said:
+
+“Tom!”
+
+“Well, Becky?”
+
+“They’ll miss us and hunt for us!”
+
+“Yes, they will! Certainly they will!”
+
+“Maybe they’re hunting for us now, Tom.”
+
+“Why, I reckon maybe they are. I hope they are.”
+
+“When would they miss us, Tom?”
+
+“When they get back to the boat, I reckon.”
+
+“Tom, it might be dark then--would they notice we hadn’t come?”
+
+“I don’t know. But anyway, your mother would miss you as soon as they
+got home.”
+
+A frightened look in Becky’s face brought Tom to his senses and he saw
+that he had made a blunder. Becky was not to have gone home that night!
+The children became silent and thoughtful. In a moment a new burst of
+grief from Becky showed Tom that the thing in his mind had struck hers
+also--that the Sabbath morning might be half spent before Mrs. Thatcher
+discovered that Becky was not at Mrs. Harper’s.
+
+The children fastened their eyes upon their bit of candle and watched it
+melt slowly and pitilessly away; saw the half inch of wick stand alone
+at last; saw the feeble flame rise and fall, climb the thin column of
+smoke, linger at its top a moment, and then--the horror of utter darkness
+reigned!
+
+How long afterward it was that Becky came to a slow consciousness that
+she was crying in Tom’s arms, neither could tell. All that they knew
+was, that after what seemed a mighty stretch of time, both awoke out of
+a dead stupor of sleep and resumed their miseries once more. Tom said
+it might be Sunday, now--maybe Monday. He tried to get Becky to talk, but
+her sorrows were too oppressive, all her hopes were gone. Tom said that
+they must have been missed long ago, and no doubt the search was going
+on. He would shout and maybe some one would come. He tried it; but in
+the darkness the distant echoes sounded so hideously that he tried it no
+more.
+
+The hours wasted away, and hunger came to torment the captives again. A
+portion of Tom’s half of the cake was left; they divided and ate it. But
+they seemed hungrier than before. The poor morsel of food only whetted
+desire.
+
+By-and-by Tom said:
+
+“SH! Did you hear that?”
+
+Both held their breath and listened. There was a sound like the
+faintest, far-off shout. Instantly Tom answered it, and leading Becky by
+the hand, started groping down the corridor in its direction. Presently
+he listened again; again the sound was heard, and apparently a little
+nearer.
+
+“It’s them!” said Tom; “they’re coming! Come along, Becky--we’re all
+right now!”
+
+The joy of the prisoners was almost overwhelming. Their speed was slow,
+however, because pitfalls were somewhat common, and had to be guarded
+against. They shortly came to one and had to stop. It might be three
+feet deep, it might be a hundred--there was no passing it at any rate.
+Tom got down on his breast and reached as far down as he could. No
+bottom. They must stay there and wait until the searchers came. They
+listened; evidently the distant shoutings were growing more distant!
+a moment or two more and they had gone altogether. The heart-sinking
+misery of it! Tom whooped until he was hoarse, but it was of no use. He
+talked hopefully to Becky; but an age of anxious waiting passed and no
+sounds came again.
+
+The children groped their way back to the spring. The weary time dragged
+on; they slept again, and awoke famished and woe-stricken. Tom believed
+it must be Tuesday by this time.
+
+Now an idea struck him. There were some side passages near at hand. It
+would be better to explore some of these than bear the weight of the
+heavy time in idleness. He took a kite-line from his pocket, tied it to
+a projection, and he and Becky started, Tom in the lead, unwinding the
+line as he groped along. At the end of twenty steps the corridor ended
+in a “jumping-off place.” Tom got down on his knees and felt below,
+and then as far around the corner as he could reach with his hands
+conveniently; he made an effort to stretch yet a little farther to the
+right, and at that moment, not twenty yards away, a human hand, holding
+a candle, appeared from behind a rock! Tom lifted up a glorious shout,
+and instantly that hand was followed by the body it belonged to--Injun
+Joe’s! Tom was paralyzed; he could not move. He was vastly gratified the
+next moment, to see the “Spaniard” take to his heels and get himself out
+of sight. Tom wondered that Joe had not recognized his voice and come
+over and killed him for testifying in court. But the echoes must have
+disguised the voice. Without doubt, that was it, he reasoned. Tom’s
+fright weakened every muscle in his body. He said to himself that if he
+had strength enough to get back to the spring he would stay there, and
+nothing should tempt him to run the risk of meeting Injun Joe again. He
+was careful to keep from Becky what it was he had seen. He told her he
+had only shouted “for luck.”
+
+But hunger and wretchedness rise superior to fears in the long run.
+Another tedious wait at the spring and another long sleep brought
+changes. The children awoke tortured with a raging hunger. Tom believed
+that it must be Wednesday or Thursday or even Friday or Saturday, now,
+and that the search had been given over. He proposed to explore another
+passage. He felt willing to risk Injun Joe and all other terrors. But
+Becky was very weak. She had sunk into a dreary apathy and would not be
+roused. She said she would wait, now, where she was, and die--it would
+not be long. She told Tom to go with the kite-line and explore if he
+chose; but she implored him to come back every little while and speak
+to her; and she made him promise that when the awful time came, he would
+stay by her and hold her hand until all was over.
+
+Tom kissed her, with a choking sensation in his throat, and made a show
+of being confident of finding the searchers or an escape from the cave;
+then he took the kite-line in his hand and went groping down one of the
+passages on his hands and knees, distressed with hunger and sick with
+bodings of coming doom.
+
+
+
+
+CHAPTER XXXII
+
+TUESDAY afternoon came, and waned to the twilight. The village of St.
+Petersburg still mourned. The lost children had not been found. Public
+prayers had been offered up for them, and many and many a private prayer
+that had the petitioner’s whole heart in it; but still no good news came
+from the cave. The majority of the searchers had given up the quest
+and gone back to their daily avocations, saying that it was plain the
+children could never be found. Mrs. Thatcher was very ill, and a great
+part of the time delirious. People said it was heartbreaking to hear her
+call her child, and raise her head and listen a whole minute at a time,
+then lay it wearily down again with a moan. Aunt Polly had drooped into
+a settled melancholy, and her gray hair had grown almost white. The
+village went to its rest on Tuesday night, sad and forlorn.
+
+Away in the middle of the night a wild peal burst from the village
+bells, and in a moment the streets were swarming with frantic half-clad
+people, who shouted, “Turn out! turn out! they’re found! they’re found!”
+ Tin pans and horns were added to the din, the population massed itself
+and moved toward the river, met the children coming in an open carriage
+drawn by shouting citizens, thronged around it, joined its homeward
+march, and swept magnificently up the main street roaring huzzah after
+huzzah!
+
+The village was illuminated; nobody went to bed again; it was the
+greatest night the little town had ever seen. During the first half-hour
+a procession of villagers filed through Judge Thatcher’s house, seized
+the saved ones and kissed them, squeezed Mrs. Thatcher’s hand, tried to
+speak but couldn’t--and drifted out raining tears all over the place.
+
+Aunt Polly’s happiness was complete, and Mrs. Thatcher’s nearly so. It
+would be complete, however, as soon as the messenger dispatched with the
+great news to the cave should get the word to her husband. Tom lay upon
+a sofa with an eager auditory about him and told the history of the
+wonderful adventure, putting in many striking additions to adorn it
+withal; and closed with a description of how he left Becky and went
+on an exploring expedition; how he followed two avenues as far as his
+kite-line would reach; how he followed a third to the fullest stretch
+of the kite-line, and was about to turn back when he glimpsed a far-off
+speck that looked like daylight; dropped the line and groped toward it,
+pushed his head and shoulders through a small hole, and saw the broad
+Mississippi rolling by!
+
+And if it had only happened to be night he would not have seen that
+speck of daylight and would not have explored that passage any more! He
+told how he went back for Becky and broke the good news and she told
+him not to fret her with such stuff, for she was tired, and knew she was
+going to die, and wanted to. He described how he labored with her and
+convinced her; and how she almost died for joy when she had groped to
+where she actually saw the blue speck of daylight; how he pushed his way
+out at the hole and then helped her out; how they sat there and cried
+for gladness; how some men came along in a skiff and Tom hailed them
+and told them their situation and their famished condition; how the men
+didn’t believe the wild tale at first, “because,” said they, “you are
+five miles down the river below the valley the cave is in”--then took
+them aboard, rowed to a house, gave them supper, made them rest till two
+or three hours after dark and then brought them home.
+
+Before day-dawn, Judge Thatcher and the handful of searchers with him
+were tracked out, in the cave, by the twine clews they had strung behind
+them, and informed of the great news.
+
+Three days and nights of toil and hunger in the cave were not to
+be shaken off at once, as Tom and Becky soon discovered. They were
+bedridden all of Wednesday and Thursday, and seemed to grow more and
+more tired and worn, all the time. Tom got about, a little, on Thursday,
+was downtown Friday, and nearly as whole as ever Saturday; but Becky
+did not leave her room until Sunday, and then she looked as if she had
+passed through a wasting illness.
+
+Tom learned of Huck’s sickness and went to see him on Friday, but could
+not be admitted to the bedroom; neither could he on Saturday or Sunday.
+He was admitted daily after that, but was warned to keep still about his
+adventure and introduce no exciting topic. The Widow Douglas stayed by
+to see that he obeyed. At home Tom learned of the Cardiff Hill event;
+also that the “ragged man’s” body had eventually been found in the river
+near the ferry-landing; he had been drowned while trying to escape,
+perhaps.
+
+About a fortnight after Tom’s rescue from the cave, he started off to
+visit Huck, who had grown plenty strong enough, now, to hear exciting
+talk, and Tom had some that would interest him, he thought. Judge
+Thatcher’s house was on Tom’s way, and he stopped to see Becky. The
+Judge and some friends set Tom to talking, and some one asked him
+ironically if he wouldn’t like to go to the cave again. Tom said he
+thought he wouldn’t mind it. The Judge said:
+
+“Well, there are others just like you, Tom, I’ve not the least doubt.
+But we have taken care of that. Nobody will get lost in that cave any
+more.”
+
+“Why?”
+
+“Because I had its big door sheathed with boiler iron two weeks ago, and
+triple-locked--and I’ve got the keys.”
+
+Tom turned as white as a sheet.
+
+“What’s the matter, boy! Here, run, somebody! Fetch a glass of water!”
+
+The water was brought and thrown into Tom’s face.
+
+“Ah, now you’re all right. What was the matter with you, Tom?”
+
+“Oh, Judge, Injun Joe’s in the cave!”
+
+
+
+
+CHAPTER XXXIII
+
+WITHIN a few minutes the news had spread, and a dozen skiff-loads of
+men were on their way to McDougal’s cave, and the ferryboat, well filled
+with passengers, soon followed. Tom Sawyer was in the skiff that bore
+Judge Thatcher.
+
+When the cave door was unlocked, a sorrowful sight presented itself in
+the dim twilight of the place. Injun Joe lay stretched upon the ground,
+dead, with his face close to the crack of the door, as if his longing
+eyes had been fixed, to the latest moment, upon the light and the cheer
+of the free world outside. Tom was touched, for he knew by his own
+experience how this wretch had suffered. His pity was moved, but
+nevertheless he felt an abounding sense of relief and security, now,
+which revealed to him in a degree which he had not fully appreciated
+before how vast a weight of dread had been lying upon him since the day
+he lifted his voice against this bloody-minded outcast.
+
+Injun Joe’s bowie-knife lay close by, its blade broken in two. The great
+foundation-beam of the door had been chipped and hacked through, with
+tedious labor; useless labor, too, it was, for the native rock formed a
+sill outside it, and upon that stubborn material the knife had wrought
+no effect; the only damage done was to the knife itself. But if there
+had been no stony obstruction there the labor would have been useless
+still, for if the beam had been wholly cut away Injun Joe could not have
+squeezed his body under the door, and he knew it. So he had only hacked
+that place in order to be doing something--in order to pass the weary
+time--in order to employ his tortured faculties. Ordinarily one could
+find half a dozen bits of candle stuck around in the crevices of this
+vestibule, left there by tourists; but there were none now. The prisoner
+had searched them out and eaten them. He had also contrived to catch a
+few bats, and these, also, he had eaten, leaving only their claws. The
+poor unfortunate had starved to death. In one place, near at hand, a
+stalagmite had been slowly growing up from the ground for ages, builded
+by the water-drip from a stalactite overhead. The captive had broken off
+the stalagmite, and upon the stump had placed a stone, wherein he had
+scooped a shallow hollow to catch the precious drop that fell once
+in every three minutes with the dreary regularity of a clock-tick--a
+dessertspoonful once in four and twenty hours. That drop was falling
+when the Pyramids were new; when Troy fell; when the foundations of Rome
+were laid; when Christ was crucified; when the Conqueror created the
+British empire; when Columbus sailed; when the massacre at Lexington was
+“news.”
+
+It is falling now; it will still be falling when all these things shall
+have sunk down the afternoon of history, and the twilight of tradition,
+and been swallowed up in the thick night of oblivion. Has everything a
+purpose and a mission? Did this drop fall patiently during five thousand
+years to be ready for this flitting human insect’s need? and has it
+another important object to accomplish ten thousand years to come? No
+matter. It is many and many a year since the hapless half-breed scooped
+out the stone to catch the priceless drops, but to this day the tourist
+stares longest at that pathetic stone and that slow-dropping water when
+he comes to see the wonders of McDougal’s cave. Injun Joe’s cup stands
+first in the list of the cavern’s marvels; even “Aladdin’s Palace”
+ cannot rival it.
+
+Injun Joe was buried near the mouth of the cave; and people flocked
+there in boats and wagons from the towns and from all the farms and
+hamlets for seven miles around; they brought their children, and
+all sorts of provisions, and confessed that they had had almost as
+satisfactory a time at the funeral as they could have had at the
+hanging.
+
+This funeral stopped the further growth of one thing--the petition to the
+governor for Injun Joe’s pardon. The petition had been largely signed;
+many tearful and eloquent meetings had been held, and a committee of
+sappy women been appointed to go in deep mourning and wail around the
+governor, and implore him to be a merciful ass and trample his duty
+under foot. Injun Joe was believed to have killed five citizens of the
+village, but what of that? If he had been Satan himself there would
+have been plenty of weaklings ready to scribble their names to a
+pardon-petition, and drip a tear on it from their permanently impaired
+and leaky water-works.
+
+The morning after the funeral Tom took Huck to a private place to have
+an important talk. Huck had learned all about Tom’s adventure from the
+Welshman and the Widow Douglas, by this time, but Tom said he reckoned
+there was one thing they had not told him; that thing was what he wanted
+to talk about now. Huck’s face saddened. He said:
+
+“I know what it is. You got into No. 2 and never found anything but
+whiskey. Nobody told me it was you; but I just knowed it must ‘a’ ben
+you, soon as I heard ‘bout that whiskey business; and I knowed you
+hadn’t got the money becuz you’d ‘a’ got at me some way or other and
+told me even if you was mum to everybody else. Tom, something’s always
+told me we’d never get holt of that swag.”
+
+“Why, Huck, I never told on that tavern-keeper. _You_ know his tavern
+was all right the Saturday I went to the picnic. Don’t you remember you
+was to watch there that night?”
+
+“Oh yes! Why, it seems ‘bout a year ago. It was that very night that I
+follered Injun Joe to the widder’s.”
+
+“_You_ followed him?”
+
+“Yes--but you keep mum. I reckon Injun Joe’s left friends behind him, and
+I don’t want ‘em souring on me and doing me mean tricks. If it hadn’t
+ben for me he’d be down in Texas now, all right.”
+
+Then Huck told his entire adventure in confidence to Tom, who had only
+heard of the Welshman’s part of it before.
+
+“Well,” said Huck, presently, coming back to the main question, “whoever
+nipped the whiskey in No. 2, nipped the money, too, I reckon--anyways
+it’s a goner for us, Tom.”
+
+“Huck, that money wasn’t ever in No. 2!”
+
+“What!” Huck searched his comrade’s face keenly. “Tom, have you got on
+the track of that money again?”
+
+“Huck, it’s in the cave!”
+
+Huck’s eyes blazed.
+
+“Say it again, Tom.”
+
+“The money’s in the cave!”
+
+“Tom--honest injun, now--is it fun, or earnest?”
+
+“Earnest, Huck--just as earnest as ever I was in my life. Will you go in
+there with me and help get it out?”
+
+“I bet I will! I will if it’s where we can blaze our way to it and not
+get lost.”
+
+“Huck, we can do that without the least little bit of trouble in the
+world.”
+
+“Good as wheat! What makes you think the money’s--”
+
+“Huck, you just wait till we get in there. If we don’t find it I’ll
+agree to give you my drum and every thing I’ve got in the world. I will,
+by jings.”
+
+“All right--it’s a whiz. When do you say?”
+
+“Right now, if you say it. Are you strong enough?”
+
+“Is it far in the cave? I ben on my pins a little, three or four days,
+now, but I can’t walk more’n a mile, Tom--least I don’t think I could.”
+
+“It’s about five mile into there the way anybody but me would go, Huck,
+but there’s a mighty short cut that they don’t anybody but me know
+about. Huck, I’ll take you right to it in a skiff. I’ll float the skiff
+down there, and I’ll pull it back again all by myself. You needn’t ever
+turn your hand over.”
+
+“Less start right off, Tom.”
+
+“All right. We want some bread and meat, and our pipes, and a little
+bag or two, and two or three kite-strings, and some of these new-fangled
+things they call lucifer matches. I tell you, many’s the time I wished I
+had some when I was in there before.”
+
+A trifle after noon the boys borrowed a small skiff from a citizen who
+was absent, and got under way at once. When they were several miles
+below “Cave Hollow,” Tom said:
+
+“Now you see this bluff here looks all alike all the way down from the
+cave hollow--no houses, no wood-yards, bushes all alike. But do you see
+that white place up yonder where there’s been a landslide? Well, that’s
+one of my marks. We’ll get ashore, now.”
+
+They landed.
+
+“Now, Huck, where we’re a-standing you could touch that hole I got out
+of with a fishing-pole. See if you can find it.”
+
+Huck searched all the place about, and found nothing. Tom proudly
+marched into a thick clump of sumach bushes and said:
+
+“Here you are! Look at it, Huck; it’s the snuggest hole in this country.
+You just keep mum about it. All along I’ve been wanting to be a robber,
+but I knew I’d got to have a thing like this, and where to run across
+it was the bother. We’ve got it now, and we’ll keep it quiet, only we’ll
+let Joe Harper and Ben Rogers in--because of course there’s got to be a
+Gang, or else there wouldn’t be any style about it. Tom Sawyer’s Gang--it
+sounds splendid, don’t it, Huck?”
+
+“Well, it just does, Tom. And who’ll we rob?”
+
+“Oh, most anybody. Waylay people--that’s mostly the way.”
+
+“And kill them?”
+
+“No, not always. Hive them in the cave till they raise a ransom.”
+
+“What’s a ransom?”
+
+“Money. You make them raise all they can, off’n their friends; and after
+you’ve kept them a year, if it ain’t raised then you kill them. That’s
+the general way. Only you don’t kill the women. You shut up the women,
+but you don’t kill them. They’re always beautiful and rich, and awfully
+scared. You take their watches and things, but you always take your hat
+off and talk polite. They ain’t anybody as polite as robbers--you’ll see
+that in any book. Well, the women get to loving you, and after they’ve
+been in the cave a week or two weeks they stop crying and after that
+you couldn’t get them to leave. If you drove them out they’d turn right
+around and come back. It’s so in all the books.”
+
+“Why, it’s real bully, Tom. I believe it’s better’n to be a pirate.”
+
+“Yes, it’s better in some ways, because it’s close to home and circuses
+and all that.”
+
+By this time everything was ready and the boys entered the hole, Tom in
+the lead. They toiled their way to the farther end of the tunnel, then
+made their spliced kite-strings fast and moved on. A few steps brought
+them to the spring, and Tom felt a shudder quiver all through him.
+He showed Huck the fragment of candle-wick perched on a lump of clay
+against the wall, and described how he and Becky had watched the flame
+struggle and expire.
+
+The boys began to quiet down to whispers, now, for the stillness and
+gloom of the place oppressed their spirits. They went on, and presently
+entered and followed Tom’s other corridor until they reached the
+“jumping-off place.” The candles revealed the fact that it was not
+really a precipice, but only a steep clay hill twenty or thirty feet
+high. Tom whispered:
+
+“Now I’ll show you something, Huck.”
+
+He held his candle aloft and said:
+
+“Look as far around the corner as you can. Do you see that? There--on the
+big rock over yonder--done with candle-smoke.”
+
+“Tom, it’s a _cross_!”
+
+“_Now_ where’s your Number Two? ‘_under the cross_,’ hey? Right yonder’s
+where I saw Injun Joe poke up his candle, Huck!”
+
+Huck stared at the mystic sign awhile, and then said with a shaky voice:
+
+“Tom, less git out of here!”
+
+“What! and leave the treasure?”
+
+“Yes--leave it. Injun Joe’s ghost is round about there, certain.”
+
+“No it ain’t, Huck, no it ain’t. It would ha’nt the place where he
+died--away out at the mouth of the cave--five mile from here.”
+
+“No, Tom, it wouldn’t. It would hang round the money. I know the ways of
+ghosts, and so do you.”
+
+Tom began to fear that Huck was right. Mis-givings gathered in his mind.
+But presently an idea occurred to him--
+
+“Lookyhere, Huck, what fools we’re making of ourselves! Injun Joe’s
+ghost ain’t a going to come around where there’s a cross!”
+
+The point was well taken. It had its effect.
+
+“Tom, I didn’t think of that. But that’s so. It’s luck for us, that
+cross is. I reckon we’ll climb down there and have a hunt for that box.”
+
+Tom went first, cutting rude steps in the clay hill as he descended.
+Huck followed. Four avenues opened out of the small cavern which the
+great rock stood in. The boys examined three of them with no result.
+They found a small recess in the one nearest the base of the rock, with
+a pallet of blankets spread down in it; also an old suspender, some
+bacon rind, and the well-gnawed bones of two or three fowls. But there
+was no moneybox. The lads searched and researched this place, but in
+vain. Tom said:
+
+“He said _under_ the cross. Well, this comes nearest to being under the
+cross. It can’t be under the rock itself, because that sets solid on the
+ground.”
+
+They searched everywhere once more, and then sat down discouraged. Huck
+could suggest nothing. By-and-by Tom said:
+
+“Lookyhere, Huck, there’s footprints and some candle-grease on the clay
+about one side of this rock, but not on the other sides. Now, what’s
+that for? I bet you the money _is_ under the rock. I’m going to dig in
+the clay.”
+
+“That ain’t no bad notion, Tom!” said Huck with animation.
+
+Tom’s “real Barlow” was out at once, and he had not dug four inches
+before he struck wood.
+
+“Hey, Huck!--you hear that?”
+
+Huck began to dig and scratch now. Some boards were soon uncovered and
+removed. They had concealed a natural chasm which led under the rock.
+Tom got into this and held his candle as far under the rock as he
+could, but said he could not see to the end of the rift. He proposed
+to explore. He stooped and passed under; the narrow way descended
+gradually. He followed its winding course, first to the right, then to
+the left, Huck at his heels. Tom turned a short curve, by-and-by, and
+exclaimed:
+
+“My goodness, Huck, lookyhere!”
+
+It was the treasure-box, sure enough, occupying a snug little cavern,
+along with an empty powder-keg, a couple of guns in leather cases, two
+or three pairs of old moccasins, a leather belt, and some other rubbish
+well soaked with the water-drip.
+
+“Got it at last!” said Huck, ploughing among the tarnished coins with
+his hand. “My, but we’re rich, Tom!”
+
+“Huck, I always reckoned we’d get it. It’s just too good to believe, but
+we _have_ got it, sure! Say--let’s not fool around here. Let’s snake it
+out. Lemme see if I can lift the box.”
+
+It weighed about fifty pounds. Tom could lift it, after an awkward
+fashion, but could not carry it conveniently.
+
+“I thought so,” he said; “_They_ carried it like it was heavy, that day
+at the ha’nted house. I noticed that. I reckon I was right to think of
+fetching the little bags along.”
+
+The money was soon in the bags and the boys took it up to the cross
+rock.
+
+“Now less fetch the guns and things,” said Huck.
+
+“No, Huck--leave them there. They’re just the tricks to have when we
+go to robbing. We’ll keep them there all the time, and we’ll hold our
+orgies there, too. It’s an awful snug place for orgies.”
+
+“What orgies?”
+
+“I dono. But robbers always have orgies, and of course we’ve got to
+have them, too. Come along, Huck, we’ve been in here a long time. It’s
+getting late, I reckon. I’m hungry, too. We’ll eat and smoke when we get
+to the skiff.”
+
+They presently emerged into the clump of sumach bushes, looked warily
+out, found the coast clear, and were soon lunching and smoking in the
+skiff. As the sun dipped toward the horizon they pushed out and got
+under way. Tom skimmed up the shore through the long twilight, chatting
+cheerily with Huck, and landed shortly after dark.
+
+“Now, Huck,” said Tom, “we’ll hide the money in the loft of the widow’s
+woodshed, and I’ll come up in the morning and we’ll count it and divide,
+and then we’ll hunt up a place out in the woods for it where it will be
+safe. Just you lay quiet here and watch the stuff till I run and hook
+Benny Taylor’s little wagon; I won’t be gone a minute.”
+
+He disappeared, and presently returned with the wagon, put the two small
+sacks into it, threw some old rags on top of them, and started off,
+dragging his cargo behind him. When the boys reached the Welshman’s
+house, they stopped to rest. Just as they were about to move on, the
+Welshman stepped out and said:
+
+“Hallo, who’s that?”
+
+“Huck and Tom Sawyer.”
+
+“Good! Come along with me, boys, you are keeping everybody waiting.
+Here--hurry up, trot ahead--I’ll haul the wagon for you. Why, it’s not as
+light as it might be. Got bricks in it?--or old metal?”
+
+“Old metal,” said Tom.
+
+“I judged so; the boys in this town will take more trouble and fool away
+more time hunting up six bits’ worth of old iron to sell to the foundry
+than they would to make twice the money at regular work. But that’s
+human nature--hurry along, hurry along!”
+
+The boys wanted to know what the hurry was about.
+
+“Never mind; you’ll see, when we get to the Widow Douglas’.”
+
+Huck said with some apprehension--for he was long used to being falsely
+accused:
+
+“Mr. Jones, we haven’t been doing nothing.”
+
+The Welshman laughed.
+
+“Well, I don’t know, Huck, my boy. I don’t know about that. Ain’t you
+and the widow good friends?”
+
+“Yes. Well, she’s ben good friends to me, anyway.”
+
+“All right, then. What do you want to be afraid for?”
+
+This question was not entirely answered in Huck’s slow mind before he
+found himself pushed, along with Tom, into Mrs. Douglas’ drawing-room.
+Mr. Jones left the wagon near the door and followed.
+
+The place was grandly lighted, and everybody that was of any consequence
+in the village was there. The Thatchers were there, the Harpers, the
+Rogerses, Aunt Polly, Sid, Mary, the minister, the editor, and a great
+many more, and all dressed in their best. The widow received the boys
+as heartily as any one could well receive two such looking beings. They
+were covered with clay and candle-grease. Aunt Polly blushed crimson
+with humiliation, and frowned and shook her head at Tom. Nobody suffered
+half as much as the two boys did, however. Mr. Jones said:
+
+“Tom wasn’t at home, yet, so I gave him up; but I stumbled on him and
+Huck right at my door, and so I just brought them along in a hurry.”
+
+“And you did just right,” said the widow. “Come with me, boys.”
+
+She took them to a bedchamber and said:
+
+“Now wash and dress yourselves. Here are two new suits of
+clothes--shirts, socks, everything complete. They’re Huck’s--no, no
+thanks, Huck--Mr. Jones bought one and I the other. But they’ll fit both
+of you. Get into them. We’ll wait--come down when you are slicked up
+enough.”
+
+Then she left.
+
+
+
+
+CHAPTER XXXIV
+
+HUCK said: “Tom, we can slope, if we can find a rope. The window ain’t
+high from the ground.”
+
+“Shucks! what do you want to slope for?”
+
+“Well, I ain’t used to that kind of a crowd. I can’t stand it. I ain’t
+going down there, Tom.”
+
+“Oh, bother! It ain’t anything. I don’t mind it a bit. I’ll take care of
+you.”
+
+Sid appeared.
+
+“Tom,” said he, “auntie has been waiting for you all the afternoon. Mary
+got your Sunday clothes ready, and everybody’s been fretting about you.
+Say--ain’t this grease and clay, on your clothes?”
+
+“Now, Mr. Siddy, you jist ‘tend to your own business. What’s all this
+blowout about, anyway?”
+
+“It’s one of the widow’s parties that she’s always having. This time
+it’s for the Welshman and his sons, on account of that scrape they
+helped her out of the other night. And say--I can tell you something, if
+you want to know.”
+
+“Well, what?”
+
+“Why, old Mr. Jones is going to try to spring something on the people
+here tonight, but I overheard him tell auntie today about it, as a
+secret, but I reckon it’s not much of a secret now. Everybody knows--the
+widow, too, for all she tries to let on she don’t. Mr. Jones was bound
+Huck should be here--couldn’t get along with his grand secret without
+Huck, you know!”
+
+“Secret about what, Sid?”
+
+“About Huck tracking the robbers to the widow’s. I reckon Mr. Jones was
+going to make a grand time over his surprise, but I bet you it will drop
+pretty flat.”
+
+Sid chuckled in a very contented and satisfied way.
+
+“Sid, was it you that told?”
+
+“Oh, never mind who it was. _Somebody_ told--that’s enough.”
+
+“Sid, there’s only one person in this town mean enough to do that, and
+that’s you. If you had been in Huck’s place you’d ‘a’ sneaked down the
+hill and never told anybody on the robbers. You can’t do any but mean
+things, and you can’t bear to see anybody praised for doing good ones.
+There--no thanks, as the widow says”--and Tom cuffed Sid’s ears and helped
+him to the door with several kicks. “Now go and tell auntie if you
+dare--and tomorrow you’ll catch it!”
+
+Some minutes later the widow’s guests were at the supper-table, and a
+dozen children were propped up at little side-tables in the same room,
+after the fashion of that country and that day. At the proper time Mr.
+Jones made his little speech, in which he thanked the widow for the
+honor she was doing himself and his sons, but said that there was
+another person whose modesty--
+
+And so forth and so on. He sprung his secret about Huck’s share in
+the adventure in the finest dramatic manner he was master of, but the
+surprise it occasioned was largely counterfeit and not as clamorous and
+effusive as it might have been under happier circumstances. However,
+the widow made a pretty fair show of astonishment, and heaped so many
+compliments and so much gratitude upon Huck that he almost forgot
+the nearly intolerable discomfort of his new clothes in the entirely
+intolerable discomfort of being set up as a target for everybody’s gaze
+and everybody’s laudations.
+
+The widow said she meant to give Huck a home under her roof and have him
+educated; and that when she could spare the money she would start him in
+business in a modest way. Tom’s chance was come. He said:
+
+“Huck don’t need it. Huck’s rich.”
+
+Nothing but a heavy strain upon the good manners of the company kept
+back the due and proper complimentary laugh at this pleasant joke. But
+the silence was a little awkward. Tom broke it:
+
+“Huck’s got money. Maybe you don’t believe it, but he’s got lots of it.
+Oh, you needn’t smile--I reckon I can show you. You just wait a minute.”
+
+Tom ran out of doors. The company looked at each other with a perplexed
+interest--and inquiringly at Huck, who was tongue-tied.
+
+“Sid, what ails Tom?” said Aunt Polly. “He--well, there ain’t ever any
+making of that boy out. I never--”
+
+Tom entered, struggling with the weight of his sacks, and Aunt Polly
+did not finish her sentence. Tom poured the mass of yellow coin upon the
+table and said:
+
+“There--what did I tell you? Half of it’s Huck’s and half of it’s mine!”
+
+The spectacle took the general breath away. All gazed, nobody spoke for
+a moment. Then there was a unanimous call for an explanation. Tom said
+he could furnish it, and he did. The tale was long, but brimful of
+interest. There was scarcely an interruption from any one to break the
+charm of its flow. When he had finished, Mr. Jones said:
+
+“I thought I had fixed up a little surprise for this occasion, but it
+don’t amount to anything now. This one makes it sing mighty small, I’m
+willing to allow.”
+
+The money was counted. The sum amounted to a little over twelve thousand
+dollars. It was more than any one present had ever seen at one time
+before, though several persons were there who were worth considerably
+more than that in property.
+
+
+
+
+CHAPTER XXXV
+
+THE reader may rest satisfied that Tom’s and Huck’s windfall made a
+mighty stir in the poor little village of St. Petersburg. So vast a
+sum, all in actual cash, seemed next to incredible. It was talked
+about, gloated over, glorified, until the reason of many of the citizens
+tottered under the strain of the unhealthy excitement. Every “haunted”
+ house in St. Petersburg and the neighboring villages was dissected,
+plank by plank, and its foundations dug up and ransacked for hidden
+treasure--and not by boys, but men--pretty grave, unromantic men, too,
+some of them. Wherever Tom and Huck appeared they were courted, admired,
+stared at. The boys were not able to remember that their remarks had
+possessed weight before; but now their sayings were treasured and
+repeated; everything they did seemed somehow to be regarded as
+remarkable; they had evidently lost the power of doing and saying
+commonplace things; moreover, their past history was raked up and
+discovered to bear marks of conspicuous originality. The village paper
+published biographical sketches of the boys.
+
+The Widow Douglas put Huck’s money out at six per cent., and Judge
+Thatcher did the same with Tom’s at Aunt Polly’s request. Each lad had
+an income, now, that was simply prodigious--a dollar for every weekday in
+the year and half of the Sundays. It was just what the minister got--no,
+it was what he was promised--he generally couldn’t collect it. A dollar
+and a quarter a week would board, lodge, and school a boy in those old
+simple days--and clothe him and wash him, too, for that matter.
+
+Judge Thatcher had conceived a great opinion of Tom. He said that no
+commonplace boy would ever have got his daughter out of the cave. When
+Becky told her father, in strict confidence, how Tom had taken her
+whipping at school, the Judge was visibly moved; and when she pleaded
+grace for the mighty lie which Tom had told in order to shift that
+whipping from her shoulders to his own, the Judge said with a fine
+outburst that it was a noble, a generous, a magnanimous lie--a lie that
+was worthy to hold up its head and march down through history breast to
+breast with George Washington’s lauded Truth about the hatchet! Becky
+thought her father had never looked so tall and so superb as when he
+walked the floor and stamped his foot and said that. She went straight
+off and told Tom about it.
+
+Judge Thatcher hoped to see Tom a great lawyer or a great soldier some
+day. He said he meant to look to it that Tom should be admitted to the
+National Military Academy and afterward trained in the best law school
+in the country, in order that he might be ready for either career or
+both.
+
+Huck Finn’s wealth and the fact that he was now under the Widow Douglas’
+protection introduced him into society--no, dragged him into it, hurled
+him into it--and his sufferings were almost more than he could bear. The
+widow’s servants kept him clean and neat, combed and brushed, and they
+bedded him nightly in unsympathetic sheets that had not one little spot
+or stain which he could press to his heart and know for a friend. He had
+to eat with a knife and fork; he had to use napkin, cup, and plate;
+he had to learn his book, he had to go to church; he had to talk so
+properly that speech was become insipid in his mouth; whithersoever he
+turned, the bars and shackles of civilization shut him in and bound him
+hand and foot.
+
+He bravely bore his miseries three weeks, and then one day turned up
+missing. For forty-eight hours the widow hunted for him everywhere in
+great distress. The public were profoundly concerned; they searched high
+and low, they dragged the river for his body. Early the third morning
+Tom Sawyer wisely went poking among some old empty hogsheads down behind
+the abandoned slaughter-house, and in one of them he found the refugee.
+Huck had slept there; he had just breakfasted upon some stolen odds and
+ends of food, and was lying off, now, in comfort, with his pipe. He was
+unkempt, uncombed, and clad in the same old ruin of rags that had made
+him picturesque in the days when he was free and happy. Tom routed him
+out, told him the trouble he had been causing, and urged him to go home.
+Huck’s face lost its tranquil content, and took a melancholy cast. He
+said:
+
+“Don’t talk about it, Tom. I’ve tried it, and it don’t work; it don’t
+work, Tom. It ain’t for me; I ain’t used to it. The widder’s good to me,
+and friendly; but I can’t stand them ways. She makes me get up just
+at the same time every morning; she makes me wash, they comb me all
+to thunder; she won’t let me sleep in the woodshed; I got to wear them
+blamed clothes that just smothers me, Tom; they don’t seem to any air
+git through ‘em, somehow; and they’re so rotten nice that I can’t
+set down, nor lay down, nor roll around anywher’s; I hain’t slid on a
+cellar-door for--well, it ‘pears to be years; I got to go to church
+and sweat and sweat--I hate them ornery sermons! I can’t ketch a fly in
+there, I can’t chaw. I got to wear shoes all Sunday. The widder eats by
+a bell; she goes to bed by a bell; she gits up by a bell--everything’s so
+awful reg’lar a body can’t stand it.”
+
+“Well, everybody does that way, Huck.”
+
+“Tom, it don’t make no difference. I ain’t everybody, and I can’t
+_stand_ it. It’s awful to be tied up so. And grub comes too easy--I don’t
+take no interest in vittles, that way. I got to ask to go a-fishing;
+I got to ask to go in a-swimming--dern’d if I hain’t got to ask to do
+everything. Well, I’d got to talk so nice it wasn’t no comfort--I’d got
+to go up in the attic and rip out awhile, every day, to git a taste
+in my mouth, or I’d a died, Tom. The widder wouldn’t let me smoke;
+she wouldn’t let me yell, she wouldn’t let me gape, nor stretch, nor
+scratch, before folks--” [Then with a spasm of special irritation and
+injury]--“And dad fetch it, she prayed all the time! I never see such a
+woman! I _had_ to shove, Tom--I just had to. And besides, that school’s
+going to open, and I’d a had to go to it--well, I wouldn’t stand _that_,
+Tom. Looky-here, Tom, being rich ain’t what it’s cracked up to be. It’s
+just worry and worry, and sweat and sweat, and a-wishing you was dead
+all the time. Now these clothes suits me, and this bar’l suits me, and
+I ain’t ever going to shake ‘em any more. Tom, I wouldn’t ever got into
+all this trouble if it hadn’t ‘a’ ben for that money; now you just take
+my sheer of it along with your’n, and gimme a ten-center sometimes--not
+many times, becuz I don’t give a dern for a thing ‘thout it’s tollable
+hard to git--and you go and beg off for me with the widder.”
+
+“Oh, Huck, you know I can’t do that. ‘Tain’t fair; and besides if you’ll
+try this thing just a while longer you’ll come to like it.”
+
+“Like it! Yes--the way I’d like a hot stove if I was to set on it long
+enough. No, Tom, I won’t be rich, and I won’t live in them cussed
+smothery houses. I like the woods, and the river, and hogsheads, and
+I’ll stick to ‘em, too. Blame it all! just as we’d got guns, and a cave,
+and all just fixed to rob, here this dern foolishness has got to come up
+and spile it all!”
+
+Tom saw his opportunity--
+
+“Lookyhere, Huck, being rich ain’t going to keep me back from turning
+robber.”
+
+“No! Oh, good-licks; are you in real dead-wood earnest, Tom?”
+
+“Just as dead earnest as I’m sitting here. But Huck, we can’t let you
+into the gang if you ain’t respectable, you know.”
+
+Huck’s joy was quenched.
+
+“Can’t let me in, Tom? Didn’t you let me go for a pirate?”
+
+“Yes, but that’s different. A robber is more high-toned than what a
+pirate is--as a general thing. In most countries they’re awful high up in
+the nobility--dukes and such.”
+
+“Now, Tom, hain’t you always ben friendly to me? You wouldn’t shet me
+out, would you, Tom? You wouldn’t do that, now, _would_ you, Tom?”
+
+“Huck, I wouldn’t want to, and I _don’t_ want to--but what would people
+say? Why, they’d say, ‘Mph! Tom Sawyer’s Gang! pretty low characters in
+it!’ They’d mean you, Huck. You wouldn’t like that, and I wouldn’t.”
+
+Huck was silent for some time, engaged in a mental struggle. Finally he
+said:
+
+“Well, I’ll go back to the widder for a month and tackle it and see if I
+can come to stand it, if you’ll let me b’long to the gang, Tom.”
+
+“All right, Huck, it’s a whiz! Come along, old chap, and I’ll ask the
+widow to let up on you a little, Huck.”
+
+“Will you, Tom--now will you? That’s good. If she’ll let up on some of
+the roughest things, I’ll smoke private and cuss private, and crowd
+through or bust. When you going to start the gang and turn robbers?”
+
+“Oh, right off. We’ll get the boys together and have the initiation
+tonight, maybe.”
+
+“Have the which?”
+
+“Have the initiation.”
+
+“What’s that?”
+
+“It’s to swear to stand by one another, and never tell the gang’s
+secrets, even if you’re chopped all to flinders, and kill anybody and
+all his family that hurts one of the gang.”
+
+“That’s gay--that’s mighty gay, Tom, I tell you.”
+
+“Well, I bet it is. And all that swearing’s got to be done at midnight,
+in the lonesomest, awfulest place you can find--a ha’nted house is the
+best, but they’re all ripped up now.”
+
+“Well, midnight’s good, anyway, Tom.”
+
+“Yes, so it is. And you’ve got to swear on a coffin, and sign it with
+blood.”
+
+“Now, that’s something _like_! Why, it’s a million times bullier than
+pirating. I’ll stick to the widder till I rot, Tom; and if I git to be
+a reg’lar ripper of a robber, and everybody talking ‘bout it, I reckon
+she’ll be proud she snaked me in out of the wet.”
+
+CONCLUSION
+
+SO endeth this chronicle. It being strictly a history of a _boy_, it
+must stop here; the story could not go much further without becoming the
+history of a _man_. When one writes a novel about grown people, he knows
+exactly where to stop--that is, with a marriage; but when he writes of
+juveniles, he must stop where he best can.
+
+Most of the characters that perform in this book still live, and are
+prosperous and happy. Some day it may seem worth while to take up the
+story of the younger ones again and see what sort of men and women they
+turned out to be; therefore it will be wisest not to reveal any of that
+part of their lives at present.
+
+End of the Project Gutenberg Ebook of Adventures of Tom Sawyer,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+***** This file should be named 74-0.txt or 74-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/74/
+
+Produced by David Widger. The previous edition was updated by Jose
+Menendez.
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES- Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND- If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY- You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/hadoop/src/main/resources/books/war-of-the-worlds.txt
+++ b/jet/hadoop/src/main/resources/books/war-of-the-worlds.txt
@@ -1,0 +1,6869 @@
+﻿The Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The War of the Worlds
+
+Author: H. G. Wells
+
+Release Date: July, 1992 [EBook #36]
+[Most recently updated October 1, 2004]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+
+
+
+
+
+
+
+
+
+
+The War of the Worlds
+
+by H. G. Wells [1898]
+
+
+     But who shall dwell in these worlds if they be
+     inhabited? .  .  .  Are we or they Lords of the
+     World? .  .  .  And how are all things made for man?--
+          KEPLER (quoted in The Anatomy of Melancholy)
+
+
+
+BOOK ONE
+
+THE COMING OF THE MARTIANS
+
+
+
+CHAPTER ONE
+
+THE EVE OF THE WAR
+
+
+No one would have believed in the last years of the nineteenth
+century that this world was being watched keenly and closely by
+intelligences greater than man's and yet as mortal as his own; that as
+men busied themselves about their various concerns they were
+scrutinised and studied, perhaps almost as narrowly as a man with a
+microscope might scrutinise the transient creatures that swarm and
+multiply in a drop of water.  With infinite complacency men went to
+and fro over this globe about their little affairs, serene in their
+assurance of their empire over matter.  It is possible that the
+infusoria under the microscope do the same.  No one gave a thought to
+the older worlds of space as sources of human danger, or thought of
+them only to dismiss the idea of life upon them as impossible or
+improbable.  It is curious to recall some of the mental habits of
+those departed days.  At most terrestrial men fancied there might be
+other men upon Mars, perhaps inferior to themselves and ready to
+welcome a missionary enterprise.  Yet across the gulf of space, minds
+that are to our minds as ours are to those of the beasts that perish,
+intellects vast and cool and unsympathetic, regarded this earth with
+envious eyes, and slowly and surely drew their plans against us.  And
+early in the twentieth century came the great disillusionment.
+
+The planet Mars, I scarcely need remind the reader, revolves about the
+sun at a mean distance of 140,000,000 miles, and the light and heat it
+receives from the sun is barely half of that received by this world.
+It must be, if the nebular hypothesis has any truth, older than our
+world; and long before this earth ceased to be molten, life upon its
+surface must have begun its course.  The fact that it is scarcely one
+seventh of the volume of the earth must have accelerated its cooling
+to the temperature at which life could begin.  It has air and water
+and all that is necessary for the support of animated existence.
+
+Yet so vain is man, and so blinded by his vanity, that no writer,
+up to the very end of the nineteenth century, expressed any idea that
+intelligent life might have developed there far, or indeed at all,
+beyond its earthly level.  Nor was it generally understood that since
+Mars is older than our earth, with scarcely a quarter of the
+superficial area and remoter from the sun, it necessarily follows that
+it is not only more distant from time's beginning but nearer its end.
+
+The secular cooling that must someday overtake our planet has
+already gone far indeed with our neighbour.  Its physical condition is
+still largely a mystery, but we know now that even in its equatorial
+region the midday temperature barely approaches that of our coldest
+winter.  Its air is much more attenuated than ours, its oceans have
+shrunk until they cover but a third of its surface, and as its slow
+seasons change huge snowcaps gather and melt about either pole and
+periodically inundate its temperate zones.  That last stage of
+exhaustion, which to us is still incredibly remote, has become a
+present-day problem for the inhabitants of Mars.  The immediate
+pressure of necessity has brightened their intellects, enlarged their
+powers, and hardened their hearts.  And looking across space with
+instruments, and intelligences such as we have scarcely dreamed of,
+they see, at its nearest distance only 35,000,000 of miles sunward of
+them, a morning star of hope, our own warmer planet, green with
+vegetation and grey with water, with a cloudy atmosphere eloquent of
+fertility, with glimpses through its drifting cloud wisps of broad
+stretches of populous country and narrow, navy-crowded seas.
+
+And we men, the creatures who inhabit this earth, must be to them
+at least as alien and lowly as are the monkeys and lemurs to us.  The
+intellectual side of man already admits that life is an incessant
+struggle for existence, and it would seem that this too is the belief
+of the minds upon Mars.  Their world is far gone in its cooling and
+this world is still crowded with life, but crowded only with what they
+regard as inferior animals.  To carry warfare sunward is, indeed,
+their only escape from the destruction that, generation after
+generation, creeps upon them.
+
+And before we judge of them too harshly we must remember what
+ruthless and utter destruction our own species has wrought, not only
+upon animals, such as the vanished bison and the dodo, but upon its
+inferior races.  The Tasmanians, in spite of their human likeness,
+were entirely swept out of existence in a war of extermination waged
+by European immigrants, in the space of fifty years.  Are we such
+apostles of mercy as to complain if the Martians warred in the same
+spirit?
+
+The Martians seem to have calculated their descent with amazing
+subtlety--their mathematical learning is evidently far in excess of
+ours--and to have carried out their preparations with a well-nigh
+perfect unanimity.  Had our instruments permitted it, we might have
+seen the gathering trouble far back in the nineteenth century.  Men
+like Schiaparelli watched the red planet--it is odd, by-the-bye, that
+for countless centuries Mars has been the star of war--but failed to
+interpret the fluctuating appearances of the markings they mapped so
+well.  All that time the Martians must have been getting ready.
+
+During the opposition of 1894 a great light was seen on the
+illuminated part of the disk, first at the Lick Observatory, then by
+Perrotin of Nice, and then by other observers.  English readers heard
+of it first in the issue of _Nature_ dated August 2.  I am inclined to
+think that this blaze may have been the casting of the huge gun, in
+the vast pit sunk into their planet, from which their shots were fired
+at us.  Peculiar markings, as yet unexplained, were seen near the site
+of that outbreak during the next two oppositions.
+
+The storm burst upon us six years ago now.  As Mars approached
+opposition, Lavelle of Java set the wires of the astronomical exchange
+palpitating with the amazing intelligence of a huge outbreak of
+incandescent gas upon the planet.  It had occurred towards midnight of
+the twelfth; and the spectroscope, to which he had at once resorted,
+indicated a mass of flaming gas, chiefly hydrogen, moving with an
+enormous velocity towards this earth.  This jet of fire had become
+invisible about a quarter past twelve.  He compared it to a colossal
+puff of flame suddenly and violently squirted out of the planet, "as
+flaming gases rushed out of a gun."
+
+A singularly appropriate phrase it proved.  Yet the next day there
+was nothing of this in the papers except a little note in the _Daily
+Telegraph_, and the world went in ignorance of one of the gravest
+dangers that ever threatened the human race. I might not have heard of
+the eruption at all had I not met Ogilvy, the well-known astronomer,
+at Ottershaw.  He was immensely excited at the news, and in the excess
+of his feelings invited me up to take a turn with him that night in a
+scrutiny of the red planet.
+
+In spite of all that has happened since, I still remember that
+vigil very distinctly: the black and silent observatory, the shadowed
+lantern throwing a feeble glow upon the floor in the corner, the
+steady ticking of the clockwork of the telescope, the little slit in
+the roof--an oblong profundity with the stardust streaked across it.
+Ogilvy moved about, invisible but audible.  Looking through the
+telescope, one saw a circle of deep blue and the little round planet
+swimming in the field.  It seemed such a little thing, so bright and
+small and still, faintly marked with transverse stripes, and slightly
+flattened from the perfect round.  But so little it was, so silvery
+warm--a pin's-head of light! It was as if it quivered, but really this
+was the telescope vibrating with the activity of the clockwork that
+kept the planet in view.
+
+As I watched, the planet seemed to grow larger and smaller and to
+advance and recede, but that was simply that my eye was tired.  Forty
+millions of miles it was from us--more than forty millions of miles of
+void.  Few people realise the immensity of vacancy in which the dust
+of the material universe swims.
+
+Near it in the field, I remember, were three faint points of light,
+three telescopic stars infinitely remote, and all around it was the
+unfathomable darkness of empty space.  You know how that blackness
+looks on a frosty starlight night.  In a telescope it seems far
+profounder.  And invisible to me because it was so remote and small,
+flying swiftly and steadily towards me across that incredible
+distance, drawing nearer every minute by so many thousands of miles,
+came the Thing they were sending us, the Thing that was to bring so
+much struggle and calamity and death to the earth.  I never dreamed of
+it then as I watched; no one on earth dreamed of that unerring
+missile.
+
+That night, too, there was another jetting out of gas from the
+distant planet.  I saw it.  A reddish flash at the edge, the slightest
+projection of the outline just as the chronometer struck midnight; and
+at that I told Ogilvy and he took my place.  The night was warm and I
+was thirsty, and I went stretching my legs clumsily and feeling my way
+in the darkness, to the little table where the siphon stood, while
+Ogilvy exclaimed at the streamer of gas that came out towards us.
+
+That night another invisible missile started on its way to the
+earth from Mars, just a second or so under twenty-four hours after the
+first one.  I remember how I sat on the table there in the blackness,
+with patches of green and crimson swimming before my eyes.  I wished I
+had a light to smoke by, little suspecting the meaning of the minute
+gleam I had seen and all that it would presently bring me.  Ogilvy
+watched till one, and then gave it up; and we lit the lantern and
+walked over to his house.  Down below in the darkness were Ottershaw
+and Chertsey and all their hundreds of people, sleeping in peace.
+
+He was full of speculation that night about the condition of Mars,
+and scoffed at the vulgar idea of its having inhabitants who were
+signalling us.  His idea was that meteorites might be falling in a
+heavy shower upon the planet, or that a huge volcanic explosion was in
+progress.  He pointed out to me how unlikely it was that organic
+evolution had taken the same direction in the two adjacent planets.
+
+"The chances against anything manlike on Mars are a million to
+one," he said.
+
+Hundreds of observers saw the flame that night and the night after
+about midnight, and again the night after; and so for ten nights, a
+flame each night.  Why the shots ceased after the tenth no one on
+earth has attempted to explain.  It may be the gases of the firing
+caused the Martians inconvenience.  Dense clouds of smoke or dust,
+visible through a powerful telescope on earth as little grey,
+fluctuating patches, spread through the clearness of the planet's
+atmosphere and obscured its more familiar features.
+
+Even the daily papers woke up to the disturbances at last, and
+popular notes appeared here, there, and everywhere concerning the
+volcanoes upon Mars.  The seriocomic periodical _Punch_, I remember,
+made a happy use of it in the political cartoon.  And, all
+unsuspected, those missiles the Martians had fired at us drew
+earthward, rushing now at a pace of many miles a second through the
+empty gulf of space, hour by hour and day by day, nearer and nearer.
+It seems to me now almost incredibly wonderful that, with that swift
+fate hanging over us, men could go about their petty concerns as they
+did.  I remember how jubilant Markham was at securing a new photograph
+of the planet for the illustrated paper he edited in those days.
+People in these latter times scarcely realise the abundance and
+enterprise of our nineteenth-century papers.  For my own part, I was
+much occupied in learning to ride the bicycle, and busy upon a series
+of papers discussing the probable developments of moral ideas as
+civilisation progressed.
+
+One night (the first missile then could scarcely have been
+10,000,000 miles away) I went for a walk with my wife.  It was
+starlight and I explained the Signs of the Zodiac to her, and pointed
+out Mars, a bright dot of light creeping zenithward, towards which so
+many telescopes were pointed.  It was a warm night.  Coming home, a
+party of excursionists from Chertsey or Isleworth passed us singing
+and playing music.  There were lights in the upper windows of the
+houses as the people went to bed.  From the railway station in the
+distance came the sound of shunting trains, ringing and rumbling,
+softened almost into melody by the distance.  My wife pointed out to
+me the brightness of the red, green, and yellow signal lights hanging
+in a framework against the sky.  It seemed so safe and tranquil.
+
+
+
+CHAPTER TWO
+
+THE FALLING STAR
+
+
+Then came the night of the first falling star.  It was seen early
+in the morning, rushing over Winchester eastward, a line of flame high
+in the atmosphere.  Hundreds must have seen it, and taken it for an
+ordinary falling star.  Albin described it as leaving a greenish
+streak behind it that glowed for some seconds.  Denning, our greatest
+authority on meteorites, stated that the height of its first
+appearance was about ninety or one hundred miles.  It seemed to him
+that it fell to earth about one hundred miles east of him.
+
+I was at home at that hour and writing in my study; and although my
+French windows face towards Ottershaw and the blind was up (for I
+loved in those days to look up at the night sky), I saw nothing of it.
+Yet this strangest of all things that ever came to earth from outer
+space must have fallen while I was sitting there, visible to me had I
+only looked up as it passed.  Some of those who saw its flight say it
+travelled with a hissing sound.  I myself heard nothing of that.  Many
+people in Berkshire, Surrey, and Middlesex must have seen the fall of
+it, and, at most, have thought that another meteorite had descended.
+No one seems to have troubled to look for the fallen mass that night.
+
+But very early in the morning poor Ogilvy, who had seen the
+shooting star and who was persuaded that a meteorite lay somewhere on
+the common between Horsell, Ottershaw, and Woking, rose early with the
+idea of finding it.  Find it he did, soon after dawn, and not far from
+the sand pits.  An enormous hole had been made by the impact of the
+projectile, and the sand and gravel had been flung violently in every
+direction over the heath, forming heaps visible a mile and a half
+away.  The heather was on fire eastward, and a thin blue smoke rose
+against the dawn.
+
+The Thing itself lay almost entirely buried in sand, amidst the
+scattered splinters of a fir tree it had shivered to fragments in its
+descent.  The uncovered part had the appearance of a huge cylinder,
+caked over and its outline softened by a thick scaly dun-coloured
+incrustation.  It had a diameter of about thirty yards.  He approached
+the mass, surprised at the size and more so at the shape, since most
+meteorites are rounded more or less completely.  It was, however,
+still so hot from its flight through the air as to forbid his near
+approach.  A stirring noise within its cylinder he ascribed to the
+unequal cooling of its surface; for at that time it had not occurred
+to him that it might be hollow.
+
+He remained standing at the edge of the pit that the Thing had made
+for itself, staring at its strange appearance, astonished chiefly at
+its unusual shape and colour, and dimly perceiving even then some
+evidence of design in its arrival.  The early morning was wonderfully
+still, and the sun, just clearing the pine trees towards Weybridge,
+was already warm.  He did not remember hearing any birds that morning,
+there was certainly no breeze stirring, and the only sounds were the
+faint movements from within the cindery cylinder.  He was all alone on
+the common.
+
+Then suddenly he noticed with a start that some of the grey
+clinker, the ashy incrustation that covered the meteorite, was falling
+off the circular edge of the end.  It was dropping off in flakes and
+raining down upon the sand.  A large piece suddenly came off and fell
+with a sharp noise that brought his heart into his mouth.
+
+For a minute he scarcely realised what this meant, and, although
+the heat was excessive, he clambered down into the pit close to the
+bulk to see the Thing more clearly.  He fancied even then that the
+cooling of the body might account for this, but what disturbed that
+idea was the fact that the ash was falling only from the end of the
+cylinder.
+
+And then he perceived that, very slowly, the circular top of the
+cylinder was rotating on its body.  It was such a gradual movement
+that he discovered it only through noticing that a black mark that had
+been near him five minutes ago was now at the other side of the
+circumference.  Even then he scarcely understood what this indicated,
+until he heard a muffled grating sound and saw the black mark jerk
+forward an inch or so.  Then the thing came upon him in a flash.  The
+cylinder was artificial--hollow--with an end that screwed out!
+Something within the cylinder was unscrewing the top!
+
+"Good heavens!" said Ogilvy.  "There's a man in it--men in it! Half
+roasted to death!  Trying to escape!"
+
+At once, with a quick mental leap, he linked the Thing with the
+flash upon Mars.
+
+The thought of the confined creature was so dreadful to him that he
+forgot the heat and went forward to the cylinder to help turn.  But
+luckily the dull radiation arrested him before he could burn his hands
+on the still-glowing metal.  At that he stood irresolute for a moment,
+then turned, scrambled out of the pit, and set off running wildly into
+Woking.  The time then must have been somewhere about six o'clock.
+He met a waggoner and tried to make him understand, but the tale he
+told and his appearance were so wild--his hat had fallen off in the
+pit--that the man simply drove on.  He was equally unsuccessful with the
+potman who was just unlocking the doors of the public-house by Horsell
+Bridge.  The fellow thought he was a lunatic at large and made an
+unsuccessful attempt to shut him into the taproom.  That sobered him a
+little; and when he saw Henderson, the London journalist, in his
+garden, he called over the palings and made himself understood.
+
+"Henderson," he called, "you saw that shooting star last night?"
+
+"Well?" said Henderson.
+
+"It's out on Horsell Common now."
+
+"Good Lord!" said Henderson.  "Fallen meteorite!  That's good."
+
+"But it's something more than a meteorite.  It's a cylinder--an
+artificial cylinder, man!  And there's something inside."
+
+Henderson stood up with his spade in his hand.
+
+"What's that?" he said.  He was deaf in one ear.
+
+Ogilvy told him all that he had seen.  Henderson was a minute or so
+taking it in.  Then he dropped his spade, snatched up his jacket, and
+came out into the road.  The two men hurried back at once to the
+common, and found the cylinder still lying in the same position.  But
+now the sounds inside had ceased, and a thin circle of bright metal
+showed between the top and the body of the cylinder.  Air was either
+entering or escaping at the rim with a thin, sizzling sound.
+
+They listened, rapped on the scaly burnt metal with a stick, and,
+meeting with no response, they both concluded the man or men inside
+must be insensible or dead.
+
+Of course the two were quite unable to do anything.  They shouted
+consolation and promises, and went off back to the town again to get
+help.  One can imagine them, covered with sand, excited and
+disordered, running up the little street in the bright sunlight just
+as the shop folks were taking down their shutters and people were
+opening their bedroom windows.  Henderson went into the railway
+station at once, in order to telegraph the news to London.  The
+newspaper articles had prepared men's minds for the reception of the
+idea.
+
+By eight o'clock a number of boys and unemployed men had already
+started for the common to see the "dead men from Mars."  That was the
+form the story took.  I heard of it first from my newspaper boy about
+a quarter to nine when I went out to get my _Daily Chronicle_.  I was
+naturally startled, and lost no time in going out and across the
+Ottershaw bridge to the sand pits.
+
+
+
+CHAPTER THREE
+
+ON HORSELL COMMON
+
+
+I found a little crowd of perhaps twenty people surrounding the
+huge hole in which the cylinder lay.  I have already described the
+appearance of that colossal bulk, embedded in the ground.  The turf
+and gravel about it seemed charred as if by a sudden explosion.  No
+doubt its impact had caused a flash of fire.  Henderson and Ogilvy
+were not there.  I think they perceived that nothing was to be done
+for the present, and had gone away to breakfast at Henderson's house.
+
+There were four or five boys sitting on the edge of the Pit, with
+their feet dangling, and amusing themselves--until I stopped them--by
+throwing stones at the giant mass.  After I had spoken to them about
+it, they began playing at "touch" in and out of the group of
+bystanders.
+
+Among these were a couple of cyclists, a jobbing gardener I
+employed sometimes, a girl carrying a baby, Gregg the butcher and his
+little boy, and two or three loafers and golf caddies who were
+accustomed to hang about the railway station.  There was very little
+talking.  Few of the common people in England had anything but the
+vaguest astronomical ideas in those days.  Most of them were staring
+quietly at the big table like end of the cylinder, which was still as
+Ogilvy and Henderson had left it.  I fancy the popular expectation of
+a heap of charred corpses was disappointed at this inanimate bulk.
+Some went away while I was there, and other people came.  I clambered
+into the pit and fancied I heard a faint movement under my feet.  The
+top had certainly ceased to rotate.
+
+It was only when I got thus close to it that the strangeness of
+this object was at all evident to me.  At the first glance it was
+really no more exciting than an overturned carriage or a tree blown
+across the road.  Not so much so, indeed.  It looked like a rusty gas
+float.  It required a certain amount of scientific education to
+perceive that the grey scale of the Thing was no common oxide, that
+the yellowish-white metal that gleamed in the crack between the lid
+and the cylinder had an unfamiliar hue.  "Extra-terrestrial" had no
+meaning for most of the onlookers.
+
+At that time it was quite clear in my own mind that the Thing had
+come from the planet Mars, but I judged it improbable that it
+contained any living creature.  I thought the unscrewing might be
+automatic.  In spite of Ogilvy, I still believed that there were men
+in Mars.  My mind ran fancifully on the possibilities of its
+containing manuscript, on the difficulties in translation that might
+arise, whether we should find coins and models in it, and so forth.
+Yet it was a little too large for assurance on this idea.  I felt an
+impatience to see it opened.  About eleven, as nothing seemed
+happening, I walked back, full of such thought, to my home in Maybury.
+But I found it difficult to get to work upon my abstract
+investigations.
+
+In the afternoon the appearance of the common had altered very
+much.  The early editions of the evening papers had startled London
+with enormous headlines:
+
+  "A MESSAGE RECEIVED FROM MARS."
+
+  "REMARKABLE STORY FROM WOKING,"
+
+and so forth.  In addition, Ogilvy's wire to the Astronomical Exchange
+had roused every observatory in the three kingdoms.
+
+There were half a dozen flies or more from the Woking station
+standing in the road by the sand pits, a basket-chaise from Chobham,
+and a rather lordly carriage.  Besides that, there was quite a heap of
+bicycles.  In addition, a large number of people must have walked, in
+spite of the heat of the day, from Woking and Chertsey, so that there
+was altogether quite a considerable crowd--one or two gaily dressed
+ladies among the others.
+
+It was glaringly hot, not a cloud in the sky nor a breath of wind,
+and the only shadow was that of the few scattered pine trees.  The
+burning heather had been extinguished, but the level ground towards
+Ottershaw was blackened as far as one could see, and still giving off
+vertical streamers of smoke.  An enterprising sweet-stuff dealer in
+the Chobham Road had sent up his son with a barrow-load of green
+apples and ginger beer.
+
+Going to the edge of the pit, I found it occupied by a group of
+about half a dozen men--Henderson, Ogilvy, and a tall, fair-haired man
+that I afterwards learned was Stent, the Astronomer Royal, with
+several workmen wielding spades and pickaxes.  Stent was giving
+directions in a clear, high-pitched voice.  He was standing on the
+cylinder, which was now evidently much cooler; his face was crimson
+and streaming with perspiration, and something seemed to have
+irritated him.
+
+A large portion of the cylinder had been uncovered, though its
+lower end was still embedded.  As soon as Ogilvy saw me among the
+staring crowd on the edge of the pit he called to me to come down, and
+asked me if I would mind going over to see Lord Hilton, the lord of
+the manor.
+
+The growing crowd, he said, was becoming a serious impediment to
+their excavations, especially the boys.  They wanted a light railing
+put up, and help to keep the people back.  He told me that a faint
+stirring was occasionally still audible within the case, but that the
+workmen had failed to unscrew the top, as it afforded no grip to them.
+The case appeared to be enormously thick, and it was possible that the
+faint sounds we heard represented a noisy tumult in the interior.
+
+I was very glad to do as he asked, and so become one of the
+privileged spectators within the contemplated enclosure.  I failed to
+find Lord Hilton at his house, but I was told he was expected from
+London by the six o'clock train from Waterloo; and as it was then
+about a quarter past five, I went home, had some tea, and walked up to
+the station to waylay him.
+
+
+
+CHAPTER FOUR
+
+THE CYLINDER OPENS
+
+
+When I returned to the common the sun was setting.  Scattered groups
+were hurrying from the direction of Woking, and one or two persons
+were returning.  The crowd about the pit had increased, and stood out
+black against the lemon yellow of the sky--a couple of hundred people,
+perhaps.  There were raised voices, and some sort of struggle appeared
+to be going on about the pit.  Strange imaginings passed through my
+mind.  As I drew nearer I heard Stent's voice:
+
+"Keep back!  Keep back!"
+
+A boy came running towards me.
+
+"It's a-movin'," he said to me as he passed; "a-screwin' and
+a-screwin' out.  I don't like it.  I'm a-goin' 'ome, I am."
+
+I went on to the crowd.  There were really, I should think, two or
+three hundred people elbowing and jostling one another, the one or two
+ladies there being by no means the least active.
+
+"He's fallen in the pit!" cried some one.
+
+"Keep back!" said several.
+
+The crowd swayed a little, and I elbowed my way through.  Every one
+seemed greatly excited.  I heard a peculiar humming sound from the
+pit.
+
+"I say!" said Ogilvy; "help keep these idiots back.  We don't know
+what's in the confounded thing, you know!"
+
+I saw a young man, a shop assistant in Woking I believe he was,
+standing on the cylinder and trying to scramble out of the hole again.
+The crowd had pushed him in.
+
+The end of the cylinder was being screwed out from within.  Nearly
+two feet of shining screw projected.  Somebody blundered against me,
+and I narrowly missed being pitched onto the top of the screw.  I
+turned, and as I did so the screw must have come out, for the lid of
+the cylinder fell upon the gravel with a ringing concussion.  I stuck
+my elbow into the person behind me, and turned my head towards the
+Thing again.  For a moment that circular cavity seemed perfectly black.
+I had the sunset in my eyes.
+
+I think everyone expected to see a man emerge--possibly something a
+little unlike us terrestrial men, but in all essentials a man.  I know
+I did.  But, looking, I presently saw something stirring within the
+shadow: greyish billowy movements, one above another, and then two
+luminous disks--like eyes.  Then something resembling a little grey
+snake, about the thickness of a walking stick, coiled up out of the
+writhing middle, and wriggled in the air towards me--and then another.
+
+A sudden chill came over me.  There was a loud shriek from a woman
+behind.  I half turned, keeping my eyes fixed upon the cylinder still,
+from which other tentacles were now projecting, and began pushing my
+way back from the edge of the pit.  I saw astonishment giving place to
+horror on the faces of the people about me.  I heard inarticulate
+exclamations on all sides.  There was a general movement backwards.
+I saw the shopman struggling still on the edge of the pit.  I found
+myself alone, and saw the people on the other side of the pit running
+off, Stent among them.  I looked again at the cylinder, and
+ungovernable terror gripped me.  I stood petrified and staring.
+
+A big greyish rounded bulk, the size, perhaps, of a bear, was
+rising slowly and painfully out of the cylinder.  As it bulged up and
+caught the light, it glistened like wet leather.
+
+Two large dark-coloured eyes were regarding me steadfastly.  The
+mass that framed them, the head of the thing, was rounded, and had,
+one might say, a face.  There was a mouth under the eyes, the lipless
+brim of which quivered and panted, and dropped saliva.  The whole
+creature heaved and pulsated convulsively.  A lank tentacular
+appendage gripped the edge of the cylinder, another swayed in the air.
+
+Those who have never seen a living Martian can scarcely imagine the
+strange horror of its appearance.  The peculiar V-shaped mouth with
+its pointed upper lip, the absence of brow ridges, the absence of a
+chin beneath the wedgelike lower lip, the incessant quivering of this
+mouth, the Gorgon groups of tentacles, the tumultuous breathing of the
+lungs in a strange atmosphere, the evident heaviness and painfulness
+of movement due to the greater gravitational energy of the earth--above
+all, the extraordinary intensity of the immense eyes--were at
+once vital, intense, inhuman, crippled and monstrous.  There was
+something fungoid in the oily brown skin, something in the clumsy
+deliberation of the tedious movements unspeakably nasty.  Even at this
+first encounter, this first glimpse, I was overcome with disgust and
+dread.
+
+Suddenly the monster vanished.  It had toppled over the brim of the
+cylinder and fallen into the pit, with a thud like the fall of a great
+mass of leather.  I heard it give a peculiar thick cry, and forthwith
+another of these creatures appeared darkly in the deep shadow of the
+aperture.
+
+I turned and, running madly, made for the first group of trees,
+perhaps a hundred yards away; but I ran slantingly and stumbling, for
+I could not avert my face from these things.
+
+There, among some young pine trees and furze bushes, I stopped,
+panting, and waited further developments.  The common round the sand
+pits was dotted with people, standing like myself in a half-fascinated
+terror, staring at these creatures, or rather at the heaped gravel at
+the edge of the pit in which they lay.  And then, with a renewed
+horror, I saw a round, black object bobbing up and down on the edge of
+the pit.  It was the head of the shopman who had fallen in, but
+showing as a little black object against the hot western sun.  Now he
+got his shoulder and knee up, and again he seemed to slip back until
+only his head was visible.  Suddenly he vanished, and I could have
+fancied a faint shriek had reached me.  I had a momentary impulse to
+go back and help him that my fears overruled.
+
+Everything was then quite invisible, hidden by the deep pit and the
+heap of sand that the fall of the cylinder had made.  Anyone coming
+along the road from Chobham or Woking would have been amazed at the
+sight--a dwindling multitude of perhaps a hundred people or more
+standing in a great irregular circle, in ditches, behind bushes,
+behind gates and hedges, saying little to one another and that in
+short, excited shouts, and staring, staring hard at a few heaps of
+sand.  The barrow of ginger beer stood, a queer derelict, black
+against the burning sky, and in the sand pits was a row of deserted
+vehicles with their horses feeding out of nosebags or pawing the
+ground.
+
+
+
+CHAPTER FIVE
+
+THE HEAT-RAY
+
+
+After the glimpse I had had of the Martians emerging from the
+cylinder in which they had come to the earth from their planet, a kind
+of fascination paralysed my actions.  I remained standing knee-deep in
+the heather, staring at the mound that hid them.  I was a battleground
+of fear and curiosity.
+
+I did not dare to go back towards the pit, but I felt a passionate
+longing to peer into it.  I began walking, therefore, in a big curve,
+seeking some point of vantage and continually looking at the sand
+heaps that hid these new-comers to our earth.  Once a leash of thin
+black whips, like the arms of an octopus, flashed across the sunset
+and was immediately withdrawn, and afterwards a thin rod rose up,
+joint by joint, bearing at its apex a circular disk that spun with a
+wobbling motion.  What could be going on there?
+
+Most of the spectators had gathered in one or two groups--one a
+little crowd towards Woking, the other a knot of people in the
+direction of Chobham.  Evidently they shared my mental conflict.
+There were few near me.  One man I approached--he was, I perceived,
+a neighbour of mine, though I did not know his name--and accosted.
+But it was scarcely a time for articulate conversation.
+
+"What ugly _brutes_!" he said.  "Good God!  What ugly brutes!"  He
+repeated this over and over again.
+
+"Did you see a man in the pit?" I said; but he made no answer to
+that.  We became silent, and stood watching for a time side by side,
+deriving, I fancy, a certain comfort in one another's company.  Then I
+shifted my position to a little knoll that gave me the advantage of a
+yard or more of elevation and when I looked for him presently he was
+walking towards Woking.
+
+The sunset faded to twilight before anything further happened.  The
+crowd far away on the left, towards Woking, seemed to grow, and I
+heard now a faint murmur from it.  The little knot of people towards
+Chobham dispersed.  There was scarcely an intimation of movement from
+the pit.
+
+It was this, as much as anything, that gave people courage, and I
+suppose the new arrivals from Woking also helped to restore
+confidence.  At any rate, as the dusk came on a slow, intermittent
+movement upon the sand pits began, a movement that seemed to gather
+force as the stillness of the evening about the cylinder remained
+unbroken.  Vertical black figures in twos and threes would advance,
+stop, watch, and advance again, spreading out as they did so in a thin
+irregular crescent that promised to enclose the pit in its attenuated
+horns.  I, too, on my side began to move towards the pit.
+
+Then I saw some cabmen and others had walked boldly into the sand
+pits, and heard the clatter of hoofs and the gride of wheels.  I saw a
+lad trundling off the barrow of apples.  And then, within thirty yards
+of the pit, advancing from the direction of Horsell, I noted a little
+black knot of men, the foremost of whom was waving a white flag.
+
+This was the Deputation.  There had been a hasty consultation, and
+since the Martians were evidently, in spite of their repulsive forms,
+intelligent creatures, it had been resolved to show them, by
+approaching them with signals, that we too were intelligent.
+
+Flutter, flutter, went the flag, first to the right, then to the
+left.  It was too far for me to recognise anyone there, but afterwards
+I learned that Ogilvy, Stent, and Henderson were with others in this
+attempt at communication.  This little group had in its advance
+dragged inward, so to speak, the circumference of the now almost
+complete circle of people, and a number of dim black figures followed
+it at discreet distances.
+
+Suddenly there was a flash of light, and a quantity of luminous
+greenish smoke came out of the pit in three distinct puffs, which
+drove up, one after the other, straight into the still air.
+
+This smoke (or flame, perhaps, would be the better word for it) was
+so bright that the deep blue sky overhead and the hazy stretches of
+brown common towards Chertsey, set with black pine trees, seemed to
+darken abruptly as these puffs arose, and to remain the darker after
+their dispersal.  At the same time a faint hissing sound became
+audible.
+
+Beyond the pit stood the little wedge of people with the white flag
+at its apex, arrested by these phenomena, a little knot of small
+vertical black shapes upon the black ground.  As the green smoke arose,
+their faces flashed out pallid green, and faded again as it vanished.
+Then slowly the hissing passed into a humming, into a long, loud,
+droning noise.  Slowly a humped shape rose out of the pit, and the
+ghost of a beam of light seemed to flicker out from it.
+
+Forthwith flashes of actual flame, a bright glare leaping from one
+to another, sprang from the scattered group of men.  It was as if some
+invisible jet impinged upon them and flashed into white flame.  It was
+as if each man were suddenly and momentarily turned to fire.
+
+Then, by the light of their own destruction, I saw them staggering
+and falling, and their supporters turning to run.
+
+I stood staring, not as yet realising that this was death leaping
+from man to man in that little distant crowd.  All I felt was that it
+was something very strange.  An almost noiseless and blinding flash of
+light, and a man fell headlong and lay still; and as the unseen shaft
+of heat passed over them, pine trees burst into fire, and every dry
+furze bush became with one dull thud a mass of flames.  And far away
+towards Knaphill I saw the flashes of trees and hedges and wooden
+buildings suddenly set alight.
+
+It was sweeping round swiftly and steadily, this flaming death,
+this invisible, inevitable sword of heat.  I perceived it coming
+towards me by the flashing bushes it touched, and was too astounded
+and stupefied to stir.  I heard the crackle of fire in the sand pits
+and the sudden squeal of a horse that was as suddenly stilled.  Then
+it was as if an invisible yet intensely heated finger were drawn
+through the heather between me and the Martians, and all along a
+curving line beyond the sand pits the dark ground smoked and crackled.
+Something fell with a crash far away to the left where the road from
+Woking station opens out on the common.  Forth-with the hissing and
+humming ceased, and the black, dome-like object sank slowly out of
+sight into the pit.
+
+All this had happened with such swiftness that I had stood
+motionless, dumbfounded and dazzled by the flashes of light.  Had that
+death swept through a full circle, it must inevitably have slain me in
+my surprise.  But it passed and spared me, and left the night about me
+suddenly dark and unfamiliar.
+
+The undulating common seemed now dark almost to blackness, except
+where its roadways lay grey and pale under the deep blue sky of the
+early night.  It was dark, and suddenly void of men.  Overhead the
+stars were mustering, and in the west the sky was still a pale,
+bright, almost greenish blue.  The tops of the pine trees and the
+roofs of Horsell came out sharp and black against the western
+afterglow.  The Martians and their appliances were altogether
+invisible, save for that thin mast upon which their restless mirror
+wobbled.  Patches of bush and isolated trees here and there smoked and
+glowed still, and the houses towards Woking station were sending up
+spires of flame into the stillness of the evening air.
+
+Nothing was changed save for that and a terrible astonishment.  The
+little group of black specks with the flag of white had been swept out
+of existence, and the stillness of the evening, so it seemed to me,
+had scarcely been broken.
+
+It came to me that I was upon this dark common, helpless,
+unprotected, and alone.  Suddenly, like a thing falling upon me from
+without, came--fear.
+
+With an effort I turned and began a stumbling run through the
+heather.
+
+The fear I felt was no rational fear, but a panic terror not only
+of the Martians, but of the dusk and stillness all about me.  Such an
+extraordinary effect in unmanning me it had that I ran weeping
+silently as a child might do.  Once I had turned, I did not dare to
+look back.
+
+I remember I felt an extraordinary persuasion that I was being
+played with, that presently, when I was upon the very verge of safety,
+this mysterious death--as swift as the passage of light--would leap
+after me from the pit about the cylinder and strike me down.
+
+
+
+CHAPTER SIX
+
+THE HEAT-RAY IN THE CHOBHAM ROAD
+
+
+It is still a matter of wonder how the Martians are able to slay
+men so swiftly and so silently.  Many think that in some way they are
+able to generate an intense heat in a chamber of practically absolute
+non-conductivity.  This intense heat they project in a parallel beam
+against any object they choose, by means of a polished parabolic
+mirror of unknown composition, much as the parabolic mirror of a
+lighthouse projects a beam of light.  But no one has absolutely proved
+these details.  However it is done, it is certain that a beam of heat
+is the essence of the matter.  Heat, and invisible, instead of
+visible, light.  Whatever is combustible flashes into flame at its
+touch, lead runs like water, it softens iron, cracks and melts glass,
+and when it falls upon water, incontinently that explodes into steam.
+
+That night nearly forty people lay under the starlight about the
+pit, charred and distorted beyond recognition, and all night long the
+common from Horsell to Maybury was deserted and brightly ablaze.
+
+The news of the massacre probably reached Chobham, Woking, and
+Ottershaw about the same time.  In Woking the shops had closed when
+the tragedy happened, and a number of people, shop people and so
+forth, attracted by the stories they had heard, were walking over the
+Horsell Bridge and along the road between the hedges that runs out at
+last upon the common.  You may imagine the young people brushed up
+after the labours of the day, and making this novelty, as they would
+make any novelty, the excuse for walking together and enjoying a
+trivial flirtation.  You may figure to yourself the hum of voices
+along the road in the gloaming. . . .
+
+As yet, of course, few people in Woking even knew that the cylinder
+had opened, though poor Henderson had sent a messenger on a bicycle to
+the post office with a special wire to an evening paper.
+
+As these folks came out by twos and threes upon the open, they
+found little knots of people talking excitedly and peering at the
+spinning mirror over the sand pits, and the newcomers were, no doubt,
+soon infected by the excitement of the occasion.
+
+By half past eight, when the Deputation was destroyed, there may
+have been a crowd of three hundred people or more at this place,
+besides those who had left the road to approach the Martians nearer.
+There were three policemen too, one of whom was mounted, doing their
+best, under instructions from Stent, to keep the people back and deter
+them from approaching the cylinder.  There was some booing from those
+more thoughtless and excitable souls to whom a crowd is always an
+occasion for noise and horse-play.
+
+Stent and Ogilvy, anticipating some possibilities of a collision,
+had telegraphed from Horsell to the barracks as soon as the Martians
+emerged, for the help of a company of soldiers to protect these
+strange creatures from violence.  After that they returned to lead that
+ill-fated advance.  The description of their death, as it was seen by
+the crowd, tallies very closely with my own impressions: the three
+puffs of green smoke, the deep humming note, and the flashes of flame.
+
+But that crowd of people had a far narrower escape than mine.  Only
+the fact that a hummock of heathery sand intercepted the lower part of
+the Heat-Ray saved them.  Had the elevation of the parabolic mirror
+been a few yards higher, none could have lived to tell the tale.  They
+saw the flashes and the men falling and an invisible hand, as it were,
+lit the bushes as it hurried towards them through the twilight.  Then,
+with a whistling note that rose above the droning of the pit, the beam
+swung close over their heads, lighting the tops of the beech trees
+that line the road, and splitting the bricks, smashing the windows,
+firing the window frames, and bringing down in crumbling ruin a
+portion of the gable of the house nearest the corner.
+
+In the sudden thud, hiss, and glare of the igniting trees, the
+panic-stricken crowd seems to have swayed hesitatingly for some
+moments.  Sparks and burning twigs began to fall into the road, and
+single leaves like puffs of flame.  Hats and dresses caught fire.  Then
+came a crying from the common.  There were shrieks and shouts, and
+suddenly a mounted policeman came galloping through the confusion with
+his hands clasped over his head, screaming.
+
+"They're coming!" a woman shrieked, and incontinently everyone was
+turning and pushing at those behind, in order to clear their way to
+Woking again.  They must have bolted as blindly as a flock of sheep.
+Where the road grows narrow and black between the high banks the crowd
+jammed, and a desperate struggle occurred.  All that crowd did not
+escape; three persons at least, two women and a little boy, were
+crushed and trampled there, and left to die amid the terror and the
+darkness.
+
+
+
+CHAPTER SEVEN
+
+HOW I REACHED HOME
+
+
+For my own part, I remember nothing of my flight except the stress
+of blundering against trees and stumbling through the heather.  All
+about me gathered the invisible terrors of the Martians; that pitiless
+sword of heat seemed whirling to and fro, flourishing overhead before
+it descended and smote me out of life.  I came into the road between
+the crossroads and Horsell, and ran along this to the crossroads.
+
+At last I could go no further; I was exhausted with the violence of
+my emotion and of my flight, and I staggered and fell by the wayside.
+That was near the bridge that crosses the canal by the gasworks.  I
+fell and lay still.
+
+I must have remained there some time.
+
+I sat up, strangely perplexed.  For a moment, perhaps, I could not
+clearly understand how I came there.  My terror had fallen from me
+like a garment.  My hat had gone, and my collar had burst away from
+its fastener.  A few minutes before, there had only been three real
+things before me--the immensity of the night and space and nature, my
+own feebleness and anguish, and the near approach of death.  Now it
+was as if something turned over, and the point of view altered
+abruptly.  There was no sensible transition from one state of mind to
+the other.  I was immediately the self of every day again--a decent,
+ordinary citizen.  The silent common, the impulse of my flight, the
+starting flames, were as if they had been in a dream.  I asked myself
+had these latter things indeed happened?  I could not credit it.
+
+I rose and walked unsteadily up the steep incline of the bridge.  My
+mind was blank wonder.  My muscles and nerves seemed drained of their
+strength.  I dare say I staggered drunkenly.  A head rose over the
+arch, and the figure of a workman carrying a basket appeared.  Beside
+him ran a little boy.  He passed me, wishing me good night.  I was
+minded to speak to him, but did not.  I answered his greeting with a
+meaningless mumble and went on over the bridge.
+
+Over the Maybury arch a train, a billowing tumult of white, firelit
+smoke, and a long caterpillar of lighted windows, went flying
+south--clatter, clatter, clap, rap, and it had gone.  A dim group of
+people talked in the gate of one of the houses in the pretty little
+row of gables that was called Oriental Terrace.  It was all so real
+and so familiar.  And that behind me!  It was frantic, fantastic!
+Such things, I told myself, could not be.
+
+Perhaps I am a man of exceptional moods.  I do not know how far my
+experience is common.  At times I suffer from the strangest sense of
+detachment from myself and the world about me; I seem to watch it all
+from the outside, from somewhere inconceivably remote, out of time,
+out of space, out of the stress and tragedy of it all.  This feeling
+was very strong upon me that night.  Here was another side to my
+dream.
+
+But the trouble was the blank incongruity of this serenity and the
+swift death flying yonder, not two miles away.  There was a noise of
+business from the gasworks, and the electric lamps were all alight.  I
+stopped at the group of people.
+
+"What news from the common?" said I.
+
+There were two men and a woman at the gate.
+
+"Eh?" said one of the men, turning.
+
+"What news from the common?" I said.
+
+"'Ain't yer just _been_ there?" asked the men.
+
+"People seem fair silly about the common," said the woman over the
+gate.  "What's it all abart?"
+
+"Haven't you heard of the men from Mars?" said I; "the creatures
+from Mars?"
+
+"Quite enough," said the woman over the gate.  "Thenks"; and all
+three of them laughed.
+
+I felt foolish and angry.  I tried and found I could not tell them
+what I had seen.  They laughed again at my broken sentences.
+
+"You'll hear more yet," I said, and went on to my home.
+
+I startled my wife at the doorway, so haggard was I.  I went into
+the dining room, sat down, drank some wine, and so soon as I could
+collect myself sufficiently I told her the things I had seen.  The
+dinner, which was a cold one, had already been served, and remained
+neglected on the table while I told my story.
+
+"There is one thing," I said, to allay the fears I had aroused;
+"they are the most sluggish things I ever saw crawl.  They may keep
+the pit and kill people who come near them, but they cannot get out
+of it. . . .  But the horror of them!"
+
+"Don't, dear!" said my wife, knitting her brows and putting her
+hand on mine.
+
+"Poor Ogilvy!" I said.  "To think he may be lying dead there!"
+
+My wife at least did not find my experience incredible.  When I saw
+how deadly white her face was, I ceased abruptly.
+
+"They may come here," she said again and again.
+
+I pressed her to take wine, and tried to reassure her.
+
+"They can scarcely move," I said.
+
+I began to comfort her and myself by repeating all that Ogilvy had
+told me of the impossibility of the Martians establishing themselves
+on the earth.  In particular I laid stress on the gravitational
+difficulty.  On the surface of the earth the force of gravity is three
+times what it is on the surface of Mars.  A Martian, therefore, would
+weigh three times more than on Mars, albeit his muscular strength
+would be the same.  His own body would be a cope of lead to him.  That,
+indeed, was the general opinion.  Both _The Times_ and the _Daily
+Telegraph_, for instance, insisted on it the next morning, and both
+overlooked, just as I did, two obvious modifying influences.
+
+The atmosphere of the earth, we now know, contains far more oxygen
+or far less argon (whichever way one likes to put it) than does Mars.
+The invigorating influences of this excess of oxygen upon the Martians
+indisputably did much to counterbalance the increased weight of their
+bodies.  And, in the second place, we all overlooked the fact that
+such mechanical intelligence as the Martian possessed was quite able
+to dispense with muscular exertion at a pinch.
+
+But I did not consider these points at the time, and so my
+reasoning was dead against the chances of the invaders.  With wine and
+food, the confidence of my own table, and the necessity of reassuring
+my wife, I grew by insensible degrees courageous and secure.
+
+"They have done a foolish thing," said I, fingering my wineglass.
+"They are dangerous because, no doubt, they are mad with terror.
+Perhaps they expected to find no living things--certainly no
+intelligent living things."
+
+"A shell in the pit" said I, "if the worst comes to the worst will
+kill them all."
+
+The intense excitement of the events had no doubt left my
+perceptive powers in a state of erethism.  I remember that dinner
+table with extraordinary vividness even now.  My dear wife's sweet
+anxious face peering at me from under the pink lamp shade, the white
+cloth with its silver and glass table furniture--for in those days
+even philosophical writers had many little luxuries--the crimson-purple
+wine in my glass, are photographically distinct.  At the end of
+it I sat, tempering nuts with a cigarette, regretting Ogilvy's
+rashness, and denouncing the shortsighted timidity of the Martians.
+
+So some respectable dodo in the Mauritius might have lorded it in
+his nest, and discussed the arrival of that shipful of pitiless
+sailors in want of animal food.  "We will peck them to death tomorrow,
+my dear."
+
+I did not know it, but that was the last civilised dinner I was to
+eat for very many strange and terrible days.
+
+
+
+CHAPTER EIGHT
+
+FRIDAY NIGHT
+
+
+The most extraordinary thing to my mind, of all the strange and
+wonderful things that happened upon that Friday, was the dovetailing
+of the commonplace habits of our social order with the first
+beginnings of the series of events that was to topple that social
+order headlong.  If on Friday night you had taken a pair of compasses
+and drawn a circle with a radius of five miles round the Woking sand
+pits, I doubt if you would have had one human being outside it, unless
+it were some relation of Stent or of the three or four cyclists or
+London people lying dead on the common, whose emotions or habits were
+at all affected by the new-comers.  Many people had heard of the
+cylinder, of course, and talked about it in their leisure, but it
+certainly did not make the sensation that an ultimatum to Germany
+would have done.
+
+In London that night poor Henderson's telegram describing the
+gradual unscrewing of the shot was judged to be a canard, and his
+evening paper, after wiring for authentication from him and receiving
+no reply--the man was killed--decided not to print a special edition.
+
+Even within the five-mile circle the great majority of people were
+inert.  I have already described the behaviour of the men and women to
+whom I spoke.  All over the district people were dining and supping;
+working men were gardening after the labours of the day, children
+were being put to bed, young people were wandering through the lanes
+love-making, students sat over their books.
+
+Maybe there was a murmur in the village streets, a novel and
+dominant topic in the public-houses, and here and there a messenger,
+or even an eye-witness of the later occurrences, caused a whirl of
+excitement, a shouting, and a running to and fro; but for the most
+part the daily routine of working, eating, drinking, sleeping, went on
+as it had done for countless years--as though no planet Mars existed
+in the sky.  Even at Woking station and Horsell and Chobham that was
+the case.
+
+In Woking junction, until a late hour, trains were stopping and
+going on, others were shunting on the sidings, passengers were
+alighting and waiting, and everything was proceeding in the most
+ordinary way.  A boy from the town, trenching on Smith's monopoly, was
+selling papers with the afternoon's news.  The ringing impact of
+trucks, the sharp whistle of the engines from the junction, mingled
+with their shouts of "Men from Mars!"  Excited men came into the
+station about nine o'clock with incredible tidings, and caused no more
+disturbance than drunkards might have done.  People rattling
+Londonwards peered into the darkness outside the carriage windows, and
+saw only a rare, flickering, vanishing spark dance up from the
+direction of Horsell, a red glow and a thin veil of smoke driving
+across the stars, and thought that nothing more serious than a heath
+fire was happening.  It was only round the edge of the common that any
+disturbance was perceptible.  There were half a dozen villas burning
+on the Woking border.  There were lights in all the houses on the
+common side of the three villages, and the people there kept awake
+till dawn.
+
+A curious crowd lingered restlessly, people coming and going but
+the crowd remaining, both on the Chobham and Horsell bridges.  One or
+two adventurous souls, it was afterwards found, went into the darkness
+and crawled quite near the Martians; but they never returned, for now
+and again a light-ray, like the beam of a warship's searchlight swept
+the common, and the Heat-Ray was ready to follow.  Save for such, that
+big area of common was silent and desolate, and the charred bodies lay
+about on it all night under the stars, and all the next day.  A noise
+of hammering from the pit was heard by many people.
+
+So you have the state of things on Friday night.  In the centre,
+sticking into the skin of our old planet Earth like a poisoned dart,
+was this cylinder.  But the poison was scarcely working yet.  Around
+it was a patch of silent common, smouldering in places, and with a few
+dark, dimly seen objects lying in contorted attitudes here and there.
+Here and there was a burning bush or tree.  Beyond was a fringe of
+excitement, and farther than that fringe the inflammation had not
+crept as yet.  In the rest of the world the stream of life still
+flowed as it had flowed for immemorial years.  The fever of war that
+would presently clog vein and artery, deaden nerve and destroy brain,
+had still to develop.
+
+All night long the Martians were hammering and stirring, sleepless,
+indefatigable, at work upon the machines they were making ready, and
+ever and again a puff of greenish-white smoke whirled up to the
+starlit sky.
+
+About eleven a company of soldiers came through Horsell, and
+deployed along the edge of the common to form a cordon.  Later a
+second company marched through Chobham to deploy on the north side of
+the common.  Several officers from the Inkerman barracks had been on
+the common earlier in the day, and one, Major Eden, was reported to be
+missing.  The colonel of the regiment came to the Chobham bridge and
+was busy questioning the crowd at midnight.  The military authorities
+were certainly alive to the seriousness of the business.  About
+eleven, the next morning's papers were able to say, a squadron of
+hussars, two Maxims, and about four hundred men of the Cardigan
+regiment started from Aldershot.
+
+A few seconds after midnight the crowd in the Chertsey road,
+Woking, saw a star fall from heaven into the pine woods to the
+northwest.  It had a greenish colour, and caused a silent brightness
+like summer lightning.  This was the second cylinder.
+
+
+
+CHAPTER NINE
+
+THE FIGHTING BEGINS
+
+
+Saturday lives in my memory as a day of suspense.  It was a day of
+lassitude too, hot and close, with, I am told, a rapidly fluctuating
+barometer.  I had slept but little, though my wife had succeeded in
+sleeping, and I rose early.  I went into my garden before breakfast
+and stood listening, but towards the common there was nothing stirring
+but a lark.
+
+The milkman came as usual.  I heard the rattle of his chariot and I
+went round to the side gate to ask the latest news.  He told me that
+during the night the Martians had been surrounded by troops, and that
+guns were expected.  Then--a familiar, reassuring note--I heard a train
+running towards Woking.
+
+"They aren't to be killed," said the milkman, "if that can possibly
+be avoided."
+
+I saw my neighbour gardening, chatted with him for a time, and then
+strolled in to breakfast.  It was a most unexceptional morning.  My
+neighbour was of opinion that the troops would be able to capture or
+to destroy the Martians during the day.
+
+"It's a pity they make themselves so unapproachable," he said.  "It
+would be curious to know how they live on another planet; we might
+learn a thing or two."
+
+He came up to the fence and extended a handful of strawberries, for
+his gardening was as generous as it was enthusiastic.  At the same
+time he told me of the burning of the pine woods about the Byfleet
+Golf Links.
+
+"They say," said he, "that there's another of those blessed things
+fallen there--number two.  But one's enough, surely.  This lot'll cost
+the insurance people a pretty penny before everything's settled."  He
+laughed with an air of the greatest good humour as he said this.  The
+woods, he said, were still burning, and pointed out a haze of smoke to
+me.  "They will be hot under foot for days, on account of the thick
+soil of pine needles and turf," he said, and then grew serious over
+"poor Ogilvy."
+
+After breakfast, instead of working, I decided to walk down
+towards the common.  Under the railway bridge I found a group of
+soldiers--sappers, I think, men in small round caps, dirty red jackets
+unbuttoned, and showing their blue shirts, dark trousers, and boots
+coming to the calf.  They told me no one was allowed over the canal,
+and, looking along the road towards the bridge, I saw one of the
+Cardigan men standing sentinel there.  I talked with these soldiers
+for a time; I told them of my sight of the Martians on the previous
+evening.  None of them had seen the Martians, and they had but the
+vaguest ideas of them, so that they plied me with questions.  They
+said that they did not know who had authorised the movements of the
+troops; their idea was that a dispute had arisen at the Horse Guards.
+The ordinary sapper is a great deal better educated than the common
+soldier, and they discussed the peculiar conditions of the possible
+fight with some acuteness.  I described the Heat-Ray to them, and they
+began to argue among themselves.
+
+"Crawl up under cover and rush 'em, say I," said one.
+
+"Get aht!" said another.  "What's cover against this 'ere 'eat?
+Sticks to cook yer!  What we got to do is to go as near as the
+ground'll let us, and then drive a trench."
+
+"Blow yer trenches!  You always want trenches; you ought to ha'
+been born a rabbit Snippy."
+
+"Ain't they got any necks, then?" said a third, abruptly--a little,
+contemplative, dark man, smoking a pipe.
+
+I repeated my description.
+
+"Octopuses," said he, "that's what I calls 'em.  Talk about fishers
+of men--fighters of fish it is this time!"
+
+"It ain't no murder killing beasts like that," said the first
+speaker.
+
+"Why not shell the darned things strite off and finish 'em?" said
+the little dark man.  "You carn tell what they might do."
+
+"Where's your shells?" said the first speaker.  "There ain't no
+time.  Do it in a rush, that's my tip, and do it at once."
+
+So they discussed it.  After a while I left them, and went on to
+the railway station to get as many morning papers as I could.
+
+But I will not weary the reader with a description of that long
+morning and of the longer afternoon.  I did not succeed in getting a
+glimpse of the common, for even Horsell and Chobham church towers were
+in the hands of the military authorities.  The soldiers I addressed
+didn't know anything; the officers were mysterious as well as busy.  I
+found people in the town quite secure again in the presence of the
+military, and I heard for the first time from Marshall, the
+tobacconist, that his son was among the dead on the common.  The
+soldiers had made the people on the outskirts of Horsell lock up and
+leave their houses.
+
+I got back to lunch about two, very tired for, as I have said, the
+day was extremely hot and dull; and in order to refresh myself I took
+a cold bath in the afternoon.  About half past four I went up to the
+railway station to get an evening paper, for the morning papers had
+contained only a very inaccurate description of the killing of Stent,
+Henderson, Ogilvy, and the others.  But there was little I didn't
+know.  The Martians did not show an inch of themselves.  They seemed
+busy in their pit, and there was a sound of hammering and an almost
+continuous streamer of smoke.  Apparently they were busy getting ready
+for a struggle.  "Fresh attempts have been made to signal, but without
+success," was the stereotyped formula of the papers.  A sapper told me
+it was done by a man in a ditch with a flag on a long pole.  The
+Martians took as much notice of such advances as we should of the
+lowing of a cow.
+
+I must confess the sight of all this armament, all this
+preparation, greatly excited me.  My imagination became belligerent,
+and defeated the invaders in a dozen striking ways; something of my
+schoolboy dreams of battle and heroism came back.  It hardly seemed a
+fair fight to me at that time.  They seemed very helpless in that pit
+of theirs.
+
+About three o'clock there began the thud of a gun at measured
+intervals from Chertsey or Addlestone.  I learned that the smouldering
+pine wood into which the second cylinder had fallen was being shelled,
+in the hope of destroying that object before it opened.  It was only
+about five, however, that a field gun reached Chobham for use against
+the first body of Martians.
+
+About six in the evening, as I sat at tea with my wife in the
+summerhouse talking vigorously about the battle that was lowering upon
+us, I heard a muffled detonation from the common, and immediately
+after a gust of firing.  Close on the heels of that came a violent
+rattling crash, quite close to us, that shook the ground; and,
+starting out upon the lawn, I saw the tops of the trees about the
+Oriental College burst into smoky red flame, and the tower of the
+little church beside it slide down into ruin.  The pinnacle of the
+mosque had vanished, and the roof line of the college itself looked as
+if a hundred-ton gun had been at work upon it.  One of our chimneys
+cracked as if a shot had hit it, flew, and a piece of it came
+clattering down the tiles and made a heap of broken red fragments upon
+the flower bed by my study window.
+
+I and my wife stood amazed.  Then I realised that the crest of
+Maybury Hill must be within range of the Martians' Heat-Ray now that
+the college was cleared out of the way.
+
+At that I gripped my wife's arm, and without ceremony ran her out
+into the road.  Then I fetched out the servant, telling her I would go
+upstairs myself for the box she was clamouring for.
+
+"We can't possibly stay here," I said; and as I spoke the firing
+reopened for a moment upon the common.
+
+"But where are we to go?" said my wife in terror.
+
+I thought perplexed.  Then I remembered her cousins at Leatherhead.
+
+"Leatherhead!" I shouted above the sudden noise.
+
+She looked away from me downhill.  The people were coming out of
+their houses, astonished.
+
+"How are we to get to Leatherhead?" she said.
+
+Down the hill I saw a bevy of hussars ride under the railway
+bridge; three galloped through the open gates of the Oriental College;
+two others dismounted, and began running from house to house.  The
+sun, shining through the smoke that drove up from the tops of the
+trees, seemed blood red, and threw an unfamiliar lurid light upon
+everything.
+
+"Stop here," said I; "you are safe here"; and I started off at once
+for the Spotted Dog, for I knew the landlord had a horse and dog cart.
+I ran, for I perceived that in a moment everyone upon this side of the
+hill would be moving.  I found him in his bar, quite unaware of what
+was going on behind his house.  A man stood with his back to me,
+talking to him.
+
+"I must have a pound," said the landlord, "and I've no one to drive
+it."
+
+"I'll give you two," said I, over the stranger's shoulder.
+
+"What for?"
+
+"And I'll bring it back by midnight," I said.
+
+"Lord!" said the landlord; "what's the hurry?  I'm selling my bit
+of a pig.  Two pounds, and you bring it back?  What's going on now?"
+
+I explained hastily that I had to leave my home, and so secured the
+dog cart.  At the time it did not seem to me nearly so urgent that the
+landlord should leave his.  I took care to have the cart there and
+then, drove it off down the road, and, leaving it in charge of my wife
+and servant, rushed into my house and packed a few valuables, such
+plate as we had, and so forth.  The beech trees below the house were
+burning while I did this, and the palings up the road glowed red.
+While I was occupied in this way, one of the dismounted hussars came
+running up.  He was going from house to house, warning people to
+leave.  He was going on as I came out of my front door, lugging my
+treasures, done up in a tablecloth.  I shouted after him:
+
+"What news?"
+
+He turned, stared, bawled something about "crawling out in a thing
+like a dish cover," and ran on to the gate of the house at the crest.
+A sudden whirl of black smoke driving across the road hid him for a
+moment.  I ran to my neighbour's door and rapped to satisfy myself of
+what I already knew, that his wife had gone to London with him and had
+locked up their house.  I went in again, according to my promise, to
+get my servant's box, lugged it out, clapped it beside her on the tail
+of the dog cart, and then caught the reins and jumped up into the
+driver's seat beside my wife.  In another moment we were clear of the
+smoke and noise, and spanking down the opposite slope of Maybury Hill
+towards Old Woking.
+
+In front was a quiet sunny landscape, a wheat field ahead on either
+side of the road, and the Maybury Inn with its swinging sign.  I saw
+the doctor's cart ahead of me.  At the bottom of the hill I turned my
+head to look at the hillside I was leaving.  Thick streamers of black
+smoke shot with threads of red fire were driving up into the still
+air, and throwing dark shadows upon the green treetops eastward.  The
+smoke already extended far away to the east and west--to the Byfleet
+pine woods eastward, and to Woking on the west.  The road was dotted
+with people running towards us.  And very faint now, but very distinct
+through the hot, quiet air, one heard the whirr of a machine-gun that
+was presently stilled, and an intermittent cracking of rifles.
+Apparently the Martians were setting fire to everything within range
+of their Heat-Ray.
+
+I am not an expert driver, and I had immediately to turn my
+attention to the horse.  When I looked back again the second hill had
+hidden the black smoke.  I slashed the horse with the whip, and gave
+him a loose rein until Woking and Send lay between us and that
+quivering tumult.  I overtook and passed the doctor between Woking and
+Send.
+
+
+
+CHAPTER TEN
+
+IN THE STORM
+
+
+Leatherhead is about twelve miles from Maybury Hill.  The scent of
+hay was in the air through the lush meadows beyond Pyrford, and the
+hedges on either side were sweet and gay with multitudes of dog-roses.
+The heavy firing that had broken out while we were driving down
+Maybury Hill ceased as abruptly as it began, leaving the evening very
+peaceful and still.  We got to Leatherhead without misadventure about
+nine o'clock, and the horse had an hour's rest while I took supper
+with my cousins and commended my wife to their care.
+
+My wife was curiously silent throughout the drive, and seemed
+oppressed with forebodings of evil.  I talked to her reassuringly,
+pointing out that the Martians were tied to the Pit by sheer
+heaviness, and at the utmost could but crawl a little out of it; but
+she answered only in monosyllables.  Had it not been for my promise to
+the innkeeper, she would, I think, have urged me to stay in
+Leatherhead that night.  Would that I had!  Her face, I remember, was
+very white as we parted.
+
+For my own part, I had been feverishly excited all day.  Something
+very like the war fever that occasionally runs through a civilised
+community had got into my blood, and in my heart I was not so very
+sorry that I had to return to Maybury that night.  I was even afraid
+that that last fusillade I had heard might mean the extermination of
+our invaders from Mars.  I can best express my state of mind by saying
+that I wanted to be in at the death.
+
+It was nearly eleven when I started to return.  The night was
+unexpectedly dark; to me, walking out of the lighted passage of my
+cousins' house, it seemed indeed black, and it was as hot and close as
+the day.  Overhead the clouds were driving fast, albeit not a breath
+stirred the shrubs about us.  My cousins' man lit both lamps.  Happily,
+I knew the road intimately.  My wife stood in the light of the
+doorway, and watched me until I jumped up into the dog cart.  Then
+abruptly she turned and went in, leaving my cousins side by side
+wishing me good hap.
+
+I was a little depressed at first with the contagion of my wife's
+fears, but very soon my thoughts reverted to the Martians.  At that
+time I was absolutely in the dark as to the course of the evening's
+fighting.  I did not know even the circumstances that had precipitated
+the conflict.  As I came through Ockham (for that was the way I
+returned, and not through Send and Old Woking) I saw along the western
+horizon a blood-red glow, which as I drew nearer, crept slowly up the
+sky.  The driving clouds of the gathering thunderstorm mingled there
+with masses of black and red smoke.
+
+Ripley Street was deserted, and except for a lighted window or so
+the village showed not a sign of life; but I narrowly escaped an
+accident at the corner of the road to Pyrford, where a knot of people
+stood with their backs to me.  They said nothing to me as I passed.  I
+do not know what they knew of the things happening beyond the hill,
+nor do I know if the silent houses I passed on my way were sleeping
+securely, or deserted and empty, or harassed and watching against the
+terror of the night.
+
+From Ripley until I came through Pyrford I was in the valley of the
+Wey, and the red glare was hidden from me.  As I ascended the little
+hill beyond Pyrford Church the glare came into view again, and the
+trees about me shivered with the first intimation of the storm that
+was upon me.  Then I heard midnight pealing out from Pyrford Church
+behind me, and then came the silhouette of Maybury Hill, with its
+tree-tops and roofs black and sharp against the red.
+
+Even as I beheld this a lurid green glare lit the road about me and
+showed the distant woods towards Addlestone.  I felt a tug at the
+reins.  I saw that the driving clouds had been pierced as it were by a
+thread of green fire, suddenly lighting their confusion and falling
+into the field to my left.  It was the third falling star!
+
+Close on its apparition, and blindingly violet by contrast, danced
+out the first lightning of the gathering storm, and the thunder burst
+like a rocket overhead.  The horse took the bit between his teeth and
+bolted.
+
+A moderate incline runs towards the foot of Maybury Hill, and down
+this we clattered.  Once the lightning had begun, it went on in as
+rapid a succession of flashes as I have ever seen.  The thunderclaps,
+treading one on the heels of another and with a strange crackling
+accompaniment, sounded more like the working of a gigantic electric
+machine than the usual detonating reverberations.  The flickering
+light was blinding and confusing, and a thin hail smote gustily at my
+face as I drove down the slope.
+
+At first I regarded little but the road before me, and then
+abruptly my attention was arrested by something that was moving
+rapidly down the opposite slope of Maybury Hill.  At first I took it
+for the wet roof of a house, but one flash following another showed it
+to be in swift rolling movement.  It was an elusive vision--a moment
+of bewildering darkness, and then, in a flash like daylight, the red
+masses of the Orphanage near the crest of the hill, the green tops of
+the pine trees, and this problematical object came out clear and sharp
+and bright.
+
+And this Thing I saw!  How can I describe it?  A monstrous tripod,
+higher than many houses, striding over the young pine trees, and
+smashing them aside in its career; a walking engine of glittering
+metal, striding now across the heather; articulate ropes of steel
+dangling from it, and the clattering tumult of its passage mingling
+with the riot of the thunder.  A flash, and it came out vividly,
+heeling over one way with two feet in the air, to vanish and reappear
+almost instantly as it seemed, with the next flash, a hundred yards
+nearer.  Can you imagine a milking stool tilted and bowled violently
+along the ground?  That was the impression those instant flashes gave.
+But instead of a milking stool imagine it a great body of machinery on
+a tripod stand.
+
+Then suddenly the trees in the pine wood ahead of me were parted,
+as brittle reeds are parted by a man thrusting through them; they were
+snapped off and driven headlong, and a second huge tripod appeared,
+rushing, as it seemed, headlong towards me.  And I was galloping hard
+to meet it! At the sight of the second monster my nerve went
+altogether.  Not stopping to look again, I wrenched the horse's head
+hard round to the right and in another moment the dog cart had heeled
+over upon the horse; the shafts smashed noisily, and I was flung
+sideways and fell heavily into a shallow pool of water.
+
+I crawled out almost immediately, and crouched, my feet still in
+the water, under a clump of furze.  The horse lay motionless (his neck
+was broken, poor brute!) and by the lightning flashes I saw the black
+bulk of the overturned dog cart and the silhouette of the wheel still
+spinning slowly.  In another moment the colossal mechanism went
+striding by me, and passed uphill towards Pyrford.
+
+Seen nearer, the Thing was incredibly strange, for it was no mere
+insensate machine driving on its way.  Machine it was, with a ringing
+metallic pace, and long, flexible, glittering tentacles (one of which
+gripped a young pine tree) swinging and rattling about its strange
+body.  It picked its road as it went striding along, and the brazen
+hood that surmounted it moved to and fro with the inevitable
+suggestion of a head looking about.  Behind the main body was a huge
+mass of white metal like a gigantic fisherman's basket, and puffs of
+green smoke squirted out from the joints of the limbs as the monster
+swept by me.  And in an instant it was gone.
+
+So much I saw then, all vaguely for the flickering of the
+lightning, in blinding highlights and dense black shadows.
+
+As it passed it set up an exultant deafening howl that drowned the
+thunder--"Aloo!  Aloo!"--and in another minute it was with its
+companion, half a mile away, stooping over something in the field.  I
+have no doubt this Thing in the field was the third of the ten
+cylinders they had fired at us from Mars.
+
+For some minutes I lay there in the rain and darkness watching, by
+the intermittent light, these monstrous beings of metal moving about
+in the distance over the hedge tops.  A thin hail was now beginning,
+and as it came and went their figures grew misty and then flashed into
+clearness again.  Now and then came a gap in the lightning, and the
+night swallowed them up.
+
+I was soaked with hail above and puddle water below.  It was some
+time before my blank astonishment would let me struggle up the bank to
+a drier position, or think at all of my imminent peril.
+
+Not far from me was a little one-roomed squatter's hut of wood,
+surrounded by a patch of potato garden.  I struggled to my feet at
+last, and, crouching and making use of every chance of cover, I made a
+run for this.  I hammered at the door, but I could not make the people
+hear (if there were any people inside), and after a time I desisted,
+and, availing myself of a ditch for the greater part of the way,
+succeeded in crawling, unobserved by these monstrous machines, into
+the pine woods towards Maybury.
+
+Under cover of this I pushed on, wet and shivering now, towards my
+own house.  I walked among the trees trying to find the footpath.  It
+was very dark indeed in the wood, for the lightning was now becoming
+infrequent, and the hail, which was pouring down in a torrent, fell in
+columns through the gaps in the heavy foliage.
+
+If I had fully realised the meaning of all the things I had seen I
+should have immediately worked my way round through Byfleet to Street
+Cobham, and so gone back to rejoin my wife at Leatherhead.  But that
+night the strangeness of things about me, and my physical
+wretchedness, prevented me, for I was bruised, weary, wet to the skin,
+deafened and blinded by the storm.
+
+I had a vague idea of going on to my own house, and that was as
+much motive as I had.  I staggered through the trees, fell into a
+ditch and bruised my knees against a plank, and finally splashed out
+into the lane that ran down from the College Arms.  I say splashed,
+for the storm water was sweeping the sand down the hill in a muddy
+torrent.  There in the darkness a man blundered into me and sent me
+reeling back.
+
+He gave a cry of terror, sprang sideways, and rushed on before I
+could gather my wits sufficiently to speak to him.  So heavy was the
+stress of the storm just at this place that I had the hardest task to
+win my way up the hill.  I went close up to the fence on the left and
+worked my way along its palings.
+
+Near the top I stumbled upon something soft, and, by a flash of
+lightning, saw between my feet a heap of black broadcloth and a pair
+of boots.  Before I could distinguish clearly how the man lay, the
+flicker of light had passed.  I stood over him waiting for the next
+flash.  When it came, I saw that he was a sturdy man, cheaply but not
+shabbily dressed; his head was bent under his body, and he lay
+crumpled up close to the fence, as though he had been flung violently
+against it.
+
+Overcoming the repugnance natural to one who had never before
+touched a dead body, I stooped and turned him over to feel for his
+heart.  He was quite dead.  Apparently his neck had been broken.  The
+lightning flashed for a third time, and his face leaped upon me.  I
+sprang to my feet.  It was the landlord of the Spotted Dog, whose
+conveyance I had taken.
+
+I stepped over him gingerly and pushed on up the hill.  I made my
+way by the police station and the College Arms towards my own house.
+Nothing was burning on the hillside, though from the common there
+still came a red glare and a rolling tumult of ruddy smoke beating up
+against the drenching hail.  So far as I could see by the flashes, the
+houses about me were mostly uninjured.  By the College Arms a dark
+heap lay in the road.
+
+Down the road towards Maybury Bridge there were voices and the
+sound of feet, but I had not the courage to shout or to go to them.  I
+let myself in with my latchkey, closed, locked and bolted the door,
+staggered to the foot of the staircase, and sat down.  My imagination
+was full of those striding metallic monsters, and of the dead body
+smashed against the fence.
+
+I crouched at the foot of the staircase with my back to the wall,
+shivering violently.
+
+
+
+CHAPTER ELEVEN
+
+AT THE WINDOW
+
+
+I have already said that my storms of emotion have a trick of
+exhausting themselves.  After a time I discovered that I was cold and
+wet, and with little pools of water about me on the stair carpet.  I
+got up almost mechanically, went into the dining room and drank some
+whiskey, and then I was moved to change my clothes.
+
+After I had done that I went upstairs to my study, but why I did so
+I do not know.  The window of my study looks over the trees and the
+railway towards Horsell Common.  In the hurry of our departure this
+window had been left open.  The passage was dark, and, by contrast with
+the picture the window frame enclosed, the side of the room seemed
+impenetrably dark.  I stopped short in the doorway.
+
+The thunderstorm had passed.  The towers of the Oriental College
+and the pine trees about it had gone, and very far away, lit by a
+vivid red glare, the common about the sand pits was visible.  Across
+the light huge black shapes, grotesque and strange, moved busily to
+and fro.
+
+It seemed indeed as if the whole country in that direction was on
+fire--a broad hillside set with minute tongues of flame, swaying and
+writhing with the gusts of the dying storm, and throwing a red
+reflection upon the cloud-scud above.  Every now and then a haze of
+smoke from some nearer conflagration drove across the window and hid
+the Martian shapes.  I could not see what they were doing, nor the
+clear form of them, nor recognise the black objects they were busied
+upon.  Neither could I see the nearer fire, though the reflections of
+it danced on the wall and ceiling of the study.  A sharp, resinous
+tang of burning was in the air.
+
+I closed the door noiselessly and crept towards the window.  As I
+did so, the view opened out until, on the one hand, it reached to the
+houses about Woking station, and on the other to the charred and
+blackened pine woods of Byfleet.  There was a light down below the
+hill, on the railway, near the arch, and several of the houses along
+the Maybury road and the streets near the station were glowing ruins.
+The light upon the railway puzzled me at first; there were a black
+heap and a vivid glare, and to the right of that a row of yellow
+oblongs.  Then I perceived this was a wrecked train, the fore part
+smashed and on fire, the hinder carriages still upon the rails.
+
+Between these three main centres of light--the houses, the train,
+and the burning county towards Chobham--stretched irregular patches of
+dark country, broken here and there by intervals of dimly glowing and
+smoking ground.  It was the strangest spectacle, that black expanse set
+with fire.  It reminded me, more than anything else, of the Potteries
+at night.  At first I could distinguish no people at all, though I
+peered intently for them.  Later I saw against the light of Woking
+station a number of black figures hurrying one after the other across
+the line.
+
+And this was the little world in which I had been living securely
+for years, this fiery chaos!  What had happened in the last seven
+hours I still did not know; nor did I know, though I was beginning to
+guess, the relation between these mechanical colossi and the sluggish
+lumps I had seen disgorged from the cylinder.  With a queer feeling of
+impersonal interest I turned my desk chair to the window, sat down,
+and stared at the blackened country, and particularly at the three
+gigantic black things that were going to and fro in the glare about
+the sand pits.
+
+They seemed amazingly busy.  I began to ask myself what they could
+be.  Were they intelligent mechanisms?  Such a thing I felt was
+impossible.  Or did a Martian sit within each, ruling, directing,
+using, much as a man's brain sits and rules in his body?  I began to
+compare the things to human machines, to ask myself for the first time
+in my life how an ironclad or a steam engine would seem to an
+intelligent lower animal.
+
+The storm had left the sky clear, and over the smoke of the burning
+land the little fading pinpoint of Mars was dropping into the west,
+when a soldier came into my garden.  I heard a slight scraping at the
+fence, and rousing myself from the lethargy that had fallen upon me, I
+looked down and saw him dimly, clambering over the palings.  At the
+sight of another human being my torpor passed, and I leaned out of the
+window eagerly.
+
+"Hist!" said I, in a whisper.
+
+He stopped astride of the fence in doubt.  Then he came over and
+across the lawn to the corner of the house.  He bent down and stepped
+softly.
+
+"Who's there?" he said, also whispering, standing under the window
+and peering up.
+
+"Where are you going?" I asked.
+
+"God knows."
+
+"Are you trying to hide?"
+
+"That's it."
+
+"Come into the house," I said.
+
+I went down, unfastened the door, and let him in, and locked the
+door again.  I could not see his face.  He was hatless, and his coat
+was unbuttoned.
+
+"My God!" he said, as I drew him in.
+
+"What has happened?" I asked.
+
+"What hasn't?"  In the obscurity I could see he made a gesture of
+despair.  "They wiped us out--simply wiped us out," he repeated again
+and again.
+
+He followed me, almost mechanically, into the dining room.
+
+"Take some whiskey," I said, pouring out a stiff dose.
+
+He drank it.  Then abruptly he sat down before the table, put his
+head on his arms, and began to sob and weep like a little boy, in a
+perfect passion of emotion, while I, with a curious forgetfulness of
+my own recent despair, stood beside him, wondering.
+
+It was a long time before he could steady his nerves to answer my
+questions, and then he answered perplexingly and brokenly.  He was a
+driver in the artillery, and had only come into action about seven.  At
+that time firing was going on across the common, and it was said the
+first party of Martians were crawling slowly towards their second
+cylinder under cover of a metal shield.
+
+Later this shield staggered up on tripod legs and became the first
+of the fighting-machines I had seen.  The gun he drove had been
+unlimbered near Horsell, in order to command the sand pits, and its
+arrival it was that had precipitated the action.  As the limber
+gunners went to the rear, his horse trod in a rabbit hole and came
+down, throwing him into a depression of the ground.  At the same
+moment the gun exploded behind him, the ammunition blew up, there was
+fire all about him, and he found himself lying under a heap of charred
+dead men and dead horses.
+
+"I lay still," he said, "scared out of my wits, with the fore quarter
+of a horse atop of me.  We'd been wiped out.  And the smell--good
+God!  Like burnt meat!  I was hurt across the back by the fall of
+the horse, and there I had to lie until I felt better.  Just like
+parade it had been a minute before--then stumble, bang, swish!"
+
+"Wiped out!" he said.
+
+He had hid under the dead horse for a long time, peeping out
+furtively across the common.  The Cardigan men had tried a rush, in
+skirmishing order, at the pit, simply to be swept out of existence.
+Then the monster had risen to its feet and had begun to walk leisurely
+to and fro across the common among the few fugitives, with its
+headlike hood turning about exactly like the head of a cowled human
+being.  A kind of arm carried a complicated metallic case, about which
+green flashes scintillated, and out of the funnel of this there smoked
+the Heat-Ray.
+
+In a few minutes there was, so far as the soldier could see, not a
+living thing left upon the common, and every bush and tree upon it
+that was not already a blackened skeleton was burning.  The hussars
+had been on the road beyond the curvature of the ground, and he saw
+nothing of them.  He heard the Martians rattle for a time and then
+become still.  The giant saved Woking station and its cluster of houses
+until the last; then in a moment the Heat-Ray was brought to bear, and
+the town became a heap of fiery ruins.  Then the Thing shut off the
+Heat-Ray, and turning its back upon the artilleryman, began to waddle
+away towards the smouldering pine woods that sheltered the second
+cylinder.  As it did so a second glittering Titan built itself up out
+of the pit.
+
+The second monster followed the first, and at that the artilleryman
+began to crawl very cautiously across the hot heather ash towards
+Horsell.  He managed to get alive into the ditch by the side of the
+road, and so escaped to Woking.  There his story became ejaculatory.
+The place was impassable.  It seems there were a few people alive
+there, frantic for the most part and many burned and scalded.  He was
+turned aside by the fire, and hid among some almost scorching heaps of
+broken wall as one of the Martian giants returned.  He saw this one
+pursue a man, catch him up in one of its steely tentacles, and knock
+his head against the trunk of a pine tree.  At last, after nightfall,
+the artilleryman made a rush for it and got over the railway
+embankment.
+
+Since then he had been skulking along towards Maybury, in the hope
+of getting out of danger Londonward.  People were hiding in trenches
+and cellars, and many of the survivors had made off towards Woking
+village and Send.  He had been consumed with thirst until he found one
+of the water mains near the railway arch smashed, and the water
+bubbling out like a spring upon the road.
+
+That was the story I got from him, bit by bit.  He grew calmer
+telling me and trying to make me see the things he had seen.  He had
+eaten no food since midday, he told me early in his narrative, and I
+found some mutton and bread in the pantry and brought it into the
+room.  We lit no lamp for fear of attracting the Martians, and ever
+and again our hands would touch upon bread or meat.  As he talked,
+things about us came darkly out of the darkness, and the trampled
+bushes and broken rose trees outside the window grew distinct.  It
+would seem that a number of men or animals had rushed across the lawn.
+I began to see his face, blackened and haggard, as no doubt mine was
+also.
+
+When we had finished eating we went softly upstairs to my study,
+and I looked again out of the open window.  In one night the valley
+had become a valley of ashes.  The fires had dwindled now.  Where
+flames had been there were now streamers of smoke; but the countless
+ruins of shattered and gutted houses and blasted and blackened trees
+that the night had hidden stood out now gaunt and terrible in the
+pitiless light of dawn.  Yet here and there some object had had the
+luck to escape--a white railway signal here, the end of a greenhouse
+there, white and fresh amid the wreckage.  Never before in the history
+of warfare had destruction been so indiscriminate and so universal.
+And shining with the growing light of the east, three of the metallic
+giants stood about the pit, their cowls rotating as though they were
+surveying the desolation they had made.
+
+It seemed to me that the pit had been enlarged, and ever and again
+puffs of vivid green vapour streamed up and out of it towards the
+brightening dawn--streamed up, whirled, broke, and vanished.
+
+Beyond were the pillars of fire about Chobham.  They became pillars
+of bloodshot smoke at the first touch of day.
+
+
+
+CHAPTER TWELVE
+
+WHAT I SAW OF THE DESTRUCTION OF WEYBRIDGE AND SHEPPERTON
+
+
+As the dawn grew brighter we withdrew from the window from which we
+had watched the Martians, and went very quietly downstairs.
+
+The artilleryman agreed with me that the house was no place to stay
+in.  He proposed, he said, to make his way Londonward, and thence
+rejoin his battery--No. 12, of the Horse Artillery.  My plan was to
+return at once to Leatherhead; and so greatly had the strength of the
+Martians impressed me that I had determined to take my wife to
+Newhaven, and go with her out of the country forthwith.  For I already
+perceived clearly that the country about London must inevitably be the
+scene of a disastrous struggle before such creatures as these could be
+destroyed.
+
+Between us and Leatherhead, however, lay the third cylinder, with
+its guarding giants.  Had I been alone, I think I should have taken my
+chance and struck across country.  But the artilleryman dissuaded me:
+"It's no kindness to the right sort of wife," he said, "to make her a
+widow"; and in the end I agreed to go with him, under cover of the
+woods, northward as far as Street Cobham before I parted with him.
+Thence I would make a big detour by Epsom to reach Leatherhead.
+
+I should have started at once, but my companion had been in active
+service and he knew better than that.  He made me ransack the house
+for a flask, which he filled with whiskey; and we lined every
+available pocket with packets of biscuits and slices of meat.  Then
+we crept out of the house, and ran as quickly as we could down the
+ill-made road by which I had come overnight.  The houses seemed
+deserted. In the road lay a group of three charred bodies close
+together, struck dead by the Heat-Ray; and here and there were things
+that people had dropped--a clock, a slipper, a silver spoon, and the
+like poor valuables.  At the corner turning up towards the post
+office a little cart, filled with boxes and furniture, and horseless,
+heeled over on a broken wheel.  A cash box had been hastily smashed
+open and thrown under the debris.
+
+Except the lodge at the Orphanage, which was still on fire, none of
+the houses had suffered very greatly here.  The Heat-Ray had shaved
+the chimney tops and passed.  Yet, save ourselves, there did not seem
+to be a living soul on Maybury Hill.  The majority of the inhabitants
+had escaped, I suppose, by way of the Old Woking road--the road I had
+taken when I drove to Leatherhead--or they had hidden.
+
+We went down the lane, by the body of the man in black, sodden now
+from the overnight hail, and broke into the woods at the foot of the
+hill.  We pushed through these towards the railway without meeting a
+soul.  The woods across the line were but the scarred and blackened
+ruins of woods; for the most part the trees had fallen, but a certain
+proportion still stood, dismal grey stems, with dark brown foliage
+instead of green.
+
+On our side the fire had done no more than scorch the nearer trees;
+it had failed to secure its footing.  In one place the woodmen had
+been at work on Saturday; trees, felled and freshly trimmed, lay in a
+clearing, with heaps of sawdust by the sawing-machine and its engine.
+Hard by was a temporary hut, deserted.  There was not a breath of wind
+this morning, and everything was strangely still.  Even the birds were
+hushed, and as we hurried along I and the artilleryman talked in
+whispers and looked now and again over our shoulders.  Once or twice
+we stopped to listen.
+
+After a time we drew near the road, and as we did so we heard the
+clatter of hoofs and saw through the tree stems three cavalry soldiers
+riding slowly towards Woking.  We hailed them, and they halted while
+we hurried towards them.  It was a lieutenant and a couple of privates
+of the 8th Hussars, with a stand like a theodolite, which the
+artilleryman told me was a heliograph.
+
+"You are the first men I've seen coming this way this morning,"
+said the lieutenant.  "What's brewing?"
+
+His voice and face were eager.  The men behind him stared
+curiously.  The artilleryman jumped down the bank into the road and
+saluted.
+
+"Gun destroyed last night, sir.  Have been hiding.  Trying to
+rejoin battery, sir.  You'll come in sight of the Martians, I expect,
+about half a mile along this road."
+
+"What the dickens are they like?" asked the lieutenant.
+
+"Giants in armour, sir.  Hundred feet high.  Three legs and a body
+like 'luminium, with a mighty great head in a hood, sir."
+
+"Get out!" said the lieutenant.  "What confounded nonsense!"
+
+"You'll see, sir.  They carry a kind of box, sir, that shoots fire
+and strikes you dead."
+
+"What d'ye mean--a gun?"
+
+"No, sir," and the artilleryman began a vivid account of the Heat-Ray.
+Halfway through, the lieutenant interrupted him and looked up at
+me.  I was still standing on the bank by the side of the road.
+
+"It's perfectly true," I said.
+
+"Well," said the lieutenant, "I suppose it's my business to see it
+too.  Look here"--to the artilleryman--"we're detailed here clearing
+people out of their houses.  You'd better go along and report yourself
+to Brigadier-General Marvin, and tell him all you know.  He's at
+Weybridge.  Know the way?"
+
+"I do," I said; and he turned his horse southward again.
+
+"Half a mile, you say?" said he.
+
+"At most," I answered, and pointed over the treetops southward.  He
+thanked me and rode on, and we saw them no more.
+
+Farther along we came upon a group of three women and two children
+in the road, busy clearing out a labourer's cottage.  They had
+got hold of a little hand truck, and were piling it up with
+unclean-looking bundles and shabby furniture.  They were all too
+assiduously engaged to talk to us as we passed.
+
+By Byfleet station we emerged from the pine trees, and found the
+country calm and peaceful under the morning sunlight.  We were far
+beyond the range of the Heat-Ray there, and had it not been for the
+silent desertion of some of the houses, the stirring movement of
+packing in others, and the knot of soldiers standing on the bridge
+over the railway and staring down the line towards Woking, the day
+would have seemed very like any other Sunday.
+
+Several farm waggons and carts were moving creakily along the road
+to Addlestone, and suddenly through the gate of a field we saw, across
+a stretch of flat meadow, six twelve-pounders standing neatly at equal
+distances pointing towards Woking.  The gunners stood by the guns
+waiting, and the ammunition waggons were at a business-like distance.
+The men stood almost as if under inspection.
+
+"That's good!" said I.  "They will get one fair shot, at any rate."
+
+The artilleryman hesitated at the gate.
+
+"I shall go on," he said.
+
+Farther on towards Weybridge, just over the bridge, there were a
+number of men in white fatigue jackets throwing up a long rampart, and
+more guns behind.
+
+"It's bows and arrows against the lightning, anyhow," said the
+artilleryman.  "They 'aven't seen that fire-beam yet."
+
+The officers who were not actively engaged stood and stared over
+the treetops southwestward, and the men digging would stop every now
+and again to stare in the same direction.
+
+Byfleet was in a tumult; people packing, and a score of hussars,
+some of them dismounted, some on horseback, were hunting them about.
+Three or four black government waggons, with crosses in white circles,
+and an old omnibus, among other vehicles, were being loaded in the
+village street.  There were scores of people, most of them
+sufficiently sabbatical to have assumed their best clothes.  The
+soldiers were having the greatest difficulty in making them realise
+the gravity of their position.  We saw one shrivelled old fellow with
+a huge box and a score or more of flower pots containing orchids,
+angrily expostulating with the corporal who would leave them behind.
+I stopped and gripped his arm.
+
+"Do you know what's over there?" I said, pointing at the pine tops
+that hid the Martians.
+
+"Eh?" said he, turning.  "I was explainin' these is vallyble."
+
+"Death!" I shouted.  "Death is coming!  Death!" and leaving him to
+digest that if he could, I hurried on after the artillery-man.  At the
+corner I looked back.  The soldier had left him, and he was still
+standing by his box, with the pots of orchids on the lid of it, and
+staring vaguely over the trees.
+
+No one in Weybridge could tell us where the headquarters were
+established; the whole place was in such confusion as I had never seen
+in any town before.  Carts, carriages everywhere, the most astonishing
+miscellany of conveyances and horseflesh.  The respectable inhabitants
+of the place, men in golf and boating costumes, wives prettily
+dressed, were packing, river-side loafers energetically helping,
+children excited, and, for the most part, highly delighted at this
+astonishing variation of their Sunday experiences.  In the midst of it
+all the worthy vicar was very pluckily holding an early celebration,
+and his bell was jangling out above the excitement.
+
+I and the artilleryman, seated on the step of the drinking
+fountain, made a very passable meal upon what we had brought with
+us. Patrols of soldiers--here no longer hussars, but grenadiers in
+white--were warning people to move now or to take refuge in their
+cellars as soon as the firing began.  We saw as we crossed the
+railway bridge that a growing crowd of people had assembled in and
+about the railway station, and the swarming platform was piled with
+boxes and packages. The ordinary traffic had been stopped, I believe,
+in order to allow of the passage of troops and guns to Chertsey, and
+I have heard since that a savage struggle occurred for places in the
+special trains that were put on at a later hour.
+
+We remained at Weybridge until midday, and at that hour we found
+ourselves at the place near Shepperton Lock where the Wey and Thames
+join.  Part of the time we spent helping two old women to pack a
+little cart.  The Wey has a treble mouth, and at this point boats are
+to be hired, and there was a ferry across the river.  On the
+Shepperton side was an inn with a lawn, and beyond that the tower of
+Shepperton Church--it has been replaced by a spire--rose above the
+trees.
+
+Here we found an excited and noisy crowd of fugitives.  As yet the
+flight had not grown to a panic, but there were already far more
+people than all the boats going to and fro could enable to cross.
+People came panting along under heavy burdens; one husband and wife
+were even carrying a small outhouse door between them, with some of
+their household goods piled thereon.  One man told us he meant to try
+to get away from Shepperton station.
+
+There was a lot of shouting, and one man was even jesting.  The idea
+people seemed to have here was that the Martians were simply
+formidable human beings, who might attack and sack the town, to be
+certainly destroyed in the end.  Every now and then people would
+glance nervously across the Wey, at the meadows towards Chertsey, but
+everything over there was still.
+
+Across the Thames, except just where the boats landed, everything
+was quiet, in vivid contrast with the Surrey side.  The people who
+landed there from the boats went tramping off down the lane.  The big
+ferryboat had just made a journey.  Three or four soldiers stood on
+the lawn of the inn, staring and jesting at the fugitives, without
+offering to help.  The inn was closed, as it was now within prohibited
+hours.
+
+"What's that?" cried a boatman, and "Shut up, you fool!" said a man
+near me to a yelping dog.  Then the sound came again, this time from
+the direction of Chertsey, a muffled thud--the sound of a gun.
+
+The fighting was beginning.  Almost immediately unseen batteries
+across the river to our right, unseen because of the trees, took up
+the chorus, firing heavily one after the other.  A woman screamed.
+Everyone stood arrested by the sudden stir of battle, near us and yet
+invisible to us.  Nothing was to be seen save flat meadows, cows
+feeding unconcernedly for the most part, and silvery pollard willows
+motionless in the warm sunlight.
+
+"The sojers'll stop 'em," said a woman beside me, doubtfully.  A
+haziness rose over the treetops.
+
+Then suddenly we saw a rush of smoke far away up the river, a puff
+of smoke that jerked up into the air and hung; and forthwith the
+ground heaved under foot and a heavy explosion shook the air, smashing
+two or three windows in the houses near, and leaving us astonished.
+
+"Here they are!" shouted a man in a blue jersey.  "Yonder! D'yer
+see them?  Yonder!"
+
+Quickly, one after the other, one, two, three, four of the armoured
+Martians appeared, far away over the little trees, across the flat
+meadows that stretched towards Chertsey, and striding hurriedly
+towards the river.  Little cowled figures they seemed at first, going
+with a rolling motion and as fast as flying birds.
+
+Then, advancing obliquely towards us, came a fifth.  Their armoured
+bodies glittered in the sun as they swept swiftly forward upon the
+guns, growing rapidly larger as they drew nearer.  One on the extreme
+left, the remotest that is, flourished a huge case high in the air,
+and the ghostly, terrible Heat-Ray I had already seen on Friday night
+smote towards Chertsey, and struck the town.
+
+At sight of these strange, swift, and terrible creatures the crowd
+near the water's edge seemed to me to be for a moment horror-struck.
+There was no screaming or shouting, but a silence.  Then a hoarse
+murmur and a movement of feet--a splashing from the water.  A man, too
+frightened to drop the portmanteau he carried on his shoulder, swung
+round and sent me staggering with a blow from the corner of his
+burden.  A woman thrust at me with her hand and rushed past me.  I
+turned with the rush of the people, but I was not too terrified for
+thought.  The terrible Heat-Ray was in my mind.  To get under water!
+That was it!
+
+"Get under water!" I shouted, unheeded.
+
+I faced about again, and rushed towards the approaching Martian,
+rushed right down the gravelly beach and headlong into the water.
+Others did the same.  A boatload of people putting back came leaping
+out as I rushed past.  The stones under my feet were muddy and
+slippery, and the river was so low that I ran perhaps twenty feet
+scarcely waist-deep.  Then, as the Martian towered overhead scarcely
+a couple of hundred yards away, I flung myself forward under the
+surface.  The splashes of the people in the boats leaping into the
+river sounded like thunderclaps in my ears.  People were landing
+hastily on both sides of the river.  But the Martian machine took no
+more notice for the moment of the people running this way and that
+than a man would of the confusion of ants in a nest against which his
+foot has kicked.  When, half suffocated, I raised my head above water,
+the Martian's hood pointed at the batteries that were still firing
+across the river, and as it advanced it swung loose what must have
+been the generator of the Heat-Ray.
+
+In another moment it was on the bank, and in a stride wading
+halfway across.  The knees of its foremost legs bent at the farther
+bank, and in another moment it had raised itself to its full height
+again, close to the village of Shepperton.  Forthwith the six guns
+which, unknown to anyone on the right bank, had been hidden behind the
+outskirts of that village, fired simultaneously.  The sudden near
+concussion, the last close upon the first, made my heart jump.  The
+monster was already raising the case generating the Heat-Ray as the
+first shell burst six yards above the hood.
+
+I gave a cry of astonishment.  I saw and thought nothing of the
+other four Martian monsters; my attention was riveted upon the nearer
+incident.  Simultaneously two other shells burst in the air near the
+body as the hood twisted round in time to receive, but not in time to
+dodge, the fourth shell.
+
+The shell burst clean in the face of the Thing.  The hood bulged,
+flashed, was whirled off in a dozen tattered fragments of red flesh
+and glittering metal.
+
+"Hit!" shouted I, with something between a scream and a cheer.
+
+I heard answering shouts from the people in the water about me.  I
+could have leaped out of the water with that momentary exultation.
+
+The decapitated colossus reeled like a drunken giant; but it did
+not fall over.  It recovered its balance by a miracle, and, no longer
+heeding its steps and with the camera that fired the Heat-Ray now
+rigidly upheld, it reeled swiftly upon Shepperton.  The living
+intelligence, the Martian within the hood, was slain and splashed to
+the four winds of heaven, and the Thing was now but a mere intricate
+device of metal whirling to destruction.  It drove along in a straight
+line, incapable of guidance.  It struck the tower of Shepperton
+Church, smashing it down as the impact of a battering ram might have
+done, swerved aside, blundered on and collapsed with tremendous force
+into the river out of my sight.
+
+A violent explosion shook the air, and a spout of water, steam,
+mud, and shattered metal shot far up into the sky.  As the camera of
+the Heat-Ray hit the water, the latter had immediately flashed into
+steam.  In another moment a huge wave, like a muddy tidal bore but
+almost scaldingly hot, came sweeping round the bend upstream.  I saw
+people struggling shorewards, and heard their screaming and shouting
+faintly above the seething and roar of the Martian's collapse.
+
+For a moment I heeded nothing of the heat, forgot the patent need
+of self-preservation.  I splashed through the tumultuous water,
+pushing aside a man in black to do so, until I could see round the
+bend.  Half a dozen deserted boats pitched aimlessly upon the
+confusion of the waves.  The fallen Martian came into sight
+downstream, lying across the river, and for the most part submerged.
+
+Thick clouds of steam were pouring off the wreckage, and through
+the tumultuously whirling wisps I could see, intermittently and
+vaguely, the gigantic limbs churning the water and flinging a splash
+and spray of mud and froth into the air.  The tentacles swayed and
+struck like living arms, and, save for the helpless purposelessness of
+these movements, it was as if some wounded thing were struggling for
+its life amid the waves.  Enormous quantities of a ruddy-brown fluid
+were spurting up in noisy jets out of the machine.
+
+My attention was diverted from this death flurry by a furious
+yelling, like that of the thing called a siren in our manufacturing
+towns.  A man, knee-deep near the towing path, shouted inaudibly to me
+and pointed.  Looking back, I saw the other Martians advancing with
+gigantic strides down the riverbank from the direction of Chertsey.
+The Shepperton guns spoke this time unavailingly.
+
+At that I ducked at once under water, and, holding my breath until
+movement was an agony, blundered painfully ahead under the surface as
+long as I could.  The water was in a tumult about me, and rapidly
+growing hotter.
+
+When for a moment I raised my head to take breath and throw the
+hair and water from my eyes, the steam was rising in a whirling white
+fog that at first hid the Martians altogether.  The noise was
+deafening.  Then I saw them dimly, colossal figures of grey, magnified
+by the mist.  They had passed by me, and two were stooping over the
+frothing, tumultuous ruins of their comrade.
+
+The third and fourth stood beside him in the water, one perhaps two
+hundred yards from me, the other towards Laleham.  The generators of
+the Heat-Rays waved high, and the hissing beams smote down this way
+and that.
+
+The air was full of sound, a deafening and confusing conflict of
+noises--the clangorous din of the Martians, the crash of falling
+houses, the thud of trees, fences, sheds flashing into flame, and the
+crackling and roaring of fire.  Dense black smoke was leaping up to
+mingle with the steam from the river, and as the Heat-Ray went to and
+fro over Weybridge its impact was marked by flashes of incandescent
+white, that gave place at once to a smoky dance of lurid flames.  The
+nearer houses still stood intact, awaiting their fate, shadowy, faint
+and pallid in the steam, with the fire behind them going to and fro.
+
+For a moment perhaps I stood there, breast-high in the almost
+boiling water, dumbfounded at my position, hopeless of escape.  Through
+the reek I could see the people who had been with me in the river
+scrambling out of the water through the reeds, like little frogs
+hurrying through grass from the advance of a man, or running to and
+fro in utter dismay on the towing path.
+
+Then suddenly the white flashes of the Heat-Ray came leaping
+towards me.  The houses caved in as they dissolved at its touch, and
+darted out flames; the trees changed to fire with a roar.  The Ray
+flickered up and down the towing path, licking off the people who ran
+this way and that, and came down to the water's edge not fifty yards
+from where I stood.  It swept across the river to Shepperton, and the
+water in its track rose in a boiling weal crested with steam.  I
+turned shoreward.
+
+In another moment the huge wave, well-nigh at the boiling-point had
+rushed upon me.  I screamed aloud, and scalded, half blinded,
+agonised, I staggered through the leaping, hissing water towards the
+shore.  Had my foot stumbled, it would have been the end.  I fell
+helplessly, in full sight of the Martians, upon the broad, bare
+gravelly spit that runs down to mark the angle of the Wey and Thames.
+I expected nothing but death.
+
+I have a dim memory of the foot of a Martian coming down within a
+score of yards of my head, driving straight into the loose gravel,
+whirling it this way and that and lifting again; of a long suspense,
+and then of the four carrying the debris of their comrade between
+them, now clear and then presently faint through a veil of smoke,
+receding interminably, as it seemed to me, across a vast space of
+river and meadow.  And then, very slowly, I realised that by a miracle
+I had escaped.
+
+
+
+CHAPTER THIRTEEN
+
+HOW I FELL IN WITH THE CURATE
+
+
+After getting this sudden lesson in the power of terrestrial
+weapons, the Martians retreated to their original position upon
+Horsell Common; and in their haste, and encumbered with the debris of
+their smashed companion, they no doubt overlooked many such a stray
+and negligible victim as myself.  Had they left their comrade and
+pushed on forthwith, there was nothing at that time between them and
+London but batteries of twelve-pounder guns, and they would certainly
+have reached the capital in advance of the tidings of their approach;
+as sudden, dreadful, and destructive their advent would have been as
+the earthquake that destroyed Lisbon a century ago.
+
+But they were in no hurry.  Cylinder followed cylinder on its
+interplanetary flight; every twenty-four hours brought them
+reinforcement.  And meanwhile the military and naval authorities, now
+fully alive to the tremendous power of their antagonists, worked with
+furious energy.  Every minute a fresh gun came into position until,
+before twilight, every copse, every row of suburban villas on the
+hilly slopes about Kingston and Richmond, masked an expectant black
+muzzle.  And through the charred and desolated area--perhaps twenty
+square miles altogether--that encircled the Martian encampment on
+Horsell Common, through charred and ruined villages among the green
+trees, through the blackened and smoking arcades that had been but a
+day ago pine spinneys, crawled the devoted scouts with the heliographs
+that were presently to warn the gunners of the Martian approach.  But
+the Martians now understood our command of artillery and the danger of
+human proximity, and not a man ventured within a mile of either
+cylinder, save at the price of his life.
+
+It would seem that these giants spent the earlier part of the
+afternoon in going to and fro, transferring everything from the second
+and third cylinders--the second in Addlestone Golf Links and the third
+at Pyrford--to their original pit on Horsell Common.  Over that, above
+the blackened heather and ruined buildings that stretched far and
+wide, stood one as sentinel, while the rest abandoned their vast
+fighting-machines and descended into the pit.  They were hard at work
+there far into the night, and the towering pillar of dense green smoke
+that rose therefrom could be seen from the hills about Merrow, and
+even, it is said, from Banstead and Epsom Downs.
+
+And while the Martians behind me were thus preparing for their next
+sally, and in front of me Humanity gathered for the battle, I made my
+way with infinite pains and labour from the fire and smoke of burning
+Weybridge towards London.
+
+I saw an abandoned boat, very small and remote, drifting down-stream;
+and throwing off the most of my sodden clothes, I went after it,
+gained it, and so escaped out of that destruction.  There were no
+oars in the boat, but I contrived to paddle, as well as my parboiled
+hands would allow, down the river towards Halliford and Walton, going
+very tediously and continually looking behind me, as you may well
+understand.  I followed the river, because I considered that the water
+gave me my best chance of escape should these giants return.
+
+The hot water from the Martian's overthrow drifted downstream with
+me, so that for the best part of a mile I could see little of either
+bank.  Once, however, I made out a string of black figures hurrying
+across the meadows from the direction of Weybridge.  Halliford, it
+seemed, was deserted, and several of the houses facing the river were
+on fire.  It was strange to see the place quite tranquil, quite
+desolate under the hot blue sky, with the smoke and little threads of
+flame going straight up into the heat of the afternoon.  Never before
+had I seen houses burning without the accompaniment of an obstructive
+crowd.  A little farther on the dry reeds up the bank were smoking and
+glowing, and a line of fire inland was marching steadily across a late
+field of hay.
+
+For a long time I drifted, so painful and weary was I after the
+violence I had been through, and so intense the heat upon the water.
+Then my fears got the better of me again, and I resumed my paddling.
+The sun scorched my bare back.  At last, as the bridge at Walton was
+coming into sight round the bend, my fever and faintness overcame my
+fears, and I landed on the Middlesex bank and lay down, deadly sick,
+amid the long grass.  I suppose the time was then about four or five
+o'clock.  I got up presently, walked perhaps half a mile without
+meeting a soul, and then lay down again in the shadow of a hedge.  I
+seem to remember talking, wanderingly, to myself during that last
+spurt.  I was also very thirsty, and bitterly regretful I had drunk no
+more water.  It is a curious thing that I felt angry with my wife; I
+cannot account for it, but my impotent desire to reach Leatherhead
+worried me excessively.
+
+I do not clearly remember the arrival of the curate, so that probably
+I dozed.  I became aware of him as a seated figure in soot-smudged
+shirt sleeves, and with his upturned, clean-shaven face staring at
+a faint flickering that danced over the sky.  The sky was what is
+called a mackerel sky--rows and rows of faint down-plumes of
+cloud, just tinted with the midsummer sunset.
+
+I sat up, and at the rustle of my motion he looked at me quickly.
+
+"Have you any water?" I asked abruptly.
+
+He shook his head.
+
+"You have been asking for water for the last hour," he said.
+
+For a moment we were silent, taking stock of each other.  I
+dare say he found me a strange enough figure, naked, save for my
+water-soaked trousers and socks, scalded, and my face and shoulders
+blackened by the smoke.  His face was a fair weakness, his chin
+retreated, and his hair lay in crisp, almost flaxen curls on his low
+forehead; his eyes were rather large, pale blue, and blankly staring.
+He spoke abruptly, looking vacantly away from me.
+
+"What does it mean?" he said.  "What do these things mean?"
+
+I stared at him and made no answer.
+
+He extended a thin white hand and spoke in almost a complaining
+tone.
+
+"Why are these things permitted?  What sins have we done?  The
+morning service was over, I was walking through the roads to clear my
+brain for the afternoon, and then--fire, earthquake, death!  As if it
+were Sodom and Gomorrah!  All our work undone, all the work---- What
+are these Martians?"
+
+"What are we?" I answered, clearing my throat.
+
+He gripped his knees and turned to look at me again.  For half a
+minute, perhaps, he stared silently.
+
+"I was walking through the roads to clear my brain," he said.  "And
+suddenly--fire, earthquake, death!"
+
+He relapsed into silence, with his chin now sunken almost to his
+knees.
+
+Presently he began waving his hand.
+
+"All the work--all the Sunday schools--What have we done--what has
+Weybridge done?  Everything gone--everything destroyed.  The church!
+We rebuilt it only three years ago.  Gone!  Swept out of existence!
+Why?"
+
+Another pause, and he broke out again like one demented.
+
+"The smoke of her burning goeth up for ever and ever!" he shouted.
+
+His eyes flamed, and he pointed a lean finger in the direction of
+Weybridge.
+
+By this time I was beginning to take his measure.  The tremendous
+tragedy in which he had been involved--it was evident he was a
+fugitive from Weybridge--had driven him to the very verge of his
+reason.
+
+"Are we far from Sunbury?" I said, in a matter-of-fact tone.
+
+"What are we to do?" he asked.  "Are these creatures everywhere?
+Has the earth been given over to them?"
+
+"Are we far from Sunbury?"
+
+"Only this morning I officiated at early celebration----"
+
+"Things have changed," I said, quietly.  "You must keep your head.
+There is still hope."
+
+"Hope!"
+
+"Yes.  Plentiful hope--for all this destruction!"
+
+I began to explain my view of our position.  He listened at first,
+but as I went on the interest dawning in his eyes gave place to their
+former stare, and his regard wandered from me.
+
+"This must be the beginning of the end," he said, interrupting me.
+"The end!  The great and terrible day of the Lord!  When men shall
+call upon the mountains and the rocks to fall upon them and hide
+them--hide them from the face of Him that sitteth upon the throne!"
+
+I began to understand the position.  I ceased my laboured
+reasoning, struggled to my feet, and, standing over him, laid my hand
+on his shoulder.
+
+"Be a man!" said I.  "You are scared out of your wits!  What good
+is religion if it collapses under calamity?  Think of what earthquakes
+and floods, wars and volcanoes, have done before to men!  Did you
+think God had exempted Weybridge?  He is not an insurance agent."
+
+For a time he sat in blank silence.
+
+"But how can we escape?" he asked, suddenly.  "They are
+invulnerable, they are pitiless."
+
+"Neither the one nor, perhaps, the other," I answered. "And the
+mightier they are the more sane and wary should we be.  One of them
+was killed yonder not three hours ago."
+
+"Killed!" he said, staring about him.  "How can God's ministers be
+killed?"
+
+"I saw it happen." I proceeded to tell him.  "We have chanced to
+come in for the thick of it," said I, "and that is all."
+
+"What is that flicker in the sky?" he asked abruptly.
+
+I told him it was the heliograph signalling--that it was the sign
+of human help and effort in the sky.
+
+"We are in the midst of it," I said, "quiet as it is.  That flicker
+in the sky tells of the gathering storm.  Yonder, I take it are the
+Martians, and Londonward, where those hills rise about Richmond and
+Kingston and the trees give cover, earthworks are being thrown up and
+guns are being placed.  Presently the Martians will be coming this way
+again."
+
+And even as I spoke he sprang to his feet and stopped me by a
+gesture.
+
+"Listen!" he said.
+
+From beyond the low hills across the water came the dull resonance
+of distant guns and a remote weird crying.  Then everything was still.
+A cockchafer came droning over the hedge and past us.  High in the
+west the crescent moon hung faint and pale above the smoke of
+Weybridge and Shepperton and the hot, still splendour of the sunset.
+
+"We had better follow this path," I said, "northward."
+
+
+
+CHAPTER FOURTEEN
+
+IN LONDON
+
+
+My younger brother was in London when the Martians fell at Woking.
+He was a medical student working for an imminent examination, and he
+heard nothing of the arrival until Saturday morning.  The morning
+papers on Saturday contained, in addition to lengthy special articles
+on the planet Mars, on life in the planets, and so forth, a brief and
+vaguely worded telegram, all the more striking for its brevity.
+
+The Martians, alarmed by the approach of a crowd, had killed a
+number of people with a quick-firing gun, so the story ran.  The
+telegram concluded with the words: "Formidable as they seem to be, the
+Martians have not moved from the pit into which they have fallen, and,
+indeed, seem incapable of doing so.  Probably this is due to the
+relative strength of the earth's gravitational energy."  On that last
+text their leader-writer expanded very comfortingly.
+
+Of course all the students in the crammer's biology class, to which
+my brother went that day, were intensely interested, but there were no
+signs of any unusual excitement in the streets.  The afternoon papers
+puffed scraps of news under big headlines.  They had nothing to tell
+beyond the movements of troops about the common, and the burning of
+the pine woods between Woking and Weybridge, until eight.  Then the
+_St. James's Gazette_, in an extra-special edition, announced the bare
+fact of the interruption of telegraphic communication.  This was
+thought to be due to the falling of burning pine trees across the
+line.  Nothing more of the fighting was known that night, the night of
+my drive to Leatherhead and back.
+
+My brother felt no anxiety about us, as he knew from the
+description in the papers that the cylinder was a good two miles from
+my house.  He made up his mind to run down that night to me, in order,
+as he says, to see the Things before they were killed.  He dispatched
+a telegram, which never reached me, about four o'clock, and spent the
+evening at a music hall.
+
+In London, also, on Saturday night there was a thunderstorm, and my
+brother reached Waterloo in a cab.  On the platform from which the
+midnight train usually starts he learned, after some waiting, that an
+accident prevented trains from reaching Woking that night.  The nature
+of the accident he could not ascertain; indeed, the railway
+authorities did not clearly know at that time.  There was very little
+excitement in the station, as the officials, failing to realise that
+anything further than a breakdown between Byfleet and Woking junction
+had occurred, were running the theatre trains which usually passed
+through Woking round by Virginia Water or Guildford.  They were busy
+making the necessary arrangements to alter the route of the
+Southampton and Portsmouth Sunday League excursions.  A nocturnal
+newspaper reporter, mistaking my brother for the traffic manager, to
+whom he bears a slight resemblance, waylaid and tried to interview
+him.  Few people, excepting the railway officials, connected the
+breakdown with the Martians.
+
+I have read, in another account of these events, that on Sunday
+morning "all London was electrified by the news from Woking."  As a
+matter of fact, there was nothing to justify that very extravagant
+phrase.  Plenty of Londoners did not hear of the Martians until the
+panic of Monday morning.  Those who did took some time to realise all
+that the hastily worded telegrams in the Sunday papers conveyed.  The
+majority of people in London do not read Sunday papers.
+
+The habit of personal security, moreover, is so deeply fixed in the
+Londoner's mind, and startling intelligence so much a matter of course
+in the papers, that they could read without any personal tremors:
+"About seven o'clock last night the Martians came out of the cylinder,
+and, moving about under an armour of metallic shields, have completely
+wrecked Woking station with the adjacent houses, and massacred an
+entire battalion of the Cardigan Regiment.  No details are known.
+Maxims have been absolutely useless against their armour; the field
+guns have been disabled by them.  Flying hussars have been galloping
+into Chertsey.  The Martians appear to be moving slowly towards
+Chertsey or Windsor.  Great anxiety prevails in West Surrey, and
+earthworks are being thrown up to check the advance Londonward."  That
+was how the Sunday _Sun_ put it, and a clever and remarkably prompt
+"handbook" article in the _Referee_ compared the affair to a menagerie
+suddenly let loose in a village.
+
+No one in London knew positively of the nature of the armoured
+Martians, and there was still a fixed idea that these monsters must be
+sluggish: "crawling," "creeping painfully"--such expressions occurred
+in almost all the earlier reports.  None of the telegrams could have
+been written by an eyewitness of their advance.  The Sunday papers
+printed separate editions as further news came to hand, some even in
+default of it.  But there was practically nothing more to tell people
+until late in the afternoon, when the authorities gave the press
+agencies the news in their possession.  It was stated that the people
+of Walton and Weybridge, and all the district were pouring along the
+roads Londonward, and that was all.
+
+My brother went to church at the Foundling Hospital in the morning,
+still in ignorance of what had happened on the previous night.  There
+he heard allusions made to the invasion, and a special prayer for
+peace.  Coming out, he bought a _Referee_.  He became alarmed at the
+news in this, and went again to Waterloo station to find out if
+communication were restored.  The omnibuses, carriages, cyclists, and
+innumerable people walking in their best clothes seemed scarcely
+affected by the strange intelligence that the news venders were
+disseminating.  People were interested, or, if alarmed, alarmed only
+on account of the local residents.  At the station he heard for the
+first time that the Windsor and Chertsey lines were now interrupted.
+The porters told him that several remarkable telegrams had been
+received in the morning from Byfleet and Chertsey stations, but that
+these had abruptly ceased.  My brother could get very little precise
+detail out of them.
+
+"There's fighting going on about Weybridge" was the extent of their
+information.
+
+The train service was now very much disorganised.  Quite a number
+of people who had been expecting friends from places on the
+South-Western network were standing about the station.  One
+grey-headed old gentleman came and abused the South-Western Company
+bitterly to my brother.  "It wants showing up," he said.
+
+One or two trains came in from Richmond, Putney, and Kingston,
+containing people who had gone out for a day's boating and found the
+locks closed and a feeling of panic in the air.  A man in a blue and
+white blazer addressed my brother, full of strange tidings.
+
+"There's hosts of people driving into Kingston in traps and carts
+and things, with boxes of valuables and all that," he said.  "They
+come from Molesey and Weybridge and Walton, and they say there's been
+guns heard at Chertsey, heavy firing, and that mounted soldiers have
+told them to get off at once because the Martians are coming.  We
+heard guns firing at Hampton Court station, but we thought it was
+thunder.  What the dickens does it all mean?  The Martians can't get
+out of their pit, can they?"
+
+My brother could not tell him.
+
+Afterwards he found that the vague feeling of alarm had spread to
+the clients of the underground railway, and that the Sunday
+excursionists began to return from all over the South-Western
+"lung"--Barnes, Wimbledon, Richmond Park, Kew, and so forth--at
+unnaturally early hours; but not a soul had anything more than vague
+hearsay to tell of.  Everyone connected with the terminus seemed
+ill-tempered.
+
+About five o'clock the gathering crowd in the station was immensely
+excited by the opening of the line of communication, which is almost
+invariably closed, between the South-Eastern and the South-Western
+stations, and the passage of carriage trucks bearing huge guns and
+carriages crammed with soldiers.  These were the guns that were
+brought up from Woolwich and Chatham to cover Kingston.  There was
+an exchange of pleasantries: "You'll get eaten!"  "We're the
+beast-tamers!" and so forth.  A little while after that a squad of
+police came into the station and began to clear the public off the
+platforms, and my brother went out into the street again.
+
+The church bells were ringing for evensong, and a squad of
+Salvation Army lassies came singing down Waterloo Road.  On the bridge
+a number of loafers were watching a curious brown scum that came
+drifting down the stream in patches.  The sun was just setting, and the
+Clock Tower and the Houses of Parliament rose against one of the most
+peaceful skies it is possible to imagine, a sky of gold, barred with
+long transverse stripes of reddish-purple cloud.  There was talk of a
+floating body.  One of the men there, a reservist he said he was, told
+my brother he had seen the heliograph flickering in the west.
+
+In Wellington Street my brother met a couple of sturdy roughs who
+had just been rushed out of Fleet Street with still-wet newspapers and
+staring placards.  "Dreadful catastrophe!" they bawled one to the
+other down Wellington Street.  "Fighting at Weybridge!  Full
+description!  Repulse of the Martians! London in Danger!"  He had to
+give threepence for a copy of that paper.
+
+Then it was, and then only, that he realised something of the full
+power and terror of these monsters.  He learned that they were not
+merely a handful of small sluggish creatures, but that they were minds
+swaying vast mechanical bodies; and that they could move swiftly and
+smite with such power that even the mightiest guns could not stand
+against them.
+
+They were described as "vast spiderlike machines, nearly a hundred
+feet high, capable of the speed of an express train, and able to shoot
+out a beam of intense heat."  Masked batteries, chiefly of field guns,
+had been planted in the country about Horsell Common, and especially
+between the Woking district and London.  Five of the machines had been
+seen moving towards the Thames, and one, by a happy chance, had been
+destroyed.  In the other cases the shells had missed, and the
+batteries had been at once annihilated by the Heat-Rays.  Heavy
+losses of soldiers were mentioned, but the tone of the dispatch was
+optimistic.
+
+The Martians had been repulsed; they were not invulnerable.  They
+had retreated to their triangle of cylinders again, in the circle
+about Woking.  Signallers with heliographs were pushing forward upon
+them from all sides.  Guns were in rapid transit from Windsor,
+Portsmouth, Aldershot, Woolwich--even from the north; among others,
+long wire-guns of ninety-five tons from Woolwich.  Altogether one
+hundred and sixteen were in position or being hastily placed, chiefly
+covering London.  Never before in England had there been such a vast
+or rapid concentration of military material.
+
+Any further cylinders that fell, it was hoped, could be destroyed
+at once by high explosives, which were being rapidly manufactured and
+distributed.  No doubt, ran the report, the situation was of the
+strangest and gravest description, but the public was exhorted to
+avoid and discourage panic.  No doubt the Martians were strange and
+terrible in the extreme, but at the outside there could not be more
+than twenty of them against our millions.
+
+The authorities had reason to suppose, from the size of the
+cylinders, that at the outside there could not be more than five in
+each cylinder--fifteen altogether.  And one at least was disposed
+of--perhaps more.  The public would be fairly warned of the approach
+of danger, and elaborate measures were being taken for the protection
+of the people in the threatened southwestern suburbs.  And so, with
+reiterated assurances of the safety of London and the ability of the
+authorities to cope with the difficulty, this quasi-proclamation
+closed.
+
+This was printed in enormous type on paper so fresh that it was
+still wet, and there had been no time to add a word of comment.  It
+was curious, my brother said, to see how ruthlessly the usual contents
+of the paper had been hacked and taken out to give this place.
+
+All down Wellington Street people could be seen fluttering out the
+pink sheets and reading, and the Strand was suddenly noisy with the
+voices of an army of hawkers following these pioneers.  Men came
+scrambling off buses to secure copies.  Certainly this news excited
+people intensely, whatever their previous apathy.  The shutters of a
+map shop in the Strand were being taken down, my brother said, and a
+man in his Sunday raiment, lemon-yellow gloves even, was visible
+inside the window hastily fastening maps of Surrey to the glass.
+
+Going on along the Strand to Trafalgar Square, the paper in his
+hand, my brother saw some of the fugitives from West Surrey.  There
+was a man with his wife and two boys and some articles of furniture in
+a cart such as greengrocers use.  He was driving from the direction of
+Westminster Bridge; and close behind him came a hay waggon with five
+or six respectable-looking people in it, and some boxes and bundles.
+The faces of these people were haggard, and their entire appearance
+contrasted conspicuously with the Sabbath-best appearance of the
+people on the omnibuses.  People in fashionable clothing peeped at
+them out of cabs.  They stopped at the Square as if undecided which
+way to take, and finally turned eastward along the Strand.  Some way
+behind these came a man in workday clothes, riding one of those
+old-fashioned tricycles with a small front wheel.  He was dirty and
+white in the face.
+
+My brother turned down towards Victoria, and met a number of such
+people.  He had a vague idea that he might see something of me.  He
+noticed an unusual number of police regulating the traffic.  Some of
+the refugees were exchanging news with the people on the omnibuses.
+One was professing to have seen the Martians.  "Boilers on stilts, I
+tell you, striding along like men."  Most of them were excited and
+animated by their strange experience.
+
+Beyond Victoria the public-houses were doing a lively trade with
+these arrivals.  At all the street corners groups of people were
+reading papers, talking excitedly, or staring at these unusual Sunday
+visitors.  They seemed to increase as night drew on, until at last the
+roads, my brother said, were like Epsom High Street on a Derby Day.  My
+brother addressed several of these fugitives and got unsatisfactory
+answers from most.
+
+None of them could tell him any news of Woking except one man, who
+assured him that Woking had been entirely destroyed on the previous
+night.
+
+"I come from Byfleet," he said; "man on a bicycle came through the
+place in the early morning, and ran from door to door warning us to
+come away.  Then came soldiers.  We went out to look, and there were
+clouds of smoke to the south--nothing but smoke, and not a soul coming
+that way.  Then we heard the guns at Chertsey, and folks coming from
+Weybridge.  So I've locked up my house and come on."
+
+At the time there was a strong feeling in the streets that the
+authorities were to blame for their incapacity to dispose of the
+invaders without all this inconvenience.
+
+About eight o'clock a noise of heavy firing was distinctly audible
+all over the south of London.  My brother could not hear it for the
+traffic in the main thoroughfares, but by striking through the quiet
+back streets to the river he was able to distinguish it quite plainly.
+
+He walked from Westminster to his apartments near Regent's Park,
+about two.  He was now very anxious on my account, and disturbed at
+the evident magnitude of the trouble.  His mind was inclined to run,
+even as mine had run on Saturday, on military details.  He thought of
+all those silent, expectant guns, of the suddenly nomadic countryside;
+he tried to imagine "boilers on stilts" a hundred feet high.
+
+There were one or two cartloads of refugees passing along Oxford
+Street, and several in the Marylebone Road, but so slowly was the news
+spreading that Regent Street and Portland Place were full of their
+usual Sunday-night promenaders, albeit they talked in groups, and
+along the edge of Regent's Park there were as many silent couples
+"walking out" together under the scattered gas lamps as ever there had
+been.  The night was warm and still, and a little oppressive; the
+sound of guns continued intermittently, and after midnight there
+seemed to be sheet lightning in the south.
+
+He read and re-read the paper, fearing the worst had happened to me.
+He was restless, and after supper prowled out again aimlessly.  He
+returned and tried in vain to divert his attention to his examination
+notes.  He went to bed a little after midnight, and was awakened from
+lurid dreams in the small hours of Monday by the sound of door
+knockers, feet running in the street, distant drumming, and a clamour
+of bells.  Red reflections danced on the ceiling.  For a moment he lay
+astonished, wondering whether day had come or the world gone mad.
+Then he jumped out of bed and ran to the window.
+
+His room was an attic and as he thrust his head out, up and down
+the street there were a dozen echoes to the noise of his window sash,
+and heads in every kind of night disarray appeared.  Enquiries were
+being shouted.  "They are coming!" bawled a policeman, hammering at
+the door; "the Martians are coming!" and hurried to the next door.
+
+The sound of drumming and trumpeting came from the Albany Street
+Barracks, and every church within earshot was hard at work killing
+sleep with a vehement disorderly tocsin.  There was a noise of doors
+opening, and window after window in the houses opposite flashed from
+darkness into yellow illumination.
+
+Up the street came galloping a closed carriage, bursting abruptly
+into noise at the corner, rising to a clattering climax under the
+window, and dying away slowly in the distance.  Close on the rear of
+this came a couple of cabs, the forerunners of a long procession of
+flying vehicles, going for the most part to Chalk Farm station, where
+the North-Western special trains were loading up, instead of coming
+down the gradient into Euston.
+
+For a long time my brother stared out of the window in blank
+astonishment, watching the policemen hammering at door after door, and
+delivering their incomprehensible message.  Then the door behind him
+opened, and the man who lodged across the landing came in, dressed
+only in shirt, trousers, and slippers, his braces loose about his
+waist, his hair disordered from his pillow.
+
+"What the devil is it?" he asked.  "A fire?  What a devil of a
+row!"
+
+They both craned their heads out of the window, straining to hear
+what the policemen were shouting.  People were coming out of the side
+streets, and standing in groups at the corners talking.
+
+"What the devil is it all about?" said my brother's fellow lodger.
+
+My brother answered him vaguely and began to dress, running with
+each garment to the window in order to miss nothing of the growing
+excitement.  And presently men selling unnaturally early newspapers
+came bawling into the street:
+
+"London in danger of suffocation!  The Kingston and Richmond
+defences forced!  Fearful massacres in the Thames Valley!"
+
+And all about him--in the rooms below, in the houses on each side
+and across the road, and behind in the Park Terraces and in the
+hundred other streets of that part of Marylebone, and the Westbourne
+Park district and St. Pancras, and westward and northward in Kilburn
+and St. John's Wood and Hampstead, and eastward in Shoreditch and
+Highbury and Haggerston and Hoxton, and, indeed, through all the
+vastness of London from Ealing to East Ham--people were rubbing their
+eyes, and opening windows to stare out and ask aimless questions,
+dressing hastily as the first breath of the coming storm of Fear blew
+through the streets.  It was the dawn of the great panic.  London,
+which had gone to bed on Sunday night oblivious and inert, was
+awakened, in the small hours of Monday morning, to a vivid sense of
+danger.
+
+Unable from his window to learn what was happening, my brother went
+down and out into the street, just as the sky between the parapets of
+the houses grew pink with the early dawn.  The flying people on foot
+and in vehicles grew more numerous every moment.  "Black Smoke!" he
+heard people crying, and again "Black Smoke!"  The contagion of such
+a unanimous fear was inevitable.  As my brother hesitated on the
+door-step, he saw another news vender approaching, and got a paper
+forthwith.  The man was running away with the rest, and selling his
+papers for a shilling each as he ran--a grotesque mingling of profit
+and panic.
+
+And from this paper my brother read that catastrophic dispatch of
+the Commander-in-Chief:
+
+"The Martians are able to discharge enormous clouds of a black and
+poisonous vapour by means of rockets.  They have smothered our
+batteries, destroyed Richmond, Kingston, and Wimbledon, and are
+advancing slowly towards London, destroying everything on the way.  It
+is impossible to stop them.  There is no safety from the Black Smoke
+but in instant flight."
+
+That was all, but it was enough.  The whole population of the great
+six-million city was stirring, slipping, running; presently it would
+be pouring _en masse_ northward.
+
+"Black Smoke!" the voices cried.  "Fire!"
+
+The bells of the neighbouring church made a jangling tumult, a cart
+carelessly driven smashed, amid shrieks and curses, against the water
+trough up the street.  Sickly yellow lights went to and fro in the
+houses, and some of the passing cabs flaunted unextinguished lamps.
+And overhead the dawn was growing brighter, clear and steady and calm.
+
+He heard footsteps running to and fro in the rooms, and up and down
+stairs behind him.  His landlady came to the door, loosely wrapped in
+dressing gown and shawl; her husband followed ejaculating.
+
+As my brother began to realise the import of all these things, he
+turned hastily to his own room, put all his available money--some ten
+pounds altogether--into his pockets, and went out again into the
+streets.
+
+
+
+CHAPTER FIFTEEN
+
+WHAT HAD HAPPENED IN SURREY
+
+
+It was while the curate had sat and talked so wildly to me under
+the hedge in the flat meadows near Halliford, and while my brother was
+watching the fugitives stream over Westminster Bridge, that the
+Martians had resumed the offensive.  So far as one can ascertain from
+the conflicting accounts that have been put forth, the majority of
+them remained busied with preparations in the Horsell pit until nine
+that night, hurrying on some operation that disengaged huge volumes of
+green smoke.
+
+But three certainly came out about eight o'clock and, advancing
+slowly and cautiously, made their way through Byfleet and Pyrford
+towards Ripley and Weybridge, and so came in sight of the expectant
+batteries against the setting sun.  These Martians did not advance in
+a body, but in a line, each perhaps a mile and a half from his nearest
+fellow.  They communicated with one another by means of sirenlike
+howls, running up and down the scale from one note to another.
+
+It was this howling and firing of the guns at Ripley and St.
+George's Hill that we had heard at Upper Halliford.  The Ripley
+gunners, unseasoned artillery volunteers who ought never to have been
+placed in such a position, fired one wild, premature, ineffectual
+volley, and bolted on horse and foot through the deserted village,
+while the Martian, without using his Heat-Ray, walked serenely over
+their guns, stepped gingerly among them, passed in front of them, and
+so came unexpectedly upon the guns in Painshill Park, which he
+destroyed.
+
+The St. George's Hill men, however, were better led or of a better
+mettle.  Hidden by a pine wood as they were, they seem to have been
+quite unsuspected by the Martian nearest to them.  They laid their
+guns as deliberately as if they had been on parade, and fired at about
+a thousand yards' range.
+
+The shells flashed all round him, and he was seen to advance a few
+paces, stagger, and go down.  Everybody yelled together, and the guns
+were reloaded in frantic haste.  The overthrown Martian set up a
+prolonged ululation, and immediately a second glittering giant,
+answering him, appeared over the trees to the south.  It would seem
+that a leg of the tripod had been smashed by one of the shells.  The
+whole of the second volley flew wide of the Martian on the ground,
+and, simultaneously, both his companions brought their Heat-Rays to
+bear on the battery.  The ammunition blew up, the pine trees all about
+the guns flashed into fire, and only one or two of the men who were
+already running over the crest of the hill escaped.
+
+After this it would seem that the three took counsel together and
+halted, and the scouts who were watching them report that they
+remained absolutely stationary for the next half hour.  The Martian
+who had been overthrown crawled tediously out of his hood, a small
+brown figure, oddly suggestive from that distance of a speck of
+blight, and apparently engaged in the repair of his support.  About
+nine he had finished, for his cowl was then seen above the trees
+again.
+
+It was a few minutes past nine that night when these three
+sentinels were joined by four other Martians, each carrying a thick
+black tube.  A similar tube was handed to each of the three, and the
+seven proceeded to distribute themselves at equal distances along a
+curved line between St. George's Hill, Weybridge, and the village of
+Send, southwest of Ripley.
+
+A dozen rockets sprang out of the hills before them so soon as they
+began to move, and warned the waiting batteries about Ditton and
+Esher.  At the same time four of their fighting machines, similarly
+armed with tubes, crossed the river, and two of them, black against
+the western sky, came into sight of myself and the curate as we
+hurried wearily and painfully along the road that runs northward out
+of Halliford.  They moved, as it seemed to us, upon a cloud, for a
+milky mist covered the fields and rose to a third of their height.
+
+At this sight the curate cried faintly in his throat, and began
+running; but I knew it was no good running from a Martian, and I
+turned aside and crawled through dewy nettles and brambles into the
+broad ditch by the side of the road.  He looked back, saw what I was
+doing, and turned to join me.
+
+The two halted, the nearer to us standing and facing Sunbury, the
+remoter being a grey indistinctness towards the evening star, away
+towards Staines.
+
+The occasional howling of the Martians had ceased; they took up
+their positions in the huge crescent about their cylinders in absolute
+silence.  It was a crescent with twelve miles between its horns.  Never
+since the devising of gunpowder was the beginning of a battle so
+still.  To us and to an observer about Ripley it would have had
+precisely the same effect--the Martians seemed in solitary possession
+of the darkling night, lit only as it was by the slender moon, the
+stars, the afterglow of the daylight, and the ruddy glare from St.
+George's Hill and the woods of Painshill.
+
+But facing that crescent everywhere--at Staines, Hounslow, Ditton,
+Esher, Ockham, behind hills and woods south of the river, and across
+the flat grass meadows to the north of it, wherever a cluster of trees
+or village houses gave sufficient cover--the guns were waiting.  The
+signal rockets burst and rained their sparks through the night and
+vanished, and the spirit of all those watching batteries rose to a
+tense expectation.  The Martians had but to advance into the line of
+fire, and instantly those motionless black forms of men, those guns
+glittering so darkly in the early night, would explode into a
+thunderous fury of battle.
+
+No doubt the thought that was uppermost in a thousand of those
+vigilant minds, even as it was uppermost in mine, was the riddle--how
+much they understood of us.  Did they grasp that we in our millions
+were organized, disciplined, working together?  Or did they interpret
+our spurts of fire, the sudden stinging of our shells, our steady
+investment of their encampment, as we should the furious unanimity of
+onslaught in a disturbed hive of bees?  Did they dream they might
+exterminate us?  (At that time no one knew what food they needed.)  A
+hundred such questions struggled together in my mind as I watched that
+vast sentinel shape.  And in the back of my mind was the sense of all
+the huge unknown and hidden forces Londonward.  Had they prepared
+pitfalls? Were the powder mills at Hounslow ready as a snare?  Would
+the Londoners have the heart and courage to make a greater Moscow of
+their mighty province of houses?
+
+Then, after an interminable time, as it seemed to us, crouching and
+peering through the hedge, came a sound like the distant concussion of
+a gun.  Another nearer, and then another.  And then the Martian beside
+us raised his tube on high and discharged it, gunwise, with a heavy
+report that made the ground heave.  The one towards Staines answered
+him.  There was no flash, no smoke, simply that loaded detonation.
+
+I was so excited by these heavy minute-guns following one another
+that I so far forgot my personal safety and my scalded hands as to
+clamber up into the hedge and stare towards Sunbury.  As I did so a
+second report followed, and a big projectile hurtled overhead towards
+Hounslow.  I expected at least to see smoke or fire, or some such
+evidence of its work.  But all I saw was the deep blue sky above, with
+one solitary star, and the white mist spreading wide and low beneath.
+And there had been no crash, no answering explosion.  The silence was
+restored; the minute lengthened to three.
+
+"What has happened?" said the curate, standing up beside me.
+
+"Heaven knows!" said I.
+
+A bat flickered by and vanished.  A distant tumult of shouting
+began and ceased.  I looked again at the Martian, and saw he was now
+moving eastward along the riverbank, with a swift, rolling motion.
+
+Every moment I expected the fire of some hidden battery to spring
+upon him; but the evening calm was unbroken.  The figure of the Martian
+grew smaller as he receded, and presently the mist and the gathering
+night had swallowed him up.  By a common impulse we clambered higher.
+Towards Sunbury was a dark appearance, as though a conical hill had
+suddenly come into being there, hiding our view of the farther
+country; and then, remoter across the river, over Walton, we saw
+another such summit.  These hill-like forms grew lower and broader
+even as we stared.
+
+Moved by a sudden thought, I looked northward, and there I
+perceived a third of these cloudy black kopjes had risen.
+
+Everything had suddenly become very still.  Far away to the
+southeast, marking the quiet, we heard the Martians hooting to one
+another, and then the air quivered again with the distant thud of
+their guns.  But the earthly artillery made no reply.
+
+Now at the time we could not understand these things, but later I
+was to learn the meaning of these ominous kopjes that gathered in the
+twilight.  Each of the Martians, standing in the great crescent I have
+described, had discharged, by means of the gunlike tube he carried, a
+huge canister over whatever hill, copse, cluster of houses, or other
+possible cover for guns, chanced to be in front of him.  Some fired
+only one of these, some two--as in the case of the one we had seen;
+the one at Ripley is said to have discharged no fewer than five at
+that time.  These canisters smashed on striking the ground--they did
+not explode--and incontinently disengaged an enormous volume of heavy,
+inky vapour, coiling and pouring upward in a huge and ebony cumulus
+cloud, a gaseous hill that sank and spread itself slowly over the
+surrounding country.  And the touch of that vapour, the inhaling of
+its pungent wisps, was death to all that breathes.
+
+It was heavy, this vapour, heavier than the densest smoke, so that,
+after the first tumultuous uprush and outflow of its impact, it sank
+down through the air and poured over the ground in a manner rather
+liquid than gaseous, abandoning the hills, and streaming into the
+valleys and ditches and watercourses even as I have heard the
+carbonic-acid gas that pours from volcanic clefts is wont to do.  And
+where it came upon water some chemical action occurred, and the
+surface would be instantly covered with a powdery scum that sank
+slowly and made way for more.  The scum was absolutely insoluble, and
+it is a strange thing, seeing the instant effect of the gas, that one
+could drink without hurt the water from which it had been strained.
+The vapour did not diffuse as a true gas would do.  It hung together
+in banks, flowing sluggishly down the slope of the land and driving
+reluctantly before the wind, and very slowly it combined with the mist
+and moisture of the air, and sank to the earth in the form of dust.
+Save that an unknown element giving a group of four lines in the blue
+of the spectrum is concerned, we are still entirely ignorant of the
+nature of this substance.
+
+Once the tumultuous upheaval of its dispersion was over, the black
+smoke clung so closely to the ground, even before its precipitation,
+that fifty feet up in the air, on the roofs and upper stories of high
+houses and on great trees, there was a chance of escaping its poison
+altogether, as was proved even that night at Street Cobham and Ditton.
+
+The man who escaped at the former place tells a wonderful story of
+the strangeness of its coiling flow, and how he looked down from the
+church spire and saw the houses of the village rising like ghosts out
+of its inky nothingness.  For a day and a half he remained there,
+weary, starving and sun-scorched, the earth under the blue sky and
+against the prospect of the distant hills a velvet-black expanse, with
+red roofs, green trees, and, later, black-veiled shrubs and gates,
+barns, outhouses, and walls, rising here and there into the sunlight.
+
+But that was at Street Cobham, where the black vapour was allowed
+to remain until it sank of its own accord into the ground.  As a rule
+the Martians, when it had served its purpose, cleared the air of it
+again by wading into it and directing a jet of steam upon it.
+
+This they did with the vapour banks near us, as we saw in the
+starlight from the window of a deserted house at Upper Halliford,
+whither we had returned.  From there we could see the searchlights on
+Richmond Hill and Kingston Hill going to and fro, and about eleven the
+windows rattled, and we heard the sound of the huge siege guns that
+had been put in position there.  These continued intermittently for
+the space of a quarter of an hour, sending chance shots at the
+invisible Martians at Hampton and Ditton, and then the pale beams of
+the electric light vanished, and were replaced by a bright red glow.
+
+Then the fourth cylinder fell--a brilliant green meteor--as I
+learned afterwards, in Bushey Park.  Before the guns on the Richmond
+and Kingston line of hills began, there was a fitful cannonade far
+away in the southwest, due, I believe, to guns being fired haphazard
+before the black vapour could overwhelm the gunners.
+
+So, setting about it as methodically as men might smoke out a
+wasps' nest, the Martians spread this strange stifling vapour over the
+Londonward country.  The horns of the crescent slowly moved apart,
+until at last they formed a line from Hanwell to Coombe and Malden.
+All night through their destructive tubes advanced.  Never once, after
+the Martian at St. George's Hill was brought down, did they give the
+artillery the ghost of a chance against them.  Wherever there was a
+possibility of guns being laid for them unseen, a fresh canister of
+the black vapour was discharged, and where the guns were openly
+displayed the Heat-Ray was brought to bear.
+
+By midnight the blazing trees along the slopes of Richmond Park and
+the glare of Kingston Hill threw their light upon a network of black
+smoke, blotting out the whole valley of the Thames and extending as
+far as the eye could reach.  And through this two Martians slowly
+waded, and turned their hissing steam jets this way and that.
+
+They were sparing of the Heat-Ray that night, either because they
+had but a limited supply of material for its production or because
+they did not wish to destroy the country but only to crush and overawe
+the opposition they had aroused.  In the latter aim they certainly
+succeeded.  Sunday night was the end of the organised opposition to
+their movements.  After that no body of men would stand against them,
+so hopeless was the enterprise.  Even the crews of the torpedo-boats
+and destroyers that had brought their quick-firers up the Thames
+refused to stop, mutinied, and went down again.  The only offensive
+operation men ventured upon after that night was the preparation of
+mines and pitfalls, and even in that their energies were frantic and
+spasmodic.
+
+One has to imagine, as well as one may, the fate of those batteries
+towards Esher, waiting so tensely in the twilight.  Survivors there
+were none.  One may picture the orderly expectation, the officers
+alert and watchful, the gunners ready, the ammunition piled to hand,
+the limber gunners with their horses and waggons, the groups of
+civilian spectators standing as near as they were permitted, the
+evening stillness, the ambulances and hospital tents with the burned
+and wounded from Weybridge; then the dull resonance of the shots the
+Martians fired, and the clumsy projectile whirling over the trees and
+houses and smashing amid the neighbouring fields.
+
+One may picture, too, the sudden shifting of the attention, the
+swiftly spreading coils and bellyings of that blackness advancing
+headlong, towering heavenward, turning the twilight to a palpable
+darkness, a strange and horrible antagonist of vapour striding upon
+its victims, men and horses near it seen dimly, running, shrieking,
+falling headlong, shouts of dismay, the guns suddenly abandoned, men
+choking and writhing on the ground, and the swift broadening-out of
+the opaque cone of smoke.  And then night and extinction--nothing but
+a silent mass of impenetrable vapour hiding its dead.
+
+Before dawn the black vapour was pouring through the streets of
+Richmond, and the disintegrating organism of government was, with a
+last expiring effort, rousing the population of London to the
+necessity of flight.
+
+
+
+CHAPTER SIXTEEN
+
+THE EXODUS FROM LONDON
+
+
+So you understand the roaring wave of fear that swept through the
+greatest city in the world just as Monday was dawning--the stream of
+flight rising swiftly to a torrent, lashing in a foaming tumult round
+the railway stations, banked up into a horrible struggle about the
+shipping in the Thames, and hurrying by every available channel
+northward and eastward.  By ten o'clock the police organisation, and
+by midday even the railway organisations, were losing coherency,
+losing shape and efficiency, guttering, softening, running at last in
+that swift liquefaction of the social body.
+
+All the railway lines north of the Thames and the South-Eastern
+people at Cannon Street had been warned by midnight on Sunday, and
+trains were being filled.  People were fighting savagely for
+standing-room in the carriages even at two o'clock.  By three, people
+were being trampled and crushed even in Bishopsgate Street, a couple
+of hundred yards or more from Liverpool Street station; revolvers were
+fired, people stabbed, and the policemen who had been sent to direct
+the traffic, exhausted and infuriated, were breaking the heads of the
+people they were called out to protect.
+
+And as the day advanced and the engine drivers and stokers refused
+to return to London, the pressure of the flight drove the people in an
+ever-thickening multitude away from the stations and along the
+northward-running roads.  By midday a Martian had been seen at Barnes,
+and a cloud of slowly sinking black vapour drove along the Thames and
+across the flats of Lambeth, cutting off all escape over the bridges
+in its sluggish advance.  Another bank drove over Ealing, and
+surrounded a little island of survivors on Castle Hill, alive, but
+unable to escape.
+
+After a fruitless struggle to get aboard a North-Western train at
+Chalk Farm--the engines of the trains that had loaded in the goods
+yard there _ploughed_ through shrieking people, and a dozen stalwart men
+fought to keep the crowd from crushing the driver against his
+furnace--my brother emerged upon the Chalk Farm road, dodged across
+through a hurrying swarm of vehicles, and had the luck to be foremost
+in the sack of a cycle shop.  The front tire of the machine he got was
+punctured in dragging it through the window, but he got up and off,
+notwithstanding, with no further injury than a cut wrist.  The steep
+foot of Haverstock Hill was impassable owing to several overturned
+horses, and my brother struck into Belsize Road.
+
+So he got out of the fury of the panic, and, skirting the Edgware
+Road, reached Edgware about seven, fasting and wearied, but well ahead
+of the crowd.  Along the road people were standing in the roadway,
+curious, wondering.  He was passed by a number of cyclists, some
+horsemen, and two motor cars.  A mile from Edgware the rim of the
+wheel broke, and the machine became unridable.  He left it by the
+roadside and trudged through the village.  There were shops half
+opened in the main street of the place, and people crowded on the
+pavement and in the doorways and windows, staring astonished at this
+extraordinary procession of fugitives that was beginning.  He
+succeeded in getting some food at an inn.
+
+For a time he remained in Edgware not knowing what next to do.  The
+flying people increased in number.  Many of them, like my brother,
+seemed inclined to loiter in the place.  There was no fresh news of
+the invaders from Mars.
+
+At that time the road was crowded, but as yet far from congested.
+Most of the fugitives at that hour were mounted on cycles, but there
+were soon motor cars, hansom cabs, and carriages hurrying along, and
+the dust hung in heavy clouds along the road to St. Albans.
+
+It was perhaps a vague idea of making his way to Chelmsford, where
+some friends of his lived, that at last induced my brother to strike
+into a quiet lane running eastward.  Presently he came upon a stile,
+and, crossing it, followed a footpath northeastward.  He passed near
+several farmhouses and some little places whose names he did not
+learn.  He saw few fugitives until, in a grass lane towards High
+Barnet, he happened upon two ladies who became his fellow travellers.
+He came upon them just in time to save them.
+
+He heard their screams, and, hurrying round the corner, saw a
+couple of men struggling to drag them out of the little pony-chaise in
+which they had been driving, while a third with difficulty held the
+frightened pony's head.  One of the ladies, a short woman dressed in
+white, was simply screaming; the other, a dark, slender figure,
+slashed at the man who gripped her arm with a whip she held in her
+disengaged hand.
+
+My brother immediately grasped the situation, shouted, and hurried
+towards the struggle.  One of the men desisted and turned towards him,
+and my brother, realising from his antagonist's face that a fight was
+unavoidable, and being an expert boxer, went into him forthwith and
+sent him down against the wheel of the chaise.
+
+It was no time for pugilistic chivalry and my brother laid him
+quiet with a kick, and gripped the collar of the man who pulled at the
+slender lady's arm.  He heard the clatter of hoofs, the whip stung
+across his face, a third antagonist struck him between the eyes, and
+the man he held wrenched himself free and made off down the lane in
+the direction from which he had come.
+
+Partly stunned, he found himself facing the man who had held the
+horse's head, and became aware of the chaise receding from him down
+the lane, swaying from side to side, and with the women in it looking
+back.  The man before him, a burly rough, tried to close, and he
+stopped him with a blow in the face.  Then, realising that he was
+deserted, he dodged round and made off down the lane after the chaise,
+with the sturdy man close behind him, and the fugitive, who had turned
+now, following remotely.
+
+Suddenly he stumbled and fell; his immediate pursuer went headlong,
+and he rose to his feet to find himself with a couple of antagonists
+again.  He would have had little chance against them had not the
+slender lady very pluckily pulled up and returned to his help.  It
+seems she had had a revolver all this time, but it had been under the
+seat when she and her companion were attacked.  She fired at six
+yards' distance, narrowly missing my brother.  The less courageous of
+the robbers made off, and his companion followed him, cursing his
+cowardice.  They both stopped in sight down the lane, where the third
+man lay insensible.
+
+"Take this!" said the slender lady, and she gave my brother her
+revolver.
+
+"Go back to the chaise," said my brother, wiping the blood from his
+split lip.
+
+She turned without a word--they were both panting--and they went
+back to where the lady in white struggled to hold back the frightened
+pony.
+
+The robbers had evidently had enough of it.  When my brother looked
+again they were retreating.
+
+"I'll sit here," said my brother, "if I may"; and he got upon the
+empty front seat.  The lady looked over her shoulder.
+
+"Give me the reins," she said, and laid the whip along the pony's
+side.  In another moment a bend in the road hid the three men from my
+brother's eyes.
+
+So, quite unexpectedly, my brother found himself, panting, with a
+cut mouth, a bruised jaw, and bloodstained knuckles, driving along an
+unknown lane with these two women.
+
+He learned they were the wife and the younger sister of a surgeon
+living at Stanmore, who had come in the small hours from a dangerous
+case at Pinner, and heard at some railway station on his way of the
+Martian advance.  He had hurried home, roused the women--their servant
+had left them two days before--packed some provisions, put his
+revolver under the seat--luckily for my brother--and told them to
+drive on to Edgware, with the idea of getting a train there.  He
+stopped behind to tell the neighbours.  He would overtake them, he
+said, at about half past four in the morning, and now it was nearly
+nine and they had seen nothing of him.  They could not stop in Edgware
+because of the growing traffic through the place, and so they had come
+into this side lane.
+
+That was the story they told my brother in fragments when presently
+they stopped again, nearer to New Barnet.  He promised to stay with
+them, at least until they could determine what to do, or until the
+missing man arrived, and professed to be an expert shot with the
+revolver--a weapon strange to him--in order to give them confidence.
+
+They made a sort of encampment by the wayside, and the pony became
+happy in the hedge.  He told them of his own escape out of London, and
+all that he knew of these Martians and their ways.  The sun crept
+higher in the sky, and after a time their talk died out and gave place
+to an uneasy state of anticipation.  Several wayfarers came along the
+lane, and of these my brother gathered such news as he could.  Every
+broken answer he had deepened his impression of the great disaster
+that had come on humanity, deepened his persuasion of the immediate
+necessity for prosecuting this flight.  He urged the matter upon them.
+
+"We have money," said the slender woman, and hesitated.
+
+Her eyes met my brother's, and her hesitation ended.
+
+"So have I," said my brother.
+
+She explained that they had as much as thirty pounds in gold,
+besides a five-pound note, and suggested that with that they might get
+upon a train at St. Albans or New Barnet.  My brother thought that was
+hopeless, seeing the fury of the Londoners to crowd upon the trains,
+and broached his own idea of striking across Essex towards Harwich and
+thence escaping from the country altogether.
+
+Mrs. Elphinstone--that was the name of the woman in white--would
+listen to no reasoning, and kept calling upon "George"; but her
+sister-in-law was astonishingly quiet and deliberate, and at last
+agreed to my brother's suggestion.  So, designing to cross the Great
+North Road, they went on towards Barnet, my brother leading the pony
+to save it as much as possible.  As the sun crept up the sky the day
+became excessively hot, and under foot a thick, whitish sand grew
+burning and blinding, so that they travelled only very slowly.  The
+hedges were grey with dust.  And as they advanced towards Barnet a
+tumultuous murmuring grew stronger.
+
+They began to meet more people.  For the most part these were
+staring before them, murmuring indistinct questions, jaded, haggard,
+unclean.  One man in evening dress passed them on foot, his eyes on
+the ground.  They heard his voice, and, looking back at him, saw one
+hand clutched in his hair and the other beating invisible things.  His
+paroxysm of rage over, he went on his way without once looking back.
+
+As my brother's party went on towards the crossroads to the south
+of Barnet they saw a woman approaching the road across some fields on
+their left, carrying a child and with two other children; and then
+passed a man in dirty black, with a thick stick in one hand and a
+small portmanteau in the other.  Then round the corner of the lane,
+from between the villas that guarded it at its confluence with the
+high road, came a little cart drawn by a sweating black pony and
+driven by a sallow youth in a bowler hat, grey with dust.  There were
+three girls, East End factory girls, and a couple of little children
+crowded in the cart.
+
+"This'll tike us rahnd Edgware?" asked the driver, wild-eyed,
+white-faced; and when my brother told him it would if he turned to the
+left, he whipped up at once without the formality of thanks.
+
+My brother noticed a pale grey smoke or haze rising among the
+houses in front of them, and veiling the white facade of a terrace
+beyond the road that appeared between the backs of the villas.  Mrs.
+Elphinstone suddenly cried out at a number of tongues of smoky red
+flame leaping up above the houses in front of them against the hot,
+blue sky.  The tumultuous noise resolved itself now into the
+disorderly mingling of many voices, the gride of many wheels, the
+creaking of waggons, and the staccato of hoofs.  The lane came round
+sharply not fifty yards from the crossroads.
+
+"Good heavens!" cried Mrs. Elphinstone.  "What is this you are
+driving us into?"
+
+My brother stopped.
+
+For the main road was a boiling stream of people, a torrent of
+human beings rushing northward, one pressing on another.  A great bank
+of dust, white and luminous in the blaze of the sun, made everything
+within twenty feet of the ground grey and indistinct and was
+perpetually renewed by the hurrying feet of a dense crowd of horses
+and of men and women on foot, and by the wheels of vehicles of every
+description.
+
+"Way!" my brother heard voices crying.  "Make way!"
+
+It was like riding into the smoke of a fire to approach the meeting
+point of the lane and road; the crowd roared like a fire, and the dust
+was hot and pungent.  And, indeed, a little way up the road a villa
+was burning and sending rolling masses of black smoke across the road
+to add to the confusion.
+
+Two men came past them.  Then a dirty woman, carrying a heavy
+bundle and weeping.  A lost retriever dog, with hanging tongue,
+circled dubiously round them, scared and wretched, and fled at my
+brother's threat.
+
+So much as they could see of the road Londonward between the houses
+to the right was a tumultuous stream of dirty, hurrying people, pent
+in between the villas on either side; the black heads, the crowded
+forms, grew into distinctness as they rushed towards the corner,
+hurried past, and merged their individuality again in a receding
+multitude that was swallowed up at last in a cloud of dust.
+
+"Go on!  Go on!" cried the voices.  "Way!  Way!"
+
+One man's hands pressed on the back of another.  My brother stood
+at the pony's head.  Irresistibly attracted, he advanced slowly, pace
+by pace, down the lane.
+
+Edgware had been a scene of confusion, Chalk Farm a riotous tumult,
+but this was a whole population in movement.  It is hard to imagine
+that host.  It had no character of its own.  The figures poured out
+past the corner, and receded with their backs to the group in the
+lane.  Along the margin came those who were on foot threatened by the
+wheels, stumbling in the ditches, blundering into one another.
+
+The carts and carriages crowded close upon one another, making
+little way for those swifter and more impatient vehicles that darted
+forward every now and then when an opportunity showed itself of doing
+so, sending the people scattering against the fences and gates of the
+villas.
+
+"Push on!" was the cry.  "Push on!  They are coming!"
+
+In one cart stood a blind man in the uniform of the Salvation Army,
+gesticulating with his crooked fingers and bawling, "Eternity!
+Eternity!"  His voice was hoarse and very loud so that my brother
+could hear him long after he was lost to sight in the dust.  Some of
+the people who crowded in the carts whipped stupidly at their horses
+and quarrelled with other drivers; some sat motionless, staring at
+nothing with miserable eyes; some gnawed their hands with thirst, or
+lay prostrate in the bottoms of their conveyances.  The horses' bits
+were covered with foam, their eyes bloodshot.
+
+There were cabs, carriages, shop cars, waggons, beyond counting; a
+mail cart, a road-cleaner's cart marked "Vestry of St. Pancras," a
+huge timber waggon crowded with roughs.  A brewer's dray rumbled by
+with its two near wheels splashed with fresh blood.
+
+"Clear the way!" cried the voices.  "Clear the way!"
+
+"Eter-nity!  Eter-nity!" came echoing down the road.
+
+There were sad, haggard women tramping by, well dressed, with
+children that cried and stumbled, their dainty clothes smothered in
+dust, their weary faces smeared with tears.  With many of these came
+men, sometimes helpful, sometimes lowering and savage.  Fighting side
+by side with them pushed some weary street outcast in faded black
+rags, wide-eyed, loud-voiced, and foul-mouthed.  There were sturdy
+workmen thrusting their way along, wretched, unkempt men, clothed like
+clerks or shopmen, struggling spasmodically; a wounded soldier my
+brother noticed, men dressed in the clothes of railway porters, one
+wretched creature in a nightshirt with a coat thrown over it.
+
+But varied as its composition was, certain things all that host had
+in common.  There were fear and pain on their faces, and fear behind
+them.  A tumult up the road, a quarrel for a place in a waggon, sent
+the whole host of them quickening their pace; even a man so scared and
+broken that his knees bent under him was galvanised for a moment into
+renewed activity.  The heat and dust had already been at work upon
+this multitude.  Their skins were dry, their lips black and cracked.
+They were all thirsty, weary, and footsore.  And amid the various
+cries one heard disputes, reproaches, groans of weariness and fatigue;
+the voices of most of them were hoarse and weak.  Through it all ran a
+refrain:
+
+"Way!  Way!  The Martians are coming!"
+
+Few stopped and came aside from that flood.  The lane opened
+slantingly into the main road with a narrow opening, and had a
+delusive appearance of coming from the direction of London.  Yet a
+kind of eddy of people drove into its mouth; weaklings elbowed out of
+the stream, who for the most part rested but a moment before plunging
+into it again.  A little way down the lane, with two friends bending
+over him, lay a man with a bare leg, wrapped about with bloody rags.
+He was a lucky man to have friends.
+
+A little old man, with a grey military moustache and a filthy black
+frock coat, limped out and sat down beside the trap, removed his
+boot--his sock was blood-stained--shook out a pebble, and hobbled on
+again; and then a little girl of eight or nine, all alone, threw
+herself under the hedge close by my brother, weeping.
+
+"I can't go on!  I can't go on!"
+
+My brother woke from his torpor of astonishment and lifted her up,
+speaking gently to her, and carried her to Miss Elphinstone.  So soon
+as my brother touched her she became quite still, as if frightened.
+
+"Ellen!" shrieked a woman in the crowd, with tears in her
+voice--"Ellen!"  And the child suddenly darted away from my brother,
+crying "Mother!"
+
+"They are coming," said a man on horseback, riding past along the
+lane.
+
+"Out of the way, there!" bawled a coachman, towering high; and my
+brother saw a closed carriage turning into the lane.
+
+The people crushed back on one another to avoid the horse.  My
+brother pushed the pony and chaise back into the hedge, and the man
+drove by and stopped at the turn of the way.  It was a carriage, with
+a pole for a pair of horses, but only one was in the traces.  My
+brother saw dimly through the dust that two men lifted out something
+on a white stretcher and put it gently on the grass beneath the privet
+hedge.
+
+One of the men came running to my brother.
+
+"Where is there any water?" he said.  "He is dying fast, and very
+thirsty.  It is Lord Garrick."
+
+"Lord Garrick!" said my brother; "the Chief Justice?"
+
+"The water?" he said.
+
+"There may be a tap," said my brother, "in some of the houses.  We
+have no water.  I dare not leave my people."
+
+The man pushed against the crowd towards the gate of the corner
+house.
+
+"Go on!" said the people, thrusting at him.  "They are coming!  Go
+on!"
+
+Then my brother's attention was distracted by a bearded, eagle-faced
+man lugging a small handbag, which split even as my brother's
+eyes rested on it and disgorged a mass of sovereigns that seemed to
+break up into separate coins as it struck the ground.  They rolled
+hither and thither among the struggling feet of men and horses.  The
+man stopped and looked stupidly at the heap, and the shaft of a cab
+struck his shoulder and sent him reeling.  He gave a shriek and dodged
+back, and a cartwheel shaved him narrowly.
+
+"Way!" cried the men all about him.  "Make way!"
+
+So soon as the cab had passed, he flung himself, with both hands
+open, upon the heap of coins, and began thrusting handfuls in his
+pocket.  A horse rose close upon him, and in another moment, half
+rising, he had been borne down under the horse's hoofs.
+
+"Stop!" screamed my brother, and pushing a woman out of his way,
+tried to clutch the bit of the horse.
+
+Before he could get to it, he heard a scream under the wheels, and
+saw through the dust the rim passing over the poor wretch's back.  The
+driver of the cart slashed his whip at my brother, who ran round
+behind the cart.  The multitudinous shouting confused his ears.  The
+man was writhing in the dust among his scattered money, unable to
+rise, for the wheel had broken his back, and his lower limbs lay limp
+and dead.  My brother stood up and yelled at the next driver, and a
+man on a black horse came to his assistance.
+
+"Get him out of the road," said he; and, clutching the man's collar
+with his free hand, my brother lugged him sideways.  But he still
+clutched after his money, and regarded my brother fiercely, hammering
+at his arm with a handful of gold.  "Go on!  Go on!" shouted angry
+voices behind.
+
+"Way!  Way!"
+
+There was a smash as the pole of a carriage crashed into the cart
+that the man on horseback stopped.  My brother looked up, and the man
+with the gold twisted his head round and bit the wrist that held his
+collar.  There was a concussion, and the black horse came staggering
+sideways, and the carthorse pushed beside it.  A hoof missed my
+brother's foot by a hair's breadth.  He released his grip on the
+fallen man and jumped back.  He saw anger change to terror on the face
+of the poor wretch on the ground, and in a moment he was hidden and my
+brother was borne backward and carried past the entrance of the lane,
+and had to fight hard in the torrent to recover it.
+
+He saw Miss Elphinstone covering her eyes, and a little child, with
+all a child's want of sympathetic imagination, staring with dilated
+eyes at a dusty something that lay black and still, ground and crushed
+under the rolling wheels.  "Let us go back!" he shouted, and began
+turning the pony round. "We cannot cross this--hell," he said and they
+went back a hundred yards the way they had come, until the fighting
+crowd was hidden.  As they passed the bend in the lane my brother saw
+the face of the dying man in the ditch under the privet, deadly white
+and drawn, and shining with perspiration.  The two women sat silent,
+crouching in their seat and shivering.
+
+Then beyond the bend my brother stopped again.  Miss Elphinstone
+was white and pale, and her sister-in-law sat weeping, too wretched
+even to call upon "George."  My brother was horrified and perplexed.
+So soon as they had retreated he realised how urgent and unavoidable
+it was to attempt this crossing.  He turned to Miss Elphinstone,
+suddenly resolute.
+
+"We must go that way," he said, and led the pony round again.
+
+For the second time that day this girl proved her quality.  To force
+their way into the torrent of people, my brother plunged into the
+traffic and held back a cab horse, while she drove the pony across its
+head.  A waggon locked wheels for a moment and ripped a long splinter
+from the chaise.  In another moment they were caught and swept forward
+by the stream.  My brother, with the cabman's whip marks red across
+his face and hands, scrambled into the chaise and took the reins from
+her.
+
+"Point the revolver at the man behind," he said, giving it to her,
+"if he presses us too hard.  No!--point it at his horse."
+
+Then he began to look out for a chance of edging to the right
+across the road.  But once in the stream he seemed to lose volition,
+to become a part of that dusty rout.  They swept through Chipping
+Barnet with the torrent; they were nearly a mile beyond the centre of
+the town before they had fought across to the opposite side of the
+way.  It was din and confusion indescribable; but in and beyond the
+town the road forks repeatedly, and this to some extent relieved the
+stress.
+
+They struck eastward through Hadley, and there on either side of
+the road, and at another place farther on they came upon a great
+multitude of people drinking at the stream, some fighting to come at
+the water.  And farther on, from a lull near East Barnet, they saw
+two trains running slowly one after the other without signal or
+order--trains swarming with people, with men even among the coals
+behind the engines--going northward along the Great Northern Railway.
+My brother supposes they must have filled outside London, for at that
+time the furious terror of the people had rendered the central
+termini impossible.
+
+Near this place they halted for the rest of the afternoon, for the
+violence of the day had already utterly exhausted all three of them.
+They began to suffer the beginnings of hunger; the night was cold, and
+none of them dared to sleep.  And in the evening many people came
+hurrying along the road nearby their stopping place, fleeing from
+unknown dangers before them, and going in the direction from which my
+brother had come.
+
+
+
+CHAPTER SEVENTEEN
+
+THE "THUNDER CHILD"
+
+
+Had the Martians aimed only at destruction, they might on Monday
+have annihilated the entire population of London, as it spread itself
+slowly through the home counties.  Not only along the road through
+Barnet, but also through Edgware and Waltham Abbey, and along the
+roads eastward to Southend and Shoeburyness, and south of the Thames
+to Deal and Broadstairs, poured the same frantic rout.  If one could
+have hung that June morning in a balloon in the blazing blue above
+London every northward and eastward road running out of the tangled
+maze of streets would have seemed stippled black with the streaming
+fugitives, each dot a human agony of terror and physical distress.  I
+have set forth at length in the last chapter my brother's account of
+the road through Chipping Barnet, in order that my readers may realise
+how that swarming of black dots appeared to one of those concerned.
+Never before in the history of the world had such a mass of human
+beings moved and suffered together.  The legendary hosts of Goths and
+Huns, the hugest armies Asia has ever seen, would have been but a drop
+in that current.  And this was no disciplined march; it was a
+stampede--a stampede gigantic and terrible--without order and without
+a goal, six million people unarmed and unprovisioned, driving
+headlong.  It was the beginning of the rout of civilisation, of the
+massacre of mankind.
+
+Directly below him the balloonist would have seen the network of
+streets far and wide, houses, churches, squares, crescents,
+gardens--already derelict--spread out like a huge map, and in the
+southward _blotted_.  Over Ealing, Richmond, Wimbledon, it would
+have seemed as if some monstrous pen had flung ink upon the chart.
+Steadily, incessantly, each black splash grew and spread, shooting out
+ramifications this way and that, now banking itself against rising
+ground, now pouring swiftly over a crest into a new-found valley,
+exactly as a gout of ink would spread itself upon blotting paper.
+
+And beyond, over the blue hills that rise southward of the river,
+the glittering Martians went to and fro, calmly and methodically
+spreading their poison cloud over this patch of country and then over
+that, laying it again with their steam jets when it had served its
+purpose, and taking possession of the conquered country.  They do not
+seem to have aimed at extermination so much as at complete
+demoralisation and the destruction of any opposition.  They exploded
+any stores of powder they came upon, cut every telegraph, and wrecked
+the railways here and there.  They were hamstringing mankind.  They
+seemed in no hurry to extend the field of their operations, and did
+not come beyond the central part of London all that day.  It is
+possible that a very considerable number of people in London stuck to
+their houses through Monday morning.  Certain it is that many died at
+home suffocated by the Black Smoke.
+
+Until about midday the Pool of London was an astonishing scene.
+Steamboats and shipping of all sorts lay there, tempted by the
+enormous sums of money offered by fugitives, and it is said that many
+who swam out to these vessels were thrust off with boathooks and
+drowned.  About one o'clock in the afternoon the thinning remnant of a
+cloud of the black vapour appeared between the arches of Blackfriars
+Bridge.  At that the Pool became a scene of mad confusion, fighting,
+and collision, and for some time a multitude of boats and barges
+jammed in the northern arch of the Tower Bridge, and the sailors and
+lightermen had to fight savagely against the people who swarmed upon
+them from the riverfront.  People were actually clambering down the
+piers of the bridge from above.
+
+When, an hour later, a Martian appeared beyond the Clock Tower and
+waded down the river, nothing but wreckage floated above Limehouse.
+
+Of the falling of the fifth cylinder I have presently to tell.  The
+sixth star fell at Wimbledon.  My brother, keeping watch beside the
+women in the chaise in a meadow, saw the green flash of it far beyond
+the hills.  On Tuesday the little party, still set upon getting across
+the sea, made its way through the swarming country towards Colchester.
+The news that the Martians were now in possession of the whole of
+London was confirmed.  They had been seen at Highgate, and even, it
+was said, at Neasden.  But they did not come into my brother's view
+until the morrow.
+
+That day the scattered multitudes began to realise the urgent need
+of provisions.  As they grew hungry the rights of property ceased to
+be regarded.  Farmers were out to defend their cattle-sheds,
+granaries, and ripening root crops with arms in their hands.  A number
+of people now, like my brother, had their faces eastward, and there
+were some desperate souls even going back towards London to get food.
+These were chiefly people from the northern suburbs, whose knowledge
+of the Black Smoke came by hearsay.  He heard that about half the
+members of the government had gathered at Birmingham, and that
+enormous quantities of high explosives were being prepared to be used
+in automatic mines across the Midland counties.
+
+He was also told that the Midland Railway Company had replaced the
+desertions of the first day's panic, had resumed traffic, and was
+running northward trains from St. Albans to relieve the congestion of
+the home counties.  There was also a placard in Chipping Ongar
+announcing that large stores of flour were available in the northern
+towns and that within twenty-four hours bread would be distributed
+among the starving people in the neighbourhood.  But this intelligence
+did not deter him from the plan of escape he had formed, and the three
+pressed eastward all day, and heard no more of the bread distribution
+than this promise.  Nor, as a matter of fact, did anyone else hear
+more of it.  That night fell the seventh star, falling upon Primrose
+Hill.  It fell while Miss Elphinstone was watching, for she took that
+duty alternately with my brother.  She saw it.
+
+On Wednesday the three fugitives--they had passed the night in a
+field of unripe wheat--reached Chelmsford, and there a body of the
+inhabitants, calling itself the Committee of Public Supply, seized the
+pony as provisions, and would give nothing in exchange for it but the
+promise of a share in it the next day.  Here there were rumours of
+Martians at Epping, and news of the destruction of Waltham Abbey
+Powder Mills in a vain attempt to blow up one of the invaders.
+
+People were watching for Martians here from the church towers.  My
+brother, very luckily for him as it chanced, preferred to push on at
+once to the coast rather than wait for food, although all three of
+them were very hungry.  By midday they passed through Tillingham,
+which, strangely enough, seemed to be quite silent and deserted, save
+for a few furtive plunderers hunting for food.  Near Tillingham they
+suddenly came in sight of the sea, and the most amazing crowd of
+shipping of all sorts that it is possible to imagine.
+
+For after the sailors could no longer come up the Thames, they came
+on to the Essex coast, to Harwich and Walton and Clacton, and
+afterwards to Foulness and Shoebury, to bring off the people.  They
+lay in a huge sickle-shaped curve that vanished into mist at last
+towards the Naze.  Close inshore was a multitude of fishing
+smacks--English, Scotch, French, Dutch, and Swedish; steam launches
+from the Thames, yachts, electric boats; and beyond were ships of large
+burden, a multitude of filthy colliers, trim merchantmen, cattle ships,
+passenger boats, petroleum tanks, ocean tramps, an old white transport
+even, neat white and grey liners from Southampton and Hamburg; and
+along the blue coast across the Blackwater my brother could make out
+dimly a dense swarm of boats chaffering with the people on the beach,
+a swarm which also extended up the Blackwater almost to Maldon.
+
+About a couple of miles out lay an ironclad, very low in the water,
+almost, to my brother's perception, like a water-logged ship.  This
+was the ram _Thunder Child_.  It was the only warship in sight, but far
+away to the right over the smooth surface of the sea--for that day
+there was a dead calm--lay a serpent of black smoke to mark the next
+ironclads of the Channel Fleet, which hovered in an extended line,
+steam up and ready for action, across the Thames estuary during the
+course of the Martian conquest, vigilant and yet powerless to prevent
+it.
+
+At the sight of the sea, Mrs. Elphinstone, in spite of the
+assurances of her sister-in-law, gave way to panic.  She had never
+been out of England before, she would rather die than trust herself
+friendless in a foreign country, and so forth.  She seemed, poor woman,
+to imagine that the French and the Martians might prove very similar.
+She had been growing increasingly hysterical, fearful, and depressed
+during the two days' journeyings.  Her great idea was to return to
+Stanmore.  Things had been always well and safe at Stanmore.  They
+would find George at Stanmore.
+
+It was with the greatest difficulty they could get her down to the
+beach, where presently my brother succeeded in attracting the
+attention of some men on a paddle steamer from the Thames.  They sent
+a boat and drove a bargain for thirty-six pounds for the three.  The
+steamer was going, these men said, to Ostend.
+
+It was about two o'clock when my brother, having paid their fares
+at the gangway, found himself safely aboard the steamboat with his
+charges.  There was food aboard, albeit at exorbitant prices, and the
+three of them contrived to eat a meal on one of the seats forward.
+
+There were already a couple of score of passengers aboard, some of
+whom had expended their last money in securing a passage, but the
+captain lay off the Blackwater until five in the afternoon, picking up
+passengers until the seated decks were even dangerously crowded.  He
+would probably have remained longer had it not been for the sound of
+guns that began about that hour in the south.  As if in answer, the
+ironclad seaward fired a small gun and hoisted a string of flags.  A
+jet of smoke sprang out of her funnels.
+
+Some of the passengers were of opinion that this firing came from
+Shoeburyness, until it was noticed that it was growing louder.  At the
+same time, far away in the southeast the masts and upperworks of three
+ironclads rose one after the other out of the sea, beneath clouds of
+black smoke.  But my brother's attention speedily reverted to the
+distant firing in the south.  He fancied he saw a column of smoke
+rising out of the distant grey haze.
+
+The little steamer was already flapping her way eastward of the big
+crescent of shipping, and the low Essex coast was growing blue and
+hazy, when a Martian appeared, small and faint in the remote distance,
+advancing along the muddy coast from the direction of Foulness.  At
+that the captain on the bridge swore at the top of his voice with fear
+and anger at his own delay, and the paddles seemed infected with his
+terror.  Every soul aboard stood at the bulwarks or on the seats of
+the steamer and stared at that distant shape, higher than the trees or
+church towers inland, and advancing with a leisurely parody of a human
+stride.
+
+It was the first Martian my brother had seen, and he stood, more
+amazed than terrified, watching this Titan advancing deliberately
+towards the shipping, wading farther and farther into the water as the
+coast fell away.  Then, far away beyond the Crouch, came another,
+striding over some stunted trees, and then yet another, still farther
+off, wading deeply through a shiny mudflat that seemed to hang halfway
+up between sea and sky.  They were all stalking seaward, as if to
+intercept the escape of the multitudinous vessels that were crowded
+between Foulness and the Naze.  In spite of the throbbing exertions of
+the engines of the little paddle-boat, and the pouring foam that her
+wheels flung behind her, she receded with terrifying slowness from
+this ominous advance.
+
+Glancing northwestward, my brother saw the large crescent of
+shipping already writhing with the approaching terror; one ship
+passing behind another, another coming round from broadside to end on,
+steamships whistling and giving off volumes of steam, sails being let
+out, launches rushing hither and thither.  He was so fascinated by
+this and by the creeping danger away to the left that he had no eyes
+for anything seaward.  And then a swift movement of the steamboat (she
+had suddenly come round to avoid being run down) flung him headlong
+from the seat upon which he was standing.  There was a shouting all
+about him, a trampling of feet, and a cheer that seemed to be answered
+faintly.  The steamboat lurched and rolled him over upon his hands.
+
+He sprang to his feet and saw to starboard, and not a hundred yards
+from their heeling, pitching boat, a vast iron bulk like the blade of
+a plough tearing through the water, tossing it on either side in huge
+waves of foam that leaped towards the steamer, flinging her paddles
+helplessly in the air, and then sucking her deck down almost to the
+waterline.
+
+A douche of spray blinded my brother for a moment.  When his eyes
+were clear again he saw the monster had passed and was rushing
+landward.  Big iron upperworks rose out of this headlong structure,
+and from that twin funnels projected and spat a smoking blast shot
+with fire.  It was the torpedo ram, _Thunder Child_, steaming headlong,
+coming to the rescue of the threatened shipping.
+
+Keeping his footing on the heaving deck by clutching the bulwarks,
+my brother looked past this charging leviathan at the Martians again,
+and he saw the three of them now close together, and standing so far
+out to sea that their tripod supports were almost entirely submerged.
+Thus sunken, and seen in remote perspective, they appeared far less
+formidable than the huge iron bulk in whose wake the steamer was
+pitching so helplessly.  It would seem they were regarding this new
+antagonist with astonishment.  To their intelligence, it may be, the
+giant was even such another as themselves.  The _Thunder Child_ fired no
+gun, but simply drove full speed towards them.  It was probably her
+not firing that enabled her to get so near the enemy as she did.  They
+did not know what to make of her.  One shell, and they would have sent
+her to the bottom forthwith with the Heat-Ray.
+
+She was steaming at such a pace that in a minute she seemed halfway
+between the steamboat and the Martians--a diminishing black bulk
+against the receding horizontal expanse of the Essex coast.
+
+Suddenly the foremost Martian lowered his tube and discharged a
+canister of the black gas at the ironclad.  It hit her larboard side
+and glanced off in an inky jet that rolled away to seaward, an
+unfolding torrent of Black Smoke, from which the ironclad drove clear.
+To the watchers from the steamer, low in the water and with the sun in
+their eyes, it seemed as though she were already among the Martians.
+
+They saw the gaunt figures separating and rising out of the water
+as they retreated shoreward, and one of them raised the camera-like
+generator of the Heat-Ray.  He held it pointing obliquely downward,
+and a bank of steam sprang from the water at its touch.  It must have
+driven through the iron of the ship's side like a white-hot iron rod
+through paper.
+
+A flicker of flame went up through the rising steam, and then the
+Martian reeled and staggered.  In another moment he was cut down, and
+a great body of water and steam shot high in the air.  The guns of the
+_Thunder Child_ sounded through the reek, going off one after the other,
+and one shot splashed the water high close by the steamer, ricocheted
+towards the other flying ships to the north, and smashed a smack to
+matchwood.
+
+But no one heeded that very much.  At the sight of the Martian's
+collapse the captain on the bridge yelled inarticulately, and all the
+crowding passengers on the steamer's stern shouted together.  And then
+they yelled again.  For, surging out beyond the white tumult, drove
+something long and black, the flames streaming from its middle parts,
+its ventilators and funnels spouting fire.
+
+She was alive still; the steering gear, it seems, was intact and
+her engines working.  She headed straight for a second Martian, and
+was within a hundred yards of him when the Heat-Ray came to bear.  Then
+with a violent thud, a blinding flash, her decks, her funnels, leaped
+upward.  The Martian staggered with the violence of her explosion, and
+in another moment the flaming wreckage, still driving forward with the
+impetus of its pace, had struck him and crumpled him up like a thing
+of cardboard.  My brother shouted involuntarily.  A boiling tumult of
+steam hid everything again.
+
+"Two!" yelled the captain.
+
+Everyone was shouting.  The whole steamer from end to end rang with
+frantic cheering that was taken up first by one and then by all in the
+crowding multitude of ships and boats that was driving out to sea.
+
+The steam hung upon the water for many minutes, hiding the third
+Martian and the coast altogether.  And all this time the boat was
+paddling steadily out to sea and away from the fight; and when at last
+the confusion cleared, the drifting bank of black vapour intervened,
+and nothing of the _Thunder Child_ could be made out, nor could the
+third Martian be seen.  But the ironclads to seaward were now quite
+close and standing in towards shore past the steamboat.
+
+The little vessel continued to beat its way seaward, and the
+ironclads receded slowly towards the coast, which was hidden still by
+a marbled bank of vapour, part steam, part black gas, eddying and
+combining in the strangest way.  The fleet of refugees was scattering
+to the northeast; several smacks were sailing between the ironclads
+and the steamboat.  After a time, and before they reached the sinking
+cloud bank, the warships turned northward, and then abruptly went
+about and passed into the thickening haze of evening southward.  The
+coast grew faint, and at last indistinguishable amid the low banks of
+clouds that were gathering about the sinking sun.
+
+Then suddenly out of the golden haze of the sunset came the
+vibration of guns, and a form of black shadows moving.  Everyone
+struggled to the rail of the steamer and peered into the blinding
+furnace of the west, but nothing was to be distinguished clearly.  A
+mass of smoke rose slanting and barred the face of the sun.  The
+steamboat throbbed on its way through an interminable suspense.
+
+The sun sank into grey clouds, the sky flushed and darkened, the
+evening star trembled into sight.  It was deep twilight when the
+captain cried out and pointed.  My brother strained his eyes.
+Something rushed up into the sky out of the greyness--rushed
+slantingly upward and very swiftly into the luminous clearness above
+the clouds in the western sky; something flat and broad, and very
+large, that swept round in a vast curve, grew smaller, sank slowly,
+and vanished again into the grey mystery of the night.  And as it flew
+it rained down darkness upon the land.
+
+
+
+BOOK TWO
+
+THE EARTH UNDER THE MARTIANS
+
+
+
+CHAPTER ONE
+
+UNDER FOOT
+
+
+In the first book I have wandered so much from my own adventures to
+tell of the experiences of my brother that all through the last two
+chapters I and the curate have been lurking in the empty house at
+Halliford whither we fled to escape the Black Smoke.  There I will
+resume.  We stopped there all Sunday night and all the next day--the
+day of the panic--in a little island of daylight, cut off by the Black
+Smoke from the rest of the world.  We could do nothing but wait in
+aching inactivity during those two weary days.
+
+My mind was occupied by anxiety for my wife.  I figured her at
+Leatherhead, terrified, in danger, mourning me already as a dead man.
+I paced the rooms and cried aloud when I thought of how I was cut off
+from her, of all that might happen to her in my absence.  My cousin I
+knew was brave enough for any emergency, but he was not the sort of
+man to realise danger quickly, to rise promptly.  What was needed now
+was not bravery, but circumspection.  My only consolation was to
+believe that the Martians were moving London-ward and away from her.
+Such vague anxieties keep the mind sensitive and painful.  I grew very
+weary and irritable with the curate's perpetual ejaculations; I tired
+of the sight of his selfish despair.  After some ineffectual
+remonstrance I kept away from him, staying in a room--evidently a
+children's schoolroom--containing globes, forms, and copybooks.  When
+he followed me thither, I went to a box room at the top of the house
+and, in order to be alone with my aching miseries, locked myself in.
+
+We were hopelessly hemmed in by the Black Smoke all that day and
+the morning of the next.  There were signs of people in the next house
+on Sunday evening--a face at a window and moving lights, and later the
+slamming of a door.  But I do not know who these people were, nor what
+became of them.  We saw nothing of them next day.  The Black Smoke
+drifted slowly riverward all through Monday morning, creeping nearer
+and nearer to us, driving at last along the roadway outside the house
+that hid us.
+
+A Martian came across the fields about midday, laying the stuff
+with a jet of superheated steam that hissed against the walls, smashed
+all the windows it touched, and scalded the curate's hand as he fled
+out of the front room.  When at last we crept across the sodden rooms
+and looked out again, the country northward was as though a black
+snowstorm had passed over it.  Looking towards the river, we were
+astonished to see an unaccountable redness mingling with the black of
+the scorched meadows.
+
+For a time we did not see how this change affected our position,
+save that we were relieved of our fear of the Black Smoke.  But later
+I perceived that we were no longer hemmed in, that now we might get
+away.  So soon as I realised that the way of escape was open, my dream
+of action returned.  But the curate was lethargic, unreasonable.
+
+"We are safe here," he repeated; "safe here."
+
+I resolved to leave him--would that I had!  Wiser now for the
+artilleryman's teaching, I sought out food and drink.  I had found oil
+and rags for my burns, and I also took a hat and a flannel shirt that
+I found in one of the bedrooms.  When it was clear to him that I meant
+to go alone--had reconciled myself to going alone--he suddenly roused
+himself to come.  And all being quiet throughout the afternoon, we
+started about five o'clock, as I should judge, along the blackened
+road to Sunbury.
+
+In Sunbury, and at intervals along the road, were dead bodies lying
+in contorted attitudes, horses as well as men, overturned carts and
+luggage, all covered thickly with black dust.  That pall of cindery
+powder made me think of what I had read of the destruction of Pompeii.
+We got to Hampton Court without misadventure, our minds full of
+strange and unfamiliar appearances, and at Hampton Court our eyes were
+relieved to find a patch of green that had escaped the suffocating
+drift.  We went through Bushey Park, with its deer going to and fro
+under the chestnuts, and some men and women hurrying in the distance
+towards Hampton, and so we came to Twickenham.  These were the first
+people we saw.
+
+Away across the road the woods beyond Ham and Petersham were still
+afire.  Twickenham was uninjured by either Heat-Ray or Black Smoke,
+and there were more people about here, though none could give us news.
+For the most part they were like ourselves, taking advantage of a lull
+to shift their quarters.  I have an impression that many of the houses
+here were still occupied by scared inhabitants, too frightened even
+for flight.  Here too the evidence of a hasty rout was abundant along
+the road.  I remember most vividly three smashed bicycles in a heap,
+pounded into the road by the wheels of subsequent carts.  We crossed
+Richmond Bridge about half past eight.  We hurried across the exposed
+bridge, of course, but I noticed floating down the stream a number
+of red masses, some many feet across.  I did not know what these
+were--there was no time for scrutiny--and I put a more horrible
+interpretation on them than they deserved.  Here again on the Surrey
+side were black dust that had once been smoke, and dead bodies--a heap
+near the approach to the station; but we had no glimpse of the
+Martians until we were some way towards Barnes.
+
+We saw in the blackened distance a group of three people running
+down a side street towards the river, but otherwise it seemed
+deserted.  Up the hill Richmond town was burning briskly; outside the
+town of Richmond there was no trace of the Black Smoke.
+
+Then suddenly, as we approached Kew, came a number of people
+running, and the upperworks of a Martian fighting-machine loomed in
+sight over the housetops, not a hundred yards away from us.  We stood
+aghast at our danger, and had the Martian looked down we must
+immediately have perished.  We were so terrified that we dared not go
+on, but turned aside and hid in a shed in a garden.  There the curate
+crouched, weeping silently, and refusing to stir again.
+
+But my fixed idea of reaching Leatherhead would not let me rest,
+and in the twilight I ventured out again.  I went through a shrubbery,
+and along a passage beside a big house standing in its own grounds,
+and so emerged upon the road towards Kew.  The curate I left in the
+shed, but he came hurrying after me.
+
+That second start was the most foolhardy thing I ever did.  For it
+was manifest the Martians were about us.  No sooner had the curate
+overtaken me than we saw either the fighting-machine we had seen
+before or another, far away across the meadows in the direction of Kew
+Lodge.  Four or five little black figures hurried before it across the
+green-grey of the field, and in a moment it was evident this Martian
+pursued them.  In three strides he was among them, and they ran
+radiating from his feet in all directions.  He used no Heat-Ray to
+destroy them, but picked them up one by one.  Apparently he tossed
+them into the great metallic carrier which projected behind him, much
+as a workman's basket hangs over his shoulder.
+
+It was the first time I realised that the Martians might have any
+other purpose than destruction with defeated humanity.  We stood for a
+moment petrified, then turned and fled through a gate behind us into a
+walled garden, fell into, rather than found, a fortunate ditch, and
+lay there, scarce daring to whisper to each other until the stars were
+out.
+
+I suppose it was nearly eleven o'clock before we gathered courage
+to start again, no longer venturing into the road, but sneaking along
+hedgerows and through plantations, and watching keenly through the
+darkness, he on the right and I on the left, for the Martians, who
+seemed to be all about us.  In one place we blundered upon a scorched
+and blackened area, now cooling and ashen, and a number of scattered
+dead bodies of men, burned horribly about the heads and trunks but
+with their legs and boots mostly intact; and of dead horses, fifty
+feet, perhaps, behind a line of four ripped guns and smashed gun
+carriages.
+
+Sheen, it seemed, had escaped destruction, but the place was silent
+and deserted.  Here we happened on no dead, though the night was too
+dark for us to see into the side roads of the place.  In Sheen my
+companion suddenly complained of faintness and thirst, and we decided
+to try one of the houses.
+
+The first house we entered, after a little difficulty with the
+window, was a small semi-detached villa, and I found nothing eatable
+left in the place but some mouldy cheese.  There was, however, water
+to drink; and I took a hatchet, which promised to be useful in our
+next house-breaking.
+
+We then crossed to a place where the road turns towards Mortlake.
+Here there stood a white house within a walled garden, and in the
+pantry of this domicile we found a store of food--two loaves of bread
+in a pan, an uncooked steak, and the half of a ham.  I give this
+catalogue so precisely because, as it happened, we were destined to
+subsist upon this store for the next fortnight.  Bottled beer stood
+under a shelf, and there were two bags of haricot beans and some limp
+lettuces.  This pantry opened into a kind of wash-up kitchen, and in
+this was firewood; there was also a cupboard, in which we found nearly
+a dozen of burgundy, tinned soups and salmon, and two tins of
+biscuits.
+
+We sat in the adjacent kitchen in the dark--for we dared not strike
+a light--and ate bread and ham, and drank beer out of the same bottle.
+The curate, who was still timorous and restless, was now, oddly
+enough, for pushing on, and I was urging him to keep up his strength
+by eating when the thing happened that was to imprison us.
+
+"It can't be midnight yet," I said, and then came a blinding glare
+of vivid green light.  Everything in the kitchen leaped out, clearly
+visible in green and black, and vanished again.  And then followed such
+a concussion as I have never heard before or since.  So close on the
+heels of this as to seem instantaneous came a thud behind me, a clash
+of glass, a crash and rattle of falling masonry all about us, and the
+plaster of the ceiling came down upon us, smashing into a multitude of
+fragments upon our heads.  I was knocked headlong across the floor
+against the oven handle and stunned.  I was insensible for a long
+time, the curate told me, and when I came to we were in darkness
+again, and he, with a face wet, as I found afterwards, with blood from
+a cut forehead, was dabbing water over me.
+
+For some time I could not recollect what had happened.  Then things
+came to me slowly.  A bruise on my temple asserted itself.
+
+"Are you better?" asked the curate in a whisper.
+
+At last I answered him.  I sat up.
+
+"Don't move," he said.  "The floor is covered with smashed crockery
+from the dresser.  You can't possibly move without making a noise, and
+I fancy _they_ are outside."
+
+We both sat quite silent, so that we could scarcely hear each other
+breathing.  Everything seemed deadly still, but once something near
+us, some plaster or broken brickwork, slid down with a rumbling sound.
+Outside and very near was an intermittent, metallic rattle.
+
+"That!" said the curate, when presently it happened again.
+
+"Yes," I said.  "But what is it?"
+
+"A Martian!" said the curate.
+
+I listened again.
+
+"It was not like the Heat-Ray," I said, and for a time I was
+inclined to think one of the great fighting-machines had stumbled
+against the house, as I had seen one stumble against the tower of
+Shepperton Church.
+
+Our situation was so strange and incomprehensible that for three or
+four hours, until the dawn came, we scarcely moved.  And then the light
+filtered in, not through the window, which remained black, but through
+a triangular aperture between a beam and a heap of broken bricks in
+the wall behind us.  The interior of the kitchen we now saw greyly for
+the first time.
+
+The window had been burst in by a mass of garden mould, which
+flowed over the table upon which we had been sitting and lay about our
+feet.  Outside, the soil was banked high against the house.  At the
+top of the window frame we could see an uprooted drainpipe.  The floor
+was littered with smashed hardware; the end of the kitchen towards the
+house was broken into, and since the daylight shone in there, it was
+evident the greater part of the house had collapsed.  Contrasting
+vividly with this ruin was the neat dresser, stained in the fashion,
+pale green, and with a number of copper and tin vessels below it, the
+wallpaper imitating blue and white tiles, and a couple of coloured
+supplements fluttering from the walls above the kitchen range.
+
+As the dawn grew clearer, we saw through the gap in the wall the
+body of a Martian, standing sentinel, I suppose, over the still
+glowing cylinder.  At the sight of that we crawled as circumspectly as
+possible out of the twilight of the kitchen into the darkness of the
+scullery.
+
+Abruptly the right interpretation dawned upon my mind.
+
+"The fifth cylinder," I whispered, "the fifth shot from Mars, has
+struck this house and buried us under the ruins!"
+
+For a time the curate was silent, and then he whispered:
+
+"God have mercy upon us!"
+
+I heard him presently whimpering to himself.
+
+Save for that sound we lay quite still in the scullery; I for my
+part scarce dared breathe, and sat with my eyes fixed on the faint
+light of the kitchen door.  I could just see the curate's face, a dim,
+oval shape, and his collar and cuffs.  Outside there began a metallic
+hammering, then a violent hooting, and then again, after a quiet
+interval, a hissing like the hissing of an engine.  These noises, for
+the most part problematical, continued intermittently, and seemed if
+anything to increase in number as time wore on.  Presently a measured
+thudding and a vibration that made everything about us quiver and the
+vessels in the pantry ring and shift, began and continued.  Once the
+light was eclipsed, and the ghostly kitchen doorway became absolutely
+dark.  For many hours we must have crouched there, silent and
+shivering, until our tired attention failed. . . .
+
+At last I found myself awake and very hungry.  I am inclined to
+believe we must have spent the greater portion of a day before that
+awakening.  My hunger was at a stride so insistent that it moved me to
+action.  I told the curate I was going to seek food, and felt my way
+towards the pantry.  He made me no answer, but so soon as I began
+eating the faint noise I made stirred him up and I heard him crawling
+after me.
+
+
+
+CHAPTER TWO
+
+WHAT WE SAW FROM THE RUINED HOUSE
+
+
+After eating we crept back to the scullery, and there I must have
+dozed again, for when presently I looked round I was alone.  The
+thudding vibration continued with wearisome persistence.  I whispered
+for the curate several times, and at last felt my way to the door of
+the kitchen.  It was still daylight, and I perceived him across the
+room, lying against the triangular hole that looked out upon the
+Martians.  His shoulders were hunched, so that his head was hidden
+from me.
+
+I could hear a number of noises almost like those in an engine
+shed; and the place rocked with that beating thud.  Through the
+aperture in the wall I could see the top of a tree touched with gold
+and the warm blue of a tranquil evening sky.  For a minute or so I
+remained watching the curate, and then I advanced, crouching and
+stepping with extreme care amid the broken crockery that littered the
+floor.
+
+I touched the curate's leg, and he started so violently that a mass
+of plaster went sliding down outside and fell with a loud impact.  I
+gripped his arm, fearing he might cry out, and for a long time we
+crouched motionless.  Then I turned to see how much of our rampart
+remained.  The detachment of the plaster had left a vertical slit open
+in the debris, and by raising myself cautiously across a beam I was
+able to see out of this gap into what had been overnight a quiet
+suburban roadway.  Vast, indeed, was the change that we beheld.
+
+The fifth cylinder must have fallen right into the midst of the
+house we had first visited.  The building had vanished, completely
+smashed, pulverised, and dispersed by the blow.  The cylinder lay now
+far beneath the original foundations--deep in a hole, already vastly
+larger than the pit I had looked into at Woking.  The earth all round
+it had splashed under that tremendous impact--"splashed" is the only
+word--and lay in heaped piles that hid the masses of the adjacent
+houses.  It had behaved exactly like mud under the violent blow of a
+hammer.  Our house had collapsed backward; the front portion, even on
+the ground floor, had been destroyed completely; by a chance the
+kitchen and scullery had escaped, and stood buried now under soil and
+ruins, closed in by tons of earth on every side save towards the
+cylinder.  Over that aspect we hung now on the very edge of the great
+circular pit the Martians were engaged in making.  The heavy beating
+sound was evidently just behind us, and ever and again a bright green
+vapour drove up like a veil across our peephole.
+
+The cylinder was already opened in the centre of the pit, and on
+the farther edge of the pit, amid the smashed and gravel-heaped
+shrubbery, one of the great fighting-machines, deserted by its
+occupant, stood stiff and tall against the evening sky.  At first I
+scarcely noticed the pit and the cylinder, although it has been
+convenient to describe them first, on account of the extraordinary
+glittering mechanism I saw busy in the excavation, and on account of
+the strange creatures that were crawling slowly and painfully across
+the heaped mould near it.
+
+The mechanism it certainly was that held my attention first.  It
+was one of those complicated fabrics that have since been called
+handling-machines, and the study of which has already given such an
+enormous impetus to terrestrial invention.  As it dawned upon me
+first, it presented a sort of metallic spider with five jointed,
+agile legs, and with an extraordinary number of jointed levers, bars,
+and reaching and clutching tentacles about its body.  Most of its
+arms were retracted, but with three long tentacles it was fishing
+out a number of rods, plates, and bars which lined the covering and
+apparently strengthened the walls of the cylinder.  These, as it
+extracted them, were lifted out and deposited upon a level surface
+of earth behind it.
+
+Its motion was so swift, complex, and perfect that at first I did
+not see it as a machine, in spite of its metallic glitter.  The
+fighting-machines were coordinated and animated to an extraordinary
+pitch, but nothing to compare with this.  People who have never seen
+these structures, and have only the ill-imagined efforts of artists or
+the imperfect descriptions of such eye-witnesses as myself to go upon,
+scarcely realise that living quality.
+
+I recall particularly the illustration of one of the first
+pamphlets to give a consecutive account of the war.  The artist had
+evidently made a hasty study of one of the fighting-machines, and
+there his knowledge ended.  He presented them as tilted, stiff
+tripods, without either flexibility or subtlety, and with an
+altogether misleading monotony of effect.  The pamphlet containing
+these renderings had a considerable vogue, and I mention them here
+simply to warn the reader against the impression they may have
+created.  They were no more like the Martians I saw in action than a
+Dutch doll is like a human being.  To my mind, the pamphlet would have
+been much better without them.
+
+At first, I say, the handling-machine did not impress me as a
+machine, but as a crablike creature with a glittering integument, the
+controlling Martian whose delicate tentacles actuated its movements
+seeming to be simply the equivalent of the crab's cerebral portion.
+But then I perceived the resemblance of its grey-brown, shiny,
+leathery integument to that of the other sprawling bodies beyond, and
+the true nature of this dexterous workman dawned upon me.  With that
+realisation my interest shifted to those other creatures, the real
+Martians.  Already I had had a transient impression of these, and the
+first nausea no longer obscured my observation.  Moreover, I was
+concealed and motionless, and under no urgency of action.
+
+They were, I now saw, the most unearthly creatures it is possible
+to conceive.  They were huge round bodies--or, rather, heads--about
+four feet in diameter, each body having in front of it a face.  This
+face had no nostrils--indeed, the Martians do not seem to have had any
+sense of smell, but it had a pair of very large dark-coloured eyes,
+and just beneath this a kind of fleshy beak.  In the back of this head
+or body--I scarcely know how to speak of it--was the single tight
+tympanic surface, since known to be anatomically an ear, though it
+must have been almost useless in our dense air.  In a group round the
+mouth were sixteen slender, almost whiplike tentacles, arranged in two
+bunches of eight each.  These bunches have since been named rather
+aptly, by that distinguished anatomist, Professor Howes, the _hands_.
+Even as I saw these Martians for the first time they seemed to be
+endeavouring to raise themselves on these hands, but of course, with
+the increased weight of terrestrial conditions, this was impossible.
+There is reason to suppose that on Mars they may have progressed upon
+them with some facility.
+
+The internal anatomy, I may remark here, as dissection has since
+shown, was almost equally simple.  The greater part of the structure
+was the brain, sending enormous nerves to the eyes, ear, and tactile
+tentacles.  Besides this were the bulky lungs, into which the mouth
+opened, and the heart and its vessels.  The pulmonary distress caused
+by the denser atmosphere and greater gravitational attraction was only
+too evident in the convulsive movements of the outer skin.
+
+And this was the sum of the Martian organs.  Strange as it may seem
+to a human being, all the complex apparatus of digestion, which makes
+up the bulk of our bodies, did not exist in the Martians.  They were
+heads--merely heads.  Entrails they had none.  They did not eat, much
+less digest.  Instead, they took the fresh, living blood of other
+creatures, and _injected_ it into their own veins.  I have myself seen
+this being done, as I shall mention in its place.  But, squeamish as I
+may seem, I cannot bring myself to describe what I could not endure
+even to continue watching.  Let it suffice to say, blood obtained from
+a still living animal, in most cases from a human being, was run
+directly by means of a little pipette into the recipient canal. . . .
+
+The bare idea of this is no doubt horribly repulsive to us, but at
+the same time I think that we should remember how repulsive our
+carnivorous habits would seem to an intelligent rabbit.
+
+The physiological advantages of the practice of injection are
+undeniable, if one thinks of the tremendous waste of human time and
+energy occasioned by eating and the digestive process.  Our bodies are
+half made up of glands and tubes and organs, occupied in turning
+heterogeneous food into blood.  The digestive processes and their
+reaction upon the nervous system sap our strength and colour our
+minds.  Men go happy or miserable as they have healthy or unhealthy
+livers, or sound gastric glands.  But the Martians were lifted above
+all these organic fluctuations of mood and emotion.
+
+Their undeniable preference for men as their source of nourishment
+is partly explained by the nature of the remains of the victims they
+had brought with them as provisions from Mars.  These creatures, to
+judge from the shrivelled remains that have fallen into human hands,
+were bipeds with flimsy, silicious skeletons (almost like those of the
+silicious sponges) and feeble musculature, standing about six feet
+high and having round, erect heads, and large eyes in flinty sockets.
+Two or three of these seem to have been brought in each cylinder, and
+all were killed before earth was reached.  It was just as well for
+them, for the mere attempt to stand upright upon our planet would have
+broken every bone in their bodies.
+
+And while I am engaged in this description, I may add in this place
+certain further details which, although they were not all evident to
+us at the time, will enable the reader who is unacquainted with them
+to form a clearer picture of these offensive creatures.
+
+In three other points their physiology differed strangely from
+ours.  Their organisms did not sleep, any more than the heart of man
+sleeps.  Since they had no extensive muscular mechanism to recuperate,
+that periodical extinction was unknown to them.  They had little or
+no sense of fatigue, it would seem.  On earth they could never have
+moved without effort, yet even to the last they kept in action.  In
+twenty-four hours they did twenty-four hours of work, as even on earth
+is perhaps the case with the ants.
+
+In the next place, wonderful as it seems in a sexual world, the
+Martians were absolutely without sex, and therefore without any of the
+tumultuous emotions that arise from that difference among men.  A
+young Martian, there can now be no dispute, was really born upon earth
+during the war, and it was found attached to its parent, partially
+_budded_ off, just as young lilybulbs bud off, or like the young animals
+in the fresh-water polyp.
+
+In man, in all the higher terrestrial animals, such a method of
+increase has disappeared; but even on this earth it was certainly the
+primitive method.  Among the lower animals, up even to those first
+cousins of the vertebrated animals, the Tunicates, the two processes
+occur side by side, but finally the sexual method superseded its
+competitor altogether.  On Mars, however, just the reverse has
+apparently been the case.
+
+It is worthy of remark that a certain speculative writer of
+quasi-scientific repute, writing long before the Martian invasion, did
+forecast for man a final structure not unlike the actual Martian
+condition.  His prophecy, I remember, appeared in November or
+December, 1893, in a long-defunct publication, the _Pall Mall Budget_,
+and I recall a caricature of it in a pre-Martian periodical called
+_Punch_.  He pointed out--writing in a foolish, facetious tone--that the
+perfection of mechanical appliances must ultimately supersede limbs;
+the perfection of chemical devices, digestion; that such organs as
+hair, external nose, teeth, ears, and chin were no longer essential
+parts of the human being, and that the tendency of natural selection
+would lie in the direction of their steady diminution through the
+coming ages.  The brain alone remained a cardinal necessity.  Only one
+other part of the body had a strong case for survival, and that was
+the hand, "teacher and agent of the brain."  While the rest of the
+body dwindled, the hands would grow larger.
+
+There is many a true word written in jest, and here in the Martians
+we have beyond dispute the actual accomplishment of such a suppression
+of the animal side of the organism by the intelligence.  To me it is
+quite credible that the Martians may be descended from beings not
+unlike ourselves, by a gradual development of brain and hands (the
+latter giving rise to the two bunches of delicate tentacles at last)
+at the expense of the rest of the body.  Without the body the brain
+would, of course, become a mere selfish intelligence, without any of
+the emotional substratum of the human being.
+
+The last salient point in which the systems of these creatures
+differed from ours was in what one might have thought a very trivial
+particular.  Micro-organisms, which cause so much disease and pain on
+earth, have either never appeared upon Mars or Martian sanitary
+science eliminated them ages ago.  A hundred diseases, all the fevers
+and contagions of human life, consumption, cancers, tumours and such
+morbidities, never enter the scheme of their life.  And speaking of
+the differences between the life on Mars and terrestrial life, I may
+allude here to the curious suggestions of the red weed.
+
+Apparently the vegetable kingdom in Mars, instead of having green
+for a dominant colour, is of a vivid blood-red tint.  At any rate, the
+seeds which the Martians (intentionally or accidentally) brought with
+them gave rise in all cases to red-coloured growths.  Only that known
+popularly as the red weed, however, gained any footing in competition
+with terrestrial forms.  The red creeper was quite a transitory
+growth, and few people have seen it growing.  For a time, however, the
+red weed grew with astonishing vigour and luxuriance.  It spread up
+the sides of the pit by the third or fourth day of our imprisonment,
+and its cactus-like branches formed a carmine fringe to the edges of
+our triangular window.  And afterwards I found it broadcast throughout
+the country, and especially wherever there was a stream of water.
+
+The Martians had what appears to have been an auditory organ, a
+single round drum at the back of the head-body, and eyes with a visual
+range not very different from ours except that, according to Philips,
+blue and violet were as black to them.  It is commonly supposed that
+they communicated by sounds and tentacular gesticulations; this is
+asserted, for instance, in the able but hastily compiled pamphlet
+(written evidently by someone not an eye-witness of Martian actions)
+to which I have already alluded, and which, so far, has been the chief
+source of information concerning them.  Now no surviving human being
+saw so much of the Martians in action as I did.  I take no credit to
+myself for an accident, but the fact is so.  And I assert that I
+watched them closely time after time, and that I have seen four, five,
+and (once) six of them sluggishly performing the most elaborately
+complicated operations together without either sound or gesture.  Their
+peculiar hooting invariably preceded feeding; it had no modulation,
+and was, I believe, in no sense a signal, but merely the expiration of
+air preparatory to the suctional operation.  I have a certain claim to
+at least an elementary knowledge of psychology, and in this matter I
+am convinced--as firmly as I am convinced of anything--that the
+Martians interchanged thoughts without any physical intermediation.
+And I have been convinced of this in spite of strong preconceptions.
+Before the Martian invasion, as an occasional reader here or there may
+remember, I had written with some little vehemence against the
+telepathic theory.
+
+The Martians wore no clothing.  Their conceptions of ornament and
+decorum were necessarily different from ours; and not only were they
+evidently much less sensible of changes of temperature than we are,
+but changes of pressure do not seem to have affected their health at
+all seriously.  Yet though they wore no clothing, it was in the other
+artificial additions to their bodily resources that their great
+superiority over man lay.  We men, with our bicycles and road-skates,
+our Lilienthal soaring-machines, our guns and sticks and so forth, are
+just in the beginning of the evolution that the Martians have worked
+out.  They have become practically mere brains, wearing different
+bodies according to their needs just as men wear suits of clothes and
+take a bicycle in a hurry or an umbrella in the wet.  And of their
+appliances, perhaps nothing is more wonderful to a man than the
+curious fact that what is the dominant feature of almost all human
+devices in mechanism is absent--the _wheel_ is absent; among all the
+things they brought to earth there is no trace or suggestion of their
+use of wheels.  One would have at least expected it in locomotion.  And
+in this connection it is curious to remark that even on this earth
+Nature has never hit upon the wheel, or has preferred other expedients
+to its development.  And not only did the Martians either not know of
+(which is incredible), or abstain from, the wheel, but in their
+apparatus singularly little use is made of the fixed pivot or
+relatively fixed pivot, with circular motions thereabout confined
+to one plane.  Almost all the joints of the machinery present a
+complicated system of sliding parts moving over small but beautifully
+curved friction bearings.  And while upon this matter of detail, it is
+remarkable that the long leverages of their machines are in most cases
+actuated by a sort of sham musculature of the disks in an elastic
+sheath; these disks become polarised and drawn closely and powerfully
+together when traversed by a current of electricity.  In this way the
+curious parallelism to animal motions, which was so striking and
+disturbing to the human beholder, was attained.  Such quasi-muscles
+abounded in the crablike handling-machine which, on my first peeping
+out of the slit, I watched unpacking the cylinder.  It seemed
+infinitely more alive than the actual Martians lying beyond it in the
+sunset light, panting, stirring ineffectual tentacles, and moving
+feebly after their vast journey across space.
+
+While I was still watching their sluggish motions in the sunlight,
+and noting each strange detail of their form, the curate reminded me
+of his presence by pulling violently at my arm.  I turned to a
+scowling face, and silent, eloquent lips.  He wanted the slit, which
+permitted only one of us to peep through; and so I had to forego
+watching them for a time while he enjoyed that privilege.
+
+When I looked again, the busy handling-machine had already put
+together several of the pieces of apparatus it had taken out of the
+cylinder into a shape having an unmistakable likeness to its own; and
+down on the left a busy little digging mechanism had come into view,
+emitting jets of green vapour and working its way round the pit,
+excavating and embanking in a methodical and discriminating manner.
+This it was which had caused the regular beating noise, and the
+rhythmic shocks that had kept our ruinous refuge quivering.  It piped
+and whistled as it worked.  So far as I could see, the thing was
+without a directing Martian at all.
+
+
+
+CHAPTER THREE
+
+THE DAYS OF IMPRISONMENT
+
+
+The arrival of a second fighting-machine drove us from our peephole
+into the scullery, for we feared that from his elevation the Martian
+might see down upon us behind our barrier.  At a later date we began
+to feel less in danger of their eyes, for to an eye in the dazzle of
+the sunlight outside our refuge must have been blank blackness, but at
+first the slightest suggestion of approach drove us into the scullery
+in heart-throbbing retreat.  Yet terrible as was the danger we
+incurred, the attraction of peeping was for both of us irresistible.
+And I recall now with a sort of wonder that, in spite of the infinite
+danger in which we were between starvation and a still more terrible
+death, we could yet struggle bitterly for that horrible privilege of
+sight.  We would race across the kitchen in a grotesque way between
+eagerness and the dread of making a noise, and strike each other, and
+thrust and kick, within a few inches of exposure.
+
+The fact is that we had absolutely incompatible dispositions and
+habits of thought and action, and our danger and isolation only
+accentuated the incompatibility.  At Halliford I had already come to
+hate the curate's trick of helpless exclamation, his stupid rigidity
+of mind.  His endless muttering monologue vitiated every effort I made
+to think out a line of action, and drove me at times, thus pent up and
+intensified, almost to the verge of craziness.  He was as lacking in
+restraint as a silly woman.  He would weep for hours together, and I
+verily believe that to the very end this spoiled child of life thought
+his weak tears in some way efficacious.  And I would sit in the
+darkness unable to keep my mind off him by reason of his
+importunities.  He ate more than I did, and it was in vain I pointed
+out that our only chance of life was to stop in the house until the
+Martians had done with their pit, that in that long patience a time
+might presently come when we should need food.  He ate and drank
+impulsively in heavy meals at long intervals.  He slept little.
+
+As the days wore on, his utter carelessness of any consideration so
+intensified our distress and danger that I had, much as I loathed
+doing it, to resort to threats, and at last to blows.  That brought him
+to reason for a time.  But he was one of those weak creatures, void of
+pride, timorous, anaemic, hateful souls, full of shifty cunning, who
+face neither God nor man, who face not even themselves.
+
+It is disagreeable for me to recall and write these things, but I
+set them down that my story may lack nothing.  Those who have escaped
+the dark and terrible aspects of life will find my brutality, my flash
+of rage in our final tragedy, easy enough to blame; for they know what
+is wrong as well as any, but not what is possible to tortured men.  But
+those who have been under the shadow, who have gone down at last to
+elemental things, will have a wider charity.
+
+And while within we fought out our dark, dim contest of whispers,
+snatched food and drink, and gripping hands and blows, without, in the
+pitiless sunlight of that terrible June, was the strange wonder, the
+unfamiliar routine of the Martians in the pit.  Let me return to those
+first new experiences of mine.  After a long time I ventured back to
+the peephole, to find that the new-comers had been reinforced by the
+occupants of no fewer than three of the fighting-machines.  These last
+had brought with them certain fresh appliances that stood in an
+orderly manner about the cylinder.  The second handling-machine was now
+completed, and was busied in serving one of the novel contrivances the
+big machine had brought.  This was a body resembling a milk can in its
+general form, above which oscillated a pear-shaped receptacle, and
+from which a stream of white powder flowed into a circular basin
+below.
+
+The oscillatory motion was imparted to this by one tentacle of the
+handling-machine.  With two spatulate hands the handling-machine was
+digging out and flinging masses of clay into the pear-shaped
+receptacle above, while with another arm it periodically opened a door
+and removed rusty and blackened clinkers from the middle part of the
+machine.  Another steely tentacle directed the powder from the basin
+along a ribbed channel towards some receiver that was hidden from me
+by the mound of bluish dust.  From this unseen receiver a little
+thread of green smoke rose vertically into the quiet air.  As I looked,
+the handling-machine, with a faint and musical clinking, extended,
+telescopic fashion, a tentacle that had been a moment before a mere
+blunt projection, until its end was hidden behind the mound of clay.
+In another second it had lifted a bar of white aluminium into sight,
+untarnished as yet, and shining dazzlingly, and deposited it in a
+growing stack of bars that stood at the side of the pit.  Between
+sunset and starlight this dexterous machine must have made more than a
+hundred such bars out of the crude clay, and the mound of bluish dust
+rose steadily until it topped the side of the pit.
+
+The contrast between the swift and complex movements of these
+contrivances and the inert panting clumsiness of their masters was
+acute, and for days I had to tell myself repeatedly that these latter
+were indeed the living of the two things.
+
+The curate had possession of the slit when the first men were
+brought to the pit.  I was sitting below, huddled up, listening with
+all my ears.  He made a sudden movement backward, and I, fearful that
+we were observed, crouched in a spasm of terror.  He came sliding down
+the rubbish and crept beside me in the darkness, inarticulate,
+gesticulating, and for a moment I shared his panic.  His gesture
+suggested a resignation of the slit, and after a little while my
+curiosity gave me courage, and I rose up, stepped across him, and
+clambered up to it.  At first I could see no reason for his frantic
+behaviour.  The twilight had now come, the stars were little and
+faint, but the pit was illuminated by the flickering green fire that
+came from the aluminium-making.  The whole picture was a flickering
+scheme of green gleams and shifting rusty black shadows, strangely
+trying to the eyes.  Over and through it all went the bats, heeding it
+not at all.  The sprawling Martians were no longer to be seen, the
+mound of blue-green powder had risen to cover them from sight, and a
+fighting-machine, with its legs contracted, crumpled, and abbreviated,
+stood across the corner of the pit.  And then, amid the clangour of
+the machinery, came a drifting suspicion of human voices, that I
+entertained at first only to dismiss.
+
+I crouched, watching this fighting-machine closely, satisfying
+myself now for the first time that the hood did indeed contain a
+Martian.  As the green flames lifted I could see the oily gleam of
+his integument and the brightness of his eyes.  And suddenly I heard
+a yell, and saw a long tentacle reaching over the shoulder of the
+machine to the little cage that hunched upon its back.  Then
+something--something struggling violently--was lifted high against the
+sky, a black, vague enigma against the starlight; and as this black
+object came down again, I saw by the green brightness that it was a
+man.  For an instant he was clearly visible.  He was a stout, ruddy,
+middle-aged man, well dressed; three days before, he must have been
+walking the world, a man of considerable consequence.  I could see his
+staring eyes and gleams of light on his studs and watch chain.  He
+vanished behind the mound, and for a moment there was silence.  And
+then began a shrieking and a sustained and cheerful hooting from the
+Martians.
+
+I slid down the rubbish, struggled to my feet, clapped my hands
+over my ears, and bolted into the scullery.  The curate, who had been
+crouching silently with his arms over his head, looked up as I passed,
+cried out quite loudly at my desertion of him, and came running after
+me.
+
+That night, as we lurked in the scullery, balanced between our
+horror and the terrible fascination this peeping had, although I felt
+an urgent need of action I tried in vain to conceive some plan of
+escape; but afterwards, during the second day, I was able to consider
+our position with great clearness.  The curate, I found, was quite
+incapable of discussion; this new and culminating atrocity had robbed
+him of all vestiges of reason or forethought.  Practically he had
+already sunk to the level of an animal.  But as the saying goes, I
+gripped myself with both hands.  It grew upon my mind, once I could
+face the facts, that terrible as our position was, there was as yet
+no justification for absolute despair.  Our chief chance lay in the
+possibility of the Martians making the pit nothing more than a
+temporary encampment.  Or even if they kept it permanently, they might
+not consider it necessary to guard it, and a chance of escape might be
+afforded us.  I also weighed very carefully the possibility of our
+digging a way out in a direction away from the pit, but the chances of
+our emerging within sight of some sentinel fighting-machine seemed at
+first too great.  And I should have had to do all the digging myself.
+The curate would certainly have failed me.
+
+It was on the third day, if my memory serves me right, that I saw
+the lad killed.  It was the only occasion on which I actually saw the
+Martians feed.  After that experience I avoided the hole in the wall
+for the better part of a day.  I went into the scullery, removed the
+door, and spent some hours digging with my hatchet as silently as
+possible; but when I had made a hole about a couple of feet deep the
+loose earth collapsed noisily, and I did not dare continue.  I lost
+heart, and lay down on the scullery floor for a long time, having no
+spirit even to move.  And after that I abandoned altogether the idea
+of escaping by excavation.
+
+It says much for the impression the Martians had made upon me that
+at first I entertained little or no hope of our escape being brought
+about by their overthrow through any human effort.  But on the fourth
+or fifth night I heard a sound like heavy guns.
+
+It was very late in the night, and the moon was shining brightly.
+The Martians had taken away the excavating-machine, and, save for a
+fighting-machine that stood in the remoter bank of the pit and a
+handling-machine that was buried out of my sight in a corner of the
+pit immediately beneath my peephole, the place was deserted by them.
+Except for the pale glow from the handling-machine and the bars and
+patches of white moonlight the pit was in darkness, and, except for
+the clinking of the handling-machine, quite still.  That night was a
+beautiful serenity; save for one planet, the moon seemed to have the
+sky to herself.  I heard a dog howling, and that familiar sound it was
+that made me listen.  Then I heard quite distinctly a booming exactly
+like the sound of great guns.  Six distinct reports I counted, and
+after a long interval six again.  And that was all.
+
+
+
+CHAPTER FOUR
+
+THE DEATH OF THE CURATE
+
+
+It was on the sixth day of our imprisonment that I peeped for the
+last time, and presently found myself alone.  Instead of keeping close
+to me and trying to oust me from the slit, the curate had gone back
+into the scullery.  I was struck by a sudden thought.  I went back
+quickly and quietly into the scullery.  In the darkness I heard the
+curate drinking.  I snatched in the darkness, and my fingers caught a
+bottle of burgundy.
+
+For a few minutes there was a tussle.  The bottle struck the floor
+and broke, and I desisted and rose.  We stood panting and threatening
+each other.  In the end I planted myself between him and the food, and
+told him of my determination to begin a discipline.  I divided the
+food in the pantry, into rations to last us ten days.  I would not let
+him eat any more that day.  In the afternoon he made a feeble effort
+to get at the food.  I had been dozing, but in an instant I was awake.
+All day and all night we sat face to face, I weary but resolute, and
+he weeping and complaining of his immediate hunger.  It was, I know, a
+night and a day, but to me it seemed--it seems now--an interminable
+length of time.
+
+And so our widened incompatibility ended at last in open conflict.
+For two vast days we struggled in undertones and wrestling contests.
+There were times when I beat and kicked him madly, times when I
+cajoled and persuaded him, and once I tried to bribe him with the last
+bottle of burgundy, for there was a rain-water pump from which I could
+get water.  But neither force nor kindness availed; he was indeed
+beyond reason.  He would neither desist from his attacks on the food
+nor from his noisy babbling to himself.  The rudimentary precautions
+to keep our imprisonment endurable he would not observe.  Slowly I
+began to realise the complete overthrow of his intelligence, to
+perceive that my sole companion in this close and sickly darkness was
+a man insane.
+
+From certain vague memories I am inclined to think my own mind
+wandered at times.  I had strange and hideous dreams whenever I slept.
+It sounds paradoxical, but I am inclined to think that the weakness
+and insanity of the curate warned me, braced me, and kept me a sane
+man.
+
+On the eighth day he began to talk aloud instead of whispering, and
+nothing I could do would moderate his speech.
+
+"It is just, O God!" he would say, over and over again. "It is
+just.  On me and mine be the punishment laid.  We have sinned, we have
+fallen short.  There was poverty, sorrow; the poor were trodden in
+the dust, and I held my peace.  I preached acceptable folly--my God,
+what folly!--when I should have stood up, though I died for it, and
+called upon them to repent--repent! . . .  Oppressors of the poor and
+needy . . . !  The wine press of God!"
+
+Then he would suddenly revert to the matter of the food I withheld
+from him, praying, begging, weeping, at last threatening.  He began to
+raise his voice--I prayed him not to.  He perceived a hold on me--he
+threatened he would shout and bring the Martians upon us.  For a time
+that scared me; but any concession would have shortened our chance of
+escape beyond estimating.  I defied him, although I felt no assurance
+that he might not do this thing.  But that day, at any rate, he did
+not.  He talked with his voice rising slowly, through the greater part
+of the eighth and ninth days--threats, entreaties, mingled with a
+torrent of half-sane and always frothy repentance for his vacant sham
+of God's service, such as made me pity him.  Then he slept awhile, and
+began again with renewed strength, so loudly that I must needs make
+him desist.
+
+"Be still!" I implored.
+
+He rose to his knees, for he had been sitting in the darkness near
+the copper.
+
+"I have been still too long," he said, in a tone that must have
+reached the pit, "and now I must bear my witness.  Woe unto this
+unfaithful city!  Woe!  Woe!  Woe!  Woe!  Woe! To the inhabitants of
+the earth by reason of the other voices of the trumpet----"
+
+"Shut up!" I said, rising to my feet, and in a terror lest the
+Martians should hear us.  "For God's sake----"
+
+"Nay," shouted the curate, at the top of his voice, standing
+likewise and extending his arms.  "Speak!  The word of the Lord is
+upon me!"
+
+In three strides he was at the door leading into the kitchen.
+
+"I must bear my witness!  I go!  It has already been too long
+delayed."
+
+I put out my hand and felt the meat chopper hanging to the wall.
+In a flash I was after him.  I was fierce with fear.  Before he was
+halfway across the kitchen I had overtaken him.  With one last touch
+of humanity I turned the blade back and struck him with the butt.  He
+went headlong forward and lay stretched on the ground.  I stumbled
+over him and stood panting.  He lay still.
+
+Suddenly I heard a noise without, the run and smash of slipping
+plaster, and the triangular aperture in the wall was darkened.  I
+looked up and saw the lower surface of a handling-machine coming
+slowly across the hole.  One of its gripping limbs curled amid the
+debris; another limb appeared, feeling its way over the fallen beams.
+I stood petrified, staring.  Then I saw through a sort of glass plate
+near the edge of the body the face, as we may call it, and the large
+dark eyes of a Martian, peering, and then a long metallic snake of
+tentacle came feeling slowly through the hole.
+
+I turned by an effort, stumbled over the curate, and stopped at the
+scullery door.  The tentacle was now some way, two yards or more, in
+the room, and twisting and turning, with queer sudden movements, this
+way and that.  For a while I stood fascinated by that slow, fitful
+advance.  Then, with a faint, hoarse cry, I forced myself across the
+scullery.  I trembled violently; I could scarcely stand upright.  I
+opened the door of the coal cellar, and stood there in the darkness
+staring at the faintly lit doorway into the kitchen, and listening.
+Had the Martian seen me?  What was it doing now?
+
+Something was moving to and fro there, very quietly; every now and
+then it tapped against the wall, or started on its movements with a
+faint metallic ringing, like the movements of keys on a split-ring.
+Then a heavy body--I knew too well what--was dragged across the floor
+of the kitchen towards the opening.  Irresistibly attracted, I crept
+to the door and peeped into the kitchen.  In the triangle of bright
+outer sunlight I saw the Martian, in its Briareus of a handling-machine,
+scrutinizing the curate's head.  I thought at once that it would infer
+my presence from the mark of the blow I had given him.
+
+I crept back to the coal cellar, shut the door, and began to cover
+myself up as much as I could, and as noiselessly as possible in the
+darkness, among the firewood and coal therein.  Every now and then I
+paused, rigid, to hear if the Martian had thrust its tentacles through
+the opening again.
+
+Then the faint metallic jingle returned.  I traced it slowly
+feeling over the kitchen.  Presently I heard it nearer--in the
+scullery, as I judged.  I thought that its length might be
+insufficient to reach me.  I prayed copiously.  It passed, scraping
+faintly across the cellar door.  An age of almost intolerable suspense
+intervened; then I heard it fumbling at the latch! It had found the
+door!  The Martians understood doors!
+
+It worried at the catch for a minute, perhaps, and then the door
+opened.
+
+In the darkness I could just see the thing--like an elephant's
+trunk more than anything else--waving towards me and touching and
+examining the wall, coals, wood and ceiling.  It was like a black worm
+swaying its blind head to and fro.
+
+Once, even, it touched the heel of my boot.  I was on the verge of
+screaming; I bit my hand.  For a time the tentacle was silent.  I
+could have fancied it had been withdrawn.  Presently, with an abrupt
+click, it gripped something--I thought it had me!--and seemed to go
+out of the cellar again.  For a minute I was not sure.  Apparently it
+had taken a lump of coal to examine.
+
+I seized the opportunity of slightly shifting my position, which
+had become cramped, and then listened.  I whispered passionate prayers
+for safety.
+
+Then I heard the slow, deliberate sound creeping towards me again.
+Slowly, slowly it drew near, scratching against the walls and tapping
+the furniture.
+
+While I was still doubtful, it rapped smartly against the cellar
+door and closed it.  I heard it go into the pantry, and the biscuit-tins
+rattled and a bottle smashed, and then came a heavy bump against
+the cellar door.  Then silence that passed into an infinity of
+suspense.
+
+Had it gone?
+
+At last I decided that it had.
+
+It came into the scullery no more; but I lay all the tenth day in
+the close darkness, buried among coals and firewood, not daring even
+to crawl out for the drink for which I craved.  It was the eleventh day
+before I ventured so far from my security.
+
+
+
+CHAPTER FIVE
+
+THE STILLNESS
+
+
+My first act before I went into the pantry was to fasten the door
+between the kitchen and the scullery.  But the pantry was empty; every
+scrap of food had gone.  Apparently, the Martian had taken it all on
+the previous day.  At that discovery I despaired for the first time.  I
+took no food, or no drink either, on the eleventh or the twelfth day.
+
+At first my mouth and throat were parched, and my strength ebbed
+sensibly.  I sat about in the darkness of the scullery, in a state of
+despondent wretchedness.  My mind ran on eating.  I thought I had
+become deaf, for the noises of movement I had been accustomed to hear
+from the pit had ceased absolutely.  I did not feel strong enough to
+crawl noiselessly to the peephole, or I would have gone there.
+
+On the twelfth day my throat was so painful that, taking the chance
+of alarming the Martians, I attacked the creaking rain-water pump that
+stood by the sink, and got a couple of glassfuls of blackened and
+tainted rain water.  I was greatly refreshed by this, and emboldened
+by the fact that no enquiring tentacle followed the noise of my
+pumping.
+
+During these days, in a rambling, inconclusive way, I thought much
+of the curate and of the manner of his death.
+
+On the thirteenth day I drank some more water, and dozed and
+thought disjointedly of eating and of vague impossible plans of
+escape.  Whenever I dozed I dreamt of horrible phantasms, of the death
+of the curate, or of sumptuous dinners; but, asleep or awake, I felt a
+keen pain that urged me to drink again and again.  The light that came
+into the scullery was no longer grey, but red.  To my disordered
+imagination it seemed the colour of blood.
+
+On the fourteenth day I went into the kitchen, and I was surprised
+to find that the fronds of the red weed had grown right across
+the hole in the wall, turning the half-light of the place into a
+crimson-coloured obscurity.
+
+It was early on the fifteenth day that I heard a curious, familiar
+sequence of sounds in the kitchen, and, listening, identified it as
+the snuffing and scratching of a dog.  Going into the kitchen, I saw a
+dog's nose peering in through a break among the ruddy fronds.  This
+greatly surprised me.  At the scent of me he barked shortly.
+
+I thought if I could induce him to come into the place quietly I
+should be able, perhaps, to kill and eat him; and in any case, it
+would be advisable to kill him, lest his actions attracted the
+attention of the Martians.
+
+I crept forward, saying "Good dog!" very softly; but he suddenly
+withdrew his head and disappeared.
+
+I listened--I was not deaf--but certainly the pit was still.  I
+heard a sound like the flutter of a bird's wings, and a hoarse
+croaking, but that was all.
+
+For a long while I lay close to the peephole, but not daring to
+move aside the red plants that obscured it.  Once or twice I heard a
+faint pitter-patter like the feet of the dog going hither and thither
+on the sand far below me, and there were more birdlike sounds, but
+that was all.  At length, encouraged by the silence, I looked out.
+
+Except in the corner, where a multitude of crows hopped and fought
+over the skeletons of the dead the Martians had consumed, there was
+not a living thing in the pit.
+
+I stared about me, scarcely believing my eyes.  All the machinery
+had gone.  Save for the big mound of greyish-blue powder in one
+corner, certain bars of aluminium in another, the black birds, and the
+skeletons of the killed, the place was merely an empty circular pit in
+the sand.
+
+Slowly I thrust myself out through the red weed, and stood upon the
+mound of rubble.  I could see in any direction save behind me, to the
+north, and neither Martians nor sign of Martians were to be seen.  The
+pit dropped sheerly from my feet, but a little way along the rubbish
+afforded a practicable slope to the summit of the ruins.  My chance of
+escape had come.  I began to tremble.
+
+I hesitated for some time, and then, in a gust of desperate
+resolution, and with a heart that throbbed violently, I scrambled to
+the top of the mound in which I had been buried so long.
+
+I looked about again.  To the northward, too, no Martian was
+visible.
+
+When I had last seen this part of Sheen in the daylight it had been
+a straggling street of comfortable white and red houses, interspersed
+with abundant shady trees.  Now I stood on a mound of smashed
+brickwork, clay, and gravel, over which spread a multitude of red
+cactus-shaped plants, knee-high, without a solitary terrestrial growth
+to dispute their footing.  The trees near me were dead and brown, but
+further a network of red thread scaled the still living stems.
+
+The neighbouring houses had all been wrecked, but none had been
+burned; their walls stood, sometimes to the second story, with smashed
+windows and shattered doors.  The red weed grew tumultuously in their
+roofless rooms.  Below me was the great pit, with the crows struggling
+for its refuse.  A number of other birds hopped about among the ruins.
+Far away I saw a gaunt cat slink crouchingly along a wall, but traces
+of men there were none.
+
+The day seemed, by contrast with my recent confinement, dazzlingly
+bright, the sky a glowing blue.  A gentle breeze kept the red weed
+that covered every scrap of unoccupied ground gently swaying.  And oh!
+the sweetness of the air!
+
+
+
+CHAPTER SIX
+
+THE WORK OF FIFTEEN DAYS
+
+
+For some time I stood tottering on the mound regardless of my
+safety.  Within that noisome den from which I had emerged I had
+thought with a narrow intensity only of our immediate security.  I had
+not realised what had been happening to the world, had not anticipated
+this startling vision of unfamiliar things.  I had expected to see
+Sheen in ruins--I found about me the landscape, weird and lurid, of
+another planet.
+
+For that moment I touched an emotion beyond the common range of
+men, yet one that the poor brutes we dominate know only too well.  I
+felt as a rabbit might feel returning to his burrow and suddenly
+confronted by the work of a dozen busy navvies digging the foundations
+of a house.  I felt the first inkling of a thing that presently grew
+quite clear in my mind, that oppressed me for many days, a sense of
+dethronement, a persuasion that I was no longer a master, but an
+animal among the animals, under the Martian heel.  With us it would be
+as with them, to lurk and watch, to run and hide; the fear and empire
+of man had passed away.
+
+But so soon as this strangeness had been realised it passed, and my
+dominant motive became the hunger of my long and dismal fast.  In the
+direction away from the pit I saw, beyond a red-covered wall, a patch
+of garden ground unburied.  This gave me a hint, and I went knee-deep,
+and sometimes neck-deep, in the red weed.  The density of the
+weed gave me a reassuring sense of hiding.  The wall was some six feet
+high, and when I attempted to clamber it I found I could not lift my
+feet to the crest.  So I went along by the side of it, and came to a
+corner and a rockwork that enabled me to get to the top, and tumble
+into the garden I coveted.  Here I found some young onions, a couple
+of gladiolus bulbs, and a quantity of immature carrots, all of which I
+secured, and, scrambling over a ruined wall, went on my way through
+scarlet and crimson trees towards Kew--it was like walking through an
+avenue of gigantic blood drops--possessed with two ideas: to get more
+food, and to limp, as soon and as far as my strength permitted, out of
+this accursed unearthly region of the pit.
+
+Some way farther, in a grassy place, was a group of mushrooms which
+also I devoured, and then I came upon a brown sheet of flowing shallow
+water, where meadows used to be.  These fragments of nourishment served
+only to whet my hunger.  At first I was surprised at this flood in a
+hot, dry summer, but afterwards I discovered that it was caused by the
+tropical exuberance of the red weed.  Directly this extraordinary
+growth encountered water it straightway became gigantic and of
+unparalleled fecundity.  Its seeds were simply poured down into the
+water of the Wey and Thames, and its swiftly growing and Titanic water
+fronds speedily choked both those rivers.
+
+At Putney, as I afterwards saw, the bridge was almost lost in a
+tangle of this weed, and at Richmond, too, the Thames water poured in
+a broad and shallow stream across the meadows of Hampton and
+Twickenham.  As the water spread the weed followed them, until the
+ruined villas of the Thames valley were for a time lost in this red
+swamp, whose margin I explored, and much of the desolation the
+Martians had caused was concealed.
+
+In the end the red weed succumbed almost as quickly as it had
+spread.  A cankering disease, due, it is believed, to the action of
+certain bacteria, presently seized upon it.  Now by the action of
+natural selection, all terrestrial plants have acquired a resisting
+power against bacterial diseases--they never succumb without a severe
+struggle, but the red weed rotted like a thing already dead.  The
+fronds became bleached, and then shrivelled and brittle.  They broke
+off at the least touch, and the waters that had stimulated their early
+growth carried their last vestiges out to sea.
+
+My first act on coming to this water was, of course, to slake my
+thirst.  I drank a great deal of it and, moved by an impulse, gnawed
+some fronds of red weed; but they were watery, and had a sickly,
+metallic taste.  I found the water was sufficiently shallow for me to
+wade securely, although the red weed impeded my feet a little; but the
+flood evidently got deeper towards the river, and I turned back to
+Mortlake.  I managed to make out the road by means of occasional ruins
+of its villas and fences and lamps, and so presently I got out of this
+spate and made my way to the hill going up towards Roehampton and came
+out on Putney Common.
+
+Here the scenery changed from the strange and unfamiliar to the
+wreckage of the familiar: patches of ground exhibited the devastation
+of a cyclone, and in a few score yards I would come upon perfectly
+undisturbed spaces, houses with their blinds trimly drawn and doors
+closed, as if they had been left for a day by the owners, or as if
+their inhabitants slept within.  The red weed was less abundant; the
+tall trees along the lane were free from the red creeper.  I hunted
+for food among the trees, finding nothing, and I also raided a couple
+of silent houses, but they had already been broken into and ransacked.
+I rested for the remainder of the daylight in a shrubbery, being, in
+my enfeebled condition, too fatigued to push on.
+
+All this time I saw no human beings, and no signs of the Martians.
+I encountered a couple of hungry-looking dogs, but both hurried
+circuitously away from the advances I made them.  Near Roehampton I
+had seen two human skeletons--not bodies, but skeletons, picked
+clean--and in the wood by me I found the crushed and scattered bones
+of several cats and rabbits and the skull of a sheep.  But though I
+gnawed parts of these in my mouth, there was nothing to be got from
+them.
+
+After sunset I struggled on along the road towards Putney, where I
+think the Heat-Ray must have been used for some reason.  And in the
+garden beyond Roehampton I got a quantity of immature potatoes,
+sufficient to stay my hunger.  From this garden one looked down upon
+Putney and the river.  The aspect of the place in the dusk was
+singularly desolate: blackened trees, blackened, desolate ruins, and
+down the hill the sheets of the flooded river, red-tinged with the
+weed.  And over all--silence.  It filled me with indescribable terror
+to think how swiftly that desolating change had come.
+
+For a time I believed that mankind had been swept out of existence,
+and that I stood there alone, the last man left alive.  Hard by the
+top of Putney Hill I came upon another skeleton, with the arms
+dislocated and removed several yards from the rest of the body.  As I
+proceeded I became more and more convinced that the extermination of
+mankind was, save for such stragglers as myself, already accomplished
+in this part of the world.  The Martians, I thought, had gone on and
+left the country desolated, seeking food elsewhere.  Perhaps even now
+they were destroying Berlin or Paris, or it might be they had gone
+northward.
+
+
+
+CHAPTER SEVEN
+
+THE MAN ON PUTNEY HILL
+
+
+I spent that night in the inn that stands at the top of Putney
+Hill, sleeping in a made bed for the first time since my flight to
+Leatherhead.  I will not tell the needless trouble I had breaking into
+that house--afterwards I found the front door was on the latch--nor
+how I ransacked every room for food, until just on the verge of
+despair, in what seemed to me to be a servant's bedroom, I found a
+rat-gnawed crust and two tins of pineapple.  The place had been
+already searched and emptied.  In the bar I afterwards found some
+biscuits and sandwiches that had been overlooked.  The latter I could
+not eat, they were too rotten, but the former not only stayed my
+hunger, but filled my pockets.  I lit no lamps, fearing some Martian
+might come beating that part of London for food in the night.  Before
+I went to bed I had an interval of restlessness, and prowled from
+window to window, peering out for some sign of these monsters.  I
+slept little.  As I lay in bed I found myself thinking consecutively--a
+thing I do not remember to have done since my last argument with the
+curate.  During all the intervening time my mental condition had been
+a hurrying succession of vague emotional states or a sort of stupid
+receptivity.  But in the night my brain, reinforced, I suppose, by the
+food I had eaten, grew clear again, and I thought.
+
+Three things struggled for possession of my mind: the killing of
+the curate, the whereabouts of the Martians, and the possible fate of
+my wife.  The former gave me no sensation of horror or remorse to
+recall; I saw it simply as a thing done, a memory infinitely
+disagreeable but quite without the quality of remorse.  I saw myself
+then as I see myself now, driven step by step towards that hasty blow,
+the creature of a sequence of accidents leading inevitably to that.  I
+felt no condemnation; yet the memory, static, unprogressive, haunted
+me.  In the silence of the night, with that sense of the nearness of
+God that sometimes comes into the stillness and the darkness, I stood
+my trial, my only trial, for that moment of wrath and fear.  I
+retraced every step of our conversation from the moment when I had
+found him crouching beside me, heedless of my thirst, and pointing to
+the fire and smoke that streamed up from the ruins of Weybridge.  We
+had been incapable of co-operation--grim chance had taken no heed of
+that.  Had I foreseen, I should have left him at Halliford.  But I did
+not foresee; and crime is to foresee and do.  And I set this down as I
+have set all this story down, as it was.  There were no witnesses--all
+these things I might have concealed.  But I set it down, and the
+reader must form his judgment as he will.
+
+And when, by an effort, I had set aside that picture of a prostrate
+body, I faced the problem of the Martians and the fate of my wife.  For
+the former I had no data; I could imagine a hundred things, and so,
+unhappily, I could for the latter.  And suddenly that night became
+terrible.  I found myself sitting up in bed, staring at the dark.  I
+found myself praying that the Heat-Ray might have suddenly and
+painlessly struck her out of being.  Since the night of my return from
+Leatherhead I had not prayed.  I had uttered prayers, fetish prayers,
+had prayed as heathens mutter charms when I was in extremity; but now
+I prayed indeed, pleading steadfastly and sanely, face to face with
+the darkness of God.  Strange night!  Strangest in this, that so soon
+as dawn had come, I, who had talked with God, crept out of the house
+like a rat leaving its hiding place--a creature scarcely larger, an
+inferior animal, a thing that for any passing whim of our masters
+might be hunted and killed.  Perhaps they also prayed confidently to
+God.  Surely, if we have learned nothing else, this war has taught us
+pity--pity for those witless souls that suffer our dominion.
+
+The morning was bright and fine, and the eastern sky glowed pink,
+and was fretted with little golden clouds.  In the road that runs from
+the top of Putney Hill to Wimbledon was a number of poor vestiges of
+the panic torrent that must have poured Londonward on the Sunday night
+after the fighting began.  There was a little two-wheeled cart
+inscribed with the name of Thomas Lobb, Greengrocer, New Malden, with
+a smashed wheel and an abandoned tin trunk; there was a straw hat
+trampled into the now hardened mud, and at the top of West Hill a lot
+of blood-stained glass about the overturned water trough.  My
+movements were languid, my plans of the vaguest.  I had an idea of
+going to Leatherhead, though I knew that there I had the poorest
+chance of finding my wife.  Certainly, unless death had overtaken them
+suddenly, my cousins and she would have fled thence; but it seemed to
+me I might find or learn there whither the Surrey people had fled.  I
+knew I wanted to find my wife, that my heart ached for her and the
+world of men, but I had no clear idea how the finding might be done.  I
+was also sharply aware now of my intense loneliness.  From the corner
+I went, under cover of a thicket of trees and bushes, to the edge of
+Wimbledon Common, stretching wide and far.
+
+That dark expanse was lit in patches by yellow gorse and broom;
+there was no red weed to be seen, and as I prowled, hesitating, on the
+verge of the open, the sun rose, flooding it all with light and
+vitality.  I came upon a busy swarm of little frogs in a swampy place
+among the trees.  I stopped to look at them, drawing a lesson from
+their stout resolve to live.  And presently, turning suddenly, with an
+odd feeling of being watched, I beheld something crouching amid a
+clump of bushes.  I stood regarding this.  I made a step towards it,
+and it rose up and became a man armed with a cutlass.  I approached
+him slowly.  He stood silent and motionless, regarding me.
+
+As I drew nearer I perceived he was dressed in clothes as dusty and
+filthy as my own; he looked, indeed, as though he had been dragged
+through a culvert.  Nearer, I distinguished the green slime of ditches
+mixing with the pale drab of dried clay and shiny, coaly patches.  His
+black hair fell over his eyes, and his face was dark and dirty and
+sunken, so that at first I did not recognise him.  There was a red cut
+across the lower part of his face.
+
+"Stop!" he cried, when I was within ten yards of him, and I
+stopped.  His voice was hoarse.  "Where do you come from?" he said.
+
+I thought, surveying him.
+
+"I come from Mortlake," I said.  "I was buried near the pit the
+Martians made about their cylinder.  I have worked my way out and
+escaped."
+
+"There is no food about here," he said.  "This is my country.  All
+this hill down to the river, and back to Clapham, and up to the edge
+of the common.  There is only food for one.  Which way are you going?"
+
+I answered slowly.
+
+"I don't know," I said.  "I have been buried in the ruins of a
+house thirteen or fourteen days.  I don't know what has happened."
+
+He looked at me doubtfully, then started, and looked with a changed
+expression.
+
+"I've no wish to stop about here," said I.  "I think I shall go to
+Leatherhead, for my wife was there."
+
+He shot out a pointing finger.
+
+"It is you," said he; "the man from Woking.  And you weren't killed
+at Weybridge?"
+
+I recognised him at the same moment.
+
+"You are the artilleryman who came into my garden."
+
+"Good luck!" he said.  "We are lucky ones!  Fancy _you_!"  He put out
+a hand, and I took it.  "I crawled up a drain," he said. "But they
+didn't kill everyone.  And after they went away I got off towards
+Walton across the fields.  But---- It's not sixteen days altogether--and
+your hair is grey."  He looked over his shoulder suddenly.  "Only
+a rook," he said.  "One gets to know that birds have shadows these
+days.  This is a bit open.  Let us crawl under those bushes and talk."
+
+"Have you seen any Martians?" I said.  "Since I crawled out----"
+
+"They've gone away across London," he said.  "I guess they've got a
+bigger camp there.  Of a night, all over there, Hampstead way, the sky
+is alive with their lights.  It's like a great city, and in the glare
+you can just see them moving.  By daylight you can't.  But nearer--I
+haven't seen them--" (he counted on his fingers) "five days.  Then I
+saw a couple across Hammersmith way carrying something big.  And the
+night before last"--he stopped and spoke impressively--"it was just a
+matter of lights, but it was something up in the air.  I believe
+they've built a flying-machine, and are learning to fly."
+
+I stopped, on hands and knees, for we had come to the bushes.
+
+"Fly!"
+
+"Yes," he said, "fly."
+
+I went on into a little bower, and sat down.
+
+"It is all over with humanity," I said.  "If they can do that they
+will simply go round the world."
+
+He nodded.
+
+"They will.  But---- It will relieve things over here a bit.  And
+besides----"  He looked at me.  "Aren't you satisfied it _is_ up with
+humanity?  I am.  We're down; we're beat."
+
+I stared.  Strange as it may seem, I had not arrived at this fact--a
+fact perfectly obvious so soon as he spoke.  I had still held a
+vague hope; rather, I had kept a lifelong habit of mind.  He repeated
+his words, "We're beat."  They carried absolute conviction.
+
+"It's all over," he said.  "They've lost _one_--just _one_.  And they've
+made their footing good and crippled the greatest power in the world.
+They've walked over us.  The death of that one at Weybridge was an
+accident.  And these are only pioneers.  They kept on coming.  These
+green stars--I've seen none these five or six days, but I've no doubt
+they're falling somewhere every night.  Nothing's to be done.  We're
+under! We're beat!"
+
+I made him no answer.  I sat staring before me, trying in vain to
+devise some countervailing thought.
+
+"This isn't a war," said the artilleryman.  "It never was a war,
+any more than there's war between man and ants."
+
+Suddenly I recalled the night in the observatory.
+
+"After the tenth shot they fired no more--at least, until the first
+cylinder came."
+
+"How do you know?" said the artilleryman.  I explained.  He thought.
+"Something wrong with the gun," he said.  "But what if there is?
+They'll get it right again.  And even if there's a delay, how can it
+alter the end?  It's just men and ants.  There's the ants builds their
+cities, live their lives, have wars, revolutions, until the men want
+them out of the way, and then they go out of the way.  That's what we
+are now--just ants.  Only----"
+
+"Yes," I said.
+
+"We're eatable ants."
+
+We sat looking at each other.
+
+"And what will they do with us?" I said.
+
+"That's what I've been thinking," he said; "that's what I've been
+thinking.  After Weybridge I went south--thinking.  I saw what was up.
+Most of the people were hard at it squealing and exciting themselves.
+But I'm not so fond of squealing.  I've been in sight of death once or
+twice; I'm not an ornamental soldier, and at the best and worst,
+death--it's just death.  And it's the man that keeps on thinking comes
+through.  I saw everyone tracking away south.  Says I, 'Food won't
+last this way,' and I turned right back.  I went for the Martians like
+a sparrow goes for man.  All round"--he waved a hand to the
+horizon--"they're starving in heaps, bolting, treading on each other.
+. . ."
+
+He saw my face, and halted awkwardly.
+
+"No doubt lots who had money have gone away to France," he said.  He
+seemed to hesitate whether to apologise, met my eyes, and went on:
+"There's food all about here.  Canned things in shops; wines, spirits,
+mineral waters; and the water mains and drains are empty.  Well, I was
+telling you what I was thinking.  'Here's intelligent things,' I said,
+'and it seems they want us for food.  First, they'll smash us up--ships,
+machines, guns, cities, all the order and organisation.  All
+that will go.  If we were the size of ants we might pull through.  But
+we're not.  It's all too bulky to stop.  That's the first certainty.'
+Eh?"
+
+I assented.
+
+"It is; I've thought it out.  Very well, then--next; at present
+we're caught as we're wanted.  A Martian has only to go a few miles to
+get a crowd on the run.  And I saw one, one day, out by Wandsworth,
+picking houses to pieces and routing among the wreckage.  But they
+won't keep on doing that.  So soon as they've settled all our guns and
+ships, and smashed our railways, and done all the things they are
+doing over there, they will begin catching us systematic, picking the
+best and storing us in cages and things.  That's what they will start
+doing in a bit.  Lord!  They haven't begun on us yet.  Don't you see
+that?"
+
+"Not begun!" I exclaimed.
+
+"Not begun.  All that's happened so far is through our not having
+the sense to keep quiet--worrying them with guns and such foolery.  And
+losing our heads, and rushing off in crowds to where there wasn't any
+more safety than where we were.  They don't want to bother us yet.
+They're making their things--making all the things they couldn't bring
+with them, getting things ready for the rest of their people.  Very
+likely that's why the cylinders have stopped for a bit, for fear of
+hitting those who are here.  And instead of our rushing about blind,
+on the howl, or getting dynamite on the chance of busting them up,
+we've got to fix ourselves up according to the new state of affairs.
+That's how I figure it out.  It isn't quite according to what a man
+wants for his species, but it's about what the facts point to.  And
+that's the principle I acted upon.  Cities, nations, civilisation,
+progress--it's all over.  That game's up.  We're beat."
+
+"But if that is so, what is there to live for?"
+
+The artilleryman looked at me for a moment.
+
+"There won't be any more blessed concerts for a million years or
+so; there won't be any Royal Academy of Arts, and no nice little feeds
+at restaurants.  If it's amusement you're after, I reckon the game is
+up.  If you've got any drawing-room manners or a dislike to eating
+peas with a knife or dropping aitches, you'd better chuck 'em away.
+They ain't no further use."
+
+"You mean----"
+
+"I mean that men like me are going on living--for the sake of the
+breed.  I tell you, I'm grim set on living.  And if I'm not mistaken,
+you'll show what insides _you've_ got, too, before long.  We aren't
+going to be exterminated.  And I don't mean to be caught either, and
+tamed and fattened and bred like a thundering ox.  Ugh! Fancy those
+brown creepers!"
+
+"You don't mean to say----"
+
+"I do.  I'm going on, under their feet.  I've got it planned; I've
+thought it out.  We men are beat.  We don't know enough.  We've got to
+learn before we've got a chance.  And we've got to live and keep
+independent while we learn.  See! That's what has to be done."
+
+I stared, astonished, and stirred profoundly by the man's
+resolution.
+
+"Great God!" cried I.  "But you are a man indeed!"  And suddenly I
+gripped his hand.
+
+"Eh!" he said, with his eyes shining.  "I've thought it out, eh?"
+
+"Go on," I said.
+
+"Well, those who mean to escape their catching must get ready.  I'm
+getting ready.  Mind you, it isn't all of us that are made for wild
+beasts; and that's what it's got to be.  That's why I watched you.  I
+had my doubts.  You're slender.  I didn't know that it was you, you
+see, or just how you'd been buried.  All these--the sort of people
+that lived in these houses, and all those damn little clerks that used
+to live down that way--they'd be no good.  They haven't any spirit in
+them--no proud dreams and no proud lusts; and a man who hasn't one or
+the other--Lord!  What is he but funk and precautions?  They just used
+to skedaddle off to work--I've seen hundreds of 'em, bit of breakfast
+in hand, running wild and shining to catch their little season-ticket
+train, for fear they'd get dismissed if they didn't; working at
+businesses they were afraid to take the trouble to understand;
+skedaddling back for fear they wouldn't be in time for dinner; keeping
+indoors after dinner for fear of the back streets, and sleeping with
+the wives they married, not because they wanted them, but because they
+had a bit of money that would make for safety in their one little
+miserable skedaddle through the world.  Lives insured and a bit
+invested for fear of accidents.  And on Sundays--fear of the
+hereafter.  As if hell was built for rabbits!  Well, the Martians will
+just be a godsend to these.  Nice roomy cages, fattening food, careful
+breeding, no worry.  After a week or so chasing about the fields and
+lands on empty stomachs, they'll come and be caught cheerful.  They'll
+be quite glad after a bit.  They'll wonder what people did before
+there were Martians to take care of them.  And the bar loafers, and
+mashers, and singers--I can imagine them.  I can imagine them," he
+said, with a sort of sombre gratification.  "There'll be any amount of
+sentiment and religion loose among them.  There's hundreds of things I
+saw with my eyes that I've only begun to see clearly these last few
+days.  There's lots will take things as they are--fat and stupid; and
+lots will be worried by a sort of feeling that it's all wrong, and
+that they ought to be doing something.  Now whenever things are so
+that a lot of people feel they ought to be doing something, the weak,
+and those who go weak with a lot of complicated thinking, always make
+for a sort of do-nothing religion, very pious and superior, and
+submit to persecution and the will of the Lord.  Very likely you've
+seen the same thing.  It's energy in a gale of funk, and turned clean
+inside out.  These cages will be full of psalms and hymns and piety.
+And those of a less simple sort will work in a bit of--what is
+it?--eroticism."
+
+He paused.
+
+"Very likely these Martians will make pets of some of them; train
+them to do tricks--who knows?--get sentimental over the pet boy who
+grew up and had to be killed.  And some, maybe, they will train to
+hunt us."
+
+"No," I cried, "that's impossible!  No human being----"
+
+"What's the good of going on with such lies?" said the
+artilleryman.  "There's men who'd do it cheerful.  What nonsense to
+pretend there isn't!"
+
+And I succumbed to his conviction.
+
+"If they come after me," he said; "Lord, if they come after me!"
+and subsided into a grim meditation.
+
+I sat contemplating these things.  I could find nothing to bring
+against this man's reasoning.  In the days before the invasion no one
+would have questioned my intellectual superiority to his--I, a
+professed and recognised writer on philosophical themes, and he, a
+common soldier; and yet he had already formulated a situation that I
+had scarcely realised.
+
+"What are you doing?" I said presently.  "What plans have you
+made?"
+
+He hesitated.
+
+"Well, it's like this," he said.  "What have we to do?  We have to
+invent a sort of life where men can live and breed, and be
+sufficiently secure to bring the children up.  Yes--wait a bit, and
+I'll make it clearer what I think ought to be done.  The tame ones
+will go like all tame beasts; in a few generations they'll be big,
+beautiful, rich-blooded, stupid--rubbish! The risk is that we who keep
+wild will go savage--degenerate into a sort of big, savage rat. . . .
+You see, how I mean to live is underground.  I've been thinking about
+the drains.  Of course those who don't know drains think horrible
+things; but under this London are miles and miles--hundreds of
+miles--and a few days rain and London empty will leave them sweet and
+clean. The main drains are big enough and airy enough for anyone.
+Then there's cellars, vaults, stores, from which bolting passages may
+be made to the drains. And the railway tunnels and subways.  Eh?  You
+begin to see?  And we form a band--able-bodied, clean-minded men.
+We're not going to pick up any rubbish that drifts in.  Weaklings
+go out again."
+
+"As you meant me to go?"
+
+"Well--I parleyed, didn't I?"
+
+"We won't quarrel about that.  Go on."
+
+"Those who stop obey orders.  Able-bodied, clean-minded women we
+want also--mothers and teachers.  No lackadaisical ladies--no blasted
+rolling eyes.  We can't have any weak or silly.  Life is real again,
+and the useless and cumbersome and mischievous have to die.  They
+ought to die.  They ought to be willing to die.  It's a sort of
+disloyalty, after all, to live and taint the race.  And they can't be
+happy.  Moreover, dying's none so dreadful; it's the funking makes it
+bad.  And in all those places we shall gather.  Our district will be
+London.  And we may even be able to keep a watch, and run about in the
+open when the Martians keep away.  Play cricket, perhaps.  That's how
+we shall save the race.  Eh?  It's a possible thing?  But saving the
+race is nothing in itself.  As I say, that's only being rats.  It's
+saving our knowledge and adding to it is the thing.  There men like
+you come in.  There's books, there's models.  We must make great safe
+places down deep, and get all the books we can; not novels and poetry
+swipes, but ideas, science books.  That's where men like you come in.
+We must go to the British Museum and pick all those books through.
+Especially we must keep up our science--learn more.  We must watch
+these Martians.  Some of us must go as spies.  When it's all working,
+perhaps I will.  Get caught, I mean.  And the great thing is, we must
+leave the Martians alone.  We mustn't even steal.  If we get in their
+way, we clear out.  We must show them we mean no harm.  Yes, I know.
+But they're intelligent things, and they won't hunt us down if they
+have all they want, and think we're just harmless vermin."
+
+The artilleryman paused and laid a brown hand upon my arm.
+
+"After all, it may not be so much we may have to learn before--Just
+imagine this: four or five of their fighting machines suddenly
+starting off--Heat-Rays right and left, and not a Martian in 'em.  Not
+a Martian in 'em, but men--men who have learned the way how.  It may
+be in my time, even--those men.  Fancy having one of them lovely
+things, with its Heat-Ray wide and free!  Fancy having it in control!
+What would it matter if you smashed to smithereens at the end of the
+run, after a bust like that?  I reckon the Martians'll open their
+beautiful eyes!  Can't you see them, man?  Can't you see them
+hurrying, hurrying--puffing and blowing and hooting to their other
+mechanical affairs?  Something out of gear in every case.  And swish,
+bang, rattle, swish!  Just as they are fumbling over it, _swish_ comes
+the Heat-Ray, and, behold! man has come back to his own."
+
+For a while the imaginative daring of the artilleryman, and the
+tone of assurance and courage he assumed, completely dominated my
+mind.  I believed unhesitatingly both in his forecast of human destiny
+and in the practicability of his astonishing scheme, and the reader
+who thinks me susceptible and foolish must contrast his position,
+reading steadily with all his thoughts about his subject, and mine,
+crouching fearfully in the bushes and listening, distracted by
+apprehension.  We talked in this manner through the early morning
+time, and later crept out of the bushes, and, after scanning the sky
+for Martians, hurried precipitately to the house on Putney Hill where
+he had made his lair.  It was the coal cellar of the place, and when I
+saw the work he had spent a week upon--it was a burrow scarcely ten
+yards long, which he designed to reach to the main drain on Putney
+Hill--I had my first inkling of the gulf between his dreams and his
+powers.  Such a hole I could have dug in a day.  But I believed in him
+sufficiently to work with him all that morning until past midday at
+his digging.  We had a garden barrow and shot the earth we removed
+against the kitchen range.  We refreshed ourselves with a tin of
+mock-turtle soup and wine from the neighbouring pantry.  I found a
+curious relief from the aching strangeness of the world in this steady
+labour. As we worked, I turned his project over in my mind, and
+presently objections and doubts began to arise; but I worked there all
+the morning, so glad was I to find myself with a purpose again.  After
+working an hour I began to speculate on the distance one had to go
+before the cloaca was reached, the chances we had of missing it
+altogether.  My immediate trouble was why we should dig this long
+tunnel, when it was possible to get into the drain at once down one of
+the manholes, and work back to the house.  It seemed to me, too, that
+the house was inconveniently chosen, and required a needless length of
+tunnel.  And just as I was beginning to face these things, the
+artilleryman stopped digging, and looked at me.
+
+"We're working well," he said.  He put down his spade. "Let us
+knock off a bit" he said.  "I think it's time we reconnoitred from the
+roof of the house."
+
+I was for going on, and after a little hesitation he resumed his
+spade; and then suddenly I was struck by a thought.  I stopped, and so
+did he at once.
+
+"Why were you walking about the common," I said, "instead of being
+here?"
+
+"Taking the air," he said.  "I was coming back.  It's safer by
+night."
+
+"But the work?"
+
+"Oh, one can't always work," he said, and in a flash I saw the man
+plain.  He hesitated, holding his spade.  "We ought to reconnoitre
+now," he said, "because if any come near they may hear the spades and
+drop upon us unawares."
+
+I was no longer disposed to object.  We went together to the roof
+and stood on a ladder peeping out of the roof door.  No Martians were
+to be seen, and we ventured out on the tiles, and slipped down under
+shelter of the parapet.
+
+From this position a shrubbery hid the greater portion of Putney,
+but we could see the river below, a bubbly mass of red weed, and the
+low parts of Lambeth flooded and red.  The red creeper swarmed up the
+trees about the old palace, and their branches stretched gaunt and
+dead, and set with shrivelled leaves, from amid its clusters.  It was
+strange how entirely dependent both these things were upon flowing
+water for their propagation.  About us neither had gained a footing;
+laburnums, pink mays, snowballs, and trees of arbor-vitae, rose out of
+laurels and hydrangeas, green and brilliant into the sunlight.  Beyond
+Kensington dense smoke was rising, and that and a blue haze hid the
+northward hills.
+
+The artilleryman began to tell me of the sort of people who still
+remained in London.
+
+"One night last week," he said, "some fools got the electric light
+in order, and there was all Regent Street and the Circus ablaze,
+crowded with painted and ragged drunkards, men and women, dancing and
+shouting till dawn.  A man who was there told me.  And as the day came
+they became aware of a fighting-machine standing near by the Langham
+and looking down at them.  Heaven knows how long he had been there.
+It must have given some of them a nasty turn.  He came down the road
+towards them, and picked up nearly a hundred too drunk or frightened
+to run away."
+
+Grotesque gleam of a time no history will ever fully describe!
+
+From that, in answer to my questions, he came round to his
+grandiose plans again.  He grew enthusiastic.  He talked so eloquently
+of the possibility of capturing a fighting-machine that I more than
+half believed in him again.  But now that I was beginning to
+understand something of his quality, I could divine the stress he laid
+on doing nothing precipitately.  And I noted that now there was no
+question that he personally was to capture and fight the great
+machine.
+
+After a time we went down to the cellar.  Neither of us seemed
+disposed to resume digging, and when he suggested a meal, I was
+nothing loath.  He became suddenly very generous, and when we had
+eaten he went away and returned with some excellent cigars.  We lit
+these, and his optimism glowed.  He was inclined to regard my coming
+as a great occasion.
+
+"There's some champagne in the cellar," he said.
+
+"We can dig better on this Thames-side burgundy," said I.
+
+"No," said he; "I am host today.  Champagne!  Great God! We've a
+heavy enough task before us!  Let us take a rest and gather strength
+while we may.  Look at these blistered hands!"
+
+And pursuant to this idea of a holiday, he insisted upon playing
+cards after we had eaten.  He taught me euchre, and after dividing
+London between us, I taking the northern side and he the southern, we
+played for parish points.  Grotesque and foolish as this will seem to
+the sober reader, it is absolutely true, and what is more remarkable,
+I found the card game and several others we played extremely
+interesting.
+
+Strange mind of man! that, with our species upon the edge of
+extermination or appalling degradation, with no clear prospect before
+us but the chance of a horrible death, we could sit following the
+chance of this painted pasteboard, and playing the "joker" with vivid
+delight.  Afterwards he taught me poker, and I beat him at three tough
+chess games.  When dark came we decided to take the risk, and lit a
+lamp.
+
+After an interminable string of games, we supped, and the
+artilleryman finished the champagne.  We went on smoking the cigars.
+He was no longer the energetic regenerator of his species I had
+encountered in the morning.  He was still optimistic, but it was a
+less kinetic, a more thoughtful optimism.  I remember he wound up with
+my health, proposed in a speech of small variety and considerable
+intermittence.  I took a cigar, and went upstairs to look at the
+lights of which he had spoken that blazed so greenly along the
+Highgate hills.
+
+At first I stared unintelligently across the London valley.  The
+northern hills were shrouded in darkness; the fires near Kensington
+glowed redly, and now and then an orange-red tongue of flame flashed
+up and vanished in the deep blue night.  All the rest of London
+was black.  Then, nearer, I perceived a strange light, a pale,
+violet-purple fluorescent glow, quivering under the night breeze.  For
+a space I could not understand it, and then I knew that it must be
+the red weed from which this faint irradiation proceeded.  With that
+realisation my dormant sense of wonder, my sense of the proportion of
+things, awoke again.  I glanced from that to Mars, red and clear,
+glowing high in the west, and then gazed long and earnestly at the
+darkness of Hampstead and Highgate.
+
+I remained a very long time upon the roof, wondering at the
+grotesque changes of the day.  I recalled my mental states from the
+midnight prayer to the foolish card-playing.  I had a violent
+revulsion of feeling.  I remember I flung away the cigar with a
+certain wasteful symbolism.  My folly came to me with glaring
+exaggeration.  I seemed a traitor to my wife and to my kind; I was
+filled with remorse.  I resolved to leave this strange undisciplined
+dreamer of great things to his drink and gluttony, and to go on into
+London.  There, it seemed to me, I had the best chance of learning
+what the Martians and my fellowmen were doing.  I was still upon the
+roof when the late moon rose.
+
+
+
+CHAPTER EIGHT
+
+DEAD LONDON
+
+
+After I had parted from the artilleryman, I went down the hill, and
+by the High Street across the bridge to Fulham.  The red weed was
+tumultuous at that time, and nearly choked the bridge roadway; but its
+fronds were already whitened in patches by the spreading disease that
+presently removed it so swiftly.
+
+At the corner of the lane that runs to Putney Bridge station I
+found a man lying.  He was as black as a sweep with the black dust,
+alive, but helplessly and speechlessly drunk.  I could get nothing
+from him but curses and furious lunges at my head.  I think I should
+have stayed by him but for the brutal expression of his face.
+
+There was black dust along the roadway from the bridge onwards, and
+it grew thicker in Fulham.  The streets were horribly quiet.  I got
+food--sour, hard, and mouldy, but quite eatable--in a baker's shop
+here.  Some way towards Walham Green the streets became clear of
+powder, and I passed a white terrace of houses on fire; the noise of
+the burning was an absolute relief.  Going on towards Brompton, the
+streets were quiet again.
+
+Here I came once more upon the black powder in the streets and upon
+dead bodies.  I saw altogether about a dozen in the length of the
+Fulham Road.  They had been dead many days, so that I hurried quickly
+past them.  The black powder covered them over, and softened their
+outlines.  One or two had been disturbed by dogs.
+
+Where there was no black powder, it was curiously like a Sunday in
+the City, with the closed shops, the houses locked up and the blinds
+drawn, the desertion, and the stillness.  In some places plunderers
+had been at work, but rarely at other than the provision and wine
+shops.  A jeweller's window had been broken open in one place, but
+apparently the thief had been disturbed, and a number of gold chains
+and a watch lay scattered on the pavement.  I did not trouble to touch
+them.  Farther on was a tattered woman in a heap on a doorstep; the
+hand that hung over her knee was gashed and bled down her rusty brown
+dress, and a smashed magnum of champagne formed a pool across the
+pavement.  She seemed asleep, but she was dead.
+
+The farther I penetrated into London, the profounder grew the
+stillness.  But it was not so much the stillness of death--it was the
+stillness of suspense, of expectation.  At any time the destruction
+that had already singed the northwestern borders of the metropolis,
+and had annihilated Ealing and Kilburn, might strike among these
+houses and leave them smoking ruins.  It was a city condemned and
+derelict. . . .
+
+In South Kensington the streets were clear of dead and of black
+powder.  It was near South Kensington that I first heard the howling.
+It crept almost imperceptibly upon my senses.  It was a sobbing
+alternation of two notes, "Ulla, ulla, ulla, ulla," keeping on
+perpetually.  When I passed streets that ran northward it grew in
+volume, and houses and buildings seemed to deaden and cut it off
+again.  It came in a full tide down Exhibition Road.  I stopped,
+staring towards Kensington Gardens, wondering at this strange, remote
+wailing.  It was as if that mighty desert of houses had found a voice
+for its fear and solitude.
+
+"Ulla, ulla, ulla, ulla," wailed that superhuman note--great waves
+of sound sweeping down the broad, sunlit roadway, between the tall
+buildings on each side.  I turned northwards, marvelling, towards the
+iron gates of Hyde Park.  I had half a mind to break into the Natural
+History Museum and find my way up to the summits of the towers, in
+order to see across the park.  But I decided to keep to the ground,
+where quick hiding was possible, and so went on up the Exhibition
+Road.  All the large mansions on each side of the road were empty and
+still, and my footsteps echoed against the sides of the houses.  At
+the top, near the park gate, I came upon a strange sight--a bus
+overturned, and the skeleton of a horse picked clean.  I puzzled over
+this for a time, and then went on to the bridge over the Serpentine.
+The voice grew stronger and stronger, though I could see nothing above
+the housetops on the north side of the park, save a haze of smoke to
+the northwest.
+
+"Ulla, ulla, ulla, ulla," cried the voice, coming, as it seemed to
+me, from the district about Regent's Park.  The desolating cry worked
+upon my mind.  The mood that had sustained me passed.  The wailing
+took possession of me.  I found I was intensely weary, footsore, and
+now again hungry and thirsty.
+
+It was already past noon.  Why was I wandering alone in this city
+of the dead?  Why was I alone when all London was lying in state, and
+in its black shroud?  I felt intolerably lonely.  My mind ran on old
+friends that I had forgotten for years.  I thought of the poisons in
+the chemists' shops, of the liquors the wine merchants stored; I
+recalled the two sodden creatures of despair, who so far as I knew,
+shared the city with myself. . . .
+
+I came into Oxford Street by the Marble Arch, and here again were
+black powder and several bodies, and an evil, ominous smell from the
+gratings of the cellars of some of the houses.  I grew very thirsty
+after the heat of my long walk.  With infinite trouble I managed to
+break into a public-house and get food and drink.  I was weary after
+eating, and went into the parlour behind the bar, and slept on a black
+horsehair sofa I found there.
+
+I awoke to find that dismal howling still in my ears, "Ulla, ulla,
+ulla, ulla."  It was now dusk, and after I had routed out some
+biscuits and a cheese in the bar--there was a meat safe, but it
+contained nothing but maggots--I wandered on through the silent
+residential squares to Baker Street--Portman Square is the only one I
+can name--and so came out at last upon Regent's Park.  And as I
+emerged from the top of Baker Street, I saw far away over the trees in
+the clearness of the sunset the hood of the Martian giant from which
+this howling proceeded.  I was not terrified.  I came upon him as if
+it were a matter of course.  I watched him for some time, but he did
+not move.  He appeared to be standing and yelling, for no reason that
+I could discover.
+
+I tried to formulate a plan of action.  That perpetual sound of
+"Ulla, ulla, ulla, ulla," confused my mind.  Perhaps I was too tired
+to be very fearful.  Certainly I was more curious to know the reason
+of this monotonous crying than afraid.  I turned back away from the
+park and struck into Park Road, intending to skirt the park, went
+along under the shelter of the terraces, and got a view of this
+stationary, howling Martian from the direction of St. John's Wood.  A
+couple of hundred yards out of Baker Street I heard a yelping chorus,
+and saw, first a dog with a piece of putrescent red meat in his jaws
+coming headlong towards me, and then a pack of starving mongrels in
+pursuit of him.  He made a wide curve to avoid me, as though he feared
+I might prove a fresh competitor.  As the yelping died away down the
+silent road, the wailing sound of "Ulla, ulla, ulla, ulla," reasserted
+itself.
+
+I came upon the wrecked handling-machine halfway to St. John's Wood
+station.  At first I thought a house had fallen across the road.  It
+was only as I clambered among the ruins that I saw, with a start, this
+mechanical Samson lying, with its tentacles bent and smashed and
+twisted, among the ruins it had made.  The forepart was shattered.  It
+seemed as if it had driven blindly straight at the house, and had been
+overwhelmed in its overthrow.  It seemed to me then that this might
+have happened by a handling-machine escaping from the guidance of its
+Martian.  I could not clamber among the ruins to see it, and the
+twilight was now so far advanced that the blood with which its seat
+was smeared, and the gnawed gristle of the Martian that the dogs had
+left, were invisible to me.
+
+Wondering still more at all that I had seen, I pushed on towards
+Primrose Hill.  Far away, through a gap in the trees, I saw a second
+Martian, as motionless as the first, standing in the park towards the
+Zoological Gardens, and silent.  A little beyond the ruins about the
+smashed handling-machine I came upon the red weed again, and found the
+Regent's Canal, a spongy mass of dark-red vegetation.
+
+As I crossed the bridge, the sound of "Ulla, ulla, ulla, ulla,"
+ceased.  It was, as it were, cut off.  The silence came like a
+thunderclap.
+
+The dusky houses about me stood faint and tall and dim; the trees
+towards the park were growing black.  All about me the red weed
+clambered among the ruins, writhing to get above me in the dimness.
+Night, the mother of fear and mystery, was coming upon me.  But while
+that voice sounded the solitude, the desolation, had been endurable;
+by virtue of it London had still seemed alive, and the sense of life
+about me had upheld me.  Then suddenly a change, the passing of
+something--I knew not what--and then a stillness that could be felt.
+Nothing but this gaunt quiet.
+
+London about me gazed at me spectrally.  The windows in the white
+houses were like the eye sockets of skulls.  About me my imagination
+found a thousand noiseless enemies moving.  Terror seized me, a horror
+of my temerity.  In front of me the road became pitchy black as though
+it was tarred, and I saw a contorted shape lying across the pathway.  I
+could not bring myself to go on.  I turned down St. John's Wood Road,
+and ran headlong from this unendurable stillness towards Kilburn.  I
+hid from the night and the silence, until long after midnight, in a
+cabmen's shelter in Harrow Road.  But before the dawn my courage
+returned, and while the stars were still in the sky I turned once more
+towards Regent's Park.  I missed my way among the streets, and
+presently saw down a long avenue, in the half-light of the early dawn,
+the curve of Primrose Hill.  On the summit, towering up to the fading
+stars, was a third Martian, erect and motionless like the others.
+
+An insane resolve possessed me.  I would die and end it.  And I
+would save myself even the trouble of killing myself.  I marched on
+recklessly towards this Titan, and then, as I drew nearer and the
+light grew, I saw that a multitude of black birds was circling and
+clustering about the hood.  At that my heart gave a bound, and I began
+running along the road.
+
+I hurried through the red weed that choked St. Edmund's Terrace (I
+waded breast-high across a torrent of water that was rushing down from
+the waterworks towards the Albert Road), and emerged upon the grass
+before the rising of the sun.  Great mounds had been heaped about the
+crest of the hill, making a huge redoubt of it--it was the final and
+largest place the Martians had made--and from behind these heaps there
+rose a thin smoke against the sky.  Against the sky line an eager dog
+ran and disappeared.  The thought that had flashed into my mind grew
+real, grew credible.  I felt no fear, only a wild, trembling
+exultation, as I ran up the hill towards the motionless monster.  Out
+of the hood hung lank shreds of brown, at which the hungry birds
+pecked and tore.
+
+In another moment I had scrambled up the earthen rampart and stood
+upon its crest, and the interior of the redoubt was below me.  A
+mighty space it was, with gigantic machines here and there within it,
+huge mounds of material and strange shelter places.  And scattered
+about it, some in their overturned war-machines, some in the now rigid
+handling-machines, and a dozen of them stark and silent and laid in a
+row, were the Martians--_dead_!--slain by the putrefactive and disease
+bacteria against which their systems were unprepared; slain as the red
+weed was being slain; slain, after all man's devices had failed, by
+the humblest things that God, in his wisdom, has put upon this earth.
+
+For so it had come about, as indeed I and many men might have
+foreseen had not terror and disaster blinded our minds.  These
+germs of disease have taken toll of humanity since the beginning of
+things--taken toll of our prehuman ancestors since life began here.
+But by virtue of this natural selection of our kind we have developed
+resisting power; to no germs do we succumb without a struggle, and to
+many--those that cause putrefaction in dead matter, for instance--our
+living frames are altogether immune.  But there are no bacteria in
+Mars, and directly these invaders arrived, directly they drank and
+fed, our microscopic allies began to work their overthrow.  Already
+when I watched them they were irrevocably doomed, dying and rotting
+even as they went to and fro.  It was inevitable.  By the toll of a
+billion deaths man has bought his birthright of the earth, and it is
+his against all comers; it would still be his were the Martians ten
+times as mighty as they are.  For neither do men live nor die in vain.
+
+Here and there they were scattered, nearly fifty altogether, in
+that great gulf they had made, overtaken by a death that must have
+seemed to them as incomprehensible as any death could be.  To me also
+at that time this death was incomprehensible.  All I knew was that
+these things that had been alive and so terrible to men were dead.
+For a moment I believed that the destruction of Sennacherib had been
+repeated, that God had repented, that the Angel of Death had slain
+them in the night.
+
+I stood staring into the pit, and my heart lightened gloriously,
+even as the rising sun struck the world to fire about me with his
+rays.  The pit was still in darkness; the mighty engines, so great and
+wonderful in their power and complexity, so unearthly in their
+tortuous forms, rose weird and vague and strange out of the shadows
+towards the light.  A multitude of dogs, I could hear, fought over the
+bodies that lay darkly in the depth of the pit, far below me.  Across
+the pit on its farther lip, flat and vast and strange, lay the great
+flying-machine with which they had been experimenting upon our denser
+atmosphere when decay and death arrested them.  Death had come not a
+day too soon.  At the sound of a cawing overhead I looked up at the
+huge fighting-machine that would fight no more for ever, at the
+tattered red shreds of flesh that dripped down upon the overturned
+seats on the summit of Primrose Hill.
+
+I turned and looked down the slope of the hill to where, enhaloed
+now in birds, stood those other two Martians that I had seen
+overnight, just as death had overtaken them.  The one had died, even
+as it had been crying to its companions; perhaps it was the last to
+die, and its voice had gone on perpetually until the force of its
+machinery was exhausted.  They glittered now, harmless tripod towers
+of shining metal, in the brightness of the rising sun.
+
+All about the pit, and saved as by a miracle from everlasting
+destruction, stretched the great Mother of Cities.  Those who have only
+seen London veiled in her sombre robes of smoke can scarcely imagine
+the naked clearness and beauty of the silent wilderness of houses.
+
+Eastward, over the blackened ruins of the Albert Terrace and the
+splintered spire of the church, the sun blazed dazzling in a clear
+sky, and here and there some facet in the great wilderness of roofs
+caught the light and glared with a white intensity.
+
+Northward were Kilburn and Hampsted, blue and crowded with houses;
+westward the great city was dimmed; and southward, beyond the
+Martians, the green waves of Regent's Park, the Langham Hotel, the
+dome of the Albert Hall, the Imperial Institute, and the giant
+mansions of the Brompton Road came out clear and little in the
+sunrise, the jagged ruins of Westminster rising hazily beyond.  Far
+away and blue were the Surrey hills, and the towers of the Crystal
+Palace glittered like two silver rods.  The dome of St. Paul's was
+dark against the sunrise, and injured, I saw for the first time, by a
+huge gaping cavity on its western side.
+
+And as I looked at this wide expanse of houses and factories and
+churches, silent and abandoned; as I thought of the multitudinous
+hopes and efforts, the innumerable hosts of lives that had gone to
+build this human reef, and of the swift and ruthless destruction that
+had hung over it all; when I realised that the shadow had been rolled
+back, and that men might still live in the streets, and this dear vast
+dead city of mine be once more alive and powerful, I felt a wave of
+emotion that was near akin to tears.
+
+The torment was over.  Even that day the healing would begin.  The
+survivors of the people scattered over the country--leaderless,
+lawless, foodless, like sheep without a shepherd--the thousands who
+had fled by sea, would begin to return; the pulse of life, growing
+stronger and stronger, would beat again in the empty streets and pour
+across the vacant squares.  Whatever destruction was done, the hand of
+the destroyer was stayed.  All the gaunt wrecks, the blackened
+skeletons of houses that stared so dismally at the sunlit grass of the
+hill, would presently be echoing with the hammers of the restorers and
+ringing with the tapping of their trowels.  At the thought I extended
+my hands towards the sky and began thanking God.  In a year, thought
+I--in a year. . .
+
+With overwhelming force came the thought of myself, of my wife, and
+the old life of hope and tender helpfulness that had ceased for ever.
+
+
+
+CHAPTER NINE
+
+WRECKAGE
+
+
+And now comes the strangest thing in my story.  Yet, perhaps, it is
+not altogether strange.  I remember, clearly and coldly and vividly,
+all that I did that day until the time that I stood weeping and
+praising God upon the summit of Primrose Hill.  And then I forget.
+
+Of the next three days I know nothing.  I have learned since that,
+so far from my being the first discoverer of the Martian overthrow,
+several such wanderers as myself had already discovered this on the
+previous night.  One man--the first--had gone to St. Martin's-le-Grand,
+and, while I sheltered in the cabmen's hut, had contrived to
+telegraph to Paris.  Thence the joyful news had flashed all over the
+world; a thousand cities, chilled by ghastly apprehensions, suddenly
+flashed into frantic illuminations; they knew of it in Dublin,
+Edinburgh, Manchester, Birmingham, at the time when I stood upon the
+verge of the pit.  Already men, weeping with joy, as I have heard,
+shouting and staying their work to shake hands and shout, were making
+up trains, even as near as Crewe, to descend upon London.  The church
+bells that had ceased a fortnight since suddenly caught the news,
+until all England was bell-ringing.  Men on cycles, lean-faced,
+unkempt, scorched along every country lane shouting of unhoped
+deliverance, shouting to gaunt, staring figures of despair.  And for
+the food!  Across the Channel, across the Irish Sea, across the
+Atlantic, corn, bread, and meat were tearing to our relief.  All the
+shipping in the world seemed going Londonward in those days.  But of
+all this I have no memory.  I drifted--a demented man.  I found myself
+in a house of kindly people, who had found me on the third day
+wandering, weeping, and raving through the streets of St. John's Wood.
+They have told me since that I was singing some insane doggerel about
+"The Last Man Left Alive! Hurrah!  The Last Man Left Alive!"  Troubled
+as they were with their own affairs, these people, whose name, much as
+I would like to express my gratitude to them, I may not even give
+here, nevertheless cumbered themselves with me, sheltered me, and
+protected me from myself.  Apparently they had learned something of my
+story from me during the days of my lapse.
+
+Very gently, when my mind was assured again, did they break to me
+what they had learned of the fate of Leatherhead.  Two days after I
+was imprisoned it had been destroyed, with every soul in it, by a
+Martian.  He had swept it out of existence, as it seemed, without any
+provocation, as a boy might crush an ant hill, in the mere wantonness
+of power.
+
+I was a lonely man, and they were very kind to me.  I was a lonely
+man and a sad one, and they bore with me.  I remained with them four
+days after my recovery.  All that time I felt a vague, a growing
+craving to look once more on whatever remained of the little life that
+seemed so happy and bright in my past.  It was a mere hopeless desire
+to feast upon my misery.  They dissuaded me.  They did all they could
+to divert me from this morbidity.  But at last I could resist the
+impulse no longer, and, promising faithfully to return to them, and
+parting, as I will confess, from these four-day friends with tears, I
+went out again into the streets that had lately been so dark and
+strange and empty.
+
+Already they were busy with returning people; in places even there
+were shops open, and I saw a drinking fountain running water.
+
+I remember how mockingly bright the day seemed as I went back on my
+melancholy pilgrimage to the little house at Woking, how busy the
+streets and vivid the moving life about me.  So many people were
+abroad everywhere, busied in a thousand activities, that it seemed
+incredible that any great proportion of the population could have been
+slain.  But then I noticed how yellow were the skins of the people I
+met, how shaggy the hair of the men, how large and bright their eyes,
+and that every other man still wore his dirty rags.  Their faces
+seemed all with one of two expressions--a leaping exultation and
+energy or a grim resolution.  Save for the expression of the faces,
+London seemed a city of tramps.  The vestries were indiscriminately
+distributing bread sent us by the French government.  The ribs of the
+few horses showed dismally.  Haggard special constables with white
+badges stood at the corners of every street.  I saw little of the
+mischief wrought by the Martians until I reached Wellington Street,
+and there I saw the red weed clambering over the buttresses of
+Waterloo Bridge.
+
+At the corner of the bridge, too, I saw one of the common contrasts
+of that grotesque time--a sheet of paper flaunting against a thicket
+of the red weed, transfixed by a stick that kept it in place.  It was
+the placard of the first newspaper to resume publication--the _Daily
+Mail_.  I bought a copy for a blackened shilling I found in my pocket.
+Most of it was in blank, but the solitary compositor who did the thing
+had amused himself by making a grotesque scheme of advertisement
+stereo on the back page.  The matter he printed was emotional; the
+news organisation had not as yet found its way back.  I learned
+nothing fresh except that already in one week the examination of the
+Martian mechanisms had yielded astonishing results.  Among other
+things, the article assured me what I did not believe at the time,
+that the "Secret of Flying," was discovered.  At Waterloo I found the
+free trains that were taking people to their homes.  The first rush
+was already over.  There were few people in the train, and I was in no
+mood for casual conversation.  I got a compartment to myself, and sat
+with folded arms, looking greyly at the sunlit devastation that flowed
+past the windows.  And just outside the terminus the train jolted over
+temporary rails, and on either side of the railway the houses were
+blackened ruins.  To Clapham Junction the face of London was grimy
+with powder of the Black Smoke, in spite of two days of thunderstorms
+and rain, and at Clapham Junction the line had been wrecked again;
+there were hundreds of out-of-work clerks and shopmen working side by
+side with the customary navvies, and we were jolted over a hasty
+relaying.
+
+All down the line from there the aspect of the country was gaunt
+and unfamiliar; Wimbledon particularly had suffered.  Walton, by virtue
+of its unburned pine woods, seemed the least hurt of any place along
+the line.  The Wandle, the Mole, every little stream, was a heaped
+mass of red weed, in appearance between butcher's meat and pickled
+cabbage.  The Surrey pine woods were too dry, however, for the festoons
+of the red climber.  Beyond Wimbledon, within sight of the line, in
+certain nursery grounds, were the heaped masses of earth about the
+sixth cylinder.  A number of people were standing about it, and some
+sappers were busy in the midst of it.  Over it flaunted a Union Jack,
+flapping cheerfully in the morning breeze.  The nursery grounds were
+everywhere crimson with the weed, a wide expanse of livid colour cut
+with purple shadows, and very painful to the eye.  One's gaze went
+with infinite relief from the scorched greys and sullen reds of the
+foreground to the blue-green softness of the eastward hills.
+
+The line on the London side of Woking station was still undergoing
+repair, so I descended at Byfleet station and took the road to
+Maybury, past the place where I and the artilleryman had talked to the
+hussars, and on by the spot where the Martian had appeared to me in
+the thunderstorm.  Here, moved by curiosity, I turned aside to find,
+among a tangle of red fronds, the warped and broken dog cart with the
+whitened bones of the horse scattered and gnawed.  For a time I stood
+regarding these vestiges. . . .
+
+Then I returned through the pine wood, neck-high with red weed here
+and there, to find the landlord of the Spotted Dog had already found
+burial, and so came home past the College Arms.  A man standing at an
+open cottage door greeted me by name as I passed.
+
+I looked at my house with a quick flash of hope that faded
+immediately.  The door had been forced; it was unfast and was opening
+slowly as I approached.
+
+It slammed again.  The curtains of my study fluttered out of the
+open window from which I and the artilleryman had watched the dawn.  No
+one had closed it since.  The smashed bushes were just as I had left
+them nearly four weeks ago.  I stumbled into the hall, and the house
+felt empty.  The stair carpet was ruffled and discoloured where I had
+crouched, soaked to the skin from the thunderstorm the night of the
+catastrophe.  Our muddy footsteps I saw still went up the stairs.
+
+I followed them to my study, and found lying on my writing-table
+still, with the selenite paper weight upon it, the sheet of work I had
+left on the afternoon of the opening of the cylinder.  For a space I
+stood reading over my abandoned arguments.  It was a paper on the
+probable development of Moral Ideas with the development of the
+civilising process; and the last sentence was the opening of a
+prophecy: "In about two hundred years," I had written, "we may
+expect----"  The sentence ended abruptly.  I remembered my inability
+to fix my mind that morning, scarcely a month gone by, and how I had
+broken off to get my _Daily Chronicle_ from the newsboy.  I remembered
+how I went down to the garden gate as he came along, and how I had
+listened to his odd story of "Men from Mars."
+
+I came down and went into the dining room.  There were the mutton
+and the bread, both far gone now in decay, and a beer bottle
+overturned, just as I and the artilleryman had left them.  My home was
+desolate.  I perceived the folly of the faint hope I had cherished so
+long.  And then a strange thing occurred.  "It is no use," said a
+voice.  "The house is deserted.  No one has been here these ten days.
+Do not stay here to torment yourself.  No one escaped but you."
+
+I was startled.  Had I spoken my thought aloud?  I turned, and the
+French window was open behind me.  I made a step to it, and stood
+looking out.
+
+And there, amazed and afraid, even as I stood amazed and afraid,
+were my cousin and my wife--my wife white and tearless.  She gave a
+faint cry.
+
+"I came," she said.  "I knew--knew----"
+
+She put her hand to her throat--swayed.  I made a step forward, and
+caught her in my arms.
+
+
+
+CHAPTER TEN
+
+THE EPILOGUE
+
+
+I cannot but regret, now that I am concluding my story, how little
+I am able to contribute to the discussion of the many debatable
+questions which are still unsettled.  In one respect I shall certainly
+provoke criticism.  My particular province is speculative philosophy.
+My knowledge of comparative physiology is confined to a book or two,
+but it seems to me that Carver's suggestions as to the reason of the
+rapid death of the Martians is so probable as to be regarded almost as
+a proven conclusion.  I have assumed that in the body of my narrative.
+
+At any rate, in all the bodies of the Martians that were examined
+after the war, no bacteria except those already known as terrestrial
+species were found.  That they did not bury any of their dead, and the
+reckless slaughter they perpetrated, point also to an entire ignorance
+of the putrefactive process.  But probable as this seems, it is by no
+means a proven conclusion.
+
+Neither is the composition of the Black Smoke known, which the
+Martians used with such deadly effect, and the generator of the
+Heat-Rays remains a puzzle.  The terrible disasters at the Ealing
+and South Kensington laboratories have disinclined analysts for further
+investigations upon the latter.  Spectrum analysis of the black powder
+points unmistakably to the presence of an unknown element with a
+brilliant group of three lines in the green, and it is possible that
+it combines with argon to form a compound which acts at once with
+deadly effect upon some constituent in the blood.  But such unproven
+speculations will scarcely be of interest to the general reader, to
+whom this story is addressed.  None of the brown scum that drifted
+down the Thames after the destruction of Shepperton was examined at
+the time, and now none is forthcoming.
+
+The results of an anatomical examination of the Martians, so far
+as the prowling dogs had left such an examination possible, I have
+already given.  But everyone is familiar with the magnificent and
+almost complete specimen in spirits at the Natural History Museum, and
+the countless drawings that have been made from it; and beyond that
+the interest of their physiology and structure is purely scientific.
+
+A question of graver and universal interest is the possibility of
+another attack from the Martians.  I do not think that nearly enough
+attention is being given to this aspect of the matter.  At present the
+planet Mars is in conjunction, but with every return to opposition I,
+for one, anticipate a renewal of their adventure.  In any case, we
+should be prepared.  It seems to me that it should be possible to
+define the position of the gun from which the shots are discharged, to
+keep a sustained watch upon this part of the planet, and to anticipate
+the arrival of the next attack.
+
+In that case the cylinder might be destroyed with dynamite or
+artillery before it was sufficiently cool for the Martians to emerge,
+or they might be butchered by means of guns so soon as the screw
+opened.  It seems to me that they have lost a vast advantage in the
+failure of their first surprise.  Possibly they see it in the same
+light.
+
+Lessing has advanced excellent reasons for supposing that the
+Martians have actually succeeded in effecting a landing on the planet
+Venus.  Seven months ago now, Venus and Mars were in alignment with
+the sun; that is to say, Mars was in opposition from the point of view
+of an observer on Venus.  Subsequently a peculiar luminous and sinuous
+marking appeared on the unillumined half of the inner planet, and
+almost simultaneously a faint dark mark of a similar sinuous character
+was detected upon a photograph of the Martian disk.  One needs to see
+the drawings of these appearances in order to appreciate fully their
+remarkable resemblance in character.
+
+At any rate, whether we expect another invasion or not, our views
+of the human future must be greatly modified by these events.  We have
+learned now that we cannot regard this planet as being fenced in and a
+secure abiding place for Man; we can never anticipate the unseen good
+or evil that may come upon us suddenly out of space.  It may be that
+in the larger design of the universe this invasion from Mars is not
+without its ultimate benefit for men; it has robbed us of that serene
+confidence in the future which is the most fruitful source of
+decadence, the gifts to human science it has brought are enormous, and
+it has done much to promote the conception of the commonweal of
+mankind.  It may be that across the immensity of space the Martians
+have watched the fate of these pioneers of theirs and learned their
+lesson, and that on the planet Venus they have found a securer
+settlement.  Be that as it may, for many years yet there will
+certainly be no relaxation of the eager scrutiny of the Martian disk,
+and those fiery darts of the sky, the shooting stars, will bring with
+them as they fall an unavoidable apprehension to all the sons of men.
+
+The broadening of men's views that has resulted can scarcely be
+exaggerated.  Before the cylinder fell there was a general persuasion
+that through all the deep of space no life existed beyond the petty
+surface of our minute sphere.  Now we see further.  If the Martians
+can reach Venus, there is no reason to suppose that the thing is
+impossible for men, and when the slow cooling of the sun makes this
+earth uninhabitable, as at last it must do, it may be that the thread
+of life that has begun here will have streamed out and caught our
+sister planet within its toils.
+
+Dim and wonderful is the vision I have conjured up in my mind of
+life spreading slowly from this little seed bed of the solar system
+throughout the inanimate vastness of sidereal space.  But that is a
+remote dream.  It may be, on the other hand, that the destruction of
+the Martians is only a reprieve.  To them, and not to us, perhaps, is
+the future ordained.
+
+I must confess the stress and danger of the time have left an
+abiding sense of doubt and insecurity in my mind.  I sit in my study
+writing by lamplight, and suddenly I see again the healing valley
+below set with writhing flames, and feel the house behind and about me
+empty and desolate.  I go out into the Byfleet Road, and vehicles pass
+me, a butcher boy in a cart, a cabful of visitors, a workman on a
+bicycle, children going to school, and suddenly they become vague and
+unreal, and I hurry again with the artilleryman through the hot,
+brooding silence.  Of a night I see the black powder darkening the
+silent streets, and the contorted bodies shrouded in that layer; they
+rise upon me tattered and dog-bitten.  They gibber and grow fiercer,
+paler, uglier, mad distortions of humanity at last, and I wake, cold
+and wretched, in the darkness of the night.
+
+I go to London and see the busy multitudes in Fleet Street and the
+Strand, and it comes across my mind that they are but the ghosts of
+the past, haunting the streets that I have seen silent and wretched,
+going to and fro, phantasms in a dead city, the mockery of life in a
+galvanised body.  And strange, too, it is to stand on Primrose Hill,
+as I did but a day before writing this last chapter, to see the great
+province of houses, dim and blue through the haze of the smoke and
+mist, vanishing at last into the vague lower sky, to see the people
+walking to and fro among the flower beds on the hill, to see the
+sight-seers about the Martian machine that stands there still, to hear
+the tumult of playing children, and to recall the time when I saw it
+all bright and clear-cut, hard and silent, under the dawn of that last
+great day. . . .
+
+And strangest of all is it to hold my wife's hand again, and to think
+that I have counted her, and that she has counted me, among the dead.
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+***** This file should be named 36.txt or 36.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/36/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/pom.xml
+++ b/jet/source-sink-builder/pom.xml
@@ -29,16 +29,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <directory>../wordcount/src/main/resources</directory>
-            </resource>
-        </resources>
-    </build>
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/jet/source-sink-builder/src/main/resources/books/a-tale-of-two-cities.txt
+++ b/jet/source-sink-builder/src/main/resources/books/a-tale-of-two-cities.txt
@@ -1,0 +1,16272 @@
+﻿The Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: A Tale of Two Cities
+       A Story of the French Revolution
+
+Author: Charles Dickens
+
+Release Date: January, 1994 [EBook #98]
+Posting Date: November 28, 2009
+Last Updated: September 25, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+
+
+
+Produced by Judith Boss
+
+
+
+
+
+
+
+
+A TALE OF TWO CITIES
+
+A STORY OF THE FRENCH REVOLUTION
+
+By Charles Dickens
+
+
+CONTENTS
+
+
+     Book the First--Recalled to Life
+
+     Chapter I      The Period
+     Chapter II     The Mail
+     Chapter III    The Night Shadows
+     Chapter IV     The Preparation
+     Chapter V      The Wine-shop
+     Chapter VI     The Shoemaker
+
+
+     Book the Second--the Golden Thread
+
+     Chapter I      Five Years Later
+     Chapter II     A Sight
+     Chapter III    A Disappointment
+     Chapter IV     Congratulatory
+     Chapter V      The Jackal
+     Chapter VI     Hundreds of People
+     Chapter VII    Monseigneur in Town
+     Chapter VIII   Monseigneur in the Country
+     Chapter IX     The Gorgon’s Head
+     Chapter X      Two Promises
+     Chapter XI     A Companion Picture
+     Chapter XII    The Fellow of Delicacy
+     Chapter XIII   The Fellow of no Delicacy
+     Chapter XIV    The Honest Tradesman
+     Chapter XV     Knitting
+     Chapter XVI    Still Knitting
+     Chapter XVII   One Night
+     Chapter XVIII  Nine Days
+     Chapter XIX    An Opinion
+     Chapter XX     A Plea
+     Chapter XXI    Echoing Footsteps
+     Chapter XXII   The Sea Still Rises
+     Chapter XXIII  Fire Rises
+     Chapter XXIV   Drawn to the Loadstone Rock
+
+
+     Book the Third--the Track of a Storm
+
+     Chapter I      In Secret
+     Chapter II     The Grindstone
+     Chapter III    The Shadow
+     Chapter IV     Calm in Storm
+     Chapter V      The Wood-sawyer
+     Chapter VI     Triumph
+     Chapter VII    A Knock at the Door
+     Chapter VIII   A Hand at Cards
+     Chapter IX     The Game Made
+     Chapter X      The Substance of the Shadow
+     Chapter XI     Dusk
+     Chapter XII    Darkness
+     Chapter XIII   Fifty-two
+     Chapter XIV    The Knitting Done
+     Chapter XV     The Footsteps Die Out For Ever
+
+
+
+
+
+Book the First--Recalled to Life
+
+
+
+
+I. The Period
+
+
+It was the best of times,
+it was the worst of times,
+it was the age of wisdom,
+it was the age of foolishness,
+it was the epoch of belief,
+it was the epoch of incredulity,
+it was the season of Light,
+it was the season of Darkness,
+it was the spring of hope,
+it was the winter of despair,
+we had everything before us,
+we had nothing before us,
+we were all going direct to Heaven,
+we were all going direct the other way--
+in short, the period was so far like the present period, that some of
+its noisiest authorities insisted on its being received, for good or for
+evil, in the superlative degree of comparison only.
+
+There were a king with a large jaw and a queen with a plain face, on the
+throne of England; there were a king with a large jaw and a queen with
+a fair face, on the throne of France. In both countries it was clearer
+than crystal to the lords of the State preserves of loaves and fishes,
+that things in general were settled for ever.
+
+It was the year of Our Lord one thousand seven hundred and seventy-five.
+Spiritual revelations were conceded to England at that favoured period,
+as at this. Mrs. Southcott had recently attained her five-and-twentieth
+blessed birthday, of whom a prophetic private in the Life Guards had
+heralded the sublime appearance by announcing that arrangements were
+made for the swallowing up of London and Westminster. Even the Cock-lane
+ghost had been laid only a round dozen of years, after rapping out its
+messages, as the spirits of this very year last past (supernaturally
+deficient in originality) rapped out theirs. Mere messages in the
+earthly order of events had lately come to the English Crown and People,
+from a congress of British subjects in America: which, strange
+to relate, have proved more important to the human race than any
+communications yet received through any of the chickens of the Cock-lane
+brood.
+
+France, less favoured on the whole as to matters spiritual than her
+sister of the shield and trident, rolled with exceeding smoothness down
+hill, making paper money and spending it. Under the guidance of her
+Christian pastors, she entertained herself, besides, with such humane
+achievements as sentencing a youth to have his hands cut off, his tongue
+torn out with pincers, and his body burned alive, because he had not
+kneeled down in the rain to do honour to a dirty procession of monks
+which passed within his view, at a distance of some fifty or sixty
+yards. It is likely enough that, rooted in the woods of France and
+Norway, there were growing trees, when that sufferer was put to death,
+already marked by the Woodman, Fate, to come down and be sawn into
+boards, to make a certain movable framework with a sack and a knife in
+it, terrible in history. It is likely enough that in the rough outhouses
+of some tillers of the heavy lands adjacent to Paris, there were
+sheltered from the weather that very day, rude carts, bespattered with
+rustic mire, snuffed about by pigs, and roosted in by poultry, which
+the Farmer, Death, had already set apart to be his tumbrils of
+the Revolution. But that Woodman and that Farmer, though they work
+unceasingly, work silently, and no one heard them as they went about
+with muffled tread: the rather, forasmuch as to entertain any suspicion
+that they were awake, was to be atheistical and traitorous.
+
+In England, there was scarcely an amount of order and protection to
+justify much national boasting. Daring burglaries by armed men, and
+highway robberies, took place in the capital itself every night;
+families were publicly cautioned not to go out of town without removing
+their furniture to upholsterers’ warehouses for security; the highwayman
+in the dark was a City tradesman in the light, and, being recognised and
+challenged by his fellow-tradesman whom he stopped in his character of
+“the Captain,” gallantly shot him through the head and rode away; the
+mail was waylaid by seven robbers, and the guard shot three dead, and
+then got shot dead himself by the other four, “in consequence of the
+failure of his ammunition:” after which the mail was robbed in peace;
+that magnificent potentate, the Lord Mayor of London, was made to stand
+and deliver on Turnham Green, by one highwayman, who despoiled the
+illustrious creature in sight of all his retinue; prisoners in London
+gaols fought battles with their turnkeys, and the majesty of the law
+fired blunderbusses in among them, loaded with rounds of shot and ball;
+thieves snipped off diamond crosses from the necks of noble lords at
+Court drawing-rooms; musketeers went into St. Giles’s, to search
+for contraband goods, and the mob fired on the musketeers, and the
+musketeers fired on the mob, and nobody thought any of these occurrences
+much out of the common way. In the midst of them, the hangman, ever busy
+and ever worse than useless, was in constant requisition; now, stringing
+up long rows of miscellaneous criminals; now, hanging a housebreaker on
+Saturday who had been taken on Tuesday; now, burning people in the
+hand at Newgate by the dozen, and now burning pamphlets at the door of
+Westminster Hall; to-day, taking the life of an atrocious murderer,
+and to-morrow of a wretched pilferer who had robbed a farmer’s boy of
+sixpence.
+
+All these things, and a thousand like them, came to pass in and close
+upon the dear old year one thousand seven hundred and seventy-five.
+Environed by them, while the Woodman and the Farmer worked unheeded,
+those two of the large jaws, and those other two of the plain and the
+fair faces, trod with stir enough, and carried their divine rights
+with a high hand. Thus did the year one thousand seven hundred
+and seventy-five conduct their Greatnesses, and myriads of small
+creatures--the creatures of this chronicle among the rest--along the
+roads that lay before them.
+
+
+
+
+II. The Mail
+
+
+It was the Dover road that lay, on a Friday night late in November,
+before the first of the persons with whom this history has business.
+The Dover road lay, as to him, beyond the Dover mail, as it lumbered up
+Shooter’s Hill. He walked up hill in the mire by the side of the mail,
+as the rest of the passengers did; not because they had the least relish
+for walking exercise, under the circumstances, but because the hill,
+and the harness, and the mud, and the mail, were all so heavy, that the
+horses had three times already come to a stop, besides once drawing the
+coach across the road, with the mutinous intent of taking it back
+to Blackheath. Reins and whip and coachman and guard, however, in
+combination, had read that article of war which forbade a purpose
+otherwise strongly in favour of the argument, that some brute animals
+are endued with Reason; and the team had capitulated and returned to
+their duty.
+
+With drooping heads and tremulous tails, they mashed their way through
+the thick mud, floundering and stumbling between whiles, as if they were
+falling to pieces at the larger joints. As often as the driver rested
+them and brought them to a stand, with a wary “Wo-ho! so-ho-then!” the
+near leader violently shook his head and everything upon it--like an
+unusually emphatic horse, denying that the coach could be got up the
+hill. Whenever the leader made this rattle, the passenger started, as a
+nervous passenger might, and was disturbed in mind.
+
+There was a steaming mist in all the hollows, and it had roamed in its
+forlornness up the hill, like an evil spirit, seeking rest and finding
+none. A clammy and intensely cold mist, it made its slow way through the
+air in ripples that visibly followed and overspread one another, as the
+waves of an unwholesome sea might do. It was dense enough to shut out
+everything from the light of the coach-lamps but these its own workings,
+and a few yards of road; and the reek of the labouring horses steamed
+into it, as if they had made it all.
+
+Two other passengers, besides the one, were plodding up the hill by the
+side of the mail. All three were wrapped to the cheekbones and over the
+ears, and wore jack-boots. Not one of the three could have said, from
+anything he saw, what either of the other two was like; and each was
+hidden under almost as many wrappers from the eyes of the mind, as from
+the eyes of the body, of his two companions. In those days, travellers
+were very shy of being confidential on a short notice, for anybody on
+the road might be a robber or in league with robbers. As to the latter,
+when every posting-house and ale-house could produce somebody in
+“the Captain’s” pay, ranging from the landlord to the lowest stable
+non-descript, it was the likeliest thing upon the cards. So the guard
+of the Dover mail thought to himself, that Friday night in November, one
+thousand seven hundred and seventy-five, lumbering up Shooter’s Hill, as
+he stood on his own particular perch behind the mail, beating his feet,
+and keeping an eye and a hand on the arm-chest before him, where a
+loaded blunderbuss lay at the top of six or eight loaded horse-pistols,
+deposited on a substratum of cutlass.
+
+The Dover mail was in its usual genial position that the guard suspected
+the passengers, the passengers suspected one another and the guard, they
+all suspected everybody else, and the coachman was sure of nothing but
+the horses; as to which cattle he could with a clear conscience have
+taken his oath on the two Testaments that they were not fit for the
+journey.
+
+“Wo-ho!” said the coachman. “So, then! One more pull and you’re at the
+top and be damned to you, for I have had trouble enough to get you to
+it!--Joe!”
+
+“Halloa!” the guard replied.
+
+“What o’clock do you make it, Joe?”
+
+“Ten minutes, good, past eleven.”
+
+“My blood!” ejaculated the vexed coachman, “and not atop of Shooter’s
+yet! Tst! Yah! Get on with you!”
+
+The emphatic horse, cut short by the whip in a most decided negative,
+made a decided scramble for it, and the three other horses followed
+suit. Once more, the Dover mail struggled on, with the jack-boots of its
+passengers squashing along by its side. They had stopped when the coach
+stopped, and they kept close company with it. If any one of the three
+had had the hardihood to propose to another to walk on a little ahead
+into the mist and darkness, he would have put himself in a fair way of
+getting shot instantly as a highwayman.
+
+The last burst carried the mail to the summit of the hill. The horses
+stopped to breathe again, and the guard got down to skid the wheel for
+the descent, and open the coach-door to let the passengers in.
+
+“Tst! Joe!” cried the coachman in a warning voice, looking down from his
+box.
+
+“What do you say, Tom?”
+
+They both listened.
+
+“I say a horse at a canter coming up, Joe.”
+
+“_I_ say a horse at a gallop, Tom,” returned the guard, leaving his hold
+of the door, and mounting nimbly to his place. “Gentlemen! In the king’s
+name, all of you!”
+
+With this hurried adjuration, he cocked his blunderbuss, and stood on
+the offensive.
+
+The passenger booked by this history, was on the coach-step, getting in;
+the two other passengers were close behind him, and about to follow. He
+remained on the step, half in the coach and half out of; they remained
+in the road below him. They all looked from the coachman to the guard,
+and from the guard to the coachman, and listened. The coachman looked
+back and the guard looked back, and even the emphatic leader pricked up
+his ears and looked back, without contradicting.
+
+The stillness consequent on the cessation of the rumbling and labouring
+of the coach, added to the stillness of the night, made it very quiet
+indeed. The panting of the horses communicated a tremulous motion to
+the coach, as if it were in a state of agitation. The hearts of the
+passengers beat loud enough perhaps to be heard; but at any rate, the
+quiet pause was audibly expressive of people out of breath, and holding
+the breath, and having the pulses quickened by expectation.
+
+The sound of a horse at a gallop came fast and furiously up the hill.
+
+“So-ho!” the guard sang out, as loud as he could roar. “Yo there! Stand!
+I shall fire!”
+
+The pace was suddenly checked, and, with much splashing and floundering,
+a man’s voice called from the mist, “Is that the Dover mail?”
+
+“Never you mind what it is!” the guard retorted. “What are you?”
+
+“_Is_ that the Dover mail?”
+
+“Why do you want to know?”
+
+“I want a passenger, if it is.”
+
+“What passenger?”
+
+“Mr. Jarvis Lorry.”
+
+Our booked passenger showed in a moment that it was his name. The guard,
+the coachman, and the two other passengers eyed him distrustfully.
+
+“Keep where you are,” the guard called to the voice in the mist,
+“because, if I should make a mistake, it could never be set right in
+your lifetime. Gentleman of the name of Lorry answer straight.”
+
+“What is the matter?” asked the passenger, then, with mildly quavering
+speech. “Who wants me? Is it Jerry?”
+
+(“I don’t like Jerry’s voice, if it is Jerry,” growled the guard to
+himself. “He’s hoarser than suits me, is Jerry.”)
+
+“Yes, Mr. Lorry.”
+
+“What is the matter?”
+
+“A despatch sent after you from over yonder. T. and Co.”
+
+“I know this messenger, guard,” said Mr. Lorry, getting down into the
+road--assisted from behind more swiftly than politely by the other two
+passengers, who immediately scrambled into the coach, shut the door, and
+pulled up the window. “He may come close; there’s nothing wrong.”
+
+“I hope there ain’t, but I can’t make so ‘Nation sure of that,” said the
+guard, in gruff soliloquy. “Hallo you!”
+
+“Well! And hallo you!” said Jerry, more hoarsely than before.
+
+“Come on at a footpace! d’ye mind me? And if you’ve got holsters to that
+saddle o’ yourn, don’t let me see your hand go nigh ‘em. For I’m a devil
+at a quick mistake, and when I make one it takes the form of Lead. So
+now let’s look at you.”
+
+The figures of a horse and rider came slowly through the eddying mist,
+and came to the side of the mail, where the passenger stood. The rider
+stooped, and, casting up his eyes at the guard, handed the passenger
+a small folded paper. The rider’s horse was blown, and both horse and
+rider were covered with mud, from the hoofs of the horse to the hat of
+the man.
+
+“Guard!” said the passenger, in a tone of quiet business confidence.
+
+The watchful guard, with his right hand at the stock of his raised
+blunderbuss, his left at the barrel, and his eye on the horseman,
+answered curtly, “Sir.”
+
+“There is nothing to apprehend. I belong to Tellson’s Bank. You must
+know Tellson’s Bank in London. I am going to Paris on business. A crown
+to drink. I may read this?”
+
+“If so be as you’re quick, sir.”
+
+He opened it in the light of the coach-lamp on that side, and
+read--first to himself and then aloud: “‘Wait at Dover for Mam’selle.’
+It’s not long, you see, guard. Jerry, say that my answer was, RECALLED
+TO LIFE.”
+
+Jerry started in his saddle. “That’s a Blazing strange answer, too,”
+ said he, at his hoarsest.
+
+“Take that message back, and they will know that I received this, as
+well as if I wrote. Make the best of your way. Good night.”
+
+With those words the passenger opened the coach-door and got in; not at
+all assisted by his fellow-passengers, who had expeditiously secreted
+their watches and purses in their boots, and were now making a general
+pretence of being asleep. With no more definite purpose than to escape
+the hazard of originating any other kind of action.
+
+The coach lumbered on again, with heavier wreaths of mist closing round
+it as it began the descent. The guard soon replaced his blunderbuss
+in his arm-chest, and, having looked to the rest of its contents, and
+having looked to the supplementary pistols that he wore in his belt,
+looked to a smaller chest beneath his seat, in which there were a
+few smith’s tools, a couple of torches, and a tinder-box. For he was
+furnished with that completeness that if the coach-lamps had been blown
+and stormed out, which did occasionally happen, he had only to shut
+himself up inside, keep the flint and steel sparks well off the straw,
+and get a light with tolerable safety and ease (if he were lucky) in
+five minutes.
+
+“Tom!” softly over the coach roof.
+
+“Hallo, Joe.”
+
+“Did you hear the message?”
+
+“I did, Joe.”
+
+“What did you make of it, Tom?”
+
+“Nothing at all, Joe.”
+
+“That’s a coincidence, too,” the guard mused, “for I made the same of it
+myself.”
+
+Jerry, left alone in the mist and darkness, dismounted meanwhile, not
+only to ease his spent horse, but to wipe the mud from his face, and
+shake the wet out of his hat-brim, which might be capable of
+holding about half a gallon. After standing with the bridle over his
+heavily-splashed arm, until the wheels of the mail were no longer within
+hearing and the night was quite still again, he turned to walk down the
+hill.
+
+“After that there gallop from Temple Bar, old lady, I won’t trust your
+fore-legs till I get you on the level,” said this hoarse messenger,
+glancing at his mare. “‘Recalled to life.’ That’s a Blazing strange
+message. Much of that wouldn’t do for you, Jerry! I say, Jerry! You’d
+be in a Blazing bad way, if recalling to life was to come into fashion,
+Jerry!”
+
+
+
+
+III. The Night Shadows
+
+
+A wonderful fact to reflect upon, that every human creature is
+constituted to be that profound secret and mystery to every other. A
+solemn consideration, when I enter a great city by night, that every
+one of those darkly clustered houses encloses its own secret; that every
+room in every one of them encloses its own secret; that every beating
+heart in the hundreds of thousands of breasts there, is, in some of
+its imaginings, a secret to the heart nearest it! Something of the
+awfulness, even of Death itself, is referable to this. No more can I
+turn the leaves of this dear book that I loved, and vainly hope in time
+to read it all. No more can I look into the depths of this unfathomable
+water, wherein, as momentary lights glanced into it, I have had glimpses
+of buried treasure and other things submerged. It was appointed that the
+book should shut with a spring, for ever and for ever, when I had read
+but a page. It was appointed that the water should be locked in an
+eternal frost, when the light was playing on its surface, and I stood
+in ignorance on the shore. My friend is dead, my neighbour is dead,
+my love, the darling of my soul, is dead; it is the inexorable
+consolidation and perpetuation of the secret that was always in that
+individuality, and which I shall carry in mine to my life’s end. In
+any of the burial-places of this city through which I pass, is there
+a sleeper more inscrutable than its busy inhabitants are, in their
+innermost personality, to me, or than I am to them?
+
+As to this, his natural and not to be alienated inheritance, the
+messenger on horseback had exactly the same possessions as the King, the
+first Minister of State, or the richest merchant in London. So with the
+three passengers shut up in the narrow compass of one lumbering old mail
+coach; they were mysteries to one another, as complete as if each had
+been in his own coach and six, or his own coach and sixty, with the
+breadth of a county between him and the next.
+
+The messenger rode back at an easy trot, stopping pretty often at
+ale-houses by the way to drink, but evincing a tendency to keep his
+own counsel, and to keep his hat cocked over his eyes. He had eyes that
+assorted very well with that decoration, being of a surface black, with
+no depth in the colour or form, and much too near together--as if they
+were afraid of being found out in something, singly, if they kept too
+far apart. They had a sinister expression, under an old cocked-hat like
+a three-cornered spittoon, and over a great muffler for the chin and
+throat, which descended nearly to the wearer’s knees. When he stopped
+for drink, he moved this muffler with his left hand, only while he
+poured his liquor in with his right; as soon as that was done, he
+muffled again.
+
+“No, Jerry, no!” said the messenger, harping on one theme as he rode.
+“It wouldn’t do for you, Jerry. Jerry, you honest tradesman, it wouldn’t
+suit _your_ line of business! Recalled--! Bust me if I don’t think he’d
+been a drinking!”
+
+His message perplexed his mind to that degree that he was fain, several
+times, to take off his hat to scratch his head. Except on the crown,
+which was raggedly bald, he had stiff, black hair, standing jaggedly all
+over it, and growing down hill almost to his broad, blunt nose. It was
+so like Smith’s work, so much more like the top of a strongly spiked
+wall than a head of hair, that the best of players at leap-frog might
+have declined him, as the most dangerous man in the world to go over.
+
+While he trotted back with the message he was to deliver to the night
+watchman in his box at the door of Tellson’s Bank, by Temple Bar, who
+was to deliver it to greater authorities within, the shadows of the
+night took such shapes to him as arose out of the message, and took such
+shapes to the mare as arose out of _her_ private topics of uneasiness.
+They seemed to be numerous, for she shied at every shadow on the road.
+
+What time, the mail-coach lumbered, jolted, rattled, and bumped upon
+its tedious way, with its three fellow-inscrutables inside. To whom,
+likewise, the shadows of the night revealed themselves, in the forms
+their dozing eyes and wandering thoughts suggested.
+
+Tellson’s Bank had a run upon it in the mail. As the bank
+passenger--with an arm drawn through the leathern strap, which did what
+lay in it to keep him from pounding against the next passenger,
+and driving him into his corner, whenever the coach got a special
+jolt--nodded in his place, with half-shut eyes, the little
+coach-windows, and the coach-lamp dimly gleaming through them, and the
+bulky bundle of opposite passenger, became the bank, and did a great
+stroke of business. The rattle of the harness was the chink of money,
+and more drafts were honoured in five minutes than even Tellson’s, with
+all its foreign and home connection, ever paid in thrice the time. Then
+the strong-rooms underground, at Tellson’s, with such of their valuable
+stores and secrets as were known to the passenger (and it was not a
+little that he knew about them), opened before him, and he went in among
+them with the great keys and the feebly-burning candle, and found them
+safe, and strong, and sound, and still, just as he had last seen them.
+
+But, though the bank was almost always with him, and though the coach
+(in a confused way, like the presence of pain under an opiate) was
+always with him, there was another current of impression that never
+ceased to run, all through the night. He was on his way to dig some one
+out of a grave.
+
+Now, which of the multitude of faces that showed themselves before him
+was the true face of the buried person, the shadows of the night did
+not indicate; but they were all the faces of a man of five-and-forty by
+years, and they differed principally in the passions they expressed,
+and in the ghastliness of their worn and wasted state. Pride, contempt,
+defiance, stubbornness, submission, lamentation, succeeded one another;
+so did varieties of sunken cheek, cadaverous colour, emaciated hands
+and figures. But the face was in the main one face, and every head was
+prematurely white. A hundred times the dozing passenger inquired of this
+spectre:
+
+“Buried how long?”
+
+The answer was always the same: “Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+“You know that you are recalled to life?”
+
+“They tell me so.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+“Shall I show her to you? Will you come and see her?”
+
+The answers to this question were various and contradictory. Sometimes
+the broken reply was, “Wait! It would kill me if I saw her too soon.”
+ Sometimes, it was given in a tender rain of tears, and then it was,
+“Take me to her.” Sometimes it was staring and bewildered, and then it
+was, “I don’t know her. I don’t understand.”
+
+After such imaginary discourse, the passenger in his fancy would dig,
+and dig, dig--now with a spade, now with a great key, now with his
+hands--to dig this wretched creature out. Got out at last, with earth
+hanging about his face and hair, he would suddenly fan away to dust. The
+passenger would then start to himself, and lower the window, to get the
+reality of mist and rain on his cheek.
+
+Yet even when his eyes were opened on the mist and rain, on the moving
+patch of light from the lamps, and the hedge at the roadside retreating
+by jerks, the night shadows outside the coach would fall into the train
+of the night shadows within. The real Banking-house by Temple Bar, the
+real business of the past day, the real strong rooms, the real express
+sent after him, and the real message returned, would all be there. Out
+of the midst of them, the ghostly face would rise, and he would accost
+it again.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+Dig--dig--dig--until an impatient movement from one of the two
+passengers would admonish him to pull up the window, draw his arm
+securely through the leathern strap, and speculate upon the two
+slumbering forms, until his mind lost its hold of them, and they again
+slid away into the bank and the grave.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+The words were still in his hearing as just spoken--distinctly in
+his hearing as ever spoken words had been in his life--when the weary
+passenger started to the consciousness of daylight, and found that the
+shadows of the night were gone.
+
+He lowered the window, and looked out at the rising sun. There was a
+ridge of ploughed land, with a plough upon it where it had been left
+last night when the horses were unyoked; beyond, a quiet coppice-wood,
+in which many leaves of burning red and golden yellow still remained
+upon the trees. Though the earth was cold and wet, the sky was clear,
+and the sun rose bright, placid, and beautiful.
+
+“Eighteen years!” said the passenger, looking at the sun. “Gracious
+Creator of day! To be buried alive for eighteen years!”
+
+
+
+
+IV. The Preparation
+
+
+When the mail got successfully to Dover, in the course of the forenoon,
+the head drawer at the Royal George Hotel opened the coach-door as his
+custom was. He did it with some flourish of ceremony, for a mail journey
+from London in winter was an achievement to congratulate an adventurous
+traveller upon.
+
+By that time, there was only one adventurous traveller left be
+congratulated: for the two others had been set down at their respective
+roadside destinations. The mildewy inside of the coach, with its damp
+and dirty straw, its disagreeable smell, and its obscurity, was rather
+like a larger dog-kennel. Mr. Lorry, the passenger, shaking himself out
+of it in chains of straw, a tangle of shaggy wrapper, flapping hat, and
+muddy legs, was rather like a larger sort of dog.
+
+“There will be a packet to Calais, tomorrow, drawer?”
+
+“Yes, sir, if the weather holds and the wind sets tolerable fair. The
+tide will serve pretty nicely at about two in the afternoon, sir. Bed,
+sir?”
+
+“I shall not go to bed till night; but I want a bedroom, and a barber.”
+
+“And then breakfast, sir? Yes, sir. That way, sir, if you please.
+Show Concord! Gentleman’s valise and hot water to Concord. Pull off
+gentleman’s boots in Concord. (You will find a fine sea-coal fire, sir.)
+Fetch barber to Concord. Stir about there, now, for Concord!”
+
+The Concord bed-chamber being always assigned to a passenger by the
+mail, and passengers by the mail being always heavily wrapped up from
+head to foot, the room had the odd interest for the establishment of the
+Royal George, that although but one kind of man was seen to go into it,
+all kinds and varieties of men came out of it. Consequently, another
+drawer, and two porters, and several maids and the landlady, were all
+loitering by accident at various points of the road between the Concord
+and the coffee-room, when a gentleman of sixty, formally dressed in a
+brown suit of clothes, pretty well worn, but very well kept, with large
+square cuffs and large flaps to the pockets, passed along on his way to
+his breakfast.
+
+The coffee-room had no other occupant, that forenoon, than the gentleman
+in brown. His breakfast-table was drawn before the fire, and as he sat,
+with its light shining on him, waiting for the meal, he sat so still,
+that he might have been sitting for his portrait.
+
+Very orderly and methodical he looked, with a hand on each knee, and a
+loud watch ticking a sonorous sermon under his flapped waist-coat,
+as though it pitted its gravity and longevity against the levity and
+evanescence of the brisk fire. He had a good leg, and was a little vain
+of it, for his brown stockings fitted sleek and close, and were of a
+fine texture; his shoes and buckles, too, though plain, were trim. He
+wore an odd little sleek crisp flaxen wig, setting very close to his
+head: which wig, it is to be presumed, was made of hair, but which
+looked far more as though it were spun from filaments of silk or glass.
+His linen, though not of a fineness in accordance with his stockings,
+was as white as the tops of the waves that broke upon the neighbouring
+beach, or the specks of sail that glinted in the sunlight far at sea. A
+face habitually suppressed and quieted, was still lighted up under the
+quaint wig by a pair of moist bright eyes that it must have cost
+their owner, in years gone by, some pains to drill to the composed and
+reserved expression of Tellson’s Bank. He had a healthy colour in his
+cheeks, and his face, though lined, bore few traces of anxiety.
+But, perhaps the confidential bachelor clerks in Tellson’s Bank were
+principally occupied with the cares of other people; and perhaps
+second-hand cares, like second-hand clothes, come easily off and on.
+
+Completing his resemblance to a man who was sitting for his portrait,
+Mr. Lorry dropped off to sleep. The arrival of his breakfast roused him,
+and he said to the drawer, as he moved his chair to it:
+
+“I wish accommodation prepared for a young lady who may come here at any
+time to-day. She may ask for Mr. Jarvis Lorry, or she may only ask for a
+gentleman from Tellson’s Bank. Please to let me know.”
+
+“Yes, sir. Tellson’s Bank in London, sir?”
+
+“Yes.”
+
+“Yes, sir. We have oftentimes the honour to entertain your gentlemen in
+their travelling backwards and forwards betwixt London and Paris, sir. A
+vast deal of travelling, sir, in Tellson and Company’s House.”
+
+“Yes. We are quite a French House, as well as an English one.”
+
+“Yes, sir. Not much in the habit of such travelling yourself, I think,
+sir?”
+
+“Not of late years. It is fifteen years since we--since I--came last
+from France.”
+
+“Indeed, sir? That was before my time here, sir. Before our people’s
+time here, sir. The George was in other hands at that time, sir.”
+
+“I believe so.”
+
+“But I would hold a pretty wager, sir, that a House like Tellson and
+Company was flourishing, a matter of fifty, not to speak of fifteen
+years ago?”
+
+“You might treble that, and say a hundred and fifty, yet not be far from
+the truth.”
+
+“Indeed, sir!”
+
+Rounding his mouth and both his eyes, as he stepped backward from the
+table, the waiter shifted his napkin from his right arm to his left,
+dropped into a comfortable attitude, and stood surveying the guest while
+he ate and drank, as from an observatory or watchtower. According to the
+immemorial usage of waiters in all ages.
+
+When Mr. Lorry had finished his breakfast, he went out for a stroll on
+the beach. The little narrow, crooked town of Dover hid itself away
+from the beach, and ran its head into the chalk cliffs, like a marine
+ostrich. The beach was a desert of heaps of sea and stones tumbling
+wildly about, and the sea did what it liked, and what it liked was
+destruction. It thundered at the town, and thundered at the cliffs, and
+brought the coast down, madly. The air among the houses was of so strong
+a piscatory flavour that one might have supposed sick fish went up to be
+dipped in it, as sick people went down to be dipped in the sea. A little
+fishing was done in the port, and a quantity of strolling about by
+night, and looking seaward: particularly at those times when the tide
+made, and was near flood. Small tradesmen, who did no business whatever,
+sometimes unaccountably realised large fortunes, and it was remarkable
+that nobody in the neighbourhood could endure a lamplighter.
+
+As the day declined into the afternoon, and the air, which had been
+at intervals clear enough to allow the French coast to be seen, became
+again charged with mist and vapour, Mr. Lorry’s thoughts seemed to cloud
+too. When it was dark, and he sat before the coffee-room fire, awaiting
+his dinner as he had awaited his breakfast, his mind was busily digging,
+digging, digging, in the live red coals.
+
+A bottle of good claret after dinner does a digger in the red coals no
+harm, otherwise than as it has a tendency to throw him out of work.
+Mr. Lorry had been idle a long time, and had just poured out his last
+glassful of wine with as complete an appearance of satisfaction as is
+ever to be found in an elderly gentleman of a fresh complexion who has
+got to the end of a bottle, when a rattling of wheels came up the narrow
+street, and rumbled into the inn-yard.
+
+He set down his glass untouched. “This is Mam’selle!” said he.
+
+In a very few minutes the waiter came in to announce that Miss Manette
+had arrived from London, and would be happy to see the gentleman from
+Tellson’s.
+
+“So soon?”
+
+Miss Manette had taken some refreshment on the road, and required none
+then, and was extremely anxious to see the gentleman from Tellson’s
+immediately, if it suited his pleasure and convenience.
+
+The gentleman from Tellson’s had nothing left for it but to empty his
+glass with an air of stolid desperation, settle his odd little flaxen
+wig at the ears, and follow the waiter to Miss Manette’s apartment.
+It was a large, dark room, furnished in a funereal manner with black
+horsehair, and loaded with heavy dark tables. These had been oiled and
+oiled, until the two tall candles on the table in the middle of the room
+were gloomily reflected on every leaf; as if _they_ were buried, in deep
+graves of black mahogany, and no light to speak of could be expected
+from them until they were dug out.
+
+The obscurity was so difficult to penetrate that Mr. Lorry, picking his
+way over the well-worn Turkey carpet, supposed Miss Manette to be, for
+the moment, in some adjacent room, until, having got past the two tall
+candles, he saw standing to receive him by the table between them and
+the fire, a young lady of not more than seventeen, in a riding-cloak,
+and still holding her straw travelling-hat by its ribbon in her hand. As
+his eyes rested on a short, slight, pretty figure, a quantity of golden
+hair, a pair of blue eyes that met his own with an inquiring look, and
+a forehead with a singular capacity (remembering how young and smooth
+it was), of rifting and knitting itself into an expression that was
+not quite one of perplexity, or wonder, or alarm, or merely of a bright
+fixed attention, though it included all the four expressions--as his
+eyes rested on these things, a sudden vivid likeness passed before him,
+of a child whom he had held in his arms on the passage across that very
+Channel, one cold time, when the hail drifted heavily and the sea ran
+high. The likeness passed away, like a breath along the surface of
+the gaunt pier-glass behind her, on the frame of which, a hospital
+procession of negro cupids, several headless and all cripples, were
+offering black baskets of Dead Sea fruit to black divinities of the
+feminine gender--and he made his formal bow to Miss Manette.
+
+“Pray take a seat, sir.” In a very clear and pleasant young voice; a
+little foreign in its accent, but a very little indeed.
+
+“I kiss your hand, miss,” said Mr. Lorry, with the manners of an earlier
+date, as he made his formal bow again, and took his seat.
+
+“I received a letter from the Bank, sir, yesterday, informing me that
+some intelligence--or discovery--”
+
+“The word is not material, miss; either word will do.”
+
+“--respecting the small property of my poor father, whom I never saw--so
+long dead--”
+
+Mr. Lorry moved in his chair, and cast a troubled look towards the
+hospital procession of negro cupids. As if _they_ had any help for
+anybody in their absurd baskets!
+
+“--rendered it necessary that I should go to Paris, there to communicate
+with a gentleman of the Bank, so good as to be despatched to Paris for
+the purpose.”
+
+“Myself.”
+
+“As I was prepared to hear, sir.”
+
+She curtseyed to him (young ladies made curtseys in those days), with a
+pretty desire to convey to him that she felt how much older and wiser he
+was than she. He made her another bow.
+
+“I replied to the Bank, sir, that as it was considered necessary, by
+those who know, and who are so kind as to advise me, that I should go to
+France, and that as I am an orphan and have no friend who could go with
+me, I should esteem it highly if I might be permitted to place myself,
+during the journey, under that worthy gentleman’s protection. The
+gentleman had left London, but I think a messenger was sent after him to
+beg the favour of his waiting for me here.”
+
+“I was happy,” said Mr. Lorry, “to be entrusted with the charge. I shall
+be more happy to execute it.”
+
+“Sir, I thank you indeed. I thank you very gratefully. It was told me
+by the Bank that the gentleman would explain to me the details of the
+business, and that I must prepare myself to find them of a surprising
+nature. I have done my best to prepare myself, and I naturally have a
+strong and eager interest to know what they are.”
+
+“Naturally,” said Mr. Lorry. “Yes--I--”
+
+After a pause, he added, again settling the crisp flaxen wig at the
+ears, “It is very difficult to begin.”
+
+He did not begin, but, in his indecision, met her glance. The young
+forehead lifted itself into that singular expression--but it was pretty
+and characteristic, besides being singular--and she raised her hand,
+as if with an involuntary action she caught at, or stayed some passing
+shadow.
+
+“Are you quite a stranger to me, sir?”
+
+“Am I not?” Mr. Lorry opened his hands, and extended them outwards with
+an argumentative smile.
+
+Between the eyebrows and just over the little feminine nose, the line of
+which was as delicate and fine as it was possible to be, the expression
+deepened itself as she took her seat thoughtfully in the chair by which
+she had hitherto remained standing. He watched her as she mused, and the
+moment she raised her eyes again, went on:
+
+“In your adopted country, I presume, I cannot do better than address you
+as a young English lady, Miss Manette?”
+
+“If you please, sir.”
+
+“Miss Manette, I am a man of business. I have a business charge to
+acquit myself of. In your reception of it, don’t heed me any more than
+if I was a speaking machine--truly, I am not much else. I will, with
+your leave, relate to you, miss, the story of one of our customers.”
+
+“Story!”
+
+He seemed wilfully to mistake the word she had repeated, when he added,
+in a hurry, “Yes, customers; in the banking business we usually call
+our connection our customers. He was a French gentleman; a scientific
+gentleman; a man of great acquirements--a Doctor.”
+
+“Not of Beauvais?”
+
+“Why, yes, of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of repute in Paris. I had the honour of knowing him there.
+Our relations were business relations, but confidential. I was at that
+time in our French House, and had been--oh! twenty years.”
+
+“At that time--I may ask, at what time, sir?”
+
+“I speak, miss, of twenty years ago. He married--an English lady--and
+I was one of the trustees. His affairs, like the affairs of many other
+French gentlemen and French families, were entirely in Tellson’s hands.
+In a similar way I am, or I have been, trustee of one kind or other for
+scores of our customers. These are mere business relations, miss;
+there is no friendship in them, no particular interest, nothing like
+sentiment. I have passed from one to another, in the course of my
+business life, just as I pass from one of our customers to another in
+the course of my business day; in short, I have no feelings; I am a mere
+machine. To go on--”
+
+“But this is my father’s story, sir; and I begin to think”--the
+curiously roughened forehead was very intent upon him--“that when I was
+left an orphan through my mother’s surviving my father only two years,
+it was you who brought me to England. I am almost sure it was you.”
+
+Mr. Lorry took the hesitating little hand that confidingly advanced
+to take his, and he put it with some ceremony to his lips. He then
+conducted the young lady straightway to her chair again, and, holding
+the chair-back with his left hand, and using his right by turns to rub
+his chin, pull his wig at the ears, or point what he said, stood looking
+down into her face while she sat looking up into his.
+
+“Miss Manette, it _was_ I. And you will see how truly I spoke of myself
+just now, in saying I had no feelings, and that all the relations I hold
+with my fellow-creatures are mere business relations, when you reflect
+that I have never seen you since. No; you have been the ward of
+Tellson’s House since, and I have been busy with the other business of
+Tellson’s House since. Feelings! I have no time for them, no chance
+of them. I pass my whole life, miss, in turning an immense pecuniary
+Mangle.”
+
+After this odd description of his daily routine of employment, Mr. Lorry
+flattened his flaxen wig upon his head with both hands (which was most
+unnecessary, for nothing could be flatter than its shining surface was
+before), and resumed his former attitude.
+
+“So far, miss (as you have remarked), this is the story of your
+regretted father. Now comes the difference. If your father had not died
+when he did--Don’t be frightened! How you start!”
+
+She did, indeed, start. And she caught his wrist with both her hands.
+
+“Pray,” said Mr. Lorry, in a soothing tone, bringing his left hand from
+the back of the chair to lay it on the supplicatory fingers that clasped
+him in so violent a tremble: “pray control your agitation--a matter of
+business. As I was saying--”
+
+Her look so discomposed him that he stopped, wandered, and began anew:
+
+“As I was saying; if Monsieur Manette had not died; if he had suddenly
+and silently disappeared; if he had been spirited away; if it had not
+been difficult to guess to what dreadful place, though no art could
+trace him; if he had an enemy in some compatriot who could exercise a
+privilege that I in my own time have known the boldest people afraid
+to speak of in a whisper, across the water there; for instance, the
+privilege of filling up blank forms for the consignment of any one
+to the oblivion of a prison for any length of time; if his wife had
+implored the king, the queen, the court, the clergy, for any tidings of
+him, and all quite in vain;--then the history of your father would have
+been the history of this unfortunate gentleman, the Doctor of Beauvais.”
+
+“I entreat you to tell me more, sir.”
+
+“I will. I am going to. You can bear it?”
+
+“I can bear anything but the uncertainty you leave me in at this
+moment.”
+
+“You speak collectedly, and you--_are_ collected. That’s good!” (Though
+his manner was less satisfied than his words.) “A matter of business.
+Regard it as a matter of business--business that must be done. Now
+if this doctor’s wife, though a lady of great courage and spirit,
+had suffered so intensely from this cause before her little child was
+born--”
+
+“The little child was a daughter, sir.”
+
+“A daughter. A-a-matter of business--don’t be distressed. Miss, if the
+poor lady had suffered so intensely before her little child was born,
+that she came to the determination of sparing the poor child the
+inheritance of any part of the agony she had known the pains of, by
+rearing her in the belief that her father was dead--No, don’t kneel! In
+Heaven’s name why should you kneel to me!”
+
+“For the truth. O dear, good, compassionate sir, for the truth!”
+
+“A--a matter of business. You confuse me, and how can I transact
+business if I am confused? Let us be clear-headed. If you could kindly
+mention now, for instance, what nine times ninepence are, or how many
+shillings in twenty guineas, it would be so encouraging. I should be so
+much more at my ease about your state of mind.”
+
+Without directly answering to this appeal, she sat so still when he had
+very gently raised her, and the hands that had not ceased to clasp
+his wrists were so much more steady than they had been, that she
+communicated some reassurance to Mr. Jarvis Lorry.
+
+“That’s right, that’s right. Courage! Business! You have business before
+you; useful business. Miss Manette, your mother took this course with
+you. And when she died--I believe broken-hearted--having never slackened
+her unavailing search for your father, she left you, at two years old,
+to grow to be blooming, beautiful, and happy, without the dark cloud
+upon you of living in uncertainty whether your father soon wore his
+heart out in prison, or wasted there through many lingering years.”
+
+As he said the words he looked down, with an admiring pity, on the
+flowing golden hair; as if he pictured to himself that it might have
+been already tinged with grey.
+
+“You know that your parents had no great possession, and that what
+they had was secured to your mother and to you. There has been no new
+discovery, of money, or of any other property; but--”
+
+He felt his wrist held closer, and he stopped. The expression in the
+forehead, which had so particularly attracted his notice, and which was
+now immovable, had deepened into one of pain and horror.
+
+“But he has been--been found. He is alive. Greatly changed, it is too
+probable; almost a wreck, it is possible; though we will hope the best.
+Still, alive. Your father has been taken to the house of an old servant
+in Paris, and we are going there: I, to identify him if I can: you, to
+restore him to life, love, duty, rest, comfort.”
+
+A shiver ran through her frame, and from it through his. She said, in a
+low, distinct, awe-stricken voice, as if she were saying it in a dream,
+
+“I am going to see his Ghost! It will be his Ghost--not him!”
+
+Mr. Lorry quietly chafed the hands that held his arm. “There, there,
+there! See now, see now! The best and the worst are known to you, now.
+You are well on your way to the poor wronged gentleman, and, with a fair
+sea voyage, and a fair land journey, you will be soon at his dear side.”
+
+She repeated in the same tone, sunk to a whisper, “I have been free, I
+have been happy, yet his Ghost has never haunted me!”
+
+“Only one thing more,” said Mr. Lorry, laying stress upon it as a
+wholesome means of enforcing her attention: “he has been found under
+another name; his own, long forgotten or long concealed. It would be
+worse than useless now to inquire which; worse than useless to seek to
+know whether he has been for years overlooked, or always designedly
+held prisoner. It would be worse than useless now to make any inquiries,
+because it would be dangerous. Better not to mention the subject,
+anywhere or in any way, and to remove him--for a while at all
+events--out of France. Even I, safe as an Englishman, and even
+Tellson’s, important as they are to French credit, avoid all naming of
+the matter. I carry about me, not a scrap of writing openly referring
+to it. This is a secret service altogether. My credentials, entries,
+and memoranda, are all comprehended in the one line, ‘Recalled to Life;’
+which may mean anything. But what is the matter! She doesn’t notice a
+word! Miss Manette!”
+
+Perfectly still and silent, and not even fallen back in her chair, she
+sat under his hand, utterly insensible; with her eyes open and fixed
+upon him, and with that last expression looking as if it were carved or
+branded into her forehead. So close was her hold upon his arm, that he
+feared to detach himself lest he should hurt her; therefore he called
+out loudly for assistance without moving.
+
+A wild-looking woman, whom even in his agitation, Mr. Lorry observed to
+be all of a red colour, and to have red hair, and to be dressed in some
+extraordinary tight-fitting fashion, and to have on her head a most
+wonderful bonnet like a Grenadier wooden measure, and good measure too,
+or a great Stilton cheese, came running into the room in advance of the
+inn servants, and soon settled the question of his detachment from the
+poor young lady, by laying a brawny hand upon his chest, and sending him
+flying back against the nearest wall.
+
+(“I really think this must be a man!” was Mr. Lorry’s breathless
+reflection, simultaneously with his coming against the wall.)
+
+“Why, look at you all!” bawled this figure, addressing the inn servants.
+“Why don’t you go and fetch things, instead of standing there staring
+at me? I am not so much to look at, am I? Why don’t you go and fetch
+things? I’ll let you know, if you don’t bring smelling-salts, cold
+water, and vinegar, quick, I will.”
+
+There was an immediate dispersal for these restoratives, and she
+softly laid the patient on a sofa, and tended her with great skill and
+gentleness: calling her “my precious!” and “my bird!” and spreading her
+golden hair aside over her shoulders with great pride and care.
+
+“And you in brown!” she said, indignantly turning to Mr. Lorry;
+“couldn’t you tell her what you had to tell her, without frightening her
+to death? Look at her, with her pretty pale face and her cold hands. Do
+you call _that_ being a Banker?”
+
+Mr. Lorry was so exceedingly disconcerted by a question so hard to
+answer, that he could only look on, at a distance, with much feebler
+sympathy and humility, while the strong woman, having banished the inn
+servants under the mysterious penalty of “letting them know” something
+not mentioned if they stayed there, staring, recovered her charge by a
+regular series of gradations, and coaxed her to lay her drooping head
+upon her shoulder.
+
+“I hope she will do well now,” said Mr. Lorry.
+
+“No thanks to you in brown, if she does. My darling pretty!”
+
+“I hope,” said Mr. Lorry, after another pause of feeble sympathy and
+humility, “that you accompany Miss Manette to France?”
+
+“A likely thing, too!” replied the strong woman. “If it was ever
+intended that I should go across salt water, do you suppose Providence
+would have cast my lot in an island?”
+
+This being another question hard to answer, Mr. Jarvis Lorry withdrew to
+consider it.
+
+
+
+
+V. The Wine-shop
+
+
+A large cask of wine had been dropped and broken, in the street. The
+accident had happened in getting it out of a cart; the cask had tumbled
+out with a run, the hoops had burst, and it lay on the stones just
+outside the door of the wine-shop, shattered like a walnut-shell.
+
+All the people within reach had suspended their business, or their
+idleness, to run to the spot and drink the wine. The rough, irregular
+stones of the street, pointing every way, and designed, one might have
+thought, expressly to lame all living creatures that approached them,
+had dammed it into little pools; these were surrounded, each by its own
+jostling group or crowd, according to its size. Some men kneeled down,
+made scoops of their two hands joined, and sipped, or tried to help
+women, who bent over their shoulders, to sip, before the wine had all
+run out between their fingers. Others, men and women, dipped in
+the puddles with little mugs of mutilated earthenware, or even with
+handkerchiefs from women’s heads, which were squeezed dry into infants’
+mouths; others made small mud-embankments, to stem the wine as it ran;
+others, directed by lookers-on up at high windows, darted here and
+there, to cut off little streams of wine that started away in new
+directions; others devoted themselves to the sodden and lee-dyed
+pieces of the cask, licking, and even champing the moister wine-rotted
+fragments with eager relish. There was no drainage to carry off the
+wine, and not only did it all get taken up, but so much mud got taken up
+along with it, that there might have been a scavenger in the street,
+if anybody acquainted with it could have believed in such a miraculous
+presence.
+
+A shrill sound of laughter and of amused voices--voices of men, women,
+and children--resounded in the street while this wine game lasted. There
+was little roughness in the sport, and much playfulness. There was a
+special companionship in it, an observable inclination on the part
+of every one to join some other one, which led, especially among the
+luckier or lighter-hearted, to frolicsome embraces, drinking of healths,
+shaking of hands, and even joining of hands and dancing, a dozen
+together. When the wine was gone, and the places where it had been
+most abundant were raked into a gridiron-pattern by fingers, these
+demonstrations ceased, as suddenly as they had broken out. The man who
+had left his saw sticking in the firewood he was cutting, set it in
+motion again; the women who had left on a door-step the little pot of
+hot ashes, at which she had been trying to soften the pain in her own
+starved fingers and toes, or in those of her child, returned to it; men
+with bare arms, matted locks, and cadaverous faces, who had emerged into
+the winter light from cellars, moved away, to descend again; and a gloom
+gathered on the scene that appeared more natural to it than sunshine.
+
+The wine was red wine, and had stained the ground of the narrow street
+in the suburb of Saint Antoine, in Paris, where it was spilled. It had
+stained many hands, too, and many faces, and many naked feet, and many
+wooden shoes. The hands of the man who sawed the wood, left red marks
+on the billets; and the forehead of the woman who nursed her baby, was
+stained with the stain of the old rag she wound about her head again.
+Those who had been greedy with the staves of the cask, had acquired a
+tigerish smear about the mouth; and one tall joker so besmirched, his
+head more out of a long squalid bag of a nightcap than in it, scrawled
+upon a wall with his finger dipped in muddy wine-lees--BLOOD.
+
+The time was to come, when that wine too would be spilled on the
+street-stones, and when the stain of it would be red upon many there.
+
+And now that the cloud settled on Saint Antoine, which a momentary
+gleam had driven from his sacred countenance, the darkness of it was
+heavy--cold, dirt, sickness, ignorance, and want, were the lords in
+waiting on the saintly presence--nobles of great power all of them;
+but, most especially the last. Samples of a people that had undergone a
+terrible grinding and regrinding in the mill, and certainly not in the
+fabulous mill which ground old people young, shivered at every corner,
+passed in and out at every doorway, looked from every window, fluttered
+in every vestige of a garment that the wind shook. The mill which
+had worked them down, was the mill that grinds young people old; the
+children had ancient faces and grave voices; and upon them, and upon the
+grown faces, and ploughed into every furrow of age and coming up afresh,
+was the sigh, Hunger. It was prevalent everywhere. Hunger was pushed out
+of the tall houses, in the wretched clothing that hung upon poles and
+lines; Hunger was patched into them with straw and rag and wood and
+paper; Hunger was repeated in every fragment of the small modicum of
+firewood that the man sawed off; Hunger stared down from the smokeless
+chimneys, and started up from the filthy street that had no offal,
+among its refuse, of anything to eat. Hunger was the inscription on the
+baker’s shelves, written in every small loaf of his scanty stock of
+bad bread; at the sausage-shop, in every dead-dog preparation that
+was offered for sale. Hunger rattled its dry bones among the roasting
+chestnuts in the turned cylinder; Hunger was shred into atomics in every
+farthing porringer of husky chips of potato, fried with some reluctant
+drops of oil.
+
+Its abiding place was in all things fitted to it. A narrow winding
+street, full of offence and stench, with other narrow winding streets
+diverging, all peopled by rags and nightcaps, and all smelling of rags
+and nightcaps, and all visible things with a brooding look upon them
+that looked ill. In the hunted air of the people there was yet some
+wild-beast thought of the possibility of turning at bay. Depressed and
+slinking though they were, eyes of fire were not wanting among them; nor
+compressed lips, white with what they suppressed; nor foreheads knitted
+into the likeness of the gallows-rope they mused about enduring, or
+inflicting. The trade signs (and they were almost as many as the shops)
+were, all, grim illustrations of Want. The butcher and the porkman
+painted up, only the leanest scrags of meat; the baker, the coarsest of
+meagre loaves. The people rudely pictured as drinking in the wine-shops,
+croaked over their scanty measures of thin wine and beer, and were
+gloweringly confidential together. Nothing was represented in a
+flourishing condition, save tools and weapons; but, the cutler’s knives
+and axes were sharp and bright, the smith’s hammers were heavy, and the
+gunmaker’s stock was murderous. The crippling stones of the pavement,
+with their many little reservoirs of mud and water, had no footways, but
+broke off abruptly at the doors. The kennel, to make amends, ran down
+the middle of the street--when it ran at all: which was only after heavy
+rains, and then it ran, by many eccentric fits, into the houses. Across
+the streets, at wide intervals, one clumsy lamp was slung by a rope and
+pulley; at night, when the lamplighter had let these down, and lighted,
+and hoisted them again, a feeble grove of dim wicks swung in a sickly
+manner overhead, as if they were at sea. Indeed they were at sea, and
+the ship and crew were in peril of tempest.
+
+For, the time was to come, when the gaunt scarecrows of that region
+should have watched the lamplighter, in their idleness and hunger, so
+long, as to conceive the idea of improving on his method, and hauling
+up men by those ropes and pulleys, to flare upon the darkness of their
+condition. But, the time was not come yet; and every wind that blew over
+France shook the rags of the scarecrows in vain, for the birds, fine of
+song and feather, took no warning.
+
+The wine-shop was a corner shop, better than most others in its
+appearance and degree, and the master of the wine-shop had stood outside
+it, in a yellow waistcoat and green breeches, looking on at the struggle
+for the lost wine. “It’s not my affair,” said he, with a final shrug
+of the shoulders. “The people from the market did it. Let them bring
+another.”
+
+There, his eyes happening to catch the tall joker writing up his joke,
+he called to him across the way:
+
+“Say, then, my Gaspard, what do you do there?”
+
+The fellow pointed to his joke with immense significance, as is often
+the way with his tribe. It missed its mark, and completely failed, as is
+often the way with his tribe too.
+
+“What now? Are you a subject for the mad hospital?” said the wine-shop
+keeper, crossing the road, and obliterating the jest with a handful of
+mud, picked up for the purpose, and smeared over it. “Why do you write
+in the public streets? Is there--tell me thou--is there no other place
+to write such words in?”
+
+In his expostulation he dropped his cleaner hand (perhaps accidentally,
+perhaps not) upon the joker’s heart. The joker rapped it with his
+own, took a nimble spring upward, and came down in a fantastic dancing
+attitude, with one of his stained shoes jerked off his foot into his
+hand, and held out. A joker of an extremely, not to say wolfishly
+practical character, he looked, under those circumstances.
+
+“Put it on, put it on,” said the other. “Call wine, wine; and finish
+there.” With that advice, he wiped his soiled hand upon the joker’s
+dress, such as it was--quite deliberately, as having dirtied the hand on
+his account; and then recrossed the road and entered the wine-shop.
+
+This wine-shop keeper was a bull-necked, martial-looking man of thirty,
+and he should have been of a hot temperament, for, although it was a
+bitter day, he wore no coat, but carried one slung over his shoulder.
+His shirt-sleeves were rolled up, too, and his brown arms were bare to
+the elbows. Neither did he wear anything more on his head than his own
+crisply-curling short dark hair. He was a dark man altogether, with good
+eyes and a good bold breadth between them. Good-humoured looking on
+the whole, but implacable-looking, too; evidently a man of a strong
+resolution and a set purpose; a man not desirable to be met, rushing
+down a narrow pass with a gulf on either side, for nothing would turn
+the man.
+
+Madame Defarge, his wife, sat in the shop behind the counter as he
+came in. Madame Defarge was a stout woman of about his own age, with
+a watchful eye that seldom seemed to look at anything, a large hand
+heavily ringed, a steady face, strong features, and great composure of
+manner. There was a character about Madame Defarge, from which one might
+have predicated that she did not often make mistakes against herself
+in any of the reckonings over which she presided. Madame Defarge being
+sensitive to cold, was wrapped in fur, and had a quantity of bright
+shawl twined about her head, though not to the concealment of her large
+earrings. Her knitting was before her, but she had laid it down to pick
+her teeth with a toothpick. Thus engaged, with her right elbow supported
+by her left hand, Madame Defarge said nothing when her lord came in, but
+coughed just one grain of cough. This, in combination with the lifting
+of her darkly defined eyebrows over her toothpick by the breadth of a
+line, suggested to her husband that he would do well to look round the
+shop among the customers, for any new customer who had dropped in while
+he stepped over the way.
+
+The wine-shop keeper accordingly rolled his eyes about, until they
+rested upon an elderly gentleman and a young lady, who were seated in
+a corner. Other company were there: two playing cards, two playing
+dominoes, three standing by the counter lengthening out a short supply
+of wine. As he passed behind the counter, he took notice that the
+elderly gentleman said in a look to the young lady, “This is our man.”
+
+“What the devil do _you_ do in that galley there?” said Monsieur Defarge
+to himself; “I don’t know you.”
+
+But, he feigned not to notice the two strangers, and fell into discourse
+with the triumvirate of customers who were drinking at the counter.
+
+“How goes it, Jacques?” said one of these three to Monsieur Defarge. “Is
+all the spilt wine swallowed?”
+
+“Every drop, Jacques,” answered Monsieur Defarge.
+
+When this interchange of Christian name was effected, Madame Defarge,
+picking her teeth with her toothpick, coughed another grain of cough,
+and raised her eyebrows by the breadth of another line.
+
+“It is not often,” said the second of the three, addressing Monsieur
+Defarge, “that many of these miserable beasts know the taste of wine, or
+of anything but black bread and death. Is it not so, Jacques?”
+
+“It is so, Jacques,” Monsieur Defarge returned.
+
+At this second interchange of the Christian name, Madame Defarge, still
+using her toothpick with profound composure, coughed another grain of
+cough, and raised her eyebrows by the breadth of another line.
+
+The last of the three now said his say, as he put down his empty
+drinking vessel and smacked his lips.
+
+“Ah! So much the worse! A bitter taste it is that such poor cattle
+always have in their mouths, and hard lives they live, Jacques. Am I
+right, Jacques?”
+
+“You are right, Jacques,” was the response of Monsieur Defarge.
+
+This third interchange of the Christian name was completed at the moment
+when Madame Defarge put her toothpick by, kept her eyebrows up, and
+slightly rustled in her seat.
+
+“Hold then! True!” muttered her husband. “Gentlemen--my wife!”
+
+The three customers pulled off their hats to Madame Defarge, with three
+flourishes. She acknowledged their homage by bending her head, and
+giving them a quick look. Then she glanced in a casual manner round the
+wine-shop, took up her knitting with great apparent calmness and repose
+of spirit, and became absorbed in it.
+
+“Gentlemen,” said her husband, who had kept his bright eye observantly
+upon her, “good day. The chamber, furnished bachelor-fashion, that you
+wished to see, and were inquiring for when I stepped out, is on the
+fifth floor. The doorway of the staircase gives on the little courtyard
+close to the left here,” pointing with his hand, “near to the window of
+my establishment. But, now that I remember, one of you has already been
+there, and can show the way. Gentlemen, adieu!”
+
+They paid for their wine, and left the place. The eyes of Monsieur
+Defarge were studying his wife at her knitting when the elderly
+gentleman advanced from his corner, and begged the favour of a word.
+
+“Willingly, sir,” said Monsieur Defarge, and quietly stepped with him to
+the door.
+
+Their conference was very short, but very decided. Almost at the first
+word, Monsieur Defarge started and became deeply attentive. It had
+not lasted a minute, when he nodded and went out. The gentleman then
+beckoned to the young lady, and they, too, went out. Madame Defarge
+knitted with nimble fingers and steady eyebrows, and saw nothing.
+
+Mr. Jarvis Lorry and Miss Manette, emerging from the wine-shop thus,
+joined Monsieur Defarge in the doorway to which he had directed his own
+company just before. It opened from a stinking little black courtyard,
+and was the general public entrance to a great pile of houses, inhabited
+by a great number of people. In the gloomy tile-paved entry to the
+gloomy tile-paved staircase, Monsieur Defarge bent down on one knee
+to the child of his old master, and put her hand to his lips. It was
+a gentle action, but not at all gently done; a very remarkable
+transformation had come over him in a few seconds. He had no good-humour
+in his face, nor any openness of aspect left, but had become a secret,
+angry, dangerous man.
+
+“It is very high; it is a little difficult. Better to begin slowly.”
+ Thus, Monsieur Defarge, in a stern voice, to Mr. Lorry, as they began
+ascending the stairs.
+
+“Is he alone?” the latter whispered.
+
+“Alone! God help him, who should be with him!” said the other, in the
+same low voice.
+
+“Is he always alone, then?”
+
+“Yes.”
+
+“Of his own desire?”
+
+“Of his own necessity. As he was, when I first saw him after they
+found me and demanded to know if I would take him, and, at my peril be
+discreet--as he was then, so he is now.”
+
+“He is greatly changed?”
+
+“Changed!”
+
+The keeper of the wine-shop stopped to strike the wall with his hand,
+and mutter a tremendous curse. No direct answer could have been half so
+forcible. Mr. Lorry’s spirits grew heavier and heavier, as he and his
+two companions ascended higher and higher.
+
+Such a staircase, with its accessories, in the older and more crowded
+parts of Paris, would be bad enough now; but, at that time, it was vile
+indeed to unaccustomed and unhardened senses. Every little habitation
+within the great foul nest of one high building--that is to say,
+the room or rooms within every door that opened on the general
+staircase--left its own heap of refuse on its own landing, besides
+flinging other refuse from its own windows. The uncontrollable and
+hopeless mass of decomposition so engendered, would have polluted
+the air, even if poverty and deprivation had not loaded it with their
+intangible impurities; the two bad sources combined made it almost
+insupportable. Through such an atmosphere, by a steep dark shaft of dirt
+and poison, the way lay. Yielding to his own disturbance of mind, and to
+his young companion’s agitation, which became greater every instant, Mr.
+Jarvis Lorry twice stopped to rest. Each of these stoppages was made
+at a doleful grating, by which any languishing good airs that were left
+uncorrupted, seemed to escape, and all spoilt and sickly vapours seemed
+to crawl in. Through the rusted bars, tastes, rather than glimpses, were
+caught of the jumbled neighbourhood; and nothing within range, nearer
+or lower than the summits of the two great towers of Notre-Dame, had any
+promise on it of healthy life or wholesome aspirations.
+
+At last, the top of the staircase was gained, and they stopped for the
+third time. There was yet an upper staircase, of a steeper inclination
+and of contracted dimensions, to be ascended, before the garret story
+was reached. The keeper of the wine-shop, always going a little in
+advance, and always going on the side which Mr. Lorry took, as though he
+dreaded to be asked any question by the young lady, turned himself about
+here, and, carefully feeling in the pockets of the coat he carried over
+his shoulder, took out a key.
+
+“The door is locked then, my friend?” said Mr. Lorry, surprised.
+
+“Ay. Yes,” was the grim reply of Monsieur Defarge.
+
+“You think it necessary to keep the unfortunate gentleman so retired?”
+
+“I think it necessary to turn the key.” Monsieur Defarge whispered it
+closer in his ear, and frowned heavily.
+
+“Why?”
+
+“Why! Because he has lived so long, locked up, that he would be
+frightened--rave--tear himself to pieces--die--come to I know not what
+harm--if his door was left open.”
+
+“Is it possible!” exclaimed Mr. Lorry.
+
+“Is it possible!” repeated Defarge, bitterly. “Yes. And a beautiful
+world we live in, when it _is_ possible, and when many other such things
+are possible, and not only possible, but done--done, see you!--under
+that sky there, every day. Long live the Devil. Let us go on.”
+
+This dialogue had been held in so very low a whisper, that not a word
+of it had reached the young lady’s ears. But, by this time she trembled
+under such strong emotion, and her face expressed such deep anxiety,
+and, above all, such dread and terror, that Mr. Lorry felt it incumbent
+on him to speak a word or two of reassurance.
+
+“Courage, dear miss! Courage! Business! The worst will be over in a
+moment; it is but passing the room-door, and the worst is over. Then,
+all the good you bring to him, all the relief, all the happiness you
+bring to him, begin. Let our good friend here, assist you on that side.
+That’s well, friend Defarge. Come, now. Business, business!”
+
+They went up slowly and softly. The staircase was short, and they were
+soon at the top. There, as it had an abrupt turn in it, they came all at
+once in sight of three men, whose heads were bent down close together at
+the side of a door, and who were intently looking into the room to which
+the door belonged, through some chinks or holes in the wall. On hearing
+footsteps close at hand, these three turned, and rose, and showed
+themselves to be the three of one name who had been drinking in the
+wine-shop.
+
+“I forgot them in the surprise of your visit,” explained Monsieur
+Defarge. “Leave us, good boys; we have business here.”
+
+The three glided by, and went silently down.
+
+There appearing to be no other door on that floor, and the keeper of
+the wine-shop going straight to this one when they were left alone, Mr.
+Lorry asked him in a whisper, with a little anger:
+
+“Do you make a show of Monsieur Manette?”
+
+“I show him, in the way you have seen, to a chosen few.”
+
+“Is that well?”
+
+“_I_ think it is well.”
+
+“Who are the few? How do you choose them?”
+
+“I choose them as real men, of my name--Jacques is my name--to whom the
+sight is likely to do good. Enough; you are English; that is another
+thing. Stay there, if you please, a little moment.”
+
+With an admonitory gesture to keep them back, he stooped, and looked in
+through the crevice in the wall. Soon raising his head again, he struck
+twice or thrice upon the door--evidently with no other object than to
+make a noise there. With the same intention, he drew the key across it,
+three or four times, before he put it clumsily into the lock, and turned
+it as heavily as he could.
+
+The door slowly opened inward under his hand, and he looked into the
+room and said something. A faint voice answered something. Little more
+than a single syllable could have been spoken on either side.
+
+He looked back over his shoulder, and beckoned them to enter. Mr. Lorry
+got his arm securely round the daughter’s waist, and held her; for he
+felt that she was sinking.
+
+“A-a-a-business, business!” he urged, with a moisture that was not of
+business shining on his cheek. “Come in, come in!”
+
+“I am afraid of it,” she answered, shuddering.
+
+“Of it? What?”
+
+“I mean of him. Of my father.”
+
+Rendered in a manner desperate, by her state and by the beckoning of
+their conductor, he drew over his neck the arm that shook upon his
+shoulder, lifted her a little, and hurried her into the room. He sat her
+down just within the door, and held her, clinging to him.
+
+Defarge drew out the key, closed the door, locked it on the inside,
+took out the key again, and held it in his hand. All this he did,
+methodically, and with as loud and harsh an accompaniment of noise as he
+could make. Finally, he walked across the room with a measured tread to
+where the window was. He stopped there, and faced round.
+
+The garret, built to be a depository for firewood and the like, was dim
+and dark: for, the window of dormer shape, was in truth a door in the
+roof, with a little crane over it for the hoisting up of stores from
+the street: unglazed, and closing up the middle in two pieces, like any
+other door of French construction. To exclude the cold, one half of this
+door was fast closed, and the other was opened but a very little way.
+Such a scanty portion of light was admitted through these means, that it
+was difficult, on first coming in, to see anything; and long habit
+alone could have slowly formed in any one, the ability to do any work
+requiring nicety in such obscurity. Yet, work of that kind was being
+done in the garret; for, with his back towards the door, and his face
+towards the window where the keeper of the wine-shop stood looking at
+him, a white-haired man sat on a low bench, stooping forward and very
+busy, making shoes.
+
+
+
+
+VI. The Shoemaker
+
+
+“Good day!” said Monsieur Defarge, looking down at the white head that
+bent low over the shoemaking.
+
+It was raised for a moment, and a very faint voice responded to the
+salutation, as if it were at a distance:
+
+“Good day!”
+
+“You are still hard at work, I see?”
+
+After a long silence, the head was lifted for another moment, and the
+voice replied, “Yes--I am working.” This time, a pair of haggard eyes
+had looked at the questioner, before the face had dropped again.
+
+The faintness of the voice was pitiable and dreadful. It was not the
+faintness of physical weakness, though confinement and hard fare no
+doubt had their part in it. Its deplorable peculiarity was, that it was
+the faintness of solitude and disuse. It was like the last feeble echo
+of a sound made long and long ago. So entirely had it lost the life and
+resonance of the human voice, that it affected the senses like a once
+beautiful colour faded away into a poor weak stain. So sunken and
+suppressed it was, that it was like a voice underground. So expressive
+it was, of a hopeless and lost creature, that a famished traveller,
+wearied out by lonely wandering in a wilderness, would have remembered
+home and friends in such a tone before lying down to die.
+
+Some minutes of silent work had passed: and the haggard eyes had looked
+up again: not with any interest or curiosity, but with a dull mechanical
+perception, beforehand, that the spot where the only visitor they were
+aware of had stood, was not yet empty.
+
+“I want,” said Defarge, who had not removed his gaze from the shoemaker,
+“to let in a little more light here. You can bear a little more?”
+
+The shoemaker stopped his work; looked with a vacant air of listening,
+at the floor on one side of him; then similarly, at the floor on the
+other side of him; then, upward at the speaker.
+
+“What did you say?”
+
+“You can bear a little more light?”
+
+“I must bear it, if you let it in.” (Laying the palest shadow of a
+stress upon the second word.)
+
+The opened half-door was opened a little further, and secured at that
+angle for the time. A broad ray of light fell into the garret, and
+showed the workman with an unfinished shoe upon his lap, pausing in his
+labour. His few common tools and various scraps of leather were at his
+feet and on his bench. He had a white beard, raggedly cut, but not very
+long, a hollow face, and exceedingly bright eyes. The hollowness and
+thinness of his face would have caused them to look large, under his yet
+dark eyebrows and his confused white hair, though they had been really
+otherwise; but, they were naturally large, and looked unnaturally so.
+His yellow rags of shirt lay open at the throat, and showed his body
+to be withered and worn. He, and his old canvas frock, and his loose
+stockings, and all his poor tatters of clothes, had, in a long seclusion
+from direct light and air, faded down to such a dull uniformity of
+parchment-yellow, that it would have been hard to say which was which.
+
+He had put up a hand between his eyes and the light, and the very bones
+of it seemed transparent. So he sat, with a steadfastly vacant gaze,
+pausing in his work. He never looked at the figure before him, without
+first looking down on this side of himself, then on that, as if he had
+lost the habit of associating place with sound; he never spoke, without
+first wandering in this manner, and forgetting to speak.
+
+“Are you going to finish that pair of shoes to-day?” asked Defarge,
+motioning to Mr. Lorry to come forward.
+
+“What did you say?”
+
+“Do you mean to finish that pair of shoes to-day?”
+
+“I can’t say that I mean to. I suppose so. I don’t know.”
+
+But, the question reminded him of his work, and he bent over it again.
+
+Mr. Lorry came silently forward, leaving the daughter by the door. When
+he had stood, for a minute or two, by the side of Defarge, the shoemaker
+looked up. He showed no surprise at seeing another figure, but the
+unsteady fingers of one of his hands strayed to his lips as he looked at
+it (his lips and his nails were of the same pale lead-colour), and then
+the hand dropped to his work, and he once more bent over the shoe. The
+look and the action had occupied but an instant.
+
+“You have a visitor, you see,” said Monsieur Defarge.
+
+“What did you say?”
+
+“Here is a visitor.”
+
+The shoemaker looked up as before, but without removing a hand from his
+work.
+
+“Come!” said Defarge. “Here is monsieur, who knows a well-made shoe when
+he sees one. Show him that shoe you are working at. Take it, monsieur.”
+
+Mr. Lorry took it in his hand.
+
+“Tell monsieur what kind of shoe it is, and the maker’s name.”
+
+There was a longer pause than usual, before the shoemaker replied:
+
+“I forget what it was you asked me. What did you say?”
+
+“I said, couldn’t you describe the kind of shoe, for monsieur’s
+information?”
+
+“It is a lady’s shoe. It is a young lady’s walking-shoe. It is in the
+present mode. I never saw the mode. I have had a pattern in my hand.” He
+glanced at the shoe with some little passing touch of pride.
+
+“And the maker’s name?” said Defarge.
+
+Now that he had no work to hold, he laid the knuckles of the right hand
+in the hollow of the left, and then the knuckles of the left hand in the
+hollow of the right, and then passed a hand across his bearded chin, and
+so on in regular changes, without a moment’s intermission. The task of
+recalling him from the vagrancy into which he always sank when he
+had spoken, was like recalling some very weak person from a swoon, or
+endeavouring, in the hope of some disclosure, to stay the spirit of a
+fast-dying man.
+
+“Did you ask me for my name?”
+
+“Assuredly I did.”
+
+“One Hundred and Five, North Tower.”
+
+“Is that all?”
+
+“One Hundred and Five, North Tower.”
+
+With a weary sound that was not a sigh, nor a groan, he bent to work
+again, until the silence was again broken.
+
+“You are not a shoemaker by trade?” said Mr. Lorry, looking steadfastly
+at him.
+
+His haggard eyes turned to Defarge as if he would have transferred the
+question to him: but as no help came from that quarter, they turned back
+on the questioner when they had sought the ground.
+
+“I am not a shoemaker by trade? No, I was not a shoemaker by trade. I-I
+learnt it here. I taught myself. I asked leave to--”
+
+He lapsed away, even for minutes, ringing those measured changes on his
+hands the whole time. His eyes came slowly back, at last, to the face
+from which they had wandered; when they rested on it, he started, and
+resumed, in the manner of a sleeper that moment awake, reverting to a
+subject of last night.
+
+“I asked leave to teach myself, and I got it with much difficulty after
+a long while, and I have made shoes ever since.”
+
+As he held out his hand for the shoe that had been taken from him, Mr.
+Lorry said, still looking steadfastly in his face:
+
+“Monsieur Manette, do you remember nothing of me?”
+
+The shoe dropped to the ground, and he sat looking fixedly at the
+questioner.
+
+“Monsieur Manette”; Mr. Lorry laid his hand upon Defarge’s arm; “do you
+remember nothing of this man? Look at him. Look at me. Is there no old
+banker, no old business, no old servant, no old time, rising in your
+mind, Monsieur Manette?”
+
+As the captive of many years sat looking fixedly, by turns, at Mr.
+Lorry and at Defarge, some long obliterated marks of an actively intent
+intelligence in the middle of the forehead, gradually forced themselves
+through the black mist that had fallen on him. They were overclouded
+again, they were fainter, they were gone; but they had been there. And
+so exactly was the expression repeated on the fair young face of her who
+had crept along the wall to a point where she could see him, and where
+she now stood looking at him, with hands which at first had been only
+raised in frightened compassion, if not even to keep him off and
+shut out the sight of him, but which were now extending towards him,
+trembling with eagerness to lay the spectral face upon her warm young
+breast, and love it back to life and hope--so exactly was the expression
+repeated (though in stronger characters) on her fair young face, that it
+looked as though it had passed like a moving light, from him to her.
+
+Darkness had fallen on him in its place. He looked at the two, less and
+less attentively, and his eyes in gloomy abstraction sought the ground
+and looked about him in the old way. Finally, with a deep long sigh, he
+took the shoe up, and resumed his work.
+
+“Have you recognised him, monsieur?” asked Defarge in a whisper.
+
+“Yes; for a moment. At first I thought it quite hopeless, but I have
+unquestionably seen, for a single moment, the face that I once knew so
+well. Hush! Let us draw further back. Hush!”
+
+She had moved from the wall of the garret, very near to the bench on
+which he sat. There was something awful in his unconsciousness of the
+figure that could have put out its hand and touched him as he stooped
+over his labour.
+
+Not a word was spoken, not a sound was made. She stood, like a spirit,
+beside him, and he bent over his work.
+
+It happened, at length, that he had occasion to change the instrument
+in his hand, for his shoemaker’s knife. It lay on that side of him
+which was not the side on which she stood. He had taken it up, and was
+stooping to work again, when his eyes caught the skirt of her dress. He
+raised them, and saw her face. The two spectators started forward,
+but she stayed them with a motion of her hand. She had no fear of his
+striking at her with the knife, though they had.
+
+He stared at her with a fearful look, and after a while his lips began
+to form some words, though no sound proceeded from them. By degrees, in
+the pauses of his quick and laboured breathing, he was heard to say:
+
+“What is this?”
+
+With the tears streaming down her face, she put her two hands to her
+lips, and kissed them to him; then clasped them on her breast, as if she
+laid his ruined head there.
+
+“You are not the gaoler’s daughter?”
+
+She sighed “No.”
+
+“Who are you?”
+
+Not yet trusting the tones of her voice, she sat down on the bench
+beside him. He recoiled, but she laid her hand upon his arm. A strange
+thrill struck him when she did so, and visibly passed over his frame; he
+laid the knife down softly, as he sat staring at her.
+
+Her golden hair, which she wore in long curls, had been hurriedly pushed
+aside, and fell down over her neck. Advancing his hand by little and
+little, he took it up and looked at it. In the midst of the action
+he went astray, and, with another deep sigh, fell to work at his
+shoemaking.
+
+But not for long. Releasing his arm, she laid her hand upon his
+shoulder. After looking doubtfully at it, two or three times, as if to
+be sure that it was really there, he laid down his work, put his hand
+to his neck, and took off a blackened string with a scrap of folded rag
+attached to it. He opened this, carefully, on his knee, and it contained
+a very little quantity of hair: not more than one or two long golden
+hairs, which he had, in some old day, wound off upon his finger.
+
+He took her hair into his hand again, and looked closely at it. “It is
+the same. How can it be! When was it! How was it!”
+
+As the concentrated expression returned to his forehead, he seemed to
+become conscious that it was in hers too. He turned her full to the
+light, and looked at her.
+
+“She had laid her head upon my shoulder, that night when I was summoned
+out--she had a fear of my going, though I had none--and when I was
+brought to the North Tower they found these upon my sleeve. ‘You will
+leave me them? They can never help me to escape in the body, though they
+may in the spirit.’ Those were the words I said. I remember them very
+well.”
+
+He formed this speech with his lips many times before he could utter it.
+But when he did find spoken words for it, they came to him coherently,
+though slowly.
+
+“How was this?--_Was it you_?”
+
+Once more, the two spectators started, as he turned upon her with a
+frightful suddenness. But she sat perfectly still in his grasp, and only
+said, in a low voice, “I entreat you, good gentlemen, do not come near
+us, do not speak, do not move!”
+
+“Hark!” he exclaimed. “Whose voice was that?”
+
+His hands released her as he uttered this cry, and went up to his white
+hair, which they tore in a frenzy. It died out, as everything but his
+shoemaking did die out of him, and he refolded his little packet and
+tried to secure it in his breast; but he still looked at her, and
+gloomily shook his head.
+
+“No, no, no; you are too young, too blooming. It can’t be. See what the
+prisoner is. These are not the hands she knew, this is not the face
+she knew, this is not a voice she ever heard. No, no. She was--and He
+was--before the slow years of the North Tower--ages ago. What is your
+name, my gentle angel?”
+
+Hailing his softened tone and manner, his daughter fell upon her knees
+before him, with her appealing hands upon his breast.
+
+“O, sir, at another time you shall know my name, and who my mother was,
+and who my father, and how I never knew their hard, hard history. But I
+cannot tell you at this time, and I cannot tell you here. All that I may
+tell you, here and now, is, that I pray to you to touch me and to bless
+me. Kiss me, kiss me! O my dear, my dear!”
+
+His cold white head mingled with her radiant hair, which warmed and
+lighted it as though it were the light of Freedom shining on him.
+
+“If you hear in my voice--I don’t know that it is so, but I hope it
+is--if you hear in my voice any resemblance to a voice that once was
+sweet music in your ears, weep for it, weep for it! If you touch, in
+touching my hair, anything that recalls a beloved head that lay on your
+breast when you were young and free, weep for it, weep for it! If, when
+I hint to you of a Home that is before us, where I will be true to you
+with all my duty and with all my faithful service, I bring back the
+remembrance of a Home long desolate, while your poor heart pined away,
+weep for it, weep for it!”
+
+She held him closer round the neck, and rocked him on her breast like a
+child.
+
+“If, when I tell you, dearest dear, that your agony is over, and that I
+have come here to take you from it, and that we go to England to be at
+peace and at rest, I cause you to think of your useful life laid waste,
+and of our native France so wicked to you, weep for it, weep for it! And
+if, when I shall tell you of my name, and of my father who is living,
+and of my mother who is dead, you learn that I have to kneel to my
+honoured father, and implore his pardon for having never for his sake
+striven all day and lain awake and wept all night, because the love of
+my poor mother hid his torture from me, weep for it, weep for it! Weep
+for her, then, and for me! Good gentlemen, thank God! I feel his sacred
+tears upon my face, and his sobs strike against my heart. O, see! Thank
+God for us, thank God!”
+
+He had sunk in her arms, and his face dropped on her breast: a sight so
+touching, yet so terrible in the tremendous wrong and suffering which
+had gone before it, that the two beholders covered their faces.
+
+When the quiet of the garret had been long undisturbed, and his heaving
+breast and shaken form had long yielded to the calm that must follow all
+storms--emblem to humanity, of the rest and silence into which the storm
+called Life must hush at last--they came forward to raise the father and
+daughter from the ground. He had gradually dropped to the floor, and lay
+there in a lethargy, worn out. She had nestled down with him, that his
+head might lie upon her arm; and her hair drooping over him curtained
+him from the light.
+
+“If, without disturbing him,” she said, raising her hand to Mr. Lorry as
+he stooped over them, after repeated blowings of his nose, “all could be
+arranged for our leaving Paris at once, so that, from the very door, he
+could be taken away--”
+
+“But, consider. Is he fit for the journey?” asked Mr. Lorry.
+
+“More fit for that, I think, than to remain in this city, so dreadful to
+him.”
+
+“It is true,” said Defarge, who was kneeling to look on and hear. “More
+than that; Monsieur Manette is, for all reasons, best out of France.
+Say, shall I hire a carriage and post-horses?”
+
+“That’s business,” said Mr. Lorry, resuming on the shortest notice his
+methodical manners; “and if business is to be done, I had better do it.”
+
+“Then be so kind,” urged Miss Manette, “as to leave us here. You see how
+composed he has become, and you cannot be afraid to leave him with me
+now. Why should you be? If you will lock the door to secure us from
+interruption, I do not doubt that you will find him, when you come back,
+as quiet as you leave him. In any case, I will take care of him until
+you return, and then we will remove him straight.”
+
+Both Mr. Lorry and Defarge were rather disinclined to this course, and
+in favour of one of them remaining. But, as there were not only carriage
+and horses to be seen to, but travelling papers; and as time pressed,
+for the day was drawing to an end, it came at last to their hastily
+dividing the business that was necessary to be done, and hurrying away
+to do it.
+
+Then, as the darkness closed in, the daughter laid her head down on the
+hard ground close at the father’s side, and watched him. The darkness
+deepened and deepened, and they both lay quiet, until a light gleamed
+through the chinks in the wall.
+
+Mr. Lorry and Monsieur Defarge had made all ready for the journey, and
+had brought with them, besides travelling cloaks and wrappers, bread and
+meat, wine, and hot coffee. Monsieur Defarge put this provender, and the
+lamp he carried, on the shoemaker’s bench (there was nothing else in the
+garret but a pallet bed), and he and Mr. Lorry roused the captive, and
+assisted him to his feet.
+
+No human intelligence could have read the mysteries of his mind, in
+the scared blank wonder of his face. Whether he knew what had happened,
+whether he recollected what they had said to him, whether he knew that
+he was free, were questions which no sagacity could have solved. They
+tried speaking to him; but, he was so confused, and so very slow to
+answer, that they took fright at his bewilderment, and agreed for
+the time to tamper with him no more. He had a wild, lost manner of
+occasionally clasping his head in his hands, that had not been seen
+in him before; yet, he had some pleasure in the mere sound of his
+daughter’s voice, and invariably turned to it when she spoke.
+
+In the submissive way of one long accustomed to obey under coercion, he
+ate and drank what they gave him to eat and drink, and put on the cloak
+and other wrappings, that they gave him to wear. He readily responded to
+his daughter’s drawing her arm through his, and took--and kept--her hand
+in both his own.
+
+They began to descend; Monsieur Defarge going first with the lamp, Mr.
+Lorry closing the little procession. They had not traversed many steps
+of the long main staircase when he stopped, and stared at the roof and
+round at the walls.
+
+“You remember the place, my father? You remember coming up here?”
+
+“What did you say?”
+
+But, before she could repeat the question, he murmured an answer as if
+she had repeated it.
+
+“Remember? No, I don’t remember. It was so very long ago.”
+
+That he had no recollection whatever of his having been brought from his
+prison to that house, was apparent to them. They heard him mutter,
+“One Hundred and Five, North Tower;” and when he looked about him, it
+evidently was for the strong fortress-walls which had long encompassed
+him. On their reaching the courtyard he instinctively altered his
+tread, as being in expectation of a drawbridge; and when there was
+no drawbridge, and he saw the carriage waiting in the open street, he
+dropped his daughter’s hand and clasped his head again.
+
+No crowd was about the door; no people were discernible at any of the
+many windows; not even a chance passerby was in the street. An unnatural
+silence and desertion reigned there. Only one soul was to be seen, and
+that was Madame Defarge--who leaned against the door-post, knitting, and
+saw nothing.
+
+The prisoner had got into a coach, and his daughter had followed
+him, when Mr. Lorry’s feet were arrested on the step by his asking,
+miserably, for his shoemaking tools and the unfinished shoes. Madame
+Defarge immediately called to her husband that she would get them, and
+went, knitting, out of the lamplight, through the courtyard. She quickly
+brought them down and handed them in;--and immediately afterwards leaned
+against the door-post, knitting, and saw nothing.
+
+Defarge got upon the box, and gave the word “To the Barrier!” The
+postilion cracked his whip, and they clattered away under the feeble
+over-swinging lamps.
+
+Under the over-swinging lamps--swinging ever brighter in the better
+streets, and ever dimmer in the worse--and by lighted shops, gay crowds,
+illuminated coffee-houses, and theatre-doors, to one of the city
+gates. Soldiers with lanterns, at the guard-house there. “Your papers,
+travellers!” “See here then, Monsieur the Officer,” said Defarge,
+getting down, and taking him gravely apart, “these are the papers of
+monsieur inside, with the white head. They were consigned to me, with
+him, at the--” He dropped his voice, there was a flutter among the
+military lanterns, and one of them being handed into the coach by an arm
+in uniform, the eyes connected with the arm looked, not an every day
+or an every night look, at monsieur with the white head. “It is well.
+Forward!” from the uniform. “Adieu!” from Defarge. And so, under a short
+grove of feebler and feebler over-swinging lamps, out under the great
+grove of stars.
+
+Beneath that arch of unmoved and eternal lights; some, so remote from
+this little earth that the learned tell us it is doubtful whether their
+rays have even yet discovered it, as a point in space where anything
+is suffered or done: the shadows of the night were broad and black.
+All through the cold and restless interval, until dawn, they once more
+whispered in the ears of Mr. Jarvis Lorry--sitting opposite the buried
+man who had been dug out, and wondering what subtle powers were for ever
+lost to him, and what were capable of restoration--the old inquiry:
+
+“I hope you care to be recalled to life?”
+
+And the old answer:
+
+“I can’t say.”
+
+
+The end of the first book.
+
+
+
+
+
+Book the Second--the Golden Thread
+
+
+
+
+I. Five Years Later
+
+
+Tellson’s Bank by Temple Bar was an old-fashioned place, even in the
+year one thousand seven hundred and eighty. It was very small, very
+dark, very ugly, very incommodious. It was an old-fashioned place,
+moreover, in the moral attribute that the partners in the House were
+proud of its smallness, proud of its darkness, proud of its ugliness,
+proud of its incommodiousness. They were even boastful of its eminence
+in those particulars, and were fired by an express conviction that, if
+it were less objectionable, it would be less respectable. This was
+no passive belief, but an active weapon which they flashed at more
+convenient places of business. Tellson’s (they said) wanted
+no elbow-room, Tellson’s wanted no light, Tellson’s wanted no
+embellishment. Noakes and Co.’s might, or Snooks Brothers’ might; but
+Tellson’s, thank Heaven--!
+
+Any one of these partners would have disinherited his son on the
+question of rebuilding Tellson’s. In this respect the House was much
+on a par with the Country; which did very often disinherit its sons for
+suggesting improvements in laws and customs that had long been highly
+objectionable, but were only the more respectable.
+
+Thus it had come to pass, that Tellson’s was the triumphant perfection
+of inconvenience. After bursting open a door of idiotic obstinacy with
+a weak rattle in its throat, you fell into Tellson’s down two steps,
+and came to your senses in a miserable little shop, with two little
+counters, where the oldest of men made your cheque shake as if the
+wind rustled it, while they examined the signature by the dingiest of
+windows, which were always under a shower-bath of mud from Fleet-street,
+and which were made the dingier by their own iron bars proper, and the
+heavy shadow of Temple Bar. If your business necessitated your seeing
+“the House,” you were put into a species of Condemned Hold at the back,
+where you meditated on a misspent life, until the House came with its
+hands in its pockets, and you could hardly blink at it in the dismal
+twilight. Your money came out of, or went into, wormy old wooden
+drawers, particles of which flew up your nose and down your throat when
+they were opened and shut. Your bank-notes had a musty odour, as if they
+were fast decomposing into rags again. Your plate was stowed away among
+the neighbouring cesspools, and evil communications corrupted its good
+polish in a day or two. Your deeds got into extemporised strong-rooms
+made of kitchens and sculleries, and fretted all the fat out of their
+parchments into the banking-house air. Your lighter boxes of family
+papers went up-stairs into a Barmecide room, that always had a great
+dining-table in it and never had a dinner, and where, even in the year
+one thousand seven hundred and eighty, the first letters written to you
+by your old love, or by your little children, were but newly released
+from the horror of being ogled through the windows, by the heads
+exposed on Temple Bar with an insensate brutality and ferocity worthy of
+Abyssinia or Ashantee.
+
+But indeed, at that time, putting to death was a recipe much in vogue
+with all trades and professions, and not least of all with Tellson’s.
+Death is Nature’s remedy for all things, and why not Legislation’s?
+Accordingly, the forger was put to Death; the utterer of a bad note
+was put to Death; the unlawful opener of a letter was put to Death; the
+purloiner of forty shillings and sixpence was put to Death; the holder
+of a horse at Tellson’s door, who made off with it, was put to
+Death; the coiner of a bad shilling was put to Death; the sounders of
+three-fourths of the notes in the whole gamut of Crime, were put to
+Death. Not that it did the least good in the way of prevention--it
+might almost have been worth remarking that the fact was exactly the
+reverse--but, it cleared off (as to this world) the trouble of each
+particular case, and left nothing else connected with it to be looked
+after. Thus, Tellson’s, in its day, like greater places of business,
+its contemporaries, had taken so many lives, that, if the heads laid
+low before it had been ranged on Temple Bar instead of being privately
+disposed of, they would probably have excluded what little light the
+ground floor had, in a rather significant manner.
+
+Cramped in all kinds of dim cupboards and hutches at Tellson’s, the
+oldest of men carried on the business gravely. When they took a young
+man into Tellson’s London house, they hid him somewhere till he was
+old. They kept him in a dark place, like a cheese, until he had the full
+Tellson flavour and blue-mould upon him. Then only was he permitted to
+be seen, spectacularly poring over large books, and casting his breeches
+and gaiters into the general weight of the establishment.
+
+Outside Tellson’s--never by any means in it, unless called in--was an
+odd-job-man, an occasional porter and messenger, who served as the live
+sign of the house. He was never absent during business hours, unless
+upon an errand, and then he was represented by his son: a grisly urchin
+of twelve, who was his express image. People understood that Tellson’s,
+in a stately way, tolerated the odd-job-man. The house had always
+tolerated some person in that capacity, and time and tide had drifted
+this person to the post. His surname was Cruncher, and on the youthful
+occasion of his renouncing by proxy the works of darkness, in the
+easterly parish church of Hounsditch, he had received the added
+appellation of Jerry.
+
+The scene was Mr. Cruncher’s private lodging in Hanging-sword-alley,
+Whitefriars: the time, half-past seven of the clock on a windy March
+morning, Anno Domini seventeen hundred and eighty. (Mr. Cruncher himself
+always spoke of the year of our Lord as Anna Dominoes: apparently under
+the impression that the Christian era dated from the invention of a
+popular game, by a lady who had bestowed her name upon it.)
+
+Mr. Cruncher’s apartments were not in a savoury neighbourhood, and were
+but two in number, even if a closet with a single pane of glass in it
+might be counted as one. But they were very decently kept. Early as
+it was, on the windy March morning, the room in which he lay abed was
+already scrubbed throughout; and between the cups and saucers arranged
+for breakfast, and the lumbering deal table, a very clean white cloth
+was spread.
+
+Mr. Cruncher reposed under a patchwork counterpane, like a Harlequin
+at home. At first, he slept heavily, but, by degrees, began to roll
+and surge in bed, until he rose above the surface, with his spiky hair
+looking as if it must tear the sheets to ribbons. At which juncture, he
+exclaimed, in a voice of dire exasperation:
+
+“Bust me, if she ain’t at it agin!”
+
+A woman of orderly and industrious appearance rose from her knees in a
+corner, with sufficient haste and trepidation to show that she was the
+person referred to.
+
+“What!” said Mr. Cruncher, looking out of bed for a boot. “You’re at it
+agin, are you?”
+
+After hailing the morn with this second salutation, he threw a boot at
+the woman as a third. It was a very muddy boot, and may introduce the
+odd circumstance connected with Mr. Cruncher’s domestic economy, that,
+whereas he often came home after banking hours with clean boots, he
+often got up next morning to find the same boots covered with clay.
+
+“What,” said Mr. Cruncher, varying his apostrophe after missing his
+mark--“what are you up to, Aggerawayter?”
+
+“I was only saying my prayers.”
+
+“Saying your prayers! You’re a nice woman! What do you mean by flopping
+yourself down and praying agin me?”
+
+“I was not praying against you; I was praying for you.”
+
+“You weren’t. And if you were, I won’t be took the liberty with. Here!
+your mother’s a nice woman, young Jerry, going a praying agin your
+father’s prosperity. You’ve got a dutiful mother, you have, my son.
+You’ve got a religious mother, you have, my boy: going and flopping
+herself down, and praying that the bread-and-butter may be snatched out
+of the mouth of her only child.”
+
+Master Cruncher (who was in his shirt) took this very ill, and, turning
+to his mother, strongly deprecated any praying away of his personal
+board.
+
+“And what do you suppose, you conceited female,” said Mr. Cruncher, with
+unconscious inconsistency, “that the worth of _your_ prayers may be?
+Name the price that you put _your_ prayers at!”
+
+“They only come from the heart, Jerry. They are worth no more than
+that.”
+
+“Worth no more than that,” repeated Mr. Cruncher. “They ain’t worth
+much, then. Whether or no, I won’t be prayed agin, I tell you. I can’t
+afford it. I’m not a going to be made unlucky by _your_ sneaking. If
+you must go flopping yourself down, flop in favour of your husband and
+child, and not in opposition to ‘em. If I had had any but a unnat’ral
+wife, and this poor boy had had any but a unnat’ral mother, I might
+have made some money last week instead of being counter-prayed and
+countermined and religiously circumwented into the worst of luck.
+B-u-u-ust me!” said Mr. Cruncher, who all this time had been putting
+on his clothes, “if I ain’t, what with piety and one blowed thing and
+another, been choused this last week into as bad luck as ever a poor
+devil of a honest tradesman met with! Young Jerry, dress yourself, my
+boy, and while I clean my boots keep a eye upon your mother now and
+then, and if you see any signs of more flopping, give me a call. For, I
+tell you,” here he addressed his wife once more, “I won’t be gone agin,
+in this manner. I am as rickety as a hackney-coach, I’m as sleepy as
+laudanum, my lines is strained to that degree that I shouldn’t know, if
+it wasn’t for the pain in ‘em, which was me and which somebody else, yet
+I’m none the better for it in pocket; and it’s my suspicion that you’ve
+been at it from morning to night to prevent me from being the better for
+it in pocket, and I won’t put up with it, Aggerawayter, and what do you
+say now!”
+
+Growling, in addition, such phrases as “Ah! yes! You’re religious, too.
+You wouldn’t put yourself in opposition to the interests of your husband
+and child, would you? Not you!” and throwing off other sarcastic sparks
+from the whirling grindstone of his indignation, Mr. Cruncher betook
+himself to his boot-cleaning and his general preparation for business.
+In the meantime, his son, whose head was garnished with tenderer spikes,
+and whose young eyes stood close by one another, as his father’s did,
+kept the required watch upon his mother. He greatly disturbed that poor
+woman at intervals, by darting out of his sleeping closet, where he made
+his toilet, with a suppressed cry of “You are going to flop, mother.
+--Halloa, father!” and, after raising this fictitious alarm, darting in
+again with an undutiful grin.
+
+Mr. Cruncher’s temper was not at all improved when he came to his
+breakfast. He resented Mrs. Cruncher’s saying grace with particular
+animosity.
+
+“Now, Aggerawayter! What are you up to? At it again?”
+
+His wife explained that she had merely “asked a blessing.”
+
+“Don’t do it!” said Mr. Crunches looking about, as if he rather expected
+to see the loaf disappear under the efficacy of his wife’s petitions. “I
+ain’t a going to be blest out of house and home. I won’t have my wittles
+blest off my table. Keep still!”
+
+Exceedingly red-eyed and grim, as if he had been up all night at a party
+which had taken anything but a convivial turn, Jerry Cruncher worried
+his breakfast rather than ate it, growling over it like any four-footed
+inmate of a menagerie. Towards nine o’clock he smoothed his ruffled
+aspect, and, presenting as respectable and business-like an exterior as
+he could overlay his natural self with, issued forth to the occupation
+of the day.
+
+It could scarcely be called a trade, in spite of his favourite
+description of himself as “a honest tradesman.” His stock consisted of
+a wooden stool, made out of a broken-backed chair cut down, which stool,
+young Jerry, walking at his father’s side, carried every morning to
+beneath the banking-house window that was nearest Temple Bar: where,
+with the addition of the first handful of straw that could be gleaned
+from any passing vehicle to keep the cold and wet from the odd-job-man’s
+feet, it formed the encampment for the day. On this post of his, Mr.
+Cruncher was as well known to Fleet-street and the Temple, as the Bar
+itself,--and was almost as in-looking.
+
+Encamped at a quarter before nine, in good time to touch his
+three-cornered hat to the oldest of men as they passed in to Tellson’s,
+Jerry took up his station on this windy March morning, with young Jerry
+standing by him, when not engaged in making forays through the Bar, to
+inflict bodily and mental injuries of an acute description on passing
+boys who were small enough for his amiable purpose. Father and son,
+extremely like each other, looking silently on at the morning traffic
+in Fleet-street, with their two heads as near to one another as the two
+eyes of each were, bore a considerable resemblance to a pair of monkeys.
+The resemblance was not lessened by the accidental circumstance, that
+the mature Jerry bit and spat out straw, while the twinkling eyes of the
+youthful Jerry were as restlessly watchful of him as of everything else
+in Fleet-street.
+
+The head of one of the regular indoor messengers attached to Tellson’s
+establishment was put through the door, and the word was given:
+
+“Porter wanted!”
+
+“Hooray, father! Here’s an early job to begin with!”
+
+Having thus given his parent God speed, young Jerry seated himself on
+the stool, entered on his reversionary interest in the straw his father
+had been chewing, and cogitated.
+
+“Al-ways rusty! His fingers is al-ways rusty!” muttered young Jerry.
+“Where does my father get all that iron rust from? He don’t get no iron
+rust here!”
+
+
+
+
+II. A Sight
+
+
+“You know the Old Bailey well, no doubt?” said one of the oldest of
+clerks to Jerry the messenger.
+
+“Ye-es, sir,” returned Jerry, in something of a dogged manner. “I _do_
+know the Bailey.”
+
+“Just so. And you know Mr. Lorry.”
+
+“I know Mr. Lorry, sir, much better than I know the Bailey. Much
+better,” said Jerry, not unlike a reluctant witness at the establishment
+in question, “than I, as a honest tradesman, wish to know the Bailey.”
+
+“Very well. Find the door where the witnesses go in, and show the
+door-keeper this note for Mr. Lorry. He will then let you in.”
+
+“Into the court, sir?”
+
+“Into the court.”
+
+Mr. Cruncher’s eyes seemed to get a little closer to one another, and to
+interchange the inquiry, “What do you think of this?”
+
+“Am I to wait in the court, sir?” he asked, as the result of that
+conference.
+
+“I am going to tell you. The door-keeper will pass the note to Mr.
+Lorry, and do you make any gesture that will attract Mr. Lorry’s
+attention, and show him where you stand. Then what you have to do, is,
+to remain there until he wants you.”
+
+“Is that all, sir?”
+
+“That’s all. He wishes to have a messenger at hand. This is to tell him
+you are there.”
+
+As the ancient clerk deliberately folded and superscribed the note,
+Mr. Cruncher, after surveying him in silence until he came to the
+blotting-paper stage, remarked:
+
+“I suppose they’ll be trying Forgeries this morning?”
+
+“Treason!”
+
+“That’s quartering,” said Jerry. “Barbarous!”
+
+“It is the law,” remarked the ancient clerk, turning his surprised
+spectacles upon him. “It is the law.”
+
+“It’s hard in the law to spile a man, I think. It’s hard enough to kill
+him, but it’s wery hard to spile him, sir.”
+
+“Not at all,” retained the ancient clerk. “Speak well of the law. Take
+care of your chest and voice, my good friend, and leave the law to take
+care of itself. I give you that advice.”
+
+“It’s the damp, sir, what settles on my chest and voice,” said Jerry. “I
+leave you to judge what a damp way of earning a living mine is.”
+
+“Well, well,” said the old clerk; “we all have our various ways of
+gaining a livelihood. Some of us have damp ways, and some of us have dry
+ways. Here is the letter. Go along.”
+
+Jerry took the letter, and, remarking to himself with less internal
+deference than he made an outward show of, “You are a lean old one,
+too,” made his bow, informed his son, in passing, of his destination,
+and went his way.
+
+They hanged at Tyburn, in those days, so the street outside Newgate had
+not obtained one infamous notoriety that has since attached to it.
+But, the gaol was a vile place, in which most kinds of debauchery and
+villainy were practised, and where dire diseases were bred, that came
+into court with the prisoners, and sometimes rushed straight from the
+dock at my Lord Chief Justice himself, and pulled him off the bench. It
+had more than once happened, that the Judge in the black cap pronounced
+his own doom as certainly as the prisoner’s, and even died before him.
+For the rest, the Old Bailey was famous as a kind of deadly inn-yard,
+from which pale travellers set out continually, in carts and coaches, on
+a violent passage into the other world: traversing some two miles and a
+half of public street and road, and shaming few good citizens, if any.
+So powerful is use, and so desirable to be good use in the beginning. It
+was famous, too, for the pillory, a wise old institution, that inflicted
+a punishment of which no one could foresee the extent; also, for
+the whipping-post, another dear old institution, very humanising and
+softening to behold in action; also, for extensive transactions in
+blood-money, another fragment of ancestral wisdom, systematically
+leading to the most frightful mercenary crimes that could be committed
+under Heaven. Altogether, the Old Bailey, at that date, was a choice
+illustration of the precept, that “Whatever is is right;” an aphorism
+that would be as final as it is lazy, did it not include the troublesome
+consequence, that nothing that ever was, was wrong.
+
+Making his way through the tainted crowd, dispersed up and down this
+hideous scene of action, with the skill of a man accustomed to make his
+way quietly, the messenger found out the door he sought, and handed in
+his letter through a trap in it. For, people then paid to see the play
+at the Old Bailey, just as they paid to see the play in Bedlam--only the
+former entertainment was much the dearer. Therefore, all the Old Bailey
+doors were well guarded--except, indeed, the social doors by which the
+criminals got there, and those were always left wide open.
+
+After some delay and demur, the door grudgingly turned on its hinges a
+very little way, and allowed Mr. Jerry Cruncher to squeeze himself into
+court.
+
+“What’s on?” he asked, in a whisper, of the man he found himself next
+to.
+
+“Nothing yet.”
+
+“What’s coming on?”
+
+“The Treason case.”
+
+“The quartering one, eh?”
+
+“Ah!” returned the man, with a relish; “he’ll be drawn on a hurdle to
+be half hanged, and then he’ll be taken down and sliced before his own
+face, and then his inside will be taken out and burnt while he looks on,
+and then his head will be chopped off, and he’ll be cut into quarters.
+That’s the sentence.”
+
+“If he’s found Guilty, you mean to say?” Jerry added, by way of proviso.
+
+“Oh! they’ll find him guilty,” said the other. “Don’t you be afraid of
+that.”
+
+Mr. Cruncher’s attention was here diverted to the door-keeper, whom he
+saw making his way to Mr. Lorry, with the note in his hand. Mr. Lorry
+sat at a table, among the gentlemen in wigs: not far from a wigged
+gentleman, the prisoner’s counsel, who had a great bundle of papers
+before him: and nearly opposite another wigged gentleman with his hands
+in his pockets, whose whole attention, when Mr. Cruncher looked at him
+then or afterwards, seemed to be concentrated on the ceiling of the
+court. After some gruff coughing and rubbing of his chin and signing
+with his hand, Jerry attracted the notice of Mr. Lorry, who had stood up
+to look for him, and who quietly nodded and sat down again.
+
+“What’s _he_ got to do with the case?” asked the man he had spoken with.
+
+“Blest if I know,” said Jerry.
+
+“What have _you_ got to do with it, then, if a person may inquire?”
+
+“Blest if I know that either,” said Jerry.
+
+The entrance of the Judge, and a consequent great stir and settling
+down in the court, stopped the dialogue. Presently, the dock became the
+central point of interest. Two gaolers, who had been standing there,
+went out, and the prisoner was brought in, and put to the bar.
+
+Everybody present, except the one wigged gentleman who looked at the
+ceiling, stared at him. All the human breath in the place, rolled
+at him, like a sea, or a wind, or a fire. Eager faces strained round
+pillars and corners, to get a sight of him; spectators in back rows
+stood up, not to miss a hair of him; people on the floor of the court,
+laid their hands on the shoulders of the people before them, to help
+themselves, at anybody’s cost, to a view of him--stood a-tiptoe, got
+upon ledges, stood upon next to nothing, to see every inch of him.
+Conspicuous among these latter, like an animated bit of the spiked wall
+of Newgate, Jerry stood: aiming at the prisoner the beery breath of a
+whet he had taken as he came along, and discharging it to mingle with
+the waves of other beer, and gin, and tea, and coffee, and what not,
+that flowed at him, and already broke upon the great windows behind him
+in an impure mist and rain.
+
+The object of all this staring and blaring, was a young man of about
+five-and-twenty, well-grown and well-looking, with a sunburnt cheek and
+a dark eye. His condition was that of a young gentleman. He was plainly
+dressed in black, or very dark grey, and his hair, which was long and
+dark, was gathered in a ribbon at the back of his neck; more to be out
+of his way than for ornament. As an emotion of the mind will express
+itself through any covering of the body, so the paleness which his
+situation engendered came through the brown upon his cheek, showing the
+soul to be stronger than the sun. He was otherwise quite self-possessed,
+bowed to the Judge, and stood quiet.
+
+The sort of interest with which this man was stared and breathed at,
+was not a sort that elevated humanity. Had he stood in peril of a less
+horrible sentence--had there been a chance of any one of its savage
+details being spared--by just so much would he have lost in his
+fascination. The form that was to be doomed to be so shamefully mangled,
+was the sight; the immortal creature that was to be so butchered
+and torn asunder, yielded the sensation. Whatever gloss the various
+spectators put upon the interest, according to their several arts and
+powers of self-deceit, the interest was, at the root of it, Ogreish.
+
+Silence in the court! Charles Darnay had yesterday pleaded Not Guilty to
+an indictment denouncing him (with infinite jingle and jangle) for that
+he was a false traitor to our serene, illustrious, excellent, and so
+forth, prince, our Lord the King, by reason of his having, on divers
+occasions, and by divers means and ways, assisted Lewis, the French
+King, in his wars against our said serene, illustrious, excellent, and
+so forth; that was to say, by coming and going, between the dominions of
+our said serene, illustrious, excellent, and so forth, and those of the
+said French Lewis, and wickedly, falsely, traitorously, and otherwise
+evil-adverbiously, revealing to the said French Lewis what forces our
+said serene, illustrious, excellent, and so forth, had in preparation
+to send to Canada and North America. This much, Jerry, with his head
+becoming more and more spiky as the law terms bristled it, made out with
+huge satisfaction, and so arrived circuitously at the understanding that
+the aforesaid, and over and over again aforesaid, Charles Darnay, stood
+there before him upon his trial; that the jury were swearing in; and
+that Mr. Attorney-General was making ready to speak.
+
+The accused, who was (and who knew he was) being mentally hanged,
+beheaded, and quartered, by everybody there, neither flinched from
+the situation, nor assumed any theatrical air in it. He was quiet and
+attentive; watched the opening proceedings with a grave interest;
+and stood with his hands resting on the slab of wood before him, so
+composedly, that they had not displaced a leaf of the herbs with which
+it was strewn. The court was all bestrewn with herbs and sprinkled with
+vinegar, as a precaution against gaol air and gaol fever.
+
+Over the prisoner’s head there was a mirror, to throw the light down
+upon him. Crowds of the wicked and the wretched had been reflected in
+it, and had passed from its surface and this earth’s together. Haunted
+in a most ghastly manner that abominable place would have been, if the
+glass could ever have rendered back its reflections, as the ocean is one
+day to give up its dead. Some passing thought of the infamy and disgrace
+for which it had been reserved, may have struck the prisoner’s mind. Be
+that as it may, a change in his position making him conscious of a bar
+of light across his face, he looked up; and when he saw the glass his
+face flushed, and his right hand pushed the herbs away.
+
+It happened, that the action turned his face to that side of the court
+which was on his left. About on a level with his eyes, there sat,
+in that corner of the Judge’s bench, two persons upon whom his look
+immediately rested; so immediately, and so much to the changing of his
+aspect, that all the eyes that were turned upon him, turned to them.
+
+The spectators saw in the two figures, a young lady of little more than
+twenty, and a gentleman who was evidently her father; a man of a very
+remarkable appearance in respect of the absolute whiteness of his hair,
+and a certain indescribable intensity of face: not of an active kind,
+but pondering and self-communing. When this expression was upon him, he
+looked as if he were old; but when it was stirred and broken up--as
+it was now, in a moment, on his speaking to his daughter--he became a
+handsome man, not past the prime of life.
+
+His daughter had one of her hands drawn through his arm, as she sat by
+him, and the other pressed upon it. She had drawn close to him, in her
+dread of the scene, and in her pity for the prisoner. Her forehead had
+been strikingly expressive of an engrossing terror and compassion
+that saw nothing but the peril of the accused. This had been so very
+noticeable, so very powerfully and naturally shown, that starers who
+had had no pity for him were touched by her; and the whisper went about,
+“Who are they?”
+
+Jerry, the messenger, who had made his own observations, in his own
+manner, and who had been sucking the rust off his fingers in his
+absorption, stretched his neck to hear who they were. The crowd about
+him had pressed and passed the inquiry on to the nearest attendant, and
+from him it had been more slowly pressed and passed back; at last it got
+to Jerry:
+
+“Witnesses.”
+
+“For which side?”
+
+“Against.”
+
+“Against what side?”
+
+“The prisoner’s.”
+
+The Judge, whose eyes had gone in the general direction, recalled them,
+leaned back in his seat, and looked steadily at the man whose life was
+in his hand, as Mr. Attorney-General rose to spin the rope, grind the
+axe, and hammer the nails into the scaffold.
+
+
+
+
+III. A Disappointment
+
+
+Mr. Attorney-General had to inform the jury, that the prisoner before
+them, though young in years, was old in the treasonable practices which
+claimed the forfeit of his life. That this correspondence with the
+public enemy was not a correspondence of to-day, or of yesterday, or
+even of last year, or of the year before. That, it was certain the
+prisoner had, for longer than that, been in the habit of passing and
+repassing between France and England, on secret business of which
+he could give no honest account. That, if it were in the nature of
+traitorous ways to thrive (which happily it never was), the real
+wickedness and guilt of his business might have remained undiscovered.
+That Providence, however, had put it into the heart of a person who
+was beyond fear and beyond reproach, to ferret out the nature of the
+prisoner’s schemes, and, struck with horror, to disclose them to his
+Majesty’s Chief Secretary of State and most honourable Privy Council.
+That, this patriot would be produced before them. That, his position and
+attitude were, on the whole, sublime. That, he had been the prisoner’s
+friend, but, at once in an auspicious and an evil hour detecting his
+infamy, had resolved to immolate the traitor he could no longer cherish
+in his bosom, on the sacred altar of his country. That, if statues
+were decreed in Britain, as in ancient Greece and Rome, to public
+benefactors, this shining citizen would assuredly have had one. That, as
+they were not so decreed, he probably would not have one. That, Virtue,
+as had been observed by the poets (in many passages which he well
+knew the jury would have, word for word, at the tips of their tongues;
+whereat the jury’s countenances displayed a guilty consciousness that
+they knew nothing about the passages), was in a manner contagious; more
+especially the bright virtue known as patriotism, or love of country.
+That, the lofty example of this immaculate and unimpeachable witness
+for the Crown, to refer to whom however unworthily was an honour, had
+communicated itself to the prisoner’s servant, and had engendered in him
+a holy determination to examine his master’s table-drawers and pockets,
+and secrete his papers. That, he (Mr. Attorney-General) was prepared to
+hear some disparagement attempted of this admirable servant; but that,
+in a general way, he preferred him to his (Mr. Attorney-General’s)
+brothers and sisters, and honoured him more than his (Mr.
+Attorney-General’s) father and mother. That, he called with confidence
+on the jury to come and do likewise. That, the evidence of these two
+witnesses, coupled with the documents of their discovering that would be
+produced, would show the prisoner to have been furnished with lists of
+his Majesty’s forces, and of their disposition and preparation, both by
+sea and land, and would leave no doubt that he had habitually conveyed
+such information to a hostile power. That, these lists could not be
+proved to be in the prisoner’s handwriting; but that it was all the
+same; that, indeed, it was rather the better for the prosecution, as
+showing the prisoner to be artful in his precautions. That, the proof
+would go back five years, and would show the prisoner already engaged
+in these pernicious missions, within a few weeks before the date of the
+very first action fought between the British troops and the Americans.
+That, for these reasons, the jury, being a loyal jury (as he knew they
+were), and being a responsible jury (as _they_ knew they were), must
+positively find the prisoner Guilty, and make an end of him, whether
+they liked it or not. That, they never could lay their heads upon their
+pillows; that, they never could tolerate the idea of their wives laying
+their heads upon their pillows; that, they never could endure the notion
+of their children laying their heads upon their pillows; in short, that
+there never more could be, for them or theirs, any laying of heads upon
+pillows at all, unless the prisoner’s head was taken off. That head
+Mr. Attorney-General concluded by demanding of them, in the name of
+everything he could think of with a round turn in it, and on the faith
+of his solemn asseveration that he already considered the prisoner as
+good as dead and gone.
+
+When the Attorney-General ceased, a buzz arose in the court as if
+a cloud of great blue-flies were swarming about the prisoner, in
+anticipation of what he was soon to become. When toned down again, the
+unimpeachable patriot appeared in the witness-box.
+
+Mr. Solicitor-General then, following his leader’s lead, examined the
+patriot: John Barsad, gentleman, by name. The story of his pure soul was
+exactly what Mr. Attorney-General had described it to be--perhaps, if
+it had a fault, a little too exactly. Having released his noble bosom
+of its burden, he would have modestly withdrawn himself, but that the
+wigged gentleman with the papers before him, sitting not far from Mr.
+Lorry, begged to ask him a few questions. The wigged gentleman sitting
+opposite, still looking at the ceiling of the court.
+
+Had he ever been a spy himself? No, he scorned the base insinuation.
+What did he live upon? His property. Where was his property? He didn’t
+precisely remember where it was. What was it? No business of anybody’s.
+Had he inherited it? Yes, he had. From whom? Distant relation. Very
+distant? Rather. Ever been in prison? Certainly not. Never in a debtors’
+prison? Didn’t see what that had to do with it. Never in a debtors’
+prison?--Come, once again. Never? Yes. How many times? Two or three
+times. Not five or six? Perhaps. Of what profession? Gentleman. Ever
+been kicked? Might have been. Frequently? No. Ever kicked downstairs?
+Decidedly not; once received a kick on the top of a staircase, and fell
+downstairs of his own accord. Kicked on that occasion for cheating at
+dice? Something to that effect was said by the intoxicated liar who
+committed the assault, but it was not true. Swear it was not true?
+Positively. Ever live by cheating at play? Never. Ever live by play? Not
+more than other gentlemen do. Ever borrow money of the prisoner? Yes.
+Ever pay him? No. Was not this intimacy with the prisoner, in reality a
+very slight one, forced upon the prisoner in coaches, inns, and packets?
+No. Sure he saw the prisoner with these lists? Certain. Knew no more
+about the lists? No. Had not procured them himself, for instance? No.
+Expect to get anything by this evidence? No. Not in regular government
+pay and employment, to lay traps? Oh dear no. Or to do anything? Oh dear
+no. Swear that? Over and over again. No motives but motives of sheer
+patriotism? None whatever.
+
+The virtuous servant, Roger Cly, swore his way through the case at a
+great rate. He had taken service with the prisoner, in good faith and
+simplicity, four years ago. He had asked the prisoner, aboard the Calais
+packet, if he wanted a handy fellow, and the prisoner had engaged him.
+He had not asked the prisoner to take the handy fellow as an act of
+charity--never thought of such a thing. He began to have suspicions of
+the prisoner, and to keep an eye upon him, soon afterwards. In arranging
+his clothes, while travelling, he had seen similar lists to these in the
+prisoner’s pockets, over and over again. He had taken these lists from
+the drawer of the prisoner’s desk. He had not put them there first. He
+had seen the prisoner show these identical lists to French gentlemen
+at Calais, and similar lists to French gentlemen, both at Calais and
+Boulogne. He loved his country, and couldn’t bear it, and had given
+information. He had never been suspected of stealing a silver tea-pot;
+he had been maligned respecting a mustard-pot, but it turned out to be
+only a plated one. He had known the last witness seven or eight years;
+that was merely a coincidence. He didn’t call it a particularly curious
+coincidence; most coincidences were curious. Neither did he call it a
+curious coincidence that true patriotism was _his_ only motive too. He
+was a true Briton, and hoped there were many like him.
+
+The blue-flies buzzed again, and Mr. Attorney-General called Mr. Jarvis
+Lorry.
+
+“Mr. Jarvis Lorry, are you a clerk in Tellson’s bank?”
+
+“I am.”
+
+“On a certain Friday night in November one thousand seven hundred and
+seventy-five, did business occasion you to travel between London and
+Dover by the mail?”
+
+“It did.”
+
+“Were there any other passengers in the mail?”
+
+“Two.”
+
+“Did they alight on the road in the course of the night?”
+
+“They did.”
+
+“Mr. Lorry, look upon the prisoner. Was he one of those two passengers?”
+
+“I cannot undertake to say that he was.”
+
+“Does he resemble either of these two passengers?”
+
+“Both were so wrapped up, and the night was so dark, and we were all so
+reserved, that I cannot undertake to say even that.”
+
+“Mr. Lorry, look again upon the prisoner. Supposing him wrapped up as
+those two passengers were, is there anything in his bulk and stature to
+render it unlikely that he was one of them?”
+
+“No.”
+
+“You will not swear, Mr. Lorry, that he was not one of them?”
+
+“No.”
+
+“So at least you say he may have been one of them?”
+
+“Yes. Except that I remember them both to have been--like
+myself--timorous of highwaymen, and the prisoner has not a timorous
+air.”
+
+“Did you ever see a counterfeit of timidity, Mr. Lorry?”
+
+“I certainly have seen that.”
+
+“Mr. Lorry, look once more upon the prisoner. Have you seen him, to your
+certain knowledge, before?”
+
+“I have.”
+
+“When?”
+
+“I was returning from France a few days afterwards, and, at Calais, the
+prisoner came on board the packet-ship in which I returned, and made the
+voyage with me.”
+
+“At what hour did he come on board?”
+
+“At a little after midnight.”
+
+“In the dead of the night. Was he the only passenger who came on board
+at that untimely hour?”
+
+“He happened to be the only one.”
+
+“Never mind about ‘happening,’ Mr. Lorry. He was the only passenger who
+came on board in the dead of the night?”
+
+“He was.”
+
+“Were you travelling alone, Mr. Lorry, or with any companion?”
+
+“With two companions. A gentleman and lady. They are here.”
+
+“They are here. Had you any conversation with the prisoner?”
+
+“Hardly any. The weather was stormy, and the passage long and rough, and
+I lay on a sofa, almost from shore to shore.”
+
+“Miss Manette!”
+
+The young lady, to whom all eyes had been turned before, and were now
+turned again, stood up where she had sat. Her father rose with her, and
+kept her hand drawn through his arm.
+
+“Miss Manette, look upon the prisoner.”
+
+To be confronted with such pity, and such earnest youth and beauty, was
+far more trying to the accused than to be confronted with all the crowd.
+Standing, as it were, apart with her on the edge of his grave, not all
+the staring curiosity that looked on, could, for the moment, nerve him
+to remain quite still. His hurried right hand parcelled out the herbs
+before him into imaginary beds of flowers in a garden; and his efforts
+to control and steady his breathing shook the lips from which the colour
+rushed to his heart. The buzz of the great flies was loud again.
+
+“Miss Manette, have you seen the prisoner before?”
+
+“Yes, sir.”
+
+“Where?”
+
+“On board of the packet-ship just now referred to, sir, and on the same
+occasion.”
+
+“You are the young lady just now referred to?”
+
+“O! most unhappily, I am!”
+
+The plaintive tone of her compassion merged into the less musical voice
+of the Judge, as he said something fiercely: “Answer the questions put
+to you, and make no remark upon them.”
+
+“Miss Manette, had you any conversation with the prisoner on that
+passage across the Channel?”
+
+“Yes, sir.”
+
+“Recall it.”
+
+In the midst of a profound stillness, she faintly began: “When the
+gentleman came on board--”
+
+“Do you mean the prisoner?” inquired the Judge, knitting his brows.
+
+“Yes, my Lord.”
+
+“Then say the prisoner.”
+
+“When the prisoner came on board, he noticed that my father,” turning
+her eyes lovingly to him as he stood beside her, “was much fatigued
+and in a very weak state of health. My father was so reduced that I was
+afraid to take him out of the air, and I had made a bed for him on the
+deck near the cabin steps, and I sat on the deck at his side to take
+care of him. There were no other passengers that night, but we four.
+The prisoner was so good as to beg permission to advise me how I could
+shelter my father from the wind and weather, better than I had done. I
+had not known how to do it well, not understanding how the wind would
+set when we were out of the harbour. He did it for me. He expressed
+great gentleness and kindness for my father’s state, and I am sure he
+felt it. That was the manner of our beginning to speak together.”
+
+“Let me interrupt you for a moment. Had he come on board alone?”
+
+“No.”
+
+“How many were with him?”
+
+“Two French gentlemen.”
+
+“Had they conferred together?”
+
+“They had conferred together until the last moment, when it was
+necessary for the French gentlemen to be landed in their boat.”
+
+“Had any papers been handed about among them, similar to these lists?”
+
+“Some papers had been handed about among them, but I don’t know what
+papers.”
+
+“Like these in shape and size?”
+
+“Possibly, but indeed I don’t know, although they stood whispering very
+near to me: because they stood at the top of the cabin steps to have the
+light of the lamp that was hanging there; it was a dull lamp, and they
+spoke very low, and I did not hear what they said, and saw only that
+they looked at papers.”
+
+“Now, to the prisoner’s conversation, Miss Manette.”
+
+“The prisoner was as open in his confidence with me--which arose out
+of my helpless situation--as he was kind, and good, and useful to my
+father. I hope,” bursting into tears, “I may not repay him by doing him
+harm to-day.”
+
+Buzzing from the blue-flies.
+
+“Miss Manette, if the prisoner does not perfectly understand that
+you give the evidence which it is your duty to give--which you must
+give--and which you cannot escape from giving--with great unwillingness,
+he is the only person present in that condition. Please to go on.”
+
+“He told me that he was travelling on business of a delicate and
+difficult nature, which might get people into trouble, and that he was
+therefore travelling under an assumed name. He said that this business
+had, within a few days, taken him to France, and might, at intervals,
+take him backwards and forwards between France and England for a long
+time to come.”
+
+“Did he say anything about America, Miss Manette? Be particular.”
+
+“He tried to explain to me how that quarrel had arisen, and he said
+that, so far as he could judge, it was a wrong and foolish one on
+England’s part. He added, in a jesting way, that perhaps George
+Washington might gain almost as great a name in history as George the
+Third. But there was no harm in his way of saying this: it was said
+laughingly, and to beguile the time.”
+
+Any strongly marked expression of face on the part of a chief actor in
+a scene of great interest to whom many eyes are directed, will be
+unconsciously imitated by the spectators. Her forehead was painfully
+anxious and intent as she gave this evidence, and, in the pauses when
+she stopped for the Judge to write it down, watched its effect upon
+the counsel for and against. Among the lookers-on there was the same
+expression in all quarters of the court; insomuch, that a great majority
+of the foreheads there, might have been mirrors reflecting the witness,
+when the Judge looked up from his notes to glare at that tremendous
+heresy about George Washington.
+
+Mr. Attorney-General now signified to my Lord, that he deemed it
+necessary, as a matter of precaution and form, to call the young lady’s
+father, Doctor Manette. Who was called accordingly.
+
+“Doctor Manette, look upon the prisoner. Have you ever seen him before?”
+
+“Once. When he called at my lodgings in London. Some three years, or
+three years and a half ago.”
+
+“Can you identify him as your fellow-passenger on board the packet, or
+speak to his conversation with your daughter?”
+
+“Sir, I can do neither.”
+
+“Is there any particular and special reason for your being unable to do
+either?”
+
+He answered, in a low voice, “There is.”
+
+“Has it been your misfortune to undergo a long imprisonment, without
+trial, or even accusation, in your native country, Doctor Manette?”
+
+He answered, in a tone that went to every heart, “A long imprisonment.”
+
+“Were you newly released on the occasion in question?”
+
+“They tell me so.”
+
+“Have you no remembrance of the occasion?”
+
+“None. My mind is a blank, from some time--I cannot even say what
+time--when I employed myself, in my captivity, in making shoes, to the
+time when I found myself living in London with my dear daughter
+here. She had become familiar to me, when a gracious God restored
+my faculties; but, I am quite unable even to say how she had become
+familiar. I have no remembrance of the process.”
+
+Mr. Attorney-General sat down, and the father and daughter sat down
+together.
+
+A singular circumstance then arose in the case. The object in hand being
+to show that the prisoner went down, with some fellow-plotter untracked,
+in the Dover mail on that Friday night in November five years ago, and
+got out of the mail in the night, as a blind, at a place where he did
+not remain, but from which he travelled back some dozen miles or more,
+to a garrison and dockyard, and there collected information; a witness
+was called to identify him as having been at the precise time required,
+in the coffee-room of an hotel in that garrison-and-dockyard town,
+waiting for another person. The prisoner’s counsel was cross-examining
+this witness with no result, except that he had never seen the prisoner
+on any other occasion, when the wigged gentleman who had all this time
+been looking at the ceiling of the court, wrote a word or two on a
+little piece of paper, screwed it up, and tossed it to him. Opening
+this piece of paper in the next pause, the counsel looked with great
+attention and curiosity at the prisoner.
+
+“You say again you are quite sure that it was the prisoner?”
+
+The witness was quite sure.
+
+“Did you ever see anybody very like the prisoner?”
+
+Not so like (the witness said) as that he could be mistaken.
+
+“Look well upon that gentleman, my learned friend there,” pointing
+to him who had tossed the paper over, “and then look well upon the
+prisoner. How say you? Are they very like each other?”
+
+Allowing for my learned friend’s appearance being careless and slovenly
+if not debauched, they were sufficiently like each other to surprise,
+not only the witness, but everybody present, when they were thus brought
+into comparison. My Lord being prayed to bid my learned friend lay aside
+his wig, and giving no very gracious consent, the likeness became
+much more remarkable. My Lord inquired of Mr. Stryver (the prisoner’s
+counsel), whether they were next to try Mr. Carton (name of my learned
+friend) for treason? But, Mr. Stryver replied to my Lord, no; but he
+would ask the witness to tell him whether what happened once, might
+happen twice; whether he would have been so confident if he had seen
+this illustration of his rashness sooner, whether he would be so
+confident, having seen it; and more. The upshot of which, was, to smash
+this witness like a crockery vessel, and shiver his part of the case to
+useless lumber.
+
+Mr. Cruncher had by this time taken quite a lunch of rust off his
+fingers in his following of the evidence. He had now to attend while Mr.
+Stryver fitted the prisoner’s case on the jury, like a compact suit
+of clothes; showing them how the patriot, Barsad, was a hired spy and
+traitor, an unblushing trafficker in blood, and one of the greatest
+scoundrels upon earth since accursed Judas--which he certainly did look
+rather like. How the virtuous servant, Cly, was his friend and partner,
+and was worthy to be; how the watchful eyes of those forgers and false
+swearers had rested on the prisoner as a victim, because some family
+affairs in France, he being of French extraction, did require his making
+those passages across the Channel--though what those affairs were, a
+consideration for others who were near and dear to him, forbade him,
+even for his life, to disclose. How the evidence that had been warped
+and wrested from the young lady, whose anguish in giving it they
+had witnessed, came to nothing, involving the mere little innocent
+gallantries and politenesses likely to pass between any young gentleman
+and young lady so thrown together;--with the exception of that
+reference to George Washington, which was altogether too extravagant and
+impossible to be regarded in any other light than as a monstrous joke.
+How it would be a weakness in the government to break down in this
+attempt to practise for popularity on the lowest national antipathies
+and fears, and therefore Mr. Attorney-General had made the most of it;
+how, nevertheless, it rested upon nothing, save that vile and infamous
+character of evidence too often disfiguring such cases, and of which the
+State Trials of this country were full. But, there my Lord interposed
+(with as grave a face as if it had not been true), saying that he could
+not sit upon that Bench and suffer those allusions.
+
+Mr. Stryver then called his few witnesses, and Mr. Cruncher had next to
+attend while Mr. Attorney-General turned the whole suit of clothes Mr.
+Stryver had fitted on the jury, inside out; showing how Barsad and
+Cly were even a hundred times better than he had thought them, and the
+prisoner a hundred times worse. Lastly, came my Lord himself, turning
+the suit of clothes, now inside out, now outside in, but on the whole
+decidedly trimming and shaping them into grave-clothes for the prisoner.
+
+And now, the jury turned to consider, and the great flies swarmed again.
+
+Mr. Carton, who had so long sat looking at the ceiling of the court,
+changed neither his place nor his attitude, even in this excitement.
+While his learned friend, Mr. Stryver, massing his papers before him,
+whispered with those who sat near, and from time to time glanced
+anxiously at the jury; while all the spectators moved more or less, and
+grouped themselves anew; while even my Lord himself arose from his seat,
+and slowly paced up and down his platform, not unattended by a suspicion
+in the minds of the audience that his state was feverish; this one man
+sat leaning back, with his torn gown half off him, his untidy wig put
+on just as it had happened to light on his head after its removal, his
+hands in his pockets, and his eyes on the ceiling as they had been all
+day. Something especially reckless in his demeanour, not only gave him
+a disreputable look, but so diminished the strong resemblance he
+undoubtedly bore to the prisoner (which his momentary earnestness,
+when they were compared together, had strengthened), that many of the
+lookers-on, taking note of him now, said to one another they would
+hardly have thought the two were so alike. Mr. Cruncher made the
+observation to his next neighbour, and added, “I’d hold half a guinea
+that _he_ don’t get no law-work to do. Don’t look like the sort of one
+to get any, do he?”
+
+Yet, this Mr. Carton took in more of the details of the scene than he
+appeared to take in; for now, when Miss Manette’s head dropped upon
+her father’s breast, he was the first to see it, and to say audibly:
+“Officer! look to that young lady. Help the gentleman to take her out.
+Don’t you see she will fall!”
+
+There was much commiseration for her as she was removed, and much
+sympathy with her father. It had evidently been a great distress to
+him, to have the days of his imprisonment recalled. He had shown
+strong internal agitation when he was questioned, and that pondering or
+brooding look which made him old, had been upon him, like a heavy cloud,
+ever since. As he passed out, the jury, who had turned back and paused a
+moment, spoke, through their foreman.
+
+They were not agreed, and wished to retire. My Lord (perhaps with George
+Washington on his mind) showed some surprise that they were not agreed,
+but signified his pleasure that they should retire under watch and ward,
+and retired himself. The trial had lasted all day, and the lamps in
+the court were now being lighted. It began to be rumoured that the
+jury would be out a long while. The spectators dropped off to get
+refreshment, and the prisoner withdrew to the back of the dock, and sat
+down.
+
+Mr. Lorry, who had gone out when the young lady and her father went out,
+now reappeared, and beckoned to Jerry: who, in the slackened interest,
+could easily get near him.
+
+“Jerry, if you wish to take something to eat, you can. But, keep in the
+way. You will be sure to hear when the jury come in. Don’t be a moment
+behind them, for I want you to take the verdict back to the bank. You
+are the quickest messenger I know, and will get to Temple Bar long
+before I can.”
+
+Jerry had just enough forehead to knuckle, and he knuckled it in
+acknowledgment of this communication and a shilling. Mr. Carton came up
+at the moment, and touched Mr. Lorry on the arm.
+
+“How is the young lady?”
+
+“She is greatly distressed; but her father is comforting her, and she
+feels the better for being out of court.”
+
+“I’ll tell the prisoner so. It won’t do for a respectable bank gentleman
+like you, to be seen speaking to him publicly, you know.”
+
+Mr. Lorry reddened as if he were conscious of having debated the point
+in his mind, and Mr. Carton made his way to the outside of the bar.
+The way out of court lay in that direction, and Jerry followed him, all
+eyes, ears, and spikes.
+
+“Mr. Darnay!”
+
+The prisoner came forward directly.
+
+“You will naturally be anxious to hear of the witness, Miss Manette. She
+will do very well. You have seen the worst of her agitation.”
+
+“I am deeply sorry to have been the cause of it. Could you tell her so
+for me, with my fervent acknowledgments?”
+
+“Yes, I could. I will, if you ask it.”
+
+Mr. Carton’s manner was so careless as to be almost insolent. He stood,
+half turned from the prisoner, lounging with his elbow against the bar.
+
+“I do ask it. Accept my cordial thanks.”
+
+“What,” said Carton, still only half turned towards him, “do you expect,
+Mr. Darnay?”
+
+“The worst.”
+
+“It’s the wisest thing to expect, and the likeliest. But I think their
+withdrawing is in your favour.”
+
+Loitering on the way out of court not being allowed, Jerry heard no
+more: but left them--so like each other in feature, so unlike each other
+in manner--standing side by side, both reflected in the glass above
+them.
+
+An hour and a half limped heavily away in the thief-and-rascal crowded
+passages below, even though assisted off with mutton pies and ale.
+The hoarse messenger, uncomfortably seated on a form after taking that
+refection, had dropped into a doze, when a loud murmur and a rapid tide
+of people setting up the stairs that led to the court, carried him along
+with them.
+
+“Jerry! Jerry!” Mr. Lorry was already calling at the door when he got
+there.
+
+“Here, sir! It’s a fight to get back again. Here I am, sir!”
+
+Mr. Lorry handed him a paper through the throng. “Quick! Have you got
+it?”
+
+“Yes, sir.”
+
+Hastily written on the paper was the word “ACQUITTED.”
+
+“If you had sent the message, ‘Recalled to Life,’ again,” muttered
+Jerry, as he turned, “I should have known what you meant, this time.”
+
+He had no opportunity of saying, or so much as thinking, anything else,
+until he was clear of the Old Bailey; for, the crowd came pouring out
+with a vehemence that nearly took him off his legs, and a loud buzz
+swept into the street as if the baffled blue-flies were dispersing in
+search of other carrion.
+
+
+
+
+IV. Congratulatory
+
+
+From the dimly-lighted passages of the court, the last sediment of the
+human stew that had been boiling there all day, was straining off, when
+Doctor Manette, Lucie Manette, his daughter, Mr. Lorry, the solicitor
+for the defence, and its counsel, Mr. Stryver, stood gathered round Mr.
+Charles Darnay--just released--congratulating him on his escape from
+death.
+
+It would have been difficult by a far brighter light, to recognise
+in Doctor Manette, intellectual of face and upright of bearing, the
+shoemaker of the garret in Paris. Yet, no one could have looked at him
+twice, without looking again: even though the opportunity of observation
+had not extended to the mournful cadence of his low grave voice, and
+to the abstraction that overclouded him fitfully, without any apparent
+reason. While one external cause, and that a reference to his long
+lingering agony, would always--as on the trial--evoke this condition
+from the depths of his soul, it was also in its nature to arise of
+itself, and to draw a gloom over him, as incomprehensible to those
+unacquainted with his story as if they had seen the shadow of the actual
+Bastille thrown upon him by a summer sun, when the substance was three
+hundred miles away.
+
+Only his daughter had the power of charming this black brooding from
+his mind. She was the golden thread that united him to a Past beyond his
+misery, and to a Present beyond his misery: and the sound of her voice,
+the light of her face, the touch of her hand, had a strong beneficial
+influence with him almost always. Not absolutely always, for she could
+recall some occasions on which her power had failed; but they were few
+and slight, and she believed them over.
+
+Mr. Darnay had kissed her hand fervently and gratefully, and had turned
+to Mr. Stryver, whom he warmly thanked. Mr. Stryver, a man of little
+more than thirty, but looking twenty years older than he was, stout,
+loud, red, bluff, and free from any drawback of delicacy, had a pushing
+way of shouldering himself (morally and physically) into companies and
+conversations, that argued well for his shouldering his way up in life.
+
+He still had his wig and gown on, and he said, squaring himself at his
+late client to that degree that he squeezed the innocent Mr. Lorry clean
+out of the group: “I am glad to have brought you off with honour, Mr.
+Darnay. It was an infamous prosecution, grossly infamous; but not the
+less likely to succeed on that account.”
+
+“You have laid me under an obligation to you for life--in two senses,”
+ said his late client, taking his hand.
+
+“I have done my best for you, Mr. Darnay; and my best is as good as
+another man’s, I believe.”
+
+It clearly being incumbent on some one to say, “Much better,” Mr. Lorry
+said it; perhaps not quite disinterestedly, but with the interested
+object of squeezing himself back again.
+
+“You think so?” said Mr. Stryver. “Well! you have been present all day,
+and you ought to know. You are a man of business, too.”
+
+“And as such,” quoth Mr. Lorry, whom the counsel learned in the law had
+now shouldered back into the group, just as he had previously shouldered
+him out of it--“as such I will appeal to Doctor Manette, to break up
+this conference and order us all to our homes. Miss Lucie looks ill, Mr.
+Darnay has had a terrible day, we are worn out.”
+
+“Speak for yourself, Mr. Lorry,” said Stryver; “I have a night’s work to
+do yet. Speak for yourself.”
+
+“I speak for myself,” answered Mr. Lorry, “and for Mr. Darnay, and for
+Miss Lucie, and--Miss Lucie, do you not think I may speak for us all?”
+ He asked her the question pointedly, and with a glance at her father.
+
+His face had become frozen, as it were, in a very curious look at
+Darnay: an intent look, deepening into a frown of dislike and distrust,
+not even unmixed with fear. With this strange expression on him his
+thoughts had wandered away.
+
+“My father,” said Lucie, softly laying her hand on his.
+
+He slowly shook the shadow off, and turned to her.
+
+“Shall we go home, my father?”
+
+With a long breath, he answered “Yes.”
+
+The friends of the acquitted prisoner had dispersed, under the
+impression--which he himself had originated--that he would not be
+released that night. The lights were nearly all extinguished in the
+passages, the iron gates were being closed with a jar and a rattle,
+and the dismal place was deserted until to-morrow morning’s interest of
+gallows, pillory, whipping-post, and branding-iron, should repeople it.
+Walking between her father and Mr. Darnay, Lucie Manette passed into
+the open air. A hackney-coach was called, and the father and daughter
+departed in it.
+
+Mr. Stryver had left them in the passages, to shoulder his way back
+to the robing-room. Another person, who had not joined the group, or
+interchanged a word with any one of them, but who had been leaning
+against the wall where its shadow was darkest, had silently strolled
+out after the rest, and had looked on until the coach drove away. He now
+stepped up to where Mr. Lorry and Mr. Darnay stood upon the pavement.
+
+“So, Mr. Lorry! Men of business may speak to Mr. Darnay now?”
+
+Nobody had made any acknowledgment of Mr. Carton’s part in the day’s
+proceedings; nobody had known of it. He was unrobed, and was none the
+better for it in appearance.
+
+“If you knew what a conflict goes on in the business mind, when the
+business mind is divided between good-natured impulse and business
+appearances, you would be amused, Mr. Darnay.”
+
+Mr. Lorry reddened, and said, warmly, “You have mentioned that before,
+sir. We men of business, who serve a House, are not our own masters. We
+have to think of the House more than ourselves.”
+
+“_I_ know, _I_ know,” rejoined Mr. Carton, carelessly. “Don’t be
+nettled, Mr. Lorry. You are as good as another, I have no doubt: better,
+I dare say.”
+
+“And indeed, sir,” pursued Mr. Lorry, not minding him, “I really don’t
+know what you have to do with the matter. If you’ll excuse me, as very
+much your elder, for saying so, I really don’t know that it is your
+business.”
+
+“Business! Bless you, _I_ have no business,” said Mr. Carton.
+
+“It is a pity you have not, sir.”
+
+“I think so, too.”
+
+“If you had,” pursued Mr. Lorry, “perhaps you would attend to it.”
+
+“Lord love you, no!--I shouldn’t,” said Mr. Carton.
+
+“Well, sir!” cried Mr. Lorry, thoroughly heated by his indifference,
+“business is a very good thing, and a very respectable thing. And, sir,
+if business imposes its restraints and its silences and impediments, Mr.
+Darnay as a young gentleman of generosity knows how to make allowance
+for that circumstance. Mr. Darnay, good night, God bless you, sir!
+I hope you have been this day preserved for a prosperous and happy
+life.--Chair there!”
+
+Perhaps a little angry with himself, as well as with the barrister, Mr.
+Lorry bustled into the chair, and was carried off to Tellson’s. Carton,
+who smelt of port wine, and did not appear to be quite sober, laughed
+then, and turned to Darnay:
+
+“This is a strange chance that throws you and me together. This must
+be a strange night to you, standing alone here with your counterpart on
+these street stones?”
+
+“I hardly seem yet,” returned Charles Darnay, “to belong to this world
+again.”
+
+“I don’t wonder at it; it’s not so long since you were pretty far
+advanced on your way to another. You speak faintly.”
+
+“I begin to think I _am_ faint.”
+
+“Then why the devil don’t you dine? I dined, myself, while those
+numskulls were deliberating which world you should belong to--this, or
+some other. Let me show you the nearest tavern to dine well at.”
+
+Drawing his arm through his own, he took him down Ludgate-hill to
+Fleet-street, and so, up a covered way, into a tavern. Here, they were
+shown into a little room, where Charles Darnay was soon recruiting
+his strength with a good plain dinner and good wine: while Carton sat
+opposite to him at the same table, with his separate bottle of port
+before him, and his fully half-insolent manner upon him.
+
+“Do you feel, yet, that you belong to this terrestrial scheme again, Mr.
+Darnay?”
+
+“I am frightfully confused regarding time and place; but I am so far
+mended as to feel that.”
+
+“It must be an immense satisfaction!”
+
+He said it bitterly, and filled up his glass again: which was a large
+one.
+
+“As to me, the greatest desire I have, is to forget that I belong to it.
+It has no good in it for me--except wine like this--nor I for it. So we
+are not much alike in that particular. Indeed, I begin to think we are
+not much alike in any particular, you and I.”
+
+Confused by the emotion of the day, and feeling his being there with
+this Double of coarse deportment, to be like a dream, Charles Darnay was
+at a loss how to answer; finally, answered not at all.
+
+“Now your dinner is done,” Carton presently said, “why don’t you call a
+health, Mr. Darnay; why don’t you give your toast?”
+
+“What health? What toast?”
+
+“Why, it’s on the tip of your tongue. It ought to be, it must be, I’ll
+swear it’s there.”
+
+“Miss Manette, then!”
+
+“Miss Manette, then!”
+
+Looking his companion full in the face while he drank the toast, Carton
+flung his glass over his shoulder against the wall, where it shivered to
+pieces; then, rang the bell, and ordered in another.
+
+“That’s a fair young lady to hand to a coach in the dark, Mr. Darnay!”
+ he said, filling his new goblet.
+
+A slight frown and a laconic “Yes,” were the answer.
+
+“That’s a fair young lady to be pitied by and wept for by! How does it
+feel? Is it worth being tried for one’s life, to be the object of such
+sympathy and compassion, Mr. Darnay?”
+
+Again Darnay answered not a word.
+
+“She was mightily pleased to have your message, when I gave it her. Not
+that she showed she was pleased, but I suppose she was.”
+
+The allusion served as a timely reminder to Darnay that this
+disagreeable companion had, of his own free will, assisted him in the
+strait of the day. He turned the dialogue to that point, and thanked him
+for it.
+
+“I neither want any thanks, nor merit any,” was the careless rejoinder.
+“It was nothing to do, in the first place; and I don’t know why I did
+it, in the second. Mr. Darnay, let me ask you a question.”
+
+“Willingly, and a small return for your good offices.”
+
+“Do you think I particularly like you?”
+
+“Really, Mr. Carton,” returned the other, oddly disconcerted, “I have
+not asked myself the question.”
+
+“But ask yourself the question now.”
+
+“You have acted as if you do; but I don’t think you do.”
+
+“_I_ don’t think I do,” said Carton. “I begin to have a very good
+opinion of your understanding.”
+
+“Nevertheless,” pursued Darnay, rising to ring the bell, “there is
+nothing in that, I hope, to prevent my calling the reckoning, and our
+parting without ill-blood on either side.”
+
+Carton rejoining, “Nothing in life!” Darnay rang. “Do you call the whole
+reckoning?” said Carton. On his answering in the affirmative, “Then
+bring me another pint of this same wine, drawer, and come and wake me at
+ten.”
+
+The bill being paid, Charles Darnay rose and wished him good night.
+Without returning the wish, Carton rose too, with something of a threat
+of defiance in his manner, and said, “A last word, Mr. Darnay: you think
+I am drunk?”
+
+“I think you have been drinking, Mr. Carton.”
+
+“Think? You know I have been drinking.”
+
+“Since I must say so, I know it.”
+
+“Then you shall likewise know why. I am a disappointed drudge, sir. I
+care for no man on earth, and no man on earth cares for me.”
+
+“Much to be regretted. You might have used your talents better.”
+
+“May be so, Mr. Darnay; may be not. Don’t let your sober face elate you,
+however; you don’t know what it may come to. Good night!”
+
+When he was left alone, this strange being took up a candle, went to a
+glass that hung against the wall, and surveyed himself minutely in it.
+
+“Do you particularly like the man?” he muttered, at his own image; “why
+should you particularly like a man who resembles you? There is nothing
+in you to like; you know that. Ah, confound you! What a change you have
+made in yourself! A good reason for taking to a man, that he shows you
+what you have fallen away from, and what you might have been! Change
+places with him, and would you have been looked at by those blue eyes as
+he was, and commiserated by that agitated face as he was? Come on, and
+have it out in plain words! You hate the fellow.”
+
+He resorted to his pint of wine for consolation, drank it all in a few
+minutes, and fell asleep on his arms, with his hair straggling over the
+table, and a long winding-sheet in the candle dripping down upon him.
+
+
+
+
+V. The Jackal
+
+
+Those were drinking days, and most men drank hard. So very great is
+the improvement Time has brought about in such habits, that a moderate
+statement of the quantity of wine and punch which one man would swallow
+in the course of a night, without any detriment to his reputation as a
+perfect gentleman, would seem, in these days, a ridiculous exaggeration.
+The learned profession of the law was certainly not behind any other
+learned profession in its Bacchanalian propensities; neither was Mr.
+Stryver, already fast shouldering his way to a large and lucrative
+practice, behind his compeers in this particular, any more than in the
+drier parts of the legal race.
+
+A favourite at the Old Bailey, and eke at the Sessions, Mr. Stryver had
+begun cautiously to hew away the lower staves of the ladder on which
+he mounted. Sessions and Old Bailey had now to summon their favourite,
+specially, to their longing arms; and shouldering itself towards the
+visage of the Lord Chief Justice in the Court of King’s Bench, the
+florid countenance of Mr. Stryver might be daily seen, bursting out of
+the bed of wigs, like a great sunflower pushing its way at the sun from
+among a rank garden-full of flaring companions.
+
+It had once been noted at the Bar, that while Mr. Stryver was a glib
+man, and an unscrupulous, and a ready, and a bold, he had not that
+faculty of extracting the essence from a heap of statements, which is
+among the most striking and necessary of the advocate’s accomplishments.
+But, a remarkable improvement came upon him as to this. The more
+business he got, the greater his power seemed to grow of getting at its
+pith and marrow; and however late at night he sat carousing with Sydney
+Carton, he always had his points at his fingers’ ends in the morning.
+
+Sydney Carton, idlest and most unpromising of men, was Stryver’s great
+ally. What the two drank together, between Hilary Term and Michaelmas,
+might have floated a king’s ship. Stryver never had a case in hand,
+anywhere, but Carton was there, with his hands in his pockets, staring
+at the ceiling of the court; they went the same Circuit, and even there
+they prolonged their usual orgies late into the night, and Carton was
+rumoured to be seen at broad day, going home stealthily and unsteadily
+to his lodgings, like a dissipated cat. At last, it began to get about,
+among such as were interested in the matter, that although Sydney Carton
+would never be a lion, he was an amazingly good jackal, and that he
+rendered suit and service to Stryver in that humble capacity.
+
+“Ten o’clock, sir,” said the man at the tavern, whom he had charged to
+wake him--“ten o’clock, sir.”
+
+“_What’s_ the matter?”
+
+“Ten o’clock, sir.”
+
+“What do you mean? Ten o’clock at night?”
+
+“Yes, sir. Your honour told me to call you.”
+
+“Oh! I remember. Very well, very well.”
+
+After a few dull efforts to get to sleep again, which the man
+dexterously combated by stirring the fire continuously for five minutes,
+he got up, tossed his hat on, and walked out. He turned into the Temple,
+and, having revived himself by twice pacing the pavements of King’s
+Bench-walk and Paper-buildings, turned into the Stryver chambers.
+
+The Stryver clerk, who never assisted at these conferences, had gone
+home, and the Stryver principal opened the door. He had his slippers on,
+and a loose bed-gown, and his throat was bare for his greater ease. He
+had that rather wild, strained, seared marking about the eyes, which
+may be observed in all free livers of his class, from the portrait of
+Jeffries downward, and which can be traced, under various disguises of
+Art, through the portraits of every Drinking Age.
+
+“You are a little late, Memory,” said Stryver.
+
+“About the usual time; it may be a quarter of an hour later.”
+
+They went into a dingy room lined with books and littered with papers,
+where there was a blazing fire. A kettle steamed upon the hob, and in
+the midst of the wreck of papers a table shone, with plenty of wine upon
+it, and brandy, and rum, and sugar, and lemons.
+
+“You have had your bottle, I perceive, Sydney.”
+
+“Two to-night, I think. I have been dining with the day’s client; or
+seeing him dine--it’s all one!”
+
+“That was a rare point, Sydney, that you brought to bear upon the
+identification. How did you come by it? When did it strike you?”
+
+“I thought he was rather a handsome fellow, and I thought I should have
+been much the same sort of fellow, if I had had any luck.”
+
+Mr. Stryver laughed till he shook his precocious paunch.
+
+“You and your luck, Sydney! Get to work, get to work.”
+
+Sullenly enough, the jackal loosened his dress, went into an adjoining
+room, and came back with a large jug of cold water, a basin, and a towel
+or two. Steeping the towels in the water, and partially wringing them
+out, he folded them on his head in a manner hideous to behold, sat down
+at the table, and said, “Now I am ready!”
+
+“Not much boiling down to be done to-night, Memory,” said Mr. Stryver,
+gaily, as he looked among his papers.
+
+“How much?”
+
+“Only two sets of them.”
+
+“Give me the worst first.”
+
+“There they are, Sydney. Fire away!”
+
+The lion then composed himself on his back on a sofa on one side of the
+drinking-table, while the jackal sat at his own paper-bestrewn table
+proper, on the other side of it, with the bottles and glasses ready to
+his hand. Both resorted to the drinking-table without stint, but each in
+a different way; the lion for the most part reclining with his hands in
+his waistband, looking at the fire, or occasionally flirting with some
+lighter document; the jackal, with knitted brows and intent face,
+so deep in his task, that his eyes did not even follow the hand he
+stretched out for his glass--which often groped about, for a minute or
+more, before it found the glass for his lips. Two or three times, the
+matter in hand became so knotty, that the jackal found it imperative on
+him to get up, and steep his towels anew. From these pilgrimages to the
+jug and basin, he returned with such eccentricities of damp headgear as
+no words can describe; which were made the more ludicrous by his anxious
+gravity.
+
+At length the jackal had got together a compact repast for the lion, and
+proceeded to offer it to him. The lion took it with care and caution,
+made his selections from it, and his remarks upon it, and the jackal
+assisted both. When the repast was fully discussed, the lion put his
+hands in his waistband again, and lay down to meditate. The jackal then
+invigorated himself with a bumper for his throttle, and a fresh application
+to his head, and applied himself to the collection of a second meal;
+this was administered to the lion in the same manner, and was not
+disposed of until the clocks struck three in the morning.
+
+“And now we have done, Sydney, fill a bumper of punch,” said Mr.
+Stryver.
+
+The jackal removed the towels from his head, which had been steaming
+again, shook himself, yawned, shivered, and complied.
+
+“You were very sound, Sydney, in the matter of those crown witnesses
+to-day. Every question told.”
+
+“I always am sound; am I not?”
+
+“I don’t gainsay it. What has roughened your temper? Put some punch to
+it and smooth it again.”
+
+With a deprecatory grunt, the jackal again complied.
+
+“The old Sydney Carton of old Shrewsbury School,” said Stryver, nodding
+his head over him as he reviewed him in the present and the past, “the
+old seesaw Sydney. Up one minute and down the next; now in spirits and
+now in despondency!”
+
+“Ah!” returned the other, sighing: “yes! The same Sydney, with the same
+luck. Even then, I did exercises for other boys, and seldom did my own.”
+
+“And why not?”
+
+“God knows. It was my way, I suppose.”
+
+He sat, with his hands in his pockets and his legs stretched out before
+him, looking at the fire.
+
+“Carton,” said his friend, squaring himself at him with a bullying air,
+as if the fire-grate had been the furnace in which sustained endeavour
+was forged, and the one delicate thing to be done for the old Sydney
+Carton of old Shrewsbury School was to shoulder him into it, “your way
+is, and always was, a lame way. You summon no energy and purpose. Look
+at me.”
+
+“Oh, botheration!” returned Sydney, with a lighter and more
+good-humoured laugh, “don’t _you_ be moral!”
+
+“How have I done what I have done?” said Stryver; “how do I do what I
+do?”
+
+“Partly through paying me to help you, I suppose. But it’s not worth
+your while to apostrophise me, or the air, about it; what you want to
+do, you do. You were always in the front rank, and I was always behind.”
+
+“I had to get into the front rank; I was not born there, was I?”
+
+“I was not present at the ceremony; but my opinion is you were,” said
+Carton. At this, he laughed again, and they both laughed.
+
+“Before Shrewsbury, and at Shrewsbury, and ever since Shrewsbury,”
+ pursued Carton, “you have fallen into your rank, and I have fallen into
+mine. Even when we were fellow-students in the Student-Quarter of Paris,
+picking up French, and French law, and other French crumbs that we
+didn’t get much good of, you were always somewhere, and I was always
+nowhere.”
+
+“And whose fault was that?”
+
+“Upon my soul, I am not sure that it was not yours. You were always
+driving and riving and shouldering and passing, to that restless degree
+that I had no chance for my life but in rust and repose. It’s a gloomy
+thing, however, to talk about one’s own past, with the day breaking.
+Turn me in some other direction before I go.”
+
+“Well then! Pledge me to the pretty witness,” said Stryver, holding up
+his glass. “Are you turned in a pleasant direction?”
+
+Apparently not, for he became gloomy again.
+
+“Pretty witness,” he muttered, looking down into his glass. “I have had
+enough of witnesses to-day and to-night; who’s your pretty witness?”
+
+“The picturesque doctor’s daughter, Miss Manette.”
+
+“_She_ pretty?”
+
+“Is she not?”
+
+“No.”
+
+“Why, man alive, she was the admiration of the whole Court!”
+
+“Rot the admiration of the whole Court! Who made the Old Bailey a judge
+of beauty? She was a golden-haired doll!”
+
+“Do you know, Sydney,” said Mr. Stryver, looking at him with sharp eyes,
+and slowly drawing a hand across his florid face: “do you know, I rather
+thought, at the time, that you sympathised with the golden-haired doll,
+and were quick to see what happened to the golden-haired doll?”
+
+“Quick to see what happened! If a girl, doll or no doll, swoons within a
+yard or two of a man’s nose, he can see it without a perspective-glass.
+I pledge you, but I deny the beauty. And now I’ll have no more drink;
+I’ll get to bed.”
+
+When his host followed him out on the staircase with a candle, to light
+him down the stairs, the day was coldly looking in through its grimy
+windows. When he got out of the house, the air was cold and sad, the
+dull sky overcast, the river dark and dim, the whole scene like a
+lifeless desert. And wreaths of dust were spinning round and round
+before the morning blast, as if the desert-sand had risen far away, and
+the first spray of it in its advance had begun to overwhelm the city.
+
+Waste forces within him, and a desert all around, this man stood still
+on his way across a silent terrace, and saw for a moment, lying in the
+wilderness before him, a mirage of honourable ambition, self-denial, and
+perseverance. In the fair city of this vision, there were airy galleries
+from which the loves and graces looked upon him, gardens in which the
+fruits of life hung ripening, waters of Hope that sparkled in his sight.
+A moment, and it was gone. Climbing to a high chamber in a well of
+houses, he threw himself down in his clothes on a neglected bed, and its
+pillow was wet with wasted tears.
+
+Sadly, sadly, the sun rose; it rose upon no sadder sight than the man of
+good abilities and good emotions, incapable of their directed exercise,
+incapable of his own help and his own happiness, sensible of the blight
+on him, and resigning himself to let it eat him away.
+
+
+
+
+VI. Hundreds of People
+
+
+The quiet lodgings of Doctor Manette were in a quiet street-corner not
+far from Soho-square. On the afternoon of a certain fine Sunday when the
+waves of four months had rolled over the trial for treason, and carried
+it, as to the public interest and memory, far out to sea, Mr. Jarvis
+Lorry walked along the sunny streets from Clerkenwell where he lived,
+on his way to dine with the Doctor. After several relapses into
+business-absorption, Mr. Lorry had become the Doctor’s friend, and the
+quiet street-corner was the sunny part of his life.
+
+On this certain fine Sunday, Mr. Lorry walked towards Soho, early in
+the afternoon, for three reasons of habit. Firstly, because, on fine
+Sundays, he often walked out, before dinner, with the Doctor and Lucie;
+secondly, because, on unfavourable Sundays, he was accustomed to be with
+them as the family friend, talking, reading, looking out of window, and
+generally getting through the day; thirdly, because he happened to have
+his own little shrewd doubts to solve, and knew how the ways of the
+Doctor’s household pointed to that time as a likely time for solving
+them.
+
+A quainter corner than the corner where the Doctor lived, was not to be
+found in London. There was no way through it, and the front windows of
+the Doctor’s lodgings commanded a pleasant little vista of street that
+had a congenial air of retirement on it. There were few buildings then,
+north of the Oxford-road, and forest-trees flourished, and wild flowers
+grew, and the hawthorn blossomed, in the now vanished fields. As a
+consequence, country airs circulated in Soho with vigorous freedom,
+instead of languishing into the parish like stray paupers without a
+settlement; and there was many a good south wall, not far off, on which
+the peaches ripened in their season.
+
+The summer light struck into the corner brilliantly in the earlier part
+of the day; but, when the streets grew hot, the corner was in shadow,
+though not in shadow so remote but that you could see beyond it into a
+glare of brightness. It was a cool spot, staid but cheerful, a wonderful
+place for echoes, and a very harbour from the raging streets.
+
+There ought to have been a tranquil bark in such an anchorage, and
+there was. The Doctor occupied two floors of a large stiff house, where
+several callings purported to be pursued by day, but whereof little was
+audible any day, and which was shunned by all of them at night. In
+a building at the back, attainable by a courtyard where a plane-tree
+rustled its green leaves, church-organs claimed to be made, and silver
+to be chased, and likewise gold to be beaten by some mysterious giant
+who had a golden arm starting out of the wall of the front hall--as if
+he had beaten himself precious, and menaced a similar conversion of all
+visitors. Very little of these trades, or of a lonely lodger rumoured
+to live up-stairs, or of a dim coach-trimming maker asserted to have
+a counting-house below, was ever heard or seen. Occasionally, a stray
+workman putting his coat on, traversed the hall, or a stranger peered
+about there, or a distant clink was heard across the courtyard, or a
+thump from the golden giant. These, however, were only the exceptions
+required to prove the rule that the sparrows in the plane-tree behind
+the house, and the echoes in the corner before it, had their own way
+from Sunday morning unto Saturday night.
+
+Doctor Manette received such patients here as his old reputation, and
+its revival in the floating whispers of his story, brought him.
+His scientific knowledge, and his vigilance and skill in conducting
+ingenious experiments, brought him otherwise into moderate request, and
+he earned as much as he wanted.
+
+These things were within Mr. Jarvis Lorry’s knowledge, thoughts, and
+notice, when he rang the door-bell of the tranquil house in the corner,
+on the fine Sunday afternoon.
+
+“Doctor Manette at home?”
+
+Expected home.
+
+“Miss Lucie at home?”
+
+Expected home.
+
+“Miss Pross at home?”
+
+Possibly at home, but of a certainty impossible for handmaid to
+anticipate intentions of Miss Pross, as to admission or denial of the
+fact.
+
+“As I am at home myself,” said Mr. Lorry, “I’ll go upstairs.”
+
+Although the Doctor’s daughter had known nothing of the country of her
+birth, she appeared to have innately derived from it that ability to
+make much of little means, which is one of its most useful and most
+agreeable characteristics. Simple as the furniture was, it was set off
+by so many little adornments, of no value but for their taste and fancy,
+that its effect was delightful. The disposition of everything in the
+rooms, from the largest object to the least; the arrangement of colours,
+the elegant variety and contrast obtained by thrift in trifles, by
+delicate hands, clear eyes, and good sense; were at once so pleasant in
+themselves, and so expressive of their originator, that, as Mr. Lorry
+stood looking about him, the very chairs and tables seemed to ask him,
+with something of that peculiar expression which he knew so well by this
+time, whether he approved?
+
+There were three rooms on a floor, and, the doors by which they
+communicated being put open that the air might pass freely through them
+all, Mr. Lorry, smilingly observant of that fanciful resemblance which
+he detected all around him, walked from one to another. The first was
+the best room, and in it were Lucie’s birds, and flowers, and books,
+and desk, and work-table, and box of water-colours; the second was
+the Doctor’s consulting-room, used also as the dining-room; the third,
+changingly speckled by the rustle of the plane-tree in the yard, was the
+Doctor’s bedroom, and there, in a corner, stood the disused shoemaker’s
+bench and tray of tools, much as it had stood on the fifth floor of the
+dismal house by the wine-shop, in the suburb of Saint Antoine in Paris.
+
+“I wonder,” said Mr. Lorry, pausing in his looking about, “that he keeps
+that reminder of his sufferings about him!”
+
+“And why wonder at that?” was the abrupt inquiry that made him start.
+
+It proceeded from Miss Pross, the wild red woman, strong of hand, whose
+acquaintance he had first made at the Royal George Hotel at Dover, and
+had since improved.
+
+“I should have thought--” Mr. Lorry began.
+
+“Pooh! You’d have thought!” said Miss Pross; and Mr. Lorry left off.
+
+“How do you do?” inquired that lady then--sharply, and yet as if to
+express that she bore him no malice.
+
+“I am pretty well, I thank you,” answered Mr. Lorry, with meekness; “how
+are you?”
+
+“Nothing to boast of,” said Miss Pross.
+
+“Indeed?”
+
+“Ah! indeed!” said Miss Pross. “I am very much put out about my
+Ladybird.”
+
+“Indeed?”
+
+“For gracious sake say something else besides ‘indeed,’ or you’ll
+fidget me to death,” said Miss Pross: whose character (dissociated from
+stature) was shortness.
+
+“Really, then?” said Mr. Lorry, as an amendment.
+
+“Really, is bad enough,” returned Miss Pross, “but better. Yes, I am
+very much put out.”
+
+“May I ask the cause?”
+
+“I don’t want dozens of people who are not at all worthy of Ladybird, to
+come here looking after her,” said Miss Pross.
+
+“_Do_ dozens come for that purpose?”
+
+“Hundreds,” said Miss Pross.
+
+It was characteristic of this lady (as of some other people before her
+time and since) that whenever her original proposition was questioned,
+she exaggerated it.
+
+“Dear me!” said Mr. Lorry, as the safest remark he could think of.
+
+“I have lived with the darling--or the darling has lived with me, and
+paid me for it; which she certainly should never have done, you may take
+your affidavit, if I could have afforded to keep either myself or her
+for nothing--since she was ten years old. And it’s really very hard,”
+ said Miss Pross.
+
+Not seeing with precision what was very hard, Mr. Lorry shook his head;
+using that important part of himself as a sort of fairy cloak that would
+fit anything.
+
+“All sorts of people who are not in the least degree worthy of the pet,
+are always turning up,” said Miss Pross. “When you began it--”
+
+“_I_ began it, Miss Pross?”
+
+“Didn’t you? Who brought her father to life?”
+
+“Oh! If _that_ was beginning it--” said Mr. Lorry.
+
+“It wasn’t ending it, I suppose? I say, when you began it, it was hard
+enough; not that I have any fault to find with Doctor Manette, except
+that he is not worthy of such a daughter, which is no imputation on
+him, for it was not to be expected that anybody should be, under any
+circumstances. But it really is doubly and trebly hard to have crowds
+and multitudes of people turning up after him (I could have forgiven
+him), to take Ladybird’s affections away from me.”
+
+Mr. Lorry knew Miss Pross to be very jealous, but he also knew her by
+this time to be, beneath the service of her eccentricity, one of those
+unselfish creatures--found only among women--who will, for pure love and
+admiration, bind themselves willing slaves, to youth when they have lost
+it, to beauty that they never had, to accomplishments that they were
+never fortunate enough to gain, to bright hopes that never shone upon
+their own sombre lives. He knew enough of the world to know that there
+is nothing in it better than the faithful service of the heart; so
+rendered and so free from any mercenary taint, he had such an exalted
+respect for it, that in the retributive arrangements made by his own
+mind--we all make such arrangements, more or less--he stationed Miss
+Pross much nearer to the lower Angels than many ladies immeasurably
+better got up both by Nature and Art, who had balances at Tellson’s.
+
+“There never was, nor will be, but one man worthy of Ladybird,” said
+Miss Pross; “and that was my brother Solomon, if he hadn’t made a
+mistake in life.”
+
+Here again: Mr. Lorry’s inquiries into Miss Pross’s personal history had
+established the fact that her brother Solomon was a heartless scoundrel
+who had stripped her of everything she possessed, as a stake to
+speculate with, and had abandoned her in her poverty for evermore, with
+no touch of compunction. Miss Pross’s fidelity of belief in Solomon
+(deducting a mere trifle for this slight mistake) was quite a serious
+matter with Mr. Lorry, and had its weight in his good opinion of her.
+
+“As we happen to be alone for the moment, and are both people of
+business,” he said, when they had got back to the drawing-room and had
+sat down there in friendly relations, “let me ask you--does the Doctor,
+in talking with Lucie, never refer to the shoemaking time, yet?”
+
+“Never.”
+
+“And yet keeps that bench and those tools beside him?”
+
+“Ah!” returned Miss Pross, shaking her head. “But I don’t say he don’t
+refer to it within himself.”
+
+“Do you believe that he thinks of it much?”
+
+“I do,” said Miss Pross.
+
+“Do you imagine--” Mr. Lorry had begun, when Miss Pross took him up
+short with:
+
+“Never imagine anything. Have no imagination at all.”
+
+“I stand corrected; do you suppose--you go so far as to suppose,
+sometimes?”
+
+“Now and then,” said Miss Pross.
+
+“Do you suppose,” Mr. Lorry went on, with a laughing twinkle in his
+bright eye, as it looked kindly at her, “that Doctor Manette has any
+theory of his own, preserved through all those years, relative to
+the cause of his being so oppressed; perhaps, even to the name of his
+oppressor?”
+
+“I don’t suppose anything about it but what Ladybird tells me.”
+
+“And that is--?”
+
+“That she thinks he has.”
+
+“Now don’t be angry at my asking all these questions; because I am a
+mere dull man of business, and you are a woman of business.”
+
+“Dull?” Miss Pross inquired, with placidity.
+
+Rather wishing his modest adjective away, Mr. Lorry replied, “No, no,
+no. Surely not. To return to business:--Is it not remarkable that Doctor
+Manette, unquestionably innocent of any crime as we are all well assured
+he is, should never touch upon that question? I will not say with me,
+though he had business relations with me many years ago, and we are now
+intimate; I will say with the fair daughter to whom he is so devotedly
+attached, and who is so devotedly attached to him? Believe me, Miss
+Pross, I don’t approach the topic with you, out of curiosity, but out of
+zealous interest.”
+
+“Well! To the best of my understanding, and bad’s the best, you’ll tell
+me,” said Miss Pross, softened by the tone of the apology, “he is afraid
+of the whole subject.”
+
+“Afraid?”
+
+“It’s plain enough, I should think, why he may be. It’s a dreadful
+remembrance. Besides that, his loss of himself grew out of it. Not
+knowing how he lost himself, or how he recovered himself, he may never
+feel certain of not losing himself again. That alone wouldn’t make the
+subject pleasant, I should think.”
+
+It was a profounder remark than Mr. Lorry had looked for. “True,” said
+he, “and fearful to reflect upon. Yet, a doubt lurks in my mind, Miss
+Pross, whether it is good for Doctor Manette to have that suppression
+always shut up within him. Indeed, it is this doubt and the uneasiness
+it sometimes causes me that has led me to our present confidence.”
+
+“Can’t be helped,” said Miss Pross, shaking her head. “Touch that
+string, and he instantly changes for the worse. Better leave it alone.
+In short, must leave it alone, like or no like. Sometimes, he gets up in
+the dead of the night, and will be heard, by us overhead there, walking
+up and down, walking up and down, in his room. Ladybird has learnt to
+know then that his mind is walking up and down, walking up and down, in
+his old prison. She hurries to him, and they go on together, walking up
+and down, walking up and down, until he is composed. But he never says
+a word of the true reason of his restlessness, to her, and she finds it
+best not to hint at it to him. In silence they go walking up and down
+together, walking up and down together, till her love and company have
+brought him to himself.”
+
+Notwithstanding Miss Pross’s denial of her own imagination, there was a
+perception of the pain of being monotonously haunted by one sad idea,
+in her repetition of the phrase, walking up and down, which testified to
+her possessing such a thing.
+
+The corner has been mentioned as a wonderful corner for echoes; it
+had begun to echo so resoundingly to the tread of coming feet, that it
+seemed as though the very mention of that weary pacing to and fro had
+set it going.
+
+“Here they are!” said Miss Pross, rising to break up the conference;
+“and now we shall have hundreds of people pretty soon!”
+
+It was such a curious corner in its acoustical properties, such a
+peculiar Ear of a place, that as Mr. Lorry stood at the open window,
+looking for the father and daughter whose steps he heard, he fancied
+they would never approach. Not only would the echoes die away, as though
+the steps had gone; but, echoes of other steps that never came would be
+heard in their stead, and would die away for good when they seemed close
+at hand. However, father and daughter did at last appear, and Miss Pross
+was ready at the street door to receive them.
+
+Miss Pross was a pleasant sight, albeit wild, and red, and grim, taking
+off her darling’s bonnet when she came up-stairs, and touching it up
+with the ends of her handkerchief, and blowing the dust off it, and
+folding her mantle ready for laying by, and smoothing her rich hair with
+as much pride as she could possibly have taken in her own hair if she
+had been the vainest and handsomest of women. Her darling was a pleasant
+sight too, embracing her and thanking her, and protesting against
+her taking so much trouble for her--which last she only dared to do
+playfully, or Miss Pross, sorely hurt, would have retired to her own
+chamber and cried. The Doctor was a pleasant sight too, looking on at
+them, and telling Miss Pross how she spoilt Lucie, in accents and with
+eyes that had as much spoiling in them as Miss Pross had, and would
+have had more if it were possible. Mr. Lorry was a pleasant sight too,
+beaming at all this in his little wig, and thanking his bachelor
+stars for having lighted him in his declining years to a Home. But, no
+Hundreds of people came to see the sights, and Mr. Lorry looked in vain
+for the fulfilment of Miss Pross’s prediction.
+
+Dinner-time, and still no Hundreds of people. In the arrangements of
+the little household, Miss Pross took charge of the lower regions, and
+always acquitted herself marvellously. Her dinners, of a very modest
+quality, were so well cooked and so well served, and so neat in their
+contrivances, half English and half French, that nothing could be
+better. Miss Pross’s friendship being of the thoroughly practical
+kind, she had ravaged Soho and the adjacent provinces, in search of
+impoverished French, who, tempted by shillings and half-crowns, would
+impart culinary mysteries to her. From these decayed sons and daughters
+of Gaul, she had acquired such wonderful arts, that the woman and girl
+who formed the staff of domestics regarded her as quite a Sorceress,
+or Cinderella’s Godmother: who would send out for a fowl, a rabbit,
+a vegetable or two from the garden, and change them into anything she
+pleased.
+
+On Sundays, Miss Pross dined at the Doctor’s table, but on other days
+persisted in taking her meals at unknown periods, either in the lower
+regions, or in her own room on the second floor--a blue chamber, to
+which no one but her Ladybird ever gained admittance. On this occasion,
+Miss Pross, responding to Ladybird’s pleasant face and pleasant efforts
+to please her, unbent exceedingly; so the dinner was very pleasant, too.
+
+It was an oppressive day, and, after dinner, Lucie proposed that the
+wine should be carried out under the plane-tree, and they should sit
+there in the air. As everything turned upon her, and revolved about her,
+they went out under the plane-tree, and she carried the wine down for
+the special benefit of Mr. Lorry. She had installed herself, some
+time before, as Mr. Lorry’s cup-bearer; and while they sat under the
+plane-tree, talking, she kept his glass replenished. Mysterious backs
+and ends of houses peeped at them as they talked, and the plane-tree
+whispered to them in its own way above their heads.
+
+Still, the Hundreds of people did not present themselves. Mr. Darnay
+presented himself while they were sitting under the plane-tree, but he
+was only One.
+
+Doctor Manette received him kindly, and so did Lucie. But, Miss Pross
+suddenly became afflicted with a twitching in the head and body, and
+retired into the house. She was not unfrequently the victim of this
+disorder, and she called it, in familiar conversation, “a fit of the
+jerks.”
+
+The Doctor was in his best condition, and looked specially young. The
+resemblance between him and Lucie was very strong at such times, and as
+they sat side by side, she leaning on his shoulder, and he resting
+his arm on the back of her chair, it was very agreeable to trace the
+likeness.
+
+He had been talking all day, on many subjects, and with unusual
+vivacity. “Pray, Doctor Manette,” said Mr. Darnay, as they sat under the
+plane-tree--and he said it in the natural pursuit of the topic in hand,
+which happened to be the old buildings of London--“have you seen much of
+the Tower?”
+
+“Lucie and I have been there; but only casually. We have seen enough of
+it, to know that it teems with interest; little more.”
+
+“_I_ have been there, as you remember,” said Darnay, with a smile,
+though reddening a little angrily, “in another character, and not in a
+character that gives facilities for seeing much of it. They told me a
+curious thing when I was there.”
+
+“What was that?” Lucie asked.
+
+“In making some alterations, the workmen came upon an old dungeon, which
+had been, for many years, built up and forgotten. Every stone of
+its inner wall was covered by inscriptions which had been carved by
+prisoners--dates, names, complaints, and prayers. Upon a corner stone
+in an angle of the wall, one prisoner, who seemed to have gone to
+execution, had cut as his last work, three letters. They were done with
+some very poor instrument, and hurriedly, with an unsteady hand.
+At first, they were read as D. I. C.; but, on being more carefully
+examined, the last letter was found to be G. There was no record or
+legend of any prisoner with those initials, and many fruitless guesses
+were made what the name could have been. At length, it was suggested
+that the letters were not initials, but the complete word, DIG. The
+floor was examined very carefully under the inscription, and, in the
+earth beneath a stone, or tile, or some fragment of paving, were found
+the ashes of a paper, mingled with the ashes of a small leathern case
+or bag. What the unknown prisoner had written will never be read, but he
+had written something, and hidden it away to keep it from the gaoler.”
+
+“My father,” exclaimed Lucie, “you are ill!”
+
+He had suddenly started up, with his hand to his head. His manner and
+his look quite terrified them all.
+
+“No, my dear, not ill. There are large drops of rain falling, and they
+made me start. We had better go in.”
+
+He recovered himself almost instantly. Rain was really falling in large
+drops, and he showed the back of his hand with rain-drops on it. But, he
+said not a single word in reference to the discovery that had been told
+of, and, as they went into the house, the business eye of Mr. Lorry
+either detected, or fancied it detected, on his face, as it turned
+towards Charles Darnay, the same singular look that had been upon it
+when it turned towards him in the passages of the Court House.
+
+He recovered himself so quickly, however, that Mr. Lorry had doubts of
+his business eye. The arm of the golden giant in the hall was not more
+steady than he was, when he stopped under it to remark to them that he
+was not yet proof against slight surprises (if he ever would be), and
+that the rain had startled him.
+
+Tea-time, and Miss Pross making tea, with another fit of the jerks upon
+her, and yet no Hundreds of people. Mr. Carton had lounged in, but he
+made only Two.
+
+The night was so very sultry, that although they sat with doors and
+windows open, they were overpowered by heat. When the tea-table was
+done with, they all moved to one of the windows, and looked out into the
+heavy twilight. Lucie sat by her father; Darnay sat beside her; Carton
+leaned against a window. The curtains were long and white, and some of
+the thunder-gusts that whirled into the corner, caught them up to the
+ceiling, and waved them like spectral wings.
+
+“The rain-drops are still falling, large, heavy, and few,” said Doctor
+Manette. “It comes slowly.”
+
+“It comes surely,” said Carton.
+
+They spoke low, as people watching and waiting mostly do; as people in a
+dark room, watching and waiting for Lightning, always do.
+
+There was a great hurry in the streets of people speeding away to
+get shelter before the storm broke; the wonderful corner for echoes
+resounded with the echoes of footsteps coming and going, yet not a
+footstep was there.
+
+“A multitude of people, and yet a solitude!” said Darnay, when they had
+listened for a while.
+
+“Is it not impressive, Mr. Darnay?” asked Lucie. “Sometimes, I have
+sat here of an evening, until I have fancied--but even the shade of
+a foolish fancy makes me shudder to-night, when all is so black and
+solemn--”
+
+“Let us shudder too. We may know what it is.”
+
+“It will seem nothing to you. Such whims are only impressive as we
+originate them, I think; they are not to be communicated. I have
+sometimes sat alone here of an evening, listening, until I have made
+the echoes out to be the echoes of all the footsteps that are coming
+by-and-bye into our lives.”
+
+“There is a great crowd coming one day into our lives, if that be so,”
+ Sydney Carton struck in, in his moody way.
+
+The footsteps were incessant, and the hurry of them became more and more
+rapid. The corner echoed and re-echoed with the tread of feet; some,
+as it seemed, under the windows; some, as it seemed, in the room; some
+coming, some going, some breaking off, some stopping altogether; all in
+the distant streets, and not one within sight.
+
+“Are all these footsteps destined to come to all of us, Miss Manette, or
+are we to divide them among us?”
+
+“I don’t know, Mr. Darnay; I told you it was a foolish fancy, but you
+asked for it. When I have yielded myself to it, I have been alone, and
+then I have imagined them the footsteps of the people who are to come
+into my life, and my father’s.”
+
+“I take them into mine!” said Carton. “_I_ ask no questions and make no
+stipulations. There is a great crowd bearing down upon us, Miss Manette,
+and I see them--by the Lightning.” He added the last words, after there
+had been a vivid flash which had shown him lounging in the window.
+
+“And I hear them!” he added again, after a peal of thunder. “Here they
+come, fast, fierce, and furious!”
+
+It was the rush and roar of rain that he typified, and it stopped him,
+for no voice could be heard in it. A memorable storm of thunder and
+lightning broke with that sweep of water, and there was not a moment’s
+interval in crash, and fire, and rain, until after the moon rose at
+midnight.
+
+The great bell of Saint Paul’s was striking one in the cleared air, when
+Mr. Lorry, escorted by Jerry, high-booted and bearing a lantern, set
+forth on his return-passage to Clerkenwell. There were solitary patches
+of road on the way between Soho and Clerkenwell, and Mr. Lorry, mindful
+of foot-pads, always retained Jerry for this service: though it was
+usually performed a good two hours earlier.
+
+“What a night it has been! Almost a night, Jerry,” said Mr. Lorry, “to
+bring the dead out of their graves.”
+
+“I never see the night myself, master--nor yet I don’t expect to--what
+would do that,” answered Jerry.
+
+“Good night, Mr. Carton,” said the man of business. “Good night, Mr.
+Darnay. Shall we ever see such a night again, together!”
+
+Perhaps. Perhaps, see the great crowd of people with its rush and roar,
+bearing down upon them, too.
+
+
+
+
+VII. Monseigneur in Town
+
+
+Monseigneur, one of the great lords in power at the Court, held his
+fortnightly reception in his grand hotel in Paris. Monseigneur was in
+his inner room, his sanctuary of sanctuaries, the Holiest of Holiests to
+the crowd of worshippers in the suite of rooms without. Monseigneur
+was about to take his chocolate. Monseigneur could swallow a great many
+things with ease, and was by some few sullen minds supposed to be rather
+rapidly swallowing France; but, his morning’s chocolate could not so
+much as get into the throat of Monseigneur, without the aid of four
+strong men besides the Cook.
+
+Yes. It took four men, all four ablaze with gorgeous decoration, and the
+Chief of them unable to exist with fewer than two gold watches in his
+pocket, emulative of the noble and chaste fashion set by Monseigneur, to
+conduct the happy chocolate to Monseigneur’s lips. One lacquey carried
+the chocolate-pot into the sacred presence; a second, milled and frothed
+the chocolate with the little instrument he bore for that function;
+a third, presented the favoured napkin; a fourth (he of the two gold
+watches), poured the chocolate out. It was impossible for Monseigneur to
+dispense with one of these attendants on the chocolate and hold his high
+place under the admiring Heavens. Deep would have been the blot upon
+his escutcheon if his chocolate had been ignobly waited on by only three
+men; he must have died of two.
+
+Monseigneur had been out at a little supper last night, where the Comedy
+and the Grand Opera were charmingly represented. Monseigneur was out at
+a little supper most nights, with fascinating company. So polite and so
+impressible was Monseigneur, that the Comedy and the Grand Opera had far
+more influence with him in the tiresome articles of state affairs and
+state secrets, than the needs of all France. A happy circumstance
+for France, as the like always is for all countries similarly
+favoured!--always was for England (by way of example), in the regretted
+days of the merry Stuart who sold it.
+
+Monseigneur had one truly noble idea of general public business, which
+was, to let everything go on in its own way; of particular public
+business, Monseigneur had the other truly noble idea that it must all go
+his way--tend to his own power and pocket. Of his pleasures, general and
+particular, Monseigneur had the other truly noble idea, that the world
+was made for them. The text of his order (altered from the original
+by only a pronoun, which is not much) ran: “The earth and the fulness
+thereof are mine, saith Monseigneur.”
+
+Yet, Monseigneur had slowly found that vulgar embarrassments crept into
+his affairs, both private and public; and he had, as to both classes of
+affairs, allied himself perforce with a Farmer-General. As to finances
+public, because Monseigneur could not make anything at all of them, and
+must consequently let them out to somebody who could; as to finances
+private, because Farmer-Generals were rich, and Monseigneur, after
+generations of great luxury and expense, was growing poor. Hence
+Monseigneur had taken his sister from a convent, while there was yet
+time to ward off the impending veil, the cheapest garment she could
+wear, and had bestowed her as a prize upon a very rich Farmer-General,
+poor in family. Which Farmer-General, carrying an appropriate cane with
+a golden apple on the top of it, was now among the company in the outer
+rooms, much prostrated before by mankind--always excepting superior
+mankind of the blood of Monseigneur, who, his own wife included, looked
+down upon him with the loftiest contempt.
+
+A sumptuous man was the Farmer-General. Thirty horses stood in his
+stables, twenty-four male domestics sat in his halls, six body-women
+waited on his wife. As one who pretended to do nothing but plunder and
+forage where he could, the Farmer-General--howsoever his matrimonial
+relations conduced to social morality--was at least the greatest reality
+among the personages who attended at the hotel of Monseigneur that day.
+
+For, the rooms, though a beautiful scene to look at, and adorned with
+every device of decoration that the taste and skill of the time could
+achieve, were, in truth, not a sound business; considered with any
+reference to the scarecrows in the rags and nightcaps elsewhere (and not
+so far off, either, but that the watching towers of Notre Dame, almost
+equidistant from the two extremes, could see them both), they would
+have been an exceedingly uncomfortable business--if that could have
+been anybody’s business, at the house of Monseigneur. Military officers
+destitute of military knowledge; naval officers with no idea of a ship;
+civil officers without a notion of affairs; brazen ecclesiastics, of the
+worst world worldly, with sensual eyes, loose tongues, and looser lives;
+all totally unfit for their several callings, all lying horribly in
+pretending to belong to them, but all nearly or remotely of the order of
+Monseigneur, and therefore foisted on all public employments from which
+anything was to be got; these were to be told off by the score and the
+score. People not immediately connected with Monseigneur or the State,
+yet equally unconnected with anything that was real, or with lives
+passed in travelling by any straight road to any true earthly end, were
+no less abundant. Doctors who made great fortunes out of dainty remedies
+for imaginary disorders that never existed, smiled upon their courtly
+patients in the ante-chambers of Monseigneur. Projectors who had
+discovered every kind of remedy for the little evils with which the
+State was touched, except the remedy of setting to work in earnest to
+root out a single sin, poured their distracting babble into any ears
+they could lay hold of, at the reception of Monseigneur. Unbelieving
+Philosophers who were remodelling the world with words, and making
+card-towers of Babel to scale the skies with, talked with Unbelieving
+Chemists who had an eye on the transmutation of metals, at this
+wonderful gathering accumulated by Monseigneur. Exquisite gentlemen of
+the finest breeding, which was at that remarkable time--and has been
+since--to be known by its fruits of indifference to every natural
+subject of human interest, were in the most exemplary state of
+exhaustion, at the hotel of Monseigneur. Such homes had these various
+notabilities left behind them in the fine world of Paris, that the spies
+among the assembled devotees of Monseigneur--forming a goodly half
+of the polite company--would have found it hard to discover among
+the angels of that sphere one solitary wife, who, in her manners and
+appearance, owned to being a Mother. Indeed, except for the mere act of
+bringing a troublesome creature into this world--which does not go far
+towards the realisation of the name of mother--there was no such thing
+known to the fashion. Peasant women kept the unfashionable babies close,
+and brought them up, and charming grandmammas of sixty dressed and
+supped as at twenty.
+
+The leprosy of unreality disfigured every human creature in attendance
+upon Monseigneur. In the outermost room were half a dozen exceptional
+people who had had, for a few years, some vague misgiving in them that
+things in general were going rather wrong. As a promising way of setting
+them right, half of the half-dozen had become members of a fantastic
+sect of Convulsionists, and were even then considering within themselves
+whether they should foam, rage, roar, and turn cataleptic on the
+spot--thereby setting up a highly intelligible finger-post to the
+Future, for Monseigneur’s guidance. Besides these Dervishes, were other
+three who had rushed into another sect, which mended matters with a
+jargon about “the Centre of Truth:” holding that Man had got out of the
+Centre of Truth--which did not need much demonstration--but had not got
+out of the Circumference, and that he was to be kept from flying out of
+the Circumference, and was even to be shoved back into the Centre,
+by fasting and seeing of spirits. Among these, accordingly, much
+discoursing with spirits went on--and it did a world of good which never
+became manifest.
+
+But, the comfort was, that all the company at the grand hotel of
+Monseigneur were perfectly dressed. If the Day of Judgment had only been
+ascertained to be a dress day, everybody there would have been eternally
+correct. Such frizzling and powdering and sticking up of hair, such
+delicate complexions artificially preserved and mended, such gallant
+swords to look at, and such delicate honour to the sense of smell, would
+surely keep anything going, for ever and ever. The exquisite gentlemen
+of the finest breeding wore little pendent trinkets that chinked as they
+languidly moved; these golden fetters rang like precious little bells;
+and what with that ringing, and with the rustle of silk and brocade and
+fine linen, there was a flutter in the air that fanned Saint Antoine and
+his devouring hunger far away.
+
+Dress was the one unfailing talisman and charm used for keeping all
+things in their places. Everybody was dressed for a Fancy Ball that
+was never to leave off. From the Palace of the Tuileries, through
+Monseigneur and the whole Court, through the Chambers, the Tribunals
+of Justice, and all society (except the scarecrows), the Fancy Ball
+descended to the Common Executioner: who, in pursuance of the charm, was
+required to officiate “frizzled, powdered, in a gold-laced coat, pumps,
+and white silk stockings.” At the gallows and the wheel--the axe was a
+rarity--Monsieur Paris, as it was the episcopal mode among his brother
+Professors of the provinces, Monsieur Orleans, and the rest, to call
+him, presided in this dainty dress. And who among the company at
+Monseigneur’s reception in that seventeen hundred and eightieth year
+of our Lord, could possibly doubt, that a system rooted in a frizzled
+hangman, powdered, gold-laced, pumped, and white-silk stockinged, would
+see the very stars out!
+
+Monseigneur having eased his four men of their burdens and taken his
+chocolate, caused the doors of the Holiest of Holiests to be thrown
+open, and issued forth. Then, what submission, what cringing and
+fawning, what servility, what abject humiliation! As to bowing down in
+body and spirit, nothing in that way was left for Heaven--which may have
+been one among other reasons why the worshippers of Monseigneur never
+troubled it.
+
+Bestowing a word of promise here and a smile there, a whisper on one
+happy slave and a wave of the hand on another, Monseigneur affably
+passed through his rooms to the remote region of the Circumference of
+Truth. There, Monseigneur turned, and came back again, and so in due
+course of time got himself shut up in his sanctuary by the chocolate
+sprites, and was seen no more.
+
+The show being over, the flutter in the air became quite a little storm,
+and the precious little bells went ringing downstairs. There was soon
+but one person left of all the crowd, and he, with his hat under his arm
+and his snuff-box in his hand, slowly passed among the mirrors on his
+way out.
+
+“I devote you,” said this person, stopping at the last door on his way,
+and turning in the direction of the sanctuary, “to the Devil!”
+
+With that, he shook the snuff from his fingers as if he had shaken the
+dust from his feet, and quietly walked downstairs.
+
+He was a man of about sixty, handsomely dressed, haughty in manner, and
+with a face like a fine mask. A face of a transparent paleness; every
+feature in it clearly defined; one set expression on it. The nose,
+beautifully formed otherwise, was very slightly pinched at the top
+of each nostril. In those two compressions, or dints, the only little
+change that the face ever showed, resided. They persisted in changing
+colour sometimes, and they would be occasionally dilated and contracted
+by something like a faint pulsation; then, they gave a look of
+treachery, and cruelty, to the whole countenance. Examined with
+attention, its capacity of helping such a look was to be found in the
+line of the mouth, and the lines of the orbits of the eyes, being much
+too horizontal and thin; still, in the effect of the face made, it was a
+handsome face, and a remarkable one.
+
+Its owner went downstairs into the courtyard, got into his carriage, and
+drove away. Not many people had talked with him at the reception; he had
+stood in a little space apart, and Monseigneur might have been warmer
+in his manner. It appeared, under the circumstances, rather agreeable
+to him to see the common people dispersed before his horses, and
+often barely escaping from being run down. His man drove as if he were
+charging an enemy, and the furious recklessness of the man brought no
+check into the face, or to the lips, of the master. The complaint had
+sometimes made itself audible, even in that deaf city and dumb age,
+that, in the narrow streets without footways, the fierce patrician
+custom of hard driving endangered and maimed the mere vulgar in a
+barbarous manner. But, few cared enough for that to think of it a second
+time, and, in this matter, as in all others, the common wretches were
+left to get out of their difficulties as they could.
+
+With a wild rattle and clatter, and an inhuman abandonment of
+consideration not easy to be understood in these days, the carriage
+dashed through streets and swept round corners, with women screaming
+before it, and men clutching each other and clutching children out of
+its way. At last, swooping at a street corner by a fountain, one of its
+wheels came to a sickening little jolt, and there was a loud cry from a
+number of voices, and the horses reared and plunged.
+
+But for the latter inconvenience, the carriage probably would not have
+stopped; carriages were often known to drive on, and leave their wounded
+behind, and why not? But the frightened valet had got down in a hurry,
+and there were twenty hands at the horses’ bridles.
+
+“What has gone wrong?” said Monsieur, calmly looking out.
+
+A tall man in a nightcap had caught up a bundle from among the feet of
+the horses, and had laid it on the basement of the fountain, and was
+down in the mud and wet, howling over it like a wild animal.
+
+“Pardon, Monsieur the Marquis!” said a ragged and submissive man, “it is
+a child.”
+
+“Why does he make that abominable noise? Is it his child?”
+
+“Excuse me, Monsieur the Marquis--it is a pity--yes.”
+
+The fountain was a little removed; for the street opened, where it was,
+into a space some ten or twelve yards square. As the tall man suddenly
+got up from the ground, and came running at the carriage, Monsieur the
+Marquis clapped his hand for an instant on his sword-hilt.
+
+“Killed!” shrieked the man, in wild desperation, extending both arms at
+their length above his head, and staring at him. “Dead!”
+
+The people closed round, and looked at Monsieur the Marquis. There was
+nothing revealed by the many eyes that looked at him but watchfulness
+and eagerness; there was no visible menacing or anger. Neither did the
+people say anything; after the first cry, they had been silent, and they
+remained so. The voice of the submissive man who had spoken, was flat
+and tame in its extreme submission. Monsieur the Marquis ran his eyes
+over them all, as if they had been mere rats come out of their holes.
+
+He took out his purse.
+
+“It is extraordinary to me,” said he, “that you people cannot take care
+of yourselves and your children. One or the other of you is for ever in
+the way. How do I know what injury you have done my horses. See! Give
+him that.”
+
+He threw out a gold coin for the valet to pick up, and all the heads
+craned forward that all the eyes might look down at it as it fell. The
+tall man called out again with a most unearthly cry, “Dead!”
+
+He was arrested by the quick arrival of another man, for whom the rest
+made way. On seeing him, the miserable creature fell upon his shoulder,
+sobbing and crying, and pointing to the fountain, where some women were
+stooping over the motionless bundle, and moving gently about it. They
+were as silent, however, as the men.
+
+“I know all, I know all,” said the last comer. “Be a brave man, my
+Gaspard! It is better for the poor little plaything to die so, than to
+live. It has died in a moment without pain. Could it have lived an hour
+as happily?”
+
+“You are a philosopher, you there,” said the Marquis, smiling. “How do
+they call you?”
+
+“They call me Defarge.”
+
+“Of what trade?”
+
+“Monsieur the Marquis, vendor of wine.”
+
+“Pick up that, philosopher and vendor of wine,” said the Marquis,
+throwing him another gold coin, “and spend it as you will. The horses
+there; are they right?”
+
+Without deigning to look at the assemblage a second time, Monsieur the
+Marquis leaned back in his seat, and was just being driven away with the
+air of a gentleman who had accidentally broke some common thing, and had
+paid for it, and could afford to pay for it; when his ease was suddenly
+disturbed by a coin flying into his carriage, and ringing on its floor.
+
+“Hold!” said Monsieur the Marquis. “Hold the horses! Who threw that?”
+
+He looked to the spot where Defarge the vendor of wine had stood, a
+moment before; but the wretched father was grovelling on his face on
+the pavement in that spot, and the figure that stood beside him was the
+figure of a dark stout woman, knitting.
+
+“You dogs!” said the Marquis, but smoothly, and with an unchanged front,
+except as to the spots on his nose: “I would ride over any of you very
+willingly, and exterminate you from the earth. If I knew which rascal
+threw at the carriage, and if that brigand were sufficiently near it, he
+should be crushed under the wheels.”
+
+So cowed was their condition, and so long and hard their experience of
+what such a man could do to them, within the law and beyond it, that not
+a voice, or a hand, or even an eye was raised. Among the men, not one.
+But the woman who stood knitting looked up steadily, and looked the
+Marquis in the face. It was not for his dignity to notice it; his
+contemptuous eyes passed over her, and over all the other rats; and he
+leaned back in his seat again, and gave the word “Go on!”
+
+He was driven on, and other carriages came whirling by in quick
+succession; the Minister, the State-Projector, the Farmer-General, the
+Doctor, the Lawyer, the Ecclesiastic, the Grand Opera, the Comedy, the
+whole Fancy Ball in a bright continuous flow, came whirling by. The rats
+had crept out of their holes to look on, and they remained looking
+on for hours; soldiers and police often passing between them and the
+spectacle, and making a barrier behind which they slunk, and through
+which they peeped. The father had long ago taken up his bundle and
+bidden himself away with it, when the women who had tended the bundle
+while it lay on the base of the fountain, sat there watching the running
+of the water and the rolling of the Fancy Ball--when the one woman who
+had stood conspicuous, knitting, still knitted on with the steadfastness
+of Fate. The water of the fountain ran, the swift river ran, the day ran
+into evening, so much life in the city ran into death according to rule,
+time and tide waited for no man, the rats were sleeping close together
+in their dark holes again, the Fancy Ball was lighted up at supper, all
+things ran their course.
+
+
+
+
+VIII. Monseigneur in the Country
+
+
+A beautiful landscape, with the corn bright in it, but not abundant.
+Patches of poor rye where corn should have been, patches of poor peas
+and beans, patches of most coarse vegetable substitutes for wheat. On
+inanimate nature, as on the men and women who cultivated it, a prevalent
+tendency towards an appearance of vegetating unwillingly--a dejected
+disposition to give up, and wither away.
+
+Monsieur the Marquis in his travelling carriage (which might have been
+lighter), conducted by four post-horses and two postilions, fagged up
+a steep hill. A blush on the countenance of Monsieur the Marquis was
+no impeachment of his high breeding; it was not from within; it was
+occasioned by an external circumstance beyond his control--the setting
+sun.
+
+The sunset struck so brilliantly into the travelling carriage when it
+gained the hill-top, that its occupant was steeped in crimson. “It will
+die out,” said Monsieur the Marquis, glancing at his hands, “directly.”
+
+In effect, the sun was so low that it dipped at the moment. When the
+heavy drag had been adjusted to the wheel, and the carriage slid down
+hill, with a cinderous smell, in a cloud of dust, the red glow departed
+quickly; the sun and the Marquis going down together, there was no glow
+left when the drag was taken off.
+
+But, there remained a broken country, bold and open, a little village
+at the bottom of the hill, a broad sweep and rise beyond it, a
+church-tower, a windmill, a forest for the chase, and a crag with a
+fortress on it used as a prison. Round upon all these darkening objects
+as the night drew on, the Marquis looked, with the air of one who was
+coming near home.
+
+The village had its one poor street, with its poor brewery, poor
+tannery, poor tavern, poor stable-yard for relays of post-horses, poor
+fountain, all usual poor appointments. It had its poor people too. All
+its people were poor, and many of them were sitting at their doors,
+shredding spare onions and the like for supper, while many were at the
+fountain, washing leaves, and grasses, and any such small yieldings of
+the earth that could be eaten. Expressive signs of what made them poor,
+were not wanting; the tax for the state, the tax for the church, the tax
+for the lord, tax local and tax general, were to be paid here and to be
+paid there, according to solemn inscription in the little village, until
+the wonder was, that there was any village left unswallowed.
+
+Few children were to be seen, and no dogs. As to the men and women,
+their choice on earth was stated in the prospect--Life on the lowest
+terms that could sustain it, down in the little village under the mill;
+or captivity and Death in the dominant prison on the crag.
+
+Heralded by a courier in advance, and by the cracking of his postilions’
+whips, which twined snake-like about their heads in the evening air, as
+if he came attended by the Furies, Monsieur the Marquis drew up in
+his travelling carriage at the posting-house gate. It was hard by the
+fountain, and the peasants suspended their operations to look at him.
+He looked at them, and saw in them, without knowing it, the slow
+sure filing down of misery-worn face and figure, that was to make the
+meagreness of Frenchmen an English superstition which should survive the
+truth through the best part of a hundred years.
+
+Monsieur the Marquis cast his eyes over the submissive faces that
+drooped before him, as the like of himself had drooped before
+Monseigneur of the Court--only the difference was, that these faces
+drooped merely to suffer and not to propitiate--when a grizzled mender
+of the roads joined the group.
+
+“Bring me hither that fellow!” said the Marquis to the courier.
+
+The fellow was brought, cap in hand, and the other fellows closed round
+to look and listen, in the manner of the people at the Paris fountain.
+
+“I passed you on the road?”
+
+“Monseigneur, it is true. I had the honour of being passed on the road.”
+
+“Coming up the hill, and at the top of the hill, both?”
+
+“Monseigneur, it is true.”
+
+“What did you look at, so fixedly?”
+
+“Monseigneur, I looked at the man.”
+
+He stooped a little, and with his tattered blue cap pointed under the
+carriage. All his fellows stooped to look under the carriage.
+
+“What man, pig? And why look there?”
+
+“Pardon, Monseigneur; he swung by the chain of the shoe--the drag.”
+
+“Who?” demanded the traveller.
+
+“Monseigneur, the man.”
+
+“May the Devil carry away these idiots! How do you call the man? You
+know all the men of this part of the country. Who was he?”
+
+“Your clemency, Monseigneur! He was not of this part of the country. Of
+all the days of my life, I never saw him.”
+
+“Swinging by the chain? To be suffocated?”
+
+“With your gracious permission, that was the wonder of it, Monseigneur.
+His head hanging over--like this!”
+
+He turned himself sideways to the carriage, and leaned back, with his
+face thrown up to the sky, and his head hanging down; then recovered
+himself, fumbled with his cap, and made a bow.
+
+“What was he like?”
+
+“Monseigneur, he was whiter than the miller. All covered with dust,
+white as a spectre, tall as a spectre!”
+
+The picture produced an immense sensation in the little crowd; but all
+eyes, without comparing notes with other eyes, looked at Monsieur
+the Marquis. Perhaps, to observe whether he had any spectre on his
+conscience.
+
+“Truly, you did well,” said the Marquis, felicitously sensible that such
+vermin were not to ruffle him, “to see a thief accompanying my carriage,
+and not open that great mouth of yours. Bah! Put him aside, Monsieur
+Gabelle!”
+
+Monsieur Gabelle was the Postmaster, and some other taxing functionary
+united; he had come out with great obsequiousness to assist at this
+examination, and had held the examined by the drapery of his arm in an
+official manner.
+
+“Bah! Go aside!” said Monsieur Gabelle.
+
+“Lay hands on this stranger if he seeks to lodge in your village
+to-night, and be sure that his business is honest, Gabelle.”
+
+“Monseigneur, I am flattered to devote myself to your orders.”
+
+“Did he run away, fellow?--where is that Accursed?”
+
+The accursed was already under the carriage with some half-dozen
+particular friends, pointing out the chain with his blue cap. Some
+half-dozen other particular friends promptly hauled him out, and
+presented him breathless to Monsieur the Marquis.
+
+“Did the man run away, Dolt, when we stopped for the drag?”
+
+“Monseigneur, he precipitated himself over the hill-side, head first, as
+a person plunges into the river.”
+
+“See to it, Gabelle. Go on!”
+
+The half-dozen who were peering at the chain were still among the
+wheels, like sheep; the wheels turned so suddenly that they were lucky
+to save their skins and bones; they had very little else to save, or
+they might not have been so fortunate.
+
+The burst with which the carriage started out of the village and up the
+rise beyond, was soon checked by the steepness of the hill. Gradually,
+it subsided to a foot pace, swinging and lumbering upward among the many
+sweet scents of a summer night. The postilions, with a thousand gossamer
+gnats circling about them in lieu of the Furies, quietly mended the
+points to the lashes of their whips; the valet walked by the horses; the
+courier was audible, trotting on ahead into the dull distance.
+
+At the steepest point of the hill there was a little burial-ground,
+with a Cross and a new large figure of Our Saviour on it; it was a poor
+figure in wood, done by some inexperienced rustic carver, but he had
+studied the figure from the life--his own life, maybe--for it was
+dreadfully spare and thin.
+
+To this distressful emblem of a great distress that had long been
+growing worse, and was not at its worst, a woman was kneeling. She
+turned her head as the carriage came up to her, rose quickly, and
+presented herself at the carriage-door.
+
+“It is you, Monseigneur! Monseigneur, a petition.”
+
+With an exclamation of impatience, but with his unchangeable face,
+Monseigneur looked out.
+
+“How, then! What is it? Always petitions!”
+
+“Monseigneur. For the love of the great God! My husband, the forester.”
+
+“What of your husband, the forester? Always the same with you people. He
+cannot pay something?”
+
+“He has paid all, Monseigneur. He is dead.”
+
+“Well! He is quiet. Can I restore him to you?”
+
+“Alas, no, Monseigneur! But he lies yonder, under a little heap of poor
+grass.”
+
+“Well?”
+
+“Monseigneur, there are so many little heaps of poor grass?”
+
+“Again, well?”
+
+She looked an old woman, but was young. Her manner was one of passionate
+grief; by turns she clasped her veinous and knotted hands together
+with wild energy, and laid one of them on the carriage-door--tenderly,
+caressingly, as if it had been a human breast, and could be expected to
+feel the appealing touch.
+
+“Monseigneur, hear me! Monseigneur, hear my petition! My husband died of
+want; so many die of want; so many more will die of want.”
+
+“Again, well? Can I feed them?”
+
+“Monseigneur, the good God knows; but I don’t ask it. My petition is,
+that a morsel of stone or wood, with my husband’s name, may be placed
+over him to show where he lies. Otherwise, the place will be quickly
+forgotten, it will never be found when I am dead of the same malady, I
+shall be laid under some other heap of poor grass. Monseigneur, they
+are so many, they increase so fast, there is so much want. Monseigneur!
+Monseigneur!”
+
+The valet had put her away from the door, the carriage had broken into
+a brisk trot, the postilions had quickened the pace, she was left far
+behind, and Monseigneur, again escorted by the Furies, was rapidly
+diminishing the league or two of distance that remained between him and
+his chateau.
+
+The sweet scents of the summer night rose all around him, and rose, as
+the rain falls, impartially, on the dusty, ragged, and toil-worn group
+at the fountain not far away; to whom the mender of roads, with the aid
+of the blue cap without which he was nothing, still enlarged upon his
+man like a spectre, as long as they could bear it. By degrees, as they
+could bear no more, they dropped off one by one, and lights twinkled
+in little casements; which lights, as the casements darkened, and more
+stars came out, seemed to have shot up into the sky instead of having
+been extinguished.
+
+The shadow of a large high-roofed house, and of many over-hanging trees,
+was upon Monsieur the Marquis by that time; and the shadow was exchanged
+for the light of a flambeau, as his carriage stopped, and the great door
+of his chateau was opened to him.
+
+“Monsieur Charles, whom I expect; is he arrived from England?”
+
+“Monseigneur, not yet.”
+
+
+
+
+IX. The Gorgon’s Head
+
+
+It was a heavy mass of building, that chateau of Monsieur the Marquis,
+with a large stone courtyard before it, and two stone sweeps of
+staircase meeting in a stone terrace before the principal door. A stony
+business altogether, with heavy stone balustrades, and stone urns, and
+stone flowers, and stone faces of men, and stone heads of lions, in
+all directions. As if the Gorgon’s head had surveyed it, when it was
+finished, two centuries ago.
+
+Up the broad flight of shallow steps, Monsieur the Marquis, flambeau
+preceded, went from his carriage, sufficiently disturbing the darkness
+to elicit loud remonstrance from an owl in the roof of the great pile
+of stable building away among the trees. All else was so quiet, that the
+flambeau carried up the steps, and the other flambeau held at the great
+door, burnt as if they were in a close room of state, instead of being
+in the open night-air. Other sound than the owl’s voice there was none,
+save the falling of a fountain into its stone basin; for, it was one of
+those dark nights that hold their breath by the hour together, and then
+heave a long low sigh, and hold their breath again.
+
+The great door clanged behind him, and Monsieur the Marquis crossed a
+hall grim with certain old boar-spears, swords, and knives of the chase;
+grimmer with certain heavy riding-rods and riding-whips, of which many a
+peasant, gone to his benefactor Death, had felt the weight when his lord
+was angry.
+
+Avoiding the larger rooms, which were dark and made fast for the night,
+Monsieur the Marquis, with his flambeau-bearer going on before, went up
+the staircase to a door in a corridor. This thrown open, admitted him
+to his own private apartment of three rooms: his bed-chamber and two
+others. High vaulted rooms with cool uncarpeted floors, great dogs upon
+the hearths for the burning of wood in winter time, and all luxuries
+befitting the state of a marquis in a luxurious age and country.
+The fashion of the last Louis but one, of the line that was never to
+break--the fourteenth Louis--was conspicuous in their rich furniture;
+but, it was diversified by many objects that were illustrations of old
+pages in the history of France.
+
+A supper-table was laid for two, in the third of the rooms; a round
+room, in one of the chateau’s four extinguisher-topped towers. A small
+lofty room, with its window wide open, and the wooden jalousie-blinds
+closed, so that the dark night only showed in slight horizontal lines of
+black, alternating with their broad lines of stone colour.
+
+“My nephew,” said the Marquis, glancing at the supper preparation; “they
+said he was not arrived.”
+
+Nor was he; but, he had been expected with Monseigneur.
+
+“Ah! It is not probable he will arrive to-night; nevertheless, leave the
+table as it is. I shall be ready in a quarter of an hour.”
+
+In a quarter of an hour Monseigneur was ready, and sat down alone to his
+sumptuous and choice supper. His chair was opposite to the window, and
+he had taken his soup, and was raising his glass of Bordeaux to his
+lips, when he put it down.
+
+“What is that?” he calmly asked, looking with attention at the
+horizontal lines of black and stone colour.
+
+“Monseigneur? That?”
+
+“Outside the blinds. Open the blinds.”
+
+It was done.
+
+“Well?”
+
+“Monseigneur, it is nothing. The trees and the night are all that are
+here.”
+
+The servant who spoke, had thrown the blinds wide, had looked out into
+the vacant darkness, and stood with that blank behind him, looking round
+for instructions.
+
+“Good,” said the imperturbable master. “Close them again.”
+
+That was done too, and the Marquis went on with his supper. He was
+half way through it, when he again stopped with his glass in his hand,
+hearing the sound of wheels. It came on briskly, and came up to the
+front of the chateau.
+
+“Ask who is arrived.”
+
+It was the nephew of Monseigneur. He had been some few leagues behind
+Monseigneur, early in the afternoon. He had diminished the distance
+rapidly, but not so rapidly as to come up with Monseigneur on the road.
+He had heard of Monseigneur, at the posting-houses, as being before him.
+
+He was to be told (said Monseigneur) that supper awaited him then and
+there, and that he was prayed to come to it. In a little while he came.
+He had been known in England as Charles Darnay.
+
+Monseigneur received him in a courtly manner, but they did not shake
+hands.
+
+“You left Paris yesterday, sir?” he said to Monseigneur, as he took his
+seat at table.
+
+“Yesterday. And you?”
+
+“I come direct.”
+
+“From London?”
+
+“Yes.”
+
+“You have been a long time coming,” said the Marquis, with a smile.
+
+“On the contrary; I come direct.”
+
+“Pardon me! I mean, not a long time on the journey; a long time
+intending the journey.”
+
+“I have been detained by”--the nephew stopped a moment in his
+answer--“various business.”
+
+“Without doubt,” said the polished uncle.
+
+So long as a servant was present, no other words passed between them.
+When coffee had been served and they were alone together, the nephew,
+looking at the uncle and meeting the eyes of the face that was like a
+fine mask, opened a conversation.
+
+“I have come back, sir, as you anticipate, pursuing the object that
+took me away. It carried me into great and unexpected peril; but it is
+a sacred object, and if it had carried me to death I hope it would have
+sustained me.”
+
+“Not to death,” said the uncle; “it is not necessary to say, to death.”
+
+“I doubt, sir,” returned the nephew, “whether, if it had carried me to
+the utmost brink of death, you would have cared to stop me there.”
+
+The deepened marks in the nose, and the lengthening of the fine straight
+lines in the cruel face, looked ominous as to that; the uncle made a
+graceful gesture of protest, which was so clearly a slight form of good
+breeding that it was not reassuring.
+
+“Indeed, sir,” pursued the nephew, “for anything I know, you may have
+expressly worked to give a more suspicious appearance to the suspicious
+circumstances that surrounded me.”
+
+“No, no, no,” said the uncle, pleasantly.
+
+“But, however that may be,” resumed the nephew, glancing at him with
+deep distrust, “I know that your diplomacy would stop me by any means,
+and would know no scruple as to means.”
+
+“My friend, I told you so,” said the uncle, with a fine pulsation in the
+two marks. “Do me the favour to recall that I told you so, long ago.”
+
+“I recall it.”
+
+“Thank you,” said the Marquis--very sweetly indeed.
+
+His tone lingered in the air, almost like the tone of a musical
+instrument.
+
+“In effect, sir,” pursued the nephew, “I believe it to be at once your
+bad fortune, and my good fortune, that has kept me out of a prison in
+France here.”
+
+“I do not quite understand,” returned the uncle, sipping his coffee.
+“Dare I ask you to explain?”
+
+“I believe that if you were not in disgrace with the Court, and had not
+been overshadowed by that cloud for years past, a letter de cachet would
+have sent me to some fortress indefinitely.”
+
+“It is possible,” said the uncle, with great calmness. “For the honour
+of the family, I could even resolve to incommode you to that extent.
+Pray excuse me!”
+
+“I perceive that, happily for me, the Reception of the day before
+yesterday was, as usual, a cold one,” observed the nephew.
+
+“I would not say happily, my friend,” returned the uncle, with refined
+politeness; “I would not be sure of that. A good opportunity for
+consideration, surrounded by the advantages of solitude, might influence
+your destiny to far greater advantage than you influence it for
+yourself. But it is useless to discuss the question. I am, as you say,
+at a disadvantage. These little instruments of correction, these gentle
+aids to the power and honour of families, these slight favours that
+might so incommode you, are only to be obtained now by interest
+and importunity. They are sought by so many, and they are granted
+(comparatively) to so few! It used not to be so, but France in all such
+things is changed for the worse. Our not remote ancestors held the right
+of life and death over the surrounding vulgar. From this room, many such
+dogs have been taken out to be hanged; in the next room (my bedroom),
+one fellow, to our knowledge, was poniarded on the spot for professing
+some insolent delicacy respecting his daughter--_his_ daughter? We have
+lost many privileges; a new philosophy has become the mode; and the
+assertion of our station, in these days, might (I do not go so far as
+to say would, but might) cause us real inconvenience. All very bad, very
+bad!”
+
+The Marquis took a gentle little pinch of snuff, and shook his head;
+as elegantly despondent as he could becomingly be of a country still
+containing himself, that great means of regeneration.
+
+“We have so asserted our station, both in the old time and in the modern
+time also,” said the nephew, gloomily, “that I believe our name to be
+more detested than any name in France.”
+
+“Let us hope so,” said the uncle. “Detestation of the high is the
+involuntary homage of the low.”
+
+“There is not,” pursued the nephew, in his former tone, “a face I can
+look at, in all this country round about us, which looks at me with any
+deference on it but the dark deference of fear and slavery.”
+
+“A compliment,” said the Marquis, “to the grandeur of the family,
+merited by the manner in which the family has sustained its grandeur.
+Hah!” And he took another gentle little pinch of snuff, and lightly
+crossed his legs.
+
+But, when his nephew, leaning an elbow on the table, covered his eyes
+thoughtfully and dejectedly with his hand, the fine mask looked at
+him sideways with a stronger concentration of keenness, closeness,
+and dislike, than was comportable with its wearer’s assumption of
+indifference.
+
+“Repression is the only lasting philosophy. The dark deference of fear
+and slavery, my friend,” observed the Marquis, “will keep the dogs
+obedient to the whip, as long as this roof,” looking up to it, “shuts
+out the sky.”
+
+That might not be so long as the Marquis supposed. If a picture of the
+chateau as it was to be a very few years hence, and of fifty like it as
+they too were to be a very few years hence, could have been shown to
+him that night, he might have been at a loss to claim his own from
+the ghastly, fire-charred, plunder-wrecked rains. As for the roof
+he vaunted, he might have found _that_ shutting out the sky in a new
+way--to wit, for ever, from the eyes of the bodies into which its lead
+was fired, out of the barrels of a hundred thousand muskets.
+
+“Meanwhile,” said the Marquis, “I will preserve the honour and repose
+of the family, if you will not. But you must be fatigued. Shall we
+terminate our conference for the night?”
+
+“A moment more.”
+
+“An hour, if you please.”
+
+“Sir,” said the nephew, “we have done wrong, and are reaping the fruits
+of wrong.”
+
+“_We_ have done wrong?” repeated the Marquis, with an inquiring smile,
+and delicately pointing, first to his nephew, then to himself.
+
+“Our family; our honourable family, whose honour is of so much account
+to both of us, in such different ways. Even in my father’s time, we did
+a world of wrong, injuring every human creature who came between us and
+our pleasure, whatever it was. Why need I speak of my father’s time,
+when it is equally yours? Can I separate my father’s twin-brother, joint
+inheritor, and next successor, from himself?”
+
+“Death has done that!” said the Marquis.
+
+“And has left me,” answered the nephew, “bound to a system that is
+frightful to me, responsible for it, but powerless in it; seeking to
+execute the last request of my dear mother’s lips, and obey the last
+look of my dear mother’s eyes, which implored me to have mercy and to
+redress; and tortured by seeking assistance and power in vain.”
+
+“Seeking them from me, my nephew,” said the Marquis, touching him on the
+breast with his forefinger--they were now standing by the hearth--“you
+will for ever seek them in vain, be assured.”
+
+Every fine straight line in the clear whiteness of his face, was
+cruelly, craftily, and closely compressed, while he stood looking
+quietly at his nephew, with his snuff-box in his hand. Once again he
+touched him on the breast, as though his finger were the fine point of
+a small sword, with which, in delicate finesse, he ran him through the
+body, and said,
+
+“My friend, I will die, perpetuating the system under which I have
+lived.”
+
+When he had said it, he took a culminating pinch of snuff, and put his
+box in his pocket.
+
+“Better to be a rational creature,” he added then, after ringing a small
+bell on the table, “and accept your natural destiny. But you are lost,
+Monsieur Charles, I see.”
+
+“This property and France are lost to me,” said the nephew, sadly; “I
+renounce them.”
+
+“Are they both yours to renounce? France may be, but is the property? It
+is scarcely worth mentioning; but, is it yet?”
+
+“I had no intention, in the words I used, to claim it yet. If it passed
+to me from you, to-morrow--”
+
+“Which I have the vanity to hope is not probable.”
+
+“--or twenty years hence--”
+
+“You do me too much honour,” said the Marquis; “still, I prefer that
+supposition.”
+
+“--I would abandon it, and live otherwise and elsewhere. It is little to
+relinquish. What is it but a wilderness of misery and ruin!”
+
+“Hah!” said the Marquis, glancing round the luxurious room.
+
+“To the eye it is fair enough, here; but seen in its integrity,
+under the sky, and by the daylight, it is a crumbling tower of waste,
+mismanagement, extortion, debt, mortgage, oppression, hunger, nakedness,
+and suffering.”
+
+“Hah!” said the Marquis again, in a well-satisfied manner.
+
+“If it ever becomes mine, it shall be put into some hands better
+qualified to free it slowly (if such a thing is possible) from the
+weight that drags it down, so that the miserable people who cannot leave
+it and who have been long wrung to the last point of endurance, may, in
+another generation, suffer less; but it is not for me. There is a curse
+on it, and on all this land.”
+
+“And you?” said the uncle. “Forgive my curiosity; do you, under your new
+philosophy, graciously intend to live?”
+
+“I must do, to live, what others of my countrymen, even with nobility at
+their backs, may have to do some day--work.”
+
+“In England, for example?”
+
+“Yes. The family honour, sir, is safe from me in this country. The
+family name can suffer from me in no other, for I bear it in no other.”
+
+The ringing of the bell had caused the adjoining bed-chamber to be
+lighted. It now shone brightly, through the door of communication. The
+Marquis looked that way, and listened for the retreating step of his
+valet.
+
+“England is very attractive to you, seeing how indifferently you have
+prospered there,” he observed then, turning his calm face to his nephew
+with a smile.
+
+“I have already said, that for my prospering there, I am sensible I may
+be indebted to you, sir. For the rest, it is my Refuge.”
+
+“They say, those boastful English, that it is the Refuge of many. You
+know a compatriot who has found a Refuge there? A Doctor?”
+
+“Yes.”
+
+“With a daughter?”
+
+“Yes.”
+
+“Yes,” said the Marquis. “You are fatigued. Good night!”
+
+As he bent his head in his most courtly manner, there was a secrecy
+in his smiling face, and he conveyed an air of mystery to those words,
+which struck the eyes and ears of his nephew forcibly. At the same
+time, the thin straight lines of the setting of the eyes, and the thin
+straight lips, and the markings in the nose, curved with a sarcasm that
+looked handsomely diabolic.
+
+“Yes,” repeated the Marquis. “A Doctor with a daughter. Yes. So
+commences the new philosophy! You are fatigued. Good night!”
+
+It would have been of as much avail to interrogate any stone face
+outside the chateau as to interrogate that face of his. The nephew
+looked at him, in vain, in passing on to the door.
+
+“Good night!” said the uncle. “I look to the pleasure of seeing you
+again in the morning. Good repose! Light Monsieur my nephew to his
+chamber there!--And burn Monsieur my nephew in his bed, if you will,” he
+added to himself, before he rang his little bell again, and summoned his
+valet to his own bedroom.
+
+The valet come and gone, Monsieur the Marquis walked to and fro in his
+loose chamber-robe, to prepare himself gently for sleep, that hot still
+night. Rustling about the room, his softly-slippered feet making no
+noise on the floor, he moved like a refined tiger:--looked like some
+enchanted marquis of the impenitently wicked sort, in story, whose
+periodical change into tiger form was either just going off, or just
+coming on.
+
+He moved from end to end of his voluptuous bedroom, looking again at the
+scraps of the day’s journey that came unbidden into his mind; the slow
+toil up the hill at sunset, the setting sun, the descent, the mill, the
+prison on the crag, the little village in the hollow, the peasants at
+the fountain, and the mender of roads with his blue cap pointing out the
+chain under the carriage. That fountain suggested the Paris fountain,
+the little bundle lying on the step, the women bending over it, and the
+tall man with his arms up, crying, “Dead!”
+
+“I am cool now,” said Monsieur the Marquis, “and may go to bed.”
+
+So, leaving only one light burning on the large hearth, he let his thin
+gauze curtains fall around him, and heard the night break its silence
+with a long sigh as he composed himself to sleep.
+
+The stone faces on the outer walls stared blindly at the black night
+for three heavy hours; for three heavy hours, the horses in the stables
+rattled at their racks, the dogs barked, and the owl made a noise with
+very little resemblance in it to the noise conventionally assigned to
+the owl by men-poets. But it is the obstinate custom of such creatures
+hardly ever to say what is set down for them.
+
+For three heavy hours, the stone faces of the chateau, lion and human,
+stared blindly at the night. Dead darkness lay on all the landscape,
+dead darkness added its own hush to the hushing dust on all the roads.
+The burial-place had got to the pass that its little heaps of poor grass
+were undistinguishable from one another; the figure on the Cross might
+have come down, for anything that could be seen of it. In the village,
+taxers and taxed were fast asleep. Dreaming, perhaps, of banquets, as
+the starved usually do, and of ease and rest, as the driven slave and
+the yoked ox may, its lean inhabitants slept soundly, and were fed and
+freed.
+
+The fountain in the village flowed unseen and unheard, and the fountain
+at the chateau dropped unseen and unheard--both melting away, like the
+minutes that were falling from the spring of Time--through three dark
+hours. Then, the grey water of both began to be ghostly in the light,
+and the eyes of the stone faces of the chateau were opened.
+
+Lighter and lighter, until at last the sun touched the tops of the still
+trees, and poured its radiance over the hill. In the glow, the water
+of the chateau fountain seemed to turn to blood, and the stone faces
+crimsoned. The carol of the birds was loud and high, and, on the
+weather-beaten sill of the great window of the bed-chamber of Monsieur
+the Marquis, one little bird sang its sweetest song with all its might.
+At this, the nearest stone face seemed to stare amazed, and, with open
+mouth and dropped under-jaw, looked awe-stricken.
+
+Now, the sun was full up, and movement began in the village. Casement
+windows opened, crazy doors were unbarred, and people came forth
+shivering--chilled, as yet, by the new sweet air. Then began the rarely
+lightened toil of the day among the village population. Some, to the
+fountain; some, to the fields; men and women here, to dig and delve; men
+and women there, to see to the poor live stock, and lead the bony cows
+out, to such pasture as could be found by the roadside. In the church
+and at the Cross, a kneeling figure or two; attendant on the latter
+prayers, the led cow, trying for a breakfast among the weeds at its
+foot.
+
+The chateau awoke later, as became its quality, but awoke gradually and
+surely. First, the lonely boar-spears and knives of the chase had been
+reddened as of old; then, had gleamed trenchant in the morning sunshine;
+now, doors and windows were thrown open, horses in their stables looked
+round over their shoulders at the light and freshness pouring in at
+doorways, leaves sparkled and rustled at iron-grated windows, dogs
+pulled hard at their chains, and reared impatient to be loosed.
+
+All these trivial incidents belonged to the routine of life, and the
+return of morning. Surely, not so the ringing of the great bell of the
+chateau, nor the running up and down the stairs; nor the hurried
+figures on the terrace; nor the booting and tramping here and there and
+everywhere, nor the quick saddling of horses and riding away?
+
+What winds conveyed this hurry to the grizzled mender of roads, already
+at work on the hill-top beyond the village, with his day’s dinner (not
+much to carry) lying in a bundle that it was worth no crow’s while to
+peck at, on a heap of stones? Had the birds, carrying some grains of it
+to a distance, dropped one over him as they sow chance seeds? Whether or
+no, the mender of roads ran, on the sultry morning, as if for his life,
+down the hill, knee-high in dust, and never stopped till he got to the
+fountain.
+
+All the people of the village were at the fountain, standing about
+in their depressed manner, and whispering low, but showing no other
+emotions than grim curiosity and surprise. The led cows, hastily brought
+in and tethered to anything that would hold them, were looking stupidly
+on, or lying down chewing the cud of nothing particularly repaying their
+trouble, which they had picked up in their interrupted saunter. Some of
+the people of the chateau, and some of those of the posting-house, and
+all the taxing authorities, were armed more or less, and were crowded
+on the other side of the little street in a purposeless way, that was
+highly fraught with nothing. Already, the mender of roads had penetrated
+into the midst of a group of fifty particular friends, and was smiting
+himself in the breast with his blue cap. What did all this portend,
+and what portended the swift hoisting-up of Monsieur Gabelle behind
+a servant on horseback, and the conveying away of the said Gabelle
+(double-laden though the horse was), at a gallop, like a new version of
+the German ballad of Leonora?
+
+It portended that there was one stone face too many, up at the chateau.
+
+The Gorgon had surveyed the building again in the night, and had added
+the one stone face wanting; the stone face for which it had waited
+through about two hundred years.
+
+It lay back on the pillow of Monsieur the Marquis. It was like a fine
+mask, suddenly startled, made angry, and petrified. Driven home into the
+heart of the stone figure attached to it, was a knife. Round its hilt
+was a frill of paper, on which was scrawled:
+
+“Drive him fast to his tomb. This, from Jacques.”
+
+
+
+
+X. Two Promises
+
+
+More months, to the number of twelve, had come and gone, and Mr. Charles
+Darnay was established in England as a higher teacher of the French
+language who was conversant with French literature. In this age, he
+would have been a Professor; in that age, he was a Tutor. He read with
+young men who could find any leisure and interest for the study of a
+living tongue spoken all over the world, and he cultivated a taste for
+its stores of knowledge and fancy. He could write of them, besides, in
+sound English, and render them into sound English. Such masters were not
+at that time easily found; Princes that had been, and Kings that were
+to be, were not yet of the Teacher class, and no ruined nobility had
+dropped out of Tellson’s ledgers, to turn cooks and carpenters. As a
+tutor, whose attainments made the student’s way unusually pleasant and
+profitable, and as an elegant translator who brought something to his
+work besides mere dictionary knowledge, young Mr. Darnay soon became
+known and encouraged. He was well acquainted, more-over, with the
+circumstances of his country, and those were of ever-growing interest.
+So, with great perseverance and untiring industry, he prospered.
+
+In London, he had expected neither to walk on pavements of gold, nor
+to lie on beds of roses; if he had had any such exalted expectation, he
+would not have prospered. He had expected labour, and he found it, and
+did it and made the best of it. In this, his prosperity consisted.
+
+A certain portion of his time was passed at Cambridge, where he
+read with undergraduates as a sort of tolerated smuggler who drove a
+contraband trade in European languages, instead of conveying Greek
+and Latin through the Custom-house. The rest of his time he passed in
+London.
+
+Now, from the days when it was always summer in Eden, to these days
+when it is mostly winter in fallen latitudes, the world of a man has
+invariably gone one way--Charles Darnay’s way--the way of the love of a
+woman.
+
+He had loved Lucie Manette from the hour of his danger. He had never
+heard a sound so sweet and dear as the sound of her compassionate voice;
+he had never seen a face so tenderly beautiful, as hers when it was
+confronted with his own on the edge of the grave that had been dug for
+him. But, he had not yet spoken to her on the subject; the assassination
+at the deserted chateau far away beyond the heaving water and the long,
+long, dusty roads--the solid stone chateau which had itself become the
+mere mist of a dream--had been done a year, and he had never yet, by so
+much as a single spoken word, disclosed to her the state of his heart.
+
+That he had his reasons for this, he knew full well. It was again a
+summer day when, lately arrived in London from his college occupation,
+he turned into the quiet corner in Soho, bent on seeking an opportunity
+of opening his mind to Doctor Manette. It was the close of the summer
+day, and he knew Lucie to be out with Miss Pross.
+
+He found the Doctor reading in his arm-chair at a window. The energy
+which had at once supported him under his old sufferings and aggravated
+their sharpness, had been gradually restored to him. He was now a
+very energetic man indeed, with great firmness of purpose, strength
+of resolution, and vigour of action. In his recovered energy he was
+sometimes a little fitful and sudden, as he had at first been in the
+exercise of his other recovered faculties; but, this had never been
+frequently observable, and had grown more and more rare.
+
+He studied much, slept little, sustained a great deal of fatigue with
+ease, and was equably cheerful. To him, now entered Charles Darnay, at
+sight of whom he laid aside his book and held out his hand.
+
+“Charles Darnay! I rejoice to see you. We have been counting on your
+return these three or four days past. Mr. Stryver and Sydney Carton were
+both here yesterday, and both made you out to be more than due.”
+
+“I am obliged to them for their interest in the matter,” he answered,
+a little coldly as to them, though very warmly as to the Doctor. “Miss
+Manette--”
+
+“Is well,” said the Doctor, as he stopped short, “and your return will
+delight us all. She has gone out on some household matters, but will
+soon be home.”
+
+“Doctor Manette, I knew she was from home. I took the opportunity of her
+being from home, to beg to speak to you.”
+
+There was a blank silence.
+
+“Yes?” said the Doctor, with evident constraint. “Bring your chair here,
+and speak on.”
+
+He complied as to the chair, but appeared to find the speaking on less
+easy.
+
+“I have had the happiness, Doctor Manette, of being so intimate here,”
+ so he at length began, “for some year and a half, that I hope the topic
+on which I am about to touch may not--”
+
+He was stayed by the Doctor’s putting out his hand to stop him. When he
+had kept it so a little while, he said, drawing it back:
+
+“Is Lucie the topic?”
+
+“She is.”
+
+“It is hard for me to speak of her at any time. It is very hard for me
+to hear her spoken of in that tone of yours, Charles Darnay.”
+
+“It is a tone of fervent admiration, true homage, and deep love, Doctor
+Manette!” he said deferentially.
+
+There was another blank silence before her father rejoined:
+
+“I believe it. I do you justice; I believe it.”
+
+His constraint was so manifest, and it was so manifest, too, that it
+originated in an unwillingness to approach the subject, that Charles
+Darnay hesitated.
+
+“Shall I go on, sir?”
+
+Another blank.
+
+“Yes, go on.”
+
+“You anticipate what I would say, though you cannot know how earnestly
+I say it, how earnestly I feel it, without knowing my secret heart, and
+the hopes and fears and anxieties with which it has long been
+laden. Dear Doctor Manette, I love your daughter fondly, dearly,
+disinterestedly, devotedly. If ever there were love in the world, I love
+her. You have loved yourself; let your old love speak for me!”
+
+The Doctor sat with his face turned away, and his eyes bent on the
+ground. At the last words, he stretched out his hand again, hurriedly,
+and cried:
+
+“Not that, sir! Let that be! I adjure you, do not recall that!”
+
+His cry was so like a cry of actual pain, that it rang in Charles
+Darnay’s ears long after he had ceased. He motioned with the hand he had
+extended, and it seemed to be an appeal to Darnay to pause. The latter
+so received it, and remained silent.
+
+“I ask your pardon,” said the Doctor, in a subdued tone, after some
+moments. “I do not doubt your loving Lucie; you may be satisfied of it.”
+
+He turned towards him in his chair, but did not look at him, or
+raise his eyes. His chin dropped upon his hand, and his white hair
+overshadowed his face:
+
+“Have you spoken to Lucie?”
+
+“No.”
+
+“Nor written?”
+
+“Never.”
+
+“It would be ungenerous to affect not to know that your self-denial is
+to be referred to your consideration for her father. Her father thanks
+you.”
+
+He offered his hand; but his eyes did not go with it.
+
+“I know,” said Darnay, respectfully, “how can I fail to know, Doctor
+Manette, I who have seen you together from day to day, that between
+you and Miss Manette there is an affection so unusual, so touching, so
+belonging to the circumstances in which it has been nurtured, that it
+can have few parallels, even in the tenderness between a father and
+child. I know, Doctor Manette--how can I fail to know--that, mingled
+with the affection and duty of a daughter who has become a woman, there
+is, in her heart, towards you, all the love and reliance of infancy
+itself. I know that, as in her childhood she had no parent, so she is
+now devoted to you with all the constancy and fervour of her present
+years and character, united to the trustfulness and attachment of the
+early days in which you were lost to her. I know perfectly well that if
+you had been restored to her from the world beyond this life, you could
+hardly be invested, in her sight, with a more sacred character than that
+in which you are always with her. I know that when she is clinging to
+you, the hands of baby, girl, and woman, all in one, are round your
+neck. I know that in loving you she sees and loves her mother at her
+own age, sees and loves you at my age, loves her mother broken-hearted,
+loves you through your dreadful trial and in your blessed restoration. I
+have known this, night and day, since I have known you in your home.”
+
+Her father sat silent, with his face bent down. His breathing was a
+little quickened; but he repressed all other signs of agitation.
+
+“Dear Doctor Manette, always knowing this, always seeing her and you
+with this hallowed light about you, I have forborne, and forborne, as
+long as it was in the nature of man to do it. I have felt, and do even
+now feel, that to bring my love--even mine--between you, is to touch
+your history with something not quite so good as itself. But I love her.
+Heaven is my witness that I love her!”
+
+“I believe it,” answered her father, mournfully. “I have thought so
+before now. I believe it.”
+
+“But, do not believe,” said Darnay, upon whose ear the mournful voice
+struck with a reproachful sound, “that if my fortune were so cast as
+that, being one day so happy as to make her my wife, I must at any time
+put any separation between her and you, I could or would breathe a
+word of what I now say. Besides that I should know it to be hopeless, I
+should know it to be a baseness. If I had any such possibility, even at
+a remote distance of years, harboured in my thoughts, and hidden in my
+heart--if it ever had been there--if it ever could be there--I could not
+now touch this honoured hand.”
+
+He laid his own upon it as he spoke.
+
+“No, dear Doctor Manette. Like you, a voluntary exile from France; like
+you, driven from it by its distractions, oppressions, and miseries; like
+you, striving to live away from it by my own exertions, and trusting
+in a happier future; I look only to sharing your fortunes, sharing your
+life and home, and being faithful to you to the death. Not to divide
+with Lucie her privilege as your child, companion, and friend; but to
+come in aid of it, and bind her closer to you, if such a thing can be.”
+
+His touch still lingered on her father’s hand. Answering the touch for a
+moment, but not coldly, her father rested his hands upon the arms of
+his chair, and looked up for the first time since the beginning of the
+conference. A struggle was evidently in his face; a struggle with that
+occasional look which had a tendency in it to dark doubt and dread.
+
+“You speak so feelingly and so manfully, Charles Darnay, that I thank
+you with all my heart, and will open all my heart--or nearly so. Have
+you any reason to believe that Lucie loves you?”
+
+“None. As yet, none.”
+
+“Is it the immediate object of this confidence, that you may at once
+ascertain that, with my knowledge?”
+
+“Not even so. I might not have the hopefulness to do it for weeks; I
+might (mistaken or not mistaken) have that hopefulness to-morrow.”
+
+“Do you seek any guidance from me?”
+
+“I ask none, sir. But I have thought it possible that you might have it
+in your power, if you should deem it right, to give me some.”
+
+“Do you seek any promise from me?”
+
+“I do seek that.”
+
+“What is it?”
+
+“I well understand that, without you, I could have no hope. I well
+understand that, even if Miss Manette held me at this moment in her
+innocent heart--do not think I have the presumption to assume so much--I
+could retain no place in it against her love for her father.”
+
+“If that be so, do you see what, on the other hand, is involved in it?”
+
+“I understand equally well, that a word from her father in any suitor’s
+favour, would outweigh herself and all the world. For which reason,
+Doctor Manette,” said Darnay, modestly but firmly, “I would not ask that
+word, to save my life.”
+
+“I am sure of it. Charles Darnay, mysteries arise out of close love, as
+well as out of wide division; in the former case, they are subtle and
+delicate, and difficult to penetrate. My daughter Lucie is, in this one
+respect, such a mystery to me; I can make no guess at the state of her
+heart.”
+
+“May I ask, sir, if you think she is--” As he hesitated, her father
+supplied the rest.
+
+“Is sought by any other suitor?”
+
+“It is what I meant to say.”
+
+Her father considered a little before he answered:
+
+“You have seen Mr. Carton here, yourself. Mr. Stryver is here too,
+occasionally. If it be at all, it can only be by one of these.”
+
+“Or both,” said Darnay.
+
+“I had not thought of both; I should not think either, likely. You want
+a promise from me. Tell me what it is.”
+
+“It is, that if Miss Manette should bring to you at any time, on her own
+part, such a confidence as I have ventured to lay before you, you will
+bear testimony to what I have said, and to your belief in it. I hope you
+may be able to think so well of me, as to urge no influence against
+me. I say nothing more of my stake in this; this is what I ask. The
+condition on which I ask it, and which you have an undoubted right to
+require, I will observe immediately.”
+
+“I give the promise,” said the Doctor, “without any condition. I believe
+your object to be, purely and truthfully, as you have stated it. I
+believe your intention is to perpetuate, and not to weaken, the ties
+between me and my other and far dearer self. If she should ever tell me
+that you are essential to her perfect happiness, I will give her to you.
+If there were--Charles Darnay, if there were--”
+
+The young man had taken his hand gratefully; their hands were joined as
+the Doctor spoke:
+
+“--any fancies, any reasons, any apprehensions, anything whatsoever,
+new or old, against the man she really loved--the direct responsibility
+thereof not lying on his head--they should all be obliterated for her
+sake. She is everything to me; more to me than suffering, more to me
+than wrong, more to me--Well! This is idle talk.”
+
+So strange was the way in which he faded into silence, and so strange
+his fixed look when he had ceased to speak, that Darnay felt his own
+hand turn cold in the hand that slowly released and dropped it.
+
+“You said something to me,” said Doctor Manette, breaking into a smile.
+“What was it you said to me?”
+
+He was at a loss how to answer, until he remembered having spoken of a
+condition. Relieved as his mind reverted to that, he answered:
+
+“Your confidence in me ought to be returned with full confidence on my
+part. My present name, though but slightly changed from my mother’s, is
+not, as you will remember, my own. I wish to tell you what that is, and
+why I am in England.”
+
+“Stop!” said the Doctor of Beauvais.
+
+“I wish it, that I may the better deserve your confidence, and have no
+secret from you.”
+
+“Stop!”
+
+For an instant, the Doctor even had his two hands at his ears; for
+another instant, even had his two hands laid on Darnay’s lips.
+
+“Tell me when I ask you, not now. If your suit should prosper, if Lucie
+should love you, you shall tell me on your marriage morning. Do you
+promise?”
+
+“Willingly.
+
+“Give me your hand. She will be home directly, and it is better she
+should not see us together to-night. Go! God bless you!”
+
+It was dark when Charles Darnay left him, and it was an hour later and
+darker when Lucie came home; she hurried into the room alone--for
+Miss Pross had gone straight up-stairs--and was surprised to find his
+reading-chair empty.
+
+“My father!” she called to him. “Father dear!”
+
+Nothing was said in answer, but she heard a low hammering sound in his
+bedroom. Passing lightly across the intermediate room, she looked in at
+his door and came running back frightened, crying to herself, with her
+blood all chilled, “What shall I do! What shall I do!”
+
+Her uncertainty lasted but a moment; she hurried back, and tapped at
+his door, and softly called to him. The noise ceased at the sound of
+her voice, and he presently came out to her, and they walked up and down
+together for a long time.
+
+She came down from her bed, to look at him in his sleep that night. He
+slept heavily, and his tray of shoemaking tools, and his old unfinished
+work, were all as usual.
+
+
+
+
+XI. A Companion Picture
+
+
+“Sydney,” said Mr. Stryver, on that self-same night, or morning, to his
+jackal; “mix another bowl of punch; I have something to say to you.”
+
+Sydney had been working double tides that night, and the night before,
+and the night before that, and a good many nights in succession, making
+a grand clearance among Mr. Stryver’s papers before the setting in
+of the long vacation. The clearance was effected at last; the Stryver
+arrears were handsomely fetched up; everything was got rid of until
+November should come with its fogs atmospheric, and fogs legal, and
+bring grist to the mill again.
+
+Sydney was none the livelier and none the soberer for so much
+application. It had taken a deal of extra wet-towelling to pull him
+through the night; a correspondingly extra quantity of wine had preceded
+the towelling; and he was in a very damaged condition, as he now pulled
+his turban off and threw it into the basin in which he had steeped it at
+intervals for the last six hours.
+
+“Are you mixing that other bowl of punch?” said Stryver the portly, with
+his hands in his waistband, glancing round from the sofa where he lay on
+his back.
+
+“I am.”
+
+“Now, look here! I am going to tell you something that will rather
+surprise you, and that perhaps will make you think me not quite as
+shrewd as you usually do think me. I intend to marry.”
+
+“_Do_ you?”
+
+“Yes. And not for money. What do you say now?”
+
+“I don’t feel disposed to say much. Who is she?”
+
+“Guess.”
+
+“Do I know her?”
+
+“Guess.”
+
+“I am not going to guess, at five o’clock in the morning, with my brains
+frying and sputtering in my head. If you want me to guess, you must ask
+me to dinner.”
+
+“Well then, I’ll tell you,” said Stryver, coming slowly into a sitting
+posture. “Sydney, I rather despair of making myself intelligible to you,
+because you are such an insensible dog.”
+
+“And you,” returned Sydney, busy concocting the punch, “are such a
+sensitive and poetical spirit--”
+
+“Come!” rejoined Stryver, laughing boastfully, “though I don’t prefer
+any claim to being the soul of Romance (for I hope I know better), still
+I am a tenderer sort of fellow than _you_.”
+
+“You are a luckier, if you mean that.”
+
+“I don’t mean that. I mean I am a man of more--more--”
+
+“Say gallantry, while you are about it,” suggested Carton.
+
+“Well! I’ll say gallantry. My meaning is that I am a man,” said Stryver,
+inflating himself at his friend as he made the punch, “who cares more to
+be agreeable, who takes more pains to be agreeable, who knows better how
+to be agreeable, in a woman’s society, than you do.”
+
+“Go on,” said Sydney Carton.
+
+“No; but before I go on,” said Stryver, shaking his head in his bullying
+way, “I’ll have this out with you. You’ve been at Doctor Manette’s house
+as much as I have, or more than I have. Why, I have been ashamed of your
+moroseness there! Your manners have been of that silent and sullen and
+hangdog kind, that, upon my life and soul, I have been ashamed of you,
+Sydney!”
+
+“It should be very beneficial to a man in your practice at the bar, to
+be ashamed of anything,” returned Sydney; “you ought to be much obliged
+to me.”
+
+“You shall not get off in that way,” rejoined Stryver, shouldering the
+rejoinder at him; “no, Sydney, it’s my duty to tell you--and I tell you
+to your face to do you good--that you are a devilish ill-conditioned
+fellow in that sort of society. You are a disagreeable fellow.”
+
+Sydney drank a bumper of the punch he had made, and laughed.
+
+“Look at me!” said Stryver, squaring himself; “I have less need to make
+myself agreeable than you have, being more independent in circumstances.
+Why do I do it?”
+
+“I never saw you do it yet,” muttered Carton.
+
+“I do it because it’s politic; I do it on principle. And look at me! I
+get on.”
+
+“You don’t get on with your account of your matrimonial intentions,”
+ answered Carton, with a careless air; “I wish you would keep to that. As
+to me--will you never understand that I am incorrigible?”
+
+He asked the question with some appearance of scorn.
+
+“You have no business to be incorrigible,” was his friend’s answer,
+delivered in no very soothing tone.
+
+“I have no business to be, at all, that I know of,” said Sydney Carton.
+“Who is the lady?”
+
+“Now, don’t let my announcement of the name make you uncomfortable,
+Sydney,” said Mr. Stryver, preparing him with ostentatious friendliness
+for the disclosure he was about to make, “because I know you don’t mean
+half you say; and if you meant it all, it would be of no importance. I
+make this little preface, because you once mentioned the young lady to
+me in slighting terms.”
+
+“I did?”
+
+“Certainly; and in these chambers.”
+
+Sydney Carton looked at his punch and looked at his complacent friend;
+drank his punch and looked at his complacent friend.
+
+“You made mention of the young lady as a golden-haired doll. The young
+lady is Miss Manette. If you had been a fellow of any sensitiveness or
+delicacy of feeling in that kind of way, Sydney, I might have been a
+little resentful of your employing such a designation; but you are not.
+You want that sense altogether; therefore I am no more annoyed when I
+think of the expression, than I should be annoyed by a man’s opinion of
+a picture of mine, who had no eye for pictures: or of a piece of music
+of mine, who had no ear for music.”
+
+Sydney Carton drank the punch at a great rate; drank it by bumpers,
+looking at his friend.
+
+“Now you know all about it, Syd,” said Mr. Stryver. “I don’t care about
+fortune: she is a charming creature, and I have made up my mind to
+please myself: on the whole, I think I can afford to please myself. She
+will have in me a man already pretty well off, and a rapidly rising man,
+and a man of some distinction: it is a piece of good fortune for her,
+but she is worthy of good fortune. Are you astonished?”
+
+Carton, still drinking the punch, rejoined, “Why should I be
+astonished?”
+
+“You approve?”
+
+Carton, still drinking the punch, rejoined, “Why should I not approve?”
+
+“Well!” said his friend Stryver, “you take it more easily than I fancied
+you would, and are less mercenary on my behalf than I thought you would
+be; though, to be sure, you know well enough by this time that your
+ancient chum is a man of a pretty strong will. Yes, Sydney, I have had
+enough of this style of life, with no other as a change from it; I
+feel that it is a pleasant thing for a man to have a home when he feels
+inclined to go to it (when he doesn’t, he can stay away), and I feel
+that Miss Manette will tell well in any station, and will always do me
+credit. So I have made up my mind. And now, Sydney, old boy, I want to
+say a word to _you_ about _your_ prospects. You are in a bad way, you
+know; you really are in a bad way. You don’t know the value of money,
+you live hard, you’ll knock up one of these days, and be ill and poor;
+you really ought to think about a nurse.”
+
+The prosperous patronage with which he said it, made him look twice as
+big as he was, and four times as offensive.
+
+“Now, let me recommend you,” pursued Stryver, “to look it in the face.
+I have looked it in the face, in my different way; look it in the face,
+you, in your different way. Marry. Provide somebody to take care of
+you. Never mind your having no enjoyment of women’s society, nor
+understanding of it, nor tact for it. Find out somebody. Find out some
+respectable woman with a little property--somebody in the landlady way,
+or lodging-letting way--and marry her, against a rainy day. That’s the
+kind of thing for _you_. Now think of it, Sydney.”
+
+“I’ll think of it,” said Sydney.
+
+
+
+
+XII. The Fellow of Delicacy
+
+
+Mr. Stryver having made up his mind to that magnanimous bestowal of good
+fortune on the Doctor’s daughter, resolved to make her happiness known
+to her before he left town for the Long Vacation. After some mental
+debating of the point, he came to the conclusion that it would be as
+well to get all the preliminaries done with, and they could then arrange
+at their leisure whether he should give her his hand a week or two
+before Michaelmas Term, or in the little Christmas vacation between it
+and Hilary.
+
+As to the strength of his case, he had not a doubt about it, but clearly
+saw his way to the verdict. Argued with the jury on substantial worldly
+grounds--the only grounds ever worth taking into account--it was a
+plain case, and had not a weak spot in it. He called himself for the
+plaintiff, there was no getting over his evidence, the counsel for
+the defendant threw up his brief, and the jury did not even turn to
+consider. After trying it, Stryver, C. J., was satisfied that no plainer
+case could be.
+
+Accordingly, Mr. Stryver inaugurated the Long Vacation with a formal
+proposal to take Miss Manette to Vauxhall Gardens; that failing, to
+Ranelagh; that unaccountably failing too, it behoved him to present
+himself in Soho, and there declare his noble mind.
+
+Towards Soho, therefore, Mr. Stryver shouldered his way from the Temple,
+while the bloom of the Long Vacation’s infancy was still upon it.
+Anybody who had seen him projecting himself into Soho while he was yet
+on Saint Dunstan’s side of Temple Bar, bursting in his full-blown way
+along the pavement, to the jostlement of all weaker people, might have
+seen how safe and strong he was.
+
+His way taking him past Tellson’s, and he both banking at Tellson’s and
+knowing Mr. Lorry as the intimate friend of the Manettes, it entered Mr.
+Stryver’s mind to enter the bank, and reveal to Mr. Lorry the brightness
+of the Soho horizon. So, he pushed open the door with the weak rattle
+in its throat, stumbled down the two steps, got past the two ancient
+cashiers, and shouldered himself into the musty back closet where Mr.
+Lorry sat at great books ruled for figures, with perpendicular iron
+bars to his window as if that were ruled for figures too, and everything
+under the clouds were a sum.
+
+“Halloa!” said Mr. Stryver. “How do you do? I hope you are well!”
+
+It was Stryver’s grand peculiarity that he always seemed too big for any
+place, or space. He was so much too big for Tellson’s, that old clerks
+in distant corners looked up with looks of remonstrance, as though he
+squeezed them against the wall. The House itself, magnificently reading
+the paper quite in the far-off perspective, lowered displeased, as if
+the Stryver head had been butted into its responsible waistcoat.
+
+The discreet Mr. Lorry said, in a sample tone of the voice he would
+recommend under the circumstances, “How do you do, Mr. Stryver? How do
+you do, sir?” and shook hands. There was a peculiarity in his manner
+of shaking hands, always to be seen in any clerk at Tellson’s who shook
+hands with a customer when the House pervaded the air. He shook in a
+self-abnegating way, as one who shook for Tellson and Co.
+
+“Can I do anything for you, Mr. Stryver?” asked Mr. Lorry, in his
+business character.
+
+“Why, no, thank you; this is a private visit to yourself, Mr. Lorry; I
+have come for a private word.”
+
+“Oh indeed!” said Mr. Lorry, bending down his ear, while his eye strayed
+to the House afar off.
+
+“I am going,” said Mr. Stryver, leaning his arms confidentially on the
+desk: whereupon, although it was a large double one, there appeared to
+be not half desk enough for him: “I am going to make an offer of myself
+in marriage to your agreeable little friend, Miss Manette, Mr. Lorry.”
+
+“Oh dear me!” cried Mr. Lorry, rubbing his chin, and looking at his
+visitor dubiously.
+
+“Oh dear me, sir?” repeated Stryver, drawing back. “Oh dear you, sir?
+What may your meaning be, Mr. Lorry?”
+
+“My meaning,” answered the man of business, “is, of course, friendly and
+appreciative, and that it does you the greatest credit, and--in short,
+my meaning is everything you could desire. But--really, you know, Mr.
+Stryver--” Mr. Lorry paused, and shook his head at him in the oddest
+manner, as if he were compelled against his will to add, internally,
+“you know there really is so much too much of you!”
+
+“Well!” said Stryver, slapping the desk with his contentious hand,
+opening his eyes wider, and taking a long breath, “if I understand you,
+Mr. Lorry, I’ll be hanged!”
+
+Mr. Lorry adjusted his little wig at both ears as a means towards that
+end, and bit the feather of a pen.
+
+“D--n it all, sir!” said Stryver, staring at him, “am I not eligible?”
+
+“Oh dear yes! Yes. Oh yes, you’re eligible!” said Mr. Lorry. “If you say
+eligible, you are eligible.”
+
+“Am I not prosperous?” asked Stryver.
+
+“Oh! if you come to prosperous, you are prosperous,” said Mr. Lorry.
+
+“And advancing?”
+
+“If you come to advancing you know,” said Mr. Lorry, delighted to be
+able to make another admission, “nobody can doubt that.”
+
+“Then what on earth is your meaning, Mr. Lorry?” demanded Stryver,
+perceptibly crestfallen.
+
+“Well! I--Were you going there now?” asked Mr. Lorry.
+
+“Straight!” said Stryver, with a plump of his fist on the desk.
+
+“Then I think I wouldn’t, if I was you.”
+
+“Why?” said Stryver. “Now, I’ll put you in a corner,” forensically
+shaking a forefinger at him. “You are a man of business and bound to
+have a reason. State your reason. Why wouldn’t you go?”
+
+“Because,” said Mr. Lorry, “I wouldn’t go on such an object without
+having some cause to believe that I should succeed.”
+
+“D--n _me_!” cried Stryver, “but this beats everything.”
+
+Mr. Lorry glanced at the distant House, and glanced at the angry
+Stryver.
+
+“Here’s a man of business--a man of years--a man of experience--_in_
+a Bank,” said Stryver; “and having summed up three leading reasons for
+complete success, he says there’s no reason at all! Says it with his
+head on!” Mr. Stryver remarked upon the peculiarity as if it would have
+been infinitely less remarkable if he had said it with his head off.
+
+“When I speak of success, I speak of success with the young lady; and
+when I speak of causes and reasons to make success probable, I speak of
+causes and reasons that will tell as such with the young lady. The young
+lady, my good sir,” said Mr. Lorry, mildly tapping the Stryver arm, “the
+young lady. The young lady goes before all.”
+
+“Then you mean to tell me, Mr. Lorry,” said Stryver, squaring his
+elbows, “that it is your deliberate opinion that the young lady at
+present in question is a mincing Fool?”
+
+“Not exactly so. I mean to tell you, Mr. Stryver,” said Mr. Lorry,
+reddening, “that I will hear no disrespectful word of that young lady
+from any lips; and that if I knew any man--which I hope I do not--whose
+taste was so coarse, and whose temper was so overbearing, that he could
+not restrain himself from speaking disrespectfully of that young lady at
+this desk, not even Tellson’s should prevent my giving him a piece of my
+mind.”
+
+The necessity of being angry in a suppressed tone had put Mr. Stryver’s
+blood-vessels into a dangerous state when it was his turn to be angry;
+Mr. Lorry’s veins, methodical as their courses could usually be, were in
+no better state now it was his turn.
+
+“That is what I mean to tell you, sir,” said Mr. Lorry. “Pray let there
+be no mistake about it.”
+
+Mr. Stryver sucked the end of a ruler for a little while, and then stood
+hitting a tune out of his teeth with it, which probably gave him the
+toothache. He broke the awkward silence by saying:
+
+“This is something new to me, Mr. Lorry. You deliberately advise me not
+to go up to Soho and offer myself--_my_self, Stryver of the King’s Bench
+bar?”
+
+“Do you ask me for my advice, Mr. Stryver?”
+
+“Yes, I do.”
+
+“Very good. Then I give it, and you have repeated it correctly.”
+
+“And all I can say of it is,” laughed Stryver with a vexed laugh, “that
+this--ha, ha!--beats everything past, present, and to come.”
+
+“Now understand me,” pursued Mr. Lorry. “As a man of business, I am
+not justified in saying anything about this matter, for, as a man of
+business, I know nothing of it. But, as an old fellow, who has carried
+Miss Manette in his arms, who is the trusted friend of Miss Manette and
+of her father too, and who has a great affection for them both, I have
+spoken. The confidence is not of my seeking, recollect. Now, you think I
+may not be right?”
+
+“Not I!” said Stryver, whistling. “I can’t undertake to find third
+parties in common sense; I can only find it for myself. I suppose sense
+in certain quarters; you suppose mincing bread-and-butter nonsense. It’s
+new to me, but you are right, I dare say.”
+
+“What I suppose, Mr. Stryver, I claim to characterise for myself--And
+understand me, sir,” said Mr. Lorry, quickly flushing again, “I
+will not--not even at Tellson’s--have it characterised for me by any
+gentleman breathing.”
+
+“There! I beg your pardon!” said Stryver.
+
+“Granted. Thank you. Well, Mr. Stryver, I was about to say:--it might be
+painful to you to find yourself mistaken, it might be painful to Doctor
+Manette to have the task of being explicit with you, it might be very
+painful to Miss Manette to have the task of being explicit with you. You
+know the terms upon which I have the honour and happiness to stand with
+the family. If you please, committing you in no way, representing you
+in no way, I will undertake to correct my advice by the exercise of a
+little new observation and judgment expressly brought to bear upon
+it. If you should then be dissatisfied with it, you can but test its
+soundness for yourself; if, on the other hand, you should be satisfied
+with it, and it should be what it now is, it may spare all sides what is
+best spared. What do you say?”
+
+“How long would you keep me in town?”
+
+“Oh! It is only a question of a few hours. I could go to Soho in the
+evening, and come to your chambers afterwards.”
+
+“Then I say yes,” said Stryver: “I won’t go up there now, I am not so
+hot upon it as that comes to; I say yes, and I shall expect you to look
+in to-night. Good morning.”
+
+Then Mr. Stryver turned and burst out of the Bank, causing such a
+concussion of air on his passage through, that to stand up against it
+bowing behind the two counters, required the utmost remaining strength
+of the two ancient clerks. Those venerable and feeble persons were
+always seen by the public in the act of bowing, and were popularly
+believed, when they had bowed a customer out, still to keep on bowing in
+the empty office until they bowed another customer in.
+
+The barrister was keen enough to divine that the banker would not have
+gone so far in his expression of opinion on any less solid ground than
+moral certainty. Unprepared as he was for the large pill he had to
+swallow, he got it down. “And now,” said Mr. Stryver, shaking his
+forensic forefinger at the Temple in general, when it was down, “my way
+out of this, is, to put you all in the wrong.”
+
+It was a bit of the art of an Old Bailey tactician, in which he found
+great relief. “You shall not put me in the wrong, young lady,” said Mr.
+Stryver; “I’ll do that for you.”
+
+Accordingly, when Mr. Lorry called that night as late as ten o’clock,
+Mr. Stryver, among a quantity of books and papers littered out for the
+purpose, seemed to have nothing less on his mind than the subject of
+the morning. He even showed surprise when he saw Mr. Lorry, and was
+altogether in an absent and preoccupied state.
+
+“Well!” said that good-natured emissary, after a full half-hour of
+bootless attempts to bring him round to the question. “I have been to
+Soho.”
+
+“To Soho?” repeated Mr. Stryver, coldly. “Oh, to be sure! What am I
+thinking of!”
+
+“And I have no doubt,” said Mr. Lorry, “that I was right in the
+conversation we had. My opinion is confirmed, and I reiterate my
+advice.”
+
+“I assure you,” returned Mr. Stryver, in the friendliest way, “that I
+am sorry for it on your account, and sorry for it on the poor father’s
+account. I know this must always be a sore subject with the family; let
+us say no more about it.”
+
+“I don’t understand you,” said Mr. Lorry.
+
+“I dare say not,” rejoined Stryver, nodding his head in a smoothing and
+final way; “no matter, no matter.”
+
+“But it does matter,” Mr. Lorry urged.
+
+“No it doesn’t; I assure you it doesn’t. Having supposed that there was
+sense where there is no sense, and a laudable ambition where there is
+not a laudable ambition, I am well out of my mistake, and no harm is
+done. Young women have committed similar follies often before, and have
+repented them in poverty and obscurity often before. In an unselfish
+aspect, I am sorry that the thing is dropped, because it would have been
+a bad thing for me in a worldly point of view; in a selfish aspect, I am
+glad that the thing has dropped, because it would have been a bad thing
+for me in a worldly point of view--it is hardly necessary to say I could
+have gained nothing by it. There is no harm at all done. I have not
+proposed to the young lady, and, between ourselves, I am by no means
+certain, on reflection, that I ever should have committed myself to
+that extent. Mr. Lorry, you cannot control the mincing vanities and
+giddinesses of empty-headed girls; you must not expect to do it, or you
+will always be disappointed. Now, pray say no more about it. I tell you,
+I regret it on account of others, but I am satisfied on my own account.
+And I am really very much obliged to you for allowing me to sound you,
+and for giving me your advice; you know the young lady better than I do;
+you were right, it never would have done.”
+
+Mr. Lorry was so taken aback, that he looked quite stupidly at Mr.
+Stryver shouldering him towards the door, with an appearance of
+showering generosity, forbearance, and goodwill, on his erring head.
+“Make the best of it, my dear sir,” said Stryver; “say no more about it;
+thank you again for allowing me to sound you; good night!”
+
+Mr. Lorry was out in the night, before he knew where he was. Mr. Stryver
+was lying back on his sofa, winking at his ceiling.
+
+
+
+
+XIII. The Fellow of No Delicacy
+
+
+If Sydney Carton ever shone anywhere, he certainly never shone in the
+house of Doctor Manette. He had been there often, during a whole year,
+and had always been the same moody and morose lounger there. When he
+cared to talk, he talked well; but, the cloud of caring for nothing,
+which overshadowed him with such a fatal darkness, was very rarely
+pierced by the light within him.
+
+And yet he did care something for the streets that environed that house,
+and for the senseless stones that made their pavements. Many a night
+he vaguely and unhappily wandered there, when wine had brought no
+transitory gladness to him; many a dreary daybreak revealed his solitary
+figure lingering there, and still lingering there when the first beams
+of the sun brought into strong relief, removed beauties of architecture
+in spires of churches and lofty buildings, as perhaps the quiet time
+brought some sense of better things, else forgotten and unattainable,
+into his mind. Of late, the neglected bed in the Temple Court had known
+him more scantily than ever; and often when he had thrown himself upon
+it no longer than a few minutes, he had got up again, and haunted that
+neighbourhood.
+
+On a day in August, when Mr. Stryver (after notifying to his jackal
+that “he had thought better of that marrying matter”) had carried his
+delicacy into Devonshire, and when the sight and scent of flowers in the
+City streets had some waifs of goodness in them for the worst, of health
+for the sickliest, and of youth for the oldest, Sydney’s feet still trod
+those stones. From being irresolute and purposeless, his feet became
+animated by an intention, and, in the working out of that intention,
+they took him to the Doctor’s door.
+
+He was shown up-stairs, and found Lucie at her work, alone. She had
+never been quite at her ease with him, and received him with some little
+embarrassment as he seated himself near her table. But, looking up at
+his face in the interchange of the first few common-places, she observed
+a change in it.
+
+“I fear you are not well, Mr. Carton!”
+
+“No. But the life I lead, Miss Manette, is not conducive to health. What
+is to be expected of, or by, such profligates?”
+
+“Is it not--forgive me; I have begun the question on my lips--a pity to
+live no better life?”
+
+“God knows it is a shame!”
+
+“Then why not change it?”
+
+Looking gently at him again, she was surprised and saddened to see that
+there were tears in his eyes. There were tears in his voice too, as he
+answered:
+
+“It is too late for that. I shall never be better than I am. I shall
+sink lower, and be worse.”
+
+He leaned an elbow on her table, and covered his eyes with his hand. The
+table trembled in the silence that followed.
+
+She had never seen him softened, and was much distressed. He knew her to
+be so, without looking at her, and said:
+
+“Pray forgive me, Miss Manette. I break down before the knowledge of
+what I want to say to you. Will you hear me?”
+
+“If it will do you any good, Mr. Carton, if it would make you happier,
+it would make me very glad!”
+
+“God bless you for your sweet compassion!”
+
+He unshaded his face after a little while, and spoke steadily.
+
+“Don’t be afraid to hear me. Don’t shrink from anything I say. I am like
+one who died young. All my life might have been.”
+
+“No, Mr. Carton. I am sure that the best part of it might still be; I am
+sure that you might be much, much worthier of yourself.”
+
+“Say of you, Miss Manette, and although I know better--although in the
+mystery of my own wretched heart I know better--I shall never forget
+it!”
+
+She was pale and trembling. He came to her relief with a fixed despair
+of himself which made the interview unlike any other that could have
+been holden.
+
+“If it had been possible, Miss Manette, that you could have returned the
+love of the man you see before yourself--flung away, wasted, drunken,
+poor creature of misuse as you know him to be--he would have been
+conscious this day and hour, in spite of his happiness, that he would
+bring you to misery, bring you to sorrow and repentance, blight you,
+disgrace you, pull you down with him. I know very well that you can have
+no tenderness for me; I ask for none; I am even thankful that it cannot
+be.”
+
+“Without it, can I not save you, Mr. Carton? Can I not recall
+you--forgive me again!--to a better course? Can I in no way repay your
+confidence? I know this is a confidence,” she modestly said, after a
+little hesitation, and in earnest tears, “I know you would say this to
+no one else. Can I turn it to no good account for yourself, Mr. Carton?”
+
+He shook his head.
+
+“To none. No, Miss Manette, to none. If you will hear me through a very
+little more, all you can ever do for me is done. I wish you to know that
+you have been the last dream of my soul. In my degradation I have not
+been so degraded but that the sight of you with your father, and of this
+home made such a home by you, has stirred old shadows that I thought had
+died out of me. Since I knew you, I have been troubled by a remorse that
+I thought would never reproach me again, and have heard whispers from
+old voices impelling me upward, that I thought were silent for ever. I
+have had unformed ideas of striving afresh, beginning anew, shaking off
+sloth and sensuality, and fighting out the abandoned fight. A dream, all
+a dream, that ends in nothing, and leaves the sleeper where he lay down,
+but I wish you to know that you inspired it.”
+
+“Will nothing of it remain? O Mr. Carton, think again! Try again!”
+
+“No, Miss Manette; all through it, I have known myself to be quite
+undeserving. And yet I have had the weakness, and have still the
+weakness, to wish you to know with what a sudden mastery you kindled me,
+heap of ashes that I am, into fire--a fire, however, inseparable in
+its nature from myself, quickening nothing, lighting nothing, doing no
+service, idly burning away.”
+
+“Since it is my misfortune, Mr. Carton, to have made you more unhappy
+than you were before you knew me--”
+
+“Don’t say that, Miss Manette, for you would have reclaimed me, if
+anything could. You will not be the cause of my becoming worse.”
+
+“Since the state of your mind that you describe, is, at all events,
+attributable to some influence of mine--this is what I mean, if I can
+make it plain--can I use no influence to serve you? Have I no power for
+good, with you, at all?”
+
+“The utmost good that I am capable of now, Miss Manette, I have come
+here to realise. Let me carry through the rest of my misdirected life,
+the remembrance that I opened my heart to you, last of all the world;
+and that there was something left in me at this time which you could
+deplore and pity.”
+
+“Which I entreated you to believe, again and again, most fervently, with
+all my heart, was capable of better things, Mr. Carton!”
+
+“Entreat me to believe it no more, Miss Manette. I have proved myself,
+and I know better. I distress you; I draw fast to an end. Will you let
+me believe, when I recall this day, that the last confidence of my life
+was reposed in your pure and innocent breast, and that it lies there
+alone, and will be shared by no one?”
+
+“If that will be a consolation to you, yes.”
+
+“Not even by the dearest one ever to be known to you?”
+
+“Mr. Carton,” she answered, after an agitated pause, “the secret is
+yours, not mine; and I promise to respect it.”
+
+“Thank you. And again, God bless you.”
+
+He put her hand to his lips, and moved towards the door.
+
+“Be under no apprehension, Miss Manette, of my ever resuming this
+conversation by so much as a passing word. I will never refer to it
+again. If I were dead, that could not be surer than it is henceforth. In
+the hour of my death, I shall hold sacred the one good remembrance--and
+shall thank and bless you for it--that my last avowal of myself was made
+to you, and that my name, and faults, and miseries were gently carried
+in your heart. May it otherwise be light and happy!”
+
+He was so unlike what he had ever shown himself to be, and it was so
+sad to think how much he had thrown away, and how much he every day kept
+down and perverted, that Lucie Manette wept mournfully for him as he
+stood looking back at her.
+
+“Be comforted!” he said, “I am not worth such feeling, Miss Manette. An
+hour or two hence, and the low companions and low habits that I scorn
+but yield to, will render me less worth such tears as those, than any
+wretch who creeps along the streets. Be comforted! But, within myself, I
+shall always be, towards you, what I am now, though outwardly I shall be
+what you have heretofore seen me. The last supplication but one I make
+to you, is, that you will believe this of me.”
+
+“I will, Mr. Carton.”
+
+“My last supplication of all, is this; and with it, I will relieve
+you of a visitor with whom I well know you have nothing in unison, and
+between whom and you there is an impassable space. It is useless to say
+it, I know, but it rises out of my soul. For you, and for any dear to
+you, I would do anything. If my career were of that better kind that
+there was any opportunity or capacity of sacrifice in it, I would
+embrace any sacrifice for you and for those dear to you. Try to hold
+me in your mind, at some quiet times, as ardent and sincere in this one
+thing. The time will come, the time will not be long in coming, when new
+ties will be formed about you--ties that will bind you yet more tenderly
+and strongly to the home you so adorn--the dearest ties that will ever
+grace and gladden you. O Miss Manette, when the little picture of a
+happy father’s face looks up in yours, when you see your own bright
+beauty springing up anew at your feet, think now and then that there is
+a man who would give his life, to keep a life you love beside you!”
+
+He said, “Farewell!” said a last “God bless you!” and left her.
+
+
+
+
+XIV. The Honest Tradesman
+
+
+To the eyes of Mr. Jeremiah Cruncher, sitting on his stool in
+Fleet-street with his grisly urchin beside him, a vast number and
+variety of objects in movement were every day presented. Who could sit
+upon anything in Fleet-street during the busy hours of the day, and
+not be dazed and deafened by two immense processions, one ever tending
+westward with the sun, the other ever tending eastward from the sun,
+both ever tending to the plains beyond the range of red and purple where
+the sun goes down!
+
+With his straw in his mouth, Mr. Cruncher sat watching the two streams,
+like the heathen rustic who has for several centuries been on duty
+watching one stream--saving that Jerry had no expectation of their ever
+running dry. Nor would it have been an expectation of a hopeful kind,
+since a small part of his income was derived from the pilotage of timid
+women (mostly of a full habit and past the middle term of life) from
+Tellson’s side of the tides to the opposite shore. Brief as such
+companionship was in every separate instance, Mr. Cruncher never failed
+to become so interested in the lady as to express a strong desire to
+have the honour of drinking her very good health. And it was from
+the gifts bestowed upon him towards the execution of this benevolent
+purpose, that he recruited his finances, as just now observed.
+
+Time was, when a poet sat upon a stool in a public place, and mused in
+the sight of men. Mr. Cruncher, sitting on a stool in a public place,
+but not being a poet, mused as little as possible, and looked about him.
+
+It fell out that he was thus engaged in a season when crowds were
+few, and belated women few, and when his affairs in general were so
+unprosperous as to awaken a strong suspicion in his breast that Mrs.
+Cruncher must have been “flopping” in some pointed manner, when an
+unusual concourse pouring down Fleet-street westward, attracted his
+attention. Looking that way, Mr. Cruncher made out that some kind of
+funeral was coming along, and that there was popular objection to this
+funeral, which engendered uproar.
+
+“Young Jerry,” said Mr. Cruncher, turning to his offspring, “it’s a
+buryin’.”
+
+“Hooroar, father!” cried Young Jerry.
+
+The young gentleman uttered this exultant sound with mysterious
+significance. The elder gentleman took the cry so ill, that he watched
+his opportunity, and smote the young gentleman on the ear.
+
+“What d’ye mean? What are you hooroaring at? What do you want to conwey
+to your own father, you young Rip? This boy is a getting too many for
+_me_!” said Mr. Cruncher, surveying him. “Him and his hooroars! Don’t
+let me hear no more of you, or you shall feel some more of me. D’ye
+hear?”
+
+“I warn’t doing no harm,” Young Jerry protested, rubbing his cheek.
+
+“Drop it then,” said Mr. Cruncher; “I won’t have none of _your_ no
+harms. Get a top of that there seat, and look at the crowd.”
+
+His son obeyed, and the crowd approached; they were bawling and hissing
+round a dingy hearse and dingy mourning coach, in which mourning coach
+there was only one mourner, dressed in the dingy trappings that were
+considered essential to the dignity of the position. The position
+appeared by no means to please him, however, with an increasing rabble
+surrounding the coach, deriding him, making grimaces at him, and
+incessantly groaning and calling out: “Yah! Spies! Tst! Yaha! Spies!”
+ with many compliments too numerous and forcible to repeat.
+
+Funerals had at all times a remarkable attraction for Mr. Cruncher; he
+always pricked up his senses, and became excited, when a funeral passed
+Tellson’s. Naturally, therefore, a funeral with this uncommon attendance
+excited him greatly, and he asked of the first man who ran against him:
+
+“What is it, brother? What’s it about?”
+
+“_I_ don’t know,” said the man. “Spies! Yaha! Tst! Spies!”
+
+He asked another man. “Who is it?”
+
+“_I_ don’t know,” returned the man, clapping his hands to his mouth
+nevertheless, and vociferating in a surprising heat and with the
+greatest ardour, “Spies! Yaha! Tst, tst! Spi--ies!”
+
+At length, a person better informed on the merits of the case, tumbled
+against him, and from this person he learned that the funeral was the
+funeral of one Roger Cly.
+
+“Was He a spy?” asked Mr. Cruncher.
+
+“Old Bailey spy,” returned his informant. “Yaha! Tst! Yah! Old Bailey
+Spi--i--ies!”
+
+“Why, to be sure!” exclaimed Jerry, recalling the Trial at which he had
+assisted. “I’ve seen him. Dead, is he?”
+
+“Dead as mutton,” returned the other, “and can’t be too dead. Have ‘em
+out, there! Spies! Pull ‘em out, there! Spies!”
+
+The idea was so acceptable in the prevalent absence of any idea,
+that the crowd caught it up with eagerness, and loudly repeating the
+suggestion to have ‘em out, and to pull ‘em out, mobbed the two vehicles
+so closely that they came to a stop. On the crowd’s opening the coach
+doors, the one mourner scuffled out of himself and was in their hands
+for a moment; but he was so alert, and made such good use of his time,
+that in another moment he was scouring away up a bye-street, after
+shedding his cloak, hat, long hatband, white pocket-handkerchief, and
+other symbolical tears.
+
+These, the people tore to pieces and scattered far and wide with great
+enjoyment, while the tradesmen hurriedly shut up their shops; for a
+crowd in those times stopped at nothing, and was a monster much dreaded.
+They had already got the length of opening the hearse to take the coffin
+out, when some brighter genius proposed instead, its being escorted to
+its destination amidst general rejoicing. Practical suggestions being
+much needed, this suggestion, too, was received with acclamation, and
+the coach was immediately filled with eight inside and a dozen out,
+while as many people got on the roof of the hearse as could by any
+exercise of ingenuity stick upon it. Among the first of these volunteers
+was Jerry Cruncher himself, who modestly concealed his spiky head from
+the observation of Tellson’s, in the further corner of the mourning
+coach.
+
+The officiating undertakers made some protest against these changes in
+the ceremonies; but, the river being alarmingly near, and several voices
+remarking on the efficacy of cold immersion in bringing refractory
+members of the profession to reason, the protest was faint and brief.
+The remodelled procession started, with a chimney-sweep driving the
+hearse--advised by the regular driver, who was perched beside him, under
+close inspection, for the purpose--and with a pieman, also attended
+by his cabinet minister, driving the mourning coach. A bear-leader, a
+popular street character of the time, was impressed as an additional
+ornament, before the cavalcade had gone far down the Strand; and his
+bear, who was black and very mangy, gave quite an Undertaking air to
+that part of the procession in which he walked.
+
+Thus, with beer-drinking, pipe-smoking, song-roaring, and infinite
+caricaturing of woe, the disorderly procession went its way, recruiting
+at every step, and all the shops shutting up before it. Its destination
+was the old church of Saint Pancras, far off in the fields. It got there
+in course of time; insisted on pouring into the burial-ground; finally,
+accomplished the interment of the deceased Roger Cly in its own way, and
+highly to its own satisfaction.
+
+The dead man disposed of, and the crowd being under the necessity of
+providing some other entertainment for itself, another brighter
+genius (or perhaps the same) conceived the humour of impeaching casual
+passers-by, as Old Bailey spies, and wreaking vengeance on them. Chase
+was given to some scores of inoffensive persons who had never been near
+the Old Bailey in their lives, in the realisation of this fancy, and
+they were roughly hustled and maltreated. The transition to the sport of
+window-breaking, and thence to the plundering of public-houses, was easy
+and natural. At last, after several hours, when sundry summer-houses had
+been pulled down, and some area-railings had been torn up, to arm
+the more belligerent spirits, a rumour got about that the Guards were
+coming. Before this rumour, the crowd gradually melted away, and perhaps
+the Guards came, and perhaps they never came, and this was the usual
+progress of a mob.
+
+Mr. Cruncher did not assist at the closing sports, but had remained
+behind in the churchyard, to confer and condole with the undertakers.
+The place had a soothing influence on him. He procured a pipe from a
+neighbouring public-house, and smoked it, looking in at the railings and
+maturely considering the spot.
+
+“Jerry,” said Mr. Cruncher, apostrophising himself in his usual way,
+“you see that there Cly that day, and you see with your own eyes that he
+was a young ‘un and a straight made ‘un.”
+
+Having smoked his pipe out, and ruminated a little longer, he turned
+himself about, that he might appear, before the hour of closing, on his
+station at Tellson’s. Whether his meditations on mortality had touched
+his liver, or whether his general health had been previously at all
+amiss, or whether he desired to show a little attention to an eminent
+man, is not so much to the purpose, as that he made a short call upon
+his medical adviser--a distinguished surgeon--on his way back.
+
+Young Jerry relieved his father with dutiful interest, and reported No
+job in his absence. The bank closed, the ancient clerks came out, the
+usual watch was set, and Mr. Cruncher and his son went home to tea.
+
+“Now, I tell you where it is!” said Mr. Cruncher to his wife, on
+entering. “If, as a honest tradesman, my wenturs goes wrong to-night, I
+shall make sure that you’ve been praying again me, and I shall work you
+for it just the same as if I seen you do it.”
+
+The dejected Mrs. Cruncher shook her head.
+
+“Why, you’re at it afore my face!” said Mr. Cruncher, with signs of
+angry apprehension.
+
+“I am saying nothing.”
+
+“Well, then; don’t meditate nothing. You might as well flop as meditate.
+You may as well go again me one way as another. Drop it altogether.”
+
+“Yes, Jerry.”
+
+“Yes, Jerry,” repeated Mr. Cruncher sitting down to tea. “Ah! It _is_
+yes, Jerry. That’s about it. You may say yes, Jerry.”
+
+Mr. Cruncher had no particular meaning in these sulky corroborations,
+but made use of them, as people not unfrequently do, to express general
+ironical dissatisfaction.
+
+“You and your yes, Jerry,” said Mr. Cruncher, taking a bite out of his
+bread-and-butter, and seeming to help it down with a large invisible
+oyster out of his saucer. “Ah! I think so. I believe you.”
+
+“You are going out to-night?” asked his decent wife, when he took
+another bite.
+
+“Yes, I am.”
+
+“May I go with you, father?” asked his son, briskly.
+
+“No, you mayn’t. I’m a going--as your mother knows--a fishing. That’s
+where I’m going to. Going a fishing.”
+
+“Your fishing-rod gets rayther rusty; don’t it, father?”
+
+“Never you mind.”
+
+“Shall you bring any fish home, father?”
+
+“If I don’t, you’ll have short commons, to-morrow,” returned that
+gentleman, shaking his head; “that’s questions enough for you; I ain’t a
+going out, till you’ve been long abed.”
+
+He devoted himself during the remainder of the evening to keeping a
+most vigilant watch on Mrs. Cruncher, and sullenly holding her in
+conversation that she might be prevented from meditating any petitions
+to his disadvantage. With this view, he urged his son to hold her in
+conversation also, and led the unfortunate woman a hard life by dwelling
+on any causes of complaint he could bring against her, rather than
+he would leave her for a moment to her own reflections. The devoutest
+person could have rendered no greater homage to the efficacy of an
+honest prayer than he did in this distrust of his wife. It was as if a
+professed unbeliever in ghosts should be frightened by a ghost story.
+
+“And mind you!” said Mr. Cruncher. “No games to-morrow! If I, as a
+honest tradesman, succeed in providing a jinte of meat or two, none
+of your not touching of it, and sticking to bread. If I, as a honest
+tradesman, am able to provide a little beer, none of your declaring
+on water. When you go to Rome, do as Rome does. Rome will be a ugly
+customer to you, if you don’t. _I_‘m your Rome, you know.”
+
+Then he began grumbling again:
+
+“With your flying into the face of your own wittles and drink! I don’t
+know how scarce you mayn’t make the wittles and drink here, by your
+flopping tricks and your unfeeling conduct. Look at your boy: he _is_
+your’n, ain’t he? He’s as thin as a lath. Do you call yourself a mother,
+and not know that a mother’s first duty is to blow her boy out?”
+
+This touched Young Jerry on a tender place; who adjured his mother to
+perform her first duty, and, whatever else she did or neglected, above
+all things to lay especial stress on the discharge of that maternal
+function so affectingly and delicately indicated by his other parent.
+
+Thus the evening wore away with the Cruncher family, until Young Jerry
+was ordered to bed, and his mother, laid under similar injunctions,
+obeyed them. Mr. Cruncher beguiled the earlier watches of the night with
+solitary pipes, and did not start upon his excursion until nearly one
+o’clock. Towards that small and ghostly hour, he rose up from his chair,
+took a key out of his pocket, opened a locked cupboard, and brought
+forth a sack, a crowbar of convenient size, a rope and chain, and other
+fishing tackle of that nature. Disposing these articles about him
+in skilful manner, he bestowed a parting defiance on Mrs. Cruncher,
+extinguished the light, and went out.
+
+Young Jerry, who had only made a feint of undressing when he went to
+bed, was not long after his father. Under cover of the darkness he
+followed out of the room, followed down the stairs, followed down the
+court, followed out into the streets. He was in no uneasiness concerning
+his getting into the house again, for it was full of lodgers, and the
+door stood ajar all night.
+
+Impelled by a laudable ambition to study the art and mystery of his
+father’s honest calling, Young Jerry, keeping as close to house fronts,
+walls, and doorways, as his eyes were close to one another, held his
+honoured parent in view. The honoured parent steering Northward, had not
+gone far, when he was joined by another disciple of Izaak Walton, and
+the two trudged on together.
+
+Within half an hour from the first starting, they were beyond the
+winking lamps, and the more than winking watchmen, and were out upon a
+lonely road. Another fisherman was picked up here--and that so silently,
+that if Young Jerry had been superstitious, he might have supposed the
+second follower of the gentle craft to have, all of a sudden, split
+himself into two.
+
+The three went on, and Young Jerry went on, until the three stopped
+under a bank overhanging the road. Upon the top of the bank was a low
+brick wall, surmounted by an iron railing. In the shadow of bank and
+wall the three turned out of the road, and up a blind lane, of which
+the wall--there, risen to some eight or ten feet high--formed one side.
+Crouching down in a corner, peeping up the lane, the next object that
+Young Jerry saw, was the form of his honoured parent, pretty well
+defined against a watery and clouded moon, nimbly scaling an iron gate.
+He was soon over, and then the second fisherman got over, and then the
+third. They all dropped softly on the ground within the gate, and lay
+there a little--listening perhaps. Then, they moved away on their hands
+and knees.
+
+It was now Young Jerry’s turn to approach the gate: which he did,
+holding his breath. Crouching down again in a corner there, and looking
+in, he made out the three fishermen creeping through some rank grass!
+and all the gravestones in the churchyard--it was a large churchyard
+that they were in--looking on like ghosts in white, while the church
+tower itself looked on like the ghost of a monstrous giant. They did not
+creep far, before they stopped and stood upright. And then they began to
+fish.
+
+They fished with a spade, at first. Presently the honoured parent
+appeared to be adjusting some instrument like a great corkscrew.
+Whatever tools they worked with, they worked hard, until the awful
+striking of the church clock so terrified Young Jerry, that he made off,
+with his hair as stiff as his father’s.
+
+But, his long-cherished desire to know more about these matters, not
+only stopped him in his running away, but lured him back again. They
+were still fishing perseveringly, when he peeped in at the gate for
+the second time; but, now they seemed to have got a bite. There was a
+screwing and complaining sound down below, and their bent figures were
+strained, as if by a weight. By slow degrees the weight broke away the
+earth upon it, and came to the surface. Young Jerry very well knew what
+it would be; but, when he saw it, and saw his honoured parent about to
+wrench it open, he was so frightened, being new to the sight, that he
+made off again, and never stopped until he had run a mile or more.
+
+He would not have stopped then, for anything less necessary than breath,
+it being a spectral sort of race that he ran, and one highly desirable
+to get to the end of. He had a strong idea that the coffin he had seen
+was running after him; and, pictured as hopping on behind him, bolt
+upright, upon its narrow end, always on the point of overtaking him
+and hopping on at his side--perhaps taking his arm--it was a pursuer to
+shun. It was an inconsistent and ubiquitous fiend too, for, while it
+was making the whole night behind him dreadful, he darted out into the
+roadway to avoid dark alleys, fearful of its coming hopping out of them
+like a dropsical boy’s Kite without tail and wings. It hid in doorways
+too, rubbing its horrible shoulders against doors, and drawing them up
+to its ears, as if it were laughing. It got into shadows on the road,
+and lay cunningly on its back to trip him up. All this time it was
+incessantly hopping on behind and gaining on him, so that when the boy
+got to his own door he had reason for being half dead. And even then
+it would not leave him, but followed him upstairs with a bump on every
+stair, scrambled into bed with him, and bumped down, dead and heavy, on
+his breast when he fell asleep.
+
+From his oppressed slumber, Young Jerry in his closet was awakened after
+daybreak and before sunrise, by the presence of his father in the
+family room. Something had gone wrong with him; at least, so Young Jerry
+inferred, from the circumstance of his holding Mrs. Cruncher by the
+ears, and knocking the back of her head against the head-board of the
+bed.
+
+“I told you I would,” said Mr. Cruncher, “and I did.”
+
+“Jerry, Jerry, Jerry!” his wife implored.
+
+“You oppose yourself to the profit of the business,” said Jerry, “and me
+and my partners suffer. You was to honour and obey; why the devil don’t
+you?”
+
+“I try to be a good wife, Jerry,” the poor woman protested, with tears.
+
+“Is it being a good wife to oppose your husband’s business? Is it
+honouring your husband to dishonour his business? Is it obeying your
+husband to disobey him on the wital subject of his business?”
+
+“You hadn’t taken to the dreadful business then, Jerry.”
+
+“It’s enough for you,” retorted Mr. Cruncher, “to be the wife of a
+honest tradesman, and not to occupy your female mind with calculations
+when he took to his trade or when he didn’t. A honouring and obeying
+wife would let his trade alone altogether. Call yourself a religious
+woman? If you’re a religious woman, give me a irreligious one! You have
+no more nat’ral sense of duty than the bed of this here Thames river has
+of a pile, and similarly it must be knocked into you.”
+
+The altercation was conducted in a low tone of voice, and terminated in
+the honest tradesman’s kicking off his clay-soiled boots, and lying down
+at his length on the floor. After taking a timid peep at him lying on
+his back, with his rusty hands under his head for a pillow, his son lay
+down too, and fell asleep again.
+
+There was no fish for breakfast, and not much of anything else. Mr.
+Cruncher was out of spirits, and out of temper, and kept an iron pot-lid
+by him as a projectile for the correction of Mrs. Cruncher, in case
+he should observe any symptoms of her saying Grace. He was brushed
+and washed at the usual hour, and set off with his son to pursue his
+ostensible calling.
+
+Young Jerry, walking with the stool under his arm at his father’s side
+along sunny and crowded Fleet-street, was a very different Young Jerry
+from him of the previous night, running home through darkness and
+solitude from his grim pursuer. His cunning was fresh with the day,
+and his qualms were gone with the night--in which particulars it is not
+improbable that he had compeers in Fleet-street and the City of London,
+that fine morning.
+
+“Father,” said Young Jerry, as they walked along: taking care to keep
+at arm’s length and to have the stool well between them: “what’s a
+Resurrection-Man?”
+
+Mr. Cruncher came to a stop on the pavement before he answered, “How
+should I know?”
+
+“I thought you knowed everything, father,” said the artless boy.
+
+“Hem! Well,” returned Mr. Cruncher, going on again, and lifting off his
+hat to give his spikes free play, “he’s a tradesman.”
+
+“What’s his goods, father?” asked the brisk Young Jerry.
+
+“His goods,” said Mr. Cruncher, after turning it over in his mind, “is a
+branch of Scientific goods.”
+
+“Persons’ bodies, ain’t it, father?” asked the lively boy.
+
+“I believe it is something of that sort,” said Mr. Cruncher.
+
+“Oh, father, I should so like to be a Resurrection-Man when I’m quite
+growed up!”
+
+Mr. Cruncher was soothed, but shook his head in a dubious and moral way.
+“It depends upon how you dewelop your talents. Be careful to dewelop
+your talents, and never to say no more than you can help to nobody, and
+there’s no telling at the present time what you may not come to be fit
+for.” As Young Jerry, thus encouraged, went on a few yards in advance,
+to plant the stool in the shadow of the Bar, Mr. Cruncher added to
+himself: “Jerry, you honest tradesman, there’s hopes wot that boy will
+yet be a blessing to you, and a recompense to you for his mother!”
+
+
+
+
+XV. Knitting
+
+
+There had been earlier drinking than usual in the wine-shop of Monsieur
+Defarge. As early as six o’clock in the morning, sallow faces peeping
+through its barred windows had descried other faces within, bending over
+measures of wine. Monsieur Defarge sold a very thin wine at the best
+of times, but it would seem to have been an unusually thin wine that
+he sold at this time. A sour wine, moreover, or a souring, for its
+influence on the mood of those who drank it was to make them gloomy. No
+vivacious Bacchanalian flame leaped out of the pressed grape of Monsieur
+Defarge: but, a smouldering fire that burnt in the dark, lay hidden in
+the dregs of it.
+
+This had been the third morning in succession, on which there had been
+early drinking at the wine-shop of Monsieur Defarge. It had begun
+on Monday, and here was Wednesday come. There had been more of early
+brooding than drinking; for, many men had listened and whispered and
+slunk about there from the time of the opening of the door, who could
+not have laid a piece of money on the counter to save their souls. These
+were to the full as interested in the place, however, as if they could
+have commanded whole barrels of wine; and they glided from seat to seat,
+and from corner to corner, swallowing talk in lieu of drink, with greedy
+looks.
+
+Notwithstanding an unusual flow of company, the master of the wine-shop
+was not visible. He was not missed; for, nobody who crossed the
+threshold looked for him, nobody asked for him, nobody wondered to see
+only Madame Defarge in her seat, presiding over the distribution of
+wine, with a bowl of battered small coins before her, as much defaced
+and beaten out of their original impress as the small coinage of
+humanity from whose ragged pockets they had come.
+
+A suspended interest and a prevalent absence of mind, were perhaps
+observed by the spies who looked in at the wine-shop, as they looked in
+at every place, high and low, from the king’s palace to the criminal’s
+gaol. Games at cards languished, players at dominoes musingly built
+towers with them, drinkers drew figures on the tables with spilt drops
+of wine, Madame Defarge herself picked out the pattern on her sleeve
+with her toothpick, and saw and heard something inaudible and invisible
+a long way off.
+
+Thus, Saint Antoine in this vinous feature of his, until midday. It was
+high noontide, when two dusty men passed through his streets and under
+his swinging lamps: of whom, one was Monsieur Defarge: the other a
+mender of roads in a blue cap. All adust and athirst, the two entered
+the wine-shop. Their arrival had lighted a kind of fire in the breast
+of Saint Antoine, fast spreading as they came along, which stirred and
+flickered in flames of faces at most doors and windows. Yet, no one had
+followed them, and no man spoke when they entered the wine-shop, though
+the eyes of every man there were turned upon them.
+
+“Good day, gentlemen!” said Monsieur Defarge.
+
+It may have been a signal for loosening the general tongue. It elicited
+an answering chorus of “Good day!”
+
+“It is bad weather, gentlemen,” said Defarge, shaking his head.
+
+Upon which, every man looked at his neighbour, and then all cast down
+their eyes and sat silent. Except one man, who got up and went out.
+
+“My wife,” said Defarge aloud, addressing Madame Defarge: “I have
+travelled certain leagues with this good mender of roads, called
+Jacques. I met him--by accident--a day and half’s journey out of Paris.
+He is a good child, this mender of roads, called Jacques. Give him to
+drink, my wife!”
+
+A second man got up and went out. Madame Defarge set wine before the
+mender of roads called Jacques, who doffed his blue cap to the company,
+and drank. In the breast of his blouse he carried some coarse dark
+bread; he ate of this between whiles, and sat munching and drinking near
+Madame Defarge’s counter. A third man got up and went out.
+
+Defarge refreshed himself with a draught of wine--but, he took less
+than was given to the stranger, as being himself a man to whom it was no
+rarity--and stood waiting until the countryman had made his breakfast.
+He looked at no one present, and no one now looked at him; not even
+Madame Defarge, who had taken up her knitting, and was at work.
+
+“Have you finished your repast, friend?” he asked, in due season.
+
+“Yes, thank you.”
+
+“Come, then! You shall see the apartment that I told you you could
+occupy. It will suit you to a marvel.”
+
+Out of the wine-shop into the street, out of the street into a
+courtyard, out of the courtyard up a steep staircase, out of the
+staircase into a garret--formerly the garret where a white-haired man
+sat on a low bench, stooping forward and very busy, making shoes.
+
+No white-haired man was there now; but, the three men were there who had
+gone out of the wine-shop singly. And between them and the white-haired
+man afar off, was the one small link, that they had once looked in at
+him through the chinks in the wall.
+
+Defarge closed the door carefully, and spoke in a subdued voice:
+
+“Jacques One, Jacques Two, Jacques Three! This is the witness
+encountered by appointment, by me, Jacques Four. He will tell you all.
+Speak, Jacques Five!”
+
+The mender of roads, blue cap in hand, wiped his swarthy forehead with
+it, and said, “Where shall I commence, monsieur?”
+
+“Commence,” was Monsieur Defarge’s not unreasonable reply, “at the
+commencement.”
+
+“I saw him then, messieurs,” began the mender of roads, “a year ago this
+running summer, underneath the carriage of the Marquis, hanging by the
+chain. Behold the manner of it. I leaving my work on the road, the sun
+going to bed, the carriage of the Marquis slowly ascending the hill, he
+hanging by the chain--like this.”
+
+Again the mender of roads went through the whole performance; in which
+he ought to have been perfect by that time, seeing that it had been
+the infallible resource and indispensable entertainment of his village
+during a whole year.
+
+Jacques One struck in, and asked if he had ever seen the man before?
+
+“Never,” answered the mender of roads, recovering his perpendicular.
+
+Jacques Three demanded how he afterwards recognised him then?
+
+“By his tall figure,” said the mender of roads, softly, and with his
+finger at his nose. “When Monsieur the Marquis demands that evening,
+‘Say, what is he like?’ I make response, ‘Tall as a spectre.’”
+
+“You should have said, short as a dwarf,” returned Jacques Two.
+
+“But what did I know? The deed was not then accomplished, neither did he
+confide in me. Observe! Under those circumstances even, I do not
+offer my testimony. Monsieur the Marquis indicates me with his finger,
+standing near our little fountain, and says, ‘To me! Bring that rascal!’
+My faith, messieurs, I offer nothing.”
+
+“He is right there, Jacques,” murmured Defarge, to him who had
+interrupted. “Go on!”
+
+“Good!” said the mender of roads, with an air of mystery. “The tall man
+is lost, and he is sought--how many months? Nine, ten, eleven?”
+
+“No matter, the number,” said Defarge. “He is well hidden, but at last
+he is unluckily found. Go on!”
+
+“I am again at work upon the hill-side, and the sun is again about to
+go to bed. I am collecting my tools to descend to my cottage down in the
+village below, where it is already dark, when I raise my eyes, and see
+coming over the hill six soldiers. In the midst of them is a tall man
+with his arms bound--tied to his sides--like this!”
+
+With the aid of his indispensable cap, he represented a man with his
+elbows bound fast at his hips, with cords that were knotted behind him.
+
+“I stand aside, messieurs, by my heap of stones, to see the soldiers
+and their prisoner pass (for it is a solitary road, that, where any
+spectacle is well worth looking at), and at first, as they approach, I
+see no more than that they are six soldiers with a tall man bound, and
+that they are almost black to my sight--except on the side of the sun
+going to bed, where they have a red edge, messieurs. Also, I see that
+their long shadows are on the hollow ridge on the opposite side of the
+road, and are on the hill above it, and are like the shadows of giants.
+Also, I see that they are covered with dust, and that the dust moves
+with them as they come, tramp, tramp! But when they advance quite near
+to me, I recognise the tall man, and he recognises me. Ah, but he would
+be well content to precipitate himself over the hill-side once again, as
+on the evening when he and I first encountered, close to the same spot!”
+
+He described it as if he were there, and it was evident that he saw it
+vividly; perhaps he had not seen much in his life.
+
+“I do not show the soldiers that I recognise the tall man; he does not
+show the soldiers that he recognises me; we do it, and we know it, with
+our eyes. ‘Come on!’ says the chief of that company, pointing to the
+village, ‘bring him fast to his tomb!’ and they bring him faster. I
+follow. His arms are swelled because of being bound so tight, his wooden
+shoes are large and clumsy, and he is lame. Because he is lame, and
+consequently slow, they drive him with their guns--like this!”
+
+He imitated the action of a man’s being impelled forward by the
+butt-ends of muskets.
+
+“As they descend the hill like madmen running a race, he falls. They
+laugh and pick him up again. His face is bleeding and covered with dust,
+but he cannot touch it; thereupon they laugh again. They bring him into
+the village; all the village runs to look; they take him past the mill,
+and up to the prison; all the village sees the prison gate open in the
+darkness of the night, and swallow him--like this!”
+
+He opened his mouth as wide as he could, and shut it with a sounding
+snap of his teeth. Observant of his unwillingness to mar the effect by
+opening it again, Defarge said, “Go on, Jacques.”
+
+“All the village,” pursued the mender of roads, on tiptoe and in a low
+voice, “withdraws; all the village whispers by the fountain; all the
+village sleeps; all the village dreams of that unhappy one, within the
+locks and bars of the prison on the crag, and never to come out of it,
+except to perish. In the morning, with my tools upon my shoulder, eating
+my morsel of black bread as I go, I make a circuit by the prison, on
+my way to my work. There I see him, high up, behind the bars of a lofty
+iron cage, bloody and dusty as last night, looking through. He has no
+hand free, to wave to me; I dare not call to him; he regards me like a
+dead man.”
+
+Defarge and the three glanced darkly at one another. The looks of all
+of them were dark, repressed, and revengeful, as they listened to the
+countryman’s story; the manner of all of them, while it was secret, was
+authoritative too. They had the air of a rough tribunal; Jacques One
+and Two sitting on the old pallet-bed, each with his chin resting on
+his hand, and his eyes intent on the road-mender; Jacques Three, equally
+intent, on one knee behind them, with his agitated hand always gliding
+over the network of fine nerves about his mouth and nose; Defarge
+standing between them and the narrator, whom he had stationed in the
+light of the window, by turns looking from him to them, and from them to
+him.
+
+“Go on, Jacques,” said Defarge.
+
+“He remains up there in his iron cage some days. The village looks
+at him by stealth, for it is afraid. But it always looks up, from a
+distance, at the prison on the crag; and in the evening, when the work
+of the day is achieved and it assembles to gossip at the fountain, all
+faces are turned towards the prison. Formerly, they were turned towards
+the posting-house; now, they are turned towards the prison. They
+whisper at the fountain, that although condemned to death he will not be
+executed; they say that petitions have been presented in Paris, showing
+that he was enraged and made mad by the death of his child; they say
+that a petition has been presented to the King himself. What do I know?
+It is possible. Perhaps yes, perhaps no.”
+
+“Listen then, Jacques,” Number One of that name sternly interposed.
+“Know that a petition was presented to the King and Queen. All here,
+yourself excepted, saw the King take it, in his carriage in the street,
+sitting beside the Queen. It is Defarge whom you see here, who, at the
+hazard of his life, darted out before the horses, with the petition in
+his hand.”
+
+“And once again listen, Jacques!” said the kneeling Number Three:
+his fingers ever wandering over and over those fine nerves, with a
+strikingly greedy air, as if he hungered for something--that was neither
+food nor drink; “the guard, horse and foot, surrounded the petitioner,
+and struck him blows. You hear?”
+
+“I hear, messieurs.”
+
+“Go on then,” said Defarge.
+
+“Again; on the other hand, they whisper at the fountain,” resumed the
+countryman, “that he is brought down into our country to be executed on
+the spot, and that he will very certainly be executed. They even whisper
+that because he has slain Monseigneur, and because Monseigneur was the
+father of his tenants--serfs--what you will--he will be executed as a
+parricide. One old man says at the fountain, that his right hand, armed
+with the knife, will be burnt off before his face; that, into wounds
+which will be made in his arms, his breast, and his legs, there will be
+poured boiling oil, melted lead, hot resin, wax, and sulphur; finally,
+that he will be torn limb from limb by four strong horses. That old man
+says, all this was actually done to a prisoner who made an attempt on
+the life of the late King, Louis Fifteen. But how do I know if he lies?
+I am not a scholar.”
+
+“Listen once again then, Jacques!” said the man with the restless hand
+and the craving air. “The name of that prisoner was Damiens, and it was
+all done in open day, in the open streets of this city of Paris; and
+nothing was more noticed in the vast concourse that saw it done, than
+the crowd of ladies of quality and fashion, who were full of eager
+attention to the last--to the last, Jacques, prolonged until nightfall,
+when he had lost two legs and an arm, and still breathed! And it was
+done--why, how old are you?”
+
+“Thirty-five,” said the mender of roads, who looked sixty.
+
+“It was done when you were more than ten years old; you might have seen
+it.”
+
+“Enough!” said Defarge, with grim impatience. “Long live the Devil! Go
+on.”
+
+“Well! Some whisper this, some whisper that; they speak of nothing else;
+even the fountain appears to fall to that tune. At length, on Sunday
+night when all the village is asleep, come soldiers, winding down from
+the prison, and their guns ring on the stones of the little street.
+Workmen dig, workmen hammer, soldiers laugh and sing; in the morning, by
+the fountain, there is raised a gallows forty feet high, poisoning the
+water.”
+
+The mender of roads looked _through_ rather than _at_ the low ceiling,
+and pointed as if he saw the gallows somewhere in the sky.
+
+“All work is stopped, all assemble there, nobody leads the cows out,
+the cows are there with the rest. At midday, the roll of drums. Soldiers
+have marched into the prison in the night, and he is in the midst
+of many soldiers. He is bound as before, and in his mouth there is
+a gag--tied so, with a tight string, making him look almost as if he
+laughed.” He suggested it, by creasing his face with his two thumbs,
+from the corners of his mouth to his ears. “On the top of the gallows is
+fixed the knife, blade upwards, with its point in the air. He is hanged
+there forty feet high--and is left hanging, poisoning the water.”
+
+They looked at one another, as he used his blue cap to wipe his face,
+on which the perspiration had started afresh while he recalled the
+spectacle.
+
+“It is frightful, messieurs. How can the women and the children draw
+water! Who can gossip of an evening, under that shadow! Under it, have
+I said? When I left the village, Monday evening as the sun was going to
+bed, and looked back from the hill, the shadow struck across the church,
+across the mill, across the prison--seemed to strike across the earth,
+messieurs, to where the sky rests upon it!”
+
+The hungry man gnawed one of his fingers as he looked at the other
+three, and his finger quivered with the craving that was on him.
+
+“That’s all, messieurs. I left at sunset (as I had been warned to do),
+and I walked on, that night and half next day, until I met (as I was
+warned I should) this comrade. With him, I came on, now riding and now
+walking, through the rest of yesterday and through last night. And here
+you see me!”
+
+After a gloomy silence, the first Jacques said, “Good! You have acted
+and recounted faithfully. Will you wait for us a little, outside the
+door?”
+
+“Very willingly,” said the mender of roads. Whom Defarge escorted to the
+top of the stairs, and, leaving seated there, returned.
+
+The three had risen, and their heads were together when he came back to
+the garret.
+
+“How say you, Jacques?” demanded Number One. “To be registered?”
+
+“To be registered, as doomed to destruction,” returned Defarge.
+
+“Magnificent!” croaked the man with the craving.
+
+“The chateau, and all the race?” inquired the first.
+
+“The chateau and all the race,” returned Defarge. “Extermination.”
+
+The hungry man repeated, in a rapturous croak, “Magnificent!” and began
+gnawing another finger.
+
+“Are you sure,” asked Jacques Two, of Defarge, “that no embarrassment
+can arise from our manner of keeping the register? Without doubt it is
+safe, for no one beyond ourselves can decipher it; but shall we always
+be able to decipher it--or, I ought to say, will she?”
+
+“Jacques,” returned Defarge, drawing himself up, “if madame my wife
+undertook to keep the register in her memory alone, she would not lose
+a word of it--not a syllable of it. Knitted, in her own stitches and her
+own symbols, it will always be as plain to her as the sun. Confide in
+Madame Defarge. It would be easier for the weakest poltroon that lives,
+to erase himself from existence, than to erase one letter of his name or
+crimes from the knitted register of Madame Defarge.”
+
+There was a murmur of confidence and approval, and then the man who
+hungered, asked: “Is this rustic to be sent back soon? I hope so. He is
+very simple; is he not a little dangerous?”
+
+“He knows nothing,” said Defarge; “at least nothing more than would
+easily elevate himself to a gallows of the same height. I charge myself
+with him; let him remain with me; I will take care of him, and set him
+on his road. He wishes to see the fine world--the King, the Queen, and
+Court; let him see them on Sunday.”
+
+“What?” exclaimed the hungry man, staring. “Is it a good sign, that he
+wishes to see Royalty and Nobility?”
+
+“Jacques,” said Defarge; “judiciously show a cat milk, if you wish her
+to thirst for it. Judiciously show a dog his natural prey, if you wish
+him to bring it down one day.”
+
+Nothing more was said, and the mender of roads, being found already
+dozing on the topmost stair, was advised to lay himself down on the
+pallet-bed and take some rest. He needed no persuasion, and was soon
+asleep.
+
+Worse quarters than Defarge’s wine-shop, could easily have been found
+in Paris for a provincial slave of that degree. Saving for a mysterious
+dread of madame by which he was constantly haunted, his life was very
+new and agreeable. But, madame sat all day at her counter, so expressly
+unconscious of him, and so particularly determined not to perceive that
+his being there had any connection with anything below the surface, that
+he shook in his wooden shoes whenever his eye lighted on her. For, he
+contended with himself that it was impossible to foresee what that lady
+might pretend next; and he felt assured that if she should take it
+into her brightly ornamented head to pretend that she had seen him do a
+murder and afterwards flay the victim, she would infallibly go through
+with it until the play was played out.
+
+Therefore, when Sunday came, the mender of roads was not enchanted
+(though he said he was) to find that madame was to accompany monsieur
+and himself to Versailles. It was additionally disconcerting to have
+madame knitting all the way there, in a public conveyance; it was
+additionally disconcerting yet, to have madame in the crowd in the
+afternoon, still with her knitting in her hands as the crowd waited to
+see the carriage of the King and Queen.
+
+“You work hard, madame,” said a man near her.
+
+“Yes,” answered Madame Defarge; “I have a good deal to do.”
+
+“What do you make, madame?”
+
+“Many things.”
+
+“For instance--”
+
+“For instance,” returned Madame Defarge, composedly, “shrouds.”
+
+The man moved a little further away, as soon as he could, and the mender
+of roads fanned himself with his blue cap: feeling it mightily close
+and oppressive. If he needed a King and Queen to restore him, he was
+fortunate in having his remedy at hand; for, soon the large-faced King
+and the fair-faced Queen came in their golden coach, attended by the
+shining Bull’s Eye of their Court, a glittering multitude of laughing
+ladies and fine lords; and in jewels and silks and powder and splendour
+and elegantly spurning figures and handsomely disdainful faces of both
+sexes, the mender of roads bathed himself, so much to his temporary
+intoxication, that he cried Long live the King, Long live the Queen,
+Long live everybody and everything! as if he had never heard of
+ubiquitous Jacques in his time. Then, there were gardens, courtyards,
+terraces, fountains, green banks, more King and Queen, more Bull’s Eye,
+more lords and ladies, more Long live they all! until he absolutely wept
+with sentiment. During the whole of this scene, which lasted some three
+hours, he had plenty of shouting and weeping and sentimental company,
+and throughout Defarge held him by the collar, as if to restrain him
+from flying at the objects of his brief devotion and tearing them to
+pieces.
+
+“Bravo!” said Defarge, clapping him on the back when it was over, like a
+patron; “you are a good boy!”
+
+The mender of roads was now coming to himself, and was mistrustful of
+having made a mistake in his late demonstrations; but no.
+
+“You are the fellow we want,” said Defarge, in his ear; “you make
+these fools believe that it will last for ever. Then, they are the more
+insolent, and it is the nearer ended.”
+
+“Hey!” cried the mender of roads, reflectively; “that’s true.”
+
+“These fools know nothing. While they despise your breath, and would
+stop it for ever and ever, in you or in a hundred like you rather than
+in one of their own horses or dogs, they only know what your breath
+tells them. Let it deceive them, then, a little longer; it cannot
+deceive them too much.”
+
+Madame Defarge looked superciliously at the client, and nodded in
+confirmation.
+
+“As to you,” said she, “you would shout and shed tears for anything, if
+it made a show and a noise. Say! Would you not?”
+
+“Truly, madame, I think so. For the moment.”
+
+“If you were shown a great heap of dolls, and were set upon them to
+pluck them to pieces and despoil them for your own advantage, you would
+pick out the richest and gayest. Say! Would you not?”
+
+“Truly yes, madame.”
+
+“Yes. And if you were shown a flock of birds, unable to fly, and were
+set upon them to strip them of their feathers for your own advantage,
+you would set upon the birds of the finest feathers; would you not?”
+
+“It is true, madame.”
+
+“You have seen both dolls and birds to-day,” said Madame Defarge, with
+a wave of her hand towards the place where they had last been apparent;
+“now, go home!”
+
+
+
+
+XVI. Still Knitting
+
+
+Madame Defarge and monsieur her husband returned amicably to the
+bosom of Saint Antoine, while a speck in a blue cap toiled through the
+darkness, and through the dust, and down the weary miles of avenue by
+the wayside, slowly tending towards that point of the compass where
+the chateau of Monsieur the Marquis, now in his grave, listened to
+the whispering trees. Such ample leisure had the stone faces, now,
+for listening to the trees and to the fountain, that the few village
+scarecrows who, in their quest for herbs to eat and fragments of dead
+stick to burn, strayed within sight of the great stone courtyard and
+terrace staircase, had it borne in upon their starved fancy that
+the expression of the faces was altered. A rumour just lived in the
+village--had a faint and bare existence there, as its people had--that
+when the knife struck home, the faces changed, from faces of pride to
+faces of anger and pain; also, that when that dangling figure was hauled
+up forty feet above the fountain, they changed again, and bore a cruel
+look of being avenged, which they would henceforth bear for ever. In the
+stone face over the great window of the bed-chamber where the murder
+was done, two fine dints were pointed out in the sculptured nose, which
+everybody recognised, and which nobody had seen of old; and on the
+scarce occasions when two or three ragged peasants emerged from the
+crowd to take a hurried peep at Monsieur the Marquis petrified, a
+skinny finger would not have pointed to it for a minute, before they all
+started away among the moss and leaves, like the more fortunate hares
+who could find a living there.
+
+Chateau and hut, stone face and dangling figure, the red stain on the
+stone floor, and the pure water in the village well--thousands of acres
+of land--a whole province of France--all France itself--lay under the
+night sky, concentrated into a faint hair-breadth line. So does a whole
+world, with all its greatnesses and littlenesses, lie in a twinkling
+star. And as mere human knowledge can split a ray of light and analyse
+the manner of its composition, so, sublimer intelligences may read in
+the feeble shining of this earth of ours, every thought and act, every
+vice and virtue, of every responsible creature on it.
+
+The Defarges, husband and wife, came lumbering under the starlight,
+in their public vehicle, to that gate of Paris whereunto their
+journey naturally tended. There was the usual stoppage at the barrier
+guardhouse, and the usual lanterns came glancing forth for the usual
+examination and inquiry. Monsieur Defarge alighted; knowing one or two
+of the soldiery there, and one of the police. The latter he was intimate
+with, and affectionately embraced.
+
+When Saint Antoine had again enfolded the Defarges in his dusky wings,
+and they, having finally alighted near the Saint’s boundaries, were
+picking their way on foot through the black mud and offal of his
+streets, Madame Defarge spoke to her husband:
+
+“Say then, my friend; what did Jacques of the police tell thee?”
+
+“Very little to-night, but all he knows. There is another spy
+commissioned for our quarter. There may be many more, for all that he
+can say, but he knows of one.”
+
+“Eh well!” said Madame Defarge, raising her eyebrows with a cool
+business air. “It is necessary to register him. How do they call that
+man?”
+
+“He is English.”
+
+“So much the better. His name?”
+
+“Barsad,” said Defarge, making it French by pronunciation. But, he had
+been so careful to get it accurately, that he then spelt it with perfect
+correctness.
+
+“Barsad,” repeated madame. “Good. Christian name?”
+
+“John.”
+
+“John Barsad,” repeated madame, after murmuring it once to herself.
+“Good. His appearance; is it known?”
+
+“Age, about forty years; height, about five feet nine; black hair;
+complexion dark; generally, rather handsome visage; eyes dark, face
+thin, long, and sallow; nose aquiline, but not straight, having a
+peculiar inclination towards the left cheek; expression, therefore,
+sinister.”
+
+“Eh my faith. It is a portrait!” said madame, laughing. “He shall be
+registered to-morrow.”
+
+They turned into the wine-shop, which was closed (for it was midnight),
+and where Madame Defarge immediately took her post at her desk, counted
+the small moneys that had been taken during her absence, examined the
+stock, went through the entries in the book, made other entries of
+her own, checked the serving man in every possible way, and finally
+dismissed him to bed. Then she turned out the contents of the bowl
+of money for the second time, and began knotting them up in her
+handkerchief, in a chain of separate knots, for safe keeping through the
+night. All this while, Defarge, with his pipe in his mouth, walked
+up and down, complacently admiring, but never interfering; in which
+condition, indeed, as to the business and his domestic affairs, he
+walked up and down through life.
+
+The night was hot, and the shop, close shut and surrounded by so foul a
+neighbourhood, was ill-smelling. Monsieur Defarge’s olfactory sense was
+by no means delicate, but the stock of wine smelt much stronger than
+it ever tasted, and so did the stock of rum and brandy and aniseed. He
+whiffed the compound of scents away, as he put down his smoked-out pipe.
+
+“You are fatigued,” said madame, raising her glance as she knotted the
+money. “There are only the usual odours.”
+
+“I am a little tired,” her husband acknowledged.
+
+“You are a little depressed, too,” said madame, whose quick eyes had
+never been so intent on the accounts, but they had had a ray or two for
+him. “Oh, the men, the men!”
+
+“But my dear!” began Defarge.
+
+“But my dear!” repeated madame, nodding firmly; “but my dear! You are
+faint of heart to-night, my dear!”
+
+“Well, then,” said Defarge, as if a thought were wrung out of his
+breast, “it _is_ a long time.”
+
+“It is a long time,” repeated his wife; “and when is it not a long time?
+Vengeance and retribution require a long time; it is the rule.”
+
+“It does not take a long time to strike a man with Lightning,” said
+Defarge.
+
+“How long,” demanded madame, composedly, “does it take to make and store
+the lightning? Tell me.”
+
+Defarge raised his head thoughtfully, as if there were something in that
+too.
+
+“It does not take a long time,” said madame, “for an earthquake to
+swallow a town. Eh well! Tell me how long it takes to prepare the
+earthquake?”
+
+“A long time, I suppose,” said Defarge.
+
+“But when it is ready, it takes place, and grinds to pieces everything
+before it. In the meantime, it is always preparing, though it is not
+seen or heard. That is your consolation. Keep it.”
+
+She tied a knot with flashing eyes, as if it throttled a foe.
+
+“I tell thee,” said madame, extending her right hand, for emphasis,
+“that although it is a long time on the road, it is on the road and
+coming. I tell thee it never retreats, and never stops. I tell thee it
+is always advancing. Look around and consider the lives of all the world
+that we know, consider the faces of all the world that we know, consider
+the rage and discontent to which the Jacquerie addresses itself with
+more and more of certainty every hour. Can such things last? Bah! I mock
+you.”
+
+“My brave wife,” returned Defarge, standing before her with his head
+a little bent, and his hands clasped at his back, like a docile and
+attentive pupil before his catechist, “I do not question all this. But
+it has lasted a long time, and it is possible--you know well, my wife,
+it is possible--that it may not come, during our lives.”
+
+“Eh well! How then?” demanded madame, tying another knot, as if there
+were another enemy strangled.
+
+“Well!” said Defarge, with a half complaining and half apologetic shrug.
+“We shall not see the triumph.”
+
+“We shall have helped it,” returned madame, with her extended hand in
+strong action. “Nothing that we do, is done in vain. I believe, with all
+my soul, that we shall see the triumph. But even if not, even if I knew
+certainly not, show me the neck of an aristocrat and tyrant, and still I
+would--”
+
+Then madame, with her teeth set, tied a very terrible knot indeed.
+
+“Hold!” cried Defarge, reddening a little as if he felt charged with
+cowardice; “I too, my dear, will stop at nothing.”
+
+“Yes! But it is your weakness that you sometimes need to see your victim
+and your opportunity, to sustain you. Sustain yourself without that.
+When the time comes, let loose a tiger and a devil; but wait for the
+time with the tiger and the devil chained--not shown--yet always ready.”
+
+Madame enforced the conclusion of this piece of advice by striking her
+little counter with her chain of money as if she knocked its brains
+out, and then gathering the heavy handkerchief under her arm in a serene
+manner, and observing that it was time to go to bed.
+
+Next noontide saw the admirable woman in her usual place in the
+wine-shop, knitting away assiduously. A rose lay beside her, and if she
+now and then glanced at the flower, it was with no infraction of her
+usual preoccupied air. There were a few customers, drinking or not
+drinking, standing or seated, sprinkled about. The day was very hot,
+and heaps of flies, who were extending their inquisitive and adventurous
+perquisitions into all the glutinous little glasses near madame, fell
+dead at the bottom. Their decease made no impression on the other flies
+out promenading, who looked at them in the coolest manner (as if they
+themselves were elephants, or something as far removed), until they met
+the same fate. Curious to consider how heedless flies are!--perhaps they
+thought as much at Court that sunny summer day.
+
+A figure entering at the door threw a shadow on Madame Defarge which she
+felt to be a new one. She laid down her knitting, and began to pin her
+rose in her head-dress, before she looked at the figure.
+
+It was curious. The moment Madame Defarge took up the rose, the
+customers ceased talking, and began gradually to drop out of the
+wine-shop.
+
+“Good day, madame,” said the new-comer.
+
+“Good day, monsieur.”
+
+She said it aloud, but added to herself, as she resumed her knitting:
+“Hah! Good day, age about forty, height about five feet nine, black
+hair, generally rather handsome visage, complexion dark, eyes dark,
+thin, long and sallow face, aquiline nose but not straight, having a
+peculiar inclination towards the left cheek which imparts a sinister
+expression! Good day, one and all!”
+
+“Have the goodness to give me a little glass of old cognac, and a
+mouthful of cool fresh water, madame.”
+
+Madame complied with a polite air.
+
+“Marvellous cognac this, madame!”
+
+It was the first time it had ever been so complimented, and Madame
+Defarge knew enough of its antecedents to know better. She said,
+however, that the cognac was flattered, and took up her knitting. The
+visitor watched her fingers for a few moments, and took the opportunity
+of observing the place in general.
+
+“You knit with great skill, madame.”
+
+“I am accustomed to it.”
+
+“A pretty pattern too!”
+
+“_You_ think so?” said madame, looking at him with a smile.
+
+“Decidedly. May one ask what it is for?”
+
+“Pastime,” said madame, still looking at him with a smile while her
+fingers moved nimbly.
+
+“Not for use?”
+
+“That depends. I may find a use for it one day. If I do--Well,” said
+madame, drawing a breath and nodding her head with a stern kind of
+coquetry, “I’ll use it!”
+
+It was remarkable; but, the taste of Saint Antoine seemed to be
+decidedly opposed to a rose on the head-dress of Madame Defarge. Two
+men had entered separately, and had been about to order drink, when,
+catching sight of that novelty, they faltered, made a pretence of
+looking about as if for some friend who was not there, and went away.
+Nor, of those who had been there when this visitor entered, was there
+one left. They had all dropped off. The spy had kept his eyes open,
+but had been able to detect no sign. They had lounged away in a
+poverty-stricken, purposeless, accidental manner, quite natural and
+unimpeachable.
+
+“_John_,” thought madame, checking off her work as her fingers knitted,
+and her eyes looked at the stranger. “Stay long enough, and I shall knit
+‘BARSAD’ before you go.”
+
+“You have a husband, madame?”
+
+“I have.”
+
+“Children?”
+
+“No children.”
+
+“Business seems bad?”
+
+“Business is very bad; the people are so poor.”
+
+“Ah, the unfortunate, miserable people! So oppressed, too--as you say.”
+
+“As _you_ say,” madame retorted, correcting him, and deftly knitting an
+extra something into his name that boded him no good.
+
+“Pardon me; certainly it was I who said so, but you naturally think so.
+Of course.”
+
+“_I_ think?” returned madame, in a high voice. “I and my husband have
+enough to do to keep this wine-shop open, without thinking. All we
+think, here, is how to live. That is the subject _we_ think of, and
+it gives us, from morning to night, enough to think about, without
+embarrassing our heads concerning others. _I_ think for others? No, no.”
+
+The spy, who was there to pick up any crumbs he could find or make, did
+not allow his baffled state to express itself in his sinister face; but,
+stood with an air of gossiping gallantry, leaning his elbow on Madame
+Defarge’s little counter, and occasionally sipping his cognac.
+
+“A bad business this, madame, of Gaspard’s execution. Ah! the poor
+Gaspard!” With a sigh of great compassion.
+
+“My faith!” returned madame, coolly and lightly, “if people use knives
+for such purposes, they have to pay for it. He knew beforehand what the
+price of his luxury was; he has paid the price.”
+
+“I believe,” said the spy, dropping his soft voice to a tone
+that invited confidence, and expressing an injured revolutionary
+susceptibility in every muscle of his wicked face: “I believe there
+is much compassion and anger in this neighbourhood, touching the poor
+fellow? Between ourselves.”
+
+“Is there?” asked madame, vacantly.
+
+“Is there not?”
+
+“--Here is my husband!” said Madame Defarge.
+
+As the keeper of the wine-shop entered at the door, the spy saluted
+him by touching his hat, and saying, with an engaging smile, “Good day,
+Jacques!” Defarge stopped short, and stared at him.
+
+“Good day, Jacques!” the spy repeated; with not quite so much
+confidence, or quite so easy a smile under the stare.
+
+“You deceive yourself, monsieur,” returned the keeper of the wine-shop.
+“You mistake me for another. That is not my name. I am Ernest Defarge.”
+
+“It is all the same,” said the spy, airily, but discomfited too: “good
+day!”
+
+“Good day!” answered Defarge, drily.
+
+“I was saying to madame, with whom I had the pleasure of chatting when
+you entered, that they tell me there is--and no wonder!--much sympathy
+and anger in Saint Antoine, touching the unhappy fate of poor Gaspard.”
+
+“No one has told me so,” said Defarge, shaking his head. “I know nothing
+of it.”
+
+Having said it, he passed behind the little counter, and stood with his
+hand on the back of his wife’s chair, looking over that barrier at the
+person to whom they were both opposed, and whom either of them would
+have shot with the greatest satisfaction.
+
+The spy, well used to his business, did not change his unconscious
+attitude, but drained his little glass of cognac, took a sip of fresh
+water, and asked for another glass of cognac. Madame Defarge poured it
+out for him, took to her knitting again, and hummed a little song over
+it.
+
+“You seem to know this quarter well; that is to say, better than I do?”
+ observed Defarge.
+
+“Not at all, but I hope to know it better. I am so profoundly interested
+in its miserable inhabitants.”
+
+“Hah!” muttered Defarge.
+
+“The pleasure of conversing with you, Monsieur Defarge, recalls to me,”
+ pursued the spy, “that I have the honour of cherishing some interesting
+associations with your name.”
+
+“Indeed!” said Defarge, with much indifference.
+
+“Yes, indeed. When Doctor Manette was released, you, his old domestic,
+had the charge of him, I know. He was delivered to you. You see I am
+informed of the circumstances?”
+
+“Such is the fact, certainly,” said Defarge. He had had it conveyed
+to him, in an accidental touch of his wife’s elbow as she knitted and
+warbled, that he would do best to answer, but always with brevity.
+
+“It was to you,” said the spy, “that his daughter came; and it was
+from your care that his daughter took him, accompanied by a neat brown
+monsieur; how is he called?--in a little wig--Lorry--of the bank of
+Tellson and Company--over to England.”
+
+“Such is the fact,” repeated Defarge.
+
+“Very interesting remembrances!” said the spy. “I have known Doctor
+Manette and his daughter, in England.”
+
+“Yes?” said Defarge.
+
+“You don’t hear much about them now?” said the spy.
+
+“No,” said Defarge.
+
+“In effect,” madame struck in, looking up from her work and her little
+song, “we never hear about them. We received the news of their safe
+arrival, and perhaps another letter, or perhaps two; but, since then,
+they have gradually taken their road in life--we, ours--and we have held
+no correspondence.”
+
+“Perfectly so, madame,” replied the spy. “She is going to be married.”
+
+“Going?” echoed madame. “She was pretty enough to have been married long
+ago. You English are cold, it seems to me.”
+
+“Oh! You know I am English.”
+
+“I perceive your tongue is,” returned madame; “and what the tongue is, I
+suppose the man is.”
+
+He did not take the identification as a compliment; but he made the best
+of it, and turned it off with a laugh. After sipping his cognac to the
+end, he added:
+
+“Yes, Miss Manette is going to be married. But not to an Englishman; to
+one who, like herself, is French by birth. And speaking of Gaspard (ah,
+poor Gaspard! It was cruel, cruel!), it is a curious thing that she is
+going to marry the nephew of Monsieur the Marquis, for whom Gaspard
+was exalted to that height of so many feet; in other words, the present
+Marquis. But he lives unknown in England, he is no Marquis there; he is
+Mr. Charles Darnay. D’Aulnais is the name of his mother’s family.”
+
+Madame Defarge knitted steadily, but the intelligence had a palpable
+effect upon her husband. Do what he would, behind the little counter,
+as to the striking of a light and the lighting of his pipe, he was
+troubled, and his hand was not trustworthy. The spy would have been no
+spy if he had failed to see it, or to record it in his mind.
+
+Having made, at least, this one hit, whatever it might prove to be
+worth, and no customers coming in to help him to any other, Mr. Barsad
+paid for what he had drunk, and took his leave: taking occasion to say,
+in a genteel manner, before he departed, that he looked forward to the
+pleasure of seeing Monsieur and Madame Defarge again. For some minutes
+after he had emerged into the outer presence of Saint Antoine, the
+husband and wife remained exactly as he had left them, lest he should
+come back.
+
+“Can it be true,” said Defarge, in a low voice, looking down at his wife
+as he stood smoking with his hand on the back of her chair: “what he has
+said of Ma’amselle Manette?”
+
+“As he has said it,” returned madame, lifting her eyebrows a little, “it
+is probably false. But it may be true.”
+
+“If it is--” Defarge began, and stopped.
+
+“If it is?” repeated his wife.
+
+“--And if it does come, while we live to see it triumph--I hope, for her
+sake, Destiny will keep her husband out of France.”
+
+“Her husband’s destiny,” said Madame Defarge, with her usual composure,
+“will take him where he is to go, and will lead him to the end that is
+to end him. That is all I know.”
+
+“But it is very strange--now, at least, is it not very strange”--said
+Defarge, rather pleading with his wife to induce her to admit it,
+“that, after all our sympathy for Monsieur her father, and herself, her
+husband’s name should be proscribed under your hand at this moment, by
+the side of that infernal dog’s who has just left us?”
+
+“Stranger things than that will happen when it does come,” answered
+madame. “I have them both here, of a certainty; and they are both here
+for their merits; that is enough.”
+
+She rolled up her knitting when she had said those words, and presently
+took the rose out of the handkerchief that was wound about her head.
+Either Saint Antoine had an instinctive sense that the objectionable
+decoration was gone, or Saint Antoine was on the watch for its
+disappearance; howbeit, the Saint took courage to lounge in, very
+shortly afterwards, and the wine-shop recovered its habitual aspect.
+
+In the evening, at which season of all others Saint Antoine turned
+himself inside out, and sat on door-steps and window-ledges, and came
+to the corners of vile streets and courts, for a breath of air, Madame
+Defarge with her work in her hand was accustomed to pass from place
+to place and from group to group: a Missionary--there were many like
+her--such as the world will do well never to breed again. All the women
+knitted. They knitted worthless things; but, the mechanical work was a
+mechanical substitute for eating and drinking; the hands moved for the
+jaws and the digestive apparatus: if the bony fingers had been still,
+the stomachs would have been more famine-pinched.
+
+But, as the fingers went, the eyes went, and the thoughts. And as Madame
+Defarge moved on from group to group, all three went quicker and fiercer
+among every little knot of women that she had spoken with, and left
+behind.
+
+Her husband smoked at his door, looking after her with admiration. “A
+great woman,” said he, “a strong woman, a grand woman, a frightfully
+grand woman!”
+
+Darkness closed around, and then came the ringing of church bells and
+the distant beating of the military drums in the Palace Courtyard, as
+the women sat knitting, knitting. Darkness encompassed them. Another
+darkness was closing in as surely, when the church bells, then ringing
+pleasantly in many an airy steeple over France, should be melted into
+thundering cannon; when the military drums should be beating to drown a
+wretched voice, that night all potent as the voice of Power and Plenty,
+Freedom and Life. So much was closing in about the women who sat
+knitting, knitting, that they their very selves were closing in around
+a structure yet unbuilt, where they were to sit knitting, knitting,
+counting dropping heads.
+
+
+
+
+XVII. One Night
+
+
+Never did the sun go down with a brighter glory on the quiet corner in
+Soho, than one memorable evening when the Doctor and his daughter sat
+under the plane-tree together. Never did the moon rise with a milder
+radiance over great London, than on that night when it found them still
+seated under the tree, and shone upon their faces through its leaves.
+
+Lucie was to be married to-morrow. She had reserved this last evening
+for her father, and they sat alone under the plane-tree.
+
+“You are happy, my dear father?”
+
+“Quite, my child.”
+
+They had said little, though they had been there a long time. When it
+was yet light enough to work and read, she had neither engaged herself
+in her usual work, nor had she read to him. She had employed herself in
+both ways, at his side under the tree, many and many a time; but, this
+time was not quite like any other, and nothing could make it so.
+
+“And I am very happy to-night, dear father. I am deeply happy in the
+love that Heaven has so blessed--my love for Charles, and Charles’s love
+for me. But, if my life were not to be still consecrated to you, or
+if my marriage were so arranged as that it would part us, even by
+the length of a few of these streets, I should be more unhappy and
+self-reproachful now than I can tell you. Even as it is--”
+
+Even as it was, she could not command her voice.
+
+In the sad moonlight, she clasped him by the neck, and laid her face
+upon his breast. In the moonlight which is always sad, as the light of
+the sun itself is--as the light called human life is--at its coming and
+its going.
+
+“Dearest dear! Can you tell me, this last time, that you feel quite,
+quite sure, no new affections of mine, and no new duties of mine, will
+ever interpose between us? _I_ know it well, but do you know it? In your
+own heart, do you feel quite certain?”
+
+Her father answered, with a cheerful firmness of conviction he could
+scarcely have assumed, “Quite sure, my darling! More than that,” he
+added, as he tenderly kissed her: “my future is far brighter, Lucie,
+seen through your marriage, than it could have been--nay, than it ever
+was--without it.”
+
+“If I could hope _that_, my father!--”
+
+“Believe it, love! Indeed it is so. Consider how natural and how plain
+it is, my dear, that it should be so. You, devoted and young, cannot
+fully appreciate the anxiety I have felt that your life should not be
+wasted--”
+
+She moved her hand towards his lips, but he took it in his, and repeated
+the word.
+
+“--wasted, my child--should not be wasted, struck aside from the
+natural order of things--for my sake. Your unselfishness cannot entirely
+comprehend how much my mind has gone on this; but, only ask yourself,
+how could my happiness be perfect, while yours was incomplete?”
+
+“If I had never seen Charles, my father, I should have been quite happy
+with you.”
+
+He smiled at her unconscious admission that she would have been unhappy
+without Charles, having seen him; and replied:
+
+“My child, you did see him, and it is Charles. If it had not been
+Charles, it would have been another. Or, if it had been no other, I
+should have been the cause, and then the dark part of my life would have
+cast its shadow beyond myself, and would have fallen on you.”
+
+It was the first time, except at the trial, of her ever hearing him
+refer to the period of his suffering. It gave her a strange and new
+sensation while his words were in her ears; and she remembered it long
+afterwards.
+
+“See!” said the Doctor of Beauvais, raising his hand towards the moon.
+“I have looked at her from my prison-window, when I could not bear her
+light. I have looked at her when it has been such torture to me to think
+of her shining upon what I had lost, that I have beaten my head against
+my prison-walls. I have looked at her, in a state so dull and lethargic,
+that I have thought of nothing but the number of horizontal lines I
+could draw across her at the full, and the number of perpendicular lines
+with which I could intersect them.” He added in his inward and pondering
+manner, as he looked at the moon, “It was twenty either way, I remember,
+and the twentieth was difficult to squeeze in.”
+
+The strange thrill with which she heard him go back to that time,
+deepened as he dwelt upon it; but, there was nothing to shock her in
+the manner of his reference. He only seemed to contrast his present
+cheerfulness and felicity with the dire endurance that was over.
+
+“I have looked at her, speculating thousands of times upon the unborn
+child from whom I had been rent. Whether it was alive. Whether it had
+been born alive, or the poor mother’s shock had killed it. Whether it
+was a son who would some day avenge his father. (There was a time in my
+imprisonment, when my desire for vengeance was unbearable.) Whether it
+was a son who would never know his father’s story; who might even live
+to weigh the possibility of his father’s having disappeared of his own
+will and act. Whether it was a daughter who would grow to be a woman.”
+
+She drew closer to him, and kissed his cheek and his hand.
+
+“I have pictured my daughter, to myself, as perfectly forgetful of
+me--rather, altogether ignorant of me, and unconscious of me. I have
+cast up the years of her age, year after year. I have seen her married
+to a man who knew nothing of my fate. I have altogether perished from
+the remembrance of the living, and in the next generation my place was a
+blank.”
+
+“My father! Even to hear that you had such thoughts of a daughter who
+never existed, strikes to my heart as if I had been that child.”
+
+“You, Lucie? It is out of the Consolation and restoration you have
+brought to me, that these remembrances arise, and pass between us and
+the moon on this last night.--What did I say just now?”
+
+“She knew nothing of you. She cared nothing for you.”
+
+“So! But on other moonlight nights, when the sadness and the silence
+have touched me in a different way--have affected me with something as
+like a sorrowful sense of peace, as any emotion that had pain for its
+foundations could--I have imagined her as coming to me in my cell, and
+leading me out into the freedom beyond the fortress. I have seen her
+image in the moonlight often, as I now see you; except that I never held
+her in my arms; it stood between the little grated window and the door.
+But, you understand that that was not the child I am speaking of?”
+
+“The figure was not; the--the--image; the fancy?”
+
+“No. That was another thing. It stood before my disturbed sense of
+sight, but it never moved. The phantom that my mind pursued, was another
+and more real child. Of her outward appearance I know no more than
+that she was like her mother. The other had that likeness too--as you
+have--but was not the same. Can you follow me, Lucie? Hardly, I think?
+I doubt you must have been a solitary prisoner to understand these
+perplexed distinctions.”
+
+His collected and calm manner could not prevent her blood from running
+cold, as he thus tried to anatomise his old condition.
+
+“In that more peaceful state, I have imagined her, in the moonlight,
+coming to me and taking me out to show me that the home of her married
+life was full of her loving remembrance of her lost father. My picture
+was in her room, and I was in her prayers. Her life was active,
+cheerful, useful; but my poor history pervaded it all.”
+
+“I was that child, my father, I was not half so good, but in my love
+that was I.”
+
+“And she showed me her children,” said the Doctor of Beauvais, “and
+they had heard of me, and had been taught to pity me. When they passed
+a prison of the State, they kept far from its frowning walls, and looked
+up at its bars, and spoke in whispers. She could never deliver me; I
+imagined that she always brought me back after showing me such things.
+But then, blessed with the relief of tears, I fell upon my knees, and
+blessed her.”
+
+“I am that child, I hope, my father. O my dear, my dear, will you bless
+me as fervently to-morrow?”
+
+“Lucie, I recall these old troubles in the reason that I have to-night
+for loving you better than words can tell, and thanking God for my great
+happiness. My thoughts, when they were wildest, never rose near the
+happiness that I have known with you, and that we have before us.”
+
+He embraced her, solemnly commended her to Heaven, and humbly thanked
+Heaven for having bestowed her on him. By-and-bye, they went into the
+house.
+
+There was no one bidden to the marriage but Mr. Lorry; there was even to
+be no bridesmaid but the gaunt Miss Pross. The marriage was to make no
+change in their place of residence; they had been able to extend it,
+by taking to themselves the upper rooms formerly belonging to the
+apocryphal invisible lodger, and they desired nothing more.
+
+Doctor Manette was very cheerful at the little supper. They were only
+three at table, and Miss Pross made the third. He regretted that Charles
+was not there; was more than half disposed to object to the loving
+little plot that kept him away; and drank to him affectionately.
+
+So, the time came for him to bid Lucie good night, and they separated.
+But, in the stillness of the third hour of the morning, Lucie came
+downstairs again, and stole into his room; not free from unshaped fears,
+beforehand.
+
+All things, however, were in their places; all was quiet; and he lay
+asleep, his white hair picturesque on the untroubled pillow, and his
+hands lying quiet on the coverlet. She put her needless candle in the
+shadow at a distance, crept up to his bed, and put her lips to his;
+then, leaned over him, and looked at him.
+
+Into his handsome face, the bitter waters of captivity had worn; but, he
+covered up their tracks with a determination so strong, that he held the
+mastery of them even in his sleep. A more remarkable face in its quiet,
+resolute, and guarded struggle with an unseen assailant, was not to be
+beheld in all the wide dominions of sleep, that night.
+
+She timidly laid her hand on his dear breast, and put up a prayer that
+she might ever be as true to him as her love aspired to be, and as his
+sorrows deserved. Then, she withdrew her hand, and kissed his lips once
+more, and went away. So, the sunrise came, and the shadows of the leaves
+of the plane-tree moved upon his face, as softly as her lips had moved
+in praying for him.
+
+
+
+
+XVIII. Nine Days
+
+
+The marriage-day was shining brightly, and they were ready outside the
+closed door of the Doctor’s room, where he was speaking with Charles
+Darnay. They were ready to go to church; the beautiful bride, Mr.
+Lorry, and Miss Pross--to whom the event, through a gradual process of
+reconcilement to the inevitable, would have been one of absolute bliss,
+but for the yet lingering consideration that her brother Solomon should
+have been the bridegroom.
+
+“And so,” said Mr. Lorry, who could not sufficiently admire the bride,
+and who had been moving round her to take in every point of her quiet,
+pretty dress; “and so it was for this, my sweet Lucie, that I brought
+you across the Channel, such a baby! Lord bless me! How little I thought
+what I was doing! How lightly I valued the obligation I was conferring
+on my friend Mr. Charles!”
+
+“You didn’t mean it,” remarked the matter-of-fact Miss Pross, “and
+therefore how could you know it? Nonsense!”
+
+“Really? Well; but don’t cry,” said the gentle Mr. Lorry.
+
+“I am not crying,” said Miss Pross; “_you_ are.”
+
+“I, my Pross?” (By this time, Mr. Lorry dared to be pleasant with her,
+on occasion.)
+
+“You were, just now; I saw you do it, and I don’t wonder at it. Such
+a present of plate as you have made ‘em, is enough to bring tears into
+anybody’s eyes. There’s not a fork or a spoon in the collection,” said
+Miss Pross, “that I didn’t cry over, last night after the box came, till
+I couldn’t see it.”
+
+“I am highly gratified,” said Mr. Lorry, “though, upon my honour, I
+had no intention of rendering those trifling articles of remembrance
+invisible to any one. Dear me! This is an occasion that makes a man
+speculate on all he has lost. Dear, dear, dear! To think that there
+might have been a Mrs. Lorry, any time these fifty years almost!”
+
+“Not at all!” From Miss Pross.
+
+“You think there never might have been a Mrs. Lorry?” asked the
+gentleman of that name.
+
+“Pooh!” rejoined Miss Pross; “you were a bachelor in your cradle.”
+
+“Well!” observed Mr. Lorry, beamingly adjusting his little wig, “that
+seems probable, too.”
+
+“And you were cut out for a bachelor,” pursued Miss Pross, “before you
+were put in your cradle.”
+
+“Then, I think,” said Mr. Lorry, “that I was very unhandsomely dealt
+with, and that I ought to have had a voice in the selection of my
+pattern. Enough! Now, my dear Lucie,” drawing his arm soothingly round
+her waist, “I hear them moving in the next room, and Miss Pross and
+I, as two formal folks of business, are anxious not to lose the final
+opportunity of saying something to you that you wish to hear. You leave
+your good father, my dear, in hands as earnest and as loving as your
+own; he shall be taken every conceivable care of; during the next
+fortnight, while you are in Warwickshire and thereabouts, even Tellson’s
+shall go to the wall (comparatively speaking) before him. And when, at
+the fortnight’s end, he comes to join you and your beloved husband, on
+your other fortnight’s trip in Wales, you shall say that we have sent
+him to you in the best health and in the happiest frame. Now, I hear
+Somebody’s step coming to the door. Let me kiss my dear girl with an
+old-fashioned bachelor blessing, before Somebody comes to claim his
+own.”
+
+For a moment, he held the fair face from him to look at the
+well-remembered expression on the forehead, and then laid the bright
+golden hair against his little brown wig, with a genuine tenderness and
+delicacy which, if such things be old-fashioned, were as old as Adam.
+
+The door of the Doctor’s room opened, and he came out with Charles
+Darnay. He was so deadly pale--which had not been the case when they
+went in together--that no vestige of colour was to be seen in his face.
+But, in the composure of his manner he was unaltered, except that to the
+shrewd glance of Mr. Lorry it disclosed some shadowy indication that the
+old air of avoidance and dread had lately passed over him, like a cold
+wind.
+
+He gave his arm to his daughter, and took her down-stairs to the chariot
+which Mr. Lorry had hired in honour of the day. The rest followed in
+another carriage, and soon, in a neighbouring church, where no strange
+eyes looked on, Charles Darnay and Lucie Manette were happily married.
+
+Besides the glancing tears that shone among the smiles of the little
+group when it was done, some diamonds, very bright and sparkling,
+glanced on the bride’s hand, which were newly released from the
+dark obscurity of one of Mr. Lorry’s pockets. They returned home to
+breakfast, and all went well, and in due course the golden hair that had
+mingled with the poor shoemaker’s white locks in the Paris garret, were
+mingled with them again in the morning sunlight, on the threshold of the
+door at parting.
+
+It was a hard parting, though it was not for long. But her father
+cheered her, and said at last, gently disengaging himself from her
+enfolding arms, “Take her, Charles! She is yours!”
+
+And her agitated hand waved to them from a chaise window, and she was
+gone.
+
+The corner being out of the way of the idle and curious, and the
+preparations having been very simple and few, the Doctor, Mr. Lorry,
+and Miss Pross, were left quite alone. It was when they turned into
+the welcome shade of the cool old hall, that Mr. Lorry observed a great
+change to have come over the Doctor; as if the golden arm uplifted
+there, had struck him a poisoned blow.
+
+He had naturally repressed much, and some revulsion might have been
+expected in him when the occasion for repression was gone. But, it was
+the old scared lost look that troubled Mr. Lorry; and through his absent
+manner of clasping his head and drearily wandering away into his own
+room when they got up-stairs, Mr. Lorry was reminded of Defarge the
+wine-shop keeper, and the starlight ride.
+
+“I think,” he whispered to Miss Pross, after anxious consideration, “I
+think we had best not speak to him just now, or at all disturb him.
+I must look in at Tellson’s; so I will go there at once and come back
+presently. Then, we will take him a ride into the country, and dine
+there, and all will be well.”
+
+It was easier for Mr. Lorry to look in at Tellson’s, than to look out of
+Tellson’s. He was detained two hours. When he came back, he ascended the
+old staircase alone, having asked no question of the servant; going thus
+into the Doctor’s rooms, he was stopped by a low sound of knocking.
+
+“Good God!” he said, with a start. “What’s that?”
+
+Miss Pross, with a terrified face, was at his ear. “O me, O me! All is
+lost!” cried she, wringing her hands. “What is to be told to Ladybird?
+He doesn’t know me, and is making shoes!”
+
+Mr. Lorry said what he could to calm her, and went himself into the
+Doctor’s room. The bench was turned towards the light, as it had been
+when he had seen the shoemaker at his work before, and his head was bent
+down, and he was very busy.
+
+“Doctor Manette. My dear friend, Doctor Manette!”
+
+The Doctor looked at him for a moment--half inquiringly, half as if he
+were angry at being spoken to--and bent over his work again.
+
+He had laid aside his coat and waistcoat; his shirt was open at the
+throat, as it used to be when he did that work; and even the old
+haggard, faded surface of face had come back to him. He worked
+hard--impatiently--as if in some sense of having been interrupted.
+
+Mr. Lorry glanced at the work in his hand, and observed that it was a
+shoe of the old size and shape. He took up another that was lying by
+him, and asked what it was.
+
+“A young lady’s walking shoe,” he muttered, without looking up. “It
+ought to have been finished long ago. Let it be.”
+
+“But, Doctor Manette. Look at me!”
+
+He obeyed, in the old mechanically submissive manner, without pausing in
+his work.
+
+“You know me, my dear friend? Think again. This is not your proper
+occupation. Think, dear friend!”
+
+Nothing would induce him to speak more. He looked up, for an instant at
+a time, when he was requested to do so; but, no persuasion would extract
+a word from him. He worked, and worked, and worked, in silence, and
+words fell on him as they would have fallen on an echoless wall, or on
+the air. The only ray of hope that Mr. Lorry could discover, was, that
+he sometimes furtively looked up without being asked. In that, there
+seemed a faint expression of curiosity or perplexity--as though he were
+trying to reconcile some doubts in his mind.
+
+Two things at once impressed themselves on Mr. Lorry, as important above
+all others; the first, that this must be kept secret from Lucie;
+the second, that it must be kept secret from all who knew him. In
+conjunction with Miss Pross, he took immediate steps towards the latter
+precaution, by giving out that the Doctor was not well, and required a
+few days of complete rest. In aid of the kind deception to be practised
+on his daughter, Miss Pross was to write, describing his having been
+called away professionally, and referring to an imaginary letter of
+two or three hurried lines in his own hand, represented to have been
+addressed to her by the same post.
+
+These measures, advisable to be taken in any case, Mr. Lorry took in
+the hope of his coming to himself. If that should happen soon, he kept
+another course in reserve; which was, to have a certain opinion that he
+thought the best, on the Doctor’s case.
+
+In the hope of his recovery, and of resort to this third course
+being thereby rendered practicable, Mr. Lorry resolved to watch him
+attentively, with as little appearance as possible of doing so. He
+therefore made arrangements to absent himself from Tellson’s for the
+first time in his life, and took his post by the window in the same
+room.
+
+He was not long in discovering that it was worse than useless to speak
+to him, since, on being pressed, he became worried. He abandoned that
+attempt on the first day, and resolved merely to keep himself always
+before him, as a silent protest against the delusion into which he had
+fallen, or was falling. He remained, therefore, in his seat near the
+window, reading and writing, and expressing in as many pleasant and
+natural ways as he could think of, that it was a free place.
+
+Doctor Manette took what was given him to eat and drink, and worked on,
+that first day, until it was too dark to see--worked on, half an hour
+after Mr. Lorry could not have seen, for his life, to read or write.
+When he put his tools aside as useless, until morning, Mr. Lorry rose
+and said to him:
+
+“Will you go out?”
+
+He looked down at the floor on either side of him in the old manner,
+looked up in the old manner, and repeated in the old low voice:
+
+“Out?”
+
+“Yes; for a walk with me. Why not?”
+
+He made no effort to say why not, and said not a word more. But, Mr.
+Lorry thought he saw, as he leaned forward on his bench in the dusk,
+with his elbows on his knees and his head in his hands, that he was in
+some misty way asking himself, “Why not?” The sagacity of the man of
+business perceived an advantage here, and determined to hold it.
+
+Miss Pross and he divided the night into two watches, and observed him
+at intervals from the adjoining room. He paced up and down for a long
+time before he lay down; but, when he did finally lay himself down, he
+fell asleep. In the morning, he was up betimes, and went straight to his
+bench and to work.
+
+On this second day, Mr. Lorry saluted him cheerfully by his name,
+and spoke to him on topics that had been of late familiar to them. He
+returned no reply, but it was evident that he heard what was said, and
+that he thought about it, however confusedly. This encouraged Mr. Lorry
+to have Miss Pross in with her work, several times during the day;
+at those times, they quietly spoke of Lucie, and of her father then
+present, precisely in the usual manner, and as if there were nothing
+amiss. This was done without any demonstrative accompaniment, not long
+enough, or often enough to harass him; and it lightened Mr. Lorry’s
+friendly heart to believe that he looked up oftener, and that he
+appeared to be stirred by some perception of inconsistencies surrounding
+him.
+
+When it fell dark again, Mr. Lorry asked him as before:
+
+“Dear Doctor, will you go out?”
+
+As before, he repeated, “Out?”
+
+“Yes; for a walk with me. Why not?”
+
+This time, Mr. Lorry feigned to go out when he could extract no answer
+from him, and, after remaining absent for an hour, returned. In the
+meanwhile, the Doctor had removed to the seat in the window, and had
+sat there looking down at the plane-tree; but, on Mr. Lorry’s return, he
+slipped away to his bench.
+
+The time went very slowly on, and Mr. Lorry’s hope darkened, and his
+heart grew heavier again, and grew yet heavier and heavier every day.
+The third day came and went, the fourth, the fifth. Five days, six days,
+seven days, eight days, nine days.
+
+With a hope ever darkening, and with a heart always growing heavier and
+heavier, Mr. Lorry passed through this anxious time. The secret was
+well kept, and Lucie was unconscious and happy; but he could not fail to
+observe that the shoemaker, whose hand had been a little out at first,
+was growing dreadfully skilful, and that he had never been so intent on
+his work, and that his hands had never been so nimble and expert, as in
+the dusk of the ninth evening.
+
+
+
+
+XIX. An Opinion
+
+
+Worn out by anxious watching, Mr. Lorry fell asleep at his post. On the
+tenth morning of his suspense, he was startled by the shining of the sun
+into the room where a heavy slumber had overtaken him when it was dark
+night.
+
+He rubbed his eyes and roused himself; but he doubted, when he had
+done so, whether he was not still asleep. For, going to the door of the
+Doctor’s room and looking in, he perceived that the shoemaker’s bench
+and tools were put aside again, and that the Doctor himself sat reading
+at the window. He was in his usual morning dress, and his face (which
+Mr. Lorry could distinctly see), though still very pale, was calmly
+studious and attentive.
+
+Even when he had satisfied himself that he was awake, Mr. Lorry felt
+giddily uncertain for some few moments whether the late shoemaking might
+not be a disturbed dream of his own; for, did not his eyes show him his
+friend before him in his accustomed clothing and aspect, and employed
+as usual; and was there any sign within their range, that the change of
+which he had so strong an impression had actually happened?
+
+It was but the inquiry of his first confusion and astonishment, the
+answer being obvious. If the impression were not produced by a real
+corresponding and sufficient cause, how came he, Jarvis Lorry, there?
+How came he to have fallen asleep, in his clothes, on the sofa in Doctor
+Manette’s consulting-room, and to be debating these points outside the
+Doctor’s bedroom door in the early morning?
+
+Within a few minutes, Miss Pross stood whispering at his side. If he
+had had any particle of doubt left, her talk would of necessity have
+resolved it; but he was by that time clear-headed, and had none.
+He advised that they should let the time go by until the regular
+breakfast-hour, and should then meet the Doctor as if nothing unusual
+had occurred. If he appeared to be in his customary state of mind, Mr.
+Lorry would then cautiously proceed to seek direction and guidance from
+the opinion he had been, in his anxiety, so anxious to obtain.
+
+Miss Pross, submitting herself to his judgment, the scheme was worked
+out with care. Having abundance of time for his usual methodical
+toilette, Mr. Lorry presented himself at the breakfast-hour in his usual
+white linen, and with his usual neat leg. The Doctor was summoned in the
+usual way, and came to breakfast.
+
+So far as it was possible to comprehend him without overstepping those
+delicate and gradual approaches which Mr. Lorry felt to be the only safe
+advance, he at first supposed that his daughter’s marriage had taken
+place yesterday. An incidental allusion, purposely thrown out, to
+the day of the week, and the day of the month, set him thinking and
+counting, and evidently made him uneasy. In all other respects, however,
+he was so composedly himself, that Mr. Lorry determined to have the aid
+he sought. And that aid was his own.
+
+Therefore, when the breakfast was done and cleared away, and he and the
+Doctor were left together, Mr. Lorry said, feelingly:
+
+“My dear Manette, I am anxious to have your opinion, in confidence, on a
+very curious case in which I am deeply interested; that is to say, it is
+very curious to me; perhaps, to your better information it may be less
+so.”
+
+Glancing at his hands, which were discoloured by his late work, the
+Doctor looked troubled, and listened attentively. He had already glanced
+at his hands more than once.
+
+“Doctor Manette,” said Mr. Lorry, touching him affectionately on the
+arm, “the case is the case of a particularly dear friend of mine. Pray
+give your mind to it, and advise me well for his sake--and above all,
+for his daughter’s--his daughter’s, my dear Manette.”
+
+“If I understand,” said the Doctor, in a subdued tone, “some mental
+shock--?”
+
+“Yes!”
+
+“Be explicit,” said the Doctor. “Spare no detail.”
+
+Mr. Lorry saw that they understood one another, and proceeded.
+
+“My dear Manette, it is the case of an old and a prolonged shock,
+of great acuteness and severity to the affections, the feelings,
+the--the--as you express it--the mind. The mind. It is the case of a
+shock under which the sufferer was borne down, one cannot say for how
+long, because I believe he cannot calculate the time himself, and there
+are no other means of getting at it. It is the case of a shock from
+which the sufferer recovered, by a process that he cannot trace
+himself--as I once heard him publicly relate in a striking manner. It is
+the case of a shock from which he has recovered, so completely, as to
+be a highly intelligent man, capable of close application of mind, and
+great exertion of body, and of constantly making fresh additions to his
+stock of knowledge, which was already very large. But, unfortunately,
+there has been,” he paused and took a deep breath--“a slight relapse.”
+
+The Doctor, in a low voice, asked, “Of how long duration?”
+
+“Nine days and nights.”
+
+“How did it show itself? I infer,” glancing at his hands again, “in the
+resumption of some old pursuit connected with the shock?”
+
+“That is the fact.”
+
+“Now, did you ever see him,” asked the Doctor, distinctly and
+collectedly, though in the same low voice, “engaged in that pursuit
+originally?”
+
+“Once.”
+
+“And when the relapse fell on him, was he in most respects--or in all
+respects--as he was then?”
+
+“I think in all respects.”
+
+“You spoke of his daughter. Does his daughter know of the relapse?”
+
+“No. It has been kept from her, and I hope will always be kept from her.
+It is known only to myself, and to one other who may be trusted.”
+
+The Doctor grasped his hand, and murmured, “That was very kind. That was
+very thoughtful!” Mr. Lorry grasped his hand in return, and neither of
+the two spoke for a little while.
+
+“Now, my dear Manette,” said Mr. Lorry, at length, in his most
+considerate and most affectionate way, “I am a mere man of business,
+and unfit to cope with such intricate and difficult matters. I do not
+possess the kind of information necessary; I do not possess the kind of
+intelligence; I want guiding. There is no man in this world on whom
+I could so rely for right guidance, as on you. Tell me, how does this
+relapse come about? Is there danger of another? Could a repetition of it
+be prevented? How should a repetition of it be treated? How does it come
+about at all? What can I do for my friend? No man ever can have been
+more desirous in his heart to serve a friend, than I am to serve mine,
+if I knew how.
+
+“But I don’t know how to originate, in such a case. If your sagacity,
+knowledge, and experience, could put me on the right track, I might be
+able to do so much; unenlightened and undirected, I can do so little.
+Pray discuss it with me; pray enable me to see it a little more clearly,
+and teach me how to be a little more useful.”
+
+Doctor Manette sat meditating after these earnest words were spoken, and
+Mr. Lorry did not press him.
+
+“I think it probable,” said the Doctor, breaking silence with an effort,
+“that the relapse you have described, my dear friend, was not quite
+unforeseen by its subject.”
+
+“Was it dreaded by him?” Mr. Lorry ventured to ask.
+
+“Very much.” He said it with an involuntary shudder.
+
+“You have no idea how such an apprehension weighs on the sufferer’s
+mind, and how difficult--how almost impossible--it is, for him to force
+himself to utter a word upon the topic that oppresses him.”
+
+“Would he,” asked Mr. Lorry, “be sensibly relieved if he could prevail
+upon himself to impart that secret brooding to any one, when it is on
+him?”
+
+“I think so. But it is, as I have told you, next to impossible. I even
+believe it--in some cases--to be quite impossible.”
+
+“Now,” said Mr. Lorry, gently laying his hand on the Doctor’s arm again,
+after a short silence on both sides, “to what would you refer this
+attack?”
+
+“I believe,” returned Doctor Manette, “that there had been a strong and
+extraordinary revival of the train of thought and remembrance that
+was the first cause of the malady. Some intense associations of a most
+distressing nature were vividly recalled, I think. It is probable that
+there had long been a dread lurking in his mind, that those associations
+would be recalled--say, under certain circumstances--say, on a
+particular occasion. He tried to prepare himself in vain; perhaps the
+effort to prepare himself made him less able to bear it.”
+
+“Would he remember what took place in the relapse?” asked Mr. Lorry,
+with natural hesitation.
+
+The Doctor looked desolately round the room, shook his head, and
+answered, in a low voice, “Not at all.”
+
+“Now, as to the future,” hinted Mr. Lorry.
+
+“As to the future,” said the Doctor, recovering firmness, “I should have
+great hope. As it pleased Heaven in its mercy to restore him so soon, I
+should have great hope. He, yielding under the pressure of a complicated
+something, long dreaded and long vaguely foreseen and contended against,
+and recovering after the cloud had burst and passed, I should hope that
+the worst was over.”
+
+“Well, well! That’s good comfort. I am thankful!” said Mr. Lorry.
+
+“I am thankful!” repeated the Doctor, bending his head with reverence.
+
+“There are two other points,” said Mr. Lorry, “on which I am anxious to
+be instructed. I may go on?”
+
+“You cannot do your friend a better service.” The Doctor gave him his
+hand.
+
+“To the first, then. He is of a studious habit, and unusually energetic;
+he applies himself with great ardour to the acquisition of professional
+knowledge, to the conducting of experiments, to many things. Now, does
+he do too much?”
+
+“I think not. It may be the character of his mind, to be always in
+singular need of occupation. That may be, in part, natural to it; in
+part, the result of affliction. The less it was occupied with healthy
+things, the more it would be in danger of turning in the unhealthy
+direction. He may have observed himself, and made the discovery.”
+
+“You are sure that he is not under too great a strain?”
+
+“I think I am quite sure of it.”
+
+“My dear Manette, if he were overworked now--”
+
+“My dear Lorry, I doubt if that could easily be. There has been a
+violent stress in one direction, and it needs a counterweight.”
+
+“Excuse me, as a persistent man of business. Assuming for a moment,
+that he _was_ overworked; it would show itself in some renewal of this
+disorder?”
+
+“I do not think so. I do not think,” said Doctor Manette with the
+firmness of self-conviction, “that anything but the one train of
+association would renew it. I think that, henceforth, nothing but some
+extraordinary jarring of that chord could renew it. After what has
+happened, and after his recovery, I find it difficult to imagine any
+such violent sounding of that string again. I trust, and I almost
+believe, that the circumstances likely to renew it are exhausted.”
+
+He spoke with the diffidence of a man who knew how slight a thing
+would overset the delicate organisation of the mind, and yet with the
+confidence of a man who had slowly won his assurance out of personal
+endurance and distress. It was not for his friend to abate that
+confidence. He professed himself more relieved and encouraged than he
+really was, and approached his second and last point. He felt it to
+be the most difficult of all; but, remembering his old Sunday morning
+conversation with Miss Pross, and remembering what he had seen in the
+last nine days, he knew that he must face it.
+
+“The occupation resumed under the influence of this passing affliction
+so happily recovered from,” said Mr. Lorry, clearing his throat, “we
+will call--Blacksmith’s work, Blacksmith’s work. We will say, to put a
+case and for the sake of illustration, that he had been used, in his bad
+time, to work at a little forge. We will say that he was unexpectedly
+found at his forge again. Is it not a pity that he should keep it by
+him?”
+
+The Doctor shaded his forehead with his hand, and beat his foot
+nervously on the ground.
+
+“He has always kept it by him,” said Mr. Lorry, with an anxious look at
+his friend. “Now, would it not be better that he should let it go?”
+
+Still, the Doctor, with shaded forehead, beat his foot nervously on the
+ground.
+
+“You do not find it easy to advise me?” said Mr. Lorry. “I quite
+understand it to be a nice question. And yet I think--” And there he
+shook his head, and stopped.
+
+“You see,” said Doctor Manette, turning to him after an uneasy pause,
+“it is very hard to explain, consistently, the innermost workings
+of this poor man’s mind. He once yearned so frightfully for that
+occupation, and it was so welcome when it came; no doubt it relieved
+his pain so much, by substituting the perplexity of the fingers for
+the perplexity of the brain, and by substituting, as he became more
+practised, the ingenuity of the hands, for the ingenuity of the mental
+torture; that he has never been able to bear the thought of putting it
+quite out of his reach. Even now, when I believe he is more hopeful of
+himself than he has ever been, and even speaks of himself with a kind
+of confidence, the idea that he might need that old employment, and not
+find it, gives him a sudden sense of terror, like that which one may
+fancy strikes to the heart of a lost child.”
+
+He looked like his illustration, as he raised his eyes to Mr. Lorry’s
+face.
+
+“But may not--mind! I ask for information, as a plodding man of business
+who only deals with such material objects as guineas, shillings, and
+bank-notes--may not the retention of the thing involve the retention of
+the idea? If the thing were gone, my dear Manette, might not the fear go
+with it? In short, is it not a concession to the misgiving, to keep the
+forge?”
+
+There was another silence.
+
+“You see, too,” said the Doctor, tremulously, “it is such an old
+companion.”
+
+“I would not keep it,” said Mr. Lorry, shaking his head; for he gained
+in firmness as he saw the Doctor disquieted. “I would recommend him to
+sacrifice it. I only want your authority. I am sure it does no good.
+Come! Give me your authority, like a dear good man. For his daughter’s
+sake, my dear Manette!”
+
+Very strange to see what a struggle there was within him!
+
+“In her name, then, let it be done; I sanction it. But, I would not take
+it away while he was present. Let it be removed when he is not there;
+let him miss his old companion after an absence.”
+
+Mr. Lorry readily engaged for that, and the conference was ended. They
+passed the day in the country, and the Doctor was quite restored. On the
+three following days he remained perfectly well, and on the fourteenth
+day he went away to join Lucie and her husband. The precaution that
+had been taken to account for his silence, Mr. Lorry had previously
+explained to him, and he had written to Lucie in accordance with it, and
+she had no suspicions.
+
+On the night of the day on which he left the house, Mr. Lorry went into
+his room with a chopper, saw, chisel, and hammer, attended by Miss Pross
+carrying a light. There, with closed doors, and in a mysterious and
+guilty manner, Mr. Lorry hacked the shoemaker’s bench to pieces, while
+Miss Pross held the candle as if she were assisting at a murder--for
+which, indeed, in her grimness, she was no unsuitable figure. The
+burning of the body (previously reduced to pieces convenient for the
+purpose) was commenced without delay in the kitchen fire; and the tools,
+shoes, and leather, were buried in the garden. So wicked do destruction
+and secrecy appear to honest minds, that Mr. Lorry and Miss Pross,
+while engaged in the commission of their deed and in the removal of its
+traces, almost felt, and almost looked, like accomplices in a horrible
+crime.
+
+
+
+
+XX. A Plea
+
+
+When the newly-married pair came home, the first person who appeared, to
+offer his congratulations, was Sydney Carton. They had not been at home
+many hours, when he presented himself. He was not improved in habits, or
+in looks, or in manner; but there was a certain rugged air of fidelity
+about him, which was new to the observation of Charles Darnay.
+
+He watched his opportunity of taking Darnay aside into a window, and of
+speaking to him when no one overheard.
+
+“Mr. Darnay,” said Carton, “I wish we might be friends.”
+
+“We are already friends, I hope.”
+
+“You are good enough to say so, as a fashion of speech; but, I don’t
+mean any fashion of speech. Indeed, when I say I wish we might be
+friends, I scarcely mean quite that, either.”
+
+Charles Darnay--as was natural--asked him, in all good-humour and
+good-fellowship, what he did mean?
+
+“Upon my life,” said Carton, smiling, “I find that easier to comprehend
+in my own mind, than to convey to yours. However, let me try. You
+remember a certain famous occasion when I was more drunk than--than
+usual?”
+
+“I remember a certain famous occasion when you forced me to confess that
+you had been drinking.”
+
+“I remember it too. The curse of those occasions is heavy upon me, for I
+always remember them. I hope it may be taken into account one day,
+when all days are at an end for me! Don’t be alarmed; I am not going to
+preach.”
+
+“I am not at all alarmed. Earnestness in you, is anything but alarming
+to me.”
+
+“Ah!” said Carton, with a careless wave of his hand, as if he waved that
+away. “On the drunken occasion in question (one of a large number, as
+you know), I was insufferable about liking you, and not liking you. I
+wish you would forget it.”
+
+“I forgot it long ago.”
+
+“Fashion of speech again! But, Mr. Darnay, oblivion is not so easy to
+me, as you represent it to be to you. I have by no means forgotten it,
+and a light answer does not help me to forget it.”
+
+“If it was a light answer,” returned Darnay, “I beg your forgiveness
+for it. I had no other object than to turn a slight thing, which, to my
+surprise, seems to trouble you too much, aside. I declare to you, on the
+faith of a gentleman, that I have long dismissed it from my mind. Good
+Heaven, what was there to dismiss! Have I had nothing more important to
+remember, in the great service you rendered me that day?”
+
+“As to the great service,” said Carton, “I am bound to avow to you, when
+you speak of it in that way, that it was mere professional claptrap, I
+don’t know that I cared what became of you, when I rendered it.--Mind! I
+say when I rendered it; I am speaking of the past.”
+
+“You make light of the obligation,” returned Darnay, “but I will not
+quarrel with _your_ light answer.”
+
+“Genuine truth, Mr. Darnay, trust me! I have gone aside from my purpose;
+I was speaking about our being friends. Now, you know me; you know I am
+incapable of all the higher and better flights of men. If you doubt it,
+ask Stryver, and he’ll tell you so.”
+
+“I prefer to form my own opinion, without the aid of his.”
+
+“Well! At any rate you know me as a dissolute dog, who has never done
+any good, and never will.”
+
+“I don’t know that you ‘never will.’”
+
+“But I do, and you must take my word for it. Well! If you could endure
+to have such a worthless fellow, and a fellow of such indifferent
+reputation, coming and going at odd times, I should ask that I might be
+permitted to come and go as a privileged person here; that I might
+be regarded as an useless (and I would add, if it were not for the
+resemblance I detected between you and me, an unornamental) piece of
+furniture, tolerated for its old service, and taken no notice of. I
+doubt if I should abuse the permission. It is a hundred to one if I
+should avail myself of it four times in a year. It would satisfy me, I
+dare say, to know that I had it.”
+
+“Will you try?”
+
+“That is another way of saying that I am placed on the footing I have
+indicated. I thank you, Darnay. I may use that freedom with your name?”
+
+“I think so, Carton, by this time.”
+
+They shook hands upon it, and Sydney turned away. Within a minute
+afterwards, he was, to all outward appearance, as unsubstantial as ever.
+
+When he was gone, and in the course of an evening passed with Miss
+Pross, the Doctor, and Mr. Lorry, Charles Darnay made some mention of
+this conversation in general terms, and spoke of Sydney Carton as a
+problem of carelessness and recklessness. He spoke of him, in short, not
+bitterly or meaning to bear hard upon him, but as anybody might who saw
+him as he showed himself.
+
+He had no idea that this could dwell in the thoughts of his fair young
+wife; but, when he afterwards joined her in their own rooms, he found
+her waiting for him with the old pretty lifting of the forehead strongly
+marked.
+
+“We are thoughtful to-night!” said Darnay, drawing his arm about her.
+
+“Yes, dearest Charles,” with her hands on his breast, and the inquiring
+and attentive expression fixed upon him; “we are rather thoughtful
+to-night, for we have something on our mind to-night.”
+
+“What is it, my Lucie?”
+
+“Will you promise not to press one question on me, if I beg you not to
+ask it?”
+
+“Will I promise? What will I not promise to my Love?”
+
+What, indeed, with his hand putting aside the golden hair from the
+cheek, and his other hand against the heart that beat for him!
+
+“I think, Charles, poor Mr. Carton deserves more consideration and
+respect than you expressed for him to-night.”
+
+“Indeed, my own? Why so?”
+
+“That is what you are not to ask me. But I think--I know--he does.”
+
+“If you know it, it is enough. What would you have me do, my Life?”
+
+“I would ask you, dearest, to be very generous with him always, and very
+lenient on his faults when he is not by. I would ask you to believe that
+he has a heart he very, very seldom reveals, and that there are deep
+wounds in it. My dear, I have seen it bleeding.”
+
+“It is a painful reflection to me,” said Charles Darnay, quite
+astounded, “that I should have done him any wrong. I never thought this
+of him.”
+
+“My husband, it is so. I fear he is not to be reclaimed; there is
+scarcely a hope that anything in his character or fortunes is reparable
+now. But, I am sure that he is capable of good things, gentle things,
+even magnanimous things.”
+
+She looked so beautiful in the purity of her faith in this lost man,
+that her husband could have looked at her as she was for hours.
+
+“And, O my dearest Love!” she urged, clinging nearer to him, laying her
+head upon his breast, and raising her eyes to his, “remember how strong
+we are in our happiness, and how weak he is in his misery!”
+
+The supplication touched him home. “I will always remember it, dear
+Heart! I will remember it as long as I live.”
+
+He bent over the golden head, and put the rosy lips to his, and folded
+her in his arms. If one forlorn wanderer then pacing the dark streets,
+could have heard her innocent disclosure, and could have seen the drops
+of pity kissed away by her husband from the soft blue eyes so loving of
+that husband, he might have cried to the night--and the words would not
+have parted from his lips for the first time--
+
+“God bless her for her sweet compassion!”
+
+
+
+
+XXI. Echoing Footsteps
+
+
+A wonderful corner for echoes, it has been remarked, that corner where
+the Doctor lived. Ever busily winding the golden thread which bound
+her husband, and her father, and herself, and her old directress and
+companion, in a life of quiet bliss, Lucie sat in the still house in
+the tranquilly resounding corner, listening to the echoing footsteps of
+years.
+
+At first, there were times, though she was a perfectly happy young wife,
+when her work would slowly fall from her hands, and her eyes would be
+dimmed. For, there was something coming in the echoes, something light,
+afar off, and scarcely audible yet, that stirred her heart too much.
+Fluttering hopes and doubts--hopes, of a love as yet unknown to her:
+doubts, of her remaining upon earth, to enjoy that new delight--divided
+her breast. Among the echoes then, there would arise the sound of
+footsteps at her own early grave; and thoughts of the husband who would
+be left so desolate, and who would mourn for her so much, swelled to her
+eyes, and broke like waves.
+
+That time passed, and her little Lucie lay on her bosom. Then, among the
+advancing echoes, there was the tread of her tiny feet and the sound of
+her prattling words. Let greater echoes resound as they would, the young
+mother at the cradle side could always hear those coming. They came, and
+the shady house was sunny with a child’s laugh, and the Divine friend of
+children, to whom in her trouble she had confided hers, seemed to take
+her child in his arms, as He took the child of old, and made it a sacred
+joy to her.
+
+Ever busily winding the golden thread that bound them all together,
+weaving the service of her happy influence through the tissue of all
+their lives, and making it predominate nowhere, Lucie heard in the
+echoes of years none but friendly and soothing sounds. Her husband’s
+step was strong and prosperous among them; her father’s firm and equal.
+Lo, Miss Pross, in harness of string, awakening the echoes, as an
+unruly charger, whip-corrected, snorting and pawing the earth under the
+plane-tree in the garden!
+
+Even when there were sounds of sorrow among the rest, they were not
+harsh nor cruel. Even when golden hair, like her own, lay in a halo on a
+pillow round the worn face of a little boy, and he said, with a radiant
+smile, “Dear papa and mamma, I am very sorry to leave you both, and to
+leave my pretty sister; but I am called, and I must go!” those were not
+tears all of agony that wetted his young mother’s cheek, as the spirit
+departed from her embrace that had been entrusted to it. Suffer them and
+forbid them not. They see my Father’s face. O Father, blessed words!
+
+Thus, the rustling of an Angel’s wings got blended with the other
+echoes, and they were not wholly of earth, but had in them that breath
+of Heaven. Sighs of the winds that blew over a little garden-tomb were
+mingled with them also, and both were audible to Lucie, in a hushed
+murmur--like the breathing of a summer sea asleep upon a sandy shore--as
+the little Lucie, comically studious at the task of the morning, or
+dressing a doll at her mother’s footstool, chattered in the tongues of
+the Two Cities that were blended in her life.
+
+The Echoes rarely answered to the actual tread of Sydney Carton. Some
+half-dozen times a year, at most, he claimed his privilege of coming in
+uninvited, and would sit among them through the evening, as he had once
+done often. He never came there heated with wine. And one other thing
+regarding him was whispered in the echoes, which has been whispered by
+all true echoes for ages and ages.
+
+No man ever really loved a woman, lost her, and knew her with a
+blameless though an unchanged mind, when she was a wife and a mother,
+but her children had a strange sympathy with him--an instinctive
+delicacy of pity for him. What fine hidden sensibilities are touched in
+such a case, no echoes tell; but it is so, and it was so here. Carton
+was the first stranger to whom little Lucie held out her chubby arms,
+and he kept his place with her as she grew. The little boy had spoken of
+him, almost at the last. “Poor Carton! Kiss him for me!”
+
+Mr. Stryver shouldered his way through the law, like some great engine
+forcing itself through turbid water, and dragged his useful friend in
+his wake, like a boat towed astern. As the boat so favoured is usually
+in a rough plight, and mostly under water, so, Sydney had a swamped
+life of it. But, easy and strong custom, unhappily so much easier and
+stronger in him than any stimulating sense of desert or disgrace, made
+it the life he was to lead; and he no more thought of emerging from his
+state of lion’s jackal, than any real jackal may be supposed to think of
+rising to be a lion. Stryver was rich; had married a florid widow with
+property and three boys, who had nothing particularly shining about them
+but the straight hair of their dumpling heads.
+
+These three young gentlemen, Mr. Stryver, exuding patronage of the most
+offensive quality from every pore, had walked before him like three
+sheep to the quiet corner in Soho, and had offered as pupils to
+Lucie’s husband: delicately saying “Halloa! here are three lumps of
+bread-and-cheese towards your matrimonial picnic, Darnay!” The polite
+rejection of the three lumps of bread-and-cheese had quite bloated Mr.
+Stryver with indignation, which he afterwards turned to account in the
+training of the young gentlemen, by directing them to beware of the
+pride of Beggars, like that tutor-fellow. He was also in the habit of
+declaiming to Mrs. Stryver, over his full-bodied wine, on the arts
+Mrs. Darnay had once put in practice to “catch” him, and on the
+diamond-cut-diamond arts in himself, madam, which had rendered him “not
+to be caught.” Some of his King’s Bench familiars, who were occasionally
+parties to the full-bodied wine and the lie, excused him for the
+latter by saying that he had told it so often, that he believed
+it himself--which is surely such an incorrigible aggravation of an
+originally bad offence, as to justify any such offender’s being carried
+off to some suitably retired spot, and there hanged out of the way.
+
+These were among the echoes to which Lucie, sometimes pensive, sometimes
+amused and laughing, listened in the echoing corner, until her little
+daughter was six years old. How near to her heart the echoes of her
+child’s tread came, and those of her own dear father’s, always active
+and self-possessed, and those of her dear husband’s, need not be told.
+Nor, how the lightest echo of their united home, directed by herself
+with such a wise and elegant thrift that it was more abundant than any
+waste, was music to her. Nor, how there were echoes all about her, sweet
+in her ears, of the many times her father had told her that he found her
+more devoted to him married (if that could be) than single, and of the
+many times her husband had said to her that no cares and duties seemed
+to divide her love for him or her help to him, and asked her “What is
+the magic secret, my darling, of your being everything to all of us,
+as if there were only one of us, yet never seeming to be hurried, or to
+have too much to do?”
+
+But, there were other echoes, from a distance, that rumbled menacingly
+in the corner all through this space of time. And it was now, about
+little Lucie’s sixth birthday, that they began to have an awful sound,
+as of a great storm in France with a dreadful sea rising.
+
+On a night in mid-July, one thousand seven hundred and eighty-nine, Mr.
+Lorry came in late, from Tellson’s, and sat himself down by Lucie and
+her husband in the dark window. It was a hot, wild night, and they were
+all three reminded of the old Sunday night when they had looked at the
+lightning from the same place.
+
+“I began to think,” said Mr. Lorry, pushing his brown wig back, “that
+I should have to pass the night at Tellson’s. We have been so full of
+business all day, that we have not known what to do first, or which way
+to turn. There is such an uneasiness in Paris, that we have actually a
+run of confidence upon us! Our customers over there, seem not to be able
+to confide their property to us fast enough. There is positively a mania
+among some of them for sending it to England.”
+
+“That has a bad look,” said Darnay--
+
+“A bad look, you say, my dear Darnay? Yes, but we don’t know what reason
+there is in it. People are so unreasonable! Some of us at Tellson’s are
+getting old, and we really can’t be troubled out of the ordinary course
+without due occasion.”
+
+“Still,” said Darnay, “you know how gloomy and threatening the sky is.”
+
+“I know that, to be sure,” assented Mr. Lorry, trying to persuade
+himself that his sweet temper was soured, and that he grumbled, “but I
+am determined to be peevish after my long day’s botheration. Where is
+Manette?”
+
+“Here he is,” said the Doctor, entering the dark room at the moment.
+
+“I am quite glad you are at home; for these hurries and forebodings by
+which I have been surrounded all day long, have made me nervous without
+reason. You are not going out, I hope?”
+
+“No; I am going to play backgammon with you, if you like,” said the
+Doctor.
+
+“I don’t think I do like, if I may speak my mind. I am not fit to be
+pitted against you to-night. Is the teaboard still there, Lucie? I can’t
+see.”
+
+“Of course, it has been kept for you.”
+
+“Thank ye, my dear. The precious child is safe in bed?”
+
+“And sleeping soundly.”
+
+“That’s right; all safe and well! I don’t know why anything should be
+otherwise than safe and well here, thank God; but I have been so put out
+all day, and I am not as young as I was! My tea, my dear! Thank ye. Now,
+come and take your place in the circle, and let us sit quiet, and hear
+the echoes about which you have your theory.”
+
+“Not a theory; it was a fancy.”
+
+“A fancy, then, my wise pet,” said Mr. Lorry, patting her hand. “They
+are very numerous and very loud, though, are they not? Only hear them!”
+
+Headlong, mad, and dangerous footsteps to force their way into anybody’s
+life, footsteps not easily made clean again if once stained red, the
+footsteps raging in Saint Antoine afar off, as the little circle sat in
+the dark London window.
+
+Saint Antoine had been, that morning, a vast dusky mass of scarecrows
+heaving to and fro, with frequent gleams of light above the billowy
+heads, where steel blades and bayonets shone in the sun. A tremendous
+roar arose from the throat of Saint Antoine, and a forest of naked arms
+struggled in the air like shrivelled branches of trees in a winter wind:
+all the fingers convulsively clutching at every weapon or semblance of a
+weapon that was thrown up from the depths below, no matter how far off.
+
+Who gave them out, whence they last came, where they began, through what
+agency they crookedly quivered and jerked, scores at a time, over the
+heads of the crowd, like a kind of lightning, no eye in the throng could
+have told; but, muskets were being distributed--so were cartridges,
+powder, and ball, bars of iron and wood, knives, axes, pikes, every
+weapon that distracted ingenuity could discover or devise. People who
+could lay hold of nothing else, set themselves with bleeding hands to
+force stones and bricks out of their places in walls. Every pulse and
+heart in Saint Antoine was on high-fever strain and at high-fever heat.
+Every living creature there held life as of no account, and was demented
+with a passionate readiness to sacrifice it.
+
+As a whirlpool of boiling waters has a centre point, so, all this raging
+circled round Defarge’s wine-shop, and every human drop in the caldron
+had a tendency to be sucked towards the vortex where Defarge himself,
+already begrimed with gunpowder and sweat, issued orders, issued arms,
+thrust this man back, dragged this man forward, disarmed one to arm
+another, laboured and strove in the thickest of the uproar.
+
+“Keep near to me, Jacques Three,” cried Defarge; “and do you, Jacques
+One and Two, separate and put yourselves at the head of as many of these
+patriots as you can. Where is my wife?”
+
+“Eh, well! Here you see me!” said madame, composed as ever, but not
+knitting to-day. Madame’s resolute right hand was occupied with an axe,
+in place of the usual softer implements, and in her girdle were a pistol
+and a cruel knife.
+
+“Where do you go, my wife?”
+
+“I go,” said madame, “with you at present. You shall see me at the head
+of women, by-and-bye.”
+
+“Come, then!” cried Defarge, in a resounding voice. “Patriots and
+friends, we are ready! The Bastille!”
+
+With a roar that sounded as if all the breath in France had been shaped
+into the detested word, the living sea rose, wave on wave, depth on
+depth, and overflowed the city to that point. Alarm-bells ringing, drums
+beating, the sea raging and thundering on its new beach, the attack
+began.
+
+Deep ditches, double drawbridge, massive stone walls, eight great
+towers, cannon, muskets, fire and smoke. Through the fire and through
+the smoke--in the fire and in the smoke, for the sea cast him up against
+a cannon, and on the instant he became a cannonier--Defarge of the
+wine-shop worked like a manful soldier, Two fierce hours.
+
+Deep ditch, single drawbridge, massive stone walls, eight great towers,
+cannon, muskets, fire and smoke. One drawbridge down! “Work, comrades
+all, work! Work, Jacques One, Jacques Two, Jacques One Thousand, Jacques
+Two Thousand, Jacques Five-and-Twenty Thousand; in the name of all
+the Angels or the Devils--which you prefer--work!” Thus Defarge of the
+wine-shop, still at his gun, which had long grown hot.
+
+“To me, women!” cried madame his wife. “What! We can kill as well as
+the men when the place is taken!” And to her, with a shrill thirsty
+cry, trooping women variously armed, but all armed alike in hunger and
+revenge.
+
+Cannon, muskets, fire and smoke; but, still the deep ditch, the single
+drawbridge, the massive stone walls, and the eight great towers. Slight
+displacements of the raging sea, made by the falling wounded. Flashing
+weapons, blazing torches, smoking waggonloads of wet straw, hard work
+at neighbouring barricades in all directions, shrieks, volleys,
+execrations, bravery without stint, boom smash and rattle, and the
+furious sounding of the living sea; but, still the deep ditch, and the
+single drawbridge, and the massive stone walls, and the eight great
+towers, and still Defarge of the wine-shop at his gun, grown doubly hot
+by the service of Four fierce hours.
+
+A white flag from within the fortress, and a parley--this dimly
+perceptible through the raging storm, nothing audible in it--suddenly
+the sea rose immeasurably wider and higher, and swept Defarge of the
+wine-shop over the lowered drawbridge, past the massive stone outer
+walls, in among the eight great towers surrendered!
+
+So resistless was the force of the ocean bearing him on, that even to
+draw his breath or turn his head was as impracticable as if he had been
+struggling in the surf at the South Sea, until he was landed in the
+outer courtyard of the Bastille. There, against an angle of a wall, he
+made a struggle to look about him. Jacques Three was nearly at his side;
+Madame Defarge, still heading some of her women, was visible in the
+inner distance, and her knife was in her hand. Everywhere was tumult,
+exultation, deafening and maniacal bewilderment, astounding noise, yet
+furious dumb-show.
+
+“The Prisoners!”
+
+“The Records!”
+
+“The secret cells!”
+
+“The instruments of torture!”
+
+“The Prisoners!”
+
+Of all these cries, and ten thousand incoherences, “The Prisoners!” was
+the cry most taken up by the sea that rushed in, as if there were an
+eternity of people, as well as of time and space. When the foremost
+billows rolled past, bearing the prison officers with them, and
+threatening them all with instant death if any secret nook remained
+undisclosed, Defarge laid his strong hand on the breast of one of
+these men--a man with a grey head, who had a lighted torch in his
+hand--separated him from the rest, and got him between himself and the
+wall.
+
+“Show me the North Tower!” said Defarge. “Quick!”
+
+“I will faithfully,” replied the man, “if you will come with me. But
+there is no one there.”
+
+“What is the meaning of One Hundred and Five, North Tower?” asked
+Defarge. “Quick!”
+
+“The meaning, monsieur?”
+
+“Does it mean a captive, or a place of captivity? Or do you mean that I
+shall strike you dead?”
+
+“Kill him!” croaked Jacques Three, who had come close up.
+
+“Monsieur, it is a cell.”
+
+“Show it me!”
+
+“Pass this way, then.”
+
+Jacques Three, with his usual craving on him, and evidently disappointed
+by the dialogue taking a turn that did not seem to promise bloodshed,
+held by Defarge’s arm as he held by the turnkey’s. Their three heads had
+been close together during this brief discourse, and it had been as much
+as they could do to hear one another, even then: so tremendous was the
+noise of the living ocean, in its irruption into the Fortress, and
+its inundation of the courts and passages and staircases. All around
+outside, too, it beat the walls with a deep, hoarse roar, from which,
+occasionally, some partial shouts of tumult broke and leaped into the
+air like spray.
+
+Through gloomy vaults where the light of day had never shone, past
+hideous doors of dark dens and cages, down cavernous flights of steps,
+and again up steep rugged ascents of stone and brick, more like dry
+waterfalls than staircases, Defarge, the turnkey, and Jacques Three,
+linked hand and arm, went with all the speed they could make. Here and
+there, especially at first, the inundation started on them and swept by;
+but when they had done descending, and were winding and climbing up a
+tower, they were alone. Hemmed in here by the massive thickness of walls
+and arches, the storm within the fortress and without was only audible
+to them in a dull, subdued way, as if the noise out of which they had
+come had almost destroyed their sense of hearing.
+
+The turnkey stopped at a low door, put a key in a clashing lock, swung
+the door slowly open, and said, as they all bent their heads and passed
+in:
+
+“One hundred and five, North Tower!”
+
+There was a small, heavily-grated, unglazed window high in the wall,
+with a stone screen before it, so that the sky could be only seen by
+stooping low and looking up. There was a small chimney, heavily barred
+across, a few feet within. There was a heap of old feathery wood-ashes
+on the hearth. There was a stool, and table, and a straw bed. There were
+the four blackened walls, and a rusted iron ring in one of them.
+
+“Pass that torch slowly along these walls, that I may see them,” said
+Defarge to the turnkey.
+
+The man obeyed, and Defarge followed the light closely with his eyes.
+
+“Stop!--Look here, Jacques!”
+
+“A. M.!” croaked Jacques Three, as he read greedily.
+
+“Alexandre Manette,” said Defarge in his ear, following the letters
+with his swart forefinger, deeply engrained with gunpowder. “And here he
+wrote ‘a poor physician.’ And it was he, without doubt, who scratched
+a calendar on this stone. What is that in your hand? A crowbar? Give it
+me!”
+
+He had still the linstock of his gun in his own hand. He made a sudden
+exchange of the two instruments, and turning on the worm-eaten stool and
+table, beat them to pieces in a few blows.
+
+“Hold the light higher!” he said, wrathfully, to the turnkey. “Look
+among those fragments with care, Jacques. And see! Here is my knife,”
+ throwing it to him; “rip open that bed, and search the straw. Hold the
+light higher, you!”
+
+With a menacing look at the turnkey he crawled upon the hearth, and,
+peering up the chimney, struck and prised at its sides with the crowbar,
+and worked at the iron grating across it. In a few minutes, some mortar
+and dust came dropping down, which he averted his face to avoid; and
+in it, and in the old wood-ashes, and in a crevice in the chimney
+into which his weapon had slipped or wrought itself, he groped with a
+cautious touch.
+
+“Nothing in the wood, and nothing in the straw, Jacques?”
+
+“Nothing.”
+
+“Let us collect them together, in the middle of the cell. So! Light
+them, you!”
+
+The turnkey fired the little pile, which blazed high and hot. Stooping
+again to come out at the low-arched door, they left it burning, and
+retraced their way to the courtyard; seeming to recover their sense
+of hearing as they came down, until they were in the raging flood once
+more.
+
+They found it surging and tossing, in quest of Defarge himself. Saint
+Antoine was clamorous to have its wine-shop keeper foremost in the guard
+upon the governor who had defended the Bastille and shot the people.
+Otherwise, the governor would not be marched to the Hotel de Ville for
+judgment. Otherwise, the governor would escape, and the people’s
+blood (suddenly of some value, after many years of worthlessness) be
+unavenged.
+
+In the howling universe of passion and contention that seemed to
+encompass this grim old officer conspicuous in his grey coat and red
+decoration, there was but one quite steady figure, and that was a
+woman’s. “See, there is my husband!” she cried, pointing him out.
+“See Defarge!” She stood immovable close to the grim old officer, and
+remained immovable close to him; remained immovable close to him through
+the streets, as Defarge and the rest bore him along; remained immovable
+close to him when he was got near his destination, and began to
+be struck at from behind; remained immovable close to him when the
+long-gathering rain of stabs and blows fell heavy; was so close to him
+when he dropped dead under it, that, suddenly animated, she put her foot
+upon his neck, and with her cruel knife--long ready--hewed off his head.
+
+The hour was come, when Saint Antoine was to execute his horrible idea
+of hoisting up men for lamps to show what he could be and do. Saint
+Antoine’s blood was up, and the blood of tyranny and domination by the
+iron hand was down--down on the steps of the Hotel de Ville where the
+governor’s body lay--down on the sole of the shoe of Madame Defarge
+where she had trodden on the body to steady it for mutilation. “Lower
+the lamp yonder!” cried Saint Antoine, after glaring round for a new
+means of death; “here is one of his soldiers to be left on guard!” The
+swinging sentinel was posted, and the sea rushed on.
+
+The sea of black and threatening waters, and of destructive upheaving
+of wave against wave, whose depths were yet unfathomed and whose forces
+were yet unknown. The remorseless sea of turbulently swaying shapes,
+voices of vengeance, and faces hardened in the furnaces of suffering
+until the touch of pity could make no mark on them.
+
+But, in the ocean of faces where every fierce and furious expression was
+in vivid life, there were two groups of faces--each seven in number--so
+fixedly contrasting with the rest, that never did sea roll which bore
+more memorable wrecks with it. Seven faces of prisoners, suddenly
+released by the storm that had burst their tomb, were carried high
+overhead: all scared, all lost, all wondering and amazed, as if the Last
+Day were come, and those who rejoiced around them were lost spirits.
+Other seven faces there were, carried higher, seven dead faces, whose
+drooping eyelids and half-seen eyes awaited the Last Day. Impassive
+faces, yet with a suspended--not an abolished--expression on them;
+faces, rather, in a fearful pause, as having yet to raise the dropped
+lids of the eyes, and bear witness with the bloodless lips, “THOU DIDST
+IT!”
+
+Seven prisoners released, seven gory heads on pikes, the keys of the
+accursed fortress of the eight strong towers, some discovered letters
+and other memorials of prisoners of old time, long dead of broken
+hearts,--such, and such--like, the loudly echoing footsteps of Saint
+Antoine escort through the Paris streets in mid-July, one thousand seven
+hundred and eighty-nine. Now, Heaven defeat the fancy of Lucie Darnay,
+and keep these feet far out of her life! For, they are headlong, mad,
+and dangerous; and in the years so long after the breaking of the cask
+at Defarge’s wine-shop door, they are not easily purified when once
+stained red.
+
+
+
+
+XXII. The Sea Still Rises
+
+
+Haggard Saint Antoine had had only one exultant week, in which to soften
+his modicum of hard and bitter bread to such extent as he could, with
+the relish of fraternal embraces and congratulations, when Madame
+Defarge sat at her counter, as usual, presiding over the customers.
+Madame Defarge wore no rose in her head, for the great brotherhood of
+Spies had become, even in one short week, extremely chary of trusting
+themselves to the saint’s mercies. The lamps across his streets had a
+portentously elastic swing with them.
+
+Madame Defarge, with her arms folded, sat in the morning light and heat,
+contemplating the wine-shop and the street. In both, there were several
+knots of loungers, squalid and miserable, but now with a manifest sense
+of power enthroned on their distress. The raggedest nightcap, awry on
+the wretchedest head, had this crooked significance in it: “I know how
+hard it has grown for me, the wearer of this, to support life in myself;
+but do you know how easy it has grown for me, the wearer of this, to
+destroy life in you?” Every lean bare arm, that had been without work
+before, had this work always ready for it now, that it could strike.
+The fingers of the knitting women were vicious, with the experience that
+they could tear. There was a change in the appearance of Saint Antoine;
+the image had been hammering into this for hundreds of years, and the
+last finishing blows had told mightily on the expression.
+
+Madame Defarge sat observing it, with such suppressed approval as was
+to be desired in the leader of the Saint Antoine women. One of her
+sisterhood knitted beside her. The short, rather plump wife of a starved
+grocer, and the mother of two children withal, this lieutenant had
+already earned the complimentary name of The Vengeance.
+
+“Hark!” said The Vengeance. “Listen, then! Who comes?”
+
+As if a train of powder laid from the outermost bound of Saint Antoine
+Quarter to the wine-shop door, had been suddenly fired, a fast-spreading
+murmur came rushing along.
+
+“It is Defarge,” said madame. “Silence, patriots!”
+
+Defarge came in breathless, pulled off a red cap he wore, and looked
+around him! “Listen, everywhere!” said madame again. “Listen to him!”
+ Defarge stood, panting, against a background of eager eyes and open
+mouths, formed outside the door; all those within the wine-shop had
+sprung to their feet.
+
+“Say then, my husband. What is it?”
+
+“News from the other world!”
+
+“How, then?” cried madame, contemptuously. “The other world?”
+
+“Does everybody here recall old Foulon, who told the famished people
+that they might eat grass, and who died, and went to Hell?”
+
+“Everybody!” from all throats.
+
+“The news is of him. He is among us!”
+
+“Among us!” from the universal throat again. “And dead?”
+
+“Not dead! He feared us so much--and with reason--that he caused himself
+to be represented as dead, and had a grand mock-funeral. But they have
+found him alive, hiding in the country, and have brought him in. I have
+seen him but now, on his way to the Hotel de Ville, a prisoner. I have
+said that he had reason to fear us. Say all! _Had_ he reason?”
+
+Wretched old sinner of more than threescore years and ten, if he had
+never known it yet, he would have known it in his heart of hearts if he
+could have heard the answering cry.
+
+A moment of profound silence followed. Defarge and his wife looked
+steadfastly at one another. The Vengeance stooped, and the jar of a drum
+was heard as she moved it at her feet behind the counter.
+
+“Patriots!” said Defarge, in a determined voice, “are we ready?”
+
+Instantly Madame Defarge’s knife was in her girdle; the drum was beating
+in the streets, as if it and a drummer had flown together by magic; and
+The Vengeance, uttering terrific shrieks, and flinging her arms about
+her head like all the forty Furies at once, was tearing from house to
+house, rousing the women.
+
+The men were terrible, in the bloody-minded anger with which they looked
+from windows, caught up what arms they had, and came pouring down into
+the streets; but, the women were a sight to chill the boldest. From
+such household occupations as their bare poverty yielded, from their
+children, from their aged and their sick crouching on the bare ground
+famished and naked, they ran out with streaming hair, urging one
+another, and themselves, to madness with the wildest cries and actions.
+Villain Foulon taken, my sister! Old Foulon taken, my mother! Miscreant
+Foulon taken, my daughter! Then, a score of others ran into the midst of
+these, beating their breasts, tearing their hair, and screaming, Foulon
+alive! Foulon who told the starving people they might eat grass! Foulon
+who told my old father that he might eat grass, when I had no bread
+to give him! Foulon who told my baby it might suck grass, when these
+breasts were dry with want! O mother of God, this Foulon! O Heaven our
+suffering! Hear me, my dead baby and my withered father: I swear on my
+knees, on these stones, to avenge you on Foulon! Husbands, and brothers,
+and young men, Give us the blood of Foulon, Give us the head of Foulon,
+Give us the heart of Foulon, Give us the body and soul of Foulon, Rend
+Foulon to pieces, and dig him into the ground, that grass may grow from
+him! With these cries, numbers of the women, lashed into blind frenzy,
+whirled about, striking and tearing at their own friends until they
+dropped into a passionate swoon, and were only saved by the men
+belonging to them from being trampled under foot.
+
+Nevertheless, not a moment was lost; not a moment! This Foulon was at
+the Hotel de Ville, and might be loosed. Never, if Saint Antoine knew
+his own sufferings, insults, and wrongs! Armed men and women flocked out
+of the Quarter so fast, and drew even these last dregs after them with
+such a force of suction, that within a quarter of an hour there was not
+a human creature in Saint Antoine’s bosom but a few old crones and the
+wailing children.
+
+No. They were all by that time choking the Hall of Examination where
+this old man, ugly and wicked, was, and overflowing into the adjacent
+open space and streets. The Defarges, husband and wife, The Vengeance,
+and Jacques Three, were in the first press, and at no great distance
+from him in the Hall.
+
+“See!” cried madame, pointing with her knife. “See the old villain bound
+with ropes. That was well done to tie a bunch of grass upon his back.
+Ha, ha! That was well done. Let him eat it now!” Madame put her knife
+under her arm, and clapped her hands as at a play.
+
+The people immediately behind Madame Defarge, explaining the cause of
+her satisfaction to those behind them, and those again explaining to
+others, and those to others, the neighbouring streets resounded with the
+clapping of hands. Similarly, during two or three hours of drawl,
+and the winnowing of many bushels of words, Madame Defarge’s frequent
+expressions of impatience were taken up, with marvellous quickness, at
+a distance: the more readily, because certain men who had by some
+wonderful exercise of agility climbed up the external architecture
+to look in from the windows, knew Madame Defarge well, and acted as a
+telegraph between her and the crowd outside the building.
+
+At length the sun rose so high that it struck a kindly ray as of hope or
+protection, directly down upon the old prisoner’s head. The favour was
+too much to bear; in an instant the barrier of dust and chaff that had
+stood surprisingly long, went to the winds, and Saint Antoine had got
+him!
+
+It was known directly, to the furthest confines of the crowd. Defarge
+had but sprung over a railing and a table, and folded the miserable
+wretch in a deadly embrace--Madame Defarge had but followed and turned
+her hand in one of the ropes with which he was tied--The Vengeance and
+Jacques Three were not yet up with them, and the men at the windows
+had not yet swooped into the Hall, like birds of prey from their high
+perches--when the cry seemed to go up, all over the city, “Bring him
+out! Bring him to the lamp!”
+
+Down, and up, and head foremost on the steps of the building; now, on
+his knees; now, on his feet; now, on his back; dragged, and struck at,
+and stifled by the bunches of grass and straw that were thrust into his
+face by hundreds of hands; torn, bruised, panting, bleeding, yet always
+entreating and beseeching for mercy; now full of vehement agony of
+action, with a small clear space about him as the people drew one
+another back that they might see; now, a log of dead wood drawn through
+a forest of legs; he was hauled to the nearest street corner where one
+of the fatal lamps swung, and there Madame Defarge let him go--as a cat
+might have done to a mouse--and silently and composedly looked at him
+while they made ready, and while he besought her: the women passionately
+screeching at him all the time, and the men sternly calling out to have
+him killed with grass in his mouth. Once, he went aloft, and the rope
+broke, and they caught him shrieking; twice, he went aloft, and the rope
+broke, and they caught him shrieking; then, the rope was merciful, and
+held him, and his head was soon upon a pike, with grass enough in the
+mouth for all Saint Antoine to dance at the sight of.
+
+Nor was this the end of the day’s bad work, for Saint Antoine so shouted
+and danced his angry blood up, that it boiled again, on hearing when
+the day closed in that the son-in-law of the despatched, another of the
+people’s enemies and insulters, was coming into Paris under a guard
+five hundred strong, in cavalry alone. Saint Antoine wrote his crimes
+on flaring sheets of paper, seized him--would have torn him out of the
+breast of an army to bear Foulon company--set his head and heart on
+pikes, and carried the three spoils of the day, in Wolf-procession
+through the streets.
+
+Not before dark night did the men and women come back to the children,
+wailing and breadless. Then, the miserable bakers’ shops were beset by
+long files of them, patiently waiting to buy bad bread; and while
+they waited with stomachs faint and empty, they beguiled the time by
+embracing one another on the triumphs of the day, and achieving them
+again in gossip. Gradually, these strings of ragged people shortened and
+frayed away; and then poor lights began to shine in high windows, and
+slender fires were made in the streets, at which neighbours cooked in
+common, afterwards supping at their doors.
+
+Scanty and insufficient suppers those, and innocent of meat, as of
+most other sauce to wretched bread. Yet, human fellowship infused
+some nourishment into the flinty viands, and struck some sparks of
+cheerfulness out of them. Fathers and mothers who had had their full
+share in the worst of the day, played gently with their meagre children;
+and lovers, with such a world around them and before them, loved and
+hoped.
+
+It was almost morning, when Defarge’s wine-shop parted with its last
+knot of customers, and Monsieur Defarge said to madame his wife, in
+husky tones, while fastening the door:
+
+“At last it is come, my dear!”
+
+“Eh well!” returned madame. “Almost.”
+
+Saint Antoine slept, the Defarges slept: even The Vengeance slept with
+her starved grocer, and the drum was at rest. The drum’s was the
+only voice in Saint Antoine that blood and hurry had not changed. The
+Vengeance, as custodian of the drum, could have wakened him up and had
+the same speech out of him as before the Bastille fell, or old Foulon
+was seized; not so with the hoarse tones of the men and women in Saint
+Antoine’s bosom.
+
+
+
+
+XXIII. Fire Rises
+
+
+There was a change on the village where the fountain fell, and where
+the mender of roads went forth daily to hammer out of the stones on the
+highway such morsels of bread as might serve for patches to hold his
+poor ignorant soul and his poor reduced body together. The prison on the
+crag was not so dominant as of yore; there were soldiers to guard it,
+but not many; there were officers to guard the soldiers, but not one of
+them knew what his men would do--beyond this: that it would probably not
+be what he was ordered.
+
+Far and wide lay a ruined country, yielding nothing but desolation.
+Every green leaf, every blade of grass and blade of grain, was as
+shrivelled and poor as the miserable people. Everything was bowed down,
+dejected, oppressed, and broken. Habitations, fences, domesticated
+animals, men, women, children, and the soil that bore them--all worn
+out.
+
+Monseigneur (often a most worthy individual gentleman) was a national
+blessing, gave a chivalrous tone to things, was a polite example of
+luxurious and shining life, and a great deal more to equal purpose;
+nevertheless, Monseigneur as a class had, somehow or other, brought
+things to this. Strange that Creation, designed expressly for
+Monseigneur, should be so soon wrung dry and squeezed out! There must
+be something short-sighted in the eternal arrangements, surely! Thus it
+was, however; and the last drop of blood having been extracted from the
+flints, and the last screw of the rack having been turned so often that
+its purchase crumbled, and it now turned and turned with nothing
+to bite, Monseigneur began to run away from a phenomenon so low and
+unaccountable.
+
+But, this was not the change on the village, and on many a village like
+it. For scores of years gone by, Monseigneur had squeezed it and wrung
+it, and had seldom graced it with his presence except for the pleasures
+of the chase--now, found in hunting the people; now, found in hunting
+the beasts, for whose preservation Monseigneur made edifying spaces
+of barbarous and barren wilderness. No. The change consisted in
+the appearance of strange faces of low caste, rather than in the
+disappearance of the high caste, chiselled, and otherwise beautified and
+beautifying features of Monseigneur.
+
+For, in these times, as the mender of roads worked, solitary, in the
+dust, not often troubling himself to reflect that dust he was and
+to dust he must return, being for the most part too much occupied in
+thinking how little he had for supper and how much more he would eat if
+he had it--in these times, as he raised his eyes from his lonely labour,
+and viewed the prospect, he would see some rough figure approaching on
+foot, the like of which was once a rarity in those parts, but was now
+a frequent presence. As it advanced, the mender of roads would discern
+without surprise, that it was a shaggy-haired man, of almost barbarian
+aspect, tall, in wooden shoes that were clumsy even to the eyes of a
+mender of roads, grim, rough, swart, steeped in the mud and dust of many
+highways, dank with the marshy moisture of many low grounds, sprinkled
+with the thorns and leaves and moss of many byways through woods.
+
+Such a man came upon him, like a ghost, at noon in the July weather,
+as he sat on his heap of stones under a bank, taking such shelter as he
+could get from a shower of hail.
+
+The man looked at him, looked at the village in the hollow, at the mill,
+and at the prison on the crag. When he had identified these objects
+in what benighted mind he had, he said, in a dialect that was just
+intelligible:
+
+“How goes it, Jacques?”
+
+“All well, Jacques.”
+
+“Touch then!”
+
+They joined hands, and the man sat down on the heap of stones.
+
+“No dinner?”
+
+“Nothing but supper now,” said the mender of roads, with a hungry face.
+
+“It is the fashion,” growled the man. “I meet no dinner anywhere.”
+
+He took out a blackened pipe, filled it, lighted it with flint and
+steel, pulled at it until it was in a bright glow: then, suddenly held
+it from him and dropped something into it from between his finger and
+thumb, that blazed and went out in a puff of smoke.
+
+“Touch then.” It was the turn of the mender of roads to say it this
+time, after observing these operations. They again joined hands.
+
+“To-night?” said the mender of roads.
+
+“To-night,” said the man, putting the pipe in his mouth.
+
+“Where?”
+
+“Here.”
+
+He and the mender of roads sat on the heap of stones looking silently at
+one another, with the hail driving in between them like a pigmy charge
+of bayonets, until the sky began to clear over the village.
+
+“Show me!” said the traveller then, moving to the brow of the hill.
+
+“See!” returned the mender of roads, with extended finger. “You go down
+here, and straight through the street, and past the fountain--”
+
+“To the Devil with all that!” interrupted the other, rolling his eye
+over the landscape. “_I_ go through no streets and past no fountains.
+Well?”
+
+“Well! About two leagues beyond the summit of that hill above the
+village.”
+
+“Good. When do you cease to work?”
+
+“At sunset.”
+
+“Will you wake me, before departing? I have walked two nights without
+resting. Let me finish my pipe, and I shall sleep like a child. Will you
+wake me?”
+
+“Surely.”
+
+The wayfarer smoked his pipe out, put it in his breast, slipped off his
+great wooden shoes, and lay down on his back on the heap of stones. He
+was fast asleep directly.
+
+As the road-mender plied his dusty labour, and the hail-clouds, rolling
+away, revealed bright bars and streaks of sky which were responded to
+by silver gleams upon the landscape, the little man (who wore a red cap
+now, in place of his blue one) seemed fascinated by the figure on the
+heap of stones. His eyes were so often turned towards it, that he used
+his tools mechanically, and, one would have said, to very poor account.
+The bronze face, the shaggy black hair and beard, the coarse woollen
+red cap, the rough medley dress of home-spun stuff and hairy skins of
+beasts, the powerful frame attenuated by spare living, and the sullen
+and desperate compression of the lips in sleep, inspired the mender
+of roads with awe. The traveller had travelled far, and his feet were
+footsore, and his ankles chafed and bleeding; his great shoes, stuffed
+with leaves and grass, had been heavy to drag over the many long
+leagues, and his clothes were chafed into holes, as he himself was into
+sores. Stooping down beside him, the road-mender tried to get a peep at
+secret weapons in his breast or where not; but, in vain, for he slept
+with his arms crossed upon him, and set as resolutely as his lips.
+Fortified towns with their stockades, guard-houses, gates, trenches, and
+drawbridges, seemed to the mender of roads, to be so much air as against
+this figure. And when he lifted his eyes from it to the horizon and
+looked around, he saw in his small fancy similar figures, stopped by no
+obstacle, tending to centres all over France.
+
+The man slept on, indifferent to showers of hail and intervals of
+brightness, to sunshine on his face and shadow, to the paltering lumps
+of dull ice on his body and the diamonds into which the sun changed
+them, until the sun was low in the west, and the sky was glowing. Then,
+the mender of roads having got his tools together and all things ready
+to go down into the village, roused him.
+
+“Good!” said the sleeper, rising on his elbow. “Two leagues beyond the
+summit of the hill?”
+
+“About.”
+
+“About. Good!”
+
+The mender of roads went home, with the dust going on before him
+according to the set of the wind, and was soon at the fountain,
+squeezing himself in among the lean kine brought there to drink, and
+appearing even to whisper to them in his whispering to all the village.
+When the village had taken its poor supper, it did not creep to bed,
+as it usually did, but came out of doors again, and remained there. A
+curious contagion of whispering was upon it, and also, when it gathered
+together at the fountain in the dark, another curious contagion of
+looking expectantly at the sky in one direction only. Monsieur Gabelle,
+chief functionary of the place, became uneasy; went out on his house-top
+alone, and looked in that direction too; glanced down from behind his
+chimneys at the darkening faces by the fountain below, and sent word to
+the sacristan who kept the keys of the church, that there might be need
+to ring the tocsin by-and-bye.
+
+The night deepened. The trees environing the old chateau, keeping its
+solitary state apart, moved in a rising wind, as though they threatened
+the pile of building massive and dark in the gloom. Up the two terrace
+flights of steps the rain ran wildly, and beat at the great door, like a
+swift messenger rousing those within; uneasy rushes of wind went through
+the hall, among the old spears and knives, and passed lamenting up the
+stairs, and shook the curtains of the bed where the last Marquis
+had slept. East, West, North, and South, through the woods, four
+heavy-treading, unkempt figures crushed the high grass and cracked the
+branches, striding on cautiously to come together in the courtyard. Four
+lights broke out there, and moved away in different directions, and all
+was black again.
+
+But, not for long. Presently, the chateau began to make itself strangely
+visible by some light of its own, as though it were growing luminous.
+Then, a flickering streak played behind the architecture of the front,
+picking out transparent places, and showing where balustrades, arches,
+and windows were. Then it soared higher, and grew broader and brighter.
+Soon, from a score of the great windows, flames burst forth, and the
+stone faces awakened, stared out of fire.
+
+A faint murmur arose about the house from the few people who were left
+there, and there was a saddling of a horse and riding away. There was
+spurring and splashing through the darkness, and bridle was drawn in the
+space by the village fountain, and the horse in a foam stood at Monsieur
+Gabelle’s door. “Help, Gabelle! Help, every one!” The tocsin rang
+impatiently, but other help (if that were any) there was none. The
+mender of roads, and two hundred and fifty particular friends, stood
+with folded arms at the fountain, looking at the pillar of fire in the
+sky. “It must be forty feet high,” said they, grimly; and never moved.
+
+The rider from the chateau, and the horse in a foam, clattered away
+through the village, and galloped up the stony steep, to the prison on
+the crag. At the gate, a group of officers were looking at the fire;
+removed from them, a group of soldiers. “Help, gentlemen--officers! The
+chateau is on fire; valuable objects may be saved from the flames by
+timely aid! Help, help!” The officers looked towards the soldiers who
+looked at the fire; gave no orders; and answered, with shrugs and biting
+of lips, “It must burn.”
+
+As the rider rattled down the hill again and through the street, the
+village was illuminating. The mender of roads, and the two hundred and
+fifty particular friends, inspired as one man and woman by the idea of
+lighting up, had darted into their houses, and were putting candles in
+every dull little pane of glass. The general scarcity of everything,
+occasioned candles to be borrowed in a rather peremptory manner of
+Monsieur Gabelle; and in a moment of reluctance and hesitation on
+that functionary’s part, the mender of roads, once so submissive to
+authority, had remarked that carriages were good to make bonfires with,
+and that post-horses would roast.
+
+The chateau was left to itself to flame and burn. In the roaring and
+raging of the conflagration, a red-hot wind, driving straight from the
+infernal regions, seemed to be blowing the edifice away. With the rising
+and falling of the blaze, the stone faces showed as if they were in
+torment. When great masses of stone and timber fell, the face with the
+two dints in the nose became obscured: anon struggled out of the smoke
+again, as if it were the face of the cruel Marquis, burning at the stake
+and contending with the fire.
+
+The chateau burned; the nearest trees, laid hold of by the fire,
+scorched and shrivelled; trees at a distance, fired by the four fierce
+figures, begirt the blazing edifice with a new forest of smoke. Molten
+lead and iron boiled in the marble basin of the fountain; the water ran
+dry; the extinguisher tops of the towers vanished like ice before the
+heat, and trickled down into four rugged wells of flame. Great rents and
+splits branched out in the solid walls, like crystallisation; stupefied
+birds wheeled about and dropped into the furnace; four fierce figures
+trudged away, East, West, North, and South, along the night-enshrouded
+roads, guided by the beacon they had lighted, towards their next
+destination. The illuminated village had seized hold of the tocsin, and,
+abolishing the lawful ringer, rang for joy.
+
+Not only that; but the village, light-headed with famine, fire, and
+bell-ringing, and bethinking itself that Monsieur Gabelle had to do with
+the collection of rent and taxes--though it was but a small instalment
+of taxes, and no rent at all, that Gabelle had got in those latter
+days--became impatient for an interview with him, and, surrounding his
+house, summoned him to come forth for personal conference. Whereupon,
+Monsieur Gabelle did heavily bar his door, and retire to hold counsel
+with himself. The result of that conference was, that Gabelle again
+withdrew himself to his housetop behind his stack of chimneys; this time
+resolved, if his door were broken in (he was a small Southern man
+of retaliative temperament), to pitch himself head foremost over the
+parapet, and crush a man or two below.
+
+Probably, Monsieur Gabelle passed a long night up there, with the
+distant chateau for fire and candle, and the beating at his door,
+combined with the joy-ringing, for music; not to mention his having an
+ill-omened lamp slung across the road before his posting-house gate,
+which the village showed a lively inclination to displace in his favour.
+A trying suspense, to be passing a whole summer night on the brink of
+the black ocean, ready to take that plunge into it upon which Monsieur
+Gabelle had resolved! But, the friendly dawn appearing at last, and the
+rush-candles of the village guttering out, the people happily dispersed,
+and Monsieur Gabelle came down bringing his life with him for that
+while.
+
+Within a hundred miles, and in the light of other fires, there were
+other functionaries less fortunate, that night and other nights, whom
+the rising sun found hanging across once-peaceful streets, where they
+had been born and bred; also, there were other villagers and townspeople
+less fortunate than the mender of roads and his fellows, upon whom the
+functionaries and soldiery turned with success, and whom they strung up
+in their turn. But, the fierce figures were steadily wending East, West,
+North, and South, be that as it would; and whosoever hung, fire burned.
+The altitude of the gallows that would turn to water and quench it,
+no functionary, by any stretch of mathematics, was able to calculate
+successfully.
+
+
+
+
+XXIV. Drawn to the Loadstone Rock
+
+
+In such risings of fire and risings of sea--the firm earth shaken by
+the rushes of an angry ocean which had now no ebb, but was always on the
+flow, higher and higher, to the terror and wonder of the beholders on
+the shore--three years of tempest were consumed. Three more birthdays
+of little Lucie had been woven by the golden thread into the peaceful
+tissue of the life of her home.
+
+Many a night and many a day had its inmates listened to the echoes in
+the corner, with hearts that failed them when they heard the thronging
+feet. For, the footsteps had become to their minds as the footsteps of
+a people, tumultuous under a red flag and with their country declared in
+danger, changed into wild beasts, by terrible enchantment long persisted
+in.
+
+Monseigneur, as a class, had dissociated himself from the phenomenon of
+his not being appreciated: of his being so little wanted in France, as
+to incur considerable danger of receiving his dismissal from it, and
+this life together. Like the fabled rustic who raised the Devil with
+infinite pains, and was so terrified at the sight of him that he could
+ask the Enemy no question, but immediately fled; so, Monseigneur, after
+boldly reading the Lord’s Prayer backwards for a great number of years,
+and performing many other potent spells for compelling the Evil One, no
+sooner beheld him in his terrors than he took to his noble heels.
+
+The shining Bull’s Eye of the Court was gone, or it would have been the
+mark for a hurricane of national bullets. It had never been a good
+eye to see with--had long had the mote in it of Lucifer’s pride,
+Sardanapalus’s luxury, and a mole’s blindness--but it had dropped
+out and was gone. The Court, from that exclusive inner circle to its
+outermost rotten ring of intrigue, corruption, and dissimulation, was
+all gone together. Royalty was gone; had been besieged in its Palace and
+“suspended,” when the last tidings came over.
+
+The August of the year one thousand seven hundred and ninety-two was
+come, and Monseigneur was by this time scattered far and wide.
+
+As was natural, the head-quarters and great gathering-place of
+Monseigneur, in London, was Tellson’s Bank. Spirits are supposed to
+haunt the places where their bodies most resorted, and Monseigneur
+without a guinea haunted the spot where his guineas used to be.
+Moreover, it was the spot to which such French intelligence as was most
+to be relied upon, came quickest. Again: Tellson’s was a munificent
+house, and extended great liberality to old customers who had fallen
+from their high estate. Again: those nobles who had seen the coming
+storm in time, and anticipating plunder or confiscation, had made
+provident remittances to Tellson’s, were always to be heard of there
+by their needy brethren. To which it must be added that every new-comer
+from France reported himself and his tidings at Tellson’s, almost as
+a matter of course. For such variety of reasons, Tellson’s was at that
+time, as to French intelligence, a kind of High Exchange; and this
+was so well known to the public, and the inquiries made there were in
+consequence so numerous, that Tellson’s sometimes wrote the latest news
+out in a line or so and posted it in the Bank windows, for all who ran
+through Temple Bar to read.
+
+On a steaming, misty afternoon, Mr. Lorry sat at his desk, and Charles
+Darnay stood leaning on it, talking with him in a low voice. The
+penitential den once set apart for interviews with the House, was now
+the news-Exchange, and was filled to overflowing. It was within half an
+hour or so of the time of closing.
+
+“But, although you are the youngest man that ever lived,” said Charles
+Darnay, rather hesitating, “I must still suggest to you--”
+
+“I understand. That I am too old?” said Mr. Lorry.
+
+“Unsettled weather, a long journey, uncertain means of travelling, a
+disorganised country, a city that may not be even safe for you.”
+
+“My dear Charles,” said Mr. Lorry, with cheerful confidence, “you touch
+some of the reasons for my going: not for my staying away. It is safe
+enough for me; nobody will care to interfere with an old fellow of hard
+upon fourscore when there are so many people there much better worth
+interfering with. As to its being a disorganised city, if it were not a
+disorganised city there would be no occasion to send somebody from our
+House here to our House there, who knows the city and the business, of
+old, and is in Tellson’s confidence. As to the uncertain travelling, the
+long journey, and the winter weather, if I were not prepared to submit
+myself to a few inconveniences for the sake of Tellson’s, after all
+these years, who ought to be?”
+
+“I wish I were going myself,” said Charles Darnay, somewhat restlessly,
+and like one thinking aloud.
+
+“Indeed! You are a pretty fellow to object and advise!” exclaimed Mr.
+Lorry. “You wish you were going yourself? And you a Frenchman born? You
+are a wise counsellor.”
+
+“My dear Mr. Lorry, it is because I am a Frenchman born, that the
+thought (which I did not mean to utter here, however) has passed through
+my mind often. One cannot help thinking, having had some sympathy for
+the miserable people, and having abandoned something to them,” he spoke
+here in his former thoughtful manner, “that one might be listened to,
+and might have the power to persuade to some restraint. Only last night,
+after you had left us, when I was talking to Lucie--”
+
+“When you were talking to Lucie,” Mr. Lorry repeated. “Yes. I wonder you
+are not ashamed to mention the name of Lucie! Wishing you were going to
+France at this time of day!”
+
+“However, I am not going,” said Charles Darnay, with a smile. “It is
+more to the purpose that you say you are.”
+
+“And I am, in plain reality. The truth is, my dear Charles,” Mr. Lorry
+glanced at the distant House, and lowered his voice, “you can have no
+conception of the difficulty with which our business is transacted, and
+of the peril in which our books and papers over yonder are involved. The
+Lord above knows what the compromising consequences would be to numbers
+of people, if some of our documents were seized or destroyed; and they
+might be, at any time, you know, for who can say that Paris is not set
+afire to-day, or sacked to-morrow! Now, a judicious selection from these
+with the least possible delay, and the burying of them, or otherwise
+getting of them out of harm’s way, is within the power (without loss of
+precious time) of scarcely any one but myself, if any one. And shall
+I hang back, when Tellson’s knows this and says this--Tellson’s, whose
+bread I have eaten these sixty years--because I am a little stiff about
+the joints? Why, I am a boy, sir, to half a dozen old codgers here!”
+
+“How I admire the gallantry of your youthful spirit, Mr. Lorry.”
+
+“Tut! Nonsense, sir!--And, my dear Charles,” said Mr. Lorry, glancing at
+the House again, “you are to remember, that getting things out of
+Paris at this present time, no matter what things, is next to an
+impossibility. Papers and precious matters were this very day brought
+to us here (I speak in strict confidence; it is not business-like to
+whisper it, even to you), by the strangest bearers you can imagine,
+every one of whom had his head hanging on by a single hair as he passed
+the Barriers. At another time, our parcels would come and go, as easily
+as in business-like Old England; but now, everything is stopped.”
+
+“And do you really go to-night?”
+
+“I really go to-night, for the case has become too pressing to admit of
+delay.”
+
+“And do you take no one with you?”
+
+“All sorts of people have been proposed to me, but I will have nothing
+to say to any of them. I intend to take Jerry. Jerry has been my
+bodyguard on Sunday nights for a long time past and I am used to him.
+Nobody will suspect Jerry of being anything but an English bull-dog, or
+of having any design in his head but to fly at anybody who touches his
+master.”
+
+“I must say again that I heartily admire your gallantry and
+youthfulness.”
+
+“I must say again, nonsense, nonsense! When I have executed this little
+commission, I shall, perhaps, accept Tellson’s proposal to retire and
+live at my ease. Time enough, then, to think about growing old.”
+
+This dialogue had taken place at Mr. Lorry’s usual desk, with
+Monseigneur swarming within a yard or two of it, boastful of what he
+would do to avenge himself on the rascal-people before long. It was too
+much the way of Monseigneur under his reverses as a refugee, and it
+was much too much the way of native British orthodoxy, to talk of this
+terrible Revolution as if it were the only harvest ever known under
+the skies that had not been sown--as if nothing had ever been done, or
+omitted to be done, that had led to it--as if observers of the wretched
+millions in France, and of the misused and perverted resources that
+should have made them prosperous, had not seen it inevitably coming,
+years before, and had not in plain words recorded what they saw. Such
+vapouring, combined with the extravagant plots of Monseigneur for the
+restoration of a state of things that had utterly exhausted itself,
+and worn out Heaven and earth as well as itself, was hard to be endured
+without some remonstrance by any sane man who knew the truth. And it was
+such vapouring all about his ears, like a troublesome confusion of blood
+in his own head, added to a latent uneasiness in his mind, which had
+already made Charles Darnay restless, and which still kept him so.
+
+Among the talkers, was Stryver, of the King’s Bench Bar, far on his
+way to state promotion, and, therefore, loud on the theme: broaching
+to Monseigneur, his devices for blowing the people up and exterminating
+them from the face of the earth, and doing without them: and for
+accomplishing many similar objects akin in their nature to the abolition
+of eagles by sprinkling salt on the tails of the race. Him, Darnay heard
+with a particular feeling of objection; and Darnay stood divided between
+going away that he might hear no more, and remaining to interpose his
+word, when the thing that was to be, went on to shape itself out.
+
+The House approached Mr. Lorry, and laying a soiled and unopened letter
+before him, asked if he had yet discovered any traces of the person to
+whom it was addressed? The House laid the letter down so close to Darnay
+that he saw the direction--the more quickly because it was his own right
+name. The address, turned into English, ran:
+
+“Very pressing. To Monsieur heretofore the Marquis St. Evremonde, of
+France. Confided to the cares of Messrs. Tellson and Co., Bankers,
+London, England.”
+
+On the marriage morning, Doctor Manette had made it his one urgent and
+express request to Charles Darnay, that the secret of this name should
+be--unless he, the Doctor, dissolved the obligation--kept inviolate
+between them. Nobody else knew it to be his name; his own wife had no
+suspicion of the fact; Mr. Lorry could have none.
+
+“No,” said Mr. Lorry, in reply to the House; “I have referred it,
+I think, to everybody now here, and no one can tell me where this
+gentleman is to be found.”
+
+The hands of the clock verging upon the hour of closing the Bank, there
+was a general set of the current of talkers past Mr. Lorry’s desk. He
+held the letter out inquiringly; and Monseigneur looked at it, in the
+person of this plotting and indignant refugee; and Monseigneur looked at
+it in the person of that plotting and indignant refugee; and This, That,
+and The Other, all had something disparaging to say, in French or in
+English, concerning the Marquis who was not to be found.
+
+“Nephew, I believe--but in any case degenerate successor--of the
+polished Marquis who was murdered,” said one. “Happy to say, I never
+knew him.”
+
+“A craven who abandoned his post,” said another--this Monseigneur had
+been got out of Paris, legs uppermost and half suffocated, in a load of
+hay--“some years ago.”
+
+“Infected with the new doctrines,” said a third, eyeing the direction
+through his glass in passing; “set himself in opposition to the last
+Marquis, abandoned the estates when he inherited them, and left them to
+the ruffian herd. They will recompense him now, I hope, as he deserves.”
+
+“Hey?” cried the blatant Stryver. “Did he though? Is that the sort of
+fellow? Let us look at his infamous name. D--n the fellow!”
+
+Darnay, unable to restrain himself any longer, touched Mr. Stryver on
+the shoulder, and said:
+
+“I know the fellow.”
+
+“Do you, by Jupiter?” said Stryver. “I am sorry for it.”
+
+“Why?”
+
+“Why, Mr. Darnay? D’ye hear what he did? Don’t ask, why, in these
+times.”
+
+“But I do ask why?”
+
+“Then I tell you again, Mr. Darnay, I am sorry for it. I am sorry to
+hear you putting any such extraordinary questions. Here is a fellow,
+who, infected by the most pestilent and blasphemous code of devilry that
+ever was known, abandoned his property to the vilest scum of the earth
+that ever did murder by wholesale, and you ask me why I am sorry that a
+man who instructs youth knows him? Well, but I’ll answer you. I am sorry
+because I believe there is contamination in such a scoundrel. That’s
+why.”
+
+Mindful of the secret, Darnay with great difficulty checked himself, and
+said: “You may not understand the gentleman.”
+
+“I understand how to put _you_ in a corner, Mr. Darnay,” said Bully
+Stryver, “and I’ll do it. If this fellow is a gentleman, I _don’t_
+understand him. You may tell him so, with my compliments. You may also
+tell him, from me, that after abandoning his worldly goods and position
+to this butcherly mob, I wonder he is not at the head of them. But, no,
+gentlemen,” said Stryver, looking all round, and snapping his fingers,
+“I know something of human nature, and I tell you that you’ll never
+find a fellow like this fellow, trusting himself to the mercies of such
+precious _protégés_. No, gentlemen; he’ll always show ‘em a clean pair
+of heels very early in the scuffle, and sneak away.”
+
+With those words, and a final snap of his fingers, Mr. Stryver
+shouldered himself into Fleet-street, amidst the general approbation of
+his hearers. Mr. Lorry and Charles Darnay were left alone at the desk,
+in the general departure from the Bank.
+
+“Will you take charge of the letter?” said Mr. Lorry. “You know where to
+deliver it?”
+
+“I do.”
+
+“Will you undertake to explain, that we suppose it to have been
+addressed here, on the chance of our knowing where to forward it, and
+that it has been here some time?”
+
+“I will do so. Do you start for Paris from here?”
+
+“From here, at eight.”
+
+“I will come back, to see you off.”
+
+Very ill at ease with himself, and with Stryver and most other men,
+Darnay made the best of his way into the quiet of the Temple, opened the
+letter, and read it. These were its contents:
+
+
+“Prison of the Abbaye, Paris.
+
+“June 21, 1792. “MONSIEUR HERETOFORE THE MARQUIS.
+
+“After having long been in danger of my life at the hands of the
+village, I have been seized, with great violence and indignity, and
+brought a long journey on foot to Paris. On the road I have suffered a
+great deal. Nor is that all; my house has been destroyed--razed to the
+ground.
+
+“The crime for which I am imprisoned, Monsieur heretofore the Marquis,
+and for which I shall be summoned before the tribunal, and shall lose my
+life (without your so generous help), is, they tell me, treason against
+the majesty of the people, in that I have acted against them for an
+emigrant. It is in vain I represent that I have acted for them, and not
+against, according to your commands. It is in vain I represent that,
+before the sequestration of emigrant property, I had remitted the
+imposts they had ceased to pay; that I had collected no rent; that I had
+had recourse to no process. The only response is, that I have acted for
+an emigrant, and where is that emigrant?
+
+“Ah! most gracious Monsieur heretofore the Marquis, where is that
+emigrant? I cry in my sleep where is he? I demand of Heaven, will he
+not come to deliver me? No answer. Ah Monsieur heretofore the Marquis,
+I send my desolate cry across the sea, hoping it may perhaps reach your
+ears through the great bank of Tilson known at Paris!
+
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name, I supplicate you, Monsieur heretofore the Marquis, to
+succour and release me. My fault is, that I have been true to you. Oh
+Monsieur heretofore the Marquis, I pray you be you true to me!
+
+“From this prison here of horror, whence I every hour tend nearer and
+nearer to destruction, I send you, Monsieur heretofore the Marquis, the
+assurance of my dolorous and unhappy service.
+
+“Your afflicted,
+
+“Gabelle.”
+
+
+The latent uneasiness in Darnay’s mind was roused to vigourous life
+by this letter. The peril of an old servant and a good one, whose
+only crime was fidelity to himself and his family, stared him so
+reproachfully in the face, that, as he walked to and fro in the Temple
+considering what to do, he almost hid his face from the passersby.
+
+He knew very well, that in his horror of the deed which had culminated
+the bad deeds and bad reputation of the old family house, in his
+resentful suspicions of his uncle, and in the aversion with which his
+conscience regarded the crumbling fabric that he was supposed to uphold,
+he had acted imperfectly. He knew very well, that in his love for Lucie,
+his renunciation of his social place, though by no means new to his own
+mind, had been hurried and incomplete. He knew that he ought to have
+systematically worked it out and supervised it, and that he had meant to
+do it, and that it had never been done.
+
+The happiness of his own chosen English home, the necessity of being
+always actively employed, the swift changes and troubles of the time
+which had followed on one another so fast, that the events of this week
+annihilated the immature plans of last week, and the events of the week
+following made all new again; he knew very well, that to the force of
+these circumstances he had yielded:--not without disquiet, but still
+without continuous and accumulating resistance. That he had watched
+the times for a time of action, and that they had shifted and struggled
+until the time had gone by, and the nobility were trooping from
+France by every highway and byway, and their property was in course of
+confiscation and destruction, and their very names were blotting out,
+was as well known to himself as it could be to any new authority in
+France that might impeach him for it.
+
+But, he had oppressed no man, he had imprisoned no man; he was so
+far from having harshly exacted payment of his dues, that he had
+relinquished them of his own will, thrown himself on a world with no
+favour in it, won his own private place there, and earned his own
+bread. Monsieur Gabelle had held the impoverished and involved estate
+on written instructions, to spare the people, to give them what little
+there was to give--such fuel as the heavy creditors would let them have
+in the winter, and such produce as could be saved from the same grip in
+the summer--and no doubt he had put the fact in plea and proof, for his
+own safety, so that it could not but appear now.
+
+This favoured the desperate resolution Charles Darnay had begun to make,
+that he would go to Paris.
+
+Yes. Like the mariner in the old story, the winds and streams had driven
+him within the influence of the Loadstone Rock, and it was drawing him
+to itself, and he must go. Everything that arose before his mind drifted
+him on, faster and faster, more and more steadily, to the terrible
+attraction. His latent uneasiness had been, that bad aims were being
+worked out in his own unhappy land by bad instruments, and that he who
+could not fail to know that he was better than they, was not there,
+trying to do something to stay bloodshed, and assert the claims of mercy
+and humanity. With this uneasiness half stifled, and half reproaching
+him, he had been brought to the pointed comparison of himself with the
+brave old gentleman in whom duty was so strong; upon that comparison
+(injurious to himself) had instantly followed the sneers of Monseigneur,
+which had stung him bitterly, and those of Stryver, which above all were
+coarse and galling, for old reasons. Upon those, had followed Gabelle’s
+letter: the appeal of an innocent prisoner, in danger of death, to his
+justice, honour, and good name.
+
+His resolution was made. He must go to Paris.
+
+Yes. The Loadstone Rock was drawing him, and he must sail on, until he
+struck. He knew of no rock; he saw hardly any danger. The intention
+with which he had done what he had done, even although he had left
+it incomplete, presented it before him in an aspect that would be
+gratefully acknowledged in France on his presenting himself to assert
+it. Then, that glorious vision of doing good, which is so often the
+sanguine mirage of so many good minds, arose before him, and he even
+saw himself in the illusion with some influence to guide this raging
+Revolution that was running so fearfully wild.
+
+As he walked to and fro with his resolution made, he considered that
+neither Lucie nor her father must know of it until he was gone.
+Lucie should be spared the pain of separation; and her father, always
+reluctant to turn his thoughts towards the dangerous ground of old,
+should come to the knowledge of the step, as a step taken, and not in
+the balance of suspense and doubt. How much of the incompleteness of his
+situation was referable to her father, through the painful anxiety
+to avoid reviving old associations of France in his mind, he did not
+discuss with himself. But, that circumstance too, had had its influence
+in his course.
+
+He walked to and fro, with thoughts very busy, until it was time to
+return to Tellson’s and take leave of Mr. Lorry. As soon as he arrived
+in Paris he would present himself to this old friend, but he must say
+nothing of his intention now.
+
+A carriage with post-horses was ready at the Bank door, and Jerry was
+booted and equipped.
+
+“I have delivered that letter,” said Charles Darnay to Mr. Lorry. “I
+would not consent to your being charged with any written answer, but
+perhaps you will take a verbal one?”
+
+“That I will, and readily,” said Mr. Lorry, “if it is not dangerous.”
+
+“Not at all. Though it is to a prisoner in the Abbaye.”
+
+“What is his name?” said Mr. Lorry, with his open pocket-book in his
+hand.
+
+“Gabelle.”
+
+“Gabelle. And what is the message to the unfortunate Gabelle in prison?”
+
+“Simply, ‘that he has received the letter, and will come.’”
+
+“Any time mentioned?”
+
+“He will start upon his journey to-morrow night.”
+
+“Any person mentioned?”
+
+“No.”
+
+He helped Mr. Lorry to wrap himself in a number of coats and cloaks,
+and went out with him from the warm atmosphere of the old Bank, into the
+misty air of Fleet-street. “My love to Lucie, and to little Lucie,” said
+Mr. Lorry at parting, “and take precious care of them till I come back.”
+ Charles Darnay shook his head and doubtfully smiled, as the carriage
+rolled away.
+
+That night--it was the fourteenth of August--he sat up late, and wrote
+two fervent letters; one was to Lucie, explaining the strong obligation
+he was under to go to Paris, and showing her, at length, the reasons
+that he had, for feeling confident that he could become involved in no
+personal danger there; the other was to the Doctor, confiding Lucie and
+their dear child to his care, and dwelling on the same topics with the
+strongest assurances. To both, he wrote that he would despatch letters
+in proof of his safety, immediately after his arrival.
+
+It was a hard day, that day of being among them, with the first
+reservation of their joint lives on his mind. It was a hard matter to
+preserve the innocent deceit of which they were profoundly unsuspicious.
+But, an affectionate glance at his wife, so happy and busy, made him
+resolute not to tell her what impended (he had been half moved to do it,
+so strange it was to him to act in anything without her quiet aid), and
+the day passed quickly. Early in the evening he embraced her, and her
+scarcely less dear namesake, pretending that he would return by-and-bye
+(an imaginary engagement took him out, and he had secreted a valise
+of clothes ready), and so he emerged into the heavy mist of the heavy
+streets, with a heavier heart.
+
+The unseen force was drawing him fast to itself, now, and all the tides
+and winds were setting straight and strong towards it. He left his
+two letters with a trusty porter, to be delivered half an hour before
+midnight, and no sooner; took horse for Dover; and began his journey.
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name!” was the poor prisoner’s cry with which he strengthened
+his sinking heart, as he left all that was dear on earth behind him, and
+floated away for the Loadstone Rock.
+
+
+The end of the second book.
+
+
+
+
+
+Book the Third--the Track of a Storm
+
+
+
+
+I. In Secret
+
+
+The traveller fared slowly on his way, who fared towards Paris from
+England in the autumn of the year one thousand seven hundred and
+ninety-two. More than enough of bad roads, bad equipages, and bad
+horses, he would have encountered to delay him, though the fallen and
+unfortunate King of France had been upon his throne in all his glory;
+but, the changed times were fraught with other obstacles than
+these. Every town-gate and village taxing-house had its band of
+citizen-patriots, with their national muskets in a most explosive state
+of readiness, who stopped all comers and goers, cross-questioned them,
+inspected their papers, looked for their names in lists of their own,
+turned them back, or sent them on, or stopped them and laid them in
+hold, as their capricious judgment or fancy deemed best for the dawning
+Republic One and Indivisible, of Liberty, Equality, Fraternity, or
+Death.
+
+A very few French leagues of his journey were accomplished, when Charles
+Darnay began to perceive that for him along these country roads there
+was no hope of return until he should have been declared a good citizen
+at Paris. Whatever might befall now, he must on to his journey’s end.
+Not a mean village closed upon him, not a common barrier dropped across
+the road behind him, but he knew it to be another iron door in
+the series that was barred between him and England. The universal
+watchfulness so encompassed him, that if he had been taken in a net,
+or were being forwarded to his destination in a cage, he could not have
+felt his freedom more completely gone.
+
+This universal watchfulness not only stopped him on the highway twenty
+times in a stage, but retarded his progress twenty times in a day, by
+riding after him and taking him back, riding before him and stopping him
+by anticipation, riding with him and keeping him in charge. He had been
+days upon his journey in France alone, when he went to bed tired out, in
+a little town on the high road, still a long way from Paris.
+
+Nothing but the production of the afflicted Gabelle’s letter from his
+prison of the Abbaye would have got him on so far. His difficulty at the
+guard-house in this small place had been such, that he felt his journey
+to have come to a crisis. And he was, therefore, as little surprised as
+a man could be, to find himself awakened at the small inn to which he
+had been remitted until morning, in the middle of the night.
+
+Awakened by a timid local functionary and three armed patriots in rough
+red caps and with pipes in their mouths, who sat down on the bed.
+
+“Emigrant,” said the functionary, “I am going to send you on to Paris,
+under an escort.”
+
+“Citizen, I desire nothing more than to get to Paris, though I could
+dispense with the escort.”
+
+“Silence!” growled a red-cap, striking at the coverlet with the butt-end
+of his musket. “Peace, aristocrat!”
+
+“It is as the good patriot says,” observed the timid functionary. “You
+are an aristocrat, and must have an escort--and must pay for it.”
+
+“I have no choice,” said Charles Darnay.
+
+“Choice! Listen to him!” cried the same scowling red-cap. “As if it was
+not a favour to be protected from the lamp-iron!”
+
+“It is always as the good patriot says,” observed the functionary. “Rise
+and dress yourself, emigrant.”
+
+Darnay complied, and was taken back to the guard-house, where other
+patriots in rough red caps were smoking, drinking, and sleeping, by
+a watch-fire. Here he paid a heavy price for his escort, and hence he
+started with it on the wet, wet roads at three o’clock in the morning.
+
+The escort were two mounted patriots in red caps and tri-coloured
+cockades, armed with national muskets and sabres, who rode one on either
+side of him.
+
+The escorted governed his own horse, but a loose line was attached to
+his bridle, the end of which one of the patriots kept girded round his
+wrist. In this state they set forth with the sharp rain driving in their
+faces: clattering at a heavy dragoon trot over the uneven town pavement,
+and out upon the mire-deep roads. In this state they traversed without
+change, except of horses and pace, all the mire-deep leagues that lay
+between them and the capital.
+
+They travelled in the night, halting an hour or two after daybreak, and
+lying by until the twilight fell. The escort were so wretchedly clothed,
+that they twisted straw round their bare legs, and thatched their ragged
+shoulders to keep the wet off. Apart from the personal discomfort of
+being so attended, and apart from such considerations of present danger
+as arose from one of the patriots being chronically drunk, and carrying
+his musket very recklessly, Charles Darnay did not allow the restraint
+that was laid upon him to awaken any serious fears in his breast; for,
+he reasoned with himself that it could have no reference to the merits
+of an individual case that was not yet stated, and of representations,
+confirmable by the prisoner in the Abbaye, that were not yet made.
+
+But when they came to the town of Beauvais--which they did at eventide,
+when the streets were filled with people--he could not conceal from
+himself that the aspect of affairs was very alarming. An ominous crowd
+gathered to see him dismount of the posting-yard, and many voices called
+out loudly, “Down with the emigrant!”
+
+He stopped in the act of swinging himself out of his saddle, and,
+resuming it as his safest place, said:
+
+“Emigrant, my friends! Do you not see me here, in France, of my own
+will?”
+
+“You are a cursed emigrant,” cried a farrier, making at him in a
+furious manner through the press, hammer in hand; “and you are a cursed
+aristocrat!”
+
+The postmaster interposed himself between this man and the rider’s
+bridle (at which he was evidently making), and soothingly said, “Let him
+be; let him be! He will be judged at Paris.”
+
+“Judged!” repeated the farrier, swinging his hammer. “Ay! and condemned
+as a traitor.” At this the crowd roared approval.
+
+Checking the postmaster, who was for turning his horse’s head to the
+yard (the drunken patriot sat composedly in his saddle looking on, with
+the line round his wrist), Darnay said, as soon as he could make his
+voice heard:
+
+“Friends, you deceive yourselves, or you are deceived. I am not a
+traitor.”
+
+“He lies!” cried the smith. “He is a traitor since the decree. His life
+is forfeit to the people. His cursed life is not his own!”
+
+At the instant when Darnay saw a rush in the eyes of the crowd, which
+another instant would have brought upon him, the postmaster turned his
+horse into the yard, the escort rode in close upon his horse’s flanks,
+and the postmaster shut and barred the crazy double gates. The farrier
+struck a blow upon them with his hammer, and the crowd groaned; but, no
+more was done.
+
+“What is this decree that the smith spoke of?” Darnay asked the
+postmaster, when he had thanked him, and stood beside him in the yard.
+
+“Truly, a decree for selling the property of emigrants.”
+
+“When passed?”
+
+“On the fourteenth.”
+
+“The day I left England!”
+
+“Everybody says it is but one of several, and that there will be
+others--if there are not already--banishing all emigrants, and
+condemning all to death who return. That is what he meant when he said
+your life was not your own.”
+
+“But there are no such decrees yet?”
+
+“What do I know!” said the postmaster, shrugging his shoulders; “there
+may be, or there will be. It is all the same. What would you have?”
+
+They rested on some straw in a loft until the middle of the night, and
+then rode forward again when all the town was asleep. Among the many
+wild changes observable on familiar things which made this wild ride
+unreal, not the least was the seeming rarity of sleep. After long and
+lonely spurring over dreary roads, they would come to a cluster of poor
+cottages, not steeped in darkness, but all glittering with lights, and
+would find the people, in a ghostly manner in the dead of the night,
+circling hand in hand round a shrivelled tree of Liberty, or all drawn
+up together singing a Liberty song. Happily, however, there was sleep in
+Beauvais that night to help them out of it and they passed on once more
+into solitude and loneliness: jingling through the untimely cold and
+wet, among impoverished fields that had yielded no fruits of the earth
+that year, diversified by the blackened remains of burnt houses, and by
+the sudden emergence from ambuscade, and sharp reining up across their
+way, of patriot patrols on the watch on all the roads.
+
+Daylight at last found them before the wall of Paris. The barrier was
+closed and strongly guarded when they rode up to it.
+
+“Where are the papers of this prisoner?” demanded a resolute-looking man
+in authority, who was summoned out by the guard.
+
+Naturally struck by the disagreeable word, Charles Darnay requested the
+speaker to take notice that he was a free traveller and French citizen,
+in charge of an escort which the disturbed state of the country had
+imposed upon him, and which he had paid for.
+
+“Where,” repeated the same personage, without taking any heed of him
+whatever, “are the papers of this prisoner?”
+
+The drunken patriot had them in his cap, and produced them. Casting his
+eyes over Gabelle’s letter, the same personage in authority showed some
+disorder and surprise, and looked at Darnay with a close attention.
+
+He left escort and escorted without saying a word, however, and went
+into the guard-room; meanwhile, they sat upon their horses outside the
+gate. Looking about him while in this state of suspense, Charles
+Darnay observed that the gate was held by a mixed guard of soldiers and
+patriots, the latter far outnumbering the former; and that while ingress
+into the city for peasants’ carts bringing in supplies, and for similar
+traffic and traffickers, was easy enough, egress, even for the homeliest
+people, was very difficult. A numerous medley of men and women, not
+to mention beasts and vehicles of various sorts, was waiting to issue
+forth; but, the previous identification was so strict, that they
+filtered through the barrier very slowly. Some of these people knew
+their turn for examination to be so far off, that they lay down on the
+ground to sleep or smoke, while others talked together, or loitered
+about. The red cap and tri-colour cockade were universal, both among men
+and women.
+
+When he had sat in his saddle some half-hour, taking note of these
+things, Darnay found himself confronted by the same man in authority,
+who directed the guard to open the barrier. Then he delivered to the
+escort, drunk and sober, a receipt for the escorted, and requested him
+to dismount. He did so, and the two patriots, leading his tired horse,
+turned and rode away without entering the city.
+
+He accompanied his conductor into a guard-room, smelling of common wine
+and tobacco, where certain soldiers and patriots, asleep and awake,
+drunk and sober, and in various neutral states between sleeping and
+waking, drunkenness and sobriety, were standing and lying about. The
+light in the guard-house, half derived from the waning oil-lamps of
+the night, and half from the overcast day, was in a correspondingly
+uncertain condition. Some registers were lying open on a desk, and an
+officer of a coarse, dark aspect, presided over these.
+
+“Citizen Defarge,” said he to Darnay’s conductor, as he took a slip of
+paper to write on. “Is this the emigrant Evremonde?”
+
+“This is the man.”
+
+“Your age, Evremonde?”
+
+“Thirty-seven.”
+
+“Married, Evremonde?”
+
+“Yes.”
+
+“Where married?”
+
+“In England.”
+
+“Without doubt. Where is your wife, Evremonde?”
+
+“In England.”
+
+“Without doubt. You are consigned, Evremonde, to the prison of La
+Force.”
+
+“Just Heaven!” exclaimed Darnay. “Under what law, and for what offence?”
+
+The officer looked up from his slip of paper for a moment.
+
+“We have new laws, Evremonde, and new offences, since you were here.” He
+said it with a hard smile, and went on writing.
+
+“I entreat you to observe that I have come here voluntarily, in response
+to that written appeal of a fellow-countryman which lies before you. I
+demand no more than the opportunity to do so without delay. Is not that
+my right?”
+
+“Emigrants have no rights, Evremonde,” was the stolid reply. The officer
+wrote until he had finished, read over to himself what he had written,
+sanded it, and handed it to Defarge, with the words “In secret.”
+
+Defarge motioned with the paper to the prisoner that he must accompany
+him. The prisoner obeyed, and a guard of two armed patriots attended
+them.
+
+“Is it you,” said Defarge, in a low voice, as they went down the
+guardhouse steps and turned into Paris, “who married the daughter of
+Doctor Manette, once a prisoner in the Bastille that is no more?”
+
+“Yes,” replied Darnay, looking at him with surprise.
+
+“My name is Defarge, and I keep a wine-shop in the Quarter Saint
+Antoine. Possibly you have heard of me.”
+
+“My wife came to your house to reclaim her father? Yes!”
+
+The word “wife” seemed to serve as a gloomy reminder to Defarge, to say
+with sudden impatience, “In the name of that sharp female newly-born,
+and called La Guillotine, why did you come to France?”
+
+“You heard me say why, a minute ago. Do you not believe it is the
+truth?”
+
+“A bad truth for you,” said Defarge, speaking with knitted brows, and
+looking straight before him.
+
+“Indeed I am lost here. All here is so unprecedented, so changed, so
+sudden and unfair, that I am absolutely lost. Will you render me a
+little help?”
+
+“None.” Defarge spoke, always looking straight before him.
+
+“Will you answer me a single question?”
+
+“Perhaps. According to its nature. You can say what it is.”
+
+“In this prison that I am going to so unjustly, shall I have some free
+communication with the world outside?”
+
+“You will see.”
+
+“I am not to be buried there, prejudged, and without any means of
+presenting my case?”
+
+“You will see. But, what then? Other people have been similarly buried
+in worse prisons, before now.”
+
+“But never by me, Citizen Defarge.”
+
+Defarge glanced darkly at him for answer, and walked on in a steady
+and set silence. The deeper he sank into this silence, the fainter hope
+there was--or so Darnay thought--of his softening in any slight degree.
+He, therefore, made haste to say:
+
+“It is of the utmost importance to me (you know, Citizen, even better
+than I, of how much importance), that I should be able to communicate to
+Mr. Lorry of Tellson’s Bank, an English gentleman who is now in Paris,
+the simple fact, without comment, that I have been thrown into the
+prison of La Force. Will you cause that to be done for me?”
+
+“I will do,” Defarge doggedly rejoined, “nothing for you. My duty is to
+my country and the People. I am the sworn servant of both, against you.
+I will do nothing for you.”
+
+Charles Darnay felt it hopeless to entreat him further, and his pride
+was touched besides. As they walked on in silence, he could not but see
+how used the people were to the spectacle of prisoners passing along the
+streets. The very children scarcely noticed him. A few passers turned
+their heads, and a few shook their fingers at him as an aristocrat;
+otherwise, that a man in good clothes should be going to prison, was no
+more remarkable than that a labourer in working clothes should be
+going to work. In one narrow, dark, and dirty street through which they
+passed, an excited orator, mounted on a stool, was addressing an excited
+audience on the crimes against the people, of the king and the royal
+family. The few words that he caught from this man’s lips, first made
+it known to Charles Darnay that the king was in prison, and that the
+foreign ambassadors had one and all left Paris. On the road (except at
+Beauvais) he had heard absolutely nothing. The escort and the universal
+watchfulness had completely isolated him.
+
+That he had fallen among far greater dangers than those which had
+developed themselves when he left England, he of course knew now. That
+perils had thickened about him fast, and might thicken faster and faster
+yet, he of course knew now. He could not but admit to himself that he
+might not have made this journey, if he could have foreseen the events
+of a few days. And yet his misgivings were not so dark as, imagined by
+the light of this later time, they would appear. Troubled as the future
+was, it was the unknown future, and in its obscurity there was ignorant
+hope. The horrible massacre, days and nights long, which, within a few
+rounds of the clock, was to set a great mark of blood upon the blessed
+garnering time of harvest, was as far out of his knowledge as if it had
+been a hundred thousand years away. The “sharp female newly-born, and
+called La Guillotine,” was hardly known to him, or to the generality
+of people, by name. The frightful deeds that were to be soon done, were
+probably unimagined at that time in the brains of the doers. How could
+they have a place in the shadowy conceptions of a gentle mind?
+
+Of unjust treatment in detention and hardship, and in cruel separation
+from his wife and child, he foreshadowed the likelihood, or the
+certainty; but, beyond this, he dreaded nothing distinctly. With this on
+his mind, which was enough to carry into a dreary prison courtyard, he
+arrived at the prison of La Force.
+
+A man with a bloated face opened the strong wicket, to whom Defarge
+presented “The Emigrant Evremonde.”
+
+“What the Devil! How many more of them!” exclaimed the man with the
+bloated face.
+
+Defarge took his receipt without noticing the exclamation, and withdrew,
+with his two fellow-patriots.
+
+“What the Devil, I say again!” exclaimed the gaoler, left with his wife.
+“How many more!”
+
+The gaoler’s wife, being provided with no answer to the question, merely
+replied, “One must have patience, my dear!” Three turnkeys who entered
+responsive to a bell she rang, echoed the sentiment, and one added, “For
+the love of Liberty;” which sounded in that place like an inappropriate
+conclusion.
+
+The prison of La Force was a gloomy prison, dark and filthy, and with a
+horrible smell of foul sleep in it. Extraordinary how soon the noisome
+flavour of imprisoned sleep, becomes manifest in all such places that
+are ill cared for!
+
+“In secret, too,” grumbled the gaoler, looking at the written paper. “As
+if I was not already full to bursting!”
+
+He stuck the paper on a file, in an ill-humour, and Charles Darnay
+awaited his further pleasure for half an hour: sometimes, pacing to and
+fro in the strong arched room: sometimes, resting on a stone seat: in
+either case detained to be imprinted on the memory of the chief and his
+subordinates.
+
+“Come!” said the chief, at length taking up his keys, “come with me,
+emigrant.”
+
+Through the dismal prison twilight, his new charge accompanied him by
+corridor and staircase, many doors clanging and locking behind them,
+until they came into a large, low, vaulted chamber, crowded with
+prisoners of both sexes. The women were seated at a long table, reading
+and writing, knitting, sewing, and embroidering; the men were for the
+most part standing behind their chairs, or lingering up and down the
+room.
+
+In the instinctive association of prisoners with shameful crime and
+disgrace, the new-comer recoiled from this company. But the crowning
+unreality of his long unreal ride, was, their all at once rising to
+receive him, with every refinement of manner known to the time, and with
+all the engaging graces and courtesies of life.
+
+So strangely clouded were these refinements by the prison manners and
+gloom, so spectral did they become in the inappropriate squalor and
+misery through which they were seen, that Charles Darnay seemed to stand
+in a company of the dead. Ghosts all! The ghost of beauty, the ghost
+of stateliness, the ghost of elegance, the ghost of pride, the ghost of
+frivolity, the ghost of wit, the ghost of youth, the ghost of age, all
+waiting their dismissal from the desolate shore, all turning on him eyes
+that were changed by the death they had died in coming there.
+
+It struck him motionless. The gaoler standing at his side, and the other
+gaolers moving about, who would have been well enough as to appearance
+in the ordinary exercise of their functions, looked so extravagantly
+coarse contrasted with sorrowing mothers and blooming daughters who were
+there--with the apparitions of the coquette, the young beauty, and the
+mature woman delicately bred--that the inversion of all experience and
+likelihood which the scene of shadows presented, was heightened to its
+utmost. Surely, ghosts all. Surely, the long unreal ride some progress
+of disease that had brought him to these gloomy shades!
+
+“In the name of the assembled companions in misfortune,” said a
+gentleman of courtly appearance and address, coming forward, “I have the
+honour of giving you welcome to La Force, and of condoling with you
+on the calamity that has brought you among us. May it soon terminate
+happily! It would be an impertinence elsewhere, but it is not so here,
+to ask your name and condition?”
+
+Charles Darnay roused himself, and gave the required information, in
+words as suitable as he could find.
+
+“But I hope,” said the gentleman, following the chief gaoler with his
+eyes, who moved across the room, “that you are not in secret?”
+
+“I do not understand the meaning of the term, but I have heard them say
+so.”
+
+“Ah, what a pity! We so much regret it! But take courage; several
+members of our society have been in secret, at first, and it has lasted
+but a short time.” Then he added, raising his voice, “I grieve to inform
+the society--in secret.”
+
+There was a murmur of commiseration as Charles Darnay crossed the room
+to a grated door where the gaoler awaited him, and many voices--among
+which, the soft and compassionate voices of women were conspicuous--gave
+him good wishes and encouragement. He turned at the grated door, to
+render the thanks of his heart; it closed under the gaoler’s hand; and
+the apparitions vanished from his sight forever.
+
+The wicket opened on a stone staircase, leading upward. When they had
+ascended forty steps (the prisoner of half an hour already counted
+them), the gaoler opened a low black door, and they passed into a
+solitary cell. It struck cold and damp, but was not dark.
+
+“Yours,” said the gaoler.
+
+“Why am I confined alone?”
+
+“How do I know!”
+
+“I can buy pen, ink, and paper?”
+
+“Such are not my orders. You will be visited, and can ask then. At
+present, you may buy your food, and nothing more.”
+
+There were in the cell, a chair, a table, and a straw mattress. As
+the gaoler made a general inspection of these objects, and of the four
+walls, before going out, a wandering fancy wandered through the mind of
+the prisoner leaning against the wall opposite to him, that this gaoler
+was so unwholesomely bloated, both in face and person, as to look like
+a man who had been drowned and filled with water. When the gaoler was
+gone, he thought in the same wandering way, “Now am I left, as if I were
+dead.” Stopping then, to look down at the mattress, he turned from it
+with a sick feeling, and thought, “And here in these crawling creatures
+is the first condition of the body after death.”
+
+“Five paces by four and a half, five paces by four and a half, five
+paces by four and a half.” The prisoner walked to and fro in his cell,
+counting its measurement, and the roar of the city arose like muffled
+drums with a wild swell of voices added to them. “He made shoes, he made
+shoes, he made shoes.” The prisoner counted the measurement again, and
+paced faster, to draw his mind with him from that latter repetition.
+“The ghosts that vanished when the wicket closed. There was one among
+them, the appearance of a lady dressed in black, who was leaning in the
+embrasure of a window, and she had a light shining upon her golden
+hair, and she looked like * * * * Let us ride on again, for God’s sake,
+through the illuminated villages with the people all awake! * * * * He
+made shoes, he made shoes, he made shoes. * * * * Five paces by four and
+a half.” With such scraps tossing and rolling upward from the depths of
+his mind, the prisoner walked faster and faster, obstinately counting
+and counting; and the roar of the city changed to this extent--that it
+still rolled in like muffled drums, but with the wail of voices that he
+knew, in the swell that rose above them.
+
+
+
+
+II. The Grindstone
+
+
+Tellson’s Bank, established in the Saint Germain Quarter of Paris, was
+in a wing of a large house, approached by a courtyard and shut off from
+the street by a high wall and a strong gate. The house belonged to
+a great nobleman who had lived in it until he made a flight from the
+troubles, in his own cook’s dress, and got across the borders. A
+mere beast of the chase flying from hunters, he was still in his
+metempsychosis no other than the same Monseigneur, the preparation
+of whose chocolate for whose lips had once occupied three strong men
+besides the cook in question.
+
+Monseigneur gone, and the three strong men absolving themselves from the
+sin of having drawn his high wages, by being more than ready and
+willing to cut his throat on the altar of the dawning Republic one and
+indivisible of Liberty, Equality, Fraternity, or Death, Monseigneur’s
+house had been first sequestrated, and then confiscated. For, all
+things moved so fast, and decree followed decree with that fierce
+precipitation, that now upon the third night of the autumn month
+of September, patriot emissaries of the law were in possession of
+Monseigneur’s house, and had marked it with the tri-colour, and were
+drinking brandy in its state apartments.
+
+A place of business in London like Tellson’s place of business in Paris,
+would soon have driven the House out of its mind and into the Gazette.
+For, what would staid British responsibility and respectability have
+said to orange-trees in boxes in a Bank courtyard, and even to a Cupid
+over the counter? Yet such things were. Tellson’s had whitewashed the
+Cupid, but he was still to be seen on the ceiling, in the coolest
+linen, aiming (as he very often does) at money from morning to
+night. Bankruptcy must inevitably have come of this young Pagan, in
+Lombard-street, London, and also of a curtained alcove in the rear of
+the immortal boy, and also of a looking-glass let into the wall, and
+also of clerks not at all old, who danced in public on the slightest
+provocation. Yet, a French Tellson’s could get on with these things
+exceedingly well, and, as long as the times held together, no man had
+taken fright at them, and drawn out his money.
+
+What money would be drawn out of Tellson’s henceforth, and what would
+lie there, lost and forgotten; what plate and jewels would tarnish in
+Tellson’s hiding-places, while the depositors rusted in prisons,
+and when they should have violently perished; how many accounts with
+Tellson’s never to be balanced in this world, must be carried over into
+the next; no man could have said, that night, any more than Mr. Jarvis
+Lorry could, though he thought heavily of these questions. He sat by
+a newly-lighted wood fire (the blighted and unfruitful year was
+prematurely cold), and on his honest and courageous face there was a
+deeper shade than the pendent lamp could throw, or any object in the
+room distortedly reflect--a shade of horror.
+
+He occupied rooms in the Bank, in his fidelity to the House of which
+he had grown to be a part, like strong root-ivy. It chanced that they
+derived a kind of security from the patriotic occupation of the main
+building, but the true-hearted old gentleman never calculated about
+that. All such circumstances were indifferent to him, so that he did
+his duty. On the opposite side of the courtyard, under a colonnade,
+was extensive standing--for carriages--where, indeed, some carriages
+of Monseigneur yet stood. Against two of the pillars were fastened two
+great flaring flambeaux, and in the light of these, standing out in the
+open air, was a large grindstone: a roughly mounted thing which appeared
+to have hurriedly been brought there from some neighbouring smithy,
+or other workshop. Rising and looking out of window at these harmless
+objects, Mr. Lorry shivered, and retired to his seat by the fire. He had
+opened, not only the glass window, but the lattice blind outside it, and
+he had closed both again, and he shivered through his frame.
+
+From the streets beyond the high wall and the strong gate, there came
+the usual night hum of the city, with now and then an indescribable ring
+in it, weird and unearthly, as if some unwonted sounds of a terrible
+nature were going up to Heaven.
+
+“Thank God,” said Mr. Lorry, clasping his hands, “that no one near and
+dear to me is in this dreadful town to-night. May He have mercy on all
+who are in danger!”
+
+Soon afterwards, the bell at the great gate sounded, and he thought,
+“They have come back!” and sat listening. But, there was no loud
+irruption into the courtyard, as he had expected, and he heard the gate
+clash again, and all was quiet.
+
+The nervousness and dread that were upon him inspired that vague
+uneasiness respecting the Bank, which a great change would naturally
+awaken, with such feelings roused. It was well guarded, and he got up to
+go among the trusty people who were watching it, when his door suddenly
+opened, and two figures rushed in, at sight of which he fell back in
+amazement.
+
+Lucie and her father! Lucie with her arms stretched out to him, and with
+that old look of earnestness so concentrated and intensified, that it
+seemed as though it had been stamped upon her face expressly to give
+force and power to it in this one passage of her life.
+
+“What is this?” cried Mr. Lorry, breathless and confused. “What is the
+matter? Lucie! Manette! What has happened? What has brought you here?
+What is it?”
+
+With the look fixed upon him, in her paleness and wildness, she panted
+out in his arms, imploringly, “O my dear friend! My husband!”
+
+“Your husband, Lucie?”
+
+“Charles.”
+
+“What of Charles?”
+
+“Here.
+
+“Here, in Paris?”
+
+“Has been here some days--three or four--I don’t know how many--I can’t
+collect my thoughts. An errand of generosity brought him here unknown to
+us; he was stopped at the barrier, and sent to prison.”
+
+The old man uttered an irrepressible cry. Almost at the same moment, the
+bell of the great gate rang again, and a loud noise of feet and voices
+came pouring into the courtyard.
+
+“What is that noise?” said the Doctor, turning towards the window.
+
+“Don’t look!” cried Mr. Lorry. “Don’t look out! Manette, for your life,
+don’t touch the blind!”
+
+The Doctor turned, with his hand upon the fastening of the window, and
+said, with a cool, bold smile:
+
+“My dear friend, I have a charmed life in this city. I have been
+a Bastille prisoner. There is no patriot in Paris--in Paris? In
+France--who, knowing me to have been a prisoner in the Bastille, would
+touch me, except to overwhelm me with embraces, or carry me in triumph.
+My old pain has given me a power that has brought us through the
+barrier, and gained us news of Charles there, and brought us here. I
+knew it would be so; I knew I could help Charles out of all danger; I
+told Lucie so.--What is that noise?” His hand was again upon the window.
+
+“Don’t look!” cried Mr. Lorry, absolutely desperate. “No, Lucie, my
+dear, nor you!” He got his arm round her, and held her. “Don’t be so
+terrified, my love. I solemnly swear to you that I know of no harm
+having happened to Charles; that I had no suspicion even of his being in
+this fatal place. What prison is he in?”
+
+“La Force!”
+
+“La Force! Lucie, my child, if ever you were brave and serviceable in
+your life--and you were always both--you will compose yourself now, to
+do exactly as I bid you; for more depends upon it than you can think, or
+I can say. There is no help for you in any action on your part to-night;
+you cannot possibly stir out. I say this, because what I must bid you
+to do for Charles’s sake, is the hardest thing to do of all. You must
+instantly be obedient, still, and quiet. You must let me put you in a
+room at the back here. You must leave your father and me alone for
+two minutes, and as there are Life and Death in the world you must not
+delay.”
+
+“I will be submissive to you. I see in your face that you know I can do
+nothing else than this. I know you are true.”
+
+The old man kissed her, and hurried her into his room, and turned the
+key; then, came hurrying back to the Doctor, and opened the window and
+partly opened the blind, and put his hand upon the Doctor’s arm, and
+looked out with him into the courtyard.
+
+Looked out upon a throng of men and women: not enough in number, or near
+enough, to fill the courtyard: not more than forty or fifty in all. The
+people in possession of the house had let them in at the gate, and they
+had rushed in to work at the grindstone; it had evidently been set up
+there for their purpose, as in a convenient and retired spot.
+
+But, such awful workers, and such awful work!
+
+The grindstone had a double handle, and, turning at it madly were two
+men, whose faces, as their long hair flapped back when the whirlings of
+the grindstone brought their faces up, were more horrible and cruel than
+the visages of the wildest savages in their most barbarous disguise.
+False eyebrows and false moustaches were stuck upon them, and their
+hideous countenances were all bloody and sweaty, and all awry with
+howling, and all staring and glaring with beastly excitement and want of
+sleep. As these ruffians turned and turned, their matted locks now flung
+forward over their eyes, now flung backward over their necks, some women
+held wine to their mouths that they might drink; and what with dropping
+blood, and what with dropping wine, and what with the stream of sparks
+struck out of the stone, all their wicked atmosphere seemed gore and
+fire. The eye could not detect one creature in the group free from
+the smear of blood. Shouldering one another to get next at the
+sharpening-stone, were men stripped to the waist, with the stain all
+over their limbs and bodies; men in all sorts of rags, with the stain
+upon those rags; men devilishly set off with spoils of women’s lace
+and silk and ribbon, with the stain dyeing those trifles through
+and through. Hatchets, knives, bayonets, swords, all brought to be
+sharpened, were all red with it. Some of the hacked swords were tied to
+the wrists of those who carried them, with strips of linen and fragments
+of dress: ligatures various in kind, but all deep of the one colour. And
+as the frantic wielders of these weapons snatched them from the stream
+of sparks and tore away into the streets, the same red hue was red in
+their frenzied eyes;--eyes which any unbrutalised beholder would have
+given twenty years of life, to petrify with a well-directed gun.
+
+All this was seen in a moment, as the vision of a drowning man, or of
+any human creature at any very great pass, could see a world if it
+were there. They drew back from the window, and the Doctor looked for
+explanation in his friend’s ashy face.
+
+“They are,” Mr. Lorry whispered the words, glancing fearfully round at
+the locked room, “murdering the prisoners. If you are sure of what you
+say; if you really have the power you think you have--as I believe you
+have--make yourself known to these devils, and get taken to La Force. It
+may be too late, I don’t know, but let it not be a minute later!”
+
+Doctor Manette pressed his hand, hastened bareheaded out of the room,
+and was in the courtyard when Mr. Lorry regained the blind.
+
+His streaming white hair, his remarkable face, and the impetuous
+confidence of his manner, as he put the weapons aside like water,
+carried him in an instant to the heart of the concourse at the stone.
+For a few moments there was a pause, and a hurry, and a murmur, and
+the unintelligible sound of his voice; and then Mr. Lorry saw him,
+surrounded by all, and in the midst of a line of twenty men long, all
+linked shoulder to shoulder, and hand to shoulder, hurried out with
+cries of--“Live the Bastille prisoner! Help for the Bastille prisoner’s
+kindred in La Force! Room for the Bastille prisoner in front there! Save
+the prisoner Evremonde at La Force!” and a thousand answering shouts.
+
+He closed the lattice again with a fluttering heart, closed the window
+and the curtain, hastened to Lucie, and told her that her father was
+assisted by the people, and gone in search of her husband. He found
+her child and Miss Pross with her; but, it never occurred to him to be
+surprised by their appearance until a long time afterwards, when he sat
+watching them in such quiet as the night knew.
+
+Lucie had, by that time, fallen into a stupor on the floor at his feet,
+clinging to his hand. Miss Pross had laid the child down on his own
+bed, and her head had gradually fallen on the pillow beside her pretty
+charge. O the long, long night, with the moans of the poor wife! And O
+the long, long night, with no return of her father and no tidings!
+
+Twice more in the darkness the bell at the great gate sounded, and the
+irruption was repeated, and the grindstone whirled and spluttered.
+“What is it?” cried Lucie, affrighted. “Hush! The soldiers’ swords are
+sharpened there,” said Mr. Lorry. “The place is national property now,
+and used as a kind of armoury, my love.”
+
+Twice more in all; but, the last spell of work was feeble and fitful.
+Soon afterwards the day began to dawn, and he softly detached himself
+from the clasping hand, and cautiously looked out again. A man, so
+besmeared that he might have been a sorely wounded soldier creeping back
+to consciousness on a field of slain, was rising from the pavement by
+the side of the grindstone, and looking about him with a vacant air.
+Shortly, this worn-out murderer descried in the imperfect light one of
+the carriages of Monseigneur, and, staggering to that gorgeous vehicle,
+climbed in at the door, and shut himself up to take his rest on its
+dainty cushions.
+
+The great grindstone, Earth, had turned when Mr. Lorry looked out again,
+and the sun was red on the courtyard. But, the lesser grindstone stood
+alone there in the calm morning air, with a red upon it that the sun had
+never given, and would never take away.
+
+
+
+
+III. The Shadow
+
+
+One of the first considerations which arose in the business mind of Mr.
+Lorry when business hours came round, was this:--that he had no right to
+imperil Tellson’s by sheltering the wife of an emigrant prisoner under
+the Bank roof. His own possessions, safety, life, he would have hazarded
+for Lucie and her child, without a moment’s demur; but the great trust
+he held was not his own, and as to that business charge he was a strict
+man of business.
+
+At first, his mind reverted to Defarge, and he thought of finding out
+the wine-shop again and taking counsel with its master in reference to
+the safest dwelling-place in the distracted state of the city. But, the
+same consideration that suggested him, repudiated him; he lived in the
+most violent Quarter, and doubtless was influential there, and deep in
+its dangerous workings.
+
+Noon coming, and the Doctor not returning, and every minute’s delay
+tending to compromise Tellson’s, Mr. Lorry advised with Lucie. She said
+that her father had spoken of hiring a lodging for a short term, in that
+Quarter, near the Banking-house. As there was no business objection to
+this, and as he foresaw that even if it were all well with Charles, and
+he were to be released, he could not hope to leave the city, Mr. Lorry
+went out in quest of such a lodging, and found a suitable one, high up
+in a removed by-street where the closed blinds in all the other windows
+of a high melancholy square of buildings marked deserted homes.
+
+To this lodging he at once removed Lucie and her child, and Miss Pross:
+giving them what comfort he could, and much more than he had himself.
+He left Jerry with them, as a figure to fill a doorway that would bear
+considerable knocking on the head, and returned to his own occupations.
+A disturbed and doleful mind he brought to bear upon them, and slowly
+and heavily the day lagged on with him.
+
+It wore itself out, and wore him out with it, until the Bank closed. He
+was again alone in his room of the previous night, considering what to
+do next, when he heard a foot upon the stair. In a few moments, a
+man stood in his presence, who, with a keenly observant look at him,
+addressed him by his name.
+
+“Your servant,” said Mr. Lorry. “Do you know me?”
+
+He was a strongly made man with dark curling hair, from forty-five
+to fifty years of age. For answer he repeated, without any change of
+emphasis, the words:
+
+“Do you know me?”
+
+“I have seen you somewhere.”
+
+“Perhaps at my wine-shop?”
+
+Much interested and agitated, Mr. Lorry said: “You come from Doctor
+Manette?”
+
+“Yes. I come from Doctor Manette.”
+
+“And what says he? What does he send me?”
+
+Defarge gave into his anxious hand, an open scrap of paper. It bore the
+words in the Doctor’s writing:
+
+    “Charles is safe, but I cannot safely leave this place yet.
+     I have obtained the favour that the bearer has a short note
+     from Charles to his wife.  Let the bearer see his wife.”
+
+It was dated from La Force, within an hour.
+
+“Will you accompany me,” said Mr. Lorry, joyfully relieved after reading
+this note aloud, “to where his wife resides?”
+
+“Yes,” returned Defarge.
+
+Scarcely noticing as yet, in what a curiously reserved and mechanical
+way Defarge spoke, Mr. Lorry put on his hat and they went down into the
+courtyard. There, they found two women; one, knitting.
+
+“Madame Defarge, surely!” said Mr. Lorry, who had left her in exactly
+the same attitude some seventeen years ago.
+
+“It is she,” observed her husband.
+
+“Does Madame go with us?” inquired Mr. Lorry, seeing that she moved as
+they moved.
+
+“Yes. That she may be able to recognise the faces and know the persons.
+It is for their safety.”
+
+Beginning to be struck by Defarge’s manner, Mr. Lorry looked dubiously
+at him, and led the way. Both the women followed; the second woman being
+The Vengeance.
+
+They passed through the intervening streets as quickly as they might,
+ascended the staircase of the new domicile, were admitted by Jerry,
+and found Lucie weeping, alone. She was thrown into a transport by the
+tidings Mr. Lorry gave her of her husband, and clasped the hand that
+delivered his note--little thinking what it had been doing near him in
+the night, and might, but for a chance, have done to him.
+
+     “DEAREST,--Take courage.  I am well, and your father has
+      influence around me.  You cannot answer this.
+      Kiss our child for me.”
+
+That was all the writing. It was so much, however, to her who received
+it, that she turned from Defarge to his wife, and kissed one of the
+hands that knitted. It was a passionate, loving, thankful, womanly
+action, but the hand made no response--dropped cold and heavy, and took
+to its knitting again.
+
+There was something in its touch that gave Lucie a check. She stopped in
+the act of putting the note in her bosom, and, with her hands yet at her
+neck, looked terrified at Madame Defarge. Madame Defarge met the lifted
+eyebrows and forehead with a cold, impassive stare.
+
+“My dear,” said Mr. Lorry, striking in to explain; “there are frequent
+risings in the streets; and, although it is not likely they will ever
+trouble you, Madame Defarge wishes to see those whom she has the power
+to protect at such times, to the end that she may know them--that she
+may identify them. I believe,” said Mr. Lorry, rather halting in his
+reassuring words, as the stony manner of all the three impressed itself
+upon him more and more, “I state the case, Citizen Defarge?”
+
+Defarge looked gloomily at his wife, and gave no other answer than a
+gruff sound of acquiescence.
+
+“You had better, Lucie,” said Mr. Lorry, doing all he could to
+propitiate, by tone and manner, “have the dear child here, and our
+good Pross. Our good Pross, Defarge, is an English lady, and knows no
+French.”
+
+The lady in question, whose rooted conviction that she was more than a
+match for any foreigner, was not to be shaken by distress and, danger,
+appeared with folded arms, and observed in English to The Vengeance,
+whom her eyes first encountered, “Well, I am sure, Boldface! I hope
+_you_ are pretty well!” She also bestowed a British cough on Madame
+Defarge; but, neither of the two took much heed of her.
+
+“Is that his child?” said Madame Defarge, stopping in her work for the
+first time, and pointing her knitting-needle at little Lucie as if it
+were the finger of Fate.
+
+“Yes, madame,” answered Mr. Lorry; “this is our poor prisoner’s darling
+daughter, and only child.”
+
+The shadow attendant on Madame Defarge and her party seemed to fall so
+threatening and dark on the child, that her mother instinctively
+kneeled on the ground beside her, and held her to her breast. The
+shadow attendant on Madame Defarge and her party seemed then to fall,
+threatening and dark, on both the mother and the child.
+
+“It is enough, my husband,” said Madame Defarge. “I have seen them. We
+may go.”
+
+But, the suppressed manner had enough of menace in it--not visible and
+presented, but indistinct and withheld--to alarm Lucie into saying, as
+she laid her appealing hand on Madame Defarge’s dress:
+
+“You will be good to my poor husband. You will do him no harm. You will
+help me to see him if you can?”
+
+“Your husband is not my business here,” returned Madame Defarge, looking
+down at her with perfect composure. “It is the daughter of your father
+who is my business here.”
+
+“For my sake, then, be merciful to my husband. For my child’s sake! She
+will put her hands together and pray you to be merciful. We are more
+afraid of you than of these others.”
+
+Madame Defarge received it as a compliment, and looked at her husband.
+Defarge, who had been uneasily biting his thumb-nail and looking at her,
+collected his face into a sterner expression.
+
+“What is it that your husband says in that little letter?” asked Madame
+Defarge, with a lowering smile. “Influence; he says something touching
+influence?”
+
+“That my father,” said Lucie, hurriedly taking the paper from her
+breast, but with her alarmed eyes on her questioner and not on it, “has
+much influence around him.”
+
+“Surely it will release him!” said Madame Defarge. “Let it do so.”
+
+“As a wife and mother,” cried Lucie, most earnestly, “I implore you to
+have pity on me and not to exercise any power that you possess, against
+my innocent husband, but to use it in his behalf. O sister-woman, think
+of me. As a wife and mother!”
+
+Madame Defarge looked, coldly as ever, at the suppliant, and said,
+turning to her friend The Vengeance:
+
+“The wives and mothers we have been used to see, since we were as little
+as this child, and much less, have not been greatly considered? We have
+known _their_ husbands and fathers laid in prison and kept from them,
+often enough? All our lives, we have seen our sister-women suffer, in
+themselves and in their children, poverty, nakedness, hunger, thirst,
+sickness, misery, oppression and neglect of all kinds?”
+
+“We have seen nothing else,” returned The Vengeance.
+
+“We have borne this a long time,” said Madame Defarge, turning her eyes
+again upon Lucie. “Judge you! Is it likely that the trouble of one wife
+and mother would be much to us now?”
+
+She resumed her knitting and went out. The Vengeance followed. Defarge
+went last, and closed the door.
+
+“Courage, my dear Lucie,” said Mr. Lorry, as he raised her. “Courage,
+courage! So far all goes well with us--much, much better than it has of
+late gone with many poor souls. Cheer up, and have a thankful heart.”
+
+“I am not thankless, I hope, but that dreadful woman seems to throw a
+shadow on me and on all my hopes.”
+
+“Tut, tut!” said Mr. Lorry; “what is this despondency in the brave
+little breast? A shadow indeed! No substance in it, Lucie.”
+
+But the shadow of the manner of these Defarges was dark upon himself,
+for all that, and in his secret mind it troubled him greatly.
+
+
+
+
+IV. Calm in Storm
+
+
+Doctor Manette did not return until the morning of the fourth day of his
+absence. So much of what had happened in that dreadful time as could be
+kept from the knowledge of Lucie was so well concealed from her, that
+not until long afterwards, when France and she were far apart, did she
+know that eleven hundred defenceless prisoners of both sexes and all
+ages had been killed by the populace; that four days and nights had been
+darkened by this deed of horror; and that the air around her had been
+tainted by the slain. She only knew that there had been an attack upon
+the prisons, that all political prisoners had been in danger, and that
+some had been dragged out by the crowd and murdered.
+
+To Mr. Lorry, the Doctor communicated under an injunction of secrecy on
+which he had no need to dwell, that the crowd had taken him through a
+scene of carnage to the prison of La Force. That, in the prison he had
+found a self-appointed Tribunal sitting, before which the prisoners were
+brought singly, and by which they were rapidly ordered to be put forth
+to be massacred, or to be released, or (in a few cases) to be sent back
+to their cells. That, presented by his conductors to this Tribunal, he
+had announced himself by name and profession as having been for eighteen
+years a secret and unaccused prisoner in the Bastille; that, one of the
+body so sitting in judgment had risen and identified him, and that this
+man was Defarge.
+
+That, hereupon he had ascertained, through the registers on the table,
+that his son-in-law was among the living prisoners, and had pleaded hard
+to the Tribunal--of whom some members were asleep and some awake, some
+dirty with murder and some clean, some sober and some not--for his life
+and liberty. That, in the first frantic greetings lavished on himself as
+a notable sufferer under the overthrown system, it had been accorded
+to him to have Charles Darnay brought before the lawless Court, and
+examined. That, he seemed on the point of being at once released, when
+the tide in his favour met with some unexplained check (not intelligible
+to the Doctor), which led to a few words of secret conference. That,
+the man sitting as President had then informed Doctor Manette that
+the prisoner must remain in custody, but should, for his sake, be held
+inviolate in safe custody. That, immediately, on a signal, the prisoner
+was removed to the interior of the prison again; but, that he, the
+Doctor, had then so strongly pleaded for permission to remain and
+assure himself that his son-in-law was, through no malice or mischance,
+delivered to the concourse whose murderous yells outside the gate had
+often drowned the proceedings, that he had obtained the permission, and
+had remained in that Hall of Blood until the danger was over.
+
+The sights he had seen there, with brief snatches of food and sleep by
+intervals, shall remain untold. The mad joy over the prisoners who were
+saved, had astounded him scarcely less than the mad ferocity against
+those who were cut to pieces. One prisoner there was, he said, who had
+been discharged into the street free, but at whom a mistaken savage had
+thrust a pike as he passed out. Being besought to go to him and dress
+the wound, the Doctor had passed out at the same gate, and had found him
+in the arms of a company of Samaritans, who were seated on the bodies
+of their victims. With an inconsistency as monstrous as anything in this
+awful nightmare, they had helped the healer, and tended the wounded man
+with the gentlest solicitude--had made a litter for him and escorted him
+carefully from the spot--had then caught up their weapons and plunged
+anew into a butchery so dreadful, that the Doctor had covered his eyes
+with his hands, and swooned away in the midst of it.
+
+As Mr. Lorry received these confidences, and as he watched the face of
+his friend now sixty-two years of age, a misgiving arose within him that
+such dread experiences would revive the old danger.
+
+But, he had never seen his friend in his present aspect: he had never
+at all known him in his present character. For the first time the Doctor
+felt, now, that his suffering was strength and power. For the first time
+he felt that in that sharp fire, he had slowly forged the iron which
+could break the prison door of his daughter’s husband, and deliver him.
+“It all tended to a good end, my friend; it was not mere waste and ruin.
+As my beloved child was helpful in restoring me to myself, I will be
+helpful now in restoring the dearest part of herself to her; by the aid
+of Heaven I will do it!” Thus, Doctor Manette. And when Jarvis Lorry saw
+the kindled eyes, the resolute face, the calm strong look and bearing
+of the man whose life always seemed to him to have been stopped, like a
+clock, for so many years, and then set going again with an energy which
+had lain dormant during the cessation of its usefulness, he believed.
+
+Greater things than the Doctor had at that time to contend with, would
+have yielded before his persevering purpose. While he kept himself
+in his place, as a physician, whose business was with all degrees
+of mankind, bond and free, rich and poor, bad and good, he used his
+personal influence so wisely, that he was soon the inspecting physician
+of three prisons, and among them of La Force. He could now assure Lucie
+that her husband was no longer confined alone, but was mixed with the
+general body of prisoners; he saw her husband weekly, and brought sweet
+messages to her, straight from his lips; sometimes her husband himself
+sent a letter to her (though never by the Doctor’s hand), but she was
+not permitted to write to him: for, among the many wild suspicions of
+plots in the prisons, the wildest of all pointed at emigrants who were
+known to have made friends or permanent connections abroad.
+
+This new life of the Doctor’s was an anxious life, no doubt; still, the
+sagacious Mr. Lorry saw that there was a new sustaining pride in it.
+Nothing unbecoming tinged the pride; it was a natural and worthy one;
+but he observed it as a curiosity. The Doctor knew, that up to that
+time, his imprisonment had been associated in the minds of his daughter
+and his friend, with his personal affliction, deprivation, and weakness.
+Now that this was changed, and he knew himself to be invested through
+that old trial with forces to which they both looked for Charles’s
+ultimate safety and deliverance, he became so far exalted by the change,
+that he took the lead and direction, and required them as the weak, to
+trust to him as the strong. The preceding relative positions of himself
+and Lucie were reversed, yet only as the liveliest gratitude and
+affection could reverse them, for he could have had no pride but in
+rendering some service to her who had rendered so much to him. “All
+curious to see,” thought Mr. Lorry, in his amiably shrewd way, “but all
+natural and right; so, take the lead, my dear friend, and keep it; it
+couldn’t be in better hands.”
+
+But, though the Doctor tried hard, and never ceased trying, to get
+Charles Darnay set at liberty, or at least to get him brought to trial,
+the public current of the time set too strong and fast for him. The new
+era began; the king was tried, doomed, and beheaded; the Republic of
+Liberty, Equality, Fraternity, or Death, declared for victory or death
+against the world in arms; the black flag waved night and day from the
+great towers of Notre Dame; three hundred thousand men, summoned to rise
+against the tyrants of the earth, rose from all the varying soils
+of France, as if the dragon’s teeth had been sown broadcast, and
+had yielded fruit equally on hill and plain, on rock, in gravel, and
+alluvial mud, under the bright sky of the South and under the clouds of
+the North, in fell and forest, in the vineyards and the olive-grounds
+and among the cropped grass and the stubble of the corn, along the
+fruitful banks of the broad rivers, and in the sand of the sea-shore.
+What private solicitude could rear itself against the deluge of the Year
+One of Liberty--the deluge rising from below, not falling from above,
+and with the windows of Heaven shut, not opened!
+
+There was no pause, no pity, no peace, no interval of relenting rest, no
+measurement of time. Though days and nights circled as regularly as when
+time was young, and the evening and morning were the first day, other
+count of time there was none. Hold of it was lost in the raging fever
+of a nation, as it is in the fever of one patient. Now, breaking the
+unnatural silence of a whole city, the executioner showed the people the
+head of the king--and now, it seemed almost in the same breath, the
+head of his fair wife which had had eight weary months of imprisoned
+widowhood and misery, to turn it grey.
+
+And yet, observing the strange law of contradiction which obtains in
+all such cases, the time was long, while it flamed by so fast. A
+revolutionary tribunal in the capital, and forty or fifty thousand
+revolutionary committees all over the land; a law of the Suspected,
+which struck away all security for liberty or life, and delivered over
+any good and innocent person to any bad and guilty one; prisons gorged
+with people who had committed no offence, and could obtain no hearing;
+these things became the established order and nature of appointed
+things, and seemed to be ancient usage before they were many weeks old.
+Above all, one hideous figure grew as familiar as if it had been before
+the general gaze from the foundations of the world--the figure of the
+sharp female called La Guillotine.
+
+It was the popular theme for jests; it was the best cure for headache,
+it infallibly prevented the hair from turning grey, it imparted a
+peculiar delicacy to the complexion, it was the National Razor which
+shaved close: who kissed La Guillotine, looked through the little window
+and sneezed into the sack. It was the sign of the regeneration of the
+human race. It superseded the Cross. Models of it were worn on breasts
+from which the Cross was discarded, and it was bowed down to and
+believed in where the Cross was denied.
+
+It sheared off heads so many, that it, and the ground it most polluted,
+were a rotten red. It was taken to pieces, like a toy-puzzle for a young
+Devil, and was put together again when the occasion wanted it. It hushed
+the eloquent, struck down the powerful, abolished the beautiful and
+good. Twenty-two friends of high public mark, twenty-one living and one
+dead, it had lopped the heads off, in one morning, in as many minutes.
+The name of the strong man of Old Scripture had descended to the chief
+functionary who worked it; but, so armed, he was stronger than his
+namesake, and blinder, and tore away the gates of God’s own Temple every
+day.
+
+Among these terrors, and the brood belonging to them, the Doctor walked
+with a steady head: confident in his power, cautiously persistent in his
+end, never doubting that he would save Lucie’s husband at last. Yet the
+current of the time swept by, so strong and deep, and carried the time
+away so fiercely, that Charles had lain in prison one year and three
+months when the Doctor was thus steady and confident. So much more
+wicked and distracted had the Revolution grown in that December month,
+that the rivers of the South were encumbered with the bodies of the
+violently drowned by night, and prisoners were shot in lines and squares
+under the southern wintry sun. Still, the Doctor walked among the
+terrors with a steady head. No man better known than he, in Paris at
+that day; no man in a stranger situation. Silent, humane, indispensable
+in hospital and prison, using his art equally among assassins and
+victims, he was a man apart. In the exercise of his skill, the
+appearance and the story of the Bastille Captive removed him from all
+other men. He was not suspected or brought in question, any more than if
+he had indeed been recalled to life some eighteen years before, or were
+a Spirit moving among mortals.
+
+
+
+
+V. The Wood-Sawyer
+
+
+One year and three months. During all that time Lucie was never
+sure, from hour to hour, but that the Guillotine would strike off her
+husband’s head next day. Every day, through the stony streets, the
+tumbrils now jolted heavily, filled with Condemned. Lovely girls; bright
+women, brown-haired, black-haired, and grey; youths; stalwart men and
+old; gentle born and peasant born; all red wine for La Guillotine, all
+daily brought into light from the dark cellars of the loathsome prisons,
+and carried to her through the streets to slake her devouring thirst.
+Liberty, equality, fraternity, or death;--the last, much the easiest to
+bestow, O Guillotine!
+
+If the suddenness of her calamity, and the whirling wheels of the time,
+had stunned the Doctor’s daughter into awaiting the result in idle
+despair, it would but have been with her as it was with many. But, from
+the hour when she had taken the white head to her fresh young bosom in
+the garret of Saint Antoine, she had been true to her duties. She was
+truest to them in the season of trial, as all the quietly loyal and good
+will always be.
+
+As soon as they were established in their new residence, and her father
+had entered on the routine of his avocations, she arranged the little
+household as exactly as if her husband had been there. Everything had
+its appointed place and its appointed time. Little Lucie she taught,
+as regularly, as if they had all been united in their English home. The
+slight devices with which she cheated herself into the show of a belief
+that they would soon be reunited--the little preparations for his speedy
+return, the setting aside of his chair and his books--these, and the
+solemn prayer at night for one dear prisoner especially, among the many
+unhappy souls in prison and the shadow of death--were almost the only
+outspoken reliefs of her heavy mind.
+
+She did not greatly alter in appearance. The plain dark dresses, akin to
+mourning dresses, which she and her child wore, were as neat and as well
+attended to as the brighter clothes of happy days. She lost her colour,
+and the old and intent expression was a constant, not an occasional,
+thing; otherwise, she remained very pretty and comely. Sometimes, at
+night on kissing her father, she would burst into the grief she had
+repressed all day, and would say that her sole reliance, under Heaven,
+was on him. He always resolutely answered: “Nothing can happen to him
+without my knowledge, and I know that I can save him, Lucie.”
+
+They had not made the round of their changed life many weeks, when her
+father said to her, on coming home one evening:
+
+“My dear, there is an upper window in the prison, to which Charles can
+sometimes gain access at three in the afternoon. When he can get to
+it--which depends on many uncertainties and incidents--he might see you
+in the street, he thinks, if you stood in a certain place that I can
+show you. But you will not be able to see him, my poor child, and even
+if you could, it would be unsafe for you to make a sign of recognition.”
+
+“O show me the place, my father, and I will go there every day.”
+
+From that time, in all weathers, she waited there two hours. As the
+clock struck two, she was there, and at four she turned resignedly away.
+When it was not too wet or inclement for her child to be with her, they
+went together; at other times she was alone; but, she never missed a
+single day.
+
+It was the dark and dirty corner of a small winding street. The hovel
+of a cutter of wood into lengths for burning, was the only house at that
+end; all else was wall. On the third day of her being there, he noticed
+her.
+
+“Good day, citizeness.”
+
+“Good day, citizen.”
+
+This mode of address was now prescribed by decree. It had been
+established voluntarily some time ago, among the more thorough patriots;
+but, was now law for everybody.
+
+“Walking here again, citizeness?”
+
+“You see me, citizen!”
+
+The wood-sawyer, who was a little man with a redundancy of gesture (he
+had once been a mender of roads), cast a glance at the prison, pointed
+at the prison, and putting his ten fingers before his face to represent
+bars, peeped through them jocosely.
+
+“But it’s not my business,” said he. And went on sawing his wood.
+
+Next day he was looking out for her, and accosted her the moment she
+appeared.
+
+“What? Walking here again, citizeness?”
+
+“Yes, citizen.”
+
+“Ah! A child too! Your mother, is it not, my little citizeness?”
+
+“Do I say yes, mamma?” whispered little Lucie, drawing close to her.
+
+“Yes, dearest.”
+
+“Yes, citizen.”
+
+“Ah! But it’s not my business. My work is my business. See my saw! I
+call it my Little Guillotine. La, la, la; La, la, la! And off his head
+comes!”
+
+The billet fell as he spoke, and he threw it into a basket.
+
+“I call myself the Samson of the firewood guillotine. See here again!
+Loo, loo, loo; Loo, loo, loo! And off _her_ head comes! Now, a child.
+Tickle, tickle; Pickle, pickle! And off _its_ head comes. All the
+family!”
+
+Lucie shuddered as he threw two more billets into his basket, but it was
+impossible to be there while the wood-sawyer was at work, and not be in
+his sight. Thenceforth, to secure his good will, she always spoke to him
+first, and often gave him drink-money, which he readily received.
+
+He was an inquisitive fellow, and sometimes when she had quite forgotten
+him in gazing at the prison roof and grates, and in lifting her heart
+up to her husband, she would come to herself to find him looking at her,
+with his knee on his bench and his saw stopped in its work. “But it’s
+not my business!” he would generally say at those times, and would
+briskly fall to his sawing again.
+
+In all weathers, in the snow and frost of winter, in the bitter winds of
+spring, in the hot sunshine of summer, in the rains of autumn, and again
+in the snow and frost of winter, Lucie passed two hours of every day at
+this place; and every day on leaving it, she kissed the prison wall.
+Her husband saw her (so she learned from her father) it might be once in
+five or six times: it might be twice or thrice running: it might be, not
+for a week or a fortnight together. It was enough that he could and did
+see her when the chances served, and on that possibility she would have
+waited out the day, seven days a week.
+
+These occupations brought her round to the December month, wherein her
+father walked among the terrors with a steady head. On a lightly-snowing
+afternoon she arrived at the usual corner. It was a day of some wild
+rejoicing, and a festival. She had seen the houses, as she came along,
+decorated with little pikes, and with little red caps stuck upon them;
+also, with tricoloured ribbons; also, with the standard inscription
+(tricoloured letters were the favourite), Republic One and Indivisible.
+Liberty, Equality, Fraternity, or Death!
+
+The miserable shop of the wood-sawyer was so small, that its whole
+surface furnished very indifferent space for this legend. He had got
+somebody to scrawl it up for him, however, who had squeezed Death in
+with most inappropriate difficulty. On his house-top, he displayed pike
+and cap, as a good citizen must, and in a window he had stationed his
+saw inscribed as his “Little Sainte Guillotine”--for the great sharp
+female was by that time popularly canonised. His shop was shut and he
+was not there, which was a relief to Lucie, and left her quite alone.
+
+But, he was not far off, for presently she heard a troubled movement
+and a shouting coming along, which filled her with fear. A moment
+afterwards, and a throng of people came pouring round the corner by the
+prison wall, in the midst of whom was the wood-sawyer hand in hand with
+The Vengeance. There could not be fewer than five hundred people, and
+they were dancing like five thousand demons. There was no other music
+than their own singing. They danced to the popular Revolution song,
+keeping a ferocious time that was like a gnashing of teeth in unison.
+Men and women danced together, women danced together, men danced
+together, as hazard had brought them together. At first, they were a
+mere storm of coarse red caps and coarse woollen rags; but, as they
+filled the place, and stopped to dance about Lucie, some ghastly
+apparition of a dance-figure gone raving mad arose among them. They
+advanced, retreated, struck at one another’s hands, clutched at one
+another’s heads, spun round alone, caught one another and spun round
+in pairs, until many of them dropped. While those were down, the rest
+linked hand in hand, and all spun round together: then the ring broke,
+and in separate rings of two and four they turned and turned until they
+all stopped at once, began again, struck, clutched, and tore, and then
+reversed the spin, and all spun round another way. Suddenly they stopped
+again, paused, struck out the time afresh, formed into lines the width
+of the public way, and, with their heads low down and their hands high
+up, swooped screaming off. No fight could have been half so terrible
+as this dance. It was so emphatically a fallen sport--a something, once
+innocent, delivered over to all devilry--a healthy pastime changed into
+a means of angering the blood, bewildering the senses, and steeling the
+heart. Such grace as was visible in it, made it the uglier, showing how
+warped and perverted all things good by nature were become. The maidenly
+bosom bared to this, the pretty almost-child’s head thus distracted, the
+delicate foot mincing in this slough of blood and dirt, were types of
+the disjointed time.
+
+This was the Carmagnole. As it passed, leaving Lucie frightened and
+bewildered in the doorway of the wood-sawyer’s house, the feathery snow
+fell as quietly and lay as white and soft, as if it had never been.
+
+“O my father!” for he stood before her when she lifted up the eyes she
+had momentarily darkened with her hand; “such a cruel, bad sight.”
+
+“I know, my dear, I know. I have seen it many times. Don’t be
+frightened! Not one of them would harm you.”
+
+“I am not frightened for myself, my father. But when I think of my
+husband, and the mercies of these people--”
+
+“We will set him above their mercies very soon. I left him climbing to
+the window, and I came to tell you. There is no one here to see. You may
+kiss your hand towards that highest shelving roof.”
+
+“I do so, father, and I send him my Soul with it!”
+
+“You cannot see him, my poor dear?”
+
+“No, father,” said Lucie, yearning and weeping as she kissed her hand,
+“no.”
+
+A footstep in the snow. Madame Defarge. “I salute you, citizeness,”
+ from the Doctor. “I salute you, citizen.” This in passing. Nothing more.
+Madame Defarge gone, like a shadow over the white road.
+
+“Give me your arm, my love. Pass from here with an air of cheerfulness
+and courage, for his sake. That was well done;” they had left the spot;
+“it shall not be in vain. Charles is summoned for to-morrow.”
+
+“For to-morrow!”
+
+“There is no time to lose. I am well prepared, but there are precautions
+to be taken, that could not be taken until he was actually summoned
+before the Tribunal. He has not received the notice yet, but I know
+that he will presently be summoned for to-morrow, and removed to the
+Conciergerie; I have timely information. You are not afraid?”
+
+She could scarcely answer, “I trust in you.”
+
+“Do so, implicitly. Your suspense is nearly ended, my darling; he shall
+be restored to you within a few hours; I have encompassed him with every
+protection. I must see Lorry.”
+
+He stopped. There was a heavy lumbering of wheels within hearing. They
+both knew too well what it meant. One. Two. Three. Three tumbrils faring
+away with their dread loads over the hushing snow.
+
+“I must see Lorry,” the Doctor repeated, turning her another way.
+
+The staunch old gentleman was still in his trust; had never left it. He
+and his books were in frequent requisition as to property confiscated
+and made national. What he could save for the owners, he saved. No
+better man living to hold fast by what Tellson’s had in keeping, and to
+hold his peace.
+
+A murky red and yellow sky, and a rising mist from the Seine, denoted
+the approach of darkness. It was almost dark when they arrived at the
+Bank. The stately residence of Monseigneur was altogether blighted and
+deserted. Above a heap of dust and ashes in the court, ran the letters:
+National Property. Republic One and Indivisible. Liberty, Equality,
+Fraternity, or Death!
+
+Who could that be with Mr. Lorry--the owner of the riding-coat upon the
+chair--who must not be seen? From whom newly arrived, did he come out,
+agitated and surprised, to take his favourite in his arms? To whom did
+he appear to repeat her faltering words, when, raising his voice and
+turning his head towards the door of the room from which he had issued,
+he said: “Removed to the Conciergerie, and summoned for to-morrow?”
+
+
+
+
+VI. Triumph
+
+
+The dread tribunal of five Judges, Public Prosecutor, and determined
+Jury, sat every day. Their lists went forth every evening, and were
+read out by the gaolers of the various prisons to their prisoners. The
+standard gaoler-joke was, “Come out and listen to the Evening Paper, you
+inside there!”
+
+“Charles Evremonde, called Darnay!”
+
+So at last began the Evening Paper at La Force.
+
+When a name was called, its owner stepped apart into a spot reserved
+for those who were announced as being thus fatally recorded. Charles
+Evremonde, called Darnay, had reason to know the usage; he had seen
+hundreds pass away so.
+
+His bloated gaoler, who wore spectacles to read with, glanced over them
+to assure himself that he had taken his place, and went through the
+list, making a similar short pause at each name. There were twenty-three
+names, but only twenty were responded to; for one of the prisoners so
+summoned had died in gaol and been forgotten, and two had already been
+guillotined and forgotten. The list was read, in the vaulted chamber
+where Darnay had seen the associated prisoners on the night of his
+arrival. Every one of those had perished in the massacre; every human
+creature he had since cared for and parted with, had died on the
+scaffold.
+
+There were hurried words of farewell and kindness, but the parting was
+soon over. It was the incident of every day, and the society of La Force
+were engaged in the preparation of some games of forfeits and a little
+concert, for that evening. They crowded to the grates and shed tears
+there; but, twenty places in the projected entertainments had to be
+refilled, and the time was, at best, short to the lock-up hour, when the
+common rooms and corridors would be delivered over to the great dogs
+who kept watch there through the night. The prisoners were far from
+insensible or unfeeling; their ways arose out of the condition of the
+time. Similarly, though with a subtle difference, a species of fervour
+or intoxication, known, without doubt, to have led some persons to
+brave the guillotine unnecessarily, and to die by it, was not mere
+boastfulness, but a wild infection of the wildly shaken public mind. In
+seasons of pestilence, some of us will have a secret attraction to the
+disease--a terrible passing inclination to die of it. And all of us have
+like wonders hidden in our breasts, only needing circumstances to evoke
+them.
+
+The passage to the Conciergerie was short and dark; the night in its
+vermin-haunted cells was long and cold. Next day, fifteen prisoners were
+put to the bar before Charles Darnay’s name was called. All the fifteen
+were condemned, and the trials of the whole occupied an hour and a half.
+
+“Charles Evremonde, called Darnay,” was at length arraigned.
+
+His judges sat upon the Bench in feathered hats; but the rough red cap
+and tricoloured cockade was the head-dress otherwise prevailing. Looking
+at the Jury and the turbulent audience, he might have thought that the
+usual order of things was reversed, and that the felons were trying the
+honest men. The lowest, cruelest, and worst populace of a city, never
+without its quantity of low, cruel, and bad, were the directing
+spirits of the scene: noisily commenting, applauding, disapproving,
+anticipating, and precipitating the result, without a check. Of the men,
+the greater part were armed in various ways; of the women, some wore
+knives, some daggers, some ate and drank as they looked on, many
+knitted. Among these last, was one, with a spare piece of knitting under
+her arm as she worked. She was in a front row, by the side of a man whom
+he had never seen since his arrival at the Barrier, but whom he directly
+remembered as Defarge. He noticed that she once or twice whispered in
+his ear, and that she seemed to be his wife; but, what he most noticed
+in the two figures was, that although they were posted as close to
+himself as they could be, they never looked towards him. They seemed to
+be waiting for something with a dogged determination, and they looked at
+the Jury, but at nothing else. Under the President sat Doctor Manette,
+in his usual quiet dress. As well as the prisoner could see, he and Mr.
+Lorry were the only men there, unconnected with the Tribunal, who
+wore their usual clothes, and had not assumed the coarse garb of the
+Carmagnole.
+
+Charles Evremonde, called Darnay, was accused by the public prosecutor
+as an emigrant, whose life was forfeit to the Republic, under the decree
+which banished all emigrants on pain of Death. It was nothing that the
+decree bore date since his return to France. There he was, and there was
+the decree; he had been taken in France, and his head was demanded.
+
+“Take off his head!” cried the audience. “An enemy to the Republic!”
+
+The President rang his bell to silence those cries, and asked the
+prisoner whether it was not true that he had lived many years in
+England?
+
+Undoubtedly it was.
+
+Was he not an emigrant then? What did he call himself?
+
+Not an emigrant, he hoped, within the sense and spirit of the law.
+
+Why not? the President desired to know.
+
+Because he had voluntarily relinquished a title that was distasteful
+to him, and a station that was distasteful to him, and had left
+his country--he submitted before the word emigrant in the present
+acceptation by the Tribunal was in use--to live by his own industry in
+England, rather than on the industry of the overladen people of France.
+
+What proof had he of this?
+
+He handed in the names of two witnesses; Theophile Gabelle, and
+Alexandre Manette.
+
+But he had married in England? the President reminded him.
+
+True, but not an English woman.
+
+A citizeness of France?
+
+Yes. By birth.
+
+Her name and family?
+
+“Lucie Manette, only daughter of Doctor Manette, the good physician who
+sits there.”
+
+This answer had a happy effect upon the audience. Cries in exaltation
+of the well-known good physician rent the hall. So capriciously were
+the people moved, that tears immediately rolled down several ferocious
+countenances which had been glaring at the prisoner a moment before, as
+if with impatience to pluck him out into the streets and kill him.
+
+On these few steps of his dangerous way, Charles Darnay had set his foot
+according to Doctor Manette’s reiterated instructions. The same cautious
+counsel directed every step that lay before him, and had prepared every
+inch of his road.
+
+The President asked, why had he returned to France when he did, and not
+sooner?
+
+He had not returned sooner, he replied, simply because he had no means
+of living in France, save those he had resigned; whereas, in England,
+he lived by giving instruction in the French language and literature.
+He had returned when he did, on the pressing and written entreaty of
+a French citizen, who represented that his life was endangered by his
+absence. He had come back, to save a citizen’s life, and to bear his
+testimony, at whatever personal hazard, to the truth. Was that criminal
+in the eyes of the Republic?
+
+The populace cried enthusiastically, “No!” and the President rang his
+bell to quiet them. Which it did not, for they continued to cry “No!”
+ until they left off, of their own will.
+
+The President required the name of that citizen. The accused explained
+that the citizen was his first witness. He also referred with confidence
+to the citizen’s letter, which had been taken from him at the Barrier,
+but which he did not doubt would be found among the papers then before
+the President.
+
+The Doctor had taken care that it should be there--had assured him that
+it would be there--and at this stage of the proceedings it was produced
+and read. Citizen Gabelle was called to confirm it, and did so. Citizen
+Gabelle hinted, with infinite delicacy and politeness, that in the
+pressure of business imposed on the Tribunal by the multitude of
+enemies of the Republic with which it had to deal, he had been slightly
+overlooked in his prison of the Abbaye--in fact, had rather passed out
+of the Tribunal’s patriotic remembrance--until three days ago; when he
+had been summoned before it, and had been set at liberty on the Jury’s
+declaring themselves satisfied that the accusation against him was
+answered, as to himself, by the surrender of the citizen Evremonde,
+called Darnay.
+
+Doctor Manette was next questioned. His high personal popularity,
+and the clearness of his answers, made a great impression; but, as he
+proceeded, as he showed that the Accused was his first friend on his
+release from his long imprisonment; that, the accused had remained in
+England, always faithful and devoted to his daughter and himself in
+their exile; that, so far from being in favour with the Aristocrat
+government there, he had actually been tried for his life by it, as
+the foe of England and friend of the United States--as he brought these
+circumstances into view, with the greatest discretion and with the
+straightforward force of truth and earnestness, the Jury and the
+populace became one. At last, when he appealed by name to Monsieur
+Lorry, an English gentleman then and there present, who, like himself,
+had been a witness on that English trial and could corroborate his
+account of it, the Jury declared that they had heard enough, and that
+they were ready with their votes if the President were content to
+receive them.
+
+At every vote (the Jurymen voted aloud and individually), the populace
+set up a shout of applause. All the voices were in the prisoner’s
+favour, and the President declared him free.
+
+Then, began one of those extraordinary scenes with which the populace
+sometimes gratified their fickleness, or their better impulses towards
+generosity and mercy, or which they regarded as some set-off against
+their swollen account of cruel rage. No man can decide now to which of
+these motives such extraordinary scenes were referable; it is probable,
+to a blending of all the three, with the second predominating. No sooner
+was the acquittal pronounced, than tears were shed as freely as blood
+at another time, and such fraternal embraces were bestowed upon the
+prisoner by as many of both sexes as could rush at him, that after
+his long and unwholesome confinement he was in danger of fainting from
+exhaustion; none the less because he knew very well, that the very same
+people, carried by another current, would have rushed at him with
+the very same intensity, to rend him to pieces and strew him over the
+streets.
+
+His removal, to make way for other accused persons who were to be tried,
+rescued him from these caresses for the moment. Five were to be tried
+together, next, as enemies of the Republic, forasmuch as they had not
+assisted it by word or deed. So quick was the Tribunal to compensate
+itself and the nation for a chance lost, that these five came down to
+him before he left the place, condemned to die within twenty-four
+hours. The first of them told him so, with the customary prison sign
+of Death--a raised finger--and they all added in words, “Long live the
+Republic!”
+
+The five had had, it is true, no audience to lengthen their proceedings,
+for when he and Doctor Manette emerged from the gate, there was a great
+crowd about it, in which there seemed to be every face he had seen in
+Court--except two, for which he looked in vain. On his coming out, the
+concourse made at him anew, weeping, embracing, and shouting, all by
+turns and all together, until the very tide of the river on the bank of
+which the mad scene was acted, seemed to run mad, like the people on the
+shore.
+
+They put him into a great chair they had among them, and which they had
+taken either out of the Court itself, or one of its rooms or passages.
+Over the chair they had thrown a red flag, and to the back of it they
+had bound a pike with a red cap on its top. In this car of triumph, not
+even the Doctor’s entreaties could prevent his being carried to his home
+on men’s shoulders, with a confused sea of red caps heaving about him,
+and casting up to sight from the stormy deep such wrecks of faces, that
+he more than once misdoubted his mind being in confusion, and that he
+was in the tumbril on his way to the Guillotine.
+
+In wild dreamlike procession, embracing whom they met and pointing
+him out, they carried him on. Reddening the snowy streets with the
+prevailing Republican colour, in winding and tramping through them, as
+they had reddened them below the snow with a deeper dye, they carried
+him thus into the courtyard of the building where he lived. Her father
+had gone on before, to prepare her, and when her husband stood upon his
+feet, she dropped insensible in his arms.
+
+As he held her to his heart and turned her beautiful head between his
+face and the brawling crowd, so that his tears and her lips might come
+together unseen, a few of the people fell to dancing. Instantly, all the
+rest fell to dancing, and the courtyard overflowed with the Carmagnole.
+Then, they elevated into the vacant chair a young woman from the
+crowd to be carried as the Goddess of Liberty, and then swelling and
+overflowing out into the adjacent streets, and along the river’s bank,
+and over the bridge, the Carmagnole absorbed them every one and whirled
+them away.
+
+After grasping the Doctor’s hand, as he stood victorious and proud
+before him; after grasping the hand of Mr. Lorry, who came panting in
+breathless from his struggle against the waterspout of the Carmagnole;
+after kissing little Lucie, who was lifted up to clasp her arms round
+his neck; and after embracing the ever zealous and faithful Pross who
+lifted her; he took his wife in his arms, and carried her up to their
+rooms.
+
+“Lucie! My own! I am safe.”
+
+“O dearest Charles, let me thank God for this on my knees as I have
+prayed to Him.”
+
+They all reverently bowed their heads and hearts. When she was again in
+his arms, he said to her:
+
+“And now speak to your father, dearest. No other man in all this France
+could have done what he has done for me.”
+
+She laid her head upon her father’s breast, as she had laid his poor
+head on her own breast, long, long ago. He was happy in the return he
+had made her, he was recompensed for his suffering, he was proud of his
+strength. “You must not be weak, my darling,” he remonstrated; “don’t
+tremble so. I have saved him.”
+
+
+
+
+VII. A Knock at the Door
+
+
+“I have saved him.” It was not another of the dreams in which he had
+often come back; he was really here. And yet his wife trembled, and a
+vague but heavy fear was upon her.
+
+All the air round was so thick and dark, the people were so passionately
+revengeful and fitful, the innocent were so constantly put to death on
+vague suspicion and black malice, it was so impossible to forget that
+many as blameless as her husband and as dear to others as he was to
+her, every day shared the fate from which he had been clutched, that her
+heart could not be as lightened of its load as she felt it ought to be.
+The shadows of the wintry afternoon were beginning to fall, and even now
+the dreadful carts were rolling through the streets. Her mind pursued
+them, looking for him among the Condemned; and then she clung closer to
+his real presence and trembled more.
+
+Her father, cheering her, showed a compassionate superiority to this
+woman’s weakness, which was wonderful to see. No garret, no shoemaking,
+no One Hundred and Five, North Tower, now! He had accomplished the task
+he had set himself, his promise was redeemed, he had saved Charles. Let
+them all lean upon him.
+
+Their housekeeping was of a very frugal kind: not only because that was
+the safest way of life, involving the least offence to the people, but
+because they were not rich, and Charles, throughout his imprisonment,
+had had to pay heavily for his bad food, and for his guard, and towards
+the living of the poorer prisoners. Partly on this account, and
+partly to avoid a domestic spy, they kept no servant; the citizen and
+citizeness who acted as porters at the courtyard gate, rendered them
+occasional service; and Jerry (almost wholly transferred to them by
+Mr. Lorry) had become their daily retainer, and had his bed there every
+night.
+
+It was an ordinance of the Republic One and Indivisible of Liberty,
+Equality, Fraternity, or Death, that on the door or doorpost of every
+house, the name of every inmate must be legibly inscribed in letters
+of a certain size, at a certain convenient height from the ground. Mr.
+Jerry Cruncher’s name, therefore, duly embellished the doorpost down
+below; and, as the afternoon shadows deepened, the owner of that name
+himself appeared, from overlooking a painter whom Doctor Manette had
+employed to add to the list the name of Charles Evremonde, called
+Darnay.
+
+In the universal fear and distrust that darkened the time, all the usual
+harmless ways of life were changed. In the Doctor’s little household, as
+in very many others, the articles of daily consumption that were wanted
+were purchased every evening, in small quantities and at various small
+shops. To avoid attracting notice, and to give as little occasion as
+possible for talk and envy, was the general desire.
+
+For some months past, Miss Pross and Mr. Cruncher had discharged the
+office of purveyors; the former carrying the money; the latter, the
+basket. Every afternoon at about the time when the public lamps were
+lighted, they fared forth on this duty, and made and brought home
+such purchases as were needful. Although Miss Pross, through her long
+association with a French family, might have known as much of their
+language as of her own, if she had had a mind, she had no mind in that
+direction; consequently she knew no more of that “nonsense” (as she was
+pleased to call it) than Mr. Cruncher did. So her manner of marketing
+was to plump a noun-substantive at the head of a shopkeeper without any
+introduction in the nature of an article, and, if it happened not to be
+the name of the thing she wanted, to look round for that thing, lay hold
+of it, and hold on by it until the bargain was concluded. She always
+made a bargain for it, by holding up, as a statement of its just price,
+one finger less than the merchant held up, whatever his number might be.
+
+“Now, Mr. Cruncher,” said Miss Pross, whose eyes were red with felicity;
+“if you are ready, I am.”
+
+Jerry hoarsely professed himself at Miss Pross’s service. He had worn
+all his rust off long ago, but nothing would file his spiky head down.
+
+“There’s all manner of things wanted,” said Miss Pross, “and we shall
+have a precious time of it. We want wine, among the rest. Nice toasts
+these Redheads will be drinking, wherever we buy it.”
+
+“It will be much the same to your knowledge, miss, I should think,”
+ retorted Jerry, “whether they drink your health or the Old Un’s.”
+
+“Who’s he?” said Miss Pross.
+
+Mr. Cruncher, with some diffidence, explained himself as meaning “Old
+Nick’s.”
+
+“Ha!” said Miss Pross, “it doesn’t need an interpreter to explain the
+meaning of these creatures. They have but one, and it’s Midnight Murder,
+and Mischief.”
+
+“Hush, dear! Pray, pray, be cautious!” cried Lucie.
+
+“Yes, yes, yes, I’ll be cautious,” said Miss Pross; “but I may say
+among ourselves, that I do hope there will be no oniony and tobaccoey
+smotherings in the form of embracings all round, going on in the
+streets. Now, Ladybird, never you stir from that fire till I come back!
+Take care of the dear husband you have recovered, and don’t move your
+pretty head from his shoulder as you have it now, till you see me again!
+May I ask a question, Doctor Manette, before I go?”
+
+“I think you may take that liberty,” the Doctor answered, smiling.
+
+“For gracious sake, don’t talk about Liberty; we have quite enough of
+that,” said Miss Pross.
+
+“Hush, dear! Again?” Lucie remonstrated.
+
+“Well, my sweet,” said Miss Pross, nodding her head emphatically, “the
+short and the long of it is, that I am a subject of His Most Gracious
+Majesty King George the Third;” Miss Pross curtseyed at the name; “and
+as such, my maxim is, Confound their politics, Frustrate their knavish
+tricks, On him our hopes we fix, God save the King!”
+
+Mr. Cruncher, in an access of loyalty, growlingly repeated the words
+after Miss Pross, like somebody at church.
+
+“I am glad you have so much of the Englishman in you, though I wish you
+had never taken that cold in your voice,” said Miss Pross, approvingly.
+“But the question, Doctor Manette. Is there”--it was the good creature’s
+way to affect to make light of anything that was a great anxiety
+with them all, and to come at it in this chance manner--“is there any
+prospect yet, of our getting out of this place?”
+
+“I fear not yet. It would be dangerous for Charles yet.”
+
+“Heigh-ho-hum!” said Miss Pross, cheerfully repressing a sigh as she
+glanced at her darling’s golden hair in the light of the fire, “then we
+must have patience and wait: that’s all. We must hold up our heads and
+fight low, as my brother Solomon used to say. Now, Mr. Cruncher!--Don’t
+you move, Ladybird!”
+
+They went out, leaving Lucie, and her husband, her father, and the
+child, by a bright fire. Mr. Lorry was expected back presently from the
+Banking House. Miss Pross had lighted the lamp, but had put it aside in
+a corner, that they might enjoy the fire-light undisturbed. Little Lucie
+sat by her grandfather with her hands clasped through his arm: and he,
+in a tone not rising much above a whisper, began to tell her a story of
+a great and powerful Fairy who had opened a prison-wall and let out
+a captive who had once done the Fairy a service. All was subdued and
+quiet, and Lucie was more at ease than she had been.
+
+“What is that?” she cried, all at once.
+
+“My dear!” said her father, stopping in his story, and laying his hand
+on hers, “command yourself. What a disordered state you are in! The
+least thing--nothing--startles you! _You_, your father’s daughter!”
+
+“I thought, my father,” said Lucie, excusing herself, with a pale face
+and in a faltering voice, “that I heard strange feet upon the stairs.”
+
+“My love, the staircase is as still as Death.”
+
+As he said the word, a blow was struck upon the door.
+
+“Oh father, father. What can this be! Hide Charles. Save him!”
+
+“My child,” said the Doctor, rising, and laying his hand upon her
+shoulder, “I _have_ saved him. What weakness is this, my dear! Let me go
+to the door.”
+
+He took the lamp in his hand, crossed the two intervening outer rooms,
+and opened it. A rude clattering of feet over the floor, and four rough
+men in red caps, armed with sabres and pistols, entered the room.
+
+“The Citizen Evremonde, called Darnay,” said the first.
+
+“Who seeks him?” answered Darnay.
+
+“I seek him. We seek him. I know you, Evremonde; I saw you before the
+Tribunal to-day. You are again the prisoner of the Republic.”
+
+The four surrounded him, where he stood with his wife and child clinging
+to him.
+
+“Tell me how and why am I again a prisoner?”
+
+“It is enough that you return straight to the Conciergerie, and will
+know to-morrow. You are summoned for to-morrow.”
+
+Doctor Manette, whom this visitation had so turned into stone, that he
+stood with the lamp in his hand, as if he were a statue made to hold it,
+moved after these words were spoken, put the lamp down, and confronting
+the speaker, and taking him, not ungently, by the loose front of his red
+woollen shirt, said:
+
+“You know him, you have said. Do you know me?”
+
+“Yes, I know you, Citizen Doctor.”
+
+“We all know you, Citizen Doctor,” said the other three.
+
+He looked abstractedly from one to another, and said, in a lower voice,
+after a pause:
+
+“Will you answer his question to me then? How does this happen?”
+
+“Citizen Doctor,” said the first, reluctantly, “he has been denounced to
+the Section of Saint Antoine. This citizen,” pointing out the second who
+had entered, “is from Saint Antoine.”
+
+The citizen here indicated nodded his head, and added:
+
+“He is accused by Saint Antoine.”
+
+“Of what?” asked the Doctor.
+
+“Citizen Doctor,” said the first, with his former reluctance, “ask no
+more. If the Republic demands sacrifices from you, without doubt you as
+a good patriot will be happy to make them. The Republic goes before all.
+The People is supreme. Evremonde, we are pressed.”
+
+“One word,” the Doctor entreated. “Will you tell me who denounced him?”
+
+“It is against rule,” answered the first; “but you can ask Him of Saint
+Antoine here.”
+
+The Doctor turned his eyes upon that man. Who moved uneasily on his
+feet, rubbed his beard a little, and at length said:
+
+“Well! Truly it is against rule. But he is denounced--and gravely--by
+the Citizen and Citizeness Defarge. And by one other.”
+
+“What other?”
+
+“Do _you_ ask, Citizen Doctor?”
+
+“Yes.”
+
+“Then,” said he of Saint Antoine, with a strange look, “you will be
+answered to-morrow. Now, I am dumb!”
+
+
+
+
+VIII. A Hand at Cards
+
+
+Happily unconscious of the new calamity at home, Miss Pross threaded her
+way along the narrow streets and crossed the river by the bridge of the
+Pont-Neuf, reckoning in her mind the number of indispensable purchases
+she had to make. Mr. Cruncher, with the basket, walked at her side. They
+both looked to the right and to the left into most of the shops they
+passed, had a wary eye for all gregarious assemblages of people, and
+turned out of their road to avoid any very excited group of talkers. It
+was a raw evening, and the misty river, blurred to the eye with blazing
+lights and to the ear with harsh noises, showed where the barges were
+stationed in which the smiths worked, making guns for the Army of the
+Republic. Woe to the man who played tricks with _that_ Army, or got
+undeserved promotion in it! Better for him that his beard had never
+grown, for the National Razor shaved him close.
+
+Having purchased a few small articles of grocery, and a measure of oil
+for the lamp, Miss Pross bethought herself of the wine they wanted.
+After peeping into several wine-shops, she stopped at the sign of the
+Good Republican Brutus of Antiquity, not far from the National Palace,
+once (and twice) the Tuileries, where the aspect of things rather
+took her fancy. It had a quieter look than any other place of the same
+description they had passed, and, though red with patriotic caps, was
+not so red as the rest. Sounding Mr. Cruncher, and finding him of her
+opinion, Miss Pross resorted to the Good Republican Brutus of Antiquity,
+attended by her cavalier.
+
+Slightly observant of the smoky lights; of the people, pipe in mouth,
+playing with limp cards and yellow dominoes; of the one bare-breasted,
+bare-armed, soot-begrimed workman reading a journal aloud, and of
+the others listening to him; of the weapons worn, or laid aside to be
+resumed; of the two or three customers fallen forward asleep, who in the
+popular high-shouldered shaggy black spencer looked, in that attitude,
+like slumbering bears or dogs; the two outlandish customers approached
+the counter, and showed what they wanted.
+
+As their wine was measuring out, a man parted from another man in a
+corner, and rose to depart. In going, he had to face Miss Pross. No
+sooner did he face her, than Miss Pross uttered a scream, and clapped
+her hands.
+
+In a moment, the whole company were on their feet. That somebody was
+assassinated by somebody vindicating a difference of opinion was the
+likeliest occurrence. Everybody looked to see somebody fall, but only
+saw a man and a woman standing staring at each other; the man with all
+the outward aspect of a Frenchman and a thorough Republican; the woman,
+evidently English.
+
+What was said in this disappointing anti-climax, by the disciples of the
+Good Republican Brutus of Antiquity, except that it was something very
+voluble and loud, would have been as so much Hebrew or Chaldean to Miss
+Pross and her protector, though they had been all ears. But, they had no
+ears for anything in their surprise. For, it must be recorded, that
+not only was Miss Pross lost in amazement and agitation, but,
+Mr. Cruncher--though it seemed on his own separate and individual
+account--was in a state of the greatest wonder.
+
+“What is the matter?” said the man who had caused Miss Pross to scream;
+speaking in a vexed, abrupt voice (though in a low tone), and in
+English.
+
+“Oh, Solomon, dear Solomon!” cried Miss Pross, clapping her hands again.
+“After not setting eyes upon you or hearing of you for so long a time,
+do I find you here!”
+
+“Don’t call me Solomon. Do you want to be the death of me?” asked the
+man, in a furtive, frightened way.
+
+“Brother, brother!” cried Miss Pross, bursting into tears. “Have I ever
+been so hard with you that you ask me such a cruel question?”
+
+“Then hold your meddlesome tongue,” said Solomon, “and come out, if you
+want to speak to me. Pay for your wine, and come out. Who’s this man?”
+
+Miss Pross, shaking her loving and dejected head at her by no means
+affectionate brother, said through her tears, “Mr. Cruncher.”
+
+“Let him come out too,” said Solomon. “Does he think me a ghost?”
+
+Apparently, Mr. Cruncher did, to judge from his looks. He said not a
+word, however, and Miss Pross, exploring the depths of her reticule
+through her tears with great difficulty paid for her wine. As she did
+so, Solomon turned to the followers of the Good Republican Brutus
+of Antiquity, and offered a few words of explanation in the French
+language, which caused them all to relapse into their former places and
+pursuits.
+
+“Now,” said Solomon, stopping at the dark street corner, “what do you
+want?”
+
+“How dreadfully unkind in a brother nothing has ever turned my love away
+from!” cried Miss Pross, “to give me such a greeting, and show me no
+affection.”
+
+“There. Confound it! There,” said Solomon, making a dab at Miss Pross’s
+lips with his own. “Now are you content?”
+
+Miss Pross only shook her head and wept in silence.
+
+“If you expect me to be surprised,” said her brother Solomon, “I am not
+surprised; I knew you were here; I know of most people who are here. If
+you really don’t want to endanger my existence--which I half believe you
+do--go your ways as soon as possible, and let me go mine. I am busy. I
+am an official.”
+
+“My English brother Solomon,” mourned Miss Pross, casting up her
+tear-fraught eyes, “that had the makings in him of one of the best and
+greatest of men in his native country, an official among foreigners, and
+such foreigners! I would almost sooner have seen the dear boy lying in
+his--”
+
+“I said so!” cried her brother, interrupting. “I knew it. You want to be
+the death of me. I shall be rendered Suspected, by my own sister. Just
+as I am getting on!”
+
+“The gracious and merciful Heavens forbid!” cried Miss Pross. “Far
+rather would I never see you again, dear Solomon, though I have ever
+loved you truly, and ever shall. Say but one affectionate word to me,
+and tell me there is nothing angry or estranged between us, and I will
+detain you no longer.”
+
+Good Miss Pross! As if the estrangement between them had come of any
+culpability of hers. As if Mr. Lorry had not known it for a fact, years
+ago, in the quiet corner in Soho, that this precious brother had spent
+her money and left her!
+
+He was saying the affectionate word, however, with a far more grudging
+condescension and patronage than he could have shown if their relative
+merits and positions had been reversed (which is invariably the case,
+all the world over), when Mr. Cruncher, touching him on the shoulder,
+hoarsely and unexpectedly interposed with the following singular
+question:
+
+“I say! Might I ask the favour? As to whether your name is John Solomon,
+or Solomon John?”
+
+The official turned towards him with sudden distrust. He had not
+previously uttered a word.
+
+“Come!” said Mr. Cruncher. “Speak out, you know.” (Which, by the way,
+was more than he could do himself.) “John Solomon, or Solomon John? She
+calls you Solomon, and she must know, being your sister. And _I_ know
+you’re John, you know. Which of the two goes first? And regarding that
+name of Pross, likewise. That warn’t your name over the water.”
+
+“What do you mean?”
+
+“Well, I don’t know all I mean, for I can’t call to mind what your name
+was, over the water.”
+
+“No?”
+
+“No. But I’ll swear it was a name of two syllables.”
+
+“Indeed?”
+
+“Yes. T’other one’s was one syllable. I know you. You was a spy--witness
+at the Bailey. What, in the name of the Father of Lies, own father to
+yourself, was you called at that time?”
+
+“Barsad,” said another voice, striking in.
+
+“That’s the name for a thousand pound!” cried Jerry.
+
+The speaker who struck in, was Sydney Carton. He had his hands behind
+him under the skirts of his riding-coat, and he stood at Mr. Cruncher’s
+elbow as negligently as he might have stood at the Old Bailey itself.
+
+“Don’t be alarmed, my dear Miss Pross. I arrived at Mr. Lorry’s, to his
+surprise, yesterday evening; we agreed that I would not present myself
+elsewhere until all was well, or unless I could be useful; I present
+myself here, to beg a little talk with your brother. I wish you had a
+better employed brother than Mr. Barsad. I wish for your sake Mr. Barsad
+was not a Sheep of the Prisons.”
+
+Sheep was a cant word of the time for a spy, under the gaolers. The spy,
+who was pale, turned paler, and asked him how he dared--
+
+“I’ll tell you,” said Sydney. “I lighted on you, Mr. Barsad, coming out
+of the prison of the Conciergerie while I was contemplating the walls,
+an hour or more ago. You have a face to be remembered, and I remember
+faces well. Made curious by seeing you in that connection, and having
+a reason, to which you are no stranger, for associating you with
+the misfortunes of a friend now very unfortunate, I walked in your
+direction. I walked into the wine-shop here, close after you, and
+sat near you. I had no difficulty in deducing from your unreserved
+conversation, and the rumour openly going about among your admirers, the
+nature of your calling. And gradually, what I had done at random, seemed
+to shape itself into a purpose, Mr. Barsad.”
+
+“What purpose?” the spy asked.
+
+“It would be troublesome, and might be dangerous, to explain in the
+street. Could you favour me, in confidence, with some minutes of your
+company--at the office of Tellson’s Bank, for instance?”
+
+“Under a threat?”
+
+“Oh! Did I say that?”
+
+“Then, why should I go there?”
+
+“Really, Mr. Barsad, I can’t say, if you can’t.”
+
+“Do you mean that you won’t say, sir?” the spy irresolutely asked.
+
+“You apprehend me very clearly, Mr. Barsad. I won’t.”
+
+Carton’s negligent recklessness of manner came powerfully in aid of his
+quickness and skill, in such a business as he had in his secret mind,
+and with such a man as he had to do with. His practised eye saw it, and
+made the most of it.
+
+“Now, I told you so,” said the spy, casting a reproachful look at his
+sister; “if any trouble comes of this, it’s your doing.”
+
+“Come, come, Mr. Barsad!” exclaimed Sydney. “Don’t be ungrateful.
+But for my great respect for your sister, I might not have led up so
+pleasantly to a little proposal that I wish to make for our mutual
+satisfaction. Do you go with me to the Bank?”
+
+“I’ll hear what you have got to say. Yes, I’ll go with you.”
+
+“I propose that we first conduct your sister safely to the corner of her
+own street. Let me take your arm, Miss Pross. This is not a good city,
+at this time, for you to be out in, unprotected; and as your escort
+knows Mr. Barsad, I will invite him to Mr. Lorry’s with us. Are we
+ready? Come then!”
+
+Miss Pross recalled soon afterwards, and to the end of her life
+remembered, that as she pressed her hands on Sydney’s arm and looked up
+in his face, imploring him to do no hurt to Solomon, there was a braced
+purpose in the arm and a kind of inspiration in the eyes, which not only
+contradicted his light manner, but changed and raised the man. She was
+too much occupied then with fears for the brother who so little deserved
+her affection, and with Sydney’s friendly reassurances, adequately to
+heed what she observed.
+
+They left her at the corner of the street, and Carton led the way to Mr.
+Lorry’s, which was within a few minutes’ walk. John Barsad, or Solomon
+Pross, walked at his side.
+
+Mr. Lorry had just finished his dinner, and was sitting before a cheery
+little log or two of fire--perhaps looking into their blaze for the
+picture of that younger elderly gentleman from Tellson’s, who had looked
+into the red coals at the Royal George at Dover, now a good many years
+ago. He turned his head as they entered, and showed the surprise with
+which he saw a stranger.
+
+“Miss Pross’s brother, sir,” said Sydney. “Mr. Barsad.”
+
+“Barsad?” repeated the old gentleman, “Barsad? I have an association
+with the name--and with the face.”
+
+“I told you you had a remarkable face, Mr. Barsad,” observed Carton,
+coolly. “Pray sit down.”
+
+As he took a chair himself, he supplied the link that Mr. Lorry wanted,
+by saying to him with a frown, “Witness at that trial.” Mr. Lorry
+immediately remembered, and regarded his new visitor with an undisguised
+look of abhorrence.
+
+“Mr. Barsad has been recognised by Miss Pross as the affectionate
+brother you have heard of,” said Sydney, “and has acknowledged the
+relationship. I pass to worse news. Darnay has been arrested again.”
+
+Struck with consternation, the old gentleman exclaimed, “What do you
+tell me! I left him safe and free within these two hours, and am about
+to return to him!”
+
+“Arrested for all that. When was it done, Mr. Barsad?”
+
+“Just now, if at all.”
+
+“Mr. Barsad is the best authority possible, sir,” said Sydney, “and I
+have it from Mr. Barsad’s communication to a friend and brother Sheep
+over a bottle of wine, that the arrest has taken place. He left the
+messengers at the gate, and saw them admitted by the porter. There is no
+earthly doubt that he is retaken.”
+
+Mr. Lorry’s business eye read in the speaker’s face that it was loss
+of time to dwell upon the point. Confused, but sensible that something
+might depend on his presence of mind, he commanded himself, and was
+silently attentive.
+
+“Now, I trust,” said Sydney to him, “that the name and influence of
+Doctor Manette may stand him in as good stead to-morrow--you said he
+would be before the Tribunal again to-morrow, Mr. Barsad?--”
+
+“Yes; I believe so.”
+
+“--In as good stead to-morrow as to-day. But it may not be so. I own
+to you, I am shaken, Mr. Lorry, by Doctor Manette’s not having had the
+power to prevent this arrest.”
+
+“He may not have known of it beforehand,” said Mr. Lorry.
+
+“But that very circumstance would be alarming, when we remember how
+identified he is with his son-in-law.”
+
+“That’s true,” Mr. Lorry acknowledged, with his troubled hand at his
+chin, and his troubled eyes on Carton.
+
+“In short,” said Sydney, “this is a desperate time, when desperate games
+are played for desperate stakes. Let the Doctor play the winning game; I
+will play the losing one. No man’s life here is worth purchase. Any one
+carried home by the people to-day, may be condemned tomorrow. Now, the
+stake I have resolved to play for, in case of the worst, is a friend
+in the Conciergerie. And the friend I purpose to myself to win, is Mr.
+Barsad.”
+
+“You need have good cards, sir,” said the spy.
+
+“I’ll run them over. I’ll see what I hold,--Mr. Lorry, you know what a
+brute I am; I wish you’d give me a little brandy.”
+
+It was put before him, and he drank off a glassful--drank off another
+glassful--pushed the bottle thoughtfully away.
+
+“Mr. Barsad,” he went on, in the tone of one who really was looking
+over a hand at cards: “Sheep of the prisons, emissary of Republican
+committees, now turnkey, now prisoner, always spy and secret informer,
+so much the more valuable here for being English that an Englishman
+is less open to suspicion of subornation in those characters than a
+Frenchman, represents himself to his employers under a false name.
+That’s a very good card. Mr. Barsad, now in the employ of the republican
+French government, was formerly in the employ of the aristocratic
+English government, the enemy of France and freedom. That’s an excellent
+card. Inference clear as day in this region of suspicion, that Mr.
+Barsad, still in the pay of the aristocratic English government, is the
+spy of Pitt, the treacherous foe of the Republic crouching in its bosom,
+the English traitor and agent of all mischief so much spoken of and so
+difficult to find. That’s a card not to be beaten. Have you followed my
+hand, Mr. Barsad?”
+
+“Not to understand your play,” returned the spy, somewhat uneasily.
+
+“I play my Ace, Denunciation of Mr. Barsad to the nearest Section
+Committee. Look over your hand, Mr. Barsad, and see what you have. Don’t
+hurry.”
+
+He drew the bottle near, poured out another glassful of brandy, and
+drank it off. He saw that the spy was fearful of his drinking himself
+into a fit state for the immediate denunciation of him. Seeing it, he
+poured out and drank another glassful.
+
+“Look over your hand carefully, Mr. Barsad. Take time.”
+
+It was a poorer hand than he suspected. Mr. Barsad saw losing cards
+in it that Sydney Carton knew nothing of. Thrown out of his honourable
+employment in England, through too much unsuccessful hard swearing
+there--not because he was not wanted there; our English reasons for
+vaunting our superiority to secrecy and spies are of very modern
+date--he knew that he had crossed the Channel, and accepted service in
+France: first, as a tempter and an eavesdropper among his own countrymen
+there: gradually, as a tempter and an eavesdropper among the natives. He
+knew that under the overthrown government he had been a spy upon Saint
+Antoine and Defarge’s wine-shop; had received from the watchful police
+such heads of information concerning Doctor Manette’s imprisonment,
+release, and history, as should serve him for an introduction to
+familiar conversation with the Defarges; and tried them on Madame
+Defarge, and had broken down with them signally. He always remembered
+with fear and trembling, that that terrible woman had knitted when he
+talked with her, and had looked ominously at him as her fingers moved.
+He had since seen her, in the Section of Saint Antoine, over and over
+again produce her knitted registers, and denounce people whose lives the
+guillotine then surely swallowed up. He knew, as every one employed as
+he was did, that he was never safe; that flight was impossible; that
+he was tied fast under the shadow of the axe; and that in spite of
+his utmost tergiversation and treachery in furtherance of the reigning
+terror, a word might bring it down upon him. Once denounced, and on such
+grave grounds as had just now been suggested to his mind, he foresaw
+that the dreadful woman of whose unrelenting character he had seen many
+proofs, would produce against him that fatal register, and would quash
+his last chance of life. Besides that all secret men are men soon
+terrified, here were surely cards enough of one black suit, to justify
+the holder in growing rather livid as he turned them over.
+
+“You scarcely seem to like your hand,” said Sydney, with the greatest
+composure. “Do you play?”
+
+“I think, sir,” said the spy, in the meanest manner, as he turned to Mr.
+Lorry, “I may appeal to a gentleman of your years and benevolence, to
+put it to this other gentleman, so much your junior, whether he can
+under any circumstances reconcile it to his station to play that Ace
+of which he has spoken. I admit that _I_ am a spy, and that it is
+considered a discreditable station--though it must be filled by
+somebody; but this gentleman is no spy, and why should he so demean
+himself as to make himself one?”
+
+“I play my Ace, Mr. Barsad,” said Carton, taking the answer on himself,
+and looking at his watch, “without any scruple, in a very few minutes.”
+
+“I should have hoped, gentlemen both,” said the spy, always striving to
+hook Mr. Lorry into the discussion, “that your respect for my sister--”
+
+“I could not better testify my respect for your sister than by finally
+relieving her of her brother,” said Sydney Carton.
+
+“You think not, sir?”
+
+“I have thoroughly made up my mind about it.”
+
+The smooth manner of the spy, curiously in dissonance with his
+ostentatiously rough dress, and probably with his usual demeanour,
+received such a check from the inscrutability of Carton,--who was a
+mystery to wiser and honester men than he,--that it faltered here and
+failed him. While he was at a loss, Carton said, resuming his former air
+of contemplating cards:
+
+“And indeed, now I think again, I have a strong impression that I
+have another good card here, not yet enumerated. That friend and
+fellow-Sheep, who spoke of himself as pasturing in the country prisons;
+who was he?”
+
+“French. You don’t know him,” said the spy, quickly.
+
+“French, eh?” repeated Carton, musing, and not appearing to notice him
+at all, though he echoed his word. “Well; he may be.”
+
+“Is, I assure you,” said the spy; “though it’s not important.”
+
+“Though it’s not important,” repeated Carton, in the same mechanical
+way--“though it’s not important--No, it’s not important. No. Yet I know
+the face.”
+
+“I think not. I am sure not. It can’t be,” said the spy.
+
+“It-can’t-be,” muttered Sydney Carton, retrospectively, and idling his
+glass (which fortunately was a small one) again. “Can’t-be. Spoke good
+French. Yet like a foreigner, I thought?”
+
+“Provincial,” said the spy.
+
+“No. Foreign!” cried Carton, striking his open hand on the table, as a
+light broke clearly on his mind. “Cly! Disguised, but the same man. We
+had that man before us at the Old Bailey.”
+
+“Now, there you are hasty, sir,” said Barsad, with a smile that gave his
+aquiline nose an extra inclination to one side; “there you really give
+me an advantage over you. Cly (who I will unreservedly admit, at this
+distance of time, was a partner of mine) has been dead several years. I
+attended him in his last illness. He was buried in London, at the church
+of Saint Pancras-in-the-Fields. His unpopularity with the blackguard
+multitude at the moment prevented my following his remains, but I helped
+to lay him in his coffin.”
+
+Here, Mr. Lorry became aware, from where he sat, of a most remarkable
+goblin shadow on the wall. Tracing it to its source, he discovered it
+to be caused by a sudden extraordinary rising and stiffening of all the
+risen and stiff hair on Mr. Cruncher’s head.
+
+“Let us be reasonable,” said the spy, “and let us be fair. To show you
+how mistaken you are, and what an unfounded assumption yours is, I will
+lay before you a certificate of Cly’s burial, which I happened to have
+carried in my pocket-book,” with a hurried hand he produced and opened
+it, “ever since. There it is. Oh, look at it, look at it! You may take
+it in your hand; it’s no forgery.”
+
+Here, Mr. Lorry perceived the reflection on the wall to elongate, and
+Mr. Cruncher rose and stepped forward. His hair could not have been more
+violently on end, if it had been that moment dressed by the Cow with the
+crumpled horn in the house that Jack built.
+
+Unseen by the spy, Mr. Cruncher stood at his side, and touched him on
+the shoulder like a ghostly bailiff.
+
+“That there Roger Cly, master,” said Mr. Cruncher, with a taciturn and
+iron-bound visage. “So _you_ put him in his coffin?”
+
+“I did.”
+
+“Who took him out of it?”
+
+Barsad leaned back in his chair, and stammered, “What do you mean?”
+
+“I mean,” said Mr. Cruncher, “that he warn’t never in it. No! Not he!
+I’ll have my head took off, if he was ever in it.”
+
+The spy looked round at the two gentlemen; they both looked in
+unspeakable astonishment at Jerry.
+
+“I tell you,” said Jerry, “that you buried paving-stones and earth in
+that there coffin. Don’t go and tell me that you buried Cly. It was a
+take in. Me and two more knows it.”
+
+“How do you know it?”
+
+“What’s that to you? Ecod!” growled Mr. Cruncher, “it’s you I have got a
+old grudge again, is it, with your shameful impositions upon tradesmen!
+I’d catch hold of your throat and choke you for half a guinea.”
+
+Sydney Carton, who, with Mr. Lorry, had been lost in amazement at
+this turn of the business, here requested Mr. Cruncher to moderate and
+explain himself.
+
+“At another time, sir,” he returned, evasively, “the present time is
+ill-conwenient for explainin’. What I stand to, is, that he knows well
+wot that there Cly was never in that there coffin. Let him say he was,
+in so much as a word of one syllable, and I’ll either catch hold of his
+throat and choke him for half a guinea;” Mr. Cruncher dwelt upon this as
+quite a liberal offer; “or I’ll out and announce him.”
+
+“Humph! I see one thing,” said Carton. “I hold another card, Mr. Barsad.
+Impossible, here in raging Paris, with Suspicion filling the air, for
+you to outlive denunciation, when you are in communication with another
+aristocratic spy of the same antecedents as yourself, who, moreover, has
+the mystery about him of having feigned death and come to life again!
+A plot in the prisons, of the foreigner against the Republic. A strong
+card--a certain Guillotine card! Do you play?”
+
+“No!” returned the spy. “I throw up. I confess that we were so unpopular
+with the outrageous mob, that I only got away from England at the risk
+of being ducked to death, and that Cly was so ferreted up and down, that
+he never would have got away at all but for that sham. Though how this
+man knows it was a sham, is a wonder of wonders to me.”
+
+“Never you trouble your head about this man,” retorted the contentious
+Mr. Cruncher; “you’ll have trouble enough with giving your attention to
+that gentleman. And look here! Once more!”--Mr. Cruncher could not
+be restrained from making rather an ostentatious parade of his
+liberality--“I’d catch hold of your throat and choke you for half a
+guinea.”
+
+The Sheep of the prisons turned from him to Sydney Carton, and said,
+with more decision, “It has come to a point. I go on duty soon, and
+can’t overstay my time. You told me you had a proposal; what is it?
+Now, it is of no use asking too much of me. Ask me to do anything in my
+office, putting my head in great extra danger, and I had better trust my
+life to the chances of a refusal than the chances of consent. In short,
+I should make that choice. You talk of desperation. We are all desperate
+here. Remember! I may denounce you if I think proper, and I can swear my
+way through stone walls, and so can others. Now, what do you want with
+me?”
+
+“Not very much. You are a turnkey at the Conciergerie?”
+
+“I tell you once for all, there is no such thing as an escape possible,”
+ said the spy, firmly.
+
+“Why need you tell me what I have not asked? You are a turnkey at the
+Conciergerie?”
+
+“I am sometimes.”
+
+“You can be when you choose?”
+
+“I can pass in and out when I choose.”
+
+Sydney Carton filled another glass with brandy, poured it slowly out
+upon the hearth, and watched it as it dropped. It being all spent, he
+said, rising:
+
+“So far, we have spoken before these two, because it was as well that
+the merits of the cards should not rest solely between you and me. Come
+into the dark room here, and let us have one final word alone.”
+
+
+
+
+IX. The Game Made
+
+
+While Sydney Carton and the Sheep of the prisons were in the adjoining
+dark room, speaking so low that not a sound was heard, Mr. Lorry looked
+at Jerry in considerable doubt and mistrust. That honest tradesman’s
+manner of receiving the look, did not inspire confidence; he changed the
+leg on which he rested, as often as if he had fifty of those limbs,
+and were trying them all; he examined his finger-nails with a very
+questionable closeness of attention; and whenever Mr. Lorry’s eye caught
+his, he was taken with that peculiar kind of short cough requiring the
+hollow of a hand before it, which is seldom, if ever, known to be an
+infirmity attendant on perfect openness of character.
+
+“Jerry,” said Mr. Lorry. “Come here.”
+
+Mr. Cruncher came forward sideways, with one of his shoulders in advance
+of him.
+
+“What have you been, besides a messenger?”
+
+After some cogitation, accompanied with an intent look at his patron,
+Mr. Cruncher conceived the luminous idea of replying, “Agicultooral
+character.”
+
+“My mind misgives me much,” said Mr. Lorry, angrily shaking a forefinger
+at him, “that you have used the respectable and great house of Tellson’s
+as a blind, and that you have had an unlawful occupation of an infamous
+description. If you have, don’t expect me to befriend you when you
+get back to England. If you have, don’t expect me to keep your secret.
+Tellson’s shall not be imposed upon.”
+
+“I hope, sir,” pleaded the abashed Mr. Cruncher, “that a gentleman like
+yourself wot I’ve had the honour of odd jobbing till I’m grey at it,
+would think twice about harming of me, even if it wos so--I don’t say it
+is, but even if it wos. And which it is to be took into account that if
+it wos, it wouldn’t, even then, be all o’ one side. There’d be two sides
+to it. There might be medical doctors at the present hour, a picking
+up their guineas where a honest tradesman don’t pick up his
+fardens--fardens! no, nor yet his half fardens--half fardens! no, nor
+yet his quarter--a banking away like smoke at Tellson’s, and a cocking
+their medical eyes at that tradesman on the sly, a going in and going
+out to their own carriages--ah! equally like smoke, if not more so.
+Well, that ‘ud be imposing, too, on Tellson’s. For you cannot sarse the
+goose and not the gander. And here’s Mrs. Cruncher, or leastways wos
+in the Old England times, and would be to-morrow, if cause given,
+a floppin’ again the business to that degree as is ruinating--stark
+ruinating! Whereas them medical doctors’ wives don’t flop--catch ‘em at
+it! Or, if they flop, their floppings goes in favour of more patients,
+and how can you rightly have one without t’other? Then, wot with
+undertakers, and wot with parish clerks, and wot with sextons, and wot
+with private watchmen (all awaricious and all in it), a man wouldn’t get
+much by it, even if it wos so. And wot little a man did get, would never
+prosper with him, Mr. Lorry. He’d never have no good of it; he’d want
+all along to be out of the line, if he, could see his way out, being
+once in--even if it wos so.”
+
+“Ugh!” cried Mr. Lorry, rather relenting, nevertheless, “I am shocked at
+the sight of you.”
+
+“Now, what I would humbly offer to you, sir,” pursued Mr. Cruncher,
+“even if it wos so, which I don’t say it is--”
+
+“Don’t prevaricate,” said Mr. Lorry.
+
+“No, I will _not_, sir,” returned Mr. Crunches as if nothing were
+further from his thoughts or practice--“which I don’t say it is--wot I
+would humbly offer to you, sir, would be this. Upon that there stool, at
+that there Bar, sets that there boy of mine, brought up and growed up to
+be a man, wot will errand you, message you, general-light-job you, till
+your heels is where your head is, if such should be your wishes. If it
+wos so, which I still don’t say it is (for I will not prewaricate to
+you, sir), let that there boy keep his father’s place, and take care of
+his mother; don’t blow upon that boy’s father--do not do it, sir--and
+let that father go into the line of the reg’lar diggin’, and make amends
+for what he would have undug--if it wos so--by diggin’ of ‘em in with
+a will, and with conwictions respectin’ the futur’ keepin’ of ‘em safe.
+That, Mr. Lorry,” said Mr. Cruncher, wiping his forehead with his
+arm, as an announcement that he had arrived at the peroration of his
+discourse, “is wot I would respectfully offer to you, sir. A man don’t
+see all this here a goin’ on dreadful round him, in the way of Subjects
+without heads, dear me, plentiful enough fur to bring the price down
+to porterage and hardly that, without havin’ his serious thoughts of
+things. And these here would be mine, if it wos so, entreatin’ of you
+fur to bear in mind that wot I said just now, I up and said in the good
+cause when I might have kep’ it back.”
+
+“That at least is true,” said Mr. Lorry. “Say no more now. It may be
+that I shall yet stand your friend, if you deserve it, and repent in
+action--not in words. I want no more words.”
+
+Mr. Cruncher knuckled his forehead, as Sydney Carton and the spy
+returned from the dark room. “Adieu, Mr. Barsad,” said the former; “our
+arrangement thus made, you have nothing to fear from me.”
+
+He sat down in a chair on the hearth, over against Mr. Lorry. When they
+were alone, Mr. Lorry asked him what he had done?
+
+“Not much. If it should go ill with the prisoner, I have ensured access
+to him, once.”
+
+Mr. Lorry’s countenance fell.
+
+“It is all I could do,” said Carton. “To propose too much, would be
+to put this man’s head under the axe, and, as he himself said, nothing
+worse could happen to him if he were denounced. It was obviously the
+weakness of the position. There is no help for it.”
+
+“But access to him,” said Mr. Lorry, “if it should go ill before the
+Tribunal, will not save him.”
+
+“I never said it would.”
+
+Mr. Lorry’s eyes gradually sought the fire; his sympathy with his
+darling, and the heavy disappointment of his second arrest, gradually
+weakened them; he was an old man now, overborne with anxiety of late,
+and his tears fell.
+
+“You are a good man and a true friend,” said Carton, in an altered
+voice. “Forgive me if I notice that you are affected. I could not see my
+father weep, and sit by, careless. And I could not respect your
+sorrow more, if you were my father. You are free from that misfortune,
+however.”
+
+Though he said the last words, with a slip into his usual manner, there
+was a true feeling and respect both in his tone and in his touch,
+that Mr. Lorry, who had never seen the better side of him, was wholly
+unprepared for. He gave him his hand, and Carton gently pressed it.
+
+“To return to poor Darnay,” said Carton. “Don’t tell Her of this
+interview, or this arrangement. It would not enable Her to go to see
+him. She might think it was contrived, in case of the worse, to convey
+to him the means of anticipating the sentence.”
+
+Mr. Lorry had not thought of that, and he looked quickly at Carton to
+see if it were in his mind. It seemed to be; he returned the look, and
+evidently understood it.
+
+“She might think a thousand things,” Carton said, “and any of them would
+only add to her trouble. Don’t speak of me to her. As I said to you when
+I first came, I had better not see her. I can put my hand out, to do any
+little helpful work for her that my hand can find to do, without that.
+You are going to her, I hope? She must be very desolate to-night.”
+
+“I am going now, directly.”
+
+“I am glad of that. She has such a strong attachment to you and reliance
+on you. How does she look?”
+
+“Anxious and unhappy, but very beautiful.”
+
+“Ah!”
+
+It was a long, grieving sound, like a sigh--almost like a sob. It
+attracted Mr. Lorry’s eyes to Carton’s face, which was turned to the
+fire. A light, or a shade (the old gentleman could not have said which),
+passed from it as swiftly as a change will sweep over a hill-side on a
+wild bright day, and he lifted his foot to put back one of the little
+flaming logs, which was tumbling forward. He wore the white riding-coat
+and top-boots, then in vogue, and the light of the fire touching their
+light surfaces made him look very pale, with his long brown hair,
+all untrimmed, hanging loose about him. His indifference to fire was
+sufficiently remarkable to elicit a word of remonstrance from Mr. Lorry;
+his boot was still upon the hot embers of the flaming log, when it had
+broken under the weight of his foot.
+
+“I forgot it,” he said.
+
+Mr. Lorry’s eyes were again attracted to his face. Taking note of the
+wasted air which clouded the naturally handsome features, and having
+the expression of prisoners’ faces fresh in his mind, he was strongly
+reminded of that expression.
+
+“And your duties here have drawn to an end, sir?” said Carton, turning
+to him.
+
+“Yes. As I was telling you last night when Lucie came in so
+unexpectedly, I have at length done all that I can do here. I hoped to
+have left them in perfect safety, and then to have quitted Paris. I have
+my Leave to Pass. I was ready to go.”
+
+They were both silent.
+
+“Yours is a long life to look back upon, sir?” said Carton, wistfully.
+
+“I am in my seventy-eighth year.”
+
+“You have been useful all your life; steadily and constantly occupied;
+trusted, respected, and looked up to?”
+
+“I have been a man of business, ever since I have been a man. Indeed, I
+may say that I was a man of business when a boy.”
+
+“See what a place you fill at seventy-eight. How many people will miss
+you when you leave it empty!”
+
+“A solitary old bachelor,” answered Mr. Lorry, shaking his head. “There
+is nobody to weep for me.”
+
+“How can you say that? Wouldn’t She weep for you? Wouldn’t her child?”
+
+“Yes, yes, thank God. I didn’t quite mean what I said.”
+
+“It _is_ a thing to thank God for; is it not?”
+
+“Surely, surely.”
+
+“If you could say, with truth, to your own solitary heart, to-night,
+‘I have secured to myself the love and attachment, the gratitude or
+respect, of no human creature; I have won myself a tender place in no
+regard; I have done nothing good or serviceable to be remembered by!’
+your seventy-eight years would be seventy-eight heavy curses; would they
+not?”
+
+“You say truly, Mr. Carton; I think they would be.”
+
+Sydney turned his eyes again upon the fire, and, after a silence of a
+few moments, said:
+
+“I should like to ask you:--Does your childhood seem far off? Do the
+days when you sat at your mother’s knee, seem days of very long ago?”
+
+Responding to his softened manner, Mr. Lorry answered:
+
+“Twenty years back, yes; at this time of my life, no. For, as I draw
+closer and closer to the end, I travel in the circle, nearer and
+nearer to the beginning. It seems to be one of the kind smoothings and
+preparings of the way. My heart is touched now, by many remembrances
+that had long fallen asleep, of my pretty young mother (and I so old!),
+and by many associations of the days when what we call the World was not
+so real with me, and my faults were not confirmed in me.”
+
+“I understand the feeling!” exclaimed Carton, with a bright flush. “And
+you are the better for it?”
+
+“I hope so.”
+
+Carton terminated the conversation here, by rising to help him on with
+his outer coat; “But you,” said Mr. Lorry, reverting to the theme, “you
+are young.”
+
+“Yes,” said Carton. “I am not old, but my young way was never the way to
+age. Enough of me.”
+
+“And of me, I am sure,” said Mr. Lorry. “Are you going out?”
+
+“I’ll walk with you to her gate. You know my vagabond and restless
+habits. If I should prowl about the streets a long time, don’t be
+uneasy; I shall reappear in the morning. You go to the Court to-morrow?”
+
+“Yes, unhappily.”
+
+“I shall be there, but only as one of the crowd. My Spy will find a
+place for me. Take my arm, sir.”
+
+Mr. Lorry did so, and they went down-stairs and out in the streets. A
+few minutes brought them to Mr. Lorry’s destination. Carton left him
+there; but lingered at a little distance, and turned back to the gate
+again when it was shut, and touched it. He had heard of her going to
+the prison every day. “She came out here,” he said, looking about him,
+“turned this way, must have trod on these stones often. Let me follow in
+her steps.”
+
+It was ten o’clock at night when he stood before the prison of La Force,
+where she had stood hundreds of times. A little wood-sawyer, having
+closed his shop, was smoking his pipe at his shop-door.
+
+“Good night, citizen,” said Sydney Carton, pausing in going by; for, the
+man eyed him inquisitively.
+
+“Good night, citizen.”
+
+“How goes the Republic?”
+
+“You mean the Guillotine. Not ill. Sixty-three to-day. We shall mount
+to a hundred soon. Samson and his men complain sometimes, of being
+exhausted. Ha, ha, ha! He is so droll, that Samson. Such a Barber!”
+
+“Do you often go to see him--”
+
+“Shave? Always. Every day. What a barber! You have seen him at work?”
+
+“Never.”
+
+“Go and see him when he has a good batch. Figure this to yourself,
+citizen; he shaved the sixty-three to-day, in less than two pipes! Less
+than two pipes. Word of honour!”
+
+As the grinning little man held out the pipe he was smoking, to explain
+how he timed the executioner, Carton was so sensible of a rising desire
+to strike the life out of him, that he turned away.
+
+“But you are not English,” said the wood-sawyer, “though you wear
+English dress?”
+
+“Yes,” said Carton, pausing again, and answering over his shoulder.
+
+“You speak like a Frenchman.”
+
+“I am an old student here.”
+
+“Aha, a perfect Frenchman! Good night, Englishman.”
+
+“Good night, citizen.”
+
+“But go and see that droll dog,” the little man persisted, calling after
+him. “And take a pipe with you!”
+
+Sydney had not gone far out of sight, when he stopped in the middle of
+the street under a glimmering lamp, and wrote with his pencil on a scrap
+of paper. Then, traversing with the decided step of one who remembered
+the way well, several dark and dirty streets--much dirtier than usual,
+for the best public thoroughfares remained uncleansed in those times of
+terror--he stopped at a chemist’s shop, which the owner was closing with
+his own hands. A small, dim, crooked shop, kept in a tortuous, up-hill
+thoroughfare, by a small, dim, crooked man.
+
+Giving this citizen, too, good night, as he confronted him at his
+counter, he laid the scrap of paper before him. “Whew!” the chemist
+whistled softly, as he read it. “Hi! hi! hi!”
+
+Sydney Carton took no heed, and the chemist said:
+
+“For you, citizen?”
+
+“For me.”
+
+“You will be careful to keep them separate, citizen? You know the
+consequences of mixing them?”
+
+“Perfectly.”
+
+Certain small packets were made and given to him. He put them, one by
+one, in the breast of his inner coat, counted out the money for them,
+and deliberately left the shop. “There is nothing more to do,” said he,
+glancing upward at the moon, “until to-morrow. I can’t sleep.”
+
+It was not a reckless manner, the manner in which he said these words
+aloud under the fast-sailing clouds, nor was it more expressive of
+negligence than defiance. It was the settled manner of a tired man, who
+had wandered and struggled and got lost, but who at length struck into
+his road and saw its end.
+
+Long ago, when he had been famous among his earliest competitors as a
+youth of great promise, he had followed his father to the grave. His
+mother had died, years before. These solemn words, which had been
+read at his father’s grave, arose in his mind as he went down the dark
+streets, among the heavy shadows, with the moon and the clouds sailing
+on high above him. “I am the resurrection and the life, saith the Lord:
+he that believeth in me, though he were dead, yet shall he live: and
+whosoever liveth and believeth in me, shall never die.”
+
+In a city dominated by the axe, alone at night, with natural sorrow
+rising in him for the sixty-three who had been that day put to death,
+and for to-morrow’s victims then awaiting their doom in the prisons,
+and still of to-morrow’s and to-morrow’s, the chain of association that
+brought the words home, like a rusty old ship’s anchor from the deep,
+might have been easily found. He did not seek it, but repeated them and
+went on.
+
+With a solemn interest in the lighted windows where the people were
+going to rest, forgetful through a few calm hours of the horrors
+surrounding them; in the towers of the churches, where no prayers
+were said, for the popular revulsion had even travelled that length
+of self-destruction from years of priestly impostors, plunderers, and
+profligates; in the distant burial-places, reserved, as they wrote upon
+the gates, for Eternal Sleep; in the abounding gaols; and in the streets
+along which the sixties rolled to a death which had become so common and
+material, that no sorrowful story of a haunting Spirit ever arose among
+the people out of all the working of the Guillotine; with a solemn
+interest in the whole life and death of the city settling down to its
+short nightly pause in fury; Sydney Carton crossed the Seine again for
+the lighter streets.
+
+Few coaches were abroad, for riders in coaches were liable to be
+suspected, and gentility hid its head in red nightcaps, and put on heavy
+shoes, and trudged. But, the theatres were all well filled, and the
+people poured cheerfully out as he passed, and went chatting home. At
+one of the theatre doors, there was a little girl with a mother, looking
+for a way across the street through the mud. He carried the child over,
+and before the timid arm was loosed from his neck asked her for a kiss.
+
+“I am the resurrection and the life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me, shall never die.”
+
+Now, that the streets were quiet, and the night wore on, the words
+were in the echoes of his feet, and were in the air. Perfectly calm
+and steady, he sometimes repeated them to himself as he walked; but, he
+heard them always.
+
+The night wore out, and, as he stood upon the bridge listening to the
+water as it splashed the river-walls of the Island of Paris, where the
+picturesque confusion of houses and cathedral shone bright in the light
+of the moon, the day came coldly, looking like a dead face out of the
+sky. Then, the night, with the moon and the stars, turned pale and died,
+and for a little while it seemed as if Creation were delivered over to
+Death’s dominion.
+
+But, the glorious sun, rising, seemed to strike those words, that burden
+of the night, straight and warm to his heart in its long bright rays.
+And looking along them, with reverently shaded eyes, a bridge of light
+appeared to span the air between him and the sun, while the river
+sparkled under it.
+
+The strong tide, so swift, so deep, and certain, was like a congenial
+friend, in the morning stillness. He walked by the stream, far from the
+houses, and in the light and warmth of the sun fell asleep on the
+bank. When he awoke and was afoot again, he lingered there yet a little
+longer, watching an eddy that turned and turned purposeless, until the
+stream absorbed it, and carried it on to the sea.--“Like me.”
+
+A trading-boat, with a sail of the softened colour of a dead leaf, then
+glided into his view, floated by him, and died away. As its silent track
+in the water disappeared, the prayer that had broken up out of his heart
+for a merciful consideration of all his poor blindnesses and errors,
+ended in the words, “I am the resurrection and the life.”
+
+Mr. Lorry was already out when he got back, and it was easy to surmise
+where the good old man was gone. Sydney Carton drank nothing but a
+little coffee, ate some bread, and, having washed and changed to refresh
+himself, went out to the place of trial.
+
+The court was all astir and a-buzz, when the black sheep--whom many fell
+away from in dread--pressed him into an obscure corner among the crowd.
+Mr. Lorry was there, and Doctor Manette was there. She was there,
+sitting beside her father.
+
+When her husband was brought in, she turned a look upon him, so
+sustaining, so encouraging, so full of admiring love and pitying
+tenderness, yet so courageous for his sake, that it called the healthy
+blood into his face, brightened his glance, and animated his heart. If
+there had been any eyes to notice the influence of her look, on Sydney
+Carton, it would have been seen to be the same influence exactly.
+
+Before that unjust Tribunal, there was little or no order of procedure,
+ensuring to any accused person any reasonable hearing. There could have
+been no such Revolution, if all laws, forms, and ceremonies, had not
+first been so monstrously abused, that the suicidal vengeance of the
+Revolution was to scatter them all to the winds.
+
+Every eye was turned to the jury. The same determined patriots and good
+republicans as yesterday and the day before, and to-morrow and the day
+after. Eager and prominent among them, one man with a craving face, and
+his fingers perpetually hovering about his lips, whose appearance
+gave great satisfaction to the spectators. A life-thirsting,
+cannibal-looking, bloody-minded juryman, the Jacques Three of St.
+Antoine. The whole jury, as a jury of dogs empannelled to try the deer.
+
+Every eye then turned to the five judges and the public prosecutor.
+No favourable leaning in that quarter to-day. A fell, uncompromising,
+murderous business-meaning there. Every eye then sought some other eye
+in the crowd, and gleamed at it approvingly; and heads nodded at one
+another, before bending forward with a strained attention.
+
+Charles Evremonde, called Darnay. Released yesterday. Reaccused and
+retaken yesterday. Indictment delivered to him last night. Suspected and
+Denounced enemy of the Republic, Aristocrat, one of a family of tyrants,
+one of a race proscribed, for that they had used their abolished
+privileges to the infamous oppression of the people. Charles Evremonde,
+called Darnay, in right of such proscription, absolutely Dead in Law.
+
+To this effect, in as few or fewer words, the Public Prosecutor.
+
+The President asked, was the Accused openly denounced or secretly?
+
+“Openly, President.”
+
+“By whom?”
+
+“Three voices. Ernest Defarge, wine-vendor of St. Antoine.”
+
+“Good.”
+
+“Therese Defarge, his wife.”
+
+“Good.”
+
+“Alexandre Manette, physician.”
+
+A great uproar took place in the court, and in the midst of it, Doctor
+Manette was seen, pale and trembling, standing where he had been seated.
+
+“President, I indignantly protest to you that this is a forgery and
+a fraud. You know the accused to be the husband of my daughter. My
+daughter, and those dear to her, are far dearer to me than my life. Who
+and where is the false conspirator who says that I denounce the husband
+of my child!”
+
+“Citizen Manette, be tranquil. To fail in submission to the authority of
+the Tribunal would be to put yourself out of Law. As to what is dearer
+to you than life, nothing can be so dear to a good citizen as the
+Republic.”
+
+Loud acclamations hailed this rebuke. The President rang his bell, and
+with warmth resumed.
+
+“If the Republic should demand of you the sacrifice of your child
+herself, you would have no duty but to sacrifice her. Listen to what is
+to follow. In the meanwhile, be silent!”
+
+Frantic acclamations were again raised. Doctor Manette sat down, with
+his eyes looking around, and his lips trembling; his daughter drew
+closer to him. The craving man on the jury rubbed his hands together,
+and restored the usual hand to his mouth.
+
+Defarge was produced, when the court was quiet enough to admit of his
+being heard, and rapidly expounded the story of the imprisonment, and of
+his having been a mere boy in the Doctor’s service, and of the release,
+and of the state of the prisoner when released and delivered to him.
+This short examination followed, for the court was quick with its work.
+
+“You did good service at the taking of the Bastille, citizen?”
+
+“I believe so.”
+
+Here, an excited woman screeched from the crowd: “You were one of the
+best patriots there. Why not say so? You were a cannonier that day
+there, and you were among the first to enter the accursed fortress when
+it fell. Patriots, I speak the truth!”
+
+It was The Vengeance who, amidst the warm commendations of the audience,
+thus assisted the proceedings. The President rang his bell; but, The
+Vengeance, warming with encouragement, shrieked, “I defy that bell!”
+ wherein she was likewise much commended.
+
+“Inform the Tribunal of what you did that day within the Bastille,
+citizen.”
+
+“I knew,” said Defarge, looking down at his wife, who stood at the
+bottom of the steps on which he was raised, looking steadily up at him;
+“I knew that this prisoner, of whom I speak, had been confined in a cell
+known as One Hundred and Five, North Tower. I knew it from himself. He
+knew himself by no other name than One Hundred and Five, North Tower,
+when he made shoes under my care. As I serve my gun that day, I resolve,
+when the place shall fall, to examine that cell. It falls. I mount to
+the cell, with a fellow-citizen who is one of the Jury, directed by a
+gaoler. I examine it, very closely. In a hole in the chimney, where a
+stone has been worked out and replaced, I find a written paper. This is
+that written paper. I have made it my business to examine some specimens
+of the writing of Doctor Manette. This is the writing of Doctor Manette.
+I confide this paper, in the writing of Doctor Manette, to the hands of
+the President.”
+
+“Let it be read.”
+
+In a dead silence and stillness--the prisoner under trial looking
+lovingly at his wife, his wife only looking from him to look with
+solicitude at her father, Doctor Manette keeping his eyes fixed on the
+reader, Madame Defarge never taking hers from the prisoner, Defarge
+never taking his from his feasting wife, and all the other eyes there
+intent upon the Doctor, who saw none of them--the paper was read, as
+follows.
+
+
+
+
+X. The Substance of the Shadow
+
+
+“I, Alexandre Manette, unfortunate physician, native of Beauvais, and
+afterwards resident in Paris, write this melancholy paper in my doleful
+cell in the Bastille, during the last month of the year, 1767. I write
+it at stolen intervals, under every difficulty. I design to secrete it
+in the wall of the chimney, where I have slowly and laboriously made a
+place of concealment for it. Some pitying hand may find it there, when I
+and my sorrows are dust.
+
+“These words are formed by the rusty iron point with which I write with
+difficulty in scrapings of soot and charcoal from the chimney, mixed
+with blood, in the last month of the tenth year of my captivity. Hope
+has quite departed from my breast. I know from terrible warnings I have
+noted in myself that my reason will not long remain unimpaired, but I
+solemnly declare that I am at this time in the possession of my right
+mind--that my memory is exact and circumstantial--and that I write the
+truth as I shall answer for these my last recorded words, whether they
+be ever read by men or not, at the Eternal Judgment-seat.
+
+“One cloudy moonlight night, in the third week of December (I think the
+twenty-second of the month) in the year 1757, I was walking on a retired
+part of the quay by the Seine for the refreshment of the frosty air,
+at an hour’s distance from my place of residence in the Street of the
+School of Medicine, when a carriage came along behind me, driven very
+fast. As I stood aside to let that carriage pass, apprehensive that it
+might otherwise run me down, a head was put out at the window, and a
+voice called to the driver to stop.
+
+“The carriage stopped as soon as the driver could rein in his horses,
+and the same voice called to me by my name. I answered. The carriage
+was then so far in advance of me that two gentlemen had time to open the
+door and alight before I came up with it.
+
+“I observed that they were both wrapped in cloaks, and appeared to
+conceal themselves. As they stood side by side near the carriage door,
+I also observed that they both looked of about my own age, or rather
+younger, and that they were greatly alike, in stature, manner, voice,
+and (as far as I could see) face too.
+
+“‘You are Doctor Manette?’ said one.
+
+“I am.”
+
+“‘Doctor Manette, formerly of Beauvais,’ said the other; ‘the young
+physician, originally an expert surgeon, who within the last year or two
+has made a rising reputation in Paris?’
+
+“‘Gentlemen,’ I returned, ‘I am that Doctor Manette of whom you speak so
+graciously.’
+
+“‘We have been to your residence,’ said the first, ‘and not being
+so fortunate as to find you there, and being informed that you were
+probably walking in this direction, we followed, in the hope of
+overtaking you. Will you please to enter the carriage?’
+
+“The manner of both was imperious, and they both moved, as these words
+were spoken, so as to place me between themselves and the carriage door.
+They were armed. I was not.
+
+“‘Gentlemen,’ said I, ‘pardon me; but I usually inquire who does me
+the honour to seek my assistance, and what is the nature of the case to
+which I am summoned.’
+
+“The reply to this was made by him who had spoken second. ‘Doctor,
+your clients are people of condition. As to the nature of the case,
+our confidence in your skill assures us that you will ascertain it for
+yourself better than we can describe it. Enough. Will you please to
+enter the carriage?’
+
+“I could do nothing but comply, and I entered it in silence. They both
+entered after me--the last springing in, after putting up the steps. The
+carriage turned about, and drove on at its former speed.
+
+“I repeat this conversation exactly as it occurred. I have no doubt that
+it is, word for word, the same. I describe everything exactly as it took
+place, constraining my mind not to wander from the task. Where I make
+the broken marks that follow here, I leave off for the time, and put my
+paper in its hiding-place.
+
+        *****
+
+“The carriage left the streets behind, passed the North Barrier, and
+emerged upon the country road. At two-thirds of a league from the
+Barrier--I did not estimate the distance at that time, but afterwards
+when I traversed it--it struck out of the main avenue, and presently
+stopped at a solitary house, We all three alighted, and walked, by
+a damp soft footpath in a garden where a neglected fountain had
+overflowed, to the door of the house. It was not opened immediately, in
+answer to the ringing of the bell, and one of my two conductors struck
+the man who opened it, with his heavy riding glove, across the face.
+
+“There was nothing in this action to attract my particular attention,
+for I had seen common people struck more commonly than dogs. But, the
+other of the two, being angry likewise, struck the man in like manner
+with his arm; the look and bearing of the brothers were then so exactly
+alike, that I then first perceived them to be twin brothers.
+
+“From the time of our alighting at the outer gate (which we found
+locked, and which one of the brothers had opened to admit us, and had
+relocked), I had heard cries proceeding from an upper chamber. I was
+conducted to this chamber straight, the cries growing louder as we
+ascended the stairs, and I found a patient in a high fever of the brain,
+lying on a bed.
+
+“The patient was a woman of great beauty, and young; assuredly not much
+past twenty. Her hair was torn and ragged, and her arms were bound to
+her sides with sashes and handkerchiefs. I noticed that these bonds were
+all portions of a gentleman’s dress. On one of them, which was a fringed
+scarf for a dress of ceremony, I saw the armorial bearings of a Noble,
+and the letter E.
+
+“I saw this, within the first minute of my contemplation of the patient;
+for, in her restless strivings she had turned over on her face on the
+edge of the bed, had drawn the end of the scarf into her mouth, and was
+in danger of suffocation. My first act was to put out my hand to relieve
+her breathing; and in moving the scarf aside, the embroidery in the
+corner caught my sight.
+
+“I turned her gently over, placed my hands upon her breast to calm her
+and keep her down, and looked into her face. Her eyes were dilated and
+wild, and she constantly uttered piercing shrieks, and repeated the
+words, ‘My husband, my father, and my brother!’ and then counted up to
+twelve, and said, ‘Hush!’ For an instant, and no more, she would pause
+to listen, and then the piercing shrieks would begin again, and she
+would repeat the cry, ‘My husband, my father, and my brother!’ and
+would count up to twelve, and say, ‘Hush!’ There was no variation in the
+order, or the manner. There was no cessation, but the regular moment’s
+pause, in the utterance of these sounds.
+
+“‘How long,’ I asked, ‘has this lasted?’
+
+“To distinguish the brothers, I will call them the elder and the
+younger; by the elder, I mean him who exercised the most authority. It
+was the elder who replied, ‘Since about this hour last night.’
+
+“‘She has a husband, a father, and a brother?’
+
+“‘A brother.’
+
+“‘I do not address her brother?’
+
+“He answered with great contempt, ‘No.’
+
+“‘She has some recent association with the number twelve?’
+
+“The younger brother impatiently rejoined, ‘With twelve o’clock?’
+
+“‘See, gentlemen,’ said I, still keeping my hands upon her breast, ‘how
+useless I am, as you have brought me! If I had known what I was coming
+to see, I could have come provided. As it is, time must be lost. There
+are no medicines to be obtained in this lonely place.’
+
+“The elder brother looked to the younger, who said haughtily, ‘There is
+a case of medicines here;’ and brought it from a closet, and put it on
+the table.
+
+        *****
+
+“I opened some of the bottles, smelt them, and put the stoppers to my
+lips. If I had wanted to use anything save narcotic medicines that were
+poisons in themselves, I would not have administered any of those.
+
+“‘Do you doubt them?’ asked the younger brother.
+
+“‘You see, monsieur, I am going to use them,’ I replied, and said no
+more.
+
+“I made the patient swallow, with great difficulty, and after many
+efforts, the dose that I desired to give. As I intended to repeat it
+after a while, and as it was necessary to watch its influence, I then
+sat down by the side of the bed. There was a timid and suppressed woman
+in attendance (wife of the man down-stairs), who had retreated into
+a corner. The house was damp and decayed, indifferently
+furnished--evidently, recently occupied and temporarily used. Some thick
+old hangings had been nailed up before the windows, to deaden the
+sound of the shrieks. They continued to be uttered in their regular
+succession, with the cry, ‘My husband, my father, and my brother!’ the
+counting up to twelve, and ‘Hush!’ The frenzy was so violent, that I had
+not unfastened the bandages restraining the arms; but, I had looked to
+them, to see that they were not painful. The only spark of encouragement
+in the case, was, that my hand upon the sufferer’s breast had this much
+soothing influence, that for minutes at a time it tranquillised the
+figure. It had no effect upon the cries; no pendulum could be more
+regular.
+
+“For the reason that my hand had this effect (I assume), I had sat by
+the side of the bed for half an hour, with the two brothers looking on,
+before the elder said:
+
+“‘There is another patient.’
+
+“I was startled, and asked, ‘Is it a pressing case?’
+
+“‘You had better see,’ he carelessly answered; and took up a light.
+
+        *****
+
+“The other patient lay in a back room across a second staircase, which
+was a species of loft over a stable. There was a low plastered ceiling
+to a part of it; the rest was open, to the ridge of the tiled roof, and
+there were beams across. Hay and straw were stored in that portion of
+the place, fagots for firing, and a heap of apples in sand. I had to
+pass through that part, to get at the other. My memory is circumstantial
+and unshaken. I try it with these details, and I see them all, in
+this my cell in the Bastille, near the close of the tenth year of my
+captivity, as I saw them all that night.
+
+“On some hay on the ground, with a cushion thrown under his head, lay a
+handsome peasant boy--a boy of not more than seventeen at the most.
+He lay on his back, with his teeth set, his right hand clenched on his
+breast, and his glaring eyes looking straight upward. I could not see
+where his wound was, as I kneeled on one knee over him; but, I could see
+that he was dying of a wound from a sharp point.
+
+“‘I am a doctor, my poor fellow,’ said I. ‘Let me examine it.’
+
+“‘I do not want it examined,’ he answered; ‘let it be.’
+
+“It was under his hand, and I soothed him to let me move his hand away.
+The wound was a sword-thrust, received from twenty to twenty-four hours
+before, but no skill could have saved him if it had been looked to
+without delay. He was then dying fast. As I turned my eyes to the elder
+brother, I saw him looking down at this handsome boy whose life was
+ebbing out, as if he were a wounded bird, or hare, or rabbit; not at all
+as if he were a fellow-creature.
+
+“‘How has this been done, monsieur?’ said I.
+
+“‘A crazed young common dog! A serf! Forced my brother to draw upon him,
+and has fallen by my brother’s sword--like a gentleman.’
+
+“There was no touch of pity, sorrow, or kindred humanity, in this
+answer. The speaker seemed to acknowledge that it was inconvenient to
+have that different order of creature dying there, and that it would
+have been better if he had died in the usual obscure routine of his
+vermin kind. He was quite incapable of any compassionate feeling about
+the boy, or about his fate.
+
+“The boy’s eyes had slowly moved to him as he had spoken, and they now
+slowly moved to me.
+
+“‘Doctor, they are very proud, these Nobles; but we common dogs are
+proud too, sometimes. They plunder us, outrage us, beat us, kill us; but
+we have a little pride left, sometimes. She--have you seen her, Doctor?’
+
+“The shrieks and the cries were audible there, though subdued by the
+distance. He referred to them, as if she were lying in our presence.
+
+“I said, ‘I have seen her.’
+
+“‘She is my sister, Doctor. They have had their shameful rights, these
+Nobles, in the modesty and virtue of our sisters, many years, but we
+have had good girls among us. I know it, and have heard my father say
+so. She was a good girl. She was betrothed to a good young man, too: a
+tenant of his. We were all tenants of his--that man’s who stands there.
+The other is his brother, the worst of a bad race.’
+
+“It was with the greatest difficulty that the boy gathered bodily force
+to speak; but, his spirit spoke with a dreadful emphasis.
+
+“‘We were so robbed by that man who stands there, as all we common dogs
+are by those superior Beings--taxed by him without mercy, obliged to
+work for him without pay, obliged to grind our corn at his mill, obliged
+to feed scores of his tame birds on our wretched crops, and forbidden
+for our lives to keep a single tame bird of our own, pillaged and
+plundered to that degree that when we chanced to have a bit of meat, we
+ate it in fear, with the door barred and the shutters closed, that his
+people should not see it and take it from us--I say, we were so robbed,
+and hunted, and were made so poor, that our father told us it was a
+dreadful thing to bring a child into the world, and that what we should
+most pray for, was, that our women might be barren and our miserable
+race die out!’
+
+“I had never before seen the sense of being oppressed, bursting forth
+like a fire. I had supposed that it must be latent in the people
+somewhere; but, I had never seen it break out, until I saw it in the
+dying boy.
+
+“‘Nevertheless, Doctor, my sister married. He was ailing at that time,
+poor fellow, and she married her lover, that she might tend and comfort
+him in our cottage--our dog-hut, as that man would call it. She had not
+been married many weeks, when that man’s brother saw her and admired
+her, and asked that man to lend her to him--for what are husbands among
+us! He was willing enough, but my sister was good and virtuous, and
+hated his brother with a hatred as strong as mine. What did the two
+then, to persuade her husband to use his influence with her, to make her
+willing?’
+
+“The boy’s eyes, which had been fixed on mine, slowly turned to the
+looker-on, and I saw in the two faces that all he said was true. The two
+opposing kinds of pride confronting one another, I can see, even in this
+Bastille; the gentleman’s, all negligent indifference; the peasant’s, all
+trodden-down sentiment, and passionate revenge.
+
+“‘You know, Doctor, that it is among the Rights of these Nobles to
+harness us common dogs to carts, and drive us. They so harnessed him and
+drove him. You know that it is among their Rights to keep us in their
+grounds all night, quieting the frogs, in order that their noble sleep
+may not be disturbed. They kept him out in the unwholesome mists at
+night, and ordered him back into his harness in the day. But he was
+not persuaded. No! Taken out of harness one day at noon, to feed--if he
+could find food--he sobbed twelve times, once for every stroke of the
+bell, and died on her bosom.’
+
+“Nothing human could have held life in the boy but his determination to
+tell all his wrong. He forced back the gathering shadows of death, as
+he forced his clenched right hand to remain clenched, and to cover his
+wound.
+
+“‘Then, with that man’s permission and even with his aid, his
+brother took her away; in spite of what I know she must have told his
+brother--and what that is, will not be long unknown to you, Doctor, if
+it is now--his brother took her away--for his pleasure and diversion,
+for a little while. I saw her pass me on the road. When I took the
+tidings home, our father’s heart burst; he never spoke one of the words
+that filled it. I took my young sister (for I have another) to a place
+beyond the reach of this man, and where, at least, she will never be
+_his_ vassal. Then, I tracked the brother here, and last night climbed
+in--a common dog, but sword in hand.--Where is the loft window? It was
+somewhere here?’
+
+“The room was darkening to his sight; the world was narrowing around
+him. I glanced about me, and saw that the hay and straw were trampled
+over the floor, as if there had been a struggle.
+
+“‘She heard me, and ran in. I told her not to come near us till he was
+dead. He came in and first tossed me some pieces of money; then struck
+at me with a whip. But I, though a common dog, so struck at him as to
+make him draw. Let him break into as many pieces as he will, the sword
+that he stained with my common blood; he drew to defend himself--thrust
+at me with all his skill for his life.’
+
+“My glance had fallen, but a few moments before, on the fragments of
+a broken sword, lying among the hay. That weapon was a gentleman’s. In
+another place, lay an old sword that seemed to have been a soldier’s.
+
+“‘Now, lift me up, Doctor; lift me up. Where is he?’
+
+“‘He is not here,’ I said, supporting the boy, and thinking that he
+referred to the brother.
+
+“‘He! Proud as these nobles are, he is afraid to see me. Where is the
+man who was here? Turn my face to him.’
+
+“I did so, raising the boy’s head against my knee. But, invested for the
+moment with extraordinary power, he raised himself completely: obliging
+me to rise too, or I could not have still supported him.
+
+“‘Marquis,’ said the boy, turned to him with his eyes opened wide, and
+his right hand raised, ‘in the days when all these things are to be
+answered for, I summon you and yours, to the last of your bad race, to
+answer for them. I mark this cross of blood upon you, as a sign that
+I do it. In the days when all these things are to be answered for,
+I summon your brother, the worst of the bad race, to answer for them
+separately. I mark this cross of blood upon him, as a sign that I do
+it.’
+
+“Twice, he put his hand to the wound in his breast, and with his
+forefinger drew a cross in the air. He stood for an instant with the
+finger yet raised, and as it dropped, he dropped with it, and I laid him
+down dead.
+
+        *****
+
+“When I returned to the bedside of the young woman, I found her raving
+in precisely the same order of continuity. I knew that this might last
+for many hours, and that it would probably end in the silence of the
+grave.
+
+“I repeated the medicines I had given her, and I sat at the side of
+the bed until the night was far advanced. She never abated the piercing
+quality of her shrieks, never stumbled in the distinctness or the order
+of her words. They were always ‘My husband, my father, and my brother!
+One, two, three, four, five, six, seven, eight, nine, ten, eleven,
+twelve. Hush!’
+
+“This lasted twenty-six hours from the time when I first saw her. I had
+come and gone twice, and was again sitting by her, when she began to
+falter. I did what little could be done to assist that opportunity, and
+by-and-bye she sank into a lethargy, and lay like the dead.
+
+“It was as if the wind and rain had lulled at last, after a long and
+fearful storm. I released her arms, and called the woman to assist me to
+compose her figure and the dress she had torn. It was then that I knew
+her condition to be that of one in whom the first expectations of being
+a mother have arisen; and it was then that I lost the little hope I had
+had of her.
+
+“‘Is she dead?’ asked the Marquis, whom I will still describe as the
+elder brother, coming booted into the room from his horse.
+
+“‘Not dead,’ said I; ‘but like to die.’
+
+“‘What strength there is in these common bodies!’ he said, looking down
+at her with some curiosity.
+
+“‘There is prodigious strength,’ I answered him, ‘in sorrow and
+despair.’
+
+“He first laughed at my words, and then frowned at them. He moved a
+chair with his foot near to mine, ordered the woman away, and said in a
+subdued voice,
+
+“‘Doctor, finding my brother in this difficulty with these hinds, I
+recommended that your aid should be invited. Your reputation is high,
+and, as a young man with your fortune to make, you are probably mindful
+of your interest. The things that you see here, are things to be seen,
+and not spoken of.’
+
+“I listened to the patient’s breathing, and avoided answering.
+
+“‘Do you honour me with your attention, Doctor?’
+
+“‘Monsieur,’ said I, ‘in my profession, the communications of patients
+are always received in confidence.’ I was guarded in my answer, for I
+was troubled in my mind with what I had heard and seen.
+
+“Her breathing was so difficult to trace, that I carefully tried the
+pulse and the heart. There was life, and no more. Looking round as I
+resumed my seat, I found both the brothers intent upon me.
+
+        *****
+
+“I write with so much difficulty, the cold is so severe, I am so
+fearful of being detected and consigned to an underground cell and total
+darkness, that I must abridge this narrative. There is no confusion or
+failure in my memory; it can recall, and could detail, every word that
+was ever spoken between me and those brothers.
+
+“She lingered for a week. Towards the last, I could understand some few
+syllables that she said to me, by placing my ear close to her lips. She
+asked me where she was, and I told her; who I was, and I told her. It
+was in vain that I asked her for her family name. She faintly shook her
+head upon the pillow, and kept her secret, as the boy had done.
+
+“I had no opportunity of asking her any question, until I had told the
+brothers she was sinking fast, and could not live another day. Until
+then, though no one was ever presented to her consciousness save the
+woman and myself, one or other of them had always jealously sat behind
+the curtain at the head of the bed when I was there. But when it came to
+that, they seemed careless what communication I might hold with her; as
+if--the thought passed through my mind--I were dying too.
+
+“I always observed that their pride bitterly resented the younger
+brother’s (as I call him) having crossed swords with a peasant, and that
+peasant a boy. The only consideration that appeared to affect the mind
+of either of them was the consideration that this was highly degrading
+to the family, and was ridiculous. As often as I caught the younger
+brother’s eyes, their expression reminded me that he disliked me deeply,
+for knowing what I knew from the boy. He was smoother and more polite to
+me than the elder; but I saw this. I also saw that I was an incumbrance
+in the mind of the elder, too.
+
+“My patient died, two hours before midnight--at a time, by my watch,
+answering almost to the minute when I had first seen her. I was alone
+with her, when her forlorn young head drooped gently on one side, and
+all her earthly wrongs and sorrows ended.
+
+“The brothers were waiting in a room down-stairs, impatient to ride
+away. I had heard them, alone at the bedside, striking their boots with
+their riding-whips, and loitering up and down.
+
+“‘At last she is dead?’ said the elder, when I went in.
+
+“‘She is dead,’ said I.
+
+“‘I congratulate you, my brother,’ were his words as he turned round.
+
+“He had before offered me money, which I had postponed taking. He now
+gave me a rouleau of gold. I took it from his hand, but laid it on
+the table. I had considered the question, and had resolved to accept
+nothing.
+
+“‘Pray excuse me,’ said I. ‘Under the circumstances, no.’
+
+“They exchanged looks, but bent their heads to me as I bent mine to
+them, and we parted without another word on either side.
+
+        *****
+
+“I am weary, weary, weary--worn down by misery. I cannot read what I
+have written with this gaunt hand.
+
+“Early in the morning, the rouleau of gold was left at my door in a
+little box, with my name on the outside. From the first, I had anxiously
+considered what I ought to do. I decided, that day, to write privately
+to the Minister, stating the nature of the two cases to which I had been
+summoned, and the place to which I had gone: in effect, stating all the
+circumstances. I knew what Court influence was, and what the immunities
+of the Nobles were, and I expected that the matter would never be
+heard of; but, I wished to relieve my own mind. I had kept the matter a
+profound secret, even from my wife; and this, too, I resolved to state
+in my letter. I had no apprehension whatever of my real danger; but
+I was conscious that there might be danger for others, if others were
+compromised by possessing the knowledge that I possessed.
+
+“I was much engaged that day, and could not complete my letter that
+night. I rose long before my usual time next morning to finish it.
+It was the last day of the year. The letter was lying before me just
+completed, when I was told that a lady waited, who wished to see me.
+
+        *****
+
+“I am growing more and more unequal to the task I have set myself. It is
+so cold, so dark, my senses are so benumbed, and the gloom upon me is so
+dreadful.
+
+“The lady was young, engaging, and handsome, but not marked for long
+life. She was in great agitation. She presented herself to me as the
+wife of the Marquis St. Evremonde. I connected the title by which the
+boy had addressed the elder brother, with the initial letter embroidered
+on the scarf, and had no difficulty in arriving at the conclusion that I
+had seen that nobleman very lately.
+
+“My memory is still accurate, but I cannot write the words of our
+conversation. I suspect that I am watched more closely than I was, and I
+know not at what times I may be watched. She had in part suspected, and
+in part discovered, the main facts of the cruel story, of her husband’s
+share in it, and my being resorted to. She did not know that the girl
+was dead. Her hope had been, she said in great distress, to show her,
+in secret, a woman’s sympathy. Her hope had been to avert the wrath of
+Heaven from a House that had long been hateful to the suffering many.
+
+“She had reasons for believing that there was a young sister living, and
+her greatest desire was, to help that sister. I could tell her nothing
+but that there was such a sister; beyond that, I knew nothing. Her
+inducement to come to me, relying on my confidence, had been the hope
+that I could tell her the name and place of abode. Whereas, to this
+wretched hour I am ignorant of both.
+
+        *****
+
+“These scraps of paper fail me. One was taken from me, with a warning,
+yesterday. I must finish my record to-day.
+
+“She was a good, compassionate lady, and not happy in her marriage. How
+could she be! The brother distrusted and disliked her, and his influence
+was all opposed to her; she stood in dread of him, and in dread of her
+husband too. When I handed her down to the door, there was a child, a
+pretty boy from two to three years old, in her carriage.
+
+“‘For his sake, Doctor,’ she said, pointing to him in tears, ‘I would do
+all I can to make what poor amends I can. He will never prosper in his
+inheritance otherwise. I have a presentiment that if no other innocent
+atonement is made for this, it will one day be required of him. What
+I have left to call my own--it is little beyond the worth of a few
+jewels--I will make it the first charge of his life to bestow, with the
+compassion and lamenting of his dead mother, on this injured family, if
+the sister can be discovered.’
+
+“She kissed the boy, and said, caressing him, ‘It is for thine own dear
+sake. Thou wilt be faithful, little Charles?’ The child answered her
+bravely, ‘Yes!’ I kissed her hand, and she took him in her arms, and
+went away caressing him. I never saw her more.
+
+“As she had mentioned her husband’s name in the faith that I knew it,
+I added no mention of it to my letter. I sealed my letter, and, not
+trusting it out of my own hands, delivered it myself that day.
+
+“That night, the last night of the year, towards nine o’clock, a man in
+a black dress rang at my gate, demanded to see me, and softly followed
+my servant, Ernest Defarge, a youth, up-stairs. When my servant came
+into the room where I sat with my wife--O my wife, beloved of my heart!
+My fair young English wife!--we saw the man, who was supposed to be at
+the gate, standing silent behind him.
+
+“An urgent case in the Rue St. Honore, he said. It would not detain me,
+he had a coach in waiting.
+
+“It brought me here, it brought me to my grave. When I was clear of the
+house, a black muffler was drawn tightly over my mouth from behind, and
+my arms were pinioned. The two brothers crossed the road from a dark
+corner, and identified me with a single gesture. The Marquis took from
+his pocket the letter I had written, showed it me, burnt it in the light
+of a lantern that was held, and extinguished the ashes with his foot.
+Not a word was spoken. I was brought here, I was brought to my living
+grave.
+
+“If it had pleased _God_ to put it in the hard heart of either of the
+brothers, in all these frightful years, to grant me any tidings of
+my dearest wife--so much as to let me know by a word whether alive or
+dead--I might have thought that He had not quite abandoned them. But,
+now I believe that the mark of the red cross is fatal to them, and that
+they have no part in His mercies. And them and their descendants, to the
+last of their race, I, Alexandre Manette, unhappy prisoner, do this last
+night of the year 1767, in my unbearable agony, denounce to the times
+when all these things shall be answered for. I denounce them to Heaven
+and to earth.”
+
+A terrible sound arose when the reading of this document was done. A
+sound of craving and eagerness that had nothing articulate in it but
+blood. The narrative called up the most revengeful passions of the time,
+and there was not a head in the nation but must have dropped before it.
+
+Little need, in presence of that tribunal and that auditory, to show
+how the Defarges had not made the paper public, with the other captured
+Bastille memorials borne in procession, and had kept it, biding their
+time. Little need to show that this detested family name had long been
+anathematised by Saint Antoine, and was wrought into the fatal register.
+The man never trod ground whose virtues and services would have
+sustained him in that place that day, against such denunciation.
+
+And all the worse for the doomed man, that the denouncer was a
+well-known citizen, his own attached friend, the father of his wife. One
+of the frenzied aspirations of the populace was, for imitations of
+the questionable public virtues of antiquity, and for sacrifices and
+self-immolations on the people’s altar. Therefore when the President
+said (else had his own head quivered on his shoulders), that the good
+physician of the Republic would deserve better still of the Republic by
+rooting out an obnoxious family of Aristocrats, and would doubtless feel
+a sacred glow and joy in making his daughter a widow and her child an
+orphan, there was wild excitement, patriotic fervour, not a touch of
+human sympathy.
+
+“Much influence around him, has that Doctor?” murmured Madame Defarge,
+smiling to The Vengeance. “Save him now, my Doctor, save him!”
+
+At every juryman’s vote, there was a roar. Another and another. Roar and
+roar.
+
+Unanimously voted. At heart and by descent an Aristocrat, an enemy
+of the Republic, a notorious oppressor of the People. Back to the
+Conciergerie, and Death within four-and-twenty hours!
+
+
+
+
+XI. Dusk
+
+
+The wretched wife of the innocent man thus doomed to die, fell under
+the sentence, as if she had been mortally stricken. But, she uttered no
+sound; and so strong was the voice within her, representing that it was
+she of all the world who must uphold him in his misery and not augment
+it, that it quickly raised her, even from that shock.
+
+The Judges having to take part in a public demonstration out of doors,
+the Tribunal adjourned. The quick noise and movement of the court’s
+emptying itself by many passages had not ceased, when Lucie stood
+stretching out her arms towards her husband, with nothing in her face
+but love and consolation.
+
+“If I might touch him! If I might embrace him once! O, good citizens, if
+you would have so much compassion for us!”
+
+There was but a gaoler left, along with two of the four men who had
+taken him last night, and Barsad. The people had all poured out to the
+show in the streets. Barsad proposed to the rest, “Let her embrace
+him then; it is but a moment.” It was silently acquiesced in, and they
+passed her over the seats in the hall to a raised place, where he, by
+leaning over the dock, could fold her in his arms.
+
+“Farewell, dear darling of my soul. My parting blessing on my love. We
+shall meet again, where the weary are at rest!”
+
+They were her husband’s words, as he held her to his bosom.
+
+“I can bear it, dear Charles. I am supported from above: don’t suffer
+for me. A parting blessing for our child.”
+
+“I send it to her by you. I kiss her by you. I say farewell to her by
+you.”
+
+“My husband. No! A moment!” He was tearing himself apart from her.
+“We shall not be separated long. I feel that this will break my heart
+by-and-bye; but I will do my duty while I can, and when I leave her, God
+will raise up friends for her, as He did for me.”
+
+Her father had followed her, and would have fallen on his knees to both
+of them, but that Darnay put out a hand and seized him, crying:
+
+“No, no! What have you done, what have you done, that you should kneel
+to us! We know now, what a struggle you made of old. We know, now what
+you underwent when you suspected my descent, and when you knew it. We
+know now, the natural antipathy you strove against, and conquered, for
+her dear sake. We thank you with all our hearts, and all our love and
+duty. Heaven be with you!”
+
+Her father’s only answer was to draw his hands through his white hair,
+and wring them with a shriek of anguish.
+
+“It could not be otherwise,” said the prisoner. “All things have worked
+together as they have fallen out. It was the always-vain endeavour to
+discharge my poor mother’s trust that first brought my fatal presence
+near you. Good could never come of such evil, a happier end was not in
+nature to so unhappy a beginning. Be comforted, and forgive me. Heaven
+bless you!”
+
+As he was drawn away, his wife released him, and stood looking after him
+with her hands touching one another in the attitude of prayer, and
+with a radiant look upon her face, in which there was even a comforting
+smile. As he went out at the prisoners’ door, she turned, laid her head
+lovingly on her father’s breast, tried to speak to him, and fell at his
+feet.
+
+Then, issuing from the obscure corner from which he had never moved,
+Sydney Carton came and took her up. Only her father and Mr. Lorry were
+with her. His arm trembled as it raised her, and supported her head.
+Yet, there was an air about him that was not all of pity--that had a
+flush of pride in it.
+
+“Shall I take her to a coach? I shall never feel her weight.”
+
+He carried her lightly to the door, and laid her tenderly down in a
+coach. Her father and their old friend got into it, and he took his seat
+beside the driver.
+
+When they arrived at the gateway where he had paused in the dark not
+many hours before, to picture to himself on which of the rough stones of
+the street her feet had trodden, he lifted her again, and carried her up
+the staircase to their rooms. There, he laid her down on a couch, where
+her child and Miss Pross wept over her.
+
+“Don’t recall her to herself,” he said, softly, to the latter, “she is
+better so. Don’t revive her to consciousness, while she only faints.”
+
+“Oh, Carton, Carton, dear Carton!” cried little Lucie, springing up and
+throwing her arms passionately round him, in a burst of grief. “Now that
+you have come, I think you will do something to help mamma, something to
+save papa! O, look at her, dear Carton! Can you, of all the people who
+love her, bear to see her so?”
+
+He bent over the child, and laid her blooming cheek against his face. He
+put her gently from him, and looked at her unconscious mother.
+
+“Before I go,” he said, and paused--“I may kiss her?”
+
+It was remembered afterwards that when he bent down and touched her face
+with his lips, he murmured some words. The child, who was nearest to
+him, told them afterwards, and told her grandchildren when she was a
+handsome old lady, that she heard him say, “A life you love.”
+
+When he had gone out into the next room, he turned suddenly on Mr. Lorry
+and her father, who were following, and said to the latter:
+
+“You had great influence but yesterday, Doctor Manette; let it at least
+be tried. These judges, and all the men in power, are very friendly to
+you, and very recognisant of your services; are they not?”
+
+“Nothing connected with Charles was concealed from me. I had the
+strongest assurances that I should save him; and I did.” He returned the
+answer in great trouble, and very slowly.
+
+“Try them again. The hours between this and to-morrow afternoon are few
+and short, but try.”
+
+“I intend to try. I will not rest a moment.”
+
+“That’s well. I have known such energy as yours do great things before
+now--though never,” he added, with a smile and a sigh together, “such
+great things as this. But try! Of little worth as life is when we misuse
+it, it is worth that effort. It would cost nothing to lay down if it
+were not.”
+
+“I will go,” said Doctor Manette, “to the Prosecutor and the President
+straight, and I will go to others whom it is better not to name. I will
+write too, and--But stay! There is a Celebration in the streets, and no
+one will be accessible until dark.”
+
+“That’s true. Well! It is a forlorn hope at the best, and not much the
+forlorner for being delayed till dark. I should like to know how you
+speed; though, mind! I expect nothing! When are you likely to have seen
+these dread powers, Doctor Manette?”
+
+“Immediately after dark, I should hope. Within an hour or two from
+this.”
+
+“It will be dark soon after four. Let us stretch the hour or two. If I
+go to Mr. Lorry’s at nine, shall I hear what you have done, either from
+our friend or from yourself?”
+
+“Yes.”
+
+“May you prosper!”
+
+Mr. Lorry followed Sydney to the outer door, and, touching him on the
+shoulder as he was going away, caused him to turn.
+
+“I have no hope,” said Mr. Lorry, in a low and sorrowful whisper.
+
+“Nor have I.”
+
+“If any one of these men, or all of these men, were disposed to spare
+him--which is a large supposition; for what is his life, or any man’s
+to them!--I doubt if they durst spare him after the demonstration in the
+court.”
+
+“And so do I. I heard the fall of the axe in that sound.”
+
+Mr. Lorry leaned his arm upon the door-post, and bowed his face upon it.
+
+“Don’t despond,” said Carton, very gently; “don’t grieve. I encouraged
+Doctor Manette in this idea, because I felt that it might one day be
+consolatory to her. Otherwise, she might think ‘his life was wantonly
+thrown away or wasted,’ and that might trouble her.”
+
+“Yes, yes, yes,” returned Mr. Lorry, drying his eyes, “you are right.
+But he will perish; there is no real hope.”
+
+“Yes. He will perish: there is no real hope,” echoed Carton.
+
+And walked with a settled step, down-stairs.
+
+
+
+
+XII. Darkness
+
+
+Sydney Carton paused in the street, not quite decided where to go. “At
+Tellson’s banking-house at nine,” he said, with a musing face. “Shall I
+do well, in the mean time, to show myself? I think so. It is best that
+these people should know there is such a man as I here; it is a sound
+precaution, and may be a necessary preparation. But care, care, care!
+Let me think it out!”
+
+Checking his steps which had begun to tend towards an object, he took a
+turn or two in the already darkening street, and traced the thought
+in his mind to its possible consequences. His first impression was
+confirmed. “It is best,” he said, finally resolved, “that these people
+should know there is such a man as I here.” And he turned his face
+towards Saint Antoine.
+
+Defarge had described himself, that day, as the keeper of a wine-shop in
+the Saint Antoine suburb. It was not difficult for one who knew the city
+well, to find his house without asking any question. Having ascertained
+its situation, Carton came out of those closer streets again, and dined
+at a place of refreshment and fell sound asleep after dinner. For the
+first time in many years, he had no strong drink. Since last night he
+had taken nothing but a little light thin wine, and last night he had
+dropped the brandy slowly down on Mr. Lorry’s hearth like a man who had
+done with it.
+
+It was as late as seven o’clock when he awoke refreshed, and went out
+into the streets again. As he passed along towards Saint Antoine, he
+stopped at a shop-window where there was a mirror, and slightly altered
+the disordered arrangement of his loose cravat, and his coat-collar, and
+his wild hair. This done, he went on direct to Defarge’s, and went in.
+
+There happened to be no customer in the shop but Jacques Three, of the
+restless fingers and the croaking voice. This man, whom he had seen upon
+the Jury, stood drinking at the little counter, in conversation with the
+Defarges, man and wife. The Vengeance assisted in the conversation, like
+a regular member of the establishment.
+
+As Carton walked in, took his seat and asked (in very indifferent
+French) for a small measure of wine, Madame Defarge cast a careless
+glance at him, and then a keener, and then a keener, and then advanced
+to him herself, and asked him what it was he had ordered.
+
+He repeated what he had already said.
+
+“English?” asked Madame Defarge, inquisitively raising her dark
+eyebrows.
+
+After looking at her, as if the sound of even a single French word were
+slow to express itself to him, he answered, in his former strong foreign
+accent. “Yes, madame, yes. I am English!”
+
+Madame Defarge returned to her counter to get the wine, and, as he
+took up a Jacobin journal and feigned to pore over it puzzling out its
+meaning, he heard her say, “I swear to you, like Evremonde!”
+
+Defarge brought him the wine, and gave him Good Evening.
+
+“How?”
+
+“Good evening.”
+
+“Oh! Good evening, citizen,” filling his glass. “Ah! and good wine. I
+drink to the Republic.”
+
+Defarge went back to the counter, and said, “Certainly, a little like.”
+ Madame sternly retorted, “I tell you a good deal like.” Jacques Three
+pacifically remarked, “He is so much in your mind, see you, madame.”
+ The amiable Vengeance added, with a laugh, “Yes, my faith! And you
+are looking forward with so much pleasure to seeing him once more
+to-morrow!”
+
+Carton followed the lines and words of his paper, with a slow
+forefinger, and with a studious and absorbed face. They were all leaning
+their arms on the counter close together, speaking low. After a silence
+of a few moments, during which they all looked towards him without
+disturbing his outward attention from the Jacobin editor, they resumed
+their conversation.
+
+“It is true what madame says,” observed Jacques Three. “Why stop? There
+is great force in that. Why stop?”
+
+“Well, well,” reasoned Defarge, “but one must stop somewhere. After all,
+the question is still where?”
+
+“At extermination,” said madame.
+
+“Magnificent!” croaked Jacques Three. The Vengeance, also, highly
+approved.
+
+“Extermination is good doctrine, my wife,” said Defarge, rather
+troubled; “in general, I say nothing against it. But this Doctor has
+suffered much; you have seen him to-day; you have observed his face when
+the paper was read.”
+
+“I have observed his face!” repeated madame, contemptuously and angrily.
+“Yes. I have observed his face. I have observed his face to be not the
+face of a true friend of the Republic. Let him take care of his face!”
+
+“And you have observed, my wife,” said Defarge, in a deprecatory manner,
+“the anguish of his daughter, which must be a dreadful anguish to him!”
+
+“I have observed his daughter,” repeated madame; “yes, I have observed
+his daughter, more times than one. I have observed her to-day, and I
+have observed her other days. I have observed her in the court, and
+I have observed her in the street by the prison. Let me but lift my
+finger--!” She seemed to raise it (the listener’s eyes were always on
+his paper), and to let it fall with a rattle on the ledge before her, as
+if the axe had dropped.
+
+“The citizeness is superb!” croaked the Juryman.
+
+“She is an Angel!” said The Vengeance, and embraced her.
+
+“As to thee,” pursued madame, implacably, addressing her husband, “if it
+depended on thee--which, happily, it does not--thou wouldst rescue this
+man even now.”
+
+“No!” protested Defarge. “Not if to lift this glass would do it! But I
+would leave the matter there. I say, stop there.”
+
+“See you then, Jacques,” said Madame Defarge, wrathfully; “and see you,
+too, my little Vengeance; see you both! Listen! For other crimes as
+tyrants and oppressors, I have this race a long time on my register,
+doomed to destruction and extermination. Ask my husband, is that so.”
+
+“It is so,” assented Defarge, without being asked.
+
+“In the beginning of the great days, when the Bastille falls, he finds
+this paper of to-day, and he brings it home, and in the middle of the
+night when this place is clear and shut, we read it, here on this spot,
+by the light of this lamp. Ask him, is that so.”
+
+“It is so,” assented Defarge.
+
+“That night, I tell him, when the paper is read through, and the lamp is
+burnt out, and the day is gleaming in above those shutters and between
+those iron bars, that I have now a secret to communicate. Ask him, is
+that so.”
+
+“It is so,” assented Defarge again.
+
+“I communicate to him that secret. I smite this bosom with these two
+hands as I smite it now, and I tell him, ‘Defarge, I was brought up
+among the fishermen of the sea-shore, and that peasant family so injured
+by the two Evremonde brothers, as that Bastille paper describes, is my
+family. Defarge, that sister of the mortally wounded boy upon the ground
+was my sister, that husband was my sister’s husband, that unborn child
+was their child, that brother was my brother, that father was my father,
+those dead are my dead, and that summons to answer for those things
+descends to me!’ Ask him, is that so.”
+
+“It is so,” assented Defarge once more.
+
+“Then tell Wind and Fire where to stop,” returned madame; “but don’t
+tell me.”
+
+Both her hearers derived a horrible enjoyment from the deadly nature
+of her wrath--the listener could feel how white she was, without seeing
+her--and both highly commended it. Defarge, a weak minority, interposed
+a few words for the memory of the compassionate wife of the Marquis; but
+only elicited from his own wife a repetition of her last reply. “Tell
+the Wind and the Fire where to stop; not me!”
+
+Customers entered, and the group was broken up. The English customer
+paid for what he had had, perplexedly counted his change, and asked, as
+a stranger, to be directed towards the National Palace. Madame Defarge
+took him to the door, and put her arm on his, in pointing out the road.
+The English customer was not without his reflections then, that it might
+be a good deed to seize that arm, lift it, and strike under it sharp and
+deep.
+
+But, he went his way, and was soon swallowed up in the shadow of the
+prison wall. At the appointed hour, he emerged from it to present
+himself in Mr. Lorry’s room again, where he found the old gentleman
+walking to and fro in restless anxiety. He said he had been with Lucie
+until just now, and had only left her for a few minutes, to come and
+keep his appointment. Her father had not been seen, since he quitted the
+banking-house towards four o’clock. She had some faint hopes that his
+mediation might save Charles, but they were very slight. He had been
+more than five hours gone: where could he be?
+
+Mr. Lorry waited until ten; but, Doctor Manette not returning, and
+he being unwilling to leave Lucie any longer, it was arranged that he
+should go back to her, and come to the banking-house again at midnight.
+In the meanwhile, Carton would wait alone by the fire for the Doctor.
+
+He waited and waited, and the clock struck twelve; but Doctor Manette
+did not come back. Mr. Lorry returned, and found no tidings of him, and
+brought none. Where could he be?
+
+They were discussing this question, and were almost building up some
+weak structure of hope on his prolonged absence, when they heard him on
+the stairs. The instant he entered the room, it was plain that all was
+lost.
+
+Whether he had really been to any one, or whether he had been all that
+time traversing the streets, was never known. As he stood staring at
+them, they asked him no question, for his face told them everything.
+
+“I cannot find it,” said he, “and I must have it. Where is it?”
+
+His head and throat were bare, and, as he spoke with a helpless look
+straying all around, he took his coat off, and let it drop on the floor.
+
+“Where is my bench? I have been looking everywhere for my bench, and I
+can’t find it. What have they done with my work? Time presses: I must
+finish those shoes.”
+
+They looked at one another, and their hearts died within them.
+
+“Come, come!” said he, in a whimpering miserable way; “let me get to
+work. Give me my work.”
+
+Receiving no answer, he tore his hair, and beat his feet upon the
+ground, like a distracted child.
+
+“Don’t torture a poor forlorn wretch,” he implored them, with a dreadful
+cry; “but give me my work! What is to become of us, if those shoes are
+not done to-night?”
+
+Lost, utterly lost!
+
+It was so clearly beyond hope to reason with him, or try to restore him,
+that--as if by agreement--they each put a hand upon his shoulder, and
+soothed him to sit down before the fire, with a promise that he should
+have his work presently. He sank into the chair, and brooded over the
+embers, and shed tears. As if all that had happened since the garret
+time were a momentary fancy, or a dream, Mr. Lorry saw him shrink into
+the exact figure that Defarge had had in keeping.
+
+Affected, and impressed with terror as they both were, by this spectacle
+of ruin, it was not a time to yield to such emotions. His lonely
+daughter, bereft of her final hope and reliance, appealed to them both
+too strongly. Again, as if by agreement, they looked at one another with
+one meaning in their faces. Carton was the first to speak:
+
+“The last chance is gone: it was not much. Yes; he had better be taken
+to her. But, before you go, will you, for a moment, steadily attend to
+me? Don’t ask me why I make the stipulations I am going to make, and
+exact the promise I am going to exact; I have a reason--a good one.”
+
+“I do not doubt it,” answered Mr. Lorry. “Say on.”
+
+The figure in the chair between them, was all the time monotonously
+rocking itself to and fro, and moaning. They spoke in such a tone as
+they would have used if they had been watching by a sick-bed in the
+night.
+
+Carton stooped to pick up the coat, which lay almost entangling his
+feet. As he did so, a small case in which the Doctor was accustomed to
+carry the lists of his day’s duties, fell lightly on the floor. Carton
+took it up, and there was a folded paper in it. “We should look
+at this!” he said. Mr. Lorry nodded his consent. He opened it, and
+exclaimed, “Thank _God!_”
+
+“What is it?” asked Mr. Lorry, eagerly.
+
+“A moment! Let me speak of it in its place. First,” he put his hand in
+his coat, and took another paper from it, “that is the certificate which
+enables me to pass out of this city. Look at it. You see--Sydney Carton,
+an Englishman?”
+
+Mr. Lorry held it open in his hand, gazing in his earnest face.
+
+“Keep it for me until to-morrow. I shall see him to-morrow, you
+remember, and I had better not take it into the prison.”
+
+“Why not?”
+
+“I don’t know; I prefer not to do so. Now, take this paper that Doctor
+Manette has carried about him. It is a similar certificate, enabling him
+and his daughter and her child, at any time, to pass the barrier and the
+frontier! You see?”
+
+“Yes!”
+
+“Perhaps he obtained it as his last and utmost precaution against evil,
+yesterday. When is it dated? But no matter; don’t stay to look; put it
+up carefully with mine and your own. Now, observe! I never doubted until
+within this hour or two, that he had, or could have such a paper. It is
+good, until recalled. But it may be soon recalled, and, I have reason to
+think, will be.”
+
+“They are not in danger?”
+
+“They are in great danger. They are in danger of denunciation by Madame
+Defarge. I know it from her own lips. I have overheard words of that
+woman’s, to-night, which have presented their danger to me in strong
+colours. I have lost no time, and since then, I have seen the spy. He
+confirms me. He knows that a wood-sawyer, living by the prison wall,
+is under the control of the Defarges, and has been rehearsed by
+Madame Defarge as to his having seen Her”--he never mentioned Lucie’s
+name--“making signs and signals to prisoners. It is easy to foresee that
+the pretence will be the common one, a prison plot, and that it will
+involve her life--and perhaps her child’s--and perhaps her father’s--for
+both have been seen with her at that place. Don’t look so horrified. You
+will save them all.”
+
+“Heaven grant I may, Carton! But how?”
+
+“I am going to tell you how. It will depend on you, and it could depend
+on no better man. This new denunciation will certainly not take place
+until after to-morrow; probably not until two or three days afterwards;
+more probably a week afterwards. You know it is a capital crime, to
+mourn for, or sympathise with, a victim of the Guillotine. She and her
+father would unquestionably be guilty of this crime, and this woman (the
+inveteracy of whose pursuit cannot be described) would wait to add that
+strength to her case, and make herself doubly sure. You follow me?”
+
+“So attentively, and with so much confidence in what you say, that for
+the moment I lose sight,” touching the back of the Doctor’s chair, “even
+of this distress.”
+
+“You have money, and can buy the means of travelling to the seacoast
+as quickly as the journey can be made. Your preparations have been
+completed for some days, to return to England. Early to-morrow have your
+horses ready, so that they may be in starting trim at two o’clock in the
+afternoon.”
+
+“It shall be done!”
+
+His manner was so fervent and inspiring, that Mr. Lorry caught the
+flame, and was as quick as youth.
+
+“You are a noble heart. Did I say we could depend upon no better man?
+Tell her, to-night, what you know of her danger as involving her child
+and her father. Dwell upon that, for she would lay her own fair head
+beside her husband’s cheerfully.” He faltered for an instant; then went
+on as before. “For the sake of her child and her father, press upon her
+the necessity of leaving Paris, with them and you, at that hour. Tell
+her that it was her husband’s last arrangement. Tell her that more
+depends upon it than she dare believe, or hope. You think that her
+father, even in this sad state, will submit himself to her; do you not?”
+
+“I am sure of it.”
+
+“I thought so. Quietly and steadily have all these arrangements made in
+the courtyard here, even to the taking of your own seat in the carriage.
+The moment I come to you, take me in, and drive away.”
+
+“I understand that I wait for you under all circumstances?”
+
+“You have my certificate in your hand with the rest, you know, and will
+reserve my place. Wait for nothing but to have my place occupied, and
+then for England!”
+
+“Why, then,” said Mr. Lorry, grasping his eager but so firm and steady
+hand, “it does not all depend on one old man, but I shall have a young
+and ardent man at my side.”
+
+“By the help of Heaven you shall! Promise me solemnly that nothing will
+influence you to alter the course on which we now stand pledged to one
+another.”
+
+“Nothing, Carton.”
+
+“Remember these words to-morrow: change the course, or delay in it--for
+any reason--and no life can possibly be saved, and many lives must
+inevitably be sacrificed.”
+
+“I will remember them. I hope to do my part faithfully.”
+
+“And I hope to do mine. Now, good bye!”
+
+Though he said it with a grave smile of earnestness, and though he even
+put the old man’s hand to his lips, he did not part from him then. He
+helped him so far to arouse the rocking figure before the dying embers,
+as to get a cloak and hat put upon it, and to tempt it forth to find
+where the bench and work were hidden that it still moaningly besought
+to have. He walked on the other side of it and protected it to the
+courtyard of the house where the afflicted heart--so happy in
+the memorable time when he had revealed his own desolate heart to
+it--outwatched the awful night. He entered the courtyard and remained
+there for a few moments alone, looking up at the light in the window of
+her room. Before he went away, he breathed a blessing towards it, and a
+Farewell.
+
+
+
+
+XIII. Fifty-two
+
+
+In the black prison of the Conciergerie, the doomed of the day awaited
+their fate. They were in number as the weeks of the year. Fifty-two were
+to roll that afternoon on the life-tide of the city to the boundless
+everlasting sea. Before their cells were quit of them, new occupants
+were appointed; before their blood ran into the blood spilled yesterday,
+the blood that was to mingle with theirs to-morrow was already set
+apart.
+
+Two score and twelve were told off. From the farmer-general of seventy,
+whose riches could not buy his life, to the seamstress of twenty, whose
+poverty and obscurity could not save her. Physical diseases, engendered
+in the vices and neglects of men, will seize on victims of all degrees;
+and the frightful moral disorder, born of unspeakable suffering,
+intolerable oppression, and heartless indifference, smote equally
+without distinction.
+
+Charles Darnay, alone in a cell, had sustained himself with no
+flattering delusion since he came to it from the Tribunal. In every line
+of the narrative he had heard, he had heard his condemnation. He had
+fully comprehended that no personal influence could possibly save him,
+that he was virtually sentenced by the millions, and that units could
+avail him nothing.
+
+Nevertheless, it was not easy, with the face of his beloved wife fresh
+before him, to compose his mind to what it must bear. His hold on life
+was strong, and it was very, very hard, to loosen; by gradual efforts
+and degrees unclosed a little here, it clenched the tighter there; and
+when he brought his strength to bear on that hand and it yielded,
+this was closed again. There was a hurry, too, in all his thoughts,
+a turbulent and heated working of his heart, that contended against
+resignation. If, for a moment, he did feel resigned, then his wife and
+child who had to live after him, seemed to protest and to make it a
+selfish thing.
+
+But, all this was at first. Before long, the consideration that there
+was no disgrace in the fate he must meet, and that numbers went the same
+road wrongfully, and trod it firmly every day, sprang up to stimulate
+him. Next followed the thought that much of the future peace of mind
+enjoyable by the dear ones, depended on his quiet fortitude. So,
+by degrees he calmed into the better state, when he could raise his
+thoughts much higher, and draw comfort down.
+
+Before it had set in dark on the night of his condemnation, he had
+travelled thus far on his last way. Being allowed to purchase the means
+of writing, and a light, he sat down to write until such time as the
+prison lamps should be extinguished.
+
+He wrote a long letter to Lucie, showing her that he had known nothing
+of her father’s imprisonment, until he had heard of it from herself,
+and that he had been as ignorant as she of his father’s and uncle’s
+responsibility for that misery, until the paper had been read. He had
+already explained to her that his concealment from herself of the name
+he had relinquished, was the one condition--fully intelligible now--that
+her father had attached to their betrothal, and was the one promise he
+had still exacted on the morning of their marriage. He entreated her,
+for her father’s sake, never to seek to know whether her father had
+become oblivious of the existence of the paper, or had had it recalled
+to him (for the moment, or for good), by the story of the Tower, on
+that old Sunday under the dear old plane-tree in the garden. If he had
+preserved any definite remembrance of it, there could be no doubt that
+he had supposed it destroyed with the Bastille, when he had found no
+mention of it among the relics of prisoners which the populace had
+discovered there, and which had been described to all the world. He
+besought her--though he added that he knew it was needless--to console
+her father, by impressing him through every tender means she could think
+of, with the truth that he had done nothing for which he could justly
+reproach himself, but had uniformly forgotten himself for their joint
+sakes. Next to her preservation of his own last grateful love and
+blessing, and her overcoming of her sorrow, to devote herself to their
+dear child, he adjured her, as they would meet in Heaven, to comfort her
+father.
+
+To her father himself, he wrote in the same strain; but, he told her
+father that he expressly confided his wife and child to his care. And
+he told him this, very strongly, with the hope of rousing him from any
+despondency or dangerous retrospect towards which he foresaw he might be
+tending.
+
+To Mr. Lorry, he commended them all, and explained his worldly affairs.
+That done, with many added sentences of grateful friendship and warm
+attachment, all was done. He never thought of Carton. His mind was so
+full of the others, that he never once thought of him.
+
+He had time to finish these letters before the lights were put out. When
+he lay down on his straw bed, he thought he had done with this world.
+
+But, it beckoned him back in his sleep, and showed itself in shining
+forms. Free and happy, back in the old house in Soho (though it had
+nothing in it like the real house), unaccountably released and light of
+heart, he was with Lucie again, and she told him it was all a dream, and
+he had never gone away. A pause of forgetfulness, and then he had even
+suffered, and had come back to her, dead and at peace, and yet there
+was no difference in him. Another pause of oblivion, and he awoke in the
+sombre morning, unconscious where he was or what had happened, until it
+flashed upon his mind, “this is the day of my death!”
+
+Thus, had he come through the hours, to the day when the fifty-two heads
+were to fall. And now, while he was composed, and hoped that he could
+meet the end with quiet heroism, a new action began in his waking
+thoughts, which was very difficult to master.
+
+He had never seen the instrument that was to terminate his life. How
+high it was from the ground, how many steps it had, where he would be
+stood, how he would be touched, whether the touching hands would be dyed
+red, which way his face would be turned, whether he would be the first,
+or might be the last: these and many similar questions, in nowise
+directed by his will, obtruded themselves over and over again, countless
+times. Neither were they connected with fear: he was conscious of no
+fear. Rather, they originated in a strange besetting desire to know what
+to do when the time came; a desire gigantically disproportionate to the
+few swift moments to which it referred; a wondering that was more like
+the wondering of some other spirit within his, than his own.
+
+The hours went on as he walked to and fro, and the clocks struck the
+numbers he would never hear again. Nine gone for ever, ten gone for
+ever, eleven gone for ever, twelve coming on to pass away. After a hard
+contest with that eccentric action of thought which had last perplexed
+him, he had got the better of it. He walked up and down, softly
+repeating their names to himself. The worst of the strife was over.
+He could walk up and down, free from distracting fancies, praying for
+himself and for them.
+
+Twelve gone for ever.
+
+He had been apprised that the final hour was Three, and he knew he would
+be summoned some time earlier, inasmuch as the tumbrils jolted heavily
+and slowly through the streets. Therefore, he resolved to keep Two
+before his mind, as the hour, and so to strengthen himself in the
+interval that he might be able, after that time, to strengthen others.
+
+Walking regularly to and fro with his arms folded on his breast, a very
+different man from the prisoner, who had walked to and fro at La Force,
+he heard One struck away from him, without surprise. The hour had
+measured like most other hours. Devoutly thankful to Heaven for his
+recovered self-possession, he thought, “There is but another now,” and
+turned to walk again.
+
+Footsteps in the stone passage outside the door. He stopped.
+
+The key was put in the lock, and turned. Before the door was opened, or
+as it opened, a man said in a low voice, in English: “He has never seen
+me here; I have kept out of his way. Go you in alone; I wait near. Lose
+no time!”
+
+The door was quickly opened and closed, and there stood before him
+face to face, quiet, intent upon him, with the light of a smile on his
+features, and a cautionary finger on his lip, Sydney Carton.
+
+There was something so bright and remarkable in his look, that, for the
+first moment, the prisoner misdoubted him to be an apparition of his own
+imagining. But, he spoke, and it was his voice; he took the prisoner’s
+hand, and it was his real grasp.
+
+“Of all the people upon earth, you least expected to see me?” he said.
+
+“I could not believe it to be you. I can scarcely believe it now. You
+are not”--the apprehension came suddenly into his mind--“a prisoner?”
+
+“No. I am accidentally possessed of a power over one of the keepers
+here, and in virtue of it I stand before you. I come from her--your
+wife, dear Darnay.”
+
+The prisoner wrung his hand.
+
+“I bring you a request from her.”
+
+“What is it?”
+
+“A most earnest, pressing, and emphatic entreaty, addressed to you
+in the most pathetic tones of the voice so dear to you, that you well
+remember.”
+
+The prisoner turned his face partly aside.
+
+“You have no time to ask me why I bring it, or what it means; I have
+no time to tell you. You must comply with it--take off those boots you
+wear, and draw on these of mine.”
+
+There was a chair against the wall of the cell, behind the prisoner.
+Carton, pressing forward, had already, with the speed of lightning, got
+him down into it, and stood over him, barefoot.
+
+“Draw on these boots of mine. Put your hands to them; put your will to
+them. Quick!”
+
+“Carton, there is no escaping from this place; it never can be done. You
+will only die with me. It is madness.”
+
+“It would be madness if I asked you to escape; but do I? When I ask you
+to pass out at that door, tell me it is madness and remain here. Change
+that cravat for this of mine, that coat for this of mine. While you do
+it, let me take this ribbon from your hair, and shake out your hair like
+this of mine!”
+
+With wonderful quickness, and with a strength both of will and action,
+that appeared quite supernatural, he forced all these changes upon him.
+The prisoner was like a young child in his hands.
+
+“Carton! Dear Carton! It is madness. It cannot be accomplished, it never
+can be done, it has been attempted, and has always failed. I implore you
+not to add your death to the bitterness of mine.”
+
+“Do I ask you, my dear Darnay, to pass the door? When I ask that,
+refuse. There are pen and ink and paper on this table. Is your hand
+steady enough to write?”
+
+“It was when you came in.”
+
+“Steady it again, and write what I shall dictate. Quick, friend, quick!”
+
+Pressing his hand to his bewildered head, Darnay sat down at the table.
+Carton, with his right hand in his breast, stood close beside him.
+
+“Write exactly as I speak.”
+
+“To whom do I address it?”
+
+“To no one.” Carton still had his hand in his breast.
+
+“Do I date it?”
+
+“No.”
+
+The prisoner looked up, at each question. Carton, standing over him with
+his hand in his breast, looked down.
+
+“‘If you remember,’” said Carton, dictating, “‘the words that passed
+between us, long ago, you will readily comprehend this when you see it.
+You do remember them, I know. It is not in your nature to forget them.’”
+
+He was drawing his hand from his breast; the prisoner chancing to look
+up in his hurried wonder as he wrote, the hand stopped, closing upon
+something.
+
+“Have you written ‘forget them’?” Carton asked.
+
+“I have. Is that a weapon in your hand?”
+
+“No; I am not armed.”
+
+“What is it in your hand?”
+
+“You shall know directly. Write on; there are but a few words more.” He
+dictated again. “‘I am thankful that the time has come, when I can prove
+them. That I do so is no subject for regret or grief.’” As he said these
+words with his eyes fixed on the writer, his hand slowly and softly
+moved down close to the writer’s face.
+
+The pen dropped from Darnay’s fingers on the table, and he looked about
+him vacantly.
+
+“What vapour is that?” he asked.
+
+“Vapour?”
+
+“Something that crossed me?”
+
+“I am conscious of nothing; there can be nothing here. Take up the pen
+and finish. Hurry, hurry!”
+
+As if his memory were impaired, or his faculties disordered, the
+prisoner made an effort to rally his attention. As he looked at Carton
+with clouded eyes and with an altered manner of breathing, Carton--his
+hand again in his breast--looked steadily at him.
+
+“Hurry, hurry!”
+
+The prisoner bent over the paper, once more.
+
+“‘If it had been otherwise;’” Carton’s hand was again watchfully and
+softly stealing down; “‘I never should have used the longer opportunity.
+If it had been otherwise;’” the hand was at the prisoner’s face; “‘I
+should but have had so much the more to answer for. If it had been
+otherwise--’” Carton looked at the pen and saw it was trailing off into
+unintelligible signs.
+
+Carton’s hand moved back to his breast no more. The prisoner sprang up
+with a reproachful look, but Carton’s hand was close and firm at his
+nostrils, and Carton’s left arm caught him round the waist. For a few
+seconds he faintly struggled with the man who had come to lay down his
+life for him; but, within a minute or so, he was stretched insensible on
+the ground.
+
+Quickly, but with hands as true to the purpose as his heart was, Carton
+dressed himself in the clothes the prisoner had laid aside, combed back
+his hair, and tied it with the ribbon the prisoner had worn. Then, he
+softly called, “Enter there! Come in!” and the Spy presented himself.
+
+“You see?” said Carton, looking up, as he kneeled on one knee beside the
+insensible figure, putting the paper in the breast: “is your hazard very
+great?”
+
+“Mr. Carton,” the Spy answered, with a timid snap of his fingers, “my
+hazard is not _that_, in the thick of business here, if you are true to
+the whole of your bargain.”
+
+“Don’t fear me. I will be true to the death.”
+
+“You must be, Mr. Carton, if the tale of fifty-two is to be right. Being
+made right by you in that dress, I shall have no fear.”
+
+“Have no fear! I shall soon be out of the way of harming you, and the
+rest will soon be far from here, please God! Now, get assistance and
+take me to the coach.”
+
+“You?” said the Spy nervously.
+
+“Him, man, with whom I have exchanged. You go out at the gate by which
+you brought me in?”
+
+“Of course.”
+
+“I was weak and faint when you brought me in, and I am fainter now you
+take me out. The parting interview has overpowered me. Such a thing has
+happened here, often, and too often. Your life is in your own hands.
+Quick! Call assistance!”
+
+“You swear not to betray me?” said the trembling Spy, as he paused for a
+last moment.
+
+“Man, man!” returned Carton, stamping his foot; “have I sworn by no
+solemn vow already, to go through with this, that you waste the precious
+moments now? Take him yourself to the courtyard you know of, place
+him yourself in the carriage, show him yourself to Mr. Lorry, tell him
+yourself to give him no restorative but air, and to remember my words of
+last night, and his promise of last night, and drive away!”
+
+The Spy withdrew, and Carton seated himself at the table, resting his
+forehead on his hands. The Spy returned immediately, with two men.
+
+“How, then?” said one of them, contemplating the fallen figure. “So
+afflicted to find that his friend has drawn a prize in the lottery of
+Sainte Guillotine?”
+
+“A good patriot,” said the other, “could hardly have been more afflicted
+if the Aristocrat had drawn a blank.”
+
+They raised the unconscious figure, placed it on a litter they had
+brought to the door, and bent to carry it away.
+
+“The time is short, Evremonde,” said the Spy, in a warning voice.
+
+“I know it well,” answered Carton. “Be careful of my friend, I entreat
+you, and leave me.”
+
+“Come, then, my children,” said Barsad. “Lift him, and come away!”
+
+The door closed, and Carton was left alone. Straining his powers of
+listening to the utmost, he listened for any sound that might denote
+suspicion or alarm. There was none. Keys turned, doors clashed,
+footsteps passed along distant passages: no cry was raised, or hurry
+made, that seemed unusual. Breathing more freely in a little while, he
+sat down at the table, and listened again until the clock struck Two.
+
+Sounds that he was not afraid of, for he divined their meaning, then
+began to be audible. Several doors were opened in succession, and
+finally his own. A gaoler, with a list in his hand, looked in, merely
+saying, “Follow me, Evremonde!” and he followed into a large dark room,
+at a distance. It was a dark winter day, and what with the shadows
+within, and what with the shadows without, he could but dimly discern
+the others who were brought there to have their arms bound. Some were
+standing; some seated. Some were lamenting, and in restless motion;
+but, these were few. The great majority were silent and still, looking
+fixedly at the ground.
+
+As he stood by the wall in a dim corner, while some of the fifty-two
+were brought in after him, one man stopped in passing, to embrace him,
+as having a knowledge of him. It thrilled him with a great dread of
+discovery; but the man went on. A very few moments after that, a young
+woman, with a slight girlish form, a sweet spare face in which there was
+no vestige of colour, and large widely opened patient eyes, rose from
+the seat where he had observed her sitting, and came to speak to him.
+
+“Citizen Evremonde,” she said, touching him with her cold hand. “I am a
+poor little seamstress, who was with you in La Force.”
+
+He murmured for answer: “True. I forget what you were accused of?”
+
+“Plots. Though the just Heaven knows that I am innocent of any. Is it
+likely? Who would think of plotting with a poor little weak creature
+like me?”
+
+The forlorn smile with which she said it, so touched him, that tears
+started from his eyes.
+
+“I am not afraid to die, Citizen Evremonde, but I have done nothing. I
+am not unwilling to die, if the Republic which is to do so much good
+to us poor, will profit by my death; but I do not know how that can be,
+Citizen Evremonde. Such a poor weak little creature!”
+
+As the last thing on earth that his heart was to warm and soften to, it
+warmed and softened to this pitiable girl.
+
+“I heard you were released, Citizen Evremonde. I hoped it was true?”
+
+“It was. But, I was again taken and condemned.”
+
+“If I may ride with you, Citizen Evremonde, will you let me hold your
+hand? I am not afraid, but I am little and weak, and it will give me
+more courage.”
+
+As the patient eyes were lifted to his face, he saw a sudden doubt in
+them, and then astonishment. He pressed the work-worn, hunger-worn young
+fingers, and touched his lips.
+
+“Are you dying for him?” she whispered.
+
+“And his wife and child. Hush! Yes.”
+
+“O you will let me hold your brave hand, stranger?”
+
+“Hush! Yes, my poor sister; to the last.”
+
+        *****
+
+The same shadows that are falling on the prison, are falling, in that
+same hour of the early afternoon, on the Barrier with the crowd about
+it, when a coach going out of Paris drives up to be examined.
+
+“Who goes here? Whom have we within? Papers!”
+
+The papers are handed out, and read.
+
+“Alexandre Manette. Physician. French. Which is he?”
+
+This is he; this helpless, inarticulately murmuring, wandering old man
+pointed out.
+
+“Apparently the Citizen-Doctor is not in his right mind? The
+Revolution-fever will have been too much for him?”
+
+Greatly too much for him.
+
+“Hah! Many suffer with it. Lucie. His daughter. French. Which is she?”
+
+This is she.
+
+“Apparently it must be. Lucie, the wife of Evremonde; is it not?”
+
+It is.
+
+“Hah! Evremonde has an assignation elsewhere. Lucie, her child. English.
+This is she?”
+
+She and no other.
+
+“Kiss me, child of Evremonde. Now, thou hast kissed a good Republican;
+something new in thy family; remember it! Sydney Carton. Advocate.
+English. Which is he?”
+
+He lies here, in this corner of the carriage. He, too, is pointed out.
+
+“Apparently the English advocate is in a swoon?”
+
+It is hoped he will recover in the fresher air. It is represented that
+he is not in strong health, and has separated sadly from a friend who is
+under the displeasure of the Republic.
+
+“Is that all? It is not a great deal, that! Many are under the
+displeasure of the Republic, and must look out at the little window.
+Jarvis Lorry. Banker. English. Which is he?”
+
+“I am he. Necessarily, being the last.”
+
+It is Jarvis Lorry who has replied to all the previous questions. It
+is Jarvis Lorry who has alighted and stands with his hand on the coach
+door, replying to a group of officials. They leisurely walk round the
+carriage and leisurely mount the box, to look at what little luggage it
+carries on the roof; the country-people hanging about, press nearer to
+the coach doors and greedily stare in; a little child, carried by its
+mother, has its short arm held out for it, that it may touch the wife of
+an aristocrat who has gone to the Guillotine.
+
+“Behold your papers, Jarvis Lorry, countersigned.”
+
+“One can depart, citizen?”
+
+“One can depart. Forward, my postilions! A good journey!”
+
+“I salute you, citizens.--And the first danger passed!”
+
+These are again the words of Jarvis Lorry, as he clasps his hands, and
+looks upward. There is terror in the carriage, there is weeping, there
+is the heavy breathing of the insensible traveller.
+
+“Are we not going too slowly? Can they not be induced to go faster?”
+ asks Lucie, clinging to the old man.
+
+“It would seem like flight, my darling. I must not urge them too much;
+it would rouse suspicion.”
+
+“Look back, look back, and see if we are pursued!”
+
+“The road is clear, my dearest. So far, we are not pursued.”
+
+Houses in twos and threes pass by us, solitary farms, ruinous buildings,
+dye-works, tanneries, and the like, open country, avenues of leafless
+trees. The hard uneven pavement is under us, the soft deep mud is on
+either side. Sometimes, we strike into the skirting mud, to avoid the
+stones that clatter us and shake us; sometimes, we stick in ruts and
+sloughs there. The agony of our impatience is then so great, that in our
+wild alarm and hurry we are for getting out and running--hiding--doing
+anything but stopping.
+
+Out of the open country, in again among ruinous buildings, solitary
+farms, dye-works, tanneries, and the like, cottages in twos and threes,
+avenues of leafless trees. Have these men deceived us, and taken us back
+by another road? Is not this the same place twice over? Thank Heaven,
+no. A village. Look back, look back, and see if we are pursued! Hush!
+the posting-house.
+
+Leisurely, our four horses are taken out; leisurely, the coach stands in
+the little street, bereft of horses, and with no likelihood upon it
+of ever moving again; leisurely, the new horses come into visible
+existence, one by one; leisurely, the new postilions follow, sucking and
+plaiting the lashes of their whips; leisurely, the old postilions count
+their money, make wrong additions, and arrive at dissatisfied results.
+All the time, our overfraught hearts are beating at a rate that would
+far outstrip the fastest gallop of the fastest horses ever foaled.
+
+At length the new postilions are in their saddles, and the old are left
+behind. We are through the village, up the hill, and down the hill, and
+on the low watery grounds. Suddenly, the postilions exchange speech with
+animated gesticulation, and the horses are pulled up, almost on their
+haunches. We are pursued?
+
+“Ho! Within the carriage there. Speak then!”
+
+“What is it?” asks Mr. Lorry, looking out at window.
+
+“How many did they say?”
+
+“I do not understand you.”
+
+“--At the last post. How many to the Guillotine to-day?”
+
+“Fifty-two.”
+
+“I said so! A brave number! My fellow-citizen here would have it
+forty-two; ten more heads are worth having. The Guillotine goes
+handsomely. I love it. Hi forward. Whoop!”
+
+The night comes on dark. He moves more; he is beginning to revive, and
+to speak intelligibly; he thinks they are still together; he asks him,
+by his name, what he has in his hand. O pity us, kind Heaven, and help
+us! Look out, look out, and see if we are pursued.
+
+The wind is rushing after us, and the clouds are flying after us, and
+the moon is plunging after us, and the whole wild night is in pursuit of
+us; but, so far, we are pursued by nothing else.
+
+
+
+
+XIV. The Knitting Done
+
+
+In that same juncture of time when the Fifty-Two awaited their fate
+Madame Defarge held darkly ominous council with The Vengeance and
+Jacques Three of the Revolutionary Jury. Not in the wine-shop did Madame
+Defarge confer with these ministers, but in the shed of the wood-sawyer,
+erst a mender of roads. The sawyer himself did not participate in the
+conference, but abided at a little distance, like an outer satellite who
+was not to speak until required, or to offer an opinion until invited.
+
+“But our Defarge,” said Jacques Three, “is undoubtedly a good
+Republican? Eh?”
+
+“There is no better,” the voluble Vengeance protested in her shrill
+notes, “in France.”
+
+“Peace, little Vengeance,” said Madame Defarge, laying her hand with
+a slight frown on her lieutenant’s lips, “hear me speak. My husband,
+fellow-citizen, is a good Republican and a bold man; he has deserved
+well of the Republic, and possesses its confidence. But my husband has
+his weaknesses, and he is so weak as to relent towards this Doctor.”
+
+“It is a great pity,” croaked Jacques Three, dubiously shaking his head,
+with his cruel fingers at his hungry mouth; “it is not quite like a good
+citizen; it is a thing to regret.”
+
+“See you,” said madame, “I care nothing for this Doctor, I. He may wear
+his head or lose it, for any interest I have in him; it is all one to
+me. But, the Evremonde people are to be exterminated, and the wife and
+child must follow the husband and father.”
+
+“She has a fine head for it,” croaked Jacques Three. “I have seen blue
+eyes and golden hair there, and they looked charming when Samson held
+them up.” Ogre that he was, he spoke like an epicure.
+
+Madame Defarge cast down her eyes, and reflected a little.
+
+“The child also,” observed Jacques Three, with a meditative enjoyment
+of his words, “has golden hair and blue eyes. And we seldom have a child
+there. It is a pretty sight!”
+
+“In a word,” said Madame Defarge, coming out of her short abstraction,
+“I cannot trust my husband in this matter. Not only do I feel, since
+last night, that I dare not confide to him the details of my projects;
+but also I feel that if I delay, there is danger of his giving warning,
+and then they might escape.”
+
+“That must never be,” croaked Jacques Three; “no one must escape. We
+have not half enough as it is. We ought to have six score a day.”
+
+“In a word,” Madame Defarge went on, “my husband has not my reason for
+pursuing this family to annihilation, and I have not his reason for
+regarding this Doctor with any sensibility. I must act for myself,
+therefore. Come hither, little citizen.”
+
+The wood-sawyer, who held her in the respect, and himself in the
+submission, of mortal fear, advanced with his hand to his red cap.
+
+“Touching those signals, little citizen,” said Madame Defarge, sternly,
+“that she made to the prisoners; you are ready to bear witness to them
+this very day?”
+
+“Ay, ay, why not!” cried the sawyer. “Every day, in all weathers, from
+two to four, always signalling, sometimes with the little one, sometimes
+without. I know what I know. I have seen with my eyes.”
+
+He made all manner of gestures while he spoke, as if in incidental
+imitation of some few of the great diversity of signals that he had
+never seen.
+
+“Clearly plots,” said Jacques Three. “Transparently!”
+
+“There is no doubt of the Jury?” inquired Madame Defarge, letting her
+eyes turn to him with a gloomy smile.
+
+“Rely upon the patriotic Jury, dear citizeness. I answer for my
+fellow-Jurymen.”
+
+“Now, let me see,” said Madame Defarge, pondering again. “Yet once more!
+Can I spare this Doctor to my husband? I have no feeling either way. Can
+I spare him?”
+
+“He would count as one head,” observed Jacques Three, in a low voice.
+“We really have not heads enough; it would be a pity, I think.”
+
+“He was signalling with her when I saw her,” argued Madame Defarge; “I
+cannot speak of one without the other; and I must not be silent, and
+trust the case wholly to him, this little citizen here. For, I am not a
+bad witness.”
+
+The Vengeance and Jacques Three vied with each other in their fervent
+protestations that she was the most admirable and marvellous of
+witnesses. The little citizen, not to be outdone, declared her to be a
+celestial witness.
+
+“He must take his chance,” said Madame Defarge. “No, I cannot spare
+him! You are engaged at three o’clock; you are going to see the batch of
+to-day executed.--You?”
+
+The question was addressed to the wood-sawyer, who hurriedly replied in
+the affirmative: seizing the occasion to add that he was the most ardent
+of Republicans, and that he would be in effect the most desolate of
+Republicans, if anything prevented him from enjoying the pleasure of
+smoking his afternoon pipe in the contemplation of the droll national
+barber. He was so very demonstrative herein, that he might have been
+suspected (perhaps was, by the dark eyes that looked contemptuously at
+him out of Madame Defarge’s head) of having his small individual fears
+for his own personal safety, every hour in the day.
+
+“I,” said madame, “am equally engaged at the same place. After it is
+over--say at eight to-night--come you to me, in Saint Antoine, and we
+will give information against these people at my Section.”
+
+The wood-sawyer said he would be proud and flattered to attend the
+citizeness. The citizeness looking at him, he became embarrassed, evaded
+her glance as a small dog would have done, retreated among his wood, and
+hid his confusion over the handle of his saw.
+
+Madame Defarge beckoned the Juryman and The Vengeance a little nearer to
+the door, and there expounded her further views to them thus:
+
+“She will now be at home, awaiting the moment of his death. She will
+be mourning and grieving. She will be in a state of mind to impeach the
+justice of the Republic. She will be full of sympathy with its enemies.
+I will go to her.”
+
+“What an admirable woman; what an adorable woman!” exclaimed Jacques
+Three, rapturously. “Ah, my cherished!” cried The Vengeance; and
+embraced her.
+
+“Take you my knitting,” said Madame Defarge, placing it in her
+lieutenant’s hands, “and have it ready for me in my usual seat. Keep
+me my usual chair. Go you there, straight, for there will probably be a
+greater concourse than usual, to-day.”
+
+“I willingly obey the orders of my Chief,” said The Vengeance with
+alacrity, and kissing her cheek. “You will not be late?”
+
+“I shall be there before the commencement.”
+
+“And before the tumbrils arrive. Be sure you are there, my soul,” said
+The Vengeance, calling after her, for she had already turned into the
+street, “before the tumbrils arrive!”
+
+Madame Defarge slightly waved her hand, to imply that she heard, and
+might be relied upon to arrive in good time, and so went through the
+mud, and round the corner of the prison wall. The Vengeance and the
+Juryman, looking after her as she walked away, were highly appreciative
+of her fine figure, and her superb moral endowments.
+
+There were many women at that time, upon whom the time laid a dreadfully
+disfiguring hand; but, there was not one among them more to be dreaded
+than this ruthless woman, now taking her way along the streets. Of a
+strong and fearless character, of shrewd sense and readiness, of great
+determination, of that kind of beauty which not only seems to impart
+to its possessor firmness and animosity, but to strike into others an
+instinctive recognition of those qualities; the troubled time would have
+heaved her up, under any circumstances. But, imbued from her childhood
+with a brooding sense of wrong, and an inveterate hatred of a class,
+opportunity had developed her into a tigress. She was absolutely without
+pity. If she had ever had the virtue in her, it had quite gone out of
+her.
+
+It was nothing to her, that an innocent man was to die for the sins of
+his forefathers; she saw, not him, but them. It was nothing to her, that
+his wife was to be made a widow and his daughter an orphan; that was
+insufficient punishment, because they were her natural enemies and
+her prey, and as such had no right to live. To appeal to her, was made
+hopeless by her having no sense of pity, even for herself. If she had
+been laid low in the streets, in any of the many encounters in which
+she had been engaged, she would not have pitied herself; nor, if she had
+been ordered to the axe to-morrow, would she have gone to it with any
+softer feeling than a fierce desire to change places with the man who
+sent her there.
+
+Such a heart Madame Defarge carried under her rough robe. Carelessly
+worn, it was a becoming robe enough, in a certain weird way, and her
+dark hair looked rich under her coarse red cap. Lying hidden in her
+bosom, was a loaded pistol. Lying hidden at her waist, was a sharpened
+dagger. Thus accoutred, and walking with the confident tread of such
+a character, and with the supple freedom of a woman who had habitually
+walked in her girlhood, bare-foot and bare-legged, on the brown
+sea-sand, Madame Defarge took her way along the streets.
+
+Now, when the journey of the travelling coach, at that very moment
+waiting for the completion of its load, had been planned out last night,
+the difficulty of taking Miss Pross in it had much engaged Mr. Lorry’s
+attention. It was not merely desirable to avoid overloading the coach,
+but it was of the highest importance that the time occupied in examining
+it and its passengers, should be reduced to the utmost; since their
+escape might depend on the saving of only a few seconds here and there.
+Finally, he had proposed, after anxious consideration, that Miss Pross
+and Jerry, who were at liberty to leave the city, should leave it at
+three o’clock in the lightest-wheeled conveyance known to that period.
+Unencumbered with luggage, they would soon overtake the coach, and,
+passing it and preceding it on the road, would order its horses in
+advance, and greatly facilitate its progress during the precious hours
+of the night, when delay was the most to be dreaded.
+
+Seeing in this arrangement the hope of rendering real service in that
+pressing emergency, Miss Pross hailed it with joy. She and Jerry had
+beheld the coach start, had known who it was that Solomon brought, had
+passed some ten minutes in tortures of suspense, and were now concluding
+their arrangements to follow the coach, even as Madame Defarge,
+taking her way through the streets, now drew nearer and nearer to the
+else-deserted lodging in which they held their consultation.
+
+“Now what do you think, Mr. Cruncher,” said Miss Pross, whose agitation
+was so great that she could hardly speak, or stand, or move, or live:
+“what do you think of our not starting from this courtyard? Another
+carriage having already gone from here to-day, it might awaken
+suspicion.”
+
+“My opinion, miss,” returned Mr. Cruncher, “is as you’re right. Likewise
+wot I’ll stand by you, right or wrong.”
+
+“I am so distracted with fear and hope for our precious creatures,” said
+Miss Pross, wildly crying, “that I am incapable of forming any plan. Are
+_you_ capable of forming any plan, my dear good Mr. Cruncher?”
+
+“Respectin’ a future spear o’ life, miss,” returned Mr. Cruncher, “I
+hope so. Respectin’ any present use o’ this here blessed old head o’
+mine, I think not. Would you do me the favour, miss, to take notice o’
+two promises and wows wot it is my wishes fur to record in this here
+crisis?”
+
+“Oh, for gracious sake!” cried Miss Pross, still wildly crying, “record
+them at once, and get them out of the way, like an excellent man.”
+
+“First,” said Mr. Cruncher, who was all in a tremble, and who spoke with
+an ashy and solemn visage, “them poor things well out o’ this, never no
+more will I do it, never no more!”
+
+“I am quite sure, Mr. Cruncher,” returned Miss Pross, “that you
+never will do it again, whatever it is, and I beg you not to think it
+necessary to mention more particularly what it is.”
+
+“No, miss,” returned Jerry, “it shall not be named to you. Second: them
+poor things well out o’ this, and never no more will I interfere with
+Mrs. Cruncher’s flopping, never no more!”
+
+“Whatever housekeeping arrangement that may be,” said Miss Pross,
+striving to dry her eyes and compose herself, “I have no doubt it
+is best that Mrs. Cruncher should have it entirely under her own
+superintendence.--O my poor darlings!”
+
+“I go so far as to say, miss, moreover,” proceeded Mr. Cruncher, with a
+most alarming tendency to hold forth as from a pulpit--“and let my words
+be took down and took to Mrs. Cruncher through yourself--that wot my
+opinions respectin’ flopping has undergone a change, and that wot I only
+hope with all my heart as Mrs. Cruncher may be a flopping at the present
+time.”
+
+“There, there, there! I hope she is, my dear man,” cried the distracted
+Miss Pross, “and I hope she finds it answering her expectations.”
+
+“Forbid it,” proceeded Mr. Cruncher, with additional solemnity,
+additional slowness, and additional tendency to hold forth and hold
+out, “as anything wot I have ever said or done should be wisited on my
+earnest wishes for them poor creeturs now! Forbid it as we shouldn’t all
+flop (if it was anyways conwenient) to get ‘em out o’ this here dismal
+risk! Forbid it, miss! Wot I say, for-_bid_ it!” This was Mr. Cruncher’s
+conclusion after a protracted but vain endeavour to find a better one.
+
+And still Madame Defarge, pursuing her way along the streets, came
+nearer and nearer.
+
+“If we ever get back to our native land,” said Miss Pross, “you may rely
+upon my telling Mrs. Cruncher as much as I may be able to remember and
+understand of what you have so impressively said; and at all events
+you may be sure that I shall bear witness to your being thoroughly in
+earnest at this dreadful time. Now, pray let us think! My esteemed Mr.
+Cruncher, let us think!”
+
+Still, Madame Defarge, pursuing her way along the streets, came nearer
+and nearer.
+
+“If you were to go before,” said Miss Pross, “and stop the vehicle and
+horses from coming here, and were to wait somewhere for me; wouldn’t
+that be best?”
+
+Mr. Cruncher thought it might be best.
+
+“Where could you wait for me?” asked Miss Pross.
+
+Mr. Cruncher was so bewildered that he could think of no locality but
+Temple Bar. Alas! Temple Bar was hundreds of miles away, and Madame
+Defarge was drawing very near indeed.
+
+“By the cathedral door,” said Miss Pross. “Would it be much out of
+the way, to take me in, near the great cathedral door between the two
+towers?”
+
+“No, miss,” answered Mr. Cruncher.
+
+“Then, like the best of men,” said Miss Pross, “go to the posting-house
+straight, and make that change.”
+
+“I am doubtful,” said Mr. Cruncher, hesitating and shaking his head,
+“about leaving of you, you see. We don’t know what may happen.”
+
+“Heaven knows we don’t,” returned Miss Pross, “but have no fear for me.
+Take me in at the cathedral, at Three o’Clock, or as near it as you can,
+and I am sure it will be better than our going from here. I feel certain
+of it. There! Bless you, Mr. Cruncher! Think-not of me, but of the lives
+that may depend on both of us!”
+
+This exordium, and Miss Pross’s two hands in quite agonised entreaty
+clasping his, decided Mr. Cruncher. With an encouraging nod or two, he
+immediately went out to alter the arrangements, and left her by herself
+to follow as she had proposed.
+
+The having originated a precaution which was already in course of
+execution, was a great relief to Miss Pross. The necessity of composing
+her appearance so that it should attract no special notice in the
+streets, was another relief. She looked at her watch, and it was twenty
+minutes past two. She had no time to lose, but must get ready at once.
+
+Afraid, in her extreme perturbation, of the loneliness of the deserted
+rooms, and of half-imagined faces peeping from behind every open door
+in them, Miss Pross got a basin of cold water and began laving her eyes,
+which were swollen and red. Haunted by her feverish apprehensions, she
+could not bear to have her sight obscured for a minute at a time by the
+dripping water, but constantly paused and looked round to see that there
+was no one watching her. In one of those pauses she recoiled and cried
+out, for she saw a figure standing in the room.
+
+The basin fell to the ground broken, and the water flowed to the feet of
+Madame Defarge. By strange stern ways, and through much staining blood,
+those feet had come to meet that water.
+
+Madame Defarge looked coldly at her, and said, “The wife of Evremonde;
+where is she?”
+
+It flashed upon Miss Pross’s mind that the doors were all standing open,
+and would suggest the flight. Her first act was to shut them. There were
+four in the room, and she shut them all. She then placed herself before
+the door of the chamber which Lucie had occupied.
+
+Madame Defarge’s dark eyes followed her through this rapid movement,
+and rested on her when it was finished. Miss Pross had nothing beautiful
+about her; years had not tamed the wildness, or softened the grimness,
+of her appearance; but, she too was a determined woman in her different
+way, and she measured Madame Defarge with her eyes, every inch.
+
+“You might, from your appearance, be the wife of Lucifer,” said Miss
+Pross, in her breathing. “Nevertheless, you shall not get the better of
+me. I am an Englishwoman.”
+
+Madame Defarge looked at her scornfully, but still with something of
+Miss Pross’s own perception that they two were at bay. She saw a tight,
+hard, wiry woman before her, as Mr. Lorry had seen in the same figure a
+woman with a strong hand, in the years gone by. She knew full well that
+Miss Pross was the family’s devoted friend; Miss Pross knew full well
+that Madame Defarge was the family’s malevolent enemy.
+
+“On my way yonder,” said Madame Defarge, with a slight movement of
+her hand towards the fatal spot, “where they reserve my chair and my
+knitting for me, I am come to make my compliments to her in passing. I
+wish to see her.”
+
+“I know that your intentions are evil,” said Miss Pross, “and you may
+depend upon it, I’ll hold my own against them.”
+
+Each spoke in her own language; neither understood the other’s words;
+both were very watchful, and intent to deduce from look and manner, what
+the unintelligible words meant.
+
+“It will do her no good to keep herself concealed from me at this
+moment,” said Madame Defarge. “Good patriots will know what that means.
+Let me see her. Go tell her that I wish to see her. Do you hear?”
+
+“If those eyes of yours were bed-winches,” returned Miss Pross, “and I
+was an English four-poster, they shouldn’t loose a splinter of me. No,
+you wicked foreign woman; I am your match.”
+
+Madame Defarge was not likely to follow these idiomatic remarks in
+detail; but, she so far understood them as to perceive that she was set
+at naught.
+
+“Woman imbecile and pig-like!” said Madame Defarge, frowning. “I take no
+answer from you. I demand to see her. Either tell her that I demand
+to see her, or stand out of the way of the door and let me go to her!”
+ This, with an angry explanatory wave of her right arm.
+
+“I little thought,” said Miss Pross, “that I should ever want to
+understand your nonsensical language; but I would give all I have,
+except the clothes I wear, to know whether you suspect the truth, or any
+part of it.”
+
+Neither of them for a single moment released the other’s eyes. Madame
+Defarge had not moved from the spot where she stood when Miss Pross
+first became aware of her; but, she now advanced one step.
+
+“I am a Briton,” said Miss Pross, “I am desperate. I don’t care an
+English Twopence for myself. I know that the longer I keep you here, the
+greater hope there is for my Ladybird. I’ll not leave a handful of that
+dark hair upon your head, if you lay a finger on me!”
+
+Thus Miss Pross, with a shake of her head and a flash of her eyes
+between every rapid sentence, and every rapid sentence a whole breath.
+Thus Miss Pross, who had never struck a blow in her life.
+
+But, her courage was of that emotional nature that it brought the
+irrepressible tears into her eyes. This was a courage that Madame
+Defarge so little comprehended as to mistake for weakness. “Ha, ha!” she
+laughed, “you poor wretch! What are you worth! I address myself to that
+Doctor.” Then she raised her voice and called out, “Citizen Doctor! Wife
+of Evremonde! Child of Evremonde! Any person but this miserable fool,
+answer the Citizeness Defarge!”
+
+Perhaps the following silence, perhaps some latent disclosure in the
+expression of Miss Pross’s face, perhaps a sudden misgiving apart from
+either suggestion, whispered to Madame Defarge that they were gone.
+Three of the doors she opened swiftly, and looked in.
+
+“Those rooms are all in disorder, there has been hurried packing, there
+are odds and ends upon the ground. There is no one in that room behind
+you! Let me look.”
+
+“Never!” said Miss Pross, who understood the request as perfectly as
+Madame Defarge understood the answer.
+
+“If they are not in that room, they are gone, and can be pursued and
+brought back,” said Madame Defarge to herself.
+
+“As long as you don’t know whether they are in that room or not, you are
+uncertain what to do,” said Miss Pross to herself; “and you shall not
+know that, if I can prevent your knowing it; and know that, or not know
+that, you shall not leave here while I can hold you.”
+
+“I have been in the streets from the first, nothing has stopped me,
+I will tear you to pieces, but I will have you from that door,” said
+Madame Defarge.
+
+“We are alone at the top of a high house in a solitary courtyard, we are
+not likely to be heard, and I pray for bodily strength to keep you here,
+while every minute you are here is worth a hundred thousand guineas to
+my darling,” said Miss Pross.
+
+Madame Defarge made at the door. Miss Pross, on the instinct of the
+moment, seized her round the waist in both her arms, and held her tight.
+It was in vain for Madame Defarge to struggle and to strike; Miss Pross,
+with the vigorous tenacity of love, always so much stronger than hate,
+clasped her tight, and even lifted her from the floor in the struggle
+that they had. The two hands of Madame Defarge buffeted and tore her
+face; but, Miss Pross, with her head down, held her round the waist, and
+clung to her with more than the hold of a drowning woman.
+
+Soon, Madame Defarge’s hands ceased to strike, and felt at her encircled
+waist. “It is under my arm,” said Miss Pross, in smothered tones, “you
+shall not draw it. I am stronger than you, I bless Heaven for it. I hold
+you till one or other of us faints or dies!”
+
+Madame Defarge’s hands were at her bosom. Miss Pross looked up, saw
+what it was, struck at it, struck out a flash and a crash, and stood
+alone--blinded with smoke.
+
+All this was in a second. As the smoke cleared, leaving an awful
+stillness, it passed out on the air, like the soul of the furious woman
+whose body lay lifeless on the ground.
+
+In the first fright and horror of her situation, Miss Pross passed the
+body as far from it as she could, and ran down the stairs to call for
+fruitless help. Happily, she bethought herself of the consequences of
+what she did, in time to check herself and go back. It was dreadful to
+go in at the door again; but, she did go in, and even went near it, to
+get the bonnet and other things that she must wear. These she put on,
+out on the staircase, first shutting and locking the door and taking
+away the key. She then sat down on the stairs a few moments to breathe
+and to cry, and then got up and hurried away.
+
+By good fortune she had a veil on her bonnet, or she could hardly have
+gone along the streets without being stopped. By good fortune, too, she
+was naturally so peculiar in appearance as not to show disfigurement
+like any other woman. She needed both advantages, for the marks of
+gripping fingers were deep in her face, and her hair was torn, and her
+dress (hastily composed with unsteady hands) was clutched and dragged a
+hundred ways.
+
+In crossing the bridge, she dropped the door key in the river. Arriving
+at the cathedral some few minutes before her escort, and waiting there,
+she thought, what if the key were already taken in a net, what if
+it were identified, what if the door were opened and the remains
+discovered, what if she were stopped at the gate, sent to prison, and
+charged with murder! In the midst of these fluttering thoughts, the
+escort appeared, took her in, and took her away.
+
+“Is there any noise in the streets?” she asked him.
+
+“The usual noises,” Mr. Cruncher replied; and looked surprised by the
+question and by her aspect.
+
+“I don’t hear you,” said Miss Pross. “What do you say?”
+
+It was in vain for Mr. Cruncher to repeat what he said; Miss Pross could
+not hear him. “So I’ll nod my head,” thought Mr. Cruncher, amazed, “at
+all events she’ll see that.” And she did.
+
+“Is there any noise in the streets now?” asked Miss Pross again,
+presently.
+
+Again Mr. Cruncher nodded his head.
+
+“I don’t hear it.”
+
+“Gone deaf in an hour?” said Mr. Cruncher, ruminating, with his mind
+much disturbed; “wot’s come to her?”
+
+“I feel,” said Miss Pross, “as if there had been a flash and a crash,
+and that crash was the last thing I should ever hear in this life.”
+
+“Blest if she ain’t in a queer condition!” said Mr. Cruncher, more and
+more disturbed. “Wot can she have been a takin’, to keep her courage up?
+Hark! There’s the roll of them dreadful carts! You can hear that, miss?”
+
+“I can hear,” said Miss Pross, seeing that he spoke to her, “nothing. O,
+my good man, there was first a great crash, and then a great stillness,
+and that stillness seems to be fixed and unchangeable, never to be
+broken any more as long as my life lasts.”
+
+“If she don’t hear the roll of those dreadful carts, now very nigh their
+journey’s end,” said Mr. Cruncher, glancing over his shoulder, “it’s my
+opinion that indeed she never will hear anything else in this world.”
+
+And indeed she never did.
+
+
+
+
+XV. The Footsteps Die Out For Ever
+
+
+Along the Paris streets, the death-carts rumble, hollow and harsh. Six
+tumbrils carry the day’s wine to La Guillotine. All the devouring and
+insatiate Monsters imagined since imagination could record itself,
+are fused in the one realisation, Guillotine. And yet there is not in
+France, with its rich variety of soil and climate, a blade, a leaf,
+a root, a sprig, a peppercorn, which will grow to maturity under
+conditions more certain than those that have produced this horror. Crush
+humanity out of shape once more, under similar hammers, and it will
+twist itself into the same tortured forms. Sow the same seed of
+rapacious license and oppression over again, and it will surely yield
+the same fruit according to its kind.
+
+Six tumbrils roll along the streets. Change these back again to what
+they were, thou powerful enchanter, Time, and they shall be seen to be
+the carriages of absolute monarchs, the equipages of feudal nobles, the
+toilettes of flaring Jezebels, the churches that are not my father’s
+house but dens of thieves, the huts of millions of starving peasants!
+No; the great magician who majestically works out the appointed order
+of the Creator, never reverses his transformations. “If thou be changed
+into this shape by the will of God,” say the seers to the enchanted, in
+the wise Arabian stories, “then remain so! But, if thou wear this
+form through mere passing conjuration, then resume thy former aspect!”
+ Changeless and hopeless, the tumbrils roll along.
+
+As the sombre wheels of the six carts go round, they seem to plough up
+a long crooked furrow among the populace in the streets. Ridges of faces
+are thrown to this side and to that, and the ploughs go steadily onward.
+So used are the regular inhabitants of the houses to the spectacle, that
+in many windows there are no people, and in some the occupation of the
+hands is not so much as suspended, while the eyes survey the faces in
+the tumbrils. Here and there, the inmate has visitors to see the sight;
+then he points his finger, with something of the complacency of a
+curator or authorised exponent, to this cart and to this, and seems to
+tell who sat here yesterday, and who there the day before.
+
+Of the riders in the tumbrils, some observe these things, and all
+things on their last roadside, with an impassive stare; others, with
+a lingering interest in the ways of life and men. Some, seated with
+drooping heads, are sunk in silent despair; again, there are some so
+heedful of their looks that they cast upon the multitude such glances as
+they have seen in theatres, and in pictures. Several close their eyes,
+and think, or try to get their straying thoughts together. Only one, and
+he a miserable creature, of a crazed aspect, is so shattered and made
+drunk by horror, that he sings, and tries to dance. Not one of the whole
+number appeals by look or gesture, to the pity of the people.
+
+There is a guard of sundry horsemen riding abreast of the tumbrils,
+and faces are often turned up to some of them, and they are asked some
+question. It would seem to be always the same question, for, it is
+always followed by a press of people towards the third cart. The
+horsemen abreast of that cart, frequently point out one man in it with
+their swords. The leading curiosity is, to know which is he; he stands
+at the back of the tumbril with his head bent down, to converse with a
+mere girl who sits on the side of the cart, and holds his hand. He has
+no curiosity or care for the scene about him, and always speaks to the
+girl. Here and there in the long street of St. Honore, cries are raised
+against him. If they move him at all, it is only to a quiet smile, as he
+shakes his hair a little more loosely about his face. He cannot easily
+touch his face, his arms being bound.
+
+On the steps of a church, awaiting the coming-up of the tumbrils, stands
+the Spy and prison-sheep. He looks into the first of them: not there.
+He looks into the second: not there. He already asks himself, “Has he
+sacrificed me?” when his face clears, as he looks into the third.
+
+“Which is Evremonde?” says a man behind him.
+
+“That. At the back there.”
+
+“With his hand in the girl’s?”
+
+“Yes.”
+
+The man cries, “Down, Evremonde! To the Guillotine all aristocrats!
+Down, Evremonde!”
+
+“Hush, hush!” the Spy entreats him, timidly.
+
+“And why not, citizen?”
+
+“He is going to pay the forfeit: it will be paid in five minutes more.
+Let him be at peace.”
+
+But the man continuing to exclaim, “Down, Evremonde!” the face of
+Evremonde is for a moment turned towards him. Evremonde then sees the
+Spy, and looks attentively at him, and goes his way.
+
+The clocks are on the stroke of three, and the furrow ploughed among the
+populace is turning round, to come on into the place of execution, and
+end. The ridges thrown to this side and to that, now crumble in and
+close behind the last plough as it passes on, for all are following
+to the Guillotine. In front of it, seated in chairs, as in a garden of
+public diversion, are a number of women, busily knitting. On one of the
+fore-most chairs, stands The Vengeance, looking about for her friend.
+
+“Therese!” she cries, in her shrill tones. “Who has seen her? Therese
+Defarge!”
+
+“She never missed before,” says a knitting-woman of the sisterhood.
+
+“No; nor will she miss now,” cries The Vengeance, petulantly. “Therese.”
+
+“Louder,” the woman recommends.
+
+Ay! Louder, Vengeance, much louder, and still she will scarcely hear
+thee. Louder yet, Vengeance, with a little oath or so added, and yet
+it will hardly bring her. Send other women up and down to seek her,
+lingering somewhere; and yet, although the messengers have done dread
+deeds, it is questionable whether of their own wills they will go far
+enough to find her!
+
+“Bad Fortune!” cries The Vengeance, stamping her foot in the chair, “and
+here are the tumbrils! And Evremonde will be despatched in a wink, and
+she not here! See her knitting in my hand, and her empty chair ready for
+her. I cry with vexation and disappointment!”
+
+As The Vengeance descends from her elevation to do it, the tumbrils
+begin to discharge their loads. The ministers of Sainte Guillotine are
+robed and ready. Crash!--A head is held up, and the knitting-women who
+scarcely lifted their eyes to look at it a moment ago when it could
+think and speak, count One.
+
+The second tumbril empties and moves on; the third comes up. Crash!--And
+the knitting-women, never faltering or pausing in their Work, count Two.
+
+The supposed Evremonde descends, and the seamstress is lifted out next
+after him. He has not relinquished her patient hand in getting out, but
+still holds it as he promised. He gently places her with her back to the
+crashing engine that constantly whirrs up and falls, and she looks into
+his face and thanks him.
+
+“But for you, dear stranger, I should not be so composed, for I am
+naturally a poor little thing, faint of heart; nor should I have been
+able to raise my thoughts to Him who was put to death, that we might
+have hope and comfort here to-day. I think you were sent to me by
+Heaven.”
+
+“Or you to me,” says Sydney Carton. “Keep your eyes upon me, dear child,
+and mind no other object.”
+
+“I mind nothing while I hold your hand. I shall mind nothing when I let
+it go, if they are rapid.”
+
+“They will be rapid. Fear not!”
+
+The two stand in the fast-thinning throng of victims, but they speak as
+if they were alone. Eye to eye, voice to voice, hand to hand, heart to
+heart, these two children of the Universal Mother, else so wide apart
+and differing, have come together on the dark highway, to repair home
+together, and to rest in her bosom.
+
+“Brave and generous friend, will you let me ask you one last question? I
+am very ignorant, and it troubles me--just a little.”
+
+“Tell me what it is.”
+
+“I have a cousin, an only relative and an orphan, like myself, whom I
+love very dearly. She is five years younger than I, and she lives in a
+farmer’s house in the south country. Poverty parted us, and she knows
+nothing of my fate--for I cannot write--and if I could, how should I
+tell her! It is better as it is.”
+
+“Yes, yes: better as it is.”
+
+“What I have been thinking as we came along, and what I am still
+thinking now, as I look into your kind strong face which gives me so
+much support, is this:--If the Republic really does good to the poor,
+and they come to be less hungry, and in all ways to suffer less, she may
+live a long time: she may even live to be old.”
+
+“What then, my gentle sister?”
+
+“Do you think:” the uncomplaining eyes in which there is so much
+endurance, fill with tears, and the lips part a little more and tremble:
+“that it will seem long to me, while I wait for her in the better land
+where I trust both you and I will be mercifully sheltered?”
+
+“It cannot be, my child; there is no Time there, and no trouble there.”
+
+“You comfort me so much! I am so ignorant. Am I to kiss you now? Is the
+moment come?”
+
+“Yes.”
+
+She kisses his lips; he kisses hers; they solemnly bless each other.
+The spare hand does not tremble as he releases it; nothing worse than
+a sweet, bright constancy is in the patient face. She goes next before
+him--is gone; the knitting-women count Twenty-Two.
+
+“I am the Resurrection and the Life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me shall never die.”
+
+The murmuring of many voices, the upturning of many faces, the pressing
+on of many footsteps in the outskirts of the crowd, so that it swells
+forward in a mass, like one great heave of water, all flashes away.
+Twenty-Three.
+
+        *****
+
+They said of him, about the city that night, that it was the
+peacefullest man’s face ever beheld there. Many added that he looked
+sublime and prophetic.
+
+One of the most remarkable sufferers by the same axe--a woman--had asked
+at the foot of the same scaffold, not long before, to be allowed to
+write down the thoughts that were inspiring her. If he had given any
+utterance to his, and they were prophetic, they would have been these:
+
+“I see Barsad, and Cly, Defarge, The Vengeance, the Juryman, the Judge,
+long ranks of the new oppressors who have risen on the destruction of
+the old, perishing by this retributive instrument, before it shall cease
+out of its present use. I see a beautiful city and a brilliant people
+rising from this abyss, and, in their struggles to be truly free, in
+their triumphs and defeats, through long years to come, I see the evil
+of this time and of the previous time of which this is the natural
+birth, gradually making expiation for itself and wearing out.
+
+“I see the lives for which I lay down my life, peaceful, useful,
+prosperous and happy, in that England which I shall see no more. I see
+Her with a child upon her bosom, who bears my name. I see her father,
+aged and bent, but otherwise restored, and faithful to all men in his
+healing office, and at peace. I see the good old man, so long their
+friend, in ten years’ time enriching them with all he has, and passing
+tranquilly to his reward.
+
+“I see that I hold a sanctuary in their hearts, and in the hearts of
+their descendants, generations hence. I see her, an old woman, weeping
+for me on the anniversary of this day. I see her and her husband, their
+course done, lying side by side in their last earthly bed, and I know
+that each was not more honoured and held sacred in the other’s soul,
+than I was in the souls of both.
+
+“I see that child who lay upon her bosom and who bore my name, a man
+winning his way up in that path of life which once was mine. I see him
+winning it so well, that my name is made illustrious there by the
+light of his. I see the blots I threw upon it, faded away. I see him,
+fore-most of just judges and honoured men, bringing a boy of my name,
+with a forehead that I know and golden hair, to this place--then fair to
+look upon, with not a trace of this day’s disfigurement--and I hear him
+tell the child my story, with a tender and a faltering voice.
+
+“It is a far, far better thing that I do, than I have ever done; it is a
+far, far better rest that I go to than I have ever known.”
+
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+*** END OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+***** This file should be named 98-0.txt or 98-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/9/98/
+
+Produced by Judith Boss
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/adventures-of-sherlock-holmes.txt
+++ b/jet/source-sink-builder/src/main/resources/books/adventures-of-sherlock-holmes.txt
@@ -1,0 +1,12759 @@
+﻿Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+
+Title: Adventures of Sherlock Holmes
+       Illustrated
+
+Author: A. Conan Doyle
+
+Release Date: February 20, 2015 [EBook #48320]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+
+
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+
+
+
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+
+
+
+[Illustration:
+
+  “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”
+                                           [Page 238
+]
+
+
+
+
+  ADVENTURES
+  OF
+  SHERLOCK HOLMES
+
+  BY
+  A. CONAN DOYLE
+
+  AUTHOR OF “MICAH CLARKE” ETC.
+
+  ILLUSTRATED
+
+  NEW YORK
+  HARPER & BROTHERS, FRANKLIN SQUARE
+
+
+
+
+  Copyright, 1892, by HARPER & BROTHERS.
+  _All rights reserved._
+
+
+
+
+CONTENTS
+
+
+                                                 PAGE
+
+     I.—A SCANDAL IN BOHEMIA                        3
+
+    II.—THE RED-HEADED LEAGUE                      29
+
+   III.—A CASE OF IDENTITY                         56
+
+    IV.—THE BOSCOMBE VALLEY MYSTERY                76
+
+     V.—THE FIVE ORANGE PIPS                      104
+
+    VI.—THE MAN WITH THE TWISTED LIP              126
+
+   VII.—THE ADVENTURE OF THE BLUE CARBUNCLE       153
+
+  VIII.—THE ADVENTURE OF THE SPECKLED BAND        176
+
+    IX.—THE ADVENTURE OF THE ENGINEER’S THUMB     205
+
+     X.—THE ADVENTURE OF THE NOBLE BACHELOR       229
+
+    XI.—THE ADVENTURE OF THE BERYL CORONET        253
+
+   XII.—THE ADVENTURE OF THE COPPER BEECHES       280
+
+
+
+
+ILLUSTRATIONS
+
+
+    “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”  _Frontispiece_
+
+    “A MAN ENTERED”                                 _Facing p._  8
+
+    “THE DOOR WAS SHUT AND LOCKED”                         ″     40
+
+    “ALL AFTERNOON HE SAT IN THE STALLS”                   ″     46
+
+    “SHERLOCK HOLMES WELCOMED HER”                         ″     60
+
+    “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”              ″     72
+
+    “THEY FOUND THE BODY”                                  ″     80
+
+    “THE MAID SHOWED US THE BOOTS”                         ″     92
+
+    “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”                ″    122
+
+    “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+        SCOUNDREL”                                         ″    134
+
+    “‘HAVE MERCY!’ HE SHRIEKED”                            ″    172
+
+    “‘GOOD-BYE, AND BE BRAVE’”                             ″    196
+
+    “‘NOT A WORD TO A SOUL’”                               ″    214
+
+    “‘I WILL WISH YOU ALL A VERY GOOD NIGHT’”              ″    250
+
+    “I CLAPPED A PISTOL TO HIS HEAD”                       ″    278
+
+    “‘I AM SO DELIGHTED THAT YOU HAVE COME’”               ″    292
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+Adventure I
+
+A SCANDAL IN BOHEMIA
+
+
+I
+
+To Sherlock Holmes she is always _the_ woman. I have seldom heard
+him mention her under any other name. In his eyes she eclipses and
+predominates the whole of her sex. It was not that he felt any emotion
+akin to love for Irene Adler. All emotions, and that one particularly,
+were abhorrent to his cold, precise, but admirably balanced mind. He
+was, I take it, the most perfect reasoning and observing machine that
+the world has seen; but, as a lover, he would have placed himself in a
+false position. He never spoke of the softer passions, save with a gibe
+and a sneer. They were admirable things for the observer—excellent
+for drawing the veil from men’s motives and actions. But for the
+trained reasoner to admit such intrusions into his own delicate and
+finely adjusted temperament was to introduce a distracting factor which
+might throw a doubt upon all his mental results. Grit in a sensitive
+instrument, or a crack in one of his own high-power lenses, would not
+be more disturbing than a strong emotion in a nature such as his. And
+yet there was but one woman to him, and that woman was the late Irene
+Adler, of dubious and questionable memory.
+
+I had seen little of Holmes lately. My marriage had drifted us away
+from each other. My own complete happiness, and the home-centred
+interests which rise up around the man who first finds himself master
+of his own establishment, were sufficient to absorb all my attention;
+while Holmes, who loathed every form of society with his whole
+Bohemian soul, remained in our lodgings in Baker Street, buried among
+his old books, and alternating from week to week between cocaine and
+ambition, the drowsiness of the drug, and the fierce energy of his
+own keen nature. He was still, as ever, deeply attracted by the study
+of crime, and occupied his immense faculties and extraordinary powers
+of observation in following out those clues, and clearing up those
+mysteries, which had been abandoned as hopeless by the official police.
+From time to time I heard some vague account of his doings: of his
+summons to Odessa in the case of the Trepoff murder, of his clearing
+up of the singular tragedy of the Atkinson brothers at Trincomalee,
+and finally of the mission which he had accomplished so delicately and
+successfully for the reigning family of Holland. Beyond these signs of
+his activity, however, which I merely shared with all the readers of
+the daily press, I knew little of my former friend and companion.
+
+One night—it was on the 20th of March, 1888—I was returning from a
+journey to a patient (for I had now returned to civil practice), when
+my way led me through Baker Street. As I passed the well-remembered
+door, which must always be associated in my mind with my wooing, and
+with the dark incidents of the Study in Scarlet, I was seized with a
+keen desire to see Holmes again, and to know how he was employing his
+extraordinary powers. His rooms were brilliantly lit, and, even as I
+looked up, I saw his tall, spare figure pass twice in a dark silhouette
+against the blind. He was pacing the room swiftly, eagerly, with his
+head sunk upon his chest and his hands clasped behind him. To me, who
+knew his every mood and habit, his attitude and manner told their own
+story. He was at work again. He had arisen out of his drug-created
+dreams, and was hot upon the scent of some new problem. I rang the
+bell, and was shown up to the chamber which had formerly been in part
+my own.
+
+His manner was not effusive. It seldom was; but he was glad, I think,
+to see me. With hardly a word spoken, but with a kindly eye, he waved
+me to an arm-chair, threw across his case of cigars, and indicated a
+spirit case and a gasogene in the corner. Then he stood before the
+fire, and looked me over in his singular introspective fashion.
+
+“Wedlock suits you,” he remarked. “I think, Watson, that you have put
+on seven and a half pounds since I saw you.”
+
+“Seven!” I answered.
+
+“Indeed, I should have thought a little more. Just a trifle more, I
+fancy, Watson. And in practice again, I observe. You did not tell me
+that you intended to go into harness.”
+
+“Then, how do you know?”
+
+“I see it, I deduce it. How do I know that you have been getting
+yourself very wet lately, and that you have a most clumsy and careless
+servant girl?”
+
+“My dear Holmes,” said I, “this is too much. You would certainly have
+been burned, had you lived a few centuries ago. It is true that I had
+a country walk on Thursday and came home in a dreadful mess; but, as I
+have changed my clothes, I can’t imagine how you deduce it. As to Mary
+Jane, she is incorrigible, and my wife has given her notice; but there,
+again, I fail to see how you work it out.”
+
+He chuckled to himself and rubbed his long, nervous hands together.
+
+“It is simplicity itself,” said he; “my eyes tell me that on the
+inside of your left shoe, just where the firelight strikes it, the
+leather is scored by six almost parallel cuts. Obviously they have
+been caused by some one who has very carelessly scraped round the
+edges of the sole in order to remove crusted mud from it. Hence, you
+see, my double deduction that you had been out in vile weather, and
+that you had a particularly malignant boot-slitting specimen of the
+London slavey. As to your practice, if a gentleman walks into my rooms
+smelling of iodoform, with a black mark of nitrate of silver upon his
+right forefinger, and a bulge on the side of his top-hat to show where
+he has secreted his stethoscope, I must be dull, indeed, if I do not
+pronounce him to be an active member of the medical profession.”
+
+I could not help laughing at the ease with which he explained his
+process of deduction. “When I hear you give your reasons,” I remarked,
+“the thing always appears to me to be so ridiculously simple that I
+could easily do it myself, though at each successive instance of your
+reasoning I am baffled, until you explain your process. And yet I
+believe that my eyes are as good as yours.”
+
+“Quite so,” he answered, lighting a cigarette, and throwing himself
+down into an arm-chair. “You see, but you do not observe. The
+distinction is clear. For example, you have frequently seen the steps
+which lead up from the hall to this room.”
+
+“Frequently.”
+
+“How often?”
+
+“Well, some hundreds of times.”
+
+“Then how many are there?”
+
+“How many? I don’t know.”
+
+“Quite so! You have not observed. And yet you have seen. That is just
+my point. Now, I know that there are seventeen steps, because I have
+both seen and observed. By-the-way, since you are interested in these
+little problems, and since you are good enough to chronicle one or two
+of my trifling experiences, you may be interested in this.” He threw
+over a sheet of thick, pink-tinted note-paper which had been lying open
+upon the table. “It came by the last post,” said he. “Read it aloud.”
+
+The note was undated, and without either signature or address.
+
+“There will call upon you to-night, at a quarter to eight o’clock,”
+it said, “a gentleman who desires to consult you upon a matter of the
+very deepest moment. Your recent services to one of the royal houses
+of Europe have shown that you are one who may safely be trusted with
+matters which are of an importance which can hardly be exaggerated.
+This account of you we have from all quarters received. Be in your
+chamber then at that hour, and do not take it amiss if your visitor
+wear a mask.”
+
+“This is indeed a mystery,” I remarked. “What do you imagine that it
+means?”
+
+“I have no data yet. It is a capital mistake to theorize before one has
+data. Insensibly one begins to twist facts to suit theories, instead of
+theories to suit facts. But the note itself. What do you deduce from
+it?”
+
+I carefully examined the writing, and the paper upon which it was
+written.
+
+“The man who wrote it was presumably well to do,” I remarked,
+endeavoring to imitate my companion’s processes. “Such paper could not
+be bought under half a crown a packet. It is peculiarly strong and
+stiff.”
+
+“Peculiar—that is the very word,” said Holmes. “It is not an English
+paper at all. Hold it up to the light.”
+
+I did so, and saw a large _E_ with a small _g_, a _P_, and a large _G_
+with a small _t_ woven into the texture of the paper.
+
+“What do you make of that?” asked Holmes.
+
+“The name of the maker, no doubt; or his monogram, rather.”
+
+“Not at all. The _G_ with the small _t_ stands for ‘Gesellschaft,’
+which is the German for ‘Company.’ It is a customary contraction like
+our ‘Co.’ _P_, of course, stands for ‘Papier.’ Now for the _Eg_. Let us
+glance at our Continental Gazetteer.” He took down a heavy brown volume
+from his shelves. “Eglow, Eglonitz—here we are, Egria. It is in a
+German-speaking country—in Bohemia, not far from Carlsbad. ‘Remarkable
+as being the scene of the death of Wallenstein, and for its numerous
+glass-factories and paper-mills.’ Ha, ha, my boy, what do you make of
+that?” His eyes sparkled, and he sent up a great blue triumphant cloud
+from his cigarette.
+
+“The paper was made in Bohemia,” I said.
+
+“Precisely. And the man who wrote the note is a German. Do you note the
+peculiar construction of the sentence—‘This account of you we have
+from all quarters received.’ A Frenchman or Russian could not have
+written that. It is the German who is so uncourteous to his verbs. It
+only remains, therefore, to discover what is wanted by this German
+who writes upon Bohemian paper, and prefers wearing a mask to showing
+his face. And here he comes, if I am not mistaken, to resolve all our
+doubts.”
+
+As he spoke there was the sharp sound of horses’ hoofs and grating
+wheels against the curb, followed by a sharp pull at the bell. Holmes
+whistled.
+
+“A pair, by the sound,” said he. “Yes,” he continued, glancing out of
+the window. “A nice little brougham and a pair of beauties. A hundred
+and fifty guineas apiece. There’s money in this case, Watson, if there
+is nothing else.”
+
+“I think that I had better go, Holmes.”
+
+“Not a bit, doctor. Stay where you are. I am lost without my Boswell.
+And this promises to be interesting. It would be a pity to miss it.”
+
+“But your client—”
+
+“Never mind him. I may want your help, and so may he. Here he comes.
+Sit down in that arm-chair, doctor, and give us your best attention.”
+
+A slow and heavy step, which had been heard upon the stairs and in the
+passage, paused immediately outside the door. Then there was a loud and
+authoritative tap.
+
+“Come in!” said Holmes.
+
+[Illustration: “A MAN ENTERED”]
+
+A man entered who could hardly have been less than six feet six inches
+in height, with the chest and limbs of a Hercules. His dress was rich
+with a richness which would, in England, be looked upon as akin to bad
+taste. Heavy bands of Astrakhan were slashed across the sleeves and
+fronts of his double-breasted coat, while the deep blue cloak which
+was thrown over his shoulders was lined with flame-colored silk, and
+secured at the neck with a brooch which consisted of a single flaming
+beryl. Boots which extended half-way up his calves, and which were
+trimmed at the tops with rich brown fur, completed the impression of
+barbaric opulence which was suggested by his whole appearance. He
+carried a broad-brimmed hat in his hand, while he wore across the upper
+part of his face, extending down past the cheekbones, a black vizard
+mask, which he had apparently adjusted that very moment, for his hand
+was still raised to it as he entered. From the lower part of the face
+he appeared to be a man of strong character, with a thick, hanging
+lip, and a long, straight chin, suggestive of resolution pushed to the
+length of obstinacy.
+
+“You had my note?” he asked, with a deep harsh voice and a strongly
+marked German accent. “I told you that I would call.” He looked from
+one to the other of us, as if uncertain which to address.
+
+“Pray take a seat,” said Holmes. “This is my friend and colleague, Dr.
+Watson, who is occasionally good enough to help me in my cases. Whom
+have I the honor to address?”
+
+“You may address me as the Count Von Kramm, a Bohemian nobleman.
+I understand that this gentleman, your friend, is a man of honor
+and discretion, whom I may trust with a matter of the most extreme
+importance. If not, I should much prefer to communicate with you alone.”
+
+I rose to go, but Holmes caught me by the wrist and pushed me back into
+my chair. “It is both, or none,” said he. “You may say before this
+gentleman anything which you may say to me.”
+
+The count shrugged his broad shoulders. “Then I must begin,” said he,
+“by binding you both to absolute secrecy for two years, at the end of
+that time the matter will be of no importance. At present it is not too
+much to say that it is of such weight it may have an influence upon
+European history.”
+
+“I promise,” said Holmes.
+
+“And I.”
+
+“You will excuse this mask,” continued our strange visitor. “The august
+person who employs me wishes his agent to be unknown to you, and I may
+confess at once that the title by which I have just called myself is
+not exactly my own.”
+
+“I was aware of it,” said Holmes, dryly.
+
+“The circumstances are of great delicacy, and every precaution has
+to be taken to quench what might grow to be an immense scandal and
+seriously compromise one of the reigning families of Europe. To speak
+plainly, the matter implicates the great House of Ormstein, hereditary
+kings of Bohemia.”
+
+“I was also aware of that,” murmured Holmes, settling himself down in
+his arm-chair and closing his eyes.
+
+Our visitor glanced with some apparent surprise at the languid,
+lounging figure of the man who had been no doubt depicted to him as
+the most incisive reasoner and most energetic agent in Europe. Holmes
+slowly reopened his eyes and looked impatiently at his gigantic client.
+
+“If your Majesty would condescend to state your case,” he remarked, “I
+should be better able to advise you.”
+
+The man sprang from his chair and paced up and down the room in
+uncontrollable agitation. Then, with a gesture of desperation, he tore
+the mask from his face and hurled it upon the ground. “You are right,”
+he cried; “I am the King. Why should I attempt to conceal it?”
+
+“Why, indeed?” murmured Holmes. “Your Majesty had not spoken before
+I was aware that I was addressing Wilhelm Gottsreich Sigismond von
+Ormstein, Grand Duke of Cassel-Felstein, and hereditary King of
+Bohemia.”
+
+“But you can understand,” said our strange visitor, sitting down once
+more and passing his hand over his high, white forehead, “you can
+understand that I am not accustomed to doing such business in my own
+person. Yet the matter was so delicate that I could not confide it to
+an agent without putting myself in his power. I have come _incognito_
+from Prague for the purpose of consulting you.”
+
+“Then, pray consult,” said Holmes, shutting his eyes once more.
+
+“The facts are briefly these: Some five years ago, during a lengthy
+visit to Warsaw, I made the acquaintance of the well-known
+adventuress, Irene Adler. The name is no doubt familiar to you.”
+
+“Kindly look her up in my index, doctor,” murmured Holmes, without
+opening his eyes. For many years he had adopted a system of docketing
+all paragraphs concerning men and things, so that it was difficult
+to name a subject or a person on which he could not at once furnish
+information. In this case I found her biography sandwiched in between
+that of a Hebrew Rabbi and that of a staff-commander who had written a
+monograph upon the deep-sea fishes.
+
+“Let me see!” said Holmes. “Hum! Born in New Jersey in the year
+1858. Contralto—hum! La Scala, hum! Prima donna Imperial Opera of
+Warsaw—Yes! Retired from operatic stage—ha! Living in London—quite
+so! Your Majesty, as I understand, became entangled with this young
+person, wrote her some compromising letters, and is now desirous of
+getting those letters back.”
+
+“Precisely so. But how—”
+
+“Was there a secret marriage?”
+
+“None.”
+
+“No legal papers or certificates?”
+
+“None.”
+
+“Then I fail to follow your Majesty. If this young person should
+produce her letters for blackmailing or other purposes, how is she to
+prove their authenticity?”
+
+“There is the writing.”
+
+“Pooh, pooh! Forgery.”
+
+“My private note-paper.”
+
+“Stolen.”
+
+“My own seal.”
+
+“Imitated.”
+
+“My photograph.”
+
+“Bought.”
+
+“We were both in the photograph.”
+
+“Oh dear! That is very bad! Your Majesty has indeed committed an
+indiscretion.”
+
+“I was mad—insane.”
+
+“You have compromised yourself seriously.”
+
+“I was only Crown Prince then. I was young. I am but thirty now.”
+
+“It must be recovered.”
+
+“We have tried and failed.”
+
+“Your Majesty must pay. It must be bought.”
+
+“She will not sell.”
+
+“Stolen, then.”
+
+“Five attempts have been made. Twice burglars in my pay ransacked her
+house. Once we diverted her luggage when she travelled. Twice she has
+been waylaid. There has been no result.”
+
+“No sign of it?”
+
+“Absolutely none.”
+
+Holmes laughed. “It is quite a pretty little problem,” said he.
+
+“But a very serious one to me,” returned the King, reproachfully.
+
+“Very, indeed. And what does she propose to do with the photograph?”
+
+“To ruin me.”
+
+“But how?”
+
+“I am about to be married.”
+
+“So I have heard.”
+
+“To Clotilde Lothman von Saxe-Meningen, second daughter of the King of
+Scandinavia. You may know the strict principles of her family. She is
+herself the very soul of delicacy. A shadow of a doubt as to my conduct
+would bring the matter to an end.”
+
+“And Irene Adler?”
+
+“Threatens to send them the photograph. And she will do it. I know that
+she will do it. You do not know her, but she has a soul of steel. She
+has the face of the most beautiful of women, and the mind of the most
+resolute of men. Rather than I should marry another woman, there are
+no lengths to which she would not go—none.”
+
+“You are sure that she has not sent it yet?”
+
+“I am sure.”
+
+“And why?”
+
+“Because she has said that she would send it on the day when the
+betrothal was publicly proclaimed. That will be next Monday.”
+
+“Oh, then, we have three days yet,” said Holmes, with a yawn. “That is
+very fortunate, as I have one or two matters of importance to look into
+just at present. Your Majesty will, of course, stay in London for the
+present?”
+
+“Certainly. You will find me at the Langham, under the name of the
+Count Von Kramm.”
+
+“Then I shall drop you a line to let you know how we progress.”
+
+“Pray do so. I shall be all anxiety.”
+
+“Then, as to money?”
+
+“You have _carte blanche_.”
+
+“Absolutely?”
+
+“I tell you that I would give one of the provinces of my kingdom to
+have that photograph.”
+
+“And for present expenses?”
+
+The king took a heavy chamois leather bag from under his cloak and laid
+it on the table.
+
+“There are three hundred pounds in gold and seven hundred in notes,” he
+said.
+
+Holmes scribbled a receipt upon a sheet of his note-book and handed it
+to him.
+
+“And mademoiselle’s address?” he asked.
+
+“Is Briony Lodge, Serpentine Avenue, St. John’s Wood.”
+
+Holmes took a note of it. “One other question,” said he. “Was the
+photograph a cabinet?”
+
+“It was.”
+
+“Then, good-night, your Majesty, and I trust that we shall soon have
+some good news for you. And good-night, Watson,” he added, as the
+wheels of the royal brougham rolled down the street. “If you will be
+good enough to call to-morrow afternoon, at three o’clock, I should
+like to chat this little matter over with you.”
+
+
+II
+
+At three o’clock precisely I was at Baker Street, but Holmes had not
+yet returned. The landlady informed me that he had left the house
+shortly after eight o’clock in the morning. I sat down beside the
+fire, however, with the intention of awaiting him, however long he
+might be. I was already deeply interested in his inquiry, for, though
+it was surrounded by none of the grim and strange features which
+were associated with the two crimes which I have already recorded,
+still, the nature of the case and the exalted station of his client
+gave it a character of its own. Indeed, apart from the nature of the
+investigation which my friend had on hand, there was something in his
+masterly grasp of a situation, and his keen, incisive reasoning, which
+made it a pleasure to me to study his system of work, and to follow the
+quick, subtle methods by which he disentangled the most inextricable
+mysteries. So accustomed was I to his invariable success that the very
+possibility of his failing had ceased to enter into my head.
+
+It was close upon four before the door opened, and a drunken-looking
+groom, ill-kempt and side-whiskered, with an inflamed face and
+disreputable clothes, walked into the room. Accustomed as I was to
+my friend’s amazing powers in the use of disguises, I had to look
+three times before I was certain that it was indeed he. With a nod
+he vanished into the bedroom, whence he emerged in five minutes
+tweed-suited and respectable, as of old. Putting his hands into his
+pockets, he stretched out his legs in front of the fire, and laughed
+heartily for some minutes.
+
+“Well, really!” he cried, and then he choked; and laughed again until
+he was obliged to lie back, limp and helpless, in the chair.
+
+“What is it?”
+
+“It’s quite too funny. I am sure you could never guess how I employed
+my morning, or what I ended by doing.”
+
+“I can’t imagine. I suppose that you have been watching the habits, and
+perhaps the house, of Miss Irene Adler.”
+
+“Quite so; but the sequel was rather unusual. I will tell you, however.
+I left the house a little after eight o’clock this morning, in the
+character of a groom out of work. There is a wonderful sympathy and
+freemasonry among horsey men. Be one of them, and you will know all
+that there is to know. I soon found Briony Lodge. It is a _bijou_
+villa, with a garden at the back, but built out in front right up to
+the road, two stories. Chubb lock to the door. Large sitting-room on
+the right side, well furnished, with long windows almost to the floor,
+and those preposterous English window fasteners which a child could
+open. Behind there was nothing remarkable, save that the passage window
+could be reached from the top of the coach-house. I walked round it
+and examined it closely from every point of view, but without noting
+anything else of interest.
+
+“I then lounged down the street, and found, as I expected, that there
+was a mews in a lane which runs down by one wall of the garden. I lent
+the ostlers a hand in rubbing down their horses, and I received in
+exchange twopence, a glass of half-and-half, two fills of shag tobacco,
+and as much information as I could desire about Miss Adler, to say
+nothing of half a dozen other people in the neighborhood in whom I was
+not in the least interested, but whose biographies I was compelled to
+listen to.”
+
+“And what of Irene Adler?” I asked.
+
+“Oh, she has turned all the men’s heads down in that part. She
+is the daintiest thing under a bonnet on this planet. So say the
+Serpentine-mews, to a man. She lives quietly, sings at concerts, drives
+out at five every day, and returns at seven sharp for dinner. Seldom
+goes out at other times, except when she sings. Has only one male
+visitor, but a good deal of him. He is dark, handsome, and dashing,
+never calls less than once a day, and often twice. He is a Mr. Godfrey
+Norton, of the Inner Temple. See the advantages of a cabman as a
+confidant. They had driven him home a dozen times from Serpentine-mews,
+and knew all about him. When I had listened to all that they had to
+tell, I began to walk up and down near Briony Lodge once more, and to
+think over my plan of campaign.
+
+“This Godfrey Norton was evidently an important factor in the
+matter. He was a lawyer. That sounded ominous. What was the relation
+between them, and what the object of his repeated visits? Was she
+his client, his friend, or his mistress? If the former, she had
+probably transferred the photograph to his keeping. If the latter,
+it was less likely. On the issue of this question depended whether I
+should continue my work at Briony Lodge, or turn my attention to the
+gentleman’s chambers in the Temple. It was a delicate point, and it
+widened the field of my inquiry. I fear that I bore you with these
+details, but I have to let you see my little difficulties, if you are
+to understand the situation.”
+
+“I am following you closely,” I answered.
+
+“I was still balancing the matter in my mind, when a hansom cab drove
+up to Briony Lodge, and a gentleman sprang out. He was a remarkably
+handsome man, dark, aquiline, and mustached—evidently the man of whom
+I had heard. He appeared to be in a great hurry, shouted to the cabman
+to wait, and brushed past the maid who opened the door with the air of
+a man who was thoroughly at home.
+
+“He was in the house about half an hour, and I could catch glimpses of
+him in the windows of the sitting-room, pacing up and down, talking
+excitedly, and waving his arms. Of her I could see nothing. Presently
+he emerged, looking even more flurried than before. As he stepped up
+to the cab, he pulled a gold watch from his pocket and looked at it
+earnestly. ‘Drive like the devil,’ he shouted, ‘first to Gross &
+Hankey’s in Regent Street, and then to the church of St. Monica in the
+Edgware Road. Half a guinea if you do it in twenty minutes!’
+
+“Away they went, and I was just wondering whether I should not do
+well to follow them, when up the lane came a neat little landau, the
+coachman with his coat only half-buttoned, and his tie under his ear,
+while all the tags of his harness were sticking out of the buckles. It
+hadn’t pulled up before she shot out of the hall door and into it. I
+only caught a glimpse of her at the moment, but she was a lovely woman,
+with a face that a man might die for.
+
+“‘The Church of St. Monica, John,’ she cried, ‘and half a sovereign if
+you reach it in twenty minutes.’
+
+“This was quite too good to lose, Watson. I was just balancing whether
+I should run for it, or whether I should perch behind her landau,
+when a cab came through the street. The driver looked twice at such a
+shabby fare; but I jumped in before he could object. ‘The Church of
+St. Monica,’ said I, ‘and half a sovereign if you reach it in twenty
+minutes.’ It was twenty-five minutes to twelve, and of course it was
+clear enough what was in the wind.
+
+“My cabby drove fast. I don’t think I ever drove faster, but the others
+were there before us. The cab and the landau with their steaming horses
+were in front of the door when I arrived. I paid the man and hurried
+into the church. There was not a soul there save the two whom I had
+followed and a surpliced clergyman, who seemed to be expostulating with
+them. They were all three standing in a knot in front of the altar. I
+lounged up the side aisle like any other idler who has dropped into a
+church. Suddenly, to my surprise, the three at the altar faced round to
+me, and Godfrey Norton came running as hard as he could towards me.”
+
+“Thank God!” he cried. “You’ll do. Come! Come!”
+
+“What then?” I asked.
+
+“Come, man, come, only three minutes, or it won’t be legal.”
+
+“I was half-dragged up to the altar, and, before I knew where I was, I
+found myself mumbling responses which were whispered in my ear, and
+vouching for things of which I knew nothing, and generally assisting
+in the secure tying up of Irene Adler, spinster, to Godfrey Norton,
+bachelor. It was all done in an instant, and there was the gentleman
+thanking me on the one side and the lady on the other, while the
+clergyman beamed on me in front. It was the most preposterous position
+in which I ever found myself in my life, and it was the thought of
+it that started me laughing just now. It seems that there had been
+some informality about their license, that the clergyman absolutely
+refused to marry them without a witness of some sort, and that my lucky
+appearance saved the bridegroom from having to sally out into the
+streets in search of a best man. The bride gave me a sovereign, and I
+mean to wear it on my watch-chain in memory of the occasion.”
+
+“This is a very unexpected turn of affairs,” said I; “and what then?”
+
+“Well, I found my plans very seriously menaced. It looked as if the
+pair might take an immediate departure, and so necessitate very prompt
+and energetic measures on my part. At the church door, however, they
+separated, he driving back to the Temple, and she to her own house. ‘I
+shall drive out in the park at five as usual,’ she said, as she left
+him. I heard no more. They drove away in different directions, and I
+went off to make my own arrangements.”
+
+“Which are?”
+
+“Some cold beef and a glass of beer,” he answered, ringing the bell. “I
+have been too busy to think of food, and I am likely to be busier still
+this evening. By the way, doctor, I shall want your co-operation.”
+
+“I shall be delighted.”
+
+“You don’t mind breaking the law?”
+
+“Not in the least.”
+
+“Nor running a chance of arrest?”
+
+“Not in a good cause.”
+
+“Oh, the cause is excellent!”
+
+“Then I am your man.”
+
+“I was sure that I might rely on you.”
+
+“But what is it you wish?”
+
+“When Mrs. Turner has brought in the tray I will make it clear to
+you. Now,” he said, as he turned hungrily on the simple fare that our
+landlady had provided, “I must discuss it while I eat, for I have not
+much time. It is nearly five now. In two hours we must be on the scene
+of action. Miss Irene, or Madame, rather, returns from her drive at
+seven. We must be at Briony Lodge to meet her.”
+
+“And what then?”
+
+“You must leave that to me. I have already arranged what is to occur.
+There is only one point on which I must insist. You must not interfere,
+come what may. You understand?”
+
+“I am to be neutral?”
+
+“To do nothing whatever. There will probably be some small
+unpleasantness. Do not join in it. It will end in my being conveyed
+into the house. Four or five minutes afterwards the sitting-room window
+will open. You are to station yourself close to that open window.”
+
+“Yes.”
+
+“You are to watch me, for I will be visible to you.”
+
+“Yes.”
+
+“And when I raise my hand—so—you will throw into the room what I give
+you to throw, and will, at the same time, raise the cry of fire. You
+quite follow me?”
+
+“Entirely.”
+
+“It is nothing very formidable,” he said, taking a long cigar-shaped
+roll from his pocket. “It is an ordinary plumber’s smoke-rocket,
+fitted with a cap at either end to make it self-lighting. Your task is
+confined to that. When you raise your cry of fire, it will be taken
+up by quite a number of people. You may then walk to the end of the
+street, and I will rejoin you in ten minutes. I hope that I have made
+myself clear?”
+
+“I am to remain neutral, to get near the window, to watch you, and, at
+the signal, to throw in this object, then to raise the cry of fire, and
+to wait you at the corner of the street.”
+
+“Precisely.”
+
+“Then you may entirely rely on me.”
+
+“That is excellent. I think, perhaps, it is almost time that I prepare
+for the new role I have to play.”
+
+He disappeared into his bedroom, and returned in a few minutes in the
+character of an amiable and simple-minded Nonconformist clergyman. His
+broad black hat, his baggy trousers, his white tie, his sympathetic
+smile, and general look of peering and benevolent curiosity were such
+as Mr. John Hare alone could have equalled. It was not merely that
+Holmes changed his costume. His expression, his manner, his very soul
+seemed to vary with every fresh part that he assumed. The stage lost a
+fine actor, even as science lost an acute reasoner, when he became a
+specialist in crime.
+
+It was a quarter past six when we left Baker Street, and it still
+wanted ten minutes to the hour when we found ourselves in Serpentine
+Avenue. It was already dusk, and the lamps were just being lighted as
+we paced up and down in front of Briony Lodge, waiting for the coming
+of its occupant. The house was just such as I had pictured it from
+Sherlock Holmes’s succinct description, but the locality appeared to
+be less private that I expected. On the contrary, for a small street
+in a quiet neighborhood, it was remarkably animated. There was a
+group of shabbily-dressed men smoking and laughing in a corner, a
+scissors-grinder with his wheel, two guardsmen who were flirting with a
+nurse-girl, and several well-dressed young men who were lounging up and
+down with cigars in their mouths.
+
+“You see,” remarked Holmes, as we paced to and fro in front of the
+house, “this marriage rather simplifies matters. The photograph becomes
+a double-edged weapon now. The chances are that she would be as averse
+to its being seen by Mr. Godfrey Norton, as our client is to its coming
+to the eyes of his princess. Now the question is, Where are we to find
+the photograph?”
+
+“Where, indeed?”
+
+“It is most unlikely that she carries it about with her. It is cabinet
+size. Too large for easy concealment about a woman’s dress. She knows
+that the King is capable of having her waylaid and searched. Two
+attempts of the sort have already been made. We may take it, then, that
+she does not carry it about with her.”
+
+“Where, then?”
+
+“Her banker or her lawyer. There is that double possibility. But I am
+inclined to think neither. Women are naturally secretive, and they
+like to do their own secreting. Why should she hand it over to any one
+else? She could trust her own guardianship, but she could not tell
+what indirect or political influence might be brought to bear upon a
+business man. Besides, remember that she had resolved to use it within
+a few days. It must be where she can lay her hands upon it. It must be
+in her own house.”
+
+“But it has twice been burgled.”
+
+“Pshaw! They did not know how to look.”
+
+“But how will you look?”
+
+“I will not look.”
+
+“What then?”
+
+“I will get her to show me.”
+
+“But she will refuse.”
+
+“She will not be able to. But I hear the rumble of wheels. It is her
+carriage. Now carry out my orders to the letter.”
+
+As he spoke the gleam of the side-lights of a carriage came round the
+curve of the avenue. It was a smart little landau which rattled up to
+the door of Briony Lodge. As it pulled up, one of the loafing men at
+the corner dashed forward to open the door in the hope of earning a
+copper, but was elbowed away by another loafer, who had rushed up with
+the same intention. A fierce quarrel broke out, which was increased by
+the two guardsmen, who took sides with one of the loungers, and by the
+scissors-grinder, who was equally hot upon the other side. A blow was
+struck, and in an instant the lady, who had stepped from her carriage,
+was the centre of a little knot of flushed and struggling men, who
+struck savagely at each other with their fists and sticks. Holmes
+dashed into the crowd to protect the lady; but just as he reached her
+he gave a cry and dropped to the ground, with the blood running freely
+down his face. At his fall the guardsmen took to their heels in one
+direction and the loungers in the other, while a number of better
+dressed people, who had watched the scuffle without taking part in it,
+crowded in to help the lady and to attend to the injured man. Irene
+Adler, as I will still call her, had hurried up the steps; but she
+stood at the top with her superb figure outlined against the lights of
+the hall, looking back into the street.
+
+“Is the poor gentleman much hurt?” she asked.
+
+“He is dead,” cried several voices.
+
+“No, no, there’s life in him!” shouted another. “But he’ll be gone
+before you can get him to hospital.”
+
+“He’s a brave fellow,” said a woman. “They would have had the lady’s
+purse and watch if it hadn’t been for him. They were a gang, and a
+rough one, too. Ah, he’s breathing now.”
+
+“He can’t lie in the street. May we bring him in, marm?”
+
+“Surely. Bring him into the sitting-room. There is a comfortable sofa.
+This way, please!”
+
+Slowly and solemnly he was borne into Briony Lodge and laid out in the
+principal room, while I still observed the proceedings from my post
+by the window. The lamps had been lit, but the blinds had not been
+drawn, so that I could see Holmes as he lay upon the couch. I do not
+know whether he was seized with compunction at that moment for the part
+he was playing, but I know that I never felt more heartily ashamed of
+myself in my life than when I saw the beautiful creature against whom
+I was conspiring, or the grace and kindliness with which she waited
+upon the injured man. And yet it would be the blackest treachery to
+Holmes to draw back now from the part which he had intrusted to me.
+I hardened my heart, and took the smoke-rocket from under my ulster.
+After all, I thought, we are not injuring her. We are but preventing
+her from injuring another.
+
+Holmes had sat up upon the couch, and I saw him motion like a man who
+is in need of air. A maid rushed across and threw open the window. At
+the same instant I saw him raise his hand, and at the signal I tossed
+my rocket into the room with a cry of “Fire!” The word was no sooner
+out of my mouth than the whole crowd of spectators, well dressed and
+ill—gentlemen, ostlers, and servant-maids—joined in a general shriek
+of “Fire!” Thick clouds of smoke curled through the room and out at
+the open window. I caught a glimpse of rushing figures, and a moment
+later the voice of Holmes from within assuring them that it was a false
+alarm. Slipping through the shouting crowd I made my way to the corner
+of the street, and in ten minutes was rejoiced to find my friend’s arm
+in mine, and to get away from the scene of uproar. He walked swiftly
+and in silence for some few minutes, until we had turned down one of
+the quiet streets which lead towards the Edgware Road.
+
+“You did it very nicely, doctor,” he remarked. “Nothing could have been
+better. It is all right.”
+
+“You have the photograph?”
+
+“I know where it is.”
+
+“And how did you find out?”
+
+“She showed me, as I told you that she would.”
+
+“I am still in the dark.”
+
+“I do not wish to make a mystery,” said he, laughing. “The matter was
+perfectly simple. You, of course, saw that every one in the street was
+an accomplice. They were all engaged for the evening.”
+
+“I guessed as much.”
+
+“Then, when the row broke out, I had a little moist red paint in the
+palm of my hand. I rushed forward, fell down, clapped my hand to my
+face, and became a piteous spectacle. It is an old trick.”
+
+“That also I could fathom.”
+
+“Then they carried me in. She was bound to have me in. What else could
+she do? And into her sitting-room, which was the very room which I
+suspected. It lay between that and her bedroom, and I was determined
+to see which. They laid me on a couch, I motioned for air, they were
+compelled to open the window, and you had your chance.”
+
+“How did that help you?”
+
+“It was all-important. When a woman thinks that her house is on fire,
+her instinct is at once to rush to the thing which she values most. It
+is a perfectly overpowering impulse, and I have more than once taken
+advantage of it. In the case of the Darlington Substitution Scandal it
+was of use to me, and also in the Arnsworth Castle business. A married
+woman grabs at her baby; an unmarried one reaches for her jewel-box.
+Now it was clear to me that our lady of to-day had nothing in the house
+more precious to her than what we are in quest of. She would rush to
+secure it. The alarm of fire was admirably done. The smoke and shouting
+were enough to shake nerves of steel. She responded beautifully. The
+photograph is in a recess behind a sliding panel just above the right
+bell-pull. She was there in an instant, and I caught a glimpse of it as
+she half-drew it out. When I cried out that it was a false alarm, she
+replaced it, glanced at the rocket, rushed from the room, and I have
+not seen her since. I rose, and, making my excuses, escaped from the
+house. I hesitated whether to attempt to secure the photograph at once;
+but the coachman had come in, and as he was watching me narrowly, it
+seemed safer to wait. A little over-precipitance may ruin all.”
+
+“And now?” I asked.
+
+“Our quest is practically finished. I shall call with the King
+to-morrow, and with you, if you care to come with us. We will be shown
+into the sitting-room to wait for the lady, but it is probable that
+when she comes she may find neither us nor the photograph. It might be
+a satisfaction to His Majesty to regain it with his own hands.”
+
+“And when will you call?”
+
+“At eight in the morning. She will not be up, so that we shall have a
+clear field. Besides, we must be prompt, for this marriage may mean a
+complete change in her life and habits. I must wire to the King without
+delay.”
+
+We had reached Baker Street, and had stopped at the door. He was
+searching his pockets for the key, when some one passing said:
+
+“Good-night, Mister Sherlock Holmes.”
+
+There were several people on the pavement at the time, but the greeting
+appeared to come from a slim youth in an ulster who had hurried by.
+
+“I’ve heard that voice before,” said Holmes, staring down the dimly-lit
+street. “Now, I wonder who the deuce that could have been.”
+
+
+III
+
+I slept at Baker Street that night, and we were engaged upon our toast
+and coffee in the morning when the King of Bohemia rushed into the room.
+
+“You have really got it!” he cried, grasping Sherlock Holmes by either
+shoulder, and looking eagerly into his face.
+
+“Not yet.”
+
+“But you have hopes?”
+
+“I have hopes.”
+
+“Then, come. I am all impatience to be gone.”
+
+“We must have a cab.”
+
+“No, my brougham is waiting.”
+
+“Then that will simplify matters.” We descended, and started off once
+more for Briony Lodge.
+
+“Irene Adler is married,” remarked Holmes.
+
+“Married! When?”
+
+“Yesterday.”
+
+“But to whom?”
+
+“To an English lawyer named Norton.”
+
+“But she could not love him?”
+
+“I am in hopes that she does.”
+
+“And why in hopes?”
+
+“Because it would spare your Majesty all fear of future annoyance. If
+the lady loves her husband, she does not love your Majesty. If she does
+not love your Majesty, there is no reason why she should interfere with
+your Majesty’s plan.”
+
+“It is true. And yet—Well! I wish she had been of my own station! What
+a queen she would have made!” He relapsed into a moody silence, which
+was not broken until we drew up in Serpentine Avenue.
+
+The door of Briony Lodge was open, and an elderly woman stood upon
+the steps. She watched us with a sardonic eye as we stepped from the
+brougham.
+
+“Mr. Sherlock Holmes, I believe?” said she.
+
+“I am Mr. Holmes,” answered my companion, looking at her with a
+questioning and rather startled gaze.
+
+“Indeed! My mistress told me that you were likely to call. She left
+this morning with her husband by the 5.15 train from Charing Cross for
+the Continent.”
+
+“What!” Sherlock Holmes staggered back, white with chagrin and
+surprise. “Do you mean that she has left England?”
+
+“Never to return.”
+
+“And the papers?” asked the King, hoarsely. “All is lost.”
+
+“We shall see.” He pushed past the servant and rushed into the
+drawing-room, followed by the King and myself. The furniture was
+scattered about in every direction, with dismantled shelves and open
+drawers, as if the lady had hurriedly ransacked them before her flight.
+Holmes rushed at the bell-pull, tore back a small sliding shutter,
+and, plunging in his hand, pulled out a photograph and a letter. The
+photograph was of Irene Adler herself in evening dress, the letter was
+superscribed to “Sherlock Holmes, Esq. To be left till called for.” My
+friend tore it open, and we all three read it together. It was dated at
+midnight of the preceding night, and ran in this way:
+
+  “MY DEAR MR. SHERLOCK HOLMES,—You really did it very
+  well. You took me in completely. Until after the alarm of
+  fire, I had not a suspicion. But then, when I found how I had
+  betrayed myself, I began to think. I had been warned against
+  you months ago. I had been told that, if the King employed an
+  agent, it would certainly be you. And your address had been
+  given me. Yet, with all this, you made me reveal what you
+  wanted to know. Even after I became suspicious, I found it hard
+  to think evil of such a dear, kind old clergyman. But, you
+  know, I have been trained as an actress myself. Male costume
+  is nothing new to me. I often take advantage of the freedom
+  which it gives. I sent John, the coachman, to watch you, ran
+  up-stairs, got into my walking-clothes, as I call them, and
+  came down just as you departed.
+
+  “Well, I followed you to your door, and so made sure that I was
+  really an object of interest to the celebrated Mr. Sherlock
+  Holmes. Then I, rather imprudently, wished you good-night, and
+  started for the Temple to see my husband.
+
+  “We both thought the best resource was flight, when pursued by
+  so formidable an antagonist; so you will find the nest empty
+  when you call to-morrow. As to the photograph, your client may
+  rest in peace. I love and am loved by a better man than he.
+  The King may do what he will without hinderance from one whom
+  he has cruelly wronged. I keep it only to safeguard myself,
+  and to preserve a weapon which will always secure me from any
+  steps which he might take in the future. I leave a photograph
+  which he might care to possess; and I remain, dear Mr. Sherlock
+  Holmes, very truly yours,      IRENE NORTON, _née_ ADLER.”
+
+“What a woman—oh, what a woman!” cried the King of Bohemia, when we
+had all three read this epistle. “Did I not tell you how quick and
+resolute she was? Would she not have made an admirable queen? Is it not
+a pity that she was not on my level?”
+
+“From what I have seen of the lady she seems indeed to be on a very
+different level to your Majesty,” said Holmes, coldly. “I am sorry
+that I have not been able to bring your Majesty’s business to a more
+successful conclusion.”
+
+“On the contrary, my dear sir,” cried the King; “nothing could be more
+successful. I know that her word is inviolate. The photograph is now as
+safe as if it were in the fire.”
+
+“I am glad to hear your Majesty say so.”
+
+“I am immensely indebted to you. Pray tell me in what way I can reward
+you. This ring—” He slipped an emerald snake ring from his finger and
+held it out upon the palm of his hand.
+
+“Your Majesty has something which I should value even more highly,”
+said Holmes.
+
+“You have but to name it.”
+
+“This photograph!”
+
+The King stared at him in amazement.
+
+“Irene’s photograph!” he cried. “Certainly, if you wish it.”
+
+“I thank your Majesty. Then there is no more to be done in the matter.
+I have the honor to wish you a very good-morning.” He bowed, and,
+turning away without observing the hand which the King had stretched
+out to him, he set off in my company for his chambers.
+
+       *       *       *       *       *
+
+And that was how a great scandal threatened to affect the kingdom of
+Bohemia, and how the best plans of Mr. Sherlock Holmes were beaten by
+a woman’s wit. He used to make merry over the cleverness of women, but
+I have not heard him do it of late. And when he speaks of Irene Adler,
+or when he refers to her photograph, it is always under the honorable
+title of _the_ woman.
+
+
+
+
+Adventure II
+
+THE RED-HEADED LEAGUE
+
+
+I had called upon my friend, Mr. Sherlock Holmes, one day in the autumn
+of last year, and found him in deep conversation with a very stout,
+florid-faced, elderly gentleman, with fiery red hair. With an apology
+for my intrusion, I was about to withdraw, when Holmes pulled me
+abruptly into the room and closed the door behind me.
+
+“You could not possibly have come at a better time, my dear Watson,” he
+said, cordially.
+
+“I was afraid that you were engaged.”
+
+“So I am. Very much so.”
+
+“Then I can wait in the next room.”
+
+“Not at all. This gentleman, Mr. Wilson, has been my partner and helper
+in many of my most successful cases, and I have no doubt that he will
+be of the utmost use to me in yours also.”
+
+The stout gentleman half-rose from his chair and gave a bob of
+greeting, with a quick, little, questioning glance from his small,
+fat-encircled eyes.
+
+“Try the settee,” said Holmes, relapsing into his arm-chair and putting
+his finger-tips together, as was his custom when in judicial moods. “I
+know, my dear Watson, that you share my love of all that is bizarre and
+outside the conventions and humdrum routine of every-day life. You have
+shown your relish for it by the enthusiasm which has prompted you to
+chronicle, and, if you will excuse my saying so, somewhat to embellish
+so many of my own little adventures.”
+
+“Your cases have indeed been of the greatest interest to me,” I
+observed.
+
+“You will remember that I remarked the other day, just before we went
+into the very simple problem presented by Miss Mary Sutherland, that
+for strange effects and extraordinary combinations we must go to
+life itself, which is always far more daring than any effort of the
+imagination.”
+
+“A proposition which I took the liberty of doubting.”
+
+“You did, doctor, but none the less you must come round to my view,
+for otherwise I shall keep on piling fact upon fact on you, until your
+reason breaks down under them and acknowledges me to be right. Now, Mr.
+Jabez Wilson here has been good enough to call upon me this morning,
+and to begin a narrative which promises to be one of the most singular
+which I have listened to for some time. You have heard me remark that
+the strangest and most unique things are very often connected not with
+the larger but with the smaller crimes, and occasionally, indeed, where
+there is room for doubt whether any positive crime has been committed.
+As far as I have heard it is impossible for me to say whether the
+present case is an instance of crime or not, but the course of events
+is certainly among the most singular that I have ever listened to.
+Perhaps, Mr. Wilson, you would have the great kindness to recommence
+your narrative. I ask you, not merely because my friend Dr. Watson has
+not heard the opening part, but also because the peculiar nature of the
+story makes me anxious to have every possible detail from your lips.
+As a rule, when I have heard some slight indication of the course of
+events, I am able to guide myself by the thousands of other similar
+cases which occur to my memory. In the present instance I am forced to
+admit that the facts are, to the best of my belief, unique.”
+
+The portly client puffed out his chest with an appearance of some
+little pride, and pulled a dirty and wrinkled newspaper from the inside
+pocket of his great-coat. As he glanced down the advertisement column,
+with his head thrust forward, and the paper flattened out upon his
+knee, I took a good look at the man, and endeavored, after the fashion
+of my companion, to read the indications which might be presented by
+his dress or appearance.
+
+I did not gain very much, however, by my inspection. Our visitor bore
+every mark of being an average commonplace British tradesman, obese,
+pompous, and slow. He wore rather baggy gray shepherd’s check trousers,
+a not over-clean black frock-coat, unbuttoned in the front, and a drab
+waistcoat with a heavy brassy Albert chain, and a square pierced bit of
+metal dangling down as an ornament. A frayed top-hat and a faded brown
+overcoat with a wrinkled velvet collar lay upon a chair beside him.
+Altogether, look as I would, there was nothing remarkable about the man
+save his blazing red head, and the expression of extreme chagrin and
+discontent upon his features.
+
+Sherlock Holmes’s quick eye took in my occupation, and he shook his
+head with a smile as he noticed my questioning glances. “Beyond the
+obvious facts that he has at some time done manual labor, that he takes
+snuff, that he is a Freemason, that he has been in China, and that he
+has done a considerable amount of writing lately, I can deduce nothing
+else.”
+
+Mr. Jabez Wilson started up in his chair, with his forefinger upon the
+paper, but his eyes upon my companion.
+
+“How, in the name of good-fortune, did you know all that, Mr. Holmes?”
+he asked. “How did you know, for example, that I did manual labor. It’s
+as true as gospel, for I began as a ship’s carpenter.”
+
+“Your hands, my dear sir. Your right hand is quite a size larger than
+your left. You have worked with it, and the muscles are more developed.”
+
+“Well, the snuff, then, and the Freemasonry?”
+
+“I won’t insult your intelligence by telling you how I read that,
+especially as, rather against the strict rules of your order, you use
+an arc-and-compass breastpin.”
+
+“Ah, of course, I forgot that. But the writing?”
+
+“What else can be indicated by that right cuff so very shiny for five
+inches, and the left one with the smooth patch near the elbow where you
+rest it upon the desk.”
+
+“Well, but China?”
+
+“The fish that you have tattooed immediately above your right wrist
+could only have been done in China. I have made a small study of tattoo
+marks, and have even contributed to the literature of the subject.
+That trick of staining the fishes’ scales of a delicate pink is quite
+peculiar to China. When, in addition, I see a Chinese coin hanging from
+your watch-chain, the matter becomes even more simple.”
+
+Mr. Jabez Wilson laughed heavily. “Well, I never!” said he. “I thought
+at first that you had done something clever, but I see that there was
+nothing in it, after all.”
+
+“I begin to think, Watson,” said Holmes, “that I make a mistake in
+explaining. ‘Omne ignotum pro magnifico,’ you know, and my poor little
+reputation, such as it is, will suffer shipwreck if I am so candid. Can
+you not find the advertisement, Mr. Wilson?”
+
+“Yes, I have got it now,” he answered, with his thick, red finger
+planted half-way down the column. “Here it is. This is what began it
+all. You just read it for yourself, sir.”
+
+I took the paper from him, and read as follows:
+
+  “TO THE RED-HEADED LEAGUE: On account of the bequest of the
+  late Ezekiah Hopkins, of Lebanon, Pa., U.S.A., there is now
+  another vacancy open which entitles a member of the League
+  to a salary of £4 a week for purely nominal services. All
+  red-headed men who are sound in body and mind, and above
+  the age of twenty-one years, are eligible. Apply in person on
+  Monday, at eleven o’clock, to Duncan Ross, at the offices of
+  the League, 7 Pope’s Court, Fleet Street.”
+
+“What on earth does this mean?” I ejaculated, after I had twice read
+over the extraordinary announcement.
+
+Holmes chuckled, and wriggled in his chair, as was his habit when in
+high spirits. “It is a little off the beaten track, isn’t it?” said
+he. “And now, Mr. Wilson, off you go at scratch, and tell us all about
+yourself, your household, and the effect which this advertisement had
+upon your fortunes. You will first make a note, doctor, of the paper
+and the date.”
+
+“It is _The Morning Chronicle_, of April 27, 1890. Just two months ago.”
+
+“Very good. Now, Mr. Wilson?”
+
+“Well, it is just as I have been telling you, Mr. Sherlock Holmes,”
+said Jabez Wilson, mopping his forehead; “I have a small pawnbroker’s
+business at Coburg Square, near the city. It’s not a very large affair,
+and of late years it has not done more than just give me a living. I
+used to be able to keep two assistants, but now I only keep one; and I
+would have a job to pay him, but that he is willing to come for half
+wages, so as to learn the business.”
+
+“What is the name of this obliging youth?” asked Sherlock Holmes.
+
+“His name is Vincent Spaulding, and he’s not such a youth, either. It’s
+hard to say his age. I should not wish a smarter assistant, Mr. Holmes;
+and I know very well that he could better himself, and earn twice what
+I am able to give him. But, after all, if he is satisfied, why should I
+put ideas in his head?”
+
+“Why, indeed? You seem most fortunate in having an _employé_ who
+comes under the full market price. It is not a common experience among
+employers in this age. I don’t know that your assistant is not as
+remarkable as your advertisement.”
+
+“Oh, he has his faults, too,” said Mr. Wilson. “Never was such a fellow
+for photography. Snapping away with a camera when he ought to be
+improving his mind, and then diving down into the cellar like a rabbit
+into its hole to develope his pictures. That is his main fault; but, on
+the whole, he’s a good worker. There’s no vice in him.”
+
+“He is still with you, I presume?”
+
+“Yes, sir. He and a girl of fourteen, who does a bit of simple cooking,
+and keeps the place clean—that’s all I have in the house, for I am a
+widower, and never had any family. We live very quietly, sir, the three
+of us; and we keep a roof over our heads, and pay our debts, if we do
+nothing more.
+
+“The first thing that put us out was that advertisement. Spaulding, he
+came down into the office just this day eight weeks, with this very
+paper in his hand, and he says:
+
+“‘I wish to the Lord, Mr. Wilson, that I was a red-headed man.’
+
+“‘Why that?’ I asks.
+
+“‘Why,’ says he, ‘here’s another vacancy on the League of the
+Red-headed Men. It’s worth quite a little fortune to any man who gets
+it, and I understand that there are more vacancies than there are men,
+so that the trustees are at their wits’ end what to do with the money.
+If my hair would only change color, here’s a nice little crib all ready
+for me to step into.’
+
+“‘Why, what is it, then?’ I asked. You see, Mr. Holmes, I am a very
+stay-at-home man, and as my business came to me instead of my having
+to go to it, I was often weeks on end without putting my foot over the
+door-mat. In that way I didn’t know much of what was going on outside,
+and I was always glad of a bit of news.
+
+“‘Have you never heard of the League of the Red-headed Men?’ he asked,
+with his eyes open.
+
+“‘Never.’
+
+“‘Why, I wonder at that, for you are eligible yourself for one of the
+vacancies.’
+
+“‘And what are they worth?’ I asked.
+
+“‘Oh, merely a couple of hundred a year, but the work is slight, and it
+need not interfere very much with one’s other occupations.’
+
+“Well, you can easily think that that made me prick up my ears, for the
+business has not been over-good for some years, and an extra couple of
+hundred would have been very handy.
+
+“‘Tell me all about it,’ said I.
+
+“‘Well,’ said he, showing me the advertisement, ‘you can see for
+yourself that the League has a vacancy, and there is the address
+where you should apply for particulars. As far as I can make out, the
+League was founded by an American millionaire, Ezekiah Hopkins, who
+was very peculiar in his ways. He was himself red-headed, and he had a
+great sympathy for all red-headed men; so, when he died, it was found
+that he had left his enormous fortune in the hands of trustees, with
+instructions to apply the interest to the providing of easy berths to
+men whose hair is of that color. From all I hear it is splendid pay,
+and very little to do.’
+
+“‘But,’ said I, ‘there would be millions of red-headed men who would
+apply.’
+
+“‘Not so many as you might think,’ he answered. ‘You see it is really
+confined to Londoners, and to grown men. This American had started from
+London when he was young, and he wanted to do the old town a good turn.
+Then, again, I have heard it is no use your applying if your hair is
+light red, or dark red, or anything but real bright, blazing, fiery
+red. Now, if you cared to apply, Mr. Wilson, you would just walk in;
+but perhaps it would hardly be worth your while to put yourself out of
+the way for the sake of a few hundred pounds.’
+
+“Now, it is a fact, gentlemen, as you may see for yourselves, that my
+hair is of a very full and rich tint, so that it seemed to me that, if
+there was to be any competition in the matter, I stood as good a chance
+as any man that I had ever met. Vincent Spaulding seemed to know so
+much about it that I thought he might prove useful, so I just ordered
+him to put up the shutters for the day, and to come right away with me.
+He was very willing to have a holiday, so we shut the business up, and
+started off for the address that was given us in the advertisement.
+
+“I never hope to see such a sight as that again, Mr. Holmes. From
+north, south, east, and west every man who had a shade of red in his
+hair had tramped into the city to answer the advertisement. Fleet
+Street was choked with red-headed folk, and Pope’s Court looked
+like a coster’s orange barrow. I should not have thought there were
+so many in the whole country as were brought together by that single
+advertisement. Every shade of color they were—straw, lemon, orange,
+brick, Irish-setter, liver, clay; but, as Spaulding said, there were
+not many who had the real vivid flame-colored tint. When I saw how many
+were waiting, I would have given it up in despair; but Spaulding would
+not hear of it. How he did it I could not imagine, but he pushed and
+pulled and butted until he got me through the crowd, and right up to
+the steps which led to the office. There was a double stream upon the
+stair, some going up in hope, and some coming back dejected; but we
+wedged in as well as we could, and soon found ourselves in the office.”
+
+“Your experience has been a most entertaining one,” remarked Holmes, as
+his client paused and refreshed his memory with a huge pinch of snuff.
+“Pray continue your very interesting statement.”
+
+“There was nothing in the office but a couple of wooden chairs and a
+deal table, behind which sat a small man, with a head that was even
+redder than mine. He said a few words to each candidate as he came
+up, and then he always managed to find some fault in them which would
+disqualify them. Getting a vacancy did not seem to be such a very easy
+matter, after all. However, when our turn came, the little man was much
+more favorable to me than to any of the others, and he closed the door
+as we entered, so that he might have a private word with us.
+
+“‘This is Mr. Jabez Wilson,’ said my assistant, ‘and he is willing to
+fill a vacancy in the League.’
+
+“‘And he is admirably suited for it,’ the other answered. ‘He has every
+requirement. I cannot recall when I have seen anything so fine.’ He
+took a step backward, cocked his head on one side, and gazed at my hair
+until I felt quite bashful. Then suddenly he plunged forward, wrung my
+hand, and congratulated me warmly on my success.
+
+“‘It would be injustice to hesitate,’ said he. ‘You will, however, I am
+sure, excuse me for taking an obvious precaution.’ With that he seized
+my hair in both his hands, and tugged until I yelled with the pain.
+‘There is water in your eyes,’ said he, as he released me. ‘I perceive
+that all is as it should be. But we have to be careful, for we have
+twice been deceived by wigs and once by paint. I could tell you tales
+of cobbler’s wax which would disgust you with human nature.’ He stepped
+over to the window, and shouted through it at the top of his voice that
+the vacancy was filled. A groan of disappointment came up from below,
+and the folk all trooped away in different directions, until there was
+not a red head to be seen except my own and that of the manager.
+
+“‘My name,’ said he, ‘is Mr. Duncan Ross, and I am myself one of the
+pensioners upon the fund left by our noble benefactor. Are you a
+married man, Mr. Wilson? Have you a family?’
+
+“I answered that I had not.
+
+“His face fell immediately.
+
+“‘Dear me!’ he said, gravely, ‘that is very serious indeed! I am sorry
+to hear you say that. The fund was, of course, for the propagation
+and spread of the red-heads as well as for their maintenance. It is
+exceedingly unfortunate that you should be a bachelor.’
+
+“My face lengthened at this, Mr. Holmes, for I thought that I was not
+to have the vacancy after all; but, after thinking it over for a few
+minutes, he said that it would be all right.
+
+“‘In the case of another,’ said he, ‘the objection might be fatal, but
+we must stretch a point in favor of a man with such a head of hair as
+yours. When shall you be able to enter upon your new duties?’
+
+“‘Well, it is a little awkward, for I have a business already,’ said I.
+
+“‘Oh, never mind about that, Mr. Wilson!’ said Vincent Spaulding. ‘I
+shall be able to look after that for you.’
+
+“‘What would be the hours?’ I asked.
+
+“‘Ten to two.’
+
+“Now a pawnbroker’s business is mostly done of an evening, Mr. Holmes,
+especially Thursday and Friday evening, which is just before pay-day;
+so it would suit me very well to earn a little in the mornings.
+Besides, I knew that my assistant was a good man, and that he would see
+to anything that turned up.
+
+“‘That would suit me very well,’ said I. ‘And the pay?’
+
+“‘Is £4 a week.’
+
+“‘And the work?’
+
+“‘Is purely nominal.’
+
+“‘What do you call purely nominal?’
+
+“‘Well, you have to be in the office, or at least in the building, the
+whole time. If you leave, you forfeit your whole position forever.
+The will is very clear upon that point. You don’t comply with the
+conditions if you budge from the office during that time.’
+
+“‘It’s only four hours a day, and I should not think of leaving,’ said
+I.
+
+“‘No excuse will avail,’ said Mr. Duncan Ross, ‘neither sickness nor
+business nor anything else. There you must stay, or you lose your
+billet.’
+
+“‘And the work?’
+
+“‘Is to copy out the “Encyclopædia Britannica.” There is the first
+volume of it in that press. You must find your own ink, pens, and
+blotting-paper, but we provide this table and chair. Will you be ready
+to-morrow?’
+
+“‘Certainly,’ I answered.
+
+“‘Then, good-bye, Mr. Jabez Wilson, and let me congratulate you once
+more on the important position which you have been fortunate enough to
+gain.’ He bowed me out of the room, and I went home with my assistant,
+hardly knowing what to say or do, I was so pleased at my own good
+fortune.
+
+“Well, I thought over the matter all day, and by evening I was in
+low spirits again; for I had quite persuaded myself that the whole
+affair must be some great hoax or fraud, though what its object might
+be I could not imagine. It seemed altogether past belief that any one
+could make such a will, or that they would pay such a sum for doing
+anything so simple as copying out the ‘Encyclopædia Britannica.’
+Vincent Spaulding did what he could to cheer me up, but by bedtime I
+had reasoned myself out of the whole thing. However, in the morning
+I determined to have a look at it anyhow, so I bought a penny bottle
+of ink, and with a quill-pen, and seven sheets of foolscap paper, I
+started off for Pope’s Court.
+
+“Well, to my surprise and delight, everything was as right as possible.
+The table was set out ready for me, and Mr. Duncan Ross was there to
+see that I got fairly to work. He started me off upon the letter A, and
+then he left me; but he would drop in from time to time to see that all
+was right with me. At two o’clock he bade me good-day, complimented me
+upon the amount that I had written, and locked the door of the office
+after me.
+
+“This went on day after day, Mr. Holmes, and on Saturday the manager
+came in and planked down four golden sovereigns for my week’s work.
+It was the same next week, and the same the week after. Every morning
+I was there at ten, and every afternoon I left at two. By degrees Mr.
+Duncan Ross took to coming in only once of a morning, and then, after
+a time, he did not come in at all. Still, of course, I never dared to
+leave the room for an instant, for I was not sure when he might come,
+and the billet was such a good one, and suited me so well, that I would
+not risk the loss of it.
+
+“Eight weeks passed away like this, and I had written about Abbots and
+Archery and Armor and Architecture and Attica, and hoped with diligence
+that I might get on to the B’s before very long. It cost me something
+in foolscap, and I had pretty nearly filled a shelf with my writings.
+And then suddenly the whole business came to an end.”
+
+“To an end?”
+
+“Yes, sir. And no later than this morning. I went to my work as usual
+at ten o’clock, but the door was shut and locked, with a little square
+of card-board hammered on to the middle of the panel with a tack. Here
+it is, and you can read for yourself.”
+
+He held up a piece of white card-board about the size of a sheet of
+note-paper. It read in this fashion:
+
+  “THE RED-HEADED LEAGUE
+   IS
+   DISSOLVED.
+   _October 9, 1890._”
+
+Sherlock Holmes and I surveyed this curt announcement and the rueful
+face behind it, until the comical side of the affair so completely
+overtopped every other consideration that we both burst out into a roar
+of laughter.
+
+“I cannot see that there is anything very funny,” cried our client,
+flushing up to the roots of his flaming head. “If you can do nothing
+better than laugh at me, I can go elsewhere.”
+
+“No, no,” cried Holmes, shoving him back into the chair from which he
+had half risen. “I really wouldn’t miss your case for the world. It is
+most refreshingly unusual. But there is, if you will excuse my saying
+so, something just a little funny about it. Pray what steps did you
+take when you found the card upon the door?”
+
+“I was staggered, sir. I did not know what to do. Then I called at
+the offices round, but none of them seemed to know anything about it.
+Finally, I went to the landlord, who is an accountant living on the
+ground-floor, and I asked him if he could tell me what had become of
+the Red-headed League. He said that he had never heard of any such
+body. Then I asked him who Mr. Duncan Ross was. He answered that the
+name was new to him.
+
+[Illustration: “THE DOOR WAS SHUT AND LOCKED”]
+
+“‘Well,’ said I, ‘the gentleman at No. 4.’
+
+“‘What, the red-headed man?’
+
+“‘Yes.’
+
+“‘Oh,’ said he, ‘his name was William Morris. He was a solicitor, and
+was using my room as a temporary convenience until his new premises
+were ready. He moved out yesterday.’
+
+“‘Where could I find him?’
+
+“‘Oh, at his new offices. He did tell me the address. Yes, 17 King
+Edward Street, near St. Paul’s.’
+
+“I started off, Mr. Holmes, but when I got to that address it was a
+manufactory of artificial knee-caps, and no one in it had ever heard of
+either Mr. William Morris or Mr. Duncan Ross.”
+
+“And what did you do then?” asked Holmes.
+
+“I went home to Saxe-Coburg Square, and I took the advice of my
+assistant. But he could not help me in any way. He could only say that
+if I waited I should hear by post. But that was not quite good enough,
+Mr. Holmes. I did not wish to lose such a place without a struggle, so,
+as I had heard that you were good enough to give advice to poor folk
+who were in need of it, I came right away to you.”
+
+“And you did very wisely,” said Holmes. “Your case is an exceedingly
+remarkable one, and I shall be happy to look into it. From what you
+have told me I think that it is possible that graver issues hang from
+it than might at first sight appear.”
+
+“Grave enough!” said Mr. Jabez Wilson. “Why, I have lost four pound a
+week.”
+
+“As far as you are personally concerned,” remarked Holmes, “I do not
+see that you have any grievance against this extraordinary league. On
+the contrary, you are, as I understand, richer by some £30, to say
+nothing of the minute knowledge which you have gained on every subject
+which comes under the letter A. You have lost nothing by them.”
+
+“No, sir. But I want to find out about them, and who they are, and what
+their object was in playing this prank—if it was a prank—upon me. It
+was a pretty expensive joke for them, for it cost them two and thirty
+pounds.”
+
+“We shall endeavor to clear up these points for you. And, first, one
+or two questions, Mr. Wilson. This assistant of yours who first called
+your attention to the advertisement—how long had he been with you?”
+
+“About a month then.”
+
+“How did he come?”
+
+“In answer to an advertisement.”
+
+“Was he the only applicant?”
+
+“No, I had a dozen.”
+
+“Why did you pick him?”
+
+“Because he was handy, and would come cheap.”
+
+“At half-wages, in fact.”
+
+“Yes.”
+
+“What is he like, this Vincent Spaulding?”
+
+“Small, stout-built, very quick in his ways, no hair on his face,
+though he’s not short of thirty. Has a white splash of acid upon his
+forehead.”
+
+Holmes sat up in his chair in considerable excitement. “I thought as
+much,” said he. “Have you ever observed that his ears are pierced for
+earrings?”
+
+“Yes, sir. He told me that a gypsy had done it for him when he was a
+lad.”
+
+“Hum!” said Holmes, sinking back in deep thought. “He is still with
+you?”
+
+“Oh yes, sir; I have only just left him.”
+
+“And has your business been attended to in your absence?”
+
+“Nothing to complain of, sir. There’s never very much to do of a
+morning.”
+
+“That will do, Mr. Wilson. I shall be happy to give you an opinion upon
+the subject in the course of a day or two. To-day is Saturday, and I
+hope that by Monday we may come to a conclusion.”
+
+“Well, Watson,” said Holmes, when our visitor had left us, “what do you
+make of it all?”
+
+“I make nothing of it,” I answered, frankly. “It is a most mysterious
+business.”
+
+“As a rule,” said Holmes, “the more bizarre a thing is the less
+mysterious it proves to be. It is your commonplace, featureless crimes
+which are really puzzling, just as a commonplace face is the most
+difficult to identify. But I must be prompt over this matter.”
+
+“What are you going to do, then?” I asked.
+
+“To smoke,” he answered. “It is quite a three-pipe problem, and I beg
+that you won’t speak to me for fifty minutes.” He curled himself up
+in his chair, with his thin knees drawn up to his hawk-like nose, and
+there he sat with his eyes closed and his black clay pipe thrusting out
+like the bill of some strange bird. I had come to the conclusion that
+he had dropped asleep, and indeed was nodding myself, when he suddenly
+sprang out of his chair with the gesture of a man who has made up his
+mind, and put his pipe down upon the mantel-piece.
+
+“Sarasate plays at the St. James’s Hall this afternoon,” he remarked.
+“What do you think, Watson? Could your patients spare you for a few
+hours?”
+
+“I have nothing to do to-day. My practice is never very absorbing.”
+
+“Then put on your hat and come. I am going through the city first, and
+we can have some lunch on the way. I observe that there is a good deal
+of German music on the programme, which is rather more to my taste than
+Italian or French. It is introspective, and I want to introspect. Come
+along!”
+
+We travelled by the Underground as far as Aldersgate; and a short walk
+took us to Saxe-Coburg Square, the scene of the singular story which we
+had listened to in the morning. It was a pokey, little, shabby-genteel
+place, where four lines of dingy two-storied brick houses looked out
+into a small railed-in enclosure, where a lawn of weedy grass and
+a few clumps of faded laurel-bushes made a hard fight against a
+smoke-laden and uncongenial atmosphere. Three gilt balls and a brown
+board with “JABEZ WILSON” in white letters, upon a corner
+house, announced the place where our red-headed client carried on his
+business. Sherlock Holmes stopped in front of it with his head on one
+side, and looked it all over, with his eyes shining brightly between
+puckered lids. Then he walked slowly up the street, and then down again
+to the corner, still looking keenly at the houses. Finally he returned
+to the pawnbroker’s, and, having thumped vigorously upon the pavement
+with his stick two or three times, he went up to the door and knocked.
+It was instantly opened by a bright-looking, clean-shaven young fellow,
+who asked him to step in.
+
+“Thank you,” said Holmes, “I only wished to ask you how you would go
+from here to the Strand.”
+
+“Third right, fourth left,” answered the assistant, promptly, closing
+the door.
+
+“Smart fellow, that,” observed Holmes, as we walked away. “He is, in my
+judgment, the fourth smartest man in London, and for daring I am not
+sure that he has not a claim to be third. I have known something of him
+before.”
+
+“Evidently,” said I, “Mr. Wilson’s assistant counts for a good deal in
+this mystery of the Red-headed League. I am sure that you inquired your
+way merely in order that you might see him.”
+
+“Not him.”
+
+“What then?”
+
+“The knees of his trousers.”
+
+“And what did you see?”
+
+“What I expected to see.”
+
+“Why did you beat the pavement?”
+
+“My dear doctor, this is a time for observation, not for talk. We are
+spies in an enemy’s country. We know something of Saxe-Coburg Square.
+Let us now explore the parts which lie behind it.”
+
+The road in which we found ourselves as we turned round the corner
+from the retired Saxe-Coburg Square presented as great a contrast to
+it as the front of a picture does to the back. It was one of the main
+arteries which convey the traffic of the city to the north and west.
+The roadway was blocked with the immense stream of commerce flowing
+in a double tide inward and outward, while the foot-paths were black
+with the hurrying swarm of pedestrians. It was difficult to realize
+as we looked at the line of fine shops and stately business premises
+that they really abutted on the other side upon the faded and stagnant
+square which we had just quitted.
+
+“Let me see,” said Holmes, standing at the corner, and glancing along
+the line, “I should like just to remember the order of the houses here.
+It is a hobby of mine to have an exact knowledge of London. There is
+Mortimer’s, the tobacconist, the little newspaper shop, the Coburg
+branch of the City and Suburban Bank, the Vegetarian Restaurant, and
+McFarlane’s carriage-building depot. That carries us right on to the
+other block. And now, doctor, we’ve done our work, so it’s time we had
+some play. A sandwich and a cup of coffee, and then off to violin-land,
+where all is sweetness and delicacy and harmony, and there are no
+red-headed clients to vex us with their conundrums.”
+
+My friend was an enthusiastic musician, being himself not only a
+very capable performer, but a composer of no ordinary merit. All the
+afternoon he sat in the stalls wrapped in the most perfect happiness,
+gently waving his long, thin fingers in time to the music, while his
+gently smiling face and his languid, dreamy eyes were as unlike those
+of Holmes, the sleuth-hound, Holmes the relentless, keen-witted,
+ready-handed criminal agent, as it was possible to conceive. In his
+singular character the dual nature alternately asserted itself, and
+his extreme exactness and astuteness represented, as I have often
+thought, the reaction against the poetic and contemplative mood which
+occasionally predominated in him. The swing of his nature took him from
+extreme languor to devouring energy; and, as I knew well, he was never
+so truly formidable as when, for days on end, he had been lounging in
+his arm-chair amid his improvisations and his black-letter editions.
+Then it was that the lust of the chase would suddenly come upon him,
+and that his brilliant reasoning power would rise to the level of
+intuition, until those who were unacquainted with his methods would
+look askance at him as on a man whose knowledge was not that of other
+mortals. When I saw him that afternoon so enrapt in the music at St.
+James’s Hall I felt that an evil time might be coming upon those whom
+he had set himself to hunt down.
+
+“You want to go home, no doubt, doctor,” he remarked, as we emerged.
+
+“Yes, it would be as well.”
+
+“And I have some business to do which will take some hours. This
+business at Coburg Square is serious.”
+
+“Why serious?”
+
+“A considerable crime is in contemplation. I have every reason to
+believe that we shall be in time to stop it. But to-day being Saturday
+rather complicates matters. I shall want your help to-night.”
+
+“At what time?”
+
+“Ten will be early enough.”
+
+“I shall be at Baker Street at ten.”
+
+“Very well. And, I say, doctor, there may be some little danger, so
+kindly put your army revolver in your pocket.” He waved his hand,
+turned on his heel, and disappeared in an instant among the crowd.
+
+[Illustration: “ALL AFTERNOON HE SAT IN THE STALLS”]
+
+I trust that I am not more dense than my neighbors, but I was always
+oppressed with a sense of my own stupidity in my dealings with Sherlock
+Holmes. Here I had heard what he had heard, I had seen what he had
+seen, and yet from his words it was evident that he saw clearly not
+only what had happened, but what was about to happen, while to me the
+whole business was still confused and grotesque. As I drove home to
+my house in Kensington I thought over it all, from the extraordinary
+story of the red-headed copier of the “Encyclopædia” down to the visit
+to Saxe-Coburg Square, and the ominous words with which he had parted
+from me. What was this nocturnal expedition, and why should I go armed?
+Where were we going, and what were we to do? I had the hint from Holmes
+that this smooth-faced pawnbroker’s assistant was a formidable man—a
+man who might play a deep game. I tried to puzzle it out, but gave it
+up in despair, and set the matter aside until night should bring an
+explanation.
+
+It was a quarter past nine when I started from home and made my way
+across the Park, and so through Oxford Street to Baker Street. Two
+hansoms were standing at the door, and, as I entered the passage, I
+heard the sound of voices from above. On entering his room I found
+Holmes in animated conversation with two men, one of whom I recognized
+as Peter Jones, the official police agent, while the other was a long,
+thin, sad-faced man, with a very shiny hat and oppressively respectable
+frock-coat.
+
+“Ha! our party is complete,” said Holmes, buttoning up his pea-jacket,
+and taking his heavy hunting crop from the rack. “Watson, I think
+you know Mr. Jones, of Scotland Yard? Let me introduce you to Mr.
+Merryweather, who is to be our companion in to-night’s adventure.”
+
+“We’re hunting in couples again, doctor, you see,” said Jones, in his
+consequential way. “Our friend here is a wonderful man for starting a
+chase. All he wants is an old dog to help him to do the running down.”
+
+“I hope a wild goose may not prove to be the end of our chase,”
+observed Mr. Merryweather, gloomily.
+
+“You may place considerable confidence in Mr. Holmes, sir,” said the
+police agent, loftily. “He has his own little methods, which are, if he
+won’t mind my saying so, just a little too theoretical and fantastic,
+but he has the makings of a detective in him. It is not too much to
+say that once or twice, as in that business of the Sholto murder and
+the Agra treasure, he has been more nearly correct than the official
+force.”
+
+“Oh, if you say so, Mr. Jones, it is all right,” said the stranger,
+with deference. “Still, I confess that I miss my rubber. It is the
+first Saturday night for seven-and-twenty years that I have not had my
+rubber.”
+
+“I think you will find,” said Sherlock Holmes, “that you will play for
+a higher stake to-night than you have ever done yet, and that the play
+will be more exciting. For you, Mr. Merryweather, the stake will be
+some £30,000; and for you, Jones, it will be the man upon whom you wish
+to lay your hands.”
+
+“John Clay, the murderer, thief, smasher, and forger. He’s a young man,
+Mr. Merryweather, but he is at the head of his profession, and I would
+rather have my bracelets on him than on any criminal in London. He’s a
+remarkable man, is young John Clay. His grandfather was a royal duke,
+and he himself has been to Eton and Oxford. His brain is as cunning as
+his fingers, and though we meet signs of him at every turn, we never
+know where to find the man himself. He’ll crack a crib in Scotland one
+week, and be raising money to build an orphanage in Cornwall the next.
+I’ve been on his track for years, and have never set eyes on him yet.”
+
+“I hope that I may have the pleasure of introducing you to-night. I’ve
+had one or two little turns also with Mr. John Clay, and I agree with
+you that he is at the head of his profession. It is past ten, however,
+and quite time that we started. If you two will take the first hansom,
+Watson and I will follow in the second.”
+
+Sherlock Holmes was not very communicative during the long drive,
+and lay back in the cab humming the tunes which he had heard in the
+afternoon. We rattled through an endless labyrinth of gas-lit streets
+until we emerged into Farringdon Street.
+
+“We are close there now,” my friend remarked. “This fellow Merryweather
+is a bank director, and personally interested in the matter. I thought
+it as well to have Jones with us also. He is not a bad fellow, though
+an absolute imbecile in his profession. He has one positive virtue. He
+is as brave as a bull-dog, and as tenacious as a lobster if he gets his
+claws upon any one. Here we are, and they are waiting for us.”
+
+We had reached the same crowded thoroughfare in which we had found
+ourselves in the morning. Our cabs were dismissed, and, following
+the guidance of Mr. Merryweather, we passed down a narrow passage
+and through a side door, which he opened for us. Within there was a
+small corridor, which ended in a very massive iron gate. This also was
+opened, and led down a flight of winding stone steps, which terminated
+at another formidable gate. Mr. Merryweather stopped to light a
+lantern, and then conducted us down a dark, earth-smelling passage, and
+so, after opening a third door, into a huge vault or cellar, which was
+piled all round with crates and massive boxes.
+
+“You are not very vulnerable from above,” Holmes remarked, as he held
+up the lantern and gazed about him.
+
+“Nor from below,” said Mr. Merryweather, striking his stick upon the
+flags which lined the floor. “Why, dear me, it sounds quite hollow!” he
+remarked, looking up in surprise.
+
+“I must really ask you to be a little more quiet,” said Holmes,
+severely. “You have already imperilled the whole success of our
+expedition. Might I beg that you would have the goodness to sit down
+upon one of those boxes, and not to interfere?”
+
+The solemn Mr. Merryweather perched himself upon a crate, with a very
+injured expression upon his face, while Holmes fell upon his knees
+upon the floor, and, with the lantern and a magnifying lens, began to
+examine minutely the cracks between the stones. A few seconds sufficed
+to satisfy him, for he sprang to his feet again, and put his glass in
+his pocket.
+
+“We have at least an hour before us,” he remarked; “for they can
+hardly take any steps until the good pawnbroker is safely in bed.
+Then they will not lose a minute, for the sooner they do their work
+the longer time they will have for their escape. We are at present,
+doctor—as no doubt you have divined—in the cellar of the city branch
+of one of the principal London banks. Mr. Merryweather is the chairman
+of directors, and he will explain to you that there are reasons why the
+more daring criminals of London should take a considerable interest in
+this cellar at present.”
+
+“It is our French gold,” whispered the director. “We have had several
+warnings that an attempt might be made upon it.”
+
+“Your French gold?”
+
+“Yes. We had occasion some months ago to strengthen our resources, and
+borrowed, for that purpose, 30,000 napoleons from the Bank of France.
+It has become known that we have never had occasion to unpack the
+money, and that it is still lying in our cellar. The crate upon which
+I sit contains 2000 napoleons packed between layers of lead foil. Our
+reserve of bullion is much larger at present than is usually kept in a
+single branch office, and the directors have had misgivings upon the
+subject.”
+
+“Which were very well justified,” observed Holmes. “And now it is time
+that we arranged our little plans. I expect that within an hour matters
+will come to a head. In the mean time, Mr. Merryweather, we must put
+the screen over that dark lantern.”
+
+“And sit in the dark?”
+
+“I am afraid so. I had brought a pack of cards in my pocket, and I
+thought that, as we were a _partie carrée_, you might have your rubber
+after all. But I see that the enemy’s preparations have gone so far
+that we cannot risk the presence of a light. And, first of all, we must
+choose our positions. These are daring men, and though we shall take
+them at a disadvantage, they may do us some harm unless we are careful.
+I shall stand behind this crate, and do you conceal yourselves behind
+those. Then, when I flash a light upon them, close in swiftly. If they
+fire, Watson, have no compunction about shooting them down.”
+
+I placed my revolver, cocked, upon the top of the wooden case behind
+which I crouched. Holmes shot the slide across the front of his
+lantern, and left us in pitch darkness—such an absolute darkness
+as I have never before experienced. The smell of hot metal remained
+to assure us that the light was still there, ready to flash out at
+a moment’s notice. To me, with my nerves worked up to a pitch of
+expectancy, there was something depressing and subduing in the sudden
+gloom, and in the cold, dank air of the vault.
+
+“They have but one retreat,” whispered Holmes. “That is back through
+the house into Saxe-Coburg Square. I hope that you have done what I
+asked you, Jones?”
+
+“I have an inspector and two officers waiting at the front door.”
+
+“Then we have stopped all the holes. And now we must be silent and
+wait.”
+
+What a time it seemed! From comparing notes afterwards it was but an
+hour and a quarter, yet it appeared to me that the night must have
+almost gone, and the dawn be breaking above us. My limbs were weary and
+stiff, for I feared to change my position; yet my nerves were worked
+up to the highest pitch of tension, and my hearing was so acute that I
+could not only hear the gentle breathing of my companions, but I could
+distinguish the deeper, heavier in-breath of the bulky Jones from the
+thin, sighing note of the bank director. From my position I could look
+over the case in the direction of the floor. Suddenly my eyes caught
+the glint of a light.
+
+At first it was but a lurid spark upon the stone pavement. Then it
+lengthened out until it became a yellow line, and then, without any
+warning or sound, a gash seemed to open and a hand appeared; a white,
+almost womanly hand, which felt about in the centre of the little area
+of light. For a minute or more the hand, with its writhing fingers,
+protruded out of the floor. Then it was withdrawn as suddenly as it
+appeared, and all was dark again save the single lurid spark which
+marked a chink between the stones.
+
+Its disappearance, however, was but momentary. With a rending, tearing
+sound, one of the broad, white stones turned over upon its side, and
+left a square, gaping hole, through which streamed the light of a
+lantern. Over the edge there peeped a clean-cut, boyish face, which
+looked keenly about it, and then, with a hand on either side of the
+aperture, drew itself shoulder-high and waist-high, until one knee
+rested upon the edge. In another instant he stood at the side of the
+hole, and was hauling after him a companion, lithe and small like
+himself, with a pale face and a shock of very red hair.
+
+“It’s all clear,” he whispered. “Have you the chisel and the bags.
+Great Scott! Jump, Archie, jump, and I’ll swing for it!”
+
+Sherlock Holmes had sprung out and seized the intruder by the collar.
+The other dived down the hole, and I heard the sound of rending cloth
+as Jones clutched at his skirts. The light flashed upon the barrel of a
+revolver, but Holmes’s hunting crop came down on the man’s wrist, and
+the pistol clinked upon the stone floor.
+
+“It’s no use, John Clay,” said Holmes, blandly. “You have no chance at
+all.”
+
+“So I see,” the other answered, with the utmost coolness. “I fancy that
+my pal is all right, though I see you have got his coat-tails.”
+
+“There are three men waiting for him at the door,” said Holmes.
+
+“Oh, indeed! You seem to have done the thing very completely. I must
+compliment you.”
+
+“And I you,” Holmes answered. “Your red-headed idea was very new and
+effective.”
+
+“You’ll see your pal again presently,” said Jones. “He’s quicker at
+climbing down holes than I am. Just hold out while I fix the derbies.”
+
+“I beg that you will not touch me with your filthy hands,” remarked
+our prisoner, as the handcuffs clattered upon his wrists. “You may not
+be aware that I have royal blood in my veins. Have the goodness, also,
+when you address me always to say ‘sir’ and ‘please.’”
+
+“All right,” said Jones, with a stare and a snigger. “Well, would you
+please, sir, march up-stairs, where we can get a cab to carry your
+highness to the police-station?”
+
+“That is better,” said John Clay, serenely. He made a sweeping bow to
+the three of us, and walked quietly off in the custody of the detective.
+
+“Really Mr. Holmes,” said Mr. Merryweather, as we followed them from
+the cellar, “I do not know how the bank can thank you or repay you.
+There is no doubt that you have detected and defeated in the most
+complete manner one of the most determined attempts at bank robbery
+that have ever come within my experience.”
+
+“I have had one or two little scores of my own to settle with Mr.
+John Clay,” said Holmes. “I have been at some small expense over this
+matter, which I shall expect the bank to refund, but beyond that I am
+amply repaid by having had an experience which is in many ways unique,
+and by hearing the very remarkable narrative of the Red-headed League.”
+
+       *       *       *       *       *
+
+“You see, Watson,” he explained, in the early hours of the morning,
+as we sat over a glass of whiskey-and-soda in Baker Street, “it was
+perfectly obvious from the first that the only possible object of this
+rather fantastic business of the advertisement of the League, and the
+copying of the ‘Encyclopædia,’ must be to get this not over-bright
+pawnbroker out of the way for a number of hours every day. It was a
+curious way of managing it, but, really, it would be difficult to
+suggest a better. The method was no doubt suggested to Clay’s ingenious
+mind by the color of his accomplice’s hair. The £4 a week was a lure
+which must draw him, and what was it to them, who were playing for
+thousands? They put in the advertisement, one rogue has the temporary
+office, the other rogue incites the man to apply for it, and together
+they manage to secure his absence every morning in the week. From
+the time that I heard of the assistant having come for half wages,
+it was obvious to me that he had some strong motive for securing the
+situation.”
+
+“But how could you guess what the motive was?”
+
+“Had there been women in the house, I should have suspected a mere
+vulgar intrigue. That, however, was out of the question. The man’s
+business was a small one, and there was nothing in his house which
+could account for such elaborate preparations, and such an expenditure
+as they were at. It must, then, be something out of the house. What
+could it be? I thought of the assistant’s fondness for photography,
+and his trick of vanishing into the cellar. The cellar! There was the
+end of this tangled clue. Then I made inquiries as to this mysterious
+assistant, and found that I had to deal with one of the coolest
+and most daring criminals in London. He was doing something in the
+cellar—something which took many hours a day for months on end. What
+could it be, once more? I could think of nothing save that he was
+running a tunnel to some other building.
+
+“So far I had got when we went to visit the scene of action. I
+surprised you by beating upon the pavement with my stick. I was
+ascertaining whether the cellar stretched out in front or behind.
+It was not in front. Then I rang the bell, and, as I hoped, the
+assistant answered it. We have had some skirmishes, but we had never
+set eyes upon each other before. I hardly looked at his face. His
+knees were what I wished to see. You must yourself have remarked how
+worn, wrinkled, and stained they were. They spoke of those hours of
+burrowing. The only remaining point was what they were burrowing for. I
+walked round the corner, saw that the City and Suburban Bank abutted on
+our friend’s premises, and felt that I had solved my problem. When you
+drove home after the concert I called upon Scotland Yard, and upon the
+chairman of the bank directors, with the result that you have seen.”
+
+“And how could you tell that they would make their attempt to-night?” I
+asked.
+
+“Well, when they closed their League offices that was a sign that they
+cared no longer about Mr. Jabez Wilson’s presence—in other words,
+that they had completed their tunnel. But it was essential that they
+should use it soon, as it might be discovered, or the bullion might
+be removed. Saturday would suit them better than any other day, as it
+would give them two days for their escape. For all these reasons I
+expected them to come to-night.”
+
+“You reasoned it out beautifully,” I exclaimed, in unfeigned
+admiration. “It is so long a chain, and yet every link rings true.”
+
+“It saved me from ennui,” he answered, yawning. “Alas! I already feel
+it closing in upon me. My life is spent in one long effort to escape
+from the commonplaces of existence. These little problems help me to do
+so.”
+
+“And you are a benefactor of the race,” said I.
+
+He shrugged his shoulders. “Well, perhaps, after all, it is of some
+little use,” he remarked. “‘L’homme c’est rien—l’oeuvre c’est
+tout,’ as Gustave Flaubert wrote to Georges Sand.”
+
+
+
+
+Adventure III
+
+A CASE OF IDENTITY
+
+
+“My dear fellow,” said Sherlock Holmes, as we sat on either side
+of the fire in his lodgings at Baker Street, “life is infinitely
+stranger than anything which the mind of man could invent. We would
+not dare to conceive the things which are really mere commonplaces of
+existence. If we could fly out of that window hand in hand, hover over
+this great city, gently remove the roofs, and peep in at the queer
+things which are going on, the strange coincidences, the plannings,
+the cross-purposes, the wonderful chains of events, working through
+generations, and leading to the most _outré_ results, it would make all
+fiction with its conventionalities and foreseen conclusions most stale
+and unprofitable.”
+
+“And yet I am not convinced of it,” I answered. “The cases which come
+to light in the papers are, as a rule, bald enough, and vulgar enough.
+We have in our police reports realism pushed to its extreme limits,
+and yet the result is, it must be confessed, neither fascinating nor
+artistic.”
+
+“A certain selection and discretion must be used in producing a
+realistic effect,” remarked Holmes. “This is wanting in the police
+report, where more stress is laid, perhaps, upon the platitudes of the
+magistrate than upon the details, which to an observer contain the
+vital essence of the whole matter. Depend upon it there is nothing so
+unnatural as the commonplace.”
+
+I smiled and shook my head. “I can quite understand you thinking so,”
+I said. “Of course, in your position of unofficial adviser and helper
+to everybody who is absolutely puzzled, throughout three continents,
+you are brought in contact with all that is strange and bizarre. But
+here”—I picked up the morning paper from the ground—“let us put it
+to a practical test. Here is the first heading upon which I come. ‘A
+husband’s cruelty to his wife.’ There is half a column of print, but
+I know without reading it that it is all perfectly familiar to me.
+There is, of course, the other woman, the drink, the push, the blow,
+the bruise, the sympathetic sister or landlady. The crudest of writers
+could invent nothing more crude.”
+
+“Indeed, your example is an unfortunate one for your argument,”
+said Holmes, taking the paper and glancing his eye down it. “This
+is the Dundas separation case, and, as it happens, I was engaged in
+clearing up some small points in connection with it. The husband was
+a teetotaler, there was no other woman, and the conduct complained of
+was that he had drifted into the habit of winding up every meal by
+taking out his false teeth and hurling them at his wife, which, you
+will allow, is not an action likely to occur to the imagination of the
+average story-teller. Take a pinch of snuff, doctor, and acknowledge
+that I have scored over you in your example.”
+
+He held out his snuffbox of old gold, with a great amethyst in the
+centre of the lid. Its splendor was in such contrast to his homely ways
+and simple life that I could not help commenting upon it.
+
+“Ah,” said he, “I forgot that I had not seen you for some weeks. It is
+a little souvenir from the King of Bohemia in return for my assistance
+in the case of the Irene Adler papers.”
+
+“And the ring?” I asked, glancing at a remarkable brilliant which
+sparkled upon his finger.
+
+“It was from the reigning family of Holland, though the matter in which
+I served them was of such delicacy that I cannot confide it even to
+you, who have been good enough to chronicle one or two of my little
+problems.”
+
+“And have you any on hand just now?” I asked, with interest.
+
+“Some ten or twelve, but none which present any feature of interest.
+They are important, you understand, without being interesting. Indeed,
+I have found that it is usually in unimportant matters that there is
+a field for the observation, and for the quick analysis of cause and
+effect which gives the charm to an investigation. The larger crimes are
+apt to be the simpler, for the bigger the crime, the more obvious, as
+a rule, is the motive. In these cases, save for one rather intricate
+matter which has been referred to me from Marseilles, there is nothing
+which presents any features of interest. It is possible, however, that
+I may have something better before very many minutes are over, for this
+is one of my clients, or I am much mistaken.”
+
+He had risen from his chair, and was standing between the parted
+blinds, gazing down into the dull, neutral-tinted London street.
+Looking over his shoulder, I saw that on the pavement opposite there
+stood a large woman with a heavy fur boa round her neck, and a large
+curling red feather in a broad-brimmed hat which was tilted in a
+coquettish Duchess-of-Devonshire fashion over her ear. From under
+this great panoply she peeped up in a nervous, hesitating fashion at
+our windows, while her body oscillated backward and forward, and her
+fingers fidgetted with her glove buttons. Suddenly, with a plunge, as
+of the swimmer who leaves the bank, she hurried across the road, and we
+heard the sharp clang of the bell.
+
+“I have seen those symptoms before,” said Holmes, throwing his
+cigarette into the fire. “Oscillation upon the pavement always means an
+_affaire de cœur_. She would like advice, but is not sure that the
+matter is not too delicate for communication. And yet even here we may
+discriminate. When a woman has been seriously wronged by a man she no
+longer oscillates, and the usual symptom is a broken bell wire. Here we
+may take it that there is a love matter, but that the maiden is not so
+much angry as perplexed, or grieved. But here she comes in person to
+resolve our doubts.”
+
+As he spoke there was a tap at the door, and the boy in buttons entered
+to announce Miss Mary Sutherland, while the lady herself loomed behind
+his small black figure like a full-sailed merchant-man behind a tiny
+pilot boat. Sherlock Holmes welcomed her with the easy courtesy for
+which he was remarkable, and having closed the door, and bowed her into
+an arm-chair, he looked her over in the minute, and yet abstracted
+fashion which was peculiar to him.
+
+“Do you not find,” he said, “that with your short sight it is a little
+trying to do so much type-writing?”
+
+“I did at first,” she answered, “but now I know where the letters
+are without looking.” Then, suddenly realizing the full purport of
+his words, she gave a violent start and looked up, with fear and
+astonishment upon her broad, good-humored face. “You’ve heard about me,
+Mr. Holmes,” she cried, “else how could you know all that?”
+
+“Never mind,” said Holmes, laughing; “it is my business to know things.
+Perhaps I have trained myself to see what others overlook. If not, why
+should you come to consult me?”
+
+“I came to you, sir, because I heard of you from Mrs. Etherege, whose
+husband you found so easy when the police and every one had given him
+up for dead. Oh, Mr. Holmes, I wish you would do as much for me. I’m
+not rich, but still I have a hundred a year in my own right, besides
+the little that I make by the machine, and I would give it all to know
+what has become of Mr. Hosmer Angel.”
+
+“Why did you come away to consult me in such a hurry?” asked Sherlock
+Holmes, with his finger-tips together, and his eyes to the ceiling.
+
+Again a startled look came over the somewhat vacuous face of Miss Mary
+Sutherland. “Yes, I did bang out of the house,” she said, “for it
+made me angry to see the easy way in which Mr. Windibank—that is, my
+father—took it all. He would not go to the police, and he would not
+go to you, and so at last, as he would do nothing, and kept on saying
+that there was no harm done, it made me mad, and I just on with my
+things and came right away to you.”
+
+“Your father,” said Holmes, “your step-father, surely, since the name
+is different.”
+
+“Yes, my step-father. I call him father, though it sounds funny, too,
+for he is only five years and two months older than myself.”
+
+“And your mother is alive?”
+
+“Oh yes, mother is alive and well. I wasn’t best pleased, Mr. Holmes,
+when she married again so soon after father’s death, and a man who was
+nearly fifteen years younger than herself. Father was a plumber in the
+Tottenham Court Road, and he left a tidy business behind him, which
+mother carried on with Mr. Hardy, the foreman; but when Mr. Windibank
+came he made her sell the business, for he was very superior, being a
+traveller in wines. They got £4700 for the goodwill and interest, which
+wasn’t near as much as father could have got if he had been alive.”
+
+I had expected to see Sherlock Holmes impatient under this rambling and
+inconsequential narrative, but, on the contrary, he had listened with
+the greatest concentration of attention.
+
+“Your own little income,” he asked, “does it come out of the business?”
+
+“Oh no, sir. It is quite separate, and was left me by my Uncle Ned
+in Auckland. It is in New Zealand stock, paying 4-1/2 per cent. Two
+thousand five hundred pounds was the amount, but I can only touch the
+interest.”
+
+“You interest me extremely,” said Holmes. “And since you draw so large
+a sum as a hundred a year, with what you earn into the bargain, you no
+doubt travel a little, and indulge yourself in every way. I believe
+that a single lady can get on very nicely upon an income of about £60.”
+
+[Illustration: “SHERLOCK HOLMES WELCOMED HER”]
+
+“I could do with much less than that, Mr. Holmes, but you understand
+that as long as I live at home I don’t wish to be a burden to them, and
+so they have the use of the money just while I am staying with them. Of
+course, that is only just for the time. Mr. Windibank draws my interest
+every quarter, and pays it over to mother, and I find that I can do
+pretty well with what I earn at type-writing. It brings me twopence a
+sheet, and I can often do from fifteen to twenty sheets in a day.”
+
+“You have made your position very clear to me,” said Holmes. “This is
+my friend, Dr. Watson, before whom you can speak as freely as before
+myself. Kindly tell us now all about your connection with Mr. Hosmer
+Angel.”
+
+A flush stole over Miss Sutherland’s face, and she picked nervously at
+the fringe of her jacket. “I met him first at the gasfitters’ ball,”
+she said. “They used to send father tickets when he was alive, and then
+afterwards they remembered us, and sent them to mother. Mr. Windibank
+did not wish us to go. He never did wish us to go anywhere. He would
+get quite mad if I wanted so much as to join a Sunday-school treat.
+But this time I was set on going, and I would go; for what right had
+he to prevent? He said the folk were not fit for us to know, when all
+father’s friends were to be there. And he said that I had nothing fit
+to wear, when I had my purple plush that I had never so much as taken
+out of the drawer. At last, when nothing else would do, he went off
+to France upon the business of the firm, but we went, mother and I,
+with Mr. Hardy, who used to be our foreman, and it was there I met Mr.
+Hosmer Angel.”
+
+“I suppose,” said Holmes, “that when Mr. Windibank came back from
+France he was very annoyed at your having gone to the ball.”
+
+“Oh, well, he was very good about it. He laughed, I remember, and
+shrugged his shoulders, and said there was no use denying anything to a
+woman, for she would have her way.”
+
+“I see. Then at the gasfitters’ ball you met, as I understand, a
+gentleman called Mr. Hosmer Angel.”
+
+“Yes, sir. I met him that night, and he called next day to ask if we
+had got home all safe, and after that we met him—that is to say, Mr.
+Holmes, I met him twice for walks, but after that father came back
+again, and Mr. Hosmer Angel could not come to the house any more.”
+
+“No?”
+
+“Well, you know, father didn’t like anything of the sort. He wouldn’t
+have any visitors if he could help it, and he used to say that a woman
+should be happy in her own family circle. But then, as I used to say to
+mother, a woman wants her own circle to begin with, and I had not got
+mine yet.”
+
+“But how about Mr. Hosmer Angel? Did he make no attempt to see you?”
+
+“Well, father was going off to France again in a week, and Hosmer wrote
+and said that it would be safer and better not to see each other until
+he had gone. We could write in the mean time, and he used to write
+every day. I took the letters in in the morning, so there was no need
+for father to know.”
+
+“Were you engaged to the gentleman at this time?”
+
+“Oh yes, Mr. Holmes. We were engaged after the first walk that we
+took. Hosmer—Mr. Angel—was a cashier in an office in Leadenhall
+Street—and—”
+
+“What office?”
+
+“That’s the worst of it, Mr. Holmes, I don’t know.”
+
+“Where did he live, then?”
+
+“He slept on the premises.”
+
+“And you don’t know his address?”
+
+“No—except that it was Leadenhall Street.”
+
+“Where did you address your letters, then?”
+
+“To the Leadenhall Street Post-office, to be left till called for. He
+said that if they were sent to the office he would be chaffed by all
+the other clerks about having letters from a lady, so I offered to
+type-write them, like he did his, but he wouldn’t have that, for he
+said that when I wrote them they seemed to come from me, but when they
+were type-written he always felt that the machine had come between us.
+That will just show you how fond he was of me, Mr. Holmes, and the
+little things that he would think of.”
+
+“It was most suggestive,” said Holmes. “It has long been an axiom of
+mine that the little things are infinitely the most important. Can you
+remember any other little things about Mr. Hosmer Angel?”
+
+“He was a very shy man, Mr. Holmes. He would rather walk with me in
+the evening than in the daylight, for he said that he hated to be
+conspicuous. Very retiring and gentlemanly he was. Even his voice was
+gentle. He’d had the quinsy and swollen glands when he was young, he
+told me, and it had left him with a weak throat, and a hesitating,
+whispering fashion of speech. He was always well dressed, very neat and
+plain, but his eyes were weak, just as mine are, and he wore tinted
+glasses against the glare.”
+
+“Well, and what happened when Mr. Windibank, your step-father, returned
+to France?”
+
+“Mr. Hosmer Angel came to the house again, and proposed that we should
+marry before father came back. He was in dreadful earnest, and made
+me swear, with my hands on the Testament, that whatever happened I
+would always be true to him. Mother said he was quite right to make me
+swear, and that it was a sign of his passion. Mother was all in his
+favor from the first, and was even fonder of him than I was. Then, when
+they talked of marrying within the week, I began to ask about father;
+but they both said never to mind about father, but just to tell him
+afterwards, and mother said she would make it all right with him. I
+didn’t quite like that, Mr. Holmes. It seemed funny that I should ask
+his leave, as he was only a few years older than me; but I didn’t want
+to do anything on the sly, so I wrote to father at Bordeaux, where the
+company has its French offices, but the letter came back to me on the
+very morning of the wedding.”
+
+“It missed him, then?”
+
+“Yes, sir; for he had started to England just before it arrived.”
+
+“Ha! that was unfortunate. Your wedding was arranged, then, for the
+Friday. Was it to be in church?”
+
+“Yes, sir, but very quietly. It was to be at St. Saviour’s, near King’s
+Cross, and we were to have breakfast afterwards at the St. Pancras
+Hotel. Hosmer came for us in a hansom, but as there were two of us, he
+put us both into it, and stepped himself into a four-wheeler, which
+happened to be the only other cab in the street. We got to the church
+first, and when the four-wheeler drove up we waited for him to step
+out, but he never did, and when the cabman got down from the box and
+looked, there was no one there! The cabman said that he could not
+imagine what had become of him, for he had seen him get in with his own
+eyes. That was last Friday, Mr. Holmes, and I have never seen or heard
+anything since then to throw any light upon what became of him.”
+
+“It seems to me that you have been very shamefully treated,” said
+Holmes.
+
+“Oh no, sir! He was too good and kind to leave me so. Why, all the
+morning he was saying to me that, whatever happened, I was to be true;
+and that even if something quite unforeseen occurred to separate
+us, I was always to remember that I was pledged to him, and that he
+would claim his pledge sooner or later. It seemed strange talk for a
+wedding-morning, but what has happened since gives a meaning to it.”
+
+“Most certainly it does. Your own opinion is, then, that some
+unforeseen catastrophe has occurred to him?”
+
+“Yes, sir. I believe that he foresaw some danger, or else he would not
+have talked so. And then I think that what he foresaw happened.”
+
+“But you have no notion as to what it could have been?”
+
+“None.”
+
+“One more question. How did your mother take the matter?”
+
+“She was angry, and said that I was never to speak of the matter again.”
+
+“And your father? Did you tell him?”
+
+“Yes; and he seemed to think, with me, that something had happened, and
+that I should hear of Hosmer again. As he said, what interest could any
+one have in bringing me to the doors of the church, and then leaving
+me? Now, if he had borrowed my money, or if he had married me and got
+my money settled on him, there might be some reason; but Hosmer was
+very independent about money, and never would look at a shilling of
+mine. And yet, what could have happened? And why could he not write?
+Oh, it drives me half-mad to think of! and I can’t sleep a wink at
+night.” She pulled a little handkerchief out of her muff, and began to
+sob heavily into it.
+
+“I shall glance into the case for you,” said Holmes, rising; “and I
+have no doubt that we shall reach some definite result. Let the weight
+of the matter rest upon me now, and do not let your mind dwell upon
+it further. Above all, try to let Mr. Hosmer Angel vanish from your
+memory, as he has done from your life.”
+
+“Then you don’t think I’ll see him again?”
+
+“I fear not.”
+
+“Then what has happened to him?”
+
+“You will leave that question in my hands. I should like an accurate
+description of him, and any letters of his which you can spare.”
+
+“I advertised for him in last Saturday’s _Chronicle_,” said she. “Here
+is the slip, and here are four letters from him.”
+
+“Thank you. And your address?”
+
+“No. 31 Lyon Place, Camberwell.”
+
+“Mr. Angel’s address you never had, I understand. Where is your
+father’s place of business?”
+
+“He travels for Westhouse & Marbank, the great claret importers of
+Fenchurch Street.”
+
+“Thank you. You have made your statement very clearly. You will leave
+the papers here, and remember the advice which I have given you. Let
+the whole incident be a sealed book, and do not allow it to affect your
+life.”
+
+“You are very kind, Mr. Holmes, but I cannot do that. I shall be true
+to Hosmer. He shall find me ready when he comes back.”
+
+For all the preposterous hat and the vacuous face, there was something
+noble in the simple faith of our visitor which compelled our respect.
+She laid her little bundle of papers upon the table, and went her way,
+with a promise to come again whenever she might be summoned.
+
+Sherlock Holmes sat silent for a few minutes with his finger-tips still
+pressed together, his legs stretched out in front of him, and his gaze
+directed upward to the ceiling. Then he took down from the rack the
+old and oily clay pipe, which was to him as a counsellor, and, having
+lit it, he leaned back in his chair, with the thick blue cloud-wreaths
+spinning up from him, and a look of infinite languor in his face.
+
+“Quite an interesting study, that maiden,” he observed. “I found her
+more interesting than her little problem, which, by the way, is rather
+a trite one. You will find parallel cases, if you consult my index, in
+Andover in ’77, and there was something of the sort at The Hague last
+year. Old as is the idea, however, there were one or two details which
+were new to me. But the maiden herself was most instructive.”
+
+“You appeared to read a good deal upon her which was quite invisible to
+me,” I remarked.
+
+“Not invisible, but unnoticed, Watson. You did not know where to look,
+and so you missed all that was important. I can never bring you to
+realize the importance of sleeves, the suggestiveness of thumb-nails,
+or the great issues that may hang from a boot-lace. Now, what did you
+gather from that woman’s appearance? Describe it.”
+
+“Well, she had a slate-colored, broad-brimmed straw hat, with a feather
+of a brickish red. Her jacket was black, with black beads sewn upon it,
+and a fringe of little black jet ornaments. Her dress was brown, rather
+darker than coffee color, with a little purple plush at the neck and
+sleeves. Her gloves were grayish, and were worn through at the right
+forefinger. Her boots I didn’t observe. She had small, round, hanging
+gold ear-rings, and a general air of being fairly well-to-do, in a
+vulgar, comfortable, easy-going way.”
+
+Sherlock Holmes clapped his hands softly together and chuckled.
+
+“’Pon my word, Watson, you are coming along wonderfully. You have
+really done very well indeed. It is true that you have missed
+everything of importance, but you have hit upon the method, and you
+have a quick eye for color. Never trust to general impressions, my boy,
+but concentrate yourself upon details. My first glance is always at a
+woman’s sleeve. In a man it is perhaps better first to take the knee
+of the trouser. As you observe, this woman had plush upon her sleeves,
+which is a most useful material for showing traces. The double line
+a little above the wrist, where the type-writist presses against the
+table, was beautifully defined. The sewing-machine, of the hand type,
+leaves a similar mark, but only on the left arm, and on the side of it
+farthest from the thumb, instead of being right across the broadest
+part, as this was. I then glanced at her face, and observing the dint
+of a pince-nez at either side of her nose, I ventured a remark upon
+short sight and type-writing, which seemed to surprise her.”
+
+“It surprised me.”
+
+“But, surely, it was very obvious. I was then much surprised and
+interested on glancing down to observe that, though the boots which she
+was wearing were not unlike each other, they were really odd ones; the
+one having a slightly decorated toe-cap, and the other a plain one.
+One was buttoned only in the two lower buttons out of five, and the
+other at the first, third, and fifth. Now, when you see that a young
+lady, otherwise neatly dressed, has come away from home with odd boots,
+half-buttoned, it is no great deduction to say that she came away in a
+hurry.”
+
+“And what else?” I asked, keenly interested, as I always was, by my
+friend’s incisive reasoning.
+
+“I noted, in passing, that she had written a note before leaving home,
+but after being fully dressed. You observed that her right glove was
+torn at the forefinger, but you did not apparently see that both glove
+and finger were stained with violet ink. She had written in a hurry,
+and dipped her pen too deep. It must have been this morning, or the
+mark would not remain clear upon the finger. All this is amusing,
+though rather elementary, but I must go back to business, Watson. Would
+you mind reading me the advertised description of Mr. Hosmer Angel?”
+
+I held the little printed slip to the light. “Missing,” it said, “on
+the morning of the 14th, a gentleman named Hosmer Angel. About 5 ft. 7
+in. in height; strongly built, sallow complexion, black hair, a little
+bald in the centre, bushy, black side-whiskers and mustache; tinted
+glasses, slight infirmity of speech. Was dressed, when last seen, in
+black frock-coat faced with silk, black waistcoat, gold Albert chain,
+and gray Harris tweed trousers, with brown gaiters over elastic-sided
+boots. Known to have been employed in an office in Leadenhall Street.
+Anybody bringing,” etc., etc.
+
+“That will do,” said Holmes. “As to the letters,” he continued,
+glancing over them, “they are very commonplace. Absolutely no clew
+in them to Mr. Angel, save that he quotes Balzac once. There is one
+remarkable point, however, which will no doubt strike you.”
+
+“They are type-written,” I remarked.
+
+“Not only that, but the signature is type-written. Look at the neat
+little ‘Hosmer Angel’ at the bottom. There is a date, you see, but no
+superscription except Leadenhall Street, which is rather vague. The
+point about the signature is very suggestive—in fact, we may call it
+conclusive.”
+
+“Of what?”
+
+“My dear fellow, is it possible you do not see how strongly it bears
+upon the case?”
+
+“I cannot say that I do, unless it were that he wished to be able to
+deny his signature if an action for breach of promise were instituted.”
+
+“No, that was not the point. However, I shall write two letters, which
+should settle the matter. One is to a firm in the city, the other is
+to the young lady’s step-father, Mr. Windibank, asking him whether he
+could meet us here at six o’clock to-morrow evening. It is just as well
+that we should do business with the male relatives. And now, doctor, we
+can do nothing until the answers to those letters come, so we may put
+our little problem upon the shelf for the interim.”
+
+I had had so many reasons to believe in my friend’s subtle powers of
+reasoning, and extraordinary energy in action, that I felt that he must
+have some solid grounds for the assured and easy demeanor with which he
+treated the singular mystery which he had been called upon to fathom.
+Once only had I known him to fail, in the case of the King of Bohemia
+and of the Irene Adler photograph; but when I looked back to the weird
+business of the Sign of Four, and the extraordinary circumstances
+connected with the Study in Scarlet, I felt that it would be a strange
+tangle indeed which he could not unravel.
+
+I left him then, still puffing at his black clay pipe, with the
+conviction that when I came again on the next evening I would find that
+he held in his hands all the clews which would lead up to the identity
+of the disappearing bridegroom of Miss Mary Sutherland.
+
+A professional case of great gravity was engaging my own attention at
+the time, and the whole of next day I was busy at the bedside of the
+sufferer. It was not until close upon six o’clock that I found myself
+free, and was able to spring into a hansom and drive to Baker Street,
+half afraid that I might be too late to assist at the _dénouement_
+of the little mystery. I found Sherlock Holmes alone, however, half
+asleep, with his long, thin form curled up in the recesses of his
+arm-chair. A formidable array of bottles and test-tubes, with the
+pungent cleanly smell of hydrochloric acid, told me that he had spent
+his day in the chemical work which was so dear to him.
+
+“Well, have you solved it?” I asked, as I entered.
+
+“Yes. It was the bisulphate of baryta.”
+
+“No, no, the mystery!” I cried.
+
+“Oh, that! I thought of the salt that I have been working upon. There
+was never any mystery in the matter, though, as I said yesterday, some
+of the details are of interest. The only drawback is that there is no
+law, I fear, that can touch the scoundrel.”
+
+“Who was he, then, and what was his object in deserting Miss
+Sutherland?”
+
+The question was hardly out of my mouth, and Holmes had not yet opened
+his lips to reply, when we heard a heavy footfall in the passage, and a
+tap at the door.
+
+“This is the girl’s step-father, Mr. James Windibank,” said Holmes. “He
+has written to me to say that he would be here at six. Come in!”
+
+The man who entered was a sturdy, middle-sized fellow, some thirty
+years of age, clean shaven, and sallow skinned, with a bland,
+insinuating manner, and a pair of wonderfully sharp and penetrating
+gray eyes. He shot a questioning glance at each of us, placed his shiny
+top hat upon the sideboard, and with a slight bow sidled down into the
+nearest chair.
+
+“Good-evening, Mr. James Windibank,” said Holmes. “I think that this
+type-written letter is from you, in which you made an appointment with
+me for six o’clock?”
+
+“Yes, sir. I am afraid that I am a little late, but I am not quite my
+own master, you know. I am sorry that Miss Sutherland has troubled you
+about this little matter, for I think it is far better not to wash
+linen of the sort in public. It was quite against my wishes that she
+came, but she is a very excitable, impulsive girl, as you may have
+noticed, and she is not easily controlled when she has made up her
+mind on a point. Of course, I did not mind you so much, as you are not
+connected with the official police, but it is not pleasant to have a
+family misfortune like this noised abroad. Besides, it is a useless
+expense, for how could you possibly find this Hosmer Angel?”
+
+“On the contrary,” said Holmes, quietly; “I have every reason to
+believe that I will succeed in discovering Mr. Hosmer Angel.”
+
+Mr. Windibank gave a violent start, and dropped his gloves. “I am
+delighted to hear it,” he said.
+
+“It is a curious thing,” remarked Holmes, “that a type-writer has
+really quite as much individuality as a man’s handwriting. Unless they
+are quite new, no two of them write exactly alike. Some letters get
+more worn than others, and some wear only on one side. Now, you remark
+in this note of yours, Mr. Windibank, that in every case there is some
+little slurring over of the ‘e,’ and a slight defect in the tail of the
+‘r.’ There are fourteen other characteristics, but those are the more
+obvious.”
+
+“We do all our correspondence with this machine at the office, and no
+doubt it is a little worn,” our visitor answered, glancing keenly at
+Holmes with his bright little eyes.
+
+“And now I will show you what is really a very interesting study,
+Mr. Windibank,” Holmes continued. “I think of writing another little
+monograph some of these days on the type-writer and its relation to
+crime. It is a subject to which I have devoted some little attention.
+I have here four letters which purport to come from the missing man.
+They are all type-written. In each case, not only are the ‘e’s’ slurred
+and the ‘r’s’ tailless, but you will observe, if you care to use my
+magnifying lens, that the fourteen other characteristics to which I
+have alluded are there as well.”
+
+Mr. Windibank sprang out of his chair, and picked up his hat. “I cannot
+waste time over this sort of fantastic talk, Mr. Holmes,” he said. “If
+you can catch the man, catch him, and let me know when you have done
+it.”
+
+“Certainly,” said Holmes, stepping over and turning the key in the
+door. “I let you know, then, that I have caught him!”
+
+“What! where?” shouted Mr. Windibank, turning white to his lips, and
+glancing about him like a rat in a trap.
+
+“Oh, it won’t do—really it won’t,” said Holmes, suavely. “There is no
+possible getting out of it, Mr. Windibank. It is quite too transparent,
+and it was a very bad compliment when you said that it was impossible
+for me to solve so simple a question. That’s right! Sit down, and let
+us talk it over.”
+
+Our visitor collapsed into a chair, with a ghastly face, and a glitter
+of moisture on his brow. “It—it’s not actionable,” he stammered.
+
+“I am very much afraid that it is not. But between ourselves,
+Windibank, it was as cruel and selfish and heartless a trick in a petty
+way as ever came before me. Now, let me just run over the course of
+events, and you will contradict me if I go wrong.”
+
+The man sat huddled up in his chair, with his head sunk upon his
+breast, like one who is utterly crushed. Holmes stuck his feet up on
+the corner of the mantel-piece, and, leaning back with his hands in his
+pockets, began talking, rather to himself, as it seemed, than to us.
+
+“The man married a woman very much older than himself for her money,”
+said he, “and he enjoyed the use of the money of the daughter as long
+as she lived with them. It was a considerable sum, for people in their
+position, and the loss of it would have made a serious difference.
+It was worth an effort to preserve it. The daughter was of a good,
+amiable disposition, but affectionate and warm-hearted in her ways, so
+that it was evident that with her fair personal advantages, and her
+little income, she would not be allowed to remain single long. Now her
+marriage would mean, of course, the loss of a hundred a year, so what
+does her step-father do to prevent it? He takes the obvious course of
+keeping her at home, and forbidding her to seek the company of people
+of her own age. But soon he found that that would not answer forever.
+She became restive, insisted upon her rights, and finally announced her
+positive intention of going to a certain ball. What does her clever
+step-father do then? He conceives an idea more creditable to his head
+than to his heart. With the connivance and assistance of his wife he
+disguised himself, covered those keen eyes with tinted glasses, masked
+the face with a mustache and a pair of bushy whiskers, sunk that clear
+voice into an insinuating whisper, and doubly secure on account of the
+girl’s short sight, he appears as Mr. Hosmer Angel, and keeps off other
+lovers by making love himself.”
+
+[Illustration: “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”]
+
+“It was only a joke at first,” groaned our visitor. “We never thought
+that she would have been so carried away.”
+
+“Very likely not. However that may be, the young lady was very
+decidedly carried away, and having quite made up her mind that her
+step-father was in France, the suspicion of treachery never for
+an instant entered her mind. She was flattered by the gentleman’s
+attentions, and the effect was increased by the loudly expressed
+admiration of her mother. Then Mr. Angel began to call, for it was
+obvious that the matter should be pushed as far as it would go,
+if a real effect were to be produced. There were meetings, and an
+engagement, which would finally secure the girl’s affections from
+turning towards any one else. But the deception could not be kept up
+forever. These pretended journeys to France were rather cumbrous. The
+thing to do was clearly to bring the business to an end in such a
+dramatic manner that it would leave a permanent impression upon the
+young lady’s mind, and prevent her from looking upon any other suitor
+for some time to come. Hence those vows of fidelity exacted upon a
+Testament, and hence also the allusions to a possibility of something
+happening on the very morning of the wedding. James Windibank wished
+Miss Sutherland to be so bound to Hosmer Angel, and so uncertain as to
+his fate, that for ten years to come, at any rate, she would not listen
+to another man. As far as the church door he brought her, and then, as
+he could go no farther, he conveniently vanished away by the old trick
+of stepping in at one door of a four-wheeler, and out at the other. I
+think that that was the chain of events, Mr. Windibank!”
+
+Our visitor had recovered something of his assurance while Holmes had
+been talking, and he rose from his chair now with a cold sneer upon his
+pale face.
+
+“It may be so, or it may not, Mr. Holmes,” said he, “but if you are so
+very sharp you ought to be sharp enough to know that it is you who are
+breaking the law now, and not me. I have done nothing actionable from
+the first, but as long as you keep that door locked you lay yourself
+open to an action for assault and illegal constraint.”
+
+“The law cannot, as you say, touch you,” said Holmes, unlocking and
+throwing open the door, “yet there never was a man who deserved
+punishment more. If the young lady has a brother or a friend, he ought
+to lay a whip across your shoulders. By Jove!” he continued, flushing
+up at the sight of the bitter sneer upon the man’s face, “it is not
+part of my duties to my client, but here’s a hunting crop handy, and I
+think I shall just treat myself to—” He took two swift steps to the
+whip, but before he could grasp it there was a wild clatter of steps
+upon the stairs, the heavy hall door banged, and from the window we
+could see Mr. James Windibank running at the top of his speed down the
+road.
+
+“There’s a cold-blooded scoundrel!” said Holmes, laughing, as he threw
+himself down into his chair once more. “That fellow will rise from
+crime to crime until he does something very bad, and ends on a gallows.
+The case has, in some respects, been not entirely devoid of interest.”
+
+“I cannot now entirely see all the steps of your reasoning,” I remarked.
+
+“Well, of course it was obvious from the first that this Mr. Hosmer
+Angel must have some strong object for his curious conduct, and it was
+equally clear that the only man who really profited by the incident,
+as far as we could see, was the step-father. Then the fact that the
+two men were never together, but that the one always appeared when
+the other was away, was suggestive. So were the tinted spectacles and
+the curious voice, which both hinted at a disguise, as did the bushy
+whiskers. My suspicions were all confirmed by his peculiar action
+in type-writing his signature, which, of course, inferred that his
+handwriting was so familiar to her that she would recognize even the
+smallest sample of it. You see all these isolated facts, together with
+many minor ones, all pointed in the same direction.”
+
+“And how did you verify them?”
+
+“Having once spotted my man, it was easy to get corroboration. I
+knew the firm for which this man worked. Having taken the printed
+description, I eliminated everything from it which could be the result
+of a disguise—the whiskers, the glasses, the voice, and I sent it
+to the firm, with a request that they would inform me whether it
+answered to the description of any of their travellers. I had already
+noticed the peculiarities of the type-writer, and I wrote to the man
+himself at his business address, asking him if he would come here. As
+I expected, his reply was type-written, and revealed the same trivial
+but characteristic defects. The same post brought me a letter from
+Westhouse & Marbank, of Fenchurch Street, to say that the description
+tallied in every respect with that of their employé, James Windibank.
+_Voila tout!_”
+
+“And Miss Sutherland?”
+
+“If I tell her she will not believe me. You may remember the old
+Persian saying, ‘There is danger for him who taketh the tiger cub, and
+danger also for whoso snatches a delusion from a woman.’ There is as
+much sense in Hafiz as in Horace, and as much knowledge of the world.”
+
+
+
+
+Adventure IV
+
+THE BOSCOMBE VALLEY MYSTERY
+
+
+We were seated at breakfast one morning, my wife and I, when the maid
+brought in a telegram. It was from Sherlock Holmes, and ran in this way:
+
+“Have you a couple of days to spare? Have just been wired for from
+the West of England in connection with Boscombe Valley tragedy. Shall
+be glad if you will come with me. Air and scenery perfect. Leave
+Paddington by the 11.15.”
+
+“What do you say, dear?” said my wife, looking across at me. “Will you
+go?”
+
+“I really don’t know what to say. I have a fairly long list at present.”
+
+“Oh, Anstruther would do your work for you. You have been looking a
+little pale lately. I think that the change would do you good, and you
+are always so interested in Mr. Sherlock Holmes’s cases.”
+
+“I should be ungrateful if I were not, seeing what I gained through one
+of them,” I answered. “But if I am to go, I must pack at once, for I
+have only half an hour.”
+
+My experience of camp life in Afghanistan had at least had the effect
+of making me a prompt and ready traveller. My wants were few and
+simple, so that in less than the time stated I was in a cab with my
+valise, rattling away to Paddington Station. Sherlock Holmes was pacing
+up and down the platform, his tall, gaunt figure made even gaunter and
+taller by his long gray travelling-cloak and close-fitting cloth cap.
+
+“It is really very good of you to come, Watson,” said he. “It makes a
+considerable difference to me, having some one with me on whom I can
+thoroughly rely. Local aid is always either worthless or else biassed.
+If you will keep the two corner seats I shall get the tickets.”
+
+We had the carriage to ourselves save for an immense litter of papers
+which Holmes had brought with him. Among these he rummaged and read,
+with intervals of note-taking and of meditation, until we were past
+Reading. Then he suddenly rolled them all into a gigantic ball, and
+tossed them up onto the rack.
+
+“Have you heard anything of the case?” he asked.
+
+“Not a word. I have not seen a paper for some days.”
+
+“The London press has not had very full accounts. I have just
+been looking through all the recent papers in order to master the
+particulars. It seems, from what I gather, to be one of those simple
+cases which are so extremely difficult.”
+
+“That sounds a little paradoxical.”
+
+“But it is profoundly true. Singularity is almost invariably a clew.
+The more featureless and commonplace a crime is, the more difficult is
+it to bring it home. In this case, however, they have established a
+very serious case against the son of the murdered man.”
+
+“It is a murder, then?”
+
+“Well, it is conjectured to be so. I shall take nothing for granted
+until I have the opportunity of looking personally into it. I will
+explain the state of things to you, as far as I have been able to
+understand it, in a very few words.
+
+“Boscombe Valley is a country district not very far from Ross, in
+Herefordshire. The largest landed proprietor in that part is a Mr. John
+Turner, who made his money in Australia, and returned some years ago to
+the old country. One of the farms which he held, that of Hatherley, was
+let to Mr. Charles McCarthy, who was also an ex-Australian. The men had
+known each other in the colonies, so that it was not unnatural that
+when they came to settle down they should do so as near each other as
+possible. Turner was apparently the richer man, so McCarthy became his
+tenant, but still remained, it seems, upon terms of perfect equality,
+as they were frequently together. McCarthy had one son, a lad of
+eighteen, and Turner had an only daughter of the same age, but neither
+of them had wives living. They appear to have avoided the society of
+the neighboring English families, and to have led retired lives, though
+both the McCarthys were fond of sport, and were frequently seen at
+the race-meetings of the neighborhood. McCarthy kept two servants—a
+man and a girl. Turner had a considerable household, some half-dozen
+at the least. That is as much as I have been able to gather about the
+families. Now for the facts.
+
+“On June 3, that is, on Monday last, McCarthy left his house at
+Hatherley about three in the afternoon, and walked down to the Boscombe
+Pool, which is a small lake formed by the spreading out of the
+stream which runs down the Boscombe Valley. He had been out with his
+serving-man in the morning at Ross, and he had told the man that he
+must hurry, as he had an appointment of importance to keep at three.
+From that appointment he never came back alive.
+
+“From Hatherley Farm-house to the Boscombe Pool is a quarter of a mile,
+and two people saw him as he passed over this ground. One was an old
+woman, whose name is not mentioned, and the other was William Crowder,
+a game-keeper in the employ of Mr. Turner. Both these witnesses depose
+that Mr. McCarthy was walking alone. The game-keeper adds that within
+a few minutes of his seeing Mr. McCarthy pass he had seen his son, Mr.
+James McCarthy, going the same way with a gun under his arm. To the
+best of his belief, the father was actually in sight at the time, and
+the son was following him. He thought no more of the matter until he
+heard in the evening of the tragedy that had occurred.
+
+“The two McCarthys were seen after the time when William Crowder, the
+game-keeper, lost sight of them. The Boscombe Pool is thickly-wooded
+round, with just a fringe of grass and of reeds round the edge. A girl
+of fourteen, Patience Moran, who is the daughter of the lodge-keeper of
+the Boscombe Valley estate, was in one of the woods picking flowers.
+She states that while she was there she saw, at the border of the wood
+and close by the lake, Mr. McCarthy and his son, and that they appeared
+to be having a violent quarrel. She heard Mr. McCarthy the elder using
+very strong language to his son, and she saw the latter raise up
+his hand as if to strike his father. She was so frightened by their
+violence that she ran away, and told her mother when she reached home
+that she had left the two McCarthys quarrelling near Boscombe Pool, and
+that she was afraid that they were going to fight. She had hardly said
+the words when young Mr. McCarthy came running up to the lodge to say
+that he had found his father dead in the wood, and to ask for the help
+of the lodge-keeper. He was much excited, without either his gun or his
+hat, and his right hand and sleeve were observed to be stained with
+fresh blood. On following him they found the dead body stretched out
+upon the grass beside the Pool. The head had been beaten in by repeated
+blows of some heavy and blunt weapon. The injuries were such as might
+very well have been inflicted by the butt-end of his son’s gun, which
+was found lying on the grass within a few paces of the body. Under
+these circumstances the young man was instantly arrested, and a verdict
+of ‘Wilful Murder’ having been returned at the inquest on Tuesday,
+he was on Wednesday brought before the magistrates at Ross, who have
+referred the case to the next assizes. Those are the main facts of the
+case as they came out before the coroner and at the police-court.”
+
+“I could hardly imagine a more damning case,” I remarked. “If ever
+circumstantial evidence pointed to a criminal it does so here.”
+
+“Circumstantial evidence is a very tricky thing,” answered Holmes,
+thoughtfully. “It may seem to point very straight to one thing, but if
+you shift your own point of view a little, you may find it pointing
+in an equally uncompromising manner to something entirely different.
+It must be confessed, however, that the case looks exceedingly grave
+against the young man, and it is very possible that he is indeed the
+culprit. There are several people in the neighborhood, however, and
+among them Miss Turner, the daughter of the neighboring land-owner,
+who believe in his innocence, and who have retained Lestrade, whom you
+may recollect in connection with the Study in Scarlet, to work out the
+case in his interest. Lestrade, being rather puzzled, has referred the
+case to me, and hence it is that two middle-aged gentlemen are flying
+westward at fifty miles an hour, instead of quietly digesting their
+breakfasts at home.”
+
+“I am afraid,” said I, “that the facts are so obvious that you will
+find little credit to be gained out of this case.”
+
+“There is nothing more deceptive than an obvious fact,” he answered,
+laughing. “Besides, we may chance to hit upon some other obvious facts
+which may have been by no means obvious to Mr. Lestrade. You know me
+too well to think that I am boasting when I say that I shall either
+confirm or destroy his theory by means which he is quite incapable of
+employing, or even of understanding. To take the first example to hand,
+I very clearly perceive that in your bedroom the window is upon the
+right-hand side, and yet I question whether Mr. Lestrade would have
+noted even so self-evident a thing as that.”
+
+“How on earth—”
+
+“My dear fellow, I know you well. I know the military neatness which
+characterizes you. You shave every morning, and in this season you
+shave by the sunlight; but since your shaving is less and less complete
+as we get farther back on the left side, until it becomes positively
+slovenly as we get round the angle of the jaw, it is surely very clear
+that that side is less well illuminated than the other. I could not
+imagine a man of your habits looking at himself in an equal light, and
+being satisfied with such a result. I only quote this as a trivial
+example of observation and inference. Therein lies my _métier_, and it
+is just possible that it may be of some service in the investigation
+which lies before us. There are one or two minor points which were
+brought out in the inquest, and which are worth considering.”
+
+[Illustration: “THEY FOUND THE BODY”]
+
+“What are they?”
+
+“It appears that his arrest did not take place at once, but after the
+return to Hatherley Farm. On the inspector of constabulary informing
+him that he was a prisoner, he remarked that he was not surprised to
+hear it, and that it was no more than his deserts. This observation of
+his had the natural effect of removing any traces of doubt which might
+have remained in the minds of the coroner’s jury.”
+
+“It was a confession,” I ejaculated.
+
+“No, for it was followed by a protestation of innocence.”
+
+“Coming on the top of such a damning series of events, it was at least
+a most suspicious remark.”
+
+“On the contrary,” said Holmes, “it is the brightest rift which I can
+at present see in the clouds. However innocent he might be, he could
+not be such an absolute imbecile as not to see that the circumstances
+were very black against him. Had he appeared surprised at his own
+arrest, or feigned indignation at it, I should have looked upon it as
+highly suspicious, because such surprise or anger would not be natural
+under the circumstances, and yet might appear to be the best policy
+to a scheming man. His frank acceptance of the situation marks him as
+either an innocent man, or else as a man of considerable self-restraint
+and firmness. As to his remark about his deserts, it was also not
+unnatural if you consider that he stood beside the dead body of his
+father, and that there is no doubt that he had that very day so far
+forgotten his filial duty as to bandy words with him, and even,
+according to the little girl whose evidence is so important, to raise
+his hand as if to strike him. The self-reproach and contrition which
+are displayed in his remark appear to me to be the signs of a healthy
+mind, rather than of a guilty one.”
+
+I shook my head. “Many men have been hanged on far slighter evidence,”
+I remarked.
+
+“So they have. And many men have been wrongfully hanged.”
+
+“What is the young man’s own account of the matter?”
+
+“It is, I am afraid, not very encouraging to his supporters, though
+there are one or two points in it which are suggestive. You will find
+it here, and may read it for yourself.”
+
+He picked out from his bundle a copy of the local Herefordshire paper,
+and having turned down the sheet, he pointed out the paragraph in which
+the unfortunate young man had given his own statement of what had
+occurred. I settled myself down in the corner of the carriage, and read
+it very carefully. It ran in this way:
+
+“Mr. James McCarthy, the only son of the deceased, was then called, and
+gave evidence as follows: ‘I had been away from home for three days at
+Bristol, and had only just returned upon the morning of last Monday,
+the 3rd. My father was absent from home at the time of my arrival, and
+I was informed by the maid that he had driven over to Ross with John
+Cobb, the groom. Shortly after my return I heard the wheels of his trap
+in the yard, and, looking out of my window, I saw him get out and walk
+rapidly out of the yard, though I was not aware in which direction he
+was going. I then took my gun, and strolled out in the direction of
+the Boscombe Pool, with the intention of visiting the rabbit-warren
+which is upon the other side. On my way I saw William Crowder, the
+game-keeper, as he had stated in his evidence; but he is mistaken in
+thinking that I was following my father. I had no idea that he was in
+front of me. When about a hundred yards from the Pool I heard a cry of
+“Cooee!” which was a usual signal between my father and myself. I then
+hurried forward, and found him standing by the Pool. He appeared to be
+much surprised at seeing me, and asked me rather roughly what I was
+doing there. A conversation ensued which led to high words, and almost
+to blows, for my father was a man of a very violent temper. Seeing
+that his passion was becoming ungovernable, I left him, and returned
+towards Hatherley Farm. I had not gone more than 150 yards, however,
+when I heard a hideous outcry behind me, which caused me to run back
+again. I found my father expiring upon the ground, with his head
+terribly injured. I dropped my gun, and held him in my arms, but he
+almost instantly expired. I knelt beside him for some minutes, and then
+made my way to Mr. Turner’s lodge-keeper, his house being the nearest,
+to ask for assistance. I saw no one near my father when I returned, and
+I have no idea how he came by his injuries. He was not a popular man,
+being somewhat cold and forbidding in his manners; but he had, as far
+as I know, no active enemies. I know nothing further of the matter.’
+
+“The Coroner: Did your father make any statement to you before he died?
+
+“Witness: He mumbled a few words, but I could only catch some allusion
+to a rat.
+
+“The Coroner: What did you understand by that?
+
+“Witness: It conveyed no meaning to me. I thought that he was delirious.
+
+“The Coroner: What was the point upon which you and your father had
+this final quarrel?
+
+“Witness: I should prefer not to answer.
+
+“The Coroner: I am afraid that I must press it.
+
+“Witness: It is really impossible for me to tell you. I can assure you
+that it has nothing to do with the sad tragedy which followed.
+
+“The Coroner: That is for the court to decide. I need not point out to
+you that your refusal to answer will prejudice your case considerably
+in any future proceedings which may arise.
+
+“Witness: I must still refuse.
+
+“The Coroner: I understand that the cry of ‘Cooee’ was a common signal
+between you and your father?
+
+“Witness: It was.
+
+“The Coroner: How was it, then, that he uttered it before he saw you,
+and before he even knew that you had returned from Bristol?
+
+“Witness (with considerable confusion): I do not know.
+
+“A Juryman: Did you see nothing which aroused your suspicions when you
+returned on hearing the cry, and found your father fatally injured?
+
+“Witness: Nothing definite.
+
+“The Coroner: What do you mean?
+
+“Witness: I was so disturbed and excited as I rushed out into the open,
+that I could think of nothing except of my father. Yet I have a vague
+impression that as I ran forward something lay upon the ground to the
+left of me. It seemed to me to be something gray in color, a coat of
+some sort, or a plaid perhaps. When I rose from my father I looked
+round for it, but it was gone.
+
+“‘Do you mean that it disappeared before you went for help?’
+
+“‘Yes, it was gone.’
+
+“‘You cannot say what it was?’
+
+“‘No, I had a feeling something was there.’
+
+“‘How far from the body?’
+
+“‘A dozen yards or so.’
+
+“‘And how far from the edge of the wood?’
+
+“‘About the same.’
+
+“‘Then if it was removed it was while you were within a dozen yards of
+it?’
+
+“‘Yes, but with my back towards it.’
+
+“This concluded the examination of the witness.”
+
+“I see,” said I, as I glanced down the column, “that the coroner in
+his concluding remarks was rather severe upon young McCarthy. He calls
+attention, and with reason, to the discrepancy about his father having
+signalled to him before seeing him, also to his refusal to give details
+of his conversation with his father, and his singular account of his
+father’s dying words. They are all, as he remarks, very much against
+the son.”
+
+Holmes laughed softly to himself, and stretched himself out upon the
+cushioned seat. “Both you and the coroner have been at some pains,”
+said he, “to single out the very strongest points in the young man’s
+favor. Don’t you see that you alternately give him credit for having
+too much imagination and too little. Too little, if he could not invent
+a cause of quarrel which would give him the sympathy of the jury;
+too much, if he evolved from his own inner consciousness anything
+so _outré_ as a dying reference to a rat, and the incident of the
+vanishing cloth. No, sir, I shall approach this case from the point of
+view that what this young man says is true, and we shall see whither
+that hypothesis will lead us. And now here is my pocket Petrarch, and
+not another word shall I say of this case until we are on the scene of
+action. We lunch at Swindon, and I see that we shall be there in twenty
+minutes.”
+
+It was nearly four o’clock when we at last, after passing through
+the beautiful Stroud Valley, and over the broad gleaming Severn,
+found ourselves at the pretty little country-town of Ross. A lean,
+ferret-like man, furtive and sly-looking, was waiting for us upon the
+platform. In spite of the light brown dustcoat and leather-leggings
+which he wore in deference to his rustic surroundings, I had no
+difficulty in recognizing Lestrade, of Scotland Yard. With him we drove
+to the Hereford Arms, where a room had already been engaged for us.
+
+“I have ordered a carriage,” said Lestrade, as we sat over a cup of
+tea. “I knew your energetic nature, and that you would not be happy
+until you had been on the scene of the crime.”
+
+“It was very nice and complimentary of you,” Holmes answered. “It is
+entirely a question of barometric pressure.”
+
+Lestrade looked startled. “I do not quite follow,” he said.
+
+“How is the glass? Twenty-nine, I see. No wind, and not a cloud in the
+sky. I have a caseful of cigarettes here which need smoking, and the
+sofa is very much superior to the usual country hotel abomination. I do
+not think that it is probable that I shall use the carriage to-night.”
+
+Lestrade laughed indulgently. “You have, no doubt, already formed your
+conclusions from the newspapers,” he said. “The case is as plain as a
+pikestaff, and the more one goes into it the plainer it becomes. Still,
+of course, one can’t refuse a lady, and such a very positive one, too.
+She had heard of you, and would have your opinion, though I repeatedly
+told her that there was nothing which you could do which I had not
+already done. Why, bless my soul! here is her carriage at the door.”
+
+He had hardly spoken before there rushed into the room one of the most
+lovely young women that I have ever seen in my life. Her violet eyes
+shining, her lips parted, a pink flush upon her cheeks, all thought of
+her natural reserve lost in her overpowering excitement and concern.
+
+“Oh, Mr. Sherlock Holmes!” she cried, glancing from one to the other
+of us, and finally, with a woman’s quick intuition, fastening upon my
+companion, “I am so glad that you have come. I have driven down to tell
+you so. I know that James didn’t do it. I know it, and I want you to
+start upon your work knowing it, too. Never let yourself doubt upon
+that point. We have known each other since we were little children, and
+I know his faults as no one else does; but he is too tender-hearted to
+hurt a fly. Such a charge is absurd to any one who really knows him.”
+
+“I hope we may clear him, Miss Turner,” said Sherlock Holmes. “You may
+rely upon my doing all that I can.”
+
+“But you have read the evidence. You have formed some conclusion? Do
+you not see some loophole, some flaw? Do you not yourself think that he
+is innocent?”
+
+“I think that it is very probable.”
+
+“There, now!” she cried, throwing back her head, and looking defiantly
+at Lestrade. “You hear! He gives me hopes.”
+
+Lestrade shrugged his shoulders. “I am afraid that my colleague has
+been a little quick in forming his conclusions,” he said.
+
+“But he is right. Oh! I know that he is right. James never did it. And
+about his quarrel with his father, I am sure that the reason why he
+would not speak about it to the coroner was because I was concerned in
+it.”
+
+“In what way?” asked Holmes.
+
+“It is no time for me to hide anything. James and his father had many
+disagreements about me. Mr. McCarthy was very anxious that there should
+be a marriage between us. James and I have always loved each other as
+brother and sister; but of course he is young, and has seen very little
+of life yet, and—and—well, he naturally did not wish to do anything
+like that yet. So there were quarrels, and this, I am sure, was one of
+them.”
+
+“And your father?” asked Holmes. “Was he in favor of such a union?”
+
+“No, he was averse to it also. No one but Mr. McCarthy was in favor of
+it.” A quick blush passed over her fresh young face as Holmes shot one
+of his keen, questioning glances at her.
+
+“Thank you for this information,” said he. “May I see your father if I
+call to-morrow?”
+
+“I am afraid the doctor won’t allow it.”
+
+“The doctor?”
+
+“Yes, have you not heard? Poor father has never been strong for years
+back, but this has broken him down completely. He has taken to his bed,
+and Dr. Willows says that he is a wreck, and that his nervous system is
+shattered. Mr. McCarthy was the only man alive who had known dad in the
+old days in Victoria.”
+
+“Ha! In Victoria! That is important.”
+
+“Yes, at the mines.”
+
+“Quite so; at the gold-mines, where, as I understand, Mr. Turner made
+his money.”
+
+“Yes, certainly.”
+
+“Thank you, Miss Turner. You have been of material assistance to me.”
+
+“You will tell me if you have any news to-morrow. No doubt you will go
+to the prison to see James. Oh, if you do, Mr. Holmes, do tell him that
+I know him to be innocent.”
+
+“I will, Miss Turner.”
+
+“I must go home now, for dad is very ill, and he misses me so if I
+leave him. Good-bye, and God help you in your undertaking.” She hurried
+from the room as impulsively as she had entered, and we heard the
+wheels of her carriage rattle off down the street.
+
+“I am ashamed of you, Holmes,” said Lestrade, with dignity, after a few
+minutes’ silence. “Why should you raise up hopes which you are bound to
+disappoint? I am not over-tender of heart, but I call it cruel.”
+
+“I think that I see my way to clearing James McCarthy,” said Holmes.
+“Have you an order to see him in prison?”
+
+“Yes, but only for you and me.”
+
+“Then I shall reconsider my resolution about going out. We have still
+time to take a train to Hereford and see him to-night?”
+
+“Ample.”
+
+“Then let us do so. Watson, I fear that you will find it very slow, but
+I shall only be away a couple of hours.”
+
+I walked down to the station with them, and then wandered through the
+streets of the little town, finally returning to the hotel, where I
+lay upon the sofa and tried to interest myself in a yellow-backed
+novel. The puny plot of the story was so thin, however, when compared
+to the deep mystery through which we were groping, and I found my
+attention wander so continually from the fiction to the fact, that I
+at last flung it across the room, and gave myself up entirely to a
+consideration of the events of the day. Supposing that this unhappy
+young man’s story was absolutely true, then what hellish thing, what
+absolutely unforeseen and extraordinary calamity could have occurred
+between the time when he parted from his father, and the moment when,
+drawn back by his screams, he rushed into the glade? It was something
+terrible and deadly. What could it be? Might not the nature of the
+injuries reveal something to my medical instincts? I rang the bell,
+and called for the weekly county paper, which contained a verbatim
+account of the inquest. In the surgeon’s deposition it was stated that
+the posterior third of the left parietal bone and the left half of the
+occipital bone had been shattered by a heavy blow from a blunt weapon.
+I marked the spot upon my own head. Clearly such a blow must have been
+struck from behind. That was to some extent in favor of the accused,
+as when seen quarrelling he was face to face with his father. Still,
+it did not go for very much, for the older man might have turned his
+back before the blow fell. Still, it might be worth while to call
+Holmes’s attention to it. Then there was the peculiar dying reference
+to a rat. What could that mean? It could not be delirium. A man dying
+from a sudden blow does not commonly become delirious. No, it was more
+likely to be an attempt to explain how he met his fate. But what could
+it indicate? I cudgelled my brains to find some possible explanation.
+And then the incident of the gray cloth, seen by young McCarthy. If
+that were true, the murderer must have dropped some part of his dress,
+presumably his overcoat, in his flight, and must have had the hardihood
+to return and to carry it away at the instant when the son was kneeling
+with his back turned not a dozen paces off. What a tissue of mysteries
+and improbabilities the whole thing was! I did not wonder at Lestrade’s
+opinion, and yet I had so much faith in Sherlock Holmes’s insight that
+I could not lose hope as long as every fresh fact seemed to strengthen
+his conviction of young McCarthy’s innocence.
+
+It was late before Sherlock Holmes returned. He came back alone, for
+Lestrade was staying in lodgings in the town.
+
+“The glass still keeps very high,” he remarked, as he sat down. “It is
+of importance that it should not rain before we are able to go over the
+ground. On the other hand, a man should be at his very best and keenest
+for such nice work as that, and I did not wish to do it when fagged by
+a long journey. I have seen young McCarthy.”
+
+“And what did you learn from him?”
+
+“Nothing.”
+
+“Could he throw no light?”
+
+“None at all. I was inclined to think at one time that he knew who had
+done it, and was screening him or her, but I am convinced now that he
+is as puzzled as every one else. He is not a very quick-witted youth,
+though comely to look at, and, I should think, sound at heart.”
+
+“I cannot admire his taste,” I remarked, “if it is indeed a fact that
+he was averse to a marriage with so charming a young lady as this Miss
+Turner.”
+
+“Ah, thereby hangs a rather painful tale. This fellow is madly,
+insanely in love with her, but some two years ago, when he was only a
+lad, and before he really knew her, for she had been away five years at
+a boarding-school, what does the idiot do but get into the clutches of
+a barmaid in Bristol, and marry her at a registry office? No one knows
+a word of the matter, but you can imagine how maddening it must be to
+him to be upbraided for not doing what he would give his very eyes to
+do, but what he knows to be absolutely impossible. It was sheer frenzy
+of this sort which made him throw his hands up into the air when his
+father, at their last interview, was goading him on to propose to Miss
+Turner. On the other hand, he had no means of supporting himself, and
+his father, who was by all accounts a very hard man, would have thrown
+him over utterly had he known the truth. It was with his barmaid wife
+that he had spent the last three days in Bristol, and his father did
+not know where he was. Mark that point. It is of importance. Good has
+come out of evil, however, for the barmaid, finding from the papers
+that he is in serious trouble, and likely to be hanged, has thrown
+him over utterly, and has written to him to say that she has a husband
+already in the Bermuda Dockyard, so that there is really no tie between
+them. I think that that bit of news has consoled young McCarthy for all
+that he has suffered.”
+
+“But if he is innocent, who has done it?”
+
+“Ah! who? I would call your attention very particularly to two points.
+One is that the murdered man had an appointment with some one at the
+Pool, and that the some one could not have been his son, for his son
+was away, and he did not know when he would return. The second is that
+the murdered man was heard to cry ‘Cooee!’ before he knew that his son
+had returned. Those are the crucial points upon which the case depends.
+And now let us talk about George Meredith, if you please, and we shall
+leave all minor matters until to-morrow.”
+
+There was no rain, as Holmes had foretold, and the morning broke
+bright and cloudless. At nine o’clock Lestrade called for us with the
+carriage, and we set off for Hatherley Farm and the Boscombe Pool.
+
+“There is serious news this morning,” Lestrade observed. “It is said
+that Mr. Turner, of the Hall, is so ill that his life is despaired of.”
+
+“An elderly man, I presume?” said Holmes.
+
+“About sixty; but his constitution has been shattered by his life
+abroad, and he has been in failing health for some time. This business
+has had a very bad effect upon him. He was an old friend of McCarthy’s,
+and, I may add, a great benefactor to him, for I have learned that he
+gave him Hatherley Farm rent free.”
+
+“Indeed! That is interesting,” said Holmes.
+
+“Oh yes! In a hundred other ways he has helped him. Everybody about
+here speaks of his kindness to him.”
+
+“Really! Does it not strike you as a little singular that this
+McCarthy, who appears to have had little of his own, and to have been
+under such obligations to Turner, should still talk of marrying his
+son to Turner’s daughter, who is, presumably, heiress to the estate,
+and that in such a very cocksure manner, as if it were merely a case of
+a proposal and all else would follow? It is the more strange, since we
+know that Turner himself was averse to the idea. The daughter told us
+as much. Do you not deduce something from that?”
+
+“We have got to the deductions and the inferences,” said Lestrade,
+winking at me. “I find it hard enough to tackle facts, Holmes, without
+flying away after theories and fancies.”
+
+“You are right,” said Holmes, demurely; “you do find it very hard to
+tackle the facts.”
+
+“Anyhow, I have grasped one fact which you seem to find it difficult to
+get hold of,” replied Lestrade, with some warmth.
+
+“And that is—”
+
+“That McCarthy, senior, met his death from McCarthy, junior, and that
+all theories to the contrary are the merest moonshine.”
+
+“Well, moonshine is a brighter thing than fog,” said Holmes, laughing.
+“But I am very much mistaken if this is not Hatherley Farm upon the
+left.”
+
+“Yes, that is it.” It was a wide-spread, comfortable-looking building,
+two-storied, slate roofed, with great yellow blotches of lichen upon
+the gray walls. The drawn blinds and the smokeless chimneys, however,
+gave it a stricken look, as though the weight of this horror still
+lay heavy upon it. We called at the door, when the maid, at Holmes’s
+request, showed us the boots which her master wore at the time of his
+death, and also a pair of the son’s, though not the pair which he had
+then had. Having measured these very carefully from seven or eight
+different points, Holmes desired to be led to the court-yard, from
+which we all followed the winding track which led to Boscombe Pool.
+
+[Illustration: “THE MAID SHOWED US THE BOOTS.”]
+
+Sherlock Holmes was transformed when he was hot upon such a scent
+as this. Men who had only known the quiet thinker and logician of
+Baker Street would have failed to recognize him. His face flushed and
+darkened. His brows were drawn into two hard, black lines, while his
+eyes shone out from beneath them with a steely glitter. His face was
+bent downward, his shoulders bowed, his lips compressed, and the veins
+stood out like whip-cord in his long, sinewy neck. His nostrils seemed
+to dilate with a purely animal lust for the chase, and his mind was so
+absolutely concentrated upon the matter before him, that a question
+or remark fell unheeded upon his ears, or, at the most, only provoked
+a quick, impatient snarl in reply. Swiftly and silently he made his
+way along the track which ran through the meadows, and so by way of
+the woods to the Boscombe Pool. It was damp, marshy ground, as is all
+that district, and there were marks of many feet, both upon the path
+and amid the short grass which bounded it on either side. Sometimes
+Holmes would hurry on, sometimes stop dead, and once he made quite a
+little _détour_ into the meadow. Lestrade and I walked behind him, the
+detective indifferent and contemptuous, while I watched my friend with
+the interest which sprang from the conviction that every one of his
+actions was directed towards a definite end.
+
+The Boscombe Pool, which is a little reed-girt sheet of water some
+fifty yards across, is situated at the boundary between the Hatherley
+Farm and the private park of the wealthy Mr. Turner. Above the woods
+which lined it upon the farther side we could see the red, jutting
+pinnacles which marked the site of the rich land-owner’s dwelling. On
+the Hatherley side of the Pool the woods grew very thick, and there was
+a narrow belt of sodden grass twenty paces across between the edge of
+the trees and the reeds which lined the lake. Lestrade showed us the
+exact spot at which the body had been found, and, indeed, so moist was
+the ground, that I could plainly see the traces which had been left by
+the fall of the stricken man. To Holmes, as I could see by his eager
+face and peering eyes, very many other things were to be read upon the
+trampled grass. He ran round, like a dog who is picking up a scent, and
+then turned upon my companion.
+
+“What did you go into the Pool for?” he asked.
+
+“I fished about with a rake. I thought there might be some weapon or
+other trace. But how on earth—”
+
+“Oh, tut, tut! I have no time! That left foot of yours with its inward
+twist is all over the place. A mole could trace it, and there it
+vanishes among the reeds. Oh, how simple it would all have been had I
+been here before they came like a herd of buffalo, and wallowed all
+over it. Here is where the party with the lodge-keeper came, and they
+have covered all tracks for six or eight feet round the body. But
+here are three separate tracks of the same feet.” He drew out a lens,
+and lay down upon his waterproof to have a better view, talking all
+the time rather to himself than to us. “These are young McCarthy’s
+feet. Twice he was walking, and once he ran swiftly so that the soles
+are deeply marked, and the heels hardly visible. That bears out his
+story. He ran when he saw his father on the ground. Then here are the
+father’s feet as he paced up and down. What is this, then? It is the
+butt-end of the gun as the son stood listening. And this? Ha, ha! What
+have we here? Tiptoes! tiptoes! Square, too, quite unusual boots! They
+come, they go, they come again—of course that was for the cloak.
+Now where did they come from?” He ran up and down, sometimes losing,
+sometimes finding the track until we were well within the edge of the
+wood, and under the shadow of a great beech, the largest tree in the
+neighborhood. Holmes traced his way to the farther side of this, and
+lay down once more upon his face with a little cry of satisfaction.
+For a long time he remained there, turning over the leaves and dried
+sticks, gathering up what seemed to me to be dust into an envelope, and
+examining with his lens not only the ground, but even the bark of the
+tree as far as he could reach. A jagged stone was lying among the moss,
+and this also he carefully examined and retained. Then he followed a
+pathway through the wood until he came to the high-road, where all
+traces were lost.
+
+“It has been a case of considerable interest,” he remarked, returning
+to his natural manner. “I fancy that this gray house on the right must
+be the lodge. I think that I will go in and have a word with Moran, and
+perhaps write a little note. Having done that, we may drive back to our
+luncheon. You may walk to the cab, and I shall be with you presently.”
+
+It was about ten minutes before we regained our cab, and drove back
+into Ross, Holmes still carrying with him the stone which he had picked
+up in the wood.
+
+“This may interest you, Lestrade,” he remarked, holding it out. “The
+murder was done with it.”
+
+“I see no marks.”
+
+“There are none.”
+
+“How do you know, then?”
+
+“The grass was growing under it. It had only lain there a few days.
+There was no sign of a place whence it had been taken. It corresponds
+with the injuries. There is no sign of any other weapon.”
+
+“And the murderer?”
+
+“Is a tall man, left-handed, limps with the right leg, wears
+thick-soled shooting-boots and a gray cloak, smokes Indian cigars, uses
+a cigar-holder, and carries a blunt penknife in his pocket. There are
+several other indications, but these may be enough to aid us in our
+search.”
+
+Lestrade laughed. “I am afraid that I am still a sceptic,” he said.
+“Theories are all very well, but we have to deal with a hard-headed
+British jury.”
+
+“_Nous verrons_,” answered Holmes, calmly. “You work your own method,
+and I shall work mine. I shall be busy this afternoon, and shall
+probably return to London by the evening train.”
+
+“And leave your case unfinished?”
+
+“No, finished.”
+
+“But the mystery?”
+
+“It is solved.”
+
+“Who was the criminal, then?”
+
+“The gentleman I describe.”
+
+“But who is he?”
+
+“Surely it would not be difficult to find out. This is not such a
+populous neighborhood.”
+
+Lestrade shrugged his shoulders. “I am a practical man,” he said,
+“and I really cannot undertake to go about the country looking
+for a left-handed gentleman with a game-leg. I should become the
+laughing-stock of Scotland Yard.”
+
+“All right,” said Holmes, quietly. “I have given you the chance. Here
+are your lodgings. Good-bye. I shall drop you a line before I leave.”
+
+Having left Lestrade at his rooms, we drove to our hotel, where we
+found lunch upon the table. Holmes was silent and buried in thought
+with a pained expression upon his face, as one who finds himself in a
+perplexing position.
+
+“Look here, Watson,” he said, when the cloth was cleared; “just sit
+down in this chair and let me preach to you for a little. I don’t quite
+know what to do, and I should value your advice. Light a cigar, and let
+me expound.”
+
+“Pray do so.”
+
+“Well, now, in considering this case there are two points about young
+McCarthy’s narrative which struck us both instantly, although they
+impressed me in his favor and you against him. One was the fact that
+his father should, according to his account, cry ‘Cooee!’ before seeing
+him. The other was his singular dying reference to a rat. He mumbled
+several words, you understand, but that was all that caught the son’s
+ear. Now from this double point our research must commence, and we will
+begin it by presuming that what the lad says is absolutely true.”
+
+“What of this ‘Cooee!’ then?”
+
+“Well, obviously it could not have been meant for the son. The son, as
+far as he knew, was in Bristol. It was mere chance that he was within
+ear-shot. The ‘Cooee!’ was meant to attract the attention of whoever
+it was that he had the appointment with. But ‘Cooee’ is a distinctly
+Australian cry, and one which is used between Australians. There is a
+strong presumption that the person whom McCarthy expected to meet him
+at Boscombe Pool was some one who had been in Australia.”
+
+“What of the rat, then?”
+
+Sherlock Holmes took a folded paper from his pocket and flattened it
+out on the table. “This is a map of the Colony of Victoria,” he said.
+“I wired to Bristol for it last night.” He put his hand over part of
+the map. “What do you read?” he asked.
+
+“ARAT,” I read.
+
+“And now?” He raised his hand.
+
+“BALLARAT.”
+
+“Quite so. That was the word the man uttered, and of which his son only
+caught the last two syllables. He was trying to utter the name of his
+murderer. So-and-so, of Ballarat.”
+
+“It is wonderful!” I exclaimed.
+
+“It is obvious. And now, you see, I had narrowed the field down
+considerably. The possession of a gray garment was a third point
+which, granting the son’s statement to be correct, was a certainty. We
+have come now out of mere vagueness to the definite conception of an
+Australian from Ballarat with a gray cloak.”
+
+“Certainly.”
+
+“And one who was at home in the district, for the Pool can only be
+approached by the farm or by the estate, where strangers could hardly
+wander.”
+
+“Quite so.”
+
+“Then comes our expedition of to-day. By an examination of the ground I
+gained the trifling details which I gave to that imbecile Lestrade, as
+to the personality of the criminal.”
+
+“But how did you gain them?”
+
+“You know my method. It is founded upon the observance of trifles.”
+
+“His height I know that you might roughly judge from the length of his
+stride. His boots, too, might be told from their traces.”
+
+“Yes, they were peculiar boots.”
+
+“But his lameness?”
+
+“The impression of his right foot was always less distinct than his
+left. He put less weight upon it. Why? Because he limped—he was lame.”
+
+“But his left-handedness.”
+
+“You were yourself struck by the nature of the injury as recorded
+by the surgeon at the inquest. The blow was struck from immediately
+behind, and yet was upon the left side. Now, how can that be unless it
+were by a left-handed man? He had stood behind that tree during the
+interview between the father and son. He had even smoked there. I found
+the ash of a cigar, which my special knowledge of tobacco ashes enabled
+me to pronounce as an Indian cigar. I have, as you know, devoted some
+attention to this, and written a little monograph on the ashes of 140
+different varieties of pipe, cigar, and cigarette tobacco. Having found
+the ash, I then looked round and discovered the stump among the moss
+where he had tossed it. It was an Indian cigar, of the variety which
+are rolled in Rotterdam.”
+
+“And the cigar-holder?”
+
+“I could see that the end had not been in his mouth. Therefore he used
+a holder. The tip had been cut off, not bitten off, but the cut was not
+a clean one, so I deduced a blunt pen-knife.”
+
+“Holmes,” I said, “you have drawn a net round this man from which he
+cannot escape, and you have saved an innocent human life as truly as
+if you had cut the cord which was hanging him. I see the direction in
+which all this points. The culprit is—”
+
+“Mr. John Turner,” cried the hotel waiter, opening the door of our
+sitting-room, and ushering in a visitor.
+
+The man who entered was a strange and impressive figure. His slow,
+limping step and bowed shoulders gave the appearance of decrepitude,
+and yet his hard, deep-lined, craggy features, and his enormous
+limbs showed that he was possessed of unusual strength of body and
+of character. His tangled beard, grizzled hair, and outstanding,
+drooping eyebrows combined to give an air of dignity and power to his
+appearance, but his face was of an ashen white, while his lips and the
+corners of his nostrils were tinged with a shade of blue. It was clear
+to me at a glance that he was in the grip of some deadly and chronic
+disease.
+
+“Pray sit down on the sofa,” said Holmes, gently. “You had my note?”
+
+“Yes, the lodge-keeper brought it up. You said that you wished to see
+me here to avoid scandal.”
+
+“I thought people would talk if I went to the Hall.”
+
+“And why did you wish to see me?” He looked across at my companion with
+despair in his weary eyes, as though his question was already answered.
+
+“Yes,” said Holmes, answering the look rather than the words. “It is
+so. I know all about McCarthy.”
+
+The old man sank his face in his hands. “God help me!” he cried. “But I
+would not have let the young man come to harm. I give you my word that
+I would have spoken out if it went against him at the Assizes.”
+
+“I am glad to hear you say so,” said Holmes, gravely.
+
+“I would have spoken now had it not been for my dear girl. It would
+break her heart—it will break her heart when she hears that I am
+arrested.”
+
+“It may not come to that,” said Holmes.
+
+“What!”
+
+“I am no official agent. I understand that it was your daughter who
+required my presence here, and I am acting in her interests. Young
+McCarthy must be got off, however.”
+
+“I am a dying man,” said old Turner. “I have had diabetes for years. My
+doctor says it is a question whether I shall live a month. Yet I would
+rather die under my own roof than in a jail.”
+
+Holmes rose and sat down at the table with his pen in his hand and a
+bundle of paper before him. “Just tell us the truth,” he said. “I
+shall jot down the facts. You will sign it, and Watson here can witness
+it. Then I could produce your confession at the last extremity to save
+young McCarthy. I promise you that I shall not use it unless it is
+absolutely needed.”
+
+“It’s as well,” said the old man; “it’s a question whether I shall live
+to the Assizes, so it matters little to me, but I should wish to spare
+Alice the shock. And now I will make the thing clear to you; it has
+been a long time in the acting, but will not take me long to tell.
+
+“You didn’t know this dead man, McCarthy. He was a devil incarnate. I
+tell you that. God keep you out of the clutches of such a man as he.
+His grip has been upon me these twenty years, and he has blasted my
+life. I’ll tell you first how I came to be in his power.
+
+“It was in the early sixties at the diggings. I was a young chap then,
+hot-blooded and reckless, ready to turn my hand at anything; I got
+among bad companions, took to drink, had no luck with my claim, took to
+the bush, and in a word became what you would call over here a highway
+robber. There were six of us, and we had a wild, free life of it,
+sticking up a station from time to time, or stopping the wagons on the
+road to the diggings. Black Jack of Ballarat was the name I went under,
+and our party is still remembered in the colony as the Ballarat Gang.
+
+“One day a gold convoy came down from Ballarat to Melbourne, and we
+lay in wait for it and attacked it. There were six troopers and six of
+us, so it was a close thing, but we emptied four of their saddles at
+the first volley. Three of our boys were killed, however, before we
+got the swag. I put my pistol to the head of the wagon-driver, who was
+this very man McCarthy. I wish to the Lord that I had shot him then,
+but I spared him, though I saw his wicked little eyes fixed on my face,
+as though to remember every feature. We got away with the gold, became
+wealthy men, and made our way over to England without being suspected.
+There I parted from my old pals, and determined to settle down to a
+quiet and respectable life. I bought this estate, which chanced to be
+in the market, and I set myself to do a little good with my money,
+to make up for the way in which I had earned it. I married, too, and
+though my wife died young, she left me my dear little Alice. Even when
+she was just a baby her wee hand seemed to lead me down the right path
+as nothing else had ever done. In a word, I turned over a new leaf, and
+did my best to make up for the past. All was going well when McCarthy
+laid his grip upon me.
+
+“I had gone up to town about an investment, and I met him in Regent
+Street with hardly a coat to his back or a boot to his foot.
+
+“‘Here we are, Jack,’ says he, touching me on the arm; ‘we’ll be as
+good as a family to you. There’s two of us, me and my son, and you can
+have the keeping of us. If you don’t—it’s a fine, law-abiding country
+is England, and there’s always a policeman within hail.’
+
+“Well, down they came to the West country, there was no shaking them
+off, and there they have lived rent free on my best land ever since.
+There was no rest for me, no peace, no forgetfulness; turn where I
+would, there was his cunning, grinning face at my elbow. It grew worse
+as Alice grew up, for he soon saw I was more afraid of her knowing my
+past than of the police. Whatever he wanted he must have, and whatever
+it was I gave him without question, land, money, houses, until at last
+he asked a thing which I could not give. He asked for Alice.
+
+“His son, you see, had grown up, and so had my girl, and as I was known
+to be in weak health, it seemed a fine stroke to him that his lad
+should step into the whole property. But there I was firm. I would not
+have his cursed stock mixed with mine; not that I had any dislike to
+the lad, but his blood was in him, and that was enough. I stood firm.
+McCarthy threatened. I braved him to do his worst. We were to meet at
+the Pool midway between our houses to talk it over.
+
+“When I went down there I found him talking with his son, so I smoked
+a cigar, and waited behind a tree until he should be alone. But as I
+listened to his talk all that was black and bitter in me seemed to
+come uppermost. He was urging his son to marry my daughter with as
+little regard for what she might think as if she were a slut from off
+the streets. It drove me mad to think that I and all that I held most
+dear should be in the power of such a man as this. Could I not snap the
+bond? I was already a dying and a desperate man. Though clear of mind
+and fairly strong of limb, I knew that my own fate was sealed. But my
+memory and my girl! Both could be saved, if I could but silence that
+foul tongue. I did it, Mr. Holmes. I would do it again. Deeply as I
+have sinned, I have led a life of martyrdom to atone for it. But that
+my girl should be entangled in the same meshes which held me was more
+than I could suffer. I struck him down with no more compunction than if
+he had been some foul and venomous beast. His cry brought back his son;
+but I had gained the cover of the wood, though I was forced to go back
+to fetch the cloak which I had dropped in my flight. That is the true
+story, gentlemen, of all that occurred.”
+
+“Well, it is not for me to judge you,” said Holmes, as the old man
+signed the statement which had been drawn out. “I pray that we may
+never be exposed to such a temptation.”
+
+“I pray not, sir. And what do you intend to do?”
+
+“In view of your health, nothing. You are yourself aware that you will
+soon have to answer for your deed at a higher court than the Assizes.
+I will keep your confession, and, if McCarthy is condemned, I shall be
+forced to use it. If not, it shall never be seen by mortal eye; and
+your secret, whether you be alive or dead, shall be safe with us.”
+
+“Farewell, then,” said the old man, solemnly. “Your own death-beds,
+when they come, will be the easier for the thought of the peace which
+you have given to mine.” Tottering and shaking in all his giant frame,
+he stumbled slowly from the room.
+
+“God help us!” said Holmes, after a long silence. “Why does fate play
+such tricks with poor, helpless worms? I never hear of such a case as
+this that I do not think of Baxter’s words, and say, ‘There, but for
+the grace of God, goes Sherlock Holmes.’”
+
+James McCarthy was acquitted at the Assizes, on the strength of a
+number of objections which had been drawn out by Holmes, and submitted
+to the defending counsel. Old Turner lived for seven months after our
+interview, but he is now dead; and there is every prospect that the son
+and daughter may come to live happily together, in ignorance of the
+black cloud which rests upon their past.
+
+
+
+
+Adventure V
+
+THE FIVE ORANGE PIPS
+
+
+When I glance over my notes and records of the Sherlock Holmes cases
+between the years ’82 and ’90, I am faced by so many which present
+strange and interesting features that it is no easy matter to know
+which to choose and which to leave. Some, however, have already gained
+publicity through the papers, and others have not offered a field
+for those peculiar qualities which my friend possessed in so high a
+degree, and which it is the object of these papers to illustrate. Some,
+too, have baffled his analytical skill, and would be, as narratives,
+beginnings without an ending, while others have been but partially
+cleared up, and have their explanations founded rather upon conjecture
+and surmise than on that absolute logical proof which was so dear to
+him. There is, however, one of these last which was so remarkable in
+its details and so startling in its results that I am tempted to give
+some account of it, in spite of the fact that there are points in
+connection with it which never have been, and probably never will be,
+entirely cleared up.
+
+The year ’87 furnished us with a long series of cases of greater
+or less interest, of which I retain the records. Among my headings
+under this one twelve months I find an account of the adventure of
+the Paradol Chamber, of the Amateur Mendicant Society, who held a
+luxurious club in the lower vault of a furniture warehouse, of the
+facts connected with the loss of the British bark _Sophy Anderson_, of
+the singular adventures of the Grice Patersons in the island of Uffa,
+and finally of the Camberwell poisoning case. In the latter, as may
+be remembered, Sherlock Holmes was able, by winding up the dead man’s
+watch, to prove that it had been wound up two hours before, and that
+therefore the deceased had gone to bed within that time—a deduction
+which was of the greatest importance in clearing up the case. All these
+I may sketch out at some future date, but none of them present such
+singular features as the strange train of circumstances which I have
+now taken up my pen to describe.
+
+It was in the latter days of September, and the equinoctial gales had
+set in with exceptional violence. All day the wind had screamed and the
+rain had beaten against the windows, so that even here in the heart
+of great, hand-made London we were forced to raise our minds for the
+instant from the routine of life, and to recognize the presence of
+those great elemental forces which shriek at mankind through the bars
+of his civilization, like untamed beasts in a cage. As evening drew in,
+the storm grew higher and louder, and the wind cried and sobbed like a
+child in the chimney. Sherlock Holmes sat moodily at one side of the
+fireplace cross-indexing his records of crime, while I at the other was
+deep in one of Clark Russell’s fine sea-stories, until the howl of the
+gale from without seemed to blend with the text, and the splash of the
+rain to lengthen out into the long swash of the sea waves. My wife was
+on a visit to her mother’s, and for a few days I was a dweller once
+more in my old quarters at Baker Street.
+
+“Why,” said I, glancing up at my companion, “that was surely the bell.
+Who could come to-night? Some friend of yours, perhaps?”
+
+“Except yourself I have none,” he answered. “I do not encourage
+visitors.”
+
+“A client, then?”
+
+“If so, it is a serious case. Nothing less would bring a man out on
+such a day and at such an hour. But I take it that it is more likely to
+be some crony of the landlady’s.”
+
+Sherlock Holmes was wrong in his conjecture, however, for there came
+a step in the passage and a tapping at the door. He stretched out his
+long arm to turn the lamp away from himself and towards the vacant
+chair upon which a new-comer must sit. “Come in!” said he.
+
+The man who entered was young, some two-and-twenty at the outside,
+well-groomed and trimly clad, with something of refinement and delicacy
+in his bearing. The steaming umbrella which he held in his hand, and
+his long shining waterproof told of the fierce weather through which he
+had come. He looked about him anxiously in the glare of the lamp, and
+I could see that his face was pale and his eyes heavy, like those of a
+man who is weighed down with some great anxiety.
+
+“I owe you an apology,” he said, raising his golden _pince-nez_ to his
+eyes. “I trust that I am not intruding. I fear that I have brought some
+traces of the storm and rain into your snug chamber.”
+
+“Give me your coat and umbrella,” said Holmes. “They may rest here
+on the hook, and will be dry presently. You have come up from the
+south-west, I see.”
+
+“Yes, from Horsham.”
+
+“That clay and chalk mixture which I see upon your toe-caps is quite
+distinctive.”
+
+“I have come for advice.”
+
+“That is easily got.”
+
+“And help.”
+
+“That is not always so easy.”
+
+“I have heard of you, Mr. Holmes. I heard from Major Prendergast how
+you saved him in the Tankerville Club Scandal.”
+
+“Ah, of course. He was wrongfully accused of cheating at cards.”
+
+“He said that you could solve anything.”
+
+“He said too much.”
+
+“That you are never beaten.”
+
+“I have been beaten four times—three times by men, and once by a
+woman.”
+
+“But what is that compared with the number of your successes?”
+
+“It is true that I have been generally successful.”
+
+“Then you may be so with me.”
+
+“I beg that you will draw your chair up to the fire, and favor me with
+some details as to your case.”
+
+“It is no ordinary one.”
+
+“None of those which come to me are. I am the last court of appeal.”
+
+“And yet I question, sir, whether, in all your experience, you have
+ever listened to a more mysterious and inexplicable chain of events
+than those which have happened in my own family.”
+
+“You fill me with interest,” said Holmes. “Pray give us the essential
+facts from the commencement, and I can afterwards question you as to
+those details which seem to me to be most important.”
+
+The young man pulled his chair up, and pushed his wet feet out towards
+the blaze.
+
+“My name,” said he, “is John Openshaw, but my own affairs have, as far
+as I can understand it, little to do with this awful business. It is an
+hereditary matter; so in order to give you an idea of the facts, I must
+go back to the commencement of the affair.
+
+“You must know that my grandfather had two sons—my uncle Elias and
+my father Joseph. My father had a small factory at Coventry, which
+he enlarged at the time of the invention of bicycling. He was the
+patentee of the Openshaw unbreakable tire, and his business met with
+such success that he was able to sell it, and to retire upon a handsome
+competence.
+
+“My uncle Elias emigrated to America when he was a young man, and
+became a planter in Florida, where he was reported to have done
+very well. At the time of the war he fought in Jackson’s army, and
+afterwards under Hood, where he rose to be a colonel. When Lee laid
+down his arms my uncle returned to his plantation, where he remained
+for three or four years. About 1869 or 1870 he came back to Europe,
+and took a small estate in Sussex, near Horsham. He had made a very
+considerable fortune in the States, and his reason for leaving them was
+his aversion to the negroes, and his dislike of the Republican policy
+in extending the franchise to them. He was a singular man, fierce and
+quick-tempered, very foul-mouthed when he was angry, and of a most
+retiring disposition. During all the years that he lived at Horsham I
+doubt if ever he set foot in the town. He had a garden and two or three
+fields round his house, and there he would take his exercise, though
+very often for weeks on end he would never leave his room. He drank
+a great deal of brandy, and smoked very heavily, but he would see no
+society, and did not want any friends, not even his own brother.
+
+“He didn’t mind me, in fact, he took a fancy to me, for at the time
+when he saw me first I was a youngster of twelve or so. This would be
+in the year 1878, after he had been eight or nine years in England. He
+begged my father to let me live with him, and he was very kind to me
+in his way. When he was sober he used to be fond of playing backgammon
+and draughts with me, and he would make me his representative both with
+the servants and with the tradespeople, so that by the time that I was
+sixteen I was quite master of the house. I kept all the keys, and could
+go where I liked and do what I liked, so long as I did not disturb him
+in his privacy. There was one singular exception, however, for he had
+a single room, a lumber-room up among the attics, which was invariably
+locked, and which he would never permit either me or anyone else to
+enter. With a boy’s curiosity I have peeped through the key-hole, but
+I was never able to see more than such a collection of old trunks and
+bundles as would be expected in such a room.
+
+“One day—it was in March, 1883—a letter with a foreign stamp lay
+upon the table in front of the Colonel’s plate. It was not a common
+thing for him to receive letters, for his bills were all paid in
+ready money, and he had no friends of any sort. ‘From India!’ said he,
+as he took it up, ‘Pondicherry postmark! What can this be?’ Opening
+it hurriedly, out there jumped five little dried orange pips, which
+pattered down upon his plate. I began to laugh at this, but the laugh
+was struck from my lips at the sight of his face. His lip had fallen,
+his eyes were protruding, his skin the color of putty, and he glared at
+the envelope which he still held in his trembling hand. ‘K. K. K.!’ he
+shrieked, and then, ‘My God, my God, my sins have overtaken me!’
+
+“‘What is it, uncle?’ I cried.
+
+“‘Death,’ said he, and rising from the table he retired to his room,
+leaving me palpitating with horror. I took up the envelope, and saw
+scrawled in red ink upon the inner flap, just above the gum, the letter
+K three times repeated. There was nothing else save the five dried
+pips. What could be the reason of his overpowering terror? I left the
+breakfast-table, and as I ascended the stair I met him coming down with
+an old rusty key, which must have belonged to the attic, in one hand,
+and a small brass box, like a cash-box, in the other.
+
+“‘They may do what they like, but I’ll checkmate them still,’ said he,
+with an oath. ‘Tell Mary that I shall want a fire in my room to-day,
+and send down to Fordham, the Horsham lawyer.’
+
+“I did as he ordered, and when the lawyer arrived I was asked to step
+up to the room. The fire was burning brightly, and in the grate there
+was a mass of black, fluffy ashes, as of burned paper, while the brass
+box stood open and empty beside it. As I glanced at the box I noticed,
+with a start, that upon the lid were printed the treble K which I had
+read in the morning upon the envelope.
+
+“‘I wish you, John,’ said my uncle, ‘to witness my will. I leave
+my estate, with all its advantages and all its disadvantages to my
+brother, your father, whence it will, no doubt, descend to you. If you
+can enjoy it in peace, well and good! If you find you cannot, take my
+advice, my boy, and leave it to your deadliest enemy. I am sorry to
+give you such a two-edged thing, but I can’t say what turn things are
+going to take. Kindly sign the paper where Mr. Fordham shows you.’
+
+“I signed the paper as directed, and the lawyer took it away with him.
+The singular incident made, as you may think, the deepest impression
+upon me, and I pondered over it, and turned it every way in my mind
+without being able to make anything of it. Yet I could not shake off
+the vague feeling of dread which it left behind though the sensation
+grew less keen as the weeks passed, and nothing happened to disturb
+the usual routine of our lives. I could see a change in my uncle,
+however. He drank more than ever, and he was less inclined for any
+sort of society. Most of his time he would spend in his room, with the
+door locked upon the inside, but sometimes he would emerge in a sort
+of drunken frenzy, and would burst out of the house and tear about the
+garden with a revolver in his hand, screaming out that he was afraid
+of no man, and that he was not to be cooped up, like a sheep in a pen,
+by man or devil. When these hot fits were over, however, he would rush
+tumultuously in at the door, and lock and bar it behind him, like a man
+who can brazen it out no longer against the terror which lies at the
+roots of his soul. At such times I have seen his face, even on a cold
+day, glisten with moisture, as though it were new raised from a basin.
+
+“Well, to come to an end of the matter, Mr. Holmes, and not to abuse
+your patience, there came a night when he made one of those drunken
+sallies from which he never came back. We found him, when we went to
+search for him, face downward in a little green-scummed pool, which lay
+at the foot of the garden. There was no sign of any violence, and the
+water was but two feet deep, so that the jury, having regard to his
+known eccentricity, brought in a verdict of suicide. But I, who knew
+how he winced from the very thought of death, had much ado to persuade
+myself that he had gone out of his way to meet it. The matter passed,
+however, and my father entered into possession of the estate, and of
+some £14,000, which lay to his credit at the bank.”
+
+“One moment,” Holmes interposed. “Your statement is, I foresee, one
+of the most remarkable to which I have ever listened. Let me have the
+date of the reception by your uncle of the letter, and the date of his
+supposed suicide.”
+
+“The latter arrived on March 10, 1883. His death was seven weeks later,
+upon the night of May 2d.”
+
+“Thank you. Pray proceed.”
+
+“When my father took over the Horsham property, he, at my request, made
+a careful examination of the attic, which had been always locked up. We
+found the brass box there, although its contents had been destroyed. On
+the inside of the cover was a paper label, with the initials of K. K.
+K. repeated upon it, and ‘Letters, memoranda, receipts, and a register’
+written beneath. These, we presume, indicated the nature of the papers
+which had been destroyed by Colonel Openshaw. For the rest, there was
+nothing of much importance in the attic, save a great many scattered
+papers and note-books bearing upon my uncle’s life in America. Some
+of them were of the war time, and showed that he had done his duty
+well, and had borne the repute of a brave soldier. Others were of a
+date during the reconstruction of the Southern States, and were mostly
+concerned with politics, for he had evidently taken a strong part in
+opposing the carpet-bag politicians who had been sent down from the
+North.
+
+“Well, it was the beginning of ’84 when my father came to live at
+Horsham, and all went as well as possible with us until the January
+of ’85. On the fourth day after the new year I heard my father give a
+sharp cry of surprise as we sat together at the breakfast-table. There
+he was, sitting with a newly-opened envelope in one hand and five dried
+orange pips in the outstretched palm of the other one. He had always
+laughed at what he called my cock-and-a-bull story about the Colonel,
+but he looked very scared and puzzled now that the same thing had come
+upon himself.
+
+“‘Why, what on earth does this mean, John?’ he stammered.
+
+“My heart had turned to lead. ‘It is K. K. K.,’ said I.
+
+“He looked inside the envelope. ‘So it is,’ he cried. ‘Here are the
+very letters. But what is this written above them?’
+
+“‘Put the papers on the sundial,’ I read, peeping over his shoulder.
+
+“‘What papers? What sundial?’ he asked.
+
+“‘The sundial in the garden. There is no other,’ said I; ‘but the
+papers must be those that are destroyed.’
+
+“‘Pooh!’ said he, gripping hard at his courage. ‘We are in a civilized
+land here, and we can’t have tomfoolery of this kind. Where does the
+thing come from?’
+
+“‘From Dundee,’ I answered, glancing at the post-mark.
+
+“‘Some preposterous practical joke,’ said he. ‘What have I to do with
+sundials and papers? I shall take no notice of such nonsense.’
+
+“‘I should certainly speak to the police,’ I said.
+
+“‘And be laughed at for my pains. Nothing of the sort.’
+
+“‘Then let me do so?’
+
+“‘No, I forbid you. I won’t have a fuss made about such nonsense.’
+
+“It was in vain to argue with him, for he was a very obstinate man. I
+went about, however, with a heart which was full of forebodings.
+
+“On the third day after the coming of the letter my father went from
+home to visit an old friend of his, Major Freebody, who is in command
+of one of the forts upon Portsdown Hill. I was glad that he should go,
+for it seemed to me that he was farther from danger when he was away
+from home. In that, however, I was in error. Upon the second day of his
+absence I received a telegram from the Major, imploring me to come at
+once. My father had fallen over one of the deep chalk-pits which abound
+in the neighborhood, and was lying senseless, with a shattered skull. I
+hurried to him, but he passed away without having ever recovered his
+consciousness. He had, as it appears, been returning from Fareham in
+the twilight, and as the country was unknown to him, and the chalk-pit
+unfenced, the jury had no hesitation in bringing in a verdict of ‘Death
+from accidental causes.’ Carefully as I examined every fact connected
+with his death, I was unable to find anything which could suggest the
+idea of murder. There were no signs of violence, no footmarks, no
+robbery, no record of strangers having been seen upon the roads. And
+yet I need not tell you that my mind was far from at ease, and that I
+was wellnigh certain that some foul plot had been woven round him.
+
+“In this sinister way I came into my inheritance. You will ask me why
+I did not dispose of it? I answer, because I was well convinced that
+our troubles were in some way dependent upon an incident in my uncle’s
+life, and that the danger would be as pressing in one house as in
+another.
+
+“It was in January, ’85, that my poor father met his end, and two years
+and eight months have elapsed since then. During that time I have lived
+happily at Horsham, and I had begun to hope that this curse had passed
+away from the family, and that it had ended with the last generation. I
+had begun to take comfort too soon, however; yesterday morning the blow
+fell in the very shape in which it had come upon my father.”
+
+The young man took from his waistcoat a crumpled envelope, and, turning
+to the table, he shook out upon it five little dried orange pips.
+
+“This is the envelope,” he continued. “The post-mark is London—eastern
+division. Within are the very words which were upon my father’s last
+message: ‘K. K. K.’; and then ‘Put the papers on the sundial.’”
+
+“What have you done?” asked Holmes.
+
+“Nothing.”
+
+“Nothing?”
+
+“To tell the truth”—he sank his face into his thin, white hands—“I
+have felt helpless. I have felt like one of those poor rabbits when
+the snake is writhing towards it. I seem to be in the grasp of some
+resistless, inexorable evil, which no foresight and no precautions can
+guard against.”
+
+“Tut! tut!” cried Sherlock Holmes. “You must act, man, or you are lost.
+Nothing but energy can save you. This is no time for despair.”
+
+“I have seen the police.”
+
+“Ah!”
+
+“But they listened to my story with a smile. I am convinced that the
+inspector has formed the opinion that the letters are all practical
+jokes, and that the deaths of my relations were really accidents, as
+the jury stated, and were not to be connected with the warnings.”
+
+Holmes shook his clenched hands in the air. “Incredible imbecility!” he
+cried.
+
+“They have, however, allowed me a policeman, who may remain in the
+house with me.”
+
+“Has he come with you to-night?”
+
+“No. His orders were to stay in the house.”
+
+Again Holmes raved in the air.
+
+“Why did you come to me?” he said; “and, above all, why did you not
+come at once?”
+
+“I did not know. It was only to-day that I spoke to Major Prendergast
+about my troubles, and was advised by him to come to you.”
+
+“It is really two days since you had the letter. We should have acted
+before this. You have no further evidence, I suppose, than that which
+you have placed before us—no suggestive detail which might help us?”
+
+“There is one thing,” said John Openshaw. He rummaged in his coat
+pocket, and drawing out a piece of discolored, blue-tinted paper, he
+laid it out upon the table. “I have some remembrance,” said he, “that
+on the day when my uncle burned the papers I observed that the small,
+unburned margins which lay amid the ashes were of this particular
+color. I found this single sheet upon the floor of his room, and I am
+inclined to think that it may be one of the papers which has, perhaps,
+fluttered out from among the others, and in that way have escaped
+destruction. Beyond the mention of pips, I do not see that it helps us
+much. I think myself that it is a page from some private diary. The
+writing is undoubtedly my uncle’s.”
+
+Holmes moved the lamp, and we both bent over the sheet of paper, which
+showed by its ragged edge that it had indeed been torn from a book. It
+was headed, “March, 1869,” and beneath were the following enigmatical
+notices:
+
+“4th. Hudson came. Same old platform.
+
+“7th. Set the pips on McCauley, Paramore, and John Swain, of St.
+Augustine.
+
+“9th. McCauley cleared.
+
+“10th. John Swain cleared.
+
+“12th. Visited Paramore. All well.”
+
+“Thank you!” said Holmes, folding up the paper, and returning it to
+our visitor. “And now you must on no account lose another instant. We
+cannot spare time even to discuss what you have told me. You must get
+home instantly and act.”
+
+“What shall I do?”
+
+“There is but one thing to do. It must be done at once. You must put
+this piece of paper which you have shown us into the brass box which
+you have described. You must also put in a note to say that all the
+other papers were burned by your uncle, and that this is the only
+one which remains. You must assert that in such words as will carry
+conviction with them. Having done this, you must at once put the box
+out upon the sundial, as directed. Do you understand?”
+
+“Entirely.”
+
+“Do not think of revenge, or anything of the sort, at present. I think
+that we may gain that by means of the law; but we have our web to
+weave, while theirs is already woven. The first consideration is to
+remove the pressing danger which threatens you. The second is to clear
+up the mystery and to punish the guilty parties.”
+
+“I thank you,” said the young man, rising, and pulling on his overcoat.
+“You have given me fresh life and hope. I shall certainly do as you
+advise.”
+
+“Do not lose an instant. And, above all, take care of yourself in the
+meanwhile, for I do not think that there can be a doubt that you are
+threatened by a very real and imminent danger. How do you go back?”
+
+“By train from Waterloo.”
+
+“It is not yet nine. The streets will be crowded, so I trust that you
+may be in safety. And yet you cannot guard yourself too closely.”
+
+“I am armed.”
+
+“That is well. To-morrow I shall set to work upon your case.”
+
+“I shall see you at Horsham, then?”
+
+“No, your secret lies in London. It is there that I shall seek it.”
+
+“Then I shall call upon you in a day, or in two days, with news as to
+the box and the papers. I shall take your advice in every particular.”
+He shook hands with us, and took his leave. Outside the wind still
+screamed, and the rain splashed and pattered against the windows.
+This strange, wild story seemed to have come to us from amid the mad
+elements—blown in upon us like a sheet of sea-weed in a gale—and now
+to have been reabsorbed by them once more.
+
+Sherlock Holmes sat for some time in silence, with his head sunk
+forward and his eyes bent upon the red glow of the fire. Then he lit
+his pipe, and leaning back in his chair he watched the blue smoke-rings
+as they chased each other up to the ceiling.
+
+“I think, Watson,” he remarked at last, “that of all our cases we have
+had none more fantastic than this.”
+
+“Save, perhaps, the Sign of Four.”
+
+“Well, yes. Save, perhaps, that. And yet this John Openshaw seems to
+me to be walking amid even greater perils than did the Sholtos.”
+
+“But have you,” I asked, “formed any definite conception as to what
+these perils are?”
+
+“There can be no question as to their nature,” he answered.
+
+“Then what are they? Who is this K. K. K., and why does he pursue this
+unhappy family?”
+
+Sherlock Holmes closed his eyes and placed his elbows upon the arms
+of his chair, with his finger-tips together. “The ideal reasoner,” he
+remarked, “would, when he had once been shown a single fact in all
+its bearings, deduce from it not only all the chain of events which
+led up to it, but also all the results which would follow from it. As
+Cuvier could correctly describe a whole animal by the contemplation of
+a single bone, so the observer who has thoroughly understood one link
+in a series of incidents, should be able to accurately state all the
+other ones, both before and after. We have not yet grasped the results
+which the reason alone can attain to. Problems may be solved in the
+study which have baffled all those who have sought a solution by the
+aid of their senses. To carry the art, however, to its highest pitch,
+it is necessary that the reasoner should be able to utilize all the
+facts which have come to his knowledge; and this in itself implies,
+as you will readily see, a possession of all knowledge, which, even
+in these days of free education and encyclopædias, is a somewhat rare
+accomplishment. It is not so impossible, however, that a man should
+possess all knowledge which is likely to be useful to him in his work,
+and this I have endeavored in my case to do. If I remember rightly, you
+on one occasion, in the early days of our friendship, defined my limits
+in a very precise fashion.”
+
+“Yes,” I answered, laughing. “It was a singular document. Philosophy,
+astronomy, and politics were marked at zero, I remember. Botany
+variable, geology profound as regards the mud-stains from any region
+within fifty miles of town, chemistry eccentric, anatomy unsystematic,
+sensational literature and crime records unique, violin-player, boxer,
+swordsman, lawyer, and self-poisoner by cocaine and tobacco. Those, I
+think, were the main points of my analysis.”
+
+Holmes grinned at the last item. “Well,” he said, “I say now, as I said
+then, that a man should keep his little brain-attic stocked with all
+the furniture that he is likely to use, and the rest he can put away
+in the lumber-room of his library, where he can get it if he wants
+it. Now, for such a case as the one which has been submitted to us
+to-night, we need certainly to muster all our resources. Kindly hand
+me down the letter K of the American Encyclopædia which stands upon
+the shelf beside you. Thank you. Now let us consider the situation,
+and see what may be deduced from it. In the first place, we may start
+with a strong presumption that Colonel Openshaw had some very strong
+reason for leaving America. Men at his time of life do not change all
+their habits, and exchange willingly the charming climate of Florida
+for the lonely life of an English provincial town. His extreme love of
+solitude in England suggests the idea that he was in fear of some one
+or something, so we may assume as a working hypothesis that it was fear
+of some one or something which drove him from America. As to what it
+was he feared, we can only deduce that by considering the formidable
+letters which were received by himself and his successors. Did you
+remark the post-marks of those letters?”
+
+“The first was from Pondicherry, the second from Dundee, and the third
+from London.”
+
+“From East London. What do you deduce from that?”
+
+“They are all seaports. That the writer was on board of a ship.”
+
+“Excellent. We have already a clew. There can be no doubt that the
+probability—the strong probability—is that the writer was on board
+of a ship. And now let us consider another point. In the case of
+Pondicherry, seven weeks elapsed between the threat and its fulfilment,
+in Dundee it was only some three or four days. Does that suggest
+anything?”
+
+“A greater distance to travel.”
+
+“But the letter had also a greater distance to come.”
+
+“Then I do not see the point.”
+
+“There is at least a presumption that the vessel in which the man
+or men are is a sailing-ship. It looks as if they always sent their
+singular warning or token before them when starting upon their mission.
+You see how quickly the deed followed the sign when it came from
+Dundee. If they had come from Pondicherry in a steamer they would
+have arrived almost as soon as their letter. But as a matter of fact
+seven weeks elapsed. I think that those seven weeks represented the
+difference between the mail-boat which brought the letter, and the
+sailing-vessel which brought the writer.”
+
+“It is possible.”
+
+“More than that. It is probable. And now you see the deadly urgency of
+this new case, and why I urged young Openshaw to caution. The blow has
+always fallen at the end of the time which it would take the senders to
+travel the distance. But this one comes from London, and therefore we
+cannot count upon delay.”
+
+“Good God!” I cried; “what can it mean, this relentless persecution?”
+
+“The papers which Openshaw carried are obviously of vital importance
+to the person or persons in the sailing-ship. I think that it is quite
+clear that there must be more than one of them. A single man could not
+have carried out two deaths in such a way as to deceive a coroner’s
+jury. There must have been several in it, and they must have been men
+of resource and determination. Their papers they mean to have, be the
+holder of them who it may. In this way you see K. K. K. ceases to be
+the initials of an individual, and becomes the badge of a society.”
+
+“But of what society?”
+
+“Have you never—” said Sherlock Holmes, bending forward and sinking
+his voice—“have you never heard of the Ku Klux Klan?”
+
+“I never have.”
+
+Holmes turned over the leaves of the book upon his knee. “Here it
+is,” said he, presently, “‘Ku Klux Klan. A name derived from the
+fanciful resemblance to the sound produced by cocking a rifle. This
+terrible secret society was formed by some ex-Confederate soldiers in
+the Southern States after the Civil War, and it rapidly formed local
+branches in different parts of the country, notably in Tennessee,
+Louisiana, the Carolinas, Georgia, and Florida. Its power was used
+for political purposes, principally for the terrorizing of the negro
+voters, and the murdering and driving from the country of those who
+were opposed to its views. Its outrages were usually preceded by
+a warning sent to the marked man in some fantastic but generally
+recognized shape—a sprig of oak-leaves in some parts, melon seeds or
+orange pips in others. On receiving this the victim might either openly
+abjure his former ways, or might fly from the country. If he braved the
+matter out, death would unfailingly come upon him, and usually in some
+strange and unforeseen manner. So perfect was the organization of the
+society, and so systematic its methods, that there is hardly a case
+upon record where any man succeeded in braving it with impunity, or in
+which any of its outrages were traced home to the perpetrators. For
+some years the organization flourished, in spite of the efforts of the
+United States Government and of the better classes of the community in
+the South. Eventually, in the year 1869, the movement rather suddenly
+collapsed, although there have been sporadic outbreaks of the same sort
+since that date.’
+
+“You will observe,” said Holmes, laying down the volume, “that the
+sudden breaking up of the society was coincident with the disappearance
+of Openshaw from America with their papers. It may well have been cause
+and effect. It is no wonder that he and his family have some of the
+more implacable spirits upon their track. You can understand that this
+register and diary may implicate some of the first men in the South,
+and that there may be many who will not sleep easy at night until it is
+recovered.”
+
+“Then the page we have seen—”
+
+“Is such as we might expect. It ran, if I remember right, ‘sent the
+pips to A, B, and C,’—that is, sent the society’s warning to them.
+Then there are successive entries that A and B cleared, or left the
+country, and finally that C was visited, with, I fear, a sinister
+result for C. Well, I think, Doctor, that we may let some light into
+this dark place, and I believe that the only chance young Openshaw has
+in the mean time is to do what I have told him. There is nothing more
+to be said or to be done to-night, so hand me over my violin, and let
+us try to forget for half an hour the miserable weather and the still
+more miserable ways of our fellow-men.”
+
+       *       *       *       *       *
+
+It had cleared in the morning, and the sun was shining with a subdued
+brightness through the dim veil which hangs over the great city.
+Sherlock Holmes was already at breakfast when I came down.
+
+“You will excuse me for not waiting for you,” said he; “I have, I
+foresee, a very busy day before me in looking into this case of young
+Openshaw’s.”
+
+“What steps will you take?” I asked.
+
+“It will very much depend upon the results of my first inquiries. I may
+have to go down to Horsham, after all.”
+
+“You will not go there first?”
+
+“No, I shall commence with the city. Just ring the bell, and the maid
+will bring up your coffee.”
+
+As I waited, I lifted the unopened newspaper from the table and glanced
+my eye over it. It rested upon a heading which sent a chill to my heart.
+
+“Holmes,” I cried, “you are too late.”
+
+“Ah!” said he, laying down his cup, “I feared as much. How was it
+done?” He spoke calmly, but I could see that he was deeply moved.
+
+“My eye caught the name of Openshaw, and the heading, ‘Tragedy near
+Waterloo Bridge.’ Here is the account: ‘Between nine and ten last
+night Police-constable Cook, of the H Division, on duty near Waterloo
+Bridge, heard a cry for help and a splash in the water. The night,
+however, was extremely dark and stormy, so that, in spite of the help
+of several passers-by, it was quite impossible to effect a rescue.
+The alarm, however, was given, and, by the aid of the water-police,
+the body was eventually recovered. It proved to be that of a young
+gentleman whose name, as it appears from an envelope which was found in
+his pocket, was John Openshaw, and whose residence is near Horsham. It
+is conjectured that he may have been hurrying down to catch the last
+train from Waterloo Station, and that in his haste and the extreme
+darkness he missed his path and walked over the edge of one of the
+small landing-places for river steamboats. The body exhibited no traces
+of violence, and there can be no doubt that the deceased had been
+the victim of an unfortunate accident, which should have the effect
+of calling the attention of the authorities to the condition of the
+river-side landing-stages.’”
+
+We sat in silence for some minutes, Holmes more depressed and shaken
+than I had ever seen him.
+
+“That hurts my pride, Watson,” he said, at last. “It is a petty
+feeling, no doubt, but it hurts my pride. It becomes a personal matter
+with me now, and, if God sends me health, I shall set my hand upon this
+gang. That he should come to me for help, and that I should send him
+away to his death—!” He sprang from his chair and paced about the room
+in uncontrollable agitation, with a flush upon his sallow cheeks, and a
+nervous clasping and unclasping of his long, thin hands.
+
+“They must be cunning devils,” he exclaimed, at last. “How could they
+have decoyed him down there? The Embankment is not on the direct line
+to the station. The bridge, no doubt, was too crowded, even on such a
+night, for their purpose. Well, Watson, we shall see who will win in
+the long run. I am going out now!”
+
+[Illustration: “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”]
+
+“To the police?”
+
+“No; I shall be my own police. When I have spun the web they may take
+the flies, but not before.”
+
+All day I was engaged in my professional work, and it was late in the
+evening before I returned to Baker Street. Sherlock Holmes had not come
+back yet. It was nearly ten o’clock before he entered, looking pale
+and worn. He walked up to the sideboard, and, tearing a piece from the
+loaf, he devoured it voraciously, washing it down with a long draught
+of water.
+
+“You are hungry,” I remarked.
+
+“Starving. It had escaped my memory. I have had nothing since
+breakfast.”
+
+“Nothing?”
+
+“Not a bite. I had no time to think of it.”
+
+“And how have you succeeded?”
+
+“Well.”
+
+“You have a clew?”
+
+“I have them in the hollow of my hand. Young Openshaw shall not long
+remain unavenged. Why, Watson, let us put their own devilish trade-mark
+upon them. It is well thought of!”
+
+“What do you mean?”
+
+He took an orange from the cupboard, and, tearing it to pieces, he
+squeezed out the pips upon the table. Of these he took five, and thrust
+them into an envelope. On the inside of the flap he wrote “S. H. for J.
+O.” Then he sealed it and addressed it to “Captain James Calhoun, Bark
+_Lone Star_, Savannah, Georgia.”
+
+“That will await him when he enters port,” said he, chuckling. “It may
+give him a sleepless night. He will find it as sure a precursor of his
+fate as Openshaw did before him.”
+
+“And who is this Captain Calhoun?”
+
+“The leader of the gang. I shall have the others, but he first.”
+
+“How did you trace it, then?”
+
+He took a large sheet of paper from his pocket, all covered with dates
+and names.
+
+“I have spent the whole day,” said he, “over Lloyd’s registers and the
+files of the old papers, following the future career of every vessel
+which touched at Pondicherry in January and February in ’83. There
+were thirty-six ships of fair tonnage which were reported there during
+those months. Of these, one, the _Lone Star_, instantly attracted my
+attention, since, although it was reported as having cleared from
+London, the name is that which is given to one of the States of the
+Union.”
+
+“Texas, I think.”
+
+“I was not and am not sure which; but I knew that the ship must have an
+American origin.”
+
+“What then?”
+
+“I searched the Dundee records, and when I found that the bark _Lone
+Star_ was there in January, ’85, my suspicion became a certainty. I
+then inquired as to the vessels which lay at present in the port of
+London.”
+
+“Yes?”
+
+“The _Lone Star_ had arrived here last week. I went down to the Albert
+Dock, and found that she had been taken down the river by the early
+tide this morning, homeward bound to Savannah. I wired to Gravesend,
+and learned that she had passed some time ago; and as the wind is
+easterly, I have no doubt that she is now past the Goodwins, and not
+very far from the Isle of Wight.”
+
+“What will you do, then?”
+
+“Oh, I have my hand upon him. He and the two mates, are, as I learn,
+the only native-born Americans in the ship. The others are Finns and
+Germans. I know, also, that they were all three away from the ship last
+night. I had it from the stevedore who has been loading their cargo. By
+the time that their sailing-ship reaches Savannah the mail-boat will
+have carried this letter, and the cable will have informed the police
+of Savannah that these three gentlemen are badly wanted here upon a
+charge of murder.”
+
+There is ever a flaw, however, in the best laid of human plans, and
+the murderers of John Openshaw were never to receive the orange pips
+which would show them that another, as cunning and as resolute as
+themselves, was upon their track. Very long and very severe were the
+equinoctial gales that year. We waited long for news of the _Lone
+Star_ of Savannah, but none ever reached us. We did at last hear that
+somewhere far out in the Atlantic a shattered stern-post of a boat was
+seen swinging in the trough of a wave, with the letters “L. S.” carved
+upon it, and that is all which we shall ever know of the fate of the
+_Lone Star_.
+
+
+
+
+Adventure VI
+
+THE MAN WITH THE TWISTED LIP
+
+
+Isa Whitney, brother of the late Elias Whitney, D.D., Principal of the
+Theological College of St. George’s, was much addicted to opium. The
+habit grew upon him, as I understand, from some foolish freak when he
+was at college; for having read De Quincey’s description of his dreams
+and sensations, he had drenched his tobacco with laudanum in an attempt
+to produce the same effects. He found, as so many more have done, that
+the practice is easier to attain than to get rid of, and for many years
+he continued to be a slave to the drug, an object of mingled horror
+and pity to his friends and relatives. I can see him now, with yellow,
+pasty face, drooping lids, and pin-point pupils, all huddled in a
+chair, the wreck and ruin of a noble man.
+
+One night—it was in June, ’89—there came a ring to my bell, about the
+hour when a man gives his first yawn and glances at the clock. I sat up
+in my chair, and my wife laid her needle-work down in her lap and made
+a little face of disappointment.
+
+“A patient!” said she. “You’ll have to go out.”
+
+I groaned, for I was newly come back from a weary day.
+
+We heard the door open, a few hurried words, and then quick steps
+upon the linoleum. Our own door flew open, and a lady, clad in some
+dark-colored stuff, with a black veil, entered the room.
+
+“You will excuse my calling so late,” she began, and then, suddenly
+losing her self-control, she ran forward, threw her arms about my
+wife’s neck, and sobbed upon her shoulder. “Oh, I’m in such trouble!”
+she cried; “I do so want a little help.”
+
+“Why,” said my wife, pulling up her veil, “it is Kate Whitney. How you
+startled me, Kate! I had not an idea who you were when you came in.”
+
+“I didn’t know what to do, so I came straight to you.” That was always
+the way. Folk who were in grief came to my wife like birds to a
+light-house.
+
+“It was very sweet of you to come. Now, you must have some wine and
+water, and sit here comfortably and tell us all about it. Or should you
+rather that I sent James off to bed?”
+
+“Oh, no, no! I want the Doctor’s advice and help, too. It’s about Isa.
+He has not been home for two days. I am so frightened about him!”
+
+It was not the first time that she had spoken to us of her husband’s
+trouble, to me as a doctor, to my wife as an old friend and school
+companion. We soothed and comforted her by such words as we could find.
+Did she know where her husband was? Was it possible that we could bring
+him back to her?
+
+It seemed that it was. She had the surest information that of late he
+had, when the fit was on him, made use of an opium den in the farthest
+east of the city. Hitherto his orgies had always been confined to one
+day, and he had come back, twitching and shattered, in the evening.
+But now the spell had been upon him eight-and-forty hours, and he lay
+there, doubtless among the dregs of the docks, breathing in the poison
+or sleeping off the effects. There he was to be found, she was sure of
+it, at the “Bar of Gold,” in Upper Swandam Lane. But what was she to
+do? How could she, a young and timid woman, make her way into such a
+place, and pluck her husband out from among the ruffians who surrounded
+him?
+
+There was the case, and of course there was but one way out of it.
+Might I not escort her to this place? And then, as a second thought,
+why should she come at all? I was Isa Whitney’s medical adviser, and
+as such I had influence over him. I could manage it better if I were
+alone. I promised her on my word that I would send him home in a
+cab within two hours if he were indeed at the address which she had
+given me. And so in ten minutes I had left my arm-chair and cheery
+sitting-room behind me, and was speeding eastward in a hansom on a
+strange errand, as it seemed to me at the time, though the future only
+could show how strange it was to be.
+
+But there was no great difficulty in the first stage of my adventure.
+Upper Swandam Lane is a vile alley lurking behind the high wharves
+which line the north side of the river to the east of London Bridge.
+Between a slop-shop and a gin-shop, approached by a steep flight of
+steps leading down to a black gap like the mouth of a cave, I found the
+den of which I was in search. Ordering my cab to wait, I passed down
+the steps, worn hollow in the centre by the ceaseless tread of drunken
+feet, and by the light of a flickering oil-lamp above the door I found
+the latch, and made my way into a long, low room, thick and heavy
+with the brown opium smoke, and terraced with wooden berths, like the
+forecastle of an emigrant ship.
+
+Through the gloom one could dimly catch a glimpse of bodies lying in
+strange fantastic poses, bowed shoulders, bent knees, heads thrown back
+and chins pointing upward, with here and there a dark, lack-lustre eye
+turned upon the new-comer. Out of the black shadows there glimmered
+little red circles of light, now bright, now faint, as the burning
+poison waxed or waned in the bowls of the metal pipes. The most lay
+silent, but some muttered to themselves, and others talked together in
+a strange, low, monotonous voice, their conversation coming in gushes,
+and then suddenly tailing off into silence, each mumbling out his own
+thoughts, and paying little heed to the words of his neighbor. At the
+farther end was a small brazier of burning charcoal, beside which on a
+three-legged wooden stool there sat a tall, thin old man, with his jaw
+resting upon his two fists, and his elbows upon his knees, staring into
+the fire.
+
+As I entered, a sallow Malay attendant had hurried up with a pipe for
+me and a supply of the drug, beckoning me to an empty berth.
+
+“Thank you. I have not come to stay,” said I. “There is a friend of
+mine here, Mr. Isa Whitney, and I wish to speak with him.”
+
+There was a movement and an exclamation from my right, and, peering
+through the gloom, I saw Whitney, pale, haggard, and unkempt, staring
+out at me.
+
+“My God! It’s Watson,” said he. He was in a pitiable state of reaction,
+with every nerve in a twitter. “I say, Watson, what o’clock is it?”
+
+“Nearly eleven.”
+
+“Of what day?”
+
+“Of Friday, June 19th.”
+
+“Good heavens! I thought it was Wednesday. It is Wednesday. What d’you
+want to frighten a chap for?” He sank his face onto his arms, and began
+to sob in a high treble key.
+
+“I tell you that it is Friday, man. Your wife has been waiting this two
+days for you. You should be ashamed of yourself!”
+
+“So I am. But you’ve got mixed, Watson, for I have only been here a few
+hours, three pipes, four pipes—I forget how many. But I’ll go home
+with you. I wouldn’t frighten Kate—poor little Kate. Give me your
+hand! Have you a cab?”
+
+“Yes, I have one waiting.”
+
+“Then I shall go in it. But I must owe something. Find what I owe,
+Watson. I am all off color. I can do nothing for myself.”
+
+I walked down the narrow passage between the double row of sleepers,
+holding my breath to keep out the vile, stupefying fumes of the drug,
+and looking about for the manager. As I passed the tall man who sat
+by the brazier I felt a sudden pluck at my skirt, and a low voice
+whispered, “Walk past me, and then look back at me.” The words fell
+quite distinctly upon my ear. I glanced down. They could only have come
+from the old man at my side, and yet he sat now as absorbed as ever,
+very thin, very wrinkled, bent with age, an opium pipe dangling down
+from between his knees, as though it had dropped in sheer lassitude
+from his fingers. I took two steps forward and looked back. It took
+all my self-control to prevent me from breaking out into a cry of
+astonishment. He had turned his back so that none could see him but
+I. His form had filled out, his wrinkles were gone, the dull eyes had
+regained their fire, and there, sitting by the fire, and grinning at
+my surprise, was none other than Sherlock Holmes. He made a slight
+motion to me to approach him, and instantly, as he turned his face half
+round to the company once more, subsided into a doddering, loose-lipped
+senility.
+
+“Holmes!” I whispered, “what on earth are you doing in this den?”
+
+“As low as you can,” he answered; “I have excellent ears. If you would
+have the great kindness to get rid of that sottish friend of yours I
+should be exceedingly glad to have a little talk with you.”
+
+“I have a cab outside.”
+
+“Then pray send him home in it. You may safely trust him, for he
+appears to be too limp to get into any mischief. I should recommend you
+also to send a note by the cabman to your wife to say that you have
+thrown in your lot with me. If you will wait outside, I shall be with
+you in five minutes.”
+
+It was difficult to refuse any of Sherlock Holmes’s requests, for they
+were always so exceedingly definite, and put forward with such a quiet
+air of mastery. I felt, however, that when Whitney was once confined
+in the cab my mission was practically accomplished, and for the rest,
+I could not wish anything better than to be associated with my friend
+in one of those singular adventures which were the normal condition of
+his existence. In a few minutes I had written my note, paid Whitney’s
+bill, led him out to the cab, and seen him driven through the darkness.
+In a very short time a decrepit figure had emerged from the opium
+den, and I was walking down the street with Sherlock Holmes. For two
+streets he shuffled along with a bent back and an uncertain foot. Then,
+glancing quickly round, he straightened himself out and burst into a
+hearty fit of laughter.
+
+“I suppose, Watson,” said he, “that you imagine that I have added
+opium-smoking to cocaine injections, and all the other little
+weaknesses on which you have favored me with your medical views.”
+
+“I was certainly surprised to find you there.”
+
+“But not more so than I to find you.”
+
+“I came to find a friend.”
+
+“And I to find an enemy.”
+
+“An enemy?”
+
+“Yes; one of my natural enemies, or, shall I say, my natural prey.
+Briefly, Watson, I am in the midst of a very remarkable inquiry, and
+I have hoped to find a clew in the incoherent ramblings of these
+sots, as I have done before now. Had I been recognized in that den my
+life would not have been worth an hour’s purchase; for I have used it
+before now for my own purposes, and the rascally Lascar who runs it has
+sworn to have vengeance upon me. There is a trap-door at the back of
+that building, near the corner of Paul’s Wharf, which could tell some
+strange tales of what has passed through it upon the moonless nights.”
+
+“What! You do not mean bodies?”
+
+“Aye, bodies, Watson. We should be rich men if we had £1000 for every
+poor devil who has been done to death in that den. It is the vilest
+murder-trap on the whole river-side, and I fear that Neville St. Clair
+has entered it never to leave it more. But our trap should be here.”
+He put his two forefingers between his teeth and whistled shrilly—a
+signal which was answered by a similar whistle from the distance,
+followed shortly by the rattle of wheels and the clink of horses’
+hoofs.
+
+“Now, Watson,” said Holmes, as a tall dog-cart dashed up through the
+gloom, throwing out two golden tunnels of yellow light from its side
+lanterns. “You’ll come with me, won’t you?”
+
+“If I can be of use.”
+
+“Oh, a trusty comrade is always of use; and a chronicler still more so.
+My room at ‘The Cedars’ is a double-bedded one.”
+
+“‘The Cedars?’”
+
+“Yes; that is Mr. St. Clair’s house. I am staying there while I conduct
+the inquiry.”
+
+“Where is it, then?”
+
+“Near Lee, in Kent. We have a seven-mile drive before us.”
+
+“But I am all in the dark.”
+
+“Of course you are. You’ll know all about it presently. Jump up here.
+All right, John; we shall not need you. Here’s half a crown. Look out
+for me to-morrow, about eleven. Give her her head. So long, then!”
+
+He flicked the horse with his whip, and we dashed away through the
+endless succession of sombre and deserted streets, which widened
+gradually, until we were flying across a broad balustraded bridge, with
+the murky river flowing sluggishly beneath us. Beyond lay another dull
+wilderness of bricks and mortar, its silence broken only by the heavy,
+regular footfall of the policeman, or the songs and shouts of some
+belated party of revellers. A dull wrack was drifting slowly across the
+sky, and a star or two twinkled dimly here and there through the rifts
+of the clouds. Holmes drove in silence, with his head sunk upon his
+breast, and the air of a man who is lost in thought, while I sat beside
+him, curious to learn what this new quest might be which seemed to tax
+his powers so sorely, and yet afraid to break in upon the current of
+his thoughts. We had driven several miles, and were beginning to get
+to the fringe of the belt of suburban villas, when he shook himself,
+shrugged his shoulders, and lit up his pipe with the air of a man who
+has satisfied himself that he is acting for the best.
+
+“You have a grand gift of silence, Watson,” said he. “It makes you
+quite invaluable as a companion. ’Pon my word, it is a great thing
+for me to have some one to talk to, for my own thoughts are not over
+pleasant. I was wondering what I should say to this dear little woman
+to-night when she meets me at the door.”
+
+“You forget that I know nothing about it.”
+
+“I shall just have time to tell you the facts of the case before we get
+to Lee. It seems absurdly simple, and yet, somehow, I can get nothing
+to go upon. There’s plenty of thread, no doubt, but I can’t get the end
+of it into my hand. Now, I’ll state the case clearly and concisely to
+you, Watson, and maybe you can see a spark where all is dark to me.”
+
+“Proceed, then.”
+
+“Some years ago—to be definite, in May, 1884—there came to Lee a
+gentleman, Neville St. Clair by name, who appeared to have plenty
+of money. He took a large villa, laid out the grounds very nicely,
+and lived generally in good style. By degrees he made friends in the
+neighborhood, and in 1887 he married the daughter of a local brewer, by
+whom he now has two children. He had no occupation, but was interested
+in several companies, and went into town as a rule in the morning,
+returning by the 5.14 from Cannon Street every night. Mr. St. Clair is
+now thirty-seven years of age, is a man of temperate habits, a good
+husband, a very affectionate father, and a man who is popular with all
+who know him. I may add that his whole debts at the present moment,
+as far as we have been able to ascertain, amount to £88 10_s._, while
+he has £220 standing to his credit in the Capital and Counties Bank.
+There is no reason, therefore, to think that money troubles have been
+weighing upon his mind.
+
+“Last Monday Mr. Neville St. Clair went into town rather earlier
+than usual, remarking before he started that he had two important
+commissions to perform, and that he would bring his little boy home a
+box of bricks. Now, by the merest chance, his wife received a telegram
+upon this same Monday, very shortly after his departure, to the effect
+that a small parcel of considerable value which she had been expecting
+was waiting for her at the offices of the Aberdeen Shipping Company.
+Now, if you are well up in your London, you will know that the offices
+of the company is in Fresno Street, which branches out of Upper Swandam
+Lane, where you found me to-night. Mrs. St. Clair had her lunch,
+started for the city, did some shopping, proceeded to the company’s
+office, got her packet, and found herself at exactly 4.35 walking
+through Swandam Lane on her way back to the station. Have you followed
+me so far?”
+
+“It is very clear.”
+
+“If you remember, Monday was an exceedingly hot day, and Mrs. St.
+Clair walked slowly, glancing about in the hope of seeing a cab, as
+she did not like the neighborhood in which she found herself. While
+she was walking in this way down Swandam Lane, she suddenly heard an
+ejaculation or cry, and was struck cold to see her husband looking down
+at her, and, as it seemed to her, beckoning to her from a second-floor
+window. The window was open, and she distinctly saw his face, which she
+describes as being terribly agitated. He waved his hands frantically
+to her, and then vanished from the window so suddenly that it seemed
+to her that he had been plucked back by some irresistible force from
+behind. One singular point which struck her quick feminine eye was
+that, although he wore some dark coat, such as he had started to town
+in, he had on neither collar nor necktie.
+
+[Illustration: “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+SCOUNDREL.”]
+
+“Convinced that something was amiss with him, she rushed down the
+steps—for the house was none other than the opium den in which you
+found me to-night—and, running through the front room, she attempted
+to ascend the stairs which led to the first floor. At the foot of the
+stairs, however, she met this Lascar scoundrel of whom I have spoken,
+who thrust her back, and, aided by a Dane, who acts as assistant there,
+pushed her out into the street. Filled with the most maddening doubts
+and fears, she rushed down the lane, and, by rare good-fortune, met, in
+Fresno Street, a number of constables with an inspector, all on their
+way to their beat. The inspector and two men accompanied her back, and,
+in spite of the continued resistance of the proprietor, they made their
+way to the room in which Mr. St. Clair had last been seen. There was no
+sign of him there. In fact, in the whole of that floor there was no one
+to be found, save a crippled wretch of hideous aspect, who, it seems,
+made his home there. Both he and the Lascar stoutly swore that no one
+else had been in the front room during the afternoon. So determined
+was their denial that the inspector was staggered, and had almost come
+to believe that Mrs. St. Clair had been deluded, when, with a cry, she
+sprang at a small deal box which lay upon the table, and tore the lid
+from it. Out there fell a cascade of children’s bricks. It was the toy
+which he had promised to bring home.
+
+“This discovery, and the evident confusion which the cripple showed,
+made the inspector realize that the matter was serious. The rooms were
+carefully examined, and results all pointed to an abominable crime.
+The front room was plainly furnished as a sitting-room, and led into a
+small bedroom, which looked out upon the back of one of the wharves.
+Between the wharf and the bedroom window is a narrow strip, which is
+dry at low tide, but is covered at high tide with at least four and
+a half feet of water. The bedroom window was a broad one, and opened
+from below. On examination traces of blood were to be seen upon the
+window-sill, and several scattered drops were visible upon the wooden
+floor of the bedroom. Thrust away behind a curtain in the front room
+were all the clothes of Mr. Neville St. Clair, with the exception of
+his coat. His boots, his socks, his hat, and his watch—all were there.
+There were no signs of violence upon any of these garments, and there
+were no other traces of Mr. Neville St. Clair. Out of the window he
+must apparently have gone, for no other exit could be discovered, and
+the ominous blood-stains upon the sill gave little promise that he
+could save himself by swimming, for the tide was at its very highest at
+the moment of the tragedy.
+
+“And now as to the villains who seemed to be immediately implicated in
+the matter. The Lascar was known to be a man of the vilest antecedents,
+but as, by Mrs. St. Clair’s story, he was known to have been at the
+foot of the stair within a very few seconds of her husband’s appearance
+at the window, he could hardly have been more than an accessory to the
+crime. His defense was one of absolute ignorance, and he protested that
+he had no knowledge as to the doings of Hugh Boone, his lodger, and
+that he could not account in any way for the presence of the missing
+gentleman’s clothes.
+
+“So much for the Lascar manager. Now for the sinister cripple who lives
+upon the second floor of the opium den, and who was certainly the
+last human being whose eyes rested upon Neville St. Clair. His name
+is Hugh Boone, and his hideous face is one which is familiar to every
+man who goes much to the city. He is a professional beggar, though,
+in order to avoid the police regulations, he pretends to a small
+trade in wax vestas. Some little distance down Threadneedle Street,
+upon the left-hand side, there is, as you may have remarked, a small
+angle in the wall. Here it is that this creature takes his daily seat,
+cross-legged, with his tiny stock of matches on his lap, and, as he is
+a piteous spectacle, a small rain of charity descends into the greasy
+leather cap which lies upon the pavement beside him. I have watched the
+fellow more than once, before ever I thought of making his professional
+acquaintance, and I have been surprised at the harvest which he has
+reaped in a short time. His appearance, you see, is so remarkable that
+no one can pass him without observing him. A shock of orange hair, a
+pale face disfigured by a horrible scar, which, by its contraction,
+has turned up the outer edge of his upper lip, a bull-dog chin, and a
+pair of very penetrating dark eyes, which present a singular contrast
+to the color of his hair, all mark him out from amid the common
+crowd of mendicants, and so, too, does his wit, for he is ever ready
+with a reply to any piece of chaff which may be thrown at him by the
+passers-by. This is the man whom we now learn to have been the lodger
+at the opium den, and to have been the last man to see the gentleman of
+whom we are in quest.”
+
+“But a cripple!” said I. “What could he have done single-handed against
+a man in the prime of life?”
+
+“He is a cripple in the sense that he walks with a limp; but in other
+respects he appears to be a powerful and well-nurtured man. Surely your
+medical experience would tell you, Watson, that weakness in one limb is
+often compensated for by exceptional strength in the others.”
+
+“Pray continue your narrative.”
+
+“Mrs. St. Clair had fainted at the sight of the blood upon the window,
+and she was escorted home in a cab by the police, as her presence
+could be of no help to them in their investigations. Inspector Barton,
+who had charge of the case, made a very careful examination of the
+premises, but without finding anything which threw any light upon the
+matter. One mistake had been made in not arresting Boone instantly, as
+he was allowed some few minutes during which he might have communicated
+with his friend the Lascar, but this fault was soon remedied, and he
+was seized and searched, without anything being found which could
+incriminate him. There were, it is true, some blood-stains upon his
+right shirt-sleeve, but he pointed to his ring-finger, which had been
+cut near the nail, and explained that the bleeding came from there,
+adding that he had been to the window not long before, and that the
+stains which had been observed there came doubtless from the same
+source. He denied strenuously having ever seen Mr. Neville St. Clair,
+and swore that the presence of the clothes in his room was as much
+a mystery to him as to the police. As to Mrs. St. Clair’s assertion
+that she had actually seen her husband at the window, he declared that
+she must have been either mad or dreaming. He was removed, loudly
+protesting, to the police-station, while the inspector remained upon
+the premises in the hope that the ebbing tide might afford some fresh
+clew.
+
+“And it did, though they hardly found upon the mud-bank what they had
+feared to find. It was Neville St. Clair’s coat, and not Neville St.
+Clair, which lay uncovered as the tide receded. And what do you think
+they found in the pockets?”
+
+“I cannot imagine.”
+
+“No, I don’t think you would guess. Every pocket stuffed with pennies
+and half-pennies—421 pennies and 270 half-pennies. It was no wonder
+that it had not been swept away by the tide. But a human body is a
+different matter. There is a fierce eddy between the wharf and the
+house. It seemed likely enough that the weighted coat had remained when
+the stripped body had been sucked away into the river.”
+
+“But I understand that all the other clothes were found in the room.
+Would the body be dressed in a coat alone?”
+
+“No, sir, but the facts might be met speciously enough. Suppose that
+this man Boone had thrust Neville St. Clair through the window, there
+is no human eye which could have seen the deed. What would he do then?
+It would of course instantly strike him that he must get rid of the
+tell-tale garments. He would seize the coat, then, and be in the act of
+throwing it out, when it would occur to him that it would swim and not
+sink. He has little time, for he has heard the scuffle down-stairs when
+the wife tried to force her way up, and perhaps he has already heard
+from his Lascar confederate that the police are hurrying up the street.
+There is not an instant to be lost. He rushes to some secret horde,
+where he has accumulated the fruits of his beggary, and he stuffs all
+the coins upon which he can lay his hands into the pockets to make sure
+of the coat’s sinking. He throws it out, and would have done the same
+with the other garments had not he heard the rush of steps below, and
+only just had time to close the window when the police appeared.”
+
+“It certainly sounds feasible.”
+
+“Well, we will take it as a working hypothesis for want of a better.
+Boone, as I have told you, was arrested and taken to the station, but
+it could not be shown that there had ever before been anything against
+him. He had for years been known as a professional beggar, but his life
+appeared to have been a very quiet and innocent one. There the matter
+stands at present, and the questions which have to be solved—what
+Neville St. Clair was doing in the opium den, what happened to him
+when there, where is he now, and what Hugh Boone had to do with his
+disappearance—are all as far from a solution as ever. I confess that I
+cannot recall any case within my experience which looked at the first
+glance so simple, and yet which presented such difficulties.”
+
+While Sherlock Holmes had been detailing this singular series of
+events, we had been whirling through the outskirts of the great town
+until the last straggling houses had been left behind, and we rattled
+along with a country hedge upon either side of us. Just as he finished,
+however, we drove through two scattered villages, where a few lights
+still glimmered in the windows.
+
+“We are on the outskirts of Lee,” said my companion. “We have touched
+on three English counties in our short drive, starting in Middlesex,
+passing over an angle of Surrey, and ending in Kent. See that light
+among the trees? That is ‘The Cedars,’ and beside that lamp sits a
+woman whose anxious ears have already, I have little doubt, caught the
+clink of our horse’s feet.”
+
+“But why are you not conducting the case from Baker Street?” I asked.
+
+“Because there are many inquiries which must be made out here. Mrs.
+St. Clair has most kindly put two rooms at my disposal, and you may
+rest assured that she will have nothing but a welcome for my friend
+and colleague. I hate to meet her, Watson, when I have no news of her
+husband. Here we are. Whoa, there, whoa!”
+
+We had pulled up in front of a large villa which stood within its own
+grounds. A stable-boy had run out to the horse’s head, and, springing
+down, I followed Holmes up the small, winding gravel-drive which led to
+the house. As we approached, the door flew open, and a little blonde
+woman stood in the opening, clad in some sort of light mousseline de
+soie, with a touch of fluffy pink chiffon at her neck and wrists. She
+stood with her figure outlined against the flood of light, one hand
+upon the door, one half-raised in her eagerness, her body slightly
+bent, her head and face protruded, with eager eyes and parted lips, a
+standing question.
+
+“Well?” she cried, “well?” And then, seeing that there were two of
+us, she gave a cry of hope which sank into a groan as she saw that my
+companion shook his head and shrugged his shoulders.
+
+“No good news?”
+
+“None.”
+
+“No bad?”
+
+“No.”
+
+“Thank God for that. But come in. You must be weary, for you have had a
+long day.”
+
+“This is my friend, Dr. Watson. He has been of most vital use to me in
+several of my cases, and a lucky chance has made it possible for me to
+bring him out and associate him with this investigation.”
+
+“I am delighted to see you,” said she, pressing my hand warmly.
+“You will, I am sure, forgive anything that may be wanting in our
+arrangements, when you consider the blow which has come so suddenly
+upon us.”
+
+“My dear madam,” said I, “I am an old campaigner, and if I were not,
+I can very well see that no apology is needed. If I can be of any
+assistance, either to you or to my friend here, I shall be indeed
+happy.”
+
+“Now, Mr. Sherlock Holmes,” said the lady, as we entered a well-lit
+dining-room, upon the table of which a cold supper had been laid out,
+“I should very much like to ask you one or two plain questions, to
+which I beg that you will give a plain answer.”
+
+“Certainly, madam.”
+
+“Do not trouble about my feelings. I am not hysterical, nor given to
+fainting. I simply wish to hear your real, real opinion.”
+
+“Upon what point?”
+
+“In your heart of hearts do you think that Neville is alive?”
+
+Sherlock Holmes seemed to be embarrassed by the question. “Frankly,
+now!” she repeated, standing upon the rug and looking keenly down at
+him as he leaned back in a basket-chair.
+
+“Frankly, then, madam, I do not.”
+
+“You think that he is dead?”
+
+“I do.”
+
+“Murdered?”
+
+“I don’t say that. Perhaps.”
+
+“And on what day did he meet his death?”
+
+“On Monday.”
+
+“Then perhaps, Mr. Holmes, you will be good enough to explain how it is
+that I have received a letter from him to-day.”
+
+Sherlock Holmes sprang out of his chair as if he had been galvanized.
+
+“What!” he roared.
+
+“Yes, to-day.” She stood smiling, holding up a little slip of paper in
+the air.
+
+“May I see it?”
+
+“Certainly.”
+
+He snatched it from her in his eagerness, and smoothing it out upon
+the table, he drew over the lamp, and examined it intently. I had left
+my chair, and was gazing at it over his shoulder. The envelope was a
+very coarse one, and was stamped with the Gravesend post-mark, and with
+the date of that very day, or rather of the day before, for it was
+considerably after midnight.
+
+“Coarse writing,” murmured Holmes. “Surely this is not your husband’s
+writing, madam.”
+
+“No, but the enclosure is.”
+
+“I perceive also that whoever addressed the envelope had to go and
+inquire as to the address.”
+
+“How can you tell that?”
+
+“The name, you see, is in perfectly black ink, which has dried itself.
+The rest is of the grayish color, which shows that blotting-paper has
+been used. If it had been written straight off, and then blotted, none
+would be of a deep black shade. This man has written the name, and
+there has then been a pause before he wrote the address, which can only
+mean that he was not familiar with it. It is, of course, a trifle, but
+there is nothing so important as trifles. Let us now see the letter.
+Ha! there has been an enclosure here!”
+
+“Yes, there was a ring. His signet-ring.”
+
+“And you are sure that this is your husband’s hand?”
+
+“One of his hands.”
+
+“One?”
+
+“His hand when he wrote hurriedly. It is very unlike his usual writing,
+and yet I know it well.”
+
+“‘Dearest do not be frightened. All will come well. There is a
+huge error which it may take some little time to rectify. Wait in
+patience.—Neville.’ Written in pencil upon the fly-leaf of a book,
+octavo size, no water-mark. Hum! Posted to-day in Gravesend by a man
+with a dirty thumb. Ha! And the flap has been gummed, if I am not very
+much in error, by a person who had been chewing tobacco. And you have
+no doubt that it is your husband’s hand, madam?”
+
+“None. Neville wrote those words.”
+
+“And they were posted to-day at Gravesend. Well, Mrs. St. Clair, the
+clouds lighten, though I should not venture to say that the danger is
+over.”
+
+“But he must be alive, Mr. Holmes.”
+
+“Unless this is a clever forgery to put us on the wrong scent. The
+ring, after all, proves nothing. It may have been taken from him.”
+
+“No, no; it is, it is, it is his very own writing!”
+
+“Very well. It may, however, have been written on Monday, and only
+posted to-day.”
+
+“That is possible.”
+
+“If so, much may have happened between.”
+
+“Oh, you must not discourage me, Mr. Holmes. I know that all is well
+with him. There is so keen a sympathy between us that I should know if
+evil came upon him. On the very day that I saw him last he cut himself
+in the bedroom, and yet I in the dining-room rushed up-stairs instantly
+with the utmost certainty that something had happened. Do you think
+that I would respond to such a trifle, and yet be ignorant of his
+death?”
+
+“I have seen too much not to know that the impression of a woman may
+be more valuable than the conclusion of an analytical reasoner. And
+in this letter you certainly have a very strong piece of evidence to
+corroborate your view. But if your husband is alive, and able to write
+letters, why should he remain away from you?”
+
+“I cannot imagine. It is unthinkable.”
+
+“And on Monday he made no remarks before leaving you?”
+
+“No.”
+
+“And you were surprised to see him in Swandam Lane?”
+
+“Very much so.”
+
+“Was the window open?”
+
+“Yes.”
+
+“Then he might have called to you?”
+
+“He might.”
+
+“He only, as I understand, gave an inarticulate cry?”
+
+“Yes.”
+
+“A call for help, you thought?”
+
+“Yes. He waved his hands.”
+
+“But it might have been a cry of surprise. Astonishment at the
+unexpected sight of you might cause him to throw up his hands?”
+
+“It is possible.”
+
+“And you thought he was pulled back?”
+
+“He disappeared so suddenly.”
+
+“He might have leaped back. You did not see any one else in the room?”
+
+“No, but this horrible man confessed to having been there, and the
+Lascar was at the foot of the stairs.”
+
+“Quite so. Your husband, as far as you could see, had his ordinary
+clothes on?”
+
+“But without his collar or tie. I distinctly saw his bare throat.”
+
+“Had he ever spoken of Swandam Lane?”
+
+“Never.”
+
+“Had he ever showed any signs of having taken opium?”
+
+“Never.”
+
+“Thank you, Mrs. St. Clair. Those are the principal points about which
+I wished to be absolutely clear. We shall now have a little supper and
+then retire, for we may have a very busy day to-morrow.”
+
+A large and comfortable double-bedded room had been placed at our
+disposal, and I was quickly between the sheets, for I was weary after
+my night of adventure. Sherlock Holmes was a man, however, who, when
+he had an unsolved problem upon his mind, would go for days, and even
+for a week, without rest, turning it over, rearranging his facts,
+looking at it from every point of view, until he had either fathomed
+it, or convinced himself that his data were insufficient. It was soon
+evident to me that he was now preparing for an all-night sitting. He
+took off his coat and waistcoat, put on a large blue dressing-gown,
+and then wandered about the room collecting pillows from his bed and
+cushions from the sofa and arm-chairs. With these he constructed a sort
+of Eastern divan, upon which he perched himself cross-legged, with an
+ounce of shag tobacco and a box of matches laid out in front of him.
+In the dim light of the lamp I saw him sitting there, an old briar
+pipe between his lips, his eyes fixed vacantly upon the corner of the
+ceiling, the blue smoke curling up from him, silent, motionless, with
+the light shining upon his strong-set aquiline features. So he sat as I
+dropped off to sleep, and so he sat when a sudden ejaculation caused me
+to wake up, and I found the summer sun shining into the apartment. The
+pipe was still between his lips, the smoke still curled upward, and the
+room was full of a dense tobacco haze, but nothing remained of the heap
+of shag which I had seen upon the previous night.
+
+“Awake, Watson?” he asked.
+
+“Yes.”
+
+“Game for a morning drive?”
+
+“Certainly.”
+
+“Then dress. No one is stirring yet, but I know where the stable-boy
+sleeps, and we shall soon have the trap out.” He chuckled to himself
+as he spoke, his eyes twinkled, and he seemed a different man to the
+sombre thinker of the previous night.
+
+As I dressed I glanced at my watch. It was no wonder that no one was
+stirring. It was twenty-five minutes past four. I had hardly finished
+when Holmes returned with the news that the boy was putting in the
+horse.
+
+“I want to test a little theory of mine,” said he, pulling on his
+boots. “I think, Watson, that you are now standing in the presence of
+one of the most absolute fools in Europe. I deserve to be kicked from
+here to Charing Cross. But I think I have the key of the affair now.”
+
+“And where is it?” I asked, smiling.
+
+“In the bath-room,” he answered. “Oh yes, I am not joking,” he
+continued, seeing my look of incredulity. “I have just been there, and
+I have taken it out, and I have got it in this Gladstone bag. Come on,
+my boy, and we shall see whether it will not fit the lock.”
+
+We made our way down-stairs as quietly as possible, and out into the
+bright morning sunshine. In the road stood our horse and trap, with
+the half-clad stable-boy waiting at the head. We both sprang in, and
+away we dashed down the London Road. A few country carts were stirring,
+bearing in vegetables to the metropolis, but the lines of villas on
+either side were as silent and lifeless as some city in a dream.
+
+“It has been in some points a singular case,” said Holmes, flicking the
+horse on into a gallop. “I confess that I have been as blind as a mole,
+but it is better to learn wisdom late than never to learn it at all.”
+
+In town the earliest risers were just beginning to look sleepily from
+their windows as we drove through the streets of the Surrey side.
+Passing down the Waterloo Bridge Road we crossed over the river, and
+dashing up Wellington Street wheeled sharply to the right, and found
+ourselves in Bow Street. Sherlock Holmes was well known to the Force,
+and the two constables at the door saluted him. One of them held the
+horse’s head while the other led us in.
+
+“Who is on duty?” asked Holmes.
+
+“Inspector Bradstreet, sir.”
+
+“Ah, Bradstreet, how are you?” A tall, stout official had come down the
+stone-flagged passage, in a peaked cap and frogged jacket. “I wish to
+have a quiet word with you, Bradstreet.”
+
+“Certainly, Mr. Holmes. Step into my room here.”
+
+It was a small, office-like room, with a huge ledger upon the table,
+and a telephone projecting from the wall. The inspector sat down at his
+desk.
+
+“What can I do for you, Mr. Holmes?”
+
+“I called about that beggarman, Boone—the one who was charged with
+being concerned in the disappearance of Mr. Neville St. Clair, of Lee.”
+
+“Yes. He was brought up and remanded for further inquiries.”
+
+“So I heard. You have him here?”
+
+“In the cells.”
+
+“Is he quiet?”
+
+“Oh, he gives no trouble. But he is a dirty scoundrel.”
+
+“Dirty?”
+
+“Yes, it is all we can do to make him wash his hands, and his face is
+as black as a tinker’s. Well, when once his case has been settled, he
+will have a regular prison bath; and I think, if you saw him, you would
+agree with me that he needed it.”
+
+“I should like to see him very much.”
+
+“Would you? That is easily done. Come this way. You can leave your bag.”
+
+“No, I think that I’ll take it.”
+
+“Very good. Come this way, if you please.” He led us down a passage,
+opened a barred door, passed down a winding stair, and brought us to a
+whitewashed corridor with a line of doors on each side.
+
+“The third on the right is his,” said the inspector. “Here it is!” He
+quietly shot back a panel in the upper part of the door and glanced
+through.
+
+“He is asleep,” said he. “You can see him very well.”
+
+We both put our eyes to the grating. The prisoner lay with his face
+towards us, in a very deep sleep, breathing slowly and heavily. He was
+a middle-sized man, coarsely clad as became his calling, with a colored
+shirt protruding through the rent in his tattered coat. He was, as the
+inspector had said, extremely dirty, but the grime which covered his
+face could not conceal its repulsive ugliness. A broad wheal from an
+old scar ran right across it from eye to chin, and by its contraction
+had turned up one side of the upper lip, so that three teeth were
+exposed in a perpetual snarl. A shock of very bright red hair grew low
+over his eyes and forehead.
+
+“He’s a beauty, isn’t he?” said the inspector.
+
+“He certainly needs a wash,” remarked Holmes. “I had an idea that he
+might, and I took the liberty of bringing the tools with me.” He opened
+the Gladstone bag as he spoke, and took out, to my astonishment, a very
+large bath-sponge.
+
+“He! he! You are a funny one,” chuckled the inspector.
+
+“Now, if you will have the great goodness to open that door very
+quietly, we will soon make him cut a much more respectable figure.”
+
+“Well, I don’t know why not,” said the inspector. “He doesn’t look
+a credit to the Bow Street cells, does he?” He slipped his key into
+the lock, and we all very quietly entered the cell. The sleeper half
+turned, and then settled down once more into a deep slumber. Holmes
+stooped to the water-jug, moistened his sponge, and then rubbed it
+twice vigorously across and down the prisoner’s face.
+
+“Let me introduce you,” he shouted, “to Mr. Neville St. Clair, of Lee,
+in the county of Kent.”
+
+Never in my life have I seen such a sight. The man’s face peeled off
+under the sponge like the bark from a tree. Gone was the coarse brown
+tint! Gone, too, was the horrid scar which had seamed it across, and
+the twisted lip which had given the repulsive sneer to the face! A
+twitch brought away the tangled red hair, and there, sitting up in
+his bed, was a pale, sad-faced, refined-looking man, black-haired and
+smooth-skinned, rubbing his eyes, and staring about him with sleepy
+bewilderment. Then suddenly realizing the exposure, he broke into a
+scream, and threw himself down with his face to the pillow.
+
+“Great heavens!” cried the inspector, “it is, indeed, the missing man.
+I know him from the photograph.”
+
+The prisoner turned with the reckless air of a man who abandons himself
+to his destiny. “Be it so,” said he. “And pray, what am I charged with?”
+
+“With making away with Mr. Neville St.—— Oh, come, you can’t be
+charged with that, unless they make a case of attempted suicide of it,”
+said the inspector, with a grin. “Well, I have been twenty-seven years
+in the force, but this really takes the cake.”
+
+“If I am Mr. Neville St. Clair, then it is obvious that no crime has
+been committed, and that, therefore, I am illegally detained.”
+
+“No crime, but a very great error has been committed,” said Holmes.
+“You would have done better to have trusted your wife.”
+
+“It was not the wife, it was the children,” groaned the prisoner. “God
+help me, I would not have them ashamed of their father. My God! What an
+exposure! What can I do?”
+
+Sherlock Holmes sat down beside him on the couch and patted him kindly
+on the shoulder.
+
+“If you leave it to a court of law to clear the matter up,” said he,
+“of course you can hardly avoid publicity. On the other hand, if you
+convince the police authorities that there is no possible case against
+you, I do not know that there is any reason that the details should
+find their way into the papers. Inspector Bradstreet would, I am sure,
+make notes upon anything which you might tell us, and submit it to the
+proper authorities. The case would then never go into court at all.”
+
+“God bless you!” cried the prisoner, passionately. “I would have
+endured imprisonment, aye, even execution, rather than have left my
+miserable secret as a family blot to my children.
+
+“You are the first who have ever heard my story. My father was
+a school-master in Chesterfield, where I received an excellent
+education. I travelled in my youth, took to the stage, and finally
+became a reporter on an evening paper in London. One day my editor
+wished to have a series of articles upon begging in the metropolis,
+and I volunteered to supply them. There was the point from which all
+my adventures started. It was only by trying begging as an amateur
+that I could get the facts upon which to base my articles. When an
+actor I had, of course, learned all the secrets of making up, and had
+been famous in the greenroom for my skill. I took advantage now of
+my attainments. I painted my face, and to make myself as pitiable as
+possible I made a good scar and fixed one side of my lip in a twist
+by the aid of a small slip of flesh-colored plaster. Then with a red
+head of hair, and an appropriate dress, I took my station in the
+busiest part of the city, ostensibly as a match-seller, but really as a
+beggar. For seven hours I plied my trade, and when I returned home in
+the evening I found, to my surprise, that I had received no less than
+26_s._ 4_d._
+
+“I wrote my articles, and thought little more of the matter until, some
+time later, I backed a bill for a friend, and had a writ served upon
+me for £25. I was at my wits’ end where to get the money, but a sudden
+idea came to me. I begged a fortnight’s grace from the creditor, asked
+for a holiday from my employers, and spent the time in begging in the
+city under my disguise. In ten days I had the money, and had paid the
+debt.
+
+“Well, you can imagine how hard it was to settle down to arduous
+work at £2 a week, when I knew that I could earn as much in a day by
+smearing my face with a little paint, laying my cap on the ground, and
+sitting still. It was a long fight between my pride and the money,
+but the dollars won at last, and I threw up reporting, and sat day
+after day in the corner which I had first chosen, inspiring pity by my
+ghastly face, and filling my pockets with coppers. Only one man knew
+my secret. He was the keeper of a low den in which I used to lodge in
+Swandam Lane, where I could every morning emerge as a squalid beggar,
+and in the evenings transform myself into a well-dressed man about
+town. This fellow, a Lascar, was well paid by me for his rooms, so that
+I knew that my secret was safe in his possession.
+
+“Well, very soon I found that I was saving considerable sums of money.
+I do not mean that any beggar in the streets of London could earn £700
+a year—which is less than my average takings—but I had exceptional
+advantages in my power of making up, and also in a facility of
+repartee, which improved by practice, and made me quite a recognized
+character in the city. All day a stream of pennies, varied by silver,
+poured in upon me, and it was a very bad day in which I failed to take
+£2.
+
+“As I grew richer I grew more ambitious, took a house in the country,
+and eventually married, without any one having a suspicion as to my
+real occupation. My dear wife knew that I had business in the city. She
+little knew what.
+
+“Last Monday I had finished for the day, and was dressing in my room
+above the opium den, when I looked out of my window, and saw, to my
+horror and astonishment, that my wife was standing in the street, with
+her eyes fixed full upon me. I gave a cry of surprise, threw up my arms
+to cover my face, and, rushing to my confidant, the Lascar, entreated
+him to prevent any one from coming up to me. I heard her voice
+down-stairs, but I knew that she could not ascend. Swiftly I threw off
+my clothes, pulled on those of a beggar, and put on my pigments and
+wig. Even a wife’s eyes could not pierce so complete a disguise. But
+then it occurred to me that there might be a search in the room, and
+that the clothes might betray me. I threw open the window, reopening
+by my violence a small cut which I had inflicted upon myself in the
+bedroom that morning. Then I seized my coat, which was weighted by
+the coppers which I had just transferred to it from the leather bag
+in which I carried my takings. I hurled it out of the window, and it
+disappeared into the Thames. The other clothes would have followed, but
+at that moment there was a rush of constables up the stair, and a few
+minutes after I found, rather, I confess, to my relief, that instead
+of being identified as Mr. Neville St. Clair, I was arrested as his
+murderer.
+
+“I do not know that there is anything else for me to explain. I was
+determined to preserve my disguise as long as possible, and hence my
+preference for a dirty face. Knowing that my wife would be terribly
+anxious, I slipped off my ring, and confided it to the Lascar at a
+moment when no constable was watching me, together with a hurried
+scrawl, telling her that she had no cause to fear.”
+
+“That note only reached her yesterday,” said Holmes.
+
+“Good God! What a week she must have spent!”
+
+“The police have watched this Lascar,” said Inspector Bradstreet, “and
+I can quite understand that he might find it difficult to post a letter
+unobserved. Probably he handed it to some sailor customer of his, who
+forgot all about it for some days.”
+
+“That was it,” said Holmes, nodding approvingly; “I have no doubt of
+it. But have you never been prosecuted for begging?”
+
+“Many times; but what was a fine to me?”
+
+“It must stop here, however,” said Bradstreet. “If the police are to
+hush this thing up, there must be no more of Hugh Boone.”
+
+“I have sworn it by the most solemn oaths which a man can take.”
+
+“In that case I think that it is probable that no further steps may be
+taken. But if you are found again, then all must come out. I am sure,
+Mr. Holmes, that we are very much indebted to you for having cleared
+the matter up. I wish I knew how you reach your results.”
+
+“I reached this one,” said my friend, “by sitting upon five pillows and
+consuming an ounce of shag. I think, Watson, that if we drive to Baker
+Street we shall just be in time for breakfast.”
+
+
+
+
+Adventure VII
+
+THE ADVENTURE OF THE BLUE CARBUNCLE
+
+
+I had called upon my friend Sherlock Holmes upon the second morning
+after Christmas, with the intention of wishing him the compliments of
+the season. He was lounging upon the sofa in a purple dressing-gown,
+a pipe-rack within his reach upon the right, and a pile of crumpled
+morning papers, evidently newly studied, near at hand. Beside the couch
+was a wooden chair, and on the angle of the back hung a very seedy
+and disreputable hard-felt hat, much the worse for wear, and cracked
+in several places. A lens and a forceps lying upon the seat of the
+chair suggested that the hat had been suspended in this manner for the
+purpose of examination.
+
+“You are engaged,” said I; “perhaps I interrupt you.”
+
+“Not at all. I am glad to have a friend with whom I can discuss my
+results. The matter is a perfectly trivial one” (he jerked his thumb in
+the direction of the old hat), “but there are points in connection with
+it which are not entirely devoid of interest and even of instruction.”
+
+I seated myself in his arm-chair and warmed my hands before his
+crackling fire, for a sharp frost had set in, and the windows were
+thick with the ice crystals. “I suppose,” I remarked, “that, homely as
+it looks, this thing has some deadly story linked on to it—that it is
+the clew which will guide you in the solution of some mystery and the
+punishment of some crime.”
+
+“No, no. No crime,” said Sherlock Holmes, laughing. “Only one of
+those whimsical little incidents which will happen when you have
+four million human beings all jostling each other within the space of
+a few square miles. Amid the action and reaction of so dense a swarm
+of humanity, every possible combination of events may be expected to
+take place, and many a little problem will be presented which may
+be striking and bizarre without being criminal. We have already had
+experience of such.”
+
+“So much so,” I remarked, “that of the last six cases which I have
+added to my notes, three have been entirely free of any legal crime.”
+
+“Precisely. You allude to my attempt to recover the Irene Adler papers,
+to the singular case of Miss Mary Sutherland, and to the adventure of
+the man with the twisted lip. Well, I have no doubt that this small
+matter will fall into the same innocent category. You know Peterson,
+the commissionaire?”
+
+“Yes.”
+
+“It is to him that this trophy belongs.”
+
+“It is his hat.”
+
+“No, no; he found it. Its owner is unknown. I beg that you will look
+upon it, not as a battered billycock, but as an intellectual problem.
+And, first, as to how it came here. It arrived upon Christmas morning,
+in company with a good fat goose, which is, I have no doubt, roasting
+at this moment in front of Peterson’s fire. The facts are these: about
+four o’clock on Christmas morning, Peterson, who, as you know, is a
+very honest fellow, was returning from some small jollification, and
+was making his way homeward down Tottenham Court Road. In front of him
+he saw, in the gaslight, a tallish man, walking with a slight stagger,
+and carrying a white goose slung over his shoulder. As he reached the
+corner of Goodge Street, a row broke out between this stranger and a
+little knot of roughs. One of the latter knocked off the man’s hat, on
+which he raised his stick to defend himself, and, swinging it over his
+head, smashed the shop window behind him. Peterson had rushed forward
+to protect the stranger from his assailants; but the man, shocked at
+having broken the window, and seeing an official-looking person in
+uniform rushing towards him, dropped his goose, took to his heels, and
+vanished amid the labyrinth of small streets which lie at the back of
+Tottenham Court Road. The roughs had also fled at the appearance of
+Peterson, so that he was left in possession of the field of battle, and
+also of the spoils of victory in the shape of this battered hat and a
+most unimpeachable Christmas goose.”
+
+“Which surely he restored to their owner?”
+
+“My dear fellow, there lies the problem. It is true that ‘For Mrs.
+Henry Baker’ was printed upon a small card which was tied to the bird’s
+left leg, and it is also true that the initials ‘H. B.’ are legible
+upon the lining of this hat; but as there are some thousands of Bakers,
+and some hundreds of Henry Bakers in this city of ours, it is not easy
+to restore lost property to any one of them.”
+
+“What, then, did Peterson do?”
+
+“He brought round both hat and goose to me on Christmas morning,
+knowing that even the smallest problems are of interest to me. The
+goose we retained until this morning, when there were signs that, in
+spite of the slight frost, it would be well that it should be eaten
+without unnecessary delay. Its finder has carried it off, therefore, to
+fulfil the ultimate destiny of a goose, while I continue to retain the
+hat of the unknown gentleman who lost his Christmas dinner.”
+
+“Did he not advertise?”
+
+“No.”
+
+“Then, what clue could you have as to his identity?”
+
+“Only as much as we can deduce.”
+
+“From his hat?”
+
+“Precisely.”
+
+“But you are joking. What can you gather from this old battered felt?”
+
+“Here is my lens. You know my methods. What can you gather yourself as
+to the individuality of the man who has worn this article?”
+
+I took the tattered object in my hands and turned it over rather
+ruefully. It was a very ordinary black hat of the usual round shape,
+hard, and much the worse for wear. The lining had been of red silk, but
+was a good deal discolored. There was no maker’s name; but, as Holmes
+had remarked, the initials “H. B.” were scrawled upon one side. It was
+pierced in the brim for a hat-securer, but the elastic was missing. For
+the rest, it was cracked, exceedingly dusty, and spotted in several
+places, although there seemed to have been some attempt to hide the
+discolored patches by smearing them with ink.
+
+“I can see nothing,” said I, handing it back to my friend.
+
+“On the contrary, Watson, you can see everything. You fail, however, to
+reason from what you see. You are too timid in drawing your inferences.”
+
+“Then, pray tell me what it is that you can infer from this hat?”
+
+He picked it up and gazed at it in the peculiar introspective fashion
+which was characteristic of him. “It is perhaps less suggestive than
+it might have been,” he remarked, “and yet there are a few inferences
+which are very distinct, and a few others which represent at least a
+strong balance of probability. That the man was highly intellectual
+is of course obvious upon the face of it, and also that he was fairly
+well-to-do within the last three years, although he has now fallen upon
+evil days. He had foresight, but has less now than formerly, pointing
+to a moral retrogression, which, when taken with the decline of his
+fortunes, seems to indicate some evil influence, probably drink, at
+work upon him. This may account also for the obvious fact that his wife
+has ceased to love him.”
+
+“My dear Holmes!”
+
+“He has, however, retained some degree of self-respect,” he continued,
+disregarding my remonstrance. “He is a man who leads a sedentary
+life, goes out little, is out of training entirely, is middle-aged,
+has grizzled hair which he has had cut within the last few days, and
+which he anoints with lime-cream. These are the more patent facts which
+are to be deduced from his hat. Also, by-the-way, that it is extremely
+improbable that he has gas laid on in his house.”
+
+“You are certainly joking, Holmes.”
+
+“Not in the least. Is it possible that even now, when I give you these
+results, you are unable to see how they are attained?”
+
+“I have no doubt that I am very stupid; but I must confess that I am
+unable to follow you. For example, how did you deduce that this man was
+intellectual?”
+
+For answer Holmes clapped the hat upon his head. It came right over the
+forehead and settled upon the bridge of his nose. “It is a question
+of cubic capacity,” said he; “a man with so large a brain must have
+something in it.”
+
+“The decline of his fortunes, then?”
+
+“This hat is three years old. These flat brims curled at the edge came
+in then. It is a hat of the very best quality. Look at the band of
+ribbed silk and the excellent lining. If this man could afford to buy
+so expensive a hat three years ago, and has had no hat since, then he
+has assuredly gone down in the world.”
+
+“Well, that is clear enough, certainly. But how about the foresight and
+the moral retrogression?”
+
+Sherlock Holmes laughed. “Here is the foresight,” said he, putting
+his finger upon the little disk and loop of the hat-securer. “They
+are never sold upon hats. If this man ordered one, it is a sign of a
+certain amount of foresight, since he went out of his way to take this
+precaution against the wind. But since we see that he has broken the
+elastic, and has not troubled to replace it, it is obvious that he
+has less foresight now than formerly, which is a distinct proof of a
+weakening nature. On the other hand, he has endeavored to conceal some
+of these stains upon the felt by daubing them with ink, which is a
+sign that he has not entirely lost his self-respect.”
+
+“Your reasoning is certainly plausible.”
+
+“The further points, that he is middle-aged, that his hair is grizzled,
+that it has been recently cut, and that he uses lime-cream, are all
+to be gathered from a close examination of the lower part of the
+lining. The lens discloses a large number of hair-ends, clean cut by
+the scissors of the barber. They all appear to be adhesive, and there
+is a distinct odor of lime-cream. This dust, you will observe, is not
+the gritty, gray dust of the street, but the fluffy brown dust of the
+house, showing that it has been hung up in-doors most of the time;
+while the marks of moisture upon the inside are proof positive that the
+wearer perspired very freely, and could, therefore, hardly be in the
+best of training.”
+
+“But his wife—you said that she had ceased to love him.”
+
+“This hat has not been brushed for weeks. When I see you, my dear
+Watson, with a week’s accumulation of dust upon your hat, and when your
+wife allows you to go out in such a state, I shall fear that you also
+have been unfortunate enough to lose your wife’s affection.”
+
+“But he might be a bachelor.”
+
+“Nay, he was bringing home the goose as a peace-offering to his wife.
+Remember the card upon the bird’s leg.”
+
+“You have an answer to everything. But how on earth do you deduce that
+the gas is not laid on in his house?”
+
+“One tallow stain, or even two, might come by chance; but when I
+see no less than five, I think that there can be little doubt that
+the individual must be brought into frequent contact with burning
+tallow—walks up-stairs at night probably with his hat in one hand and
+a guttering candle in the other. Anyhow, he never got tallow-stains
+from a gas-jet. Are you satisfied?”
+
+“Well, it is very ingenious,” said I, laughing; “but since, as you said
+just now, there has been no crime committed, and no harm done, save
+the loss of a goose, all this seems to be rather a waste of energy.”
+
+Sherlock Holmes had opened his mouth to reply, when the door flew
+open, and Peterson, the commissionaire, rushed into the apartment with
+flushed cheeks and the face of a man who is dazed with astonishment.
+
+“The goose, Mr. Holmes! The goose, sir!” he gasped.
+
+“Eh? What of it, then? Has it returned to life and flapped off through
+the kitchen window?” Holmes twisted himself round upon the sofa to get
+a fairer view of the man’s excited face.
+
+“See here, sir! See what my wife found in its crop!” He held out
+his hand and displayed upon the centre of the palm a brilliantly
+scintillating blue stone, rather smaller than a bean in size, but of
+such purity and radiance that it twinkled like an electric point in the
+dark hollow of his hand.
+
+Sherlock Holmes sat up with a whistle. “By Jove, Peterson!” said he,
+“this is treasure trove indeed. I suppose you know what you have got?”
+
+“A diamond, sir? A precious stone. It cuts into glass as though it were
+putty.”
+
+“It’s more than a precious stone. It is _the_ precious stone.”
+
+“Not the Countess of Morcar’s blue carbuncle!” I ejaculated.
+
+“Precisely so. I ought to know its size and shape, seeing that I have
+read the advertisement about it in _The Times_ every day lately. It
+is absolutely unique, and its value can only be conjectured, but the
+reward offered of £1000 is certainly not within a twentieth part of the
+market price.”
+
+“A thousand pounds! Great Lord of mercy!” The commissionaire plumped
+down into a chair, and stared from one to the other of us.
+
+“That is the reward, and I have reason to know that there are
+sentimental considerations in the background which would induce the
+countess to part with half her fortune if she could but recover the
+gem.”
+
+“It was lost, if I remember aright, at the ‘Hotel Cosmopolitan,’” I
+remarked.
+
+“Precisely so, on December 22d, just five days ago. John Horner,
+a plumber, was accused of having abstracted it from the lady’s
+jewel-case. The evidence against him was so strong that the case has
+been referred to the Assizes. I have some account of the matter here,
+I believe.” He rummaged amid his newspapers, glancing over the dates,
+until at last he smoothed one out, doubled it over, and read the
+following paragraph:
+
+“‘Hotel Cosmopolitan Jewel Robbery. John Horner, 26, plumber, was
+brought up upon the charge of having upon the 22d inst. abstracted from
+the jewel-case of the Countess of Morcar the valuable gem known as the
+blue carbuncle. James Ryder, upper-attendant at the hotel, gave his
+evidence to the effect that he had shown Horner up to the dressing-room
+of the Countess of Morcar upon the day of the robbery, in order that
+he might solder the second bar of the grate, which was loose. He had
+remained with Horner some little time, but had finally been called
+away. On returning, he found that Horner had disappeared, that the
+bureau had been forced open, and that the small morocco casket in
+which, as it afterwards transpired, the countess was accustomed to keep
+her jewel, was lying empty upon the dressing-table. Ryder instantly
+gave the alarm, and Horner was arrested the same evening; but the stone
+could not be found either upon his person or in his rooms. Catherine
+Cusack, maid to the countess, deposed to having heard Ryder’s cry of
+dismay on discovering the robbery, and to having rushed into the room,
+where she found matters as described by the last witness. Inspector
+Bradstreet, B division, gave evidence as to the arrest of Horner, who
+struggled frantically, and protested his innocence in the strongest
+terms. Evidence of a previous conviction for robbery having been given
+against the prisoner, the magistrate refused to deal summarily with
+the offence, but referred it to the Assizes. Horner, who had shown
+signs of intense emotion during the proceedings, fainted away at the
+conclusion, and was carried out of court.’
+
+“Hum! So much for the police-court,” said Holmes, thoughtfully, tossing
+aside the paper. “The question for us now to solve is the sequence
+of events leading from a rifled jewel-case at one end to the crop of
+a goose in Tottenham Court Road at the other. You see, Watson, our
+little deductions have suddenly assumed a much more important and less
+innocent aspect. Here is the stone; the stone came from the goose, and
+the goose came from Mr. Henry Baker, the gentleman with the bad hat
+and all the other characteristics with which I have bored you. So now
+we must set ourselves very seriously to finding this gentleman, and
+ascertaining what part he has played in this little mystery. To do
+this, we must try the simplest means first, and these lie undoubtedly
+in an advertisement in all the evening papers. If this fails, I shall
+have recourse to other methods.”
+
+“What will you say?”
+
+“Give me a pencil and that slip of paper. Now, then: ‘Found at the
+corner of Goodge Street, a goose and a black felt hat. Mr. Henry Baker
+can have the same by applying at 6.30 this evening at 221B,
+Baker Street.’ That is clear and concise.”
+
+“Very. But will he see it?”
+
+“Well, he is sure to keep an eye on the papers, since, to a poor man,
+the loss was a heavy one. He was clearly so scared by his mischance
+in breaking the window and by the approach of Peterson, that he
+thought of nothing but flight; but since then he must have bitterly
+regretted the impulse which caused him to drop his bird. Then, again,
+the introduction of his name will cause him to see it, for every one
+who knows him will direct his attention to it. Here you are, Peterson,
+run down to the advertising agency, and have this put in the evening
+papers.”
+
+“In which, sir?”
+
+“Oh, in the _Globe_, _Star_, _Pall Mall_, _St. James’s_, _Evening
+News_, _Standard_, _Echo_, and any others that occur to you.”
+
+“Very well, sir. And this stone?”
+
+“Ah, yes, I shall keep the stone. Thank you. And, I say, Peterson,
+just buy a goose on your way back, and leave it here with me, for we
+must have one to give to this gentleman in place of the one which your
+family is now devouring.”
+
+When the commissionaire had gone, Holmes took up the stone and held
+it against the light. “It’s a bonny thing,” said he. “Just see how it
+glints and sparkles. Of course it is a nucleus and focus of crime.
+Every good stone is. They are the devil’s pet baits. In the larger and
+older jewels every facet may stand for a bloody deed. This stone is not
+yet twenty years old. It was found in the banks of the Amoy River in
+Southern China, and is remarkable in having every characteristic of the
+carbuncle, save that it is blue in shade, instead of ruby red. In spite
+of its youth, it has already a sinister history. There have been two
+murders, a vitriol-throwing, a suicide, and several robberies brought
+about for the sake of this forty-grain weight of crystallized charcoal.
+Who would think that so pretty a toy would be a purveyor to the gallows
+and the prison? I’ll lock it up in my strong box now, and drop a line
+to the countess to say that we have it.”
+
+“Do you think that this man Horner is innocent?”
+
+“I cannot tell.”
+
+“Well, then, do you imagine that this other one, Henry Baker, had
+anything to do with the matter?”
+
+“It is, I think, much more likely that Henry Baker is an absolutely
+innocent man, who had no idea that the bird which he was carrying was
+of considerably more value than if it were made of solid gold. That,
+however, I shall determine by a very simple test, if we have an answer
+to our advertisement.”
+
+“And you can do nothing until then?”
+
+“Nothing.”
+
+“In that case I shall continue my professional round. But I shall come
+back in the evening at the hour you have mentioned, for I should like
+to see the solution of so tangled a business.”
+
+“Very glad to see you. I dine at seven. There is a woodcock, I believe.
+By-the-way, in view of recent occurrences, perhaps I ought to ask Mrs.
+Hudson to examine its crop.”
+
+I had been delayed at a case, and it was a little after half-past
+six when I found myself in Baker Street once more. As I approached
+the house I saw a tall man in a Scotch bonnet with a coat which was
+buttoned up to his chin, waiting outside in the bright semicircle which
+was thrown from the fanlight. Just as I arrived, the door was opened,
+and we were shown up together to Holmes’s room.
+
+“Mr. Henry Baker, I believe,” said he, rising from his arm-chair, and
+greeting his visitor with the easy air of geniality which he could so
+readily assume. “Pray take this chair by the fire, Mr. Baker. It is a
+cold night, and I observe that your circulation is more adapted for
+summer than for winter. Ah, Watson, you have just come at the right
+time. Is that your hat, Mr. Baker?”
+
+“Yes, sir, that is undoubtedly my hat.”
+
+He was a large man, with rounded shoulders, a massive head, and a
+broad, intelligent face, sloping down to a pointed beard of grizzled
+brown. A touch of red in nose and cheeks, with a slight tremor of his
+extended hand, recalled Holmes’s surmise as to his habits. His rusty
+black frock-coat was buttoned right up in front, with the collar turned
+up, and his lank wrists protruded from his sleeves without a sign of
+cuff or shirt. He spoke in a slow staccato fashion, choosing his words
+with care, and gave the impression generally of a man of learning and
+letters who had had ill-usage at the hands of fortune.
+
+“We have retained these things for some days,” said Holmes, “because we
+expected to see an advertisement from you giving your address. I am at
+a loss to know now why you did not advertise.”
+
+Our visitor gave a rather shamefaced laugh. “Shillings have not been
+so plentiful with me as they once were,” he remarked. “I had no doubt
+that the gang of roughs who assaulted me had carried off both my hat
+and the bird. I did not care to spend more money in a hopeless attempt
+at recovering them.”
+
+“Very naturally. By-the-way, about the bird, we were compelled to eat
+it.”
+
+“To eat it!” Our visitor half rose from his chair in his excitement.
+
+“Yes, it would have been of no use to any one had we not done so. But
+I presume that this other goose upon the sideboard, which is about the
+same weight and perfectly fresh, will answer your purpose equally well?”
+
+“Oh, certainly, certainly;” answered Mr. Baker, with a sigh of relief.
+
+“Of course, we still have the feathers, legs, crop, and so on of your
+own bird, so if you wish—”
+
+The man burst into a hearty laugh. “They might be useful to me as
+relics of my adventure,” said he, “but beyond that I can hardly see
+what use the _disjecta membra_ of my late acquaintance are going to be
+to me. No, sir, I think that, with your permission, I will confine my
+attentions to the excellent bird which I perceive upon the sideboard.”
+
+Sherlock Holmes glanced sharply across at me with a slight shrug of his
+shoulders.
+
+“There is your hat, then, and there your bird,” said he. “By-the-way,
+would it bore you to tell me where you got the other one from? I am
+somewhat of a fowl fancier, and I have seldom seen a better grown
+goose.”
+
+“Certainly, sir,” said Baker, who had risen and tucked his newly-gained
+property under his arm. “There are a few of us who frequent the ‘Alpha
+Inn,’ near the Museum—we are to be found in the Museum itself during
+the day, you understand. This year our good host, Windigate by name,
+instituted a goose club, by which, on consideration of some few pence
+every week, we were each to receive a bird at Christmas. My pence were
+duly paid, and the rest is familiar to you. I am much indebted to you,
+sir, for a Scotch bonnet is fitted neither to my years nor my gravity.”
+With a comical pomposity of manner he bowed solemnly to both of us and
+strode off upon his way.
+
+“So much for Mr. Henry Baker,” said Holmes, when he had closed the door
+behind him. “It is quite certain that he knows nothing whatever about
+the matter. Are you hungry, Watson?”
+
+“Not particularly.”
+
+“Then I suggest that we turn our dinner into a supper, and follow up
+this clew while it is still hot.”
+
+“By all means.”
+
+It was a bitter night, so we drew on our ulsters and wrapped cravats
+about our throats. Outside, the stars were shining coldly in a
+cloudless sky, and the breath of the passers-by blew out into smoke
+like so many pistol shots. Our footfalls rang out crisply and loudly
+as we swung through the Doctors’ quarter, Wimpole Street, Harley
+Street, and so through Wigmore Street into Oxford Street. In a quarter
+of an hour we were in Bloomsbury at the “Alpha Inn,” which is a small
+public-house at the corner of one of the streets which runs down into
+Holborn. Holmes pushed open the door of the private bar, and ordered
+two glasses of beer from the ruddy-faced, white-aproned landlord.
+
+“Your beer should be excellent if it is as good as your geese,” said he.
+
+“My geese!” The man seemed surprised.
+
+“Yes. I was speaking only half an hour ago to Mr. Henry Baker, who was
+a member of your goose club.”
+
+“Ah! yes, I see. But you see, sir, them’s not _our_ geese.”
+
+“Indeed! Whose, then?”
+
+“Well, I got the two dozen from a salesman in Covent Garden.”
+
+“Indeed? I know some of them. Which was it?”
+
+“Breckinridge is his name.”
+
+“Ah! I don’t know him. Well, here’s your good health, landlord, and
+prosperity to your house. Good-night?”
+
+“Now for Mr. Breckinridge,” he continued, buttoning up his coat, as we
+came out into the frosty air. “Remember, Watson, that though we have
+so homely a thing as a goose at one end of this chain, we have at the
+other a man who will certainly get seven years’ penal servitude unless
+we can establish his innocence. It is possible that our inquiry may but
+confirm his guilt; but, in any case, we have a line of investigation
+which has been missed by the police, and which a singular chance has
+placed in our hands. Let us follow it out to the bitter end. Faces to
+the south, then, and quick march!”
+
+We passed across Holborn, down Endell Street, and so through a zigzag
+of slums to Covent Garden Market. One of the largest stalls bore the
+name of Breckinridge upon it, and the proprietor, a horsey-looking man,
+with a sharp face and trim side-whiskers, was helping a boy to put up
+the shutters.
+
+“Good-evening. It’s a cold night,” said Holmes.
+
+The salesman nodded, and shot a questioning glance at my companion.
+
+“Sold out of geese, I see,” continued Holmes, pointing at the bare
+slabs of marble.
+
+“Let you have 500 to-morrow morning.”
+
+“That’s no good.”
+
+“Well, there are some on the stall with the gas-flare.”
+
+“Ah, but I was recommended to you.”
+
+“Who by?”
+
+“The landlord of the ‘Alpha.’”
+
+“Oh, yes; I sent him a couple of dozen.”
+
+“Fine birds they were, too. Now where did you get them from?”
+
+To my surprise the question provoked a burst of anger from the salesman.
+
+“Now, then, mister,” said he, with his head cocked and his arms
+akimbo, “what are you driving at? Let’s have it straight, now.”
+
+“It is straight enough. I should like to know who sold you the geese
+which you supplied to the ‘Alpha.’”
+
+“Well, then, I sha’n’t tell you. So now!”
+
+“Oh, it is a matter of no importance; but I don’t know why you should
+be so warm over such a trifle.”
+
+“Warm! You’d be as warm, maybe, if you were as pestered as I am. When
+I pay good money for a good article there should be an end of the
+business; but it’s ‘Where are the geese?’ and ‘Who did you sell the
+geese to?’ and ‘What will you take for the geese?’ One would think they
+were the only geese in the world, to hear the fuss that is made over
+them.”
+
+“Well, I have no connection with any other people who have been making
+inquiries,” said Holmes, carelessly. “If you won’t tell us the bet is
+off, that is all. But I’m always ready to back my opinion on a matter
+of fowls, and I have a fiver on it that the bird I ate is country bred.”
+
+“Well, then, you’ve lost your fiver, for it’s town bred,” snapped the
+salesman.
+
+“It’s nothing of the kind.”
+
+“I say it is.”
+
+“I don’t believe it.”
+
+“D’you think you know more about fowls than I, who have handled them
+ever since I was a nipper? I tell you, all those birds that went to the
+‘Alpha’ were town bred.”
+
+“You’ll never persuade me to believe that.”
+
+“Will you bet, then?”
+
+“It’s merely taking your money, for I know that I am right. But I’ll
+have a sovereign on with you, just to teach you not to be obstinate.”
+
+The salesman chuckled grimly. “Bring me the books, Bill,” said he.
+
+The small boy brought round a small thin volume and a great
+greasy-backed one, laying them out together beneath the hanging lamp.
+
+“Now then, Mr. Cocksure,” said the salesman, “I thought that I was out
+of geese, but before I finish you’ll find that there is still one left
+in my shop. You see this little book?”
+
+“Well?”
+
+“That’s the list of the folk from whom I buy. D’you see? Well, then,
+here on this page are the country folk, and the numbers after their
+names are where their accounts are in the big ledger. Now, then!
+You see this other page in red ink? Well, that is a list of my town
+suppliers. Now, look at that third name. Just read it out to me.”
+
+“Mrs. Oakshott, 117, Brixton Road—249,” read Holmes.
+
+“Quite so. Now turn that up in the ledger.”
+
+Holmes turned to the page indicated. “Here you are, ‘Mrs. Oakshott,
+117, Brixton Road, egg and poultry supplier.’”
+
+“Now, then, what’s the last entry?”
+
+“‘December 22. Twenty-four geese at 7_s._ 6_d._’”
+
+“Quite so. There you are. And underneath?”
+
+“‘Sold to Mr. Windigate of the ‘Alpha,’ at 12_s._’”
+
+“What have you to say now?”
+
+Sherlock Holmes looked deeply chagrined. He drew a sovereign from his
+pocket and threw it down upon the slab, turning away with the air of
+a man whose disgust is too deep for words. A few yards off he stopped
+under a lamp-post, and laughed in the hearty, noiseless fashion which
+was peculiar to him.
+
+“When you see a man with whiskers of that cut and the ‘pink ‘un’
+protruding out of his pocket, you can always draw him by a bet,” said
+he. “I dare say that if I had put £100 down in front of him, that man
+would not have given me such complete information as was drawn from
+him by the idea that he was doing me on a wager. Well, Watson, we
+are, I fancy, nearing the end of our quest, and the only point which
+remains to be determined is whether we should go on to this Mrs.
+Oakshott to-night, or whether we should reserve it for to-morrow. It is
+clear from what that surly fellow said that there are others besides
+ourselves who are anxious about the matter, and I should—”
+
+His remarks were suddenly cut short by a loud hubbub which broke out
+from the stall which we had just left. Turning round we saw a little
+rat-faced fellow standing in the centre of the circle of yellow light
+which was thrown by the swinging lamp, while Breckinridge the salesman,
+framed in the door of his stall, was shaking his fists fiercely at the
+cringing figure.
+
+“I’ve had enough of you and your geese,” he shouted. “I wish you were
+all at the devil together. If you come pestering me any more with your
+silly talk I’ll set the dog at you. You bring Mrs. Oakshott here and
+I’ll answer her, but what have you to do with it? Did I buy the geese
+off you?”
+
+“No; but one of them was mine all the same,” whined the little man.
+
+“Well, then, ask Mrs. Oakshott for it.”
+
+“She told me to ask you.”
+
+“Well, you can ask the King of Proosia, for all I care. I’ve had enough
+of it. Get out of this!” He rushed fiercely forward, and the inquirer
+flitted away into the darkness.
+
+“Ha! this may save us a visit to Brixton Road,” whispered Holmes. “Come
+with me, and we will see what is to be made of this fellow.” Striding
+through the scattered knots of people who lounged round the flaring
+stalls, my companion speedily overtook the little man and touched him
+upon the shoulder. He sprang round, and I could see in the gaslight
+that every vestige of color had been driven from his face.
+
+“Who are you, then? What do you want?” he asked, in a quavering voice.
+
+“You will excuse me,” said Holmes, blandly, “but I could not help
+overhearing the questions which you put to the salesman just now. I
+think that I could be of assistance to you.”
+
+“You? Who are you? How could you know anything of the matter?”
+
+“My name is Sherlock Holmes. It is my business to know what other
+people don’t know.”
+
+“But you can know nothing of this?”
+
+“Excuse me, I know everything of it. You are endeavoring to trace some
+geese which were sold by Mrs. Oakshott, of Brixton Road, to a salesman
+named Breckinridge, by him in turn to Mr. Windigate, of the ‘Alpha,’
+and by him to his club, of which Mr. Henry Baker is a member.”
+
+“Oh, sir, you are the very man whom I have longed to meet,” cried the
+little fellow, with outstretched hands and quivering fingers. “I can
+hardly explain to you how interested I am in this matter.”
+
+Sherlock Holmes hailed a four-wheeler which was passing. “In that case
+we had better discuss it in a cosey room rather than in this windswept
+market-place,” said he. “But pray tell me, before we go farther, who it
+is that I have the pleasure of assisting.”
+
+The man hesitated for an instant. “My name is John Robinson,” he
+answered, with a sidelong glance.
+
+“No, no; the real name,” said Holmes, sweetly. “It is always awkward
+doing business with an _alias_.”
+
+A flush sprang to the white cheeks of the stranger. “Well, then,” said
+he, “my real name is James Ryder.”
+
+“Precisely so. Head attendant at the ‘Hotel Cosmopolitan.’ Pray step
+into the cab, and I shall soon be able to tell you everything which you
+would wish to know.”
+
+The little man stood glancing from one to the other of us with
+half-frightened, half-hopeful eyes, as one who is not sure whether he
+is on the verge of a windfall or of a catastrophe. Then he stepped into
+the cab, and in half an hour we were back in the sitting-room at Baker
+Street. Nothing had been said during our drive, but the high, thin
+breathing of our new companion, and the claspings and unclaspings of
+his hands, spoke of the nervous tension within him.
+
+“Here we are!” said Holmes, cheerily, as we filed into the room. “The
+fire looks very seasonable in this weather. You look cold, Mr. Ryder.
+Pray take the basket-chair. I will just put on my slippers before we
+settle this little matter of yours. Now, then! You want to know what
+became of those geese?”
+
+“Yes, sir.”
+
+“Or rather, I fancy, of that goose. It was one bird, I imagine, in
+which you were interested—white, with a black bar across the tail.”
+
+Ryder quivered with emotion. “Oh, sir,” he cried, “can you tell me
+where it went to?”
+
+“It came here.”
+
+“Here?”
+
+“Yes, and a most remarkable bird it proved. I don’t wonder that you
+should take an interest in it. It laid an egg after it was dead—the
+bonniest, brightest little blue egg that ever was seen. I have it here
+in my museum.”
+
+Our visitor staggered to his feet and clutched the mantel-piece with
+his right hand. Holmes unlocked his strong-box, and held up the blue
+carbuncle, which shone out like a star, with a cold, brilliant,
+many-pointed radiance. Ryder stood glaring with a drawn face, uncertain
+whether to claim or to disown it.
+
+“The game’s up, Ryder,” said Holmes, quietly. “Hold up, man, or you’ll
+be into the fire! Give him an arm back into his chair, Watson. He’s not
+got blood enough to go in for felony with impunity. Give him a dash of
+brandy. So! Now he looks a little more human. What a shrimp it is, to
+be sure!”
+
+For a moment he had staggered and nearly fallen, but the brandy brought
+a tinge of color into his cheeks, and he sat staring with frightened
+eyes at his accuser.
+
+“I have almost every link in my hands, and all the proofs which I could
+possibly need, so there is little which you need tell me. Still, that
+little may as well be cleared up to make the case complete. You had
+heard, Ryder, of this blue stone of the Countess of Morcar’s?”
+
+“It was Catherine Cusack who told me of it,” said he, in a crackling
+voice.
+
+“I see—her ladyship’s waiting-maid. Well, the temptation of sudden
+wealth so easily acquired was too much for you, as it has been for
+better men before you; but you were not very scrupulous in the means
+you used. It seems to me, Ryder, that there is the making of a very
+pretty villain in you. You knew that this man Horner, the plumber, had
+been concerned in some such matter before, and that suspicion would
+rest the more readily upon him. What did you do, then? You made some
+small job in my lady’s room—you and your confederate Cusack—and you
+managed that he should be the man sent for. Then, when he had left, you
+rifled the jewel-case, raised the alarm, and had this unfortunate man
+arrested. You then—”
+
+Ryder threw himself down suddenly upon the rug and clutched at my
+companion’s knees. “For God’s sake, have mercy!” he shrieked. “Think
+of my father! of my mother! It would break their hearts. I never went
+wrong before! I never will again. I swear it. I’ll swear it on a Bible.
+Oh, don’t bring it into court! For Christ’s sake, don’t!”
+
+“Get back into your chair!” said Holmes, sternly. “It is very well to
+cringe and crawl now, but you thought little enough of this poor Horner
+in the dock for a crime of which he knew nothing.”
+
+“I will fly, Mr. Holmes. I will leave the country, sir. Then the charge
+against him will break down.”
+
+“Hum! We will talk about that. And now let us hear a true account of
+the next act. How came the stone into the goose, and how came the goose
+into the open market? Tell us the truth, for there lies your only hope
+of safety.”
+
+[Illustration: “‘HAVE MERCY!’ HE SHRIEKED”]
+
+Ryder passed his tongue over his parched lips. “I will tell you it
+just as it happened, sir,” said he. “When Horner had been arrested, it
+seemed to me that it would be best for me to get away with the stone
+at once, for I did not know at what moment the police might not take
+it into their heads to search me and my room. There was no place about
+the hotel where it would be safe. I went out, as if on some commission,
+and I made for my sister’s house. She had married a man named Oakshott,
+and lived in Brixton Road, where she fattened fowls for the market.
+All the way there every man I met seemed to me to be a policeman or a
+detective; and, for all that it was a cold night, the sweat was pouring
+down my face before I came to the Brixton Road. My sister asked me what
+was the matter, and why I was so pale; but I told her that I had been
+upset by the jewel robbery at the hotel. Then I went into the back yard
+and smoked a pipe, and wondered what it would be best to do.
+
+“I had a friend once called Maudsley, who went to the bad, and has just
+been serving his time in Pentonville. One day he had met me, and fell
+into talk about the ways of thieves, and how they could get rid of what
+they stole. I knew that he would be true to me, for I knew one or two
+things about him; so I made up my mind to go right on to Kilburn, where
+he lived, and take him into my confidence. He would show me how to
+turn the stone into money. But how to get to him in safety? I thought
+of the agonies I had gone through in coming from the hotel. I might
+at any moment be seized and searched, and there would be the stone
+in my waistcoat pocket. I was leaning against the wall at the time,
+and looking at the geese which were waddling about round my feet, and
+suddenly an idea came into my head which showed me how I could beat the
+best detective that ever lived.
+
+“My sister had told me some weeks before that I might have the pick of
+her geese for a Christmas present, and I knew that she was always as
+good as her word. I would take my goose now, and in it I would carry
+my stone to Kilburn. There was a little shed in the yard, and behind
+this I drove one of the birds—a fine big one, white, with a barred
+tail. I caught it, and, prying its bill open, I thrust the stone down
+its throat as far as my finger could reach. The bird gave a gulp, and I
+felt the stone pass along its gullet and down into its crop. But the
+creature flapped and struggled, and out came my sister to know what
+was the matter. As I turned to speak to her the brute broke loose and
+fluttered off among the others.
+
+“‘Whatever were you doing with that bird, Jem?’ says she.
+
+“‘Well,’ said I, ‘you said you’d give me one for Christmas, and I was
+feeling which was the fattest.’
+
+“‘Oh,’ says she, ‘we’ve set yours aside for you—Jem’s bird, we call
+it. It’s the big white one over yonder. There’s twenty-six of them,
+which makes one for you, and one for us, and two dozen for the market.’
+
+“‘Thank you, Maggie,’ says I; ‘but if it is all the same to you, I’d
+rather have that one I was handling just now.’
+
+“‘The other is a good three pound heavier,’ said she, ‘and we fattened
+it expressly for you.’
+
+“‘Never mind. I’ll have the other, and I’ll take it now,’ said I.
+
+“‘Oh, just as you like,’ said she, a little huffed. ‘Which is it you
+want, then?’
+
+“‘That white one with the barred tail, right in the middle of the
+flock.’
+
+“‘Oh, very well. Kill it and take it with you.’
+
+“Well, I did what she said, Mr. Holmes, and I carried the bird all the
+way to Kilburn. I told my pal what I had done, for he was a man that
+it was easy to tell a thing like that to. He laughed until he choked,
+and we got a knife and opened the goose. My heart turned to water, for
+there was no sign of the stone, and I knew that some terrible mistake
+had occurred. I left the bird, rushed back to my sister’s, and hurried
+into the back yard. There was not a bird to be seen there.
+
+“‘Where are they all, Maggie?’ I cried.
+
+“‘Gone to the dealer’s, Jem.’
+
+“‘Which dealer’s?’
+
+“‘Breckinridge, of Covent Garden.’
+
+“‘But was there another with a barred tail?’ I asked, ‘the same as the
+one I chose?’
+
+“‘Yes, Jem; there were two barred-tailed ones, and I could never tell
+them apart.’
+
+“Well, then, of course I saw it all, and I ran off as hard as my feet
+would carry me to this man Breckinridge; but he had sold the lot at
+once, and not one word would he tell me as to where they had gone. You
+heard him yourselves to-night. Well, he has always answered me like
+that. My sister thinks that I am going mad. Sometimes I think that I
+am myself. And now—and now I am myself a branded thief, without ever
+having touched the wealth for which I sold my character. God help me!
+God help me!” He burst into convulsive sobbing, with his face buried in
+his hands.
+
+There was a long silence, broken only by his heavy breathing, and by
+the measured tapping of Sherlock Holmes’s finger-tips upon the edge of
+the table. Then my friend rose and threw open the door.
+
+“Get out!” said he.
+
+“What, sir! Oh, heaven bless you!”
+
+“No more words. Get out!”
+
+And no more words were needed. There was a rush, a clatter upon the
+stairs, the bang of a door, and the crisp rattle of running footfalls
+from the street.
+
+“After all, Watson,” said Holmes, reaching up his hand for his clay
+pipe, “I am not retained by the police to supply their deficiencies. If
+Horner were in danger it would be another thing; but this fellow will
+not appear against him, and the case must collapse. I suppose that I am
+commuting a felony, but it is just possible that I am saving a soul.
+This fellow will not go wrong again; he is too terribly frightened.
+Send him to jail now, and you make him a jail-bird for life. Besides,
+it is the season of forgiveness. Chance has put in our way a most
+singular and whimsical problem, and its solution is its own reward.
+If you will have the goodness to touch the bell, doctor, we will
+begin another investigation, in which, also, a bird will be the chief
+feature.”
+
+
+
+
+Adventure VIII
+
+THE ADVENTURE OF THE SPECKLED BAND
+
+
+On glancing over my notes of the seventy odd cases in which I have
+during the last eight years studied the methods of my friend Sherlock
+Holmes, I find many tragic, some comic, a large number merely strange,
+but none commonplace; for, working as he did rather for the love of his
+art than for the acquirement of wealth, he refused to associate himself
+with any investigation which did not tend towards the unusual, and even
+the fantastic. Of all these varied cases, however, I cannot recall any
+which presented more singular features than that which was associated
+with the well-known Surrey family of the Roylotts of Stoke Moran. The
+events in question occurred in the early days of my association with
+Holmes, when we were sharing rooms as bachelors in Baker Street. It
+is possible that I might have placed them upon record before, but a
+promise of secrecy was made at the time, from which I have only been
+freed during the last month by the untimely death of the lady to whom
+the pledge was given. It is perhaps as well that the facts should now
+come to light, for I have reasons to know that there are wide-spread
+rumors as to the death of Dr. Grimesby Roylott which tend to make the
+matter even more terrible than the truth.
+
+It was early in April in the year ’83 that I woke one morning to find
+Sherlock Holmes standing, fully dressed, by the side of my bed. He was
+a late riser as a rule, and as the clock on the mantel-piece showed
+me that it was only a quarter past seven, I blinked up at him in some
+surprise, and perhaps just a little resentment, for I was myself
+regular in my habits.
+
+“Very sorry to knock you up, Watson,” said he, “but it’s the common lot
+this morning. Mrs. Hudson has been knocked up, she retorted upon me,
+and I on you.”
+
+“What is it, then—a fire?”
+
+“No; a client. It seems that a young lady has arrived in a considerable
+state of excitement, who insists upon seeing me. She is waiting now in
+the sitting-room. Now, when young ladies wander about the metropolis
+at this hour of the morning, and knock sleepy people up out of their
+beds, I presume that it is something very pressing which they have to
+communicate. Should it prove to be an interesting case, you would, I am
+sure, wish to follow it from the outset. I thought, at any rate, that I
+should call you and give you the chance.”
+
+“My dear fellow, I would not miss it for anything.”
+
+I had no keener pleasure than in following Holmes in his professional
+investigations, and in admiring the rapid deductions, as swift as
+intuitions, and yet always founded on a logical basis, with which he
+unravelled the problems which were submitted to him. I rapidly threw on
+my clothes, and was ready in a few minutes to accompany my friend down
+to the sitting-room. A lady dressed in black and heavily veiled, who
+had been sitting in the window, rose as we entered.
+
+“Good-morning, madam,” said Holmes, cheerily. “My name is Sherlock
+Holmes. This is my intimate friend and associate, Dr. Watson, before
+whom you can speak as freely as before myself. Ha! I am glad to see
+that Mrs. Hudson has had the good sense to light the fire. Pray draw up
+to it, and I shall order you a cup of hot coffee, for I observe that
+you are shivering.”
+
+“It is not cold which makes me shiver,” said the woman, in a low voice,
+changing her seat as requested.
+
+“What, then?”
+
+“It is fear, Mr. Holmes. It is terror.” She raised her veil as she
+spoke, and we could see that she was indeed in a pitiable state of
+agitation, her face all drawn and gray, with restless, frightened eyes,
+like those of some hunted animal. Her features and figure were those of
+a woman of thirty, but her hair was shot with premature gray, and her
+expression was weary and haggard. Sherlock Holmes ran her over with one
+of his quick, all-comprehensive glances.
+
+“You must not fear,” said he, soothingly, bending forward and patting
+her forearm. “We shall soon set matters right, I have no doubt. You
+have come in by train this morning, I see.”
+
+“You know me, then?”
+
+“No, but I observe the second half of a return ticket in the palm of
+your left glove. You must have started early, and yet you had a good
+drive in a dog-cart, along heavy roads, before you reached the station.”
+
+The lady gave a violent start, and stared in bewilderment at my
+companion.
+
+“There is no mystery, my dear madam,” said he, smiling. “The left arm
+of your jacket is spattered with mud in no less than seven places. The
+marks are perfectly fresh. There is no vehicle save a dog-cart which
+throws up mud in that way, and then only when you sit on the left-hand
+side of the driver.”
+
+“Whatever your reasons may be, you are perfectly correct,” said she. “I
+started from home before six, reached Leatherhead at twenty past, and
+came in by the first train to Waterloo. Sir, I can stand this strain no
+longer; I shall go mad if it continues. I have no one to turn to—none,
+save only one, who cares for me, and he, poor fellow, can be of little
+aid. I have heard of you, Mr. Holmes; I have heard of you from Mrs.
+Farintosh, whom you helped in the hour of her sore need. It was from
+her that I had your address. Oh, sir, do you not think that you could
+help me, too, and at least throw a little light through the dense
+darkness which surrounds me? At present it is out of my power to reward
+you for your services, but in a month or six weeks I shall be married,
+with the control of my own income, and then at least you shall not
+find me ungrateful.”
+
+Holmes turned to his desk, and unlocking it, drew out a small
+case-book, which he consulted.
+
+“Farintosh,” said he. “Ah yes, I recall the case; it was concerned with
+an opal tiara. I think it was before your time, Watson. I can only say,
+madam, that I shall be happy to devote the same care to your case as
+I did to that of your friend. As to reward, my profession is its own
+reward; but you are at liberty to defray whatever expenses I may be put
+to, at the time which suits you best. And now I beg that you will lay
+before us everything that may help us in forming an opinion upon the
+matter.”
+
+“Alas!” replied our visitor, “the very horror of my situation lies
+in the fact that my fears are so vague, and my suspicions depend so
+entirely upon small points, which might seem trivial to another, that
+even he to whom of all others I have a right to look for help and
+advice looks upon all that I tell him about it as the fancies of a
+nervous woman. He does not say so, but I can read it from his soothing
+answers and averted eyes. But I have heard, Mr. Holmes, that you can
+see deeply into the manifold wickedness of the human heart. You may
+advise me how to walk amid the dangers which encompass me.”
+
+“I am all attention, madam.”
+
+“My name is Helen Stoner, and I am living with my step-father, who is
+the last survivor of one of the oldest Saxon families in England, the
+Roylotts of Stoke Moran, on the western border of Surrey.”
+
+Holmes nodded his head. “The name is familiar to me,” said he.
+
+“The family was at one time among the richest in England, and the
+estates extended over the borders into Berkshire in the north, and
+Hampshire in the west. In the last century, however, four successive
+heirs were of a dissolute and wasteful disposition, and the family
+ruin was eventually completed by a gambler in the days of the
+Regency. Nothing was left save a few acres of ground, and the
+two-hundred-year-old house, which is itself crushed under a heavy
+mortgage. The last squire dragged out his existence there, living
+the horrible life of an aristocratic pauper; but his only son, my
+step-father, seeing that he must adapt himself to the new conditions,
+obtained an advance from a relative, which enabled him to take a
+medical degree, and went out to Calcutta, where, by his professional
+skill and his force of character, he established a large practice.
+In a fit of anger, however, caused by some robberies which had been
+perpetrated in the house, he beat his native butler to death, and
+narrowly escaped a capital sentence. As it was, he suffered a long
+term of imprisonment, and afterwards returned to England a morose and
+disappointed man.
+
+“When Dr. Roylott was in India he married my mother, Mrs. Stoner, the
+young widow of Major-general Stoner, of the Bengal Artillery. My sister
+Julia and I were twins, and we were only two years old at the time of
+my mother’s re-marriage. She had a considerable sum of money—not less
+than £1000 a year—and this she bequeathed to Dr. Roylott entirely
+while we resided with him, with a provision that a certain annual sum
+should be allowed to each of us in the event of our marriage. Shortly
+after our return to England my mother died—she was killed eight years
+ago in a railway accident near Crewe. Dr. Roylott then abandoned his
+attempts to establish himself in practice in London, and took us to
+live with him in the old ancestral house at Stoke Moran. The money
+which my mother had left was enough for all our wants, and there seemed
+to be no obstacle to our happiness.
+
+“But a terrible change came over our step-father about this time.
+Instead of making friends and exchanging visits with our neighbors, who
+had at first been overjoyed to see a Roylott of Stoke Moran back in
+the old family seat, he shut himself up in his house, and seldom came
+out save to indulge in ferocious quarrels with whoever might cross his
+path. Violence of temper approaching to mania has been hereditary in
+the men of the family, and in my step-father’s case it had, I believe,
+been intensified by his long residence in the tropics. A series of
+disgraceful brawls took place, two of which ended in the police-court,
+until at last he became the terror of the village, and the folks
+would fly at his approach, for he is a man of immense strength, and
+absolutely uncontrollable in his anger.
+
+“Last week he hurled the local blacksmith over a parapet into a stream,
+and it was only by paying over all the money which I could gather
+together that I was able to avert another public exposure. He had no
+friends at all save the wandering gypsies, and he would give these
+vagabonds leave to encamp upon the few acres of bramble-covered land
+which represent the family estate, and would accept in return the
+hospitality of their tents, wandering away with them sometimes for
+weeks on end. He has a passion also for Indian animals, which are sent
+over to him by a correspondent, and he has at this moment a cheetah and
+a baboon, which wander freely over his grounds, and are feared by the
+villagers almost as much as their master.
+
+“You can imagine from what I say that my poor sister Julia and I had no
+great pleasure in our lives. No servant would stay with us, and for a
+long time we did all the work of the house. She was but thirty at the
+time of her death, and yet her hair had already begun to whiten, even
+as mine has.”
+
+“Your sister is dead, then?”
+
+“She died just two years ago, and it is of her death that I wish to
+speak to you. You can understand that, living the life which I have
+described, we were little likely to see anyone of our own age and
+position. We had, however, an aunt, my mother’s maiden sister, Miss
+Honoria Westphail, who lives near Harrow, and we were occasionally
+allowed to pay short visits at this lady’s house. Julia went there at
+Christmas two years ago, and met there a half-pay major of marines,
+to whom she became engaged. My step-father learned of the engagement
+when my sister returned, and offered no objection to the marriage; but
+within a fortnight of the day which had been fixed for the wedding, the
+terrible event occurred which has deprived me of my only companion.”
+
+Sherlock Holmes had been leaning back in his chair with his eyes closed
+and his head sunk in a cushion, but he half opened his lids now and
+glanced across at his visitor.
+
+“Pray be precise as to details,” said he.
+
+“It is easy for me to be so, for every event of that dreadful time is
+seared into my memory. The manor-house is, as I have already said, very
+old, and only one wing is now inhabited. The bedrooms in this wing are
+on the ground floor, the sitting-rooms being in the central block of
+the buildings. Of these bedrooms the first is Dr. Roylott’s, the second
+my sister’s, and the third my own. There is no communication between
+them, but they all open out into the same corridor. Do I make myself
+plain?”
+
+“Perfectly so.”
+
+“The windows of the three rooms open out upon the lawn. That fatal
+night Dr. Roylott had gone to his room early, though we knew that he
+had not retired to rest, for my sister was troubled by the smell of
+the strong Indian cigars which it was his custom to smoke. She left
+her room, therefore, and came into mine, where she sat for some time,
+chatting about her approaching wedding. At eleven o’clock she rose to
+leave me but she paused at the door and looked back.
+
+“‘Tell me, Helen,’ said she, ‘have you ever heard any one whistle in
+the dead of the night?’
+
+“‘Never,’ said I.
+
+“‘I suppose that you could not possibly whistle, yourself, in your
+sleep?’
+
+“‘Certainly not. But why?’
+
+“‘Because during the last few nights I have always, about three in
+the morning, heard a low, clear whistle. I am a light sleeper, and it
+has awakened me. I cannot tell where it came from—perhaps from the
+next room, perhaps from the lawn. I thought that I would just ask you
+whether you had heard it.’
+
+“‘No, I have not. It must be those wretched gypsies in the plantation.’
+
+“‘Very likely. And yet if it were on the lawn, I wonder that you did
+not hear it also.’
+
+“‘Ah, but I sleep more heavily than you.’
+
+“‘Well, it is of no great consequence, at any rate.’ She smiled back at
+me, closed my door, and a few moments later I heard her key turn in the
+lock.”
+
+“Indeed,” said Holmes. “Was it your custom always to lock yourselves in
+at night?”
+
+“Always.”
+
+“And why?”
+
+“I think that I mentioned to you that the doctor kept a cheetah and a
+baboon. We had no feeling of security unless our doors were locked.”
+
+“Quite so. Pray proceed with your statement.”
+
+“I could not sleep that night. A vague feeling of impending misfortune
+impressed me. My sister and I, you will recollect, were twins, and you
+know how subtle are the links which bind two souls which are so closely
+allied. It was a wild night. The wind was howling outside, and the rain
+was beating and splashing against the windows. Suddenly, amid all the
+hubbub of the gale, there burst forth the wild scream of a terrified
+woman. I knew that it was my sister’s voice. I sprang from my bed,
+wrapped a shawl round me, and rushed into the corridor. As I opened my
+door I seemed to hear a low whistle, such as my sister described, and a
+few moments later a clanging sound, as if a mass of metal had fallen.
+As I ran down the passage, my sister’s door was unlocked, and revolved
+slowly upon its hinges. I stared at it horror-stricken, not knowing
+what was about to issue from it. By the light of the corridor-lamp I
+saw my sister appear at the opening, her face blanched with terror, her
+hands groping for help, her whole figure swaying to and fro like that
+of a drunkard. I ran to her and threw my arms round her, but at that
+moment her knees seemed to give way and she fell to the ground. She
+writhed as one who is in terrible pain, and her limbs were dreadfully
+convulsed. At first I thought that she had not recognized me, but as I
+bent over her she suddenly shrieked out in a voice which I shall never
+forget, ‘Oh, my God! Helen! It was the band! The speckled band!’ There
+was something else which she would fain have said, and she stabbed with
+her finger into the air in the direction of the doctor’s room, but a
+fresh convulsion seized her and choked her words. I rushed out, calling
+loudly for my step-father, and I met him hastening from his room in his
+dressing-gown. When he reached my sister’s side she was unconscious,
+and though he poured brandy down her throat and sent for medical aid
+from the village, all efforts were in vain, for she slowly sank and
+died without having recovered her consciousness. Such was the dreadful
+end of my beloved sister.”
+
+“One moment,” said Holmes; “are you sure about this whistle and
+metallic sound? Could you swear to it?”
+
+“That was what the county coroner asked me at the inquiry. It is my
+strong impression that I heard it, and yet, among the crash of the gale
+and the creaking of an old house, I may possibly have been deceived.”
+
+“Was your sister dressed?”
+
+“No, she was in her night-dress. In her right hand was found the
+charred stump of a match, and in her left a matchbox.”
+
+“Showing that she had struck a light and looked about her when the
+alarm took place. That is important. And what conclusions did the
+coroner come to?”
+
+“He investigated the case with great care, for Dr. Roylott’s conduct
+had long been notorious in the county, but he was unable to find any
+satisfactory cause of death. My evidence showed that the door had
+been fastened upon the inner side, and the windows were blocked by
+old-fashioned shutters with broad iron bars, which were secured every
+night. The walls were carefully sounded, and were shown to be quite
+solid all round, and the flooring was also thoroughly examined, with
+the same result. The chimney is wide, but is barred up by four large
+staples. It is certain, therefore, that my sister was quite alone when
+she met her end. Besides, there were no marks of any violence upon her.”
+
+“How about poison?”
+
+“The doctors examined her for it, but without success.”
+
+“What do you think that this unfortunate lady died of, then?”
+
+“It is my belief that she died of pure fear and nervous shock, though
+what it was that frightened her I cannot imagine.”
+
+“Were there gypsies in the plantation at the time?”
+
+“Yes, there are nearly always some there.”
+
+“Ah, and what did you gather from this allusion to a band—a speckled
+band?”
+
+“Sometimes I have thought that it was merely the wild talk of delirium,
+sometimes that it may have referred to some band of people, perhaps to
+these very gypsies in the plantation. I do not know whether the spotted
+handkerchiefs which so many of them wear over their heads might have
+suggested the strange adjective which she used.”
+
+Holmes shook his head like a man who is far from being satisfied.
+
+“These are very deep waters,” said he; “pray go on with your narrative.”
+
+“Two years have passed since then, and my life has been until lately
+lonelier than ever. A month ago, however, a dear friend, whom I have
+known for many years, has done me the honor to ask my hand in marriage.
+His name is Armitage—Percy Armitage—the second son of Mr. Armitage,
+of Crane Water, near Reading. My step-father has offered no opposition
+to the match, and we are to be married in the course of the spring. Two
+days ago some repairs were started in the west wing of the building,
+and my bedroom wall has been pierced, so that I have had to move into
+the chamber in which my sister died, and to sleep in the very bed in
+which she slept. Imagine, then, my thrill of terror when last night,
+as I lay awake, thinking over her terrible fate, I suddenly heard in
+the silence of the night the low whistle which had been the herald of
+her own death. I sprang up and lit the lamp, but nothing was to be
+seen in the room. I was too shaken to go to bed again, however, so I
+dressed, and as soon as it was daylight I slipped down, got a dog-cart
+at the ‘Crown Inn,’ which is opposite, and drove to Leatherhead, from
+whence I have come on this morning with the one object of seeing you
+and asking your advice.”
+
+“You have done wisely,” said my friend. “But have you told me all?”
+
+“Yes, all.”
+
+“Miss Roylott, you have not. You are screening your step-father.”
+
+“Why, what do you mean?”
+
+For answer Holmes pushed back the frill of black lace which fringed the
+hand that lay upon our visitor’s knee. Five little livid spots, the
+marks of four fingers and a thumb, were printed upon the white wrist.
+
+“You have been cruelly used,” said Holmes.
+
+The lady colored deeply and covered over her injured wrist. “He is a
+hard man,” she said, “and perhaps he hardly knows his own strength.”
+
+There was a long silence, during which Holmes leaned his chin upon his
+hands and stared into the crackling fire.
+
+“This is a very deep business,” he said, at last. “There are a thousand
+details which I should desire to know before I decide upon our course
+of action. Yet we have not a moment to lose. If we were to come to
+Stoke Moran to-day, would it be possible for us to see over these rooms
+without the knowledge of your step-father?”
+
+“As it happens, he spoke of coming into town to-day upon some most
+important business. It is probable that he will be away all day, and
+that there would be nothing to disturb you. We have a house-keeper
+now, but she is old and foolish, and I could easily get her out of the
+way.”
+
+“Excellent. You are not averse to this trip, Watson?”
+
+“By no means.”
+
+“Then we shall both come. What are you going to do yourself?”
+
+“I have one or two things which I would wish to do now that I am in
+town. But I shall return by the twelve o’clock train, so as to be there
+in time for your coming.”
+
+“And you may expect us early in the afternoon. I have myself some small
+business matters to attend to. Will you not wait and breakfast?”
+
+“No, I must go. My heart is lightened already since I have confided
+my trouble to you. I shall look forward to seeing you again this
+afternoon.” She dropped her thick black veil over her face and glided
+from the room.
+
+“And what do you think of it all, Watson?” asked Sherlock Holmes,
+leaning back in his chair.
+
+“It seems to me to be a most dark and sinister business.”
+
+“Dark enough and sinister enough.”
+
+“Yet if the lady is correct in saying that the flooring and walls are
+sound, and that the door, window, and chimney are impassable, then her
+sister must have been undoubtedly alone when she met her mysterious
+end.”
+
+“What becomes, then, of these nocturnal whistles, and what of the very
+peculiar words of the dying woman?”
+
+“I cannot think.”
+
+“When you combine the ideas of whistles at night, the presence of a
+band of gypsies who are on intimate terms with this old doctor, the
+fact that we have every reason to believe that the doctor has an
+interest in preventing his step-daughter’s marriage, the dying allusion
+to a band, and, finally, the fact that Miss Helen Stoner heard a
+metallic clang, which might have been caused by one of those metal bars
+which secured the shutters falling back into their place, I think that
+there is good ground to think that the mystery may be cleared along
+those lines.”
+
+“But what, then, did the gypsies do?”
+
+“I cannot imagine.”
+
+“I see many objections to any such theory.”
+
+“And so do I. It is precisely for that reason that we are going to
+Stoke Moran this day. I want to see whether the objections are fatal,
+or if they may be explained away. But what in the name of the devil!”
+
+The ejaculation had been drawn from my companion by the fact that our
+door had been suddenly dashed open, and that a huge man had framed
+himself in the aperture. His costume was a peculiar mixture of the
+professional and of the agricultural, having a black top-hat, a long
+frock-coat, and a pair of high gaiters, with a hunting-crop swinging in
+his hand. So tall was he that his hat actually brushed the cross bar
+of the doorway, and his breadth seemed to span it across from side to
+side. A large face, seared with a thousand wrinkles, burned yellow with
+the sun, and marked with every evil passion, was turned from one to the
+other of us, while his deep-set, bile-shot eyes, and his high, thin,
+fleshless nose, gave him somewhat the resemblance to a fierce old bird
+of prey.
+
+“Which of you is Holmes?” asked this apparition.
+
+“My name, sir; but you have the advantage of me,” said my companion,
+quietly.
+
+“I am Dr. Grimesby Roylott, of Stoke Moran.”
+
+“Indeed, doctor,” said Holmes, blandly. “Pray take a seat.”
+
+“I will do nothing of the kind. My step-daughter has been here. I have
+traced her. What has she been saying to you?”
+
+“It is a little cold for the time of the year,” said Holmes.
+
+“What has she been saying to you?” screamed the old man, furiously.
+
+“But I have heard that the crocuses promise well,” continued my
+companion, imperturbably.
+
+“Ha! You put me off, do you?” said our new visitor, taking a step
+forward and shaking his hunting-crop. “I know you, you scoundrel! I
+have heard of you before. You are Holmes, the meddler.”
+
+My friend smiled.
+
+“Holmes, the busybody!”
+
+His smile broadened.
+
+“Holmes, the Scotland-yard Jack-in-office!”
+
+Holmes chuckled heartily. “Your conversation is most entertaining,”
+said he. “When you go out close the door, for there is a decided
+draught.”
+
+“I will go when I have said my say. Don’t you dare to meddle with my
+affairs. I know that Miss Stoner has been here. I traced her! I am a
+dangerous man to fall foul of! See here.” He stepped swiftly forward,
+seized the poker, and bent it into a curve with his huge brown hands.
+
+“See that you keep yourself out of my grip,” he snarled, and hurling
+the twisted poker into the fireplace, he strode out of the room.
+
+“He seems a very amiable person,” said Holmes, laughing. “I am not
+quite so bulky, but if he had remained I might have shown him that my
+grip was not much more feeble than his own.” As he spoke he picked up
+the steel poker, and with a sudden effort straightened it out again.
+
+“Fancy his having the insolence to confound me with the official
+detective force! This incident gives zest to our investigation,
+however, and I only trust that our little friend will not suffer from
+her imprudence in allowing this brute to trace her. And now, Watson,
+we shall order breakfast, and afterwards I shall walk down to Doctors’
+Commons, where I hope to get some data which may help us in this
+matter.”
+
+       *       *       *       *       *
+
+It was nearly one o’clock when Sherlock Holmes returned from his
+excursion. He held in his hand a sheet of blue paper, scrawled over
+with notes and figures.
+
+“I have seen the will of the deceased wife,” said he. “To determine
+its exact meaning I have been obliged to work out the present prices
+of the investments with which it is concerned. The total income, which
+at the time of the wife’s death was little short of £1100, is now,
+through the fall in agricultural prices, not more than £750. Each
+daughter can claim an income of £250, in case of marriage. It is
+evident, therefore, that if both girls had married, this beauty would
+have had a mere pittance, while even one of them would cripple him to
+a very serious extent. My morning’s work has not been wasted, since it
+has proved that he has the very strongest motives for standing in the
+way of anything of the sort. And now, Watson, this is too serious for
+dawdling, especially as the old man is aware that we are interesting
+ourselves in his affairs; so if you are ready, we shall call a cab and
+drive to Waterloo. I should be very much obliged if you would slip your
+revolver into your pocket. An Eley’s No. 2 is an excellent argument
+with gentlemen who can twist steel pokers into knots. That and a
+tooth-brush are, I think, all that we need.”
+
+At Waterloo we were fortunate in catching a train for Leatherhead,
+where we hired a trap at the station inn, and drove for four or five
+miles through the lovely Surrey lanes. It was a perfect day, with
+a bright sun and a few fleecy clouds in the heavens. The trees and
+way-side hedges were just throwing out their first green shoots, and
+the air was full of the pleasant smell of the moist earth. To me at
+least there was a strange contrast between the sweet promise of the
+spring and this sinister quest upon which we were engaged. My companion
+sat in the front of the trap, his arms folded, his hat pulled down over
+his eyes, and his chin sunk upon his breast, buried in the deepest
+thought. Suddenly, however, he started, tapped me on the shoulder, and
+pointed over the meadows.
+
+“Look there!” said he.
+
+A heavily-timbered park stretched up in a gentle slope, thickening into
+a grove at the highest point. From amid the branches there jutted out
+the gray gables and high roof-tree of a very old mansion.
+
+“Stoke Moran?” said he.
+
+“Yes, sir, that be the house of Dr. Grimesby Roylott,” remarked the
+driver.
+
+“There is some building going on there,” said Holmes; “that is where we
+are going.”
+
+“There’s the village,” said the driver, pointing to a cluster of roofs
+some distance to the left; “but if you want to get to the house, you’ll
+find it shorter to get over this stile, and so by the foot-path over
+the fields. There it is, where the lady is walking.”
+
+“And the lady, I fancy, is Miss Stoner,” observed Holmes, shading his
+eyes. “Yes, I think we had better do as you suggest.”
+
+We got off, paid our fare, and the trap rattled back on its way to
+Leatherhead.
+
+“I thought it as well,” said Holmes, as we climbed the stile, “that
+this fellow should think we had come here as architects, or on some
+definite business. It may stop his gossip. Good-afternoon, Miss Stoner.
+You see that we have been as good as our word.”
+
+Our client of the morning had hurried forward to meet us with a face
+which spoke her joy. “I have been waiting so eagerly for you,” she
+cried, shaking hands with us warmly. “All has turned out splendidly.
+Dr. Roylott has gone to town, and it is unlikely that he will be back
+before evening.”
+
+“We have had the pleasure of making the doctor’s acquaintance,” said
+Holmes, and in a few words he sketched out what had occurred. Miss
+Stoner turned white to the lips as she listened.
+
+“Good heavens!” she cried, “he has followed me, then.”
+
+“So it appears.”
+
+“He is so cunning that I never know when I am safe from him. What will
+he say when he returns?”
+
+“He must guard himself, for he may find that there is some one more
+cunning than himself upon his track. You must lock yourself up from him
+to-night. If he is violent, we shall take you away to your aunt’s at
+Harrow. Now, we must make the best use of our time, so kindly take us
+at once to the rooms which we are to examine.”
+
+The building was of gray, lichen-blotched stone, with a high central
+portion, and two curving wings, like the claws of a crab, thrown out
+on each side. In one of these wings the windows were broken, and
+blocked with wooden boards, while the roof was partly caved in, a
+picture of ruin. The central portion was in little better repair, but
+the right-hand block was comparatively modern, and the blinds in the
+windows, with the blue smoke curling up from the chimneys, showed that
+this was where the family resided. Some scaffolding had been erected
+against the end wall, and the stone-work had been broken into, but
+there were no signs of any workmen at the moment of our visit. Holmes
+walked slowly up and down the ill-trimmed lawn, and examined with deep
+attention the outsides of the windows.
+
+“This, I take it, belongs to the room in which you used to sleep, the
+centre one to your sister’s, and the one next to the main building to
+Dr. Roylott’s chamber?”
+
+“Exactly so. But I am now sleeping in the middle one.”
+
+“Pending the alterations, as I understand. By-the-way, there does not
+seem to be any very pressing need for repairs at that end wall.”
+
+“There were none. I believe that it was an excuse to move me from my
+room.”
+
+“Ah! that is suggestive. Now, on the other side of this narrow wing
+runs the corridor from which these three rooms open. There are windows
+in it, of course?”
+
+“Yes, but very small ones. Too narrow for any one to pass through.”
+
+“As you both locked your doors at night, your rooms were unapproachable
+from that side. Now, would you have the kindness to go into your room
+and bar your shutters.”
+
+Miss Stoner did so, and Holmes, after a careful examination through
+the open window, endeavored in every way to force the shutter open,
+but without success. There was no slit through which a knife could be
+passed to raise the bar. Then with his lens he tested the hinges, but
+they were of solid iron, built firmly into the massive masonry. “Hum!”
+said he, scratching his chin in some perplexity; “my theory certainly
+presents some difficulties. No one could pass these shutters if they
+were bolted. Well, we shall see if the inside throws any light upon the
+matter.”
+
+A small side door led into the whitewashed corridor from which the
+three bedrooms opened. Holmes refused to examine the third chamber,
+so we passed at once to the second, that in which Miss Stoner was now
+sleeping, and in which her sister had met with her fate. It was a
+homely little room, with a low ceiling and a gaping fireplace, after
+the fashion of old country-houses. A brown chest of drawers stood
+in one corner, a narrow white-counterpaned bed in another, and a
+dressing-table on the left-hand side of the window. These articles,
+with two small wicker-work chairs, made up all the furniture in the
+room, save for a square of Wilton carpet in the centre. The boards
+round and the panelling of the walls were of brown, worm-eaten oak, so
+old and discolored that it may have dated from the original building of
+the house. Holmes drew one of the chairs into a corner and sat silent,
+while his eyes travelled round and round and up and down, taking in
+every detail of the apartment.
+
+“Where does that bell communicate with?” he asked, at last, pointing to
+a thick bell-rope which hung down beside the bed, the tassel actually
+lying upon the pillow.
+
+“It goes to the house-keeper’s room.”
+
+“It looks newer than the other things?”
+
+“Yes, it was only put there a couple of years ago.”
+
+“Your sister asked for it, I suppose?”
+
+“No, I never heard of her using it. We used always to get what we
+wanted for ourselves.”
+
+“Indeed, it seemed unnecessary to put so nice a bell-pull there. You
+will excuse me for a few minutes while I satisfy myself as to this
+floor.” He threw himself down upon his face with his lens in his hand,
+and crawled swiftly backward and forward, examining minutely the cracks
+between the boards. Then he did the same with the wood-work with which
+the chamber was panelled. Finally he walked over to the bed, and spent
+some time in staring at it, and in running his eye up and down the
+wall. Finally he took the bell-rope in his hand and gave it a brisk tug.
+
+“Why, it’s a dummy,” said he.
+
+“Won’t it ring?”
+
+“No, it is not even attached to a wire. This is very interesting. You
+can see now that it is fastened to a hook just above where the little
+opening for the ventilator is.”
+
+“How very absurd! I never noticed that before.”
+
+“Very strange!” muttered Holmes, pulling at the rope. “There are one or
+two very singular points about this room. For example, what a fool a
+builder must be to open a ventilator into another room, when, with the
+same trouble, he might have communicated with the outside air!”
+
+“That is also quite modern,” said the lady.
+
+“Done about the same time as the bell-rope?” remarked Holmes.
+
+“Yes, there were several little changes carried out about that time.”
+
+“They seem to have been of a most interesting character—dummy
+bell-ropes, and ventilators which do not ventilate. With your
+permission, Miss Stoner, we shall now carry our researches into the
+inner apartment.”
+
+Dr. Grimesby Roylott’s chamber was larger than that of his
+step-daughter, but was as plainly furnished. A camp-bed, a small wooden
+shelf full of books, mostly of a technical character, an arm-chair
+beside the bed, a plain wooden chair against the wall, a round table,
+and a large iron safe were the principal things which met the eye.
+Holmes walked slowly round and examined each and all of them with the
+keenest interest.
+
+“What’s in here?” he asked, tapping the safe.
+
+“My step-father’s business papers.”
+
+“Oh! you have seen inside, then?”
+
+“Only once, some years ago. I remember that it was full of papers.”
+
+“There isn’t a cat in it, for example?”
+
+“No. What a strange idea!”
+
+“Well, look at this!” He took up a small saucer of milk which stood on
+the top of it.
+
+“No; we don’t keep a cat. But there is a cheetah and a baboon.”
+
+“Ah, yes, of course! Well, a cheetah is just a big cat, and yet a
+saucer of milk does not go very far in satisfying its wants, I dare
+say. There is one point which I should wish to determine.” He squatted
+down in front of the wooden chair, and examined the seat of it with the
+greatest attention.
+
+“Thank you. That is quite settled,” said he, rising and putting his
+lens in his pocket. “Hello! Here is something interesting!”
+
+The object which had caught his eye was a small dog-lash hung on one
+corner of the bed. The lash, however, was curled upon itself, and tied
+so as to make a loop of whip-cord.
+
+“What do you make of that, Watson?”
+
+“It’s a common enough lash. But I don’t know why it should be tied.”
+
+“That is not quite so common, is it? Ah, me! it’s a wicked world,
+and when a clever man turns his brains to crime it is the worst of
+all. I think that I have seen enough now, Miss Stoner, and with your
+permission we shall walk out upon the lawn.”
+
+I had never seen my friend’s face so grim or his brow so dark as it
+was when we turned from the scene of this investigation. We had walked
+several times up and down the lawn, neither Miss Stoner nor myself
+liking to break in upon his thoughts before he roused himself from his
+reverie.
+
+“It is very essential, Miss Stoner,” said he, “that you should
+absolutely follow my advice in every respect.”
+
+“I shall most certainly do so.”
+
+“The matter is too serious for any hesitation. Your life may depend
+upon your compliance.”
+
+“I assure you that I am in your hands.”
+
+“In the first place, both my friend and I must spend the night in your
+room.”
+
+Both Miss Stoner and I gazed at him in astonishment.
+
+“Yes, it must be so. Let me explain. I believe that that is the village
+inn over there?”
+
+“Yes, that is the ‘Crown.’”
+
+“Very good. Your windows would be visible from there?”
+
+“Certainly.”
+
+“You must confine yourself to your room, on pretence of a headache,
+when your step-father comes back. Then when you hear him retire for
+the night, you must open the shutters of your window, undo the hasp,
+put your lamp there as a signal to us, and then withdraw quietly with
+everything which you are likely to want into the room which you used to
+occupy. I have no doubt that, in spite of the repairs, you could manage
+there for one night.”
+
+“Oh yes, easily.”
+
+“The rest you will leave in our hands.”
+
+“But what will you do?”
+
+“We shall spend the night in your room, and we shall investigate the
+cause of this noise which has disturbed you.”
+
+“I believe, Mr. Holmes, that you have already made up your mind,” said
+Miss Stoner, laying her hand upon my companion’s sleeve.
+
+“Perhaps I have.”
+
+“Then for pity’s sake tell me what was the cause of my sister’s death.”
+
+“I should prefer to have clearer proofs before I speak.”
+
+“You can at least tell me whether my own thought is correct, and if she
+died from some sudden fright.”
+
+[Illustration: “‘GOOD-BYE, AND BE BRAVE’”]
+
+“No, I do not think so. I think that there was probably some more
+tangible cause. And now, Miss Stoner, we must leave you, for if Dr.
+Roylott returned and saw us, our journey would be in vain. Good-bye,
+and be brave, for if you will do what I have told you, you may rest
+assured that we shall soon drive away the dangers that threaten you.”
+
+Sherlock Holmes and I had no difficulty in engaging a bedroom and
+sitting-room at the “Crown Inn.” They were on the upper floor, and
+from our window we could command a view of the avenue gate, and of the
+inhabited wing of Stoke Moran Manor House. At dusk we saw Dr. Grimesby
+Roylott drive past, his huge form looming up beside the little figure
+of the lad who drove him. The boy had some slight difficulty in undoing
+the heavy iron gates, and we heard the hoarse roar of the doctor’s
+voice, and saw the fury with which he shook his clinched fists at him.
+The trap drove on, and a few minutes later we saw a sudden light spring
+up among the trees as the lamp was lit in one of the sitting-rooms.
+
+“Do you know, Watson,” said Holmes, as we sat together in the gathering
+darkness, “I have really some scruples as to taking you to-night. There
+is a distinct element of danger.”
+
+“Can I be of assistance?”
+
+“Your presence might be invaluable.”
+
+“Then I shall certainly come.”
+
+“It is very kind of you.”
+
+“You speak of danger. You have evidently seen more in these rooms than
+was visible to me.”
+
+“No, but I fancy that I may have deduced a little more. I imagine that
+you saw all that I did.”
+
+“I saw nothing remarkable save the bell-rope, and what purpose that
+could answer I confess is more than I can imagine.”
+
+“You saw the ventilator, too?”
+
+“Yes, but I do not think that it is such a very unusual thing to have
+a small opening between two rooms. It was so small that a rat could
+hardly pass through.”
+
+“I knew that we should find a ventilator before ever we came to Stoke
+Moran.”
+
+“My dear Holmes!”
+
+“Oh yes, I did. You remember in her statement she said that her sister
+could smell Dr. Roylott’s cigar. Now, of course that suggested at once
+that there must be a communication between the two rooms. It could only
+be a small one, or it would have been remarked upon at the coroner’s
+inquiry. I deduced a ventilator.”
+
+“But what harm can there be in that?”
+
+“Well, there is at least a curious coincidence of dates. A ventilator
+is made, a cord is hung, and a lady who sleeps in the bed dies. Does
+not that strike you?”
+
+“I cannot as yet see any connection.”
+
+“Did you observe anything very peculiar about that bed?”
+
+“No.”
+
+“It was clamped to the floor. Did you ever see a bed fastened like that
+before?”
+
+“I cannot say that I have.”
+
+“The lady could not move her bed. It must always be in the same
+relative position to the ventilator and to the rope—for so we may call
+it, since it was clearly never meant for a bell-pull.”
+
+“Holmes,” I cried, “I seem to see dimly what you are hinting at. We are
+only just in time to prevent some subtle and horrible crime.”
+
+“Subtle enough and horrible enough. When a doctor does go wrong, he is
+the first of criminals. He has nerve and he has knowledge. Palmer and
+Pritchard were among the heads of their profession. This man strikes
+even deeper, but I think, Watson, that we shall be able to strike
+deeper still. But we shall have horrors enough before the night is
+over; for goodness’ sake let us have a quiet pipe, and turn our minds
+for a few hours to something more cheerful.”
+
+       *       *       *       *       *
+
+About nine o’clock the light among the trees was extinguished, and all
+was dark in the direction of the Manor House. Two hours passed slowly
+away, and then, suddenly, just at the stroke of eleven, a single
+bright light shone out right in front of us.
+
+“That is our signal,” said Holmes, springing to his feet; “it comes
+from the middle window.”
+
+As we passed out he exchanged a few words with the landlord, explaining
+that we were going on a late visit to an acquaintance, and that it was
+possible that we might spend the night there. A moment later we were
+out on the dark road, a chill wind blowing in our faces, and one yellow
+light twinkling in front of us through the gloom to guide us on our
+sombre errand.
+
+There was little difficulty in entering the grounds, for unrepaired
+breaches gaped in the old park wall. Making our way among the trees,
+we reached the lawn, crossed it, and were about to enter through the
+window, when out from a clump of laurel bushes there darted what seemed
+to be a hideous and distorted child, who threw itself upon the grass
+with writhing limbs, and then ran swiftly across the lawn into the
+darkness.
+
+“My God!” I whispered; “did you see it?”
+
+Holmes was for the moment as startled as I. His hand closed like a vice
+upon my wrist in his agitation. Then he broke into a low laugh, and put
+his lips to my ear.
+
+“It is a nice household,” he murmured. “That is the baboon.”
+
+I had forgotten the strange pets which the doctor affected. There was
+a cheetah, too; perhaps we might find it upon our shoulders at any
+moment. I confess that I felt easier in my mind when, after following
+Holmes’s example and slipping off my shoes, I found myself inside the
+bedroom. My companion noiselessly closed the shutters, moved the lamp
+onto the table, and cast his eyes round the room. All was as we had
+seen it in the daytime. Then creeping up to me and making a trumpet of
+his hand, he whispered into my ear again so gently that it was all that
+I could do to distinguish the words:
+
+“The least sound would be fatal to our plans.”
+
+I nodded to show that I had heard.
+
+“We must sit without light. He would see it through the ventilator.”
+
+I nodded again.
+
+“Do not go asleep; your very life may depend upon it. Have your pistol
+ready in case we should need it. I will sit on the side of the bed, and
+you in that chair.”
+
+I took out my revolver and laid it on the corner of the table.
+
+Holmes had brought up a long thin cane, and this he placed upon the bed
+beside him. By it he laid the box of matches and the stump of a candle.
+Then he turned down the lamp, and we were left in darkness.
+
+How shall I ever forget that dreadful vigil? I could not hear a sound,
+not even the drawing of a breath, and yet I knew that my companion
+sat open-eyed, within a few feet of me, in the same state of nervous
+tension in which I was myself. The shutters cut off the least ray
+of light, and we waited in absolute darkness. From outside came the
+occasional cry of a night-bird, and once at our very window a long
+drawn cat-like whine, which told us that the cheetah was indeed at
+liberty. Far away we could hear the deep tones of the parish clock,
+which boomed out every quarter of an hour. How long they seemed, those
+quarters! Twelve struck, and one and two and three, and still we sat
+waiting silently for whatever might befall.
+
+Suddenly there was the momentary gleam of a light up in the direction
+of the ventilator, which vanished immediately, but was succeeded by
+a strong smell of burning oil and heated metal. Some one in the next
+room had lit a dark-lantern. I heard a gentle sound of movement, and
+then all was silent once more, though the smell grew stronger. For half
+an hour I sat with straining ears. Then suddenly another sound became
+audible—a very gentle, soothing sound, like that of a small jet of
+steam escaping continually from a kettle. The instant that we heard it,
+Holmes sprang from the bed, struck a match, and lashed furiously with
+his cane at the bell-pull.
+
+“You see it, Watson?” he yelled. “You see it?”
+
+But I saw nothing. At the moment when Holmes struck the light I heard
+a low, clear whistle, but the sudden glare flashing into my weary eyes
+made it impossible for me to tell what it was at which my friend lashed
+so savagely. I could, however, see that his face was deadly pale, and
+filled with horror and loathing.
+
+He had ceased to strike, and was gazing up at the ventilator, when
+suddenly there broke from the silence of the night the most horrible
+cry to which I have ever listened. It swelled up louder and louder, a
+hoarse yell of pain and fear and anger all mingled in the one dreadful
+shriek. They say that away down in the village, and even in the distant
+parsonage, that cry raised the sleepers from their beds. It struck cold
+to our hearts, and I stood gazing at Holmes, and he at me, until the
+last echoes of it had died away into the silence from which it rose.
+
+“What can it mean?” I gasped.
+
+“It means that it is all over,” Holmes answered. “And perhaps, after
+all, it is for the best. Take your pistol, and we will enter Dr.
+Roylott’s room.”
+
+With a grave face he lit the lamp and led the way down the corridor.
+Twice he struck at the chamber door without any reply from within.
+Then he turned the handle and entered, I at his heels, with the cocked
+pistol in my hand.
+
+It was a singular sight which met our eyes. On the table stood a
+dark-lantern with the shutter half open, throwing a brilliant beam
+of light upon the iron safe, the door of which was ajar. Beside this
+table, on the wooden chair, sat Dr. Grimesby Roylott, clad in a long
+gray dressing-gown, his bare ankles protruding beneath, and his feet
+thrust into red heelless Turkish slippers. Across his lap lay the short
+stock with the long lash which we had noticed during the day. His chin
+was cocked upward and his eyes were fixed in a dreadful, rigid stare
+at the corner of the ceiling. Round his brow he had a peculiar yellow
+band, with brownish speckles, which seemed to be bound tightly round
+his head. As we entered he made neither sound nor motion.
+
+“The band! the speckled band!” whispered Holmes.
+
+I took a step forward. In an instant his strange head-gear began
+to move, and there reared itself from among his hair the squat
+diamond-shaped head and puffed neck of a loathsome serpent.
+
+“It is a swamp adder!” cried Holmes; “the deadliest snake in India. He
+has died within ten seconds of being bitten. Violence does, in truth,
+recoil upon the violent, and the schemer falls into the pit which he
+digs for another. Let us thrust this creature back into its den, and
+we can then remove Miss Stoner to some place of shelter, and let the
+county police know what has happened.”
+
+As he spoke he drew the dog-whip swiftly from the dead man’s lap, and
+throwing the noose round the reptile’s neck, he drew it from its horrid
+perch, and carrying it at arm’s length, threw it into the iron safe,
+which he closed upon it.
+
+       *       *       *       *       *
+
+Such are the true facts of the death of Dr. Grimesby Roylott, of Stoke
+Moran. It is not necessary that I should prolong a narrative which has
+already run to too great a length, by telling how we broke the sad news
+to the terrified girl, how we conveyed her by the morning train to the
+care of her good aunt at Harrow, of how the slow process of official
+inquiry came to the conclusion that the doctor met his fate while
+indiscreetly playing with a dangerous pet. The little which I had yet
+to learn of the case was told me by Sherlock Holmes as we travelled
+back next day.
+
+“I had,” said he, “come to an entirely erroneous conclusion, which
+shows, my dear Watson, how dangerous it always is to reason from
+insufficient data. The presence of the gypsies, and the use of the
+word ‘band,’ which was used by the poor girl, no doubt to explain the
+appearance which she had caught a hurried glimpse of by the light of
+her match, were sufficient to put me upon an entirely wrong scent. I
+can only claim the merit that I instantly reconsidered my position
+when, however, it became clear to me that whatever danger threatened
+an occupant of the room could not come either from the window or the
+door. My attention was speedily drawn, as I have already remarked to
+you, to this ventilator, and to the bell-rope which hung down to the
+bed. The discovery that this was a dummy, and that the bed was clamped
+to the floor, instantly gave rise to the suspicion that the rope was
+there as bridge for something passing through the hole, and coming
+to the bed. The idea of a snake instantly occurred to me, and when
+I coupled it with my knowledge that the doctor was furnished with a
+supply of creatures from India, I felt that I was probably on the right
+track. The idea of using a form of poison which could not possibly be
+discovered by any chemical test was just such a one as would occur to a
+clever and ruthless man who had had an Eastern training. The rapidity
+with which such a poison would take effect would also, from his point
+of view, be an advantage. It would be a sharp-eyed coroner, indeed, who
+could distinguish the two little dark punctures which would show where
+the poison fangs had done their work. Then I thought of the whistle. Of
+course he must recall the snake before the morning light revealed it to
+the victim. He had trained it, probably by the use of the milk which
+we saw, to return to him when summoned. He would put it through this
+ventilator at the hour that he thought best, with the certainty that it
+would crawl down the rope and land on the bed. It might or might not
+bite the occupant, perhaps she might escape every night for a week, but
+sooner or later she must fall a victim.
+
+“I had come to these conclusions before ever I had entered his room.
+An inspection of his chair showed me that he had been in the habit of
+standing on it, which of course would be necessary in order that he
+should reach the ventilator. The sight of the safe, the saucer of milk,
+and the loop of whip-cord were enough to finally dispel any doubts
+which may have remained. The metallic clang heard by Miss Stoner was
+obviously caused by her step-father hastily closing the door of his
+safe upon its terrible occupant. Having once made up my mind, you know
+the steps which I took in order to put the matter to the proof. I
+heard the creature hiss, as I have no doubt that you did also, and I
+instantly lit the light and attacked it.”
+
+“With the result of driving it through the ventilator.”
+
+“And also with the result of causing it to turn upon its master at the
+other side. Some of the blows of my cane came home, and roused its
+snakish temper, so that it flew upon the first person it saw. In this
+way I am no doubt indirectly responsible for Dr. Grimesby Roylott’s
+death, and I cannot say that it is likely to weigh very heavily upon my
+conscience.”
+
+
+
+
+Adventure IX
+
+THE ADVENTURE OF THE ENGINEER’S THUMB
+
+
+Of all the problems which have been submitted to my friend Mr. Sherlock
+Holmes for solution during the years of our intimacy, there were only
+two which I was the means of introducing to his notice—that of Mr.
+Hatherley’s thumb, and that of Colonel Warburton’s madness. Of these
+the latter may have afforded a finer field for an acute and original
+observer, but the other was so strange in its inception and so dramatic
+in its details, that it may be the more worthy of being placed upon
+record, even if it gave my friend fewer openings for those deductive
+methods of reasoning by which he achieved such remarkable results. The
+story has, I believe, been told more than once in the newspapers, but,
+like all such narratives, its effect is much less striking when set
+forth _en bloc_ in a single half-column of print than when the facts
+slowly evolve before your own eyes, and the mystery clears gradually
+away as each new discovery furnishes a step which leads on to the
+complete truth. At the time the circumstances made a deep impression
+upon me, and the lapse of two years has hardly served to weaken the
+effect.
+
+It was in the summer of ’89, not long after my marriage, that the
+events occurred which I am now about to summarize. I had returned to
+civil practice, and had finally abandoned Holmes in his Baker Street
+rooms, although I continually visited him, and occasionally even
+persuaded him to forego his Bohemian habits so far as to come and visit
+us. My practice had steadily increased, and as I happened to live at
+no very great distance from Paddington Station, I got a few patients
+from among the officials. One of these, whom I had cured of a painful
+and lingering disease, was never weary of advertising my virtues, and
+of endeavoring to send me on every sufferer over whom he might have any
+influence.
+
+One morning, at a little before seven o’clock, I was awakened by
+the maid tapping at the door, to announce that two men had come
+from Paddington, and were waiting in the consulting-room. I dressed
+hurriedly, for I knew by experience that railway cases were seldom
+trivial, and hastened down-stairs. As I descended, my old ally, the
+guard, came out of the room and closed the door tightly behind him.
+
+“I’ve got him here,” he whispered, jerking his thumb over his shoulder;
+“he’s all right.”
+
+“What is it, then?” I asked, for his manner suggested that it was some
+strange creature which he had caged up in my room.
+
+“It’s a new patient,” he whispered. “I thought I’d bring him round
+myself; then he couldn’t slip away. There he is, all safe and sound. I
+must go now, doctor; I have my dooties, just the same as you.” And off
+he went, this trusty tout, without even giving me time to thank him.
+
+I entered my consulting-room and found a gentleman seated by the
+table. He was quietly dressed in a suit of heather tweed, with a soft
+cloth cap, which he had laid down upon my books. Round one of his
+hands he had a handkerchief wrapped, which was mottled all over with
+blood-stains. He was young, not more than five-and-twenty, I should
+say, with a strong, masculine face; but he was exceedingly pale, and
+gave me the impression of a man who was suffering from some strong
+agitation, which it took all his strength of mind to control.
+
+“I am sorry to knock you up so early, doctor,” said he, “but I have
+had a very serious accident during the night. I came in by train this
+morning, and on inquiring at Paddington as to where I might find a
+doctor, a worthy fellow very kindly escorted me here. I gave the maid a
+card, but I see that she has left it upon the side-table.”
+
+I took it up and glanced at it. “Mr. Victor Hatherley, hydraulic
+engineer, 16A, Victoria Street (3d floor).” That was the name,
+style, and abode of my morning visitor. “I regret that I have kept you
+waiting,” said I, sitting down in my library-chair. “You are fresh
+from a night journey, I understand, which is in itself a monotonous
+occupation.”
+
+“Oh, my night could not be called monotonous,” said he, and laughed. He
+laughed very heartily, with a high, ringing note, leaning back in his
+chair and shaking his sides. All my medical instincts rose up against
+that laugh.
+
+“Stop it!” I cried; “pull yourself together!” and I poured out some
+water from a caraffe.
+
+It was useless, however. He was off in one of those hysterical
+outbursts which come upon a strong nature when some great crisis is
+over and gone. Presently he came to himself once more, very weary and
+blushing hotly.
+
+“I have been making a fool of myself,” he gasped.
+
+“Not at all. Drink this.” I dashed some brandy into the water, and the
+color began to come back to his bloodless cheeks.
+
+“That’s better!” said he. “And now, doctor, perhaps you would kindly
+attend to my thumb, or rather to the place where my thumb used to be.”
+
+He unwound the handkerchief and held out his hand. It gave even my
+hardened nerves a shudder to look at it. There were four protruding
+fingers and a horrid red, spongy surface where the thumb should have
+been. It had been hacked or torn right out from the roots.
+
+“Good heavens!” I cried, “this is a terrible injury. It must have bled
+considerably.”
+
+“Yes, it did. I fainted when it was done, and I think that I must have
+been senseless for a long time. When I came to I found that it was
+still bleeding, so I tied one end of my handkerchief very tightly
+round the wrist, and braced it up with a twig.”
+
+“Excellent! You should have been a surgeon.”
+
+“It is a question of hydraulics, you see, and came within my own
+province.”
+
+“This has been done,” said I, examining the wound, “by a very heavy and
+sharp instrument.”
+
+“A thing like a cleaver,” said he.
+
+“An accident, I presume?”
+
+“By no means.”
+
+“What! a murderous attack?”
+
+“Very murderous indeed.”
+
+“You horrify me.”
+
+I sponged the wound, cleaned it, dressed it, and finally covered it
+over with cotton wadding and carbolized bandages. He lay back without
+wincing, though he bit his lip from time to time.
+
+“How is that?” I asked, when I had finished.
+
+“Capital! Between your brandy and your bandage, I feel a new man. I was
+very weak, but I have had a good deal to go through.”
+
+“Perhaps you had better not speak of the matter. It is evidently trying
+to your nerves.”
+
+“Oh no, not now. I shall have to tell my tale to the police; but,
+between ourselves, if it were not for the convincing evidence of this
+wound of mine, I should be surprised if they believed my statement; for
+it is a very extraordinary one, and I have not much in the way of proof
+with which to back it up; and, even if they believe me, the clews which
+I can give them are so vague that it is a question whether justice will
+be done.”
+
+“Ha!” cried I, “if it is anything in the nature of a problem which you
+desire to see solved, I should strongly recommend you to come to my
+friend Mr. Sherlock Holmes before you go to the official police.”
+
+“Oh, I have heard of that fellow,” answered my visitor, “and I should
+be very glad if he would take the matter up, though of course I must
+use the official police as well. Would you give me an introduction to
+him?”
+
+“I’ll do better. I’ll take you round to him myself.”
+
+“I should be immensely obliged to you.”
+
+“We’ll call a cab and go together. We shall just be in time to have a
+little breakfast with him. Do you feel equal to it?”
+
+“Yes; I shall not feel easy until I have told my story.”
+
+“Then my servant will call a cab, and I shall be with you in an
+instant.” I rushed up-stairs, explained the matter shortly to my
+wife, and in five minutes was inside a hansom, driving with my new
+acquaintance to Baker Street.
+
+Sherlock Holmes was, as I expected, lounging about his sitting-room in
+his dressing-gown, reading the agony column of _The Times_, and smoking
+his before-breakfast pipe, which was composed of all the plugs and
+dottels left from his smokes of the day before, all carefully dried
+and collected on the corner of the mantel-piece. He received us in his
+quietly genial fashion, ordered fresh rashers and eggs, and joined us
+in a hearty meal. When it was concluded he settled our new acquaintance
+upon the sofa, placed a pillow beneath his head, and laid a glass of
+brandy-and-water within his reach.
+
+“It is easy to see that your experience has been no common one, Mr.
+Hatherley,” said he. “Pray, lie down there and make yourself absolutely
+at home. Tell us what you can, but stop when you are tired, and keep up
+your strength with a little stimulant.”
+
+“Thank you,” said my patient, “but I have felt another man since the
+doctor bandaged me, and I think that your breakfast has completed the
+cure. I shall take up as little of your valuable time as possible, so I
+shall start at once upon my peculiar experiences.”
+
+Holmes sat in his big arm-chair with the weary, heavy-lidded expression
+which veiled his keen and eager nature, while I sat opposite to him,
+and we listened in silence to the strange story which our visitor
+detailed to us.
+
+“You must know,” said he, “that I am an orphan and a bachelor, residing
+alone in lodgings in London. By profession I am an hydraulic engineer,
+and I have had considerable experience of my work during the seven
+years that I was apprenticed to Venner & Matheson, the well-known
+firm, of Greenwich. Two years ago, having served my time, and having
+also come into a fair sum of money through my poor father’s death,
+I determined to start in business for myself, and took professional
+chambers in Victoria Street.
+
+“I suppose that every one finds his first independent start in business
+a dreary experience. To me it has been exceptionally so. During two
+years I have had three consultations and one small job, and that is
+absolutely all that my profession has brought me. My gross takings
+amount to £27 10_s._ Every day, from nine in the morning until four in
+the afternoon, I waited in my little den, until at last my heart began
+to sink, and I came to believe that I should never have any practice at
+all.
+
+“Yesterday, however, just as I was thinking of leaving the office,
+my clerk entered to say there was a gentleman waiting who wished to
+see me upon business. He brought up a card, too, with the name of
+‘Colonel Lysander Stark’ engraved upon it. Close at his heels came the
+colonel himself, a man rather over the middle size, but of an exceeding
+thinness. I do not think that I have ever seen so thin a man. His whole
+face sharpened away into nose and chin, and the skin of his cheeks
+was drawn quite tense over his outstanding bones. Yet this emaciation
+seemed to be his natural habit, and due to no disease, for his eye was
+bright, his step brisk, and his bearing assured. He was plainly but
+neatly dressed, and his age, I should judge, would be nearer forty than
+thirty.
+
+“‘Mr. Hatherley?’ said he, with something of a German accent. ‘You
+have been recommended to me, Mr. Hatherley, as being a man who is not
+only proficient in his profession, but is also discreet and capable of
+preserving a secret.’
+
+“I bowed, feeling as flattered as any young man would at such an
+address. ‘May I ask who it was who gave me so good a character?’
+
+“‘Well, perhaps it is better that I should not tell you that just at
+this moment. I have it from the same source that you are both an orphan
+and a bachelor, and are residing alone in London.’
+
+“‘That is quite correct,’ I answered, ‘but you will excuse me if
+I say that I cannot see how all this bears upon my professional
+qualifications. I understood that it was on a professional matter that
+you wished to speak to me?’
+
+“‘Undoubtedly so. But you will find that all I say is really to the
+point. I have a professional commission for you, but absolute secrecy
+is quite essential—_absolute_ secrecy, you understand, and of course
+we may expect that more from a man who is alone than from one who lives
+in the bosom of his family.’
+
+“‘If I promise to keep a secret,’ said I, ‘you may absolutely depend
+upon my doing so.’
+
+“He looked very hard at me as I spoke, and it seemed to me that I had
+never seen so suspicious and questioning an eye.
+
+“‘Do you promise, then?’ said he, at last.
+
+“‘Yes, I promise.’
+
+“‘Absolute and complete silence before, during, and after? No reference
+to the matter at all, either in word or writing?’
+
+“‘I have already given you my word.’
+
+“‘Very good.’ He suddenly sprang up, and darting like lightning across
+the room, he flung open the door. The passage outside was empty.
+
+“‘That’s all right,’ said he, coming back. ‘I know that clerks are
+sometimes curious as to their master’s affairs. Now we can talk in
+safety.’ He drew up his chair very close to mine, and began to stare at
+me again with the same questioning and thoughtful look.
+
+“A feeling of repulsion, and of something akin to fear had begun to
+rise within me at the strange antics of this fleshless man. Even
+my dread of losing a client could not restrain me from showing my
+impatience.
+
+“‘I beg that you will state your business, sir,’ said I; ‘my time is of
+value.’ Heaven forgive me for that last sentence, but the words came to
+my lips.
+
+“‘How would fifty guineas for a night’s work suit you?’ he asked.
+
+“‘Most admirably.’
+
+“‘I say a night’s work, but an hour’s would be nearer the mark. I
+simply want your opinion about a hydraulic stamping machine which has
+got out of gear. If you show us what is wrong we shall soon set it
+right ourselves. What do you think of such a commission as that?’
+
+“‘The work appears to be light and the pay munificent.’
+
+“‘Precisely so. We shall want you to come to-night by the last train.’
+
+“‘Where to?’
+
+“‘To Eyford, in Berkshire. It is a little place near the borders of
+Oxfordshire, and within seven miles of Reading. There is a train from
+Paddington which would bring you there at about 11.15.’
+
+“‘Very good.’
+
+“‘I shall come down in a carriage to meet you.’
+
+“‘There is a drive, then?’
+
+“‘Yes, our little place is quite out in the country. It is a good seven
+miles from Eyford Station.’
+
+“‘Then we can hardly get there before midnight. I suppose there would
+be no chance of a train back. I should be compelled to stop the night.’
+
+“‘Yes, we could easily give you a shake-down.’
+
+“‘That is very awkward. Could I not come at some more convenient hour?’
+
+“‘We have judged it best that you should come late. It is to recompense
+you for any inconvenience that we are paying to you, a young and
+unknown man, a fee which would buy an opinion from the very heads of
+your profession. Still, of course, if you would like to draw out of
+the business, there is plenty of time to do so.’
+
+“I thought of the fifty guineas, and of how very useful they would be
+to me. ‘Not at all,’ said I, ‘I shall be very happy to accommodate
+myself to your wishes. I should like, however, to understand a little
+more clearly what it is that you wish me to do.’
+
+“‘Quite so. It is very natural that the pledge of secrecy which we have
+exacted from you should have aroused your curiosity. I have no wish to
+commit you to anything without your having it all laid before you. I
+suppose that we are absolutely safe from eavesdroppers?’
+
+“‘Entirely.’
+
+“‘Then the matter stands thus. You are probably aware that
+fuller’s-earth is a valuable product, and that it is only found in one
+or two places in England?’
+
+“‘I have heard so.’
+
+“‘Some little time ago I bought a small place—a very small
+place—within ten miles of Reading. I was fortunate enough to discover
+that there was a deposit of fuller’s-earth in one of my fields. On
+examining it, however, I found that this deposit was a comparatively
+small one, and that it formed a link between two very much larger ones
+upon the right and left—both of them, however, in the grounds of my
+neighbors. These good people were absolutely ignorant that their land
+contained that which was quite as valuable as a gold-mine. Naturally,
+it was to my interest to buy their land before they discovered its true
+value; but, unfortunately, I had no capital by which I could do this. I
+took a few of my friends into the secret, however, and they suggested
+that we should quietly and secretly work our own little deposit, and
+that in this way we should earn the money which would enable us to buy
+the neighboring fields. This we have now been doing for some time, and
+in order to help us in our operations we erected an hydraulic press.
+This press, as I have already explained, has got out of order, and we
+wish your advice upon the subject. We guard our secret very jealously,
+however, and if it once became known that we had hydraulic engineers
+coming to our little house, it would soon rouse inquiry, and then, if
+the facts came out, it would be good-bye to any chance of getting these
+fields and carrying out our plans. That is why I have made you promise
+me that you will not tell a human being that you are going to Eyford
+to-night. I hope that I make it all plain?’
+
+“‘I quite follow you,’ said I. ‘The only point which I could not
+quite understand, was what use you could make of an hydraulic press
+in excavating fuller’s-earth, which, as I understand, is dug out like
+gravel from a pit.’
+
+“‘Ah!’ said he, carelessly, ‘we have our own process. We compress
+the earth into bricks, so as to remove them without revealing what
+they are. But that is a mere detail. I have taken you fully into my
+confidence now, Mr. Hatherley, and I have shown you how I trust you.’
+He rose as he spoke. ‘I shall expect you, then, at Eyford at 11.15.’
+
+“‘I shall certainly be there.’
+
+“‘And not a word to a soul.’ He looked at me with a last, long,
+questioning gaze, and then, pressing my hand in a cold, dank grasp, he
+hurried from the room.
+
+“Well, when I came to think it all over in cool blood I was very much
+astonished, as you may both think, at this sudden commission which had
+been intrusted to me. On the one hand, of course, I was glad, for the
+fee was at least tenfold what I should have asked had I set a price
+upon my own services, and it was possible that this order might lead
+to other ones. On the other hand, the face and manner of my patron
+had made an unpleasant impression upon me, and I could not think that
+his explanation of the fuller’s-earth was sufficient to explain the
+necessity for my coming at midnight, and his extreme anxiety lest I
+should tell any one of my errand. However, I threw all fears to the
+winds, ate a hearty supper, drove to Paddington, and started off,
+having obeyed to the letter the injunction as to holding my tongue.
+
+[Illustration: “‘NOT A WORD TO A SOUL’”]
+
+“At Reading I had to change not only my carriage, but my station.
+However, I was in time for the last train to Eyford, and I reached the
+little dim-lit station after eleven o’clock. I was the only passenger
+who got out there, and there was no one upon the platform save a single
+sleepy porter with a lantern. As I passed out through the wicket gate,
+however, I found my acquaintance of the morning waiting in the shadow
+upon the other side. Without a word he grasped my arm and hurried me
+into a carriage, the door of which was standing open. He drew up the
+windows on either side, tapped on the wood-work, and away we went as
+fast as the horse could go.”
+
+“One horse?” interjected Holmes.
+
+“Yes, only one.”
+
+“Did you observe the color?”
+
+“Yes, I saw it by the side-lights when I was stepping into the
+carriage. It was a chestnut.”
+
+“Tired-looking or fresh?”
+
+“Oh, fresh and glossy.”
+
+“Thank you. I am sorry to have interrupted you. Pray continue your most
+interesting statement.”
+
+“Away we went then, and we drove for at least an hour. Colonel Lysander
+Stark had said that it was only seven miles, but I should think, from
+the rate that we seemed to go, and from the time that we took, that
+it must have been nearer twelve. He sat at my side in silence all the
+time, and I was aware, more than once when I glanced in his direction,
+that he was looking at me with great intensity. The country roads seem
+to be not very good in that part of the world, for we lurched and
+jolted terribly. I tried to look out of the windows to see something of
+where we were, but they were made of frosted glass, and I could make
+out nothing save the occasional bright blur of a passing light. Now
+and then I hazarded some remark to break the monotony of the journey,
+but the colonel answered only in monosyllables, and the conversation
+soon flagged. At last, however, the bumping of the road was exchanged
+for the crisp smoothness of a gravel-drive, and the carriage came to
+a stand. Colonel Lysander Stark sprang out, and, as I followed after
+him, pulled me swiftly into a porch which gaped in front of us. We
+stepped, as it were, right out of the carriage and into the hall, so
+that I failed to catch the most fleeting glance of the front of the
+house. The instant that I had crossed the threshold the door slammed
+heavily behind us, and I heard faintly the rattle of the wheels as the
+carriage drove away.
+
+“It was pitch dark inside the house, and the colonel fumbled about
+looking for matches, and muttering under his breath. Suddenly a door
+opened at the other end of the passage, and a long, golden bar of light
+shot out in our direction. It grew broader, and a woman appeared with
+a lamp in her hand, which she held above her head, pushing her face
+forward and peering at us. I could see that she was pretty, and from
+the gloss with which the light shone upon her dark dress I knew that
+it was a rich material. She spoke a few words in a foreign tongue in a
+tone as though asking a question, and when my companion answered in a
+gruff monosyllable she gave such a start that the lamp nearly fell from
+her hand. Colonel Stark went up to her, whispered something in her ear,
+and then, pushing her back into the room from whence she had come, he
+walked towards me again with the lamp in his hand.
+
+“‘Perhaps you will have the kindness to wait in this room for a few
+minutes,’ said he, throwing open another door. It was a quiet, little,
+plainly-furnished room, with a round table in the centre, on which
+several German books were scattered. Colonel Stark laid down the lamp
+on the top of a harmonium beside the door. ‘I shall not keep you
+waiting an instant,’ said he, and vanished into the darkness.
+
+“I glanced at the books upon the table, and in spite of my ignorance
+of German I could see that two of them were treatises on science, the
+others being volumes of poetry. Then I walked across to the window,
+hoping that I might catch some glimpse of the country-side, but an oak
+shutter, heavily barred, was folded across it. It was a wonderfully
+silent house. There was an old clock ticking loudly somewhere in the
+passage, but otherwise everything was deadly still. A vague feeling of
+uneasiness began to steal over me. Who were these German people, and
+what were they doing, living in this strange, out-of-the-way place?
+And where was the place? I was ten miles or so from Eyford, that was
+all I knew, but whether north, south, east, or west I had no idea.
+For that matter, Reading, and possibly other large towns, were within
+that radius, so the place might not be so secluded, after all. Yet it
+was quite certain, from the absolute stillness, that we were in the
+country. I paced up and down the room, humming a tune under my breath
+to keep up my spirits, and feeling that I was thoroughly earning my
+fifty-guinea fee.
+
+“Suddenly, without any preliminary sound in the midst of the utter
+stillness, the door of my room swung slowly open. The woman was
+standing in the aperture, the darkness of the hall behind her, the
+yellow light from my lamp beating upon her eager and beautiful face. I
+could see at a glance that she was sick with fear, and the sight sent a
+chill to my own heart. She held up one shaking finger to warn me to be
+silent, and she shot a few whispered words of broken English at me, her
+eyes glancing back, like those of a frightened horse, into the gloom
+behind her.
+
+“‘I would go,’ said she, trying hard, as it seemed to me, to speak
+calmly; ‘I would go. I should not stay here. There is no good for you
+to do.’
+
+“‘But, madam,’ said I, ‘I have not yet done what I came for. I cannot
+possibly leave until I have seen the machine.’
+
+“‘It is not worth your while to wait,’ she went on. ‘You can pass
+through the door; no one hinders.’ And then, seeing that I smiled and
+shook my head, she suddenly threw aside her constraint and made a step
+forward, with her hands wrung together. ‘For the love of Heaven!’ she
+whispered, ‘get away from here before it is too late!’
+
+“But I am somewhat headstrong by nature, and the more ready to engage
+in an affair when there is some obstacle in the way. I thought of my
+fifty-guinea fee, of my wearisome journey, and of the unpleasant night
+which seemed to be before me. Was it all to go for nothing? Why should
+I slink away without having carried out my commission, and without
+the payment which was my due? This woman might, for all I knew, be a
+monomaniac. With a stout bearing, therefore, though her manner had
+shaken me more than I cared to confess, I still shook my head, and
+declared my intention of remaining where I was. She was about to renew
+her entreaties, when a door slammed overhead, and the sound of several
+footsteps were heard upon the stairs. She listened for an instant,
+threw up her hands with a despairing gesture, and vanished as suddenly
+and as noiselessly as she had come.
+
+“The new-comers were Colonel Lysander Stark and a short, thick man with
+a chinchilla beard growing out of the creases of his double chin, who
+was introduced to me as Mr. Ferguson.
+
+“‘This is my secretary and manager,’ said the colonel. ‘By-the-way, I
+was under the impression that I left this door shut just now. I fear
+that you have felt the draught.’
+
+“‘On the contrary,’ said I, ‘I opened the door myself, because I felt
+the room to be a little close.’
+
+“He shot one of his suspicious looks at me. ‘Perhaps we had better
+proceed to business, then,’ said he. ‘Mr. Ferguson and I will take you
+up to see the machine.’
+
+“‘I had better put my hat on, I suppose.’
+
+“‘Oh no, it is in the house.’
+
+“‘What, you dig fuller’s-earth in the house?’
+
+“‘No, no. This is only where we compress it. But never mind that. All
+we wish you to do is to examine the machine, and to let us know what is
+wrong with it.’
+
+“We went up-stairs together, the colonel first with the lamp, the fat
+manager, and I behind him. It was a labyrinth of an old house, with
+corridors, passages, narrow winding staircases, and little low doors,
+the thresholds of which were hollowed out by the generations who had
+crossed them. There were no carpets and no signs of any furniture
+above the ground floor, while the plaster was peeling off the walls,
+and the damp was breaking through in green, unhealthy blotches. I tried
+to put on as unconcerned an air as possible, but I had not forgotten
+the warnings of the lady, even though I disregarded them, and I kept a
+keen eye upon my two companions. Ferguson appeared to be a morose and
+silent man, but I could see from the little that he said that he was at
+least a fellow-countryman.
+
+“Colonel Lysander Stark stopped at last before a low door, which he
+unlocked. Within was a small, square room, in which the three of us
+could hardly get at one time. Ferguson remained outside, and the
+colonel ushered me in.
+
+“‘We are now,’ said he, ‘actually within the hydraulic press, and it
+would be a particularly unpleasant thing for us if any one were to
+turn it on. The ceiling of this small chamber is really the end of the
+descending piston, and it comes down with the force of many tons upon
+this metal floor. There are small lateral columns of water outside
+which receive the force, and which transmit and multiply it in the
+manner which is familiar to you. The machine goes readily enough, but
+there is some stiffness in the working of it, and it has lost a little
+of its force. Perhaps you will have the goodness to look it over and to
+show us how we can set it right.’
+
+“I took the lamp from him, and I examined the machine very thoroughly.
+It was indeed a gigantic one, and capable of exercising enormous
+pressure. When I passed outside, however, and pressed down the levers
+which controlled it, I knew at once by the whishing sound that there
+was a slight leakage, which allowed a regurgitation of water through
+one of the side cylinders. An examination showed that one of the
+india-rubber bands which was round the head of a driving-rod had shrunk
+so as not quite to fill the socket along which it worked. This was
+clearly the cause of the loss of power, and I pointed it out to my
+companions, who followed my remarks very carefully, and asked several
+practical questions as to how they should proceed to set it right. When
+I had made it clear to them, I returned to the main chamber of the
+machine and took a good look at it to satisfy my own curiosity. It was
+obvious at a glance that the story of the fuller’s-earth was the merest
+fabrication, for it would be absurd to suppose that so powerful an
+engine could be designed for so inadequate a purpose. The walls were of
+wood, but the floor consisted of a large iron trough, and when I came
+to examine it I could see a crust of metallic deposit all over it. I
+had stooped and was scraping at this to see exactly what it was, when I
+heard a muttered exclamation in German, and saw the cadaverous face of
+the colonel looking down at me.
+
+“‘What are you doing there?’ he asked.
+
+“I felt angry at having been tricked by so elaborate a story as that
+which he had told me. ‘I was admiring your fuller’s-earth,’ said I; ‘I
+think that I should be better able to advise you as to your machine if
+I knew what the exact purpose was for which it was used.’
+
+“The instant that I uttered the words I regretted the rashness of my
+speech. His face set hard, and a baleful light sprang up in his gray
+eyes.
+
+“‘Very well,’ said he, ‘you shall know all about the machine.’ He took
+a step backward, slammed the little door, and turned the key in the
+lock. I rushed towards it and pulled at the handle, but it was quite
+secure, and did not give in the least to my kicks and shoves. ‘Hello!’
+I yelled. ‘Hello! Colonel! Let me out!’
+
+“And then suddenly in the silence I heard a sound which sent my heart
+into my mouth. It was the clank of the levers and the swish of the
+leaking cylinder. He had set the engine at work. The lamp still stood
+upon the floor where I had placed it when examining the trough. By its
+light I saw that the black ceiling was coming down upon me, slowly,
+jerkily, but, as none knew better than myself, with a force which
+must within a minute grind me to a shapeless pulp. I threw myself,
+screaming, against the door, and dragged with my nails at the lock. I
+implored the colonel to let me out, but the remorseless clanking of the
+levers drowned my cries. The ceiling was only a foot or two above my
+head, and with my hand upraised I could feel its hard, rough surface.
+Then it flashed through my mind that the pain of my death would depend
+very much upon the position in which I met it. If I lay on my face
+the weight would come upon my spine, and I shuddered to think of that
+dreadful snap. Easier the other way, perhaps; and yet, had I the nerve
+to lie and look up at that deadly black shadow wavering down upon me?
+Already I was unable to stand erect, when my eye caught something which
+brought a gush of hope back to my heart.
+
+“I have said that though the floor and ceiling were of iron, the walls
+were of wood. As I gave a last hurried glance around, I saw a thin
+line of yellow light between two of the boards, which broadened and
+broadened as a small panel was pushed backward. For an instant I could
+hardly believe that here was indeed a door which led away from death.
+The next instant I threw myself through, and lay half-fainting upon the
+other side. The panel had closed again behind me, but the crash of the
+lamp, and a few moments afterwards the clang of the two slabs of metal,
+told me how narrow had been my escape.
+
+“I was recalled to myself by a frantic plucking at my wrist, and I
+found myself lying upon the stone floor of a narrow corridor, while a
+woman bent over me and tugged at me with her left hand, while she held
+a candle in her right. It was the same good friend whose warning I had
+so foolishly rejected.
+
+“‘Come! come!’ she cried, breathlessly. ‘They will be here in a moment.
+They will see that you are not there. Oh, do not waste the so-precious
+time, but come!’
+
+“This time, at least, I did not scorn her advice. I staggered to my
+feet and ran with her along the corridor and down a winding stair. The
+latter led to another broad passage, and, just as we reached it, we
+heard the sound of running feet and the shouting of two voices, one
+answering the other, from the floor on which we were and from the one
+beneath. My guide stopped and looked about her like one who is at her
+wits’ end. Then she threw open a door which led into a bedroom, through
+the window of which the moon was shining brightly.
+
+“‘It is your only chance,’ said she. ‘It is high, but it may be that
+you can jump it.’
+
+“As she spoke a light sprang into view at the further end of the
+passage, and I saw the lean figure of Colonel Lysander Stark rushing
+forward with a lantern in one hand and a weapon like a butcher’s
+cleaver in the other. I rushed across the bedroom, flung open the
+window, and looked out. How quiet and sweet and wholesome the garden
+looked in the moonlight, and it could not be more than thirty feet
+down. I clambered out upon the sill, but I hesitated to jump until I
+should have heard what passed between my savior and the ruffian who
+pursued me. If she were ill-used, then at any risks I was determined to
+go back to her assistance. The thought had hardly flashed through my
+mind before he was at the door, pushing his way past her; but she threw
+her arms round him and tried to hold him back.
+
+“‘Fritz! Fritz!’ she cried, in English, ‘remember your promise after
+the last time. You said it should not be again. He will be silent! Oh,
+he will be silent!’
+
+“‘You are mad, Elise!’ he shouted, struggling to break away from her.
+‘You will be the ruin of us. He has seen too much. Let me pass, I say!’
+He dashed her to one side, and, rushing to the window, cut at me with
+his heavy weapon. I had let myself go, and was hanging by the hands to
+the sill, when his blow fell. I was conscious of a dull pain, my grip
+loosened, and I fell into the garden below.
+
+“I was shaken but not hurt by the fall; so I picked myself up and
+rushed off among the bushes as hard as I could run, for I understood
+that I was far from being out of danger yet. Suddenly, however, as I
+ran, a deadly dizziness and sickness came over me. I glanced down at
+my hand, which was throbbing painfully, and then, for the first time,
+saw that my thumb had been cut off and that the blood was pouring from
+my wound. I endeavored to tie my handkerchief round it, but there came
+a sudden buzzing in my ears, and next moment I fell in a dead faint
+among the rose-bushes.
+
+“How long I remained unconscious I cannot tell. It must have been
+a very long time, for the moon had sunk, and a bright morning was
+breaking when I came to myself. My clothes were all sodden with dew,
+and my coat-sleeve was drenched with blood from my wounded thumb.
+The smarting of it recalled in an instant all the particulars of my
+night’s adventure, and I sprang to my feet with the feeling that I
+might hardly yet be safe from my pursuers. But, to my astonishment,
+when I came to look round me, neither house nor garden were to be seen.
+I had been lying in an angle of the hedge close by the high-road, and
+just a little lower down was a long building, which proved, upon my
+approaching it, to be the very station at which I had arrived upon the
+previous night. Were it not for the ugly wound upon my hand, all that
+had passed during those dreadful hours might have been an evil dream.
+
+“Half dazed, I went into the station and asked about the morning train.
+There would be one to Reading in less than an hour. The same porter
+was on duty, I found, as had been there when I arrived. I inquired of
+him whether he had ever heard of Colonel Lysander Stark. The name was
+strange to him. Had he observed a carriage the night before waiting for
+me? No, he had not. Was there a police-station anywhere near? There was
+one about three miles off.
+
+“It was too far for me to go, weak and ill as I was. I determined to
+wait until I got back to town before telling my story to the police. It
+was a little past six when I arrived, so I went first to have my wound
+dressed, and then the doctor was kind enough to bring me along here. I
+put the case into your hands, and shall do exactly what you advise.”
+
+We both sat in silence for some little time after, listening to this
+extraordinary narrative. Then Sherlock Holmes pulled down from the
+shelf one of the ponderous commonplace books in which he placed his
+cuttings.
+
+“Here is an advertisement which will interest you,” said he. “It
+appeared in all the papers about a year ago. Listen to this: ‘Lost,
+on the 9th inst., Mr. Jeremiah Hayling, aged twenty-six, an hydraulic
+engineer. Left his lodgings at ten o’clock at night, and has not been
+heard of since. Was dressed in,’ etc., etc. Ha! That represents the
+last time that the colonel needed to have his machine overhauled, I
+fancy.”
+
+“Good heavens!” cried my patient. “Then that explains what the girl
+said.”
+
+“Undoubtedly. It is quite clear that the colonel was a cool and
+desperate man, who was absolutely determined that nothing should stand
+in the way of his little game, like those out-and-out pirates who will
+leave no survivor from a captured ship. Well, every moment now is
+precious, so if you feel equal to it, we shall go down to Scotland Yard
+at once as a preliminary to starting for Eyford.”
+
+Some three hours or so afterwards we were all in the train together,
+bound from Reading to the little Berkshire village. There were Sherlock
+Holmes, the hydraulic engineer, Inspector Bradstreet, of Scotland Yard,
+a plain-clothes man, and myself. Bradstreet had spread an ordnance
+map of the county out upon the seat, and was busy with his compasses
+drawing a circle with Eyford for its centre.
+
+“There you are,” said he. “That circle is drawn at a radius of ten
+miles from the village. The place we want must be somewhere near that
+line. You said ten miles, I think, sir.”
+
+“It was an hour’s good drive.”
+
+“And you think that they brought you back all that way when you were
+unconscious?”
+
+“They must have done so. I have a confused memory, too, of having been
+lifted and conveyed somewhere.”
+
+“What I cannot understand,” said I, “is why they should have spared you
+when they found you lying fainting in the garden. Perhaps the villain
+was softened by the woman’s entreaties.”
+
+“I hardly think that likely. I never saw a more inexorable face in my
+life.”
+
+“Oh, we shall soon clear up all that,” said Bradstreet. “Well, I have
+drawn my circle, and I only wish I knew at what point upon it the folk
+that we are in search of are to be found.”
+
+“I think I could lay my finger on it,” said Holmes, quietly.
+
+“Really, now!” cried the inspector, “you have formed your opinion!
+Come, now, we shall see who agrees with you. I say it is south, for the
+country is more deserted there.”
+
+“And I say east,” said my patient.
+
+“I am for west,” remarked the plain-clothes man. “There are several
+quiet little villages up there.”
+
+“And I am for north,” said I, “because there are no hills there, and
+our friend says that he did not notice the carriage go up any.”
+
+“Come,” cried the inspector, laughing; “it’s a very pretty diversity
+of opinion. We have boxed the compass among us. Who do you give your
+casting vote to?”
+
+“You are all wrong.”
+
+“But we can’t _all_ be.”
+
+“Oh yes, you can. This is my point;” he placed his finger in the centre
+of the circle. “This is where we shall find them.”
+
+“But the twelve-mile drive?” gasped Hatherley.
+
+“Six out and six back. Nothing simpler. You say yourself that the horse
+was fresh and glossy when you got in. How could it be that if it had
+gone twelve miles over heavy roads?”
+
+“Indeed, it is a likely ruse enough,” observed Bradstreet,
+thoughtfully. “Of course there can be no doubt as to the nature of this
+gang.”
+
+“None at all,” said Holmes. “They are coiners on a large scale, and
+have used the machine to form the amalgam which has taken the place of
+silver.”
+
+“We have known for some time that a clever gang was at work,” said the
+inspector. “They have been turning out half-crowns by the thousand. We
+even traced them as far as Reading, but could get no farther, for they
+had covered their traces in a way that showed that they were very old
+hands. But now, thanks to this lucky chance, I think that we have got
+them right enough.”
+
+But the inspector was mistaken, for those criminals were not destined
+to fall into the hands of justice. As we rolled into Eyford Station we
+saw a gigantic column of smoke which streamed up from behind a small
+clump of trees in the neighborhood, and hung like an immense ostrich
+feather over the landscape.
+
+“A house on fire?” asked Bradstreet, as the train steamed off again on
+its way.
+
+“Yes, sir!” said the station-master.
+
+“When did it break out?”
+
+“I hear that it was during the night, sir, but it has got worse, and
+the whole place is in a blaze.”
+
+“Whose house is it?”
+
+“Dr. Becher’s.”
+
+“Tell me,” broke in the engineer, “is Dr. Becher a German, very thin,
+with a long, sharp nose?”
+
+The station-master laughed heartily. “No, sir, Dr. Becher is an
+Englishman, and there isn’t a man in the parish who has a better-lined
+waistcoat. But he has a gentleman staying with him, a patient, as
+I understand, who is a foreigner, and he looks as if a little good
+Berkshire beef would do him no harm.”
+
+The station-master had not finished his speech before we were all
+hastening in the direction of the fire. The road topped a low hill,
+and there was a great wide-spread whitewashed building in front of us,
+spouting fire at every chink and window, while in the garden in front
+three fire-engines were vainly striving to keep the flames under.
+
+“That’s it!” cried Hatherley, in intense excitement. “There is the
+gravel-drive, and there are the rose-bushes where I lay. That second
+window is the one that I jumped from.”
+
+“Well, at least,” said Holmes, “you have had your revenge upon them.
+There can be no question that it was your oil-lamp which, when it was
+crushed in the press, set fire to the wooden walls, though no doubt
+they were too excited in the chase after you to observe it at the time.
+Now keep your eyes open in this crowd for your friends of last night,
+though I very much fear that they are a good hundred miles off by now.”
+
+And Holmes’s fears came to be realized, for from that day to this no
+word has ever been heard either of the beautiful woman, the sinister
+German, or the morose Englishman. Early that morning a peasant had met
+a cart containing several people and some very bulky boxes driving
+rapidly in the direction of Reading, but there all traces of the
+fugitives disappeared, and even Holmes’s ingenuity failed ever to
+discover the least clew as to their whereabouts.
+
+The firemen had been much perturbed at the strange arrangements which
+they had found within, and still more so by discovering a newly severed
+human thumb upon a window-sill of the second floor. About sunset,
+however, their efforts were at last successful, and they subdued the
+flames, but not before the roof had fallen in, and the whole place been
+reduced to such absolute ruin that, save some twisted cylinders and
+iron piping, not a trace remained of the machinery which had cost our
+unfortunate acquaintance so dearly. Large masses of nickel and of tin
+were discovered stored in an out-house, but no coins were to be found,
+which may have explained the presence of those bulky boxes which have
+been already referred to.
+
+How our hydraulic engineer had been conveyed from the garden to the
+spot where he recovered his senses might have remained forever a
+mystery were it not for the soft mould, which told us a very plain
+tale. He had evidently been carried down by two persons, one of whom
+had remarkably small feet and the other unusually large ones. On the
+whole, it was most probable that the silent Englishman, being less bold
+or less murderous than his companion, had assisted the woman to bear
+the unconscious man out of the way of danger.
+
+“Well,” said our engineer ruefully, as we took our seats to return once
+more to London, “it has been a pretty business for me! I have lost my
+thumb and I have lost a fifty-guinea fee, and what have I gained?”
+
+“Experience,” said Holmes, laughing. “Indirectly it may be of value,
+you know; you have only to put it into words to gain the reputation of
+being excellent company for the remainder of your existence.”
+
+
+
+
+Adventure X
+
+THE ADVENTURE OF THE NOBLE BACHELOR
+
+
+The Lord St. Simon marriage, and its curious termination, have long
+ceased to be a subject of interest in those exalted circles in which
+the unfortunate bridegroom moves. Fresh scandals have eclipsed it,
+and their more piquant details have drawn the gossips away from this
+four-year-old drama. As I have reason to believe, however, that the
+full facts have never been revealed to the general public, and as my
+friend Sherlock Holmes had a considerable share in clearing the matter
+up, I feel that no memoir of him would be complete without some little
+sketch of this remarkable episode.
+
+It was a few weeks before my own marriage, during the days when I was
+still sharing rooms with Holmes in Baker Street, that he came home from
+an afternoon stroll to find a letter on the table waiting for him.
+I had remained in-doors all day, for the weather had taken a sudden
+turn to rain, with high autumnal winds, and the jezail bullet which I
+had brought back in one of my limbs as a relic of my Afghan campaign,
+throbbed with dull persistency. With my body in one easy-chair and my
+legs upon another, I had surrounded myself with a cloud of newspapers,
+until at last, saturated with the news of the day, I tossed them all
+aside and lay listless, watching the huge crest and monogram upon the
+envelope upon the table, and wondering lazily who my friend’s noble
+correspondent could be.
+
+“Here is a very fashionable epistle,” I remarked, as he entered. “Your
+morning letters, if I remember right, were from a fish-monger and a
+tide-waiter.”
+
+“Yes, my correspondence has certainly the charm of variety,” he
+answered, smiling, “and the humbler are usually the more interesting.
+This looks like one of those unwelcome social summonses which call upon
+a man either to be bored or to lie.”
+
+He broke the seal and glanced over the contents.
+
+“Oh, come, it may prove to be something of interest after all.”
+
+“Not social, then?”
+
+“No, distinctly professional.”
+
+“And from a noble client?”
+
+“One of the highest in England.”
+
+“My dear fellow, I congratulate you.”
+
+“I assure you, Watson, without affectation, that the status of my
+client is a matter of less moment to me than the interest of his case.
+It is just possible, however, that that also may not be wanting in this
+new investigation. You have been reading the papers diligently of late,
+have you not?”
+
+“It looks like it,” said I, ruefully, pointing to a huge bundle in the
+corner. “I have had nothing else to do.”
+
+“It is fortunate, for you will perhaps be able to post me up. I read
+nothing except the criminal news and the agony column. The latter is
+always instructive. But if you have followed recent events so closely
+you must have read about Lord St. Simon and his wedding?”
+
+“Oh yes, with the deepest interest.”
+
+“That is well. The letter which I hold in my hand is from Lord St.
+Simon. I will read it to you, and in return you must turn over these
+papers and let me have whatever bears upon the matter. This is what he
+says:
+
+  “‘MY DEAR MR. SHERLOCK HOLMES,—Lord Backwater tells me that I
+  may place implicit reliance upon your judgment and discretion.
+  I have determined, therefore, to call upon you, and to consult
+  you in reference to the very painful event which has occurred
+  in connection with my wedding. Mr. Lestrade, of Scotland Yard,
+  is acting already in the matter, but he assures me that he sees
+  no objection to your co-operation, and that he even thinks that
+  it might be of some assistance. I will call at four o’clock in
+  the afternoon, and, should you have any other engagement at
+  that time, I hope that you will postpone it, as this matter is
+  of paramount importance.    Yours faithfully,   ST. SIMON.’
+
+“It is dated from Grosvenor Mansions, written with a quill pen, and the
+noble lord has had the misfortune to get a smear of ink upon the outer
+side of his right little finger,” remarked Holmes, as he folded up the
+epistle.
+
+“He says four o’clock. It is three now. He will be here in an hour.”
+
+“Then I have just time, with your assistance, to get clear upon the
+subject. Turn over those papers, and arrange the extracts in their
+order of time, while I take a glance as to who our client is.” He
+picked a red-covered volume from a line of books of reference beside
+the mantel-piece. “Here he is,” said he, sitting down and flattening it
+out upon his knee. “Lord Robert Walsingham de Vere St. Simon, second
+son of the Duke of Balmoral—Hum! Arms: Azure, three caltrops in chief
+over a fess sable. Born in 1846. He’s forty-one years of age, which
+is mature for marriage. Was Undersecretary for the Colonies in a late
+Administration. The Duke, his father, was at one time Secretary for
+Foreign Affairs. They inherit Plantagenet blood by direct descent, and
+Tudor on the distaff side. Ha! Well, there is nothing very instructive
+in all this. I think that I must turn to you, Watson, for something
+more solid.”
+
+“I have very little difficulty in finding what I want,” said I, “for
+the facts are quite recent, and the matter struck me as remarkable. I
+feared to refer them to you, however, as I knew that you had an inquiry
+on hand, and that you disliked the intrusion of other matters.”
+
+“Oh, you mean the little problem of the Grosvenor Square furniture
+van. That is quite cleared up now—though, indeed, it was obvious from
+the first. Pray give me the results of your newspaper selections.”
+
+“Here is the first notice which I can find. It is in the personal
+column of _The Morning Post_, and dates, as you see, some weeks back.
+‘A marriage has been arranged,’ it says, ‘and will, if rumor is
+correct, very shortly take place, between Lord Robert St. Simon, second
+son of the Duke of Balmoral, and Miss Hatty Doran, the only daughter of
+Aloysius Doran, Esq., of San Francisco, Cal., U.S.A.’ That is all.”
+
+“Terse and to the point,” remarked Holmes, stretching his long, thin
+legs towards the fire.
+
+“There was a paragraph amplifying this in one of the society papers
+of the same week. Ah, here it is. ‘There will soon be a call for
+protection in the marriage market, for the present free-trade principle
+appears to tell heavily against our home product. One by one the
+management of the noble houses of Great Britain is passing into the
+hands of our fair cousins from across the Atlantic. An important
+addition has been made during the last week to the list of the prizes
+which have been borne away by these charming invaders. Lord St. Simon,
+who has shown himself for over twenty years proof against the little
+god’s arrows, has now definitely announced his approaching marriage
+with Miss Hatty Doran, the fascinating daughter of a California
+millionaire. Miss Doran, whose graceful figure and striking face
+attracted much attention at the Westbury House festivities, is an
+only child, and it is currently reported that her dowry will run to
+considerably over the six figures, with expectancies for the future.
+As it is an open secret that the Duke of Balmoral has been compelled
+to sell his pictures within the last few years, and as Lord St. Simon
+has no property of his own, save the small estate of Birchmoor, it
+is obvious that the Californian heiress is not the only gainer by an
+alliance which will enable her to make the easy and common transition
+from a Republican lady to a British peeress.’”
+
+“Anything else?” asked Holmes, yawning.
+
+“Oh yes; plenty. Then there is another note in _The Morning Post_ to
+say that the marriage would be an absolutely quiet one, that it would
+be at St. George’s, Hanover Square, that only half a dozen intimate
+friends would be invited, and that the party would return to the
+furnished house at Lancaster Gate which has been taken by Mr. Aloysius
+Doran. Two days later—that is, on Wednesday last—there is a curt
+announcement that the wedding had taken place, and that the honey-moon
+would be passed at Lord Backwater’s place, near Petersfield. Those are
+all the notices which appeared before the disappearance of the bride.”
+
+“Before the what?” asked Holmes, with a start.
+
+“The vanishing of the lady.”
+
+“When did she vanish, then?”
+
+“At the wedding breakfast.”
+
+“Indeed. This is more interesting than it promised to be; quite
+dramatic, in fact.”
+
+“Yes; it struck me as being a little out of the common.”
+
+“They often vanish before the ceremony, and occasionally during the
+honey-moon; but I cannot call to mind anything quite so prompt as this.
+Pray let me have the details.”
+
+“I warn you that they are very incomplete.”
+
+“Perhaps we may make them less so.”
+
+“Such as they are, they are set forth in a single article of a morning
+paper of yesterday, which I will read to you. It is headed, ‘Singular
+Occurrence at a Fashionable Wedding’:
+
+“‘The family of Lord Robert St. Simon has been thrown into the
+greatest consternation by the strange and painful episodes which have
+taken place in connection with his wedding. The ceremony, as shortly
+announced in the papers of yesterday, occurred on the previous morning;
+but it is only now that it has been possible to confirm the strange
+rumors which have been so persistently floating about. In spite of
+the attempts of the friends to hush the matter up, so much public
+attention has now been drawn to it that no good purpose can be served
+by affecting to disregard what is a common subject for conversation.
+
+“‘The ceremony, which was performed at St. George’s, Hanover Square,
+was a very quiet one, no one being present save the father of the
+bride, Mr. Aloysius Doran, the Duchess of Balmoral, Lord Backwater,
+Lord Eustace, and Lady Clara St. Simon (the younger brother and sister
+of the bridegroom), and Lady Alicia Whittington. The whole party
+proceeded afterwards to the house of Mr. Aloysius Doran, at Lancaster
+Gate, where breakfast had been prepared. It appears that some little
+trouble was caused by a woman, whose name has not been ascertained,
+who endeavored to force her way into the house after the bridal party,
+alleging that she had some claim upon Lord St. Simon. It was only after
+a painful and prolonged scene that she was ejected by the butler and
+the footman. The bride, who had fortunately entered the house before
+this unpleasant interruption, had sat down to breakfast with the rest,
+when she complained of a sudden indisposition, and retired to her room.
+Her prolonged absence having caused some comment, her father followed
+her, but learned from her maid that she had only come up to her chamber
+for an instant, caught up an ulster and bonnet, and hurried down to
+the passage. One of the footmen declared that he had seen a lady leave
+the house thus apparelled, but had refused to credit that it was his
+mistress, believing her to be with the company. On ascertaining that
+his daughter had disappeared, Mr. Aloysius Doran, in conjunction with
+the bridegroom, instantly put themselves into communication with
+the police, and very energetic inquiries are being made, which will
+probably result in a speedy clearing up of this very singular business.
+Up to a late hour last night, however, nothing had transpired as to
+the whereabouts of the missing lady. There are rumors of foul play in
+the matter, and it is said that the police have caused the arrest of
+the woman who had caused the original disturbance, in the belief that,
+from jealousy or some other motive, she may have been concerned in the
+strange disappearance of the bride.’”
+
+“And is that all?”
+
+“Only one little item in another of the morning papers, but it is a
+suggestive one.”
+
+“And it is—”
+
+“That Miss Flora Millar, the lady who had caused the disturbance, has
+actually been arrested. It appears that she was formerly a _danseuse_
+at the ‘Allegro,’ and that she has known the bridegroom for some years.
+There are no further particulars, and the whole case is in your hands
+now—so far as it has been set forth in the public press.”
+
+“And an exceedingly interesting case it appears to be. I would not have
+missed it for worlds. But there is a ring at the bell, Watson, and as
+the clock makes it a few minutes after four, I have no doubt that this
+will prove to be our noble client. Do not dream of going, Watson, for I
+very much prefer having a witness, if only as a check to my own memory.”
+
+“Lord Robert St. Simon,” announced our page-boy, throwing open the
+door. A gentleman entered, with a pleasant, cultured face, high-nosed
+and pale, with something perhaps of petulance about the mouth, and
+with the steady, well-opened eye of a man whose pleasant lot it had
+ever been to command and to be obeyed. His manner was brisk, and yet
+his general appearance gave an undue impression of age, for he had a
+slight forward stoop and a little bend of the knees as he walked. His
+hair, too, as he swept off his very curly-brimmed hat, was grizzled
+round the edges and thin upon the top. As to his dress, it was careful
+to the verge of foppishness, with high collar, black frock-coat, white
+waistcoat, yellow gloves, patent-leather shoes, and light-colored
+gaiters. He advanced slowly into the room, turning his head from left
+to right, and swinging in his right hand the cord which held his golden
+eye-glasses.
+
+“Good-day, Lord St. Simon,” said Holmes, rising and bowing. “Pray take
+the basket-chair. This is my friend and colleague, Dr. Watson. Draw up
+a little to the fire, and we will talk this matter over.”
+
+“A most painful matter to me, as you can most readily imagine, Mr.
+Holmes. I have been cut to the quick. I understand that you have
+already managed several delicate cases of this sort, sir, though I
+presume that they were hardly from the same class of society.”
+
+“No, I am descending.”
+
+“I beg pardon.”
+
+“My last client of the sort was a king.”
+
+“Oh, really! I had no idea. And which king?”
+
+“The King of Scandinavia.”
+
+“What! Had he lost his wife?”
+
+“You can understand,” said Holmes, suavely, “that I extend to the
+affairs of my other clients the same secrecy which I promise to you in
+yours.”
+
+“Of course! Very right! very right! I’m sure I beg pardon. As to my own
+case, I am ready to give you any information which may assist you in
+forming an opinion.”
+
+“Thank you. I have already learned all that is in the public prints,
+nothing more. I presume that I may take it as correct—this article,
+for example, as to the disappearance of the bride.”
+
+Lord St. Simon glanced over it. “Yes, it is correct, as far as it goes.”
+
+“But it needs a great deal of supplementing before any one could offer
+an opinion. I think that I may arrive at my facts most directly by
+questioning you.”
+
+“Pray do so.”
+
+“When did you first meet Miss Hatty Doran?”
+
+“In San Francisco, a year ago.”
+
+“You were travelling in the States?”
+
+“Yes.”
+
+“Did you become engaged then?”
+
+“No.”
+
+“But you were on a friendly footing?”
+
+“I was amused by her society, and she could see that I was amused.”
+
+“Her father is very rich?”
+
+“He is said to be the richest man on the Pacific slope.”
+
+“And how did he make his money?”
+
+“In mining. He had nothing a few years ago. Then he struck gold,
+invested it, and came up by leaps and bounds.”
+
+“Now, what is your own impression as to the young lady’s—your wife’s
+character?”
+
+The nobleman swung his glasses a little faster and stared down into the
+fire. “You see, Mr. Holmes,” said he, “my wife was twenty before her
+father became a rich man. During that time she ran free in a mining
+camp, and wandered through woods or mountains, so that her education
+has come from Nature rather than from the school-master. She is what
+we call in England a tomboy, with a strong nature, wild and free,
+unfettered by any sort of traditions. She is impetuous—volcanic, I
+was about to say. She is swift in making up her mind, and fearless
+in carrying out her resolutions. On the other hand, I would not have
+given her the name which I have the honor to bear”—he gave a little
+stately cough—“had not I thought her to be at bottom a noble woman. I
+believe that she is capable of heroic self-sacrifice, and that anything
+dishonorable would be repugnant to her.”
+
+“Have you her photograph?”
+
+“I brought this with me.” He opened a locket, and showed us the full
+face of a very lovely woman. It was not a photograph, but an ivory
+miniature, and the artist had brought out the full effect of the
+lustrous black hair, the large dark eyes, and the exquisite mouth.
+Holmes gazed long and earnestly at it. Then he closed the locket and
+handed it back to Lord St. Simon.
+
+“The young lady came to London, then, and you renewed your
+acquaintance?”
+
+“Yes, her father brought her over for this last London season. I met
+her several times, became engaged to her, and have now married her.”
+
+“She brought, I understand, a considerable dowry?”
+
+“A fair dowry. Not more than is usual in my family.”
+
+“And this, of course, remains to you, since the marriage is a _fait
+accompli_?”
+
+“I really have made no inquiries on the subject.”
+
+“Very naturally not. Did you see Miss Doran on the day before the
+wedding?”
+
+“Yes.”
+
+“Was she in good spirits?”
+
+“Never better. She kept talking of what we should do in our future
+lives.”
+
+“Indeed! That is very interesting. And on the morning of the wedding?”
+
+“She was as bright as possible—at least, until after the ceremony.”
+
+“And did you observe any change in her then?”
+
+“Well, to tell the truth, I saw then the first signs that I had ever
+seen that her temper was just a little sharp. The incident, however,
+was too trivial to relate, and can have no possible bearing upon the
+case.”
+
+“Pray let us have it, for all that.”
+
+“Oh, it is childish. She dropped her bouquet as we went towards the
+vestry. She was passing the front pew at the time, and it fell over
+into the pew. There was a moment’s delay, but the gentleman in the
+pew handed it up to her again, and it did not appear to be the worse
+for the fall. Yet, when I spoke to her of the matter, she answered me
+abruptly; and in the carriage, on our way home, she seemed absurdly
+agitated over this trifling cause.”
+
+“Indeed! You say that there was a gentleman in the pew. Some of the
+general public were present, then?”
+
+“Oh yes. It is impossible to exclude them when the church is open.”
+
+“This gentleman was not one of your wife’s friends?”
+
+“No, no; I call him a gentleman by courtesy, but he was quite a
+common-looking person. I hardly noticed his appearance. But really I
+think that we are wandering rather far from the point.”
+
+“Lady St. Simon, then, returned from the wedding in a less cheerful
+frame of mind than she had gone to it. What did she do on re-entering
+her father’s house?”
+
+“I saw her in conversation with her maid.”
+
+“And who is her maid?”
+
+“Alice is her name. She is an American, and came from California with
+her.”
+
+“A confidential servant?”
+
+“A little too much so. It seemed to me that her mistress allowed her to
+take great liberties. Still, of course, in America they look upon these
+things in a different way.”
+
+“How long did she speak to this Alice?”
+
+“Oh, a few minutes. I had something else to think of.”
+
+“You did not overhear what they said?”
+
+“Lady St. Simon said something about ‘jumping a claim.’ She was
+accustomed to use slang of the kind. I have no idea what she meant.”
+
+“American slang is very expressive sometimes. And what did your wife do
+when she finished speaking to her maid?”
+
+“She walked into the breakfast-room.”
+
+“On your arm?”
+
+“No, alone. She was very independent in little matters like that.
+Then, after we had sat down for ten minutes or so, she rose hurriedly,
+muttered some words of apology, and left the room. She never came back.”
+
+“But this maid, Alice, as I understand, deposes that she went to her
+room, covered her bride’s dress with a long ulster, put on a bonnet,
+and went out.”
+
+“Quite so. And she was afterwards seen walking into Hyde Park in
+company with Flora Millar, a woman who is now in custody, and who had
+already made a disturbance at Mr. Doran’s house that morning.”
+
+“Ah, yes. I should like a few particulars as to this young lady, and
+your relations to her.”
+
+Lord St. Simon shrugged his shoulders and raised his eyebrows. “We
+have been on a friendly footing for some years—I may say on a _very_
+friendly footing. She used to be at the ‘Allegro.’ I have not treated
+her ungenerously, and she has no just cause of complaint against me;
+but you know what women are, Mr. Holmes. Flora was a dear little thing,
+but exceedingly hot-headed, and devotedly attached to me. She wrote me
+dreadful letters when she heard that I was about to be married; and, to
+tell the truth, the reason why I had the marriage celebrated so quietly
+was that I feared lest there might be a scandal in the church. She came
+to Mr. Doran’s door just after we returned, and she endeavored to push
+her way in, uttering very abusive expressions towards my wife, and even
+threatening her, but I had foreseen the possibility of something of the
+sort, and I had two police fellows there in private clothes, who soon
+pushed her out again. She was quiet when she saw that there was no good
+in making a row.”
+
+“Did your wife hear all this?”
+
+“No, thank goodness, she did not.”
+
+“And she was seen walking with this very woman afterwards?”
+
+“Yes. That is what Mr. Lestrade, of Scotland Yard, looks upon as so
+serious. It is thought that Flora decoyed my wife out, and laid some
+terrible trap for her.”
+
+“Well, it is a possible supposition.”
+
+“You think so, too?”
+
+“I did not say a probable one. But you do not yourself look upon this
+as likely?”
+
+“I do not think Flora would hurt a fly.”
+
+“Still, jealousy is a strange transformer of characters. Pray what is
+your own theory as to what took place?”
+
+“Well, really, I came to seek a theory, not to propound one. I have
+given you all the facts. Since you ask me, however, I may say that it
+has occurred to me as possible that the excitement of this affair, the
+consciousness that she had made so immense a social stride, had the
+effect of causing some little nervous disturbance in my wife.”
+
+“In short, that she had become suddenly deranged?”
+
+“Well, really, when I consider that she has turned her back—I will
+not say upon me, but upon so much that many have aspired to without
+success—I can hardly explain it in any other fashion.”
+
+“Well, certainly that is also a conceivable hypothesis,” said Holmes,
+smiling. “And now, Lord St. Simon, I think that I have nearly all my
+data. May I ask whether you were seated at the breakfast-table so that
+you could see out of the window?”
+
+“We could see the other side of the road and the Park.”
+
+“Quite so. Then I do not think that I need to detain you longer. I
+shall communicate with you.”
+
+“Should you be fortunate enough to solve this problem,” said our
+client, rising.
+
+“I have solved it.”
+
+“Eh? What was that?”
+
+“I say that I have solved it.”
+
+“Where, then, is my wife?”
+
+“That is a detail which I shall speedily supply.”
+
+Lord St. Simon shook his head. “I am afraid that it will take wiser
+heads than yours or mine,” he remarked, and bowing in a stately,
+old-fashioned manner, he departed.
+
+“It is very good of Lord St. Simon to honor my head by putting it
+on a level with his own,” said Sherlock Holmes, laughing. “I think
+that I shall have a whiskey-and-soda and a cigar after all this
+cross-questioning. I had formed my conclusions as to the case before
+our client came into the room.”
+
+“My dear Holmes!”
+
+“I have notes of several similar cases, though none, as I remarked
+before, which were quite as prompt. My whole examination served to
+turn my conjecture into a certainty. Circumstantial evidence is
+occasionally very convincing, as when you find a trout in the milk, to
+quote Thoreau’s example.”
+
+“But I have heard all that you have heard.”
+
+“Without, however, the knowledge of pre-existing cases which serves me
+so well. There was a parallel instance in Aberdeen some years back,
+and something on very much the same lines at Munich the year after the
+Franco-Prussian war. It is one of these cases—but, hello, here is
+Lestrade! Good-afternoon, Lestrade! You will find an extra tumbler upon
+the sideboard, and there are cigars in the box.”
+
+The official detective was attired in a pea-jacket and cravat, which
+gave him a decidedly nautical appearance, and he carried a black canvas
+bag in his hand. With a short greeting he seated himself and lit the
+cigar which had been offered to him.
+
+“What’s up, then?” asked Holmes, with a twinkle in his eye. “You look
+dissatisfied.”
+
+“And I feel dissatisfied. It is this infernal St. Simon marriage case.
+I can make neither head nor tail of the business.”
+
+“Really! You surprise me.”
+
+“Who ever heard of such a mixed affair? Every clew seems to slip
+through my fingers. I have been at work upon it all day.”
+
+“And very wet it seems to have made you,” said Holmes, laying his hand
+upon the arm of the pea-jacket.
+
+“Yes, I have been dragging the Serpentine.”
+
+“In Heaven’s name, what for?”
+
+“In search of the body of Lady St. Simon.”
+
+Sherlock Holmes leaned back in his chair and laughed heartily.
+
+“Have you dragged the basin of Trafalgar Square fountain?” he asked.
+
+“Why? What do you mean?”
+
+“Because you have just as good a chance of finding this lady in the one
+as in the other.”
+
+Lestrade shot an angry glance at my companion. “I suppose you know all
+about it,” he snarled.
+
+“Well, I have only just heard the facts, but my mind is made up.”
+
+“Oh, indeed! Then you think that the Serpentine plays no part in the
+matter?”
+
+“I think it very unlikely.”
+
+“Then perhaps you will kindly explain how it is that we found this
+in it?” He opened his bag as he spoke, and tumbled onto the floor a
+wedding-dress of watered silk, a pair of white satin shoes, and a
+bride’s wreath and veil, all discolored and soaked in water. “There,”
+said he, putting a new wedding-ring upon the top of the pile. “There is
+a little nut for you to crack, Master Holmes.”
+
+“Oh, indeed!” said my friend, blowing blue rings into the air. “You
+dragged them from the Serpentine?”
+
+“No. They were found floating near the margin by a park-keeper. They
+have been identified as her clothes, and it seemed to me that if the
+clothes were there the body would not be far off.”
+
+“By the same brilliant reasoning, every man’s body is to be found in
+the neighborhood of his wardrobe. And pray what did you hope to arrive
+at through this?”
+
+“At some evidence implicating Flora Millar in the disappearance.”
+
+“I am afraid that you will find it difficult.”
+
+“Are you, indeed, now?” cried Lestrade, with some bitterness. “I am
+afraid, Holmes, that you are not very practical with your deductions
+and your inferences. You have made two blunders in as many minutes.
+This dress does implicate Miss Flora Millar.”
+
+“And how?”
+
+“In the dress is a pocket. In the pocket is a card-case. In the
+card-case is a note. And here is the very note.” He slapped it down
+upon the table in front of him. “Listen to this: ‘You will see me when
+all is ready. Come at once. F. H. M.’ Now my theory all along has been
+that Lady St. Simon was decoyed away by Flora Millar, and that she,
+with confederates, no doubt, was responsible for her disappearance.
+Here, signed with her initials, is the very note which was no doubt
+quietly slipped into her hand at the door, and which lured her within
+their reach.”
+
+“Very good, Lestrade,” said Holmes, laughing. “You really are very fine
+indeed. Let me see it.” He took up the paper in a listless way, but
+his attention instantly became riveted, and he gave a little cry of
+satisfaction. “This is indeed important,” said he.
+
+“Ha! you find it so?”
+
+“Extremely so. I congratulate you warmly.”
+
+Lestrade rose in his triumph and bent his head to look. “Why,” he
+shrieked, “you’re looking at the wrong side!”
+
+“On the contrary, this is the right side.”
+
+“The right side? You’re mad! Here is the note written in pencil over
+here.”
+
+“And over here is what appears to be the fragment of a hotel bill,
+which interests me deeply.”
+
+“There’s nothing in it. I looked at it before,” said Lestrade. “‘Oct.
+4th, rooms 8_s._, breakfast 2_s._ 6_d._, cocktail 1_s._, lunch 2_s._
+6_d._, glass sherry, 8_d._’ I see nothing in that.”
+
+“Very likely not. It is most important, all the same. As to the note,
+it is important also, or at least the initials are, so I congratulate
+you again.”
+
+“I’ve wasted time enough,” said Lestrade, rising. “I believe in hard
+work, and not in sitting by the fire spinning fine theories. Good-day,
+Mr. Holmes, and we shall see which gets to the bottom of the matter
+first.” He gathered up the garments, thrust them into the bag, and made
+for the door.
+
+“Just one hint to you, Lestrade,” drawled Holmes, before his rival
+vanished; “I will tell you the true solution of the matter. Lady St.
+Simon is a myth. There is not, and there never has been, any such
+person.”
+
+Lestrade looked sadly at my companion. Then he turned to me, tapped
+his forehead three times, shook his head solemnly, and hurried away.
+
+He had hardly shut the door behind him when Holmes rose and put on his
+overcoat. “There is something in what the fellow says about out-door
+work,” he remarked, “so I think, Watson, that I must leave you to your
+papers for a little.”
+
+It was after five o’clock when Sherlock Holmes left me, but I had no
+time to be lonely, for within an hour there arrived a confectioner’s
+man with a very large flat box. This he unpacked with the help of a
+youth whom he had brought with him, and presently, to my very great
+astonishment, a quite epicurean little cold supper began to be laid out
+upon our humble lodging-house mahogany. There were a couple of brace of
+cold woodcock, a pheasant, a _pâté de foie gras_ pie, with a group of
+ancient and cobwebby bottles. Having laid out all these luxuries, my
+two visitors vanished away, like the genii of the Arabian Nights, with
+no explanation save that the things had been paid for and were ordered
+to this address.
+
+Just before nine o’clock Sherlock Holmes stepped briskly into the room.
+His features were gravely set, but there was a light in his eye which
+made me think that he had not been disappointed in his conclusions.
+
+“They have laid the supper, then,” he said, rubbing his hands.
+
+“You seem to expect company. They have laid for five.”
+
+“Yes, I fancy we may have some company dropping in,” said he. “I am
+surprised that Lord St. Simon has not already arrived. Ha! I fancy that
+I hear his step now upon the stairs.”
+
+It was indeed our visitor of the morning who came bustling in, dangling
+his glasses more vigorously than ever, and with a very perturbed
+expression upon his aristocratic features.
+
+“My messenger reached you, then?” asked Holmes.
+
+“Yes, and I confess that the contents startled me beyond measure. Have
+you good authority for what you say?”
+
+“The best possible.”
+
+Lord St. Simon sank into a chair and passed his hand over his forehead.
+
+“What will the duke say,” he murmured, “when he hears that one of the
+family has been subjected to such humiliation?”
+
+“It is the purest accident. I cannot allow that there is any
+humiliation.”
+
+“Ah, you look on these things from another stand-point.”
+
+“I fail to see that any one is to blame. I can hardly see how the lady
+could have acted otherwise, though her abrupt method of doing it was
+undoubtedly to be regretted. Having no mother, she had no one to advise
+her at such a crisis.”
+
+“It was a slight, sir, a public slight,” said Lord St. Simon, tapping
+his fingers upon the table.
+
+“You must make allowance for this poor girl, placed in so unprecedented
+a position.”
+
+“I will make no allowance. I am very angry indeed, and I have been
+shamefully used.”
+
+“I think that I heard a ring,” said Holmes. “Yes, there are steps on
+the landing. If I cannot persuade you to take a lenient view of the
+matter, Lord St. Simon, I have brought an advocate here who may be more
+successful.” He opened the door and ushered in a lady and gentleman.
+“Lord St. Simon,” said he, “allow me to introduce you to Mr. and Mrs.
+Francis Hay Moulton. The lady, I think, you have already met.”
+
+At the sight of these new-comers our client had sprung from his seat
+and stood very erect, with his eyes cast down and his hand thrust into
+the breast of his frock-coat, a picture of offended dignity. The lady
+had taken a quick step forward and had held out her hand to him, but
+he still refused to raise his eyes. It was as well for his resolution,
+perhaps, for her pleading face was one which it was hard to resist.
+
+“You’re angry, Robert,” said she. “Well, I guess you have every cause
+to be.”
+
+“Pray make no apology to me,” said Lord St. Simon, bitterly.
+
+“Oh yes, I know that I have treated you real bad, and that I should
+have spoken to you before I went; but I was kind of rattled, and from
+the time when I saw Frank here again I just didn’t know what I was
+doing or saying. I only wonder I didn’t fall down and do a faint right
+there before the altar.”
+
+“Perhaps, Mrs. Moulton, you would like my friend and me to leave the
+room while you explain this matter?”
+
+“If I may give an opinion,” remarked the strange gentleman, “we’ve had
+just a little too much secrecy over this business already. For my part,
+I should like all Europe and America to hear the rights of it.” He was
+a small, wiry, sunburnt man, clean shaven, with a sharp face and alert
+manner.
+
+“Then I’ll tell our story right away,” said the lady. “Frank here and I
+met in ’84, in McQuire’s camp, near the Rockies, where pa was working
+a claim. We were engaged to each other, Frank and I; but then one day
+father struck a rich pocket and made a pile, while poor Frank here had
+a claim that petered out and came to nothing. The richer pa grew, the
+poorer was Frank; so at last pa wouldn’t hear of our engagement lasting
+any longer, and he took me away to ’Frisco. Frank wouldn’t throw up
+his hand, though; so he followed me there, and he saw me without pa
+knowing anything about it. It would only have made him mad to know, so
+we just fixed it all up for ourselves. Frank said that he would go and
+make his pile, too, and never come back to claim me until he had as
+much as pa. So then I promised to wait for him to the end of time, and
+pledged myself not to marry any one else while he lived. ‘Why shouldn’t
+we be married right away, then,’ said he, ‘and then I will feel sure of
+you; and I won’t claim to be your husband until I come back?’ Well, we
+talked it over, and he had fixed it all up so nicely, with a clergyman
+all ready in waiting, that we just did it right there; and then Frank
+went off to seek his fortune, and I went back to pa.
+
+“The next I heard of Frank was that he was in Montana, and then he went
+prospecting in Arizona, and then I heard of him from New Mexico. After
+that came a long newspaper story about how a miners’ camp had been
+attacked by Apache Indians, and there was my Frank’s name among the
+killed. I fainted dead away, and I was very sick for months after. Pa
+thought I had a decline, and took me to half the doctors in ’Frisco.
+Not a word of news came for a year and more, so that I never doubted
+that Frank was really dead. Then Lord St. Simon came to ’Frisco, and we
+came to London, and a marriage was arranged, and pa was very pleased,
+but I felt all the time that no man on this earth would ever take the
+place in my heart that had been given to my poor Frank.
+
+“Still, if I had married Lord St. Simon, of course I’d have done my
+duty by him. We can’t command our love, but we can our actions. I went
+to the altar with him with the intention to make him just as good a
+wife as it was in me to be. But you may imagine what I felt when, just
+as I came to the altar rails, I glanced back and saw Frank standing
+and looking at me out of the first pew. I thought it was his ghost at
+first; but when I looked again, there he was still, with a kind of
+question in his eyes as if to ask me whether I were glad or sorry to
+see him. I wonder I didn’t drop. I know that everything was turning
+round, and the words of the clergyman were just like the buzz of a bee
+in my ear. I didn’t know what to do. Should I stop the service and make
+a scene in the church? I glanced at him again, and he seemed to know
+what I was thinking, for he raised his finger to his lips to tell me to
+be still. Then I saw him scribble on a piece of paper, and I knew that
+he was writing me a note. As I passed his pew on the way out I dropped
+my bouquet over to him, and he slipped the note into my hand when he
+returned me the flowers. It was only a line asking me to join him when
+he made the sign to me to do so. Of course I never doubted for a moment
+that my first duty was now to him, and I determined to do just whatever
+he might direct.
+
+“When I got back I told my maid, who had known him in California, and
+had always been his friend. I ordered her to say nothing, but to get a
+few things packed and my ulster ready. I know I ought to have spoken
+to Lord St. Simon, but it was dreadful hard before his mother and all
+those great people. I just made up my mind to run away and explain
+afterwards. I hadn’t been at the table ten minutes before I saw Frank
+out of the window at the other side of the road. He beckoned to me, and
+then began walking into the Park. I slipped out, put on my things, and
+followed him. Some woman came talking something or other about Lord
+St. Simon to me—seemed to me from the little I heard as if he had a
+little secret of his own before marriage also—but I managed to get
+away from her, and soon overtook Frank. We got into a cab together, and
+away we drove to some lodgings he had taken in Gordon Square, and that
+was my true wedding after all those years of waiting. Frank had been a
+prisoner among the Apaches, had escaped, came on to ’Frisco, found that
+I had given him up for dead and had gone to England, followed me there,
+and had come upon me at last on the very morning of my second wedding.”
+
+“I saw it in a paper,” explained the American. “It gave the name and
+the church, but not where the lady lived.”
+
+“Then we had a talk as to what we should do, and Frank was all for
+openness, but I was so ashamed of it all that I felt as if I should
+like to vanish away and never see any of them again—just sending
+a line to pa, perhaps, to show him that I was alive. It was awful
+to me to think of all those lords and ladies sitting round that
+breakfast-table and waiting for me to come back. So Frank took my
+wedding-clothes and things and made a bundle of them, so that I should
+not be traced, and dropped them away somewhere where no one could find
+them. It is likely that we should have gone on to Paris to-morrow, only
+that this good gentleman, Mr. Holmes, came round to us this evening,
+though how he found us is more than I can think, and he showed us very
+clearly and kindly that I was wrong and that Frank was right, and that
+we should be putting ourselves in the wrong if we were so secret. Then
+he offered to give us a chance of talking to Lord St. Simon alone, and
+so we came right away round to his rooms at once. Now, Robert, you have
+heard it all, and I am very sorry if I have given you pain, and I hope
+that you do not think very meanly of me.”
+
+Lord St. Simon had by no means relaxed his rigid attitude, but had
+listened with a frowning brow and a compressed lip to this long
+narrative.
+
+“Excuse me,” he said, “but it is not my custom to discuss my most
+intimate personal affairs in this public manner.”
+
+“Then you won’t forgive me? You won’t shake hands before I go?”
+
+“Oh, certainly, if it would give you any pleasure.” He put out his hand
+and coldly grasped that which she extended to him.
+
+“I had hoped,” suggested Holmes, “that you would have joined us in a
+friendly supper.”
+
+“I think that there you ask a little too much,” responded his lordship.
+“I may be forced to acquiesce in these recent developments, but I can
+hardly be expected to make merry over them. I think that, with your
+permission, I will now wish you all a very good-night.” He included us
+all in a sweeping bow and stalked out of the room.
+
+“Then I trust that you at least will honor me with your company,” said
+Sherlock Holmes. “It is always a joy to meet an American, Mr. Moulton,
+for I am one of those who believe that the folly of a monarch and
+the blundering of a minister in far-gone years will not prevent our
+children from being some day citizens of the same world-wide country
+under a flag which shall be a quartering of the Union Jack with the
+Stars and Stripes.”
+
+       *       *       *       *       *
+
+“The case has been an interesting one,” remarked Holmes, when our
+visitors had left us, “because it serves to show very clearly how
+simple the explanation may be of an affair which at first sight seems
+to be almost inexplicable. Nothing could be more natural than the
+sequence of events as narrated by this lady, and nothing stranger than
+the result when viewed, for instance, by Mr. Lestrade, of Scotland
+Yard.”
+
+[Illustration: “‘I WILL WISH YOU ALL A VERY GOOD NIGHT.’”]
+
+“You were not yourself at fault at all, then?”
+
+“From the first, two facts were very obvious to me, the one that the
+lady had been quite willing to undergo the wedding ceremony, the other
+that she had repented of it within a few minutes of returning home.
+Obviously something had occurred during the morning, then, to cause her
+to change her mind. What could that something be? She could not have
+spoken to any one when she was out, for she had been in the company
+of the bridegroom. Had she seen some one, then? If she had, it must
+be some one from America, because she had spent so short a time in
+this country that she could hardly have allowed any one to acquire so
+deep an influence over her that the mere sight of him would induce her
+to change her plans so completely. You see we have already arrived,
+by a process of exclusion, at the idea that she might have seen an
+American. Then who could this American be, and why should he possess so
+much influence over her? It might be a lover; it might be a husband.
+Her young womanhood had, I knew, been spent in rough scenes and under
+strange conditions. So far I had got before I ever heard Lord St.
+Simon’s narrative. When he told us of a man in a pew, of the change in
+the bride’s manner, of so transparent a device for obtaining a note as
+the dropping of a bouquet, of her resort to her confidential maid, and
+of her very significant allusion to claim-jumping—which in miners’
+parlance means taking possession of that which another person has a
+prior claim to—the whole situation became absolutely clear. She had
+gone off with a man, and the man was either a lover or was a previous
+husband—the chances being in favor of the latter.”
+
+“And how in the world did you find them?”
+
+“It might have been difficult, but friend Lestrade held information in
+his hands the value of which he did not himself know. The initials were
+of course of the highest importance, but more valuable still was it
+to know that within a week he had settled his bill at one of the most
+select London hotels.”
+
+“How did you deduce the select?”
+
+“By the select prices. Eight shillings for a bed and eight-pence for a
+glass of sherry pointed to one of the most expensive hotels. There are
+not many in London which charge at that rate. In the second one which
+I visited in Northumberland Avenue, I learned by an inspection of the
+book that Francis H. Moulton, an American gentleman, had left only the
+day before, and on looking over the entries against him, I came upon
+the very items which I had seen in the duplicate bill. His letters
+were to be forwarded to 226 Gordon Square; so thither I travelled, and
+being fortunate enough to find the loving couple at home, I ventured to
+give them some paternal advice, and to point out to them that it would
+be better in every way that they should make their position a little
+clearer both to the general public and to Lord St. Simon in particular.
+I invited them to meet him here, and, as you see, I made him keep the
+appointment.”
+
+“But with no very good result,” I remarked. “His conduct was certainly
+not very gracious.”
+
+“Ah, Watson,” said Holmes, smiling, “perhaps you would not be very
+gracious either, if, after all the trouble of wooing and wedding, you
+found yourself deprived in an instant of wife and of fortune. I think
+that we may judge Lord St. Simon very mercifully, and thank our stars
+that we are never likely to find ourselves in the same position. Draw
+your chair up, and hand me my violin, for the only problem we have
+still to solve is how to while away these bleak autumnal evenings.”
+
+
+
+
+Adventure XI
+
+THE ADVENTURE OF THE BERYL CORONET
+
+
+“Holmes,” said I, as I stood one morning in our bow-window looking down
+the street, “here is a madman coming along. It seems rather sad that
+his relatives should allow him to come out alone.”
+
+My friend rose lazily from his arm-chair and stood with his hands in
+the pockets of his dressing-gown, looking over my shoulder. It was a
+bright, crisp February morning, and the snow of the day before still
+lay deep upon the ground, shimmering brightly in the wintry sun. Down
+the centre of Baker Street it had been ploughed into a brown crumbly
+band by the traffic, but at either side and on the heaped-up edges of
+the foot-paths it still lay as white as when it fell. The gray pavement
+had been cleaned and scraped, but was still dangerously slippery, so
+that there were fewer passengers than usual. Indeed, from the direction
+of the Metropolitan Station no one was coming save the single gentleman
+whose eccentric conduct had drawn my attention.
+
+He was a man of about fifty, tall, portly, and imposing, with a
+massive, strongly marked face and a commanding figure. He was dressed
+in a sombre yet rich style, in black frock-coat, shining hat, neat
+brown gaiters, and well-cut pearl-gray trousers. Yet his actions were
+in absurd contrast to the dignity of his dress and features, for he
+was running hard, with occasional little springs, such as a weary man
+gives who is little accustomed to set any tax upon his legs. As he ran
+he jerked his hands up and down, waggled his head, and writhed his face
+into the most extraordinary contortions.
+
+“What on earth can be the matter with him?” I asked. “He is looking up
+at the numbers of the houses.”
+
+“I believe that he is coming here,” said Holmes, rubbing his hands.
+
+“Here?”
+
+“Yes; I rather think he is coming to consult me professionally. I think
+that I recognize the symptoms. Ha! did I not tell you?” As he spoke,
+the man, puffing and blowing, rushed at our door and pulled at our bell
+until the whole house resounded with the clanging.
+
+A few moments later he was in our room, still puffing, still
+gesticulating, but with so fixed a look of grief and despair in his
+eyes that our smiles were turned in an instant to horror and pity. For
+a while he could not get his words out, but swayed his body and plucked
+at his hair like one who has been driven to the extreme limits of his
+reason. Then, suddenly springing to his feet, he beat his head against
+the wall with such force that we both rushed upon him and tore him away
+to the centre of the room. Sherlock Holmes pushed him down into the
+easy-chair, and, sitting beside him, patted his hand, and chatted with
+him in the easy, soothing tones which he knew so well how to employ.
+
+“You have come to me to tell your story, have you not?” said he. “You
+are fatigued with your haste. Pray wait until you have recovered
+yourself, and then I shall be most happy to look into any little
+problem which you may submit to me.”
+
+The man sat for a minute or more with a heaving chest, fighting against
+his emotion. Then he passed his handkerchief over his brow, set his
+lips tight, and turned his face towards us.
+
+“No doubt you think me mad?” said he.
+
+“I see that you have had some great trouble,” responded Holmes.
+
+“God knows I have!—a trouble which is enough to unseat my reason,
+so sudden and so terrible is it. Public disgrace I might have faced,
+although I am a man whose character has never yet borne a stain.
+Private affliction also is the lot of every man; but the two coming
+together, and in so frightful a form, have been enough to shake my very
+soul. Besides, it is not I alone. The very noblest in the land may
+suffer, unless some way be found out of this horrible affair.”
+
+“Pray compose yourself, sir,” said Holmes, “and let me have a clear
+account of who you are, and what it is that has befallen you.”
+
+“My name,” answered our visitor, “is probably familiar to your ears.
+I am Alexander Holder, of the banking firm of Holder & Stevenson, of
+Threadneedle Street.”
+
+The name was indeed well known to us as belonging to the senior partner
+in the second largest private banking concern in the City of London.
+What could have happened, then, to bring one of the foremost citizens
+of London to this most pitiable pass? We waited, all curiosity, until
+with another effort he braced himself to tell his story.
+
+“I feel that time is of value,” said he; “that is why I hastened
+here when the police inspector suggested that I should secure your
+co-operation. I came to Baker Street by the Underground, and hurried
+from there on foot, for the cabs go slowly through this snow. That
+is why I was so out of breath, for I am a man who takes very little
+exercise. I feel better now, and I will put the facts before you as
+shortly and yet as clearly as I can.
+
+“It is, of course, well known to you that in a successful banking
+business as much depends upon our being able to find remunerative
+investments for our funds as upon our increasing our connection and the
+number of our depositors. One of our most lucrative means of laying out
+money is in the shape of loans, where the security is unimpeachable. We
+have done a good deal in this direction during the last few years, and
+there are many noble families to whom we have advanced large sums upon
+the security of their pictures, libraries, or plate.
+
+“Yesterday morning I was seated in my office at the bank when a card
+was brought in to me by one of the clerks. I started when I saw the
+name, for it was that of none other than—well, perhaps even to you I
+had better say no more than that it was a name which is a household
+word all over the earth—one of the highest, noblest, most exalted
+names in England. I was overwhelmed by the honor, and attempted, when
+he entered, to say so, but he plunged at once into business with the
+air of a man who wishes to hurry quickly through a disagreeable task.
+
+“‘Mr. Holder,’ said he, ‘I have been informed that you are in the habit
+of advancing money.’
+
+“‘The firm do so when the security is good,’ I answered.
+
+“‘It is absolutely essential to me,’ said he, ‘that I should have
+£50,000 at once. I could of course borrow so trifling a sum ten
+times over from my friends, but I much prefer to make it a matter of
+business, and to carry out that business myself. In my position you
+can readily understand that it is unwise to place one’s self under
+obligations.’
+
+“‘For how long, may I ask, do you want this sum?’ I asked.
+
+“‘Next Monday I have a large sum due to me, and I shall then most
+certainly repay what you advance, with whatever interest you think it
+right to charge. But it is very essential to me that the money should
+be paid at once.’
+
+“‘I should be happy to advance it without further parley from my own
+private purse,’ said I, ‘were it not that the strain would be rather
+more than it could bear. If, on the other hand, I am to do it in the
+name of the firm, then in justice to my partner I must insist that,
+even in your case, every business-like precaution should be taken.’
+
+“‘I should much prefer to have it so,’ said he, raising up a square,
+black morocco case which he had laid beside his chair. ‘You have
+doubtless heard of the Beryl Coronet?’
+
+“‘One of the most precious public possessions of the empire,’ said I.
+
+“‘Precisely.’ He opened the case, and there, imbedded in soft,
+flesh-colored velvet, lay the magnificent piece of jewelry which he
+had named. ‘There are thirty-nine enormous beryls,’ said he, ‘and the
+price of the gold chasing is incalculable. The lowest estimate would
+put the worth of the coronet at double the sum which I have asked. I am
+prepared to leave it with you as my security.’
+
+“I took the precious case into my hands and looked in some perplexity
+from it to my illustrious client.
+
+“‘You doubt its value?’ he asked.
+
+“‘Not at all. I only doubt—’
+
+“‘The propriety of my leaving it. You may set your mind at rest about
+that. I should not dream of doing so were it not absolutely certain
+that I should be able in four days to reclaim it. It is a pure matter
+of form. Is the security sufficient?’
+
+“‘Ample.’
+
+“‘You understand, Mr. Holder, that I am giving you a strong proof of
+the confidence which I have in you, founded upon all that I have heard
+of you. I rely upon you not only to be discreet and to refrain from all
+gossip upon the matter, but, above all, to preserve this coronet with
+every possible precaution, because I need not say that a great public
+scandal would be caused if any harm were to befall it. Any injury to
+it would be almost as serious as its complete loss, for there are no
+beryls in the world to match these, and it would be impossible to
+replace them. I leave it with you, however, with every confidence, and
+I shall call for it in person on Monday morning.’
+
+“Seeing that my client was anxious to leave, I said no more; but,
+calling for my cashier, I ordered him to pay over fifty £1000 notes.
+When I was alone once more, however, with the precious case lying upon
+the table in front of me, I could not but think with some misgivings of
+the immense responsibility which it entailed upon me. There could be no
+doubt that, as it was a national possession, a horrible scandal would
+ensue if any misfortune should occur to it. I already regretted having
+ever consented to take charge of it. However, it was too late to alter
+the matter now, so I locked it up in my private safe, and turned once
+more to my work.
+
+“When evening came I felt that it would be an imprudence to leave so
+precious a thing in the office behind me. Bankers’ safes had been
+forced before now, and why should not mine be? If so, how terrible
+would be the position in which I should find myself! I determined,
+therefore, that for the next few days I would always carry the case
+backward and forward with me, so that it might never be really out
+of my reach. With this intention, I called a cab, and drove out to
+my house at Streatham, carrying the jewel with me. I did not breathe
+freely until I had taken it up-stairs and locked it in the bureau of my
+dressing-room.
+
+“And now a word as to my household, Mr. Holmes, for I wish you to
+thoroughly understand the situation. My groom and my page sleep out of
+the house, and may be set aside altogether. I have three maid-servants
+who have been with me a number of years, and whose absolute reliability
+is quite above suspicion. Another, Lucy Parr, the second waiting-maid,
+has only been in my service a few months. She came with an excellent
+character, however, and has always given me satisfaction. She is a very
+pretty girl, and has attracted admirers who have occasionally hung
+about the place. That is the only drawback which we have found to her,
+but we believe her to be a thoroughly good girl in every way.
+
+“So much for the servants. My family itself is so small that it will
+not take me long to describe it. I am a widower, and have an only son,
+Arthur. He has been a disappointment to me, Mr. Holmes—a grievous
+disappointment. I have no doubt that I am myself to blame. People tell
+me that I have spoiled him. Very likely I have. When my dear wife died
+I felt that he was all I had to love. I could not bear to see the smile
+fade even for a moment from his face. I have never denied him a wish.
+Perhaps it would have been better for both of us had I been sterner,
+but I meant it for the best.
+
+“It was naturally my intention that he should succeed me in my
+business, but he was not of a business turn. He was wild, wayward, and,
+to speak the truth, I could not trust him in the handling of large
+sums of money. When he was young he became a member of an aristocratic
+club, and there, having charming manners, he was soon the intimate of a
+number of men with long purses and expensive habits. He learned to play
+heavily at cards and to squander money on the turf, until he had again
+and again to come to me and implore me to give him an advance upon his
+allowance, that he might settle his debts of honor. He tried more than
+once to break away from the dangerous company which he was keeping, but
+each time the influence of his friend Sir George Burnwell was enough to
+draw him back again.
+
+“And, indeed, I could not wonder that such a man as Sir George Burnwell
+should gain an influence over him, for he has frequently brought him
+to my house, and I have found myself that I could hardly resist the
+fascination of his manner. He is older than Arthur, a man of the world
+to his finger-tips, one who had been everywhere, seen everything, a
+brilliant talker, and a man of great personal beauty. Yet when I think
+of him in cold blood, far away from the glamour of his presence, I am
+convinced from his cynical speech, and the look which I have caught in
+his eyes, that he is one who should be deeply distrusted. So I think,
+and so, too, thinks my little Mary, who has a woman’s quick insight
+into character.
+
+“And now there is only she to be described. She is my niece; but when
+my brother died five years ago and left her alone in the world I
+adopted her, and have looked upon her ever since as my daughter. She is
+a sunbeam in my house—sweet, loving, beautiful, a wonderful manager
+and house-keeper, yet as tender and quiet and gentle as a woman could
+be. She is my right hand. I do not know what I could do without her. In
+only one matter has she ever gone against my wishes. Twice my boy has
+asked her to marry him, for he loves her devotedly, but each time she
+has refused him. I think that if any one could have drawn him into the
+right path it would have been she, and that his marriage might have
+changed his whole life; but now, alas! it is too late—for ever too
+late!
+
+“Now, Mr. Holmes, you know the people who live under my roof, and I
+shall continue with my miserable story.
+
+“When we were taking coffee in the drawing-room that night, after
+dinner, I told Arthur and Mary my experience, and of the precious
+treasure which we had under our roof, suppressing only the name of my
+client. Lucy Parr, who had brought in the coffee, had, I am sure, left
+the room; but I cannot swear that the door was closed. Mary and Arthur
+were much interested, and wished to see the famous coronet, but I
+thought it better not to disturb it.
+
+“‘Where have you put it?’ asked Arthur.
+
+“‘In my own bureau.’
+
+“‘Well, I hope to goodness the house won’t be burgled during the
+night,’ said he.
+
+“‘It is locked up,’ I answered.
+
+“‘Oh, any old key will fit that bureau. When I was a youngster I have
+opened it myself with the key of the box-room cupboard.’
+
+“He often had a wild way of talking, so that I thought little of what
+he said. He followed me to my room, however, that night with a very
+grave face.
+
+“‘Look here, dad,’ said he, with his eyes cast down, ‘can you let me
+have £200?’
+
+“‘No, I cannot!’ I answered, sharply. ‘I have been far too generous
+with you in money matters.’
+
+“‘You have been very kind,’ said he: ‘but I must have this money, or
+else I can never show my face inside the club again.’
+
+“‘And a very good thing, too!’ I cried.
+
+“‘Yes, but you would not have me leave it a dishonored man,’ said he.
+‘I could not bear the disgrace. I must raise the money in some way, and
+if you will not let me have it, then I must try other means.’
+
+“I was very angry, for this was the third demand during the month. ‘You
+shall not have a farthing from me,’ I cried; on which he bowed and left
+the room without another word.
+
+“When he was gone I unlocked my bureau, made sure that my treasure was
+safe, and locked it again. Then I started to go round the house to see
+that all was secure—a duty which I usually leave to Mary, but which I
+thought it well to perform myself that night. As I came down the stairs
+I saw Mary herself at the side window of the hall, which she closed and
+fastened as I approached.
+
+“‘Tell me, dad,’ said she, looking, I thought, a little disturbed, ‘did
+you give Lucy, the maid, leave to go out to-night?’
+
+“‘Certainly not.’
+
+“‘She came in just now by the back door. I have no doubt that she has
+only been to the side gate to see some one; but I think that it is
+hardly safe, and should be stopped.”
+
+“‘You must speak to her in the morning, or I will, if you prefer it.
+Are you sure that everything is fastened?’
+
+“‘Quite sure, dad.’
+
+“‘Then, good-night.’ I kissed her, and went up to my bedroom again,
+where I was soon asleep.
+
+“I am endeavoring to tell you everything, Mr. Holmes, which may have
+any bearing upon the case, but I beg that you will question me upon any
+point which I do not make clear.”
+
+“On the contrary, your statement is singularly lucid.”
+
+“I come to a part of my story now in which I should wish to be
+particularly so. I am not a very heavy sleeper, and the anxiety in my
+mind tended, no doubt, to make me even less so than usual. About two
+in the morning, then, I was awakened by some sound in the house. It
+had ceased ere I was wide awake, but it had left an impression behind
+it as though a window had gently closed somewhere. I lay listening
+with all my ears. Suddenly, to my horror, there was a distinct sound
+of footsteps moving softly in the next room. I slipped out of bed, all
+palpitating with fear, and peeped round the corner of my dressing-room
+door.
+
+“‘Arthur!’ I screamed, ‘you villain! you thief! How dare you touch that
+coronet?’
+
+“The gas was half up, as I had left it, and my unhappy boy, dressed
+only in his shirt and trousers, was standing beside the light, holding
+the coronet in his hands. He appeared to be wrenching at it, or bending
+it with all his strength. At my cry he dropped it from his grasp, and
+turned as pale as death. I snatched it up and examined it. One of the
+gold corners, with three of the beryls in it, was missing.
+
+“‘You blackguard!’ I shouted, beside myself with rage. ‘You have
+destroyed it! You have dishonored me for ever! Where are the jewels
+which you have stolen?’
+
+“‘Stolen!’ he cried.
+
+“‘Yes, you thief!’ I roared, shaking him by the shoulder.
+
+“‘There are none missing. There cannot be any missing,’ said he.
+
+“‘There are three missing. And you know where they are. Must I call you
+a liar as well as a thief? Did I not see you trying to tear off another
+piece?’
+
+“‘You have called me names enough,’ said he; ‘I will not stand it any
+longer. I shall not say another word about this business since you have
+chosen to insult me. I will leave your house in the morning and make my
+own way in the world.’
+
+“‘You shall leave it in the hands of the police!’ I cried, half-mad
+with grief and rage. ‘I shall have this matter probed to the bottom.’
+
+“‘You shall learn nothing from me,’ said he, with a passion such as I
+should not have thought was in his nature. ‘If you choose to call the
+police, let the police find what they can.’
+
+“By this time the whole house was astir, for I had raised my voice in
+my anger. Mary was the first to rush into my room, and, at the sight of
+the coronet and of Arthur’s face, she read the whole story, and, with
+a scream, fell down senseless on the ground. I sent the house-maid for
+the police, and put the investigation into their hands at once. When
+the inspector and a constable entered the house, Arthur, who had stood
+sullenly with his arms folded, asked me whether it was my intention to
+charge him with theft. I answered that it had ceased to be a private
+matter, but had become a public one, since the ruined coronet was
+national property. I was determined that the law should have its way in
+everything.
+
+“‘At least,’ said he, ‘you will not have me arrested at once. It would
+be to your advantage as well as mine if I might leave the house for
+five minutes.’
+
+“‘That you may get away, or perhaps that you may conceal what you have
+stolen,’ said I. And then realizing the dreadful position in which I
+was placed, I implored him to remember that not only my honor, but that
+of one who was far greater than I was at stake; and that he threatened
+to raise a scandal which would convulse the nation. He might avert it
+all if he would but tell me what he had done with the three missing
+stones.
+
+“‘You may as well face the matter,’ said I; ‘you have been caught in
+the act, and no confession could make your guilt more heinous. If you
+but make such reparation as is in your power, by telling us where the
+beryls are, all shall be forgiven and forgotten.’
+
+“‘Keep your forgiveness for those who ask for it,’ he answered, turning
+away from me, with a sneer. I saw that he was too hardened for any
+words of mine to influence him. There was but one way for it. I called
+in the inspector, and gave him into custody. A search was made at once,
+not only of his person, but of his room, and of every portion of the
+house where he could possibly have concealed the gems; but no trace of
+them could be found, nor would the wretched boy open his mouth for all
+our persuasions and our threats. This morning he was removed to a cell,
+and I, after going through all the police formalities, have hurried
+round to you, to implore you to use your skill in unravelling the
+matter. The police have openly confessed that they can at present make
+nothing of it. You may go to any expense which you think necessary. I
+have already offered a reward of £1000. My God, what shall I do! I have
+lost my honor, my gems, and my son in one night. Oh, what shall I do!”
+
+He put a hand on either side of his head, and rocked himself to and
+fro, droning to himself like a child whose grief has got beyond words.
+
+Sherlock Holmes sat silent for some few minutes, with his brows knitted
+and his eyes fixed upon the fire.
+
+“Do you receive much company?” he asked.
+
+“None, save my partner with his family, and an occasional friend of
+Arthur’s. Sir George Burnwell has been several times lately. No one
+else, I think.”
+
+“Do you go out much in society?”
+
+“Arthur does. Mary and I stay at home. We neither of us care for it.”
+
+“That is unusual in a young girl.”
+
+“She is of a quiet nature. Besides, she is not so very young. She is
+four-and-twenty.”
+
+“This matter, from what you say, seems to have been a shock to her
+also.”
+
+“Terrible! She is even more affected than I.”
+
+“You have neither of you any doubt as to your son’s guilt?”
+
+“How can we have, when I saw him with my own eyes with the coronet in
+his hands.”
+
+“I hardly consider that a conclusive proof. Was the remainder of the
+coronet at all injured?”
+
+“Yes, it was twisted.”
+
+“Do you not think, then, that he might have been trying to straighten
+it?”
+
+“God bless you! You are doing what you can for him and for me. But it
+is too heavy a task. What was he doing there at all? If his purpose
+were innocent, why did he not say so?”
+
+“Precisely. And if it were guilty, why did he not invent a lie? His
+silence appears to me to cut both ways. There are several singular
+points about the case. What did the police think of the noise which
+awoke you from your sleep?”
+
+“They considered that it might be caused by Arthur’s closing his
+bedroom door.”
+
+“A likely story! As if a man bent on felony would slam his door so as
+to wake a household. What did they say, then, of the disappearance of
+these gems?”
+
+“They are still sounding the planking and probing the furniture in the
+hope of finding them.”
+
+“Have they thought of looking outside the house?”
+
+“Yes, they have shown extraordinary energy. The whole garden has
+already been minutely examined.”
+
+“Now, my dear sir,” said Holmes, “is it not obvious to you now that
+this matter really strikes very much deeper than either you or the
+police were at first inclined to think? It appeared to you to be a
+simple case; to me it seems exceedingly complex. Consider what is
+involved by your theory. You suppose that your son came down from his
+bed, went, at great risk, to your dressing-room, opened your bureau,
+took out your coronet, broke off by main force a small portion of
+it, went off to some other place, concealed three gems out of the
+thirty-nine, with such skill that nobody can find them, and then
+returned with the other thirty-six into the room in which he exposed
+himself to the greatest danger of being discovered. I ask you now, is
+such a theory tenable?”
+
+“But what other is there?” cried the banker, with a gesture of despair.
+“If his motives were innocent, why does he not explain them?”
+
+“It is our task to find that out,” replied Holmes; “so now, if you
+please, Mr. Holder, we will set off for Streatham together, and devote
+an hour to glancing a little more closely into details.”
+
+My friend insisted upon my accompanying them in their expedition,
+which I was eager enough to do, for my curiosity and sympathy were
+deeply stirred by the story to which we had listened. I confess that
+the guilt of the banker’s son appeared to me to be as obvious as it
+did to his unhappy father, but still I had such faith in Holmes’s
+judgment that I felt that there must be some grounds for hope as long
+as he was dissatisfied with the accepted explanation. He hardly spoke
+a word the whole way out to the southern suburb, but sat with his chin
+upon his breast and his hat drawn over his eyes, sunk in the deepest
+thought. Our client appeared to have taken fresh heart at the little
+glimpse of hope which had been presented to him, and he even broke into
+a desultory chat with me over his business affairs. A short railway
+journey and a shorter walk brought us to Fairbank, the modest residence
+of the great financier.
+
+Fairbank was a good-sized square house of white stone, standing back
+a little from the road. A double carriage-sweep, with a snow-clad
+lawn, stretched down in front to two large iron gates which closed the
+entrance. On the right side was a small wooden thicket, which led into
+a narrow path between two neat hedges stretching from the road to the
+kitchen door, and forming the tradesmen’s entrance. On the left ran a
+lane which led to the stables, and was not itself within the grounds
+at all, being a public, though little used, thoroughfare. Holmes left
+us standing at the door, and walked slowly all round the house, across
+the front, down the tradesmen’s path, and so round by the garden behind
+into the stable lane. So long was he that Mr. Holder and I went into
+the dining-room and waited by the fire until he should return. We were
+sitting there in silence when the door opened and a young lady came in.
+She was rather above the middle height, slim, with dark hair and eyes,
+which seemed the darker against the absolute pallor of her skin. I do
+not think that I have ever seen such deadly paleness in a woman’s face.
+Her lips, too, were bloodless, but her eyes were flushed with crying.
+As she swept silently into the room she impressed me with a greater
+sense of grief than the banker had done in the morning, and it was the
+more striking in her as she was evidently a woman of strong character,
+with immense capacity for self-restraint. Disregarding my presence,
+she went straight to her uncle, and passed her hand over his head with
+a sweet womanly caress.
+
+“You have given orders that Arthur should be liberated, have you not,
+dad?” she asked.
+
+“No, no, my girl, the matter must be probed to the bottom.”
+
+“But I am so sure that he is innocent. You know what women’s instincts
+are. I know that he has done no harm and that you will be sorry for
+having acted so harshly.”
+
+“Why is he silent, then, if he is innocent?”
+
+“Who knows? Perhaps because he was so angry that you should suspect
+him.”
+
+“How could I help suspecting him, when I actually saw him with the
+coronet in his hand?”
+
+“Oh, but he had only picked it up to look at it. Oh do, do take my word
+for it that he is innocent. Let the matter drop and say no more. It is
+so dreadful to think of our dear Arthur in prison!”
+
+“I shall never let it drop until the gems are found—never, Mary! Your
+affection for Arthur blinds you as to the awful consequences to me. Far
+from hushing the thing up, I have brought a gentleman down from London
+to inquire more deeply into it.”
+
+“This gentleman?” she asked, facing round to me.
+
+“No, his friend. He wished us to leave him alone. He is round in the
+stable lane now.”
+
+“The stable lane?” She raised her dark eyebrows. “What can he hope to
+find there? Ah! this, I suppose, is he. I trust, sir, that you will
+succeed in proving, what I feel sure is the truth, that my cousin
+Arthur is innocent of this crime.”
+
+“I fully share your opinion, and I trust, with you, that we may prove
+it,” returned Holmes, going back to the mat to knock the snow from his
+shoes. “I believe I have the honor of addressing Miss Mary Holder.
+Might I ask you a question or two?”
+
+“Pray do, sir, if it may help to clear this horrible affair up.”
+
+“You heard nothing yourself last night?”
+
+“Nothing, until my uncle here began to speak loudly. I heard that, and
+I came down.”
+
+“You shut up the windows and doors the night before. Did you fasten all
+the windows?”
+
+“Yes.”
+
+“Were they all fastened this morning?”
+
+“Yes.”
+
+“You have a maid who has a sweetheart? I think that you remarked to
+your uncle last night that she had been out to see him?”
+
+“Yes, and she was the girl who waited in the drawing-room, and who may
+have heard uncle’s remarks about the coronet.”
+
+“I see. You infer that she may have gone out to tell her sweetheart,
+and that the two may have planned the robbery.”
+
+“But what is the good of all these vague theories,” cried the banker,
+impatiently, “when I have told you that I saw Arthur with the coronet
+in his hands?”
+
+“Wait a little, Mr. Holder. We must come back to that. About this girl,
+Miss Holder. You saw her return by the kitchen door, I presume?”
+
+“Yes; when I went to see if the door was fastened for the night I met
+her slipping in. I saw the man, too, in the gloom.”
+
+“Do you know him?”
+
+“Oh yes; he is the green-grocer who brings our vegetables round. His
+name is Francis Prosper.”
+
+“He stood,” said Holmes, “to the left of the door—that is to say,
+farther up the path than is necessary to reach the door?”
+
+“Yes, he did.”
+
+“And he is a man with a wooden leg?”
+
+Something like fear sprang up in the young lady’s expressive black
+eyes. “Why, you are like a magician,” said she. “How do you know that?”
+She smiled, but there was no answering smile in Holmes’s thin, eager
+face.
+
+“I should be very glad now to go up-stairs,” said he. “I shall probably
+wish to go over the outside of the house again. Perhaps I had better
+take a look at the lower windows before I go up.”
+
+He walked swiftly round from one to the other, pausing only at the
+large one which looked from the hall onto the stable lane. This he
+opened, and made a very careful examination of the sill with his
+powerful magnifying lens. “Now we shall go up-stairs,” said he, at last.
+
+The banker’s dressing-room was a plainly furnished little chamber, with
+a gray carpet, a large bureau, and a long mirror. Holmes went to the
+bureau first and looked hard at the lock.
+
+“Which key was used to open it?” he asked.
+
+“That which my son himself indicated—that of the cupboard of the
+lumber-room.”
+
+“Have you it here?”
+
+“That is it on the dressing-table.”
+
+Sherlock Holmes took it up and opened the bureau.
+
+“It is a noiseless lock,” said he. “It is no wonder that it did not
+wake you. This case, I presume, contains the coronet. We must have a
+look at it.” He opened the case, and, taking out the diadem, he laid it
+upon the table. It was a magnificent specimen of the jeweller’s art,
+and the thirty-six stones were the finest that I have ever seen. At one
+side of the coronet was a cracked edge, where a corner holding three
+gems had been torn away.
+
+“Now, Mr. Holder,” said Holmes, “here is the corner which corresponds
+to that which has been so unfortunately lost. Might I beg that you will
+break it off.”
+
+The banker recoiled in horror. “I should not dream of trying,” said he.
+
+“Then I will.” Holmes suddenly bent his strength upon it, but without
+result. “I feel it give a little,” said he; “but, though I am
+exceptionally strong in the fingers, it would take me all my time to
+break it. An ordinary man could not do it. Now, what do you think would
+happen if I did break it, Mr. Holder? There would be a noise like a
+pistol shot. Do you tell me that all this happened within a few yards
+of your bed, and that you heard nothing of it?”
+
+“I do not know what to think. It is all dark to me.”
+
+“But perhaps it may grow lighter as we go. What do you think, Miss
+Holder?”
+
+“I confess that I still share my uncle’s perplexity.”
+
+“Your son had no shoes or slippers on when you saw him?”
+
+“He had nothing on save only his trousers and shirt.”
+
+“Thank you. We have certainly been favored with extraordinary luck
+during this inquiry, and it will be entirely our own fault if we do not
+succeed in clearing the matter up. With your permission, Mr. Holder, I
+shall now continue my investigations outside.”
+
+He went alone, at his own request, for he explained that any
+unnecessary footmarks might make his task more difficult. For an hour
+or more he was at work, returning at last with his feet heavy with snow
+and his features as inscrutable as ever.
+
+“I think that I have seen now all that there is to see, Mr. Holder,”
+said he; “I can serve you best by returning to my rooms.”
+
+“But the gems, Mr. Holmes. Where are they?”
+
+“I cannot tell.”
+
+The banker wrung his hands. “I shall never see them again!” he cried.
+“And my son? You give me hopes?”
+
+“My opinion is in no way altered.”
+
+“Then, for God’s sake, what was this dark business which was acted in
+my house last night?”
+
+“If you can call upon me at my Baker Street rooms to-morrow morning
+between nine and ten I shall be happy to do what I can to make it
+clearer. I understand that you give me _carte blanche_ to act for you,
+provided only that I get back the gems, and that you place no limit on
+the sum I may draw.”
+
+“I would give my fortune to have them back.”
+
+“Very good. I shall look into the matter between this and then.
+Good-bye; it is just possible that I may have to come over here again
+before evening.”
+
+It was obvious to me that my companion’s mind was now made up about
+the case, although what his conclusions were was more than I could
+even dimly imagine. Several times during our homeward journey I
+endeavored to sound him upon the point, but he always glided away to
+some other topic, until at last I gave it over in despair. It was not
+yet three when we found ourselves in our room once more. He hurried to
+his chamber, and was down again in a few minutes dressed as a common
+loafer. With his collar turned up, his shiny, seedy coat, his red
+cravat, and his worn boots, he was a perfect sample of the class.
+
+“I think that this should do,” said he, glancing into the glass above
+the fireplace. “I only wish that you could come with me, Watson, but
+I fear that it won’t do. I may be on the trail in this matter, or I
+may be following a will-of-the-wisp, but I shall soon know which it
+is. I hope that I may be back in a few hours.” He cut a slice of beef
+from the joint upon the sideboard, sandwiched it between two rounds of
+bread, and, thrusting this rude meal into his pocket, he started off
+upon his expedition.
+
+I had just finished my tea when he returned, evidently in excellent
+spirits, swinging an old elastic-sided boot in his hand. He chucked it
+down into a corner and helped himself to a cup of tea.
+
+“I only looked in as I passed,” said he. “I am going right on.”
+
+“Where to?”
+
+“Oh, to the other side of the West End. It may be some time before I
+get back. Don’t wait up for me in case I should be late.”
+
+“How are you getting on?”
+
+“Oh, so so. Nothing to complain of. I have been out to Streatham since
+I saw you last, but I did not call at the house. It is a very sweet
+little problem, and I would not have missed it for a good deal.
+However, I must not sit gossiping here, but must get these disreputable
+clothes off and return to my highly respectable self.”
+
+I could see by his manner that he had stronger reasons for satisfaction
+than his words alone would imply. His eyes twinkled, and there was even
+a touch of color upon his sallow cheeks. He hastened up-stairs, and a
+few minutes later I heard the slam of the hall door, which told me that
+he was off once more upon his congenial hunt.
+
+I waited until midnight, but there was no sign of his return, so I
+retired to my room. It was no uncommon thing for him to be away for
+days and nights on end when he was hot upon a scent, so that his
+lateness caused me no surprise. I do not know at what hour he came in,
+but when I came down to breakfast in the morning, there he was with a
+cup of coffee in one hand and the paper in the other, as fresh and trim
+as possible.
+
+“You will excuse my beginning without you, Watson,” said he; “but you
+remember that our client has rather an early appointment this morning.”
+
+“Why, it is after nine now,” I answered. “I should not be surprised if
+that were he. I thought I heard a ring.”
+
+It was, indeed, our friend the financier. I was shocked by the change
+which had come over him, for his face, which was naturally of a broad
+and massive mould, was now pinched and fallen in, while his hair seemed
+to me at least a shade whiter. He entered with a weariness and lethargy
+which was even more painful than his violence of the morning before,
+and he dropped heavily into the arm-chair which I pushed forward for
+him.
+
+“I do not know what I have done to be so severely tried,” said he.
+“Only two days ago I was a happy and prosperous man, without a care in
+the world. Now I am left to a lonely and dishonored age. One sorrow
+comes close upon the heels of another. My niece, Mary, has deserted me.”
+
+“Deserted you?”
+
+“Yes. Her bed this morning had not been slept in, her room was empty,
+and a note for me lay upon the hall table. I had said to her last
+night, in sorrow and not in anger, that if she had married my boy all
+might have been well with him. Perhaps it was thoughtless of me to say
+so. It is to that remark that she refers in this note:
+
+  “‘MY DEAREST UNCLE,—I feel that I have brought trouble
+  upon you, and that if I had acted differently this terrible
+  misfortune might never have occurred. I cannot, with this
+  thought in my mind, ever again be happy under your roof, and
+  I feel that I must leave you for ever. Do not worry about my
+  future, for that is provided for; and, above all, do not search
+  for me, for it will be fruitless labor and an ill-service to
+  me. In life or in death, I am ever your loving       MARY.’
+
+“What could she mean by that note, Mr. Holmes? Do you think it points
+to suicide?”
+
+“No, no, nothing of the kind. It is perhaps the best possible solution.
+I trust, Mr. Holder, that you are nearing the end of your troubles.”
+
+“Ha! You say so! You have heard something, Mr. Holmes; you have learned
+something! Where are the gems?”
+
+“You would not think £1000 apiece an excessive sum for them?”
+
+“I would pay ten.”
+
+“That would be unnecessary. Three thousand will cover the matter. And
+there is a little reward, I fancy. Have you your check-book? Here is a
+pen. Better make it out for £4000 pounds.”
+
+With a dazed face the banker made out the required check. Holmes walked
+over to his desk, took out a little triangular piece of gold with three
+gems in it, and threw it down upon the table.
+
+With a shriek of joy our client clutched it up.
+
+“You have it!” he gasped. “I am saved! I am saved!”
+
+The reaction of joy was as passionate as his grief had been, and he
+hugged his recovered gems to his bosom.
+
+“There is one other thing you owe, Mr. Holder,” said Sherlock Holmes,
+rather sternly.
+
+“Owe!” He caught up a pen. “Name the sum, and I will pay it.”
+
+“No, the debt is not to me. You owe a very humble apology to that noble
+lad, your son, who has carried himself in this matter as I should be
+proud to see my own son do, should I ever chance to have one.”
+
+“Then it was not Arthur who took them?”
+
+“I told you yesterday, and I repeat to-day, that it was not.”
+
+“You are sure of it! Then let us hurry to him at once, to let him know
+that the truth is known.”
+
+“He knows it already. When I had cleared it all up I had an interview
+with him, and, finding that he would not tell me the story, I told it
+to him, on which he had to confess that I was right, and to add the
+very few details which were not yet quite clear to me. Your news of
+this morning, however, may open his lips.”
+
+“For Heaven’s sake, tell me, then, what is this extraordinary mystery!”
+
+“I will do so, and I will show you the steps by which I reached it. And
+let me say to you, first, that which it is hardest for me to say and
+for you to hear: there has been an understanding between Sir George
+Burnwell and your niece Mary. They have now fled together.”
+
+“My Mary? Impossible!”
+
+“It is, unfortunately, more than possible; it is certain. Neither you
+nor your son knew the true character of this man when you admitted
+him into your family circle. He is one of the most dangerous men in
+England—a ruined gambler, an absolutely desperate villain, a man
+without heart or conscience. Your niece knew nothing of such men. When
+he breathed his vows to her, as he had done to a hundred before her,
+she flattered herself that she alone had touched his heart. The devil
+knows best what he said, but at least she became his tool, and was in
+the habit of seeing him nearly every evening.”
+
+“I cannot, and I will not, believe it!” cried the banker, with an ashen
+face.
+
+“I will tell you, then, what occurred in your house last night. Your
+niece, when you had, as she thought, gone to your room, slipped down
+and talked to her lover through the window which leads into the stable
+lane. His footmarks had pressed right through the snow, so long had
+he stood there. She told him of the coronet. His wicked lust for gold
+kindled at the news, and he bent her to his will. I have no doubt
+that she loved you, but there are women in whom the love of a lover
+extinguishes all other loves, and I think that she must have been one.
+She had hardly listened to his instructions when she saw you coming
+down-stairs, on which she closed the window rapidly, and told you about
+one of the servants’ escapade with her wooden-legged lover, which was
+all perfectly true.
+
+“Your boy, Arthur, went to bed after his interview with you, but
+he slept badly on account of his uneasiness about his club debts.
+In the middle of the night he heard a soft tread pass his door, so
+he rose, and looking out, was surprised to see his cousin walking
+very stealthily along the passage, until she disappeared into your
+dressing-room. Petrified with astonishment, the lad slipped on some
+clothes, and waited there in the dark to see what would come of this
+strange affair. Presently she emerged from the room again, and in the
+light of the passage-lamp your son saw that she carried the precious
+coronet in her hands. She passed down the stairs, and he, thrilling
+with horror, ran along and slipped behind the curtain near your door,
+whence he could see what passed in the hall beneath. He saw her
+stealthily open the window, hand out the coronet to some one in the
+gloom, and then closing it once more hurry back to her room, passing
+quite close to where he stood hid behind the curtain.
+
+“As long as she was on the scene he could not take any action without
+a horrible exposure of the woman whom he loved. But the instant that
+she was gone he realized how crushing a misfortune this would be for
+you, and how all-important it was to set it right. He rushed down, just
+as he was, in his bare feet, opened the window, sprang out into the
+snow, and ran down the lane, where he could see a dark figure in the
+moonlight. Sir George Burnwell tried to get away, but Arthur caught
+him, and there was a struggle between them, your lad tugging at one
+side of the coronet, and his opponent at the other. In the scuffle,
+your son struck Sir George, and cut him over the eye. Then something
+suddenly snapped, and your son, finding that he had the coronet in his
+hands, rushed back, closed the window, ascended to your room, and had
+just observed that the coronet had been twisted in the struggle, and
+was endeavoring to straighten it when you appeared upon the scene.”
+
+“Is it possible?” gasped the banker.
+
+“You then roused his anger by calling him names at a moment when he
+felt that he had deserved your warmest thanks. He could not explain
+the true state of affairs without betraying one who certainly deserved
+little enough consideration at his hands. He took the more chivalrous
+view, however, and preserved her secret.”
+
+“And that was why she shrieked and fainted when she saw the coronet,”
+cried Mr. Holder. “Oh, my God! what a blind fool I have been! And his
+asking to be allowed to go out for five minutes! The dear fellow wanted
+to see if the missing piece were at the scene of the struggle. How
+cruelly I have misjudged him!”
+
+“When I arrived at the house,” continued Holmes, “I at once went very
+carefully round it to observe if there were any traces in the snow
+which might help me. I knew that none had fallen since the evening
+before, and also that there had been a strong frost to preserve
+impressions. I passed along the tradesmen’s path, but found it all
+trampled down and indistinguishable. Just beyond it, however, at the
+far side of the kitchen door, a woman had stood and talked with a man,
+whose round impressions on one side showed that he had a wooden leg.
+I could even tell that they had been disturbed, for the woman had run
+back swiftly to the door, as was shown by the deep toe and light heel
+marks, while Wooden-leg had waited a little, and then had gone away.
+I thought at the time that this might be the maid and her sweetheart,
+of whom you had already spoken to me, and inquiry showed it was so.
+I passed round the garden without seeing anything more than random
+tracks, which I took to be the police; but when I got into the stable
+lane a very long and complex story was written in the snow in front of
+me.
+
+“There was a double line of tracks of a booted man, and a second double
+line which I saw with delight belonged to a man with naked feet. I was
+at once convinced from what you had told me that the latter was your
+son. The first had walked both ways, but the other had run swiftly,
+and, as his tread was marked in places over the depression of the boot,
+it was obvious that he had passed after the other. I followed them up,
+and found that they led to the hall window, where Boots had worn all
+the snow away while waiting. Then I walked to the other end, which was
+a hundred yards or more down the lane. I saw where Boots had faced
+round, where the snow was cut up as though there had been a struggle,
+and, finally, where a few drops of blood had fallen, to show me that I
+was not mistaken. Boots had then run down the lane, and another little
+smudge of blood showed that it was he who had been hurt. When he came
+to the high-road at the other end, I found that the pavement had been
+cleared, so there was an end to that clew.
+
+“On entering the house, however, I examined, as you remember, the sill
+and framework of the hall window with my lens, and I could at once
+see that some one had passed out. I could distinguish the outline of
+an instep where the wet foot had been placed in coming in. I was then
+beginning to be able to form an opinion as to what had occurred. A man
+had waited outside the window, some one had brought the gems; the deed
+had been overseen by your son, he had pursued the thief, had struggled
+with him, they had each tugged at the coronet, their united strength
+causing injuries which neither alone could have effected. He had
+returned with the prize, but had left a fragment in the grasp of his
+opponent. So far I was clear. The question now was, who was the man,
+and who was it brought him the coronet?
+
+“It is an old maxim of mine that when you have excluded the impossible,
+whatever remains, however improbable, must be the truth. Now, I knew
+that it was not you who had brought it down, so there only remained
+your niece and the maids. But if it were the maids, why should your son
+allow himself to be accused in their place? There could be no possible
+reason. As he loved his cousin, however, there was an excellent
+explanation why he should retain her secret—the more so as the secret
+was a disgraceful one. When I remembered that you had seen her at
+that window, and how she had fainted on seeing the coronet again, my
+conjecture became a certainty.
+
+“And who could it be who was her confederate? A lover evidently, for
+who else could outweigh the love and gratitude which she must feel to
+you? I knew that you went out little, and that your circle of friends
+was a very limited one. But among them was Sir George Burnwell. I had
+heard of him before as being a man of evil reputation among women. It
+must have been he who wore those boots and retained the missing gems.
+Even though he knew that Arthur had discovered him, he might still
+flatter himself that he was safe, for the lad could not say a word
+without compromising his own family.
+
+“Well, your own good sense will suggest what measures I took next. I
+went in the shape of a loafer to Sir George’s house, managed to pick
+up an acquaintance with his valet, learned that his master had cut his
+head the night before, and, finally, at the expense of six shillings,
+made all sure by buying a pair of his cast-off shoes. With these I
+journeyed down to Streatham, and saw that they exactly fitted the
+tracks.”
+
+[Illustration: “I CLAPPED A PISTOL TO HIS HEAD”]
+
+“I saw an ill-dressed vagabond in the lane yesterday evening,” said Mr.
+Holder.
+
+“Precisely. It was I. I found that I had my man, so I came home and
+changed my clothes. It was a delicate part which I had to play then,
+for I saw that a prosecution must be avoided to avert scandal, and I
+knew that so astute a villain would see that our hands were tied in the
+matter. I went and saw him. At first, of course, he denied everything.
+But when I gave him every particular that had occurred, he tried to
+bluster, and took down a life-preserver from the wall. I knew my man,
+however, and I clapped a pistol to his head before he could strike.
+Then he became a little more reasonable. I told him that we would give
+him a price for the stones he held—£1000 apiece. That brought out the
+first signs of grief that he had shown. ‘Why, dash it all!’ said he,
+‘I’ve let them go at six hundred for the three!’ I soon managed to get
+the address of the receiver who had them, on promising him that there
+would be no prosecution. Off I set to him, and after much chaffering I
+got our stones at £1000 apiece. Then I looked in upon your son, told
+him that all was right, and eventually got to my bed about two o’clock,
+after what I may call a really hard day’s work.”
+
+“A day which has saved England from a great public scandal,” said the
+banker, rising. “Sir, I cannot find words to thank you, but you shall
+not find me ungrateful for what you have done. Your skill has indeed
+exceeded all that I have heard of it. And now I must fly to my dear boy
+to apologize to him for the wrong which I have done him. As to what you
+tell me of poor Mary, it goes to my very heart. Not even your skill can
+inform me where she is now.”
+
+“I think that we may safely say,” returned Holmes, “that she is
+wherever Sir George Burnwell is. It is equally certain, too, that
+whatever her sins are, they will soon receive a more than sufficient
+punishment.”
+
+
+
+
+Adventure XII
+
+THE ADVENTURE OF THE COPPER BEECHES
+
+
+“To the man who loves art for its own sake,” remarked Sherlock Holmes,
+tossing aside the advertisement sheet of _The Daily Telegraph_, “it is
+frequently in its least important and lowliest manifestations that the
+keenest pleasure is to be derived. It is pleasant to me to observe,
+Watson, that you have so far grasped this truth that in these little
+records of our cases which you have been good enough to draw up, and, I
+am bound to say, occasionally to embellish, you have given prominence
+not so much to the many _causes célèbres_ and sensational trials in
+which I have figured, but rather to those incidents which may have been
+trivial in themselves, but which have given room for those faculties
+of deduction and of logical synthesis which I have made my special
+province.”
+
+“And yet,” said I, smiling, “I cannot quite hold myself absolved from
+the charge of sensationalism which has been urged against my records.”
+
+“You have erred, perhaps,” he observed, taking up a glowing cinder with
+the tongs, and lighting with it the long cherry-wood pipe which was
+wont to replace his clay when he was in a disputatious, rather than a
+meditative mood—“you have erred perhaps in attempting to put color and
+life into each of your statements, instead of confining yourself to the
+task of placing upon record that severe reasoning from cause to effect
+which is really the only notable feature about the thing.”
+
+“It seems to me that I have done you full justice in the matter,” I
+remarked, with some coldness, for I was repelled by the egotism which
+I had more than once observed to be a strong factor in my friend’s
+singular character.
+
+“No, it is not selfishness or conceit,” said he, answering, as was his
+wont, my thoughts rather than my words. “If I claim full justice for my
+art, it is because it is an impersonal thing—a thing beyond myself.
+Crime is common. Logic is rare. Therefore it is upon the logic rather
+than upon the crime that you should dwell. You have degraded what
+should have been a course of lectures into a series of tales.”
+
+It was a cold morning of the early spring, and we sat after breakfast
+on either side of a cheery fire in the old room at Baker Street. A
+thick fog rolled down between the lines of dun-colored houses, and the
+opposing windows loomed like dark, shapeless blurs through the heavy
+yellow wreaths. Our gas was lit, and shone on the white cloth and
+glimmer of china and metal, for the table had not been cleared yet.
+Sherlock Holmes had been silent all the morning, dipping continuously
+into the advertisement columns of a succession of papers, until at
+last, having apparently given up his search, he had emerged in no very
+sweet temper to lecture me upon my literary shortcomings.
+
+“At the same time,” he remarked, after a pause, during which he had sat
+puffing at his long pipe and gazing down into the fire, “you can hardly
+be open to a charge of sensationalism, for out of these cases which you
+have been so kind as to interest yourself in, a fair proportion do not
+treat of crime, in its legal sense, at all. The small matter in which I
+endeavored to help the King of Bohemia, the singular experience of Miss
+Mary Sutherland, the problem connected with the man with the twisted
+lip, and the incident of the noble bachelor, were all matters which are
+outside the pale of the law. But in avoiding the sensational, I fear
+that you may have bordered on the trivial.”
+
+“The end may have been so,” I answered, “but the methods I hold to have
+been novel and of interest.”
+
+“Pshaw, my dear fellow, what do the public, the great unobservant
+public, who could hardly tell a weaver by his tooth or a compositor by
+his left thumb, care about the finer shades of analysis and deduction!
+But, indeed, if you are trivial, I cannot blame you, for the days of
+the great cases are past. Man, or at least criminal man, has lost all
+enterprise and originality. As to my own little practice, it seems to
+be degenerating into an agency for recovering lost lead pencils and
+giving advice to young ladies from boarding-schools. I think that I
+have touched bottom at last, however. This note I had this morning
+marks my zero-point, I fancy. Read it!” He tossed a crumpled letter
+across to me.
+
+It was dated from Montague Place upon the preceding evening, and ran
+thus:
+
+  “DEAR MR. HOLMES,—I am very anxious to consult you as
+  to whether I should or should not accept a situation which has
+  been offered to me as governess. I shall call at half-past ten
+  to-morrow, if I do not inconvenience you.
+
+  “Yours faithfully,     VIOLET HUNTER.”
+
+“Do you know the young lady?” I asked.
+
+“Not I.”
+
+“It is half-past ten now.”
+
+“Yes, and I have no doubt that is her ring.”
+
+“It may turn out to be of more interest than you think. You remember
+that the affair of the blue carbuncle, which appeared to be a mere whim
+at first, developed into a serious investigation. It may be so in this
+case, also.”
+
+“Well, let us hope so. But our doubts will very soon be solved, for
+here, unless I am much mistaken, is the person in question.”
+
+As he spoke the door opened and a young lady entered the room. She was
+plainly but neatly dressed, with a bright, quick face, freckled like a
+plover’s egg, and with the brisk manner of a woman who has had her own
+way to make in the world.
+
+“You will excuse my troubling you, I am sure,” said she, as my
+companion rose to greet her; “but I have had a very strange experience,
+and as I have no parents or relations of any sort from whom I could ask
+advice, I thought that perhaps you would be kind enough to tell me what
+I should do.”
+
+“Pray take a seat, Miss Hunter. I shall be happy to do anything that I
+can to serve you.”
+
+I could see that Holmes was favorably impressed by the manner and
+speech of his new client. He looked her over in his searching fashion,
+and then composed himself, with his lids drooping and his finger tips
+together, to listen to her story.
+
+“I have been a governess for five years,” said she, “in the family
+of Colonel Spence Munro, but two months ago the colonel received an
+appointment at Halifax, in Nova Scotia, and took his children over
+to America with him, so that I found myself without a situation. I
+advertised, and I answered advertisements, but without success. At last
+the little money which I had saved began to run short, and I was at my
+wits’ end as to what I should do.
+
+“There is a well-known agency for governesses in the West End called
+Westaway’s, and there I used to call about once a week in order to
+see whether anything had turned up which might suit me. Westaway was
+the name of the founder of the business, but it is really managed by
+Miss Stoper. She sits in her own little office, and the ladies who are
+seeking employment wait in an ante-room, and are then shown in one by
+one, when she consults her ledgers, and sees whether she has anything
+which would suit them.
+
+“Well, when I called last week I was shown into the little office as
+usual, but I found that Miss Stoper was not alone. A prodigiously stout
+man with a very smiling face, and a great heavy chin which rolled down
+in fold upon fold over his throat, sat at her elbow with a pair of
+glasses on his nose, looking very earnestly at the ladies who entered.
+As I came in he gave quite a jump in his chair, and turned quickly to
+Miss Stoper:
+
+“‘That will do,’ said he; ‘I could not ask for anything better. Capital!
+capital!’ He seemed quite enthusiastic, and rubbed his hands together
+in the most genial fashion. He was such a comfortable-looking man that
+it was quite a pleasure to look at him.
+
+“‘You are looking for a situation, miss?’ he asked.
+
+“‘Yes, sir.’
+
+“‘As governess?’
+
+“‘Yes, sir.’
+
+“‘And what salary do you ask?’
+
+“‘I had £4 a month in my last place with Colonel Spence Munro.’
+
+“‘Oh, tut, tut! sweating—rank sweating!’ he cried, throwing his fat
+hands out into the air like a man who is in a boiling passion. ‘How
+could any one offer so pitiful a sum to a lady with such attractions
+and accomplishments?’
+
+“‘My accomplishments, sir, may be less than you imagine,’ said I. ‘A
+little French, a little German, music, and drawing—’
+
+“‘Tut, tut!’ he cried. ‘This is all quite beside the question. The
+point is, have you or have you not the bearing and deportment of a
+lady? There it is in a nutshell. If you have not, you are not fitted
+for the rearing of a child who may some day play a considerable part
+in the history of the country. But if you have, why, then, how could
+any gentleman ask you to condescend to accept anything under the three
+figures? Your salary with me, madam, would commence at £100 a year.’
+
+“You may imagine, Mr. Holmes, that to me, destitute as I was, such an
+offer seemed almost too good to be true. The gentleman, however, seeing
+perhaps the look of incredulity upon my face, opened a pocket-book and
+took out a note.
+
+“‘It is also my custom,’ said he, smiling in the most pleasant fashion
+until his eyes were just two little shining slits amid the white
+creases of his face, ‘to advance to my young ladies half their salary
+beforehand, so that they may meet any little expenses of their journey
+and their wardrobe.’
+
+“It seemed to me that I had never met so fascinating and so thoughtful
+a man. As I was already in debt to my tradesmen, the advance was a
+great convenience, and yet there was something unnatural about the
+whole transaction which made me wish to know a little more before I
+quite committed myself.
+
+“‘May I ask where you live, sir?’ said I.
+
+“‘Hampshire. Charming rural place. The Copper Beeches, five miles on the
+far side of Winchester. It is the most lovely country, my dear young
+lady, and the dearest old country-house.’
+
+“‘And my duties, sir? I should be glad to know what they would be.’
+
+“‘One child—one dear little romper just six years old. Oh, if you could
+see him killing cockroaches with a slipper! Smack! smack! smack! Three
+gone before you could wink!’ He leaned back in his chair and laughed
+his eyes into his head again.
+
+“I was a little startled at the nature of the child’s amusement, but
+the father’s laughter made me think that perhaps he was joking.
+
+“‘My sole duties, then,’ I asked, ‘are to take charge of a single child?’
+
+“‘No, no, not the sole, not the sole, my dear young lady,’ he cried.
+‘Your duty would be, as I am sure your good sense would suggest, to
+obey any little commands my wife might give, provided always that they
+were such commands as a lady might with propriety obey. You see no
+difficulty, heh?’
+
+“‘I should be happy to make myself useful.’
+
+“‘Quite so. In dress now, for example. We are faddy people, you
+know—faddy but kind-hearted. If you were asked to wear any dress which
+we might give you, you would not object to our little whim. Heh?’
+
+“‘No,’ said I, considerably astonished at his words.
+
+“‘Or to sit here, or sit there, that would not be offensive to you?’
+
+“‘Oh, no.’
+
+“‘Or to cut your hair quite short before you come to us?’
+
+“I could hardly believe my ears. As you may observe, Mr. Holmes, my
+hair is somewhat luxuriant, and of a rather peculiar tint of chestnut.
+It has been considered artistic. I could not dream of sacrificing it in
+this off-hand fashion.
+
+“‘I am afraid that that is quite impossible,’ said I. He had been
+watching me eagerly out of his small eyes, and I could see a shadow
+pass over his face as I spoke.
+
+“‘I am afraid that it is quite essential,’ said he. ‘It is a little
+fancy of my wife’s, and ladies’ fancies, you know, madam, ladies’
+fancies must be consulted. And so you won’t cut your hair?’
+
+“‘No, sir, I really could not,’ I answered, firmly.
+
+“‘Ah, very well; then that quite settles the matter. It is a pity,
+because in other respects you would really have done very nicely. In
+that case, Miss Stoper, I had best inspect a few more of your young
+ladies.’
+
+“The manageress had sat all this while busy with her papers without a
+word to either of us, but she glanced at me now with so much annoyance
+upon her face that I could not help suspecting that she had lost a
+handsome commission through my refusal.
+
+“‘Do you desire your name to be kept upon the books?’ she asked.
+
+“‘If you please, Miss Stoper.’
+
+“‘Well, really, it seems rather useless, since you refuse the most
+excellent offers in this fashion,’ said she, sharply. ‘You can hardly
+expect us to exert ourselves to find another such opening for you.
+Good-day to you, Miss Hunter.’ She struck a gong upon the table, and I
+was shown out by the page.
+
+“Well, Mr. Holmes, when I got back to my lodgings and found little
+enough in the cupboard, and two or three bills upon the table, I began
+to ask myself whether I had not done a very foolish thing. After all,
+if these people had strange fads, and expected obedience on the most
+extraordinary matters, they were at least ready to pay for their
+eccentricity. Very few governesses in England are getting £100 a
+year. Besides, what use was my hair to me? Many people are improved by
+wearing it short, and perhaps I should be among the number. Next day I
+was inclined to think that I had made a mistake, and by the day after
+I was sure of it. I had almost overcome my pride, so far as to go back
+to the agency and inquire whether the place was still open, when I
+received this letter from the gentleman himself. I have it here, and I
+will read it to you:
+
+    “‘The Copper Beeches, near Winchester.
+
+    “‘DEAR MISS HUNTER,—Miss Stoper has very kindly given me your
+    address, and I write from here to ask you whether you have
+    reconsidered your decision. My wife is very anxious that you
+    should come, for she has been much attracted by my description
+    of you. We are willing to give £30 a quarter, or £120 a year, so
+    as to recompense you for any little inconvenience which our fads
+    may cause you. They are not very exacting, after all. My wife
+    is fond of a particular shade of electric blue, and would like
+    you to wear such a dress in-doors in the morning. You need not,
+    however, go to the expense of purchasing one, as we have one
+    belonging to my dear daughter Alice (now in Philadelphia), which
+    would, I should think, fit you very well. Then, as to sitting
+    here or there, or amusing yourself in any manner indicated, that
+    need cause you no inconvenience. As regards your hair, it is
+    no doubt a pity, especially as I could not help remarking its
+    beauty during our short interview, but I am afraid that I must
+    remain firm upon this point, and I only hope that the increased
+    salary may recompense you for the loss. Your duties, as far as
+    the child is concerned, are very light. Now do try to come, and
+    I shall meet you with the dog-cart at Winchester. Let me know
+    your train.         Yours faithfully,      JEPHRO RUCASTLE.’
+
+“That is the letter which I have just received, Mr. Holmes, and my mind
+is made up that I will accept it. I thought, however, that before
+taking the final step I should like to submit the whole matter to your
+consideration.”
+
+“Well, Miss Hunter, if your mind is made up, that settles the
+question,” said Holmes, smiling.
+
+“But you would not advise me to refuse?”
+
+“I confess that it is not the situation which I should like to see a
+sister of mine apply for.”
+
+“What is the meaning of it all, Mr. Holmes?”
+
+“Ah, I have no data. I cannot tell. Perhaps you have yourself formed
+some opinion?”
+
+“Well, there seems to me to be only one possible solution. Mr. Rucastle
+seemed to be a very kind, good-natured man. Is it not possible that his
+wife is a lunatic, that he desires to keep the matter quiet for fear
+she should be taken to an asylum, and that he humors her fancies in
+every way in order to prevent an outbreak.”
+
+“That is a possible solution—in fact, as matters stand, it is the most
+probable one. But in any case it does not seem to be a nice household
+for a young lady.”
+
+“But the money, Mr. Holmes, the money!”
+
+“Well, yes, of course the pay is good—too good. That is what makes
+me uneasy. Why should they give you £120 a year, when they could have
+their pick for £40? There must be some strong reason behind.”
+
+“I thought that if I told you the circumstances you would understand
+afterwards if I wanted your help. I should feel so much stronger if I
+felt that you were at the back of me.”
+
+“Oh, you may carry that feeling away with you. I assure you that your
+little problem promises to be the most interesting which has come my
+way for some months. There is something distinctly novel about some of
+the features. If you should find yourself in doubt or in danger—”
+
+“Danger! What danger do you foresee?”
+
+Holmes shook his head gravely. “It would cease to be a danger if we
+could define it,” said he. “But at any time, day or night, a telegram
+would bring me down to your help.”
+
+“That is enough.” She rose briskly from her chair with the anxiety
+all swept from her face. “I shall go down to Hampshire quite easy in
+my mind now. I shall write to Mr. Rucastle at once, sacrifice my poor
+hair to-night, and start for Winchester to-morrow.” With a few grateful
+words to Holmes she bade us both good-night and bustled off upon her
+way.
+
+“At least,” said I, as we heard her quick, firm step descending the
+stairs, “she seems to be a young lady who is very well able to take
+care of herself.”
+
+“And she would need to be,” said Holmes, gravely; “I am much mistaken
+if we do not hear from her before many days are past.”
+
+It was not very long before my friend’s prediction was fulfilled. A
+fortnight went by, during which I frequently found my thoughts turning
+in her direction, and wondering what strange side-alley of human
+experience this lonely woman had strayed into. The unusual salary,
+the curious conditions, the light duties, all pointed to something
+abnormal, though whether a fad or a plot, or whether the man were
+a philanthropist or a villain, it was quite beyond my powers to
+determine. As to Holmes, I observed that he sat frequently for half an
+hour on end, with knitted brows and an abstracted air, but he swept the
+matter away with a wave of his hand when I mentioned it. “Data! data!
+data!” he cried, impatiently. “I can’t make bricks without clay.” And
+yet he would always wind up by muttering that no sister of his should
+ever have accepted such a situation.
+
+The telegram which we eventually received came late one night, just as
+I was thinking of turning in, and Holmes was settling down to one of
+those all-night chemical researches which he frequently indulged in,
+when I would leave him stooping over a retort and a test-tube at night,
+and find him in the same position when I came down to breakfast in
+the morning. He opened the yellow envelope, and then, glancing at the
+message, threw it across to me.
+
+“Just look up the trains in Bradshaw,” said he, and turned back to his
+chemical studies.
+
+The summons was a brief and urgent one.
+
+  “Please be at the ‘Black Swan’ Hotel at Winchester at
+  mid-day to-morrow,” it said. “Do come! I am at my wits’
+  end.                                       HUNTER.”
+
+“Will you come with me?” asked Holmes, glancing up.
+
+“I should wish to.”
+
+“Just look it up, then.”
+
+“There is a train at half-past nine,” said I, glancing over my
+Bradshaw. “It is due at Winchester at 11.30.”
+
+“That will do very nicely. Then perhaps I had better postpone my
+analysis of the acetones, as we may need to be at our best in the
+morning.”
+
+       *       *       *       *       *
+
+By eleven o’clock the next day we were well upon our way to the old
+English capital. Holmes had been buried in the morning papers all the
+way down, but after we had passed the Hampshire border he threw them
+down, and began to admire the scenery. It was an ideal spring day, a
+light blue sky, flecked with little fleecy white clouds drifting across
+from west to east. The sun was shining very brightly, and yet there was
+an exhilarating nip in the air, which set an edge to a man’s energy.
+All over the country-side, away to the rolling hills around Aldershot,
+the little red and gray roofs of the farm-steadings peeped out from
+amid the light green of the new foliage.
+
+“Are they not fresh and beautiful?” I cried, with all the enthusiasm of
+a man fresh from the fogs of Baker Street.
+
+But Holmes shook his head gravely.
+
+“Do you know, Watson,” said he, “that it is one of the curses of a mind
+with a turn like mine that I must look at everything with reference to
+my own special subject. You look at these scattered houses, and you are
+impressed by their beauty. I look at them, and the only thought which
+comes to me is a feeling of their isolation and of the impunity with
+which crime may be committed there.”
+
+“Good heavens!” I cried. “Who would associate crime with these dear old
+homesteads?”
+
+“They always fill me with a certain horror. It is my belief, Watson,
+founded upon my experience, that the lowest and vilest alleys in London
+do not present a more dreadful record of sin than does the smiling and
+beautiful country-side.”
+
+“You horrify me!”
+
+“But the reason is very obvious. The pressure of public opinion can
+do in the town what the law cannot accomplish. There is no lane so
+vile that the scream of a tortured child, or the thud of a drunkard’s
+blow, does not beget sympathy and indignation among the neighbors, and
+then the whole machinery of justice is ever so close that a word of
+complaint can set it going, and there is but a step between the crime
+and the dock. But look at these lonely houses, each in its own fields,
+filled for the most part with poor ignorant folk who know little of
+the law. Think of the deeds of hellish cruelty, the hidden wickedness
+which may go on, year in, year out, in such places, and none the wiser.
+Had this lady who appeals to us for help gone to live in Winchester, I
+should never have had a fear for her. It is the five miles of country
+which makes the danger. Still, it is clear that she is not personally
+threatened.”
+
+“No. If she can come to Winchester to meet us she can get away.”
+
+“Quite so. She has her freedom.”
+
+“What _can_ be the matter, then? Can you suggest no explanation?”
+
+“I have devised seven separate explanations, each of which would cover
+the facts as far as we know them. But which of these is correct can
+only be determined by the fresh information which we shall no doubt
+find waiting for us. Well, there is the tower of the cathedral, and we
+shall soon learn all that Miss Hunter has to tell.”
+
+The “Black Swan” is an inn of repute in the High Street, at no
+distance from the station, and there we found the young lady waiting
+for us. She had engaged a sitting-room, and our lunch awaited us upon
+the table.
+
+“I am so delighted that you have come,” she said, earnestly. “It is so
+very kind of you both; but indeed I do not know what I should do. Your
+advice will be altogether invaluable to me.”
+
+“Pray tell us what has happened to you.”
+
+“I will do so, and I must be quick, for I have promised Mr. Rucastle to
+be back before three. I got his leave to come into town this morning,
+though he little knew for what purpose.”
+
+“Let us have everything in its due order.” Holmes thrust his long thin
+legs out towards the fire and composed himself to listen.
+
+“In the first place, I may say that I have met, on the whole, with no
+actual ill-treatment from Mr. and Mrs. Rucastle. It is only fair to
+them to say that. But I cannot understand them, and I am not easy in my
+mind about them.”
+
+“What can you not understand?”
+
+“Their reasons for their conduct. But you shall have it all just as
+it occurred. When I came down, Mr. Rucastle met me here, and drove me
+in his dog-cart to the Copper Beeches. It is, as he said, beautifully
+situated, but it is not beautiful in itself, for it is a large square
+block of a house, whitewashed, but all stained and streaked with damp
+and bad weather. There are grounds round it, woods on three sides, and
+on the fourth a field which slopes down to the Southampton high-road,
+which curves past about a hundred yards from the front door. This
+ground in front belongs to the house, but the woods all round are part
+of Lord Southerton’s preserves. A clump of copper beeches immediately
+in front of the hall door has given its name to the place.
+
+[Illustration: “‘I AM SO DELIGHTED THAT YOU HAVE COME’”]
+
+“I was driven over by my employer, who was as amiable as ever, and was
+introduced by him that evening to his wife and the child. There was no
+truth, Mr. Holmes, in the conjecture which seemed to us to be probable
+in your rooms at Baker Street. Mrs. Rucastle is not mad. I found her
+to be a silent, pale-faced woman, much younger than her husband, not
+more than thirty, I should think, while he can hardly be less than
+forty-five. From their conversation I have gathered that they have been
+married about seven years, that he was a widower, and that his only
+child by the first wife was the daughter who has gone to Philadelphia.
+Mr. Rucastle told me in private that the reason why she had left them
+was that she had an unreasoning aversion to her step-mother. As the
+daughter could not have been less than twenty, I can quite imagine that
+her position must have been uncomfortable with her father’s young wife.
+
+“Mrs. Rucastle seemed to me to be colorless in mind as well as in
+feature. She impressed me neither favorably nor the reverse. She was a
+nonentity. It was easy to see that she was passionately devoted both
+to her husband and to her little son. Her light gray eyes wandered
+continually from one to the other, noting every little want and
+forestalling it if possible. He was kind to her also in his bluff,
+boisterous fashion, and on the whole they seemed to be a happy couple.
+And yet she had some secret sorrow, this woman. She would often be lost
+in deep thought, with the saddest look upon her face. More than once I
+have surprised her in tears. I have thought sometimes that it was the
+disposition of her child which weighed upon her mind, for I have never
+met so utterly spoilt and so ill-natured a little creature. He is small
+for his age, with a head which is quite disproportionately large. His
+whole life appears to be spent in an alternation between savage fits of
+passion and gloomy intervals of sulking. Giving pain to any creature
+weaker than himself seems to be his one idea of amusement, and he
+shows quite remarkable talent in planning the capture of mice, little
+birds, and insects. But I would rather not talk about the creature, Mr.
+Holmes, and, indeed, he has little to do with my story.”
+
+“I am glad of all details,” remarked my friend, “whether they seem to
+you to be relevant or not.”
+
+“I shall try not to miss anything of importance. The one unpleasant
+thing about the house, which struck me at once, was the appearance
+and conduct of the servants. There are only two, a man and his wife.
+Toller, for that is his name, is a rough, uncouth man, with grizzled
+hair and whiskers, and a perpetual smell of drink. Twice since I have
+been with them he has been quite drunk, and yet Mr. Rucastle seemed to
+take no notice of it. His wife is a very tall and strong woman with a
+sour face, as silent as Mrs. Rucastle, and much less amiable. They are
+a most unpleasant couple, but fortunately I spend most of my time in
+the nursery and my own room, which are next to each other in one corner
+of the building.
+
+“For two days after my arrival at the Copper Beeches my life was very
+quiet; on the third, Mrs. Rucastle came down just after breakfast and
+whispered something to her husband.
+
+“‘Oh yes,’ said he, turning to me; ‘we are very much obliged to you,
+Miss Hunter, for falling in with our whims so far as to cut your hair.
+I assure you that it has not detracted in the tiniest iota from your
+appearance. We shall now see how the electric-blue dress will become
+you. You will find it laid out upon the bed in your room, and if you
+would be so good as to put it on we should both be extremely obliged.’
+
+“The dress which I found waiting for me was of a peculiar shade of
+blue. It was of excellent material, a sort of beige, but it bore
+unmistakable signs of having been worn before. It could not have been
+a better fit if I had been measured for it. Both Mr. and Mrs. Rucastle
+expressed a delight at the look of it, which seemed quite exaggerated
+in its vehemence. They were waiting for me in the drawing-room, which
+is a very large room, stretching along the entire front of the house,
+with three long windows reaching down to the floor. A chair had been
+placed close to the central window, with its back turned towards it. In
+this I was asked to sit, and then Mr. Rucastle, walking up and down on
+the other side of the room, began to tell me a series of the funniest
+stories that I have ever listened to. You cannot imagine how comical he
+was, and I laughed until I was quite weary. Mrs. Rucastle, however, who
+has evidently no sense of humor, never so much as smiled, but sat with
+her hands in her lap, and a sad, anxious look upon her face. After an
+hour or so, Mr. Rucastle suddenly remarked that it was time to commence
+the duties of the day, and that I might change my dress and go to
+little Edward in the nursery.
+
+“Two days later this same performance was gone through under exactly
+similar circumstances. Again I changed my dress, again I sat in the
+window, and again I laughed very heartily at the funny stories of which
+my employer had an immense _répertoire_, and which he told inimitably.
+Then he handed me a yellow-backed novel, and, moving my chair a little
+sideways, that my own shadow might not fall upon the page, he begged me
+to read aloud to him. I read for about ten minutes, beginning in the
+heart of a chapter, and then suddenly, in the middle of a sentence, he
+ordered me to cease and to change my dress.
+
+“You can easily imagine, Mr. Holmes, how curious I became as to what
+the meaning of this extraordinary performance could possibly be. They
+were always very careful, I observed, to turn my face away from the
+window, so that I became consumed with the desire to see what was going
+on behind my back. At first it seemed to be impossible, but I soon
+devised a means. My hand-mirror had been broken, so a happy thought
+seized me, and I concealed a piece of the glass in my handkerchief. On
+the next occasion, in the midst of my laughter, I put my handkerchief
+up to my eyes, and was able with a little management to see all that
+there was behind me. I confess that I was disappointed. There was
+nothing. At least that was my first impression. At the second glance,
+however, I perceived that there was a man standing in the Southampton
+Road, a small bearded man in a gray suit, who seemed to be looking in
+my direction. The road is an important highway, and there are usually
+people there. This man, however, was leaning against the railings
+which bordered our field, and was looking earnestly up. I lowered my
+handkerchief and glanced at Mrs. Rucastle, to find her eyes fixed upon
+me with a most searching gaze. She said nothing, but I am convinced
+that she had divined that I had a mirror in my hand, and had seen what
+was behind me. She rose at once.
+
+“‘Jephro,’ said she, ‘there is an impertinent fellow upon the road
+there who stares up at Miss Hunter.’
+
+“‘No friend of yours, Miss Hunter?’ he asked.
+
+“‘No; I know no one in these parts.’
+
+“‘Dear me! How very impertinent! Kindly turn round and motion to him to
+go away.’
+
+“‘Surely it would be better to take no notice.’
+
+“‘No, no, we should have him loitering here always. Kindly turn round
+and wave him away like that.’
+
+“I did as I was told, and at the same instant Mrs. Rucastle drew down
+the blind. That was a week ago, and from that time I have not sat again
+in the window, nor have I worn the blue dress, nor seen the man in the
+road.”
+
+“Pray continue,” said Holmes. “Your narrative promises to be a most
+interesting one.”
+
+“You will find it rather disconnected, I fear, and there may prove to
+be little relation between the different incidents of which I speak.
+On the very first day that I was at the Copper Beeches, Mr. Rucastle
+took me to a small out-house which stands near the kitchen door. As we
+approached it I heard the sharp rattling of a chain, and the sound as
+of a large animal moving about.
+
+“‘Look in here!’ said Mr. Rucastle, showing me a slit between two
+planks. ‘Is he not a beauty?’
+
+“I looked through, and was conscious of two glowing eyes, and of a
+vague figure huddled up in the darkness.
+
+“‘Don’t be frightened,’ said my employer, laughing at the start which I
+had given. ‘It’s only Carlo, my mastiff. I call him mine, but really
+old Toller, my groom, is the only man who can do anything with him. We
+feed him once a day, and not too much then, so that he is always as
+keen as mustard. Toller lets him loose every night, and God help the
+trespasser whom he lays his fangs upon. For goodness’ sake don’t you
+ever on any pretext set your foot over the threshold at night, for it
+is as much as your life is worth.’
+
+“The warning was no idle one, for two nights later I happened to look
+out of my bedroom window about two o’clock in the morning. It was a
+beautiful moonlight night, and the lawn in front of the house was
+silvered over and almost as bright as day. I was standing, rapt in
+the peaceful beauty of the scene, when I was aware that something was
+moving under the shadow of the copper beeches. As it emerged into the
+moonshine I saw what it was. It was a giant dog, as large as a calf,
+tawny tinted, with hanging jowl, black muzzle, and huge projecting
+bones. It walked slowly across the lawn and vanished into the shadow
+upon the other side. That dreadful silent sentinel sent a chill to my
+heart which I do not think that any burglar could have done.
+
+“And now I have a very strange experience to tell you. I had, as you
+know, cut off my hair in London, and I had placed it in a great coil
+at the bottom of my trunk. One evening, after the child was in bed,
+I began to amuse myself by examining the furniture of my room and by
+rearranging my own little things. There was an old chest of drawers
+in the room, the two upper ones empty and open, the lower one locked.
+I had filled the first two with my linen, and, as I had still much
+to pack away, I was naturally annoyed at not having the use of the
+third drawer. It struck me that it might have been fastened by a mere
+oversight, so I took out my bunch of keys and tried to open it. The
+very first key fitted to perfection, and I drew the drawer open. There
+was only one thing in it, but I am sure that you would never guess what
+it was. It was my coil of hair.
+
+“I took it up and examined it. It was of the same peculiar tint, and
+the same thickness. But then the impossibility of the thing obtruded
+itself upon me. How _could_ my hair have been locked in the drawer?
+With trembling hands I undid my trunk, turned out the contents, and
+drew from the bottom my own hair. I laid the two tresses together, and
+I assure you that they were identical. Was it not extraordinary? Puzzle
+as I would, I could make nothing at all of what it meant. I returned
+the strange hair to the drawer, and I said nothing of the matter to the
+Rucastles, as I felt that I had put myself in the wrong by opening a
+drawer which they had locked.
+
+“I am naturally observant, as you may have remarked, Mr. Holmes, and I
+soon had a pretty good plan of the whole house in my head. There was
+one wing, however, which appeared not to be inhabited at all. A door
+which faced that which led into the quarters of the Tollers opened
+into this suite, but it was invariably locked. One day, however, as I
+ascended the stair, I met Mr. Rucastle coming out through this door,
+his keys in his hand, and a look on his face which made him a very
+different person to the round, jovial man to whom I was accustomed. His
+cheeks were red, his brow was all crinkled with anger, and the veins
+stood out at his temples with passion. He locked the door and hurried
+past me without a word or a look.
+
+“This aroused my curiosity; so when I went out for a walk in the
+grounds with my charge, I strolled round to the side from which I could
+see the windows of this part of the house. There were four of them in a
+row, three of which were simply dirty, while the fourth was shuttered
+up. They were evidently all deserted. As I strolled up and down,
+glancing at them occasionally, Mr. Rucastle came out to me, looking as
+merry and jovial as ever.
+
+“‘Ah!’ said he, ‘you must not think me rude if I passed you without a
+word, my dear young lady. I was preoccupied with business matters.’
+
+“I assured him that I was not offended. ‘By-the-way,’ said I, ‘you
+seem to have quite a suite of spare rooms up there, and one of them has
+the shutters up.’
+
+“He looked surprised, and, as it seemed to me, a little startled at my
+remark.
+
+“‘Photography is one of my hobbies,’ said he. ‘I have made my dark room
+up there. But, dear me! what an observant young lady we have come upon.
+Who would have believed it? Who would have ever believed it?’ He spoke
+in a jesting tone, but there was no jest in his eyes as he looked at
+me. I read suspicion there and annoyance, but no jest.
+
+“Well, Mr. Holmes, from the moment that I understood that there was
+something about that suite of rooms which I was not to know, I was all
+on fire to go over them. It was not mere curiosity, though I have my
+share of that. It was more a feeling of duty—a feeling that some good
+might come from my penetrating to this place. They talk of woman’s
+instinct; perhaps it was woman’s instinct which gave me that feeling.
+At any rate, it was there, and I was keenly on the lookout for any
+chance to pass the forbidden door.
+
+“It was only yesterday that the chance came. I may tell you that,
+besides Mr. Rucastle, both Toller and his wife find something to do in
+these deserted rooms, and I once saw him carrying a large black linen
+bag with him through the door. Recently he has been drinking hard, and
+yesterday evening he was very drunk; and, when I came up-stairs, there
+was the key in the door. I have no doubt at all that he had left it
+there. Mr. and Mrs. Rucastle were both down-stairs, and the child was
+with them, so that I had an admirable opportunity. I turned the key
+gently in the lock, opened the door, and slipped through.
+
+“There was a little passage in front of me, unpapered and uncarpeted,
+which turned at a right angle at the farther end. Round this corner
+were three doors in a line, the first and third of which were open.
+They each led into an empty room, dusty and cheerless, with two windows
+in the one and one in the other, so thick with dirt that the evening
+light glimmered dimly through them. The centre door was closed, and
+across the outside of it had been fastened one of the broad bars of
+an iron bed, padlocked at one end to a ring in the wall, and fastened
+at the other with stout cord. The door itself was locked as well, and
+the key was not there. This barricaded door corresponded clearly with
+the shuttered window outside, and yet I could see by the glimmer from
+beneath it that the room was not in darkness. Evidently there was a
+skylight which let in light from above. As I stood in the passage
+gazing at the sinister door, and wondering what secret it might veil,
+I suddenly heard the sound of steps within the room, and saw a shadow
+pass backward and forward against the little slit of dim light which
+shone out from under the door. A mad, unreasoning terror rose up in
+me at the sight, Mr. Holmes. My overstrung nerves failed me suddenly,
+and I turned and ran—ran as though some dreadful hand were behind me
+clutching at the skirt of my dress. I rushed down the passage, through
+the door, and straight into the arms of Mr. Rucastle, who was waiting
+outside.
+
+“‘So,’ said he, smiling, ‘it was you, then. I thought that it must be
+when I saw the door open.’
+
+“‘Oh, I am so frightened!’ I panted.
+
+“‘My dear young lady! my dear young lady!’—you cannot think how
+caressing and soothing his manner was—‘and what has frightened you, my
+dear young lady?’
+
+“But his voice was just a little too coaxing. He overdid it. I was
+keenly on my guard against him.
+
+“‘I was foolish enough to go into the empty wing,’ I answered. ‘But it
+is so lonely and eerie in this dim light that I was frightened and ran
+out again. Oh, it is so dreadfully still in there!’
+
+“‘Only that?’ said he, looking at me keenly.
+
+“‘Why, what did you think?’ I asked.
+
+“‘Why do you think that I lock this door?’
+
+“‘I am sure that I do not know.’
+
+“‘It is to keep people out who have no business there. Do you see?’ He
+was still smiling in the most amiable manner.
+
+“‘I am sure if I had known—’
+
+“‘Well, then, you know now. And if you ever put your foot over that
+threshold again—’ here in an instant the smile hardened into a grin of
+rage, and he glared down at me with the face of a demon—‘I’ll throw
+you to the mastiff.’
+
+“I was so terrified that I do not know what I did. I suppose that I
+must have rushed past him into my room. I remember nothing until I
+found myself lying on my bed trembling all over. Then I thought of you,
+Mr. Holmes. I could not live there longer without some advice. I was
+frightened of the house, of the man, of the woman, of the servants,
+even of the child. They were all horrible to me. If I could only bring
+you down all would be well. Of course I might have fled from the house,
+but my curiosity was almost as strong as my fears. My mind was soon
+made up. I would send you a wire. I put on my hat and cloak, went down
+to the office, which is about half a mile from the house, and then
+returned, feeling very much easier. A horrible doubt came into my mind
+as I approached the door lest the dog might be loose, but I remembered
+that Toller had drunk himself into a state of insensibility that
+evening, and I knew that he was the only one in the household who had
+any influence with the savage creature, or who would venture to set him
+free. I slipped in in safety, and lay awake half the night in my joy at
+the thought of seeing you. I had no difficulty in getting leave to come
+into Winchester this morning, but I must be back before three o’clock,
+for Mr. and Mrs. Rucastle are going on a visit, and will be away all
+the evening, so that I must look after the child. Now I have told you
+all my adventures, Mr. Holmes, and I should be very glad if you could
+tell me what it all means, and, above all, what I should do.”
+
+Holmes and I had listened spellbound to this extraordinary story. My
+friend rose now and paced up and down the room, his hands in his
+pockets, and an expression of the most profound gravity upon his face.
+
+“Is Toller still drunk?” he asked.
+
+“Yes. I heard his wife tell Mrs. Rucastle that she could do nothing
+with him.”
+
+“That is well. And the Rucastles go out to-night?”
+
+“Yes.”
+
+“Is there a cellar with a good strong lock?”
+
+“Yes, the wine-cellar.”
+
+“You seem to me to have acted all through this matter like a very brave
+and sensible girl, Miss Hunter. Do you think that you could perform one
+more feat? I should not ask it of you if I did not think you a quite
+exceptional woman.”
+
+“I will try. What is it?”
+
+“We shall be at the Copper Beeches by seven o’clock, my friend and I.
+The Rucastles will be gone by that time, and Toller will, we hope, be
+incapable. There only remains Mrs. Toller, who might give the alarm. If
+you could send her into the cellar on some errand, and then turn the
+key upon her, you would facilitate matters immensely.”
+
+“I will do it.”
+
+“Excellent! We shall then look thoroughly into the affair. Of course
+there is only one feasible explanation. You have been brought there to
+personate some one, and the real person is imprisoned in this chamber.
+That is obvious. As to who this prisoner is, I have no doubt that it is
+the daughter, Miss Alice Rucastle, if I remember right, who was said
+to have gone to America. You were chosen, doubtless, as resembling her
+in height, figure, and the color of your hair. Hers had been cut off,
+very possibly in some illness through which she has passed, and so, of
+course, yours had to be sacrificed also. By a curious chance you came
+upon her tresses. The man in the road was, undoubtedly, some friend of
+hers—possibly her _fiancé_—and no doubt, as you wore the girl’s dress
+and were so like her, he was convinced from your laughter, whenever
+he saw you, and afterwards from your gesture, that Miss Rucastle was
+perfectly happy, and that she no longer desired his attentions. The dog
+is let loose at night to prevent him from endeavoring to communicate
+with her. So much is fairly clear. The most serious point in the case
+is the disposition of the child.”
+
+“What on earth has that to do with it?” I ejaculated.
+
+“My dear Watson, you as a medical man are continually gaining light as
+to the tendencies of a child by the study of the parents. Don’t you see
+that the converse is equally valid. I have frequently gained my first
+real insight into the character of parents by studying their children.
+This child’s disposition is abnormally cruel, merely for cruelty’s
+sake, and whether he derives this from his smiling father, as I should
+suspect, or from his mother, it bodes evil for the poor girl who is in
+their power.”
+
+“I am sure that you are right, Mr. Holmes,” cried our client. “A
+thousand things come back to me which make me certain that you have
+hit it. Oh, let us lose not an instant in bringing help to this poor
+creature.”
+
+“We must be circumspect, for we are dealing with a very cunning man. We
+can do nothing until seven o’clock. At that hour we shall be with you,
+and it will not be long before we solve the mystery.”
+
+We were as good as our word, for it was just seven when we reached the
+Copper Beeches, having put up our trap at a way-side public-house. The
+group of trees, with their dark leaves shining like burnished metal in
+the light of the setting sun, were sufficient to mark the house even
+had Miss Hunter not been standing smiling on the door-step.
+
+“Have you managed it?” asked Holmes.
+
+A loud thudding noise came from somewhere down-stairs. “That is
+Mrs. Toller in the cellar,” said she. “Her husband lies snoring on
+the kitchen rug. Here are his keys, which are the duplicates of Mr.
+Rucastle’s.”
+
+“You have done well indeed!” cried Holmes, with enthusiasm. “Now lead
+the way, and we shall soon see the end of this black business.”
+
+We passed up the stair, unlocked the door, followed on down a passage,
+and found ourselves in front of the barricade which Miss Hunter had
+described. Holmes cut the cord and removed the transverse bar. Then he
+tried the various keys in the lock, but without success. No sound came
+from within, and at the silence Holmes’s face clouded over.
+
+“I trust that we are not too late,” said he. “I think, Miss Hunter,
+that we had better go in without you. Now, Watson, put your shoulder to
+it, and we shall see whether we cannot make our way in.”
+
+It was an old rickety door, and gave at once before our united
+strength. Together we rushed into the room. It was empty. There was no
+furniture save a little pallet bed, a small table, and a basketful of
+linen. The skylight above was open, and the prisoner gone.
+
+“There has been some villainy here,” said Holmes; “this beauty has
+guessed Miss Hunter’s intentions, and has carried his victim off.”
+
+“But how?”
+
+“Through the skylight. We shall soon see how he managed it.” He swung
+himself up onto the roof. “Ah, yes,” he cried; “here’s the end of a
+long light ladder against the eaves. That is how he did it.”
+
+“But it is impossible,” said Miss Hunter; “the ladder was not there
+when the Rucastles went away.”
+
+“He has come back and done it. I tell you that he is a clever and
+dangerous man. I should not be very much surprised if this were he
+whose step I hear now upon the stair. I think, Watson, that it would be
+as well for you to have your pistol ready.”
+
+The words were hardly out of his mouth before a man appeared at the
+door of the room, a very fat and burly man, with a heavy stick in his
+hand. Miss Hunter screamed and shrunk against the wall at the sight of
+him, but Sherlock Holmes sprang forward and confronted him.
+
+“You villain!” said he, “where’s your daughter?”
+
+The fat man cast his eyes round, and then up at the open skylight.
+
+“It is for me to ask you that,” he shrieked, “you thieves! Spies and
+thieves! I have caught you, have I? You are in my power. I’ll serve
+you!” He turned and clattered down the stairs as hard as he could go.
+
+“He’s gone for the dog!” cried Miss Hunter.
+
+“I have my revolver,” said I.
+
+“Better close the front door,” cried Holmes, and we all rushed down
+the stairs together. We had hardly reached the hall when we heard the
+baying of a hound, and then a scream of agony, with a horrible worrying
+sound which it was dreadful to listen to. An elderly man with a red
+face and shaking limbs came staggering out at a side door.
+
+“My God!” he cried. “Some one has loosed the dog. It’s not been fed for
+two days. Quick, quick, or it’ll be too late!”
+
+Holmes and I rushed out and round the angle of the house, with Toller
+hurrying behind us. There was the huge famished brute, its black muzzle
+buried in Rucastle’s throat, while he writhed and screamed upon the
+ground. Running up, I blew its brains out, and it fell over with its
+keen white teeth still meeting in the great creases of his neck. With
+much labor we separated them, and carried him, living but horribly
+mangled, into the house. We laid him upon the drawing-room sofa, and,
+having despatched the sobered Toller to bear the news to his wife, I
+did what I could to relieve his pain. We were all assembled round him
+when the door opened, and a tall, gaunt woman entered the room.
+
+“Mrs. Toller!” cried Miss Hunter.
+
+“Yes, miss. Mr. Rucastle let me out when he came back before he went
+up to you. Ah, miss, it is a pity you didn’t let me know what you were
+planning, for I would have told you that your pains were wasted.”
+
+“Ha!” said Holmes, looking keenly at her. “It is clear that Mrs. Toller
+knows more about this matter than any one else.”
+
+“Yes, sir, I do, and I am ready enough to tell what I know.”
+
+“Then, pray, sit down, and let us hear it, for there are several points
+on which I must confess that I am still in the dark.”
+
+“I will soon make it clear to you,” said she; “and I’d have done
+so before now if I could ha’ got out from the cellar. If there’s
+police-court business over this, you’ll remember that I was the one
+that stood your friend, and that I was Miss Alice’s friend too.
+
+“She was never happy at home, Miss Alice wasn’t, from the time that
+her father married again. She was slighted like, and had no say in
+anything; but it never really became bad for her until after she met
+Mr. Fowler at a friend’s house. As well as I could learn, Miss Alice
+had rights of her own by will, but she was so quiet and patient, she
+was, that she never said a word about them, but just left everything in
+Mr. Rucastle’s hands. He knew he was safe with her; but when there was
+a chance of a husband coming forward, who would ask for all that the
+law would give him, then her father thought it time to put a stop on
+it. He wanted her to sign a paper, so that whether she married or not,
+he could use her money. When she wouldn’t do it, he kept on worrying
+her until she got brain-fever, and for six weeks was at death’s door.
+Then she got better at last, all worn to a shadow, and with her
+beautiful hair cut off; but that didn’t make no change in her young
+man, and he stuck to her as true as man could be.”
+
+“Ah,” said Holmes, “I think that what you have been good enough to
+tell us makes the matter fairly clear, and that I can deduce all
+that remains. Mr. Rucastle then, I presume, took to this system of
+imprisonment?”
+
+“Yes, sir.”
+
+“And brought Miss Hunter down from London in order to get rid of the
+disagreeable persistence of Mr. Fowler.”
+
+“That was it, sir.”
+
+“But Mr. Fowler being a persevering man, as a good seaman should
+be, blockaded the house, and, having met you, succeeded by certain
+arguments, metallic or otherwise, in convincing you that your interests
+were the same as his.”
+
+“Mr. Fowler was a very kind-spoken, free-handed gentleman,” said Mrs.
+Toller, serenely.
+
+“And in this way he managed that your good man should have no want of
+drink, and that a ladder should be ready at the moment when your master
+had gone out.”
+
+“You have it, sir, just as it happened.”
+
+“I am sure we owe you an apology, Mrs. Toller,” said Holmes, “for you
+have certainly cleared up everything which puzzled us. And here comes
+the country surgeon and Mrs. Rucastle, so I think, Watson, that we had
+best escort Miss Hunter back to Winchester, as it seems to me that our
+_locus standi_ now is rather a questionable one.”
+
+And thus was solved the mystery of the sinister house with the copper
+beeches in front of the door. Mr. Rucastle survived, but was always a
+broken man, kept alive solely through the care of his devoted wife.
+They still live with their old servants, who probably know so much of
+Rucastle’s past life that he finds it difficult to part from them.
+Mr. Fowler and Miss Rucastle were married, by special license, in
+Southampton the day after their flight, and he is now the holder of a
+Government appointment in the Island of Mauritius. As to Miss Violet
+Hunter, my friend Holmes, rather to my disappointment, manifested no
+further interest in her when once she had ceased to be the centre of
+one of his problems, and she is now the head of a private school at
+Walsall, where I believe that she has met with considerable success.
+
+
+THE END
+
+
+
+
+BY W. D. HOWELLS.
+
+
+  THE QUALITY OF MERCY. A Novel. 12mo, Cloth, $1 50; Paper,
+    75 cents.
+
+  AN IMPERATIVE DUTY. A Novel. 12mo, Cloth, $1 00.
+
+  A HAZARD OF NEW FORTUNES. A Novel. 2 Volumes. 12mo, Cloth,
+    $2 00; Illustrated. 12mo, Paper, $1 00.
+
+  THE SHADOW OF A DREAM. A Story. 12mo, Cloth, $1 00; Paper,
+    50 cents.
+
+  ANNIE KILBURN. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  APRIL HOPES. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  CHRISTMAS EVERY DAY, AND OTHER STORIES. Illustrated. Post 8vo,
+    Cloth, $1 25.
+
+  A BOY’S TOWN. Illustrated. Post 8vo, Cloth, $1 25.
+
+  CRITICISM AND FICTION. With Portrait. 16mo, Cloth, $1 00.
+
+  MODERN ITALIAN POETS. With Portraits. 12mo, Half Cloth, $2 00.
+
+  THE MOUSE-TRAP, AND OTHER FARCES. Illustrated. 12mo, Cloth,
+    $1 00.
+
+  A LETTER OF INTRODUCTION. A Farce. Illustrated. 32mo, Cloth,
+    50 cents.
+
+  A LITTLE SWISS SOJOURN. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE ALBANY DEPOT. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE GARROTERS. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above works are for sale by all booksellers, or will be sent
+by the publishers, postage prepaid, to any part of the United States,
+Canada, or Mexico, on receipt of the price._
+
+
+
+
+R. D. BLACKMORE’S NOVELS.
+
+
+His descriptions are wonderfully vivid and natural. His pages are
+brightened everywhere with great humor; the quaint, dry turns of
+thought remind you occasionally of Fielding.—_London Times._
+
+Mr. Blackmore always writes like a scholar and a
+gentleman—_Athenæum_, London.
+
+His tales, all of them, are pre-eminently meritorious. They are
+remarkable for their careful elaboration, the conscientious finish of
+their workmanship, their affluence of striking dramatic and narrative
+incident, their close observation and general interpretation of nature,
+their profusion of picturesque description, and their quiet and
+sustained humor. Besides, they are pervaded by a bright and elastic
+atmosphere which diffuses a cheery feeling of healthful and robust
+vigor. While they charm us by their sprightly vivacity and their
+naturalness, they never in the slightest degree transcend the limits
+of delicacy or good taste. While radiating warmth and brightness, they
+are as pure as the new-fallen snow.... Their literary execution is
+admirable, and their dramatic power is as exceptional as their moral
+purity.—_Christian Intelligencer_, N. Y.
+
+  LORNA DOONE. Illustrated. 12mo, Cloth, $1 00; 8vo, Paper,
+    40 cents.
+
+  KIT AND KITTY. 12mo, Cloth, $1 25; Paper, 35 cents.
+
+  SPRINGHAVEN. Illustrated. 12mo, Cloth, $1 50; 4to, Paper,
+    25 cents.
+
+  CHRISTOWELL. 4to, Paper, 20 cents.
+
+  CRADOCK NOWELL. 8vo, Paper, 60 cents.
+
+  EREMA; OR, MY FATHER’S SIN. 8vo, Paper, 50 cents.
+
+  MARY ANERLEY. 16mo, Cloth, $1 00; 4to, Paper, 15 cents.
+
+  TOMMY UPMORE. 16mo, Cloth, 50 cents; Paper, 35 cents; 4to,
+    Paper, 20 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works will be sent by mail, postage prepaid,
+to any part of the United States, Canada, or Mexico, on receipt of
+the price._
+
+
+
+
+By CAPT. CHARLES KING.
+
+
+  CAMPAIGNING WITH CROOK, AND STORIES OF ARMY LIFE. Post 8vo,
+      Cloth, $1 25.
+
+  A WAR-TIME WOOING. Illustrated by R. F. ZOGBAUM. pp. iv.,
+      196. Post 8vo, Cloth, $1 00.
+
+  BETWEEN THE LINES. A Story of the War. Illustrated by GILBERT
+      GAUL. pp. iv., 312. Post 8vo, Cloth, $1 25.
+
+In all of Captain King’s stories the author holds to lofty ideals of
+manhood and womanhood, and inculcates the lessons of honor, generosity,
+courage, and self-control.—_Literary World_, Boston.
+
+The vivacity and charm which signally distinguish Captain King’s
+pen.... He occupies a position in American literature entirely
+his own.... His is the literature of honest sentiment, pure and
+tender.—_N. Y. Press._
+
+A romance by Captain King is always a pleasure, because he has so
+complete a mastery of the subjects with which he deals.... Captain
+King has few rivals in his domain.... The general tone of Captain
+King’s stories is highly commendable. The heroes are simple, frank,
+and soldierly; the heroines are dignified and maidenly in the most
+unconventional situations.—_Epoch_, N. Y.
+
+All Captain King’s stories are full of spirit and with the true ring
+about them.—_Philadelphia Item._
+
+Captain King’s stories of army life are so brilliant and intense, they
+have such a ring of true experience, and his characters are so lifelike
+and vivid that the announcement of a new one is always received with
+pleasure.—_New Haven Palladium._
+
+Captain King is a delightful story-teller.—_Washington Post._
+
+In the delineation of war scenes Captain King’s style is crisp and
+vigorous, inspiring in the breast of the reader a thrill of genuine
+patriotic fervor.—_Boston Commonwealth._
+
+Captain King is almost without a rival in the field he has chosen....
+His style is at once vigorous and sentimental in the best sense of that
+word, so that his novels are pleasing to young men as well as young
+women.—_Pittsburgh Bulletin._
+
+It is good to think that there is at least one man who believes that
+all the spirit of romance and chivalry has not yet died out of the
+world, and that there are as brave and honest hearts to-day as there
+were in the days of knights and paladins.—_Philadelphia Record._
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+BEN-HUR: A TALE OF THE CHRIST.
+
+
+  By LEW. WALLACE. 16mo, Cloth, $1 50. _Garfield Edition._
+    Two Volumes. Twenty Full-page Photogravures. Over 1000
+    Illustrations as Marginal Drawings by WILLIAM MARTIN JOHNSON.
+    Crown 8vo, Printed on Fine Super-calendered Plate-paper, Uncut
+    Edges and Gilt Tops, Bound in Silk and Gold, $7 00. (_In a
+    Gladstone Box._)
+
+Anything so startling, new, and distinctive as the leading feature of
+this romance does not often appear in works of fiction.... Some of Mr.
+Wallace’s writing is remarkable for its pathetic eloquence. The scenes
+described in the New Testament are rewritten with the power and skill
+of an accomplished master of style.—_N. Y. Times._
+
+Its real basis is a description of the life of the Jews and Romans
+at the beginning of the Christian era, and this is both forcible and
+brilliant.... We are carried through a surprising variety of scenes;
+we witness a sea-fight, a chariot-race, the internal economy of a
+Roman galley, domestic interiors at Antioch, at Jerusalem, and among
+the tribes of the desert; palaces, prisons, the haunts of dissipated
+Roman youth, the houses of pious families of Israel. There is plenty of
+exciting incident; everything is animated, vivid and glowing.—_N. Y.
+Tribune._
+
+From the opening of the volume to the very close the reader’s interest
+will be kept at the highest pitch, and the novel will be pronounced by
+all one of the greatest novels of the day.—_Boston Post._
+
+“Ben Hur” is interesting, and its characterization is fine and strong.
+Meanwhile it evinces careful study of the period in which the scene
+is laid, and will help those who read it with reasonable attention to
+realize the nature and conditions of Hebrew life in Jerusalem and Roman
+life at Antioch at the time of our Saviour’s advent.—_Examiner_, N. Y.
+
+The book is one of unquestionable power, and will be read with unwonted
+interest by many readers who are weary of the conventional novel and
+romance.—_Boston Journal._
+
+One of the most remarkable and delightful books. It is as real and
+warm as life itself, and as attractive as the grandest and most heroic
+chapters of history.—_Indianapolis Journal._
+
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above work will be sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+Transcriber’s Note:
+
+The text published in the original publication has been
+preserved except as follows:
+
+  Punctuation has been standardised.
+
+  Page 5
+  scored by six almost paralled _changed to_
+  scored by six almost parallel
+
+  Page 20
+  Sherlock Holmes’ succinct description _changed to_
+  Sherlock Holmes’s succinct description
+
+  Page 37
+  injustice to hestitate _changed to_
+  injustice to hesitate
+
+  Page 46
+  I saw him that afternoon so enwrapped _changed to_
+  I saw him that afternoon so enrapt
+
+  Page 81
+  his had the natural ef-effect _changed to_
+  his had the natural effect
+
+  Page 87
+  brother and siser; but of course _changed to_
+  brother and sister; but of course
+
+  Page 93
+  at this. Men who had only know _changed to_
+  as this. Men who had only know
+
+  Page 148
+  and we very all quietly entered _changed to_
+  and we all very quietly entered
+
+  Page 156
+  had remarked, the initals “H. B.” _changed to_
+  had remarked, the initials “H. B.”
+
+  Page 161
+  If this fail _changed to_
+  If this fails
+
+  Page 174
+  Gone to the dealer’s, Jim _changed to_
+  Gone to the dealer’s, Jem
+
+  Page 185
+  delirum, sometimes that it _changed to_
+  delirium, sometimes that it
+
+  Page 192
+  The centra portion was in _changed to_
+  The central portion was in
+
+  Page 200
+  waiting silently for for whatever _changed to_
+  waiting silently for whatever
+
+  Page 215
+  save the occasional bright blurr _changed to_
+  save the occasional bright blur
+
+  Page 245
+  a _pâtè de foie gras_ pie _changed to_
+  a _pâté de foie gras_ pie
+
+  Page 250
+  permision, I will now wish _changed to_
+  permission, I will now wish
+
+  Page 293
+  boisterious fashion, and on the whole _changed to_
+  boisterous fashion, and on the whole
+
+  Page 297
+  wrapt in the peaceful beauty _changed to_
+  rapt in the peaceful beauty
+
+
+
+
+
+
+
+End of Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+***** This file should be named 48320-0.txt or 48320-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/4/8/3/2/48320/
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/anderson-fairy-tales.txt
+++ b/jet/source-sink-builder/src/main/resources/books/anderson-fairy-tales.txt
@@ -1,0 +1,6206 @@
+﻿Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Andersen’s Fairy Tales
+
+Author: Hans Christian Andersen
+
+Posting Date: October 10, 2008 [EBook #1597]
+Release Date: January, 1999
+Last Updated: October 8, 2016
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+
+
+
+Produced by Dianne Bean
+
+
+
+
+
+ANDERSEN’S FAIRY TALES
+
+By Hans Christian Andersen
+
+
+
+CONTENTS
+
+
+     The Emperor’s New Clothes
+     The Swineherd
+     The Real Princess
+     The Shoes of Fortune
+     The Fir Tree
+     The Snow Queen
+     The Leap-Frog
+     The Elderbush
+     The Bell
+     The Old House
+     The Happy Family
+     The Story of a Mother
+     The False Collar
+     The Shadow
+     The Little Match Girl
+     The Dream of Little Tuk
+     The Naughty Boy
+     The Red Shoes
+
+
+
+
+THE EMPEROR’S NEW CLOTHES
+
+Many years ago, there was an Emperor, who was so excessively fond of
+new clothes, that he spent all his money in dress. He did not trouble
+himself in the least about his soldiers; nor did he care to go either to
+the theatre or the chase, except for the opportunities then afforded him
+for displaying his new clothes. He had a different suit for each hour of
+the day; and as of any other king or emperor, one is accustomed to say,
+“he is sitting in council,” it was always said of him, “The Emperor is
+sitting in his wardrobe.”
+
+Time passed merrily in the large town which was his capital; strangers
+arrived every day at the court. One day, two rogues, calling themselves
+weavers, made their appearance. They gave out that they knew how to
+weave stuffs of the most beautiful colors and elaborate patterns, the
+clothes manufactured from which should have the wonderful property of
+remaining invisible to everyone who was unfit for the office he held, or
+who was extraordinarily simple in character.
+
+“These must, indeed, be splendid clothes!” thought the Emperor. “Had I
+such a suit, I might at once find out what men in my realms are unfit
+for their office, and also be able to distinguish the wise from the
+foolish! This stuff must be woven for me immediately.” And he caused
+large sums of money to be given to both the weavers in order that they
+might begin their work directly.
+
+So the two pretended weavers set up two looms, and affected to work very
+busily, though in reality they did nothing at all. They asked for the
+most delicate silk and the purest gold thread; put both into their own
+knapsacks; and then continued their pretended work at the empty looms
+until late at night.
+
+“I should like to know how the weavers are getting on with my cloth,”
+ said the Emperor to himself, after some little time had elapsed; he was,
+however, rather embarrassed, when he remembered that a simpleton, or
+one unfit for his office, would be unable to see the manufacture. To be
+sure, he thought he had nothing to risk in his own person; but yet, he
+would prefer sending somebody else, to bring him intelligence about the
+weavers, and their work, before he troubled himself in the affair. All
+the people throughout the city had heard of the wonderful property the
+cloth was to possess; and all were anxious to learn how wise, or how
+ignorant, their neighbors might prove to be.
+
+“I will send my faithful old minister to the weavers,” said the Emperor
+at last, after some deliberation, “he will be best able to see how the
+cloth looks; for he is a man of sense, and no one can be more suitable
+for his office than he is.”
+
+So the faithful old minister went into the hall, where the knaves were
+working with all their might, at their empty looms. “What can be the
+meaning of this?” thought the old man, opening his eyes very wide. “I
+cannot discover the least bit of thread on the looms.” However, he did
+not express his thoughts aloud.
+
+The impostors requested him very courteously to be so good as to come
+nearer their looms; and then asked him whether the design pleased
+him, and whether the colors were not very beautiful; at the same time
+pointing to the empty frames. The poor old minister looked and looked,
+he could not discover anything on the looms, for a very good reason,
+viz: there was nothing there. “What!” thought he again. “Is it possible
+that I am a simpleton? I have never thought so myself; and no one must
+know it now if I am so. Can it be, that I am unfit for my office? No,
+that must not be said either. I will never confess that I could not see
+the stuff.”
+
+“Well, Sir Minister!” said one of the knaves, still pretending to work.
+“You do not say whether the stuff pleases you.”
+
+“Oh, it is excellent!” replied the old minister, looking at the loom
+through his spectacles. “This pattern, and the colors, yes, I will tell
+the Emperor without delay, how very beautiful I think them.”
+
+“We shall be much obliged to you,” said the impostors, and then they
+named the different colors and described the pattern of the pretended
+stuff. The old minister listened attentively to their words, in order
+that he might repeat them to the Emperor; and then the knaves asked for
+more silk and gold, saying that it was necessary to complete what
+they had begun. However, they put all that was given them into their
+knapsacks; and continued to work with as much apparent diligence as
+before at their empty looms.
+
+The Emperor now sent another officer of his court to see how the men
+were getting on, and to ascertain whether the cloth would soon be
+ready. It was just the same with this gentleman as with the minister;
+he surveyed the looms on all sides, but could see nothing at all but the
+empty frames.
+
+“Does not the stuff appear as beautiful to you, as it did to my lord the
+minister?” asked the impostors of the Emperor’s second ambassador; at
+the same time making the same gestures as before, and talking of the
+design and colors which were not there.
+
+“I certainly am not stupid!” thought the messenger. “It must be, that I
+am not fit for my good, profitable office! That is very odd; however, no
+one shall know anything about it.” And accordingly he praised the stuff
+he could not see, and declared that he was delighted with both colors
+and patterns. “Indeed, please your Imperial Majesty,” said he to his
+sovereign when he returned, “the cloth which the weavers are preparing
+is extraordinarily magnificent.”
+
+The whole city was talking of the splendid cloth which the Emperor had
+ordered to be woven at his own expense.
+
+And now the Emperor himself wished to see the costly manufacture, while
+it was still in the loom. Accompanied by a select number of officers of
+the court, among whom were the two honest men who had already admired
+the cloth, he went to the crafty impostors, who, as soon as they were
+aware of the Emperor’s approach, went on working more diligently than
+ever; although they still did not pass a single thread through the
+looms.
+
+“Is not the work absolutely magnificent?” said the two officers of the
+crown, already mentioned. “If your Majesty will only be pleased to look
+at it! What a splendid design! What glorious colors!” and at the same
+time they pointed to the empty frames; for they imagined that everyone
+else could see this exquisite piece of workmanship.
+
+“How is this?” said the Emperor to himself. “I can see nothing! This
+is indeed a terrible affair! Am I a simpleton, or am I unfit to be an
+Emperor? That would be the worst thing that could happen--Oh! the cloth
+is charming,” said he, aloud. “It has my complete approbation.” And he
+smiled most graciously, and looked closely at the empty looms; for on no
+account would he say that he could not see what two of the officers of
+his court had praised so much. All his retinue now strained their eyes,
+hoping to discover something on the looms, but they could see no more
+than the others; nevertheless, they all exclaimed, “Oh, how beautiful!”
+ and advised his majesty to have some new clothes made from this splendid
+material, for the approaching procession. “Magnificent! Charming!
+Excellent!” resounded on all sides; and everyone was uncommonly gay. The
+Emperor shared in the general satisfaction; and presented the impostors
+with the riband of an order of knighthood, to be worn in their
+button-holes, and the title of “Gentlemen Weavers.”
+
+The rogues sat up the whole of the night before the day on which the
+procession was to take place, and had sixteen lights burning, so that
+everyone might see how anxious they were to finish the Emperor’s new
+suit. They pretended to roll the cloth off the looms; cut the air with
+their scissors; and sewed with needles without any thread in them.
+“See!” cried they, at last. “The Emperor’s new clothes are ready!”
+
+And now the Emperor, with all the grandees of his court, came to the
+weavers; and the rogues raised their arms, as if in the act of holding
+something up, saying, “Here are your Majesty’s trousers! Here is the
+scarf! Here is the mantle! The whole suit is as light as a cobweb;
+one might fancy one has nothing at all on, when dressed in it; that,
+however, is the great virtue of this delicate cloth.”
+
+“Yes indeed!” said all the courtiers, although not one of them could see
+anything of this exquisite manufacture.
+
+“If your Imperial Majesty will be graciously pleased to take off your
+clothes, we will fit on the new suit, in front of the looking glass.”
+
+The Emperor was accordingly undressed, and the rogues pretended to
+array him in his new suit; the Emperor turning round, from side to side,
+before the looking glass.
+
+“How splendid his Majesty looks in his new clothes, and how well they
+fit!” everyone cried out. “What a design! What colors! These are indeed
+royal robes!”
+
+“The canopy which is to be borne over your Majesty, in the procession,
+is waiting,” announced the chief master of the ceremonies.
+
+“I am quite ready,” answered the Emperor. “Do my new clothes fit well?”
+ asked he, turning himself round again before the looking glass, in order
+that he might appear to be examining his handsome suit.
+
+The lords of the bedchamber, who were to carry his Majesty’s train felt
+about on the ground, as if they were lifting up the ends of the mantle;
+and pretended to be carrying something; for they would by no means
+betray anything like simplicity, or unfitness for their office.
+
+So now the Emperor walked under his high canopy in the midst of the
+procession, through the streets of his capital; and all the people
+standing by, and those at the windows, cried out, “Oh! How beautiful
+are our Emperor’s new clothes! What a magnificent train there is to
+the mantle; and how gracefully the scarf hangs!” in short, no one would
+allow that he could not see these much-admired clothes; because, in
+doing so, he would have declared himself either a simpleton or unfit
+for his office. Certainly, none of the Emperor’s various suits, had ever
+made so great an impression, as these invisible ones.
+
+“But the Emperor has nothing at all on!” said a little child.
+
+“Listen to the voice of innocence!” exclaimed his father; and what the
+child had said was whispered from one to another.
+
+“But he has nothing at all on!” at last cried out all the people.
+The Emperor was vexed, for he knew that the people were right; but he
+thought the procession must go on now! And the lords of the bedchamber
+took greater pains than ever, to appear holding up a train, although, in
+reality, there was no train to hold.
+
+
+
+
+THE SWINEHERD
+
+There was once a poor Prince, who had a kingdom. His kingdom was very
+small, but still quite large enough to marry upon; and he wished to
+marry.
+
+It was certainly rather cool of him to say to the Emperor’s daughter,
+“Will you have me?” But so he did; for his name was renowned far and
+wide; and there were a hundred princesses who would have answered,
+“Yes!” and “Thank you kindly.” We shall see what this princess said.
+
+Listen!
+
+It happened that where the Prince’s father lay buried, there grew a rose
+tree--a most beautiful rose tree, which blossomed only once in every
+five years, and even then bore only one flower, but that was a rose!
+It smelt so sweet that all cares and sorrows were forgotten by him who
+inhaled its fragrance.
+
+And furthermore, the Prince had a nightingale, who could sing in such a
+manner that it seemed as though all sweet melodies dwelt in her little
+throat. So the Princess was to have the rose, and the nightingale; and
+they were accordingly put into large silver caskets, and sent to her.
+
+The Emperor had them brought into a large hall, where the Princess was
+playing at “Visiting,” with the ladies of the court; and when she saw
+the caskets with the presents, she clapped her hands for joy.
+
+“Ah, if it were but a little pussy-cat!” said she; but the rose tree,
+with its beautiful rose came to view.
+
+“Oh, how prettily it is made!” said all the court ladies.
+
+“It is more than pretty,” said the Emperor, “it is charming!”
+
+But the Princess touched it, and was almost ready to cry.
+
+“Fie, papa!” said she. “It is not made at all, it is natural!”
+
+“Let us see what is in the other casket, before we get into a bad
+humor,” said the Emperor. So the nightingale came forth and sang so
+delightfully that at first no one could say anything ill-humored of her.
+
+“Superbe! Charmant!” exclaimed the ladies; for they all used to chatter
+French, each one worse than her neighbor.
+
+“How much the bird reminds me of the musical box that belonged to our
+blessed Empress,” said an old knight. “Oh yes! These are the same tones,
+the same execution.”
+
+“Yes! yes!” said the Emperor, and he wept like a child at the
+remembrance.
+
+“I will still hope that it is not a real bird,” said the Princess.
+
+“Yes, it is a real bird,” said those who had brought it. “Well then let
+the bird fly,” said the Princess; and she positively refused to see the
+Prince.
+
+However, he was not to be discouraged; he daubed his face over brown and
+black; pulled his cap over his ears, and knocked at the door.
+
+“Good day to my lord, the Emperor!” said he. “Can I have employment at
+the palace?”
+
+“Why, yes,” said the Emperor. “I want some one to take care of the pigs,
+for we have a great many of them.”
+
+So the Prince was appointed “Imperial Swineherd.” He had a dirty little
+room close by the pigsty; and there he sat the whole day, and worked. By
+the evening he had made a pretty little kitchen-pot. Little bells were
+hung all round it; and when the pot was boiling, these bells tinkled in
+the most charming manner, and played the old melody,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”*
+
+    * “Ah! dear Augustine!
+    All is gone, gone, gone!”
+
+
+But what was still more curious, whoever held his finger in the smoke of
+the kitchen-pot, immediately smelt all the dishes that were cooking on
+every hearth in the city--this, you see, was something quite different
+from the rose.
+
+Now the Princess happened to walk that way; and when she heard the tune,
+she stood quite still, and seemed pleased; for she could play “Lieber
+Augustine”; it was the only piece she knew; and she played it with one
+finger.
+
+“Why there is my piece,” said the Princess. “That swineherd must
+certainly have been well educated! Go in and ask him the price of the
+instrument.”
+
+So one of the court-ladies must run in; however, she drew on wooden
+slippers first.
+
+“What will you take for the kitchen-pot?” said the lady.
+
+“I will have ten kisses from the Princess,” said the swineherd.
+
+“Yes, indeed!” said the lady.
+
+“I cannot sell it for less,” rejoined the swineherd.
+
+“He is an impudent fellow!” said the Princess, and she walked on; but
+when she had gone a little way, the bells tinkled so prettily
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+“Stay,” said the Princess. “Ask him if he will have ten kisses from the
+ladies of my court.”
+
+“No, thank you!” said the swineherd. “Ten kisses from the Princess, or I
+keep the kitchen-pot myself.”
+
+“That must not be, either!” said the Princess. “But do you all stand
+before me that no one may see us.”
+
+And the court-ladies placed themselves in front of her, and spread
+out their dresses--the swineherd got ten kisses, and the Princess--the
+kitchen-pot.
+
+That was delightful! The pot was boiling the whole evening, and the
+whole of the following day. They knew perfectly well what was cooking at
+every fire throughout the city, from the chamberlain’s to the cobbler’s;
+the court-ladies danced and clapped their hands.
+
+“We know who has soup, and who has pancakes for dinner to-day, who has
+cutlets, and who has eggs. How interesting!”
+
+“Yes, but keep my secret, for I am an Emperor’s daughter.”
+
+The swineherd--that is to say--the Prince, for no one knew that he was
+other than an ill-favored swineherd, let not a day pass without working
+at something; he at last constructed a rattle, which, when it was swung
+round, played all the waltzes and jig tunes, which have ever been heard
+since the creation of the world.
+
+“Ah, that is superbe!” said the Princess when she passed by. “I have
+never heard prettier compositions! Go in and ask him the price of the
+instrument; but mind, he shall have no more kisses!”
+
+“He will have a hundred kisses from the Princess!” said the lady who had
+been to ask.
+
+“I think he is not in his right senses!” said the Princess, and walked
+on, but when she had gone a little way, she stopped again. “One must
+encourage art,” said she, “I am the Emperor’s daughter. Tell him he
+shall, as on yesterday, have ten kisses from me, and may take the rest
+from the ladies of the court.”
+
+“Oh--but we should not like that at all!” said they. “What are you
+muttering?” asked the Princess. “If I can kiss him, surely you can.
+Remember that you owe everything to me.” So the ladies were obliged to
+go to him again.
+
+“A hundred kisses from the Princess,” said he, “or else let everyone
+keep his own!”
+
+“Stand round!” said she; and all the ladies stood round her whilst the
+kissing was going on.
+
+“What can be the reason for such a crowd close by the pigsty?” said the
+Emperor, who happened just then to step out on the balcony; he rubbed
+his eyes, and put on his spectacles. “They are the ladies of the
+court; I must go down and see what they are about!” So he pulled up his
+slippers at the heel, for he had trodden them down.
+
+As soon as he had got into the court-yard, he moved very softly, and the
+ladies were so much engrossed with counting the kisses, that all might
+go on fairly, that they did not perceive the Emperor. He rose on his
+tiptoes.
+
+“What is all this?” said he, when he saw what was going on, and he boxed
+the Princess’s ears with his slipper, just as the swineherd was taking
+the eighty-sixth kiss.
+
+“March out!” said the Emperor, for he was very angry; and both Princess
+and swineherd were thrust out of the city.
+
+The Princess now stood and wept, the swineherd scolded, and the rain
+poured down.
+
+“Alas! Unhappy creature that I am!” said the Princess. “If I had but
+married the handsome young Prince! Ah! how unfortunate I am!”
+
+And the swineherd went behind a tree, washed the black and brown color
+from his face, threw off his dirty clothes, and stepped forth in his
+princely robes; he looked so noble that the Princess could not help
+bowing before him.
+
+“I am come to despise thee,” said he. “Thou would’st not have an
+honorable Prince! Thou could’st not prize the rose and the nightingale,
+but thou wast ready to kiss the swineherd for the sake of a trumpery
+plaything. Thou art rightly served.”
+
+He then went back to his own little kingdom, and shut the door of his
+palace in her face. Now she might well sing,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+
+
+
+THE REAL PRINCESS
+
+There was once a Prince who wished to marry a Princess; but then she
+must be a real Princess. He travelled all over the world in hopes of
+finding such a lady; but there was always something wrong. Princesses he
+found in plenty; but whether they were real Princesses it was impossible
+for him to decide, for now one thing, now another, seemed to him not
+quite right about the ladies. At last he returned to his palace quite
+cast down, because he wished so much to have a real Princess for his
+wife.
+
+One evening a fearful tempest arose, it thundered and lightened, and the
+rain poured down from the sky in torrents: besides, it was as dark as
+pitch. All at once there was heard a violent knocking at the door, and
+the old King, the Prince’s father, went out himself to open it.
+
+It was a Princess who was standing outside the door. What with the rain
+and the wind, she was in a sad condition; the water trickled down from
+her hair, and her clothes clung to her body. She said she was a real
+Princess.
+
+“Ah! we shall soon see that!” thought the old Queen-mother; however, she
+said not a word of what she was going to do; but went quietly into the
+bedroom, took all the bed-clothes off the bed, and put three little peas
+on the bedstead. She then laid twenty mattresses one upon another over
+the three peas, and put twenty feather beds over the mattresses.
+
+Upon this bed the Princess was to pass the night.
+
+The next morning she was asked how she had slept. “Oh, very badly
+indeed!” she replied. “I have scarcely closed my eyes the whole night
+through. I do not know what was in my bed, but I had something hard
+under me, and am all over black and blue. It has hurt me so much!”
+
+Now it was plain that the lady must be a real Princess, since she had
+been able to feel the three little peas through the twenty mattresses
+and twenty feather beds. None but a real Princess could have had such a
+delicate sense of feeling.
+
+The Prince accordingly made her his wife; being now convinced that he
+had found a real Princess. The three peas were however put into the
+cabinet of curiosities, where they are still to be seen, provided they
+are not lost.
+
+Wasn’t this a lady of real delicacy?
+
+
+
+
+THE SHOES OF FORTUNE
+
+I. A Beginning
+
+Every author has some peculiarity in his descriptions or in his style
+of writing. Those who do not like him, magnify it, shrug up their
+shoulders, and exclaim--there he is again! I, for my part, know very
+well how I can bring about this movement and this exclamation. It would
+happen immediately if I were to begin here, as I intended to do, with:
+“Rome has its Corso, Naples its Toledo”--“Ah! that Andersen; there he is
+again!” they would cry; yet I must, to please my fancy, continue quite
+quietly, and add: “But Copenhagen has its East Street.”
+
+Here, then, we will stay for the present. In one of the houses not far
+from the new market a party was invited--a very large party, in order,
+as is often the case, to get a return invitation from the others. One
+half of the company was already seated at the card-table, the other half
+awaited the result of the stereotype preliminary observation of the lady
+of the house:
+
+“Now let us see what we can do to amuse ourselves.”
+
+They had got just so far, and the conversation began to crystallise,
+as it could but do with the scanty stream which the commonplace world
+supplied. Amongst other things they spoke of the middle ages: some
+praised that period as far more interesting, far more poetical than our
+own too sober present; indeed Councillor Knap defended this opinion
+so warmly, that the hostess declared immediately on his side, and both
+exerted themselves with unwearied eloquence. The Councillor boldly
+declared the time of King Hans to be the noblest and the most happy
+period.*
+
+* A.D. 1482-1513
+
+
+While the conversation turned on this subject, and was only for a moment
+interrupted by the arrival of a journal that contained nothing worth
+reading, we will just step out into the antechamber, where cloaks,
+mackintoshes, sticks, umbrellas, and shoes, were deposited. Here sat two
+female figures, a young and an old one. One might have thought at first
+they were servants come to accompany their mistresses home; but on
+looking nearer, one soon saw they could scarcely be mere servants; their
+forms were too noble for that, their skin too fine, the cut of their
+dress too striking. Two fairies were they; the younger, it is true,
+was not Dame Fortune herself, but one of the waiting-maids of her
+handmaidens who carry about the lesser good things that she distributes;
+the other looked extremely gloomy--it was Care. She always attends to
+her own serious business herself, as then she is sure of having it done
+properly.
+
+They were telling each other, with a confidential interchange of ideas,
+where they had been during the day. The messenger of Fortune had only
+executed a few unimportant commissions, such as saving a new bonnet from
+a shower of rain, etc.; but what she had yet to perform was something
+quite unusual.
+
+“I must tell you,” said she, “that to-day is my birthday; and in honor
+of it, a pair of walking-shoes or galoshes has been entrusted to me,
+which I am to carry to mankind. These shoes possess the property of
+instantly transporting him who has them on to the place or the period
+in which he most wishes to be; every wish, as regards time or place, or
+state of being, will be immediately fulfilled, and so at last man will
+be happy, here below.”
+
+“Do you seriously believe it?” replied Care, in a severe tone of
+reproach. “No; he will be very unhappy, and will assuredly bless the
+moment when he feels that he has freed himself from the fatal shoes.”
+
+“Stupid nonsense!” said the other angrily. “I will put them here by
+the door. Some one will make a mistake for certain and take the wrong
+ones--he will be a happy man.”
+
+Such was their conversation.
+
+
+II. What Happened to the Councillor
+
+It was late; Councillor Knap, deeply occupied with the times of King
+Hans, intended to go home, and malicious Fate managed matters so that
+his feet, instead of finding their way to his own galoshes, slipped
+into those of Fortune. Thus caparisoned the good man walked out of the
+well-lighted rooms into East Street. By the magic power of the shoes he
+was carried back to the times of King Hans; on which account his foot
+very naturally sank in the mud and puddles of the street, there having
+been in those days no pavement in Copenhagen.
+
+“Well! This is too bad! How dirty it is here!” sighed the Councillor.
+“As to a pavement, I can find no traces of one, and all the lamps, it
+seems, have gone to sleep.”
+
+The moon was not yet very high; it was besides rather foggy, so that
+in the darkness all objects seemed mingled in chaotic confusion. At the
+next corner hung a votive lamp before a Madonna, but the light it gave
+was little better than none at all; indeed, he did not observe it before
+he was exactly under it, and his eyes fell upon the bright colors of the
+pictures which represented the well-known group of the Virgin and the
+infant Jesus.
+
+“That is probably a wax-work show,” thought he; “and the people delay
+taking down their sign in hopes of a late visitor or two.”
+
+A few persons in the costume of the time of King Hans passed quickly by
+him.
+
+“How strange they look! The good folks come probably from a masquerade!”
+
+Suddenly was heard the sound of drums and fifes; the bright blaze of a
+fire shot up from time to time, and its ruddy gleams seemed to contend
+with the bluish light of the torches. The Councillor stood still, and
+watched a most strange procession pass by. First came a dozen drummers,
+who understood pretty well how to handle their instruments; then came
+halberdiers, and some armed with cross-bows. The principal person in the
+procession was a priest. Astonished at what he saw, the Councillor asked
+what was the meaning of all this mummery, and who that man was.
+
+“That’s the Bishop of Zealand,” was the answer.
+
+“Good Heavens! What has taken possession of the Bishop?” sighed the
+Councillor, shaking his head. It certainly could not be the Bishop; even
+though he was considered the most absent man in the whole kingdom, and
+people told the drollest anecdotes about him. Reflecting on the matter,
+and without looking right or left, the Councillor went through East
+Street and across the Habro-Platz. The bridge leading to Palace Square
+was not to be found; scarcely trusting his senses, the nocturnal
+wanderer discovered a shallow piece of water, and here fell in with two
+men who very comfortably were rocking to and fro in a boat.
+
+“Does your honor want to cross the ferry to the Holme?” asked they.
+
+“Across to the Holme!” said the Councillor, who knew nothing of the age
+in which he at that moment was. “No, I am going to Christianshafen, to
+Little Market Street.”
+
+Both men stared at him in astonishment.
+
+“Only just tell me where the bridge is,” said he. “It is really
+unpardonable that there are no lamps here; and it is as dirty as if one
+had to wade through a morass.”
+
+The longer he spoke with the boatmen, the more unintelligible did their
+language become to him.
+
+“I don’t understand your Bornholmish dialect,” said he at last, angrily,
+and turning his back upon them. He was unable to find the bridge: there
+was no railway either. “It is really disgraceful what a state this place
+is in,” muttered he to himself. Never had his age, with which, however,
+he was always grumbling, seemed so miserable as on this evening. “I’ll
+take a hackney-coach!” thought he. But where were the hackney-coaches?
+Not one was to be seen.
+
+“I must go back to the New Market; there, it is to be hoped, I
+shall find some coaches; for if I don’t, I shall never get safe to
+Christianshafen.”
+
+So off he went in the direction of East Street, and had nearly got to
+the end of it when the moon shone forth.
+
+“God bless me! What wooden scaffolding is that which they have set up
+there?” cried he involuntarily, as he looked at East Gate, which, in
+those days, was at the end of East Street.
+
+He found, however, a little side-door open, and through this he went,
+and stepped into our New Market of the present time. It was a huge
+desolate plain; some wild bushes stood up here and there, while across
+the field flowed a broad canal or river. Some wretched hovels for the
+Dutch sailors, resembling great boxes, and after which the place was
+named, lay about in confused disorder on the opposite bank.
+
+“I either behold a fata morgana, or I am regularly tipsy,” whimpered out
+the Councillor. “But what’s this?”
+
+He turned round anew, firmly convinced that he was seriously ill. He
+gazed at the street formerly so well known to him, and now so strange in
+appearance, and looked at the houses more attentively: most of them were
+of wood, slightly put together; and many had a thatched roof.
+
+“No--I am far from well,” sighed he; “and yet I drank only one glass of
+punch; but I cannot suppose it--it was, too, really very wrong to give
+us punch and hot salmon for supper. I shall speak about it at the first
+opportunity. I have half a mind to go back again, and say what I suffer.
+But no, that would be too silly; and Heaven only knows if they are up
+still.”
+
+He looked for the house, but it had vanished.
+
+“It is really dreadful,” groaned he with increasing anxiety; “I cannot
+recognise East Street again; there is not a single decent shop from one
+end to the other! Nothing but wretched huts can I see anywhere; just
+as if I were at Ringstead. Oh! I am ill! I can scarcely bear myself any
+longer. Where the deuce can the house be? It must be here on this very
+spot; yet there is not the slightest idea of resemblance, to such a
+degree has everything changed this night! At all events here are some
+people up and stirring. Oh! oh! I am certainly very ill.”
+
+He now hit upon a half-open door, through a chink of which a faint light
+shone. It was a sort of hostelry of those times; a kind of public-house.
+The room had some resemblance to the clay-floored halls in Holstein; a
+pretty numerous company, consisting of seamen, Copenhagen burghers, and
+a few scholars, sat here in deep converse over their pewter cans, and
+gave little heed to the person who entered.
+
+“By your leave!” said the Councillor to the Hostess, who came bustling
+towards him. “I’ve felt so queer all of a sudden; would you have the
+goodness to send for a hackney-coach to take me to Christianshafen?”
+
+The woman examined him with eyes of astonishment, and shook her head;
+she then addressed him in German. The Councillor thought she did not
+understand Danish, and therefore repeated his wish in German. This, in
+connection with his costume, strengthened the good woman in the belief
+that he was a foreigner. That he was ill, she comprehended directly; so
+she brought him a pitcher of water, which tasted certainly pretty strong
+of the sea, although it had been fetched from the well.
+
+The Councillor supported his head on his hand, drew a long breath, and
+thought over all the wondrous things he saw around him.
+
+“Is this the Daily News of this evening?” he asked mechanically, as he
+saw the Hostess push aside a large sheet of paper.
+
+The meaning of this councillorship query remained, of course, a riddle
+to her, yet she handed him the paper without replying. It was a coarse
+wood-cut, representing a splendid meteor “as seen in the town of
+Cologne,” which was to be read below in bright letters.
+
+“That is very old!” said the Councillor, whom this piece of antiquity
+began to make considerably more cheerful. “Pray how did you come into
+possession of this rare print? It is extremely interesting, although the
+whole is a mere fable. Such meteorous appearances are to be explained in
+this way--that they are the reflections of the Aurora Borealis, and it
+is highly probable they are caused principally by electricity.”
+
+Those persons who were sitting nearest him and heard his speech,
+stared at him in wonderment; and one of them rose, took off his hat
+respectfully, and said with a serious countenance, “You are no doubt a
+very learned man, Monsieur.”
+
+“Oh no,” answered the Councillor, “I can only join in conversation on
+this topic and on that, as indeed one must do according to the demands
+of the world at present.”
+
+“Modestia is a fine virtue,” continued the gentleman; “however, as to
+your speech, I must say mihi secus videtur: yet I am willing to suspend
+my judicium.”
+
+“May I ask with whom I have the pleasure of speaking?” asked the
+Councillor.
+
+“I am a Bachelor in Theologia,” answered the gentleman with a stiff
+reverence.
+
+This reply fully satisfied the Councillor; the title suited the dress.
+“He is certainly,” thought he, “some village schoolmaster--some queer
+old fellow, such as one still often meets with in Jutland.”
+
+“This is no locus docendi, it is true,” began the clerical gentleman;
+“yet I beg you earnestly to let us profit by your learning. Your reading
+in the ancients is, sine dubio, of vast extent?”
+
+“Oh yes, I’ve read something, to be sure,” replied the Councillor. “I
+like reading all useful works; but I do not on that account despise the
+modern ones; ‘tis only the unfortunate ‘Tales of Every-day Life’ that I
+cannot bear--we have enough and more than enough such in reality.”
+
+“‘Tales of Every-day Life?’” said our Bachelor inquiringly.
+
+“I mean those new fangled novels, twisting and writhing themselves in
+the dust of commonplace, which also expect to find a reading public.”
+
+“Oh,” exclaimed the clerical gentleman smiling, “there is much wit in
+them; besides they are read at court. The King likes the history of Sir
+Iffven and Sir Gaudian particularly, which treats of King Arthur, and
+his Knights of the Round Table; he has more than once joked about it
+with his high vassals.”
+
+“I have not read that novel,” said the Councillor; “it must be quite a
+new one, that Heiberg has published lately.”
+
+“No,” answered the theologian of the time of King Hans: “that book is
+not written by a Heiberg, but was imprinted by Godfrey von Gehmen.”
+
+“Oh, is that the author’s name?” said the Councillor. “It is a very
+old name, and, as well as I recollect, he was the first printer that
+appeared in Denmark.”
+
+“Yes, he is our first printer,” replied the clerical gentleman hastily.
+
+So far all went on well. Some one of the worthy burghers now spoke of
+the dreadful pestilence that had raged in the country a few years back,
+meaning that of 1484. The Councillor imagined it was the cholera that
+was meant, which people made so much fuss about; and the discourse
+passed off satisfactorily enough. The war of the buccaneers of 1490 was
+so recent that it could not fail being alluded to; the English
+pirates had, they said, most shamefully taken their ships while in the
+roadstead; and the Councillor, before whose eyes the Herostratic [*]
+event of 1801 still floated vividly, agreed entirely with the others in
+abusing the rascally English. With other topics he was not so fortunate;
+every moment brought about some new confusion, and threatened to become
+a perfect Babel; for the worthy Bachelor was really too ignorant, and
+the simplest observations of the Councillor sounded to him too daring
+and phantastical. They looked at one another from the crown of the head
+to the soles of the feet; and when matters grew to too high a
+pitch, then the Bachelor talked Latin, in the hope of being better
+understood--but it was of no use after all.
+
+     * Herostratus, or Eratostratus--an Ephesian, who wantonly
+     set fire to the famous temple of Diana, in order to
+     commemorate his name by so uncommon an action.
+
+“What’s the matter?” asked the Hostess, plucking the Councillor by the
+sleeve; and now his recollection returned, for in the course of the
+conversation he had entirely forgotten all that had preceded it.
+
+“Merciful God, where am I!” exclaimed he in agony; and while he so
+thought, all his ideas and feelings of overpowering dizziness, against
+which he struggled with the utmost power of desperation, encompassed
+him with renewed force. “Let us drink claret and mead, and Bremen beer,”
+ shouted one of the guests--“and you shall drink with us!”
+
+Two maidens approached. One wore a cap of two staring colors, denoting
+the class of persons to which she belonged. They poured out the liquor,
+and made the most friendly gesticulations; while a cold perspiration
+trickled down the back of the poor Councillor.
+
+“What’s to be the end of this! What’s to become of me!” groaned he; but
+he was forced, in spite of his opposition, to drink with the rest. They
+took hold of the worthy man; who, hearing on every side that he was
+intoxicated, did not in the least doubt the truth of this certainly
+not very polite assertion; but on the contrary, implored the ladies
+and gentlemen present to procure him a hackney-coach: they, however,
+imagined he was talking Russian.
+
+Never before, he thought, had he been in such a coarse and ignorant
+company; one might almost fancy the people had turned heathens again.
+“It is the most dreadful moment of my life: the whole world is leagued
+against me!” But suddenly it occurred to him that he might stoop down
+under the table, and then creep unobserved out of the door. He did so;
+but just as he was going, the others remarked what he was about; they
+laid hold of him by the legs; and now, happily for him, off fell his
+fatal shoes--and with them the charm was at an end.
+
+The Councillor saw quite distinctly before him a lantern burning, and
+behind this a large handsome house. All seemed to him in proper order as
+usual; it was East Street, splendid and elegant as we now see it. He lay
+with his feet towards a doorway, and exactly opposite sat the watchman
+asleep.
+
+“Gracious Heaven!” said he. “Have I lain here in the street and dreamed?
+Yes; ‘tis East Street! How splendid and light it is! But really it is
+terrible what an effect that one glass of punch must have had on me!”
+
+Two minutes later, he was sitting in a hackney-coach and driving to
+Frederickshafen. He thought of the distress and agony he had endured,
+and praised from the very bottom of his heart the happy reality--our own
+time--which, with all its deficiencies, is yet much better than that in
+which, so much against his inclination, he had lately been.
+
+
+III. The Watchman’s Adventure
+
+“Why, there is a pair of galoshes, as sure as I’m alive!” said the
+watchman, awaking from a gentle slumber. “They belong no doubt to the
+lieutenant who lives over the way. They lie close to the door.”
+
+The worthy man was inclined to ring and deliver them at the house, for
+there was still a light in the window; but he did not like disturbing
+the other people in their beds, and so very considerately he left the
+matter alone.
+
+“Such a pair of shoes must be very warm and comfortable,” said he; “the
+leather is so soft and supple.” They fitted his feet as though they
+had been made for him. “‘Tis a curious world we live in,” continued he,
+soliloquizing. “There is the lieutenant, now, who might go quietly to
+bed if he chose, where no doubt he could stretch himself at his ease;
+but does he do it? No; he saunters up and down his room, because,
+probably, he has enjoyed too many of the good things of this world at
+his dinner. That’s a happy fellow! He has neither an infirm mother, nor
+a whole troop of everlastingly hungry children to torment him. Every
+evening he goes to a party, where his nice supper costs him nothing:
+would to Heaven I could but change with him! How happy should I be!”
+
+While expressing his wish, the charm of the shoes, which he had put on,
+began to work; the watchman entered into the being and nature of the
+lieutenant. He stood in the handsomely furnished apartment, and held
+between his fingers a small sheet of rose-colored paper, on which some
+verses were written--written indeed by the officer himself; for who has
+not, at least once in his life, had a lyrical moment? And if one then
+marks down one’s thoughts, poetry is produced. But here was written:
+
+                  OH, WERE I RICH!
+
+     “Oh, were I rich! Such was my wish, yea such
+      When hardly three feet high, I longed for much.
+       Oh, were I rich! an officer were I,
+       With sword, and uniform, and plume so high.
+       And the time came, and officer was I!
+     But yet I grew not rich. Alas, poor me!
+     Have pity, Thou, who all man’s wants dost see.
+
+        “I sat one evening sunk in dreams of bliss,
+      A maid of seven years old gave me a kiss,
+       I at that time was rich in poesy
+       And tales of old, though poor as poor could be;
+       But all she asked for was this poesy.
+     Then was I rich, but not in gold, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich! Oft asked I for this boon.
+      The child grew up to womanhood full soon.
+       She is so pretty, clever, and so kind
+     Oh, did she know what’s hidden in my mind--
+       A tale of old. Would she to me were kind!
+     But I’m condemned to silence! oh, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich in calm and peace of mind,
+      My grief you then would not here written find!
+       O thou, to whom I do my heart devote,
+       Oh read this page of glad days now remote,
+       A dark, dark tale, which I tonight devote!
+     Dark is the future now. Alas, poor me!
+     Have pity Thou, who all men’s pains dost see.”
+
+Such verses as these people write when they are in love! But no man
+in his senses ever thinks of printing them. Here one of the sorrows of
+life, in which there is real poetry, gave itself vent; not that
+barren grief which the poet may only hint at, but never depict in its
+detail--misery and want: that animal necessity, in short, to snatch
+at least at a fallen leaf of the bread-fruit tree, if not at the fruit
+itself. The higher the position in which one finds oneself transplanted,
+the greater is the suffering. Everyday necessity is the stagnant pool of
+life--no lovely picture reflects itself therein. Lieutenant, love, and
+lack of money--that is a symbolic triangle, or much the same as the
+half of the shattered die of Fortune. This the lieutenant felt most
+poignantly, and this was the reason he leant his head against the
+window, and sighed so deeply.
+
+“The poor watchman out there in the street is far happier than I. He
+knows not what I term privation. He has a home, a wife, and children,
+who weep with him over his sorrows, who rejoice with him when he is
+glad. Oh, far happier were I, could I exchange with him my being--with
+his desires and with his hopes perform the weary pilgrimage of life! Oh,
+he is a hundred times happier than I!”
+
+In the same moment the watchman was again watchman. It was the shoes
+that caused the metamorphosis by means of which, unknown to himself, he
+took upon him the thoughts and feelings of the officer; but, as we have
+just seen, he felt himself in his new situation much less contented,
+and now preferred the very thing which but some minutes before he had
+rejected. So then the watchman was again watchman.
+
+“That was an unpleasant dream,” said he; “but ‘twas droll enough
+altogether. I fancied that I was the lieutenant over there: and yet
+the thing was not very much to my taste after all. I missed my good old
+mother and the dear little ones; who almost tear me to pieces for sheer
+love.”
+
+He seated himself once more and nodded: the dream continued to haunt
+him, for he still had the shoes on his feet. A falling star shone in the
+dark firmament.
+
+“There falls another star,” said he: “but what does it matter; there
+are always enough left. I should not much mind examining the little
+glimmering things somewhat nearer, especially the moon; for that would
+not slip so easily through a man’s fingers. When we die--so at least
+says the student, for whom my wife does the washing--we shall fly about
+as light as a feather from one such a star to the other. That’s, of
+course, not true: but ‘twould be pretty enough if it were so. If I could
+but once take a leap up there, my body might stay here on the steps for
+what I care.”
+
+Behold--there are certain things in the world to which one ought never
+to give utterance except with the greatest caution; but doubly careful
+must one be when we have the Shoes of Fortune on our feet. Now just
+listen to what happened to the watchman.
+
+As to ourselves, we all know the speed produced by the employment of
+steam; we have experienced it either on railroads, or in boats when
+crossing the sea; but such a flight is like the travelling of a sloth in
+comparison with the velocity with which light moves. It flies nineteen
+million times faster than the best race-horse; and yet electricity is
+quicker still. Death is an electric shock which our heart receives; the
+freed soul soars upwards on the wings of electricity. The sun’s light
+wants eight minutes and some seconds to perform a journey of more than
+twenty million of our Danish [*] miles; borne by electricity, the soul
+wants even some minutes less to accomplish the same flight. To it the
+space between the heavenly bodies is not greater than the distance
+between the homes of our friends in town is for us, even if they live a
+short way from each other; such an electric shock in the heart, however,
+costs us the use of the body here below; unless, like the watchman of
+East Street, we happen to have on the Shoes of Fortune.
+
+     * A Danish mile is nearly 4 3/4 English.
+
+
+In a few seconds the watchman had done the fifty-two thousand of our
+miles up to the moon, which, as everyone knows, was formed out of
+matter much lighter than our earth; and is, so we should say, as soft
+as newly-fallen snow. He found himself on one of the many circumjacent
+mountain-ridges with which we are acquainted by means of Dr. Madler’s
+“Map of the Moon.” Within, down it sunk perpendicularly into a caldron,
+about a Danish mile in depth; while below lay a town, whose appearance
+we can, in some measure, realize to ourselves by beating the white of
+an egg in a glass of water. The matter of which it was built was just as
+soft, and formed similar towers, and domes, and pillars, transparent and
+rocking in the thin air; while above his head our earth was rolling like
+a large fiery ball.
+
+He perceived immediately a quantity of beings who were certainly what
+we call “men”; yet they looked different to us. A far more correct
+imagination than that of the pseudo-Herschel* had created them; and
+if they had been placed in rank and file, and copied by some skilful
+painter’s hand, one would, without doubt, have exclaimed involuntarily,
+“What a beautiful arabesque!”
+
+*This relates to a book published some years ago in Germany, and said
+to be by Herschel, which contained a description of the moon and its
+inhabitants, written with such a semblance of truth that many were
+deceived by the imposture.
+
+Probably a translation of the celebrated Moon hoax, written by Richard
+A. Locke, and originally published in New York.
+
+
+They had a language too; but surely nobody can expect that the soul of
+the watchman should understand it. Be that as it may, it did comprehend
+it; for in our souls there germinate far greater powers than we poor
+mortals, despite all our cleverness, have any notion of. Does she
+not show us--she the queen in the land of enchantment--her astounding
+dramatic talent in all our dreams? There every acquaintance appears and
+speaks upon the stage, so entirely in character, and with the same tone
+of voice, that none of us, when awake, were able to imitate it. How
+well can she recall persons to our mind, of whom we have not thought for
+years; when suddenly they step forth “every inch a man,” resembling the
+real personages, even to the finest features, and become the heroes
+or heroines of our world of dreams. In reality, such remembrances are
+rather unpleasant: every sin, every evil thought, may, like a clock with
+alarm or chimes, be repeated at pleasure; then the question is if we can
+trust ourselves to give an account of every unbecoming word in our heart
+and on our lips.
+
+The watchman’s spirit understood the language of the inhabitants of the
+moon pretty well. The Selenites* disputed variously about our earth,
+and expressed their doubts if it could be inhabited: the air, they said,
+must certainly be too dense to allow any rational dweller in the moon
+the necessary free respiration. They considered the moon alone to
+be inhabited: they imagined it was the real heart of the universe or
+planetary system, on which the genuine Cosmopolites, or citizens of the
+world, dwelt. What strange things men--no, what strange things Selenites
+sometimes take into their heads!
+
+* Dwellers in the moon.
+
+
+About politics they had a good deal to say. But little Denmark must
+take care what it is about, and not run counter to the moon; that
+great realm, that might in an ill-humor bestir itself, and dash down a
+hail-storm in our faces, or force the Baltic to overflow the sides of
+its gigantic basin.
+
+We will, therefore, not listen to what was spoken, and on no condition
+run in the possibility of telling tales out of school; but we will
+rather proceed, like good quiet citizens, to East Street, and observe
+what happened meanwhile to the body of the watchman.
+
+He sat lifeless on the steps: the morning-star,* that is to say, the
+heavy wooden staff, headed with iron spikes, and which had nothing else
+in common with its sparkling brother in the sky, had glided from his
+hand; while his eyes were fixed with glassy stare on the moon, looking
+for the good old fellow of a spirit which still haunted it.
+
+*The watchmen in Germany, had formerly, and in some places they still
+carry with them, on their rounds at night, a sort of mace or club, known
+in ancient times by the above denomination.
+
+
+“What’s the hour, watchman?” asked a passer-by. But when the watchman
+gave no reply, the merry roysterer, who was now returning home from a
+noisy drinking bout, took it into his head to try what a tweak of the
+nose would do, on which the supposed sleeper lost his balance, the body
+lay motionless, stretched out on the pavement: the man was dead. When
+the patrol came up, all his comrades, who comprehended nothing of the
+whole affair, were seized with a dreadful fright, for dead he was,
+and he remained so. The proper authorities were informed of the
+circumstance, people talked a good deal about it, and in the morning the
+body was carried to the hospital.
+
+Now that would be a very pretty joke, if the spirit when it came back
+and looked for the body in East Street, were not to find one. No doubt
+it would, in its anxiety, run off to the police, and then to the
+“Hue and Cry” office, to announce that “the finder will be handsomely
+rewarded,” and at last away to the hospital; yet we may boldly assert
+that the soul is shrewdest when it shakes off every fetter, and every
+sort of leading-string--the body only makes it stupid.
+
+The seemingly dead body of the watchman wandered, as we have said, to
+the hospital, where it was brought into the general viewing-room:
+and the first thing that was done here was naturally to pull off the
+galoshes--when the spirit, that was merely gone out on adventures, must
+have returned with the quickness of lightning to its earthly tenement.
+It took its direction towards the body in a straight line; and a few
+seconds after, life began to show itself in the man. He asserted that
+the preceding night had been the worst that ever the malice of fate had
+allotted him; he would not for two silver marks again go through what he
+had endured while moon-stricken; but now, however, it was over.
+
+The same day he was discharged from the hospital as perfectly cured; but
+the Shoes meanwhile remained behind.
+
+
+IV. A Moment of Head Importance--An Evening’s “Dramatic Readings”--A
+Most Strange Journey
+
+Every inhabitant of Copenhagen knows, from personal inspection, how
+the entrance to Frederick’s Hospital looks; but as it is possible that
+others, who are not Copenhagen people, may also read this little work,
+we will beforehand give a short description of it.
+
+The extensive building is separated from the street by a pretty high
+railing, the thick iron bars of which are so far apart, that in
+all seriousness, it is said, some very thin fellow had of a night
+occasionally squeezed himself through to go and pay his little visits
+in the town. The part of the body most difficult to manage on such
+occasions was, no doubt, the head; here, as is so often the case in
+the world, long-headed people get through best. So much, then, for the
+introduction.
+
+One of the young men, whose head, in a physical sense only, might be
+said to be of the thickest, had the watch that evening. The rain poured
+down in torrents; yet despite these two obstacles, the young man was
+obliged to go out, if it were but for a quarter of an hour; and as
+to telling the door-keeper about it, that, he thought, was quite
+unnecessary, if, with a whole skin, he were able to slip through the
+railings. There, on the floor lay the galoshes, which the watchman
+had forgotten; he never dreamed for a moment that they were those of
+Fortune; and they promised to do him good service in the wet; so he put
+them on. The question now was, if he could squeeze himself through the
+grating, for he had never tried before. Well, there he stood.
+
+“Would to Heaven I had got my head through!” said he, involuntarily; and
+instantly through it slipped, easily and without pain, notwithstanding
+it was pretty large and thick. But now the rest of the body was to be
+got through!
+
+“Ah! I am much too stout,” groaned he aloud, while fixed as in a vice.
+“I had thought the head was the most difficult part of the matter--oh!
+oh! I really cannot squeeze myself through!”
+
+He now wanted to pull his over-hasty head back again, but he could not.
+For his neck there was room enough, but for nothing more. His first
+feeling was of anger; his next that his temper fell to zero. The
+Shoes of Fortune had placed him in the most dreadful situation; and,
+unfortunately, it never occurred to him to wish himself free. The
+pitch-black clouds poured down their contents in still heavier torrents;
+not a creature was to be seen in the streets. To reach up to the bell
+was what he did not like; to cry aloud for help would have availed him
+little; besides, how ashamed would he have been to be found caught in a
+trap, like an outwitted fox! How was he to twist himself through! He saw
+clearly that it was his irrevocable destiny to remain a prisoner till
+dawn, or, perhaps, even late in the morning; then the smith must be
+fetched to file away the bars; but all that would not be done so quickly
+as he could think about it. The whole Charity School, just opposite,
+would be in motion; all the new booths, with their not very
+courtier-like swarm of seamen, would join them out of curiosity, and
+would greet him with a wild “hurrah!” while he was standing in his
+pillory: there would be a mob, a hissing, and rejoicing, and jeering,
+ten times worse than in the rows about the Jews some years ago--“Oh, my
+blood is mounting to my brain; ‘tis enough to drive one mad! I shall go
+wild! I know not what to do. Oh! were I but loose; my dizziness would
+then cease; oh, were my head but loose!”
+
+You see he ought to have said that sooner; for the moment he expressed
+the wish his head was free; and cured of all his paroxysms of love, he
+hastened off to his room, where the pains consequent on the fright the
+Shoes had prepared for him, did not so soon take their leave.
+
+But you must not think that the affair is over now; it grows much worse.
+
+The night passed, the next day also; but nobody came to fetch the Shoes.
+
+In the evening “Dramatic Readings” were to be given at the little
+theatre in King Street. The house was filled to suffocation; and among
+other pieces to be recited was a new poem by H. C. Andersen, called, My
+Aunt’s Spectacles; the contents of which were pretty nearly as follows:
+
+“A certain person had an aunt, who boasted of particular skill in
+fortune-telling with cards, and who was constantly being stormed by
+persons that wanted to have a peep into futurity. But she was full of
+mystery about her art, in which a certain pair of magic spectacles
+did her essential service. Her nephew, a merry boy, who was his aunt’s
+darling, begged so long for these spectacles, that, at last, she lent
+him the treasure, after having informed him, with many exhortations,
+that in order to execute the interesting trick, he need only repair to
+some place where a great many persons were assembled; and then, from a
+higher position, whence he could overlook the crowd, pass the company in
+review before him through his spectacles. Immediately ‘the inner man’ of
+each individual would be displayed before him, like a game of cards, in
+which he unerringly might read what the future of every person presented
+was to be. Well pleased the little magician hastened away to prove the
+powers of the spectacles in the theatre; no place seeming to him more
+fitted for such a trial. He begged permission of the worthy audience,
+and set his spectacles on his nose. A motley phantasmagoria presents
+itself before him, which he describes in a few satirical touches, yet
+without expressing his opinion openly: he tells the people enough to set
+them all thinking and guessing; but in order to hurt nobody, he wraps
+his witty oracular judgments in a transparent veil, or rather in a lurid
+thundercloud, shooting forth bright sparks of wit, that they may fall in
+the powder-magazine of the expectant audience.”
+
+The humorous poem was admirably recited, and the speaker much applauded.
+Among the audience was the young man of the hospital, who seemed to have
+forgotten his adventure of the preceding night. He had on the Shoes; for
+as yet no lawful owner had appeared to claim them; and besides it was so
+very dirty out-of-doors, they were just the thing for him, he thought.
+
+The beginning of the poem he praised with great generosity: he even
+found the idea original and effective. But that the end of it, like the
+Rhine, was very insignificant, proved, in his opinion, the author’s
+want of invention; he was without genius, etc. This was an excellent
+opportunity to have said something clever.
+
+Meanwhile he was haunted by the idea--he should like to possess such a
+pair of spectacles himself; then, perhaps, by using them circumspectly,
+one would be able to look into people’s hearts, which, he thought, would
+be far more interesting than merely to see what was to happen next year;
+for that we should all know in proper time, but the other never.
+
+“I can now,” said he to himself, “fancy the whole row of ladies and
+gentlemen sitting there in the front row; if one could but see into
+their hearts--yes, that would be a revelation--a sort of bazar. In that
+lady yonder, so strangely dressed, I should find for certain a large
+milliner’s shop; in that one the shop is empty, but it wants cleaning
+plain enough. But there would also be some good stately shops among
+them. Alas!” sighed he, “I know one in which all is stately; but there
+sits already a spruce young shopman, which is the only thing that’s
+amiss in the whole shop. All would be splendidly decked out, and we
+should hear, ‘Walk in, gentlemen, pray walk in; here you will find all
+you please to want.’ Ah! I wish to Heaven I could walk in and take a
+trip right through the hearts of those present!”
+
+And behold! to the Shoes of Fortune this was the cue; the whole man
+shrunk together and a most uncommon journey through the hearts of the
+front row of spectators, now began. The first heart through which he
+came, was that of a middle-aged lady, but he instantly fancied himself
+in the room of the “Institution for the cure of the crooked and
+deformed,” where casts of mis-shapen limbs are displayed in naked
+reality on the wall. Yet there was this difference, in the institution
+the casts were taken at the entry of the patient; but here they were
+retained and guarded in the heart while the sound persons went away.
+They were, namely, casts of female friends, whose bodily or mental
+deformities were here most faithfully preserved.
+
+With the snake-like writhings of an idea he glided into another female
+heart; but this seemed to him like a large holy fane. [*] The white dove of
+innocence fluttered over the altar. How gladly would he have sunk upon
+his knees; but he must away to the next heart; yet he still heard the
+pealing tones of the organ, and he himself seemed to have become a newer
+and a better man; he felt unworthy to tread the neighboring sanctuary
+which a poor garret, with a sick bed-rid mother, revealed. But God’s
+warm sun streamed through the open window; lovely roses nodded from
+the wooden flower-boxes on the roof, and two sky-blue birds sang
+rejoicingly, while the sick mother implored God’s richest blessings on
+her pious daughter.
+
+     * temple
+
+
+He now crept on hands and feet through a butcher’s shop; at least on
+every side, and above and below, there was nought but flesh. It was the
+heart of a most respectable rich man, whose name is certain to be found
+in the Directory.
+
+He was now in the heart of the wife of this worthy gentleman. It was an
+old, dilapidated, mouldering dovecot. The husband’s portrait was used as
+a weather-cock, which was connected in some way or other with the doors,
+and so they opened and shut of their own accord, whenever the stern old
+husband turned round.
+
+Hereupon he wandered into a boudoir formed entirely of mirrors, like
+the one in Castle Rosenburg; but here the glasses magnified to an
+astonishing degree. On the floor, in the middle of the room, sat, like a
+Dalai-Lama, the insignificant “Self” of the person, quite confounded at
+his own greatness. He then imagined he had got into a needle-case full
+of pointed needles of every size.
+
+“This is certainly the heart of an old maid,” thought he. But he was
+mistaken. It was the heart of a young military man; a man, as people
+said, of talent and feeling.
+
+In the greatest perplexity, he now came out of the last heart in the
+row; he was unable to put his thoughts in order, and fancied that his
+too lively imagination had run away with him.
+
+“Good Heavens!” sighed he. “I have surely a disposition to madness--‘tis
+dreadfully hot here; my blood boils in my veins and my head is burning
+like a coal.” And he now remembered the important event of the evening
+before, how his head had got jammed in between the iron railings of the
+hospital. “That’s what it is, no doubt,” said he. “I must do something
+in time: under such circumstances a Russian bath might do me good. I
+only wish I were already on the upper bank.” [*]
+
+     *In these Russian (vapor) baths the person extends himself
+     on a bank or form, and as he gets accustomed to the heat,
+     moves to another higher up towards the ceiling, where, of
+     course, the vapor is warmest. In this manner he ascends
+     gradually to the highest.
+
+And so there he lay on the uppermost bank in the vapor-bath; but with
+all his clothes on, in his boots and galoshes, while the hot drops fell
+scalding from the ceiling on his face.
+
+“Holloa!” cried he, leaping down. The bathing attendant, on his side,
+uttered a loud cry of astonishment when he beheld in the bath, a man
+completely dressed.
+
+The other, however, retained sufficient presence of mind to whisper to
+him, “‘Tis a bet, and I have won it!” But the first thing he did as soon
+as he got home, was to have a large blister put on his chest and back to
+draw out his madness.
+
+The next morning he had a sore chest and a bleeding back; and, excepting
+the fright, that was all that he had gained by the Shoes of Fortune.
+
+
+V. Metamorphosis of the Copying-Clerk
+
+The watchman, whom we have certainly not forgotten, thought meanwhile
+of the galoshes he had found and taken with him to the hospital; he now
+went to fetch them; and as neither the lieutenant, nor anybody else in
+the street, claimed them as his property, they were delivered over to
+the police-office.*
+
+*As on the continent, in all law and police practices nothing is verbal,
+but any circumstance, however trifling, is reduced to writing, the
+labor, as well as the number of papers that thus accumulate, is
+enormous. In a police-office, consequently, we find copying-clerks among
+many other scribes of various denominations, of which, it seems, our
+hero was one.
+
+
+“Why, I declare the Shoes look just like my own,” said one of the
+clerks, eying the newly-found treasure, whose hidden powers, even he,
+sharp as he was, was not able to discover. “One must have more than
+the eye of a shoemaker to know one pair from the other,” said he,
+soliloquizing; and putting, at the same time, the galoshes in search of
+an owner, beside his own in the corner.
+
+“Here, sir!” said one of the men, who panting brought him a tremendous
+pile of papers.
+
+The copying-clerk turned round and spoke awhile with the man about the
+reports and legal documents in question; but when he had finished, and
+his eye fell again on the Shoes, he was unable to say whether those to
+the left or those to the right belonged to him. “At all events it must
+be those which are wet,” thought he; but this time, in spite of his
+cleverness, he guessed quite wrong, for it was just those of Fortune
+which played as it were into his hands, or rather on his feet. And why,
+I should like to know, are the police never to be wrong? So he put them
+on quickly, stuck his papers in his pocket, and took besides a few under
+his arm, intending to look them through at home to make the necessary
+notes. It was noon; and the weather, that had threatened rain, began
+to clear up, while gaily dressed holiday folks filled the streets. “A
+little trip to Fredericksburg would do me no great harm,” thought he;
+“for I, poor beast of burden that I am, have so much to annoy me, that I
+don’t know what a good appetite is. ‘Tis a bitter crust, alas! at which
+I am condemned to gnaw!”
+
+Nobody could be more steady or quiet than this young man; we therefore
+wish him joy of the excursion with all our heart; and it will certainly
+be beneficial for a person who leads so sedentary a life. In the park
+he met a friend, one of our young poets, who told him that the following
+day he should set out on his long-intended tour.
+
+“So you are going away again!” said the clerk. “You are a very free
+and happy being; we others are chained by the leg and held fast to our
+desk.”
+
+“Yes; but it is a chain, friend, which ensures you the blessed bread
+of existence,” answered the poet. “You need feel no care for the coming
+morrow: when you are old, you receive a pension.”
+
+“True,” said the clerk, shrugging his shoulders; “and yet you are
+the better off. To sit at one’s ease and poetise--that is a pleasure;
+everybody has something agreeable to say to you, and you are always your
+own master. No, friend, you should but try what it is to sit from one
+year’s end to the other occupied with and judging the most trivial
+matters.”
+
+The poet shook his head, the copying-clerk did the same. Each one kept
+to his own opinion, and so they separated.
+
+“It’s a strange race, those poets!” said the clerk, who was very fond of
+soliloquizing. “I should like some day, just for a trial, to take such
+nature upon me, and be a poet myself; I am very sure I should make
+no such miserable verses as the others. Today, methinks, is a most
+delicious day for a poet. Nature seems anew to celebrate her awakening
+into life. The air is so unusually clear, the clouds sail on so
+buoyantly, and from the green herbage a fragrance is exhaled that fills
+me with delight. For many a year have I not felt as at this moment.”
+
+We see already, by the foregoing effusion, that he is become a poet; to
+give further proof of it, however, would in most cases be insipid, for
+it is a most foolish notion to fancy a poet different from other men.
+Among the latter there may be far more poetical natures than many an
+acknowledged poet, when examined more closely, could boast of; the
+difference only is, that the poet possesses a better mental memory, on
+which account he is able to retain the feeling and the thought till they
+can be embodied by means of words; a faculty which the others do not
+possess. But the transition from a commonplace nature to one that is
+richly endowed, demands always a more or less breakneck leap over a
+certain abyss which yawns threateningly below; and thus must the sudden
+change with the clerk strike the reader.
+
+“The sweet air!” continued he of the police-office, in his dreamy
+imaginings; “how it reminds me of the violets in the garden of my aunt
+Magdalena! Yes, then I was a little wild boy, who did not go to school
+very regularly. O heavens! ‘tis a long time since I have thought on
+those times. The good old soul! She lived behind the Exchange. She
+always had a few twigs or green shoots in water--let the winter rage
+without as it might. The violets exhaled their sweet breath, whilst I
+pressed against the windowpanes covered with fantastic frost-work the
+copper coin I had heated on the stove, and so made peep-holes.
+What splendid vistas were then opened to my view! What change--what
+magnificence! Yonder in the canal lay the ships frozen up, and deserted
+by their whole crews, with a screaming crow for the sole occupant. But
+when the spring, with a gentle stirring motion, announced her arrival,
+a new and busy life arose; with songs and hurrahs the ice was sawn
+asunder, the ships were fresh tarred and rigged, that they might sail
+away to distant lands. But I have remained here--must always remain
+here, sitting at my desk in the office, and patiently see other people
+fetch their passports to go abroad. Such is my fate! Alas!”--sighed he,
+and was again silent. “Great Heaven! What is come to me! Never have I
+thought or felt like this before! It must be the summer air that affects
+me with feelings almost as disquieting as they are refreshing.”
+
+He felt in his pocket for the papers. “These police-reports will soon
+stem the torrent of my ideas, and effectually hinder any rebellious
+overflowing of the time-worn banks of official duties”; he said to
+himself consolingly, while his eye ran over the first page. “DAME
+TIGBRITH, tragedy in five acts.” “What is that? And yet it is undeniably
+my own handwriting. Have I written the tragedy? Wonderful, very
+wonderful!--And this--what have I here? ‘INTRIGUE ON THE RAMPARTS; or
+THE DAY OF REPENTANCE: vaudeville with new songs to the most favorite
+airs.’ The deuce! Where did I get all this rubbish? Some one must have
+slipped it slyly into my pocket for a joke. There is too a letter to me;
+a crumpled letter and the seal broken.”
+
+Yes; it was not a very polite epistle from the manager of a theatre, in
+which both pieces were flatly refused.
+
+“Hem! hem!” said the clerk breathlessly, and quite exhausted he seated
+himself on a bank. His thoughts were so elastic, his heart so tender;
+and involuntarily he picked one of the nearest flowers. It is a simple
+daisy, just bursting out of the bud. What the botanist tells us after
+a number of imperfect lectures, the flower proclaimed in a minute. It
+related the mythus of its birth, told of the power of the sun-light that
+spread out its delicate leaves, and forced them to impregnate the air
+with their incense--and then he thought of the manifold struggles of
+life, which in like manner awaken the budding flowers of feeling in our
+bosom. Light and air contend with chivalric emulation for the love of
+the fair flower that bestowed her chief favors on the latter; full of
+longing she turned towards the light, and as soon as it vanished, rolled
+her tender leaves together and slept in the embraces of the air. “It is
+the light which adorns me,” said the flower.
+
+“But ‘tis the air which enables thee to breathe,” said the poet’s voice.
+
+Close by stood a boy who dashed his stick into a wet ditch. The drops of
+water splashed up to the green leafy roof, and the clerk thought of the
+million of ephemera which in a single drop were thrown up to a height,
+that was as great doubtless for their size, as for us if we were to
+be hurled above the clouds. While he thought of this and of the whole
+metamorphosis he had undergone, he smiled and said, “I sleep and dream;
+but it is wonderful how one can dream so naturally, and know besides so
+exactly that it is but a dream. If only to-morrow on awaking, I could
+again call all to mind so vividly! I seem in unusually good spirits; my
+perception of things is clear, I feel as light and cheerful as though
+I were in heaven; but I know for a certainty, that if to-morrow a dim
+remembrance of it should swim before my mind, it will then seem nothing
+but stupid nonsense, as I have often experienced already--especially
+before I enlisted under the banner of the police, for that dispels like
+a whirlwind all the visions of an unfettered imagination. All we hear
+or say in a dream that is fair and beautiful is like the gold of the
+subterranean spirits; it is rich and splendid when it is given us, but
+viewed by daylight we find only withered leaves. Alas!” he sighed quite
+sorrowful, and gazed at the chirping birds that hopped contentedly from
+branch to branch, “they are much better off than I! To fly must be a
+heavenly art; and happy do I prize that creature in which it is innate.
+Yes! Could I exchange my nature with any other creature, I fain would be
+such a happy little lark!”
+
+He had hardly uttered these hasty words when the skirts and sleeves
+of his coat folded themselves together into wings; the clothes became
+feathers, and the galoshes claws. He observed it perfectly, and laughed
+in his heart. “Now then, there is no doubt that I am dreaming; but I
+never before was aware of such mad freaks as these.” And up he flew into
+the green roof and sang; but in the song there was no poetry, for the
+spirit of the poet was gone. The Shoes, as is the case with anybody who
+does what he has to do properly, could only attend to one thing at a
+time. He wanted to be a poet, and he was one; he now wished to be a
+merry chirping bird: but when he was metamorphosed into one, the former
+peculiarities ceased immediately. “It is really pleasant enough,” said
+he: “the whole day long I sit in the office amid the driest
+law-papers, and at night I fly in my dream as a lark in the gardens of
+Fredericksburg; one might really write a very pretty comedy upon it.” He
+now fluttered down into the grass, turned his head gracefully on every
+side, and with his bill pecked the pliant blades of grass, which, in
+comparison to his present size, seemed as majestic as the palm-branches
+of northern Africa.
+
+Unfortunately the pleasure lasted but a moment. Presently black night
+overshadowed our enthusiast, who had so entirely missed his part of
+copying-clerk at a police-office; some vast object seemed to be thrown
+over him. It was a large oil-skin cap, which a sailor-boy of the quay
+had thrown over the struggling bird; a coarse hand sought its way
+carefully in under the broad rim, and seized the clerk over the back
+and wings. In the first moment of fear, he called, indeed, as loud as
+he could--“You impudent little blackguard! I am a copying-clerk at
+the police-office; and you know you cannot insult any belonging to the
+constabulary force without a chastisement. Besides, you good-for-nothing
+rascal, it is strictly forbidden to catch birds in the royal gardens of
+Fredericksburg; but your blue uniform betrays where you come from.”
+ This fine tirade sounded, however, to the ungodly sailor-boy like a mere
+“Pippi-pi.” He gave the noisy bird a knock on his beak, and walked on.
+
+He was soon met by two schoolboys of the upper class--that is to say as
+individuals, for with regard to learning they were in the lowest class
+in the school; and they bought the stupid bird. So the copying-clerk
+came to Copenhagen as guest, or rather as prisoner in a family living in
+Gother Street.
+
+“‘Tis well that I’m dreaming,” said the clerk, “or I really should get
+angry. First I was a poet; now sold for a few pence as a lark; no doubt
+it was that accursed poetical nature which has metamorphosed me
+into such a poor harmless little creature. It is really pitiable,
+particularly when one gets into the hands of a little blackguard,
+perfect in all sorts of cruelty to animals: all I should like to know
+is, how the story will end.”
+
+The two schoolboys, the proprietors now of the transformed clerk,
+carried him into an elegant room. A stout stately dame received them
+with a smile; but she expressed much dissatisfaction that a common
+field-bird, as she called the lark, should appear in such high society.
+For to-day, however, she would allow it; and they must shut him in the
+empty cage that was standing in the window. “Perhaps he will amuse my
+good Polly,” added the lady, looking with a benignant smile at a large
+green parrot that swung himself backwards and forwards most comfortably
+in his ring, inside a magnificent brass-wired cage. “To-day is Polly’s
+birthday,” said she with stupid simplicity: “and the little brown
+field-bird must wish him joy.”
+
+Mr. Polly uttered not a syllable in reply, but swung to and fro with
+dignified condescension; while a pretty canary, as yellow as gold, that
+had lately been brought from his sunny fragrant home, began to sing
+aloud.
+
+“Noisy creature! Will you be quiet!” screamed the lady of the house,
+covering the cage with an embroidered white pocket handkerchief.
+
+“Chirp, chirp!” sighed he. “That was a dreadful snowstorm”; and he
+sighed again, and was silent.
+
+The copying-clerk, or, as the lady said, the brown field-bird, was
+put into a small cage, close to the Canary, and not far from “my good
+Polly.” The only human sounds that the Parrot could bawl out
+were, “Come, let us be men!” Everything else that he said was as
+unintelligible to everybody as the chirping of the Canary, except to the
+clerk, who was now a bird too: he understood his companion perfectly.
+
+“I flew about beneath the green palms and the blossoming almond-trees,”
+ sang the Canary; “I flew around, with my brothers and sisters, over
+the beautiful flowers, and over the glassy lakes, where the bright
+water-plants nodded to me from below. There, too, I saw many
+splendidly-dressed paroquets, that told the drollest stories, and the
+wildest fairy tales without end.”
+
+“Oh! those were uncouth birds,” answered the Parrot. “They had no
+education, and talked of whatever came into their head.
+
+“If my mistress and all her friends can laugh at what I say, so may you
+too, I should think. It is a great fault to have no taste for what is
+witty or amusing--come, let us be men.”
+
+“Ah, you have no remembrance of love for the charming maidens that
+danced beneath the outspread tents beside the bright fragrant flowers?
+Do you no longer remember the sweet fruits, and the cooling juice in
+the wild plants of our never-to-be-forgotten home?” said the former
+inhabitant of the Canary Isles, continuing his dithyrambic.
+
+“Oh, yes,” said the Parrot; “but I am far better off here. I am well
+fed, and get friendly treatment. I know I am a clever fellow; and that
+is all I care about. Come, let us be men. You are of a poetical nature,
+as it is called--I, on the contrary, possess profound knowledge and
+inexhaustible wit. You have genius; but clear-sighted, calm discretion
+does not take such lofty flights, and utter such high natural tones.
+For this they have covered you over--they never do the like to me; for
+I cost more. Besides, they are afraid of my beak; and I have always a
+witty answer at hand. Come, let us be men!”
+
+“O warm spicy land of my birth,” sang the Canary bird; “I will sing of
+thy dark-green bowers, of the calm bays where the pendent boughs
+kiss the surface of the water; I will sing of the rejoicing of all my
+brothers and sisters where the cactus grows in wanton luxuriance.”
+
+“Spare us your elegiac tones,” said the Parrot giggling. “Rather speak
+of something at which one may laugh heartily. Laughing is an infallible
+sign of the highest degree of mental development. Can a dog, or a horse
+laugh? No, but they can cry. The gift of laughing was given to man
+alone. Ha! ha! ha!” screamed Polly, and added his stereotype witticism.
+“Come, let us be men!”
+
+“Poor little Danish grey-bird,” said the Canary; “you have been caught
+too. It is, no doubt, cold enough in your woods, but there at least
+is the breath of liberty; therefore fly away. In the hurry they have
+forgotten to shut your cage, and the upper window is open. Fly, my
+friend; fly away. Farewell!”
+
+Instinctively the Clerk obeyed; with a few strokes of his wings he was
+out of the cage; but at the same moment the door, which was only ajar,
+and which led to the next room, began to creak, and supple and creeping
+came the large tomcat into the room, and began to pursue him. The
+frightened Canary fluttered about in his cage; the Parrot flapped his
+wings, and cried, “Come, let us be men!” The Clerk felt a mortal fright,
+and flew through the window, far away over the houses and streets. At
+last he was forced to rest a little.
+
+The neighboring house had a something familiar about it; a window stood
+open; he flew in; it was his own room. He perched upon the table.
+
+“Come, let us be men!” said he, involuntarily imitating the chatter of
+the Parrot, and at the same moment he was again a copying-clerk; but he
+was sitting in the middle of the table.
+
+“Heaven help me!” cried he. “How did I get up here--and so buried in
+sleep, too? After all, that was a very unpleasant, disagreeable dream
+that haunted me! The whole story is nothing but silly, stupid nonsense!”
+
+
+VI. The Best That the Galoshes Gave
+
+The following day, early in the morning, while the Clerk was still in
+bed, someone knocked at his door. It was his neighbor, a young Divine,
+who lived on the same floor. He walked in.
+
+“Lend me your Galoshes,” said he; “it is so wet in the garden, though
+the sun is shining most invitingly. I should like to go out a little.”
+
+He got the Galoshes, and he was soon below in a little duodecimo garden,
+where between two immense walls a plumtree and an apple-tree were
+standing. Even such a little garden as this was considered in the
+metropolis of Copenhagen as a great luxury.
+
+The young man wandered up and down the narrow paths, as well as the
+prescribed limits would allow; the clock struck six; without was heard
+the horn of a post-boy.
+
+“To travel! to travel!” exclaimed he, overcome by most painful and
+passionate remembrances. “That is the happiest thing in the world! That
+is the highest aim of all my wishes! Then at last would the agonizing
+restlessness be allayed, which destroys my existence! But it must be
+far, far away! I would behold magnificent Switzerland; I would travel to
+Italy, and--”
+
+It was a good thing that the power of the Galoshes worked as
+instantaneously as lightning in a powder-magazine would do, otherwise
+the poor man with his overstrained wishes would have travelled about
+the world too much for himself as well as for us. In short, he was
+travelling. He was in the middle of Switzerland, but packed up with
+eight other passengers in the inside of an eternally-creaking diligence;
+his head ached till it almost split, his weary neck could hardly bear
+the heavy load, and his feet, pinched by his torturing boots, were
+terribly swollen. He was in an intermediate state between sleeping and
+waking; at variance with himself, with his company, with the country,
+and with the government. In his right pocket he had his letter of
+credit, in the left, his passport, and in a small leathern purse some
+double louis d’or, carefully sewn up in the bosom of his waistcoat.
+Every dream proclaimed that one or the other of these valuables was
+lost; wherefore he started up as in a fever; and the first movement
+which his hand made, described a magic triangle from the right pocket to
+the left, and then up towards the bosom, to feel if he had them all safe
+or not. From the roof inside the carriage, umbrellas, walking-sticks,
+hats, and sundry other articles were depending, and hindered the view,
+which was particularly imposing. He now endeavored as well as he
+was able to dispel his gloom, which was caused by outward chance
+circumstances merely, and on the bosom of nature imbibe the milk of
+purest human enjoyment.
+
+Grand, solemn, and dark was the whole landscape around. The gigantic
+pine-forests, on the pointed crags, seemed almost like little tufts of
+heather, colored by the surrounding clouds. It began to snow, a cold
+wind blew and roared as though it were seeking a bride.
+
+“Augh!” sighed he, “were we only on the other side the Alps, then we
+should have summer, and I could get my letters of credit cashed. The
+anxiety I feel about them prevents me enjoying Switzerland. Were I but
+on the other side!”
+
+And so saying he was on the other side in Italy, between Florence and
+Rome. Lake Thracymene, illumined by the evening sun, lay like flaming
+gold between the dark-blue mountain-ridges; here, where Hannibal
+defeated Flaminius, the rivers now held each other in their green
+embraces; lovely, half-naked children tended a herd of black swine,
+beneath a group of fragrant laurel-trees, hard by the road-side.
+Could we render this inimitable picture properly, then would everybody
+exclaim, “Beautiful, unparalleled Italy!” But neither the young Divine
+said so, nor anyone of his grumbling companions in the coach of the
+vetturino.
+
+The poisonous flies and gnats swarmed around by thousands; in vain one
+waved myrtle-branches about like mad; the audacious insect population
+did not cease to sting; nor was there a single person in the
+well-crammed carriage whose face was not swollen and sore from their
+ravenous bites. The poor horses, tortured almost to death, suffered most
+from this truly Egyptian plague; the flies alighted upon them in large
+disgusting swarms; and if the coachman got down and scraped them off,
+hardly a minute elapsed before they were there again. The sun now set: a
+freezing cold, though of short duration pervaded the whole creation;
+it was like a horrid gust coming from a burial-vault on a warm summer’s
+day--but all around the mountains retained that wonderful green tone
+which we see in some old pictures, and which, should we not have seen a
+similar play of color in the South, we declare at once to be unnatural.
+It was a glorious prospect; but the stomach was empty, the body tired;
+all that the heart cared and longed for was good night-quarters; yet
+how would they be? For these one looked much more anxiously than for the
+charms of nature, which every where were so profusely displayed.
+
+The road led through an olive-grove, and here the solitary inn was
+situated. Ten or twelve crippled-beggars had encamped outside. The
+healthiest of them resembled, to use an expression of Marryat’s,
+“Hunger’s eldest son when he had come of age”; the others were either
+blind, had withered legs and crept about on their hands, or withered
+arms and fingerless hands. It was the most wretched misery, dragged
+from among the filthiest rags. “Excellenza, miserabili!” sighed they,
+thrusting forth their deformed limbs to view. Even the hostess, with
+bare feet, uncombed hair, and dressed in a garment of doubtful color,
+received the guests grumblingly. The doors were fastened with a loop of
+string; the floor of the rooms presented a stone paving half torn
+up; bats fluttered wildly about the ceiling; and as to the smell
+therein--no--that was beyond description.
+
+“You had better lay the cloth below in the stable,” said one of the
+travellers; “there, at all events, one knows what one is breathing.”
+
+The windows were quickly opened, to let in a little fresh air. Quicker,
+however, than the breeze, the withered, sallow arms of the beggars were
+thrust in, accompanied by the eternal whine of “Miserabili, miserabili,
+excellenza!” On the walls were displayed innumerable inscriptions,
+written in nearly every language of Europe, some in verse, some in
+prose, most of them not very laudatory of “bella Italia.”
+
+The meal was served. It consisted of a soup of salted water, seasoned
+with pepper and rancid oil. The last ingredient played a very prominent
+part in the salad; stale eggs and roasted cocks’-combs furnished the
+grand dish of the repast; the wine even was not without a disgusting
+taste--it was like a medicinal draught.
+
+At night the boxes and other effects of the passengers were placed
+against the rickety doors. One of the travellers kept watch while the
+others slept. The sentry was our young Divine. How close it was in the
+chamber! The heat oppressive to suffocation--the gnats hummed and stung
+unceasingly--the “miserabili” without whined and moaned in their sleep.
+
+“Travelling would be agreeable enough,” said he groaning, “if one only
+had no body, or could send it to rest while the spirit went on its
+pilgrimage unhindered, whither the voice within might call it. Wherever
+I go, I am pursued by a longing that is insatiable--that I cannot
+explain to myself, and that tears my very heart. I want something better
+than what is but what is fled in an instant. But what is it, and where
+is it to be found? Yet, I know in reality what it is I wish for. Oh!
+most happy were I, could I but reach one aim--could but reach the
+happiest of all!”
+
+And as he spoke the word he was again in his home; the long white
+curtains hung down from the windows, and in the middle of the floor
+stood the black coffin; in it he lay in the sleep of death. His wish
+was fulfilled--the body rested, while the spirit went unhindered on its
+pilgrimage. “Let no one deem himself happy before his end,” were the
+words of Solon; and here was a new and brilliant proof of the wisdom of
+the old apothegm.
+
+Every corpse is a sphynx of immortality; here too on the black coffin
+the sphynx gave us no answer to what he who lay within had written two
+days before:
+
+     “O mighty Death! thy silence teaches nought,
+       Thou leadest only to the near grave’s brink;
+      Is broken now the ladder of my thoughts?
+     Do I instead of mounting only sink?
+
+     Our heaviest grief the world oft seeth not,
+      Our sorest pain we hide from stranger eyes:
+      And for the sufferer there is nothing left
+     But the green mound that o’er the coffin lies.”
+
+Two figures were moving in the chamber. We knew them both; it was the
+fairy of Care, and the emissary of Fortune. They both bent over the
+corpse.
+
+“Do you now see,” said Care, “what happiness your Galoshes have brought
+to mankind?”
+
+“To him, at least, who slumbers here, they have brought an imperishable
+blessing,” answered the other.
+
+“Ah no!” replied Care. “He took his departure himself; he was not called
+away. His mental powers here below were not strong enough to reach the
+treasures lying beyond this life, and which his destiny ordained he
+should obtain. I will now confer a benefit on him.”
+
+And she took the Galoshes from his feet; his sleep of death was ended;
+and he who had been thus called back again to life arose from his
+dread couch in all the vigor of youth. Care vanished, and with her the
+Galoshes. She has no doubt taken them for herself, to keep them to all
+eternity.
+
+
+
+
+THE FIR TREE
+
+Out in the woods stood a nice little Fir Tree. The place he had was a
+very good one: the sun shone on him: as to fresh air, there was enough
+of that, and round him grew many large-sized comrades, pines as well as
+firs. But the little Fir wanted so very much to be a grown-up tree.
+
+He did not think of the warm sun and of the fresh air; he did not care
+for the little cottage children that ran about and prattled when they
+were in the woods looking for wild-strawberries. The children often came
+with a whole pitcher full of berries, or a long row of them threaded on
+a straw, and sat down near the young tree and said, “Oh, how pretty he
+is! What a nice little fir!” But this was what the Tree could not bear
+to hear.
+
+At the end of a year he had shot up a good deal, and after another year
+he was another long bit taller; for with fir trees one can always tell
+by the shoots how many years old they are.
+
+“Oh! Were I but such a high tree as the others are,” sighed he. “Then I
+should be able to spread out my branches, and with the tops to look into
+the wide world! Then would the birds build nests among my branches: and
+when there was a breeze, I could bend with as much stateliness as the
+others!”
+
+Neither the sunbeams, nor the birds, nor the red clouds which morning
+and evening sailed above him, gave the little Tree any pleasure.
+
+In winter, when the snow lay glittering on the ground, a hare would
+often come leaping along, and jump right over the little Tree. Oh, that
+made him so angry! But two winters were past, and in the third the Tree
+was so large that the hare was obliged to go round it. “To grow and
+grow, to get older and be tall,” thought the Tree--“that, after all, is
+the most delightful thing in the world!”
+
+In autumn the wood-cutters always came and felled some of the largest
+trees. This happened every year; and the young Fir Tree, that had now
+grown to a very comely size, trembled at the sight; for the magnificent
+great trees fell to the earth with noise and cracking, the branches were
+lopped off, and the trees looked long and bare; they were hardly to be
+recognised; and then they were laid in carts, and the horses dragged
+them out of the wood.
+
+Where did they go to? What became of them?
+
+In spring, when the swallows and the storks came, the Tree asked them,
+“Don’t you know where they have been taken? Have you not met them
+anywhere?”
+
+The swallows did not know anything about it; but the Stork looked
+musing, nodded his head, and said, “Yes; I think I know; I met many
+ships as I was flying hither from Egypt; on the ships were magnificent
+masts, and I venture to assert that it was they that smelt so of fir.
+I may congratulate you, for they lifted themselves on high most
+majestically!”
+
+“Oh, were I but old enough to fly across the sea! But how does the sea
+look in reality? What is it like?”
+
+“That would take a long time to explain,” said the Stork, and with these
+words off he went.
+
+“Rejoice in thy growth!” said the Sunbeams. “Rejoice in thy vigorous
+growth, and in the fresh life that moveth within thee!”
+
+And the Wind kissed the Tree, and the Dew wept tears over him; but the
+Fir understood it not.
+
+When Christmas came, quite young trees were cut down: trees which often
+were not even as large or of the same age as this Fir Tree, who could
+never rest, but always wanted to be off. These young trees, and they
+were always the finest looking, retained their branches; they were laid
+on carts, and the horses drew them out of the wood.
+
+“Where are they going to?” asked the Fir. “They are not taller than
+I; there was one indeed that was considerably shorter; and why do they
+retain all their branches? Whither are they taken?”
+
+“We know! We know!” chirped the Sparrows. “We have peeped in at the
+windows in the town below! We know whither they are taken! The greatest
+splendor and the greatest magnificence one can imagine await them. We
+peeped through the windows, and saw them planted in the middle of the
+warm room and ornamented with the most splendid things, with gilded
+apples, with gingerbread, with toys, and many hundred lights!”
+
+“And then?” asked the Fir Tree, trembling in every bough. “And then?
+What happens then?”
+
+“We did not see anything more: it was incomparably beautiful.”
+
+“I would fain know if I am destined for so glorious a career,” cried
+the Tree, rejoicing. “That is still better than to cross the sea! What
+a longing do I suffer! Were Christmas but come! I am now tall, and my
+branches spread like the others that were carried off last year! Oh!
+were I but already on the cart! Were I in the warm room with all the
+splendor and magnificence! Yes; then something better, something still
+grander, will surely follow, or wherefore should they thus ornament me?
+Something better, something still grander must follow--but what? Oh, how
+I long, how I suffer! I do not know myself what is the matter with me!”
+
+“Rejoice in our presence!” said the Air and the Sunlight. “Rejoice in
+thy own fresh youth!”
+
+But the Tree did not rejoice at all; he grew and grew, and was green
+both winter and summer. People that saw him said, “What a fine tree!”
+ and towards Christmas he was one of the first that was cut down. The axe
+struck deep into the very pith; the Tree fell to the earth with a sigh;
+he felt a pang--it was like a swoon; he could not think of happiness,
+for he was sorrowful at being separated from his home, from the place
+where he had sprung up. He well knew that he should never see his dear
+old comrades, the little bushes and flowers around him, anymore; perhaps
+not even the birds! The departure was not at all agreeable.
+
+The Tree only came to himself when he was unloaded in a court-yard with
+the other trees, and heard a man say, “That one is splendid! We don’t
+want the others.” Then two servants came in rich livery and carried the
+Fir Tree into a large and splendid drawing-room. Portraits were hanging
+on the walls, and near the white porcelain stove stood two large Chinese
+vases with lions on the covers. There, too, were large easy-chairs,
+silken sofas, large tables full of picture-books and full of toys, worth
+hundreds and hundreds of crowns--at least the children said so. And the
+Fir Tree was stuck upright in a cask that was filled with sand; but no
+one could see that it was a cask, for green cloth was hung all round it,
+and it stood on a large gaily-colored carpet. Oh! how the Tree quivered!
+What was to happen? The servants, as well as the young ladies, decorated
+it. On one branch there hung little nets cut out of colored paper, and
+each net was filled with sugarplums; and among the other boughs gilded
+apples and walnuts were suspended, looking as though they had grown
+there, and little blue and white tapers were placed among the leaves.
+Dolls that looked for all the world like men--the Tree had never beheld
+such before--were seen among the foliage, and at the very top a
+large star of gold tinsel was fixed. It was really splendid--beyond
+description splendid.
+
+“This evening!” they all said. “How it will shine this evening!”
+
+“Oh!” thought the Tree. “If the evening were but come! If the tapers
+were but lighted! And then I wonder what will happen! Perhaps the other
+trees from the forest will come to look at me! Perhaps the sparrows will
+beat against the windowpanes! I wonder if I shall take root here, and
+winter and summer stand covered with ornaments!”
+
+He knew very much about the matter--but he was so impatient that for
+sheer longing he got a pain in his back, and this with trees is the same
+thing as a headache with us.
+
+The candles were now lighted--what brightness! What splendor! The
+Tree trembled so in every bough that one of the tapers set fire to the
+foliage. It blazed up famously.
+
+“Help! Help!” cried the young ladies, and they quickly put out the fire.
+
+Now the Tree did not even dare tremble. What a state he was in! He was
+so uneasy lest he should lose something of his splendor, that he was
+quite bewildered amidst the glare and brightness; when suddenly both
+folding-doors opened and a troop of children rushed in as if they would
+upset the Tree. The older persons followed quietly; the little ones
+stood quite still. But it was only for a moment; then they shouted that
+the whole place re-echoed with their rejoicing; they danced round the
+Tree, and one present after the other was pulled off.
+
+“What are they about?” thought the Tree. “What is to happen now!” And
+the lights burned down to the very branches, and as they burned down
+they were put out one after the other, and then the children had
+permission to plunder the Tree. So they fell upon it with such violence
+that all its branches cracked; if it had not been fixed firmly in the
+ground, it would certainly have tumbled down.
+
+The children danced about with their beautiful playthings; no one looked
+at the Tree except the old nurse, who peeped between the branches; but
+it was only to see if there was a fig or an apple left that had been
+forgotten.
+
+“A story! A story!” cried the children, drawing a little fat man towards
+the Tree. He seated himself under it and said, “Now we are in the shade,
+and the Tree can listen too. But I shall tell only one story. Now which
+will you have; that about Ivedy-Avedy, or about Humpy-Dumpy, who
+tumbled downstairs, and yet after all came to the throne and married the
+princess?”
+
+“Ivedy-Avedy,” cried some; “Humpy-Dumpy,” cried the others. There was
+such a bawling and screaming--the Fir Tree alone was silent, and he
+thought to himself, “Am I not to bawl with the rest? Am I to do nothing
+whatever?” for he was one of the company, and had done what he had to
+do.
+
+And the man told about Humpy-Dumpy that tumbled down, who
+notwithstanding came to the throne, and at last married the princess.
+And the children clapped their hands, and cried. “Oh, go on! Do go on!”
+ They wanted to hear about Ivedy-Avedy too, but the little man only told
+them about Humpy-Dumpy. The Fir Tree stood quite still and absorbed
+in thought; the birds in the wood had never related the like of this.
+“Humpy-Dumpy fell downstairs, and yet he married the princess! Yes, yes!
+That’s the way of the world!” thought the Fir Tree, and believed it all,
+because the man who told the story was so good-looking. “Well, well! who
+knows, perhaps I may fall downstairs, too, and get a princess as wife!”
+ And he looked forward with joy to the morrow, when he hoped to be decked
+out again with lights, playthings, fruits, and tinsel.
+
+“I won’t tremble to-morrow!” thought the Fir Tree. “I will enjoy to
+the full all my splendor! To-morrow I shall hear again the story of
+Humpy-Dumpy, and perhaps that of Ivedy-Avedy too.” And the whole night
+the Tree stood still and in deep thought.
+
+In the morning the servant and the housemaid came in.
+
+“Now then the splendor will begin again,” thought the Fir. But they
+dragged him out of the room, and up the stairs into the loft: and here,
+in a dark corner, where no daylight could enter, they left him. “What’s
+the meaning of this?” thought the Tree. “What am I to do here? What
+shall I hear now, I wonder?” And he leaned against the wall lost in
+reverie. Time enough had he too for his reflections; for days and nights
+passed on, and nobody came up; and when at last somebody did come, it
+was only to put some great trunks in a corner, out of the way. There
+stood the Tree quite hidden; it seemed as if he had been entirely
+forgotten.
+
+“‘Tis now winter out-of-doors!” thought the Tree. “The earth is hard and
+covered with snow; men cannot plant me now, and therefore I have been
+put up here under shelter till the spring-time comes! How thoughtful
+that is! How kind man is, after all! If it only were not so dark here,
+and so terribly lonely! Not even a hare! And out in the woods it was
+so pleasant, when the snow was on the ground, and the hare leaped by;
+yes--even when he jumped over me; but I did not like it then! It is
+really terribly lonely here!”
+
+“Squeak! Squeak!” said a little Mouse, at the same moment, peeping out
+of his hole. And then another little one came. They snuffed about the
+Fir Tree, and rustled among the branches.
+
+“It is dreadfully cold,” said the Mouse. “But for that, it would be
+delightful here, old Fir, wouldn’t it?”
+
+“I am by no means old,” said the Fir Tree. “There’s many a one
+considerably older than I am.”
+
+“Where do you come from,” asked the Mice; “and what can you do?” They
+were so extremely curious. “Tell us about the most beautiful spot on the
+earth. Have you never been there? Were you never in the larder, where
+cheeses lie on the shelves, and hams hang from above; where one dances
+about on tallow candles: that place where one enters lean, and comes out
+again fat and portly?”
+
+“I know no such place,” said the Tree. “But I know the wood, where the
+sun shines and where the little birds sing.” And then he told all about
+his youth; and the little Mice had never heard the like before; and they
+listened and said,
+
+“Well, to be sure! How much you have seen! How happy you must have
+been!”
+
+“I!” said the Fir Tree, thinking over what he had himself related.
+“Yes, in reality those were happy times.” And then he told about
+Christmas-eve, when he was decked out with cakes and candles.
+
+“Oh,” said the little Mice, “how fortunate you have been, old Fir Tree!”
+
+“I am by no means old,” said he. “I came from the wood this winter; I am
+in my prime, and am only rather short for my age.”
+
+“What delightful stories you know,” said the Mice: and the next night
+they came with four other little Mice, who were to hear what the Tree
+recounted: and the more he related, the more he remembered himself; and
+it appeared as if those times had really been happy times. “But they may
+still come--they may still come! Humpy-Dumpy fell downstairs, and yet
+he got a princess!” and he thought at the moment of a nice little Birch
+Tree growing out in the woods: to the Fir, that would be a real charming
+princess.
+
+“Who is Humpy-Dumpy?” asked the Mice. So then the Fir Tree told the
+whole fairy tale, for he could remember every single word of it; and the
+little Mice jumped for joy up to the very top of the Tree. Next night
+two more Mice came, and on Sunday two Rats even; but they said the
+stories were not interesting, which vexed the little Mice; and they,
+too, now began to think them not so very amusing either.
+
+“Do you know only one story?” asked the Rats.
+
+“Only that one,” answered the Tree. “I heard it on my happiest evening;
+but I did not then know how happy I was.”
+
+“It is a very stupid story! Don’t you know one about bacon and tallow
+candles? Can’t you tell any larder stories?”
+
+“No,” said the Tree.
+
+“Then good-bye,” said the Rats; and they went home.
+
+At last the little Mice stayed away also; and the Tree sighed: “After
+all, it was very pleasant when the sleek little Mice sat round me, and
+listened to what I told them. Now that too is over. But I will take good
+care to enjoy myself when I am brought out again.”
+
+But when was that to be? Why, one morning there came a quantity of
+people and set to work in the loft. The trunks were moved, the tree was
+pulled out and thrown--rather hard, it is true--down on the floor, but a
+man drew him towards the stairs, where the daylight shone.
+
+“Now a merry life will begin again,” thought the Tree. He felt the fresh
+air, the first sunbeam--and now he was out in the courtyard. All passed
+so quickly, there was so much going on around him, the Tree quite forgot
+to look to himself. The court adjoined a garden, and all was in flower;
+the roses hung so fresh and odorous over the balustrade, the lindens
+were in blossom, the Swallows flew by, and said, “Quirre-vit! My husband
+is come!” but it was not the Fir Tree that they meant.
+
+“Now, then, I shall really enjoy life,” said he exultingly, and spread
+out his branches; but, alas, they were all withered and yellow! It was
+in a corner that he lay, among weeds and nettles. The golden star of
+tinsel was still on the top of the Tree, and glittered in the sunshine.
+
+In the court-yard some of the merry children were playing who had danced
+at Christmas round the Fir Tree, and were so glad at the sight of him.
+One of the youngest ran and tore off the golden star.
+
+“Only look what is still on the ugly old Christmas tree!” said he,
+trampling on the branches, so that they all cracked beneath his feet.
+
+And the Tree beheld all the beauty of the flowers, and the freshness in
+the garden; he beheld himself, and wished he had remained in his dark
+corner in the loft; he thought of his first youth in the wood, of the
+merry Christmas-eve, and of the little Mice who had listened with so
+much pleasure to the story of Humpy-Dumpy.
+
+“‘Tis over--‘tis past!” said the poor Tree. “Had I but rejoiced when I
+had reason to do so! But now ‘tis past, ‘tis past!”
+
+And the gardener’s boy chopped the Tree into small pieces; there was a
+whole heap lying there. The wood flamed up splendidly under the large
+brewing copper, and it sighed so deeply! Each sigh was like a shot.
+
+The boys played about in the court, and the youngest wore the gold star
+on his breast which the Tree had had on the happiest evening of his
+life. However, that was over now--the Tree gone, the story at an end.
+All, all was over--every tale must end at last.
+
+
+
+
+THE SNOW QUEEN
+
+FIRST STORY. Which Treats of a Mirror and of the Splinters
+
+Now then, let us begin. When we are at the end of the story, we shall
+know more than we know now: but to begin.
+
+Once upon a time there was a wicked sprite, indeed he was the most
+mischievous of all sprites. One day he was in a very good humor, for
+he had made a mirror with the power of causing all that was good and
+beautiful when it was reflected therein, to look poor and mean; but
+that which was good-for-nothing and looked ugly was shown magnified
+and increased in ugliness. In this mirror the most beautiful landscapes
+looked like boiled spinach, and the best persons were turned into
+frights, or appeared to stand on their heads; their faces were so
+distorted that they were not to be recognised; and if anyone had a mole,
+you might be sure that it would be magnified and spread over both nose
+and mouth.
+
+“That’s glorious fun!” said the sprite. If a good thought passed through
+a man’s mind, then a grin was seen in the mirror, and the sprite laughed
+heartily at his clever discovery. All the little sprites who went to his
+school--for he kept a sprite school--told each other that a miracle had
+happened; and that now only, as they thought, it would be possible to
+see how the world really looked. They ran about with the mirror; and at
+last there was not a land or a person who was not represented distorted
+in the mirror. So then they thought they would fly up to the sky,
+and have a joke there. The higher they flew with the mirror, the more
+terribly it grinned: they could hardly hold it fast. Higher and higher
+still they flew, nearer and nearer to the stars, when suddenly the
+mirror shook so terribly with grinning, that it flew out of their hands
+and fell to the earth, where it was dashed in a hundred million and more
+pieces. And now it worked much more evil than before; for some of these
+pieces were hardly so large as a grain of sand, and they flew about in
+the wide world, and when they got into people’s eyes, there they stayed;
+and then people saw everything perverted, or only had an eye for that
+which was evil. This happened because the very smallest bit had the
+same power which the whole mirror had possessed. Some persons even got
+a splinter in their heart, and then it made one shudder, for their heart
+became like a lump of ice. Some of the broken pieces were so large that
+they were used for windowpanes, through which one could not see one’s
+friends. Other pieces were put in spectacles; and that was a sad affair
+when people put on their glasses to see well and rightly. Then the
+wicked sprite laughed till he almost choked, for all this tickled his
+fancy. The fine splinters still flew about in the air: and now we shall
+hear what happened next.
+
+
+SECOND STORY. A Little Boy and a Little Girl
+
+In a large town, where there are so many houses, and so many people,
+that there is no roof left for everybody to have a little garden; and
+where, on this account, most persons are obliged to content themselves
+with flowers in pots; there lived two little children, who had a garden
+somewhat larger than a flower-pot. They were not brother and sister; but
+they cared for each other as much as if they were. Their parents lived
+exactly opposite. They inhabited two garrets; and where the roof of the
+one house joined that of the other, and the gutter ran along the extreme
+end of it, there was to each house a small window: one needed only to
+step over the gutter to get from one window to the other.
+
+The children’s parents had large wooden boxes there, in which vegetables
+for the kitchen were planted, and little rosetrees besides: there was a
+rose in each box, and they grew splendidly. They now thought of placing
+the boxes across the gutter, so that they nearly reached from one window
+to the other, and looked just like two walls of flowers. The tendrils
+of the peas hung down over the boxes; and the rose-trees shot up long
+branches, twined round the windows, and then bent towards each other: it
+was almost like a triumphant arch of foliage and flowers. The boxes were
+very high, and the children knew that they must not creep over them; so
+they often obtained permission to get out of the windows to each other,
+and to sit on their little stools among the roses, where they could play
+delightfully. In winter there was an end of this pleasure. The windows
+were often frozen over; but then they heated copper farthings on the
+stove, and laid the hot farthing on the windowpane, and then they had a
+capital peep-hole, quite nicely rounded; and out of each peeped a gentle
+friendly eye--it was the little boy and the little girl who were looking
+out. His name was Kay, hers was Gerda. In summer, with one jump, they
+could get to each other; but in winter they were obliged first to
+go down the long stairs, and then up the long stairs again: and
+out-of-doors there was quite a snow-storm.
+
+“It is the white bees that are swarming,” said Kay’s old grandmother.
+
+“Do the white bees choose a queen?” asked the little boy; for he knew
+that the honey-bees always have one.
+
+“Yes,” said the grandmother, “she flies where the swarm hangs in the
+thickest clusters. She is the largest of all; and she can never remain
+quietly on the earth, but goes up again into the black clouds. Many a
+winter’s night she flies through the streets of the town, and peeps in
+at the windows; and they then freeze in so wondrous a manner that they
+look like flowers.”
+
+“Yes, I have seen it,” said both the children; and so they knew that it
+was true.
+
+“Can the Snow Queen come in?” said the little girl.
+
+“Only let her come in!” said the little boy. “Then I’d put her on the
+stove, and she’d melt.”
+
+And then his grandmother patted his head and told him other stories.
+
+In the evening, when little Kay was at home, and half undressed, he
+climbed up on the chair by the window, and peeped out of the little
+hole. A few snow-flakes were falling, and one, the largest of all,
+remained lying on the edge of a flower-pot.
+
+The flake of snow grew larger and larger; and at last it was like a
+young lady, dressed in the finest white gauze, made of a million little
+flakes like stars. She was so beautiful and delicate, but she was of
+ice, of dazzling, sparkling ice; yet she lived; her eyes gazed fixedly,
+like two stars; but there was neither quiet nor repose in them. She
+nodded towards the window, and beckoned with her hand. The little boy
+was frightened, and jumped down from the chair; it seemed to him as if,
+at the same moment, a large bird flew past the window.
+
+The next day it was a sharp frost--and then the spring came; the sun
+shone, the green leaves appeared, the swallows built their nests, the
+windows were opened, and the little children again sat in their pretty
+garden, high up on the leads at the top of the house.
+
+That summer the roses flowered in unwonted beauty. The little girl had
+learned a hymn, in which there was something about roses; and then she
+thought of her own flowers; and she sang the verse to the little boy,
+who then sang it with her:
+
+     “The rose in the valley is blooming so sweet,
+     And angels descend there the children to greet.”
+
+And the children held each other by the hand, kissed the roses, looked
+up at the clear sunshine, and spoke as though they really saw angels
+there. What lovely summer-days those were! How delightful to be out in
+the air, near the fresh rose-bushes, that seem as if they would never
+finish blossoming!
+
+Kay and Gerda looked at the picture-book full of beasts and of birds;
+and it was then--the clock in the church-tower was just striking
+five--that Kay said, “Oh! I feel such a sharp pain in my heart; and now
+something has got into my eye!”
+
+The little girl put her arms around his neck. He winked his eyes; now
+there was nothing to be seen.
+
+“I think it is out now,” said he; but it was not. It was just one of
+those pieces of glass from the magic mirror that had got into his eye;
+and poor Kay had got another piece right in his heart. It will soon
+become like ice. It did not hurt any longer, but there it was.
+
+“What are you crying for?” asked he. “You look so ugly! There’s nothing
+the matter with me. Ah,” said he at once, “that rose is cankered! And
+look, this one is quite crooked! After all, these roses are very ugly!
+They are just like the box they are planted in!” And then he gave the
+box a good kick with his foot, and pulled both the roses up.
+
+“What are you doing?” cried the little girl; and as he perceived her
+fright, he pulled up another rose, got in at the window, and hastened
+off from dear little Gerda.
+
+Afterwards, when she brought her picture-book, he asked, “What horrid
+beasts have you there?” And if his grandmother told them stories, he
+always interrupted her; besides, if he could manage it, he would get
+behind her, put on her spectacles, and imitate her way of speaking; he
+copied all her ways, and then everybody laughed at him. He was soon able
+to imitate the gait and manner of everyone in the street. Everything
+that was peculiar and displeasing in them--that Kay knew how to imitate:
+and at such times all the people said, “The boy is certainly very
+clever!” But it was the glass he had got in his eye; the glass that was
+sticking in his heart, which made him tease even little Gerda, whose
+whole soul was devoted to him.
+
+His games now were quite different to what they had formerly been, they
+were so very knowing. One winter’s day, when the flakes of snow were
+flying about, he spread the skirts of his blue coat, and caught the snow
+as it fell.
+
+“Look through this glass, Gerda,” said he. And every flake seemed
+larger, and appeared like a magnificent flower, or beautiful star; it
+was splendid to look at!
+
+“Look, how clever!” said Kay. “That’s much more interesting than real
+flowers! They are as exact as possible; there is not a fault in them, if
+they did not melt!”
+
+It was not long after this, that Kay came one day with large gloves on,
+and his little sledge at his back, and bawled right into Gerda’s ears,
+“I have permission to go out into the square where the others are
+playing”; and off he was in a moment.
+
+There, in the market-place, some of the boldest of the boys used to tie
+their sledges to the carts as they passed by, and so they were pulled
+along, and got a good ride. It was so capital! Just as they were in the
+very height of their amusement, a large sledge passed by: it was painted
+quite white, and there was someone in it wrapped up in a rough white
+mantle of fur, with a rough white fur cap on his head. The sledge drove
+round the square twice, and Kay tied on his sledge as quickly as he
+could, and off he drove with it. On they went quicker and quicker into
+the next street; and the person who drove turned round to Kay, and
+nodded to him in a friendly manner, just as if they knew each other.
+Every time he was going to untie his sledge, the person nodded to him,
+and then Kay sat quiet; and so on they went till they came outside
+the gates of the town. Then the snow began to fall so thickly that the
+little boy could not see an arm’s length before him, but still on he
+went: when suddenly he let go the string he held in his hand in order
+to get loose from the sledge, but it was of no use; still the little
+vehicle rushed on with the quickness of the wind. He then cried as loud
+as he could, but no one heard him; the snow drifted and the sledge flew
+on, and sometimes it gave a jerk as though they were driving over hedges
+and ditches. He was quite frightened, and he tried to repeat the
+Lord’s Prayer; but all he could do, he was only able to remember the
+multiplication table.
+
+The snow-flakes grew larger and larger, till at last they looked just
+like great white fowls. Suddenly they flew on one side; the large sledge
+stopped, and the person who drove rose up. It was a lady; her cloak and
+cap were of snow. She was tall and of slender figure, and of a dazzling
+whiteness. It was the Snow Queen.
+
+“We have travelled fast,” said she; “but it is freezingly cold. Come
+under my bearskin.” And she put him in the sledge beside her,
+wrapped the fur round him, and he felt as though he were sinking in a
+snow-wreath.
+
+“Are you still cold?” asked she; and then she kissed his forehead.
+Ah! it was colder than ice; it penetrated to his very heart, which was
+already almost a frozen lump; it seemed to him as if he were about to
+die--but a moment more and it was quite congenial to him, and he did not
+remark the cold that was around him.
+
+“My sledge! Do not forget my sledge!” It was the first thing he thought
+of. It was there tied to one of the white chickens, who flew along with
+it on his back behind the large sledge. The Snow Queen kissed Kay once
+more, and then he forgot little Gerda, grandmother, and all whom he had
+left at his home.
+
+“Now you will have no more kisses,” said she, “or else I should kiss you
+to death!”
+
+Kay looked at her. She was very beautiful; a more clever, or a more
+lovely countenance he could not fancy to himself; and she no longer
+appeared of ice as before, when she sat outside the window, and beckoned
+to him; in his eyes she was perfect, he did not fear her at all, and
+told her that he could calculate in his head and with fractions, even;
+that he knew the number of square miles there were in the different
+countries, and how many inhabitants they contained; and she smiled while
+he spoke. It then seemed to him as if what he knew was not enough, and
+he looked upwards in the large huge empty space above him, and on she
+flew with him; flew high over the black clouds, while the storm moaned
+and whistled as though it were singing some old tune. On they flew
+over woods and lakes, over seas, and many lands; and beneath them the
+chilling storm rushed fast, the wolves howled, the snow crackled; above
+them flew large screaming crows, but higher up appeared the moon, quite
+large and bright; and it was on it that Kay gazed during the long long
+winter’s night; while by day he slept at the feet of the Snow Queen.
+
+
+THIRD STORY. Of the Flower-Garden At the Old Woman’s Who Understood
+Witchcraft
+
+But what became of little Gerda when Kay did not return? Where could he
+be? Nobody knew; nobody could give any intelligence. All the boys knew
+was, that they had seen him tie his sledge to another large and splendid
+one, which drove down the street and out of the town. Nobody knew
+where he was; many sad tears were shed, and little Gerda wept long and
+bitterly; at last she said he must be dead; that he had been drowned in
+the river which flowed close to the town. Oh! those were very long and
+dismal winter evenings!
+
+At last spring came, with its warm sunshine.
+
+“Kay is dead and gone!” said little Gerda.
+
+“That I don’t believe,” said the Sunshine.
+
+“Kay is dead and gone!” said she to the Swallows.
+
+“That I don’t believe,” said they: and at last little Gerda did not
+think so any longer either.
+
+“I’ll put on my red shoes,” said she, one morning; “Kay has never seen
+them, and then I’ll go down to the river and ask there.”
+
+It was quite early; she kissed her old grandmother, who was still
+asleep, put on her red shoes, and went alone to the river.
+
+“Is it true that you have taken my little playfellow? I will make you a
+present of my red shoes, if you will give him back to me.”
+
+And, as it seemed to her, the blue waves nodded in a strange manner;
+then she took off her red shoes, the most precious things she possessed,
+and threw them both into the river. But they fell close to the bank, and
+the little waves bore them immediately to land; it was as if the stream
+would not take what was dearest to her; for in reality it had not got
+little Kay; but Gerda thought that she had not thrown the shoes out far
+enough, so she clambered into a boat which lay among the rushes, went
+to the farthest end, and threw out the shoes. But the boat was not
+fastened, and the motion which she occasioned, made it drift from the
+shore. She observed this, and hastened to get back; but before she could
+do so, the boat was more than a yard from the land, and was gliding
+quickly onward.
+
+Little Gerda was very frightened, and began to cry; but no one heard her
+except the sparrows, and they could not carry her to land; but they flew
+along the bank, and sang as if to comfort her, “Here we are! Here we
+are!” The boat drifted with the stream, little Gerda sat quite still
+without shoes, for they were swimming behind the boat, but she could not
+reach them, because the boat went much faster than they did.
+
+The banks on both sides were beautiful; lovely flowers, venerable trees,
+and slopes with sheep and cows, but not a human being was to be seen.
+
+“Perhaps the river will carry me to little Kay,” said she; and then
+she grew less sad. She rose, and looked for many hours at the beautiful
+green banks. Presently she sailed by a large cherry-orchard, where was
+a little cottage with curious red and blue windows; it was thatched,
+and before it two wooden soldiers stood sentry, and presented arms when
+anyone went past.
+
+Gerda called to them, for she thought they were alive; but they, of
+course, did not answer. She came close to them, for the stream drifted
+the boat quite near the land.
+
+Gerda called still louder, and an old woman then came out of the
+cottage, leaning upon a crooked stick. She had a large broad-brimmed hat
+on, painted with the most splendid flowers.
+
+“Poor little child!” said the old woman. “How did you get upon the large
+rapid river, to be driven about so in the wide world!” And then the
+old woman went into the water, caught hold of the boat with her crooked
+stick, drew it to the bank, and lifted little Gerda out.
+
+And Gerda was so glad to be on dry land again; but she was rather afraid
+of the strange old woman.
+
+“But come and tell me who you are, and how you came here,” said she.
+
+And Gerda told her all; and the old woman shook her head and said,
+“A-hem! a-hem!” and when Gerda had told her everything, and asked her if
+she had not seen little Kay, the woman answered that he had not passed
+there, but he no doubt would come; and she told her not to be cast down,
+but taste her cherries, and look at her flowers, which were finer than
+any in a picture-book, each of which could tell a whole story. She then
+took Gerda by the hand, led her into the little cottage, and locked the
+door.
+
+The windows were very high up; the glass was red, blue, and green, and
+the sunlight shone through quite wondrously in all sorts of colors. On
+the table stood the most exquisite cherries, and Gerda ate as many as
+she chose, for she had permission to do so. While she was eating, the
+old woman combed her hair with a golden comb, and her hair curled and
+shone with a lovely golden color around that sweet little face, which
+was so round and so like a rose.
+
+“I have often longed for such a dear little girl,” said the old woman.
+“Now you shall see how well we agree together”; and while she combed
+little Gerda’s hair, the child forgot her foster-brother Kay more and
+more, for the old woman understood magic; but she was no evil being, she
+only practised witchcraft a little for her own private amusement, and
+now she wanted very much to keep little Gerda. She therefore went out
+in the garden, stretched out her crooked stick towards the rose-bushes,
+which, beautifully as they were blowing, all sank into the earth and no
+one could tell where they had stood. The old woman feared that if Gerda
+should see the roses, she would then think of her own, would remember
+little Kay, and run away from her.
+
+She now led Gerda into the flower-garden. Oh, what odour and what
+loveliness was there! Every flower that one could think of, and of every
+season, stood there in fullest bloom; no picture-book could be gayer or
+more beautiful. Gerda jumped for joy, and played till the sun set behind
+the tall cherry-tree; she then had a pretty bed, with a red silken
+coverlet filled with blue violets. She fell asleep, and had as pleasant
+dreams as ever a queen on her wedding-day.
+
+The next morning she went to play with the flowers in the warm sunshine,
+and thus passed away a day. Gerda knew every flower; and, numerous as
+they were, it still seemed to Gerda that one was wanting, though she
+did not know which. One day while she was looking at the hat of the old
+woman painted with flowers, the most beautiful of them all seemed to her
+to be a rose. The old woman had forgotten to take it from her hat
+when she made the others vanish in the earth. But so it is when one’s
+thoughts are not collected. “What!” said Gerda. “Are there no roses
+here?” and she ran about amongst the flowerbeds, and looked, and looked,
+but there was not one to be found. She then sat down and wept; but her
+hot tears fell just where a rose-bush had sunk; and when her warm tears
+watered the ground, the tree shot up suddenly as fresh and blooming as
+when it had been swallowed up. Gerda kissed the roses, thought of her
+own dear roses at home, and with them of little Kay.
+
+“Oh, how long I have stayed!” said the little girl. “I intended to look
+for Kay! Don’t you know where he is?” she asked of the roses. “Do you
+think he is dead and gone?”
+
+“Dead he certainly is not,” said the Roses. “We have been in the earth
+where all the dead are, but Kay was not there.”
+
+“Many thanks!” said little Gerda; and she went to the other flowers,
+looked into their cups, and asked, “Don’t you know where little Kay is?”
+
+But every flower stood in the sunshine, and dreamed its own fairy tale
+or its own story: and they all told her very many things, but not one
+knew anything of Kay.
+
+Well, what did the Tiger-Lily say?
+
+“Hearest thou not the drum? Bum! Bum! Those are the only two tones.
+Always bum! Bum! Hark to the plaintive song of the old woman, to the
+call of the priests! The Hindoo woman in her long robe stands upon the
+funeral pile; the flames rise around her and her dead husband, but the
+Hindoo woman thinks on the living one in the surrounding circle; on him
+whose eyes burn hotter than the flames--on him, the fire of whose eyes
+pierces her heart more than the flames which soon will burn her body to
+ashes. Can the heart’s flame die in the flame of the funeral pile?”
+
+“I don’t understand that at all,” said little Gerda.
+
+“That is my story,” said the Lily.
+
+What did the Convolvulus say?
+
+“Projecting over a narrow mountain-path there hangs an old feudal
+castle. Thick evergreens grow on the dilapidated walls, and around the
+altar, where a lovely maiden is standing: she bends over the railing and
+looks out upon the rose. No fresher rose hangs on the branches than she;
+no appleblossom carried away by the wind is more buoyant! How her silken
+robe is rustling!
+
+“‘Is he not yet come?’”
+
+“Is it Kay that you mean?” asked little Gerda.
+
+“I am speaking about my story--about my dream,” answered the
+Convolvulus.
+
+What did the Snowdrops say?
+
+“Between the trees a long board is hanging--it is a swing. Two little
+girls are sitting in it, and swing themselves backwards and forwards;
+their frocks are as white as snow, and long green silk ribands flutter
+from their bonnets. Their brother, who is older than they are, stands up
+in the swing; he twines his arms round the cords to hold himself fast,
+for in one hand he has a little cup, and in the other a clay-pipe. He is
+blowing soap-bubbles. The swing moves, and the bubbles float in charming
+changing colors: the last is still hanging to the end of the pipe, and
+rocks in the breeze. The swing moves. The little black dog, as light as
+a soap-bubble, jumps up on his hind legs to try to get into the swing.
+It moves, the dog falls down, barks, and is angry. They tease him; the
+bubble bursts! A swing, a bursting bubble--such is my song!”
+
+“What you relate may be very pretty, but you tell it in so melancholy a
+manner, and do not mention Kay.”
+
+What do the Hyacinths say?
+
+“There were once upon a time three sisters, quite transparent, and very
+beautiful. The robe of the one was red, that of the second blue, and
+that of the third white. They danced hand in hand beside the calm
+lake in the clear moonshine. They were not elfin maidens, but mortal
+children. A sweet fragrance was smelt, and the maidens vanished in the
+wood; the fragrance grew stronger--three coffins, and in them three
+lovely maidens, glided out of the forest and across the lake: the
+shining glow-worms flew around like little floating lights. Do the
+dancing maidens sleep, or are they dead? The odour of the flowers says
+they are corpses; the evening bell tolls for the dead!”
+
+“You make me quite sad,” said little Gerda. “I cannot help thinking of
+the dead maidens. Oh! is little Kay really dead? The Roses have been in
+the earth, and they say no.”
+
+“Ding, dong!” sounded the Hyacinth bells. “We do not toll for little
+Kay; we do not know him. That is our way of singing, the only one we
+have.”
+
+And Gerda went to the Ranunculuses, that looked forth from among the
+shining green leaves.
+
+“You are a little bright sun!” said Gerda. “Tell me if you know where I
+can find my playfellow.”
+
+And the Ranunculus shone brightly, and looked again at Gerda. What
+song could the Ranunculus sing? It was one that said nothing about Kay
+either.
+
+“In a small court the bright sun was shining in the first days of
+spring. The beams glided down the white walls of a neighbor’s house, and
+close by the fresh yellow flowers were growing, shining like gold in
+the warm sun-rays. An old grandmother was sitting in the air; her
+grand-daughter, the poor and lovely servant just come for a short visit.
+She knows her grandmother. There was gold, pure virgin gold in that
+blessed kiss. There, that is my little story,” said the Ranunculus.
+
+“My poor old grandmother!” sighed Gerda. “Yes, she is longing for me,
+no doubt: she is sorrowing for me, as she did for little Kay. But I
+will soon come home, and then I will bring Kay with me. It is of no use
+asking the flowers; they only know their own old rhymes, and can tell me
+nothing.” And she tucked up her frock, to enable her to run quicker; but
+the Narcissus gave her a knock on the leg, just as she was going to
+jump over it. So she stood still, looked at the long yellow flower, and
+asked, “You perhaps know something?” and she bent down to the Narcissus.
+And what did it say?
+
+“I can see myself--I can see myself! Oh, how odorous I am! Up in the
+little garret there stands, half-dressed, a little Dancer. She stands
+now on one leg, now on both; she despises the whole world; yet she lives
+only in imagination. She pours water out of the teapot over a piece of
+stuff which she holds in her hand; it is the bodice; cleanliness is a
+fine thing. The white dress is hanging on the hook; it was washed in the
+teapot, and dried on the roof. She puts it on, ties a saffron-colored
+kerchief round her neck, and then the gown looks whiter. I can see
+myself--I can see myself!”
+
+“That’s nothing to me,” said little Gerda. “That does not concern me.”
+ And then off she ran to the further end of the garden.
+
+The gate was locked, but she shook the rusted bolt till it was loosened,
+and the gate opened; and little Gerda ran off barefooted into the wide
+world. She looked round her thrice, but no one followed her. At last she
+could run no longer; she sat down on a large stone, and when she looked
+about her, she saw that the summer had passed; it was late in the
+autumn, but that one could not remark in the beautiful garden, where
+there was always sunshine, and where there were flowers the whole year
+round.
+
+“Dear me, how long I have staid!” said Gerda. “Autumn is come. I must
+not rest any longer.” And she got up to go further.
+
+Oh, how tender and wearied her little feet were! All around it looked
+so cold and raw: the long willow-leaves were quite yellow, and the fog
+dripped from them like water; one leaf fell after the other: the sloes
+only stood full of fruit, which set one’s teeth on edge. Oh, how dark
+and comfortless it was in the dreary world!
+
+
+FOURTH STORY. The Prince and Princess
+
+Gerda was obliged to rest herself again, when, exactly opposite to her,
+a large Raven came hopping over the white snow. He had long been looking
+at Gerda and shaking his head; and now he said, “Caw! Caw!” Good day!
+Good day! He could not say it better; but he felt a sympathy for the
+little girl, and asked her where she was going all alone. The word
+“alone” Gerda understood quite well, and felt how much was expressed
+by it; so she told the Raven her whole history, and asked if he had not
+seen Kay.
+
+The Raven nodded very gravely, and said, “It may be--it may be!”
+
+“What, do you really think so?” cried the little girl; and she nearly
+squeezed the Raven to death, so much did she kiss him.
+
+“Gently, gently,” said the Raven. “I think I know; I think that it may
+be little Kay. But now he has forgotten you for the Princess.”
+
+“Does he live with a Princess?” asked Gerda.
+
+“Yes--listen,” said the Raven; “but it will be difficult for me to
+speak your language. If you understand the Raven language I can tell you
+better.”
+
+“No, I have not learnt it,” said Gerda; “but my grandmother understands
+it, and she can speak gibberish too. I wish I had learnt it.”
+
+“No matter,” said the Raven; “I will tell you as well as I can; however,
+it will be bad enough.” And then he told all he knew.
+
+“In the kingdom where we now are there lives a Princess, who is
+extraordinarily clever; for she has read all the newspapers in the whole
+world, and has forgotten them again--so clever is she. She was lately,
+it is said, sitting on her throne--which is not very amusing after
+all--when she began humming an old tune, and it was just, ‘Oh, why
+should I not be married?’ ‘That song is not without its meaning,’ said
+she, and so then she was determined to marry; but she would have a
+husband who knew how to give an answer when he was spoken to--not
+one who looked only as if he were a great personage, for that is so
+tiresome. She then had all the ladies of the court drummed together; and
+when they heard her intention, all were very pleased, and said, ‘We are
+very glad to hear it; it is the very thing we were thinking of.’ You may
+believe every word I say,” said the Raven; “for I have a tame sweetheart
+that hops about in the palace quite free, and it was she who told me all
+this.
+
+“The newspapers appeared forthwith with a border of hearts and the
+initials of the Princess; and therein you might read that every
+good-looking young man was at liberty to come to the palace and speak to
+the Princess; and he who spoke in such wise as showed he felt himself at
+home there, that one the Princess would choose for her husband.
+
+“Yes, Yes,” said the Raven, “you may believe it; it is as true as I am
+sitting here. People came in crowds; there was a crush and a hurry, but
+no one was successful either on the first or second day. They could all
+talk well enough when they were out in the street; but as soon as
+they came inside the palace gates, and saw the guard richly dressed
+in silver, and the lackeys in gold on the staircase, and the large
+illuminated saloons, then they were abashed; and when they stood before
+the throne on which the Princess was sitting, all they could do was
+to repeat the last word they had uttered, and to hear it again did not
+interest her very much. It was just as if the people within were under
+a charm, and had fallen into a trance till they came out again into the
+street; for then--oh, then--they could chatter enough. There was a whole
+row of them standing from the town-gates to the palace. I was there
+myself to look,” said the Raven. “They grew hungry and thirsty; but from
+the palace they got nothing whatever, not even a glass of water. Some
+of the cleverest, it is true, had taken bread and butter with them:
+but none shared it with his neighbor, for each thought, ‘Let him look
+hungry, and then the Princess won’t have him.’”
+
+“But Kay--little Kay,” said Gerda, “when did he come? Was he among the
+number?”
+
+“Patience, patience; we are just come to him. It was on the third day
+when a little personage without horse or equipage, came marching right
+boldly up to the palace; his eyes shone like yours, he had beautiful
+long hair, but his clothes were very shabby.”
+
+“That was Kay,” cried Gerda, with a voice of delight. “Oh, now I’ve
+found him!” and she clapped her hands for joy.
+
+“He had a little knapsack at his back,” said the Raven.
+
+“No, that was certainly his sledge,” said Gerda; “for when he went away
+he took his sledge with him.”
+
+“That may be,” said the Raven; “I did not examine him so minutely; but
+I know from my tame sweetheart, that when he came into the court-yard
+of the palace, and saw the body-guard in silver, the lackeys on the
+staircase, he was not the least abashed; he nodded, and said to them,
+‘It must be very tiresome to stand on the stairs; for my part, I shall
+go in.’ The saloons were gleaming with lustres--privy councillors and
+excellencies were walking about barefooted, and wore gold keys; it was
+enough to make any one feel uncomfortable. His boots creaked, too, so
+loudly, but still he was not at all afraid.”
+
+“That’s Kay for certain,” said Gerda. “I know he had on new boots; I
+have heard them creaking in grandmama’s room.”
+
+“Yes, they creaked,” said the Raven. “And on he went boldly up to the
+Princess, who was sitting on a pearl as large as a spinning-wheel.
+All the ladies of the court, with their attendants and attendants’
+attendants, and all the cavaliers, with their gentlemen and gentlemen’s
+gentlemen, stood round; and the nearer they stood to the door, the
+prouder they looked. It was hardly possible to look at the gentleman’s
+gentleman, so very haughtily did he stand in the doorway.”
+
+“It must have been terrible,” said little Gerda. “And did Kay get the
+Princess?”
+
+“Were I not a Raven, I should have taken the Princess myself, although
+I am promised. It is said he spoke as well as I speak when I talk Raven
+language; this I learned from my tame sweetheart. He was bold and nicely
+behaved; he had not come to woo the Princess, but only to hear her
+wisdom. She pleased him, and he pleased her.”
+
+“Yes, yes; for certain that was Kay,” said Gerda. “He was so clever;
+he could reckon fractions in his head. Oh, won’t you take me to the
+palace?”
+
+“That is very easily said,” answered the Raven. “But how are we to
+manage it? I’ll speak to my tame sweetheart about it: she must advise
+us; for so much I must tell you, such a little girl as you are will
+never get permission to enter.”
+
+“Oh, yes I shall,” said Gerda; “when Kay hears that I am here, he will
+come out directly to fetch me.”
+
+“Wait for me here on these steps,” said the Raven. He moved his head
+backwards and forwards and flew away.
+
+The evening was closing in when the Raven returned. “Caw--caw!” said he.
+“She sends you her compliments; and here is a roll for you. She took
+it out of the kitchen, where there is bread enough. You are hungry,
+no doubt. It is not possible for you to enter the palace, for you are
+barefooted: the guards in silver, and the lackeys in gold, would not
+allow it; but do not cry, you shall come in still. My sweetheart knows a
+little back stair that leads to the bedchamber, and she knows where she
+can get the key of it.”
+
+And they went into the garden in the large avenue, where one leaf was
+falling after the other; and when the lights in the palace had all
+gradually disappeared, the Raven led little Gerda to the back door,
+which stood half open.
+
+Oh, how Gerda’s heart beat with anxiety and longing! It was just as if
+she had been about to do something wrong; and yet she only wanted to
+know if little Kay was there. Yes, he must be there. She called to mind
+his intelligent eyes, and his long hair, so vividly, she could quite see
+him as he used to laugh when they were sitting under the roses at home.
+“He will, no doubt, be glad to see you--to hear what a long way you have
+come for his sake; to know how unhappy all at home were when he did not
+come back.”
+
+Oh, what a fright and a joy it was!
+
+They were now on the stairs. A single lamp was burning there; and on the
+floor stood the tame Raven, turning her head on every side and looking
+at Gerda, who bowed as her grandmother had taught her to do.
+
+“My intended has told me so much good of you, my dear young lady,” said
+the tame Raven. “Your tale is very affecting. If you will take the lamp,
+I will go before. We will go straight on, for we shall meet no one.”
+
+“I think there is somebody just behind us,” said Gerda; and something
+rushed past: it was like shadowy figures on the wall; horses with
+flowing manes and thin legs, huntsmen, ladies and gentlemen on
+horseback.
+
+“They are only dreams,” said the Raven. “They come to fetch the thoughts
+of the high personages to the chase; ‘tis well, for now you can observe
+them in bed all the better. But let me find, when you enjoy honor and
+distinction, that you possess a grateful heart.”
+
+“Tut! That’s not worth talking about,” said the Raven of the woods.
+
+They now entered the first saloon, which was of rose-colored satin, with
+artificial flowers on the wall. Here the dreams were rushing past,
+but they hastened by so quickly that Gerda could not see the high
+personages. One hall was more magnificent than the other; one might
+indeed well be abashed; and at last they came into the bedchamber. The
+ceiling of the room resembled a large palm-tree with leaves of glass,
+of costly glass; and in the middle, from a thick golden stem, hung two
+beds, each of which resembled a lily. One was white, and in this lay the
+Princess; the other was red, and it was here that Gerda was to look for
+little Kay. She bent back one of the red leaves, and saw a brown neck.
+Oh! that was Kay! She called him quite loud by name, held the lamp
+towards him--the dreams rushed back again into the chamber--he awoke,
+turned his head, and--it was not little Kay!
+
+The Prince was only like him about the neck; but he was young and
+handsome. And out of the white lily leaves the Princess peeped, too,
+and asked what was the matter. Then little Gerda cried, and told her her
+whole history, and all that the Ravens had done for her.
+
+“Poor little thing!” said the Prince and the Princess. They praised the
+Ravens very much, and told them they were not at all angry with them,
+but they were not to do so again. However, they should have a reward.
+“Will you fly about here at liberty,” asked the Princess; “or would you
+like to have a fixed appointment as court ravens, with all the broken
+bits from the kitchen?”
+
+And both the Ravens nodded, and begged for a fixed appointment; for
+they thought of their old age, and said, “It is a good thing to have a
+provision for our old days.”
+
+And the Prince got up and let Gerda sleep in his bed, and more than this
+he could not do. She folded her little hands and thought, “How good men
+and animals are!” and she then fell asleep and slept soundly. All the
+dreams flew in again, and they now looked like the angels; they drew
+a little sledge, in which little Kay sat and nodded his head; but the
+whole was only a dream, and therefore it all vanished as soon as she
+awoke.
+
+The next day she was dressed from head to foot in silk and velvet. They
+offered to let her stay at the palace, and lead a happy life; but she
+begged to have a little carriage with a horse in front, and for a small
+pair of shoes; then, she said, she would again go forth in the wide
+world and look for Kay.
+
+Shoes and a muff were given her; she was, too, dressed very nicely; and
+when she was about to set off, a new carriage stopped before the door.
+It was of pure gold, and the arms of the Prince and Princess shone
+like a star upon it; the coachman, the footmen, and the outriders, for
+outriders were there, too, all wore golden crowns. The Prince and the
+Princess assisted her into the carriage themselves, and wished her all
+success. The Raven of the woods, who was now married, accompanied her
+for the first three miles. He sat beside Gerda, for he could not bear
+riding backwards; the other Raven stood in the doorway, and flapped her
+wings; she could not accompany Gerda, because she suffered from headache
+since she had had a fixed appointment and ate so much. The carriage
+was lined inside with sugar-plums, and in the seats were fruits and
+gingerbread.
+
+“Farewell! Farewell!” cried Prince and Princess; and Gerda wept, and
+the Raven wept. Thus passed the first miles; and then the Raven bade her
+farewell, and this was the most painful separation of all. He flew into
+a tree, and beat his black wings as long as he could see the carriage,
+that shone from afar like a sunbeam.
+
+
+FIFTH STORY. The Little Robber Maiden
+
+They drove through the dark wood; but the carriage shone like a torch,
+and it dazzled the eyes of the robbers, so that they could not bear to
+look at it.
+
+“‘Tis gold! ‘Tis gold!” they cried; and they rushed forward, seized
+the horses, knocked down the little postilion, the coachman, and the
+servants, and pulled little Gerda out of the carriage.
+
+“How plump, how beautiful she is! She must have been fed on
+nut-kernels,” said the old female robber, who had a long, scrubby beard,
+and bushy eyebrows that hung down over her eyes. “She is as good as a
+fatted lamb! How nice she will be!” And then she drew out a knife, the
+blade of which shone so that it was quite dreadful to behold.
+
+“Oh!” cried the woman at the same moment. She had been bitten in the ear
+by her own little daughter, who hung at her back; and who was so wild
+and unmanageable, that it was quite amusing to see her. “You naughty
+child!” said the mother: and now she had not time to kill Gerda.
+
+“She shall play with me,” said the little robber child. “She shall give
+me her muff, and her pretty frock; she shall sleep in my bed!” And then
+she gave her mother another bite, so that she jumped, and ran round with
+the pain; and the Robbers laughed, and said, “Look, how she is dancing
+with the little one!”
+
+“I will go into the carriage,” said the little robber maiden; and she
+would have her will, for she was very spoiled and very headstrong. She
+and Gerda got in; and then away they drove over the stumps of felled
+trees, deeper and deeper into the woods. The little robber maiden was as
+tall as Gerda, but stronger, broader-shouldered, and of dark complexion;
+her eyes were quite black; they looked almost melancholy. She embraced
+little Gerda, and said, “They shall not kill you as long as I am not
+displeased with you. You are, doubtless, a Princess?”
+
+“No,” said little Gerda; who then related all that had happened to her,
+and how much she cared about little Kay.
+
+The little robber maiden looked at her with a serious air, nodded her
+head slightly, and said, “They shall not kill you, even if I am angry
+with you: then I will do it myself”; and she dried Gerda’s eyes, and put
+both her hands in the handsome muff, which was so soft and warm.
+
+At length the carriage stopped. They were in the midst of the court-yard
+of a robber’s castle. It was full of cracks from top to bottom; and out
+of the openings magpies and rooks were flying; and the great bull-dogs,
+each of which looked as if he could swallow a man, jumped up, but they
+did not bark, for that was forbidden.
+
+In the midst of the large, old, smoking hall burnt a great fire on the
+stone floor. The smoke disappeared under the stones, and had to seek
+its own egress. In an immense caldron soup was boiling; and rabbits and
+hares were being roasted on a spit.
+
+“You shall sleep with me to-night, with all my animals,” said the little
+robber maiden. They had something to eat and drink; and then went into
+a corner, where straw and carpets were lying. Beside them, on laths and
+perches, sat nearly a hundred pigeons, all asleep, seemingly; but yet
+they moved a little when the robber maiden came. “They are all mine,”
+ said she, at the same time seizing one that was next to her by the legs
+and shaking it so that its wings fluttered. “Kiss it,” cried the little
+girl, and flung the pigeon in Gerda’s face. “Up there is the rabble of
+the wood,” continued she, pointing to several laths which were fastened
+before a hole high up in the wall; “that’s the rabble; they would all
+fly away immediately, if they were not well fastened in. And here is my
+dear old Bac”; and she laid hold of the horns of a reindeer, that had a
+bright copper ring round its neck, and was tethered to the spot. “We are
+obliged to lock this fellow in too, or he would make his escape. Every
+evening I tickle his neck with my sharp knife; he is so frightened at
+it!” and the little girl drew forth a long knife, from a crack in the
+wall, and let it glide over the Reindeer’s neck. The poor animal kicked;
+the girl laughed, and pulled Gerda into bed with her.
+
+“Do you intend to keep your knife while you sleep?” asked Gerda; looking
+at it rather fearfully.
+
+“I always sleep with the knife,” said the little robber maiden. “There
+is no knowing what may happen. But tell me now, once more, all about
+little Kay; and why you have started off in the wide world alone.” And
+Gerda related all, from the very beginning: the Wood-pigeons cooed above
+in their cage, and the others slept. The little robber maiden wound her
+arm round Gerda’s neck, held the knife in the other hand, and snored so
+loud that everybody could hear her; but Gerda could not close her eyes,
+for she did not know whether she was to live or die. The robbers sat
+round the fire, sang and drank; and the old female robber jumped about
+so, that it was quite dreadful for Gerda to see her.
+
+Then the Wood-pigeons said, “Coo! Coo! We have seen little Kay! A white
+hen carries his sledge; he himself sat in the carriage of the Snow
+Queen, who passed here, down just over the wood, as we lay in our nest.
+She blew upon us young ones; and all died except we two. Coo! Coo!”
+
+“What is that you say up there?” cried little Gerda. “Where did the Snow
+Queen go to? Do you know anything about it?”
+
+“She is no doubt gone to Lapland; for there is always snow and ice
+there. Only ask the Reindeer, who is tethered there.”
+
+“Ice and snow is there! There it is, glorious and beautiful!” said the
+Reindeer. “One can spring about in the large shining valleys! The Snow
+Queen has her summer-tent there; but her fixed abode is high up towards
+the North Pole, on the Island called Spitzbergen.”
+
+“Oh, Kay! Poor little Kay!” sighed Gerda.
+
+“Do you choose to be quiet?” said the robber maiden. “If you don’t, I
+shall make you.”
+
+In the morning Gerda told her all that the Wood-pigeons had said; and
+the little maiden looked very serious, but she nodded her head, and
+said, “That’s no matter--that’s no matter. Do you know where Lapland
+lies!” she asked of the Reindeer.
+
+“Who should know better than I?” said the animal; and his eyes rolled in
+his head. “I was born and bred there--there I leapt about on the fields
+of snow.”
+
+“Listen,” said the robber maiden to Gerda. “You see that the men are
+gone; but my mother is still here, and will remain. However, towards
+morning she takes a draught out of the large flask, and then she sleeps
+a little: then I will do something for you.” She now jumped out of bed,
+flew to her mother; with her arms round her neck, and pulling her by the
+beard, said, “Good morrow, my own sweet nanny-goat of a mother.” And her
+mother took hold of her nose, and pinched it till it was red and blue;
+but this was all done out of pure love.
+
+When the mother had taken a sup at her flask, and was having a nap, the
+little robber maiden went to the Reindeer, and said, “I should very much
+like to give you still many a tickling with the sharp knife, for then
+you are so amusing; however, I will untether you, and help you out,
+so that you may go back to Lapland. But you must make good use of your
+legs; and take this little girl for me to the palace of the Snow Queen,
+where her playfellow is. You have heard, I suppose, all she said; for
+she spoke loud enough, and you were listening.”
+
+The Reindeer gave a bound for joy. The robber maiden lifted up little
+Gerda, and took the precaution to bind her fast on the Reindeer’s back;
+she even gave her a small cushion to sit on. “Here are your worsted
+leggins, for it will be cold; but the muff I shall keep for myself, for
+it is so very pretty. But I do not wish you to be cold. Here is a pair
+of lined gloves of my mother’s; they just reach up to your elbow. On
+with them! Now you look about the hands just like my ugly old mother!”
+
+And Gerda wept for joy.
+
+“I can’t bear to see you fretting,” said the little robber maiden. “This
+is just the time when you ought to look pleased. Here are two loaves and
+a ham for you, so that you won’t starve.” The bread and the meat were
+fastened to the Reindeer’s back; the little maiden opened the door,
+called in all the dogs, and then with her knife cut the rope that
+fastened the animal, and said to him, “Now, off with you; but take good
+care of the little girl!”
+
+And Gerda stretched out her hands with the large wadded gloves towards
+the robber maiden, and said, “Farewell!” and the Reindeer flew on over
+bush and bramble through the great wood, over moor and heath, as fast as
+he could go.
+
+“Ddsa! Ddsa!” was heard in the sky. It was just as if somebody was
+sneezing.
+
+“These are my old northern-lights,” said the Reindeer, “look how they
+gleam!” And on he now sped still quicker--day and night on he went: the
+loaves were consumed, and the ham too; and now they were in Lapland.
+
+
+SIXTH STORY. The Lapland Woman and the Finland Woman
+
+Suddenly they stopped before a little house, which looked very
+miserable. The roof reached to the ground; and the door was so low, that
+the family were obliged to creep upon their stomachs when they went in
+or out. Nobody was at home except an old Lapland woman, who was dressing
+fish by the light of an oil lamp. And the Reindeer told her the whole
+of Gerda’s history, but first of all his own; for that seemed to him of
+much greater importance. Gerda was so chilled that she could not speak.
+
+“Poor thing,” said the Lapland woman, “you have far to run still. You
+have more than a hundred miles to go before you get to Finland; there
+the Snow Queen has her country-house, and burns blue lights every
+evening. I will give you a few words from me, which I will write on a
+dried haberdine, for paper I have none; this you can take with you to
+the Finland woman, and she will be able to give you more information
+than I can.”
+
+When Gerda had warmed herself, and had eaten and drunk, the Lapland
+woman wrote a few words on a dried haberdine, begged Gerda to take care
+of them, put her on the Reindeer, bound her fast, and away sprang the
+animal. “Ddsa! Ddsa!” was again heard in the air; the most charming
+blue lights burned the whole night in the sky, and at last they came to
+Finland. They knocked at the chimney of the Finland woman; for as to a
+door, she had none.
+
+There was such a heat inside that the Finland woman herself went about
+almost naked. She was diminutive and dirty. She immediately loosened
+little Gerda’s clothes, pulled off her thick gloves and boots; for
+otherwise the heat would have been too great--and after laying a piece
+of ice on the Reindeer’s head, read what was written on the fish-skin.
+She read it three times: she then knew it by heart; so she put the fish
+into the cupboard--for it might very well be eaten, and she never threw
+anything away.
+
+Then the Reindeer related his own story first, and afterwards that of
+little Gerda; and the Finland woman winked her eyes, but said nothing.
+
+“You are so clever,” said the Reindeer; “you can, I know, twist all the
+winds of the world together in a knot. If the seaman loosens one knot,
+then he has a good wind; if a second, then it blows pretty stiffly; if
+he undoes the third and fourth, then it rages so that the forests are
+upturned. Will you give the little maiden a potion, that she may possess
+the strength of twelve men, and vanquish the Snow Queen?”
+
+“The strength of twelve men!” said the Finland woman. “Much good that
+would be!” Then she went to a cupboard, and drew out a large skin rolled
+up. When she had unrolled it, strange characters were to be seen written
+thereon; and the Finland woman read at such a rate that the perspiration
+trickled down her forehead.
+
+But the Reindeer begged so hard for little Gerda, and Gerda looked so
+imploringly with tearful eyes at the Finland woman, that she winked, and
+drew the Reindeer aside into a corner, where they whispered together,
+while the animal got some fresh ice put on his head.
+
+“‘Tis true little Kay is at the Snow Queen’s, and finds everything there
+quite to his taste; and he thinks it the very best place in the world;
+but the reason of that is, he has a splinter of glass in his eye, and in
+his heart. These must be got out first; otherwise he will never go back
+to mankind, and the Snow Queen will retain her power over him.”
+
+“But can you give little Gerda nothing to take which will endue her with
+power over the whole?”
+
+“I can give her no more power than what she has already. Don’t you see
+how great it is? Don’t you see how men and animals are forced to serve
+her; how well she gets through the world barefooted? She must not hear
+of her power from us; that power lies in her heart, because she is
+a sweet and innocent child! If she cannot get to the Snow Queen by
+herself, and rid little Kay of the glass, we cannot help her. Two miles
+hence the garden of the Snow Queen begins; thither you may carry the
+little girl. Set her down by the large bush with red berries, standing
+in the snow; don’t stay talking, but hasten back as fast as possible.”
+ And now the Finland woman placed little Gerda on the Reindeer’s back,
+and off he ran with all imaginable speed.
+
+“Oh! I have not got my boots! I have not brought my gloves!” cried
+little Gerda. She remarked she was without them from the cutting frost;
+but the Reindeer dared not stand still; on he ran till he came to the
+great bush with the red berries, and there he set Gerda down, kissed her
+mouth, while large bright tears flowed from the animal’s eyes, and then
+back he went as fast as possible. There stood poor Gerda now, without
+shoes or gloves, in the very middle of dreadful icy Finland.
+
+She ran on as fast as she could. There then came a whole regiment of
+snow-flakes, but they did not fall from above, and they were quite
+bright and shining from the Aurora Borealis. The flakes ran along
+the ground, and the nearer they came the larger they grew. Gerda well
+remembered how large and strange the snow-flakes appeared when she
+once saw them through a magnifying-glass; but now they were large and
+terrific in another manner--they were all alive. They were the outposts
+of the Snow Queen. They had the most wondrous shapes; some looked like
+large ugly porcupines; others like snakes knotted together, with their
+heads sticking out; and others, again, like small fat bears, with the
+hair standing on end: all were of dazzling whiteness--all were living
+snow-flakes.
+
+Little Gerda repeated the Lord’s Prayer. The cold was so intense that
+she could see her own breath, which came like smoke out of her mouth. It
+grew thicker and thicker, and took the form of little angels, that grew
+more and more when they touched the earth. All had helms on their heads,
+and lances and shields in their hands; they increased in numbers; and
+when Gerda had finished the Lord’s Prayer, she was surrounded by a whole
+legion. They thrust at the horrid snow-flakes with their spears, so that
+they flew into a thousand pieces; and little Gerda walked on bravely and
+in security. The angels patted her hands and feet; and then she felt the
+cold less, and went on quickly towards the palace of the Snow Queen.
+
+But now we shall see how Kay fared. He never thought of Gerda, and least
+of all that she was standing before the palace.
+
+
+SEVENTH STORY. What Took Place in the Palace of the Snow Queen, and what
+Happened Afterward.
+
+The walls of the palace were of driving snow, and the windows and doors
+of cutting winds. There were more than a hundred halls there, according
+as the snow was driven by the winds. The largest was many miles in
+extent; all were lighted up by the powerful Aurora Borealis, and all
+were so large, so empty, so icy cold, and so resplendent! Mirth never
+reigned there; there was never even a little bear-ball, with the storm
+for music, while the polar bears went on their hind legs and showed off
+their steps. Never a little tea-party of white young lady foxes; vast,
+cold, and empty were the halls of the Snow Queen. The northern-lights
+shone with such precision that one could tell exactly when they were
+at their highest or lowest degree of brightness. In the middle of the
+empty, endless hall of snow, was a frozen lake; it was cracked in a
+thousand pieces, but each piece was so like the other, that it seemed
+the work of a cunning artificer. In the middle of this lake sat the Snow
+Queen when she was at home; and then she said she was sitting in the
+Mirror of Understanding, and that this was the only one and the best
+thing in the world.
+
+Little Kay was quite blue, yes nearly black with cold; but he did not
+observe it, for she had kissed away all feeling of cold from his body,
+and his heart was a lump of ice. He was dragging along some pointed
+flat pieces of ice, which he laid together in all possible ways, for he
+wanted to make something with them; just as we have little flat pieces
+of wood to make geometrical figures with, called the Chinese Puzzle.
+Kay made all sorts of figures, the most complicated, for it was
+an ice-puzzle for the understanding. In his eyes the figures were
+extraordinarily beautiful, and of the utmost importance; for the bit
+of glass which was in his eye caused this. He found whole figures which
+represented a written word; but he never could manage to represent just
+the word he wanted--that word was “eternity”; and the Snow Queen had
+said, “If you can discover that figure, you shall be your own master,
+and I will make you a present of the whole world and a pair of new
+skates.” But he could not find it out.
+
+“I am going now to warm lands,” said the Snow Queen. “I must have a look
+down into the black caldrons.” It was the volcanoes Vesuvius and Etna
+that she meant. “I will just give them a coating of white, for that is
+as it ought to be; besides, it is good for the oranges and the grapes.”
+ And then away she flew, and Kay sat quite alone in the empty halls of
+ice that were miles long, and looked at the blocks of ice, and thought
+and thought till his skull was almost cracked. There he sat quite
+benumbed and motionless; one would have imagined he was frozen to death.
+
+Suddenly little Gerda stepped through the great portal into the palace.
+The gate was formed of cutting winds; but Gerda repeated her evening
+prayer, and the winds were laid as though they slept; and the little
+maiden entered the vast, empty, cold halls. There she beheld Kay: she
+recognised him, flew to embrace him, and cried out, her arms firmly
+holding him the while, “Kay, sweet little Kay! Have I then found you at
+last?”
+
+But he sat quite still, benumbed and cold. Then little Gerda shed
+burning tears; and they fell on his bosom, they penetrated to his
+heart, they thawed the lumps of ice, and consumed the splinters of the
+looking-glass; he looked at her, and she sang the hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+Hereupon Kay burst into tears; he wept so much that the splinter rolled
+out of his eye, and he recognised her, and shouted, “Gerda, sweet little
+Gerda! Where have you been so long? And where have I been?” He looked
+round him. “How cold it is here!” said he. “How empty and cold!” And he
+held fast by Gerda, who laughed and wept for joy. It was so beautiful,
+that even the blocks of ice danced about for joy; and when they were
+tired and laid themselves down, they formed exactly the letters which
+the Snow Queen had told him to find out; so now he was his own master,
+and he would have the whole world and a pair of new skates into the
+bargain.
+
+Gerda kissed his cheeks, and they grew quite blooming; she kissed his
+eyes, and they shone like her own; she kissed his hands and feet, and he
+was again well and merry. The Snow Queen might come back as soon as she
+liked; there stood his discharge written in resplendent masses of ice.
+
+They took each other by the hand, and wandered forth out of the large
+hall; they talked of their old grandmother, and of the roses upon the
+roof; and wherever they went, the winds ceased raging, and the sun burst
+forth. And when they reached the bush with the red berries, they found
+the Reindeer waiting for them. He had brought another, a young one, with
+him, whose udder was filled with milk, which he gave to the little ones,
+and kissed their lips. They then carried Kay and Gerda--first to the
+Finland woman, where they warmed themselves in the warm room, and
+learned what they were to do on their journey home; and they went to
+the Lapland woman, who made some new clothes for them and repaired their
+sledges.
+
+The Reindeer and the young hind leaped along beside them, and
+accompanied them to the boundary of the country. Here the first
+vegetation peeped forth; here Kay and Gerda took leave of the Lapland
+woman. “Farewell! Farewell!” they all said. And the first green buds
+appeared, the first little birds began to chirrup; and out of the wood
+came, riding on a magnificent horse, which Gerda knew (it was one of the
+leaders in the golden carriage), a young damsel with a bright-red cap on
+her head, and armed with pistols. It was the little robber maiden, who,
+tired of being at home, had determined to make a journey to the north;
+and afterwards in another direction, if that did not please her. She
+recognised Gerda immediately, and Gerda knew her too. It was a joyful
+meeting.
+
+“You are a fine fellow for tramping about,” said she to little Kay; “I
+should like to know, faith, if you deserve that one should run from one
+end of the world to the other for your sake?”
+
+But Gerda patted her cheeks, and inquired for the Prince and Princess.
+
+“They are gone abroad,” said the other.
+
+“But the Raven?” asked little Gerda.
+
+“Oh! The Raven is dead,” she answered. “His tame sweetheart is a
+widow, and wears a bit of black worsted round her leg; she laments most
+piteously, but it’s all mere talk and stuff! Now tell me what you’ve
+been doing and how you managed to catch him.”
+
+And Gerda and Kay both told their story.
+
+And “Schnipp-schnapp-schnurre-basselurre,” said the robber maiden; and
+she took the hands of each, and promised that if she should some day
+pass through the town where they lived, she would come and visit them;
+and then away she rode. Kay and Gerda took each other’s hand: it was
+lovely spring weather, with abundance of flowers and of verdure. The
+church-bells rang, and the children recognised the high towers, and the
+large town; it was that in which they dwelt. They entered and hastened
+up to their grandmother’s room, where everything was standing as
+formerly. The clock said “tick! tack!” and the finger moved round; but
+as they entered, they remarked that they were now grown up. The roses
+on the leads hung blooming in at the open window; there stood the little
+children’s chairs, and Kay and Gerda sat down on them, holding each
+other by the hand; they both had forgotten the cold empty splendor of
+the Snow Queen, as though it had been a dream. The grandmother sat in
+the bright sunshine, and read aloud from the Bible: “Unless ye become as
+little children, ye cannot enter the kingdom of heaven.”
+
+And Kay and Gerda looked in each other’s eyes, and all at once they
+understood the old hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+There sat the two grown-up persons; grown-up, and yet children; children
+at least in heart; and it was summer-time; summer, glorious summer!
+
+
+
+
+THE LEAP-FROG
+
+A Flea, a Grasshopper, and a Leap-frog once wanted to see which could
+jump highest; and they invited the whole world, and everybody else
+besides who chose to come to see the festival. Three famous jumpers were
+they, as everyone would say, when they all met together in the room.
+
+“I will give my daughter to him who jumps highest,” exclaimed the King;
+“for it is not so amusing where there is no prize to jump for.”
+
+The Flea was the first to step forward. He had exquisite manners, and
+bowed to the company on all sides; for he had noble blood, and was,
+moreover, accustomed to the society of man alone; and that makes a great
+difference.
+
+Then came the Grasshopper. He was considerably heavier, but he was
+well-mannered, and wore a green uniform, which he had by right of birth;
+he said, moreover, that he belonged to a very ancient Egyptian family,
+and that in the house where he then was, he was thought much of. The
+fact was, he had been just brought out of the fields, and put in a
+pasteboard house, three stories high, all made of court-cards, with the
+colored side inwards; and doors and windows cut out of the body of
+the Queen of Hearts. “I sing so well,” said he, “that sixteen native
+grasshoppers who have chirped from infancy, and yet got no house built
+of cards to live in, grew thinner than they were before for sheer
+vexation when they heard me.”
+
+It was thus that the Flea and the Grasshopper gave an account of
+themselves, and thought they were quite good enough to marry a Princess.
+
+The Leap-frog said nothing; but people gave it as their opinion, that
+he therefore thought the more; and when the housedog snuffed at him
+with his nose, he confessed the Leap-frog was of good family. The old
+councillor, who had had three orders given him to make him hold his
+tongue, asserted that the Leap-frog was a prophet; for that one could
+see on his back, if there would be a severe or mild winter, and that
+was what one could not see even on the back of the man who writes the
+almanac.
+
+“I say nothing, it is true,” exclaimed the King; “but I have my own
+opinion, notwithstanding.”
+
+Now the trial was to take place. The Flea jumped so high that nobody
+could see where he went to; so they all asserted he had not jumped at
+all; and that was dishonorable.
+
+The Grasshopper jumped only half as high; but he leaped into the King’s
+face, who said that was ill-mannered.
+
+The Leap-frog stood still for a long time lost in thought; it was
+believed at last he would not jump at all.
+
+“I only hope he is not unwell,” said the house-dog; when, pop! he made a
+jump all on one side into the lap of the Princess, who was sitting on a
+little golden stool close by.
+
+Hereupon the King said, “There is nothing above my daughter; therefore
+to bound up to her is the highest jump that can be made; but for this,
+one must possess understanding, and the Leap-frog has shown that he has
+understanding. He is brave and intellectual.”
+
+And so he won the Princess.
+
+“It’s all the same to me,” said the Flea. “She may have the old
+Leap-frog, for all I care. I jumped the highest; but in this world
+merit seldom meets its reward. A fine exterior is what people look at
+now-a-days.”
+
+The Flea then went into foreign service, where, it is said, he was
+killed.
+
+The Grasshopper sat without on a green bank, and reflected on worldly
+things; and he said too, “Yes, a fine exterior is everything--a fine
+exterior is what people care about.” And then he began chirping his
+peculiar melancholy song, from which we have taken this history; and
+which may, very possibly, be all untrue, although it does stand here
+printed in black and white.
+
+
+
+
+THE ELDERBUSH
+
+Once upon a time there was a little boy who had taken cold. He had
+gone out and got his feet wet; though nobody could imagine how it had
+happened, for it was quite dry weather. So his mother undressed him, put
+him to bed, and had the tea-pot brought in, to make him a good cup of
+Elderflower tea. Just at that moment the merry old man came in who
+lived up a-top of the house all alone; for he had neither wife nor
+children--but he liked children very much, and knew so many fairy tales,
+that it was quite delightful.
+
+“Now drink your tea,” said the boy’s mother; “then, perhaps, you may
+hear a fairy tale.”
+
+“If I had but something new to tell,” said the old man. “But how did the
+child get his feet wet?”
+
+“That is the very thing that nobody can make out,” said his mother.
+
+“Am I to hear a fairy tale?” asked the little boy.
+
+“Yes, if you can tell me exactly--for I must know that first--how deep
+the gutter is in the little street opposite, that you pass through in
+going to school.”
+
+“Just up to the middle of my boot,” said the child; “but then I must go
+into the deep hole.”
+
+“Ah, ah! That’s where the wet feet came from,” said the old man. “I
+ought now to tell you a story; but I don’t know any more.”
+
+“You can make one in a moment,” said the little boy. “My mother says
+that all you look at can be turned into a fairy tale: and that you can
+find a story in everything.”
+
+“Yes, but such tales and stories are good for nothing. The right sort
+come of themselves; they tap at my forehead and say, ‘Here we are.’”
+
+“Won’t there be a tap soon?” asked the little boy. And his mother
+laughed, put some Elder-flowers in the tea-pot, and poured boiling water
+upon them.
+
+“Do tell me something! Pray do!”
+
+“Yes, if a fairy tale would come of its own accord; but they are proud
+and haughty, and come only when they choose. Stop!” said he, all on a
+sudden. “I have it! Pay attention! There is one in the tea-pot!”
+
+And the little boy looked at the tea-pot. The cover rose more and more;
+and the Elder-flowers came forth so fresh and white, and shot up long
+branches. Out of the spout even did they spread themselves on all sides,
+and grew larger and larger; it was a splendid Elderbush, a whole tree;
+and it reached into the very bed, and pushed the curtains aside. How
+it bloomed! And what an odour! In the middle of the bush sat a
+friendly-looking old woman in a most strange dress. It was quite
+green, like the leaves of the elder, and was trimmed with large white
+Elder-flowers; so that at first one could not tell whether it was a
+stuff, or a natural green and real flowers.
+
+“What’s that woman’s name?” asked the little boy.
+
+“The Greeks and Romans,” said the old man, “called her a Dryad; but that
+we do not understand. The people who live in the New Booths [*] have a much
+better name for her; they call her ‘old Granny’--and she it is to
+whom you are to pay attention. Now listen, and look at the beautiful
+Elderbush.
+
+     * A row of buildings for seamen in Copenhagen.
+
+“Just such another large blooming Elder Tree stands near the New Booths.
+It grew there in the corner of a little miserable court-yard; and under
+it sat, of an afternoon, in the most splendid sunshine, two old
+people; an old, old seaman, and his old, old wife. They had
+great-grand-children, and were soon to celebrate the fiftieth
+anniversary of their marriage; but they could not exactly recollect the
+date: and old Granny sat in the tree, and looked as pleased as now. ‘I
+know the date,’ said she; but those below did not hear her, for they
+were talking about old times.
+
+“‘Yes, can’t you remember when we were very little,’ said the old
+seaman, ‘and ran and played about? It was the very same court-yard where
+we now are, and we stuck slips in the ground, and made a garden.’
+
+“‘I remember it well,’ said the old woman; ‘I remember it quite well. We
+watered the slips, and one of them was an Elderbush. It took root, put
+forth green shoots, and grew up to be the large tree under which we old
+folks are now sitting.’
+
+“‘To be sure,’ said he. ‘And there in the corner stood a waterpail,
+where I used to swim my boats.’
+
+“‘True; but first we went to school to learn somewhat,’ said she; ‘and
+then we were confirmed. We both cried; but in the afternoon we went up
+the Round Tower, and looked down on Copenhagen, and far, far away over
+the water; then we went to Friedericksberg, where the King and the Queen
+were sailing about in their splendid barges.’
+
+“‘But I had a different sort of sailing to that, later; and that, too,
+for many a year; a long way off, on great voyages.’
+
+“‘Yes, many a time have I wept for your sake,’ said she. ‘I thought you
+were dead and gone, and lying down in the deep waters. Many a night have
+I got up to see if the wind had not changed: and changed it had, sure
+enough; but you never came. I remember so well one day, when the rain
+was pouring down in torrents, the scavengers were before the house where
+I was in service, and I had come up with the dust, and remained standing
+at the door--it was dreadful weather--when just as I was there, the
+postman came and gave me a letter. It was from you! What a tour that
+letter had made! I opened it instantly and read: I laughed and wept.
+I was so happy. In it I read that you were in warm lands where the
+coffee-tree grows. What a blessed land that must be! You related so
+much, and I saw it all the while the rain was pouring down, and I
+standing there with the dust-box. At the same moment came someone who
+embraced me.’
+
+“‘Yes; but you gave him a good box on his ear that made it tingle!’
+
+“‘But I did not know it was you. You arrived as soon as your letter,
+and you were so handsome--that you still are--and had a long yellow silk
+handkerchief round your neck, and a bran new hat on; oh, you were so
+dashing! Good heavens! What weather it was, and what a state the street
+was in!’
+
+“‘And then we married,’ said he. ‘Don’t you remember? And then we
+had our first little boy, and then Mary, and Nicholas, and Peter, and
+Christian.’
+
+“‘Yes, and how they all grew up to be honest people, and were beloved by
+everybody.’
+
+“‘And their children also have children,’ said the old sailor; ‘yes,
+those are our grand-children, full of strength and vigor. It was,
+methinks about this season that we had our wedding.’
+
+“‘Yes, this very day is the fiftieth anniversary of the marriage,’ said
+old Granny, sticking her head between the two old people; who thought
+it was their neighbor who nodded to them. They looked at each other and
+held one another by the hand. Soon after came their children, and their
+grand-children; for they knew well enough that it was the day of the
+fiftieth anniversary, and had come with their gratulations that very
+morning; but the old people had forgotten it, although they were able
+to remember all that had happened many years ago. And the Elderbush sent
+forth a strong odour in the sun, that was just about to set, and shone
+right in the old people’s faces. They both looked so rosy-cheeked; and
+the youngest of the grandchildren danced around them, and called out
+quite delighted, that there was to be something very splendid that
+evening--they were all to have hot potatoes. And old Nanny nodded in the
+bush, and shouted ‘hurrah!’ with the rest.”
+
+“But that is no fairy tale,” said the little boy, who was listening to
+the story.
+
+“The thing is, you must understand it,” said the narrator; “let us ask
+old Nanny.”
+
+“That was no fairy tale, ‘tis true,” said old Nanny; “but now it’s
+coming. The most wonderful fairy tales grow out of that which is
+reality; were that not the case, you know, my magnificent Elderbush
+could not have grown out of the tea-pot.” And then she took the little
+boy out of bed, laid him on her bosom, and the branches of the Elder
+Tree, full of flowers, closed around her. They sat in an aerial
+dwelling, and it flew with them through the air. Oh, it was wondrous
+beautiful! Old Nanny had grown all of a sudden a young and pretty
+maiden; but her robe was still the same green stuff with white flowers,
+which she had worn before. On her bosom she had a real Elderflower,
+and in her yellow waving hair a wreath of the flowers; her eyes were so
+large and blue that it was a pleasure to look at them; she kissed the
+boy, and now they were of the same age and felt alike.
+
+Hand in hand they went out of the bower, and they were standing in the
+beautiful garden of their home. Near the green lawn papa’s walking-stick
+was tied, and for the little ones it seemed to be endowed with life; for
+as soon as they got astride it, the round polished knob was turned into
+a magnificent neighing head, a long black mane fluttered in the breeze,
+and four slender yet strong legs shot out. The animal was strong and
+handsome, and away they went at full gallop round the lawn.
+
+“Huzza! Now we are riding miles off,” said the boy. “We are riding away
+to the castle where we were last year!”
+
+And on they rode round the grass-plot; and the little maiden, who, we
+know, was no one else but old Nanny, kept on crying out, “Now we are in
+the country! Don’t you see the farm-house yonder? And there is an Elder
+Tree standing beside it; and the cock is scraping away the earth for the
+hens, look, how he struts! And now we are close to the church. It lies
+high upon the hill, between the large oak-trees, one of which is half
+decayed. And now we are by the smithy, where the fire is blazing, and
+where the half-naked men are banging with their hammers till the sparks
+fly about. Away! away! To the beautiful country-seat!”
+
+And all that the little maiden, who sat behind on the stick, spoke of,
+flew by in reality. The boy saw it all, and yet they were only going
+round the grass-plot. Then they played in a side avenue, and marked out
+a little garden on the earth; and they took Elder-blossoms from their
+hair, planted them, and they grew just like those the old people planted
+when they were children, as related before. They went hand in hand, as
+the old people had done when they were children; but not to the Round
+Tower, or to Friedericksberg; no, the little damsel wound her arms round
+the boy, and then they flew far away through all Denmark. And spring
+came, and summer; and then it was autumn, and then winter; and a
+thousand pictures were reflected in the eye and in the heart of the boy;
+and the little girl always sang to him, “This you will never forget.”
+ And during their whole flight the Elder Tree smelt so sweet and odorous;
+he remarked the roses and the fresh beeches, but the Elder Tree had
+a more wondrous fragrance, for its flowers hung on the breast of the
+little maiden; and there, too, did he often lay his head during the
+flight.
+
+“It is lovely here in spring!” said the young maiden. And they stood in
+a beech-wood that had just put on its first green, where the woodroof [*]
+at their feet sent forth its fragrance, and the pale-red anemony looked
+so pretty among the verdure. “Oh, would it were always spring in the
+sweetly-smelling Danish beech-forests!”
+
+     * Asperula odorata.
+
+“It is lovely here in summer!” said she. And she flew past old castles
+of by-gone days of chivalry, where the red walls and the embattled
+gables were mirrored in the canal, where the swans were swimming, and
+peered up into the old cool avenues. In the fields the corn was waving
+like the sea; in the ditches red and yellow flowers were growing; while
+wild-drone flowers, and blooming convolvuluses were creeping in the
+hedges; and towards evening the moon rose round and large, and the
+haycocks in the meadows smelt so sweetly. “This one never forgets!”
+
+“It is lovely here in autumn!” said the little maiden. And suddenly the
+atmosphere grew as blue again as before; the forest grew red, and green,
+and yellow-colored. The dogs came leaping along, and whole flocks of
+wild-fowl flew over the cairn, where blackberry-bushes were hanging
+round the old stones. The sea was dark blue, covered with ships full
+of white sails; and in the barn old women, maidens, and children were
+sitting picking hops into a large cask; the young sang songs, but the
+old told fairy tales of mountain-sprites and soothsayers. Nothing could
+be more charming.
+
+“It is delightful here in winter!” said the little maiden. And all the
+trees were covered with hoar-frost; they looked like white corals; the
+snow crackled under foot, as if one had new boots on; and one falling
+star after the other was seen in the sky. The Christmas-tree was lighted
+in the room; presents were there, and good-humor reigned. In the country
+the violin sounded in the room of the peasant; the newly-baked cakes
+were attacked; even the poorest child said, “It is really delightful
+here in winter!”
+
+Yes, it was delightful; and the little maiden showed the boy everything;
+and the Elder Tree still was fragrant, and the red flag, with the white
+cross, was still waving: the flag under which the old seaman in the New
+Booths had sailed. And the boy grew up to be a lad, and was to go forth
+in the wide world-far, far away to warm lands, where the coffee-tree
+grows; but at his departure the little maiden took an Elder-blossom from
+her bosom, and gave it him to keep; and it was placed between the leaves
+of his Prayer-Book; and when in foreign lands he opened the book, it
+was always at the place where the keepsake-flower lay; and the more he
+looked at it, the fresher it became; he felt as it were, the fragrance
+of the Danish groves; and from among the leaves of the flowers he could
+distinctly see the little maiden, peeping forth with her bright blue
+eyes--and then she whispered, “It is delightful here in Spring, Summer,
+Autumn, and Winter”; and a hundred visions glided before his mind.
+
+Thus passed many years, and he was now an old man, and sat with his old
+wife under the blooming tree. They held each other by the hand, as the
+old grand-father and grand-mother yonder in the New Booths did, and they
+talked exactly like them of old times, and of the fiftieth anniversary
+of their wedding. The little maiden, with the blue eyes, and with
+Elder-blossoms in her hair, sat in the tree, nodded to both of them,
+and said, “To-day is the fiftieth anniversary!” And then she took two
+flowers out of her hair, and kissed them. First, they shone like silver,
+then like gold; and when they laid them on the heads of the old people,
+each flower became a golden crown. So there they both sat, like a king
+and a queen, under the fragrant tree, that looked exactly like an elder:
+the old man told his wife the story of “Old Nanny,” as it had been told
+him when a boy. And it seemed to both of them it contained much that
+resembled their own history; and those parts that were like it pleased
+them best.
+
+“Thus it is,” said the little maiden in the tree, “some call me ‘Old
+Nanny,’ others a ‘Dryad,’ but, in reality, my name is ‘Remembrance’;
+‘tis I who sit in the tree that grows and grows! I can remember; I can
+tell things! Let me see if you have my flower still?”
+
+And the old man opened his Prayer-Book. There lay the Elder-blossom,
+as fresh as if it had been placed there but a short time before; and
+Remembrance nodded, and the old people, decked with crowns of gold, sat
+in the flush of the evening sun. They closed their eyes, and--and--!
+Yes, that’s the end of the story!
+
+The little boy lay in his bed; he did not know if he had dreamed or
+not, or if he had been listening while someone told him the story. The
+tea-pot was standing on the table, but no Elder Tree was growing out
+of it! And the old man, who had been talking, was just on the point of
+going out at the door, and he did go.
+
+“How splendid that was!” said the little boy. “Mother, I have been to
+warm countries.”
+
+“So I should think,” said his mother. “When one has drunk two good
+cupfuls of Elder-flower tea, ‘tis likely enough one goes into warm
+climates”; and she tucked him up nicely, least he should take cold. “You
+have had a good sleep while I have been sitting here, and arguing with
+him whether it was a story or a fairy tale.”
+
+“And where is old Nanny?” asked the little boy.
+
+“In the tea-pot,” said his mother; “and there she may remain.”
+
+
+
+
+THE BELL
+
+People said “The Evening Bell is sounding, the sun is setting.” For a
+strange wondrous tone was heard in the narrow streets of a large town.
+It was like the sound of a church-bell: but it was only heard for a
+moment, for the rolling of the carriages and the voices of the multitude
+made too great a noise.
+
+Those persons who were walking outside the town, where the houses were
+farther apart, with gardens or little fields between them, could see
+the evening sky still better, and heard the sound of the bell much
+more distinctly. It was as if the tones came from a church in the still
+forest; people looked thitherward, and felt their minds attuned most
+solemnly.
+
+A long time passed, and people said to each other--“I wonder if there
+is a church out in the wood? The bell has a tone that is wondrous sweet;
+let us stroll thither, and examine the matter nearer.” And the rich
+people drove out, and the poor walked, but the way seemed strangely
+long to them; and when they came to a clump of willows which grew on the
+skirts of the forest, they sat down, and looked up at the long
+branches, and fancied they were now in the depth of the green wood. The
+confectioner of the town came out, and set up his booth there; and soon
+after came another confectioner, who hung a bell over his stand, as
+a sign or ornament, but it had no clapper, and it was tarred over to
+preserve it from the rain. When all the people returned home, they said
+it had been very romantic, and that it was quite a different sort of
+thing to a pic-nic or tea-party. There were three persons who asserted
+they had penetrated to the end of the forest, and that they had always
+heard the wonderful sounds of the bell, but it had seemed to them as if
+it had come from the town. One wrote a whole poem about it, and said the
+bell sounded like the voice of a mother to a good dear child, and
+that no melody was sweeter than the tones of the bell. The king of the
+country was also observant of it, and vowed that he who could discover
+whence the sounds proceeded, should have the title of “Universal
+Bell-ringer,” even if it were not really a bell.
+
+Many persons now went to the wood, for the sake of getting the place,
+but one only returned with a sort of explanation; for nobody went far
+enough, that one not further than the others. However, he said that
+the sound proceeded from a very large owl, in a hollow tree; a sort of
+learned owl, that continually knocked its head against the branches. But
+whether the sound came from his head or from the hollow tree, that no
+one could say with certainty. So now he got the place of “Universal
+Bell-ringer,” and wrote yearly a short treatise “On the Owl”; but
+everybody was just as wise as before.
+
+It was the day of confirmation. The clergyman had spoken so touchingly,
+the children who were confirmed had been greatly moved; it was
+an eventful day for them; from children they become all at once
+grown-up-persons; it was as if their infant souls were now to fly all
+at once into persons with more understanding. The sun was shining
+gloriously; the children that had been confirmed went out of the town;
+and from the wood was borne towards them the sounds of the unknown bell
+with wonderful distinctness. They all immediately felt a wish to go
+thither; all except three. One of them had to go home to try on a
+ball-dress; for it was just the dress and the ball which had caused her
+to be confirmed this time, for otherwise she would not have come;
+the other was a poor boy, who had borrowed his coat and boots to be
+confirmed in from the innkeeper’s son, and he was to give them back by
+a certain hour; the third said that he never went to a strange place
+if his parents were not with him--that he had always been a good boy
+hitherto, and would still be so now that he was confirmed, and that one
+ought not to laugh at him for it: the others, however, did make fun of
+him, after all.
+
+There were three, therefore, that did not go; the others hastened on.
+The sun shone, the birds sang, and the children sang too, and each held
+the other by the hand; for as yet they had none of them any high office,
+and were all of equal rank in the eye of God.
+
+But two of the youngest soon grew tired, and both returned to town; two
+little girls sat down, and twined garlands, so they did not go either;
+and when the others reached the willow-tree, where the confectioner was,
+they said, “Now we are there! In reality the bell does not exist; it is
+only a fancy that people have taken into their heads!”
+
+At the same moment the bell sounded deep in the wood, so clear and
+solemnly that five or six determined to penetrate somewhat further. It
+was so thick, and the foliage so dense, that it was quite fatiguing
+to proceed. Woodroof and anemonies grew almost too high; blooming
+convolvuluses and blackberry-bushes hung in long garlands from tree to
+tree, where the nightingale sang and the sunbeams were playing: it was
+very beautiful, but it was no place for girls to go; their clothes would
+get so torn. Large blocks of stone lay there, overgrown with moss of
+every color; the fresh spring bubbled forth, and made a strange gurgling
+sound.
+
+“That surely cannot be the bell,” said one of the children, lying down
+and listening. “This must be looked to.” So he remained, and let the
+others go on without him.
+
+They afterwards came to a little house, made of branches and the bark of
+trees; a large wild apple-tree bent over it, as if it would shower down
+all its blessings on the roof, where roses were blooming. The long stems
+twined round the gable, on which there hung a small bell.
+
+Was it that which people had heard? Yes, everybody was unanimous on the
+subject, except one, who said that the bell was too small and too fine
+to be heard at so great a distance, and besides it was very different
+tones to those that could move a human heart in such a manner. It was a
+king’s son who spoke; whereon the others said, “Such people always want
+to be wiser than everybody else.”
+
+They now let him go on alone; and as he went, his breast was filled more
+and more with the forest solitude; but he still heard the little bell
+with which the others were so satisfied, and now and then, when the
+wind blew, he could also hear the people singing who were sitting at tea
+where the confectioner had his tent; but the deep sound of the bell rose
+louder; it was almost as if an organ were accompanying it, and the tones
+came from the left hand, the side where the heart is placed. A rustling
+was heard in the bushes, and a little boy stood before the King’s Son, a
+boy in wooden shoes, and with so short a jacket that one could see what
+long wrists he had. Both knew each other: the boy was that one among
+the children who could not come because he had to go home and return his
+jacket and boots to the innkeeper’s son. This he had done, and was now
+going on in wooden shoes and in his humble dress, for the bell sounded
+with so deep a tone, and with such strange power, that proceed he must.
+
+“Why, then, we can go together,” said the King’s Son. But the poor
+child that had been confirmed was quite ashamed; he looked at his wooden
+shoes, pulled at the short sleeves of his jacket, and said that he was
+afraid he could not walk so fast; besides, he thought that the bell must
+be looked for to the right; for that was the place where all sorts of
+beautiful things were to be found.
+
+“But there we shall not meet,” said the King’s Son, nodding at the same
+time to the poor boy, who went into the darkest, thickest part of the
+wood, where thorns tore his humble dress, and scratched his face and
+hands and feet till they bled. The King’s Son got some scratches too;
+but the sun shone on his path, and it is him that we will follow, for he
+was an excellent and resolute youth.
+
+“I must and will find the bell,” said he, “even if I am obliged to go to
+the end of the world.”
+
+The ugly apes sat upon the trees, and grinned. “Shall we thrash him?”
+ said they. “Shall we thrash him? He is the son of a king!”
+
+But on he went, without being disheartened, deeper and deeper into the
+wood, where the most wonderful flowers were growing. There stood white
+lilies with blood-red stamina, skyblue tulips, which shone as they waved
+in the winds, and apple-trees, the apples of which looked exactly like
+large soapbubbles: so only think how the trees must have sparkled in the
+sunshine! Around the nicest green meads, where the deer were playing in
+the grass, grew magnificent oaks and beeches; and if the bark of one of
+the trees was cracked, there grass and long creeping plants grew in
+the crevices. And there were large calm lakes there too, in which white
+swans were swimming, and beat the air with their wings. The King’s Son
+often stood still and listened. He thought the bell sounded from the
+depths of these still lakes; but then he remarked again that the tone
+proceeded not from there, but farther off, from out the depths of the
+forest.
+
+The sun now set: the atmosphere glowed like fire. It was still in the
+woods, so very still; and he fell on his knees, sung his evening hymn,
+and said: “I cannot find what I seek; the sun is going down, and night
+is coming--the dark, dark night. Yet perhaps I may be able once more
+to see the round red sun before he entirely disappears. I will climb up
+yonder rock.”
+
+And he seized hold of the creeping-plants, and the roots of
+trees--climbed up the moist stones where the water-snakes were writhing
+and the toads were croaking--and he gained the summit before the sun
+had quite gone down. How magnificent was the sight from this height! The
+sea--the great, the glorious sea, that dashed its long waves against the
+coast--was stretched out before him. And yonder, where sea and sky meet,
+stood the sun, like a large shining altar, all melted together in the
+most glowing colors. And the wood and the sea sang a song of rejoicing,
+and his heart sang with the rest: all nature was a vast holy church,
+in which the trees and the buoyant clouds were the pillars, flowers and
+grass the velvet carpeting, and heaven itself the large cupola. The red
+colors above faded away as the sun vanished, but a million stars were
+lighted, a million lamps shone; and the King’s Son spread out his arms
+towards heaven, and wood, and sea; when at the same moment, coming by
+a path to the right, appeared, in his wooden shoes and jacket, the poor
+boy who had been confirmed with him. He had followed his own path, and
+had reached the spot just as soon as the son of the king had done. They
+ran towards each other, and stood together hand in hand in the vast
+church of nature and of poetry, while over them sounded the invisible
+holy bell: blessed spirits floated around them, and lifted up their
+voices in a rejoicing hallelujah!
+
+
+
+
+THE OLD HOUSE
+
+In the street, up there, was an old, a very old house--it was almost
+three hundred years old, for that might be known by reading the great
+beam on which the date of the year was carved: together with tulips and
+hop-binds there were whole verses spelled as in former times, and over
+every window was a distorted face cut out in the beam. The one story
+stood forward a great way over the other; and directly under the eaves
+was a leaden spout with a dragon’s head; the rain-water should have run
+out of the mouth, but it ran out of the belly, for there was a hole in
+the spout.
+
+All the other houses in the street were so new and so neat, with large
+window panes and smooth walls, one could easily see that they would have
+nothing to do with the old house: they certainly thought, “How long is
+that old decayed thing to stand here as a spectacle in the street? And
+then the projecting windows stand so far out, that no one can see from
+our windows what happens in that direction! The steps are as broad as
+those of a palace, and as high as to a church tower. The iron railings
+look just like the door to an old family vault, and then they have brass
+tops--that’s so stupid!”
+
+On the other side of the street were also new and neat houses, and they
+thought just as the others did; but at the window opposite the old house
+there sat a little boy with fresh rosy cheeks and bright beaming eyes:
+he certainly liked the old house best, and that both in sunshine and
+moonshine. And when he looked across at the wall where the mortar
+had fallen out, he could sit and find out there the strangest figures
+imaginable; exactly as the street had appeared before, with steps,
+projecting windows, and pointed gables; he could see soldiers with
+halberds, and spouts where the water ran, like dragons and serpents.
+That was a house to look at; and there lived an old man, who wore plush
+breeches; and he had a coat with large brass buttons, and a wig that one
+could see was a real wig. Every morning there came an old fellow to him
+who put his rooms in order, and went on errands; otherwise, the old man
+in the plush breeches was quite alone in the old house. Now and then he
+came to the window and looked out, and the little boy nodded to him,
+and the old man nodded again, and so they became acquaintances, and then
+they were friends, although they had never spoken to each other--but
+that made no difference. The little boy heard his parents say, “The old
+man opposite is very well off, but he is so very, very lonely!”
+
+The Sunday following, the little boy took something, and wrapped it up
+in a piece of paper, went downstairs, and stood in the doorway; and when
+the man who went on errands came past, he said to him--
+
+“I say, master! will you give this to the old man over the way from me?
+I have two pewter soldiers--this is one of them, and he shall have it,
+for I know he is so very, very lonely.”
+
+And the old errand man looked quite pleased, nodded, and took the pewter
+soldier over to the old house. Afterwards there came a message; it was
+to ask if the little boy himself had not a wish to come over and pay a
+visit; and so he got permission of his parents, and then went over to
+the old house.
+
+And the brass balls on the iron railings shone much brighter than ever;
+one would have thought they were polished on account of the visit; and
+it was as if the carved-out trumpeters--for there were trumpeters, who
+stood in tulips, carved out on the door--blew with all their
+might, their cheeks appeared so much rounder than before. Yes, they
+blew--“Trateratra! The little boy comes! Trateratra!”--and then the door
+opened.
+
+The whole passage was hung with portraits of knights in armor, and
+ladies in silken gowns; and the armor rattled, and the silken gowns
+rustled! And then there was a flight of stairs which went a good way
+upwards, and a little way downwards, and then one came on a balcony
+which was in a very dilapidated state, sure enough, with large holes and
+long crevices, but grass grew there and leaves out of them altogether,
+for the whole balcony outside, the yard, and the walls, were overgrown
+with so much green stuff, that it looked like a garden; only a balcony.
+Here stood old flower-pots with faces and asses’ ears, and the flowers
+grew just as they liked. One of the pots was quite overrun on all sides
+with pinks, that is to say, with the green part; shoot stood by shoot,
+and it said quite distinctly, “The air has cherished me, the sun has
+kissed me, and promised me a little flower on Sunday! a little flower on
+Sunday!”
+
+And then they entered a chamber where the walls were covered with hog’s
+leather, and printed with gold flowers.
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+said the walls.
+
+And there stood easy-chairs, with such high backs, and so carved out,
+and with arms on both sides. “Sit down! sit down!” said they. “Ugh! how
+I creak; now I shall certainly get the gout, like the old clothespress,
+ugh!”
+
+And then the little boy came into the room where the projecting windows
+were, and where the old man sat.
+
+“I thank you for the pewter soldier, my little friend!” said the old
+man. “And I thank you because you come over to me.”
+
+“Thankee! thankee!” or “cranky! cranky!” sounded from all the furniture;
+there was so much of it, that each article stood in the other’s way, to
+get a look at the little boy.
+
+In the middle of the wall hung a picture representing a beautiful lady,
+so young, so glad, but dressed quite as in former times, with clothes
+that stood quite stiff, and with powder in her hair; she neither said
+“thankee, thankee!” nor “cranky, cranky!” but looked with her mild eyes
+at the little boy, who directly asked the old man, “Where did you get
+her?”
+
+“Yonder, at the broker’s,” said the old man, “where there are so many
+pictures hanging. No one knows or cares about them, for they are all of
+them buried; but I knew her in by-gone days, and now she has been dead
+and gone these fifty years!”
+
+Under the picture, in a glazed frame, there hung a bouquet of withered
+flowers; they were almost fifty years old; they looked so very old!
+
+The pendulum of the great clock went to and fro, and the hands turned,
+and everything in the room became still older; but they did not observe
+it.
+
+“They say at home,” said the little boy, “that you are so very, very
+lonely!”
+
+“Oh!” said he. “The old thoughts, with what they may bring with them,
+come and visit me, and now you also come! I am very well off!”
+
+Then he took a book with pictures in it down from the shelf; there were
+whole long processions and pageants, with the strangest characters,
+which one never sees now-a-days; soldiers like the knave of clubs,
+and citizens with waving flags: the tailors had theirs, with a pair of
+shears held by two lions--and the shoemakers theirs, without boots,
+but with an eagle that had two heads, for the shoemakers must have
+everything so that they can say, it is a pair! Yes, that was a picture
+book!
+
+The old man now went into the other room to fetch preserves, apples, and
+nuts--yes, it was delightful over there in the old house.
+
+“I cannot bear it any longer!” said the pewter soldier, who sat on the
+drawers. “It is so lonely and melancholy here! But when one has been in
+a family circle one cannot accustom oneself to this life! I cannot bear
+it any longer! The whole day is so long, and the evenings are still
+longer! Here it is not at all as it is over the way at your home, where
+your father and mother spoke so pleasantly, and where you and all your
+sweet children made such a delightful noise. Nay, how lonely the old man
+is--do you think that he gets kisses? Do you think he gets mild eyes,
+or a Christmas tree? He will get nothing but a grave! I can bear it no
+longer!”
+
+“You must not let it grieve you so much,” said the little boy. “I find
+it so very delightful here, and then all the old thoughts, with what
+they may bring with them, they come and visit here.”
+
+“Yes, it’s all very well, but I see nothing of them, and I don’t know
+them!” said the pewter soldier. “I cannot bear it!”
+
+“But you must!” said the little boy.
+
+Then in came the old man with the most pleased and happy face, the most
+delicious preserves, apples, and nuts, and so the little boy thought no
+more about the pewter soldier.
+
+The little boy returned home happy and pleased, and weeks and days
+passed away, and nods were made to the old house, and from the old
+house, and then the little boy went over there again.
+
+The carved trumpeters blew, “Trateratra! There is the little boy!
+Trateratra!” and the swords and armor on the knights’ portraits rattled,
+and the silk gowns rustled; the hog’s leather spoke, and the old chairs
+had the gout in their legs and rheumatism in their backs: Ugh! it was
+exactly like the first time, for over there one day and hour was just
+like another.
+
+“I cannot bear it!” said the pewter soldier. “I have shed pewter tears!
+It is too melancholy! Rather let me go to the wars and lose arms and
+legs! It would at least be a change. I cannot bear it longer! Now, I
+know what it is to have a visit from one’s old thoughts, with what they
+may bring with them! I have had a visit from mine, and you may be sure
+it is no pleasant thing in the end; I was at last about to jump down
+from the drawers.
+
+“I saw you all over there at home so distinctly, as if you really were
+here; it was again that Sunday morning; all you children stood before
+the table and sung your Psalms, as you do every morning. You stood
+devoutly with folded hands; and father and mother were just as pious;
+and then the door was opened, and little sister Mary, who is not two
+years old yet, and who always dances when she hears music or singing, of
+whatever kind it may be, was put into the room--though she ought not to
+have been there--and then she began to dance, but could not keep time,
+because the tones were so long; and then she stood, first on the one
+leg, and bent her head forwards, and then on the other leg, and bent
+her head forwards--but all would not do. You stood very seriously all
+together, although it was difficult enough; but I laughed to myself, and
+then I fell off the table, and got a bump, which I have still--for it
+was not right of me to laugh. But the whole now passes before me again
+in thought, and everything that I have lived to see; and these are the
+old thoughts, with what they may bring with them.
+
+“Tell me if you still sing on Sundays? Tell me something about little
+Mary! And how my comrade, the other pewter soldier, lives! Yes, he is
+happy enough, that’s sure! I cannot bear it any longer!”
+
+“You are given away as a present!” said the little boy. “You must
+remain. Can you not understand that?”
+
+The old man now came with a drawer, in which there was much to be seen,
+both “tin boxes” and “balsam boxes,” old cards, so large and so gilded,
+such as one never sees them now. And several drawers were opened, and
+the piano was opened; it had landscapes on the inside of the lid, and it
+was so hoarse when the old man played on it! and then he hummed a song.
+
+“Yes, she could sing that!” said he, and nodded to the portrait, which
+he had bought at the broker’s, and the old man’s eyes shone so bright!
+
+“I will go to the wars! I will go to the wars!” shouted the pewter
+soldier as loud as he could, and threw himself off the drawers right
+down on the floor. What became of him? The old man sought, and the
+little boy sought; he was away, and he stayed away.
+
+“I shall find him!” said the old man; but he never found him. The floor
+was too open--the pewter soldier had fallen through a crevice, and there
+he lay as in an open tomb.
+
+That day passed, and the little boy went home, and that week passed,
+and several weeks too. The windows were quite frozen, the little boy was
+obliged to sit and breathe on them to get a peep-hole over to the old
+house, and there the snow had been blown into all the carved work and
+inscriptions; it lay quite up over the steps, just as if there was no
+one at home--nor was there any one at home--the old man was dead!
+
+In the evening there was a hearse seen before the door, and he was borne
+into it in his coffin: he was now to go out into the country, to lie in
+his grave. He was driven out there, but no one followed; all his friends
+were dead, and the little boy kissed his hand to the coffin as it was
+driven away.
+
+Some days afterwards there was an auction at the old house, and the
+little boy saw from his window how they carried the old knights and the
+old ladies away, the flower-pots with the long ears, the old chairs, and
+the old clothes-presses. Something came here, and something came there;
+the portrait of her who had been found at the broker’s came to the
+broker’s again; and there it hung, for no one knew her more--no one
+cared about the old picture.
+
+In the spring they pulled the house down, for, as people said, it was
+a ruin. One could see from the street right into the room with the
+hog’s-leather hanging, which was slashed and torn; and the green grass
+and leaves about the balcony hung quite wild about the falling beams.
+And then it was put to rights.
+
+“That was a relief,” said the neighboring houses.
+
+A fine house was built there, with large windows, and smooth white
+walls; but before it, where the old house had in fact stood, was a
+little garden laid out, and a wild grapevine ran up the wall of the
+neighboring house. Before the garden there was a large iron railing
+with an iron door, it looked quite splendid, and people stood still and
+peeped in, and the sparrows hung by scores in the vine, and chattered
+away at each other as well as they could, but it was not about the old
+house, for they could not remember it, so many years had passed--so many
+that the little boy had grown up to a whole man, yes, a clever man, and
+a pleasure to his parents; and he had just been married, and, together
+with his little wife, had come to live in the house here, where the
+garden was; and he stood by her there whilst she planted a field-flower
+that she found so pretty; she planted it with her little hand, and
+pressed the earth around it with her fingers. Oh! what was that? She
+had stuck herself. There sat something pointed, straight out of the soft
+mould.
+
+It was--yes, guess! It was the pewter soldier, he that was lost up at
+the old man’s, and had tumbled and turned about amongst the timber and
+the rubbish, and had at last laid for many years in the ground.
+
+The young wife wiped the dirt off the soldier, first with a green leaf,
+and then with her fine handkerchief--it had such a delightful smell,
+that it was to the pewter soldier just as if he had awaked from a
+trance.
+
+“Let me see him,” said the young man. He laughed, and then shook his
+head. “Nay, it cannot be he; but he reminds me of a story about a pewter
+soldier which I had when I was a little boy!” And then he told his wife
+about the old house, and the old man, and about the pewter soldier that
+he sent over to him because he was so very, very lonely; and he told it
+as correctly as it had really been, so that the tears came into the eyes
+of his young wife, on account of the old house and the old man.
+
+“It may possibly be, however, that it is the same pewter soldier!” said
+she. “I will take care of it, and remember all that you have told me;
+but you must show me the old man’s grave!”
+
+“But I do not know it,” said he, “and no one knows it! All his friends
+were dead, no one took care of it, and I was then a little boy!”
+
+“How very, very lonely he must have been!” said she.
+
+“Very, very lonely!” said the pewter soldier. “But it is delightful not
+to be forgotten!”
+
+“Delightful!” shouted something close by; but no one, except the pewter
+soldier, saw that it was a piece of the hog’s-leather hangings; it had
+lost all its gilding, it looked like a piece of wet clay, but it had an
+opinion, and it gave it:
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+This the pewter soldier did not believe.
+
+
+
+
+THE HAPPY FAMILY
+
+Really, the largest green leaf in this country is a dock-leaf; if one
+holds it before one, it is like a whole apron, and if one holds it over
+one’s head in rainy weather, it is almost as good as an umbrella, for
+it is so immensely large. The burdock never grows alone, but where there
+grows one there always grow several: it is a great delight, and all this
+delightfulness is snails’ food. The great white snails which persons of
+quality in former times made fricassees of, ate, and said, “Hem,
+hem! how delicious!” for they thought it tasted so delicate--lived on
+dock-leaves, and therefore burdock seeds were sown.
+
+Now, there was an old manor-house, where they no longer ate snails, they
+were quite extinct; but the burdocks were not extinct, they grew and
+grew all over the walks and all the beds; they could not get the mastery
+over them--it was a whole forest of burdocks. Here and there stood an
+apple and a plum-tree, or else one never would have thought that it was
+a garden; all was burdocks, and there lived the two last venerable old
+snails.
+
+They themselves knew not how old they were, but they could remember
+very well that there had been many more; that they were of a family
+from foreign lands, and that for them and theirs the whole forest was
+planted. They had never been outside it, but they knew that there was
+still something more in the world, which was called the manor-house, and
+that there they were boiled, and then they became black, and were then
+placed on a silver dish; but what happened further they knew not; or, in
+fact, what it was to be boiled, and to lie on a silver dish, they could
+not possibly imagine; but it was said to be delightful, and particularly
+genteel. Neither the chafers, the toads, nor the earth-worms, whom they
+asked about it could give them any information--none of them had been
+boiled or laid on a silver dish.
+
+The old white snails were the first persons of distinction in the
+world, that they knew; the forest was planted for their sake, and the
+manor-house was there that they might be boiled and laid on a silver
+dish.
+
+Now they lived a very lonely and happy life; and as they had no children
+themselves, they had adopted a little common snail, which they brought
+up as their own; but the little one would not grow, for he was of a
+common family; but the old ones, especially Dame Mother Snail, thought
+they could observe how he increased in size, and she begged father,
+if he could not see it, that he would at least feel the little snail’s
+shell; and then he felt it, and found the good dame was right.
+
+One day there was a heavy storm of rain.
+
+“Hear how it beats like a drum on the dock-leaves!” said Father Snail.
+
+“There are also rain-drops!” said Mother Snail. “And now the rain pours
+right down the stalk! You will see that it will be wet here! I am very
+happy to think that we have our good house, and the little one has
+his also! There is more done for us than for all other creatures, sure
+enough; but can you not see that we are folks of quality in the world?
+We are provided with a house from our birth, and the burdock forest is
+planted for our sakes! I should like to know how far it extends, and
+what there is outside!”
+
+“There is nothing at all,” said Father Snail. “No place can be better
+than ours, and I have nothing to wish for!”
+
+“Yes,” said the dame. “I would willingly go to the manorhouse, be
+boiled, and laid on a silver dish; all our forefathers have been treated
+so; there is something extraordinary in it, you may be sure!”
+
+“The manor-house has most likely fallen to ruin!” said Father Snail. “Or
+the burdocks have grown up over it, so that they cannot come out. There
+need not, however, be any haste about that; but you are always in such a
+tremendous hurry, and the little one is beginning to be the same. Has he
+not been creeping up that stalk these three days? It gives me a headache
+when I look up to him!”
+
+“You must not scold him,” said Mother Snail. “He creeps so carefully; he
+will afford us much pleasure--and we have nothing but him to live for!
+But have you not thought of it? Where shall we get a wife for him? Do
+you not think that there are some of our species at a great distance in
+the interior of the burdock forest?”
+
+“Black snails, I dare say, there are enough of,” said the old one.
+“Black snails without a house--but they are so common, and so conceited.
+But we might give the ants a commission to look out for us; they run
+to and fro as if they had something to do, and they certainly know of a
+wife for our little snail!”
+
+“I know one, sure enough--the most charming one!” said one of the ants.
+“But I am afraid we shall hardly succeed, for she is a queen!”
+
+“That is nothing!” said the old folks. “Has she a house?”
+
+“She has a palace!” said the ant. “The finest ant’s palace, with seven
+hundred passages!”
+
+“I thank you!” said Mother Snail. “Our son shall not go into an
+ant-hill; if you know nothing better than that, we shall give the
+commission to the white gnats. They fly far and wide, in rain and
+sunshine; they know the whole forest here, both within and without.”
+
+“We have a wife for him,” said the gnats. “At a hundred human paces from
+here there sits a little snail in her house, on a gooseberry bush; she
+is quite lonely, and old enough to be married. It is only a hundred
+human paces!”
+
+“Well, then, let her come to him!” said the old ones. “He has a whole
+forest of burdocks, she has only a bush!”
+
+And so they went and fetched little Miss Snail. It was a whole week
+before she arrived; but therein was just the very best of it, for one
+could thus see that she was of the same species.
+
+And then the marriage was celebrated. Six earth-worms shone as well as
+they could. In other respects the whole went off very quietly, for the
+old folks could not bear noise and merriment; but old Dame Snail made
+a brilliant speech. Father Snail could not speak, he was too much
+affected; and so they gave them as a dowry and inheritance, the whole
+forest of burdocks, and said--what they had always said--that it was
+the best in the world; and if they lived honestly and decently, and
+increased and multiplied, they and their children would once in the
+course of time come to the manor-house, be boiled black, and laid on
+silver dishes. After this speech was made, the old ones crept into their
+shells, and never more came out. They slept; the young couple governed
+in the forest, and had a numerous progeny, but they were never boiled,
+and never came on the silver dishes; so from this they concluded that
+the manor-house had fallen to ruins, and that all the men in the world
+were extinct; and as no one contradicted them, so, of course it was so.
+And the rain beat on the dock-leaves to make drum-music for their sake,
+and the sun shone in order to give the burdock forest a color for their
+sakes; and they were very happy, and the whole family was happy; for
+they, indeed were so.
+
+
+
+
+THE STORY OF A MOTHER
+
+A mother sat there with her little child. She was so downcast, so
+afraid that it should die! It was so pale, the small eyes had closed
+themselves, and it drew its breath so softly, now and then, with a
+deep respiration, as if it sighed; and the mother looked still more
+sorrowfully on the little creature.
+
+Then a knocking was heard at the door, and in came a poor old man
+wrapped up as in a large horse-cloth, for it warms one, and he needed
+it, as it was the cold winter season! Everything out-of-doors was
+covered with ice and snow, and the wind blew so that it cut the face.
+
+As the old man trembled with cold, and the little child slept a moment,
+the mother went and poured some ale into a pot and set it on the stove,
+that it might be warm for him; the old man sat and rocked the cradle,
+and the mother sat down on a chair close by him, and looked at her
+little sick child that drew its breath so deep, and raised its little
+hand.
+
+“Do you not think that I shall save him?” said she. “Our Lord will not
+take him from me!”
+
+And the old man--it was Death himself--he nodded so strangely, it could
+just as well signify yes as no. And the mother looked down in her lap,
+and the tears ran down over her cheeks; her head became so heavy--she
+had not closed her eyes for three days and nights; and now she slept,
+but only for a minute, when she started up and trembled with cold.
+
+“What is that?” said she, and looked on all sides; but the old man was
+gone, and her little child was gone--he had taken it with him; and the
+old clock in the corner burred, and burred, the great leaden weight ran
+down to the floor, bump! and then the clock also stood still.
+
+But the poor mother ran out of the house and cried aloud for her child.
+
+Out there, in the midst of the snow, there sat a woman in long, black
+clothes; and she said, “Death has been in thy chamber, and I saw him
+hasten away with thy little child; he goes faster than the wind, and he
+never brings back what he takes!”
+
+“Oh, only tell me which way he went!” said the mother. “Tell me the way,
+and I shall find him!”
+
+“I know it!” said the woman in the black clothes. “But before I tell it,
+thou must first sing for me all the songs thou hast sung for thy child!
+I am fond of them. I have heard them before; I am Night; I saw thy tears
+whilst thou sang’st them!”
+
+“I will sing them all, all!” said the mother. “But do not stop me now--I
+may overtake him--I may find my child!”
+
+But Night stood still and mute. Then the mother wrung her hands, sang
+and wept, and there were many songs, but yet many more tears; and then
+Night said, “Go to the right, into the dark pine forest; thither I saw
+Death take his way with thy little child!”
+
+The roads crossed each other in the depths of the forest, and she no
+longer knew whither she should go! then there stood a thorn-bush;
+there was neither leaf nor flower on it, it was also in the cold winter
+season, and ice-flakes hung on the branches.
+
+“Hast thou not seen Death go past with my little child?” said the
+mother.
+
+“Yes,” said the thorn-bush; “but I will not tell thee which way he took,
+unless thou wilt first warm me up at thy heart. I am freezing to death;
+I shall become a lump of ice!”
+
+And she pressed the thorn-bush to her breast, so firmly, that it might
+be thoroughly warmed, and the thorns went right into her flesh, and her
+blood flowed in large drops, but the thornbush shot forth fresh green
+leaves, and there came flowers on it in the cold winter night, the heart
+of the afflicted mother was so warm; and the thorn-bush told her the way
+she should go.
+
+She then came to a large lake, where there was neither ship nor boat.
+The lake was not frozen sufficiently to bear her; neither was it open,
+nor low enough that she could wade through it; and across it she must go
+if she would find her child! Then she lay down to drink up the lake, and
+that was an impossibility for a human being, but the afflicted mother
+thought that a miracle might happen nevertheless.
+
+“Oh, what would I not give to come to my child!” said the weeping
+mother; and she wept still more, and her eyes sunk down in the depths of
+the waters, and became two precious pearls; but the water bore her up,
+as if she sat in a swing, and she flew in the rocking waves to the shore
+on the opposite side, where there stood a mile-broad, strange house, one
+knew not if it were a mountain with forests and caverns, or if it were
+built up; but the poor mother could not see it; she had wept her eyes
+out.
+
+“Where shall I find Death, who took away my little child?” said she.
+
+“He has not come here yet!” said the old grave woman, who was appointed
+to look after Death’s great greenhouse! “How have you been able to find
+the way hither? And who has helped you?”
+
+“OUR LORD has helped me,” said she. “He is merciful, and you will also
+be so! Where shall I find my little child?”
+
+“Nay, I know not,” said the woman, “and you cannot see! Many flowers and
+trees have withered this night; Death will soon come and plant them over
+again! You certainly know that every person has his or her life’s tree
+or flower, just as everyone happens to be settled; they look like other
+plants, but they have pulsations of the heart. Children’s hearts can
+also beat; go after yours, perhaps you may know your child’s; but what
+will you give me if I tell you what you shall do more?”
+
+“I have nothing to give,” said the afflicted mother, “but I will go to
+the world’s end for you!”
+
+“Nay, I have nothing to do there!” said the woman. “But you can give
+me your long black hair; you know yourself that it is fine, and that
+I like! You shall have my white hair instead, and that’s always
+something!”
+
+“Do you demand nothing else?” said she. “That I will gladly give you!”
+ And she gave her her fine black hair, and got the old woman’s snow-white
+hair instead.
+
+So they went into Death’s great greenhouse, where flowers and trees
+grew strangely into one another. There stood fine hyacinths under glass
+bells, and there stood strong-stemmed peonies; there grew water plants,
+some so fresh, others half sick, the water-snakes lay down on them,
+and black crabs pinched their stalks. There stood beautiful palm-trees,
+oaks, and plantains; there stood parsley and flowering thyme: every tree
+and every flower had its name; each of them was a human life, the human
+frame still lived--one in China, and another in Greenland--round about
+in the world. There were large trees in small pots, so that they stood
+so stunted in growth, and ready to burst the pots; in other places,
+there was a little dull flower in rich mould, with moss round about it,
+and it was so petted and nursed. But the distressed mother bent down
+over all the smallest plants, and heard within them how the human heart
+beat; and amongst millions she knew her child’s.
+
+“There it is!” cried she, and stretched her hands out over a little blue
+crocus, that hung quite sickly on one side.
+
+“Don’t touch the flower!” said the old woman. “But place yourself here,
+and when Death comes--I expect him every moment--do not let him pluck
+the flower up, but threaten him that you will do the same with the
+others. Then he will be afraid! He is responsible for them to OUR LORD,
+and no one dares to pluck them up before HE gives leave.”
+
+All at once an icy cold rushed through the great hall, and the blind
+mother could feel that it was Death that came.
+
+“How hast thou been able to find thy way hither?” he asked. “How couldst
+thou come quicker than I?”
+
+“I am a mother,” said she.
+
+And Death stretched out his long hand towards the fine little flower,
+but she held her hands fast around his, so tight, and yet afraid that
+she should touch one of the leaves. Then Death blew on her hands, and
+she felt that it was colder than the cold wind, and her hands fell down
+powerless.
+
+“Thou canst not do anything against me!” said Death.
+
+“But OUR LORD can!” said she.
+
+“I only do His bidding!” said Death. “I am His gardener, I take all His
+flowers and trees, and plant them out in the great garden of Paradise,
+in the unknown land; but how they grow there, and how it is there I dare
+not tell thee.”
+
+“Give me back my child!” said the mother, and she wept and prayed. At
+once she seized hold of two beautiful flowers close by, with each hand,
+and cried out to Death, “I will tear all thy flowers off, for I am in
+despair.”
+
+“Touch them not!” said Death. “Thou say’st that thou art so unhappy, and
+now thou wilt make another mother equally unhappy.”
+
+“Another mother!” said the poor woman, and directly let go her hold of
+both the flowers.
+
+“There, thou hast thine eyes,” said Death; “I fished them up from the
+lake, they shone so bright; I knew not they were thine. Take them again,
+they are now brighter than before; now look down into the deep well
+close by; I shall tell thee the names of the two flowers thou wouldst
+have torn up, and thou wilt see their whole future life--their whole
+human existence: and see what thou wast about to disturb and destroy.”
+
+And she looked down into the well; and it was a happiness to see how the
+one became a blessing to the world, to see how much happiness and joy
+were felt everywhere. And she saw the other’s life, and it was sorrow
+and distress, horror, and wretchedness.
+
+“Both of them are God’s will!” said Death.
+
+“Which of them is Misfortune’s flower and which is that of Happiness?”
+ asked she.
+
+“That I will not tell thee,” said Death; “but this thou shalt know from
+me, that the one flower was thy own child! it was thy child’s fate thou
+saw’st--thy own child’s future life!”
+
+Then the mother screamed with terror, “Which of them was my child? Tell
+it me! Save the innocent! Save my child from all that misery! Rather
+take it away! Take it into God’s kingdom! Forget my tears, forget my
+prayers, and all that I have done!”
+
+“I do not understand thee!” said Death. “Wilt thou have thy child again,
+or shall I go with it there, where thou dost not know!”
+
+Then the mother wrung her hands, fell on her knees, and prayed to our
+Lord: “Oh, hear me not when I pray against Thy will, which is the best!
+hear me not! hear me not!”
+
+And she bowed her head down in her lap, and Death took her child and
+went with it into the unknown land.
+
+
+
+
+THE FALSE COLLAR
+
+There was once a fine gentleman, all of whose moveables were a boot-jack
+and a hair-comb: but he had the finest false collars in the world; and
+it is about one of these collars that we are now to hear a story.
+
+It was so old, that it began to think of marriage; and it happened that
+it came to be washed in company with a garter.
+
+“Nay!” said the collar. “I never did see anything so slender and so
+fine, so soft and so neat. May I not ask your name?”
+
+“That I shall not tell you!” said the garter.
+
+“Where do you live?” asked the collar.
+
+But the garter was so bashful, so modest, and thought it was a strange
+question to answer.
+
+“You are certainly a girdle,” said the collar; “that is to say an inside
+girdle. I see well that you are both for use and ornament, my dear young
+lady.”
+
+“I will thank you not to speak to me,” said the garter. “I think I have
+not given the least occasion for it.”
+
+“Yes! When one is as handsome as you,” said the collar, “that is
+occasion enough.”
+
+“Don’t come so near me, I beg of you!” said the garter. “You look so
+much like those men-folks.”
+
+“I am also a fine gentleman,” said the collar. “I have a bootjack and a
+hair-comb.”
+
+But that was not true, for it was his master who had them: but he
+boasted.
+
+“Don’t come so near me,” said the garter: “I am not accustomed to it.”
+
+“Prude!” exclaimed the collar; and then it was taken out of the
+washing-tub. It was starched, hung over the back of a chair in the
+sunshine, and was then laid on the ironing-blanket; then came the warm
+box-iron. “Dear lady!” said the collar. “Dear widow-lady! I feel quite
+hot. I am quite changed. I begin to unfold myself. You will burn a hole
+in me. Oh! I offer you my hand.”
+
+“Rag!” said the box-iron; and went proudly over the collar: for she
+fancied she was a steam-engine, that would go on the railroad and draw
+the waggons. “Rag!” said the box-iron.
+
+The collar was a little jagged at the edge, and so came the long
+scissors to cut off the jagged part. “Oh!” said the collar. “You are
+certainly the first opera dancer. How well you can stretch your legs
+out! It is the most graceful performance I have ever seen. No one can
+imitate you.”
+
+“I know it,” said the scissors.
+
+“You deserve to be a baroness,” said the collar. “All that I have is a
+fine gentleman, a boot-jack, and a hair-comb. If I only had the barony!”
+
+“Do you seek my hand?” said the scissors; for she was angry; and without
+more ado, she CUT HIM, and then he was condemned.
+
+“I shall now be obliged to ask the hair-comb. It is surprising how well
+you preserve your teeth, Miss,” said the collar. “Have you never thought
+of being betrothed?”
+
+“Yes, of course! you may be sure of that,” said the hair-comb. “I AM
+betrothed--to the boot-jack!”
+
+“Betrothed!” exclaimed the collar. Now there was no other to court, and
+so he despised it.
+
+A long time passed away, then the collar came into the rag chest at the
+paper mill; there was a large company of rags, the fine by themselves,
+and the coarse by themselves, just as it should be. They all had much to
+say, but the collar the most; for he was a real boaster.
+
+“I have had such an immense number of sweethearts!” said the collar.
+“I could not be in peace! It is true, I was always a fine starched-up
+gentleman! I had both a boot-jack and a hair-comb, which I never used!
+You should have seen me then, you should have seen me when I lay down!
+I shall never forget MY FIRST LOVE--she was a girdle, so fine, so soft,
+and so charming, she threw herself into a tub of water for my sake!
+There was also a widow, who became glowing hot, but I left her standing
+till she got black again; there was also the first opera dancer, she
+gave me that cut which I now go with, she was so ferocious! My
+own hair-comb was in love with me, she lost all her teeth from the
+heart-ache; yes, I have lived to see much of that sort of thing; but I
+am extremely sorry for the garter--I mean the girdle--that went into the
+water-tub. I have much on my conscience, I want to become white paper!”
+
+And it became so, all the rags were turned into white paper; but the
+collar came to be just this very piece of white paper we here see,
+and on which the story is printed; and that was because it boasted so
+terribly afterwards of what had never happened to it. It would be well
+for us to beware, that we may not act in a similar manner, for we can
+never know if we may not, in the course of time, also come into the
+rag chest, and be made into white paper, and then have our whole life’s
+history printed on it, even the most secret, and be obliged to run about
+and tell it ourselves, just like this collar.
+
+
+
+
+THE SHADOW
+
+It is in the hot lands that the sun burns, sure enough! there the people
+become quite a mahogany brown, ay, and in the HOTTEST lands they are
+burnt to Negroes. But now it was only to the HOT lands that a learned
+man had come from the cold; there he thought that he could run about
+just as when at home, but he soon found out his mistake.
+
+He, and all sensible folks, were obliged to stay within doors--the
+window-shutters and doors were closed the whole day; it looked as if the
+whole house slept, or there was no one at home.
+
+The narrow street with the high houses, was built so that the sunshine
+must fall there from morning till evening--it was really not to be
+borne.
+
+The learned man from the cold lands--he was a young man, and seemed to
+be a clever man--sat in a glowing oven; it took effect on him, he became
+quite meagre--even his shadow shrunk in, for the sun had also an effect
+on it. It was first towards evening when the sun was down, that they
+began to freshen up again.
+
+In the warm lands every window has a balcony, and the people came out on
+all the balconies in the street--for one must have air, even if one be
+accustomed to be mahogany!* It was lively both up and down the
+street. Tailors, and shoemakers, and all the folks, moved out into the
+street--chairs and tables were brought forth--and candles burnt--yes,
+above a thousand lights were burning--and the one talked and the other
+sung; and people walked and church-bells rang, and asses went along with
+a dingle-dingle-dong! for they too had bells on. The street boys were
+screaming and hooting, and shouting and shooting, with devils and
+detonating balls--and there came corpse bearers and hood wearers--for
+there were funerals with psalm and hymn--and then the din of carriages
+driving and company arriving: yes, it was, in truth, lively enough down
+in the street. Only in that single house, which stood opposite that in
+which the learned foreigner lived, it was quite still; and yet some one
+lived there, for there stood flowers in the balcony--they grew so
+well in the sun’s heat! and that they could not do unless they were
+watered--and some one must water them--there must be somebody there.
+The door opposite was also opened late in the evening, but it was dark
+within, at least in the front room; further in there was heard the sound
+of music. The learned foreigner thought it quite marvellous, but now--it
+might be that he only imagined it--for he found everything marvellous
+out there, in the warm lands, if there had only been no sun. The
+stranger’s landlord said that he didn’t know who had taken the house
+opposite, one saw no person about, and as to the music, it appeared
+to him to be extremely tiresome. “It is as if some one sat there, and
+practised a piece that he could not master--always the same piece. ‘I
+shall master it!’ says he; but yet he cannot master it, however long he
+plays.”
+
+* The word mahogany can be understood, in Danish, as having two
+meanings. In general, it means the reddish-brown wood itself; but in
+jest, it signifies “excessively fine,” which arose from an anecdote of
+Nyboder, in Copenhagen, (the seamen’s quarter.) A sailor’s wife, who was
+always proud and fine, in her way, came to her neighbor, and complained
+that she had got a splinter in her finger. “What of?” asked the
+neighbor’s wife. “It is a mahogany splinter,” said the other. “Mahogany!
+It cannot be less with you!” exclaimed the woman--and thence the
+proverb, “It is so mahogany!”--(that is, so excessively fine)--is
+derived.
+
+
+One night the stranger awoke--he slept with the doors of the balcony
+open--the curtain before it was raised by the wind, and he thought
+that a strange lustre came from the opposite neighbor’s house; all the
+flowers shone like flames, in the most beautiful colors, and in the
+midst of the flowers stood a slender, graceful maiden--it was as if she
+also shone; the light really hurt his eyes. He now opened them quite
+wide--yes, he was quite awake; with one spring he was on the floor; he
+crept gently behind the curtain, but the maiden was gone; the flowers
+shone no longer, but there they stood, fresh and blooming as ever;
+the door was ajar, and, far within, the music sounded so soft and
+delightful, one could really melt away in sweet thoughts from it. Yet
+it was like a piece of enchantment. And who lived there? Where was the
+actual entrance? The whole of the ground-floor was a row of shops, and
+there people could not always be running through.
+
+One evening the stranger sat out on the balcony. The light burnt in the
+room behind him; and thus it was quite natural that his shadow should
+fall on his opposite neighbor’s wall. Yes! there it sat, directly
+opposite, between the flowers on the balcony; and when the stranger
+moved, the shadow also moved: for that it always does.
+
+“I think my shadow is the only living thing one sees over there,” said
+the learned man. “See, how nicely it sits between the flowers. The door
+stands half-open: now the shadow should be cunning, and go into the
+room, look about, and then come and tell me what it had seen. Come, now!
+Be useful, and do me a service,” said he, in jest. “Have the kindness to
+step in. Now! Art thou going?” and then he nodded to the shadow, and the
+shadow nodded again. “Well then, go! But don’t stay away.”
+
+The stranger rose, and his shadow on the opposite neighbor’s balcony
+rose also; the stranger turned round and the shadow also turned round.
+Yes! if anyone had paid particular attention to it, they would have
+seen, quite distinctly, that the shadow went in through the half-open
+balcony-door of their opposite neighbor, just as the stranger went into
+his own room, and let the long curtain fall down after him.
+
+Next morning, the learned man went out to drink coffee and read the
+newspapers.
+
+“What is that?” said he, as he came out into the sunshine. “I have no
+shadow! So then, it has actually gone last night, and not come again. It
+is really tiresome!”
+
+This annoyed him: not so much because the shadow was gone, but because
+he knew there was a story about a man without a shadow.* It was known
+to everybody at home, in the cold lands; and if the learned man now came
+there and told his story, they would say that he was imitating it, and
+that he had no need to do. He would, therefore, not talk about it at
+all; and that was wisely thought.
+
+*Peter Schlemihl, the shadowless man.
+
+
+In the evening he went out again on the balcony. He had placed the light
+directly behind him, for he knew that the shadow would always have its
+master for a screen, but he could not entice it. He made himself little;
+he made himself great: but no shadow came again. He said, “Hem! hem!”
+ but it was of no use.
+
+It was vexatious; but in the warm lands everything grows so quickly; and
+after the lapse of eight days he observed, to his great joy, that a new
+shadow came in the sunshine. In the course of three weeks he had a very
+fair shadow, which, when he set out for his home in the northern lands,
+grew more and more in the journey, so that at last it was so long and so
+large, that it was more than sufficient.
+
+The learned man then came home, and he wrote books about what was true
+in the world, and about what was good and what was beautiful; and there
+passed days and years--yes! many years passed away.
+
+One evening, as he was sitting in his room, there was a gentle knocking
+at the door.
+
+“Come in!” said he; but no one came in; so he opened the door, and there
+stood before him such an extremely lean man, that he felt quite strange.
+As to the rest, the man was very finely dressed--he must be a gentleman.
+
+“Whom have I the honor of speaking?” asked the learned man.
+
+“Yes! I thought as much,” said the fine man. “I thought you would not
+know me. I have got so much body. I have even got flesh and clothes. You
+certainly never thought of seeing me so well off. Do you not know your
+old shadow? You certainly thought I should never more return. Things
+have gone on well with me since I was last with you. I have, in all
+respects, become very well off. Shall I purchase my freedom from
+service? If so, I can do it”; and then he rattled a whole bunch of
+valuable seals that hung to his watch, and he stuck his hand in the
+thick gold chain he wore around his neck--nay! how all his fingers
+glittered with diamond rings; and then all were pure gems.
+
+“Nay; I cannot recover from my surprise!” said the learned man. “What is
+the meaning of all this?”
+
+“Something common, is it not,” said the shadow. “But you yourself do not
+belong to the common order; and I, as you know well, have from a child
+followed in your footsteps. As soon as you found I was capable to go
+out alone in the world, I went my own way. I am in the most brilliant
+circumstances, but there came a sort of desire over me to see you once
+more before you die; you will die, I suppose? I also wished to see this
+land again--for you know we always love our native land. I know you have
+got another shadow again; have I anything to pay to it or you? If so,
+you will oblige me by saying what it is.”
+
+“Nay, is it really thou?” said the learned man. “It is most remarkable:
+I never imagined that one’s old shadow could come again as a man.”
+
+“Tell me what I have to pay,” said the shadow; “for I don’t like to be
+in any sort of debt.”
+
+“How canst thou talk so?” said the learned man. “What debt is there to
+talk about? Make thyself as free as anyone else. I am extremely glad to
+hear of thy good fortune: sit down, old friend, and tell me a little
+how it has gone with thee, and what thou hast seen at our opposite
+neighbor’s there--in the warm lands.”
+
+“Yes, I will tell you all about it,” said the shadow, and sat down: “but
+then you must also promise me, that, wherever you may meet me, you will
+never say to anyone here in the town that I have been your shadow. I
+intend to get betrothed, for I can provide for more than one family.”
+
+“Be quite at thy ease about that,” said the learned man; “I shall not
+say to anyone who thou actually art: here is my hand--I promise it, and
+a man’s bond is his word.”
+
+“A word is a shadow,” said the shadow, “and as such it must speak.”
+
+It was really quite astonishing how much of a man it was. It was dressed
+entirely in black, and of the very finest cloth; it had patent leather
+boots, and a hat that could be folded together, so that it was bare
+crown and brim; not to speak of what we already know it had--seals, gold
+neck-chain, and diamond rings; yes, the shadow was well-dressed, and it
+was just that which made it quite a man.
+
+“Now I shall tell you my adventures,” said the shadow; and then he
+sat, with the polished boots, as heavily as he could, on the arm of the
+learned man’s new shadow, which lay like a poodle-dog at his feet.
+Now this was perhaps from arrogance; and the shadow on the ground kept
+itself so still and quiet, that it might hear all that passed: it wished
+to know how it could get free, and work its way up, so as to become its
+own master.
+
+“Do you know who lived in our opposite neighbor’s house?” said the
+shadow. “It was the most charming of all beings, it was Poesy! I was
+there for three weeks, and that has as much effect as if one had lived
+three thousand years, and read all that was composed and written;
+that is what I say, and it is right. I have seen everything and I know
+everything!”
+
+“Poesy!” cried the learned man. “Yes, yes, she often dwells a recluse
+in large cities! Poesy! Yes, I have seen her--a single short moment,
+but sleep came into my eyes! She stood on the balcony and shone as the
+Aurora Borealis shines. Go on, go on--thou wert on the balcony, and went
+through the doorway, and then--”
+
+“Then I was in the antechamber,” said the shadow. “You always sat and
+looked over to the antechamber. There was no light; there was a sort
+of twilight, but the one door stood open directly opposite the other
+through a long row of rooms and saloons, and there it was lighted up. I
+should have been completely killed if I had gone over to the maiden; but
+I was circumspect, I took time to think, and that one must always do.”
+
+“And what didst thou then see?” asked the learned man.
+
+“I saw everything, and I shall tell all to you: but--it is no pride on
+my part--as a free man, and with the knowledge I have, not to speak of
+my position in life, my excellent circumstances--I certainly wish that
+you would say YOU* to me!”
+
+* It is the custom in Denmark for intimate acquaintances to use the
+second person singular, “Du,” (thou) when speaking to each other. When
+a friendship is formed between men, they generally affirm it, when
+occasion offers, either in public or private, by drinking to each other
+and exclaiming, “thy health,” at the same time striking their glasses
+together. This is called drinking “Duus”: they are then, “Duus Brodre,”
+ (thou brothers) and ever afterwards use the pronoun “thou,” to each
+other, it being regarded as more familiar than “De,” (you). Father and
+mother, sister and brother say thou to one another--without regard to
+age or rank. Master and mistress say thou to their servants the superior
+to the inferior. But servants and inferiors do not use the same term
+to their masters, or superiors--nor is it ever used when speaking to a
+stranger, or anyone with whom they are but slightly acquainted--they
+then say as in English--you.
+
+
+“I beg your pardon,” said the learned man; “it is an old habit with me.
+YOU are perfectly right, and I shall remember it; but now you must tell
+me all YOU saw!”
+
+“Everything!” said the shadow. “For I saw everything, and I know
+everything!”
+
+“How did it look in the furthest saloon?” asked the learned man. “Was it
+there as in the fresh woods? Was it there as in a holy church? Were the
+saloons like the starlit firmament when we stand on the high mountains?”
+
+“Everything was there!” said the shadow. “I did not go quite in, I
+remained in the foremost room, in the twilight, but I stood there
+quite well; I saw everything, and I know everything! I have been in the
+antechamber at the court of Poesy.”
+
+“But WHAT DID you see? Did all the gods of the olden times pass through
+the large saloons? Did the old heroes combat there? Did sweet children
+play there, and relate their dreams?”
+
+“I tell you I was there, and you can conceive that I saw everything
+there was to be seen. Had you come over there, you would not have been
+a man; but I became so! And besides, I learned to know my inward nature,
+my innate qualities, the relationship I had with Poesy. At the time I
+was with you, I thought not of that, but always--you know it well--when
+the sun rose, and when the sun went down, I became so strangely great;
+in the moonlight I was very near being more distinct than yourself; at
+that time I did not understand my nature; it was revealed to me in the
+antechamber! I became a man! I came out matured; but you were no longer
+in the warm lands; as a man I was ashamed to go as I did. I was in
+want of boots, of clothes, of the whole human varnish that makes a man
+perceptible. I took my way--I tell it to you, but you will not put it in
+any book--I took my way to the cake woman--I hid myself behind her;
+the woman didn’t think how much she concealed. I went out first in the
+evening; I ran about the streets in the moonlight; I made myself long up
+the walls--it tickles the back so delightfully! I ran up, and ran down,
+peeped into the highest windows, into the saloons, and on the roofs, I
+peeped in where no one could peep, and I saw what no one else saw, what
+no one else should see! This is, in fact, a base world! I would not be a
+man if it were not now once accepted and regarded as something to be so!
+I saw the most unimaginable things with the women, with the men, with
+parents, and with the sweet, matchless children; I saw,” said the
+shadow, “what no human being must know, but what they would all
+so willingly know--what is bad in their neighbor. Had I written a
+newspaper, it would have been read! But I wrote direct to the persons
+themselves, and there was consternation in all the towns where I came.
+They were so afraid of me, and yet they were so excessively fond of
+me. The professors made a professor of me; the tailors gave me new
+clothes--I am well furnished; the master of the mint struck new coin for
+me, and the women said I was so handsome! And so I became the man I am.
+And I now bid you farewell. Here is my card--I live on the sunny side
+of the street, and am always at home in rainy weather!” And so away went
+the shadow. “That was most extraordinary!” said the learned man. Years
+and days passed away, then the shadow came again. “How goes it?” said
+the shadow.
+
+“Alas!” said the learned man. “I write about the true, and the good,
+and the beautiful, but no one cares to hear such things; I am quite
+desperate, for I take it so much to heart!”
+
+“But I don’t!” said the shadow. “I become fat, and it is that one wants
+to become! You do not understand the world. You will become ill by it.
+You must travel! I shall make a tour this summer; will you go with me?
+I should like to have a travelling companion! Will you go with me, as
+shadow? It will be a great pleasure for me to have you with me; I shall
+pay the travelling expenses!”
+
+“Nay, this is too much!” said the learned man.
+
+“It is just as one takes it!” said the shadow. “It will do you much good
+to travel! Will you be my shadow? You shall have everything free on the
+journey!”
+
+“Nay, that is too bad!” said the learned man.
+
+“But it is just so with the world!” said the shadow, “and so it will
+be!” and away it went again.
+
+The learned man was not at all in the most enviable state; grief and
+torment followed him, and what he said about the true, and the good, and
+the beautiful, was, to most persons, like roses for a cow! He was quite
+ill at last.
+
+“You really look like a shadow!” said his friends to him; and the
+learned man trembled, for he thought of it.
+
+“You must go to a watering-place!” said the shadow, who came and visited
+him. “There is nothing else for it! I will take you with me for old
+acquaintance’ sake; I will pay the travelling expenses, and you write
+the descriptions--and if they are a little amusing for me on the way!
+I will go to a watering-place--my beard does not grow out as it
+ought--that is also a sickness--and one must have a beard! Now you be
+wise and accept the offer; we shall travel as comrades!”
+
+And so they travelled; the shadow was master, and the master was the
+shadow; they drove with each other, they rode and walked together, side
+by side, before and behind, just as the sun was; the shadow always took
+care to keep itself in the master’s place. Now the learned man didn’t
+think much about that; he was a very kind-hearted man, and particularly
+mild and friendly, and so he said one day to the shadow: “As we have
+now become companions, and in this way have grown up together from
+childhood, shall we not drink ‘thou’ together, it is more familiar?”
+
+“You are right,” said the shadow, who was now the proper master. “It is
+said in a very straight-forward and well-meant manner. You, as a learned
+man, certainly know how strange nature is. Some persons cannot bear to
+touch grey paper, or they become ill; others shiver in every limb if one
+rub a pane of glass with a nail: I have just such a feeling on hearing
+you say thou to me; I feel myself as if pressed to the earth in my first
+situation with you. You see that it is a feeling; that it is not pride:
+I cannot allow you to say THOU to me, but I will willingly say THOU to
+you, so it is half done!”
+
+So the shadow said THOU to its former master.
+
+“This is rather too bad,” thought he, “that I must say YOU and he say
+THOU,” but he was now obliged to put up with it.
+
+So they came to a watering-place where there were many strangers, and
+amongst them was a princess, who was troubled with seeing too well; and
+that was so alarming!
+
+She directly observed that the stranger who had just come was quite a
+different sort of person to all the others; “He has come here in order
+to get his beard to grow, they say, but I see the real cause, he cannot
+cast a shadow.”
+
+She had become inquisitive; and so she entered into conversation
+directly with the strange gentleman, on their promenades. As the
+daughter of a king, she needed not to stand upon trifles, so she said,
+“Your complaint is, that you cannot cast a shadow?”
+
+“Your Royal Highness must be improving considerably,” said the shadow,
+“I know your complaint is, that you see too clearly, but it has
+decreased, you are cured. I just happen to have a very unusual shadow!
+Do you not see that person who always goes with me? Other persons have
+a common shadow, but I do not like what is common to all. We give our
+servants finer cloth for their livery than we ourselves use, and so I
+had my shadow trimmed up into a man: yes, you see I have even given him
+a shadow. It is somewhat expensive, but I like to have something for
+myself!”
+
+“What!” thought the princess. “Should I really be cured! These baths are
+the first in the world! In our time water has wonderful powers. But I
+shall not leave the place, for it now begins to be amusing here. I am
+extremely fond of that stranger: would that his beard should not grow,
+for in that case he will leave us!”
+
+In the evening, the princess and the shadow danced together in the large
+ball-room. She was light, but he was still lighter; she had never had
+such a partner in the dance. She told him from what land she came, and
+he knew that land; he had been there, but then she was not at home; he
+had peeped in at the window, above and below--he had seen both the
+one and the other, and so he could answer the princess, and make
+insinuations, so that she was quite astonished; he must be the wisest
+man in the whole world! She felt such respect for what he knew! So that
+when they again danced together she fell in love with him; and that the
+shadow could remark, for she almost pierced him through with her eyes.
+So they danced once more together; and she was about to declare herself,
+but she was discreet; she thought of her country and kingdom, and of the
+many persons she would have to reign over.
+
+“He is a wise man,” said she to herself--“It is well; and he dances
+delightfully--that is also good; but has he solid knowledge? That is
+just as important! He must be examined.”
+
+So she began, by degrees, to question him about the most difficult
+things she could think of, and which she herself could not have
+answered; so that the shadow made a strange face.
+
+“You cannot answer these questions?” said the princess.
+
+“They belong to my childhood’s learning,” said the shadow. “I really
+believe my shadow, by the door there, can answer them!”
+
+“Your shadow!” said the princess. “That would indeed be marvellous!”
+
+“I will not say for a certainty that he can,” said the shadow, “but I
+think so; he has now followed me for so many years, and listened to my
+conversation--I should think it possible. But your royal highness will
+permit me to observe, that he is so proud of passing himself off for
+a man, that when he is to be in a proper humor--and he must be so to
+answer well--he must be treated quite like a man.”
+
+“Oh! I like that!” said the princess.
+
+So she went to the learned man by the door, and she spoke to him about
+the sun and the moon, and about persons out of and in the world, and he
+answered with wisdom and prudence.
+
+“What a man that must be who has so wise a shadow!” thought she. “It
+will be a real blessing to my people and kingdom if I choose him for my
+consort--I will do it!”
+
+They were soon agreed, both the princess and the shadow; but no one was
+to know about it before she arrived in her own kingdom.
+
+“No one--not even my shadow!” said the shadow, and he had his own
+thoughts about it!
+
+Now they were in the country where the princess reigned when she was at
+home.
+
+“Listen, my good friend,” said the shadow to the learned man. “I have
+now become as happy and mighty as anyone can be; I will, therefore, do
+something particular for thee! Thou shalt always live with me in the
+palace, drive with me in my royal carriage, and have ten thousand
+pounds a year; but then thou must submit to be called SHADOW by all and
+everyone; thou must not say that thou hast ever been a man; and once
+a year, when I sit on the balcony in the sunshine, thou must lie at my
+feet, as a shadow shall do! I must tell thee: I am going to marry the
+king’s daughter, and the nuptials are to take place this evening!”
+
+“Nay, this is going too far!” said the learned man. “I will not have it;
+I will not do it! It is to deceive the whole country and the princess
+too! I will tell everything! That I am a man, and that thou art a
+shadow--thou art only dressed up!”
+
+“There is no one who will believe it!” said the shadow. “Be reasonable,
+or I will call the guard!”
+
+“I will go directly to the princess!” said the learned man.
+
+“But I will go first!” said the shadow. “And thou wilt go to prison!”
+ and that he was obliged to do--for the sentinels obeyed him whom they
+knew the king’s daughter was to marry.
+
+“You tremble!” said the princess, as the shadow came into her chamber.
+“Has anything happened? You must not be unwell this evening, now that we
+are to have our nuptials celebrated.”
+
+“I have lived to see the most cruel thing that anyone can live to
+see!” said the shadow. “Only imagine--yes, it is true, such a poor
+shadow-skull cannot bear much--only think, my shadow has become mad;
+he thinks that he is a man, and that I--now only think--that I am his
+shadow!”
+
+“It is terrible!” said the princess; “but he is confined, is he not?”
+
+“That he is. I am afraid that he will never recover.”
+
+“Poor shadow!” said the princess. “He is very unfortunate; it would be
+a real work of charity to deliver him from the little life he has, and,
+when I think properly over the matter, I am of opinion that it will be
+necessary to do away with him in all stillness!”
+
+“It is certainly hard,” said the shadow, “for he was a faithful
+servant!” and then he gave a sort of sigh.
+
+“You are a noble character!” said the princess.
+
+The whole city was illuminated in the evening, and the cannons went off
+with a bum! bum! and the soldiers presented arms. That was a marriage!
+The princess and the shadow went out on the balcony to show themselves,
+and get another hurrah!
+
+The learned man heard nothing of all this--for they had deprived him of
+life.
+
+
+
+
+THE LITTLE MATCH GIRL
+
+Most terribly cold it was; it snowed, and was nearly quite dark, and
+evening--the last evening of the year. In this cold and darkness there
+went along the street a poor little girl, bareheaded, and with naked
+feet. When she left home she had slippers on, it is true; but what was
+the good of that? They were very large slippers, which her mother had
+hitherto worn; so large were they; and the poor little thing lost them
+as she scuffled away across the street, because of two carriages that
+rolled by dreadfully fast.
+
+One slipper was nowhere to be found; the other had been laid hold of by
+an urchin, and off he ran with it; he thought it would do capitally for
+a cradle when he some day or other should have children himself. So the
+little maiden walked on with her tiny naked feet, that were quite red
+and blue from cold. She carried a quantity of matches in an old apron,
+and she held a bundle of them in her hand. Nobody had bought anything of
+her the whole livelong day; no one had given her a single farthing.
+
+She crept along trembling with cold and hunger--a very picture of
+sorrow, the poor little thing!
+
+The flakes of snow covered her long fair hair, which fell in beautiful
+curls around her neck; but of that, of course, she never once now
+thought. From all the windows the candles were gleaming, and it smelt so
+deliciously of roast goose, for you know it was New Year’s Eve; yes, of
+that she thought.
+
+In a corner formed by two houses, of which one advanced more than the
+other, she seated herself down and cowered together. Her little feet
+she had drawn close up to her, but she grew colder and colder, and to go
+home she did not venture, for she had not sold any matches and could
+not bring a farthing of money: from her father she would certainly get
+blows, and at home it was cold too, for above her she had only the roof,
+through which the wind whistled, even though the largest cracks were
+stopped up with straw and rags.
+
+Her little hands were almost numbed with cold. Oh! a match might afford
+her a world of comfort, if she only dared take a single one out of the
+bundle, draw it against the wall, and warm her fingers by it. She drew
+one out. “Rischt!” how it blazed, how it burnt! It was a warm, bright
+flame, like a candle, as she held her hands over it: it was a wonderful
+light. It seemed really to the little maiden as though she were sitting
+before a large iron stove, with burnished brass feet and a brass
+ornament at top. The fire burned with such blessed influence; it warmed
+so delightfully. The little girl had already stretched out her feet to
+warm them too; but--the small flame went out, the stove vanished: she
+had only the remains of the burnt-out match in her hand.
+
+She rubbed another against the wall: it burned brightly, and where the
+light fell on the wall, there the wall became transparent like a
+veil, so that she could see into the room. On the table was spread a
+snow-white tablecloth; upon it was a splendid porcelain service, and the
+roast goose was steaming famously with its stuffing of apple and dried
+plums. And what was still more capital to behold was, the goose hopped
+down from the dish, reeled about on the floor with knife and fork in its
+breast, till it came up to the poor little girl; when--the match went
+out and nothing but the thick, cold, damp wall was left behind.
+She lighted another match. Now there she was sitting under the most
+magnificent Christmas tree: it was still larger, and more decorated than
+the one which she had seen through the glass door in the rich merchant’s
+house.
+
+Thousands of lights were burning on the green branches, and
+gaily-colored pictures, such as she had seen in the shop-windows, looked
+down upon her. The little maiden stretched out her hands towards them
+when--the match went out. The lights of the Christmas tree rose higher
+and higher, she saw them now as stars in heaven; one fell down and
+formed a long trail of fire.
+
+“Someone is just dead!” said the little girl; for her old grandmother,
+the only person who had loved her, and who was now no more, had told
+her, that when a star falls, a soul ascends to God.
+
+She drew another match against the wall: it was again light, and in the
+lustre there stood the old grandmother, so bright and radiant, so mild,
+and with such an expression of love.
+
+“Grandmother!” cried the little one. “Oh, take me with you! You go
+away when the match burns out; you vanish like the warm stove, like the
+delicious roast goose, and like the magnificent Christmas tree!” And
+she rubbed the whole bundle of matches quickly against the wall, for
+she wanted to be quite sure of keeping her grandmother near her. And
+the matches gave such a brilliant light that it was brighter than at
+noon-day: never formerly had the grandmother been so beautiful and
+so tall. She took the little maiden, on her arm, and both flew in
+brightness and in joy so high, so very high, and then above was neither
+cold, nor hunger, nor anxiety--they were with God.
+
+But in the corner, at the cold hour of dawn, sat the poor girl, with
+rosy cheeks and with a smiling mouth, leaning against the wall--frozen
+to death on the last evening of the old year. Stiff and stark sat the
+child there with her matches, of which one bundle had been burnt. “She
+wanted to warm herself,” people said. No one had the slightest suspicion
+of what beautiful things she had seen; no one even dreamed of the
+splendor in which, with her grandmother she had entered on the joys of a
+new year.
+
+
+
+
+THE DREAM OF LITTLE TUK
+
+Ah! yes, that was little Tuk: in reality his name was not Tuk, but that
+was what he called himself before he could speak plain: he meant it for
+Charles, and it is all well enough if one does but know it. He had now
+to take care of his little sister Augusta, who was much younger than
+himself, and he was, besides, to learn his lesson at the same time; but
+these two things would not do together at all. There sat the poor little
+fellow, with his sister on his lap, and he sang to her all the songs he
+knew; and he glanced the while from time to time into the geography-book
+that lay open before him. By the next morning he was to have learnt
+all the towns in Zealand by heart, and to know about them all that is
+possible to be known.
+
+His mother now came home, for she had been out, and took little Augusta
+on her arm. Tuk ran quickly to the window, and read so eagerly that he
+pretty nearly read his eyes out; for it got darker and darker, but his
+mother had no money to buy a candle.
+
+“There goes the old washerwoman over the way,” said his mother, as she
+looked out of the window. “The poor woman can hardly drag herself along,
+and she must now drag the pail home from the fountain. Be a good boy,
+Tukey, and run across and help the old woman, won’t you?”
+
+So Tuk ran over quickly and helped her; but when he came back again into
+the room it was quite dark, and as to a light, there was no thought of
+such a thing. He was now to go to bed; that was an old turn-up bedstead;
+in it he lay and thought about his geography lesson, and of Zealand, and
+of all that his master had told him. He ought, to be sure, to have read
+over his lesson again, but that, you know, he could not do. He therefore
+put his geography-book under his pillow, because he had heard that was
+a very good thing to do when one wants to learn one’s lesson; but one
+cannot, however, rely upon it entirely. Well, there he lay, and thought
+and thought, and all at once it was just as if someone kissed his eyes
+and mouth: he slept, and yet he did not sleep; it was as though the old
+washerwoman gazed on him with her mild eyes and said, “It were a great
+sin if you were not to know your lesson tomorrow morning. You have aided
+me, I therefore will now help you; and the loving God will do so at all
+times.” And all of a sudden the book under Tuk’s pillow began scraping
+and scratching.
+
+“Kickery-ki! kluk! kluk! kluk!”--that was an old hen who came creeping
+along, and she was from Kjoge. “I am a Kjoger hen,” [*] said she, and then
+she related how many inhabitants there were there, and about the battle
+that had taken place, and which, after all, was hardly worth talking
+about.
+
+     * Kjoge, a town in the bay of Kjoge. “To see the Kjoge
+     hens,” is an expression similar to “showing a child London,”
+      which is said to be done by taking his head in both bands,
+     and so lifting him off the ground. At the invasion of the
+     English in 1807, an encounter of a no very glorious nature
+     took place between the British troops and the undisciplined
+     Danish militia.
+
+“Kribledy, krabledy--plump!” down fell somebody: it was a wooden bird,
+the popinjay used at the shooting-matches at Prastoe. Now he said that
+there were just as many inhabitants as he had nails in his body; and he
+was very proud. “Thorwaldsen lived almost next door to me.* Plump! Here
+I lie capitally.”
+
+* Prastoe, a still smaller town than Kjoge. Some hundred paces from
+it lies the manor-house Ny Soe, where Thorwaldsen, the famed sculptor,
+generally sojourned during his stay in Denmark, and where he called many
+of his immortal works into existence.
+
+
+But little Tuk was no longer lying down: all at once he was on
+horseback. On he went at full gallop, still galloping on and on. A
+knight with a gleaming plume, and most magnificently dressed, held him
+before him on the horse, and thus they rode through the wood to the old
+town of Bordingborg, and that was a large and very lively town. High
+towers rose from the castle of the king, and the brightness of many
+candles streamed from all the windows; within was dance and song,
+and King Waldemar and the young, richly-attired maids of honor danced
+together. The morn now came; and as soon as the sun appeared, the whole
+town and the king’s palace crumbled together, and one tower after the
+other; and at last only a single one remained standing where the castle
+had been before,* and the town was so small and poor, and the school
+boys came along with their books under their arms, and said, “2000
+inhabitants!” but that was not true, for there were not so many.
+
+*Bordingborg, in the reign of King Waldemar, a considerable place, now
+an unimportant little town. One solitary tower only, and some remains of
+a wall, show where the castle once stood.
+
+
+And little Tukey lay in his bed: it seemed to him as if he dreamed, and
+yet as if he were not dreaming; however, somebody was close beside him.
+
+“Little Tukey! Little Tukey!” cried someone near. It was a seaman,
+quite a little personage, so little as if he were a midshipman; but a
+midshipman it was not.
+
+“Many remembrances from Corsor.* That is a town that is just rising
+into importance; a lively town that has steam-boats and stagecoaches:
+formerly people called it ugly, but that is no longer true. I lie on
+the sea,” said Corsor; “I have high roads and gardens, and I have given
+birth to a poet who was witty and amusing, which all poets are not. I
+once intended to equip a ship that was to sail all round the earth; but
+I did not do it, although I could have done so: and then, too, I smell
+so deliciously, for close before the gate bloom the most beautiful
+roses.”
+
+*Corsor, on the Great Belt, called, formerly, before the introduction
+of steam-vessels, when travellers were often obliged to wait a long time
+for a favorable wind, “the most tiresome of towns.” The poet Baggesen
+was born here.
+
+
+Little Tuk looked, and all was red and green before his eyes; but as
+soon as the confusion of colors was somewhat over, all of a sudden there
+appeared a wooded slope close to the bay, and high up above stood a
+magnificent old church, with two high pointed towers. From out the
+hill-side spouted fountains in thick streams of water, so that there
+was a continual splashing; and close beside them sat an old king with
+a golden crown upon his white head: that was King Hroar, near the
+fountains, close to the town of Roeskilde, as it is now called. And up
+the slope into the old church went all the kings and queens of Denmark,
+hand in hand, all with their golden crowns; and the organ played and
+the fountains rustled. Little Tuk saw all, heard all. “Do not forget the
+diet,” said King Hroar.*
+
+*Roeskilde, once the capital of Denmark. The town takes its name from
+King Hroar, and the many fountains in the neighborhood. In the beautiful
+cathedral the greater number of the kings and queens of Denmark are
+interred. In Roeskilde, too, the members of the Danish Diet assemble.
+
+
+Again all suddenly disappeared. Yes, and whither? It seemed to him
+just as if one turned over a leaf in a book. And now stood there an
+old peasant-woman, who came from Soroe,* where grass grows in the
+market-place. She had an old grey linen apron hanging over her head and
+back: it was so wet, it certainly must have been raining. “Yes, that it
+has,” said she; and she now related many pretty things out of Holberg’s
+comedies, and about Waldemar and Absalon; but all at once she cowered
+together, and her head began shaking backwards and forwards, and she
+looked as she were going to make a spring. “Croak! croak!” said she.
+“It is wet, it is wet; there is such a pleasant deathlike stillness in
+Sorbe!” She was now suddenly a frog, “Croak”; and now she was an old
+woman. “One must dress according to the weather,” said she. “It is wet;
+it is wet. My town is just like a bottle; and one gets in by the neck,
+and by the neck one must get out again! In former times I had the
+finest fish, and now I have fresh rosy-cheeked boys at the bottom of the
+bottle, who learn wisdom, Hebrew, Greek--Croak!”
+
+* Sorbe, a very quiet little town, beautifully situated, surrounded by
+woods and lakes. Holberg, Denmark’s Moliere, founded here an academy
+for the sons of the nobles. The poets Hauch and Ingemann were appointed
+professors here. The latter lives there still.
+
+
+When she spoke it sounded just like the noise of frogs, or as if one
+walked with great boots over a moor; always the same tone, so uniform
+and so tiring that little Tuk fell into a good sound sleep, which, by
+the bye, could not do him any harm.
+
+But even in this sleep there came a dream, or whatever else it was: his
+little sister Augusta, she with the blue eyes and the fair curling hair,
+was suddenly a tall, beautiful girl, and without having wings was yet
+able to fly; and she now flew over Zealand--over the green woods and the
+blue lakes.
+
+“Do you hear the cock crow, Tukey? Cock-a-doodle-doo! The cocks are
+flying up from Kjoge! You will have a farm-yard, so large, oh! so very
+large! You will suffer neither hunger nor thirst! You will get on in the
+world! You will be a rich and happy man! Your house will exalt itself
+like King Waldemar’s tower, and will be richly decorated with marble
+statues, like that at Prastoe. You understand what I mean. Your name
+shall circulate with renown all round the earth, like unto the ship that
+was to have sailed from Corsor; and in Roeskilde--”
+
+“Do not forget the diet!” said King Hroar.
+
+“Then you will speak well and wisely, little Tukey; and when at last you
+sink into your grave, you shall sleep as quietly--”
+
+“As if I lay in Soroe,” said Tuk, awaking. It was bright day, and he was
+now quite unable to call to mind his dream; that, however, was not at
+all necessary, for one may not know what the future will bring.
+
+And out of bed he jumped, and read in his book, and now all at once he
+knew his whole lesson. And the old washerwoman popped her head in at the
+door, nodded to him friendly, and said, “Thanks, many thanks, my good
+child, for your help! May the good ever-loving God fulfil your loveliest
+dream!”
+
+Little Tukey did not at all know what he had dreamed, but the loving God
+knew it.
+
+
+
+
+THE NAUGHTY BOY
+
+Along time ago, there lived an old poet, a thoroughly kind old poet. As
+he was sitting one evening in his room, a dreadful storm arose without,
+and the rain streamed down from heaven; but the old poet sat warm
+and comfortable in his chimney-corner, where the fire blazed and the
+roasting apple hissed.
+
+“Those who have not a roof over their heads will be wetted to the skin,”
+ said the good old poet.
+
+“Oh let me in! Let me in! I am cold, and I’m so wet!” exclaimed suddenly
+a child that stood crying at the door and knocking for admittance, while
+the rain poured down, and the wind made all the windows rattle.
+
+“Poor thing!” said the old poet, as he went to open the door. There
+stood a little boy, quite naked, and the water ran down from his long
+golden hair; he trembled with cold, and had he not come into a warm room
+he would most certainly have perished in the frightful tempest.
+
+“Poor child!” said the old poet, as he took the boy by the hand. “Come
+in, come in, and I will soon restore thee! Thou shalt have wine and
+roasted apples, for thou art verily a charming child!” And the boy was
+so really. His eyes were like two bright stars; and although the water
+trickled down his hair, it waved in beautiful curls. He looked exactly
+like a little angel, but he was so pale, and his whole body trembled
+with cold. He had a nice little bow in his hand, but it was quite
+spoiled by the rain, and the tints of his many-colored arrows ran one
+into the other.
+
+The old poet seated himself beside his hearth, and took the little
+fellow on his lap; he squeezed the water out of his dripping hair,
+warmed his hands between his own, and boiled for him some sweet wine.
+Then the boy recovered, his cheeks again grew rosy, he jumped down from
+the lap where he was sitting, and danced round the kind old poet.
+
+“You are a merry fellow,” said the old man. “What’s your name?”
+
+“My name is Cupid,” answered the boy. “Don’t you know me? There lies my
+bow; it shoots well, I can assure you! Look, the weather is now clearing
+up, and the moon is shining clear again through the window.”
+
+“Why, your bow is quite spoiled,” said the old poet.
+
+“That were sad indeed,” said the boy, and he took the bow in his hand
+and examined it on every side. “Oh, it is dry again, and is not hurt at
+all; the string is quite tight. I will try it directly.” And he bent his
+bow, took aim, and shot an arrow at the old poet, right into his heart.
+“You see now that my bow was not spoiled,” said he laughing; and away he
+ran.
+
+The naughty boy, to shoot the old poet in that way; he who had taken him
+into his warm room, who had treated him so kindly, and who had given him
+warm wine and the very best apples!
+
+The poor poet lay on the earth and wept, for the arrow had really flown
+into his heart.
+
+“Fie!” said he. “How naughty a boy Cupid is! I will tell all children
+about him, that they may take care and not play with him, for he will
+only cause them sorrow and many a heartache.”
+
+And all good children to whom he related this story, took great heed
+of this naughty Cupid; but he made fools of them still, for he is
+astonishingly cunning. When the university students come from the
+lectures, he runs beside them in a black coat, and with a book under his
+arm. It is quite impossible for them to know him, and they walk along
+with him arm in arm, as if he, too, were a student like themselves; and
+then, unperceived, he thrusts an arrow to their bosom. When the young
+maidens come from being examined by the clergyman, or go to church to
+be confirmed, there he is again close behind them. Yes, he is forever
+following people. At the play, he sits in the great chandelier and burns
+in bright flames, so that people think it is really a flame, but they
+soon discover it is something else. He roves about in the garden of the
+palace and upon the ramparts: yes, once he even shot your father and
+mother right in the heart. Ask them only and you will hear what they’ll
+tell you. Oh, he is a naughty boy, that Cupid; you must never have
+anything to do with him. He is forever running after everybody. Only
+think, he shot an arrow once at your old grandmother! But that is a
+long time ago, and it is all past now; however, a thing of that sort she
+never forgets. Fie, naughty Cupid! But now you know him, and you know,
+too, how ill-behaved he is!
+
+
+
+
+THE RED SHOES
+
+There was once a little girl who was very pretty and delicate, but in
+summer she was forced to run about with bare feet, she was so poor, and
+in winter wear very large wooden shoes, which made her little insteps
+quite red, and that looked so dangerous!
+
+In the middle of the village lived old Dame Shoemaker; she sat and sewed
+together, as well as she could, a little pair of shoes out of old red
+strips of cloth; they were very clumsy, but it was a kind thought. They
+were meant for the little girl. The little girl was called Karen.
+
+On the very day her mother was buried, Karen received the red shoes,
+and wore them for the first time. They were certainly not intended for
+mourning, but she had no others, and with stockingless feet she followed
+the poor straw coffin in them.
+
+Suddenly a large old carriage drove up, and a large old lady sat in it:
+she looked at the little girl, felt compassion for her, and then said to
+the clergyman:
+
+“Here, give me the little girl. I will adopt her!”
+
+And Karen believed all this happened on account of the red shoes, but
+the old lady thought they were horrible, and they were burnt. But Karen
+herself was cleanly and nicely dressed; she must learn to read and sew;
+and people said she was a nice little thing, but the looking-glass said:
+“Thou art more than nice, thou art beautiful!”
+
+Now the queen once travelled through the land, and she had her little
+daughter with her. And this little daughter was a princess, and people
+streamed to the castle, and Karen was there also, and the little
+princess stood in her fine white dress, in a window, and let herself be
+stared at; she had neither a train nor a golden crown, but splendid
+red morocco shoes. They were certainly far handsomer than those Dame
+Shoemaker had made for little Karen. Nothing in the world can be
+compared with red shoes.
+
+Now Karen was old enough to be confirmed; she had new clothes and was to
+have new shoes also. The rich shoemaker in the city took the measure of
+her little foot. This took place at his house, in his room; where stood
+large glass-cases, filled with elegant shoes and brilliant boots. All
+this looked charming, but the old lady could not see well, and so had
+no pleasure in them. In the midst of the shoes stood a pair of red ones,
+just like those the princess had worn. How beautiful they were! The
+shoemaker said also they had been made for the child of a count, but had
+not fitted.
+
+“That must be patent leather!” said the old lady. “They shine so!”
+
+“Yes, they shine!” said Karen, and they fitted, and were bought, but the
+old lady knew nothing about their being red, else she would never have
+allowed Karen to have gone in red shoes to be confirmed. Yet such was
+the case.
+
+Everybody looked at her feet; and when she stepped through the chancel
+door on the church pavement, it seemed to her as if the old figures on
+the tombs, those portraits of old preachers and preachers’ wives, with
+stiff ruffs, and long black dresses, fixed their eyes on her red shoes.
+And she thought only of them as the clergyman laid his hand upon her
+head, and spoke of the holy baptism, of the covenant with God, and how
+she should be now a matured Christian; and the organ pealed so solemnly;
+the sweet children’s voices sang, and the old music-directors sang, but
+Karen only thought of her red shoes.
+
+In the afternoon, the old lady heard from everyone that the shoes had
+been red, and she said that it was very wrong of Karen, that it was not
+at all becoming, and that in future Karen should only go in black shoes
+to church, even when she should be older.
+
+The next Sunday there was the sacrament, and Karen looked at the black
+shoes, looked at the red ones--looked at them again, and put on the red
+shoes.
+
+The sun shone gloriously; Karen and the old lady walked along the path
+through the corn; it was rather dusty there.
+
+At the church door stood an old soldier with a crutch, and with a
+wonderfully long beard, which was more red than white, and he bowed to
+the ground, and asked the old lady whether he might dust her shoes. And
+Karen stretched out her little foot.
+
+“See, what beautiful dancing shoes!” said the soldier. “Sit firm when
+you dance”; and he put his hand out towards the soles.
+
+And the old lady gave the old soldier alms, and went into the church
+with Karen.
+
+And all the people in the church looked at Karen’s red shoes, and all
+the pictures, and as Karen knelt before the altar, and raised the cup to
+her lips, she only thought of the red shoes, and they seemed to swim
+in it; and she forgot to sing her psalm, and she forgot to pray, “Our
+Father in Heaven!”
+
+Now all the people went out of church, and the old lady got into her
+carriage. Karen raised her foot to get in after her, when the old
+soldier said,
+
+“Look, what beautiful dancing shoes!”
+
+And Karen could not help dancing a step or two, and when she began her
+feet continued to dance; it was just as though the shoes had power over
+them. She danced round the church corner, she could not leave off; the
+coachman was obliged to run after and catch hold of her, and he lifted
+her in the carriage, but her feet continued to dance so that she trod on
+the old lady dreadfully. At length she took the shoes off, and then her
+legs had peace.
+
+The shoes were placed in a closet at home, but Karen could not avoid
+looking at them.
+
+Now the old lady was sick, and it was said she could not recover. She
+must be nursed and waited upon, and there was no one whose duty it was
+so much as Karen’s. But there was a great ball in the city, to which
+Karen was invited. She looked at the old lady, who could not recover,
+she looked at the red shoes, and she thought there could be no sin in
+it; she put on the red shoes, she might do that also, she thought. But
+then she went to the ball and began to dance.
+
+When she wanted to dance to the right, the shoes would dance to the
+left, and when she wanted to dance up the room, the shoes danced back
+again, down the steps, into the street, and out of the city gate. She
+danced, and was forced to dance straight out into the gloomy wood.
+
+Then it was suddenly light up among the trees, and she fancied it must
+be the moon, for there was a face; but it was the old soldier with
+the red beard; he sat there, nodded his head, and said, “Look, what
+beautiful dancing shoes!”
+
+Then she was terrified, and wanted to fling off the red shoes, but they
+clung fast; and she pulled down her stockings, but the shoes seemed to
+have grown to her feet. And she danced, and must dance, over fields and
+meadows, in rain and sunshine, by night and day; but at night it was the
+most fearful.
+
+She danced over the churchyard, but the dead did not dance--they had
+something better to do than to dance. She wished to seat herself on a
+poor man’s grave, where the bitter tansy grew; but for her there was
+neither peace nor rest; and when she danced towards the open church
+door, she saw an angel standing there. He wore long, white garments; he
+had wings which reached from his shoulders to the earth; his countenance
+was severe and grave; and in his hand he held a sword, broad and
+glittering.
+
+“Dance shalt thou!” said he. “Dance in thy red shoes till thou art pale
+and cold! Till thy skin shrivels up and thou art a skeleton! Dance shalt
+thou from door to door, and where proud, vain children dwell, thou shalt
+knock, that they may hear thee and tremble! Dance shalt thou--!”
+
+“Mercy!” cried Karen. But she did not hear the angel’s reply, for the
+shoes carried her through the gate into the fields, across roads and
+bridges, and she must keep ever dancing.
+
+One morning she danced past a door which she well knew. Within sounded
+a psalm; a coffin, decked with flowers, was borne forth. Then she knew
+that the old lady was dead, and felt that she was abandoned by all, and
+condemned by the angel of God.
+
+She danced, and she was forced to dance through the gloomy night. The
+shoes carried her over stack and stone; she was torn till she bled; she
+danced over the heath till she came to a little house. Here, she knew,
+dwelt the executioner; and she tapped with her fingers at the window,
+and said, “Come out! Come out! I cannot come in, for I am forced to
+dance!”
+
+And the executioner said, “Thou dost not know who I am, I fancy? I
+strike bad people’s heads off; and I hear that my axe rings!”
+
+“Don’t strike my head off!” said Karen. “Then I can’t repent of my sins!
+But strike off my feet in the red shoes!”
+
+And then she confessed her entire sin, and the executioner struck off
+her feet with the red shoes, but the shoes danced away with the little
+feet across the field into the deep wood.
+
+And he carved out little wooden feet for her, and crutches, taught
+her the psalm criminals always sing; and she kissed the hand which had
+wielded the axe, and went over the heath.
+
+“Now I have suffered enough for the red shoes!” said she. “Now I will
+go into the church that people may see me!” And she hastened towards the
+church door: but when she was near it, the red shoes danced before her,
+and she was terrified, and turned round. The whole week she was unhappy,
+and wept many bitter tears; but when Sunday returned, she said, “Well,
+now I have suffered and struggled enough! I really believe I am as good
+as many a one who sits in the church, and holds her head so high!”
+
+And away she went boldly; but she had not got farther than the
+churchyard gate before she saw the red shoes dancing before her; and she
+was frightened, and turned back, and repented of her sin from her heart.
+
+And she went to the parsonage, and begged that they would take her
+into service; she would be very industrious, she said, and would do
+everything she could; she did not care about the wages, only she wished
+to have a home, and be with good people. And the clergyman’s wife was
+sorry for her and took her into service; and she was industrious and
+thoughtful. She sat still and listened when the clergyman read the Bible
+in the evenings. All the children thought a great deal of her; but when
+they spoke of dress, and grandeur, and beauty, she shook her head.
+
+The following Sunday, when the family was going to church, they asked
+her whether she would not go with them; but she glanced sorrowfully,
+with tears in her eyes, at her crutches. The family went to hear the
+word of God; but she went alone into her little chamber; there was only
+room for a bed and chair to stand in it; and here she sat down with her
+Prayer-Book; and whilst she read with a pious mind, the wind bore
+the strains of the organ towards her, and she raised her tearful
+countenance, and said, “O God, help me!”
+
+And the sun shone so clearly, and straight before her stood the angel
+of God in white garments, the same she had seen that night at the church
+door; but he no longer carried the sharp sword, but in its stead a
+splendid green spray, full of roses. And he touched the ceiling with the
+spray, and the ceiling rose so high, and where he had touched it there
+gleamed a golden star. And he touched the walls, and they widened out,
+and she saw the organ which was playing; she saw the old pictures of the
+preachers and the preachers’ wives. The congregation sat in cushioned
+seats, and sang out of their Prayer-Books. For the church itself had
+come to the poor girl in her narrow chamber, or else she had come into
+the church. She sat in the pew with the clergyman’s family, and when
+they had ended the psalm and looked up, they nodded and said, “It is
+right that thou art come!”
+
+“It was through mercy!” she said.
+
+And the organ pealed, and the children’s voices in the choir sounded so
+sweet and soft! The clear sunshine streamed so warmly through the window
+into the pew where Karen sat! Her heart was so full of sunshine, peace,
+and joy, that it broke. Her soul flew on the sunshine to God, and there
+no one asked after the RED SHOES.
+
+
+
+
+
+End of Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+***** This file should be named 1597-0.txt or 1597-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/5/9/1597/
+
+Produced by Dianne Bean
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/around-the-world-in-eighty-days.txt
+++ b/jet/source-sink-builder/src/main/resources/books/around-the-world-in-eighty-days.txt
@@ -1,0 +1,8406 @@
+﻿The Project Gutenberg EBook of Around the World in 80 Days, by Jules Verne
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Around the World in 80 Days
+
+Author: Jules Verne
+
+Release Date: May 15, 2008 [EBook #103]
+Last updated: February 18, 2012
+Last updated: May 5, 2012
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+
+
+
+
+
+
+
+
+
+
+
+
+AROUND THE WORLD IN EIGHTY DAYS
+
+
+
+CONTENTS
+
+
+CHAPTER
+
+      I  IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER, THE
+         ONE AS MASTER, THE OTHER AS MAN
+
+     II  IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND
+         HIS IDEAL
+
+    III  IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST
+         PHILEAS FOGG DEAR
+
+     IV  IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+      V  IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN,
+         APPEARS ON 'CHANGE
+
+     VI  IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+    VII  WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS
+         AIDS TO dETECTIVES
+
+   VIII  IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+     IX  IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS
+         TO THE DESIGNS OF PHILEAS FOGG
+
+      X  IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS
+         OF HIS SHOES
+
+     XI  IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE
+         AT A FABULOUS PRICE
+
+    XII  IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE
+         INDIAN FORESTS, AND WHAT ENSUED
+
+   XIII  IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS
+         THE BRAVE
+
+    XIV  IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL
+         VALLEY OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+     XV  IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS
+         MORE
+
+    XVI  IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS
+         SAID TO HIM
+
+   XVII  SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+  XVIII  IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS
+         BUSINESS
+
+    XIX  IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER,
+         AND WHAT COMES OF IT
+
+     XX  IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+    XXI  IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING
+         A REWARD OF TWO HUNDRED POUNDS
+
+   XXII  IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES,
+         IT IS CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+  XXIII  IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+  XXIV  DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+    XXV  IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+   XXVI  IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+  XXVII  IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN
+         HOUR, A COURSE OF MORMON HISTORY
+
+ XXVIII  IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN
+         TO REASON
+
+   XXIX  IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET
+         WITH ON AMERICAN RAILROADS
+
+    XXX  IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+   XXXI  IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS
+         OF PHILEAS FOGG
+
+  XXXII  IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD
+         FORTUNE
+
+ XXXIII  IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+  XXXIV  IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+   XXXV  IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+         PASSEPARTOUT TWICE
+
+  XXXVI  IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+ XXXVII  IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+         AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+
+
+Chapter I
+
+IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER,
+THE ONE AS MASTER, THE OTHER AS MAN
+
+
+Mr. Phileas Fogg lived, in 1872, at No. 7, Saville Row, Burlington
+Gardens, the house in which Sheridan died in 1814.  He was one of the
+most noticeable members of the Reform Club, though he seemed always to
+avoid attracting attention; an enigmatical personage, about whom little
+was known, except that he was a polished man of the world.  People said
+that he resembled Byron--at least that his head was Byronic; but he was
+a bearded, tranquil Byron, who might live on a thousand years without
+growing old.
+
+Certainly an Englishman, it was more doubtful whether Phileas Fogg was
+a Londoner.  He was never seen on 'Change, nor at the Bank, nor in the
+counting-rooms of the "City"; no ships ever came into London docks of
+which he was the owner; he had no public employment; he had never been
+entered at any of the Inns of Court, either at the Temple, or Lincoln's
+Inn, or Gray's Inn; nor had his voice ever resounded in the Court of
+Chancery, or in the Exchequer, or the Queen's Bench, or the
+Ecclesiastical Courts.  He certainly was not a manufacturer; nor was he
+a merchant or a gentleman farmer.  His name was strange to the
+scientific and learned societies, and he never was known to take part
+in the sage deliberations of the Royal Institution or the London
+Institution, the Artisan's Association, or the Institution of Arts and
+Sciences.  He belonged, in fact, to none of the numerous societies
+which swarm in the English capital, from the Harmonic to that of the
+Entomologists, founded mainly for the purpose of abolishing pernicious
+insects.
+
+Phileas Fogg was a member of the Reform, and that was all.
+
+The way in which he got admission to this exclusive club was simple
+enough.
+
+He was recommended by the Barings, with whom he had an open credit.
+His cheques were regularly paid at sight from his account current,
+which was always flush.
+
+Was Phileas Fogg rich?  Undoubtedly.  But those who knew him best could
+not imagine how he had made his fortune, and Mr. Fogg was the last
+person to whom to apply for the information.  He was not lavish, nor,
+on the contrary, avaricious; for, whenever he knew that money was
+needed for a noble, useful, or benevolent purpose, he supplied it
+quietly and sometimes anonymously.  He was, in short, the least
+communicative of men.  He talked very little, and seemed all the more
+mysterious for his taciturn manner.  His daily habits were quite open
+to observation; but whatever he did was so exactly the same thing that
+he had always done before, that the wits of the curious were fairly
+puzzled.
+
+Had he travelled?  It was likely, for no one seemed to know the world
+more familiarly; there was no spot so secluded that he did not appear
+to have an intimate acquaintance with it.  He often corrected, with a
+few clear words, the thousand conjectures advanced by members of the
+club as to lost and unheard-of travellers, pointing out the true
+probabilities, and seeming as if gifted with a sort of second sight, so
+often did events justify his predictions.  He must have travelled
+everywhere, at least in the spirit.
+
+It was at least certain that Phileas Fogg had not absented himself from
+London for many years.  Those who were honoured by a better
+acquaintance with him than the rest, declared that nobody could pretend
+to have ever seen him anywhere else.  His sole pastimes were reading
+the papers and playing whist.  He often won at this game, which, as a
+silent one, harmonised with his nature; but his winnings never went
+into his purse, being reserved as a fund for his charities.  Mr. Fogg
+played, not to win, but for the sake of playing.  The game was in his
+eyes a contest, a struggle with a difficulty, yet a motionless,
+unwearying struggle, congenial to his tastes.
+
+Phileas Fogg was not known to have either wife or children, which may
+happen to the most honest people; either relatives or near friends,
+which is certainly more unusual.  He lived alone in his house in
+Saville Row, whither none penetrated.  A single domestic sufficed to
+serve him.  He breakfasted and dined at the club, at hours
+mathematically fixed, in the same room, at the same table, never taking
+his meals with other members, much less bringing a guest with him; and
+went home at exactly midnight, only to retire at once to bed.  He never
+used the cosy chambers which the Reform provides for its favoured
+members.  He passed ten hours out of the twenty-four in Saville Row,
+either in sleeping or making his toilet.  When he chose to take a walk
+it was with a regular step in the entrance hall with its mosaic
+flooring, or in the circular gallery with its dome supported by twenty
+red porphyry Ionic columns, and illumined by blue painted windows.
+When he breakfasted or dined all the resources of the club--its
+kitchens and pantries, its buttery and dairy--aided to crowd his table
+with their most succulent stores; he was served by the gravest waiters,
+in dress coats, and shoes with swan-skin soles, who proffered the
+viands in special porcelain, and on the finest linen; club decanters,
+of a lost mould, contained his sherry, his port, and his
+cinnamon-spiced claret; while his beverages were refreshingly cooled
+with ice, brought at great cost from the American lakes.
+
+If to live in this style is to be eccentric, it must be confessed that
+there is something good in eccentricity.
+
+The mansion in Saville Row, though not sumptuous, was exceedingly
+comfortable.  The habits of its occupant were such as to demand but
+little from the sole domestic, but Phileas Fogg required him to be
+almost superhumanly prompt and regular.  On this very 2nd of October he
+had dismissed James Forster, because that luckless youth had brought
+him shaving-water at eighty-four degrees Fahrenheit instead of
+eighty-six; and he was awaiting his successor, who was due at the house
+between eleven and half-past.
+
+Phileas Fogg was seated squarely in his armchair, his feet close
+together like those of a grenadier on parade, his hands resting on his
+knees, his body straight, his head erect; he was steadily watching a
+complicated clock which indicated the hours, the minutes, the seconds,
+the days, the months, and the years.  At exactly half-past eleven Mr.
+Fogg would, according to his daily habit, quit Saville Row, and repair
+to the Reform.
+
+A rap at this moment sounded on the door of the cosy apartment where
+Phileas Fogg was seated, and James Forster, the dismissed servant,
+appeared.
+
+"The new servant," said he.
+
+A young man of thirty advanced and bowed.
+
+"You are a Frenchman, I believe," asked Phileas Fogg, "and your name is
+John?"
+
+"Jean, if monsieur pleases," replied the newcomer, "Jean Passepartout,
+a surname which has clung to me because I have a natural aptness for
+going out of one business into another.  I believe I'm honest,
+monsieur, but, to be outspoken, I've had several trades.  I've been an
+itinerant singer, a circus-rider, when I used to vault like Leotard,
+and dance on a rope like Blondin.  Then I got to be a professor of
+gymnastics, so as to make better use of my talents; and then I was a
+sergeant fireman at Paris, and assisted at many a big fire.  But I
+quitted France five years ago, and, wishing to taste the sweets of
+domestic life, took service as a valet here in England.  Finding myself
+out of place, and hearing that Monsieur Phileas Fogg was the most exact
+and settled gentleman in the United Kingdom, I have come to monsieur in
+the hope of living with him a tranquil life, and forgetting even the
+name of Passepartout."
+
+"Passepartout suits me," responded Mr. Fogg.  "You are well recommended
+to me; I hear a good report of you.  You know my conditions?"
+
+"Yes, monsieur."
+
+"Good!  What time is it?"
+
+"Twenty-two minutes after eleven," returned Passepartout, drawing an
+enormous silver watch from the depths of his pocket.
+
+"You are too slow," said Mr. Fogg.
+
+"Pardon me, monsieur, it is impossible--"
+
+"You are four minutes too slow.  No matter; it's enough to mention the
+error.  Now from this moment, twenty-nine minutes after eleven, a.m.,
+this Wednesday, 2nd October, you are in my service."
+
+Phileas Fogg got up, took his hat in his left hand, put it on his head
+with an automatic motion, and went off without a word.
+
+Passepartout heard the street door shut once; it was his new master
+going out.  He heard it shut again; it was his predecessor, James
+Forster, departing in his turn.  Passepartout remained alone in the
+house in Saville Row.
+
+
+
+
+Chapter II
+
+IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND HIS IDEAL
+
+
+"Faith," muttered Passepartout, somewhat flurried, "I've seen people at
+Madame Tussaud's as lively as my new master!"
+
+Madame Tussaud's "people," let it be said, are of wax, and are much
+visited in London; speech is all that is wanting to make them human.
+
+During his brief interview with Mr. Fogg, Passepartout had been
+carefully observing him.  He appeared to be a man about forty years of
+age, with fine, handsome features, and a tall, well-shaped figure; his
+hair and whiskers were light, his forehead compact and unwrinkled, his
+face rather pale, his teeth magnificent.  His countenance possessed in
+the highest degree what physiognomists call "repose in action," a
+quality of those who act rather than talk.  Calm and phlegmatic, with a
+clear eye, Mr. Fogg seemed a perfect type of that English composure
+which Angelica Kauffmann has so skilfully represented on canvas.  Seen
+in the various phases of his daily life, he gave the idea of being
+perfectly well-balanced, as exactly regulated as a Leroy chronometer.
+Phileas Fogg was, indeed, exactitude personified, and this was betrayed
+even in the expression of his very hands and feet; for in men, as well
+as in animals, the limbs themselves are expressive of the passions.
+
+He was so exact that he was never in a hurry, was always ready, and was
+economical alike of his steps and his motions.  He never took one step
+too many, and always went to his destination by the shortest cut; he
+made no superfluous gestures, and was never seen to be moved or
+agitated.  He was the most deliberate person in the world, yet always
+reached his destination at the exact moment.
+
+He lived alone, and, so to speak, outside of every social relation; and
+as he knew that in this world account must be taken of friction, and
+that friction retards, he never rubbed against anybody.
+
+As for Passepartout, he was a true Parisian of Paris.  Since he had
+abandoned his own country for England, taking service as a valet, he
+had in vain searched for a master after his own heart.  Passepartout
+was by no means one of those pert dunces depicted by Moliere with a
+bold gaze and a nose held high in the air; he was an honest fellow,
+with a pleasant face, lips a trifle protruding, soft-mannered and
+serviceable, with a good round head, such as one likes to see on the
+shoulders of a friend.  His eyes were blue, his complexion rubicund,
+his figure almost portly and well-built, his body muscular, and his
+physical powers fully developed by the exercises of his younger days.
+His brown hair was somewhat tumbled; for, while the ancient sculptors
+are said to have known eighteen methods of arranging Minerva's tresses,
+Passepartout was familiar with but one of dressing his own: three
+strokes of a large-tooth comb completed his toilet.
+
+It would be rash to predict how Passepartout's lively nature would
+agree with Mr. Fogg.  It was impossible to tell whether the new servant
+would turn out as absolutely methodical as his master required;
+experience alone could solve the question.  Passepartout had been a
+sort of vagrant in his early years, and now yearned for repose; but so
+far he had failed to find it, though he had already served in ten
+English houses.  But he could not take root in any of these; with
+chagrin, he found his masters invariably whimsical and irregular,
+constantly running about the country, or on the look-out for adventure.
+His last master, young Lord Longferry, Member of Parliament, after
+passing his nights in the Haymarket taverns, was too often brought home
+in the morning on policemen's shoulders.  Passepartout, desirous of
+respecting the gentleman whom he served, ventured a mild remonstrance
+on such conduct; which, being ill-received, he took his leave.  Hearing
+that Mr. Phileas Fogg was looking for a servant, and that his life was
+one of unbroken regularity, that he neither travelled nor stayed from
+home overnight, he felt sure that this would be the place he was after.
+He presented himself, and was accepted, as has been seen.
+
+At half-past eleven, then, Passepartout found himself alone in the
+house in Saville Row.  He began its inspection without delay, scouring
+it from cellar to garret.  So clean, well-arranged, solemn a mansion
+pleased him; it seemed to him like a snail's shell, lighted and warmed
+by gas, which sufficed for both these purposes.  When Passepartout
+reached the second story he recognised at once the room which he was to
+inhabit, and he was well satisfied with it.  Electric bells and
+speaking-tubes afforded communication with the lower stories; while on
+the mantel stood an electric clock, precisely like that in Mr. Fogg's
+bedchamber, both beating the same second at the same instant.  "That's
+good, that'll do," said Passepartout to himself.
+
+He suddenly observed, hung over the clock, a card which, upon
+inspection, proved to be a programme of the daily routine of the house.
+It comprised all that was required of the servant, from eight in the
+morning, exactly at which hour Phileas Fogg rose, till half-past
+eleven, when he left the house for the Reform Club--all the details of
+service, the tea and toast at twenty-three minutes past eight, the
+shaving-water at thirty-seven minutes past nine, and the toilet at
+twenty minutes before ten.  Everything was regulated and foreseen that
+was to be done from half-past eleven a.m. till midnight, the hour at
+which the methodical gentleman retired.
+
+Mr. Fogg's wardrobe was amply supplied and in the best taste.  Each
+pair of trousers, coat, and vest bore a number, indicating the time of
+year and season at which they were in turn to be laid out for wearing;
+and the same system was applied to the master's shoes.  In short, the
+house in Saville Row, which must have been a very temple of disorder
+and unrest under the illustrious but dissipated Sheridan, was cosiness,
+comfort, and method idealised.  There was no study, nor were there
+books, which would have been quite useless to Mr. Fogg; for at the
+Reform two libraries, one of general literature and the other of law
+and politics, were at his service.  A moderate-sized safe stood in his
+bedroom, constructed so as to defy fire as well as burglars; but
+Passepartout found neither arms nor hunting weapons anywhere;
+everything betrayed the most tranquil and peaceable habits.
+
+Having scrutinised the house from top to bottom, he rubbed his hands, a
+broad smile overspread his features, and he said joyfully, "This is
+just what I wanted!  Ah, we shall get on together, Mr. Fogg and I!
+What a domestic and regular gentleman!  A real machine; well, I don't
+mind serving a machine."
+
+
+
+
+Chapter III
+
+IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST PHILEAS
+FOGG DEAR
+
+
+Phileas Fogg, having shut the door of his house at half-past eleven,
+and having put his right foot before his left five hundred and
+seventy-five times, and his left foot before his right five hundred and
+seventy-six times, reached the Reform Club, an imposing edifice in Pall
+Mall, which could not have cost less than three millions.  He repaired
+at once to the dining-room, the nine windows of which open upon a
+tasteful garden, where the trees were already gilded with an autumn
+colouring; and took his place at the habitual table, the cover of which
+had already been laid for him.  His breakfast consisted of a side-dish,
+a broiled fish with Reading sauce, a scarlet slice of roast beef
+garnished with mushrooms, a rhubarb and gooseberry tart, and a morsel
+of Cheshire cheese, the whole being washed down with several cups of
+tea, for which the Reform is famous.  He rose at thirteen minutes to
+one, and directed his steps towards the large hall, a sumptuous
+apartment adorned with lavishly-framed paintings.  A flunkey handed him
+an uncut Times, which he proceeded to cut with a skill which betrayed
+familiarity with this delicate operation.  The perusal of this paper
+absorbed Phileas Fogg until a quarter before four, whilst the Standard,
+his next task, occupied him till the dinner hour.  Dinner passed as
+breakfast had done, and Mr. Fogg re-appeared in the reading-room and
+sat down to the Pall Mall at twenty minutes before six.  Half an hour
+later several members of the Reform came in and drew up to the
+fireplace, where a coal fire was steadily burning.  They were Mr.
+Fogg's usual partners at whist: Andrew Stuart, an engineer; John
+Sullivan and Samuel Fallentin, bankers; Thomas Flanagan, a brewer; and
+Gauthier Ralph, one of the Directors of the Bank of England--all rich
+and highly respectable personages, even in a club which comprises the
+princes of English trade and finance.
+
+"Well, Ralph," said Thomas Flanagan, "what about that robbery?"
+
+"Oh," replied Stuart, "the Bank will lose the money."
+
+"On the contrary," broke in Ralph, "I hope we may put our hands on the
+robber.  Skilful detectives have been sent to all the principal ports
+of America and the Continent, and he'll be a clever fellow if he slips
+through their fingers."
+
+"But have you got the robber's description?" asked Stuart.
+
+"In the first place, he is no robber at all," returned Ralph,
+positively.
+
+"What! a fellow who makes off with fifty-five thousand pounds, no
+robber?"
+
+"No."
+
+"Perhaps he's a manufacturer, then."
+
+"The Daily Telegraph says that he is a gentleman."
+
+It was Phileas Fogg, whose head now emerged from behind his newspapers,
+who made this remark.  He bowed to his friends, and entered into the
+conversation.  The affair which formed its subject, and which was town
+talk, had occurred three days before at the Bank of England.  A package
+of banknotes, to the value of fifty-five thousand pounds, had been
+taken from the principal cashier's table, that functionary being at the
+moment engaged in registering the receipt of three shillings and
+sixpence.  Of course, he could not have his eyes everywhere.  Let it be
+observed that the Bank of England reposes a touching confidence in the
+honesty of the public.  There are neither guards nor gratings to
+protect its treasures; gold, silver, banknotes are freely exposed, at
+the mercy of the first comer.  A keen observer of English customs
+relates that, being in one of the rooms of the Bank one day, he had the
+curiosity to examine a gold ingot weighing some seven or eight pounds.
+He took it up, scrutinised it, passed it to his neighbour, he to the
+next man, and so on until the ingot, going from hand to hand, was
+transferred to the end of a dark entry; nor did it return to its place
+for half an hour.  Meanwhile, the cashier had not so much as raised his
+head.  But in the present instance things had not gone so smoothly.
+The package of notes not being found when five o'clock sounded from the
+ponderous clock in the "drawing office," the amount was passed to the
+account of profit and loss.  As soon as the robbery was discovered,
+picked detectives hastened off to Liverpool, Glasgow, Havre, Suez,
+Brindisi, New York, and other ports, inspired by the proffered reward
+of two thousand pounds, and five per cent. on the sum that might be
+recovered.  Detectives were also charged with narrowly watching those
+who arrived at or left London by rail, and a judicial examination was
+at once entered upon.
+
+There were real grounds for supposing, as the Daily Telegraph said,
+that the thief did not belong to a professional band.  On the day of
+the robbery a well-dressed gentleman of polished manners, and with a
+well-to-do air, had been observed going to and fro in the paying room
+where the crime was committed.  A description of him was easily
+procured and sent to the detectives; and some hopeful spirits, of whom
+Ralph was one, did not despair of his apprehension.  The papers and
+clubs were full of the affair, and everywhere people were discussing
+the probabilities of a successful pursuit; and the Reform Club was
+especially agitated, several of its members being Bank officials.
+
+Ralph would not concede that the work of the detectives was likely to
+be in vain, for he thought that the prize offered would greatly
+stimulate their zeal and activity.  But Stuart was far from sharing
+this confidence; and, as they placed themselves at the whist-table,
+they continued to argue the matter.  Stuart and Flanagan played
+together, while Phileas Fogg had Fallentin for his partner.  As the
+game proceeded the conversation ceased, excepting between the rubbers,
+when it revived again.
+
+"I maintain," said Stuart, "that the chances are in favour of the
+thief, who must be a shrewd fellow."
+
+"Well, but where can he fly to?" asked Ralph.  "No country is safe for
+him."
+
+"Pshaw!"
+
+"Where could he go, then?"
+
+"Oh, I don't know that.  The world is big enough."
+
+"It was once," said Phileas Fogg, in a low tone.  "Cut, sir," he added,
+handing the cards to Thomas Flanagan.
+
+The discussion fell during the rubber, after which Stuart took up its
+thread.
+
+"What do you mean by `once'?  Has the world grown smaller?"
+
+"Certainly," returned Ralph.  "I agree with Mr. Fogg.  The world has
+grown smaller, since a man can now go round it ten times more quickly
+than a hundred years ago.  And that is why the search for this thief
+will be more likely to succeed."
+
+"And also why the thief can get away more easily."
+
+"Be so good as to play, Mr. Stuart," said Phileas Fogg.
+
+But the incredulous Stuart was not convinced, and when the hand was
+finished, said eagerly: "You have a strange way, Ralph, of proving that
+the world has grown smaller.  So, because you can go round it in three
+months--"
+
+"In eighty days," interrupted Phileas Fogg.
+
+"That is true, gentlemen," added John Sullivan.  "Only eighty days, now
+that the section between Rothal and Allahabad, on the Great Indian
+Peninsula Railway, has been opened.  Here is the estimate made by the
+Daily Telegraph:
+
+  From London to Suez via Mont Cenis and
+    Brindisi, by rail and steamboats .................  7 days
+  From Suez to Bombay, by steamer .................... 13  "
+  From Bombay to Calcutta, by rail ...................  3  "
+  From Calcutta to Hong Kong, by steamer ............. 13  "
+  From Hong Kong to Yokohama (Japan), by steamer .....  6  "
+  From Yokohama to San Francisco, by steamer ......... 22  "
+  From San Francisco to New York, by rail ............. 7  "
+  From New York to London, by steamer and rail ........ 9  "
+                                                       ------
+    Total ............................................ 80 days."
+
+"Yes, in eighty days!" exclaimed Stuart, who in his excitement made a
+false deal.  "But that doesn't take into account bad weather, contrary
+winds, shipwrecks, railway accidents, and so on."
+
+"All included," returned Phileas Fogg, continuing to play despite the
+discussion.
+
+"But suppose the Hindoos or Indians pull up the rails," replied Stuart;
+"suppose they stop the trains, pillage the luggage-vans, and scalp the
+passengers!"
+
+"All included," calmly retorted Fogg; adding, as he threw down the
+cards, "Two trumps."
+
+Stuart, whose turn it was to deal, gathered them up, and went on: "You
+are right, theoretically, Mr. Fogg, but practically--"
+
+"Practically also, Mr. Stuart."
+
+"I'd like to see you do it in eighty days."
+
+"It depends on you.  Shall we go?"
+
+"Heaven preserve me!  But I would wager four thousand pounds that such
+a journey, made under these conditions, is impossible."
+
+"Quite possible, on the contrary," returned Mr. Fogg.
+
+"Well, make it, then!"
+
+"The journey round the world in eighty days?"
+
+"Yes."
+
+"I should like nothing better."
+
+"When?"
+
+"At once.  Only I warn you that I shall do it at your expense."
+
+"It's absurd!" cried Stuart, who was beginning to be annoyed at the
+persistency of his friend.  "Come, let's go on with the game."
+
+"Deal over again, then," said Phileas Fogg.  "There's a false deal."
+
+Stuart took up the pack with a feverish hand; then suddenly put them
+down again.
+
+"Well, Mr. Fogg," said he, "it shall be so: I will wager the four
+thousand on it."
+
+"Calm yourself, my dear Stuart," said Fallentin.  "It's only a joke."
+
+"When I say I'll wager," returned Stuart, "I mean it."  
+
+"All right," said Mr. Fogg; and, turning to the others, he continued:
+"I have a deposit of twenty thousand at Baring's which I will willingly
+risk upon it."
+
+"Twenty thousand pounds!" cried Sullivan.  "Twenty thousand pounds,
+which you would lose by a single accidental delay!"
+
+"The unforeseen does not exist," quietly replied Phileas Fogg.
+
+"But, Mr. Fogg, eighty days are only the estimate of the least possible
+time in which the journey can be made."
+
+"A well-used minimum suffices for everything."
+
+"But, in order not to exceed it, you must jump mathematically from the
+trains upon the steamers, and from the steamers upon the trains again."
+
+"I will jump--mathematically."
+
+"You are joking."
+
+"A true Englishman doesn't joke when he is talking about so serious a
+thing as a wager," replied Phileas Fogg, solemnly.  "I will bet twenty
+thousand pounds against anyone who wishes that I will make the tour of
+the world in eighty days or less; in nineteen hundred and twenty hours,
+or a hundred and fifteen thousand two hundred minutes.  Do you accept?"
+
+"We accept," replied Messrs. Stuart, Fallentin, Sullivan, Flanagan, and
+Ralph, after consulting each other.
+
+"Good," said Mr. Fogg.  "The train leaves for Dover at a quarter before
+nine.  I will take it."
+
+"This very evening?" asked Stuart.
+
+"This very evening," returned Phileas Fogg.  He took out and consulted
+a pocket almanac, and added,  "As today is Wednesday, the 2nd of
+October, I shall be due in London in this very room of the Reform Club,
+on Saturday, the 21st of December, at a quarter before nine p.m.; or
+else the twenty thousand pounds, now deposited in my name at Baring's,
+will belong to you, in fact and in right, gentlemen.  Here is a cheque
+for the amount."
+
+A memorandum of the wager was at once drawn up and signed by the six
+parties, during which Phileas Fogg preserved a stoical composure.  He
+certainly did not bet to win, and had only staked the twenty thousand
+pounds, half of his fortune, because he foresaw that he might have to
+expend the other half to carry out this difficult, not to say
+unattainable, project.  As for his antagonists, they seemed much
+agitated; not so much by the value of their stake, as because they had
+some scruples about betting under conditions so difficult to their
+friend.
+
+The clock struck seven, and the party offered to suspend the game so
+that Mr. Fogg might make his preparations for departure.
+
+"I am quite ready now," was his tranquil response.  "Diamonds are
+trumps: be so good as to play, gentlemen."
+
+
+
+
+Chapter IV
+
+IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+
+Having won twenty guineas at whist, and taken leave of his friends,
+Phileas Fogg, at twenty-five minutes past seven, left the Reform Club.
+
+Passepartout, who had conscientiously studied the programme of his
+duties, was more than surprised to see his master guilty of the
+inexactness of appearing at this unaccustomed hour; for, according to
+rule, he was not due in Saville Row until precisely midnight.
+
+Mr. Fogg repaired to his bedroom, and called out, "Passepartout!"
+
+Passepartout did not reply.  It could not be he who was called; it was
+not the right hour.
+
+"Passepartout!" repeated Mr. Fogg, without raising his voice.
+
+Passepartout made his appearance.
+
+"I've called you twice," observed his master.
+
+"But it is not midnight," responded the other, showing his watch.
+
+"I know it; I don't blame you.  We start for Dover and Calais in ten
+minutes."
+
+A puzzled grin overspread Passepartout's round face; clearly he had not
+comprehended his master.
+
+"Monsieur is going to leave home?"
+
+"Yes," returned Phileas Fogg.  "We are going round the world."
+
+Passepartout opened wide his eyes, raised his eyebrows, held up his
+hands, and seemed about to collapse, so overcome was he with stupefied
+astonishment.
+
+"Round the world!" he murmured.
+
+"In eighty days," responded Mr. Fogg.  "So we haven't a moment to lose."
+
+"But the trunks?" gasped Passepartout, unconsciously swaying his head
+from right to left.
+
+"We'll have no trunks; only a carpet-bag, with two shirts and three
+pairs of stockings for me, and the same for you.  We'll buy our clothes
+on the way.  Bring down my mackintosh and traveling-cloak, and some
+stout shoes, though we shall do little walking.  Make haste!"
+
+Passepartout tried to reply, but could not.  He went out, mounted to
+his own room, fell into a chair, and muttered: "That's good, that is!
+And I, who wanted to remain quiet!"
+
+He mechanically set about making the preparations for departure.
+Around the world in eighty days!  Was his master a fool?  No.  Was this
+a joke, then?  They were going to Dover; good!  To Calais; good again!
+After all, Passepartout, who had been away from France five years,
+would not be sorry to set foot on his native soil again.  Perhaps they
+would go as far as Paris, and it would do his eyes good to see Paris
+once more.  But surely a gentleman so chary of his steps would stop
+there; no doubt--but, then, it was none the less true that he was
+going away, this so domestic person hitherto!
+
+By eight o'clock Passepartout had packed the modest carpet-bag,
+containing the wardrobes of his master and himself; then, still
+troubled in mind, he carefully shut the door of his room, and descended
+to Mr. Fogg.
+
+Mr. Fogg was quite ready.  Under his arm might have been observed a
+red-bound copy of Bradshaw's Continental Railway Steam Transit and
+General Guide, with its timetables showing the arrival and departure of
+steamers and railways.  He took the carpet-bag, opened it, and slipped
+into it a goodly roll of Bank of England notes, which would pass
+wherever he might go.
+
+"You have forgotten nothing?" asked he.
+
+"Nothing, monsieur."
+
+"My mackintosh and cloak?"
+
+"Here they are."
+
+"Good!  Take this carpet-bag," handing it to Passepartout.  "Take good
+care of it, for there are twenty thousand pounds in it."
+
+Passepartout nearly dropped the bag, as if the twenty thousand pounds
+were in gold, and weighed him down.
+
+Master and man then descended, the street-door was double-locked, and
+at the end of Saville Row they took a cab and drove rapidly to Charing
+Cross.  The cab stopped before the railway station at twenty minutes
+past eight.  Passepartout jumped off the box and followed his master,
+who, after paying the cabman, was about to enter the station, when a
+poor beggar-woman, with a child in her arms, her naked feet smeared
+with mud, her head covered with a wretched bonnet, from which hung a
+tattered feather, and her shoulders shrouded in a ragged shawl,
+approached, and mournfully asked for alms.
+
+Mr. Fogg took out the twenty guineas he had just won at whist, and
+handed them to the beggar, saying, "Here, my good woman.  I'm glad that
+I met you;" and passed on.
+
+Passepartout had a moist sensation about the eyes; his master's action
+touched his susceptible heart.
+
+Two first-class tickets for Paris having been speedily purchased, Mr.
+Fogg was crossing the station to the train, when he perceived his five
+friends of the Reform.
+
+"Well, gentlemen," said he, "I'm off, you see; and, if you will examine
+my passport when I get back, you will be able to judge whether I have
+accomplished the journey agreed upon."
+
+"Oh, that would be quite unnecessary, Mr. Fogg," said Ralph politely.
+"We will trust your word, as a gentleman of honour."
+
+"You do not forget when you are due in London again?"  asked Stuart.
+
+"In eighty days; on Saturday, the 21st of December, 1872, at a quarter
+before nine p.m.  Good-bye, gentlemen."
+
+Phileas Fogg and his servant seated themselves in a first-class
+carriage at twenty minutes before nine; five minutes later the whistle
+screamed, and the train slowly glided out of the station.
+
+The night was dark, and a fine, steady rain was falling.  Phileas Fogg,
+snugly ensconced in his corner, did not open his lips.  Passepartout,
+not yet recovered from his stupefaction, clung mechanically to the
+carpet-bag, with its enormous treasure.
+
+Just as the train was whirling through Sydenham, Passepartout suddenly
+uttered a cry of despair.
+
+"What's the matter?" asked Mr. Fogg.
+
+"Alas!  In my hurry--I--I forgot--"
+
+"What?"
+
+"To turn off the gas in my room!"
+
+"Very well, young man," returned Mr. Fogg, coolly; "it will burn--at
+your expense."
+
+
+
+
+Chapter V
+
+
+IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN, APPEARS ON
+'CHANGE
+
+
+Phileas Fogg rightly suspected that his departure from London would
+create a lively sensation at the West End.  The news of the bet spread
+through the Reform Club, and afforded an exciting topic of conversation
+to its members.  From the club it soon got into the papers throughout
+England.  The boasted "tour of the world" was talked about, disputed,
+argued with as much warmth as if the subject were another Alabama
+claim.  Some took sides with Phileas Fogg, but the large majority shook
+their heads and declared against him; it was absurd, impossible, they
+declared, that the tour of the world could be made, except
+theoretically and on paper, in this minimum of time, and with the
+existing means of travelling.  The Times, Standard, Morning Post, and
+Daily News, and twenty other highly respectable newspapers scouted Mr.
+Fogg's project as madness; the Daily Telegraph alone hesitatingly
+supported him.  People in general thought him a lunatic, and blamed his
+Reform Club friends for having accepted a wager which betrayed the
+mental aberration of its proposer.
+
+Articles no less passionate than logical appeared on the question, for
+geography is one of the pet subjects of the English; and the columns
+devoted to Phileas Fogg's venture were eagerly devoured by all classes
+of readers.  At first some rash individuals, principally of the gentler
+sex, espoused his cause, which became still more popular when the
+Illustrated London News came out with his portrait, copied from a
+photograph in the Reform Club.  A few readers of the Daily Telegraph
+even dared to say, "Why not, after all?  Stranger things have come to
+pass."
+
+At last a long article appeared, on the 7th of October, in the bulletin
+of the Royal Geographical Society, which treated the question from
+every point of view, and demonstrated the utter folly of the enterprise.
+
+Everything, it said, was against the travellers, every obstacle imposed
+alike by man and by nature.  A miraculous agreement of the times of
+departure and arrival, which was impossible, was absolutely necessary
+to his success.  He might, perhaps, reckon on the arrival of trains at
+the designated hours, in Europe, where the distances were relatively
+moderate; but when he calculated upon crossing India in three days, and
+the United States in seven, could he rely beyond misgiving upon
+accomplishing his task?  There were accidents to machinery, the
+liability of trains to run off the line, collisions, bad weather, the
+blocking up by snow--were not all these against Phileas Fogg?  Would he
+not find himself, when travelling by steamer in winter, at the mercy of
+the winds and fogs?  Is it uncommon for the best ocean steamers to be
+two or three days behind time?  But a single delay would suffice to
+fatally break the chain of communication; should Phileas Fogg once
+miss, even by an hour; a steamer, he would have to wait for the next,
+and that would irrevocably render his attempt vain.
+
+This article made a great deal of noise, and, being copied into all the
+papers, seriously depressed the advocates of the rash tourist.
+
+Everybody knows that England is the world of betting men, who are of a
+higher class than mere gamblers; to bet is in the English temperament.
+Not only the members of the Reform, but the general public, made heavy
+wagers for or against Phileas Fogg, who was set down in the betting
+books as if he were a race-horse.  Bonds were issued, and made their
+appearance on 'Change; "Phileas Fogg bonds" were offered at par or at a
+premium, and a great business was done in them.  But five days after
+the article in the bulletin of the Geographical Society appeared, the
+demand began to subside:  "Phileas Fogg" declined.  They were offered
+by packages, at first of five, then of ten, until at last nobody would
+take less than twenty, fifty, a hundred!
+
+Lord Albemarle, an elderly paralytic gentleman, was now the only
+advocate of Phileas Fogg left.  This noble lord, who was fastened to
+his chair, would have given his fortune to be able to make the tour of
+the world, if it took ten years; and he bet five thousand pounds on
+Phileas Fogg.  When the folly as well as the uselessness of the
+adventure was pointed out to him, he contented himself with replying,
+"If the thing is feasible, the first to do it ought to be an
+Englishman."
+
+The Fogg party dwindled more and more, everybody was going against him,
+and the bets stood a hundred and fifty and two hundred to one; and a
+week after his departure an incident occurred which deprived him of
+backers at any price.
+
+The commissioner of police was sitting in his office at nine o'clock
+one evening, when the following telegraphic dispatch was put into his
+hands:
+
+Suez to London.
+
+Rowan, Commissioner of Police, Scotland Yard:
+
+I've found the bank robber, Phileas Fogg.  Send with out delay warrant
+of arrest to Bombay.
+
+Fix, Detective.
+
+The effect of this dispatch was instantaneous.  The polished gentleman
+disappeared to give place to the bank robber.  His photograph, which
+was hung with those of the rest of the members at the Reform Club, was
+minutely examined, and it betrayed, feature by feature, the description
+of the robber which had been provided to the police.  The mysterious
+habits of Phileas Fogg were recalled; his solitary ways, his sudden
+departure; and it seemed clear that, in undertaking a tour round the
+world on the pretext of a wager, he had had no other end in view than
+to elude the detectives, and throw them off his track.
+
+
+
+
+Chapter VI
+
+IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+
+The circumstances under which this telegraphic dispatch about Phileas
+Fogg was sent were as follows:
+
+The steamer Mongolia, belonging to the Peninsular and Oriental Company,
+built of iron, of two thousand eight hundred tons burden, and five
+hundred horse-power, was due at eleven o'clock a.m. on Wednesday, the
+9th of October, at Suez.  The Mongolia plied regularly between Brindisi
+and Bombay via the Suez Canal, and was one of the fastest steamers
+belonging to the company, always making more than ten knots an hour
+between Brindisi and Suez, and nine and a half between Suez and Bombay.
+
+Two men were promenading up and down the wharves, among the crowd of
+natives and strangers who were sojourning at this once straggling
+village--now, thanks to the enterprise of M. Lesseps, a fast-growing
+town.  One was the British consul at Suez, who, despite the prophecies
+of the English Government, and the unfavourable predictions of
+Stephenson, was in the habit of seeing, from his office window, English
+ships daily passing to and fro on the great canal, by which the old
+roundabout route from England to India by the Cape of Good Hope was
+abridged by at least a half.  The other was a small, slight-built
+personage, with a nervous, intelligent face, and bright eyes peering
+out from under eyebrows which he was incessantly twitching.  He was
+just now manifesting unmistakable signs of impatience, nervously pacing
+up and down, and unable to stand still for a moment.  This was Fix, one
+of the detectives who had been dispatched from England in search of the
+bank robber; it was his task to narrowly watch every passenger who
+arrived at Suez, and to follow up all who seemed to be suspicious
+characters, or bore a resemblance to the description of the criminal,
+which he had received two days before from the police headquarters at
+London.  The detective was evidently inspired by the hope of obtaining
+the splendid reward which would be the prize of success, and awaited
+with a feverish impatience, easy to understand, the arrival of the
+steamer Mongolia.
+
+"So you say, consul," asked he for the twentieth time, "that this
+steamer is never behind time?"
+
+"No, Mr. Fix," replied the consul.  "She was bespoken yesterday at Port
+Said, and the rest of the way is of no account to such a craft.  I
+repeat that the Mongolia has been in advance of the time required by
+the company's regulations, and gained the prize awarded for excess of
+speed."
+
+"Does she come directly from Brindisi?"
+
+"Directly from Brindisi; she takes on the Indian mails there, and she
+left there Saturday at five p.m.  Have patience, Mr. Fix; she will not
+be late.  But really, I don't see how, from the description you have,
+you will be able to recognise your man, even if he is on board the
+Mongolia."
+
+"A man rather feels the presence of these fellows, consul, than
+recognises them.  You must have a scent for them, and a scent is like a
+sixth sense which combines hearing, seeing, and smelling.  I've
+arrested more than one of these gentlemen in my time, and, if my thief
+is on board, I'll answer for it; he'll not slip through my fingers."
+
+"I hope so, Mr. Fix, for it was a heavy robbery."
+
+"A magnificent robbery, consul; fifty-five thousand pounds!  We don't
+often have such windfalls.  Burglars are getting to be so contemptible
+nowadays!  A fellow gets hung for a handful of shillings!"
+
+"Mr. Fix," said the consul, "I like your way of talking, and hope
+you'll succeed; but I fear you will find it far from easy.  Don't you
+see, the description which you have there has a singular resemblance to
+an honest man?"
+
+"Consul," remarked the detective, dogmatically, "great robbers always
+resemble honest folks.  Fellows who have rascally faces have only one
+course to take, and that is to remain honest; otherwise they would be
+arrested off-hand.  The artistic thing is, to unmask honest
+countenances; it's no light task, I admit, but a real art."
+
+Mr. Fix evidently was not wanting in a tinge of self-conceit.
+
+Little by little the scene on the quay became more animated; sailors of
+various nations, merchants, ship-brokers, porters, fellahs, bustled to
+and fro as if the steamer were immediately expected.  The weather was
+clear, and slightly chilly.  The minarets of the town loomed above the
+houses in the pale rays of the sun.  A jetty pier, some two thousand
+yards along, extended into the roadstead.  A number of fishing-smacks
+and coasting boats, some retaining the fantastic fashion of ancient
+galleys, were discernible on the Red Sea.
+
+As he passed among the busy crowd, Fix, according to habit, scrutinised
+the passers-by with a keen, rapid glance.
+
+It was now half-past ten.
+
+"The steamer doesn't come!" he exclaimed, as the port clock struck.
+
+"She can't be far off now," returned his companion.
+
+"How long will she stop at Suez?"
+
+"Four hours; long enough to get in her coal.  It is thirteen hundred
+and ten miles from Suez to Aden, at the other end of the Red Sea, and
+she has to take in a fresh coal supply."
+
+"And does she go from Suez directly to Bombay?"
+
+"Without putting in anywhere."
+
+"Good!" said Fix.  "If the robber is on board he will no doubt get off
+at Suez, so as to reach the Dutch or French colonies in Asia by some
+other route.  He ought to know that he would not be safe an hour in
+India, which is English soil."
+
+"Unless," objected the consul, "he is exceptionally shrewd.  An English
+criminal, you know, is always better concealed in London than anywhere
+else."
+
+This observation furnished the detective food for thought, and
+meanwhile the consul went away to his office.  Fix, left alone, was
+more impatient than ever, having a presentiment that the robber was on
+board the Mongolia.  If he had indeed left London intending to reach
+the New World, he would naturally take the route via India, which was
+less watched and more difficult to watch than that of the Atlantic.
+But Fix's reflections were soon interrupted by a succession of sharp
+whistles, which announced the arrival of the Mongolia.  The porters and
+fellahs rushed down the quay, and a dozen boats pushed off from the
+shore to go and meet the steamer.  Soon her gigantic hull appeared
+passing along between the banks, and eleven o'clock struck as she
+anchored in the road.  She brought an unusual number of passengers,
+some of whom remained on deck to scan the picturesque panorama of the
+town, while the greater part disembarked in the boats, and landed on
+the quay.
+
+Fix took up a position, and carefully examined each face and figure
+which made its appearance.  Presently one of the passengers, after
+vigorously pushing his way through the importunate crowd of porters,
+came up to him and politely asked if he could point out the English
+consulate, at the same time showing a passport which he wished to have
+visaed.  Fix instinctively took the passport, and with a rapid glance
+read the description of its bearer.  An involuntary motion of surprise
+nearly escaped him, for the description in the passport was identical
+with that of the bank robber which he had received from Scotland Yard.
+
+"Is this your passport?" asked he.
+
+"No, it's my master's."
+
+"And your master is--"
+
+"He stayed on board."
+
+"But he must go to the consul's in person, so as to establish his
+identity."
+
+"Oh, is that necessary?"
+
+"Quite indispensable."
+
+"And where is the consulate?"
+
+"There, on the corner of the square," said Fix, pointing to a house two
+hundred steps off.
+
+"I'll go and fetch my master, who won't be much pleased, however, to be
+disturbed."
+
+The passenger bowed to Fix, and returned to the steamer.
+
+
+
+
+Chapter VII
+
+WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS AIDS TO
+DETECTIVES
+
+
+The detective passed down the quay, and rapidly made his way to the
+consul's office, where he was at once admitted to the presence of that
+official.
+
+"Consul," said he, without preamble, "I have strong reasons for
+believing that my man is a passenger on the Mongolia." And he narrated
+what had just passed concerning the passport.
+
+"Well, Mr. Fix," replied the consul, "I shall not be sorry to see the
+rascal's face; but perhaps he won't come here--that is, if he is the
+person you suppose him to be.  A robber doesn't quite like to leave
+traces of his flight behind him; and, besides, he is not obliged to
+have his passport countersigned."
+
+"If he is as shrewd as I think he is, consul, he will come."
+
+"To have his passport visaed?"
+
+"Yes.  Passports are only good for annoying honest folks, and aiding in
+the flight of rogues.  I assure you it will be quite the thing for him
+to do; but I hope you will not visa the passport."
+
+"Why not?  If the passport is genuine I have no right to refuse."
+
+"Still, I must keep this man here until I can get a warrant to arrest
+him from London."
+
+"Ah, that's your look-out.  But I cannot--"
+
+The consul did not finish his sentence, for as he spoke a knock was
+heard at the door, and two strangers entered, one of whom was the
+servant whom Fix had met on the quay.  The other, who was his master,
+held out his passport with the request that the consul would do him the
+favour to visa it.  The consul took the document and carefully read it,
+whilst Fix observed, or rather devoured, the stranger with his eyes
+from a corner of the room.
+
+"You are Mr. Phileas Fogg?" said the consul, after reading the passport.
+
+"I am."
+
+"And this man is your servant?"
+
+"He is: a Frenchman, named Passepartout."
+
+"You are from London?"
+
+"Yes."
+
+"And you are going--"
+
+"To Bombay."
+
+"Very good, sir.  You know that a visa is useless, and that no passport
+is required?"
+
+"I know it, sir," replied Phileas Fogg; "but I wish to prove, by your
+visa, that I came by Suez."
+
+"Very well, sir."
+
+The consul proceeded to sign and date the passport, after which he
+added his official seal.  Mr. Fogg paid the customary fee, coldly
+bowed, and went out, followed by his servant.
+
+"Well?" queried the detective.
+
+"Well, he looks and acts like a perfectly honest man," replied the
+consul.
+
+"Possibly; but that is not the question.  Do you think, consul, that
+this phlegmatic gentleman resembles, feature by feature, the robber
+whose description I have received?"
+
+"I concede that; but then, you know, all descriptions--"
+
+"I'll make certain of it," interrupted Fix.  "The servant seems to me
+less mysterious than the master; besides, he's a Frenchman, and can't
+help talking.  Excuse me for a little while, consul."
+
+Fix started off in search of Passepartout.
+
+Meanwhile Mr. Fogg, after leaving the consulate, repaired to the quay,
+gave some orders to Passepartout, went off to the    Mongolia in a
+boat, and descended to his cabin.  He took up his note-book, which
+contained the following memoranda:
+
+"Left London, Wednesday, October 2nd, at 8.45 p.m.  "Reached Paris,
+Thursday, October 3rd, at 7.20 a.m.  "Left Paris, Thursday, at 8.40
+a.m.  "Reached Turin by Mont Cenis, Friday, October 4th, at 6.35 a.m.
+"Left Turin, Friday, at 7.20 a.m.  "Arrived at Brindisi, Saturday,
+October 5th, at 4 p.m.  "Sailed on the Mongolia, Saturday, at 5 p.m.
+"Reached Suez, Wednesday, October 9th, at 11 a.m.  "Total of hours
+spent, 158+; or, in days, six days and a half."
+
+These dates were inscribed in an itinerary divided into columns,
+indicating the month, the day of the month, and the day for the
+stipulated and actual arrivals at each principal point Paris, Brindisi,
+Suez, Bombay, Calcutta, Singapore, Hong Kong, Yokohama, San Francisco,
+New York, and London--from the 2nd of October to the 21st of December;
+and giving a space for setting down the gain made or the loss suffered
+on arrival at each locality.  This methodical record thus contained an
+account of everything needed, and Mr. Fogg always knew whether he was
+behind-hand or in advance of his time.  On this Friday, October 9th, he
+noted his arrival at Suez, and observed that he had as yet neither
+gained nor lost.  He sat down quietly to breakfast in his cabin, never
+once thinking of inspecting the town, being one of those Englishmen who
+are wont to see foreign countries through the eyes of their domestics.
+
+
+
+
+Chapter VIII
+
+IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+
+Fix soon rejoined Passepartout, who was lounging and looking about on
+the quay, as if he did not feel that he, at least, was obliged not to
+see anything.
+
+"Well, my friend," said the detective, coming up with him, "is your
+passport visaed?"
+
+"Ah, it's you, is it, monsieur?" responded Passepartout.  "Thanks, yes,
+the passport is all right."
+
+"And you are looking about you?"
+
+"Yes; but we travel so fast that I seem to be journeying in a dream.
+So this is Suez?"
+
+"Yes."
+
+"In Egypt?"
+
+"Certainly, in Egypt."
+
+"And in Africa?"
+
+"In Africa."
+
+"In Africa!" repeated Passepartout.  "Just think, monsieur, I had no
+idea that we should go farther than Paris; and all that I saw of Paris
+was between twenty minutes past seven and twenty minutes before nine in
+the morning, between the Northern and the Lyons stations, through the
+windows of a car, and in a driving rain!  How I regret not having seen
+once more Pere la Chaise and the circus in the Champs Elysees!"
+
+"You are in a great hurry, then?"
+
+"I am not, but my master is.  By the way, I must buy some shoes and
+shirts.  We came away without trunks, only with a carpet-bag."
+
+"I will show you an excellent shop for getting what you want."
+
+"Really, monsieur, you are very kind."
+
+And they walked off together, Passepartout chatting volubly as they
+went along.
+
+"Above all," said he; "don't let me lose the steamer."
+
+"You have plenty of time; it's only twelve o'clock."
+
+Passepartout pulled out his big watch.  "Twelve!" he exclaimed; "why,
+it's only eight minutes before ten."
+
+"Your watch is slow."
+
+"My watch?  A family watch, monsieur, which has come down from my
+great-grandfather!  It doesn't vary five minutes in the year.  It's a
+perfect chronometer, look you."
+
+"I see how it is," said Fix.  "You have kept London time, which is two
+hours behind that of Suez.  You ought to regulate your watch at noon in
+each country."
+
+"I regulate my watch?  Never!"
+
+"Well, then, it will not agree with the sun."
+
+"So much the worse for the sun, monsieur.  The sun will be wrong, then!"
+
+And the worthy fellow returned the watch to its fob with a defiant
+gesture.  After a few minutes silence, Fix resumed: "You left London
+hastily, then?"
+
+"I rather think so!  Last Friday at eight o'clock in the evening,
+Monsieur Fogg came home from his club, and three-quarters of an hour
+afterwards we were off."
+
+"But where is your master going?"
+
+"Always straight ahead.  He is going round the world."
+
+"Round the world?" cried Fix.
+
+"Yes, and in eighty days!  He says it is on a wager; but, between us, I
+don't believe a word of it.  That wouldn't be common sense.  There's
+something else in the wind."
+
+"Ah!  Mr. Fogg is a character, is he?"
+
+"I should say he was."
+
+"Is he rich?"
+
+"No doubt, for he is carrying an enormous sum in brand new banknotes
+with him.  And he doesn't spare the money on the way, either: he has
+offered a large reward to the engineer of the Mongolia if he gets us to
+Bombay well in advance of time."
+
+"And you have known your master a long time?"
+
+"Why, no; I entered his service the very day we left London."
+
+The effect of these replies upon the already suspicious and excited
+detective may be imagined.  The hasty departure from London soon after
+the robbery; the large sum carried by Mr. Fogg; his eagerness to reach
+distant countries; the pretext of an eccentric and foolhardy bet--all
+confirmed Fix in his theory.  He continued to pump poor Passepartout,
+and learned that he really knew little or nothing of his master, who
+lived a solitary existence in London, was said to be rich, though no
+one knew whence came his riches, and was mysterious and impenetrable in
+his affairs and habits.  Fix felt sure that Phileas Fogg would not land
+at Suez, but was really going on to Bombay.
+
+"Is Bombay far from here?" asked Passepartout.
+
+"Pretty far.  It is a ten days' voyage by sea."
+
+"And in what country is Bombay?"
+
+"India."
+
+"In Asia?"
+
+"Certainly."
+
+"The deuce!  I was going to tell you there's one thing that worries
+me--my burner!"
+
+"What burner?"
+
+"My gas-burner, which I forgot to turn off, and which is at this moment
+burning at my expense.  I have calculated, monsieur, that I lose two
+shillings every four and twenty hours, exactly sixpence more than I
+earn; and you will understand that the longer our journey--"
+
+Did Fix pay any attention to Passepartout's trouble about the gas?  It
+is not probable.  He was not listening, but was cogitating a project.
+Passepartout and he had now reached the shop, where Fix left his
+companion to make his purchases, after recommending him not to miss the
+steamer, and hurried back to the consulate.  Now that he was fully
+convinced, Fix had quite recovered his equanimity.
+
+"Consul," said he, "I have no longer any doubt.  I have spotted my man.
+He passes himself off as an odd stick who is going round the world in
+eighty days."
+
+"Then he's a sharp fellow," returned the consul, "and counts on
+returning to London after putting the police of the two countries off
+his track."
+
+"We'll see about that," replied Fix.
+
+"But are you not mistaken?"
+
+"I am not mistaken."
+
+"Why was this robber so anxious to prove, by the visa, that he had
+passed through Suez?"
+
+"Why?  I have no idea; but listen to me."
+
+He reported in a few words the most important parts of his conversation
+with Passepartout.
+
+"In short," said the consul, "appearances are wholly against this man.
+And what are you going to do?"
+
+"Send a dispatch to London for a warrant of arrest to be dispatched
+instantly to Bombay, take passage on board the Mongolia, follow my
+rogue to India, and there, on English ground, arrest him politely, with
+my warrant in my hand, and my hand on his shoulder."
+
+Having uttered these words with a cool, careless air, the detective
+took leave of the consul, and repaired to the telegraph office, whence
+he sent the dispatch which we have seen to the London police office.  A
+quarter of an hour later found Fix, with a small bag in his hand,
+proceeding on board the Mongolia; and, ere many moments longer, the
+noble steamer rode out at full steam upon the waters of the Red Sea.
+
+
+
+
+Chapter IX
+
+IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS TO THE
+DESIGNS OF PHILEAS FOGG
+
+
+The distance between Suez and Aden is precisely thirteen hundred and
+ten miles, and the regulations of the company allow the steamers one
+hundred and thirty-eight hours in which to traverse it.  The Mongolia,
+thanks to the vigorous exertions of the engineer, seemed likely, so
+rapid was her speed, to reach her destination considerably within that
+time.  The greater part of the passengers from Brindisi were bound for
+India some for Bombay, others for Calcutta by way of Bombay, the
+nearest route thither, now that a railway crosses the Indian peninsula.
+Among the passengers was a number of officials and military officers of
+various grades, the latter being either attached to the regular British
+forces or commanding the Sepoy troops, and receiving high salaries ever
+since the central government has assumed the powers of the East India
+Company: for the sub-lieutenants get 280 pounds, brigadiers, 2,400
+pounds, and generals of divisions, 4,000 pounds.  What with the
+military men, a number of rich young Englishmen on their travels, and
+the hospitable efforts of the purser, the time passed quickly on the
+Mongolia.  The best of fare was spread upon the cabin tables at
+breakfast, lunch, dinner, and the eight o'clock supper, and the ladies
+scrupulously changed their toilets twice a day; and the hours were
+whirled away, when the sea was tranquil, with music, dancing, and games.
+
+But the Red Sea is full of caprice, and often boisterous, like most
+long and narrow gulfs.  When the wind came from the African or Asian
+coast the Mongolia, with her long hull, rolled fearfully.  Then the
+ladies speedily disappeared below; the pianos were silent; singing and
+dancing suddenly ceased.  Yet the good ship ploughed straight on,
+unretarded by wind or wave, towards the straits of Bab-el-Mandeb.  What
+was Phileas Fogg doing all this time?  It might be thought that, in his
+anxiety, he would be constantly watching the changes of the wind, the
+disorderly raging of the billows--every chance, in short, which might
+force the Mongolia to slacken her speed, and thus interrupt his
+journey.  But, if he thought of these possibilities, he did not betray
+the fact by any outward sign.
+
+Always the same impassible member of the Reform Club, whom no incident
+could surprise, as unvarying as the ship's chronometers, and seldom
+having the curiosity even to go upon the deck, he passed through the
+memorable scenes of the Red Sea with cold indifference; did not care to
+recognise the historic towns and villages which, along its borders,
+raised their picturesque outlines against the sky; and betrayed no fear
+of the dangers of the Arabic Gulf, which the old historians always
+spoke of with horror, and upon which the ancient navigators never
+ventured without propitiating the gods by ample sacrifices.  How did
+this eccentric personage pass his time on the Mongolia?  He made his
+four hearty meals every day, regardless of the most persistent rolling
+and pitching on the part of the steamer; and he played whist
+indefatigably, for he had found partners as enthusiastic in the game as
+himself.  A tax-collector, on the way to his post at Goa; the Rev.
+Decimus Smith, returning to his parish at Bombay; and a
+brigadier-general of the English army, who was about to rejoin his
+brigade at Benares, made up the party, and, with Mr. Fogg, played whist
+by the hour together in absorbing silence.
+
+As for Passepartout, he, too, had escaped sea-sickness, and took his
+meals conscientiously in the forward cabin.  He rather enjoyed the
+voyage, for he was well fed and well lodged, took a great interest in
+the scenes through which they were passing, and consoled himself with
+the delusion that his master's whim would end at Bombay.  He was
+pleased, on the day after leaving Suez, to find on deck the obliging
+person with whom he had walked and chatted on the quays.
+
+"If I am not mistaken," said he, approaching this person, with his most
+amiable smile, "you are the gentleman who so kindly volunteered to
+guide me at Suez?"
+
+"Ah!  I quite recognise you.  You are the servant of the strange
+Englishman--"
+
+"Just so, monsieur--"
+
+"Fix."
+
+"Monsieur Fix," resumed Passepartout, "I'm charmed to find you on
+board.  Where are you bound?"
+
+"Like you, to Bombay."
+
+"That's capital!  Have you made this trip before?"
+
+"Several times.  I am one of the agents of the Peninsular Company."
+
+"Then you know India?"
+
+"Why yes," replied Fix, who spoke cautiously.
+
+"A curious place, this India?"
+
+"Oh, very curious.  Mosques, minarets, temples, fakirs, pagodas,
+tigers, snakes, elephants!  I hope you will have ample time to see the
+sights."
+
+"I hope so, Monsieur Fix.  You see, a man of sound sense ought not to
+spend his life jumping from a steamer upon a railway train, and from a
+railway train upon a steamer again, pretending to make the tour of the
+world in eighty days!  No; all these gymnastics, you may be sure, will
+cease at Bombay."
+
+"And Mr. Fogg is getting on well?" asked Fix, in the most natural tone
+in the world.
+
+"Quite well, and I too.  I eat like a famished ogre; it's the sea air."
+
+"But I never see your master on deck."
+
+"Never; he hasn't the least curiosity."
+
+"Do you know, Mr. Passepartout, that this pretended tour in eighty days
+may conceal some secret errand--perhaps a diplomatic mission?"
+
+"Faith, Monsieur Fix, I assure you I know nothing about it, nor would I
+give half a crown to find out."
+
+After this meeting, Passepartout and Fix got into the habit of chatting
+together, the latter making it a point to gain the worthy man's
+confidence.  He frequently offered him a glass of whiskey or pale ale
+in the steamer bar-room, which Passepartout never failed to accept with
+graceful alacrity, mentally pronouncing Fix the best of good fellows.
+
+Meanwhile the Mongolia was pushing forward rapidly; on the 13th, Mocha,
+surrounded by its ruined walls whereon date-trees were growing, was
+sighted, and on the mountains beyond were espied vast coffee-fields.
+Passepartout was ravished to behold this celebrated place, and thought
+that, with its circular walls and dismantled fort, it looked like an
+immense coffee-cup and saucer. The following night they passed through
+the Strait of Bab-el-Mandeb, which means in Arabic The Bridge of Tears,
+and the next day they put in at Steamer Point, north-west of Aden
+harbour, to take in coal.  This matter of fuelling steamers is a
+serious one at such distances from the coal-mines; it costs the
+Peninsular Company some eight hundred thousand pounds a year.  In these
+distant seas, coal is worth three or four pounds sterling a ton.
+
+The Mongolia had still sixteen hundred and fifty miles to traverse
+before reaching Bombay, and was obliged to remain four hours at Steamer
+Point to coal up.  But this delay, as it was foreseen, did not affect
+Phileas Fogg's programme; besides, the Mongolia, instead of reaching
+Aden on the morning of the 15th, when she was due, arrived there on the
+evening of the 14th, a gain of fifteen hours.
+
+Mr. Fogg and his servant went ashore at Aden to have the passport again
+visaed; Fix, unobserved, followed them.  The visa procured, Mr. Fogg
+returned on board to resume his former habits; while Passepartout,
+according to custom, sauntered about among the mixed population of
+Somalis, Banyans, Parsees, Jews, Arabs, and Europeans who comprise the
+twenty-five thousand inhabitants of Aden.  He gazed with wonder upon
+the fortifications which make this place the Gibraltar of the Indian
+Ocean, and the vast cisterns where the English engineers were still at
+work, two thousand years after the engineers of Solomon.
+
+"Very curious, very curious," said Passepartout to himself, on
+returning to the steamer.  "I see that it is by no means useless to
+travel, if a man wants to see something new."  At six p.m.  the
+Mongolia slowly moved out of the roadstead, and was soon once more on
+the Indian Ocean.  She had a hundred and sixty-eight hours in which to
+reach Bombay, and the sea was favourable, the wind being in the
+north-west, and all sails aiding the engine.  The steamer rolled but
+little, the ladies, in fresh toilets, reappeared on deck, and the
+singing and dancing were resumed.  The trip was being accomplished most
+successfully, and Passepartout was enchanted with the congenial
+companion which chance had secured him in the person of the delightful
+Fix.  On Sunday, October 20th, towards noon, they came in sight of the
+Indian coast: two hours later the pilot came on board.  A range of
+hills lay against the sky in the horizon, and soon the rows of palms
+which adorn Bombay came distinctly into view.  The steamer entered the
+road formed by the islands in the bay, and at half-past four she hauled
+up at the quays of Bombay.
+
+Phileas Fogg was in the act of finishing the thirty-third rubber of the
+voyage, and his partner and himself having, by a bold stroke, captured
+all thirteen of the tricks, concluded this fine campaign with a
+brilliant victory.
+
+The Mongolia was due at Bombay on the 22nd; she arrived on the 20th.
+This was a gain to Phileas Fogg of two days since his departure from
+London, and he calmly entered the fact in the itinerary, in the column
+of gains.
+
+
+
+
+Chapter X
+
+IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS OF HIS
+SHOES
+
+
+Everybody knows that the great reversed triangle of land, with its base
+in the north and its apex in the south, which is called India, embraces
+fourteen hundred thousand square miles, upon which is spread unequally
+a population of one hundred and eighty millions of souls.  The British
+Crown exercises a real and despotic dominion over the larger portion of
+this vast country, and has a governor-general stationed at Calcutta,
+governors at Madras, Bombay, and in Bengal, and a lieutenant-governor
+at Agra.
+
+But British India, properly so called, only embraces seven hundred
+thousand square miles, and a population of from one hundred to one
+hundred and ten millions of inhabitants.  A considerable portion of
+India is still free from British authority; and there are certain
+ferocious rajahs in the interior who are absolutely independent.  The
+celebrated East India Company was all-powerful from 1756, when the
+English first gained a foothold on the spot where now stands the city
+of Madras, down to the time of the great Sepoy insurrection.  It
+gradually annexed province after province, purchasing them of the
+native chiefs, whom it seldom paid, and appointed the governor-general
+and his subordinates, civil and military.  But the East India Company
+has now passed away, leaving the British possessions in India directly
+under the control of the Crown.  The aspect of the country, as well as
+the manners and distinctions of race, is daily changing.
+
+Formerly one was obliged to travel in India by the old cumbrous methods
+of going on foot or on horseback, in palanquins or unwieldy coaches;
+now fast steamboats ply on the Indus and the Ganges, and a great
+railway, with branch lines joining the main line at many points on its
+route, traverses the peninsula from Bombay to Calcutta in three days.
+This railway does not run in a direct line across India.  The distance
+between Bombay and Calcutta, as the bird flies, is only from one
+thousand to eleven hundred miles; but the deflections of the road
+increase this distance by more than a third.
+
+The general route of the Great Indian Peninsula Railway is as follows:
+Leaving Bombay, it passes through Salcette, crossing to the continent
+opposite Tannah, goes over the chain of the Western Ghauts, runs thence
+north-east as far as Burhampoor, skirts the nearly independent
+territory of Bundelcund, ascends to Allahabad, turns thence eastwardly,
+meeting the Ganges at Benares, then departs from the river a little,
+and, descending south-eastward by Burdivan and the French town of
+Chandernagor, has its terminus at Calcutta.
+
+The passengers of the Mongolia went ashore at half-past four p.m.; at
+exactly eight the train would start for Calcutta.
+
+Mr. Fogg, after bidding good-bye to his whist partners, left the
+steamer, gave his servant several errands to do, urged it upon him to
+be at the station promptly at eight, and, with his regular step, which
+beat to the second, like an astronomical clock, directed his steps to
+the passport office.  As for the wonders of Bombay--its famous city
+hall, its splendid library, its forts and docks, its bazaars, mosques,
+synagogues, its Armenian churches, and the noble pagoda on Malabar
+Hill, with its two polygonal towers--he cared not a straw to see them.
+He would not deign to examine even the masterpieces of Elephanta, or
+the mysterious hypogea, concealed south-east from the docks, or those
+fine remains of Buddhist architecture, the Kanherian grottoes of the
+island of Salcette.
+
+Having transacted his business at the passport office, Phileas Fogg
+repaired quietly to the railway station, where he ordered dinner.
+Among the dishes served up to him, the landlord especially recommended
+a certain giblet of "native rabbit," on which he prided himself.
+
+Mr. Fogg accordingly tasted the dish, but, despite its spiced sauce,
+found it far from palatable.  He rang for the landlord, and, on his
+appearance, said, fixing his clear eyes upon him, "Is this rabbit, sir?"
+
+"Yes, my lord," the rogue boldly replied, "rabbit from the jungles."
+
+"And this rabbit did not mew when he was killed?"
+
+"Mew, my lord!  What, a rabbit mew!  I swear to you--"
+
+"Be so good, landlord, as not to swear, but remember this: cats were
+formerly considered, in India, as sacred animals.  That was a good
+time."
+
+"For the cats, my lord?"
+
+"Perhaps for the travellers as well!"
+
+After which Mr. Fogg quietly continued his dinner.  Fix had gone on
+shore shortly after Mr. Fogg, and his first destination was the
+headquarters of the Bombay police.  He made himself known as a London
+detective, told his business at Bombay, and the position of affairs
+relative to the supposed robber, and nervously asked if a warrant had
+arrived from London.  It had not reached the office; indeed, there had
+not yet been time for it to arrive.  Fix was sorely disappointed, and
+tried to obtain an order of arrest from the director of the Bombay
+police.  This the director refused, as the matter concerned the London
+office, which alone could legally deliver the warrant.  Fix did not
+insist, and was fain to resign himself to await the arrival of the
+important document; but he was determined not to lose sight of the
+mysterious rogue as long as he stayed in Bombay.  He did not doubt for
+a moment, any more than Passepartout, that Phileas Fogg would remain
+there, at least until it was time for the warrant to arrive.
+
+Passepartout, however, had no sooner heard his master's orders on
+leaving the Mongolia than he saw at once that they were to leave Bombay
+as they had done Suez and Paris, and that the journey would be extended
+at least as far as Calcutta, and perhaps beyond that place.  He began
+to ask himself if this bet that Mr. Fogg talked about was not really in
+good earnest, and whether his fate was not in truth forcing him,
+despite his love of repose, around the world in eighty days!
+
+Having purchased the usual quota of shirts and shoes, he took a
+leisurely promenade about the streets, where crowds of people of many
+nationalities--Europeans, Persians with pointed caps, Banyas with round
+turbans, Sindes with square bonnets, Parsees with black mitres, and
+long-robed Armenians--were collected.  It happened to be the day of a
+Parsee festival.  These descendants of the sect of Zoroaster--the most
+thrifty, civilised, intelligent, and austere of the East Indians, among
+whom are counted the richest native merchants of Bombay--were
+celebrating a sort of religious carnival, with processions and shows,
+in the midst of which Indian dancing-girls, clothed in rose-coloured
+gauze, looped up with gold and silver, danced airily, but with perfect
+modesty, to the sound of viols and the clanging of tambourines.  It is
+needless to say that Passepartout watched these curious ceremonies with
+staring eyes and gaping mouth, and that his countenance was that of the
+greenest booby imaginable.
+
+Unhappily for his master, as well as himself, his curiosity drew him
+unconsciously farther off than he intended to go.  At last, having seen
+the Parsee carnival wind away in the distance, he was turning his steps
+towards the station, when he happened to espy the splendid pagoda on
+Malabar Hill, and was seized with an irresistible desire to see its
+interior.  He was quite ignorant that it is forbidden to Christians to
+enter certain Indian temples, and that even the faithful must not go in
+without first leaving their shoes outside the door.  It may be said
+here that the wise policy of the British Government severely punishes a
+disregard of the practices of the native religions.
+
+Passepartout, however, thinking no harm, went in like a simple tourist,
+and was soon lost in admiration of the splendid Brahmin ornamentation
+which everywhere met his eyes, when of a sudden he found himself
+sprawling on the sacred flagging.  He looked up to behold three enraged
+priests, who forthwith fell upon him; tore off his shoes, and began to
+beat him with loud, savage exclamations.  The agile Frenchman was soon
+upon his feet again, and lost no time in knocking down two of his
+long-gowned adversaries with his fists and a vigorous application of
+his toes; then, rushing out of the pagoda as fast as his legs could
+carry him, he soon escaped the third priest by mingling with the crowd
+in the streets.
+
+At five minutes before eight, Passepartout, hatless, shoeless, and
+having in the squabble lost his package of shirts and shoes, rushed
+breathlessly into the station.
+
+Fix, who had followed Mr. Fogg to the station, and saw that he was
+really going to leave Bombay, was there, upon the platform.  He had
+resolved to follow the supposed robber to Calcutta, and farther, if
+necessary.  Passepartout did not observe the detective, who stood in an
+obscure corner; but Fix heard him relate his adventures in a few words
+to Mr. Fogg.
+
+"I hope that this will not happen again," said Phileas Fogg coldly, as
+he got into the train.  Poor Passepartout, quite crestfallen, followed
+his master without a word.  Fix was on the point of entering another
+carriage, when an idea struck him which induced him to alter his plan.
+
+"No, I'll stay," muttered he.  "An offence has been committed on Indian
+soil.  I've got my man."
+
+Just then the locomotive gave a sharp screech, and the train passed out
+into the darkness of the night.
+
+
+
+
+Chapter XI
+
+IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE AT A
+FABULOUS PRICE
+
+
+The train had started punctually.  Among the passengers were a number
+of officers, Government officials, and opium and indigo merchants,
+whose business called them to the eastern coast.  Passepartout rode in
+the same carriage with his master, and a third passenger occupied a
+seat opposite to them.  This was Sir Francis Cromarty, one of Mr.
+Fogg's whist partners on the Mongolia, now on his way to join his corps
+at Benares.  Sir Francis was a tall, fair man of fifty, who had greatly
+distinguished himself in the last Sepoy revolt.  He made India his
+home, only paying brief visits to England at rare intervals; and was
+almost as familiar as a native with the customs, history, and character
+of India and its people.  But Phileas Fogg, who was not travelling, but
+only describing a circumference, took no pains to inquire into these
+subjects; he was a solid body, traversing an orbit around the
+terrestrial globe, according to the laws of rational mechanics.  He was
+at this moment calculating in his mind the number of hours spent since
+his departure from London, and, had it been in his nature to make a
+useless demonstration, would have rubbed his hands for satisfaction.
+Sir Francis Cromarty had observed the oddity of his travelling
+companion--although the only opportunity he had for studying him had
+been while he was dealing the cards, and between two rubbers--and
+questioned himself whether a human heart really beat beneath this cold
+exterior, and whether Phileas Fogg had any sense of the beauties of
+nature.  The brigadier-general was free to mentally confess that, of
+all the eccentric persons he had ever met, none was comparable to this
+product of the exact sciences.
+
+Phileas Fogg had not concealed from Sir Francis his design of going
+round the world, nor the circumstances under which he set out; and the
+general only saw in the wager a useless eccentricity and a lack of
+sound common sense.  In the way this strange gentleman was going on, he
+would leave the world without having done any good to himself or
+anybody else.
+
+An hour after leaving Bombay the train had passed the viaducts and the
+Island of Salcette, and had got into the open country.  At Callyan they
+reached the junction of the branch line which descends towards
+south-eastern India by Kandallah and Pounah; and, passing Pauwell, they
+entered the defiles of the mountains, with their basalt bases, and
+their summits crowned with thick and verdant forests.  Phileas Fogg and
+Sir Francis Cromarty exchanged a few words from time to time, and now
+Sir Francis, reviving the conversation, observed, "Some years ago, Mr.
+Fogg, you would have met with a delay at this point which would
+probably have lost you your wager."
+
+"How so, Sir Francis?"
+
+"Because the railway stopped at the base of these mountains, which the
+passengers were obliged to cross in palanquins or on ponies to
+Kandallah, on the other side."
+
+"Such a delay would not have deranged my plans in the least," said Mr.
+Fogg.  "I have constantly foreseen the likelihood of certain obstacles."
+
+"But, Mr. Fogg," pursued Sir Francis, "you run the risk of having some
+difficulty about this worthy fellow's adventure at the pagoda."
+Passepartout, his feet comfortably wrapped in his travelling-blanket,
+was sound asleep and did not dream that anybody was talking about him.
+"The Government is very severe upon that kind of offence.  It takes
+particular care that the religious customs of the Indians should be
+respected, and if your servant were caught--"
+
+"Very well, Sir Francis," replied Mr. Fogg; "if he had been caught he
+would have been condemned and punished, and then would have quietly
+returned to Europe.  I don't see how this affair could have delayed his
+master."
+
+The conversation fell again.  During the night the train left the
+mountains behind, and passed Nassik, and the next day proceeded over
+the flat, well-cultivated country of the Khandeish, with its straggling
+villages, above which rose the minarets of the pagodas.  This fertile
+territory is watered by numerous small rivers and limpid streams,
+mostly tributaries of the Godavery.
+
+Passepartout, on waking and looking out, could not realise that he was
+actually crossing India in a railway train.  The locomotive, guided by
+an English engineer and fed with English coal, threw out its smoke upon
+cotton, coffee, nutmeg, clove, and pepper plantations, while the steam
+curled in spirals around groups of palm-trees, in the midst of which
+were seen picturesque bungalows, viharis (sort of abandoned
+monasteries), and marvellous temples enriched by the exhaustless
+ornamentation of Indian architecture.  Then they came upon vast tracts
+extending to the horizon, with jungles inhabited by snakes and tigers,
+which fled at the noise of the train; succeeded by forests penetrated
+by the railway, and still haunted by elephants which, with pensive
+eyes, gazed at the train as it passed.  The travellers crossed, beyond
+Milligaum, the fatal country so often stained with blood by the
+sectaries of the goddess Kali.  Not far off rose Ellora, with its
+graceful pagodas, and the famous Aurungabad, capital of the ferocious
+Aureng-Zeb, now the chief town of one of the detached provinces of the
+kingdom of the Nizam.  It was thereabouts that Feringhea, the Thuggee
+chief, king of the stranglers, held his sway.  These ruffians, united
+by a secret bond, strangled victims of every age in honour of the
+goddess Death, without ever shedding blood; there was a period when
+this part of the country could scarcely be travelled over without
+corpses being found in every direction.  The English Government has
+succeeded in greatly diminishing these murders, though the Thuggees
+still exist, and pursue the exercise of their horrible rites.
+
+At half-past twelve the train stopped at Burhampoor where Passepartout
+was able to purchase some Indian slippers, ornamented with false
+pearls, in which, with evident vanity, he proceeded to encase his feet.
+The travellers made a hasty breakfast and started off for Assurghur,
+after skirting for a little the banks of the small river Tapty, which
+empties into the Gulf of Cambray, near Surat.
+
+Passepartout was now plunged into absorbing reverie.  Up to his arrival
+at Bombay, he had entertained hopes that their journey would end there;
+but, now that they were plainly whirling across India at full speed, a
+sudden change had come over the spirit of his dreams.  His old vagabond
+nature returned to him; the fantastic ideas of his youth once more took
+possession of him.  He came to regard his master's project as intended
+in good earnest, believed in the reality of the bet, and therefore in
+the tour of the world and the necessity of making it without fail
+within the designated period.  Already he began to worry about possible
+delays, and accidents which might happen on the way.  He recognised
+himself as being personally interested in the wager, and trembled at
+the thought that he might have been the means of losing it by his
+unpardonable folly of the night before.  Being much less cool-headed
+than Mr. Fogg, he was much more restless, counting and recounting the
+days passed over, uttering maledictions when the train stopped, and
+accusing it of sluggishness, and mentally blaming Mr. Fogg for not
+having bribed the engineer.  The worthy fellow was ignorant that, while
+it was possible by such means to hasten the rate of a steamer, it could
+not be done on the railway.
+
+The train entered the defiles of the Sutpour Mountains, which separate
+the Khandeish from Bundelcund, towards evening.  The next day Sir
+Francis Cromarty asked Passepartout what time it was; to which, on
+consulting his watch, he replied that it was three in the morning.
+This famous timepiece, always regulated on the Greenwich meridian,
+which was now some seventy-seven degrees westward, was at least four
+hours slow.  Sir Francis corrected Passepartout's time, whereupon the
+latter made the same remark that he had done to Fix; and upon the
+general insisting that the watch should be regulated in each new
+meridian, since he was constantly going eastward, that is in the face
+of the sun, and therefore the days were shorter by four minutes for
+each degree gone over, Passepartout obstinately refused to alter his
+watch, which he kept at London time.  It was an innocent delusion which
+could harm no one.
+
+The train stopped, at eight o'clock, in the midst of a glade some
+fifteen miles beyond Rothal, where there were several bungalows, and
+workmen's cabins.  The conductor, passing along the carriages, shouted,
+"Passengers will get out here!"
+
+Phileas Fogg looked at Sir Francis Cromarty for an explanation; but the
+general could not tell what meant a halt in the midst of this forest of
+dates and acacias.
+
+Passepartout, not less surprised, rushed out and speedily returned,
+crying: "Monsieur, no more railway!"
+
+"What do you mean?" asked Sir Francis.
+
+"I mean to say that the train isn't going on."
+
+The general at once stepped out, while Phileas Fogg calmly followed
+him, and they proceeded together to the conductor.
+
+"Where are we?" asked Sir Francis.
+
+"At the hamlet of Kholby."
+
+"Do we stop here?"
+
+"Certainly.  The railway isn't finished."
+
+"What! not finished?"
+
+"No.  There's still a matter of fifty miles to be laid from here to
+Allahabad, where the line begins again."
+
+"But the papers announced the opening of the railway throughout."
+
+"What would you have, officer?  The papers were mistaken."
+
+"Yet you sell tickets from Bombay to Calcutta," retorted Sir Francis,
+who was growing warm.
+
+"No doubt," replied the conductor; "but the passengers know that they
+must provide means of transportation for themselves from Kholby to
+Allahabad."
+
+Sir Francis was furious.  Passepartout would willingly have knocked the
+conductor down, and did not dare to look at his master.
+
+"Sir Francis," said Mr. Fogg quietly, "we will, if you please, look
+about for some means of conveyance to Allahabad."
+
+"Mr. Fogg, this is a delay greatly to your disadvantage."
+
+"No, Sir Francis; it was foreseen."
+
+"What!  You knew that the way--"
+
+"Not at all; but I knew that some obstacle or other would sooner or
+later arise on my route.  Nothing, therefore, is lost. I have two days,
+which I have already gained, to sacrifice.  A steamer leaves Calcutta
+for Hong Kong at noon, on the 25th.  This is the 22nd, and we shall
+reach Calcutta in time."
+
+There was nothing to say to so confident a response.
+
+It was but too true that the railway came to a termination at this
+point.  The papers were like some watches, which have a way of getting
+too fast, and had been premature in their announcement of the
+completion of the line.  The greater part of the travellers were aware
+of this interruption, and, leaving the train, they began to engage such
+vehicles as the village could provide four-wheeled palkigharis, waggons
+drawn by zebus, carriages that looked like perambulating pagodas,
+palanquins, ponies, and what not.
+
+Mr. Fogg and Sir Francis Cromarty, after searching the village from end
+to end, came back without having found anything.
+
+"I shall go afoot," said Phileas Fogg.
+
+Passepartout, who had now rejoined his master, made a wry grimace, as
+he thought of his magnificent, but too frail Indian shoes.  Happily he
+too had been looking about him, and, after a moment's hesitation, said,
+"Monsieur, I think I have found a means of conveyance."
+
+"What?"
+
+"An elephant!  An elephant that belongs to an Indian who lives but a
+hundred steps from here."
+
+"Let's go and see the elephant," replied Mr. Fogg.
+
+They soon reached a small hut, near which, enclosed within some high
+palings, was the animal in question.  An Indian came out of the hut,
+and, at their request, conducted them within the enclosure.  The
+elephant, which its owner had reared, not for a beast of burden, but
+for warlike purposes, was half domesticated.  The Indian had begun
+already, by often irritating him, and feeding him every three months on
+sugar and butter, to impart to him a ferocity not in his nature, this
+method being often employed by those who train the Indian elephants for
+battle.  Happily, however, for Mr. Fogg, the animal's instruction in
+this direction had not gone far, and the elephant still preserved his
+natural gentleness.  Kiouni--this was the name of the beast--could
+doubtless travel rapidly for a long time, and, in default of any other
+means of conveyance, Mr. Fogg resolved to hire him.  But elephants are
+far from cheap in India, where they are becoming scarce, the males,
+which alone are suitable for circus shows, are much sought, especially
+as but few of them are domesticated.  When therefore Mr. Fogg proposed
+to the Indian to hire Kiouni, he refused point-blank.  Mr. Fogg
+persisted, offering the excessive sum of ten pounds an hour for the
+loan of the beast to Allahabad.  Refused.  Twenty pounds?  Refused
+also.  Forty pounds?  Still refused.  Passepartout jumped at each
+advance; but the Indian declined to be tempted.  Yet the offer was an
+alluring one, for, supposing it took the elephant fifteen hours to
+reach Allahabad, his owner would receive no less than six hundred
+pounds sterling.
+
+Phileas Fogg, without getting in the least flurried, then proposed to
+purchase the animal outright, and at first offered a thousand pounds
+for him.  The Indian, perhaps thinking he was going to make a great
+bargain, still refused.
+
+Sir Francis Cromarty took Mr. Fogg aside, and begged him to reflect
+before he went any further; to which that gentleman replied that he was
+not in the habit of acting rashly, that a bet of twenty thousand pounds
+was at stake, that the elephant was absolutely necessary to him, and
+that he would secure him if he had to pay twenty times his value.
+Returning to the Indian, whose small, sharp eyes, glistening with
+avarice, betrayed that with him it was only a question of how great a
+price he could obtain.  Mr. Fogg offered first twelve hundred, then
+fifteen hundred, eighteen hundred, two thousand pounds.  Passepartout,
+usually so rubicund, was fairly white with suspense.
+
+At two thousand pounds the Indian yielded.
+
+"What a price, good heavens!" cried Passepartout, "for an elephant."
+
+It only remained now to find a guide, which was comparatively easy.  A
+young Parsee, with an intelligent face, offered his services, which Mr.
+Fogg accepted, promising so generous a reward as to materially
+stimulate his zeal.  The elephant was led out and equipped.  The
+Parsee, who was an accomplished elephant driver, covered his back with
+a sort of saddle-cloth, and attached to each of his flanks some
+curiously uncomfortable howdahs.  Phileas Fogg paid the Indian with
+some banknotes which he extracted from the famous carpet-bag, a
+proceeding that seemed to deprive poor Passepartout of his vitals.
+Then he offered to carry Sir Francis to Allahabad, which the brigadier
+gratefully accepted, as one traveller the more would not be likely to
+fatigue the gigantic beast.  Provisions were purchased at Kholby, and,
+while Sir Francis and Mr. Fogg took the howdahs on either side,
+Passepartout got astride the saddle-cloth between them.  The Parsee
+perched himself on the elephant's neck, and at nine o'clock they set
+out from the village, the animal marching off through the dense forest
+of palms by the shortest cut.
+
+
+
+
+Chapter XII
+
+IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE INDIAN
+FORESTS, AND WHAT ENSUED
+
+
+In order to shorten the journey, the guide passed to the left of the
+line where the railway was still in process of being built.  This line,
+owing to the capricious turnings of the Vindhia Mountains, did not
+pursue a straight course.  The Parsee, who was quite familiar with the
+roads and paths in the district, declared that they would gain twenty
+miles by striking directly through the forest.
+
+Phileas Fogg and Sir Francis Cromarty, plunged to the neck in the
+peculiar howdahs provided for them, were horribly jostled by the swift
+trotting of the elephant, spurred on as he was by the skilful Parsee;
+but they endured the discomfort with true British phlegm, talking
+little, and scarcely able to catch a glimpse of each other.  As for
+Passepartout, who was mounted on the beast's back, and received the
+direct force of each concussion as he trod along, he was very careful,
+in accordance with his master's advice, to keep his tongue from between
+his teeth, as it would otherwise have been bitten off short.  The
+worthy fellow bounced from the elephant's neck to his rump, and vaulted
+like a clown on a spring-board; yet he laughed in the midst of his
+bouncing, and from time to time took a piece of sugar out of his
+pocket, and inserted it in Kiouni's trunk, who received it without in
+the least slackening his regular trot.
+
+After two hours the guide stopped the elephant, and gave him an hour
+for rest, during which Kiouni, after quenching his thirst at a
+neighbouring spring, set to devouring the branches and shrubs round
+about him.  Neither Sir Francis nor Mr. Fogg regretted the delay, and
+both descended with a feeling of relief.  "Why, he's made of iron!"
+exclaimed the general, gazing admiringly on Kiouni.
+
+"Of forged iron," replied Passepartout, as he set about preparing a
+hasty breakfast.
+
+At noon the Parsee gave the signal of departure.  The country soon
+presented a very savage aspect.  Copses of dates and dwarf-palms
+succeeded the dense forests; then vast, dry plains, dotted with scanty
+shrubs, and sown with great blocks of syenite.  All this portion of
+Bundelcund, which is little frequented by travellers, is inhabited by a
+fanatical population, hardened in the most horrible practices of the
+Hindoo faith.  The English have not been able to secure complete
+dominion over this territory, which is subjected to the influence of
+rajahs, whom it is almost impossible to reach in their inaccessible
+mountain fastnesses. The travellers several times saw bands of
+ferocious Indians, who, when they perceived the elephant striding
+across-country, made angry and threatening motions.  The Parsee avoided
+them as much as possible.  Few animals were observed on the route; even
+the monkeys hurried from their path with contortions and grimaces which
+convulsed Passepartout with laughter.
+
+In the midst of his gaiety, however, one thought troubled the worthy
+servant.  What would Mr. Fogg do with the elephant when he got to
+Allahabad?  Would he carry him on with him?  Impossible!  The cost of
+transporting him would make him ruinously expensive.  Would he sell
+him, or set him free?  The estimable beast certainly deserved some
+consideration.  Should Mr. Fogg choose to make him, Passepartout, a
+present of Kiouni, he would be very much embarrassed; and these
+thoughts did not cease worrying him for a long time.
+
+The principal chain of the Vindhias was crossed by eight in the
+evening, and another halt was made on the northern slope, in a ruined
+bungalow.  They had gone nearly twenty-five miles that day, and an
+equal distance still separated them from the station of Allahabad.
+
+The night was cold.  The Parsee lit a fire in the bungalow with a few
+dry branches, and the warmth was very grateful, provisions purchased at
+Kholby sufficed for supper, and the travellers ate ravenously.  The
+conversation, beginning with a few disconnected phrases, soon gave
+place to loud and steady snores.  The guide watched Kiouni, who slept
+standing, bolstering himself against the trunk of a large tree.
+Nothing occurred during the night to disturb the slumberers, although
+occasional growls from panthers and chatterings of monkeys broke the
+silence; the more formidable beasts made no cries or hostile
+demonstration against the occupants of the bungalow.  Sir Francis slept
+heavily, like an honest soldier overcome with fatigue.  Passepartout
+was wrapped in uneasy dreams of the bouncing of the day before.  As for
+Mr. Fogg, he slumbered as peacefully as if he had been in his serene
+mansion in Saville Row.
+
+The journey was resumed at six in the morning; the guide hoped to reach
+Allahabad by evening.  In that case, Mr. Fogg would only lose a part of
+the forty-eight hours saved since the beginning of the tour.  Kiouni,
+resuming his rapid gait, soon descended the lower spurs of the
+Vindhias, and towards noon they passed by the village of Kallenger, on
+the Cani, one of the branches of the Ganges.  The guide avoided
+inhabited places, thinking it safer to keep the open country, which
+lies along the first depressions of the basin of the great river.
+Allahabad was now only twelve miles to the north-east.  They stopped
+under a clump of bananas, the fruit of which, as healthy as bread and
+as succulent as cream, was amply partaken of and appreciated.
+
+At two o'clock the guide entered a thick forest which extended several
+miles; he preferred to travel under cover of the woods.  They had not
+as yet had any unpleasant encounters, and the journey seemed on the
+point of being successfully accomplished, when the elephant, becoming
+restless, suddenly stopped.
+
+It was then four o'clock.
+
+"What's the matter?" asked Sir Francis, putting out his head.
+
+"I don't know, officer," replied the Parsee, listening attentively to a
+confused murmur which came through the thick branches.
+
+The murmur soon became more distinct; it now seemed like a distant
+concert of human voices accompanied by brass instruments.  Passepartout
+was all eyes and ears.  Mr. Fogg patiently waited without a word.  The
+Parsee jumped to the ground, fastened the elephant to a tree, and
+plunged into the thicket.  He soon returned, saying:
+
+"A procession of Brahmins is coming this way.  We must prevent their
+seeing us, if possible."
+
+The guide unloosed the elephant and led him into a thicket, at the same
+time asking the travellers not to stir.  He held himself ready to
+bestride the animal at a moment's notice, should flight become
+necessary; but he evidently thought that the procession of the faithful
+would pass without perceiving them amid the thick foliage, in which
+they were wholly concealed.
+
+The discordant tones of the voices and instruments drew nearer, and now
+droning songs mingled with the sound of the tambourines and cymbals.
+The head of the procession soon appeared beneath the trees, a hundred
+paces away; and the strange figures who performed the religious
+ceremony were easily distinguished through the branches.  First came
+the priests, with mitres on their heads, and clothed in long lace
+robes.  They were surrounded by men, women, and children, who sang a
+kind of lugubrious psalm, interrupted at regular intervals by the
+tambourines and cymbals; while behind them was drawn a car with large
+wheels, the spokes of which represented serpents entwined with each
+other.  Upon the car, which was drawn by four richly caparisoned zebus,
+stood a hideous statue with four arms, the body coloured a dull red,
+with haggard eyes, dishevelled hair, protruding tongue, and lips tinted
+with betel.  It stood upright upon the figure of a prostrate and
+headless giant.
+
+Sir Francis, recognising the statue, whispered, "The goddess Kali; the
+goddess of love and death."
+
+"Of death, perhaps," muttered back Passepartout, "but of love--that
+ugly old hag?  Never!"
+
+The Parsee made a motion to keep silence.
+
+A group of old fakirs were capering and making a wild ado round the
+statue; these were striped with ochre, and covered with cuts whence
+their blood issued drop by drop--stupid fanatics, who, in the great
+Indian ceremonies, still throw themselves under the wheels of
+Juggernaut.  Some Brahmins, clad in all the sumptuousness of Oriental
+apparel, and leading a woman who faltered at every step, followed.
+This woman was young, and as fair as a European.  Her head and neck,
+shoulders, ears, arms, hands, and toes were loaded down with jewels and
+gems with bracelets, earrings, and rings; while a tunic bordered with
+gold, and covered with a light muslin robe, betrayed the outline of her
+form.
+
+The guards who followed the young woman presented a violent contrast to
+her, armed as they were with naked sabres hung at their waists, and
+long damascened pistols, and bearing a corpse on a palanquin.  It was
+the body of an old man, gorgeously arrayed in the habiliments of a
+rajah, wearing, as in life, a turban embroidered with pearls, a robe of
+tissue of silk and gold, a scarf of cashmere sewed with diamonds, and
+the magnificent weapons of a Hindoo prince.  Next came the musicians
+and a rearguard of capering fakirs, whose cries sometimes drowned the
+noise of the instruments; these closed the procession.
+
+Sir Francis watched the procession with a sad countenance, and, turning
+to the guide, said, "A suttee."
+
+The Parsee nodded, and put his finger to his lips.  The procession
+slowly wound under the trees, and soon its last ranks disappeared in
+the depths of the wood.  The songs gradually died away; occasionally
+cries were heard in the distance, until at last all was silence again.
+
+Phileas Fogg had heard what Sir Francis said, and, as soon as the
+procession had disappeared, asked: "What is a suttee?"
+
+"A suttee," returned the general, "is a human sacrifice, but a
+voluntary one.  The woman you have just seen will be burned to-morrow
+at the dawn of day."
+
+"Oh, the scoundrels!" cried Passepartout, who could not repress his
+indignation.
+
+"And the corpse?" asked Mr. Fogg.
+
+"Is that of the prince, her husband," said the guide; "an independent
+rajah of Bundelcund."
+
+"Is it possible," resumed Phileas Fogg, his voice betraying not the
+least emotion, "that these barbarous customs still exist in India, and
+that the English have been unable to put a stop to them?"
+
+"These sacrifices do not occur in the larger portion of India," replied
+Sir Francis; "but we have no power over these savage territories, and
+especially here in Bundelcund.  The whole district north of the
+Vindhias is the theatre of incessant murders and pillage."
+
+"The poor wretch!" exclaimed Passepartout, "to be burned alive!"
+
+"Yes," returned Sir Francis, "burned alive.  And, if she were not, you
+cannot conceive what treatment she would be obliged to submit to from
+her relatives.  They would shave off her hair, feed her on a scanty
+allowance of rice, treat her with contempt; she would be looked upon as
+an unclean creature, and would die in some corner, like a scurvy dog.
+The prospect of so frightful an existence drives these poor creatures
+to the sacrifice much more than love or religious fanaticism.
+Sometimes, however, the sacrifice is really voluntary, and it requires
+the active interference of the Government to prevent it.  Several years
+ago, when I was living at Bombay, a young widow asked permission of the
+governor to be burned along with her husband's body; but, as you may
+imagine, he refused.  The woman left the town, took refuge with an
+independent rajah, and there carried out her self-devoted purpose."
+
+While Sir Francis was speaking, the guide shook his head several times,
+and now said: "The sacrifice which will take place to-morrow at dawn is
+not a voluntary one."
+
+"How do you know?"
+
+"Everybody knows about this affair in Bundelcund."
+
+"But the wretched creature did not seem to be making any resistance,"
+observed Sir Francis.
+
+"That was because they had intoxicated her with fumes of hemp and
+opium."
+
+"But where are they taking her?"
+
+"To the pagoda of Pillaji, two miles from here; she will pass the night
+there."
+
+"And the sacrifice will take place--"
+
+"To-morrow, at the first light of dawn."
+
+The guide now led the elephant out of the thicket, and leaped upon his
+neck.  Just at the moment that he was about to urge Kiouni forward with
+a peculiar whistle, Mr. Fogg stopped him, and, turning to Sir Francis
+Cromarty, said, "Suppose we save this woman."
+
+"Save the woman, Mr. Fogg!"
+
+"I have yet twelve hours to spare; I can devote them to that."
+
+"Why, you are a man of heart!"
+
+"Sometimes," replied Phileas Fogg, quietly; "when I have the time."
+
+
+
+
+Chapter XIII
+
+IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS THE BRAVE
+
+
+The project was a bold one, full of difficulty, perhaps impracticable.
+Mr. Fogg was going to risk life, or at least liberty, and therefore the
+success of his tour.  But he did not hesitate, and he found in Sir
+Francis Cromarty an enthusiastic ally.
+
+As for Passepartout, he was ready for anything that might be proposed.
+His master's idea charmed him; he perceived a heart, a soul, under that
+icy exterior.  He began to love Phileas Fogg.
+
+There remained the guide: what course would he adopt?  Would he not
+take part with the Indians?  In default of his assistance, it was
+necessary to be assured of his neutrality.
+
+Sir Francis frankly put the question to him.
+
+"Officers," replied the guide, "I am a Parsee, and this woman is a
+Parsee.  Command me as you will."
+
+"Excellent!" said Mr. Fogg.
+
+"However," resumed the guide, "it is certain, not only that we shall
+risk our lives, but horrible tortures, if we are taken."
+
+"That is foreseen," replied Mr. Fogg.  "I think we must wait till night
+before acting."
+
+"I think so," said the guide.
+
+The worthy Indian then gave some account of the victim, who, he said,
+was a celebrated beauty of the Parsee race, and the daughter of a
+wealthy Bombay merchant.  She had received a thoroughly English
+education in that city, and, from her manners and intelligence, would
+be thought an European.  Her name was Aouda.  Left an orphan, she was
+married against her will to the old rajah of Bundelcund; and, knowing
+the fate that awaited her, she escaped, was retaken, and devoted by the
+rajah's relatives, who had an interest in her death, to the sacrifice
+from which it seemed she could not escape.
+
+The Parsee's narrative only confirmed Mr. Fogg and his companions in
+their generous design.  It was decided that the guide should direct the
+elephant towards the pagoda of Pillaji, which he accordingly approached
+as quickly as possible.  They halted, half an hour afterwards, in a
+copse, some five hundred feet from the pagoda, where they were well
+concealed; but they could hear the groans and cries of the fakirs
+distinctly.
+
+They then discussed the means of getting at the victim.  The guide was
+familiar with the pagoda of Pillaji, in which, as he declared, the
+young woman was imprisoned.  Could they enter any of its doors while
+the whole party of Indians was plunged in a drunken sleep, or was it
+safer to attempt to make a hole in the walls?  This could only be
+determined at the moment and the place themselves; but it was certain
+that the abduction must be made that night, and not when, at break of
+day, the victim was led to her funeral pyre.  Then no human
+intervention could save her.
+
+As soon as night fell, about six o'clock, they decided to make a
+reconnaissance around the pagoda.  The cries of the fakirs were just
+ceasing; the Indians were in the act of plunging themselves into the
+drunkenness caused by liquid opium mingled with hemp, and it might be
+possible to slip between them to the temple itself.
+
+The Parsee, leading the others, noiselessly crept through the wood, and
+in ten minutes they found themselves on the banks of a small stream,
+whence, by the light of the rosin torches, they perceived a pyre of
+wood, on the top of which lay the embalmed body of the rajah, which was
+to be burned with his wife.  The pagoda, whose minarets loomed above
+the trees in the deepening dusk, stood a hundred steps away.
+
+"Come!" whispered the guide.
+
+He slipped more cautiously than ever through the brush, followed by his
+companions; the silence around was only broken by the low murmuring of
+the wind among the branches.
+
+Soon the Parsee stopped on the borders of the glade, which was lit up
+by the torches.  The ground was covered by groups of the Indians,
+motionless in their drunken sleep; it seemed a battlefield strewn with
+the dead.  Men, women, and children lay together.
+
+In the background, among the trees, the pagoda of Pillaji loomed
+distinctly.  Much to the guide's disappointment, the guards of the
+rajah, lighted by torches, were watching at the doors and marching to
+and fro with naked sabres; probably the priests, too, were watching
+within.
+
+The Parsee, now convinced that it was impossible to force an entrance
+to the temple, advanced no farther, but led his companions back again.
+Phileas Fogg and Sir Francis Cromarty also saw that nothing could be
+attempted in that direction.  They stopped, and engaged in a whispered
+colloquy.
+
+"It is only eight now," said the brigadier, "and these guards may also
+go to sleep."
+
+"It is not impossible," returned the Parsee.
+
+They lay down at the foot of a tree, and waited.
+
+The time seemed long; the guide ever and anon left them to take an
+observation on the edge of the wood, but the guards watched steadily by
+the glare of the torches, and a dim light crept through the windows of
+the pagoda.
+
+They waited till midnight; but no change took place among the guards,
+and it became apparent that their yielding to sleep could not be
+counted on.  The other plan must be carried out; an opening in the
+walls of the pagoda must be made.  It remained to ascertain whether the
+priests were watching by the side of their victim as assiduously as
+were the soldiers at the door.
+
+After a last consultation, the guide announced that he was ready for
+the attempt, and advanced, followed by the others.  They took a
+roundabout way, so as to get at the pagoda on the rear.  They reached
+the walls about half-past twelve, without having met anyone; here there
+was no guard, nor were there either windows or doors.
+
+The night was dark.  The moon, on the wane, scarcely left the horizon,
+and was covered with heavy clouds; the height of the trees deepened the
+darkness.
+
+It was not enough to reach the walls; an opening in them must be
+accomplished, and to attain this purpose the party only had their
+pocket-knives.  Happily the temple walls were built of brick and wood,
+which could be penetrated with little difficulty; after one brick had
+been taken out, the rest would yield easily.
+
+They set noiselessly to work, and the Parsee on one side and
+Passepartout on the other began to loosen the bricks so as to make an
+aperture two feet wide.  They were getting on rapidly, when suddenly a
+cry was heard in the interior of the temple, followed almost instantly
+by other cries replying from the outside.  Passepartout and the guide
+stopped.  Had they been heard?  Was the alarm being given?  Common
+prudence urged them to retire, and they did so, followed by Phileas
+Fogg and Sir Francis.  They again hid themselves in the wood, and
+waited till the disturbance, whatever it might be, ceased, holding
+themselves ready to resume their attempt without delay.  But, awkwardly
+enough, the guards now appeared at the rear of the temple, and there
+installed themselves, in readiness to prevent a surprise.
+
+It would be difficult to describe the disappointment of the party, thus
+interrupted in their work.  They could not now reach the victim; how,
+then, could they save her?  Sir Francis shook his fists, Passepartout
+was beside himself, and the guide gnashed his teeth with rage.  The
+tranquil Fogg waited, without betraying any emotion.
+
+"We have nothing to do but to go away," whispered Sir Francis.
+
+"Nothing but to go away," echoed the guide.
+
+"Stop," said Fogg.  "I am only due at Allahabad tomorrow before noon."
+
+"But what can you hope to do?" asked Sir Francis.  "In a few hours it
+will be daylight, and--"
+
+"The chance which now seems lost may present itself at the last moment."
+
+Sir Francis would have liked to read Phileas Fogg's eyes.  What was
+this cool Englishman thinking of?  Was he planning to make a rush for
+the young woman at the very moment of the sacrifice, and boldly snatch
+her from her executioners?
+
+This would be utter folly, and it was hard to admit that Fogg was such
+a fool.  Sir Francis consented, however, to remain to the end of this
+terrible drama.  The guide led them to the rear of the glade, where
+they were able to observe the sleeping groups.
+
+Meanwhile Passepartout, who had perched himself on the lower branches
+of a tree, was resolving an idea which had at first struck him like a
+flash, and which was now firmly lodged in his brain.
+
+He had commenced by saying to himself, "What folly!" and then he
+repeated, "Why not, after all?  It's a chance,--perhaps the only one; and
+with such sots!" Thinking thus, he slipped, with the suppleness of a
+serpent, to the lowest branches, the ends of which bent almost to the
+ground.
+
+The hours passed, and the lighter shades now announced the approach of
+day, though it was not yet light.  This was the moment.  The slumbering
+multitude became animated, the tambourines sounded, songs and cries
+arose; the hour of the sacrifice had come.  The doors of the pagoda
+swung open, and a bright light escaped from its interior, in the midst
+of which Mr. Fogg and Sir Francis espied the victim.  She seemed,
+having shaken off the stupor of intoxication, to be striving to escape
+from her executioner.  Sir Francis's heart throbbed; and, convulsively
+seizing Mr. Fogg's hand, found in it an open knife.  Just at this
+moment the crowd began to move.  The young woman had again fallen into
+a stupor caused by the fumes of hemp, and passed among the fakirs, who
+escorted her with their wild, religious cries.
+
+Phileas Fogg and his companions, mingling in the rear ranks of the
+crowd, followed; and in two minutes they reached the banks of the
+stream, and stopped fifty paces from the pyre, upon which still lay the
+rajah's corpse.  In the semi-obscurity they saw the victim, quite
+senseless, stretched out beside her husband's body. Then a torch was
+brought, and the wood, heavily soaked with oil, instantly took fire.
+
+At this moment Sir Francis and the guide seized Phileas Fogg, who, in
+an instant of mad generosity, was about to rush upon the pyre.  But he
+had quickly pushed them aside, when the whole scene suddenly changed.
+A cry of terror arose.  The whole multitude prostrated themselves,
+terror-stricken, on the ground.
+
+The old rajah was not dead, then, since he rose of a sudden, like a
+spectre, took up his wife in his arms, and descended from the pyre in
+the midst of the clouds of smoke, which only heightened his ghostly
+appearance.
+
+Fakirs and soldiers and priests, seized with instant terror, lay there,
+with their faces on the ground, not daring to lift their eyes and
+behold such a prodigy.
+
+The inanimate victim was borne along by the vigorous arms which
+supported her, and which she did not seem in the least to burden.  Mr.
+Fogg and Sir Francis stood erect, the Parsee bowed his head, and
+Passepartout was, no doubt, scarcely less stupefied.
+
+The resuscitated rajah approached Sir Francis and Mr. Fogg, and, in an
+abrupt tone, said, "Let us be off!"
+
+It was Passepartout himself, who had slipped upon the pyre in the midst
+of the smoke and, profiting by the still overhanging darkness, had
+delivered the young woman from death!  It was Passepartout who, playing
+his part with a happy audacity, had passed through the crowd amid the
+general terror.
+
+A moment after all four of the party had disappeared in the woods, and
+the elephant was bearing them away at a rapid pace. But the cries and
+noise, and a ball which whizzed through Phileas Fogg's hat, apprised
+them that the trick had been discovered.
+
+The old rajah's body, indeed, now appeared upon the burning pyre; and
+the priests, recovered from their terror, perceived that an abduction
+had taken place.  They hastened into the forest, followed by the
+soldiers, who fired a volley after the fugitives; but the latter
+rapidly increased the distance between them, and ere long found
+themselves beyond the reach of the bullets and arrows.
+
+
+
+
+Chapter XIV
+
+IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL VALLEY
+OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+
+The rash exploit had been accomplished; and for an hour Passepartout
+laughed gaily at his success.  Sir Francis pressed the worthy fellow's
+hand, and his master said, "Well done!" which, from him, was high
+commendation; to which Passepartout replied that all the credit of the
+affair belonged to Mr. Fogg.  As for him, he had only been struck with
+a "queer" idea; and he laughed to think that for a few moments he,
+Passepartout, the ex-gymnast, ex-sergeant fireman, had been the spouse
+of a charming woman, a venerable, embalmed rajah!  As for the young
+Indian woman, she had been unconscious throughout of what was passing,
+and now, wrapped up in a travelling-blanket, was reposing in one of the
+howdahs.
+
+The elephant, thanks to the skilful guidance of the Parsee, was
+advancing rapidly through the still darksome forest, and, an hour after
+leaving the pagoda, had crossed a vast plain.  They made a halt at
+seven o'clock, the young woman being still in a state of complete
+prostration.  The guide made her drink a little brandy and water, but
+the drowsiness which stupefied her could not yet be shaken off.  Sir
+Francis, who was familiar with the effects of the intoxication produced
+by the fumes of hemp, reassured his companions on her account.  But he
+was more disturbed at the prospect of her future fate.  He told Phileas
+Fogg that, should Aouda remain in India, she would inevitably fall
+again into the hands of her executioners.  These fanatics were
+scattered throughout the county, and would, despite the English police,
+recover their victim at Madras, Bombay, or Calcutta.  She would only be
+safe by quitting India for ever.
+
+Phileas Fogg replied that he would reflect upon the matter.
+
+The station at Allahabad was reached about ten o'clock, and, the
+interrupted line of railway being resumed, would enable them to reach
+Calcutta in less than twenty-four hours.  Phileas Fogg would thus be
+able to arrive in time to take the steamer which left Calcutta the next
+day, October 25th, at noon, for Hong Kong.
+
+The young woman was placed in one of the waiting-rooms of the station,
+whilst Passepartout was charged with purchasing for her various
+articles of toilet, a dress, shawl, and some furs; for which his master
+gave him unlimited credit.  Passepartout started off forthwith, and
+found himself in the streets of Allahabad, that is, the City of God,
+one of the most venerated in India, being built at the junction of the
+two sacred rivers, Ganges and Jumna, the waters of which attract
+pilgrims from every part of the peninsula.  The Ganges, according to
+the legends of the Ramayana, rises in heaven, whence, owing to Brahma's
+agency, it descends to the earth.
+
+Passepartout made it a point, as he made his purchases, to take a good
+look at the city.  It was formerly defended by a noble fort, which has
+since become a state prison; its commerce has dwindled away, and
+Passepartout in vain looked about him for such a bazaar as he used to
+frequent in Regent Street.  At last he came upon an elderly, crusty
+Jew, who sold second-hand articles, and from whom he purchased a dress
+of Scotch stuff, a large mantle, and a fine otter-skin pelisse, for
+which he did not hesitate to pay seventy-five pounds.  He then returned
+triumphantly to the station.
+
+The influence to which the priests of Pillaji had subjected Aouda began
+gradually to yield, and she became more herself, so that her fine eyes
+resumed all their soft Indian expression.
+
+When the poet-king, Ucaf Uddaul, celebrates the charms of the queen of
+Ahmehnagara, he speaks thus:
+
+"Her shining tresses, divided in two parts, encircle the harmonious
+contour of her white and delicate cheeks, brilliant in their glow and
+freshness.  Her ebony brows have the form and charm of the bow of Kama,
+the god of love, and beneath her long silken lashes the purest
+reflections and a celestial light swim, as in the sacred lakes of
+Himalaya, in the black pupils of her great clear eyes.  Her teeth,
+fine, equal, and white, glitter between her smiling lips like dewdrops
+in a passion-flower's half-enveloped breast.  Her delicately formed
+ears, her vermilion hands, her little feet, curved and tender as the
+lotus-bud, glitter with the brilliancy of the loveliest pearls of
+Ceylon, the most dazzling diamonds of Golconda.  Her narrow and supple
+waist, which a hand may clasp around, sets forth the outline of her
+rounded figure and the beauty of her bosom, where youth in its flower
+displays the wealth of its treasures; and beneath the silken folds of
+her tunic she seems to have been modelled in pure silver by the godlike
+hand of Vicvarcarma, the immortal sculptor."
+
+It is enough to say, without applying this poetical rhapsody to Aouda,
+that she was a charming woman, in all the European acceptation of the
+phrase.  She spoke English with great purity, and the guide had not
+exaggerated in saying that the young Parsee had been transformed by her
+bringing up.
+
+The train was about to start from Allahabad, and Mr. Fogg proceeded to
+pay the guide the price agreed upon for his service, and not a farthing
+more; which astonished Passepartout, who remembered all that his master
+owed to the guide's devotion.  He had, indeed, risked his life in the
+adventure at Pillaji, and, if he should be caught afterwards by the
+Indians, he would with difficulty escape their vengeance.  Kiouni,
+also, must be disposed of.  What should be done with the elephant,
+which had been so dearly purchased?  Phileas Fogg had already
+determined this question.
+
+"Parsee," said he to the guide, "you have been serviceable and devoted.
+I have paid for your service, but not for your devotion.  Would you
+like to have this elephant?  He is yours."
+
+The guide's eyes glistened.
+
+"Your honour is giving me a fortune!" cried he.
+
+"Take him, guide," returned Mr. Fogg, "and I shall still be your
+debtor."
+
+"Good!" exclaimed Passepartout.  "Take him, friend.  Kiouni is a brave
+and faithful beast."  And, going up to the elephant, he gave him
+several lumps of sugar, saying, "Here, Kiouni, here, here."
+
+The elephant grunted out his satisfaction, and, clasping Passepartout
+around the waist with his trunk, lifted him as high as his head.
+Passepartout, not in the least alarmed, caressed the animal, which
+replaced him gently on the ground.
+
+Soon after, Phileas Fogg, Sir Francis Cromarty, and Passepartout,
+installed in a carriage with Aouda, who had the best seat, were
+whirling at full speed towards Benares.  It was a run of eighty miles,
+and was accomplished in two hours.  During the journey, the young woman
+fully recovered her senses.  What was her astonishment to find herself
+in this carriage, on the railway, dressed in European habiliments, and
+with travellers who were quite strangers to her!  Her companions first
+set about fully reviving her with a little liquor, and then Sir Francis
+narrated to her what had passed, dwelling upon the courage with which
+Phileas Fogg had not hesitated to risk his life to save her, and
+recounting the happy sequel of the venture, the result of
+Passepartout's rash idea.  Mr. Fogg said nothing; while Passepartout,
+abashed, kept repeating that "it wasn't worth telling."
+
+Aouda pathetically thanked her deliverers, rather with tears than
+words; her fine eyes interpreted her gratitude better than her lips.
+Then, as her thoughts strayed back to the scene of the sacrifice, and
+recalled the dangers which still menaced her, she shuddered with terror.
+
+Phileas Fogg understood what was passing in Aouda's mind, and offered,
+in order to reassure her, to escort her to Hong Kong, where she might
+remain safely until the affair was hushed up--an offer which she
+eagerly and gratefully accepted.  She had, it seems, a Parsee relation,
+who was one of the principal merchants of Hong Kong, which is wholly an
+English city, though on an island on the Chinese coast.
+
+At half-past twelve the train stopped at Benares.  The Brahmin legends
+assert that this city is built on the site of the ancient Casi, which,
+like Mahomet's tomb, was once suspended between heaven and earth;
+though the Benares of to-day, which the Orientalists call the Athens of
+India, stands quite unpoetically on the solid earth, Passepartout
+caught glimpses of its brick houses and clay huts, giving an aspect of
+desolation to the place, as the train entered it.
+
+Benares was Sir Francis Cromarty's destination, the troops he was
+rejoining being encamped some miles northward of the city.  He bade
+adieu to Phileas Fogg, wishing him all success, and expressing the hope
+that he would come that way again in a less original but more
+profitable fashion.  Mr. Fogg lightly pressed him by the hand.  The
+parting of Aouda, who did not forget what she owed to Sir Francis,
+betrayed more warmth; and, as for Passepartout, he received a hearty
+shake of the hand from the gallant general.
+
+The railway, on leaving Benares, passed for a while along the valley of
+the Ganges.  Through the windows of their carriage the travellers had
+glimpses of the diversified landscape of Behar, with its mountains
+clothed in verdure, its fields of barley, wheat, and corn, its jungles
+peopled with green alligators, its neat villages, and its still
+thickly-leaved forests.  Elephants were bathing in the waters of the
+sacred river, and groups of Indians, despite the advanced season and
+chilly air, were performing solemnly their pious ablutions.  These were
+fervent Brahmins, the bitterest foes of Buddhism, their deities being
+Vishnu, the solar god, Shiva, the divine impersonation of natural
+forces, and Brahma, the supreme ruler of priests and legislators.  What
+would these divinities think of India, anglicised as it is to-day, with
+steamers whistling and scudding along the Ganges, frightening the gulls
+which float upon its surface, the turtles swarming along its banks, and
+the faithful dwelling upon its borders?
+
+The panorama passed before their eyes like a flash, save when the steam
+concealed it fitfully from the view; the travellers could scarcely
+discern the fort of Chupenie, twenty miles south-westward from Benares,
+the ancient stronghold of the rajahs of Behar; or Ghazipur and its
+famous rose-water factories; or the tomb of Lord Cornwallis, rising on
+the left bank of the Ganges; the fortified town of Buxar, or Patna, a
+large manufacturing and trading-place, where is held the principal
+opium market of India; or Monghir, a more than European town, for it is
+as English as Manchester or Birmingham, with its iron foundries,
+edgetool factories, and high chimneys puffing clouds of black smoke
+heavenward.
+
+Night came on; the train passed on at full speed, in the midst of the
+roaring of the tigers, bears, and wolves which fled before the
+locomotive; and the marvels of Bengal, Golconda ruined Gour,
+Murshedabad, the ancient capital, Burdwan, Hugly, and the French town
+of Chandernagor, where Passepartout would have been proud to see his
+country's flag flying, were hidden from their view in the darkness.
+
+Calcutta was reached at seven in the morning, and the packet left for
+Hong Kong at noon; so that Phileas Fogg had five hours before him.
+
+According to his journal, he was due at Calcutta on the 25th of
+October, and that was the exact date of his actual arrival.  He was
+therefore neither behind-hand nor ahead of time.  The two days gained
+between London and Bombay had been lost, as has been seen, in the
+journey across India.  But it is not to be supposed that Phileas Fogg
+regretted them.
+
+
+
+
+Chapter XV
+
+IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS MORE
+
+
+The train entered the station, and Passepartout jumping out first, was
+followed by Mr. Fogg, who assisted his fair companion to descend.
+Phileas Fogg intended to proceed at once to the Hong Kong steamer, in
+order to get Aouda comfortably settled for the voyage.  He was
+unwilling to leave her while they were still on dangerous ground.
+
+Just as he was leaving the station a policeman came up to him, and
+said, "Mr. Phileas Fogg?"
+
+"I am he."
+
+"Is this man your servant?" added the policeman, pointing to
+Passepartout.
+
+"Yes."
+
+"Be so good, both of you, as to follow me."
+
+Mr. Fogg betrayed no surprise whatever.  The policeman was a
+representative of the law, and law is sacred to an Englishman.
+Passepartout tried to reason about the matter, but the policeman tapped
+him with his stick, and Mr. Fogg made him a signal to obey.
+
+"May this young lady go with us?" asked he.
+
+"She may," replied the policeman.
+
+Mr. Fogg, Aouda, and Passepartout were conducted to a palkigahri, a
+sort of four-wheeled carriage, drawn by two horses, in which they took
+their places and were driven away.  No one spoke during the twenty
+minutes which elapsed before they reached their destination.  They
+first passed through the "black town," with its narrow streets, its
+miserable, dirty huts, and squalid population; then through the
+"European town," which presented a relief in its bright brick mansions,
+shaded by coconut-trees and bristling with masts, where, although it
+was early morning, elegantly dressed horsemen and handsome equipages
+were passing back and forth.
+
+The carriage stopped before a modest-looking house, which, however, did
+not have the appearance of a private mansion.  The policeman having
+requested his prisoners--for so, truly, they might be called--to descend,
+conducted them into a room with barred windows, and said:  "You will
+appear before Judge Obadiah at half-past eight."
+
+He then retired, and closed the door.
+
+"Why, we are prisoners!" exclaimed Passepartout, falling into a chair.
+
+Aouda, with an emotion she tried to conceal, said to Mr. Fogg: "Sir,
+you must leave me to my fate!  It is on my account that you receive
+this treatment, it is for having saved me!"
+
+Phileas Fogg contented himself with saying that it was impossible.  It
+was quite unlikely that he should be arrested for preventing a suttee.
+The complainants would not dare present themselves with such a charge.
+There was some mistake.  Moreover, he would not, in any event, abandon
+Aouda, but would escort her to Hong Kong.
+
+"But the steamer leaves at noon!" observed Passepartout, nervously.
+
+"We shall be on board by noon," replied his master, placidly.
+
+It was said so positively that Passepartout could not help muttering to
+himself, "Parbleu that's certain!  Before noon we shall be on board."
+But he was by no means reassured.
+
+At half-past eight the door opened, the policeman appeared, and,
+requesting them to follow him, led the way to an adjoining hall.  It
+was evidently a court-room, and a crowd of Europeans and natives
+already occupied the rear of the apartment.
+
+Mr. Fogg and his two companions took their places on a bench opposite
+the desks of the magistrate and his clerk.  Immediately after, Judge
+Obadiah, a fat, round man, followed by the clerk, entered.  He
+proceeded to take down a wig which was hanging on a nail, and put it
+hurriedly on his head.
+
+"The first case," said he.  Then, putting his hand to his head, he
+exclaimed, "Heh!  This is not my wig!"
+
+"No, your worship," returned the clerk, "it is mine."
+
+"My dear Mr. Oysterpuff, how can a judge give a wise sentence in a
+clerk's wig?"
+
+The wigs were exchanged.
+
+Passepartout was getting nervous, for the hands on the face of the big
+clock over the judge seemed to go around with terrible rapidity.
+
+"The first case," repeated Judge Obadiah.
+
+"Phileas Fogg?" demanded Oysterpuff.
+
+"I am here," replied Mr. Fogg.
+
+"Passepartout?"
+
+"Present," responded Passepartout.
+
+"Good," said the judge.  "You have been looked for, prisoners, for two
+days on the trains from Bombay."
+
+"But of what are we accused?" asked Passepartout, impatiently.
+
+"You are about to be informed."
+
+"I am an English subject, sir," said Mr. Fogg, "and I have the right--"
+
+"Have you been ill-treated?"
+
+"Not at all."
+
+"Very well; let the complainants come in."
+
+A door was swung open by order of the judge, and three Indian priests
+entered.
+
+"That's it," muttered Passepartout; "these are the rogues who were
+going to burn our young lady."
+
+The priests took their places in front of the judge, and the clerk
+proceeded to read in a loud voice a complaint of sacrilege against
+Phileas Fogg and his servant, who were accused of having violated a
+place held consecrated by the Brahmin religion.
+
+"You hear the charge?" asked the judge.
+
+"Yes, sir," replied Mr. Fogg, consulting his watch, "and I admit it."
+
+"You admit it?"
+
+"I admit it, and I wish to hear these priests admit, in their turn,
+what they were going to do at the pagoda of Pillaji."
+
+The priests looked at each other; they did not seem to understand what
+was said.
+
+"Yes," cried Passepartout, warmly; "at the pagoda of Pillaji, where
+they were on the point of burning their victim."
+
+The judge stared with astonishment, and the priests were stupefied.
+
+"What victim?" said Judge Obadiah.  "Burn whom?  In Bombay itself?"
+
+"Bombay?" cried Passepartout.
+
+"Certainly.  We are not talking of the pagoda of Pillaji, but of the
+pagoda of Malabar Hill, at Bombay."
+
+"And as a proof," added the clerk, "here are the desecrator's very
+shoes, which he left behind him."
+
+Whereupon he placed a pair of shoes on his desk.
+
+"My shoes!" cried Passepartout, in his surprise permitting this
+imprudent exclamation to escape him.
+
+The confusion of master and man, who had quite forgotten the affair at
+Bombay, for which they were now detained at Calcutta, may be imagined.
+
+Fix the detective, had foreseen the advantage which Passepartout's
+escapade gave him, and, delaying his departure for twelve hours, had
+consulted the priests of Malabar Hill.  Knowing that the English
+authorities dealt very severely with this kind of misdemeanour, he
+promised them a goodly sum in damages, and sent them forward to
+Calcutta by the next train.  Owing to the delay caused by the rescue of
+the young widow, Fix and the priests reached the Indian capital before
+Mr. Fogg and his servant, the magistrates having been already warned by
+a dispatch to arrest them should they arrive.  Fix's disappointment
+when he learned that Phileas Fogg had not made his appearance in
+Calcutta may be imagined.  He made up his mind that the robber had
+stopped somewhere on the route and taken refuge in the southern
+provinces.  For twenty-four hours Fix watched the station with feverish
+anxiety; at last he was rewarded by seeing Mr. Fogg and Passepartout
+arrive, accompanied by a young woman, whose presence he was wholly at a
+loss to explain.  He hastened for a policeman; and this was how the
+party came to be arrested and brought before Judge Obadiah.
+
+Had Passepartout been a little less preoccupied, he would have espied
+the detective ensconced in a corner of the court-room, watching the
+proceedings with an interest easily understood; for the warrant had
+failed to reach him at Calcutta, as it had done at Bombay and Suez.
+
+Judge Obadiah had unfortunately caught Passepartout's rash exclamation,
+which the poor fellow would have given the world to recall.
+
+"The facts are admitted?" asked the judge.
+
+"Admitted," replied Mr. Fogg, coldly.
+
+"Inasmuch," resumed the judge, "as the English law protects equally and
+sternly the religions of the Indian people, and as the man Passepartout
+has admitted that he violated the sacred pagoda of Malabar Hill, at
+Bombay, on the 20th of October, I condemn the said Passepartout to
+imprisonment for fifteen days and a fine of three hundred pounds."
+
+"Three hundred pounds!" cried Passepartout, startled at the largeness
+of the sum.
+
+"Silence!" shouted the constable.
+
+"And inasmuch," continued the judge, "as it is not proved that the act
+was not done by the connivance of the master with the servant, and as
+the master in any case must be held responsible for the acts of his
+paid servant, I condemn Phileas Fogg to a week's imprisonment and a
+fine of one hundred and fifty pounds."
+
+Fix rubbed his hands softly with satisfaction; if Phileas Fogg could be
+detained in Calcutta a week, it would be more than time for the warrant
+to arrive.  Passepartout was stupefied.  This sentence ruined his
+master.  A wager of twenty thousand pounds lost, because he, like a
+precious fool, had gone into that abominable pagoda!
+
+Phileas Fogg, as self-composed as if the judgment did not in the least
+concern him, did not even lift his eyebrows while it was being
+pronounced.  Just as the clerk was calling the next case, he rose, and
+said, "I offer bail."
+
+"You have that right," returned the judge.
+
+Fix's blood ran cold, but he resumed his composure when he heard the
+judge announce that the bail required for each prisoner would be one
+thousand pounds.
+
+"I will pay it at once," said Mr. Fogg, taking a roll of bank-bills
+from the carpet-bag, which Passepartout had by him, and placing them on
+the clerk's desk.
+
+"This sum will be restored to you upon your release from prison," said
+the judge.  "Meanwhile, you are liberated on bail."
+
+"Come!" said Phileas Fogg to his servant.
+
+"But let them at least give me back my shoes!" cried Passepartout
+angrily.
+
+"Ah, these are pretty dear shoes!" he muttered, as they were handed to
+him.  "More than a thousand pounds apiece; besides, they pinch my feet."
+
+Mr. Fogg, offering his arm to Aouda, then departed, followed by the
+crestfallen Passepartout.  Fix still nourished hopes that the robber
+would not, after all, leave the two thousand pounds behind him, but
+would decide to serve out his week in jail, and issued forth on Mr.
+Fogg's traces.  That gentleman took a carriage, and the party were soon
+landed on one of the quays.
+
+The Rangoon was moored half a mile off in the harbour, its signal of
+departure hoisted at the mast-head.  Eleven o'clock was striking; Mr.
+Fogg was an hour in advance of time.  Fix saw them leave the carriage
+and push off in a boat for the steamer, and stamped his feet with
+disappointment.
+
+"The rascal is off, after all!" he exclaimed.  "Two thousand pounds
+sacrificed!  He's as prodigal as a thief!  I'll follow him to the end
+of the world if necessary; but, at the rate he is going on, the stolen
+money will soon be exhausted."
+
+The detective was not far wrong in making this conjecture.  Since
+leaving London, what with travelling expenses, bribes, the purchase of
+the elephant, bails, and fines, Mr. Fogg had already spent more than
+five thousand pounds on the way, and the percentage of the sum
+recovered from the bank robber promised to the detectives, was rapidly
+diminishing.
+
+
+
+
+Chapter XVI
+
+IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS SAID TO
+HIM
+
+
+The Rangoon--one of the Peninsular and Oriental Company's boats plying
+in the Chinese and Japanese seas--was a screw steamer, built of iron,
+weighing about seventeen hundred and seventy tons, and with engines of
+four hundred horse-power.  She was as fast, but not as well fitted up,
+as the Mongolia, and Aouda was not as comfortably provided for on board
+of her as Phileas Fogg could have wished.  However, the trip from
+Calcutta to Hong Kong only comprised some three thousand five hundred
+miles, occupying from ten to twelve days, and the young woman was not
+difficult to please.
+
+During the first days of the journey Aouda became better acquainted
+with her protector, and constantly gave evidence of her deep gratitude
+for what he had done.  The phlegmatic gentleman listened to her,
+apparently at least, with coldness, neither his voice nor his manner
+betraying the slightest emotion; but he seemed to be always on the
+watch that nothing should be wanting to Aouda's comfort.  He visited
+her regularly each day at certain hours, not so much to talk himself,
+as to sit and hear her talk.  He treated her with the strictest
+politeness, but with the precision of an automaton, the movements of
+which had been arranged for this purpose.  Aouda did not quite know
+what to make of him, though Passepartout had given her some hints of
+his master's eccentricity, and made her smile by telling her of the
+wager which was sending him round the world.  After all, she owed
+Phileas Fogg her life, and she always regarded him through the exalting
+medium of her gratitude.
+
+Aouda confirmed the Parsee guide's narrative of her touching history.
+She did, indeed, belong to the highest of the native races of India.
+Many of the Parsee merchants have made great fortunes there by dealing
+in cotton; and one of them, Sir Jametsee Jeejeebhoy, was made a baronet
+by the English government.  Aouda was a relative of this great man, and
+it was his cousin, Jeejeeh, whom she hoped to join at Hong Kong.
+Whether she would find a protector in him she could not tell; but Mr.
+Fogg essayed to calm her anxieties, and to assure her that everything
+would be mathematically--he used the very word--arranged.  Aouda
+fastened her great eyes, "clear as the sacred lakes of the Himalaya,"
+upon him; but the intractable Fogg, as reserved as ever, did not seem
+at all inclined to throw himself into this lake.
+
+The first few days of the voyage passed prosperously, amid favourable
+weather and propitious winds, and they soon came in sight of the great
+Andaman, the principal of the islands in the Bay of Bengal, with its
+picturesque Saddle Peak, two thousand four hundred feet high, looming
+above the waters.  The steamer passed along near the shores, but the
+savage Papuans, who are in the lowest scale of humanity, but are not,
+as has been asserted, cannibals, did not make their appearance.
+
+The panorama of the islands, as they steamed by them, was superb.  Vast
+forests of palms, arecs, bamboo, teakwood, of the gigantic mimosa, and
+tree-like ferns covered the foreground, while behind, the graceful
+outlines of the mountains were traced against the sky; and along the
+coasts swarmed by thousands the precious swallows whose nests furnish a
+luxurious dish to the tables of the Celestial Empire.  The varied
+landscape afforded by the Andaman Islands was soon passed, however, and
+the Rangoon rapidly approached the Straits of Malacca, which gave
+access to the China seas.
+
+What was detective Fix, so unluckily drawn on from country to country,
+doing all this while?  He had managed to embark on the Rangoon at
+Calcutta without being seen by Passepartout, after leaving orders that,
+if the warrant should arrive, it should be forwarded to him at Hong
+Kong; and he hoped to conceal his presence to the end of the voyage.
+It would have been difficult to explain why he was on board without
+awakening Passepartout's suspicions, who thought him still at Bombay.
+But necessity impelled him, nevertheless, to renew his acquaintance
+with the worthy servant, as will be seen.
+
+All the detective's hopes and wishes were now centred on Hong Kong; for
+the steamer's stay at Singapore would be too brief to enable him to
+take any steps there.  The arrest must be made at Hong Kong, or the
+robber would probably escape him for ever.  Hong Kong was the last
+English ground on which he would set foot; beyond, China, Japan,
+America offered to Fogg an almost certain refuge.  If the warrant
+should at last make its appearance at Hong Kong, Fix could arrest him
+and give him into the hands of the local police, and there would be no
+further trouble.  But beyond Hong Kong, a simple warrant would be of no
+avail; an extradition warrant would be necessary, and that would result
+in delays and obstacles, of which the rascal would take advantage to
+elude justice.
+
+Fix thought over these probabilities during the long hours which he
+spent in his cabin, and kept repeating to himself, "Now, either the
+warrant will be at Hong Kong, in which case I shall arrest my man, or
+it will not be there; and this time it is absolutely necessary that I
+should delay his departure.  I have failed at Bombay, and I have failed
+at Calcutta; if I fail at Hong Kong, my reputation is lost:  Cost what
+it may, I must succeed!  But how shall I prevent his departure, if that
+should turn out to be my last resource?"
+
+Fix made up his mind that, if worst came to worst, he would make a
+confidant of Passepartout, and tell him what kind of a fellow his
+master really was.  That Passepartout was not Fogg's accomplice, he was
+very certain.  The servant, enlightened by his disclosure, and afraid
+of being himself implicated in the crime, would doubtless become an
+ally of the detective.  But this method was a dangerous one, only to be
+employed when everything else had failed.  A word from Passepartout to
+his master would ruin all.  The detective was therefore in a sore
+strait.  But suddenly a new idea struck him.  The presence of Aouda on
+the Rangoon, in company with Phileas Fogg, gave him new material for
+reflection.
+
+Who was this woman?  What combination of events had made her Fogg's
+travelling companion?  They had evidently met somewhere between Bombay
+and Calcutta; but where?  Had they met accidentally, or had Fogg gone
+into the interior purposely in quest of this charming damsel?  Fix was
+fairly puzzled.  He asked himself whether there had not been a wicked
+elopement; and this idea so impressed itself upon his mind that he
+determined to make use of the supposed intrigue.  Whether the young
+woman were married or not, he would be able to create such difficulties
+for Mr. Fogg at Hong Kong that he could not escape by paying any amount
+of money.
+
+But could he even wait till they reached Hong Kong?  Fogg had an
+abominable way of jumping from one boat to another, and, before
+anything could be effected, might get full under way again for Yokohama.
+
+Fix decided that he must warn the English authorities, and signal the
+Rangoon before her arrival.  This was easy to do, since the steamer
+stopped at Singapore, whence there is a telegraphic wire to Hong Kong.
+He finally resolved, moreover, before acting more positively, to
+question Passepartout.  It would not be difficult to make him talk;
+and, as there was no time to lose, Fix prepared to make himself known.
+
+It was now the 30th of October, and on the following day the Rangoon
+was due at Singapore.
+
+Fix emerged from his cabin and went on deck.  Passepartout was
+promenading up and down in the forward part of the steamer.  The
+detective rushed forward with every appearance of extreme surprise, and
+exclaimed, "You here, on the Rangoon?"
+
+"What, Monsieur Fix, are you on board?" returned the really astonished
+Passepartout, recognising his crony of the Mongolia.  "Why, I left you
+at Bombay, and here you are, on the way to Hong Kong!  Are you going
+round the world too?"
+
+"No, no," replied Fix; "I shall stop at Hong Kong--at least for some
+days."
+
+"Hum!" said Passepartout, who seemed for an instant perplexed.  "But
+how is it I have not seen you on board since we left Calcutta?"
+
+"Oh, a trifle of sea-sickness--I've been staying in my berth.  The Gulf
+of Bengal does not agree with me as well as the Indian Ocean.  And how
+is Mr. Fogg?"
+
+"As well and as punctual as ever, not a day behind time!  But, Monsieur
+Fix, you don't know that we have a young lady with us."
+
+"A young lady?" replied the detective, not seeming to comprehend what
+was said.
+
+Passepartout thereupon recounted Aouda's history, the affair at the
+Bombay pagoda, the purchase of the elephant for two thousand pounds,
+the rescue, the arrest, and sentence of the Calcutta court, and the
+restoration of Mr. Fogg and himself to liberty on bail.  Fix, who was
+familiar with the last events, seemed to be equally ignorant of all
+that Passepartout related; and the later was charmed to find so
+interested a listener.
+
+"But does your master propose to carry this young woman to Europe?"
+
+"Not at all.  We are simply going to place her under the protection of
+one of her relatives, a rich merchant at Hong Kong."
+
+"Nothing to be done there," said Fix to himself, concealing his
+disappointment.  "A glass of gin, Mr. Passepartout?"
+
+"Willingly, Monsieur Fix.  We must at least have a friendly glass on
+board the Rangoon."
+
+
+
+
+Chapter XVII
+
+SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+
+The detective and Passepartout met often on deck after this interview,
+though Fix was reserved, and did not attempt to induce his companion to
+divulge any more facts concerning Mr. Fogg.  He caught a glimpse of
+that mysterious gentleman once or twice; but Mr. Fogg usually confined
+himself to the cabin, where he kept Aouda company, or, according to his
+inveterate habit, took a hand at whist.
+
+Passepartout began very seriously to conjecture what strange chance
+kept Fix still on the route that his master was pursuing.  It was
+really worth considering why this certainly very amiable and complacent
+person, whom he had first met at Suez, had then encountered on board
+the Mongolia, who disembarked at Bombay, which he announced as his
+destination, and now turned up so unexpectedly on the Rangoon, was
+following Mr. Fogg's tracks step by step.  What was Fix's object?
+Passepartout was ready to wager his Indian shoes--which he religiously
+preserved--that Fix would also leave Hong Kong at the same time with
+them, and probably on the same steamer.
+
+Passepartout might have cudgelled his brain for a century without
+hitting upon the real object which the detective had in view.  He never
+could have imagined that Phileas Fogg was being tracked as a robber
+around the globe.  But, as it is in human nature to attempt the
+solution of every mystery, Passepartout suddenly discovered an
+explanation of Fix's movements, which was in truth far from
+unreasonable.  Fix, he thought, could only be an agent of Mr. Fogg's
+friends at the Reform Club, sent to follow him up, and to ascertain
+that he really went round the world as had been agreed upon.
+
+"It's clear!" repeated the worthy servant to himself, proud of his
+shrewdness.  "He's a spy sent to keep us in view!  That isn't quite the
+thing, either, to be spying Mr. Fogg, who is so honourable a man!  Ah,
+gentlemen of the Reform, this shall cost you dear!"
+
+Passepartout, enchanted with his discovery, resolved to say nothing to
+his master, lest he should be justly offended at this mistrust on the
+part of his adversaries.  But he determined to chaff Fix, when he had
+the chance, with mysterious allusions, which, however, need not betray
+his real suspicions.
+
+During the afternoon of Wednesday, 30th October, the Rangoon entered
+the Strait of Malacca, which separates the peninsula of that name from
+Sumatra.  The mountainous and craggy islets intercepted the beauties of
+this noble island from the view of the travellers.  The Rangoon weighed
+anchor at Singapore the next day at four a.m., to receive coal, having
+gained half a day on the prescribed time of her arrival.  Phileas Fogg
+noted this gain in his journal, and then, accompanied by Aouda, who
+betrayed a desire for a walk on shore, disembarked.
+
+Fix, who suspected Mr. Fogg's every movement, followed them cautiously,
+without being himself perceived; while Passepartout, laughing in his
+sleeve at Fix's manoeuvres, went about his usual errands.
+
+The island of Singapore is not imposing in aspect, for there are no
+mountains; yet its appearance is not without attractions.  It is a park
+checkered by pleasant highways and avenues.  A handsome carriage, drawn
+by a sleek pair of New Holland horses, carried Phileas Fogg and Aouda
+into the midst of rows of palms with brilliant foliage, and of
+clove-trees, whereof the cloves form the heart of a half-open flower.
+Pepper plants replaced the prickly hedges of European fields;
+sago-bushes, large ferns with gorgeous branches, varied the aspect of
+this tropical clime; while nutmeg-trees in full foliage filled the air
+with a penetrating perfume.  Agile and grinning bands of monkeys
+skipped about in the trees, nor were tigers wanting in the jungles.
+
+After a drive of two hours through the country, Aouda and Mr. Fogg
+returned to the town, which is a vast collection of heavy-looking,
+irregular houses, surrounded by charming gardens rich in tropical
+fruits and plants; and at ten o'clock they re-embarked, closely
+followed by the detective, who had kept them constantly in sight.
+
+Passepartout, who had been purchasing several dozen mangoes--a fruit
+as large as good-sized apples, of a dark-brown colour outside and a
+bright red within, and whose white pulp, melting in the mouth, affords
+gourmands a delicious sensation--was waiting for them on deck.  He was
+only too glad to offer some mangoes to Aouda, who thanked him very
+gracefully for them.
+
+At eleven o'clock the Rangoon rode out of Singapore harbour, and in a
+few hours the high mountains of Malacca, with their forests, inhabited
+by the most beautifully-furred tigers in the world, were lost to view.
+Singapore is distant some thirteen hundred miles from the island of
+Hong Kong, which is a little English colony near the Chinese coast.
+Phileas Fogg hoped to accomplish the journey in six days, so as to be
+in time for the steamer which would leave on the 6th of November for
+Yokohama, the principal Japanese port.
+
+The Rangoon had a large quota of passengers, many of whom disembarked
+at Singapore, among them a number of Indians, Ceylonese, Chinamen,
+Malays, and Portuguese, mostly second-class travellers.
+
+The weather, which had hitherto been fine, changed with the last
+quarter of the moon.  The sea rolled heavily, and the wind at intervals
+rose almost to a storm, but happily blew from the south-west, and thus
+aided the steamer's progress.  The captain as often as possible put up
+his sails, and under the double action of steam and sail the vessel
+made rapid progress along the coasts of Anam and Cochin China.  Owing
+to the defective construction of the Rangoon, however, unusual
+precautions became necessary in unfavourable weather; but the loss of
+time which resulted from this cause, while it nearly drove Passepartout
+out of his senses, did not seem to affect his master in the least.
+Passepartout blamed the captain, the engineer, and the crew, and
+consigned all who were connected with the ship to the land where the
+pepper grows.  Perhaps the thought of the gas, which was remorselessly
+burning at his expense in Saville Row, had something to do with his hot
+impatience.
+
+"You are in a great hurry, then," said Fix to him one day, "to reach
+Hong Kong?"
+
+"A very great hurry!"
+
+"Mr. Fogg, I suppose, is anxious to catch the steamer for Yokohama?"
+
+"Terribly anxious."
+
+"You believe in this journey around the world, then?"
+
+"Absolutely.  Don't you, Mr. Fix?"
+
+"I?  I don't believe a word of it."
+
+"You're a sly dog!" said Passepartout, winking at him.
+
+This expression rather disturbed Fix, without his knowing why.  Had the
+Frenchman guessed his real purpose?  He knew not what to think.  But
+how could Passepartout have discovered that he was a detective?  Yet,
+in speaking as he did, the man evidently meant more than he expressed.
+
+Passepartout went still further the next day; he could not hold his
+tongue.
+
+"Mr. Fix," said he, in a bantering tone, "shall we be so unfortunate as
+to lose you when we get to Hong Kong?"
+
+"Why," responded Fix, a little embarrassed, "I don't know; perhaps--"
+
+"Ah, if you would only go on with us!  An agent of the Peninsular
+Company, you know, can't stop on the way!  You were only going to
+Bombay, and here you are in China.  America is not far off, and from
+America to Europe is only a step."
+
+Fix looked intently at his companion, whose countenance was as serene
+as possible, and laughed with him.  But Passepartout persisted in
+chaffing him by asking him if he made much by his present occupation.
+
+"Yes, and no," returned Fix; "there is good and bad luck in such
+things.  But you must understand that I don't travel at my own expense."
+
+"Oh, I am quite sure of that!" cried Passepartout, laughing heartily.
+
+Fix, fairly puzzled, descended to his cabin and gave himself up to his
+reflections.  He was evidently suspected; somehow or other the
+Frenchman had found out that he was a detective.  But had he told his
+master?  What part was he playing in all this: was he an accomplice or
+not?  Was the game, then, up?  Fix spent several hours turning these
+things over in his mind, sometimes thinking that all was lost, then
+persuading himself that Fogg was ignorant of his presence, and then
+undecided what course it was best to take.
+
+Nevertheless, he preserved his coolness of mind, and at last resolved
+to deal plainly with Passepartout.  If he did not find it practicable
+to arrest Fogg at Hong Kong, and if Fogg made preparations to leave
+that last foothold of English territory, he, Fix, would tell
+Passepartout all.  Either the servant was the accomplice of his master,
+and in this case the master knew of his operations, and he should fail;
+or else the servant knew nothing about the robbery, and then his
+interest would be to abandon the robber.
+
+Such was the situation between Fix and Passepartout.  Meanwhile Phileas
+Fogg moved about above them in the most majestic and unconscious
+indifference.  He was passing methodically in his orbit around the
+world, regardless of the lesser stars which gravitated around him.  Yet
+there was near by what the astronomers would call a disturbing star,
+which might have produced an agitation in this gentleman's heart.  But
+no! the charms of Aouda failed to act, to Passepartout's great
+surprise; and the disturbances, if they existed, would have been more
+difficult to calculate than those of Uranus which led to the discovery
+of Neptune.
+
+It was every day an increasing wonder to Passepartout, who read in
+Aouda's eyes the depths of her gratitude to his master.  Phileas Fogg,
+though brave and gallant, must be, he thought, quite heartless.  As to
+the sentiment which this journey might have awakened in him, there was
+clearly no trace of such a thing; while poor Passepartout existed in
+perpetual reveries.
+
+One day he was leaning on the railing of the engine-room, and was
+observing the engine, when a sudden pitch of the steamer threw the
+screw out of the water.  The steam came hissing out of the valves; and
+this made Passepartout indignant.
+
+"The valves are not sufficiently charged!" he exclaimed.  "We are not
+going.  Oh, these English!  If this was an American craft, we should
+blow up, perhaps, but we should at all events go faster!"
+
+
+
+
+Chapter XVIII
+
+IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS BUSINESS
+
+
+The weather was bad during the latter days of the voyage.  The wind,
+obstinately remaining in the north-west, blew a gale, and retarded the
+steamer.  The Rangoon rolled heavily and the passengers became
+impatient of the long, monstrous waves which the wind raised before
+their path.  A sort of tempest arose on the 3rd of November, the squall
+knocking the vessel about with fury, and the waves running high.  The
+Rangoon reefed all her sails, and even the rigging proved too much,
+whistling and shaking amid the squall.  The steamer was forced to
+proceed slowly, and the captain estimated that she would reach Hong
+Kong twenty hours behind time, and more if the storm lasted.
+
+Phileas Fogg gazed at the tempestuous sea, which seemed to be
+struggling especially to delay him, with his habitual tranquillity.  He
+never changed countenance for an instant, though a delay of twenty
+hours, by making him too late for the Yokohama boat, would almost
+inevitably cause the loss of the wager.  But this man of nerve
+manifested neither impatience nor annoyance; it seemed as if the storm
+were a part of his programme, and had been foreseen.  Aouda was amazed
+to find him as calm as he had been from the first time she saw him.
+
+Fix did not look at the state of things in the same light.  The storm
+greatly pleased him.  His satisfaction would have been complete had the
+Rangoon been forced to retreat before the violence of wind and waves.
+Each delay filled him with hope, for it became more and more probable
+that Fogg would be obliged to remain some days at Hong Kong; and now
+the heavens themselves became his allies, with the gusts and squalls.
+It mattered not that they made him sea-sick--he made no account of this
+inconvenience; and, whilst his body was writhing under their effects,
+his spirit bounded with hopeful exultation.
+
+Passepartout was enraged beyond expression by the unpropitious weather.
+Everything had gone so well till now!  Earth and sea had seemed to be
+at his master's service; steamers and railways obeyed him; wind and
+steam united to speed his journey.  Had the hour of adversity come?
+Passepartout was as much excited as if the twenty thousand pounds were
+to come from his own pocket.  The storm exasperated him, the gale made
+him furious, and he longed to lash the obstinate sea into obedience.
+Poor fellow!  Fix carefully concealed from him his own satisfaction,
+for, had he betrayed it, Passepartout could scarcely have restrained
+himself from personal violence.
+
+Passepartout remained on deck as long as the tempest lasted, being
+unable to remain quiet below, and taking it into his head to aid the
+progress of the ship by lending a hand with the crew.  He overwhelmed
+the captain, officers, and sailors, who could not help laughing at his
+impatience, with all sorts of questions.  He wanted to know exactly how
+long the storm was going to last; whereupon he was referred to the
+barometer, which seemed to have no intention of rising.  Passepartout
+shook it, but with no perceptible effect; for neither shaking nor
+maledictions could prevail upon it to change its mind.
+
+On the 4th, however, the sea became more calm, and the storm lessened
+its violence; the wind veered southward, and was once more favourable.
+Passepartout cleared up with the weather.  Some of the sails were
+unfurled, and the Rangoon resumed its most rapid speed.  The time lost
+could not, however, be regained.  Land was not signalled until five
+o'clock on the morning of the 6th; the steamer was due on the 5th.
+Phileas Fogg was twenty-four hours behind-hand, and the Yokohama
+steamer would, of course, be missed.
+
+The pilot went on board at six, and took his place on the bridge, to
+guide the Rangoon through the channels to the port of Hong Kong.
+Passepartout longed to ask him if the steamer had left for Yokohama;
+but he dared not, for he wished to preserve the spark of hope, which
+still remained till the last moment.  He had confided his anxiety to
+Fix who--the sly rascal!--tried to console him by saying that Mr. Fogg
+would be in time if he took the next boat; but this only put
+Passepartout in a passion.
+
+Mr. Fogg, bolder than his servant, did not hesitate to approach the
+pilot, and tranquilly ask him if he knew when a steamer would leave
+Hong Kong for Yokohama.
+
+"At high tide to-morrow morning," answered the pilot.
+
+"Ah!" said Mr. Fogg, without betraying any astonishment.
+
+Passepartout, who heard what passed, would willingly have embraced the
+pilot, while Fix would have been glad to twist his neck.
+
+"What is the steamer's name?" asked Mr. Fogg.
+
+"The Carnatic."
+
+"Ought she not to have gone yesterday?"
+
+"Yes, sir; but they had to repair one of her boilers, and so her
+departure was postponed till to-morrow."
+
+"Thank you," returned Mr. Fogg, descending mathematically to the saloon.
+
+Passepartout clasped the pilot's hand and shook it heartily in his
+delight, exclaiming, "Pilot, you are the best of good fellows!"
+
+The pilot probably does not know to this day why his responses won him
+this enthusiastic greeting.  He remounted the bridge, and guided the
+steamer through the flotilla of junks, tankas, and fishing boats which
+crowd the harbour of Hong Kong.
+
+At one o'clock the Rangoon was at the quay, and the passengers were
+going ashore.
+
+Chance had strangely favoured Phileas Fogg, for had not the Carnatic
+been forced to lie over for repairing her boilers, she would have left
+on the 6th of November, and the passengers for Japan would have been
+obliged to await for a week the sailing of the next steamer.  Mr. Fogg
+was, it is true, twenty-four hours behind his time; but this could not
+seriously imperil the remainder of his tour.
+
+The steamer which crossed the Pacific from Yokohama to San Francisco
+made a direct connection with that from Hong Kong, and it could not
+sail until the latter reached Yokohama; and if Mr. Fogg was twenty-four
+hours late on reaching Yokohama, this time would no doubt be easily
+regained in the voyage of twenty-two days across the Pacific.  He found
+himself, then, about twenty-four hours behind-hand, thirty-five days
+after leaving London.
+
+The Carnatic was announced to leave Hong Kong at five the next morning.
+Mr. Fogg had sixteen hours in which to attend to his business there,
+which was to deposit Aouda safely with her wealthy relative.
+
+On landing, he conducted her to a palanquin, in which they repaired to
+the Club Hotel.  A room was engaged for the young woman, and Mr. Fogg,
+after seeing that she wanted for nothing, set out in search of her
+cousin Jeejeeh.  He instructed Passepartout to remain at the hotel
+until his return, that Aouda might not be left entirely alone.
+
+Mr. Fogg repaired to the Exchange, where, he did not doubt, every one
+would know so wealthy and considerable a personage as the Parsee
+merchant.  Meeting a broker, he made the inquiry, to learn that Jeejeeh
+had left China two years before, and, retiring from business with an
+immense fortune, had taken up his residence in Europe--in Holland the
+broker thought, with the merchants of which country he had principally
+traded.  Phileas Fogg returned to the hotel, begged a moment's
+conversation with Aouda, and without more ado, apprised her that
+Jeejeeh was no longer at Hong Kong, but probably in Holland.
+
+Aouda at first said nothing.  She passed her hand across her forehead,
+and reflected a few moments.  Then, in her sweet, soft voice, she said:
+"What ought I to do, Mr. Fogg?"
+
+"It is very simple," responded the gentleman.  "Go on to Europe."
+
+"But I cannot intrude--"
+
+"You do not intrude, nor do you in the least embarrass my project.
+Passepartout!"
+
+"Monsieur."
+
+"Go to the Carnatic, and engage three cabins."
+
+Passepartout, delighted that the young woman, who was very gracious to
+him, was going to continue the journey with them, went off at a brisk
+gait to obey his master's order.
+
+
+
+
+Chapter XIX
+
+IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER, AND
+WHAT COMES OF IT
+
+
+Hong Kong is an island which came into the possession of the English by
+the Treaty of Nankin, after the war of 1842; and the colonising genius
+of the English has created upon it an important city and an excellent
+port.  The island is situated at the mouth of the Canton River, and is
+separated by about sixty miles from the Portuguese town of Macao, on
+the opposite coast.  Hong Kong has beaten Macao in the struggle for the
+Chinese trade, and now the greater part of the transportation of
+Chinese goods finds its depot at the former place.  Docks, hospitals,
+wharves, a Gothic cathedral, a government house, macadamised streets,
+give to Hong Kong the appearance of a town in Kent or Surrey
+transferred by some strange magic to the antipodes.
+
+Passepartout wandered, with his hands in his pockets, towards the
+Victoria port, gazing as he went at the curious palanquins and other
+modes of conveyance, and the groups of Chinese, Japanese, and Europeans
+who passed to and fro in the streets.  Hong Kong seemed to him not
+unlike Bombay, Calcutta, and Singapore, since, like them, it betrayed
+everywhere the evidence of English supremacy.  At the Victoria port he
+found a confused mass of ships of all nations: English, French,
+American, and Dutch, men-of-war and trading vessels, Japanese and
+Chinese junks, sempas, tankas, and flower-boats, which formed so many
+floating parterres.  Passepartout noticed in the crowd a number of the
+natives who seemed very old and were dressed in yellow.  On going into
+a barber's to get shaved he learned that these ancient men were all at
+least eighty years old, at which age they are permitted to wear yellow,
+which is the Imperial colour.  Passepartout, without exactly knowing
+why, thought this very funny.
+
+On reaching the quay where they were to embark on the Carnatic, he was
+not astonished to find Fix walking up and down.  The detective seemed
+very much disturbed and disappointed.
+
+"This is bad," muttered Passepartout, "for the gentlemen of the Reform
+Club!"  He accosted Fix with a merry smile, as if he had not perceived
+that gentleman's chagrin.  The detective had, indeed, good reasons to
+inveigh against the bad luck which pursued him.  The warrant had not
+come!  It was certainly on the way, but as certainly it could not now
+reach Hong Kong for several days; and, this being the last English
+territory on Mr. Fogg's route, the robber would escape, unless he could
+manage to detain him.
+
+"Well, Monsieur Fix," said Passepartout, "have you decided to go with
+us so far as America?"
+
+"Yes," returned Fix, through his set teeth.
+
+"Good!" exclaimed Passepartout, laughing heartily.  "I knew you could
+not persuade yourself to separate from us.  Come and engage your berth."
+
+They entered the steamer office and secured cabins for four persons.
+The clerk, as he gave them the tickets, informed them that, the repairs
+on the Carnatic having been completed, the steamer would leave that
+very evening, and not next morning, as had been announced.
+
+"That will suit my master all the better," said Passepartout.  "I will
+go and let him know."
+
+Fix now decided to make a bold move; he resolved to tell Passepartout
+all.  It seemed to be the only possible means of keeping Phileas Fogg
+several days longer at Hong Kong.  He accordingly invited his companion
+into a tavern which caught his eye on the quay.  On entering, they
+found themselves in a large room handsomely decorated, at the end of
+which was a large camp-bed furnished with cushions.  Several persons
+lay upon this bed in a deep sleep.  At the small tables which were
+arranged about the room some thirty customers were drinking English
+beer, porter, gin, and brandy; smoking, the while, long red clay pipes
+stuffed with little balls of opium mingled with essence of rose.  From
+time to time one of the smokers, overcome with the narcotic, would slip
+under the table, whereupon the waiters, taking him by the head and
+feet, carried and laid him upon the bed.  The bed already supported
+twenty of these stupefied sots.
+
+Fix and Passepartout saw that they were in a smoking-house haunted by
+those wretched, cadaverous, idiotic creatures to whom the English
+merchants sell every year the miserable drug called opium, to the
+amount of one million four hundred thousand pounds--thousands devoted
+to one of the most despicable vices which afflict humanity!  The
+Chinese government has in vain attempted to deal with the evil by
+stringent laws.  It passed gradually from the rich, to whom it was at
+first exclusively reserved, to the lower classes, and then its ravages
+could not be arrested.  Opium is smoked everywhere, at all times, by
+men and women, in the Celestial Empire; and, once accustomed to it, the
+victims cannot dispense with it, except by suffering horrible bodily
+contortions and agonies.  A great smoker can smoke as many as eight
+pipes a day; but he dies in five years.  It was in one of these dens
+that Fix and Passepartout, in search of a friendly glass, found
+themselves.  Passepartout had no money, but willingly accepted Fix's
+invitation in the hope of returning the obligation at some future time.
+
+They ordered two bottles of port, to which the Frenchman did ample
+justice, whilst Fix observed him with close attention.  They chatted
+about the journey, and Passepartout was especially merry at the idea
+that Fix was going to continue it with them.  When the bottles were
+empty, however, he rose to go and tell his master of the change in the
+time of the sailing of the Carnatic.
+
+Fix caught him by the arm, and said, "Wait a moment."
+
+"What for, Mr. Fix?"
+
+"I want to have a serious talk with you."
+
+"A serious talk!" cried Passepartout, drinking up the little wine that
+was left in the bottom of his glass.  "Well, we'll talk about it
+to-morrow; I haven't time now."
+
+"Stay!  What I have to say concerns your master."
+
+Passepartout, at this, looked attentively at his companion.  Fix's face
+seemed to have a singular expression.  He resumed his seat.
+
+"What is it that you have to say?"
+
+Fix placed his hand upon Passepartout's arm, and, lowering his voice,
+said, "You have guessed who I am?"
+
+"Parbleu!" said Passepartout, smiling.
+
+"Then I'm going to tell you everything--"
+
+"Now that I know everything, my friend!  Ah! that's very good.  But go
+on, go on.  First, though, let me tell you that those gentlemen have
+put themselves to a useless expense."
+
+"Useless!" said Fix.  "You speak confidently.  It's clear that you
+don't know how large the sum is."
+
+"Of course I do," returned Passepartout.  "Twenty thousand pounds."
+
+"Fifty-five thousand!" answered Fix, pressing his companion's hand.
+
+"What!" cried the Frenchman.  "Has Monsieur Fogg dared--fifty-five
+thousand pounds!  Well, there's all the more reason for not losing an
+instant," he continued, getting up hastily.
+
+Fix pushed Passepartout back in his chair, and resumed: "Fifty-five
+thousand pounds; and if I succeed, I get two thousand pounds.  If
+you'll help me, I'll let you have five hundred of them."
+
+"Help you?" cried Passepartout, whose eyes were standing wide open.
+
+"Yes; help me keep Mr. Fogg here for two or three days."
+
+"Why, what are you saying?  Those gentlemen are not satisfied with
+following my master and suspecting his honour, but they must try to put
+obstacles in his way!  I blush for them!"
+
+"What do you mean?"
+
+"I mean that it is a piece of shameful trickery.  They might as well
+waylay Mr. Fogg and put his money in their pockets!"
+
+"That's just what we count on doing."
+
+"It's a conspiracy, then," cried Passepartout, who became more and more
+excited as the liquor mounted in his head, for he drank without
+perceiving it.  "A real conspiracy!  And gentlemen, too. Bah!"
+
+Fix began to be puzzled.
+
+"Members of the Reform Club!" continued Passepartout.  "You must know,
+Monsieur Fix, that my master is an honest man, and that, when he makes
+a wager, he tries to win it fairly!"
+
+"But who do you think I am?" asked Fix, looking at him intently.
+
+"Parbleu!  An agent of the members of the Reform Club, sent out here to
+interrupt my master's journey.  But, though I found you out some time
+ago, I've taken good care to say nothing about it to Mr. Fogg."
+
+"He knows nothing, then?"
+
+"Nothing," replied Passepartout, again emptying his glass.
+
+The detective passed his hand across his forehead, hesitating before he
+spoke again.  What should he do?  Passepartout's mistake seemed
+sincere, but it made his design more difficult.  It was evident that
+the servant was not the master's accomplice, as Fix had been inclined
+to suspect.
+
+"Well," said the detective to himself, "as he is not an accomplice, he
+will help me."
+
+He had no time to lose: Fogg must be detained at Hong Kong, so he
+resolved to make a clean breast of it.
+
+"Listen to me," said Fix abruptly.  "I am not, as you think, an agent
+of the members of the Reform Club--"
+
+"Bah!" retorted Passepartout, with an air of raillery.
+
+"I am a police detective, sent out here by the London office."
+
+"You, a detective?"
+
+"I will prove it.  Here is my commission."
+
+Passepartout was speechless with astonishment when Fix displayed this
+document, the genuineness of which could not be doubted.
+
+"Mr. Fogg's wager," resumed Fix, "is only a pretext, of which you and
+the gentlemen of the Reform are dupes.  He had a motive for securing
+your innocent complicity."
+
+"But why?"
+
+"Listen.  On the 28th of last September a robbery of fifty-five
+thousand pounds was committed at the Bank of England by a person whose
+description was fortunately secured.  Here is his description; it
+answers exactly to that of Mr. Phileas Fogg."
+
+"What nonsense!" cried Passepartout, striking the table with his fist.
+"My master is the most honourable of men!"
+
+"How can you tell?  You know scarcely anything about him.  You went
+into his service the day he came away; and he came away on a foolish
+pretext, without trunks, and carrying a large amount in banknotes.  And
+yet you are bold enough to assert that he is an honest man!"
+
+"Yes, yes," repeated the poor fellow, mechanically.
+
+"Would you like to be arrested as his accomplice?"
+
+Passepartout, overcome by what he had heard, held his head between his
+hands, and did not dare to look at the detective.  Phileas Fogg, the
+saviour of Aouda, that brave and generous man, a robber!  And yet how
+many presumptions there were against him!  Passepartout essayed to
+reject the suspicions which forced themselves upon his mind; he did not
+wish to believe that his master was guilty.
+
+"Well, what do you want of me?" said he, at last, with an effort.
+
+"See here," replied Fix; "I have tracked Mr. Fogg to this place, but as
+yet I have failed to receive the warrant of arrest for which I sent to
+London.  You must help me to keep him here in Hong Kong--"
+
+"I!  But I--"
+
+"I will share with you the two thousand pounds reward offered by the
+Bank of England."
+
+"Never!" replied Passepartout, who tried to rise, but fell back,
+exhausted in mind and body.
+
+"Mr. Fix," he stammered, "even should what you say be true--if my
+master is really the robber you are seeking for--which I deny--I have
+been, am, in his service; I have seen his generosity and goodness; and
+I will never betray him--not for all the gold in the world.  I come
+from a village where they don't eat that kind of bread!"
+
+"You refuse?"
+
+"I refuse."
+
+"Consider that I've said nothing," said Fix; "and let us drink."
+
+"Yes; let us drink!"
+
+Passepartout felt himself yielding more and more to the effects of the
+liquor.  Fix, seeing that he must, at all hazards, be separated from
+his master, wished to entirely overcome him.  Some pipes full of opium
+lay upon the table.  Fix slipped one into Passepartout's hand.  He took
+it, put it between his lips, lit it, drew several puffs, and his head,
+becoming heavy under the influence of the narcotic, fell upon the table.
+
+"At last!" said Fix, seeing Passepartout unconscious.  "Mr. Fogg will
+not be informed of the Carnatic's departure; and, if he is, he will
+have to go without this cursed Frenchman!"
+
+And, after paying his bill, Fix left the tavern.
+
+
+
+
+Chapter XX
+
+IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+
+While these events were passing at the opium-house, Mr. Fogg,
+unconscious of the danger he was in of losing the steamer, was quietly
+escorting Aouda about the streets of the English quarter, making the
+necessary purchases for the long voyage before them.  It was all very
+well for an Englishman like Mr. Fogg to make the tour of the world with
+a carpet-bag; a lady could not be expected to travel comfortably under
+such conditions.  He acquitted his task with characteristic serenity,
+and invariably replied to the remonstrances of his fair companion, who
+was confused by his patience and generosity:
+
+"It is in the interest of my journey--a part of my programme."
+
+The purchases made, they returned to the hotel, where they dined at a
+sumptuously served table-d'hote; after which Aouda, shaking hands with
+her protector after the English fashion, retired to her room for rest.
+Mr. Fogg absorbed himself throughout the evening in the perusal of The
+Times and Illustrated London News.
+
+Had he been capable of being astonished at anything, it would have been
+not to see his servant return at bedtime.  But, knowing that the
+steamer was not to leave for Yokohama until the next morning, he did
+not disturb himself about the matter.  When Passepartout did not appear
+the next morning to answer his master's bell, Mr. Fogg, not betraying
+the least vexation, contented himself with taking his carpet-bag,
+calling Aouda, and sending for a palanquin.
+
+It was then eight o'clock; at half-past nine, it being then high tide,
+the Carnatic would leave the harbour.  Mr. Fogg and Aouda got into the
+palanquin, their luggage being brought after on a wheelbarrow, and half
+an hour later stepped upon the quay whence they were to embark.  Mr.
+Fogg then learned that the Carnatic had sailed the evening before.  He
+had expected to find not only the steamer, but his domestic, and was
+forced to give up both; but no sign of disappointment appeared on his
+face, and he merely remarked to Aouda, "It is an accident, madam;
+nothing more."
+
+At this moment a man who had been observing him attentively approached.
+It was Fix, who, bowing, addressed Mr. Fogg:  "Were you not, like me,
+sir, a passenger by the Rangoon, which arrived yesterday?"
+
+"I was, sir," replied Mr. Fogg coldly.  "But I have not the honour--"
+
+"Pardon me; I thought I should find your servant here."
+
+"Do you know where he is, sir?" asked Aouda anxiously.
+
+"What!" responded Fix, feigning surprise.  "Is he not with you?"
+
+"No," said Aouda.  "He has not made his appearance since yesterday.
+Could he have gone on board the Carnatic without us?"
+
+"Without you, madam?" answered the detective.  "Excuse me, did you
+intend to sail in the Carnatic?"
+
+"Yes, sir."
+
+"So did I, madam, and I am excessively disappointed.  The Carnatic, its
+repairs being completed, left Hong Kong twelve hours before the stated
+time, without any notice being given; and we must now wait a week for
+another steamer."
+
+As he said "a week" Fix felt his heart leap for joy.  Fogg detained at
+Hong Kong for a week!  There would be time for the warrant to arrive,
+and fortune at last favoured the representative of the law.  His horror
+may be imagined when he heard Mr. Fogg say, in his placid voice, "But
+there are other vessels besides the Carnatic, it seems to me, in the
+harbour of Hong Kong."
+
+And, offering his arm to Aouda, he directed his steps toward the docks
+in search of some craft about to start.  Fix, stupefied, followed; it
+seemed as if he were attached to Mr. Fogg by an invisible thread.
+Chance, however, appeared really to have abandoned the man it had
+hitherto served so well.  For three hours Phileas Fogg wandered about
+the docks, with the determination, if necessary, to charter a vessel to
+carry him to Yokohama; but he could only find vessels which were
+loading or unloading, and which could not therefore set sail.  Fix
+began to hope again.
+
+But Mr. Fogg, far from being discouraged, was continuing his search,
+resolved not to stop if he had to resort to Macao, when he was accosted
+by a sailor on one of the wharves.
+
+"Is your honour looking for a boat?"
+
+"Have you a boat ready to sail?"
+
+"Yes, your honour; a pilot-boat--No. 43--the best in the harbour."
+
+"Does she go fast?"
+
+"Between eight and nine knots the hour.  Will you look at her?"
+
+"Yes."
+
+"Your honour will be satisfied with her.  Is it for a sea excursion?"
+
+"No; for a voyage."
+
+"A voyage?"
+
+"Yes, will you agree to take me to Yokohama?"
+
+The sailor leaned on the railing, opened his eyes wide, and said, "Is
+your honour joking?"
+
+"No.  I have missed the Carnatic, and I must get to Yokohama by the
+14th at the latest, to take the boat for San Francisco."
+
+"I am sorry," said the sailor; "but it is impossible."
+
+"I offer you a hundred pounds per day, and an additional reward of two
+hundred pounds if I reach Yokohama in time."
+
+"Are you in earnest?"
+
+"Very much so."
+
+The pilot walked away a little distance, and gazed out to sea,
+evidently struggling between the anxiety to gain a large sum and the
+fear of venturing so far.  Fix was in mortal suspense.
+
+Mr. Fogg turned to Aouda and asked her, "You would not be afraid, would
+you, madam?"
+
+"Not with you, Mr. Fogg," was her answer.
+
+The pilot now returned, shuffling his hat in his hands.
+
+"Well, pilot?" said Mr. Fogg.
+
+"Well, your honour," replied he, "I could not risk myself, my men, or
+my little boat of scarcely twenty tons on so long a voyage at this time
+of year.  Besides, we could not reach Yokohama in time, for it is
+sixteen hundred and sixty miles from Hong Kong."
+
+"Only sixteen hundred," said Mr. Fogg.
+
+"It's the same thing."
+
+Fix breathed more freely.
+
+"But," added the pilot, "it might be arranged another way."
+
+Fix ceased to breathe at all.
+
+"How?" asked Mr. Fogg.
+
+"By going to Nagasaki, at the extreme south of Japan, or even to
+Shanghai, which is only eight hundred miles from here.  In going to
+Shanghai we should not be forced to sail wide of the Chinese coast,
+which would be a great advantage, as the currents run northward, and
+would aid us."
+
+"Pilot," said Mr. Fogg, "I must take the American steamer at Yokohama,
+and not at Shanghai or Nagasaki."
+
+"Why not?" returned the pilot.  "The San Francisco steamer does not
+start from Yokohama.  It puts in at Yokohama and Nagasaki, but it
+starts from Shanghai."
+
+"You are sure of that?"
+
+"Perfectly."
+
+"And when does the boat leave Shanghai?"
+
+"On the 11th, at seven in the evening.  We have, therefore, four days
+before us, that is ninety-six hours; and in that time, if we had good
+luck and a south-west wind, and the sea was calm, we could make those
+eight hundred miles to Shanghai."
+
+"And you could go--"
+
+"In an hour; as soon as provisions could be got aboard and the sails
+put up."
+
+"It is a bargain.  Are you the master of the boat?"
+
+"Yes; John Bunsby, master of the Tankadere."
+
+"Would you like some earnest-money?"
+
+"If it would not put your honour out--"
+
+"Here are two hundred pounds on account sir," added Phileas Fogg,
+turning to Fix, "if you would like to take advantage--"
+
+"Thanks, sir; I was about to ask the favour."
+
+"Very well.  In half an hour we shall go on board."
+
+"But poor Passepartout?" urged Aouda, who was much disturbed by the
+servant's disappearance.
+
+"I shall do all I can to find him," replied Phileas Fogg.
+
+While Fix, in a feverish, nervous state, repaired to the pilot-boat,
+the others directed their course to the police-station at Hong Kong.
+Phileas Fogg there gave Passepartout's description, and left a sum of
+money to be spent in the search for him.  The same formalities having
+been gone through at the French consulate, and the palanquin having
+stopped at the hotel for the luggage, which had been sent back there,
+they returned to the wharf.
+
+It was now three o'clock; and pilot-boat No. 43, with its crew on
+board, and its provisions stored away, was ready for departure.
+
+The Tankadere was a neat little craft of twenty tons, as gracefully
+built as if she were a racing yacht.  Her shining copper sheathing, her
+galvanised iron-work, her deck, white as ivory, betrayed the pride
+taken by John Bunsby in making her presentable.  Her two masts leaned a
+trifle backward; she carried brigantine, foresail, storm-jib, and
+standing-jib, and was well rigged for running before the wind; and she
+seemed capable of brisk speed, which, indeed, she had already proved by
+gaining several prizes in pilot-boat races.  The crew of the Tankadere
+was composed of John Bunsby, the master, and four hardy mariners, who
+were familiar with the Chinese seas.  John Bunsby, himself, a man of
+forty-five or thereabouts, vigorous, sunburnt, with a sprightly
+expression of the eye, and energetic and self-reliant countenance,
+would have inspired confidence in the most timid.
+
+Phileas Fogg and Aouda went on board, where they found Fix already
+installed.  Below deck was a square cabin, of which the walls bulged
+out in the form of cots, above a circular divan; in the centre was a
+table provided with a swinging lamp.  The accommodation was confined,
+but neat.
+
+"I am sorry to have nothing better to offer you," said Mr. Fogg to Fix,
+who bowed without responding.
+
+The detective had a feeling akin to humiliation in profiting by the
+kindness of Mr. Fogg.
+
+"It's certain," thought he, "though rascal as he is, he is a polite
+one!"
+
+The sails and the English flag were hoisted at ten minutes past three.
+Mr. Fogg and Aouda, who were seated on deck, cast a last glance at the
+quay, in the hope of espying Passepartout.  Fix was not without his
+fears lest chance should direct the steps of the unfortunate servant,
+whom he had so badly treated, in this direction; in which case an
+explanation the reverse of satisfactory to the detective must have
+ensued.  But the Frenchman did not appear, and, without doubt, was
+still lying under the stupefying influence of the opium.
+
+John Bunsby, master, at length gave the order to start, and the
+Tankadere, taking the wind under her brigantine, foresail, and
+standing-jib, bounded briskly forward over the waves.
+
+
+
+
+Chapter XXI
+
+IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING A
+REWARD OF TWO HUNDRED POUNDS
+
+
+This voyage of eight hundred miles was a perilous venture on a craft of
+twenty tons, and at that season of the year.  The Chinese seas are
+usually boisterous, subject to terrible gales of wind, and especially
+during the equinoxes; and it was now early November.
+
+It would clearly have been to the master's advantage to carry his
+passengers to Yokohama, since he was paid a certain sum per day; but he
+would have been rash to attempt such a voyage, and it was imprudent
+even to attempt to reach Shanghai.  But John Bunsby believed in the
+Tankadere, which rode on the waves like a seagull; and perhaps he was
+not wrong.
+
+Late in the day they passed through the capricious channels of Hong
+Kong, and the Tankadere, impelled by favourable winds, conducted
+herself admirably.
+
+"I do not need, pilot," said Phileas Fogg, when they got into the open
+sea, "to advise you to use all possible speed."
+
+"Trust me, your honour.  We are carrying all the sail the wind will let
+us.  The poles would add nothing, and are only used when we are going
+into port."
+
+"It's your trade, not mine, pilot, and I confide in you."
+
+Phileas Fogg, with body erect and legs wide apart, standing like a
+sailor, gazed without staggering at the swelling waters.  The young
+woman, who was seated aft, was profoundly affected as she looked out
+upon the ocean, darkening now with the twilight, on which she had
+ventured in so frail a vessel.  Above her head rustled the white sails,
+which seemed like great white wings.  The boat, carried forward by the
+wind, seemed to be flying in the air.
+
+Night came.  The moon was entering her first quarter, and her
+insufficient light would soon die out in the mist on the horizon.
+Clouds were rising from the east, and already overcast a part of the
+heavens.
+
+The pilot had hung out his lights, which was very necessary in these
+seas crowded with vessels bound landward; for collisions are not
+uncommon occurrences, and, at the speed she was going, the least shock
+would shatter the gallant little craft.
+
+Fix, seated in the bow, gave himself up to meditation.  He kept apart
+from his fellow-travellers, knowing Mr. Fogg's taciturn tastes;
+besides, he did not quite like to talk to the man whose favours he had
+accepted.  He was thinking, too, of the future.  It seemed certain that
+Fogg would not stop at Yokohama, but would at once take the boat for
+San Francisco; and the vast extent of America would ensure him impunity
+and safety.  Fogg's plan appeared to him the simplest in the world.
+Instead of sailing directly from England to the United States, like a
+common villain, he had traversed three quarters of the globe, so as to
+gain the American continent more surely; and there, after throwing the
+police off his track, he would quietly enjoy himself with the fortune
+stolen from the bank.  But, once in the United States, what should he,
+Fix, do?  Should he abandon this man?  No, a hundred times no!  Until
+he had secured his extradition, he would not lose sight of him for an
+hour.  It was his duty, and he would fulfil it to the end.  At all
+events, there was one thing to be thankful for; Passepartout was not
+with his master; and it was above all important, after the confidences
+Fix had imparted to him, that the servant should never have speech with
+his master.
+
+Phileas Fogg was also thinking of Passepartout, who had so strangely
+disappeared.  Looking at the matter from every point of view, it did
+not seem to him impossible that, by some mistake, the man might have
+embarked on the Carnatic at the last moment; and this was also Aouda's
+opinion, who regretted very much the loss of the worthy fellow to whom
+she owed so much.  They might then find him at Yokohama; for, if the
+Carnatic was carrying him thither, it would be easy to ascertain if he
+had been on board.
+
+A brisk breeze arose about ten o'clock; but, though it might have been
+prudent to take in a reef, the pilot, after carefully examining the
+heavens, let the craft remain rigged as before.  The Tankadere bore
+sail admirably, as she drew a great deal of water, and everything was
+prepared for high speed in case of a gale.
+
+Mr. Fogg and Aouda descended into the cabin at midnight, having been
+already preceded by Fix, who had lain down on one of the cots.  The
+pilot and crew remained on deck all night.
+
+At sunrise the next day, which was 8th November, the boat had made more
+than one hundred miles.  The log indicated a mean speed of between
+eight and nine miles.  The Tankadere still carried all sail, and was
+accomplishing her greatest capacity of speed.  If the wind held as it
+was, the chances would be in her favour.  During the day she kept along
+the coast, where the currents were favourable; the coast, irregular in
+profile, and visible sometimes across the clearings, was at most five
+miles distant.  The sea was less boisterous, since the wind came off
+land--a fortunate circumstance for the boat, which would suffer, owing
+to its small tonnage, by a heavy surge on the sea.
+
+The breeze subsided a little towards noon, and set in from the
+south-west.  The pilot put up his poles, but took them down again
+within two hours, as the wind freshened up anew.
+
+Mr. Fogg and Aouda, happily unaffected by the roughness of the sea, ate
+with a good appetite, Fix being invited to share their repast, which he
+accepted with secret chagrin.  To travel at this man's expense and live
+upon his provisions was not palatable to him.  Still, he was obliged to
+eat, and so he ate.
+
+When the meal was over, he took Mr. Fogg apart, and said, "sir"--this
+"sir" scorched his lips, and he had to control himself to avoid
+collaring this "gentleman"--"sir, you have been very kind to give me a
+passage on this boat.  But, though my means will not admit of my
+expending them as freely as you, I must ask to pay my share--"
+
+"Let us not speak of that, sir," replied Mr. Fogg.
+
+"But, if I insist--"
+
+"No, sir," repeated Mr. Fogg, in a tone which did not admit of a reply.
+"This enters into my general expenses."
+
+Fix, as he bowed, had a stifled feeling, and, going forward, where he
+ensconced himself, did not open his mouth for the rest of the day.
+
+Meanwhile they were progressing famously, and John Bunsby was in high
+hope.  He several times assured Mr. Fogg that they would reach Shanghai
+in time; to which that gentleman responded that he counted upon it.
+The crew set to work in good earnest, inspired by the reward to be
+gained.  There was not a sheet which was not tightened, not a sail which
+was not vigorously hoisted; not a lurch could be charged to the man at
+the helm.  They worked as desperately as if they were contesting in a
+Royal yacht regatta.
+
+By evening, the log showed that two hundred and twenty miles had been
+accomplished from Hong Kong, and Mr. Fogg might hope that he would be
+able to reach Yokohama without recording any delay in his journal; in
+which case, the many misadventures which had overtaken him since he
+left London would not seriously affect his journey.
+
+The Tankadere entered the Straits of Fo-Kien, which separate the island
+of Formosa from the Chinese coast, in the small hours of the night, and
+crossed the Tropic of Cancer.  The sea was very rough in the straits,
+full of eddies formed by the counter-currents, and the chopping waves
+broke her course, whilst it became very difficult to stand on deck.
+
+At daybreak the wind began to blow hard again, and the heavens seemed
+to predict a gale.  The barometer announced a speedy change, the
+mercury rising and falling capriciously; the sea also, in the
+south-east, raised long surges which indicated a tempest.  The sun had
+set the evening before in a red mist, in the midst of the
+phosphorescent scintillations of the ocean.
+
+John Bunsby long examined the threatening aspect of the heavens,
+muttering indistinctly between his teeth.  At last he said in a low
+voice to Mr. Fogg, "Shall I speak out to your honour?"
+
+"Of course."
+
+"Well, we are going to have a squall."
+
+"Is the wind north or south?" asked Mr. Fogg quietly.
+
+"South.  Look! a typhoon is coming up."
+
+"Glad it's a typhoon from the south, for it will carry us forward."
+
+"Oh, if you take it that way," said John Bunsby, "I've nothing more to
+say." John Bunsby's suspicions were confirmed.  At a less advanced
+season of the year the typhoon, according to a famous meteorologist,
+would have passed away like a luminous cascade of electric flame; but
+in the winter equinox it was to be feared that it would burst upon them
+with great violence.
+
+The pilot took his precautions in advance.  He reefed all sail, the
+pole-masts were dispensed with; all hands went forward to the bows.  A
+single triangular sail, of strong canvas, was hoisted as a storm-jib,
+so as to hold the wind from behind.  Then they waited.
+
+John Bunsby had requested his passengers to go below; but this
+imprisonment in so narrow a space, with little air, and the boat
+bouncing in the gale, was far from pleasant.  Neither Mr. Fogg, Fix,
+nor Aouda consented to leave the deck.
+
+The storm of rain and wind descended upon them towards eight o'clock.
+With but its bit of sail, the Tankadere was lifted like a feather by a
+wind, an idea of whose violence can scarcely be given.  To compare her
+speed to four times that of a locomotive going on full steam would be
+below the truth.
+
+The boat scudded thus northward during the whole day, borne on by
+monstrous waves, preserving always, fortunately, a speed equal to
+theirs.  Twenty times she seemed almost to be submerged by these
+mountains of water which rose behind her; but the adroit management of
+the pilot saved her.  The passengers were often bathed in spray, but
+they submitted to it philosophically.  Fix cursed it, no doubt; but
+Aouda, with her eyes fastened upon her protector, whose coolness amazed
+her, showed herself worthy of him, and bravely weathered the storm.  As
+for Phileas Fogg, it seemed just as if the typhoon were a part of his
+programme.
+
+Up to this time the Tankadere had always held her course to the north;
+but towards evening the wind, veering three quarters, bore down from
+the north-west.  The boat, now lying in the trough of the waves, shook
+and rolled terribly; the sea struck her with fearful violence.  At
+night the tempest increased in violence.  John Bunsby saw the approach
+of darkness and the rising of the storm with dark misgivings.  He
+thought awhile, and then asked his crew if it was not time to slacken
+speed.  After a consultation he approached Mr. Fogg, and said, "I
+think, your honour, that we should do well to make for one of the ports
+on the coast."
+
+"I think so too."
+
+"Ah!" said the pilot.  "But which one?"
+
+"I know of but one," returned Mr. Fogg tranquilly.
+
+"And that is--"
+
+"Shanghai."
+
+The pilot, at first, did not seem to comprehend; he could scarcely
+realise so much determination and tenacity.  Then he cried, "Well--yes!
+Your honour is right.  To Shanghai!"
+
+So the Tankadere kept steadily on her northward track.
+
+The night was really terrible; it would be a miracle if the craft did
+not founder.  Twice it could have been all over with her if the crew
+had not been constantly on the watch.  Aouda was exhausted, but did not
+utter a complaint.  More than once Mr. Fogg rushed to protect her from
+the violence of the waves.
+
+Day reappeared.  The tempest still raged with undiminished fury; but
+the wind now returned to the south-east.  It was a favourable change,
+and the Tankadere again bounded forward on this mountainous sea, though
+the waves crossed each other, and imparted shocks and counter-shocks
+which would have crushed a craft less solidly built.  From time to time
+the coast was visible through the broken mist, but no vessel was in
+sight.  The Tankadere was alone upon the sea.
+
+There were some signs of a calm at noon, and these became more distinct
+as the sun descended toward the horizon.  The tempest had been as brief
+as terrific.  The passengers, thoroughly exhausted, could now eat a
+little, and take some repose.
+
+The night was comparatively quiet.  Some of the sails were again
+hoisted, and the speed of the boat was very good.  The next morning at
+dawn they espied the coast, and John Bunsby was able to assert that
+they were not one hundred miles from Shanghai.  A hundred miles, and
+only one day to traverse them!  That very evening Mr. Fogg was due at
+Shanghai, if he did not wish to miss the steamer to Yokohama.  Had
+there been no storm, during which several hours were lost, they would
+be at this moment within thirty miles of their destination.
+
+The wind grew decidedly calmer, and happily the sea fell with it.  All
+sails were now hoisted, and at noon the Tankadere was within forty-five
+miles of Shanghai.  There remained yet six hours in which to accomplish
+that distance.  All on board feared that it could not be done, and
+every one--Phileas Fogg, no doubt, excepted--felt his heart beat with
+impatience.  The boat must keep up an average of nine miles an hour,
+and the wind was becoming calmer every moment!  It was a capricious
+breeze, coming from the coast, and after it passed the sea became
+smooth.  Still, the Tankadere was so light, and her fine sails caught
+the fickle zephyrs so well, that, with the aid of the currents John
+Bunsby found himself at six o'clock not more than ten miles from the
+mouth of Shanghai River.  Shanghai itself is situated at least twelve
+miles up the stream.  At seven they were still three miles from
+Shanghai.  The pilot swore an angry oath; the reward of two hundred
+pounds was evidently on the point of escaping him.  He looked at Mr.
+Fogg.  Mr. Fogg was perfectly tranquil; and yet his whole fortune was
+at this moment at stake.
+
+At this moment, also, a long black funnel, crowned with wreaths of
+smoke, appeared on the edge of the waters.  It was the American
+steamer, leaving for Yokohama at the appointed time.
+
+"Confound her!" cried John Bunsby, pushing back the rudder with a
+desperate jerk.
+
+"Signal her!" said Phileas Fogg quietly.
+
+A small brass cannon stood on the forward deck of the Tankadere, for
+making signals in the fogs.  It was loaded to the muzzle; but just as
+the pilot was about to apply a red-hot coal to the touchhole, Mr. Fogg
+said, "Hoist your flag!"
+
+The flag was run up at half-mast, and, this being the signal of
+distress, it was hoped that the American steamer, perceiving it, would
+change her course a little, so as to succour the pilot-boat.
+
+"Fire!" said Mr. Fogg.  And the booming of the little cannon resounded
+in the air.
+
+
+
+
+Chapter XXII
+
+IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES, IT IS
+CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+
+The Carnatic, setting sail from Hong Kong at half-past six on the 7th
+of November, directed her course at full steam towards Japan.  She
+carried a large cargo and a well-filled cabin of passengers.  Two
+state-rooms in the rear were, however, unoccupied--those which had been
+engaged by Phileas Fogg.
+
+The next day a passenger with a half-stupefied eye, staggering gait,
+and disordered hair, was seen to emerge from the second cabin, and to
+totter to a seat on deck.
+
+It was Passepartout; and what had happened to him was as follows:
+Shortly after Fix left the opium den, two waiters had lifted the
+unconscious Passepartout, and had carried him to the bed reserved for
+the smokers.  Three hours later, pursued even in his dreams by a fixed
+idea, the poor fellow awoke, and struggled against the stupefying
+influence of the narcotic.  The thought of a duty unfulfilled shook off
+his torpor, and he hurried from the abode of drunkenness.  Staggering
+and holding himself up by keeping against the walls, falling down and
+creeping up again, and irresistibly impelled by a kind of instinct, he
+kept crying out, "The Carnatic! the Carnatic!"
+
+The steamer lay puffing alongside the quay, on the point of starting.
+Passepartout had but few steps to go; and, rushing upon the plank, he
+crossed it, and fell unconscious on the deck, just as the Carnatic was
+moving off.  Several sailors, who were evidently accustomed to this
+sort of scene, carried the poor Frenchman down into the second cabin,
+and Passepartout did not wake until they were one hundred and fifty
+miles away from China.  Thus he found himself the next morning on the
+deck of the Carnatic, and eagerly inhaling the exhilarating sea-breeze.
+The pure air sobered him.  He began to collect his sense, which he
+found a difficult task; but at last he recalled the events of the
+evening before, Fix's revelation, and the opium-house.
+
+"It is evident," said he to himself, "that I have been abominably
+drunk!  What will Mr. Fogg say?  At least I have not missed the
+steamer, which is the most important thing."
+
+Then, as Fix occurred to him: "As for that rascal, I hope we are well
+rid of him, and that he has not dared, as he proposed, to follow us on
+board the Carnatic.  A detective on the track of Mr. Fogg, accused of
+robbing the Bank of England!  Pshaw!  Mr. Fogg is no more a robber than
+I am a murderer."
+
+Should he divulge Fix's real errand to his master?  Would it do to tell
+the part the detective was playing?  Would it not be better to wait
+until Mr. Fogg reached London again, and then impart to him that an
+agent of the metropolitan police had been following him round the
+world, and have a good laugh over it?  No doubt; at least, it was worth
+considering.  The first thing to do was to find Mr. Fogg, and apologise
+for his singular behaviour.
+
+Passepartout got up and proceeded, as well as he could with the rolling
+of the steamer, to the after-deck.  He saw no one who resembled either
+his master or Aouda.  "Good!"  muttered he; "Aouda has not got up yet,
+and Mr. Fogg has probably found some partners at whist."
+
+He descended to the saloon.  Mr. Fogg was not there.  Passepartout had
+only, however, to ask the purser the number of his master's state-room.
+The purser replied that he did not know any passenger by the name of
+Fogg.
+
+"I beg your pardon," said Passepartout persistently.  "He is a tall
+gentleman, quiet, and not very talkative, and has with him a young
+lady--"
+
+"There is no young lady on board," interrupted the purser.  "Here is a
+list of the passengers; you may see for yourself."
+
+Passepartout scanned the list, but his master's name was not upon it.
+All at once an idea struck him.
+
+"Ah! am I on the Carnatic?"
+
+"Yes."
+
+"On the way to Yokohama?"
+
+"Certainly."
+
+Passepartout had for an instant feared that he was on the wrong boat;
+but, though he was really on the Carnatic, his master was not there.
+
+He fell thunderstruck on a seat.  He saw it all now.  He remembered
+that the time of sailing had been changed, that he should have informed
+his master of that fact, and that he had not done so.  It was his
+fault, then, that Mr. Fogg and Aouda had missed the steamer.  Yes, but
+it was still more the fault of the traitor who, in order to separate
+him from his master, and detain the latter at Hong Kong, had inveigled
+him into getting drunk!  He now saw the detective's trick; and at this
+moment Mr. Fogg was certainly ruined, his bet was lost, and he himself
+perhaps arrested and imprisoned!  At this thought Passepartout tore his
+hair.  Ah, if Fix ever came within his reach, what a settling of
+accounts there would be!
+
+After his first depression, Passepartout became calmer, and began to
+study his situation.  It was certainly not an enviable one.  He found
+himself on the way to Japan, and what should he do when he got there?
+His pocket was empty; he had not a solitary shilling, not so much as a
+penny.  His passage had fortunately been paid for in advance; and he
+had five or six days in which to decide upon his future course.  He
+fell to at meals with an appetite, and ate for Mr. Fogg, Aouda, and
+himself.  He helped himself as generously as if Japan were a desert,
+where nothing to eat was to be looked for.
+
+At dawn on the 13th the Carnatic entered the port of Yokohama.  This is
+an important port of call in the Pacific, where all the mail-steamers,
+and those carrying travellers between North America, China, Japan, and
+the Oriental islands put in.  It is situated in the bay of Yeddo, and
+at but a short distance from that second capital of the Japanese
+Empire, and the residence of the Tycoon, the civil Emperor, before the
+Mikado, the spiritual Emperor, absorbed his office in his own.  The
+Carnatic anchored at the quay near the custom-house, in the midst of a
+crowd of ships bearing the flags of all nations.
+
+Passepartout went timidly ashore on this so curious territory of the
+Sons of the Sun.  He had nothing better to do than, taking chance for
+his guide, to wander aimlessly through the streets of Yokohama.  He
+found himself at first in a thoroughly European quarter, the houses
+having low fronts, and being adorned with verandas, beneath which he
+caught glimpses of neat peristyles.  This quarter occupied, with its
+streets, squares, docks, and warehouses, all the space between the
+"promontory of the Treaty" and the river.  Here, as at Hong Kong and
+Calcutta, were mixed crowds of all races, Americans and English,
+Chinamen and Dutchmen, mostly merchants ready to buy or sell anything.
+The Frenchman felt himself as much alone among them as if he had
+dropped down in the midst of Hottentots.
+
+He had, at least, one resource,--to call on the French and English
+consuls at Yokohama for assistance.  But he shrank from telling the
+story of his adventures, intimately connected as it was with that of
+his master; and, before doing so, he determined to exhaust all other
+means of aid.  As chance did not favour him in the European quarter, he
+penetrated that inhabited by the native Japanese, determined, if
+necessary, to push on to Yeddo.
+
+The Japanese quarter of Yokohama is called Benten, after the goddess of
+the sea, who is worshipped on the islands round about.  There
+Passepartout beheld beautiful fir and cedar groves, sacred gates of a
+singular architecture, bridges half hid in the midst of bamboos and
+reeds, temples shaded by immense cedar-trees, holy retreats where were
+sheltered Buddhist priests and sectaries of Confucius, and interminable
+streets, where a perfect harvest of rose-tinted and red-cheeked
+children, who looked as if they had been cut out of Japanese screens,
+and who were playing in the midst of short-legged poodles and yellowish
+cats, might have been gathered.
+
+The streets were crowded with people.  Priests were passing in
+processions, beating their dreary tambourines; police and custom-house
+officers with pointed hats encrusted with lac and carrying two sabres
+hung to their waists; soldiers, clad in blue cotton with white stripes,
+and bearing guns; the Mikado's guards, enveloped in silken doubles,
+hauberks and coats of mail; and numbers of military folk of all
+ranks--for the military profession is as much respected in Japan as it
+is despised in China--went hither and thither in groups and pairs.
+Passepartout saw, too, begging friars, long-robed pilgrims, and simple
+civilians, with their warped and jet-black hair, big heads, long busts,
+slender legs, short stature, and complexions varying from copper-colour
+to a dead white, but never yellow, like the Chinese, from whom the
+Japanese widely differ.  He did not fail to observe the curious
+equipages--carriages and palanquins, barrows supplied with sails, and
+litters made of bamboo; nor the women--whom he thought not especially
+handsome--who took little steps with their little feet, whereon they
+wore canvas shoes, straw sandals, and clogs of worked wood, and who
+displayed tight-looking eyes, flat chests, teeth fashionably blackened,
+and gowns crossed with silken scarfs, tied in an enormous knot behind
+an ornament which the modern Parisian ladies seem to have borrowed from
+the dames of Japan.
+
+Passepartout wandered for several hours in the midst of this motley
+crowd, looking in at the windows of the rich and curious shops, the
+jewellery establishments glittering with quaint Japanese ornaments, the
+restaurants decked with streamers and banners, the tea-houses, where
+the odorous beverage was being drunk with saki, a liquor concocted from
+the fermentation of rice, and the comfortable smoking-houses, where
+they were puffing, not opium, which is almost unknown in Japan, but a
+very fine, stringy tobacco.  He went on till he found himself in the
+fields, in the midst of vast rice plantations.  There he saw dazzling
+camellias expanding themselves, with flowers which were giving forth
+their last colours and perfumes, not on bushes, but on trees, and
+within bamboo enclosures, cherry, plum, and apple trees, which the
+Japanese cultivate rather for their blossoms than their fruit, and
+which queerly-fashioned, grinning scarecrows protected from the
+sparrows, pigeons, ravens, and other voracious birds.  On the branches
+of the cedars were perched large eagles; amid the foliage of the
+weeping willows were herons, solemnly standing on one leg; and on every
+hand were crows, ducks, hawks, wild birds, and a multitude of cranes,
+which the Japanese consider sacred, and which to their minds symbolise
+long life and prosperity.
+
+As he was strolling along, Passepartout espied some violets among the
+shrubs.
+
+"Good!" said he; "I'll have some supper."
+
+But, on smelling them, he found that they were odourless.
+
+"No chance there," thought he.
+
+The worthy fellow had certainly taken good care to eat as hearty a
+breakfast as possible before leaving the Carnatic; but, as he had been
+walking about all day, the demands of hunger were becoming importunate.
+He observed that the butchers stalls contained neither mutton, goat,
+nor pork; and, knowing also that it is a sacrilege to kill cattle,
+which are preserved solely for farming, he made up his mind that meat
+was far from plentiful in Yokohama--nor was he mistaken; and, in
+default of butcher's meat, he could have wished for a quarter of wild
+boar or deer, a partridge, or some quails, some game or fish, which,
+with rice, the Japanese eat almost exclusively.  But he found it
+necessary to keep up a stout heart, and to postpone the meal he craved
+till the following morning.  Night came, and Passepartout re-entered
+the native quarter, where he wandered through the streets, lit by
+vari-coloured lanterns, looking on at the dancers, who were executing
+skilful steps and boundings, and the astrologers who stood in the open
+air with their telescopes.  Then he came to the harbour, which was lit
+up by the resin torches of the fishermen, who were fishing from their
+boats.
+
+The streets at last became quiet, and the patrol, the officers of
+which, in their splendid costumes, and surrounded by their suites,
+Passepartout thought seemed like ambassadors, succeeded the bustling
+crowd.  Each time a company passed, Passepartout chuckled, and said to
+himself: "Good! another Japanese embassy departing for Europe!"
+
+
+
+
+Chapter XXIII
+
+IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+
+The next morning poor, jaded, famished Passepartout said to himself
+that he must get something to eat at all hazards, and the sooner he did
+so the better.  He might, indeed, sell his watch; but he would have
+starved first.  Now or never he must use the strong, if not melodious
+voice which nature had bestowed upon him.  He knew several French and
+English songs, and resolved to try them upon the Japanese, who must be
+lovers of music, since they were for ever pounding on their cymbals,
+tam-tams, and tambourines, and could not but appreciate European talent.
+
+It was, perhaps, rather early in the morning to get up a concert, and
+the audience prematurely aroused from their slumbers, might not
+possibly pay their entertainer with coin bearing the Mikado's features.
+Passepartout therefore decided to wait several hours; and, as he was
+sauntering along, it occurred to him that he would seem rather too well
+dressed for a wandering artist.  The idea struck him to change his
+garments for clothes more in harmony with his project; by which he
+might also get a little money to satisfy the immediate cravings of
+hunger.  The resolution taken, it remained to carry it out.
+
+It was only after a long search that Passepartout discovered a native
+dealer in old clothes, to whom he applied for an exchange.  The man
+liked the European costume, and ere long Passepartout issued from his
+shop accoutred in an old Japanese coat, and a sort of one-sided turban,
+faded with long use.  A few small pieces of silver, moreover, jingled
+in his pocket.
+
+"Good!" thought he.  "I will imagine I am at the Carnival!"
+
+His first care, after being thus "Japanesed," was to enter a tea-house
+of modest appearance, and, upon half a bird and a little rice, to
+breakfast like a man for whom dinner was as yet a problem to be solved.
+
+"Now," thought he, when he had eaten heartily, "I mustn't lose my head.
+I can't sell this costume again for one still more Japanese.  I must
+consider how to leave this country of the Sun, of which I shall not
+retain the most delightful of memories, as quickly as possible."
+
+It occurred to him to visit the steamers which were about to leave for
+America.  He would offer himself as a cook or servant, in payment of
+his passage and meals.  Once at San Francisco, he would find some means
+of going on.  The difficulty was, how to traverse the four thousand
+seven hundred miles of the Pacific which lay between Japan and the New
+World.
+
+Passepartout was not the man to let an idea go begging, and directed
+his steps towards the docks.  But, as he approached them, his project,
+which at first had seemed so simple, began to grow more and more
+formidable to his mind.  What need would they have of a cook or servant
+on an American steamer, and what confidence would they put in him,
+dressed as he was?  What references could he give?
+
+As he was reflecting in this wise, his eyes fell upon an immense
+placard which a sort of clown was carrying through the streets.  This
+placard, which was in English, read as follows:
+
+          ACROBATIC JAPANESE TROUPE,
+   HONOURABLE WILLIAM BATULCAR, PROPRIETOR,
+           LAST REPRESENTATIONS,
+PRIOR TO THEIR DEPARTURE TO THE UNITED STATES,
+                  OF THE
+        LONG NOSES!   LONG NOSES!
+UNDER THE DIRECT PATRONAGE OF THE GOD TINGOU!
+           GREAT ATTRACTION!
+
+"The United States!" said Passepartout; "that's just what I want!"
+
+He followed the clown, and soon found himself once more in the Japanese
+quarter.  A quarter of an hour later he stopped before a large cabin,
+adorned with several clusters of streamers, the exterior walls of which
+were designed to represent, in violent colours and without perspective,
+a company of jugglers.
+
+This was the Honourable William Batulcar's establishment.  That
+gentleman was a sort of Barnum, the director of a troupe of
+mountebanks, jugglers, clowns, acrobats, equilibrists, and gymnasts,
+who, according to the placard, was giving his last performances before
+leaving the Empire of the Sun for the States of the Union.
+
+Passepartout entered and asked for Mr. Batulcar, who straightway
+appeared in person.
+
+"What do you want?" said he to Passepartout, whom he at first took for
+a native.
+
+"Would you like a servant, sir?" asked Passepartout.
+
+"A servant!" cried Mr. Batulcar, caressing the thick grey beard which
+hung from his chin.  "I already have two who are obedient and faithful,
+have never left me, and serve me for their nourishment and here they
+are," added he, holding out his two robust arms, furrowed with veins as
+large as the strings of a bass-viol.
+
+"So I can be of no use to you?"
+
+"None."
+
+"The devil!  I should so like to cross the Pacific with you!"
+
+"Ah!" said the Honourable Mr. Batulcar.  "You are no more a Japanese
+than I am a monkey!  Who are you dressed up in that way?"
+
+"A man dresses as he can."
+
+"That's true.  You are a Frenchman, aren't you?"
+
+"Yes; a Parisian of Paris."
+
+"Then you ought to know how to make grimaces?"
+
+"Why," replied Passepartout, a little vexed that his nationality should
+cause this question, "we Frenchmen know how to make grimaces, it is
+true but not any better than the Americans do."
+
+"True.  Well, if I can't take you as a servant, I can as a clown.  You
+see, my friend, in France they exhibit foreign clowns, and in foreign
+parts French clowns."
+
+"Ah!"
+
+"You are pretty strong, eh?"
+
+"Especially after a good meal."
+
+"And you can sing?"
+
+"Yes," returned Passepartout, who had formerly been wont to sing in the
+streets.
+
+"But can you sing standing on your head, with a top spinning on your
+left foot, and a sabre balanced on your right?"
+
+"Humph!  I think so," replied Passepartout, recalling the exercises of
+his younger days.
+
+"Well, that's enough," said the Honourable William Batulcar.
+
+The engagement was concluded there and then.
+
+Passepartout had at last found something to do.  He was engaged to act
+in the celebrated Japanese troupe.  It was not a very dignified
+position, but within a week he would be on his way to San Francisco.
+
+The performance, so noisily announced by the Honourable Mr. Batulcar,
+was to commence at three o'clock, and soon the deafening instruments of
+a Japanese orchestra resounded at the door.  Passepartout, though he
+had not been able to study or rehearse a part, was designated to lend
+the aid of his sturdy shoulders in the great exhibition of the "human
+pyramid," executed by the Long Noses of the god Tingou.  This "great
+attraction" was to close the performance.
+
+Before three o'clock the large shed was invaded by the spectators,
+comprising Europeans and natives, Chinese and Japanese, men, women and
+children, who precipitated themselves upon the narrow benches and into
+the boxes opposite the stage.  The musicians took up a position inside,
+and were vigorously performing on their gongs, tam-tams, flutes, bones,
+tambourines, and immense drums.
+
+The performance was much like all acrobatic displays; but it must be
+confessed that the Japanese are the first equilibrists in the world.
+
+One, with a fan and some bits of paper, performed the graceful trick of
+the butterflies and the flowers; another traced in the air, with the
+odorous smoke of his pipe, a series of blue words, which composed a
+compliment to the audience; while a third juggled with some lighted
+candles, which he extinguished successively as they passed his lips,
+and relit again without interrupting for an instant his juggling.
+Another reproduced the most singular combinations with a spinning-top;
+in his hands the revolving tops seemed to be animated with a life of
+their own in their interminable whirling; they ran over pipe-stems, the
+edges of sabres, wires and even hairs stretched across the stage; they
+turned around on the edges of large glasses, crossed bamboo ladders,
+dispersed into all the corners, and produced strange musical effects by
+the combination of their various pitches of tone.  The jugglers tossed
+them in the air, threw them like shuttlecocks with wooden battledores,
+and yet they kept on spinning; they put them into their pockets, and
+took them out still whirling as before.
+
+It is useless to describe the astonishing performances of the acrobats
+and gymnasts.  The turning on ladders, poles, balls, barrels, &c., was
+executed with wonderful precision.
+
+But the principal attraction was the exhibition of the Long Noses, a
+show to which Europe is as yet a stranger.
+
+The Long Noses form a peculiar company, under the direct patronage of
+the god Tingou.  Attired after the fashion of the Middle Ages, they
+bore upon their shoulders a splendid pair of wings; but what especially
+distinguished them was the long noses which were fastened to their
+faces, and the uses which they made of them.  These noses were made of
+bamboo, and were five, six, and even ten feet long, some straight,
+others curved, some ribboned, and some having imitation warts upon
+them.  It was upon these appendages, fixed tightly on their real noses,
+that they performed their gymnastic exercises.  A dozen of these
+sectaries of Tingou lay flat upon their backs, while others, dressed to
+represent lightning-rods, came and frolicked on their noses, jumping
+from one to another, and performing the most skilful leapings and
+somersaults.
+
+As a last scene, a "human pyramid" had been announced, in which fifty
+Long Noses were to represent the Car of Juggernaut.  But, instead of
+forming a pyramid by mounting each other's shoulders, the artists were
+to group themselves on top of the noses.  It happened that the
+performer who had hitherto formed the base of the Car had quitted the
+troupe, and as, to fill this part, only strength and adroitness were
+necessary, Passepartout had been chosen to take his place.
+
+The poor fellow really felt sad when--melancholy reminiscence of his
+youth!--he donned his costume, adorned with vari-coloured wings, and
+fastened to his natural feature a false nose six feet long.  But he
+cheered up when he thought that this nose was winning him something to
+eat.
+
+He went upon the stage, and took his place beside the rest who were to
+compose the base of the Car of Juggernaut.  They all stretched
+themselves on the floor, their noses pointing to the ceiling.  A second
+group of artists disposed themselves on these long appendages, then a
+third above these, then a fourth, until a human monument reaching to
+the very cornices of the theatre soon arose on top of the noses.  This
+elicited loud applause, in the midst of which the orchestra was just
+striking up a deafening air, when the pyramid tottered, the balance was
+lost, one of the lower noses vanished from the pyramid, and the human
+monument was shattered like a castle built of cards!
+
+It was Passepartout's fault.  Abandoning his position, clearing the
+footlights without the aid of his wings, and, clambering up to the
+right-hand gallery, he fell at the feet of one of the spectators,
+crying, "Ah, my master! my master!"
+
+"You here?"
+
+"Myself."
+
+"Very well; then let us go to the steamer, young man!"
+
+Mr. Fogg, Aouda, and Passepartout passed through the lobby of the
+theatre to the outside, where they encountered the Honourable Mr.
+Batulcar, furious with rage.  He demanded damages for the "breakage" of
+the pyramid; and Phileas Fogg appeased him by giving him a handful of
+banknotes.
+
+At half-past six, the very hour of departure, Mr. Fogg and Aouda,
+followed by Passepartout, who in his hurry had retained his wings, and
+nose six feet long, stepped upon the American steamer.
+
+
+
+
+Chapter XXIV
+
+DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+
+What happened when the pilot-boat came in sight of Shanghai will be
+easily guessed.  The signals made by the Tankadere had been seen by the
+captain of the Yokohama steamer, who, espying the flag at half-mast,
+had directed his course towards the little craft.  Phileas Fogg, after
+paying the stipulated price of his passage to John Busby, and rewarding
+that worthy with the additional sum of five hundred and fifty pounds,
+ascended the steamer with Aouda and Fix; and they started at once for
+Nagasaki and Yokohama.
+
+They reached their destination on the morning of the 14th of November.
+Phileas Fogg lost no time in going on board the Carnatic, where he
+learned, to Aouda's great delight--and perhaps to his own, though he
+betrayed no emotion--that Passepartout, a Frenchman, had really arrived
+on her the day before.
+
+The San Francisco steamer was announced to leave that very evening, and
+it became necessary to find Passepartout, if possible, without delay.
+Mr. Fogg applied in vain to the French and English consuls, and, after
+wandering through the streets a long time, began to despair of finding
+his missing servant.  Chance, or perhaps a kind of presentiment, at
+last led him into the Honourable Mr. Batulcar's theatre.  He certainly
+would not have recognised Passepartout in the eccentric mountebank's
+costume; but the latter, lying on his back, perceived his master in the
+gallery.  He could not help starting, which so changed the position of
+his nose as to bring the "pyramid" pell-mell upon the stage.
+
+All this Passepartout learned from Aouda, who recounted to him what had
+taken place on the voyage from Hong Kong to Shanghai on the Tankadere,
+in company with one Mr. Fix.
+
+Passepartout did not change countenance on hearing this name.  He
+thought that the time had not yet arrived to divulge to his master what
+had taken place between the detective and himself; and, in the account
+he gave of his absence, he simply excused himself for having been
+overtaken by drunkenness, in smoking opium at a tavern in Hong Kong.
+
+Mr. Fogg heard this narrative coldly, without a word; and then
+furnished his man with funds necessary to obtain clothing more in
+harmony with his position.  Within an hour the Frenchman had cut off
+his nose and parted with his wings, and retained nothing about him
+which recalled the sectary of the god Tingou.
+
+The steamer which was about to depart from Yokohama to San Francisco
+belonged to the Pacific Mail Steamship Company, and was named the
+General Grant.  She was a large paddle-wheel steamer of two thousand
+five hundred tons; well equipped and very fast.  The massive
+walking-beam rose and fell above the deck; at one end a piston-rod
+worked up and down; and at the other was a connecting-rod which, in
+changing the rectilinear motion to a circular one, was directly
+connected with the shaft of the paddles.  The General Grant was rigged
+with three masts, giving a large capacity for sails, and thus
+materially aiding the steam power.  By making twelve miles an hour, she
+would cross the ocean in twenty-one days.  Phileas Fogg was therefore
+justified in hoping that he would reach San Francisco by the 2nd of
+December, New York by the 11th, and London on the 20th--thus gaining
+several hours on the fatal date of the 21st of December.
+
+There was a full complement of passengers on board, among them English,
+many Americans, a large number of coolies on their way to California,
+and several East Indian officers, who were spending their vacation in
+making the tour of the world.  Nothing of moment happened on the
+voyage; the steamer, sustained on its large paddles, rolled but little,
+and the Pacific almost justified its name.  Mr. Fogg was as calm and
+taciturn as ever.  His young companion felt herself more and more
+attached to him by other ties than gratitude; his silent but generous
+nature impressed her more than she thought; and it was almost
+unconsciously that she yielded to emotions which did not seem to have
+the least effect upon her protector.  Aouda took the keenest interest
+in his plans, and became impatient at any incident which seemed likely
+to retard his journey.
+
+She often chatted with Passepartout, who did not fail to perceive the
+state of the lady's heart; and, being the most faithful of domestics,
+he never exhausted his eulogies of Phileas Fogg's honesty, generosity,
+and devotion.  He took pains to calm Aouda's doubts of a successful
+termination of the journey, telling her that the most difficult part of
+it had passed, that now they were beyond the fantastic countries of
+Japan and China, and were fairly on their way to civilised places
+again.  A railway train from San Francisco to New York, and a
+transatlantic steamer from New York to Liverpool, would doubtless bring
+them to the end of this impossible journey round the world within the
+period agreed upon.
+
+On the ninth day after leaving Yokohama, Phileas Fogg had traversed
+exactly one half of the terrestrial globe.  The General Grant passed,
+on the 23rd of November, the one hundred and eightieth meridian, and
+was at the very antipodes of London.  Mr. Fogg had, it is true,
+exhausted fifty-two of the eighty days in which he was to complete the
+tour, and there were only twenty-eight left.  But, though he was only
+half-way by the difference of meridians, he had really gone over
+two-thirds of the whole journey; for he had been obliged to make long
+circuits from London to Aden, from Aden to Bombay, from Calcutta to
+Singapore, and from Singapore to Yokohama.  Could he have followed
+without deviation the fiftieth parallel, which is that of London, the
+whole distance would only have been about twelve thousand miles;
+whereas he would be forced, by the irregular methods of locomotion, to
+traverse twenty-six thousand, of which he had, on the 23rd of November,
+accomplished seventeen thousand five hundred.  And now the course was a
+straight one, and Fix was no longer there to put obstacles in their way!
+
+It happened also, on the 23rd of November, that Passepartout made a
+joyful discovery.  It will be remembered that the obstinate fellow had
+insisted on keeping his famous family watch at London time, and on
+regarding that of the countries he had passed through as quite false
+and unreliable.  Now, on this day, though he had not changed the hands,
+he found that his watch exactly agreed with the ship's chronometers.
+His triumph was hilarious.  He would have liked to know what Fix would
+say if he were aboard!
+
+"The rogue told me a lot of stories," repeated Passepartout, "about the
+meridians, the sun, and the moon!  Moon, indeed!  moonshine more
+likely!  If one listened to that sort of people, a pretty sort of time
+one would keep!  I was sure that the sun would some day regulate itself
+by my watch!"
+
+Passepartout was ignorant that, if the face of his watch had been
+divided into twenty-four hours, like the Italian clocks, he would have
+no reason for exultation; for the hands of his watch would then,
+instead of as now indicating nine o'clock in the morning, indicate nine
+o'clock in the evening, that is, the twenty-first hour after midnight
+precisely the difference between London time and that of the one
+hundred and eightieth meridian.  But if Fix had been able to explain
+this purely physical effect, Passepartout would not have admitted, even
+if he had comprehended it.  Moreover, if the detective had been on
+board at that moment, Passepartout would have joined issue with him on
+a quite different subject, and in an entirely different manner.
+
+Where was Fix at that moment?
+
+He was actually on board the General Grant.
+
+On reaching Yokohama, the detective, leaving Mr. Fogg, whom he expected
+to meet again during the day, had repaired at once to the English
+consulate, where he at last found the warrant of arrest.  It had
+followed him from Bombay, and had come by the Carnatic, on which
+steamer he himself was supposed to be.  Fix's disappointment may be
+imagined when he reflected that the warrant was now useless.  Mr. Fogg
+had left English ground, and it was now necessary to procure his
+extradition!
+
+"Well," thought Fix, after a moment of anger, "my warrant is not good
+here, but it will be in England.  The rogue evidently intends to return
+to his own country, thinking he has thrown the police off his track.
+Good!  I will follow him across the Atlantic.  As for the money, heaven
+grant there may be some left!  But the fellow has already spent in
+travelling, rewards, trials, bail, elephants, and all sorts of charges,
+more than five thousand pounds.  Yet, after all, the Bank is rich!"
+
+His course decided on, he went on board the General Grant, and was
+there when Mr. Fogg and Aouda arrived.  To his utter amazement, he
+recognised Passepartout, despite his theatrical disguise.  He quickly
+concealed himself in his cabin, to avoid an awkward explanation, and
+hoped--thanks to the number of passengers--to remain unperceived by Mr.
+Fogg's servant.
+
+On that very day, however, he met Passepartout face to face on the
+forward deck.  The latter, without a word, made a rush for him, grasped
+him by the throat, and, much to the amusement of a group of Americans,
+who immediately began to bet on him, administered to the detective a
+perfect volley of blows, which proved the great superiority of French
+over English pugilistic skill.
+
+When Passepartout had finished, he found himself relieved and
+comforted.  Fix got up in a somewhat rumpled condition, and, looking at
+his adversary, coldly said, "Have you done?"
+
+"For this time--yes."
+
+"Then let me have a word with you."
+
+"But I--"
+
+"In your master's interests."
+
+Passepartout seemed to be vanquished by Fix's coolness, for he quietly
+followed him, and they sat down aside from the rest of the passengers.
+
+"You have given me a thrashing," said Fix.  "Good, I expected it.  Now,
+listen to me.  Up to this time I have been Mr. Fogg's adversary.  I am
+now in his game."
+
+"Aha!" cried Passepartout; "you are convinced he is an honest man?"
+
+"No," replied Fix coldly, "I think him a rascal.  Sh! don't budge, and
+let me speak.  As long as Mr. Fogg was on English ground, it was for my
+interest to detain him there until my warrant of arrest arrived.  I did
+everything I could to keep him back.  I sent the Bombay priests after
+him, I got you intoxicated at Hong Kong, I separated you from him, and
+I made him miss the Yokohama steamer."
+
+Passepartout listened, with closed fists.
+
+"Now," resumed Fix, "Mr. Fogg seems to be going back to England.  Well,
+I will follow him there.  But hereafter I will do as much to keep
+obstacles out of his way as I have done up to this time to put them in
+his path.  I've changed my game, you see, and simply because it was for
+my interest to change it.  Your interest is the same as mine; for it is
+only in England that you will ascertain whether you are in the service
+of a criminal or an honest man."
+
+Passepartout listened very attentively to Fix, and was convinced that
+he spoke with entire good faith.
+
+"Are we friends?" asked the detective.
+
+"Friends?--no," replied Passepartout; "but allies, perhaps.  At the
+least sign of treason, however, I'll twist your neck for you."
+
+"Agreed," said the detective quietly.
+
+Eleven days later, on the 3rd of December, the General Grant entered
+the bay of the Golden Gate, and reached San Francisco.
+
+Mr. Fogg had neither gained nor lost a single day.
+
+
+
+
+Chapter XXV
+
+IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+
+It was seven in the morning when Mr. Fogg, Aouda, and Passepartout set
+foot upon the American continent, if this name can be given to the
+floating quay upon which they disembarked.  These quays, rising and
+falling with the tide, thus facilitate the loading and unloading of
+vessels.  Alongside them were clippers of all sizes, steamers of all
+nationalities, and the steamboats, with several decks rising one above
+the other, which ply on the Sacramento and its tributaries.  There were
+also heaped up the products of a commerce which extends to Mexico,
+Chili, Peru, Brazil, Europe, Asia, and all the Pacific islands.
+
+Passepartout, in his joy on reaching at last the American continent,
+thought he would manifest it by executing a perilous vault in fine
+style; but, tumbling upon some worm-eaten planks, he fell through them.
+Put out of countenance by the manner in which he thus "set foot" upon
+the New World, he uttered a loud cry, which so frightened the
+innumerable cormorants and pelicans that are always perched upon these
+movable quays, that they flew noisily away.
+
+Mr. Fogg, on reaching shore, proceeded to find out at what hour the
+first train left for New York, and learned that this was at six o'clock
+p.m.; he had, therefore, an entire day to spend in the Californian
+capital.  Taking a carriage at a charge of three dollars, he and Aouda
+entered it, while Passepartout mounted the box beside the driver, and
+they set out for the International Hotel.
+
+From his exalted position Passepartout observed with much curiosity the
+wide streets, the low, evenly ranged houses, the Anglo-Saxon Gothic
+churches, the great docks, the palatial wooden and brick warehouses,
+the numerous conveyances, omnibuses, horse-cars, and upon the
+side-walks, not only Americans and Europeans, but Chinese and Indians.
+Passepartout was surprised at all he saw.  San Francisco was no longer
+the legendary city of 1849--a city of banditti, assassins, and
+incendiaries, who had flocked hither in crowds in pursuit of plunder; a
+paradise of outlaws, where they gambled with gold-dust, a revolver in
+one hand and a bowie-knife in the other: it was now a great commercial
+emporium.
+
+The lofty tower of its City Hall overlooked the whole panorama of the
+streets and avenues, which cut each other at right-angles, and in the
+midst of which appeared pleasant, verdant squares, while beyond
+appeared the Chinese quarter, seemingly imported from the Celestial
+Empire in a toy-box.  Sombreros and red shirts and plumed Indians were
+rarely to be seen; but there were silk hats and black coats everywhere
+worn by a multitude of nervously active, gentlemanly-looking men.  Some
+of the streets--especially Montgomery Street, which is to San Francisco
+what Regent Street is to London, the Boulevard des Italiens to Paris,
+and Broadway to New York--were lined with splendid and spacious
+stores, which exposed in their windows the products of the entire world.
+
+When Passepartout reached the International Hotel, it did not seem to
+him as if he had left England at all.
+
+The ground floor of the hotel was occupied by a large bar, a sort of
+restaurant freely open to all passers-by, who might partake of dried
+beef, oyster soup, biscuits, and cheese, without taking out their
+purses.  Payment was made only for the ale, porter, or sherry which was
+drunk.  This seemed "very American" to Passepartout.  The hotel
+refreshment-rooms were comfortable, and Mr. Fogg and Aouda, installing
+themselves at a table, were abundantly served on diminutive plates by
+negroes of darkest hue.
+
+After breakfast, Mr. Fogg, accompanied by Aouda, started for the
+English consulate to have his passport visaed.  As he was going out, he
+met Passepartout, who asked him if it would not be well, before taking
+the train, to purchase some dozens of Enfield rifles and Colt's
+revolvers.  He had been listening to stories of attacks upon the trains
+by the Sioux and Pawnees.  Mr. Fogg thought it a useless precaution,
+but told him to do as he thought best, and went on to the consulate.
+
+He had not proceeded two hundred steps, however, when, "by the greatest
+chance in the world," he met Fix.  The detective seemed wholly taken by
+surprise.  What!  Had Mr. Fogg and himself crossed the Pacific
+together, and not met on the steamer!  At least Fix felt honoured to
+behold once more the gentleman to whom he owed so much, and, as his
+business recalled him to Europe, he should be delighted to continue the
+journey in such pleasant company.
+
+Mr. Fogg replied that the honour would be his; and the detective--who
+was determined not to lose sight of him--begged permission to accompany
+them in their walk about San Francisco--a request which Mr. Fogg
+readily granted.
+
+They soon found themselves in Montgomery Street, where a great crowd
+was collected; the side-walks, street, horsecar rails, the shop-doors,
+the windows of the houses, and even the roofs, were full of people.
+Men were going about carrying large posters, and flags and streamers
+were floating in the wind; while loud cries were heard on every hand.
+
+"Hurrah for Camerfield!"
+
+"Hurrah for Mandiboy!"
+
+It was a political meeting; at least so Fix conjectured, who said to
+Mr. Fogg, "Perhaps we had better not mingle with the crowd.  There may
+be danger in it."
+
+"Yes," returned Mr. Fogg; "and blows, even if they are political are
+still blows."
+
+Fix smiled at this remark; and, in order to be able to see without
+being jostled about, the party took up a position on the top of a
+flight of steps situated at the upper end of Montgomery Street.
+Opposite them, on the other side of the street, between a coal wharf
+and a petroleum warehouse, a large platform had been erected in the
+open air, towards which the current of the crowd seemed to be directed.
+
+For what purpose was this meeting?  What was the occasion of this
+excited assemblage?  Phileas Fogg could not imagine.  Was it to
+nominate some high official--a governor or member of Congress?  It was
+not improbable, so agitated was the multitude before them.
+
+Just at this moment there was an unusual stir in the human mass.  All
+the hands were raised in the air.  Some, tightly closed, seemed to
+disappear suddenly in the midst of the cries--an energetic way, no
+doubt, of casting a vote.  The crowd swayed back, the banners and flags
+wavered, disappeared an instant, then reappeared in tatters.  The
+undulations of the human surge reached the steps, while all the heads
+floundered on the surface like a sea agitated by a squall.  Many of the
+black hats disappeared, and the greater part of the crowd seemed to
+have diminished in height.
+
+"It is evidently a meeting," said Fix, "and its object must be an
+exciting one.  I should not wonder if it were about the Alabama,
+despite the fact that that question is settled."
+
+"Perhaps," replied Mr. Fogg, simply.
+
+"At least, there are two champions in presence of each other, the
+Honourable Mr. Camerfield and the Honourable Mr. Mandiboy."
+
+Aouda, leaning upon Mr. Fogg's arm, observed the tumultuous scene with
+surprise, while Fix asked a man near him what the cause of it all was.
+Before the man could reply, a fresh agitation arose; hurrahs and
+excited shouts were heard; the staffs of the banners began to be used
+as offensive weapons; and fists flew about in every direction.  Thumps
+were exchanged from the tops of the carriages and omnibuses which had
+been blocked up in the crowd.  Boots and shoes went whirling through
+the air, and Mr. Fogg thought he even heard the crack of revolvers
+mingling in the din, the rout approached the stairway, and flowed over
+the lower step.  One of the parties had evidently been repulsed; but
+the mere lookers-on could not tell whether Mandiboy or Camerfield had
+gained the upper hand.
+
+"It would be prudent for us to retire," said Fix, who was anxious that
+Mr. Fogg should not receive any injury, at least until they got back to
+London.  "If there is any question about England in all this, and we
+were recognised, I fear it would go hard with us."
+
+"An English subject--" began Mr. Fogg.
+
+He did not finish his sentence; for a terrific hubbub now arose on the
+terrace behind the flight of steps where they stood, and there were
+frantic shouts of, "Hurrah for Mandiboy!  Hip, hip, hurrah!"
+
+It was a band of voters coming to the rescue of their allies, and
+taking the Camerfield forces in flank.  Mr. Fogg, Aouda, and Fix found
+themselves between two fires; it was too late to escape.  The torrent
+of men, armed with loaded canes and sticks, was irresistible.  Phileas
+Fogg and Fix were roughly hustled in their attempts to protect their
+fair companion; the former, as cool as ever, tried to defend himself
+with the weapons which nature has placed at the end of every
+Englishman's arm, but in vain.  A big brawny fellow with a red beard,
+flushed face, and broad shoulders, who seemed to be the chief of the
+band, raised his clenched fist to strike Mr. Fogg, whom he would have
+given a crushing blow, had not Fix rushed in and received it in his
+stead.  An enormous bruise immediately made its appearance under the
+detective's silk hat, which was completely smashed in.
+
+"Yankee!" exclaimed Mr. Fogg, darting a contemptuous look at the
+ruffian.
+
+"Englishman!" returned the other.  "We will meet again!"
+
+"When you please."
+
+"What is your name?"
+
+"Phileas Fogg.  And yours?"
+
+"Colonel Stamp Proctor."
+
+The human tide now swept by, after overturning Fix, who speedily got
+upon his feet again, though with tattered clothes.  Happily, he was not
+seriously hurt.  His travelling overcoat was divided into two unequal
+parts, and his trousers resembled those of certain Indians, which fit
+less compactly than they are easy to put on.  Aouda had escaped
+unharmed, and Fix alone bore marks of the fray in his black and blue
+bruise.
+
+"Thanks," said Mr. Fogg to the detective, as soon as they were out of
+the crowd.
+
+"No thanks are necessary," replied.  Fix; "but let us go."
+
+"Where?"
+
+"To a tailor's."
+
+Such a visit was, indeed, opportune.  The clothing of both Mr. Fogg and
+Fix was in rags, as if they had themselves been actively engaged in the
+contest between Camerfield and Mandiboy.  An hour after, they were once
+more suitably attired, and with Aouda returned to the International
+Hotel.
+
+Passepartout was waiting for his master, armed with half a dozen
+six-barrelled revolvers.  When he perceived Fix, he knit his brows; but
+Aouda having, in a few words, told him of their adventure, his
+countenance resumed its placid expression.  Fix evidently was no longer
+an enemy, but an ally; he was faithfully keeping his word.
+
+Dinner over, the coach which was to convey the passengers and their
+luggage to the station drew up to the door.  As he was getting in, Mr.
+Fogg said to Fix, "You have not seen this Colonel Proctor again?"
+
+"No."
+
+"I will come back to America to find him," said Phileas Fogg calmly.
+"It would not be right for an Englishman to permit himself to be
+treated in that way, without retaliating."
+
+The detective smiled, but did not reply.  It was clear that Mr. Fogg
+was one of those Englishmen who, while they do not tolerate duelling at
+home, fight abroad when their honour is attacked.
+
+At a quarter before six the travellers reached the station, and found
+the train ready to depart.  As he was about to enter it, Mr. Fogg
+called a porter, and said to him: "My friend, was there not some
+trouble to-day in San Francisco?"
+
+"It was a political meeting, sir," replied the porter.
+
+"But I thought there was a great deal of disturbance in the streets."
+
+"It was only a meeting assembled for an election."
+
+"The election of a general-in-chief, no doubt?" asked Mr. Fogg.
+
+"No, sir; of a justice of the peace."
+
+Phileas Fogg got into the train, which started off at full speed.
+
+
+
+
+Chapter XXVI
+
+IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+
+"From ocean to ocean"--so say the Americans; and these four words
+compose the general designation of the "great trunk line" which crosses
+the entire width of the United States.  The Pacific Railroad is,
+however, really divided into two distinct lines: the Central Pacific,
+between San Francisco and Ogden, and the Union Pacific, between Ogden
+and Omaha.  Five main lines connect Omaha with New York.
+
+New York and San Francisco are thus united by an uninterrupted metal
+ribbon, which measures no less than three thousand seven hundred and
+eighty-six miles.  Between Omaha and the Pacific the railway crosses a
+territory which is still infested by Indians and wild beasts, and a
+large tract which the Mormons, after they were driven from Illinois in
+1845, began to colonise.
+
+The journey from New York to San Francisco consumed, formerly, under
+the most favourable conditions, at least six months.  It is now
+accomplished in seven days.
+
+It was in 1862 that, in spite of the Southern Members of Congress, who
+wished a more southerly route, it was decided to lay the road between
+the forty-first and forty-second parallels.  President Lincoln himself
+fixed the end of the line at Omaha, in Nebraska.  The work was at once
+commenced, and pursued with true American energy; nor did the rapidity
+with which it went on injuriously affect its good execution.  The road
+grew, on the prairies, a mile and a half a day.  A locomotive, running
+on the rails laid down the evening before, brought the rails to be laid
+on the morrow, and advanced upon them as fast as they were put in
+position.
+
+The Pacific Railroad is joined by several branches in Iowa, Kansas,
+Colorado, and Oregon.  On leaving Omaha, it passes along the left bank
+of the Platte River as far as the junction of its northern branch,
+follows its southern branch, crosses the Laramie territory and the
+Wahsatch Mountains, turns the Great Salt Lake, and reaches Salt Lake
+City, the Mormon capital, plunges into the Tuilla Valley, across the
+American Desert, Cedar and Humboldt Mountains, the Sierra Nevada, and
+descends, via Sacramento, to the Pacific--its grade, even on the Rocky
+Mountains, never exceeding one hundred and twelve feet to the mile.
+
+Such was the road to be traversed in seven days, which would enable
+Phileas Fogg--at least, so he hoped--to take the Atlantic steamer at
+New York on the 11th for Liverpool.
+
+The car which he occupied was a sort of long omnibus on eight wheels,
+and with no compartments in the interior.  It was supplied with two
+rows of seats, perpendicular to the direction of the train on either
+side of an aisle which conducted to the front and rear platforms.
+These platforms were found throughout the train, and the passengers
+were able to pass from one end of the train to the other.  It was
+supplied with saloon cars, balcony cars, restaurants, and smoking-cars;
+theatre cars alone were wanting, and they will have these some day.
+
+Book and news dealers, sellers of edibles, drinkables, and cigars, who
+seemed to have plenty of customers, were continually circulating in the
+aisles.
+
+The train left Oakland station at six o'clock.  It was already night,
+cold and cheerless, the heavens being overcast with clouds which seemed
+to threaten snow.  The train did not proceed rapidly; counting the
+stoppages, it did not run more than twenty miles an hour, which was a
+sufficient speed, however, to enable it to reach Omaha within its
+designated time.
+
+There was but little conversation in the car, and soon many of the
+passengers were overcome with sleep.  Passepartout found himself beside
+the detective; but he did not talk to him.  After recent events, their
+relations with each other had grown somewhat cold; there could no
+longer be mutual sympathy or intimacy between them.  Fix's manner had
+not changed; but Passepartout was very reserved, and ready to strangle
+his former friend on the slightest provocation.
+
+Snow began to fall an hour after they started, a fine snow, however,
+which happily could not obstruct the train; nothing could be seen from
+the windows but a vast, white sheet, against which the smoke of the
+locomotive had a greyish aspect.
+
+At eight o'clock a steward entered the car and announced that the time
+for going to bed had arrived; and in a few minutes the car was
+transformed into a dormitory.  The backs of the seats were thrown back,
+bedsteads carefully packed were rolled out by an ingenious system,
+berths were suddenly improvised, and each traveller had soon at his
+disposition a comfortable bed, protected from curious eyes by thick
+curtains.  The sheets were clean and the pillows soft.  It only
+remained to go to bed and sleep which everybody did--while the train
+sped on across the State of California.
+
+The country between San Francisco and Sacramento is not very hilly.
+The Central Pacific, taking Sacramento for its starting-point, extends
+eastward to meet the road from Omaha.  The line from San Francisco to
+Sacramento runs in a north-easterly direction, along the American
+River, which empties into San Pablo Bay.  The one hundred and twenty
+miles between these cities were accomplished in six hours, and towards
+midnight, while fast asleep, the travellers passed through Sacramento;
+so that they saw nothing of that important place, the seat of the State
+government, with its fine quays, its broad streets, its noble hotels,
+squares, and churches.
+
+The train, on leaving Sacramento, and passing the junction, Roclin,
+Auburn, and Colfax, entered the range of the Sierra Nevada.  'Cisco was
+reached at seven in the morning; and an hour later the dormitory was
+transformed into an ordinary car, and the travellers could observe the
+picturesque beauties of the mountain region through which they were
+steaming.  The railway track wound in and out among the passes, now
+approaching the mountain-sides, now suspended over precipices, avoiding
+abrupt angles by bold curves, plunging into narrow defiles, which
+seemed to have no outlet.  The locomotive, its great funnel emitting a
+weird light, with its sharp bell, and its cow-catcher extended like a
+spur, mingled its shrieks and bellowings with the noise of torrents and
+cascades, and twined its smoke among the branches of the gigantic pines.
+
+There were few or no bridges or tunnels on the route.  The railway
+turned around the sides of the mountains, and did not attempt to
+violate nature by taking the shortest cut from one point to another.
+
+The train entered the State of Nevada through the Carson Valley about
+nine o'clock, going always northeasterly; and at midday reached Reno,
+where there was a delay of twenty minutes for breakfast.
+
+From this point the road, running along Humboldt River, passed
+northward for several miles by its banks; then it turned eastward, and
+kept by the river until it reached the Humboldt Range, nearly at the
+extreme eastern limit of Nevada.
+
+Having breakfasted, Mr. Fogg and his companions resumed their places in
+the car, and observed the varied landscape which unfolded itself as
+they passed along the vast prairies, the mountains lining the horizon,
+and the creeks, with their frothy, foaming streams.  Sometimes a great
+herd of buffaloes, massing together in the distance, seemed like a
+moveable dam.  These innumerable multitudes of ruminating beasts often
+form an insurmountable obstacle to the passage of the trains; thousands
+of them have been seen passing over the track for hours together, in
+compact ranks.  The locomotive is then forced to stop and wait till the
+road is once more clear.
+
+This happened, indeed, to the train in which Mr. Fogg was travelling.
+About twelve o'clock a troop of ten or twelve thousand head of buffalo
+encumbered the track.  The locomotive, slackening its speed, tried to
+clear the way with its cow-catcher; but the mass of animals was too
+great.  The buffaloes marched along with a tranquil gait, uttering now
+and then deafening bellowings.  There was no use of interrupting them,
+for, having taken a particular direction, nothing can moderate and
+change their course; it is a torrent of living flesh which no dam could
+contain.
+
+The travellers gazed on this curious spectacle from the platforms; but
+Phileas Fogg, who had the most reason of all to be in a hurry, remained
+in his seat, and waited philosophically until it should please the
+buffaloes to get out of the way.
+
+Passepartout was furious at the delay they occasioned, and longed to
+discharge his arsenal of revolvers upon them.
+
+"What a country!" cried he.  "Mere cattle stop the trains, and go by in
+a procession, just as if they were not impeding travel!  Parbleu!  I
+should like to know if Mr. Fogg foresaw this mishap in his programme!
+And here's an engineer who doesn't dare to run the locomotive into this
+herd of beasts!"
+
+The engineer did not try to overcome the obstacle, and he was wise.  He
+would have crushed the first buffaloes, no doubt, with the cow-catcher;
+but the locomotive, however powerful, would soon have been checked, the
+train would inevitably have been thrown off the track, and would then
+have been helpless.
+
+The best course was to wait patiently, and regain the lost time by
+greater speed when the obstacle was removed.  The procession of
+buffaloes lasted three full hours, and it was night before the track
+was clear.  The last ranks of the herd were now passing over the rails,
+while the first had already disappeared below the southern horizon.
+
+It was eight o'clock when the train passed through the defiles of the
+Humboldt Range, and half-past nine when it penetrated Utah, the region
+of the Great Salt Lake, the singular colony of the Mormons.
+
+
+
+
+Chapter XXVII
+
+IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN HOUR, A
+COURSE OF MORMON HISTORY
+
+
+During the night of the 5th of December, the train ran south-easterly
+for about fifty miles; then rose an equal distance in a north-easterly
+direction, towards the Great Salt Lake.
+
+Passepartout, about nine o'clock, went out upon the platform to take
+the air.  The weather was cold, the heavens grey, but it was not
+snowing.  The sun's disc, enlarged by the mist, seemed an enormous ring
+of gold, and Passepartout was amusing himself by calculating its value
+in pounds sterling, when he was diverted from this interesting study by
+a strange-looking personage who made his appearance on the platform.
+
+This personage, who had taken the train at Elko, was tall and dark,
+with black moustache, black stockings, a black silk hat, a black
+waistcoat, black trousers, a white cravat, and dogskin gloves.  He
+might have been taken for a clergyman.  He went from one end of the
+train to the other, and affixed to the door of each car a notice
+written in manuscript.
+
+Passepartout approached and read one of these notices, which stated
+that Elder William Hitch, Mormon missionary, taking advantage of his
+presence on train No. 48, would deliver a lecture on Mormonism in car
+No. 117, from eleven to twelve o'clock; and that he invited all who
+were desirous of being instructed concerning the mysteries of the
+religion of the "Latter Day Saints" to attend.
+
+"I'll go," said Passepartout to himself.  He knew nothing of Mormonism
+except the custom of polygamy, which is its foundation.
+
+The news quickly spread through the train, which contained about one
+hundred passengers, thirty of whom, at most, attracted by the notice,
+ensconced themselves in car No. 117.  Passepartout took one of the
+front seats.  Neither Mr. Fogg nor Fix cared to attend.
+
+At the appointed hour Elder William Hitch rose, and, in an irritated
+voice, as if he had already been contradicted, said, "I tell you that
+Joe Smith is a martyr, that his brother Hiram is a martyr, and that the
+persecutions of the United States Government against the prophets will
+also make a martyr of Brigham Young.  Who dares to say the contrary?"
+
+No one ventured to gainsay the missionary, whose excited tone
+contrasted curiously with his naturally calm visage.  No doubt his
+anger arose from the hardships to which the Mormons were actually
+subjected.  The government had just succeeded, with some difficulty, in
+reducing these independent fanatics to its rule.  It had made itself
+master of Utah, and subjected that territory to the laws of the Union,
+after imprisoning Brigham Young on a charge of rebellion and polygamy.
+The disciples of the prophet had since redoubled their efforts, and
+resisted, by words at least, the authority of Congress.  Elder Hitch,
+as is seen, was trying to make proselytes on the very railway trains.
+
+Then, emphasising his words with his loud voice and frequent gestures,
+he related the history of the Mormons from Biblical times: how that, in
+Israel, a Mormon prophet of the tribe of Joseph published the annals of
+the new religion, and bequeathed them to his son Mormon; how, many
+centuries later, a translation of this precious book, which was written
+in Egyptian, was made by Joseph Smith, junior, a Vermont farmer, who
+revealed himself as a mystical prophet in 1825; and how, in short, the
+celestial messenger appeared to him in an illuminated forest, and gave
+him the annals of the Lord.
+
+Several of the audience, not being much interested in the missionary's
+narrative, here left the car; but Elder Hitch, continuing his lecture,
+related how Smith, junior, with his father, two brothers, and a few
+disciples, founded the church of the "Latter Day Saints," which,
+adopted not only in America, but in England, Norway and Sweden, and
+Germany, counts many artisans, as well as men engaged in the liberal
+professions, among its members; how a colony was established in Ohio, a
+temple erected there at a cost of two hundred thousand dollars, and a
+town built at Kirkland; how Smith became an enterprising banker, and
+received from a simple mummy showman a papyrus scroll written by
+Abraham and several famous Egyptians.
+
+The Elder's story became somewhat wearisome, and his audience grew
+gradually less, until it was reduced to twenty passengers.  But this
+did not disconcert the enthusiast, who proceeded with the story of
+Joseph Smith's bankruptcy in 1837, and how his ruined creditors gave
+him a coat of tar and feathers; his reappearance some years afterwards,
+more honourable and honoured than ever, at Independence, Missouri, the
+chief of a flourishing colony of three thousand disciples, and his
+pursuit thence by outraged Gentiles, and retirement into the Far West.
+
+Ten hearers only were now left, among them honest Passepartout, who was
+listening with all his ears.  Thus he learned that, after long
+persecutions, Smith reappeared in Illinois, and in 1839 founded a
+community at Nauvoo, on the Mississippi, numbering twenty-five thousand
+souls, of which he became mayor, chief justice, and general-in-chief;
+that he announced himself, in 1843, as a candidate for the Presidency
+of the United States; and that finally, being drawn into ambuscade at
+Carthage, he was thrown into prison, and assassinated by a band of men
+disguised in masks.
+
+Passepartout was now the only person left in the car, and the Elder,
+looking him full in the face, reminded him that, two years after the
+assassination of Joseph Smith, the inspired prophet, Brigham Young, his
+successor, left Nauvoo for the banks of the Great Salt Lake, where, in
+the midst of that fertile region, directly on the route of the
+emigrants who crossed Utah on their way to California, the new colony,
+thanks to the polygamy practised by the Mormons, had flourished beyond
+expectations.
+
+"And this," added Elder William Hitch, "this is why the jealousy of
+Congress has been aroused against us!  Why have the soldiers of the
+Union invaded the soil of Utah?  Why has Brigham Young, our chief, been
+imprisoned, in contempt of all justice?  Shall we yield to force?
+Never!  Driven from Vermont, driven from Illinois, driven from Ohio,
+driven from Missouri, driven from Utah, we shall yet find some
+independent territory on which to plant our tents.  And you, my
+brother," continued the Elder, fixing his angry eyes upon his single
+auditor, "will you not plant yours there, too, under the shadow of our
+flag?"
+
+"No!" replied Passepartout courageously, in his turn retiring from the
+car, and leaving the Elder to preach to vacancy.
+
+During the lecture the train had been making good progress, and towards
+half-past twelve it reached the northwest border of the Great Salt
+Lake.  Thence the passengers could observe the vast extent of this
+interior sea, which is also called the Dead Sea, and into which flows
+an American Jordan.  It is a picturesque expanse, framed in lofty crags
+in large strata, encrusted with white salt--a superb sheet of water,
+which was formerly of larger extent than now, its shores having
+encroached with the lapse of time, and thus at once reduced its breadth
+and increased its depth.
+
+The Salt Lake, seventy miles long and thirty-five wide, is situated
+three miles eight hundred feet above the sea.  Quite different from
+Lake Asphaltite, whose depression is twelve hundred feet below the sea,
+it contains considerable salt, and one quarter of the weight of its
+water is solid matter, its specific weight being 1,170, and, after
+being distilled, 1,000.  Fishes are, of course, unable to live in it,
+and those which descend through the Jordan, the Weber, and other
+streams soon perish.
+
+The country around the lake was well cultivated, for the Mormons are
+mostly farmers; while ranches and pens for domesticated animals, fields
+of wheat, corn, and other cereals, luxuriant prairies, hedges of wild
+rose, clumps of acacias and milk-wort, would have been seen six months
+later.  Now the ground was covered with a thin powdering of snow.
+
+The train reached Ogden at two o'clock, where it rested for six hours,
+Mr. Fogg and his party had time to pay a visit to Salt Lake City,
+connected with Ogden by a branch road; and they spent two hours in this
+strikingly American town, built on the pattern of other cities of the
+Union, like a checker-board, "with the sombre sadness of right-angles,"
+as Victor Hugo expresses it.  The founder of the City of the Saints
+could not escape from the taste for symmetry which distinguishes the
+Anglo-Saxons.  In this strange country, where the people are certainly
+not up to the level of their institutions, everything is done
+"squarely"--cities, houses, and follies.
+
+The travellers, then, were promenading, at three o'clock, about the
+streets of the town built between the banks of the Jordan and the spurs
+of the Wahsatch Range.  They saw few or no churches, but the prophet's
+mansion, the court-house, and the arsenal, blue-brick houses with
+verandas and porches, surrounded by gardens bordered with acacias,
+palms, and locusts.  A clay and pebble wall, built in 1853, surrounded
+the town; and in the principal street were the market and several
+hotels adorned with pavilions.  The place did not seem thickly
+populated.  The streets were almost deserted, except in the vicinity of
+the temple, which they only reached after having traversed several
+quarters surrounded by palisades.  There were many women, which was
+easily accounted for by the "peculiar institution" of the Mormons; but
+it must not be supposed that all the Mormons are polygamists.  They are
+free to marry or not, as they please; but it is worth noting that it is
+mainly the female citizens of Utah who are anxious to marry, as,
+according to the Mormon religion, maiden ladies are not admitted to the
+possession of its highest joys.  These poor creatures seemed to be
+neither well off nor happy.  Some--the more well-to-do, no doubt--wore
+short, open, black silk dresses, under a hood or modest shawl; others
+were habited in Indian fashion.
+
+Passepartout could not behold without a certain fright these women,
+charged, in groups, with conferring happiness on a single Mormon.  His
+common sense pitied, above all, the husband.  It seemed to him a
+terrible thing to have to guide so many wives at once across the
+vicissitudes of life, and to conduct them, as it were, in a body to the
+Mormon paradise with the prospect of seeing them in the company of the
+glorious Smith, who doubtless was the chief ornament of that delightful
+place, to all eternity.  He felt decidedly repelled from such a
+vocation, and he imagined--perhaps he was mistaken--that the fair ones
+of Salt Lake City cast rather alarming glances on his person.  Happily,
+his stay there was but brief.  At four the party found themselves again
+at the station, took their places in the train, and the whistle sounded
+for starting.  Just at the moment, however, that the locomotive wheels
+began to move, cries of "Stop! stop!" were heard.
+
+Trains, like time and tide, stop for no one.  The gentleman who uttered
+the cries was evidently a belated Mormon.  He was breathless with
+running.  Happily for him, the station had neither gates nor barriers.
+He rushed along the track, jumped on the rear platform of the train,
+and fell, exhausted, into one of the seats.
+
+Passepartout, who had been anxiously watching this amateur gymnast,
+approached him with lively interest, and learned that he had taken
+flight after an unpleasant domestic scene.
+
+When the Mormon had recovered his breath, Passepartout ventured to ask
+him politely how many wives he had; for, from the manner in which he
+had decamped, it might be thought that he had twenty at least.
+
+"One, sir," replied the Mormon, raising his arms heavenward--"one, and
+that was enough!"
+
+
+
+
+Chapter XXVIII
+
+IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN TO
+REASON
+
+
+The train, on leaving Great Salt Lake at Ogden, passed northward for an
+hour as far as Weber River, having completed nearly nine hundred miles
+from San Francisco.  From this point it took an easterly direction
+towards the jagged Wahsatch Mountains.  It was in the section included
+between this range and the Rocky Mountains that the American engineers
+found the most formidable difficulties in laying the road, and that the
+government granted a subsidy of forty-eight thousand dollars per mile,
+instead of sixteen thousand allowed for the work done on the plains.
+But the engineers, instead of violating nature, avoided its
+difficulties by winding around, instead of penetrating the rocks.  One
+tunnel only, fourteen thousand feet in length, was pierced in order to
+arrive at the great basin.
+
+The track up to this time had reached its highest elevation at the
+Great Salt Lake.  From this point it described a long curve, descending
+towards Bitter Creek Valley, to rise again to the dividing ridge of the
+waters between the Atlantic and the Pacific.  There were many creeks in
+this mountainous region, and it was necessary to cross Muddy Creek,
+Green Creek, and others, upon culverts.
+
+Passepartout grew more and more impatient as they went on, while Fix
+longed to get out of this difficult region, and was more anxious than
+Phileas Fogg himself to be beyond the danger of delays and accidents,
+and set foot on English soil.
+
+At ten o'clock at night the train stopped at Fort Bridger station, and
+twenty minutes later entered Wyoming Territory, following the valley of
+Bitter Creek throughout.  The next day, 7th December, they stopped for
+a quarter of an hour at Green River station.  Snow had fallen
+abundantly during the night, but, being mixed with rain, it had half
+melted, and did not interrupt their progress.  The bad weather,
+however, annoyed Passepartout; for the accumulation of snow, by
+blocking the wheels of the cars, would certainly have been fatal to Mr.
+Fogg's tour.
+
+"What an idea!" he said to himself.  "Why did my master make this
+journey in winter?  Couldn't he have waited for the good season to
+increase his chances?"
+
+While the worthy Frenchman was absorbed in the state of the sky and the
+depression of the temperature, Aouda was experiencing fears from a
+totally different cause.
+
+Several passengers had got off at Green River, and were walking up and
+down the platforms; and among these Aouda recognised Colonel Stamp
+Proctor, the same who had so grossly insulted Phileas Fogg at the San
+Francisco meeting.  Not wishing to be recognised, the young woman drew
+back from the window, feeling much alarm at her discovery.  She was
+attached to the man who, however coldly, gave her daily evidences of
+the most absolute devotion.  She did not comprehend, perhaps, the depth
+of the sentiment with which her protector inspired her, which she
+called gratitude, but which, though she was unconscious of it, was
+really more than that.  Her heart sank within her when she recognised
+the man whom Mr. Fogg desired, sooner or later, to call to account for
+his conduct.  Chance alone, it was clear, had brought Colonel Proctor
+on this train; but there he was, and it was necessary, at all hazards,
+that Phileas Fogg should not perceive his adversary.
+
+Aouda seized a moment when Mr. Fogg was asleep to tell Fix and
+Passepartout whom she had seen.
+
+"That Proctor on this train!" cried Fix.  "Well, reassure yourself,
+madam; before he settles with Mr. Fogg; he has got to deal with me!  It
+seems to me that I was the more insulted of the two."
+
+"And, besides," added Passepartout, "I'll take charge of him, colonel
+as he is."
+
+"Mr. Fix," resumed Aouda, "Mr. Fogg will allow no one to avenge him.
+He said that he would come back to America to find this man.  Should he
+perceive Colonel Proctor, we could not prevent a collision which might
+have terrible results.  He must not see him."
+
+"You are right, madam," replied Fix; "a meeting between them might ruin
+all.  Whether he were victorious or beaten, Mr. Fogg would be delayed,
+and--"
+
+"And," added Passepartout, "that would play the game of the gentlemen
+of the Reform Club.  In four days we shall be in New York.  Well, if my
+master does not leave this car during those four days, we may hope that
+chance will not bring him face to face with this confounded American.
+We must, if possible, prevent his stirring out of it."
+
+The conversation dropped.  Mr. Fogg had just woke up, and was looking
+out of the window.  Soon after Passepartout, without being heard by his
+master or Aouda, whispered to the detective, "Would you really fight
+for him?"
+
+"I would do anything," replied Fix, in a tone which betrayed determined
+will, "to get him back living to Europe!"
+
+Passepartout felt something like a shudder shoot through his frame, but
+his confidence in his master remained unbroken.
+
+Was there any means of detaining Mr. Fogg in the car, to avoid a
+meeting between him and the colonel?  It ought not to be a difficult
+task, since that gentleman was naturally sedentary and little curious.
+The detective, at least, seemed to have found a way; for, after a few
+moments, he said to Mr. Fogg, "These are long and slow hours, sir, that
+we are passing on the railway."
+
+"Yes," replied Mr. Fogg; "but they pass."
+
+"You were in the habit of playing whist," resumed Fix, "on the
+steamers."
+
+"Yes; but it would be difficult to do so here.  I have neither cards
+nor partners."
+
+"Oh, but we can easily buy some cards, for they are sold on all the
+American trains.  And as for partners, if madam plays--"
+
+"Certainly, sir," Aouda quickly replied; "I understand whist.  It is
+part of an English education."
+
+"I myself have some pretensions to playing a good game.  Well, here are
+three of us, and a dummy--"
+
+"As you please, sir," replied Phileas Fogg, heartily glad to resume his
+favourite pastime even on the railway.
+
+Passepartout was dispatched in search of the steward, and soon returned
+with two packs of cards, some pins, counters, and a shelf covered with
+cloth.
+
+The game commenced.  Aouda understood whist sufficiently well, and even
+received some compliments on her playing from Mr. Fogg.  As for the
+detective, he was simply an adept, and worthy of being matched against
+his present opponent.
+
+"Now," thought Passepartout, "we've got him.  He won't budge."
+
+At eleven in the morning the train had reached the dividing ridge of
+the waters at Bridger Pass, seven thousand five hundred and twenty-four
+feet above the level of the sea, one of the highest points attained by
+the track in crossing the Rocky Mountains.  After going about two
+hundred miles, the travellers at last found themselves on one of those
+vast plains which extend to the Atlantic, and which nature has made so
+propitious for laying the iron road.
+
+On the declivity of the Atlantic basin the first streams, branches of
+the North Platte River, already appeared.  The whole northern and
+eastern horizon was bounded by the immense semi-circular curtain which
+is formed by the southern portion of the Rocky Mountains, the highest
+being Laramie Peak.  Between this and the railway extended vast plains,
+plentifully irrigated.  On the right rose the lower spurs of the
+mountainous mass which extends southward to the sources of the Arkansas
+River, one of the great tributaries of the Missouri.
+
+At half-past twelve the travellers caught sight for an instant of Fort
+Halleck, which commands that section; and in a few more hours the Rocky
+Mountains were crossed.  There was reason to hope, then, that no
+accident would mark the journey through this difficult country.  The
+snow had ceased falling, and the air became crisp and cold.  Large
+birds, frightened by the locomotive, rose and flew off in the distance.
+No wild beast appeared on the plain.  It was a desert in its vast
+nakedness.
+
+After a comfortable breakfast, served in the car, Mr. Fogg and his
+partners had just resumed whist, when a violent whistling was heard,
+and the train stopped.  Passepartout put his head out of the door, but
+saw nothing to cause the delay; no station was in view.
+
+Aouda and Fix feared that Mr. Fogg might take it into his head to get
+out; but that gentleman contented himself with saying to his servant,
+"See what is the matter."
+
+Passepartout rushed out of the car.  Thirty or forty passengers had
+already descended, amongst them Colonel Stamp Proctor.
+
+The train had stopped before a red signal which blocked the way.  The
+engineer and conductor were talking excitedly with a signal-man, whom
+the station-master at Medicine Bow, the next stopping place, had sent
+on before.  The passengers drew around and took part in the discussion,
+in which Colonel Proctor, with his insolent manner, was conspicuous.
+
+Passepartout, joining the group, heard the signal-man say, "No! you
+can't pass.  The bridge at Medicine Bow is shaky, and would not bear
+the weight of the train."
+
+This was a suspension-bridge thrown over some rapids, about a mile from
+the place where they now were.  According to the signal-man, it was in
+a ruinous condition, several of the iron wires being broken; and it was
+impossible to risk the passage.  He did not in any way exaggerate the
+condition of the bridge.  It may be taken for granted that, rash as the
+Americans usually are, when they are prudent there is good reason for
+it.
+
+Passepartout, not daring to apprise his master of what he heard,
+listened with set teeth, immovable as a statue.
+
+"Hum!" cried Colonel Proctor; "but we are not going to stay here, I
+imagine, and take root in the snow?"
+
+"Colonel," replied the conductor, "we have telegraphed to Omaha for a
+train, but it is not likely that it will reach Medicine Bow in less
+than six hours."
+
+"Six hours!" cried Passepartout.
+
+"Certainly," returned the conductor, "besides, it will take us as long
+as that to reach Medicine Bow on foot."
+
+"But it is only a mile from here," said one of the passengers.
+
+"Yes, but it's on the other side of the river."
+
+"And can't we cross that in a boat?" asked the colonel.
+
+"That's impossible.  The creek is swelled by the rains.  It is a rapid,
+and we shall have to make a circuit of ten miles to the north to find a
+ford."
+
+The colonel launched a volley of oaths, denouncing the railway company
+and the conductor; and Passepartout, who was furious, was not
+disinclined to make common cause with him.  Here was an obstacle,
+indeed, which all his master's banknotes could not remove.
+
+There was a general disappointment among the passengers, who, without
+reckoning the delay, saw themselves compelled to trudge fifteen miles
+over a plain covered with snow.  They grumbled and protested, and would
+certainly have thus attracted Phileas Fogg's attention if he had not
+been completely absorbed in his game.
+
+Passepartout found that he could not avoid telling his master what had
+occurred, and, with hanging head, he was turning towards the car, when
+the engineer, a true Yankee, named Forster called out, "Gentlemen,
+perhaps there is a way, after all, to get over."
+
+"On the bridge?" asked a passenger.
+
+"On the bridge."
+
+"With our train?"
+
+"With our train."
+
+Passepartout stopped short, and eagerly listened to the engineer.
+
+"But the bridge is unsafe," urged the conductor.
+
+"No matter," replied Forster; "I think that by putting on the very
+highest speed we might have a chance of getting over."
+
+"The devil!" muttered Passepartout.
+
+But a number of the passengers were at once attracted by the engineer's
+proposal, and Colonel Proctor was especially delighted, and found the
+plan a very feasible one.  He told stories about engineers leaping
+their trains over rivers without bridges, by putting on full steam; and
+many of those present avowed themselves of the engineer's mind.
+
+"We have fifty chances out of a hundred of getting over," said one.
+
+"Eighty! ninety!"
+
+Passepartout was astounded, and, though ready to attempt anything to
+get over Medicine Creek, thought the experiment proposed a little too
+American.  "Besides," thought he, "there's a still more simple way, and
+it does not even occur to any of these people!  Sir," said he aloud to
+one of the passengers, "the engineer's plan seems to me a little
+dangerous, but--"
+
+"Eighty chances!" replied the passenger, turning his back on him.
+
+"I know it," said Passepartout, turning to another passenger, "but a
+simple idea--"
+
+"Ideas are no use," returned the American, shrugging his shoulders, "as
+the engineer assures us that we can pass."
+
+"Doubtless," urged Passepartout, "we can pass, but perhaps it would be
+more prudent--"
+
+"What!  Prudent!" cried Colonel Proctor, whom this word seemed to
+excite prodigiously.  "At full speed, don't you see, at full speed!"
+
+"I know--I see," repeated Passepartout; "but it would be, if not more
+prudent, since that word displeases you, at least more natural--"
+
+"Who!  What!  What's the matter with this fellow?" cried several.
+
+The poor fellow did not know to whom to address himself.
+
+"Are you afraid?" asked Colonel Proctor.
+
+"I afraid?  Very well; I will show these people that a Frenchman can be
+as American as they!"
+
+"All aboard!" cried the conductor.
+
+"Yes, all aboard!" repeated Passepartout, and immediately.  "But they
+can't prevent me from thinking that it would be more natural for us to
+cross the bridge on foot, and let the train come after!"
+
+But no one heard this sage reflection, nor would anyone have
+acknowledged its justice.  The passengers resumed their places in the
+cars.  Passepartout took his seat without telling what had passed.  The
+whist-players were quite absorbed in their game.
+
+The locomotive whistled vigorously; the engineer, reversing the steam,
+backed the train for nearly a mile--retiring, like a jumper, in order
+to take a longer leap.  Then, with another whistle, he began to move
+forward; the train increased its speed, and soon its rapidity became
+frightful; a prolonged screech issued from the locomotive; the piston
+worked up and down twenty strokes to the second.  They perceived that
+the whole train, rushing on at the rate of a hundred miles an hour,
+hardly bore upon the rails at all.
+
+And they passed over!  It was like a flash.  No one saw the bridge.
+The train leaped, so to speak, from one bank to the other, and the
+engineer could not stop it until it had gone five miles beyond the
+station.  But scarcely had the train passed the river, when the bridge,
+completely ruined, fell with a crash into the rapids of Medicine Bow.
+
+
+
+
+Chapter XXIX
+
+IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET WITH
+ON AMERICAN RAILROADS
+
+
+The train pursued its course, that evening, without interruption,
+passing Fort Saunders, crossing Cheyne Pass, and reaching Evans Pass.
+The road here attained the highest elevation of the journey, eight
+thousand and ninety-two feet above the level of the sea.  The
+travellers had now only to descend to the Atlantic by limitless plains,
+levelled by nature.  A branch of the "grand trunk" led off southward to
+Denver, the capital of Colorado.  The country round about is rich in
+gold and silver, and more than fifty thousand inhabitants are already
+settled there.
+
+Thirteen hundred and eighty-two miles had been passed over from San
+Francisco, in three days and three nights; four days and nights more
+would probably bring them to New York.  Phileas Fogg was not as yet
+behind-hand.
+
+During the night Camp Walbach was passed on the left; Lodge Pole Creek
+ran parallel with the road, marking the boundary between the
+territories of Wyoming and Colorado.  They entered Nebraska at eleven,
+passed near Sedgwick, and touched at Julesburg, on the southern branch
+of the Platte River.
+
+It was here that the Union Pacific Railroad was inaugurated on the 23rd
+of October, 1867, by the chief engineer, General Dodge.  Two powerful
+locomotives, carrying nine cars of invited guests, amongst whom was
+Thomas C. Durant, vice-president of the road, stopped at this point;
+cheers were given, the Sioux and Pawnees performed an imitation Indian
+battle, fireworks were let off, and the first number of the Railway
+Pioneer was printed by a press brought on the train.  Thus was
+celebrated the inauguration of this great railroad, a mighty instrument
+of progress and civilisation, thrown across the desert, and destined to
+link together cities and towns which do not yet exist.  The whistle of
+the locomotive, more powerful than Amphion's lyre, was about to bid
+them rise from American soil.
+
+Fort McPherson was left behind at eight in the morning, and three
+hundred and fifty-seven miles had yet to be traversed before reaching
+Omaha.  The road followed the capricious windings of the southern
+branch of the Platte River, on its left bank.  At nine the train
+stopped at the important town of North Platte, built between the two
+arms of the river, which rejoin each other around it and form a single
+artery, a large tributary, whose waters empty into the Missouri a
+little above Omaha.
+
+The one hundred and first meridian was passed.
+
+Mr. Fogg and his partners had resumed their game; no one--not even the
+dummy--complained of the length of the trip.  Fix had begun by winning
+several guineas, which he seemed likely to lose; but he showed himself
+a not less eager whist-player than Mr. Fogg.  During the morning,
+chance distinctly favoured that gentleman.  Trumps and honours were
+showered upon his hands.
+
+Once, having resolved on a bold stroke, he was on the point of playing
+a spade, when a voice behind him said, "I should play a diamond."
+
+Mr. Fogg, Aouda, and Fix raised their heads, and beheld Colonel Proctor.
+
+Stamp Proctor and Phileas Fogg recognised each other at once.
+
+"Ah! it's you, is it, Englishman?" cried the colonel; "it's you who are
+going to play a spade!"
+
+"And who plays it," replied Phileas Fogg coolly, throwing down the ten
+of spades.
+
+"Well, it pleases me to have it diamonds," replied Colonel Proctor, in
+an insolent tone.
+
+He made a movement as if to seize the card which had just been played,
+adding, "You don't understand anything about whist."
+
+"Perhaps I do, as well as another," said Phileas Fogg, rising.
+
+"You have only to try, son of John Bull," replied the colonel.
+
+Aouda turned pale, and her blood ran cold.  She seized Mr. Fogg's arm
+and gently pulled him back.  Passepartout was ready to pounce upon the
+American, who was staring insolently at his opponent.  But Fix got up,
+and, going to Colonel Proctor said, "You forget that it is I with whom
+you have to deal, sir; for it was I whom you not only insulted, but
+struck!"
+
+"Mr. Fix," said Mr. Fogg, "pardon me, but this affair is mine, and mine
+only.  The colonel has again insulted me, by insisting that I should
+not play a spade, and he shall give me satisfaction for it."
+
+"When and where you will," replied the American, "and with whatever
+weapon you choose."
+
+Aouda in vain attempted to retain Mr. Fogg; as vainly did the detective
+endeavour to make the quarrel his.  Passepartout wished to throw the
+colonel out of the window, but a sign from his master checked him.
+Phileas Fogg left the car, and the American followed him upon the
+platform.  "Sir," said Mr. Fogg to his adversary, "I am in a great
+hurry to get back to Europe, and any delay whatever will be greatly to
+my disadvantage."
+
+"Well, what's that to me?" replied Colonel Proctor.
+
+"Sir," said Mr. Fogg, very politely, "after our meeting at San
+Francisco, I determined to return to America and find you as soon as I
+had completed the business which called me to England."
+
+"Really!"
+
+"Will you appoint a meeting for six months hence?"
+
+"Why not ten years hence?"
+
+"I say six months," returned Phileas Fogg; "and I shall be at the place
+of meeting promptly."
+
+"All this is an evasion," cried Stamp Proctor.  "Now or never!"
+
+"Very good.  You are going to New York?"
+
+"No."
+
+"To Chicago?"
+
+"No."
+
+"To Omaha?"
+
+"What difference is it to you?  Do you know Plum Creek?"
+
+"No," replied Mr. Fogg.
+
+"It's the next station.  The train will be there in an hour, and will
+stop there ten minutes.  In ten minutes several revolver-shots could be
+exchanged."
+
+"Very well," said Mr. Fogg.  "I will stop at Plum Creek."
+
+"And I guess you'll stay there too," added the American insolently.
+
+"Who knows?" replied Mr. Fogg, returning to the car as coolly as usual.
+He began to reassure Aouda, telling her that blusterers were never to
+be feared, and begged Fix to be his second at the approaching duel, a
+request which the detective could not refuse.  Mr. Fogg resumed the
+interrupted game with perfect calmness.
+
+At eleven o'clock the locomotive's whistle announced that they were
+approaching Plum Creek station.  Mr. Fogg rose, and, followed by Fix,
+went out upon the platform.  Passepartout accompanied him, carrying a
+pair of revolvers.  Aouda remained in the car, as pale as death.
+
+The door of the next car opened, and Colonel Proctor appeared on the
+platform, attended by a Yankee of his own stamp as his second.  But
+just as the combatants were about to step from the train, the conductor
+hurried up, and shouted, "You can't get off, gentlemen!"
+
+"Why not?" asked the colonel.
+
+"We are twenty minutes late, and we shall not stop."
+
+"But I am going to fight a duel with this gentleman."
+
+"I am sorry," said the conductor; "but we shall be off at once.
+There's the bell ringing now."
+
+The train started.
+
+"I'm really very sorry, gentlemen," said the conductor.  "Under any
+other circumstances I should have been happy to oblige you.  But, after
+all, as you have not had time to fight here, why not fight as we go
+along?"
+
+"That wouldn't be convenient, perhaps, for this gentleman," said the
+colonel, in a jeering tone.
+
+"It would be perfectly so," replied Phileas Fogg.
+
+"Well, we are really in America," thought Passepartout, "and the
+conductor is a gentleman of the first order!"
+
+So muttering, he followed his master.
+
+The two combatants, their seconds, and the conductor passed through the
+cars to the rear of the train.  The last car was only occupied by a
+dozen passengers, whom the conductor politely asked if they would not
+be so kind as to leave it vacant for a few moments, as two gentlemen
+had an affair of honour to settle.  The passengers granted the request
+with alacrity, and straightway disappeared on the platform.
+
+The car, which was some fifty feet long, was very convenient for their
+purpose.  The adversaries might march on each other in the aisle, and
+fire at their ease.  Never was duel more easily arranged.  Mr. Fogg and
+Colonel Proctor, each provided with two six-barrelled revolvers,
+entered the car.  The seconds, remaining outside, shut them in.  They
+were to begin firing at the first whistle of the locomotive.  After an
+interval of two minutes, what remained of the two gentlemen would be
+taken from the car.
+
+Nothing could be more simple.  Indeed, it was all so simple that Fix
+and Passepartout felt their hearts beating as if they would crack.
+They were listening for the whistle agreed upon, when suddenly savage
+cries resounded in the air, accompanied by reports which certainly did
+not issue from the car where the duellists were.  The reports continued
+in front and the whole length of the train.  Cries of terror proceeded
+from the interior of the cars.
+
+Colonel Proctor and Mr. Fogg, revolvers in hand, hastily quitted their
+prison, and rushed forward where the noise was most clamorous.  They
+then perceived that the train was attacked by a band of Sioux.
+
+This was not the first attempt of these daring Indians, for more than
+once they had waylaid trains on the road.  A hundred of them had,
+according to their habit, jumped upon the steps without stopping the
+train, with the ease of a clown mounting a horse at full gallop.
+
+The Sioux were armed with guns, from which came the reports, to which
+the passengers, who were almost all armed, responded by revolver-shots.
+
+The Indians had first mounted the engine, and half stunned the engineer
+and stoker with blows from their muskets.  A Sioux chief, wishing to
+stop the train, but not knowing how to work the regulator, had opened
+wide instead of closing the steam-valve, and the locomotive was
+plunging forward with terrific velocity.
+
+The Sioux had at the same time invaded the cars, skipping like enraged
+monkeys over the roofs, thrusting open the doors, and fighting hand to
+hand with the passengers.  Penetrating the baggage-car, they pillaged
+it, throwing the trunks out of the train.  The cries and shots were
+constant.  The travellers defended themselves bravely; some of the cars
+were barricaded, and sustained a siege, like moving forts, carried
+along at a speed of a hundred miles an hour.
+
+Aouda behaved courageously from the first.  She defended herself like a
+true heroine with a revolver, which she shot through the broken windows
+whenever a savage made his appearance.  Twenty Sioux had fallen
+mortally wounded to the ground, and the wheels crushed those who fell
+upon the rails as if they had been worms.  Several passengers, shot or
+stunned, lay on the seats.
+
+It was necessary to put an end to the struggle, which had lasted for
+ten minutes, and which would result in the triumph of the Sioux if the
+train was not stopped.  Fort Kearney station, where there was a
+garrison, was only two miles distant; but, that once passed, the Sioux
+would be masters of the train between Fort Kearney and the station
+beyond.
+
+The conductor was fighting beside Mr. Fogg, when he was shot and fell.
+At the same moment he cried, "Unless the train is stopped in five
+minutes, we are lost!"
+
+"It shall be stopped," said Phileas Fogg, preparing to rush from the
+car.
+
+"Stay, monsieur," cried Passepartout; "I will go."
+
+Mr. Fogg had not time to stop the brave fellow, who, opening a door
+unperceived by the Indians, succeeded in slipping under the car; and
+while the struggle continued and the balls whizzed across each other
+over his head, he made use of his old acrobatic experience, and with
+amazing agility worked his way under the cars, holding on to the
+chains, aiding himself by the brakes and edges of the sashes, creeping
+from one car to another with marvellous skill, and thus gaining the
+forward end of the train.
+
+There, suspended by one hand between the baggage-car and the tender,
+with the other he loosened the safety chains; but, owing to the
+traction, he would never have succeeded in unscrewing the yoking-bar,
+had not a violent concussion jolted this bar out.  The train, now
+detached from the engine, remained a little behind, whilst the
+locomotive rushed forward with increased speed.
+
+Carried on by the force already acquired, the train still moved for
+several minutes; but the brakes were worked and at last they stopped,
+less than a hundred feet from Kearney station.
+
+The soldiers of the fort, attracted by the shots, hurried up; the Sioux
+had not expected them, and decamped in a body before the train entirely
+stopped.
+
+But when the passengers counted each other on the station platform
+several were found missing; among others the courageous Frenchman,
+whose devotion had just saved them.
+
+
+
+
+Chapter XXX
+
+IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+
+Three passengers including Passepartout had disappeared.  Had they been
+killed in the struggle?  Were they taken prisoners by the Sioux?  It
+was impossible to tell.
+
+There were many wounded, but none mortally.  Colonel Proctor was one of
+the most seriously hurt; he had fought bravely, and a ball had entered
+his groin.  He was carried into the station with the other wounded
+passengers, to receive such attention as could be of avail.
+
+Aouda was safe; and Phileas Fogg, who had been in the thickest of the
+fight, had not received a scratch.  Fix was slightly wounded in the
+arm.  But Passepartout was not to be found, and tears coursed down
+Aouda's cheeks.
+
+All the passengers had got out of the train, the wheels of which were
+stained with blood.  From the tyres and spokes hung ragged pieces of
+flesh.  As far as the eye could reach on the white plain behind, red
+trails were visible.  The last Sioux were disappearing in the south,
+along the banks of Republican River.
+
+Mr. Fogg, with folded arms, remained motionless.  He had a serious
+decision to make.  Aouda, standing near him, looked at him without
+speaking, and he understood her look.  If his servant was a prisoner,
+ought he not to risk everything to rescue him from the Indians?  "I
+will find him, living or dead," said he quietly to Aouda.
+
+"Ah, Mr.--Mr. Fogg!" cried she, clasping his hands and covering them
+with tears.
+
+"Living," added Mr. Fogg, "if we do not lose a moment."
+
+Phileas Fogg, by this resolution, inevitably sacrificed himself; he
+pronounced his own doom.  The delay of a single day would make him lose
+the steamer at New York, and his bet would be certainly lost.  But as
+he thought, "It is my duty," he did not hesitate.
+
+The commanding officer of Fort Kearney was there.  A hundred of his
+soldiers had placed themselves in a position to defend the station,
+should the Sioux attack it.
+
+"Sir," said Mr. Fogg to the captain, "three passengers have
+disappeared."
+
+"Dead?" asked the captain.
+
+"Dead or prisoners; that is the uncertainty which must be solved.  Do
+you propose to pursue the Sioux?"
+
+"That's a serious thing to do, sir," returned the captain.  "These
+Indians may retreat beyond the Arkansas, and I cannot leave the fort
+unprotected."
+
+"The lives of three men are in question, sir," said Phileas Fogg.
+
+"Doubtless; but can I risk the lives of fifty men to save three?"
+
+"I don't know whether you can, sir; but you ought to do so."
+
+"Nobody here," returned the other, "has a right to teach me my duty."
+
+"Very well," said Mr. Fogg, coldly.  "I will go alone."
+
+"You, sir!" cried Fix, coming up; "you go alone in pursuit of the
+Indians?"
+
+"Would you have me leave this poor fellow to perish--him to whom every
+one present owes his life?  I shall go."
+
+"No, sir, you shall not go alone," cried the captain, touched in spite
+of himself.  "No! you are a brave man.  Thirty volunteers!" he added,
+turning to the soldiers.
+
+The whole company started forward at once.  The captain had only to
+pick his men.  Thirty were chosen, and an old sergeant placed at their
+head.
+
+"Thanks, captain," said Mr. Fogg.
+
+"Will you let me go with you?" asked Fix.
+
+"Do as you please, sir.  But if you wish to do me a favour, you will
+remain with Aouda.  In case anything should happen to me--"
+
+A sudden pallor overspread the detective's face.  Separate himself from
+the man whom he had so persistently followed step by step!  Leave him
+to wander about in this desert!  Fix gazed attentively at Mr. Fogg,
+and, despite his suspicions and of the struggle which was going on
+within him, he lowered his eyes before that calm and frank look.
+
+"I will stay," said he.
+
+A few moments after, Mr. Fogg pressed the young woman's hand, and,
+having confided to her his precious carpet-bag, went off with the
+sergeant and his little squad.  But, before going, he had said to the
+soldiers, "My friends, I will divide five thousand dollars among you,
+if we save the prisoners."
+
+It was then a little past noon.
+
+Aouda retired to a waiting-room, and there she waited alone, thinking
+of the simple and noble generosity, the tranquil courage of Phileas
+Fogg.  He had sacrificed his fortune, and was now risking his life, all
+without hesitation, from duty, in silence.
+
+Fix did not have the same thoughts, and could scarcely conceal his
+agitation.  He walked feverishly up and down the platform, but soon
+resumed his outward composure.  He now saw the folly of which he had
+been guilty in letting Fogg go alone.  What!  This man, whom he had
+just followed around the world, was permitted now to separate himself
+from him!  He began to accuse and abuse himself, and, as if he were
+director of police, administered to himself a sound lecture for his
+greenness.
+
+"I have been an idiot!" he thought, "and this man will see it.  He has
+gone, and won't come back!  But how is it that I, Fix, who have in my
+pocket a warrant for his arrest, have been so fascinated by him?
+Decidedly, I am nothing but an ass!"
+
+So reasoned the detective, while the hours crept by all too slowly.  He
+did not know what to do.  Sometimes he was tempted to tell Aouda all;
+but he could not doubt how the young woman would receive his
+confidences.  What course should he take?  He thought of pursuing Fogg
+across the vast white plains; it did not seem impossible that he might
+overtake him.  Footsteps were easily printed on the snow!  But soon,
+under a new sheet, every imprint would be effaced.
+
+Fix became discouraged.  He felt a sort of insurmountable longing to
+abandon the game altogether.  He could now leave Fort Kearney station,
+and pursue his journey homeward in peace.
+
+Towards two o'clock in the afternoon, while it was snowing hard, long
+whistles were heard approaching from the east.  A great shadow,
+preceded by a wild light, slowly advanced, appearing still larger
+through the mist, which gave it a fantastic aspect.  No train was
+expected from the east, neither had there been time for the succour
+asked for by telegraph to arrive; the train from Omaha to San Francisco
+was not due till the next day.  The mystery was soon explained.
+
+The locomotive, which was slowly approaching with deafening whistles,
+was that which, having been detached from the train, had continued its
+route with such terrific rapidity, carrying off the unconscious
+engineer and stoker.  It had run several miles, when, the fire becoming
+low for want of fuel, the steam had slackened; and it had finally
+stopped an hour after, some twenty miles beyond Fort Kearney.  Neither
+the engineer nor the stoker was dead, and, after remaining for some
+time in their swoon, had come to themselves.  The train had then
+stopped.  The engineer, when he found himself in the desert, and the
+locomotive without cars, understood what had happened.  He could not
+imagine how the locomotive had become separated from the train; but he
+did not doubt that the train left behind was in distress.
+
+He did not hesitate what to do.  It would be prudent to continue on to
+Omaha, for it would be dangerous to return to the train, which the
+Indians might still be engaged in pillaging.  Nevertheless, he began to
+rebuild the fire in the furnace; the pressure again mounted, and the
+locomotive returned, running backwards to Fort Kearney.  This it was
+which was whistling in the mist.
+
+The travellers were glad to see the locomotive resume its place at the
+head of the train.  They could now continue the journey so terribly
+interrupted.
+
+Aouda, on seeing the locomotive come up, hurried out of the station,
+and asked the conductor, "Are you going to start?"
+
+"At once, madam."
+
+"But the prisoners, our unfortunate fellow-travellers--"
+
+"I cannot interrupt the trip," replied the conductor.  "We are already
+three hours behind time."
+
+"And when will another train pass here from San Francisco?"
+
+"To-morrow evening, madam."
+
+"To-morrow evening!  But then it will be too late!  We must wait--"
+
+"It is impossible," responded the conductor.  "If you wish to go,
+please get in."
+
+"I will not go," said Aouda.
+
+Fix had heard this conversation.  A little while before, when there was
+no prospect of proceeding on the journey, he had made up his mind to
+leave Fort Kearney; but now that the train was there, ready to start,
+and he had only to take his seat in the car, an irresistible influence
+held him back.  The station platform burned his feet, and he could not
+stir.  The conflict in his mind again began; anger and failure stifled
+him.  He wished to struggle on to the end.
+
+Meanwhile the passengers and some of the wounded, among them Colonel
+Proctor, whose injuries were serious, had taken their places in the
+train.  The buzzing of the over-heated boiler was heard, and the steam
+was escaping from the valves.  The engineer whistled, the train
+started, and soon disappeared, mingling its white smoke with the eddies
+of the densely falling snow.
+
+The detective had remained behind.
+
+Several hours passed.  The weather was dismal, and it was very cold.
+Fix sat motionless on a bench in the station; he might have been
+thought asleep.  Aouda, despite the storm, kept coming out of the
+waiting-room, going to the end of the platform, and peering through the
+tempest of snow, as if to pierce the mist which narrowed the horizon
+around her, and to hear, if possible, some welcome sound.  She heard
+and saw nothing.  Then she would return, chilled through, to issue out
+again after the lapse of a few moments, but always in vain.
+
+Evening came, and the little band had not returned.  Where could they
+be?  Had they found the Indians, and were they having a conflict with
+them, or were they still wandering amid the mist?  The commander of the
+fort was anxious, though he tried to conceal his apprehensions.  As
+night approached, the snow fell less plentifully, but it became
+intensely cold.  Absolute silence rested on the plains.  Neither flight
+of bird nor passing of beast troubled the perfect calm.
+
+Throughout the night Aouda, full of sad forebodings, her heart stifled
+with anguish, wandered about on the verge of the plains.  Her
+imagination carried her far off, and showed her innumerable dangers.
+What she suffered through the long hours it would be impossible to
+describe.
+
+Fix remained stationary in the same place, but did not sleep.  Once a
+man approached and spoke to him, and the detective merely replied by
+shaking his head.
+
+Thus the night passed.  At dawn, the half-extinguished disc of the sun
+rose above a misty horizon; but it was now possible to recognise
+objects two miles off.  Phileas Fogg and the squad had gone southward;
+in the south all was still vacancy.  It was then seven o'clock.
+
+The captain, who was really alarmed, did not know what course to take.
+
+Should he send another detachment to the rescue of the first?  Should
+he sacrifice more men, with so few chances of saving those already
+sacrificed?  His hesitation did not last long, however.  Calling one of
+his lieutenants, he was on the point of ordering a reconnaissance, when
+gunshots were heard.  Was it a signal?  The soldiers rushed out of the
+fort, and half a mile off they perceived a little band returning in
+good order.
+
+Mr. Fogg was marching at their head, and just behind him were
+Passepartout and the other two travellers, rescued from the Sioux.
+
+They had met and fought the Indians ten miles south of Fort Kearney.
+Shortly before the detachment arrived, Passepartout and his companions
+had begun to struggle with their captors, three of whom the Frenchman
+had felled with his fists, when his master and the soldiers hastened up
+to their relief.
+
+All were welcomed with joyful cries.  Phileas Fogg distributed the
+reward he had promised to the soldiers, while Passepartout, not without
+reason, muttered to himself, "It must certainly be confessed that I
+cost my master dear!"
+
+Fix, without saying a word, looked at Mr. Fogg, and it would have been
+difficult to analyse the thoughts which struggled within him.  As for
+Aouda, she took her protector's hand and pressed it in her own, too
+much moved to speak.
+
+Meanwhile, Passepartout was looking about for the train; he thought he
+should find it there, ready to start for Omaha, and he hoped that the
+time lost might be regained.
+
+"The train! the train!" cried he.
+
+"Gone," replied Fix.
+
+"And when does the next train pass here?" said Phileas Fogg.
+
+"Not till this evening."
+
+"Ah!" returned the impassible gentleman quietly.
+
+
+
+
+Chapter XXXI
+
+IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS OF
+PHILEAS FOGG
+
+
+Phileas Fogg found himself twenty hours behind time.  Passepartout, the
+involuntary cause of this delay, was desperate.  He had ruined his
+master!
+
+At this moment the detective approached Mr. Fogg, and, looking him
+intently in the face, said:
+
+"Seriously, sir, are you in great haste?"
+
+"Quite seriously."
+
+"I have a purpose in asking," resumed Fix.  "Is it absolutely necessary
+that you should be in New York on the 11th, before nine o'clock in the
+evening, the time that the steamer leaves for Liverpool?"
+
+"It is absolutely necessary."
+
+"And, if your journey had not been interrupted by these Indians, you
+would have reached New York on the morning of the 11th?"
+
+"Yes; with eleven hours to spare before the steamer left."
+
+"Good! you are therefore twenty hours behind.  Twelve from twenty
+leaves eight.  You must regain eight hours.  Do you wish to try to do
+so?"
+
+"On foot?" asked Mr. Fogg.
+
+"No; on a sledge," replied Fix.  "On a sledge with sails.  A man has
+proposed such a method to me."
+
+It was the man who had spoken to Fix during the night, and whose offer
+he had refused.
+
+Phileas Fogg did not reply at once; but Fix, having pointed out the
+man, who was walking up and down in front of the station, Mr. Fogg went
+up to him.  An instant after, Mr. Fogg and the American, whose name was
+Mudge, entered a hut built just below the fort.
+
+There Mr. Fogg examined a curious vehicle, a kind of frame on two long
+beams, a little raised in front like the runners of a sledge, and upon
+which there was room for five or six persons.  A high mast was fixed on
+the frame, held firmly by metallic lashings, to which was attached a
+large brigantine sail.  This mast held an iron stay upon which to hoist
+a jib-sail.  Behind, a sort of rudder served to guide the vehicle.  It
+was, in short, a sledge rigged like a sloop.  During the winter, when
+the trains are blocked up by the snow, these sledges make extremely
+rapid journeys across the frozen plains from one station to another.
+Provided with more sails than a cutter, and with the wind behind them,
+they slip over the surface of the prairies with a speed equal if not
+superior to that of the express trains.
+
+Mr. Fogg readily made a bargain with the owner of this land-craft.  The
+wind was favourable, being fresh, and blowing from the west.  The snow
+had hardened, and Mudge was very confident of being able to transport
+Mr. Fogg in a few hours to Omaha.  Thence the trains eastward run
+frequently to Chicago and New York.  It was not impossible that the
+lost time might yet be recovered; and such an opportunity was not to be
+rejected.
+
+Not wishing to expose Aouda to the discomforts of travelling in the
+open air, Mr. Fogg proposed to leave her with Passepartout at Fort
+Kearney, the servant taking upon himself to escort her to Europe by a
+better route and under more favourable conditions.  But Aouda refused
+to separate from Mr. Fogg, and Passepartout was delighted with her
+decision; for nothing could induce him to leave his master while Fix
+was with him.
+
+It would be difficult to guess the detective's thoughts.  Was this
+conviction shaken by Phileas Fogg's return, or did he still regard him
+as an exceedingly shrewd rascal, who, his journey round the world
+completed, would think himself absolutely safe in England?  Perhaps
+Fix's opinion of Phileas Fogg was somewhat modified; but he was
+nevertheless resolved to do his duty, and to hasten the return of the
+whole party to England as much as possible.
+
+At eight o'clock the sledge was ready to start.  The passengers took
+their places on it, and wrapped themselves up closely in their
+travelling-cloaks.  The two great sails were hoisted, and under the
+pressure of the wind the sledge slid over the hardened snow with a
+velocity of forty miles an hour.
+
+The distance between Fort Kearney and Omaha, as the birds fly, is at
+most two hundred miles.  If the wind held good, the distance might be
+traversed in five hours; if no accident happened the sledge might reach
+Omaha by one o'clock.
+
+What a journey!  The travellers, huddled close together, could not
+speak for the cold, intensified by the rapidity at which they were
+going.  The sledge sped on as lightly as a boat over the waves.  When
+the breeze came skimming the earth the sledge seemed to be lifted off
+the ground by its sails.  Mudge, who was at the rudder, kept in a
+straight line, and by a turn of his hand checked the lurches which the
+vehicle had a tendency to make.  All the sails were up, and the jib was
+so arranged as not to screen the brigantine.  A top-mast was hoisted,
+and another jib, held out to the wind, added its force to the other
+sails.  Although the speed could not be exactly estimated, the sledge
+could not be going at less than forty miles an hour.
+
+"If nothing breaks," said Mudge, "we shall get there!"
+
+Mr. Fogg had made it for Mudge's interest to reach Omaha within the
+time agreed on, by the offer of a handsome reward.
+
+The prairie, across which the sledge was moving in a straight line, was
+as flat as a sea.  It seemed like a vast frozen lake.  The railroad
+which ran through this section ascended from the south-west to the
+north-west by Great Island, Columbus, an important Nebraska town,
+Schuyler, and Fremont, to Omaha.  It followed throughout the right bank
+of the Platte River.  The sledge, shortening this route, took a chord
+of the arc described by the railway.  Mudge was not afraid of being
+stopped by the Platte River, because it was frozen.  The road, then,
+was quite clear of obstacles, and Phileas Fogg had but two things to
+fear--an accident to the sledge, and a change or calm in the wind.
+
+But the breeze, far from lessening its force, blew as if to bend the
+mast, which, however, the metallic lashings held firmly.  These
+lashings, like the chords of a stringed instrument, resounded as if
+vibrated by a violin bow.  The sledge slid along in the midst of a
+plaintively intense melody.
+
+"Those chords give the fifth and the octave," said Mr. Fogg.
+
+These were the only words he uttered during the journey.  Aouda, cosily
+packed in furs and cloaks, was sheltered as much as possible from the
+attacks of the freezing wind.  As for Passepartout, his face was as red
+as the sun's disc when it sets in the mist, and he laboriously inhaled
+the biting air.  With his natural buoyancy of spirits, he began to hope
+again.  They would reach New York on the evening, if not on the
+morning, of the 11th, and there was still some chances that it would be
+before the steamer sailed for Liverpool.
+
+Passepartout even felt a strong desire to grasp his ally, Fix, by the
+hand.  He remembered that it was the detective who procured the sledge,
+the only means of reaching Omaha in time; but, checked by some
+presentiment, he kept his usual reserve.  One thing, however,
+Passepartout would never forget, and that was the sacrifice which Mr.
+Fogg had made, without hesitation, to rescue him from the Sioux.  Mr.
+Fogg had risked his fortune and his life. No!  His servant would never
+forget that!
+
+While each of the party was absorbed in reflections so different, the
+sledge flew past over the vast carpet of snow.  The creeks it passed
+over were not perceived.  Fields and streams disappeared under the
+uniform whiteness.  The plain was absolutely deserted.  Between the
+Union Pacific road and the branch which unites Kearney with Saint
+Joseph it formed a great uninhabited island.  Neither village, station,
+nor fort appeared.  From time to time they sped by some phantom-like
+tree, whose white skeleton twisted and rattled in the wind.  Sometimes
+flocks of wild birds rose, or bands of gaunt, famished, ferocious
+prairie-wolves ran howling after the sledge.  Passepartout, revolver in
+hand, held himself ready to fire on those which came too near.  Had an
+accident then happened to the sledge, the travellers, attacked by these
+beasts, would have been in the most terrible danger; but it held on its
+even course, soon gained on the wolves, and ere long left the howling
+band at a safe distance behind.
+
+About noon Mudge perceived by certain landmarks that he was crossing
+the Platte River.  He said nothing, but he felt certain that he was now
+within twenty miles of Omaha.  In less than an hour he left the rudder
+and furled his sails, whilst the sledge, carried forward by the great
+impetus the wind had given it, went on half a mile further with its
+sails unspread.
+
+It stopped at last, and Mudge, pointing to a mass of roofs white with
+snow, said: "We have got there!"
+
+Arrived!  Arrived at the station which is in daily communication, by
+numerous trains, with the Atlantic seaboard!
+
+Passepartout and Fix jumped off, stretched their stiffened limbs, and
+aided Mr. Fogg and the young woman to descend from the sledge.  Phileas
+Fogg generously rewarded Mudge, whose hand Passepartout warmly grasped,
+and the party directed their steps to the Omaha railway station.
+
+The Pacific Railroad proper finds its terminus at this important
+Nebraska town.  Omaha is connected with Chicago by the Chicago and Rock
+Island Railroad, which runs directly east, and passes fifty stations.
+
+A train was ready to start when Mr. Fogg and his party reached the
+station, and they only had time to get into the cars.  They had seen
+nothing of Omaha; but Passepartout confessed to himself that this was
+not to be regretted, as they were not travelling to see the sights.
+
+The train passed rapidly across the State of Iowa, by Council Bluffs,
+Des Moines, and Iowa City.  During the night it crossed the Mississippi
+at Davenport, and by Rock Island entered Illinois.  The next day, which
+was the 10th, at four o'clock in the evening, it reached Chicago,
+already risen from its ruins, and more proudly seated than ever on the
+borders of its beautiful Lake Michigan.
+
+Nine hundred miles separated Chicago from New York; but trains are not
+wanting at Chicago.  Mr. Fogg passed at once from one to the other, and
+the locomotive of the Pittsburgh, Fort Wayne, and Chicago Railway left
+at full speed, as if it fully comprehended that that gentleman had no
+time to lose.  It traversed Indiana, Ohio, Pennsylvania, and New Jersey
+like a flash, rushing through towns with antique names, some of which
+had streets and car-tracks, but as yet no houses.  At last the Hudson
+came into view; and, at a quarter-past eleven in the evening of the
+11th, the train stopped in the station on the right bank of the river,
+before the very pier of the Cunard line.
+
+The China, for Liverpool, had started three-quarters of an hour before!
+
+
+
+
+Chapter XXXII
+
+IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD FORTUNE
+
+
+The China, in leaving, seemed to have carried off Phileas Fogg's last
+hope.  None of the other steamers were able to serve his projects.  The
+Pereire, of the French Transatlantic Company, whose admirable steamers
+are equal to any in speed and comfort, did not leave until the 14th;
+the Hamburg boats did not go directly to Liverpool or London, but to
+Havre; and the additional trip from Havre to Southampton would render
+Phileas Fogg's last efforts of no avail.  The Inman steamer did not
+depart till the next day, and could not cross the Atlantic in time to
+save the wager.
+
+Mr. Fogg learned all this in consulting his Bradshaw, which gave him
+the daily movements of the trans-Atlantic steamers.
+
+Passepartout was crushed; it overwhelmed him to lose the boat by
+three-quarters of an hour.  It was his fault, for, instead of helping
+his master, he had not ceased putting obstacles in his path!  And when
+he recalled all the incidents of the tour, when he counted up the sums
+expended in pure loss and on his own account, when he thought that the
+immense stake, added to the heavy charges of this useless journey,
+would completely ruin Mr. Fogg, he overwhelmed himself with bitter
+self-accusations.  Mr. Fogg, however, did not reproach him; and, on
+leaving the Cunard pier, only said: "We will consult about what is best
+to-morrow.  Come."
+
+The party crossed the Hudson in the Jersey City ferryboat, and drove in
+a carriage to the St. Nicholas Hotel, on Broadway.  Rooms were engaged,
+and the night passed, briefly to Phileas Fogg, who slept profoundly,
+but very long to Aouda and the others, whose agitation did not permit
+them to rest.
+
+The next day was the 12th of December.  From seven in the morning of
+the 12th to a quarter before nine in the evening of the 21st there were
+nine days, thirteen hours, and forty-five minutes.  If Phileas Fogg had
+left in the China, one of the fastest steamers on the Atlantic, he
+would have reached Liverpool, and then London, within the period agreed
+upon.
+
+Mr. Fogg left the hotel alone, after giving Passepartout instructions
+to await his return, and inform Aouda to be ready at an instant's
+notice.  He proceeded to the banks of the Hudson, and looked about
+among the vessels moored or anchored in the river, for any that were
+about to depart.  Several had departure signals, and were preparing to
+put to sea at morning tide; for in this immense and admirable port
+there is not one day in a hundred that vessels do not set out for every
+quarter of the globe.  But they were mostly sailing vessels, of which,
+of course, Phileas Fogg could make no use.
+
+He seemed about to give up all hope, when he espied, anchored at the
+Battery, a cable's length off at most, a trading vessel, with a screw,
+well-shaped, whose funnel, puffing a cloud of smoke, indicated that she
+was getting ready for departure.
+
+Phileas Fogg hailed a boat, got into it, and soon found himself on
+board the Henrietta, iron-hulled, wood-built above.  He ascended to the
+deck, and asked for the captain, who forthwith presented himself.  He
+was a man of fifty, a sort of sea-wolf, with big eyes, a complexion of
+oxidised copper, red hair and thick neck, and a growling voice.
+
+"The captain?" asked Mr. Fogg.
+
+"I am the captain."
+
+"I am Phileas Fogg, of London."
+
+"And I am Andrew Speedy, of Cardiff."
+
+"You are going to put to sea?"
+
+"In an hour."
+
+"You are bound for--"
+
+"Bordeaux."
+
+"And your cargo?"
+
+"No freight.  Going in ballast."
+
+"Have you any passengers?"
+
+"No passengers.  Never have passengers.  Too much in the way."
+
+"Is your vessel a swift one?"
+
+"Between eleven and twelve knots.  The Henrietta, well known."
+
+"Will you carry me and three other persons to Liverpool?"
+
+"To Liverpool?  Why not to China?"
+
+"I said Liverpool."
+
+"No!"
+
+"No?"
+
+"No.  I am setting out for Bordeaux, and shall go to Bordeaux."
+
+"Money is no object?"
+
+"None."
+
+The captain spoke in a tone which did not admit of a reply.
+
+"But the owners of the Henrietta--" resumed Phileas Fogg.
+
+"The owners are myself," replied the captain.  "The vessel belongs to
+me."
+
+"I will freight it for you."
+
+"No."
+
+"I will buy it of you."
+
+"No."
+
+Phileas Fogg did not betray the least disappointment; but the situation
+was a grave one.  It was not at New York as at Hong Kong, nor with the
+captain of the Henrietta as with the captain of the Tankadere.  Up to
+this time money had smoothed away every obstacle.  Now money failed.
+
+Still, some means must be found to cross the Atlantic on a boat, unless
+by balloon--which would have been venturesome, besides not being
+capable of being put in practice.  It seemed that Phileas Fogg had an
+idea, for he said to the captain, "Well, will you carry me to Bordeaux?"
+
+"No, not if you paid me two hundred dollars."
+
+"I offer you two thousand."
+
+"Apiece?"
+
+"Apiece."
+
+"And there are four of you?"
+
+"Four."
+
+Captain Speedy began to scratch his head.  There were eight thousand
+dollars to gain, without changing his route; for which it was well
+worth conquering the repugnance he had for all kinds of passengers.
+Besides, passengers at two thousand dollars are no longer passengers,
+but valuable merchandise.  "I start at nine o'clock," said Captain
+Speedy, simply.  "Are you and your party ready?"
+
+"We will be on board at nine o'clock," replied, no less simply, Mr.
+Fogg.
+
+It was half-past eight.  To disembark from the Henrietta, jump into a
+hack, hurry to the St. Nicholas, and return with Aouda, Passepartout,
+and even the inseparable Fix was the work of a brief time, and was
+performed by Mr. Fogg with the coolness which never abandoned him.
+They were on board when the Henrietta made ready to weigh anchor.
+
+When Passepartout heard what this last voyage was going to cost, he
+uttered a prolonged "Oh!" which extended throughout his vocal gamut.
+
+As for Fix, he said to himself that the Bank of England would certainly
+not come out of this affair well indemnified.  When they reached
+England, even if Mr. Fogg did not throw some handfuls of bank-bills
+into the sea, more than seven thousand pounds would have been spent!
+
+
+
+
+Chapter XXXIII
+
+IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+
+An hour after, the Henrietta passed the lighthouse which marks the
+entrance of the Hudson, turned the point of Sandy Hook, and put to sea.
+During the day she skirted Long Island, passed Fire Island, and
+directed her course rapidly eastward.
+
+At noon the next day, a man mounted the bridge to ascertain the
+vessel's position.  It might be thought that this was Captain Speedy.
+Not the least in the world.  It was Phileas Fogg, Esquire.  As for
+Captain Speedy, he was shut up in his cabin under lock and key, and was
+uttering loud cries, which signified an anger at once pardonable and
+excessive.
+
+What had happened was very simple.  Phileas Fogg wished to go to
+Liverpool, but the captain would not carry him there.  Then Phileas
+Fogg had taken passage for Bordeaux, and, during the thirty hours he
+had been on board, had so shrewdly managed with his banknotes that the
+sailors and stokers, who were only an occasional crew, and were not on
+the best terms with the captain, went over to him in a body.  This was
+why Phileas Fogg was in command instead of Captain Speedy; why the
+captain was a prisoner in his cabin; and why, in short, the Henrietta
+was directing her course towards Liverpool.  It was very clear, to see
+Mr. Fogg manage the craft, that he had been a sailor.
+
+How the adventure ended will be seen anon.  Aouda was anxious, though
+she said nothing.  As for Passepartout, he thought Mr. Fogg's manoeuvre
+simply glorious.  The captain had said "between eleven and twelve
+knots," and the Henrietta confirmed his prediction.
+
+If, then--for there were "ifs" still--the sea did not become too
+boisterous, if the wind did not veer round to the east, if no accident
+happened to the boat or its machinery, the Henrietta might cross the
+three thousand miles from New York to Liverpool in the nine days,
+between the 12th and the 21st of December.  It is true that, once
+arrived, the affair on board the Henrietta, added to that of the Bank
+of England, might create more difficulties for Mr. Fogg than he
+imagined or could desire.
+
+During the first days, they went along smoothly enough.  The sea was
+not very unpropitious, the wind seemed stationary in the north-east,
+the sails were hoisted, and the Henrietta ploughed across the waves
+like a real trans-Atlantic steamer.
+
+Passepartout was delighted.  His master's last exploit, the
+consequences of which he ignored, enchanted him.  Never had the crew
+seen so jolly and dexterous a fellow.  He formed warm friendships with
+the sailors, and amazed them with his acrobatic feats.  He thought they
+managed the vessel like gentlemen, and that the stokers fired up like
+heroes.  His loquacious good-humour infected everyone.  He had
+forgotten the past, its vexations and delays.  He only thought of the
+end, so nearly accomplished; and sometimes he boiled over with
+impatience, as if heated by the furnaces of the Henrietta.  Often,
+also, the worthy fellow revolved around Fix, looking at him with a
+keen, distrustful eye; but he did not speak to him, for their old
+intimacy no longer existed.
+
+Fix, it must be confessed, understood nothing of what was going on.
+The conquest of the Henrietta, the bribery of the crew, Fogg managing
+the boat like a skilled seaman, amazed and confused him.  He did not
+know what to think.  For, after all, a man who began by stealing
+fifty-five thousand pounds might end by stealing a vessel; and Fix was
+not unnaturally inclined to conclude that the Henrietta under Fogg's
+command, was not going to Liverpool at all, but to some part of the
+world where the robber, turned into a pirate, would quietly put himself
+in safety.  The conjecture was at least a plausible one, and the
+detective began to seriously regret that he had embarked on the affair.
+
+As for Captain Speedy, he continued to howl and growl in his cabin; and
+Passepartout, whose duty it was to carry him his meals, courageous as
+he was, took the greatest precautions.  Mr. Fogg did not seem even to
+know that there was a captain on board.
+
+On the 13th they passed the edge of the Banks of Newfoundland, a
+dangerous locality; during the winter, especially, there are frequent
+fogs and heavy gales of wind.  Ever since the evening before the
+barometer, suddenly falling, had indicated an approaching change in the
+atmosphere; and during the night the temperature varied, the cold
+became sharper, and the wind veered to the south-east.
+
+This was a misfortune.  Mr. Fogg, in order not to deviate from his
+course, furled his sails and increased the force of the steam; but the
+vessel's speed slackened, owing to the state of the sea, the long waves
+of which broke against the stern.  She pitched violently, and this
+retarded her progress.  The breeze little by little swelled into a
+tempest, and it was to be feared that the Henrietta might not be able
+to maintain herself upright on the waves.
+
+Passepartout's visage darkened with the skies, and for two days the
+poor fellow experienced constant fright.  But Phileas Fogg was a bold
+mariner, and knew how to maintain headway against the sea; and he kept
+on his course, without even decreasing his steam.  The Henrietta, when
+she could not rise upon the waves, crossed them, swamping her deck, but
+passing safely.  Sometimes the screw rose out of the water, beating its
+protruding end, when a mountain of water raised the stern above the
+waves; but the craft always kept straight ahead.
+
+The wind, however, did not grow as boisterous as might have been
+feared; it was not one of those tempests which burst, and rush on with
+a speed of ninety miles an hour.  It continued fresh, but, unhappily,
+it remained obstinately in the south-east, rendering the sails useless.
+
+The 16th of December was the seventy-fifth day since Phileas Fogg's
+departure from London, and the Henrietta had not yet been seriously
+delayed.  Half of the voyage was almost accomplished, and the worst
+localities had been passed.  In summer, success would have been
+well-nigh certain.  In winter, they were at the mercy of the bad
+season.  Passepartout said nothing; but he cherished hope in secret,
+and comforted himself with the reflection that, if the wind failed
+them, they might still count on the steam.
+
+On this day the engineer came on deck, went up to Mr. Fogg, and began
+to speak earnestly with him.  Without knowing why it was a
+presentiment, perhaps Passepartout became vaguely uneasy.  He would
+have given one of his ears to hear with the other what the engineer was
+saying.  He finally managed to catch a few words, and was sure he heard
+his master say, "You are certain of what you tell me?"
+
+"Certain, sir," replied the engineer.  "You must remember that, since
+we started, we have kept up hot fires in all our furnaces, and, though
+we had coal enough to go on short steam from New York to Bordeaux, we
+haven't enough to go with all steam from New York to Liverpool." "I
+will consider," replied Mr. Fogg.
+
+Passepartout understood it all; he was seized with mortal anxiety.  The
+coal was giving out!  "Ah, if my master can get over that," muttered
+he, "he'll be a famous man!"  He could not help imparting to Fix what
+he had overheard.
+
+"Then you believe that we really are going to Liverpool?"
+
+"Of course."
+
+"Ass!" replied the detective, shrugging his shoulders and turning on
+his heel.
+
+Passepartout was on the point of vigorously resenting the epithet, the
+reason of which he could not for the life of him comprehend; but he
+reflected that the unfortunate Fix was probably very much disappointed
+and humiliated in his self-esteem, after having so awkwardly followed a
+false scent around the world, and refrained.
+
+And now what course would Phileas Fogg adopt?  It was difficult to
+imagine.  Nevertheless he seemed to have decided upon one, for that
+evening he sent for the engineer, and said to him, "Feed all the fires
+until the coal is exhausted."
+
+A few moments after, the funnel of the Henrietta vomited forth torrents
+of smoke.  The vessel continued to proceed with all steam on; but on
+the 18th, the engineer, as he had predicted, announced that the coal
+would give out in the course of the day.
+
+"Do not let the fires go down," replied Mr. Fogg.  "Keep them up to the
+last.  Let the valves be filled."
+
+Towards noon Phileas Fogg, having ascertained their position, called
+Passepartout, and ordered him to go for Captain Speedy.  It was as if
+the honest fellow had been commanded to unchain a tiger.  He went to
+the poop, saying to himself, "He will be like a madman!"
+
+In a few moments, with cries and oaths, a bomb appeared on the
+poop-deck.  The bomb was Captain Speedy.  It was clear that he was on
+the point of bursting.  "Where are we?"  were the first words his anger
+permitted him to utter.  Had the poor man been an apoplectic, he could
+never have recovered from his paroxysm of wrath.
+
+"Where are we?" he repeated, with purple face.
+
+"Seven hundred and seven miles from Liverpool," replied Mr. Fogg, with
+imperturbable calmness.
+
+"Pirate!" cried Captain Speedy.
+
+"I have sent for you, sir--"
+
+"Pickaroon!"
+
+"--sir," continued Mr. Fogg, "to ask you to sell me your vessel."
+
+"No!  By all the devils, no!"
+
+"But I shall be obliged to burn her."
+
+"Burn the Henrietta!"
+
+"Yes; at least the upper part of her.  The coal has given out."
+
+"Burn my vessel!" cried Captain Speedy, who could scarcely pronounce
+the words.  "A vessel worth fifty thousand dollars!"
+
+"Here are sixty thousand," replied Phileas Fogg, handing the captain a
+roll of bank-bills.  This had a prodigious effect on Andrew Speedy.  An
+American can scarcely remain unmoved at the sight of sixty thousand
+dollars.  The captain forgot in an instant his anger, his imprisonment,
+and all his grudges against his passenger.  The Henrietta was twenty
+years old; it was a great bargain.  The bomb would not go off after
+all.  Mr. Fogg had taken away the match.
+
+"And I shall still have the iron hull," said the captain in a softer
+tone.
+
+"The iron hull and the engine.  Is it agreed?"
+
+"Agreed."
+
+And Andrew Speedy, seizing the banknotes, counted them and consigned
+them to his pocket.
+
+During this colloquy, Passepartout was as white as a sheet, and Fix
+seemed on the point of having an apoplectic fit.  Nearly twenty
+thousand pounds had been expended, and Fogg left the hull and engine to
+the captain, that is, near the whole value of the craft!  It was true,
+however, that fifty-five thousand pounds had been stolen from the Bank.
+
+When Andrew Speedy had pocketed the money, Mr. Fogg said to him, "Don't
+let this astonish you, sir.  You must know that I shall lose twenty
+thousand pounds, unless I arrive in London by a quarter before nine on
+the evening of the 21st of December.  I missed the steamer at New York,
+and as you refused to take me to Liverpool--"
+
+"And I did well!" cried Andrew Speedy; "for I have gained at least
+forty thousand dollars by it!"  He added, more sedately, "Do you know
+one thing, Captain--"
+
+"Fogg."
+
+"Captain Fogg, you've got something of the Yankee about you."
+
+And, having paid his passenger what he considered a high compliment, he
+was going away, when Mr. Fogg said, "The vessel now belongs to me?"
+
+"Certainly, from the keel to the truck of the masts--all the wood, that
+is."
+
+"Very well.  Have the interior seats, bunks, and frames pulled down,
+and burn them."
+
+It was necessary to have dry wood to keep the steam up to the adequate
+pressure, and on that day the poop, cabins, bunks, and the spare deck
+were sacrificed.  On the next day, the 19th of December, the masts,
+rafts, and spars were burned; the crew worked lustily, keeping up the
+fires.  Passepartout hewed, cut, and sawed away with all his might.
+There was a perfect rage for demolition.
+
+The railings, fittings, the greater part of the deck, and top sides
+disappeared on the 20th, and the Henrietta was now only a flat hulk.
+But on this day they sighted the Irish coast and Fastnet Light.  By ten
+in the evening they were passing Queenstown.  Phileas Fogg had only
+twenty-four hours more in which to get to London; that length of time
+was necessary to reach Liverpool, with all steam on.  And the steam was
+about to give out altogether!
+
+"Sir," said Captain Speedy, who was now deeply interested in Mr. Fogg's
+project, "I really commiserate you.  Everything is against you.  We are
+only opposite Queenstown."
+
+"Ah," said Mr. Fogg, "is that place where we see the lights Queenstown?"
+
+"Yes."
+
+"Can we enter the harbour?"
+
+"Not under three hours.  Only at high tide."
+
+"Stay," replied Mr. Fogg calmly, without betraying in his features that
+by a supreme inspiration he was about to attempt once more to conquer
+ill-fortune.
+
+Queenstown is the Irish port at which the trans-Atlantic steamers stop
+to put off the mails.  These mails are carried to Dublin by express
+trains always held in readiness to start; from Dublin they are sent on
+to Liverpool by the most rapid boats, and thus gain twelve hours on the
+Atlantic steamers.
+
+Phileas Fogg counted on gaining twelve hours in the same way.  Instead
+of arriving at Liverpool the next evening by the Henrietta, he would be
+there by noon, and would therefore have time to reach London before a
+quarter before nine in the evening.
+
+The Henrietta entered Queenstown Harbour at one o'clock in the morning,
+it then being high tide; and Phileas Fogg, after being grasped heartily
+by the hand by Captain Speedy, left that gentleman on the levelled hulk
+of his craft, which was still worth half what he had sold it for.
+
+The party went on shore at once.  Fix was greatly tempted to arrest Mr.
+Fogg on the spot; but he did not.  Why?  What struggle was going on
+within him?  Had he changed his mind about "his man"?  Did he
+understand that he had made a grave mistake?  He did not, however,
+abandon Mr. Fogg.  They all got upon the train, which was just ready to
+start, at half-past one; at dawn of day they were in Dublin; and they
+lost no time in embarking on a steamer which, disdaining to rise upon
+the waves, invariably cut through them.
+
+Phileas Fogg at last disembarked on the Liverpool quay, at twenty
+minutes before twelve, 21st December.  He was only six hours distant
+from London.
+
+But at this moment Fix came up, put his hand upon Mr. Fogg's shoulder,
+and, showing his warrant, said, "You are really Phileas Fogg?"
+
+"I am."
+
+"I arrest you in the Queen's name!"
+
+
+
+
+Chapter XXXIV
+
+IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+
+Phileas Fogg was in prison.  He had been shut up in the Custom House,
+and he was to be transferred to London the next day.
+
+Passepartout, when he saw his master arrested, would have fallen upon
+Fix had he not been held back by some policemen.  Aouda was
+thunderstruck at the suddenness of an event which she could not
+understand.  Passepartout explained to her how it was that the honest
+and courageous Fogg was arrested as a robber.  The young woman's heart
+revolted against so heinous a charge, and when she saw that she could
+attempt to do nothing to save her protector, she wept bitterly.
+
+As for Fix, he had arrested Mr. Fogg because it was his duty, whether
+Mr. Fogg were guilty or not.
+
+The thought then struck Passepartout, that he was the cause of this new
+misfortune!  Had he not concealed Fix's errand from his master?  When
+Fix revealed his true character and purpose, why had he not told Mr.
+Fogg?  If the latter had been warned, he would no doubt have given Fix
+proof of his innocence, and satisfied him of his mistake; at least, Fix
+would not have continued his journey at the expense and on the heels of
+his master, only to arrest him the moment he set foot on English soil.
+Passepartout wept till he was blind, and felt like blowing his brains
+out.
+
+Aouda and he had remained, despite the cold, under the portico of the
+Custom House.  Neither wished to leave the place; both were anxious to
+see Mr. Fogg again.
+
+That gentleman was really ruined, and that at the moment when he was
+about to attain his end.  This arrest was fatal.  Having arrived at
+Liverpool at twenty minutes before twelve on the 21st of December, he
+had till a quarter before nine that evening to reach the Reform Club,
+that is, nine hours and a quarter; the journey from Liverpool to London
+was six hours.
+
+If anyone, at this moment, had entered the Custom House, he would have
+found Mr. Fogg seated, motionless, calm, and without apparent anger,
+upon a wooden bench.  He was not, it is true, resigned; but this last
+blow failed to force him into an outward betrayal of any emotion.  Was
+he being devoured by one of those secret rages, all the more terrible
+because contained, and which only burst forth, with an irresistible
+force, at the last moment?  No one could tell.  There he sat, calmly
+waiting--for what?  Did he still cherish hope?  Did he still believe,
+now that the door of this prison was closed upon him, that he would
+succeed?
+
+However that may have been, Mr. Fogg carefully put his watch upon the
+table, and observed its advancing hands.  Not a word escaped his lips,
+but his look was singularly set and stern.  The situation, in any
+event, was a terrible one, and might be thus stated: if Phileas Fogg
+was honest he was ruined; if he was a knave, he was caught.
+
+Did escape occur to him?  Did he examine to see if there were any
+practicable outlet from his prison?  Did he think of escaping from it?
+Possibly; for once he walked slowly around the room.  But the door was
+locked, and the window heavily barred with iron rods.  He sat down
+again, and drew his journal from his pocket.  On the line where these
+words were written, "21st December, Saturday, Liverpool," he added,
+"80th day, 11.40 a.m.," and waited.
+
+The Custom House clock struck one.  Mr. Fogg observed that his watch
+was two hours too fast.
+
+Two hours!  Admitting that he was at this moment taking an express
+train, he could reach London and the Reform Club by a quarter before
+nine, p.m.  His forehead slightly wrinkled.
+
+At thirty-three minutes past two he heard a singular noise outside,
+then a hasty opening of doors.  Passepartout's voice was audible, and
+immediately after that of Fix.  Phileas Fogg's eyes brightened for an
+instant.
+
+The door swung open, and he saw Passepartout, Aouda, and Fix, who
+hurried towards him.
+
+Fix was out of breath, and his hair was in disorder.  He could not
+speak.  "Sir," he stammered, "sir--forgive me--most--unfortunate
+resemblance--robber arrested three days ago--you are free!"
+
+Phileas Fogg was free!  He walked to the detective, looked him steadily
+in the face, and with the only rapid motion he had ever made in his
+life, or which he ever would make, drew back his arms, and with the
+precision of a machine knocked Fix down.
+
+"Well hit!" cried Passepartout, "Parbleu! that's what you might call a
+good application of English fists!"
+
+Fix, who found himself on the floor, did not utter a word.  He had only
+received his deserts.  Mr. Fogg, Aouda, and Passepartout left the
+Custom House without delay, got into a cab, and in a few moments
+descended at the station.
+
+Phileas Fogg asked if there was an express train about to leave for
+London.  It was forty minutes past two.  The express train had left
+thirty-five minutes before.  Phileas Fogg then ordered a special train.
+
+There were several rapid locomotives on hand; but the railway
+arrangements did not permit the special train to leave until three
+o'clock.
+
+At that hour Phileas Fogg, having stimulated the engineer by the offer
+of a generous reward, at last set out towards London with Aouda and his
+faithful servant.
+
+It was necessary to make the journey in five hours and a half; and this
+would have been easy on a clear road throughout.  But there were forced
+delays, and when Mr. Fogg stepped from the train at the terminus, all
+the clocks in London were striking ten minutes before nine.
+
+Having made the tour of the world, he was behind-hand five minutes.  He
+had lost the wager!
+
+
+
+
+Chapter XXXV
+
+IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+PASSEPARTOUT TWICE
+
+
+The dwellers in Saville Row would have been surprised the next day, if
+they had been told that Phileas Fogg had returned home.  His doors and
+windows were still closed, no appearance of change was visible.
+
+After leaving the station, Mr. Fogg gave Passepartout instructions to
+purchase some provisions, and quietly went to his domicile.
+
+He bore his misfortune with his habitual tranquillity.  Ruined!  And by
+the blundering of the detective!  After having steadily traversed that
+long journey, overcome a hundred obstacles, braved many dangers, and
+still found time to do some good on his way, to fail near the goal by a
+sudden event which he could not have foreseen, and against which he was
+unarmed; it was terrible!  But a few pounds were left of the large sum
+he had carried with him.  There only remained of his fortune the twenty
+thousand pounds deposited at Barings, and this amount he owed to his
+friends of the Reform Club.  So great had been the expense of his tour
+that, even had he won, it would not have enriched him; and it is
+probable that he had not sought to enrich himself, being a man who
+rather laid wagers for honour's sake than for the stake proposed.  But
+this wager totally ruined him.
+
+Mr. Fogg's course, however, was fully decided upon; he knew what
+remained for him to do.
+
+A room in the house in Saville Row was set apart for Aouda, who was
+overwhelmed with grief at her protector's misfortune.  From the words
+which Mr. Fogg dropped, she saw that he was meditating some serious
+project.
+
+Knowing that Englishmen governed by a fixed idea sometimes resort to
+the desperate expedient of suicide, Passepartout kept a narrow watch
+upon his master, though he carefully concealed the appearance of so
+doing.
+
+First of all, the worthy fellow had gone up to his room, and had
+extinguished the gas burner, which had been burning for eighty days.
+He had found in the letter-box a bill from the gas company, and he
+thought it more than time to put a stop to this expense, which he had
+been doomed to bear.
+
+The night passed.  Mr. Fogg went to bed, but did he sleep?  Aouda did
+not once close her eyes.  Passepartout watched all night, like a
+faithful dog, at his master's door.
+
+Mr. Fogg called him in the morning, and told him to get Aouda's
+breakfast, and a cup of tea and a chop for himself.  He desired Aouda
+to excuse him from breakfast and dinner, as his time would be absorbed
+all day in putting his affairs to rights.  In the evening he would ask
+permission to have a few moment's conversation with the young lady.
+
+Passepartout, having received his orders, had nothing to do but obey
+them.  He looked at his imperturbable master, and could scarcely bring
+his mind to leave him.  His heart was full, and his conscience tortured
+by remorse; for he accused himself more bitterly than ever of being the
+cause of the irretrievable disaster.  Yes! if he had warned Mr. Fogg,
+and had betrayed Fix's projects to him, his master would certainly not
+have given the detective passage to Liverpool, and then--
+
+Passepartout could hold in no longer.
+
+"My master!  Mr. Fogg!" he cried, "why do you not curse me?  It was my
+fault that--"
+
+"I blame no one," returned Phileas Fogg, with perfect calmness.  "Go!"
+
+Passepartout left the room, and went to find Aouda, to whom he
+delivered his master's message.
+
+"Madam," he added, "I can do nothing myself--nothing!  I have no
+influence over my master; but you, perhaps--"
+
+"What influence could I have?" replied Aouda.  "Mr. Fogg is influenced
+by no one.  Has he ever understood that my gratitude to him is
+overflowing?  Has he ever read my heart?  My friend, he must not be
+left alone an instant!  You say he is going to speak with me this
+evening?"
+
+"Yes, madam; probably to arrange for your protection and comfort in
+England."
+
+"We shall see," replied Aouda, becoming suddenly pensive.
+
+Throughout this day (Sunday) the house in Saville Row was as if
+uninhabited, and Phileas Fogg, for the first time since he had lived in
+that house, did not set out for his club when Westminster clock struck
+half-past eleven.
+
+Why should he present himself at the Reform?  His friends no longer
+expected him there.  As Phileas Fogg had not appeared in the saloon on
+the evening before (Saturday, the 21st of December, at a quarter before
+nine), he had lost his wager.  It was not even necessary that he should
+go to his bankers for the twenty thousand pounds; for his antagonists
+already had his cheque in their hands, and they had only to fill it out
+and send it to the Barings to have the amount transferred to their
+credit.
+
+Mr. Fogg, therefore, had no reason for going out, and so he remained at
+home.  He shut himself up in his room, and busied himself putting his
+affairs in order.  Passepartout continually ascended and descended the
+stairs.  The hours were long for him. He listened at his master's door,
+and looked through the keyhole, as if he had a perfect right so to do,
+and as if he feared that something terrible might happen at any moment.
+Sometimes he thought of Fix, but no longer in anger.  Fix, like all the
+world, had been mistaken in Phileas Fogg, and had only done his duty in
+tracking and arresting him; while he, Passepartout. . . .  This thought
+haunted him, and he never ceased cursing his miserable folly.
+
+Finding himself too wretched to remain alone, he knocked at Aouda's
+door, went into her room, seated himself, without speaking, in a
+corner, and looked ruefully at the young woman. Aouda was still pensive.
+
+About half-past seven in the evening Mr. Fogg sent to know if Aouda
+would receive him, and in a few moments he found himself alone with her.
+
+Phileas Fogg took a chair, and sat down near the fireplace, opposite
+Aouda.  No emotion was visible on his face.  Fogg returned was exactly
+the Fogg who had gone away; there was the same calm, the same
+impassibility.
+
+He sat several minutes without speaking; then, bending his eyes on
+Aouda, "Madam," said he, "will you pardon me for bringing you to
+England?"
+
+"I, Mr. Fogg!" replied Aouda, checking the pulsations of her heart.
+
+"Please let me finish," returned Mr. Fogg.  "When I decided to bring
+you far away from the country which was so unsafe for you, I was rich,
+and counted on putting a portion of my fortune at your disposal; then
+your existence would have been free and happy.  But now I am ruined."
+
+"I know it, Mr. Fogg," replied Aouda; "and I ask you in my turn, will
+you forgive me for having followed you, and--who knows?--for having,
+perhaps, delayed you, and thus contributed to your ruin?"
+
+"Madam, you could not remain in India, and your safety could only be
+assured by bringing you to such a distance that your persecutors could
+not take you."
+
+"So, Mr. Fogg," resumed Aouda, "not content with rescuing me from a
+terrible death, you thought yourself bound to secure my comfort in a
+foreign land?"
+
+"Yes, madam; but circumstances have been against me.  Still, I beg to
+place the little I have left at your service."
+
+"But what will become of you, Mr. Fogg?"
+
+"As for me, madam," replied the gentleman, coldly, "I have need of
+nothing."
+
+"But how do you look upon the fate, sir, which awaits you?"
+
+"As I am in the habit of doing."
+
+"At least," said Aouda, "want should not overtake a man like you.  Your
+friends--"
+
+"I have no friends, madam."
+
+"Your relatives--"
+
+"I have no longer any relatives."
+
+"I pity you, then, Mr. Fogg, for solitude is a sad thing, with no heart
+to which to confide your griefs.  They say, though, that misery itself,
+shared by two sympathetic souls, may be borne with patience."
+
+"They say so, madam."
+
+"Mr. Fogg," said Aouda, rising and seizing his hand, "do you wish at
+once a kinswoman and friend?  Will you have me for your wife?"
+
+Mr. Fogg, at this, rose in his turn.  There was an unwonted light in
+his eyes, and a slight trembling of his lips.  Aouda looked into his
+face.  The sincerity, rectitude, firmness, and sweetness of this soft
+glance of a noble woman, who could dare all to save him to whom she
+owed all, at first astonished, then penetrated him.  He shut his eyes
+for an instant, as if to avoid her look.  When he opened them again, "I
+love you!" he said, simply.  "Yes, by all that is holiest, I love you,
+and I am entirely yours!"
+
+"Ah!" cried Aouda, pressing his hand to her heart.
+
+Passepartout was summoned and appeared immediately.  Mr. Fogg still
+held Aouda's hand in his own; Passepartout understood, and his big,
+round face became as radiant as the tropical sun at its zenith.
+
+Mr. Fogg asked him if it was not too late to notify the Reverend Samuel
+Wilson, of Marylebone parish, that evening.
+
+Passepartout smiled his most genial smile, and said, "Never too late."
+
+It was five minutes past eight.
+
+"Will it be for to-morrow, Monday?"
+
+"For to-morrow, Monday," said Mr. Fogg, turning to Aouda.
+
+"Yes; for to-morrow, Monday," she replied.
+
+Passepartout hurried off as fast as his legs could carry him.
+
+
+
+
+Chapter XXXVI
+
+IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+
+It is time to relate what a change took place in English public opinion
+when it transpired that the real bankrobber, a certain James Strand,
+had been arrested, on the 17th day of December, at Edinburgh.  Three
+days before, Phileas Fogg had been a criminal, who was being
+desperately followed up by the police; now he was an honourable
+gentleman, mathematically pursuing his eccentric journey round the
+world.
+
+The papers resumed their discussion about the wager; all those who had
+laid bets, for or against him, revived their interest, as if by magic;
+the "Phileas Fogg bonds" again became negotiable, and many new wagers
+were made.  Phileas Fogg's name was once more at a premium on 'Change.
+
+His five friends of the Reform Club passed these three days in a state
+of feverish suspense.  Would Phileas Fogg, whom they had forgotten,
+reappear before their eyes!  Where was he at this moment?  The 17th of
+December, the day of James Strand's arrest, was the seventy-sixth since
+Phileas Fogg's departure, and no news of him had been received.  Was he
+dead?  Had he abandoned the effort, or was he continuing his journey
+along the route agreed upon?  And would he appear on Saturday, the 21st
+of December, at a quarter before nine in the evening, on the threshold
+of the Reform Club saloon?
+
+The anxiety in which, for three days, London society existed, cannot be
+described.  Telegrams were sent to America and Asia for news of Phileas
+Fogg.  Messengers were dispatched to the house in Saville Row morning
+and evening.  No news.  The police were ignorant what had become of the
+detective, Fix, who had so unfortunately followed up a false scent.
+Bets increased, nevertheless, in number and value.  Phileas Fogg, like
+a racehorse, was drawing near his last turning-point.  The bonds were
+quoted, no longer at a hundred below par, but at twenty, at ten, and at
+five; and paralytic old Lord Albemarle bet even in his favour.
+
+A great crowd was collected in Pall Mall and the neighbouring streets
+on Saturday evening; it seemed like a multitude of brokers permanently
+established around the Reform Club.  Circulation was impeded, and
+everywhere disputes, discussions, and financial transactions were going
+on.  The police had great difficulty in keeping back the crowd, and as
+the hour when Phileas Fogg was due approached, the excitement rose to
+its highest pitch.
+
+The five antagonists of Phileas Fogg had met in the great saloon of the
+club.  John Sullivan and Samuel Fallentin, the bankers, Andrew Stuart,
+the engineer, Gauthier Ralph, the director of the Bank of England, and
+Thomas Flanagan, the brewer, one and all waited anxiously.
+
+When the clock indicated twenty minutes past eight, Andrew Stuart got
+up, saying, "Gentlemen, in twenty minutes the time agreed upon between
+Mr. Fogg and ourselves will have expired."
+
+"What time did the last train arrive from Liverpool?"  asked Thomas
+Flanagan.
+
+"At twenty-three minutes past seven," replied Gauthier Ralph; "and the
+next does not arrive till ten minutes after twelve."
+
+"Well, gentlemen," resumed Andrew Stuart, "if Phileas Fogg had come in
+the 7:23 train, he would have got here by this time.  We can,
+therefore, regard the bet as won."
+
+"Wait; don't let us be too hasty," replied Samuel Fallentin.  "You know
+that Mr. Fogg is very eccentric.  His punctuality is well known; he
+never arrives too soon, or too late; and I should not be surprised if
+he appeared before us at the last minute."
+
+"Why," said Andrew Stuart nervously, "if I should see him, I should not
+believe it was he."
+
+"The fact is," resumed Thomas Flanagan, "Mr. Fogg's project was
+absurdly foolish.  Whatever his punctuality, he could not prevent the
+delays which were certain to occur; and a delay of only two or three
+days would be fatal to his tour."
+
+"Observe, too," added John Sullivan, "that we have received no
+intelligence from him, though there are telegraphic lines all along his
+route."
+
+"He has lost, gentleman," said Andrew Stuart, "he has a hundred times
+lost!  You know, besides, that the China the only steamer he could have
+taken from New York to get here in time arrived yesterday.  I have seen
+a list of the passengers, and the name of Phileas Fogg is not among
+them.  Even if we admit that fortune has favoured him, he can scarcely
+have reached America.  I think he will be at least twenty days
+behind-hand, and that Lord Albemarle will lose a cool five thousand."
+
+"It is clear," replied Gauthier Ralph; "and we have nothing to do but
+to present Mr. Fogg's cheque at Barings to-morrow."
+
+At this moment, the hands of the club clock pointed to twenty minutes
+to nine.
+
+"Five minutes more," said Andrew Stuart.
+
+The five gentlemen looked at each other.  Their anxiety was becoming
+intense; but, not wishing to betray it, they readily assented to Mr.
+Fallentin's proposal of a rubber.
+
+"I wouldn't give up my four thousand of the bet," said Andrew Stuart,
+as he took his seat, "for three thousand nine hundred and ninety-nine."
+
+The clock indicated eighteen minutes to nine.
+
+The players took up their cards, but could not keep their eyes off the
+clock.  Certainly, however secure they felt, minutes had never seemed
+so long to them!
+
+"Seventeen minutes to nine," said Thomas Flanagan, as he cut the cards
+which Ralph handed to him.
+
+Then there was a moment of silence.  The great saloon was perfectly
+quiet; but the murmurs of the crowd outside were heard, with now and
+then a shrill cry.  The pendulum beat the seconds, which each player
+eagerly counted, as he listened, with mathematical regularity.
+
+"Sixteen minutes to nine!" said John Sullivan, in a voice which
+betrayed his emotion.
+
+One minute more, and the wager would be won.  Andrew Stuart and his
+partners suspended their game.  They left their cards, and counted the
+seconds.
+
+At the fortieth second, nothing.  At the fiftieth, still nothing.
+
+At the fifty-fifth, a loud cry was heard in the street, followed by
+applause, hurrahs, and some fierce growls.
+
+The players rose from their seats.
+
+At the fifty-seventh second the door of the saloon opened; and the
+pendulum had not beat the sixtieth second when Phileas Fogg appeared,
+followed by an excited crowd who had forced their way through the club
+doors, and in his calm voice, said, "Here I am, gentlemen!"
+
+
+
+
+Chapter XXXVII
+
+IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+Yes; Phileas Fogg in person.
+
+The reader will remember that at five minutes past eight in the
+evening--about five and twenty hours after the arrival of the
+travellers in London--Passepartout had been sent by his master to
+engage the services of the Reverend Samuel Wilson in a certain marriage
+ceremony, which was to take place the next day.
+
+Passepartout went on his errand enchanted.  He soon reached the
+clergyman's house, but found him not at home.  Passepartout waited a
+good twenty minutes, and when he left the reverend gentleman, it was
+thirty-five minutes past eight.  But in what a state he was!  With his
+hair in disorder, and without his hat, he ran along the street as never
+man was seen to run before, overturning passers-by, rushing over the
+sidewalk like a waterspout.
+
+In three minutes he was in Saville Row again, and staggered back into
+Mr. Fogg's room.
+
+He could not speak.
+
+"What is the matter?" asked Mr. Fogg.
+
+"My master!" gasped Passepartout--"marriage--impossible--"
+
+"Impossible?"
+
+"Impossible--for to-morrow."
+
+"Why so?"
+
+"Because to-morrow--is Sunday!"
+
+"Monday," replied Mr. Fogg.
+
+"No--to-day is Saturday."
+
+"Saturday?  Impossible!"
+
+"Yes, yes, yes, yes!" cried Passepartout.  "You have made a mistake of
+one day!  We arrived twenty-four hours ahead of time; but there are
+only ten minutes left!"
+
+Passepartout had seized his master by the collar, and was dragging him
+along with irresistible force.
+
+Phileas Fogg, thus kidnapped, without having time to think, left his
+house, jumped into a cab, promised a hundred pounds to the cabman, and,
+having run over two dogs and overturned five carriages, reached the
+Reform Club.
+
+The clock indicated a quarter before nine when he appeared in the great
+saloon.
+
+Phileas Fogg had accomplished the journey round the world in eighty
+days!
+
+Phileas Fogg had won his wager of twenty thousand pounds!
+
+How was it that a man so exact and fastidious could have made this
+error of a day?  How came he to think that he had arrived in London on
+Saturday, the twenty-first day of December, when it was really Friday,
+the twentieth, the seventy-ninth day only from his departure?
+
+The cause of the error is very simple.
+
+Phileas Fogg had, without suspecting it, gained one day on his journey,
+and this merely because he had travelled constantly eastward; he would,
+on the contrary, have lost a day had he gone in the opposite direction,
+that is, westward.
+
+In journeying eastward he had gone towards the sun, and the days
+therefore diminished for him as many times four minutes as he crossed
+degrees in this direction.  There are three hundred and sixty degrees
+on the circumference of the earth; and these three hundred and sixty
+degrees, multiplied by four minutes, gives precisely twenty-four
+hours--that is, the day unconsciously gained.  In other words, while
+Phileas Fogg, going eastward, saw the sun pass the meridian eighty
+times, his friends in London only saw it pass the meridian seventy-nine
+times.  This is why they awaited him at the Reform Club on Saturday,
+and not Sunday, as Mr. Fogg thought.
+
+And Passepartout's famous family watch, which had always kept London
+time, would have betrayed this fact, if it had marked the days as well
+as the hours and the minutes!
+
+Phileas Fogg, then, had won the twenty thousand pounds; but, as he had
+spent nearly nineteen thousand on the way, the pecuniary gain was
+small.  His object was, however, to be victorious, and not to win
+money.  He divided the one thousand pounds that remained between
+Passepartout and the unfortunate Fix, against whom he cherished no
+grudge.  He deducted, however, from Passepartout's share the cost of
+the gas which had burned in his room for nineteen hundred and twenty
+hours, for the sake of regularity.
+
+That evening, Mr. Fogg, as tranquil and phlegmatic as ever, said to
+Aouda: "Is our marriage still agreeable to you?"
+
+"Mr. Fogg," replied she, "it is for me to ask that question.  You were
+ruined, but now you are rich again."
+
+"Pardon me, madam; my fortune belongs to you.  If you had not suggested
+our marriage, my servant would not have gone to the Reverend Samuel
+Wilson's, I should not have been apprised of my error, and--"
+
+"Dear Mr. Fogg!" said the young woman.
+
+"Dear Aouda!" replied Phileas Fogg.
+
+It need not be said that the marriage took place forty-eight hours
+after, and that Passepartout, glowing and dazzling, gave the bride
+away.  Had he not saved her, and was he not entitled to this honour?
+
+The next day, as soon as it was light, Passepartout rapped vigorously
+at his master's door.  Mr. Fogg opened it, and asked, "What's the
+matter, Passepartout?"
+
+"What is it, sir?  Why, I've just this instant found out--"
+
+"What?"
+
+"That we might have made the tour of the world in only seventy-eight
+days."
+
+"No doubt," returned Mr. Fogg, "by not crossing India.  But if I had
+not crossed India, I should not have saved Aouda; she would not have
+been my wife, and--"
+
+Mr. Fogg quietly shut the door.
+
+Phileas Fogg had won his wager, and had made his journey around the
+world in eighty days.  To do this he had employed every means of
+conveyance--steamers, railways, carriages, yachts, trading-vessels,
+sledges, elephants.  The eccentric gentleman had throughout displayed
+all his marvellous qualities of coolness and exactitude.  But what
+then?  What had he really gained by all this trouble?  What had he
+brought back from this long and weary journey?
+
+Nothing, say you?  Perhaps so; nothing but a charming woman, who,
+strange as it may appear, made him the happiest of men!
+
+Truly, would you not for less than that make the tour around the world?
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's Around the World in 80 Days, by Jules Verne
+
+*** END OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+***** This file should be named 103.txt or 103.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/0/103/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/dorian-gray.txt
+++ b/jet/source-sink-builder/src/main/resources/books/dorian-gray.txt
@@ -1,0 +1,8904 @@
+﻿The Project Gutenberg EBook of The Picture of Dorian Gray, by Oscar Wilde
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Picture of Dorian Gray
+
+Author: Oscar Wilde
+
+Release Date: June 9, 2008 [EBook #174]
+[This file last updated on July 2, 2011]
+[This file last updated on July 23, 2014]
+
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+
+
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+The Picture of Dorian Gray
+
+by
+
+Oscar Wilde
+
+
+
+
+THE PREFACE
+
+The artist is the creator of beautiful things.  To reveal art and
+conceal the artist is art's aim.  The critic is he who can translate
+into another manner or a new material his impression of beautiful
+things.
+
+The highest as the lowest form of criticism is a mode of autobiography.
+Those who find ugly meanings in beautiful things are corrupt without
+being charming.  This is a fault.
+
+Those who find beautiful meanings in beautiful things are the
+cultivated.  For these there is hope.  They are the elect to whom
+beautiful things mean only beauty.
+
+There is no such thing as a moral or an immoral book.  Books are well
+written, or badly written.  That is all.
+
+The nineteenth century dislike of realism is the rage of Caliban seeing
+his own face in a glass.
+
+The nineteenth century dislike of romanticism is the rage of Caliban
+not seeing his own face in a glass.  The moral life of man forms part
+of the subject-matter of the artist, but the morality of art consists
+in the perfect use of an imperfect medium.  No artist desires to prove
+anything.  Even things that are true can be proved.  No artist has
+ethical sympathies.  An ethical sympathy in an artist is an
+unpardonable mannerism of style.  No artist is ever morbid.  The artist
+can express everything.  Thought and language are to the artist
+instruments of an art.  Vice and virtue are to the artist materials for
+an art.  From the point of view of form, the type of all the arts is
+the art of the musician.  From the point of view of feeling, the
+actor's craft is the type.  All art is at once surface and symbol.
+Those who go beneath the surface do so at their peril.  Those who read
+the symbol do so at their peril.  It is the spectator, and not life,
+that art really mirrors.  Diversity of opinion about a work of art
+shows that the work is new, complex, and vital.  When critics disagree,
+the artist is in accord with himself.  We can forgive a man for making
+a useful thing as long as he does not admire it.  The only excuse for
+making a useless thing is that one admires it intensely.
+
+               All art is quite useless.
+
+                            OSCAR WILDE
+
+
+
+
+CHAPTER 1
+
+The studio was filled with the rich odour of roses, and when the light
+summer wind stirred amidst the trees of the garden, there came through
+the open door the heavy scent of the lilac, or the more delicate
+perfume of the pink-flowering thorn.
+
+From the corner of the divan of Persian saddle-bags on which he was
+lying, smoking, as was his custom, innumerable cigarettes, Lord Henry
+Wotton could just catch the gleam of the honey-sweet and honey-coloured
+blossoms of a laburnum, whose tremulous branches seemed hardly able to
+bear the burden of a beauty so flamelike as theirs; and now and then
+the fantastic shadows of birds in flight flitted across the long
+tussore-silk curtains that were stretched in front of the huge window,
+producing a kind of momentary Japanese effect, and making him think of
+those pallid, jade-faced painters of Tokyo who, through the medium of
+an art that is necessarily immobile, seek to convey the sense of
+swiftness and motion.  The sullen murmur of the bees shouldering their
+way through the long unmown grass, or circling with monotonous
+insistence round the dusty gilt horns of the straggling woodbine,
+seemed to make the stillness more oppressive.  The dim roar of London
+was like the bourdon note of a distant organ.
+
+In the centre of the room, clamped to an upright easel, stood the
+full-length portrait of a young man of extraordinary personal beauty,
+and in front of it, some little distance away, was sitting the artist
+himself, Basil Hallward, whose sudden disappearance some years ago
+caused, at the time, such public excitement and gave rise to so many
+strange conjectures.
+
+As the painter looked at the gracious and comely form he had so
+skilfully mirrored in his art, a smile of pleasure passed across his
+face, and seemed about to linger there.  But he suddenly started up,
+and closing his eyes, placed his fingers upon the lids, as though he
+sought to imprison within his brain some curious dream from which he
+feared he might awake.
+
+"It is your best work, Basil, the best thing you have ever done," said
+Lord Henry languidly.  "You must certainly send it next year to the
+Grosvenor.  The Academy is too large and too vulgar.  Whenever I have
+gone there, there have been either so many people that I have not been
+able to see the pictures, which was dreadful, or so many pictures that
+I have not been able to see the people, which was worse.  The Grosvenor
+is really the only place."
+
+"I don't think I shall send it anywhere," he answered, tossing his head
+back in that odd way that used to make his friends laugh at him at
+Oxford.  "No, I won't send it anywhere."
+
+Lord Henry elevated his eyebrows and looked at him in amazement through
+the thin blue wreaths of smoke that curled up in such fanciful whorls
+from his heavy, opium-tainted cigarette.  "Not send it anywhere?  My
+dear fellow, why?  Have you any reason?  What odd chaps you painters
+are!  You do anything in the world to gain a reputation.  As soon as
+you have one, you seem to want to throw it away.  It is silly of you,
+for there is only one thing in the world worse than being talked about,
+and that is not being talked about.  A portrait like this would set you
+far above all the young men in England, and make the old men quite
+jealous, if old men are ever capable of any emotion."
+
+"I know you will laugh at me," he replied, "but I really can't exhibit
+it.  I have put too much of myself into it."
+
+Lord Henry stretched himself out on the divan and laughed.
+
+"Yes, I knew you would; but it is quite true, all the same."
+
+"Too much of yourself in it! Upon my word, Basil, I didn't know you
+were so vain; and I really can't see any resemblance between you, with
+your rugged strong face and your coal-black hair, and this young
+Adonis, who looks as if he was made out of ivory and rose-leaves. Why,
+my dear Basil, he is a Narcissus, and you--well, of course you have an
+intellectual expression and all that.  But beauty, real beauty, ends
+where an intellectual expression begins.  Intellect is in itself a mode
+of exaggeration, and destroys the harmony of any face.  The moment one
+sits down to think, one becomes all nose, or all forehead, or something
+horrid.  Look at the successful men in any of the learned professions.
+How perfectly hideous they are!  Except, of course, in the Church.  But
+then in the Church they don't think.  A bishop keeps on saying at the
+age of eighty what he was told to say when he was a boy of eighteen,
+and as a natural consequence he always looks absolutely delightful.
+Your mysterious young friend, whose name you have never told me, but
+whose picture really fascinates me, never thinks.  I feel quite sure of
+that.  He is some brainless beautiful creature who should be always
+here in winter when we have no flowers to look at, and always here in
+summer when we want something to chill our intelligence.  Don't flatter
+yourself, Basil:  you are not in the least like him."
+
+"You don't understand me, Harry," answered the artist.  "Of course I am
+not like him.  I know that perfectly well.  Indeed, I should be sorry
+to look like him.  You shrug your shoulders?  I am telling you the
+truth.  There is a fatality about all physical and intellectual
+distinction, the sort of fatality that seems to dog through history the
+faltering steps of kings.  It is better not to be different from one's
+fellows.  The ugly and the stupid have the best of it in this world.
+They can sit at their ease and gape at the play.  If they know nothing
+of victory, they are at least spared the knowledge of defeat.  They
+live as we all should live--undisturbed, indifferent, and without
+disquiet.  They neither bring ruin upon others, nor ever receive it
+from alien hands.  Your rank and wealth, Harry; my brains, such as they
+are--my art, whatever it may be worth; Dorian Gray's good looks--we
+shall all suffer for what the gods have given us, suffer terribly."
+
+"Dorian Gray?  Is that his name?" asked Lord Henry, walking across the
+studio towards Basil Hallward.
+
+"Yes, that is his name.  I didn't intend to tell it to you."
+
+"But why not?"
+
+"Oh, I can't explain.  When I like people immensely, I never tell their
+names to any one.  It is like surrendering a part of them.  I have
+grown to love secrecy.  It seems to be the one thing that can make
+modern life mysterious or marvellous to us.  The commonest thing is
+delightful if one only hides it.  When I leave town now I never tell my
+people where I am going.  If I did, I would lose all my pleasure.  It
+is a silly habit, I dare say, but somehow it seems to bring a great
+deal of romance into one's life.  I suppose you think me awfully
+foolish about it?"
+
+"Not at all," answered Lord Henry, "not at all, my dear Basil.  You
+seem to forget that I am married, and the one charm of marriage is that
+it makes a life of deception absolutely necessary for both parties.  I
+never know where my wife is, and my wife never knows what I am doing.
+When we meet--we do meet occasionally, when we dine out together, or go
+down to the Duke's--we tell each other the most absurd stories with the
+most serious faces.  My wife is very good at it--much better, in fact,
+than I am.  She never gets confused over her dates, and I always do.
+But when she does find me out, she makes no row at all.  I sometimes
+wish she would; but she merely laughs at me."
+
+"I hate the way you talk about your married life, Harry," said Basil
+Hallward, strolling towards the door that led into the garden.  "I
+believe that you are really a very good husband, but that you are
+thoroughly ashamed of your own virtues.  You are an extraordinary
+fellow.  You never say a moral thing, and you never do a wrong thing.
+Your cynicism is simply a pose."
+
+"Being natural is simply a pose, and the most irritating pose I know,"
+cried Lord Henry, laughing; and the two young men went out into the
+garden together and ensconced themselves on a long bamboo seat that
+stood in the shade of a tall laurel bush.  The sunlight slipped over
+the polished leaves.  In the grass, white daisies were tremulous.
+
+After a pause, Lord Henry pulled out his watch.  "I am afraid I must be
+going, Basil," he murmured, "and before I go, I insist on your
+answering a question I put to you some time ago."
+
+"What is that?" said the painter, keeping his eyes fixed on the ground.
+
+"You know quite well."
+
+"I do not, Harry."
+
+"Well, I will tell you what it is.  I want you to explain to me why you
+won't exhibit Dorian Gray's picture.  I want the real reason."
+
+"I told you the real reason."
+
+"No, you did not.  You said it was because there was too much of
+yourself in it.  Now, that is childish."
+
+"Harry," said Basil Hallward, looking him straight in the face, "every
+portrait that is painted with feeling is a portrait of the artist, not
+of the sitter.  The sitter is merely the accident, the occasion.  It is
+not he who is revealed by the painter; it is rather the painter who, on
+the coloured canvas, reveals himself.  The reason I will not exhibit
+this picture is that I am afraid that I have shown in it the secret of
+my own soul."
+
+Lord Henry laughed.  "And what is that?" he asked.
+
+"I will tell you," said Hallward; but an expression of perplexity came
+over his face.
+
+"I am all expectation, Basil," continued his companion, glancing at him.
+
+"Oh, there is really very little to tell, Harry," answered the painter;
+"and I am afraid you will hardly understand it.  Perhaps you will
+hardly believe it."
+
+Lord Henry smiled, and leaning down, plucked a pink-petalled daisy from
+the grass and examined it.  "I am quite sure I shall understand it," he
+replied, gazing intently at the little golden, white-feathered disk,
+"and as for believing things, I can believe anything, provided that it
+is quite incredible."
+
+The wind shook some blossoms from the trees, and the heavy
+lilac-blooms, with their clustering stars, moved to and fro in the
+languid air.  A grasshopper began to chirrup by the wall, and like a
+blue thread a long thin dragon-fly floated past on its brown gauze
+wings.  Lord Henry felt as if he could hear Basil Hallward's heart
+beating, and wondered what was coming.
+
+"The story is simply this," said the painter after some time.  "Two
+months ago I went to a crush at Lady Brandon's. You know we poor
+artists have to show ourselves in society from time to time, just to
+remind the public that we are not savages.  With an evening coat and a
+white tie, as you told me once, anybody, even a stock-broker, can gain
+a reputation for being civilized.  Well, after I had been in the room
+about ten minutes, talking to huge overdressed dowagers and tedious
+academicians, I suddenly became conscious that some one was looking at
+me.  I turned half-way round and saw Dorian Gray for the first time.
+When our eyes met, I felt that I was growing pale.  A curious sensation
+of terror came over me.  I knew that I had come face to face with some
+one whose mere personality was so fascinating that, if I allowed it to
+do so, it would absorb my whole nature, my whole soul, my very art
+itself.  I did not want any external influence in my life.  You know
+yourself, Harry, how independent I am by nature.  I have always been my
+own master; had at least always been so, till I met Dorian Gray.
+Then--but I don't know how to explain it to you.  Something seemed to
+tell me that I was on the verge of a terrible crisis in my life.  I had
+a strange feeling that fate had in store for me exquisite joys and
+exquisite sorrows.  I grew afraid and turned to quit the room.  It was
+not conscience that made me do so:  it was a sort of cowardice.  I take
+no credit to myself for trying to escape."
+
+"Conscience and cowardice are really the same things, Basil.
+Conscience is the trade-name of the firm.  That is all."
+
+"I don't believe that, Harry, and I don't believe you do either.
+However, whatever was my motive--and it may have been pride, for I used
+to be very proud--I certainly struggled to the door.  There, of course,
+I stumbled against Lady Brandon.  'You are not going to run away so
+soon, Mr. Hallward?' she screamed out.  You know her curiously shrill
+voice?"
+
+"Yes; she is a peacock in everything but beauty," said Lord Henry,
+pulling the daisy to bits with his long nervous fingers.
+
+"I could not get rid of her.  She brought me up to royalties, and
+people with stars and garters, and elderly ladies with gigantic tiaras
+and parrot noses.  She spoke of me as her dearest friend.  I had only
+met her once before, but she took it into her head to lionize me.  I
+believe some picture of mine had made a great success at the time, at
+least had been chattered about in the penny newspapers, which is the
+nineteenth-century standard of immortality.  Suddenly I found myself
+face to face with the young man whose personality had so strangely
+stirred me.  We were quite close, almost touching.  Our eyes met again.
+It was reckless of me, but I asked Lady Brandon to introduce me to him.
+Perhaps it was not so reckless, after all.  It was simply inevitable.
+We would have spoken to each other without any introduction.  I am sure
+of that.  Dorian told me so afterwards.  He, too, felt that we were
+destined to know each other."
+
+"And how did Lady Brandon describe this wonderful young man?" asked his
+companion.  "I know she goes in for giving a rapid _precis_ of all her
+guests.  I remember her bringing me up to a truculent and red-faced old
+gentleman covered all over with orders and ribbons, and hissing into my
+ear, in a tragic whisper which must have been perfectly audible to
+everybody in the room, the most astounding details.  I simply fled.  I
+like to find out people for myself.  But Lady Brandon treats her guests
+exactly as an auctioneer treats his goods.  She either explains them
+entirely away, or tells one everything about them except what one wants
+to know."
+
+"Poor Lady Brandon!  You are hard on her, Harry!" said Hallward
+listlessly.
+
+"My dear fellow, she tried to found a _salon_, and only succeeded in
+opening a restaurant.  How could I admire her?  But tell me, what did
+she say about Mr. Dorian Gray?"
+
+"Oh, something like, 'Charming boy--poor dear mother and I absolutely
+inseparable.  Quite forget what he does--afraid he--doesn't do
+anything--oh, yes, plays the piano--or is it the violin, dear Mr.
+Gray?'  Neither of us could help laughing, and we became friends at
+once."
+
+"Laughter is not at all a bad beginning for a friendship, and it is far
+the best ending for one," said the young lord, plucking another daisy.
+
+Hallward shook his head.  "You don't understand what friendship is,
+Harry," he murmured--"or what enmity is, for that matter.  You like
+every one; that is to say, you are indifferent to every one."
+
+"How horribly unjust of you!" cried Lord Henry, tilting his hat back
+and looking up at the little clouds that, like ravelled skeins of
+glossy white silk, were drifting across the hollowed turquoise of the
+summer sky.  "Yes; horribly unjust of you.  I make a great difference
+between people.  I choose my friends for their good looks, my
+acquaintances for their good characters, and my enemies for their good
+intellects.  A man cannot be too careful in the choice of his enemies.
+I have not got one who is a fool.  They are all men of some
+intellectual power, and consequently they all appreciate me.  Is that
+very vain of me?  I think it is rather vain."
+
+"I should think it was, Harry.  But according to your category I must
+be merely an acquaintance."
+
+"My dear old Basil, you are much more than an acquaintance."
+
+"And much less than a friend.  A sort of brother, I suppose?"
+
+"Oh, brothers!  I don't care for brothers.  My elder brother won't die,
+and my younger brothers seem never to do anything else."
+
+"Harry!" exclaimed Hallward, frowning.
+
+"My dear fellow, I am not quite serious.  But I can't help detesting my
+relations.  I suppose it comes from the fact that none of us can stand
+other people having the same faults as ourselves.  I quite sympathize
+with the rage of the English democracy against what they call the vices
+of the upper orders.  The masses feel that drunkenness, stupidity, and
+immorality should be their own special property, and that if any one of
+us makes an ass of himself, he is poaching on their preserves.  When
+poor Southwark got into the divorce court, their indignation was quite
+magnificent.  And yet I don't suppose that ten per cent of the
+proletariat live correctly."
+
+"I don't agree with a single word that you have said, and, what is
+more, Harry, I feel sure you don't either."
+
+Lord Henry stroked his pointed brown beard and tapped the toe of his
+patent-leather boot with a tasselled ebony cane.  "How English you are
+Basil!  That is the second time you have made that observation.  If one
+puts forward an idea to a true Englishman--always a rash thing to
+do--he never dreams of considering whether the idea is right or wrong.
+The only thing he considers of any importance is whether one believes
+it oneself.  Now, the value of an idea has nothing whatsoever to do
+with the sincerity of the man who expresses it.  Indeed, the
+probabilities are that the more insincere the man is, the more purely
+intellectual will the idea be, as in that case it will not be coloured
+by either his wants, his desires, or his prejudices.  However, I don't
+propose to discuss politics, sociology, or metaphysics with you.  I
+like persons better than principles, and I like persons with no
+principles better than anything else in the world.  Tell me more about
+Mr. Dorian Gray.  How often do you see him?"
+
+"Every day.  I couldn't be happy if I didn't see him every day.  He is
+absolutely necessary to me."
+
+"How extraordinary!  I thought you would never care for anything but
+your art."
+
+"He is all my art to me now," said the painter gravely.  "I sometimes
+think, Harry, that there are only two eras of any importance in the
+world's history.  The first is the appearance of a new medium for art,
+and the second is the appearance of a new personality for art also.
+What the invention of oil-painting was to the Venetians, the face of
+Antinous was to late Greek sculpture, and the face of Dorian Gray will
+some day be to me.  It is not merely that I paint from him, draw from
+him, sketch from him.  Of course, I have done all that.  But he is much
+more to me than a model or a sitter.  I won't tell you that I am
+dissatisfied with what I have done of him, or that his beauty is such
+that art cannot express it.  There is nothing that art cannot express,
+and I know that the work I have done, since I met Dorian Gray, is good
+work, is the best work of my life.  But in some curious way--I wonder
+will you understand me?--his personality has suggested to me an
+entirely new manner in art, an entirely new mode of style.  I see
+things differently, I think of them differently.  I can now recreate
+life in a way that was hidden from me before.  'A dream of form in days
+of thought'--who is it who says that?  I forget; but it is what Dorian
+Gray has been to me.  The merely visible presence of this lad--for he
+seems to me little more than a lad, though he is really over
+twenty--his merely visible presence--ah!  I wonder can you realize all
+that that means?  Unconsciously he defines for me the lines of a fresh
+school, a school that is to have in it all the passion of the romantic
+spirit, all the perfection of the spirit that is Greek.  The harmony of
+soul and body--how much that is!  We in our madness have separated the
+two, and have invented a realism that is vulgar, an ideality that is
+void.  Harry! if you only knew what Dorian Gray is to me!  You remember
+that landscape of mine, for which Agnew offered me such a huge price
+but which I would not part with?  It is one of the best things I have
+ever done.  And why is it so?  Because, while I was painting it, Dorian
+Gray sat beside me.  Some subtle influence passed from him to me, and
+for the first time in my life I saw in the plain woodland the wonder I
+had always looked for and always missed."
+
+"Basil, this is extraordinary!  I must see Dorian Gray."
+
+Hallward got up from the seat and walked up and down the garden.  After
+some time he came back.  "Harry," he said, "Dorian Gray is to me simply
+a motive in art.  You might see nothing in him.  I see everything in
+him.  He is never more present in my work than when no image of him is
+there.  He is a suggestion, as I have said, of a new manner.  I find
+him in the curves of certain lines, in the loveliness and subtleties of
+certain colours.  That is all."
+
+"Then why won't you exhibit his portrait?" asked Lord Henry.
+
+"Because, without intending it, I have put into it some expression of
+all this curious artistic idolatry, of which, of course, I have never
+cared to speak to him.  He knows nothing about it.  He shall never know
+anything about it.  But the world might guess it, and I will not bare
+my soul to their shallow prying eyes.  My heart shall never be put
+under their microscope.  There is too much of myself in the thing,
+Harry--too much of myself!"
+
+"Poets are not so scrupulous as you are.  They know how useful passion
+is for publication.  Nowadays a broken heart will run to many editions."
+
+"I hate them for it," cried Hallward.  "An artist should create
+beautiful things, but should put nothing of his own life into them.  We
+live in an age when men treat art as if it were meant to be a form of
+autobiography.  We have lost the abstract sense of beauty.  Some day I
+will show the world what it is; and for that reason the world shall
+never see my portrait of Dorian Gray."
+
+"I think you are wrong, Basil, but I won't argue with you.  It is only
+the intellectually lost who ever argue.  Tell me, is Dorian Gray very
+fond of you?"
+
+The painter considered for a few moments.  "He likes me," he answered
+after a pause; "I know he likes me.  Of course I flatter him
+dreadfully.  I find a strange pleasure in saying things to him that I
+know I shall be sorry for having said.  As a rule, he is charming to
+me, and we sit in the studio and talk of a thousand things.  Now and
+then, however, he is horribly thoughtless, and seems to take a real
+delight in giving me pain.  Then I feel, Harry, that I have given away
+my whole soul to some one who treats it as if it were a flower to put
+in his coat, a bit of decoration to charm his vanity, an ornament for a
+summer's day."
+
+"Days in summer, Basil, are apt to linger," murmured Lord Henry.
+"Perhaps you will tire sooner than he will.  It is a sad thing to think
+of, but there is no doubt that genius lasts longer than beauty.  That
+accounts for the fact that we all take such pains to over-educate
+ourselves.  In the wild struggle for existence, we want to have
+something that endures, and so we fill our minds with rubbish and
+facts, in the silly hope of keeping our place.  The thoroughly
+well-informed man--that is the modern ideal.  And the mind of the
+thoroughly well-informed man is a dreadful thing.  It is like a
+_bric-a-brac_ shop, all monsters and dust, with everything priced above
+its proper value.  I think you will tire first, all the same.  Some day
+you will look at your friend, and he will seem to you to be a little
+out of drawing, or you won't like his tone of colour, or something.
+You will bitterly reproach him in your own heart, and seriously think
+that he has behaved very badly to you.  The next time he calls, you
+will be perfectly cold and indifferent.  It will be a great pity, for
+it will alter you.  What you have told me is quite a romance, a romance
+of art one might call it, and the worst of having a romance of any kind
+is that it leaves one so unromantic."
+
+"Harry, don't talk like that.  As long as I live, the personality of
+Dorian Gray will dominate me.  You can't feel what I feel.  You change
+too often."
+
+"Ah, my dear Basil, that is exactly why I can feel it.  Those who are
+faithful know only the trivial side of love: it is the faithless who
+know love's tragedies."  And Lord Henry struck a light on a dainty
+silver case and began to smoke a cigarette with a self-conscious and
+satisfied air, as if he had summed up the world in a phrase.  There was
+a rustle of chirruping sparrows in the green lacquer leaves of the ivy,
+and the blue cloud-shadows chased themselves across the grass like
+swallows.  How pleasant it was in the garden!  And how delightful other
+people's emotions were!--much more delightful than their ideas, it
+seemed to him.  One's own soul, and the passions of one's
+friends--those were the fascinating things in life.  He pictured to
+himself with silent amusement the tedious luncheon that he had missed
+by staying so long with Basil Hallward.  Had he gone to his aunt's, he
+would have been sure to have met Lord Goodbody there, and the whole
+conversation would have been about the feeding of the poor and the
+necessity for model lodging-houses. Each class would have preached the
+importance of those virtues, for whose exercise there was no necessity
+in their own lives.  The rich would have spoken on the value of thrift,
+and the idle grown eloquent over the dignity of labour.  It was
+charming to have escaped all that!  As he thought of his aunt, an idea
+seemed to strike him.  He turned to Hallward and said, "My dear fellow,
+I have just remembered."
+
+"Remembered what, Harry?"
+
+"Where I heard the name of Dorian Gray."
+
+"Where was it?" asked Hallward, with a slight frown.
+
+"Don't look so angry, Basil.  It was at my aunt, Lady Agatha's.  She
+told me she had discovered a wonderful young man who was going to help
+her in the East End, and that his name was Dorian Gray.  I am bound to
+state that she never told me he was good-looking. Women have no
+appreciation of good looks; at least, good women have not.  She said
+that he was very earnest and had a beautiful nature.  I at once
+pictured to myself a creature with spectacles and lank hair, horribly
+freckled, and tramping about on huge feet.  I wish I had known it was
+your friend."
+
+"I am very glad you didn't, Harry."
+
+"Why?"
+
+"I don't want you to meet him."
+
+"You don't want me to meet him?"
+
+"No."
+
+"Mr. Dorian Gray is in the studio, sir," said the butler, coming into
+the garden.
+
+"You must introduce me now," cried Lord Henry, laughing.
+
+The painter turned to his servant, who stood blinking in the sunlight.
+"Ask Mr. Gray to wait, Parker:  I shall be in in a few moments." The
+man bowed and went up the walk.
+
+Then he looked at Lord Henry.  "Dorian Gray is my dearest friend," he
+said.  "He has a simple and a beautiful nature.  Your aunt was quite
+right in what she said of him.  Don't spoil him.  Don't try to
+influence him.  Your influence would be bad.  The world is wide, and
+has many marvellous people in it.  Don't take away from me the one
+person who gives to my art whatever charm it possesses:  my life as an
+artist depends on him.  Mind, Harry, I trust you."  He spoke very
+slowly, and the words seemed wrung out of him almost against his will.
+
+"What nonsense you talk!" said Lord Henry, smiling, and taking Hallward
+by the arm, he almost led him into the house.
+
+
+
+CHAPTER 2
+
+As they entered they saw Dorian Gray.  He was seated at the piano, with
+his back to them, turning over the pages of a volume of Schumann's
+"Forest Scenes."  "You must lend me these, Basil," he cried.  "I want
+to learn them.  They are perfectly charming."
+
+"That entirely depends on how you sit to-day, Dorian."
+
+"Oh, I am tired of sitting, and I don't want a life-sized portrait of
+myself," answered the lad, swinging round on the music-stool in a
+wilful, petulant manner.  When he caught sight of Lord Henry, a faint
+blush coloured his cheeks for a moment, and he started up.  "I beg your
+pardon, Basil, but I didn't know you had any one with you."
+
+"This is Lord Henry Wotton, Dorian, an old Oxford friend of mine.  I
+have just been telling him what a capital sitter you were, and now you
+have spoiled everything."
+
+"You have not spoiled my pleasure in meeting you, Mr. Gray," said Lord
+Henry, stepping forward and extending his hand.  "My aunt has often
+spoken to me about you.  You are one of her favourites, and, I am
+afraid, one of her victims also."
+
+"I am in Lady Agatha's black books at present," answered Dorian with a
+funny look of penitence.  "I promised to go to a club in Whitechapel
+with her last Tuesday, and I really forgot all about it.  We were to
+have played a duet together--three duets, I believe.  I don't know what
+she will say to me.  I am far too frightened to call."
+
+"Oh, I will make your peace with my aunt.  She is quite devoted to you.
+And I don't think it really matters about your not being there.  The
+audience probably thought it was a duet.  When Aunt Agatha sits down to
+the piano, she makes quite enough noise for two people."
+
+"That is very horrid to her, and not very nice to me," answered Dorian,
+laughing.
+
+Lord Henry looked at him.  Yes, he was certainly wonderfully handsome,
+with his finely curved scarlet lips, his frank blue eyes, his crisp
+gold hair.  There was something in his face that made one trust him at
+once.  All the candour of youth was there, as well as all youth's
+passionate purity.  One felt that he had kept himself unspotted from
+the world.  No wonder Basil Hallward worshipped him.
+
+"You are too charming to go in for philanthropy, Mr. Gray--far too
+charming." And Lord Henry flung himself down on the divan and opened
+his cigarette-case.
+
+The painter had been busy mixing his colours and getting his brushes
+ready.  He was looking worried, and when he heard Lord Henry's last
+remark, he glanced at him, hesitated for a moment, and then said,
+"Harry, I want to finish this picture to-day. Would you think it
+awfully rude of me if I asked you to go away?"
+
+Lord Henry smiled and looked at Dorian Gray.  "Am I to go, Mr. Gray?"
+he asked.
+
+"Oh, please don't, Lord Henry.  I see that Basil is in one of his sulky
+moods, and I can't bear him when he sulks.  Besides, I want you to tell
+me why I should not go in for philanthropy."
+
+"I don't know that I shall tell you that, Mr. Gray.  It is so tedious a
+subject that one would have to talk seriously about it.  But I
+certainly shall not run away, now that you have asked me to stop.  You
+don't really mind, Basil, do you?  You have often told me that you
+liked your sitters to have some one to chat to."
+
+Hallward bit his lip.  "If Dorian wishes it, of course you must stay.
+Dorian's whims are laws to everybody, except himself."
+
+Lord Henry took up his hat and gloves.  "You are very pressing, Basil,
+but I am afraid I must go.  I have promised to meet a man at the
+Orleans.  Good-bye, Mr. Gray.  Come and see me some afternoon in Curzon
+Street.  I am nearly always at home at five o'clock. Write to me when
+you are coming.  I should be sorry to miss you."
+
+"Basil," cried Dorian Gray, "if Lord Henry Wotton goes, I shall go,
+too.  You never open your lips while you are painting, and it is
+horribly dull standing on a platform and trying to look pleasant.  Ask
+him to stay.  I insist upon it."
+
+"Stay, Harry, to oblige Dorian, and to oblige me," said Hallward,
+gazing intently at his picture.  "It is quite true, I never talk when I
+am working, and never listen either, and it must be dreadfully tedious
+for my unfortunate sitters.  I beg you to stay."
+
+"But what about my man at the Orleans?"
+
+The painter laughed.  "I don't think there will be any difficulty about
+that.  Sit down again, Harry.  And now, Dorian, get up on the platform,
+and don't move about too much, or pay any attention to what Lord Henry
+says.  He has a very bad influence over all his friends, with the
+single exception of myself."
+
+Dorian Gray stepped up on the dais with the air of a young Greek
+martyr, and made a little _moue_ of discontent to Lord Henry, to whom he
+had rather taken a fancy.  He was so unlike Basil.  They made a
+delightful contrast.  And he had such a beautiful voice.  After a few
+moments he said to him, "Have you really a very bad influence, Lord
+Henry?  As bad as Basil says?"
+
+"There is no such thing as a good influence, Mr. Gray.  All influence
+is immoral--immoral from the scientific point of view."
+
+"Why?"
+
+"Because to influence a person is to give him one's own soul.  He does
+not think his natural thoughts, or burn with his natural passions.  His
+virtues are not real to him.  His sins, if there are such things as
+sins, are borrowed.  He becomes an echo of some one else's music, an
+actor of a part that has not been written for him.  The aim of life is
+self-development. To realize one's nature perfectly--that is what each
+of us is here for.  People are afraid of themselves, nowadays.  They
+have forgotten the highest of all duties, the duty that one owes to
+one's self.  Of course, they are charitable.  They feed the hungry and
+clothe the beggar.  But their own souls starve, and are naked.  Courage
+has gone out of our race.  Perhaps we never really had it.  The terror
+of society, which is the basis of morals, the terror of God, which is
+the secret of religion--these are the two things that govern us.  And
+yet--"
+
+"Just turn your head a little more to the right, Dorian, like a good
+boy," said the painter, deep in his work and conscious only that a look
+had come into the lad's face that he had never seen there before.
+
+"And yet," continued Lord Henry, in his low, musical voice, and with
+that graceful wave of the hand that was always so characteristic of
+him, and that he had even in his Eton days, "I believe that if one man
+were to live out his life fully and completely, were to give form to
+every feeling, expression to every thought, reality to every dream--I
+believe that the world would gain such a fresh impulse of joy that we
+would forget all the maladies of mediaevalism, and return to the
+Hellenic ideal--to something finer, richer than the Hellenic ideal, it
+may be.  But the bravest man amongst us is afraid of himself.  The
+mutilation of the savage has its tragic survival in the self-denial
+that mars our lives.  We are punished for our refusals.  Every impulse
+that we strive to strangle broods in the mind and poisons us.  The body
+sins once, and has done with its sin, for action is a mode of
+purification.  Nothing remains then but the recollection of a pleasure,
+or the luxury of a regret.  The only way to get rid of a temptation is
+to yield to it.  Resist it, and your soul grows sick with longing for
+the things it has forbidden to itself, with desire for what its
+monstrous laws have made monstrous and unlawful.  It has been said that
+the great events of the world take place in the brain.  It is in the
+brain, and the brain only, that the great sins of the world take place
+also.  You, Mr. Gray, you yourself, with your rose-red youth and your
+rose-white boyhood, you have had passions that have made you afraid,
+thoughts that have filled you with terror, day-dreams and sleeping
+dreams whose mere memory might stain your cheek with shame--"
+
+"Stop!" faltered Dorian Gray, "stop! you bewilder me.  I don't know
+what to say.  There is some answer to you, but I cannot find it.  Don't
+speak.  Let me think.  Or, rather, let me try not to think."
+
+For nearly ten minutes he stood there, motionless, with parted lips and
+eyes strangely bright.  He was dimly conscious that entirely fresh
+influences were at work within him.  Yet they seemed to him to have
+come really from himself.  The few words that Basil's friend had said
+to him--words spoken by chance, no doubt, and with wilful paradox in
+them--had touched some secret chord that had never been touched before,
+but that he felt was now vibrating and throbbing to curious pulses.
+
+Music had stirred him like that.  Music had troubled him many times.
+But music was not articulate.  It was not a new world, but rather
+another chaos, that it created in us.  Words!  Mere words!  How
+terrible they were!  How clear, and vivid, and cruel!  One could not
+escape from them.  And yet what a subtle magic there was in them!  They
+seemed to be able to give a plastic form to formless things, and to
+have a music of their own as sweet as that of viol or of lute.  Mere
+words!  Was there anything so real as words?
+
+Yes; there had been things in his boyhood that he had not understood.
+He understood them now.  Life suddenly became fiery-coloured to him.
+It seemed to him that he had been walking in fire.  Why had he not
+known it?
+
+With his subtle smile, Lord Henry watched him.  He knew the precise
+psychological moment when to say nothing.  He felt intensely
+interested.  He was amazed at the sudden impression that his words had
+produced, and, remembering a book that he had read when he was sixteen,
+a book which had revealed to him much that he had not known before, he
+wondered whether Dorian Gray was passing through a similar experience.
+He had merely shot an arrow into the air.  Had it hit the mark?  How
+fascinating the lad was!
+
+Hallward painted away with that marvellous bold touch of his, that had
+the true refinement and perfect delicacy that in art, at any rate comes
+only from strength.  He was unconscious of the silence.
+
+"Basil, I am tired of standing," cried Dorian Gray suddenly.  "I must
+go out and sit in the garden.  The air is stifling here."
+
+"My dear fellow, I am so sorry.  When I am painting, I can't think of
+anything else.  But you never sat better.  You were perfectly still.
+And I have caught the effect I wanted--the half-parted lips and the
+bright look in the eyes.  I don't know what Harry has been saying to
+you, but he has certainly made you have the most wonderful expression.
+I suppose he has been paying you compliments.  You mustn't believe a
+word that he says."
+
+"He has certainly not been paying me compliments.  Perhaps that is the
+reason that I don't believe anything he has told me."
+
+"You know you believe it all," said Lord Henry, looking at him with his
+dreamy languorous eyes.  "I will go out to the garden with you.  It is
+horribly hot in the studio.  Basil, let us have something iced to
+drink, something with strawberries in it."
+
+"Certainly, Harry.  Just touch the bell, and when Parker comes I will
+tell him what you want.  I have got to work up this background, so I
+will join you later on.  Don't keep Dorian too long.  I have never been
+in better form for painting than I am to-day. This is going to be my
+masterpiece.  It is my masterpiece as it stands."
+
+Lord Henry went out to the garden and found Dorian Gray burying his
+face in the great cool lilac-blossoms, feverishly drinking in their
+perfume as if it had been wine.  He came close to him and put his hand
+upon his shoulder.  "You are quite right to do that," he murmured.
+"Nothing can cure the soul but the senses, just as nothing can cure the
+senses but the soul."
+
+The lad started and drew back.  He was bareheaded, and the leaves had
+tossed his rebellious curls and tangled all their gilded threads.
+There was a look of fear in his eyes, such as people have when they are
+suddenly awakened.  His finely chiselled nostrils quivered, and some
+hidden nerve shook the scarlet of his lips and left them trembling.
+
+"Yes," continued Lord Henry, "that is one of the great secrets of
+life--to cure the soul by means of the senses, and the senses by means
+of the soul.  You are a wonderful creation.  You know more than you
+think you know, just as you know less than you want to know."
+
+Dorian Gray frowned and turned his head away.  He could not help liking
+the tall, graceful young man who was standing by him.  His romantic,
+olive-coloured face and worn expression interested him.  There was
+something in his low languid voice that was absolutely fascinating.
+His cool, white, flowerlike hands, even, had a curious charm.  They
+moved, as he spoke, like music, and seemed to have a language of their
+own.  But he felt afraid of him, and ashamed of being afraid.  Why had
+it been left for a stranger to reveal him to himself?  He had known
+Basil Hallward for months, but the friendship between them had never
+altered him.  Suddenly there had come some one across his life who
+seemed to have disclosed to him life's mystery.  And, yet, what was
+there to be afraid of?  He was not a schoolboy or a girl.  It was
+absurd to be frightened.
+
+"Let us go and sit in the shade," said Lord Henry.  "Parker has brought
+out the drinks, and if you stay any longer in this glare, you will be
+quite spoiled, and Basil will never paint you again.  You really must
+not allow yourself to become sunburnt.  It would be unbecoming."
+
+"What can it matter?" cried Dorian Gray, laughing, as he sat down on
+the seat at the end of the garden.
+
+"It should matter everything to you, Mr. Gray."
+
+"Why?"
+
+"Because you have the most marvellous youth, and youth is the one thing
+worth having."
+
+"I don't feel that, Lord Henry."
+
+"No, you don't feel it now.  Some day, when you are old and wrinkled
+and ugly, when thought has seared your forehead with its lines, and
+passion branded your lips with its hideous fires, you will feel it, you
+will feel it terribly.  Now, wherever you go, you charm the world.
+Will it always be so? ... You have a wonderfully beautiful face, Mr.
+Gray.  Don't frown.  You have.  And beauty is a form of genius--is
+higher, indeed, than genius, as it needs no explanation.  It is of the
+great facts of the world, like sunlight, or spring-time, or the
+reflection in dark waters of that silver shell we call the moon.  It
+cannot be questioned.  It has its divine right of sovereignty.  It
+makes princes of those who have it.  You smile?  Ah! when you have lost
+it you won't smile.... People say sometimes that beauty is only
+superficial.  That may be so, but at least it is not so superficial as
+thought is.  To me, beauty is the wonder of wonders.  It is only
+shallow people who do not judge by appearances.  The true mystery of
+the world is the visible, not the invisible.... Yes, Mr. Gray, the
+gods have been good to you.  But what the gods give they quickly take
+away.  You have only a few years in which to live really, perfectly,
+and fully.  When your youth goes, your beauty will go with it, and then
+you will suddenly discover that there are no triumphs left for you, or
+have to content yourself with those mean triumphs that the memory of
+your past will make more bitter than defeats.  Every month as it wanes
+brings you nearer to something dreadful.  Time is jealous of you, and
+wars against your lilies and your roses.  You will become sallow, and
+hollow-cheeked, and dull-eyed.  You will suffer horribly.... Ah!
+realize your youth while you have it.  Don't squander the gold of your
+days, listening to the tedious, trying to improve the hopeless failure,
+or giving away your life to the ignorant, the common, and the vulgar.
+These are the sickly aims, the false ideals, of our age.  Live!  Live
+the wonderful life that is in you!  Let nothing be lost upon you.  Be
+always searching for new sensations.  Be afraid of nothing.... A new
+Hedonism--that is what our century wants.  You might be its visible
+symbol.  With your personality there is nothing you could not do.  The
+world belongs to you for a season.... The moment I met you I saw that
+you were quite unconscious of what you really are, of what you really
+might be.  There was so much in you that charmed me that I felt I must
+tell you something about yourself.  I thought how tragic it would be if
+you were wasted.  For there is such a little time that your youth will
+last--such a little time.  The common hill-flowers wither, but they
+blossom again.  The laburnum will be as yellow next June as it is now.
+In a month there will be purple stars on the clematis, and year after
+year the green night of its leaves will hold its purple stars.  But we
+never get back our youth.  The pulse of joy that beats in us at twenty
+becomes sluggish.  Our limbs fail, our senses rot.  We degenerate into
+hideous puppets, haunted by the memory of the passions of which we were
+too much afraid, and the exquisite temptations that we had not the
+courage to yield to.  Youth!  Youth!  There is absolutely nothing in
+the world but youth!"
+
+Dorian Gray listened, open-eyed and wondering.  The spray of lilac fell
+from his hand upon the gravel.  A furry bee came and buzzed round it
+for a moment.  Then it began to scramble all over the oval stellated
+globe of the tiny blossoms.  He watched it with that strange interest
+in trivial things that we try to develop when things of high import
+make us afraid, or when we are stirred by some new emotion for which we
+cannot find expression, or when some thought that terrifies us lays
+sudden siege to the brain and calls on us to yield.  After a time the
+bee flew away.  He saw it creeping into the stained trumpet of a Tyrian
+convolvulus.  The flower seemed to quiver, and then swayed gently to
+and fro.
+
+Suddenly the painter appeared at the door of the studio and made
+staccato signs for them to come in.  They turned to each other and
+smiled.
+
+"I am waiting," he cried.  "Do come in.  The light is quite perfect,
+and you can bring your drinks."
+
+They rose up and sauntered down the walk together.  Two green-and-white
+butterflies fluttered past them, and in the pear-tree at the corner of
+the garden a thrush began to sing.
+
+"You are glad you have met me, Mr. Gray," said Lord Henry, looking at
+him.
+
+"Yes, I am glad now.  I wonder shall I always be glad?"
+
+"Always!  That is a dreadful word.  It makes me shudder when I hear it.
+Women are so fond of using it.  They spoil every romance by trying to
+make it last for ever.  It is a meaningless word, too.  The only
+difference between a caprice and a lifelong passion is that the caprice
+lasts a little longer."
+
+As they entered the studio, Dorian Gray put his hand upon Lord Henry's
+arm.  "In that case, let our friendship be a caprice," he murmured,
+flushing at his own boldness, then stepped up on the platform and
+resumed his pose.
+
+Lord Henry flung himself into a large wicker arm-chair and watched him.
+The sweep and dash of the brush on the canvas made the only sound that
+broke the stillness, except when, now and then, Hallward stepped back
+to look at his work from a distance.  In the slanting beams that
+streamed through the open doorway the dust danced and was golden.  The
+heavy scent of the roses seemed to brood over everything.
+
+After about a quarter of an hour Hallward stopped painting, looked for
+a long time at Dorian Gray, and then for a long time at the picture,
+biting the end of one of his huge brushes and frowning.  "It is quite
+finished," he cried at last, and stooping down he wrote his name in
+long vermilion letters on the left-hand corner of the canvas.
+
+Lord Henry came over and examined the picture.  It was certainly a
+wonderful work of art, and a wonderful likeness as well.
+
+"My dear fellow, I congratulate you most warmly," he said.  "It is the
+finest portrait of modern times.  Mr. Gray, come over and look at
+yourself."
+
+The lad started, as if awakened from some dream.
+
+"Is it really finished?" he murmured, stepping down from the platform.
+
+"Quite finished," said the painter.  "And you have sat splendidly
+to-day. I am awfully obliged to you."
+
+"That is entirely due to me," broke in Lord Henry.  "Isn't it, Mr.
+Gray?"
+
+Dorian made no answer, but passed listlessly in front of his picture
+and turned towards it.  When he saw it he drew back, and his cheeks
+flushed for a moment with pleasure.  A look of joy came into his eyes,
+as if he had recognized himself for the first time.  He stood there
+motionless and in wonder, dimly conscious that Hallward was speaking to
+him, but not catching the meaning of his words.  The sense of his own
+beauty came on him like a revelation.  He had never felt it before.
+Basil Hallward's compliments had seemed to him to be merely the
+charming exaggeration of friendship.  He had listened to them, laughed
+at them, forgotten them.  They had not influenced his nature.  Then had
+come Lord Henry Wotton with his strange panegyric on youth, his
+terrible warning of its brevity.  That had stirred him at the time, and
+now, as he stood gazing at the shadow of his own loveliness, the full
+reality of the description flashed across him.  Yes, there would be a
+day when his face would be wrinkled and wizen, his eyes dim and
+colourless, the grace of his figure broken and deformed.  The scarlet
+would pass away from his lips and the gold steal from his hair.  The
+life that was to make his soul would mar his body.  He would become
+dreadful, hideous, and uncouth.
+
+As he thought of it, a sharp pang of pain struck through him like a
+knife and made each delicate fibre of his nature quiver.  His eyes
+deepened into amethyst, and across them came a mist of tears.  He felt
+as if a hand of ice had been laid upon his heart.
+
+"Don't you like it?" cried Hallward at last, stung a little by the
+lad's silence, not understanding what it meant.
+
+"Of course he likes it," said Lord Henry.  "Who wouldn't like it?  It
+is one of the greatest things in modern art.  I will give you anything
+you like to ask for it.  I must have it."
+
+"It is not my property, Harry."
+
+"Whose property is it?"
+
+"Dorian's, of course," answered the painter.
+
+"He is a very lucky fellow."
+
+"How sad it is!" murmured Dorian Gray with his eyes still fixed upon
+his own portrait.  "How sad it is!  I shall grow old, and horrible, and
+dreadful.  But this picture will remain always young.  It will never be
+older than this particular day of June.... If it were only the other
+way!  If it were I who was to be always young, and the picture that was
+to grow old!  For that--for that--I would give everything!  Yes, there
+is nothing in the whole world I would not give!  I would give my soul
+for that!"
+
+"You would hardly care for such an arrangement, Basil," cried Lord
+Henry, laughing.  "It would be rather hard lines on your work."
+
+"I should object very strongly, Harry," said Hallward.
+
+Dorian Gray turned and looked at him.  "I believe you would, Basil.
+You like your art better than your friends.  I am no more to you than a
+green bronze figure.  Hardly as much, I dare say."
+
+The painter stared in amazement.  It was so unlike Dorian to speak like
+that.  What had happened?  He seemed quite angry.  His face was flushed
+and his cheeks burning.
+
+"Yes," he continued, "I am less to you than your ivory Hermes or your
+silver Faun.  You will like them always.  How long will you like me?
+Till I have my first wrinkle, I suppose.  I know, now, that when one
+loses one's good looks, whatever they may be, one loses everything.
+Your picture has taught me that.  Lord Henry Wotton is perfectly right.
+Youth is the only thing worth having.  When I find that I am growing
+old, I shall kill myself."
+
+Hallward turned pale and caught his hand.  "Dorian!  Dorian!" he cried,
+"don't talk like that.  I have never had such a friend as you, and I
+shall never have such another.  You are not jealous of material things,
+are you?--you who are finer than any of them!"
+
+"I am jealous of everything whose beauty does not die.  I am jealous of
+the portrait you have painted of me.  Why should it keep what I must
+lose?  Every moment that passes takes something from me and gives
+something to it.  Oh, if it were only the other way!  If the picture
+could change, and I could be always what I am now!  Why did you paint
+it?  It will mock me some day--mock me horribly!"  The hot tears welled
+into his eyes; he tore his hand away and, flinging himself on the
+divan, he buried his face in the cushions, as though he was praying.
+
+"This is your doing, Harry," said the painter bitterly.
+
+Lord Henry shrugged his shoulders.  "It is the real Dorian Gray--that
+is all."
+
+"It is not."
+
+"If it is not, what have I to do with it?"
+
+"You should have gone away when I asked you," he muttered.
+
+"I stayed when you asked me," was Lord Henry's answer.
+
+"Harry, I can't quarrel with my two best friends at once, but between
+you both you have made me hate the finest piece of work I have ever
+done, and I will destroy it.  What is it but canvas and colour?  I will
+not let it come across our three lives and mar them."
+
+Dorian Gray lifted his golden head from the pillow, and with pallid
+face and tear-stained eyes, looked at him as he walked over to the deal
+painting-table that was set beneath the high curtained window.  What
+was he doing there?  His fingers were straying about among the litter
+of tin tubes and dry brushes, seeking for something.  Yes, it was for
+the long palette-knife, with its thin blade of lithe steel.  He had
+found it at last.  He was going to rip up the canvas.
+
+With a stifled sob the lad leaped from the couch, and, rushing over to
+Hallward, tore the knife out of his hand, and flung it to the end of
+the studio.  "Don't, Basil, don't!" he cried.  "It would be murder!"
+
+"I am glad you appreciate my work at last, Dorian," said the painter
+coldly when he had recovered from his surprise.  "I never thought you
+would."
+
+"Appreciate it?  I am in love with it, Basil.  It is part of myself.  I
+feel that."
+
+"Well, as soon as you are dry, you shall be varnished, and framed, and
+sent home.  Then you can do what you like with yourself." And he walked
+across the room and rang the bell for tea.  "You will have tea, of
+course, Dorian?  And so will you, Harry?  Or do you object to such
+simple pleasures?"
+
+"I adore simple pleasures," said Lord Henry.  "They are the last refuge
+of the complex.  But I don't like scenes, except on the stage.  What
+absurd fellows you are, both of you!  I wonder who it was defined man
+as a rational animal.  It was the most premature definition ever given.
+Man is many things, but he is not rational.  I am glad he is not, after
+all--though I wish you chaps would not squabble over the picture.  You
+had much better let me have it, Basil.  This silly boy doesn't really
+want it, and I really do."
+
+"If you let any one have it but me, Basil, I shall never forgive you!"
+cried Dorian Gray; "and I don't allow people to call me a silly boy."
+
+"You know the picture is yours, Dorian.  I gave it to you before it
+existed."
+
+"And you know you have been a little silly, Mr. Gray, and that you
+don't really object to being reminded that you are extremely young."
+
+"I should have objected very strongly this morning, Lord Henry."
+
+"Ah! this morning!  You have lived since then."
+
+There came a knock at the door, and the butler entered with a laden
+tea-tray and set it down upon a small Japanese table.  There was a
+rattle of cups and saucers and the hissing of a fluted Georgian urn.
+Two globe-shaped china dishes were brought in by a page.  Dorian Gray
+went over and poured out the tea.  The two men sauntered languidly to
+the table and examined what was under the covers.
+
+"Let us go to the theatre to-night," said Lord Henry.  "There is sure
+to be something on, somewhere.  I have promised to dine at White's, but
+it is only with an old friend, so I can send him a wire to say that I
+am ill, or that I am prevented from coming in consequence of a
+subsequent engagement.  I think that would be a rather nice excuse:  it
+would have all the surprise of candour."
+
+"It is such a bore putting on one's dress-clothes," muttered Hallward.
+"And, when one has them on, they are so horrid."
+
+"Yes," answered Lord Henry dreamily, "the costume of the nineteenth
+century is detestable.  It is so sombre, so depressing.  Sin is the
+only real colour-element left in modern life."
+
+"You really must not say things like that before Dorian, Harry."
+
+"Before which Dorian?  The one who is pouring out tea for us, or the
+one in the picture?"
+
+"Before either."
+
+"I should like to come to the theatre with you, Lord Henry," said the
+lad.
+
+"Then you shall come; and you will come, too, Basil, won't you?"
+
+"I can't, really.  I would sooner not.  I have a lot of work to do."
+
+"Well, then, you and I will go alone, Mr. Gray."
+
+"I should like that awfully."
+
+The painter bit his lip and walked over, cup in hand, to the picture.
+"I shall stay with the real Dorian," he said, sadly.
+
+"Is it the real Dorian?" cried the original of the portrait, strolling
+across to him.  "Am I really like that?"
+
+"Yes; you are just like that."
+
+"How wonderful, Basil!"
+
+"At least you are like it in appearance.  But it will never alter,"
+sighed Hallward.  "That is something."
+
+"What a fuss people make about fidelity!" exclaimed Lord Henry.  "Why,
+even in love it is purely a question for physiology.  It has nothing to
+do with our own will.  Young men want to be faithful, and are not; old
+men want to be faithless, and cannot: that is all one can say."
+
+"Don't go to the theatre to-night, Dorian," said Hallward.  "Stop and
+dine with me."
+
+"I can't, Basil."
+
+"Why?"
+
+"Because I have promised Lord Henry Wotton to go with him."
+
+"He won't like you the better for keeping your promises.  He always
+breaks his own.  I beg you not to go."
+
+Dorian Gray laughed and shook his head.
+
+"I entreat you."
+
+The lad hesitated, and looked over at Lord Henry, who was watching them
+from the tea-table with an amused smile.
+
+"I must go, Basil," he answered.
+
+"Very well," said Hallward, and he went over and laid down his cup on
+the tray.  "It is rather late, and, as you have to dress, you had
+better lose no time.  Good-bye, Harry.  Good-bye, Dorian.  Come and see
+me soon.  Come to-morrow."
+
+"Certainly."
+
+"You won't forget?"
+
+"No, of course not," cried Dorian.
+
+"And ... Harry!"
+
+"Yes, Basil?"
+
+"Remember what I asked you, when we were in the garden this morning."
+
+"I have forgotten it."
+
+"I trust you."
+
+"I wish I could trust myself," said Lord Henry, laughing.  "Come, Mr.
+Gray, my hansom is outside, and I can drop you at your own place.
+Good-bye, Basil.  It has been a most interesting afternoon."
+
+As the door closed behind them, the painter flung himself down on a
+sofa, and a look of pain came into his face.
+
+
+
+CHAPTER 3
+
+At half-past twelve next day Lord Henry Wotton strolled from Curzon
+Street over to the Albany to call on his uncle, Lord Fermor, a genial
+if somewhat rough-mannered old bachelor, whom the outside world called
+selfish because it derived no particular benefit from him, but who was
+considered generous by Society as he fed the people who amused him.
+His father had been our ambassador at Madrid when Isabella was young
+and Prim unthought of, but had retired from the diplomatic service in a
+capricious moment of annoyance on not being offered the Embassy at
+Paris, a post to which he considered that he was fully entitled by
+reason of his birth, his indolence, the good English of his dispatches,
+and his inordinate passion for pleasure.  The son, who had been his
+father's secretary, had resigned along with his chief, somewhat
+foolishly as was thought at the time, and on succeeding some months
+later to the title, had set himself to the serious study of the great
+aristocratic art of doing absolutely nothing.  He had two large town
+houses, but preferred to live in chambers as it was less trouble, and
+took most of his meals at his club.  He paid some attention to the
+management of his collieries in the Midland counties, excusing himself
+for this taint of industry on the ground that the one advantage of
+having coal was that it enabled a gentleman to afford the decency of
+burning wood on his own hearth.  In politics he was a Tory, except when
+the Tories were in office, during which period he roundly abused them
+for being a pack of Radicals.  He was a hero to his valet, who bullied
+him, and a terror to most of his relations, whom he bullied in turn.
+Only England could have produced him, and he always said that the
+country was going to the dogs.  His principles were out of date, but
+there was a good deal to be said for his prejudices.
+
+When Lord Henry entered the room, he found his uncle sitting in a rough
+shooting-coat, smoking a cheroot and grumbling over _The Times_.  "Well,
+Harry," said the old gentleman, "what brings you out so early?  I
+thought you dandies never got up till two, and were not visible till
+five."
+
+"Pure family affection, I assure you, Uncle George.  I want to get
+something out of you."
+
+"Money, I suppose," said Lord Fermor, making a wry face.  "Well, sit
+down and tell me all about it.  Young people, nowadays, imagine that
+money is everything."
+
+"Yes," murmured Lord Henry, settling his button-hole in his coat; "and
+when they grow older they know it.  But I don't want money.  It is only
+people who pay their bills who want that, Uncle George, and I never pay
+mine.  Credit is the capital of a younger son, and one lives charmingly
+upon it.  Besides, I always deal with Dartmoor's tradesmen, and
+consequently they never bother me.  What I want is information:  not
+useful information, of course; useless information."
+
+"Well, I can tell you anything that is in an English Blue Book, Harry,
+although those fellows nowadays write a lot of nonsense.  When I was in
+the Diplomatic, things were much better.  But I hear they let them in
+now by examination.  What can you expect?  Examinations, sir, are pure
+humbug from beginning to end.  If a man is a gentleman, he knows quite
+enough, and if he is not a gentleman, whatever he knows is bad for him."
+
+"Mr. Dorian Gray does not belong to Blue Books, Uncle George," said
+Lord Henry languidly.
+
+"Mr. Dorian Gray?  Who is he?" asked Lord Fermor, knitting his bushy
+white eyebrows.
+
+"That is what I have come to learn, Uncle George.  Or rather, I know
+who he is.  He is the last Lord Kelso's grandson.  His mother was a
+Devereux, Lady Margaret Devereux.  I want you to tell me about his
+mother.  What was she like?  Whom did she marry?  You have known nearly
+everybody in your time, so you might have known her.  I am very much
+interested in Mr. Gray at present.  I have only just met him."
+
+"Kelso's grandson!" echoed the old gentleman.  "Kelso's grandson! ...
+Of course.... I knew his mother intimately.  I believe I was at her
+christening.  She was an extraordinarily beautiful girl, Margaret
+Devereux, and made all the men frantic by running away with a penniless
+young fellow--a mere nobody, sir, a subaltern in a foot regiment, or
+something of that kind.  Certainly.  I remember the whole thing as if
+it happened yesterday.  The poor chap was killed in a duel at Spa a few
+months after the marriage.  There was an ugly story about it.  They
+said Kelso got some rascally adventurer, some Belgian brute, to insult
+his son-in-law in public--paid him, sir, to do it, paid him--and that
+the fellow spitted his man as if he had been a pigeon.  The thing was
+hushed up, but, egad, Kelso ate his chop alone at the club for some
+time afterwards.  He brought his daughter back with him, I was told,
+and she never spoke to him again.  Oh, yes; it was a bad business.  The
+girl died, too, died within a year.  So she left a son, did she?  I had
+forgotten that.  What sort of boy is he?  If he is like his mother, he
+must be a good-looking chap."
+
+"He is very good-looking," assented Lord Henry.
+
+"I hope he will fall into proper hands," continued the old man.  "He
+should have a pot of money waiting for him if Kelso did the right thing
+by him.  His mother had money, too.  All the Selby property came to
+her, through her grandfather.  Her grandfather hated Kelso, thought him
+a mean dog.  He was, too.  Came to Madrid once when I was there.  Egad,
+I was ashamed of him.  The Queen used to ask me about the English noble
+who was always quarrelling with the cabmen about their fares.  They
+made quite a story of it.  I didn't dare show my face at Court for a
+month.  I hope he treated his grandson better than he did the jarvies."
+
+"I don't know," answered Lord Henry.  "I fancy that the boy will be
+well off.  He is not of age yet.  He has Selby, I know.  He told me so.
+And ... his mother was very beautiful?"
+
+"Margaret Devereux was one of the loveliest creatures I ever saw,
+Harry.  What on earth induced her to behave as she did, I never could
+understand.  She could have married anybody she chose.  Carlington was
+mad after her.  She was romantic, though.  All the women of that family
+were.  The men were a poor lot, but, egad! the women were wonderful.
+Carlington went on his knees to her.  Told me so himself.  She laughed
+at him, and there wasn't a girl in London at the time who wasn't after
+him.  And by the way, Harry, talking about silly marriages, what is
+this humbug your father tells me about Dartmoor wanting to marry an
+American?  Ain't English girls good enough for him?"
+
+"It is rather fashionable to marry Americans just now, Uncle George."
+
+"I'll back English women against the world, Harry," said Lord Fermor,
+striking the table with his fist.
+
+"The betting is on the Americans."
+
+"They don't last, I am told," muttered his uncle.
+
+"A long engagement exhausts them, but they are capital at a
+steeplechase.  They take things flying.  I don't think Dartmoor has a
+chance."
+
+"Who are her people?" grumbled the old gentleman.  "Has she got any?"
+
+Lord Henry shook his head.  "American girls are as clever at concealing
+their parents, as English women are at concealing their past," he said,
+rising to go.
+
+"They are pork-packers, I suppose?"
+
+"I hope so, Uncle George, for Dartmoor's sake.  I am told that
+pork-packing is the most lucrative profession in America, after
+politics."
+
+"Is she pretty?"
+
+"She behaves as if she was beautiful.  Most American women do.  It is
+the secret of their charm."
+
+"Why can't these American women stay in their own country?  They are
+always telling us that it is the paradise for women."
+
+"It is.  That is the reason why, like Eve, they are so excessively
+anxious to get out of it," said Lord Henry.  "Good-bye, Uncle George.
+I shall be late for lunch, if I stop any longer.  Thanks for giving me
+the information I wanted.  I always like to know everything about my
+new friends, and nothing about my old ones."
+
+"Where are you lunching, Harry?"
+
+"At Aunt Agatha's. I have asked myself and Mr. Gray.  He is her latest
+_protege_."
+
+"Humph! tell your Aunt Agatha, Harry, not to bother me any more with
+her charity appeals.  I am sick of them.  Why, the good woman thinks
+that I have nothing to do but to write cheques for her silly fads."
+
+"All right, Uncle George, I'll tell her, but it won't have any effect.
+Philanthropic people lose all sense of humanity.  It is their
+distinguishing characteristic."
+
+The old gentleman growled approvingly and rang the bell for his
+servant.  Lord Henry passed up the low arcade into Burlington Street
+and turned his steps in the direction of Berkeley Square.
+
+So that was the story of Dorian Gray's parentage.  Crudely as it had
+been told to him, it had yet stirred him by its suggestion of a
+strange, almost modern romance.  A beautiful woman risking everything
+for a mad passion.  A few wild weeks of happiness cut short by a
+hideous, treacherous crime.  Months of voiceless agony, and then a
+child born in pain.  The mother snatched away by death, the boy left to
+solitude and the tyranny of an old and loveless man.  Yes; it was an
+interesting background.  It posed the lad, made him more perfect, as it
+were.  Behind every exquisite thing that existed, there was something
+tragic.  Worlds had to be in travail, that the meanest flower might
+blow.... And how charming he had been at dinner the night before, as
+with startled eyes and lips parted in frightened pleasure he had sat
+opposite to him at the club, the red candleshades staining to a richer
+rose the wakening wonder of his face.  Talking to him was like playing
+upon an exquisite violin.  He answered to every touch and thrill of the
+bow.... There was something terribly enthralling in the exercise of
+influence.  No other activity was like it.  To project one's soul into
+some gracious form, and let it tarry there for a moment; to hear one's
+own intellectual views echoed back to one with all the added music of
+passion and youth; to convey one's temperament into another as though
+it were a subtle fluid or a strange perfume: there was a real joy in
+that--perhaps the most satisfying joy left to us in an age so limited
+and vulgar as our own, an age grossly carnal in its pleasures, and
+grossly common in its aims.... He was a marvellous type, too, this lad,
+whom by so curious a chance he had met in Basil's studio, or could be
+fashioned into a marvellous type, at any rate.  Grace was his, and the
+white purity of boyhood, and beauty such as old Greek marbles kept for
+us.  There was nothing that one could not do with him.  He could be
+made a Titan or a toy.  What a pity it was that such beauty was
+destined to fade! ...  And Basil?  From a psychological point of view,
+how interesting he was!  The new manner in art, the fresh mode of
+looking at life, suggested so strangely by the merely visible presence
+of one who was unconscious of it all; the silent spirit that dwelt in
+dim woodland, and walked unseen in open field, suddenly showing
+herself, Dryadlike and not afraid, because in his soul who sought for
+her there had been wakened that wonderful vision to which alone are
+wonderful things revealed; the mere shapes and patterns of things
+becoming, as it were, refined, and gaining a kind of symbolical value,
+as though they were themselves patterns of some other and more perfect
+form whose shadow they made real:  how strange it all was!  He
+remembered something like it in history.  Was it not Plato, that artist
+in thought, who had first analyzed it?  Was it not Buonarotti who had
+carved it in the coloured marbles of a sonnet-sequence? But in our own
+century it was strange.... Yes; he would try to be to Dorian Gray
+what, without knowing it, the lad was to the painter who had fashioned
+the wonderful portrait.  He would seek to dominate him--had already,
+indeed, half done so.  He would make that wonderful spirit his own.
+There was something fascinating in this son of love and death.
+
+Suddenly he stopped and glanced up at the houses.  He found that he had
+passed his aunt's some distance, and, smiling to himself, turned back.
+When he entered the somewhat sombre hall, the butler told him that they
+had gone in to lunch.  He gave one of the footmen his hat and stick and
+passed into the dining-room.
+
+"Late as usual, Harry," cried his aunt, shaking her head at him.
+
+He invented a facile excuse, and having taken the vacant seat next to
+her, looked round to see who was there.  Dorian bowed to him shyly from
+the end of the table, a flush of pleasure stealing into his cheek.
+Opposite was the Duchess of Harley, a lady of admirable good-nature and
+good temper, much liked by every one who knew her, and of those ample
+architectural proportions that in women who are not duchesses are
+described by contemporary historians as stoutness.  Next to her sat, on
+her right, Sir Thomas Burdon, a Radical member of Parliament, who
+followed his leader in public life and in private life followed the
+best cooks, dining with the Tories and thinking with the Liberals, in
+accordance with a wise and well-known rule.  The post on her left was
+occupied by Mr. Erskine of Treadley, an old gentleman of considerable
+charm and culture, who had fallen, however, into bad habits of silence,
+having, as he explained once to Lady Agatha, said everything that he
+had to say before he was thirty.  His own neighbour was Mrs. Vandeleur,
+one of his aunt's oldest friends, a perfect saint amongst women, but so
+dreadfully dowdy that she reminded one of a badly bound hymn-book.
+Fortunately for him she had on the other side Lord Faudel, a most
+intelligent middle-aged mediocrity, as bald as a ministerial statement
+in the House of Commons, with whom she was conversing in that intensely
+earnest manner which is the one unpardonable error, as he remarked once
+himself, that all really good people fall into, and from which none of
+them ever quite escape.
+
+"We are talking about poor Dartmoor, Lord Henry," cried the duchess,
+nodding pleasantly to him across the table.  "Do you think he will
+really marry this fascinating young person?"
+
+"I believe she has made up her mind to propose to him, Duchess."
+
+"How dreadful!" exclaimed Lady Agatha.  "Really, some one should
+interfere."
+
+"I am told, on excellent authority, that her father keeps an American
+dry-goods store," said Sir Thomas Burdon, looking supercilious.
+
+"My uncle has already suggested pork-packing, Sir Thomas."
+
+"Dry-goods! What are American dry-goods?" asked the duchess, raising
+her large hands in wonder and accentuating the verb.
+
+"American novels," answered Lord Henry, helping himself to some quail.
+
+The duchess looked puzzled.
+
+"Don't mind him, my dear," whispered Lady Agatha.  "He never means
+anything that he says."
+
+"When America was discovered," said the Radical member--and he began to
+give some wearisome facts.  Like all people who try to exhaust a
+subject, he exhausted his listeners.  The duchess sighed and exercised
+her privilege of interruption.  "I wish to goodness it never had been
+discovered at all!" she exclaimed.  "Really, our girls have no chance
+nowadays.  It is most unfair."
+
+"Perhaps, after all, America never has been discovered," said Mr.
+Erskine; "I myself would say that it had merely been detected."
+
+"Oh! but I have seen specimens of the inhabitants," answered the
+duchess vaguely.  "I must confess that most of them are extremely
+pretty.  And they dress well, too.  They get all their dresses in
+Paris.  I wish I could afford to do the same."
+
+"They say that when good Americans die they go to Paris," chuckled Sir
+Thomas, who had a large wardrobe of Humour's cast-off clothes.
+
+"Really!  And where do bad Americans go to when they die?" inquired the
+duchess.
+
+"They go to America," murmured Lord Henry.
+
+Sir Thomas frowned.  "I am afraid that your nephew is prejudiced
+against that great country," he said to Lady Agatha.  "I have travelled
+all over it in cars provided by the directors, who, in such matters,
+are extremely civil.  I assure you that it is an education to visit it."
+
+"But must we really see Chicago in order to be educated?" asked Mr.
+Erskine plaintively.  "I don't feel up to the journey."
+
+Sir Thomas waved his hand.  "Mr. Erskine of Treadley has the world on
+his shelves. We practical men like to see things, not to read about
+them. The Americans are an extremely interesting people. They are
+absolutely reasonable. I think that is their distinguishing
+characteristic. Yes, Mr. Erskine, an absolutely reasonable people. I
+assure you there is no nonsense about the Americans."
+
+"How dreadful!" cried Lord Henry.  "I can stand brute force, but brute
+reason is quite unbearable.  There is something unfair about its use.
+It is hitting below the intellect."
+
+"I do not understand you," said Sir Thomas, growing rather red.
+
+"I do, Lord Henry," murmured Mr. Erskine, with a smile.
+
+"Paradoxes are all very well in their way...." rejoined the baronet.
+
+"Was that a paradox?" asked Mr. Erskine.  "I did not think so.  Perhaps
+it was.  Well, the way of paradoxes is the way of truth.  To test
+reality we must see it on the tight rope.  When the verities become
+acrobats, we can judge them."
+
+"Dear me!" said Lady Agatha, "how you men argue!  I am sure I never can
+make out what you are talking about.  Oh!  Harry, I am quite vexed with
+you.  Why do you try to persuade our nice Mr. Dorian Gray to give up
+the East End?  I assure you he would be quite invaluable.  They would
+love his playing."
+
+"I want him to play to me," cried Lord Henry, smiling, and he looked
+down the table and caught a bright answering glance.
+
+"But they are so unhappy in Whitechapel," continued Lady Agatha.
+
+"I can sympathize with everything except suffering," said Lord Henry,
+shrugging his shoulders.  "I cannot sympathize with that.  It is too
+ugly, too horrible, too distressing.  There is something terribly
+morbid in the modern sympathy with pain.  One should sympathize with
+the colour, the beauty, the joy of life.  The less said about life's
+sores, the better."
+
+"Still, the East End is a very important problem," remarked Sir Thomas
+with a grave shake of the head.
+
+"Quite so," answered the young lord.  "It is the problem of slavery,
+and we try to solve it by amusing the slaves."
+
+The politician looked at him keenly.  "What change do you propose,
+then?" he asked.
+
+Lord Henry laughed.  "I don't desire to change anything in England
+except the weather," he answered.  "I am quite content with philosophic
+contemplation.  But, as the nineteenth century has gone bankrupt
+through an over-expenditure of sympathy, I would suggest that we should
+appeal to science to put us straight.  The advantage of the emotions is
+that they lead us astray, and the advantage of science is that it is
+not emotional."
+
+"But we have such grave responsibilities," ventured Mrs. Vandeleur
+timidly.
+
+"Terribly grave," echoed Lady Agatha.
+
+Lord Henry looked over at Mr. Erskine.  "Humanity takes itself too
+seriously.  It is the world's original sin.  If the caveman had known
+how to laugh, history would have been different."
+
+"You are really very comforting," warbled the duchess.  "I have always
+felt rather guilty when I came to see your dear aunt, for I take no
+interest at all in the East End.  For the future I shall be able to
+look her in the face without a blush."
+
+"A blush is very becoming, Duchess," remarked Lord Henry.
+
+"Only when one is young," she answered.  "When an old woman like myself
+blushes, it is a very bad sign.  Ah!  Lord Henry, I wish you would tell
+me how to become young again."
+
+He thought for a moment.  "Can you remember any great error that you
+committed in your early days, Duchess?" he asked, looking at her across
+the table.
+
+"A great many, I fear," she cried.
+
+"Then commit them over again," he said gravely.  "To get back one's
+youth, one has merely to repeat one's follies."
+
+"A delightful theory!" she exclaimed.  "I must put it into practice."
+
+"A dangerous theory!" came from Sir Thomas's tight lips.  Lady Agatha
+shook her head, but could not help being amused.  Mr. Erskine listened.
+
+"Yes," he continued, "that is one of the great secrets of life.
+Nowadays most people die of a sort of creeping common sense, and
+discover when it is too late that the only things one never regrets are
+one's mistakes."
+
+A laugh ran round the table.
+
+He played with the idea and grew wilful; tossed it into the air and
+transformed it; let it escape and recaptured it; made it iridescent
+with fancy and winged it with paradox.  The praise of folly, as he went
+on, soared into a philosophy, and philosophy herself became young, and
+catching the mad music of pleasure, wearing, one might fancy, her
+wine-stained robe and wreath of ivy, danced like a Bacchante over the
+hills of life, and mocked the slow Silenus for being sober.  Facts fled
+before her like frightened forest things.  Her white feet trod the huge
+press at which wise Omar sits, till the seething grape-juice rose round
+her bare limbs in waves of purple bubbles, or crawled in red foam over
+the vat's black, dripping, sloping sides.  It was an extraordinary
+improvisation.  He felt that the eyes of Dorian Gray were fixed on him,
+and the consciousness that amongst his audience there was one whose
+temperament he wished to fascinate seemed to give his wit keenness and
+to lend colour to his imagination.  He was brilliant, fantastic,
+irresponsible.  He charmed his listeners out of themselves, and they
+followed his pipe, laughing.  Dorian Gray never took his gaze off him,
+but sat like one under a spell, smiles chasing each other over his lips
+and wonder growing grave in his darkening eyes.
+
+At last, liveried in the costume of the age, reality entered the room
+in the shape of a servant to tell the duchess that her carriage was
+waiting.  She wrung her hands in mock despair.  "How annoying!" she
+cried.  "I must go.  I have to call for my husband at the club, to take
+him to some absurd meeting at Willis's Rooms, where he is going to be
+in the chair.  If I am late he is sure to be furious, and I couldn't
+have a scene in this bonnet.  It is far too fragile.  A harsh word
+would ruin it.  No, I must go, dear Agatha.  Good-bye, Lord Henry, you
+are quite delightful and dreadfully demoralizing.  I am sure I don't
+know what to say about your views.  You must come and dine with us some
+night.  Tuesday?  Are you disengaged Tuesday?"
+
+"For you I would throw over anybody, Duchess," said Lord Henry with a
+bow.
+
+"Ah! that is very nice, and very wrong of you," she cried; "so mind you
+come"; and she swept out of the room, followed by Lady Agatha and the
+other ladies.
+
+When Lord Henry had sat down again, Mr. Erskine moved round, and taking
+a chair close to him, placed his hand upon his arm.
+
+"You talk books away," he said; "why don't you write one?"
+
+"I am too fond of reading books to care to write them, Mr. Erskine.  I
+should like to write a novel certainly, a novel that would be as lovely
+as a Persian carpet and as unreal.  But there is no literary public in
+England for anything except newspapers, primers, and encyclopaedias.
+Of all people in the world the English have the least sense of the
+beauty of literature."
+
+"I fear you are right," answered Mr. Erskine.  "I myself used to have
+literary ambitions, but I gave them up long ago.  And now, my dear
+young friend, if you will allow me to call you so, may I ask if you
+really meant all that you said to us at lunch?"
+
+"I quite forget what I said," smiled Lord Henry.  "Was it all very bad?"
+
+"Very bad indeed.  In fact I consider you extremely dangerous, and if
+anything happens to our good duchess, we shall all look on you as being
+primarily responsible.  But I should like to talk to you about life.
+The generation into which I was born was tedious.  Some day, when you
+are tired of London, come down to Treadley and expound to me your
+philosophy of pleasure over some admirable Burgundy I am fortunate
+enough to possess."
+
+"I shall be charmed.  A visit to Treadley would be a great privilege.
+It has a perfect host, and a perfect library."
+
+"You will complete it," answered the old gentleman with a courteous
+bow.  "And now I must bid good-bye to your excellent aunt.  I am due at
+the Athenaeum.  It is the hour when we sleep there."
+
+"All of you, Mr. Erskine?"
+
+"Forty of us, in forty arm-chairs. We are practising for an English
+Academy of Letters."
+
+Lord Henry laughed and rose.  "I am going to the park," he cried.
+
+As he was passing out of the door, Dorian Gray touched him on the arm.
+"Let me come with you," he murmured.
+
+"But I thought you had promised Basil Hallward to go and see him,"
+answered Lord Henry.
+
+"I would sooner come with you; yes, I feel I must come with you.  Do
+let me.  And you will promise to talk to me all the time?  No one talks
+so wonderfully as you do."
+
+"Ah!  I have talked quite enough for to-day," said Lord Henry, smiling.
+"All I want now is to look at life.  You may come and look at it with
+me, if you care to."
+
+
+
+CHAPTER 4
+
+One afternoon, a month later, Dorian Gray was reclining in a luxurious
+arm-chair, in the little library of Lord Henry's house in Mayfair.  It
+was, in its way, a very charming room, with its high panelled
+wainscoting of olive-stained oak, its cream-coloured frieze and ceiling
+of raised plasterwork, and its brickdust felt carpet strewn with silk,
+long-fringed Persian rugs.  On a tiny satinwood table stood a statuette
+by Clodion, and beside it lay a copy of Les Cent Nouvelles, bound for
+Margaret of Valois by Clovis Eve and powdered with the gilt daisies
+that Queen had selected for her device.  Some large blue china jars and
+parrot-tulips were ranged on the mantelshelf, and through the small
+leaded panes of the window streamed the apricot-coloured light of a
+summer day in London.
+
+Lord Henry had not yet come in.  He was always late on principle, his
+principle being that punctuality is the thief of time.  So the lad was
+looking rather sulky, as with listless fingers he turned over the pages
+of an elaborately illustrated edition of Manon Lescaut that he had
+found in one of the book-cases. The formal monotonous ticking of the
+Louis Quatorze clock annoyed him.  Once or twice he thought of going
+away.
+
+At last he heard a step outside, and the door opened.  "How late you
+are, Harry!" he murmured.
+
+"I am afraid it is not Harry, Mr. Gray," answered a shrill voice.
+
+He glanced quickly round and rose to his feet.  "I beg your pardon.  I
+thought--"
+
+"You thought it was my husband.  It is only his wife.  You must let me
+introduce myself.  I know you quite well by your photographs.  I think
+my husband has got seventeen of them."
+
+"Not seventeen, Lady Henry?"
+
+"Well, eighteen, then.  And I saw you with him the other night at the
+opera."  She laughed nervously as she spoke, and watched him with her
+vague forget-me-not eyes.  She was a curious woman, whose dresses
+always looked as if they had been designed in a rage and put on in a
+tempest.  She was usually in love with somebody, and, as her passion
+was never returned, she had kept all her illusions.  She tried to look
+picturesque, but only succeeded in being untidy.  Her name was
+Victoria, and she had a perfect mania for going to church.
+
+"That was at Lohengrin, Lady Henry, I think?"
+
+"Yes; it was at dear Lohengrin.  I like Wagner's music better than
+anybody's. It is so loud that one can talk the whole time without other
+people hearing what one says.  That is a great advantage, don't you
+think so, Mr. Gray?"
+
+The same nervous staccato laugh broke from her thin lips, and her
+fingers began to play with a long tortoise-shell paper-knife.
+
+Dorian smiled and shook his head:  "I am afraid I don't think so, Lady
+Henry.  I never talk during music--at least, during good music.  If one
+hears bad music, it is one's duty to drown it in conversation."
+
+"Ah! that is one of Harry's views, isn't it, Mr. Gray?  I always hear
+Harry's views from his friends.  It is the only way I get to know of
+them.  But you must not think I don't like good music.  I adore it, but
+I am afraid of it.  It makes me too romantic.  I have simply worshipped
+pianists--two at a time, sometimes, Harry tells me.  I don't know what
+it is about them.  Perhaps it is that they are foreigners.  They all
+are, ain't they?  Even those that are born in England become foreigners
+after a time, don't they?  It is so clever of them, and such a
+compliment to art.  Makes it quite cosmopolitan, doesn't it?  You have
+never been to any of my parties, have you, Mr. Gray?  You must come.  I
+can't afford orchids, but I spare no expense in foreigners.  They make
+one's rooms look so picturesque.  But here is Harry!  Harry, I came in
+to look for you, to ask you something--I forget what it was--and I
+found Mr. Gray here.  We have had such a pleasant chat about music.  We
+have quite the same ideas.  No; I think our ideas are quite different.
+But he has been most pleasant.  I am so glad I've seen him."
+
+"I am charmed, my love, quite charmed," said Lord Henry, elevating his
+dark, crescent-shaped eyebrows and looking at them both with an amused
+smile.  "So sorry I am late, Dorian.  I went to look after a piece of
+old brocade in Wardour Street and had to bargain for hours for it.
+Nowadays people know the price of everything and the value of nothing."
+
+"I am afraid I must be going," exclaimed Lady Henry, breaking an
+awkward silence with her silly sudden laugh.  "I have promised to drive
+with the duchess.  Good-bye, Mr. Gray.  Good-bye, Harry.  You are
+dining out, I suppose?  So am I. Perhaps I shall see you at Lady
+Thornbury's."
+
+"I dare say, my dear," said Lord Henry, shutting the door behind her
+as, looking like a bird of paradise that had been out all night in the
+rain, she flitted out of the room, leaving a faint odour of
+frangipanni.  Then he lit a cigarette and flung himself down on the
+sofa.
+
+"Never marry a woman with straw-coloured hair, Dorian," he said after a
+few puffs.
+
+"Why, Harry?"
+
+"Because they are so sentimental."
+
+"But I like sentimental people."
+
+"Never marry at all, Dorian.  Men marry because they are tired; women,
+because they are curious:  both are disappointed."
+
+"I don't think I am likely to marry, Harry.  I am too much in love.
+That is one of your aphorisms.  I am putting it into practice, as I do
+everything that you say."
+
+"Who are you in love with?" asked Lord Henry after a pause.
+
+"With an actress," said Dorian Gray, blushing.
+
+Lord Henry shrugged his shoulders.  "That is a rather commonplace
+_debut_."
+
+"You would not say so if you saw her, Harry."
+
+"Who is she?"
+
+"Her name is Sibyl Vane."
+
+"Never heard of her."
+
+"No one has.  People will some day, however.  She is a genius."
+
+"My dear boy, no woman is a genius.  Women are a decorative sex.  They
+never have anything to say, but they say it charmingly.  Women
+represent the triumph of matter over mind, just as men represent the
+triumph of mind over morals."
+
+"Harry, how can you?"
+
+"My dear Dorian, it is quite true.  I am analysing women at present, so
+I ought to know.  The subject is not so abstruse as I thought it was.
+I find that, ultimately, there are only two kinds of women, the plain
+and the coloured.  The plain women are very useful.  If you want to
+gain a reputation for respectability, you have merely to take them down
+to supper.  The other women are very charming.  They commit one
+mistake, however.  They paint in order to try and look young.  Our
+grandmothers painted in order to try and talk brilliantly.  _Rouge_ and
+_esprit_ used to go together.  That is all over now.  As long as a woman
+can look ten years younger than her own daughter, she is perfectly
+satisfied.  As for conversation, there are only five women in London
+worth talking to, and two of these can't be admitted into decent
+society.  However, tell me about your genius.  How long have you known
+her?"
+
+"Ah!  Harry, your views terrify me."
+
+"Never mind that.  How long have you known her?"
+
+"About three weeks."
+
+"And where did you come across her?"
+
+"I will tell you, Harry, but you mustn't be unsympathetic about it.
+After all, it never would have happened if I had not met you.  You
+filled me with a wild desire to know everything about life.  For days
+after I met you, something seemed to throb in my veins.  As I lounged
+in the park, or strolled down Piccadilly, I used to look at every one
+who passed me and wonder, with a mad curiosity, what sort of lives they
+led.  Some of them fascinated me.  Others filled me with terror.  There
+was an exquisite poison in the air.  I had a passion for sensations....
+Well, one evening about seven o'clock, I determined to go out in search
+of some adventure.  I felt that this grey monstrous London of ours,
+with its myriads of people, its sordid sinners, and its splendid sins,
+as you once phrased it, must have something in store for me.  I fancied
+a thousand things.  The mere danger gave me a sense of delight.  I
+remembered what you had said to me on that wonderful evening when we
+first dined together, about the search for beauty being the real secret
+of life.  I don't know what I expected, but I went out and wandered
+eastward, soon losing my way in a labyrinth of grimy streets and black
+grassless squares.  About half-past eight I passed by an absurd little
+theatre, with great flaring gas-jets and gaudy play-bills.  A hideous
+Jew, in the most amazing waistcoat I ever beheld in my life, was
+standing at the entrance, smoking a vile cigar.  He had greasy
+ringlets, and an enormous diamond blazed in the centre of a soiled
+shirt. 'Have a box, my Lord?' he said, when he saw me, and he took off
+his hat with an air of gorgeous servility.  There was something about
+him, Harry, that amused me.  He was such a monster.  You will laugh at
+me, I know, but I really went in and paid a whole guinea for the
+stage-box. To the present day I can't make out why I did so; and yet if
+I hadn't--my dear Harry, if I hadn't--I should have missed the greatest
+romance of my life.  I see you are laughing.  It is horrid of you!"
+
+"I am not laughing, Dorian; at least I am not laughing at you.  But you
+should not say the greatest romance of your life.  You should say the
+first romance of your life.  You will always be loved, and you will
+always be in love with love.  A _grande passion_ is the privilege of
+people who have nothing to do.  That is the one use of the idle classes
+of a country.  Don't be afraid.  There are exquisite things in store
+for you.  This is merely the beginning."
+
+"Do you think my nature so shallow?" cried Dorian Gray angrily.
+
+"No; I think your nature so deep."
+
+"How do you mean?"
+
+"My dear boy, the people who love only once in their lives are really
+the shallow people.  What they call their loyalty, and their fidelity,
+I call either the lethargy of custom or their lack of imagination.
+Faithfulness is to the emotional life what consistency is to the life
+of the intellect--simply a confession of failure.  Faithfulness!  I
+must analyse it some day.  The passion for property is in it.  There
+are many things that we would throw away if we were not afraid that
+others might pick them up.  But I don't want to interrupt you.  Go on
+with your story."
+
+"Well, I found myself seated in a horrid little private box, with a
+vulgar drop-scene staring me in the face.  I looked out from behind the
+curtain and surveyed the house.  It was a tawdry affair, all Cupids and
+cornucopias, like a third-rate wedding-cake. The gallery and pit were
+fairly full, but the two rows of dingy stalls were quite empty, and
+there was hardly a person in what I suppose they called the
+dress-circle.  Women went about with oranges and ginger-beer, and there
+was a terrible consumption of nuts going on."
+
+"It must have been just like the palmy days of the British drama."
+
+"Just like, I should fancy, and very depressing.  I began to wonder
+what on earth I should do when I caught sight of the play-bill.  What
+do you think the play was, Harry?"
+
+"I should think 'The Idiot Boy', or 'Dumb but Innocent'.  Our fathers
+used to like that sort of piece, I believe.  The longer I live, Dorian,
+the more keenly I feel that whatever was good enough for our fathers is
+not good enough for us.  In art, as in politics, _les grandperes ont
+toujours tort_."
+
+"This play was good enough for us, Harry.  It was Romeo and Juliet.  I
+must admit that I was rather annoyed at the idea of seeing Shakespeare
+done in such a wretched hole of a place.  Still, I felt interested, in
+a sort of way.  At any rate, I determined to wait for the first act.
+There was a dreadful orchestra, presided over by a young Hebrew who sat
+at a cracked piano, that nearly drove me away, but at last the
+drop-scene was drawn up and the play began.  Romeo was a stout elderly
+gentleman, with corked eyebrows, a husky tragedy voice, and a figure
+like a beer-barrel. Mercutio was almost as bad.  He was played by the
+low-comedian, who had introduced gags of his own and was on most
+friendly terms with the pit.  They were both as grotesque as the
+scenery, and that looked as if it had come out of a country-booth. But
+Juliet!  Harry, imagine a girl, hardly seventeen years of age, with a
+little, flowerlike face, a small Greek head with plaited coils of
+dark-brown hair, eyes that were violet wells of passion, lips that were
+like the petals of a rose.  She was the loveliest thing I had ever seen
+in my life.  You said to me once that pathos left you unmoved, but that
+beauty, mere beauty, could fill your eyes with tears.  I tell you,
+Harry, I could hardly see this girl for the mist of tears that came
+across me.  And her voice--I never heard such a voice.  It was very low
+at first, with deep mellow notes that seemed to fall singly upon one's
+ear.  Then it became a little louder, and sounded like a flute or a
+distant hautboy.  In the garden-scene it had all the tremulous ecstasy
+that one hears just before dawn when nightingales are singing.  There
+were moments, later on, when it had the wild passion of violins.  You
+know how a voice can stir one.  Your voice and the voice of Sibyl Vane
+are two things that I shall never forget.  When I close my eyes, I hear
+them, and each of them says something different.  I don't know which to
+follow.  Why should I not love her?  Harry, I do love her.  She is
+everything to me in life.  Night after night I go to see her play.  One
+evening she is Rosalind, and the next evening she is Imogen.  I have
+seen her die in the gloom of an Italian tomb, sucking the poison from
+her lover's lips.  I have watched her wandering through the forest of
+Arden, disguised as a pretty boy in hose and doublet and dainty cap.
+She has been mad, and has come into the presence of a guilty king, and
+given him rue to wear and bitter herbs to taste of.  She has been
+innocent, and the black hands of jealousy have crushed her reedlike
+throat.  I have seen her in every age and in every costume.  Ordinary
+women never appeal to one's imagination.  They are limited to their
+century.  No glamour ever transfigures them.  One knows their minds as
+easily as one knows their bonnets.  One can always find them.  There is
+no mystery in any of them.  They ride in the park in the morning and
+chatter at tea-parties in the afternoon.  They have their stereotyped
+smile and their fashionable manner.  They are quite obvious.  But an
+actress!  How different an actress is!  Harry! why didn't you tell me
+that the only thing worth loving is an actress?"
+
+"Because I have loved so many of them, Dorian."
+
+"Oh, yes, horrid people with dyed hair and painted faces."
+
+"Don't run down dyed hair and painted faces.  There is an extraordinary
+charm in them, sometimes," said Lord Henry.
+
+"I wish now I had not told you about Sibyl Vane."
+
+"You could not have helped telling me, Dorian.  All through your life
+you will tell me everything you do."
+
+"Yes, Harry, I believe that is true.  I cannot help telling you things.
+You have a curious influence over me.  If I ever did a crime, I would
+come and confess it to you.  You would understand me."
+
+"People like you--the wilful sunbeams of life--don't commit crimes,
+Dorian.  But I am much obliged for the compliment, all the same.  And
+now tell me--reach me the matches, like a good boy--thanks--what are
+your actual relations with Sibyl Vane?"
+
+Dorian Gray leaped to his feet, with flushed cheeks and burning eyes.
+"Harry!  Sibyl Vane is sacred!"
+
+"It is only the sacred things that are worth touching, Dorian," said
+Lord Henry, with a strange touch of pathos in his voice.  "But why
+should you be annoyed?  I suppose she will belong to you some day.
+When one is in love, one always begins by deceiving one's self, and one
+always ends by deceiving others.  That is what the world calls a
+romance.  You know her, at any rate, I suppose?"
+
+"Of course I know her.  On the first night I was at the theatre, the
+horrid old Jew came round to the box after the performance was over and
+offered to take me behind the scenes and introduce me to her.  I was
+furious with him, and told him that Juliet had been dead for hundreds
+of years and that her body was lying in a marble tomb in Verona.  I
+think, from his blank look of amazement, that he was under the
+impression that I had taken too much champagne, or something."
+
+"I am not surprised."
+
+"Then he asked me if I wrote for any of the newspapers.  I told him I
+never even read them.  He seemed terribly disappointed at that, and
+confided to me that all the dramatic critics were in a conspiracy
+against him, and that they were every one of them to be bought."
+
+"I should not wonder if he was quite right there.  But, on the other
+hand, judging from their appearance, most of them cannot be at all
+expensive."
+
+"Well, he seemed to think they were beyond his means," laughed Dorian.
+"By this time, however, the lights were being put out in the theatre,
+and I had to go.  He wanted me to try some cigars that he strongly
+recommended.  I declined.  The next night, of course, I arrived at the
+place again.  When he saw me, he made me a low bow and assured me that
+I was a munificent patron of art.  He was a most offensive brute,
+though he had an extraordinary passion for Shakespeare.  He told me
+once, with an air of pride, that his five bankruptcies were entirely
+due to 'The Bard,' as he insisted on calling him.  He seemed to think
+it a distinction."
+
+"It was a distinction, my dear Dorian--a great distinction.  Most
+people become bankrupt through having invested too heavily in the prose
+of life.  To have ruined one's self over poetry is an honour.  But when
+did you first speak to Miss Sibyl Vane?"
+
+"The third night.  She had been playing Rosalind.  I could not help
+going round.  I had thrown her some flowers, and she had looked at
+me--at least I fancied that she had.  The old Jew was persistent.  He
+seemed determined to take me behind, so I consented.  It was curious my
+not wanting to know her, wasn't it?"
+
+"No; I don't think so."
+
+"My dear Harry, why?"
+
+"I will tell you some other time.  Now I want to know about the girl."
+
+"Sibyl?  Oh, she was so shy and so gentle.  There is something of a
+child about her.  Her eyes opened wide in exquisite wonder when I told
+her what I thought of her performance, and she seemed quite unconscious
+of her power.  I think we were both rather nervous.  The old Jew stood
+grinning at the doorway of the dusty greenroom, making elaborate
+speeches about us both, while we stood looking at each other like
+children.  He would insist on calling me 'My Lord,' so I had to assure
+Sibyl that I was not anything of the kind.  She said quite simply to
+me, 'You look more like a prince.  I must call you Prince Charming.'"
+
+"Upon my word, Dorian, Miss Sibyl knows how to pay compliments."
+
+"You don't understand her, Harry.  She regarded me merely as a person
+in a play.  She knows nothing of life.  She lives with her mother, a
+faded tired woman who played Lady Capulet in a sort of magenta
+dressing-wrapper on the first night, and looks as if she had seen
+better days."
+
+"I know that look.  It depresses me," murmured Lord Henry, examining
+his rings.
+
+"The Jew wanted to tell me her history, but I said it did not interest
+me."
+
+"You were quite right.  There is always something infinitely mean about
+other people's tragedies."
+
+"Sibyl is the only thing I care about.  What is it to me where she came
+from?  From her little head to her little feet, she is absolutely and
+entirely divine.  Every night of my life I go to see her act, and every
+night she is more marvellous."
+
+"That is the reason, I suppose, that you never dine with me now.  I
+thought you must have some curious romance on hand.  You have; but it
+is not quite what I expected."
+
+"My dear Harry, we either lunch or sup together every day, and I have
+been to the opera with you several times," said Dorian, opening his
+blue eyes in wonder.
+
+"You always come dreadfully late."
+
+"Well, I can't help going to see Sibyl play," he cried, "even if it is
+only for a single act.  I get hungry for her presence; and when I think
+of the wonderful soul that is hidden away in that little ivory body, I
+am filled with awe."
+
+"You can dine with me to-night, Dorian, can't you?"
+
+He shook his head.  "To-night she is Imogen," he answered, "and
+to-morrow night she will be Juliet."
+
+"When is she Sibyl Vane?"
+
+"Never."
+
+"I congratulate you."
+
+"How horrid you are!  She is all the great heroines of the world in
+one.  She is more than an individual.  You laugh, but I tell you she
+has genius.  I love her, and I must make her love me.  You, who know
+all the secrets of life, tell me how to charm Sibyl Vane to love me!  I
+want to make Romeo jealous.  I want the dead lovers of the world to
+hear our laughter and grow sad.  I want a breath of our passion to stir
+their dust into consciousness, to wake their ashes into pain.  My God,
+Harry, how I worship her!"  He was walking up and down the room as he
+spoke.  Hectic spots of red burned on his cheeks.  He was terribly
+excited.
+
+Lord Henry watched him with a subtle sense of pleasure.  How different
+he was now from the shy frightened boy he had met in Basil Hallward's
+studio!  His nature had developed like a flower, had borne blossoms of
+scarlet flame.  Out of its secret hiding-place had crept his soul, and
+desire had come to meet it on the way.
+
+"And what do you propose to do?" said Lord Henry at last.
+
+"I want you and Basil to come with me some night and see her act.  I
+have not the slightest fear of the result.  You are certain to
+acknowledge her genius.  Then we must get her out of the Jew's hands.
+She is bound to him for three years--at least for two years and eight
+months--from the present time.  I shall have to pay him something, of
+course.  When all that is settled, I shall take a West End theatre and
+bring her out properly.  She will make the world as mad as she has made
+me."
+
+"That would be impossible, my dear boy."
+
+"Yes, she will.  She has not merely art, consummate art-instinct, in
+her, but she has personality also; and you have often told me that it
+is personalities, not principles, that move the age."
+
+"Well, what night shall we go?"
+
+"Let me see.  To-day is Tuesday.  Let us fix to-morrow. She plays
+Juliet to-morrow."
+
+"All right.  The Bristol at eight o'clock; and I will get Basil."
+
+"Not eight, Harry, please.  Half-past six.  We must be there before the
+curtain rises.  You must see her in the first act, where she meets
+Romeo."
+
+"Half-past six!  What an hour!  It will be like having a meat-tea, or
+reading an English novel.  It must be seven.  No gentleman dines before
+seven.  Shall you see Basil between this and then?  Or shall I write to
+him?"
+
+"Dear Basil!  I have not laid eyes on him for a week.  It is rather
+horrid of me, as he has sent me my portrait in the most wonderful
+frame, specially designed by himself, and, though I am a little jealous
+of the picture for being a whole month younger than I am, I must admit
+that I delight in it.  Perhaps you had better write to him.  I don't
+want to see him alone.  He says things that annoy me.  He gives me good
+advice."
+
+Lord Henry smiled.  "People are very fond of giving away what they need
+most themselves.  It is what I call the depth of generosity."
+
+"Oh, Basil is the best of fellows, but he seems to me to be just a bit
+of a Philistine.  Since I have known you, Harry, I have discovered
+that."
+
+"Basil, my dear boy, puts everything that is charming in him into his
+work.  The consequence is that he has nothing left for life but his
+prejudices, his principles, and his common sense.  The only artists I
+have ever known who are personally delightful are bad artists.  Good
+artists exist simply in what they make, and consequently are perfectly
+uninteresting in what they are.  A great poet, a really great poet, is
+the most unpoetical of all creatures.  But inferior poets are
+absolutely fascinating.  The worse their rhymes are, the more
+picturesque they look.  The mere fact of having published a book of
+second-rate sonnets makes a man quite irresistible.  He lives the
+poetry that he cannot write.  The others write the poetry that they
+dare not realize."
+
+"I wonder is that really so, Harry?" said Dorian Gray, putting some
+perfume on his handkerchief out of a large, gold-topped bottle that
+stood on the table.  "It must be, if you say it.  And now I am off.
+Imogen is waiting for me.  Don't forget about to-morrow. Good-bye."
+
+As he left the room, Lord Henry's heavy eyelids drooped, and he began
+to think.  Certainly few people had ever interested him so much as
+Dorian Gray, and yet the lad's mad adoration of some one else caused
+him not the slightest pang of annoyance or jealousy.  He was pleased by
+it.  It made him a more interesting study.  He had been always
+enthralled by the methods of natural science, but the ordinary
+subject-matter of that science had seemed to him trivial and of no
+import.  And so he had begun by vivisecting himself, as he had ended by
+vivisecting others.  Human life--that appeared to him the one thing
+worth investigating.  Compared to it there was nothing else of any
+value.  It was true that as one watched life in its curious crucible of
+pain and pleasure, one could not wear over one's face a mask of glass,
+nor keep the sulphurous fumes from troubling the brain and making the
+imagination turbid with monstrous fancies and misshapen dreams.  There
+were poisons so subtle that to know their properties one had to sicken
+of them.  There were maladies so strange that one had to pass through
+them if one sought to understand their nature.  And, yet, what a great
+reward one received!  How wonderful the whole world became to one!  To
+note the curious hard logic of passion, and the emotional coloured life
+of the intellect--to observe where they met, and where they separated,
+at what point they were in unison, and at what point they were at
+discord--there was a delight in that!  What matter what the cost was?
+One could never pay too high a price for any sensation.
+
+He was conscious--and the thought brought a gleam of pleasure into his
+brown agate eyes--that it was through certain words of his, musical
+words said with musical utterance, that Dorian Gray's soul had turned
+to this white girl and bowed in worship before her.  To a large extent
+the lad was his own creation.  He had made him premature.  That was
+something.  Ordinary people waited till life disclosed to them its
+secrets, but to the few, to the elect, the mysteries of life were
+revealed before the veil was drawn away.  Sometimes this was the effect
+of art, and chiefly of the art of literature, which dealt immediately
+with the passions and the intellect.  But now and then a complex
+personality took the place and assumed the office of art, was indeed,
+in its way, a real work of art, life having its elaborate masterpieces,
+just as poetry has, or sculpture, or painting.
+
+Yes, the lad was premature.  He was gathering his harvest while it was
+yet spring.  The pulse and passion of youth were in him, but he was
+becoming self-conscious. It was delightful to watch him.  With his
+beautiful face, and his beautiful soul, he was a thing to wonder at.
+It was no matter how it all ended, or was destined to end.  He was like
+one of those gracious figures in a pageant or a play, whose joys seem
+to be remote from one, but whose sorrows stir one's sense of beauty,
+and whose wounds are like red roses.
+
+Soul and body, body and soul--how mysterious they were!  There was
+animalism in the soul, and the body had its moments of spirituality.
+The senses could refine, and the intellect could degrade.  Who could
+say where the fleshly impulse ceased, or the psychical impulse began?
+How shallow were the arbitrary definitions of ordinary psychologists!
+And yet how difficult to decide between the claims of the various
+schools!  Was the soul a shadow seated in the house of sin?  Or was the
+body really in the soul, as Giordano Bruno thought?  The separation of
+spirit from matter was a mystery, and the union of spirit with matter
+was a mystery also.
+
+He began to wonder whether we could ever make psychology so absolute a
+science that each little spring of life would be revealed to us.  As it
+was, we always misunderstood ourselves and rarely understood others.
+Experience was of no ethical value.  It was merely the name men gave to
+their mistakes.  Moralists had, as a rule, regarded it as a mode of
+warning, had claimed for it a certain ethical efficacy in the formation
+of character, had praised it as something that taught us what to follow
+and showed us what to avoid.  But there was no motive power in
+experience.  It was as little of an active cause as conscience itself.
+All that it really demonstrated was that our future would be the same
+as our past, and that the sin we had done once, and with loathing, we
+would do many times, and with joy.
+
+It was clear to him that the experimental method was the only method by
+which one could arrive at any scientific analysis of the passions; and
+certainly Dorian Gray was a subject made to his hand, and seemed to
+promise rich and fruitful results.  His sudden mad love for Sibyl Vane
+was a psychological phenomenon of no small interest.  There was no
+doubt that curiosity had much to do with it, curiosity and the desire
+for new experiences, yet it was not a simple, but rather a very complex
+passion.  What there was in it of the purely sensuous instinct of
+boyhood had been transformed by the workings of the imagination,
+changed into something that seemed to the lad himself to be remote from
+sense, and was for that very reason all the more dangerous.  It was the
+passions about whose origin we deceived ourselves that tyrannized most
+strongly over us.  Our weakest motives were those of whose nature we
+were conscious.  It often happened that when we thought we were
+experimenting on others we were really experimenting on ourselves.
+
+While Lord Henry sat dreaming on these things, a knock came to the
+door, and his valet entered and reminded him it was time to dress for
+dinner.  He got up and looked out into the street.  The sunset had
+smitten into scarlet gold the upper windows of the houses opposite.
+The panes glowed like plates of heated metal.  The sky above was like a
+faded rose.  He thought of his friend's young fiery-coloured life and
+wondered how it was all going to end.
+
+When he arrived home, about half-past twelve o'clock, he saw a telegram
+lying on the hall table.  He opened it and found it was from Dorian
+Gray.  It was to tell him that he was engaged to be married to Sibyl
+Vane.
+
+
+
+CHAPTER 5
+
+"Mother, Mother, I am so happy!" whispered the girl, burying her face
+in the lap of the faded, tired-looking woman who, with back turned to
+the shrill intrusive light, was sitting in the one arm-chair that their
+dingy sitting-room contained.  "I am so happy!" she repeated, "and you
+must be happy, too!"
+
+Mrs. Vane winced and put her thin, bismuth-whitened hands on her
+daughter's head.  "Happy!" she echoed, "I am only happy, Sibyl, when I
+see you act.  You must not think of anything but your acting.  Mr.
+Isaacs has been very good to us, and we owe him money."
+
+The girl looked up and pouted.  "Money, Mother?" she cried, "what does
+money matter?  Love is more than money."
+
+"Mr. Isaacs has advanced us fifty pounds to pay off our debts and to
+get a proper outfit for James.  You must not forget that, Sibyl.  Fifty
+pounds is a very large sum.  Mr. Isaacs has been most considerate."
+
+"He is not a gentleman, Mother, and I hate the way he talks to me,"
+said the girl, rising to her feet and going over to the window.
+
+"I don't know how we could manage without him," answered the elder
+woman querulously.
+
+Sibyl Vane tossed her head and laughed.  "We don't want him any more,
+Mother.  Prince Charming rules life for us now." Then she paused.  A
+rose shook in her blood and shadowed her cheeks.  Quick breath parted
+the petals of her lips.  They trembled.  Some southern wind of passion
+swept over her and stirred the dainty folds of her dress.  "I love
+him," she said simply.
+
+"Foolish child! foolish child!" was the parrot-phrase flung in answer.
+The waving of crooked, false-jewelled fingers gave grotesqueness to the
+words.
+
+The girl laughed again.  The joy of a caged bird was in her voice.  Her
+eyes caught the melody and echoed it in radiance, then closed for a
+moment, as though to hide their secret.  When they opened, the mist of
+a dream had passed across them.
+
+Thin-lipped wisdom spoke at her from the worn chair, hinted at
+prudence, quoted from that book of cowardice whose author apes the name
+of common sense.  She did not listen.  She was free in her prison of
+passion.  Her prince, Prince Charming, was with her.  She had called on
+memory to remake him.  She had sent her soul to search for him, and it
+had brought him back.  His kiss burned again upon her mouth.  Her
+eyelids were warm with his breath.
+
+Then wisdom altered its method and spoke of espial and discovery.  This
+young man might be rich.  If so, marriage should be thought of.
+Against the shell of her ear broke the waves of worldly cunning.  The
+arrows of craft shot by her.  She saw the thin lips moving, and smiled.
+
+Suddenly she felt the need to speak.  The wordy silence troubled her.
+"Mother, Mother," she cried, "why does he love me so much?  I know why
+I love him.  I love him because he is like what love himself should be.
+But what does he see in me?  I am not worthy of him.  And yet--why, I
+cannot tell--though I feel so much beneath him, I don't feel humble.  I
+feel proud, terribly proud.  Mother, did you love my father as I love
+Prince Charming?"
+
+The elder woman grew pale beneath the coarse powder that daubed her
+cheeks, and her dry lips twitched with a spasm of pain.  Sybil rushed
+to her, flung her arms round her neck, and kissed her.  "Forgive me,
+Mother.  I know it pains you to talk about our father.  But it only
+pains you because you loved him so much.  Don't look so sad.  I am as
+happy to-day as you were twenty years ago.  Ah! let me be happy for
+ever!"
+
+"My child, you are far too young to think of falling in love.  Besides,
+what do you know of this young man?  You don't even know his name.  The
+whole thing is most inconvenient, and really, when James is going away
+to Australia, and I have so much to think of, I must say that you
+should have shown more consideration.  However, as I said before, if he
+is rich ..."
+
+"Ah!  Mother, Mother, let me be happy!"
+
+Mrs. Vane glanced at her, and with one of those false theatrical
+gestures that so often become a mode of second nature to a
+stage-player, clasped her in her arms.  At this moment, the door opened
+and a young lad with rough brown hair came into the room.  He was
+thick-set of figure, and his hands and feet were large and somewhat
+clumsy in movement.  He was not so finely bred as his sister.  One
+would hardly have guessed the close relationship that existed between
+them.  Mrs. Vane fixed her eyes on him and intensified her smile.  She
+mentally elevated her son to the dignity of an audience.  She felt sure
+that the _tableau_ was interesting.
+
+"You might keep some of your kisses for me, Sibyl, I think," said the
+lad with a good-natured grumble.
+
+"Ah! but you don't like being kissed, Jim," she cried.  "You are a
+dreadful old bear."  And she ran across the room and hugged him.
+
+James Vane looked into his sister's face with tenderness.  "I want you
+to come out with me for a walk, Sibyl.  I don't suppose I shall ever
+see this horrid London again.  I am sure I don't want to."
+
+"My son, don't say such dreadful things," murmured Mrs. Vane, taking up
+a tawdry theatrical dress, with a sigh, and beginning to patch it.  She
+felt a little disappointed that he had not joined the group.  It would
+have increased the theatrical picturesqueness of the situation.
+
+"Why not, Mother?  I mean it."
+
+"You pain me, my son.  I trust you will return from Australia in a
+position of affluence.  I believe there is no society of any kind in
+the Colonies--nothing that I would call society--so when you have made
+your fortune, you must come back and assert yourself in London."
+
+"Society!" muttered the lad.  "I don't want to know anything about
+that.  I should like to make some money to take you and Sibyl off the
+stage.  I hate it."
+
+"Oh, Jim!" said Sibyl, laughing, "how unkind of you!  But are you
+really going for a walk with me?  That will be nice!  I was afraid you
+were going to say good-bye to some of your friends--to Tom Hardy, who
+gave you that hideous pipe, or Ned Langton, who makes fun of you for
+smoking it.  It is very sweet of you to let me have your last
+afternoon.  Where shall we go?  Let us go to the park."
+
+"I am too shabby," he answered, frowning.  "Only swell people go to the
+park."
+
+"Nonsense, Jim," she whispered, stroking the sleeve of his coat.
+
+He hesitated for a moment.  "Very well," he said at last, "but don't be
+too long dressing."  She danced out of the door.  One could hear her
+singing as she ran upstairs.  Her little feet pattered overhead.
+
+He walked up and down the room two or three times.  Then he turned to
+the still figure in the chair.  "Mother, are my things ready?" he asked.
+
+"Quite ready, James," she answered, keeping her eyes on her work.  For
+some months past she had felt ill at ease when she was alone with this
+rough stern son of hers.  Her shallow secret nature was troubled when
+their eyes met.  She used to wonder if he suspected anything.  The
+silence, for he made no other observation, became intolerable to her.
+She began to complain.  Women defend themselves by attacking, just as
+they attack by sudden and strange surrenders.  "I hope you will be
+contented, James, with your sea-faring life," she said.  "You must
+remember that it is your own choice.  You might have entered a
+solicitor's office.  Solicitors are a very respectable class, and in
+the country often dine with the best families."
+
+"I hate offices, and I hate clerks," he replied.  "But you are quite
+right.  I have chosen my own life.  All I say is, watch over Sibyl.
+Don't let her come to any harm.  Mother, you must watch over her."
+
+"James, you really talk very strangely.  Of course I watch over Sibyl."
+
+"I hear a gentleman comes every night to the theatre and goes behind to
+talk to her.  Is that right?  What about that?"
+
+"You are speaking about things you don't understand, James.  In the
+profession we are accustomed to receive a great deal of most gratifying
+attention.  I myself used to receive many bouquets at one time.  That
+was when acting was really understood.  As for Sibyl, I do not know at
+present whether her attachment is serious or not.  But there is no
+doubt that the young man in question is a perfect gentleman.  He is
+always most polite to me.  Besides, he has the appearance of being
+rich, and the flowers he sends are lovely."
+
+"You don't know his name, though," said the lad harshly.
+
+"No," answered his mother with a placid expression in her face.  "He
+has not yet revealed his real name.  I think it is quite romantic of
+him.  He is probably a member of the aristocracy."
+
+James Vane bit his lip.  "Watch over Sibyl, Mother," he cried, "watch
+over her."
+
+"My son, you distress me very much.  Sibyl is always under my special
+care.  Of course, if this gentleman is wealthy, there is no reason why
+she should not contract an alliance with him.  I trust he is one of the
+aristocracy.  He has all the appearance of it, I must say.  It might be
+a most brilliant marriage for Sibyl.  They would make a charming
+couple.  His good looks are really quite remarkable; everybody notices
+them."
+
+The lad muttered something to himself and drummed on the window-pane
+with his coarse fingers.  He had just turned round to say something
+when the door opened and Sibyl ran in.
+
+"How serious you both are!" she cried.  "What is the matter?"
+
+"Nothing," he answered.  "I suppose one must be serious sometimes.
+Good-bye, Mother; I will have my dinner at five o'clock. Everything is
+packed, except my shirts, so you need not trouble."
+
+"Good-bye, my son," she answered with a bow of strained stateliness.
+
+She was extremely annoyed at the tone he had adopted with her, and
+there was something in his look that had made her feel afraid.
+
+"Kiss me, Mother," said the girl.  Her flowerlike lips touched the
+withered cheek and warmed its frost.
+
+"My child! my child!" cried Mrs. Vane, looking up to the ceiling in
+search of an imaginary gallery.
+
+"Come, Sibyl," said her brother impatiently.  He hated his mother's
+affectations.
+
+They went out into the flickering, wind-blown sunlight and strolled
+down the dreary Euston Road.  The passersby glanced in wonder at the
+sullen heavy youth who, in coarse, ill-fitting clothes, was in the
+company of such a graceful, refined-looking girl.  He was like a common
+gardener walking with a rose.
+
+Jim frowned from time to time when he caught the inquisitive glance of
+some stranger.  He had that dislike of being stared at, which comes on
+geniuses late in life and never leaves the commonplace.  Sibyl,
+however, was quite unconscious of the effect she was producing.  Her
+love was trembling in laughter on her lips.  She was thinking of Prince
+Charming, and, that she might think of him all the more, she did not
+talk of him, but prattled on about the ship in which Jim was going to
+sail, about the gold he was certain to find, about the wonderful
+heiress whose life he was to save from the wicked, red-shirted
+bushrangers.  For he was not to remain a sailor, or a supercargo, or
+whatever he was going to be.  Oh, no!  A sailor's existence was
+dreadful.  Fancy being cooped up in a horrid ship, with the hoarse,
+hump-backed waves trying to get in, and a black wind blowing the masts
+down and tearing the sails into long screaming ribands!  He was to
+leave the vessel at Melbourne, bid a polite good-bye to the captain,
+and go off at once to the gold-fields. Before a week was over he was to
+come across a large nugget of pure gold, the largest nugget that had
+ever been discovered, and bring it down to the coast in a waggon
+guarded by six mounted policemen.  The bushrangers were to attack them
+three times, and be defeated with immense slaughter.  Or, no.  He was
+not to go to the gold-fields at all.  They were horrid places, where
+men got intoxicated, and shot each other in bar-rooms, and used bad
+language.  He was to be a nice sheep-farmer, and one evening, as he was
+riding home, he was to see the beautiful heiress being carried off by a
+robber on a black horse, and give chase, and rescue her.  Of course,
+she would fall in love with him, and he with her, and they would get
+married, and come home, and live in an immense house in London.  Yes,
+there were delightful things in store for him.  But he must be very
+good, and not lose his temper, or spend his money foolishly.  She was
+only a year older than he was, but she knew so much more of life.  He
+must be sure, also, to write to her by every mail, and to say his
+prayers each night before he went to sleep.  God was very good, and
+would watch over him.  She would pray for him, too, and in a few years
+he would come back quite rich and happy.
+
+The lad listened sulkily to her and made no answer.  He was heart-sick
+at leaving home.
+
+Yet it was not this alone that made him gloomy and morose.
+Inexperienced though he was, he had still a strong sense of the danger
+of Sibyl's position.  This young dandy who was making love to her could
+mean her no good.  He was a gentleman, and he hated him for that, hated
+him through some curious race-instinct for which he could not account,
+and which for that reason was all the more dominant within him.  He was
+conscious also of the shallowness and vanity of his mother's nature,
+and in that saw infinite peril for Sibyl and Sibyl's happiness.
+Children begin by loving their parents; as they grow older they judge
+them; sometimes they forgive them.
+
+His mother!  He had something on his mind to ask of her, something that
+he had brooded on for many months of silence.  A chance phrase that he
+had heard at the theatre, a whispered sneer that had reached his ears
+one night as he waited at the stage-door, had set loose a train of
+horrible thoughts.  He remembered it as if it had been the lash of a
+hunting-crop across his face.  His brows knit together into a wedge-like
+furrow, and with a twitch of pain he bit his underlip.
+
+"You are not listening to a word I am saying, Jim," cried Sibyl, "and I
+am making the most delightful plans for your future.  Do say something."
+
+"What do you want me to say?"
+
+"Oh! that you will be a good boy and not forget us," she answered,
+smiling at him.
+
+He shrugged his shoulders.  "You are more likely to forget me than I am
+to forget you, Sibyl."
+
+She flushed.  "What do you mean, Jim?" she asked.
+
+"You have a new friend, I hear.  Who is he?  Why have you not told me
+about him?  He means you no good."
+
+"Stop, Jim!" she exclaimed.  "You must not say anything against him.  I
+love him."
+
+"Why, you don't even know his name," answered the lad.  "Who is he?  I
+have a right to know."
+
+"He is called Prince Charming.  Don't you like the name.  Oh! you silly
+boy! you should never forget it.  If you only saw him, you would think
+him the most wonderful person in the world.  Some day you will meet
+him--when you come back from Australia.  You will like him so much.
+Everybody likes him, and I ... love him.  I wish you could come to the
+theatre to-night. He is going to be there, and I am to play Juliet.
+Oh! how I shall play it!  Fancy, Jim, to be in love and play Juliet!
+To have him sitting there!  To play for his delight!  I am afraid I may
+frighten the company, frighten or enthrall them.  To be in love is to
+surpass one's self.  Poor dreadful Mr. Isaacs will be shouting 'genius'
+to his loafers at the bar.  He has preached me as a dogma; to-night he
+will announce me as a revelation.  I feel it.  And it is all his, his
+only, Prince Charming, my wonderful lover, my god of graces.  But I am
+poor beside him.  Poor?  What does that matter?  When poverty creeps in
+at the door, love flies in through the window.  Our proverbs want
+rewriting.  They were made in winter, and it is summer now; spring-time
+for me, I think, a very dance of blossoms in blue skies."
+
+"He is a gentleman," said the lad sullenly.
+
+"A prince!" she cried musically.  "What more do you want?"
+
+"He wants to enslave you."
+
+"I shudder at the thought of being free."
+
+"I want you to beware of him."
+
+"To see him is to worship him; to know him is to trust him."
+
+"Sibyl, you are mad about him."
+
+She laughed and took his arm.  "You dear old Jim, you talk as if you
+were a hundred.  Some day you will be in love yourself.  Then you will
+know what it is.  Don't look so sulky.  Surely you should be glad to
+think that, though you are going away, you leave me happier than I have
+ever been before.  Life has been hard for us both, terribly hard and
+difficult.  But it will be different now.  You are going to a new
+world, and I have found one.  Here are two chairs; let us sit down and
+see the smart people go by."
+
+They took their seats amidst a crowd of watchers.  The tulip-beds
+across the road flamed like throbbing rings of fire.  A white
+dust--tremulous cloud of orris-root it seemed--hung in the panting air.
+The brightly coloured parasols danced and dipped like monstrous
+butterflies.
+
+She made her brother talk of himself, his hopes, his prospects.  He
+spoke slowly and with effort.  They passed words to each other as
+players at a game pass counters.  Sibyl felt oppressed.  She could not
+communicate her joy.  A faint smile curving that sullen mouth was all
+the echo she could win.  After some time she became silent.  Suddenly
+she caught a glimpse of golden hair and laughing lips, and in an open
+carriage with two ladies Dorian Gray drove past.
+
+She started to her feet.  "There he is!" she cried.
+
+"Who?" said Jim Vane.
+
+"Prince Charming," she answered, looking after the victoria.
+
+He jumped up and seized her roughly by the arm.  "Show him to me.
+Which is he?  Point him out.  I must see him!" he exclaimed; but at
+that moment the Duke of Berwick's four-in-hand came between, and when
+it had left the space clear, the carriage had swept out of the park.
+
+"He is gone," murmured Sibyl sadly.  "I wish you had seen him."
+
+"I wish I had, for as sure as there is a God in heaven, if he ever does
+you any wrong, I shall kill him."
+
+She looked at him in horror.  He repeated his words.  They cut the air
+like a dagger.  The people round began to gape.  A lady standing close
+to her tittered.
+
+"Come away, Jim; come away," she whispered.  He followed her doggedly
+as she passed through the crowd.  He felt glad at what he had said.
+
+When they reached the Achilles Statue, she turned round.  There was
+pity in her eyes that became laughter on her lips.  She shook her head
+at him.  "You are foolish, Jim, utterly foolish; a bad-tempered boy,
+that is all.  How can you say such horrible things?  You don't know
+what you are talking about.  You are simply jealous and unkind.  Ah!  I
+wish you would fall in love.  Love makes people good, and what you said
+was wicked."
+
+"I am sixteen," he answered, "and I know what I am about.  Mother is no
+help to you.  She doesn't understand how to look after you.  I wish now
+that I was not going to Australia at all.  I have a great mind to chuck
+the whole thing up.  I would, if my articles hadn't been signed."
+
+"Oh, don't be so serious, Jim.  You are like one of the heroes of those
+silly melodramas Mother used to be so fond of acting in.  I am not
+going to quarrel with you.  I have seen him, and oh! to see him is
+perfect happiness.  We won't quarrel.  I know you would never harm any
+one I love, would you?"
+
+"Not as long as you love him, I suppose," was the sullen answer.
+
+"I shall love him for ever!" she cried.
+
+"And he?"
+
+"For ever, too!"
+
+"He had better."
+
+She shrank from him.  Then she laughed and put her hand on his arm.  He
+was merely a boy.
+
+At the Marble Arch they hailed an omnibus, which left them close to
+their shabby home in the Euston Road.  It was after five o'clock, and
+Sibyl had to lie down for a couple of hours before acting.  Jim
+insisted that she should do so.  He said that he would sooner part with
+her when their mother was not present.  She would be sure to make a
+scene, and he detested scenes of every kind.
+
+In Sybil's own room they parted.  There was jealousy in the lad's
+heart, and a fierce murderous hatred of the stranger who, as it seemed
+to him, had come between them.  Yet, when her arms were flung round his
+neck, and her fingers strayed through his hair, he softened and kissed
+her with real affection.  There were tears in his eyes as he went
+downstairs.
+
+His mother was waiting for him below.  She grumbled at his
+unpunctuality, as he entered.  He made no answer, but sat down to his
+meagre meal.  The flies buzzed round the table and crawled over the
+stained cloth.  Through the rumble of omnibuses, and the clatter of
+street-cabs, he could hear the droning voice devouring each minute that
+was left to him.
+
+After some time, he thrust away his plate and put his head in his
+hands.  He felt that he had a right to know.  It should have been told
+to him before, if it was as he suspected.  Leaden with fear, his mother
+watched him.  Words dropped mechanically from her lips.  A tattered
+lace handkerchief twitched in her fingers.  When the clock struck six,
+he got up and went to the door.  Then he turned back and looked at her.
+Their eyes met.  In hers he saw a wild appeal for mercy.  It enraged
+him.
+
+"Mother, I have something to ask you," he said.  Her eyes wandered
+vaguely about the room.  She made no answer.  "Tell me the truth.  I
+have a right to know.  Were you married to my father?"
+
+She heaved a deep sigh.  It was a sigh of relief.  The terrible moment,
+the moment that night and day, for weeks and months, she had dreaded,
+had come at last, and yet she felt no terror.  Indeed, in some measure
+it was a disappointment to her.  The vulgar directness of the question
+called for a direct answer.  The situation had not been gradually led
+up to.  It was crude.  It reminded her of a bad rehearsal.
+
+"No," she answered, wondering at the harsh simplicity of life.
+
+"My father was a scoundrel then!" cried the lad, clenching his fists.
+
+She shook her head.  "I knew he was not free.  We loved each other very
+much.  If he had lived, he would have made provision for us.  Don't
+speak against him, my son.  He was your father, and a gentleman.
+Indeed, he was highly connected."
+
+An oath broke from his lips.  "I don't care for myself," he exclaimed,
+"but don't let Sibyl.... It is a gentleman, isn't it, who is in love
+with her, or says he is?  Highly connected, too, I suppose."
+
+For a moment a hideous sense of humiliation came over the woman.  Her
+head drooped.  She wiped her eyes with shaking hands.  "Sibyl has a
+mother," she murmured; "I had none."
+
+The lad was touched.  He went towards her, and stooping down, he kissed
+her.  "I am sorry if I have pained you by asking about my father," he
+said, "but I could not help it.  I must go now.  Good-bye. Don't forget
+that you will have only one child now to look after, and believe me
+that if this man wrongs my sister, I will find out who he is, track him
+down, and kill him like a dog.  I swear it."
+
+The exaggerated folly of the threat, the passionate gesture that
+accompanied it, the mad melodramatic words, made life seem more vivid
+to her.  She was familiar with the atmosphere.  She breathed more
+freely, and for the first time for many months she really admired her
+son.  She would have liked to have continued the scene on the same
+emotional scale, but he cut her short.  Trunks had to be carried down
+and mufflers looked for.  The lodging-house drudge bustled in and out.
+There was the bargaining with the cabman.  The moment was lost in
+vulgar details.  It was with a renewed feeling of disappointment that
+she waved the tattered lace handkerchief from the window, as her son
+drove away.  She was conscious that a great opportunity had been
+wasted.  She consoled herself by telling Sibyl how desolate she felt
+her life would be, now that she had only one child to look after.  She
+remembered the phrase.  It had pleased her.  Of the threat she said
+nothing.  It was vividly and dramatically expressed.  She felt that
+they would all laugh at it some day.
+
+
+
+CHAPTER 6
+
+"I suppose you have heard the news, Basil?" said Lord Henry that
+evening as Hallward was shown into a little private room at the Bristol
+where dinner had been laid for three.
+
+"No, Harry," answered the artist, giving his hat and coat to the bowing
+waiter.  "What is it?  Nothing about politics, I hope!  They don't
+interest me.  There is hardly a single person in the House of Commons
+worth painting, though many of them would be the better for a little
+whitewashing."
+
+"Dorian Gray is engaged to be married," said Lord Henry, watching him
+as he spoke.
+
+Hallward started and then frowned.  "Dorian engaged to be married!" he
+cried.  "Impossible!"
+
+"It is perfectly true."
+
+"To whom?"
+
+"To some little actress or other."
+
+"I can't believe it.  Dorian is far too sensible."
+
+"Dorian is far too wise not to do foolish things now and then, my dear
+Basil."
+
+"Marriage is hardly a thing that one can do now and then, Harry."
+
+"Except in America," rejoined Lord Henry languidly.  "But I didn't say
+he was married.  I said he was engaged to be married.  There is a great
+difference.  I have a distinct remembrance of being married, but I have
+no recollection at all of being engaged.  I am inclined to think that I
+never was engaged."
+
+"But think of Dorian's birth, and position, and wealth.  It would be
+absurd for him to marry so much beneath him."
+
+"If you want to make him marry this girl, tell him that, Basil.  He is
+sure to do it, then.  Whenever a man does a thoroughly stupid thing, it
+is always from the noblest motives."
+
+"I hope the girl is good, Harry.  I don't want to see Dorian tied to
+some vile creature, who might degrade his nature and ruin his
+intellect."
+
+"Oh, she is better than good--she is beautiful," murmured Lord Henry,
+sipping a glass of vermouth and orange-bitters. "Dorian says she is
+beautiful, and he is not often wrong about things of that kind.  Your
+portrait of him has quickened his appreciation of the personal
+appearance of other people.  It has had that excellent effect, amongst
+others.  We are to see her to-night, if that boy doesn't forget his
+appointment."
+
+"Are you serious?"
+
+"Quite serious, Basil.  I should be miserable if I thought I should
+ever be more serious than I am at the present moment."
+
+"But do you approve of it, Harry?" asked the painter, walking up and
+down the room and biting his lip.  "You can't approve of it, possibly.
+It is some silly infatuation."
+
+"I never approve, or disapprove, of anything now.  It is an absurd
+attitude to take towards life.  We are not sent into the world to air
+our moral prejudices.  I never take any notice of what common people
+say, and I never interfere with what charming people do.  If a
+personality fascinates me, whatever mode of expression that personality
+selects is absolutely delightful to me.  Dorian Gray falls in love with
+a beautiful girl who acts Juliet, and proposes to marry her.  Why not?
+If he wedded Messalina, he would be none the less interesting.  You
+know I am not a champion of marriage.  The real drawback to marriage is
+that it makes one unselfish.  And unselfish people are colourless.
+They lack individuality.  Still, there are certain temperaments that
+marriage makes more complex.  They retain their egotism, and add to it
+many other egos.  They are forced to have more than one life.  They
+become more highly organized, and to be highly organized is, I should
+fancy, the object of man's existence.  Besides, every experience is of
+value, and whatever one may say against marriage, it is certainly an
+experience.  I hope that Dorian Gray will make this girl his wife,
+passionately adore her for six months, and then suddenly become
+fascinated by some one else.  He would be a wonderful study."
+
+"You don't mean a single word of all that, Harry; you know you don't.
+If Dorian Gray's life were spoiled, no one would be sorrier than
+yourself.  You are much better than you pretend to be."
+
+Lord Henry laughed.  "The reason we all like to think so well of others
+is that we are all afraid for ourselves.  The basis of optimism is
+sheer terror.  We think that we are generous because we credit our
+neighbour with the possession of those virtues that are likely to be a
+benefit to us.  We praise the banker that we may overdraw our account,
+and find good qualities in the highwayman in the hope that he may spare
+our pockets.  I mean everything that I have said.  I have the greatest
+contempt for optimism.  As for a spoiled life, no life is spoiled but
+one whose growth is arrested.  If you want to mar a nature, you have
+merely to reform it.  As for marriage, of course that would be silly,
+but there are other and more interesting bonds between men and women.
+I will certainly encourage them.  They have the charm of being
+fashionable.  But here is Dorian himself.  He will tell you more than I
+can."
+
+"My dear Harry, my dear Basil, you must both congratulate me!" said the
+lad, throwing off his evening cape with its satin-lined wings and
+shaking each of his friends by the hand in turn.  "I have never been so
+happy.  Of course, it is sudden--all really delightful things are.  And
+yet it seems to me to be the one thing I have been looking for all my
+life." He was flushed with excitement and pleasure, and looked
+extraordinarily handsome.
+
+"I hope you will always be very happy, Dorian," said Hallward, "but I
+don't quite forgive you for not having let me know of your engagement.
+You let Harry know."
+
+"And I don't forgive you for being late for dinner," broke in Lord
+Henry, putting his hand on the lad's shoulder and smiling as he spoke.
+"Come, let us sit down and try what the new _chef_ here is like, and then
+you will tell us how it all came about."
+
+"There is really not much to tell," cried Dorian as they took their
+seats at the small round table.  "What happened was simply this.  After
+I left you yesterday evening, Harry, I dressed, had some dinner at that
+little Italian restaurant in Rupert Street you introduced me to, and
+went down at eight o'clock to the theatre.  Sibyl was playing Rosalind.
+Of course, the scenery was dreadful and the Orlando absurd.  But Sibyl!
+You should have seen her!  When she came on in her boy's clothes, she
+was perfectly wonderful.  She wore a moss-coloured velvet jerkin with
+cinnamon sleeves, slim, brown, cross-gartered hose, a dainty little
+green cap with a hawk's feather caught in a jewel, and a hooded cloak
+lined with dull red.  She had never seemed to me more exquisite.  She
+had all the delicate grace of that Tanagra figurine that you have in
+your studio, Basil.  Her hair clustered round her face like dark leaves
+round a pale rose.  As for her acting--well, you shall see her
+to-night. She is simply a born artist.  I sat in the dingy box
+absolutely enthralled.  I forgot that I was in London and in the
+nineteenth century.  I was away with my love in a forest that no man
+had ever seen.  After the performance was over, I went behind and spoke
+to her.  As we were sitting together, suddenly there came into her eyes
+a look that I had never seen there before.  My lips moved towards hers.
+We kissed each other.  I can't describe to you what I felt at that
+moment.  It seemed to me that all my life had been narrowed to one
+perfect point of rose-coloured joy.  She trembled all over and shook
+like a white narcissus.  Then she flung herself on her knees and kissed
+my hands.  I feel that I should not tell you all this, but I can't help
+it.  Of course, our engagement is a dead secret.  She has not even told
+her own mother.  I don't know what my guardians will say.  Lord Radley
+is sure to be furious.  I don't care.  I shall be of age in less than a
+year, and then I can do what I like.  I have been right, Basil, haven't
+I, to take my love out of poetry and to find my wife in Shakespeare's
+plays?  Lips that Shakespeare taught to speak have whispered their
+secret in my ear.  I have had the arms of Rosalind around me, and
+kissed Juliet on the mouth."
+
+"Yes, Dorian, I suppose you were right," said Hallward slowly.
+
+"Have you seen her to-day?" asked Lord Henry.
+
+Dorian Gray shook his head.  "I left her in the forest of Arden; I
+shall find her in an orchard in Verona."
+
+Lord Henry sipped his champagne in a meditative manner.  "At what
+particular point did you mention the word marriage, Dorian?  And what
+did she say in answer?  Perhaps you forgot all about it."
+
+"My dear Harry, I did not treat it as a business transaction, and I did
+not make any formal proposal.  I told her that I loved her, and she
+said she was not worthy to be my wife.  Not worthy!  Why, the whole
+world is nothing to me compared with her."
+
+"Women are wonderfully practical," murmured Lord Henry, "much more
+practical than we are.  In situations of that kind we often forget to
+say anything about marriage, and they always remind us."
+
+Hallward laid his hand upon his arm.  "Don't, Harry.  You have annoyed
+Dorian.  He is not like other men.  He would never bring misery upon
+any one.  His nature is too fine for that."
+
+Lord Henry looked across the table.  "Dorian is never annoyed with me,"
+he answered.  "I asked the question for the best reason possible, for
+the only reason, indeed, that excuses one for asking any
+question--simple curiosity.  I have a theory that it is always the
+women who propose to us, and not we who propose to the women.  Except,
+of course, in middle-class life.  But then the middle classes are not
+modern."
+
+Dorian Gray laughed, and tossed his head.  "You are quite incorrigible,
+Harry; but I don't mind.  It is impossible to be angry with you.  When
+you see Sibyl Vane, you will feel that the man who could wrong her
+would be a beast, a beast without a heart.  I cannot understand how any
+one can wish to shame the thing he loves.  I love Sibyl Vane.  I want
+to place her on a pedestal of gold and to see the world worship the
+woman who is mine.  What is marriage?  An irrevocable vow.  You mock at
+it for that.  Ah! don't mock.  It is an irrevocable vow that I want to
+take.  Her trust makes me faithful, her belief makes me good.  When I
+am with her, I regret all that you have taught me.  I become different
+from what you have known me to be.  I am changed, and the mere touch of
+Sibyl Vane's hand makes me forget you and all your wrong, fascinating,
+poisonous, delightful theories."
+
+"And those are ...?" asked Lord Henry, helping himself to some salad.
+
+"Oh, your theories about life, your theories about love, your theories
+about pleasure.  All your theories, in fact, Harry."
+
+"Pleasure is the only thing worth having a theory about," he answered
+in his slow melodious voice.  "But I am afraid I cannot claim my theory
+as my own.  It belongs to Nature, not to me.  Pleasure is Nature's
+test, her sign of approval.  When we are happy, we are always good, but
+when we are good, we are not always happy."
+
+"Ah! but what do you mean by good?" cried Basil Hallward.
+
+"Yes," echoed Dorian, leaning back in his chair and looking at Lord
+Henry over the heavy clusters of purple-lipped irises that stood in the
+centre of the table, "what do you mean by good, Harry?"
+
+"To be good is to be in harmony with one's self," he replied, touching
+the thin stem of his glass with his pale, fine-pointed fingers.
+"Discord is to be forced to be in harmony with others.  One's own
+life--that is the important thing.  As for the lives of one's
+neighbours, if one wishes to be a prig or a Puritan, one can flaunt
+one's moral views about them, but they are not one's concern.  Besides,
+individualism has really the higher aim.  Modern morality consists in
+accepting the standard of one's age.  I consider that for any man of
+culture to accept the standard of his age is a form of the grossest
+immorality."
+
+"But, surely, if one lives merely for one's self, Harry, one pays a
+terrible price for doing so?" suggested the painter.
+
+"Yes, we are overcharged for everything nowadays.  I should fancy that
+the real tragedy of the poor is that they can afford nothing but
+self-denial. Beautiful sins, like beautiful things, are the privilege
+of the rich."
+
+"One has to pay in other ways but money."
+
+"What sort of ways, Basil?"
+
+"Oh!  I should fancy in remorse, in suffering, in ... well, in the
+consciousness of degradation."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, mediaeval art is
+charming, but mediaeval emotions are out of date.  One can use them in
+fiction, of course.  But then the only things that one can use in
+fiction are the things that one has ceased to use in fact.  Believe me,
+no civilized man ever regrets a pleasure, and no uncivilized man ever
+knows what a pleasure is."
+
+"I know what pleasure is," cried Dorian Gray.  "It is to adore some
+one."
+
+"That is certainly better than being adored," he answered, toying with
+some fruits.  "Being adored is a nuisance.  Women treat us just as
+humanity treats its gods.  They worship us, and are always bothering us
+to do something for them."
+
+"I should have said that whatever they ask for they had first given to
+us," murmured the lad gravely.  "They create love in our natures.  They
+have a right to demand it back."
+
+"That is quite true, Dorian," cried Hallward.
+
+"Nothing is ever quite true," said Lord Henry.
+
+"This is," interrupted Dorian.  "You must admit, Harry, that women give
+to men the very gold of their lives."
+
+"Possibly," he sighed, "but they invariably want it back in such very
+small change.  That is the worry.  Women, as some witty Frenchman once
+put it, inspire us with the desire to do masterpieces and always
+prevent us from carrying them out."
+
+"Harry, you are dreadful!  I don't know why I like you so much."
+
+"You will always like me, Dorian," he replied.  "Will you have some
+coffee, you fellows?  Waiter, bring coffee, and _fine-champagne_, and
+some cigarettes.  No, don't mind the cigarettes--I have some.  Basil, I
+can't allow you to smoke cigars.  You must have a cigarette.  A
+cigarette is the perfect type of a perfect pleasure.  It is exquisite,
+and it leaves one unsatisfied.  What more can one want?  Yes, Dorian,
+you will always be fond of me.  I represent to you all the sins you
+have never had the courage to commit."
+
+"What nonsense you talk, Harry!" cried the lad, taking a light from a
+fire-breathing silver dragon that the waiter had placed on the table.
+"Let us go down to the theatre.  When Sibyl comes on the stage you will
+have a new ideal of life.  She will represent something to you that you
+have never known."
+
+"I have known everything," said Lord Henry, with a tired look in his
+eyes, "but I am always ready for a new emotion.  I am afraid, however,
+that, for me at any rate, there is no such thing.  Still, your
+wonderful girl may thrill me.  I love acting.  It is so much more real
+than life.  Let us go.  Dorian, you will come with me.  I am so sorry,
+Basil, but there is only room for two in the brougham.  You must follow
+us in a hansom."
+
+They got up and put on their coats, sipping their coffee standing.  The
+painter was silent and preoccupied.  There was a gloom over him.  He
+could not bear this marriage, and yet it seemed to him to be better
+than many other things that might have happened.  After a few minutes,
+they all passed downstairs.  He drove off by himself, as had been
+arranged, and watched the flashing lights of the little brougham in
+front of him.  A strange sense of loss came over him.  He felt that
+Dorian Gray would never again be to him all that he had been in the
+past.  Life had come between them.... His eyes darkened, and the
+crowded flaring streets became blurred to his eyes.  When the cab drew
+up at the theatre, it seemed to him that he had grown years older.
+
+
+
+CHAPTER 7
+
+For some reason or other, the house was crowded that night, and the fat
+Jew manager who met them at the door was beaming from ear to ear with
+an oily tremulous smile.  He escorted them to their box with a sort of
+pompous humility, waving his fat jewelled hands and talking at the top
+of his voice.  Dorian Gray loathed him more than ever.  He felt as if
+he had come to look for Miranda and had been met by Caliban.  Lord
+Henry, upon the other hand, rather liked him.  At least he declared he
+did, and insisted on shaking him by the hand and assuring him that he
+was proud to meet a man who had discovered a real genius and gone
+bankrupt over a poet.  Hallward amused himself with watching the faces
+in the pit.  The heat was terribly oppressive, and the huge sunlight
+flamed like a monstrous dahlia with petals of yellow fire.  The youths
+in the gallery had taken off their coats and waistcoats and hung them
+over the side.  They talked to each other across the theatre and shared
+their oranges with the tawdry girls who sat beside them.  Some women
+were laughing in the pit.  Their voices were horribly shrill and
+discordant.  The sound of the popping of corks came from the bar.
+
+"What a place to find one's divinity in!" said Lord Henry.
+
+"Yes!" answered Dorian Gray.  "It was here I found her, and she is
+divine beyond all living things.  When she acts, you will forget
+everything.  These common rough people, with their coarse faces and
+brutal gestures, become quite different when she is on the stage.  They
+sit silently and watch her.  They weep and laugh as she wills them to
+do.  She makes them as responsive as a violin.  She spiritualizes them,
+and one feels that they are of the same flesh and blood as one's self."
+
+"The same flesh and blood as one's self!  Oh, I hope not!" exclaimed
+Lord Henry, who was scanning the occupants of the gallery through his
+opera-glass.
+
+"Don't pay any attention to him, Dorian," said the painter.  "I
+understand what you mean, and I believe in this girl.  Any one you love
+must be marvellous, and any girl who has the effect you describe must
+be fine and noble.  To spiritualize one's age--that is something worth
+doing.  If this girl can give a soul to those who have lived without
+one, if she can create the sense of beauty in people whose lives have
+been sordid and ugly, if she can strip them of their selfishness and
+lend them tears for sorrows that are not their own, she is worthy of
+all your adoration, worthy of the adoration of the world.  This
+marriage is quite right.  I did not think so at first, but I admit it
+now.  The gods made Sibyl Vane for you.  Without her you would have
+been incomplete."
+
+"Thanks, Basil," answered Dorian Gray, pressing his hand.  "I knew that
+you would understand me.  Harry is so cynical, he terrifies me.  But
+here is the orchestra.  It is quite dreadful, but it only lasts for
+about five minutes.  Then the curtain rises, and you will see the girl
+to whom I am going to give all my life, to whom I have given everything
+that is good in me."
+
+A quarter of an hour afterwards, amidst an extraordinary turmoil of
+applause, Sibyl Vane stepped on to the stage.  Yes, she was certainly
+lovely to look at--one of the loveliest creatures, Lord Henry thought,
+that he had ever seen.  There was something of the fawn in her shy
+grace and startled eyes.  A faint blush, like the shadow of a rose in a
+mirror of silver, came to her cheeks as she glanced at the crowded
+enthusiastic house.  She stepped back a few paces and her lips seemed
+to tremble.  Basil Hallward leaped to his feet and began to applaud.
+Motionless, and as one in a dream, sat Dorian Gray, gazing at her.
+Lord Henry peered through his glasses, murmuring, "Charming! charming!"
+
+The scene was the hall of Capulet's house, and Romeo in his pilgrim's
+dress had entered with Mercutio and his other friends.  The band, such
+as it was, struck up a few bars of music, and the dance began.  Through
+the crowd of ungainly, shabbily dressed actors, Sibyl Vane moved like a
+creature from a finer world.  Her body swayed, while she danced, as a
+plant sways in the water.  The curves of her throat were the curves of
+a white lily.  Her hands seemed to be made of cool ivory.
+
+Yet she was curiously listless.  She showed no sign of joy when her
+eyes rested on Romeo.  The few words she had to speak--
+
+    Good pilgrim, you do wrong your hand too much,
+        Which mannerly devotion shows in this;
+    For saints have hands that pilgrims' hands do touch,
+        And palm to palm is holy palmers' kiss--
+
+with the brief dialogue that follows, were spoken in a thoroughly
+artificial manner.  The voice was exquisite, but from the point of view
+of tone it was absolutely false.  It was wrong in colour.  It took away
+all the life from the verse.  It made the passion unreal.
+
+Dorian Gray grew pale as he watched her.  He was puzzled and anxious.
+Neither of his friends dared to say anything to him.  She seemed to
+them to be absolutely incompetent.  They were horribly disappointed.
+
+Yet they felt that the true test of any Juliet is the balcony scene of
+the second act.  They waited for that.  If she failed there, there was
+nothing in her.
+
+She looked charming as she came out in the moonlight.  That could not
+be denied.  But the staginess of her acting was unbearable, and grew
+worse as she went on.  Her gestures became absurdly artificial.  She
+overemphasized everything that she had to say.  The beautiful passage--
+
+    Thou knowest the mask of night is on my face,
+    Else would a maiden blush bepaint my cheek
+    For that which thou hast heard me speak to-night--
+
+was declaimed with the painful precision of a schoolgirl who has been
+taught to recite by some second-rate professor of elocution. When she
+leaned over the balcony and came to those wonderful lines--
+
+        Although I joy in thee,
+    I have no joy of this contract to-night:
+    It is too rash, too unadvised, too sudden;
+    Too like the lightning, which doth cease to be
+    Ere one can say, "It lightens."  Sweet, good-night!
+    This bud of love by summer's ripening breath
+    May prove a beauteous flower when next we meet--
+
+she spoke the words as though they conveyed no meaning to her. It was
+not nervousness. Indeed, so far from being nervous, she was absolutely
+self-contained. It was simply bad art. She was a complete failure.
+
+Even the common uneducated audience of the pit and gallery lost their
+interest in the play. They got restless, and began to talk loudly and
+to whistle. The Jew manager, who was standing at the back of the
+dress-circle, stamped and swore with rage. The only person unmoved was
+the girl herself.
+
+When the second act was over, there came a storm of hisses, and Lord
+Henry got up from his chair and put on his coat.  "She is quite
+beautiful, Dorian," he said, "but she can't act.  Let us go."
+
+"I am going to see the play through," answered the lad, in a hard
+bitter voice.  "I am awfully sorry that I have made you waste an
+evening, Harry.  I apologize to you both."
+
+"My dear Dorian, I should think Miss Vane was ill," interrupted
+Hallward.  "We will come some other night."
+
+"I wish she were ill," he rejoined.  "But she seems to me to be simply
+callous and cold.  She has entirely altered.  Last night she was a
+great artist.  This evening she is merely a commonplace mediocre
+actress."
+
+"Don't talk like that about any one you love, Dorian.  Love is a more
+wonderful thing than art."
+
+"They are both simply forms of imitation," remarked Lord Henry.  "But
+do let us go.  Dorian, you must not stay here any longer.  It is not
+good for one's morals to see bad acting.  Besides, I don't suppose you
+will want your wife to act, so what does it matter if she plays Juliet
+like a wooden doll?  She is very lovely, and if she knows as little
+about life as she does about acting, she will be a delightful
+experience.  There are only two kinds of people who are really
+fascinating--people who know absolutely everything, and people who know
+absolutely nothing.  Good heavens, my dear boy, don't look so tragic!
+The secret of remaining young is never to have an emotion that is
+unbecoming.  Come to the club with Basil and myself.  We will smoke
+cigarettes and drink to the beauty of Sibyl Vane.  She is beautiful.
+What more can you want?"
+
+"Go away, Harry," cried the lad.  "I want to be alone.  Basil, you must
+go.  Ah! can't you see that my heart is breaking?"  The hot tears came
+to his eyes.  His lips trembled, and rushing to the back of the box, he
+leaned up against the wall, hiding his face in his hands.
+
+"Let us go, Basil," said Lord Henry with a strange tenderness in his
+voice, and the two young men passed out together.
+
+A few moments afterwards the footlights flared up and the curtain rose
+on the third act.  Dorian Gray went back to his seat.  He looked pale,
+and proud, and indifferent.  The play dragged on, and seemed
+interminable.  Half of the audience went out, tramping in heavy boots
+and laughing.  The whole thing was a _fiasco_.  The last act was played
+to almost empty benches.  The curtain went down on a titter and some
+groans.
+
+As soon as it was over, Dorian Gray rushed behind the scenes into the
+greenroom.  The girl was standing there alone, with a look of triumph
+on her face.  Her eyes were lit with an exquisite fire.  There was a
+radiance about her.  Her parted lips were smiling over some secret of
+their own.
+
+When he entered, she looked at him, and an expression of infinite joy
+came over her.  "How badly I acted to-night, Dorian!" she cried.
+
+"Horribly!" he answered, gazing at her in amazement.  "Horribly!  It
+was dreadful.  Are you ill?  You have no idea what it was.  You have no
+idea what I suffered."
+
+The girl smiled.  "Dorian," she answered, lingering over his name with
+long-drawn music in her voice, as though it were sweeter than honey to
+the red petals of her mouth.  "Dorian, you should have understood.  But
+you understand now, don't you?"
+
+"Understand what?" he asked, angrily.
+
+"Why I was so bad to-night. Why I shall always be bad.  Why I shall
+never act well again."
+
+He shrugged his shoulders.  "You are ill, I suppose.  When you are ill
+you shouldn't act.  You make yourself ridiculous.  My friends were
+bored.  I was bored."
+
+She seemed not to listen to him.  She was transfigured with joy.  An
+ecstasy of happiness dominated her.
+
+"Dorian, Dorian," she cried, "before I knew you, acting was the one
+reality of my life.  It was only in the theatre that I lived.  I
+thought that it was all true.  I was Rosalind one night and Portia the
+other.  The joy of Beatrice was my joy, and the sorrows of Cordelia
+were mine also.  I believed in everything.  The common people who acted
+with me seemed to me to be godlike.  The painted scenes were my world.
+I knew nothing but shadows, and I thought them real.  You came--oh, my
+beautiful love!--and you freed my soul from prison.  You taught me what
+reality really is.  To-night, for the first time in my life, I saw
+through the hollowness, the sham, the silliness of the empty pageant in
+which I had always played.  To-night, for the first time, I became
+conscious that the Romeo was hideous, and old, and painted, that the
+moonlight in the orchard was false, that the scenery was vulgar, and
+that the words I had to speak were unreal, were not my words, were not
+what I wanted to say.  You had brought me something higher, something
+of which all art is but a reflection.  You had made me understand what
+love really is.  My love!  My love!  Prince Charming!  Prince of life!
+I have grown sick of shadows.  You are more to me than all art can ever
+be.  What have I to do with the puppets of a play?  When I came on
+to-night, I could not understand how it was that everything had gone
+from me.  I thought that I was going to be wonderful.  I found that I
+could do nothing.  Suddenly it dawned on my soul what it all meant.
+The knowledge was exquisite to me.  I heard them hissing, and I smiled.
+What could they know of love such as ours?  Take me away, Dorian--take
+me away with you, where we can be quite alone.  I hate the stage.  I
+might mimic a passion that I do not feel, but I cannot mimic one that
+burns me like fire.  Oh, Dorian, Dorian, you understand now what it
+signifies?  Even if I could do it, it would be profanation for me to
+play at being in love.  You have made me see that."
+
+He flung himself down on the sofa and turned away his face.  "You have
+killed my love," he muttered.
+
+She looked at him in wonder and laughed.  He made no answer.  She came
+across to him, and with her little fingers stroked his hair.  She knelt
+down and pressed his hands to her lips.  He drew them away, and a
+shudder ran through him.
+
+Then he leaped up and went to the door.  "Yes," he cried, "you have
+killed my love.  You used to stir my imagination.  Now you don't even
+stir my curiosity.  You simply produce no effect.  I loved you because
+you were marvellous, because you had genius and intellect, because you
+realized the dreams of great poets and gave shape and substance to the
+shadows of art.  You have thrown it all away.  You are shallow and
+stupid.  My God! how mad I was to love you!  What a fool I have been!
+You are nothing to me now.  I will never see you again.  I will never
+think of you.  I will never mention your name.  You don't know what you
+were to me, once.  Why, once ... Oh, I can't bear to think of it!  I
+wish I had never laid eyes upon you!  You have spoiled the romance of
+my life.  How little you can know of love, if you say it mars your art!
+Without your art, you are nothing.  I would have made you famous,
+splendid, magnificent.  The world would have worshipped you, and you
+would have borne my name.  What are you now?  A third-rate actress with
+a pretty face."
+
+The girl grew white, and trembled.  She clenched her hands together,
+and her voice seemed to catch in her throat.  "You are not serious,
+Dorian?" she murmured.  "You are acting."
+
+"Acting!  I leave that to you.  You do it so well," he answered
+bitterly.
+
+She rose from her knees and, with a piteous expression of pain in her
+face, came across the room to him.  She put her hand upon his arm and
+looked into his eyes.  He thrust her back.  "Don't touch me!" he cried.
+
+A low moan broke from her, and she flung herself at his feet and lay
+there like a trampled flower.  "Dorian, Dorian, don't leave me!" she
+whispered.  "I am so sorry I didn't act well.  I was thinking of you
+all the time.  But I will try--indeed, I will try.  It came so suddenly
+across me, my love for you.  I think I should never have known it if
+you had not kissed me--if we had not kissed each other.  Kiss me again,
+my love.  Don't go away from me.  I couldn't bear it.  Oh! don't go
+away from me.  My brother ... No; never mind.  He didn't mean it.  He
+was in jest.... But you, oh! can't you forgive me for to-night? I will
+work so hard and try to improve.  Don't be cruel to me, because I love
+you better than anything in the world.  After all, it is only once that
+I have not pleased you.  But you are quite right, Dorian.  I should
+have shown myself more of an artist.  It was foolish of me, and yet I
+couldn't help it.  Oh, don't leave me, don't leave me." A fit of
+passionate sobbing choked her.  She crouched on the floor like a
+wounded thing, and Dorian Gray, with his beautiful eyes, looked down at
+her, and his chiselled lips curled in exquisite disdain.  There is
+always something ridiculous about the emotions of people whom one has
+ceased to love.  Sibyl Vane seemed to him to be absurdly melodramatic.
+Her tears and sobs annoyed him.
+
+"I am going," he said at last in his calm clear voice.  "I don't wish
+to be unkind, but I can't see you again.  You have disappointed me."
+
+She wept silently, and made no answer, but crept nearer.  Her little
+hands stretched blindly out, and appeared to be seeking for him.  He
+turned on his heel and left the room.  In a few moments he was out of
+the theatre.
+
+Where he went to he hardly knew.  He remembered wandering through dimly
+lit streets, past gaunt, black-shadowed archways and evil-looking
+houses.  Women with hoarse voices and harsh laughter had called after
+him.  Drunkards had reeled by, cursing and chattering to themselves
+like monstrous apes.  He had seen grotesque children huddled upon
+door-steps, and heard shrieks and oaths from gloomy courts.
+
+As the dawn was just breaking, he found himself close to Covent Garden.
+The darkness lifted, and, flushed with faint fires, the sky hollowed
+itself into a perfect pearl.  Huge carts filled with nodding lilies
+rumbled slowly down the polished empty street.  The air was heavy with
+the perfume of the flowers, and their beauty seemed to bring him an
+anodyne for his pain.  He followed into the market and watched the men
+unloading their waggons.  A white-smocked carter offered him some
+cherries.  He thanked him, wondered why he refused to accept any money
+for them, and began to eat them listlessly.  They had been plucked at
+midnight, and the coldness of the moon had entered into them.  A long
+line of boys carrying crates of striped tulips, and of yellow and red
+roses, defiled in front of him, threading their way through the huge,
+jade-green piles of vegetables.  Under the portico, with its grey,
+sun-bleached pillars, loitered a troop of draggled bareheaded girls,
+waiting for the auction to be over.  Others crowded round the swinging
+doors of the coffee-house in the piazza.  The heavy cart-horses slipped
+and stamped upon the rough stones, shaking their bells and trappings.
+Some of the drivers were lying asleep on a pile of sacks.  Iris-necked
+and pink-footed, the pigeons ran about picking up seeds.
+
+After a little while, he hailed a hansom and drove home.  For a few
+moments he loitered upon the doorstep, looking round at the silent
+square, with its blank, close-shuttered windows and its staring blinds.
+The sky was pure opal now, and the roofs of the houses glistened like
+silver against it.  From some chimney opposite a thin wreath of smoke
+was rising.  It curled, a violet riband, through the nacre-coloured air.
+
+In the huge gilt Venetian lantern, spoil of some Doge's barge, that
+hung from the ceiling of the great, oak-panelled hall of entrance,
+lights were still burning from three flickering jets: thin blue petals
+of flame they seemed, rimmed with white fire.  He turned them out and,
+having thrown his hat and cape on the table, passed through the library
+towards the door of his bedroom, a large octagonal chamber on the
+ground floor that, in his new-born feeling for luxury, he had just had
+decorated for himself and hung with some curious Renaissance tapestries
+that had been discovered stored in a disused attic at Selby Royal.  As
+he was turning the handle of the door, his eye fell upon the portrait
+Basil Hallward had painted of him.  He started back as if in surprise.
+Then he went on into his own room, looking somewhat puzzled.  After he
+had taken the button-hole out of his coat, he seemed to hesitate.
+Finally, he came back, went over to the picture, and examined it.  In
+the dim arrested light that struggled through the cream-coloured silk
+blinds, the face appeared to him to be a little changed.  The
+expression looked different.  One would have said that there was a
+touch of cruelty in the mouth.  It was certainly strange.
+
+He turned round and, walking to the window, drew up the blind.  The
+bright dawn flooded the room and swept the fantastic shadows into dusky
+corners, where they lay shuddering.  But the strange expression that he
+had noticed in the face of the portrait seemed to linger there, to be
+more intensified even.  The quivering ardent sunlight showed him the
+lines of cruelty round the mouth as clearly as if he had been looking
+into a mirror after he had done some dreadful thing.
+
+He winced and, taking up from the table an oval glass framed in ivory
+Cupids, one of Lord Henry's many presents to him, glanced hurriedly
+into its polished depths.  No line like that warped his red lips.  What
+did it mean?
+
+He rubbed his eyes, and came close to the picture, and examined it
+again.  There were no signs of any change when he looked into the
+actual painting, and yet there was no doubt that the whole expression
+had altered.  It was not a mere fancy of his own.  The thing was
+horribly apparent.
+
+He threw himself into a chair and began to think.  Suddenly there
+flashed across his mind what he had said in Basil Hallward's studio the
+day the picture had been finished.  Yes, he remembered it perfectly.
+He had uttered a mad wish that he himself might remain young, and the
+portrait grow old; that his own beauty might be untarnished, and the
+face on the canvas bear the burden of his passions and his sins; that
+the painted image might be seared with the lines of suffering and
+thought, and that he might keep all the delicate bloom and loveliness
+of his then just conscious boyhood.  Surely his wish had not been
+fulfilled?  Such things were impossible.  It seemed monstrous even to
+think of them.  And, yet, there was the picture before him, with the
+touch of cruelty in the mouth.
+
+Cruelty!  Had he been cruel?  It was the girl's fault, not his.  He had
+dreamed of her as a great artist, had given his love to her because he
+had thought her great.  Then she had disappointed him.  She had been
+shallow and unworthy.  And, yet, a feeling of infinite regret came over
+him, as he thought of her lying at his feet sobbing like a little
+child.  He remembered with what callousness he had watched her.  Why
+had he been made like that?  Why had such a soul been given to him?
+But he had suffered also.  During the three terrible hours that the
+play had lasted, he had lived centuries of pain, aeon upon aeon of
+torture.  His life was well worth hers.  She had marred him for a
+moment, if he had wounded her for an age.  Besides, women were better
+suited to bear sorrow than men.  They lived on their emotions.  They
+only thought of their emotions.  When they took lovers, it was merely
+to have some one with whom they could have scenes.  Lord Henry had told
+him that, and Lord Henry knew what women were.  Why should he trouble
+about Sibyl Vane?  She was nothing to him now.
+
+But the picture?  What was he to say of that?  It held the secret of
+his life, and told his story.  It had taught him to love his own
+beauty.  Would it teach him to loathe his own soul?  Would he ever look
+at it again?
+
+No; it was merely an illusion wrought on the troubled senses.  The
+horrible night that he had passed had left phantoms behind it.
+Suddenly there had fallen upon his brain that tiny scarlet speck that
+makes men mad.  The picture had not changed.  It was folly to think so.
+
+Yet it was watching him, with its beautiful marred face and its cruel
+smile.  Its bright hair gleamed in the early sunlight.  Its blue eyes
+met his own.  A sense of infinite pity, not for himself, but for the
+painted image of himself, came over him.  It had altered already, and
+would alter more.  Its gold would wither into grey.  Its red and white
+roses would die.  For every sin that he committed, a stain would fleck
+and wreck its fairness.  But he would not sin.  The picture, changed or
+unchanged, would be to him the visible emblem of conscience.  He would
+resist temptation.  He would not see Lord Henry any more--would not, at
+any rate, listen to those subtle poisonous theories that in Basil
+Hallward's garden had first stirred within him the passion for
+impossible things.  He would go back to Sibyl Vane, make her amends,
+marry her, try to love her again.  Yes, it was his duty to do so.  She
+must have suffered more than he had.  Poor child!  He had been selfish
+and cruel to her.  The fascination that she had exercised over him
+would return.  They would be happy together.  His life with her would
+be beautiful and pure.
+
+He got up from his chair and drew a large screen right in front of the
+portrait, shuddering as he glanced at it.  "How horrible!" he murmured
+to himself, and he walked across to the window and opened it.  When he
+stepped out on to the grass, he drew a deep breath.  The fresh morning
+air seemed to drive away all his sombre passions.  He thought only of
+Sibyl.  A faint echo of his love came back to him.  He repeated her
+name over and over again.  The birds that were singing in the
+dew-drenched garden seemed to be telling the flowers about her.
+
+
+
+CHAPTER 8
+
+It was long past noon when he awoke.  His valet had crept several times
+on tiptoe into the room to see if he was stirring, and had wondered
+what made his young master sleep so late.  Finally his bell sounded,
+and Victor came in softly with a cup of tea, and a pile of letters, on
+a small tray of old Sevres china, and drew back the olive-satin
+curtains, with their shimmering blue lining, that hung in front of the
+three tall windows.
+
+"Monsieur has well slept this morning," he said, smiling.
+
+"What o'clock is it, Victor?" asked Dorian Gray drowsily.
+
+"One hour and a quarter, Monsieur."
+
+How late it was!  He sat up, and having sipped some tea, turned over
+his letters.  One of them was from Lord Henry, and had been brought by
+hand that morning.  He hesitated for a moment, and then put it aside.
+The others he opened listlessly.  They contained the usual collection
+of cards, invitations to dinner, tickets for private views, programmes
+of charity concerts, and the like that are showered on fashionable
+young men every morning during the season.  There was a rather heavy
+bill for a chased silver Louis-Quinze toilet-set that he had not yet
+had the courage to send on to his guardians, who were extremely
+old-fashioned people and did not realize that we live in an age when
+unnecessary things are our only necessities; and there were several
+very courteously worded communications from Jermyn Street money-lenders
+offering to advance any sum of money at a moment's notice and at the
+most reasonable rates of interest.
+
+After about ten minutes he got up, and throwing on an elaborate
+dressing-gown of silk-embroidered cashmere wool, passed into the
+onyx-paved bathroom.  The cool water refreshed him after his long
+sleep.  He seemed to have forgotten all that he had gone through.  A
+dim sense of having taken part in some strange tragedy came to him once
+or twice, but there was the unreality of a dream about it.
+
+As soon as he was dressed, he went into the library and sat down to a
+light French breakfast that had been laid out for him on a small round
+table close to the open window.  It was an exquisite day.  The warm air
+seemed laden with spices.  A bee flew in and buzzed round the
+blue-dragon bowl that, filled with sulphur-yellow roses, stood before
+him.  He felt perfectly happy.
+
+Suddenly his eye fell on the screen that he had placed in front of the
+portrait, and he started.
+
+"Too cold for Monsieur?" asked his valet, putting an omelette on the
+table.  "I shut the window?"
+
+Dorian shook his head.  "I am not cold," he murmured.
+
+Was it all true?  Had the portrait really changed?  Or had it been
+simply his own imagination that had made him see a look of evil where
+there had been a look of joy?  Surely a painted canvas could not alter?
+The thing was absurd.  It would serve as a tale to tell Basil some day.
+It would make him smile.
+
+And, yet, how vivid was his recollection of the whole thing!  First in
+the dim twilight, and then in the bright dawn, he had seen the touch of
+cruelty round the warped lips.  He almost dreaded his valet leaving the
+room.  He knew that when he was alone he would have to examine the
+portrait.  He was afraid of certainty.  When the coffee and cigarettes
+had been brought and the man turned to go, he felt a wild desire to
+tell him to remain.  As the door was closing behind him, he called him
+back.  The man stood waiting for his orders.  Dorian looked at him for
+a moment.  "I am not at home to any one, Victor," he said with a sigh.
+The man bowed and retired.
+
+Then he rose from the table, lit a cigarette, and flung himself down on
+a luxuriously cushioned couch that stood facing the screen.  The screen
+was an old one, of gilt Spanish leather, stamped and wrought with a
+rather florid Louis-Quatorze pattern.  He scanned it curiously,
+wondering if ever before it had concealed the secret of a man's life.
+
+Should he move it aside, after all?  Why not let it stay there?  What
+was the use of knowing? If the thing was true, it was terrible.  If it
+was not true, why trouble about it?  But what if, by some fate or
+deadlier chance, eyes other than his spied behind and saw the horrible
+change?  What should he do if Basil Hallward came and asked to look at
+his own picture?  Basil would be sure to do that.  No; the thing had to
+be examined, and at once.  Anything would be better than this dreadful
+state of doubt.
+
+He got up and locked both doors.  At least he would be alone when he
+looked upon the mask of his shame.  Then he drew the screen aside and
+saw himself face to face.  It was perfectly true.  The portrait had
+altered.
+
+As he often remembered afterwards, and always with no small wonder, he
+found himself at first gazing at the portrait with a feeling of almost
+scientific interest.  That such a change should have taken place was
+incredible to him.  And yet it was a fact.  Was there some subtle
+affinity between the chemical atoms that shaped themselves into form
+and colour on the canvas and the soul that was within him?  Could it be
+that what that soul thought, they realized?--that what it dreamed, they
+made true?  Or was there some other, more terrible reason?  He
+shuddered, and felt afraid, and, going back to the couch, lay there,
+gazing at the picture in sickened horror.
+
+One thing, however, he felt that it had done for him.  It had made him
+conscious how unjust, how cruel, he had been to Sibyl Vane.  It was not
+too late to make reparation for that.  She could still be his wife.
+His unreal and selfish love would yield to some higher influence, would
+be transformed into some nobler passion, and the portrait that Basil
+Hallward had painted of him would be a guide to him through life, would
+be to him what holiness is to some, and conscience to others, and the
+fear of God to us all.  There were opiates for remorse, drugs that
+could lull the moral sense to sleep.  But here was a visible symbol of
+the degradation of sin.  Here was an ever-present sign of the ruin men
+brought upon their souls.
+
+Three o'clock struck, and four, and the half-hour rang its double
+chime, but Dorian Gray did not stir.  He was trying to gather up the
+scarlet threads of life and to weave them into a pattern; to find his
+way through the sanguine labyrinth of passion through which he was
+wandering.  He did not know what to do, or what to think.  Finally, he
+went over to the table and wrote a passionate letter to the girl he had
+loved, imploring her forgiveness and accusing himself of madness.  He
+covered page after page with wild words of sorrow and wilder words of
+pain.  There is a luxury in self-reproach. When we blame ourselves, we
+feel that no one else has a right to blame us.  It is the confession,
+not the priest, that gives us absolution.  When Dorian had finished the
+letter, he felt that he had been forgiven.
+
+Suddenly there came a knock to the door, and he heard Lord Henry's
+voice outside.  "My dear boy, I must see you.  Let me in at once.  I
+can't bear your shutting yourself up like this."
+
+He made no answer at first, but remained quite still.  The knocking
+still continued and grew louder.  Yes, it was better to let Lord Henry
+in, and to explain to him the new life he was going to lead, to quarrel
+with him if it became necessary to quarrel, to part if parting was
+inevitable.  He jumped up, drew the screen hastily across the picture,
+and unlocked the door.
+
+"I am so sorry for it all, Dorian," said Lord Henry as he entered.
+"But you must not think too much about it."
+
+"Do you mean about Sibyl Vane?" asked the lad.
+
+"Yes, of course," answered Lord Henry, sinking into a chair and slowly
+pulling off his yellow gloves.  "It is dreadful, from one point of
+view, but it was not your fault.  Tell me, did you go behind and see
+her, after the play was over?"
+
+"Yes."
+
+"I felt sure you had.  Did you make a scene with her?"
+
+"I was brutal, Harry--perfectly brutal.  But it is all right now.  I am
+not sorry for anything that has happened.  It has taught me to know
+myself better."
+
+"Ah, Dorian, I am so glad you take it in that way!  I was afraid I
+would find you plunged in remorse and tearing that nice curly hair of
+yours."
+
+"I have got through all that," said Dorian, shaking his head and
+smiling.  "I am perfectly happy now.  I know what conscience is, to
+begin with.  It is not what you told me it was.  It is the divinest
+thing in us.  Don't sneer at it, Harry, any more--at least not before
+me.  I want to be good.  I can't bear the idea of my soul being
+hideous."
+
+"A very charming artistic basis for ethics, Dorian!  I congratulate you
+on it.  But how are you going to begin?"
+
+"By marrying Sibyl Vane."
+
+"Marrying Sibyl Vane!" cried Lord Henry, standing up and looking at him
+in perplexed amazement.  "But, my dear Dorian--"
+
+"Yes, Harry, I know what you are going to say.  Something dreadful
+about marriage.  Don't say it.  Don't ever say things of that kind to
+me again.  Two days ago I asked Sibyl to marry me.  I am not going to
+break my word to her.  She is to be my wife."
+
+"Your wife!  Dorian! ... Didn't you get my letter?  I wrote to you this
+morning, and sent the note down by my own man."
+
+"Your letter?  Oh, yes, I remember.  I have not read it yet, Harry.  I
+was afraid there might be something in it that I wouldn't like.  You
+cut life to pieces with your epigrams."
+
+"You know nothing then?"
+
+"What do you mean?"
+
+Lord Henry walked across the room, and sitting down by Dorian Gray,
+took both his hands in his own and held them tightly.  "Dorian," he
+said, "my letter--don't be frightened--was to tell you that Sibyl Vane
+is dead."
+
+A cry of pain broke from the lad's lips, and he leaped to his feet,
+tearing his hands away from Lord Henry's grasp.  "Dead!  Sibyl dead!
+It is not true!  It is a horrible lie!  How dare you say it?"
+
+"It is quite true, Dorian," said Lord Henry, gravely.  "It is in all
+the morning papers.  I wrote down to you to ask you not to see any one
+till I came.  There will have to be an inquest, of course, and you must
+not be mixed up in it.  Things like that make a man fashionable in
+Paris.  But in London people are so prejudiced.  Here, one should never
+make one's _debut_ with a scandal.  One should reserve that to give an
+interest to one's old age.  I suppose they don't know your name at the
+theatre?  If they don't, it is all right.  Did any one see you going
+round to her room?  That is an important point."
+
+Dorian did not answer for a few moments.  He was dazed with horror.
+Finally he stammered, in a stifled voice, "Harry, did you say an
+inquest?  What did you mean by that?  Did Sibyl--? Oh, Harry, I can't
+bear it!  But be quick.  Tell me everything at once."
+
+"I have no doubt it was not an accident, Dorian, though it must be put
+in that way to the public.  It seems that as she was leaving the
+theatre with her mother, about half-past twelve or so, she said she had
+forgotten something upstairs.  They waited some time for her, but she
+did not come down again.  They ultimately found her lying dead on the
+floor of her dressing-room. She had swallowed something by mistake,
+some dreadful thing they use at theatres.  I don't know what it was,
+but it had either prussic acid or white lead in it.  I should fancy it
+was prussic acid, as she seems to have died instantaneously."
+
+"Harry, Harry, it is terrible!" cried the lad.
+
+"Yes; it is very tragic, of course, but you must not get yourself mixed
+up in it.  I see by _The Standard_ that she was seventeen.  I should have
+thought she was almost younger than that.  She looked such a child, and
+seemed to know so little about acting.  Dorian, you mustn't let this
+thing get on your nerves.  You must come and dine with me, and
+afterwards we will look in at the opera.  It is a Patti night, and
+everybody will be there.  You can come to my sister's box.  She has got
+some smart women with her."
+
+"So I have murdered Sibyl Vane," said Dorian Gray, half to himself,
+"murdered her as surely as if I had cut her little throat with a knife.
+Yet the roses are not less lovely for all that.  The birds sing just as
+happily in my garden.  And to-night I am to dine with you, and then go
+on to the opera, and sup somewhere, I suppose, afterwards.  How
+extraordinarily dramatic life is!  If I had read all this in a book,
+Harry, I think I would have wept over it.  Somehow, now that it has
+happened actually, and to me, it seems far too wonderful for tears.
+Here is the first passionate love-letter I have ever written in my
+life.  Strange, that my first passionate love-letter should have been
+addressed to a dead girl.  Can they feel, I wonder, those white silent
+people we call the dead?  Sibyl!  Can she feel, or know, or listen?
+Oh, Harry, how I loved her once!  It seems years ago to me now.  She
+was everything to me.  Then came that dreadful night--was it really
+only last night?--when she played so badly, and my heart almost broke.
+She explained it all to me.  It was terribly pathetic.  But I was not
+moved a bit.  I thought her shallow.  Suddenly something happened that
+made me afraid.  I can't tell you what it was, but it was terrible.  I
+said I would go back to her.  I felt I had done wrong.  And now she is
+dead.  My God!  My God!  Harry, what shall I do?  You don't know the
+danger I am in, and there is nothing to keep me straight.  She would
+have done that for me.  She had no right to kill herself.  It was
+selfish of her."
+
+"My dear Dorian," answered Lord Henry, taking a cigarette from his case
+and producing a gold-latten matchbox, "the only way a woman can ever
+reform a man is by boring him so completely that he loses all possible
+interest in life.  If you had married this girl, you would have been
+wretched.  Of course, you would have treated her kindly.  One can
+always be kind to people about whom one cares nothing.  But she would
+have soon found out that you were absolutely indifferent to her.  And
+when a woman finds that out about her husband, she either becomes
+dreadfully dowdy, or wears very smart bonnets that some other woman's
+husband has to pay for.  I say nothing about the social mistake, which
+would have been abject--which, of course, I would not have allowed--but
+I assure you that in any case the whole thing would have been an
+absolute failure."
+
+"I suppose it would," muttered the lad, walking up and down the room
+and looking horribly pale.  "But I thought it was my duty.  It is not
+my fault that this terrible tragedy has prevented my doing what was
+right.  I remember your saying once that there is a fatality about good
+resolutions--that they are always made too late.  Mine certainly were."
+
+"Good resolutions are useless attempts to interfere with scientific
+laws.  Their origin is pure vanity.  Their result is absolutely _nil_.
+They give us, now and then, some of those luxurious sterile emotions
+that have a certain charm for the weak.  That is all that can be said
+for them.  They are simply cheques that men draw on a bank where they
+have no account."
+
+"Harry," cried Dorian Gray, coming over and sitting down beside him,
+"why is it that I cannot feel this tragedy as much as I want to?  I
+don't think I am heartless.  Do you?"
+
+"You have done too many foolish things during the last fortnight to be
+entitled to give yourself that name, Dorian," answered Lord Henry with
+his sweet melancholy smile.
+
+The lad frowned.  "I don't like that explanation, Harry," he rejoined,
+"but I am glad you don't think I am heartless.  I am nothing of the
+kind.  I know I am not.  And yet I must admit that this thing that has
+happened does not affect me as it should.  It seems to me to be simply
+like a wonderful ending to a wonderful play.  It has all the terrible
+beauty of a Greek tragedy, a tragedy in which I took a great part, but
+by which I have not been wounded."
+
+"It is an interesting question," said Lord Henry, who found an
+exquisite pleasure in playing on the lad's unconscious egotism, "an
+extremely interesting question.  I fancy that the true explanation is
+this:  It often happens that the real tragedies of life occur in such
+an inartistic manner that they hurt us by their crude violence, their
+absolute incoherence, their absurd want of meaning, their entire lack
+of style.  They affect us just as vulgarity affects us.  They give us
+an impression of sheer brute force, and we revolt against that.
+Sometimes, however, a tragedy that possesses artistic elements of
+beauty crosses our lives.  If these elements of beauty are real, the
+whole thing simply appeals to our sense of dramatic effect.  Suddenly
+we find that we are no longer the actors, but the spectators of the
+play.  Or rather we are both.  We watch ourselves, and the mere wonder
+of the spectacle enthralls us.  In the present case, what is it that
+has really happened?  Some one has killed herself for love of you.  I
+wish that I had ever had such an experience.  It would have made me in
+love with love for the rest of my life.  The people who have adored
+me--there have not been very many, but there have been some--have
+always insisted on living on, long after I had ceased to care for them,
+or they to care for me.  They have become stout and tedious, and when I
+meet them, they go in at once for reminiscences.  That awful memory of
+woman!  What a fearful thing it is!  And what an utter intellectual
+stagnation it reveals!  One should absorb the colour of life, but one
+should never remember its details.  Details are always vulgar."
+
+"I must sow poppies in my garden," sighed Dorian.
+
+"There is no necessity," rejoined his companion.  "Life has always
+poppies in her hands.  Of course, now and then things linger.  I once
+wore nothing but violets all through one season, as a form of artistic
+mourning for a romance that would not die.  Ultimately, however, it did
+die.  I forget what killed it.  I think it was her proposing to
+sacrifice the whole world for me.  That is always a dreadful moment.
+It fills one with the terror of eternity.  Well--would you believe
+it?--a week ago, at Lady Hampshire's, I found myself seated at dinner
+next the lady in question, and she insisted on going over the whole
+thing again, and digging up the past, and raking up the future.  I had
+buried my romance in a bed of asphodel.  She dragged it out again and
+assured me that I had spoiled her life.  I am bound to state that she
+ate an enormous dinner, so I did not feel any anxiety.  But what a lack
+of taste she showed!  The one charm of the past is that it is the past.
+But women never know when the curtain has fallen.  They always want a
+sixth act, and as soon as the interest of the play is entirely over,
+they propose to continue it.  If they were allowed their own way, every
+comedy would have a tragic ending, and every tragedy would culminate in
+a farce.  They are charmingly artificial, but they have no sense of
+art.  You are more fortunate than I am.  I assure you, Dorian, that not
+one of the women I have known would have done for me what Sibyl Vane
+did for you.  Ordinary women always console themselves.  Some of them
+do it by going in for sentimental colours.  Never trust a woman who
+wears mauve, whatever her age may be, or a woman over thirty-five who
+is fond of pink ribbons.  It always means that they have a history.
+Others find a great consolation in suddenly discovering the good
+qualities of their husbands.  They flaunt their conjugal felicity in
+one's face, as if it were the most fascinating of sins.  Religion
+consoles some.  Its mysteries have all the charm of a flirtation, a
+woman once told me, and I can quite understand it.  Besides, nothing
+makes one so vain as being told that one is a sinner.  Conscience makes
+egotists of us all.  Yes; there is really no end to the consolations
+that women find in modern life.  Indeed, I have not mentioned the most
+important one."
+
+"What is that, Harry?" said the lad listlessly.
+
+"Oh, the obvious consolation.  Taking some one else's admirer when one
+loses one's own.  In good society that always whitewashes a woman.  But
+really, Dorian, how different Sibyl Vane must have been from all the
+women one meets!  There is something to me quite beautiful about her
+death.  I am glad I am living in a century when such wonders happen.
+They make one believe in the reality of the things we all play with,
+such as romance, passion, and love."
+
+"I was terribly cruel to her.  You forget that."
+
+"I am afraid that women appreciate cruelty, downright cruelty, more
+than anything else.  They have wonderfully primitive instincts.  We
+have emancipated them, but they remain slaves looking for their
+masters, all the same.  They love being dominated.  I am sure you were
+splendid.  I have never seen you really and absolutely angry, but I can
+fancy how delightful you looked.  And, after all, you said something to
+me the day before yesterday that seemed to me at the time to be merely
+fanciful, but that I see now was absolutely true, and it holds the key
+to everything."
+
+"What was that, Harry?"
+
+"You said to me that Sibyl Vane represented to you all the heroines of
+romance--that she was Desdemona one night, and Ophelia the other; that
+if she died as Juliet, she came to life as Imogen."
+
+"She will never come to life again now," muttered the lad, burying his
+face in his hands.
+
+"No, she will never come to life.  She has played her last part.  But
+you must think of that lonely death in the tawdry dressing-room simply
+as a strange lurid fragment from some Jacobean tragedy, as a wonderful
+scene from Webster, or Ford, or Cyril Tourneur.  The girl never really
+lived, and so she has never really died.  To you at least she was
+always a dream, a phantom that flitted through Shakespeare's plays and
+left them lovelier for its presence, a reed through which Shakespeare's
+music sounded richer and more full of joy.  The moment she touched
+actual life, she marred it, and it marred her, and so she passed away.
+Mourn for Ophelia, if you like.  Put ashes on your head because
+Cordelia was strangled.  Cry out against Heaven because the daughter of
+Brabantio died.  But don't waste your tears over Sibyl Vane.  She was
+less real than they are."
+
+There was a silence.  The evening darkened in the room.  Noiselessly,
+and with silver feet, the shadows crept in from the garden.  The
+colours faded wearily out of things.
+
+After some time Dorian Gray looked up.  "You have explained me to
+myself, Harry," he murmured with something of a sigh of relief.  "I
+felt all that you have said, but somehow I was afraid of it, and I
+could not express it to myself.  How well you know me!  But we will not
+talk again of what has happened.  It has been a marvellous experience.
+That is all.  I wonder if life has still in store for me anything as
+marvellous."
+
+"Life has everything in store for you, Dorian.  There is nothing that
+you, with your extraordinary good looks, will not be able to do."
+
+"But suppose, Harry, I became haggard, and old, and wrinkled?  What
+then?"
+
+"Ah, then," said Lord Henry, rising to go, "then, my dear Dorian, you
+would have to fight for your victories.  As it is, they are brought to
+you.  No, you must keep your good looks.  We live in an age that reads
+too much to be wise, and that thinks too much to be beautiful.  We
+cannot spare you.  And now you had better dress and drive down to the
+club.  We are rather late, as it is."
+
+"I think I shall join you at the opera, Harry.  I feel too tired to eat
+anything.  What is the number of your sister's box?"
+
+"Twenty-seven, I believe.  It is on the grand tier.  You will see her
+name on the door.  But I am sorry you won't come and dine."
+
+"I don't feel up to it," said Dorian listlessly.  "But I am awfully
+obliged to you for all that you have said to me.  You are certainly my
+best friend.  No one has ever understood me as you have."
+
+"We are only at the beginning of our friendship, Dorian," answered Lord
+Henry, shaking him by the hand.  "Good-bye. I shall see you before
+nine-thirty, I hope.  Remember, Patti is singing."
+
+As he closed the door behind him, Dorian Gray touched the bell, and in
+a few minutes Victor appeared with the lamps and drew the blinds down.
+He waited impatiently for him to go.  The man seemed to take an
+interminable time over everything.
+
+As soon as he had left, he rushed to the screen and drew it back.  No;
+there was no further change in the picture.  It had received the news
+of Sibyl Vane's death before he had known of it himself.  It was
+conscious of the events of life as they occurred.  The vicious cruelty
+that marred the fine lines of the mouth had, no doubt, appeared at the
+very moment that the girl had drunk the poison, whatever it was.  Or
+was it indifferent to results?  Did it merely take cognizance of what
+passed within the soul?  He wondered, and hoped that some day he would
+see the change taking place before his very eyes, shuddering as he
+hoped it.
+
+Poor Sibyl!  What a romance it had all been!  She had often mimicked
+death on the stage.  Then Death himself had touched her and taken her
+with him.  How had she played that dreadful last scene?  Had she cursed
+him, as she died?  No; she had died for love of him, and love would
+always be a sacrament to him now.  She had atoned for everything by the
+sacrifice she had made of her life.  He would not think any more of
+what she had made him go through, on that horrible night at the
+theatre.  When he thought of her, it would be as a wonderful tragic
+figure sent on to the world's stage to show the supreme reality of
+love.  A wonderful tragic figure?  Tears came to his eyes as he
+remembered her childlike look, and winsome fanciful ways, and shy
+tremulous grace.  He brushed them away hastily and looked again at the
+picture.
+
+He felt that the time had really come for making his choice.  Or had
+his choice already been made?  Yes, life had decided that for
+him--life, and his own infinite curiosity about life.  Eternal youth,
+infinite passion, pleasures subtle and secret, wild joys and wilder
+sins--he was to have all these things.  The portrait was to bear the
+burden of his shame: that was all.
+
+A feeling of pain crept over him as he thought of the desecration that
+was in store for the fair face on the canvas.  Once, in boyish mockery
+of Narcissus, he had kissed, or feigned to kiss, those painted lips
+that now smiled so cruelly at him.  Morning after morning he had sat
+before the portrait wondering at its beauty, almost enamoured of it, as
+it seemed to him at times.  Was it to alter now with every mood to
+which he yielded?  Was it to become a monstrous and loathsome thing, to
+be hidden away in a locked room, to be shut out from the sunlight that
+had so often touched to brighter gold the waving wonder of its hair?
+The pity of it! the pity of it!
+
+For a moment, he thought of praying that the horrible sympathy that
+existed between him and the picture might cease.  It had changed in
+answer to a prayer; perhaps in answer to a prayer it might remain
+unchanged.  And yet, who, that knew anything about life, would
+surrender the chance of remaining always young, however fantastic that
+chance might be, or with what fateful consequences it might be fraught?
+Besides, was it really under his control?  Had it indeed been prayer
+that had produced the substitution?  Might there not be some curious
+scientific reason for it all?  If thought could exercise its influence
+upon a living organism, might not thought exercise an influence upon
+dead and inorganic things?  Nay, without thought or conscious desire,
+might not things external to ourselves vibrate in unison with our moods
+and passions, atom calling to atom in secret love or strange affinity?
+But the reason was of no importance.  He would never again tempt by a
+prayer any terrible power.  If the picture was to alter, it was to
+alter.  That was all.  Why inquire too closely into it?
+
+For there would be a real pleasure in watching it.  He would be able to
+follow his mind into its secret places.  This portrait would be to him
+the most magical of mirrors.  As it had revealed to him his own body,
+so it would reveal to him his own soul.  And when winter came upon it,
+he would still be standing where spring trembles on the verge of
+summer.  When the blood crept from its face, and left behind a pallid
+mask of chalk with leaden eyes, he would keep the glamour of boyhood.
+Not one blossom of his loveliness would ever fade.  Not one pulse of
+his life would ever weaken.  Like the gods of the Greeks, he would be
+strong, and fleet, and joyous.  What did it matter what happened to the
+coloured image on the canvas?  He would be safe.  That was everything.
+
+He drew the screen back into its former place in front of the picture,
+smiling as he did so, and passed into his bedroom, where his valet was
+already waiting for him.  An hour later he was at the opera, and Lord
+Henry was leaning over his chair.
+
+
+
+CHAPTER 9
+
+As he was sitting at breakfast next morning, Basil Hallward was shown
+into the room.
+
+"I am so glad I have found you, Dorian," he said gravely.  "I called
+last night, and they told me you were at the opera.  Of course, I knew
+that was impossible.  But I wish you had left word where you had really
+gone to.  I passed a dreadful evening, half afraid that one tragedy
+might be followed by another.  I think you might have telegraphed for
+me when you heard of it first.  I read of it quite by chance in a late
+edition of _The Globe_ that I picked up at the club.  I came here at once
+and was miserable at not finding you.  I can't tell you how
+heart-broken I am about the whole thing.  I know what you must suffer.
+But where were you?  Did you go down and see the girl's mother?  For a
+moment I thought of following you there.  They gave the address in the
+paper.  Somewhere in the Euston Road, isn't it?  But I was afraid of
+intruding upon a sorrow that I could not lighten.  Poor woman!  What a
+state she must be in!  And her only child, too!  What did she say about
+it all?"
+
+"My dear Basil, how do I know?" murmured Dorian Gray, sipping some
+pale-yellow wine from a delicate, gold-beaded bubble of Venetian glass
+and looking dreadfully bored.  "I was at the opera.  You should have
+come on there.  I met Lady Gwendolen, Harry's sister, for the first
+time.  We were in her box.  She is perfectly charming; and Patti sang
+divinely.  Don't talk about horrid subjects.  If one doesn't talk about
+a thing, it has never happened.  It is simply expression, as Harry
+says, that gives reality to things.  I may mention that she was not the
+woman's only child.  There is a son, a charming fellow, I believe.  But
+he is not on the stage.  He is a sailor, or something.  And now, tell
+me about yourself and what you are painting."
+
+"You went to the opera?" said Hallward, speaking very slowly and with a
+strained touch of pain in his voice.  "You went to the opera while
+Sibyl Vane was lying dead in some sordid lodging?  You can talk to me
+of other women being charming, and of Patti singing divinely, before
+the girl you loved has even the quiet of a grave to sleep in?  Why,
+man, there are horrors in store for that little white body of hers!"
+
+"Stop, Basil!  I won't hear it!" cried Dorian, leaping to his feet.
+"You must not tell me about things.  What is done is done.  What is
+past is past."
+
+"You call yesterday the past?"
+
+"What has the actual lapse of time got to do with it?  It is only
+shallow people who require years to get rid of an emotion.  A man who
+is master of himself can end a sorrow as easily as he can invent a
+pleasure.  I don't want to be at the mercy of my emotions.  I want to
+use them, to enjoy them, and to dominate them."
+
+"Dorian, this is horrible!  Something has changed you completely.  You
+look exactly the same wonderful boy who, day after day, used to come
+down to my studio to sit for his picture.  But you were simple,
+natural, and affectionate then.  You were the most unspoiled creature
+in the whole world.  Now, I don't know what has come over you.  You
+talk as if you had no heart, no pity in you.  It is all Harry's
+influence.  I see that."
+
+The lad flushed up and, going to the window, looked out for a few
+moments on the green, flickering, sun-lashed garden.  "I owe a great
+deal to Harry, Basil," he said at last, "more than I owe to you.  You
+only taught me to be vain."
+
+"Well, I am punished for that, Dorian--or shall be some day."
+
+"I don't know what you mean, Basil," he exclaimed, turning round.  "I
+don't know what you want.  What do you want?"
+
+"I want the Dorian Gray I used to paint," said the artist sadly.
+
+"Basil," said the lad, going over to him and putting his hand on his
+shoulder, "you have come too late.  Yesterday, when I heard that Sibyl
+Vane had killed herself--"
+
+"Killed herself!  Good heavens! is there no doubt about that?" cried
+Hallward, looking up at him with an expression of horror.
+
+"My dear Basil!  Surely you don't think it was a vulgar accident?  Of
+course she killed herself."
+
+The elder man buried his face in his hands.  "How fearful," he
+muttered, and a shudder ran through him.
+
+"No," said Dorian Gray, "there is nothing fearful about it.  It is one
+of the great romantic tragedies of the age.  As a rule, people who act
+lead the most commonplace lives.  They are good husbands, or faithful
+wives, or something tedious.  You know what I mean--middle-class virtue
+and all that kind of thing.  How different Sibyl was!  She lived her
+finest tragedy.  She was always a heroine.  The last night she
+played--the night you saw her--she acted badly because she had known
+the reality of love.  When she knew its unreality, she died, as Juliet
+might have died.  She passed again into the sphere of art.  There is
+something of the martyr about her.  Her death has all the pathetic
+uselessness of martyrdom, all its wasted beauty.  But, as I was saying,
+you must not think I have not suffered.  If you had come in yesterday
+at a particular moment--about half-past five, perhaps, or a quarter to
+six--you would have found me in tears.  Even Harry, who was here, who
+brought me the news, in fact, had no idea what I was going through.  I
+suffered immensely.  Then it passed away.  I cannot repeat an emotion.
+No one can, except sentimentalists.  And you are awfully unjust, Basil.
+You come down here to console me.  That is charming of you.  You find
+me consoled, and you are furious.  How like a sympathetic person!  You
+remind me of a story Harry told me about a certain philanthropist who
+spent twenty years of his life in trying to get some grievance
+redressed, or some unjust law altered--I forget exactly what it was.
+Finally he succeeded, and nothing could exceed his disappointment.  He
+had absolutely nothing to do, almost died of _ennui_, and became a
+confirmed misanthrope.  And besides, my dear old Basil, if you really
+want to console me, teach me rather to forget what has happened, or to
+see it from a proper artistic point of view.  Was it not Gautier who
+used to write about _la consolation des arts_?  I remember picking up a
+little vellum-covered book in your studio one day and chancing on that
+delightful phrase.  Well, I am not like that young man you told me of
+when we were down at Marlow together, the young man who used to say
+that yellow satin could console one for all the miseries of life.  I
+love beautiful things that one can touch and handle.  Old brocades,
+green bronzes, lacquer-work, carved ivories, exquisite surroundings,
+luxury, pomp--there is much to be got from all these.  But the artistic
+temperament that they create, or at any rate reveal, is still more to
+me.  To become the spectator of one's own life, as Harry says, is to
+escape the suffering of life.  I know you are surprised at my talking
+to you like this.  You have not realized how I have developed.  I was a
+schoolboy when you knew me.  I am a man now.  I have new passions, new
+thoughts, new ideas.  I am different, but you must not like me less.  I
+am changed, but you must always be my friend.  Of course, I am very
+fond of Harry.  But I know that you are better than he is.  You are not
+stronger--you are too much afraid of life--but you are better.  And how
+happy we used to be together!  Don't leave me, Basil, and don't quarrel
+with me.  I am what I am.  There is nothing more to be said."
+
+The painter felt strangely moved.  The lad was infinitely dear to him,
+and his personality had been the great turning point in his art.  He
+could not bear the idea of reproaching him any more.  After all, his
+indifference was probably merely a mood that would pass away.  There
+was so much in him that was good, so much in him that was noble.
+
+"Well, Dorian," he said at length, with a sad smile, "I won't speak to
+you again about this horrible thing, after to-day.  I only trust your
+name won't be mentioned in connection with it.  The inquest is to take
+place this afternoon.  Have they summoned you?"
+
+Dorian shook his head, and a look of annoyance passed over his face at
+the mention of the word "inquest."  There was something so crude and
+vulgar about everything of the kind.  "They don't know my name," he
+answered.
+
+"But surely she did?"
+
+"Only my Christian name, and that I am quite sure she never mentioned
+to any one.  She told me once that they were all rather curious to
+learn who I was, and that she invariably told them my name was Prince
+Charming.  It was pretty of her.  You must do me a drawing of Sibyl,
+Basil.  I should like to have something more of her than the memory of
+a few kisses and some broken pathetic words."
+
+"I will try and do something, Dorian, if it would please you.  But you
+must come and sit to me yourself again.  I can't get on without you."
+
+"I can never sit to you again, Basil.  It is impossible!" he exclaimed,
+starting back.
+
+The painter stared at him.  "My dear boy, what nonsense!" he cried.
+"Do you mean to say you don't like what I did of you?  Where is it?
+Why have you pulled the screen in front of it?  Let me look at it.  It
+is the best thing I have ever done.  Do take the screen away, Dorian.
+It is simply disgraceful of your servant hiding my work like that.  I
+felt the room looked different as I came in."
+
+"My servant has nothing to do with it, Basil.  You don't imagine I let
+him arrange my room for me?  He settles my flowers for me
+sometimes--that is all.  No; I did it myself.  The light was too strong
+on the portrait."
+
+"Too strong!  Surely not, my dear fellow?  It is an admirable place for
+it.  Let me see it."  And Hallward walked towards the corner of the
+room.
+
+A cry of terror broke from Dorian Gray's lips, and he rushed between
+the painter and the screen.  "Basil," he said, looking very pale, "you
+must not look at it.  I don't wish you to."
+
+"Not look at my own work!  You are not serious.  Why shouldn't I look
+at it?" exclaimed Hallward, laughing.
+
+"If you try to look at it, Basil, on my word of honour I will never
+speak to you again as long as I live.  I am quite serious.  I don't
+offer any explanation, and you are not to ask for any.  But, remember,
+if you touch this screen, everything is over between us."
+
+Hallward was thunderstruck.  He looked at Dorian Gray in absolute
+amazement.  He had never seen him like this before.  The lad was
+actually pallid with rage.  His hands were clenched, and the pupils of
+his eyes were like disks of blue fire.  He was trembling all over.
+
+"Dorian!"
+
+"Don't speak!"
+
+"But what is the matter?  Of course I won't look at it if you don't
+want me to," he said, rather coldly, turning on his heel and going over
+towards the window.  "But, really, it seems rather absurd that I
+shouldn't see my own work, especially as I am going to exhibit it in
+Paris in the autumn.  I shall probably have to give it another coat of
+varnish before that, so I must see it some day, and why not to-day?"
+
+"To exhibit it!  You want to exhibit it?" exclaimed Dorian Gray, a
+strange sense of terror creeping over him.  Was the world going to be
+shown his secret?  Were people to gape at the mystery of his life?
+That was impossible.  Something--he did not know what--had to be done
+at once.
+
+"Yes; I don't suppose you will object to that.  Georges Petit is going
+to collect all my best pictures for a special exhibition in the Rue de
+Seze, which will open the first week in October.  The portrait will
+only be away a month.  I should think you could easily spare it for
+that time.  In fact, you are sure to be out of town.  And if you keep
+it always behind a screen, you can't care much about it."
+
+Dorian Gray passed his hand over his forehead.  There were beads of
+perspiration there.  He felt that he was on the brink of a horrible
+danger.  "You told me a month ago that you would never exhibit it," he
+cried.  "Why have you changed your mind?  You people who go in for
+being consistent have just as many moods as others have.  The only
+difference is that your moods are rather meaningless.  You can't have
+forgotten that you assured me most solemnly that nothing in the world
+would induce you to send it to any exhibition.  You told Harry exactly
+the same thing." He stopped suddenly, and a gleam of light came into
+his eyes.  He remembered that Lord Henry had said to him once, half
+seriously and half in jest, "If you want to have a strange quarter of
+an hour, get Basil to tell you why he won't exhibit your picture.  He
+told me why he wouldn't, and it was a revelation to me."  Yes, perhaps
+Basil, too, had his secret.  He would ask him and try.
+
+"Basil," he said, coming over quite close and looking him straight in
+the face, "we have each of us a secret.  Let me know yours, and I shall
+tell you mine.  What was your reason for refusing to exhibit my
+picture?"
+
+The painter shuddered in spite of himself.  "Dorian, if I told you, you
+might like me less than you do, and you would certainly laugh at me.  I
+could not bear your doing either of those two things.  If you wish me
+never to look at your picture again, I am content.  I have always you
+to look at.  If you wish the best work I have ever done to be hidden
+from the world, I am satisfied.  Your friendship is dearer to me than
+any fame or reputation."
+
+"No, Basil, you must tell me," insisted Dorian Gray.  "I think I have a
+right to know."  His feeling of terror had passed away, and curiosity
+had taken its place.  He was determined to find out Basil Hallward's
+mystery.
+
+"Let us sit down, Dorian," said the painter, looking troubled.  "Let us
+sit down.  And just answer me one question.  Have you noticed in the
+picture something curious?--something that probably at first did not
+strike you, but that revealed itself to you suddenly?"
+
+"Basil!" cried the lad, clutching the arms of his chair with trembling
+hands and gazing at him with wild startled eyes.
+
+"I see you did.  Don't speak.  Wait till you hear what I have to say.
+Dorian, from the moment I met you, your personality had the most
+extraordinary influence over me.  I was dominated, soul, brain, and
+power, by you.  You became to me the visible incarnation of that unseen
+ideal whose memory haunts us artists like an exquisite dream.  I
+worshipped you.  I grew jealous of every one to whom you spoke.  I
+wanted to have you all to myself.  I was only happy when I was with
+you.  When you were away from me, you were still present in my art....
+Of course, I never let you know anything about this.  It would have
+been impossible.  You would not have understood it.  I hardly
+understood it myself.  I only knew that I had seen perfection face to
+face, and that the world had become wonderful to my eyes--too
+wonderful, perhaps, for in such mad worships there is peril, the peril
+of losing them, no less than the peril of keeping them....  Weeks and
+weeks went on, and I grew more and more absorbed in you.  Then came a
+new development.  I had drawn you as Paris in dainty armour, and as
+Adonis with huntsman's cloak and polished boar-spear. Crowned with
+heavy lotus-blossoms you had sat on the prow of Adrian's barge, gazing
+across the green turbid Nile.  You had leaned over the still pool of
+some Greek woodland and seen in the water's silent silver the marvel of
+your own face.  And it had all been what art should be--unconscious,
+ideal, and remote.  One day, a fatal day I sometimes think, I
+determined to paint a wonderful portrait of you as you actually are,
+not in the costume of dead ages, but in your own dress and in your own
+time.  Whether it was the realism of the method, or the mere wonder of
+your own personality, thus directly presented to me without mist or
+veil, I cannot tell.  But I know that as I worked at it, every flake
+and film of colour seemed to me to reveal my secret.  I grew afraid
+that others would know of my idolatry.  I felt, Dorian, that I had told
+too much, that I had put too much of myself into it.  Then it was that
+I resolved never to allow the picture to be exhibited.  You were a
+little annoyed; but then you did not realize all that it meant to me.
+Harry, to whom I talked about it, laughed at me.  But I did not mind
+that.  When the picture was finished, and I sat alone with it, I felt
+that I was right.... Well, after a few days the thing left my studio,
+and as soon as I had got rid of the intolerable fascination of its
+presence, it seemed to me that I had been foolish in imagining that I
+had seen anything in it, more than that you were extremely good-looking
+and that I could paint.  Even now I cannot help feeling that it is a
+mistake to think that the passion one feels in creation is ever really
+shown in the work one creates.  Art is always more abstract than we
+fancy.  Form and colour tell us of form and colour--that is all.  It
+often seems to me that art conceals the artist far more completely than
+it ever reveals him.  And so when I got this offer from Paris, I
+determined to make your portrait the principal thing in my exhibition.
+It never occurred to me that you would refuse.  I see now that you were
+right.  The picture cannot be shown.  You must not be angry with me,
+Dorian, for what I have told you.  As I said to Harry, once, you are
+made to be worshipped."
+
+Dorian Gray drew a long breath.  The colour came back to his cheeks,
+and a smile played about his lips.  The peril was over.  He was safe
+for the time.  Yet he could not help feeling infinite pity for the
+painter who had just made this strange confession to him, and wondered
+if he himself would ever be so dominated by the personality of a
+friend.  Lord Henry had the charm of being very dangerous.  But that
+was all.  He was too clever and too cynical to be really fond of.
+Would there ever be some one who would fill him with a strange
+idolatry?  Was that one of the things that life had in store?
+
+"It is extraordinary to me, Dorian," said Hallward, "that you should
+have seen this in the portrait.  Did you really see it?"
+
+"I saw something in it," he answered, "something that seemed to me very
+curious."
+
+"Well, you don't mind my looking at the thing now?"
+
+Dorian shook his head.  "You must not ask me that, Basil.  I could not
+possibly let you stand in front of that picture."
+
+"You will some day, surely?"
+
+"Never."
+
+"Well, perhaps you are right.  And now good-bye, Dorian.  You have been
+the one person in my life who has really influenced my art.  Whatever I
+have done that is good, I owe to you.  Ah! you don't know what it cost
+me to tell you all that I have told you."
+
+"My dear Basil," said Dorian, "what have you told me?  Simply that you
+felt that you admired me too much.  That is not even a compliment."
+
+"It was not intended as a compliment.  It was a confession.  Now that I
+have made it, something seems to have gone out of me.  Perhaps one
+should never put one's worship into words."
+
+"It was a very disappointing confession."
+
+"Why, what did you expect, Dorian?  You didn't see anything else in the
+picture, did you?  There was nothing else to see?"
+
+"No; there was nothing else to see.  Why do you ask?  But you mustn't
+talk about worship.  It is foolish.  You and I are friends, Basil, and
+we must always remain so."
+
+"You have got Harry," said the painter sadly.
+
+"Oh, Harry!" cried the lad, with a ripple of laughter.  "Harry spends
+his days in saying what is incredible and his evenings in doing what is
+improbable.  Just the sort of life I would like to lead.  But still I
+don't think I would go to Harry if I were in trouble.  I would sooner
+go to you, Basil."
+
+"You will sit to me again?"
+
+"Impossible!"
+
+"You spoil my life as an artist by refusing, Dorian.  No man comes
+across two ideal things.  Few come across one."
+
+"I can't explain it to you, Basil, but I must never sit to you again.
+There is something fatal about a portrait.  It has a life of its own.
+I will come and have tea with you.  That will be just as pleasant."
+
+"Pleasanter for you, I am afraid," murmured Hallward regretfully.  "And
+now good-bye. I am sorry you won't let me look at the picture once
+again.  But that can't be helped.  I quite understand what you feel
+about it."
+
+As he left the room, Dorian Gray smiled to himself.  Poor Basil!  How
+little he knew of the true reason!  And how strange it was that,
+instead of having been forced to reveal his own secret, he had
+succeeded, almost by chance, in wresting a secret from his friend!  How
+much that strange confession explained to him!  The painter's absurd
+fits of jealousy, his wild devotion, his extravagant panegyrics, his
+curious reticences--he understood them all now, and he felt sorry.
+There seemed to him to be something tragic in a friendship so coloured
+by romance.
+
+He sighed and touched the bell.  The portrait must be hidden away at
+all costs.  He could not run such a risk of discovery again.  It had
+been mad of him to have allowed the thing to remain, even for an hour,
+in a room to which any of his friends had access.
+
+
+
+CHAPTER 10
+
+When his servant entered, he looked at him steadfastly and wondered if
+he had thought of peering behind the screen.  The man was quite
+impassive and waited for his orders.  Dorian lit a cigarette and walked
+over to the glass and glanced into it.  He could see the reflection of
+Victor's face perfectly.  It was like a placid mask of servility.
+There was nothing to be afraid of, there.  Yet he thought it best to be
+on his guard.
+
+Speaking very slowly, he told him to tell the house-keeper that he
+wanted to see her, and then to go to the frame-maker and ask him to
+send two of his men round at once.  It seemed to him that as the man
+left the room his eyes wandered in the direction of the screen.  Or was
+that merely his own fancy?
+
+After a few moments, in her black silk dress, with old-fashioned thread
+mittens on her wrinkled hands, Mrs. Leaf bustled into the library.  He
+asked her for the key of the schoolroom.
+
+"The old schoolroom, Mr. Dorian?" she exclaimed.  "Why, it is full of
+dust.  I must get it arranged and put straight before you go into it.
+It is not fit for you to see, sir.  It is not, indeed."
+
+"I don't want it put straight, Leaf.  I only want the key."
+
+"Well, sir, you'll be covered with cobwebs if you go into it.  Why, it
+hasn't been opened for nearly five years--not since his lordship died."
+
+He winced at the mention of his grandfather.  He had hateful memories
+of him.  "That does not matter," he answered.  "I simply want to see
+the place--that is all.  Give me the key."
+
+"And here is the key, sir," said the old lady, going over the contents
+of her bunch with tremulously uncertain hands.  "Here is the key.  I'll
+have it off the bunch in a moment.  But you don't think of living up
+there, sir, and you so comfortable here?"
+
+"No, no," he cried petulantly.  "Thank you, Leaf.  That will do."
+
+She lingered for a few moments, and was garrulous over some detail of
+the household.  He sighed and told her to manage things as she thought
+best.  She left the room, wreathed in smiles.
+
+As the door closed, Dorian put the key in his pocket and looked round
+the room.  His eye fell on a large, purple satin coverlet heavily
+embroidered with gold, a splendid piece of late seventeenth-century
+Venetian work that his grandfather had found in a convent near Bologna.
+Yes, that would serve to wrap the dreadful thing in.  It had perhaps
+served often as a pall for the dead.  Now it was to hide something that
+had a corruption of its own, worse than the corruption of death
+itself--something that would breed horrors and yet would never die.
+What the worm was to the corpse, his sins would be to the painted image
+on the canvas.  They would mar its beauty and eat away its grace.  They
+would defile it and make it shameful.  And yet the thing would still
+live on.  It would be always alive.
+
+He shuddered, and for a moment he regretted that he had not told Basil
+the true reason why he had wished to hide the picture away.  Basil
+would have helped him to resist Lord Henry's influence, and the still
+more poisonous influences that came from his own temperament.  The love
+that he bore him--for it was really love--had nothing in it that was
+not noble and intellectual.  It was not that mere physical admiration
+of beauty that is born of the senses and that dies when the senses
+tire.  It was such love as Michelangelo had known, and Montaigne, and
+Winckelmann, and Shakespeare himself.  Yes, Basil could have saved him.
+But it was too late now.  The past could always be annihilated.
+Regret, denial, or forgetfulness could do that.  But the future was
+inevitable.  There were passions in him that would find their terrible
+outlet, dreams that would make the shadow of their evil real.
+
+He took up from the couch the great purple-and-gold texture that
+covered it, and, holding it in his hands, passed behind the screen.
+Was the face on the canvas viler than before?  It seemed to him that it
+was unchanged, and yet his loathing of it was intensified.  Gold hair,
+blue eyes, and rose-red lips--they all were there.  It was simply the
+expression that had altered.  That was horrible in its cruelty.
+Compared to what he saw in it of censure or rebuke, how shallow Basil's
+reproaches about Sibyl Vane had been!--how shallow, and of what little
+account!  His own soul was looking out at him from the canvas and
+calling him to judgement.  A look of pain came across him, and he flung
+the rich pall over the picture.  As he did so, a knock came to the
+door.  He passed out as his servant entered.
+
+"The persons are here, Monsieur."
+
+He felt that the man must be got rid of at once.  He must not be
+allowed to know where the picture was being taken to.  There was
+something sly about him, and he had thoughtful, treacherous eyes.
+Sitting down at the writing-table he scribbled a note to Lord Henry,
+asking him to send him round something to read and reminding him that
+they were to meet at eight-fifteen that evening.
+
+"Wait for an answer," he said, handing it to him, "and show the men in
+here."
+
+In two or three minutes there was another knock, and Mr. Hubbard
+himself, the celebrated frame-maker of South Audley Street, came in
+with a somewhat rough-looking young assistant.  Mr. Hubbard was a
+florid, red-whiskered little man, whose admiration for art was
+considerably tempered by the inveterate impecuniosity of most of the
+artists who dealt with him.  As a rule, he never left his shop.  He
+waited for people to come to him.  But he always made an exception in
+favour of Dorian Gray.  There was something about Dorian that charmed
+everybody.  It was a pleasure even to see him.
+
+"What can I do for you, Mr. Gray?" he said, rubbing his fat freckled
+hands.  "I thought I would do myself the honour of coming round in
+person.  I have just got a beauty of a frame, sir.  Picked it up at a
+sale.  Old Florentine.  Came from Fonthill, I believe.  Admirably
+suited for a religious subject, Mr. Gray."
+
+"I am so sorry you have given yourself the trouble of coming round, Mr.
+Hubbard.  I shall certainly drop in and look at the frame--though I
+don't go in much at present for religious art--but to-day I only want a
+picture carried to the top of the house for me.  It is rather heavy, so
+I thought I would ask you to lend me a couple of your men."
+
+"No trouble at all, Mr. Gray.  I am delighted to be of any service to
+you.  Which is the work of art, sir?"
+
+"This," replied Dorian, moving the screen back.  "Can you move it,
+covering and all, just as it is?  I don't want it to get scratched
+going upstairs."
+
+"There will be no difficulty, sir," said the genial frame-maker,
+beginning, with the aid of his assistant, to unhook the picture from
+the long brass chains by which it was suspended.  "And, now, where
+shall we carry it to, Mr. Gray?"
+
+"I will show you the way, Mr. Hubbard, if you will kindly follow me.
+Or perhaps you had better go in front.  I am afraid it is right at the
+top of the house.  We will go up by the front staircase, as it is
+wider."
+
+He held the door open for them, and they passed out into the hall and
+began the ascent.  The elaborate character of the frame had made the
+picture extremely bulky, and now and then, in spite of the obsequious
+protests of Mr. Hubbard, who had the true tradesman's spirited dislike
+of seeing a gentleman doing anything useful, Dorian put his hand to it
+so as to help them.
+
+"Something of a load to carry, sir," gasped the little man when they
+reached the top landing.  And he wiped his shiny forehead.
+
+"I am afraid it is rather heavy," murmured Dorian as he unlocked the
+door that opened into the room that was to keep for him the curious
+secret of his life and hide his soul from the eyes of men.
+
+He had not entered the place for more than four years--not, indeed,
+since he had used it first as a play-room when he was a child, and then
+as a study when he grew somewhat older.  It was a large,
+well-proportioned room, which had been specially built by the last Lord
+Kelso for the use of the little grandson whom, for his strange likeness
+to his mother, and also for other reasons, he had always hated and
+desired to keep at a distance.  It appeared to Dorian to have but
+little changed.  There was the huge Italian _cassone_, with its
+fantastically painted panels and its tarnished gilt mouldings, in which
+he had so often hidden himself as a boy.  There the satinwood book-case
+filled with his dog-eared schoolbooks.  On the wall behind it was
+hanging the same ragged Flemish tapestry where a faded king and queen
+were playing chess in a garden, while a company of hawkers rode by,
+carrying hooded birds on their gauntleted wrists.  How well he
+remembered it all!  Every moment of his lonely childhood came back to
+him as he looked round.  He recalled the stainless purity of his boyish
+life, and it seemed horrible to him that it was here the fatal portrait
+was to be hidden away.  How little he had thought, in those dead days,
+of all that was in store for him!
+
+But there was no other place in the house so secure from prying eyes as
+this.  He had the key, and no one else could enter it.  Beneath its
+purple pall, the face painted on the canvas could grow bestial, sodden,
+and unclean.  What did it matter?  No one could see it.  He himself
+would not see it.  Why should he watch the hideous corruption of his
+soul?  He kept his youth--that was enough.  And, besides, might not
+his nature grow finer, after all?  There was no reason that the future
+should be so full of shame.  Some love might come across his life, and
+purify him, and shield him from those sins that seemed to be already
+stirring in spirit and in flesh--those curious unpictured sins whose
+very mystery lent them their subtlety and their charm.  Perhaps, some
+day, the cruel look would have passed away from the scarlet sensitive
+mouth, and he might show to the world Basil Hallward's masterpiece.
+
+No; that was impossible.  Hour by hour, and week by week, the thing
+upon the canvas was growing old.  It might escape the hideousness of
+sin, but the hideousness of age was in store for it.  The cheeks would
+become hollow or flaccid.  Yellow crow's feet would creep round the
+fading eyes and make them horrible.  The hair would lose its
+brightness, the mouth would gape or droop, would be foolish or gross,
+as the mouths of old men are.  There would be the wrinkled throat, the
+cold, blue-veined hands, the twisted body, that he remembered in the
+grandfather who had been so stern to him in his boyhood.  The picture
+had to be concealed.  There was no help for it.
+
+"Bring it in, Mr. Hubbard, please," he said, wearily, turning round.
+"I am sorry I kept you so long.  I was thinking of something else."
+
+"Always glad to have a rest, Mr. Gray," answered the frame-maker, who
+was still gasping for breath.  "Where shall we put it, sir?"
+
+"Oh, anywhere.  Here:  this will do.  I don't want to have it hung up.
+Just lean it against the wall.  Thanks."
+
+"Might one look at the work of art, sir?"
+
+Dorian started.  "It would not interest you, Mr. Hubbard," he said,
+keeping his eye on the man.  He felt ready to leap upon him and fling
+him to the ground if he dared to lift the gorgeous hanging that
+concealed the secret of his life.  "I shan't trouble you any more now.
+I am much obliged for your kindness in coming round."
+
+"Not at all, not at all, Mr. Gray.  Ever ready to do anything for you,
+sir." And Mr. Hubbard tramped downstairs, followed by the assistant,
+who glanced back at Dorian with a look of shy wonder in his rough
+uncomely face.  He had never seen any one so marvellous.
+
+When the sound of their footsteps had died away, Dorian locked the door
+and put the key in his pocket.  He felt safe now.  No one would ever
+look upon the horrible thing.  No eye but his would ever see his shame.
+
+On reaching the library, he found that it was just after five o'clock
+and that the tea had been already brought up.  On a little table of
+dark perfumed wood thickly incrusted with nacre, a present from Lady
+Radley, his guardian's wife, a pretty professional invalid who had
+spent the preceding winter in Cairo, was lying a note from Lord Henry,
+and beside it was a book bound in yellow paper, the cover slightly torn
+and the edges soiled.  A copy of the third edition of _The St. James's
+Gazette_ had been placed on the tea-tray. It was evident that Victor had
+returned.  He wondered if he had met the men in the hall as they were
+leaving the house and had wormed out of them what they had been doing.
+He would be sure to miss the picture--had no doubt missed it already,
+while he had been laying the tea-things. The screen had not been set
+back, and a blank space was visible on the wall.  Perhaps some night he
+might find him creeping upstairs and trying to force the door of the
+room.  It was a horrible thing to have a spy in one's house.  He had
+heard of rich men who had been blackmailed all their lives by some
+servant who had read a letter, or overheard a conversation, or picked
+up a card with an address, or found beneath a pillow a withered flower
+or a shred of crumpled lace.
+
+He sighed, and having poured himself out some tea, opened Lord Henry's
+note.  It was simply to say that he sent him round the evening paper,
+and a book that might interest him, and that he would be at the club at
+eight-fifteen. He opened _The St. James's_ languidly, and looked through
+it.  A red pencil-mark on the fifth page caught his eye.  It drew
+attention to the following paragraph:
+
+
+INQUEST ON AN ACTRESS.--An inquest was held this morning at the Bell
+Tavern, Hoxton Road, by Mr. Danby, the District Coroner, on the body of
+Sibyl Vane, a young actress recently engaged at the Royal Theatre,
+Holborn.  A verdict of death by misadventure was returned.
+Considerable sympathy was expressed for the mother of the deceased, who
+was greatly affected during the giving of her own evidence, and that of
+Dr. Birrell, who had made the post-mortem examination of the deceased.
+
+
+He frowned, and tearing the paper in two, went across the room and
+flung the pieces away.  How ugly it all was!  And how horribly real
+ugliness made things!  He felt a little annoyed with Lord Henry for
+having sent him the report.  And it was certainly stupid of him to have
+marked it with red pencil.  Victor might have read it.  The man knew
+more than enough English for that.
+
+Perhaps he had read it and had begun to suspect something.  And, yet,
+what did it matter?  What had Dorian Gray to do with Sibyl Vane's
+death?  There was nothing to fear.  Dorian Gray had not killed her.
+
+His eye fell on the yellow book that Lord Henry had sent him.  What was
+it, he wondered.  He went towards the little, pearl-coloured octagonal
+stand that had always looked to him like the work of some strange
+Egyptian bees that wrought in silver, and taking up the volume, flung
+himself into an arm-chair and began to turn over the leaves.  After a
+few minutes he became absorbed.  It was the strangest book that he had
+ever read.  It seemed to him that in exquisite raiment, and to the
+delicate sound of flutes, the sins of the world were passing in dumb
+show before him.  Things that he had dimly dreamed of were suddenly
+made real to him.  Things of which he had never dreamed were gradually
+revealed.
+
+It was a novel without a plot and with only one character, being,
+indeed, simply a psychological study of a certain young Parisian who
+spent his life trying to realize in the nineteenth century all the
+passions and modes of thought that belonged to every century except his
+own, and to sum up, as it were, in himself the various moods through
+which the world-spirit had ever passed, loving for their mere
+artificiality those renunciations that men have unwisely called virtue,
+as much as those natural rebellions that wise men still call sin.  The
+style in which it was written was that curious jewelled style, vivid
+and obscure at once, full of _argot_ and of archaisms, of technical
+expressions and of elaborate paraphrases, that characterizes the work
+of some of the finest artists of the French school of _Symbolistes_.
+There were in it metaphors as monstrous as orchids and as subtle in
+colour.  The life of the senses was described in the terms of mystical
+philosophy.  One hardly knew at times whether one was reading the
+spiritual ecstasies of some mediaeval saint or the morbid confessions
+of a modern sinner.  It was a poisonous book.  The heavy odour of
+incense seemed to cling about its pages and to trouble the brain.  The
+mere cadence of the sentences, the subtle monotony of their music, so
+full as it was of complex refrains and movements elaborately repeated,
+produced in the mind of the lad, as he passed from chapter to chapter,
+a form of reverie, a malady of dreaming, that made him unconscious of
+the falling day and creeping shadows.
+
+Cloudless, and pierced by one solitary star, a copper-green sky gleamed
+through the windows.  He read on by its wan light till he could read no
+more.  Then, after his valet had reminded him several times of the
+lateness of the hour, he got up, and going into the next room, placed
+the book on the little Florentine table that always stood at his
+bedside and began to dress for dinner.
+
+It was almost nine o'clock before he reached the club, where he found
+Lord Henry sitting alone, in the morning-room, looking very much bored.
+
+"I am so sorry, Harry," he cried, "but really it is entirely your
+fault.  That book you sent me so fascinated me that I forgot how the
+time was going."
+
+"Yes, I thought you would like it," replied his host, rising from his
+chair.
+
+"I didn't say I liked it, Harry.  I said it fascinated me.  There is a
+great difference."
+
+"Ah, you have discovered that?" murmured Lord Henry.  And they passed
+into the dining-room.
+
+
+
+CHAPTER 11
+
+For years, Dorian Gray could not free himself from the influence of
+this book.  Or perhaps it would be more accurate to say that he never
+sought to free himself from it.  He procured from Paris no less than
+nine large-paper copies of the first edition, and had them bound in
+different colours, so that they might suit his various moods and the
+changing fancies of a nature over which he seemed, at times, to have
+almost entirely lost control.  The hero, the wonderful young Parisian
+in whom the romantic and the scientific temperaments were so strangely
+blended, became to him a kind of prefiguring type of himself.  And,
+indeed, the whole book seemed to him to contain the story of his own
+life, written before he had lived it.
+
+In one point he was more fortunate than the novel's fantastic hero.  He
+never knew--never, indeed, had any cause to know--that somewhat
+grotesque dread of mirrors, and polished metal surfaces, and still
+water which came upon the young Parisian so early in his life, and was
+occasioned by the sudden decay of a beau that had once, apparently,
+been so remarkable.  It was with an almost cruel joy--and perhaps in
+nearly every joy, as certainly in every pleasure, cruelty has its
+place--that he used to read the latter part of the book, with its
+really tragic, if somewhat overemphasized, account of the sorrow and
+despair of one who had himself lost what in others, and the world, he
+had most dearly valued.
+
+For the wonderful beauty that had so fascinated Basil Hallward, and
+many others besides him, seemed never to leave him.  Even those who had
+heard the most evil things against him--and from time to time strange
+rumours about his mode of life crept through London and became the
+chatter of the clubs--could not believe anything to his dishonour when
+they saw him.  He had always the look of one who had kept himself
+unspotted from the world.  Men who talked grossly became silent when
+Dorian Gray entered the room.  There was something in the purity of his
+face that rebuked them.  His mere presence seemed to recall to them the
+memory of the innocence that they had tarnished.  They wondered how one
+so charming and graceful as he was could have escaped the stain of an
+age that was at once sordid and sensual.
+
+Often, on returning home from one of those mysterious and prolonged
+absences that gave rise to such strange conjecture among those who were
+his friends, or thought that they were so, he himself would creep
+upstairs to the locked room, open the door with the key that never left
+him now, and stand, with a mirror, in front of the portrait that Basil
+Hallward had painted of him, looking now at the evil and aging face on
+the canvas, and now at the fair young face that laughed back at him
+from the polished glass.  The very sharpness of the contrast used to
+quicken his sense of pleasure.  He grew more and more enamoured of his
+own beauty, more and more interested in the corruption of his own soul.
+He would examine with minute care, and sometimes with a monstrous and
+terrible delight, the hideous lines that seared the wrinkling forehead
+or crawled around the heavy sensual mouth, wondering sometimes which
+were the more horrible, the signs of sin or the signs of age.  He would
+place his white hands beside the coarse bloated hands of the picture,
+and smile.  He mocked the misshapen body and the failing limbs.
+
+There were moments, indeed, at night, when, lying sleepless in his own
+delicately scented chamber, or in the sordid room of the little
+ill-famed tavern near the docks which, under an assumed name and in
+disguise, it was his habit to frequent, he would think of the ruin he
+had brought upon his soul with a pity that was all the more poignant
+because it was purely selfish.  But moments such as these were rare.
+That curiosity about life which Lord Henry had first stirred in him, as
+they sat together in the garden of their friend, seemed to increase
+with gratification.  The more he knew, the more he desired to know.  He
+had mad hungers that grew more ravenous as he fed them.
+
+Yet he was not really reckless, at any rate in his relations to
+society.  Once or twice every month during the winter, and on each
+Wednesday evening while the season lasted, he would throw open to the
+world his beautiful house and have the most celebrated musicians of the
+day to charm his guests with the wonders of their art.  His little
+dinners, in the settling of which Lord Henry always assisted him, were
+noted as much for the careful selection and placing of those invited,
+as for the exquisite taste shown in the decoration of the table, with
+its subtle symphonic arrangements of exotic flowers, and embroidered
+cloths, and antique plate of gold and silver.  Indeed, there were many,
+especially among the very young men, who saw, or fancied that they saw,
+in Dorian Gray the true realization of a type of which they had often
+dreamed in Eton or Oxford days, a type that was to combine something of
+the real culture of the scholar with all the grace and distinction and
+perfect manner of a citizen of the world.  To them he seemed to be of
+the company of those whom Dante describes as having sought to "make
+themselves perfect by the worship of beauty."  Like Gautier, he was one
+for whom "the visible world existed."
+
+And, certainly, to him life itself was the first, the greatest, of the
+arts, and for it all the other arts seemed to be but a preparation.
+Fashion, by which what is really fantastic becomes for a moment
+universal, and dandyism, which, in its own way, is an attempt to assert
+the absolute modernity of beauty, had, of course, their fascination for
+him.  His mode of dressing, and the particular styles that from time to
+time he affected, had their marked influence on the young exquisites of
+the Mayfair balls and Pall Mall club windows, who copied him in
+everything that he did, and tried to reproduce the accidental charm of
+his graceful, though to him only half-serious, fopperies.
+
+For, while he was but too ready to accept the position that was almost
+immediately offered to him on his coming of age, and found, indeed, a
+subtle pleasure in the thought that he might really become to the
+London of his own day what to imperial Neronian Rome the author of the
+Satyricon once had been, yet in his inmost heart he desired to be
+something more than a mere _arbiter elegantiarum_, to be consulted on the
+wearing of a jewel, or the knotting of a necktie, or the conduct of a
+cane.  He sought to elaborate some new scheme of life that would have
+its reasoned philosophy and its ordered principles, and find in the
+spiritualizing of the senses its highest realization.
+
+The worship of the senses has often, and with much justice, been
+decried, men feeling a natural instinct of terror about passions and
+sensations that seem stronger than themselves, and that they are
+conscious of sharing with the less highly organized forms of existence.
+But it appeared to Dorian Gray that the true nature of the senses had
+never been understood, and that they had remained savage and animal
+merely because the world had sought to starve them into submission or
+to kill them by pain, instead of aiming at making them elements of a
+new spirituality, of which a fine instinct for beauty was to be the
+dominant characteristic.  As he looked back upon man moving through
+history, he was haunted by a feeling of loss.  So much had been
+surrendered! and to such little purpose!  There had been mad wilful
+rejections, monstrous forms of self-torture and self-denial, whose
+origin was fear and whose result was a degradation infinitely more
+terrible than that fancied degradation from which, in their ignorance,
+they had sought to escape; Nature, in her wonderful irony, driving out
+the anchorite to feed with the wild animals of the desert and giving to
+the hermit the beasts of the field as his companions.
+
+Yes:  there was to be, as Lord Henry had prophesied, a new Hedonism
+that was to recreate life and to save it from that harsh uncomely
+puritanism that is having, in our own day, its curious revival.  It was
+to have its service of the intellect, certainly, yet it was never to
+accept any theory or system that would involve the sacrifice of any
+mode of passionate experience.  Its aim, indeed, was to be experience
+itself, and not the fruits of experience, sweet or bitter as they might
+be.  Of the asceticism that deadens the senses, as of the vulgar
+profligacy that dulls them, it was to know nothing.  But it was to
+teach man to concentrate himself upon the moments of a life that is
+itself but a moment.
+
+There are few of us who have not sometimes wakened before dawn, either
+after one of those dreamless nights that make us almost enamoured of
+death, or one of those nights of horror and misshapen joy, when through
+the chambers of the brain sweep phantoms more terrible than reality
+itself, and instinct with that vivid life that lurks in all grotesques,
+and that lends to Gothic art its enduring vitality, this art being, one
+might fancy, especially the art of those whose minds have been troubled
+with the malady of reverie.  Gradually white fingers creep through the
+curtains, and they appear to tremble.  In black fantastic shapes, dumb
+shadows crawl into the corners of the room and crouch there.  Outside,
+there is the stirring of birds among the leaves, or the sound of men
+going forth to their work, or the sigh and sob of the wind coming down
+from the hills and wandering round the silent house, as though it
+feared to wake the sleepers and yet must needs call forth sleep from
+her purple cave.  Veil after veil of thin dusky gauze is lifted, and by
+degrees the forms and colours of things are restored to them, and we
+watch the dawn remaking the world in its antique pattern.  The wan
+mirrors get back their mimic life.  The flameless tapers stand where we
+had left them, and beside them lies the half-cut book that we had been
+studying, or the wired flower that we had worn at the ball, or the
+letter that we had been afraid to read, or that we had read too often.
+Nothing seems to us changed.  Out of the unreal shadows of the night
+comes back the real life that we had known.  We have to resume it where
+we had left off, and there steals over us a terrible sense of the
+necessity for the continuance of energy in the same wearisome round of
+stereotyped habits, or a wild longing, it may be, that our eyelids
+might open some morning upon a world that had been refashioned anew in
+the darkness for our pleasure, a world in which things would have fresh
+shapes and colours, and be changed, or have other secrets, a world in
+which the past would have little or no place, or survive, at any rate,
+in no conscious form of obligation or regret, the remembrance even of
+joy having its bitterness and the memories of pleasure their pain.
+
+It was the creation of such worlds as these that seemed to Dorian Gray
+to be the true object, or amongst the true objects, of life; and in his
+search for sensations that would be at once new and delightful, and
+possess that element of strangeness that is so essential to romance, he
+would often adopt certain modes of thought that he knew to be really
+alien to his nature, abandon himself to their subtle influences, and
+then, having, as it were, caught their colour and satisfied his
+intellectual curiosity, leave them with that curious indifference that
+is not incompatible with a real ardour of temperament, and that,
+indeed, according to certain modern psychologists, is often a condition
+of it.
+
+It was rumoured of him once that he was about to join the Roman
+Catholic communion, and certainly the Roman ritual had always a great
+attraction for him.  The daily sacrifice, more awful really than all
+the sacrifices of the antique world, stirred him as much by its superb
+rejection of the evidence of the senses as by the primitive simplicity
+of its elements and the eternal pathos of the human tragedy that it
+sought to symbolize.  He loved to kneel down on the cold marble
+pavement and watch the priest, in his stiff flowered dalmatic, slowly
+and with white hands moving aside the veil of the tabernacle, or
+raising aloft the jewelled, lantern-shaped monstrance with that pallid
+wafer that at times, one would fain think, is indeed the "_panis
+caelestis_," the bread of angels, or, robed in the garments of the
+Passion of Christ, breaking the Host into the chalice and smiting his
+breast for his sins.  The fuming censers that the grave boys, in their
+lace and scarlet, tossed into the air like great gilt flowers had their
+subtle fascination for him.  As he passed out, he used to look with
+wonder at the black confessionals and long to sit in the dim shadow of
+one of them and listen to men and women whispering through the worn
+grating the true story of their lives.
+
+But he never fell into the error of arresting his intellectual
+development by any formal acceptance of creed or system, or of
+mistaking, for a house in which to live, an inn that is but suitable
+for the sojourn of a night, or for a few hours of a night in which
+there are no stars and the moon is in travail.  Mysticism, with its
+marvellous power of making common things strange to us, and the subtle
+antinomianism that always seems to accompany it, moved him for a
+season; and for a season he inclined to the materialistic doctrines of
+the _Darwinismus_ movement in Germany, and found a curious pleasure in
+tracing the thoughts and passions of men to some pearly cell in the
+brain, or some white nerve in the body, delighting in the conception of
+the absolute dependence of the spirit on certain physical conditions,
+morbid or healthy, normal or diseased.  Yet, as has been said of him
+before, no theory of life seemed to him to be of any importance
+compared with life itself.  He felt keenly conscious of how barren all
+intellectual speculation is when separated from action and experiment.
+He knew that the senses, no less than the soul, have their spiritual
+mysteries to reveal.
+
+And so he would now study perfumes and the secrets of their
+manufacture, distilling heavily scented oils and burning odorous gums
+from the East.  He saw that there was no mood of the mind that had not
+its counterpart in the sensuous life, and set himself to discover their
+true relations, wondering what there was in frankincense that made one
+mystical, and in ambergris that stirred one's passions, and in violets
+that woke the memory of dead romances, and in musk that troubled the
+brain, and in champak that stained the imagination; and seeking often
+to elaborate a real psychology of perfumes, and to estimate the several
+influences of sweet-smelling roots and scented, pollen-laden flowers;
+of aromatic balms and of dark and fragrant woods; of spikenard, that
+sickens; of hovenia, that makes men mad; and of aloes, that are said to
+be able to expel melancholy from the soul.
+
+At another time he devoted himself entirely to music, and in a long
+latticed room, with a vermilion-and-gold ceiling and walls of
+olive-green lacquer, he used to give curious concerts in which mad
+gipsies tore wild music from little zithers, or grave, yellow-shawled
+Tunisians plucked at the strained strings of monstrous lutes, while
+grinning Negroes beat monotonously upon copper drums and, crouching
+upon scarlet mats, slim turbaned Indians blew through long pipes of
+reed or brass and charmed--or feigned to charm--great hooded snakes and
+horrible horned adders.  The harsh intervals and shrill discords of
+barbaric music stirred him at times when Schubert's grace, and Chopin's
+beautiful sorrows, and the mighty harmonies of Beethoven himself, fell
+unheeded on his ear.  He collected together from all parts of the world
+the strangest instruments that could be found, either in the tombs of
+dead nations or among the few savage tribes that have survived contact
+with Western civilizations, and loved to touch and try them.  He had
+the mysterious _juruparis_ of the Rio Negro Indians, that women are not
+allowed to look at and that even youths may not see till they have been
+subjected to fasting and scourging, and the earthen jars of the
+Peruvians that have the shrill cries of birds, and flutes of human
+bones such as Alfonso de Ovalle heard in Chile, and the sonorous green
+jaspers that are found near Cuzco and give forth a note of singular
+sweetness.  He had painted gourds filled with pebbles that rattled when
+they were shaken; the long _clarin_ of the Mexicans, into which the
+performer does not blow, but through which he inhales the air; the
+harsh _ture_ of the Amazon tribes, that is sounded by the sentinels who
+sit all day long in high trees, and can be heard, it is said, at a
+distance of three leagues; the _teponaztli_, that has two vibrating
+tongues of wood and is beaten with sticks that are smeared with an
+elastic gum obtained from the milky juice of plants; the _yotl_-bells of
+the Aztecs, that are hung in clusters like grapes; and a huge
+cylindrical drum, covered with the skins of great serpents, like the
+one that Bernal Diaz saw when he went with Cortes into the Mexican
+temple, and of whose doleful sound he has left us so vivid a
+description.  The fantastic character of these instruments fascinated
+him, and he felt a curious delight in the thought that art, like
+Nature, has her monsters, things of bestial shape and with hideous
+voices.  Yet, after some time, he wearied of them, and would sit in his
+box at the opera, either alone or with Lord Henry, listening in rapt
+pleasure to "Tannhauser" and seeing in the prelude to that great work
+of art a presentation of the tragedy of his own soul.
+
+On one occasion he took up the study of jewels, and appeared at a
+costume ball as Anne de Joyeuse, Admiral of France, in a dress covered
+with five hundred and sixty pearls.  This taste enthralled him for
+years, and, indeed, may be said never to have left him.  He would often
+spend a whole day settling and resettling in their cases the various
+stones that he had collected, such as the olive-green chrysoberyl that
+turns red by lamplight, the cymophane with its wirelike line of silver,
+the pistachio-coloured peridot, rose-pink and wine-yellow topazes,
+carbuncles of fiery scarlet with tremulous, four-rayed stars, flame-red
+cinnamon-stones, orange and violet spinels, and amethysts with their
+alternate layers of ruby and sapphire.  He loved the red gold of the
+sunstone, and the moonstone's pearly whiteness, and the broken rainbow
+of the milky opal.  He procured from Amsterdam three emeralds of
+extraordinary size and richness of colour, and had a turquoise _de la
+vieille roche_ that was the envy of all the connoisseurs.
+
+He discovered wonderful stories, also, about jewels.  In Alphonso's
+Clericalis Disciplina a serpent was mentioned with eyes of real
+jacinth, and in the romantic history of Alexander, the Conqueror of
+Emathia was said to have found in the vale of Jordan snakes "with
+collars of real emeralds growing on their backs." There was a gem in
+the brain of the dragon, Philostratus told us, and "by the exhibition
+of golden letters and a scarlet robe" the monster could be thrown into
+a magical sleep and slain.  According to the great alchemist, Pierre de
+Boniface, the diamond rendered a man invisible, and the agate of India
+made him eloquent.  The cornelian appeased anger, and the hyacinth
+provoked sleep, and the amethyst drove away the fumes of wine.  The
+garnet cast out demons, and the hydropicus deprived the moon of her
+colour.  The selenite waxed and waned with the moon, and the meloceus,
+that discovers thieves, could be affected only by the blood of kids.
+Leonardus Camillus had seen a white stone taken from the brain of a
+newly killed toad, that was a certain antidote against poison.  The
+bezoar, that was found in the heart of the Arabian deer, was a charm
+that could cure the plague.  In the nests of Arabian birds was the
+aspilates, that, according to Democritus, kept the wearer from any
+danger by fire.
+
+The King of Ceilan rode through his city with a large ruby in his hand,
+as the ceremony of his coronation.  The gates of the palace of John the
+Priest were "made of sardius, with the horn of the horned snake
+inwrought, so that no man might bring poison within." Over the gable
+were "two golden apples, in which were two carbuncles," so that the
+gold might shine by day and the carbuncles by night.  In Lodge's
+strange romance 'A Margarite of America', it was stated that in the
+chamber of the queen one could behold "all the chaste ladies of the
+world, inchased out of silver, looking through fair mirrours of
+chrysolites, carbuncles, sapphires, and greene emeraults." Marco Polo
+had seen the inhabitants of Zipangu place rose-coloured pearls in the
+mouths of the dead.  A sea-monster had been enamoured of the pearl that
+the diver brought to King Perozes, and had slain the thief, and mourned
+for seven moons over its loss.  When the Huns lured the king into the
+great pit, he flung it away--Procopius tells the story--nor was it ever
+found again, though the Emperor Anastasius offered five hundred-weight
+of gold pieces for it.  The King of Malabar had shown to a certain
+Venetian a rosary of three hundred and four pearls, one for every god
+that he worshipped.
+
+When the Duke de Valentinois, son of Alexander VI, visited Louis XII of
+France, his horse was loaded with gold leaves, according to Brantome,
+and his cap had double rows of rubies that threw out a great light.
+Charles of England had ridden in stirrups hung with four hundred and
+twenty-one diamonds.  Richard II had a coat, valued at thirty thousand
+marks, which was covered with balas rubies.  Hall described Henry VIII,
+on his way to the Tower previous to his coronation, as wearing "a
+jacket of raised gold, the placard embroidered with diamonds and other
+rich stones, and a great bauderike about his neck of large balasses."
+The favourites of James I wore ear-rings of emeralds set in gold
+filigrane.  Edward II gave to Piers Gaveston a suit of red-gold armour
+studded with jacinths, a collar of gold roses set with
+turquoise-stones, and a skull-cap _parseme_ with pearls.  Henry II wore
+jewelled gloves reaching to the elbow, and had a hawk-glove sewn with
+twelve rubies and fifty-two great orients.  The ducal hat of Charles
+the Rash, the last Duke of Burgundy of his race, was hung with
+pear-shaped pearls and studded with sapphires.
+
+How exquisite life had once been!  How gorgeous in its pomp and
+decoration!  Even to read of the luxury of the dead was wonderful.
+
+Then he turned his attention to embroideries and to the tapestries that
+performed the office of frescoes in the chill rooms of the northern
+nations of Europe.  As he investigated the subject--and he always had
+an extraordinary faculty of becoming absolutely absorbed for the moment
+in whatever he took up--he was almost saddened by the reflection of the
+ruin that time brought on beautiful and wonderful things.  He, at any
+rate, had escaped that.  Summer followed summer, and the yellow
+jonquils bloomed and died many times, and nights of horror repeated the
+story of their shame, but he was unchanged.  No winter marred his face
+or stained his flowerlike bloom.  How different it was with material
+things!  Where had they passed to?  Where was the great crocus-coloured
+robe, on which the gods fought against the giants, that had been worked
+by brown girls for the pleasure of Athena?  Where the huge velarium
+that Nero had stretched across the Colosseum at Rome, that Titan sail
+of purple on which was represented the starry sky, and Apollo driving a
+chariot drawn by white, gilt-reined steeds?  He longed to see the
+curious table-napkins wrought for the Priest of the Sun, on which were
+displayed all the dainties and viands that could be wanted for a feast;
+the mortuary cloth of King Chilperic, with its three hundred golden
+bees; the fantastic robes that excited the indignation of the Bishop of
+Pontus and were figured with "lions, panthers, bears, dogs, forests,
+rocks, hunters--all, in fact, that a painter can copy from nature"; and
+the coat that Charles of Orleans once wore, on the sleeves of which
+were embroidered the verses of a song beginning "_Madame, je suis tout
+joyeux_," the musical accompaniment of the words being wrought in gold
+thread, and each note, of square shape in those days, formed with four
+pearls.  He read of the room that was prepared at the palace at Rheims
+for the use of Queen Joan of Burgundy and was decorated with "thirteen
+hundred and twenty-one parrots, made in broidery, and blazoned with the
+king's arms, and five hundred and sixty-one butterflies, whose wings
+were similarly ornamented with the arms of the queen, the whole worked
+in gold."  Catherine de Medicis had a mourning-bed made for her of
+black velvet powdered with crescents and suns.  Its curtains were of
+damask, with leafy wreaths and garlands, figured upon a gold and silver
+ground, and fringed along the edges with broideries of pearls, and it
+stood in a room hung with rows of the queen's devices in cut black
+velvet upon cloth of silver.  Louis XIV had gold embroidered caryatides
+fifteen feet high in his apartment.  The state bed of Sobieski, King of
+Poland, was made of Smyrna gold brocade embroidered in turquoises with
+verses from the Koran.  Its supports were of silver gilt, beautifully
+chased, and profusely set with enamelled and jewelled medallions.  It
+had been taken from the Turkish camp before Vienna, and the standard of
+Mohammed had stood beneath the tremulous gilt of its canopy.
+
+And so, for a whole year, he sought to accumulate the most exquisite
+specimens that he could find of textile and embroidered work, getting
+the dainty Delhi muslins, finely wrought with gold-thread palmates and
+stitched over with iridescent beetles' wings; the Dacca gauzes, that
+from their transparency are known in the East as "woven air," and
+"running water," and "evening dew"; strange figured cloths from Java;
+elaborate yellow Chinese hangings; books bound in tawny satins or fair
+blue silks and wrought with _fleurs-de-lis_, birds and images; veils of
+_lacis_ worked in Hungary point; Sicilian brocades and stiff Spanish
+velvets; Georgian work, with its gilt coins, and Japanese _Foukousas_,
+with their green-toned golds and their marvellously plumaged birds.
+
+He had a special passion, also, for ecclesiastical vestments, as indeed
+he had for everything connected with the service of the Church.  In the
+long cedar chests that lined the west gallery of his house, he had
+stored away many rare and beautiful specimens of what is really the
+raiment of the Bride of Christ, who must wear purple and jewels and
+fine linen that she may hide the pallid macerated body that is worn by
+the suffering that she seeks for and wounded by self-inflicted pain.
+He possessed a gorgeous cope of crimson silk and gold-thread damask,
+figured with a repeating pattern of golden pomegranates set in
+six-petalled formal blossoms, beyond which on either side was the
+pine-apple device wrought in seed-pearls. The orphreys were divided
+into panels representing scenes from the life of the Virgin, and the
+coronation of the Virgin was figured in coloured silks upon the hood.
+This was Italian work of the fifteenth century.  Another cope was of
+green velvet, embroidered with heart-shaped groups of acanthus-leaves,
+from which spread long-stemmed white blossoms, the details of which
+were picked out with silver thread and coloured crystals.  The morse
+bore a seraph's head in gold-thread raised work.  The orphreys were
+woven in a diaper of red and gold silk, and were starred with
+medallions of many saints and martyrs, among whom was St. Sebastian.
+He had chasubles, also, of amber-coloured silk, and blue silk and gold
+brocade, and yellow silk damask and cloth of gold, figured with
+representations of the Passion and Crucifixion of Christ, and
+embroidered with lions and peacocks and other emblems; dalmatics of
+white satin and pink silk damask, decorated with tulips and dolphins
+and _fleurs-de-lis_; altar frontals of crimson velvet and blue linen; and
+many corporals, chalice-veils, and sudaria.  In the mystic offices to
+which such things were put, there was something that quickened his
+imagination.
+
+For these treasures, and everything that he collected in his lovely
+house, were to be to him means of forgetfulness, modes by which he
+could escape, for a season, from the fear that seemed to him at times
+to be almost too great to be borne.  Upon the walls of the lonely
+locked room where he had spent so much of his boyhood, he had hung with
+his own hands the terrible portrait whose changing features showed him
+the real degradation of his life, and in front of it had draped the
+purple-and-gold pall as a curtain.  For weeks he would not go there,
+would forget the hideous painted thing, and get back his light heart,
+his wonderful joyousness, his passionate absorption in mere existence.
+Then, suddenly, some night he would creep out of the house, go down to
+dreadful places near Blue Gate Fields, and stay there, day after day,
+until he was driven away.  On his return he would sit in front of the
+picture, sometimes loathing it and himself, but filled, at other
+times, with that pride of individualism that is half the
+fascination of sin, and smiling with secret pleasure at the misshapen
+shadow that had to bear the burden that should have been his own.
+
+After a few years he could not endure to be long out of England, and
+gave up the villa that he had shared at Trouville with Lord Henry, as
+well as the little white walled-in house at Algiers where they had more
+than once spent the winter.  He hated to be separated from the picture
+that was such a part of his life, and was also afraid that during his
+absence some one might gain access to the room, in spite of the
+elaborate bars that he had caused to be placed upon the door.
+
+He was quite conscious that this would tell them nothing.  It was true
+that the portrait still preserved, under all the foulness and ugliness
+of the face, its marked likeness to himself; but what could they learn
+from that?  He would laugh at any one who tried to taunt him.  He had
+not painted it.  What was it to him how vile and full of shame it
+looked?  Even if he told them, would they believe it?
+
+Yet he was afraid.  Sometimes when he was down at his great house in
+Nottinghamshire, entertaining the fashionable young men of his own rank
+who were his chief companions, and astounding the county by the wanton
+luxury and gorgeous splendour of his mode of life, he would suddenly
+leave his guests and rush back to town to see that the door had not
+been tampered with and that the picture was still there.  What if it
+should be stolen?  The mere thought made him cold with horror.  Surely
+the world would know his secret then.  Perhaps the world already
+suspected it.
+
+For, while he fascinated many, there were not a few who distrusted him.
+He was very nearly blackballed at a West End club of which his birth
+and social position fully entitled him to become a member, and it was
+said that on one occasion, when he was brought by a friend into the
+smoking-room of the Churchill, the Duke of Berwick and another
+gentleman got up in a marked manner and went out.  Curious stories
+became current about him after he had passed his twenty-fifth year.  It
+was rumoured that he had been seen brawling with foreign sailors in a
+low den in the distant parts of Whitechapel, and that he consorted with
+thieves and coiners and knew the mysteries of their trade.  His
+extraordinary absences became notorious, and, when he used to reappear
+again in society, men would whisper to each other in corners, or pass
+him with a sneer, or look at him with cold searching eyes, as though
+they were determined to discover his secret.
+
+Of such insolences and attempted slights he, of course, took no notice,
+and in the opinion of most people his frank debonair manner, his
+charming boyish smile, and the infinite grace of that wonderful youth
+that seemed never to leave him, were in themselves a sufficient answer
+to the calumnies, for so they termed them, that were circulated about
+him.  It was remarked, however, that some of those who had been most
+intimate with him appeared, after a time, to shun him.  Women who had
+wildly adored him, and for his sake had braved all social censure and
+set convention at defiance, were seen to grow pallid with shame or
+horror if Dorian Gray entered the room.
+
+Yet these whispered scandals only increased in the eyes of many his
+strange and dangerous charm.  His great wealth was a certain element of
+security.  Society--civilized society, at least--is never very ready to
+believe anything to the detriment of those who are both rich and
+fascinating.  It feels instinctively that manners are of more
+importance than morals, and, in its opinion, the highest respectability
+is of much less value than the possession of a good _chef_.  And, after
+all, it is a very poor consolation to be told that the man who has
+given one a bad dinner, or poor wine, is irreproachable in his private
+life.  Even the cardinal virtues cannot atone for half-cold _entrees_, as
+Lord Henry remarked once, in a discussion on the subject, and there is
+possibly a good deal to be said for his view.  For the canons of good
+society are, or should be, the same as the canons of art.  Form is
+absolutely essential to it.  It should have the dignity of a ceremony,
+as well as its unreality, and should combine the insincere character of
+a romantic play with the wit and beauty that make such plays delightful
+to us.  Is insincerity such a terrible thing?  I think not.  It is
+merely a method by which we can multiply our personalities.
+
+Such, at any rate, was Dorian Gray's opinion.  He used to wonder at the
+shallow psychology of those who conceive the ego in man as a thing
+simple, permanent, reliable, and of one essence.  To him, man was a
+being with myriad lives and myriad sensations, a complex multiform
+creature that bore within itself strange legacies of thought and
+passion, and whose very flesh was tainted with the monstrous maladies
+of the dead.  He loved to stroll through the gaunt cold picture-gallery
+of his country house and look at the various portraits of those whose
+blood flowed in his veins.  Here was Philip Herbert, described by
+Francis Osborne, in his Memoires on the Reigns of Queen Elizabeth and
+King James, as one who was "caressed by the Court for his handsome
+face, which kept him not long company."  Was it young Herbert's life
+that he sometimes led?  Had some strange poisonous germ crept from body
+to body till it had reached his own?  Was it some dim sense of that
+ruined grace that had made him so suddenly, and almost without cause,
+give utterance, in Basil Hallward's studio, to the mad prayer that had
+so changed his life?  Here, in gold-embroidered red doublet, jewelled
+surcoat, and gilt-edged ruff and wristbands, stood Sir Anthony Sherard,
+with his silver-and-black armour piled at his feet.  What had this
+man's legacy been?  Had the lover of Giovanna of Naples bequeathed him
+some inheritance of sin and shame?  Were his own actions merely the
+dreams that the dead man had not dared to realize?  Here, from the
+fading canvas, smiled Lady Elizabeth Devereux, in her gauze hood, pearl
+stomacher, and pink slashed sleeves.  A flower was in her right hand,
+and her left clasped an enamelled collar of white and damask roses.  On
+a table by her side lay a mandolin and an apple.  There were large
+green rosettes upon her little pointed shoes.  He knew her life, and
+the strange stories that were told about her lovers.  Had he something
+of her temperament in him?  These oval, heavy-lidded eyes seemed to
+look curiously at him.  What of George Willoughby, with his powdered
+hair and fantastic patches?  How evil he looked!  The face was
+saturnine and swarthy, and the sensual lips seemed to be twisted with
+disdain.  Delicate lace ruffles fell over the lean yellow hands that
+were so overladen with rings.  He had been a macaroni of the eighteenth
+century, and the friend, in his youth, of Lord Ferrars.  What of the
+second Lord Beckenham, the companion of the Prince Regent in his
+wildest days, and one of the witnesses at the secret marriage with Mrs.
+Fitzherbert?  How proud and handsome he was, with his chestnut curls
+and insolent pose!  What passions had he bequeathed?  The world had
+looked upon him as infamous.  He had led the orgies at Carlton House.
+The star of the Garter glittered upon his breast.  Beside him hung the
+portrait of his wife, a pallid, thin-lipped woman in black.  Her blood,
+also, stirred within him.  How curious it all seemed!  And his mother
+with her Lady Hamilton face and her moist, wine-dashed lips--he knew
+what he had got from her.  He had got from her his beauty, and his
+passion for the beauty of others.  She laughed at him in her loose
+Bacchante dress.  There were vine leaves in her hair.  The purple
+spilled from the cup she was holding.  The carnations of the painting
+had withered, but the eyes were still wonderful in their depth and
+brilliancy of colour.  They seemed to follow him wherever he went.
+
+Yet one had ancestors in literature as well as in one's own race,
+nearer perhaps in type and temperament, many of them, and certainly
+with an influence of which one was more absolutely conscious.  There
+were times when it appeared to Dorian Gray that the whole of history
+was merely the record of his own life, not as he had lived it in act
+and circumstance, but as his imagination had created it for him, as it
+had been in his brain and in his passions.  He felt that he had known
+them all, those strange terrible figures that had passed across the
+stage of the world and made sin so marvellous and evil so full of
+subtlety.  It seemed to him that in some mysterious way their lives had
+been his own.
+
+The hero of the wonderful novel that had so influenced his life had
+himself known this curious fancy.  In the seventh chapter he tells how,
+crowned with laurel, lest lightning might strike him, he had sat, as
+Tiberius, in a garden at Capri, reading the shameful books of
+Elephantis, while dwarfs and peacocks strutted round him and the
+flute-player mocked the swinger of the censer; and, as Caligula, had
+caroused with the green-shirted jockeys in their stables and supped in
+an ivory manger with a jewel-frontleted horse; and, as Domitian, had
+wandered through a corridor lined with marble mirrors, looking round
+with haggard eyes for the reflection of the dagger that was to end his
+days, and sick with that ennui, that terrible _taedium vitae_, that comes
+on those to whom life denies nothing; and had peered through a clear
+emerald at the red shambles of the circus and then, in a litter of
+pearl and purple drawn by silver-shod mules, been carried through the
+Street of Pomegranates to a House of Gold and heard men cry on Nero
+Caesar as he passed by; and, as Elagabalus, had painted his face with
+colours, and plied the distaff among the women, and brought the Moon
+from Carthage and given her in mystic marriage to the Sun.
+
+Over and over again Dorian used to read this fantastic chapter, and the
+two chapters immediately following, in which, as in some curious
+tapestries or cunningly wrought enamels, were pictured the awful and
+beautiful forms of those whom vice and blood and weariness had made
+monstrous or mad:  Filippo, Duke of Milan, who slew his wife and
+painted her lips with a scarlet poison that her lover might suck death
+from the dead thing he fondled; Pietro Barbi, the Venetian, known as
+Paul the Second, who sought in his vanity to assume the title of
+Formosus, and whose tiara, valued at two hundred thousand florins, was
+bought at the price of a terrible sin; Gian Maria Visconti, who used
+hounds to chase living men and whose murdered body was covered with
+roses by a harlot who had loved him; the Borgia on his white horse,
+with Fratricide riding beside him and his mantle stained with the blood
+of Perotto; Pietro Riario, the young Cardinal Archbishop of Florence,
+child and minion of Sixtus IV, whose beauty was equalled only by his
+debauchery, and who received Leonora of Aragon in a pavilion of white
+and crimson silk, filled with nymphs and centaurs, and gilded a boy
+that he might serve at the feast as Ganymede or Hylas; Ezzelin, whose
+melancholy could be cured only by the spectacle of death, and who had a
+passion for red blood, as other men have for red wine--the son of the
+Fiend, as was reported, and one who had cheated his father at dice when
+gambling with him for his own soul; Giambattista Cibo, who in mockery
+took the name of Innocent and into whose torpid veins the blood of
+three lads was infused by a Jewish doctor; Sigismondo Malatesta, the
+lover of Isotta and the lord of Rimini, whose effigy was burned at Rome
+as the enemy of God and man, who strangled Polyssena with a napkin, and
+gave poison to Ginevra d'Este in a cup of emerald, and in honour of a
+shameful passion built a pagan church for Christian worship; Charles
+VI, who had so wildly adored his brother's wife that a leper had warned
+him of the insanity that was coming on him, and who, when his brain had
+sickened and grown strange, could only be soothed by Saracen cards
+painted with the images of love and death and madness; and, in his
+trimmed jerkin and jewelled cap and acanthuslike curls, Grifonetto
+Baglioni, who slew Astorre with his bride, and Simonetto with his page,
+and whose comeliness was such that, as he lay dying in the yellow
+piazza of Perugia, those who had hated him could not choose but weep,
+and Atalanta, who had cursed him, blessed him.
+
+There was a horrible fascination in them all.  He saw them at night,
+and they troubled his imagination in the day.  The Renaissance knew of
+strange manners of poisoning--poisoning by a helmet and a lighted
+torch, by an embroidered glove and a jewelled fan, by a gilded pomander
+and by an amber chain.  Dorian Gray had been poisoned by a book.  There
+were moments when he looked on evil simply as a mode through which he
+could realize his conception of the beautiful.
+
+
+
+CHAPTER 12
+
+It was on the ninth of November, the eve of his own thirty-eighth
+birthday, as he often remembered afterwards.
+
+He was walking home about eleven o'clock from Lord Henry's, where he
+had been dining, and was wrapped in heavy furs, as the night was cold
+and foggy.  At the corner of Grosvenor Square and South Audley Street,
+a man passed him in the mist, walking very fast and with the collar of
+his grey ulster turned up.  He had a bag in his hand.  Dorian
+recognized him.  It was Basil Hallward.  A strange sense of fear, for
+which he could not account, came over him.  He made no sign of
+recognition and went on quickly in the direction of his own house.
+
+But Hallward had seen him.  Dorian heard him first stopping on the
+pavement and then hurrying after him.  In a few moments, his hand was
+on his arm.
+
+"Dorian!  What an extraordinary piece of luck!  I have been waiting for
+you in your library ever since nine o'clock. Finally I took pity on
+your tired servant and told him to go to bed, as he let me out.  I am
+off to Paris by the midnight train, and I particularly wanted to see
+you before I left.  I thought it was you, or rather your fur coat, as
+you passed me.  But I wasn't quite sure.  Didn't you recognize me?"
+
+"In this fog, my dear Basil?  Why, I can't even recognize Grosvenor
+Square.  I believe my house is somewhere about here, but I don't feel
+at all certain about it.  I am sorry you are going away, as I have not
+seen you for ages.  But I suppose you will be back soon?"
+
+"No:  I am going to be out of England for six months.  I intend to take
+a studio in Paris and shut myself up till I have finished a great
+picture I have in my head.  However, it wasn't about myself I wanted to
+talk.  Here we are at your door.  Let me come in for a moment.  I have
+something to say to you."
+
+"I shall be charmed.  But won't you miss your train?" said Dorian Gray
+languidly as he passed up the steps and opened the door with his
+latch-key.
+
+The lamplight struggled out through the fog, and Hallward looked at his
+watch.  "I have heaps of time," he answered.  "The train doesn't go
+till twelve-fifteen, and it is only just eleven.  In fact, I was on my
+way to the club to look for you, when I met you.  You see, I shan't
+have any delay about luggage, as I have sent on my heavy things.  All I
+have with me is in this bag, and I can easily get to Victoria in twenty
+minutes."
+
+Dorian looked at him and smiled.  "What a way for a fashionable painter
+to travel!  A Gladstone bag and an ulster!  Come in, or the fog will
+get into the house.  And mind you don't talk about anything serious.
+Nothing is serious nowadays.  At least nothing should be."
+
+Hallward shook his head, as he entered, and followed Dorian into the
+library.  There was a bright wood fire blazing in the large open
+hearth.  The lamps were lit, and an open Dutch silver spirit-case
+stood, with some siphons of soda-water and large cut-glass tumblers, on
+a little marqueterie table.
+
+"You see your servant made me quite at home, Dorian.  He gave me
+everything I wanted, including your best gold-tipped cigarettes.  He is
+a most hospitable creature.  I like him much better than the Frenchman
+you used to have.  What has become of the Frenchman, by the bye?"
+
+Dorian shrugged his shoulders.  "I believe he married Lady Radley's
+maid, and has established her in Paris as an English dressmaker.
+Anglomania is very fashionable over there now, I hear.  It seems silly
+of the French, doesn't it?  But--do you know?--he was not at all a bad
+servant.  I never liked him, but I had nothing to complain about.  One
+often imagines things that are quite absurd.  He was really very
+devoted to me and seemed quite sorry when he went away.  Have another
+brandy-and-soda? Or would you like hock-and-seltzer? I always take
+hock-and-seltzer myself.  There is sure to be some in the next room."
+
+"Thanks, I won't have anything more," said the painter, taking his cap
+and coat off and throwing them on the bag that he had placed in the
+corner.  "And now, my dear fellow, I want to speak to you seriously.
+Don't frown like that.  You make it so much more difficult for me."
+
+"What is it all about?" cried Dorian in his petulant way, flinging
+himself down on the sofa.  "I hope it is not about myself.  I am tired
+of myself to-night. I should like to be somebody else."
+
+"It is about yourself," answered Hallward in his grave deep voice, "and
+I must say it to you.  I shall only keep you half an hour."
+
+Dorian sighed and lit a cigarette.  "Half an hour!" he murmured.
+
+"It is not much to ask of you, Dorian, and it is entirely for your own
+sake that I am speaking.  I think it right that you should know that
+the most dreadful things are being said against you in London."
+
+"I don't wish to know anything about them.  I love scandals about other
+people, but scandals about myself don't interest me.  They have not got
+the charm of novelty."
+
+"They must interest you, Dorian.  Every gentleman is interested in his
+good name.  You don't want people to talk of you as something vile and
+degraded.  Of course, you have your position, and your wealth, and all
+that kind of thing.  But position and wealth are not everything.  Mind
+you, I don't believe these rumours at all.  At least, I can't believe
+them when I see you.  Sin is a thing that writes itself across a man's
+face.  It cannot be concealed.  People talk sometimes of secret vices.
+There are no such things.  If a wretched man has a vice, it shows
+itself in the lines of his mouth, the droop of his eyelids, the
+moulding of his hands even.  Somebody--I won't mention his name, but
+you know him--came to me last year to have his portrait done.  I had
+never seen him before, and had never heard anything about him at the
+time, though I have heard a good deal since.  He offered an extravagant
+price.  I refused him.  There was something in the shape of his fingers
+that I hated.  I know now that I was quite right in what I fancied
+about him.  His life is dreadful.  But you, Dorian, with your pure,
+bright, innocent face, and your marvellous untroubled youth--I can't
+believe anything against you.  And yet I see you very seldom, and you
+never come down to the studio now, and when I am away from you, and I
+hear all these hideous things that people are whispering about you, I
+don't know what to say.  Why is it, Dorian, that a man like the Duke of
+Berwick leaves the room of a club when you enter it?  Why is it that so
+many gentlemen in London will neither go to your house or invite you to
+theirs?  You used to be a friend of Lord Staveley.  I met him at dinner
+last week.  Your name happened to come up in conversation, in
+connection with the miniatures you have lent to the exhibition at the
+Dudley.  Staveley curled his lip and said that you might have the most
+artistic tastes, but that you were a man whom no pure-minded girl
+should be allowed to know, and whom no chaste woman should sit in the
+same room with.  I reminded him that I was a friend of yours, and asked
+him what he meant.  He told me.  He told me right out before everybody.
+It was horrible!  Why is your friendship so fatal to young men?  There
+was that wretched boy in the Guards who committed suicide.  You were
+his great friend.  There was Sir Henry Ashton, who had to leave England
+with a tarnished name.  You and he were inseparable.  What about Adrian
+Singleton and his dreadful end?  What about Lord Kent's only son and
+his career?  I met his father yesterday in St. James's Street.  He
+seemed broken with shame and sorrow.  What about the young Duke of
+Perth?  What sort of life has he got now?  What gentleman would
+associate with him?"
+
+"Stop, Basil.  You are talking about things of which you know nothing,"
+said Dorian Gray, biting his lip, and with a note of infinite contempt
+in his voice.  "You ask me why Berwick leaves a room when I enter it.
+It is because I know everything about his life, not because he knows
+anything about mine.  With such blood as he has in his veins, how could
+his record be clean?  You ask me about Henry Ashton and young Perth.
+Did I teach the one his vices, and the other his debauchery?  If Kent's
+silly son takes his wife from the streets, what is that to me?  If
+Adrian Singleton writes his friend's name across a bill, am I his
+keeper?  I know how people chatter in England.  The middle classes air
+their moral prejudices over their gross dinner-tables, and whisper
+about what they call the profligacies of their betters in order to try
+and pretend that they are in smart society and on intimate terms with
+the people they slander.  In this country, it is enough for a man to
+have distinction and brains for every common tongue to wag against him.
+And what sort of lives do these people, who pose as being moral, lead
+themselves?  My dear fellow, you forget that we are in the native land
+of the hypocrite."
+
+"Dorian," cried Hallward, "that is not the question.  England is bad
+enough I know, and English society is all wrong.  That is the reason
+why I want you to be fine.  You have not been fine.  One has a right to
+judge of a man by the effect he has over his friends.  Yours seem to
+lose all sense of honour, of goodness, of purity.  You have filled them
+with a madness for pleasure.  They have gone down into the depths.  You
+led them there.  Yes:  you led them there, and yet you can smile, as
+you are smiling now.  And there is worse behind.  I know you and Harry
+are inseparable.  Surely for that reason, if for none other, you should
+not have made his sister's name a by-word."
+
+"Take care, Basil.  You go too far."
+
+"I must speak, and you must listen.  You shall listen.  When you met
+Lady Gwendolen, not a breath of scandal had ever touched her.  Is there
+a single decent woman in London now who would drive with her in the
+park?  Why, even her children are not allowed to live with her.  Then
+there are other stories--stories that you have been seen creeping at
+dawn out of dreadful houses and slinking in disguise into the foulest
+dens in London.  Are they true?  Can they be true?  When I first heard
+them, I laughed.  I hear them now, and they make me shudder.  What
+about your country-house and the life that is led there?  Dorian, you
+don't know what is said about you.  I won't tell you that I don't want
+to preach to you.  I remember Harry saying once that every man who
+turned himself into an amateur curate for the moment always began by
+saying that, and then proceeded to break his word.  I do want to preach
+to you.  I want you to lead such a life as will make the world respect
+you.  I want you to have a clean name and a fair record.  I want you to
+get rid of the dreadful people you associate with.  Don't shrug your
+shoulders like that.  Don't be so indifferent.  You have a wonderful
+influence.  Let it be for good, not for evil.  They say that you
+corrupt every one with whom you become intimate, and that it is quite
+sufficient for you to enter a house for shame of some kind to follow
+after.  I don't know whether it is so or not.  How should I know?  But
+it is said of you.  I am told things that it seems impossible to doubt.
+Lord Gloucester was one of my greatest friends at Oxford.  He showed me
+a letter that his wife had written to him when she was dying alone in
+her villa at Mentone.  Your name was implicated in the most terrible
+confession I ever read.  I told him that it was absurd--that I knew you
+thoroughly and that you were incapable of anything of the kind.  Know
+you?  I wonder do I know you?  Before I could answer that, I should
+have to see your soul."
+
+"To see my soul!" muttered Dorian Gray, starting up from the sofa and
+turning almost white from fear.
+
+"Yes," answered Hallward gravely, and with deep-toned sorrow in his
+voice, "to see your soul.  But only God can do that."
+
+A bitter laugh of mockery broke from the lips of the younger man.  "You
+shall see it yourself, to-night!" he cried, seizing a lamp from the
+table.  "Come:  it is your own handiwork.  Why shouldn't you look at
+it?  You can tell the world all about it afterwards, if you choose.
+Nobody would believe you.  If they did believe you, they would like me
+all the better for it.  I know the age better than you do, though you
+will prate about it so tediously.  Come, I tell you.  You have
+chattered enough about corruption.  Now you shall look on it face to
+face."
+
+There was the madness of pride in every word he uttered.  He stamped
+his foot upon the ground in his boyish insolent manner.  He felt a
+terrible joy at the thought that some one else was to share his secret,
+and that the man who had painted the portrait that was the origin of
+all his shame was to be burdened for the rest of his life with the
+hideous memory of what he had done.
+
+"Yes," he continued, coming closer to him and looking steadfastly into
+his stern eyes, "I shall show you my soul.  You shall see the thing
+that you fancy only God can see."
+
+Hallward started back.  "This is blasphemy, Dorian!" he cried.  "You
+must not say things like that.  They are horrible, and they don't mean
+anything."
+
+"You think so?"  He laughed again.
+
+"I know so.  As for what I said to you to-night, I said it for your
+good.  You know I have been always a stanch friend to you."
+
+"Don't touch me.  Finish what you have to say."
+
+A twisted flash of pain shot across the painter's face.  He paused for
+a moment, and a wild feeling of pity came over him.  After all, what
+right had he to pry into the life of Dorian Gray?  If he had done a
+tithe of what was rumoured about him, how much he must have suffered!
+Then he straightened himself up, and walked over to the fire-place, and
+stood there, looking at the burning logs with their frostlike ashes and
+their throbbing cores of flame.
+
+"I am waiting, Basil," said the young man in a hard clear voice.
+
+He turned round.  "What I have to say is this," he cried.  "You must
+give me some answer to these horrible charges that are made against
+you.  If you tell me that they are absolutely untrue from beginning to
+end, I shall believe you.  Deny them, Dorian, deny them!  Can't you see
+what I am going through?  My God! don't tell me that you are bad, and
+corrupt, and shameful."
+
+Dorian Gray smiled.  There was a curl of contempt in his lips.  "Come
+upstairs, Basil," he said quietly.  "I keep a diary of my life from day
+to day, and it never leaves the room in which it is written.  I shall
+show it to you if you come with me."
+
+"I shall come with you, Dorian, if you wish it.  I see I have missed my
+train.  That makes no matter.  I can go to-morrow. But don't ask me to
+read anything to-night. All I want is a plain answer to my question."
+
+"That shall be given to you upstairs.  I could not give it here.  You
+will not have to read long."
+
+
+
+CHAPTER 13
+
+He passed out of the room and began the ascent, Basil Hallward
+following close behind.  They walked softly, as men do instinctively at
+night.  The lamp cast fantastic shadows on the wall and staircase.  A
+rising wind made some of the windows rattle.
+
+When they reached the top landing, Dorian set the lamp down on the
+floor, and taking out the key, turned it in the lock.  "You insist on
+knowing, Basil?" he asked in a low voice.
+
+"Yes."
+
+"I am delighted," he answered, smiling.  Then he added, somewhat
+harshly, "You are the one man in the world who is entitled to know
+everything about me.  You have had more to do with my life than you
+think"; and, taking up the lamp, he opened the door and went in.  A
+cold current of air passed them, and the light shot up for a moment in
+a flame of murky orange.  He shuddered.  "Shut the door behind you," he
+whispered, as he placed the lamp on the table.
+
+Hallward glanced round him with a puzzled expression.  The room looked
+as if it had not been lived in for years.  A faded Flemish tapestry, a
+curtained picture, an old Italian _cassone_, and an almost empty
+book-case--that was all that it seemed to contain, besides a chair and
+a table.  As Dorian Gray was lighting a half-burned candle that was
+standing on the mantelshelf, he saw that the whole place was covered
+with dust and that the carpet was in holes.  A mouse ran scuffling
+behind the wainscoting.  There was a damp odour of mildew.
+
+"So you think that it is only God who sees the soul, Basil?  Draw that
+curtain back, and you will see mine."
+
+The voice that spoke was cold and cruel.  "You are mad, Dorian, or
+playing a part," muttered Hallward, frowning.
+
+"You won't? Then I must do it myself," said the young man, and he tore
+the curtain from its rod and flung it on the ground.
+
+An exclamation of horror broke from the painter's lips as he saw in the
+dim light the hideous face on the canvas grinning at him.  There was
+something in its expression that filled him with disgust and loathing.
+Good heavens! it was Dorian Gray's own face that he was looking at!
+The horror, whatever it was, had not yet entirely spoiled that
+marvellous beauty.  There was still some gold in the thinning hair and
+some scarlet on the sensual mouth.  The sodden eyes had kept something
+of the loveliness of their blue, the noble curves had not yet
+completely passed away from chiselled nostrils and from plastic throat.
+Yes, it was Dorian himself.  But who had done it?  He seemed to
+recognize his own brushwork, and the frame was his own design.  The
+idea was monstrous, yet he felt afraid.  He seized the lighted candle,
+and held it to the picture.  In the left-hand corner was his own name,
+traced in long letters of bright vermilion.
+
+It was some foul parody, some infamous ignoble satire.  He had never
+done that.  Still, it was his own picture.  He knew it, and he felt as
+if his blood had changed in a moment from fire to sluggish ice.  His
+own picture!  What did it mean?  Why had it altered?  He turned and
+looked at Dorian Gray with the eyes of a sick man.  His mouth twitched,
+and his parched tongue seemed unable to articulate.  He passed his hand
+across his forehead.  It was dank with clammy sweat.
+
+The young man was leaning against the mantelshelf, watching him with
+that strange expression that one sees on the faces of those who are
+absorbed in a play when some great artist is acting.  There was neither
+real sorrow in it nor real joy.  There was simply the passion of the
+spectator, with perhaps a flicker of triumph in his eyes.  He had taken
+the flower out of his coat, and was smelling it, or pretending to do so.
+
+"What does this mean?" cried Hallward, at last.  His own voice sounded
+shrill and curious in his ears.
+
+"Years ago, when I was a boy," said Dorian Gray, crushing the flower in
+his hand, "you met me, flattered me, and taught me to be vain of my
+good looks.  One day you introduced me to a friend of yours, who
+explained to me the wonder of youth, and you finished a portrait of me
+that revealed to me the wonder of beauty.  In a mad moment that, even
+now, I don't know whether I regret or not, I made a wish, perhaps you
+would call it a prayer...."
+
+"I remember it!  Oh, how well I remember it!  No! the thing is
+impossible.  The room is damp.  Mildew has got into the canvas.  The
+paints I used had some wretched mineral poison in them.  I tell you the
+thing is impossible."
+
+"Ah, what is impossible?" murmured the young man, going over to the
+window and leaning his forehead against the cold, mist-stained glass.
+
+"You told me you had destroyed it."
+
+"I was wrong.  It has destroyed me."
+
+"I don't believe it is my picture."
+
+"Can't you see your ideal in it?" said Dorian bitterly.
+
+"My ideal, as you call it..."
+
+"As you called it."
+
+"There was nothing evil in it, nothing shameful.  You were to me such
+an ideal as I shall never meet again.  This is the face of a satyr."
+
+"It is the face of my soul."
+
+"Christ! what a thing I must have worshipped!  It has the eyes of a
+devil."
+
+"Each of us has heaven and hell in him, Basil," cried Dorian with a
+wild gesture of despair.
+
+Hallward turned again to the portrait and gazed at it.  "My God!  If it
+is true," he exclaimed, "and this is what you have done with your life,
+why, you must be worse even than those who talk against you fancy you
+to be!" He held the light up again to the canvas and examined it.  The
+surface seemed to be quite undisturbed and as he had left it.  It was
+from within, apparently, that the foulness and horror had come.
+Through some strange quickening of inner life the leprosies of sin were
+slowly eating the thing away.  The rotting of a corpse in a watery
+grave was not so fearful.
+
+His hand shook, and the candle fell from its socket on the floor and
+lay there sputtering.  He placed his foot on it and put it out.  Then
+he flung himself into the rickety chair that was standing by the table
+and buried his face in his hands.
+
+"Good God, Dorian, what a lesson!  What an awful lesson!" There was no
+answer, but he could hear the young man sobbing at the window.  "Pray,
+Dorian, pray," he murmured.  "What is it that one was taught to say in
+one's boyhood?  'Lead us not into temptation.  Forgive us our sins.
+Wash away our iniquities.'  Let us say that together.  The prayer of
+your pride has been answered.  The prayer of your repentance will be
+answered also.  I worshipped you too much.  I am punished for it.  You
+worshipped yourself too much.  We are both punished."
+
+Dorian Gray turned slowly around and looked at him with tear-dimmed
+eyes.  "It is too late, Basil," he faltered.
+
+"It is never too late, Dorian.  Let us kneel down and try if we cannot
+remember a prayer.  Isn't there a verse somewhere, 'Though your sins be
+as scarlet, yet I will make them as white as snow'?"
+
+"Those words mean nothing to me now."
+
+"Hush!  Don't say that.  You have done enough evil in your life.  My
+God!  Don't you see that accursed thing leering at us?"
+
+Dorian Gray glanced at the picture, and suddenly an uncontrollable
+feeling of hatred for Basil Hallward came over him, as though it had
+been suggested to him by the image on the canvas, whispered into his
+ear by those grinning lips.  The mad passions of a hunted animal
+stirred within him, and he loathed the man who was seated at the table,
+more than in his whole life he had ever loathed anything.  He glanced
+wildly around.  Something glimmered on the top of the painted chest
+that faced him.  His eye fell on it.  He knew what it was.  It was a
+knife that he had brought up, some days before, to cut a piece of cord,
+and had forgotten to take away with him.  He moved slowly towards it,
+passing Hallward as he did so.  As soon as he got behind him, he seized
+it and turned round.  Hallward stirred in his chair as if he was going
+to rise.  He rushed at him and dug the knife into the great vein that
+is behind the ear, crushing the man's head down on the table and
+stabbing again and again.
+
+There was a stifled groan and the horrible sound of some one choking
+with blood.  Three times the outstretched arms shot up convulsively,
+waving grotesque, stiff-fingered hands in the air.  He stabbed him
+twice more, but the man did not move.  Something began to trickle on
+the floor.  He waited for a moment, still pressing the head down.  Then
+he threw the knife on the table, and listened.
+
+He could hear nothing, but the drip, drip on the threadbare carpet.  He
+opened the door and went out on the landing.  The house was absolutely
+quiet.  No one was about.  For a few seconds he stood bending over the
+balustrade and peering down into the black seething well of darkness.
+Then he took out the key and returned to the room, locking himself in
+as he did so.
+
+The thing was still seated in the chair, straining over the table with
+bowed head, and humped back, and long fantastic arms.  Had it not been
+for the red jagged tear in the neck and the clotted black pool that was
+slowly widening on the table, one would have said that the man was
+simply asleep.
+
+How quickly it had all been done!  He felt strangely calm, and walking
+over to the window, opened it and stepped out on the balcony.  The wind
+had blown the fog away, and the sky was like a monstrous peacock's
+tail, starred with myriads of golden eyes.  He looked down and saw the
+policeman going his rounds and flashing the long beam of his lantern on
+the doors of the silent houses.  The crimson spot of a prowling hansom
+gleamed at the corner and then vanished.  A woman in a fluttering shawl
+was creeping slowly by the railings, staggering as she went.  Now and
+then she stopped and peered back.  Once, she began to sing in a hoarse
+voice.  The policeman strolled over and said something to her.  She
+stumbled away, laughing.  A bitter blast swept across the square.  The
+gas-lamps flickered and became blue, and the leafless trees shook their
+black iron branches to and fro.  He shivered and went back, closing the
+window behind him.
+
+Having reached the door, he turned the key and opened it.  He did not
+even glance at the murdered man.  He felt that the secret of the whole
+thing was not to realize the situation.  The friend who had painted the
+fatal portrait to which all his misery had been due had gone out of his
+life.  That was enough.
+
+Then he remembered the lamp.  It was a rather curious one of Moorish
+workmanship, made of dull silver inlaid with arabesques of burnished
+steel, and studded with coarse turquoises.  Perhaps it might be missed
+by his servant, and questions would be asked.  He hesitated for a
+moment, then he turned back and took it from the table.  He could not
+help seeing the dead thing.  How still it was!  How horribly white the
+long hands looked!  It was like a dreadful wax image.
+
+Having locked the door behind him, he crept quietly downstairs.  The
+woodwork creaked and seemed to cry out as if in pain.  He stopped
+several times and waited.  No:  everything was still.  It was merely
+the sound of his own footsteps.
+
+When he reached the library, he saw the bag and coat in the corner.
+They must be hidden away somewhere.  He unlocked a secret press that
+was in the wainscoting, a press in which he kept his own curious
+disguises, and put them into it.  He could easily burn them afterwards.
+Then he pulled out his watch.  It was twenty minutes to two.
+
+He sat down and began to think.  Every year--every month, almost--men
+were strangled in England for what he had done.  There had been a
+madness of murder in the air.  Some red star had come too close to the
+earth.... And yet, what evidence was there against him?  Basil Hallward
+had left the house at eleven.  No one had seen him come in again.  Most
+of the servants were at Selby Royal.  His valet had gone to bed....
+Paris!  Yes.  It was to Paris that Basil had gone, and by the midnight
+train, as he had intended.  With his curious reserved habits, it would
+be months before any suspicions would be roused.  Months!  Everything
+could be destroyed long before then.
+
+A sudden thought struck him.  He put on his fur coat and hat and went
+out into the hall.  There he paused, hearing the slow heavy tread of
+the policeman on the pavement outside and seeing the flash of the
+bull's-eye reflected in the window.  He waited and held his breath.
+
+After a few moments he drew back the latch and slipped out, shutting
+the door very gently behind him.  Then he began ringing the bell.  In
+about five minutes his valet appeared, half-dressed and looking very
+drowsy.
+
+"I am sorry to have had to wake you up, Francis," he said, stepping in;
+"but I had forgotten my latch-key. What time is it?"
+
+"Ten minutes past two, sir," answered the man, looking at the clock and
+blinking.
+
+"Ten minutes past two?  How horribly late!  You must wake me at nine
+to-morrow. I have some work to do."
+
+"All right, sir."
+
+"Did any one call this evening?"
+
+"Mr. Hallward, sir.  He stayed here till eleven, and then he went away
+to catch his train."
+
+"Oh!  I am sorry I didn't see him.  Did he leave any message?"
+
+"No, sir, except that he would write to you from Paris, if he did not
+find you at the club."
+
+"That will do, Francis.  Don't forget to call me at nine to-morrow."
+
+"No, sir."
+
+The man shambled down the passage in his slippers.
+
+Dorian Gray threw his hat and coat upon the table and passed into the
+library.  For a quarter of an hour he walked up and down the room,
+biting his lip and thinking.  Then he took down the Blue Book from one
+of the shelves and began to turn over the leaves.  "Alan Campbell, 152,
+Hertford Street, Mayfair."  Yes; that was the man he wanted.
+
+
+
+CHAPTER 14
+
+At nine o'clock the next morning his servant came in with a cup of
+chocolate on a tray and opened the shutters.  Dorian was sleeping quite
+peacefully, lying on his right side, with one hand underneath his
+cheek.  He looked like a boy who had been tired out with play, or study.
+
+The man had to touch him twice on the shoulder before he woke, and as
+he opened his eyes a faint smile passed across his lips, as though he
+had been lost in some delightful dream.  Yet he had not dreamed at all.
+His night had been untroubled by any images of pleasure or of pain.
+But youth smiles without any reason.  It is one of its chiefest charms.
+
+He turned round, and leaning upon his elbow, began to sip his
+chocolate.  The mellow November sun came streaming into the room.  The
+sky was bright, and there was a genial warmth in the air.  It was
+almost like a morning in May.
+
+Gradually the events of the preceding night crept with silent,
+blood-stained feet into his brain and reconstructed themselves there
+with terrible distinctness.  He winced at the memory of all that he had
+suffered, and for a moment the same curious feeling of loathing for
+Basil Hallward that had made him kill him as he sat in the chair came
+back to him, and he grew cold with passion.  The dead man was still
+sitting there, too, and in the sunlight now.  How horrible that was!
+Such hideous things were for the darkness, not for the day.
+
+He felt that if he brooded on what he had gone through he would sicken
+or grow mad.  There were sins whose fascination was more in the memory
+than in the doing of them, strange triumphs that gratified the pride
+more than the passions, and gave to the intellect a quickened sense of
+joy, greater than any joy they brought, or could ever bring, to the
+senses.  But this was not one of them.  It was a thing to be driven out
+of the mind, to be drugged with poppies, to be strangled lest it might
+strangle one itself.
+
+When the half-hour struck, he passed his hand across his forehead, and
+then got up hastily and dressed himself with even more than his usual
+care, giving a good deal of attention to the choice of his necktie and
+scarf-pin and changing his rings more than once.  He spent a long time
+also over breakfast, tasting the various dishes, talking to his valet
+about some new liveries that he was thinking of getting made for the
+servants at Selby, and going through his correspondence.  At some of
+the letters, he smiled.  Three of them bored him.  One he read several
+times over and then tore up with a slight look of annoyance in his
+face.  "That awful thing, a woman's memory!" as Lord Henry had once
+said.
+
+After he had drunk his cup of black coffee, he wiped his lips slowly
+with a napkin, motioned to his servant to wait, and going over to the
+table, sat down and wrote two letters.  One he put in his pocket, the
+other he handed to the valet.
+
+"Take this round to 152, Hertford Street, Francis, and if Mr. Campbell
+is out of town, get his address."
+
+As soon as he was alone, he lit a cigarette and began sketching upon a
+piece of paper, drawing first flowers and bits of architecture, and
+then human faces.  Suddenly he remarked that every face that he drew
+seemed to have a fantastic likeness to Basil Hallward.  He frowned, and
+getting up, went over to the book-case and took out a volume at hazard.
+He was determined that he would not think about what had happened until
+it became absolutely necessary that he should do so.
+
+When he had stretched himself on the sofa, he looked at the title-page
+of the book.  It was Gautier's Emaux et Camees, Charpentier's
+Japanese-paper edition, with the Jacquemart etching.  The binding was
+of citron-green leather, with a design of gilt trellis-work and dotted
+pomegranates.  It had been given to him by Adrian Singleton.  As he
+turned over the pages, his eye fell on the poem about the hand of
+Lacenaire, the cold yellow hand "_du supplice encore mal lavee_," with
+its downy red hairs and its "_doigts de faune_."  He glanced at his own
+white taper fingers, shuddering slightly in spite of himself, and
+passed on, till he came to those lovely stanzas upon Venice:
+
+     Sur une gamme chromatique,
+       Le sein de peries ruisselant,
+     La Venus de l'Adriatique
+       Sort de l'eau son corps rose et blanc.
+
+     Les domes, sur l'azur des ondes
+       Suivant la phrase au pur contour,
+     S'enflent comme des gorges rondes
+       Que souleve un soupir d'amour.
+
+     L'esquif aborde et me depose,
+       Jetant son amarre au pilier,
+     Devant une facade rose,
+       Sur le marbre d'un escalier.
+
+
+How exquisite they were!  As one read them, one seemed to be floating
+down the green water-ways of the pink and pearl city, seated in a black
+gondola with silver prow and trailing curtains.  The mere lines looked
+to him like those straight lines of turquoise-blue that follow one as
+one pushes out to the Lido.  The sudden flashes of colour reminded him
+of the gleam of the opal-and-iris-throated birds that flutter round the
+tall honeycombed Campanile, or stalk, with such stately grace, through
+the dim, dust-stained arcades.  Leaning back with half-closed eyes, he
+kept saying over and over to himself:
+
+     "Devant une facade rose,
+        Sur le marbre d'un escalier."
+
+The whole of Venice was in those two lines.  He remembered the autumn
+that he had passed there, and a wonderful love that had stirred him to
+mad delightful follies.  There was romance in every place.  But Venice,
+like Oxford, had kept the background for romance, and, to the true
+romantic, background was everything, or almost everything.  Basil had
+been with him part of the time, and had gone wild over Tintoret.  Poor
+Basil!  What a horrible way for a man to die!
+
+He sighed, and took up the volume again, and tried to forget.  He read
+of the swallows that fly in and out of the little _cafe_ at Smyrna where
+the Hadjis sit counting their amber beads and the turbaned merchants
+smoke their long tasselled pipes and talk gravely to each other; he
+read of the Obelisk in the Place de la Concorde that weeps tears of
+granite in its lonely sunless exile and longs to be back by the hot,
+lotus-covered Nile, where there are Sphinxes, and rose-red ibises, and
+white vultures with gilded claws, and crocodiles with small beryl eyes
+that crawl over the green steaming mud; he began to brood over those
+verses which, drawing music from kiss-stained marble, tell of that
+curious statue that Gautier compares to a contralto voice, the "_monstre
+charmant_" that couches in the porphyry-room of the Louvre.  But after a
+time the book fell from his hand.  He grew nervous, and a horrible fit
+of terror came over him.  What if Alan Campbell should be out of
+England?  Days would elapse before he could come back.  Perhaps he
+might refuse to come.  What could he do then?  Every moment was of
+vital importance.
+
+They had been great friends once, five years before--almost
+inseparable, indeed.  Then the intimacy had come suddenly to an end.
+When they met in society now, it was only Dorian Gray who smiled:  Alan
+Campbell never did.
+
+He was an extremely clever young man, though he had no real
+appreciation of the visible arts, and whatever little sense of the
+beauty of poetry he possessed he had gained entirely from Dorian.  His
+dominant intellectual passion was for science.  At Cambridge he had
+spent a great deal of his time working in the laboratory, and had taken
+a good class in the Natural Science Tripos of his year.  Indeed, he was
+still devoted to the study of chemistry, and had a laboratory of his
+own in which he used to shut himself up all day long, greatly to the
+annoyance of his mother, who had set her heart on his standing for
+Parliament and had a vague idea that a chemist was a person who made up
+prescriptions.  He was an excellent musician, however, as well, and
+played both the violin and the piano better than most amateurs.  In
+fact, it was music that had first brought him and Dorian Gray
+together--music and that indefinable attraction that Dorian seemed to
+be able to exercise whenever he wished--and, indeed, exercised often
+without being conscious of it.  They had met at Lady Berkshire's the
+night that Rubinstein played there, and after that used to be always
+seen together at the opera and wherever good music was going on.  For
+eighteen months their intimacy lasted.  Campbell was always either at
+Selby Royal or in Grosvenor Square.  To him, as to many others, Dorian
+Gray was the type of everything that is wonderful and fascinating in
+life.  Whether or not a quarrel had taken place between them no one
+ever knew.  But suddenly people remarked that they scarcely spoke when
+they met and that Campbell seemed always to go away early from any
+party at which Dorian Gray was present.  He had changed, too--was
+strangely melancholy at times, appeared almost to dislike hearing
+music, and would never himself play, giving as his excuse, when he was
+called upon, that he was so absorbed in science that he had no time
+left in which to practise.  And this was certainly true.  Every day he
+seemed to become more interested in biology, and his name appeared once
+or twice in some of the scientific reviews in connection with certain
+curious experiments.
+
+This was the man Dorian Gray was waiting for.  Every second he kept
+glancing at the clock.  As the minutes went by he became horribly
+agitated.  At last he got up and began to pace up and down the room,
+looking like a beautiful caged thing.  He took long stealthy strides.
+His hands were curiously cold.
+
+The suspense became unbearable.  Time seemed to him to be crawling with
+feet of lead, while he by monstrous winds was being swept towards the
+jagged edge of some black cleft of precipice.  He knew what was waiting
+for him there; saw it, indeed, and, shuddering, crushed with dank hands
+his burning lids as though he would have robbed the very brain of sight
+and driven the eyeballs back into their cave.  It was useless.  The
+brain had its own food on which it battened, and the imagination, made
+grotesque by terror, twisted and distorted as a living thing by pain,
+danced like some foul puppet on a stand and grinned through moving
+masks.  Then, suddenly, time stopped for him.  Yes:  that blind,
+slow-breathing thing crawled no more, and horrible thoughts, time being
+dead, raced nimbly on in front, and dragged a hideous future from its
+grave, and showed it to him.  He stared at it.  Its very horror made
+him stone.
+
+At last the door opened and his servant entered.  He turned glazed eyes
+upon him.
+
+"Mr. Campbell, sir," said the man.
+
+A sigh of relief broke from his parched lips, and the colour came back
+to his cheeks.
+
+"Ask him to come in at once, Francis."  He felt that he was himself
+again.  His mood of cowardice had passed away.
+
+The man bowed and retired.  In a few moments, Alan Campbell walked in,
+looking very stern and rather pale, his pallor being intensified by his
+coal-black hair and dark eyebrows.
+
+"Alan!  This is kind of you.  I thank you for coming."
+
+"I had intended never to enter your house again, Gray.  But you said it
+was a matter of life and death."  His voice was hard and cold.  He
+spoke with slow deliberation.  There was a look of contempt in the
+steady searching gaze that he turned on Dorian.  He kept his hands in
+the pockets of his Astrakhan coat, and seemed not to have noticed the
+gesture with which he had been greeted.
+
+"Yes:  it is a matter of life and death, Alan, and to more than one
+person.  Sit down."
+
+Campbell took a chair by the table, and Dorian sat opposite to him.
+The two men's eyes met.  In Dorian's there was infinite pity.  He knew
+that what he was going to do was dreadful.
+
+After a strained moment of silence, he leaned across and said, very
+quietly, but watching the effect of each word upon the face of him he
+had sent for, "Alan, in a locked room at the top of this house, a room
+to which nobody but myself has access, a dead man is seated at a table.
+He has been dead ten hours now.  Don't stir, and don't look at me like
+that.  Who the man is, why he died, how he died, are matters that do
+not concern you.  What you have to do is this--"
+
+"Stop, Gray.  I don't want to know anything further.  Whether what you
+have told me is true or not true doesn't concern me.  I entirely
+decline to be mixed up in your life.  Keep your horrible secrets to
+yourself.  They don't interest me any more."
+
+"Alan, they will have to interest you.  This one will have to interest
+you.  I am awfully sorry for you, Alan.  But I can't help myself.  You
+are the one man who is able to save me.  I am forced to bring you into
+the matter.  I have no option.  Alan, you are scientific.  You know
+about chemistry and things of that kind.  You have made experiments.
+What you have got to do is to destroy the thing that is upstairs--to
+destroy it so that not a vestige of it will be left.  Nobody saw this
+person come into the house.  Indeed, at the present moment he is
+supposed to be in Paris.  He will not be missed for months.  When he is
+missed, there must be no trace of him found here.  You, Alan, you must
+change him, and everything that belongs to him, into a handful of ashes
+that I may scatter in the air."
+
+"You are mad, Dorian."
+
+"Ah!  I was waiting for you to call me Dorian."
+
+"You are mad, I tell you--mad to imagine that I would raise a finger to
+help you, mad to make this monstrous confession.  I will have nothing
+to do with this matter, whatever it is.  Do you think I am going to
+peril my reputation for you?  What is it to me what devil's work you
+are up to?"
+
+"It was suicide, Alan."
+
+"I am glad of that.  But who drove him to it?  You, I should fancy."
+
+"Do you still refuse to do this for me?"
+
+"Of course I refuse.  I will have absolutely nothing to do with it.  I
+don't care what shame comes on you.  You deserve it all.  I should not
+be sorry to see you disgraced, publicly disgraced.  How dare you ask
+me, of all men in the world, to mix myself up in this horror?  I should
+have thought you knew more about people's characters.  Your friend Lord
+Henry Wotton can't have taught you much about psychology, whatever else
+he has taught you.  Nothing will induce me to stir a step to help you.
+You have come to the wrong man.  Go to some of your friends.  Don't
+come to me."
+
+"Alan, it was murder.  I killed him.  You don't know what he had made
+me suffer.  Whatever my life is, he had more to do with the making or
+the marring of it than poor Harry has had.  He may not have intended
+it, the result was the same."
+
+"Murder!  Good God, Dorian, is that what you have come to?  I shall not
+inform upon you.  It is not my business.  Besides, without my stirring
+in the matter, you are certain to be arrested.  Nobody ever commits a
+crime without doing something stupid.  But I will have nothing to do
+with it."
+
+"You must have something to do with it.  Wait, wait a moment; listen to
+me.  Only listen, Alan.  All I ask of you is to perform a certain
+scientific experiment.  You go to hospitals and dead-houses, and the
+horrors that you do there don't affect you.  If in some hideous
+dissecting-room or fetid laboratory you found this man lying on a
+leaden table with red gutters scooped out in it for the blood to flow
+through, you would simply look upon him as an admirable subject.  You
+would not turn a hair.  You would not believe that you were doing
+anything wrong.  On the contrary, you would probably feel that you were
+benefiting the human race, or increasing the sum of knowledge in the
+world, or gratifying intellectual curiosity, or something of that kind.
+What I want you to do is merely what you have often done before.
+Indeed, to destroy a body must be far less horrible than what you are
+accustomed to work at.  And, remember, it is the only piece of evidence
+against me.  If it is discovered, I am lost; and it is sure to be
+discovered unless you help me."
+
+"I have no desire to help you.  You forget that.  I am simply
+indifferent to the whole thing.  It has nothing to do with me."
+
+"Alan, I entreat you.  Think of the position I am in.  Just before you
+came I almost fainted with terror.  You may know terror yourself some
+day.  No! don't think of that.  Look at the matter purely from the
+scientific point of view.  You don't inquire where the dead things on
+which you experiment come from.  Don't inquire now.  I have told you
+too much as it is.  But I beg of you to do this.  We were friends once,
+Alan."
+
+"Don't speak about those days, Dorian--they are dead."
+
+"The dead linger sometimes.  The man upstairs will not go away.  He is
+sitting at the table with bowed head and outstretched arms.  Alan!
+Alan!  If you don't come to my assistance, I am ruined.  Why, they will
+hang me, Alan!  Don't you understand?  They will hang me for what I
+have done."
+
+"There is no good in prolonging this scene.  I absolutely refuse to do
+anything in the matter.  It is insane of you to ask me."
+
+"You refuse?"
+
+"Yes."
+
+"I entreat you, Alan."
+
+"It is useless."
+
+The same look of pity came into Dorian Gray's eyes.  Then he stretched
+out his hand, took a piece of paper, and wrote something on it.  He
+read it over twice, folded it carefully, and pushed it across the
+table.  Having done this, he got up and went over to the window.
+
+Campbell looked at him in surprise, and then took up the paper, and
+opened it.  As he read it, his face became ghastly pale and he fell
+back in his chair.  A horrible sense of sickness came over him.  He
+felt as if his heart was beating itself to death in some empty hollow.
+
+After two or three minutes of terrible silence, Dorian turned round and
+came and stood behind him, putting his hand upon his shoulder.
+
+"I am so sorry for you, Alan," he murmured, "but you leave me no
+alternative.  I have a letter written already.  Here it is.  You see
+the address.  If you don't help me, I must send it.  If you don't help
+me, I will send it.  You know what the result will be.  But you are
+going to help me.  It is impossible for you to refuse now.  I tried to
+spare you.  You will do me the justice to admit that.  You were stern,
+harsh, offensive.  You treated me as no man has ever dared to treat
+me--no living man, at any rate.  I bore it all.  Now it is for me to
+dictate terms."
+
+Campbell buried his face in his hands, and a shudder passed through him.
+
+"Yes, it is my turn to dictate terms, Alan.  You know what they are.
+The thing is quite simple.  Come, don't work yourself into this fever.
+The thing has to be done.  Face it, and do it."
+
+A groan broke from Campbell's lips and he shivered all over.  The
+ticking of the clock on the mantelpiece seemed to him to be dividing
+time into separate atoms of agony, each of which was too terrible to be
+borne.  He felt as if an iron ring was being slowly tightened round his
+forehead, as if the disgrace with which he was threatened had already
+come upon him.  The hand upon his shoulder weighed like a hand of lead.
+It was intolerable.  It seemed to crush him.
+
+"Come, Alan, you must decide at once."
+
+"I cannot do it," he said, mechanically, as though words could alter
+things.
+
+"You must.  You have no choice.  Don't delay."
+
+He hesitated a moment.  "Is there a fire in the room upstairs?"
+
+"Yes, there is a gas-fire with asbestos."
+
+"I shall have to go home and get some things from the laboratory."
+
+"No, Alan, you must not leave the house.  Write out on a sheet of
+notepaper what you want and my servant will take a cab and bring the
+things back to you."
+
+Campbell scrawled a few lines, blotted them, and addressed an envelope
+to his assistant.  Dorian took the note up and read it carefully.  Then
+he rang the bell and gave it to his valet, with orders to return as
+soon as possible and to bring the things with him.
+
+As the hall door shut, Campbell started nervously, and having got up
+from the chair, went over to the chimney-piece. He was shivering with a
+kind of ague.  For nearly twenty minutes, neither of the men spoke.  A
+fly buzzed noisily about the room, and the ticking of the clock was
+like the beat of a hammer.
+
+As the chime struck one, Campbell turned round, and looking at Dorian
+Gray, saw that his eyes were filled with tears.  There was something in
+the purity and refinement of that sad face that seemed to enrage him.
+"You are infamous, absolutely infamous!" he muttered.
+
+"Hush, Alan.  You have saved my life," said Dorian.
+
+"Your life?  Good heavens! what a life that is!  You have gone from
+corruption to corruption, and now you have culminated in crime.  In
+doing what I am going to do--what you force me to do--it is not of your
+life that I am thinking."
+
+"Ah, Alan," murmured Dorian with a sigh, "I wish you had a thousandth
+part of the pity for me that I have for you." He turned away as he
+spoke and stood looking out at the garden.  Campbell made no answer.
+
+After about ten minutes a knock came to the door, and the servant
+entered, carrying a large mahogany chest of chemicals, with a long coil
+of steel and platinum wire and two rather curiously shaped iron clamps.
+
+"Shall I leave the things here, sir?" he asked Campbell.
+
+"Yes," said Dorian.  "And I am afraid, Francis, that I have another
+errand for you.  What is the name of the man at Richmond who supplies
+Selby with orchids?"
+
+"Harden, sir."
+
+"Yes--Harden.  You must go down to Richmond at once, see Harden
+personally, and tell him to send twice as many orchids as I ordered,
+and to have as few white ones as possible.  In fact, I don't want any
+white ones.  It is a lovely day, Francis, and Richmond is a very pretty
+place--otherwise I wouldn't bother you about it."
+
+"No trouble, sir.  At what time shall I be back?"
+
+Dorian looked at Campbell.  "How long will your experiment take, Alan?"
+he said in a calm indifferent voice.  The presence of a third person in
+the room seemed to give him extraordinary courage.
+
+Campbell frowned and bit his lip.  "It will take about five hours," he
+answered.
+
+"It will be time enough, then, if you are back at half-past seven,
+Francis.  Or stay:  just leave my things out for dressing.  You can
+have the evening to yourself.  I am not dining at home, so I shall not
+want you."
+
+"Thank you, sir," said the man, leaving the room.
+
+"Now, Alan, there is not a moment to be lost.  How heavy this chest is!
+I'll take it for you.  You bring the other things."  He spoke rapidly
+and in an authoritative manner.  Campbell felt dominated by him.  They
+left the room together.
+
+When they reached the top landing, Dorian took out the key and turned
+it in the lock.  Then he stopped, and a troubled look came into his
+eyes.  He shuddered.  "I don't think I can go in, Alan," he murmured.
+
+"It is nothing to me.  I don't require you," said Campbell coldly.
+
+Dorian half opened the door.  As he did so, he saw the face of his
+portrait leering in the sunlight.  On the floor in front of it the torn
+curtain was lying.  He remembered that the night before he had
+forgotten, for the first time in his life, to hide the fatal canvas,
+and was about to rush forward, when he drew back with a shudder.
+
+What was that loathsome red dew that gleamed, wet and glistening, on
+one of the hands, as though the canvas had sweated blood?  How horrible
+it was!--more horrible, it seemed to him for the moment, than the
+silent thing that he knew was stretched across the table, the thing
+whose grotesque misshapen shadow on the spotted carpet showed him that
+it had not stirred, but was still there, as he had left it.
+
+He heaved a deep breath, opened the door a little wider, and with
+half-closed eyes and averted head, walked quickly in, determined that
+he would not look even once upon the dead man.  Then, stooping down and
+taking up the gold-and-purple hanging, he flung it right over the
+picture.
+
+There he stopped, feeling afraid to turn round, and his eyes fixed
+themselves on the intricacies of the pattern before him.  He heard
+Campbell bringing in the heavy chest, and the irons, and the other
+things that he had required for his dreadful work.  He began to wonder
+if he and Basil Hallward had ever met, and, if so, what they had
+thought of each other.
+
+"Leave me now," said a stern voice behind him.
+
+He turned and hurried out, just conscious that the dead man had been
+thrust back into the chair and that Campbell was gazing into a
+glistening yellow face.  As he was going downstairs, he heard the key
+being turned in the lock.
+
+It was long after seven when Campbell came back into the library.  He
+was pale, but absolutely calm.  "I have done what you asked me to do,"
+he muttered. "And now, good-bye. Let us never see each other again."
+
+"You have saved me from ruin, Alan.  I cannot forget that," said Dorian
+simply.
+
+As soon as Campbell had left, he went upstairs.  There was a horrible
+smell of nitric acid in the room.  But the thing that had been sitting
+at the table was gone.
+
+
+
+CHAPTER 15
+
+That evening, at eight-thirty, exquisitely dressed and wearing a large
+button-hole of Parma violets, Dorian Gray was ushered into Lady
+Narborough's drawing-room by bowing servants.  His forehead was
+throbbing with maddened nerves, and he felt wildly excited, but his
+manner as he bent over his hostess's hand was as easy and graceful as
+ever.  Perhaps one never seems so much at one's ease as when one has to
+play a part.  Certainly no one looking at Dorian Gray that night could
+have believed that he had passed through a tragedy as horrible as any
+tragedy of our age.  Those finely shaped fingers could never have
+clutched a knife for sin, nor those smiling lips have cried out on God
+and goodness.  He himself could not help wondering at the calm of his
+demeanour, and for a moment felt keenly the terrible pleasure of a
+double life.
+
+It was a small party, got up rather in a hurry by Lady Narborough, who
+was a very clever woman with what Lord Henry used to describe as the
+remains of really remarkable ugliness.  She had proved an excellent
+wife to one of our most tedious ambassadors, and having buried her
+husband properly in a marble mausoleum, which she had herself designed,
+and married off her daughters to some rich, rather elderly men, she
+devoted herself now to the pleasures of French fiction, French cookery,
+and French _esprit_ when she could get it.
+
+Dorian was one of her especial favourites, and she always told him that
+she was extremely glad she had not met him in early life.  "I know, my
+dear, I should have fallen madly in love with you," she used to say,
+"and thrown my bonnet right over the mills for your sake.  It is most
+fortunate that you were not thought of at the time.  As it was, our
+bonnets were so unbecoming, and the mills were so occupied in trying to
+raise the wind, that I never had even a flirtation with anybody.
+However, that was all Narborough's fault.  He was dreadfully
+short-sighted, and there is no pleasure in taking in a husband who
+never sees anything."
+
+Her guests this evening were rather tedious.  The fact was, as she
+explained to Dorian, behind a very shabby fan, one of her married
+daughters had come up quite suddenly to stay with her, and, to make
+matters worse, had actually brought her husband with her.  "I think it
+is most unkind of her, my dear," she whispered.  "Of course I go and
+stay with them every summer after I come from Homburg, but then an old
+woman like me must have fresh air sometimes, and besides, I really wake
+them up.  You don't know what an existence they lead down there.  It is
+pure unadulterated country life.  They get up early, because they have
+so much to do, and go to bed early, because they have so little to
+think about.  There has not been a scandal in the neighbourhood since
+the time of Queen Elizabeth, and consequently they all fall asleep
+after dinner.  You shan't sit next either of them.  You shall sit by me
+and amuse me."
+
+Dorian murmured a graceful compliment and looked round the room.  Yes:
+it was certainly a tedious party.  Two of the people he had never seen
+before, and the others consisted of Ernest Harrowden, one of those
+middle-aged mediocrities so common in London clubs who have no enemies,
+but are thoroughly disliked by their friends; Lady Ruxton, an
+overdressed woman of forty-seven, with a hooked nose, who was always
+trying to get herself compromised, but was so peculiarly plain that to
+her great disappointment no one would ever believe anything against
+her; Mrs. Erlynne, a pushing nobody, with a delightful lisp and
+Venetian-red hair; Lady Alice Chapman, his hostess's daughter, a dowdy
+dull girl, with one of those characteristic British faces that, once
+seen, are never remembered; and her husband, a red-cheeked,
+white-whiskered creature who, like so many of his class, was under the
+impression that inordinate joviality can atone for an entire lack of
+ideas.
+
+He was rather sorry he had come, till Lady Narborough, looking at the
+great ormolu gilt clock that sprawled in gaudy curves on the
+mauve-draped mantelshelf, exclaimed:  "How horrid of Henry Wotton to be
+so late!  I sent round to him this morning on chance and he promised
+faithfully not to disappoint me."
+
+It was some consolation that Harry was to be there, and when the door
+opened and he heard his slow musical voice lending charm to some
+insincere apology, he ceased to feel bored.
+
+But at dinner he could not eat anything.  Plate after plate went away
+untasted.  Lady Narborough kept scolding him for what she called "an
+insult to poor Adolphe, who invented the _menu_ specially for you," and
+now and then Lord Henry looked across at him, wondering at his silence
+and abstracted manner.  From time to time the butler filled his glass
+with champagne.  He drank eagerly, and his thirst seemed to increase.
+
+"Dorian," said Lord Henry at last, as the _chaud-froid_ was being handed
+round, "what is the matter with you to-night? You are quite out of
+sorts."
+
+"I believe he is in love," cried Lady Narborough, "and that he is
+afraid to tell me for fear I should be jealous.  He is quite right.  I
+certainly should."
+
+"Dear Lady Narborough," murmured Dorian, smiling, "I have not been in
+love for a whole week--not, in fact, since Madame de Ferrol left town."
+
+"How you men can fall in love with that woman!" exclaimed the old lady.
+"I really cannot understand it."
+
+"It is simply because she remembers you when you were a little girl,
+Lady Narborough," said Lord Henry.  "She is the one link between us and
+your short frocks."
+
+"She does not remember my short frocks at all, Lord Henry.  But I
+remember her very well at Vienna thirty years ago, and how _decolletee_
+she was then."
+
+"She is still _decolletee_," he answered, taking an olive in his long
+fingers; "and when she is in a very smart gown she looks like an
+_edition de luxe_ of a bad French novel.  She is really wonderful, and
+full of surprises.  Her capacity for family affection is extraordinary.
+When her third husband died, her hair turned quite gold from grief."
+
+"How can you, Harry!" cried Dorian.
+
+"It is a most romantic explanation," laughed the hostess.  "But her
+third husband, Lord Henry!  You don't mean to say Ferrol is the fourth?"
+
+"Certainly, Lady Narborough."
+
+"I don't believe a word of it."
+
+"Well, ask Mr. Gray.  He is one of her most intimate friends."
+
+"Is it true, Mr. Gray?"
+
+"She assures me so, Lady Narborough," said Dorian.  "I asked her
+whether, like Marguerite de Navarre, she had their hearts embalmed and
+hung at her girdle.  She told me she didn't, because none of them had
+had any hearts at all."
+
+"Four husbands!  Upon my word that is _trop de zele_."
+
+"_Trop d'audace_, I tell her," said Dorian.
+
+"Oh! she is audacious enough for anything, my dear.  And what is Ferrol
+like?  I don't know him."
+
+"The husbands of very beautiful women belong to the criminal classes,"
+said Lord Henry, sipping his wine.
+
+Lady Narborough hit him with her fan.  "Lord Henry, I am not at all
+surprised that the world says that you are extremely wicked."
+
+"But what world says that?" asked Lord Henry, elevating his eyebrows.
+"It can only be the next world.  This world and I are on excellent
+terms."
+
+"Everybody I know says you are very wicked," cried the old lady,
+shaking her head.
+
+Lord Henry looked serious for some moments.  "It is perfectly
+monstrous," he said, at last, "the way people go about nowadays saying
+things against one behind one's back that are absolutely and entirely
+true."
+
+"Isn't he incorrigible?" cried Dorian, leaning forward in his chair.
+
+"I hope so," said his hostess, laughing.  "But really, if you all
+worship Madame de Ferrol in this ridiculous way, I shall have to marry
+again so as to be in the fashion."
+
+"You will never marry again, Lady Narborough," broke in Lord Henry.
+"You were far too happy.  When a woman marries again, it is because she
+detested her first husband.  When a man marries again, it is because he
+adored his first wife.  Women try their luck; men risk theirs."
+
+"Narborough wasn't perfect," cried the old lady.
+
+"If he had been, you would not have loved him, my dear lady," was the
+rejoinder.  "Women love us for our defects.  If we have enough of them,
+they will forgive us everything, even our intellects.  You will never
+ask me to dinner again after saying this, I am afraid, Lady Narborough,
+but it is quite true."
+
+"Of course it is true, Lord Henry.  If we women did not love you for
+your defects, where would you all be?  Not one of you would ever be
+married.  You would be a set of unfortunate bachelors.  Not, however,
+that that would alter you much.  Nowadays all the married men live like
+bachelors, and all the bachelors like married men."
+
+"_Fin de siecle_," murmured Lord Henry.
+
+"_Fin du globe_," answered his hostess.
+
+"I wish it were _fin du globe_," said Dorian with a sigh.  "Life is a
+great disappointment."
+
+"Ah, my dear," cried Lady Narborough, putting on her gloves, "don't
+tell me that you have exhausted life.  When a man says that one knows
+that life has exhausted him.  Lord Henry is very wicked, and I
+sometimes wish that I had been; but you are made to be good--you look
+so good.  I must find you a nice wife.  Lord Henry, don't you think
+that Mr. Gray should get married?"
+
+"I am always telling him so, Lady Narborough," said Lord Henry with a
+bow.
+
+"Well, we must look out for a suitable match for him.  I shall go
+through Debrett carefully to-night and draw out a list of all the
+eligible young ladies."
+
+"With their ages, Lady Narborough?" asked Dorian.
+
+"Of course, with their ages, slightly edited.  But nothing must be done
+in a hurry.  I want it to be what _The Morning Post_ calls a suitable
+alliance, and I want you both to be happy."
+
+"What nonsense people talk about happy marriages!" exclaimed Lord
+Henry.  "A man can be happy with any woman, as long as he does not love
+her."
+
+"Ah! what a cynic you are!" cried the old lady, pushing back her chair
+and nodding to Lady Ruxton.  "You must come and dine with me soon
+again.  You are really an admirable tonic, much better than what Sir
+Andrew prescribes for me.  You must tell me what people you would like
+to meet, though.  I want it to be a delightful gathering."
+
+"I like men who have a future and women who have a past," he answered.
+"Or do you think that would make it a petticoat party?"
+
+"I fear so," she said, laughing, as she stood up.  "A thousand pardons,
+my dear Lady Ruxton," she added, "I didn't see you hadn't finished your
+cigarette."
+
+"Never mind, Lady Narborough.  I smoke a great deal too much.  I am
+going to limit myself, for the future."
+
+"Pray don't, Lady Ruxton," said Lord Henry.  "Moderation is a fatal
+thing.  Enough is as bad as a meal.  More than enough is as good as a
+feast."
+
+Lady Ruxton glanced at him curiously.  "You must come and explain that
+to me some afternoon, Lord Henry.  It sounds a fascinating theory," she
+murmured, as she swept out of the room.
+
+"Now, mind you don't stay too long over your politics and scandal,"
+cried Lady Narborough from the door.  "If you do, we are sure to
+squabble upstairs."
+
+The men laughed, and Mr. Chapman got up solemnly from the foot of the
+table and came up to the top.  Dorian Gray changed his seat and went
+and sat by Lord Henry.  Mr. Chapman began to talk in a loud voice about
+the situation in the House of Commons.  He guffawed at his adversaries.
+The word _doctrinaire_--word full of terror to the British
+mind--reappeared from time to time between his explosions.  An
+alliterative prefix served as an ornament of oratory.  He hoisted the
+Union Jack on the pinnacles of thought.  The inherited stupidity of the
+race--sound English common sense he jovially termed it--was shown to be
+the proper bulwark for society.
+
+A smile curved Lord Henry's lips, and he turned round and looked at
+Dorian.
+
+"Are you better, my dear fellow?" he asked.  "You seemed rather out of
+sorts at dinner."
+
+"I am quite well, Harry.  I am tired.  That is all."
+
+"You were charming last night.  The little duchess is quite devoted to
+you.  She tells me she is going down to Selby."
+
+"She has promised to come on the twentieth."
+
+"Is Monmouth to be there, too?"
+
+"Oh, yes, Harry."
+
+"He bores me dreadfully, almost as much as he bores her.  She is very
+clever, too clever for a woman.  She lacks the indefinable charm of
+weakness.  It is the feet of clay that make the gold of the image
+precious.  Her feet are very pretty, but they are not feet of clay.
+White porcelain feet, if you like.  They have been through the fire,
+and what fire does not destroy, it hardens.  She has had experiences."
+
+"How long has she been married?" asked Dorian.
+
+"An eternity, she tells me.  I believe, according to the peerage, it is
+ten years, but ten years with Monmouth must have been like eternity,
+with time thrown in.  Who else is coming?"
+
+"Oh, the Willoughbys, Lord Rugby and his wife, our hostess, Geoffrey
+Clouston, the usual set.  I have asked Lord Grotrian."
+
+"I like him," said Lord Henry.  "A great many people don't, but I find
+him charming.  He atones for being occasionally somewhat overdressed by
+being always absolutely over-educated. He is a very modern type."
+
+"I don't know if he will be able to come, Harry.  He may have to go to
+Monte Carlo with his father."
+
+"Ah! what a nuisance people's people are!  Try and make him come.  By
+the way, Dorian, you ran off very early last night.  You left before
+eleven.  What did you do afterwards?  Did you go straight home?"
+
+Dorian glanced at him hurriedly and frowned.
+
+"No, Harry," he said at last, "I did not get home till nearly three."
+
+"Did you go to the club?"
+
+"Yes," he answered.  Then he bit his lip.  "No, I don't mean that.  I
+didn't go to the club.  I walked about.  I forget what I did.... How
+inquisitive you are, Harry!  You always want to know what one has been
+doing.  I always want to forget what I have been doing.  I came in at
+half-past two, if you wish to know the exact time.  I had left my
+latch-key at home, and my servant had to let me in.  If you want any
+corroborative evidence on the subject, you can ask him."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, as if I cared!
+Let us go up to the drawing-room. No sherry, thank you, Mr. Chapman.
+Something has happened to you, Dorian.  Tell me what it is.  You are
+not yourself to-night."
+
+"Don't mind me, Harry.  I am irritable, and out of temper.  I shall
+come round and see you to-morrow, or next day.  Make my excuses to Lady
+Narborough.  I shan't go upstairs.  I shall go home.  I must go home."
+
+"All right, Dorian.  I dare say I shall see you to-morrow at tea-time.
+The duchess is coming."
+
+"I will try to be there, Harry," he said, leaving the room.  As he
+drove back to his own house, he was conscious that the sense of terror
+he thought he had strangled had come back to him.  Lord Henry's casual
+questioning had made him lose his nerve for the moment, and he wanted
+his nerve still.  Things that were dangerous had to be destroyed.  He
+winced.  He hated the idea of even touching them.
+
+Yet it had to be done.  He realized that, and when he had locked the
+door of his library, he opened the secret press into which he had
+thrust Basil Hallward's coat and bag.  A huge fire was blazing.  He
+piled another log on it.  The smell of the singeing clothes and burning
+leather was horrible.  It took him three-quarters of an hour to consume
+everything.  At the end he felt faint and sick, and having lit some
+Algerian pastilles in a pierced copper brazier, he bathed his hands and
+forehead with a cool musk-scented vinegar.
+
+Suddenly he started.  His eyes grew strangely bright, and he gnawed
+nervously at his underlip.  Between two of the windows stood a large
+Florentine cabinet, made out of ebony and inlaid with ivory and blue
+lapis.  He watched it as though it were a thing that could fascinate
+and make afraid, as though it held something that he longed for and yet
+almost loathed.  His breath quickened.  A mad craving came over him.
+He lit a cigarette and then threw it away.  His eyelids drooped till
+the long fringed lashes almost touched his cheek.  But he still watched
+the cabinet.  At last he got up from the sofa on which he had been
+lying, went over to it, and having unlocked it, touched some hidden
+spring.  A triangular drawer passed slowly out.  His fingers moved
+instinctively towards it, dipped in, and closed on something.  It was a
+small Chinese box of black and gold-dust lacquer, elaborately wrought,
+the sides patterned with curved waves, and the silken cords hung with
+round crystals and tasselled in plaited metal threads.  He opened it.
+Inside was a green paste, waxy in lustre, the odour curiously heavy and
+persistent.
+
+He hesitated for some moments, with a strangely immobile smile upon his
+face.  Then shivering, though the atmosphere of the room was terribly
+hot, he drew himself up and glanced at the clock.  It was twenty
+minutes to twelve.  He put the box back, shutting the cabinet doors as
+he did so, and went into his bedroom.
+
+As midnight was striking bronze blows upon the dusky air, Dorian Gray,
+dressed commonly, and with a muffler wrapped round his throat, crept
+quietly out of his house.  In Bond Street he found a hansom with a good
+horse.  He hailed it and in a low voice gave the driver an address.
+
+The man shook his head.  "It is too far for me," he muttered.
+
+"Here is a sovereign for you," said Dorian.  "You shall have another if
+you drive fast."
+
+"All right, sir," answered the man, "you will be there in an hour," and
+after his fare had got in he turned his horse round and drove rapidly
+towards the river.
+
+
+
+CHAPTER 16
+
+A cold rain began to fall, and the blurred street-lamps looked ghastly
+in the dripping mist.  The public-houses were just closing, and dim men
+and women were clustering in broken groups round their doors.  From
+some of the bars came the sound of horrible laughter.  In others,
+drunkards brawled and screamed.
+
+Lying back in the hansom, with his hat pulled over his forehead, Dorian
+Gray watched with listless eyes the sordid shame of the great city, and
+now and then he repeated to himself the words that Lord Henry had said
+to him on the first day they had met, "To cure the soul by means of the
+senses, and the senses by means of the soul."  Yes, that was the
+secret.  He had often tried it, and would try it again now.  There were
+opium dens where one could buy oblivion, dens of horror where the
+memory of old sins could be destroyed by the madness of sins that were
+new.
+
+The moon hung low in the sky like a yellow skull.  From time to time a
+huge misshapen cloud stretched a long arm across and hid it.  The
+gas-lamps grew fewer, and the streets more narrow and gloomy.  Once the
+man lost his way and had to drive back half a mile.  A steam rose from
+the horse as it splashed up the puddles.  The sidewindows of the hansom
+were clogged with a grey-flannel mist.
+
+"To cure the soul by means of the senses, and the senses by means of
+the soul!"  How the words rang in his ears!  His soul, certainly, was
+sick to death.  Was it true that the senses could cure it?  Innocent
+blood had been spilled.  What could atone for that?  Ah! for that there
+was no atonement; but though forgiveness was impossible, forgetfulness
+was possible still, and he was determined to forget, to stamp the thing
+out, to crush it as one would crush the adder that had stung one.
+Indeed, what right had Basil to have spoken to him as he had done?  Who
+had made him a judge over others?  He had said things that were
+dreadful, horrible, not to be endured.
+
+On and on plodded the hansom, going slower, it seemed to him, at each
+step.  He thrust up the trap and called to the man to drive faster.
+The hideous hunger for opium began to gnaw at him.  His throat burned
+and his delicate hands twitched nervously together.  He struck at the
+horse madly with his stick.  The driver laughed and whipped up.  He
+laughed in answer, and the man was silent.
+
+The way seemed interminable, and the streets like the black web of some
+sprawling spider.  The monotony became unbearable, and as the mist
+thickened, he felt afraid.
+
+Then they passed by lonely brickfields.  The fog was lighter here, and
+he could see the strange, bottle-shaped kilns with their orange,
+fanlike tongues of fire.  A dog barked as they went by, and far away in
+the darkness some wandering sea-gull screamed.  The horse stumbled in a
+rut, then swerved aside and broke into a gallop.
+
+After some time they left the clay road and rattled again over
+rough-paven streets.  Most of the windows were dark, but now and then
+fantastic shadows were silhouetted against some lamplit blind.  He
+watched them curiously.  They moved like monstrous marionettes and made
+gestures like live things.  He hated them.  A dull rage was in his
+heart.  As they turned a corner, a woman yelled something at them from
+an open door, and two men ran after the hansom for about a hundred
+yards.  The driver beat at them with his whip.
+
+It is said that passion makes one think in a circle.  Certainly with
+hideous iteration the bitten lips of Dorian Gray shaped and reshaped
+those subtle words that dealt with soul and sense, till he had found in
+them the full expression, as it were, of his mood, and justified, by
+intellectual approval, passions that without such justification would
+still have dominated his temper.  From cell to cell of his brain crept
+the one thought; and the wild desire to live, most terrible of all
+man's appetites, quickened into force each trembling nerve and fibre.
+Ugliness that had once been hateful to him because it made things real,
+became dear to him now for that very reason.  Ugliness was the one
+reality.  The coarse brawl, the loathsome den, the crude violence of
+disordered life, the very vileness of thief and outcast, were more
+vivid, in their intense actuality of impression, than all the gracious
+shapes of art, the dreamy shadows of song.  They were what he needed
+for forgetfulness.  In three days he would be free.
+
+Suddenly the man drew up with a jerk at the top of a dark lane.  Over
+the low roofs and jagged chimney-stacks of the houses rose the black
+masts of ships.  Wreaths of white mist clung like ghostly sails to the
+yards.
+
+"Somewhere about here, sir, ain't it?" he asked huskily through the
+trap.
+
+Dorian started and peered round.  "This will do," he answered, and
+having got out hastily and given the driver the extra fare he had
+promised him, he walked quickly in the direction of the quay.  Here and
+there a lantern gleamed at the stern of some huge merchantman.  The
+light shook and splintered in the puddles.  A red glare came from an
+outward-bound steamer that was coaling.  The slimy pavement looked like
+a wet mackintosh.
+
+He hurried on towards the left, glancing back now and then to see if he
+was being followed.  In about seven or eight minutes he reached a small
+shabby house that was wedged in between two gaunt factories.  In one of
+the top-windows stood a lamp.  He stopped and gave a peculiar knock.
+
+After a little time he heard steps in the passage and the chain being
+unhooked.  The door opened quietly, and he went in without saying a
+word to the squat misshapen figure that flattened itself into the
+shadow as he passed.  At the end of the hall hung a tattered green
+curtain that swayed and shook in the gusty wind which had followed him
+in from the street.  He dragged it aside and entered a long low room
+which looked as if it had once been a third-rate dancing-saloon. Shrill
+flaring gas-jets, dulled and distorted in the fly-blown mirrors that
+faced them, were ranged round the walls.  Greasy reflectors of ribbed
+tin backed them, making quivering disks of light.  The floor was
+covered with ochre-coloured sawdust, trampled here and there into mud,
+and stained with dark rings of spilled liquor.  Some Malays were
+crouching by a little charcoal stove, playing with bone counters and
+showing their white teeth as they chattered.  In one corner, with his
+head buried in his arms, a sailor sprawled over a table, and by the
+tawdrily painted bar that ran across one complete side stood two
+haggard women, mocking an old man who was brushing the sleeves of his
+coat with an expression of disgust.  "He thinks he's got red ants on
+him," laughed one of them, as Dorian passed by.  The man looked at her
+in terror and began to whimper.
+
+At the end of the room there was a little staircase, leading to a
+darkened chamber.  As Dorian hurried up its three rickety steps, the
+heavy odour of opium met him.  He heaved a deep breath, and his
+nostrils quivered with pleasure.  When he entered, a young man with
+smooth yellow hair, who was bending over a lamp lighting a long thin
+pipe, looked up at him and nodded in a hesitating manner.
+
+"You here, Adrian?" muttered Dorian.
+
+"Where else should I be?" he answered, listlessly.  "None of the chaps
+will speak to me now."
+
+"I thought you had left England."
+
+"Darlington is not going to do anything.  My brother paid the bill at
+last.  George doesn't speak to me either.... I don't care," he added
+with a sigh.  "As long as one has this stuff, one doesn't want friends.
+I think I have had too many friends."
+
+Dorian winced and looked round at the grotesque things that lay in such
+fantastic postures on the ragged mattresses.  The twisted limbs, the
+gaping mouths, the staring lustreless eyes, fascinated him.  He knew in
+what strange heavens they were suffering, and what dull hells were
+teaching them the secret of some new joy.  They were better off than he
+was.  He was prisoned in thought.  Memory, like a horrible malady, was
+eating his soul away.  From time to time he seemed to see the eyes of
+Basil Hallward looking at him.  Yet he felt he could not stay.  The
+presence of Adrian Singleton troubled him.  He wanted to be where no
+one would know who he was.  He wanted to escape from himself.
+
+"I am going on to the other place," he said after a pause.
+
+"On the wharf?"
+
+"Yes."
+
+"That mad-cat is sure to be there.  They won't have her in this place
+now."
+
+Dorian shrugged his shoulders.  "I am sick of women who love one.
+Women who hate one are much more interesting.  Besides, the stuff is
+better."
+
+"Much the same."
+
+"I like it better.  Come and have something to drink.  I must have
+something."
+
+"I don't want anything," murmured the young man.
+
+"Never mind."
+
+Adrian Singleton rose up wearily and followed Dorian to the bar.  A
+half-caste, in a ragged turban and a shabby ulster, grinned a hideous
+greeting as he thrust a bottle of brandy and two tumblers in front of
+them.  The women sidled up and began to chatter.  Dorian turned his
+back on them and said something in a low voice to Adrian Singleton.
+
+A crooked smile, like a Malay crease, writhed across the face of one of
+the women.  "We are very proud to-night," she sneered.
+
+"For God's sake don't talk to me," cried Dorian, stamping his foot on
+the ground.  "What do you want?  Money?  Here it is.  Don't ever talk
+to me again."
+
+Two red sparks flashed for a moment in the woman's sodden eyes, then
+flickered out and left them dull and glazed.  She tossed her head and
+raked the coins off the counter with greedy fingers.  Her companion
+watched her enviously.
+
+"It's no use," sighed Adrian Singleton.  "I don't care to go back.
+What does it matter?  I am quite happy here."
+
+"You will write to me if you want anything, won't you?" said Dorian,
+after a pause.
+
+"Perhaps."
+
+"Good night, then."
+
+"Good night," answered the young man, passing up the steps and wiping
+his parched mouth with a handkerchief.
+
+Dorian walked to the door with a look of pain in his face.  As he drew
+the curtain aside, a hideous laugh broke from the painted lips of the
+woman who had taken his money.  "There goes the devil's bargain!" she
+hiccoughed, in a hoarse voice.
+
+"Curse you!" he answered, "don't call me that."
+
+She snapped her fingers.  "Prince Charming is what you like to be
+called, ain't it?" she yelled after him.
+
+The drowsy sailor leaped to his feet as she spoke, and looked wildly
+round.  The sound of the shutting of the hall door fell on his ear.  He
+rushed out as if in pursuit.
+
+Dorian Gray hurried along the quay through the drizzling rain.  His
+meeting with Adrian Singleton had strangely moved him, and he wondered
+if the ruin of that young life was really to be laid at his door, as
+Basil Hallward had said to him with such infamy of insult.  He bit his
+lip, and for a few seconds his eyes grew sad.  Yet, after all, what did
+it matter to him?  One's days were too brief to take the burden of
+another's errors on one's shoulders.  Each man lived his own life and
+paid his own price for living it.  The only pity was one had to pay so
+often for a single fault.  One had to pay over and over again, indeed.
+In her dealings with man, destiny never closed her accounts.
+
+There are moments, psychologists tell us, when the passion for sin, or
+for what the world calls sin, so dominates a nature that every fibre of
+the body, as every cell of the brain, seems to be instinct with fearful
+impulses.  Men and women at such moments lose the freedom of their
+will.  They move to their terrible end as automatons move.  Choice is
+taken from them, and conscience is either killed, or, if it lives at
+all, lives but to give rebellion its fascination and disobedience its
+charm.  For all sins, as theologians weary not of reminding us, are
+sins of disobedience.  When that high spirit, that morning star of
+evil, fell from heaven, it was as a rebel that he fell.
+
+Callous, concentrated on evil, with stained mind, and soul hungry for
+rebellion, Dorian Gray hastened on, quickening his step as he went, but
+as he darted aside into a dim archway, that had served him often as a
+short cut to the ill-famed place where he was going, he felt himself
+suddenly seized from behind, and before he had time to defend himself,
+he was thrust back against the wall, with a brutal hand round his
+throat.
+
+He struggled madly for life, and by a terrible effort wrenched the
+tightening fingers away.  In a second he heard the click of a revolver,
+and saw the gleam of a polished barrel, pointing straight at his head,
+and the dusky form of a short, thick-set man facing him.
+
+"What do you want?" he gasped.
+
+"Keep quiet," said the man.  "If you stir, I shoot you."
+
+"You are mad.  What have I done to you?"
+
+"You wrecked the life of Sibyl Vane," was the answer, "and Sibyl Vane
+was my sister.  She killed herself.  I know it.  Her death is at your
+door.  I swore I would kill you in return.  For years I have sought
+you.  I had no clue, no trace.  The two people who could have described
+you were dead.  I knew nothing of you but the pet name she used to call
+you.  I heard it to-night by chance.  Make your peace with God, for
+to-night you are going to die."
+
+Dorian Gray grew sick with fear.  "I never knew her," he stammered.  "I
+never heard of her.  You are mad."
+
+"You had better confess your sin, for as sure as I am James Vane, you
+are going to die."  There was a horrible moment.  Dorian did not know
+what to say or do.  "Down on your knees!" growled the man.  "I give you
+one minute to make your peace--no more.  I go on board to-night for
+India, and I must do my job first.  One minute.  That's all."
+
+Dorian's arms fell to his side.  Paralysed with terror, he did not know
+what to do.  Suddenly a wild hope flashed across his brain.  "Stop," he
+cried.  "How long ago is it since your sister died?  Quick, tell me!"
+
+"Eighteen years," said the man.  "Why do you ask me?  What do years
+matter?"
+
+"Eighteen years," laughed Dorian Gray, with a touch of triumph in his
+voice.  "Eighteen years!  Set me under the lamp and look at my face!"
+
+James Vane hesitated for a moment, not understanding what was meant.
+Then he seized Dorian Gray and dragged him from the archway.
+
+Dim and wavering as was the wind-blown light, yet it served to show him
+the hideous error, as it seemed, into which he had fallen, for the face
+of the man he had sought to kill had all the bloom of boyhood, all the
+unstained purity of youth.  He seemed little more than a lad of twenty
+summers, hardly older, if older indeed at all, than his sister had been
+when they had parted so many years ago.  It was obvious that this was
+not the man who had destroyed her life.
+
+He loosened his hold and reeled back.  "My God! my God!" he cried, "and
+I would have murdered you!"
+
+Dorian Gray drew a long breath.  "You have been on the brink of
+committing a terrible crime, my man," he said, looking at him sternly.
+"Let this be a warning to you not to take vengeance into your own
+hands."
+
+"Forgive me, sir," muttered James Vane.  "I was deceived.  A chance
+word I heard in that damned den set me on the wrong track."
+
+"You had better go home and put that pistol away, or you may get into
+trouble," said Dorian, turning on his heel and going slowly down the
+street.
+
+James Vane stood on the pavement in horror.  He was trembling from head
+to foot.  After a little while, a black shadow that had been creeping
+along the dripping wall moved out into the light and came close to him
+with stealthy footsteps.  He felt a hand laid on his arm and looked
+round with a start.  It was one of the women who had been drinking at
+the bar.
+
+"Why didn't you kill him?" she hissed out, putting haggard face quite
+close to his.  "I knew you were following him when you rushed out from
+Daly's. You fool!  You should have killed him.  He has lots of money,
+and he's as bad as bad."
+
+"He is not the man I am looking for," he answered, "and I want no man's
+money.  I want a man's life.  The man whose life I want must be nearly
+forty now.  This one is little more than a boy.  Thank God, I have not
+got his blood upon my hands."
+
+The woman gave a bitter laugh.  "Little more than a boy!" she sneered.
+"Why, man, it's nigh on eighteen years since Prince Charming made me
+what I am."
+
+"You lie!" cried James Vane.
+
+She raised her hand up to heaven.  "Before God I am telling the truth,"
+she cried.
+
+"Before God?"
+
+"Strike me dumb if it ain't so.  He is the worst one that comes here.
+They say he has sold himself to the devil for a pretty face.  It's nigh
+on eighteen years since I met him.  He hasn't changed much since then.
+I have, though," she added, with a sickly leer.
+
+"You swear this?"
+
+"I swear it," came in hoarse echo from her flat mouth.  "But don't give
+me away to him," she whined; "I am afraid of him.  Let me have some
+money for my night's lodging."
+
+He broke from her with an oath and rushed to the corner of the street,
+but Dorian Gray had disappeared.  When he looked back, the woman had
+vanished also.
+
+
+
+CHAPTER 17
+
+A week later Dorian Gray was sitting in the conservatory at Selby
+Royal, talking to the pretty Duchess of Monmouth, who with her husband,
+a jaded-looking man of sixty, was amongst his guests.  It was tea-time,
+and the mellow light of the huge, lace-covered lamp that stood on the
+table lit up the delicate china and hammered silver of the service at
+which the duchess was presiding.  Her white hands were moving daintily
+among the cups, and her full red lips were smiling at something that
+Dorian had whispered to her.  Lord Henry was lying back in a
+silk-draped wicker chair, looking at them.  On a peach-coloured divan
+sat Lady Narborough, pretending to listen to the duke's description of
+the last Brazilian beetle that he had added to his collection.  Three
+young men in elaborate smoking-suits were handing tea-cakes to some of
+the women.  The house-party consisted of twelve people, and there were
+more expected to arrive on the next day.
+
+"What are you two talking about?" said Lord Henry, strolling over to
+the table and putting his cup down.  "I hope Dorian has told you about
+my plan for rechristening everything, Gladys.  It is a delightful idea."
+
+"But I don't want to be rechristened, Harry," rejoined the duchess,
+looking up at him with her wonderful eyes.  "I am quite satisfied with
+my own name, and I am sure Mr. Gray should be satisfied with his."
+
+"My dear Gladys, I would not alter either name for the world.  They are
+both perfect.  I was thinking chiefly of flowers.  Yesterday I cut an
+orchid, for my button-hole. It was a marvellous spotted thing, as
+effective as the seven deadly sins.  In a thoughtless moment I asked
+one of the gardeners what it was called.  He told me it was a fine
+specimen of _Robinsoniana_, or something dreadful of that kind.  It is a
+sad truth, but we have lost the faculty of giving lovely names to
+things.  Names are everything.  I never quarrel with actions.  My one
+quarrel is with words.  That is the reason I hate vulgar realism in
+literature.  The man who could call a spade a spade should be compelled
+to use one.  It is the only thing he is fit for."
+
+"Then what should we call you, Harry?" she asked.
+
+"His name is Prince Paradox," said Dorian.
+
+"I recognize him in a flash," exclaimed the duchess.
+
+"I won't hear of it," laughed Lord Henry, sinking into a chair.  "From
+a label there is no escape!  I refuse the title."
+
+"Royalties may not abdicate," fell as a warning from pretty lips.
+
+"You wish me to defend my throne, then?"
+
+"Yes."
+
+"I give the truths of to-morrow."
+
+"I prefer the mistakes of to-day," she answered.
+
+"You disarm me, Gladys," he cried, catching the wilfulness of her mood.
+
+"Of your shield, Harry, not of your spear."
+
+"I never tilt against beauty," he said, with a wave of his hand.
+
+"That is your error, Harry, believe me.  You value beauty far too much."
+
+"How can you say that?  I admit that I think that it is better to be
+beautiful than to be good.  But on the other hand, no one is more ready
+than I am to acknowledge that it is better to be good than to be ugly."
+
+"Ugliness is one of the seven deadly sins, then?" cried the duchess.
+"What becomes of your simile about the orchid?"
+
+"Ugliness is one of the seven deadly virtues, Gladys.  You, as a good
+Tory, must not underrate them.  Beer, the Bible, and the seven deadly
+virtues have made our England what she is."
+
+"You don't like your country, then?" she asked.
+
+"I live in it."
+
+"That you may censure it the better."
+
+"Would you have me take the verdict of Europe on it?" he inquired.
+
+"What do they say of us?"
+
+"That Tartuffe has emigrated to England and opened a shop."
+
+"Is that yours, Harry?"
+
+"I give it to you."
+
+"I could not use it.  It is too true."
+
+"You need not be afraid.  Our countrymen never recognize a description."
+
+"They are practical."
+
+"They are more cunning than practical.  When they make up their ledger,
+they balance stupidity by wealth, and vice by hypocrisy."
+
+"Still, we have done great things."
+
+"Great things have been thrust on us, Gladys."
+
+"We have carried their burden."
+
+"Only as far as the Stock Exchange."
+
+She shook her head.  "I believe in the race," she cried.
+
+"It represents the survival of the pushing."
+
+"It has development."
+
+"Decay fascinates me more."
+
+"What of art?" she asked.
+
+"It is a malady."
+
+"Love?"
+
+"An illusion."
+
+"Religion?"
+
+"The fashionable substitute for belief."
+
+"You are a sceptic."
+
+"Never!  Scepticism is the beginning of faith."
+
+"What are you?"
+
+"To define is to limit."
+
+"Give me a clue."
+
+"Threads snap.  You would lose your way in the labyrinth."
+
+"You bewilder me.  Let us talk of some one else."
+
+"Our host is a delightful topic.  Years ago he was christened Prince
+Charming."
+
+"Ah! don't remind me of that," cried Dorian Gray.
+
+"Our host is rather horrid this evening," answered the duchess,
+colouring.  "I believe he thinks that Monmouth married me on purely
+scientific principles as the best specimen he could find of a modern
+butterfly."
+
+"Well, I hope he won't stick pins into you, Duchess," laughed Dorian.
+
+"Oh! my maid does that already, Mr. Gray, when she is annoyed with me."
+
+"And what does she get annoyed with you about, Duchess?"
+
+"For the most trivial things, Mr. Gray, I assure you.  Usually because
+I come in at ten minutes to nine and tell her that I must be dressed by
+half-past eight."
+
+"How unreasonable of her!  You should give her warning."
+
+"I daren't, Mr. Gray.  Why, she invents hats for me.  You remember the
+one I wore at Lady Hilstone's garden-party?  You don't, but it is nice
+of you to pretend that you do.  Well, she made it out of nothing.  All
+good hats are made out of nothing."
+
+"Like all good reputations, Gladys," interrupted Lord Henry.  "Every
+effect that one produces gives one an enemy.  To be popular one must be
+a mediocrity."
+
+"Not with women," said the duchess, shaking her head; "and women rule
+the world.  I assure you we can't bear mediocrities.  We women, as some
+one says, love with our ears, just as you men love with your eyes, if
+you ever love at all."
+
+"It seems to me that we never do anything else," murmured Dorian.
+
+"Ah! then, you never really love, Mr. Gray," answered the duchess with
+mock sadness.
+
+"My dear Gladys!" cried Lord Henry.  "How can you say that?  Romance
+lives by repetition, and repetition converts an appetite into an art.
+Besides, each time that one loves is the only time one has ever loved.
+Difference of object does not alter singleness of passion.  It merely
+intensifies it.  We can have in life but one great experience at best,
+and the secret of life is to reproduce that experience as often as
+possible."
+
+"Even when one has been wounded by it, Harry?" asked the duchess after
+a pause.
+
+"Especially when one has been wounded by it," answered Lord Henry.
+
+The duchess turned and looked at Dorian Gray with a curious expression
+in her eyes.  "What do you say to that, Mr. Gray?" she inquired.
+
+Dorian hesitated for a moment.  Then he threw his head back and
+laughed.  "I always agree with Harry, Duchess."
+
+"Even when he is wrong?"
+
+"Harry is never wrong, Duchess."
+
+"And does his philosophy make you happy?"
+
+"I have never searched for happiness.  Who wants happiness?  I have
+searched for pleasure."
+
+"And found it, Mr. Gray?"
+
+"Often.  Too often."
+
+The duchess sighed.  "I am searching for peace," she said, "and if I
+don't go and dress, I shall have none this evening."
+
+"Let me get you some orchids, Duchess," cried Dorian, starting to his
+feet and walking down the conservatory.
+
+"You are flirting disgracefully with him," said Lord Henry to his
+cousin.  "You had better take care.  He is very fascinating."
+
+"If he were not, there would be no battle."
+
+"Greek meets Greek, then?"
+
+"I am on the side of the Trojans.  They fought for a woman."
+
+"They were defeated."
+
+"There are worse things than capture," she answered.
+
+"You gallop with a loose rein."
+
+"Pace gives life," was the _riposte_.
+
+"I shall write it in my diary to-night."
+
+"What?"
+
+"That a burnt child loves the fire."
+
+"I am not even singed.  My wings are untouched."
+
+"You use them for everything, except flight."
+
+"Courage has passed from men to women.  It is a new experience for us."
+
+"You have a rival."
+
+"Who?"
+
+He laughed.  "Lady Narborough," he whispered.  "She perfectly adores
+him."
+
+"You fill me with apprehension.  The appeal to antiquity is fatal to us
+who are romanticists."
+
+"Romanticists!  You have all the methods of science."
+
+"Men have educated us."
+
+"But not explained you."
+
+"Describe us as a sex," was her challenge.
+
+"Sphinxes without secrets."
+
+She looked at him, smiling.  "How long Mr. Gray is!" she said.  "Let us
+go and help him.  I have not yet told him the colour of my frock."
+
+"Ah! you must suit your frock to his flowers, Gladys."
+
+"That would be a premature surrender."
+
+"Romantic art begins with its climax."
+
+"I must keep an opportunity for retreat."
+
+"In the Parthian manner?"
+
+"They found safety in the desert.  I could not do that."
+
+"Women are not always allowed a choice," he answered, but hardly had he
+finished the sentence before from the far end of the conservatory came
+a stifled groan, followed by the dull sound of a heavy fall.  Everybody
+started up.  The duchess stood motionless in horror.  And with fear in
+his eyes, Lord Henry rushed through the flapping palms to find Dorian
+Gray lying face downwards on the tiled floor in a deathlike swoon.
+
+He was carried at once into the blue drawing-room and laid upon one of
+the sofas.  After a short time, he came to himself and looked round
+with a dazed expression.
+
+"What has happened?" he asked.  "Oh!  I remember.  Am I safe here,
+Harry?" He began to tremble.
+
+"My dear Dorian," answered Lord Henry, "you merely fainted.  That was
+all.  You must have overtired yourself.  You had better not come down
+to dinner.  I will take your place."
+
+"No, I will come down," he said, struggling to his feet.  "I would
+rather come down.  I must not be alone."
+
+He went to his room and dressed.  There was a wild recklessness of
+gaiety in his manner as he sat at table, but now and then a thrill of
+terror ran through him when he remembered that, pressed against the
+window of the conservatory, like a white handkerchief, he had seen the
+face of James Vane watching him.
+
+
+
+CHAPTER 18
+
+The next day he did not leave the house, and, indeed, spent most of the
+time in his own room, sick with a wild terror of dying, and yet
+indifferent to life itself.  The consciousness of being hunted, snared,
+tracked down, had begun to dominate him.  If the tapestry did but
+tremble in the wind, he shook.  The dead leaves that were blown against
+the leaded panes seemed to him like his own wasted resolutions and wild
+regrets.  When he closed his eyes, he saw again the sailor's face
+peering through the mist-stained glass, and horror seemed once more to
+lay its hand upon his heart.
+
+But perhaps it had been only his fancy that had called vengeance out of
+the night and set the hideous shapes of punishment before him.  Actual
+life was chaos, but there was something terribly logical in the
+imagination.  It was the imagination that set remorse to dog the feet
+of sin.  It was the imagination that made each crime bear its misshapen
+brood.  In the common world of fact the wicked were not punished, nor
+the good rewarded.  Success was given to the strong, failure thrust
+upon the weak.  That was all.  Besides, had any stranger been prowling
+round the house, he would have been seen by the servants or the
+keepers.  Had any foot-marks been found on the flower-beds, the
+gardeners would have reported it.  Yes, it had been merely fancy.
+Sibyl Vane's brother had not come back to kill him.  He had sailed away
+in his ship to founder in some winter sea.  From him, at any rate, he
+was safe.  Why, the man did not know who he was, could not know who he
+was.  The mask of youth had saved him.
+
+And yet if it had been merely an illusion, how terrible it was to think
+that conscience could raise such fearful phantoms, and give them
+visible form, and make them move before one!  What sort of life would
+his be if, day and night, shadows of his crime were to peer at him from
+silent corners, to mock him from secret places, to whisper in his ear
+as he sat at the feast, to wake him with icy fingers as he lay asleep!
+As the thought crept through his brain, he grew pale with terror, and
+the air seemed to him to have become suddenly colder.  Oh! in what a
+wild hour of madness he had killed his friend!  How ghastly the mere
+memory of the scene!  He saw it all again.  Each hideous detail came
+back to him with added horror.  Out of the black cave of time, terrible
+and swathed in scarlet, rose the image of his sin.  When Lord Henry
+came in at six o'clock, he found him crying as one whose heart will
+break.
+
+It was not till the third day that he ventured to go out.  There was
+something in the clear, pine-scented air of that winter morning that
+seemed to bring him back his joyousness and his ardour for life.  But
+it was not merely the physical conditions of environment that had
+caused the change.  His own nature had revolted against the excess of
+anguish that had sought to maim and mar the perfection of its calm.
+With subtle and finely wrought temperaments it is always so.  Their
+strong passions must either bruise or bend.  They either slay the man,
+or themselves die.  Shallow sorrows and shallow loves live on.  The
+loves and sorrows that are great are destroyed by their own plenitude.
+Besides, he had convinced himself that he had been the victim of a
+terror-stricken imagination, and looked back now on his fears with
+something of pity and not a little of contempt.
+
+After breakfast, he walked with the duchess for an hour in the garden
+and then drove across the park to join the shooting-party. The crisp
+frost lay like salt upon the grass.  The sky was an inverted cup of
+blue metal.  A thin film of ice bordered the flat, reed-grown lake.
+
+At the corner of the pine-wood he caught sight of Sir Geoffrey
+Clouston, the duchess's brother, jerking two spent cartridges out of
+his gun.  He jumped from the cart, and having told the groom to take
+the mare home, made his way towards his guest through the withered
+bracken and rough undergrowth.
+
+"Have you had good sport, Geoffrey?" he asked.
+
+"Not very good, Dorian.  I think most of the birds have gone to the
+open.  I dare say it will be better after lunch, when we get to new
+ground."
+
+Dorian strolled along by his side.  The keen aromatic air, the brown
+and red lights that glimmered in the wood, the hoarse cries of the
+beaters ringing out from time to time, and the sharp snaps of the guns
+that followed, fascinated him and filled him with a sense of delightful
+freedom.  He was dominated by the carelessness of happiness, by the
+high indifference of joy.
+
+Suddenly from a lumpy tussock of old grass some twenty yards in front
+of them, with black-tipped ears erect and long hinder limbs throwing it
+forward, started a hare.  It bolted for a thicket of alders.  Sir
+Geoffrey put his gun to his shoulder, but there was something in the
+animal's grace of movement that strangely charmed Dorian Gray, and he
+cried out at once, "Don't shoot it, Geoffrey.  Let it live."
+
+"What nonsense, Dorian!" laughed his companion, and as the hare bounded
+into the thicket, he fired.  There were two cries heard, the cry of a
+hare in pain, which is dreadful, the cry of a man in agony, which is
+worse.
+
+"Good heavens!  I have hit a beater!" exclaimed Sir Geoffrey.  "What an
+ass the man was to get in front of the guns!  Stop shooting there!" he
+called out at the top of his voice.  "A man is hurt."
+
+The head-keeper came running up with a stick in his hand.
+
+"Where, sir?  Where is he?" he shouted.  At the same time, the firing
+ceased along the line.
+
+"Here," answered Sir Geoffrey angrily, hurrying towards the thicket.
+"Why on earth don't you keep your men back?  Spoiled my shooting for
+the day."
+
+Dorian watched them as they plunged into the alder-clump, brushing the
+lithe swinging branches aside.  In a few moments they emerged, dragging
+a body after them into the sunlight.  He turned away in horror.  It
+seemed to him that misfortune followed wherever he went.  He heard Sir
+Geoffrey ask if the man was really dead, and the affirmative answer of
+the keeper.  The wood seemed to him to have become suddenly alive with
+faces.  There was the trampling of myriad feet and the low buzz of
+voices.  A great copper-breasted pheasant came beating through the
+boughs overhead.
+
+After a few moments--that were to him, in his perturbed state, like
+endless hours of pain--he felt a hand laid on his shoulder.  He started
+and looked round.
+
+"Dorian," said Lord Henry, "I had better tell them that the shooting is
+stopped for to-day. It would not look well to go on."
+
+"I wish it were stopped for ever, Harry," he answered bitterly.  "The
+whole thing is hideous and cruel.  Is the man ...?"
+
+He could not finish the sentence.
+
+"I am afraid so," rejoined Lord Henry.  "He got the whole charge of
+shot in his chest.  He must have died almost instantaneously.  Come;
+let us go home."
+
+They walked side by side in the direction of the avenue for nearly
+fifty yards without speaking.  Then Dorian looked at Lord Henry and
+said, with a heavy sigh, "It is a bad omen, Harry, a very bad omen."
+
+"What is?" asked Lord Henry.  "Oh! this accident, I suppose.  My dear
+fellow, it can't be helped.  It was the man's own fault.  Why did he
+get in front of the guns?  Besides, it is nothing to us.  It is rather
+awkward for Geoffrey, of course.  It does not do to pepper beaters.  It
+makes people think that one is a wild shot.  And Geoffrey is not; he
+shoots very straight.  But there is no use talking about the matter."
+
+Dorian shook his head.  "It is a bad omen, Harry.  I feel as if
+something horrible were going to happen to some of us.  To myself,
+perhaps," he added, passing his hand over his eyes, with a gesture of
+pain.
+
+The elder man laughed.  "The only horrible thing in the world is _ennui_,
+Dorian.  That is the one sin for which there is no forgiveness.  But we
+are not likely to suffer from it unless these fellows keep chattering
+about this thing at dinner.  I must tell them that the subject is to be
+tabooed.  As for omens, there is no such thing as an omen.  Destiny
+does not send us heralds.  She is too wise or too cruel for that.
+Besides, what on earth could happen to you, Dorian?  You have
+everything in the world that a man can want.  There is no one who would
+not be delighted to change places with you."
+
+"There is no one with whom I would not change places, Harry.  Don't
+laugh like that.  I am telling you the truth.  The wretched peasant who
+has just died is better off than I am.  I have no terror of death.  It
+is the coming of death that terrifies me.  Its monstrous wings seem to
+wheel in the leaden air around me.  Good heavens! don't you see a man
+moving behind the trees there, watching me, waiting for me?"
+
+Lord Henry looked in the direction in which the trembling gloved hand
+was pointing.  "Yes," he said, smiling, "I see the gardener waiting for
+you.  I suppose he wants to ask you what flowers you wish to have on
+the table to-night. How absurdly nervous you are, my dear fellow!  You
+must come and see my doctor, when we get back to town."
+
+Dorian heaved a sigh of relief as he saw the gardener approaching.  The
+man touched his hat, glanced for a moment at Lord Henry in a hesitating
+manner, and then produced a letter, which he handed to his master.
+"Her Grace told me to wait for an answer," he murmured.
+
+Dorian put the letter into his pocket.  "Tell her Grace that I am
+coming in," he said, coldly.  The man turned round and went rapidly in
+the direction of the house.
+
+"How fond women are of doing dangerous things!" laughed Lord Henry.
+"It is one of the qualities in them that I admire most.  A woman will
+flirt with anybody in the world as long as other people are looking on."
+
+"How fond you are of saying dangerous things, Harry!  In the present
+instance, you are quite astray.  I like the duchess very much, but I
+don't love her."
+
+"And the duchess loves you very much, but she likes you less, so you
+are excellently matched."
+
+"You are talking scandal, Harry, and there is never any basis for
+scandal."
+
+"The basis of every scandal is an immoral certainty," said Lord Henry,
+lighting a cigarette.
+
+"You would sacrifice anybody, Harry, for the sake of an epigram."
+
+"The world goes to the altar of its own accord," was the answer.
+
+"I wish I could love," cried Dorian Gray with a deep note of pathos in
+his voice.  "But I seem to have lost the passion and forgotten the
+desire.  I am too much concentrated on myself.  My own personality has
+become a burden to me.  I want to escape, to go away, to forget.  It
+was silly of me to come down here at all.  I think I shall send a wire
+to Harvey to have the yacht got ready.  On a yacht one is safe."
+
+"Safe from what, Dorian?  You are in some trouble.  Why not tell me
+what it is?  You know I would help you."
+
+"I can't tell you, Harry," he answered sadly.  "And I dare say it is
+only a fancy of mine.  This unfortunate accident has upset me.  I have
+a horrible presentiment that something of the kind may happen to me."
+
+"What nonsense!"
+
+"I hope it is, but I can't help feeling it.  Ah! here is the duchess,
+looking like Artemis in a tailor-made gown.  You see we have come back,
+Duchess."
+
+"I have heard all about it, Mr. Gray," she answered.  "Poor Geoffrey is
+terribly upset.  And it seems that you asked him not to shoot the hare.
+How curious!"
+
+"Yes, it was very curious.  I don't know what made me say it.  Some
+whim, I suppose.  It looked the loveliest of little live things.  But I
+am sorry they told you about the man.  It is a hideous subject."
+
+"It is an annoying subject," broke in Lord Henry.  "It has no
+psychological value at all.  Now if Geoffrey had done the thing on
+purpose, how interesting he would be!  I should like to know some one
+who had committed a real murder."
+
+"How horrid of you, Harry!" cried the duchess.  "Isn't it, Mr. Gray?
+Harry, Mr. Gray is ill again.  He is going to faint."
+
+Dorian drew himself up with an effort and smiled.  "It is nothing,
+Duchess," he murmured; "my nerves are dreadfully out of order.  That is
+all.  I am afraid I walked too far this morning.  I didn't hear what
+Harry said.  Was it very bad?  You must tell me some other time.  I
+think I must go and lie down.  You will excuse me, won't you?"
+
+They had reached the great flight of steps that led from the
+conservatory on to the terrace.  As the glass door closed behind
+Dorian, Lord Henry turned and looked at the duchess with his slumberous
+eyes.  "Are you very much in love with him?" he asked.
+
+She did not answer for some time, but stood gazing at the landscape.
+"I wish I knew," she said at last.
+
+He shook his head.  "Knowledge would be fatal.  It is the uncertainty
+that charms one.  A mist makes things wonderful."
+
+"One may lose one's way."
+
+"All ways end at the same point, my dear Gladys."
+
+"What is that?"
+
+"Disillusion."
+
+"It was my _debut_ in life," she sighed.
+
+"It came to you crowned."
+
+"I am tired of strawberry leaves."
+
+"They become you."
+
+"Only in public."
+
+"You would miss them," said Lord Henry.
+
+"I will not part with a petal."
+
+"Monmouth has ears."
+
+"Old age is dull of hearing."
+
+"Has he never been jealous?"
+
+"I wish he had been."
+
+He glanced about as if in search of something.  "What are you looking
+for?" she inquired.
+
+"The button from your foil," he answered.  "You have dropped it."
+
+She laughed.  "I have still the mask."
+
+"It makes your eyes lovelier," was his reply.
+
+She laughed again.  Her teeth showed like white seeds in a scarlet
+fruit.
+
+Upstairs, in his own room, Dorian Gray was lying on a sofa, with terror
+in every tingling fibre of his body.  Life had suddenly become too
+hideous a burden for him to bear.  The dreadful death of the unlucky
+beater, shot in the thicket like a wild animal, had seemed to him to
+pre-figure death for himself also.  He had nearly swooned at what Lord
+Henry had said in a chance mood of cynical jesting.
+
+At five o'clock he rang his bell for his servant and gave him orders to
+pack his things for the night-express to town, and to have the brougham
+at the door by eight-thirty. He was determined not to sleep another
+night at Selby Royal.  It was an ill-omened place.  Death walked there
+in the sunlight.  The grass of the forest had been spotted with blood.
+
+Then he wrote a note to Lord Henry, telling him that he was going up to
+town to consult his doctor and asking him to entertain his guests in
+his absence.  As he was putting it into the envelope, a knock came to
+the door, and his valet informed him that the head-keeper wished to see
+him.  He frowned and bit his lip.  "Send him in," he muttered, after
+some moments' hesitation.
+
+As soon as the man entered, Dorian pulled his chequebook out of a
+drawer and spread it out before him.
+
+"I suppose you have come about the unfortunate accident of this
+morning, Thornton?" he said, taking up a pen.
+
+"Yes, sir," answered the gamekeeper.
+
+"Was the poor fellow married?  Had he any people dependent on him?"
+asked Dorian, looking bored.  "If so, I should not like them to be left
+in want, and will send them any sum of money you may think necessary."
+
+"We don't know who he is, sir.  That is what I took the liberty of
+coming to you about."
+
+"Don't know who he is?" said Dorian, listlessly.  "What do you mean?
+Wasn't he one of your men?"
+
+"No, sir.  Never saw him before.  Seems like a sailor, sir."
+
+The pen dropped from Dorian Gray's hand, and he felt as if his heart
+had suddenly stopped beating.  "A sailor?" he cried out.  "Did you say
+a sailor?"
+
+"Yes, sir.  He looks as if he had been a sort of sailor; tattooed on
+both arms, and that kind of thing."
+
+"Was there anything found on him?" said Dorian, leaning forward and
+looking at the man with startled eyes.  "Anything that would tell his
+name?"
+
+"Some money, sir--not much, and a six-shooter. There was no name of any
+kind.  A decent-looking man, sir, but rough-like. A sort of sailor we
+think."
+
+Dorian started to his feet.  A terrible hope fluttered past him.  He
+clutched at it madly.  "Where is the body?" he exclaimed.  "Quick!  I
+must see it at once."
+
+"It is in an empty stable in the Home Farm, sir.  The folk don't like
+to have that sort of thing in their houses.  They say a corpse brings
+bad luck."
+
+"The Home Farm!  Go there at once and meet me.  Tell one of the grooms
+to bring my horse round.  No. Never mind.  I'll go to the stables
+myself.  It will save time."
+
+In less than a quarter of an hour, Dorian Gray was galloping down the
+long avenue as hard as he could go.  The trees seemed to sweep past him
+in spectral procession, and wild shadows to fling themselves across his
+path.  Once the mare swerved at a white gate-post and nearly threw him.
+He lashed her across the neck with his crop.  She cleft the dusky air
+like an arrow.  The stones flew from her hoofs.
+
+At last he reached the Home Farm.  Two men were loitering in the yard.
+He leaped from the saddle and threw the reins to one of them.  In the
+farthest stable a light was glimmering.  Something seemed to tell him
+that the body was there, and he hurried to the door and put his hand
+upon the latch.
+
+There he paused for a moment, feeling that he was on the brink of a
+discovery that would either make or mar his life.  Then he thrust the
+door open and entered.
+
+On a heap of sacking in the far corner was lying the dead body of a man
+dressed in a coarse shirt and a pair of blue trousers.  A spotted
+handkerchief had been placed over the face.  A coarse candle, stuck in
+a bottle, sputtered beside it.
+
+Dorian Gray shuddered.  He felt that his could not be the hand to take
+the handkerchief away, and called out to one of the farm-servants to
+come to him.
+
+"Take that thing off the face.  I wish to see it," he said, clutching
+at the door-post for support.
+
+When the farm-servant had done so, he stepped forward.  A cry of joy
+broke from his lips.  The man who had been shot in the thicket was
+James Vane.
+
+He stood there for some minutes looking at the dead body.  As he rode
+home, his eyes were full of tears, for he knew he was safe.
+
+
+
+CHAPTER 19
+
+"There is no use your telling me that you are going to be good," cried
+Lord Henry, dipping his white fingers into a red copper bowl filled
+with rose-water. "You are quite perfect.  Pray, don't change."
+
+Dorian Gray shook his head.  "No, Harry, I have done too many dreadful
+things in my life.  I am not going to do any more.  I began my good
+actions yesterday."
+
+"Where were you yesterday?"
+
+"In the country, Harry.  I was staying at a little inn by myself."
+
+"My dear boy," said Lord Henry, smiling, "anybody can be good in the
+country.  There are no temptations there.  That is the reason why
+people who live out of town are so absolutely uncivilized.
+Civilization is not by any means an easy thing to attain to.  There are
+only two ways by which man can reach it.  One is by being cultured, the
+other by being corrupt.  Country people have no opportunity of being
+either, so they stagnate."
+
+"Culture and corruption," echoed Dorian.  "I have known something of
+both.  It seems terrible to me now that they should ever be found
+together.  For I have a new ideal, Harry.  I am going to alter.  I
+think I have altered."
+
+"You have not yet told me what your good action was.  Or did you say
+you had done more than one?" asked his companion as he spilled into his
+plate a little crimson pyramid of seeded strawberries and, through a
+perforated, shell-shaped spoon, snowed white sugar upon them.
+
+"I can tell you, Harry.  It is not a story I could tell to any one
+else.  I spared somebody.  It sounds vain, but you understand what I
+mean.  She was quite beautiful and wonderfully like Sibyl Vane.  I
+think it was that which first attracted me to her.  You remember Sibyl,
+don't you?  How long ago that seems!  Well, Hetty was not one of our
+own class, of course.  She was simply a girl in a village.  But I
+really loved her.  I am quite sure that I loved her.  All during this
+wonderful May that we have been having, I used to run down and see her
+two or three times a week.  Yesterday she met me in a little orchard.
+The apple-blossoms kept tumbling down on her hair, and she was
+laughing.  We were to have gone away together this morning at dawn.
+Suddenly I determined to leave her as flowerlike as I had found her."
+
+"I should think the novelty of the emotion must have given you a thrill
+of real pleasure, Dorian," interrupted Lord Henry.  "But I can finish
+your idyll for you.  You gave her good advice and broke her heart.
+That was the beginning of your reformation."
+
+"Harry, you are horrible!  You mustn't say these dreadful things.
+Hetty's heart is not broken.  Of course, she cried and all that.  But
+there is no disgrace upon her.  She can live, like Perdita, in her
+garden of mint and marigold."
+
+"And weep over a faithless Florizel," said Lord Henry, laughing, as he
+leaned back in his chair.  "My dear Dorian, you have the most curiously
+boyish moods.  Do you think this girl will ever be really content now
+with any one of her own rank?  I suppose she will be married some day
+to a rough carter or a grinning ploughman.  Well, the fact of having
+met you, and loved you, will teach her to despise her husband, and she
+will be wretched.  From a moral point of view, I cannot say that I
+think much of your great renunciation.  Even as a beginning, it is
+poor.  Besides, how do you know that Hetty isn't floating at the
+present moment in some starlit mill-pond, with lovely water-lilies
+round her, like Ophelia?"
+
+"I can't bear this, Harry!  You mock at everything, and then suggest
+the most serious tragedies.  I am sorry I told you now.  I don't care
+what you say to me.  I know I was right in acting as I did.  Poor
+Hetty!  As I rode past the farm this morning, I saw her white face at
+the window, like a spray of jasmine.  Don't let us talk about it any
+more, and don't try to persuade me that the first good action I have
+done for years, the first little bit of self-sacrifice I have ever
+known, is really a sort of sin.  I want to be better.  I am going to be
+better.  Tell me something about yourself.  What is going on in town?
+I have not been to the club for days."
+
+"The people are still discussing poor Basil's disappearance."
+
+"I should have thought they had got tired of that by this time," said
+Dorian, pouring himself out some wine and frowning slightly.
+
+"My dear boy, they have only been talking about it for six weeks, and
+the British public are really not equal to the mental strain of having
+more than one topic every three months.  They have been very fortunate
+lately, however.  They have had my own divorce-case and Alan Campbell's
+suicide.  Now they have got the mysterious disappearance of an artist.
+Scotland Yard still insists that the man in the grey ulster who left
+for Paris by the midnight train on the ninth of November was poor
+Basil, and the French police declare that Basil never arrived in Paris
+at all.  I suppose in about a fortnight we shall be told that he has
+been seen in San Francisco.  It is an odd thing, but every one who
+disappears is said to be seen at San Francisco.  It must be a
+delightful city, and possess all the attractions of the next world."
+
+"What do you think has happened to Basil?" asked Dorian, holding up his
+Burgundy against the light and wondering how it was that he could
+discuss the matter so calmly.
+
+"I have not the slightest idea.  If Basil chooses to hide himself, it
+is no business of mine.  If he is dead, I don't want to think about
+him.  Death is the only thing that ever terrifies me.  I hate it."
+
+"Why?" said the younger man wearily.
+
+"Because," said Lord Henry, passing beneath his nostrils the gilt
+trellis of an open vinaigrette box, "one can survive everything
+nowadays except that.  Death and vulgarity are the only two facts in
+the nineteenth century that one cannot explain away.  Let us have our
+coffee in the music-room, Dorian.  You must play Chopin to me.  The man
+with whom my wife ran away played Chopin exquisitely.  Poor Victoria!
+I was very fond of her.  The house is rather lonely without her.  Of
+course, married life is merely a habit, a bad habit.  But then one
+regrets the loss even of one's worst habits.  Perhaps one regrets them
+the most.  They are such an essential part of one's personality."
+
+Dorian said nothing, but rose from the table, and passing into the next
+room, sat down to the piano and let his fingers stray across the white
+and black ivory of the keys.  After the coffee had been brought in, he
+stopped, and looking over at Lord Henry, said, "Harry, did it ever
+occur to you that Basil was murdered?"
+
+Lord Henry yawned.  "Basil was very popular, and always wore a
+Waterbury watch.  Why should he have been murdered?  He was not clever
+enough to have enemies.  Of course, he had a wonderful genius for
+painting.  But a man can paint like Velasquez and yet be as dull as
+possible.  Basil was really rather dull.  He only interested me once,
+and that was when he told me, years ago, that he had a wild adoration
+for you and that you were the dominant motive of his art."
+
+"I was very fond of Basil," said Dorian with a note of sadness in his
+voice.  "But don't people say that he was murdered?"
+
+"Oh, some of the papers do.  It does not seem to me to be at all
+probable.  I know there are dreadful places in Paris, but Basil was not
+the sort of man to have gone to them.  He had no curiosity.  It was his
+chief defect."
+
+"What would you say, Harry, if I told you that I had murdered Basil?"
+said the younger man.  He watched him intently after he had spoken.
+
+"I would say, my dear fellow, that you were posing for a character that
+doesn't suit you.  All crime is vulgar, just as all vulgarity is crime.
+It is not in you, Dorian, to commit a murder.  I am sorry if I hurt
+your vanity by saying so, but I assure you it is true.  Crime belongs
+exclusively to the lower orders.  I don't blame them in the smallest
+degree.  I should fancy that crime was to them what art is to us,
+simply a method of procuring extraordinary sensations."
+
+"A method of procuring sensations?  Do you think, then, that a man who
+has once committed a murder could possibly do the same crime again?
+Don't tell me that."
+
+"Oh! anything becomes a pleasure if one does it too often," cried Lord
+Henry, laughing.  "That is one of the most important secrets of life.
+I should fancy, however, that murder is always a mistake.  One should
+never do anything that one cannot talk about after dinner.  But let us
+pass from poor Basil.  I wish I could believe that he had come to such
+a really romantic end as you suggest, but I can't. I dare say he fell
+into the Seine off an omnibus and that the conductor hushed up the
+scandal.  Yes:  I should fancy that was his end.  I see him lying now
+on his back under those dull-green waters, with the heavy barges
+floating over him and long weeds catching in his hair.  Do you know, I
+don't think he would have done much more good work.  During the last
+ten years his painting had gone off very much."
+
+Dorian heaved a sigh, and Lord Henry strolled across the room and began
+to stroke the head of a curious Java parrot, a large, grey-plumaged
+bird with pink crest and tail, that was balancing itself upon a bamboo
+perch.  As his pointed fingers touched it, it dropped the white scurf
+of crinkled lids over black, glasslike eyes and began to sway backwards
+and forwards.
+
+"Yes," he continued, turning round and taking his handkerchief out of
+his pocket; "his painting had quite gone off.  It seemed to me to have
+lost something.  It had lost an ideal.  When you and he ceased to be
+great friends, he ceased to be a great artist.  What was it separated
+you?  I suppose he bored you.  If so, he never forgave you.  It's a
+habit bores have.  By the way, what has become of that wonderful
+portrait he did of you?  I don't think I have ever seen it since he
+finished it.  Oh!  I remember your telling me years ago that you had
+sent it down to Selby, and that it had got mislaid or stolen on the
+way.  You never got it back?  What a pity! it was really a
+masterpiece.  I remember I wanted to buy it.  I wish I had now.  It
+belonged to Basil's best period.  Since then, his work was that curious
+mixture of bad painting and good intentions that always entitles a man
+to be called a representative British artist.  Did you advertise for
+it?  You should."
+
+"I forget," said Dorian.  "I suppose I did.  But I never really liked
+it.  I am sorry I sat for it.  The memory of the thing is hateful to
+me.  Why do you talk of it?  It used to remind me of those curious
+lines in some play--Hamlet, I think--how do they run?--
+
+    "Like the painting of a sorrow,
+     A face without a heart."
+
+Yes:  that is what it was like."
+
+Lord Henry laughed.  "If a man treats life artistically, his brain is
+his heart," he answered, sinking into an arm-chair.
+
+Dorian Gray shook his head and struck some soft chords on the piano.
+"'Like the painting of a sorrow,'" he repeated, "'a face without a
+heart.'"
+
+The elder man lay back and looked at him with half-closed eyes.  "By
+the way, Dorian," he said after a pause, "'what does it profit a man if
+he gain the whole world and lose--how does the quotation run?--his own
+soul'?"
+
+The music jarred, and Dorian Gray started and stared at his friend.
+"Why do you ask me that, Harry?"
+
+"My dear fellow," said Lord Henry, elevating his eyebrows in surprise,
+"I asked you because I thought you might be able to give me an answer.
+That is all.  I was going through the park last Sunday, and close by
+the Marble Arch there stood a little crowd of shabby-looking people
+listening to some vulgar street-preacher. As I passed by, I heard the
+man yelling out that question to his audience.  It struck me as being
+rather dramatic.  London is very rich in curious effects of that kind.
+A wet Sunday, an uncouth Christian in a mackintosh, a ring of sickly
+white faces under a broken roof of dripping umbrellas, and a wonderful
+phrase flung into the air by shrill hysterical lips--it was really very
+good in its way, quite a suggestion.  I thought of telling the prophet
+that art had a soul, but that man had not.  I am afraid, however, he
+would not have understood me."
+
+"Don't, Harry.  The soul is a terrible reality.  It can be bought, and
+sold, and bartered away.  It can be poisoned, or made perfect.  There
+is a soul in each one of us.  I know it."
+
+"Do you feel quite sure of that, Dorian?"
+
+"Quite sure."
+
+"Ah! then it must be an illusion.  The things one feels absolutely
+certain about are never true.  That is the fatality of faith, and the
+lesson of romance.  How grave you are!  Don't be so serious.  What have
+you or I to do with the superstitions of our age?  No:  we have given
+up our belief in the soul.  Play me something.  Play me a nocturne,
+Dorian, and, as you play, tell me, in a low voice, how you have kept
+your youth.  You must have some secret.  I am only ten years older than
+you are, and I am wrinkled, and worn, and yellow.  You are really
+wonderful, Dorian.  You have never looked more charming than you do
+to-night. You remind me of the day I saw you first.  You were rather
+cheeky, very shy, and absolutely extraordinary.  You have changed, of
+course, but not in appearance.  I wish you would tell me your secret.
+To get back my youth I would do anything in the world, except take
+exercise, get up early, or be respectable.  Youth!  There is nothing
+like it.  It's absurd to talk of the ignorance of youth.  The only
+people to whose opinions I listen now with any respect are people much
+younger than myself.  They seem in front of me.  Life has revealed to
+them her latest wonder.  As for the aged, I always contradict the aged.
+I do it on principle.  If you ask them their opinion on something that
+happened yesterday, they solemnly give you the opinions current in
+1820, when people wore high stocks, believed in everything, and knew
+absolutely nothing.  How lovely that thing you are playing is!  I
+wonder, did Chopin write it at Majorca, with the sea weeping round the
+villa and the salt spray dashing against the panes?  It is marvellously
+romantic.  What a blessing it is that there is one art left to us that
+is not imitative!  Don't stop.  I want music to-night. It seems to me
+that you are the young Apollo and that I am Marsyas listening to you.
+I have sorrows, Dorian, of my own, that even you know nothing of.  The
+tragedy of old age is not that one is old, but that one is young.  I am
+amazed sometimes at my own sincerity.  Ah, Dorian, how happy you are!
+What an exquisite life you have had!  You have drunk deeply of
+everything.  You have crushed the grapes against your palate.  Nothing
+has been hidden from you.  And it has all been to you no more than the
+sound of music.  It has not marred you.  You are still the same."
+
+"I am not the same, Harry."
+
+"Yes, you are the same.  I wonder what the rest of your life will be.
+Don't spoil it by renunciations.  At present you are a perfect type.
+Don't make yourself incomplete.  You are quite flawless now.  You need
+not shake your head:  you know you are.  Besides, Dorian, don't deceive
+yourself.  Life is not governed by will or intention.  Life is a
+question of nerves, and fibres, and slowly built-up cells in which
+thought hides itself and passion has its dreams.  You may fancy
+yourself safe and think yourself strong.  But a chance tone of colour
+in a room or a morning sky, a particular perfume that you had once
+loved and that brings subtle memories with it, a line from a forgotten
+poem that you had come across again, a cadence from a piece of music
+that you had ceased to play--I tell you, Dorian, that it is on things
+like these that our lives depend.  Browning writes about that
+somewhere; but our own senses will imagine them for us.  There are
+moments when the odour of _lilas blanc_ passes suddenly across me, and I
+have to live the strangest month of my life over again.  I wish I could
+change places with you, Dorian.  The world has cried out against us
+both, but it has always worshipped you.  It always will worship you.
+You are the type of what the age is searching for, and what it is
+afraid it has found.  I am so glad that you have never done anything,
+never carved a statue, or painted a picture, or produced anything
+outside of yourself!  Life has been your art.  You have set yourself to
+music.  Your days are your sonnets."
+
+Dorian rose up from the piano and passed his hand through his hair.
+"Yes, life has been exquisite," he murmured, "but I am not going to
+have the same life, Harry.  And you must not say these extravagant
+things to me.  You don't know everything about me.  I think that if you
+did, even you would turn from me.  You laugh.  Don't laugh."
+
+"Why have you stopped playing, Dorian?  Go back and give me the
+nocturne over again.  Look at that great, honey-coloured moon that
+hangs in the dusky air.  She is waiting for you to charm her, and if
+you play she will come closer to the earth.  You won't?  Let us go to
+the club, then.  It has been a charming evening, and we must end it
+charmingly.  There is some one at White's who wants immensely to know
+you--young Lord Poole, Bournemouth's eldest son.  He has already copied
+your neckties, and has begged me to introduce him to you.  He is quite
+delightful and rather reminds me of you."
+
+"I hope not," said Dorian with a sad look in his eyes.  "But I am tired
+to-night, Harry.  I shan't go to the club.  It is nearly eleven, and I
+want to go to bed early."
+
+"Do stay.  You have never played so well as to-night. There was
+something in your touch that was wonderful.  It had more expression
+than I had ever heard from it before."
+
+"It is because I am going to be good," he answered, smiling.  "I am a
+little changed already."
+
+"You cannot change to me, Dorian," said Lord Henry.  "You and I will
+always be friends."
+
+"Yet you poisoned me with a book once.  I should not forgive that.
+Harry, promise me that you will never lend that book to any one.  It
+does harm."
+
+"My dear boy, you are really beginning to moralize.  You will soon be
+going about like the converted, and the revivalist, warning people
+against all the sins of which you have grown tired.  You are much too
+delightful to do that.  Besides, it is no use.  You and I are what we
+are, and will be what we will be.  As for being poisoned by a book,
+there is no such thing as that.  Art has no influence upon action.  It
+annihilates the desire to act.  It is superbly sterile.  The books that
+the world calls immoral are books that show the world its own shame.
+That is all.  But we won't discuss literature.  Come round to-morrow. I
+am going to ride at eleven.  We might go together, and I will take you
+to lunch afterwards with Lady Branksome.  She is a charming woman, and
+wants to consult you about some tapestries she is thinking of buying.
+Mind you come.  Or shall we lunch with our little duchess?  She says
+she never sees you now.  Perhaps you are tired of Gladys?  I thought
+you would be.  Her clever tongue gets on one's nerves.  Well, in any
+case, be here at eleven."
+
+"Must I really come, Harry?"
+
+"Certainly.  The park is quite lovely now.  I don't think there have
+been such lilacs since the year I met you."
+
+"Very well.  I shall be here at eleven," said Dorian.  "Good night,
+Harry."  As he reached the door, he hesitated for a moment, as if he
+had something more to say.  Then he sighed and went out.
+
+
+
+CHAPTER 20
+
+It was a lovely night, so warm that he threw his coat over his arm and
+did not even put his silk scarf round his throat.  As he strolled home,
+smoking his cigarette, two young men in evening dress passed him.  He
+heard one of them whisper to the other, "That is Dorian Gray." He
+remembered how pleased he used to be when he was pointed out, or stared
+at, or talked about.  He was tired of hearing his own name now.  Half
+the charm of the little village where he had been so often lately was
+that no one knew who he was.  He had often told the girl whom he had
+lured to love him that he was poor, and she had believed him.  He had
+told her once that he was wicked, and she had laughed at him and
+answered that wicked people were always very old and very ugly.  What a
+laugh she had!--just like a thrush singing.  And how pretty she had
+been in her cotton dresses and her large hats!  She knew nothing, but
+she had everything that he had lost.
+
+When he reached home, he found his servant waiting up for him.  He sent
+him to bed, and threw himself down on the sofa in the library, and
+began to think over some of the things that Lord Henry had said to him.
+
+Was it really true that one could never change?  He felt a wild longing
+for the unstained purity of his boyhood--his rose-white boyhood, as
+Lord Henry had once called it.  He knew that he had tarnished himself,
+filled his mind with corruption and given horror to his fancy; that he
+had been an evil influence to others, and had experienced a terrible
+joy in being so; and that of the lives that had crossed his own, it had
+been the fairest and the most full of promise that he had brought to
+shame.  But was it all irretrievable?  Was there no hope for him?
+
+Ah! in what a monstrous moment of pride and passion he had prayed that
+the portrait should bear the burden of his days, and he keep the
+unsullied splendour of eternal youth!  All his failure had been due to
+that.  Better for him that each sin of his life had brought its sure
+swift penalty along with it.  There was purification in punishment.
+Not "Forgive us our sins" but "Smite us for our iniquities" should be
+the prayer of man to a most just God.
+
+The curiously carved mirror that Lord Henry had given to him, so many
+years ago now, was standing on the table, and the white-limbed Cupids
+laughed round it as of old.  He took it up, as he had done on that
+night of horror when he had first noted the change in the fatal
+picture, and with wild, tear-dimmed eyes looked into its polished
+shield.  Once, some one who had terribly loved him had written to him a
+mad letter, ending with these idolatrous words: "The world is changed
+because you are made of ivory and gold.  The curves of your lips
+rewrite history."  The phrases came back to his memory, and he repeated
+them over and over to himself.  Then he loathed his own beauty, and
+flinging the mirror on the floor, crushed it into silver splinters
+beneath his heel.  It was his beauty that had ruined him, his beauty
+and the youth that he had prayed for.  But for those two things, his
+life might have been free from stain.  His beauty had been to him but a
+mask, his youth but a mockery.  What was youth at best?  A green, an
+unripe time, a time of shallow moods, and sickly thoughts.  Why had he
+worn its livery?  Youth had spoiled him.
+
+It was better not to think of the past.  Nothing could alter that.  It
+was of himself, and of his own future, that he had to think.  James
+Vane was hidden in a nameless grave in Selby churchyard.  Alan Campbell
+had shot himself one night in his laboratory, but had not revealed the
+secret that he had been forced to know.  The excitement, such as it
+was, over Basil Hallward's disappearance would soon pass away.  It was
+already waning.  He was perfectly safe there.  Nor, indeed, was it the
+death of Basil Hallward that weighed most upon his mind.  It was the
+living death of his own soul that troubled him.  Basil had painted the
+portrait that had marred his life.  He could not forgive him that.  It
+was the portrait that had done everything.  Basil had said things to
+him that were unbearable, and that he had yet borne with patience.  The
+murder had been simply the madness of a moment.  As for Alan Campbell,
+his suicide had been his own act.  He had chosen to do it.  It was
+nothing to him.
+
+A new life!  That was what he wanted.  That was what he was waiting
+for.  Surely he had begun it already.  He had spared one innocent
+thing, at any rate.  He would never again tempt innocence.  He would be
+good.
+
+As he thought of Hetty Merton, he began to wonder if the portrait in
+the locked room had changed.  Surely it was not still so horrible as it
+had been?  Perhaps if his life became pure, he would be able to expel
+every sign of evil passion from the face.  Perhaps the signs of evil
+had already gone away.  He would go and look.
+
+He took the lamp from the table and crept upstairs.  As he unbarred the
+door, a smile of joy flitted across his strangely young-looking face
+and lingered for a moment about his lips.  Yes, he would be good, and
+the hideous thing that he had hidden away would no longer be a terror
+to him.  He felt as if the load had been lifted from him already.
+
+He went in quietly, locking the door behind him, as was his custom, and
+dragged the purple hanging from the portrait.  A cry of pain and
+indignation broke from him.  He could see no change, save that in the
+eyes there was a look of cunning and in the mouth the curved wrinkle of
+the hypocrite.  The thing was still loathsome--more loathsome, if
+possible, than before--and the scarlet dew that spotted the hand seemed
+brighter, and more like blood newly spilled.  Then he trembled.  Had it
+been merely vanity that had made him do his one good deed?  Or the
+desire for a new sensation, as Lord Henry had hinted, with his mocking
+laugh?  Or that passion to act a part that sometimes makes us do things
+finer than we are ourselves?  Or, perhaps, all these?  And why was the
+red stain larger than it had been?  It seemed to have crept like a
+horrible disease over the wrinkled fingers.  There was blood on the
+painted feet, as though the thing had dripped--blood even on the hand
+that had not held the knife.  Confess?  Did it mean that he was to
+confess?  To give himself up and be put to death?  He laughed.  He felt
+that the idea was monstrous.  Besides, even if he did confess, who
+would believe him?  There was no trace of the murdered man anywhere.
+Everything belonging to him had been destroyed.  He himself had burned
+what had been below-stairs. The world would simply say that he was mad.
+They would shut him up if he persisted in his story.... Yet it was
+his duty to confess, to suffer public shame, and to make public
+atonement.  There was a God who called upon men to tell their sins to
+earth as well as to heaven.  Nothing that he could do would cleanse him
+till he had told his own sin.  His sin?  He shrugged his shoulders.
+The death of Basil Hallward seemed very little to him.  He was thinking
+of Hetty Merton.  For it was an unjust mirror, this mirror of his soul
+that he was looking at.  Vanity?  Curiosity?  Hypocrisy?  Had there
+been nothing more in his renunciation than that?  There had been
+something more.  At least he thought so.  But who could tell? ... No.
+There had been nothing more.  Through vanity he had spared her.  In
+hypocrisy he had worn the mask of goodness.  For curiosity's sake he
+had tried the denial of self.  He recognized that now.
+
+But this murder--was it to dog him all his life?  Was he always to be
+burdened by his past?  Was he really to confess?  Never.  There was
+only one bit of evidence left against him.  The picture itself--that
+was evidence.  He would destroy it.  Why had he kept it so long?  Once
+it had given him pleasure to watch it changing and growing old.  Of
+late he had felt no such pleasure.  It had kept him awake at night.
+When he had been away, he had been filled with terror lest other eyes
+should look upon it.  It had brought melancholy across his passions.
+Its mere memory had marred many moments of joy.  It had been like
+conscience to him.  Yes, it had been conscience.  He would destroy it.
+
+He looked round and saw the knife that had stabbed Basil Hallward.  He
+had cleaned it many times, till there was no stain left upon it.  It
+was bright, and glistened.  As it had killed the painter, so it would
+kill the painter's work, and all that that meant.  It would kill the
+past, and when that was dead, he would be free.  It would kill this
+monstrous soul-life, and without its hideous warnings, he would be at
+peace.  He seized the thing, and stabbed the picture with it.
+
+There was a cry heard, and a crash.  The cry was so horrible in its
+agony that the frightened servants woke and crept out of their rooms.
+Two gentlemen, who were passing in the square below, stopped and looked
+up at the great house.  They walked on till they met a policeman and
+brought him back.  The man rang the bell several times, but there was
+no answer.  Except for a light in one of the top windows, the house was
+all dark.  After a time, he went away and stood in an adjoining portico
+and watched.
+
+"Whose house is that, Constable?" asked the elder of the two gentlemen.
+
+"Mr. Dorian Gray's, sir," answered the policeman.
+
+They looked at each other, as they walked away, and sneered.  One of
+them was Sir Henry Ashton's uncle.
+
+Inside, in the servants' part of the house, the half-clad domestics
+were talking in low whispers to each other.  Old Mrs. Leaf was crying
+and wringing her hands.  Francis was as pale as death.
+
+After about a quarter of an hour, he got the coachman and one of the
+footmen and crept upstairs.  They knocked, but there was no reply.
+They called out.  Everything was still.  Finally, after vainly trying
+to force the door, they got on the roof and dropped down on to the
+balcony.  The windows yielded easily--their bolts were old.
+
+When they entered, they found hanging upon the wall a splendid portrait
+of their master as they had last seen him, in all the wonder of his
+exquisite youth and beauty.  Lying on the floor was a dead man, in
+evening dress, with a knife in his heart.  He was withered, wrinkled,
+and loathsome of visage.  It was not till they had examined the rings
+that they recognized who it was.
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's The Picture of Dorian Gray, by Oscar Wilde
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+***** This file should be named 174.txt or 174.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/174/
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/edgar-allan-poe-works-1.txt
+++ b/jet/source-sink-builder/src/main/resources/books/edgar-allan-poe-works-1.txt
@@ -1,0 +1,9226 @@
+﻿Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Works of Edgar Allan Poe
+       Volume 1 (of 5) of the Raven Edition
+
+Author: Edgar Allan Poe
+
+Release Date: May 19, 2008 [EBook #2147]
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+
+
+
+Produced by David Widger and Carlo Traverso
+
+
+
+
+
+
+
+
+THE WORKS OF EDGAR ALLAN POE
+
+IN FIVE VOLUMES
+
+
+The Raven Edition
+
+
+
+
+VOLUME I
+
+
+Contents:
+
+     Edgar Allan Poe, An Appreciation
+     Life of Poe, by James Russell Lowell
+     Death of Poe, by N. P. Willis
+     The Unparalleled Adventures of One Hans Pfaall
+     The Gold-Bug
+     Four Beasts in One
+     The Murders in the Rue Morgue
+     The Mystery of Marie Rogêt
+     The Balloon-Hoax
+     MS. Found in a Bottle
+     The Oval Portrait
+
+
+
+
+EDGAR ALLAN POE
+
+AN APPRECIATION
+
+
+   Caught from some unhappy master whom unmerciful Disaster
+   Followed fast and followed faster till his songs one burden bore--
+   Till the dirges of his Hope that melancholy burden bore
+         Of “never--never more!”
+
+THIS stanza from “The Raven” was recommended by James Russell Lowell as
+an inscription upon the Baltimore monument which marks the resting place
+of Edgar Allan Poe, the most interesting and original figure in American
+letters. And, to signify that peculiar musical quality of Poe’s genius
+which inthralls every reader, Mr. Lowell suggested this additional
+verse, from the “Haunted Palace”:
+
+   And all with pearl and ruby glowing
+    Was the fair palace door,
+   Through which came flowing, flowing, flowing,
+    And sparkling ever more,
+   A troop of Echoes, whose sweet duty
+    Was but to sing,
+   In voices of surpassing beauty,
+    The wit and wisdom of their king.
+
+
+Born in poverty at Boston, January 19, 1809, dying under painful
+circumstances at Baltimore, October 7, 1849, his whole literary career
+of scarcely fifteen years a pitiful struggle for mere subsistence, his
+memory malignantly misrepresented by his earliest biographer, Griswold,
+how completely has truth at last routed falsehood and how magnificently
+has Poe come into his own. For “The Raven,” first published in 1845,
+and, within a few months, read, recited and parodied wherever the
+English language was spoken, the half-starved poet received $10! Less
+than a year later his brother poet, N. P. Willis, issued this touching
+appeal to the admirers of genius on behalf of the neglected author, his
+dying wife and her devoted mother, then living under very straitened
+circumstances in a little cottage at Fordham, N. Y.:
+
+“Here is one of the finest scholars, one of the most original men of
+genius, and one of the most industrious of the literary profession of
+our country, whose temporary suspension of labor, from bodily illness,
+drops him immediately to a level with the common objects of public
+charity. There is no intermediate stopping-place, no respectful shelter,
+where, with the delicacy due to genius and culture, he might secure
+aid, till, with returning health, he would resume his labors, and his
+unmortified sense of independence.”
+
+And this was the tribute paid by the American public to the master who
+had given to it such tales of conjuring charm, of witchery and mystery
+as “The Fall of the House of Usher” and “Ligeia”; such fascinating
+hoaxes as “The Unparalleled Adventure of Hans Pfaall,” “MSS. Found in a
+Bottle,” “A Descent Into a Maelstrom” and “The Balloon-Hoax”; such tales
+of conscience as “William Wilson,” “The Black Cat” and “The Tell-tale
+Heart,” wherein the retributions of remorse are portrayed with an awful
+fidelity; such tales of natural beauty as “The Island of the Fay” and
+“The Domain of Arnheim”; such marvellous studies in ratiocination as the
+“Gold-bug,” “The Murders in the Rue Morgue,” “The Purloined Letter”
+ and “The Mystery of Marie Roget,” the latter, a recital of fact,
+demonstrating the author’s wonderful capability of correctly analyzing
+the mysteries of the human mind; such tales of illusion and banter
+as “The Premature Burial” and “The System of Dr. Tarr and Professor
+Fether”; such bits of extravaganza as “The Devil in the Belfry” and “The
+Angel of the Odd”; such tales of adventure as “The Narrative of Arthur
+Gordon Pym”; such papers of keen criticism and review as won for Poe the
+enthusiastic admiration of Charles Dickens, although they made him many
+enemies among the over-puffed minor American writers so mercilessly
+exposed by him; such poems of beauty and melody as “The Bells,” “The
+Haunted Palace,” “Tamerlane,” “The City in the Sea” and “The Raven.”
+ What delight for the jaded senses of the reader is this enchanted domain
+of wonder-pieces! What an atmosphere of beauty, music, color! What
+resources of imagination, construction, analysis and absolute art! One
+might almost sympathize with Sarah Helen Whitman, who, confessing to
+a half faith in the old superstition of the significance of anagrams,
+found, in the transposed letters of Edgar Poe’s name, the words “a
+God-peer.” His mind, she says, was indeed a “Haunted Palace,” echoing to
+the footfalls of angels and demons.
+
+“No man,” Poe himself wrote, “has recorded, no man has dared to record,
+the wonders of his inner life.”
+
+In these twentieth century days--of lavish recognition--artistic,
+popular and material--of genius, what rewards might not a Poe claim!
+
+Edgar’s father, a son of General David Poe, the American revolutionary
+patriot and friend of Lafayette, had married Mrs. Hopkins, an English
+actress, and, the match meeting with parental disapproval, had himself
+taken to the stage as a profession. Notwithstanding Mrs. Poe’s beauty
+and talent the young couple had a sorry struggle for existence. When
+Edgar, at the age of two years, was orphaned, the family was in the
+utmost destitution. Apparently the future poet was to be cast upon the
+world homeless and friendless. But fate decreed that a few glimmers of
+sunshine were to illumine his life, for the little fellow was adopted
+by John Allan, a wealthy merchant of Richmond, Va. A brother and sister,
+the remaining children, were cared for by others.
+
+In his new home Edgar found all the luxury and advantages money could
+provide. He was petted, spoiled and shown off to strangers. In Mrs.
+Allan he found all the affection a childless wife could bestow. Mr.
+Allan took much pride in the captivating, precocious lad. At the age of
+five the boy recited, with fine effect, passages of English poetry to
+the visitors at the Allan house.
+
+From his eighth to his thirteenth year he attended the Manor House
+school, at Stoke-Newington, a suburb of London. It was the Rev. Dr.
+Bransby, head of the school, whom Poe so quaintly portrayed in “William
+Wilson.” Returning to Richmond in 1820 Edgar was sent to the school
+of Professor Joseph H. Clarke. He proved an apt pupil. Years afterward
+Professor Clarke thus wrote:
+
+“While the other boys wrote mere mechanical verses, Poe wrote genuine
+poetry; the boy was a born poet. As a scholar he was ambitious to
+excel. He was remarkable for self-respect, without haughtiness. He had
+a sensitive and tender heart and would do anything for a friend. His
+nature was entirely free from selfishness.”
+
+At the age of seventeen Poe entered the University of Virginia at
+Charlottesville. He left that institution after one session. Official
+records prove that he was not expelled. On the contrary, he gained
+a creditable record as a student, although it is admitted that he
+contracted debts and had “an ungovernable passion for card-playing.”
+ These debts may have led to his quarrel with Mr. Allan which eventually
+compelled him to make his own way in the world.
+
+Early in 1827 Poe made his first literary venture. He induced Calvin
+Thomas, a poor and youthful printer, to publish a small volume of his
+verses under the title “Tamerlane and Other Poems.” In 1829 we find Poe
+in Baltimore with another manuscript volume of verses, which was soon
+published. Its title was “Al Aaraaf, Tamerlane and Other Poems.” Neither
+of these ventures seems to have attracted much attention.
+
+Soon after Mrs. Allan’s death, which occurred in 1829, Poe, through
+the aid of Mr. Allan, secured admission to the United States Military
+Academy at West Point. Any glamour which may have attached to cadet life
+in Poe’s eyes was speedily lost, for discipline at West Point was never
+so severe nor were the accommodations ever so poor. Poe’s bent was
+more and more toward literature. Life at the academy daily became
+increasingly distasteful. Soon he began to purposely neglect his studies
+and to disregard his duties, his aim being to secure his dismissal from
+the United States service. In this he succeeded. On March 7, 1831, Poe
+found himself free. Mr. Allan’s second marriage had thrown the lad on
+his own resources. His literary career was to begin.
+
+Poe’s first genuine victory was won in 1833, when he was the successful
+competitor for a prize of $100 offered by a Baltimore periodical for the
+best prose story. “A MSS. Found in a Bottle” was the winning tale. Poe
+had submitted six stories in a volume. “Our only difficulty,” says Mr.
+Latrobe, one of the judges, “was in selecting from the rich contents of
+the volume.”
+
+During the fifteen years of his literary life Poe was connected with
+various newspapers and magazines in Richmond, Philadelphia and New York.
+He was faithful, punctual, industrious, thorough. N. P. Willis, who for
+some time employed Poe as critic and sub-editor on the “Evening Mirror,”
+ wrote thus:
+
+“With the highest admiration for Poe’s genius, and a willingness to
+let it alone for more than ordinary irregularity, we were led by
+common report to expect a very capricious attention to his duties, and
+occasionally a scene of violence and difficulty. Time went on,
+however, and he was invariably punctual and industrious. We saw but
+one presentiment of the man-a quiet, patient, industrious and most
+gentlemanly person.
+
+“We heard, from one who knew him well (what should be stated in all
+mention of his lamentable irregularities), that with a single glass of
+wine his whole nature was reversed, the demon became uppermost, and,
+though none of the usual signs of intoxication were visible, his will
+was palpably insane. In this reversed character, we repeat, it was never
+our chance to meet him.”
+
+On September 22, 1835, Poe married his cousin, Virginia Clemm, in
+Baltimore. She had barely turned thirteen years, Poe himself was but
+twenty-six. He then was a resident of Richmond and a regular contributor
+to the “Southern Literary Messenger.” It was not until a year later that
+the bride and her widowed mother followed him thither.
+
+Poe’s devotion to his child-wife was one of the most beautiful features
+of his life. Many of his famous poetic productions were inspired by her
+beauty and charm. Consumption had marked her for its victim, and the
+constant efforts of husband and mother were to secure for her all the
+comfort and happiness their slender means permitted. Virginia died
+January 30, 1847, when but twenty-five years of age. A friend of the
+family pictures the death-bed scene--mother and husband trying to impart
+warmth to her by chafing her hands and her feet, while her pet cat was
+suffered to nestle upon her bosom for the sake of added warmth.
+
+These verses from “Annabel Lee,” written by Poe in 1849, the last year
+of his life, tell of his sorrow at the loss of his child-wife:
+
+     I was a child and _she_ was a child,
+      In a kingdom by the sea;
+
+     But we loved with _a _love that was more than love--
+       I and my Annabel Lee;
+
+     With a love that the winged seraphs of heaven
+      Coveted her and me.
+     And this was the reason that, long ago;
+      In this kingdom by the sea.
+     A wind blew out of a cloud, chilling
+      My beautiful Annabel Lee;
+
+     So that her high-born kinsmen came
+      And bore her away from me,
+     To shut her up in a sepulchre
+      In this kingdom by the sea,
+
+
+Poe was connected at various times and in various capacities with the
+“Southern Literary Messenger” in Richmond, Va.; “Graham’s Magazine” and
+the “Gentleman’s Magazine” in Philadelphia; the “Evening Mirror,” the
+“Broadway Journal,” and “Godey’s Lady’s Book” in New York. Everywhere
+Poe’s life was one of unremitting toil. No tales and poems were ever
+produced at a greater cost of brain and spirit.
+
+Poe’s initial salary with the “Southern Literary Messenger,” to which
+he contributed the first drafts of a number of his best-known tales,
+was $10 a week! Two years later his salary was but $600 a year. Even in
+1844, when his literary reputation was established securely, he wrote to
+a friend expressing his pleasure because a magazine to which he was to
+contribute had agreed to pay him $20 monthly for two pages of criticism.
+
+Those were discouraging times in American literature, but Poe never
+lost faith. He was finally to triumph wherever pre-eminent talents win
+admirers. His genius has had no better description than in this stanza
+from William Winter’s poem, read at the dedication exercises of the
+Actors’ Monument to Poe, May 4, 1885, in New York:
+
+     He was the voice of beauty and of woe,
+     Passion and mystery and the dread unknown;
+     Pure as the mountains of perpetual snow,
+     Cold as the icy winds that round them moan,
+     Dark as the caves wherein earth’s thunders groan,
+     Wild as the tempests of the upper sky,
+     Sweet as the faint, far-off celestial tone of angel
+         whispers, fluttering from on high,
+     And tender as love’s tear when youth and beauty die.
+
+
+In the two and a half score years that have elapsed since Poe’s death
+he has come fully into his own. For a while Griswold’s malignant
+misrepresentations colored the public estimate of Poe as man and as
+writer. But, thanks to J. H. Ingram, W. F. Gill, Eugene Didier, Sarah
+Helen Whitman and others these scandals have been dispelled and Poe is
+seen as he actually was-not as a man without failings, it is true, but
+as the finest and most original genius in American letters. As the
+years go on his fame increases. His works have been translated into
+many foreign languages. His is a household name in France and England-in
+fact, the latter nation has often uttered the reproach that Poe’s own
+country has been slow to appreciate him. But that reproach, if it ever
+was warranted, certainly is untrue.
+
+                                     W. H. R.
+
+
+
+
+EDGAR ALLAN POE
+
+By James Russell Lowell
+
+
+THE situation of American literature is anomalous. It has no centre, or,
+if it have, it is like that of the sphere of Hermes. It is divided
+into many systems, each revolving round its several suns, and often
+presenting to the rest only the faint glimmer of a milk-and-water way.
+Our capital city, unlike London or Paris, is not a great central heart
+from which life and vigor radiate to the extremities, but resembles more
+an isolated umbilicus stuck down as near as may be to the centre of the
+land, and seeming rather to tell a legend of former usefulness than to
+serve any present need. Boston, New York, Philadelphia, each has its
+literature almost more distinct than those of the different dialects
+of Germany; and the Young Queen of the West has also one of her own,
+of which some articulate rumor barely has reached us dwellers by the
+Atlantic.
+
+Perhaps there is no task more difficult than the just criticism of
+contemporary literature. It is even more grateful to give praise where
+it is needed than where it is deserved, and friendship so often seduces
+the iron stylus of justice into a vague flourish, that she writes what
+seems rather like an epitaph than a criticism. Yet if praise be given
+as an alms, we could not drop so poisonous a one into any man’s hat. The
+critic’s ink may suffer equally from too large an infusion of nutgalls
+or of sugar. But it is easier to be generous than to be just, and we
+might readily put faith in that fabulous direction to the hiding place
+of truth, did we judge from the amount of water which we usually find
+mixed with it.
+
+Remarkable experiences are usually confined to the inner life of
+imaginative men, but Mr. Poe’s biography displays a vicissitude and
+peculiarity of interest such as is rarely met with. The offspring of a
+romantic marriage, and left an orphan at an early age, he was adopted
+by Mr. Allan, a wealthy Virginian, whose barren marriage-bed seemed the
+warranty of a large estate to the young poet.
+
+Having received a classical education in England, he returned home and
+entered the University of Virginia, where, after an extravagant course,
+followed by reformation at the last extremity, he was graduated with
+the highest honors of his class. Then came a boyish attempt to join the
+fortunes of the insurgent Greeks, which ended at St. Petersburg, where
+he got into difficulties through want of a passport, from which he
+was rescued by the American consul and sent home. He now entered the
+military academy at West Point, from which he obtained a dismissal
+on hearing of the birth of a son to his adopted father, by a second
+marriage, an event which cut off his expectations as an heir. The death
+of Mr. Allan, in whose will his name was not mentioned, soon after
+relieved him of all doubt in this regard, and he committed himself at
+once to authorship for a support. Previously to this, however, he had
+published (in 1827) a small volume of poems, which soon ran through
+three editions, and excited high expectations of its author’s future
+distinction in the minds of many competent judges.
+
+That no certain augury can be drawn from a poet’s earliest lispings
+there are instances enough to prove. Shakespeare’s first poems, though
+brimful of vigor and youth and picturesqueness, give but a very faint
+promise of the directness, condensation and overflowing moral of his
+maturer works. Perhaps, however, Shakespeare is hardly a case in
+point, his “Venus and Adonis” having been published, we believe, in his
+twenty-sixth year. Milton’s Latin verses show tenderness, a fine eye for
+nature, and a delicate appreciation of classic models, but give no hint
+of the author of a new style in poetry. Pope’s youthful pieces have
+all the sing-song, wholly unrelieved by the glittering malignity
+and eloquent irreligion of his later productions. Collins’ callow
+namby-pamby died and gave no sign of the vigorous and original genius
+which he afterward displayed. We have never thought that the world lost
+more in the “marvellous boy,” Chatterton, than a very ingenious imitator
+of obscure and antiquated dulness. Where he becomes original (as it is
+called), the interest of ingenuity ceases and he becomes stupid. Kirke
+White’s promises were indorsed by the respectable name of Mr. Southey,
+but surely with no authority from Apollo. They have the merit of a
+traditional piety, which to our mind, if uttered at all, had been less
+objectionable in the retired closet of a diary, and in the sober raiment
+of prose. They do not clutch hold of the memory with the drowning
+pertinacity of Watts; neither have they the interest of his occasional
+simple, lucky beauty. Burns having fortunately been rescued by his
+humble station from the contaminating society of the “Best models,”
+ wrote well and naturally from the first. Had he been unfortunate enough
+to have had an educated taste, we should have had a series of poems from
+which, as from his letters, we could sift here and there a kernel from
+the mass of chaff. Coleridge’s youthful efforts give no promise whatever
+of that poetical genius which produced at once the wildest, tenderest,
+most original and most purely imaginative poems of modern times. Byron’s
+“Hours of Idleness” would never find a reader except from an intrepid
+and indefatigable curiosity. In Wordsworth’s first preludings there
+is but a dim foreboding of the creator of an era. From Southey’s early
+poems, a safer augury might have been drawn. They show the patient
+investigator, the close student of history, and the unwearied explorer
+of the beauties of predecessors, but they give no assurances of a man
+who should add aught to stock of household words, or to the rarer
+and more sacred delights of the fireside or the arbor. The earliest
+specimens of Shelley’s poetic mind already, also, give tokens of that
+ethereal sublimation in which the spirit seems to soar above the regions
+of words, but leaves its body, the verse, to be entombed, without hope
+of resurrection, in a mass of them. Cowley is generally instanced as a
+wonder of precocity. But his early insipidities show only a capacity
+for rhyming and for the metrical arrangement of certain conventional
+combinations of words, a capacity wholly dependent on a delicate
+physical organization, and an unhappy memory. An early poem is only
+remarkable when it displays an effort of _reason, _and the rudest verses
+in which we can trace some conception of the ends of poetry, are worth
+all the miracles of smooth juvenile versification. A school-boy, one
+would say, might acquire the regular see-saw of Pope merely by an
+association with the motion of the play-ground tilt.
+
+Mr. Poe’s early productions show that he could see through the verse to
+the spirit beneath, and that he already had a feeling that all the life
+and grace of the one must depend on and be modulated by the will of the
+other. We call them the most remarkable boyish poems that we have
+ever read. We know of none that can compare with them for maturity of
+purpose, and a nice understanding of the effects of language and metre.
+Such pieces are only valuable when they display what we can only express
+by the contradictory phrase of _innate experience. _We copy one of the
+shorter poems, written when the author was only fourteen. There is a
+little dimness in the filling up, but the grace and symmetry of the
+outline are such as few poets ever attain. There is a smack of ambrosia
+about it.
+
+     TO HELEN
+
+     Helen, thy beauty is to me
+       Like those Nicean barks of yore,
+     That gently, o’er a perfumed sea,
+       The weary, way-worn wanderer bore
+     To his own native shore.
+
+     On desperate seas long wont to roam,
+       Thy hyacinth hair, thy classic face,
+     Thy Naiad airs have brought me home
+       To the glory that was Greece
+     And the grandeur that was Rome.
+
+     Lo! in yon brilliant window-niche
+       How statue-like I see thee stand!
+     The agate lamp within thy hand,
+       Ah! Psyche, from the regions which
+     Are Holy Land!
+
+
+It is the tendency of the young poet that impresses us. Here is no
+“withering scorn,” no heart “blighted” ere it has safely got into its
+teens, none of the drawing-room sansculottism which Byron had brought
+into vogue. All is limpid and serene, with a pleasant dash of the Greek
+Helicon in it. The melody of the whole, too, is remarkable. It is not of
+that kind which can be demonstrated arithmetically upon the tips of
+the fingers. It is of that finer sort which the inner ear alone
+_can _estimate. It seems simple, like a Greek column, because of its
+perfection. In a poem named “Ligeia,” under which title he intended
+to personify the music of nature, our boy-poet gives us the following
+exquisite picture:
+
+       Ligeia! Ligeia!
+     My beautiful one,
+       Whose harshest idea
+     Will to melody run,
+       Say, is it thy will,
+     On the breezes to toss,
+       Or, capriciously still,
+     Like the lone albatross,
+       Incumbent on night,
+     As she on the air,
+       To keep watch with delight
+     On the harmony there?
+
+John Neal, himself a man of genius, and whose lyre has been too long
+capriciously silent, appreciated the high merit of these and similar
+passages, and drew a proud horoscope for their author.
+
+Mr. Poe had that indescribable something which men have agreed to call
+_genius_. No man could ever tell us precisely what it is, and yet there
+is none who is not inevitably aware of its presence and its power. Let
+talent writhe and contort itself as it may, it has no such magnetism.
+Larger of bone and sinew it may be, but the wings are wanting. Talent
+sticks fast to earth, and its most perfect works have still one foot of
+clay. Genius claims kindred with the very workings of Nature herself, so
+that a sunset shall seem like a quotation from Dante, and if Shakespeare
+be read in the very presence of the sea itself, his verses shall but
+seem nobler for the sublime criticism of ocean. Talent may make friends
+for itself, but only genius can give to its creations the divine power
+of winning love and veneration. Enthusiasm cannot cling to what itself
+is unenthusiastic, nor will he ever have disciples who has not himself
+impulsive zeal enough to be a disciple. Great wits are allied to madness
+only inasmuch as they are possessed and carried away by their demon,
+while talent keeps him, as Paracelsus did, securely prisoned in the
+pommel of his sword. To the eye of genius, the veil of the spiritual
+world is ever rent asunder that it may perceive the ministers of good
+and evil who throng continually around it. No man of mere talent ever
+flung his inkstand at the devil.
+
+When we say that Mr. Poe had genius, we do not mean to say that he has
+produced evidence of the highest. But to say that he possesses it at
+all is to say that he needs only zeal, industry, and a reverence for the
+trust reposed in him, to achieve the proudest triumphs and the greenest
+laurels. If we may believe the Longinuses and Aristotles of our
+newspapers, we have quite too many geniuses of the loftiest order to
+render a place among them at all desirable, whether for its hardness
+of attainment or its seclusion. The highest peak of our Parnassus is,
+according to these gentlemen, by far the most thickly settled portion
+of the country, a circumstance which must make it an uncomfortable
+residence for individuals of a poetical temperament, if love of
+solitude be, as immemorial tradition asserts, a necessary part of their
+idiosyncrasy.
+
+Mr. Poe has two of the prime qualities of genius, a faculty of vigorous
+yet minute analysis, and a wonderful fecundity of imagination. The first
+of these faculties is as needful to the artist in words, as a knowledge
+of anatomy is to the artist in colors or in stone. This enables him to
+conceive truly, to maintain a proper relation of parts, and to draw a
+correct outline, while the second groups, fills up and colors. Both
+of these Mr. Poe has displayed with singular distinctness in his prose
+works, the last predominating in his earlier tales, and the first in his
+later ones. In judging of the merit of an author, and assigning him his
+niche among our household gods, we have a right to regard him from
+our own point of view, and to measure him by our own standard. But,
+in estimating the amount of power displayed in his works, we must be
+governed by his own design, and placing them by the side of his own
+ideal, find how much is wanting. We differ from Mr. Poe in his opinions
+of the objects of art. He esteems that object to be the creation of
+Beauty, and perhaps it is only in the definition of that word that we
+disagree with him. But in what we shall say of his writings, we shall
+take his own standard as our guide. The temple of the god of song is
+equally accessible from every side, and there is room enough in it for
+all who bring offerings, or seek in oracle.
+
+In his tales, Mr. Poe has chosen to exhibit his power chiefly in that
+dim region which stretches from the very utmost limits of the probable
+into the weird confines of superstition and unreality. He combines in
+a very remarkable manner two faculties which are seldom found united; a
+power of influencing the mind of the reader by the impalpable shadows
+of mystery, and a minuteness of detail which does not leave a pin or
+a button unnoticed. Both are, in truth, the natural results of the
+predominating quality of his mind, to which we have before alluded,
+analysis. It is this which distinguishes the artist. His mind at once
+reaches forward to the effect to be produced. Having resolved to bring
+about certain emotions in the reader, he makes all subordinate parts
+tend strictly to the common centre. Even his mystery is mathematical
+to his own mind. To him X is a known quantity all along. In any picture
+that he paints he understands the chemical properties of all his
+colors. However vague some of his figures may seem, however formless
+the shadows, to him the outline is as clear and distinct as that of
+a geometrical diagram. For this reason Mr. Poe has no sympathy with
+Mysticism. The Mystic dwells in the mystery, is enveloped with it; it
+colors all his thoughts; it affects his optic nerve especially, and the
+commonest things get a rainbow edging from it. Mr. Poe, on the other
+hand, is a spectator _ab extra_. He analyzes, he dissects, he watches
+
+        “with an eye serene,
+     The very pulse of the machine,”
+
+
+for such it practically is to him, with wheels and cogs and piston-rods,
+all working to produce a certain end.
+
+This analyzing tendency of his mind balances the poetical, and by giving
+him the patience to be minute, enables him to throw a wonderful reality
+into his most unreal fancies. A monomania he paints with great power. He
+loves to dissect one of these cancers of the mind, and to trace all the
+subtle ramifications of its roots. In raising images of horror, also,
+he has strange success, conveying to us sometimes by a dusky hint
+some terrible _doubt _which is the secret of all horror. He leaves to
+imagination the task of finishing the picture, a task to which only she
+is competent.
+
+     “For much imaginary work was there;
+     Conceit deceitful, so compact, so kind,
+     That for Achilles’ image stood his spear
+     Grasped in an armed hand; himself behind
+     Was left unseen, save to the eye of mind.”
+
+Besides the merit of conception, Mr. Poe’s writings have also that of
+form.
+
+His style is highly finished, graceful and truly classical. It would be
+hard to find a living author who had displayed such varied powers. As an
+example of his style we would refer to one of his tales, “The House
+of Usher,” in the first volume of his “Tales of the Grotesque and
+Arabesque.” It has a singular charm for us, and we think that no one
+could read it without being strongly moved by its serene and sombre
+beauty. Had its author written nothing else, it would alone have been
+enough to stamp him as a man of genius, and the master of a classic
+style. In this tale occurs, perhaps, the most beautiful of his poems.
+
+The great masters of imagination have seldom resorted to the vague and
+the unreal as sources of effect. They have not used dread and horror
+alone, but only in combination with other qualities, as means of
+subjugating the fancies of their readers. The loftiest muse has ever a
+household and fireside charm about her. Mr. Poe’s secret lies mainly in
+the skill with which he has employed the strange fascination of mystery
+and terror. In this his success is so great and striking as to deserve
+the name of art, not artifice. We cannot call his materials the noblest
+or purest, but we must concede to him the highest merit of construction.
+
+As a critic, Mr. Poe was aesthetically deficient. Unerring in his
+analysis of dictions, metres and plots, he seemed wanting in the faculty
+of perceiving the profounder ethics of art. His criticisms are, however,
+distinguished for scientific precision and coherence of logic. They
+have the exactness, and at the same time, the coldness of mathematical
+demonstrations. Yet they stand in strikingly refreshing contrast with
+the vague generalisms and sharp personalities of the day. If deficient
+in warmth, they are also without the heat of partisanship. They are
+especially valuable as illustrating the great truth, too generally
+overlooked, that analytic power is a subordinate quality of the critic.
+
+On the whole, it may be considered certain that Mr. Poe has attained an
+individual eminence in our literature which he will keep. He has given
+proof of power and originality. He has done that which could only be
+done once with success or safety, and the imitation or repetition of
+which would produce weariness.
+
+
+
+
+DEATH OF EDGAR A. POE
+
+By N. P. Willis
+
+
+THE ancient fable of two antagonistic spirits imprisoned in one body,
+equally powerful and having the complete mastery by turns-of one man,
+that is to say, inhabited by both a devil and an angel seems to
+have been realized, if all we hear is true, in the character of the
+extraordinary man whose name we have written above. Our own impression
+of the nature of Edgar A. Poe, differs in some important degree,
+however, from that which has been generally conveyed in the notices of
+his death. Let us, before telling what we personally know of him, copy
+a graphic and highly finished portraiture, from the pen of Dr. Rufus W.
+Griswold, which appeared in a recent number of the “Tribune”:
+
+“Edgar Allen Poe is dead. He died in Baltimore on Sunday, October 7th.
+This announcement will startle many, but few will be grieved by it. The
+poet was known, personally or by reputation, in all this country; he had
+readers in England and in several of the states of Continental Europe;
+but he had few or no friends; and the regrets for his death will be
+suggested principally by the consideration that in him literary art has
+lost one of its most brilliant but erratic stars.
+
+“His conversation was at times almost supramortal in its eloquence. His
+voice was modulated with astonishing skill, and his large and variably
+expressive eyes looked repose or shot fiery tumult into theirs who
+listened, while his own face glowed, or was changeless in pallor, as his
+imagination quickened his blood or drew it back frozen to his heart. His
+imagery was from the worlds which no mortals can see but with the vision
+of genius. Suddenly starting from a proposition, exactly and sharply
+defined, in terms of utmost simplicity and clearness, he rejected the
+forms of customary logic, and by a crystalline process of accretion,
+built up his ocular demonstrations in forms of gloomiest and ghastliest
+grandeur, or in those of the most airy and delicious beauty, so minutely
+and distinctly, yet so rapidly, that the attention which was yielded
+to him was chained till it stood among his wonderful creations, till he
+himself dissolved the spell, and brought his hearers back to common
+and base existence, by vulgar fancies or exhibitions of the ignoblest
+passion.
+
+“He was at all times a dreamer dwelling in ideal realms, in heaven or
+hell, peopled with the creatures and the accidents of his brain. He
+walked the streets, in madness or melancholy, with lips moving in
+indistinct curses, or with eyes upturned in passionate prayer (never for
+himself, for he felt, or professed to feel, that he was already damned,
+but) for their happiness who at the moment were objects of his idolatry;
+or with his glances introverted to a heart gnawed with anguish, and with
+a face shrouded in gloom, he would brave the wildest storms, and all
+night, with drenched garments and arms beating the winds and rains,
+would speak as if the spirits that at such times only could be evoked by
+him from the Aidenn, close by whose portals his disturbed soul sought to
+forget the ills to which his constitution subjected him--close by the
+Aidenn where were those he loved--the Aidenn which he might never see,
+but in fitful glimpses, as its gates opened to receive the less fiery
+and more happy natures whose destiny to sin did not involve the doom of
+death.
+
+“He seemed, except when some fitful pursuit subjugated his will and
+engrossed his faculties, always to bear the memory of some controlling
+sorrow. The remarkable poem of ‘The Raven’ was probably much more nearly
+than has been supposed, even by those who were very intimate with him, a
+reflection and an echo of his own history. _He_ was that bird’s
+
+     “‘Unhappy master whom unmerciful Disaster
+     Followed fast and followed faster till his songs one burden bore--
+     Till the dirges of his Hope that melancholy burden bore
+          Of ‘Never-never more.’
+
+
+“Every genuine author in a greater or less degree leaves in his works,
+whatever their design, traces of his personal character: elements of his
+immortal being, in which the individual survives the person. While we
+read the pages of the ‘Fall of the House of Usher,’ or of ‘Mesmeric
+Revelations,’ we see in the solemn and stately gloom which invests one,
+and in the subtle metaphysical analysis of both, indications of the
+idiosyncrasies of what was most remarkable and peculiar in the author’s
+intellectual nature. But we see here only the better phases of his
+nature, only the symbols of his juster action, for his harsh experience
+had deprived him of all faith in man or woman. He had made up his mind
+upon the numberless complexities of the social world, and the whole
+system with him was an imposture. This conviction gave a direction to
+his shrewd and naturally unamiable character. Still, though he regarded
+society as composed altogether of villains, the sharpness of his
+intellect was not of that kind which enabled him to cope with villany,
+while it continually caused him by overshots to fail of the success of
+honesty. He was in many respects like Francis Vivian in Bulwer’s novel
+of ‘The Caxtons.’ Passion, in him, comprehended--many of the worst
+emotions which militate against human happiness. You could not
+contradict him, but you raised quick choler; you could not speak of
+wealth, but his cheek paled with gnawing envy. The astonishing natural
+advantages of this poor boy--his beauty, his readiness, the daring
+spirit that breathed around him like a fiery atmosphere--had raised his
+constitutional self-confidence into an arrogance that turned his
+very claims to admiration into prejudices against him. Irascible,
+envious--bad enough, but not the worst, for these salient angles were
+all varnished over with a cold, repellant cynicism, his passions vented
+themselves in sneers. There seemed to him no moral susceptibility; and,
+what was more remarkable in a proud nature, little or nothing of the
+true point of honor. He had, to a morbid excess, that, desire to rise
+which is vulgarly called ambition, but no wish for the esteem or the
+love of his species; only the hard wish to succeed-not shine, not
+serve--succeed, that he might have the right to despise a world which
+galled his self-conceit.
+
+“We have suggested the influence of his aims and vicissitudes upon his
+literature. It was more conspicuous in his later than in his
+earlier writings. Nearly all that he wrote in the last two or three
+years-including much of his best poetry-was in some sense biographical;
+in draperies of his imagination, those who had taken the trouble to
+trace his steps, could perceive, but slightly concealed, the figure of
+himself.”
+
+Apropos of the disparaging portion of the above well-written sketch, let
+us truthfully say:
+
+Some four or five years since, when editing a daily paper in this
+city, Mr. Poe was employed by us, for several months, as critic and
+sub-editor. This was our first personal acquaintance with him. He
+resided with his wife and mother at Fordham, a few miles out of town,
+but was at his desk in the office, from nine in the morning till the
+evening paper went to press. With the highest admiration for his genius,
+and a willingness to let it atone for more than ordinary irregularity,
+we were led by common report to expect a very capricious attention to
+his duties, and occasionally a scene of violence and difficulty. Time
+went on, however, and he was invariably punctual and industrious. With
+his pale, beautiful, and intellectual face, as a reminder of what genius
+was in him, it was impossible, of course, not to treat him always with
+deferential courtesy, and, to our occasional request that he would not
+probe too deep in a criticism, or that he would erase a passage colored
+too highly with his resentments against society and mankind, he readily
+and courteously assented-far more yielding than most men, we thought,
+on points so excusably sensitive. With a prospect of taking the lead in
+another periodical, he, at last, voluntarily gave up his employment
+with us, and, through all this considerable period, we had seen but
+one presentment of the man-a quiet, patient, industrious, and most
+gentlemanly person, commanding the utmost respect and good feeling by
+his unvarying deportment and ability.
+
+Residing as he did in the country, we never met Mr. Poe in hours of
+leisure; but he frequently called on us afterward at our place of
+business, and we met him often in the street-invariably the same sad
+mannered, winning and refined gentleman, such as we had always known
+him. It was by rumor only, up to the day of his death, that we knew of
+any other development of manner or character. We heard, from one who
+knew him well (what should be stated in all mention of his lamentable
+irregularities), that, with a single glass of wine, his whole nature
+was reversed, the demon became uppermost, and, though none of the
+usual signs of intoxication were visible, his will was palpably insane.
+Possessing his reasoning faculties in excited activity, at such times,
+and seeking his acquaintances with his wonted look and memory, he easily
+seemed personating only another phase of his natural character, and was
+accused, accordingly, of insulting arrogance and bad-heartedness. In
+this reversed character, we repeat, it was never our chance to see him.
+We know it from hearsay, and we mention it in connection with this sad
+infirmity of physical constitution; which puts it upon very nearly the
+ground of a temporary and almost irresponsible insanity.
+
+The arrogance, vanity, and depravity of heart, of which Mr. Poe was
+generally accused, seem to us referable altogether to this reversed
+phase of his character. Under that degree of intoxication which only
+acted upon him by demonizing his sense of truth and right, he doubtless
+said and did much that was wholly irreconcilable with his better nature;
+but, when himself, and as we knew him only, his modesty and unaffected
+humility, as to his own deservings, were a constant charm to his
+character. His letters, of which the constant application for autographs
+has taken from us, we are sorry to confess, the greater portion,
+exhibited this quality very strongly. In one of the carelessly written
+notes of which we chance still to retain possession, for instance, he
+speaks of “The Raven”--that extraordinary poem which electrified the
+world of imaginative readers, and has become the type of a school of
+poetry of its own-and, in evident earnest, attributes its success to
+the few words of commendation with which we had prefaced it in this
+paper.--It will throw light on his sane character to give a literal copy
+of the note:
+
+                                  “FORDHAM, April 20, 1849
+
+
+“My DEAR WILLIS--The poem which I inclose, and which I am so vain as to
+hope you will like, in some respects, has been just published in a paper
+for which sheer necessity compels me to write, now and then. It pays
+well as times go-but unquestionably it ought to pay ten prices; for
+whatever I send it I feel I am consigning to the tomb of the Capulets.
+The verses accompanying this, may I beg you to take out of the tomb, and
+bring them to light in the ‘Home journal?’ If you can oblige me so far
+as to copy them, I do not think it will be necessary to say ‘From the
+----, that would be too bad; and, perhaps, ‘From a late ---- paper,’
+would do.
+
+“I have not forgotten how a ‘good word in season’ from you made ‘The
+Raven,’ and made ‘Ulalume’ (which by-the-way, people have done me the
+honor of attributing to you), therefore, I would ask you (if I dared) to
+say something of these lines if they please you.
+
+                      “Truly yours ever,
+
+                        “EDGAR A. POE.”
+
+
+In double proof of his earnest disposition to do the best for himself,
+and of the trustful and grateful nature which has been denied him, we
+give another of the only three of his notes which we chance to retain:
+
+                          “FORDHAM, January 22, 1848.
+
+
+“My DEAR MR. WILLIS--I am about to make an effort at re-establishing
+myself in the literary world, and _feel _that I may depend upon your
+aid.
+
+“My general aim is to start a Magazine, to be called ‘The Stylus,’ but
+it would be useless to me, even when established, if not entirely out of
+the control of a publisher. I mean, therefore, to get up a journal which
+shall be _my own_ at all points. With this end in view, I must get a
+list of at least five hundred subscribers to begin with; nearly two
+hundred I have already. I propose, however, to go South and West,
+among my personal and literary friends--old college and West Point
+acquaintances--and see what I can do. In order to get the means of
+taking the first step, I propose to lecture at the Society Library,
+on Thursday, the 3d of February, and, that there may be no cause of
+_squabbling_, my subject shall _not be literary _at all. I have chosen a
+broad text: ‘The Universe.’
+
+“Having thus given you _the facts_ of the case, I leave all the rest
+to the suggestions of your own tact and generosity. Gratefully, _most
+gratefully,_
+
+                         _“Your friend always,_
+
+                             _“EDGAR A. POE._”
+
+
+Brief and chance-taken as these letters are, we think they sufficiently
+prove the existence of the very qualities denied to Mr. Poe-humility,
+willingness to persevere, belief in another’s friendship, and capability
+of cordial and grateful friendship! Such he assuredly was when sane.
+Such only he has invariably seemed to us, in all we have happened
+personally to know of him, through a friendship of five or six years.
+And so much easier is it to believe what we have seen and known, than
+what we hear of only, that we remember him but with admiration and
+respect; these descriptions of him, when morally insane, seeming to
+us like portraits, painted in sickness, of a man we have only known in
+health.
+
+But there is another, more touching, and far more forcible evidence that
+there was _goodness _in Edgar A. Poe. To reveal it we are obliged to
+venture upon the lifting of the veil which sacredly covers grief and
+refinement in poverty; but we think it may be excused, if so we can
+brighten the memory of the poet, even were there not a more needed and
+immediate service which it may render to the nearest link broken by his
+death.
+
+Our first knowledge of Mr. Poe’s removal to this city was by a call
+which we received from a lady who introduced herself to us as the mother
+of his wife. She was in search of employment for him, and she excused
+her errand by mentioning that he was ill, that her daughter was a
+confirmed invalid, and that their circumstances were such as compelled
+her taking it upon herself. The countenance of this lady, made beautiful
+and saintly with an evidently complete giving up of her life to
+privation and sorrowful tenderness, her gentle and mournful voice urging
+its plea, her long-forgotten but habitually and unconsciously refined
+manners, and her appealing and yet appreciative mention of the claims
+and abilities of her son, disclosed at once the presence of one of those
+angels upon earth that women in adversity can be. It was a hard fate
+that she was watching over. Mr. Poe wrote with fastidious difficulty,
+and in a style too much above the popular level to be well paid. He was
+always in pecuniary difficulty, and, with his sick wife, frequently in
+want of the merest necessaries of life. Winter after winter, for
+years, the most touching sight to us, in this whole city, has been that
+tireless minister to genius, thinly and insufficiently clad, going from
+office to office with a poem, or an article on some literary subject, to
+sell, sometimes simply pleading in a broken voice that he was ill, and
+begging for him, mentioning nothing but that “he was ill,” whatever
+might be the reason for his writing nothing, and never, amid all her
+tears and recitals of distress, suffering one syllable to escape her
+lips that could convey a doubt of him, or a complaint, or a lessening of
+pride in his genius and good intentions. Her daughter died a year and
+a half since, but she did not desert him. She continued his ministering
+angel--living with him, caring for him, guarding him against exposure,
+and when he was carried away by temptation, amid grief and the
+loneliness of feelings unreplied to, and awoke from his self abandonment
+prostrated in destitution and suffering, _begging _for him still. If
+woman’s devotion, born with a first love, and fed with human passion,
+hallow its object, as it is allowed to do, what does not a devotion
+like this-pure, disinterested and holy as the watch of an invisible
+spirit-say for him who inspired it?
+
+We have a letter before us, written by this lady, Mrs. Clemm, on the
+morning in which she heard of the death of this object of her untiring
+care. It is merely a request that we would call upon her, but we will
+copy a few of its words--sacred as its privacy is--to warrant the truth
+of the picture we have drawn above, and add force to the appeal we wish
+to make for her:
+
+“I have this morning heard of the death of my darling Eddie.... Can you
+give me any circumstances or particulars?... Oh! do not desert your
+poor friend in his bitter affliction!... Ask Mr. ---- to come, as I must
+deliver a message to him from my poor Eddie.... I need not ask you to
+notice his death and to speak well of him. I know you will. But say what
+an affectionate son he was to me, his poor desolate mother...”
+
+To hedge round a grave with respect, what choice is there, between the
+relinquished wealth and honors of the world, and the story of such a
+woman’s unrewarded devotion! Risking what we do, in delicacy, by making
+it public, we feel--other reasons aside--that it betters the world to
+make known that there are such ministrations to its erring and gifted.
+What we have said will speak to some hearts. There are those who will
+be glad to know how the lamp, whose light of poetry has beamed on their
+far-away recognition, was watched over with care and pain, that they
+may send to her, who is more darkened than they by its extinction, some
+token of their sympathy. She is destitute and alone. If any, far or
+near, will send to us what may aid and cheer her through the remainder
+of her life, we will joyfully place it in her hands.
+
+
+
+
+
+THE UNPARALLELED ADVENTURES OF ONE HANS PFAALL (*1)
+
+BY late accounts from Rotterdam, that city seems to be in a high state
+of philosophical excitement. Indeed, phenomena have there occurred of
+a nature so completely unexpected--so entirely novel--so utterly at
+variance with preconceived opinions--as to leave no doubt on my mind
+that long ere this all Europe is in an uproar, all physics in a ferment,
+all reason and astronomy together by the ears.
+
+It appears that on the---- day of---- (I am not positive about the
+date), a vast crowd of people, for purposes not specifically
+mentioned, were assembled in the great square of the Exchange in the
+well-conditioned city of Rotterdam. The day was warm--unusually so for
+the season--there was hardly a breath of air stirring; and the multitude
+were in no bad humor at being now and then besprinkled with friendly
+showers of momentary duration, that fell from large white masses
+of cloud which chequered in a fitful manner the blue vault of the
+firmament. Nevertheless, about noon, a slight but remarkable agitation
+became apparent in the assembly: the clattering of ten thousand tongues
+succeeded; and, in an instant afterward, ten thousand faces were
+upturned toward the heavens, ten thousand pipes descended simultaneously
+from the corners of ten thousand mouths, and a shout, which could be
+compared to nothing but the roaring of Niagara, resounded long, loudly,
+and furiously, through all the environs of Rotterdam.
+
+The origin of this hubbub soon became sufficiently evident. From behind
+the huge bulk of one of those sharply-defined masses of cloud already
+mentioned, was seen slowly to emerge into an open area of blue space, a
+queer, heterogeneous, but apparently solid substance, so oddly shaped,
+so whimsically put together, as not to be in any manner comprehended,
+and never to be sufficiently admired, by the host of sturdy burghers who
+stood open-mouthed below. What could it be? In the name of all the vrows
+and devils in Rotterdam, what could it possibly portend? No one knew, no
+one could imagine; no one--not even the burgomaster Mynheer Superbus Von
+Underduk--had the slightest clew by which to unravel the mystery; so, as
+nothing more reasonable could be done, every one to a man replaced his
+pipe carefully in the corner of his mouth, and cocking up his right
+eye towards the phenomenon, puffed, paused, waddled about, and grunted
+significantly--then waddled back, grunted, paused, and finally--puffed
+again.
+
+In the meantime, however, lower and still lower toward the goodly city,
+came the object of so much curiosity, and the cause of so much smoke. In
+a very few minutes it arrived near enough to be accurately discerned. It
+appeared to be--yes! it was undoubtedly a species of balloon; but surely
+no such balloon had ever been seen in Rotterdam before. For who, let me
+ask, ever heard of a balloon manufactured entirely of dirty newspapers?
+No man in Holland certainly; yet here, under the very noses of the
+people, or rather at some distance above their noses was the identical
+thing in question, and composed, I have it on the best authority, of
+the precise material which no one had ever before known to be used for
+a similar purpose. It was an egregious insult to the good sense of the
+burghers of Rotterdam. As to the shape of the phenomenon, it was even
+still more reprehensible. Being little or nothing better than a huge
+foolscap turned upside down. And this similitude was regarded as by no
+means lessened when, upon nearer inspection, there was perceived a large
+tassel depending from its apex, and, around the upper rim or base of the
+cone, a circle of little instruments, resembling sheep-bells, which kept
+up a continual tinkling to the tune of Betty Martin. But still worse.
+Suspended by blue ribbons to the end of this fantastic machine,
+there hung, by way of car, an enormous drab beaver hat, with a brim
+superlatively broad, and a hemispherical crown with a black band and a
+silver buckle. It is, however, somewhat remarkable that many citizens
+of Rotterdam swore to having seen the same hat repeatedly before; and
+indeed the whole assembly seemed to regard it with eyes of familiarity;
+while the vrow Grettel Pfaall, upon sight of it, uttered an exclamation
+of joyful surprise, and declared it to be the identical hat of her good
+man himself. Now this was a circumstance the more to be observed, as
+Pfaall, with three companions, had actually disappeared from Rotterdam
+about five years before, in a very sudden and unaccountable manner, and
+up to the date of this narrative all attempts had failed of obtaining
+any intelligence concerning them whatsoever. To be sure, some bones
+which were thought to be human, mixed up with a quantity of odd-looking
+rubbish, had been lately discovered in a retired situation to the east
+of Rotterdam, and some people went so far as to imagine that in this
+spot a foul murder had been committed, and that the sufferers were in
+all probability Hans Pfaall and his associates. But to return.
+
+The balloon (for such no doubt it was) had now descended to within
+a hundred feet of the earth, allowing the crowd below a sufficiently
+distinct view of the person of its occupant. This was in truth a very
+droll little somebody. He could not have been more than two feet in
+height; but this altitude, little as it was, would have been sufficient
+to destroy his equilibrium, and tilt him over the edge of his tiny
+car, but for the intervention of a circular rim reaching as high as
+the breast, and rigged on to the cords of the balloon. The body of the
+little man was more than proportionately broad, giving to his entire
+figure a rotundity highly absurd. His feet, of course, could not be seen
+at all, although a horny substance of suspicious nature was occasionally
+protruded through a rent in the bottom of the car, or to speak more
+properly, in the top of the hat. His hands were enormously large. His
+hair was extremely gray, and collected in a cue behind. His nose was
+prodigiously long, crooked, and inflammatory; his eyes full, brilliant,
+and acute; his chin and cheeks, although wrinkled with age, were broad,
+puffy, and double; but of ears of any kind or character there was not a
+semblance to be discovered upon any portion of his head. This odd little
+gentleman was dressed in a loose surtout of sky-blue satin, with tight
+breeches to match, fastened with silver buckles at the knees. His vest
+was of some bright yellow material; a white taffety cap was set jauntily
+on one side of his head; and, to complete his equipment, a blood-red
+silk handkerchief enveloped his throat, and fell down, in a dainty
+manner, upon his bosom, in a fantastic bow-knot of super-eminent
+dimensions.
+
+Having descended, as I said before, to about one hundred feet from the
+surface of the earth, the little old gentleman was suddenly seized
+with a fit of trepidation, and appeared disinclined to make any nearer
+approach to terra firma. Throwing out, therefore, a quantity of sand
+from a canvas bag, which, he lifted with great difficulty, he became
+stationary in an instant. He then proceeded, in a hurried and agitated
+manner, to extract from a side-pocket in his surtout a large morocco
+pocket-book. This he poised suspiciously in his hand, then eyed it with
+an air of extreme surprise, and was evidently astonished at its weight.
+He at length opened it, and drawing there from a huge letter sealed with
+red sealing-wax and tied carefully with red tape, let it fall precisely
+at the feet of the burgomaster, Superbus Von Underduk. His Excellency
+stooped to take it up. But the aeronaut, still greatly discomposed, and
+having apparently no farther business to detain him in Rotterdam, began
+at this moment to make busy preparations for departure; and it being
+necessary to discharge a portion of ballast to enable him to reascend,
+the half dozen bags which he threw out, one after another, without
+taking the trouble to empty their contents, tumbled, every one of them,
+most unfortunately upon the back of the burgomaster, and rolled him over
+and over no less than one-and-twenty times, in the face of every man in
+Rotterdam. It is not to be supposed, however, that the great Underduk
+suffered this impertinence on the part of the little old man to pass off
+with impunity. It is said, on the contrary, that during each and every
+one of his one-and twenty circumvolutions he emitted no less than
+one-and-twenty distinct and furious whiffs from his pipe, to which he
+held fast the whole time with all his might, and to which he intends
+holding fast until the day of his death.
+
+In the meantime the balloon arose like a lark, and, soaring far away
+above the city, at length drifted quietly behind a cloud similar to that
+from which it had so oddly emerged, and was thus lost forever to the
+wondering eyes of the good citizens of Rotterdam. All attention was
+now directed to the letter, the descent of which, and the consequences
+attending thereupon, had proved so fatally subversive of both person and
+personal dignity to his Excellency, the illustrious Burgomaster Mynheer
+Superbus Von Underduk. That functionary, however, had not failed, during
+his circumgyratory movements, to bestow a thought upon the important
+subject of securing the packet in question, which was seen, upon
+inspection, to have fallen into the most proper hands, being actually
+addressed to himself and Professor Rub-a-dub, in their official
+capacities of President and Vice-President of the Rotterdam College of
+Astronomy. It was accordingly opened by those dignitaries upon the
+spot, and found to contain the following extraordinary, and indeed very
+serious, communications.
+
+To their Excellencies Von Underduk and Rub-a-dub, President and
+Vice-President of the States’ College of Astronomers, in the city of
+Rotterdam.
+
+“Your Excellencies may perhaps be able to remember an humble artizan, by
+name Hans Pfaall, and by occupation a mender of bellows, who, with three
+others, disappeared from Rotterdam, about five years ago, in a manner
+which must have been considered by all parties at once sudden, and
+extremely unaccountable. If, however, it so please your Excellencies, I,
+the writer of this communication, am the identical Hans Pfaall himself.
+It is well known to most of my fellow citizens, that for the period of
+forty years I continued to occupy the little square brick building, at
+the head of the alley called Sauerkraut, in which I resided at the time
+of my disappearance. My ancestors have also resided therein time out of
+mind--they, as well as myself, steadily following the respectable and
+indeed lucrative profession of mending of bellows. For, to speak the
+truth, until of late years, that the heads of all the people have been
+set agog with politics, no better business than my own could an
+honest citizen of Rotterdam either desire or deserve. Credit was good,
+employment was never wanting, and on all hands there was no lack of
+either money or good-will. But, as I was saying, we soon began to feel
+the effects of liberty and long speeches, and radicalism, and all that
+sort of thing. People who were formerly, the very best customers in the
+world, had now not a moment of time to think of us at all. They had, so
+they said, as much as they could do to read about the revolutions, and
+keep up with the march of intellect and the spirit of the age. If a fire
+wanted fanning, it could readily be fanned with a newspaper, and as the
+government grew weaker, I have no doubt that leather and iron acquired
+durability in proportion, for, in a very short time, there was not a
+pair of bellows in all Rotterdam that ever stood in need of a stitch or
+required the assistance of a hammer. This was a state of things not
+to be endured. I soon grew as poor as a rat, and, having a wife and
+children to provide for, my burdens at length became intolerable, and I
+spent hour after hour in reflecting upon the most convenient method of
+putting an end to my life. Duns, in the meantime, left me little leisure
+for contemplation. My house was literally besieged from morning till
+night, so that I began to rave, and foam, and fret like a caged
+tiger against the bars of his enclosure. There were three fellows in
+particular who worried me beyond endurance, keeping watch continually
+about my door, and threatening me with the law. Upon these three I
+internally vowed the bitterest revenge, if ever I should be so happy as
+to get them within my clutches; and I believe nothing in the world but
+the pleasure of this anticipation prevented me from putting my plan
+of suicide into immediate execution, by blowing my brains out with a
+blunderbuss. I thought it best, however, to dissemble my wrath, and to
+treat them with promises and fair words, until, by some good turn of
+fate, an opportunity of vengeance should be afforded me.
+
+“One day, having given my creditors the slip, and feeling more than
+usually dejected, I continued for a long time to wander about the most
+obscure streets without object whatever, until at length I chanced to
+stumble against the corner of a bookseller’s stall. Seeing a chair close
+at hand, for the use of customers, I threw myself doggedly into it,
+and, hardly knowing why, opened the pages of the first volume which
+came within my reach. It proved to be a small pamphlet treatise on
+Speculative Astronomy, written either by Professor Encke of Berlin or
+by a Frenchman of somewhat similar name. I had some little tincture of
+information on matters of this nature, and soon became more and more
+absorbed in the contents of the book, reading it actually through twice
+before I awoke to a recollection of what was passing around me. By this
+time it began to grow dark, and I directed my steps toward home. But
+the treatise had made an indelible impression on my mind, and, as I
+sauntered along the dusky streets, I revolved carefully over in my
+memory the wild and sometimes unintelligible reasonings of the writer.
+There are some particular passages which affected my imagination in a
+powerful and extraordinary manner. The longer I meditated upon these
+the more intense grew the interest which had been excited within me.
+The limited nature of my education in general, and more especially my
+ignorance on subjects connected with natural philosophy, so far from
+rendering me diffident of my own ability to comprehend what I had read,
+or inducing me to mistrust the many vague notions which had arisen in
+consequence, merely served as a farther stimulus to imagination; and I
+was vain enough, or perhaps reasonable enough, to doubt whether
+those crude ideas which, arising in ill-regulated minds, have all the
+appearance, may not often in effect possess all the force, the reality,
+and other inherent properties, of instinct or intuition; whether, to
+proceed a step farther, profundity itself might not, in matters of a
+purely speculative nature, be detected as a legitimate source of falsity
+and error. In other words, I believed, and still do believe, that truth,
+is frequently of its own essence, superficial, and that, in many cases,
+the depth lies more in the abysses where we seek her, than in the actual
+situations wherein she may be found. Nature herself seemed to afford
+me corroboration of these ideas. In the contemplation of the heavenly
+bodies it struck me forcibly that I could not distinguish a star with
+nearly as much precision, when I gazed on it with earnest, direct and
+undeviating attention, as when I suffered my eye only to glance in
+its vicinity alone. I was not, of course, at that time aware that this
+apparent paradox was occasioned by the center of the visual area being
+less susceptible of feeble impressions of light than the exterior
+portions of the retina. This knowledge, and some of another kind, came
+afterwards in the course of an eventful five years, during which I
+have dropped the prejudices of my former humble situation in life, and
+forgotten the bellows-mender in far different occupations. But at the
+epoch of which I speak, the analogy which a casual observation of a star
+offered to the conclusions I had already drawn, struck me with the force
+of positive conformation, and I then finally made up my mind to the
+course which I afterwards pursued.
+
+“It was late when I reached home, and I went immediately to bed. My
+mind, however, was too much occupied to sleep, and I lay the whole night
+buried in meditation. Arising early in the morning, and contriving
+again to escape the vigilance of my creditors, I repaired eagerly to the
+bookseller’s stall, and laid out what little ready money I possessed,
+in the purchase of some volumes of Mechanics and Practical Astronomy.
+Having arrived at home safely with these, I devoted every spare moment
+to their perusal, and soon made such proficiency in studies of this
+nature as I thought sufficient for the execution of my plan. In the
+intervals of this period, I made every endeavor to conciliate the
+three creditors who had given me so much annoyance. In this I finally
+succeeded--partly by selling enough of my household furniture to satisfy
+a moiety of their claim, and partly by a promise of paying the balance
+upon completion of a little project which I told them I had in view, and
+for assistance in which I solicited their services. By these means--for
+they were ignorant men--I found little difficulty in gaining them over
+to my purpose.
+
+“Matters being thus arranged, I contrived, by the aid of my wife and
+with the greatest secrecy and caution, to dispose of what property I had
+remaining, and to borrow, in small sums, under various pretences,
+and without paying any attention to my future means of repayment, no
+inconsiderable quantity of ready money. With the means thus accruing I
+proceeded to procure at intervals, cambric muslin, very fine, in pieces
+of twelve yards each; twine; a lot of the varnish of caoutchouc; a
+large and deep basket of wicker-work, made to order; and several other
+articles necessary in the construction and equipment of a balloon of
+extraordinary dimensions. This I directed my wife to make up as soon as
+possible, and gave her all requisite information as to the particular
+method of proceeding. In the meantime I worked up the twine into
+a net-work of sufficient dimensions; rigged it with a hoop and the
+necessary cords; bought a quadrant, a compass, a spy-glass, a common
+barometer with some important modifications, and two astronomical
+instruments not so generally known. I then took opportunities of
+conveying by night, to a retired situation east of Rotterdam, five
+iron-bound casks, to contain about fifty gallons each, and one of a
+larger size; six tinned ware tubes, three inches in diameter, properly
+shaped, and ten feet in length; a quantity of a particular metallic
+substance, or semi-metal, which I shall not name, and a dozen demijohns
+of a very common acid. The gas to be formed from these latter materials
+is a gas never yet generated by any other person than myself--or at
+least never applied to any similar purpose. The secret I would make no
+difficulty in disclosing, but that it of right belongs to a citizen of
+Nantz, in France, by whom it was conditionally communicated to myself.
+The same individual submitted to me, without being at all aware of my
+intentions, a method of constructing balloons from the membrane of a
+certain animal, through which substance any escape of gas was nearly an
+impossibility. I found it, however, altogether too expensive, and was
+not sure, upon the whole, whether cambric muslin with a coating of
+gum caoutchouc, was not equally as good. I mention this circumstance,
+because I think it probable that hereafter the individual in question
+may attempt a balloon ascension with the novel gas and material I have
+spoken of, and I do not wish to deprive him of the honor of a very
+singular invention.
+
+“On the spot which I intended each of the smaller casks to occupy
+respectively during the inflation of the balloon, I privately dug a hole
+two feet deep; the holes forming in this manner a circle twenty-five
+feet in diameter. In the centre of this circle, being the station
+designed for the large cask, I also dug a hole three feet in depth. In
+each of the five smaller holes, I deposited a canister containing
+fifty pounds, and in the larger one a keg holding one hundred and fifty
+pounds, of cannon powder. These--the keg and canisters--I connected in
+a proper manner with covered trains; and having let into one of the
+canisters the end of about four feet of slow match, I covered up the
+hole, and placed the cask over it, leaving the other end of the match
+protruding about an inch, and barely visible beyond the cask. I then
+filled up the remaining holes, and placed the barrels over them in their
+destined situation.
+
+“Besides the articles above enumerated, I conveyed to the depot, and
+there secreted, one of M. Grimm’s improvements upon the apparatus for
+condensation of the atmospheric air. I found this machine, however,
+to require considerable alteration before it could be adapted to the
+purposes to which I intended making it applicable. But, with severe
+labor and unremitting perseverance, I at length met with entire success
+in all my preparations. My balloon was soon completed. It would contain
+more than forty thousand cubic feet of gas; would take me up easily, I
+calculated, with all my implements, and, if I managed rightly, with
+one hundred and seventy-five pounds of ballast into the bargain. It
+had received three coats of varnish, and I found the cambric muslin to
+answer all the purposes of silk itself, quite as strong and a good deal
+less expensive.
+
+“Everything being now ready, I exacted from my wife an oath of secrecy
+in relation to all my actions from the day of my first visit to the
+bookseller’s stall; and promising, on my part, to return as soon as
+circumstances would permit, I gave her what little money I had left,
+and bade her farewell. Indeed I had no fear on her account. She was
+what people call a notable woman, and could manage matters in the world
+without my assistance. I believe, to tell the truth, she always looked
+upon me as an idle boy, a mere make-weight, good for nothing but
+building castles in the air, and was rather glad to get rid of me.
+It was a dark night when I bade her good-bye, and taking with me, as
+aides-de-camp, the three creditors who had given me so much trouble,
+we carried the balloon, with the car and accoutrements, by a roundabout
+way, to the station where the other articles were deposited. We there
+found them all unmolested, and I proceeded immediately to business.
+
+“It was the first of April. The night, as I said before, was dark; there
+was not a star to be seen; and a drizzling rain, falling at intervals,
+rendered us very uncomfortable. But my chief anxiety was concerning
+the balloon, which, in spite of the varnish with which it was defended,
+began to grow rather heavy with the moisture; the powder also was liable
+to damage. I therefore kept my three duns working with great diligence,
+pounding down ice around the central cask, and stirring the acid in the
+others. They did not cease, however, importuning me with questions as
+to what I intended to do with all this apparatus, and expressed much
+dissatisfaction at the terrible labor I made them undergo. They could
+not perceive, so they said, what good was likely to result from
+their getting wet to the skin, merely to take a part in such horrible
+incantations. I began to get uneasy, and worked away with all my might,
+for I verily believe the idiots supposed that I had entered into a
+compact with the devil, and that, in short, what I was now doing was
+nothing better than it should be. I was, therefore, in great fear of
+their leaving me altogether. I contrived, however, to pacify them by
+promises of payment of all scores in full, as soon as I could bring
+the present business to a termination. To these speeches they gave, of
+course, their own interpretation; fancying, no doubt, that at all events
+I should come into possession of vast quantities of ready money; and
+provided I paid them all I owed, and a trifle more, in consideration of
+their services, I dare say they cared very little what became of either
+my soul or my carcass.
+
+“In about four hours and a half I found the balloon sufficiently
+inflated. I attached the car, therefore, and put all my implements in
+it--not forgetting the condensing apparatus, a copious supply of water,
+and a large quantity of provisions, such as pemmican, in which much
+nutriment is contained in comparatively little bulk. I also secured in
+the car a pair of pigeons and a cat. It was now nearly daybreak, and I
+thought it high time to take my departure. Dropping a lighted cigar on
+the ground, as if by accident, I took the opportunity, in stooping to
+pick it up, of igniting privately the piece of slow match, whose end,
+as I said before, protruded a very little beyond the lower rim of one of
+the smaller casks. This manoeuvre was totally unperceived on the part of
+the three duns; and, jumping into the car, I immediately cut the single
+cord which held me to the earth, and was pleased to find that I shot
+upward, carrying with all ease one hundred and seventy-five pounds of
+leaden ballast, and able to have carried up as many more.
+
+“Scarcely, however, had I attained the height of fifty yards, when,
+roaring and rumbling up after me in the most horrible and tumultuous
+manner, came so dense a hurricane of fire, and smoke, and sulphur, and
+legs and arms, and gravel, and burning wood, and blazing metal, that
+my very heart sunk within me, and I fell down in the bottom of the car,
+trembling with unmitigated terror. Indeed, I now perceived that I had
+entirely overdone the business, and that the main consequences of the
+shock were yet to be experienced. Accordingly, in less than a second,
+I felt all the blood in my body rushing to my temples, and immediately
+thereupon, a concussion, which I shall never forget, burst abruptly
+through the night and seemed to rip the very firmament asunder. When
+I afterward had time for reflection, I did not fail to attribute the
+extreme violence of the explosion, as regarded myself, to its proper
+cause--my situation directly above it, and in the line of its greatest
+power. But at the time, I thought only of preserving my life. The
+balloon at first collapsed, then furiously expanded, then whirled round
+and round with horrible velocity, and finally, reeling and staggering
+like a drunken man, hurled me with great force over the rim of the car,
+and left me dangling, at a terrific height, with my head downward, and
+my face outwards, by a piece of slender cord about three feet in
+length, which hung accidentally through a crevice near the bottom of
+the wicker-work, and in which, as I fell, my left foot became most
+providentially entangled. It is impossible--utterly impossible--to form
+any adequate idea of the horror of my situation. I gasped convulsively
+for breath--a shudder resembling a fit of the ague agitated every nerve
+and muscle of my frame--I felt my eyes starting from their sockets--a
+horrible nausea overwhelmed me--and at length I fainted away.
+
+“How long I remained in this state it is impossible to say. It must,
+however, have been no inconsiderable time, for when I partially
+recovered the sense of existence, I found the day breaking, the balloon
+at a prodigious height over a wilderness of ocean, and not a trace
+of land to be discovered far and wide within the limits of the vast
+horizon. My sensations, however, upon thus recovering, were by no means
+so rife with agony as might have been anticipated. Indeed, there was
+much of incipient madness in the calm survey which I began to take of my
+situation. I drew up to my eyes each of my hands, one after the other,
+and wondered what occurrence could have given rise to the swelling of
+the veins, and the horrible blackness of the fingernails. I afterward
+carefully examined my head, shaking it repeatedly, and feeling it with
+minute attention, until I succeeded in satisfying myself that it was
+not, as I had more than half suspected, larger than my balloon. Then,
+in a knowing manner, I felt in both my breeches pockets, and, missing
+therefrom a set of tablets and a toothpick case, endeavored to account
+for their disappearance, and not being able to do so, felt inexpressibly
+chagrined. It now occurred to me that I suffered great uneasiness in the
+joint of my left ankle, and a dim consciousness of my situation began to
+glimmer through my mind. But, strange to say! I was neither astonished
+nor horror-stricken. If I felt any emotion at all, it was a kind of
+chuckling satisfaction at the cleverness I was about to display in
+extricating myself from this dilemma; and I never, for a moment, looked
+upon my ultimate safety as a question susceptible of doubt. For a few
+minutes I remained wrapped in the profoundest meditation. I have a
+distinct recollection of frequently compressing my lips, putting
+my forefinger to the side of my nose, and making use of other
+gesticulations and grimaces common to men who, at ease in their
+arm-chairs, meditate upon matters of intricacy or importance. Having,
+as I thought, sufficiently collected my ideas, I now, with great caution
+and deliberation, put my hands behind my back, and unfastened the large
+iron buckle which belonged to the waistband of my inexpressibles. This
+buckle had three teeth, which, being somewhat rusty, turned with great
+difficulty on their axis. I brought them, however, after some trouble,
+at right angles to the body of the buckle, and was glad to find them
+remain firm in that position. Holding the instrument thus obtained
+within my teeth, I now proceeded to untie the knot of my cravat. I had
+to rest several times before I could accomplish this manoeuvre, but it
+was at length accomplished. To one end of the cravat I then made fast
+the buckle, and the other end I tied, for greater security, tightly
+around my wrist. Drawing now my body upwards, with a prodigious exertion
+of muscular force, I succeeded, at the very first trial, in throwing
+the buckle over the car, and entangling it, as I had anticipated, in the
+circular rim of the wicker-work.
+
+“My body was now inclined towards the side of the car, at an angle
+of about forty-five degrees; but it must not be understood that I was
+therefore only forty-five degrees below the perpendicular. So far from
+it, I still lay nearly level with the plane of the horizon; for the
+change of situation which I had acquired, had forced the bottom of the
+car considerably outwards from my position, which was accordingly one
+of the most imminent and deadly peril. It should be remembered, however,
+that when I fell in the first instance, from the car, if I had fallen
+with my face turned toward the balloon, instead of turned outwardly from
+it, as it actually was; or if, in the second place, the cord by which
+I was suspended had chanced to hang over the upper edge, instead of
+through a crevice near the bottom of the car,--I say it may be readily
+conceived that, in either of these supposed cases, I should have been
+unable to accomplish even as much as I had now accomplished, and the
+wonderful adventures of Hans Pfaall would have been utterly lost to
+posterity, I had therefore every reason to be grateful; although, in
+point of fact, I was still too stupid to be anything at all, and hung
+for, perhaps, a quarter of an hour in that extraordinary manner, without
+making the slightest farther exertion whatsoever, and in a singularly
+tranquil state of idiotic enjoyment. But this feeling did not fail to
+die rapidly away, and thereunto succeeded horror, and dismay, and a
+chilling sense of utter helplessness and ruin. In fact, the blood so
+long accumulating in the vessels of my head and throat, and which had
+hitherto buoyed up my spirits with madness and delirium, had now begun
+to retire within their proper channels, and the distinctness which was
+thus added to my perception of the danger, merely served to deprive me
+of the self-possession and courage to encounter it. But this weakness
+was, luckily for me, of no very long duration. In good time came to my
+rescue the spirit of despair, and, with frantic cries and struggles, I
+jerked my way bodily upwards, till at length, clutching with a vise-like
+grip the long-desired rim, I writhed my person over it, and fell
+headlong and shuddering within the car.
+
+“It was not until some time afterward that I recovered myself
+sufficiently to attend to the ordinary cares of the balloon. I then,
+however, examined it with attention, and found it, to my great relief,
+uninjured. My implements were all safe, and, fortunately, I had lost
+neither ballast nor provisions. Indeed, I had so well secured them in
+their places, that such an accident was entirely out of the question.
+Looking at my watch, I found it six o’clock. I was still rapidly
+ascending, and my barometer gave a present altitude of three and
+three-quarter miles. Immediately beneath me in the ocean, lay a small
+black object, slightly oblong in shape, seemingly about the size, and
+in every way bearing a great resemblance to one of those childish
+toys called a domino. Bringing my telescope to bear upon it, I plainly
+discerned it to be a British ninety four-gun ship, close-hauled, and
+pitching heavily in the sea with her head to the W.S.W. Besides this
+ship, I saw nothing but the ocean and the sky, and the sun, which had
+long arisen.
+
+“It is now high time that I should explain to your Excellencies the
+object of my perilous voyage. Your Excellencies will bear in mind that
+distressed circumstances in Rotterdam had at length driven me to the
+resolution of committing suicide. It was not, however, that to life
+itself I had any, positive disgust, but that I was harassed beyond
+endurance by the adventitious miseries attending my situation. In this
+state of mind, wishing to live, yet wearied with life, the treatise at
+the stall of the bookseller opened a resource to my imagination. I then
+finally made up my mind. I determined to depart, yet live--to leave the
+world, yet continue to exist--in short, to drop enigmas, I resolved, let
+what would ensue, to force a passage, if I could, to the moon. Now, lest
+I should be supposed more of a madman than I actually am, I will detail,
+as well as I am able, the considerations which led me to believe that
+an achievement of this nature, although without doubt difficult, and
+incontestably full of danger, was not absolutely, to a bold spirit,
+beyond the confines of the possible.
+
+“The moon’s actual distance from the earth was the first thing to be
+attended to. Now, the mean or average interval between the centres of
+the two planets is 59.9643 of the earth’s equatorial radii, or only
+about 237,000 miles. I say the mean or average interval. But it must
+be borne in mind that the form of the moon’s orbit being an ellipse of
+eccentricity amounting to no less than 0.05484 of the major semi-axis of
+the ellipse itself, and the earth’s centre being situated in its focus,
+if I could, in any manner, contrive to meet the moon, as it were, in its
+perigee, the above mentioned distance would be materially diminished.
+But, to say nothing at present of this possibility, it was very certain
+that, at all events, from the 237,000 miles I would have to deduct the
+radius of the earth, say 4,000, and the radius of the moon, say 1080,
+in all 5,080, leaving an actual interval to be traversed, under average
+circumstances, of 231,920 miles. Now this, I reflected, was no
+very extraordinary distance. Travelling on land has been repeatedly
+accomplished at the rate of thirty miles per hour, and indeed a much
+greater speed may be anticipated. But even at this velocity, it would
+take me no more than 322 days to reach the surface of the moon. There
+were, however, many particulars inducing me to believe that my average
+rate of travelling might possibly very much exceed that of thirty miles
+per hour, and, as these considerations did not fail to make a deep
+impression upon my mind, I will mention them more fully hereafter.
+
+“The next point to be regarded was a matter of far greater importance.
+From indications afforded by the barometer, we find that, in ascensions
+from the surface of the earth we have, at the height of 1,000 feet, left
+below us about one-thirtieth of the entire mass of atmospheric air, that
+at 10,600 we have ascended through nearly one-third; and that at 18,000,
+which is not far from the elevation of Cotopaxi, we have surmounted
+one-half the material, or, at all events, one-half the ponderable,
+body of air incumbent upon our globe. It is also calculated that at an
+altitude not exceeding the hundredth part of the earth’s diameter--that
+is, not exceeding eighty miles--the rarefaction would be so excessive
+that animal life could in no manner be sustained, and, moreover, that
+the most delicate means we possess of ascertaining the presence of the
+atmosphere would be inadequate to assure us of its existence. But I
+did not fail to perceive that these latter calculations are founded
+altogether on our experimental knowledge of the properties of air, and
+the mechanical laws regulating its dilation and compression, in what may
+be called, comparatively speaking, the immediate vicinity of the earth
+itself; and, at the same time, it is taken for granted that animal
+life is and must be essentially incapable of modification at any given
+unattainable distance from the surface. Now, all such reasoning and from
+such data must, of course, be simply analogical. The greatest height
+ever reached by man was that of 25,000 feet, attained in the aeronautic
+expedition of Messieurs Gay-Lussac and Biot. This is a moderate
+altitude, even when compared with the eighty miles in question; and I
+could not help thinking that the subject admitted room for doubt and
+great latitude for speculation.
+
+“But, in point of fact, an ascension being made to any given altitude,
+the ponderable quantity of air surmounted in any farther ascension is
+by no means in proportion to the additional height ascended (as may
+be plainly seen from what has been stated before), but in a ratio
+constantly decreasing. It is therefore evident that, ascend as high as
+we may, we cannot, literally speaking, arrive at a limit beyond which
+no atmosphere is to be found. It must exist, I argued; although it may
+exist in a state of infinite rarefaction.
+
+“On the other hand, I was aware that arguments have not been wanting
+to prove the existence of a real and definite limit to the atmosphere,
+beyond which there is absolutely no air whatsoever. But a circumstance
+which has been left out of view by those who contend for such a limit
+seemed to me, although no positive refutation of their creed, still
+a point worthy very serious investigation. On comparing the intervals
+between the successive arrivals of Encke’s comet at its perihelion,
+after giving credit, in the most exact manner, for all the disturbances
+due to the attractions of the planets, it appears that the periods are
+gradually diminishing; that is to say, the major axis of the comet’s
+ellipse is growing shorter, in a slow but perfectly regular decrease.
+Now, this is precisely what ought to be the case, if we suppose a
+resistance experienced from the comet from an extremely rare ethereal
+medium pervading the regions of its orbit. For it is evident that such
+a medium must, in retarding the comet’s velocity, increase its
+centripetal, by weakening its centrifugal force. In other words, the
+sun’s attraction would be constantly attaining greater power, and the
+comet would be drawn nearer at every revolution. Indeed, there is no
+other way of accounting for the variation in question. But again. The
+real diameter of the same comet’s nebulosity is observed to contract
+rapidly as it approaches the sun, and dilate with equal rapidity in its
+departure towards its aphelion. Was I not justifiable in supposing with
+M. Valz, that this apparent condensation of volume has its origin in
+the compression of the same ethereal medium I have spoken of before,
+and which is only denser in proportion to its solar vicinity? The
+lenticular-shaped phenomenon, also called the zodiacal light, was a
+matter worthy of attention. This radiance, so apparent in the tropics,
+and which cannot be mistaken for any meteoric lustre, extends from the
+horizon obliquely upward, and follows generally the direction of the
+sun’s equator. It appeared to me evidently in the nature of a rare
+atmosphere extending from the sun outward, beyond the orbit of Venus at
+least, and I believed indefinitely farther.(*2) Indeed, this medium I
+could not suppose confined to the path of the comet’s ellipse, or to
+the immediate neighborhood of the sun. It was easy, on the contrary,
+to imagine it pervading the entire regions of our planetary system,
+condensed into what we call atmosphere at the planets themselves, and
+perhaps at some of them modified by considerations, so to speak, purely
+geological.
+
+“Having adopted this view of the subject, I had little further
+hesitation. Granting that on my passage I should meet with atmosphere
+essentially the same as at the surface of the earth, I conceived that,
+by means of the very ingenious apparatus of M. Grimm, I should readily
+be enabled to condense it in sufficient quantity for the purposes of
+respiration. This would remove the chief obstacle in a journey to the
+moon. I had indeed spent some money and great labor in adapting the
+apparatus to the object intended, and confidently looked forward to its
+successful application, if I could manage to complete the voyage within
+any reasonable period. This brings me back to the rate at which it might
+be possible to travel.
+
+“It is true that balloons, in the first stage of their ascensions from
+the earth, are known to rise with a velocity comparatively moderate.
+Now, the power of elevation lies altogether in the superior lightness of
+the gas in the balloon compared with the atmospheric air; and, at
+first sight, it does not appear probable that, as the balloon acquires
+altitude, and consequently arrives successively in atmospheric strata
+of densities rapidly diminishing--I say, it does not appear at all
+reasonable that, in this its progress upwards, the original velocity
+should be accelerated. On the other hand, I was not aware that, in any
+recorded ascension, a diminution was apparent in the absolute rate
+of ascent; although such should have been the case, if on account
+of nothing else, on account of the escape of gas through balloons
+ill-constructed, and varnished with no better material than the ordinary
+varnish. It seemed, therefore, that the effect of such escape was only
+sufficient to counterbalance the effect of some accelerating power. I
+now considered that, provided in my passage I found the medium I
+had imagined, and provided that it should prove to be actually
+and essentially what we denominate atmospheric air, it could make
+comparatively little difference at what extreme state of rarefaction
+I should discover it--that is to say, in regard to my power of
+ascending--for the gas in the balloon would not only be itself subject
+to rarefaction partially similar (in proportion to the occurrence of
+which, I could suffer an escape of so much as would be requisite to
+prevent explosion), but, being what it was, would, at all events,
+continue specifically lighter than any compound whatever of mere
+nitrogen and oxygen. In the meantime, the force of gravitation would be
+constantly diminishing, in proportion to the squares of the distances,
+and thus, with a velocity prodigiously accelerating, I should at
+length arrive in those distant regions where the force of the earth’s
+attraction would be superseded by that of the moon. In accordance with
+these ideas, I did not think it worth while to encumber myself with more
+provisions than would be sufficient for a period of forty days.
+
+“There was still, however, another difficulty, which occasioned me some
+little disquietude. It has been observed, that, in balloon ascensions to
+any considerable height, besides the pain attending respiration, great
+uneasiness is experienced about the head and body, often accompanied
+with bleeding at the nose, and other symptoms of an alarming kind,
+and growing more and more inconvenient in proportion to the altitude
+attained.(*3) This was a reflection of a nature somewhat startling. Was
+it not probable that these symptoms would increase indefinitely, or at
+least until terminated by death itself? I finally thought not. Their
+origin was to be looked for in the progressive removal of the customary
+atmospheric pressure upon the surface of the body, and consequent
+distention of the superficial blood-vessels--not in any positive
+disorganization of the animal system, as in the case of difficulty in
+breathing, where the atmospheric density is chemically insufficient
+for the due renovation of blood in a ventricle of the heart. Unless for
+default of this renovation, I could see no reason, therefore, why
+life could not be sustained even in a vacuum; for the expansion and
+compression of chest, commonly called breathing, is action purely
+muscular, and the cause, not the effect, of respiration. In a word,
+I conceived that, as the body should become habituated to the want
+of atmospheric pressure, the sensations of pain would gradually
+diminish--and to endure them while they continued, I relied with
+confidence upon the iron hardihood of my constitution.
+
+“Thus, may it please your Excellencies, I have detailed some, though by
+no means all, the considerations which led me to form the project of
+a lunar voyage. I shall now proceed to lay before you the result of an
+attempt so apparently audacious in conception, and, at all events, so
+utterly unparalleled in the annals of mankind.
+
+“Having attained the altitude before mentioned, that is to say three
+miles and three-quarters, I threw out from the car a quantity of
+feathers, and found that I still ascended with sufficient rapidity;
+there was, therefore, no necessity for discharging any ballast. I was
+glad of this, for I wished to retain with me as much weight as I could
+carry, for reasons which will be explained in the sequel. I as yet
+suffered no bodily inconvenience, breathing with great freedom, and
+feeling no pain whatever in the head. The cat was lying very demurely
+upon my coat, which I had taken off, and eyeing the pigeons with an air
+of nonchalance. These latter being tied by the leg, to prevent their
+escape, were busily employed in picking up some grains of rice scattered
+for them in the bottom of the car.
+
+“At twenty minutes past six o’clock, the barometer showed an elevation
+of 26,400 feet, or five miles to a fraction. The prospect seemed
+unbounded. Indeed, it is very easily calculated by means of spherical
+geometry, what a great extent of the earth’s area I beheld. The convex
+surface of any segment of a sphere is, to the entire surface of the
+sphere itself, as the versed sine of the segment to the diameter of the
+sphere. Now, in my case, the versed sine--that is to say, the thickness
+of the segment beneath me--was about equal to my elevation, or the
+elevation of the point of sight above the surface. ‘As five miles, then,
+to eight thousand,’ would express the proportion of the earth’s area
+seen by me. In other words, I beheld as much as a sixteen-hundredth
+part of the whole surface of the globe. The sea appeared unruffled as a
+mirror, although, by means of the spy-glass, I could perceive it to be
+in a state of violent agitation. The ship was no longer visible, having
+drifted away, apparently to the eastward. I now began to experience, at
+intervals, severe pain in the head, especially about the ears--still,
+however, breathing with tolerable freedom. The cat and pigeons seemed to
+suffer no inconvenience whatsoever.
+
+“At twenty minutes before seven, the balloon entered a long series of
+dense cloud, which put me to great trouble, by damaging my condensing
+apparatus and wetting me to the skin. This was, to be sure, a singular
+recontre, for I had not believed it possible that a cloud of this nature
+could be sustained at so great an elevation. I thought it best, however,
+to throw out two five-pound pieces of ballast, reserving still a weight
+of one hundred and sixty-five pounds. Upon so doing, I soon rose above
+the difficulty, and perceived immediately, that I had obtained a great
+increase in my rate of ascent. In a few seconds after my leaving the
+cloud, a flash of vivid lightning shot from one end of it to the other,
+and caused it to kindle up, throughout its vast extent, like a mass of
+ignited and glowing charcoal. This, it must be remembered, was in the
+broad light of day. No fancy may picture the sublimity which might have
+been exhibited by a similar phenomenon taking place amid the darkness of
+the night. Hell itself might have been found a fitting image. Even as
+it was, my hair stood on end, while I gazed afar down within the yawning
+abysses, letting imagination descend, as it were, and stalk about in the
+strange vaulted halls, and ruddy gulfs, and red ghastly chasms of the
+hideous and unfathomable fire. I had indeed made a narrow escape. Had
+the balloon remained a very short while longer within the cloud--that
+is to say--had not the inconvenience of getting wet, determined me to
+discharge the ballast, inevitable ruin would have been the consequence.
+Such perils, although little considered, are perhaps the greatest which
+must be encountered in balloons. I had by this time, however, attained
+too great an elevation to be any longer uneasy on this head.
+
+“I was now rising rapidly, and by seven o’clock the barometer indicated
+an altitude of no less than nine miles and a half. I began to find great
+difficulty in drawing my breath. My head, too, was excessively painful;
+and, having felt for some time a moisture about my cheeks, I at length
+discovered it to be blood, which was oozing quite fast from the drums of
+my ears. My eyes, also, gave me great uneasiness. Upon passing the
+hand over them they seemed to have protruded from their sockets in no
+inconsiderable degree; and all objects in the car, and even the balloon
+itself, appeared distorted to my vision. These symptoms were more than
+I had expected, and occasioned me some alarm. At this juncture, very
+imprudently, and without consideration, I threw out from the car three
+five-pound pieces of ballast. The accelerated rate of ascent thus
+obtained, carried me too rapidly, and without sufficient gradation, into
+a highly rarefied stratum of the atmosphere, and the result had nearly
+proved fatal to my expedition and to myself. I was suddenly seized with
+a spasm which lasted for more than five minutes, and even when this, in
+a measure, ceased, I could catch my breath only at long intervals, and
+in a gasping manner--bleeding all the while copiously at the nose and
+ears, and even slightly at the eyes. The pigeons appeared distressed
+in the extreme, and struggled to escape; while the cat mewed piteously,
+and, with her tongue hanging out of her mouth, staggered to and fro in
+the car as if under the influence of poison. I now too late discovered
+the great rashness of which I had been guilty in discharging the
+ballast, and my agitation was excessive. I anticipated nothing less than
+death, and death in a few minutes. The physical suffering I underwent
+contributed also to render me nearly incapable of making any exertion
+for the preservation of my life. I had, indeed, little power of
+reflection left, and the violence of the pain in my head seemed to be
+greatly on the increase. Thus I found that my senses would shortly give
+way altogether, and I had already clutched one of the valve ropes with
+the view of attempting a descent, when the recollection of the trick I
+had played the three creditors, and the possible consequences to myself,
+should I return, operated to deter me for the moment. I lay down in the
+bottom of the car, and endeavored to collect my faculties. In this I
+so far succeeded as to determine upon the experiment of losing blood.
+Having no lancet, however, I was constrained to perform the operation in
+the best manner I was able, and finally succeeded in opening a vein
+in my right arm, with the blade of my penknife. The blood had hardly
+commenced flowing when I experienced a sensible relief, and by the time
+I had lost about half a moderate basin full, most of the worst symptoms
+had abandoned me entirely. I nevertheless did not think it expedient to
+attempt getting on my feet immediately; but, having tied up my arm as
+well as I could, I lay still for about a quarter of an hour. At the end
+of this time I arose, and found myself freer from absolute pain of any
+kind than I had been during the last hour and a quarter of my ascension.
+The difficulty of breathing, however, was diminished in a very slight
+degree, and I found that it would soon be positively necessary to make
+use of my condenser. In the meantime, looking toward the cat, who was
+again snugly stowed away upon my coat, I discovered to my infinite
+surprise, that she had taken the opportunity of my indisposition to
+bring into light a litter of three little kittens. This was an addition
+to the number of passengers on my part altogether unexpected; but I was
+pleased at the occurrence. It would afford me a chance of bringing to a
+kind of test the truth of a surmise, which, more than anything else,
+had influenced me in attempting this ascension. I had imagined that the
+habitual endurance of the atmospheric pressure at the surface of
+the earth was the cause, or nearly so, of the pain attending animal
+existence at a distance above the surface. Should the kittens be found
+to suffer uneasiness in an equal degree with their mother, I must
+consider my theory in fault, but a failure to do so I should look upon
+as a strong confirmation of my idea.
+
+“By eight o’clock I had actually attained an elevation of seventeen
+miles above the surface of the earth. Thus it seemed to me evident that
+my rate of ascent was not only on the increase, but that the progression
+would have been apparent in a slight degree even had I not discharged
+the ballast which I did. The pains in my head and ears returned, at
+intervals, with violence, and I still continued to bleed occasionally at
+the nose; but, upon the whole, I suffered much less than might have
+been expected. I breathed, however, at every moment, with more and
+more difficulty, and each inhalation was attended with a troublesome
+spasmodic action of the chest. I now unpacked the condensing apparatus,
+and got it ready for immediate use.
+
+“The view of the earth, at this period of my ascension, was beautiful
+indeed. To the westward, the northward, and the southward, as far as I
+could see, lay a boundless sheet of apparently unruffled ocean, which
+every moment gained a deeper and a deeper tint of blue and began already
+to assume a slight appearance of convexity. At a vast distance to the
+eastward, although perfectly discernible, extended the islands of Great
+Britain, the entire Atlantic coasts of France and Spain, with a small
+portion of the northern part of the continent of Africa. Of individual
+edifices not a trace could be discovered, and the proudest cities of
+mankind had utterly faded away from the face of the earth. From the rock
+of Gibraltar, now dwindled into a dim speck, the dark Mediterranean sea,
+dotted with shining islands as the heaven is dotted with stars, spread
+itself out to the eastward as far as my vision extended, until its
+entire mass of waters seemed at length to tumble headlong over the abyss
+of the horizon, and I found myself listening on tiptoe for the echoes
+of the mighty cataract. Overhead, the sky was of a jetty black, and the
+stars were brilliantly visible.
+
+“The pigeons about this time seeming to undergo much suffering, I
+determined upon giving them their liberty. I first untied one of them,
+a beautiful gray-mottled pigeon, and placed him upon the rim of the
+wicker-work. He appeared extremely uneasy, looking anxiously around him,
+fluttering his wings, and making a loud cooing noise, but could not be
+persuaded to trust himself from off the car. I took him up at last,
+and threw him to about half a dozen yards from the balloon. He made,
+however, no attempt to descend as I had expected, but struggled with
+great vehemence to get back, uttering at the same time very shrill and
+piercing cries. He at length succeeded in regaining his former station
+on the rim, but had hardly done so when his head dropped upon his
+breast, and he fell dead within the car. The other one did not prove so
+unfortunate. To prevent his following the example of his companion, and
+accomplishing a return, I threw him downward with all my force, and was
+pleased to find him continue his descent, with great velocity, making
+use of his wings with ease, and in a perfectly natural manner. In a very
+short time he was out of sight, and I have no doubt he reached home in
+safety. Puss, who seemed in a great measure recovered from her illness,
+now made a hearty meal of the dead bird and then went to sleep with much
+apparent satisfaction. Her kittens were quite lively, and so far evinced
+not the slightest sign of any uneasiness whatever.
+
+“At a quarter-past eight, being no longer able to draw breath without
+the most intolerable pain, I proceeded forthwith to adjust around
+the car the apparatus belonging to the condenser. This apparatus will
+require some little explanation, and your Excellencies will please to
+bear in mind that my object, in the first place, was to surround myself
+and cat entirely with a barricade against the highly rarefied atmosphere
+in which I was existing, with the intention of introducing within this
+barricade, by means of my condenser, a quantity of this same atmosphere
+sufficiently condensed for the purposes of respiration. With this object
+in view I had prepared a very strong perfectly air-tight, but flexible
+gum-elastic bag. In this bag, which was of sufficient dimensions, the
+entire car was in a manner placed. That is to say, it (the bag) was
+drawn over the whole bottom of the car, up its sides, and so on, along
+the outside of the ropes, to the upper rim or hoop where the net-work
+is attached. Having pulled the bag up in this way, and formed a complete
+enclosure on all sides, and at bottom, it was now necessary to fasten
+up its top or mouth, by passing its material over the hoop of the
+net-work--in other words, between the net-work and the hoop. But if the
+net-work were separated from the hoop to admit this passage, what was
+to sustain the car in the meantime? Now the net-work was not permanently
+fastened to the hoop, but attached by a series of running loops or
+nooses. I therefore undid only a few of these loops at one time, leaving
+the car suspended by the remainder. Having thus inserted a portion of
+the cloth forming the upper part of the bag, I refastened the loops--not
+to the hoop, for that would have been impossible, since the cloth
+now intervened--but to a series of large buttons, affixed to the cloth
+itself, about three feet below the mouth of the bag, the intervals
+between the buttons having been made to correspond to the intervals
+between the loops. This done, a few more of the loops were unfastened
+from the rim, a farther portion of the cloth introduced, and the
+disengaged loops then connected with their proper buttons. In this way
+it was possible to insert the whole upper part of the bag between the
+net-work and the hoop. It is evident that the hoop would now drop down
+within the car, while the whole weight of the car itself, with all its
+contents, would be held up merely by the strength of the buttons. This,
+at first sight, would seem an inadequate dependence; but it was by no
+means so, for the buttons were not only very strong in themselves, but
+so close together that a very slight portion of the whole weight was
+supported by any one of them. Indeed, had the car and contents been
+three times heavier than they were, I should not have been at
+all uneasy. I now raised up the hoop again within the covering of
+gum-elastic, and propped it at nearly its former height by means of
+three light poles prepared for the occasion. This was done, of course,
+to keep the bag distended at the top, and to preserve the lower part
+of the net-work in its proper situation. All that now remained was to
+fasten up the mouth of the enclosure; and this was readily accomplished
+by gathering the folds of the material together, and twisting them up
+very tightly on the inside by means of a kind of stationary tourniquet.
+
+“In the sides of the covering thus adjusted round the car, had been
+inserted three circular panes of thick but clear glass, through which I
+could see without difficulty around me in every horizontal direction.
+In that portion of the cloth forming the bottom, was likewise, a fourth
+window, of the same kind, and corresponding with a small aperture in the
+floor of the car itself. This enabled me to see perpendicularly
+down, but having found it impossible to place any similar contrivance
+overhead, on account of the peculiar manner of closing up the opening
+there, and the consequent wrinkles in the cloth, I could expect to see
+no objects situated directly in my zenith. This, of course, was a matter
+of little consequence; for had I even been able to place a window at
+top, the balloon itself would have prevented my making any use of it.
+
+“About a foot below one of the side windows was a circular opening,
+eight inches in diameter, and fitted with a brass rim adapted in its
+inner edge to the windings of a screw. In this rim was screwed the large
+tube of the condenser, the body of the machine being, of course, within
+the chamber of gum-elastic. Through this tube a quantity of the rare
+atmosphere circumjacent being drawn by means of a vacuum created in the
+body of the machine, was thence discharged, in a state of condensation,
+to mingle with the thin air already in the chamber. This operation being
+repeated several times, at length filled the chamber with atmosphere
+proper for all the purposes of respiration. But in so confined a space
+it would, in a short time, necessarily become foul, and unfit for use
+from frequent contact with the lungs. It was then ejected by a small
+valve at the bottom of the car--the dense air readily sinking into the
+thinner atmosphere below. To avoid the inconvenience of making a total
+vacuum at any moment within the chamber, this purification was never
+accomplished all at once, but in a gradual manner--the valve being
+opened only for a few seconds, then closed again, until one or two
+strokes from the pump of the condenser had supplied the place of the
+atmosphere ejected. For the sake of experiment I had put the cat and
+kittens in a small basket, and suspended it outside the car to a button
+at the bottom, close by the valve, through which I could feed them at
+any moment when necessary. I did this at some little risk, and before
+closing the mouth of the chamber, by reaching under the car with one of
+the poles before mentioned to which a hook had been attached.
+
+“By the time I had fully completed these arrangements and filled the
+chamber as explained, it wanted only ten minutes of nine o’clock. During
+the whole period of my being thus employed, I endured the most terrible
+distress from difficulty of respiration, and bitterly did I repent the
+negligence or rather fool-hardiness, of which I had been guilty, of
+putting off to the last moment a matter of so much importance. But
+having at length accomplished it, I soon began to reap the benefit of
+my invention. Once again I breathed with perfect freedom and ease--and
+indeed why should I not? I was also agreeably surprised to find myself,
+in a great measure, relieved from the violent pains which had hitherto
+tormented me. A slight headache, accompanied with a sensation of fulness
+or distention about the wrists, the ankles, and the throat, was nearly
+all of which I had now to complain. Thus it seemed evident that a
+greater part of the uneasiness attending the removal of atmospheric
+pressure had actually worn off, as I had expected, and that much of
+the pain endured for the last two hours should have been attributed
+altogether to the effects of a deficient respiration.
+
+“At twenty minutes before nine o’clock--that is to say, a short time
+prior to my closing up the mouth of the chamber, the mercury attained
+its limit, or ran down, in the barometer, which, as I mentioned before,
+was one of an extended construction. It then indicated an altitude on
+my part of 132,000 feet, or five-and-twenty miles, and I consequently
+surveyed at that time an extent of the earth’s area amounting to no less
+than the three hundred-and-twentieth part of its entire superficies.
+At nine o’clock I had again lost sight of land to the eastward, but not
+before I became aware that the balloon was drifting rapidly to the N.
+N. W. The convexity of the ocean beneath me was very evident indeed,
+although my view was often interrupted by the masses of cloud which
+floated to and fro. I observed now that even the lightest vapors never
+rose to more than ten miles above the level of the sea.
+
+“At half past nine I tried the experiment of throwing out a handful of
+feathers through the valve. They did not float as I had expected; but
+dropped down perpendicularly, like a bullet, en masse, and with the
+greatest velocity--being out of sight in a very few seconds. I did not
+at first know what to make of this extraordinary phenomenon; not being
+able to believe that my rate of ascent had, of a sudden, met with
+so prodigious an acceleration. But it soon occurred to me that the
+atmosphere was now far too rare to sustain even the feathers; that they
+actually fell, as they appeared to do, with great rapidity; and that I
+had been surprised by the united velocities of their descent and my own
+elevation.
+
+“By ten o’clock I found that I had very little to occupy my immediate
+attention. Affairs went swimmingly, and I believed the balloon to be
+going upward with a speed increasing momently although I had no longer
+any means of ascertaining the progression of the increase. I suffered no
+pain or uneasiness of any kind, and enjoyed better spirits than I had
+at any period since my departure from Rotterdam, busying myself now in
+examining the state of my various apparatus, and now in regenerating the
+atmosphere within the chamber. This latter point I determined to
+attend to at regular intervals of forty minutes, more on account of
+the preservation of my health, than from so frequent a renovation
+being absolutely necessary. In the meanwhile I could not help making
+anticipations. Fancy revelled in the wild and dreamy regions of the
+moon. Imagination, feeling herself for once unshackled, roamed at will
+among the ever-changing wonders of a shadowy and unstable land. Now
+there were hoary and time-honored forests, and craggy precipices, and
+waterfalls tumbling with a loud noise into abysses without a bottom.
+Then I came suddenly into still noonday solitudes, where no wind of
+heaven ever intruded, and where vast meadows of poppies, and slender,
+lily-looking flowers spread themselves out a weary distance, all silent
+and motionless forever. Then again I journeyed far down away into
+another country where it was all one dim and vague lake, with a boundary
+line of clouds. And out of this melancholy water arose a forest of tall
+eastern trees, like a wilderness of dreams. And I have in mind that
+the shadows of the trees which fell upon the lake remained not on
+the surface where they fell, but sunk slowly and steadily down, and
+commingled with the waves, while from the trunks of the trees other
+shadows were continually coming out, and taking the place of their
+brothers thus entombed. “This then,” I said thoughtfully, “is the very
+reason why the waters of this lake grow blacker with age, and more
+melancholy as the hours run on.” But fancies such as these were not the
+sole possessors of my brain. Horrors of a nature most stern and most
+appalling would too frequently obtrude themselves upon my mind, and
+shake the innermost depths of my soul with the bare supposition of their
+possibility. Yet I would not suffer my thoughts for any length of time
+to dwell upon these latter speculations, rightly judging the real and
+palpable dangers of the voyage sufficient for my undivided attention.
+
+“At five o’clock, p.m., being engaged in regenerating the atmosphere
+within the chamber, I took that opportunity of observing the cat and
+kittens through the valve. The cat herself appeared to suffer again very
+much, and I had no hesitation in attributing her uneasiness chiefly to a
+difficulty in breathing; but my experiment with the kittens had resulted
+very strangely. I had expected, of course, to see them betray a sense of
+pain, although in a less degree than their mother, and this would have
+been sufficient to confirm my opinion concerning the habitual endurance
+of atmospheric pressure. But I was not prepared to find them, upon close
+examination, evidently enjoying a high degree of health, breathing with
+the greatest ease and perfect regularity, and evincing not the slightest
+sign of any uneasiness whatever. I could only account for all this by
+extending my theory, and supposing that the highly rarefied atmosphere
+around might perhaps not be, as I had taken for granted, chemically
+insufficient for the purposes of life, and that a person born in such
+a medium might, possibly, be unaware of any inconvenience attending its
+inhalation, while, upon removal to the denser strata near the earth,
+he might endure tortures of a similar nature to those I had so lately
+experienced. It has since been to me a matter of deep regret that an
+awkward accident, at this time, occasioned me the loss of my little
+family of cats, and deprived me of the insight into this matter which a
+continued experiment might have afforded. In passing my hand through
+the valve, with a cup of water for the old puss, the sleeves of my shirt
+became entangled in the loop which sustained the basket, and thus, in
+a moment, loosened it from the bottom. Had the whole actually vanished
+into air, it could not have shot from my sight in a more abrupt and
+instantaneous manner. Positively, there could not have intervened the
+tenth part of a second between the disengagement of the basket and its
+absolute and total disappearance with all that it contained. My good
+wishes followed it to the earth, but of course, I had no hope that
+either cat or kittens would ever live to tell the tale of their
+misfortune.
+
+“At six o’clock, I perceived a great portion of the earth’s visible area
+to the eastward involved in thick shadow, which continued to advance
+with great rapidity, until, at five minutes before seven, the whole
+surface in view was enveloped in the darkness of night. It was not,
+however, until long after this time that the rays of the setting sun
+ceased to illumine the balloon; and this circumstance, although of
+course fully anticipated, did not fail to give me an infinite deal
+of pleasure. It was evident that, in the morning, I should behold the
+rising luminary many hours at least before the citizens of Rotterdam, in
+spite of their situation so much farther to the eastward, and thus, day
+after day, in proportion to the height ascended, would I enjoy the light
+of the sun for a longer and a longer period. I now determined to keep a
+journal of my passage, reckoning the days from one to twenty-four
+hours continuously, without taking into consideration the intervals of
+darkness.
+
+“At ten o’clock, feeling sleepy, I determined to lie down for the rest
+of the night; but here a difficulty presented itself, which, obvious as
+it may appear, had escaped my attention up to the very moment of which
+I am now speaking. If I went to sleep as I proposed, how could the
+atmosphere in the chamber be regenerated in the interim? To breathe
+it for more than an hour, at the farthest, would be a matter of
+impossibility, or, if even this term could be extended to an hour and a
+quarter, the most ruinous consequences might ensue. The consideration
+of this dilemma gave me no little disquietude; and it will hardly be
+believed, that, after the dangers I had undergone, I should look
+upon this business in so serious a light, as to give up all hope of
+accomplishing my ultimate design, and finally make up my mind to the
+necessity of a descent. But this hesitation was only momentary. I
+reflected that man is the veriest slave of custom, and that many points
+in the routine of his existence are deemed essentially important, which
+are only so at all by his having rendered them habitual. It was very
+certain that I could not do without sleep; but I might easily bring
+myself to feel no inconvenience from being awakened at intervals of an
+hour during the whole period of my repose. It would require but five
+minutes at most to regenerate the atmosphere in the fullest manner, and
+the only real difficulty was to contrive a method of arousing myself
+at the proper moment for so doing. But this was a question which, I am
+willing to confess, occasioned me no little trouble in its solution. To
+be sure, I had heard of the student who, to prevent his falling asleep
+over his books, held in one hand a ball of copper, the din of whose
+descent into a basin of the same metal on the floor beside his chair,
+served effectually to startle him up, if, at any moment, he should
+be overcome with drowsiness. My own case, however, was very different
+indeed, and left me no room for any similar idea; for I did not wish to
+keep awake, but to be aroused from slumber at regular intervals of time.
+I at length hit upon the following expedient, which, simple as it may
+seem, was hailed by me, at the moment of discovery, as an invention
+fully equal to that of the telescope, the steam-engine, or the art of
+printing itself.
+
+“It is necessary to premise, that the balloon, at the elevation now
+attained, continued its course upward with an even and undeviating
+ascent, and the car consequently followed with a steadiness so perfect
+that it would have been impossible to detect in it the slightest
+vacillation whatever. This circumstance favored me greatly in the
+project I now determined to adopt. My supply of water had been put on
+board in kegs containing five gallons each, and ranged very securely
+around the interior of the car. I unfastened one of these, and taking
+two ropes tied them tightly across the rim of the wicker-work from one
+side to the other; placing them about a foot apart and parallel so as to
+form a kind of shelf, upon which I placed the keg, and steadied it in a
+horizontal position. About eight inches immediately below these ropes,
+and four feet from the bottom of the car I fastened another shelf--but
+made of thin plank, being the only similar piece of wood I had. Upon
+this latter shelf, and exactly beneath one of the rims of the keg, a
+small earthern pitcher was deposited. I now bored a hole in the end of
+the keg over the pitcher, and fitted in a plug of soft wood, cut in a
+tapering or conical shape. This plug I pushed in or pulled out, as might
+happen, until, after a few experiments, it arrived at that exact degree
+of tightness, at which the water, oozing from the hole, and falling into
+the pitcher below, would fill the latter to the brim in the period
+of sixty minutes. This, of course, was a matter briefly and easily
+ascertained, by noticing the proportion of the pitcher filled in any
+given time. Having arranged all this, the rest of the plan is obvious.
+My bed was so contrived upon the floor of the car, as to bring my
+head, in lying down, immediately below the mouth of the pitcher. It was
+evident, that, at the expiration of an hour, the pitcher, getting full,
+would be forced to run over, and to run over at the mouth, which was
+somewhat lower than the rim. It was also evident, that the water thus
+falling from a height of more than four feet, could not do otherwise
+than fall upon my face, and that the sure consequences would be, to
+waken me up instantaneously, even from the soundest slumber in the
+world.
+
+“It was fully eleven by the time I had completed these arrangements,
+and I immediately betook myself to bed, with full confidence in the
+efficiency of my invention. Nor in this matter was I disappointed.
+Punctually every sixty minutes was I aroused by my trusty chronometer,
+when, having emptied the pitcher into the bung-hole of the keg, and
+performed the duties of the condenser, I retired again to bed. These
+regular interruptions to my slumber caused me even less discomfort than
+I had anticipated; and when I finally arose for the day, it was seven
+o’clock, and the sun had attained many degrees above the line of my
+horizon.
+
+“April 3d. I found the balloon at an immense height indeed, and the
+earth’s apparent convexity increased in a material degree. Below me in
+the ocean lay a cluster of black specks, which undoubtedly were islands.
+Far away to the northward I perceived a thin, white, and exceedingly
+brilliant line, or streak, on the edge of the horizon, and I had no
+hesitation in supposing it to be the southern disk of the ices of the
+Polar Sea. My curiosity was greatly excited, for I had hopes of passing
+on much farther to the north, and might possibly, at some period, find
+myself placed directly above the Pole itself. I now lamented that my
+great elevation would, in this case, prevent my taking as accurate a
+survey as I could wish. Much, however, might be ascertained. Nothing
+else of an extraordinary nature occurred during the day. My apparatus
+all continued in good order, and the balloon still ascended without any
+perceptible vacillation. The cold was intense, and obliged me to wrap
+up closely in an overcoat. When darkness came over the earth, I betook
+myself to bed, although it was for many hours afterward broad daylight
+all around my immediate situation. The water-clock was punctual in its
+duty, and I slept until next morning soundly, with the exception of the
+periodical interruption.
+
+“April 4th. Arose in good health and spirits, and was astonished at the
+singular change which had taken place in the appearance of the sea.
+It had lost, in a great measure, the deep tint of blue it had hitherto
+worn, being now of a grayish-white, and of a lustre dazzling to the eye.
+The islands were no longer visible; whether they had passed down the
+horizon to the southeast, or whether my increasing elevation had left
+them out of sight, it is impossible to say. I was inclined, however, to
+the latter opinion. The rim of ice to the northward was growing more
+and more apparent. Cold by no means so intense. Nothing of importance
+occurred, and I passed the day in reading, having taken care to supply
+myself with books.
+
+“April 5th. Beheld the singular phenomenon of the sun rising while
+nearly the whole visible surface of the earth continued to be involved
+in darkness. In time, however, the light spread itself over all, and I
+again saw the line of ice to the northward. It was now very distinct,
+and appeared of a much darker hue than the waters of the ocean. I was
+evidently approaching it, and with great rapidity. Fancied I could
+again distinguish a strip of land to the eastward, and one also to the
+westward, but could not be certain. Weather moderate. Nothing of any
+consequence happened during the day. Went early to bed.
+
+“April 6th. Was surprised at finding the rim of ice at a very moderate
+distance, and an immense field of the same material stretching away off
+to the horizon in the north. It was evident that if the balloon held its
+present course, it would soon arrive above the Frozen Ocean, and I had
+now little doubt of ultimately seeing the Pole. During the whole of the
+day I continued to near the ice. Toward night the limits of my horizon
+very suddenly and materially increased, owing undoubtedly to the
+earth’s form being that of an oblate spheroid, and my arriving above the
+flattened regions in the vicinity of the Arctic circle. When darkness at
+length overtook me, I went to bed in great anxiety, fearing to pass over
+the object of so much curiosity when I should have no opportunity of
+observing it.
+
+“April 7th. Arose early, and, to my great joy, at length beheld what
+there could be no hesitation in supposing the northern Pole itself. It
+was there, beyond a doubt, and immediately beneath my feet; but, alas! I
+had now ascended to so vast a distance, that nothing could with accuracy
+be discerned. Indeed, to judge from the progression of the numbers
+indicating my various altitudes, respectively, at different periods,
+between six A.M. on the second of April, and twenty minutes before nine
+A.M. of the same day (at which time the barometer ran down), it might be
+fairly inferred that the balloon had now, at four o’clock in the morning
+of April the seventh, reached a height of not less, certainly, than
+7,254 miles above the surface of the sea. This elevation may appear
+immense, but the estimate upon which it is calculated gave a result in
+all probability far inferior to the truth. At all events I undoubtedly
+beheld the whole of the earth’s major diameter; the entire northern
+hemisphere lay beneath me like a chart orthographically projected: and
+the great circle of the equator itself formed the boundary line of
+my horizon. Your Excellencies may, however, readily imagine that the
+confined regions hitherto unexplored within the limits of the Arctic
+circle, although situated directly beneath me, and therefore seen
+without any appearance of being foreshortened, were still, in
+themselves, comparatively too diminutive, and at too great a distance
+from the point of sight, to admit of any very accurate examination.
+Nevertheless, what could be seen was of a nature singular and exciting.
+Northwardly from that huge rim before mentioned, and which, with slight
+qualification, may be called the limit of human discovery in these
+regions, one unbroken, or nearly unbroken, sheet of ice continues to
+extend. In the first few degrees of this its progress, its surface is
+very sensibly flattened, farther on depressed into a plane, and finally,
+becoming not a little concave, it terminates, at the Pole itself, in a
+circular centre, sharply defined, whose apparent diameter subtended at
+the balloon an angle of about sixty-five seconds, and whose dusky hue,
+varying in intensity, was, at all times, darker than any other spot upon
+the visible hemisphere, and occasionally deepened into the most
+absolute and impenetrable blackness. Farther than this, little could
+be ascertained. By twelve o’clock the circular centre had materially
+decreased in circumference, and by seven P.M. I lost sight of it
+entirely; the balloon passing over the western limb of the ice, and
+floating away rapidly in the direction of the equator.
+
+“April 8th. Found a sensible diminution in the earth’s apparent
+diameter, besides a material alteration in its general color and
+appearance. The whole visible area partook in different degrees of a
+tint of pale yellow, and in some portions had acquired a brilliancy even
+painful to the eye. My view downward was also considerably impeded by
+the dense atmosphere in the vicinity of the surface being loaded with
+clouds, between whose masses I could only now and then obtain a glimpse
+of the earth itself. This difficulty of direct vision had troubled me
+more or less for the last forty-eight hours; but my present enormous
+elevation brought closer together, as it were, the floating bodies of
+vapor, and the inconvenience became, of course, more and more palpable
+in proportion to my ascent. Nevertheless, I could easily perceive that
+the balloon now hovered above the range of great lakes in the continent
+of North America, and was holding a course, due south, which would bring
+me to the tropics. This circumstance did not fail to give me the most
+heartful satisfaction, and I hailed it as a happy omen of ultimate
+success. Indeed, the direction I had hitherto taken, had filled me with
+uneasiness; for it was evident that, had I continued it much longer,
+there would have been no possibility of my arriving at the moon at all,
+whose orbit is inclined to the ecliptic at only the small angle of 5
+degrees 8’ 48”.
+
+“April 9th. To-day the earth’s diameter was greatly diminished, and the
+color of the surface assumed hourly a deeper tint of yellow. The balloon
+kept steadily on her course to the southward, and arrived, at nine P.M.,
+over the northern edge of the Mexican Gulf.
+
+“April 10th. I was suddenly aroused from slumber, about five o’clock
+this morning, by a loud, crackling, and terrific sound, for which I
+could in no manner account. It was of very brief duration, but, while
+it lasted resembled nothing in the world of which I had any previous
+experience. It is needless to say that I became excessively alarmed,
+having, in the first instance, attributed the noise to the bursting of
+the balloon. I examined all my apparatus, however, with great attention,
+and could discover nothing out of order. Spent a great part of the day
+in meditating upon an occurrence so extraordinary, but could find no
+means whatever of accounting for it. Went to bed dissatisfied, and in a
+state of great anxiety and agitation.
+
+“April 11th. Found a startling diminution in the apparent diameter of
+the earth, and a considerable increase, now observable for the first
+time, in that of the moon itself, which wanted only a few days of being
+full. It now required long and excessive labor to condense within the
+chamber sufficient atmospheric air for the sustenance of life.
+
+“April 12th. A singular alteration took place in regard to the direction
+of the balloon, and although fully anticipated, afforded me the most
+unequivocal delight. Having reached, in its former course, about the
+twentieth parallel of southern latitude, it turned off suddenly, at an
+acute angle, to the eastward, and thus proceeded throughout the day,
+keeping nearly, if not altogether, in the exact plane of the lunar
+elipse. What was worthy of remark, a very perceptible vacillation in
+the car was a consequence of this change of route--a vacillation which
+prevailed, in a more or less degree, for a period of many hours.
+
+“April 13th. Was again very much alarmed by a repetition of the loud,
+crackling noise which terrified me on the tenth. Thought long upon
+the subject, but was unable to form any satisfactory conclusion. Great
+decrease in the earth’s apparent diameter, which now subtended from the
+balloon an angle of very little more than twenty-five degrees. The moon
+could not be seen at all, being nearly in my zenith. I still continued
+in the plane of the elipse, but made little progress to the eastward.
+
+“April 14th. Extremely rapid decrease in the diameter of the earth.
+To-day I became strongly impressed with the idea, that the balloon was
+now actually running up the line of apsides to the point of perigee--in
+other words, holding the direct course which would bring it immediately
+to the moon in that part of its orbit the nearest to the earth. The moon
+itself was directly overhead, and consequently hidden from my view.
+Great and long-continued labor necessary for the condensation of the
+atmosphere.
+
+“April 15th. Not even the outlines of continents and seas could now
+be traced upon the earth with anything approaching distinctness. About
+twelve o’clock I became aware, for the third time, of that appalling
+sound which had so astonished me before. It now, however, continued for
+some moments, and gathered intensity as it continued. At length, while,
+stupefied and terror-stricken, I stood in expectation of I knew not what
+hideous destruction, the car vibrated with excessive violence, and
+a gigantic and flaming mass of some material which I could not
+distinguish, came with a voice of a thousand thunders, roaring and
+booming by the balloon. When my fears and astonishment had in some
+degree subsided, I had little difficulty in supposing it to be some
+mighty volcanic fragment ejected from that world to which I was so
+rapidly approaching, and, in all probability, one of that singular class
+of substances occasionally picked up on the earth, and termed meteoric
+stones for want of a better appellation.
+
+“April 16th. To-day, looking upward as well as I could, through each
+of the side windows alternately, I beheld, to my great delight, a very
+small portion of the moon’s disk protruding, as it were, on all sides
+beyond the huge circumference of the balloon. My agitation was extreme;
+for I had now little doubt of soon reaching the end of my perilous
+voyage. Indeed, the labor now required by the condenser had increased
+to a most oppressive degree, and allowed me scarcely any respite from
+exertion. Sleep was a matter nearly out of the question. I became quite
+ill, and my frame trembled with exhaustion. It was impossible that human
+nature could endure this state of intense suffering much longer. During
+the now brief interval of darkness a meteoric stone again passed in my
+vicinity, and the frequency of these phenomena began to occasion me much
+apprehension.
+
+“April 17th. This morning proved an epoch in my voyage. It will be
+remembered that, on the thirteenth, the earth subtended an angular
+breadth of twenty-five degrees. On the fourteenth this had greatly
+diminished; on the fifteenth a still more remarkable decrease was
+observable; and, on retiring on the night of the sixteenth, I had
+noticed an angle of no more than about seven degrees and fifteen
+minutes. What, therefore, must have been my amazement, on awakening
+from a brief and disturbed slumber, on the morning of this day,
+the seventeenth, at finding the surface beneath me so suddenly and
+wonderfully augmented in volume, as to subtend no less than thirty-nine
+degrees in apparent angular diameter! I was thunderstruck! No words
+can give any adequate idea of the extreme, the absolute horror and
+astonishment, with which I was seized possessed, and altogether
+overwhelmed. My knees tottered beneath me--my teeth chattered--my hair
+started up on end. “The balloon, then, had actually burst!” These were
+the first tumultuous ideas that hurried through my mind: “The balloon
+had positively burst!--I was falling--falling with the most impetuous,
+the most unparalleled velocity! To judge by the immense distance already
+so quickly passed over, it could not be more than ten minutes, at the
+farthest, before I should meet the surface of the earth, and be hurled
+into annihilation!” But at length reflection came to my relief. I
+paused; I considered; and I began to doubt. The matter was impossible.
+I could not in any reason have so rapidly come down. Besides, although
+I was evidently approaching the surface below me, it was with a speed
+by no means commensurate with the velocity I had at first so horribly
+conceived. This consideration served to calm the perturbation of my
+mind, and I finally succeeded in regarding the phenomenon in its proper
+point of view. In fact, amazement must have fairly deprived me of my
+senses, when I could not see the vast difference, in appearance, between
+the surface below me, and the surface of my mother earth. The latter
+was indeed over my head, and completely hidden by the balloon, while the
+moon--the moon itself in all its glory--lay beneath me, and at my feet.
+
+“The stupor and surprise produced in my mind by this extraordinary
+change in the posture of affairs was perhaps, after all, that part of
+the adventure least susceptible of explanation. For the bouleversement
+in itself was not only natural and inevitable, but had been long
+actually anticipated as a circumstance to be expected whenever I should
+arrive at that exact point of my voyage where the attraction of the
+planet should be superseded by the attraction of the satellite--or, more
+precisely, where the gravitation of the balloon toward the earth should
+be less powerful than its gravitation toward the moon. To be sure I
+arose from a sound slumber, with all my senses in confusion, to the
+contemplation of a very startling phenomenon, and one which, although
+expected, was not expected at the moment. The revolution itself must, of
+course, have taken place in an easy and gradual manner, and it is by no
+means clear that, had I even been awake at the time of the occurrence,
+I should have been made aware of it by any internal evidence of an
+inversion--that is to say, by any inconvenience or disarrangement,
+either about my person or about my apparatus.
+
+“It is almost needless to say that, upon coming to a due sense of my
+situation, and emerging from the terror which had absorbed every faculty
+of my soul, my attention was, in the first place, wholly directed to
+the contemplation of the general physical appearance of the moon. It
+lay beneath me like a chart--and although I judged it to be still at no
+inconsiderable distance, the indentures of its surface were defined
+to my vision with a most striking and altogether unaccountable
+distinctness. The entire absence of ocean or sea, and indeed of any lake
+or river, or body of water whatsoever, struck me, at first glance, as
+the most extraordinary feature in its geological condition. Yet, strange
+to say, I beheld vast level regions of a character decidedly alluvial,
+although by far the greater portion of the hemisphere in sight was
+covered with innumerable volcanic mountains, conical in shape, and
+having more the appearance of artificial than of natural protuberance.
+The highest among them does not exceed three and three-quarter miles
+in perpendicular elevation; but a map of the volcanic districts of the
+Campi Phlegraei would afford to your Excellencies a better idea of their
+general surface than any unworthy description I might think proper to
+attempt. The greater part of them were in a state of evident eruption,
+and gave me fearfully to understand their fury and their power, by the
+repeated thunders of the miscalled meteoric stones, which now rushed
+upward by the balloon with a frequency more and more appalling.
+
+“April 18th. To-day I found an enormous increase in the moon’s apparent
+bulk--and the evidently accelerated velocity of my descent began to fill
+me with alarm. It will be remembered, that, in the earliest stage of
+my speculations upon the possibility of a passage to the moon, the
+existence, in its vicinity, of an atmosphere, dense in proportion to the
+bulk of the planet, had entered largely into my calculations; this too
+in spite of many theories to the contrary, and, it may be added, in
+spite of a general disbelief in the existence of any lunar atmosphere at
+all. But, in addition to what I have already urged in regard to Encke’s
+comet and the zodiacal light, I had been strengthened in my opinion by
+certain observations of Mr. Schroeter, of Lilienthal. He observed the
+moon when two days and a half old, in the evening soon after sunset,
+before the dark part was visible, and continued to watch it until it
+became visible. The two cusps appeared tapering in a very sharp faint
+prolongation, each exhibiting its farthest extremity faintly illuminated
+by the solar rays, before any part of the dark hemisphere was
+visible. Soon afterward, the whole dark limb became illuminated. This
+prolongation of the cusps beyond the semicircle, I thought, must have
+arisen from the refraction of the sun’s rays by the moon’s atmosphere. I
+computed, also, the height of the atmosphere (which could refract light
+enough into its dark hemisphere to produce a twilight more luminous than
+the light reflected from the earth when the moon is about 32 degrees
+from the new) to be 1,356 Paris feet; in this view, I supposed the
+greatest height capable of refracting the solar ray, to be 5,376 feet.
+My ideas on this topic had also received confirmation by a passage in
+the eighty-second volume of the Philosophical Transactions, in which
+it is stated that at an occultation of Jupiter’s satellites, the third
+disappeared after having been about 1” or 2” of time indistinct, and the
+fourth became indiscernible near the limb.(*4)
+
+“Cassini frequently observed Saturn, Jupiter, and the fixed stars,
+when approaching the moon to occultation, to have their circular figure
+changed into an oval one; and, in other occultations, he found no
+alteration of figure at all. Hence it might be supposed, that at some
+times and not at others, there is a dense matter encompassing the moon
+wherein the rays of the stars are refracted.
+
+“Upon the resistance or, more properly, upon the support of an
+atmosphere, existing in the state of density imagined, I had, of course,
+entirely depended for the safety of my ultimate descent. Should I then,
+after all, prove to have been mistaken, I had in consequence nothing
+better to expect, as a finale to my adventure, than being dashed into
+atoms against the rugged surface of the satellite. And, indeed, I
+had now every reason to be terrified. My distance from the moon was
+comparatively trifling, while the labor required by the condenser was
+diminished not at all, and I could discover no indication whatever of a
+decreasing rarity in the air.
+
+“April 19th. This morning, to my great joy, about nine o’clock, the
+surface of the moon being frightfully near, and my apprehensions excited
+to the utmost, the pump of my condenser at length gave evident tokens
+of an alteration in the atmosphere. By ten, I had reason to believe
+its density considerably increased. By eleven, very little labor was
+necessary at the apparatus; and at twelve o’clock, with some hesitation,
+I ventured to unscrew the tourniquet, when, finding no inconvenience
+from having done so, I finally threw open the gum-elastic chamber, and
+unrigged it from around the car. As might have been expected, spasms
+and violent headache were the immediate consequences of an experiment
+so precipitate and full of danger. But these and other difficulties
+attending respiration, as they were by no means so great as to put me
+in peril of my life, I determined to endure as I best could, in
+consideration of my leaving them behind me momently in my approach
+to the denser strata near the moon. This approach, however, was still
+impetuous in the extreme; and it soon became alarmingly certain that,
+although I had probably not been deceived in the expectation of an
+atmosphere dense in proportion to the mass of the satellite, still I
+had been wrong in supposing this density, even at the surface, at all
+adequate to the support of the great weight contained in the car of my
+balloon. Yet this should have been the case, and in an equal degree
+as at the surface of the earth, the actual gravity of bodies at either
+planet supposed in the ratio of the atmospheric condensation. That
+it was not the case, however, my precipitous downfall gave testimony
+enough; why it was not so, can only be explained by a reference to those
+possible geological disturbances to which I have formerly alluded. At
+all events I was now close upon the planet, and coming down with the
+most terrible impetuosity. I lost not a moment, accordingly, in throwing
+overboard first my ballast, then my water-kegs, then my condensing
+apparatus and gum-elastic chamber, and finally every article within the
+car. But it was all to no purpose. I still fell with horrible rapidity,
+and was now not more than half a mile from the surface. As a last
+resource, therefore, having got rid of my coat, hat, and boots, I cut
+loose from the balloon the car itself, which was of no inconsiderable
+weight, and thus, clinging with both hands to the net-work, I had barely
+time to observe that the whole country, as far as the eye could reach,
+was thickly interspersed with diminutive habitations, ere I tumbled
+headlong into the very heart of a fantastical-looking city, and into the
+middle of a vast crowd of ugly little people, who none of them uttered
+a single syllable, or gave themselves the least trouble to render me
+assistance, but stood, like a parcel of idiots, grinning in a ludicrous
+manner, and eyeing me and my balloon askant, with their arms set
+a-kimbo. I turned from them in contempt, and, gazing upward at the earth
+so lately left, and left perhaps for ever, beheld it like a huge, dull,
+copper shield, about two degrees in diameter, fixed immovably in the
+heavens overhead, and tipped on one of its edges with a crescent
+border of the most brilliant gold. No traces of land or water could be
+discovered, and the whole was clouded with variable spots, and belted
+with tropical and equatorial zones.
+
+“Thus, may it please your Excellencies, after a series of great
+anxieties, unheard of dangers, and unparalleled escapes, I had, at
+length, on the nineteenth day of my departure from Rotterdam, arrived in
+safety at the conclusion of a voyage undoubtedly the most extraordinary,
+and the most momentous, ever accomplished, undertaken, or conceived by
+any denizen of earth. But my adventures yet remain to be related. And
+indeed your Excellencies may well imagine that, after a residence of
+five years upon a planet not only deeply interesting in its own peculiar
+character, but rendered doubly so by its intimate connection, in
+capacity of satellite, with the world inhabited by man, I may have
+intelligence for the private ear of the States’ College of Astronomers
+of far more importance than the details, however wonderful, of the mere
+voyage which so happily concluded. This is, in fact, the case. I
+have much--very much which it would give me the greatest pleasure to
+communicate. I have much to say of the climate of the planet; of its
+wonderful alternations of heat and cold, of unmitigated and burning
+sunshine for one fortnight, and more than polar frigidity for the next;
+of a constant transfer of moisture, by distillation like that in vacuo,
+from the point beneath the sun to the point the farthest from it; of
+a variable zone of running water, of the people themselves; of their
+manners, customs, and political institutions; of their peculiar physical
+construction; of their ugliness; of their want of ears, those useless
+appendages in an atmosphere so peculiarly modified; of their consequent
+ignorance of the use and properties of speech; of their substitute
+for speech in a singular method of inter-communication; of the
+incomprehensible connection between each particular individual in
+the moon with some particular individual on the earth--a connection
+analogous with, and depending upon, that of the orbs of the planet and
+the satellites, and by means of which the lives and destinies of the
+inhabitants of the one are interwoven with the lives and destinies
+of the inhabitants of the other; and above all, if it so please your
+Excellencies--above all, of those dark and hideous mysteries which lie
+in the outer regions of the moon--regions which, owing to the almost
+miraculous accordance of the satellite’s rotation on its own axis with
+its sidereal revolution about the earth, have never yet been turned,
+and, by God’s mercy, never shall be turned, to the scrutiny of the
+telescopes of man. All this, and more--much more--would I most
+willingly detail. But, to be brief, I must have my reward. I am pining
+for a return to my family and to my home, and as the price of any
+farther communication on my part--in consideration of the light which
+I have it in my power to throw upon many very important branches of
+physical and metaphysical science--I must solicit, through the influence
+of your honorable body, a pardon for the crime of which I have been
+guilty in the death of the creditors upon my departure from Rotterdam.
+This, then, is the object of the present paper. Its bearer, an
+inhabitant of the moon, whom I have prevailed upon, and properly
+instructed, to be my messenger to the earth, will await your
+Excellencies’ pleasure, and return to me with the pardon in question, if
+it can, in any manner, be obtained.
+
+“I have the honor to be, etc., your Excellencies’ very humble servant,
+
+“HANS PFAALL.”
+
+Upon finishing the perusal of this very extraordinary document,
+Professor Rub-a-dub, it is said, dropped his pipe upon the ground in
+the extremity of his surprise, and Mynheer Superbus Von Underduk having
+taken off his spectacles, wiped them, and deposited them in his pocket,
+so far forgot both himself and his dignity, as to turn round three times
+upon his heel in the quintessence of astonishment and admiration. There
+was no doubt about the matter--the pardon should be obtained. So at
+least swore, with a round oath, Professor Rub-a-dub, and so finally
+thought the illustrious Von Underduk, as he took the arm of his brother
+in science, and without saying a word, began to make the best of his way
+home to deliberate upon the measures to be adopted. Having reached the
+door, however, of the burgomaster’s dwelling, the professor ventured to
+suggest that as the messenger had thought proper to disappear--no
+doubt frightened to death by the savage appearance of the burghers of
+Rotterdam--the pardon would be of little use, as no one but a man of
+the moon would undertake a voyage to so vast a distance. To the truth of
+this observation the burgomaster assented, and the matter was therefore
+at an end. Not so, however, rumors and speculations. The letter, having
+been published, gave rise to a variety of gossip and opinion. Some of
+the over-wise even made themselves ridiculous by decrying the whole
+business; as nothing better than a hoax. But hoax, with these sort
+of people, is, I believe, a general term for all matters above their
+comprehension. For my part, I cannot conceive upon what data they have
+founded such an accusation. Let us see what they say:
+
+Imprimus. That certain wags in Rotterdam have certain especial
+antipathies to certain burgomasters and astronomers.
+
+Don’t understand at all.
+
+Secondly. That an odd little dwarf and bottle conjurer, both of whose
+ears, for some misdemeanor, have been cut off close to his head, has
+been missing for several days from the neighboring city of Bruges.
+
+Well--what of that?
+
+Thirdly. That the newspapers which were stuck all over the little
+balloon were newspapers of Holland, and therefore could not have been
+made in the moon. They were dirty papers--very dirty--and Gluck, the
+printer, would take his Bible oath to their having been printed in
+Rotterdam.
+
+He was mistaken--undoubtedly--mistaken.
+
+Fourthly, That Hans Pfaall himself, the drunken villain, and the three
+very idle gentlemen styled his creditors, were all seen, no longer than
+two or three days ago, in a tippling house in the suburbs, having just
+returned, with money in their pockets, from a trip beyond the sea.
+
+Don’t believe it--don’t believe a word of it.
+
+Lastly. That it is an opinion very generally received, or which ought
+to be generally received, that the College of Astronomers in the city
+of Rotterdam, as well as other colleges in all other parts of the
+world,--not to mention colleges and astronomers in general,--are, to say
+the least of the matter, not a whit better, nor greater, nor wiser than
+they ought to be.
+
+~~~ End of Text ~~~
+
+Notes to Hans Pfaal
+
+(*1) NOTE--Strictly speaking, there is but little similarity between the
+above sketchy trifle and the celebrated “Moon-Story” of Mr. Locke; but
+as both have the character of _hoaxes _(although the one is in a tone of
+banter, the other of downright earnest), and as both hoaxes are on the
+same subject, the moon--moreover, as both attempt to give plausibility
+by scientific detail--the author of “Hans Pfaall” thinks it necessary to
+say, in _self-defence, _that his own _jeu d’esprit _was published in the
+“Southern Literary Messenger” about three weeks before the commencement
+of Mr. L’s in the “New York Sun.” Fancying a likeness which, perhaps,
+does not exist, some of the New York papers copied “Hans Pfaall,” and
+collated it with the “Moon-Hoax,” by way of detecting the writer of the
+one in the writer of the other.
+
+As many more persons were actually gulled by the “Moon-Hoax” than would
+be willing to acknowledge the fact, it may here afford some little
+amusement to show why no one should have been deceived-to point out
+those particulars of the story which should have been sufficient to
+establish its real character. Indeed, however rich the imagination
+displayed in this ingenious fiction, it wanted much of the force which
+might have been given it by a more scrupulous attention to facts and
+to general analogy. That the public were misled, even for an instant,
+merely proves the gross ignorance which is so generally prevalent upon
+subjects of an astronomical nature.
+
+The moon’s distance from the earth is, in round numbers, 240,000 miles.
+If we desire to ascertain how near, apparently, a lens would bring the
+satellite (or any distant object), we, of course, have but to divide the
+distance by the magnifying or, more strictly, by the space-penetrating
+power of the glass. Mr. L. makes his lens have a power of 42,000 times.
+By this divide 240,000 (the moon’s real distance), and we have five
+miles and five sevenths, as the apparent distance. No animal at all
+could be seen so far; much less the minute points particularized in the
+story. Mr. L. speaks about Sir John Herschel’s perceiving flowers (the
+Papaver rheas, etc.), and even detecting the color and the shape of the
+eyes of small birds. Shortly before, too, he has himself observed that
+the lens would not render perceptible objects of less than eighteen
+inches in diameter; but even this, as I have said, is giving the glass
+by far too great power. It may be observed, in passing, that this
+prodigious glass is said to have been molded at the glasshouse of
+Messrs. Hartley and Grant, in Dumbarton; but Messrs. H. and G.’s
+establishment had ceased operations for many years previous to the
+publication of the hoax.
+
+On page 13, pamphlet edition, speaking of “a hairy veil” over the eyes
+of a species of bison, the author says: “It immediately occurred to the
+acute mind of Dr. Herschel that this was a providential contrivance
+to protect the eyes of the animal from the great extremes of light
+and darkness to which all the inhabitants of our side of the moon are
+periodically subjected.” But this cannot be thought a very “acute”
+ observation of the Doctor’s. The inhabitants of our side of the moon
+have, evidently, no darkness at all, so there can be nothing of the
+“extremes” mentioned. In the absence of the sun they have a light from
+the earth equal to that of thirteen full unclouded moons.
+
+The topography throughout, even when professing to accord with Blunt’s
+Lunar Chart, is entirely at variance with that or any other lunar chart,
+and even grossly at variance with itself. The points of the compass,
+too, are in inextricable confusion; the writer appearing to be ignorant
+that, on a lunar map, these are not in accordance with terrestrial
+points; the east being to the left, etc.
+
+Deceived, perhaps, by the vague titles, Mare Nubium, Mare
+Tranquillitatis, Mare Faecunditatis, etc., given to the dark spots by
+former astronomers, Mr. L. has entered into details regarding oceans
+and other large bodies of water in the moon; whereas there is no
+astronomical point more positively ascertained than that no such bodies
+exist there. In examining the boundary between light and darkness (in
+the crescent or gibbous moon) where this boundary crosses any of the
+dark places, the line of division is found to be rough and jagged; but,
+were these dark places liquid, it would evidently be even.
+
+The description of the wings of the man-bat, on page 21, is but a
+literal copy of Peter Wilkins’ account of the wings of his flying
+islanders. This simple fact should have induced suspicion, at least, it
+might be thought.
+
+On page 23, we have the following: “What a prodigious influence must our
+thirteen times larger globe have exercised upon this satellite when an
+embryo in the womb of time, the passive subject of chemical affinity!”
+ This is very fine; but it should be observed that no astronomer would
+have made such remark, especially to any journal of Science; for the
+earth, in the sense intended, is not only thirteen, but forty-nine times
+larger than the moon. A similar objection applies to the whole of the
+concluding pages, where, by way of introduction to some discoveries in
+Saturn, the philosophical correspondent enters into a minute schoolboy
+account of that planet--this to the “Edinburgh journal of Science!”
+
+But there is one point, in particular, which should have betrayed the
+fiction. Let us imagine the power actually possessed of seeing animals
+upon the moon’s surface--what would first arrest the attention of an
+observer from the earth? Certainly neither their shape, size, nor any
+other such peculiarity, so soon as their remarkable _situation_. They
+would appear to be walking, with heels up and head down, in the manner
+of flies on a ceiling. The _real_ observer would have uttered an instant
+ejaculation of surprise (however prepared by previous knowledge) at the
+singularity of their position; the _fictitious_ observer has not even
+mentioned the subject, but speaks of seeing the entire bodies of such
+creatures, when it is demonstrable that he could have seen only the
+diameter of their heads!
+
+It might as well be remarked, in conclusion, that the size, and
+particularly the powers of the man-bats (for example, their ability to
+fly in so rare an atmosphere--if, indeed, the moon have any), with most
+of the other fancies in regard to animal and vegetable existence, are at
+variance, generally, with all analogical reasoning on these themes; and
+that analogy here will often amount to conclusive demonstration. It is,
+perhaps, scarcely necessary to add, that all the suggestions attributed
+to Brewster and Herschel, in the beginning of the article, about “a
+transfusion of artificial light through the focal object of vision,”
+ etc., etc., belong to that species of figurative writing which comes,
+most properly, under the denomination of rigmarole.
+
+There is a real and very definite limit to optical discovery among the
+stars--a limit whose nature need only be stated to be understood. If,
+indeed, the casting of large lenses were all that is required, man’s
+ingenuity would ultimately prove equal to the task, and we might have
+them of any size demanded. But, unhappily, in proportion to the increase
+of size in the lens, and consequently of space-penetrating power, is the
+diminution of light from the object, by diffusion of its rays. And for
+this evil there is no remedy within human ability; for an object is seen
+by means of that light alone which proceeds from itself, whether direct
+or reflected. Thus the only “artificial” light which could avail
+Mr. Locke, would be some artificial light which he should be able to
+throw-not upon the “focal object of vision,” but upon the real object
+to be viewed-to wit: upon the moon. It has been easily calculated that,
+when the light proceeding from a star becomes so diffused as to be as
+weak as the natural light proceeding from the whole of the stars, in
+a clear and moonless night, then the star is no longer visible for any
+practical purpose.
+
+The Earl of Ross’s telescope, lately constructed in England, has
+a _speculum_ with a reflecting surface of 4,071 square inches; the
+Herschel telescope having one of only 1,811. The metal of the Earl of
+Ross’s is 6 feet diameter; it is 5 1/2 inches thick at the edges, and 5
+at the centre. The weight is 3 tons. The focal length is 50 feet.
+
+I have lately read a singular and somewhat ingenious little book, whose
+title-page runs thus: “L’Homme dans la lvne ou le Voyage Chimerique
+fait au Monde de la Lvne, nouellement decouvert par Dominique Gonzales,
+Aduanturier Espagnol, autrem?t dit le Courier volant. Mis en notre
+langve par J. B. D. A. Paris, chez Francois Piot, pres la Fontaine de
+Saint Benoist. Et chez J. Goignard, au premier pilier de la grand’salle
+du Palais, proche les Consultations, MDCXLVII.” Pp. 76.
+
+The writer professes to have translated his work from the English of one
+Mr. D’Avisson (Davidson?) although there is a terrible ambiguity in the
+statement. “J’ en ai eu,” says he “l’original de Monsieur D’Avisson,
+medecin des mieux versez qui soient aujourd’huy dans la cõnoissance des
+Belles Lettres, et sur tout de la Philosophic Naturelle. Je lui ai cette
+obligation entre les autres, de m’ auoir non seulement mis en main
+cc Livre en anglois, mais encore le Manuscrit du Sieur Thomas D’Anan,
+gentilhomme Eccossois, recommandable pour sa vertu, sur la version
+duquel j’ advoue que j’ ay tiré le plan de la mienne.”
+
+After some irrelevant adventures, much in the manner of Gil Blas, and
+which occupy the first thirty pages, the author relates that, being
+ill during a sea voyage, the crew abandoned him, together with a
+negro servant, on the island of St. Helena. To increase the chances of
+obtaining food, the two separate, and live as far apart as possible.
+This brings about a training of birds, to serve the purpose of
+carrier-pigeons between them. By and by these are taught to carry
+parcels of some weight-and this weight is gradually increased. At length
+the idea is entertained of uniting the force of a great number of the
+birds, with a view to raising the author himself. A machine is contrived
+for the purpose, and we have a minute description of it, which is
+materially helped out by a steel engraving. Here we perceive the
+Signor Gonzales, with point ruffles and a huge periwig, seated astride
+something which resembles very closely a broomstick, and borne aloft by
+a multitude of wild swans _(ganzas) _who had strings reaching from their
+tails to the machine.
+
+The main event detailed in the Signor’s narrative depends upon a very
+important fact, of which the reader is kept in ignorance until near the
+end of the book. The _ganzas, _with whom he had become so familiar, were
+not really denizens of St. Helena, but of the moon. Thence it had been
+their custom, time out of mind, to migrate annually to some portion of
+the earth. In proper season, of course, they would return home; and
+the author, happening, one day, to require their services for a short
+voyage, is unexpectedly carried straight tip, and in a very brief period
+arrives at the satellite. Here he finds, among other odd things, that
+the people enjoy extreme happiness; that they have no _law; _that they
+die without pain; that they are from ten to thirty feet in height;
+that they live five thousand years; that they have an emperor called
+Irdonozur; and that they can jump sixty feet high, when, being out of
+the gravitating influence, they fly about with fans.
+
+I cannot forbear giving a specimen of the general _philosophy _of the
+volume.
+
+“I must not forget here, that the stars appeared only on that side of
+the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also me and the earth. As to the
+stars, _since there was no night where I was, they always had the same
+appearance; not brilliant, as usual, but pale, and very nearly like the
+moon of a morning. _But few of them were visible, and these ten times
+larger (as well as I could judge) than they seem to the inhabitants
+of the earth. The moon, which wanted two days of being full, was of a
+terrible bigness.
+
+ “I must not forget here, that the stars appeared only on that side
+of the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also to inform you that, whether it was
+calm weather or stormy, I found myself _always immediately between the
+moon and the earth._ I_ _was convinced of this for two reasons-because
+my birds always flew in a straight line; and because whenever we
+attempted to rest, _we were carried insensibly around the globe of the
+earth. _For I admit the opinion of Copernicus, who maintains that it
+never ceases to revolve _from the east to the west, _not upon the poles
+of the Equinoctial, commonly called the poles of the world, but upon
+those of the Zodiac, a question of which I propose to speak more at
+length here-after, when I shall have leisure to refresh my memory in
+regard to the astrology which I learned at Salamanca when young, and
+have since forgotten.”
+
+Notwithstanding the blunders italicized, the book is not without
+some claim to attention, as affording a naive specimen of the current
+astronomical notions of the time. One of these assumed, that the
+“gravitating power” extended but a short distance from the earth’s
+surface, and, accordingly, we find our voyager “carried insensibly
+around the globe,” etc.
+
+There have been other “voyages to the moon,” but none of higher merit
+than the one just mentioned. That of Bergerac is utterly meaningless. In
+the third volume of the “American Quarterly Review” will be found
+quite an elaborate criticism upon a certain “journey” of the kind in
+question--a criticism in which it is difficult to say whether the critic
+most exposes the stupidity of the book, or his own absurd ignorance of
+astronomy. I forget the title of the work; but the _means _of the voyage
+are more deplorably ill conceived than are even the _ganzas _of our
+friend the Signor Gonzales. The adventurer, in digging the earth,
+happens to discover a peculiar metal for which the moon has a strong
+attraction, and straightway constructs of it a box, which, when cast
+loose from its terrestrial fastenings, flies with him, forthwith, to
+the satellite. The “Flight of Thomas O’Rourke,” is a _jeu d’ esprit _not
+altogether contemptible, and has been translated into German. Thomas,
+the hero, was, in fact, the gamekeeper of an Irish peer, whose
+eccentricities gave rise to the tale. The “flight” is made on an eagle’s
+back, from Hungry Hill, a lofty mountain at the end of Bantry Bay.
+
+In these various _brochures _the aim is always satirical; the theme
+being a description of Lunarian customs as compared with ours. In none
+is there any effort at _plausibility _in the details of the voyage
+itself. The writers seem, in each instance, to be utterly uninformed in
+respect to astronomy. In “Hans Pfaall” the design is original, inasmuch
+as regards an attempt at _verisimilitude, _in the application of
+scientific principles (so far as the whimsical nature of the subject
+would permit), to the actual passage between the earth and the moon.
+
+(*2) The zodiacal light is probably what the ancients called Trabes.
+Emicant Trabes quos docos vocant.--Pliny, lib. 2, p. 26.
+
+(*3) Since the original publication of Hans Pfaall, I find that Mr.
+Green, of Nassau balloon notoriety, and other late aeronauts, deny
+the assertions of Humboldt, in this respect, and speak of a decreasing
+inconvenience,--precisely in accordance with the theory here urged in a
+mere spirit of banter.
+
+(*4) Havelius writes that he has several times found, in skies
+perfectly clear, when even stars of the sixth and seventh magnitude
+were conspicuous, that, at the same altitude of the moon, at the
+same elongation from the earth, and with one and the same excellent
+telescope, the moon and its maculae did not appear equally lucid at all
+times. From the circumstances of the observation, it is evident that the
+cause of this phenomenon is not either in our air, in the tube, in
+the moon, or in the eye of the spectator, but must be looked for in
+something (an atmosphere?) existing about the moon.
+
+
+
+
+THE GOLD-BUG
+
+          What ho! what ho! this fellow is dancing mad!
+
+               He hath been bitten by the Tarantula.
+
+                    _--All in the Wrong._
+
+MANY years ago, I contracted an intimacy with a Mr. William Legrand.
+He was of an ancient Huguenot family, and had once been wealthy; but
+a series of misfortunes had reduced him to want. To avoid the
+mortification consequent upon his disasters, he left New Orleans, the
+city of his forefathers, and took up his residence at Sullivan’s Island,
+near Charleston, South Carolina. This Island is a very singular one.
+It consists of little else than the sea sand, and is about three
+miles long. Its breadth at no point exceeds a quarter of a mile. It is
+separated from the main land by a scarcely perceptible creek, oozing its
+way through a wilderness of reeds and slime, a favorite resort of the
+marsh hen. The vegetation, as might be supposed, is scant, or at least
+dwarfish. No trees of any magnitude are to be seen. Near the western
+extremity, where Fort Moultrie stands, and where are some miserable
+frame buildings, tenanted, during summer, by the fugitives from
+Charleston dust and fever, may be found, indeed, the bristly palmetto;
+but the whole island, with the exception of this western point, and
+a line of hard, white beach on the seacoast, is covered with a dense
+undergrowth of the sweet myrtle, so much prized by the horticulturists
+of England. The shrub here often attains the height of fifteen or twenty
+feet, and forms an almost impenetrable coppice, burthening the air with
+its fragrance.
+
+In the inmost recesses of this coppice, not far from the eastern or more
+remote end of the island, Legrand had built himself a small hut, which
+he occupied when I first, by mere accident, made his acquaintance.
+This soon ripened into friendship--for there was much in the recluse
+to excite interest and esteem. I found him well educated, with unusual
+powers of mind, but infected with misanthropy, and subject to perverse
+moods of alternate enthusiasm and melancholy. He had with him many
+books, but rarely employed them. His chief amusements were gunning and
+fishing, or sauntering along the beach and through the myrtles, in quest
+of shells or entomological specimens;--his collection of the latter
+might have been envied by a Swammerdamm. In these excursions he was
+usually accompanied by an old negro, called Jupiter, who had been
+manumitted before the reverses of the family, but who could be induced,
+neither by threats nor by promises, to abandon what he considered his
+right of attendance upon the footsteps of his young “Massa Will.” It
+is not improbable that the relatives of Legrand, conceiving him to be
+somewhat unsettled in intellect, had contrived to instil this obstinacy
+into Jupiter, with a view to the supervision and guardianship of the
+wanderer.
+
+The winters in the latitude of Sullivan’s Island are seldom very severe,
+and in the fall of the year it is a rare event indeed when a fire is
+considered necessary. About the middle of October, 18-, there occurred,
+however, a day of remarkable chilliness. Just before sunset I scrambled
+my way through the evergreens to the hut of my friend, whom I had
+not visited for several weeks--my residence being, at that time,
+in Charleston, a distance of nine miles from the Island, while the
+facilities of passage and re-passage were very far behind those of
+the present day. Upon reaching the hut I rapped, as was my custom,
+and getting no reply, sought for the key where I knew it was secreted,
+unlocked the door and went in. A fine fire was blazing upon the hearth.
+It was a novelty, and by no means an ungrateful one. I threw off an
+overcoat, took an arm-chair by the crackling logs, and awaited patiently
+the arrival of my hosts.
+
+Soon after dark they arrived, and gave me a most cordial welcome.
+Jupiter, grinning from ear to ear, bustled about to prepare some
+marsh-hens for supper. Legrand was in one of his fits--how else shall
+I term them?--of enthusiasm. He had found an unknown bivalve, forming
+a new genus, and, more than this, he had hunted down and secured, with
+Jupiter’s assistance, a scarabæus which he believed to be totally new,
+but in respect to which he wished to have my opinion on the morrow.
+
+“And why not to-night?” I asked, rubbing my hands over the blaze, and
+wishing the whole tribe of scarabæi at the devil.
+
+“Ah, if I had only known you were here!” said Legrand, “but it’s so long
+since I saw you; and how could I foresee that you would pay me a visit
+this very night of all others? As I was coming home I met Lieutenant
+G--, from the fort, and, very foolishly, I lent him the bug; so it will
+be impossible for you to see it until the morning. Stay here to-night,
+and I will send Jup down for it at sunrise. It is the loveliest thing in
+creation!”
+
+“What?--sunrise?”
+
+“Nonsense! no!--the bug. It is of a brilliant gold color--about the size
+of a large hickory-nut--with two jet black spots near one extremity of
+the back, and another, somewhat longer, at the other. The antennæ are--”
+
+“Dey aint no tin in him, Massa Will, I keep a tellin on you,” here
+interrupted Jupiter; “de bug is a goole bug, solid, ebery bit of him,
+inside and all, sep him wing--neber feel half so hebby a bug in my
+life.”
+
+“Well, suppose it is, Jup,” replied Legrand, somewhat more earnestly,
+it seemed to me, than the case demanded, “is that any reason for your
+letting the birds burn? The color”--here he turned to me--“is really
+almost enough to warrant Jupiter’s idea. You never saw a more brilliant
+metallic lustre than the scales emit--but of this you cannot judge
+till tomorrow. In the mean time I can give you some idea of the shape.”
+ Saying this, he seated himself at a small table, on which were a pen and
+ink, but no paper. He looked for some in a drawer, but found none.
+
+“Never mind,” said he at length, “this will answer;” and he drew from
+his waistcoat pocket a scrap of what I took to be very dirty foolscap,
+and made upon it a rough drawing with the pen. While he did this, I
+retained my seat by the fire, for I was still chilly. When the design
+was complete, he handed it to me without rising. As I received it, a
+loud growl was heard, succeeded by a scratching at the door. Jupiter
+opened it, and a large Newfoundland, belonging to Legrand, rushed in,
+leaped upon my shoulders, and loaded me with caresses; for I had shown
+him much attention during previous visits. When his gambols were over, I
+looked at the paper, and, to speak the truth, found myself not a little
+puzzled at what my friend had depicted.
+
+“Well!” I said, after contemplating it for some minutes, “this is a
+strange scarabæus, I must confess: new to me: never saw anything like it
+before--unless it was a skull, or a death’s-head--which it more nearly
+resembles than anything else that has come under my observation.”
+
+“A death’s-head!” echoed Legrand--“Oh--yes--well, it has something of
+that appearance upon paper, no doubt. The two upper black spots look
+like eyes, eh? and the longer one at the bottom like a mouth--and then
+the shape of the whole is oval.”
+
+“Perhaps so,” said I; “but, Legrand, I fear you are no artist. I must
+wait until I see the beetle itself, if I am to form any idea of its
+personal appearance.”
+
+“Well, I don’t know,” said he, a little nettled, “I draw
+tolerably--should do it at least--have had good masters, and flatter
+myself that I am not quite a blockhead.”
+
+“But, my dear fellow, you are joking then,” said I, “this is a very
+passable skull--indeed, I may say that it is a very excellent skull,
+according to the vulgar notions about such specimens of physiology--and
+your scarabæus must be the queerest scarabæus in the world if it
+resembles it. Why, we may get up a very thrilling bit of superstition
+upon this hint. I presume you will call the bug scarabæus caput hominis,
+or something of that kind--there are many similar titles in the Natural
+Histories. But where are the antennæ you spoke of?”
+
+“The antennæ!” said Legrand, who seemed to be getting unaccountably warm
+upon the subject; “I am sure you must see the antennæ. I made them
+as distinct as they are in the original insect, and I presume that is
+sufficient.”
+
+“Well, well,” I said, “perhaps you have--still I don’t see them;” and
+I handed him the paper without additional remark, not wishing to ruffle
+his temper; but I was much surprised at the turn affairs had taken; his
+ill humor puzzled me--and, as for the drawing of the beetle, there
+were positively no antennæ visible, and the whole did bear a very close
+resemblance to the ordinary cuts of a death’s-head.
+
+He received the paper very peevishly, and was about to crumple it,
+apparently to throw it in the fire, when a casual glance at the design
+seemed suddenly to rivet his attention. In an instant his face grew
+violently red--in another as excessively pale. For some minutes he
+continued to scrutinize the drawing minutely where he sat. At length he
+arose, took a candle from the table, and proceeded to seat himself upon
+a sea-chest in the farthest corner of the room. Here again he made an
+anxious examination of the paper; turning it in all directions. He said
+nothing, however, and his conduct greatly astonished me; yet I thought
+it prudent not to exacerbate the growing moodiness of his temper by any
+comment. Presently he took from his coat pocket a wallet, placed the
+paper carefully in it, and deposited both in a writing-desk, which he
+locked. He now grew more composed in his demeanor; but his original air
+of enthusiasm had quite disappeared. Yet he seemed not so much sulky as
+abstracted. As the evening wore away he became more and more absorbed in
+reverie, from which no sallies of mine could arouse him. It had been my
+intention to pass the night at the hut, as I had frequently done before,
+but, seeing my host in this mood, I deemed it proper to take leave. He
+did not press me to remain, but, as I departed, he shook my hand with
+even more than his usual cordiality.
+
+It was about a month after this (and during the interval I had seen
+nothing of Legrand) when I received a visit, at Charleston, from his
+man, Jupiter. I had never seen the good old negro look so dispirited,
+and I feared that some serious disaster had befallen my friend.
+
+“Well, Jup,” said I, “what is the matter now?--how is your master?”
+
+“Why, to speak de troof, massa, him not so berry well as mought be.”
+
+“Not well! I am truly sorry to hear it. What does he complain of?”
+
+“Dar! dat’s it!--him neber plain of notin--but him berry sick for all
+dat.”
+
+“Very sick, Jupiter!--why didn’t you say so at once? Is he confined to
+bed?”
+
+“No, dat he aint!--he aint find nowhar--dat’s just whar de shoe
+pinch--my mind is got to be berry hebby bout poor Massa Will.”
+
+“Jupiter, I should like to understand what it is you are talking about.
+You say your master is sick. Hasn’t he told you what ails him?”
+
+“Why, massa, taint worf while for to git mad about de matter--Massa
+Will say noffin at all aint de matter wid him--but den what make him go
+about looking dis here way, wid he head down and he soldiers up, and as
+white as a gose? And den he keep a syphon all de time--”
+
+“Keeps a what, Jupiter?”
+
+“Keeps a syphon wid de figgurs on de slate--de queerest figgurs I ebber
+did see. Ise gittin to be skeered, I tell you. Hab for to keep mighty
+tight eye pon him noovers. Todder day he gib me slip fore de sun up and
+was gone de whole ob de blessed day. I had a big stick ready cut for to
+gib him deuced good beating when he did come--but Ise sich a fool dat I
+hadn’t de heart arter all--he look so berry poorly.”
+
+“Eh?--what?--ah yes!--upon the whole I think you had better not be too
+severe with the poor fellow--don’t flog him, Jupiter--he can’t very well
+stand it--but can you form no idea of what has occasioned this illness,
+or rather this change of conduct? Has anything unpleasant happened since
+I saw you?”
+
+“No, massa, dey aint bin noffin unpleasant since den--‘twas fore den I’m
+feared--‘twas de berry day you was dare.”
+
+“How? what do you mean?”
+
+“Why, massa, I mean de bug--dare now.”
+
+“The what?”
+
+“De bug,--I’m berry sartain dat Massa Will bin bit somewhere bout de
+head by dat goole-bug.”
+
+“And what cause have you, Jupiter, for such a supposition?”
+
+“Claws enuff, massa, and mouth too. I nebber did see sick a deuced
+bug--he kick and he bite ebery ting what cum near him. Massa Will cotch
+him fuss, but had for to let him go gin mighty quick, I tell you--den
+was de time he must ha got de bite. I did n’t like de look oh de bug
+mouff, myself, no how, so I would n’t take hold ob him wid my finger,
+but I cotch him wid a piece ob paper dat I found. I rap him up in de
+paper and stuff piece ob it in he mouff--dat was de way.”
+
+“And you think, then, that your master was really bitten by the beetle,
+and that the bite made him sick?”
+
+“I do n’t tink noffin about it--I nose it. What make him dream bout de
+goole so much, if taint cause he bit by de goole-bug? Ise heerd bout dem
+goole-bugs fore dis.”
+
+“But how do you know he dreams about gold?”
+
+“How I know? why cause he talk about it in he sleep--dat’s how I nose.”
+
+“Well, Jup, perhaps you are right; but to what fortunate circumstance am
+I to attribute the honor of a visit from you to-day?”
+
+“What de matter, massa?”
+
+“Did you bring any message from Mr. Legrand?”
+
+“No, massa, I bring dis here pissel;” and here Jupiter handed me a note
+which ran thus:
+
+    MY DEAR ----
+
+Why have I not seen you for so long a time? I hope you have not been so
+foolish as to take offence at any little _brusquerie_ of mine; but no,
+that is improbable. Since I saw you I have had great cause for anxiety.
+I have something to tell you, yet scarcely know how to tell it, or
+whether I should tell it at all.
+
+I have not been quite well for some days past, and poor old Jup annoys
+me, almost beyond endurance, by his well-meant attentions Would you
+believe it?--he had prepared a huge stick, the other day, with which
+to chastise me for giving him the slip, and spending the day, _solus_,
+among the hills on the main land. I verily believe that my ill looks
+alone saved me a flogging.
+
+I have made no addition to my cabinet since we met.
+
+If you can, in any way, make it convenient, come over with Jupiter.
+_Do_ come. I wish to see you to-_night_, upon business of importance. I
+assure you that it is of the _highest_ importance.
+
+        Ever yours,                     WILLIAM LEGRAND.
+
+There was something in the tone of this note which gave me great
+uneasiness. Its whole style differed materially from that of Legrand.
+What could he be dreaming of? What new crotchet possessed his excitable
+brain? What “business of the highest importance” could he possibly have
+to transact? Jupiter’s account of him boded no good. I dreaded lest the
+continued pressure of misfortune had, at length, fairly unsettled
+the reason of my friend. Without a moment’s hesitation, therefore, I
+prepared to accompany the negro.
+
+Upon reaching the wharf, I noticed a scythe and three spades, all
+apparently new, lying in the bottom of the boat in which we were to
+embark.
+
+“What is the meaning of all this, Jup?” I inquired.
+
+“Him syfe, massa, and spade.”
+
+“Very true; but what are they doing here?”
+
+“Him de syfe and de spade what Massa Will sis pon my buying for him in
+de town, and de debbils own lot of money I had to gib for em.”
+
+“But what, in the name of all that is mysterious, is your ‘Massa Will’
+going to do with scythes and spades?”
+
+“Dat’s more dan I know, and debbil take me if I don’t blieve ‘tis more
+dan he know, too. But it’s all cum ob do bug.”
+
+Finding that no satisfaction was to be obtained of Jupiter, whose whole
+intellect seemed to be absorbed by “de bug,” I now stepped into the boat
+and made sail. With a fair and strong breeze we soon ran into the little
+cove to the northward of Fort Moultrie, and a walk of some two miles
+brought us to the hut. It was about three in the afternoon when we
+arrived. Legrand had been awaiting us in eager expectation. He grasped
+my hand with a nervous empressement which alarmed me and strengthened
+the suspicions already entertained. His countenance was pale even to
+ghastliness, and his deep-set eyes glared with unnatural lustre. After
+some inquiries respecting his health, I asked him, not knowing what
+better to say, if he had yet obtained the scarabæus from Lieutenant
+G ----.
+
+“Oh, yes,” he replied, coloring violently, “I got it from him the next
+morning. Nothing should tempt me to part with that scarabæus. Do you
+know that Jupiter is quite right about it?”
+
+“In what way?” I asked, with a sad foreboding at heart.
+
+“In supposing it to be a bug of real gold.” He said this with an air of
+profound seriousness, and I felt inexpressibly shocked.
+
+“This bug is to make my fortune,” he continued, with a triumphant smile,
+“to reinstate me in my family possessions. Is it any wonder, then, that
+I prize it? Since Fortune has thought fit to bestow it upon me, I have
+only to use it properly and I shall arrive at the gold of which it is
+the index. Jupiter; bring me that scarabæus!”
+
+“What! de bug, massa? I’d rudder not go fer trubble dat bug--you mus git
+him for your own self.” Hereupon Legrand arose, with a grave and
+stately air, and brought me the beetle from a glass case in which it was
+enclosed. It was a beautiful scarabæus, and, at that time, unknown to
+naturalists--of course a great prize in a scientific point of view.
+There were two round, black spots near one extremity of the back, and
+a long one near the other. The scales were exceedingly hard and glossy,
+with all the appearance of burnished gold. The weight of the insect
+was very remarkable, and, taking all things into consideration, I could
+hardly blame Jupiter for his opinion respecting it; but what to make of
+Legrand’s concordance with that opinion, I could not, for the life of
+me, tell.
+
+“I sent for you,” said he, in a grandiloquent tone, when I had completed
+my examination of the beetle, “I sent for you, that I might have your
+counsel and assistance in furthering the views of Fate and of the bug”--
+
+“My dear Legrand,” I cried, interrupting him, “you are certainly unwell,
+and had better use some little precautions. You shall go to bed, and
+I will remain with you a few days, until you get over this. You are
+feverish and”--
+
+“Feel my pulse,” said he.
+
+I felt it, and, to say the truth, found not the slightest indication of
+fever.
+
+“But you may be ill and yet have no fever. Allow me this once to
+prescribe for you. In the first place, go to bed. In the next”--
+
+“You are mistaken,” he interposed, “I am as well as I can expect to be
+under the excitement which I suffer. If you really wish me well, you
+will relieve this excitement.”
+
+“And how is this to be done?”
+
+“Very easily. Jupiter and myself are going upon an expedition into the
+hills, upon the main land, and, in this expedition we shall need the
+aid of some person in whom we can confide. You are the only one we can
+trust. Whether we succeed or fail, the excitement which you now perceive
+in me will be equally allayed.”
+
+“I am anxious to oblige you in any way,” I replied; “but do you mean to
+say that this infernal beetle has any connection with your expedition
+into the hills?”
+
+“It has.”
+
+“Then, Legrand, I can become a party to no such absurd proceeding.”
+
+“I am sorry--very sorry--for we shall have to try it by ourselves.”
+
+“Try it by yourselves! The man is surely mad!--but stay!--how long do
+you propose to be absent?”
+
+“Probably all night. We shall start immediately, and be back, at all
+events, by sunrise.”
+
+“And will you promise me, upon your honor, that when this freak of yours
+is over, and the bug business (good God!) settled to your satisfaction,
+you will then return home and follow my advice implicitly, as that of
+your physician?”
+
+“Yes; I promise; and now let us be off, for we have no time to lose.”
+
+With a heavy heart I accompanied my friend. We started about four
+o’clock--Legrand, Jupiter, the dog, and myself. Jupiter had with him the
+scythe and spades--the whole of which he insisted upon carrying--more
+through fear, it seemed to me, of trusting either of the implements
+within reach of his master, than from any excess of industry or
+complaisance. His demeanor was dogged in the extreme, and “dat deuced
+bug” were the sole words which escaped his lips during the journey. For
+my own part, I had charge of a couple of dark lanterns, while Legrand
+contented himself with the scarabæus, which he carried attached to the
+end of a bit of whip-cord; twirling it to and fro, with the air of a
+conjuror, as he went. When I observed this last, plain evidence of my
+friend’s aberration of mind, I could scarcely refrain from tears. I
+thought it best, however, to humor his fancy, at least for the present,
+or until I could adopt some more energetic measures with a chance of
+success. In the mean time I endeavored, but all in vain, to sound him in
+regard to the object of the expedition. Having succeeded in inducing
+me to accompany him, he seemed unwilling to hold conversation upon any
+topic of minor importance, and to all my questions vouchsafed no other
+reply than “we shall see!”
+
+We crossed the creek at the head of the island by means of a skiff; and,
+ascending the high grounds on the shore of the main land, proceeded in a
+northwesterly direction, through a tract of country excessively wild and
+desolate, where no trace of a human footstep was to be seen. Legrand led
+the way with decision; pausing only for an instant, here and there, to
+consult what appeared to be certain landmarks of his own contrivance
+upon a former occasion.
+
+In this manner we journeyed for about two hours, and the sun was just
+setting when we entered a region infinitely more dreary than any yet
+seen. It was a species of table land, near the summit of an almost
+inaccessible hill, densely wooded from base to pinnacle, and
+interspersed with huge crags that appeared to lie loosely upon the soil,
+and in many cases were prevented from precipitating themselves into the
+valleys below, merely by the support of the trees against which they
+reclined. Deep ravines, in various directions, gave an air of still
+sterner solemnity to the scene.
+
+The natural platform to which we had clambered was thickly overgrown
+with brambles, through which we soon discovered that it would have
+been impossible to force our way but for the scythe; and Jupiter, by
+direction of his master, proceeded to clear for us a path to the foot of
+an enormously tall tulip-tree, which stood, with some eight or ten oaks,
+upon the level, and far surpassed them all, and all other trees which I
+had then ever seen, in the beauty of its foliage and form, in the wide
+spread of its branches, and in the general majesty of its appearance.
+When we reached this tree, Legrand turned to Jupiter, and asked him if
+he thought he could climb it. The old man seemed a little staggered
+by the question, and for some moments made no reply. At length he
+approached the huge trunk, walked slowly around it, and examined it with
+minute attention. When he had completed his scrutiny, he merely said,
+
+“Yes, massa, Jup climb any tree he ebber see in he life.”
+
+“Then up with you as soon as possible, for it will soon be too dark to
+see what we are about.”
+
+“How far mus go up, massa?” inquired Jupiter.
+
+“Get up the main trunk first, and then I will tell you which way to
+go--and here--stop! take this beetle with you.”
+
+“De bug, Massa Will!--de goole bug!” cried the negro, drawing back in
+dismay--“what for mus tote de bug way up de tree?--d-n if I do!”
+
+“If you are afraid, Jup, a great big negro like you, to take hold of
+a harmless little dead beetle, why you can carry it up by this
+string--but, if you do not take it up with you in some way, I shall be
+under the necessity of breaking your head with this shovel.”
+
+“What de matter now, massa?” said Jup, evidently shamed into compliance;
+“always want for to raise fuss wid old nigger. Was only funnin any how.
+Me feered de bug! what I keer for de bug?” Here he took cautiously hold
+of the extreme end of the string, and, maintaining the insect as far
+from his person as circumstances would permit, prepared to ascend the
+tree.
+
+In youth, the tulip-tree, or Liriodendron Tulipferum, the most
+magnificent of American foresters, has a trunk peculiarly smooth, and
+often rises to a great height without lateral branches; but, in its
+riper age, the bark becomes gnarled and uneven, while many short limbs
+make their appearance on the stem. Thus the difficulty of ascension, in
+the present case, lay more in semblance than in reality. Embracing the
+huge cylinder, as closely as possible, with his arms and knees, seizing
+with his hands some projections, and resting his naked toes upon
+others, Jupiter, after one or two narrow escapes from falling, at length
+wriggled himself into the first great fork, and seemed to consider the
+whole business as virtually accomplished. The risk of the achievement
+was, in fact, now over, although the climber was some sixty or seventy
+feet from the ground.
+
+“Which way mus go now, Massa Will?” he asked.
+
+“Keep up the largest branch--the one on this side,” said Legrand. The
+negro obeyed him promptly, and apparently with but little trouble;
+ascending higher and higher, until no glimpse of his squat figure could
+be obtained through the dense foliage which enveloped it. Presently his
+voice was heard in a sort of halloo.
+
+“How much fudder is got for go?”
+
+“How high up are you?” asked Legrand.
+
+“Ebber so fur,” replied the negro; “can see de sky fru de top ob de
+tree.”
+
+“Never mind the sky, but attend to what I say. Look down the trunk and
+count the limbs below you on this side. How many limbs have you passed?”
+
+“One, two, tree, four, fibe--I done pass fibe big limb, massa, pon dis
+side.”
+
+“Then go one limb higher.”
+
+In a few minutes the voice was heard again, announcing that the seventh
+limb was attained.
+
+“Now, Jup,” cried Legrand, evidently much excited, “I want you to work
+your way out upon that limb as far as you can. If you see anything
+strange, let me know.” By this time what little doubt I might have
+entertained of my poor friend’s insanity, was put finally at rest. I had
+no alternative but to conclude him stricken with lunacy, and I became
+seriously anxious about getting him home. While I was pondering upon
+what was best to be done, Jupiter’s voice was again heard.
+
+“Mos feerd for to ventur pon dis limb berry far--tis dead limb putty
+much all de way.”
+
+“Did you say it was a dead limb, Jupiter?” cried Legrand in a quavering
+voice.
+
+“Yes, massa, him dead as de door-nail--done up for sartain--done
+departed dis here life.”
+
+“What in the name heaven shall I do?” asked Legrand, seemingly in the
+greatest distress. “Do!” said I, glad of an opportunity to interpose
+a word, “why come home and go to bed. Come now!--that’s a fine fellow.
+It’s getting late, and, besides, you remember your promise.”
+
+“Jupiter,” cried he, without heeding me in the least, “do you hear me?”
+
+“Yes, Massa Will, hear you ebber so plain.”
+
+“Try the wood well, then, with your knife, and see if you think it very
+rotten.”
+
+“Him rotten, massa, sure nuff,” replied the negro in a few moments, “but
+not so berry rotten as mought be. Mought ventur out leetle way pon de
+limb by myself, dat’s true.”
+
+“By yourself!--what do you mean?”
+
+“Why I mean de bug. ‘Tis berry hebby bug. Spose I drop him down fuss,
+and den de limb won’t break wid just de weight ob one nigger.”
+
+“You infernal scoundrel!” cried Legrand, apparently much relieved, “what
+do you mean by telling me such nonsense as that? As sure as you drop
+that beetle I’ll break your neck. Look here, Jupiter, do you hear me?”
+
+“Yes, massa, needn’t hollo at poor nigger dat style.”
+
+“Well! now listen!--if you will venture out on the limb as far as you
+think safe, and not let go the beetle, I’ll make you a present of a
+silver dollar as soon as you get down.”
+
+“I’m gwine, Massa Will--deed I is,” replied the negro very
+promptly--“mos out to the eend now.”
+
+“Out to the end!” here fairly screamed Legrand, “do you say you are out
+to the end of that limb?”
+
+“Soon be to de eend, massa,--o-o-o-o-oh! Lor-gol-a-marcy! what is dis
+here pon de tree?”
+
+“Well!” cried Legrand, highly delighted, “what is it?”
+
+“Why taint noffin but a skull--somebody bin lef him head up de tree, and
+de crows done gobble ebery bit ob de meat off.”
+
+“A skull, you say!--very well!--how is it fastened to the limb?--what
+holds it on?”
+
+“Sure nuff, massa; mus look. Why dis berry curous sarcumstance, pon my
+word--dare’s a great big nail in de skull, what fastens ob it on to de
+tree.”
+
+“Well now, Jupiter, do exactly as I tell you--do you hear?”
+
+“Yes, massa.”
+
+“Pay attention, then!--find the left eye of the skull.”
+
+“Hum! hoo! dat’s good! why dare aint no eye lef at all.”
+
+“Curse your stupidity! do you know your right hand from your left?”
+
+“Yes, I nose dat--nose all bout dat--tis my lef hand what I chops de
+wood wid.”
+
+“To be sure! you are left-handed; and your left eye is on the same
+side as your left hand. Now, I suppose, you can find the left eye of the
+skull, or the place where the left eye has been. Have you found it?”
+
+Here was a long pause. At length the negro asked,
+
+“Is de lef eye of de skull pon de same side as de lef hand of de skull,
+too?--cause de skull aint got not a bit ob a hand at all--nebber mind!
+I got de lef eye now--here de lef eye! what mus do wid it?”
+
+“Let the beetle drop through it, as far as the string will reach--but
+be careful and not let go your hold of the string.”
+
+“All dat done, Massa Will; mighty easy ting for to put de bug fru de
+hole--look out for him dare below!”
+
+During this colloquy no portion of Jupiter’s person could be seen; but
+the beetle, which he had suffered to descend, was now visible at the
+end of the string, and glistened, like a globe of burnished gold, in the
+last rays of the setting sun, some of which still faintly illumined
+the eminence upon which we stood. The scarabæus hung quite clear of
+any branches, and, if allowed to fall, would have fallen at our feet.
+Legrand immediately took the scythe, and cleared with it a circular
+space, three or four yards in diameter, just beneath the insect, and,
+having accomplished this, ordered Jupiter to let go the string and come
+down from the tree.
+
+Driving a peg, with great nicety, into the ground, at the precise spot
+where the beetle fell, my friend now produced from his pocket a tape
+measure. Fastening one end of this at that point of the trunk, of the
+tree which was nearest the peg, he unrolled it till it reached the peg,
+and thence farther unrolled it, in the direction already established
+by the two points of the tree and the peg, for the distance of fifty
+feet--Jupiter clearing away the brambles with the scythe. At the spot
+thus attained a second peg was driven, and about this, as a centre, a
+rude circle, about four feet in diameter, described. Taking now a spade
+himself, and giving one to Jupiter and one to me, Legrand begged us to
+set about digging as quickly as possible.
+
+To speak the truth, I had no especial relish for such amusement at any
+time, and, at that particular moment, would most willingly have declined
+it; for the night was coming on, and I felt much fatigued with the
+exercise already taken; but I saw no mode of escape, and was fearful
+of disturbing my poor friend’s equanimity by a refusal. Could I have
+depended, indeed, upon Jupiter’s aid, I would have had no hesitation in
+attempting to get the lunatic home by force; but I was too well assured
+of the old negro’s disposition, to hope that he would assist me, under
+any circumstances, in a personal contest with his master. I made no
+doubt that the latter had been infected with some of the innumerable
+Southern superstitions about money buried, and that his phantasy had
+received confirmation by the finding of the scarabæus, or, perhaps, by
+Jupiter’s obstinacy in maintaining it to be “a bug of real gold.” A
+mind disposed to lunacy would readily be led away by such
+suggestions--especially if chiming in with favorite preconceived
+ideas--and then I called to mind the poor fellow’s speech about the
+beetle’s being “the index of his fortune.” Upon the whole, I was sadly
+vexed and puzzled, but, at length, I concluded to make a virtue of
+necessity--to dig with a good will, and thus the sooner to convince the
+visionary, by ocular demonstration, of the fallacy of the opinions he
+entertained.
+
+The lanterns having been lit, we all fell to work with a zeal worthy
+a more rational cause; and, as the glare fell upon our persons and
+implements, I could not help thinking how picturesque a group we
+composed, and how strange and suspicious our labors must have appeared
+to any interloper who, by chance, might have stumbled upon our
+whereabouts.
+
+We dug very steadily for two hours. Little was said; and our chief
+embarrassment lay in the yelpings of the dog, who took exceeding
+interest in our proceedings. He, at length, became so obstreperous
+that we grew fearful of his giving the alarm to some stragglers in
+the vicinity;--or, rather, this was the apprehension of Legrand;--for
+myself, I should have rejoiced at any interruption which might have
+enabled me to get the wanderer home. The noise was, at length, very
+effectually silenced by Jupiter, who, getting out of the hole with a
+dogged air of deliberation, tied the brute’s mouth up with one of his
+suspenders, and then returned, with a grave chuckle, to his task.
+
+When the time mentioned had expired, we had reached a depth of five
+feet, and yet no signs of any treasure became manifest. A general pause
+ensued, and I began to hope that the farce was at an end. Legrand,
+however, although evidently much disconcerted, wiped his brow
+thoughtfully and recommenced. We had excavated the entire circle of four
+feet diameter, and now we slightly enlarged the limit, and went to the
+farther depth of two feet. Still nothing appeared. The gold-seeker, whom
+I sincerely pitied, at length clambered from the pit, with the bitterest
+disappointment imprinted upon every feature, and proceeded, slowly
+and reluctantly, to put on his coat, which he had thrown off at the
+beginning of his labor. In the mean time I made no remark. Jupiter, at a
+signal from his master, began to gather up his tools. This done, and the
+dog having been unmuzzled, we turned in profound silence towards home.
+
+We had taken, perhaps, a dozen steps in this direction, when, with a
+loud oath, Legrand strode up to Jupiter, and seized him by the collar.
+The astonished negro opened his eyes and mouth to the fullest extent,
+let fall the spades, and fell upon his knees.
+
+“You scoundrel,” said Legrand, hissing out the syllables from between
+his clenched teeth--“you infernal black villain!--speak, I tell
+you!--answer me this instant, without prevarication!--which--which is
+your left eye?”
+
+“Oh, my golly, Massa Will! aint dis here my lef eye for sartain?” roared
+the terrified Jupiter, placing his hand upon his right organ of vision,
+and holding it there with a desperate pertinacity, as if in immediate
+dread of his master’s attempt at a gouge.
+
+“I thought so!--I knew it! hurrah!” vociferated Legrand, letting the
+negro go, and executing a series of curvets and caracols, much to the
+astonishment of his valet, who, arising from his knees, looked, mutely,
+from his master to myself, and then from myself to his master.
+
+“Come! we must go back,” said the latter, “the game’s not up yet;” and
+he again led the way to the tulip-tree.
+
+“Jupiter,” said he, when we reached its foot, “come here! was the skull
+nailed to the limb with the face outwards, or with the face to the
+limb?”
+
+“De face was out, massa, so dat de crows could get at de eyes good,
+widout any trouble.”
+
+“Well, then, was it this eye or that through which you dropped the
+beetle?”--here Legrand touched each of Jupiter’s eyes.
+
+“Twas dis eye, massa--de lef eye--jis as you tell me,” and here it was
+his right eye that the negro indicated.
+
+“That will do--must try it again.”
+
+Here my friend, about whose madness I now saw, or fancied that I saw,
+certain indications of method, removed the peg which marked the spot
+where the beetle fell, to a spot about three inches to the westward
+of its former position. Taking, now, the tape measure from the nearest
+point of the trunk to the peg, as before, and continuing the extension
+in a straight line to the distance of fifty feet, a spot was indicated,
+removed, by several yards, from the point at which we had been digging.
+
+Around the new position a circle, somewhat larger than in the former
+instance, was now described, and we again set to work with the spades.
+I was dreadfully weary, but, scarcely understanding what had occasioned
+the change in my thoughts, I felt no longer any great aversion from the
+labor imposed. I had become most unaccountably interested--nay, even
+excited. Perhaps there was something, amid all the extravagant demeanor
+of Legrand--some air of forethought, or of deliberation, which impressed
+me. I dug eagerly, and now and then caught myself actually looking,
+with something that very much resembled expectation, for the fancied
+treasure, the vision of which had demented my unfortunate companion. At
+a period when such vagaries of thought most fully possessed me, and
+when we had been at work perhaps an hour and a half, we were again
+interrupted by the violent howlings of the dog. His uneasiness, in the
+first instance, had been, evidently, but the result of playfulness or
+caprice, but he now assumed a bitter and serious tone. Upon Jupiter’s
+again attempting to muzzle him, he made furious resistance, and, leaping
+into the hole, tore up the mould frantically with his claws. In a few
+seconds he had uncovered a mass of human bones, forming two complete
+skeletons, intermingled with several buttons of metal, and what appeared
+to be the dust of decayed woollen. One or two strokes of a spade
+upturned the blade of a large Spanish knife, and, as we dug farther,
+three or four loose pieces of gold and silver coin came to light.
+
+At sight of these the joy of Jupiter could scarcely be restrained, but
+the countenance of his master wore an air of extreme disappointment He
+urged us, however, to continue our exertions, and the words were hardly
+uttered when I stumbled and fell forward, having caught the toe of my
+boot in a large ring of iron that lay half buried in the loose earth.
+
+We now worked in earnest, and never did I pass ten minutes of more
+intense excitement. During this interval we had fairly unearthed an
+oblong chest of wood, which, from its perfect preservation and
+wonderful hardness, had plainly been subjected to some mineralizing
+process--perhaps that of the Bi-chloride of Mercury. This box was three
+feet and a half long, three feet broad, and two and a half feet deep. It
+was firmly secured by bands of wrought iron, riveted, and forming a kind
+of open trelliswork over the whole. On each side of the chest, near the
+top, were three rings of iron--six in all--by means of which a firm hold
+could be obtained by six persons. Our utmost united endeavors served
+only to disturb the coffer very slightly in its bed. We at once saw
+the impossibility of removing so great a weight. Luckily, the sole
+fastenings of the lid consisted of two sliding bolts. These we drew
+back--trembling and panting with anxiety. In an instant, a treasure of
+incalculable value lay gleaming before us. As the rays of the lanterns
+fell within the pit, there flashed upwards a glow and a glare, from a
+confused heap of gold and of jewels, that absolutely dazzled our eyes.
+
+I shall not pretend to describe the feelings with which I gazed.
+Amazement was, of course, predominant. Legrand appeared exhausted with
+excitement, and spoke very few words. Jupiter’s countenance wore, for
+some minutes, as deadly a pallor as it is possible, in nature of things,
+for any negro’s visage to assume. He seemed stupified--thunderstricken.
+Presently he fell upon his knees in the pit, and, burying his naked
+arms up to the elbows in gold, let them there remain, as if enjoying the
+luxury of a bath. At length, with a deep sigh, he exclaimed, as if in a
+soliloquy,
+
+“And dis all cum ob de goole-bug! de putty goole bug! de poor little
+goole-bug, what I boosed in dat sabage kind ob style! Aint you shamed ob
+yourself, nigger?--answer me dat!”
+
+It became necessary, at last, that I should arouse both master and valet
+to the expediency of removing the treasure. It was growing late, and
+it behooved us to make exertion, that we might get every thing housed
+before daylight. It was difficult to say what should be done, and much
+time was spent in deliberation--so confused were the ideas of all. We,
+finally, lightened the box by removing two thirds of its contents,
+when we were enabled, with some trouble, to raise it from the hole. The
+articles taken out were deposited among the brambles, and the dog
+left to guard them, with strict orders from Jupiter neither, upon any
+pretence, to stir from the spot, nor to open his mouth until our return.
+We then hurriedly made for home with the chest; reaching the hut in
+safety, but after excessive toil, at one o’clock in the morning. Worn
+out as we were, it was not in human nature to do more immediately. We
+rested until two, and had supper; starting for the hills immediately
+afterwards, armed with three stout sacks, which, by good luck, were upon
+the premises. A little before four we arrived at the pit, divided the
+remainder of the booty, as equally as might be, among us, and, leaving
+the holes unfilled, again set out for the hut, at which, for the second
+time, we deposited our golden burthens, just as the first faint streaks
+of the dawn gleamed from over the tree-tops in the East.
+
+We were now thoroughly broken down; but the intense excitement of the
+time denied us repose. After an unquiet slumber of some three or four
+hours’ duration, we arose, as if by preconcert, to make examination of
+our treasure.
+
+The chest had been full to the brim, and we spent the whole day, and the
+greater part of the next night, in a scrutiny of its contents. There had
+been nothing like order or arrangement. Every thing had been heaped
+in promiscuously. Having assorted all with care, we found ourselves
+possessed of even vaster wealth than we had at first supposed. In
+coin there was rather more than four hundred and fifty thousand
+dollars--estimating the value of the pieces, as accurately as we could,
+by the tables of the period. There was not a particle of silver. All was
+gold of antique date and of great variety--French, Spanish, and German
+money, with a few English guineas, and some counters, of which we had
+never seen specimens before. There were several very large and heavy
+coins, so worn that we could make nothing of their inscriptions. There
+was no American money. The value of the jewels we found more difficulty
+in estimating. There were diamonds--some of them exceedingly large and
+fine--a hundred and ten in all, and not one of them small; eighteen
+rubies of remarkable brilliancy;--three hundred and ten emeralds, all
+very beautiful; and twenty-one sapphires, with an opal. These stones had
+all been broken from their settings and thrown loose in the chest. The
+settings themselves, which we picked out from among the other gold,
+appeared to have been beaten up with hammers, as if to prevent
+identification. Besides all this, there was a vast quantity of solid
+gold ornaments;--nearly two hundred massive finger and earrings;--rich
+chains--thirty of these, if I remember;--eighty-three very large and
+heavy crucifixes;--five gold censers of great value;--a prodigious
+golden punch bowl, ornamented with richly chased vine-leaves and
+Bacchanalian figures; with two sword-handles exquisitely embossed, and
+many other smaller articles which I cannot recollect. The weight of
+these valuables exceeded three hundred and fifty pounds avoirdupois; and
+in this estimate I have not included one hundred and ninety-seven superb
+gold watches; three of the number being worth each five hundred dollars,
+if one. Many of them were very old, and as time keepers valueless; the
+works having suffered, more or less, from corrosion--but all were richly
+jewelled and in cases of great worth. We estimated the entire contents
+of the chest, that night, at a million and a half of dollars; and upon
+the subsequent disposal of the trinkets and jewels (a few being retained
+for our own use), it was found that we had greatly undervalued the
+treasure. When, at length, we had concluded our examination, and the
+intense excitement of the time had, in some measure, subsided, Legrand,
+who saw that I was dying with impatience for a solution of this
+most extraordinary riddle, entered into a full detail of all the
+circumstances connected with it.
+
+“You remember;” said he, “the night when I handed you the rough sketch I
+had made of the scarabæus. You recollect also, that I became quite vexed
+at you for insisting that my drawing resembled a death’s-head. When you
+first made this assertion I thought you were jesting; but afterwards
+I called to mind the peculiar spots on the back of the insect, and
+admitted to myself that your remark had some little foundation in fact.
+Still, the sneer at my graphic powers irritated me--for I am considered
+a good artist--and, therefore, when you handed me the scrap of
+parchment, I was about to crumple it up and throw it angrily into the
+fire.”
+
+“The scrap of paper, you mean,” said I.
+
+“No; it had much of the appearance of paper, and at first I supposed it
+to be such, but when I came to draw upon it, I discovered it, at once,
+to be a piece of very thin parchment. It was quite dirty, you remember.
+Well, as I was in the very act of crumpling it up, my glance fell
+upon the sketch at which you had been looking, and you may imagine my
+astonishment when I perceived, in fact, the figure of a death’s-head
+just where, it seemed to me, I had made the drawing of the beetle. For
+a moment I was too much amazed to think with accuracy. I knew that my
+design was very different in detail from this--although there was a
+certain similarity in general outline. Presently I took a candle, and
+seating myself at the other end of the room, proceeded to scrutinize the
+parchment more closely. Upon turning it over, I saw my own sketch
+upon the reverse, just as I had made it. My first idea, now, was mere
+surprise at the really remarkable similarity of outline--at the singular
+coincidence involved in the fact, that unknown to me, there should have
+been a skull upon the other side of the parchment, immediately beneath
+my figure of the scarabæus, and that this skull, not only in outline,
+but in size, should so closely resemble my drawing. I say the
+singularity of this coincidence absolutely stupified me for a time.
+This is the usual effect of such coincidences. The mind struggles to
+establish a connexion--a sequence of cause and effect--and, being
+unable to do so, suffers a species of temporary paralysis. But, when I
+recovered from this stupor, there dawned upon me gradually a conviction
+which startled me even far more than the coincidence. I began
+distinctly, positively, to remember that there had been no drawing upon
+the parchment when I made my sketch of the scarabæus. I became perfectly
+certain of this; for I recollected turning up first one side and then
+the other, in search of the cleanest spot. Had the skull been then
+there, of course I could not have failed to notice it. Here was indeed
+a mystery which I felt it impossible to explain; but, even at that early
+moment, there seemed to glimmer, faintly, within the most remote and
+secret chambers of my intellect, a glow-worm-like conception of
+that truth which last night’s adventure brought to so magnificent a
+demonstration. I arose at once, and putting the parchment securely away,
+dismissed all farther reflection until I should be alone.
+
+“When you had gone, and when Jupiter was fast asleep, I betook myself
+to a more methodical investigation of the affair. In the first place
+I considered the manner in which the parchment had come into my
+possession. The spot where we discovered the scarabaeus was on the coast
+of the main land, about a mile eastward of the island, and but a short
+distance above high water mark. Upon my taking hold of it, it gave me a
+sharp bite, which caused me to let it drop. Jupiter, with his accustomed
+caution, before seizing the insect, which had flown towards him, looked
+about him for a leaf, or something of that nature, by which to take hold
+of it. It was at this moment that his eyes, and mine also, fell upon the
+scrap of parchment, which I then supposed to be paper. It was lying half
+buried in the sand, a corner sticking up. Near the spot where we found
+it, I observed the remnants of the hull of what appeared to have been a
+ship’s long boat. The wreck seemed to have been there for a very great
+while; for the resemblance to boat timbers could scarcely be traced.
+
+“Well, Jupiter picked up the parchment, wrapped the beetle in it, and
+gave it to me. Soon afterwards we turned to go home, and on the way met
+Lieutenant G-. I showed him the insect, and he begged me to let him
+take it to the fort. Upon my consenting, he thrust it forthwith into his
+waistcoat pocket, without the parchment in which it had been wrapped,
+and which I had continued to hold in my hand during his inspection.
+Perhaps he dreaded my changing my mind, and thought it best to make sure
+of the prize at once--you know how enthusiastic he is on all subjects
+connected with Natural History. At the same time, without being
+conscious of it, I must have deposited the parchment in my own pocket.
+
+“You remember that when I went to the table, for the purpose of making
+a sketch of the beetle, I found no paper where it was usually kept.
+I looked in the drawer, and found none there. I searched my pockets,
+hoping to find an old letter, when my hand fell upon the parchment. I
+thus detail the precise mode in which it came into my possession; for
+the circumstances impressed me with peculiar force.
+
+“No doubt you will think me fanciful--but I had already established a
+kind of connexion. I had put together two links of a great chain. There
+was a boat lying upon a sea-coast, and not far from the boat was a
+parchment--not a paper--with a skull depicted upon it. You will,
+of course, ask ‘where is the connexion?’ I reply that the skull, or
+death’s-head, is the well-known emblem of the pirate. The flag of the
+death’s head is hoisted in all engagements.
+
+“I have said that the scrap was parchment, and not paper. Parchment
+is durable--almost imperishable. Matters of little moment are rarely
+consigned to parchment; since, for the mere ordinary purposes of drawing
+or writing, it is not nearly so well adapted as paper. This reflection
+suggested some meaning--some relevancy--in the death’s-head. I did not
+fail to observe, also, the form of the parchment. Although one of its
+corners had been, by some accident, destroyed, it could be seen that the
+original form was oblong. It was just such a slip, indeed, as might
+have been chosen for a memorandum--for a record of something to be long
+remembered and carefully preserved.”
+
+“But,” I interposed, “you say that the skull was not upon the parchment
+when you made the drawing of the beetle. How then do you trace any
+connexion between the boat and the skull--since this latter, according
+to your own admission, must have been designed (God only knows how or by
+whom) at some period subsequent to your sketching the scarabæus?”
+
+“Ah, hereupon turns the whole mystery; although the secret, at this
+point, I had comparatively little difficulty in solving. My steps were
+sure, and could afford but a single result. I reasoned, for example,
+thus: When I drew the scarabæus, there was no skull apparent upon
+the parchment. When I had completed the drawing I gave it to you, and
+observed you narrowly until you returned it. You, therefore, did not
+design the skull, and no one else was present to do it. Then it was not
+done by human agency. And nevertheless it was done.
+
+“At this stage of my reflections I endeavored to remember, and did
+remember, with entire distinctness, every incident which occurred about
+the period in question. The weather was chilly (oh rare and happy
+accident!), and a fire was blazing upon the hearth. I was heated with
+exercise and sat near the table. You, however, had drawn a chair close
+to the chimney. Just as I placed the parchment in your hand, and as you
+were in the act of inspecting it, Wolf, the Newfoundland, entered,
+and leaped upon your shoulders. With your left hand you caressed him and
+kept him off, while your right, holding the parchment, was permitted to
+fall listlessly between your knees, and in close proximity to the fire.
+At one moment I thought the blaze had caught it, and was about to
+caution you, but, before I could speak, you had withdrawn it, and were
+engaged in its examination. When I considered all these particulars, I
+doubted not for a moment that heat had been the agent in bringing to
+light, upon the parchment, the skull which I saw designed upon it. You
+are well aware that chemical preparations exist, and have existed time
+out of mind, by means of which it is possible to write upon either paper
+or vellum, so that the characters shall become visible only when
+subjected to the action of fire. Zaffre, digested in aqua regia, and
+diluted with four times its weight of water, is sometimes employed; a
+green tint results. The regulus of cobalt, dissolved in spirit of nitre,
+gives a red. These colors disappear at longer or shorter intervals after
+the material written upon cools, but again become apparent upon the
+re-application of heat.
+
+“I now scrutinized the death’s-head with care. Its outer edges--the
+edges of the drawing nearest the edge of the vellum--were far more
+distinct than the others. It was clear that the action of the caloric
+had been imperfect or unequal. I immediately kindled a fire, and
+subjected every portion of the parchment to a glowing heat. At first,
+the only effect was the strengthening of the faint lines in the skull;
+but, upon persevering in the experiment, there became visible, at
+the corner of the slip, diagonally opposite to the spot in which the
+death’s-head was delineated, the figure of what I at first supposed to
+be a goat. A closer scrutiny, however, satisfied me that it was intended
+for a kid.”
+
+“Ha! ha!” said I, “to be sure I have no right to laugh at you--a million
+and a half of money is too serious a matter for mirth--but you are not
+about to establish a third link in your chain--you will not find any
+especial connexion between your pirates and a goat--pirates, you know,
+have nothing to do with goats; they appertain to the farming interest.”
+
+“But I have just said that the figure was not that of a goat.”
+
+“Well, a kid then--pretty much the same thing.”
+
+“Pretty much, but not altogether,” said Legrand. “You may have heard of
+one Captain Kidd. I at once looked upon the figure of the animal as a
+kind of punning or hieroglyphical signature. I say signature; because
+its position upon the vellum suggested this idea. The death’s-head at
+the corner diagonally opposite, had, in the same manner, the air of a
+stamp, or seal. But I was sorely put out by the absence of all else--of
+the body to my imagined instrument--of the text for my context.”
+
+“I presume you expected to find a letter between the stamp and the
+signature.”
+
+“Something of that kind. The fact is, I felt irresistibly impressed with
+a presentiment of some vast good fortune impending. I can scarcely
+say why. Perhaps, after all, it was rather a desire than an actual
+belief;--but do you know that Jupiter’s silly words, about the bug
+being of solid gold, had a remarkable effect upon my fancy? And then the
+series of accidents and coincidences--these were so very extraordinary.
+Do you observe how mere an accident it was that these events should have
+occurred upon the sole day of all the year in which it has been, or may
+be, sufficiently cool for fire, and that without the fire, or without
+the intervention of the dog at the precise moment in which he appeared,
+I should never have become aware of the death’s-head, and so never the
+possessor of the treasure?”
+
+“But proceed--I am all impatience.”
+
+“Well; you have heard, of course, the many stories current--the thousand
+vague rumors afloat about money buried, somewhere upon the Atlantic
+coast, by Kidd and his associates. These rumors must have had some
+foundation in fact. And that the rumors have existed so long and so
+continuous, could have resulted, it appeared to me, only from the
+circumstance of the buried treasure still remaining entombed. Had Kidd
+concealed his plunder for a time, and afterwards reclaimed it, the
+rumors would scarcely have reached us in their present unvarying form.
+You will observe that the stories told are all about money-seekers,
+not about money-finders. Had the pirate recovered his money, there the
+affair would have dropped. It seemed to me that some accident--say the
+loss of a memorandum indicating its locality--had deprived him of the
+means of recovering it, and that this accident had become known to his
+followers, who otherwise might never have heard that treasure had been
+concealed at all, and who, busying themselves in vain, because unguided
+attempts, to regain it, had given first birth, and then universal
+currency, to the reports which are now so common. Have you ever heard of
+any important treasure being unearthed along the coast?”
+
+“Never.”
+
+“But that Kidd’s accumulations were immense, is well known. I took it
+for granted, therefore, that the earth still held them; and you will
+scarcely be surprised when I tell you that I felt a hope, nearly
+amounting to certainty, that the parchment so strangely found, involved
+a lost record of the place of deposit.”
+
+“But how did you proceed?”
+
+“I held the vellum again to the fire, after increasing the heat; but
+nothing appeared. I now thought it possible that the coating of dirt
+might have something to do with the failure; so I carefully rinsed the
+parchment by pouring warm water over it, and, having done this, I
+placed it in a tin pan, with the skull downwards, and put the pan upon
+a furnace of lighted charcoal. In a few minutes, the pan having become
+thoroughly heated, I removed the slip, and, to my inexpressible joy,
+found it spotted, in several places, with what appeared to be figures
+arranged in lines. Again I placed it in the pan, and suffered it to
+remain another minute. Upon taking it off, the whole was just as you see
+it now.” Here Legrand, having re-heated the parchment, submitted it to
+my inspection. The following characters were rudely traced, in a red
+tint, between the death’s-head and the goat:
+
+  “53‡‡†305))6*;4826)4‡)4‡);806*;48†8¶60))85;1‡);:‡
+  *8†83(88)5*†;46(;88*96*?;8)*‡(;485);5*†2:*‡(;4956*
+  2(5*--4)8¶8*;4069285);)6†8)4‡‡;1(‡9;48081;8:8‡1;4
+  8†85;4)485†528806*81(‡9;48;(88;4(‡?34;48)4‡;161;:
+  188;‡?;”
+
+“But,” said I, returning him the slip, “I am as much in the dark as
+ever. Were all the jewels of Golconda awaiting me upon my solution of
+this enigma, I am quite sure that I should be unable to earn them.”
+
+“And yet,” said Legrand, “the solution is by no means so difficult as
+you might be lead to imagine from the first hasty inspection of the
+characters. These characters, as any one might readily guess, form a
+cipher--that is to say, they convey a meaning; but then, from what is
+known of Kidd, I could not suppose him capable of constructing any of
+the more abstruse cryptographs. I made up my mind, at once, that this
+was of a simple species--such, however, as would appear, to the crude
+intellect of the sailor, absolutely insoluble without the key.”
+
+“And you really solved it?”
+
+“Readily; I have solved others of an abstruseness ten thousand times
+greater. Circumstances, and a certain bias of mind, have led me to
+take interest in such riddles, and it may well be doubted whether human
+ingenuity can construct an enigma of the kind which human ingenuity may
+not, by proper application, resolve. In fact, having once established
+connected and legible characters, I scarcely gave a thought to the mere
+difficulty of developing their import.
+
+“In the present case--indeed in all cases of secret writing--the first
+question regards the language of the cipher; for the principles of
+solution, so far, especially, as the more simple ciphers are concerned,
+depend upon, and are varied by, the genius of the particular idiom.
+In general, there is no alternative but experiment (directed by
+probabilities) of every tongue known to him who attempts the solution,
+until the true one be attained. But, with the cipher now before us, all
+difficulty was removed by the signature. The pun upon the word ‘Kidd’
+is appreciable in no other language than the English. But for this
+consideration I should have begun my attempts with the Spanish and
+French, as the tongues in which a secret of this kind would most
+naturally have been written by a pirate of the Spanish main. As it was,
+I assumed the cryptograph to be English.
+
+“You observe there are no divisions between the words. Had there been
+divisions, the task would have been comparatively easy. In such case
+I should have commenced with a collation and analysis of the shorter
+words, and, had a word of a single letter occurred, as is most likely,
+(a or I, for example,) I should have considered the solution as assured.
+But, there being no division, my first step was to ascertain the
+predominant letters, as well as the least frequent. Counting all, I
+constructed a table, thus:
+
+Of the character 8 there are 33.
+
+                          ;        “     26.
+                          4        “     19.
+                        ‡ )        “     16.
+                          *        “     13.
+                          5        “     12.
+                          6        “     11.
+                        † 1        “      8.
+                          0        “      6.
+                        9 2        “      5.
+                        : 3        “      4.
+                          ?        “      3.
+                          ¶        “      2.
+                         -.        “      1.
+
+“Now, in English, the letter which most frequently occurs is e.
+Afterwards, succession runs thus: _a o i d h n r s t u y c f g l m w b k
+p q x z_. _E_ predominates so remarkably that an individual sentence of
+any length is rarely seen, in which it is not the prevailing character.
+
+“Here, then, we leave, in the very beginning, the groundwork for
+something more than a mere guess. The general use which may be made of
+the table is obvious--but, in this particular cipher, we shall only very
+partially require its aid. As our predominant character is 8, we will
+commence by assuming it as the _e_ of the natural alphabet. To verify
+the supposition, let us observe if the 8 be seen often in couples--for
+_e_ is doubled with great frequency in English--in such words, for
+example, as ‘meet,’ ‘.fleet,’ ‘speed,’ ‘seen,’ been,’ ‘agree,’ &c. In
+the present instance we see it doubled no less than five times, although
+the cryptograph is brief.
+
+“Let us assume 8, then, as _e_. Now, of all _words_ in the language,
+‘the’ is most usual; let us see, therefore, whether there are not
+repetitions of any three characters, in the same order of collocation,
+the last of them being 8. If we discover repetitions of such letters,
+so arranged, they will most probably represent the word ‘the.’ Upon
+inspection, we find no less than seven such arrangements, the characters
+being;48. We may, therefore, assume that; represents _t_, 4 represents
+_h_, and 8 represents _e_--the last being now well confirmed. Thus a
+great step has been taken.
+
+“But, having established a single word, we are enabled to establish
+a vastly important point; that is to say, several commencements and
+terminations of other words. Let us refer, for example, to the last
+instance but one, in which the combination;48 occurs--not far from
+the end of the cipher. We know that the; immediately ensuing is the
+commencement of a word, and, of the six characters succeeding this
+‘the,’ we are cognizant of no less than five. Let us set these
+characters down, thus, by the letters we know them to represent, leaving
+a space for the unknown--
+
+t eeth.
+
+“Here we are enabled, at once, to discard the ‘th,’ as forming no
+portion of the word commencing with the first t; since, by experiment
+of the entire alphabet for a letter adapted to the vacancy, we perceive
+that no word can be formed of which this _th_ can be a part. We are thus
+narrowed into
+
+t ee,
+
+and, going through the alphabet, if necessary, as before, we arrive
+at the word ‘tree,’ as the sole possible reading. We thus gain
+another letter, _r_, represented by (, with the words ‘the tree’ in
+juxtaposition.
+
+“Looking beyond these words, for a short distance, we again see
+the combination;48, and employ it by way of _termination_ to what
+immediately precedes. We have thus this arrangement:
+
+the tree;4(‡?34 the,
+
+or, substituting the natural letters, where known, it reads thus:
+
+the tree thr‡?3h the.
+
+“Now, if, in place of the unknown characters, we leave blank spaces, or
+substitute dots, we read thus:
+
+the tree thr...h the,
+
+when the word ‘_through_’ makes itself evident at once. But this
+discovery gives us three new letters, _o_, _u_ and _g_, represented by
+‡? and 3.
+
+“Looking now, narrowly, through the cipher for combinations of known
+characters, we find, not very far from the beginning, this arrangement,
+
+83(88, or egree,
+
+which, plainly, is the conclusion of the word ‘degree,’ and gives us
+another letter, _d_, represented by †.
+
+“Four letters beyond the word ‘degree,’ we perceive the combination
+
+;46(;88.
+
+“Translating the known characters, and representing the unknown by dots,
+as before, we read thus: th rtee. an arrangement immediately suggestive
+of the word ‘thirteen,’ and again furnishing us with two new characters,
+_i_ and _n_, represented by 6 and *.
+
+“Referring, now, to the beginning of the cryptograph, we find the
+combination,
+
+53‡‡†.
+
+“Translating, as before, we obtain
+
+good,
+
+which assures us that the first letter is _A_, and that the first two
+words are ‘A good.’
+
+“It is now time that we arrange our key, as far as discovered, in a
+tabular form, to avoid confusion. It will stand thus:
+
+                5 represents      a
+                †       “         d
+                8       “         e
+                3       “         g
+                4       “         h
+                6       “         i
+                *       “         n
+                ‡       “         o
+                (       “         r
+                ;       “         t
+
+“We have, therefore, no less than ten of the most important letters
+represented, and it will be unnecessary to proceed with the details of
+the solution. I have said enough to convince you that ciphers of this
+nature are readily soluble, and to give you some insight into the
+rationale of their development. But be assured that the specimen before
+us appertains to the very simplest species of cryptograph. It now only
+remains to give you the full translation of the characters upon the
+parchment, as unriddled. Here it is:
+
+“‘_A good glass in the bishop’s hostel in the devil’s seat forty-one
+degrees and thirteen minutes northeast and by north main branch seventh
+limb east side shoot from the left eye of the death’s-head a bee line
+from the tree through the shot fifty feet out_.’”
+
+“But,” said I, “the enigma seems still in as bad a condition as ever.
+How is it possible to extort a meaning from all this jargon about
+‘devil’s seats,’ ‘death’s heads,’ and ‘bishop’s hotels?’”
+
+“I confess,” replied Legrand, “that the matter still wears a serious
+aspect, when regarded with a casual glance. My first endeavor was
+to divide the sentence into the natural division intended by the
+cryptographist.”
+
+“You mean, to punctuate it?”
+
+“Something of that kind.”
+
+“But how was it possible to effect this?”
+
+“I reflected that it had been a point with the writer to run his words
+together without division, so as to increase the difficulty of solution.
+Now, a not over-acute man, in pursuing such an object would be nearly
+certain to overdo the matter. When, in the course of his composition, he
+arrived at a break in his subject which would naturally require a pause,
+or a point, he would be exceedingly apt to run his characters, at this
+place, more than usually close together. If you will observe the MS., in
+the present instance, you will easily detect five such cases of unusual
+crowding. Acting upon this hint, I made the division thus: ‘A good
+glass in the Bishop’s hostel in the Devil’s seat--forty-one degrees and
+thirteen minutes--northeast and by north--main branch seventh limb east
+side--shoot from the left eye of the death’s-head--a bee-line from the
+tree through the shot fifty feet out.’”
+
+“Even this division,” said I, “leaves me still in the dark.”
+
+“It left me also in the dark,” replied Legrand, “for a few days; during
+which I made diligent inquiry, in the neighborhood of Sullivan’s Island,
+for any building which went by the name of the ‘Bishop’s Hotel;’ for, of
+course, I dropped the obsolete word ‘hostel.’ Gaining no information on
+the subject, I was on the point of extending my sphere of search, and
+proceeding in a more systematic manner, when, one morning, it entered
+into my head, quite suddenly, that this ‘Bishop’s Hostel’ might have
+some reference to an old family, of the name of Bessop, which, time out
+of mind, had held possession of an ancient manor-house, about four
+miles to the northward of the Island. I accordingly went over to the
+plantation, and re-instituted my inquiries among the older negroes of
+the place. At length one of the most aged of the women said that she
+had heard of such a place as Bessop’s Castle, and thought that she could
+guide me to it, but that it was not a castle nor a tavern, but a high
+rock.
+
+“I offered to pay her well for her trouble, and, after some demur,
+she consented to accompany me to the spot. We found it without much
+difficulty, when, dismissing her, I proceeded to examine the place. The
+‘castle’ consisted of an irregular assemblage of cliffs and rocks--one
+of the latter being quite remarkable for its height as well as for its
+insulated and artificial appearance I clambered to its apex, and then
+felt much at a loss as to what should be next done.
+
+“While I was busied in reflection, my eyes fell upon a narrow ledge in
+the eastern face of the rock, perhaps a yard below the summit upon which
+I stood. This ledge projected about eighteen inches, and was not more
+than a foot wide, while a niche in the cliff just above it, gave it
+a rude resemblance to one of the hollow-backed chairs used by our
+ancestors. I made no doubt that here was the ‘devil’s seat’ alluded to
+in the MS., and now I seemed to grasp the full secret of the riddle.
+
+“The ‘good glass,’ I knew, could have reference to nothing but a
+telescope; for the word ‘glass’ is rarely employed in any other sense
+by seamen. Now here, I at once saw, was a telescope to be used, and a
+definite point of view, admitting no variation, from which to use it.
+Nor did I hesitate to believe that the phrases, “forty-one degrees
+and thirteen minutes,’ and ‘northeast and by north,’ were intended as
+directions for the levelling of the glass. Greatly excited by these
+discoveries, I hurried home, procured a telescope, and returned to the
+rock.
+
+“I let myself down to the ledge, and found that it was impossible to
+retain a seat upon it except in one particular position. This fact
+confirmed my preconceived idea. I proceeded to use the glass. Of course,
+the ‘forty-one degrees and thirteen minutes’ could allude to nothing but
+elevation above the visible horizon, since the horizontal direction was
+clearly indicated by the words, ‘northeast and by north.’ This latter
+direction I at once established by means of a pocket-compass; then,
+pointing the glass as nearly at an angle of forty-one degrees of
+elevation as I could do it by guess, I moved it cautiously up or down,
+until my attention was arrested by a circular rift or opening in the
+foliage of a large tree that overtopped its fellows in the distance.
+In the centre of this rift I perceived a white spot, but could not, at
+first, distinguish what it was. Adjusting the focus of the telescope, I
+again looked, and now made it out to be a human skull.
+
+“Upon this discovery I was so sanguine as to consider the enigma solved;
+for the phrase ‘main branch, seventh limb, east side,’ could refer only
+to the position of the skull upon the tree, while ‘shoot from the left
+eye of the death’s head’ admitted, also, of but one interpretation, in
+regard to a search for buried treasure. I perceived that the design was
+to drop a bullet from the left eye of the skull, and that a bee-line,
+or, in other words, a straight line, drawn from the nearest point of
+the trunk through ‘the shot,’ (or the spot where the bullet fell,) and
+thence extended to a distance of fifty feet, would indicate a definite
+point--and beneath this point I thought it at least possible that a
+deposit of value lay concealed.”
+
+“All this,” I said, “is exceedingly clear, and, although ingenious,
+still simple and explicit. When you left the Bishop’s Hotel, what then?”
+
+“Why, having carefully taken the bearings of the tree, I turned
+homewards. The instant that I left ‘the devil’s seat,’ however, the
+circular rift vanished; nor could I get a glimpse of it afterwards, turn
+as I would. What seems to me the chief ingenuity in this whole business,
+is the fact (for repeated experiment has convinced me it is a fact) that
+the circular opening in question is visible from no other attainable
+point of view than that afforded by the narrow ledge upon the face of
+the rock.
+
+“In this expedition to the ‘Bishop’s Hotel’ I had been attended
+by Jupiter, who had, no doubt, observed, for some weeks past, the
+abstraction of my demeanor, and took especial care not to leave me
+alone. But, on the next day, getting up very early, I contrived to give
+him the slip, and went into the hills in search of the tree. After much
+toil I found it. When I came home at night my valet proposed to give
+me a flogging. With the rest of the adventure I believe you are as well
+acquainted as myself.”
+
+“I suppose,” said I, “you missed the spot, in the first attempt at
+digging, through Jupiter’s stupidity in letting the bug fall through the
+right instead of through the left eye of the skull.”
+
+“Precisely. This mistake made a difference of about two inches and a
+half in the ‘shot’--that is to say, in the position of the peg nearest
+the tree; and had the treasure been beneath the ‘shot,’ the error would
+have been of little moment; but ‘the shot,’ together with the nearest
+point of the tree, were merely two points for the establishment of
+a line of direction; of course the error, however trivial in the
+beginning, increased as we proceeded with the line, and by the time
+we had gone fifty feet, threw us quite off the scent. But for my
+deep-seated impressions that treasure was here somewhere actually
+buried, we might have had all our labor in vain.”
+
+“But your grandiloquence, and your conduct in swinging the beetle--how
+excessively odd! I was sure you were mad. And why did you insist upon
+letting fall the bug, instead of a bullet, from the skull?”
+
+“Why, to be frank, I felt somewhat annoyed by your evident suspicions
+touching my sanity, and so resolved to punish you quietly, in my own
+way, by a little bit of sober mystification. For this reason I swung
+the beetle, and for this reason I let it fall it from the tree. An
+observation of yours about its great weight suggested the latter idea.”
+
+“Yes, I perceive; and now there is only one point which puzzles me. What
+are we to make of the skeletons found in the hole?”
+
+“That is a question I am no more able to answer than yourself. There
+seems, however, only one plausible way of accounting for them--and yet
+it is dreadful to believe in such atrocity as my suggestion would imply.
+It is clear that Kidd--if Kidd indeed secreted this treasure, which I
+doubt not--it is clear that he must have had assistance in the labor.
+But this labor concluded, he may have thought it expedient to remove
+all participants in his secret. Perhaps a couple of blows with a mattock
+were sufficient, while his coadjutors were busy in the pit; perhaps it
+required a dozen--who shall tell?”
+
+
+
+
+FOUR BEASTS IN ONE--THE HOMO-CAMELEOPARD
+
+                     Chacun a ses vertus.
+                        --_Crebillon’s Xerxes._
+
+ANTIOCHUS EPIPHANES is very generally looked upon as the Gog of the
+prophet Ezekiel. This honor is, however, more properly attributable to
+Cambyses, the son of Cyrus. And, indeed, the character of the
+Syrian monarch does by no means stand in need of any adventitious
+embellishment. His accession to the throne, or rather his usurpation of
+the sovereignty, a hundred and seventy-one years before the coming
+of Christ; his attempt to plunder the temple of Diana at Ephesus; his
+implacable hostility to the Jews; his pollution of the Holy of Holies;
+and his miserable death at Taba, after a tumultuous reign of eleven
+years, are circumstances of a prominent kind, and therefore more
+generally noticed by the historians of his time than the impious,
+dastardly, cruel, silly, and whimsical achievements which make up the
+sum total of his private life and reputation.
+
+Let us suppose, gentle reader, that it is now the year of the world
+three thousand eight hundred and thirty, and let us, for a few minutes,
+imagine ourselves at that most grotesque habitation of man, the
+remarkable city of Antioch. To be sure there were, in Syria and other
+countries, sixteen cities of that appellation, besides the one to which
+I more particularly allude. But ours is that which went by the name of
+Antiochia Epidaphne, from its vicinity to the little village of Daphne,
+where stood a temple to that divinity. It was built (although about this
+matter there is some dispute) by Seleucus Nicanor, the first king of the
+country after Alexander the Great, in memory of his father Antiochus,
+and became immediately the residence of the Syrian monarchy. In the
+flourishing times of the Roman Empire, it was the ordinary station of
+the prefect of the eastern provinces; and many of the emperors of the
+queen city (among whom may be mentioned, especially, Verus and Valens)
+spent here the greater part of their time. But I perceive we have
+arrived at the city itself. Let us ascend this battlement, and throw our
+eyes upon the town and neighboring country.
+
+“What broad and rapid river is that which forces its way, with
+innumerable falls, through the mountainous wilderness, and finally
+through the wilderness of buildings?”
+
+That is the Orontes, and it is the only water in sight, with the
+exception of the Mediterranean, which stretches, like a broad mirror,
+about twelve miles off to the southward. Every one has seen the
+Mediterranean; but let me tell you, there are few who have had a peep at
+Antioch. By few, I mean, few who, like you and me, have had, at the same
+time, the advantages of a modern education. Therefore cease to regard
+that sea, and give your whole attention to the mass of houses that lie
+beneath us. You will remember that it is now the year of the world three
+thousand eight hundred and thirty. Were it later--for example, were
+it the year of our Lord eighteen hundred and forty-five, we should be
+deprived of this extraordinary spectacle. In the nineteenth century
+Antioch is--that is to say, Antioch will be--in a lamentable state
+of decay. It will have been, by that time, totally destroyed, at three
+different periods, by three successive earthquakes. Indeed, to say the
+truth, what little of its former self may then remain, will be found in
+so desolate and ruinous a state that the patriarch shall have removed
+his residence to Damascus. This is well. I see you profit by my advice,
+and are making the most of your time in inspecting the premises--in
+
+-satisfying your eyes
+
+With the memorials and the things of fame
+
+That most renown this city.--
+
+I beg pardon; I had forgotten that Shakespeare will not flourish for
+seventeen hundred and fifty years to come. But does not the appearance
+of Epidaphne justify me in calling it grotesque?
+
+“It is well fortified; and in this respect is as much indebted to nature
+as to art.”
+
+Very true.
+
+“There are a prodigious number of stately palaces.”
+
+There are.
+
+“And the numerous temples, sumptuous and magnificent, may bear
+comparison with the most lauded of antiquity.”
+
+All this I must acknowledge. Still there is an infinity of mud huts, and
+abominable hovels. We cannot help perceiving abundance of filth in
+every kennel, and, were it not for the over-powering fumes of idolatrous
+incense, I have no doubt we should find a most intolerable stench.
+Did you ever behold streets so insufferably narrow, or houses so
+miraculously tall? What gloom their shadows cast upon the ground! It
+is well the swinging lamps in those endless colonnades are kept burning
+throughout the day; we should otherwise have the darkness of Egypt in
+the time of her desolation.
+
+“It is certainly a strange place! What is the meaning of yonder singular
+building? See! it towers above all others, and lies to the eastward of
+what I take to be the royal palace.”
+
+That is the new Temple of the Sun, who is adored in Syria under the
+title of Elah Gabalah. Hereafter a very notorious Roman Emperor
+will institute this worship in Rome, and thence derive a cognomen,
+Heliogabalus. I dare say you would like to take a peep at the divinity
+of the temple. You need not look up at the heavens; his Sunship is not
+there--at least not the Sunship adored by the Syrians. That deity will
+be found in the interior of yonder building. He is worshipped under the
+figure of a large stone pillar terminating at the summit in a cone or
+pyramid, whereby is denoted Fire.
+
+“Hark--behold!--who can those ridiculous beings be, half naked, with
+their faces painted, shouting and gesticulating to the rabble?”
+
+Some few are mountebanks. Others more particularly belong to the race
+of philosophers. The greatest portion, however--those especially who
+belabor the populace with clubs--are the principal courtiers of the
+palace, executing as in duty bound, some laudable comicality of the
+king’s.
+
+“But what have we here? Heavens! the town is swarming with wild beasts!
+How terrible a spectacle!--how dangerous a peculiarity!”
+
+Terrible, if you please; but not in the least degree dangerous. Each
+animal if you will take the pains to observe, is following, very
+quietly, in the wake of its master. Some few, to be sure, are led with a
+rope about the neck, but these are chiefly the lesser or timid species.
+The lion, the tiger, and the leopard are entirely without restraint.
+They have been trained without difficulty to their present
+profession, and attend upon their respective owners in the capacity of
+valets-de-chambre. It is true, there are occasions when Nature asserts
+her violated dominions;--but then the devouring of a man-at-arms, or the
+throttling of a consecrated bull, is a circumstance of too little moment
+to be more than hinted at in Epidaphne.
+
+“But what extraordinary tumult do I hear? Surely this is a loud noise
+even for Antioch! It argues some commotion of unusual interest.”
+
+Yes--undoubtedly. The king has ordered some novel spectacle--some
+gladiatorial exhibition at the hippodrome--or perhaps the massacre of
+the Scythian prisoners--or the conflagration of his new palace--or the
+tearing down of a handsome temple--or, indeed, a bonfire of a few Jews.
+The uproar increases. Shouts of laughter ascend the skies. The air
+becomes dissonant with wind instruments, and horrible with clamor of a
+million throats. Let us descend, for the love of fun, and see what is
+going on! This way--be careful! Here we are in the principal street,
+which is called the street of Timarchus. The sea of people is coming
+this way, and we shall find a difficulty in stemming the tide. They are
+pouring through the alley of Heraclides, which leads directly from the
+palace;--therefore the king is most probably among the rioters. Yes;--I
+hear the shouts of the herald proclaiming his approach in the pompous
+phraseology of the East. We shall have a glimpse of his person as
+he passes by the temple of Ashimah. Let us ensconce ourselves in the
+vestibule of the sanctuary; he will be here anon. In the meantime let
+us survey this image. What is it? Oh! it is the god Ashimah in proper
+person. You perceive, however, that he is neither a lamb, nor a
+goat, nor a satyr, neither has he much resemblance to the Pan of the
+Arcadians. Yet all these appearances have been given--I beg pardon--will
+be given--by the learned of future ages, to the Ashimah of the Syrians.
+Put on your spectacles, and tell me what it is. What is it?
+
+“Bless me! it is an ape!”
+
+True--a baboon; but by no means the less a deity. His name is a
+derivation of the Greek Simia--what great fools are antiquarians! But
+see!--see!--yonder scampers a ragged little urchin. Where is he going?
+What is he bawling about? What does he say? Oh! he says the king
+is coming in triumph; that he is dressed in state; that he has just
+finished putting to death, with his own hand, a thousand chained
+Israelitish prisoners! For this exploit the ragamuffin is lauding him to
+the skies. Hark! here comes a troop of a similar description. They have
+made a Latin hymn upon the valor of the king, and are singing it as they
+go:
+
+Mille, mille, mille,
+
+Mille, mille, mille,
+
+Decollavimus, unus homo!
+
+Mille, mille, mille, mille, decollavimus!
+
+Mille, mille, mille,
+
+Vivat qui mille mille occidit!
+
+Tantum vini habet nemo
+
+Quantum sanguinis effudit!(*1)
+
+Which may be thus paraphrased:
+
+A thousand, a thousand, a thousand,
+
+A thousand, a thousand, a thousand,
+
+We, with one warrior, have slain!
+
+A thousand, a thousand, a thousand, a thousand.
+
+Sing a thousand over again!
+
+Soho!--let us sing
+
+Long life to our king,
+
+Who knocked over a thousand so fine!
+
+Soho!--let us roar,
+
+He has given us more
+
+Red gallons of gore
+
+Than all Syria can furnish of wine!
+
+“Do you hear that flourish of trumpets?”
+
+Yes: the king is coming! See! the people are aghast with admiration,
+and lift up their eyes to the heavens in reverence. He comes;--he is
+coming;--there he is!
+
+“Who?--where?--the king?--do not behold him--cannot say that I perceive
+him.”
+
+Then you must be blind.
+
+“Very possible. Still I see nothing but a tumultuous mob of idiots
+and madmen, who are busy in prostrating themselves before a gigantic
+cameleopard, and endeavoring to obtain a kiss of the animal’s hoofs.
+See! the beast has very justly kicked one of the rabble over--and
+another--and another--and another. Indeed, I cannot help admiring the
+animal for the excellent use he is making of his feet.”
+
+Rabble, indeed!--why these are the noble and free citizens of Epidaphne!
+Beasts, did you say?--take care that you are not overheard. Do you not
+perceive that the animal has the visage of a man? Why, my dear sir,
+that cameleopard is no other than Antiochus Epiphanes, Antiochus the
+Illustrious, King of Syria, and the most potent of all the autocrats
+of the East! It is true, that he is entitled, at times, Antiochus
+Epimanes--Antiochus the madman--but that is because all people have not
+the capacity to appreciate his merits. It is also certain that he is at
+present ensconced in the hide of a beast, and is doing his best to play
+the part of a cameleopard; but this is done for the better sustaining
+his dignity as king. Besides, the monarch is of gigantic stature,
+and the dress is therefore neither unbecoming nor over large. We may,
+however, presume he would not have adopted it but for some occasion
+of especial state. Such, you will allow, is the massacre of a thousand
+Jews. With how superior a dignity the monarch perambulates on all fours!
+His tail, you perceive, is held aloft by his two principal concubines,
+Elline and Argelais; and his whole appearance would be infinitely
+prepossessing, were it not for the protuberance of his eyes, which will
+certainly start out of his head, and the queer color of his face, which
+has become nondescript from the quantity of wine he has swallowed. Let
+us follow him to the hippodrome, whither he is proceeding, and listen to
+the song of triumph which he is commencing:
+
+Who is king but Epiphanes?
+
+Say--do you know?
+
+Who is king but Epiphanes?
+
+Bravo!--bravo!
+
+There is none but Epiphanes,
+
+No--there is none:
+
+So tear down the temples,
+
+And put out the sun!
+
+Well and strenuously sung! The populace are hailing him ‘Prince of
+Poets,’ as well as ‘Glory of the East,’ ‘Delight of the Universe,’ and
+‘Most Remarkable of Cameleopards.’ They have encored his effusion,
+and do you hear?--he is singing it over again. When he arrives at the
+hippodrome, he will be crowned with the poetic wreath, in anticipation
+of his victory at the approaching Olympics.
+
+“But, good Jupiter! what is the matter in the crowd behind us?”
+
+Behind us, did you say?--oh! ah!--I perceive. My friend, it is well
+that you spoke in time. Let us get into a place of safety as soon as
+possible. Here!--let us conceal ourselves in the arch of this aqueduct,
+and I will inform you presently of the origin of the commotion. It has
+turned out as I have been anticipating. The singular appearance of the
+cameleopard and the head of a man, has, it seems, given offence to
+the notions of propriety entertained, in general, by the wild animals
+domesticated in the city. A mutiny has been the result; and, as is usual
+upon such occasions, all human efforts will be of no avail in quelling
+the mob. Several of the Syrians have already been devoured; but the
+general voice of the four-footed patriots seems to be for eating up the
+cameleopard. ‘The Prince of Poets,’ therefore, is upon his hinder legs,
+running for his life. His courtiers have left him in the lurch, and
+his concubines have followed so excellent an example. ‘Delight of the
+Universe,’ thou art in a sad predicament! ‘Glory of the East,’ thou art
+in danger of mastication! Therefore never regard so piteously thy tail;
+it will undoubtedly be draggled in the mud, and for this there is no
+help. Look not behind thee, then, at its unavoidable degradation; but
+take courage, ply thy legs with vigor, and scud for the hippodrome!
+Remember that thou art Antiochus Epiphanes. Antiochus the
+Illustrious!--also ‘Prince of Poets,’ ‘Glory of the East,’ ‘Delight of
+the Universe,’ and ‘Most Remarkable of Cameleopards!’ Heavens! what a
+power of speed thou art displaying! What a capacity for leg-bail
+thou art developing! Run, Prince!--Bravo, Epiphanes! Well done,
+Cameleopard!--Glorious Antiochus!--He runs!--he leaps!--he flies! Like
+an arrow from a catapult he approaches the hippodrome! He leaps!--he
+shrieks!--he is there! This is well; for hadst thou, ‘Glory of
+the East,’ been half a second longer in reaching the gates of the
+Amphitheatre, there is not a bear’s cub in Epidaphne that would not
+have had a nibble at thy carcase. Let us be off--let us take our
+departure!--for we shall find our delicate modern ears unable to endure
+the vast uproar which is about to commence in celebration of the king’s
+escape! Listen! it has already commenced. See!--the whole town is
+topsy-turvy.
+
+“Surely this is the most populous city of the East! What a wilderness
+of people! what a jumble of all ranks and ages! what a multiplicity
+of sects and nations! what a variety of costumes! what a Babel of
+languages! what a screaming of beasts! what a tinkling of instruments!
+what a parcel of philosophers!”
+
+Come let us be off.
+
+“Stay a moment! I see a vast hubbub in the hippodrome; what is the
+meaning of it, I beseech you?”
+
+That?--oh, nothing! The noble and free citizens of Epidaphne being, as
+they declare, well satisfied of the faith, valor, wisdom, and divinity
+of their king, and having, moreover, been eye-witnesses of his late
+superhuman agility, do think it no more than their duty to invest his
+brows (in addition to the poetic crown) with the wreath of victory
+in the footrace--a wreath which it is evident he must obtain at the
+celebration of the next Olympiad, and which, therefore, they now give
+him in advance.
+
+
+Footnotes--Four Beasts
+
+(*1) Flavius Vospicus says, that the hymn here introduced was sung by
+the rabble upon the occasion of Aurelian, in the Sarmatic war, having
+slain, with his own hand, nine hundred and fifty of the enemy.
+
+
+
+
+THE MURDERS IN THE RUE MORGUE
+
+  What song the Syrens sang, or what name Achilles assumed when he hid
+  himself among women, although puzzling questions, are not beyond
+  _all_ conjecture.
+
+                    --_Sir Thomas Browne._
+
+
+The mental features discoursed of as the analytical, are, in themselves,
+but little susceptible of analysis. We appreciate them only in their
+effects. We know of them, among other things, that they are always to
+their possessor, when inordinately possessed, a source of the liveliest
+enjoyment. As the strong man exults in his physical ability, delighting
+in such exercises as call his muscles into action, so glories the
+analyst in that moral activity which _disentangles._ He derives pleasure
+from even the most trivial occupations bringing his talent into play. He
+is fond of enigmas, of conundrums, of hieroglyphics; exhibiting in his
+solutions of each a degree of _acumen_ which appears to the ordinary
+apprehension præternatural. His results, brought about by the very soul
+and essence of method, have, in truth, the whole air of intuition.
+
+The faculty of re-solution is possibly much invigorated by mathematical
+study, and especially by that highest branch of it which, unjustly, and
+merely on account of its retrograde operations, has been called, as
+if _par excellence_, analysis. Yet to calculate is not in itself to
+analyse. A chess-player, for example, does the one without effort at
+the other. It follows that the game of chess, in its effects upon mental
+character, is greatly misunderstood. I am not now writing a treatise,
+but simply prefacing a somewhat peculiar narrative by observations very
+much at random; I will, therefore, take occasion to assert that the
+higher powers of the reflective intellect are more decidedly and more
+usefully tasked by the unostentatious game of draughts than by all the
+elaborate frivolity of chess. In this latter, where the pieces have
+different and _bizarre_ motions, with various and variable values, what
+is only complex is mistaken (a not unusual error) for what is profound.
+The _attention_ is here called powerfully into play. If it flag for an
+instant, an oversight is committed resulting in injury or defeat. The
+possible moves being not only manifold but involute, the chances of such
+oversights are multiplied; and in nine cases out of ten it is the
+more concentrative rather than the more acute player who conquers. In
+draughts, on the contrary, where the moves are _unique_ and have but
+little variation, the probabilities of inadvertence are diminished, and
+the mere attention being left comparatively unemployed, what advantages
+are obtained by either party are obtained by superior _acumen_. To be
+less abstract--Let us suppose a game of draughts where the pieces are
+reduced to four kings, and where, of course, no oversight is to be
+expected. It is obvious that here the victory can be decided (the
+players being at all equal) only by some _recherché_ movement, the
+result of some strong exertion of the intellect. Deprived of ordinary
+resources, the analyst throws himself into the spirit of his opponent,
+identifies himself therewith, and not unfrequently sees thus, at a
+glance, the sole methods (sometime indeed absurdly simple ones) by which
+he may seduce into error or hurry into miscalculation.
+
+Whist has long been noted for its influence upon what is termed the
+calculating power; and men of the highest order of intellect have been
+known to take an apparently unaccountable delight in it, while eschewing
+chess as frivolous. Beyond doubt there is nothing of a similar nature
+so greatly tasking the faculty of analysis. The best chess-player in
+Christendom _may_ be little more than the best player of chess; but
+proficiency in whist implies capacity for success in all those more
+important undertakings where mind struggles with mind. When I say
+proficiency, I mean that perfection in the game which includes a
+comprehension of _all_ the sources whence legitimate advantage may be
+derived. These are not only manifold but multiform, and lie frequently
+among recesses of thought altogether inaccessible to the ordinary
+understanding. To observe attentively is to remember distinctly; and,
+so far, the concentrative chess-player will do very well at whist; while
+the rules of Hoyle (themselves based upon the mere mechanism of the
+game) are sufficiently and generally comprehensible. Thus to have a
+retentive memory, and to proceed by “the book,” are points commonly
+regarded as the sum total of good playing. But it is in matters beyond
+the limits of mere rule that the skill of the analyst is evinced. He
+makes, in silence, a host of observations and inferences. So, perhaps,
+do his companions; and the difference in the extent of the information
+obtained, lies not so much in the validity of the inference as in the
+quality of the observation. The necessary knowledge is that of _what_ to
+observe. Our player confines himself not at all; nor, because the game
+is the object, does he reject deductions from things external to the
+game. He examines the countenance of his partner, comparing it carefully
+with that of each of his opponents. He considers the mode of assorting
+the cards in each hand; often counting trump by trump, and honor by
+honor, through the glances bestowed by their holders upon each. He notes
+every variation of face as the play progresses, gathering a fund
+of thought from the differences in the expression of certainty, of
+surprise, of triumph, or of chagrin. From the manner of gathering up
+a trick he judges whether the person taking it can make another in the
+suit. He recognises what is played through feint, by the air with
+which it is thrown upon the table. A casual or inadvertent word; the
+accidental dropping or turning of a card, with the accompanying anxiety
+or carelessness in regard to its concealment; the counting of the
+tricks, with the order of their arrangement; embarrassment, hesitation,
+eagerness or trepidation--all afford, to his apparently intuitive
+perception, indications of the true state of affairs. The first two
+or three rounds having been played, he is in full possession of the
+contents of each hand, and thenceforward puts down his cards with as
+absolute a precision of purpose as if the rest of the party had turned
+outward the faces of their own.
+
+The analytical power should not be confounded with ample ingenuity; for
+while the analyst is necessarily ingenious, the ingenious man is often
+remarkably incapable of analysis. The constructive or combining power,
+by which ingenuity is usually manifested, and to which the phrenologists
+(I believe erroneously) have assigned a separate organ, supposing it a
+primitive faculty, has been so frequently seen in those whose intellect
+bordered otherwise upon idiocy, as to have attracted general observation
+among writers on morals. Between ingenuity and the analytic ability
+there exists a difference far greater, indeed, than that between the
+fancy and the imagination, but of a character very strictly analogous.
+It will be found, in fact, that the ingenious are always fanciful, and
+the _truly_ imaginative never otherwise than analytic.
+
+The narrative which follows will appear to the reader somewhat in the
+light of a commentary upon the propositions just advanced.
+
+Residing in Paris during the spring and part of the summer of 18--, I
+there became acquainted with a Monsieur C. Auguste Dupin. This young
+gentleman was of an excellent--indeed of an illustrious family, but, by
+a variety of untoward events, had been reduced to such poverty that the
+energy of his character succumbed beneath it, and he ceased to bestir
+himself in the world, or to care for the retrieval of his fortunes.
+By courtesy of his creditors, there still remained in his possession a
+small remnant of his patrimony; and, upon the income arising from this,
+he managed, by means of a rigorous economy, to procure the necessaries
+of life, without troubling himself about its superfluities. Books,
+indeed, were his sole luxuries, and in Paris these are easily obtained.
+
+Our first meeting was at an obscure library in the Rue Montmartre, where
+the accident of our both being in search of the same very rare and very
+remarkable volume, brought us into closer communion. We saw each other
+again and again. I was deeply interested in the little family history
+which he detailed to me with all that candor which a Frenchman indulges
+whenever mere self is his theme. I was astonished, too, at the vast
+extent of his reading; and, above all, I felt my soul enkindled within
+me by the wild fervor, and the vivid freshness of his imagination.
+Seeking in Paris the objects I then sought, I felt that the society of
+such a man would be to me a treasure beyond price; and this feeling I
+frankly confided to him. It was at length arranged that we should live
+together during my stay in the city; and as my worldly circumstances
+were somewhat less embarrassed than his own, I was permitted to be
+at the expense of renting, and furnishing in a style which suited the
+rather fantastic gloom of our common temper, a time-eaten and grotesque
+mansion, long deserted through superstitions into which we did not
+inquire, and tottering to its fall in a retired and desolate portion of
+the Faubourg St. Germain.
+
+Had the routine of our life at this place been known to the world, we
+should have been regarded as madmen--although, perhaps, as madmen of
+a harmless nature. Our seclusion was perfect. We admitted no visitors.
+Indeed the locality of our retirement had been carefully kept a secret
+from my own former associates; and it had been many years since Dupin
+had ceased to know or be known in Paris. We existed within ourselves
+alone.
+
+It was a freak of fancy in my friend (for what else shall I call it?) to
+be enamored of the Night for her own sake; and into this _bizarrerie_,
+as into all his others, I quietly fell; giving myself up to his wild
+whims with a perfect _abandon_. The sable divinity would not herself
+dwell with us always; but we could counterfeit her presence. At the
+first dawn of the morning we closed all the messy shutters of our old
+building; lighting a couple of tapers which, strongly perfumed, threw
+out only the ghastliest and feeblest of rays. By the aid of these we
+then busied our souls in dreams--reading, writing, or conversing, until
+warned by the clock of the advent of the true Darkness. Then we sallied
+forth into the streets arm in arm, continuing the topics of the day, or
+roaming far and wide until a late hour, seeking, amid the wild lights
+and shadows of the populous city, that infinity of mental excitement
+which quiet observation can afford.
+
+At such times I could not help remarking and admiring (although from
+his rich ideality I had been prepared to expect it) a peculiar analytic
+ability in Dupin. He seemed, too, to take an eager delight in its
+exercise--if not exactly in its display--and did not hesitate to confess
+the pleasure thus derived. He boasted to me, with a low chuckling laugh,
+that most men, in respect to himself, wore windows in their bosoms,
+and was wont to follow up such assertions by direct and very startling
+proofs of his intimate knowledge of my own. His manner at these moments
+was frigid and abstract; his eyes were vacant in expression; while his
+voice, usually a rich tenor, rose into a treble which would have sounded
+petulantly but for the deliberateness and entire distinctness of the
+enunciation. Observing him in these moods, I often dwelt meditatively
+upon the old philosophy of the Bi-Part Soul, and amused myself with the
+fancy of a double Dupin--the creative and the resolvent.
+
+Let it not be supposed, from what I have just said, that I am detailing
+any mystery, or penning any romance. What I have described in the
+Frenchman, was merely the result of an excited, or perhaps of a diseased
+intelligence. But of the character of his remarks at the periods in
+question an example will best convey the idea.
+
+We were strolling one night down a long dirty street in the vicinity of
+the Palais Royal. Being both, apparently, occupied with thought, neither
+of us had spoken a syllable for fifteen minutes at least. All at once
+Dupin broke forth with these words:
+
+“He is a very little fellow, that’s true, and would do better for the
+_Théâtre des Variétés_.”
+
+“There can be no doubt of that,” I replied unwittingly, and not at first
+observing (so much had I been absorbed in reflection) the extraordinary
+manner in which the speaker had chimed in with my meditations. In
+an instant afterward I recollected myself, and my astonishment was
+profound.
+
+“Dupin,” said I, gravely, “this is beyond my comprehension. I do not
+hesitate to say that I am amazed, and can scarcely credit my senses. How
+was it possible you should know I was thinking of -----?” Here I paused,
+to ascertain beyond a doubt whether he really knew of whom I thought.
+
+--“of Chantilly,” said he, “why do you pause? You were remarking to
+yourself that his diminutive figure unfitted him for tragedy.”
+
+This was precisely what had formed the subject of my reflections.
+Chantilly was a _quondam_ cobbler of the Rue St. Denis, who, becoming
+stage-mad, had attempted the _rôle_ of Xerxes, in Crébillon’s tragedy so
+called, and been notoriously Pasquinaded for his pains.
+
+“Tell me, for Heaven’s sake,” I exclaimed, “the method--if method there
+is--by which you have been enabled to fathom my soul in this matter.” In
+fact I was even more startled than I would have been willing to express.
+
+“It was the fruiterer,” replied my friend, “who brought you to the
+conclusion that the mender of soles was not of sufficient height for
+Xerxes _et id genus omne_.”
+
+“The fruiterer!--you astonish me--I know no fruiterer whomsoever.”
+
+“The man who ran up against you as we entered the street--it may have
+been fifteen minutes ago.”
+
+I now remembered that, in fact, a fruiterer, carrying upon his head a
+large basket of apples, had nearly thrown me down, by accident, as we
+passed from the Rue C ---- into the thoroughfare where we stood; but
+what this had to do with Chantilly I could not possibly understand.
+
+There was not a particle of _charlatanerie_ about Dupin. “I will
+explain,” he said, “and that you may comprehend all clearly, we will
+first retrace the course of your meditations, from the moment in which
+I spoke to you until that of the _rencontre_ with the fruiterer in
+question. The larger links of the chain run thus--Chantilly, Orion, Dr.
+Nichols, Epicurus, Stereotomy, the street stones, the fruiterer.”
+
+There are few persons who have not, at some period of their lives,
+amused themselves in retracing the steps by which particular conclusions
+of their own minds have been attained. The occupation is often full of
+interest and he who attempts it for the first time is astonished by
+the apparently illimitable distance and incoherence between the
+starting-point and the goal. What, then, must have been my amazement
+when I heard the Frenchman speak what he had just spoken, and when I
+could not help acknowledging that he had spoken the truth. He continued:
+
+“We had been talking of horses, if I remember aright, just before
+leaving the Rue C ----. This was the last subject we discussed. As we
+crossed into this street, a fruiterer, with a large basket upon his
+head, brushing quickly past us, thrust you upon a pile of paving stones
+collected at a spot where the causeway is undergoing repair. You stepped
+upon one of the loose fragments, slipped, slightly strained your ankle,
+appeared vexed or sulky, muttered a few words, turned to look at the
+pile, and then proceeded in silence. I was not particularly attentive to
+what you did; but observation has become with me, of late, a species of
+necessity.
+
+“You kept your eyes upon the ground--glancing, with a petulant
+expression, at the holes and ruts in the pavement, (so that I saw you
+were still thinking of the stones,) until we reached the little alley
+called Lamartine, which has been paved, by way of experiment, with the
+overlapping and riveted blocks. Here your countenance brightened up,
+and, perceiving your lips move, I could not doubt that you murmured the
+word ‘stereotomy,’ a term very affectedly applied to this species of
+pavement. I knew that you could not say to yourself ‘stereotomy’ without
+being brought to think of atomies, and thus of the theories of Epicurus;
+and since, when we discussed this subject not very long ago, I mentioned
+to you how singularly, yet with how little notice, the vague guesses
+of that noble Greek had met with confirmation in the late nebular
+cosmogony, I felt that you could not avoid casting your eyes upward to
+the great _nebula_ in Orion, and I certainly expected that you would do
+so. You did look up; and I was now assured that I had correctly followed
+your steps. But in that bitter _tirade_ upon Chantilly, which appeared
+in yesterday’s ‘_Musée_,’ the satirist, making some disgraceful
+allusions to the cobbler’s change of name upon assuming the buskin,
+quoted a Latin line about which we have often conversed. I mean the line
+
+     Perdidit antiquum litera sonum.
+
+“I had told you that this was in reference to Orion, formerly written
+Urion; and, from certain pungencies connected with this explanation, I
+was aware that you could not have forgotten it. It was clear, therefore,
+that you would not fail to combine the two ideas of Orion and Chantilly.
+That you did combine them I saw by the character of the smile which
+passed over your lips. You thought of the poor cobbler’s immolation. So
+far, you had been stooping in your gait; but now I saw you draw yourself
+up to your full height. I was then sure that you reflected upon the
+diminutive figure of Chantilly. At this point I interrupted your
+meditations to remark that as, in fact, he was a very little
+fellow--that Chantilly--he would do better at the _Théâtre des
+Variétés_.”
+
+Not long after this, we were looking over an evening edition of the
+“Gazette des Tribunaux,” when the following paragraphs arrested our
+attention.
+
+“EXTRAORDINARY MURDERS.--This morning, about three o’clock, the
+inhabitants of the Quartier St. Roch were aroused from sleep by a
+succession of terrific shrieks, issuing, apparently, from the fourth
+story of a house in the Rue Morgue, known to be in the sole occupancy of
+one Madame L’Espanaye, and her daughter Mademoiselle Camille L’Espanaye.
+After some delay, occasioned by a fruitless attempt to procure admission
+in the usual manner, the gateway was broken in with a crowbar, and eight
+or ten of the neighbors entered accompanied by two _gendarmes_. By this
+time the cries had ceased; but, as the party rushed up the first
+flight of stairs, two or more rough voices in angry contention were
+distinguished and seemed to proceed from the upper part of the house.
+As the second landing was reached, these sounds, also, had ceased and
+everything remained perfectly quiet. The party spread themselves and
+hurried from room to room. Upon arriving at a large back chamber in
+the fourth story, (the door of which, being found locked, with the key
+inside, was forced open,) a spectacle presented itself which struck
+every one present not less with horror than with astonishment.
+
+“The apartment was in the wildest disorder--the furniture broken and
+thrown about in all directions. There was only one bedstead; and from
+this the bed had been removed, and thrown into the middle of the floor.
+On a chair lay a razor, besmeared with blood. On the hearth were two or
+three long and thick tresses of grey human hair, also dabbled in blood,
+and seeming to have been pulled out by the roots. Upon the floor were
+found four Napoleons, an ear-ring of topaz, three large silver spoons,
+three smaller of_ métal d’Alger_, and two bags, containing nearly four
+thousand francs in gold. The drawers of a _bureau_, which stood in
+one corner were open, and had been, apparently, rifled, although many
+articles still remained in them. A small iron safe was discovered under
+the _bed_ (not under the bedstead). It was open, with the key still in
+the door. It had no contents beyond a few old letters, and other papers
+of little consequence.
+
+“Of Madame L’Espanaye no traces were here seen; but an unusual quantity
+of soot being observed in the fire-place, a search was made in the
+chimney, and (horrible to relate!) the corpse of the daughter, head
+downward, was dragged therefrom; it having been thus forced up the
+narrow aperture for a considerable distance. The body was quite warm.
+Upon examining it, many excoriations were perceived, no doubt occasioned
+by the violence with which it had been thrust up and disengaged. Upon
+the face were many severe scratches, and, upon the throat, dark bruises,
+and deep indentations of finger nails, as if the deceased had been
+throttled to death.
+
+“After a thorough investigation of every portion of the house, without
+farther discovery, the party made its way into a small paved yard in
+the rear of the building, where lay the corpse of the old lady, with her
+throat so entirely cut that, upon an attempt to raise her, the head fell
+off. The body, as well as the head, was fearfully mutilated--the former
+so much so as scarcely to retain any semblance of humanity.
+
+“To this horrible mystery there is not as yet, we believe, the slightest
+clew.”
+
+The next day’s paper had these additional particulars.
+
+“_The Tragedy in the Rue Morgue._ Many individuals have been examined
+in relation to this most extraordinary and frightful affair. [The word
+‘affaire’ has not yet, in France, that levity of import which it conveys
+with us,] “but nothing whatever has transpired to throw light upon it.
+We give below all the material testimony elicited.
+
+“_Pauline Dubourg_, laundress, deposes that she has known both the
+deceased for three years, having washed for them during that period.
+The old lady and her daughter seemed on good terms--very affectionate
+towards each other. They were excellent pay. Could not speak in regard
+to their mode or means of living. Believed that Madame L. told fortunes
+for a living. Was reputed to have money put by. Never met any persons
+in the house when she called for the clothes or took them home. Was sure
+that they had no servant in employ. There appeared to be no furniture in
+any part of the building except in the fourth story.
+
+“_Pierre Moreau_, tobacconist, deposes that he has been in the habit of
+selling small quantities of tobacco and snuff to Madame L’Espanaye for
+nearly four years. Was born in the neighborhood, and has always resided
+there. The deceased and her daughter had occupied the house in which the
+corpses were found, for more than six years. It was formerly occupied by
+a jeweller, who under-let the upper rooms to various persons. The house
+was the property of Madame L. She became dissatisfied with the abuse of
+the premises by her tenant, and moved into them herself, refusing to let
+any portion. The old lady was childish. Witness had seen the daughter
+some five or six times during the six years. The two lived an
+exceedingly retired life--were reputed to have money. Had heard it said
+among the neighbors that Madame L. told fortunes--did not believe it.
+Had never seen any person enter the door except the old lady and her
+daughter, a porter once or twice, and a physician some eight or ten
+times.
+
+“Many other persons, neighbors, gave evidence to the same effect. No one
+was spoken of as frequenting the house. It was not known whether there
+were any living connexions of Madame L. and her daughter. The shutters
+of the front windows were seldom opened. Those in the rear were always
+closed, with the exception of the large back room, fourth story. The
+house was a good house--not very old.
+
+“_Isidore Muset_, _gendarme_, deposes that he was called to the house
+about three o’clock in the morning, and found some twenty or thirty
+persons at the gateway, endeavoring to gain admittance. Forced it open,
+at length, with a bayonet--not with a crowbar. Had but little difficulty
+in getting it open, on account of its being a double or folding gate,
+and bolted neither at bottom not top. The shrieks were continued until
+the gate was forced--and then suddenly ceased. They seemed to be screams
+of some person (or persons) in great agony--were loud and drawn out,
+not short and quick. Witness led the way up stairs. Upon reaching the
+first landing, heard two voices in loud and angry contention--the one
+a gruff voice, the other much shriller--a very strange voice. Could
+distinguish some words of the former, which was that of a Frenchman. Was
+positive that it was not a woman’s voice. Could distinguish the words
+‘_sacré_’ and ‘_diable._’ The shrill voice was that of a foreigner.
+Could not be sure whether it was the voice of a man or of a woman. Could
+not make out what was said, but believed the language to be Spanish. The
+state of the room and of the bodies was described by this witness as we
+described them yesterday.
+
+“_Henri Duval_, a neighbor, and by trade a silver-smith, deposes that
+he was one of the party who first entered the house. Corroborates the
+testimony of Muset in general. As soon as they forced an entrance, they
+reclosed the door, to keep out the crowd, which collected very fast,
+notwithstanding the lateness of the hour. The shrill voice, this witness
+thinks, was that of an Italian. Was certain it was not French. Could not
+be sure that it was a man’s voice. It might have been a woman’s. Was not
+acquainted with the Italian language. Could not distinguish the words,
+but was convinced by the intonation that the speaker was an Italian.
+Knew Madame L. and her daughter. Had conversed with both frequently. Was
+sure that the shrill voice was not that of either of the deceased.
+
+“--_Odenheimer, restaurateur._ This witness volunteered his testimony.
+Not speaking French, was examined through an interpreter. Is a native of
+Amsterdam. Was passing the house at the time of the shrieks. They lasted
+for several minutes--probably ten. They were long and loud--very awful
+and distressing. Was one of those who entered the building. Corroborated
+the previous evidence in every respect but one. Was sure that the shrill
+voice was that of a man--of a Frenchman. Could not distinguish the
+words uttered. They were loud and quick--unequal--spoken apparently in
+fear as well as in anger. The voice was harsh--not so much shrill as
+harsh. Could not call it a shrill voice. The gruff voice said repeatedly
+‘_sacré_,’ ‘_diable_,’ and once ‘_mon Dieu._’
+
+“_Jules Mignaud_, banker, of the firm of Mignaud et Fils, Rue Deloraine.
+Is the elder Mignaud. Madame L’Espanaye had some property. Had opened an
+account with his banking house in the spring of the year--(eight years
+previously). Made frequent deposits in small sums. Had checked for
+nothing until the third day before her death, when she took out in
+person the sum of 4000 francs. This sum was paid in gold, and a clerk
+went home with the money.
+
+“_Adolphe Le Bon_, clerk to Mignaud et Fils, deposes that on the day in
+question, about noon, he accompanied Madame L’Espanaye to her residence
+with the 4000 francs, put up in two bags. Upon the door being opened,
+Mademoiselle L. appeared and took from his hands one of the bags, while
+the old lady relieved him of the other. He then bowed and departed. Did
+not see any person in the street at the time. It is a bye-street--very
+lonely.
+
+“_William Bird_, tailor deposes that he was one of the party who entered
+the house. Is an Englishman. Has lived in Paris two years. Was one of
+the first to ascend the stairs. Heard the voices in contention. The
+gruff voice was that of a Frenchman. Could make out several words, but
+cannot now remember all. Heard distinctly ‘_sacré_’ and ‘_mon Dieu._’
+There was a sound at the moment as if of several persons struggling--a
+scraping and scuffling sound. The shrill voice was very loud--louder
+than the gruff one. Is sure that it was not the voice of an Englishman.
+Appeared to be that of a German. Might have been a woman’s voice. Does
+not understand German.
+
+“Four of the above-named witnesses, being recalled, deposed that the
+door of the chamber in which was found the body of Mademoiselle L.
+was locked on the inside when the party reached it. Every thing was
+perfectly silent--no groans or noises of any kind. Upon forcing the door
+no person was seen. The windows, both of the back and front room, were
+down and firmly fastened from within. A door between the two rooms was
+closed, but not locked. The door leading from the front room into the
+passage was locked, with the key on the inside. A small room in the
+front of the house, on the fourth story, at the head of the passage was
+open, the door being ajar. This room was crowded with old beds, boxes,
+and so forth. These were carefully removed and searched. There was not
+an inch of any portion of the house which was not carefully searched.
+Sweeps were sent up and down the chimneys. The house was a four story
+one, with garrets (_mansardes._) A trap-door on the roof was nailed down
+very securely--did not appear to have been opened for years. The
+time elapsing between the hearing of the voices in contention and the
+breaking open of the room door, was variously stated by the witnesses.
+Some made it as short as three minutes--some as long as five. The door
+was opened with difficulty.
+
+“_Alfonzo Garcio_, undertaker, deposes that he resides in the Rue
+Morgue. Is a native of Spain. Was one of the party who entered the
+house. Did not proceed up stairs. Is nervous, and was apprehensive of
+the consequences of agitation. Heard the voices in contention. The gruff
+voice was that of a Frenchman. Could not distinguish what was said.
+The shrill voice was that of an Englishman--is sure of this. Does not
+understand the English language, but judges by the intonation.
+
+“_Alberto Montani_, confectioner, deposes that he was among the first
+to ascend the stairs. Heard the voices in question. The gruff voice was
+that of a Frenchman. Distinguished several words. The speaker appeared
+to be expostulating. Could not make out the words of the shrill voice.
+Spoke quick and unevenly. Thinks it the voice of a Russian. Corroborates
+the general testimony. Is an Italian. Never conversed with a native of
+Russia.
+
+“Several witnesses, recalled, here testified that the chimneys of all
+the rooms on the fourth story were too narrow to admit the passage of a
+human being. By ‘sweeps’ were meant cylindrical sweeping brushes, such
+as are employed by those who clean chimneys. These brushes were passed
+up and down every flue in the house. There is no back passage by which
+any one could have descended while the party proceeded up stairs. The
+body of Mademoiselle L’Espanaye was so firmly wedged in the chimney that
+it could not be got down until four or five of the party united their
+strength.
+
+“_Paul Dumas_, physician, deposes that he was called to view the
+bodies about day-break. They were both then lying on the sacking of the
+bedstead in the chamber where Mademoiselle L. was found. The corpse of
+the young lady was much bruised and excoriated. The fact that it
+had been thrust up the chimney would sufficiently account for these
+appearances. The throat was greatly chafed. There were several deep
+scratches just below the chin, together with a series of livid spots
+which were evidently the impression of fingers. The face was fearfully
+discolored, and the eye-balls protruded. The tongue had been partially
+bitten through. A large bruise was discovered upon the pit of the
+stomach, produced, apparently, by the pressure of a knee. In the opinion
+of M. Dumas, Mademoiselle L’Espanaye had been throttled to death by
+some person or persons unknown. The corpse of the mother was horribly
+mutilated. All the bones of the right leg and arm were more or less
+shattered. The left _tibia_ much splintered, as well as all the ribs of
+the left side. Whole body dreadfully bruised and discolored. It was not
+possible to say how the injuries had been inflicted. A heavy club of
+wood, or a broad bar of iron--a chair--any large, heavy, and obtuse
+weapon would have produced such results, if wielded by the hands of
+a very powerful man. No woman could have inflicted the blows with any
+weapon. The head of the deceased, when seen by witness, was entirely
+separated from the body, and was also greatly shattered. The throat
+had evidently been cut with some very sharp instrument--probably with a
+razor.
+
+“_Alexandre Etienne_, surgeon, was called with M. Dumas to view the
+bodies. Corroborated the testimony, and the opinions of M. Dumas.
+
+“Nothing farther of importance was elicited, although several other
+persons were examined. A murder so mysterious, and so perplexing in all
+its particulars, was never before committed in Paris--if indeed a murder
+has been committed at all. The police are entirely at fault--an unusual
+occurrence in affairs of this nature. There is not, however, the shadow
+of a clew apparent.”
+
+The evening edition of the paper stated that the greatest excitement
+still continued in the Quartier St. Roch--that the premises in question
+had been carefully re-searched, and fresh examinations of witnesses
+instituted, but all to no purpose. A postscript, however, mentioned
+that Adolphe Le Bon had been arrested and imprisoned--although nothing
+appeared to criminate him, beyond the facts already detailed.
+
+Dupin seemed singularly interested in the progress of this affair--at
+least so I judged from his manner, for he made no comments. It was only
+after the announcement that Le Bon had been imprisoned, that he asked me
+my opinion respecting the murders.
+
+I could merely agree with all Paris in considering them an insoluble
+mystery. I saw no means by which it would be possible to trace the
+murderer.
+
+“We must not judge of the means,” said Dupin, “by this shell of an
+examination. The Parisian police, so much extolled for _acumen_, are
+cunning, but no more. There is no method in their proceedings, beyond
+the method of the moment. They make a vast parade of measures; but, not
+unfrequently, these are so ill adapted to the objects proposed, as
+to put us in mind of Monsieur Jourdain’s calling for his
+_robe-de-chambre--pour mieux entendre la musique._ The results attained
+by them are not unfrequently surprising, but, for the most part, are
+brought about by simple diligence and activity. When these qualities are
+unavailing, their schemes fail. Vidocq, for example, was a good
+guesser and a persevering man. But, without educated thought, he erred
+continually by the very intensity of his investigations. He impaired his
+vision by holding the object too close. He might see, perhaps, one or
+two points with unusual clearness, but in so doing he, necessarily, lost
+sight of the matter as a whole. Thus there is such a thing as being too
+profound. Truth is not always in a well. In fact, as regards the more
+important knowledge, I do believe that she is invariably superficial.
+The depth lies in the valleys where we seek her, and not upon the
+mountain-tops where she is found. The modes and sources of this kind of
+error are well typified in the contemplation of the heavenly bodies.
+To look at a star by glances--to view it in a side-long way, by turning
+toward it the exterior portions of the _retina_ (more susceptible of
+feeble impressions of light than the interior), is to behold the star
+distinctly--is to have the best appreciation of its lustre--a lustre
+which grows dim just in proportion as we turn our vision _fully_ upon
+it. A greater number of rays actually fall upon the eye in the latter
+case, but, in the former, there is the more refined capacity for
+comprehension. By undue profundity we perplex and enfeeble thought; and
+it is possible to make even Venus herself vanish from the firmanent by a
+scrutiny too sustained, too concentrated, or too direct.
+
+“As for these murders, let us enter into some examinations for
+ourselves, before we make up an opinion respecting them. An inquiry will
+afford us amusement,” [I thought this an odd term, so applied, but said
+nothing] “and, besides, Le Bon once rendered me a service for which I
+am not ungrateful. We will go and see the premises with our own eyes.
+I know G----, the Prefect of Police, and shall have no difficulty in
+obtaining the necessary permission.”
+
+The permission was obtained, and we proceeded at once to the Rue Morgue.
+This is one of those miserable thoroughfares which intervene between the
+Rue Richelieu and the Rue St. Roch. It was late in the afternoon when we
+reached it; as this quarter is at a great distance from that in which we
+resided. The house was readily found; for there were still many persons
+gazing up at the closed shutters, with an objectless curiosity, from
+the opposite side of the way. It was an ordinary Parisian house, with
+a gateway, on one side of which was a glazed watch-box, with a sliding
+panel in the window, indicating a _loge de concierge._ Before going in
+we walked up the street, turned down an alley, and then, again turning,
+passed in the rear of the building--Dupin, meanwhile examining the whole
+neighborhood, as well as the house, with a minuteness of attention for
+which I could see no possible object.
+
+Retracing our steps, we came again to the front of the dwelling, rang,
+and, having shown our credentials, were admitted by the agents
+in charge. We went up stairs--into the chamber where the body of
+Mademoiselle L’Espanaye had been found, and where both the deceased
+still lay. The disorders of the room had, as usual, been suffered to
+exist. I saw nothing beyond what had been stated in the “Gazette des
+Tribunaux.” Dupin scrutinized every thing--not excepting the bodies of
+the victims. We then went into the other rooms, and into the yard; a
+_gendarme_ accompanying us throughout. The examination occupied us until
+dark, when we took our departure. On our way home my companion stepped
+in for a moment at the office of one of the daily papers.
+
+I have said that the whims of my friend were manifold, and that _Je les
+ménageais_:--for this phrase there is no English equivalent. It was his
+humor, now, to decline all conversation on the subject of the murder,
+until about noon the next day. He then asked me, suddenly, if I had
+observed any thing _peculiar_ at the scene of the atrocity.
+
+There was something in his manner of emphasizing the word “peculiar,”
+ which caused me to shudder, without knowing why.
+
+“No, nothing _peculiar_,” I said; “nothing more, at least, than we both
+saw stated in the paper.”
+
+“The ‘Gazette,’” he replied, “has not entered, I fear, into the unusual
+horror of the thing. But dismiss the idle opinions of this print. It
+appears to me that this mystery is considered insoluble, for the very
+reason which should cause it to be regarded as easy of solution--I mean
+for the _outré_ character of its features. The police are confounded by
+the seeming absence of motive--not for the murder itself--but for
+the atrocity of the murder. They are puzzled, too, by the seeming
+impossibility of reconciling the voices heard in contention, with
+the facts that no one was discovered up stairs but the assassinated
+Mademoiselle L’Espanaye, and that there were no means of egress without
+the notice of the party ascending. The wild disorder of the room; the
+corpse thrust, with the head downward, up the chimney; the frightful
+mutilation of the body of the old lady; these considerations, with those
+just mentioned, and others which I need not mention, have sufficed
+to paralyze the powers, by putting completely at fault the boasted
+_acumen_, of the government agents. They have fallen into the gross but
+common error of confounding the unusual with the abstruse. But it is by
+these deviations from the plane of the ordinary, that reason feels its
+way, if at all, in its search for the true. In investigations such as we
+are now pursuing, it should not be so much asked ‘what has occurred,’
+as ‘what has occurred that has never occurred before.’ In fact, the
+facility with which I shall arrive, or have arrived, at the solution of
+this mystery, is in the direct ratio of its apparent insolubility in the
+eyes of the police.”
+
+I stared at the speaker in mute astonishment.
+
+“I am now awaiting,” continued he, looking toward the door of our
+apartment--“I am now awaiting a person who, although perhaps not
+the perpetrator of these butcheries, must have been in some measure
+implicated in their perpetration. Of the worst portion of the crimes
+committed, it is probable that he is innocent. I hope that I am right
+in this supposition; for upon it I build my expectation of reading the
+entire riddle. I look for the man here--in this room--every moment. It
+is true that he may not arrive; but the probability is that he will.
+Should he come, it will be necessary to detain him. Here are pistols;
+and we both know how to use them when occasion demands their use.”
+
+I took the pistols, scarcely knowing what I did, or believing what
+I heard, while Dupin went on, very much as if in a soliloquy. I have
+already spoken of his abstract manner at such times. His discourse was
+addressed to myself; but his voice, although by no means loud, had that
+intonation which is commonly employed in speaking to some one at a great
+distance. His eyes, vacant in expression, regarded only the wall.
+
+“That the voices heard in contention,” he said, “by the party upon the
+stairs, were not the voices of the women themselves, was fully proved
+by the evidence. This relieves us of all doubt upon the question whether
+the old lady could have first destroyed the daughter and afterward have
+committed suicide. I speak of this point chiefly for the sake of method;
+for the strength of Madame L’Espanaye would have been utterly unequal
+to the task of thrusting her daughter’s corpse up the chimney as it
+was found; and the nature of the wounds upon her own person entirely
+preclude the idea of self-destruction. Murder, then, has been committed
+by some third party; and the voices of this third party were those heard
+in contention. Let me now advert--not to the whole testimony respecting
+these voices--but to what was _peculiar_ in that testimony. Did you
+observe any thing peculiar about it?”
+
+I remarked that, while all the witnesses agreed in supposing the gruff
+voice to be that of a Frenchman, there was much disagreement in regard
+to the shrill, or, as one individual termed it, the harsh voice.
+
+“That was the evidence itself,” said Dupin, “but it was not the
+peculiarity of the evidence. You have observed nothing distinctive.
+Yet there _was_ something to be observed. The witnesses, as you remark,
+agreed about the gruff voice; they were here unanimous. But in regard to
+the shrill voice, the peculiarity is--not that they disagreed--but
+that, while an Italian, an Englishman, a Spaniard, a Hollander, and a
+Frenchman attempted to describe it, each one spoke of it as that _of
+a foreigner_. Each is sure that it was not the voice of one of his own
+countrymen. Each likens it--not to the voice of an individual of any
+nation with whose language he is conversant--but the converse.
+The Frenchman supposes it the voice of a Spaniard, and ‘might have
+distinguished some words _had he been acquainted with the Spanish._’ The
+Dutchman maintains it to have been that of a Frenchman; but we find it
+stated that ‘_not understanding French this witness was examined through
+an interpreter._’ The Englishman thinks it the voice of a German, and
+‘_does not understand German._’ The Spaniard ‘is sure’ that it was that
+of an Englishman, but ‘judges by the intonation’ altogether, ‘_as he has
+no knowledge of the English._’ The Italian believes it the voice of a
+Russian, but ‘_has never conversed with a native of Russia._’ A second
+Frenchman differs, moreover, with the first, and is positive that the
+voice was that of an Italian; but, _not being cognizant of that tongue_,
+is, like the Spaniard, ‘convinced by the intonation.’ Now, how strangely
+unusual must that voice have really been, about which such testimony as
+this _could_ have been elicited!--in whose _tones_, even, denizens of
+the five great divisions of Europe could recognise nothing familiar! You
+will say that it might have been the voice of an Asiatic--of an African.
+Neither Asiatics nor Africans abound in Paris; but, without denying the
+inference, I will now merely call your attention to three points.
+The voice is termed by one witness ‘harsh rather than shrill.’ It
+is represented by two others to have been ‘quick and _unequal._’ No
+words--no sounds resembling words--were by any witness mentioned as
+distinguishable.
+
+“I know not,” continued Dupin, “what impression I may have made, so
+far, upon your own understanding; but I do not hesitate to say that
+legitimate deductions even from this portion of the testimony--the
+portion respecting the gruff and shrill voices--are in themselves
+sufficient to engender a suspicion which should give direction to all
+farther progress in the investigation of the mystery. I said ‘legitimate
+deductions;’ but my meaning is not thus fully expressed. I designed
+to imply that the deductions are the _sole_ proper ones, and that the
+suspicion arises _inevitably_ from them as the single result. What the
+suspicion is, however, I will not say just yet. I merely wish you to
+bear in mind that, with myself, it was sufficiently forcible to give a
+definite form--a certain tendency--to my inquiries in the chamber.
+
+“Let us now transport ourselves, in fancy, to this chamber. What shall
+we first seek here? The means of egress employed by the murderers. It is
+not too much to say that neither of us believe in præternatural events.
+Madame and Mademoiselle L’Espanaye were not destroyed by spirits. The
+doers of the deed were material, and escaped materially. Then how?
+Fortunately, there is but one mode of reasoning upon the point, and that
+mode _must_ lead us to a definite decision.--Let us examine, each by
+each, the possible means of egress. It is clear that the assassins were
+in the room where Mademoiselle L’Espanaye was found, or at least in the
+room adjoining, when the party ascended the stairs. It is then only from
+these two apartments that we have to seek issues. The police have laid
+bare the floors, the ceilings, and the masonry of the walls, in every
+direction. No _secret_ issues could have escaped their vigilance. But,
+not trusting to _their_ eyes, I examined with my own. There were, then,
+no secret issues. Both doors leading from the rooms into the passage
+were securely locked, with the keys inside. Let us turn to the chimneys.
+These, although of ordinary width for some eight or ten feet above the
+hearths, will not admit, throughout their extent, the body of a large
+cat. The impossibility of egress, by means already stated, being thus
+absolute, we are reduced to the windows. Through those of the front room
+no one could have escaped without notice from the crowd in the street.
+The murderers _must_ have passed, then, through those of the back room.
+Now, brought to this conclusion in so unequivocal a manner as we are,
+it is not our part, as reasoners, to reject it on account of apparent
+impossibilities. It is only left for us to prove that these apparent
+‘impossibilities’ are, in reality, not such.
+
+“There are two windows in the chamber. One of them is unobstructed by
+furniture, and is wholly visible. The lower portion of the other is
+hidden from view by the head of the unwieldy bedstead which is thrust
+close up against it. The former was found securely fastened from within.
+It resisted the utmost force of those who endeavored to raise it. A
+large gimlet-hole had been pierced in its frame to the left, and a very
+stout nail was found fitted therein, nearly to the head. Upon examining
+the other window, a similar nail was seen similarly fitted in it; and
+a vigorous attempt to raise this sash, failed also. The police were now
+entirely satisfied that egress had not been in these directions. And,
+_therefore_, it was thought a matter of supererogation to withdraw the
+nails and open the windows.
+
+“My own examination was somewhat more particular, and was so for the
+reason I have just given--because here it was, I knew, that all apparent
+impossibilities _must_ be proved to be not such in reality.
+
+“I proceeded to think thus--_a posteriori_. The murderers did escape
+from one of these windows. This being so, they could not have refastened
+the sashes from the inside, as they were found fastened;--the
+consideration which put a stop, through its obviousness, to the scrutiny
+of the police in this quarter. Yet the sashes _were_ fastened. They
+_must_, then, have the power of fastening themselves. There was no
+escape from this conclusion. I stepped to the unobstructed casement,
+withdrew the nail with some difficulty and attempted to raise the sash.
+It resisted all my efforts, as I had anticipated. A concealed spring
+must, I now know, exist; and this corroboration of my idea convinced
+me that my premises at least, were correct, however mysterious still
+appeared the circumstances attending the nails. A careful search soon
+brought to light the hidden spring. I pressed it, and, satisfied with
+the discovery, forbore to upraise the sash.
+
+“I now replaced the nail and regarded it attentively. A person passing
+out through this window might have reclosed it, and the spring would
+have caught--but the nail could not have been replaced. The conclusion
+was plain, and again narrowed in the field of my investigations. The
+assassins _must_ have escaped through the other window. Supposing, then,
+the springs upon each sash to be the same, as was probable, there _must_
+be found a difference between the nails, or at least between the modes
+of their fixture. Getting upon the sacking of the bedstead, I looked
+over the head-board minutely at the second casement. Passing my hand
+down behind the board, I readily discovered and pressed the spring,
+which was, as I had supposed, identical in character with its neighbor.
+I now looked at the nail. It was as stout as the other, and apparently
+fitted in the same manner--driven in nearly up to the head.
+
+“You will say that I was puzzled; but, if you think so, you must have
+misunderstood the nature of the inductions. To use a sporting phrase,
+I had not been once ‘at fault.’ The scent had never for an instant
+been lost. There was no flaw in any link of the chain. I had traced the
+secret to its ultimate result,--and that result was _the nail._ It
+had, I say, in every respect, the appearance of its fellow in the other
+window; but this fact was an absolute nullity (conclusive us it might
+seem to be) when compared with the consideration that here, at this
+point, terminated the clew. ‘There _must_ be something wrong,’ I said,
+‘about the nail.’ I touched it; and the head, with about a quarter of an
+inch of the shank, came off in my fingers. The rest of the shank was in
+the gimlet-hole where it had been broken off. The fracture was an old
+one (for its edges were incrusted with rust), and had apparently been
+accomplished by the blow of a hammer, which had partially imbedded,
+in the top of the bottom sash, the head portion of the nail. I now
+carefully replaced this head portion in the indentation whence I had
+taken it, and the resemblance to a perfect nail was complete--the
+fissure was invisible. Pressing the spring, I gently raised the sash
+for a few inches; the head went up with it, remaining firm in its bed.
+I closed the window, and the semblance of the whole nail was again
+perfect.
+
+“The riddle, so far, was now unriddled. The assassin had escaped through
+the window which looked upon the bed. Dropping of its own accord upon
+his exit (or perhaps purposely closed), it had become fastened by the
+spring; and it was the retention of this spring which had been mistaken
+by the police for that of the nail,--farther inquiry being thus
+considered unnecessary.
+
+“The next question is that of the mode of descent. Upon this point I had
+been satisfied in my walk with you around the building. About five feet
+and a half from the casement in question there runs a lightning-rod.
+From this rod it would have been impossible for any one to reach the
+window itself, to say nothing of entering it. I observed, however, that
+the shutters of the fourth story were of the peculiar kind called by
+Parisian carpenters _ferrades_--a kind rarely employed at the present
+day, but frequently seen upon very old mansions at Lyons and Bordeaux.
+They are in the form of an ordinary door, (a single, not a folding door)
+except that the lower half is latticed or worked in open trellis--thus
+affording an excellent hold for the hands. In the present instance these
+shutters are fully three feet and a half broad. When we saw them from
+the rear of the house, they were both about half open--that is to say,
+they stood off at right angles from the wall. It is probable that the
+police, as well as myself, examined the back of the tenement; but, if
+so, in looking at these _ferrades_ in the line of their breadth (as they
+must have done), they did not perceive this great breadth itself, or,
+at all events, failed to take it into due consideration. In fact, having
+once satisfied themselves that no egress could have been made in this
+quarter, they would naturally bestow here a very cursory examination.
+It was clear to me, however, that the shutter belonging to the window
+at the head of the bed, would, if swung fully back to the wall, reach
+to within two feet of the lightning-rod. It was also evident that, by
+exertion of a very unusual degree of activity and courage, an entrance
+into the window, from the rod, might have been thus effected.--By
+reaching to the distance of two feet and a half (we now suppose the
+shutter open to its whole extent) a robber might have taken a firm grasp
+upon the trellis-work. Letting go, then, his hold upon the rod, placing
+his feet securely against the wall, and springing boldly from it, he
+might have swung the shutter so as to close it, and, if we imagine the
+window open at the time, might even have swung himself into the room.
+
+“I wish you to bear especially in mind that I have spoken of a _very_
+unusual degree of activity as requisite to success in so hazardous and
+so difficult a feat. It is my design to show you, first, that the thing
+might possibly have been accomplished:--but, secondly and _chiefly_, I
+wish to impress upon your understanding the _very extraordinary_--the
+almost præternatural character of that agility which could have
+accomplished it.
+
+“You will say, no doubt, using the language of the law, that ‘to make
+out my case,’ I should rather undervalue, than insist upon a full
+estimation of the activity required in this matter. This may be the
+practice in law, but it is not the usage of reason. My ultimate object
+is only the truth. My immediate purpose is to lead you to place in
+juxtaposition, that _very unusual_ activity of which I have just spoken
+with that _very peculiar_ shrill (or harsh) and _unequal_ voice, about
+whose nationality no two persons could be found to agree, and in whose
+utterance no syllabification could be detected.”
+
+At these words a vague and half-formed conception of the meaning
+of Dupin flitted over my mind. I seemed to be upon the verge of
+comprehension without power to comprehend--men, at times, find
+themselves upon the brink of remembrance without being able, in the end,
+to remember. My friend went on with his discourse.
+
+“You will see,” he said, “that I have shifted the question from the mode
+of egress to that of ingress. It was my design to convey the idea that
+both were effected in the same manner, at the same point. Let us now
+revert to the interior of the room. Let us survey the appearances here.
+The drawers of the bureau, it is said, had been rifled, although many
+articles of apparel still remained within them. The conclusion here is
+absurd. It is a mere guess--a very silly one--and no more. How are
+we to know that the articles found in the drawers were not all these
+drawers had originally contained? Madame L’Espanaye and her daughter
+lived an exceedingly retired life--saw no company--seldom went out--had
+little use for numerous changes of habiliment. Those found were at least
+of as good quality as any likely to be possessed by these ladies. If a
+thief had taken any, why did he not take the best--why did he not take
+all? In a word, why did he abandon four thousand francs in gold to
+encumber himself with a bundle of linen? The gold _was _abandoned.
+Nearly the whole sum mentioned by Monsieur Mignaud, the banker, was
+discovered, in bags, upon the floor. I wish you, therefore, to discard
+from your thoughts the blundering idea of _motive_, engendered in the
+brains of the police by that portion of the evidence which speaks of
+money delivered at the door of the house. Coincidences ten times as
+remarkable as this (the delivery of the money, and murder committed
+within three days upon the party receiving it), happen to all of us
+every hour of our lives, without attracting even momentary notice.
+Coincidences, in general, are great stumbling-blocks in the way of that
+class of thinkers who have been educated to know nothing of the theory
+of probabilities--that theory to which the most glorious objects of
+human research are indebted for the most glorious of illustration. In
+the present instance, had the gold been gone, the fact of its delivery
+three days before would have formed something more than a coincidence.
+It would have been corroborative of this idea of motive. But, under the
+real circumstances of the case, if we are to suppose gold the motive
+of this outrage, we must also imagine the perpetrator so vacillating an
+idiot as to have abandoned his gold and his motive together.
+
+“Keeping now steadily in mind the points to which I have drawn your
+attention--that peculiar voice, that unusual agility, and that startling
+absence of motive in a murder so singularly atrocious as this--let us
+glance at the butchery itself. Here is a woman strangled to death
+by manual strength, and thrust up a chimney, head downward. Ordinary
+assassins employ no such modes of murder as this. Least of all, do they
+thus dispose of the murdered. In the manner of thrusting the corpse
+up the chimney, you will admit that there was something _excessively
+outré_--something altogether irreconcilable with our common notions of
+human action, even when we suppose the actors the most depraved of men.
+Think, too, how great must have been that strength which could have
+thrust the body _up_ such an aperture so forcibly that the united vigor
+of several persons was found barely sufficient to drag it _down!_
+
+“Turn, now, to other indications of the employment of a vigor most
+marvellous. On the hearth were thick tresses--very thick tresses--of
+grey human hair. These had been torn out by the roots. You are aware of
+the great force necessary in tearing thus from the head even twenty or
+thirty hairs together. You saw the locks in question as well as myself.
+Their roots (a hideous sight!) were clotted with fragments of the flesh
+of the scalp--sure token of the prodigious power which had been exerted
+in uprooting perhaps half a million of hairs at a time. The throat of
+the old lady was not merely cut, but the head absolutely severed from
+the body: the instrument was a mere razor. I wish you also to look at
+the _brutal_ ferocity of these deeds. Of the bruises upon the body
+of Madame L’Espanaye I do not speak. Monsieur Dumas, and his worthy
+coadjutor Monsieur Etienne, have pronounced that they were inflicted by
+some obtuse instrument; and so far these gentlemen are very correct. The
+obtuse instrument was clearly the stone pavement in the yard, upon which
+the victim had fallen from the window which looked in upon the bed. This
+idea, however simple it may now seem, escaped the police for the same
+reason that the breadth of the shutters escaped them--because, by the
+affair of the nails, their perceptions had been hermetically sealed
+against the possibility of the windows having ever been opened at all.
+
+“If now, in addition to all these things, you have properly reflected
+upon the odd disorder of the chamber, we have gone so far as to combine
+the ideas of an agility astounding, a strength superhuman, a ferocity
+brutal, a butchery without motive, a _grotesquerie_ in horror absolutely
+alien from humanity, and a voice foreign in tone to the ears of men
+of many nations, and devoid of all distinct or intelligible
+syllabification. What result, then, has ensued? What impression have I
+made upon your fancy?”
+
+I felt a creeping of the flesh as Dupin asked me the question. “A
+madman,” I said, “has done this deed--some raving maniac, escaped from a
+neighboring _Maison de Santé._”
+
+“In some respects,” he replied, “your idea is not irrelevant. But the
+voices of madmen, even in their wildest paroxysms, are never found to
+tally with that peculiar voice heard upon the stairs. Madmen are of some
+nation, and their language, however incoherent in its words, has always
+the coherence of syllabification. Besides, the hair of a madman is not
+such as I now hold in my hand. I disentangled this little tuft from the
+rigidly clutched fingers of Madame L’Espanaye. Tell me what you can make
+of it.”
+
+“Dupin!” I said, completely unnerved; “this hair is most unusual--this
+is no _human_ hair.”
+
+“I have not asserted that it is,” said he; “but, before we decide this
+point, I wish you to glance at the little sketch I have here traced upon
+this paper. It is a _fac-simile_ drawing of what has been described in
+one portion of the testimony as ‘dark bruises, and deep indentations
+of finger nails,’ upon the throat of Mademoiselle L’Espanaye, and in
+another, (by Messrs. Dumas and Etienne,) as a ‘series of livid spots,
+evidently the impression of fingers.’
+
+“You will perceive,” continued my friend, spreading out the paper upon
+the table before us, “that this drawing gives the idea of a firm
+and fixed hold. There is no _slipping_ apparent. Each finger has
+retained--possibly until the death of the victim--the fearful grasp by
+which it originally imbedded itself. Attempt, now, to place all your
+fingers, at the same time, in the respective impressions as you see
+them.”
+
+I made the attempt in vain.
+
+“We are possibly not giving this matter a fair trial,” he said. “The
+paper is spread out upon a plane surface; but the human throat is
+cylindrical. Here is a billet of wood, the circumference of which
+is about that of the throat. Wrap the drawing around it, and try the
+experiment again.”
+
+I did so; but the difficulty was even more obvious than before. “This,”
+ I said, “is the mark of no human hand.”
+
+“Read now,” replied Dupin, “this passage from Cuvier.”
+
+It was a minute anatomical and generally descriptive account of the
+large fulvous Ourang-Outang of the East Indian Islands. The gigantic
+stature, the prodigious strength and activity, the wild ferocity, and
+the imitative propensities of these mammalia are sufficiently well known
+to all. I understood the full horrors of the murder at once.
+
+“The description of the digits,” said I, as I made an end of reading,
+“is in exact accordance with this drawing. I see that no animal but an
+Ourang-Outang, of the species here mentioned, could have impressed the
+indentations as you have traced them. This tuft of tawny hair, too, is
+identical in character with that of the beast of Cuvier. But I cannot
+possibly comprehend the particulars of this frightful mystery. Besides,
+there were _two_ voices heard in contention, and one of them was
+unquestionably the voice of a Frenchman.”
+
+“True; and you will remember an expression attributed almost
+unanimously, by the evidence, to this voice,--the expression, ‘_mon
+Dieu!_’ This, under the circumstances, has been justly characterized by
+one of the witnesses (Montani, the confectioner,) as an expression of
+remonstrance or expostulation. Upon these two words, therefore, I have
+mainly built my hopes of a full solution of the riddle. A Frenchman
+was cognizant of the murder. It is possible--indeed it is far more
+than probable--that he was innocent of all participation in the bloody
+transactions which took place. The Ourang-Outang may have escaped from
+him. He may have traced it to the chamber; but, under the agitating
+circumstances which ensued, he could never have re-captured it. It is
+still at large. I will not pursue these guesses--for I have no right to
+call them more--since the shades of reflection upon which they are based
+are scarcely of sufficient depth to be appreciable by my own intellect,
+and since I could not pretend to make them intelligible to the
+understanding of another. We will call them guesses then, and speak
+of them as such. If the Frenchman in question is indeed, as I suppose,
+innocent of this atrocity, this advertisement which I left last night,
+upon our return home, at the office of ‘Le Monde,’ (a paper devoted to
+the shipping interest, and much sought by sailors,) will bring him to
+our residence.”
+
+He handed me a paper, and I read thus:
+
+CAUGHT--_In the Bois de Boulogne, early in the morning of the--inst.,_
+(the morning of the murder,) _a very large, tawny Ourang-Outang of
+the Bornese species. The owner, (who is ascertained to be a sailor,
+belonging to a Maltese vessel,) may have the animal again, upon
+identifying it satisfactorily, and paying a few charges arising from
+its capture and keeping. Call at No. ----, Rue ----, Faubourg St.
+Germain--au troisiême._
+
+“How was it possible,” I asked, “that you should know the man to be a
+sailor, and belonging to a Maltese vessel?”
+
+“I do _not_ know it,” said Dupin. “I am not _sure_ of it. Here, however,
+is a small piece of ribbon, which from its form, and from its greasy
+appearance, has evidently been used in tying the hair in one of those
+long _queues_ of which sailors are so fond. Moreover, this knot is one
+which few besides sailors can tie, and is peculiar to the Maltese. I
+picked the ribbon up at the foot of the lightning-rod. It could not have
+belonged to either of the deceased. Now if, after all, I am wrong in my
+induction from this ribbon, that the Frenchman was a sailor belonging to
+a Maltese vessel, still I can have done no harm in saying what I did in
+the advertisement. If I am in error, he will merely suppose that I have
+been misled by some circumstance into which he will not take the trouble
+to inquire. But if I am right, a great point is gained. Cognizant
+although innocent of the murder, the Frenchman will naturally hesitate
+about replying to the advertisement--about demanding the Ourang-Outang.
+He will reason thus:--‘I am innocent; I am poor; my Ourang-Outang is of
+great value--to one in my circumstances a fortune of itself--why should
+I lose it through idle apprehensions of danger? Here it is, within my
+grasp. It was found in the Bois de Boulogne--at a vast distance from the
+scene of that butchery. How can it ever be suspected that a brute beast
+should have done the deed? The police are at fault--they have failed to
+procure the slightest clew. Should they even trace the animal, it would
+be impossible to prove me cognizant of the murder, or to implicate me
+in guilt on account of that cognizance. Above all, _I am known._ The
+advertiser designates me as the possessor of the beast. I am not sure to
+what limit his knowledge may extend. Should I avoid claiming a property
+of so great value, which it is known that I possess, I will render the
+animal at least, liable to suspicion. It is not my policy to attract
+attention either to myself or to the beast. I will answer the
+advertisement, get the Ourang-Outang, and keep it close until this
+matter has blown over.’”
+
+At this moment we heard a step upon the stairs.
+
+“Be ready,” said Dupin, “with your pistols, but neither use them nor
+show them until at a signal from myself.”
+
+The front door of the house had been left open, and the visiter had
+entered, without ringing, and advanced several steps upon the staircase.
+Now, however, he seemed to hesitate. Presently we heard him descending.
+Dupin was moving quickly to the door, when we again heard him coming up.
+He did not turn back a second time, but stepped up with decision, and
+rapped at the door of our chamber.
+
+“Come in,” said Dupin, in a cheerful and hearty tone.
+
+A man entered. He was a sailor, evidently,--a tall, stout, and
+muscular-looking person, with a certain dare-devil expression of
+countenance, not altogether unprepossessing. His face, greatly sunburnt,
+was more than half hidden by whisker and _mustachio._ He had with him
+a huge oaken cudgel, but appeared to be otherwise unarmed. He bowed
+awkwardly, and bade us “good evening,” in French accents, which,
+although somewhat Neufchatelish, were still sufficiently indicative of a
+Parisian origin.
+
+“Sit down, my friend,” said Dupin. “I suppose you have called about the
+Ourang-Outang. Upon my word, I almost envy you the possession of him;
+a remarkably fine, and no doubt a very valuable animal. How old do you
+suppose him to be?”
+
+The sailor drew a long breath, with the air of a man relieved of some
+intolerable burden, and then replied, in an assured tone:
+
+“I have no way of telling--but he can’t be more than four or five years
+old. Have you got him here?”
+
+“Oh no, we had no conveniences for keeping him here. He is at a livery
+stable in the Rue Dubourg, just by. You can get him in the morning. Of
+course you are prepared to identify the property?”
+
+“To be sure I am, sir.”
+
+“I shall be sorry to part with him,” said Dupin.
+
+“I don’t mean that you should be at all this trouble for nothing, sir,”
+ said the man. “Couldn’t expect it. Am very willing to pay a reward for
+the finding of the animal--that is to say, any thing in reason.”
+
+“Well,” replied my friend, “that is all very fair, to be sure. Let me
+think!--what should I have? Oh! I will tell you. My reward shall be
+this. You shall give me all the information in your power about these
+murders in the Rue Morgue.”
+
+Dupin said the last words in a very low tone, and very quietly. Just as
+quietly, too, he walked toward the door, locked it and put the key in
+his pocket. He then drew a pistol from his bosom and placed it, without
+the least flurry, upon the table.
+
+The sailor’s face flushed up as if he were struggling with suffocation.
+He started to his feet and grasped his cudgel, but the next moment he
+fell back into his seat, trembling violently, and with the countenance
+of death itself. He spoke not a word. I pitied him from the bottom of my
+heart.
+
+“My friend,” said Dupin, in a kind tone, “you are alarming yourself
+unnecessarily--you are indeed. We mean you no harm whatever. I pledge
+you the honor of a gentleman, and of a Frenchman, that we intend you no
+injury. I perfectly well know that you are innocent of the atrocities
+in the Rue Morgue. It will not do, however, to deny that you are in some
+measure implicated in them. From what I have already said, you must know
+that I have had means of information about this matter--means of which
+you could never have dreamed. Now the thing stands thus. You have done
+nothing which you could have avoided--nothing, certainly, which renders
+you culpable. You were not even guilty of robbery, when you might have
+robbed with impunity. You have nothing to conceal. You have no reason
+for concealment. On the other hand, you are bound by every principle
+of honor to confess all you know. An innocent man is now imprisoned,
+charged with that crime of which you can point out the perpetrator.”
+
+The sailor had recovered his presence of mind, in a great measure, while
+Dupin uttered these words; but his original boldness of bearing was all
+gone.
+
+“So help me God,” said he, after a brief pause, “I will tell you all I
+know about this affair;--but I do not expect you to believe one half I
+say--I would be a fool indeed if I did. Still, I am innocent, and I will
+make a clean breast if I die for it.”
+
+What he stated was, in substance, this. He had lately made a voyage
+to the Indian Archipelago. A party, of which he formed one, landed
+at Borneo, and passed into the interior on an excursion of pleasure.
+Himself and a companion had captured the Ourang-Outang. This companion
+dying, the animal fell into his own exclusive possession. After great
+trouble, occasioned by the intractable ferocity of his captive during
+the home voyage, he at length succeeded in lodging it safely at his own
+residence in Paris, where, not to attract toward himself the unpleasant
+curiosity of his neighbors, he kept it carefully secluded, until such
+time as it should recover from a wound in the foot, received from a
+splinter on board ship. His ultimate design was to sell it.
+
+Returning home from some sailors’ frolic the night, or rather in the
+morning of the murder, he found the beast occupying his own bed-room,
+into which it had broken from a closet adjoining, where it had been, as
+was thought, securely confined. Razor in hand, and fully lathered, it
+was sitting before a looking-glass, attempting the operation of shaving,
+in which it had no doubt previously watched its master through the
+key-hole of the closet. Terrified at the sight of so dangerous a weapon
+in the possession of an animal so ferocious, and so well able to use
+it, the man, for some moments, was at a loss what to do. He had been
+accustomed, however, to quiet the creature, even in its fiercest moods,
+by the use of a whip, and to this he now resorted. Upon sight of it, the
+Ourang-Outang sprang at once through the door of the chamber, down
+the stairs, and thence, through a window, unfortunately open, into the
+street.
+
+The Frenchman followed in despair; the ape, razor still in hand,
+occasionally stopping to look back and gesticulate at its pursuer, until
+the latter had nearly come up with it. It then again made off. In this
+manner the chase continued for a long time. The streets were profoundly
+quiet, as it was nearly three o’clock in the morning. In passing down
+an alley in the rear of the Rue Morgue, the fugitive’s attention was
+arrested by a light gleaming from the open window of Madame L’Espanaye’s
+chamber, in the fourth story of her house. Rushing to the building, it
+perceived the lightning rod, clambered up with inconceivable agility,
+grasped the shutter, which was thrown fully back against the wall, and,
+by its means, swung itself directly upon the headboard of the bed. The
+whole feat did not occupy a minute. The shutter was kicked open again by
+the Ourang-Outang as it entered the room.
+
+The sailor, in the meantime, was both rejoiced and perplexed. He had
+strong hopes of now recapturing the brute, as it could scarcely escape
+from the trap into which it had ventured, except by the rod, where it
+might be intercepted as it came down. On the other hand, there was
+much cause for anxiety as to what it might do in the house. This latter
+reflection urged the man still to follow the fugitive. A lightning rod
+is ascended without difficulty, especially by a sailor; but, when he had
+arrived as high as the window, which lay far to his left, his career was
+stopped; the most that he could accomplish was to reach over so as to
+obtain a glimpse of the interior of the room. At this glimpse he nearly
+fell from his hold through excess of horror. Now it was that those
+hideous shrieks arose upon the night, which had startled from slumber
+the inmates of the Rue Morgue. Madame L’Espanaye and her daughter,
+habited in their night clothes, had apparently been occupied in
+arranging some papers in the iron chest already mentioned, which had
+been wheeled into the middle of the room. It was open, and its contents
+lay beside it on the floor. The victims must have been sitting with
+their backs toward the window; and, from the time elapsing between the
+ingress of the beast and the screams, it seems probable that it was not
+immediately perceived. The flapping-to of the shutter would naturally
+have been attributed to the wind.
+
+As the sailor looked in, the gigantic animal had seized Madame
+L’Espanaye by the hair, (which was loose, as she had been combing
+it,) and was flourishing the razor about her face, in imitation of the
+motions of a barber. The daughter lay prostrate and motionless; she had
+swooned. The screams and struggles of the old lady (during which the
+hair was torn from her head) had the effect of changing the probably
+pacific purposes of the Ourang-Outang into those of wrath. With one
+determined sweep of its muscular arm it nearly severed her head from her
+body. The sight of blood inflamed its anger into phrenzy. Gnashing its
+teeth, and flashing fire from its eyes, it flew upon the body of the
+girl, and imbedded its fearful talons in her throat, retaining its grasp
+until she expired. Its wandering and wild glances fell at this moment
+upon the head of the bed, over which the face of its master, rigid with
+horror, was just discernible. The fury of the beast, who no doubt bore
+still in mind the dreaded whip, was instantly converted into fear.
+Conscious of having deserved punishment, it seemed desirous of
+concealing its bloody deeds, and skipped about the chamber in an agony
+of nervous agitation; throwing down and breaking the furniture as it
+moved, and dragging the bed from the bedstead. In conclusion, it seized
+first the corpse of the daughter, and thrust it up the chimney, as
+it was found; then that of the old lady, which it immediately hurled
+through the window headlong.
+
+As the ape approached the casement with its mutilated burden, the sailor
+shrank aghast to the rod, and, rather gliding than clambering down it,
+hurried at once home--dreading the consequences of the butchery, and
+gladly abandoning, in his terror, all solicitude about the fate of the
+Ourang-Outang. The words heard by the party upon the staircase were the
+Frenchman’s exclamations of horror and affright, commingled with the
+fiendish jabberings of the brute.
+
+I have scarcely anything to add. The Ourang-Outang must have escaped
+from the chamber, by the rod, just before the break of the door. It
+must have closed the window as it passed through it. It was subsequently
+caught by the owner himself, who obtained for it a very large sum at the
+_Jardin des Plantes._ Le Don was instantly released, upon our narration
+of the circumstances (with some comments from Dupin) at the bureau of
+the Prefect of Police. This functionary, however well disposed to my
+friend, could not altogether conceal his chagrin at the turn which
+affairs had taken, and was fain to indulge in a sarcasm or two, about
+the propriety of every person minding his own business.
+
+“Let him talk,” said Dupin, who had not thought it necessary to reply.
+“Let him discourse; it will ease his conscience, I am satisfied with
+having defeated him in his own castle. Nevertheless, that he failed
+in the solution of this mystery, is by no means that matter for wonder
+which he supposes it; for, in truth, our friend the Prefect is somewhat
+too cunning to be profound. In his wisdom is no _stamen._ It is all head
+and no body, like the pictures of the Goddess Laverna,--or, at best, all
+head and shoulders, like a codfish. But he is a good creature after all.
+I like him especially for one master stroke of cant, by which he has
+attained his reputation for ingenuity. I mean the way he has ‘_de nier
+ce qui est, et d’expliquer ce qui n’est pas._’” (*)
+
+(*) Rousseau--Nouvelle Heloise.
+
+
+
+
+THE MYSTERY OF MARIE ROGET.(*1)
+
+A SEQUEL TO “THE MURDERS IN THE RUE MORGUE.”
+
+
+  Es giebt eine Reihe idealischer Begebenheiten, die der Wirklichkeit
+  parallel lauft. Selten fallen sie zusammen. Menschen und zufalle
+  modifieiren gewohulich die idealische Begebenheit, so dass sie
+  unvollkommen erscheint, und ihre Folgen gleichfalls unvollkommen
+  sind. So bei der Reformation; statt des Protestantismus kam das
+  Lutherthum hervor.
+
+  There are ideal series of events which run parallel with the real
+  ones. They rarely coincide. Men and circumstances generally modify
+  the ideal train of events, so that it seems imperfect, and its
+  consequences are equally imperfect. Thus with the Reformation;
+  instead of Protestantism came Lutheranism.
+
+              --Novalis. (*2) Moral Ansichten.
+
+THERE are few persons, even among the calmest thinkers, who have not
+occasionally been startled into a vague yet thrilling half-credence in
+the supernatural, by coincidences of so seemingly marvellous a character
+that, as mere coincidences, the intellect has been unable to receive
+them. Such sentiments--for the half-credences of which I speak have
+never the full force of thought--such sentiments are seldom thoroughly
+stifled unless by reference to the doctrine of chance, or, as it is
+technically termed, the Calculus of Probabilities. Now this Calculus is,
+in its essence, purely mathematical; and thus we have the anomaly of the
+most rigidly exact in science applied to the shadow and spirituality of
+the most intangible in speculation.
+
+The extraordinary details which I am now called upon to make public,
+will be found to form, as regards sequence of time, the primary branch
+of a series of scarcely intelligible coincidences, whose secondary or
+concluding branch will be recognized by all readers in the late murder
+of Mary Cecila Rogers, at New York.
+
+When, in an article entitled “The Murders in the Rue Morgue,” I
+endeavored, about a year ago, to depict some very remarkable features
+in the mental character of my friend, the Chevalier C. Auguste Dupin,
+it did not occur to me that I should ever resume the subject. This
+depicting of character constituted my design; and this design was
+thoroughly fulfilled in the wild train of circumstances brought to
+instance Dupin’s idiosyncrasy. I might have adduced other examples, but
+I should have proven no more. Late events, however, in their surprising
+development, have startled me into some farther details, which will
+carry with them the air of extorted confession. Hearing what I have
+lately heard, it would be indeed strange should I remain silent in
+regard to what I both heard and saw so long ago.
+
+Upon the winding up of the tragedy involved in the deaths of Madame
+L’Espanaye and her daughter, the Chevalier dismissed the affair at once
+from his attention, and relapsed into his old habits of moody reverie.
+Prone, at all times, to abstraction, I readily fell in with his humor;
+and, continuing to occupy our chambers in the Faubourg Saint Germain, we
+gave the Future to the winds, and slumbered tranquilly in the Present,
+weaving the dull world around us into dreams.
+
+But these dreams were not altogether uninterrupted. It may readily be
+supposed that the part played by my friend, in the drama at the Rue
+Morgue, had not failed of its impression upon the fancies of the
+Parisian police. With its emissaries, the name of Dupin had grown into a
+household word. The simple character of those inductions by which he
+had disentangled the mystery never having been explained even to the
+Prefect, or to any other individual than myself, of course it is not
+surprising that the affair was regarded as little less than miraculous,
+or that the Chevalier’s analytical abilities acquired for him the
+credit of intuition. His frankness would have led him to disabuse every
+inquirer of such prejudice; but his indolent humor forbade all farther
+agitation of a topic whose interest to himself had long ceased. It thus
+happened that he found himself the cynosure of the political eyes; and
+the cases were not few in which attempt was made to engage his services
+at the Prefecture. One of the most remarkable instances was that of the
+murder of a young girl named Marie Rogêt.
+
+This event occurred about two years after the atrocity in the Rue
+Morgue. Marie, whose Christian and family name will at once arrest
+attention from their resemblance to those of the unfortunate
+“cigargirl,” was the only daughter of the widow Estelle Rogêt. The
+father had died during the child’s infancy, and from the period of his
+death, until within eighteen months before the assassination which forms
+the subject of our narrative, the mother and daughter had dwelt together
+in the Rue Pavée Saint Andrée; (*3) Madame there keeping a pension,
+assisted by Marie. Affairs went on thus until the latter had attained
+her twenty-second year, when her great beauty attracted the notice of a
+perfumer, who occupied one of the shops in the basement of the Palais
+Royal, and whose custom lay chiefly among the desperate adventurers
+infesting that neighborhood. Monsieur Le Blanc (*4) was not unaware of
+the advantages to be derived from the attendance of the fair Marie in
+his perfumery; and his liberal proposals were accepted eagerly by the
+girl, although with somewhat more of hesitation by Madame.
+
+The anticipations of the shopkeeper were realized, and his rooms soon
+became notorious through the charms of the sprightly grisette. She had
+been in his employ about a year, when her admirers were thrown info
+confusion by her sudden disappearance from the shop. Monsieur Le Blanc
+was unable to account for her absence, and Madame Rogêt was distracted
+with anxiety and terror. The public papers immediately took up
+the theme, and the police were upon the point of making serious
+investigations, when, one fine morning, after the lapse of a week,
+Marie, in good health, but with a somewhat saddened air, made her
+re-appearance at her usual counter in the perfumery. All inquiry, except
+that of a private character, was of course immediately hushed. Monsieur
+Le Blanc professed total ignorance, as before. Marie, with Madame,
+replied to all questions, that the last week had been spent at the
+house of a relation in the country. Thus the affair died away, and was
+generally forgotten; for the girl, ostensibly to relieve herself from
+the impertinence of curiosity, soon bade a final adieu to the perfumer,
+and sought the shelter of her mother’s residence in the Rue Pavée Saint
+Andrée.
+
+It was about five months after this return home, that her friends were
+alarmed by her sudden disappearance for the second time. Three days
+elapsed, and nothing was heard of her. On the fourth her corpse was
+found floating in the Seine, * near the shore which is opposite the
+Quartier of the Rue Saint Andree, and at a point not very far distant
+from the secluded neighborhood of the Barrière du Roule. (*6)
+
+The atrocity of this murder, (for it was at once evident that murder had
+been committed,) the youth and beauty of the victim, and, above all, her
+previous notoriety, conspired to produce intense excitement in the minds
+of the sensitive Parisians. I can call to mind no similar occurrence
+producing so general and so intense an effect. For several weeks, in
+the discussion of this one absorbing theme, even the momentous political
+topics of the day were forgotten. The Prefect made unusual exertions;
+and the powers of the whole Parisian police were, of course, tasked to
+the utmost extent.
+
+Upon the first discovery of the corpse, it was not supposed that the
+murderer would be able to elude, for more than a very brief period,
+the inquisition which was immediately set on foot. It was not until the
+expiration of a week that it was deemed necessary to offer a reward; and
+even then this reward was limited to a thousand francs. In the mean time
+the investigation proceeded with vigor, if not always with judgment, and
+numerous individuals were examined to no purpose; while, owing to the
+continual absence of all clue to the mystery, the popular excitement
+greatly increased. At the end of the tenth day it was thought advisable
+to double the sum originally proposed; and, at length, the second week
+having elapsed without leading to any discoveries, and the prejudice
+which always exists in Paris against the Police having given vent to
+itself in several serious émeutes, the Prefect took it upon himself
+to offer the sum of twenty thousand francs “for the conviction of the
+assassin,” or, if more than one should prove to have been implicated,
+“for the conviction of any one of the assassins.” In the proclamation
+setting forth this reward, a full pardon was promised to any accomplice
+who should come forward in evidence against his fellow; and to the whole
+was appended, wherever it appeared, the private placard of a committee
+of citizens, offering ten thousand francs, in addition to the amount
+proposed by the Prefecture. The entire reward thus stood at no less than
+thirty thousand francs, which will be regarded as an extraordinary
+sum when we consider the humble condition of the girl, and the great
+frequency, in large cities, of such atrocities as the one described.
+
+No one doubted now that the mystery of this murder would be immediately
+brought to light. But although, in one or two instances, arrests were
+made which promised elucidation, yet nothing was elicited which could
+implicate the parties suspected; and they were discharged forthwith.
+Strange as it may appear, the third week from the discovery of the body
+had passed, and passed without any light being thrown upon the subject,
+before even a rumor of the events which had so agitated the public
+mind, reached the ears of Dupin and myself. Engaged in researches which
+absorbed our whole attention, it had been nearly a month since either of
+us had gone abroad, or received a visiter, or more than glanced at
+the leading political articles in one of the daily papers. The first
+intelligence of the murder was brought us by G ----, in person. He
+called upon us early in the afternoon of the thirteenth of July, 18--,
+and remained with us until late in the night. He had been piqued by
+the failure of all his endeavors to ferret out the assassins. His
+reputation--so he said with a peculiarly Parisian air--was at stake.
+Even his honor was concerned. The eyes of the public were upon him; and
+there was really no sacrifice which he would not be willing to make for
+the development of the mystery. He concluded a somewhat droll speech
+with a compliment upon what he was pleased to term the tact of Dupin,
+and made him a direct, and certainly a liberal proposition, the precise
+nature of which I do not feel myself at liberty to disclose, but which
+has no bearing upon the proper subject of my narrative.
+
+The compliment my friend rebutted as best he could, but the proposition
+he accepted at once, although its advantages were altogether
+provisional. This point being settled, the Prefect broke forth at
+once into explanations of his own views, interspersing them with
+long comments upon the evidence; of which latter we were not yet in
+possession. He discoursed much, and beyond doubt, learnedly; while
+I hazarded an occasional suggestion as the night wore drowsily away.
+Dupin, sitting steadily in his accustomed arm-chair, was the embodiment
+of respectful attention. He wore spectacles, during the whole interview;
+and an occasional signal glance beneath their green glasses, sufficed
+to convince me that he slept not the less soundly, because silently,
+throughout the seven or eight leaden-footed hours which immediately
+preceded the departure of the Prefect.
+
+In the morning, I procured, at the Prefecture, a full report of all
+the evidence elicited, and, at the various newspaper offices, a copy
+of every paper in which, from first to last, had been published any
+decisive information in regard to this sad affair. Freed from all that
+was positively disproved, this mass of information stood thus:
+
+Marie Rogêt left the residence of her mother, in the Rue Pavée
+St. Andrée, about nine o’clock in the morning of Sunday June the
+twenty-second, 18--. In going out, she gave notice to a Monsieur Jacques
+St. Eustache, (*7) and to him only, of her intent intention to spend the
+day with an aunt who resided in the Rue des Drômes. The Rue des Drômes
+is a short and narrow but populous thoroughfare, not far from the banks
+of the river, and at a distance of some two miles, in the most direct
+course possible, from the pension of Madame Rogêt. St. Eustache was the
+accepted suitor of Marie, and lodged, as well as took his meals, at
+the pension. He was to have gone for his betrothed at dusk, and to
+have escorted her home. In the afternoon, however, it came on to rain
+heavily; and, supposing that she would remain all night at her aunt’s,
+(as she had done under similar circumstances before,) he did not think
+it necessary to keep his promise. As night drew on, Madame Rogêt (who
+was an infirm old lady, seventy years of age,) was heard to express
+a fear “that she should never see Marie again;” but this observation
+attracted little attention at the time.
+
+On Monday, it was ascertained that the girl had not been to the Rue des
+Drômes; and when the day elapsed without tidings of her, a tardy search
+was instituted at several points in the city, and its environs. It was
+not, however until the fourth day from the period of disappearance that
+any thing satisfactory was ascertained respecting her. On this day,
+(Wednesday, the twenty-fifth of June,) a Monsieur Beauvais, (*8) who,
+with a friend, had been making inquiries for Marie near the Barrière
+du Roule, on the shore of the Seine which is opposite the Rue Pavée St.
+Andrée, was informed that a corpse had just been towed ashore by some
+fishermen, who had found it floating in the river. Upon seeing the
+body, Beauvais, after some hesitation, identified it as that of the
+perfumery-girl. His friend recognized it more promptly.
+
+The face was suffused with dark blood, some of which issued from the
+mouth. No foam was seen, as in the case of the merely drowned. There was
+no discoloration in the cellular tissue. About the throat were bruises
+and impressions of fingers. The arms were bent over on the chest and
+were rigid. The right hand was clenched; the left partially open. On
+the left wrist were two circular excoriations, apparently the effect
+of ropes, or of a rope in more than one volution. A part of the right
+wrist, also, was much chafed, as well as the back throughout its extent,
+but more especially at the shoulder-blades. In bringing the body to
+the shore the fishermen had attached to it a rope; but none of the
+excoriations had been effected by this. The flesh of the neck was much
+swollen. There were no cuts apparent, or bruises which appeared the
+effect of blows. A piece of lace was found tied so tightly around the
+neck as to be hidden from sight; it was completely buried in the flesh,
+and was fasted by a knot which lay just under the left ear. This alone
+would have sufficed to produce death. The medical testimony spoke
+confidently of the virtuous character of the deceased. She had been
+subjected, it said, to brutal violence. The corpse was in such condition
+when found, that there could have been no difficulty in its recognition
+by friends.
+
+The dress was much torn and otherwise disordered. In the outer garment,
+a slip, about a foot wide, had been torn upward from the bottom hem to
+the waist, but not torn off. It was wound three times around the waist,
+and secured by a sort of hitch in the back. The dress immediately
+beneath the frock was of fine muslin; and from this a slip eighteen
+inches wide had been torn entirely out--torn very evenly and with great
+care. It was found around her neck, fitting loosely, and secured with a
+hard knot. Over this muslin slip and the slip of lace, the strings of a
+bonnet were attached; the bonnet being appended. The knot by which the
+strings of the bonnet were fastened, was not a lady’s, but a slip or
+sailor’s knot.
+
+After the recognition of the corpse, it was not, as usual, taken to the
+Morgue, (this formality being superfluous,) but hastily interred not far
+from the spot at which it was brought ashore. Through the exertions of
+Beauvais, the matter was industriously hushed up, as far as possible;
+and several days had elapsed before any public emotion resulted. A
+weekly paper, (*9) however, at length took up the theme; the corpse was
+disinterred, and a re-examination instituted; but nothing was elicited
+beyond what has been already noted. The clothes, however, were
+now submitted to the mother and friends of the deceased, and fully
+identified as those worn by the girl upon leaving home.
+
+Meantime, the excitement increased hourly. Several individuals were
+arrested and discharged. St. Eustache fell especially under suspicion;
+and he failed, at first, to give an intelligible account of his
+whereabouts during the Sunday on which Marie left home. Subsequently,
+however, he submitted to Monsieur G----, affidavits, accounting
+satisfactorily for every hour of the day in question. As time passed and
+no discovery ensued, a thousand contradictory rumors were circulated,
+and journalists busied themselves in suggestions. Among these, the one
+which attracted the most notice, was the idea that Marie Rogêt still
+lived--that the corpse found in the Seine was that of some other
+unfortunate. It will be proper that I submit to the reader some passages
+which embody the suggestion alluded to. These passages are literal
+translations from L’Etoile, (*10) a paper conducted, in general, with
+much ability.
+
+“Mademoiselle Rogêt left her mother’s house on Sunday morning, June the
+twenty-second, 18--, with the ostensible purpose of going to see her
+aunt, or some other connexion, in the Rue des Drômes. From that hour,
+nobody is proved to have seen her. There is no trace or tidings of her
+at all.... There has no person, whatever, come forward, so far, who
+saw her at all, on that day, after she left her mother’s door.... Now,
+though we have no evidence that Marie Rogêt was in the land of the
+living after nine o’clock on Sunday, June the twenty-second, we have
+proof that, up to that hour, she was alive. On Wednesday noon, at
+twelve, a female body was discovered afloat on the shore of the Barrière
+de Roule. This was, even if we presume that Marie Rogêt was thrown into
+the river within three hours after she left her mother’s house, only
+three days from the time she left her home--three days to an hour. But
+it is folly to suppose that the murder, if murder was committed on
+her body, could have been consummated soon enough to have enabled her
+murderers to throw the body into the river before midnight. Those who
+are guilty of such horrid crimes, choose darkness rather the light....
+Thus we see that if the body found in the river was that of Marie Rogêt,
+it could only have been in the water two and a half days, or three at
+the outside. All experience has shown that drowned bodies, or bodies
+thrown into the water immediately after death by violence, require from
+six to ten days for decomposition to take place to bring them to the top
+of the water. Even where a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again, if let
+alone. Now, we ask, what was there in this cave to cause a departure
+from the ordinary course of nature?... If the body had been kept in its
+mangled state on shore until Tuesday night, some trace would be found on
+shore of the murderers. It is a doubtful point, also, whether the body
+would be so soon afloat, even were it thrown in after having been
+dead two days. And, furthermore, it is exceedingly improbable that any
+villains who had committed such a murder as is here supposed, would
+have thrown the body in without weight to sink it, when such a precaution
+could have so easily been taken.”
+
+The editor here proceeds to argue that the body must have been in the
+water “not three days merely, but, at least, five times three days,”
+ because it was so far decomposed that Beauvais had great difficulty
+in recognizing it. This latter point, however, was fully disproved. I
+continue the translation:
+
+“What, then, are the facts on which M. Beauvais says that he has no
+doubt the body was that of Marie Rogêt? He ripped up the gown sleeve,
+and says he found marks which satisfied him of the identity. The public
+generally supposed those marks to have consisted of some description
+of scars. He rubbed the arm and found hair upon it--something as
+indefinite, we think, as can readily be imagined--as little conclusive
+as finding an arm in the sleeve. M. Beauvais did not return that night,
+but sent word to Madame Rogêt, at seven o’clock, on Wednesday evening,
+that an investigation was still in progress respecting her daughter. If
+we allow that Madame Rogêt, from her age and grief, could not go over,
+(which is allowing a great deal,) there certainly must have been some
+one who would have thought it worth while to go over and attend the
+investigation, if they thought the body was that of Marie. Nobody went
+over. There was nothing said or heard about the matter in the Rue Pavée
+St. Andrée, that reached even the occupants of the same building. M. St.
+Eustache, the lover and intended husband of Marie, who boarded in her
+mother’s house, deposes that he did not hear of the discovery of the
+body of his intended until the next morning, when M. Beauvais came
+into his chamber and told him of it. For an item of news like this, it
+strikes us it was very coolly received.”
+
+In this way the journal endeavored to create the impression of an apathy
+on the part of the relatives of Marie, inconsistent with the supposition
+that these relatives believed the corpse to be hers. Its insinuations
+amount to this:--that Marie, with the connivance of her friends, had
+absented herself from the city for reasons involving a charge against
+her chastity; and that these friends, upon the discovery of a corpse in
+the Seine, somewhat resembling that of the girl, had availed themselves
+of the opportunity to impress the public with the belief of her
+death. But L’Etoile was again over-hasty. It was distinctly proved
+that no apathy, such as was imagined, existed; that the old lady was
+exceedingly feeble, and so agitated as to be unable to attend to any
+duty, that St. Eustache, so far from receiving the news coolly, was
+distracted with grief, and bore himself so frantically, that M. Beauvais
+prevailed upon a friend and relative to take charge of him, and prevent
+his attending the examination at the disinterment. Moreover, although
+it was stated by L’Etoile, that the corpse was re-interred at the public
+expense--that an advantageous offer of private sculpture was absolutely
+declined by the family--and that no member of the family attended the
+ceremonial:--although, I say, all this was asserted by L’Etoile in
+furtherance of the impression it designed to convey--yet all this
+was satisfactorily disproved. In a subsequent number of the paper, an
+attempt was made to throw suspicion upon Beauvais himself. The editor
+says:
+
+“Now, then, a change comes over the matter. We are told that on one
+occasion, while a Madame B---- was at Madame Rogêt’s house, M. Beauvais,
+who was going out, told her that a gendarme was expected there, and she,
+Madame B., must not say anything to the gendarme until he returned,
+but let the matter be for him.... In the present posture of affairs,
+M. Beauvais appears to have the whole matter locked up in his head. A
+single step cannot be taken without M. Beauvais; for, go which way you
+will, you run against him.... For some reason, he determined that nobody
+shall have any thing to do with the proceedings but himself, and he
+has elbowed the male relatives out of the way, according to their
+representations, in a very singular manner. He seems to have been very
+much averse to permitting the relatives to see the body.”
+
+By the following fact, some color was given to the suspicion thus thrown
+upon Beauvais. A visiter at his office, a few days prior to the girl’s
+disappearance, and during the absence of its occupant, had observed a
+rose in the key-hole of the door, and the name “Marie” inscribed upon a
+slate which hung near at hand.
+
+The general impression, so far as we were enabled to glean it from the
+newspapers, seemed to be, that Marie had been the victim of a gang
+of desperadoes--that by these she had been borne across the river,
+maltreated and murdered. Le Commerciel, (*11) however, a print of
+extensive influence, was earnest in combating this popular idea. I quote
+a passage or two from its columns:
+
+“We are persuaded that pursuit has hitherto been on a false scent, so
+far as it has been directed to the Barrière du Roule. It is impossible
+that a person so well known to thousands as this young woman was, should
+have passed three blocks without some one having seen her; and any one
+who saw her would have remembered it, for she interested all who knew
+her. It was when the streets were full of people, when she went out....
+It is impossible that she could have gone to the Barrière du Roule, or
+to the Rue des Drômes, without being recognized by a dozen persons; yet
+no one has come forward who saw her outside of her mother’s door, and
+there is no evidence, except the testimony concerning her expressed
+intentions, that she did go out at all. Her gown was torn, bound round
+her, and tied; and by that the body was carried as a bundle. If the
+murder had been committed at the Barrière du Roule, there would have
+been no necessity for any such arrangement. The fact that the body was
+found floating near the Barrière, is no proof as to where it was thrown
+into the water..... A piece of one of the unfortunate girl’s petticoats,
+two feet long and one foot wide, was torn out and tied under her chin
+around the back of her head, probably to prevent screams. This was done
+by fellows who had no pocket-handkerchief.”
+
+A day or two before the Prefect called upon us, however, some important
+information reached the police, which seemed to overthrow, at least,
+the chief portion of Le Commerciel’s argument. Two small boys, sons of a
+Madame Deluc, while roaming among the woods near the Barrière du Roule,
+chanced to penetrate a close thicket, within which were three or four
+large stones, forming a kind of seat, with a back and footstool. On
+the upper stone lay a white petticoat; on the second a silk scarf. A
+parasol, gloves, and a pocket-handkerchief were also here found. The
+handkerchief bore the name “Marie Rogêt.” Fragments of dress were
+discovered on the brambles around. The earth was trampled, the bushes
+were broken, and there was every evidence of a struggle. Between the
+thicket and the river, the fences were found taken down, and the ground
+bore evidence of some heavy burthen having been dragged along it.
+
+A weekly paper, Le Soleil,(*12) had the following comments upon this
+discovery--comments which merely echoed the sentiment of the whole
+Parisian press:
+
+“The things had all evidently been there at least three or four weeks;
+they were all mildewed down hard with the action of the rain and stuck
+together from mildew. The grass had grown around and over some of them.
+The silk on the parasol was strong, but the threads of it were run
+together within. The upper part, where it had been doubled and folded,
+was all mildewed and rotten, and tore on its being opened..... The
+pieces of her frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock, and it had been
+mended; the other piece was part of the skirt, not the hem. They looked
+like strips torn off, and were on the thorn bush, about a foot from
+the ground..... There can be no doubt, therefore, that the spot of this
+appalling outrage has been discovered.”
+
+Consequent upon this discovery, new evidence appeared. Madame Deluc
+testified that she keeps a roadside inn not far from the bank of the
+river, opposite the Barrière du Roule. The neighborhood is
+secluded--particularly so. It is the usual Sunday resort of blackguards
+from the city, who cross the river in boats. About three o’clock, in the
+afternoon of the Sunday in question, a young girl arrived at the inn,
+accompanied by a young man of dark complexion. The two remained here for
+some time. On their departure, they took the road to some thick woods in
+the vicinity. Madame Deluc’s attention was called to the dress worn by
+the girl, on account of its resemblance to one worn by a deceased
+relative. A scarf was particularly noticed. Soon after the departure of
+the couple, a gang of miscreants made their appearance, behaved
+boisterously, ate and drank without making payment, followed in the
+route of the young man and girl, returned to the inn about dusk, and
+re-crossed the river as if in great haste.
+
+It was soon after dark, upon this same evening, that Madame Deluc, as
+well as her eldest son, heard the screams of a female in the vicinity
+of the inn. The screams were violent but brief. Madame D. recognized not
+only the scarf which was found in the thicket, but the dress which was
+discovered upon the corpse. An omnibus driver, Valence, (*13) now also
+testified that he saw Marie Rogêt cross a ferry on the Seine, on the
+Sunday in question, in company with a young man of dark complexion.
+He, Valence, knew Marie, and could not be mistaken in her identity. The
+articles found in the thicket were fully identified by the relatives of
+Marie.
+
+The items of evidence and information thus collected by myself, from
+the newspapers, at the suggestion of Dupin, embraced only one more
+point--but this was a point of seemingly vast consequence. It appears
+that, immediately after the discovery of the clothes as above described,
+the lifeless, or nearly lifeless body of St. Eustache, Marie’s
+betrothed, was found in the vicinity of what all now supposed the scene
+of the outrage. A phial labelled “laudanum,” and emptied, was found near
+him. His breath gave evidence of the poison. He died without speaking.
+Upon his person was found a letter, briefly stating his love for Marie,
+with his design of self-destruction.
+
+“I need scarcely tell you,” said Dupin, as he finished the perusal of
+my notes, “that this is a far more intricate case than that of the
+Rue Morgue; from which it differs in one important respect. This is
+an ordinary, although an atrocious instance of crime. There is nothing
+peculiarly outré about it. You will observe that, for this reason, the
+mystery has been considered easy, when, for this reason, it should have
+been considered difficult, of solution. Thus; at first, it was thought
+unnecessary to offer a reward. The myrmidons of G---- were able at once
+to comprehend how and why such an atrocity might have been committed.
+They could picture to their imaginations a mode--many modes--and a
+motive--many motives; and because it was not impossible that either of
+these numerous modes and motives could have been the actual one, they
+have taken it for granted that one of them must. But the case with which
+these variable fancies were entertained, and the very plausibility which
+each assumed, should have been understood as indicative rather of the
+difficulties than of the facilities which must attend elucidation. I
+have before observed that it is by prominences above the plane of the
+ordinary, that reason feels her way, if at all, in her search for the
+true, and that the proper question in cases such as this, is not so
+much ‘what has occurred?’ as ‘what has occurred that has never occurred
+before?’ In the investigations at the house of Madame L’Espanaye,
+(*14) the agents of G---- were discouraged and confounded by that
+very unusualness which, to a properly regulated intellect, would have
+afforded the surest omen of success; while this same intellect might
+have been plunged in despair at the ordinary character of all that met
+the eye in the case of the perfumery-girl, and yet told of nothing but
+easy triumph to the functionaries of the Prefecture.
+
+“In the case of Madame L’Espanaye and her daughter there was, even
+at the beginning of our investigation, no doubt that murder had been
+committed. The idea of suicide was excluded at once. Here, too, we are
+freed, at the commencement, from all supposition of self-murder. The
+body found at the Barrière du Roule, was found under such circumstances
+as to leave us no room for embarrassment upon this important point. But
+it has been suggested that the corpse discovered, is not that of the
+Marie Rogêt for the conviction of whose assassin, or assassins, the
+reward is offered, and respecting whom, solely, our agreement has been
+arranged with the Prefect. We both know this gentleman well. It will not
+do to trust him too far. If, dating our inquiries from the body found,
+and thence tracing a murderer, we yet discover this body to be that of
+some other individual than Marie; or, if starting from the living Marie,
+we find her, yet find her unassassinated--in either case we lose our
+labor; since it is Monsieur G---- with whom we have to deal. For our
+own purpose, therefore, if not for the purpose of justice, it is
+indispensable that our first step should be the determination of the
+identity of the corpse with the Marie Rogêt who is missing.
+
+“With the public the arguments of L’Etoile have had weight; and that the
+journal itself is convinced of their importance would appear from
+the manner in which it commences one of its essays upon the
+subject--‘Several of the morning papers of the day,’ it says, ‘speak of
+the _conclusive_ article in Monday’s Etoile.’ To me, this article
+appears conclusive of little beyond the zeal of its inditer. We should
+bear in mind that, in general, it is the object of our newspapers rather
+to create a sensation--to make a point--than to further the cause of
+truth. The latter end is only pursued when it seems coincident with the
+former. The print which merely falls in with ordinary opinion (however
+well founded this opinion may be) earns for itself no credit with the
+mob. The mass of the people regard as profound only him who suggests
+_pungent contradictions_ of the general idea. In ratiocination, not less
+than in literature, it is the epigram which is the most immediately and
+the most universally appreciated. In both, it is of the lowest order of
+merit.
+
+“What I mean to say is, that it is the mingled epigram and melodrame
+of the idea, that Marie Rogêt still lives, rather than any true
+plausibility in this idea, which have suggested it to L’Etoile, and
+secured it a favorable reception with the public. Let us examine the
+heads of this journal’s argument; endeavoring to avoid the incoherence
+with which it is originally set forth.
+
+“The first aim of the writer is to show, from the brevity of the
+interval between Marie’s disappearance and the finding of the floating
+corpse, that this corpse cannot be that of Marie. The reduction of this
+interval to its smallest possible dimension, becomes thus, at once, an
+object with the reasoner. In the rash pursuit of this object, he rushes
+into mere assumption at the outset. ‘It is folly to suppose,’ he says,
+‘that the murder, if murder was committed on her body, could have been
+consummated soon enough to have enabled her murderers to throw the body
+into the river before midnight.’ We demand at once, and very naturally,
+why? Why is it folly to suppose that the murder was committed _within
+five minutes_ after the girl’s quitting her mother’s house? Why is it
+folly to suppose that the murder was committed at any given period
+of the day? There have been assassinations at all hours. But, had the
+murder taken place at any moment between nine o’clock in the morning of
+Sunday, and a quarter before midnight, there would still have been
+time enough ‘to throw the body into the river before midnight.’ This
+assumption, then, amounts precisely to this--that the murder was not
+committed on Sunday at all--and, if we allow L’Etoile to assume this,
+we may permit it any liberties whatever. The paragraph beginning ‘It is
+folly to suppose that the murder, etc.,’ however it appears as printed
+in L’Etoile, may be imagined to have existed actually thus in the brain
+of its inditer--‘It is folly to suppose that the murder, if murder was
+committed on the body, could have been committed soon enough to have
+enabled her murderers to throw the body into the river before midnight;
+it is folly, we say, to suppose all this, and to suppose at the same
+time, (as we are resolved to suppose,) that the body was not thrown
+in until after midnight’--a sentence sufficiently inconsequential in
+itself, but not so utterly preposterous as the one printed.
+
+“Were it my purpose,” continued Dupin, “merely to _make out a case_
+against this passage of L’Etoile’s argument, I might safely leave it
+where it is. It is not, however, with L’Etoile that we have to do, but
+with the truth. The sentence in question has but one meaning, as it
+stands; and this meaning I have fairly stated: but it is material
+that we go behind the mere words, for an idea which these words have
+obviously intended, and failed to convey. It was the design of the
+journalist to say that, at whatever period of the day or night of Sunday
+this murder was committed, it was improbable that the assassins would
+have ventured to bear the corpse to the river before midnight. And
+herein lies, really, the assumption of which I complain. It is assumed
+that the murder was committed at such a position, and under such
+circumstances, that the bearing it to the river became necessary. Now,
+the assassination might have taken place upon the river’s brink, or on
+the river itself; and, thus, the throwing the corpse in the water might
+have been resorted to, at any period of the day or night, as the most
+obvious and most immediate mode of disposal. You will understand that I
+suggest nothing here as probable, or as cöincident with my own opinion.
+My design, so far, has no reference to the facts of the case. I wish
+merely to caution you against the whole tone of L’Etoile’s suggestion,
+by calling your attention to its ex parte character at the outset.
+
+“Having prescribed thus a limit to suit its own preconceived notions;
+having assumed that, if this were the body of Marie, it could have been
+in the water but a very brief time; the journal goes on to say:
+
+‘All experience has shown that drowned bodies, or bodies thrown into the
+water immediately after death by violence, require from six to ten days
+for sufficient decomposition to take place to bring them to the top
+of the water. Even when a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again if let
+alone.’
+
+“These assertions have been tacitly received by every paper in Paris,
+with the exception of Le Moniteur. (*15) This latter print endeavors
+to combat that portion of the paragraph which has reference to ‘drowned
+bodies’ only, by citing some five or six instances in which the bodies
+of individuals known to be drowned were found floating after the lapse
+of less time than is insisted upon by L’Etoile. But there is something
+excessively unphilosophical in the attempt on the part of Le Moniteur,
+to rebut the general assertion of L’Etoile, by a citation of particular
+instances militating against that assertion. Had it been possible to
+adduce fifty instead of five examples of bodies found floating at the
+end of two or three days, these fifty examples could still have been
+properly regarded only as exceptions to L’Etoile’s rule, until such time
+as the rule itself should be confuted. Admitting the rule, (and this
+Le Moniteur does not deny, insisting merely upon its exceptions,) the
+argument of L’Etoile is suffered to remain in full force; for this
+argument does not pretend to involve more than a question of the
+probability of the body having risen to the surface in less than three
+days; and this probability will be in favor of L’Etoile’s position until
+the instances so childishly adduced shall be sufficient in number to
+establish an antagonistical rule.
+
+“You will see at once that all argument upon this head should be urged,
+if at all, against the rule itself; and for this end we must examine the
+rationale of the rule. Now the human body, in general, is neither much
+lighter nor much heavier than the water of the Seine; that is to say,
+the specific gravity of the human body, in its natural condition, is
+about equal to the bulk of fresh water which it displaces. The bodies
+of fat and fleshy persons, with small bones, and of women generally,
+are lighter than those of the lean and large-boned, and of men; and the
+specific gravity of the water of a river is somewhat influenced by the
+presence of the tide from sea. But, leaving this tide out of question,
+it may be said that very few human bodies will sink at all, even in
+fresh water, of their own accord. Almost any one, falling into a river,
+will be enabled to float, if he suffer the specific gravity of the water
+fairly to be adduced in comparison with his own--that is to say, if
+he suffer his whole person to be immersed, with as little exception as
+possible. The proper position for one who cannot swim, is the upright
+position of the walker on land, with the head thrown fully back, and
+immersed; the mouth and nostrils alone remaining above the surface.
+Thus circumstanced, we shall find that we float without difficulty and
+without exertion. It is evident, however, that the gravities of the
+body, and of the bulk of water displaced, are very nicely balanced, and
+that a trifle will cause either to preponderate. An arm, for instance,
+uplifted from the water, and thus deprived of its support, is an
+additional weight sufficient to immerse the whole head, while the
+accidental aid of the smallest piece of timber will enable us to elevate
+the head so as to look about. Now, in the struggles of one unused to
+swimming, the arms are invariably thrown upwards, while an attempt is
+made to keep the head in its usual perpendicular position. The result
+is the immersion of the mouth and nostrils, and the inception, during
+efforts to breathe while beneath the surface, of water into the lungs.
+Much is also received into the stomach, and the whole body becomes
+heavier by the difference between the weight of the air originally
+distending these cavities, and that of the fluid which now fills them.
+This difference is sufficient to cause the body to sink, as a general
+rule; but is insufficient in the cases of individuals with small bones
+and an abnormal quantity of flaccid or fatty matter. Such individuals
+float even after drowning.
+
+“The corpse, being supposed at the bottom of the river, will there
+remain until, by some means, its specific gravity again becomes less
+than that of the bulk of water which it displaces. This effect
+is brought about by decomposition, or otherwise. The result of
+decomposition is the generation of gas, distending the cellular tissues
+and all the cavities, and giving the puffed appearance which is so
+horrible. When this distension has so far progressed that the bulk of
+the corpse is materially increased without a corresponding increase of
+mass or weight, its specific gravity becomes less than that of the water
+displaced, and it forthwith makes its appearance at the surface. But
+decomposition is modified by innumerable circumstances--is hastened or
+retarded by innumerable agencies; for example, by the heat or cold of
+the season, by the mineral impregnation or purity of the water, by its
+depth or shallowness, by its currency or stagnation, by the temperament
+of the body, by its infection or freedom from disease before death.
+Thus it is evident that we can assign no period, with any thing like
+accuracy, at which the corpse shall rise through decomposition. Under
+certain conditions this result would be brought about within an hour;
+under others, it might not take place at all. There are chemical
+infusions by which the animal frame can be preserved forever from
+corruption; the Bi-chloride of Mercury is one. But, apart from
+decomposition, there may be, and very usually is, a generation of gas
+within the stomach, from the acetous fermentation of vegetable matter
+(or within other cavities from other causes) sufficient to induce a
+distension which will bring the body to the surface. The effect produced
+by the firing of a cannon is that of simple vibration. This may either
+loosen the corpse from the soft mud or ooze in which it is imbedded,
+thus permitting it to rise when other agencies have already prepared
+it for so doing; or it may overcome the tenacity of some putrescent
+portions of the cellular tissue; allowing the cavities to distend under
+the influence of the gas.
+
+“Having thus before us the whole philosophy of this subject, we can
+easily test by it the assertions of L’Etoile. ‘All experience shows,’
+says this paper, ‘that drowned bodies, or bodies thrown into the water
+immediately after death by violence, require from six to ten days for
+sufficient decomposition to take place to bring them to the top of the
+water. Even when a cannon is fired over a corpse, and it rises before at
+least five or six days’ immersion, it sinks again if let alone.’
+
+“The whole of this paragraph must now appear a tissue of inconsequence
+and incoherence. All experience does not show that ‘drowned bodies’
+require from six to ten days for sufficient decomposition to take place
+to bring them to the surface. Both science and experience show that the
+period of their rising is, and necessarily must be, indeterminate. If,
+moreover, a body has risen to the surface through firing of cannon,
+it will not ‘sink again if let alone,’ until decomposition has so far
+progressed as to permit the escape of the generated gas. But I wish to
+call your attention to the distinction which is made between ‘drowned
+bodies,’ and ‘bodies thrown into the water immediately after death by
+violence.’ Although the writer admits the distinction, he yet includes
+them all in the same category. I have shown how it is that the body of
+a drowning man becomes specifically heavier than its bulk of water,
+and that he would not sink at all, except for the struggles by which
+he elevates his arms above the surface, and his gasps for breath while
+beneath the surface--gasps which supply by water the place of the
+original air in the lungs. But these struggles and these gasps would
+not occur in the body ‘thrown into the water immediately after death by
+violence.’ Thus, in the latter instance, the body, as a general rule,
+would not sink at all--a fact of which L’Etoile is evidently ignorant.
+When decomposition had proceeded to a very great extent--when the flesh
+had in a great measure left the bones--then, indeed, but not till then,
+should we lose sight of the corpse.
+
+“And now what are we to make of the argument, that the body found could
+not be that of Marie Rogêt, because, three days only having elapsed,
+this body was found floating? If drowned, being a woman, she might never
+have sunk; or having sunk, might have reappeared in twenty-four hours,
+or less. But no one supposes her to have been drowned; and, dying before
+being thrown into the river, she might have been found floating at any
+period afterwards whatever.
+
+“‘But,’ says L’Etoile, ‘if the body had been kept in its mangled state
+on shore until Tuesday night, some trace would be found on shore of the
+murderers.’ Here it is at first difficult to perceive the intention
+of the reasoner. He means to anticipate what he imagines would be an
+objection to his theory--viz: that the body was kept on shore two days,
+suffering rapid decomposition--more rapid than if immersed in water. He
+supposes that, had this been the case, it might have appeared at the
+surface on the Wednesday, and thinks that only under such circumstances
+it could so have appeared. He is accordingly in haste to show that it
+was not kept on shore; for, if so, ‘some trace would be found on shore
+of the murderers.’ I presume you smile at the sequitur. You cannot
+be made to see how the mere duration of the corpse on the shore could
+operate to multiply traces of the assassins. Nor can I.
+
+“‘And furthermore it is exceedingly improbable,’ continues our journal,
+‘that any villains who had committed such a murder as is here supposed,
+would have thrown the body in without weight to sink it, when such
+a precaution could have so easily been taken.’ Observe, here, the
+laughable confusion of thought! No one--not even L’Etoile--disputes
+the murder committed _on the body found_. The marks of violence are too
+obvious. It is our reasoner’s object merely to show that this body is
+not Marie’s. He wishes to prove that Marie is not assassinated--not that
+the corpse was not. Yet his observation proves only the latter point.
+Here is a corpse without weight attached. Murderers, casting it in,
+would not have failed to attach a weight. Therefore it was not thrown in
+by murderers. This is all which is proved, if any thing is. The question
+of identity is not even approached, and L’Etoile has been at great pains
+merely to gainsay now what it has admitted only a moment before. ‘We
+are perfectly convinced,’ it says, ‘that the body found was that of a
+murdered female.’
+
+“Nor is this the sole instance, even in this division of his subject,
+where our reasoner unwittingly reasons against himself. His evident
+object, I have already said, is to reduce, as much as possible, the
+interval between Marie’s disappearance and the finding of the corpse.
+Yet we find him urging the point that no person saw the girl from the
+moment of her leaving her mother’s house. ‘We have no evidence,’ he
+says, ‘that Marie Rogêt was in the land of the living after nine o’clock
+on Sunday, June the twenty-second.’ As his argument is obviously an ex
+parte one, he should, at least, have left this matter out of sight; for
+had any one been known to see Marie, say on Monday, or on Tuesday,
+the interval in question would have been much reduced, and, by his own
+ratiocination, the probability much diminished of the corpse being that
+of the grisette. It is, nevertheless, amusing to observe that L’Etoile
+insists upon its point in the full belief of its furthering its general
+argument.
+
+“Reperuse now that portion of this argument which has reference to the
+identification of the corpse by Beauvais. In regard to the hair upon the
+arm, L’Etoile has been obviously disingenuous. M. Beauvais, not being an
+idiot, could never have urged, in identification of the corpse, simply
+hair upon its arm. No arm is without hair. The generality of the
+expression of L’Etoile is a mere perversion of the witness’ phraseology.
+He must have spoken of some peculiarity in this hair. It must have been
+a peculiarity of color, of quantity, of length, or of situation.
+
+“‘Her foot,’ says the journal, ‘was small--so are thousands of feet. Her
+garter is no proof whatever--nor is her shoe--for shoes and garters are
+sold in packages. The same may be said of the flowers in her hat. One
+thing upon which M. Beauvais strongly insists is, that the clasp on the
+garter found, had been set back to take it in. This amounts to nothing;
+for most women find it proper to take a pair of garters home and fit
+them to the size of the limbs they are to encircle, rather than to try
+them in the store where they purchase.’ Here it is difficult to suppose
+the reasoner in earnest. Had M. Beauvais, in his search for the body of
+Marie, discovered a corpse corresponding in general size and appearance
+to the missing girl, he would have been warranted (without reference to
+the question of habiliment at all) in forming an opinion that his search
+had been successful. If, in addition to the point of general size and
+contour, he had found upon the arm a peculiar hairy appearance which he
+had observed upon the living Marie, his opinion might have been justly
+strengthened; and the increase of positiveness might well have been in
+the ratio of the peculiarity, or unusualness, of the hairy mark. If,
+the feet of Marie being small, those of the corpse were also small, the
+increase of probability that the body was that of Marie would not be an
+increase in a ratio merely arithmetical, but in one highly geometrical,
+or accumulative. Add to all this shoes such as she had been known to
+wear upon the day of her disappearance, and, although these shoes may be
+‘sold in packages,’ you so far augment the probability as to verge upon
+the certain. What, of itself, would be no evidence of identity, becomes
+through its corroborative position, proof most sure. Give us, then,
+flowers in the hat corresponding to those worn by the missing girl, and
+we seek for nothing farther. If only one flower, we seek for nothing
+farther--what then if two or three, or more? Each successive one
+is multiple evidence--proof not _added_ to proof, but multiplied by
+hundreds or thousands. Let us now discover, upon the deceased, garters
+such as the living used, and it is almost folly to proceed. But these
+garters are found to be tightened, by the setting back of a clasp,
+in just such a manner as her own had been tightened by Marie, shortly
+previous to her leaving home. It is now madness or hypocrisy to doubt.
+What L’Etoile says in respect to this abbreviation of the garter’s being
+an usual occurrence, shows nothing beyond its own pertinacity in error.
+The elastic nature of the clasp-garter is self-demonstration of the
+unusualness of the abbreviation. What is made to adjust itself, must of
+necessity require foreign adjustment but rarely. It must have been by an
+accident, in its strictest sense, that these garters of Marie needed
+the tightening described. They alone would have amply established her
+identity. But it is not that the corpse was found to have the garters
+of the missing girl, or found to have her shoes, or her bonnet, or the
+flowers of her bonnet, or her feet, or a peculiar mark upon the arm,
+or her general size and appearance--it is that the corpse had each,
+and _all collectively_. Could it be proved that the editor of L’Etoile
+_really_ entertained a doubt, under the circumstances, there would be
+no need, in his case, of a commission de lunatico inquirendo. He has
+thought it sagacious to echo the small talk of the lawyers, who, for the
+most part, content themselves with echoing the rectangular precepts of
+the courts. I would here observe that very much of what is rejected as
+evidence by a court, is the best of evidence to the intellect. For
+the court, guiding itself by the general principles of evidence--the
+recognized and _booked_ principles--is averse from swerving at
+particular instances. And this steadfast adherence to principle, with
+rigorous disregard of the conflicting exception, is a sure mode of
+attaining the maximum of attainable truth, in any long sequence of time.
+The practice, in mass, is therefore philosophical; but it is not the
+less certain that it engenders vast individual error. (*16)
+
+“In respect to the insinuations levelled at Beauvais, you will be
+willing to dismiss them in a breath. You have already fathomed the
+true character of this good gentleman. He is a busy-body, with much
+of romance and little of wit. Any one so constituted will readily so
+conduct himself, upon occasion of real excitement, as to render himself
+liable to suspicion on the part of the over acute, or the ill-disposed.
+M. Beauvais (as it appears from your notes) had some personal interviews
+with the editor of L’Etoile, and offended him by venturing an opinion
+that the corpse, notwithstanding the theory of the editor, was, in sober
+fact, that of Marie. ‘He persists,’ says the paper, ‘in asserting the
+corpse to be that of Marie, but cannot give a circumstance, in addition
+to those which we have commented upon, to make others believe.’ Now,
+without re-adverting to the fact that stronger evidence ‘to make others
+believe,’ could never have been adduced, it may be remarked that a man
+may very well be understood to believe, in a case of this kind, without
+the ability to advance a single reason for the belief of a second party.
+Nothing is more vague than impressions of individual identity. Each man
+recognizes his neighbor, yet there are few instances in which any one
+is prepared to give a reason for his recognition. The editor of L’Etoile
+had no right to be offended at M. Beauvais’ unreasoning belief.
+
+“The suspicious circumstances which invest him, will be found to tally
+much better with my hypothesis of romantic busy-bodyism, than with
+the reasoner’s suggestion of guilt. Once adopting the more charitable
+interpretation, we shall find no difficulty in comprehending the rose
+in the key-hole; the ‘Marie’ upon the slate; the ‘elbowing the male
+relatives out of the way;’ the ‘aversion to permitting them to see
+the body;’ the caution given to Madame B----, that she must hold no
+conversation with the gendarme until his return (Beauvais’); and,
+lastly, his apparent determination ‘that nobody should have anything to
+do with the proceedings except himself.’ It seems to me unquestionable
+that Beauvais was a suitor of Marie’s; that she coquetted with him; and
+that he was ambitious of being thought to enjoy her fullest intimacy
+and confidence. I shall say nothing more upon this point; and, as the
+evidence fully rebuts the assertion of L’Etoile, touching the matter
+of apathy on the part of the mother and other relatives--an apathy
+inconsistent with the supposition of their believing the corpse to be
+that of the perfumery-girl--we shall now proceed as if the question of
+identity were settled to our perfect satisfaction.”
+
+“And what,” I here demanded, “do you think of the opinions of Le
+Commerciel?”
+
+“That, in spirit, they are far more worthy of attention than any which
+have been promulgated upon the subject. The deductions from the premises
+are philosophical and acute; but the premises, in two instances, at
+least, are founded in imperfect observation. Le Commerciel wishes to
+intimate that Marie was seized by some gang of low ruffians not far from
+her mother’s door. ‘It is impossible,’ it urges, ‘that a person so well
+known to thousands as this young woman was, should have passed three
+blocks without some one having seen her.’ This is the idea of a man long
+resident in Paris--a public man--and one whose walks to and fro in the
+city, have been mostly limited to the vicinity of the public offices.
+He is aware that he seldom passes so far as a dozen blocks from his own
+bureau, without being recognized and accosted. And, knowing the extent
+of his personal acquaintance with others, and of others with him, he
+compares his notoriety with that of the perfumery-girl, finds no great
+difference between them, and reaches at once the conclusion that she, in
+her walks, would be equally liable to recognition with himself in
+his. This could only be the case were her walks of the same unvarying,
+methodical character, and within the same species of limited region
+as are his own. He passes to and fro, at regular intervals, within a
+confined periphery, abounding in individuals who are led to observation
+of his person through interest in the kindred nature of his occupation
+with their own. But the walks of Marie may, in general, be supposed
+discursive. In this particular instance, it will be understood as most
+probable, that she proceeded upon a route of more than average diversity
+from her accustomed ones. The parallel which we imagine to have existed
+in the mind of Le Commerciel would only be sustained in the event of the
+two individuals’ traversing the whole city. In this case, granting the
+personal acquaintances to be equal, the chances would be also equal that
+an equal number of personal rencounters would be made. For my own
+part, I should hold it not only as possible, but as very far more than
+probable, that Marie might have proceeded, at any given period, by any
+one of the many routes between her own residence and that of her aunt,
+without meeting a single individual whom she knew, or by whom she was
+known. In viewing this question in its full and proper light, we must
+hold steadily in mind the great disproportion between the personal
+acquaintances of even the most noted individual in Paris, and the entire
+population of Paris itself.
+
+“But whatever force there may still appear to be in the suggestion of Le
+Commerciel, will be much diminished when we take into consideration the
+hour at which the girl went abroad. ‘It was when the streets were full
+of people,’ says Le Commerciel, ‘that she went out.’ But not so. It was
+at nine o’clock in the morning. Now at nine o’clock of every morning in
+the week, _with the exception of Sunday_, the streets of the city are,
+it is true, thronged with people. At nine on Sunday, the populace are
+chiefly within doors _preparing for church_. No observing person can
+have failed to notice the peculiarly deserted air of the town, from
+about eight until ten on the morning of every Sabbath. Between ten and
+eleven the streets are thronged, but not at so early a period as that
+designated.
+
+“There is another point at which there seems a deficiency of observation
+on the part of Le Commerciel. ‘A piece,’ it says, ‘of one of the
+unfortunate girl’s petticoats, two feet long, and one foot wide, was
+torn out and tied under her chin, and around the back of her head,
+probably to prevent screams. This was done, by fellows who had no
+pocket-handkerchiefs.’ Whether this idea is, or is not well founded,
+we will endeavor to see hereafter; but by ‘fellows who have no
+pocket-handkerchiefs’ the editor intends the lowest class of ruffians.
+These, however, are the very description of people who will always be
+found to have handkerchiefs even when destitute of shirts. You must have
+had occasion to observe how absolutely indispensable, of late years, to
+the thorough blackguard, has become the pocket-handkerchief.”
+
+“And what are we to think,” I asked, “of the article in Le Soleil?”
+
+“That it is a vast pity its inditer was not born a parrot--in which
+case he would have been the most illustrious parrot of his race. He has
+merely repeated the individual items of the already published opinion;
+collecting them, with a laudable industry, from this paper and from
+that. ‘The things had all evidently been there,’ he says, ‘at least,
+three or four weeks, and there can be _no doubt_ that the spot of this
+appalling outrage has been discovered.’ The facts here re-stated by
+Le Soleil, are very far indeed from removing my own doubts upon this
+subject, and we will examine them more particularly hereafter in
+connexion with another division of the theme.
+
+“At present we must occupy ourselves with other investigations. You
+cannot fail to have remarked the extreme laxity of the examination of
+the corpse. To be sure, the question of identity was readily determined,
+or should have been; but there were other points to be ascertained. Had
+the body been in any respect despoiled? Had the deceased any articles
+of jewelry about her person upon leaving home? if so, had she any when
+found? These are important questions utterly untouched by the evidence;
+and there are others of equal moment, which have met with no attention.
+We must endeavor to satisfy ourselves by personal inquiry. The case of
+St. Eustache must be re-examined. I have no suspicion of this person;
+but let us proceed methodically. We will ascertain beyond a doubt the
+validity of the affidavits in regard to his whereabouts on the Sunday.
+Affidavits of this character are readily made matter of mystification.
+Should there be nothing wrong here, however, we will dismiss St.
+Eustache from our investigations. His suicide, however corroborative of
+suspicion, were there found to be deceit in the affidavits, is, without
+such deceit, in no respect an unaccountable circumstance, or one which
+need cause us to deflect from the line of ordinary analysis.
+
+“In that which I now propose, we will discard the interior points of
+this tragedy, and concentrate our attention upon its outskirts. Not the
+least usual error, in investigations such as this, is the limiting of
+inquiry to the immediate, with total disregard of the collateral or
+circumstantial events. It is the mal-practice of the courts to confine
+evidence and discussion to the bounds of apparent relevancy. Yet
+experience has shown, and a true philosophy will always show, that a
+vast, perhaps the larger portion of truth, arises from the seemingly
+irrelevant. It is through the spirit of this principle, if not precisely
+through its letter, that modern science has resolved to calculate upon
+the unforeseen. But perhaps you do not comprehend me. The history of
+human knowledge has so uninterruptedly shown that to collateral, or
+incidental, or accidental events we are indebted for the most numerous
+and most valuable discoveries, that it has at length become necessary,
+in any prospective view of improvement, to make not only large, but the
+largest allowances for inventions that shall arise by chance, and quite
+out of the range of ordinary expectation. It is no longer philosophical
+to base, upon what has been, a vision of what is to be. Accident is
+admitted as a portion of the substructure. We make chance a matter of
+absolute calculation. We subject the unlooked for and unimagined, to the
+mathematical _formulae_ of the schools.
+
+“I repeat that it is no more than fact, that the larger portion of all
+truth has sprung from the collateral; and it is but in accordance with
+the spirit of the principle involved in this fact, that I would divert
+inquiry, in the present case, from the trodden and hitherto unfruitful
+ground of the event itself, to the contemporary circumstances which
+surround it. While you ascertain the validity of the affidavits, I will
+examine the newspapers more generally than you have as yet done. So far,
+we have only reconnoitred the field of investigation; but it will be
+strange indeed if a comprehensive survey, such as I propose, of the
+public prints, will not afford us some minute points which shall
+establish a direction for inquiry.”
+
+In pursuance of Dupin’s suggestion, I made scrupulous examination of
+the affair of the affidavits. The result was a firm conviction of their
+validity, and of the consequent innocence of St. Eustache. In the mean
+time my friend occupied himself, with what seemed to me a minuteness
+altogether objectless, in a scrutiny of the various newspaper files. At
+the end of a week he placed before me the following extracts:
+
+“About three years and a half ago, a disturbance very similar to the
+present, was caused by the disappearance of this same Marie Rogêt, from
+the parfumerie of Monsieur Le Blanc, in the Palais Royal. At the end of
+a week, however, she re-appeared at her customary comptoir, as well as
+ever, with the exception of a slight paleness not altogether usual. It
+was given out by Monsieur Le Blanc and her mother, that she had merely
+been on a visit to some friend in the country; and the affair was
+speedily hushed up. We presume that the present absence is a freak of
+the same nature, and that, at the expiration of a week, or perhaps of
+a month, we shall have her among us again.”--Evening Paper--Monday June
+23. (*17)
+
+“An evening journal of yesterday, refers to a former mysterious
+disappearance of Mademoiselle Rogêt. It is well known that, during the
+week of her absence from Le Blanc’s parfumerie, she was in the company
+of a young naval officer, much noted for his debaucheries. A quarrel, it
+is supposed, providentially led to her return home. We have the name of
+the Lothario in question, who is, at present, stationed in Paris, but,
+for obvious reasons, forbear to make it public.”--Le Mercurie--Tuesday
+Morning, June 24. (*18)
+
+“An outrage of the most atrocious character was perpetrated near this
+city the day before yesterday. A gentleman, with his wife and daughter,
+engaged, about dusk, the services of six young men, who were idly rowing
+a boat to and fro near the banks of the Seine, to convey him across the
+river. Upon reaching the opposite shore, the three passengers stepped
+out, and had proceeded so far as to be beyond the view of the boat,
+when the daughter discovered that she had left in it her parasol. She
+returned for it, was seized by the gang, carried out into the stream,
+gagged, brutally treated, and finally taken to the shore at a point
+not far from that at which she had originally entered the boat with her
+parents. The villains have escaped for the time, but the police are upon
+their trail, and some of them will soon be taken.”--Morning Paper--June
+25. (*19)
+
+“We have received one or two communications, the object of which is to
+fasten the crime of the late atrocity upon Mennais; (*20) but as this
+gentleman has been fully exonerated by a loyal inquiry, and as the
+arguments of our several correspondents appear to be more zealous than
+profound, we do not think it advisable to make them public.”--Morning
+Paper--June 28. (*21)
+
+“We have received several forcibly written communications, apparently
+from various sources, and which go far to render it a matter of
+certainty that the unfortunate Marie Rogêt has become a victim of one of
+the numerous bands of blackguards which infest the vicinity of the city
+upon Sunday. Our own opinion is decidedly in favor of this
+supposition. We shall endeavor to make room for some of these arguments
+hereafter.”--Evening Paper--Tuesday, June 31. (*22)
+
+“On Monday, one of the bargemen connected with the revenue service, saw
+a empty boat floating down the Seine. Sails were lying in the bottom of
+the boat. The bargeman towed it under the barge office. The next morning
+it was taken from thence, without the knowledge of any of the officers.
+The rudder is now at the barge office.”--Le Diligence--Thursday, June
+26.
+
+Upon reading these various extracts, they not only seemed to me
+irrelevant, but I could perceive no mode in which any one of them
+could be brought to bear upon the matter in hand. I waited for some
+explanation from Dupin.
+
+“It is not my present design,” he said, “to dwell upon the first and
+second of those extracts. I have copied them chiefly to show you the
+extreme remissness of the police, who, as far as I can understand from
+the Prefect, have not troubled themselves, in any respect, with an
+examination of the naval officer alluded to. Yet it is mere folly to say
+that between the first and second disappearance of Marie, there is
+no _supposable_ connection. Let us admit the first elopement to have
+resulted in a quarrel between the lovers, and the return home of the
+betrayed. We are now prepared to view a second elopement (if we know
+that an elopement has again taken place) as indicating a renewal of the
+betrayer’s advances, rather than as the result of new proposals by a
+second individual--we are prepared to regard it as a ‘making up’ of the
+old amour, rather than as the commencement of a new one. The chances are
+ten to one, that he who had once eloped with Marie, would again propose
+an elopement, rather than that she to whom proposals of elopement had
+been made by one individual, should have them made to her by another.
+And here let me call your attention to the fact, that the time elapsing
+between the first ascertained, and the second supposed elopement, is
+a few months more than the general period of the cruises of our
+men-of-war. Had the lover been interrupted in his first villany by the
+necessity of departure to sea, and had he seized the first moment of his
+return to renew the base designs not yet altogether accomplished--or
+not yet altogether accomplished by _him?_ Of all these things we know
+nothing.
+
+“You will say, however, that, in the second instance, there was no
+elopement as imagined. Certainly not--but are we prepared to say that
+there was not the frustrated design? Beyond St. Eustache, and perhaps
+Beauvais, we find no recognized, no open, no honorable suitors of Marie.
+Of none other is there any thing said. Who, then, is the secret lover,
+of whom the relatives (at least most of them) know nothing, but whom
+Marie meets upon the morning of Sunday, and who is so deeply in her
+confidence, that she hesitates not to remain with him until the shades
+of the evening descend, amid the solitary groves of the Barrière du
+Roule? Who is that secret lover, I ask, of whom, at least, most of the
+relatives know nothing? And what means the singular prophecy of Madame
+Rogêt on the morning of Marie’s departure?--‘I fear that I shall never
+see Marie again.’
+
+“But if we cannot imagine Madame Rogêt privy to the design of elopement,
+may we not at least suppose this design entertained by the girl? Upon
+quitting home, she gave it to be understood that she was about to visit
+her aunt in the Rue des Drômes and St. Eustache was requested to call
+for her at dark. Now, at first glance, this fact strongly militates
+against my suggestion;--but let us reflect. That she did meet some
+companion, and proceed with him across the river, reaching the Barrière
+du Roule at so late an hour as three o’clock in the afternoon, is
+known. But in consenting so to accompany this individual, (_for whatever
+purpose--to her mother known or unknown,_) she must have thought of her
+expressed intention when leaving home, and of the surprise and suspicion
+aroused in the bosom of her affianced suitor, St. Eustache, when,
+calling for her, at the hour appointed, in the Rue des Drômes, he should
+find that she had not been there, and when, moreover, upon returning to
+the pension with this alarming intelligence, he should become aware of
+her continued absence from home. She must have thought of these things,
+I say. She must have foreseen the chagrin of St. Eustache, the suspicion
+of all. She could not have thought of returning to brave this suspicion;
+but the suspicion becomes a point of trivial importance to her, if we
+suppose her not intending to return.
+
+“We may imagine her thinking thus--‘I am to meet a certain person for
+the purpose of elopement, or for certain other purposes known only to
+myself. It is necessary that there be no chance of interruption--there
+must be sufficient time given us to elude pursuit--I will give it to be
+understood that I shall visit and spend the day with my aunt at the Rue
+des Drômes--I well tell St. Eustache not to call for me until dark--in
+this way, my absence from home for the longest possible period, without
+causing suspicion or anxiety, will be accounted for, and I shall gain
+more time than in any other manner. If I bid St. Eustache call for me
+at dark, he will be sure not to call before; but, if I wholly neglect
+to bid him call, my time for escape will be diminished, since it will
+be expected that I return the earlier, and my absence will the sooner
+excite anxiety. Now, if it were my design to return at all--if I had in
+contemplation merely a stroll with the individual in question--it would
+not be my policy to bid St. Eustache call; for, calling, he will be sure
+to ascertain that I have played him false--a fact of which I might keep
+him for ever in ignorance, by leaving home without notifying him of my
+intention, by returning before dark, and by then stating that I had been
+to visit my aunt in the Rue des Drômes. But, as it is my design never
+to return--or not for some weeks--or not until certain concealments are
+effected--the gaining of time is the only point about which I need give
+myself any concern.’
+
+“You have observed, in your notes, that the most general opinion in
+relation to this sad affair is, and was from the first, that the girl
+had been the victim of a gang of blackguards. Now, the popular opinion,
+under certain conditions, is not to be disregarded. When arising of
+itself--when manifesting itself in a strictly spontaneous manner--we
+should look upon it as analogous with that _intuition_ which is the
+idiosyncrasy of the individual man of genius. In ninety-nine cases from
+the hundred I would abide by its decision. But it is important that we
+find no palpable traces of _suggestion_. The opinion must be rigorously
+_the public’s own_; and the distinction is often exceedingly difficult
+to perceive and to maintain. In the present instance, it appears to me
+that this ‘public opinion’ in respect to a gang, has been superinduced
+by the collateral event which is detailed in the third of my extracts.
+All Paris is excited by the discovered corpse of Marie, a girl young,
+beautiful and notorious. This corpse is found, bearing marks of
+violence, and floating in the river. But it is now made known that, at
+the very period, or about the very period, in which it is supposed that
+the girl was assassinated, an outrage similar in nature to that endured
+by the deceased, although less in extent, was perpetuated, by a gang
+of young ruffians, upon the person of a second young female. Is it
+wonderful that the one known atrocity should influence the popular
+judgment in regard to the other unknown? This judgment awaited
+direction, and the known outrage seemed so opportunely to afford it!
+Marie, too, was found in the river; and upon this very river was this
+known outrage committed. The connexion of the two events had about it so
+much of the palpable, that the true wonder would have been a failure
+of the populace to appreciate and to seize it. But, in fact, the one
+atrocity, known to be so committed, is, if any thing, evidence that the
+other, committed at a time nearly coincident, was not so committed.
+It would have been a miracle indeed, if, while a gang of ruffians were
+perpetrating, at a given locality, a most unheard-of wrong, there should
+have been another similar gang, in a similar locality, in the same
+city, under the same circumstances, with the same means and appliances,
+engaged in a wrong of precisely the same aspect, at precisely the
+same period of time! Yet in what, if not in this marvellous train of
+coincidence, does the accidentally suggested opinion of the populace
+call upon us to believe?
+
+“Before proceeding farther, let us consider the supposed scene of the
+assassination, in the thicket at the Barrière du Roule. This thicket,
+although dense, was in the close vicinity of a public road. Within
+were three or four large stones, forming a kind of seat with a back and
+footstool. On the upper stone was discovered a white petticoat; on the
+second, a silk scarf. A parasol, gloves, and a pocket-handkerchief,
+were also here found. The handkerchief bore the name, ‘Marie Rogêt.’
+Fragments of dress were seen on the branches around. The earth was
+trampled, the bushes were broken, and there was every evidence of a
+violent struggle.
+
+“Notwithstanding the acclamation with which the discovery of this
+thicket was received by the press, and the unanimity with which it
+was supposed to indicate the precise scene of the outrage, it must be
+admitted that there was some very good reason for doubt. That it was the
+scene, I may or I may not believe--but there was excellent reason for
+doubt. Had the true scene been, as Le Commerciel suggested, in the
+neighborhood of the Rue Pavée St. Andrée, the perpetrators of the
+crime, supposing them still resident in Paris, would naturally have been
+stricken with terror at the public attention thus acutely directed into
+the proper channel; and, in certain classes of minds, there would have
+arisen, at once, a sense of the necessity of some exertion to redivert
+this attention. And thus, the thicket of the Barrière du Roule having
+been already suspected, the idea of placing the articles where they were
+found, might have been naturally entertained. There is no real evidence,
+although Le Soleil so supposes, that the articles discovered had
+been more than a very few days in the thicket; while there is much
+circumstantial proof that they could not have remained there, without
+attracting attention, during the twenty days elapsing between the fatal
+Sunday and the afternoon upon which they were found by the boys. ‘They
+were all _mildewed_ down hard,’ says Le Soleil, adopting the opinions of
+its predecessors, ‘with the action of the rain, and stuck together from
+_mildew_. The grass had grown around and over some of them. The silk of
+the parasol was strong, but the threads of it were run together within.
+The upper part, where it had been doubled and folded, was all _mildewed_
+and rotten, and tore on being opened.’ In respect to the grass having
+‘grown around and over some of them,’ it is obvious that the fact
+could only have been ascertained from the words, and thus from the
+recollections, of two small boys; for these boys removed the articles
+and took them home before they had been seen by a third party. But grass
+will grow, especially in warm and damp weather, (such as was that of the
+period of the murder,) as much as two or three inches in a single day.
+A parasol lying upon a newly turfed ground, might, in a single week,
+be entirely concealed from sight by the upspringing grass. And touching
+that mildew upon which the editor of Le Soleil so pertinaciously
+insists, that he employs the word no less than three times in the
+brief paragraph just quoted, is he really unaware of the nature of this
+mildew? Is he to be told that it is one of the many classes of fungus,
+of which the most ordinary feature is its upspringing and decadence
+within twenty-four hours?
+
+“Thus we see, at a glance, that what has been most triumphantly adduced
+in support of the idea that the articles had been ‘for at least three
+or four weeks’ in the thicket, is most absurdly null as regards any
+evidence of that fact. On the other hand, it is exceedingly difficult
+to believe that these articles could have remained in the thicket
+specified, for a longer period than a single week--for a longer period
+than from one Sunday to the next. Those who know any thing of the
+vicinity of Paris, know the extreme difficulty of finding seclusion
+unless at a great distance from its suburbs. Such a thing as an
+unexplored, or even an unfrequently visited recess, amid its woods or
+groves, is not for a moment to be imagined. Let any one who, being at
+heart a lover of nature, is yet chained by duty to the dust and heat
+of this great metropolis--let any such one attempt, even during the
+weekdays, to slake his thirst for solitude amid the scenes of natural
+loveliness which immediately surround us. At every second step, he will
+find the growing charm dispelled by the voice and personal intrusion
+of some ruffian or party of carousing blackguards. He will seek privacy
+amid the densest foliage, all in vain. Here are the very nooks where the
+unwashed most abound--here are the temples most desecrate. With sickness
+of the heart the wanderer will flee back to the polluted Paris as to
+a less odious because less incongruous sink of pollution. But if the
+vicinity of the city is so beset during the working days of the week,
+how much more so on the Sabbath! It is now especially that, released
+from the claims of labor, or deprived of the customary opportunities of
+crime, the town blackguard seeks the precincts of the town, not through
+love of the rural, which in his heart he despises, but by way of escape
+from the restraints and conventionalities of society. He desires
+less the fresh air and the green trees, than the utter license of the
+country. Here, at the road-side inn, or beneath the foliage of the
+woods, he indulges, unchecked by any eye except those of his boon
+companions, in all the mad excess of a counterfeit hilarity--the joint
+offspring of liberty and of rum. I say nothing more than what must
+be obvious to every dispassionate observer, when I repeat that the
+circumstance of the articles in question having remained undiscovered,
+for a longer period--than from one Sunday to another, in any thicket in
+the immediate neighborhood of Paris, is to be looked upon as little less
+than miraculous.
+
+“But there are not wanting other grounds for the suspicion that the
+articles were placed in the thicket with the view of diverting attention
+from the real scene of the outrage. And, first, let me direct your
+notice to the date of the discovery of the articles. Collate this with
+the date of the fifth extract made by myself from the newspapers. You
+will find that the discovery followed, almost immediately, the urgent
+communications sent to the evening paper. These communications, although
+various and apparently from various sources, tended all to the same
+point--viz., the directing of attention to a gang as the perpetrators
+of the outrage, and to the neighborhood of the Barrière du Roule as its
+scene. Now here, of course, the suspicion is not that, in consequence of
+these communications, or of the public attention by them directed, the
+articles were found by the boys; but the suspicion might and may well
+have been, that the articles were not before found by the boys, for the
+reason that the articles had not before been in the thicket; having
+been deposited there only at so late a period as at the date, or shortly
+prior to the date of the communications by the guilty authors of these
+communications themselves.
+
+“This thicket was a singular--an exceedingly singular one. It was
+unusually dense. Within its naturally walled enclosure were three
+extraordinary stones, forming a seat with a back and footstool. And this
+thicket, so full of a natural art, was in the immediate vicinity, within
+a few rods, of the dwelling of Madame Deluc, whose boys were in the
+habit of closely examining the shrubberies about them in search of
+the bark of the sassafras. Would it be a rash wager--a wager of one
+thousand to one--that a day never passed over the heads of these boys
+without finding at least one of them ensconced in the umbrageous hall,
+and enthroned upon its natural throne? Those who would hesitate at such
+a wager, have either never been boys themselves, or have forgotten the
+boyish nature. I repeat--it is exceedingly hard to comprehend how the
+articles could have remained in this thicket undiscovered, for a longer
+period than one or two days; and that thus there is good ground for
+suspicion, in spite of the dogmatic ignorance of Le Soleil, that they
+were, at a comparatively late date, deposited where found.
+
+“But there are still other and stronger reasons for believing them so
+deposited, than any which I have as yet urged. And, now, let me beg
+your notice to the highly artificial arrangement of the articles. On the
+upper stone lay a white petticoat; on the second a silk scarf; scattered
+around, were a parasol, gloves, and a pocket-handkerchief bearing the
+name, ‘Marie Rogêt.’ Here is just such an arrangement as would naturally
+be made by a not over-acute person wishing to dispose the articles
+naturally. But it is by no means a really natural arrangement. I
+should rather have looked to see the things all lying on the ground and
+trampled under foot. In the narrow limits of that bower, it would have
+been scarcely possible that the petticoat and scarf should have retained
+a position upon the stones, when subjected to the brushing to and fro
+of many struggling persons. ‘There was evidence,’ it is said, ‘of a
+struggle; and the earth was trampled, the bushes were broken,’--but the
+petticoat and the scarf are found deposited as if upon shelves. ‘The
+pieces of the frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock and it had been
+mended. They looked like strips torn off.’ Here, inadvertently, Le
+Soleil has employed an exceedingly suspicious phrase. The pieces, as
+described, do indeed ‘look like strips torn off;’ but purposely and by
+hand. It is one of the rarest of accidents that a piece is ‘torn off,’
+from any garment such as is now in question, by the agency of a thorn.
+From the very nature of such fabrics, a thorn or nail becoming entangled
+in them, tears them rectangularly--divides them into two longitudinal
+rents, at right angles with each other, and meeting at an apex where the
+thorn enters--but it is scarcely possible to conceive the piece ‘torn
+off.’ I never so knew it, nor did you. To tear a piece off from such
+fabric, two distinct forces, in different directions, will be, in almost
+every case, required. If there be two edges to the fabric--if, for
+example, it be a pocket-handkerchief, and it is desired to tear from it
+a slip, then, and then only, will the one force serve the purpose. But
+in the present case the question is of a dress, presenting but one edge.
+To tear a piece from the interior, where no edge is presented, could
+only be effected by a miracle through the agency of thorns, and no one
+thorn could accomplish it. But, even where an edge is presented, two
+thorns will be necessary, operating, the one in two distinct directions,
+and the other in one. And this in the supposition that the edge is
+unhemmed. If hemmed, the matter is nearly out of the question. We thus
+see the numerous and great obstacles in the way of pieces being ‘torn
+off’ through the simple agency of ‘thorns;’ yet we are required to
+believe not only that one piece but that many have been so torn. ‘And
+one part,’ too, ‘was the hem of the frock!’ Another piece was ‘part
+of the skirt, not the hem,’--that is to say, was torn completely out
+through the agency of thorns, from the uncaged interior of the
+dress! These, I say, are things which one may well be pardoned for
+disbelieving; yet, taken collectedly, they form, perhaps, less of
+reasonable ground for suspicion, than the one startling circumstance of
+the articles’ having been left in this thicket at all, by any murderers
+who had enough precaution to think of removing the corpse. You will not
+have apprehended me rightly, however, if you suppose it my design to
+deny this thicket as the scene of the outrage. There might have been a
+wrong here, or, more possibly, an accident at Madame Deluc’s. But, in
+fact, this is a point of minor importance. We are not engaged in an
+attempt to discover the scene, but to produce the perpetrators of the
+murder. What I have adduced, notwithstanding the minuteness with which I
+have adduced it, has been with the view, first, to show the folly of the
+positive and headlong assertions of Le Soleil, but secondly and chiefly,
+to bring you, by the most natural route, to a further contemplation of
+the doubt whether this assassination has, or has not been, the work of a
+gang.
+
+“We will resume this question by mere allusion to the revolting details
+of the surgeon examined at the inquest. It is only necessary to say that
+his published inferences, in regard to the number of ruffians, have been
+properly ridiculed as unjust and totally baseless, by all the reputable
+anatomists of Paris. Not that the matter might not have been as
+inferred, but that there was no ground for the inference:--was there not
+much for another?
+
+“Let us reflect now upon ‘the traces of a struggle;’ and let me ask what
+these traces have been supposed to demonstrate. A gang. But do they not
+rather demonstrate the absence of a gang? What struggle could have taken
+place--what struggle so violent and so enduring as to have left its
+‘traces’ in all directions--between a weak and defenceless girl and the
+gang of ruffians imagined? The silent grasp of a few rough arms and all
+would have been over. The victim must have been absolutely passive at
+their will. You will here bear in mind that the arguments urged against
+the thicket as the scene, are applicable in chief part, only against it
+as the scene of an outrage committed by more than a single individual.
+If we imagine but one violator, we can conceive, and thus only conceive,
+the struggle of so violent and so obstinate a nature as to have left the
+‘traces’ apparent.
+
+“And again. I have already mentioned the suspicion to be excited by the
+fact that the articles in question were suffered to remain at all in
+the thicket where discovered. It seems almost impossible that these
+evidences of guilt should have been accidentally left where found. There
+was sufficient presence of mind (it is supposed) to remove the corpse;
+and yet a more positive evidence than the corpse itself (whose features
+might have been quickly obliterated by decay,) is allowed to lie
+conspicuously in the scene of the outrage--I allude to the handkerchief
+with the name of the deceased. If this was accident, it was not
+the accident of a gang. We can imagine it only the accident of an
+individual. Let us see. An individual has committed the murder. He
+is alone with the ghost of the departed. He is appalled by what lies
+motionless before him. The fury of his passion is over, and there is
+abundant room in his heart for the natural awe of the deed. His is none
+of that confidence which the presence of numbers inevitably inspires.
+He is alone with the dead. He trembles and is bewildered. Yet there is
+a necessity for disposing of the corpse. He bears it to the river, but
+leaves behind him the other evidences of guilt; for it is difficult, if
+not impossible to carry all the burthen at once, and it will be easy to
+return for what is left. But in his toilsome journey to the water his
+fears redouble within him. The sounds of life encompass his path. A
+dozen times he hears or fancies the step of an observer. Even the very
+lights from the city bewilder him. Yet, in time and by long and frequent
+pauses of deep agony, he reaches the river’s brink, and disposes of
+his ghastly charge--perhaps through the medium of a boat. But now what
+treasure does the world hold--what threat of vengeance could it hold
+out--which would have power to urge the return of that lonely murderer
+over that toilsome and perilous path, to the thicket and its blood
+chilling recollections? He returns not, let the consequences be what
+they may. He could not return if he would. His sole thought is immediate
+escape. He turns his back forever upon those dreadful shrubberies and
+flees as from the wrath to come.
+
+“But how with a gang? Their number would have inspired them with
+confidence; if, indeed confidence is ever wanting in the breast of the
+arrant blackguard; and of arrant blackguards alone are the supposed
+gangs ever constituted. Their number, I say, would have prevented the
+bewildering and unreasoning terror which I have imagined to paralyze the
+single man. Could we suppose an oversight in one, or two, or three, this
+oversight would have been remedied by a fourth. They would have left
+nothing behind them; for their number would have enabled them to carry
+all at once. There would have been no need of return.
+
+“Consider now the circumstance that in the outer garment of the corpse
+when found, ‘a slip, about a foot wide had been torn upward from the
+bottom hem to the waist wound three times round the waist, and secured
+by a sort of hitch in the back.’ This was done with the obvious design
+of affording a handle by which to carry the body. But would any number
+of men have dreamed of resorting to such an expedient? To three or four,
+the limbs of the corpse would have afforded not only a sufficient, but
+the best possible hold. The device is that of a single individual; and
+this brings us to the fact that ‘between the thicket and the river, the
+rails of the fences were found taken down, and the ground bore evident
+traces of some heavy burden having been dragged along it!’ But would a
+number of men have put themselves to the superfluous trouble of taking
+down a fence, for the purpose of dragging through it a corpse which they
+might have lifted over any fence in an instant? Would a number of men
+have so dragged a corpse at all as to have left evident traces of the
+dragging?
+
+“And here we must refer to an observation of Le Commerciel; an
+observation upon which I have already, in some measure, commented. ‘A
+piece,’ says this journal, ‘of one of the unfortunate girl’s petticoats
+was torn out and tied under her chin, and around the back of her
+head, probably to prevent screams. This was done by fellows who had no
+pocket-handkerchiefs.’
+
+“I have before suggested that a genuine blackguard is never without a
+pocket-handkerchief. But it is not to this fact that I now especially
+advert. That it was not through want of a handkerchief for the purpose
+imagined by Le Commerciel, that this bandage was employed, is rendered
+apparent by the handkerchief left in the thicket; and that the object
+was not ‘to prevent screams’ appears, also, from the bandage having been
+employed in preference to what would so much better have answered
+the purpose. But the language of the evidence speaks of the strip in
+question as ‘found around the neck, fitting loosely, and secured with
+a hard knot.’ These words are sufficiently vague, but differ materially
+from those of Le Commerciel. The slip was eighteen inches wide, and
+therefore, although of muslin, would form a strong band when folded or
+rumpled longitudinally. And thus rumpled it was discovered. My inference
+is this. The solitary murderer, having borne the corpse, for some
+distance, (whether from the thicket or elsewhere) by means of the
+bandage hitched around its middle, found the weight, in this mode
+of procedure, too much for his strength. He resolved to drag the
+burthen--the evidence goes to show that it was dragged. With this object
+in view, it became necessary to attach something like a rope to one of
+the extremities. It could be best attached about the neck, where the
+head would prevent its slipping off. And, now, the murderer bethought
+him, unquestionably, of the bandage about the loins. He would have used
+this, but for its volution about the corpse, the hitch which embarrassed
+it, and the reflection that it had not been ‘torn off’ from the garment.
+It was easier to tear a new slip from the petticoat. He tore it, made
+it fast about the neck, and so dragged his victim to the brink of the
+river. That this ‘bandage,’ only attainable with trouble and delay, and
+but imperfectly answering its purpose--that this bandage was employed
+at all, demonstrates that the necessity for its employment sprang from
+circumstances arising at a period when the handkerchief was no longer
+attainable--that is to say, arising, as we have imagined, after quitting
+the thicket, (if the thicket it was), and on the road between the
+thicket and the river.
+
+“But the evidence, you will say, of Madame Deluc, (!) points especially
+to the presence of a gang, in the vicinity of the thicket, at or about
+the epoch of the murder. This I grant. I doubt if there were not a dozen
+gangs, such as described by Madame Deluc, in and about the vicinity of
+the Barrière du Roule at or about the period of this tragedy. But the
+gang which has drawn upon itself the pointed animadversion, although the
+somewhat tardy and very suspicious evidence of Madame Deluc, is the
+only gang which is represented by that honest and scrupulous old lady
+as having eaten her cakes and swallowed her brandy, without putting
+themselves to the trouble of making her payment. Et hinc illæ iræ?
+
+“But what is the precise evidence of Madame Deluc? ‘A gang of miscreants
+made their appearance, behaved boisterously, ate and drank without
+making payment, followed in the route of the young man and girl,
+returned to the inn about dusk, and recrossed the river as if in great
+haste.’
+
+“Now this ‘great haste’ very possibly seemed greater haste in the eyes
+of Madame Deluc, since she dwelt lingeringly and lamentingly upon her
+violated cakes and ale--cakes and ale for which she might still have
+entertained a faint hope of compensation. Why, otherwise, since it was
+about dusk, should she make a point of the haste? It is no cause for
+wonder, surely, that even a gang of blackguards should make haste to
+get home, when a wide river is to be crossed in small boats, when storm
+impends, and when night approaches.
+
+“I say approaches; for the night had not yet arrived. It was only about
+dusk that the indecent haste of these ‘miscreants’ offended the sober
+eyes of Madame Deluc. But we are told that it was upon this very evening
+that Madame Deluc, as well as her eldest son, ‘heard the screams of a
+female in the vicinity of the inn.’ And in what words does Madame Deluc
+designate the period of the evening at which these screams were heard?
+‘It was soon after dark,’ she says. But ‘soon after dark,’ is, at least,
+dark; and ‘about dusk’ is as certainly daylight. Thus it is abundantly
+clear that the gang quitted the Barrière du Roule prior to the screams
+overheard (?) by Madame Deluc. And although, in all the many reports of
+the evidence, the relative expressions in question are distinctly and
+invariably employed just as I have employed them in this conversation
+with yourself, no notice whatever of the gross discrepancy has, as yet,
+been taken by any of the public journals, or by any of the Myrmidons of
+police.
+
+“I shall add but one to the arguments against a gang; but this one has,
+to my own understanding at least, a weight altogether irresistible.
+Under the circumstances of large reward offered, and full pardon to
+any King’s evidence, it is not to be imagined, for a moment, that some
+member of a gang of low ruffians, or of any body of men, would not long
+ago have betrayed his accomplices. Each one of a gang so placed, is not
+so much greedy of reward, or anxious for escape, as fearful of betrayal.
+He betrays eagerly and early that he may not himself be betrayed. That
+the secret has not been divulged, is the very best of proof that it is,
+in fact, a secret. The horrors of this dark deed are known only to one,
+or two, living human beings, and to God.
+
+“Let us sum up now the meagre yet certain fruits of our long analysis.
+We have attained the idea either of a fatal accident under the roof of
+Madame Deluc, or of a murder perpetrated, in the thicket at the Barrière
+du Roule, by a lover, or at least by an intimate and secret associate of
+the deceased. This associate is of swarthy complexion. This complexion,
+the ‘hitch’ in the bandage, and the ‘sailor’s knot,’ with which the
+bonnet-ribbon is tied, point to a seaman. His companionship with the
+deceased, a gay, but not an abject young girl, designates him as
+above the grade of the common sailor. Here the well written and urgent
+communications to the journals are much in the way of corroboration. The
+circumstance of the first elopement, as mentioned by Le Mercurie, tends
+to blend the idea of this seaman with that of the ‘naval officer’ who is
+first known to have led the unfortunate into crime.
+
+“And here, most fitly, comes the consideration of the continued
+absence of him of the dark complexion. Let me pause to observe that the
+complexion of this man is dark and swarthy; it was no common swarthiness
+which constituted the sole point of remembrance, both as regards Valence
+and Madame Deluc. But why is this man absent? Was he murdered by the
+gang? If so, why are there only traces of the assassinated girl? The
+scene of the two outrages will naturally be supposed identical. And
+where is his corpse? The assassins would most probably have disposed
+of both in the same way. But it may be said that this man lives, and is
+deterred from making himself known, through dread of being charged with
+the murder. This consideration might be supposed to operate upon him
+now--at this late period--since it has been given in evidence that he
+was seen with Marie--but it would have had no force at the period of the
+deed. The first impulse of an innocent man would have been to announce
+the outrage, and to aid in identifying the ruffians. This policy would
+have suggested. He had been seen with the girl. He had crossed the river
+with her in an open ferry-boat. The denouncing of the assassins would
+have appeared, even to an idiot, the surest and sole means of relieving
+himself from suspicion. We cannot suppose him, on the night of the fatal
+Sunday, both innocent himself and incognizant of an outrage committed.
+Yet only under such circumstances is it possible to imagine that he
+would have failed, if alive, in the denouncement of the assassins.
+
+“And what means are ours, of attaining the truth? We shall find these
+means multiplying and gathering distinctness as we proceed. Let us sift
+to the bottom this affair of the first elopement. Let us know the
+full history of ‘the officer,’ with his present circumstances, and
+his whereabouts at the precise period of the murder. Let us carefully
+compare with each other the various communications sent to the evening
+paper, in which the object was to inculpate a gang. This done, let us
+compare these communications, both as regards style and MS., with
+those sent to the morning paper, at a previous period, and insisting so
+vehemently upon the guilt of Mennais. And, all this done, let us again
+compare these various communications with the known MSS. of the officer.
+Let us endeavor to ascertain, by repeated questionings of Madame Deluc
+and her boys, as well as of the omnibus driver, Valence, something more
+of the personal appearance and bearing of the ‘man of dark complexion.’
+Queries, skilfully directed, will not fail to elicit, from some of
+these parties, information on this particular point (or upon
+others)--information which the parties themselves may not even be aware
+of possessing. And let us now trace the boat picked up by the bargeman
+on the morning of Monday the twenty-third of June, and which was
+removed from the barge-office, without the cognizance of the officer
+in attendance, and without the rudder, at some period prior to the
+discovery of the corpse. With a proper caution and perseverance we shall
+infallibly trace this boat; for not only can the bargeman who picked
+it up identify it, but the rudder is at hand. The rudder of a sail-boat
+would not have been abandoned, without inquiry, by one altogether at
+ease in heart. And here let me pause to insinuate a question. There was
+no advertisement of the picking up of this boat. It was silently
+taken to the barge-office, and as silently removed. But its owner or
+employer--how happened he, at so early a period as Tuesday morning, to
+be informed, without the agency of advertisement, of the locality of
+the boat taken up on Monday, unless we imagine some connexion with the
+navy--some personal permanent connexion leading to cognizance of its
+minute in interests--its petty local news?
+
+“In speaking of the lonely assassin dragging his burden to the shore,
+I have already suggested the probability of his availing himself of a
+boat. Now we are to understand that Marie Rogêt was precipitated from a
+boat. This would naturally have been the case. The corpse could not have
+been trusted to the shallow waters of the shore. The peculiar marks on
+the back and shoulders of the victim tell of the bottom ribs of a boat.
+That the body was found without weight is also corroborative of the
+idea. If thrown from the shore a weight would have been attached. We can
+only account for its absence by supposing the murderer to have neglected
+the precaution of supplying himself with it before pushing off. In the
+act of consigning the corpse to the water, he would unquestionably have
+noticed his oversight; but then no remedy would have been at hand.
+Any risk would have been preferred to a return to that accursed shore.
+Having rid himself of his ghastly charge, the murderer would have
+hastened to the city. There, at some obscure wharf, he would have leaped
+on land. But the boat--would he have secured it? He would have been
+in too great haste for such things as securing a boat. Moreover, in
+fastening it to the wharf, he would have felt as if securing evidence
+against himself. His natural thought would have been to cast from him,
+as far as possible, all that had held connection with his crime. He
+would not only have fled from the wharf, but he would not have permitted
+the boat to remain. Assuredly he would have cast it adrift. Let us
+pursue our fancies.--In the morning, the wretch is stricken with
+unutterable horror at finding that the boat has been picked up and
+detained at a locality which he is in the daily habit of frequenting
+--at a locality, perhaps, which his duty compels him to frequent. The
+next night, without daring to ask for the rudder, he removes it. Now
+where is that rudderless boat? Let it be one of our first purposes
+to discover. With the first glimpse we obtain of it, the dawn of our
+success shall begin. This boat shall guide us, with a rapidity which
+will surprise even ourselves, to him who employed it in the midnight of
+the fatal Sabbath. Corroboration will rise upon corroboration, and the
+murderer will be traced.”
+
+[For reasons which we shall not specify, but which to many readers will
+appear obvious, we have taken the liberty of here omitting, from the
+MSS. placed in our hands, such portion as details the following up of
+the apparently slight clew obtained by Dupin. We feel it advisable only
+to state, in brief, that the result desired was brought to pass; and
+that the Prefect fulfilled punctually, although with reluctance, the
+terms of his compact with the Chevalier. Mr. Poe’s article concludes
+with the following words.--Eds. (*23)]
+
+It will be understood that I speak of coincidences and no more. What
+I have said above upon this topic must suffice. In my own heart there
+dwells no faith in præter-nature. That Nature and its God are two, no
+man who thinks, will deny. That the latter, creating the former, can, at
+will, control or modify it, is also unquestionable. I say “at will;” for
+the question is of will, and not, as the insanity of logic has assumed,
+of power. It is not that the Deity cannot modify his laws, but that we
+insult him in imagining a possible necessity for modification. In their
+origin these laws were fashioned to embrace all contingencies which
+could lie in the Future. With God all is Now.
+
+I repeat, then, that I speak of these things only as of coincidences.
+And farther: in what I relate it will be seen that between the fate of
+the unhappy Mary Cecilia Rogers, so far as that fate is known, and the
+fate of one Marie Rogêt up to a certain epoch in her history, there has
+existed a parallel in the contemplation of whose wonderful exactitude
+the reason becomes embarrassed. I say all this will be seen. But let it
+not for a moment be supposed that, in proceeding with the sad narrative
+of Marie from the epoch just mentioned, and in tracing to its dénouement
+the mystery which enshrouded her, it is my covert design to hint at an
+extension of the parallel, or even to suggest that the measures adopted
+in Paris for the discovery of the assassin of a grisette, or measures
+founded in any similar ratiocination, would produce any similar result.
+
+For, in respect to the latter branch of the supposition, it should be
+considered that the most trifling variation in the facts of the
+two cases might give rise to the most important miscalculations,
+by diverting thoroughly the two courses of events; very much as,
+in arithmetic, an error which, in its own individuality, may be
+inappreciable, produces, at length, by dint of multiplication at all
+points of the process, a result enormously at variance with truth. And,
+in regard to the former branch, we must not fail to hold in view that
+the very Calculus of Probabilities to which I have referred, forbids all
+idea of the extension of the parallel:--forbids it with a positiveness
+strong and decided just in proportion as this parallel has already been
+long-drawn and exact. This is one of those anomalous propositions which,
+seemingly appealing to thought altogether apart from the mathematical,
+is yet one which only the mathematician can fully entertain. Nothing,
+for example, is more difficult than to convince the merely general
+reader that the fact of sixes having been thrown twice in succession by
+a player at dice, is sufficient cause for betting the largest odds that
+sixes will not be thrown in the third attempt. A suggestion to this
+effect is usually rejected by the intellect at once. It does not
+appear that the two throws which have been completed, and which lie now
+absolutely in the Past, can have influence upon the throw which exists
+only in the Future. The chance for throwing sixes seems to be precisely
+as it was at any ordinary time--that is to say, subject only to the
+influence of the various other throws which may be made by the dice. And
+this is a reflection which appears so exceedingly obvious that attempts
+to controvert it are received more frequently with a derisive smile
+than with anything like respectful attention. The error here involved--a
+gross error redolent of mischief--I cannot pretend to expose within the
+limits assigned me at present; and with the philosophical it needs
+no exposure. It may be sufficient here to say that it forms one of an
+infinite series of mistakes which arise in the path of Reason through
+her propensity for seeking truth in detail.
+
+Footnotes--Marie Rogêt
+
+(*1) Upon the original publication of “Marie Roget,” the foot-notes now
+appended were considered unnecessary; but the lapse of several years
+since the tragedy upon which the tale is based, renders it expedient
+to give them, and also to say a few words in explanation of the general
+design. A young girl, Mary Cecilia Rogers, was murdered in the
+vicinity of New York; and, although her death occasioned an intense and
+long-enduring excitement, the mystery attending it had remained
+unsolved at the period when the present paper was written and published
+(November, 1842). Herein, under pretence of relating the fate of
+a Parisian grisette, the author has followed in minute detail, the
+essential, while merely paralleling the inessential facts of the real
+murder of Mary Rogers. Thus all argument founded upon the fiction is
+applicable to the truth: and the investigation of the truth was the
+object. The “Mystery of Marie Roget” was composed at a distance from the
+scene of the atrocity, and with no other means of investigation than the
+newspapers afforded. Thus much escaped the writer of which he could have
+availed himself had he been upon the spot, and visited the localities.
+It may not be improper to record, nevertheless, that the confessions of
+two persons, (one of them the Madame Deluc of the narrative) made, at
+different periods, long subsequent to the publication, confirmed, in
+full, not only the general conclusion, but absolutely all the chief
+hypothetical details by which that conclusion was attained.
+
+(*2) The nom de plume of Von Hardenburg.
+
+(*3) Nassau Street.
+
+(*4) Anderson.
+
+(*5) The Hudson.
+
+(*6) Weehawken.
+
+(*7) Payne.
+
+(*8) Crommelin.
+
+(*9) The New York “Mercury.”
+
+(*10) The New York “Brother Jonathan,” edited by H. Hastings Weld, Esq.
+
+(*11) New York “Journal of Commerce.”
+
+(*12) Philadelphia “Saturday Evening Post,” edited by C. I. Peterson,
+Esq.
+
+(*13) Adam
+
+(*14) See “Murders in the Rue Morgue.”
+
+(*15) The New York “Commercial Advertiser,” edited by Col. Stone.
+
+(*16) “A theory based on the qualities of an object, will prevent its
+being unfolded according to its objects; and he who arranges topics in
+reference to their causes, will cease to value them according to their
+results. Thus the jurisprudence of every nation will show that, when law
+becomes a science and a system, it ceases to be justice. The errors
+into which a blind devotion to principles of classification has led the
+common law, will be seen by observing how often the legislature has
+been obliged to come forward to restore the equity its scheme had
+lost.”--Landor.
+
+(*17) New York “Express”
+
+(*18) New York “Herald.”
+
+(*19) New York “Courier and Inquirer.”
+
+(*20) Mennais was one of the parties originally suspected and arrested,
+but discharged through total lack of evidence.
+
+(*21) New York “Courier and Inquirer.”
+
+(*22) New York “Evening Post.”
+
+(*23) Of the Magazine in which the article was originally published.
+
+
+
+
+THE BALLOON-HOAX
+
+ [Astounding News by Express, _via_ Norfolk!--The Atlantic
+ crossed in Three Days!  Signal Triumph of Mr. Monck Mason’s Flying
+ Machine!--Arrival at Sullivan’s Island, near Charlestown, S.C., of
+ Mr. Mason, Mr. Robert Holland, Mr. Henson, Mr. Harrison Ainsworth,
+ and four others, in the Steering Balloon, “Victoria,” after a passage
+ of Seventy-five Hours from Land to Land!  Full Particulars of the
+ Voyage!
+
+ The subjoined _jeu d’esprit_ with the preceding heading in
+ magnificent capitals, well interspersed with notes of admiration, was
+ originally published, as matter of fact, in the “New York Sun,” a
+ daily newspaper, and therein fully subserved the purpose of creating
+ indigestible aliment for the _quidnuncs_ during the few hours
+ intervening between a couple of the Charleston mails.  The rush for
+ the “sole paper which had the news,” was something beyond even the
+ prodigious;  and, in fact, if (as some assert) the “Victoria” _did_
+ not absolutely accomplish the voyage recorded, it will be difficult
+ to assign a reason why she _should_ not have accomplished it.]
+
+THE great problem is at length solved! The air, as well as the earth
+and the ocean, has been subdued by science, and will become a common and
+convenient highway for mankind. _The Atlantic has been actually crossed
+in a Balloon!_ and this too without difficulty--without any great
+apparent danger--with thorough control of the machine--and in the
+inconceivably brief period of seventy-five hours from shore to shore!
+By the energy of an agent at Charleston, S.C., we are enabled to be
+the first to furnish the public with a detailed account of this most
+extraordinary voyage, which was performed between Saturday, the 6th
+instant, at 11, A.M., and 2, P.M., on Tuesday, the 9th instant, by Sir
+Everard Bringhurst; Mr. Osborne, a nephew of Lord Bentinck’s; Mr. Monck
+Mason and Mr. Robert Holland, the well-known æronauts; Mr. Harrison
+Ainsworth, author of “Jack Sheppard,” &c.; and Mr. Henson, the
+projector of the late unsuccessful flying machine--with two seamen from
+Woolwich--in all, eight persons. The particulars furnished below may be
+relied on as authentic and accurate in every respect, as, with a slight
+exception, they are copied _verbatim_ from the joint diaries of Mr.
+Monck Mason and Mr. Harrison Ainsworth, to whose politeness our agent is
+also indebted for much verbal information respecting the balloon itself,
+its construction, and other matters of interest. The only alteration in
+the MS. received, has been made for the purpose of throwing the hurried
+account of our agent, Mr. Forsyth, into a connected and intelligible
+form.
+
+“THE BALLOON.
+
+“Two very decided failures, of late--those of Mr. Henson and Sir George
+Cayley--had much weakened the public interest in the subject of aerial
+navigation. Mr. Henson’s scheme (which at first was considered very
+feasible even by men of science,) was founded upon the principle of an
+inclined plane, started from an eminence by an extrinsic force, applied
+and continued by the revolution of impinging vanes, in form and number
+resembling the vanes of a windmill. But, in all the experiments made
+with models at the Adelaide Gallery, it was found that the operation of
+these fans not only did not propel the machine, but actually impeded
+its flight. The only propelling force it ever exhibited, was the mere
+_impetus_ acquired from the descent of the inclined plane; and this
+_impetus_ carried the machine farther when the vanes were at rest, than
+when they were in motion--a fact which sufficiently demonstrates their
+inutility; and in the absence of the propelling, which was also the
+_sustaining_ power, the whole fabric would necessarily descend.
+This consideration led Sir George Cayley to think only of adapting
+a propeller to some machine having of itself an independent power of
+support--in a word, to a balloon; the idea, however, being novel,
+or original, with Sir George, only so far as regards the mode of its
+application to practice. He exhibited a model of his invention at the
+Polytechnic Institution. The propelling principle, or power, was here,
+also, applied to interrupted surfaces, or vanes, put in revolution.
+These vanes were four in number, but were found entirely ineffectual in
+moving the balloon, or in aiding its ascending power. The whole project
+was thus a complete failure.
+
+“It was at this juncture that Mr. Monck Mason (whose voyage from Dover
+to Weilburg in the balloon, “Nassau,” occasioned so much excitement in
+1837,) conceived the idea of employing the principle of the Archimedean
+screw for the purpose of propulsion through the air--rightly
+attributing the failure of Mr. Henson’s scheme, and of Sir George
+Cayley’s, to the interruption of surface in the independent vanes.
+He made the first public experiment at Willis’s Rooms, but afterward
+removed his model to the Adelaide Gallery.
+
+“Like Sir George Cayley’s balloon, his own was an ellipsoid. Its
+length was thirteen feet six inches--height, six feet eight inches. It
+contained about three hundred and twenty cubic feet of gas, which, if
+pure hydrogen, would support twenty-one pounds upon its first inflation,
+before the gas has time to deteriorate or escape. The weight of the
+whole machine and apparatus was seventeen pounds--leaving about four
+pounds to spare. Beneath the centre of the balloon, was a frame of light
+wood, about nine feet long, and rigged on to the balloon itself with
+a network in the customary manner. From this framework was suspended a
+wicker basket or car.
+
+“The screw consists of an axis of hollow brass tube, eighteen inches in
+length, through which, upon a semi-spiral inclined at fifteen degrees,
+pass a series of steel wire radii, two feet long, and thus projecting a
+foot on either side. These radii are connected at the outer extremities
+by two bands of flattened wire--the whole in this manner forming the
+framework of the screw, which is completed by a covering of oiled silk
+cut into gores, and tightened so as to present a tolerably uniform
+surface. At each end of its axis this screw is supported by pillars of
+hollow brass tube descending from the hoop. In the lower ends of these
+tubes are holes in which the pivots of the axis revolve. From the end
+of the axis which is next the car, proceeds a shaft of steel, connecting
+the screw with the pinion of a piece of spring machinery fixed in the
+car. By the operation of this spring, the screw is made to revolve with
+great rapidity, communicating a progressive motion to the whole. By
+means of the rudder, the machine was readily turned in any direction.
+The spring was of great power, compared with its dimensions, being
+capable of raising forty-five pounds upon a barrel of four inches
+diameter, after the first turn, and gradually increasing as it was wound
+up. It weighed, altogether, eight pounds six ounces. The rudder was
+a light frame of cane covered with silk, shaped somewhat like a
+battle-door, and was about three feet long, and at the widest, one foot.
+Its weight was about two ounces. It could be turned _flat_, and directed
+upwards or downwards, as well as to the right or left; and thus enabled
+the æronaut to transfer the resistance of the air which in an inclined
+position it must generate in its passage, to any side upon which he
+might desire to act; thus determining the balloon in the opposite
+direction.
+
+“This model (which, through want of time, we have necessarily described
+in an imperfect manner,) was put in action at the Adelaide Gallery,
+where it accomplished a velocity of five miles per hour; although,
+strange to say, it excited very little interest in comparison with the
+previous complex machine of Mr. Henson--so resolute is the world
+to despise anything which carries with it an air of simplicity. To
+accomplish the great desideratum of ærial navigation, it was very
+generally supposed that some exceedingly complicated application must be
+made of some unusually profound principle in dynamics.
+
+“So well satisfied, however, was Mr. Mason of the ultimate success of
+his invention, that he determined to construct immediately, if possible,
+a balloon of sufficient capacity to test the question by a voyage of
+some extent--the original design being to cross the British Channel, as
+before, in the Nassau balloon. To carry out his views, he solicited and
+obtained the patronage of Sir Everard Bringhurst and Mr. Osborne, two
+gentlemen well known for scientific acquirement, and especially for the
+interest they have exhibited in the progress of ærostation. The project,
+at the desire of Mr. Osborne, was kept a profound secret from the
+public--the only persons entrusted with the design being those actually
+engaged in the construction of the machine, which was built (under the
+superintendence of Mr. Mason, Mr. Holland, Sir Everard Bringhurst, and
+Mr. Osborne,) at the seat of the latter gentleman near Penstruthal, in
+Wales. Mr. Henson, accompanied by his friend Mr. Ainsworth, was admitted
+to a private view of the balloon, on Saturday last--when the two
+gentlemen made final arrangements to be included in the adventure. We
+are not informed for what reason the two seamen were also included in
+the party--but, in the course of a day or two, we shall put our readers
+in possession of the minutest particulars respecting this extraordinary
+voyage.
+
+“The balloon is composed of silk, varnished with the liquid gum
+caoutchouc. It is of vast dimensions, containing more than 40,000 cubic
+feet of gas; but as coal gas was employed in place of the more expensive
+and inconvenient hydrogen, the supporting power of the machine, when
+fully inflated, and immediately after inflation, is not more than about
+2500 pounds. The coal gas is not only much less costly, but is easily
+procured and managed.
+
+“For its introduction into common use for purposes of aerostation, we
+are indebted to Mr. Charles Green. Up to his discovery, the process of
+inflation was not only exceedingly expensive, but uncertain. Two, and
+even three days, have frequently been wasted in futile attempts to
+procure a sufficiency of hydrogen to fill a balloon, from which it
+had great tendency to escape, owing to its extreme subtlety, and its
+affinity for the surrounding atmosphere. In a balloon sufficiently
+perfect to retain its contents of coal-gas unaltered, in quantity or
+amount, for six months, an equal quantity of hydrogen could not be
+maintained in equal purity for six weeks.
+
+“The supporting power being estimated at 2500 pounds, and the united
+weights of the party amounting only to about 1200, there was left a
+surplus of 1300, of which again 1200 was exhausted by ballast, arranged
+in bags of different sizes, with their respective weights marked upon
+them--by cordage, barometers, telescopes, barrels containing provision
+for a fortnight, water-casks, cloaks, carpet-bags, and various other
+indispensable matters, including a coffee-warmer, contrived for warming
+coffee by means of slack-lime, so as to dispense altogether with fire,
+if it should be judged prudent to do so. All these articles, with the
+exception of the ballast, and a few trifles, were suspended from the
+hoop overhead. The car is much smaller and lighter, in proportion, than
+the one appended to the model. It is formed of a light wicker, and is
+wonderfully strong, for so frail looking a machine. Its rim is about
+four feet deep. The rudder is also very much larger, in proportion, than
+that of the model; and the screw is considerably smaller. The balloon is
+furnished besides with a grapnel, and a guide-rope; which latter is of
+the most indispensable importance. A few words, in explanation, will
+here be necessary for such of our readers as are not conversant with the
+details of aerostation.
+
+“As soon as the balloon quits the earth, it is subjected to the
+influence of many circumstances tending to create a difference in its
+weight; augmenting or diminishing its ascending power. For example,
+there may be a deposition of dew upon the silk, to the extent, even,
+of several hundred pounds; ballast has then to be thrown out, or the
+machine may descend. This ballast being discarded, and a clear sunshine
+evaporating the dew, and at the same time expanding the gas in the silk,
+the whole will again rapidly ascend. To check this ascent, the only
+recourse is, (or rather _was_, until Mr. Green’s invention of the
+guide-rope,) the permission of the escape of gas from the valve; but, in
+the loss of gas, is a proportionate general loss of ascending power; so
+that, in a comparatively brief period, the best-constructed balloon must
+necessarily exhaust all its resources, and come to the earth. This was
+the great obstacle to voyages of length.
+
+“The guide-rope remedies the difficulty in the simplest manner
+conceivable. It is merely a very long rope which is suffered to trail
+from the car, and the effect of which is to prevent the balloon from
+changing its level in any material degree. If, for example, there should
+be a deposition of moisture upon the silk, and the machine begins to
+descend in consequence, there will be no necessity for discharging
+ballast to remedy the increase of weight, for it is remedied, or
+counteracted, in an exactly just proportion, by the deposit on the
+ground of just so much of the end of the rope as is necessary. If,
+on the other hand, any circumstances should cause undue levity, and
+consequent ascent, this levity is immediately counteracted by the
+additional weight of rope upraised from the earth. Thus, the balloon
+can neither ascend or descend, except within very narrow limits, and its
+resources, either in gas or ballast, remain comparatively unimpaired.
+When passing over an expanse of water, it becomes necessary to employ
+small kegs of copper or wood, filled with liquid ballast of a lighter
+nature than water. These float, and serve all the purposes of a mere
+rope on land. Another most important office of the guide-rope, is to
+point out the _direction_ of the balloon. The rope _drags_, either on
+land or sea, while the balloon is free; the latter, consequently, is
+always in advance, when any progress whatever is made: a comparison,
+therefore, by means of the compass, of the relative positions of the two
+objects, will always indicate the _course_. In the same way, the angle
+formed by the rope with the vertical axis of the machine, indicates
+the _velocity_. When there is _no_ angle--in other words, when the rope
+hangs perpendicularly, the whole apparatus is stationary; but the larger
+the angle, that is to say, the farther the balloon precedes the end of
+the rope, the greater the velocity; and the converse.
+
+“As the original design was to cross the British Channel, and alight as
+near Paris as possible, the voyagers had taken the precaution to prepare
+themselves with passports directed to all parts of the Continent,
+specifying the nature of the expedition, as in the case of the Nassau
+voyage, and entitling the adventurers to exemption from the usual
+formalities of office: unexpected events, however, rendered these
+passports superfluous.
+
+“The inflation was commenced very quietly at daybreak, on Saturday
+morning, the 6th instant, in the Court-Yard of Weal-Vor House, Mr.
+Osborne’s seat, about a mile from Penstruthal, in North Wales; and at 7
+minutes past 11, every thing being ready for departure, the balloon was
+set free, rising gently but steadily, in a direction nearly South; no
+use being made, for the first half hour, of either the screw or the
+rudder. We proceed now with the journal, as transcribed by Mr. Forsyth
+from the joint MSS. Of Mr. Monck Mason, and Mr. Ainsworth. The body of
+the journal, as given, is in the hand-writing of Mr. Mason, and a P.
+S. is appended, each day, by Mr. Ainsworth, who has in preparation, and
+will shortly give the public a more minute, and no doubt, a thrillingly
+interesting account of the voyage.
+
+“THE JOURNAL.
+
+“_Saturday, April the 6th_.--Every preparation likely to embarrass us,
+having been made over night, we commenced the inflation this morning at
+daybreak; but owing to a thick fog, which encumbered the folds of the
+silk and rendered it unmanageable, we did not get through before nearly
+eleven o’clock. Cut loose, then, in high spirits, and rose gently but
+steadily, with a light breeze at North, which bore us in the direction
+of the British Channel. Found the ascending force greater than we had
+expected; and as we arose higher and so got clear of the cliffs, and
+more in the sun’s rays, our ascent became very rapid. I did not wish,
+however, to lose gas at so early a period of the adventure, and so
+concluded to ascend for the present. We soon ran out our guide-rope;
+but even when we had raised it clear of the earth, we still went up very
+rapidly. The balloon was unusually steady, and looked beautifully. In
+about ten minutes after starting, the barometer indicated an altitude
+of 15,000 feet. The weather was remarkably fine, and the view of the
+subjacent country--a most romantic one when seen from any point,--was
+now especially sublime. The numerous deep gorges presented the
+appearance of lakes, on account of the dense vapors with which they
+were filled, and the pinnacles and crags to the South East, piled in
+inextricable confusion, resembling nothing so much as the giant cities
+of eastern fable. We were rapidly approaching the mountains in the
+South; but our elevation was more than sufficient to enable us to pass
+them in safety. In a few minutes we soared over them in fine style; and
+Mr. Ainsworth, with the seamen, was surprised at their apparent want of
+altitude when viewed from the car, the tendency of great elevation in a
+balloon being to reduce inequalities of the surface below, to nearly
+a dead level. At half-past eleven still proceeding nearly South, we
+obtained our first view of the Bristol Channel; and, in fifteen minutes
+afterward, the line of breakers on the coast appeared immediately
+beneath us, and we were fairly out at sea. We now resolved to let off
+enough gas to bring our guide-rope, with the buoys affixed, into the
+water. This was immediately done, and we commenced a gradual descent.
+In about twenty minutes our first buoy dipped, and at the touch of the
+second soon afterwards, we remained stationary as to elevation. We were
+all now anxious to test the efficiency of the rudder and screw, and we
+put them both into requisition forthwith, for the purpose of altering
+our direction more to the eastward, and in a line for Paris. By means of
+the rudder we instantly effected the necessary change of direction, and
+our course was brought nearly at right angles to that of the wind; when
+we set in motion the spring of the screw, and were rejoiced to find it
+propel us readily as desired. Upon this we gave nine hearty cheers, and
+dropped in the sea a bottle, enclosing a slip of parchment with a brief
+account of the principle of the invention. Hardly, however, had we
+done with our rejoicings, when an unforeseen accident occurred which
+discouraged us in no little degree. The steel rod connecting the spring
+with the propeller was suddenly jerked out of place, at the car end, (by
+a swaying of the car through some movement of one of the two seamen we
+had taken up,) and in an instant hung dangling out of reach, from the
+pivot of the axis of the screw. While we were endeavoring to regain it,
+our attention being completely absorbed, we became involved in a strong
+current of wind from the East, which bore us, with rapidly increasing
+force, towards the Atlantic. We soon found ourselves driving out to sea
+at the rate of not less, certainly, than fifty or sixty miles an hour,
+so that we came up with Cape Clear, at some forty miles to our North,
+before we had secured the rod, and had time to think what we were about.
+It was now that Mr. Ainsworth made an extraordinary, but to my fancy,
+a by no means unreasonable or chimerical proposition, in which he was
+instantly seconded by Mr. Holland--viz.: that we should take advantage
+of the strong gale which bore us on, and in place of beating back to
+Paris, make an attempt to reach the coast of North America. After slight
+reflection I gave a willing assent to this bold proposition, which
+(strange to say) met with objection from the two seamen only. As the
+stronger party, however, we overruled their fears, and kept resolutely
+upon our course. We steered due West; but as the trailing of the buoys
+materially impeded our progress, and we had the balloon abundantly at
+command, either for ascent or descent, we first threw out fifty pounds
+of ballast, and then wound up (by means of a windlass) so much of the
+rope as brought it quite clear of the sea. We perceived the effect of
+this manoeuvre immediately, in a vastly increased rate of progress; and,
+as the gale freshened, we flew with a velocity nearly inconceivable; the
+guide-rope flying out behind the car, like a streamer from a vessel. It
+is needless to say that a very short time sufficed us to lose sight of
+the coast. We passed over innumerable vessels of all kinds, a few of
+which were endeavoring to beat up, but the most of them lying to. We
+occasioned the greatest excitement on board all--an excitement greatly
+relished by ourselves, and especially by our two men, who, now under the
+influence of a dram of Geneva, seemed resolved to give all scruple, or
+fear, to the wind. Many of the vessels fired signal guns; and in all
+we were saluted with loud cheers (which we heard with surprising
+distinctness) and the waving of caps and handkerchiefs. We kept on in
+this manner throughout the day, with no material incident, and, as
+the shades of night closed around us, we made a rough estimate of the
+distance traversed. It could not have been less than five hundred
+miles, and was probably much more. The propeller was kept in constant
+operation, and, no doubt, aided our progress materially. As the sun
+went down, the gale freshened into an absolute hurricane, and the ocean
+beneath was clearly visible on account of its phosphorescence. The wind
+was from the East all night, and gave us the brightest omen of success.
+We suffered no little from cold, and the dampness of the atmosphere was
+most unpleasant; but the ample space in the car enabled us to lie down,
+and by means of cloaks and a few blankets, we did sufficiently well.
+
+“P.S. (by Mr. Ainsworth.) The last nine hours have been unquestionably
+the most exciting of my life. I can conceive nothing more sublimating
+than the strange peril and novelty of an adventure such as this. May
+God grant that we succeed! I ask not success for mere safety to my
+insignificant person, but for the sake of human knowledge and--for the
+vastness of the triumph. And yet the feat is only so evidently feasible
+that the sole wonder is why men have scrupled to attempt it before. One
+single gale such as now befriends us--let such a tempest whirl forward
+a balloon for four or five days (these gales often last longer) and the
+voyager will be easily borne, in that period, from coast to coast. In
+view of such a gale the broad Atlantic becomes a mere lake. I am more
+struck, just now, with the supreme silence which reigns in the
+sea beneath us, notwithstanding its agitation, than with any other
+phenomenon presenting itself. The waters give up no voice to
+the heavens. The immense flaming ocean writhes and is tortured
+uncomplainingly. The mountainous surges suggest the idea of innumerable
+dumb gigantic fiends struggling in impotent agony. In a night such as is
+this to me, a man _lives_--lives a whole century of ordinary life--nor
+would I forego this rapturous delight for that of a whole century of
+ordinary existence.
+
+“_Sunday, the seventh_. [Mr. Mason’s MS.] This morning the gale, by 10,
+had subsided to an eight or nine--knot breeze, (for a vessel at sea,)
+and bears us, perhaps, thirty miles per hour, or more. It has veered,
+however, very considerably to the north; and now, at sundown, we are
+holding our course due west, principally by the screw and rudder, which
+answer their purposes to admiration. I regard the project as thoroughly
+successful, and the easy navigation of the air in any direction (not
+exactly in the teeth of a gale) as no longer problematical. We could not
+have made head against the strong wind of yesterday; but, by ascending,
+we might have got out of its influence, if requisite. Against a pretty
+stiff breeze, I feel convinced, we can make our way with the propeller.
+At noon, to-day, ascended to an elevation of nearly 25,000 feet, by
+discharging ballast. Did this to search for a more direct current, but
+found none so favorable as the one we are now in. We have an abundance
+of gas to take us across this small pond, even should the voyage
+last three weeks. I have not the slightest fear for the result. The
+difficulty has been strangely exaggerated and misapprehended. I can
+choose my current, and should I find _all_ currents against me, I can
+make very tolerable headway with the propeller. We have had no incidents
+worth recording. The night promises fair.
+
+P.S. [By Mr. Ainsworth.] I have little to record, except the fact (to me
+quite a surprising one) that, at an elevation equal to that of Cotopaxi,
+I experienced neither very intense cold, nor headache, nor difficulty
+of breathing; neither, I find, did Mr. Mason, nor Mr. Holland, nor Sir
+Everard. Mr. Osborne complained of constriction of the chest--but this
+soon wore off. We have flown at a great rate during the day, and we
+must be more than half way across the Atlantic. We have passed over
+some twenty or thirty vessels of various kinds, and all seem to be
+delightfully astonished. Crossing the ocean in a balloon is not so
+difficult a feat after all. _Omne ignotum pro magnifico. Mem:_ at
+25,000 feet elevation the sky appears nearly black, and the stars are
+distinctly visible; while the sea does not seem convex (as one might
+suppose) but absolutely and most unequivocally _concave_.(*1)
+
+“_Monday, the 8th_. [Mr. Mason’s MS.] This morning we had again some
+little trouble with the rod of the propeller, which must be entirely
+remodelled, for fear of serious accident--I mean the steel rod--not
+the vanes. The latter could not be improved. The wind has been blowing
+steadily and strongly from the north-east all day and so far fortune
+seems bent upon favoring us. Just before day, we were all somewhat
+alarmed at some odd noises and concussions in the balloon, accompanied
+with the apparent rapid subsidence of the whole machine. These phenomena
+were occasioned by the expansion of the gas, through increase of heat in
+the atmosphere, and the consequent disruption of the minute particles of
+ice with which the network had become encrusted during the night. Threw
+down several bottles to the vessels below. Saw one of them picked up by
+a large ship--seemingly one of the New York line packets. Endeavored to
+make out her name, but could not be sure of it. Mr. Osborne’s telescope
+made it out something like “Atalanta.” It is now 12, at night, and we
+are still going nearly west, at a rapid pace. The sea is peculiarly
+phosphorescent.
+
+“P.S. [By Mr. Ainsworth.] It is now 2, A.M., and nearly calm, as well as
+I can judge--but it is very difficult to determine this point, since
+we move _with_ the air so completely. I have not slept since quitting
+Wheal-Vor, but can stand it no longer, and must take a nap. We cannot be
+far from the American coast.
+
+“_Tuesday, the _9_th_. [Mr. Ainsworth’s MS.] _One, P.M. We are in
+full view of the low coast of South Carolina_. The great problem is
+accomplished. We have crossed the Atlantic--fairly and _easily_
+crossed it in a balloon! God be praised! Who shall say that anything is
+impossible hereafter?”
+
+The Journal here ceases. Some particulars of the descent were
+communicated, however, by Mr. Ainsworth to Mr. Forsyth. It was nearly
+dead calm when the voyagers first came in view of the coast, which
+was immediately recognized by both the seamen, and by Mr. Osborne.
+The latter gentleman having acquaintances at Fort Moultrie, it was
+immediately resolved to descend in its vicinity. The balloon was brought
+over the beach (the tide being out and the sand hard, smooth, and
+admirably adapted for a descent,) and the grapnel let go, which took
+firm hold at once. The inhabitants of the island, and of the fort,
+thronged out, of course, to see the balloon; but it was with the
+greatest difficulty that any one could be made to credit the actual
+voyage--_the crossing of the Atlantic_. The grapnel caught at 2, P.M.,
+precisely; and thus the whole voyage was completed in seventy-five
+hours; or rather less, counting from shore to shore. No serious accident
+occurred. No real danger was at any time apprehended. The balloon was
+exhausted and secured without trouble; and when the MS.  from which this
+narrative is compiled was despatched from Charleston, the party were
+still at Fort Moultrie. Their farther intentions were not ascertained;
+but we can safely promise our readers some additional information either
+on Monday or in the course of the next day, at farthest.
+
+This is unquestionably the most stupendous, the most interesting, and
+the most important undertaking, ever accomplished or even attempted by
+man. What magnificent events may ensue, it would be useless now to think
+of determining.
+
+(*1) _Note_.--Mr. Ainsworth has not attempted to account for this
+phenomenon, which, however, is quite susceptible of explanation. A line
+dropped from an elevation of 25,000 feet, perpendicularly to the surface
+of the earth (or sea), would form the perpendicular of a right-angled
+triangle, of which the base would extend from the right angle to the
+horizon, and the hypothenuse from the horizon to the balloon. But the
+25,000 feet of altitude is little or nothing, in comparison with the
+extent of the prospect. In other words, the base and hypothenuse of the
+supposed triangle would be so long when compared with the perpendicular,
+that the two former may be regarded as nearly parallel. In this manner
+the horizon of the æronaut would appear to be _on a level_ with the
+car. But, as the point immediately beneath him seems, and is, at a great
+distance below him, it seems, of course, also, at a great distance below
+the horizon. Hence the impression of _concavity_; and this impression
+must remain, until the elevation shall bear so great a proportion to
+the extent of prospect, that the apparent parallelism of the base and
+hypothenuse disappears--when the earth’s real convexity must become
+apparent.
+
+
+
+
+MS. FOUND IN A BOTTLE
+
+               Qui n’a plus qu’un moment a vivre
+
+               N’a plus rien a dissimuler.
+
+                            --Quinault--Atys.
+
+OF my country and of my family I have little to say. Ill usage and
+length of years have driven me from the one, and estranged me from the
+other. Hereditary wealth afforded me an education of no common order,
+and a contemplative turn of mind enabled me to methodize the stores
+which early study very diligently garnered up.--Beyond all things,
+the study of the German moralists gave me great delight; not from any
+ill-advised admiration of their eloquent madness, but from the ease with
+which my habits of rigid thought enabled me to detect their falsities.
+I have often been reproached with the aridity of my genius; a deficiency
+of imagination has been imputed to me as a crime; and the Pyrrhonism
+of my opinions has at all times rendered me notorious. Indeed, a strong
+relish for physical philosophy has, I fear, tinctured my mind with
+a very common error of this age--I mean the habit of referring
+occurrences, even the least susceptible of such reference, to the
+principles of that science. Upon the whole, no person could be less
+liable than myself to be led away from the severe precincts of truth by
+the ignes fatui of superstition. I have thought proper to premise thus
+much, lest the incredible tale I have to tell should be considered
+rather the raving of a crude imagination, than the positive experience
+of a mind to which the reveries of fancy have been a dead letter and a
+nullity.
+
+After many years spent in foreign travel, I sailed in the year 18-- ,
+from the port of Batavia, in the rich and populous island of Java, on
+a voyage to the Archipelago of the Sunda islands. I went as
+passenger--having no other inducement than a kind of nervous
+restlessness which haunted me as a fiend.
+
+Our vessel was a beautiful ship of about four hundred tons,
+copper-fastened, and built at Bombay of Malabar teak. She was freighted
+with cotton-wool and oil, from the Lachadive islands. We had also on
+board coir, jaggeree, ghee, cocoa-nuts, and a few cases of opium. The
+stowage was clumsily done, and the vessel consequently crank.
+
+We got under way with a mere breath of wind, and for many days stood
+along the eastern coast of Java, without any other incident to beguile
+the monotony of our course than the occasional meeting with some of the
+small grabs of the Archipelago to which we were bound.
+
+One evening, leaning over the taffrail, I observed a very singular,
+isolated cloud, to the N.W. It was remarkable, as well for its color, as
+from its being the first we had seen since our departure from Batavia.
+I watched it attentively until sunset, when it spread all at once to
+the eastward and westward, girting in the horizon with a narrow strip
+of vapor, and looking like a long line of low beach. My notice was soon
+afterwards attracted by the dusky-red appearance of the moon, and the
+peculiar character of the sea. The latter was undergoing a rapid change,
+and the water seemed more than usually transparent. Although I could
+distinctly see the bottom, yet, heaving the lead, I found the ship in
+fifteen fathoms. The air now became intolerably hot, and was loaded with
+spiral exhalations similar to those arising from heat iron. As night
+came on, every breath of wind died away, an more entire calm it is
+impossible to conceive. The flame of a candle burned upon the poop
+without the least perceptible motion, and a long hair, held between the
+finger and thumb, hung without the possibility of detecting a vibration.
+However, as the captain said he could perceive no indication of danger,
+and as we were drifting in bodily to shore, he ordered the sails to
+be furled, and the anchor let go. No watch was set, and the crew,
+consisting principally of Malays, stretched themselves deliberately upon
+deck. I went below--not without a full presentiment of evil. Indeed,
+every appearance warranted me in apprehending a Simoom. I told the
+captain my fears; but he paid no attention to what I said, and left me
+without deigning to give a reply. My uneasiness, however, prevented me
+from sleeping, and about midnight I went upon deck.--As I placed my foot
+upon the upper step of the companion-ladder, I was startled by a
+loud, humming noise, like that occasioned by the rapid revolution of a
+mill-wheel, and before I could ascertain its meaning, I found the ship
+quivering to its centre. In the next instant, a wilderness of foam
+hurled us upon our beam-ends, and, rushing over us fore and aft, swept
+the entire decks from stem to stern.
+
+The extreme fury of the blast proved, in a great measure, the salvation
+of the ship. Although completely water-logged, yet, as her masts had
+gone by the board, she rose, after a minute, heavily from the sea, and,
+staggering awhile beneath the immense pressure of the tempest, finally
+righted.
+
+By what miracle I escaped destruction, it is impossible to say. Stunned
+by the shock of the water, I found myself, upon recovery, jammed in
+between the stern-post and rudder. With great difficulty I gained my
+feet, and looking dizzily around, was, at first, struck with the idea of
+our being among breakers; so terrific, beyond the wildest imagination,
+was the whirlpool of mountainous and foaming ocean within which we were
+engulfed. After a while, I heard the voice of an old Swede, who had
+shipped with us at the moment of our leaving port. I hallooed to
+him with all my strength, and presently he came reeling aft. We soon
+discovered that we were the sole survivors of the accident. All on deck,
+with the exception of ourselves, had been swept overboard;--the captain
+and mates must have perished as they slept, for the cabins were deluged
+with water. Without assistance, we could expect to do little for the
+security of the ship, and our exertions were at first paralyzed by the
+momentary expectation of going down. Our cable had, of course, parted
+like pack-thread, at the first breath of the hurricane, or we should
+have been instantaneously overwhelmed. We scudded with frightful
+velocity before the sea, and the water made clear breaches over us. The
+frame-work of our stern was shattered excessively, and, in almost every
+respect, we had received considerable injury; but to our extreme Joy we
+found the pumps unchoked, and that we had made no great shifting of
+our ballast. The main fury of the blast had already blown over, and we
+apprehended little danger from the violence of the wind; but we looked
+forward to its total cessation with dismay; well believing, that, in our
+shattered condition, we should inevitably perish in the tremendous swell
+which would ensue. But this very just apprehension seemed by no means
+likely to be soon verified. For five entire days and nights--during
+which our only subsistence was a small quantity of jaggeree, procured
+with great difficulty from the forecastle--the hulk flew at a rate
+defying computation, before rapidly succeeding flaws of wind, which,
+without equalling the first violence of the Simoom, were still more
+terrific than any tempest I had before encountered. Our course for the
+first four days was, with trifling variations, S.E. and by S.; and we
+must have run down the coast of New Holland.--On the fifth day the cold
+became extreme, although the wind had hauled round a point more to the
+northward.--The sun arose with a sickly yellow lustre, and clambered a
+very few degrees above the horizon--emitting no decisive light.--There
+were no clouds apparent, yet the wind was upon the increase, and blew
+with a fitful and unsteady fury. About noon, as nearly as we could
+guess, our attention was again arrested by the appearance of the sun.
+It gave out no light, properly so called, but a dull and sullen glow
+without reflection, as if all its rays were polarized. Just before
+sinking within the turgid sea, its central fires suddenly went out, as
+if hurriedly extinguished by some unaccountable power. It was a dim,
+sliver-like rim, alone, as it rushed down the unfathomable ocean.
+
+We waited in vain for the arrival of the sixth day--that day to me
+has not arrived--to the Swede, never did arrive. Thenceforward we were
+enshrouded in patchy darkness, so that we could not have seen an object
+at twenty paces from the ship. Eternal night continued to envelop us,
+all unrelieved by the phosphoric sea-brilliancy to which we had been
+accustomed in the tropics. We observed too, that, although the tempest
+continued to rage with unabated violence, there was no longer to be
+discovered the usual appearance of surf, or foam, which had hitherto
+attended us. All around were horror, and thick gloom, and a black
+sweltering desert of ebony.--Superstitious terror crept by degrees into
+the spirit of the old Swede, and my own soul was wrapped up in silent
+wonder. We neglected all care of the ship, as worse than useless, and
+securing ourselves, as well as possible, to the stump of the mizen-mast,
+looked out bitterly into the world of ocean. We had no means of
+calculating time, nor could we form any guess of our situation. We were,
+however, well aware of having made farther to the southward than any
+previous navigators, and felt great amazement at not meeting with the
+usual impediments of ice. In the meantime every moment threatened to be
+our last--every mountainous billow hurried to overwhelm us. The swell
+surpassed anything I had imagined possible, and that we were not
+instantly buried is a miracle. My companion spoke of the lightness of
+our cargo, and reminded me of the excellent qualities of our ship; but
+I could not help feeling the utter hopelessness of hope itself, and
+prepared myself gloomily for that death which I thought nothing could
+defer beyond an hour, as, with every knot of way the ship made,
+the swelling of the black stupendous seas became more dismally
+appalling. At times we gasped for breath at an elevation beyond the
+albatross--at times became dizzy with the velocity of our descent into
+some watery hell, where the air grew stagnant, and no sound disturbed
+the slumbers of the kraken.
+
+We were at the bottom of one of these abysses, when a quick scream
+from my companion broke fearfully upon the night. “See! see!” cried he,
+shrieking in my ears, “Almighty God! see! see!” As he spoke, I became
+aware of a dull, sullen glare of red light which streamed down the sides
+of the vast chasm where we lay, and threw a fitful brilliancy upon our
+deck. Casting my eyes upwards, I beheld a spectacle which froze the
+current of my blood. At a terrific height directly above us, and upon
+the very verge of the precipitous descent, hovered a gigantic ship of,
+perhaps, four thousand tons. Although upreared upon the summit of a wave
+more than a hundred times her own altitude, her apparent size exceeded
+that of any ship of the line or East Indiaman in existence. Her huge
+hull was of a deep dingy black, unrelieved by any of the customary
+carvings of a ship. A single row of brass cannon protruded from her open
+ports, and dashed from their polished surfaces the fires of innumerable
+battle-lanterns, which swung to and fro about her rigging. But what
+mainly inspired us with horror and astonishment, was that she bore up
+under a press of sail in the very teeth of that supernatural sea, and of
+that ungovernable hurricane. When we first discovered her, her bows
+were alone to be seen, as she rose slowly from the dim and horrible gulf
+beyond her. For a moment of intense terror she paused upon the giddy
+pinnacle, as if in contemplation of her own sublimity, then trembled and
+tottered, and--came down.
+
+At this instant, I know not what sudden self-possession came over my
+spirit. Staggering as far aft as I could, I awaited fearlessly the ruin
+that was to overwhelm. Our own vessel was at length ceasing from her
+struggles, and sinking with her head to the sea. The shock of the
+descending mass struck her, consequently, in that portion of her frame
+which was already under water, and the inevitable result was to hurl me,
+with irresistible violence, upon the rigging of the stranger.
+
+As I fell, the ship hove in stays, and went about; and to the confusion
+ensuing I attributed my escape from the notice of the crew. With little
+difficulty I made my way unperceived to the main hatchway, which was
+partially open, and soon found an opportunity of secreting myself in the
+hold. Why I did so I can hardly tell. An indefinite sense of awe, which
+at first sight of the navigators of the ship had taken hold of my mind,
+was perhaps the principle of my concealment. I was unwilling to trust
+myself with a race of people who had offered, to the cursory glance I
+had taken, so many points of vague novelty, doubt, and apprehension. I
+therefore thought proper to contrive a hiding-place in the hold. This I
+did by removing a small portion of the shifting-boards, in such a manner
+as to afford me a convenient retreat between the huge timbers of the
+ship.
+
+I had scarcely completed my work, when a footstep in the hold forced me
+to make use of it. A man passed by my place of concealment with a feeble
+and unsteady gait. I could not see his face, but had an opportunity
+of observing his general appearance. There was about it an evidence of
+great age and infirmity. His knees tottered beneath a load of years, and
+his entire frame quivered under the burthen. He muttered to himself,
+in a low broken tone, some words of a language which I could not
+understand, and groped in a corner among a pile of singular-looking
+instruments, and decayed charts of navigation. His manner was a wild
+mixture of the peevishness of second childhood, and the solemn dignity
+of a God. He at length went on deck, and I saw him no more.
+
+* * * * *
+
+A feeling, for which I have no name, has taken possession of my soul
+--a sensation which will admit of no analysis, to which the lessons of
+bygone times are inadequate, and for which I fear futurity itself
+will offer me no key. To a mind constituted like my own, the latter
+consideration is an evil. I shall never--I know that I shall
+never--be satisfied with regard to the nature of my conceptions. Yet it
+is not wonderful that these conceptions are indefinite, since they have
+their origin in sources so utterly novel. A new sense--a new entity is
+added to my soul.
+
+* * * * *
+
+It is long since I first trod the deck of this terrible ship, and the
+rays of my destiny are, I think, gathering to a focus. Incomprehensible
+men! Wrapped up in meditations of a kind which I cannot divine, they
+pass me by unnoticed. Concealment is utter folly on my part, for the
+people will not see. It was but just now that I passed directly before
+the eyes of the mate--it was no long while ago that I ventured into the
+captain’s own private cabin, and took thence the materials with which
+I write, and have written. I shall from time to time continue this
+Journal. It is true that I may not find an opportunity of transmitting
+it to the world, but I will not fall to make the endeavour. At the last
+moment I will enclose the MS. in a bottle, and cast it within the sea.
+
+* * * * *
+
+An incident has occurred which has given me new room for meditation. Are
+such things the operation of ungoverned Chance? I had ventured upon deck
+and thrown myself down, without attracting any notice, among a pile of
+ratlin-stuff and old sails in the bottom of the yawl. While musing upon
+the singularity of my fate, I unwittingly daubed with a tar-brush the
+edges of a neatly-folded studding-sail which lay near me on a barrel.
+The studding-sail is now bent upon the ship, and the thoughtless touches
+of the brush are spread out into the word DISCOVERY.
+
+I have made many observations lately upon the structure of the vessel.
+Although well armed, she is not, I think, a ship of war. Her rigging,
+build, and general equipment, all negative a supposition of this
+kind. What she is not, I can easily perceive--what she is I fear it is
+impossible to say. I know not how it is, but in scrutinizing her strange
+model and singular cast of spars, her huge size and overgrown suits
+of canvas, her severely simple bow and antiquated stern, there will
+occasionally flash across my mind a sensation of familiar things, and
+there is always mixed up with such indistinct shadows of recollection,
+an unaccountable memory of old foreign chronicles and ages long ago.
+
+* * * * *
+
+I have been looking at the timbers of the ship. She is built of a
+material to which I am a stranger. There is a peculiar character about
+the wood which strikes me as rendering it unfit for the purpose to
+which it has been applied. I mean its extreme porousness, considered
+independently by the worm-eaten condition which is a consequence of
+navigation in these seas, and apart from the rottenness attendant upon
+age. It will appear perhaps an observation somewhat over-curious, but
+this wood would have every characteristic of Spanish oak, if Spanish oak
+were distended by any unnatural means.
+
+In reading the above sentence a curious apothegm of an old
+weather-beaten Dutch navigator comes full upon my recollection. “It
+is as sure,” he was wont to say, when any doubt was entertained of his
+veracity, “as sure as there is a sea where the ship itself will grow in
+bulk like the living body of the seaman.”
+
+* * * * *
+
+About an hour ago, I made bold to thrust myself among a group of the
+crew. They paid me no manner of attention, and, although I stood in the
+very midst of them all, seemed utterly unconscious of my presence. Like
+the one I had at first seen in the hold, they all bore about them the
+marks of a hoary old age. Their knees trembled with infirmity; their
+shoulders were bent double with decrepitude; their shrivelled skins
+rattled in the wind; their voices were low, tremulous and broken; their
+eyes glistened with the rheum of years; and their gray hairs streamed
+terribly in the tempest. Around them, on every part of the deck, lay
+scattered mathematical instruments of the most quaint and obsolete
+construction.
+
+* * * * *
+
+I mentioned some time ago the bending of a studding-sail. From that
+period the ship, being thrown dead off the wind, has continued her
+terrific course due south, with every rag of canvas packed upon her,
+from her trucks to her lower studding-sail booms, and rolling every
+moment her top-gallant yard-arms into the most appalling hell of water
+which it can enter into the mind of a man to imagine. I have just left
+the deck, where I find it impossible to maintain a footing, although the
+crew seem to experience little inconvenience. It appears to me a miracle
+of miracles that our enormous bulk is not swallowed up at once and
+forever. We are surely doomed to hover continually upon the brink of
+Eternity, without taking a final plunge into the abyss. From billows a
+thousand times more stupendous than any I have ever seen, we glide away
+with the facility of the arrowy sea-gull; and the colossal waters rear
+their heads above us like demons of the deep, but like demons confined
+to simple threats and forbidden to destroy. I am led to attribute these
+frequent escapes to the only natural cause which can account for such
+effect.--I must suppose the ship to be within the influence of some
+strong current, or impetuous under-tow.
+
+* * * * *
+
+I have seen the captain face to face, and in his own cabin--but, as I
+expected, he paid me no attention. Although in his appearance there is,
+to a casual observer, nothing which might bespeak him more or less than
+man--still a feeling of irrepressible reverence and awe mingled with the
+sensation of wonder with which I regarded him. In stature he is nearly
+my own height; that is, about five feet eight inches. He is of a
+well-knit and compact frame of body, neither robust nor remarkably
+otherwise. But it is the singularity of the expression which reigns upon
+the face--it is the intense, the wonderful, the thrilling evidence of
+old age, so utter, so extreme, which excites within my spirit a sense--a
+sentiment ineffable. His forehead, although little wrinkled, seems to
+bear upon it the stamp of a myriad of years.--His gray hairs are records
+of the past, and his grayer eyes are Sybils of the future. The cabin
+floor was thickly strewn with strange, iron-clasped folios, and
+mouldering instruments of science, and obsolete long-forgotten charts.
+His head was bowed down upon his hands, and he pored, with a fiery
+unquiet eye, over a paper which I took to be a commission, and which, at
+all events, bore the signature of a monarch. He muttered to himself, as
+did the first seaman whom I saw in the hold, some low peevish syllables
+of a foreign tongue, and although the speaker was close at my elbow, his
+voice seemed to reach my ears from the distance of a mile.
+
+* * * * *
+
+The ship and all in it are imbued with the spirit of Eld. The crew glide
+to and fro like the ghosts of buried centuries; their eyes have an eager
+and uneasy meaning; and when their fingers fall athwart my path in the
+wild glare of the battle-lanterns, I feel as I have never felt before,
+although I have been all my life a dealer in antiquities, and have
+imbibed the shadows of fallen columns at Balbec, and Tadmor, and
+Persepolis, until my very soul has become a ruin.
+
+* * * * *
+
+When I look around me I feel ashamed of my former apprehensions. If I
+trembled at the blast which has hitherto attended us, shall I not stand
+aghast at a warring of wind and ocean, to convey any idea of which
+the words tornado and simoom are trivial and ineffective? All in the
+immediate vicinity of the ship is the blackness of eternal night, and a
+chaos of foamless water; but, about a league on either side of us, may
+be seen, indistinctly and at intervals, stupendous ramparts of ice,
+towering away into the desolate sky, and looking like the walls of the
+universe.
+
+* * * * *
+
+As I imagined, the ship proves to be in a current; if that appellation
+can properly be given to a tide which, howling and shrieking by the
+white ice, thunders on to the southward with a velocity like the
+headlong dashing of a cataract.
+
+* * * * *
+
+To conceive the horror of my sensations is, I presume, utterly
+impossible; yet a curiosity to penetrate the mysteries of these awful
+regions, predominates even over my despair, and will reconcile me to the
+most hideous aspect of death. It is evident that we are hurrying onwards
+to some exciting knowledge--some never-to-be-imparted secret, whose
+attainment is destruction. Perhaps this current leads us to the southern
+pole itself. It must be confessed that a supposition apparently so wild
+has every probability in its favor.
+
+* * * * *
+
+The crew pace the deck with unquiet and tremulous step; but there is
+upon their countenances an expression more of the eagerness of hope than
+of the apathy of despair.
+
+In the meantime the wind is still in our poop, and, as we carry a crowd
+of canvas, the ship is at times lifted bodily from out the sea--Oh,
+horror upon horror! the ice opens suddenly to the right, and to the
+left, and we are whirling dizzily, in immense concentric circles, round
+and round the borders of a gigantic amphitheatre, the summit of whose
+walls is lost in the darkness and the distance. But little time will be
+left me to ponder upon my destiny--the circles rapidly grow small--we
+are plunging madly within the grasp of the whirlpool--and amid a
+roaring, and bellowing, and thundering of ocean and of tempest, the ship
+is quivering, oh God! and--going down.
+
+NOTE.--The “MS. Found in a Bottle,” was originally published in 1831,
+and it was not until many years afterwards that I became acquainted with
+the maps of Mercator, in which the ocean is represented as rushing, by
+four mouths, into the (northern) Polar Gulf, to be absorbed into the
+bowels of the earth; the Pole itself being represented by a black rock,
+towering to a prodigious height.
+
+
+
+
+THE OVAL PORTRAIT
+
+THE chateau into which my valet had ventured to make forcible entrance,
+rather than permit me, in my desperately wounded condition, to pass a
+night in the open air, was one of those piles of commingled gloom and
+grandeur which have so long frowned among the Appennines, not less in
+fact than in the fancy of Mrs. Radcliffe. To all appearance it had been
+temporarily and very lately abandoned. We established ourselves in one
+of the smallest and least sumptuously furnished apartments. It lay in a
+remote turret of the building. Its decorations were rich, yet tattered
+and antique. Its walls were hung with tapestry and bedecked with
+manifold and multiform armorial trophies, together with an unusually
+great number of very spirited modern paintings in frames of rich golden
+arabesque. In these paintings, which depended from the walls not only
+in their main surfaces, but in very many nooks which the bizarre
+architecture of the chateau rendered necessary--in these paintings my
+incipient delirium, perhaps, had caused me to take deep interest; so
+that I bade Pedro to close the heavy shutters of the room--since it was
+already night--to light the tongues of a tall candelabrum which stood by
+the head of my bed--and to throw open far and wide the fringed curtains
+of black velvet which enveloped the bed itself. I wished all this done
+that I might resign myself, if not to sleep, at least alternately to the
+contemplation of these pictures, and the perusal of a small volume which
+had been found upon the pillow, and which purported to criticise and
+describe them.
+
+Long--long I read--and devoutly, devotedly I gazed. Rapidly and
+gloriously the hours flew by and the deep midnight came. The position of
+the candelabrum displeased me, and outreaching my hand with difficulty,
+rather than disturb my slumbering valet, I placed it so as to throw its
+rays more fully upon the book.
+
+But the action produced an effect altogether unanticipated. The rays of
+the numerous candles (for there were many) now fell within a niche of
+the room which had hitherto been thrown into deep shade by one of the
+bed-posts. I thus saw in vivid light a picture all unnoticed before. It
+was the portrait of a young girl just ripening into womanhood. I glanced
+at the painting hurriedly, and then closed my eyes. Why I did this
+was not at first apparent even to my own perception. But while my lids
+remained thus shut, I ran over in my mind my reason for so shutting
+them. It was an impulsive movement to gain time for thought--to make
+sure that my vision had not deceived me--to calm and subdue my fancy for
+a more sober and more certain gaze. In a very few moments I again looked
+fixedly at the painting.
+
+That I now saw aright I could not and would not doubt; for the first
+flashing of the candles upon that canvas had seemed to dissipate the
+dreamy stupor which was stealing over my senses, and to startle me at
+once into waking life.
+
+The portrait, I have already said, was that of a young girl. It was a
+mere head and shoulders, done in what is technically termed a vignette
+manner; much in the style of the favorite heads of Sully. The arms, the
+bosom, and even the ends of the radiant hair melted imperceptibly into
+the vague yet deep shadow which formed the back-ground of the whole. The
+frame was oval, richly gilded and filigreed in Moresque. As a thing of
+art nothing could be more admirable than the painting itself. But it
+could have been neither the execution of the work, nor the immortal
+beauty of the countenance, which had so suddenly and so vehemently moved
+me. Least of all, could it have been that my fancy, shaken from its half
+slumber, had mistaken the head for that of a living person. I saw at
+once that the peculiarities of the design, of the vignetting, and of the
+frame, must have instantly dispelled such idea--must have prevented even
+its momentary entertainment. Thinking earnestly upon these points, I
+remained, for an hour perhaps, half sitting, half reclining, with my
+vision riveted upon the portrait. At length, satisfied with the true
+secret of its effect, I fell back within the bed. I had found the spell
+of the picture in an absolute life-likeliness of expression, which, at
+first startling, finally confounded, subdued, and appalled me. With deep
+and reverent awe I replaced the candelabrum in its former position. The
+cause of my deep agitation being thus shut from view, I sought eagerly
+the volume which discussed the paintings and their histories. Turning
+to the number which designated the oval portrait, I there read the vague
+and quaint words which follow:
+
+“She was a maiden of rarest beauty, and not more lovely than full of
+glee. And evil was the hour when she saw, and loved, and wedded the
+painter. He, passionate, studious, austere, and having already a bride
+in his Art; she a maiden of rarest beauty, and not more lovely than full
+of glee; all light and smiles, and frolicsome as the young fawn; loving
+and cherishing all things; hating only the Art which was her rival;
+dreading only the pallet and brushes and other untoward instruments
+which deprived her of the countenance of her lover. It was thus a
+terrible thing for this lady to hear the painter speak of his desire to
+portray even his young bride. But she was humble and obedient, and sat
+meekly for many weeks in the dark, high turret-chamber where the light
+dripped upon the pale canvas only from overhead. But he, the painter,
+took glory in his work, which went on from hour to hour, and from day to
+day. And he was a passionate, and wild, and moody man, who became lost
+in reveries; so that he would not see that the light which fell so
+ghastly in that lone turret withered the health and the spirits of his
+bride, who pined visibly to all but him. Yet she smiled on and still on,
+uncomplainingly, because she saw that the painter (who had high renown)
+took a fervid and burning pleasure in his task, and wrought day and
+night to depict her who so loved him, yet who grew daily more dispirited
+and weak. And in sooth some who beheld the portrait spoke of its
+resemblance in low words, as of a mighty marvel, and a proof not less of
+the power of the painter than of his deep love for her whom he depicted
+so surpassingly well. But at length, as the labor drew nearer to its
+conclusion, there were admitted none into the turret; for the painter
+had grown wild with the ardor of his work, and turned his eyes from
+canvas merely, even to regard the countenance of his wife. And he would
+not see that the tints which he spread upon the canvas were drawn from
+the cheeks of her who sate beside him. And when many weeks had passed,
+and but little remained to do, save one brush upon the mouth and one
+tint upon the eye, the spirit of the lady again flickered up as the
+flame within the socket of the lamp. And then the brush was given,
+and then the tint was placed; and, for one moment, the painter stood
+entranced before the work which he had wrought; but in the next, while
+he yet gazed, he grew tremulous and very pallid, and aghast, and crying
+with a loud voice, ‘This is indeed Life itself!’ turned suddenly to
+regard his beloved:--She was dead!”
+
+
+
+
+
+
+
+End of Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+***** This file should be named 2147-0.txt or 2147-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/1/4/2147/
+
+Produced by David Widger and Carlo Traverso
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/frankenstein.txt
+++ b/jet/source-sink-builder/src/main/resources/books/frankenstein.txt
@@ -1,0 +1,7653 @@
+﻿Project Gutenberg's Frankenstein, by Mary Wollstonecraft (Godwin) Shelley
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Frankenstein
+       or The Modern Prometheus
+
+Author: Mary Wollstonecraft (Godwin) Shelley
+
+Release Date: June 17, 2008 [EBook #84]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+
+
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+Frankenstein,
+
+or the Modern Prometheus
+
+
+by
+
+Mary Wollstonecraft (Godwin) Shelley
+
+
+
+
+Letter 1
+
+
+St. Petersburgh, Dec. 11th, 17--
+
+TO Mrs. Saville, England
+
+You will rejoice to hear that no disaster has accompanied the
+commencement of an enterprise which you have regarded with such evil
+forebodings.  I arrived here yesterday, and my first task is to assure
+my dear sister of my welfare and increasing confidence in the success
+of my undertaking.
+
+I am already far north of London, and as I walk in the streets of
+Petersburgh, I feel a cold northern breeze play upon my cheeks, which
+braces my nerves and fills me with delight.  Do you understand this
+feeling?  This breeze, which has travelled from the regions towards
+which I am advancing, gives me a foretaste of those icy climes.
+Inspirited by this wind of promise, my daydreams become more fervent
+and vivid.  I try in vain to be persuaded that the pole is the seat of
+frost and desolation; it ever presents itself to my imagination as the
+region of beauty and delight.  There, Margaret, the sun is forever
+visible, its broad disk just skirting the horizon and diffusing a
+perpetual splendour.  There--for with your leave, my sister, I will put
+some trust in preceding navigators--there snow and frost are banished;
+and, sailing over a calm sea, we may be wafted to a land surpassing in
+wonders and in beauty every region hitherto discovered on the habitable
+globe.  Its productions and features may be without example, as the
+phenomena of the heavenly bodies undoubtedly are in those undiscovered
+solitudes.  What may not be expected in a country of eternal light?  I
+may there discover the wondrous power which attracts the needle and may
+regulate a thousand celestial observations that require only this
+voyage to render their seeming eccentricities consistent forever.  I
+shall satiate my ardent curiosity with the sight of a part of the world
+never before visited, and may tread a land never before imprinted by
+the foot of man. These are my enticements, and they are sufficient to
+conquer all fear of danger or death and to induce me to commence this
+laborious voyage with the joy a child feels when he embarks in a little
+boat, with his holiday mates, on an expedition of discovery up his
+native river. But supposing all these conjectures to be false, you
+cannot contest the inestimable benefit which I shall confer on all
+mankind, to the last generation, by discovering a passage near the pole
+to those countries, to reach which at present so many months are
+requisite; or by ascertaining the secret of the magnet, which, if at
+all possible, can only be effected by an undertaking such as mine.
+
+These reflections have dispelled the agitation with which I began my
+letter, and I feel my heart glow with an enthusiasm which elevates me
+to heaven, for nothing contributes so much to tranquillize the mind as
+a steady purpose--a point on which the soul may fix its intellectual
+eye.  This expedition has been the favourite dream of my early years. I
+have read with ardour the accounts of the various voyages which have
+been made in the prospect of arriving at the North Pacific Ocean
+through the seas which surround the pole.  You may remember that a
+history of all the voyages made for purposes of discovery composed the
+whole of our good Uncle Thomas' library.  My education was neglected,
+yet I was passionately fond of reading.  These volumes were my study
+day and night, and my familiarity with them increased that regret which
+I had felt, as a child, on learning that my father's dying injunction
+had forbidden my uncle to allow me to embark in a seafaring life.
+
+These visions faded when I perused, for the first time, those poets
+whose effusions entranced my soul and lifted it to heaven.  I also
+became a poet and for one year lived in a paradise of my own creation;
+I imagined that I also might obtain a niche in the temple where the
+names of Homer and Shakespeare are consecrated.  You are well
+acquainted with my failure and how heavily I bore the disappointment.
+But just at that time I inherited the fortune of my cousin, and my
+thoughts were turned into the channel of their earlier bent.
+
+Six years have passed since I resolved on my present undertaking.  I
+can, even now, remember the hour from which I dedicated myself to this
+great enterprise.  I commenced by inuring my body to hardship.  I
+accompanied the whale-fishers on several expeditions to the North Sea;
+I voluntarily endured cold, famine, thirst, and want of sleep; I often
+worked harder than the common sailors during the day and devoted my
+nights to the study of mathematics, the theory of medicine, and those
+branches of physical science from which a naval adventurer might derive
+the greatest practical advantage.  Twice I actually hired myself as an
+under-mate in a Greenland whaler, and acquitted myself to admiration. I
+must own I felt a little proud when my captain offered me the second
+dignity in the vessel and entreated me to remain with the greatest
+earnestness, so valuable did he consider my services.  And now, dear
+Margaret, do I not deserve to accomplish some great purpose?  My life
+might have been passed in ease and luxury, but I preferred glory to
+every enticement that wealth placed in my path.  Oh, that some
+encouraging voice would answer in the affirmative!  My courage and my
+resolution is firm; but my hopes fluctuate, and my spirits are often
+depressed.  I am about to proceed on a long and difficult voyage, the
+emergencies of which will demand all my fortitude:  I am required not
+only to raise the spirits of others, but sometimes to sustain my own,
+when theirs are failing.
+
+This is the most favourable period for travelling in Russia.  They fly
+quickly over the snow in their sledges; the motion is pleasant, and, in
+my opinion, far more agreeable than that of an English stagecoach.  The
+cold is not excessive, if you are wrapped in furs--a dress which I have
+already adopted, for there is a great difference between walking the
+deck and remaining seated motionless for hours, when no exercise
+prevents the blood from actually freezing in your veins.  I have no
+ambition to lose my life on the post-road between St. Petersburgh and
+Archangel. I shall depart for the latter town in a fortnight or three
+weeks; and my intention is to hire a ship there, which can easily be
+done by paying the insurance for the owner, and to engage as many
+sailors as I think necessary among those who are accustomed to the
+whale-fishing.  I do not intend to sail until the month of June; and
+when shall I return?  Ah, dear sister, how can I answer this question?
+If I succeed, many, many months, perhaps years, will pass before you
+and I may meet.  If I fail, you will see me again soon, or never.
+Farewell, my dear, excellent Margaret. Heaven shower down blessings on
+you, and save me, that I may again and again testify my gratitude for
+all your love and kindness.
+
+Your affectionate brother,
+  R. Walton
+
+
+
+Letter 2
+
+
+Archangel, 28th March, 17--
+
+To Mrs. Saville, England
+
+How slowly the time passes here, encompassed as I am by frost and snow!
+Yet a second step is taken towards my enterprise.  I have hired a
+vessel and am occupied in collecting my sailors; those whom I have
+already engaged appear to be men on whom I can depend and are certainly
+possessed of dauntless courage.
+
+But I have one want which I have never yet been able to satisfy, and
+the absence of the object of which I now feel as a most severe evil, I
+have no friend, Margaret:  when I am glowing with the enthusiasm of
+success, there will be none to participate my joy; if I am assailed by
+disappointment, no one will endeavour to sustain me in dejection. I
+shall commit my thoughts to paper, it is true; but that is a poor
+medium for the communication of feeling.  I desire the company of a man
+who could sympathize with me, whose eyes would reply to mine. You may
+deem me romantic, my dear sister, but I bitterly feel the want of a
+friend.  I have no one near me, gentle yet courageous, possessed of a
+cultivated as well as of a capacious mind, whose tastes are like my
+own, to approve or amend my plans.  How would such a friend repair the
+faults of your poor brother!  I am too ardent in execution and too
+impatient of difficulties.  But it is a still greater evil to me that I
+am self-educated:  for the first fourteen years of my life I ran wild
+on a common and read nothing but our Uncle Thomas' books of voyages. At
+that age I became acquainted with the celebrated poets of our own
+country; but it was only when it had ceased to be in my power to derive
+its most important benefits from such a conviction that I perceived the
+necessity of becoming acquainted with more languages than that of my
+native country.  Now I am twenty-eight and am in reality more
+illiterate than many schoolboys of fifteen.  It is true that I have
+thought more and that my daydreams are more extended and magnificent,
+but they want (as the painters call it) KEEPING; and I greatly need a
+friend who would have sense enough not to despise me as romantic, and
+affection enough for me to endeavour to regulate my mind.  Well, these
+are useless complaints; I shall certainly find no friend on the wide
+ocean, nor even here in Archangel, among merchants and seamen.  Yet
+some feelings, unallied to the dross of human nature, beat even in
+these rugged bosoms.  My lieutenant, for instance, is a man of
+wonderful courage and enterprise; he is madly desirous of glory, or
+rather, to word my phrase more characteristically, of advancement in
+his profession.  He is an Englishman, and in the midst of national and
+professional prejudices, unsoftened by cultivation, retains some of the
+noblest endowments of humanity.  I first became acquainted with him on
+board a whale vessel; finding that he was unemployed in this city, I
+easily engaged him to assist in my enterprise.  The master is a person
+of an excellent disposition and is remarkable in the ship for his
+gentleness and the mildness of his discipline.  This circumstance,
+added to his well-known integrity and dauntless courage, made me very
+desirous to engage him.  A youth passed in solitude, my best years
+spent under your gentle and feminine fosterage, has so refined the
+groundwork of my character that I cannot overcome an intense distaste
+to the usual brutality exercised on board ship:  I have never believed
+it to be necessary, and when I heard of a mariner equally noted for his
+kindliness of heart and the respect and obedience paid to him by his
+crew, I felt myself peculiarly fortunate in being able to secure his
+services.  I heard of him first in rather a romantic manner, from a
+lady who owes to him the happiness of her life.  This, briefly, is his
+story.  Some years ago he loved a young Russian lady of moderate
+fortune, and having amassed a considerable sum in prize-money, the
+father of the girl consented to the match.  He saw his mistress once
+before the destined ceremony; but she was bathed in tears, and throwing
+herself at his feet, entreated him to spare her, confessing at the same
+time that she loved another, but that he was poor, and that her father
+would never consent to the union.  My generous friend reassured the
+suppliant, and on being informed of the name of her lover, instantly
+abandoned his pursuit.  He had already bought a farm with his money, on
+which he had designed to pass the remainder of his life; but he
+bestowed the whole on his rival, together with the remains of his
+prize-money to purchase stock, and then himself solicited the young
+woman's father to consent to her marriage with her lover.  But the old
+man decidedly refused, thinking himself bound in honour to my friend,
+who, when he found the father inexorable, quitted his country, nor
+returned until he heard that his former mistress was married according
+to her inclinations.  "What a noble fellow!" you will exclaim.  He is
+so; but then he is wholly uneducated:  he is as silent as a Turk, and a
+kind of ignorant carelessness attends him, which, while it renders his
+conduct the more astonishing, detracts from the interest and sympathy
+which otherwise he would command.
+
+Yet do not suppose, because I complain a little or because I can
+conceive a consolation for my toils which I may never know, that I am
+wavering in my resolutions.  Those are as fixed as fate, and my voyage
+is only now delayed until the weather shall permit my embarkation.  The
+winter has been dreadfully severe, but the spring promises well, and it
+is considered as a remarkably early season, so that perhaps I may sail
+sooner than I expected.  I shall do nothing rashly:  you know me
+sufficiently to confide in my prudence and considerateness whenever the
+safety of others is committed to my care.
+
+I cannot describe to you my sensations on the near prospect of my
+undertaking.  It is impossible to communicate to you a conception of
+the trembling sensation, half pleasurable and half fearful, with which
+I am preparing to depart.  I am going to unexplored regions, to "the
+land of mist and snow," but I shall kill no albatross; therefore do not
+be alarmed for my safety or if I should come back to you as worn and
+woeful as the "Ancient Mariner."  You will smile at my allusion, but I
+will disclose a secret.  I have often attributed my attachment to, my
+passionate enthusiasm for, the dangerous mysteries of ocean to that
+production of the most imaginative of modern poets.  There is something
+at work in my soul which I do not understand.  I am practically
+industrious--painstaking, a workman to execute with perseverance and
+labour--but besides this there is a love for the marvellous, a belief
+in the marvellous, intertwined in all my projects, which hurries me out
+of the common pathways of men, even to the wild sea and unvisited
+regions I am about to explore. But to return to dearer considerations.
+Shall I meet you again, after having traversed immense seas, and
+returned by the most southern cape of Africa or America?  I dare not
+expect such success, yet I cannot bear to look on the reverse of the
+picture.  Continue for the present to write to me by every opportunity:
+I may receive your letters on some occasions when I need them most to
+support my spirits.  I love you very tenderly.  Remember me with
+affection, should you never hear from me again.
+
+Your affectionate brother,
+  Robert Walton
+
+
+
+Letter 3
+
+
+
+July 7th, 17--
+
+To Mrs. Saville, England
+
+My dear Sister,
+
+I write a few lines in haste to say that I am safe--and well advanced
+on my voyage.  This letter will reach England by a merchantman now on
+its homeward voyage from Archangel; more fortunate than I, who may not
+see my native land, perhaps, for many years.  I am, however, in good
+spirits:  my men are bold and apparently firm of purpose, nor do the
+floating sheets of ice that continually pass us, indicating the dangers
+of the region towards which we are advancing, appear to dismay them. We
+have already reached a very high latitude; but it is the height of
+summer, and although not so warm as in England, the southern gales,
+which blow us speedily towards those shores which I so ardently desire
+to attain, breathe a degree of renovating warmth which I had not
+expected.
+
+No incidents have hitherto befallen us that would make a figure in a
+letter.  One or two stiff gales and the springing of a leak are
+accidents which experienced navigators scarcely remember to record, and
+I shall be well content if nothing worse happen to us during our voyage.
+
+Adieu, my dear Margaret.  Be assured that for my own sake, as well as
+yours, I will not rashly encounter danger.  I will be cool,
+persevering, and prudent.
+
+But success SHALL crown my endeavours.  Wherefore not?  Thus far I have
+gone, tracing a secure way over the pathless seas, the very stars
+themselves being witnesses and testimonies of my triumph.  Why not
+still proceed over the untamed yet obedient element?  What can stop the
+determined heart and resolved will of man?
+
+My swelling heart involuntarily pours itself out thus.  But I must
+finish.  Heaven bless my beloved sister!
+
+R.W.
+
+
+
+Letter 4
+
+
+
+August 5th, 17--
+
+To Mrs. Saville, England
+
+So strange an accident has happened to us that I cannot forbear
+recording it, although it is very probable that you will see me before
+these papers can come into your possession.
+
+Last Monday (July 31st) we were nearly surrounded by ice, which closed
+in the ship on all sides, scarcely leaving her the sea-room in which
+she floated.  Our situation was somewhat dangerous, especially as we
+were compassed round by a very thick fog.  We accordingly lay to,
+hoping that some change would take place in the atmosphere and weather.
+
+About two o'clock the mist cleared away, and we beheld, stretched out
+in every direction, vast and irregular plains of ice, which seemed to
+have no end.  Some of my comrades groaned, and my own mind began to
+grow watchful with anxious thoughts, when a strange sight suddenly
+attracted our attention and diverted our solicitude from our own
+situation.  We perceived a low carriage, fixed on a sledge and drawn by
+dogs, pass on towards the north, at the distance of half a mile; a
+being which had the shape of a man, but apparently of gigantic stature,
+sat in the sledge and guided the dogs.  We watched the rapid progress
+of the traveller with our telescopes until he was lost among the
+distant inequalities of the ice.  This appearance excited our
+unqualified wonder.  We were, as we believed, many hundred miles from
+any land; but this apparition seemed to denote that it was not, in
+reality, so distant as we had supposed.  Shut in, however, by ice, it
+was impossible to follow his track, which we had observed with the
+greatest attention.  About two hours after this occurrence we heard the
+ground sea, and before night the ice broke and freed our ship.  We,
+however, lay to until the morning, fearing to encounter in the dark
+those large loose masses which float about after the breaking up of the
+ice.  I profited of this time to rest for a few hours.
+
+In the morning, however, as soon as it was light, I went upon deck and
+found all the sailors busy on one side of the vessel, apparently
+talking to someone in the sea.  It was, in fact, a sledge, like that we
+had seen before, which had drifted towards us in the night on a large
+fragment of ice.  Only one dog remained alive; but there was a human
+being within it whom the sailors were persuading to enter the vessel.
+He was not, as the other traveller seemed to be, a savage inhabitant of
+some undiscovered island, but a European.  When I appeared on deck the
+master said, "Here is our captain, and he will not allow you to perish
+on the open sea."
+
+On perceiving me, the stranger addressed me in English, although with a
+foreign accent.  "Before I come on board your vessel," said he, "will
+you have the kindness to inform me whither you are bound?"
+
+You may conceive my astonishment on hearing such a question addressed
+to me from a man on the brink of destruction and to whom I should have
+supposed that my vessel would have been a resource which he would not
+have exchanged for the most precious wealth the earth can afford.  I
+replied, however, that we were on a voyage of discovery towards the
+northern pole.
+
+Upon hearing this he appeared satisfied and consented to come on board.
+Good God!  Margaret, if you had seen the man who thus capitulated for
+his safety, your surprise would have been boundless.  His limbs were
+nearly frozen, and his body dreadfully emaciated by fatigue and
+suffering.  I never saw a man in so wretched a condition.  We attempted
+to carry him into the cabin, but as soon as he had quitted the fresh
+air he fainted.  We accordingly brought him back to the deck and
+restored him to animation by rubbing him with brandy and forcing him to
+swallow a small quantity.  As soon as he showed signs of life we
+wrapped him up in blankets and placed him near the chimney of the
+kitchen stove.  By slow degrees he recovered and ate a little soup,
+which restored him wonderfully.
+
+Two days passed in this manner before he was able to speak, and I often
+feared that his sufferings had deprived him of understanding.  When he
+had in some measure recovered, I removed him to my own cabin and
+attended on him as much as my duty would permit.  I never saw a more
+interesting creature:  his eyes have generally an expression of
+wildness, and even madness, but there are moments when, if anyone
+performs an act of kindness towards him or does him any the most
+trifling service, his whole countenance is lighted up, as it were, with
+a beam of benevolence and sweetness that I never saw equalled.  But he
+is generally melancholy and despairing, and sometimes he gnashes his
+teeth, as if impatient of the weight of woes that oppresses him.
+
+When my guest was a little recovered I had great trouble to keep off
+the men, who wished to ask him a thousand questions; but I would not
+allow him to be tormented by their idle curiosity, in a state of body
+and mind whose restoration evidently depended upon entire repose.
+Once, however, the lieutenant asked why he had come so far upon the ice
+in so strange a vehicle.
+
+His countenance instantly assumed an aspect of the deepest gloom, and
+he replied, "To seek one who fled from me."
+
+"And did the man whom you pursued travel in the same fashion?"
+
+"Yes."
+
+"Then I fancy we have seen him, for the day before we picked you up we
+saw some dogs drawing a sledge, with a man in it, across the ice."
+
+This aroused the stranger's attention, and he asked a multitude of
+questions concerning the route which the demon, as he called him, had
+pursued.  Soon after, when he was alone with me, he said, "I have,
+doubtless, excited your curiosity, as well as that of these good
+people; but you are too considerate to make inquiries."
+
+"Certainly; it would indeed be very impertinent and inhuman in me to
+trouble you with any inquisitiveness of mine."
+
+"And yet you rescued me from a strange and perilous situation; you have
+benevolently restored me to life."
+
+Soon after this he inquired if I thought that the breaking up of the
+ice had destroyed the other sledge.  I replied that I could not answer
+with any degree of certainty, for the ice had not broken until near
+midnight, and the traveller might have arrived at a place of safety
+before that time; but of this I could not judge.  From this time a new
+spirit of life animated the decaying frame of the stranger.  He
+manifested the greatest eagerness to be upon deck to watch for the
+sledge which had before appeared; but I have persuaded him to remain in
+the cabin, for he is far too weak to sustain the rawness of the
+atmosphere.  I have promised that someone should watch for him and give
+him instant notice if any new object should appear in sight.
+
+Such is my journal of what relates to this strange occurrence up to the
+present day.  The stranger has gradually improved in health but is very
+silent and appears uneasy when anyone except myself enters his cabin.
+Yet his manners are so conciliating and gentle that the sailors are all
+interested in him, although they have had very little communication
+with him.  For my own part, I begin to love him as a brother, and his
+constant and deep grief fills me with sympathy and compassion.  He must
+have been a noble creature in his better days, being even now in wreck
+so attractive and amiable.  I said in one of my letters, my dear
+Margaret, that I should find no friend on the wide ocean; yet I have
+found a man who, before his spirit had been broken by misery, I should
+have been happy to have possessed as the brother of my heart.
+
+I shall continue my journal concerning the stranger at intervals,
+should I have any fresh incidents to record.
+
+
+August 13th, 17--
+
+My affection for my guest increases every day.  He excites at once my
+admiration and my pity to an astonishing degree.  How can I see so
+noble a creature destroyed by misery without feeling the most poignant
+grief?  He is so gentle, yet so wise; his mind is so cultivated, and
+when he speaks, although his words are culled with the choicest art,
+yet they flow with rapidity and unparalleled eloquence.  He is now much
+recovered from his illness and is continually on the deck, apparently
+watching for the sledge that preceded his own.  Yet, although unhappy,
+he is not so utterly occupied by his own misery but that he interests
+himself deeply in the projects of others.  He has frequently conversed
+with me on mine, which I have communicated to him without disguise.  He
+entered attentively into all my arguments in favour of my eventual
+success and into every minute detail of the measures I had taken to
+secure it.  I was easily led by the sympathy which he evinced to use
+the language of my heart, to give utterance to the burning ardour of my
+soul and to say, with all the fervour that warmed me, how gladly I
+would sacrifice my fortune, my existence, my every hope, to the
+furtherance of my enterprise.  One man's life or death were but a small
+price to pay for the acquirement of the knowledge which I sought, for
+the dominion I should acquire and transmit over the elemental foes of
+our race.  As I spoke, a dark gloom spread over my listener's
+countenance.  At first I perceived that he tried to suppress his
+emotion; he placed his hands before his eyes, and my voice quivered and
+failed me as I beheld tears trickle fast from between his fingers; a
+groan burst from his heaving breast.  I paused; at length he spoke, in
+broken accents:  "Unhappy man!  Do you share my madness?  Have you
+drunk also of the intoxicating draught?  Hear me; let me reveal my
+tale, and you will dash the cup from your lips!"
+
+Such words, you may imagine, strongly excited my curiosity; but the
+paroxysm of grief that had seized the stranger overcame his weakened
+powers, and many hours of repose and tranquil conversation were
+necessary to restore his composure.  Having conquered the violence of
+his feelings, he appeared to despise himself for being the slave of
+passion; and quelling the dark tyranny of despair, he led me again to
+converse concerning myself personally.  He asked me the history of my
+earlier years.  The tale was quickly told, but it awakened various
+trains of reflection.  I spoke of my desire of finding a friend, of my
+thirst for a more intimate sympathy with a fellow mind than had ever
+fallen to my lot, and expressed my conviction that a man could boast of
+little happiness who did not enjoy this blessing.  "I agree with you,"
+replied the stranger; "we are unfashioned creatures, but half made up,
+if one wiser, better, dearer than ourselves--such a friend ought to
+be--do not lend his aid to perfectionate our weak and faulty natures. I
+once had a friend, the most noble of human creatures, and am entitled,
+therefore, to judge respecting friendship.  You have hope, and the
+world before you, and have no cause for despair.  But I--I have lost
+everything and cannot begin life anew."
+
+As he said this his countenance became expressive of a calm, settled
+grief that touched me to the heart.  But he was silent and presently
+retired to his cabin.
+
+Even broken in spirit as he is, no one can feel more deeply than he
+does the beauties of nature.  The starry sky, the sea, and every sight
+afforded by these wonderful regions seem still to have the power of
+elevating his soul from earth.  Such a man has a double existence:  he
+may suffer misery and be overwhelmed by disappointments, yet when he
+has retired into himself, he will be like a celestial spirit that has a
+halo around him, within whose circle no grief or folly ventures.
+
+Will you smile at the enthusiasm I express concerning this divine
+wanderer?  You would not if you saw him.  You have been tutored and
+refined by books and retirement from the world, and you are therefore
+somewhat fastidious; but this only renders you the more fit to
+appreciate the extraordinary merits of this wonderful man.  Sometimes I
+have endeavoured to discover what quality it is which he possesses that
+elevates him so immeasurably above any other person I ever knew.  I
+believe it to be an intuitive discernment, a quick but never-failing
+power of judgment, a penetration into the causes of things, unequalled
+for clearness and precision; add to this a facility of expression and a
+voice whose varied intonations are soul-subduing music.
+
+
+August 19, 17--
+
+Yesterday the stranger said to me, "You may easily perceive, Captain
+Walton, that I have suffered great and unparalleled misfortunes.  I had
+determined at one time that the memory of these evils should die with
+me, but you have won me to alter my determination.  You seek for
+knowledge and wisdom, as I once did; and I ardently hope that the
+gratification of your wishes may not be a serpent to sting you, as mine
+has been.  I do not know that the relation of my disasters will be
+useful to you; yet, when I reflect that you are pursuing the same
+course, exposing yourself to the same dangers which have rendered me
+what I am, I imagine that you may deduce an apt moral from my tale, one
+that may direct you if you succeed in your undertaking and console you
+in case of failure.  Prepare to hear of occurrences which are usually
+deemed marvellous.  Were we among the tamer scenes of nature I might
+fear to encounter your unbelief, perhaps your ridicule; but many things
+will appear possible in these wild and mysterious regions which would
+provoke the laughter of those unacquainted with the ever-varied powers
+of nature; nor can I doubt but that my tale conveys in its series
+internal evidence of the truth of the events of which it is composed."
+
+You may easily imagine that I was much gratified by the offered
+communication, yet I could not endure that he should renew his grief by
+a recital of his misfortunes.  I felt the greatest eagerness to hear
+the promised narrative, partly from curiosity and partly from a strong
+desire to ameliorate his fate if it were in my power.  I expressed
+these feelings in my answer.
+
+"I thank you," he replied, "for your sympathy, but it is useless; my
+fate is nearly fulfilled.  I wait but for one event, and then I shall
+repose in peace.  I understand your feeling," continued he, perceiving
+that I wished to interrupt him; "but you are mistaken, my friend, if
+thus you will allow me to name you; nothing can alter my destiny;
+listen to my history, and you will perceive how irrevocably it is
+determined."
+
+He then told me that he would commence his narrative the next day when
+I should be at leisure.  This promise drew from me the warmest thanks.
+I have resolved every night, when I am not imperatively occupied by my
+duties, to record, as nearly as possible in his own words, what he has
+related during the day.  If I should be engaged, I will at least make
+notes.  This manuscript will doubtless afford you the greatest
+pleasure; but to me, who know him, and who hear it from his own
+lips--with what interest and sympathy shall I read it in some future
+day!  Even now, as I commence my task, his full-toned voice swells in
+my ears; his lustrous eyes dwell on me with all their melancholy
+sweetness; I see his thin hand raised in animation, while the
+lineaments of his face are irradiated by the soul within.
+
+Strange and harrowing must be his story, frightful the storm which
+embraced the gallant vessel on its course and wrecked it--thus!
+
+
+
+Chapter 1
+
+I am by birth a Genevese, and my family is one of the most
+distinguished of that republic.  My ancestors had been for many years
+counsellors and syndics, and my father had filled several public
+situations with honour and reputation.  He was respected by all who
+knew him for his integrity and indefatigable attention to public
+business.  He passed his younger days perpetually occupied by the
+affairs of his country; a variety of circumstances had prevented his
+marrying early, nor was it until the decline of life that he became a
+husband and the father of a family.
+
+As the circumstances of his marriage illustrate his character, I cannot
+refrain from relating them.  One of his most intimate friends was a
+merchant who, from a flourishing state, fell, through numerous
+mischances, into poverty.  This man, whose name was Beaufort, was of a
+proud and unbending disposition and could not bear to live in poverty
+and oblivion in the same country where he had formerly been
+distinguished for his rank and magnificence.  Having paid his debts,
+therefore, in the most honourable manner, he retreated with his
+daughter to the town of Lucerne, where he lived unknown and in
+wretchedness.  My father loved Beaufort with the truest friendship and
+was deeply grieved by his retreat in these unfortunate circumstances.
+He bitterly deplored the false pride which led his friend to a conduct
+so little worthy of the affection that united them.  He lost no time in
+endeavouring to seek him out, with the hope of persuading him to begin
+the world again through his credit and assistance.
+
+Beaufort had taken effectual measures to conceal himself, and it was ten
+months before my father discovered his abode.  Overjoyed at this
+discovery, he hastened to the house, which was situated in a mean street
+near the Reuss.  But when he entered, misery and despair alone welcomed
+him.  Beaufort had saved but a very small sum of money from the wreck of
+his fortunes, but it was sufficient to provide him with sustenance for
+some months, and in the meantime he hoped to procure some respectable
+employment in a merchant's house.  The interval was, consequently, spent
+in inaction; his grief only became more deep and rankling when he had
+leisure for reflection, and at length it took so fast hold of his mind
+that at the end of three months he lay on a bed of sickness, incapable
+of any exertion.
+
+His daughter attended him with the greatest tenderness, but she saw
+with despair that their little fund was rapidly decreasing and that
+there was no other prospect of support.  But Caroline Beaufort
+possessed a mind of an uncommon mould, and her courage rose to support
+her in her adversity.  She procured plain work; she plaited straw and
+by various means contrived to earn a pittance scarcely sufficient to
+support life.
+
+Several months passed in this manner.  Her father grew worse; her time
+was more entirely occupied in attending him; her means of subsistence
+decreased; and in the tenth month her father died in her arms, leaving
+her an orphan and a beggar.  This last blow overcame her, and she knelt
+by Beaufort's coffin weeping bitterly, when my father entered the
+chamber.  He came like a protecting spirit to the poor girl, who
+committed herself to his care; and after the interment of his friend he
+conducted her to Geneva and placed her under the protection of a
+relation.  Two years after this event Caroline became his wife.
+
+There was a considerable difference between the ages of my parents, but
+this circumstance seemed to unite them only closer in bonds of devoted
+affection.  There was a sense of justice in my father's upright mind
+which rendered it necessary that he should approve highly to love
+strongly.  Perhaps during former years he had suffered from the
+late-discovered unworthiness of one beloved and so was disposed to set
+a greater value on tried worth.  There was a show of gratitude and
+worship in his attachment to my mother, differing wholly from the
+doting fondness of age, for it was inspired by reverence for her
+virtues and a desire to be the means of, in some degree, recompensing
+her for the sorrows she had endured, but which gave inexpressible grace
+to his behaviour to her.  Everything was made to yield to her wishes
+and her convenience.  He strove to shelter her, as a fair exotic is
+sheltered by the gardener, from every rougher wind and to surround her
+with all that could tend to excite pleasurable emotion in her soft and
+benevolent mind.  Her health, and even the tranquillity of her hitherto
+constant spirit, had been shaken by what she had gone through.  During
+the two years that had elapsed previous to their marriage my father had
+gradually relinquished all his public functions; and immediately after
+their union they sought the pleasant climate of Italy, and the change
+of scene and interest attendant on a tour through that land of wonders,
+as a restorative for her weakened frame.
+
+From Italy they visited Germany and France.  I, their eldest child, was
+born at Naples, and as an infant accompanied them in their rambles.  I
+remained for several years their only child.  Much as they were
+attached to each other, they seemed to draw inexhaustible stores of
+affection from a very mine of love to bestow them upon me.  My mother's
+tender caresses and my father's smile of benevolent pleasure while
+regarding me are my first recollections.  I was their plaything and
+their idol, and something better--their child, the innocent and
+helpless creature bestowed on them by heaven, whom to bring up to good,
+and whose future lot it was in their hands to direct to happiness or
+misery, according as they fulfilled their duties towards me.  With this
+deep consciousness of what they owed towards the being to which they
+had given life, added to the active spirit of tenderness that animated
+both, it may be imagined that while during every hour of my infant life
+I received a lesson of patience, of charity, and of self-control, I was
+so guided by a silken cord that all seemed but one train of enjoyment
+to me. For a long time I was their only care.  My mother had much
+desired to have a daughter, but I continued their single offspring.
+When I was about five years old, while making an excursion beyond the
+frontiers of Italy, they passed a week on the shores of the Lake of
+Como.  Their benevolent disposition often made them enter the cottages
+of the poor.  This, to my mother, was more than a duty; it was a
+necessity, a passion--remembering what she had suffered, and how she
+had been relieved--for her to act in her turn the guardian angel to the
+afflicted.  During one of their walks a poor cot in the foldings of a
+vale attracted their notice as being singularly disconsolate, while the
+number of half-clothed children gathered about it spoke of penury in
+its worst shape.  One day, when my father had gone by himself to Milan,
+my mother, accompanied by me, visited this abode.  She found a peasant
+and his wife, hard working, bent down by care and labour, distributing
+a scanty meal to five hungry babes.  Among these there was one which
+attracted my mother far above all the rest.  She appeared of a
+different stock.  The four others were dark-eyed, hardy little
+vagrants; this child was thin and very fair.  Her hair was the
+brightest living gold, and despite the poverty of her clothing, seemed
+to set a crown of distinction on her head.  Her brow was clear and
+ample, her blue eyes cloudless, and her lips and the moulding of her
+face so expressive of sensibility and sweetness that none could behold
+her without looking on her as of a distinct species, a being
+heaven-sent, and bearing a celestial stamp in all her features. The
+peasant woman, perceiving that my mother fixed eyes of wonder and
+admiration on this lovely girl, eagerly communicated her history.  She
+was not her child, but the daughter of a Milanese nobleman.  Her mother
+was a German and had died on giving her birth.  The infant had been
+placed with these good people to nurse:  they were better off then.
+They had not been long married, and their eldest child was but just
+born.  The father of their charge was one of those Italians nursed in
+the memory of the antique glory of Italy--one among the schiavi ognor
+frementi, who exerted himself to obtain the liberty of his country.  He
+became the victim of its weakness.  Whether he had died or still
+lingered in the dungeons of Austria was not known.  His property was
+confiscated; his child became an orphan and a beggar.  She continued
+with her foster parents and bloomed in their rude abode, fairer than a
+garden rose among dark-leaved brambles.  When my father returned from
+Milan, he found playing with me in the hall of our villa a child fairer
+than pictured cherub--a creature who seemed to shed radiance from her
+looks and whose form and motions were lighter than the chamois of the
+hills.  The apparition was soon explained.  With his permission my
+mother prevailed on her rustic guardians to yield their charge to her.
+They were fond of the sweet orphan.  Her presence had seemed a blessing
+to them, but it would be unfair to her to keep her in poverty and want
+when Providence afforded her such powerful protection.  They consulted
+their village priest, and the result was that Elizabeth Lavenza became
+the inmate of my parents' house--my more than sister--the beautiful and
+adored companion of all my occupations and my pleasures.
+
+Everyone loved Elizabeth.  The passionate and almost reverential
+attachment with which all regarded her became, while I shared it, my
+pride and my delight.  On the evening previous to her being brought to
+my home, my mother had said playfully, "I have a pretty present for my
+Victor--tomorrow he shall have it."  And when, on the morrow, she
+presented Elizabeth to me as her promised gift, I, with childish
+seriousness, interpreted her words literally and looked upon Elizabeth
+as mine--mine to protect, love, and cherish.  All praises bestowed on
+her I received as made to a possession of my own.  We called each other
+familiarly by the name of cousin.  No word, no expression could body
+forth the kind of relation in which she stood to me--my more than
+sister, since till death she was to be mine only.
+
+
+
+Chapter 2
+
+We were brought up together; there was not quite a year difference in
+our ages.  I need not say that we were strangers to any species of
+disunion or dispute.  Harmony was the soul of our companionship, and
+the diversity and contrast that subsisted in our characters drew us
+nearer together.  Elizabeth was of a calmer and more concentrated
+disposition; but, with all my ardour, I was capable of a more intense
+application and was more deeply smitten with the thirst for knowledge.
+She busied herself with following the aerial creations of the poets;
+and in the majestic and wondrous scenes which surrounded our Swiss home
+--the sublime shapes of the mountains, the changes of the seasons,
+tempest and calm, the silence of winter, and the life and turbulence of
+our Alpine summers--she found ample scope for admiration and delight.
+While my companion contemplated with a serious and satisfied spirit the
+magnificent appearances of things, I delighted in investigating their
+causes.  The world was to me a secret which I desired to divine.
+Curiosity, earnest research to learn the hidden laws of nature,
+gladness akin to rapture, as they were unfolded to me, are among the
+earliest sensations I can remember.
+
+On the birth of a second son, my junior by seven years, my parents gave
+up entirely their wandering life and fixed themselves in their native
+country.  We possessed a house in Geneva, and a campagne on Belrive,
+the eastern shore of the lake, at the distance of rather more than a
+league from the city.  We resided principally in the latter, and the
+lives of my parents were passed in considerable seclusion.  It was my
+temper to avoid a crowd and to attach myself fervently to a few.  I was
+indifferent, therefore, to my school-fellows in general; but I united
+myself in the bonds of the closest friendship to one among them.  Henry
+Clerval was the son of a merchant of Geneva.  He was a boy of singular
+talent and fancy.  He loved enterprise, hardship, and even danger for
+its own sake.  He was deeply read in books of chivalry and romance.  He
+composed heroic songs and began to write many a tale of enchantment and
+knightly adventure.  He tried to make us act plays and to enter into
+masquerades, in which the characters were drawn from the heroes of
+Roncesvalles, of the Round Table of King Arthur, and the chivalrous
+train who shed their blood to redeem the holy sepulchre from the hands
+of the infidels.
+
+No human being could have passed a happier childhood than myself.  My
+parents were possessed by the very spirit of kindness and indulgence.
+We felt that they were not the tyrants to rule our lot according to
+their caprice, but the agents and creators of all the many delights
+which we enjoyed.  When I mingled with other families I distinctly
+discerned how peculiarly fortunate my lot was, and gratitude assisted
+the development of filial love.
+
+My temper was sometimes violent, and my passions vehement; but by some
+law in my temperature they were turned not towards childish pursuits
+but to an eager desire to learn, and not to learn all things
+indiscriminately.  I confess that neither the structure of languages,
+nor the code of governments, nor the politics of various states
+possessed attractions for me.  It was the secrets of heaven and earth
+that I desired to learn; and whether it was the outward substance of
+things or the inner spirit of nature and the mysterious soul of man
+that occupied me, still my inquiries were directed to the metaphysical,
+or in its highest sense, the physical secrets of the world.
+
+Meanwhile Clerval occupied himself, so to speak, with the moral
+relations of things.  The busy stage of life, the virtues of heroes,
+and the actions of men were his theme; and his hope and his dream was
+to become one among those whose names are recorded in story as the
+gallant and adventurous benefactors of our species.  The saintly soul
+of Elizabeth shone like a shrine-dedicated lamp in our peaceful home.
+Her sympathy was ours; her smile, her soft voice, the sweet glance of
+her celestial eyes, were ever there to bless and animate us.  She was
+the living spirit of love to soften and attract; I might have become
+sullen in my study, rough through the ardour of my nature, but that
+she was there to subdue me to a semblance of her own gentleness.  And
+Clerval--could aught ill entrench on the noble spirit of Clerval?  Yet
+he might not have been so perfectly humane, so thoughtful in his
+generosity, so full of kindness and tenderness amidst his passion for
+adventurous exploit, had she not unfolded to him the real loveliness of
+beneficence and made the doing good the end and aim of his soaring
+ambition.
+
+I feel exquisite pleasure in dwelling on the recollections of
+childhood, before misfortune had tainted my mind and changed its bright
+visions of extensive usefulness into gloomy and narrow reflections upon
+self.  Besides, in drawing the picture of my early days, I also record
+those events which led, by insensible steps, to my after tale of
+misery, for when I would account to myself for the birth of that
+passion which afterwards ruled my destiny I find it arise, like a
+mountain river, from ignoble and almost forgotten sources; but,
+swelling as it proceeded, it became the torrent which, in its course,
+has swept away all my hopes and joys.  Natural philosophy is the genius
+that has regulated my fate; I desire, therefore, in this narration, to
+state those facts which led to my predilection for that science.  When
+I was thirteen years of age we all went on a party of pleasure to the
+baths near Thonon; the inclemency of the weather obliged us to remain a
+day confined to the inn.  In this house I chanced to find a volume of
+the works of Cornelius Agrippa.  I opened it with apathy; the theory
+which he attempts to demonstrate and the wonderful facts which he
+relates soon changed this feeling into enthusiasm.  A new light seemed
+to dawn upon my mind, and bounding with joy, I communicated my
+discovery to my father.  My father looked carelessly at the title page
+of my book and said, "Ah!  Cornelius Agrippa!  My dear Victor, do not
+waste your time upon this; it is sad trash."
+
+If, instead of this remark, my father had taken the pains to explain to
+me that the principles of Agrippa had been entirely exploded and that a
+modern system of science had been introduced which possessed much
+greater powers than the ancient, because the powers of the latter were
+chimerical, while those of the former were real and practical, under
+such circumstances I should certainly have thrown Agrippa aside and
+have contented my imagination, warmed as it was, by returning with
+greater ardour to my former studies.  It is even possible that the
+train of my ideas would never have received the fatal impulse that led
+to my ruin.  But the cursory glance my father had taken of my volume by
+no means assured me that he was acquainted with its contents, and I
+continued to read with the greatest avidity.  When I returned home my
+first care was to procure the whole works of this author, and
+afterwards of Paracelsus and Albertus Magnus.  I read and studied the
+wild fancies of these writers with delight; they appeared to me
+treasures known to few besides myself.  I have described myself as
+always having been imbued with a fervent longing to penetrate the
+secrets of nature.  In spite of the intense labour and wonderful
+discoveries of modern philosophers, I always came from my studies
+discontented and unsatisfied.  Sir Isaac Newton is said to have avowed
+that he felt like a child picking up shells beside the great and
+unexplored ocean of truth.  Those of his successors in each branch of
+natural philosophy with whom I was acquainted appeared even to my boy's
+apprehensions as tyros engaged in the same pursuit.
+
+The untaught peasant beheld the elements around him and was acquainted
+with their practical uses.  The most learned philosopher knew little
+more.  He had partially unveiled the face of Nature, but her immortal
+lineaments were still a wonder and a mystery.  He might dissect,
+anatomize, and give names; but, not to speak of a final cause, causes
+in their secondary and tertiary grades were utterly unknown to him.  I
+had gazed upon the fortifications and impediments that seemed to keep
+human beings from entering the citadel of nature, and rashly and
+ignorantly I had repined.
+
+But here were books, and here were men who had penetrated deeper and
+knew more.  I took their word for all that they averred, and I became
+their disciple.  It may appear strange that such should arise in the
+eighteenth century; but while I followed the routine of education in
+the schools of Geneva, I was, to a great degree, self-taught with
+regard to my favourite studies.  My father was not scientific, and I
+was left to struggle with a child's blindness, added to a student's
+thirst for knowledge.  Under the guidance of my new preceptors I
+entered with the greatest diligence into the search of the
+philosopher's stone and the elixir of life; but the latter soon
+obtained my undivided attention.  Wealth was an inferior object, but
+what glory would attend the discovery if I could banish disease from
+the human frame and render man invulnerable to any but a violent death!
+Nor were these my only visions.  The raising of ghosts or devils was a
+promise liberally accorded by my favourite authors, the fulfilment of
+which I most eagerly sought; and if my incantations were always
+unsuccessful, I attributed the failure rather to my own inexperience
+and mistake than to a want of skill or fidelity in my instructors.  And
+thus for a time I was occupied by exploded systems, mingling, like an
+unadept, a thousand contradictory theories and floundering desperately
+in a very slough of multifarious knowledge, guided by an ardent
+imagination and childish reasoning, till an accident again changed the
+current of my ideas.  When I was about fifteen years old we had retired
+to our house near Belrive, when we witnessed a most violent and
+terrible thunderstorm.  It advanced from behind the mountains of Jura,
+and the thunder burst at once with frightful loudness from various
+quarters of the heavens.  I remained, while the storm lasted, watching
+its progress with curiosity and delight.  As I stood at the door, on a
+sudden I beheld a stream of fire issue from an old and beautiful oak
+which stood about twenty yards from our house; and so soon as the
+dazzling light vanished, the oak had disappeared, and nothing remained
+but a blasted stump.  When we visited it the next morning, we found the
+tree shattered in a singular manner.  It was not splintered by the
+shock, but entirely reduced to thin ribbons of wood.  I never beheld
+anything so utterly destroyed.
+
+Before this I was not unacquainted with the more obvious laws of
+electricity.  On this occasion a man of great research in natural
+philosophy was with us, and excited by this catastrophe, he entered on
+the explanation of a theory which he had formed on the subject of
+electricity and galvanism, which was at once new and astonishing to me.
+All that he said threw greatly into the shade Cornelius Agrippa,
+Albertus Magnus, and Paracelsus, the lords of my imagination; but by
+some fatality the overthrow of these men disinclined me to pursue my
+accustomed studies.  It seemed to me as if nothing would or could ever
+be known.  All that had so long engaged my attention suddenly grew
+despicable.  By one of those caprices of the mind which we are perhaps
+most subject to in early youth, I at once gave up my former
+occupations, set down natural history and all its progeny as a deformed
+and abortive creation, and entertained the greatest disdain for a
+would-be science which could never even step within the threshold of
+real knowledge.  In this mood of mind I betook myself to the
+mathematics and the branches of study appertaining to that science as
+being built upon secure foundations, and so worthy of my consideration.
+
+Thus strangely are our souls constructed, and by such slight ligaments
+are we bound to prosperity or ruin.  When I look back, it seems to me
+as if this almost miraculous change of inclination and will was the
+immediate suggestion of the guardian angel of my life--the last effort
+made by the spirit of preservation to avert the storm that was even
+then hanging in the stars and ready to envelop me.  Her victory was
+announced by an unusual tranquillity and gladness of soul which
+followed the relinquishing of my ancient and latterly tormenting
+studies.  It was thus that I was to be taught to associate evil with
+their prosecution, happiness with their disregard.
+
+It was a strong effort of the spirit of good, but it was ineffectual.
+Destiny was too potent, and her immutable laws had decreed my utter and
+terrible destruction.
+
+
+
+Chapter 3
+
+When I had attained the age of seventeen my parents resolved that I
+should become a student at the university of Ingolstadt.  I had
+hitherto attended the schools of Geneva, but my father thought it
+necessary for the completion of my education that I should be made
+acquainted with other customs than those of my native country.  My
+departure was therefore fixed at an early date, but before the day
+resolved upon could arrive, the first misfortune of my life
+occurred--an omen, as it were, of my future misery.  Elizabeth had
+caught the scarlet fever; her illness was severe, and she was in the
+greatest danger.  During her illness many arguments had been urged to
+persuade my mother to refrain from attending upon her.  She had at
+first yielded to our entreaties, but when she heard that the life of
+her favourite was menaced, she could no longer control her anxiety. She
+attended her sickbed; her watchful attentions triumphed over the
+malignity of the distemper--Elizabeth was saved, but the consequences
+of this imprudence were fatal to her preserver.  On the third day my
+mother sickened; her fever was accompanied by the most alarming
+symptoms, and the looks of her medical attendants prognosticated the
+worst event.  On her deathbed the fortitude and benignity of this best
+of women did not desert her.  She joined the hands of Elizabeth and
+myself.  "My children," she said, "my firmest hopes of future happiness
+were placed on the prospect of your union.  This expectation will now
+be the consolation of your father.  Elizabeth, my love, you must supply
+my place to my younger children.  Alas!  I regret that I am taken from
+you; and, happy and beloved as I have been, is it not hard to quit you
+all?  But these are not thoughts befitting me; I will endeavour to
+resign myself cheerfully to death and will indulge a hope of meeting
+you in another world."
+
+She died calmly, and her countenance expressed affection even in death.
+I need not describe the feelings of those whose dearest ties are rent
+by that most irreparable evil, the void that presents itself to the
+soul, and the despair that is exhibited on the countenance.  It is so
+long before the mind can persuade itself that she whom we saw every day
+and whose very existence appeared a part of our own can have departed
+forever--that the brightness of a beloved eye can have been
+extinguished and the sound of a voice so familiar and dear to the ear
+can be hushed, never more to be heard.  These are the reflections of
+the first days; but when the lapse of time proves the reality of the
+evil, then the actual bitterness of grief commences.  Yet from whom has
+not that rude hand rent away some dear connection?  And why should I
+describe a sorrow which all have felt, and must feel?  The time at
+length arrives when grief is rather an indulgence than a necessity; and
+the smile that plays upon the lips, although it may be deemed a
+sacrilege, is not banished.  My mother was dead, but we had still
+duties which we ought to perform; we must continue our course with the
+rest and learn to think ourselves fortunate whilst one remains whom the
+spoiler has not seized.
+
+My departure for Ingolstadt, which had been deferred by these events,
+was now again determined upon.  I obtained from my father a respite of
+some weeks.  It appeared to me sacrilege so soon to leave the repose,
+akin to death, of the house of mourning and to rush into the thick of
+life.  I was new to sorrow, but it did not the less alarm me.  I was
+unwilling to quit the sight of those that remained to me, and above
+all, I desired to see my sweet Elizabeth in some degree consoled.
+
+She indeed veiled her grief and strove to act the comforter to us all.
+She looked steadily on life and assumed its duties with courage and
+zeal.  She devoted herself to those whom she had been taught to call
+her uncle and cousins.  Never was she so enchanting as at this time,
+when she recalled the sunshine of her smiles and spent them upon us.
+She forgot even her own regret in her endeavours to make us forget.
+
+The day of my departure at length arrived.  Clerval spent the last
+evening with us.  He had endeavoured to persuade his father to permit
+him to accompany me and to become my fellow student, but in vain.  His
+father was a narrow-minded trader and saw idleness and ruin in the
+aspirations and ambition of his son.  Henry deeply felt the misfortune
+of being debarred from a liberal education.  He said little, but when
+he spoke I read in his kindling eye and in his animated glance a
+restrained but firm resolve not to be chained to the miserable details
+of commerce.
+
+We sat late.  We could not tear ourselves away from each other nor
+persuade ourselves to say the word "Farewell!"  It was said, and we
+retired under the pretence of seeking repose, each fancying that the
+other was deceived; but when at morning's dawn I descended to the
+carriage which was to convey me away, they were all there--my father
+again to bless me, Clerval to press my hand once more, my Elizabeth to
+renew her entreaties that I would write often and to bestow the last
+feminine attentions on her playmate and friend.
+
+I threw myself into the chaise that was to convey me away and indulged
+in the most melancholy reflections.  I, who had ever been surrounded by
+amiable companions, continually engaged in endeavouring to bestow
+mutual pleasure--I was now alone.  In the university whither I was
+going I must form my own friends and be my own protector.  My life had
+hitherto been remarkably secluded and domestic, and this had given me
+invincible repugnance to new countenances.  I loved my brothers,
+Elizabeth, and Clerval; these were "old familiar faces," but I believed
+myself totally unfitted for the company of strangers.  Such were my
+reflections as I commenced my journey; but as I proceeded, my spirits
+and hopes rose.  I ardently desired the acquisition of knowledge.  I
+had often, when at home, thought it hard to remain during my youth
+cooped up in one place and had longed to enter the world and take my
+station among other human beings.  Now my desires were complied with,
+and it would, indeed, have been folly to repent.
+
+I had sufficient leisure for these and many other reflections during my
+journey to Ingolstadt, which was long and fatiguing.  At length the
+high white steeple of the town met my eyes.  I alighted and was
+conducted to my solitary apartment to spend the evening as I pleased.
+
+The next morning I delivered my letters of introduction and paid a
+visit to some of the principal professors.  Chance--or rather the evil
+influence, the Angel of Destruction, which asserted omnipotent sway
+over me from the moment I turned my reluctant steps from my father's
+door--led me first to M. Krempe, professor of natural philosophy.  He
+was an uncouth man, but deeply imbued in the secrets of his science. He
+asked me several questions concerning my progress in the different
+branches of science appertaining to natural philosophy.  I replied
+carelessly, and partly in contempt, mentioned the names of my
+alchemists as the principal authors I had studied.  The professor
+stared.  "Have you," he said, "really spent your time in studying such
+nonsense?"
+
+I replied in the affirmative.  "Every minute," continued M. Krempe with
+warmth, "every instant that you have wasted on those books is utterly
+and entirely lost.  You have burdened your memory with exploded systems
+and useless names.  Good God!  In what desert land have you lived,
+where no one was kind enough to inform you that these fancies which you
+have so greedily imbibed are a thousand years old and as musty as they
+are ancient?  I little expected, in this enlightened and scientific
+age, to find a disciple of Albertus Magnus and Paracelsus.  My dear
+sir, you must begin your studies entirely anew."
+
+So saying, he stepped aside and wrote down a list of several books
+treating of natural philosophy which he desired me to procure, and
+dismissed me after mentioning that in the beginning of the following
+week he intended to commence a course of lectures upon natural
+philosophy in its general relations, and that M. Waldman, a fellow
+professor, would lecture upon chemistry the alternate days that he
+omitted.
+
+I returned home not disappointed, for I have said that I had long
+considered those authors useless whom the professor reprobated; but I
+returned not at all the more inclined to recur to these studies in any
+shape.  M. Krempe was a little squat man with a gruff voice and a
+repulsive countenance; the teacher, therefore, did not prepossess me in
+favour of his pursuits.  In rather a too philosophical and connected a
+strain, perhaps, I have given an account of the conclusions I had come
+to concerning them in my early years.  As a child I had not been
+content with the results promised by the modern professors of natural
+science.  With a confusion of ideas only to be accounted for by my
+extreme youth and my want of a guide on such matters, I had retrod the
+steps of knowledge along the paths of time and exchanged the
+discoveries of recent inquirers for the dreams of forgotten alchemists.
+Besides, I had a contempt for the uses of modern natural philosophy.
+It was very different when the masters of the science sought
+immortality and power; such views, although futile, were grand; but now
+the scene was changed.  The ambition of the inquirer seemed to limit
+itself to the annihilation of those visions on which my interest in
+science was chiefly founded.  I was required to exchange chimeras of
+boundless grandeur for realities of little worth.
+
+Such were my reflections during the first two or three days of my
+residence at Ingolstadt, which were chiefly spent in becoming
+acquainted with the localities and the principal residents in my new
+abode.  But as the ensuing week commenced, I thought of the information
+which M. Krempe had given me concerning the lectures.  And although I
+could not consent to go and hear that little conceited fellow deliver
+sentences out of a pulpit, I recollected what he had said of M.
+Waldman, whom I had never seen, as he had hitherto been out of town.
+
+Partly from curiosity and partly from idleness, I went into the
+lecturing room, which M. Waldman entered shortly after.  This professor
+was very unlike his colleague.  He appeared about fifty years of age,
+but with an aspect expressive of the greatest benevolence; a few grey
+hairs covered his temples, but those at the back of his head were
+nearly black.  His person was short but remarkably erect and his voice
+the sweetest I had ever heard.  He began his lecture by a
+recapitulation of the history of chemistry and the various improvements
+made by different men of learning, pronouncing with fervour the names
+of the most distinguished discoverers.  He then took a cursory view of
+the present state of the science and explained many of its elementary
+terms.  After having made a few preparatory experiments, he concluded
+with a panegyric upon modern chemistry, the terms of which I shall
+never forget:  "The ancient teachers of this science," said he,
+"promised impossibilities and performed nothing.  The modern masters
+promise very little; they know that metals cannot be transmuted and
+that the elixir of life is a chimera but these philosophers, whose
+hands seem only made to dabble in dirt, and their eyes to pore over the
+microscope or crucible, have indeed performed miracles.  They penetrate
+into the recesses of nature and show how she works in her
+hiding-places.  They ascend into the heavens; they have discovered how
+the blood circulates, and the nature of the air we breathe.  They have
+acquired new and almost unlimited powers; they can command the thunders
+of heaven, mimic the earthquake, and even mock the invisible world with
+its own shadows."
+
+Such were the professor's words--rather let me say such the words of
+the fate--enounced to destroy me.  As he went on I felt as if my soul
+were grappling with a palpable enemy; one by one the various keys were
+touched which formed the mechanism of my being; chord after chord was
+sounded, and soon my mind was filled with one thought, one conception,
+one purpose.  So much has been done, exclaimed the soul of
+Frankenstein--more, far more, will I achieve; treading in the steps
+already marked, I will pioneer a new way, explore unknown powers, and
+unfold to the world the deepest mysteries of creation.
+
+I closed not my eyes that night.  My internal being was in a state of
+insurrection and turmoil; I felt that order would thence arise, but I
+had no power to produce it.  By degrees, after the morning's dawn,
+sleep came.  I awoke, and my yesternight's thoughts were as a dream.
+There only remained a resolution to return to my ancient studies and to
+devote myself to a science for which I believed myself to possess a
+natural talent.  On the same day I paid M. Waldman a visit.  His
+manners in private were even more mild and attractive than in public,
+for there was a certain dignity in his mien during his lecture which in
+his own house was replaced by the greatest affability and kindness.  I
+gave him pretty nearly the same account of my former pursuits as I had
+given to his fellow professor.  He heard with attention the little
+narration concerning my studies and smiled at the names of Cornelius
+Agrippa and Paracelsus, but without the contempt that M. Krempe had
+exhibited. He said that "These were men to whose indefatigable zeal
+modern philosophers were indebted for most of the foundations of their
+knowledge.  They had left to us, as an easier task, to give new names
+and arrange in connected classifications the facts which they in a
+great degree had been the instruments of bringing to light.  The
+labours of men of genius, however erroneously directed, scarcely ever
+fail in ultimately turning to the solid advantage of mankind."  I
+listened to his statement, which was delivered without any presumption
+or affectation, and then added that his lecture had removed my
+prejudices against modern chemists; I expressed myself in measured
+terms, with the modesty and deference due from a youth to his
+instructor, without letting escape (inexperience in life would have
+made me ashamed) any of the enthusiasm which stimulated my intended
+labours.  I requested his advice concerning the books I ought to
+procure.
+
+"I am happy," said M. Waldman, "to have gained a disciple; and if your
+application equals your ability, I have no doubt of your success.
+Chemistry is that branch of natural philosophy in which the greatest
+improvements have been and may be made; it is on that account that I
+have made it my peculiar study; but at the same time, I have not
+neglected the other branches of science.  A man would make but a very
+sorry chemist if he attended to that department of human knowledge
+alone.  If your wish is to become really a man of science and not
+merely a petty experimentalist, I should advise you to apply to every
+branch of natural philosophy, including mathematics."  He then took me
+into his laboratory and explained to me the uses of his various
+machines, instructing me as to what I ought to procure and promising me
+the use of his own when I should have advanced far enough in the
+science not to derange their mechanism.  He also gave me the list of
+books which I had requested, and I took my leave.
+
+Thus ended a day memorable to me; it decided my future destiny.
+
+
+
+Chapter 4
+
+From this day natural philosophy, and particularly chemistry, in the
+most comprehensive sense of the term, became nearly my sole occupation.
+I read with ardour those works, so full of genius and discrimination,
+which modern inquirers have written on these subjects.  I attended the
+lectures and cultivated the acquaintance of the men of science of the
+university, and I found even in M. Krempe a great deal of sound sense
+and real information, combined, it is true, with a repulsive
+physiognomy and manners, but not on that account the less valuable.  In
+M. Waldman I found a true friend.  His gentleness was never tinged by
+dogmatism, and his instructions were given with an air of frankness and
+good nature that banished every idea of pedantry.  In a thousand ways
+he smoothed for me the path of knowledge and made the most abstruse
+inquiries clear and facile to my apprehension.  My application was at
+first fluctuating and uncertain; it gained strength as I proceeded and
+soon became so ardent and eager that the stars often disappeared in the
+light of morning whilst I was yet engaged in my laboratory.
+
+As I applied so closely, it may be easily conceived that my progress
+was rapid.  My ardour was indeed the astonishment of the students, and
+my proficiency that of the masters.  Professor Krempe often asked me,
+with a sly smile, how Cornelius Agrippa went on, whilst M. Waldman
+expressed the most heartfelt exultation in my progress.  Two years
+passed in this manner, during which I paid no visit to Geneva, but was
+engaged, heart and soul, in the pursuit of some discoveries which I
+hoped to make.  None but those who have experienced them can conceive
+of the enticements of science.  In other studies you go as far as
+others have gone before you, and there is nothing more to know; but in
+a scientific pursuit there is continual food for discovery and wonder.
+A mind of moderate capacity which closely pursues one study must
+infallibly arrive at great proficiency in that study; and I, who
+continually sought the attainment of one object of pursuit and was
+solely wrapped up in this, improved so rapidly that at the end of two
+years I made some discoveries in the improvement of some chemical
+instruments, which procured me great esteem and admiration at the
+university.  When I had arrived at this point and had become as well
+acquainted with the theory and practice of natural philosophy as
+depended on the lessons of any of the professors at Ingolstadt, my
+residence there being no longer conducive to my improvements, I thought
+of returning to my friends and my native town, when an incident
+happened that protracted my stay.
+
+One of the phenomena which had peculiarly attracted my attention was
+the structure of the human frame, and, indeed, any animal endued with
+life.  Whence, I often asked myself, did the principle of life proceed?
+It was a bold question, and one which has ever been considered as a
+mystery; yet with how many things are we upon the brink of becoming
+acquainted, if cowardice or carelessness did not restrain our
+inquiries.  I revolved these circumstances in my mind and determined
+thenceforth to apply myself more particularly to those branches of
+natural philosophy which relate to physiology.  Unless I had been
+animated by an almost supernatural enthusiasm, my application to this
+study would have been irksome and almost intolerable.  To examine the
+causes of life, we must first have recourse to death.  I became
+acquainted with the science of anatomy, but this was not sufficient; I
+must also observe the natural decay and corruption of the human body.
+In my education my father had taken the greatest precautions that my
+mind should be impressed with no supernatural horrors.  I do not ever
+remember to have trembled at a tale of superstition or to have feared
+the apparition of a spirit.  Darkness had no effect upon my fancy, and
+a churchyard was to me merely the receptacle of bodies deprived of
+life, which, from being the seat of beauty and strength, had become
+food for the worm.  Now I was led to examine the cause and progress of
+this decay and forced to spend days and nights in vaults and
+charnel-houses.  My attention was fixed upon every object the most
+insupportable to the delicacy of the human feelings.  I saw how the
+fine form of man was degraded and wasted; I beheld the corruption of
+death succeed to the blooming cheek of life; I saw how the worm
+inherited the wonders of the eye and brain.  I paused, examining and
+analysing all the minutiae of causation, as exemplified in the change
+from life to death, and death to life, until from the midst of this
+darkness a sudden light broke in upon me--a light so brilliant and
+wondrous, yet so simple, that while I became dizzy with the immensity
+of the prospect which it illustrated, I was surprised that among so
+many men of genius who had directed their inquiries towards the same
+science, that I alone should be reserved to discover so astonishing a
+secret.
+
+Remember, I am not recording the vision of a madman.  The sun does not
+more certainly shine in the heavens than that which I now affirm is
+true.  Some miracle might have produced it, yet the stages of the
+discovery were distinct and probable.  After days and nights of
+incredible labour and fatigue, I succeeded in discovering the cause of
+generation and life; nay, more, I became myself capable of bestowing
+animation upon lifeless matter.
+
+The astonishment which I had at first experienced on this discovery
+soon gave place to delight and rapture.  After so much time spent in
+painful labour, to arrive at once at the summit of my desires was the
+most gratifying consummation of my toils.  But this discovery was so
+great and overwhelming that all the steps by which I had been
+progressively led to it were obliterated, and I beheld only the result.
+What had been the study and desire of the wisest men since the creation
+of the world was now within my grasp.  Not that, like a magic scene, it
+all opened upon me at once:  the information I had obtained was of a
+nature rather to direct my endeavours so soon as I should point them
+towards the object of my search than to exhibit that object already
+accomplished.  I was like the Arabian who had been buried with the dead
+and found a passage to life, aided only by one glimmering and seemingly
+ineffectual light.
+
+I see by your eagerness and the wonder and hope which your eyes
+express, my friend, that you expect to be informed of the secret with
+which I am acquainted; that cannot be; listen patiently until the end
+of my story, and you will easily perceive why I am reserved upon that
+subject.  I will not lead you on, unguarded and ardent as I then was,
+to your destruction and infallible misery.  Learn from me, if not by my
+precepts, at least by my example, how dangerous is the acquirement of
+knowledge and how much happier that man is who believes his native town
+to be the world, than he who aspires to become greater than his nature
+will allow.
+
+When I found so astonishing a power placed within my hands, I hesitated
+a long time concerning the manner in which I should employ it.
+Although I possessed the capacity of bestowing animation, yet to
+prepare a frame for the reception of it, with all its intricacies of
+fibres, muscles, and veins, still remained a work of inconceivable
+difficulty and labour.  I doubted at first whether I should attempt the
+creation of a being like myself, or one of simpler organization; but my
+imagination was too much exalted by my first success to permit me to
+doubt of my ability to give life to an animal as complex and wonderful
+as man.  The materials at present within my command hardly appeared
+adequate to so arduous an undertaking, but I doubted not that I should
+ultimately succeed.  I prepared myself for a multitude of reverses; my
+operations might be incessantly baffled, and at last my work be
+imperfect, yet when I considered the improvement which every day takes
+place in science and mechanics, I was encouraged to hope my present
+attempts would at least lay the foundations of future success.  Nor
+could I consider the magnitude and complexity of my plan as any
+argument of its impracticability.  It was with these feelings that I
+began the creation of a human being.  As the minuteness of the parts
+formed a great hindrance to my speed, I resolved, contrary to my first
+intention, to make the being of a gigantic stature, that is to say,
+about eight feet in height, and proportionably large.  After having
+formed this determination and having spent some months in successfully
+collecting and arranging my materials, I began.
+
+No one can conceive the variety of feelings which bore me onwards, like
+a hurricane, in the first enthusiasm of success.  Life and death
+appeared to me ideal bounds, which I should first break through, and
+pour a torrent of light into our dark world.  A new species would bless
+me as its creator and source; many happy and excellent natures would
+owe their being to me.  No father could claim the gratitude of his
+child so completely as I should deserve theirs.  Pursuing these
+reflections, I thought that if I could bestow animation upon lifeless
+matter, I might in process of time (although I now found it impossible)
+renew life where death had apparently devoted the body to corruption.
+
+These thoughts supported my spirits, while I pursued my undertaking
+with unremitting ardour.  My cheek had grown pale with study, and my
+person had become emaciated with confinement.  Sometimes, on the very
+brink of certainty, I failed; yet still I clung to the hope which the
+next day or the next hour might realize.  One secret which I alone
+possessed was the hope to which I had dedicated myself; and the moon
+gazed on my midnight labours, while, with unrelaxed and breathless
+eagerness, I pursued nature to her hiding-places.  Who shall conceive
+the horrors of my secret toil as I dabbled among the unhallowed damps
+of the grave or tortured the living animal to animate the lifeless
+clay?  My limbs now tremble, and my eyes swim with the remembrance; but
+then a resistless and almost frantic impulse urged me forward; I seemed
+to have lost all soul or sensation but for this one pursuit.  It was
+indeed but a passing trance, that only made me feel with renewed
+acuteness so soon as, the unnatural stimulus ceasing to operate, I had
+returned to my old habits.  I collected bones from charnel-houses and
+disturbed, with profane fingers, the tremendous secrets of the human
+frame.  In a solitary chamber, or rather cell, at the top of the house,
+and separated from all the other apartments by a gallery and staircase,
+I kept my workshop of filthy creation; my eyeballs were starting from
+their sockets in attending to the details of my employment.  The
+dissecting room and the slaughter-house furnished many of my materials;
+and often did my human nature turn with loathing from my occupation,
+whilst, still urged on by an eagerness which perpetually increased, I
+brought my work near to a conclusion.
+
+The summer months passed while I was thus engaged, heart and soul, in
+one pursuit.  It was a most beautiful season; never did the fields
+bestow a more plentiful harvest or the vines yield a more luxuriant
+vintage, but my eyes were insensible to the charms of nature.  And the
+same feelings which made me neglect the scenes around me caused me also
+to forget those friends who were so many miles absent, and whom I had
+not seen for so long a time.  I knew my silence disquieted them, and I
+well remembered the words of my father:  "I know that while you are
+pleased with yourself you will think of us with affection, and we shall
+hear regularly from you.  You must pardon me if I regard any
+interruption in your correspondence as a proof that your other duties
+are equally neglected."
+
+I knew well therefore what would be my father's feelings, but I could
+not tear my thoughts from my employment, loathsome in itself, but which
+had taken an irresistible hold of my imagination.  I wished, as it
+were, to procrastinate all that related to my feelings of affection
+until the great object, which swallowed up every habit of my nature,
+should be completed.
+
+I then thought that my father would be unjust if he ascribed my neglect
+to vice or faultiness on my part, but I am now convinced that he was
+justified in conceiving that I should not be altogether free from
+blame.  A human being in perfection ought always to preserve a calm and
+peaceful mind and never to allow passion or a transitory desire to
+disturb his tranquillity.  I do not think that the pursuit of knowledge
+is an exception to this rule.  If the study to which you apply yourself
+has a tendency to weaken your affections and to destroy your taste for
+those simple pleasures in which no alloy can possibly mix, then that
+study is certainly unlawful, that is to say, not befitting the human
+mind.  If this rule were always observed; if no man allowed any pursuit
+whatsoever to interfere with the tranquillity of his domestic
+affections, Greece had not been enslaved, Caesar would have spared his
+country, America would have been discovered more gradually, and the
+empires of Mexico and Peru had not been destroyed.
+
+But I forget that I am moralizing in the most interesting part of my
+tale, and your looks remind me to proceed.  My father made no reproach
+in his letters and only took notice of my silence by inquiring into my
+occupations more particularly than before.  Winter, spring, and summer
+passed away during my labours; but I did not watch the blossom or the
+expanding leaves--sights which before always yielded me supreme
+delight--so deeply was I engrossed in my occupation.  The leaves of
+that year had withered before my work drew near to a close, and now
+every day showed me more plainly how well I had succeeded.  But my
+enthusiasm was checked by my anxiety, and I appeared rather like one
+doomed by slavery to toil in the mines, or any other unwholesome trade
+than an artist occupied by his favourite employment.  Every night I was
+oppressed by a slow fever, and I became nervous to a most painful
+degree; the fall of a leaf startled me, and I shunned my fellow
+creatures as if I had been guilty of a crime.  Sometimes I grew alarmed
+at the wreck I perceived that I had become; the energy of my purpose
+alone sustained me:  my labours would soon end, and I believed that
+exercise and amusement would then drive away incipient disease; and I
+promised myself both of these when my creation should be complete.
+
+
+
+Chapter 5
+
+It was on a dreary night of November that I beheld the accomplishment
+of my toils.  With an anxiety that almost amounted to agony, I
+collected the instruments of life around me, that I might infuse a
+spark of being into the lifeless thing that lay at my feet.  It was
+already one in the morning; the rain pattered dismally against the
+panes, and my candle was nearly burnt out, when, by the glimmer of the
+half-extinguished light, I saw the dull yellow eye of the creature
+open; it breathed hard, and a convulsive motion agitated its limbs.
+
+How can I describe my emotions at this catastrophe, or how delineate
+the wretch whom with such infinite pains and care I had endeavoured to
+form?  His limbs were in proportion, and I had selected his features as
+beautiful.  Beautiful!  Great God!  His yellow skin scarcely covered
+the work of muscles and arteries beneath; his hair was of a lustrous
+black, and flowing; his teeth of a pearly whiteness; but these
+luxuriances only formed a more horrid contrast with his watery eyes,
+that seemed almost of the same colour as the dun-white sockets in which
+they were set, his shrivelled complexion and straight black lips.
+
+The different accidents of life are not so changeable as the feelings
+of human nature.  I had worked hard for nearly two years, for the sole
+purpose of infusing life into an inanimate body.  For this I had
+deprived myself of rest and health.  I had desired it with an ardour
+that far exceeded moderation; but now that I had finished, the beauty
+of the dream vanished, and breathless horror and disgust filled my
+heart.  Unable to endure the aspect of the being I had created, I
+rushed out of the room and continued a long time traversing my
+bed-chamber, unable to compose my mind to sleep.  At length lassitude
+succeeded to the tumult I had before endured, and I threw myself on the
+bed in my clothes, endeavouring to seek a few moments of forgetfulness.
+But it was in vain; I slept, indeed, but I was disturbed by the wildest
+dreams.  I thought I saw Elizabeth, in the bloom of health, walking in
+the streets of Ingolstadt.  Delighted and surprised, I embraced her,
+but as I imprinted the first kiss on her lips, they became livid with
+the hue of death; her features appeared to change, and I thought that I
+held the corpse of my dead mother in my arms; a shroud enveloped her
+form, and I saw the grave-worms crawling in the folds of the flannel.
+I started from my sleep with horror; a cold dew covered my forehead, my
+teeth chattered, and every limb became convulsed; when, by the dim and
+yellow light of the moon, as it forced its way through the window
+shutters, I beheld the wretch--the miserable monster whom I had
+created.  He held up the curtain of the bed; and his eyes, if eyes they
+may be called, were fixed on me.  His jaws opened, and he muttered some
+inarticulate sounds, while a grin wrinkled his cheeks.  He might have
+spoken, but I did not hear; one hand was stretched out, seemingly to
+detain me, but I escaped and rushed downstairs.  I took refuge in the
+courtyard belonging to the house which I inhabited, where I remained
+during the rest of the night, walking up and down in the greatest
+agitation, listening attentively, catching and fearing each sound as if
+it were to announce the approach of the demoniacal corpse to which I
+had so miserably given life.
+
+Oh!  No mortal could support the horror of that countenance.  A mummy
+again endued with animation could not be so hideous as that wretch.  I
+had gazed on him while unfinished; he was ugly then, but when those
+muscles and joints were rendered capable of motion, it became a thing
+such as even Dante could not have conceived.
+
+I passed the night wretchedly.  Sometimes my pulse beat so quickly and
+hardly that I felt the palpitation of every artery; at others, I nearly
+sank to the ground through languor and extreme weakness.  Mingled with
+this horror, I felt the bitterness of disappointment; dreams that had
+been my food and pleasant rest for so long a space were now become a
+hell to me; and the change was so rapid, the overthrow so complete!
+
+Morning, dismal and wet, at length dawned and discovered to my
+sleepless and aching eyes the church of Ingolstadt, its white steeple
+and clock, which indicated the sixth hour.  The porter opened the gates
+of the court, which had that night been my asylum, and I issued into
+the streets, pacing them with quick steps, as if I sought to avoid the
+wretch whom I feared every turning of the street would present to my
+view.  I did not dare return to the apartment which I inhabited, but
+felt impelled to hurry on, although drenched by the rain which poured
+from a black and comfortless sky.
+
+I continued walking in this manner for some time, endeavouring by
+bodily exercise to ease the load that weighed upon my mind.  I
+traversed the streets without any clear conception of where I was or
+what I was doing.  My heart palpitated in the sickness of fear, and I
+hurried on with irregular steps, not daring to look about me:
+
+
+  Like one who, on a lonely road,
+  Doth walk in fear and dread,
+  And, having once turned round, walks on,
+  And turns no more his head;
+  Because he knows a frightful fiend
+  Doth close behind him tread.
+
+  [Coleridge's "Ancient Mariner."]
+
+
+Continuing thus, I came at length opposite to the inn at which the
+various diligences and carriages usually stopped.  Here I paused, I
+knew not why; but I remained some minutes with my eyes fixed on a coach
+that was coming towards me from the other end of the street.  As it
+drew nearer I observed that it was the Swiss diligence; it stopped just
+where I was standing, and on the door being opened, I perceived Henry
+Clerval, who, on seeing me, instantly sprung out.  "My dear
+Frankenstein," exclaimed he, "how glad I am to see you!  How fortunate
+that you should be here at the very moment of my alighting!"
+
+Nothing could equal my delight on seeing Clerval; his presence brought
+back to my thoughts my father, Elizabeth, and all those scenes of home
+so dear to my recollection.  I grasped his hand, and in a moment forgot
+my horror and misfortune; I felt suddenly, and for the first time
+during many months, calm and serene joy.  I welcomed my friend,
+therefore, in the most cordial manner, and we walked towards my
+college.  Clerval continued talking for some time about our mutual
+friends and his own good fortune in being permitted to come to
+Ingolstadt.  "You may easily believe," said he, "how great was the
+difficulty to persuade my father that all necessary knowledge was not
+comprised in the noble art of book-keeping; and, indeed, I believe I
+left him incredulous to the last, for his constant answer to my
+unwearied entreaties was the same as that of the Dutch schoolmaster in
+The Vicar of Wakefield:  'I have ten thousand florins a year without
+Greek, I eat heartily without Greek.'  But his affection for me at
+length overcame his dislike of learning, and he has permitted me to
+undertake a voyage of discovery to the land of knowledge."
+
+"It gives me the greatest delight to see you; but tell me how you left
+my father, brothers, and Elizabeth."
+
+"Very well, and very happy, only a little uneasy that they hear from
+you so seldom.  By the by, I mean to lecture you a little upon their
+account myself.  But, my dear Frankenstein," continued he, stopping
+short and gazing full in my face, "I did not before remark how very ill
+you appear; so thin and pale; you look as if you had been watching for
+several nights."
+
+"You have guessed right; I have lately been so deeply engaged in one
+occupation that I have not allowed myself sufficient rest, as you see;
+but I hope, I sincerely hope, that all these employments are now at an
+end and that I am at length free."
+
+I trembled excessively; I could not endure to think of, and far less to
+allude to, the occurrences of the preceding night.  I walked with a
+quick pace, and we soon arrived at my college.  I then reflected, and
+the thought made me shiver, that the creature whom I had left in my
+apartment might still be there, alive and walking about.  I dreaded to
+behold this monster, but I feared still more that Henry should see him.
+Entreating him, therefore, to remain a few minutes at the bottom of the
+stairs, I darted up towards my own room.  My hand was already on the
+lock of the door before I recollected myself.  I then paused, and a
+cold shivering came over me.  I threw the door forcibly open, as
+children are accustomed to do when they expect a spectre to stand in
+waiting for them on the other side; but nothing appeared.  I stepped
+fearfully in:  the apartment was empty, and my bedroom was also freed
+from its hideous guest.  I could hardly believe that so great a good
+fortune could have befallen me, but when I became assured that my enemy
+had indeed fled, I clapped my hands for joy and ran down to Clerval.
+
+We ascended into my room, and the servant presently brought breakfast;
+but I was unable to contain myself.  It was not joy only that possessed
+me; I felt my flesh tingle with excess of sensitiveness, and my pulse
+beat rapidly.  I was unable to remain for a single instant in the same
+place; I jumped over the chairs, clapped my hands, and laughed aloud.
+Clerval at first attributed my unusual spirits to joy on his arrival,
+but when he observed me more attentively, he saw a wildness in my eyes
+for which he could not account, and my loud, unrestrained, heartless
+laughter frightened and astonished him.
+
+"My dear Victor," cried he, "what, for God's sake, is the matter?  Do
+not laugh in that manner.  How ill you are!  What is the cause of all
+this?"
+
+"Do not ask me," cried I, putting my hands before my eyes, for I
+thought I saw the dreaded spectre glide into the room; "HE can tell.
+Oh, save me!  Save me!"  I imagined that the monster seized me; I
+struggled furiously and fell down in a fit.
+
+Poor Clerval!  What must have been his feelings?  A meeting, which he
+anticipated with such joy, so strangely turned to bitterness.  But I
+was not the witness of his grief, for I was lifeless and did not
+recover my senses for a long, long time.
+
+This was the commencement of a nervous fever which confined me for
+several months.  During all that time Henry was my only nurse.  I
+afterwards learned that, knowing my father's advanced age and unfitness
+for so long a journey, and how wretched my sickness would make
+Elizabeth, he spared them this grief by concealing the extent of my
+disorder.  He knew that I could not have a more kind and attentive
+nurse than himself; and, firm in the hope he felt of my recovery, he
+did not doubt that, instead of doing harm, he performed the kindest
+action that he could towards them.
+
+But I was in reality very ill, and surely nothing but the unbounded and
+unremitting attentions of my friend could have restored me to life.
+The form of the monster on whom I had bestowed existence was forever
+before my eyes, and I raved incessantly concerning him.  Doubtless my
+words surprised Henry; he at first believed them to be the wanderings
+of my disturbed imagination, but the pertinacity with which I
+continually recurred to the same subject persuaded him that my disorder
+indeed owed its origin to some uncommon and terrible event.
+
+By very slow degrees, and with frequent relapses that alarmed and
+grieved my friend, I recovered.  I remember the first time I became
+capable of observing outward objects with any kind of pleasure, I
+perceived that the fallen leaves had disappeared and that the young
+buds were shooting forth from the trees that shaded my window.  It was
+a divine spring, and the season contributed greatly to my
+convalescence.  I felt also sentiments of joy and affection revive in
+my bosom; my gloom disappeared, and in a short time I became as
+cheerful as before I was attacked by the fatal passion.
+
+"Dearest Clerval," exclaimed I, "how kind, how very good you are to me.
+This whole winter, instead of being spent in study, as you promised
+yourself, has been consumed in my sick room.  How shall I ever repay
+you?  I feel the greatest remorse for the disappointment of which I
+have been the occasion, but you will forgive me."
+
+"You will repay me entirely if you do not discompose yourself, but get
+well as fast as you can; and since you appear in such good spirits, I
+may speak to you on one subject, may I not?"
+
+I trembled.  One subject!  What could it be?  Could he allude to an
+object on whom I dared not even think?  "Compose yourself," said
+Clerval, who observed my change of colour, "I will not mention it if it
+agitates you; but your father and cousin would be very happy if they
+received a letter from you in your own handwriting.  They hardly know
+how ill you have been and are uneasy at your long silence."
+
+"Is that all, my dear Henry?  How could you suppose that my first
+thought would not fly towards those dear, dear friends whom I love and
+who are so deserving of my love?"
+
+"If this is your present temper, my friend, you will perhaps be glad to
+see a letter that has been lying here some days for you; it is from
+your cousin, I believe."
+
+
+
+Chapter 6
+
+Clerval then put the following letter into my hands.  It was from my
+own Elizabeth:
+
+"My dearest Cousin,
+
+"You have been ill, very ill, and even the constant letters of dear
+kind Henry are not sufficient to reassure me on your account.  You are
+forbidden to write--to hold a pen; yet one word from you, dear Victor,
+is necessary to calm our apprehensions.  For a long time I have thought
+that each post would bring this line, and my persuasions have
+restrained my uncle from undertaking a journey to Ingolstadt.  I have
+prevented his encountering the inconveniences and perhaps dangers of so
+long a journey, yet how often have I regretted not being able to
+perform it myself!  I figure to myself that the task of attending on
+your sickbed has devolved on some mercenary old nurse, who could never
+guess your wishes nor minister to them with the care and affection of
+your poor cousin.  Yet that is over now:  Clerval writes that indeed
+you are getting better.  I eagerly hope that you will confirm this
+intelligence soon in your own handwriting.
+
+"Get well--and return to us.  You will find a happy, cheerful home and
+friends who love you dearly.  Your father's health is vigorous, and he
+asks but to see you, but to be assured that you are well; and not a
+care will ever cloud his benevolent countenance.  How pleased you would
+be to remark the improvement of our Ernest!  He is now sixteen and full
+of activity and spirit.  He is desirous to be a true Swiss and to enter
+into foreign service, but we cannot part with him, at least until his
+elder brother returns to us.  My uncle is not pleased with the idea of
+a military career in a distant country, but Ernest never had your
+powers of application.  He looks upon study as an odious fetter; his
+time is spent in the open air, climbing the hills or rowing on the
+lake.  I fear that he will become an idler unless we yield the point
+and permit him to enter on the profession which he has selected.
+
+"Little alteration, except the growth of our dear children, has taken
+place since you left us.  The blue lake and snow-clad mountains--they
+never change; and I think our placid home and our contented hearts are
+regulated by the same immutable laws.  My trifling occupations take up
+my time and amuse me, and I am rewarded for any exertions by seeing
+none but happy, kind faces around me.  Since you left us, but one
+change has taken place in our little household.  Do you remember on
+what occasion Justine Moritz entered our family?  Probably you do not;
+I will relate her history, therefore in a few words.  Madame Moritz,
+her mother, was a widow with four children, of whom Justine was the
+third.  This girl had always been the favourite of her father, but
+through a strange perversity, her mother could not endure her, and
+after the death of M. Moritz, treated her very ill.  My aunt observed
+this, and when Justine was twelve years of age, prevailed on her mother
+to allow her to live at our house.  The republican institutions of our
+country have produced simpler and happier manners than those which
+prevail in the great monarchies that surround it.  Hence there is less
+distinction between the several classes of its inhabitants; and the
+lower orders, being neither so poor nor so despised, their manners are
+more refined and moral.  A servant in Geneva does not mean the same
+thing as a servant in France and England.  Justine, thus received in
+our family, learned the duties of a servant, a condition which, in our
+fortunate country, does not include the idea of ignorance and a
+sacrifice of the dignity of a human being.
+
+"Justine, you may remember, was a great favourite of yours; and I
+recollect you once remarked that if you were in an ill humour, one
+glance from Justine could dissipate it, for the same reason that
+Ariosto gives concerning the beauty of Angelica--she looked so
+frank-hearted and happy.  My aunt conceived a great attachment for her,
+by which she was induced to give her an education superior to that
+which she had at first intended.  This benefit was fully repaid;
+Justine was the most grateful little creature in the world:  I do not
+mean that she made any professions I never heard one pass her lips, but
+you could see by her eyes that she almost adored her protectress.
+Although her disposition was gay and in many respects inconsiderate,
+yet she paid the greatest attention to every gesture of my aunt.  She
+thought her the model of all excellence and endeavoured to imitate her
+phraseology and manners, so that even now she often reminds me of her.
+
+"When my dearest aunt died every one was too much occupied in their own
+grief to notice poor Justine, who had attended her during her illness
+with the most anxious affection.  Poor Justine was very ill; but other
+trials were reserved for her.
+
+"One by one, her brothers and sister died; and her mother, with the
+exception of her neglected daughter, was left childless.  The
+conscience of the woman was troubled; she began to think that the
+deaths of her favourites was a judgement from heaven to chastise her
+partiality.  She was a Roman Catholic; and I believe her confessor
+confirmed the idea which she had conceived.  Accordingly, a few months
+after your departure for Ingolstadt, Justine was called home by her
+repentant mother.  Poor girl!  She wept when she quitted our house; she
+was much altered since the death of my aunt; grief had given softness
+and a winning mildness to her manners, which had before been remarkable
+for vivacity.  Nor was her residence at her mother's house of a nature
+to restore her gaiety.  The poor woman was very vacillating in her
+repentance.  She sometimes begged Justine to forgive her unkindness,
+but much oftener accused her of having caused the deaths of her
+brothers and sister.  Perpetual fretting at length threw Madame Moritz
+into a decline, which at first increased her irritability, but she is
+now at peace for ever.  She died on the first approach of cold weather,
+at the beginning of this last winter.  Justine has just returned to us;
+and I assure you I love her tenderly.  She is very clever and gentle,
+and extremely pretty; as I mentioned before, her mien and her
+expression continually remind me of my dear aunt.
+
+"I must say also a few words to you, my dear cousin, of little darling
+William.  I wish you could see him; he is very tall of his age, with
+sweet laughing blue eyes, dark eyelashes, and curling hair.  When he
+smiles, two little dimples appear on each cheek, which are rosy with
+health.  He has already had one or two little WIVES, but Louisa Biron
+is his favourite, a pretty little girl of five years of age.
+
+"Now, dear Victor, I dare say you wish to be indulged in a little
+gossip concerning the good people of Geneva.  The pretty Miss Mansfield
+has already received the congratulatory visits on her approaching
+marriage with a young Englishman, John Melbourne, Esq.  Her ugly
+sister, Manon, married M. Duvillard, the rich banker, last autumn. Your
+favourite schoolfellow, Louis Manoir, has suffered several misfortunes
+since the departure of Clerval from Geneva.  But he has already
+recovered his spirits, and is reported to be on the point of marrying a
+lively pretty Frenchwoman, Madame Tavernier.  She is a widow, and much
+older than Manoir; but she is very much admired, and a favourite with
+everybody.
+
+"I have written myself into better spirits, dear cousin; but my anxiety
+returns upon me as I conclude.  Write, dearest Victor,--one line--one
+word will be a blessing to us.  Ten thousand thanks to Henry for his
+kindness, his affection, and his many letters; we are sincerely
+grateful.  Adieu!  my cousin; take care of your self; and, I entreat
+you, write!
+
+"Elizabeth Lavenza.
+
+"Geneva, March 18, 17--."
+
+
+"Dear, dear Elizabeth!" I exclaimed, when I had read her letter:  "I
+will write instantly and relieve them from the anxiety they must feel."
+I wrote, and this exertion greatly fatigued me; but my convalescence
+had commenced, and proceeded regularly.  In another fortnight I was
+able to leave my chamber.
+
+One of my first duties on my recovery was to introduce Clerval to the
+several professors of the university.  In doing this, I underwent a
+kind of rough usage, ill befitting the wounds that my mind had
+sustained.  Ever since the fatal night, the end of my labours, and the
+beginning of my misfortunes, I had conceived a violent antipathy even
+to the name of natural philosophy.  When I was otherwise quite restored
+to health, the sight of a chemical instrument would renew all the agony
+of my nervous symptoms.  Henry saw this, and had removed all my
+apparatus from my view.  He had also changed my apartment; for he
+perceived that I had acquired a dislike for the room which had
+previously been my laboratory.  But these cares of Clerval were made of
+no avail when I visited the professors.  M. Waldman inflicted torture
+when he praised, with kindness and warmth, the astonishing progress I
+had made in the sciences.  He soon perceived that I disliked the
+subject; but not guessing the real cause, he attributed my feelings to
+modesty, and changed the subject from my improvement, to the science
+itself, with a desire, as I evidently saw, of drawing me out.  What
+could I do?  He meant to please, and he tormented me.  I felt as if he
+had placed carefully, one by one, in my view those instruments which
+were to be afterwards used in putting me to a slow and cruel death.  I
+writhed under his words, yet dared not exhibit the pain I felt.
+Clerval, whose eyes and feelings were always quick in discerning the
+sensations of others, declined the subject, alleging, in excuse, his
+total ignorance; and the conversation took a more general turn.  I
+thanked my friend from my heart, but I did not speak.  I saw plainly
+that he was surprised, but he never attempted to draw my secret from
+me; and although I loved him with a mixture of affection and reverence
+that knew no bounds, yet I could never persuade myself to confide in
+him that event which was so often present to my recollection, but which
+I feared the detail to another would only impress more deeply.
+
+M. Krempe was not equally docile; and in my condition at that time, of
+almost insupportable sensitiveness, his harsh blunt encomiums gave me
+even more pain than the benevolent approbation of M. Waldman.  "D--n
+the fellow!" cried he; "why, M. Clerval, I assure you he has outstript
+us all.  Ay, stare if you please; but it is nevertheless true.  A
+youngster who, but a few years ago, believed in Cornelius Agrippa as
+firmly as in the gospel, has now set himself at the head of the
+university; and if he is not soon pulled down, we shall all be out of
+countenance.--Ay, ay," continued he, observing my face expressive of
+suffering, "M. Frankenstein is modest; an excellent quality in a young
+man.  Young men should be diffident of themselves, you know, M.
+Clerval:  I was myself when young; but that wears out in a very short
+time."
+
+M. Krempe had now commenced an eulogy on himself, which happily turned
+the conversation from a subject that was so annoying to me.
+
+Clerval had never sympathized in my tastes for natural science; and his
+literary pursuits differed wholly from those which had occupied me.  He
+came to the university with the design of making himself complete
+master of the oriental languages, and thus he should open a field for
+the plan of life he had marked out for himself.  Resolved to pursue no
+inglorious career, he turned his eyes toward the East, as affording
+scope for his spirit of enterprise.  The Persian, Arabic, and Sanskrit
+languages engaged his attention, and I was easily induced to enter on
+the same studies.  Idleness had ever been irksome to me, and now that I
+wished to fly from reflection, and hated my former studies, I felt
+great relief in being the fellow-pupil with my friend, and found not
+only instruction but consolation in the works of the orientalists.  I
+did not, like him, attempt a critical knowledge of their dialects, for
+I did not contemplate making any other use of them than temporary
+amusement.  I read merely to understand their meaning, and they well
+repaid my labours.  Their melancholy is soothing, and their joy
+elevating, to a degree I never experienced in studying the authors of
+any other country.  When you read their writings, life appears to
+consist in a warm sun and a garden of roses,--in the smiles and frowns
+of a fair enemy, and the fire that consumes your own heart.  How
+different from the manly and heroical poetry of Greece and Rome!
+
+Summer passed away in these occupations, and my return to Geneva was
+fixed for the latter end of autumn; but being delayed by several
+accidents, winter and snow arrived, the roads were deemed impassable,
+and my journey was retarded until the ensuing spring.  I felt this
+delay very bitterly; for I longed to see my native town and my beloved
+friends.  My return had only been delayed so long, from an
+unwillingness to leave Clerval in a strange place, before he had become
+acquainted with any of its inhabitants.  The winter, however, was spent
+cheerfully; and although the spring was uncommonly late, when it came
+its beauty compensated for its dilatoriness.
+
+The month of May had already commenced, and I expected the letter daily
+which was to fix the date of my departure, when Henry proposed a
+pedestrian tour in the environs of Ingolstadt, that I might bid a
+personal farewell to the country I had so long inhabited.  I acceded
+with pleasure to this proposition:  I was fond of exercise, and Clerval
+had always been my favourite companion in the ramble of this nature
+that I had taken among the scenes of my native country.
+
+We passed a fortnight in these perambulations:  my health and spirits
+had long been restored, and they gained additional strength from the
+salubrious air I breathed, the natural incidents of our progress, and
+the conversation of my friend.  Study had before secluded me from the
+intercourse of my fellow-creatures, and rendered me unsocial; but
+Clerval called forth the better feelings of my heart; he again taught
+me to love the aspect of nature, and the cheerful faces of children.
+Excellent friend!  how sincerely you did love me, and endeavour to
+elevate my mind until it was on a level with your own.  A selfish
+pursuit had cramped and narrowed me, until your gentleness and
+affection warmed and opened my senses; I became the same happy creature
+who, a few years ago, loved and beloved by all, had no sorrow or care.
+When happy, inanimate nature had the power of bestowing on me the most
+delightful sensations.  A serene sky and verdant fields filled me with
+ecstasy.  The present season was indeed divine; the flowers of spring
+bloomed in the hedges, while those of summer were already in bud.  I
+was undisturbed by thoughts which during the preceding year had pressed
+upon me, notwithstanding my endeavours to throw them off, with an
+invincible burden.
+
+Henry rejoiced in my gaiety, and sincerely sympathised in my feelings:
+he exerted himself to amuse me, while he expressed the sensations that
+filled his soul.  The resources of his mind on this occasion were truly
+astonishing:  his conversation was full of imagination; and very often,
+in imitation of the Persian and Arabic writers, he invented tales of
+wonderful fancy and passion.  At other times he repeated my favourite
+poems, or drew me out into arguments, which he supported with great
+ingenuity.  We returned to our college on a Sunday afternoon:  the
+peasants were dancing, and every one we met appeared gay and happy.  My
+own spirits were high, and I bounded along with feelings of unbridled
+joy and hilarity.
+
+
+
+Chapter 7
+
+On my return, I found the following letter from my father:--
+
+
+"My dear Victor,
+
+"You have probably waited impatiently for a letter to fix the date of
+your return to us; and I was at first tempted to write only a few
+lines, merely mentioning the day on which I should expect you.  But
+that would be a cruel kindness, and I dare not do it.  What would be
+your surprise, my son, when you expected a happy and glad welcome, to
+behold, on the contrary, tears and wretchedness?  And how, Victor, can
+I relate our misfortune?  Absence cannot have rendered you callous to
+our joys and griefs; and how shall I inflict pain on my long absent
+son?  I wish to prepare you for the woeful news, but I know it is
+impossible; even now your eye skims over the page to seek the words
+which are to convey to you the horrible tidings.
+
+"William is dead!--that sweet child, whose smiles delighted and warmed
+my heart, who was so gentle, yet so gay!  Victor, he is murdered!
+
+"I will not attempt to console you; but will simply relate the
+circumstances of the transaction.
+
+"Last Thursday (May 7th), I, my niece, and your two brothers, went to
+walk in Plainpalais.  The evening was warm and serene, and we prolonged
+our walk farther than usual.  It was already dusk before we thought of
+returning; and then we discovered that William and Ernest, who had gone
+on before, were not to be found.  We accordingly rested on a seat until
+they should return.  Presently Ernest came, and enquired if we had seen
+his brother; he said, that he had been playing with him, that William
+had run away to hide himself, and that he vainly sought for him, and
+afterwards waited for a long time, but that he did not return.
+
+"This account rather alarmed us, and we continued to search for him
+until night fell, when Elizabeth conjectured that he might have
+returned to the house.  He was not there.  We returned again, with
+torches; for I could not rest, when I thought that my sweet boy had
+lost himself, and was exposed to all the damps and dews of night;
+Elizabeth also suffered extreme anguish.  About five in the morning I
+discovered my lovely boy, whom the night before I had seen blooming and
+active in health, stretched on the grass livid and motionless; the
+print of the murder's finger was on his neck.
+
+"He was conveyed home, and the anguish that was visible in my
+countenance betrayed the secret to Elizabeth.  She was very earnest to
+see the corpse.  At first I attempted to prevent her but she persisted,
+and entering the room where it lay, hastily examined the neck of the
+victim, and clasping her hands exclaimed, 'O God!  I have murdered my
+darling child!'
+
+"She fainted, and was restored with extreme difficulty.  When she again
+lived, it was only to weep and sigh.  She told me, that that same
+evening William had teased her to let him wear a very valuable
+miniature that she possessed of your mother.  This picture is gone, and
+was doubtless the temptation which urged the murderer to the deed.  We
+have no trace of him at present, although our exertions to discover him
+are unremitted; but they will not restore my beloved William!
+
+"Come, dearest Victor; you alone can console Elizabeth.  She weeps
+continually, and accuses herself unjustly as the cause of his death;
+her words pierce my heart.  We are all unhappy; but will not that be an
+additional motive for you, my son, to return and be our comforter?
+Your dear mother!  Alas, Victor!  I now say, Thank God she did not live
+to witness the cruel, miserable death of her youngest darling!
+
+"Come, Victor; not brooding thoughts of vengeance against the assassin,
+but with feelings of peace and gentleness, that will heal, instead of
+festering, the wounds of our minds.  Enter the house of mourning, my
+friend, but with kindness and affection for those who love you, and not
+with hatred for your enemies.
+
+               "Your affectionate and afflicted father,
+                              "Alphonse Frankenstein.
+
+
+
+"Geneva, May 12th, 17--."
+
+Clerval, who had watched my countenance as I read this letter, was
+surprised to observe the despair that succeeded the joy I at first
+expressed on receiving new from my friends.  I threw the letter on the
+table, and covered my face with my hands.
+
+"My dear Frankenstein," exclaimed Henry, when he perceived me weep with
+bitterness, "are you always to be unhappy?  My dear friend, what has
+happened?"
+
+I motioned him to take up the letter, while I walked up and down the
+room in the extremest agitation.  Tears also gushed from the eyes of
+Clerval, as he read the account of my misfortune.
+
+"I can offer you no consolation, my friend," said he; "your disaster is
+irreparable.  What do you intend to do?"
+
+"To go instantly to Geneva: come with me, Henry, to order the horses."
+
+During our walk, Clerval endeavoured to say a few words of consolation;
+he could only express his heartfelt sympathy.  "Poor William!" said he,
+"dear lovely child, he now sleeps with his angel mother!  Who that had
+seen him bright and joyous in his young beauty, but must weep over his
+untimely loss!  To die so miserably; to feel the murderer's grasp!  How
+much more a murdered that could destroy radiant innocence!  Poor little
+fellow! one only consolation have we; his friends mourn and weep, but
+he is at rest. The pang is over, his sufferings are at an end for ever.
+A sod covers his gentle form, and he knows no pain.  He can no longer
+be a subject for pity; we must reserve that for his miserable
+survivors."
+
+Clerval spoke thus as we hurried through the streets; the words
+impressed themselves on my mind and I remembered them afterwards in
+solitude.  But now, as soon as the horses arrived, I hurried into a
+cabriolet, and bade farewell to my friend.
+
+My journey was very melancholy.  At first I wished to hurry on, for I
+longed to console and sympathise with my loved and sorrowing friends;
+but when I drew near my native town, I slackened my progress.  I could
+hardly sustain the multitude of feelings that crowded into my mind.  I
+passed through scenes familiar to my youth, but which I had not seen
+for nearly six years.  How altered every thing might be during that
+time!  One sudden and desolating change had taken place; but a thousand
+little circumstances might have by degrees worked other alterations,
+which, although they were done more tranquilly, might not be the less
+decisive.  Fear overcame me; I dared no advance, dreading a thousand
+nameless evils that made me tremble, although I was unable to define
+them.  I remained two days at Lausanne, in this painful state of mind.
+I contemplated the lake:  the waters were placid; all around was calm;
+and the snowy mountains, 'the palaces of nature,' were not changed.  By
+degrees the calm and heavenly scene restored me, and I continued my
+journey towards Geneva.
+
+The road ran by the side of the lake, which became narrower as I
+approached my native town.  I discovered more distinctly the black
+sides of Jura, and the bright summit of Mont Blanc.  I wept like a
+child.  "Dear mountains! my own beautiful lake! how do you welcome your
+wanderer?  Your summits are clear; the sky and lake are blue and
+placid.  Is this to prognosticate peace, or to mock at my unhappiness?"
+
+I fear, my friend, that I shall render myself tedious by dwelling on
+these preliminary circumstances; but they were days of comparative
+happiness, and I think of them with pleasure.  My country, my beloved
+country! who but a native can tell the delight I took in again
+beholding thy streams, thy mountains, and, more than all, thy lovely
+lake!
+
+Yet, as I drew nearer home, grief and fear again overcame me.  Night
+also closed around; and when I could hardly see the dark mountains, I
+felt still more gloomily.  The picture appeared a vast and dim scene of
+evil, and I foresaw obscurely that I was destined to become the most
+wretched of human beings.  Alas!  I prophesied truly, and failed only
+in one single circumstance, that in all the misery I imagined and
+dreaded, I did not conceive the hundredth part of the anguish I was
+destined to endure.  It was completely dark when I arrived in the
+environs of Geneva; the gates of the town were already shut; and I was
+obliged to pass the night at Secheron, a village at the distance of
+half a league from the city.  The sky was serene; and, as I was unable
+to rest, I resolved to visit the spot where my poor William had been
+murdered.  As I could not pass through the town, I was obliged to cross
+the lake in a boat to arrive at Plainpalais.  During this short voyage
+I saw the lightning playing on the summit of Mont Blanc in the most
+beautiful figures.  The storm appeared to approach rapidly, and, on
+landing, I ascended a low hill, that I might observe its progress.  It
+advanced; the heavens were clouded, and I soon felt the rain coming
+slowly in large drops, but its violence quickly increased.
+
+I quitted my seat, and walked on, although the darkness and storm
+increased every minute, and the thunder burst with a terrific crash
+over my head.  It was echoed from Saleve, the Juras, and the Alps of
+Savoy; vivid flashes of lightning dazzled my eyes, illuminating the
+lake, making it appear like a vast sheet of fire; then for an instant
+every thing seemed of a pitchy darkness, until the eye recovered itself
+from the preceding flash.  The storm, as is often the case in
+Switzerland, appeared at once in various parts of the heavens.  The
+most violent storm hung exactly north of the town, over the part of the
+lake which lies between the promontory of Belrive and the village of
+Copet.  Another storm enlightened Jura with faint flashes; and another
+darkened and sometimes disclosed the Mole, a peaked mountain to the
+east of the lake.
+
+While I watched the tempest, so beautiful yet terrific, I wandered on
+with a hasty step.  This noble war in the sky elevated my spirits; I
+clasped my hands, and exclaimed aloud, "William, dear angel! this is
+thy funeral, this thy dirge!" As I said these words, I perceived in the
+gloom a figure which stole from behind a clump of trees near me; I
+stood fixed, gazing intently:  I could not be mistaken.  A flash of
+lightning illuminated the object, and discovered its shape plainly to
+me; its gigantic stature, and the deformity of its aspect more hideous
+than belongs to humanity, instantly informed me that it was the wretch,
+the filthy daemon, to whom I had given life.  What did he there?  Could
+he be (I shuddered at the conception) the murderer of my brother?  No
+sooner did that idea cross my imagination, than I became convinced of
+its truth; my teeth chattered, and I was forced to lean against a tree
+for support.  The figure passed me quickly, and I lost it in the gloom.
+
+Nothing in human shape could have destroyed the fair child.  HE was the
+murderer!  I could not doubt it.  The mere presence of the idea was an
+irresistible proof of the fact.  I thought of pursuing the devil; but
+it would have been in vain, for another flash discovered him to me
+hanging among the rocks of the nearly perpendicular ascent of Mont
+Saleve, a hill that bounds Plainpalais on the south.  He soon reached
+the summit, and disappeared.
+
+I remained motionless.  The thunder ceased; but the rain still
+continued, and the scene was enveloped in an impenetrable darkness.  I
+revolved in my mind the events which I had until now sought to forget:
+the whole train of my progress toward the creation; the appearance of
+the works of my own hands at my bedside; its departure.  Two years had
+now nearly elapsed since the night on which he first received life; and
+was this his first crime?  Alas!  I had turned loose into the world a
+depraved wretch, whose delight was in carnage and misery; had he not
+murdered my brother?
+
+No one can conceive the anguish I suffered during the remainder of the
+night, which I spent, cold and wet, in the open air.  But I did not
+feel the inconvenience of the weather; my imagination was busy in
+scenes of evil and despair.  I considered the being whom I had cast
+among mankind, and endowed with the will and power to effect purposes
+of horror, such as the deed which he had now done, nearly in the light
+of my own vampire, my own spirit let loose from the grave, and forced
+to destroy all that was dear to me.
+
+Day dawned; and I directed my steps towards the town.  The gates were
+open, and I hastened to my father's house.  My first thought was to
+discover what I knew of the murderer, and cause instant pursuit to be
+made.  But I paused when I reflected on the story that I had to tell. A
+being whom I myself had formed, and endued with life, had met me at
+midnight among the precipices of an inaccessible mountain.  I
+remembered also the nervous fever with which I had been seized just at
+the time that I dated my creation, and which would give an air of
+delirium to a tale otherwise so utterly improbable.  I well knew that
+if any other had communicated such a relation to me, I should have
+looked upon it as the ravings of insanity.  Besides, the strange nature
+of the animal would elude all pursuit, even if I were so far credited
+as to persuade my relatives to commence it.  And then of what use would
+be pursuit?  Who could arrest a creature capable of scaling the
+overhanging sides of Mont Saleve?  These reflections determined me, and
+I resolved to remain silent.
+
+It was about five in the morning when I entered my father's house.  I
+told the servants not to disturb the family, and went into the library
+to attend their usual hour of rising.
+
+Six years had elapsed, passed in a dream but for one indelible trace,
+and I stood in the same place where I had last embraced my father
+before my departure for Ingolstadt.  Beloved and venerable parent!  He
+still remained to me.  I gazed on the picture of my mother, which stood
+over the mantel-piece.  It was an historical subject, painted at my
+father's desire, and represented Caroline Beaufort in an agony of
+despair, kneeling by the coffin of her dead father.  Her garb was
+rustic, and her cheek pale; but there was an air of dignity and beauty,
+that hardly permitted the sentiment of pity.  Below this picture was a
+miniature of William; and my tears flowed when I looked upon it.  While
+I was thus engaged, Ernest entered:  he had heard me arrive, and
+hastened to welcome me:  "Welcome, my dearest Victor," said he.  "Ah! I
+wish you had come three months ago, and then you would have found us
+all joyous and delighted.  You come to us now to share a misery which
+nothing can alleviate; yet your presence will, I hope, revive our
+father, who seems sinking under his misfortune; and your persuasions
+will induce poor Elizabeth to cease her vain and tormenting
+self-accusations.--Poor William! he was our darling and our pride!"
+
+Tears, unrestrained, fell from my brother's eyes; a sense of mortal
+agony crept over my frame.  Before, I had only imagined the
+wretchedness of my desolated home; the reality came on me as a new, and
+a not less terrible, disaster.  I tried to calm Ernest; I enquired more
+minutely concerning my father, and here I named my cousin.
+
+"She most of all," said Ernest, "requires consolation; she accused
+herself of having caused the death of my brother, and that made her
+very wretched.  But since the murderer has been discovered--"
+
+"The murderer discovered!  Good God! how can that be? who could attempt
+to pursue him?  It is impossible; one might as well try to overtake the
+winds, or confine a mountain-stream with a straw.  I saw him too; he
+was free last night!"
+
+"I do not know what you mean," replied my brother, in accents of
+wonder, "but to us the discovery we have made completes our misery.  No
+one would believe it at first; and even now Elizabeth will not be
+convinced, notwithstanding all the evidence.  Indeed, who would credit
+that Justine Moritz, who was so amiable, and fond of all the family,
+could suddenly become so capable of so frightful, so appalling a crime?"
+
+"Justine Moritz!  Poor, poor girl, is she the accused?  But it is
+wrongfully; every one knows that; no one believes it, surely, Ernest?"
+
+"No one did at first; but several circumstances came out, that have
+almost forced conviction upon us; and her own behaviour has been so
+confused, as to add to the evidence of facts a weight that, I fear,
+leaves no hope for doubt.  But she will be tried today, and you will
+then hear all."
+
+He then related that, the morning on which the murder of poor William
+had been discovered, Justine had been taken ill, and confined to her
+bed for several days.  During this interval, one of the servants,
+happening to examine the apparel she had worn on the night of the
+murder, had discovered in her pocket the picture of my mother, which
+had been judged to be the temptation of the murderer.  The servant
+instantly showed it to one of the others, who, without saying a word to
+any of the family, went to a magistrate; and, upon their deposition,
+Justine was apprehended.  On being charged with the fact, the poor girl
+confirmed the suspicion in a great measure by her extreme confusion of
+manner.
+
+This was a strange tale, but it did not shake my faith; and I replied
+earnestly, "You are all mistaken; I know the murderer.  Justine, poor,
+good Justine, is innocent."
+
+At that instant my father entered.  I saw unhappiness deeply impressed
+on his countenance, but he endeavoured to welcome me cheerfully; and,
+after we had exchanged our mournful greeting, would have introduced
+some other topic than that of our disaster, had not Ernest exclaimed,
+"Good God, papa!  Victor says that he knows who was the murderer of
+poor William."
+
+"We do also, unfortunately," replied my father, "for indeed I had
+rather have been for ever ignorant than have discovered so much
+depravity and ungratitude in one I valued so highly."
+
+"My dear father, you are mistaken; Justine is innocent."
+
+"If she is, God forbid that she should suffer as guilty.  She is to be
+tried today, and I hope, I sincerely hope, that she will be acquitted."
+
+This speech calmed me.  I was firmly convinced in my own mind that
+Justine, and indeed every human being, was guiltless of this murder.  I
+had no fear, therefore, that any circumstantial evidence could be
+brought forward strong enough to convict her.  My tale was not one to
+announce publicly; its astounding horror would be looked upon as
+madness by the vulgar.  Did any one indeed exist, except I, the
+creator, who would believe, unless his senses convinced him, in the
+existence of the living monument of presumption and rash ignorance
+which I had let loose upon the world?
+
+We were soon joined by Elizabeth.  Time had altered her since I last
+beheld her; it had endowed her with loveliness surpassing the beauty of
+her childish years.  There was the same candour, the same vivacity, but
+it was allied to an expression more full of sensibility and intellect.
+She welcomed me with the greatest affection.  "Your arrival, my dear
+cousin," said she, "fills me with hope.  You perhaps will find some
+means to justify my poor guiltless Justine.  Alas! who is safe, if she
+be convicted of crime?  I rely on her innocence as certainly as I do
+upon my own.  Our misfortune is doubly hard to us; we have not only
+lost that lovely darling boy, but this poor girl, whom I sincerely
+love, is to be torn away by even a worse fate.  If she is condemned, I
+never shall know joy more.  But she will not, I am sure she will not;
+and then I shall be happy again, even after the sad death of my little
+William."
+
+"She is innocent, my Elizabeth," said I, "and that shall be proved;
+fear nothing, but let your spirits be cheered by the assurance of her
+acquittal."
+
+"How kind and generous you are! every one else believes in her guilt,
+and that made me wretched, for I knew that it was impossible:  and to
+see every one else prejudiced in so deadly a manner rendered me
+hopeless and despairing."  She wept.
+
+"Dearest niece," said my father, "dry your tears.  If she is, as you
+believe, innocent, rely on the justice of our laws, and the activity
+with which I shall prevent the slightest shadow of partiality."
+
+
+
+Chapter 8
+
+We passed a few sad hours until eleven o'clock, when the trial was to
+commence.  My father and the rest of the family being obliged to attend
+as witnesses, I accompanied them to the court.  During the whole of
+this wretched mockery of justice I suffered living torture.  It was to
+be decided whether the result of my curiosity and lawless devices would
+cause the death of two of my fellow beings:  one a smiling babe full of
+innocence and joy, the other far more dreadfully murdered, with every
+aggravation of infamy that could make the murder memorable in horror.
+Justine also was a girl of merit and possessed qualities which promised
+to render her life happy; now all was to be obliterated in an
+ignominious grave, and I the cause!  A thousand times rather would I
+have confessed myself guilty of the crime ascribed to Justine, but I
+was absent when it was committed, and such a declaration would have
+been considered as the ravings of a madman and would not have
+exculpated her who suffered through me.
+
+The appearance of Justine was calm.  She was dressed in mourning, and
+her countenance, always engaging, was rendered, by the solemnity of her
+feelings, exquisitely beautiful.  Yet she appeared confident in
+innocence and did not tremble, although gazed on and execrated by
+thousands, for all the kindness which her beauty might otherwise have
+excited was obliterated in the minds of the spectators by the
+imagination of the enormity she was supposed to have committed.  She
+was tranquil, yet her tranquillity was evidently constrained; and as
+her confusion had before been adduced as a proof of her guilt, she
+worked up her mind to an appearance of courage.  When she entered the
+court she threw her eyes round it and quickly discovered where we were
+seated.  A tear seemed to dim her eye when she saw us, but she quickly
+recovered herself, and a look of sorrowful affection seemed to attest
+her utter guiltlessness.
+
+The trial began, and after the advocate against her had stated the
+charge, several witnesses were called.  Several strange facts combined
+against her, which might have staggered anyone who had not such proof
+of her innocence as I had.  She had been out the whole of the night on
+which the murder had been committed and towards morning had been
+perceived by a market-woman not far from the spot where the body of the
+murdered child had been afterwards found.  The woman asked her what she
+did there, but she looked very strangely and only returned a confused
+and unintelligible answer.  She returned to the house about eight
+o'clock, and when one inquired where she had passed the night, she
+replied that she had been looking for the child and demanded earnestly
+if anything had been heard concerning him.  When shown the body, she
+fell into violent hysterics and kept her bed for several days.  The
+picture was then produced which the servant had found in her pocket;
+and when Elizabeth, in a faltering voice, proved that it was the same
+which, an hour before the child had been missed, she had placed round
+his neck, a murmur of horror and indignation filled the court.
+
+Justine was called on for her defence.  As the trial had proceeded, her
+countenance had altered.  Surprise, horror, and misery were strongly
+expressed.  Sometimes she struggled with her tears, but when she was
+desired to plead, she collected her powers and spoke in an audible
+although variable voice.
+
+"God knows," she said, "how entirely I am innocent.  But I do not
+pretend that my protestations should acquit me; I rest my innocence on
+a plain and simple explanation of the facts which have been adduced
+against me, and I hope the character I have always borne will incline
+my judges to a favourable interpretation where any circumstance appears
+doubtful or suspicious."
+
+She then related that, by the permission of Elizabeth, she had passed
+the evening of the night on which the murder had been committed at the
+house of an aunt at Chene, a village situated at about a league from
+Geneva.  On her return, at about nine o'clock, she met a man who asked
+her if she had seen anything of the child who was lost.  She was
+alarmed by this account and passed several hours in looking for him,
+when the gates of Geneva were shut, and she was forced to remain
+several hours of the night in a barn belonging to a cottage, being
+unwilling to call up the inhabitants, to whom she was well known.  Most
+of the night she spent here watching; towards morning she believed that
+she slept for a few minutes; some steps disturbed her, and she awoke.
+It was dawn, and she quitted her asylum, that she might again endeavour
+to find my brother.  If she had gone near the spot where his body lay,
+it was without her knowledge.  That she had been bewildered when
+questioned by the market-woman was not surprising, since she had passed
+a sleepless night and the fate of poor William was yet uncertain.
+Concerning the picture she could give no account.
+
+"I know," continued the unhappy victim, "how heavily and fatally this
+one circumstance weighs against me, but I have no power of explaining
+it; and when I have expressed my utter ignorance, I am only left to
+conjecture concerning the probabilities by which it might have been
+placed in my pocket.  But here also I am checked.  I believe that I
+have no enemy on earth, and none surely would have been so wicked as to
+destroy me wantonly.  Did the murderer place it there?  I know of no
+opportunity afforded him for so doing; or, if I had, why should he have
+stolen the jewel, to part with it again so soon?
+
+"I commit my cause to the justice of my judges, yet I see no room for
+hope.  I beg permission to have a few witnesses examined concerning my
+character, and if their testimony shall not overweigh my supposed
+guilt, I must be condemned, although I would pledge my salvation on my
+innocence."
+
+Several witnesses were called who had known her for many years, and
+they spoke well of her; but fear and hatred of the crime of which they
+supposed her guilty rendered them timorous and unwilling to come
+forward.  Elizabeth saw even this last resource, her excellent
+dispositions and irreproachable conduct, about to fail the accused,
+when, although violently agitated, she desired permission to address
+the court.
+
+"I am," said she, "the cousin of the unhappy child who was murdered, or
+rather his sister, for I was educated by and have lived with his
+parents ever since and even long before his birth.  It may therefore be
+judged indecent in me to come forward on this occasion, but when I see
+a fellow creature about to perish through the cowardice of her
+pretended friends, I wish to be allowed to speak, that I may say what I
+know of her character.  I am well acquainted with the accused.  I have
+lived in the same house with her, at one time for five and at another
+for nearly two years.  During all that period she appeared to me the
+most amiable and benevolent of human creatures.  She nursed Madame
+Frankenstein, my aunt, in her last illness, with the greatest affection
+and care and afterwards attended her own mother during a tedious
+illness, in a manner that excited the admiration of all who knew her,
+after which she again lived in my uncle's house, where she was beloved
+by all the family.  She was warmly attached to the child who is now
+dead and acted towards him like a most affectionate mother.  For my own
+part, I do not hesitate to say that, notwithstanding all the evidence
+produced against her, I believe and rely on her perfect innocence.  She
+had no temptation for such an action; as to the bauble on which the
+chief proof rests, if she had earnestly desired it, I should have
+willingly given it to her, so much do I esteem and value her."
+
+A murmur of approbation followed Elizabeth's simple and powerful
+appeal, but it was excited by her generous interference, and not in
+favour of poor Justine, on whom the public indignation was turned with
+renewed violence, charging her with the blackest ingratitude.  She
+herself wept as Elizabeth spoke, but she did not answer.  My own
+agitation and anguish was extreme during the whole trial.  I believed
+in her innocence; I knew it.  Could the demon who had (I did not for a
+minute doubt) murdered my brother also in his hellish sport have
+betrayed the innocent to death and ignominy?  I could not sustain the
+horror of my situation, and when I perceived that the popular voice and
+the countenances of the judges had already condemned my unhappy victim,
+I rushed out of the court in agony.  The tortures of the accused did
+not equal mine; she was sustained by innocence, but the fangs of
+remorse tore my bosom and would not forgo their hold.
+
+I passed a night of unmingled wretchedness.  In the morning I went to
+the court; my lips and throat were parched.  I dared not ask the fatal
+question, but I was known, and the officer guessed the cause of my
+visit.  The ballots had been thrown; they were all black, and Justine
+was condemned.
+
+I cannot pretend to describe what I then felt.  I had before
+experienced sensations of horror, and I have endeavoured to bestow upon
+them adequate expressions, but words cannot convey an idea of the
+heart-sickening despair that I then endured.  The person to whom I
+addressed myself added that Justine had already confessed her guilt.
+"That evidence," he observed, "was hardly required in so glaring a
+case, but I am glad of it, and, indeed, none of our judges like to
+condemn a criminal upon circumstantial evidence, be it ever so
+decisive."
+
+This was strange and unexpected intelligence; what could it mean?  Had
+my eyes deceived me?  And was I really as mad as the whole world would
+believe me to be if I disclosed the object of my suspicions?  I
+hastened to return home, and Elizabeth eagerly demanded the result.
+
+"My cousin," replied I, "it is decided as you may have expected; all
+judges had rather that ten innocent should suffer than that one guilty
+should escape.  But she has confessed."
+
+This was a dire blow to poor Elizabeth, who had relied with firmness
+upon Justine's innocence.  "Alas!" said she.  "How shall I ever again
+believe in human goodness?  Justine, whom I loved and esteemed as my
+sister, how could she put on those smiles of innocence only to betray?
+Her mild eyes seemed incapable of any severity or guile, and yet she
+has committed a murder."
+
+Soon after we heard that the poor victim had expressed a desire to see
+my cousin.  My father wished her not to go but said that he left it to
+her own judgment and feelings to decide.  "Yes," said Elizabeth, "I
+will go, although she is guilty; and you, Victor, shall accompany me; I
+cannot go alone."  The idea of this visit was torture to me, yet I
+could not refuse.  We entered the gloomy prison chamber and beheld
+Justine sitting on some straw at the farther end; her hands were
+manacled, and her head rested on her knees.  She rose on seeing us
+enter, and when we were left alone with her, she threw herself at the
+feet of Elizabeth, weeping bitterly.  My cousin wept also.
+
+"Oh, Justine!" said she.  "Why did you rob me of my last consolation?
+I relied on your innocence, and although I was then very wretched, I
+was not so miserable as I am now."
+
+"And do you also believe that I am so very, very wicked?  Do you also
+join with my enemies to crush me, to condemn me as a murderer?" Her
+voice was suffocated with sobs.
+
+"Rise, my poor girl," said Elizabeth; "why do you kneel, if you are
+innocent?  I am not one of your enemies, I believed you guiltless,
+notwithstanding every evidence, until I heard that you had yourself
+declared your guilt.  That report, you say, is false; and be assured,
+dear Justine, that nothing can shake my confidence in you for a moment,
+but your own confession."
+
+"I did confess, but I confessed a lie.  I confessed, that I might
+obtain absolution; but now that falsehood lies heavier at my heart than
+all my other sins.  The God of heaven forgive me!  Ever since I was
+condemned, my confessor has besieged me; he threatened and menaced,
+until I almost began to think that I was the monster that he said I
+was.  He threatened excommunication and hell fire in my last moments if
+I continued obdurate.  Dear lady, I had none to support me; all looked
+on me as a wretch doomed to ignominy and perdition.  What could I do?
+In an evil hour I subscribed to a lie; and now only am I truly
+miserable."
+
+She paused, weeping, and then continued, "I thought with horror, my
+sweet lady, that you should believe your Justine, whom your blessed
+aunt had so highly honoured, and whom you loved, was a creature capable
+of a crime which none but the devil himself could have perpetrated.
+Dear William! dearest blessed child!  I soon shall see you again in
+heaven, where we shall all be happy; and that consoles me, going as I
+am to suffer ignominy and death."
+
+"Oh, Justine!  Forgive me for having for one moment distrusted you.
+Why did you confess?  But do not mourn, dear girl.  Do not fear.  I
+will proclaim, I will prove your innocence.  I will melt the stony
+hearts of your enemies by my tears and prayers.  You shall not die!
+You, my playfellow, my companion, my sister, perish on the scaffold!
+No!  No!  I never could survive so horrible a misfortune."
+
+Justine shook her head mournfully.  "I do not fear to die," she said;
+"that pang is past.  God raises my weakness and gives me courage to
+endure the worst.  I leave a sad and bitter world; and if you remember
+me and think of me as of one unjustly condemned, I am resigned to the
+fate awaiting me.  Learn from me, dear lady, to submit in patience to
+the will of heaven!"
+
+During this conversation I had retired to a corner of the prison room,
+where I could conceal the horrid anguish that possessed me.  Despair!
+Who dared talk of that?  The poor victim, who on the morrow was to pass
+the awful boundary between life and death, felt not, as I did, such
+deep and bitter agony.  I gnashed my teeth and ground them together,
+uttering a groan that came from my inmost soul.  Justine started.  When
+she saw who it was, she approached me and said, "Dear sir, you are very
+kind to visit me; you, I hope, do not believe that I am guilty?"
+
+I could not answer.  "No, Justine," said Elizabeth; "he is more
+convinced of your innocence than I was, for even when he heard that you
+had confessed, he did not credit it."
+
+"I truly thank him.  In these last moments I feel the sincerest
+gratitude towards those who think of me with kindness.  How sweet is
+the affection of others to such a wretch as I am!  It removes more than
+half my misfortune, and I feel as if I could die in peace now that my
+innocence is acknowledged by you, dear lady, and your cousin."
+
+Thus the poor sufferer tried to comfort others and herself.  She indeed
+gained the resignation she desired.  But I, the true murderer, felt the
+never-dying worm alive in my bosom, which allowed of no hope or
+consolation.  Elizabeth also wept and was unhappy, but hers also was
+the misery of innocence, which, like a cloud that passes over the fair
+moon, for a while hides but cannot tarnish its brightness.  Anguish and
+despair had penetrated into the core of my heart; I bore a hell within
+me which nothing could extinguish.  We stayed several hours with
+Justine, and it was with great difficulty that Elizabeth could tear
+herself away.  "I wish," cried she, "that I were to die with you; I
+cannot live in this world of misery."
+
+Justine assumed an air of cheerfulness, while she with difficulty
+repressed her bitter tears.  She embraced Elizabeth and said in a voice
+of half-suppressed emotion, "Farewell, sweet lady, dearest Elizabeth,
+my beloved and only friend; may heaven, in its bounty, bless and
+preserve you; may this be the last misfortune that you will ever
+suffer!  Live, and be happy, and make others so."
+
+And on the morrow Justine died.  Elizabeth's heart-rending eloquence
+failed to move the judges from their settled conviction in the
+criminality of the saintly sufferer.  My passionate and indignant
+appeals were lost upon them.  And when I received their cold answers
+and heard the harsh, unfeeling reasoning of these men, my purposed
+avowal died away on my lips.  Thus I might proclaim myself a madman,
+but not revoke the sentence passed upon my wretched victim.  She
+perished on the scaffold as a murderess!
+
+From the tortures of my own heart, I turned to contemplate the deep and
+voiceless grief of my Elizabeth.  This also was my doing!  And my
+father's woe, and the desolation of that late so smiling home all was
+the work of my thrice-accursed hands!  Ye weep, unhappy ones, but these
+are not your last tears!  Again shall you raise the funeral wail, and
+the sound of your lamentations shall again and again be heard!
+Frankenstein, your son, your kinsman, your early, much-loved friend; he
+who would spend each vital drop of blood for your sakes, who has no
+thought nor sense of joy except as it is mirrored also in your dear
+countenances, who would fill the air with blessings and spend his life
+in serving you--he bids you weep, to shed countless tears; happy beyond
+his hopes, if thus inexorable fate be satisfied, and if the destruction
+pause before the peace of the grave have succeeded to your sad torments!
+
+Thus spoke my prophetic soul, as, torn by remorse, horror, and despair,
+I beheld those I loved spend vain sorrow upon the graves of William and
+Justine, the first hapless victims to my unhallowed arts.
+
+
+
+Chapter 9
+
+Nothing is more painful to the human mind than, after the feelings have
+been worked up by a quick succession of events, the dead calmness of
+inaction and certainty which follows and deprives the soul both of hope
+and fear.  Justine died, she rested, and I was alive.  The blood flowed
+freely in my veins, but a weight of despair and remorse pressed on my
+heart which nothing could remove.  Sleep fled from my eyes; I wandered
+like an evil spirit, for I had committed deeds of mischief beyond
+description horrible, and more, much more (I persuaded myself) was yet
+behind.  Yet my heart overflowed with kindness and the love of virtue.
+I had begun life with benevolent intentions and thirsted for the moment
+when I should put them in practice and make myself useful to my fellow
+beings.  Now all was blasted; instead of that serenity of conscience
+which allowed me to look back upon the past with self-satisfaction, and
+from thence to gather promise of new hopes, I was seized by remorse and
+the sense of guilt, which hurried me away to a hell of intense tortures
+such as no language can describe.
+
+This state of mind preyed upon my health, which had perhaps never
+entirely recovered from the first shock it had sustained.  I shunned
+the face of man; all sound of joy or complacency was torture to me;
+solitude was my only consolation--deep, dark, deathlike solitude.
+
+My father observed with pain the alteration perceptible in my
+disposition and habits and endeavoured by arguments deduced from the
+feelings of his serene conscience and guiltless life to inspire me with
+fortitude and awaken in me the courage to dispel the dark cloud which
+brooded over me.  "Do you think, Victor," said he, "that I do not
+suffer also?  No one could love a child more than I loved your
+brother"--tears came into his eyes as he spoke--"but is it not a duty
+to the survivors that we should refrain from augmenting their
+unhappiness by an appearance of immoderate grief?  It is also a duty
+owed to yourself, for excessive sorrow prevents improvement or
+enjoyment, or even the discharge of daily usefulness, without which no
+man is fit for society."
+
+This advice, although good, was totally inapplicable to my case; I
+should have been the first to hide my grief and console my friends if
+remorse had not mingled its bitterness, and terror its alarm, with my
+other sensations.  Now I could only answer my father with a look of
+despair and endeavour to hide myself from his view.
+
+About this time we retired to our house at Belrive.  This change was
+particularly agreeable to me.  The shutting of the gates regularly at
+ten o'clock and the impossibility of remaining on the lake after that
+hour had rendered our residence within the walls of Geneva very irksome
+to me.  I was now free.  Often, after the rest of the family had
+retired for the night, I took the boat and passed many hours upon the
+water.  Sometimes, with my sails set, I was carried by the wind; and
+sometimes, after rowing into the middle of the lake, I left the boat to
+pursue its own course and gave way to my own miserable reflections.  I
+was often tempted, when all was at peace around me, and I the only
+unquiet thing that wandered restless in a scene so beautiful and
+heavenly--if I except some bat, or the frogs, whose harsh and
+interrupted croaking was heard only when I approached the shore--often,
+I say, I was tempted to plunge into the silent lake, that the waters
+might close over me and my calamities forever.  But I was restrained,
+when I thought of the heroic and suffering Elizabeth, whom I tenderly
+loved, and whose existence was bound up in mine.  I thought also of my
+father and surviving brother; should I by my base desertion leave them
+exposed and unprotected to the malice of the fiend whom I had let loose
+among them?
+
+At these moments I wept bitterly and wished that peace would revisit my
+mind only that I might afford them consolation and happiness.  But that
+could not be.  Remorse extinguished every hope.  I had been the author
+of unalterable evils, and I lived in daily fear lest the monster whom I
+had created should perpetrate some new wickedness.  I had an obscure
+feeling that all was not over and that he would still commit some
+signal crime, which by its enormity should almost efface the
+recollection of the past.  There was always scope for fear so long as
+anything I loved remained behind.  My abhorrence of this fiend cannot
+be conceived.  When I thought of him I gnashed my teeth, my eyes became
+inflamed, and I ardently wished to extinguish that life which I had so
+thoughtlessly bestowed.  When I reflected on his crimes and malice, my
+hatred and revenge burst all bounds of moderation.  I would have made a
+pilgrimage to the highest peak of the Andes, could I when there have
+precipitated him to their base.  I wished to see him again, that I
+might wreak the utmost extent of abhorrence on his head and avenge the
+deaths of William and Justine.  Our house was the house of mourning. My
+father's health was deeply shaken by the horror of the recent events.
+Elizabeth was sad and desponding; she no longer took delight in her
+ordinary occupations; all pleasure seemed to her sacrilege toward the
+dead; eternal woe and tears she then thought was the just tribute she
+should pay to innocence so blasted and destroyed.  She was no longer
+that happy creature who in earlier youth wandered with me on the banks
+of the lake and talked with ecstasy of our future prospects.  The first
+of those sorrows which are sent to wean us from the earth had visited
+her, and its dimming influence quenched her dearest smiles.
+
+"When I reflect, my dear cousin," said she, "on the miserable death of
+Justine Moritz, I no longer see the world and its works as they before
+appeared to me.  Before, I looked upon the accounts of vice and
+injustice that I read in books or heard from others as tales of ancient
+days or imaginary evils; at least they were remote and more familiar to
+reason than to the imagination; but now misery has come home, and men
+appear to me as monsters thirsting for each other's blood.  Yet I am
+certainly unjust.  Everybody believed that poor girl to be guilty; and
+if she could have committed the crime for which she suffered, assuredly
+she would have been the most depraved of human creatures.  For the sake
+of a few jewels, to have murdered the son of her benefactor and friend,
+a child whom she had nursed from its birth, and appeared to love as if
+it had been her own!  I could not consent to the death of any human
+being, but certainly I should have thought such a creature unfit to
+remain in the society of men.  But she was innocent.  I know, I feel
+she was innocent; you are of the same opinion, and that confirms me.
+Alas!  Victor, when falsehood can look so like the truth, who can
+assure themselves of certain happiness?  I feel as if I were walking on
+the edge of a precipice, towards which thousands are crowding and
+endeavouring to plunge me into the abyss.  William and Justine were
+assassinated, and the murderer escapes; he walks about the world free,
+and perhaps respected.  But even if I were condemned to suffer on the
+scaffold for the same crimes, I would not change places with such a
+wretch."
+
+I listened to this discourse with the extremest agony.  I, not in deed,
+but in effect, was the true murderer.  Elizabeth read my anguish in my
+countenance, and kindly taking my hand, said, "My dearest friend, you
+must calm yourself.  These events have affected me, God knows how
+deeply; but I am not so wretched as you are.  There is an expression of
+despair, and sometimes of revenge, in your countenance that makes me
+tremble.  Dear Victor, banish these dark passions.  Remember the
+friends around you, who centre all their hopes in you.  Have we lost
+the power of rendering you happy?  Ah!  While we love, while we are
+true to each other, here in this land of peace and beauty, your native
+country, we may reap every tranquil blessing--what can disturb our
+peace?"
+
+And could not such words from her whom I fondly prized before every
+other gift of fortune suffice to chase away the fiend that lurked in my
+heart?  Even as she spoke I drew near to her, as if in terror, lest at
+that very moment the destroyer had been near to rob me of her.
+
+Thus not the tenderness of friendship, nor the beauty of earth, nor of
+heaven, could redeem my soul from woe; the very accents of love were
+ineffectual.  I was encompassed by a cloud which no beneficial
+influence could penetrate.  The wounded deer dragging its fainting
+limbs to some untrodden brake, there to gaze upon the arrow which had
+pierced it, and to die, was but a type of me.
+
+Sometimes I could cope with the sullen despair that overwhelmed me, but
+sometimes the whirlwind passions of my soul drove me to seek, by bodily
+exercise and by change of place, some relief from my intolerable
+sensations.  It was during an access of this kind that I suddenly left
+my home, and bending my steps towards the near Alpine valleys, sought
+in the magnificence, the eternity of such scenes, to forget myself and
+my ephemeral, because human, sorrows.  My wanderings were directed
+towards the valley of Chamounix.  I had visited it frequently during my
+boyhood.  Six years had passed since then:  _I_ was a wreck, but nought
+had changed in those savage and enduring scenes.
+
+I performed the first part of my journey on horseback.  I afterwards
+hired a mule, as the more sure-footed and least liable to receive
+injury on these rugged roads.  The weather was fine; it was about the
+middle of the month of August, nearly two months after the death of
+Justine, that miserable epoch from which I dated all my woe.  The
+weight upon my spirit was sensibly lightened as I plunged yet deeper in
+the ravine of Arve.  The immense mountains and precipices that overhung
+me on every side, the sound of the river raging among the rocks, and
+the dashing of the waterfalls around spoke of a power mighty as
+Omnipotence--and I ceased to fear or to bend before any being less
+almighty than that which had created and ruled the elements, here
+displayed in their most terrific guise.  Still, as I ascended higher,
+the valley assumed a more magnificent and astonishing character.
+Ruined castles hanging on the precipices of piny mountains, the
+impetuous Arve, and cottages every here and there peeping forth from
+among the trees formed a scene of singular beauty.  But it was
+augmented and rendered sublime by the mighty Alps, whose white and
+shining pyramids and domes towered above all, as belonging to another
+earth, the habitations of another race of beings.
+
+I passed the bridge of Pelissier, where the ravine, which the river
+forms, opened before me, and I began to ascend the mountain that
+overhangs it.  Soon after, I entered the valley of Chamounix.  This
+valley is more wonderful and sublime, but not so beautiful and
+picturesque as that of Servox, through which I had just passed.  The
+high and snowy mountains were its immediate boundaries, but I saw no
+more ruined castles and fertile fields.  Immense glaciers approached
+the road; I heard the rumbling thunder of the falling avalanche and
+marked the smoke of its passage.  Mont Blanc, the supreme and
+magnificent Mont Blanc, raised itself from the surrounding aiguilles,
+and its tremendous dome overlooked the valley.
+
+A tingling long-lost sense of pleasure often came across me during this
+journey.  Some turn in the road, some new object suddenly perceived and
+recognized, reminded me of days gone by, and were associated with the
+lighthearted gaiety of boyhood.  The very winds whispered in soothing
+accents, and maternal Nature bade me weep no more.  Then again the
+kindly influence ceased to act--I found myself fettered again to grief
+and indulging in all the misery of reflection.  Then I spurred on my
+animal, striving so to forget the world, my fears, and more than all,
+myself--or, in a more desperate fashion, I alighted and threw myself on
+the grass, weighed down by horror and despair.
+
+At length I arrived at the village of Chamounix.  Exhaustion succeeded
+to the extreme fatigue both of body and of mind which I had endured.
+For a short space of time I remained at the window watching the pallid
+lightnings that played above Mont Blanc and listening to the rushing of
+the Arve, which pursued its noisy way beneath.  The same lulling sounds
+acted as a lullaby to my too keen sensations; when I placed my head
+upon my pillow, sleep crept over me; I felt it as it came and blessed
+the giver of oblivion.
+
+
+
+Chapter 10
+
+I spent the following day roaming through the valley.  I stood beside
+the sources of the Arveiron, which take their rise in a glacier, that
+with slow pace is advancing down from the summit of the hills to
+barricade the valley.  The abrupt sides of vast mountains were before
+me; the icy wall of the glacier overhung me; a few shattered pines were
+scattered around; and the solemn silence of this glorious
+presence-chamber of imperial nature was broken only by the brawling
+waves or the fall of some vast fragment, the thunder sound of the
+avalanche or the cracking, reverberated along the mountains, of the
+accumulated ice, which, through the silent working of immutable laws,
+was ever and anon rent and torn, as if it had been but a plaything in
+their hands.  These sublime and magnificent scenes afforded me the
+greatest consolation that I was capable of receiving.  They elevated me
+from all littleness of feeling, and although they did not remove my
+grief, they subdued and tranquillized it.  In some degree, also, they
+diverted my mind from the thoughts over which it had brooded for the
+last month.  I retired to rest at night; my slumbers, as it were,
+waited on and ministered to by the assemblance of grand shapes which I
+had contemplated during the day.  They congregated round me; the
+unstained snowy mountain-top, the glittering pinnacle, the pine woods,
+and ragged bare ravine, the eagle, soaring amidst the clouds--they all
+gathered round me and bade me be at peace.
+
+Where had they fled when the next morning I awoke?  All of
+soul-inspiriting fled with sleep, and dark melancholy clouded every
+thought.  The rain was pouring in torrents, and thick mists hid the
+summits of the mountains, so that I even saw not the faces of those
+mighty friends.  Still I would penetrate their misty veil and seek them
+in their cloudy retreats.  What were rain and storm to me?  My mule was
+brought to the door, and I resolved to ascend to the summit of
+Montanvert.  I remembered the effect that the view of the tremendous
+and ever-moving glacier had produced upon my mind when I first saw it.
+It had then filled me with a sublime ecstasy that gave wings to the
+soul and allowed it to soar from the obscure world to light and joy.
+The sight of the awful and majestic in nature had indeed always the
+effect of solemnizing my mind and causing me to forget the passing
+cares of life.  I determined to go without a guide, for I was well
+acquainted with the path, and the presence of another would destroy the
+solitary grandeur of the scene.
+
+The ascent is precipitous, but the path is cut into continual and short
+windings, which enable you to surmount the perpendicularity of the
+mountain.  It is a scene terrifically desolate.  In a thousand spots
+the traces of the winter avalanche may be perceived, where trees lie
+broken and strewed on the ground, some entirely destroyed, others bent,
+leaning upon the jutting rocks of the mountain or transversely upon
+other trees.  The path, as you ascend higher, is intersected by ravines
+of snow, down which stones continually roll from above; one of them is
+particularly dangerous, as the slightest sound, such as even speaking
+in a loud voice, produces a concussion of air sufficient to draw
+destruction upon the head of the speaker.  The pines are not tall or
+luxuriant, but they are sombre and add an air of severity to the scene.
+I looked on the valley beneath; vast mists were rising from the rivers
+which ran through it and curling in thick wreaths around the opposite
+mountains, whose summits were hid in the uniform clouds, while rain
+poured from the dark sky and added to the melancholy impression I
+received from the objects around me.  Alas!  Why does man boast of
+sensibilities superior to those apparent in the brute; it only renders
+them more necessary beings.  If our impulses were confined to hunger,
+thirst, and desire, we might be nearly free; but now we are moved by
+every wind that blows and a chance word or scene that that word may
+convey to us.
+
+
+  We rest; a dream has power to poison sleep.
+   We rise; one wand'ring thought pollutes the day.
+  We feel, conceive, or reason; laugh or weep,
+   Embrace fond woe, or cast our cares away;
+  It is the same:  for, be it joy or sorrow,
+   The path of its departure still is free.
+  Man's yesterday may ne'er be like his morrow;
+   Nought may endure but mutability!
+
+
+It was nearly noon when I arrived at the top of the ascent.  For some
+time I sat upon the rock that overlooks the sea of ice.  A mist covered
+both that and the surrounding mountains.  Presently a breeze dissipated
+the cloud, and I descended upon the glacier.  The surface is very
+uneven, rising like the waves of a troubled sea, descending low, and
+interspersed by rifts that sink deep.  The field of ice is almost a
+league in width, but I spent nearly two hours in crossing it.  The
+opposite mountain is a bare perpendicular rock.  From the side where I
+now stood Montanvert was exactly opposite, at the distance of a league;
+and above it rose Mont Blanc, in awful majesty.  I remained in a recess
+of the rock, gazing on this wonderful and stupendous scene.  The sea,
+or rather the vast river of ice, wound among its dependent mountains,
+whose aerial summits hung over its recesses.  Their icy and glittering
+peaks shone in the sunlight over the clouds.  My heart, which was
+before sorrowful, now swelled with something like joy; I exclaimed,
+"Wandering spirits, if indeed ye wander, and do not rest in your narrow
+beds, allow me this faint happiness, or take me, as your companion,
+away from the joys of life."
+
+As I said this I suddenly beheld the figure of a man, at some distance,
+advancing towards me with superhuman speed.  He bounded over the
+crevices in the ice, among which I had walked with caution; his
+stature, also, as he approached, seemed to exceed that of man.  I was
+troubled; a mist came over my eyes, and I felt a faintness seize me,
+but I was quickly restored by the cold gale of the mountains.  I
+perceived, as the shape came nearer (sight tremendous and abhorred!)
+that it was the wretch whom I had created.  I trembled with rage and
+horror, resolving to wait his approach and then close with him in
+mortal combat.  He approached; his countenance bespoke bitter anguish,
+combined with disdain and malignity, while its unearthly ugliness
+rendered it almost too horrible for human eyes.  But I scarcely
+observed this; rage and hatred had at first deprived me of utterance,
+and I recovered only to overwhelm him with words expressive of furious
+detestation and contempt.
+
+"Devil," I exclaimed, "do you dare approach me?  And do not you fear
+the fierce vengeance of my arm wreaked on your miserable head?  Begone,
+vile insect!  Or rather, stay, that I may trample you to dust!  And,
+oh!  That I could, with the extinction of your miserable existence,
+restore those victims whom you have so diabolically murdered!"
+
+"I expected this reception," said the daemon.  "All men hate the
+wretched; how, then, must I be hated, who am miserable beyond all
+living things!  Yet you, my creator, detest and spurn me, thy creature,
+to whom thou art bound by ties only dissoluble by the annihilation of
+one of us.  You purpose to kill me.  How dare you sport thus with life?
+Do your duty towards me, and I will do mine towards you and the rest of
+mankind.  If you will comply with my conditions, I will leave them and
+you at peace; but if you refuse, I will glut the maw of death, until it
+be satiated with the blood of your remaining friends."
+
+"Abhorred monster!  Fiend that thou art!  The tortures of hell are too
+mild a vengeance for thy crimes.  Wretched devil!  You reproach me with
+your creation, come on, then, that I may extinguish the spark which I
+so negligently bestowed."
+
+My rage was without bounds; I sprang on him, impelled by all the
+feelings which can arm one being against the existence of another.
+
+He easily eluded me and said,
+
+"Be calm!  I entreat you to hear me before you give vent to your hatred
+on my devoted head.  Have I not suffered enough, that you seek to
+increase my misery?  Life, although it may only be an accumulation of
+anguish, is dear to me, and I will defend it.  Remember, thou hast made
+me more powerful than thyself; my height is superior to thine, my
+joints more supple.  But I will not be tempted to set myself in
+opposition to thee.  I am thy creature, and I will be even mild and
+docile to my natural lord and king if thou wilt also perform thy part,
+the which thou owest me.  Oh, Frankenstein, be not equitable to every
+other and trample upon me alone, to whom thy justice, and even thy
+clemency and affection, is most due.  Remember that I am thy creature;
+I ought to be thy Adam, but I am rather the fallen angel, whom thou
+drivest from joy for no misdeed.  Everywhere I see bliss, from which I
+alone am irrevocably excluded.  I was benevolent and good; misery made
+me a fiend.  Make me happy, and I shall again be virtuous."
+
+"Begone!  I will not hear you.  There can be no community between you
+and me; we are enemies.  Begone, or let us try our strength in a fight,
+in which one must fall."
+
+"How can I move thee?  Will no entreaties cause thee to turn a
+favourable eye upon thy creature, who implores thy goodness and
+compassion?  Believe me, Frankenstein, I was benevolent; my soul glowed
+with love and humanity; but am I not alone, miserably alone?  You, my
+creator, abhor me; what hope can I gather from your fellow creatures,
+who owe me nothing?  They spurn and hate me.  The desert mountains and
+dreary glaciers are my refuge.  I have wandered here many days; the
+caves of ice, which I only do not fear, are a dwelling to me, and the
+only one which man does not grudge.  These bleak skies I hail, for they
+are kinder to me than your fellow beings.  If the multitude of mankind
+knew of my existence, they would do as you do, and arm themselves for
+my destruction.  Shall I not then hate them who abhor me?  I will keep
+no terms with my enemies.  I am miserable, and they shall share my
+wretchedness.  Yet it is in your power to recompense me, and deliver
+them from an evil which it only remains for you to make so great, that
+not only you and your family, but thousands of others, shall be
+swallowed up in the whirlwinds of its rage.  Let your compassion be
+moved, and do not disdain me.  Listen to my tale; when you have heard
+that, abandon or commiserate me, as you shall judge that I deserve.
+But hear me.  The guilty are allowed, by human laws, bloody as they
+are, to speak in their own defence before they are condemned.  Listen
+to me, Frankenstein.  You accuse me of murder, and yet you would, with
+a satisfied conscience, destroy your own creature.  Oh, praise the
+eternal justice of man!  Yet I ask you not to spare me; listen to me,
+and then, if you can, and if you will, destroy the work of your hands."
+
+"Why do you call to my remembrance," I rejoined, "circumstances of
+which I shudder to reflect, that I have been the miserable origin and
+author?  Cursed be the day, abhorred devil, in which you first saw
+light!  Cursed (although I curse myself) be the hands that formed you!
+You have made me wretched beyond expression.  You have left me no power
+to consider whether I am just to you or not.  Begone!  Relieve me from
+the sight of your detested form."
+
+"Thus I relieve thee, my creator," he said, and placed his hated hands
+before my eyes, which I flung from me with violence; "thus I take from
+thee a sight which you abhor.  Still thou canst listen to me and grant
+me thy compassion.  By the virtues that I once possessed, I demand this
+from you.  Hear my tale; it is long and strange, and the temperature of
+this place is not fitting to your fine sensations; come to the hut upon
+the mountain.  The sun is yet high in the heavens; before it descends
+to hide itself behind your snowy precipices and illuminate another
+world, you will have heard my story and can decide.  On you it rests,
+whether I quit forever the neighbourhood of man and lead a harmless
+life, or become the scourge of your fellow creatures and the author of
+your own speedy ruin."
+
+As he said this he led the way across the ice; I followed.  My heart
+was full, and I did not answer him, but as I proceeded, I weighed the
+various arguments that he had used and determined at least to listen to
+his tale.  I was partly urged by curiosity, and compassion confirmed my
+resolution.  I had hitherto supposed him to be the murderer of my
+brother, and I eagerly sought a confirmation or denial of this opinion.
+For the first time, also, I felt what the duties of a creator towards
+his creature were, and that I ought to render him happy before I
+complained of his wickedness.  These motives urged me to comply with
+his demand.  We crossed the ice, therefore, and ascended the opposite
+rock.  The air was cold, and the rain again began to descend; we
+entered the hut, the fiend with an air of exultation, I with a heavy
+heart and depressed spirits.  But I consented to listen, and seating
+myself by the fire which my odious companion had lighted, he thus began
+his tale.
+
+
+
+Chapter 11
+
+"It is with considerable difficulty that I remember the original era of
+my being; all the events of that period appear confused and indistinct.
+A strange multiplicity of sensations seized me, and I saw, felt, heard,
+and smelt at the same time; and it was, indeed, a long time before I
+learned to distinguish between the operations of my various senses.  By
+degrees, I remember, a stronger light pressed upon my nerves, so that I
+was obliged to shut my eyes.  Darkness then came over me and troubled
+me, but hardly had I felt this when, by opening my eyes, as I now
+suppose, the light poured in upon me again.  I walked and, I believe,
+descended, but I presently found a great alteration in my sensations.
+Before, dark and opaque bodies had surrounded me, impervious to my
+touch or sight; but I now found that I could wander on at liberty, with
+no obstacles which I could not either surmount or avoid.  The light
+became more and more oppressive to me, and the heat wearying me as I
+walked, I sought a place where I could receive shade.  This was the
+forest near Ingolstadt; and here I lay by the side of a brook resting
+from my fatigue, until I felt tormented by hunger and thirst.  This
+roused me from my nearly dormant state, and I ate some berries which I
+found hanging on the trees or lying on the ground.  I slaked my thirst
+at the brook, and then lying down, was overcome by sleep.
+
+"It was dark when I awoke; I felt cold also, and half frightened, as it
+were, instinctively, finding myself so desolate.  Before I had quitted
+your apartment, on a sensation of cold, I had covered myself with some
+clothes, but these were insufficient to secure me from the dews of
+night.  I was a poor, helpless, miserable wretch; I knew, and could
+distinguish, nothing; but feeling pain invade me on all sides, I sat
+down and wept.
+
+"Soon a gentle light stole over the heavens and gave me a sensation of
+pleasure.  I started up and beheld a radiant form rise from among the
+trees.  [The moon]  I gazed with a kind of wonder.  It moved slowly,
+but it enlightened my path, and I again went out in search of berries.
+I was still cold when under one of the trees I found a huge cloak, with
+which I covered myself, and sat down upon the ground.  No distinct
+ideas occupied my mind; all was confused.  I felt light, and hunger,
+and thirst, and darkness; innumerable sounds rang in my ears, and on
+all sides various scents saluted me; the only object that I could
+distinguish was the bright moon, and I fixed my eyes on that with
+pleasure.
+
+"Several changes of day and night passed, and the orb of night had
+greatly lessened, when I began to distinguish my sensations from each
+other.  I gradually saw plainly the clear stream that supplied me with
+drink and the trees that shaded me with their foliage.  I was delighted
+when I first discovered that a pleasant sound, which often saluted my
+ears, proceeded from the throats of the little winged animals who had
+often intercepted the light from my eyes.  I began also to observe,
+with greater accuracy, the forms that surrounded me and to perceive the
+boundaries of the radiant roof of light which canopied me.  Sometimes I
+tried to imitate the pleasant songs of the birds but was unable.
+Sometimes I wished to express my sensations in my own mode, but the
+uncouth and inarticulate sounds which broke from me frightened me into
+silence again.
+
+"The moon had disappeared from the night, and again, with a lessened
+form, showed itself, while I still remained in the forest.  My
+sensations had by this time become distinct, and my mind received every
+day additional ideas.  My eyes became accustomed to the light and to
+perceive objects in their right forms; I distinguished the insect from
+the herb, and by degrees, one herb from another.  I found that the
+sparrow uttered none but harsh notes, whilst those of the blackbird and
+thrush were sweet and enticing.
+
+"One day, when I was oppressed by cold, I found a fire which had been
+left by some wandering beggars, and was overcome with delight at the
+warmth I experienced from it.  In my joy I thrust my hand into the live
+embers, but quickly drew it out again with a cry of pain.  How strange,
+I thought, that the same cause should produce such opposite effects!  I
+examined the materials of the fire, and to my joy found it to be
+composed of wood.  I quickly collected some branches, but they were wet
+and would not burn.  I was pained at this and sat still watching the
+operation of the fire.  The wet wood which I had placed near the heat
+dried and itself became inflamed.  I reflected on this, and by touching
+the various branches, I discovered the cause and busied myself in
+collecting a great quantity of wood, that I might dry it and have a
+plentiful supply of fire.  When night came on and brought sleep with
+it, I was in the greatest fear lest my fire should be extinguished.  I
+covered it carefully with dry wood and leaves and placed wet branches
+upon it; and then, spreading my cloak, I lay on the ground and sank
+into sleep.
+
+"It was morning when I awoke, and my first care was to visit the fire.
+I uncovered it, and a gentle breeze quickly fanned it into a flame.  I
+observed this also and contrived a fan of branches, which roused the
+embers when they were nearly extinguished.  When night came again I
+found, with pleasure, that the fire gave light as well as heat and that
+the discovery of this element was useful to me in my food, for I found
+some of the offals that the travellers had left had been roasted, and
+tasted much more savoury than the berries I gathered from the trees.  I
+tried, therefore, to dress my food in the same manner, placing it on
+the live embers.  I found that the berries were spoiled by this
+operation, and the nuts and roots much improved.
+
+"Food, however, became scarce, and I often spent the whole day
+searching in vain for a few acorns to assuage the pangs of hunger. When
+I found this, I resolved to quit the place that I had hitherto
+inhabited, to seek for one where the few wants I experienced would be
+more easily satisfied.  In this emigration I exceedingly lamented the
+loss of the fire which I had obtained through accident and knew not how
+to reproduce it.  I gave several hours to the serious consideration of
+this difficulty, but I was obliged to relinquish all attempt to supply
+it, and wrapping myself up in my cloak, I struck across the wood
+towards the setting sun.  I passed three days in these rambles and at
+length discovered the open country.  A great fall of snow had taken
+place the night before, and the fields were of one uniform white; the
+appearance was disconsolate, and I found my feet chilled by the cold
+damp substance that covered the ground.
+
+"It was about seven in the morning, and I longed to obtain food and
+shelter; at length I perceived a small hut, on a rising ground, which
+had doubtless been built for the convenience of some shepherd.  This
+was a new sight to me, and I examined the structure with great
+curiosity.  Finding the door open, I entered.  An old man sat in it,
+near a fire, over which he was preparing his breakfast.  He turned on
+hearing a noise, and perceiving me, shrieked loudly, and quitting the
+hut, ran across the fields with a speed of which his debilitated form
+hardly appeared capable.  His appearance, different from any I had ever
+before seen, and his flight somewhat surprised me.  But I was enchanted
+by the appearance of the hut; here the snow and rain could not
+penetrate; the ground was dry; and it presented to me then as exquisite
+and divine a retreat as Pandemonium appeared to the demons of hell
+after their sufferings in the lake of fire.  I greedily devoured the
+remnants of the shepherd's breakfast, which consisted of bread, cheese,
+milk, and wine; the latter, however, I did not like.  Then, overcome by
+fatigue, I lay down among some straw and fell asleep.
+
+"It was noon when I awoke, and allured by the warmth of the sun, which
+shone brightly on the white ground, I determined to recommence my
+travels; and, depositing the remains of the peasant's breakfast in a
+wallet I found, I proceeded across the fields for several hours, until
+at sunset I arrived at a village.  How miraculous did this appear!  The
+huts, the neater cottages, and stately houses engaged my admiration by
+turns.  The vegetables in the gardens, the milk and cheese that I saw
+placed at the windows of some of the cottages, allured my appetite. One
+of the best of these I entered, but I had hardly placed my foot within
+the door before the children shrieked, and one of the women fainted.
+The whole village was roused; some fled, some attacked me, until,
+grievously bruised by stones and many other kinds of missile weapons, I
+escaped to the open country and fearfully took refuge in a low hovel,
+quite bare, and making a wretched appearance after the palaces I had
+beheld in the village.  This hovel however, joined a cottage of a neat
+and pleasant appearance, but after my late dearly bought experience, I
+dared not enter it.  My place of refuge was constructed of wood, but so
+low that I could with difficulty sit upright in it.  No wood, however,
+was placed on the earth, which formed the floor, but it was dry; and
+although the wind entered it by innumerable chinks, I found it an
+agreeable asylum from the snow and rain.
+
+"Here, then, I retreated and lay down happy to have found a shelter,
+however miserable, from the inclemency of the season, and still more
+from the barbarity of man.  As soon as morning dawned I crept from my
+kennel, that I might view the adjacent cottage and discover if I could
+remain in the habitation I had found.  It was situated against the back
+of the cottage and surrounded on the sides which were exposed by a pig
+sty and a clear pool of water.  One part was open, and by that I had
+crept in; but now I covered every crevice by which I might be perceived
+with stones and wood, yet in such a manner that I might move them on
+occasion to pass out; all the light I enjoyed came through the sty, and
+that was sufficient for me.
+
+"Having thus arranged my dwelling and carpeted it with clean straw, I
+retired, for I saw the figure of a man at a distance, and I remembered
+too well my treatment the night before to trust myself in his power.  I
+had first, however, provided for my sustenance for that day by a loaf
+of coarse bread, which I purloined, and a cup with which I could drink
+more conveniently than from my hand of the pure water which flowed by
+my retreat.  The floor was a little raised, so that it was kept
+perfectly dry, and by its vicinity to the chimney of the cottage it was
+tolerably warm.
+
+"Being thus provided, I resolved to reside in this hovel until
+something should occur which might alter my determination.  It was
+indeed a paradise compared to the bleak forest, my former residence,
+the rain-dropping branches, and dank earth.  I ate my breakfast with
+pleasure and was about to remove a plank to procure myself a little
+water when I heard a step, and looking through a small chink, I beheld
+a young creature, with a pail on her head, passing before my hovel. The
+girl was young and of gentle demeanour, unlike what I have since found
+cottagers and farmhouse servants to be.  Yet she was meanly dressed, a
+coarse blue petticoat and a linen jacket being her only garb; her fair
+hair was plaited but not adorned:  she looked patient yet sad.  I lost
+sight of her, and in about a quarter of an hour she returned bearing
+the pail, which was now partly filled with milk.  As she walked along,
+seemingly incommoded by the burden, a young man met her, whose
+countenance expressed a deeper despondence.  Uttering a few sounds with
+an air of melancholy, he took the pail from her head and bore it to the
+cottage himself.  She followed, and they disappeared.  Presently I saw
+the young man again, with some tools in his hand, cross the field
+behind the cottage; and the girl was also busied, sometimes in the
+house and sometimes in the yard.
+
+"On examining my dwelling, I found that one of the windows of the
+cottage had formerly occupied a part of it, but the panes had been
+filled up with wood. In one of these was a small and almost
+imperceptible chink through which the eye could just penetrate.
+Through this crevice a small room was visible, whitewashed and clean
+but very bare of furniture. In one corner, near a small fire, sat an
+old man, leaning his head on his hands in a disconsolate attitude. The
+young girl was occupied in arranging the cottage; but presently she
+took something out of a drawer, which employed her hands, and she sat
+down beside the old man, who, taking up an instrument, began to play
+and to produce sounds sweeter than the voice of the thrush or the
+nightingale. It was a lovely sight, even to me, poor wretch who had
+never beheld aught beautiful before. The silver hair and benevolent
+countenance of the aged cottager won my reverence, while the gentle
+manners of the girl enticed my love. He played a sweet mournful air
+which I perceived drew tears from the eyes of his amiable companion, of
+which the old man took no notice, until she sobbed audibly; he then
+pronounced a few sounds, and the fair creature, leaving her work, knelt
+at his feet. He raised her and smiled with such kindness and affection
+that I felt sensations of a peculiar and overpowering nature; they were
+a mixture of pain and pleasure, such as I had never before experienced,
+either from hunger or cold, warmth or food; and I withdrew from the
+window, unable to bear these emotions.
+
+"Soon after this the young man returned, bearing on his shoulders a
+load of wood.  The girl met him at the door, helped to relieve him of
+his burden, and taking some of the fuel into the cottage, placed it on
+the fire; then she and the youth went apart into a nook of the cottage,
+and he showed her a large loaf and a piece of cheese.  She seemed
+pleased and went into the garden for some roots and plants, which she
+placed in water, and then upon the fire.  She afterwards continued her
+work, whilst the young man went into the garden and appeared busily
+employed in digging and pulling up roots.  After he had been employed
+thus about an hour, the young woman joined him and they entered the
+cottage together.
+
+"The old man had, in the meantime, been pensive, but on the appearance
+of his companions he assumed a more cheerful air, and they sat down to
+eat.  The meal was quickly dispatched.  The young woman was again
+occupied in arranging the cottage, the old man walked before the
+cottage in the sun for a few minutes, leaning on the arm of the youth.
+Nothing could exceed in beauty the contrast between these two excellent
+creatures.  One was old, with silver hairs and a countenance beaming
+with benevolence and love; the younger was slight and graceful in his
+figure, and his features were moulded with the finest symmetry, yet his
+eyes and attitude expressed the utmost sadness and despondency.  The
+old man returned to the cottage, and the youth, with tools different
+from those he had used in the morning, directed his steps across the
+fields.
+
+"Night quickly shut in, but to my extreme wonder, I found that the
+cottagers had a means of prolonging light by the use of tapers, and was
+delighted to find that the setting of the sun did not put an end to the
+pleasure I experienced in watching my human neighbours.  In the evening
+the young girl and her companion were employed in various occupations
+which I did not understand; and the old man again took up the
+instrument which produced the divine sounds that had enchanted me in
+the morning.  So soon as he had finished, the youth began, not to play,
+but to utter sounds that were monotonous, and neither resembling the
+harmony of the old man's instrument nor the songs of the birds; I since
+found that he read aloud, but at that time I knew nothing of the
+science of words or letters.
+
+"The family, after having been thus occupied for a short time,
+extinguished their lights and retired, as I conjectured, to rest."
+
+
+
+Chapter 12
+
+"I lay on my straw, but I could not sleep.  I thought of the
+occurrences of the day.  What chiefly struck me was the gentle manners
+of these people, and I longed to join them, but dared not.  I
+remembered too well the treatment I had suffered the night before from
+the barbarous villagers, and resolved, whatever course of conduct I
+might hereafter think it right to pursue, that for the present I would
+remain quietly in my hovel, watching and endeavouring to discover the
+motives which influenced their actions.
+
+"The cottagers arose the next morning before the sun.  The young woman
+arranged the cottage and prepared the food, and the youth departed
+after the first meal.
+
+"This day was passed in the same routine as that which preceded it.
+The young man was constantly employed out of doors, and the girl in
+various laborious occupations within.  The old man, whom I soon
+perceived to be blind, employed his leisure hours on his instrument or
+in contemplation.  Nothing could exceed the love and respect which the
+younger cottagers exhibited towards their venerable companion.  They
+performed towards him every little office of affection and duty with
+gentleness, and he rewarded them by his benevolent smiles.
+
+"They were not entirely happy.  The young man and his companion often
+went apart and appeared to weep.  I saw no cause for their unhappiness,
+but I was deeply affected by it.  If such lovely creatures were
+miserable, it was less strange that I, an imperfect and solitary being,
+should be wretched.  Yet why were these gentle beings unhappy?  They
+possessed a delightful house (for such it was in my eyes) and every
+luxury; they had a fire to warm them when chill and delicious viands
+when hungry; they were dressed in excellent clothes; and, still more,
+they enjoyed one another's company and speech, interchanging each day
+looks of affection and kindness.  What did their tears imply?  Did they
+really express pain?  I was at first unable to solve these questions,
+but perpetual attention and time explained to me many appearances which
+were at first enigmatic.
+
+"A considerable period elapsed before I discovered one of the causes of
+the uneasiness of this amiable family:  it was poverty, and they
+suffered that evil in a very distressing degree.  Their nourishment
+consisted entirely of the vegetables of their garden and the milk of
+one cow, which gave very little during the winter, when its masters
+could scarcely procure food to support it.  They often, I believe,
+suffered the pangs of hunger very poignantly, especially the two
+younger cottagers, for several times they placed food before the old
+man when they reserved none for themselves.
+
+"This trait of kindness moved me sensibly.  I had been accustomed,
+during the night, to steal a part of their store for my own
+consumption, but when I found that in doing this I inflicted pain on
+the cottagers, I abstained and satisfied myself with berries, nuts, and
+roots which I gathered from a neighbouring wood.
+
+"I discovered also another means through which I was enabled to assist
+their labours.  I found that the youth spent a great part of each day
+in collecting wood for the family fire, and during the night I often
+took his tools, the use of which I quickly discovered, and brought home
+firing sufficient for the consumption of several days.
+
+"I remember, the first time that I did this, the young woman, when she
+opened the door in the morning, appeared greatly astonished on seeing a
+great pile of wood on the outside.  She uttered some words in a loud
+voice, and the youth joined her, who also expressed surprise.  I
+observed, with pleasure, that he did not go to the forest that day, but
+spent it in repairing the cottage and cultivating the garden.
+
+"By degrees I made a discovery of still greater moment.  I found that
+these people possessed a method of communicating their experience and
+feelings to one another by articulate sounds.  I perceived that the
+words they spoke sometimes produced pleasure or pain, smiles or
+sadness, in the minds and countenances of the hearers.  This was indeed
+a godlike science, and I ardently desired to become acquainted with it.
+But I was baffled in every attempt I made for this purpose.  Their
+pronunciation was quick, and the words they uttered, not having any
+apparent connection with visible objects, I was unable to discover any
+clue by which I could unravel the mystery of their reference.  By great
+application, however, and after having remained during the space of
+several revolutions of the moon in my hovel, I discovered the names
+that were given to some of the most familiar objects of discourse; I
+learned and applied the words, 'fire,' 'milk,' 'bread,' and 'wood.'  I
+learned also the names of the cottagers themselves.  The youth and his
+companion had each of them several names, but the old man had only one,
+which was 'father.' The girl was called 'sister' or 'Agatha,' and the
+youth 'Felix,' 'brother,' or 'son.'  I cannot describe the delight I
+felt when I learned the ideas appropriated to each of these sounds and
+was able to pronounce them.  I distinguished several other words
+without being able as yet to understand or apply them, such as 'good,'
+'dearest,' 'unhappy.'
+
+"I spent the winter in this manner.  The gentle manners and beauty of
+the cottagers greatly endeared them to me; when they were unhappy, I
+felt depressed; when they rejoiced, I sympathized in their joys.  I saw
+few human beings besides them, and if any other happened to enter the
+cottage, their harsh manners and rude gait only enhanced to me the
+superior accomplishments of my friends.  The old man, I could perceive,
+often endeavoured to encourage his children, as sometimes I found that
+he called them, to cast off their melancholy.  He would talk in a
+cheerful accent, with an expression of goodness that bestowed pleasure
+even upon me.  Agatha listened with respect, her eyes sometimes filled
+with tears, which she endeavoured to wipe away unperceived; but I
+generally found that her countenance and tone were more cheerful after
+having listened to the exhortations of her father.  It was not thus
+with Felix.  He was always the saddest of the group, and even to my
+unpractised senses, he appeared to have suffered more deeply than his
+friends.  But if his countenance was more sorrowful, his voice was more
+cheerful than that of his sister, especially when he addressed the old
+man.
+
+"I could mention innumerable instances which, although slight, marked
+the dispositions of these amiable cottagers.  In the midst of poverty
+and want, Felix carried with pleasure to his sister the first little
+white flower that peeped out from beneath the snowy ground.  Early in
+the morning, before she had risen, he cleared away the snow that
+obstructed her path to the milk-house, drew water from the well, and
+brought the wood from the outhouse, where, to his perpetual
+astonishment, he found his store always replenished by an invisible
+hand.  In the day, I believe, he worked sometimes for a neighbouring
+farmer, because he often went forth and did not return until dinner,
+yet brought no wood with him.  At other times he worked in the garden,
+but as there was little to do in the frosty season, he read to the old
+man and Agatha.
+
+"This reading had puzzled me extremely at first, but by degrees I
+discovered that he uttered many of the same sounds when he read as when
+he talked.  I conjectured, therefore, that he found on the paper signs
+for speech which he understood, and I ardently longed to comprehend
+these also; but how was that possible when I did not even understand
+the sounds for which they stood as signs?  I improved, however,
+sensibly in this science, but not sufficiently to follow up any kind of
+conversation, although I applied my whole mind to the endeavour, for I
+easily perceived that, although I eagerly longed to discover myself to
+the cottagers, I ought not to make the attempt until I had first become
+master of their language, which knowledge might enable me to make them
+overlook the deformity of my figure, for with this also the contrast
+perpetually presented to my eyes had made me acquainted.
+
+"I had admired the perfect forms of my cottagers--their grace, beauty,
+and delicate complexions; but how was I terrified when I viewed myself
+in a transparent pool!  At first I started back, unable to believe that
+it was indeed I who was reflected in the mirror; and when I became
+fully convinced that I was in reality the monster that I am, I was
+filled with the bitterest sensations of despondence and mortification.
+Alas!  I did not yet entirely know the fatal effects of this miserable
+deformity.
+
+"As the sun became warmer and the light of day longer, the snow
+vanished, and I beheld the bare trees and the black earth.  From this
+time Felix was more employed, and the heart-moving indications of
+impending famine disappeared.  Their food, as I afterwards found, was
+coarse, but it was wholesome; and they procured a sufficiency of it.
+Several new kinds of plants sprang up in the garden, which they
+dressed; and these signs of comfort increased daily as the season
+advanced.
+
+"The old man, leaning on his son, walked each day at noon, when it did
+not rain, as I found it was called when the heavens poured forth its
+waters.  This frequently took place, but a high wind quickly dried the
+earth, and the season became far more pleasant than it had been.
+
+"My mode of life in my hovel was uniform.  During the morning I
+attended the motions of the cottagers, and when they were dispersed in
+various occupations, I slept; the remainder of the day was spent in
+observing my friends.  When they had retired to rest, if there was any
+moon or the night was star-light, I went into the woods and collected
+my own food and fuel for the cottage.  When I returned, as often as it
+was necessary, I cleared their path from the snow and performed those
+offices that I had seen done by Felix.  I afterwards found that these
+labours, performed by an invisible hand, greatly astonished them; and
+once or twice I heard them, on these occasions, utter the words 'good
+spirit,' 'wonderful'; but I did not then understand the signification
+of these terms.
+
+"My thoughts now became more active, and I longed to discover the
+motives and feelings of these lovely creatures; I was inquisitive to
+know why Felix appeared so miserable and Agatha so sad.  I thought
+(foolish wretch!) that it might be in my power to restore happiness to
+these deserving people.  When I slept or was absent, the forms of the
+venerable blind father, the gentle Agatha, and the excellent Felix
+flitted before me.  I looked upon them as superior beings who would be
+the arbiters of my future destiny.  I formed in my imagination a
+thousand pictures of presenting myself to them, and their reception of
+me.  I imagined that they would be disgusted, until, by my gentle
+demeanour and conciliating words, I should first win their favour and
+afterwards their love.
+
+"These thoughts exhilarated me and led me to apply with fresh ardour to
+the acquiring the art of language.  My organs were indeed harsh, but
+supple; and although my voice was very unlike the soft music of their
+tones, yet I pronounced such words as I understood with tolerable ease.
+It was as the ass and the lap-dog; yet surely the gentle ass whose
+intentions were affectionate, although his manners were rude, deserved
+better treatment than blows and execration.
+
+"The pleasant showers and genial warmth of spring greatly altered the
+aspect of the earth.  Men who before this change seemed to have been
+hid in caves dispersed themselves and were employed in various arts of
+cultivation.  The birds sang in more cheerful notes, and the leaves
+began to bud forth on the trees.  Happy, happy earth!  Fit habitation
+for gods, which, so short a time before, was bleak, damp, and
+unwholesome.  My spirits were elevated by the enchanting appearance of
+nature; the past was blotted from my memory, the present was tranquil,
+and the future gilded by bright rays of hope and anticipations of joy."
+
+
+
+Chapter 13
+
+"I now hasten to the more moving part of my story.  I shall relate
+events that impressed me with feelings which, from what I had been,
+have made me what I am.
+
+"Spring advanced rapidly; the weather became fine and the skies
+cloudless.  It surprised me that what before was desert and gloomy
+should now bloom with the most beautiful flowers and verdure.  My
+senses were gratified and refreshed by a thousand scents of delight and
+a thousand sights of beauty.
+
+"It was on one of these days, when my cottagers periodically rested
+from labour--the old man played on his guitar, and the children
+listened to him--that I observed the countenance of Felix was
+melancholy beyond expression; he sighed frequently, and once his father
+paused in his music, and I conjectured by his manner that he inquired
+the cause of his son's sorrow.  Felix replied in a cheerful accent, and
+the old man was recommencing his music when someone tapped at the door.
+
+"It was a lady on horseback, accompanied by a country-man as a guide.
+The lady was dressed in a dark suit and covered with a thick black
+veil.  Agatha asked a question, to which the stranger only replied by
+pronouncing, in a sweet accent, the name of Felix.  Her voice was
+musical but unlike that of either of my friends.  On hearing this word,
+Felix came up hastily to the lady, who, when she saw him, threw up her
+veil, and I beheld a countenance of angelic beauty and expression.  Her
+hair of a shining raven black, and curiously braided; her eyes were
+dark, but gentle, although animated; her features of a regular
+proportion, and her complexion wondrously fair, each cheek tinged with
+a lovely pink.
+
+"Felix seemed ravished with delight when he saw her, every trait of
+sorrow vanished from his face, and it instantly expressed a degree of
+ecstatic joy, of which I could hardly have believed it capable; his
+eyes sparkled, as his cheek flushed with pleasure; and at that moment I
+thought him as beautiful as the stranger.  She appeared affected by
+different feelings; wiping a few tears from her lovely eyes, she held
+out her hand to Felix, who kissed it rapturously and called her, as
+well as I could distinguish, his sweet Arabian.  She did not appear to
+understand him, but smiled.  He assisted her to dismount, and
+dismissing her guide, conducted her into the cottage.  Some
+conversation took place between him and his father, and the young
+stranger knelt at the old man's feet and would have kissed his hand,
+but he raised her and embraced her affectionately.
+
+"I soon perceived that although the stranger uttered articulate sounds
+and appeared to have a language of her own, she was neither understood
+by nor herself understood the cottagers.  They made many signs which I
+did not comprehend, but I saw that her presence diffused gladness
+through the cottage, dispelling their sorrow as the sun dissipates the
+morning mists.  Felix seemed peculiarly happy and with smiles of
+delight welcomed his Arabian.  Agatha, the ever-gentle Agatha, kissed
+the hands of the lovely stranger, and pointing to her brother, made
+signs which appeared to me to mean that he had been sorrowful until she
+came.  Some hours passed thus, while they, by their countenances,
+expressed joy, the cause of which I did not comprehend.  Presently I
+found, by the frequent recurrence of some sound which the stranger
+repeated after them, that she was endeavouring to learn their language;
+and the idea instantly occurred to me that I should make use of the
+same instructions to the same end.  The stranger learned about twenty
+words at the first lesson; most of them, indeed, were those which I had
+before understood, but I profited by the others.
+
+"As night came on, Agatha and the Arabian retired early.  When they
+separated Felix kissed the hand of the stranger and said, 'Good night
+sweet Safie.'  He sat up much longer, conversing with his father, and
+by the frequent repetition of her name I conjectured that their lovely
+guest was the subject of their conversation.  I ardently desired to
+understand them, and bent every faculty towards that purpose, but found
+it utterly impossible.
+
+"The next morning Felix went out to his work, and after the usual
+occupations of Agatha were finished, the Arabian sat at the feet of the
+old man, and taking his guitar, played some airs so entrancingly
+beautiful that they at once drew tears of sorrow and delight from my
+eyes.  She sang, and her voice flowed in a rich cadence, swelling or
+dying away like a nightingale of the woods.
+
+"When she had finished, she gave the guitar to Agatha, who at first
+declined it.  She played a simple air, and her voice accompanied it in
+sweet accents, but unlike the wondrous strain of the stranger.  The old
+man appeared enraptured and said some words which Agatha endeavoured to
+explain to Safie, and by which he appeared to wish to express that she
+bestowed on him the greatest delight by her music.
+
+"The days now passed as peaceably as before, with the sole alteration
+that joy had taken place of sadness in the countenances of my friends.
+Safie was always gay and happy; she and I improved rapidly in the
+knowledge of language, so that in two months I began to comprehend most
+of the words uttered by my protectors.
+
+"In the meanwhile also the black ground was covered with herbage, and
+the green banks interspersed with innumerable flowers, sweet to the
+scent and the eyes, stars of pale radiance among the moonlight woods;
+the sun became warmer, the nights clear and balmy; and my nocturnal
+rambles were an extreme pleasure to me, although they were considerably
+shortened by the late setting and early rising of the sun, for I never
+ventured abroad during daylight, fearful of meeting with the same
+treatment I had formerly endured in the first village which I entered.
+
+"My days were spent in close attention, that I might more speedily
+master the language; and I may boast that I improved more rapidly than
+the Arabian, who understood very little and conversed in broken
+accents, whilst I comprehended and could imitate almost every word that
+was spoken.
+
+"While I improved in speech, I also learned the science of letters as
+it was taught to the stranger, and this opened before me a wide field
+for wonder and delight.
+
+"The book from which Felix instructed Safie was Volney's Ruins of
+Empires.  I should not have understood the purport of this book had not
+Felix, in reading it, given very minute explanations.  He had chosen
+this work, he said, because the declamatory style was framed in
+imitation of the Eastern authors.  Through this work I obtained a
+cursory knowledge of history and a view of the several empires at
+present existing in the world; it gave me an insight into the manners,
+governments, and religions of the different nations of the earth.  I
+heard of the slothful Asiatics, of the stupendous genius and mental
+activity of the Grecians, of the wars and wonderful virtue of the early
+Romans--of their subsequent degenerating--of the decline of that mighty
+empire, of chivalry, Christianity, and kings.  I heard of the discovery
+of the American hemisphere and wept with Safie over the hapless fate of
+its original inhabitants.
+
+"These wonderful narrations inspired me with strange feelings.  Was
+man, indeed, at once so powerful, so virtuous and magnificent, yet so
+vicious and base?  He appeared at one time a mere scion of the evil
+principle and at another as all that can be conceived of noble and
+godlike.  To be a great and virtuous man appeared the highest honour
+that can befall a sensitive being; to be base and vicious, as many on
+record have been, appeared the lowest degradation, a condition more
+abject than that of the blind mole or harmless worm.  For a long time I
+could not conceive how one man could go forth to murder his fellow, or
+even why there were laws and governments; but when I heard details of
+vice and bloodshed, my wonder ceased and I turned away with disgust and
+loathing.
+
+"Every conversation of the cottagers now opened new wonders to me.
+While I listened to the instructions which Felix bestowed upon the
+Arabian, the strange system of human society was explained to me.  I
+heard of the division of property, of immense wealth and squalid
+poverty, of rank, descent, and noble blood.
+
+"The words induced me to turn towards myself.  I learned that the
+possessions most esteemed by your fellow creatures were high and
+unsullied descent united with riches.  A man might be respected with
+only one of these advantages, but without either he was considered,
+except in very rare instances, as a vagabond and a slave, doomed to
+waste his powers for the profits of the chosen few!  And what was I? Of
+my creation and creator I was absolutely ignorant, but I knew that I
+possessed no money, no friends, no kind of property.  I was, besides,
+endued with a figure hideously deformed and loathsome; I was not even
+of the same nature as man.  I was more agile than they and could
+subsist upon coarser diet; I bore the extremes of heat and cold with
+less injury to my frame; my stature far exceeded theirs.  When I looked
+around I saw and heard of none like me.  Was I, then, a monster, a blot
+upon the earth, from which all men fled and whom all men disowned?
+
+"I cannot describe to you the agony that these reflections inflicted
+upon me; I tried to dispel them, but sorrow only increased with
+knowledge.  Oh, that I had forever remained in my native wood, nor
+known nor felt beyond the sensations of hunger, thirst, and heat!
+
+"Of what a strange nature is knowledge!  It clings to the mind when it
+has once seized on it like a lichen on the rock.  I wished sometimes to
+shake off all thought and feeling, but I learned that there was but one
+means to overcome the sensation of pain, and that was death--a state
+which I feared yet did not understand.  I admired virtue and good
+feelings and loved the gentle manners and amiable qualities of my
+cottagers, but I was shut out from intercourse with them, except
+through means which I obtained by stealth, when I was unseen and
+unknown, and which rather increased than satisfied the desire I had of
+becoming one among my fellows.  The gentle words of Agatha and  the
+animated smiles of the charming Arabian were not for me.  The mild
+exhortations of the old man and the lively conversation of the loved
+Felix were not for me. Miserable, unhappy wretch!
+
+"Other lessons were impressed upon me even more deeply.  I heard of the
+difference of sexes, and the birth and growth of children, how the
+father doted on the smiles of the infant, and the lively sallies of the
+older child, how all the life and cares of the mother were wrapped up
+in the precious charge, how the mind of youth expanded and gained
+knowledge, of brother, sister, and all the various relationships which
+bind one human being to another in mutual bonds.
+
+"But where were my friends and relations?  No father had watched my
+infant days, no mother had blessed me with smiles and caresses; or if
+they had, all my past life was now a blot, a blind vacancy in which I
+distinguished nothing.  From my earliest remembrance I had been as I
+then was in height and proportion.  I had never yet seen a being
+resembling me or who claimed any intercourse with me.  What was I?  The
+question again recurred, to be answered only with groans.
+
+"I will soon explain to what these feelings tended, but allow me now to
+return to the cottagers, whose story excited in me such various
+feelings of indignation, delight, and wonder, but which all terminated
+in additional love and reverence for my protectors (for so I loved, in
+an innocent, half-painful self-deceit, to call them)."
+
+
+
+Chapter 14
+
+"Some time elapsed before I learned the history of my friends.  It was
+one which could not fail to impress itself deeply on my mind, unfolding
+as it did a number of circumstances, each interesting and wonderful to
+one so utterly inexperienced as I was.
+
+"The name of the old man was De Lacey.  He was descended from a good
+family in France, where he had lived for many years in affluence,
+respected by his superiors and beloved by his equals.  His son was bred
+in the service of his country, and Agatha had ranked with ladies of the
+highest distinction.  A few months before my arrival they had lived in
+a large and luxurious city called Paris, surrounded by friends and
+possessed of every enjoyment which virtue, refinement of intellect, or
+taste, accompanied by a moderate fortune, could afford.
+
+"The father of Safie had been the cause of their ruin.  He was a
+Turkish merchant and had inhabited Paris for many years, when, for some
+reason which I could not learn, he became obnoxious to the government.
+He was seized and cast into prison the very day that Safie arrived from
+Constantinople to join him.  He was tried and condemned to death.  The
+injustice of his sentence was very flagrant; all Paris was indignant;
+and it was judged that his religion and wealth rather than the crime
+alleged against him had been the cause of his condemnation.
+
+"Felix had accidentally been present at the trial; his horror and
+indignation were uncontrollable when he heard the decision of the
+court.  He made, at that moment, a solemn vow to deliver him and then
+looked around for the means.  After many fruitless attempts to gain
+admittance to the prison, he found a strongly grated window in an
+unguarded part of the building, which lighted the dungeon of the
+unfortunate Muhammadan, who, loaded with chains, waited in despair the
+execution of the barbarous sentence.  Felix visited the grate at night
+and made known to the prisoner his intentions in his favour.  The Turk,
+amazed and delighted, endeavoured to kindle the zeal of his deliverer
+by promises of reward and wealth.  Felix rejected his offers with
+contempt, yet when he saw the lovely Safie, who was allowed to visit
+her father and who by her gestures expressed her lively gratitude, the
+youth could not help owning to his own mind that the captive possessed
+a treasure which would fully reward his toil and hazard.
+
+"The Turk quickly perceived the impression that his daughter had made
+on the heart of Felix and endeavoured to secure him more entirely in
+his interests by the promise of her hand in marriage so soon as he
+should be conveyed to a place of safety.  Felix was too delicate to
+accept this offer, yet he looked forward to the probability of the
+event as to the consummation of his happiness.
+
+"During the ensuing days, while the preparations were going forward for
+the escape of the merchant, the zeal of Felix was warmed by several
+letters that he received from this lovely girl, who found means to
+express her thoughts in the language of her lover by the aid of an old
+man, a servant of her father who understood French.  She thanked him in
+the most ardent terms for his intended services towards her parent, and
+at the same time she gently deplored her own fate.
+
+"I have copies of these letters, for I found means, during my residence
+in the hovel, to procure the implements of writing; and the letters
+were often in the hands of Felix or Agatha.  Before I depart I will
+give them to you; they will prove the truth of my tale; but at present,
+as the sun is already far declined, I shall only have time to repeat
+the substance of them to you.
+
+"Safie related that her mother was a Christian Arab, seized and made a
+slave by the Turks; recommended by her beauty, she had won the heart of
+the father of Safie, who married her.  The young girl spoke in high and
+enthusiastic terms of her mother, who, born in freedom, spurned the
+bondage to which she was now reduced.  She instructed her daughter in
+the tenets of her religion and taught her to aspire to higher powers of
+intellect and an independence of spirit forbidden to the female
+followers of Muhammad.  This lady died, but her lessons were indelibly
+impressed on the mind of Safie, who sickened at the prospect of again
+returning to Asia and being immured within the walls of a harem,
+allowed only to occupy herself with infantile amusements, ill-suited to
+the temper of her soul, now accustomed to grand ideas and a noble
+emulation for virtue.  The prospect of marrying a Christian and
+remaining in a country where women were allowed to take a rank in
+society was enchanting to her.
+
+"The day for the execution of the Turk was fixed, but on the night
+previous to it he quitted his prison and before morning was distant
+many leagues from Paris.  Felix had procured passports in the name of
+his father, sister, and himself.  He had previously communicated his
+plan to the former, who aided the deceit by quitting his house, under
+the pretence of a journey and concealed himself, with his daughter, in
+an obscure part of Paris.
+
+"Felix conducted the fugitives through France to Lyons and across Mont
+Cenis to Leghorn, where the merchant had decided to wait a favourable
+opportunity of passing into some part of the Turkish dominions.
+
+"Safie resolved to remain with her father until the moment of his
+departure, before which time the Turk renewed his promise that she
+should be united to his deliverer; and Felix remained with them in
+expectation of that event; and in the meantime he enjoyed the society
+of the Arabian, who exhibited towards him the simplest and tenderest
+affection.  They conversed with one another through the means of an
+interpreter, and sometimes with the interpretation of looks; and Safie
+sang to him the divine airs of her native country.
+
+"The Turk allowed this intimacy to take place and encouraged the hopes
+of the youthful lovers, while in his heart he had formed far other
+plans.  He loathed the idea that his daughter should be united to a
+Christian, but he feared the resentment of Felix if he should appear
+lukewarm, for he knew that he was still in the power of his deliverer
+if he should choose to betray him to the Italian state which they
+inhabited.  He revolved a thousand plans by which he should be enabled
+to prolong the deceit until it might be no longer necessary, and
+secretly to take his daughter with him when he departed.  His plans
+were facilitated by the news which arrived from Paris.
+
+"The government of France were greatly enraged at the escape of their
+victim and spared no pains to detect and punish his deliverer.  The
+plot of Felix was quickly discovered, and De Lacey and Agatha were
+thrown into prison.  The news reached Felix and roused him from his
+dream of pleasure.  His blind and aged father and his gentle sister lay
+in a noisome dungeon while he enjoyed the free air and the society of
+her whom he loved.  This idea was torture to him.  He quickly arranged
+with the Turk that if the latter should find a favourable opportunity
+for escape before Felix could return to Italy, Safie should remain as a
+boarder at a convent at Leghorn; and then, quitting the lovely Arabian,
+he hastened to Paris and delivered himself up to the vengeance of the
+law, hoping to free De Lacey and Agatha by this proceeding.
+
+"He did not succeed.  They remained confined for five months before the
+trial took place, the result of which deprived them of their fortune
+and condemned them to a perpetual exile from their native country.
+
+"They found a miserable asylum in the cottage in Germany, where I
+discovered them.  Felix soon learned that the treacherous Turk, for
+whom he and his family endured such unheard-of oppression, on
+discovering that his deliverer was thus reduced to poverty and ruin,
+became a traitor to good feeling and honour and had quitted Italy with
+his daughter, insultingly sending Felix a pittance of money to aid him,
+as he said, in some plan of future maintenance.
+
+"Such were the events that preyed on the heart of Felix and rendered
+him, when I first saw him, the most miserable of his family.  He could
+have endured poverty, and while this distress had been the meed of his
+virtue, he gloried in it; but the ingratitude of the Turk and the loss
+of his beloved Safie were misfortunes more bitter and irreparable.  The
+arrival of the Arabian now infused new life into his soul.
+
+"When the news reached Leghorn that Felix was deprived of his wealth
+and rank, the merchant commanded his daughter to think no more of her
+lover, but to prepare to return to her native country.  The generous
+nature of Safie was outraged by this command; she attempted to
+expostulate with her father, but he left her angrily, reiterating his
+tyrannical mandate.
+
+"A few days after, the Turk entered his daughter's apartment and told
+her hastily that he had reason to believe that his residence at Leghorn
+had been divulged and that he should speedily be delivered up to the
+French government; he had consequently hired a vessel to convey him to
+Constantinople, for which city he should sail in a few hours.  He
+intended to leave his daughter under the care of a confidential
+servant, to follow at her leisure with the greater part of his
+property, which had not yet arrived at Leghorn.
+
+"When alone, Safie resolved in her own mind the plan of conduct that it
+would become her to pursue in this emergency.  A residence in Turkey
+was abhorrent to her; her religion and her feelings were alike averse
+to it.  By some papers of her father which fell into her hands she
+heard of the exile of her lover and learnt the name of the spot where
+he then resided.  She hesitated some time, but at length she formed her
+determination.  Taking with her some jewels that belonged to her and a
+sum of money, she quitted Italy with an attendant, a native of Leghorn,
+but who understood the common language of Turkey, and departed for
+Germany.
+
+"She arrived in safety at a town about twenty leagues from the cottage
+of De Lacey, when her attendant fell dangerously ill.  Safie nursed her
+with the most devoted affection, but the poor girl died, and the
+Arabian was left alone, unacquainted with the language of the country
+and utterly ignorant of the customs of the world.  She fell, however,
+into good hands.  The Italian had mentioned the name of the spot for
+which they were bound, and after her death the woman of the house in
+which they had lived took care that Safie should arrive in safety at
+the cottage of her lover."
+
+
+
+Chapter 15
+
+"Such was the history of my beloved cottagers.  It impressed me deeply.
+I learned, from the views of social life which it developed, to admire
+their virtues and to deprecate the vices of mankind.
+
+"As yet I looked upon crime as a distant evil, benevolence and
+generosity were ever present before me, inciting within me a desire to
+become an actor in the busy scene where so many admirable qualities
+were called forth and displayed.  But in giving an account of the
+progress of my intellect, I must not omit a circumstance which occurred
+in the beginning of the month of August of the same year.
+
+"One night during my accustomed visit to the neighbouring wood where I
+collected my own food and brought home firing for my protectors, I
+found on the ground a leathern portmanteau containing several articles
+of dress and some books.  I eagerly seized the prize and returned with
+it to my hovel.  Fortunately the books were written in the language,
+the elements of which I had acquired at the cottage; they consisted of
+Paradise Lost, a volume of Plutarch's Lives, and the Sorrows of Werter.
+The possession of these treasures gave me extreme delight; I now
+continually studied and exercised my mind upon these histories, whilst
+my friends were employed in their ordinary occupations.
+
+"I can hardly describe to you the effect of these books.  They produced
+in me an infinity of new images and feelings, that sometimes raised me
+to ecstasy, but more frequently sunk me into the lowest dejection.  In
+the Sorrows of Werter, besides the interest of its simple and affecting
+story, so many opinions are canvassed and so many lights thrown upon
+what had hitherto been to me obscure subjects that I found in it a
+never-ending source of speculation and astonishment.  The gentle and
+domestic manners it described, combined with lofty sentiments and
+feelings, which had for their object something out of self, accorded
+well with my experience among my protectors and with the wants which
+were forever alive in my own bosom.  But I thought Werter himself a
+more divine being than I had ever beheld or imagined; his character
+contained no pretension, but it sank deep.  The disquisitions upon
+death and suicide were calculated to fill  me with wonder.  I did not
+pretend to enter into the merits of the case, yet I inclined towards
+the opinions of the hero, whose extinction I wept, without precisely
+understanding it.
+
+"As I read, however, I applied much personally to my own feelings and
+condition.  I found myself similar yet at the same time strangely
+unlike to the beings concerning whom I read and to whose conversation I
+was a listener.  I sympathized with and partly understood them, but I
+was unformed in mind; I was dependent on none and related to none.
+'The path of my departure was free,' and there was none to lament my
+annihilation.  My person was hideous and my stature gigantic.  What did
+this mean?  Who was I?  What was I?  Whence did I come?  What was my
+destination?  These questions continually recurred, but I was unable to
+solve them.
+
+"The volume of Plutarch's Lives which I possessed contained the
+histories of the first founders of the ancient republics.  This book
+had a far different effect upon me from the Sorrows of Werter.  I
+learned from Werter's imaginations despondency and gloom, but Plutarch
+taught me high thoughts; he elevated me above the wretched sphere of my
+own reflections, to admire and love the heroes of past ages.  Many
+things I read surpassed my understanding and experience.  I had a very
+confused knowledge of kingdoms, wide extents of country, mighty rivers,
+and boundless seas.  But I was perfectly unacquainted with towns and
+large assemblages of men. The cottage of my protectors had been the
+only school in which I had studied human nature, but this book
+developed new and mightier scenes of action.  I read of men concerned
+in public affairs, governing or massacring their species.  I felt the
+greatest ardour for virtue rise within me, and abhorrence for vice, as
+far as I understood the signification of those terms, relative as they
+were, as I applied them, to pleasure and pain alone.  Induced by these
+feelings, I was of course led to admire peaceable lawgivers, Numa,
+Solon, and Lycurgus, in preference to Romulus and Theseus.  The
+patriarchal lives of my protectors caused these impressions to take a
+firm hold on my mind; perhaps, if my first introduction to humanity had
+been made by a young soldier, burning for glory and slaughter, I should
+have been imbued with different sensations.
+
+"But Paradise Lost excited different and far deeper emotions.  I read
+it, as I had read the other volumes which had fallen into my hands, as
+a true history.  It moved every feeling of wonder and awe that the
+picture of an omnipotent God warring with his creatures was capable of
+exciting.  I often referred the several situations, as their similarity
+struck me, to my own.  Like Adam, I was apparently united by no link to
+any other being in existence; but his state was far different from mine
+in every other respect.  He had come forth from the hands of God a
+perfect creature, happy and prosperous, guarded by the especial care of
+his Creator; he was allowed to converse with and acquire knowledge from
+beings of a superior nature, but I was wretched, helpless, and alone.
+Many times I considered Satan as the fitter emblem of my condition, for
+often, like him, when I viewed the bliss of my protectors, the bitter
+gall of envy rose within me.
+
+"Another circumstance strengthened and confirmed these feelings.  Soon
+after my arrival in the hovel I discovered some papers in the pocket of
+the dress which I had taken from your laboratory.  At first I had
+neglected them, but now that I was able to decipher the characters in
+which they were written, I began to study them with diligence.  It was
+your journal of the four months that preceded my creation.  You
+minutely described in these papers every step you took in the progress
+of your work; this history was mingled with accounts of domestic
+occurrences.  You doubtless recollect these papers.  Here they are.
+Everything is related in them which bears reference to my accursed
+origin; the whole detail of that series of disgusting circumstances
+which produced it is set in view; the minutest description of my odious
+and loathsome person is given, in language which painted your own
+horrors and rendered mine indelible.  I sickened as I read.  'Hateful
+day when I received life!' I exclaimed in agony.  'Accursed creator!
+Why did you form a monster so hideous that even YOU turned from me in
+disgust?  God, in pity, made man beautiful and alluring, after his own
+image; but my form is a filthy type of yours, more horrid even from the
+very resemblance.  Satan had his companions, fellow devils, to admire
+and encourage him, but I am solitary and abhorred.'
+
+"These were the reflections of my hours of despondency and solitude;
+but when I contemplated the virtues of the cottagers, their amiable and
+benevolent dispositions, I persuaded myself that when they should
+become acquainted with my admiration of their virtues they  would
+compassionate me and overlook my personal deformity.  Could they turn
+from their door one, however monstrous, who solicited their compassion
+and friendship?  I resolved, at least, not to despair, but in every way
+to fit myself for an interview with them which would decide my fate.  I
+postponed this attempt for some months longer, for the importance
+attached to its success inspired me with a dread lest I should fail.
+Besides, I found that my understanding improved so much with every
+day's experience that I was unwilling to commence this undertaking
+until a few more months should have added to my sagacity.
+
+"Several changes, in the meantime, took place in the cottage.  The
+presence of Safie diffused happiness among its inhabitants, and I also
+found that a greater degree of plenty reigned there.  Felix and Agatha
+spent more time in amusement and conversation, and were assisted in
+their labours by servants.  They did not appear rich, but they were
+contented and happy; their feelings were serene and peaceful, while
+mine became every day more tumultuous.  Increase of knowledge only
+discovered to me more clearly what a wretched outcast I was.  I
+cherished hope, it is true, but it vanished when I beheld my person
+reflected in water or my shadow in the moonshine, even as that frail
+image and that inconstant shade.
+
+"I endeavoured to crush these fears and to fortify myself for the trial
+which in a few months I resolved to undergo; and sometimes I allowed my
+thoughts, unchecked by reason, to ramble in the fields of Paradise, and
+dared to fancy amiable and lovely creatures sympathizing with my
+feelings and cheering my gloom; their angelic countenances breathed
+smiles of consolation.  But it was all a dream; no Eve soothed my
+sorrows nor shared my thoughts; I was alone.  I remembered Adam's
+supplication to his Creator.  But where was mine?  He had abandoned me,
+and in the bitterness of my heart I cursed him.
+
+"Autumn passed thus.  I saw, with surprise and grief, the leaves decay
+and fall, and nature again assume the barren and bleak appearance it
+had worn when I first beheld the woods and the lovely moon.  Yet I did
+not heed the bleakness of the weather; I was better fitted by my
+conformation for the endurance of cold than heat.  But my chief
+delights were the sight of the flowers, the birds, and all the gay
+apparel of summer; when those deserted me, I turned with more attention
+towards the cottagers.  Their happiness was not decreased by the
+absence of summer.  They loved and sympathized with one another; and
+their joys, depending on each other, were not interrupted by the
+casualties that took place around them.  The more I saw of them, the
+greater became my desire to claim their protection and kindness; my
+heart yearned to be known and loved by these amiable creatures; to see
+their sweet looks directed towards me with affection was the utmost
+limit of my ambition.  I dared not think that they would turn them from
+me with disdain and horror.  The poor that stopped at their door were
+never driven away.  I asked, it is true, for greater treasures than a
+little food or rest:  I required kindness and sympathy; but I did not
+believe myself utterly unworthy of it.
+
+"The winter advanced, and an entire revolution of the seasons had taken
+place since I awoke into life.  My attention at this time was solely
+directed towards my plan of introducing myself into the cottage of my
+protectors.  I revolved many projects, but that on which I finally
+fixed was to enter the dwelling when the blind old man should be alone.
+I had sagacity enough to discover that the unnatural hideousness of my
+person was the chief object of horror with those who had formerly
+beheld me.  My voice, although harsh, had nothing terrible in it; I
+thought, therefore, that if in the absence of his children I could gain
+the good will and mediation of the old De Lacey, I might by his means
+be tolerated by my younger protectors.
+
+"One day, when the sun shone on the red leaves that strewed the ground
+and diffused cheerfulness, although it denied warmth, Safie, Agatha,
+and Felix departed on a long country walk, and the old man, at his own
+desire, was left alone in the cottage.  When his children had departed,
+he took up his guitar and played several mournful but sweet airs, more
+sweet and mournful than I had ever heard him play before.  At first his
+countenance was illuminated with pleasure, but as he continued,
+thoughtfulness and sadness succeeded; at length, laying aside the
+instrument, he sat absorbed in reflection.
+
+"My heart beat quick; this was the hour and moment of trial, which
+would decide my hopes or realize my fears.  The servants were gone to a
+neighbouring fair.  All was silent in and around the cottage; it was an
+excellent opportunity; yet, when I proceeded to execute my plan, my
+limbs failed me and I sank to the ground.  Again I rose, and exerting
+all the firmness of which I was master, removed the planks which I had
+placed before my hovel to conceal my retreat.  The fresh air revived
+me, and with renewed determination I approached the door of their
+cottage.
+
+"I knocked.  'Who is there?' said the old man.  'Come in.'
+
+"I entered.  'Pardon this intrusion,' said I; 'I am a traveller in want
+of a little rest; you would greatly oblige me if you would allow me to
+remain a few minutes before the fire.'
+
+"'Enter,' said De Lacey, 'and I will try in what manner I can to
+relieve your wants; but, unfortunately, my children are from home, and
+as I am blind, I am afraid I shall find it difficult to procure food
+for you.'
+
+"'Do not trouble yourself, my kind host; I have food; it is warmth and
+rest only that I need.'
+
+"I sat down, and a silence ensued.  I knew that every minute was
+precious to me, yet I remained irresolute in what manner to commence
+the interview, when the old man addressed me.  'By your language,
+stranger, I suppose you are my countryman; are you French?'
+
+"'No; but I was educated by a French family and understand that
+language only.  I am now going to claim the protection of some friends,
+whom I sincerely love, and of whose favour I have some hopes.'
+
+"'Are they Germans?'
+
+"'No, they are French.  But let us change the subject.  I am an
+unfortunate and deserted creature, I look around and I have no relation
+or friend upon earth.  These amiable people to whom I go have never
+seen me and know little of me.  I am full of fears, for if I fail
+there, I am an outcast in the world forever.'
+
+"'Do not despair.  To be friendless is indeed to be unfortunate, but
+the hearts of men, when unprejudiced by any obvious self-interest, are
+full of brotherly love and charity.  Rely, therefore, on your hopes;
+and if these friends are good and amiable, do not despair.'
+
+"'They are kind--they are the most excellent creatures in the world;
+but, unfortunately, they are prejudiced against me.  I have good
+dispositions; my life has been hitherto harmless and in some degree
+beneficial; but a fatal prejudice clouds their eyes, and where they
+ought to see a feeling and kind friend, they behold only a detestable
+monster.'
+
+"'That is indeed unfortunate; but if you are really blameless, cannot
+you undeceive them?'
+
+"'I am about to undertake that task; and it is on that account that I
+feel so many overwhelming terrors.  I tenderly love these friends; I
+have, unknown to them, been for many months in the habits of daily
+kindness towards them; but they believe that I wish to injure them, and
+it is that prejudice which I wish to overcome.'
+
+"'Where do these friends reside?'
+
+"'Near this spot.'
+
+"The old man paused and then continued, 'If you will unreservedly
+confide to me the particulars of your tale, I perhaps may be of use in
+undeceiving them.  I am blind and cannot judge of your countenance, but
+there is something in your words which persuades me that you are
+sincere.  I am poor and an exile, but it will afford me true pleasure
+to be in any way serviceable to a human creature.'
+
+"'Excellent man!  I thank you and accept your generous offer.  You
+raise me from the dust by this kindness; and I trust that, by your aid,
+I shall not be driven from the society and sympathy of your fellow
+creatures.'
+
+"'Heaven forbid!  Even if you were really criminal, for that can only
+drive you to desperation, and not instigate you to virtue.  I also am
+unfortunate; I and my family have been condemned, although innocent;
+judge, therefore, if I do not feel for your misfortunes.'
+
+"'How can I thank you, my best and only benefactor?  From your lips
+first have I heard the voice of kindness directed towards me; I shall
+be forever grateful; and your present humanity assures me of success
+with those friends whom I am on the point of meeting.'
+
+"'May I know the names and residence of those friends?'
+
+"I paused. This, I thought, was the moment of decision, which was to
+rob me of or bestow happiness on me forever.  I struggled vainly for
+firmness sufficient to answer him, but the effort destroyed all my
+remaining strength; I sank on the chair and sobbed aloud.  At that
+moment I heard the steps of my younger protectors.  I had not a moment
+to lose, but seizing the hand of the old man, I cried, 'Now is the
+time!  Save and protect me!  You and your family are the friends whom I
+seek.  Do not you desert me in the hour of trial!'
+
+"'Great God!' exclaimed the old man.  'Who are you?'
+
+"At that instant the cottage door was opened, and Felix, Safie, and
+Agatha entered.  Who can describe their horror and consternation on
+beholding me?  Agatha fainted, and Safie, unable to attend to her
+friend, rushed out of the cottage.  Felix darted forward, and with
+supernatural force tore me from his father, to whose knees I clung, in
+a transport of fury, he dashed me to the ground and struck me violently
+with a stick.  I could have torn him limb from limb, as the lion rends
+the antelope.  But my heart sank within me as with bitter sickness, and
+I refrained.  I saw him on the point of repeating his blow, when,
+overcome by pain and anguish, I quitted the cottage, and in the general
+tumult escaped unperceived to my hovel."
+
+
+
+Chapter 16
+
+"Cursed, cursed creator!  Why did I live?  Why, in that instant, did I
+not extinguish the spark of existence which you had so wantonly
+bestowed?  I know not; despair had not yet taken possession of me; my
+feelings were those of rage and revenge.  I could with pleasure have
+destroyed the cottage and its inhabitants and have glutted myself with
+their shrieks and misery.
+
+"When night came I quitted my retreat and wandered in the wood; and
+now, no longer restrained by the fear of discovery, I gave vent to my
+anguish in fearful howlings.  I was like a wild beast that had broken
+the toils, destroying the objects that obstructed me and ranging
+through the wood with a stag-like swiftness.  Oh!  What a miserable
+night I passed!  The cold stars shone in mockery, and the bare trees
+waved their branches above me; now and then the sweet voice of a bird
+burst forth amidst the universal stillness.  All, save I, were at rest
+or in enjoyment; I, like the arch-fiend, bore a hell within me, and
+finding myself unsympathized with, wished to tear up the trees, spread
+havoc and destruction around me, and then to have sat down and enjoyed
+the ruin.
+
+"But this was a luxury of sensation that could not endure; I became
+fatigued with excess of bodily exertion and sank on the damp grass in
+the sick impotence of despair.  There was none among the myriads of men
+that existed who would pity or assist me; and should I feel kindness
+towards my enemies?  No; from that moment I declared everlasting war
+against the species, and more than all, against him who had formed me
+and sent me forth to this insupportable misery.
+
+"The sun rose; I heard the voices of men and knew that it was
+impossible to return to my retreat during that day.  Accordingly I hid
+myself in some thick underwood, determining to devote the ensuing hours
+to reflection on my situation.
+
+"The pleasant sunshine and the pure air of day restored me to some
+degree of tranquillity; and when I considered what had passed at the
+cottage, I could not help believing that I had been too hasty in my
+conclusions.  I had certainly acted imprudently.  It was apparent that
+my conversation had interested the father in my behalf, and  I was a
+fool in having exposed my person to the horror of his children.  I
+ought to have familiarized the old De Lacey to me, and by degrees to
+have discovered myself to the rest of his family, when they should have
+been  prepared for my approach.  But I did not believe my errors to be
+irretrievable, and after much consideration I resolved to return to the
+cottage, seek the old man, and by my representations win him to my
+party.
+
+"These thoughts calmed me, and in the afternoon I sank into a profound
+sleep; but the fever of my blood did not allow me to be visited by
+peaceful dreams.  The horrible scene of the preceding day was forever
+acting before my eyes; the females were flying and the enraged Felix
+tearing me from his father's feet.  I awoke exhausted, and finding that
+it was already night, I crept forth from my hiding-place, and went in
+search of food.
+
+"When my hunger was appeased, I directed my steps towards the
+well-known path that conducted to the cottage.  All there was at peace.
+I crept into my hovel and remained in silent expectation of the
+accustomed hour when the family arose.  That hour passed, the sun
+mounted high in the heavens, but the cottagers did not appear.  I
+trembled violently, apprehending some dreadful misfortune.  The inside
+of the cottage was dark, and I heard no motion; I cannot describe the
+agony of this suspense.
+
+"Presently two countrymen passed by, but pausing near the cottage, they
+entered into conversation, using violent gesticulations; but I did not
+understand what they said, as they spoke the language of the country,
+which differed from that of my protectors.  Soon after, however, Felix
+approached with another man; I was surprised, as I knew that he had not
+quitted the cottage that morning, and waited anxiously to discover from
+his discourse the meaning of these unusual appearances.
+
+"'Do you consider,' said his companion to him, 'that you will be
+obliged to pay three months' rent and to lose the produce of your
+garden?  I do not wish to take any unfair advantage, and I beg
+therefore that you will take some days to consider of your
+determination.'
+
+"'It is utterly useless,' replied Felix; 'we can never again inhabit
+your cottage.  The life of my father is in the greatest danger, owing
+to the dreadful circumstance that I have related.  My wife and my
+sister will never recover from their horror.  I entreat you not to
+reason with me any more.  Take possession of your tenement and let me
+fly from this place.'
+
+"Felix trembled violently as he said this.  He and his companion
+entered the cottage, in which they remained for a few minutes, and then
+departed.  I never saw any of the family of De Lacey more.
+
+"I continued for the remainder of the day in my hovel in a state of
+utter and stupid despair.  My protectors had departed and had broken
+the only link that held me to the world.  For the first time the
+feelings of revenge and hatred filled my bosom, and I did not strive to
+control them, but allowing myself to be borne away by the stream, I
+bent my mind towards injury and death.  When I thought of my friends,
+of the mild voice of De Lacey, the gentle eyes of Agatha, and the
+exquisite beauty of the Arabian, these thoughts vanished and a gush of
+tears somewhat soothed me.  But again when I reflected that they had
+spurned and deserted me, anger returned, a rage of anger, and unable to
+injure anything human, I turned my fury towards inanimate objects.  As
+night advanced I placed a variety of combustibles around the cottage,
+and after having destroyed every vestige of cultivation in the garden,
+I waited with forced impatience until the moon had sunk to commence my
+operations.
+
+"As the night advanced, a fierce wind arose from the woods and quickly
+dispersed the clouds that had loitered in the heavens; the blast tore
+along like a mighty avalanche and produced a kind of insanity in my
+spirits that burst all bounds of reason and reflection.  I lighted the
+dry branch of a tree and danced with fury around the devoted cottage,
+my eyes still fixed on the western horizon, the edge of which the moon
+nearly touched.  A part of its orb was at length hid, and I waved my
+brand; it sank, and with a loud scream I fired the straw, and heath,
+and bushes, which I had collected.  The wind fanned the fire, and the
+cottage was quickly enveloped by the flames, which clung to it and
+licked it with their forked and destroying tongues.
+
+"As soon as I was convinced that no assistance could save any part of
+the habitation, I quitted the scene and sought for refuge in the woods.
+
+"And now, with the world before me, whither should I bend my steps?  I
+resolved to fly far from the scene of my misfortunes; but to me, hated
+and despised, every country must be equally horrible.  At length the
+thought of you crossed my mind.  I learned from your papers that you
+were my father, my creator; and to whom could I apply with more fitness
+than to him who had given me life?  Among the lessons that Felix had
+bestowed upon Safie, geography had not been omitted; I had learned from
+these the relative situations of the different countries of the earth.
+You had mentioned Geneva as the name of your native town, and towards
+this place I resolved to proceed.
+
+"But how was I to direct myself?  I knew that I must travel in a
+southwesterly direction to reach my destination, but the sun was my
+only guide.  I did not know the names of the towns that I was to pass
+through, nor could I ask information from a single human being; but I
+did not despair.  From you only could I hope for succour, although
+towards you I felt no sentiment but that of hatred.  Unfeeling,
+heartless creator!  You had endowed me with perceptions and passions
+and then cast me abroad an object for the scorn and horror of mankind.
+But on you only had I any claim for pity and redress, and from you I
+determined to seek that justice which I vainly attempted to gain from
+any other being that wore the human form.
+
+"My travels were long and the sufferings I endured intense.  It was
+late in autumn when I quitted the district where I had so long resided.
+I travelled only at night, fearful of encountering the visage of a
+human being.  Nature decayed around me, and the sun became heatless;
+rain and snow poured around me; mighty rivers were frozen; the surface
+of the earth was hard and chill, and bare, and I found no shelter.  Oh,
+earth!  How often did I imprecate curses on the cause of my being!  The
+mildness of my nature had fled, and all within me was turned to gall
+and bitterness.  The nearer I approached to your habitation, the more
+deeply did I feel the spirit of revenge enkindled in my heart.  Snow
+fell, and the waters were hardened, but I rested not.  A few incidents
+now and then directed me, and I possessed a map of the country; but I
+often wandered wide from my path.  The agony of my feelings allowed me
+no respite; no incident occurred from which my rage and misery could
+not extract its food; but a circumstance that happened when I arrived
+on the confines of Switzerland, when the sun had recovered its warmth
+and the earth again began to look green, confirmed in an especial
+manner the bitterness and horror of my feelings.
+
+"I generally rested during the day and travelled only when I was
+secured by night from the view of man.  One morning, however, finding
+that my path lay through a deep wood, I ventured to continue my journey
+after the sun had risen; the day, which was one of the first of spring,
+cheered even me by the loveliness of its sunshine and the balminess of
+the air.  I felt emotions of gentleness and pleasure, that had long
+appeared dead, revive within me.  Half surprised by the novelty of
+these sensations, I allowed myself to be borne away by them, and
+forgetting my solitude and deformity, dared to be happy.  Soft tears
+again bedewed my cheeks, and I even raised my humid eyes with
+thankfulness towards the blessed sun, which bestowed such joy upon me.
+
+"I continued to wind among the paths of the wood, until I came to its
+boundary, which was skirted by a deep and rapid river, into which many
+of the trees bent their branches, now budding with the fresh spring.
+Here I paused, not exactly knowing what path to pursue, when I heard
+the sound of voices, that induced me to conceal myself under the shade
+of a cypress.  I was scarcely hid when a young girl came running
+towards the spot where I was concealed, laughing, as if she ran from
+someone in sport.  She continued her course along the precipitous sides
+of the river, when suddenly her foot slipped, and she fell into the
+rapid stream.  I rushed from my hiding-place and with extreme labour,
+from the force of the current, saved her and dragged her to shore.  She
+was senseless, and I endeavoured by every means in my power to restore
+animation, when I was suddenly interrupted by the approach of a rustic,
+who was probably the person from whom she had playfully fled.  On
+seeing me, he darted towards me, and tearing the girl from my arms,
+hastened towards the deeper parts of the wood.  I followed speedily, I
+hardly knew why; but when the man saw me draw near, he aimed a gun,
+which he carried, at my body and fired.  I sank to the ground, and my
+injurer, with increased swiftness, escaped into the wood.
+
+"This was then the reward of my benevolence!  I had saved a human being
+from destruction, and as a recompense I now writhed under the miserable
+pain of a wound which shattered the flesh and bone.  The feelings of
+kindness and gentleness which I had entertained but a few moments
+before gave place to hellish rage and gnashing of teeth.  Inflamed by
+pain, I vowed eternal hatred and vengeance to all mankind.  But the
+agony of my wound overcame me; my pulses paused, and I fainted.
+
+"For some weeks I led a miserable life in the woods, endeavouring to
+cure the wound which I had received.  The ball had entered my shoulder,
+and I knew not whether it had remained there or passed through; at any
+rate I had no means of extracting it.  My sufferings were augmented
+also by the oppressive sense of the injustice and ingratitude of their
+infliction.  My daily vows rose for revenge--a deep and deadly revenge,
+such as would alone compensate for the outrages and anguish I had
+endured.
+
+"After some weeks my wound healed, and I continued my journey.  The
+labours I endured were no longer to be alleviated by the bright sun or
+gentle breezes of spring; all joy was but a mockery which insulted my
+desolate state and made me feel more painfully that I was not made for
+the enjoyment of pleasure.
+
+"But my toils now drew near a close, and in two months from this time I
+reached the environs of Geneva.
+
+"It was evening when I arrived, and I retired to a hiding-place among
+the fields that surround it to meditate in what manner I should apply
+to you.  I was oppressed by fatigue and hunger and far too unhappy to
+enjoy the gentle breezes of evening or the prospect of the sun setting
+behind the stupendous mountains of Jura.
+
+"At this time a slight sleep relieved me from the pain of reflection,
+which was disturbed by the approach of a beautiful child, who came
+running into the recess I had chosen, with all the sportiveness of
+infancy.  Suddenly, as I gazed on him, an idea seized me that this
+little creature was unprejudiced and had lived too short a time to have
+imbibed a horror of deformity.  If, therefore, I could seize him and
+educate him as my companion and friend, I should not be so desolate in
+this peopled earth.
+
+"Urged by this impulse, I seized on the boy as he passed and drew him
+towards me.  As soon as he beheld my form, he placed his hands before
+his eyes and uttered a shrill scream; I drew his hand forcibly from his
+face and said, 'Child, what is the meaning of this?  I do not intend to
+hurt you; listen to me.'
+
+"He struggled violently.  'Let me go,' he cried; 'monster!  Ugly
+wretch!  You wish to eat me and tear me to pieces.  You are an ogre.
+Let me go, or I will tell my papa.'
+
+"'Boy, you will never see your father again; you must come with me.'
+
+"'Hideous monster!  Let me go.  My papa is a syndic--he is M.
+Frankenstein--he will punish you.  You dare not keep me.'
+
+"'Frankenstein! you belong then to my enemy--to him towards whom I have
+sworn eternal revenge; you shall be my first victim.'
+
+"The child still struggled and loaded me with epithets which carried
+despair to my heart; I grasped his throat to silence him, and in a
+moment he lay dead at my feet.
+
+"I gazed on my victim, and my heart swelled with exultation and hellish
+triumph; clapping my hands, I exclaimed, 'I too can create desolation;
+my enemy is not invulnerable; this death will carry despair to him, and
+a thousand other miseries shall torment and destroy him.'
+
+"As I fixed my eyes on the child, I saw something glittering on his
+breast.  I took it; it was a portrait of a most lovely woman.  In spite
+of my malignity, it softened and attracted me.  For a few moments I
+gazed with delight on her dark eyes, fringed by deep lashes, and her
+lovely lips; but presently my rage returned; I remembered that I was
+forever deprived of the delights that such beautiful creatures could
+bestow and that she whose resemblance I contemplated would, in
+regarding me, have changed that air of divine benignity to one
+expressive of disgust and affright.
+
+"Can you wonder that such thoughts transported me with rage?  I only
+wonder that at that moment, instead of venting my sensations in
+exclamations and agony, I did not rush among mankind and perish in the
+attempt to destroy them.
+
+"While I was overcome by these feelings, I left the spot where I had
+committed the murder, and seeking a more secluded hiding-place, I
+entered a barn which had appeared to me to be empty.  A woman was
+sleeping on some straw; she was young, not indeed so beautiful as her
+whose portrait I held, but of an agreeable aspect and blooming in the
+loveliness of youth and health.  Here, I thought, is one of those whose
+joy-imparting smiles are bestowed on all but me.  And then I bent over
+her and whispered, 'Awake, fairest, thy lover is near--he who would
+give his life but to obtain one look of affection from thine eyes; my
+beloved, awake!'
+
+"The sleeper stirred; a thrill of terror ran through me.  Should she
+indeed awake, and see me, and curse me, and denounce the murderer? Thus
+would she assuredly act if her darkened eyes opened and she beheld me.
+The thought was madness; it stirred the fiend within me--not I, but
+she, shall suffer; the murder I have committed because I am forever
+robbed of all that she could give me, she shall atone.  The crime had
+its source in her; be hers the punishment!  Thanks to the lessons of
+Felix and the sanguinary laws of man, I had learned now to work
+mischief.  I bent over her and placed the portrait securely in one of
+the folds of her dress.  She moved again, and I fled.
+
+"For some days I haunted the spot where these scenes had taken place,
+sometimes wishing to see you, sometimes resolved to quit the world and
+its miseries forever.  At length I wandered towards these mountains,
+and have ranged through their immense recesses, consumed by a burning
+passion which you alone can gratify.  We may not part until you have
+promised to comply with my requisition.  I am alone and miserable; man
+will not associate with me; but one as deformed and horrible as myself
+would not deny herself to me.  My companion must be of the same species
+and have the same defects.  This being you must create."
+
+
+
+Chapter 17
+
+The being finished speaking and fixed his looks upon me in the
+expectation of a reply.  But I was bewildered, perplexed, and unable to
+arrange my ideas sufficiently to understand the full extent of his
+proposition.  He continued,
+
+"You must create a female for me with whom I can live in the
+interchange of those sympathies necessary for my being.  This you alone
+can do, and I demand it of you as a right which you must not refuse to
+concede."
+
+The latter part of his tale had kindled anew in me the anger that had
+died away while he narrated his peaceful life among the cottagers, and
+as he said this I could no longer suppress the rage that burned within
+me.
+
+"I do refuse it," I replied; "and no torture shall ever extort a
+consent from me.  You may render me the most miserable of men, but you
+shall never make me base in my own eyes.  Shall I create another like
+yourself, whose joint wickedness might desolate the world.  Begone!  I
+have answered you; you may torture me, but I will never consent."
+
+"You are in the wrong," replied the fiend; "and instead of threatening,
+I am content to reason with you.  I am malicious because I am
+miserable.  Am I not shunned and hated by all mankind?  You, my
+creator, would tear me to pieces and triumph; remember that, and tell
+me why I should pity man more than he pities me?  You would not call it
+murder if you could precipitate me into one of those ice-rifts and
+destroy my frame, the work of your own hands.  Shall I respect man when
+he condemns me?  Let him live with me in the interchange of kindness,
+and instead of injury I would bestow every benefit upon him with tears
+of gratitude at his acceptance.  But that cannot be; the human senses
+are insurmountable barriers to our union.  Yet mine shall not be the
+submission of abject slavery.  I will revenge my injuries; if I cannot
+inspire love, I will cause fear, and chiefly towards you my arch-enemy,
+because my creator, do I swear inextinguishable hatred.  Have a care; I
+will work at your destruction, nor finish until I desolate your heart,
+so that you shall curse the hour of your birth."
+
+A fiendish rage animated him as he said this; his face was wrinkled
+into contortions too horrible for human eyes to behold; but presently
+he calmed himself and proceeded--
+
+"I intended to reason.  This passion is detrimental to me, for you do
+not reflect that YOU are the cause of its excess.  If any being felt
+emotions of benevolence towards me, I should return them a hundred and
+a hundredfold; for that one creature's sake I would make peace with the
+whole kind!  But I now indulge in dreams of bliss that cannot be
+realized.  What I ask of you is reasonable and moderate; I demand a
+creature of another sex, but as hideous as myself; the gratification is
+small, but it is all that I can receive, and it shall content me.  It
+is true, we shall be monsters, cut off from all the world; but on that
+account we shall be more attached to one another.  Our lives will not
+be happy, but they will be harmless and free from the misery I now
+feel.  Oh!  My creator, make me happy; let me feel gratitude towards
+you for one benefit!  Let me see that I excite the sympathy of some
+existing thing; do not deny me my request!"
+
+I was moved.  I shuddered when I thought of the possible consequences
+of my consent, but I felt that there was some justice in his argument.
+His tale and the feelings he now expressed proved him to be a creature
+of fine sensations, and did I not as his maker owe him all the portion
+of happiness that it was in my power to bestow?  He saw my change of
+feeling and continued,
+
+"If you consent, neither you nor any other human being shall ever see
+us again; I will go to the vast wilds of South America.  My food is not
+that of man; I do not destroy the lamb and the kid to glut my appetite;
+acorns and berries afford me sufficient nourishment.  My companion will
+be of the same nature as myself and will be content with the same fare.
+We shall make our bed of dried leaves; the sun will shine on us as on
+man and will ripen our food.  The picture I present to you is peaceful
+and human, and you must feel that you could deny it only in the
+wantonness of power and cruelty.  Pitiless as you have been towards me,
+I now see compassion in your eyes; let me seize the favourable moment
+and persuade you to promise what I so ardently desire."
+
+"You propose," replied I, "to fly from the habitations of man, to dwell
+in those wilds where the beasts of the field will be your only
+companions.  How can you, who long for the love and sympathy of man,
+persevere in this exile?  You will return and again seek their
+kindness, and you will meet with their detestation; your evil passions
+will be renewed, and you will then have a companion to aid you in the
+task of destruction.  This may not be; cease to argue the point, for I
+cannot consent."
+
+"How inconstant are your feelings!  But a moment ago you were moved by
+my representations, and why do you again harden yourself to my
+complaints?  I swear to you, by the earth which I inhabit, and by you
+that made me, that with the companion you bestow I will quit the
+neighbourhood of man and dwell, as it may chance, in the most savage of
+places.  My evil passions will have fled, for I shall meet with
+sympathy!  My life will flow quietly away, and in my dying moments I
+shall not curse my maker."
+
+His words had a strange effect upon me.  I compassionated him and
+sometimes felt a wish to console him, but when I looked upon him, when
+I saw the filthy mass that moved and talked, my heart sickened and my
+feelings were altered to those of horror and hatred.  I tried to stifle
+these sensations; I thought that as I could not sympathize with him, I
+had no right to withhold from him the small portion of happiness which
+was yet in my power to bestow.
+
+"You swear," I said, "to be harmless; but have you not already shown a
+degree of malice that should reasonably make me distrust you?  May not
+even this be a feint that will increase your triumph by affording a
+wider scope for your revenge?"
+
+"How is this?  I must not be trifled with, and I demand an answer.  If
+I have no ties and no affections, hatred and vice must be my portion;
+the love of another will destroy the cause of my crimes, and I shall
+become a thing of whose existence everyone will be ignorant.  My vices
+are the children of a forced solitude that I abhor, and my virtues will
+necessarily arise when I live in communion with an equal.  I shall feel
+the affections of a sensitive being and become linked to the chain of
+existence and events from which I am now excluded."
+
+I paused some time to reflect on all he had related and the various
+arguments which he had employed.  I thought of the promise of virtues
+which he had displayed on the opening of his existence and the
+subsequent blight of all kindly feeling by the loathing and scorn which
+his protectors had manifested towards him.  His power and threats were
+not omitted in my calculations; a creature who could exist in the ice
+caves of the glaciers and hide himself from pursuit among the ridges of
+inaccessible precipices was a being possessing faculties it would be
+vain to cope with.  After a long pause of reflection I concluded that
+the justice due both to him and my fellow creatures demanded of me that
+I should comply with his request.  Turning to him, therefore, I said,
+
+"I consent to your demand, on your solemn oath to quit Europe forever,
+and every other place in the neighbourhood of man, as soon as I shall
+deliver into your hands a female who will accompany you in your exile."
+
+"I swear," he cried, "by the sun, and by the blue sky of heaven, and by
+the fire of love that burns my heart, that if you grant my prayer,
+while they exist you shall never behold me again.  Depart to your home
+and commence your labours; I shall watch their progress with
+unutterable anxiety; and fear not but that when you are ready I shall
+appear."
+
+Saying this, he suddenly quitted me, fearful, perhaps, of any change in
+my sentiments.  I saw him descend the mountain with greater speed than
+the flight of an eagle, and quickly lost among the undulations of the
+sea of ice.
+
+His tale had occupied the whole day, and the sun was upon the verge of
+the horizon when he departed.  I knew that I ought to hasten my descent
+towards the valley, as I should soon be encompassed in darkness; but my
+heart was heavy, and my steps slow.  The labour of winding among the
+little paths of the mountain and fixing my feet firmly as I advanced
+perplexed me, occupied as I was by the emotions which the occurrences
+of the day had produced.  Night was far advanced when I came to the
+halfway resting-place and seated myself beside the fountain.  The stars
+shone at intervals as the clouds passed from over them; the dark pines
+rose before me, and every here and there a broken tree lay on the
+ground; it was a scene of wonderful solemnity and stirred strange
+thoughts within me.  I wept bitterly, and clasping my hands in agony, I
+exclaimed, "Oh!  Stars and clouds and winds, ye are all about to mock
+me; if ye really pity me, crush sensation and memory; let me become as
+nought; but if not, depart, depart, and leave me in darkness."
+
+These were wild and miserable thoughts, but I cannot describe to you
+how the eternal twinkling of the stars weighed upon me and how I
+listened to every blast of wind as if it were a dull ugly siroc on its
+way to consume me.
+
+Morning dawned before I arrived at the village of Chamounix; I took no
+rest, but returned immediately to Geneva.  Even in my own heart I could
+give no expression to my sensations--they weighed on me with a
+mountain's weight and their excess destroyed my agony beneath them.
+Thus I returned home, and entering the house, presented myself to the
+family.  My haggard and wild appearance awoke intense alarm, but I
+answered no question, scarcely did I speak.  I felt as if I were placed
+under a ban--as if I had no right to claim their sympathies--as if
+never more might I enjoy companionship with them.  Yet even thus I
+loved them to adoration; and to save them, I resolved to dedicate
+myself to my most abhorred task.  The prospect of such an occupation
+made every other circumstance of existence pass before me like a dream,
+and that thought only had to me the reality of life.
+
+
+
+Chapter 18
+
+Day after day, week after week, passed away on my return to Geneva; and
+I could not collect the courage to recommence my work.  I feared the
+vengeance of the disappointed fiend, yet I was unable to overcome my
+repugnance to the task which was enjoined me.  I found that I could not
+compose a female without again devoting several months to profound
+study and laborious disquisition.  I had heard of some discoveries
+having been made by an English philosopher, the knowledge of which was
+material to my success, and I sometimes thought of obtaining my
+father's consent to visit England for this purpose; but I clung to
+every pretence of delay and shrank from taking the first step in an
+undertaking whose immediate necessity began to appear less absolute to
+me.  A change indeed had taken place in me; my health, which had
+hitherto declined, was now much restored; and my spirits, when
+unchecked by the memory of my unhappy promise, rose proportionably.  My
+father saw this change with pleasure, and he turned his thoughts
+towards the best method of eradicating the remains of my melancholy,
+which every now and then would return by fits, and with a devouring
+blackness overcast the approaching sunshine.  At these moments I took
+refuge in the most perfect solitude.  I passed whole days on the lake
+alone in a little boat, watching the clouds and listening to the
+rippling of the waves, silent and listless.  But the fresh air and
+bright sun seldom failed to restore me to some degree of composure, and
+on my return I met the salutations of my friends with a readier smile
+and a more cheerful heart.
+
+It was after my return from one of these rambles that my father,
+calling me aside, thus addressed me,
+
+"I am happy to remark, my dear son, that you have resumed your former
+pleasures and seem to be returning to yourself.  And yet you are still
+unhappy and still avoid our society.  For some time I was lost in
+conjecture as to the cause of this, but yesterday an idea struck me,
+and if it is well founded, I conjure you to avow it.  Reserve on such a
+point would be not only useless, but draw down treble misery on us all."
+
+I trembled violently at his exordium, and my father continued--"I
+confess, my son, that I have always looked forward to your marriage
+with our dear Elizabeth as the tie of our domestic comfort and the stay
+of my declining years.  You were attached to each other from your
+earliest infancy; you studied together, and appeared, in dispositions
+and tastes, entirely suited to one another.  But so blind is the
+experience of man that what I conceived to be the best assistants to my
+plan may have entirely destroyed it.  You, perhaps, regard her as your
+sister, without any wish that she might become your wife.  Nay, you may
+have met with another whom you may love; and considering yourself as
+bound in honour to Elizabeth, this struggle may occasion the poignant
+misery which you appear to feel."
+
+"My dear father, reassure yourself.  I love my cousin tenderly and
+sincerely.  I never saw any woman who excited, as Elizabeth does, my
+warmest admiration and affection.  My future hopes and prospects are
+entirely bound up in the expectation of our union."
+
+"The expression of your sentiments of this subject, my dear Victor,
+gives me more pleasure than I have for some time experienced.  If you
+feel thus, we shall assuredly be happy, however present events may cast
+a gloom over us.  But it is this gloom which appears to have taken so
+strong a hold of your mind that I wish to dissipate.  Tell me,
+therefore, whether you object to an immediate solemnization of the
+marriage.  We have been unfortunate, and recent events have drawn us
+from that everyday tranquillity befitting my years and infirmities. You
+are younger; yet I do not suppose, possessed as you are of a competent
+fortune, that an early marriage would at all interfere with any future
+plans of honour and utility that you may have formed.  Do not suppose,
+however, that I wish to dictate happiness to you or that a delay on
+your part would cause me any serious uneasiness.  Interpret my words
+with candour and answer me, I conjure you, with confidence and
+sincerity."
+
+I listened to my father in silence and remained for some time incapable
+of offering any reply.  I revolved rapidly in my mind a multitude of
+thoughts and endeavoured to arrive at some conclusion.  Alas!  To me
+the idea of an immediate union with my Elizabeth was one of horror and
+dismay.  I was bound by a solemn promise which I had not yet fulfilled
+and dared not break, or if I did, what manifold miseries might not
+impend over me and my devoted family!  Could I enter into a festival
+with this deadly weight yet hanging round my neck and bowing me to the
+ground?  I must perform my engagement and let the monster depart with
+his mate before I allowed myself to enjoy the delight of a union from
+which I expected peace.
+
+I remembered also the necessity imposed upon me of either journeying to
+England or entering into a long correspondence with those philosophers
+of that country whose knowledge and discoveries were of indispensable
+use to me in my present undertaking.  The latter method of obtaining
+the desired intelligence was dilatory and unsatisfactory; besides, I
+had an insurmountable aversion to the idea of engaging myself in my
+loathsome task in my father's house while in habits of familiar
+intercourse with those I loved.  I knew that a thousand fearful
+accidents might occur, the slightest of which would disclose a tale to
+thrill all connected with me with horror.  I was aware also that I
+should often lose all self-command, all capacity of hiding the
+harrowing sensations that would possess me during the progress of my
+unearthly occupation.  I must absent myself from all I loved while thus
+employed.  Once commenced, it would quickly be achieved, and I might be
+restored to my family in peace and happiness.  My promise fulfilled,
+the monster would depart forever.  Or (so my fond fancy imaged) some
+accident might meanwhile occur to destroy him and put an end to my
+slavery forever.
+
+These feelings dictated my answer to my father.  I expressed a wish to
+visit England, but concealing the true reasons of this request, I
+clothed my desires under a guise which excited no suspicion, while I
+urged my desire with an earnestness that easily induced my father to
+comply.  After so long a period of an absorbing melancholy that
+resembled madness in its intensity and effects, he was glad to find
+that I was capable of taking pleasure in the idea of such a journey,
+and he hoped that change of scene and varied amusement would, before my
+return, have restored me entirely to myself.
+
+The duration of my absence was left to my own choice; a few months, or
+at most a year, was the period contemplated.  One paternal kind
+precaution he had taken to ensure my having a companion.  Without
+previously communicating with me, he had, in concert with Elizabeth,
+arranged that Clerval should join me at Strasbourg.  This interfered
+with the solitude I coveted for the prosecution of my task; yet at the
+commencement of my journey the presence of my friend could in no way be
+an impediment, and truly I rejoiced that thus I should be saved many
+hours of lonely, maddening reflection.  Nay, Henry might stand between
+me and the intrusion of my foe.  If I were alone, would he not at times
+force his abhorred presence on me to remind me of my task or to
+contemplate its progress?
+
+To England, therefore, I was bound, and it was understood that my union
+with Elizabeth should take place immediately on my return.  My father's
+age rendered him extremely averse to delay.  For myself, there was one
+reward I promised myself from my detested toils--one consolation for my
+unparalleled sufferings; it was the prospect of that day when,
+enfranchised from my miserable slavery, I might claim Elizabeth and
+forget the past in my union with her.
+
+I now made arrangements for my journey, but one feeling haunted me
+which filled me with fear and agitation.  During my absence I should
+leave my friends unconscious of the existence of their enemy and
+unprotected from his attacks, exasperated as he might be by my
+departure.  But he had promised to follow me wherever I might go, and
+would he not accompany me to England?  This imagination was dreadful in
+itself, but soothing inasmuch as it supposed the safety of my friends.
+I was agonized with the idea of the possibility that the reverse of
+this might happen.  But through the whole period during which I was the
+slave of my creature I allowed myself to be governed by the impulses of
+the moment; and my present sensations strongly intimated that the fiend
+would follow me and exempt my family from the danger of his
+machinations.
+
+It was in the latter end of September that I again quitted my native
+country.  My journey had been my own suggestion, and Elizabeth
+therefore acquiesced, but she was filled with disquiet at the idea of
+my suffering, away from her, the inroads of misery and grief.  It had
+been her care which provided me a companion in Clerval--and yet a man
+is blind to a thousand minute circumstances which call forth a woman's
+sedulous attention.  She longed to bid me hasten my return; a thousand
+conflicting emotions rendered her mute as she bade me a tearful, silent
+farewell.
+
+I threw myself into the carriage that was to convey me away, hardly
+knowing whither I was going, and careless of what was passing around.
+I remembered only, and it was with a bitter anguish that I reflected on
+it, to order that my chemical instruments should be packed to go with
+me.  Filled with dreary imaginations, I passed through many beautiful
+and majestic scenes, but my eyes were fixed and unobserving.  I could
+only think of the bourne of my travels and the work which was to occupy
+me whilst they endured.
+
+After some days spent in listless indolence, during which I traversed
+many leagues, I arrived at Strasbourg, where I waited two days for
+Clerval.  He came.  Alas, how great was the contrast between us!  He
+was alive to every new scene, joyful when he saw the beauties of the
+setting sun, and more happy when he beheld it rise and recommence a new
+day.  He pointed out to me the shifting colours of the landscape and
+the appearances of the sky.  "This is what it is to live," he cried;
+"how I enjoy existence!  But you, my dear Frankenstein, wherefore are
+you desponding and sorrowful!" In truth, I was occupied by gloomy
+thoughts and neither saw the descent of the evening star nor the golden
+sunrise reflected in the Rhine.  And you, my friend, would be far more
+amused with the journal of Clerval, who observed the scenery with an
+eye of feeling and delight, than in listening to my reflections.  I, a
+miserable wretch, haunted by a curse that shut up every avenue to
+enjoyment.
+
+We had agreed to descend the Rhine in a boat from Strasbourg to
+Rotterdam, whence we might take shipping for London.  During this
+voyage we passed many willowy islands and saw several beautiful towns.
+We stayed a day at Mannheim, and on the fifth from our departure from
+Strasbourg, arrived at Mainz.  The course of the Rhine below Mainz
+becomes much more picturesque.  The river descends rapidly and winds
+between hills, not high, but steep, and of beautiful forms.  We saw
+many ruined castles standing on the edges of precipices, surrounded by
+black woods, high and inaccessible.  This part of the Rhine, indeed,
+presents a singularly variegated landscape.  In one spot you view
+rugged hills, ruined castles overlooking tremendous precipices, with
+the dark Rhine rushing beneath; and on the sudden turn of a promontory,
+flourishing vineyards with green sloping banks and a meandering river
+and populous towns occupy the scene.
+
+We travelled at the time of the vintage and heard the song of the
+labourers as we glided down the stream.  Even I, depressed in mind, and
+my spirits continually agitated by gloomy feelings, even I was pleased.
+I lay at the bottom of the boat, and as I gazed on the cloudless blue
+sky, I seemed to drink in a tranquillity to which I had long been a
+stranger.  And if these were my sensations, who can describe those of
+Henry?  He felt as if he had been transported to fairy-land and enjoyed
+a happiness seldom tasted by man.  "I have seen," he said, "the most
+beautiful scenes of my own country; I have visited the lakes of Lucerne
+and Uri, where the snowy mountains descend almost perpendicularly to
+the water, casting black and impenetrable shades, which would cause a
+gloomy and mournful appearance were it not for the most verdant islands
+that believe the eye by their gay appearance; I have seen this lake
+agitated by a tempest, when the wind tore up whirlwinds of water and
+gave you an idea of what the water-spout must be on the great ocean;
+and the waves dash with fury the base of the mountain, where the priest
+and his mistress were overwhelmed by an avalanche and where their dying
+voices are still said to be heard amid the pauses of the nightly wind;
+I have seen the mountains of La Valais, and the Pays de Vaud; but this
+country, Victor, pleases me more than all those wonders.  The mountains
+of Switzerland are more majestic and strange, but there is a charm in
+the banks of this divine river that I never before saw equalled.  Look
+at that castle which overhangs yon precipice; and that also on the
+island, almost concealed amongst the foliage of those lovely trees; and
+now that group of labourers coming from among their vines; and that
+village half hid in the recess of the mountain.  Oh, surely the spirit
+that inhabits and guards this place has a soul more in harmony with man
+than those who pile the glacier or retire to the inaccessible peaks of
+the mountains of our own country." Clerval!  Beloved friend!  Even now
+it delights me to record your words and to dwell on the praise of which
+you are so eminently deserving.  He was a being formed in the "very
+poetry of nature." His wild and enthusiastic imagination was chastened
+by the sensibility of his heart.  His soul overflowed with ardent
+affections, and his friendship was of that devoted and wondrous nature
+that the world-minded teach us to look for only in the imagination. But
+even human sympathies were not sufficient to satisfy his eager mind.
+The scenery of external nature, which others regard only with
+admiration, he loved with ardour:--
+
+
+     ----The sounding cataract
+     Haunted him like a passion:  the tall rock,
+     The mountain, and the deep and gloomy wood,
+     Their colours and their forms, were then to him
+     An appetite; a feeling, and a love,
+     That had no need of a remoter charm,
+     By thought supplied, or any interest
+     Unborrow'd from the eye.
+
+                    [Wordsworth's "Tintern Abbey".]
+
+
+And where does he now exist?  Is this gentle and lovely being lost
+forever?  Has this mind, so replete with ideas, imaginations fanciful
+and magnificent, which formed a world, whose existence depended on the
+life of its creator;--has this mind perished?  Does it now only exist
+in my memory?  No, it is not thus; your form so divinely wrought, and
+beaming with beauty, has decayed, but your spirit still visits and
+consoles your unhappy friend.
+
+Pardon this gush of sorrow; these ineffectual words are but a slight
+tribute to the unexampled worth of Henry, but they soothe my heart,
+overflowing with the anguish which his remembrance creates.  I will
+proceed with my tale.
+
+Beyond Cologne we descended to the plains of Holland; and we resolved
+to post the remainder of our way, for the wind was contrary and the
+stream of the river was too gentle to aid us.  Our journey here lost
+the interest arising from beautiful scenery, but we arrived in a few
+days at Rotterdam, whence we proceeded by sea to England.  It was on a
+clear morning, in the latter days of December, that I first saw the
+white cliffs of Britain.  The banks of the Thames presented a new
+scene; they were flat but fertile, and almost every town was marked by
+the remembrance of some story.  We saw Tilbury Fort and remembered the
+Spanish Armada, Gravesend, Woolwich, and Greenwich--places which I had
+heard of even in my country.
+
+At length we saw the numerous steeples of London, St. Paul's towering
+above all, and the Tower famed in English history.
+
+
+
+Chapter 19
+
+London was our present point of rest; we determined to remain several
+months in this wonderful and celebrated city.  Clerval desired the
+intercourse of the men of genius and talent who flourished at this
+time, but this was with me a secondary object; I was principally
+occupied with the means of obtaining the information necessary for the
+completion of my promise and quickly availed myself of the letters of
+introduction that I had brought with me, addressed to the most
+distinguished natural philosophers.
+
+If this journey had taken place during my days of study and happiness,
+it would have afforded me inexpressible pleasure.  But a blight had
+come over my existence, and I only visited these people for the sake of
+the information they might give me on the subject in which my interest
+was so terribly profound.  Company was irksome to me; when alone, I
+could fill my mind with the sights of heaven and earth; the voice of
+Henry soothed me, and I could thus cheat myself into a transitory
+peace.  But busy, uninteresting, joyous faces brought back despair to
+my heart.  I saw an insurmountable barrier placed between me and my
+fellow men; this barrier was sealed with the blood of William and
+Justine, and to reflect on the events connected with those names filled
+my soul with anguish.
+
+But in Clerval I saw the image of my former self; he was inquisitive
+and anxious to gain experience and instruction.  The difference of
+manners which he observed was to him an inexhaustible source of
+instruction and amusement.  He was also pursuing an object he had long
+had in view.  His design was to visit India, in the belief that he had
+in his knowledge of its various languages, and in the views he had
+taken of its society, the means of materially assisting the progress of
+European colonization and trade.  In Britain only could he further the
+execution of his plan.  He was forever busy, and the only check to his
+enjoyments was my sorrowful and dejected mind.  I tried to conceal this
+as much as possible, that I might not debar him from the pleasures
+natural to one who was entering on a new scene of life, undisturbed by
+any care or bitter recollection.  I often refused to accompany him,
+alleging another engagement, that I might remain alone.  I now also
+began to collect the materials necessary for my new creation, and this
+was to me like the torture of single drops of water continually falling
+on the head.  Every thought that was devoted to it was an extreme
+anguish, and every word that I spoke in allusion to it caused my lips
+to quiver, and my heart to palpitate.
+
+After passing some months in London, we received a letter from a person
+in Scotland who had formerly been our visitor at Geneva.  He mentioned
+the beauties of his native country and asked us if those were not
+sufficient allurements to induce us to prolong our journey as far north
+as Perth, where he resided.  Clerval eagerly desired to accept this
+invitation, and I, although I abhorred society, wished to view again
+mountains and streams and all the wondrous works with which Nature
+adorns her chosen dwelling-places.  We had arrived in England at the
+beginning of October, and it was now February.  We accordingly
+determined to commence our journey towards the north at the expiration
+of another month.  In this expedition we did not intend to follow the
+great road to Edinburgh, but to visit Windsor, Oxford, Matlock, and the
+Cumberland lakes, resolving to arrive at the completion of this tour
+about the end of July.  I packed up my chemical instruments and the
+materials I had collected, resolving to finish my labours in some
+obscure nook in the northern highlands of Scotland.
+
+We quitted London on the 27th of March and remained a few days at
+Windsor, rambling in its beautiful forest.  This was a new scene to us
+mountaineers; the majestic oaks, the quantity of game, and the herds of
+stately deer were all novelties to us.
+
+From thence we proceeded to Oxford.  As we entered this city our minds
+were filled with the remembrance of the events that had been transacted
+there more than a century and a half before.  It was here that Charles
+I. had collected his forces.  This city had remained faithful to him,
+after the whole nation had forsaken his cause to join the standard of
+Parliament and liberty.  The memory of that unfortunate king and his
+companions, the amiable Falkland, the insolent Goring, his queen, and
+son, gave a peculiar interest to every part of the city which they
+might be supposed to have inhabited.  The spirit of elder days found a
+dwelling here, and we delighted to trace its footsteps.  If these
+feelings had not found an imaginary gratification, the appearance of
+the city had yet in itself sufficient beauty to obtain our admiration.
+The colleges are ancient and picturesque; the streets are almost
+magnificent; and the lovely Isis, which flows beside it through meadows
+of exquisite verdure, is spread forth into a placid expanse of waters,
+which reflects its majestic assemblage of towers, and spires, and
+domes, embosomed among aged trees.
+
+I enjoyed this scene, and yet my enjoyment was embittered both by the
+memory of the past and the anticipation of the future.  I was formed
+for peaceful happiness.  During my youthful days discontent never
+visited my mind, and if I was ever overcome by ennui, the sight of what
+is beautiful in nature or the study of what is excellent and sublime in
+the productions of man could always interest my heart and communicate
+elasticity to my spirits.  But I am a blasted tree; the bolt has
+entered my soul; and I felt then that I should survive to exhibit what
+I shall soon cease to be--a miserable spectacle of wrecked humanity,
+pitiable to others and intolerable to myself.
+
+We passed a considerable period at Oxford, rambling among its environs
+and endeavouring to identify every spot which might relate to the most
+animating epoch of English history.  Our little voyages of discovery
+were often prolonged by the successive objects that presented
+themselves.  We visited the tomb of the illustrious Hampden and the
+field on which that patriot fell.  For a moment my soul was elevated
+from its debasing and miserable fears to contemplate the divine ideas
+of liberty and self sacrifice of which these sights were the monuments
+and the remembrancers.  For an instant I dared to shake off my chains
+and look around me with a free and lofty spirit, but the iron had eaten
+into my flesh, and I sank again, trembling and hopeless, into my
+miserable self.
+
+We left Oxford with regret and proceeded to Matlock, which was our next
+place of rest.  The country in the neighbourhood of this village
+resembled, to a greater degree, the scenery of Switzerland; but
+everything is on a lower scale, and the green hills want the crown of
+distant white Alps which always attend on the piny mountains of my
+native country.  We visited the wondrous cave and the little cabinets
+of natural history, where the curiosities are disposed in the same
+manner as in the collections at Servox and Chamounix.  The latter name
+made me tremble when pronounced by Henry, and I hastened to quit
+Matlock, with which that terrible scene was thus associated.
+
+From Derby, still journeying northwards, we passed two months in
+Cumberland and Westmorland.  I could now almost fancy myself among the
+Swiss mountains.  The little patches of snow which yet lingered on the
+northern sides of the mountains, the lakes, and the dashing of the
+rocky streams were all familiar and dear sights to me.  Here also we
+made some acquaintances, who almost contrived to cheat me into
+happiness.  The delight of Clerval was proportionably greater than
+mine; his mind expanded in the company of men of talent, and he found
+in his own nature greater capacities and resources than he could have
+imagined himself to have possessed while he associated with his
+inferiors.  "I could pass my life here," said he to me; "and among
+these mountains I should scarcely regret Switzerland and the Rhine."
+
+But he found that a traveller's life is one that includes much pain
+amidst its enjoyments.  His feelings are forever on the stretch; and
+when he begins to sink into repose, he finds himself obliged to quit
+that on which he rests in pleasure for something new, which again
+engages his attention, and which also he forsakes for other novelties.
+
+We had scarcely visited the various lakes of Cumberland and Westmorland
+and conceived an affection for some of the inhabitants when the period
+of our appointment with our Scotch friend approached, and we left them
+to travel on.  For my own part I was not sorry.  I had now neglected my
+promise for some time, and I feared the effects of the daemon's
+disappointment.  He might remain in Switzerland and wreak his vengeance
+on my relatives.  This idea pursued me and tormented me at every moment
+from which I might otherwise have snatched repose and peace.  I waited
+for my letters with feverish impatience; if they were delayed I was
+miserable and overcome by a thousand fears; and when they arrived and I
+saw the superscription of Elizabeth or my father, I hardly dared to
+read and ascertain my fate.  Sometimes I thought that the fiend
+followed me and might expedite my remissness by murdering my companion.
+When these thoughts possessed me, I would not quit Henry for a moment,
+but followed him as his shadow, to protect him from the fancied rage of
+his destroyer.  I felt as if I had committed some great crime, the
+consciousness of which haunted me.  I was guiltless, but I had indeed
+drawn down a horrible curse upon my head, as mortal as that of crime.
+
+I visited Edinburgh with languid eyes and mind; and yet that city might
+have interested the most unfortunate being.  Clerval did not like it so
+well as Oxford, for the antiquity of the latter city was more pleasing
+to him.  But the beauty and regularity of the new town of Edinburgh,
+its romantic castle and its environs, the most delightful in the world,
+Arthur's Seat, St. Bernard's Well, and the Pentland Hills compensated
+him for the change and filled him with cheerfulness and admiration. But
+I was impatient to arrive at the termination of my journey.
+
+We left Edinburgh in a week, passing through Coupar, St. Andrew's, and
+along the banks of the Tay, to Perth, where our friend expected us.
+But I was in no mood to laugh and talk with strangers or enter into
+their feelings or plans with the good humour expected from a guest; and
+accordingly I told Clerval that I wished to make the tour of Scotland
+alone.  "Do you," said I, "enjoy yourself, and let this be our
+rendezvous.  I may be absent a month or two; but do not interfere with
+my motions, I entreat you; leave me to peace and solitude for a short
+time; and when I return, I hope it will be with a lighter heart, more
+congenial to your own temper."
+
+Henry wished to dissuade me, but seeing me bent on this plan, ceased to
+remonstrate.  He entreated me to write often.  "I had rather be with
+you," he said, "in your solitary rambles, than with these Scotch
+people, whom I do not know; hasten, then, my dear  friend, to return,
+that I may again feel myself somewhat at home, which I cannot do in
+your absence."
+
+Having parted from my friend, I determined to visit some remote spot of
+Scotland and finish my work in solitude.  I did not doubt but that the
+monster followed me and would discover himself to me when I should have
+finished, that he might receive his companion.  With this resolution I
+traversed the northern highlands and fixed on one of the remotest of
+the Orkneys as the scene of my labours.  It was a place fitted for such
+a work, being hardly more than a rock whose high sides were continually
+beaten upon by the waves.  The soil was barren, scarcely affording
+pasture for a few miserable cows, and oatmeal for its inhabitants,
+which consisted of five persons, whose gaunt and scraggy limbs gave
+tokens of their miserable fare.  Vegetables and bread, when they
+indulged in such luxuries, and even fresh water, was to be procured
+from the mainland, which was about five miles distant.
+
+On the whole island there were but three miserable huts, and one of
+these was vacant when I arrived.  This I hired.  It contained but two
+rooms, and these exhibited all the squalidness of the most miserable
+penury.  The thatch had fallen in, the walls were unplastered, and the
+door was off its hinges.  I ordered it to be repaired, bought some
+furniture, and took possession, an incident which would doubtless have
+occasioned some surprise had not all the senses of the cottagers been
+benumbed by want and squalid poverty.  As it was, I lived ungazed at
+and unmolested, hardly thanked for the pittance of food and clothes
+which I gave, so much does suffering blunt even the coarsest sensations
+of men.
+
+In this retreat I devoted the morning to labour; but in the evening,
+when the weather permitted, I walked on the stony beach of the sea to
+listen to the waves as they roared and dashed at my feet.  It was a
+monotonous yet ever-changing scene.  I thought of Switzerland; it was
+far different from this desolate and appalling landscape.  Its hills
+are covered with vines, and its cottages are scattered thickly in the
+plains.  Its fair lakes reflect a blue and gentle sky, and when
+troubled by the winds, their tumult is but as the play of a lively
+infant when compared to the roarings of the giant ocean.
+
+In this manner I distributed my occupations when I first arrived, but
+as I proceeded in my labour, it became every day more horrible and
+irksome to me.  Sometimes I could not prevail on myself to enter my
+laboratory for several days, and at other times I toiled day and night
+in order to complete my work.  It was, indeed, a filthy process in
+which I was engaged.  During my first experiment, a kind of
+enthusiastic frenzy had blinded me to the horror of my employment; my
+mind was intently fixed on the consummation of my labour, and my eyes
+were shut to the horror of my proceedings.  But now I went to it in
+cold blood, and my heart often sickened at the work of my hands.
+
+Thus situated, employed in the most detestable occupation, immersed in
+a solitude where nothing could for an instant call my attention from
+the actual scene in which I was engaged, my spirits became unequal; I
+grew restless and nervous.  Every moment I feared to meet my
+persecutor.  Sometimes I sat with my eyes fixed on the ground, fearing
+to raise them lest they should encounter the object which I so much
+dreaded to behold.  I feared to wander from the sight of my fellow
+creatures lest when alone he should come to claim his companion.
+
+In the mean time I worked on, and my labour was already considerably
+advanced.  I looked towards its completion with a tremulous and eager
+hope, which I dared not trust myself to question but which was
+intermixed with obscure forebodings of evil that made my heart sicken
+in my bosom.
+
+
+
+Chapter 20
+
+I sat one evening in my laboratory; the sun had set, and the moon was
+just rising from the sea; I had not sufficient light for my employment,
+and I remained idle, in a pause of consideration of whether I should
+leave my labour for the night or hasten its conclusion by an
+unremitting attention to it.  As I sat, a train of reflection occurred
+to me which led me to consider the effects of what I was now doing.
+Three years before, I was engaged in the same manner and had created a
+fiend whose unparalleled barbarity had desolated my heart and filled it
+forever with the bitterest remorse.  I was now about to form another
+being of whose dispositions I was alike ignorant; she might become ten
+thousand times more malignant than her mate and delight, for its own
+sake, in murder and wretchedness.  He had sworn to quit the
+neighbourhood of man and hide himself in deserts, but she had not; and
+she, who in all probability was to become a thinking and reasoning
+animal, might refuse to comply with a compact made before her creation.
+They might even hate each other; the creature who already lived loathed
+his own deformity, and might he not conceive a greater abhorrence for
+it when it came before his eyes in the female form?  She also might
+turn with disgust from him to the superior beauty of man; she might
+quit him, and he be again alone, exasperated by the fresh provocation
+of being deserted by one of his own species.  Even if they were to
+leave Europe and inhabit the deserts of the new world, yet one of the
+first results of those sympathies for which the daemon thirsted would
+be children, and a race of devils would be propagated upon the earth
+who might make the very existence of the species of man a condition
+precarious and full of terror.  Had I right, for my own benefit, to
+inflict this curse upon everlasting generations?  I had before been
+moved by the sophisms of the being I had created; I had been struck
+senseless by his fiendish threats; but now, for the first time, the
+wickedness of my promise burst upon me; I shuddered to think that
+future ages might curse me as their pest, whose selfishness had not
+hesitated to buy its own peace at the price, perhaps, of the existence
+of the whole human race.
+
+I trembled and my heart failed within me, when, on looking up, I saw by
+the light of the moon the daemon at the casement.  A ghastly grin
+wrinkled his lips as he gazed on me, where I sat fulfilling the task
+which he had allotted to me.  Yes, he had followed me in my travels; he
+had loitered in forests, hid himself in caves, or taken refuge in wide
+and desert heaths; and he now came to mark my progress and claim the
+fulfilment of my promise.
+
+As I looked on him, his countenance expressed the utmost extent of
+malice and treachery.  I thought with a sensation of madness on my
+promise of creating another like to him, and trembling with passion,
+tore to pieces the thing on which I was engaged.  The wretch saw me
+destroy the creature on whose future existence he depended for
+happiness, and with a howl of devilish despair and revenge, withdrew.
+
+I left the room, and locking the door, made a solemn vow in my own
+heart never to resume my labours; and then, with trembling steps, I
+sought my own apartment. I was alone; none were near me to dissipate
+the gloom and relieve me from the sickening oppression of the most
+terrible reveries.
+
+Several hours passed, and I remained near my window gazing on the sea;
+it was almost motionless, for the winds were hushed, and all nature
+reposed under the eye of the quiet moon.  A few fishing vessels alone
+specked the water, and now and then the gentle breeze wafted the sound
+of voices as the fishermen called to one another.  I felt the silence,
+although I was hardly conscious of its extreme profundity, until my ear
+was suddenly arrested by the paddling of oars near the shore, and a
+person landed close to my house.
+
+In a few minutes after, I heard the creaking of my door, as if some one
+endeavoured to open it softly.  I trembled from head to foot; I felt a
+presentiment of who it was and wished to rouse one of the peasants who
+dwelt in a cottage not far from mine; but I was overcome by the
+sensation of helplessness, so often felt in frightful dreams, when you
+in vain endeavour to fly from an impending danger, and was rooted to
+the spot. Presently I heard the sound of footsteps along the passage;
+the door opened, and the wretch whom I dreaded appeared.
+
+Shutting the door, he approached me and said in a smothered voice, "You
+have destroyed the work which you began; what is it that you intend?
+Do you dare to break your promise?  I have endured toil and misery; I
+left Switzerland with you; I crept along the shores of the Rhine, among
+its willow islands and over the summits of its hills.  I have dwelt
+many months in the heaths of England and among the deserts of Scotland.
+I have endured incalculable fatigue, and cold, and hunger; do you dare
+destroy my hopes?"
+
+"Begone!  I do break my promise; never will I create another like
+yourself, equal in deformity and wickedness."
+
+"Slave, I before reasoned with you, but you have proved yourself
+unworthy of my condescension.  Remember that I have power; you believe
+yourself miserable, but I can make you so wretched that the light of
+day will be hateful to you.  You are my creator, but I am your master;
+obey!"
+
+"The hour of my irresolution is past, and the period of your power is
+arrived.  Your threats cannot move me to do an act of wickedness; but
+they confirm me in a determination of not creating you a companion in
+vice.  Shall I, in cool blood, set loose upon the earth a daemon whose
+delight is in death and wretchedness?  Begone!  I am firm, and your
+words will only exasperate my rage."
+
+The monster saw my determination in my face and gnashed his teeth in
+the impotence of anger.  "Shall each man," cried he, "find a wife for
+his bosom, and each beast have his mate, and I be alone?  I had
+feelings of affection, and they were requited by detestation and scorn.
+Man!  You may hate, but beware!  Your hours will pass in dread and
+misery, and soon the bolt  will fall which must ravish from you your
+happiness forever.  Are you to be happy while I grovel in the intensity
+of my wretchedness?  You can blast my other passions, but revenge
+remains--revenge, henceforth dearer than light or food!  I may die, but
+first you, my tyrant and tormentor, shall curse the sun that gazes on
+your misery.  Beware, for I am fearless and therefore powerful.  I will
+watch with the wiliness of a snake, that I may sting with its venom.
+Man, you shall repent of the injuries you inflict."
+
+"Devil, cease; and do not poison the air with these sounds of malice.
+I have declared my resolution to you, and I am no coward to bend
+beneath words.  Leave me; I am inexorable."
+
+"It is well.  I go; but remember, I shall be with you on your
+wedding-night."
+
+I started forward and exclaimed, "Villain!  Before you sign my
+death-warrant, be sure that you are yourself safe."
+
+I would have seized him, but he eluded me and quitted the house with
+precipitation.  In a few moments I saw him in his boat, which shot
+across the waters with an arrowy swiftness and was soon lost amidst the
+waves.
+
+All was again silent, but his words rang in my ears.  I burned with
+rage to pursue the murderer of my peace and precipitate him into the
+ocean.  I walked up and down my room hastily and perturbed, while my
+imagination conjured up a thousand images to torment and sting me.  Why
+had I not followed him and closed with him in mortal strife?  But I had
+suffered him to depart, and he had directed his course towards the
+mainland.  I shuddered to think who might be the next victim sacrificed
+to his insatiate revenge.  And then I thought again of his words--"I
+WILL BE WITH YOU ON YOUR WEDDING-NIGHT."  That, then, was the period
+fixed for the fulfilment of my destiny.  In that hour I should die and
+at once satisfy and extinguish his malice.  The prospect did not move
+me to fear; yet when I thought of my beloved Elizabeth, of her tears
+and endless sorrow, when she should find her lover so barbarously
+snatched from her, tears, the first I had shed for many months,
+streamed from my eyes, and I resolved not to fall before my enemy
+without a bitter struggle.
+
+The night passed away, and the sun rose from the ocean; my feelings
+became calmer, if it may be called calmness when the violence of rage
+sinks into the depths of despair.  I left the house, the horrid scene
+of the last night's contention, and walked on the beach of the sea,
+which I almost regarded as an insuperable barrier between me and my
+fellow creatures; nay, a wish that such should prove the fact stole
+across me.
+
+I desired that I might pass my life on that barren rock, wearily, it is
+true, but uninterrupted by any sudden shock of misery.  If I returned,
+it was to be sacrificed or to see those whom I most loved die under the
+grasp of a daemon whom I had myself created.
+
+I walked about the isle like a restless spectre, separated from all it
+loved and miserable in the separation.  When it became noon, and the
+sun rose higher, I lay down on the grass and was overpowered by a deep
+sleep.  I had been awake the whole of the preceding night, my nerves
+were agitated, and my eyes inflamed by watching and misery.  The sleep
+into which I now sank refreshed me; and when I awoke, I again felt as
+if I belonged to a race of human beings like myself, and I began to
+reflect upon what had passed with greater composure; yet still the
+words of the fiend rang in my ears like a death-knell; they appeared
+like a dream, yet distinct and oppressive as a reality.
+
+The sun had far descended, and I still sat on the shore, satisfying my
+appetite, which had become ravenous, with an oaten cake, when I saw a
+fishing-boat land close to me, and one of the men brought me a packet;
+it contained letters from Geneva, and one from Clerval entreating me to
+join him.  He said that he was wearing away his time fruitlessly where
+he was, that letters from the friends he had formed in London desired
+his return to complete the negotiation they had entered into for his
+Indian enterprise.  He could not any longer delay his departure; but as
+his journey to London might be followed, even sooner than he now
+conjectured, by his longer voyage, he entreated me to bestow as much of
+my society on him as I could spare.  He besought me, therefore, to
+leave my solitary isle and to meet him at Perth, that we might proceed
+southwards together.  This letter in a degree recalled me to life, and
+I determined to quit my island at the expiration of two days.  Yet,
+before I departed, there was a task to perform, on which I shuddered to
+reflect; I must pack up my chemical instruments, and for that purpose I
+must enter the room which had been the scene of my odious work, and I
+must handle those utensils the sight of which was sickening to me. The
+next morning, at daybreak, I summoned sufficient courage and unlocked
+the door of my laboratory.  The remains of the half-finished creature,
+whom I had destroyed, lay scattered on the floor, and I almost felt as
+if I had mangled the living flesh of a human being.  I paused to
+collect myself and then entered the chamber.  With trembling hand I
+conveyed the instruments out of the room, but I reflected that I ought
+not to leave the relics of my work to excite the horror and suspicion
+of the peasants; and I accordingly put them into a basket, with a great
+quantity of stones, and laying them up, determined to throw them into
+the sea that very night; and in the meantime I sat upon the beach,
+employed in cleaning and arranging my chemical apparatus.
+
+Nothing could be more complete than the alteration that had taken place
+in my feelings since the night of the appearance of the daemon.  I had
+before regarded my promise with a gloomy despair as a thing that, with
+whatever consequences, must be fulfilled; but I now felt as if a film
+had been taken from before my eyes and that I for the first time saw
+clearly.  The idea of renewing my labours did not for one instant occur
+to me; the threat I had heard weighed on my thoughts, but I did not
+reflect that a voluntary act of mine could avert it.  I had resolved in
+my own mind that to create another like the fiend I had first made
+would be an act of the basest and most atrocious selfishness, and I
+banished from my mind every thought that could lead to a different
+conclusion.
+
+Between two and three in the morning the moon rose; and I then, putting
+my basket aboard a little skiff, sailed out about four miles from the
+shore.  The scene was perfectly solitary; a few boats were returning
+towards land, but I sailed away from them.  I felt as if I was about
+the commission of a dreadful crime and avoided with shuddering anxiety
+any encounter with my fellow creatures.  At one time the moon, which
+had before been clear, was suddenly overspread by a thick cloud, and I
+took advantage of the moment of darkness and cast my basket into the
+sea; I listened to the gurgling sound as it sank and then sailed away
+from the spot.  The sky became clouded, but the air was pure, although
+chilled by the northeast breeze that was then rising.  But it refreshed
+me and filled me with such agreeable sensations that I resolved to
+prolong my stay on the water, and fixing the rudder in a direct
+position, stretched myself at the bottom of the boat.  Clouds hid the
+moon, everything was obscure, and I heard only the sound of the boat as
+its keel cut through the waves; the murmur lulled me, and in a short
+time I slept soundly. I do not know how long I remained in this
+situation, but when I awoke I found that the sun had already mounted
+considerably.  The wind was high, and the waves continually threatened
+the safety of my little skiff.  I found that the wind was northeast and
+must have driven me far from the coast from which I had embarked.  I
+endeavoured to change my course but quickly found that if I again made
+the attempt the boat would be instantly filled with water.  Thus
+situated, my only resource was to drive before the wind.  I confess
+that I felt a few sensations of terror.  I had no compass with me and
+was so slenderly acquainted with the geography of this part of the
+world that the sun was of little benefit to me.  I might be driven into
+the wide Atlantic and feel all the tortures of starvation or be
+swallowed up in the immeasurable waters that roared and buffeted around
+me.  I had already been out many hours and felt the torment of a
+burning thirst, a prelude to my other sufferings.  I looked on the
+heavens, which were covered by clouds that flew before the wind, only
+to be replaced by others; I looked upon the sea; it was to be my grave.
+"Fiend," I exclaimed, "your task is already fulfilled!"  I thought of
+Elizabeth, of my father, and of Clerval--all left behind, on whom the
+monster might satisfy his sanguinary and merciless passions.  This idea
+plunged me into a reverie so despairing and frightful that even now,
+when the scene is on the point of closing before me forever, I shudder
+to reflect on it.
+
+Some hours passed thus; but by degrees, as the sun declined towards the
+horizon, the wind died away into a gentle breeze and the sea became
+free from breakers.  But these gave place to a heavy swell; I felt sick
+and hardly able to hold the rudder, when suddenly I saw a line of high
+land towards the south.
+
+Almost spent, as I was, by fatigue and the dreadful suspense I endured
+for several hours, this sudden certainty of life rushed like a flood of
+warm joy to my heart, and tears gushed from my eyes.
+
+How mutable are our feelings, and how strange is that clinging love we
+have of life even in the excess of misery!  I constructed another sail
+with a part of my dress and eagerly steered my course towards the land.
+It had a wild and rocky appearance, but as I approached nearer I easily
+perceived the traces of cultivation.  I saw vessels near the shore and
+found myself suddenly transported back to the neighbourhood of
+civilized man.  I carefully traced the windings of the land and hailed
+a steeple which I at length saw issuing from behind a small promontory.
+As I was in a state of extreme debility, I resolved to sail directly
+towards the town, as a place where I could most easily procure
+nourishment.  Fortunately I had money with me.
+
+As I turned the promontory I perceived a small neat town and a good
+harbour, which I entered, my heart bounding with joy at my unexpected
+escape.
+
+As I was occupied in fixing the boat and arranging the sails, several
+people crowded towards the spot.  They seemed much surprised at my
+appearance, but instead of offering me any assistance, whispered
+together with gestures that at any other time might have produced in me
+a slight sensation of alarm. As it was, I merely remarked that they
+spoke English, and I therefore addressed them in that language.  "My
+good friends," said I, "will you be so kind as to tell me the name of
+this town and inform me where I am?"
+
+"You will know that soon enough," replied a man with a hoarse voice.
+"Maybe you are come to a place that will not prove much to your taste,
+but you will not be consulted as to your quarters, I promise you."
+
+I was exceedingly surprised on receiving so rude an answer from a
+stranger, and I was also disconcerted on perceiving the frowning and
+angry countenances of his companions.  "Why do you answer me so
+roughly?"  I replied.  "Surely it is not the custom of Englishmen to
+receive strangers so inhospitably."
+
+"I do not know," said the man, "what the custom of the English may be,
+but it is the custom of the Irish to hate villains." While this strange
+dialogue continued, I perceived the crowd rapidly increase.  Their
+faces expressed a mixture of curiosity and anger, which annoyed  and in
+some degree alarmed me.
+
+I inquired the way to the inn, but no one replied.  I then moved
+forward, and a murmuring sound arose from the crowd as they followed
+and surrounded me, when an ill-looking man approaching tapped me on the
+shoulder and said, "Come, sir, you must follow me to Mr. Kirwin's to
+give an account of yourself."
+
+"Who is Mr. Kirwin?  Why am I to give an account of myself?  Is not
+this a free country?"
+
+"Ay, sir, free enough for honest folks.  Mr. Kirwin is a magistrate,
+and you are to give an account of the death of a gentleman who was
+found murdered here last night."
+
+This answer startled me, but I presently recovered myself.  I was
+innocent; that could easily be proved; accordingly I followed my
+conductor in silence and was led to one of the best houses in the town.
+I was ready to sink from fatigue and hunger, but being surrounded by a
+crowd, I thought it politic to rouse all my strength, that no physical
+debility might be construed into apprehension or conscious guilt.
+Little did I then expect the calamity that was in a few moments to
+overwhelm me and extinguish in horror and despair all fear of ignominy
+or death. I must pause here, for it requires all my fortitude to recall
+the memory of the frightful events which I am about to relate, in
+proper detail, to my recollection.
+
+
+
+Chapter 21
+
+I was soon introduced into the presence of the magistrate, an old
+benevolent man with calm and mild manners.  He looked upon me, however,
+with some degree of severity, and then, turning towards my conductors,
+he asked who appeared as witnesses on this occasion.
+
+About half a dozen men came forward; and, one being selected by the
+magistrate, he deposed that he had been out fishing the night before
+with his son and brother-in-law, Daniel Nugent, when, about ten
+o'clock, they observed a strong northerly blast rising, and they
+accordingly put in for port.  It was a very dark night, as the moon had
+not yet risen; they did not land at the harbour, but, as they had been
+accustomed, at a creek about two miles below.  He walked on first,
+carrying a part of the fishing tackle, and his companions followed him
+at some distance.
+
+As he was proceeding along the sands, he struck his foot against
+something and fell at his length on the ground. His companions came up
+to assist him, and by the light of their lantern they found that he had
+fallen on the body of a man, who was to all appearance dead.  Their
+first supposition was that it was the corpse of some person who had
+been drowned and was thrown on shore by the waves, but on examination
+they found that the clothes were not wet and even that the body was not
+then cold.  They instantly carried it to the cottage of an old woman
+near the spot and endeavoured, but in vain, to restore it to life.  It
+appeared to be a handsome young man, about five and twenty years of
+age.  He had apparently been strangled, for there was no sign of any
+violence except the black mark of fingers on his neck.
+
+The first part of this deposition did not in the least interest me, but
+when the mark of the fingers was mentioned I remembered the murder of
+my brother and felt myself extremely agitated; my limbs trembled, and a
+mist came over my eyes, which obliged me to lean on a chair for
+support.  The magistrate observed me with a keen eye and of course drew
+an unfavourable augury from my manner.
+
+The son confirmed his father's account, but when Daniel Nugent was
+called he swore positively that just before the fall of his companion,
+he saw a boat, with a single man in it, at a short distance from the
+shore; and as far as he could judge by the light of a few stars, it was
+the same boat in which I had just landed.  A woman deposed that she
+lived near the beach and was standing at the door of her cottage,
+waiting for the return of the fishermen, about an hour before she heard
+of the discovery of the body, when she saw a boat with only one man in
+it push off from that part of the shore where the corpse was afterwards
+found.
+
+Another woman confirmed the account of the fishermen having brought the
+body into her house; it was not cold.  They put it into a bed and
+rubbed it, and Daniel went to the town for an apothecary, but life was
+quite gone.
+
+Several other men were examined concerning my landing, and they agreed
+that, with the strong north wind that had arisen during the night, it
+was very probable that I had beaten about for many hours and had been
+obliged to return nearly to the same spot from which I had departed.
+Besides, they observed that it appeared that I had brought the body
+from another place, and it was likely that as I did not appear to know
+the shore, I might have put into the harbour ignorant of the distance
+of the town of ---- from the place where I had deposited the corpse.
+
+Mr. Kirwin, on hearing this evidence, desired that I should be taken
+into the room where the body lay for interment, that it might be
+observed what effect the sight of it would produce upon me.  This idea
+was probably suggested by the extreme agitation I had exhibited when
+the mode of the murder had been described.  I was accordingly
+conducted, by the magistrate and several other persons, to the inn.  I
+could not help being struck by the strange coincidences that had taken
+place during this eventful night; but, knowing that I had been
+conversing with several persons in the island I had inhabited about the
+time that the body had been found, I was perfectly tranquil as to the
+consequences of the affair.  I entered the room where the corpse lay
+and was led up to the coffin.  How can I describe my sensations on
+beholding it?  I feel yet parched with horror, nor can I reflect on
+that terrible moment without shuddering and agony.  The examination,
+the presence of the magistrate and witnesses, passed like a dream from
+my memory when I saw the lifeless form of Henry Clerval stretched
+before me.  I gasped for breath, and throwing myself on the body, I
+exclaimed, "Have my murderous machinations deprived you also, my
+dearest Henry, of life?  Two I have already destroyed; other victims
+await their destiny; but you, Clerval, my friend, my benefactor--"
+
+The human frame could no longer support the agonies that I endured, and
+I was carried out of the room in strong convulsions.  A fever succeeded
+to this.  I lay for two months on the point of death; my ravings, as I
+afterwards heard, were frightful; I called myself the murderer of
+William, of Justine, and of Clerval.  Sometimes I entreated my
+attendants to assist me in the destruction of the fiend by whom I was
+tormented; and at others I felt the fingers of the monster already
+grasping my neck, and screamed aloud with agony and terror.
+Fortunately, as I spoke my native language, Mr. Kirwin alone understood
+me; but my gestures and bitter cries were sufficient to affright the
+other witnesses.  Why did I not die?  More miserable than man ever was
+before, why did I not sink into forgetfulness and rest?  Death snatches
+away many blooming children, the only hopes of their doting parents;
+how many brides and youthful lovers have been one day in the bloom of
+health and hope, and the next a prey for worms and the decay of the
+tomb!  Of what materials was I made that I could thus resist so many
+shocks, which, like the turning of the wheel, continually renewed the
+torture?
+
+But I was doomed to live and in two months found myself as awaking from
+a dream, in a prison, stretched on a wretched bed, surrounded by
+jailers, turnkeys, bolts, and all the miserable apparatus of a dungeon.
+It was morning, I remember, when I thus awoke to understanding; I had
+forgotten the particulars of what had happened and only felt as if some
+great misfortune had suddenly overwhelmed me; but when I looked around
+and saw the barred windows and the squalidness of the room in which I
+was, all flashed across my memory and I groaned bitterly.
+
+This sound disturbed an old woman who was sleeping in a chair beside
+me.  She was a hired nurse, the wife of one of the turnkeys, and her
+countenance expressed all those bad qualities which often characterize
+that class.  The lines of her face were hard and rude, like that of
+persons accustomed to see without sympathizing in sights of misery. Her
+tone expressed her entire indifference; she addressed me in English,
+and the voice struck me as one that I had heard during my sufferings.
+"Are you better now, sir?" said she.
+
+I replied in the same language, with a feeble voice, "I believe I am;
+but if it be all true, if indeed I did not dream, I am sorry that I am
+still alive to feel this misery and horror."
+
+"For that matter," replied the old woman, "if you mean about the
+gentleman you murdered, I believe that it were better for you if you
+were dead, for I fancy it will go hard with you!  However, that's none
+of my business; I am sent to nurse you and get you well; I do my duty
+with a safe conscience; it were well if everybody did the same."
+
+I turned with loathing from the woman who could utter so unfeeling a
+speech to a person just saved, on the very edge of death; but I felt
+languid and unable to reflect on all that had passed.  The whole series
+of my life appeared to me as a dream; I sometimes doubted if indeed it
+were all true, for it never presented itself to my mind with the force
+of reality.
+
+As the images that floated before me became more distinct, I grew
+feverish; a darkness pressed around me; no one was near me who soothed
+me with the gentle voice of love; no dear hand supported me.  The
+physician came and prescribed medicines, and the old woman prepared
+them for me; but utter carelessness was visible in the first, and the
+expression of brutality was strongly marked in the visage of the
+second.  Who could be interested in the fate of a murderer but the
+hangman who would gain his fee?
+
+These were my first reflections, but I soon learned that Mr. Kirwin had
+shown me extreme kindness.  He had caused the best room in the prison
+to be prepared for me (wretched indeed was the best); and it was he who
+had provided a physician and a nurse.  It is true, he seldom came to
+see me, for although he ardently desired to relieve the sufferings of
+every human creature, he did not wish to be present at the agonies and
+miserable ravings of a murderer.  He came, therefore, sometimes to see
+that I was not neglected, but his visits were short and with long
+intervals.  One day, while I was gradually recovering, I was seated in
+a chair, my eyes half open and my cheeks livid like those in death.  I
+was overcome by gloom and misery and often reflected I had better seek
+death than desire to remain in a world which to me was replete with
+wretchedness.  At one time I considered whether I should not declare
+myself guilty and suffer the penalty of the law, less innocent than
+poor Justine had been.  Such were my thoughts when the door of my
+apartment was opened and Mr. Kirwin entered.  His countenance expressed
+sympathy and compassion; he drew a chair close to mine and addressed me
+in French, "I fear that this place is very shocking to you; can I do
+anything to make you more comfortable?"
+
+"I thank you, but all that you mention is nothing to me; on the whole
+earth there is no comfort which I am capable of receiving."
+
+"I know that the sympathy of a stranger can be but of little relief to
+one borne down as you are by so strange a misfortune.  But you will, I
+hope, soon quit this melancholy abode, for doubtless evidence can
+easily be brought to free you from the criminal charge."
+
+"That is my least concern; I am, by a course of strange events, become
+the most miserable of mortals.  Persecuted and tortured as I am and
+have been, can death be any evil to me?"
+
+"Nothing indeed could be more unfortunate and agonizing than the
+strange chances that have lately occurred.  You were thrown, by some
+surprising accident, on this shore, renowned for its hospitality,
+seized immediately, and charged with murder.  The first sight that was
+presented to your eyes was the body of your friend, murdered in so
+unaccountable a manner and placed, as it were, by some fiend across
+your path."
+
+As Mr. Kirwin said this, notwithstanding the agitation I endured on
+this retrospect of my sufferings, I also felt considerable surprise at
+the knowledge he seemed to possess concerning me.  I suppose some
+astonishment was exhibited in my countenance, for Mr. Kirwin hastened
+to say, "Immediately upon your being taken ill, all the papers that
+were on your person were brought me, and I examined them that I might
+discover some trace by which I could send to your relations an account
+of your misfortune and illness. I found several letters, and, among
+others, one which I discovered from its commencement to be from your
+father.  I instantly wrote to Geneva; nearly two months have elapsed
+since the departure of my letter.  But you are ill; even now you
+tremble; you are unfit for agitation of any kind."
+
+"This suspense is a thousand times worse than the most horrible event;
+tell me what new scene of death has been acted, and whose murder I am
+now to lament?"
+
+"Your family is perfectly well," said Mr. Kirwin with gentleness; "and
+someone, a friend, is come to visit you."
+
+I know not by what chain of thought the idea presented itself, but it
+instantly darted into my mind that the murderer had come to mock at my
+misery and taunt me with the death of Clerval, as a new incitement for
+me to comply with his hellish desires.  I put my hand before my eyes,
+and cried out in agony, "Oh! Take him away!  I cannot see him; for
+God's sake, do not let him enter!"
+
+Mr. Kirwin regarded me with a troubled countenance.  He could not help
+regarding my exclamation as a presumption of my guilt and said in
+rather a severe tone, "I should have thought, young man, that the
+presence of your father would have been welcome instead of inspiring
+such violent repugnance."
+
+"My father!" cried I, while every feature and every muscle was relaxed
+from anguish to pleasure.  "Is my father indeed come?  How kind, how
+very kind!  But where is he, why does he not hasten to me?"
+
+My change of manner surprised and pleased the magistrate; perhaps he
+thought that my former exclamation was a momentary return of delirium,
+and now he instantly resumed his former benevolence.  He rose and
+quitted the room with my nurse, and in a moment my father entered it.
+
+Nothing, at this moment, could have given me greater pleasure than the
+arrival of my father.  I stretched out my hand to him and cried, "Are
+you, then, safe--and Elizabeth--and Ernest?" My father calmed me with
+assurances of their welfare and endeavoured, by dwelling on these
+subjects so interesting to my heart, to raise my desponding spirits;
+but he soon felt that a prison cannot be the abode of cheerfulness.
+
+"What a place is this that you inhabit, my son!" said he, looking
+mournfully at the barred windows and wretched appearance of the room.
+"You travelled to seek happiness, but a fatality seems to pursue you.
+And poor Clerval--"
+
+The name of my unfortunate and murdered friend was an agitation too
+great to be endured in my weak state; I shed tears.  "Alas!  Yes, my
+father," replied I; "some destiny of the most horrible kind hangs over
+me, and I must live to fulfil it, or surely I should have died on the
+coffin of Henry."
+
+We were not allowed to converse for any length of time, for the
+precarious state of my health rendered every precaution necessary that
+could ensure tranquillity.  Mr. Kirwin came in and insisted that my
+strength should not be exhausted by too much exertion.  But the
+appearance of my father was to me like that of my good angel, and I
+gradually recovered my health.
+
+As my sickness quitted me, I was absorbed by a gloomy and black
+melancholy that nothing could dissipate.  The image of Clerval was
+forever before me, ghastly and murdered.  More than once the agitation
+into which these reflections threw me made my friends dread a dangerous
+relapse.  Alas!  Why did they preserve so miserable and detested a
+life?  It was surely that I might fulfil my destiny, which is now
+drawing to a close.  Soon, oh, very soon, will death extinguish these
+throbbings and relieve me from the mighty weight of anguish that bears
+me to the dust; and, in executing the award of justice, I shall also
+sink to rest.  Then the appearance of death was distant, although the
+wish was ever present to my thoughts; and I often sat for hours
+motionless and speechless, wishing for some mighty revolution that
+might bury me and my destroyer in its ruins.
+
+The season of the assizes approached.  I had already been three months
+in prison, and although I was still weak and in continual danger of a
+relapse, I was obliged to travel nearly a hundred miles to the country
+town where the court was held.  Mr. Kirwin charged himself with every
+care of collecting witnesses and arranging my defence.  I was spared
+the disgrace of appearing publicly as a criminal, as the case was not
+brought before the court that decides on life and death.  The grand
+jury rejected the bill, on its being proved that I was on the Orkney
+Islands at the hour the body of my friend was found; and a fortnight
+after my removal I was liberated from prison.
+
+My father was enraptured on finding me freed from the vexations of a
+criminal charge, that I was again allowed to breathe the fresh
+atmosphere and permitted to return to my native country.  I did not
+participate in these feelings, for to me the walls of a dungeon or a
+palace were alike hateful.  The cup of life was poisoned forever, and
+although the sun shone upon me, as upon the happy and gay of heart, I
+saw around me nothing but a dense and frightful darkness, penetrated by
+no light but the glimmer of two eyes that glared upon me.  Sometimes
+they were the expressive eyes of Henry, languishing in death, the dark
+orbs nearly covered by the lids and the long black lashes that fringed
+them; sometimes it was the watery, clouded eyes of the monster, as I
+first saw them in my chamber at Ingolstadt.
+
+My father tried to awaken in me the feelings of affection.  He talked
+of Geneva, which I should soon visit, of Elizabeth and Ernest; but
+these words only drew deep groans from me.  Sometimes, indeed, I felt a
+wish for happiness and thought with melancholy delight of my beloved
+cousin or longed, with a devouring maladie du pays, to see once more
+the blue lake and rapid Rhone, that had been so dear to me in early
+childhood; but my general state of feeling was a torpor in which a
+prison was as welcome a residence as the divinest scene in nature; and
+these fits were seldom interrupted but by paroxysms of anguish and
+despair.  At these moments I often endeavoured to put an end to the
+existence I loathed, and it required unceasing attendance and vigilance
+to restrain me from committing some dreadful act of violence.
+
+Yet one duty remained to me, the recollection of which finally
+triumphed over my selfish despair.  It was necessary that I should
+return without delay to Geneva, there to watch over the lives of those
+I so fondly loved and to lie in wait for the murderer, that if any
+chance led me to the place of his concealment, or if he dared again to
+blast me by his presence, I might, with unfailing aim, put an end to
+the existence of the monstrous image which  I had endued with the
+mockery of a soul still more monstrous.  My father still desired to
+delay our departure, fearful that I could not sustain the fatigues of a
+journey, for I was a shattered wreck--the shadow of a human being.  My
+strength was gone.  I was a mere skeleton, and fever night and day
+preyed upon my wasted frame.  Still, as I urged our leaving Ireland
+with such inquietude and impatience, my father thought it best to
+yield.  We took our passage on board a vessel bound for Havre-de-Grace
+and sailed with a fair wind from the Irish shores.  It was midnight.  I
+lay on the deck looking at the stars and listening to the dashing of
+the waves.  I hailed the darkness that shut Ireland from my sight, and
+my pulse beat with a feverish joy when I reflected that I should soon
+see Geneva.  The past appeared to me in the light of a frightful dream;
+yet the vessel in which I was, the wind that blew me from the detested
+shore of Ireland, and the sea which surrounded me told me too forcibly
+that I was deceived by no vision and that Clerval, my friend and
+dearest companion, had fallen a victim to me and the monster of my
+creation.  I repassed, in my memory, my whole life--my quiet happiness
+while residing with my family in Geneva, the death of my mother, and my
+departure for Ingolstadt.  I remembered, shuddering, the mad enthusiasm
+that hurried me on to the creation of my hideous enemy, and I called to
+mind the night in which he first lived.  I was unable to pursue the
+train of thought; a thousand feelings pressed upon me, and I wept
+bitterly.  Ever since my recovery from the fever I had been in the
+custom of taking every night a small quantity of laudanum, for it was
+by means of this drug only that I was enabled to gain the rest
+necessary for the preservation of life.  Oppressed by the recollection
+of my various misfortunes, I now swallowed double my usual quantity and
+soon slept profoundly.  But sleep did not afford me respite from
+thought and misery; my dreams presented a thousand objects that scared
+me.  Towards morning I was possessed by a kind of nightmare; I felt the
+fiend's grasp in my neck and could not free myself from it; groans and
+cries rang in my ears.  My father, who was watching over me, perceiving
+my restlessness, awoke me; the dashing waves were around, the cloudy
+sky above, the fiend was not here: a sense of security, a feeling that
+a truce was established between the present hour and the irresistible,
+disastrous future imparted to me a kind of calm forgetfulness, of which
+the human mind is by its structure peculiarly susceptible.
+
+
+
+Chapter 22
+
+The voyage came to an end.  We landed, and proceeded to Paris.  I soon
+found that I had overtaxed my strength and that I must repose before I
+could continue my journey.  My father's care and attentions were
+indefatigable, but he did not know the origin of my sufferings and
+sought erroneous methods to remedy the incurable ill.  He wished me to
+seek amusement in society.  I abhorred the face of man.  Oh, not
+abhorred!  They were my brethren, my fellow beings, and I felt
+attracted even to the most repulsive among them, as to creatures of an
+angelic nature and celestial mechanism.  But I felt that I had no right
+to share their intercourse.  I had unchained an enemy among them whose
+joy it was to shed their blood and to revel in their groans.  How they
+would, each and all, abhor me and hunt me from the world did they know
+my unhallowed acts and the crimes which had their source in me!
+
+My father yielded at length to my desire to avoid society and strove by
+various arguments to banish my despair.  Sometimes he thought that I
+felt deeply the degradation of being obliged to answer a charge of
+murder, and he endeavoured to prove to me the futility of pride.
+
+"Alas!  My father," said I, "how little do you know me.  Human beings,
+their feelings and passions, would indeed be degraded if such a wretch
+as I felt pride.  Justine, poor unhappy Justine, was as innocent as I,
+and she suffered the same charge; she died for it; and I am the cause
+of this--I murdered her.  William, Justine, and Henry--they all died by
+my hands."
+
+My father had often, during my imprisonment, heard me make the same
+assertion; when I thus accused myself, he sometimes seemed to desire an
+explanation, and at others he appeared to consider it as the offspring
+of delirium, and that, during my illness, some idea of this kind had
+presented itself to my imagination, the remembrance of which I
+preserved in my convalescence.
+
+I avoided explanation and maintained a continual silence concerning the
+wretch I had created.  I had a persuasion that I should be supposed
+mad, and this in itself would forever have chained my tongue.  But,
+besides, I could not bring myself to disclose a secret which would fill
+my hearer with consternation and make fear and unnatural horror the
+inmates of his breast.  I checked, therefore, my impatient thirst for
+sympathy and was silent when I would have given the world to have
+confided the fatal secret.  Yet, still, words like those I have
+recorded would burst uncontrollably from me.  I could offer no
+explanation of them, but their truth in part relieved the burden of my
+mysterious woe.  Upon this occasion my father said, with an expression
+of unbounded wonder, "My dearest Victor, what infatuation is this?  My
+dear son, I entreat you never to make such an assertion again."
+
+"I am not mad," I cried energetically; "the sun and the heavens, who
+have viewed my operations, can bear witness of my truth.  I am the
+assassin of those most innocent victims; they died by my machinations.
+A thousand times would I have shed my own blood, drop by drop, to have
+saved their lives; but I could not, my father, indeed I could not
+sacrifice the whole human race."
+
+The conclusion of this speech convinced my father that my ideas were
+deranged, and he instantly changed the subject of our conversation and
+endeavoured to alter the course of my thoughts.  He wished as much as
+possible to obliterate the memory of the scenes that had taken place in
+Ireland and never alluded to them or suffered me to speak of my
+misfortunes.
+
+As time passed away I became more calm; misery had her dwelling in my
+heart, but I no longer talked in the same incoherent manner of my own
+crimes; sufficient for me was the consciousness of them.  By the utmost
+self-violence I curbed the imperious voice of wretchedness, which
+sometimes desired to declare itself to the whole world, and my manners
+were calmer and more composed than they had ever been since my journey
+to the sea of ice.  A few days before we left Paris on our way to
+Switzerland, I received the following letter from Elizabeth:
+
+
+"My dear Friend,
+
+"It gave me the greatest pleasure to receive a letter from my uncle
+dated at Paris; you are no longer at a formidable distance, and I may
+hope to see you in less than a fortnight.  My poor cousin, how much you
+must have suffered!  I expect to see you looking even more ill than
+when you quitted Geneva.  This winter has been passed most miserably,
+tortured as I have been by anxious suspense; yet I hope to see peace in
+your countenance and to find that your heart is not totally void of
+comfort and tranquillity.
+
+"Yet I fear that the same feelings now exist that made you so miserable
+a year ago, even perhaps augmented by time.  I would not disturb you at
+this period, when so many misfortunes weigh upon you, but a
+conversation that I had with my uncle previous to his departure renders
+some explanation necessary before we meet.   Explanation!  You may
+possibly say, What can Elizabeth have to explain?  If you really say
+this, my questions are answered and all my doubts satisfied.  But you
+are distant from me, and it is possible that you may dread and yet be
+pleased with this explanation; and in a probability of this being the
+case, I dare not any longer postpone writing what, during your absence,
+I have often wished to express to you but have never had the courage to
+begin.
+
+"You well know, Victor, that our union had been the favourite plan of
+your parents ever since our infancy.  We were told this when young, and
+taught to look forward to it as an event that would certainly take
+place.  We were affectionate playfellows during childhood, and, I
+believe, dear and valued friends to one another as we grew older. But
+as brother and sister often entertain a lively affection towards each
+other without desiring a more intimate union, may not such also be our
+case?  Tell me, dearest Victor.  Answer me, I conjure you by our mutual
+happiness, with simple truth--Do you not love another?
+
+"You have travelled; you have spent several years of your life at
+Ingolstadt; and I confess to you, my friend, that when I saw you last
+autumn so unhappy, flying to solitude from the society of every
+creature, I could not help supposing that you might regret our
+connection and believe yourself bound in honour to fulfil the wishes of
+your parents, although they opposed themselves to your inclinations.
+But this is false reasoning.  I confess to you, my friend, that I love
+you and that in my airy dreams of futurity you have been my constant
+friend and companion.   But it is your happiness I desire as well as my
+own when I declare to you that our marriage would render me eternally
+miserable unless it were the dictate of your own free choice.  Even now
+I weep to think that, borne down as you are by the cruellest
+misfortunes, you may stifle, by the word 'honour,' all hope of that
+love and happiness which would alone restore you to yourself.  I, who
+have so disinterested an affection for you, may increase your miseries
+tenfold by being an obstacle to your wishes.  Ah! Victor, be assured
+that your cousin and playmate has too sincere a love for you not to be
+made miserable by this supposition.  Be happy, my friend; and if you
+obey me in this one request, remain satisfied that nothing on earth
+will have the power to interrupt my tranquillity.
+
+"Do not let this letter disturb you; do not answer tomorrow, or the
+next day, or even until you come, if it will give you pain.  My uncle
+will send me news of your health, and if I see but one smile on your
+lips when we meet, occasioned by this or any other exertion of mine, I
+shall need no other happiness.
+
+                                                "Elizabeth Lavenza
+
+
+    "Geneva, May 18th, 17--"
+
+
+This letter revived in my memory what I had before forgotten, the
+threat of the fiend--"I WILL BE WITH YOU ON YOUR WEDDING-NIGHT!" Such
+was my sentence, and on that night would the daemon employ every art to
+destroy me and tear me from the glimpse of happiness which promised
+partly to console my sufferings.  On that night he had determined to
+consummate his crimes by my death.  Well, be it so; a deadly struggle
+would then assuredly take place, in which if he were victorious I
+should be at peace and his power over me be at an end.  If he were
+vanquished, I should be a free man.  Alas!  What freedom?  Such as the
+peasant enjoys when his family have been massacred before his eyes, his
+cottage burnt, his lands laid waste, and he is turned adrift, homeless,
+penniless, and alone, but free. Such would be my liberty except that in
+my Elizabeth I possessed a treasure, alas, balanced by those horrors of
+remorse and guilt which would pursue me until death.
+
+Sweet and beloved Elizabeth!  I read and reread her letter, and some
+softened feelings stole into my heart and dared to whisper paradisiacal
+dreams of love and joy; but the apple was already eaten, and the
+angel's arm bared to drive me from all hope.  Yet I would die to make
+her happy.  If the monster executed his threat, death was inevitable;
+yet, again, I considered whether my marriage would hasten my fate.  My
+destruction might indeed arrive a few months sooner, but if my torturer
+should suspect that I postponed it, influenced by his menaces, he would
+surely find other and perhaps more dreadful means of revenge.
+
+He had vowed TO BE WITH ME ON MY WEDDING-NIGHT, yet he did not consider
+that threat as binding him to peace in the meantime, for as if to show
+me that he was not yet satiated with blood, he had murdered Clerval
+immediately after the enunciation of his threats.  I resolved,
+therefore, that if my immediate union with my cousin would conduce
+either to hers or my father's happiness, my adversary's designs against
+my life should not retard it a single hour.
+
+In this state of mind I wrote to Elizabeth.  My letter was calm and
+affectionate.  "I fear, my beloved girl," I said, "little happiness
+remains for us on earth; yet all that I may one day enjoy is centred in
+you.  Chase away your idle fears; to you alone do I consecrate my life
+and my endeavours for contentment.  I have one secret, Elizabeth, a
+dreadful one; when revealed to you, it will chill your frame with
+horror, and then, far from being surprised at my misery, you will only
+wonder that I survive what I have endured.  I will confide this tale of
+misery and terror to you the day after our marriage shall take place,
+for, my sweet cousin, there must be perfect confidence between us.  But
+until then, I conjure you, do not mention or allude to it.  This I most
+earnestly entreat, and I know you will comply."
+
+In about a week after the arrival of Elizabeth's letter we returned to
+Geneva.  The sweet girl welcomed me with warm affection, yet tears were
+in her eyes as she beheld my emaciated frame and feverish  cheeks.  I
+saw a change in her also.  She was thinner and had lost much of that
+heavenly vivacity that had before charmed me; but her gentleness and
+soft looks of compassion made her a more fit companion for one blasted
+and miserable as I was.  The tranquillity which I now enjoyed did not
+endure.  Memory brought madness with it, and when I thought of what had
+passed, a real insanity possessed me; sometimes I was furious and burnt
+with rage, sometimes low and despondent.  I neither spoke nor looked at
+anyone, but sat motionless, bewildered by the multitude of miseries
+that overcame me.
+
+Elizabeth alone had the power to draw me from these fits; her gentle
+voice would soothe me when transported by passion and inspire me with
+human feelings when sunk in torpor.  She wept with me and for me.  When
+reason returned, she would remonstrate and endeavour to inspire me with
+resignation.  Ah!  It is well for the unfortunate to be resigned, but
+for the guilty there is no peace.  The agonies of remorse poison the
+luxury there is otherwise sometimes found in indulging the excess of
+grief.  Soon after my arrival my father spoke of my immediate marriage
+with Elizabeth.  I remained silent.
+
+"Have you, then, some other attachment?"
+
+"None on earth.  I love Elizabeth and look forward to our union with
+delight.  Let the day therefore be fixed; and on it I will consecrate
+myself, in life or death, to the happiness of my cousin."
+
+"My dear Victor, do not speak thus.  Heavy misfortunes have befallen
+us, but let us only cling closer to what remains and transfer our love
+for those whom we have lost to those who yet live.  Our circle will be
+small but bound close by the ties of affection and mutual misfortune.
+And when time shall have softened your despair, new and dear objects of
+care will be born to replace those of whom we have been so cruelly
+deprived."
+
+Such were the lessons of my father.  But to me the remembrance of the
+threat returned; nor can you wonder that, omnipotent as the fiend had
+yet been in his deeds of blood, I should almost regard him as
+invincible, and that when he had pronounced the words "I SHALL BE WITH
+YOU ON YOUR WEDDING-NIGHT," I should regard the threatened fate as
+unavoidable.  But death was no evil to me if the loss of Elizabeth were
+balanced with it, and I therefore, with a contented and even cheerful
+countenance, agreed with my father that if my cousin would consent, the
+ceremony should take place in ten days, and thus put, as I imagined,
+the seal to my fate.
+
+Great God!  If for one instant I had thought what might be the hellish
+intention of my fiendish adversary, I would rather have banished myself
+forever from my native country and wandered a friendless outcast over
+the earth than have consented to this miserable marriage.  But, as if
+possessed of magic powers, the monster had blinded me to his real
+intentions; and when I thought that I had prepared only my own death, I
+hastened that of a far dearer victim.
+
+As the period fixed for our marriage drew nearer, whether from
+cowardice or a prophetic feeling, I felt my heart sink within me.  But
+I concealed my feelings by an appearance of hilarity that brought
+smiles and joy to the countenance of my father, but hardly deceived the
+ever-watchful and nicer eye of Elizabeth.  She looked forward to our
+union with placid contentment, not unmingled with a little fear, which
+past misfortunes had impressed, that what now appeared certain and
+tangible happiness might soon dissipate into an airy dream and leave no
+trace but deep and everlasting regret.  Preparations were made for the
+event, congratulatory visits were received, and all wore a smiling
+appearance.  I shut up, as well as I could, in my own heart the anxiety
+that preyed there and entered with seeming earnestness into the plans
+of my father, although they might only serve as the decorations of my
+tragedy.  Through my father's exertions a part of the inheritance of
+Elizabeth had been restored to her by the Austrian government.  A small
+possession on the shores of Como belonged to her.  It was agreed that,
+immediately after our union, we should proceed to Villa Lavenza and
+spend our first days of happiness beside the beautiful lake near which
+it stood.
+
+In the meantime I took every precaution to defend my person in case the
+fiend should openly attack me.  I carried pistols and a dagger
+constantly about me and was ever on the watch to prevent artifice, and
+by these means gained a greater degree of tranquillity.  Indeed, as the
+period approached, the threat appeared more as a delusion, not to be
+regarded as worthy to disturb my peace, while the happiness I hoped for
+in my marriage wore a greater appearance of certainty as the day fixed
+for its solemnization drew nearer and I heard it continually spoken of
+as an occurrence which no accident could possibly prevent.
+
+Elizabeth seemed happy; my tranquil demeanour contributed greatly to
+calm her mind.  But on the day that was to fulfil my wishes and my
+destiny, she was melancholy, and a presentiment of evil pervaded her;
+and perhaps also she thought of the dreadful secret which I had
+promised to reveal to her on the following day.  My father was in the
+meantime overjoyed and in the bustle of preparation only recognized in
+the melancholy of his niece the diffidence of a bride.
+
+After the ceremony was performed a large party assembled at my
+father's, but it was agreed that Elizabeth and I should commence our
+journey by water, sleeping that night at Evian and continuing our
+voyage on the following day.  The day was fair, the wind favourable;
+all smiled on our nuptial embarkation.
+
+Those were the last moments of my life during which I enjoyed the
+feeling of happiness.  We passed rapidly along; the sun was hot, but we
+were sheltered from its rays by a kind of canopy while we enjoyed the
+beauty of the scene, sometimes on one side of the lake, where we saw
+Mont Saleve, the pleasant banks of Montalegre, and at a distance,
+surmounting all, the beautiful Mont Blanc and the assemblage of snowy
+mountains that in vain endeavour to emulate her; sometimes coasting the
+opposite banks, we saw the mighty Jura opposing its dark side to the
+ambition that would quit its native country, and an almost
+insurmountable barrier to the invader who should wish to enslave it.
+
+I took the hand of Elizabeth.  "You are sorrowful, my love.  Ah!  If
+you knew what I have suffered and what I may yet endure, you would
+endeavour to let me taste the quiet and freedom from despair that this
+one day at least permits me to enjoy."
+
+"Be happy, my dear Victor," replied Elizabeth; "there is, I hope,
+nothing to distress you; and be assured that if a lively joy is not
+painted in my face, my heart is contented.  Something whispers to me
+not to depend too much on the prospect that is opened before us, but I
+will not listen to such a sinister voice.  Observe how fast we move
+along and how the clouds, which sometimes obscure and sometimes rise
+above the dome of Mont Blanc, render this scene of beauty still more
+interesting.  Look also at the innumerable fish that are swimming in
+the clear waters, where we can distinguish every pebble that lies at
+the bottom.  What a divine day!  How happy and serene all nature
+appears!"
+
+Thus Elizabeth endeavoured to divert her thoughts and mine from all
+reflection upon melancholy subjects.  But her temper was fluctuating;
+joy for a few instants shone in her eyes, but it continually gave place
+to distraction and reverie.
+
+The sun sank lower in the heavens; we passed the river Drance and
+observed its path through the chasms of the higher and the glens of the
+lower hills.  The Alps here come closer to the lake, and we approached
+the amphitheatre of mountains which forms its eastern boundary.  The
+spire of Evian shone under the woods that surrounded it and the range
+of mountain above mountain by which it was overhung.
+
+The wind, which had hitherto carried us along with amazing rapidity,
+sank at sunset to a light breeze; the soft air just ruffled the water
+and caused a pleasant motion among the trees as we approached the
+shore, from which it wafted the most delightful scent of flowers and
+hay.  The sun sank beneath the horizon as we landed, and as I touched
+the shore I felt those cares and fears revive which soon were to clasp
+me and cling to me forever.
+
+
+
+Chapter 23
+
+It was eight o'clock when we landed; we walked for a short time on the
+shore, enjoying the transitory light, and then retired to the inn and
+contemplated the lovely scene of waters, woods, and mountains, obscured
+in darkness, yet still displaying their black outlines.
+
+The wind, which had fallen in the south, now rose with great violence
+in the west.  The moon had reached her summit in the heavens and was
+beginning to descend; the clouds swept across it swifter than the
+flight of the vulture and dimmed her rays, while the lake reflected the
+scene of the busy heavens, rendered still busier by the restless waves
+that were beginning to rise.  Suddenly a heavy storm of rain descended.
+
+I had been calm during the day, but so soon as night obscured the
+shapes of objects, a thousand fears arose in my mind.  I was anxious
+and watchful, while my right hand grasped a pistol which was hidden in
+my bosom; every sound terrified me, but I resolved that I would sell my
+life dearly and not shrink from the conflict until my own life or that
+of my adversary was extinguished.  Elizabeth observed my agitation for
+some time in timid and fearful silence, but there was something in my
+glance which communicated terror to her, and trembling, she asked,
+"What is it that agitates you, my dear Victor?  What is it you fear?"
+
+"Oh!  Peace, peace, my love," replied I; "this night, and all will be
+safe; but this night is dreadful, very dreadful."
+
+I passed an hour in this state of mind, when suddenly I reflected how
+fearful the combat which I momentarily expected would be to my wife,
+and I earnestly entreated her to retire, resolving not to join her
+until I had obtained some knowledge as to the situation of my enemy.
+
+She left me, and I continued some time walking up and down the passages
+of the house and inspecting every corner that might afford a retreat to
+my adversary.  But I discovered no trace of him and was beginning to
+conjecture that some fortunate chance had intervened to prevent the
+execution of his menaces when suddenly I heard a shrill and dreadful
+scream.  It came from the room into which Elizabeth had retired.  As I
+heard it, the whole truth rushed into my mind, my arms dropped, the
+motion of every muscle and fibre was suspended; I could feel the blood
+trickling in my veins and tingling in the extremities of my limbs. This
+state lasted but for an instant; the scream was repeated, and I rushed
+into the room.  Great God!  Why did I not then expire!  Why am I here
+to relate the destruction of the best hope and the purest creature on
+earth?  She was there, lifeless and inanimate, thrown across the bed,
+her head hanging down and her pale and distorted features half covered
+by her hair.  Everywhere I turn I see the same figure--her bloodless
+arms and relaxed form flung by the murderer on its bridal bier.  Could
+I behold this and live?  Alas!  Life is obstinate and clings closest
+where it is most hated.  For a moment only did I lose recollection; I
+fell senseless on the ground.
+
+When I recovered I found myself surrounded by the people of the inn;
+their countenances expressed a breathless terror, but the horror of
+others appeared only as a mockery, a shadow of the feelings that
+oppressed me.  I escaped from them to the room where lay the body of
+Elizabeth, my love, my wife, so lately living, so dear, so worthy.  She
+had been moved from the posture in which I had first beheld her, and
+now, as she lay, her head upon her arm and a handkerchief thrown across
+her face and neck, I might have supposed her asleep. I rushed towards
+her and embraced her with ardour, but the deadly languor and coldness
+of the limbs told me that what I now held in my arms had ceased to be
+the Elizabeth whom I had loved and cherished.  The murderous mark of
+the fiend's grasp was on her neck, and the breath had ceased to issue
+from her lips.  While I still hung over her in the agony of despair, I
+happened to look up.  The windows of the room had before been darkened,
+and I felt a kind of panic on seeing the pale yellow light of the moon
+illuminate the chamber.  The shutters had been thrown back, and with a
+sensation of horror not to be described, I saw at the open window a
+figure the most hideous and abhorred.  A grin was on the face of the
+monster; he seemed to jeer, as with his fiendish finger he pointed
+towards the corpse of my wife.  I rushed towards the window, and
+drawing a pistol from my bosom, fired; but he eluded me, leaped from
+his station, and running with the swiftness of lightning, plunged into
+the lake.
+
+The report of the pistol brought a crowd into the room. I pointed to
+the spot where he had disappeared, and we followed the track with
+boats; nets were cast, but in vain.  After passing several hours, we
+returned hopeless, most of my companions believing it to have been a
+form conjured up by my fancy.  After having landed, they proceeded to
+search the country, parties going in different directions among the
+woods and vines.
+
+I attempted to accompany them and proceeded a short distance from the
+house, but my head whirled round, my steps were like those of a drunken
+man, I fell at last in a state of utter exhaustion; a film covered my
+eyes, and my skin was parched with the heat of fever.  In this state I
+was carried back and placed on a bed, hardly conscious of what had
+happened; my eyes wandered round the room as if to seek something that
+I had lost.
+
+After an interval I arose, and as if by instinct, crawled into the room
+where the corpse of my beloved lay.  There were women weeping around; I
+hung over it and joined my sad tears to theirs; all this time no
+distinct idea presented itself to my mind, but my thoughts rambled to
+various subjects, reflecting confusedly on my misfortunes and their
+cause.  I was bewildered, in a cloud of wonder and horror.  The death
+of William, the execution of Justine, the murder of Clerval, and lastly
+of my wife; even at that moment I knew not that my only remaining
+friends were safe from the malignity of the fiend; my father even now
+might be writhing under his grasp, and Ernest might be dead at his
+feet.  This idea made me shudder and recalled me to action.  I started
+up and resolved to return to Geneva with all possible speed.
+
+There were no horses to be procured, and I must return by the lake; but
+the wind was unfavourable, and the rain fell in torrents.  However, it
+was hardly morning, and I might reasonably hope to arrive by night.  I
+hired men to row and took an oar myself, for I had always experienced
+relief from mental torment in bodily exercise.  But the overflowing
+misery I now felt, and the excess of agitation that I endured rendered
+me incapable of any exertion.  I threw down the oar, and leaning my
+head upon my hands, gave way to every gloomy idea that arose.  If I
+looked up, I saw scenes which were familiar to me in my happier time
+and which I had contemplated but the day before in the company of her
+who was now but a shadow and a recollection.  Tears streamed from my
+eyes.  The rain had ceased for a moment, and I saw the fish play in the
+waters as they had done a few hours before; they had then been observed
+by Elizabeth.  Nothing is so painful to the human mind as a great and
+sudden change.  The sun might shine or the clouds might lower, but
+nothing could appear to me as it had done the day before.  A fiend had
+snatched from me every hope of future happiness; no creature had ever
+been so miserable as I was; so frightful an event is single in the
+history of man. But why should I dwell upon the incidents that followed
+this last overwhelming event?  Mine has been a tale of horrors; I have
+reached their acme, and what I must now relate can but be tedious to
+you.  Know that, one by one, my friends were snatched away; I was left
+desolate.  My own strength is exhausted, and I must tell, in a few
+words, what remains of my hideous narration. I arrived at Geneva.  My
+father and Ernest yet lived, but the former sunk under the tidings that
+I bore.  I see him now, excellent and venerable old man!  His eyes
+wandered in vacancy, for they had lost their charm and their
+delight--his Elizabeth, his more than daughter, whom he doted on with
+all that affection which a man feels, who in the decline of life,
+having few affections, clings more earnestly to those that remain.
+Cursed, cursed be the fiend that brought misery on his grey hairs and
+doomed him to waste in wretchedness!  He could not live under the
+horrors that were accumulated around him; the springs of existence
+suddenly gave way; he was unable to rise from his bed, and in a few
+days he died in my arms.
+
+What then became of me?  I know not; I lost sensation, and chains and
+darkness were the only objects that pressed upon me.  Sometimes,
+indeed, I dreamt that I wandered in flowery meadows and pleasant vales
+with the friends of my youth, but I awoke and found myself in a
+dungeon.  Melancholy followed, but by degrees I gained a clear
+conception of my miseries and situation and was then released from my
+prison.  For they had called me mad, and during many months, as I
+understood, a solitary cell had been my habitation.
+
+Liberty, however, had been a useless gift to me, had I not, as I
+awakened to reason, at the same time awakened to revenge.  As the
+memory of past misfortunes pressed upon me, I began to reflect on their
+cause--the monster whom I had created, the miserable daemon whom I had
+sent abroad into the world for my destruction.  I was possessed by a
+maddening rage when I thought of him, and desired and ardently prayed
+that I might have him within my grasp to wreak a great and signal
+revenge on his cursed head.
+
+Nor did my hate long confine itself to useless wishes; I began to
+reflect on the best means of securing him; and for this purpose, about
+a month after my release, I repaired to a criminal judge in the town
+and told him that I had an accusation to make, that I knew the
+destroyer of my family, and that I required him to exert his whole
+authority for the apprehension of the murderer.  The magistrate
+listened to me with attention and kindness.
+
+"Be assured, sir," said he, "no pains or exertions on my part shall be
+spared to discover the villain."
+
+"I thank you," replied I; "listen, therefore, to the deposition that I
+have to make.  It is indeed a tale so strange that I should fear you
+would not credit it were there not something in truth which, however
+wonderful, forces conviction.  The story is too connected to be
+mistaken for a dream, and I have no motive for falsehood." My manner as
+I thus addressed him was impressive but calm; I had formed in my own
+heart a resolution to pursue my destroyer to death, and this purpose
+quieted my agony and for an interval reconciled me to life.  I now
+related my history briefly but with firmness and precision, marking the
+dates with accuracy and never deviating into invective or exclamation.
+
+The magistrate appeared at first perfectly incredulous, but as I
+continued he became more attentive and interested; I saw him sometimes
+shudder with horror; at others a lively surprise, unmingled with
+disbelief, was painted on his countenance.  When I had concluded my
+narration I said, "This is the being whom I accuse and for whose
+seizure and punishment I call upon you to exert your whole power.  It
+is your duty as a magistrate, and I believe and hope that your feelings
+as a man will not revolt from the execution of those functions on this
+occasion."  This address caused a considerable change in the
+physiognomy of my own auditor.  He had heard my story with that half
+kind of belief that is given to a tale of spirits and supernatural
+events; but when he was called upon to act officially in consequence,
+the whole tide of his incredulity returned.  He, however, answered
+mildly, "I would willingly afford you every aid in your pursuit, but
+the creature of whom you speak appears to have powers which would put
+all my exertions to defiance.  Who can follow an animal which can
+traverse the sea of ice and inhabit caves and dens where no man would
+venture to intrude?  Besides, some months have elapsed since the
+commission of his crimes, and no one can conjecture to what place he
+has wandered or what region he may now inhabit."
+
+"I do not doubt that he hovers near the spot which I inhabit, and if he
+has indeed taken refuge in the Alps, he may be hunted like the chamois
+and destroyed as a beast of prey.  But I perceive your thoughts; you do
+not credit my narrative and do not intend to pursue my enemy with the
+punishment which is his desert." As I spoke, rage sparkled in my eyes;
+the magistrate was intimidated.  "You are mistaken," said he.  "I will
+exert myself, and if it is in my power to seize the monster, be assured
+that he shall suffer punishment proportionate to his crimes.  But I
+fear, from what you have yourself described to be his properties, that
+this will prove impracticable; and thus, while every proper measure is
+pursued, you should make up your mind to disappointment."
+
+"That cannot be; but all that I can say will be of little avail.  My
+revenge is of no moment to you; yet, while I allow it to be a vice, I
+confess that it is the devouring and only passion of my soul.  My rage
+is unspeakable when I reflect that the murderer, whom I have turned
+loose upon society, still exists.  You refuse my just demand; I have
+but one resource, and I devote myself, either in my life or death, to
+his destruction."
+
+I trembled with excess of agitation as I said this; there was a frenzy
+in my manner, and something, I doubt not, of that haughty fierceness
+which the martyrs of old are said to have possessed.  But to a Genevan
+magistrate, whose mind was occupied by far other ideas than those of
+devotion and heroism, this elevation of mind had much the appearance of
+madness.  He endeavoured to soothe me as a nurse does a child and
+reverted to my tale as the effects of delirium.
+
+"Man," I cried, "how ignorant art thou in thy pride of wisdom!  Cease;
+you know not what it is you say."
+
+I broke from the house angry and disturbed and retired to meditate on
+some other mode of action.
+
+
+
+Chapter 24
+
+My present situation was one in which all voluntary thought was
+swallowed up and lost.  I was hurried away by fury; revenge alone
+endowed me with strength and composure; it moulded my feelings and
+allowed me to be calculating and calm at periods when otherwise
+delirium or death would have been my portion.
+
+My first resolution was to quit Geneva forever; my country, which, when
+I was happy and beloved, was dear to me, now, in my adversity, became
+hateful.  I provided myself with a sum of money, together with a few
+jewels which had belonged to my mother, and departed.  And now my
+wanderings began which are to cease but with life.  I have traversed a
+vast portion of the earth and have endured all the hardships which
+travellers in deserts and barbarous countries are wont to meet.  How I
+have lived I hardly know; many times have I stretched my failing limbs
+upon the sandy plain and prayed for death.  But revenge kept me alive;
+I dared not die and leave my adversary in being.
+
+When I quitted Geneva my first labour was to gain some clue by which I
+might trace the steps of my fiendish enemy.  But my plan was unsettled,
+and I wandered many hours round the confines of the town, uncertain
+what path I should pursue.  As night approached I found myself at the
+entrance of the cemetery where William, Elizabeth, and my father
+reposed.  I entered it and approached the tomb which marked their
+graves.  Everything was silent except the leaves of the trees, which
+were gently agitated by the wind; the night was nearly dark, and the
+scene would have been solemn and affecting even to an uninterested
+observer.  The spirits of the departed seemed to flit around and to
+cast a shadow, which was felt but not seen, around the head of the
+mourner.
+
+The deep grief which this scene had at first excited quickly gave way
+to rage and despair.  They were dead, and I lived; their murderer also
+lived, and to destroy him I must drag out my weary existence.  I knelt
+on the grass and kissed the earth and with quivering lips exclaimed,
+"By the sacred earth on which I kneel, by the shades that wander near
+me, by the deep and eternal grief that I feel, I swear; and by thee, O
+Night, and the spirits that preside over thee, to pursue the daemon who
+caused this misery, until he or I shall perish in mortal conflict.  For
+this purpose I will preserve my life; to execute this dear revenge will
+I again behold the sun and tread the green herbage of earth, which
+otherwise should vanish from my eyes forever.  And I call on you,
+spirits of the dead, and on you, wandering ministers of vengeance, to
+aid and conduct me in my work.  Let the cursed and hellish monster
+drink deep of agony; let him feel the despair that now torments me."  I
+had begun my adjuration with solemnity and an awe which almost assured
+me that the shades of my murdered friends heard and approved my
+devotion, but the furies possessed me as I concluded, and rage choked
+my utterance.
+
+I was answered through the stillness of night by a loud and fiendish
+laugh.  It rang on my ears long and heavily; the mountains re-echoed
+it, and I felt as if all hell surrounded me with mockery and laughter.
+Surely in that moment I should have been possessed by frenzy and have
+destroyed my miserable existence but that my vow was heard and that I
+was reserved for vengeance.  The laughter died away, when a well-known
+and abhorred voice, apparently close to my ear, addressed me in an
+audible whisper, "I am satisfied, miserable wretch!  You have
+determined to live, and I am satisfied."
+
+I darted towards the spot from which the sound proceeded, but the devil
+eluded my grasp.  Suddenly the broad disk of the moon arose and shone
+full upon his ghastly and distorted shape as he fled with more than
+mortal speed.
+
+I pursued him, and for many months this has been my task.  Guided by a
+slight clue, I followed the windings of the Rhone, but vainly.  The
+blue Mediterranean appeared, and by a strange chance, I saw the fiend
+enter by night and hide himself in a vessel bound for the Black Sea.  I
+took my passage in the same ship, but he escaped, I know not how.
+
+Amidst the wilds of Tartary and Russia, although he still evaded me, I
+have ever followed in his track.  Sometimes the peasants, scared by
+this horrid apparition, informed me of his path; sometimes he himself,
+who feared that if I lost all trace of him I should despair and die,
+left some mark to guide me.  The snows descended on my head, and I saw
+the print of his huge step on the white plain.  To you first entering
+on life, to whom care is new and agony unknown, how can you understand
+what I have felt and still feel?  Cold, want, and fatigue were the
+least pains which I was destined to endure; I was cursed by some devil
+and carried about with me my eternal hell; yet still a spirit of good
+followed and directed my steps and when I most murmured would suddenly
+extricate me from seemingly insurmountable difficulties.  Sometimes,
+when nature, overcome by hunger, sank under the exhaustion, a repast
+was prepared for me in the desert that restored and inspirited me.  The
+fare was, indeed, coarse, such as the peasants of the country ate, but
+I will not doubt that it was set there by the spirits that I had
+invoked to aid me.  Often, when all was dry, the heavens cloudless, and
+I was parched by thirst, a slight cloud would bedim the sky, shed the
+few drops that revived me, and vanish.
+
+I followed, when I could, the courses of the rivers; but the daemon
+generally avoided these, as it was here that the population of the
+country chiefly collected.  In other places human beings were seldom
+seen, and I generally subsisted on the wild animals that crossed my
+path.  I had money with me and gained the friendship of the villagers
+by distributing it; or I brought with me some food that I had killed,
+which, after taking a small part, I always presented to those who had
+provided me with fire and utensils for cooking.
+
+My life, as it passed thus, was indeed hateful to me, and it was during
+sleep alone that I could taste joy.  O blessed sleep!  Often, when most
+miserable, I sank to repose, and my dreams lulled me even to rapture.
+The spirits that guarded me had provided these moments, or rather
+hours, of happiness that I might retain strength to fulfil my
+pilgrimage.  Deprived of this respite, I should have sunk under my
+hardships.  During the day I was sustained and inspirited by the hope
+of night, for in sleep I saw my friends, my wife, and my beloved
+country; again I saw the benevolent countenance of my father, heard the
+silver tones of my Elizabeth's voice, and beheld Clerval enjoying
+health and youth.  Often, when wearied by a toilsome march, I persuaded
+myself that I was dreaming until night should come and that I should
+then enjoy reality in the arms of my dearest friends.  What agonizing
+fondness did I feel for them!  How did I cling to their dear forms, as
+sometimes they haunted even my waking hours, and persuade myself that
+they still lived!  At such moments vengeance, that burned within me,
+died in my heart, and I pursued my path towards the destruction of the
+daemon more as a task enjoined by heaven, as the mechanical impulse of
+some power of which I was unconscious, than as the ardent desire of my
+soul.  What his feelings were whom I pursued I cannot know.  Sometimes,
+indeed, he left marks in writing on the barks of the trees or cut in
+stone that guided me and instigated my fury.  "My reign is not yet
+over"--these words were legible in one of these inscriptions--"you
+live, and my power is complete.  Follow me; I seek the everlasting ices
+of the north, where you will feel the misery of cold and frost, to
+which I am impassive.  You will find near this place, if you follow not
+too tardily, a dead hare; eat and be refreshed.  Come on, my enemy; we
+have yet to wrestle for our lives, but many hard and miserable hours
+must you endure until that period shall arrive."
+
+Scoffing devil!  Again do I vow vengeance; again do I devote thee,
+miserable fiend, to torture and death.  Never will I give up my search
+until he or I perish; and then with what ecstasy shall I join my
+Elizabeth and my departed friends, who even now prepare for me the
+reward of my tedious toil and horrible pilgrimage!
+
+As I still pursued my journey to the northward, the snows thickened and
+the cold increased in a degree almost too severe to support.  The
+peasants were shut up in their hovels, and only a few of the most hardy
+ventured forth to seize the animals whom starvation had forced from
+their hiding-places to seek for prey.  The rivers were covered with
+ice, and no fish could be procured; and thus I was cut off from my
+chief article of maintenance.  The triumph of my enemy increased with
+the difficulty of my labours.  One inscription that he left was in
+these words:  "Prepare!  Your toils only begin; wrap yourself in furs
+and provide food, for we shall soon enter upon a journey where your
+sufferings will satisfy my everlasting hatred."
+
+My courage and perseverance were invigorated by these scoffing words; I
+resolved not to fail in my purpose, and calling on heaven to support
+me, I continued with unabated fervour to traverse immense deserts,
+until the ocean appeared at a distance and formed the utmost boundary
+of the horizon.  Oh!  How unlike it was to the blue seasons of the
+south!  Covered with ice, it was only to be distinguished from land by
+its superior wildness and ruggedness.  The Greeks wept for joy when
+they beheld the Mediterranean from the hills of Asia, and hailed with
+rapture the boundary of their toils.  I did not weep, but I knelt down
+and with a full heart thanked my guiding spirit for conducting me in
+safety to the place where I hoped, notwithstanding my adversary's gibe,
+to meet and grapple with him.
+
+Some weeks before this period I had procured a sledge and dogs and thus
+traversed the snows with inconceivable speed.  I know not whether the
+fiend possessed the same advantages, but I found that, as before I had
+daily lost ground in the pursuit, I now gained on him, so much so that
+when I first saw the ocean he was but one day's journey in advance, and
+I hoped to intercept him before he should reach the beach.  With new
+courage, therefore, I pressed on, and in two days arrived at a wretched
+hamlet on the seashore.  I inquired of the inhabitants concerning the
+fiend and gained accurate information.  A gigantic monster, they said,
+had arrived the night before, armed with a gun and many pistols,
+putting to flight the inhabitants of a solitary cottage through fear of
+his terrific appearance.  He had carried off their store of winter
+food, and placing it in a sledge, to draw which he had seized on a
+numerous drove of trained dogs, he had harnessed them, and the same
+night, to the joy of the horror-struck villagers, had pursued his
+journey across the sea in a direction that led to no land; and they
+conjectured that he must speedily be destroyed by the breaking of the
+ice or frozen by the eternal  frosts.
+
+On hearing this information I suffered a temporary access of despair.
+He had escaped me, and I must commence a destructive and almost endless
+journey across the mountainous ices of the ocean, amidst cold that few
+of the inhabitants could long endure and which I, the native of a
+genial and sunny climate, could not hope to survive.  Yet at the idea
+that the fiend should live and be triumphant, my rage and vengeance
+returned, and like a mighty tide, overwhelmed every other feeling.
+After a slight repose, during which the spirits of the dead hovered
+round and instigated me to toil and revenge, I prepared for my journey.
+I exchanged my land-sledge for one fashioned for the inequalities of
+the frozen ocean, and purchasing a plentiful stock of provisions, I
+departed from land.
+
+I cannot guess how many days have passed since then, but I have endured
+misery which nothing but the eternal sentiment of a just retribution
+burning within my heart could have enabled me to support.  Immense and
+rugged mountains of ice often barred up my passage, and I often heard
+the thunder of the ground sea, which threatened my destruction.  But
+again the frost came and made the paths of the sea secure.
+
+By the quantity of provision which I had consumed, I should guess that
+I had passed three weeks in this journey; and the continual protraction
+of hope, returning back upon the heart, often wrung bitter drops of
+despondency and grief from my eyes.  Despair had indeed almost secured
+her prey, and I should soon have sunk beneath this misery.  Once, after
+the poor animals that conveyed me had with incredible toil gained the
+summit of a sloping ice mountain, and one, sinking under his fatigue,
+died, I viewed the expanse before me with anguish, when suddenly my eye
+caught a dark speck upon the dusky plain.  I strained my sight to
+discover what it could be and uttered a wild cry of ecstasy when I
+distinguished a sledge and the distorted proportions of a well-known
+form within.  Oh!  With what a burning gush did hope revisit my heart!
+Warm tears filled my eyes, which I hastily wiped away, that they might
+not intercept the view I had of the daemon; but still my sight was
+dimmed by the burning drops, until, giving way to the emotions that
+oppressed me, I wept aloud.
+
+But this was not the time for delay; I disencumbered the dogs of their
+dead companion, gave them a plentiful portion of food, and after an
+hour's rest, which was absolutely necessary, and yet which was bitterly
+irksome to me, I continued my route.  The sledge was still visible, nor
+did I again lose sight of it except at the moments when for a short
+time some ice-rock concealed it with its intervening crags.  I indeed
+perceptibly gained on it, and when, after nearly two days' journey, I
+beheld my enemy at no more than a mile distant, my heart bounded within
+me.
+
+But now, when I appeared almost within grasp of my foe, my hopes were
+suddenly extinguished, and I lost all trace of him more utterly than I
+had ever done before.  A ground sea was heard; the thunder of its
+progress, as the waters rolled and swelled beneath me, became every
+moment more ominous and terrific.  I pressed on, but in vain.  The wind
+arose; the sea roared; and, as with the mighty shock of an earthquake,
+it split and cracked with a tremendous and overwhelming sound.  The
+work was soon finished; in a few minutes a tumultuous sea rolled
+between me and my enemy, and I was left drifting on a scattered piece
+of ice that was continually lessening and thus preparing for me a
+hideous death.  In this manner many appalling hours passed; several of
+my dogs died, and I myself was about to sink under the accumulation of
+distress when I saw your vessel riding at anchor and holding forth to
+me hopes of succour and life.  I had no conception that vessels ever
+came so far north and was astounded at the sight.  I quickly destroyed
+part of my sledge to construct oars, and by these means was enabled,
+with infinite fatigue, to move my ice raft in the direction of your
+ship.  I had determined, if you were going southwards, still to trust
+myself to the mercy of the seas rather than abandon my purpose.  I
+hoped to induce you to grant me a boat with which I could pursue my
+enemy.  But your direction was northwards.  You took me on board when
+my vigour was exhausted, and I should soon have sunk under my
+multiplied hardships into a death which I still dread, for my task is
+unfulfilled.
+
+Oh!  When will my guiding spirit, in conducting me to the daemon, allow
+me the rest I so much desire; or must I die, and he yet live?  If I do,
+swear to me, Walton, that he shall not escape, that you will seek him
+and satisfy my vengeance in his death.  And do I dare to ask of you to
+undertake my pilgrimage, to endure the hardships that I have undergone?
+No; I am not so selfish.  Yet, when I am dead, if he should appear, if
+the ministers of vengeance should conduct him to you, swear that he
+shall not live--swear that he shall not triumph over my accumulated
+woes and survive to add to the list of his dark crimes.  He is eloquent
+and persuasive, and once his words had even power over my heart; but
+trust him not.  His soul is as hellish as his form, full of treachery
+and fiend-like malice.  Hear him not; call on the names of William,
+Justine, Clerval, Elizabeth, my father, and of the wretched Victor, and
+thrust your sword into his heart.  I will hover near and direct the
+steel aright.
+
+
+               Walton, in continuation.
+
+
+
+                                                August 26th, 17--
+
+
+You have read this strange and terrific story, Margaret; and do you not
+feel your blood congeal with horror, like that which even now curdles
+mine?  Sometimes, seized with sudden agony, he could not continue his
+tale; at others, his voice broken, yet piercing, uttered with
+difficulty the words so replete with anguish.  His fine and lovely eyes
+were now lighted up with indignation, now subdued to downcast sorrow
+and quenched in infinite wretchedness.  Sometimes he commanded his
+countenance and tones and related the most horrible incidents with a
+tranquil voice, suppressing every mark of agitation; then, like a
+volcano bursting forth, his face would suddenly change to an expression
+of the wildest rage as he shrieked out imprecations on his persecutor.
+
+His tale is connected and told with an appearance of the simplest
+truth, yet I own to you that the letters of Felix and Safie, which he
+showed me, and the apparition of the monster seen from our ship,
+brought to me a greater conviction of the truth of his narrative than
+his asseverations, however earnest and connected.  Such a monster has,
+then, really existence!  I cannot doubt it, yet I am lost in surprise
+and admiration.  Sometimes I endeavoured to gain from Frankenstein the
+particulars of his creature's formation, but on this point he was
+impenetrable. "Are you mad, my friend?" said he.  "Or whither does your
+senseless curiosity lead you?  Would you also create for yourself and
+the world a demoniacal enemy?  Peace, peace!  Learn my miseries and do
+not seek to increase your own."  Frankenstein discovered that I made
+notes concerning his history; he asked to see them and then himself
+corrected and augmented them in many places, but principally in giving
+the life and spirit to the conversations he held with his enemy. "Since
+you have preserved my narration," said he, "I would not that a
+mutilated one should go down to posterity."
+
+Thus has a week passed away, while I have listened to the strangest
+tale that ever imagination formed.  My thoughts and every feeling of my
+soul have been drunk up by the interest for my guest which this tale
+and his own elevated and gentle manners have created.  I wish to soothe
+him, yet can I counsel one so infinitely miserable, so destitute of
+every hope of consolation, to live?  Oh, no!  The only joy that he can
+now know will be when he composes his shattered spirit to peace and
+death.  Yet he enjoys one comfort, the offspring of solitude and
+delirium; he believes that when in dreams he holds converse with his
+friends and derives from that communion consolation for his miseries or
+excitements to his vengeance, that they are not the creations of his
+fancy, but the beings themselves who visit him from the regions of a
+remote world.  This faith gives a solemnity to his reveries that render
+them to me almost as imposing and interesting as truth.
+
+Our conversations are not always confined to his own history and
+misfortunes.  On every point of general literature he displays
+unbounded knowledge and a quick and piercing apprehension.  His
+eloquence is forcible and touching; nor can I hear him, when he relates
+a pathetic incident or endeavours to move the passions of pity or love,
+without tears.  What a glorious creature must he have been in the days
+of his prosperity, when he is thus noble and godlike in ruin!  He seems
+to feel his own worth and the greatness of his fall.
+
+"When younger," said he, "I believed myself destined for some great
+enterprise.  My feelings are profound, but I possessed a  coolness of
+judgment that fitted me for illustrious achievements.  This sentiment
+of the worth of my nature supported me when others would have been
+oppressed, for I deemed it criminal to throw away in useless grief
+those talents that might be useful to my fellow creatures.  When I
+reflected on the work I had completed, no less a one than the creation
+of a sensitive and rational animal, I could not rank myself with the
+herd of common projectors.  But this thought, which supported me in the
+commencement of my career, now serves only to plunge me lower in the
+dust.  All my speculations and hopes are as nothing, and like the
+archangel who aspired to omnipotence, I am chained in an eternal hell.
+My imagination was vivid, yet my powers of analysis and application
+were intense; by the union of these qualities I conceived the idea and
+executed the creation of a man.  Even now I cannot recollect without
+passion my reveries while the work was incomplete.  I trod heaven in my
+thoughts, now exulting in my powers, now burning with the idea of their
+effects.  From my infancy I was imbued with high hopes and a lofty
+ambition; but how am I sunk!  Oh!  My friend, if you had known me as I
+once was, you would not recognize me in this state of degradation.
+Despondency rarely visited my heart; a high destiny seemed to bear me
+on, until I fell, never, never again to rise."  Must I then lose this
+admirable being?  I have longed for a friend; I have sought one who
+would sympathize with and love me.  Behold, on these desert seas I have
+found such a one, but I fear I have gained him only to know his value
+and lose him.  I would reconcile him to life, but he repulses the idea.
+
+"I thank you, Walton," he said, "for your kind intentions towards so
+miserable a wretch; but when you speak of new ties and fresh
+affections, think you that any can replace those who are gone?  Can any
+man be to me as Clerval was, or any woman another Elizabeth?  Even
+where the affections are not strongly moved by any superior excellence,
+the companions of our childhood always possess a certain power over our
+minds which hardly any later friend can obtain.  They know our
+infantine dispositions, which, however they may be afterwards modified,
+are never eradicated; and they can judge of our actions with more
+certain conclusions as to the integrity of our motives.  A sister or a
+brother can never, unless indeed such symptoms have been shown early,
+suspect the other of fraud or false dealing, when another friend,
+however strongly he may be attached, may, in spite of himself, be
+contemplated with suspicion.  But I enjoyed friends, dear not only
+through habit and association, but from their own merits; and wherever
+I am, the soothing voice of my Elizabeth and the conversation of
+Clerval will be ever whispered in my ear. They are dead, and but one
+feeling in such a solitude can persuade me to preserve my life.  If I
+were engaged in any high undertaking or design, fraught with extensive
+utility to my fellow creatures, then could I live to fulfil it.  But
+such is not my destiny; I must pursue and destroy the being to whom I
+gave existence; then my lot on earth will be fulfilled and I may die."
+
+
+
+
+September 2nd
+
+My beloved Sister,
+
+I write to you, encompassed by peril and ignorant whether I am ever
+doomed to see again dear England and the dearer friends that inhabit
+it.  I am surrounded by mountains of ice which admit of no escape and
+threaten every moment to crush my vessel.  The brave fellows whom I
+have persuaded to be my companions look towards me for aid, but I have
+none to bestow.  There is something terribly appalling in our
+situation, yet my courage and hopes do not desert me.  Yet it is
+terrible to reflect that the lives of all these men are endangered
+through me.  If we are lost, my mad schemes are the cause.
+
+And what, Margaret, will be the state of your mind?  You will not hear
+of my destruction, and you will anxiously await my return.  Years will
+pass, and you will have visitings of despair and yet be tortured by
+hope.  Oh!  My beloved sister, the sickening failing of your heart-felt
+expectations is, in prospect, more terrible to me than my own death.
+
+But you have a husband and lovely children; you may be happy.  Heaven
+bless you and make you so!
+
+My unfortunate guest regards me with the tenderest compassion.  He
+endeavours to fill me with hope and talks as if life were a possession
+which he valued.  He reminds me how often the same accidents have
+happened to other navigators who have attempted this sea, and in spite
+of myself, he fills me with cheerful auguries.  Even the sailors feel
+the power of his eloquence; when he speaks, they no longer despair; he
+rouses their energies, and while they hear his voice they believe these
+vast mountains of ice are mole-hills which will vanish before the
+resolutions of man.  These feelings are transitory; each day of
+expectation delayed fills them with fear, and I almost dread a mutiny
+caused by this despair.
+
+
+
+September 5th
+
+
+A scene has just passed of such uncommon interest that, although it is
+highly probable that these papers may never reach you, yet I cannot
+forbear recording it.
+
+We are still surrounded by mountains of ice, still in imminent danger
+of being crushed in their conflict.  The cold is excessive, and many of
+my unfortunate comrades have already found a grave amidst this scene of
+desolation.  Frankenstein has daily declined in health; a feverish fire
+still glimmers in his eyes, but he is exhausted, and when suddenly
+roused to any exertion, he speedily sinks again into apparent
+lifelessness.
+
+I mentioned in my last letter the fears I entertained of a mutiny.
+This morning, as I sat watching the wan countenance of my friend--his
+eyes half closed and his limbs hanging listlessly--I was roused by half
+a dozen of the sailors, who demanded admission into the cabin.  They
+entered, and their leader addressed me.  He told me that he and his
+companions had been chosen by the other sailors to come in deputation
+to me to make me a requisition which, in justice, I could not refuse.
+We were immured in ice and should probably never escape, but they
+feared that if, as was possible, the ice should dissipate and a free
+passage be opened, I should be rash enough to continue my voyage and
+lead them into fresh dangers, after they might happily have surmounted
+this.  They insisted, therefore, that I should engage with a solemn
+promise that if the vessel should be freed I would instantly direct my
+course southwards.
+
+This speech troubled me.  I had not despaired, nor had I yet conceived
+the idea of returning if set free.  Yet could I, in justice, or even in
+possibility, refuse this demand?  I hesitated before I answered, when
+Frankenstein, who had at first been silent, and indeed appeared hardly
+to have force enough to attend, now roused himself; his eyes sparkled,
+and his cheeks flushed with momentary vigour.  Turning towards the men,
+he said, "What do you mean?  What do you demand of your captain?  Are
+you, then, so easily turned from your design?  Did you not call this a
+glorious expedition?
+
+"And wherefore was it glorious?  Not because the way was smooth and
+placid as a southern sea, but because it was full of dangers and
+terror, because at every new incident your fortitude was to be called
+forth and your courage exhibited, because danger and death surrounded
+it, and these you were to brave and overcome.  For this was it a
+glorious, for this was it an honourable undertaking.  You were
+hereafter to be hailed as the benefactors of your species, your names
+adored as belonging to brave men who encountered death for honour and
+the benefit of mankind. And now, behold, with the first imagination of
+danger, or, if you will, the first mighty and terrific trial of your
+courage, you shrink away and are content to be handed down as men who
+had not strength enough to endure cold and peril; and so, poor souls,
+they were chilly and returned to their warm firesides.  Why, that
+requires not this preparation; ye need not have come thus far and
+dragged your captain to the shame of a defeat merely to prove
+yourselves cowards.  Oh!  Be men, or be more than men.  Be steady to
+your purposes and firm as a rock. This ice is not made of such stuff as
+your hearts may be; it is mutable and cannot withstand you if you say
+that it shall not.  Do not return to your families with the stigma of
+disgrace marked on your brows.  Return as heroes who have fought and
+conquered and who know not what it is to turn their backs on the foe."
+He spoke this with a voice so modulated to the different feelings
+expressed in his speech, with an eye so full of lofty design and
+heroism, that can you wonder that these men were moved?  They looked at
+one another and were unable to reply.  I spoke; I told them to retire
+and consider of what had been said, that I would not lead them farther
+north if they strenuously desired the contrary, but that I hoped that,
+with reflection, their courage would return.  They retired and I turned
+towards my friend, but he was sunk in languor and almost deprived of
+life.
+
+How all this will terminate, I know not, but I had rather die than
+return shamefully, my purpose unfulfilled.  Yet I fear such will be my
+fate; the men, unsupported by ideas of glory and honour, can never
+willingly continue to endure their present hardships.
+
+
+
+September 7th
+
+
+The die is cast; I have consented to return if we are not destroyed.
+Thus are my hopes blasted by cowardice and indecision; I come back
+ignorant and disappointed.  It requires more philosophy than I possess
+to bear this injustice with patience.
+
+
+
+September 12th
+
+
+It is past; I am returning to England.  I have lost my hopes of utility
+and glory; I have lost my friend.  But I will endeavour to detail these
+bitter circumstances to you, my dear sister; and while I am wafted
+towards England and towards you, I will not despond.
+
+September 9th, the ice began to move, and roarings like thunder were
+heard at a distance as the islands split and cracked in every
+direction.  We were in the most imminent peril, but as we could only
+remain passive, my chief attention was occupied by my unfortunate guest
+whose illness increased in such a degree that he was entirely confined
+to his bed.  The ice cracked behind us and was driven with force
+towards the north; a breeze sprang from the west, and on the 11th the
+passage towards the south became perfectly free.  When the sailors saw
+this and that their return to their native country was apparently
+assured, a shout of tumultuous joy broke from them, loud and
+long-continued.  Frankenstein, who was dozing, awoke and asked the
+cause of the tumult.  "They shout," I said, "because they will soon
+return to England."
+
+"Do you, then, really return?"
+
+"Alas!  Yes; I cannot withstand their demands.  I cannot lead them
+unwillingly to danger, and I must return."
+
+"Do so, if you will; but I will not.  You may give up your purpose, but
+mine is assigned to me by heaven, and I dare not.  I am weak, but
+surely the spirits who assist my vengeance will endow me with
+sufficient strength."  Saying this, he endeavoured to spring from the
+bed, but the exertion was too great for him; he fell back and fainted.
+
+It was long before he was restored, and I often thought that life was
+entirely extinct.  At length he opened his eyes; he breathed with
+difficulty and was unable to speak.  The surgeon gave him a composing
+draught and ordered us to leave him undisturbed. In the meantime he
+told me that my friend had certainly not many hours to live.
+
+His sentence was pronounced, and I could only grieve and be patient.  I
+sat by his bed, watching him; his eyes were closed, and I thought he
+slept; but presently he called to me in a feeble voice, and bidding me
+come near, said, "Alas!  The strength I relied on is gone; I feel that
+I shall soon die, and he, my enemy and persecutor, may still be in
+being.  Think not, Walton, that in the last moments of my existence I
+feel that burning hatred and ardent desire of revenge I once expressed;
+but I feel myself justified in desiring the death of my adversary.
+During these last days I have been occupied in examining my past
+conduct; nor do I find it blamable.  In a fit of enthusiastic madness I
+created a rational creature and was bound towards him to assure, as far
+as was in my power, his happiness and well-being.
+
+"This was my duty, but there was another still paramount to that.  My
+duties towards the beings of my own species had greater claims to my
+attention because they included a greater proportion of happiness or
+misery.  Urged by this view, I refused, and I did right in refusing, to
+create a companion for the first creature.  He showed unparalleled
+malignity and selfishness in evil; he destroyed my friends; he devoted
+to destruction beings who possessed exquisite sensations, happiness,
+and wisdom; nor do I know where this thirst for vengeance may end.
+Miserable himself that he may render no other wretched, he ought to
+die.  The task of his destruction was mine, but I have failed.  When
+actuated by selfish and vicious motives, I asked you to undertake my
+unfinished work, and I renew this request now, when I am only induced
+by reason and virtue.
+
+"Yet I cannot ask you to renounce your country and friends to fulfil
+this task; and now that you are returning to England, you will have
+little chance of meeting with him.  But the consideration of these
+points, and the well balancing of what you may esteem your duties, I
+leave to you; my judgment and ideas are already disturbed by the near
+approach of death.  I dare not ask you to do what I think right, for I
+may still be misled by passion.
+
+"That he should live to be an instrument of mischief disturbs me; in
+other respects, this hour, when I momentarily expect my release, is the
+only happy one which I have enjoyed for several years.  The forms of
+the beloved dead flit before me, and I hasten to their arms.  Farewell,
+Walton!  Seek happiness in tranquillity and avoid ambition, even if it
+be only the apparently innocent one of distinguishing yourself in
+science and discoveries.  Yet why do I say this?  I have myself been
+blasted in these hopes, yet another may succeed."
+
+His voice became fainter as he spoke, and at length, exhausted by his
+effort, he sank into silence.  About half an hour afterwards he
+attempted again to speak but was unable; he pressed my hand feebly, and
+his eyes closed forever, while the irradiation of a gentle smile passed
+away from his lips.
+
+Margaret, what comment can I make on the untimely extinction of this
+glorious spirit?  What can I say that will enable you to understand the
+depth of my sorrow?  All that I should express would be inadequate and
+feeble.  My tears flow; my mind is overshadowed by a cloud of
+disappointment.  But I journey towards England, and I may there find
+consolation.
+
+I am interrupted.  What do these sounds portend?  It is midnight; the
+breeze blows fairly, and the watch on deck scarcely stir.  Again there
+is a sound as of a human voice, but hoarser; it comes from the cabin
+where the remains of Frankenstein still lie.  I must arise and examine.
+Good night, my sister.
+
+Great God! what a scene has just taken place!  I am yet dizzy with the
+remembrance of it.  I hardly know whether I shall have the power to
+detail it; yet the tale which I have recorded would be incomplete
+without this final and wonderful catastrophe. I entered the cabin where
+lay the remains of my ill-fated and admirable friend.  Over him hung a
+form which I cannot find words to describe--gigantic in stature, yet
+uncouth and distorted in its proportions.  As he hung over the coffin,
+his face was concealed by long locks of ragged hair; but one vast hand
+was extended, in colour and apparent texture like that of a mummy. When
+he heard the sound of my approach, he ceased to utter exclamations of
+grief and horror and sprung towards the window.  Never did I behold a
+vision so horrible as his face, of such loathsome yet appalling
+hideousness.  I shut my eyes involuntarily and endeavoured to recollect
+what were my duties with regard to this destroyer.  I called on him to
+stay.
+
+He paused, looking on me with wonder, and again turning towards the
+lifeless form of his creator, he seemed to forget my presence, and
+every feature and gesture seemed instigated by the wildest rage of some
+uncontrollable passion.
+
+"That is also my victim!" he exclaimed.  "In his murder my crimes are
+consummated; the miserable series of my being is wound to its close!
+Oh, Frankenstein!  Generous and self-devoted being!  What does it avail
+that I now ask thee to pardon me?  I, who irretrievably destroyed thee
+by destroying all thou lovedst.  Alas!  He is cold, he cannot answer
+me." His voice seemed suffocated, and my first impulses, which had
+suggested to me the duty of obeying the dying request of my friend in
+destroying his enemy, were now suspended by a mixture of curiosity and
+compassion.  I approached this tremendous being; I dared not again
+raise my eyes to his face, there was something so scaring and unearthly
+in his ugliness.  I attempted to speak, but the words died away on my
+lips.  The monster continued to utter wild and incoherent
+self-reproaches.  At length I gathered resolution to address him in a
+pause of the tempest of his passion.
+
+"Your repentance," I said, "is now superfluous. If you had listened to
+the voice of conscience and heeded the stings of remorse before you had
+urged your diabolical vengeance to this extremity, Frankenstein would
+yet have lived."
+
+"And do you dream?" said the daemon.  "Do you think that I was then
+dead to agony and remorse?  He," he continued, pointing to the corpse,
+"he suffered not in the consummation of the deed. Oh!  Not the
+ten-thousandth portion of the anguish that was mine during the
+lingering detail of its execution.  A frightful selfishness hurried me
+on, while my heart was poisoned with remorse.  Think you that the
+groans of Clerval were music to my ears?  My heart was fashioned to be
+susceptible of love and sympathy, and when wrenched by misery to vice
+and hatred, it did not endure the violence of the change without
+torture such as you cannot even imagine.
+
+"After the murder of Clerval I returned to Switzerland, heart-broken
+and overcome.  I pitied Frankenstein; my pity amounted to horror; I
+abhorred myself.  But when I discovered that he, the author at once of
+my existence and of its unspeakable torments, dared to hope for
+happiness, that while he accumulated wretchedness and despair upon me
+he sought his own enjoyment in feelings and passions from the
+indulgence of which I was forever barred, then impotent envy and bitter
+indignation filled me with an insatiable thirst for vengeance.  I
+recollected my threat and resolved that it should be accomplished.  I
+knew that I was preparing for myself a deadly torture, but I was the
+slave, not the master, of an impulse which I detested yet could not
+disobey.  Yet when she died!  Nay, then I was not miserable.  I had
+cast off all feeling, subdued all anguish, to riot in the excess of my
+despair.  Evil thenceforth became my good.  Urged thus far, I had no
+choice but to adapt my nature to an element which I had willingly
+chosen.  The completion of my demoniacal design became an insatiable
+passion.  And now it is ended; there is my last victim!"
+
+I was at first touched by the expressions of his misery; yet, when I
+called to mind what Frankenstein had said of his powers of eloquence
+and persuasion, and when I again cast my eyes on the lifeless form of
+my friend, indignation was rekindled within me.  "Wretch!" I said.  "It
+is well that you come here to whine over the desolation that you have
+made.  You throw a torch into a pile of buildings, and when they are
+consumed, you sit among the ruins and lament the fall.  Hypocritical
+fiend!  If he whom you mourn still lived, still would he be the object,
+again would he become the prey, of your accursed vengeance.  It is not
+pity that you feel; you lament only because the victim of your
+malignity is withdrawn from your power."
+
+"Oh, it is not thus--not thus," interrupted the being.  "Yet such must
+be the impression conveyed to you by what appears to be the purport of
+my actions.  Yet I seek not a fellow feeling in my misery.  No sympathy
+may I ever find.  When I first sought it, it was the love of virtue,
+the feelings of happiness and affection with which my whole being
+overflowed, that I wished to be participated.  But now that virtue has
+become to me a shadow, and that happiness and affection are turned into
+bitter and loathing despair, in what should I seek for sympathy?  I am
+content to suffer alone while my sufferings shall endure; when I die, I
+am well satisfied that abhorrence and opprobrium should load my memory.
+Once my fancy was soothed with dreams of virtue, of fame, and of
+enjoyment.  Once I falsely hoped to meet with beings who, pardoning my
+outward form, would love me for the excellent qualities which I was
+capable of unfolding.  I was nourished with high thoughts of honour and
+devotion.  But now crime has degraded me beneath the meanest animal. No
+guilt, no mischief, no malignity, no misery, can be found comparable to
+mine.  When I run over the frightful catalogue of my sins, I cannot
+believe that I am the same creature whose thoughts were once filled
+with sublime and transcendent visions of the beauty and the majesty of
+goodness.  But it is even so; the fallen angel becomes a malignant
+devil.  Yet even that enemy of God and man had friends and associates
+in his desolation; I am alone.
+
+"You, who call Frankenstein your friend, seem to have a knowledge of my
+crimes and his misfortunes. But in the detail which he gave you of them
+he could not sum up the hours and months of misery which I endured
+wasting in impotent passions. For while I destroyed his hopes, I did
+not satisfy my own desires. They were forever ardent and craving; still
+I desired love and fellowship, and I was still spurned.  Was there no
+injustice in this? Am I to be thought the only criminal, when all
+humankind sinned against me? Why do you not hate Felix, who drove his
+friend from his door with contumely? Why do you not execrate the rustic
+who sought to destroy the saviour of his child? Nay, these are virtuous
+and immaculate beings! I, the miserable and the abandoned, am an
+abortion, to be spurned at, and kicked, and trampled on. Even now my
+blood boils at the recollection of this injustice.
+
+"But it is true that I am a wretch.  I have murdered the lovely and the
+helpless; I have strangled the innocent as they slept and grasped to
+death his throat who never injured me or any other living thing.  I
+have devoted my creator, the select specimen of all that is worthy of
+love and admiration among men, to misery; I have pursued him even to
+that irremediable ruin.
+
+"There he lies, white and cold in death.  You hate me, but your
+abhorrence cannot equal that with which I regard myself.  I look on the
+hands which executed the deed; I think on the heart in which the
+imagination of it was conceived and long for the moment when these
+hands will meet my eyes, when that imagination will haunt my thoughts
+no more.
+
+"Fear not that I shall be the instrument of future mischief.  My work
+is nearly complete.  Neither yours nor any man's death is needed to
+consummate the series of my being and accomplish that which must be
+done, but it requires my own.  Do not think that I shall be slow to
+perform this sacrifice.  I shall quit your vessel on the ice raft which
+brought me thither and shall seek the most northern extremity of the
+globe; I shall collect my funeral pile and consume to ashes this
+miserable frame, that its remains may afford no light to any curious
+and unhallowed wretch who would create such another as I have been.  I
+shall die.  I shall no longer feel the agonies which now consume me or
+be the prey of feelings unsatisfied, yet unquenched.  He is dead who
+called me into being; and when I shall be no more, the very remembrance
+of us both will speedily vanish.  I shall no longer see the sun or
+stars or feel the winds play on my cheeks.
+
+"Light, feeling, and sense will pass away; and in this condition must I
+find my happiness.  Some years ago, when the images which this world
+affords first opened upon me, when I felt the cheering warmth of summer
+and heard the rustling of the leaves and the warbling of the birds, and
+these were all to me, I should have wept to die; now it is my only
+consolation.  Polluted by crimes and torn by the bitterest remorse,
+where can I find rest but in death?
+
+"Farewell!  I leave you, and in you the last of humankind whom these
+eyes will ever behold. Farewell, Frankenstein! If thou wert yet alive
+and yet cherished a desire of revenge against me, it would be better
+satiated in my life than in my destruction. But it was not so; thou
+didst seek my extinction, that I might not cause greater wretchedness;
+and if yet, in some mode unknown to me, thou hadst not ceased to think
+and feel, thou wouldst not desire against me a vengeance greater than
+that which I feel. Blasted as thou wert, my agony was still superior to
+thine, for the bitter sting of remorse will not cease to rankle in my
+wounds until death shall close them forever.
+
+"But soon," he cried with sad and solemn enthusiasm, "I shall die, and
+what I now feel be no longer felt.  Soon these burning miseries will be
+extinct.  I shall ascend my funeral pile triumphantly and exult in the
+agony of the torturing flames. The light of that conflagration will
+fade away; my ashes will be swept into the sea by the winds.  My spirit
+will sleep in peace, or if it thinks, it will not surely think thus.
+Farewell."
+
+He sprang from the cabin window as he said this, upon the ice raft
+which lay close to the vessel.  He was soon borne away by the waves and
+lost in darkness and distance.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of Frankenstein, by
+Mary Wollstonecraft (Godwin) Shelley
+
+*** END OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+***** This file should be named 84.txt or 84.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/8/84/
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/grimm-brothers.txt
+++ b/jet/source-sink-builder/src/main/resources/books/grimm-brothers.txt
@@ -1,0 +1,9571 @@
+﻿The Project Gutenberg EBook of Grimms’ Fairy Tales, by The Brothers Grimm
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Grimms’ Fairy Tales
+
+Author: The Brothers Grimm
+
+Translator: Edgar Taylor and Marian Edwardes
+
+Posting Date: December 14, 2008 [EBook #2591]
+Release Date: April, 2001
+Last Updated: November 7, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+
+
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+
+
+
+
+FAIRY TALES
+
+By The Brothers Grimm
+
+
+
+PREPARER’S NOTE
+
+     The text is based on translations from
+     the Grimms’ Kinder und Hausmarchen by
+     Edgar Taylor and Marian Edwardes.
+
+
+
+
+CONTENTS:
+
+     THE GOLDEN BIRD
+     HANS IN LUCK
+     JORINDA AND JORINDEL
+     THE TRAVELLING MUSICIANS
+     OLD SULTAN
+     THE STRAW, THE COAL, AND THE BEAN
+     BRIAR ROSE
+     THE DOG AND THE SPARROW
+     THE TWELVE DANCING PRINCESSES
+     THE FISHERMAN AND HIS WIFE
+     THE WILLOW-WREN AND THE BEAR
+     THE FROG-PRINCE
+     CAT AND MOUSE IN PARTNERSHIP
+     THE GOOSE-GIRL
+     THE ADVENTURES OF CHANTICLEER AND PARTLET
+       1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+       2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+     RAPUNZEL
+     FUNDEVOGEL
+     THE VALIANT LITTLE TAILOR
+     HANSEL AND GRETEL
+     THE MOUSE, THE BIRD, AND THE SAUSAGE
+     MOTHER HOLLE
+     LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+     THE ROBBER BRIDEGROOM
+     TOM THUMB
+     RUMPELSTILTSKIN
+     CLEVER GRETEL
+     THE OLD MAN AND HIS GRANDSON
+     THE LITTLE PEASANT
+     FREDERICK AND CATHERINE
+     SWEETHEART ROLAND
+     SNOWDROP
+     THE PINK
+     CLEVER ELSIE
+     THE MISER IN THE BUSH
+     ASHPUTTEL
+     THE WHITE SNAKE
+     THE WOLF AND THE SEVEN LITTLE KIDS
+     THE QUEEN BEE
+     THE ELVES AND THE SHOEMAKER
+     THE JUNIPER-TREE
+     the juniper-tree.
+     THE TURNIP
+     CLEVER HANS
+     THE THREE LANGUAGES
+     THE FOX AND THE CAT
+     THE FOUR CLEVER BROTHERS
+     LILY AND THE LION
+     THE FOX AND THE HORSE
+     THE BLUE LIGHT
+     THE RAVEN
+     THE GOLDEN GOOSE
+     THE WATER OF LIFE
+     THE TWELVE HUNTSMEN
+     THE KING OF THE GOLDEN MOUNTAIN
+     DOCTOR KNOWALL
+     THE SEVEN RAVENS
+     THE WEDDING OF MRS FOX
+     FIRST STORY
+     SECOND STORY
+     THE SALAD
+     THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+     KING GRISLY-BEARD
+     IRON HANS
+     CAT-SKIN
+     SNOW-WHITE AND ROSE-RED
+
+
+
+
+THE BROTHERS GRIMM FAIRY TALES
+
+
+
+
+THE GOLDEN BIRD
+
+A certain king had a beautiful garden, and in the garden stood a tree
+which bore golden apples. These apples were always counted, and about
+the time when they began to grow ripe it was found that every night one
+of them was gone. The king became very angry at this, and ordered the
+gardener to keep watch all night under the tree. The gardener set his
+eldest son to watch; but about twelve o’clock he fell asleep, and in
+the morning another of the apples was missing. Then the second son was
+ordered to watch; and at midnight he too fell asleep, and in the morning
+another apple was gone. Then the third son offered to keep watch; but
+the gardener at first would not let him, for fear some harm should come
+to him: however, at last he consented, and the young man laid himself
+under the tree to watch. As the clock struck twelve he heard a rustling
+noise in the air, and a bird came flying that was of pure gold; and as
+it was snapping at one of the apples with its beak, the gardener’s son
+jumped up and shot an arrow at it. But the arrow did the bird no harm;
+only it dropped a golden feather from its tail, and then flew away.
+The golden feather was brought to the king in the morning, and all the
+council was called together. Everyone agreed that it was worth more than
+all the wealth of the kingdom: but the king said, ‘One feather is of no
+use to me, I must have the whole bird.’
+
+Then the gardener’s eldest son set out and thought to find the golden
+bird very easily; and when he had gone but a little way, he came to a
+wood, and by the side of the wood he saw a fox sitting; so he took his
+bow and made ready to shoot at it. Then the fox said, ‘Do not shoot me,
+for I will give you good counsel; I know what your business is, and
+that you want to find the golden bird. You will reach a village in the
+evening; and when you get there, you will see two inns opposite to each
+other, one of which is very pleasant and beautiful to look at: go not in
+there, but rest for the night in the other, though it may appear to you
+to be very poor and mean.’ But the son thought to himself, ‘What can
+such a beast as this know about the matter?’ So he shot his arrow at
+the fox; but he missed it, and it set up its tail above its back and
+ran into the wood. Then he went his way, and in the evening came to
+the village where the two inns were; and in one of these were people
+singing, and dancing, and feasting; but the other looked very dirty,
+and poor. ‘I should be very silly,’ said he, ‘if I went to that shabby
+house, and left this charming place’; so he went into the smart house,
+and ate and drank at his ease, and forgot the bird, and his country too.
+
+Time passed on; and as the eldest son did not come back, and no tidings
+were heard of him, the second son set out, and the same thing happened
+to him. He met the fox, who gave him the good advice: but when he came
+to the two inns, his eldest brother was standing at the window where
+the merrymaking was, and called to him to come in; and he could not
+withstand the temptation, but went in, and forgot the golden bird and
+his country in the same manner.
+
+Time passed on again, and the youngest son too wished to set out into
+the wide world to seek for the golden bird; but his father would not
+listen to it for a long while, for he was very fond of his son, and
+was afraid that some ill luck might happen to him also, and prevent his
+coming back. However, at last it was agreed he should go, for he would
+not rest at home; and as he came to the wood, he met the fox, and heard
+the same good counsel. But he was thankful to the fox, and did not
+attempt his life as his brothers had done; so the fox said, ‘Sit upon my
+tail, and you will travel faster.’ So he sat down, and the fox began to
+run, and away they went over stock and stone so quick that their hair
+whistled in the wind.
+
+When they came to the village, the son followed the fox’s counsel, and
+without looking about him went to the shabby inn and rested there all
+night at his ease. In the morning came the fox again and met him as he
+was beginning his journey, and said, ‘Go straight forward, till you come
+to a castle, before which lie a whole troop of soldiers fast asleep and
+snoring: take no notice of them, but go into the castle and pass on and
+on till you come to a room, where the golden bird sits in a wooden cage;
+close by it stands a beautiful golden cage; but do not try to take the
+bird out of the shabby cage and put it into the handsome one, otherwise
+you will repent it.’ Then the fox stretched out his tail again, and the
+young man sat himself down, and away they went over stock and stone till
+their hair whistled in the wind.
+
+Before the castle gate all was as the fox had said: so the son went in
+and found the chamber where the golden bird hung in a wooden cage, and
+below stood the golden cage, and the three golden apples that had been
+lost were lying close by it. Then thought he to himself, ‘It will be a
+very droll thing to bring away such a fine bird in this shabby cage’; so
+he opened the door and took hold of it and put it into the golden cage.
+But the bird set up such a loud scream that all the soldiers awoke, and
+they took him prisoner and carried him before the king. The next morning
+the court sat to judge him; and when all was heard, it sentenced him to
+die, unless he should bring the king the golden horse which could run as
+swiftly as the wind; and if he did this, he was to have the golden bird
+given him for his own.
+
+So he set out once more on his journey, sighing, and in great despair,
+when on a sudden his friend the fox met him, and said, ‘You see now
+what has happened on account of your not listening to my counsel. I will
+still, however, tell you how to find the golden horse, if you will do as
+I bid you. You must go straight on till you come to the castle where the
+horse stands in his stall: by his side will lie the groom fast asleep
+and snoring: take away the horse quietly, but be sure to put the old
+leathern saddle upon him, and not the golden one that is close by it.’
+Then the son sat down on the fox’s tail, and away they went over stock
+and stone till their hair whistled in the wind.
+
+All went right, and the groom lay snoring with his hand upon the golden
+saddle. But when the son looked at the horse, he thought it a great pity
+to put the leathern saddle upon it. ‘I will give him the good one,’
+said he; ‘I am sure he deserves it.’ As he took up the golden saddle the
+groom awoke and cried out so loud, that all the guards ran in and took
+him prisoner, and in the morning he was again brought before the court
+to be judged, and was sentenced to die. But it was agreed, that, if he
+could bring thither the beautiful princess, he should live, and have the
+bird and the horse given him for his own.
+
+Then he went his way very sorrowful; but the old fox came and said, ‘Why
+did not you listen to me? If you had, you would have carried away
+both the bird and the horse; yet will I once more give you counsel. Go
+straight on, and in the evening you will arrive at a castle. At twelve
+o’clock at night the princess goes to the bathing-house: go up to her
+and give her a kiss, and she will let you lead her away; but take care
+you do not suffer her to go and take leave of her father and mother.’
+Then the fox stretched out his tail, and so away they went over stock
+and stone till their hair whistled again.
+
+As they came to the castle, all was as the fox had said, and at twelve
+o’clock the young man met the princess going to the bath and gave her the
+kiss, and she agreed to run away with him, but begged with many tears
+that he would let her take leave of her father. At first he refused,
+but she wept still more and more, and fell at his feet, till at last
+he consented; but the moment she came to her father’s house the guards
+awoke and he was taken prisoner again.
+
+Then he was brought before the king, and the king said, ‘You shall never
+have my daughter unless in eight days you dig away the hill that stops
+the view from my window.’ Now this hill was so big that the whole world
+could not take it away: and when he had worked for seven days, and had
+done very little, the fox came and said. ‘Lie down and go to sleep; I
+will work for you.’ And in the morning he awoke and the hill was gone;
+so he went merrily to the king, and told him that now that it was
+removed he must give him the princess.
+
+Then the king was obliged to keep his word, and away went the young man
+and the princess; and the fox came and said to him, ‘We will have all
+three, the princess, the horse, and the bird.’ ‘Ah!’ said the young man,
+‘that would be a great thing, but how can you contrive it?’
+
+‘If you will only listen,’ said the fox, ‘it can be done. When you come
+to the king, and he asks for the beautiful princess, you must say, “Here
+she is!” Then he will be very joyful; and you will mount the golden
+horse that they are to give you, and put out your hand to take leave of
+them; but shake hands with the princess last. Then lift her quickly on
+to the horse behind you; clap your spurs to his side, and gallop away as
+fast as you can.’
+
+All went right: then the fox said, ‘When you come to the castle where
+the bird is, I will stay with the princess at the door, and you will
+ride in and speak to the king; and when he sees that it is the right
+horse, he will bring out the bird; but you must sit still, and say that
+you want to look at it, to see whether it is the true golden bird; and
+when you get it into your hand, ride away.’
+
+This, too, happened as the fox said; they carried off the bird, the
+princess mounted again, and they rode on to a great wood. Then the fox
+came, and said, ‘Pray kill me, and cut off my head and my feet.’ But the
+young man refused to do it: so the fox said, ‘I will at any rate give
+you good counsel: beware of two things; ransom no one from the gallows,
+and sit down by the side of no river.’ Then away he went. ‘Well,’
+thought the young man, ‘it is no hard matter to keep that advice.’
+
+He rode on with the princess, till at last he came to the village where
+he had left his two brothers. And there he heard a great noise and
+uproar; and when he asked what was the matter, the people said, ‘Two men
+are going to be hanged.’ As he came nearer, he saw that the two men were
+his brothers, who had turned robbers; so he said, ‘Cannot they in any
+way be saved?’ But the people said ‘No,’ unless he would bestow all his
+money upon the rascals and buy their liberty. Then he did not stay to
+think about the matter, but paid what was asked, and his brothers were
+given up, and went on with him towards their home.
+
+And as they came to the wood where the fox first met them, it was so
+cool and pleasant that the two brothers said, ‘Let us sit down by the
+side of the river, and rest a while, to eat and drink.’ So he said,
+‘Yes,’ and forgot the fox’s counsel, and sat down on the side of the
+river; and while he suspected nothing, they came behind, and threw him
+down the bank, and took the princess, the horse, and the bird, and went
+home to the king their master, and said. ‘All this have we won by our
+labour.’ Then there was great rejoicing made; but the horse would not
+eat, the bird would not sing, and the princess wept.
+
+The youngest son fell to the bottom of the river’s bed: luckily it was
+nearly dry, but his bones were almost broken, and the bank was so steep
+that he could find no way to get out. Then the old fox came once more,
+and scolded him for not following his advice; otherwise no evil would
+have befallen him: ‘Yet,’ said he, ‘I cannot leave you here, so lay hold
+of my tail and hold fast.’ Then he pulled him out of the river, and said
+to him, as he got upon the bank, ‘Your brothers have set watch to kill
+you, if they find you in the kingdom.’ So he dressed himself as a poor
+man, and came secretly to the king’s court, and was scarcely within the
+doors when the horse began to eat, and the bird to sing, and the princess
+left off weeping. Then he went to the king, and told him all his
+brothers’ roguery; and they were seized and punished, and he had the
+princess given to him again; and after the king’s death he was heir to
+his kingdom.
+
+A long while after, he went to walk one day in the wood, and the old fox
+met him, and besought him with tears in his eyes to kill him, and cut
+off his head and feet. And at last he did so, and in a moment the
+fox was changed into a man, and turned out to be the brother of the
+princess, who had been lost a great many many years.
+
+
+
+
+HANS IN LUCK
+
+Some men are born to good luck: all they do or try to do comes
+right--all that falls to them is so much gain--all their geese are
+swans--all their cards are trumps--toss them which way you will, they
+will always, like poor puss, alight upon their legs, and only move on so
+much the faster. The world may very likely not always think of them as
+they think of themselves, but what care they for the world? what can it
+know about the matter?
+
+One of these lucky beings was neighbour Hans. Seven long years he had
+worked hard for his master. At last he said, ‘Master, my time is up; I
+must go home and see my poor mother once more: so pray pay me my wages
+and let me go.’ And the master said, ‘You have been a faithful and good
+servant, Hans, so your pay shall be handsome.’ Then he gave him a lump
+of silver as big as his head.
+
+Hans took out his pocket-handkerchief, put the piece of silver into it,
+threw it over his shoulder, and jogged off on his road homewards. As he
+went lazily on, dragging one foot after another, a man came in sight,
+trotting gaily along on a capital horse. ‘Ah!’ said Hans aloud, ‘what a
+fine thing it is to ride on horseback! There he sits as easy and happy
+as if he was at home, in the chair by his fireside; he trips against no
+stones, saves shoe-leather, and gets on he hardly knows how.’ Hans did
+not speak so softly but the horseman heard it all, and said, ‘Well,
+friend, why do you go on foot then?’ ‘Ah!’ said he, ‘I have this load to
+carry: to be sure it is silver, but it is so heavy that I can’t hold up
+my head, and you must know it hurts my shoulder sadly.’ ‘What do you say
+of making an exchange?’ said the horseman. ‘I will give you my horse,
+and you shall give me the silver; which will save you a great deal of
+trouble in carrying such a heavy load about with you.’ ‘With all my
+heart,’ said Hans: ‘but as you are so kind to me, I must tell you one
+thing--you will have a weary task to draw that silver about with you.’
+However, the horseman got off, took the silver, helped Hans up, gave him
+the bridle into one hand and the whip into the other, and said, ‘When
+you want to go very fast, smack your lips loudly together, and cry
+“Jip!”’
+
+Hans was delighted as he sat on the horse, drew himself up, squared his
+elbows, turned out his toes, cracked his whip, and rode merrily off, one
+minute whistling a merry tune, and another singing,
+
+ ‘No care and no sorrow,
+  A fig for the morrow!
+  We’ll laugh and be merry,
+  Sing neigh down derry!’
+
+After a time he thought he should like to go a little faster, so he
+smacked his lips and cried ‘Jip!’ Away went the horse full gallop; and
+before Hans knew what he was about, he was thrown off, and lay on his
+back by the road-side. His horse would have ran off, if a shepherd who
+was coming by, driving a cow, had not stopped it. Hans soon came to
+himself, and got upon his legs again, sadly vexed, and said to the
+shepherd, ‘This riding is no joke, when a man has the luck to get upon
+a beast like this that stumbles and flings him off as if it would break
+his neck. However, I’m off now once for all: I like your cow now a great
+deal better than this smart beast that played me this trick, and has
+spoiled my best coat, you see, in this puddle; which, by the by, smells
+not very like a nosegay. One can walk along at one’s leisure behind that
+cow--keep good company, and have milk, butter, and cheese, every day,
+into the bargain. What would I give to have such a prize!’ ‘Well,’ said
+the shepherd, ‘if you are so fond of her, I will change my cow for your
+horse; I like to do good to my neighbours, even though I lose by it
+myself.’ ‘Done!’ said Hans, merrily. ‘What a noble heart that good man
+has!’ thought he. Then the shepherd jumped upon the horse, wished Hans
+and the cow good morning, and away he rode.
+
+Hans brushed his coat, wiped his face and hands, rested a while, and
+then drove off his cow quietly, and thought his bargain a very lucky
+one. ‘If I have only a piece of bread (and I certainly shall always be
+able to get that), I can, whenever I like, eat my butter and cheese with
+it; and when I am thirsty I can milk my cow and drink the milk: and what
+can I wish for more?’ When he came to an inn, he halted, ate up all his
+bread, and gave away his last penny for a glass of beer. When he had
+rested himself he set off again, driving his cow towards his mother’s
+village. But the heat grew greater as soon as noon came on, till at
+last, as he found himself on a wide heath that would take him more than
+an hour to cross, he began to be so hot and parched that his tongue
+clave to the roof of his mouth. ‘I can find a cure for this,’ thought
+he; ‘now I will milk my cow and quench my thirst’: so he tied her to the
+stump of a tree, and held his leathern cap to milk into; but not a drop
+was to be had. Who would have thought that this cow, which was to bring
+him milk and butter and cheese, was all that time utterly dry? Hans had
+not thought of looking to that.
+
+While he was trying his luck in milking, and managing the matter very
+clumsily, the uneasy beast began to think him very troublesome; and at
+last gave him such a kick on the head as knocked him down; and there he
+lay a long while senseless. Luckily a butcher soon came by, driving a
+pig in a wheelbarrow. ‘What is the matter with you, my man?’ said the
+butcher, as he helped him up. Hans told him what had happened, how he
+was dry, and wanted to milk his cow, but found the cow was dry too. Then
+the butcher gave him a flask of ale, saying, ‘There, drink and refresh
+yourself; your cow will give you no milk: don’t you see she is an old
+beast, good for nothing but the slaughter-house?’ ‘Alas, alas!’ said
+Hans, ‘who would have thought it? What a shame to take my horse, and
+give me only a dry cow! If I kill her, what will she be good for? I hate
+cow-beef; it is not tender enough for me. If it were a pig now--like
+that fat gentleman you are driving along at his ease--one could do
+something with it; it would at any rate make sausages.’ ‘Well,’ said
+the butcher, ‘I don’t like to say no, when one is asked to do a kind,
+neighbourly thing. To please you I will change, and give you my fine fat
+pig for the cow.’ ‘Heaven reward you for your kindness and self-denial!’
+said Hans, as he gave the butcher the cow; and taking the pig off the
+wheel-barrow, drove it away, holding it by the string that was tied to
+its leg.
+
+So on he jogged, and all seemed now to go right with him: he had met
+with some misfortunes, to be sure; but he was now well repaid for all.
+How could it be otherwise with such a travelling companion as he had at
+last got?
+
+The next man he met was a countryman carrying a fine white goose. The
+countryman stopped to ask what was o’clock; this led to further chat;
+and Hans told him all his luck, how he had so many good bargains, and
+how all the world went gay and smiling with him. The countryman then
+began to tell his tale, and said he was going to take the goose to a
+christening. ‘Feel,’ said he, ‘how heavy it is, and yet it is only eight
+weeks old. Whoever roasts and eats it will find plenty of fat upon it,
+it has lived so well!’ ‘You’re right,’ said Hans, as he weighed it in
+his hand; ‘but if you talk of fat, my pig is no trifle.’ Meantime the
+countryman began to look grave, and shook his head. ‘Hark ye!’ said he,
+‘my worthy friend, you seem a good sort of fellow, so I can’t help doing
+you a kind turn. Your pig may get you into a scrape. In the village I
+just came from, the squire has had a pig stolen out of his sty. I was
+dreadfully afraid when I saw you that you had got the squire’s pig. If
+you have, and they catch you, it will be a bad job for you. The least
+they will do will be to throw you into the horse-pond. Can you swim?’
+
+Poor Hans was sadly frightened. ‘Good man,’ cried he, ‘pray get me out
+of this scrape. I know nothing of where the pig was either bred or born;
+but he may have been the squire’s for aught I can tell: you know this
+country better than I do, take my pig and give me the goose.’ ‘I ought
+to have something into the bargain,’ said the countryman; ‘give a fat
+goose for a pig, indeed! ‘Tis not everyone would do so much for you as
+that. However, I will not be hard upon you, as you are in trouble.’ Then
+he took the string in his hand, and drove off the pig by a side path;
+while Hans went on the way homewards free from care. ‘After all,’
+thought he, ‘that chap is pretty well taken in. I don’t care whose pig
+it is, but wherever it came from it has been a very good friend to me. I
+have much the best of the bargain. First there will be a capital roast;
+then the fat will find me in goose-grease for six months; and then there
+are all the beautiful white feathers. I will put them into my pillow,
+and then I am sure I shall sleep soundly without rocking. How happy my
+mother will be! Talk of a pig, indeed! Give me a fine fat goose.’
+
+As he came to the next village, he saw a scissor-grinder with his wheel,
+working and singing,
+
+ ‘O’er hill and o’er dale
+  So happy I roam,
+  Work light and live well,
+  All the world is my home;
+  Then who so blythe, so merry as I?’
+
+Hans stood looking on for a while, and at last said, ‘You must be well
+off, master grinder! you seem so happy at your work.’ ‘Yes,’ said the
+other, ‘mine is a golden trade; a good grinder never puts his hand
+into his pocket without finding money in it--but where did you get that
+beautiful goose?’ ‘I did not buy it, I gave a pig for it.’ ‘And where
+did you get the pig?’ ‘I gave a cow for it.’ ‘And the cow?’ ‘I gave a
+horse for it.’ ‘And the horse?’ ‘I gave a lump of silver as big as my
+head for it.’ ‘And the silver?’ ‘Oh! I worked hard for that seven long
+years.’ ‘You have thriven well in the world hitherto,’ said the grinder,
+‘now if you could find money in your pocket whenever you put your hand
+in it, your fortune would be made.’ ‘Very true: but how is that to be
+managed?’ ‘How? Why, you must turn grinder like myself,’ said the other;
+‘you only want a grindstone; the rest will come of itself. Here is one
+that is but little the worse for wear: I would not ask more than the
+value of your goose for it--will you buy?’ ‘How can you ask?’ said
+Hans; ‘I should be the happiest man in the world, if I could have money
+whenever I put my hand in my pocket: what could I want more? there’s
+the goose.’ ‘Now,’ said the grinder, as he gave him a common rough stone
+that lay by his side, ‘this is a most capital stone; do but work it well
+enough, and you can make an old nail cut with it.’
+
+Hans took the stone, and went his way with a light heart: his eyes
+sparkled for joy, and he said to himself, ‘Surely I must have been born
+in a lucky hour; everything I could want or wish for comes of itself.
+People are so kind; they seem really to think I do them a favour in
+letting them make me rich, and giving me good bargains.’
+
+Meantime he began to be tired, and hungry too, for he had given away his
+last penny in his joy at getting the cow.
+
+At last he could go no farther, for the stone tired him sadly: and he
+dragged himself to the side of a river, that he might take a drink of
+water, and rest a while. So he laid the stone carefully by his side on
+the bank: but, as he stooped down to drink, he forgot it, pushed it a
+little, and down it rolled, plump into the stream.
+
+For a while he watched it sinking in the deep clear water; then sprang
+up and danced for joy, and again fell upon his knees and thanked Heaven,
+with tears in his eyes, for its kindness in taking away his only plague,
+the ugly heavy stone.
+
+‘How happy am I!’ cried he; ‘nobody was ever so lucky as I.’ Then up he
+got with a light heart, free from all his troubles, and walked on till
+he reached his mother’s house, and told her how very easy the road to
+good luck was.
+
+
+
+
+JORINDA AND JORINDEL
+
+There was once an old castle, that stood in the middle of a deep gloomy
+wood, and in the castle lived an old fairy. Now this fairy could take
+any shape she pleased. All the day long she flew about in the form of
+an owl, or crept about the country like a cat; but at night she always
+became an old woman again. When any young man came within a hundred
+paces of her castle, he became quite fixed, and could not move a step
+till she came and set him free; which she would not do till he had given
+her his word never to come there again: but when any pretty maiden came
+within that space she was changed into a bird, and the fairy put her
+into a cage, and hung her up in a chamber in the castle. There were
+seven hundred of these cages hanging in the castle, and all with
+beautiful birds in them.
+
+Now there was once a maiden whose name was Jorinda. She was prettier
+than all the pretty girls that ever were seen before, and a shepherd
+lad, whose name was Jorindel, was very fond of her, and they were soon
+to be married. One day they went to walk in the wood, that they might be
+alone; and Jorindel said, ‘We must take care that we don’t go too near
+to the fairy’s castle.’ It was a beautiful evening; the last rays of the
+setting sun shone bright through the long stems of the trees upon
+the green underwood beneath, and the turtle-doves sang from the tall
+birches.
+
+Jorinda sat down to gaze upon the sun; Jorindel sat by her side; and
+both felt sad, they knew not why; but it seemed as if they were to be
+parted from one another for ever. They had wandered a long way; and when
+they looked to see which way they should go home, they found themselves
+at a loss to know what path to take.
+
+The sun was setting fast, and already half of its circle had sunk behind
+the hill: Jorindel on a sudden looked behind him, and saw through the
+bushes that they had, without knowing it, sat down close under the old
+walls of the castle. Then he shrank for fear, turned pale, and trembled.
+Jorinda was just singing,
+
+ ‘The ring-dove sang from the willow spray,
+  Well-a-day! Well-a-day!
+  He mourn’d for the fate of his darling mate,
+  Well-a-day!’
+
+when her song stopped suddenly. Jorindel turned to see the reason, and
+beheld his Jorinda changed into a nightingale, so that her song ended
+with a mournful _jug, jug_. An owl with fiery eyes flew three times
+round them, and three times screamed:
+
+ ‘Tu whu! Tu whu! Tu whu!’
+
+Jorindel could not move; he stood fixed as a stone, and could neither
+weep, nor speak, nor stir hand or foot. And now the sun went quite down;
+the gloomy night came; the owl flew into a bush; and a moment after the
+old fairy came forth pale and meagre, with staring eyes, and a nose and
+chin that almost met one another.
+
+She mumbled something to herself, seized the nightingale, and went away
+with it in her hand. Poor Jorindel saw the nightingale was gone--but
+what could he do? He could not speak, he could not move from the spot
+where he stood. At last the fairy came back and sang with a hoarse
+voice:
+
+ ‘Till the prisoner is fast,
+  And her doom is cast,
+  There stay! Oh, stay!
+  When the charm is around her,
+  And the spell has bound her,
+  Hie away! away!’
+
+On a sudden Jorindel found himself free. Then he fell on his knees
+before the fairy, and prayed her to give him back his dear Jorinda: but
+she laughed at him, and said he should never see her again; then she
+went her way.
+
+He prayed, he wept, he sorrowed, but all in vain. ‘Alas!’ he said, ‘what
+will become of me?’ He could not go back to his own home, so he went to
+a strange village, and employed himself in keeping sheep. Many a time
+did he walk round and round as near to the hated castle as he dared go,
+but all in vain; he heard or saw nothing of Jorinda.
+
+At last he dreamt one night that he found a beautiful purple flower,
+and that in the middle of it lay a costly pearl; and he dreamt that he
+plucked the flower, and went with it in his hand into the castle, and
+that everything he touched with it was disenchanted, and that there he
+found his Jorinda again.
+
+In the morning when he awoke, he began to search over hill and dale for
+this pretty flower; and eight long days he sought for it in vain: but
+on the ninth day, early in the morning, he found the beautiful purple
+flower; and in the middle of it was a large dewdrop, as big as a costly
+pearl. Then he plucked the flower, and set out and travelled day and
+night, till he came again to the castle.
+
+He walked nearer than a hundred paces to it, and yet he did not become
+fixed as before, but found that he could go quite close up to the door.
+Jorindel was very glad indeed to see this. Then he touched the door with
+the flower, and it sprang open; so that he went in through the court,
+and listened when he heard so many birds singing. At last he came to the
+chamber where the fairy sat, with the seven hundred birds singing in
+the seven hundred cages. When she saw Jorindel she was very angry, and
+screamed with rage; but she could not come within two yards of him, for
+the flower he held in his hand was his safeguard. He looked around at
+the birds, but alas! there were many, many nightingales, and how then
+should he find out which was his Jorinda? While he was thinking what to
+do, he saw the fairy had taken down one of the cages, and was making the
+best of her way off through the door. He ran or flew after her, touched
+the cage with the flower, and Jorinda stood before him, and threw her
+arms round his neck looking as beautiful as ever, as beautiful as when
+they walked together in the wood.
+
+Then he touched all the other birds with the flower, so that they all
+took their old forms again; and he took Jorinda home, where they were
+married, and lived happily together many years: and so did a good many
+other lads, whose maidens had been forced to sing in the old fairy’s
+cages by themselves, much longer than they liked.
+
+
+
+
+THE TRAVELLING MUSICIANS
+
+An honest farmer had once an ass that had been a faithful servant to him
+a great many years, but was now growing old and every day more and more
+unfit for work. His master therefore was tired of keeping him and
+began to think of putting an end to him; but the ass, who saw that some
+mischief was in the wind, took himself slyly off, and began his journey
+towards the great city, ‘For there,’ thought he, ‘I may turn musician.’
+
+After he had travelled a little way, he spied a dog lying by the
+roadside and panting as if he were tired. ‘What makes you pant so, my
+friend?’ said the ass. ‘Alas!’ said the dog, ‘my master was going to
+knock me on the head, because I am old and weak, and can no longer make
+myself useful to him in hunting; so I ran away; but what can I do to
+earn my livelihood?’ ‘Hark ye!’ said the ass, ‘I am going to the great
+city to turn musician: suppose you go with me, and try what you can
+do in the same way?’ The dog said he was willing, and they jogged on
+together.
+
+They had not gone far before they saw a cat sitting in the middle of the
+road and making a most rueful face. ‘Pray, my good lady,’ said the ass,
+‘what’s the matter with you? You look quite out of spirits!’ ‘Ah, me!’
+said the cat, ‘how can one be in good spirits when one’s life is in
+danger? Because I am beginning to grow old, and had rather lie at my
+ease by the fire than run about the house after the mice, my mistress
+laid hold of me, and was going to drown me; and though I have been lucky
+enough to get away from her, I do not know what I am to live upon.’
+‘Oh,’ said the ass, ‘by all means go with us to the great city; you are
+a good night singer, and may make your fortune as a musician.’ The cat
+was pleased with the thought, and joined the party.
+
+Soon afterwards, as they were passing by a farmyard, they saw a cock
+perched upon a gate, and screaming out with all his might and main.
+‘Bravo!’ said the ass; ‘upon my word, you make a famous noise; pray what
+is all this about?’ ‘Why,’ said the cock, ‘I was just now saying that
+we should have fine weather for our washing-day, and yet my mistress and
+the cook don’t thank me for my pains, but threaten to cut off my
+head tomorrow, and make broth of me for the guests that are coming
+on Sunday!’ ‘Heaven forbid!’ said the ass, ‘come with us Master
+Chanticleer; it will be better, at any rate, than staying here to have
+your head cut off! Besides, who knows? If we care to sing in tune, we
+may get up some kind of a concert; so come along with us.’ ‘With all my
+heart,’ said the cock: so they all four went on jollily together.
+
+They could not, however, reach the great city the first day; so when
+night came on, they went into a wood to sleep. The ass and the dog laid
+themselves down under a great tree, and the cat climbed up into the
+branches; while the cock, thinking that the higher he sat the safer he
+should be, flew up to the very top of the tree, and then, according to
+his custom, before he went to sleep, looked out on all sides of him to
+see that everything was well. In doing this, he saw afar off something
+bright and shining and calling to his companions said, ‘There must be a
+house no great way off, for I see a light.’ ‘If that be the case,’ said
+the ass, ‘we had better change our quarters, for our lodging is not the
+best in the world!’ ‘Besides,’ added the dog, ‘I should not be the
+worse for a bone or two, or a bit of meat.’ So they walked off together
+towards the spot where Chanticleer had seen the light, and as they drew
+near it became larger and brighter, till they at last came close to a
+house in which a gang of robbers lived.
+
+The ass, being the tallest of the company, marched up to the window and
+peeped in. ‘Well, Donkey,’ said Chanticleer, ‘what do you see?’ ‘What
+do I see?’ replied the ass. ‘Why, I see a table spread with all kinds of
+good things, and robbers sitting round it making merry.’ ‘That would
+be a noble lodging for us,’ said the cock. ‘Yes,’ said the ass, ‘if we
+could only get in’; so they consulted together how they should contrive
+to get the robbers out; and at last they hit upon a plan. The ass placed
+himself upright on his hind legs, with his forefeet resting against the
+window; the dog got upon his back; the cat scrambled up to the dog’s
+shoulders, and the cock flew up and sat upon the cat’s head. When
+all was ready a signal was given, and they began their music. The ass
+brayed, the dog barked, the cat mewed, and the cock screamed; and then
+they all broke through the window at once, and came tumbling into
+the room, amongst the broken glass, with a most hideous clatter! The
+robbers, who had been not a little frightened by the opening concert,
+had now no doubt that some frightful hobgoblin had broken in upon them,
+and scampered away as fast as they could.
+
+The coast once clear, our travellers soon sat down and dispatched what
+the robbers had left, with as much eagerness as if they had not expected
+to eat again for a month. As soon as they had satisfied themselves, they
+put out the lights, and each once more sought out a resting-place to
+his own liking. The donkey laid himself down upon a heap of straw in
+the yard, the dog stretched himself upon a mat behind the door, the
+cat rolled herself up on the hearth before the warm ashes, and the
+cock perched upon a beam on the top of the house; and, as they were all
+rather tired with their journey, they soon fell asleep.
+
+But about midnight, when the robbers saw from afar that the lights were
+out and that all seemed quiet, they began to think that they had been in
+too great a hurry to run away; and one of them, who was bolder than
+the rest, went to see what was going on. Finding everything still, he
+marched into the kitchen, and groped about till he found a match in
+order to light a candle; and then, espying the glittering fiery eyes of
+the cat, he mistook them for live coals, and held the match to them to
+light it. But the cat, not understanding this joke, sprang at his face,
+and spat, and scratched at him. This frightened him dreadfully, and away
+he ran to the back door; but there the dog jumped up and bit him in the
+leg; and as he was crossing over the yard the ass kicked him; and the
+cock, who had been awakened by the noise, crowed with all his might. At
+this the robber ran back as fast as he could to his comrades, and told
+the captain how a horrid witch had got into the house, and had spat at
+him and scratched his face with her long bony fingers; how a man with a
+knife in his hand had hidden himself behind the door, and stabbed him
+in the leg; how a black monster stood in the yard and struck him with a
+club, and how the devil had sat upon the top of the house and cried out,
+‘Throw the rascal up here!’ After this the robbers never dared to go
+back to the house; but the musicians were so pleased with their quarters
+that they took up their abode there; and there they are, I dare say, at
+this very day.
+
+
+
+
+OLD SULTAN
+
+A shepherd had a faithful dog, called Sultan, who was grown very old,
+and had lost all his teeth. And one day when the shepherd and his wife
+were standing together before the house the shepherd said, ‘I will shoot
+old Sultan tomorrow morning, for he is of no use now.’ But his wife
+said, ‘Pray let the poor faithful creature live; he has served us well a
+great many years, and we ought to give him a livelihood for the rest of
+his days.’ ‘But what can we do with him?’ said the shepherd, ‘he has not
+a tooth in his head, and the thieves don’t care for him at all; to
+be sure he has served us, but then he did it to earn his livelihood;
+tomorrow shall be his last day, depend upon it.’
+
+Poor Sultan, who was lying close by them, heard all that the shepherd
+and his wife said to one another, and was very much frightened to think
+tomorrow would be his last day; so in the evening he went to his good
+friend the wolf, who lived in the wood, and told him all his sorrows,
+and how his master meant to kill him in the morning. ‘Make yourself
+easy,’ said the wolf, ‘I will give you some good advice. Your master,
+you know, goes out every morning very early with his wife into the
+field; and they take their little child with them, and lay it down
+behind the hedge in the shade while they are at work. Now do you lie
+down close by the child, and pretend to be watching it, and I will come
+out of the wood and run away with it; you must run after me as fast as
+you can, and I will let it drop; then you may carry it back, and they
+will think you have saved their child, and will be so thankful to you
+that they will take care of you as long as you live.’ The dog liked this
+plan very well; and accordingly so it was managed. The wolf ran with the
+child a little way; the shepherd and his wife screamed out; but Sultan
+soon overtook him, and carried the poor little thing back to his master
+and mistress. Then the shepherd patted him on the head, and said, ‘Old
+Sultan has saved our child from the wolf, and therefore he shall live
+and be well taken care of, and have plenty to eat. Wife, go home, and
+give him a good dinner, and let him have my old cushion to sleep on
+as long as he lives.’ So from this time forward Sultan had all that he
+could wish for.
+
+Soon afterwards the wolf came and wished him joy, and said, ‘Now, my
+good fellow, you must tell no tales, but turn your head the other way
+when I want to taste one of the old shepherd’s fine fat sheep.’ ‘No,’
+said the Sultan; ‘I will be true to my master.’ However, the wolf
+thought he was in joke, and came one night to get a dainty morsel. But
+Sultan had told his master what the wolf meant to do; so he laid wait
+for him behind the barn door, and when the wolf was busy looking out for
+a good fat sheep, he had a stout cudgel laid about his back, that combed
+his locks for him finely.
+
+Then the wolf was very angry, and called Sultan ‘an old rogue,’ and
+swore he would have his revenge. So the next morning the wolf sent the
+boar to challenge Sultan to come into the wood to fight the matter. Now
+Sultan had nobody he could ask to be his second but the shepherd’s old
+three-legged cat; so he took her with him, and as the poor thing limped
+along with some trouble, she stuck up her tail straight in the air.
+
+The wolf and the wild boar were first on the ground; and when they
+espied their enemies coming, and saw the cat’s long tail standing
+straight in the air, they thought she was carrying a sword for Sultan to
+fight with; and every time she limped, they thought she was picking up
+a stone to throw at them; so they said they should not like this way of
+fighting, and the boar lay down behind a bush, and the wolf jumped
+up into a tree. Sultan and the cat soon came up, and looked about and
+wondered that no one was there. The boar, however, had not quite hidden
+himself, for his ears stuck out of the bush; and when he shook one of
+them a little, the cat, seeing something move, and thinking it was a
+mouse, sprang upon it, and bit and scratched it, so that the boar jumped
+up and grunted, and ran away, roaring out, ‘Look up in the tree, there
+sits the one who is to blame.’ So they looked up, and espied the wolf
+sitting amongst the branches; and they called him a cowardly rascal,
+and would not suffer him to come down till he was heartily ashamed of
+himself, and had promised to be good friends again with old Sultan.
+
+
+
+
+THE STRAW, THE COAL, AND THE BEAN
+
+In a village dwelt a poor old woman, who had gathered together a dish
+of beans and wanted to cook them. So she made a fire on her hearth, and
+that it might burn the quicker, she lighted it with a handful of straw.
+When she was emptying the beans into the pan, one dropped without her
+observing it, and lay on the ground beside a straw, and soon afterwards
+a burning coal from the fire leapt down to the two. Then the straw
+began and said: ‘Dear friends, from whence do you come here?’ The coal
+replied: ‘I fortunately sprang out of the fire, and if I had not escaped
+by sheer force, my death would have been certain,--I should have been
+burnt to ashes.’ The bean said: ‘I too have escaped with a whole skin,
+but if the old woman had got me into the pan, I should have been made
+into broth without any mercy, like my comrades.’ ‘And would a better
+fate have fallen to my lot?’ said the straw. ‘The old woman has
+destroyed all my brethren in fire and smoke; she seized sixty of them at
+once, and took their lives. I luckily slipped through her fingers.’
+
+‘But what are we to do now?’ said the coal.
+
+‘I think,’ answered the bean, ‘that as we have so fortunately escaped
+death, we should keep together like good companions, and lest a new
+mischance should overtake us here, we should go away together, and
+repair to a foreign country.’
+
+The proposition pleased the two others, and they set out on their way
+together. Soon, however, they came to a little brook, and as there was
+no bridge or foot-plank, they did not know how they were to get over
+it. The straw hit on a good idea, and said: ‘I will lay myself straight
+across, and then you can walk over on me as on a bridge.’ The straw
+therefore stretched itself from one bank to the other, and the coal,
+who was of an impetuous disposition, tripped quite boldly on to the
+newly-built bridge. But when she had reached the middle, and heard the
+water rushing beneath her, she was after all, afraid, and stood still,
+and ventured no farther. The straw, however, began to burn, broke in
+two pieces, and fell into the stream. The coal slipped after her, hissed
+when she got into the water, and breathed her last. The bean, who had
+prudently stayed behind on the shore, could not but laugh at the event,
+was unable to stop, and laughed so heartily that she burst. It would
+have been all over with her, likewise, if, by good fortune, a tailor who
+was travelling in search of work, had not sat down to rest by the brook.
+As he had a compassionate heart he pulled out his needle and thread,
+and sewed her together. The bean thanked him most prettily, but as the
+tailor used black thread, all beans since then have a black seam.
+
+
+
+
+BRIAR ROSE
+
+A king and queen once upon a time reigned in a country a great way off,
+where there were in those days fairies. Now this king and queen had
+plenty of money, and plenty of fine clothes to wear, and plenty of
+good things to eat and drink, and a coach to ride out in every day: but
+though they had been married many years they had no children, and this
+grieved them very much indeed. But one day as the queen was walking
+by the side of the river, at the bottom of the garden, she saw a poor
+little fish, that had thrown itself out of the water, and lay gasping
+and nearly dead on the bank. Then the queen took pity on the little
+fish, and threw it back again into the river; and before it swam away
+it lifted its head out of the water and said, ‘I know what your wish is,
+and it shall be fulfilled, in return for your kindness to me--you will
+soon have a daughter.’ What the little fish had foretold soon came to
+pass; and the queen had a little girl, so very beautiful that the king
+could not cease looking on it for joy, and said he would hold a great
+feast and make merry, and show the child to all the land. So he asked
+his kinsmen, and nobles, and friends, and neighbours. But the queen
+said, ‘I will have the fairies also, that they might be kind and good
+to our little daughter.’ Now there were thirteen fairies in the kingdom;
+but as the king and queen had only twelve golden dishes for them to eat
+out of, they were forced to leave one of the fairies without asking her.
+So twelve fairies came, each with a high red cap on her head, and red
+shoes with high heels on her feet, and a long white wand in her hand:
+and after the feast was over they gathered round in a ring and gave all
+their best gifts to the little princess. One gave her goodness, another
+beauty, another riches, and so on till she had all that was good in the
+world.
+
+Just as eleven of them had done blessing her, a great noise was heard in
+the courtyard, and word was brought that the thirteenth fairy was
+come, with a black cap on her head, and black shoes on her feet, and a
+broomstick in her hand: and presently up she came into the dining-hall.
+Now, as she had not been asked to the feast she was very angry, and
+scolded the king and queen very much, and set to work to take her
+revenge. So she cried out, ‘The king’s daughter shall, in her fifteenth
+year, be wounded by a spindle, and fall down dead.’ Then the twelfth of
+the friendly fairies, who had not yet given her gift, came forward, and
+said that the evil wish must be fulfilled, but that she could soften its
+mischief; so her gift was, that the king’s daughter, when the spindle
+wounded her, should not really die, but should only fall asleep for a
+hundred years.
+
+However, the king hoped still to save his dear child altogether from
+the threatened evil; so he ordered that all the spindles in the kingdom
+should be bought up and burnt. But all the gifts of the first eleven
+fairies were in the meantime fulfilled; for the princess was so
+beautiful, and well behaved, and good, and wise, that everyone who knew
+her loved her.
+
+It happened that, on the very day she was fifteen years old, the king
+and queen were not at home, and she was left alone in the palace. So she
+roved about by herself, and looked at all the rooms and chambers, till
+at last she came to an old tower, to which there was a narrow staircase
+ending with a little door. In the door there was a golden key, and when
+she turned it the door sprang open, and there sat an old lady spinning
+away very busily. ‘Why, how now, good mother,’ said the princess; ‘what
+are you doing there?’ ‘Spinning,’ said the old lady, and nodded her
+head, humming a tune, while buzz! went the wheel. ‘How prettily that
+little thing turns round!’ said the princess, and took the spindle
+and began to try and spin. But scarcely had she touched it, before the
+fairy’s prophecy was fulfilled; the spindle wounded her, and she fell
+down lifeless on the ground.
+
+However, she was not dead, but had only fallen into a deep sleep; and
+the king and the queen, who had just come home, and all their court,
+fell asleep too; and the horses slept in the stables, and the dogs in
+the court, the pigeons on the house-top, and the very flies slept upon
+the walls. Even the fire on the hearth left off blazing, and went to
+sleep; the jack stopped, and the spit that was turning about with a
+goose upon it for the king’s dinner stood still; and the cook, who was
+at that moment pulling the kitchen-boy by the hair to give him a box
+on the ear for something he had done amiss, let him go, and both fell
+asleep; the butler, who was slyly tasting the ale, fell asleep with the
+jug at his lips: and thus everything stood still, and slept soundly.
+
+A large hedge of thorns soon grew round the palace, and every year it
+became higher and thicker; till at last the old palace was surrounded
+and hidden, so that not even the roof or the chimneys could be seen. But
+there went a report through all the land of the beautiful sleeping Briar
+Rose (for so the king’s daughter was called): so that, from time to
+time, several kings’ sons came, and tried to break through the thicket
+into the palace. This, however, none of them could ever do; for the
+thorns and bushes laid hold of them, as it were with hands; and there
+they stuck fast, and died wretchedly.
+
+After many, many years there came a king’s son into that land: and an
+old man told him the story of the thicket of thorns; and how a beautiful
+palace stood behind it, and how a wonderful princess, called Briar Rose,
+lay in it asleep, with all her court. He told, too, how he had heard
+from his grandfather that many, many princes had come, and had tried to
+break through the thicket, but that they had all stuck fast in it, and
+died. Then the young prince said, ‘All this shall not frighten me; I
+will go and see this Briar Rose.’ The old man tried to hinder him, but
+he was bent upon going.
+
+Now that very day the hundred years were ended; and as the prince came
+to the thicket he saw nothing but beautiful flowering shrubs, through
+which he went with ease, and they shut in after him as thick as ever.
+Then he came at last to the palace, and there in the court lay the dogs
+asleep; and the horses were standing in the stables; and on the roof sat
+the pigeons fast asleep, with their heads under their wings. And when he
+came into the palace, the flies were sleeping on the walls; the spit
+was standing still; the butler had the jug of ale at his lips, going
+to drink a draught; the maid sat with a fowl in her lap ready to be
+plucked; and the cook in the kitchen was still holding up her hand, as
+if she was going to beat the boy.
+
+Then he went on still farther, and all was so still that he could hear
+every breath he drew; till at last he came to the old tower, and opened
+the door of the little room in which Briar Rose was; and there she lay,
+fast asleep on a couch by the window. She looked so beautiful that he
+could not take his eyes off her, so he stooped down and gave her a kiss.
+But the moment he kissed her she opened her eyes and awoke, and smiled
+upon him; and they went out together; and soon the king and queen also
+awoke, and all the court, and gazed on each other with great wonder.
+And the horses shook themselves, and the dogs jumped up and barked; the
+pigeons took their heads from under their wings, and looked about and
+flew into the fields; the flies on the walls buzzed again; the fire in
+the kitchen blazed up; round went the jack, and round went the spit,
+with the goose for the king’s dinner upon it; the butler finished his
+draught of ale; the maid went on plucking the fowl; and the cook gave
+the boy the box on his ear.
+
+And then the prince and Briar Rose were married, and the wedding feast
+was given; and they lived happily together all their lives long.
+
+
+
+
+THE DOG AND THE SPARROW
+
+A shepherd’s dog had a master who took no care of him, but often let him
+suffer the greatest hunger. At last he could bear it no longer; so he
+took to his heels, and off he ran in a very sad and sorrowful mood.
+On the road he met a sparrow that said to him, ‘Why are you so sad,
+my friend?’ ‘Because,’ said the dog, ‘I am very very hungry, and have
+nothing to eat.’ ‘If that be all,’ answered the sparrow, ‘come with me
+into the next town, and I will soon find you plenty of food.’ So on they
+went together into the town: and as they passed by a butcher’s shop,
+the sparrow said to the dog, ‘Stand there a little while till I peck you
+down a piece of meat.’ So the sparrow perched upon the shelf: and having
+first looked carefully about her to see if anyone was watching her, she
+pecked and scratched at a steak that lay upon the edge of the shelf,
+till at last down it fell. Then the dog snapped it up, and scrambled
+away with it into a corner, where he soon ate it all up. ‘Well,’ said
+the sparrow, ‘you shall have some more if you will; so come with me to
+the next shop, and I will peck you down another steak.’ When the dog had
+eaten this too, the sparrow said to him, ‘Well, my good friend, have you
+had enough now?’ ‘I have had plenty of meat,’ answered he, ‘but I should
+like to have a piece of bread to eat after it.’ ‘Come with me then,’
+said the sparrow, ‘and you shall soon have that too.’ So she took him
+to a baker’s shop, and pecked at two rolls that lay in the window, till
+they fell down: and as the dog still wished for more, she took him to
+another shop and pecked down some more for him. When that was eaten, the
+sparrow asked him whether he had had enough now. ‘Yes,’ said he; ‘and
+now let us take a walk a little way out of the town.’ So they both went
+out upon the high road; but as the weather was warm, they had not gone
+far before the dog said, ‘I am very much tired--I should like to take a
+nap.’ ‘Very well,’ answered the sparrow, ‘do so, and in the meantime
+I will perch upon that bush.’ So the dog stretched himself out on the
+road, and fell fast asleep. Whilst he slept, there came by a carter with
+a cart drawn by three horses, and loaded with two casks of wine. The
+sparrow, seeing that the carter did not turn out of the way, but would
+go on in the track in which the dog lay, so as to drive over him, called
+out, ‘Stop! stop! Mr Carter, or it shall be the worse for you.’ But the
+carter, grumbling to himself, ‘You make it the worse for me, indeed!
+what can you do?’ cracked his whip, and drove his cart over the poor
+dog, so that the wheels crushed him to death. ‘There,’ cried the
+sparrow, ‘thou cruel villain, thou hast killed my friend the dog. Now
+mind what I say. This deed of thine shall cost thee all thou art worth.’
+‘Do your worst, and welcome,’ said the brute, ‘what harm can you do me?’
+and passed on. But the sparrow crept under the tilt of the cart, and
+pecked at the bung of one of the casks till she loosened it; and then
+all the wine ran out, without the carter seeing it. At last he looked
+round, and saw that the cart was dripping, and the cask quite empty.
+‘What an unlucky wretch I am!’ cried he. ‘Not wretch enough yet!’ said
+the sparrow, as she alighted upon the head of one of the horses, and
+pecked at him till he reared up and kicked. When the carter saw this,
+he drew out his hatchet and aimed a blow at the sparrow, meaning to kill
+her; but she flew away, and the blow fell upon the poor horse’s head
+with such force, that he fell down dead. ‘Unlucky wretch that I am!’
+cried he. ‘Not wretch enough yet!’ said the sparrow. And as the carter
+went on with the other two horses, she again crept under the tilt of the
+cart, and pecked out the bung of the second cask, so that all the wine
+ran out. When the carter saw this, he again cried out, ‘Miserable wretch
+that I am!’ But the sparrow answered, ‘Not wretch enough yet!’ and
+perched on the head of the second horse, and pecked at him too. The
+carter ran up and struck at her again with his hatchet; but away she
+flew, and the blow fell upon the second horse and killed him on the
+spot. ‘Unlucky wretch that I am!’ said he. ‘Not wretch enough yet!’ said
+the sparrow; and perching upon the third horse, she began to peck him
+too. The carter was mad with fury; and without looking about him, or
+caring what he was about, struck again at the sparrow; but killed his
+third horse as he done the other two. ‘Alas! miserable wretch that I
+am!’ cried he. ‘Not wretch enough yet!’ answered the sparrow as she flew
+away; ‘now will I plague and punish thee at thy own house.’ The
+carter was forced at last to leave his cart behind him, and to go home
+overflowing with rage and vexation. ‘Alas!’ said he to his wife, ‘what
+ill luck has befallen me!--my wine is all spilt, and my horses all three
+dead.’ ‘Alas! husband,’ replied she, ‘and a wicked bird has come into
+the house, and has brought with her all the birds in the world, I am
+sure, and they have fallen upon our corn in the loft, and are eating it
+up at such a rate!’ Away ran the husband upstairs, and saw thousands of
+birds sitting upon the floor eating up his corn, with the sparrow in the
+midst of them. ‘Unlucky wretch that I am!’ cried the carter; for he saw
+that the corn was almost all gone. ‘Not wretch enough yet!’ said the
+sparrow; ‘thy cruelty shall cost thee thy life yet!’ and away she flew.
+
+The carter seeing that he had thus lost all that he had, went down
+into his kitchen; and was still not sorry for what he had done, but sat
+himself angrily and sulkily in the chimney corner. But the sparrow sat
+on the outside of the window, and cried ‘Carter! thy cruelty shall cost
+thee thy life!’ With that he jumped up in a rage, seized his hatchet,
+and threw it at the sparrow; but it missed her, and only broke the
+window. The sparrow now hopped in, perched upon the window-seat, and
+cried, ‘Carter! it shall cost thee thy life!’ Then he became mad and
+blind with rage, and struck the window-seat with such force that he
+cleft it in two: and as the sparrow flew from place to place, the carter
+and his wife were so furious, that they broke all their furniture,
+glasses, chairs, benches, the table, and at last the walls, without
+touching the bird at all. In the end, however, they caught her: and the
+wife said, ‘Shall I kill her at once?’ ‘No,’ cried he, ‘that is letting
+her off too easily: she shall die a much more cruel death; I will eat
+her.’ But the sparrow began to flutter about, and stretch out her neck
+and cried, ‘Carter! it shall cost thee thy life yet!’ With that he
+could wait no longer: so he gave his wife the hatchet, and cried, ‘Wife,
+strike at the bird and kill her in my hand.’ And the wife struck; but
+she missed her aim, and hit her husband on the head so that he fell down
+dead, and the sparrow flew quietly home to her nest.
+
+
+
+
+THE TWELVE DANCING PRINCESSES
+
+There was a king who had twelve beautiful daughters. They slept in
+twelve beds all in one room; and when they went to bed, the doors were
+shut and locked up; but every morning their shoes were found to be quite
+worn through as if they had been danced in all night; and yet nobody
+could find out how it happened, or where they had been.
+
+Then the king made it known to all the land, that if any person could
+discover the secret, and find out where it was that the princesses
+danced in the night, he should have the one he liked best for his
+wife, and should be king after his death; but whoever tried and did not
+succeed, after three days and nights, should be put to death.
+
+A king’s son soon came. He was well entertained, and in the evening was
+taken to the chamber next to the one where the princesses lay in their
+twelve beds. There he was to sit and watch where they went to dance;
+and, in order that nothing might pass without his hearing it, the door
+of his chamber was left open. But the king’s son soon fell asleep; and
+when he awoke in the morning he found that the princesses had all been
+dancing, for the soles of their shoes were full of holes. The same thing
+happened the second and third night: so the king ordered his head to be
+cut off. After him came several others; but they had all the same luck,
+and all lost their lives in the same manner.
+
+Now it chanced that an old soldier, who had been wounded in battle
+and could fight no longer, passed through the country where this king
+reigned: and as he was travelling through a wood, he met an old woman,
+who asked him where he was going. ‘I hardly know where I am going, or
+what I had better do,’ said the soldier; ‘but I think I should like very
+well to find out where it is that the princesses dance, and then in time
+I might be a king.’ ‘Well,’ said the old dame, ‘that is no very hard
+task: only take care not to drink any of the wine which one of the
+princesses will bring to you in the evening; and as soon as she leaves
+you pretend to be fast asleep.’
+
+Then she gave him a cloak, and said, ‘As soon as you put that on
+you will become invisible, and you will then be able to follow the
+princesses wherever they go.’ When the soldier heard all this good
+counsel, he determined to try his luck: so he went to the king, and said
+he was willing to undertake the task.
+
+He was as well received as the others had been, and the king ordered
+fine royal robes to be given him; and when the evening came he was led
+to the outer chamber. Just as he was going to lie down, the eldest of
+the princesses brought him a cup of wine; but the soldier threw it all
+away secretly, taking care not to drink a drop. Then he laid himself
+down on his bed, and in a little while began to snore very loud as if
+he was fast asleep. When the twelve princesses heard this they laughed
+heartily; and the eldest said, ‘This fellow too might have done a wiser
+thing than lose his life in this way!’ Then they rose up and opened
+their drawers and boxes, and took out all their fine clothes, and
+dressed themselves at the glass, and skipped about as if they were eager
+to begin dancing. But the youngest said, ‘I don’t know how it is, while
+you are so happy I feel very uneasy; I am sure some mischance will
+befall us.’ ‘You simpleton,’ said the eldest, ‘you are always afraid;
+have you forgotten how many kings’ sons have already watched in vain?
+And as for this soldier, even if I had not given him his sleeping
+draught, he would have slept soundly enough.’
+
+When they were all ready, they went and looked at the soldier; but he
+snored on, and did not stir hand or foot: so they thought they were
+quite safe; and the eldest went up to her own bed and clapped her hands,
+and the bed sank into the floor and a trap-door flew open. The soldier
+saw them going down through the trap-door one after another, the eldest
+leading the way; and thinking he had no time to lose, he jumped up, put
+on the cloak which the old woman had given him, and followed them;
+but in the middle of the stairs he trod on the gown of the youngest
+princess, and she cried out to her sisters, ‘All is not right; someone
+took hold of my gown.’ ‘You silly creature!’ said the eldest, ‘it is
+nothing but a nail in the wall.’ Then down they all went, and at the
+bottom they found themselves in a most delightful grove of trees; and
+the leaves were all of silver, and glittered and sparkled beautifully.
+The soldier wished to take away some token of the place; so he broke
+off a little branch, and there came a loud noise from the tree. Then the
+youngest daughter said again, ‘I am sure all is not right--did not you
+hear that noise? That never happened before.’ But the eldest said, ‘It
+is only our princes, who are shouting for joy at our approach.’
+
+Then they came to another grove of trees, where all the leaves were of
+gold; and afterwards to a third, where the leaves were all glittering
+diamonds. And the soldier broke a branch from each; and every time there
+was a loud noise, which made the youngest sister tremble with fear; but
+the eldest still said, it was only the princes, who were crying for joy.
+So they went on till they came to a great lake; and at the side of the
+lake there lay twelve little boats with twelve handsome princes in them,
+who seemed to be waiting there for the princesses.
+
+One of the princesses went into each boat, and the soldier stepped into
+the same boat with the youngest. As they were rowing over the lake, the
+prince who was in the boat with the youngest princess and the soldier
+said, ‘I do not know why it is, but though I am rowing with all my might
+we do not get on so fast as usual, and I am quite tired: the boat
+seems very heavy today.’ ‘It is only the heat of the weather,’ said the
+princess: ‘I feel it very warm too.’
+
+On the other side of the lake stood a fine illuminated castle, from
+which came the merry music of horns and trumpets. There they all landed,
+and went into the castle, and each prince danced with his princess; and
+the soldier, who was all the time invisible, danced with them too; and
+when any of the princesses had a cup of wine set by her, he drank it
+all up, so that when she put the cup to her mouth it was empty. At this,
+too, the youngest sister was terribly frightened, but the eldest always
+silenced her. They danced on till three o’clock in the morning, and then
+all their shoes were worn out, so that they were obliged to leave off.
+The princes rowed them back again over the lake (but this time the
+soldier placed himself in the boat with the eldest princess); and on the
+opposite shore they took leave of each other, the princesses promising
+to come again the next night.
+
+When they came to the stairs, the soldier ran on before the princesses,
+and laid himself down; and as the twelve sisters slowly came up very
+much tired, they heard him snoring in his bed; so they said, ‘Now all
+is quite safe’; then they undressed themselves, put away their fine
+clothes, pulled off their shoes, and went to bed. In the morning the
+soldier said nothing about what had happened, but determined to see more
+of this strange adventure, and went again the second and third night;
+and every thing happened just as before; the princesses danced each time
+till their shoes were worn to pieces, and then returned home. However,
+on the third night the soldier carried away one of the golden cups as a
+token of where he had been.
+
+As soon as the time came when he was to declare the secret, he was taken
+before the king with the three branches and the golden cup; and the
+twelve princesses stood listening behind the door to hear what he would
+say. And when the king asked him. ‘Where do my twelve daughters dance at
+night?’ he answered, ‘With twelve princes in a castle under ground.’ And
+then he told the king all that had happened, and showed him the three
+branches and the golden cup which he had brought with him. Then the king
+called for the princesses, and asked them whether what the soldier said
+was true: and when they saw that they were discovered, and that it was
+of no use to deny what had happened, they confessed it all. And the king
+asked the soldier which of them he would choose for his wife; and he
+answered, ‘I am not very young, so I will have the eldest.’--And they
+were married that very day, and the soldier was chosen to be the king’s
+heir.
+
+
+
+
+THE FISHERMAN AND HIS WIFE
+
+There was once a fisherman who lived with his wife in a pigsty, close
+by the seaside. The fisherman used to go out all day long a-fishing; and
+one day, as he sat on the shore with his rod, looking at the sparkling
+waves and watching his line, all on a sudden his float was dragged away
+deep into the water: and in drawing it up he pulled out a great fish.
+But the fish said, ‘Pray let me live! I am not a real fish; I am an
+enchanted prince: put me in the water again, and let me go!’ ‘Oh, ho!’
+said the man, ‘you need not make so many words about the matter; I will
+have nothing to do with a fish that can talk: so swim away, sir, as soon
+as you please!’ Then he put him back into the water, and the fish darted
+straight down to the bottom, and left a long streak of blood behind him
+on the wave.
+
+When the fisherman went home to his wife in the pigsty, he told her how
+he had caught a great fish, and how it had told him it was an enchanted
+prince, and how, on hearing it speak, he had let it go again. ‘Did not
+you ask it for anything?’ said the wife, ‘we live very wretchedly here,
+in this nasty dirty pigsty; do go back and tell the fish we want a snug
+little cottage.’
+
+The fisherman did not much like the business: however, he went to the
+seashore; and when he came back there the water looked all yellow and
+green. And he stood at the water’s edge, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+Then the fish came swimming to him, and said, ‘Well, what is her will?
+What does your wife want?’ ‘Ah!’ said the fisherman, ‘she says that when
+I had caught you, I ought to have asked you for something before I let
+you go; she does not like living any longer in the pigsty, and wants
+a snug little cottage.’ ‘Go home, then,’ said the fish; ‘she is in the
+cottage already!’ So the man went home, and saw his wife standing at the
+door of a nice trim little cottage. ‘Come in, come in!’ said she; ‘is
+not this much better than the filthy pigsty we had?’ And there was a
+parlour, and a bedchamber, and a kitchen; and behind the cottage there
+was a little garden, planted with all sorts of flowers and fruits; and
+there was a courtyard behind, full of ducks and chickens. ‘Ah!’ said the
+fisherman, ‘how happily we shall live now!’ ‘We will try to do so, at
+least,’ said his wife.
+
+Everything went right for a week or two, and then Dame Ilsabill said,
+‘Husband, there is not near room enough for us in this cottage; the
+courtyard and the garden are a great deal too small; I should like to
+have a large stone castle to live in: go to the fish again and tell him
+to give us a castle.’ ‘Wife,’ said the fisherman, ‘I don’t like to go to
+him again, for perhaps he will be angry; we ought to be easy with this
+pretty cottage to live in.’ ‘Nonsense!’ said the wife; ‘he will do it
+very willingly, I know; go along and try!’
+
+The fisherman went, but his heart was very heavy: and when he came to
+the sea, it looked blue and gloomy, though it was very calm; and he went
+close to the edge of the waves, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what does she want now?’ said the fish. ‘Ah!’ said the man,
+dolefully, ‘my wife wants to live in a stone castle.’ ‘Go home, then,’
+said the fish; ‘she is standing at the gate of it already.’ So away went
+the fisherman, and found his wife standing before the gate of a great
+castle. ‘See,’ said she, ‘is not this grand?’ With that they went into
+the castle together, and found a great many servants there, and the
+rooms all richly furnished, and full of golden chairs and tables; and
+behind the castle was a garden, and around it was a park half a
+mile long, full of sheep, and goats, and hares, and deer; and in the
+courtyard were stables and cow-houses. ‘Well,’ said the man, ‘now we
+will live cheerful and happy in this beautiful castle for the rest of
+our lives.’ ‘Perhaps we may,’ said the wife; ‘but let us sleep upon it,
+before we make up our minds to that.’ So they went to bed.
+
+The next morning when Dame Ilsabill awoke it was broad daylight, and
+she jogged the fisherman with her elbow, and said, ‘Get up, husband,
+and bestir yourself, for we must be king of all the land.’ ‘Wife, wife,’
+said the man, ‘why should we wish to be the king? I will not be king.’
+‘Then I will,’ said she. ‘But, wife,’ said the fisherman, ‘how can you
+be king--the fish cannot make you a king?’ ‘Husband,’ said she, ‘say
+no more about it, but go and try! I will be king.’ So the man went away
+quite sorrowful to think that his wife should want to be king. This time
+the sea looked a dark grey colour, and was overspread with curling waves
+and the ridges of foam as he cried out:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what would she have now?’ said the fish. ‘Alas!’ said the poor
+man, ‘my wife wants to be king.’ ‘Go home,’ said the fish; ‘she is king
+already.’
+
+Then the fisherman went home; and as he came close to the palace he saw
+a troop of soldiers, and heard the sound of drums and trumpets. And when
+he went in he saw his wife sitting on a throne of gold and diamonds,
+with a golden crown upon her head; and on each side of her stood six
+fair maidens, each a head taller than the other. ‘Well, wife,’ said the
+fisherman, ‘are you king?’ ‘Yes,’ said she, ‘I am king.’ And when he had
+looked at her for a long time, he said, ‘Ah, wife! what a fine thing it
+is to be king! Now we shall never have anything more to wish for as long
+as we live.’ ‘I don’t know how that may be,’ said she; ‘never is a long
+time. I am king, it is true; but I begin to be tired of that, and I
+think I should like to be emperor.’ ‘Alas, wife! why should you wish to
+be emperor?’ said the fisherman. ‘Husband,’ said she, ‘go to the fish!
+I say I will be emperor.’ ‘Ah, wife!’ replied the fisherman, ‘the fish
+cannot make an emperor, I am sure, and I should not like to ask him for
+such a thing.’ ‘I am king,’ said Ilsabill, ‘and you are my slave; so go
+at once!’
+
+So the fisherman was forced to go; and he muttered as he went along,
+‘This will come to no good, it is too much to ask; the fish will be
+tired at last, and then we shall be sorry for what we have done.’ He
+soon came to the seashore; and the water was quite black and muddy, and
+a mighty whirlwind blew over the waves and rolled them about, but he
+went as near as he could to the water’s brink, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What would she have now?’ said the fish. ‘Ah!’ said the fisherman,
+‘she wants to be emperor.’ ‘Go home,’ said the fish; ‘she is emperor
+already.’
+
+So he went home again; and as he came near he saw his wife Ilsabill
+sitting on a very lofty throne made of solid gold, with a great crown on
+her head full two yards high; and on each side of her stood her guards
+and attendants in a row, each one smaller than the other, from the
+tallest giant down to a little dwarf no bigger than my finger. And
+before her stood princes, and dukes, and earls: and the fisherman went
+up to her and said, ‘Wife, are you emperor?’ ‘Yes,’ said she, ‘I am
+emperor.’ ‘Ah!’ said the man, as he gazed upon her, ‘what a fine thing
+it is to be emperor!’ ‘Husband,’ said she, ‘why should we stop at being
+emperor? I will be pope next.’ ‘O wife, wife!’ said he, ‘how can you be
+pope? there is but one pope at a time in Christendom.’ ‘Husband,’ said
+she, ‘I will be pope this very day.’ ‘But,’ replied the husband, ‘the
+fish cannot make you pope.’ ‘What nonsense!’ said she; ‘if he can make
+an emperor, he can make a pope: go and try him.’
+
+So the fisherman went. But when he came to the shore the wind was raging
+and the sea was tossed up and down in boiling waves, and the ships were
+in trouble, and rolled fearfully upon the tops of the billows. In the
+middle of the heavens there was a little piece of blue sky, but towards
+the south all was red, as if a dreadful storm was rising. At this sight
+the fisherman was dreadfully frightened, and he trembled so that his
+knees knocked together: but still he went down near to the shore, and
+said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said the fisherman, ‘my
+wife wants to be pope.’ ‘Go home,’ said the fish; ‘she is pope already.’
+
+Then the fisherman went home, and found Ilsabill sitting on a throne
+that was two miles high. And she had three great crowns on her head, and
+around her stood all the pomp and power of the Church. And on each side
+of her were two rows of burning lights, of all sizes, the greatest as
+large as the highest and biggest tower in the world, and the least no
+larger than a small rushlight. ‘Wife,’ said the fisherman, as he looked
+at all this greatness, ‘are you pope?’ ‘Yes,’ said she, ‘I am pope.’
+‘Well, wife,’ replied he, ‘it is a grand thing to be pope; and now
+you must be easy, for you can be nothing greater.’ ‘I will think about
+that,’ said the wife. Then they went to bed: but Dame Ilsabill could not
+sleep all night for thinking what she should be next. At last, as she
+was dropping asleep, morning broke, and the sun rose. ‘Ha!’ thought she,
+as she woke up and looked at it through the window, ‘after all I cannot
+prevent the sun rising.’ At this thought she was very angry, and wakened
+her husband, and said, ‘Husband, go to the fish and tell him I must
+be lord of the sun and moon.’ The fisherman was half asleep, but the
+thought frightened him so much that he started and fell out of bed.
+‘Alas, wife!’ said he, ‘cannot you be easy with being pope?’ ‘No,’
+said she, ‘I am very uneasy as long as the sun and moon rise without my
+leave. Go to the fish at once!’
+
+Then the man went shivering with fear; and as he was going down to
+the shore a dreadful storm arose, so that the trees and the very rocks
+shook. And all the heavens became black with stormy clouds, and the
+lightnings played, and the thunders rolled; and you might have seen in
+the sea great black waves, swelling up like mountains with crowns of
+white foam upon their heads. And the fisherman crept towards the sea,
+and cried out, as well as he could:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said he, ‘she wants to
+be lord of the sun and moon.’ ‘Go home,’ said the fish, ‘to your pigsty
+again.’
+
+And there they live to this very day.
+
+
+
+
+THE WILLOW-WREN AND THE BEAR
+
+Once in summer-time the bear and the wolf were walking in the forest,
+and the bear heard a bird singing so beautifully that he said: ‘Brother
+wolf, what bird is it that sings so well?’ ‘That is the King of birds,’
+said the wolf, ‘before whom we must bow down.’ In reality the bird was
+the willow-wren. ‘IF that’s the case,’ said the bear, ‘I should very
+much like to see his royal palace; come, take me thither.’ ‘That is not
+done quite as you seem to think,’ said the wolf; ‘you must wait until
+the Queen comes,’ Soon afterwards, the Queen arrived with some food in
+her beak, and the lord King came too, and they began to feed their young
+ones. The bear would have liked to go at once, but the wolf held him
+back by the sleeve, and said: ‘No, you must wait until the lord and lady
+Queen have gone away again.’ So they took stock of the hole where the
+nest lay, and trotted away. The bear, however, could not rest until he
+had seen the royal palace, and when a short time had passed, went to it
+again. The King and Queen had just flown out, so he peeped in and saw
+five or six young ones lying there. ‘Is that the royal palace?’ cried
+the bear; ‘it is a wretched palace, and you are not King’s children, you
+are disreputable children!’ When the young wrens heard that, they were
+frightfully angry, and screamed: ‘No, that we are not! Our parents are
+honest people! Bear, you will have to pay for that!’
+
+The bear and the wolf grew uneasy, and turned back and went into their
+holes. The young willow-wrens, however, continued to cry and scream, and
+when their parents again brought food they said: ‘We will not so much as
+touch one fly’s leg, no, not if we were dying of hunger, until you have
+settled whether we are respectable children or not; the bear has been
+here and has insulted us!’ Then the old King said: ‘Be easy, he shall
+be punished,’ and he at once flew with the Queen to the bear’s cave, and
+called in: ‘Old Growler, why have you insulted my children? You shall
+suffer for it--we will punish you by a bloody war.’ Thus war was
+announced to the Bear, and all four-footed animals were summoned to take
+part in it, oxen, asses, cows, deer, and every other animal the earth
+contained. And the willow-wren summoned everything which flew in the
+air, not only birds, large and small, but midges, and hornets, bees and
+flies had to come.
+
+When the time came for the war to begin, the willow-wren sent out spies
+to discover who was the enemy’s commander-in-chief. The gnat, who was
+the most crafty, flew into the forest where the enemy was assembled,
+and hid herself beneath a leaf of the tree where the password was to be
+announced. There stood the bear, and he called the fox before him
+and said: ‘Fox, you are the most cunning of all animals, you shall be
+general and lead us.’ ‘Good,’ said the fox, ‘but what signal shall we
+agree upon?’ No one knew that, so the fox said: ‘I have a fine long
+bushy tail, which almost looks like a plume of red feathers. When I lift
+my tail up quite high, all is going well, and you must charge; but if I
+let it hang down, run away as fast as you can.’ When the gnat had heard
+that, she flew away again, and revealed everything, down to the minutest
+detail, to the willow-wren. When day broke, and the battle was to begin,
+all the four-footed animals came running up with such a noise that the
+earth trembled. The willow-wren with his army also came flying through
+the air with such a humming, and whirring, and swarming that every one
+was uneasy and afraid, and on both sides they advanced against each
+other. But the willow-wren sent down the hornet, with orders to settle
+beneath the fox’s tail, and sting with all his might. When the fox felt
+the first string, he started so that he lifted one leg, from pain, but
+he bore it, and still kept his tail high in the air; at the second
+sting, he was forced to put it down for a moment; at the third, he could
+hold out no longer, screamed, and put his tail between his legs. When
+the animals saw that, they thought all was lost, and began to flee, each
+into his hole, and the birds had won the battle.
+
+Then the King and Queen flew home to their children and cried:
+‘Children, rejoice, eat and drink to your heart’s content, we have won
+the battle!’ But the young wrens said: ‘We will not eat yet, the bear
+must come to the nest, and beg for pardon and say that we are honourable
+children, before we will do that.’ Then the willow-wren flew to the
+bear’s hole and cried: ‘Growler, you are to come to the nest to my
+children, and beg their pardon, or else every rib of your body shall
+be broken.’ So the bear crept thither in the greatest fear, and begged
+their pardon. And now at last the young wrens were satisfied, and sat
+down together and ate and drank, and made merry till quite late into the
+night.
+
+
+
+
+THE FROG-PRINCE
+
+One fine evening a young princess put on her bonnet and clogs, and went
+out to take a walk by herself in a wood; and when she came to a cool
+spring of water, that rose in the midst of it, she sat herself down
+to rest a while. Now she had a golden ball in her hand, which was her
+favourite plaything; and she was always tossing it up into the air, and
+catching it again as it fell. After a time she threw it up so high that
+she missed catching it as it fell; and the ball bounded away, and rolled
+along upon the ground, till at last it fell down into the spring. The
+princess looked into the spring after her ball, but it was very deep, so
+deep that she could not see the bottom of it. Then she began to bewail
+her loss, and said, ‘Alas! if I could only get my ball again, I would
+give all my fine clothes and jewels, and everything that I have in the
+world.’
+
+Whilst she was speaking, a frog put its head out of the water, and said,
+‘Princess, why do you weep so bitterly?’ ‘Alas!’ said she, ‘what can you
+do for me, you nasty frog? My golden ball has fallen into the spring.’
+The frog said, ‘I want not your pearls, and jewels, and fine clothes;
+but if you will love me, and let me live with you and eat from off
+your golden plate, and sleep upon your bed, I will bring you your ball
+again.’ ‘What nonsense,’ thought the princess, ‘this silly frog is
+talking! He can never even get out of the spring to visit me, though
+he may be able to get my ball for me, and therefore I will tell him he
+shall have what he asks.’ So she said to the frog, ‘Well, if you will
+bring me my ball, I will do all you ask.’ Then the frog put his head
+down, and dived deep under the water; and after a little while he came
+up again, with the ball in his mouth, and threw it on the edge of the
+spring. As soon as the young princess saw her ball, she ran to pick
+it up; and she was so overjoyed to have it in her hand again, that she
+never thought of the frog, but ran home with it as fast as she could.
+The frog called after her, ‘Stay, princess, and take me with you as you
+said,’ But she did not stop to hear a word.
+
+The next day, just as the princess had sat down to dinner, she heard a
+strange noise--tap, tap--plash, plash--as if something was coming up the
+marble staircase: and soon afterwards there was a gentle knock at the
+door, and a little voice cried out and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the princess ran to the door and opened it, and there she saw
+the frog, whom she had quite forgotten. At this sight she was sadly
+frightened, and shutting the door as fast as she could came back to her
+seat. The king, her father, seeing that something had frightened her,
+asked her what was the matter. ‘There is a nasty frog,’ said she, ‘at
+the door, that lifted my ball for me out of the spring this morning: I
+told him that he should live with me here, thinking that he could never
+get out of the spring; but there he is at the door, and he wants to come
+in.’
+
+While she was speaking the frog knocked again at the door, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the king said to the young princess, ‘As you have given your word
+you must keep it; so go and let him in.’ She did so, and the frog hopped
+into the room, and then straight on--tap, tap--plash, plash--from the
+bottom of the room to the top, till he came up close to the table where
+the princess sat. ‘Pray lift me upon chair,’ said he to the princess,
+‘and let me sit next to you.’ As soon as she had done this, the frog
+said, ‘Put your plate nearer to me, that I may eat out of it.’ This
+she did, and when he had eaten as much as he could, he said, ‘Now I am
+tired; carry me upstairs, and put me into your bed.’ And the princess,
+though very unwilling, took him up in her hand, and put him upon the
+pillow of her own bed, where he slept all night long. As soon as it was
+light he jumped up, hopped downstairs, and went out of the house.
+‘Now, then,’ thought the princess, ‘at last he is gone, and I shall be
+troubled with him no more.’
+
+But she was mistaken; for when night came again she heard the same
+tapping at the door; and the frog came once more, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+And when the princess opened the door the frog came in, and slept upon
+her pillow as before, till the morning broke. And the third night he did
+the same. But when the princess awoke on the following morning she was
+astonished to see, instead of the frog, a handsome prince, gazing on her
+with the most beautiful eyes she had ever seen, and standing at the head
+of her bed.
+
+He told her that he had been enchanted by a spiteful fairy, who had
+changed him into a frog; and that he had been fated so to abide till
+some princess should take him out of the spring, and let him eat from
+her plate, and sleep upon her bed for three nights. ‘You,’ said the
+prince, ‘have broken his cruel charm, and now I have nothing to wish for
+but that you should go with me into my father’s kingdom, where I will
+marry you, and love you as long as you live.’
+
+The young princess, you may be sure, was not long in saying ‘Yes’ to
+all this; and as they spoke a gay coach drove up, with eight beautiful
+horses, decked with plumes of feathers and a golden harness; and behind
+the coach rode the prince’s servant, faithful Heinrich, who had bewailed
+the misfortunes of his dear master during his enchantment so long and so
+bitterly, that his heart had well-nigh burst.
+
+They then took leave of the king, and got into the coach with eight
+horses, and all set out, full of joy and merriment, for the prince’s
+kingdom, which they reached safely; and there they lived happily a great
+many years.
+
+
+
+
+CAT AND MOUSE IN PARTNERSHIP
+
+A certain cat had made the acquaintance of a mouse, and had said so much
+to her about the great love and friendship she felt for her, that at
+length the mouse agreed that they should live and keep house together.
+‘But we must make a provision for winter, or else we shall suffer
+from hunger,’ said the cat; ‘and you, little mouse, cannot venture
+everywhere, or you will be caught in a trap some day.’ The good advice
+was followed, and a pot of fat was bought, but they did not know where
+to put it. At length, after much consideration, the cat said: ‘I know no
+place where it will be better stored up than in the church, for no one
+dares take anything away from there. We will set it beneath the altar,
+and not touch it until we are really in need of it.’ So the pot was
+placed in safety, but it was not long before the cat had a great
+yearning for it, and said to the mouse: ‘I want to tell you something,
+little mouse; my cousin has brought a little son into the world, and has
+asked me to be godmother; he is white with brown spots, and I am to hold
+him over the font at the christening. Let me go out today, and you look
+after the house by yourself.’ ‘Yes, yes,’ answered the mouse, ‘by all
+means go, and if you get anything very good to eat, think of me. I
+should like a drop of sweet red christening wine myself.’ All this,
+however, was untrue; the cat had no cousin, and had not been asked to
+be godmother. She went straight to the church, stole to the pot of fat,
+began to lick at it, and licked the top of the fat off. Then she took a
+walk upon the roofs of the town, looked out for opportunities, and then
+stretched herself in the sun, and licked her lips whenever she thought
+of the pot of fat, and not until it was evening did she return home.
+‘Well, here you are again,’ said the mouse, ‘no doubt you have had a
+merry day.’ ‘All went off well,’ answered the cat. ‘What name did they
+give the child?’ ‘Top off!’ said the cat quite coolly. ‘Top off!’ cried
+the mouse, ‘that is a very odd and uncommon name, is it a usual one in
+your family?’ ‘What does that matter,’ said the cat, ‘it is no worse
+than Crumb-stealer, as your godchildren are called.’
+
+Before long the cat was seized by another fit of yearning. She said to
+the mouse: ‘You must do me a favour, and once more manage the house for
+a day alone. I am again asked to be godmother, and, as the child has a
+white ring round its neck, I cannot refuse.’ The good mouse consented,
+but the cat crept behind the town walls to the church, and devoured
+half the pot of fat. ‘Nothing ever seems so good as what one keeps to
+oneself,’ said she, and was quite satisfied with her day’s work. When
+she went home the mouse inquired: ‘And what was the child christened?’
+‘Half-done,’ answered the cat. ‘Half-done! What are you saying? I
+never heard the name in my life, I’ll wager anything it is not in the
+calendar!’
+
+The cat’s mouth soon began to water for some more licking. ‘All good
+things go in threes,’ said she, ‘I am asked to stand godmother again.
+The child is quite black, only it has white paws, but with that
+exception, it has not a single white hair on its whole body; this only
+happens once every few years, you will let me go, won’t you?’ ‘Top-off!
+Half-done!’ answered the mouse, ‘they are such odd names, they make me
+very thoughtful.’ ‘You sit at home,’ said the cat, ‘in your dark-grey
+fur coat and long tail, and are filled with fancies, that’s because
+you do not go out in the daytime.’ During the cat’s absence the mouse
+cleaned the house, and put it in order, but the greedy cat entirely
+emptied the pot of fat. ‘When everything is eaten up one has some
+peace,’ said she to herself, and well filled and fat she did not return
+home till night. The mouse at once asked what name had been given to
+the third child. ‘It will not please you more than the others,’ said the
+cat. ‘He is called All-gone.’ ‘All-gone,’ cried the mouse ‘that is the
+most suspicious name of all! I have never seen it in print. All-gone;
+what can that mean?’ and she shook her head, curled herself up, and lay
+down to sleep.
+
+From this time forth no one invited the cat to be godmother, but
+when the winter had come and there was no longer anything to be found
+outside, the mouse thought of their provision, and said: ‘Come, cat,
+we will go to our pot of fat which we have stored up for ourselves--we
+shall enjoy that.’ ‘Yes,’ answered the cat, ‘you will enjoy it as much
+as you would enjoy sticking that dainty tongue of yours out of the
+window.’ They set out on their way, but when they arrived, the pot of
+fat certainly was still in its place, but it was empty. ‘Alas!’ said the
+mouse, ‘now I see what has happened, now it comes to light! You are a true
+friend! You have devoured all when you were standing godmother. First
+top off, then half-done, then--’ ‘Will you hold your tongue,’ cried the
+cat, ‘one word more, and I will eat you too.’ ‘All-gone’ was already on
+the poor mouse’s lips; scarcely had she spoken it before the cat sprang
+on her, seized her, and swallowed her down. Verily, that is the way of
+the world.
+
+
+
+
+THE GOOSE-GIRL
+
+The king of a great land died, and left his queen to take care of their
+only child. This child was a daughter, who was very beautiful; and her
+mother loved her dearly, and was very kind to her. And there was a good
+fairy too, who was fond of the princess, and helped her mother to watch
+over her. When she grew up, she was betrothed to a prince who lived a
+great way off; and as the time drew near for her to be married, she
+got ready to set off on her journey to his country. Then the queen her
+mother, packed up a great many costly things; jewels, and gold, and
+silver; trinkets, fine dresses, and in short everything that became a
+royal bride. And she gave her a waiting-maid to ride with her, and give
+her into the bridegroom’s hands; and each had a horse for the journey.
+Now the princess’s horse was the fairy’s gift, and it was called Falada,
+and could speak.
+
+When the time came for them to set out, the fairy went into her
+bed-chamber, and took a little knife, and cut off a lock of her hair,
+and gave it to the princess, and said, ‘Take care of it, dear child; for
+it is a charm that may be of use to you on the road.’ Then they all took
+a sorrowful leave of the princess; and she put the lock of hair into
+her bosom, got upon her horse, and set off on her journey to her
+bridegroom’s kingdom.
+
+One day, as they were riding along by a brook, the princess began to
+feel very thirsty: and she said to her maid, ‘Pray get down, and fetch
+me some water in my golden cup out of yonder brook, for I want to
+drink.’ ‘Nay,’ said the maid, ‘if you are thirsty, get off yourself, and
+stoop down by the water and drink; I shall not be your waiting-maid any
+longer.’ Then she was so thirsty that she got down, and knelt over the
+little brook, and drank; for she was frightened, and dared not bring out
+her golden cup; and she wept and said, ‘Alas! what will become of me?’
+And the lock answered her, and said:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+But the princess was very gentle and meek, so she said nothing to her
+maid’s ill behaviour, but got upon her horse again.
+
+Then all rode farther on their journey, till the day grew so warm, and
+the sun so scorching, that the bride began to feel very thirsty again;
+and at last, when they came to a river, she forgot her maid’s rude
+speech, and said, ‘Pray get down, and fetch me some water to drink in
+my golden cup.’ But the maid answered her, and even spoke more haughtily
+than before: ‘Drink if you will, but I shall not be your waiting-maid.’
+Then the princess was so thirsty that she got off her horse, and lay
+down, and held her head over the running stream, and cried and said,
+‘What will become of me?’ And the lock of hair answered her again:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And as she leaned down to drink, the lock of hair fell from her bosom,
+and floated away with the water. Now she was so frightened that she did
+not see it; but her maid saw it, and was very glad, for she knew the
+charm; and she saw that the poor bride would be in her power, now that
+she had lost the hair. So when the bride had done drinking, and would
+have got upon Falada again, the maid said, ‘I shall ride upon Falada,
+and you may have my horse instead’; so she was forced to give up her
+horse, and soon afterwards to take off her royal clothes and put on her
+maid’s shabby ones.
+
+At last, as they drew near the end of their journey, this treacherous
+servant threatened to kill her mistress if she ever told anyone what had
+happened. But Falada saw it all, and marked it well.
+
+Then the waiting-maid got upon Falada, and the real bride rode upon the
+other horse, and they went on in this way till at last they came to the
+royal court. There was great joy at their coming, and the prince flew to
+meet them, and lifted the maid from her horse, thinking she was the one
+who was to be his wife; and she was led upstairs to the royal chamber;
+but the true princess was told to stay in the court below.
+
+Now the old king happened just then to have nothing else to do; so he
+amused himself by sitting at his kitchen window, looking at what was
+going on; and he saw her in the courtyard. As she looked very pretty,
+and too delicate for a waiting-maid, he went up into the royal chamber
+to ask the bride who it was she had brought with her, that was thus left
+standing in the court below. ‘I brought her with me for the sake of her
+company on the road,’ said she; ‘pray give the girl some work to do,
+that she may not be idle.’ The old king could not for some time think
+of any work for her to do; but at last he said, ‘I have a lad who takes
+care of my geese; she may go and help him.’ Now the name of this lad,
+that the real bride was to help in watching the king’s geese, was
+Curdken.
+
+But the false bride said to the prince, ‘Dear husband, pray do me one
+piece of kindness.’ ‘That I will,’ said the prince. ‘Then tell one of
+your slaughterers to cut off the head of the horse I rode upon, for it
+was very unruly, and plagued me sadly on the road’; but the truth was,
+she was very much afraid lest Falada should some day or other speak, and
+tell all she had done to the princess. She carried her point, and the
+faithful Falada was killed; but when the true princess heard of it, she
+wept, and begged the man to nail up Falada’s head against a large
+dark gate of the city, through which she had to pass every morning
+and evening, that there she might still see him sometimes. Then the
+slaughterer said he would do as she wished; and cut off the head, and
+nailed it up under the dark gate.
+
+Early the next morning, as she and Curdken went out through the gate,
+she said sorrowfully:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then they went out of the city, and drove the geese on. And when she
+came to the meadow, she sat down upon a bank there, and let down her
+waving locks of hair, which were all of pure silver; and when Curdken
+saw it glitter in the sun, he ran up, and would have pulled some of the
+locks out, but she cried:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then there came a wind, so strong that it blew off Curdken’s hat; and
+away it flew over the hills: and he was forced to turn and run after
+it; till, by the time he came back, she had done combing and curling her
+hair, and had put it up again safe. Then he was very angry and sulky,
+and would not speak to her at all; but they watched the geese until it
+grew dark in the evening, and then drove them homewards.
+
+The next morning, as they were going through the dark gate, the poor
+girl looked up at Falada’s head, and cried:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then she drove on the geese, and sat down again in the meadow, and began
+to comb out her hair as before; and Curdken ran up to her, and wanted to
+take hold of it; but she cried out quickly:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then the wind came and blew away his hat; and off it flew a great way,
+over the hills and far away, so that he had to run after it; and when
+he came back she had bound up her hair again, and all was safe. So they
+watched the geese till it grew dark.
+
+In the evening, after they came home, Curdken went to the old king, and
+said, ‘I cannot have that strange girl to help me to keep the geese any
+longer.’ ‘Why?’ said the king. ‘Because, instead of doing any good, she
+does nothing but tease me all day long.’ Then the king made him tell him
+what had happened. And Curdken said, ‘When we go in the morning through
+the dark gate with our flock of geese, she cries and talks with the head
+of a horse that hangs upon the wall, and says:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answers:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And Curdken went on telling the king what had happened upon the meadow
+where the geese fed; how his hat was blown away; and how he was forced
+to run after it, and to leave his flock of geese to themselves. But the
+old king told the boy to go out again the next day: and when morning
+came, he placed himself behind the dark gate, and heard how she spoke
+to Falada, and how Falada answered. Then he went into the field, and
+hid himself in a bush by the meadow’s side; and he soon saw with his own
+eyes how they drove the flock of geese; and how, after a little time,
+she let down her hair that glittered in the sun. And then he heard her
+say:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+And soon came a gale of wind, and carried away Curdken’s hat, and away
+went Curdken after it, while the girl went on combing and curling her
+hair. All this the old king saw: so he went home without being seen; and
+when the little goose-girl came back in the evening he called her aside,
+and asked her why she did so: but she burst into tears, and said, ‘That
+I must not tell you or any man, or I shall lose my life.’
+
+But the old king begged so hard, that she had no peace till she had told
+him all the tale, from beginning to end, word for word. And it was very
+lucky for her that she did so, for when she had done the king ordered
+royal clothes to be put upon her, and gazed on her with wonder, she was
+so beautiful. Then he called his son and told him that he had only a
+false bride; for that she was merely a waiting-maid, while the true
+bride stood by. And the young king rejoiced when he saw her beauty, and
+heard how meek and patient she had been; and without saying anything to
+the false bride, the king ordered a great feast to be got ready for all
+his court. The bridegroom sat at the top, with the false princess on one
+side, and the true one on the other; but nobody knew her again, for her
+beauty was quite dazzling to their eyes; and she did not seem at all
+like the little goose-girl, now that she had her brilliant dress on.
+
+When they had eaten and drank, and were very merry, the old king said
+he would tell them a tale. So he began, and told all the story of the
+princess, as if it was one that he had once heard; and he asked the
+true waiting-maid what she thought ought to be done to anyone who would
+behave thus. ‘Nothing better,’ said this false bride, ‘than that she
+should be thrown into a cask stuck round with sharp nails, and that
+two white horses should be put to it, and should drag it from street to
+street till she was dead.’ ‘Thou art she!’ said the old king; ‘and as
+thou has judged thyself, so shall it be done to thee.’ And the young
+king was then married to his true wife, and they reigned over the
+kingdom in peace and happiness all their lives; and the good fairy came
+to see them, and restored the faithful Falada to life again.
+
+
+
+
+THE ADVENTURES OF CHANTICLEER AND PARTLET
+
+
+1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+
+‘The nuts are quite ripe now,’ said Chanticleer to his wife Partlet,
+‘suppose we go together to the mountains, and eat as many as we can,
+before the squirrel takes them all away.’ ‘With all my heart,’ said
+Partlet, ‘let us go and make a holiday of it together.’
+
+So they went to the mountains; and as it was a lovely day, they stayed
+there till the evening. Now, whether it was that they had eaten so many
+nuts that they could not walk, or whether they were lazy and would not,
+I do not know: however, they took it into their heads that it did not
+become them to go home on foot. So Chanticleer began to build a little
+carriage of nutshells: and when it was finished, Partlet jumped into
+it and sat down, and bid Chanticleer harness himself to it and draw her
+home. ‘That’s a good joke!’ said Chanticleer; ‘no, that will never do;
+I had rather by half walk home; I’ll sit on the box and be coachman,
+if you like, but I’ll not draw.’ While this was passing, a duck came
+quacking up and cried out, ‘You thieving vagabonds, what business have
+you in my grounds? I’ll give it you well for your insolence!’ and upon
+that she fell upon Chanticleer most lustily. But Chanticleer was no
+coward, and returned the duck’s blows with his sharp spurs so fiercely
+that she soon began to cry out for mercy; which was only granted her
+upon condition that she would draw the carriage home for them. This she
+agreed to do; and Chanticleer got upon the box, and drove, crying, ‘Now,
+duck, get on as fast as you can.’ And away they went at a pretty good
+pace.
+
+After they had travelled along a little way, they met a needle and a pin
+walking together along the road: and the needle cried out, ‘Stop, stop!’
+and said it was so dark that they could hardly find their way, and such
+dirty walking they could not get on at all: he told them that he and his
+friend, the pin, had been at a public-house a few miles off, and had sat
+drinking till they had forgotten how late it was; he begged therefore
+that the travellers would be so kind as to give them a lift in their
+carriage. Chanticleer observing that they were but thin fellows, and not
+likely to take up much room, told them they might ride, but made them
+promise not to dirty the wheels of the carriage in getting in, nor to
+tread on Partlet’s toes.
+
+Late at night they arrived at an inn; and as it was bad travelling in
+the dark, and the duck seemed much tired, and waddled about a good
+deal from one side to the other, they made up their minds to fix their
+quarters there: but the landlord at first was unwilling, and said his
+house was full, thinking they might not be very respectable company:
+however, they spoke civilly to him, and gave him the egg which Partlet
+had laid by the way, and said they would give him the duck, who was in
+the habit of laying one every day: so at last he let them come in, and
+they bespoke a handsome supper, and spent the evening very jollily.
+
+Early in the morning, before it was quite light, and when nobody was
+stirring in the inn, Chanticleer awakened his wife, and, fetching the
+egg, they pecked a hole in it, ate it up, and threw the shells into the
+fireplace: they then went to the pin and needle, who were fast asleep,
+and seizing them by the heads, stuck one into the landlord’s easy chair
+and the other into his handkerchief; and, having done this, they crept
+away as softly as possible. However, the duck, who slept in the open
+air in the yard, heard them coming, and jumping into the brook which ran
+close by the inn, soon swam out of their reach.
+
+An hour or two afterwards the landlord got up, and took his handkerchief
+to wipe his face, but the pin ran into him and pricked him: then he
+walked into the kitchen to light his pipe at the fire, but when he
+stirred it up the eggshells flew into his eyes, and almost blinded him.
+‘Bless me!’ said he, ‘all the world seems to have a design against my
+head this morning’: and so saying, he threw himself sulkily into his
+easy chair; but, oh dear! the needle ran into him; and this time the
+pain was not in his head. He now flew into a very great passion, and,
+suspecting the company who had come in the night before, he went to look
+after them, but they were all off; so he swore that he never again
+would take in such a troop of vagabonds, who ate a great deal, paid no
+reckoning, and gave him nothing for his trouble but their apish tricks.
+
+
+2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+
+Another day, Chanticleer and Partlet wished to ride out together;
+so Chanticleer built a handsome carriage with four red wheels, and
+harnessed six mice to it; and then he and Partlet got into the carriage,
+and away they drove. Soon afterwards a cat met them, and said, ‘Where
+are you going?’ And Chanticleer replied,
+
+ ‘All on our way
+  A visit to pay
+  To Mr Korbes, the fox, today.’
+
+Then the cat said, ‘Take me with you,’ Chanticleer said, ‘With all my
+heart: get up behind, and be sure you do not fall off.’
+
+ ‘Take care of this handsome coach of mine,
+  Nor dirty my pretty red wheels so fine!
+  Now, mice, be ready,
+  And, wheels, run steady!
+  For we are going a visit to pay
+  To Mr Korbes, the fox, today.’
+
+Soon after came up a millstone, an egg, a duck, and a pin; and
+Chanticleer gave them all leave to get into the carriage and go with
+them.
+
+When they arrived at Mr Korbes’s house, he was not at home; so the mice
+drew the carriage into the coach-house, Chanticleer and Partlet flew
+upon a beam, the cat sat down in the fireplace, the duck got into
+the washing cistern, the pin stuck himself into the bed pillow, the
+millstone laid himself over the house door, and the egg rolled himself
+up in the towel.
+
+When Mr Korbes came home, he went to the fireplace to make a fire; but
+the cat threw all the ashes in his eyes: so he ran to the kitchen to
+wash himself; but there the duck splashed all the water in his face; and
+when he tried to wipe himself, the egg broke to pieces in the towel all
+over his face and eyes. Then he was very angry, and went without his
+supper to bed; but when he laid his head on the pillow, the pin ran into
+his cheek: at this he became quite furious, and, jumping up, would have
+run out of the house; but when he came to the door, the millstone fell
+down on his head, and killed him on the spot.
+
+
+3. HOW PARTLET DIED AND WAS BURIED, AND HOW CHANTICLEER DIED OF GRIEF
+
+Another day Chanticleer and Partlet agreed to go again to the mountains
+to eat nuts; and it was settled that all the nuts which they found
+should be shared equally between them. Now Partlet found a very large
+nut; but she said nothing about it to Chanticleer, and kept it all to
+herself: however, it was so big that she could not swallow it, and it
+stuck in her throat. Then she was in a great fright, and cried out to
+Chanticleer, ‘Pray run as fast as you can, and fetch me some water, or I
+shall be choked.’ Chanticleer ran as fast as he could to the river, and
+said, ‘River, give me some water, for Partlet lies in the mountain, and
+will be choked by a great nut.’ The river said, ‘Run first to the bride,
+and ask her for a silken cord to draw up the water.’ Chanticleer ran to
+the bride, and said, ‘Bride, you must give me a silken cord, for then
+the river will give me water, and the water I will carry to Partlet, who
+lies on the mountain, and will be choked by a great nut.’ But the bride
+said, ‘Run first, and bring me my garland that is hanging on a willow
+in the garden.’ Then Chanticleer ran to the garden, and took the garland
+from the bough where it hung, and brought it to the bride; and then
+the bride gave him the silken cord, and he took the silken cord to
+the river, and the river gave him water, and he carried the water to
+Partlet; but in the meantime she was choked by the great nut, and lay
+quite dead, and never moved any more.
+
+Then Chanticleer was very sorry, and cried bitterly; and all the beasts
+came and wept with him over poor Partlet. And six mice built a little
+hearse to carry her to her grave; and when it was ready they harnessed
+themselves before it, and Chanticleer drove them. On the way they
+met the fox. ‘Where are you going, Chanticleer?’ said he. ‘To bury my
+Partlet,’ said the other. ‘May I go with you?’ said the fox. ‘Yes; but
+you must get up behind, or my horses will not be able to draw you.’ Then
+the fox got up behind; and presently the wolf, the bear, the goat, and
+all the beasts of the wood, came and climbed upon the hearse.
+
+So on they went till they came to a rapid stream. ‘How shall we get
+over?’ said Chanticleer. Then said a straw, ‘I will lay myself across,
+and you may pass over upon me.’ But as the mice were going over, the
+straw slipped away and fell into the water, and the six mice all fell in
+and were drowned. What was to be done? Then a large log of wood came
+and said, ‘I am big enough; I will lay myself across the stream, and you
+shall pass over upon me.’ So he laid himself down; but they managed
+so clumsily, that the log of wood fell in and was carried away by the
+stream. Then a stone, who saw what had happened, came up and kindly
+offered to help poor Chanticleer by laying himself across the stream;
+and this time he got safely to the other side with the hearse, and
+managed to get Partlet out of it; but the fox and the other mourners,
+who were sitting behind, were too heavy, and fell back into the water
+and were all carried away by the stream and drowned.
+
+Thus Chanticleer was left alone with his dead Partlet; and having dug
+a grave for her, he laid her in it, and made a little hillock over her.
+Then he sat down by the grave, and wept and mourned, till at last he
+died too; and so all were dead.
+
+
+
+
+RAPUNZEL
+
+There were once a man and a woman who had long in vain wished for a
+child. At length the woman hoped that God was about to grant her desire.
+These people had a little window at the back of their house from which
+a splendid garden could be seen, which was full of the most beautiful
+flowers and herbs. It was, however, surrounded by a high wall, and no
+one dared to go into it because it belonged to an enchantress, who had
+great power and was dreaded by all the world. One day the woman was
+standing by this window and looking down into the garden, when she saw a
+bed which was planted with the most beautiful rampion (rapunzel), and it
+looked so fresh and green that she longed for it, she quite pined away,
+and began to look pale and miserable. Then her husband was alarmed, and
+asked: ‘What ails you, dear wife?’ ‘Ah,’ she replied, ‘if I can’t eat
+some of the rampion, which is in the garden behind our house, I shall
+die.’ The man, who loved her, thought: ‘Sooner than let your wife die,
+bring her some of the rampion yourself, let it cost what it will.’
+At twilight, he clambered down over the wall into the garden of the
+enchantress, hastily clutched a handful of rampion, and took it to his
+wife. She at once made herself a salad of it, and ate it greedily. It
+tasted so good to her--so very good, that the next day she longed for it
+three times as much as before. If he was to have any rest, her husband
+must once more descend into the garden. In the gloom of evening
+therefore, he let himself down again; but when he had clambered down the
+wall he was terribly afraid, for he saw the enchantress standing before
+him. ‘How can you dare,’ said she with angry look, ‘descend into my
+garden and steal my rampion like a thief? You shall suffer for it!’
+‘Ah,’ answered he, ‘let mercy take the place of justice, I only made
+up my mind to do it out of necessity. My wife saw your rampion from the
+window, and felt such a longing for it that she would have died if she
+had not got some to eat.’ Then the enchantress allowed her anger to be
+softened, and said to him: ‘If the case be as you say, I will allow
+you to take away with you as much rampion as you will, only I make one
+condition, you must give me the child which your wife will bring into
+the world; it shall be well treated, and I will care for it like a
+mother.’ The man in his terror consented to everything, and when the
+woman was brought to bed, the enchantress appeared at once, gave the
+child the name of Rapunzel, and took it away with her.
+
+Rapunzel grew into the most beautiful child under the sun. When she was
+twelve years old, the enchantress shut her into a tower, which lay in
+a forest, and had neither stairs nor door, but quite at the top was a
+little window. When the enchantress wanted to go in, she placed herself
+beneath it and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Rapunzel had magnificent long hair, fine as spun gold, and when she
+heard the voice of the enchantress she unfastened her braided tresses,
+wound them round one of the hooks of the window above, and then the hair
+fell twenty ells down, and the enchantress climbed up by it.
+
+After a year or two, it came to pass that the king’s son rode through
+the forest and passed by the tower. Then he heard a song, which was so
+charming that he stood still and listened. This was Rapunzel, who in her
+solitude passed her time in letting her sweet voice resound. The king’s
+son wanted to climb up to her, and looked for the door of the tower,
+but none was to be found. He rode home, but the singing had so deeply
+touched his heart, that every day he went out into the forest and
+listened to it. Once when he was thus standing behind a tree, he saw
+that an enchantress came there, and he heard how she cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Then Rapunzel let down the braids of her hair, and the enchantress
+climbed up to her. ‘If that is the ladder by which one mounts, I too
+will try my fortune,’ said he, and the next day when it began to grow
+dark, he went to the tower and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Immediately the hair fell down and the king’s son climbed up.
+
+At first Rapunzel was terribly frightened when a man, such as her eyes
+had never yet beheld, came to her; but the king’s son began to talk to
+her quite like a friend, and told her that his heart had been so stirred
+that it had let him have no rest, and he had been forced to see her.
+Then Rapunzel lost her fear, and when he asked her if she would take
+him for her husband, and she saw that he was young and handsome, she
+thought: ‘He will love me more than old Dame Gothel does’; and she said
+yes, and laid her hand in his. She said: ‘I will willingly go away with
+you, but I do not know how to get down. Bring with you a skein of silk
+every time that you come, and I will weave a ladder with it, and when
+that is ready I will descend, and you will take me on your horse.’ They
+agreed that until that time he should come to her every evening, for the
+old woman came by day. The enchantress remarked nothing of this, until
+once Rapunzel said to her: ‘Tell me, Dame Gothel, how it happens that
+you are so much heavier for me to draw up than the young king’s son--he
+is with me in a moment.’ ‘Ah! you wicked child,’ cried the enchantress.
+‘What do I hear you say! I thought I had separated you from all
+the world, and yet you have deceived me!’ In her anger she clutched
+Rapunzel’s beautiful tresses, wrapped them twice round her left hand,
+seized a pair of scissors with the right, and snip, snap, they were cut
+off, and the lovely braids lay on the ground. And she was so pitiless
+that she took poor Rapunzel into a desert where she had to live in great
+grief and misery.
+
+On the same day that she cast out Rapunzel, however, the enchantress
+fastened the braids of hair, which she had cut off, to the hook of the
+window, and when the king’s son came and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+she let the hair down. The king’s son ascended, but instead of finding
+his dearest Rapunzel, he found the enchantress, who gazed at him with
+wicked and venomous looks. ‘Aha!’ she cried mockingly, ‘you would fetch
+your dearest, but the beautiful bird sits no longer singing in the nest;
+the cat has got it, and will scratch out your eyes as well. Rapunzel is
+lost to you; you will never see her again.’ The king’s son was beside
+himself with pain, and in his despair he leapt down from the tower. He
+escaped with his life, but the thorns into which he fell pierced his
+eyes. Then he wandered quite blind about the forest, ate nothing but
+roots and berries, and did naught but lament and weep over the loss of
+his dearest wife. Thus he roamed about in misery for some years, and at
+length came to the desert where Rapunzel, with the twins to which she
+had given birth, a boy and a girl, lived in wretchedness. He heard a
+voice, and it seemed so familiar to him that he went towards it, and
+when he approached, Rapunzel knew him and fell on his neck and wept. Two
+of her tears wetted his eyes and they grew clear again, and he could
+see with them as before. He led her to his kingdom where he was
+joyfully received, and they lived for a long time afterwards, happy and
+contented.
+
+
+
+
+FUNDEVOGEL
+
+There was once a forester who went into the forest to hunt, and as
+he entered it he heard a sound of screaming as if a little child were
+there. He followed the sound, and at last came to a high tree, and at
+the top of this a little child was sitting, for the mother had fallen
+asleep under the tree with the child, and a bird of prey had seen it in
+her arms, had flown down, snatched it away, and set it on the high tree.
+
+The forester climbed up, brought the child down, and thought to himself:
+‘You will take him home with you, and bring him up with your Lina.’ He
+took it home, therefore, and the two children grew up together. And the
+one, which he had found on a tree was called Fundevogel, because a bird
+had carried it away. Fundevogel and Lina loved each other so dearly that
+when they did not see each other they were sad.
+
+Now the forester had an old cook, who one evening took two pails and
+began to fetch water, and did not go once only, but many times, out
+to the spring. Lina saw this and said, ‘Listen, old Sanna, why are you
+fetching so much water?’ ‘If you will never repeat it to anyone, I will
+tell you why.’ So Lina said, no, she would never repeat it to anyone,
+and then the cook said: ‘Early tomorrow morning, when the forester
+is out hunting, I will heat the water, and when it is boiling in the
+kettle, I will throw in Fundevogel, and will boil him in it.’
+
+Early next morning the forester got up and went out hunting, and when he
+was gone the children were still in bed. Then Lina said to Fundevogel:
+‘If you will never leave me, I too will never leave you.’ Fundevogel
+said: ‘Neither now, nor ever will I leave you.’ Then said Lina: ‘Then
+will I tell you. Last night, old Sanna carried so many buckets of water
+into the house that I asked her why she was doing that, and she said
+that if I would promise not to tell anyone, and she said that early
+tomorrow morning when father was out hunting, she would set the kettle
+full of water, throw you into it and boil you; but we will get up
+quickly, dress ourselves, and go away together.’
+
+The two children therefore got up, dressed themselves quickly, and went
+away. When the water in the kettle was boiling, the cook went into the
+bedroom to fetch Fundevogel and throw him into it. But when she came in,
+and went to the beds, both the children were gone. Then she was terribly
+alarmed, and she said to herself: ‘What shall I say now when the
+forester comes home and sees that the children are gone? They must be
+followed instantly to get them back again.’
+
+Then the cook sent three servants after them, who were to run and
+overtake the children. The children, however, were sitting outside the
+forest, and when they saw from afar the three servants running, Lina
+said to Fundevogel: ‘Never leave me, and I will never leave you.’
+Fundevogel said: ‘Neither now, nor ever.’ Then said Lina: ‘Do you become
+a rose-tree, and I the rose upon it.’ When the three servants came to
+the forest, nothing was there but a rose-tree and one rose on it, but
+the children were nowhere. Then said they: ‘There is nothing to be done
+here,’ and they went home and told the cook that they had seen nothing
+in the forest but a little rose-bush with one rose on it. Then the
+old cook scolded and said: ‘You simpletons, you should have cut the
+rose-bush in two, and have broken off the rose and brought it home with
+you; go, and do it at once.’ They had therefore to go out and look for
+the second time. The children, however, saw them coming from a distance.
+Then Lina said: ‘Fundevogel, never leave me, and I will never leave
+you.’ Fundevogel said: ‘Neither now; nor ever.’ Said Lina: ‘Then do you
+become a church, and I’ll be the chandelier in it.’ So when the three
+servants came, nothing was there but a church, with a chandelier in
+it. They said therefore to each other: ‘What can we do here, let us go
+home.’ When they got home, the cook asked if they had not found them;
+so they said no, they had found nothing but a church, and there was a
+chandelier in it. And the cook scolded them and said: ‘You fools! why
+did you not pull the church to pieces, and bring the chandelier home
+with you?’ And now the old cook herself got on her legs, and went with
+the three servants in pursuit of the children. The children, however,
+saw from afar that the three servants were coming, and the cook waddling
+after them. Then said Lina: ‘Fundevogel, never leave me, and I will
+never leave you.’ Then said Fundevogel: ‘Neither now, nor ever.’
+Said Lina: ‘Be a fishpond, and I will be the duck upon it.’ The cook,
+however, came up to them, and when she saw the pond she lay down by it,
+and was about to drink it up. But the duck swam quickly to her, seized
+her head in its beak and drew her into the water, and there the old
+witch had to drown. Then the children went home together, and were
+heartily delighted, and if they have not died, they are living still.
+
+
+
+
+THE VALIANT LITTLE TAILOR
+
+One summer’s morning a little tailor was sitting on his table by the
+window; he was in good spirits, and sewed with all his might. Then came
+a peasant woman down the street crying: ‘Good jams, cheap! Good jams,
+cheap!’ This rang pleasantly in the tailor’s ears; he stretched his
+delicate head out of the window, and called: ‘Come up here, dear woman;
+here you will get rid of your goods.’ The woman came up the three steps
+to the tailor with her heavy basket, and he made her unpack all the pots
+for him. He inspected each one, lifted it up, put his nose to it, and
+at length said: ‘The jam seems to me to be good, so weigh me out four
+ounces, dear woman, and if it is a quarter of a pound that is of no
+consequence.’ The woman who had hoped to find a good sale, gave him
+what he desired, but went away quite angry and grumbling. ‘Now, this jam
+shall be blessed by God,’ cried the little tailor, ‘and give me health
+and strength’; so he brought the bread out of the cupboard, cut himself
+a piece right across the loaf and spread the jam over it. ‘This won’t
+taste bitter,’ said he, ‘but I will just finish the jacket before I
+take a bite.’ He laid the bread near him, sewed on, and in his joy, made
+bigger and bigger stitches. In the meantime the smell of the sweet jam
+rose to where the flies were sitting in great numbers, and they were
+attracted and descended on it in hosts. ‘Hi! who invited you?’ said the
+little tailor, and drove the unbidden guests away. The flies, however,
+who understood no German, would not be turned away, but came back
+again in ever-increasing companies. The little tailor at last lost all
+patience, and drew a piece of cloth from the hole under his work-table,
+and saying: ‘Wait, and I will give it to you,’ struck it mercilessly on
+them. When he drew it away and counted, there lay before him no fewer
+than seven, dead and with legs stretched out. ‘Are you a fellow of that
+sort?’ said he, and could not help admiring his own bravery. ‘The whole
+town shall know of this!’ And the little tailor hastened to cut himself
+a girdle, stitched it, and embroidered on it in large letters: ‘Seven at
+one stroke!’ ‘What, the town!’ he continued, ‘the whole world shall hear
+of it!’ and his heart wagged with joy like a lamb’s tail. The tailor
+put on the girdle, and resolved to go forth into the world, because he
+thought his workshop was too small for his valour. Before he went away,
+he sought about in the house to see if there was anything which he could
+take with him; however, he found nothing but an old cheese, and that
+he put in his pocket. In front of the door he observed a bird which
+had caught itself in the thicket. It had to go into his pocket with the
+cheese. Now he took to the road boldly, and as he was light and nimble,
+he felt no fatigue. The road led him up a mountain, and when he had
+reached the highest point of it, there sat a powerful giant looking
+peacefully about him. The little tailor went bravely up, spoke to him,
+and said: ‘Good day, comrade, so you are sitting there overlooking the
+wide-spread world! I am just on my way thither, and want to try my luck.
+Have you any inclination to go with me?’ The giant looked contemptuously
+at the tailor, and said: ‘You ragamuffin! You miserable creature!’
+
+‘Oh, indeed?’ answered the little tailor, and unbuttoned his coat, and
+showed the giant the girdle, ‘there may you read what kind of a man I
+am!’ The giant read: ‘Seven at one stroke,’ and thought that they had
+been men whom the tailor had killed, and began to feel a little respect
+for the tiny fellow. Nevertheless, he wished to try him first, and took
+a stone in his hand and squeezed it together so that water dropped out
+of it. ‘Do that likewise,’ said the giant, ‘if you have strength.’ ‘Is
+that all?’ said the tailor, ‘that is child’s play with us!’ and put his
+hand into his pocket, brought out the soft cheese, and pressed it until
+the liquid ran out of it. ‘Faith,’ said he, ‘that was a little better,
+wasn’t it?’ The giant did not know what to say, and could not believe it
+of the little man. Then the giant picked up a stone and threw it so high
+that the eye could scarcely follow it. ‘Now, little mite of a man, do
+that likewise,’ ‘Well thrown,’ said the tailor, ‘but after all the stone
+came down to earth again; I will throw you one which shall never come
+back at all,’ and he put his hand into his pocket, took out the bird,
+and threw it into the air. The bird, delighted with its liberty,
+rose, flew away and did not come back. ‘How does that shot please you,
+comrade?’ asked the tailor. ‘You can certainly throw,’ said the giant,
+‘but now we will see if you are able to carry anything properly.’ He
+took the little tailor to a mighty oak tree which lay there felled on
+the ground, and said: ‘If you are strong enough, help me to carry the
+tree out of the forest.’ ‘Readily,’ answered the little man; ‘take you
+the trunk on your shoulders, and I will raise up the branches and twigs;
+after all, they are the heaviest.’ The giant took the trunk on his
+shoulder, but the tailor seated himself on a branch, and the giant, who
+could not look round, had to carry away the whole tree, and the little
+tailor into the bargain: he behind, was quite merry and happy, and
+whistled the song: ‘Three tailors rode forth from the gate,’ as if
+carrying the tree were child’s play. The giant, after he had dragged the
+heavy burden part of the way, could go no further, and cried: ‘Hark
+you, I shall have to let the tree fall!’ The tailor sprang nimbly down,
+seized the tree with both arms as if he had been carrying it, and said
+to the giant: ‘You are such a great fellow, and yet cannot even carry
+the tree!’
+
+They went on together, and as they passed a cherry-tree, the giant laid
+hold of the top of the tree where the ripest fruit was hanging, bent it
+down, gave it into the tailor’s hand, and bade him eat. But the little
+tailor was much too weak to hold the tree, and when the giant let it go,
+it sprang back again, and the tailor was tossed into the air with it.
+When he had fallen down again without injury, the giant said: ‘What is
+this? Have you not strength enough to hold the weak twig?’ ‘There is no
+lack of strength,’ answered the little tailor. ‘Do you think that could
+be anything to a man who has struck down seven at one blow? I leapt over
+the tree because the huntsmen are shooting down there in the thicket.
+Jump as I did, if you can do it.’ The giant made the attempt but he
+could not get over the tree, and remained hanging in the branches, so
+that in this also the tailor kept the upper hand.
+
+The giant said: ‘If you are such a valiant fellow, come with me into our
+cavern and spend the night with us.’ The little tailor was willing, and
+followed him. When they went into the cave, other giants were sitting
+there by the fire, and each of them had a roasted sheep in his hand and
+was eating it. The little tailor looked round and thought: ‘It is much
+more spacious here than in my workshop.’ The giant showed him a bed, and
+said he was to lie down in it and sleep. The bed, however, was too
+big for the little tailor; he did not lie down in it, but crept into
+a corner. When it was midnight, and the giant thought that the little
+tailor was lying in a sound sleep, he got up, took a great iron bar,
+cut through the bed with one blow, and thought he had finished off the
+grasshopper for good. With the earliest dawn the giants went into the
+forest, and had quite forgotten the little tailor, when all at once he
+walked up to them quite merrily and boldly. The giants were terrified,
+they were afraid that he would strike them all dead, and ran away in a
+great hurry.
+
+The little tailor went onwards, always following his own pointed nose.
+After he had walked for a long time, he came to the courtyard of a royal
+palace, and as he felt weary, he lay down on the grass and fell asleep.
+Whilst he lay there, the people came and inspected him on all sides, and
+read on his girdle: ‘Seven at one stroke.’ ‘Ah!’ said they, ‘what does
+the great warrior want here in the midst of peace? He must be a mighty
+lord.’ They went and announced him to the king, and gave it as their
+opinion that if war should break out, this would be a weighty and useful
+man who ought on no account to be allowed to depart. The counsel pleased
+the king, and he sent one of his courtiers to the little tailor to offer
+him military service when he awoke. The ambassador remained standing by
+the sleeper, waited until he stretched his limbs and opened his eyes,
+and then conveyed to him this proposal. ‘For this very reason have
+I come here,’ the tailor replied, ‘I am ready to enter the king’s
+service.’ He was therefore honourably received, and a special dwelling
+was assigned him.
+
+The soldiers, however, were set against the little tailor, and wished
+him a thousand miles away. ‘What is to be the end of this?’ they said
+among themselves. ‘If we quarrel with him, and he strikes about him,
+seven of us will fall at every blow; not one of us can stand against
+him.’ They came therefore to a decision, betook themselves in a body to
+the king, and begged for their dismissal. ‘We are not prepared,’ said
+they, ‘to stay with a man who kills seven at one stroke.’ The king was
+sorry that for the sake of one he should lose all his faithful servants,
+wished that he had never set eyes on the tailor, and would willingly
+have been rid of him again. But he did not venture to give him his
+dismissal, for he dreaded lest he should strike him and all his people
+dead, and place himself on the royal throne. He thought about it for a
+long time, and at last found good counsel. He sent to the little tailor
+and caused him to be informed that as he was a great warrior, he had one
+request to make to him. In a forest of his country lived two giants,
+who caused great mischief with their robbing, murdering, ravaging,
+and burning, and no one could approach them without putting himself in
+danger of death. If the tailor conquered and killed these two giants, he
+would give him his only daughter to wife, and half of his kingdom as a
+dowry, likewise one hundred horsemen should go with him to assist him.
+‘That would indeed be a fine thing for a man like me!’ thought the
+little tailor. ‘One is not offered a beautiful princess and half a
+kingdom every day of one’s life!’ ‘Oh, yes,’ he replied, ‘I will soon
+subdue the giants, and do not require the help of the hundred horsemen
+to do it; he who can hit seven with one blow has no need to be afraid of
+two.’
+
+The little tailor went forth, and the hundred horsemen followed him.
+When he came to the outskirts of the forest, he said to his followers:
+‘Just stay waiting here, I alone will soon finish off the giants.’ Then
+he bounded into the forest and looked about right and left. After a
+while he perceived both giants. They lay sleeping under a tree, and
+snored so that the branches waved up and down. The little tailor, not
+idle, gathered two pocketsful of stones, and with these climbed up the
+tree. When he was halfway up, he slipped down by a branch, until he sat
+just above the sleepers, and then let one stone after another fall on
+the breast of one of the giants. For a long time the giant felt nothing,
+but at last he awoke, pushed his comrade, and said: ‘Why are you
+knocking me?’ ‘You must be dreaming,’ said the other, ‘I am not knocking
+you.’ They laid themselves down to sleep again, and then the tailor
+threw a stone down on the second. ‘What is the meaning of this?’ cried
+the other ‘Why are you pelting me?’ ‘I am not pelting you,’ answered
+the first, growling. They disputed about it for a time, but as they were
+weary they let the matter rest, and their eyes closed once more. The
+little tailor began his game again, picked out the biggest stone, and
+threw it with all his might on the breast of the first giant. ‘That
+is too bad!’ cried he, and sprang up like a madman, and pushed his
+companion against the tree until it shook. The other paid him back in
+the same coin, and they got into such a rage that they tore up trees and
+belaboured each other so long, that at last they both fell down dead on
+the ground at the same time. Then the little tailor leapt down. ‘It is
+a lucky thing,’ said he, ‘that they did not tear up the tree on which
+I was sitting, or I should have had to sprint on to another like a
+squirrel; but we tailors are nimble.’ He drew out his sword and gave
+each of them a couple of thrusts in the breast, and then went out to the
+horsemen and said: ‘The work is done; I have finished both of them
+off, but it was hard work! They tore up trees in their sore need, and
+defended themselves with them, but all that is to no purpose when a man
+like myself comes, who can kill seven at one blow.’ ‘But are you not
+wounded?’ asked the horsemen. ‘You need not concern yourself about
+that,’ answered the tailor, ‘they have not bent one hair of mine.’ The
+horsemen would not believe him, and rode into the forest; there they
+found the giants swimming in their blood, and all round about lay the
+torn-up trees.
+
+The little tailor demanded of the king the promised reward; he, however,
+repented of his promise, and again bethought himself how he could get
+rid of the hero. ‘Before you receive my daughter, and the half of my
+kingdom,’ said he to him, ‘you must perform one more heroic deed. In
+the forest roams a unicorn which does great harm, and you must catch
+it first.’ ‘I fear one unicorn still less than two giants. Seven at one
+blow, is my kind of affair.’ He took a rope and an axe with him, went
+forth into the forest, and again bade those who were sent with him to
+wait outside. He had not long to seek. The unicorn soon came towards
+him, and rushed directly on the tailor, as if it would gore him with its
+horn without more ado. ‘Softly, softly; it can’t be done as quickly as
+that,’ said he, and stood still and waited until the animal was quite
+close, and then sprang nimbly behind the tree. The unicorn ran against
+the tree with all its strength, and stuck its horn so fast in the trunk
+that it had not the strength enough to draw it out again, and thus it
+was caught. ‘Now, I have got the bird,’ said the tailor, and came out
+from behind the tree and put the rope round its neck, and then with his
+axe he hewed the horn out of the tree, and when all was ready he led the
+beast away and took it to the king.
+
+The king still would not give him the promised reward, and made a third
+demand. Before the wedding the tailor was to catch him a wild boar that
+made great havoc in the forest, and the huntsmen should give him their
+help. ‘Willingly,’ said the tailor, ‘that is child’s play!’ He did not
+take the huntsmen with him into the forest, and they were well pleased
+that he did not, for the wild boar had several times received them in
+such a manner that they had no inclination to lie in wait for him. When
+the boar perceived the tailor, it ran on him with foaming mouth and
+whetted tusks, and was about to throw him to the ground, but the hero
+fled and sprang into a chapel which was near and up to the window at
+once, and in one bound out again. The boar ran after him, but the tailor
+ran round outside and shut the door behind it, and then the raging
+beast, which was much too heavy and awkward to leap out of the window,
+was caught. The little tailor called the huntsmen thither that they
+might see the prisoner with their own eyes. The hero, however, went to
+the king, who was now, whether he liked it or not, obliged to keep his
+promise, and gave his daughter and the half of his kingdom. Had he known
+that it was no warlike hero, but a little tailor who was standing before
+him, it would have gone to his heart still more than it did. The wedding
+was held with great magnificence and small joy, and out of a tailor a
+king was made.
+
+After some time the young queen heard her husband say in his dreams at
+night: ‘Boy, make me the doublet, and patch the pantaloons, or else I
+will rap the yard-measure over your ears.’ Then she discovered in what
+state of life the young lord had been born, and next morning complained
+of her wrongs to her father, and begged him to help her to get rid of
+her husband, who was nothing else but a tailor. The king comforted her
+and said: ‘Leave your bedroom door open this night, and my servants
+shall stand outside, and when he has fallen asleep shall go in, bind
+him, and take him on board a ship which shall carry him into the wide
+world.’ The woman was satisfied with this; but the king’s armour-bearer,
+who had heard all, was friendly with the young lord, and informed him of
+the whole plot. ‘I’ll put a screw into that business,’ said the little
+tailor. At night he went to bed with his wife at the usual time, and
+when she thought that he had fallen asleep, she got up, opened the door,
+and then lay down again. The little tailor, who was only pretending to
+be asleep, began to cry out in a clear voice: ‘Boy, make me the doublet
+and patch me the pantaloons, or I will rap the yard-measure over your
+ears. I smote seven at one blow. I killed two giants, I brought away one
+unicorn, and caught a wild boar, and am I to fear those who are standing
+outside the room.’ When these men heard the tailor speaking thus, they
+were overcome by a great dread, and ran as if the wild huntsman were
+behind them, and none of them would venture anything further against
+him. So the little tailor was and remained a king to the end of his
+life.
+
+
+
+
+HANSEL AND GRETEL
+
+Hard by a great forest dwelt a poor wood-cutter with his wife and his
+two children. The boy was called Hansel and the girl Gretel. He had
+little to bite and to break, and once when great dearth fell on the
+land, he could no longer procure even daily bread. Now when he thought
+over this by night in his bed, and tossed about in his anxiety, he
+groaned and said to his wife: ‘What is to become of us? How are we
+to feed our poor children, when we no longer have anything even for
+ourselves?’ ‘I’ll tell you what, husband,’ answered the woman, ‘early
+tomorrow morning we will take the children out into the forest to where
+it is the thickest; there we will light a fire for them, and give each
+of them one more piece of bread, and then we will go to our work and
+leave them alone. They will not find the way home again, and we shall be
+rid of them.’ ‘No, wife,’ said the man, ‘I will not do that; how can I
+bear to leave my children alone in the forest?--the wild animals would
+soon come and tear them to pieces.’ ‘O, you fool!’ said she, ‘then we
+must all four die of hunger, you may as well plane the planks for our
+coffins,’ and she left him no peace until he consented. ‘But I feel very
+sorry for the poor children, all the same,’ said the man.
+
+The two children had also not been able to sleep for hunger, and had
+heard what their stepmother had said to their father. Gretel wept
+bitter tears, and said to Hansel: ‘Now all is over with us.’ ‘Be quiet,
+Gretel,’ said Hansel, ‘do not distress yourself, I will soon find a way
+to help us.’ And when the old folks had fallen asleep, he got up, put
+on his little coat, opened the door below, and crept outside. The moon
+shone brightly, and the white pebbles which lay in front of the house
+glittered like real silver pennies. Hansel stooped and stuffed the
+little pocket of his coat with as many as he could get in. Then he went
+back and said to Gretel: ‘Be comforted, dear little sister, and sleep in
+peace, God will not forsake us,’ and he lay down again in his bed. When
+day dawned, but before the sun had risen, the woman came and awoke the
+two children, saying: ‘Get up, you sluggards! we are going into the
+forest to fetch wood.’ She gave each a little piece of bread, and said:
+‘There is something for your dinner, but do not eat it up before then,
+for you will get nothing else.’ Gretel took the bread under her apron,
+as Hansel had the pebbles in his pocket. Then they all set out together
+on the way to the forest. When they had walked a short time, Hansel
+stood still and peeped back at the house, and did so again and again.
+His father said: ‘Hansel, what are you looking at there and staying
+behind for? Pay attention, and do not forget how to use your legs.’ ‘Ah,
+father,’ said Hansel, ‘I am looking at my little white cat, which is
+sitting up on the roof, and wants to say goodbye to me.’ The wife said:
+‘Fool, that is not your little cat, that is the morning sun which is
+shining on the chimneys.’ Hansel, however, had not been looking back at
+the cat, but had been constantly throwing one of the white pebble-stones
+out of his pocket on the road.
+
+When they had reached the middle of the forest, the father said: ‘Now,
+children, pile up some wood, and I will light a fire that you may not
+be cold.’ Hansel and Gretel gathered brushwood together, as high as a
+little hill. The brushwood was lighted, and when the flames were burning
+very high, the woman said: ‘Now, children, lay yourselves down by the
+fire and rest, we will go into the forest and cut some wood. When we
+have done, we will come back and fetch you away.’
+
+Hansel and Gretel sat by the fire, and when noon came, each ate a little
+piece of bread, and as they heard the strokes of the wood-axe they
+believed that their father was near. It was not the axe, however, but
+a branch which he had fastened to a withered tree which the wind was
+blowing backwards and forwards. And as they had been sitting such a long
+time, their eyes closed with fatigue, and they fell fast asleep. When
+at last they awoke, it was already dark night. Gretel began to cry and
+said: ‘How are we to get out of the forest now?’ But Hansel comforted
+her and said: ‘Just wait a little, until the moon has risen, and then we
+will soon find the way.’ And when the full moon had risen, Hansel took
+his little sister by the hand, and followed the pebbles which shone like
+newly-coined silver pieces, and showed them the way.
+
+They walked the whole night long, and by break of day came once more
+to their father’s house. They knocked at the door, and when the woman
+opened it and saw that it was Hansel and Gretel, she said: ‘You naughty
+children, why have you slept so long in the forest?--we thought you were
+never coming back at all!’ The father, however, rejoiced, for it had cut
+him to the heart to leave them behind alone.
+
+Not long afterwards, there was once more great dearth throughout the
+land, and the children heard their mother saying at night to their
+father: ‘Everything is eaten again, we have one half loaf left, and that
+is the end. The children must go, we will take them farther into the
+wood, so that they will not find their way out again; there is no other
+means of saving ourselves!’ The man’s heart was heavy, and he thought:
+‘It would be better for you to share the last mouthful with your
+children.’ The woman, however, would listen to nothing that he had to
+say, but scolded and reproached him. He who says A must say B, likewise,
+and as he had yielded the first time, he had to do so a second time
+also.
+
+The children, however, were still awake and had heard the conversation.
+When the old folks were asleep, Hansel again got up, and wanted to go
+out and pick up pebbles as he had done before, but the woman had locked
+the door, and Hansel could not get out. Nevertheless he comforted his
+little sister, and said: ‘Do not cry, Gretel, go to sleep quietly, the
+good God will help us.’
+
+Early in the morning came the woman, and took the children out of their
+beds. Their piece of bread was given to them, but it was still smaller
+than the time before. On the way into the forest Hansel crumbled his
+in his pocket, and often stood still and threw a morsel on the ground.
+‘Hansel, why do you stop and look round?’ said the father, ‘go on.’ ‘I
+am looking back at my little pigeon which is sitting on the roof, and
+wants to say goodbye to me,’ answered Hansel. ‘Fool!’ said the woman,
+‘that is not your little pigeon, that is the morning sun that is shining
+on the chimney.’ Hansel, however little by little, threw all the crumbs
+on the path.
+
+The woman led the children still deeper into the forest, where they had
+never in their lives been before. Then a great fire was again made, and
+the mother said: ‘Just sit there, you children, and when you are tired
+you may sleep a little; we are going into the forest to cut wood, and in
+the evening when we are done, we will come and fetch you away.’ When
+it was noon, Gretel shared her piece of bread with Hansel, who had
+scattered his by the way. Then they fell asleep and evening passed, but
+no one came to the poor children. They did not awake until it was dark
+night, and Hansel comforted his little sister and said: ‘Just wait,
+Gretel, until the moon rises, and then we shall see the crumbs of bread
+which I have strewn about, they will show us our way home again.’ When
+the moon came they set out, but they found no crumbs, for the many
+thousands of birds which fly about in the woods and fields had picked
+them all up. Hansel said to Gretel: ‘We shall soon find the way,’ but
+they did not find it. They walked the whole night and all the next day
+too from morning till evening, but they did not get out of the forest,
+and were very hungry, for they had nothing to eat but two or three
+berries, which grew on the ground. And as they were so weary that their
+legs would carry them no longer, they lay down beneath a tree and fell
+asleep.
+
+It was now three mornings since they had left their father’s house. They
+began to walk again, but they always came deeper into the forest, and if
+help did not come soon, they must die of hunger and weariness. When it
+was mid-day, they saw a beautiful snow-white bird sitting on a bough,
+which sang so delightfully that they stood still and listened to it. And
+when its song was over, it spread its wings and flew away before them,
+and they followed it until they reached a little house, on the roof of
+which it alighted; and when they approached the little house they saw
+that it was built of bread and covered with cakes, but that the windows
+were of clear sugar. ‘We will set to work on that,’ said Hansel, ‘and
+have a good meal. I will eat a bit of the roof, and you Gretel, can eat
+some of the window, it will taste sweet.’ Hansel reached up above, and
+broke off a little of the roof to try how it tasted, and Gretel leant
+against the window and nibbled at the panes. Then a soft voice cried
+from the parlour:
+
+ ‘Nibble, nibble, gnaw,
+  Who is nibbling at my little house?’
+
+The children answered:
+
+ ‘The wind, the wind,
+  The heaven-born wind,’
+
+and went on eating without disturbing themselves. Hansel, who liked the
+taste of the roof, tore down a great piece of it, and Gretel pushed out
+the whole of one round window-pane, sat down, and enjoyed herself with
+it. Suddenly the door opened, and a woman as old as the hills, who
+supported herself on crutches, came creeping out. Hansel and Gretel were
+so terribly frightened that they let fall what they had in their
+hands. The old woman, however, nodded her head, and said: ‘Oh, you dear
+children, who has brought you here? do come in, and stay with me. No
+harm shall happen to you.’ She took them both by the hand, and led them
+into her little house. Then good food was set before them, milk and
+pancakes, with sugar, apples, and nuts. Afterwards two pretty little
+beds were covered with clean white linen, and Hansel and Gretel lay down
+in them, and thought they were in heaven.
+
+The old woman had only pretended to be so kind; she was in reality
+a wicked witch, who lay in wait for children, and had only built the
+little house of bread in order to entice them there. When a child fell
+into her power, she killed it, cooked and ate it, and that was a feast
+day with her. Witches have red eyes, and cannot see far, but they have
+a keen scent like the beasts, and are aware when human beings draw near.
+When Hansel and Gretel came into her neighbourhood, she laughed with
+malice, and said mockingly: ‘I have them, they shall not escape me
+again!’ Early in the morning before the children were awake, she was
+already up, and when she saw both of them sleeping and looking so
+pretty, with their plump and rosy cheeks she muttered to herself: ‘That
+will be a dainty mouthful!’ Then she seized Hansel with her shrivelled
+hand, carried him into a little stable, and locked him in behind a
+grated door. Scream as he might, it would not help him. Then she went to
+Gretel, shook her till she awoke, and cried: ‘Get up, lazy thing, fetch
+some water, and cook something good for your brother, he is in the
+stable outside, and is to be made fat. When he is fat, I will eat him.’
+Gretel began to weep bitterly, but it was all in vain, for she was
+forced to do what the wicked witch commanded.
+
+And now the best food was cooked for poor Hansel, but Gretel got nothing
+but crab-shells. Every morning the woman crept to the little stable, and
+cried: ‘Hansel, stretch out your finger that I may feel if you will soon
+be fat.’ Hansel, however, stretched out a little bone to her, and
+the old woman, who had dim eyes, could not see it, and thought it was
+Hansel’s finger, and was astonished that there was no way of fattening
+him. When four weeks had gone by, and Hansel still remained thin, she
+was seized with impatience and would not wait any longer. ‘Now, then,
+Gretel,’ she cried to the girl, ‘stir yourself, and bring some water.
+Let Hansel be fat or lean, tomorrow I will kill him, and cook him.’ Ah,
+how the poor little sister did lament when she had to fetch the water,
+and how her tears did flow down her cheeks! ‘Dear God, do help us,’ she
+cried. ‘If the wild beasts in the forest had but devoured us, we should
+at any rate have died together.’ ‘Just keep your noise to yourself,’
+said the old woman, ‘it won’t help you at all.’
+
+Early in the morning, Gretel had to go out and hang up the cauldron with
+the water, and light the fire. ‘We will bake first,’ said the old woman,
+‘I have already heated the oven, and kneaded the dough.’ She pushed poor
+Gretel out to the oven, from which flames of fire were already darting.
+‘Creep in,’ said the witch, ‘and see if it is properly heated, so that
+we can put the bread in.’ And once Gretel was inside, she intended to
+shut the oven and let her bake in it, and then she would eat her, too.
+But Gretel saw what she had in mind, and said: ‘I do not know how I am
+to do it; how do I get in?’ ‘Silly goose,’ said the old woman. ‘The door
+is big enough; just look, I can get in myself!’ and she crept up and
+thrust her head into the oven. Then Gretel gave her a push that drove
+her far into it, and shut the iron door, and fastened the bolt. Oh! then
+she began to howl quite horribly, but Gretel ran away and the godless
+witch was miserably burnt to death.
+
+Gretel, however, ran like lightning to Hansel, opened his little stable,
+and cried: ‘Hansel, we are saved! The old witch is dead!’ Then Hansel
+sprang like a bird from its cage when the door is opened. How they did
+rejoice and embrace each other, and dance about and kiss each other! And
+as they had no longer any need to fear her, they went into the witch’s
+house, and in every corner there stood chests full of pearls and jewels.
+‘These are far better than pebbles!’ said Hansel, and thrust into his
+pockets whatever could be got in, and Gretel said: ‘I, too, will take
+something home with me,’ and filled her pinafore full. ‘But now we must
+be off,’ said Hansel, ‘that we may get out of the witch’s forest.’
+
+When they had walked for two hours, they came to a great stretch of
+water. ‘We cannot cross,’ said Hansel, ‘I see no foot-plank, and no
+bridge.’ ‘And there is also no ferry,’ answered Gretel, ‘but a white
+duck is swimming there: if I ask her, she will help us over.’ Then she
+cried:
+
+ ‘Little duck, little duck, dost thou see,
+  Hansel and Gretel are waiting for thee?
+  There’s never a plank, or bridge in sight,
+  Take us across on thy back so white.’
+
+The duck came to them, and Hansel seated himself on its back, and told
+his sister to sit by him. ‘No,’ replied Gretel, ‘that will be too heavy
+for the little duck; she shall take us across, one after the other.’ The
+good little duck did so, and when they were once safely across and had
+walked for a short time, the forest seemed to be more and more familiar
+to them, and at length they saw from afar their father’s house. Then
+they began to run, rushed into the parlour, and threw themselves round
+their father’s neck. The man had not known one happy hour since he had
+left the children in the forest; the woman, however, was dead. Gretel
+emptied her pinafore until pearls and precious stones ran about the
+room, and Hansel threw one handful after another out of his pocket to
+add to them. Then all anxiety was at an end, and they lived together
+in perfect happiness. My tale is done, there runs a mouse; whosoever
+catches it, may make himself a big fur cap out of it.
+
+
+
+
+THE MOUSE, THE BIRD, AND THE SAUSAGE
+
+Once upon a time, a mouse, a bird, and a sausage, entered into
+partnership and set up house together. For a long time all went well;
+they lived in great comfort, and prospered so far as to be able to add
+considerably to their stores. The bird’s duty was to fly daily into the
+wood and bring in fuel; the mouse fetched the water, and the sausage saw
+to the cooking.
+
+When people are too well off they always begin to long for something
+new. And so it came to pass, that the bird, while out one day, met a
+fellow bird, to whom he boastfully expatiated on the excellence of his
+household arrangements. But the other bird sneered at him for being a
+poor simpleton, who did all the hard work, while the other two stayed
+at home and had a good time of it. For, when the mouse had made the fire
+and fetched in the water, she could retire into her little room and rest
+until it was time to set the table. The sausage had only to watch the
+pot to see that the food was properly cooked, and when it was near
+dinner-time, he just threw himself into the broth, or rolled in and out
+among the vegetables three or four times, and there they were, buttered,
+and salted, and ready to be served. Then, when the bird came home and
+had laid aside his burden, they sat down to table, and when they had
+finished their meal, they could sleep their fill till the following
+morning: and that was really a very delightful life.
+
+Influenced by those remarks, the bird next morning refused to bring in
+the wood, telling the others that he had been their servant long enough,
+and had been a fool into the bargain, and that it was now time to make a
+change, and to try some other way of arranging the work. Beg and pray
+as the mouse and the sausage might, it was of no use; the bird remained
+master of the situation, and the venture had to be made. They therefore
+drew lots, and it fell to the sausage to bring in the wood, to the mouse
+to cook, and to the bird to fetch the water.
+
+And now what happened? The sausage started in search of wood, the bird
+made the fire, and the mouse put on the pot, and then these two waited
+till the sausage returned with the fuel for the following day. But the
+sausage remained so long away, that they became uneasy, and the bird
+flew out to meet him. He had not flown far, however, when he came across
+a dog who, having met the sausage, had regarded him as his legitimate
+booty, and so seized and swallowed him. The bird complained to the dog
+of this bare-faced robbery, but nothing he said was of any avail, for
+the dog answered that he found false credentials on the sausage, and
+that was the reason his life had been forfeited.
+
+He picked up the wood, and flew sadly home, and told the mouse all he
+had seen and heard. They were both very unhappy, but agreed to make the
+best of things and to remain with one another.
+
+So now the bird set the table, and the mouse looked after the food and,
+wishing to prepare it in the same way as the sausage, by rolling in and
+out among the vegetables to salt and butter them, she jumped into the
+pot; but she stopped short long before she reached the bottom, having
+already parted not only with her skin and hair, but also with life.
+
+Presently the bird came in and wanted to serve up the dinner, but he
+could nowhere see the cook. In his alarm and flurry, he threw the wood
+here and there about the floor, called and searched, but no cook was to
+be found. Then some of the wood that had been carelessly thrown down,
+caught fire and began to blaze. The bird hastened to fetch some water,
+but his pail fell into the well, and he after it, and as he was unable
+to recover himself, he was drowned.
+
+
+
+
+MOTHER HOLLE
+
+Once upon a time there was a widow who had two daughters; one of them
+was beautiful and industrious, the other ugly and lazy. The mother,
+however, loved the ugly and lazy one best, because she was her own
+daughter, and so the other, who was only her stepdaughter, was made
+to do all the work of the house, and was quite the Cinderella of the
+family. Her stepmother sent her out every day to sit by the well in
+the high road, there to spin until she made her fingers bleed. Now it
+chanced one day that some blood fell on to the spindle, and as the girl
+stopped over the well to wash it off, the spindle suddenly sprang out
+of her hand and fell into the well. She ran home crying to tell of her
+misfortune, but her stepmother spoke harshly to her, and after giving
+her a violent scolding, said unkindly, ‘As you have let the spindle fall
+into the well you may go yourself and fetch it out.’
+
+The girl went back to the well not knowing what to do, and at last in
+her distress she jumped into the water after the spindle.
+
+She remembered nothing more until she awoke and found herself in a
+beautiful meadow, full of sunshine, and with countless flowers blooming
+in every direction.
+
+She walked over the meadow, and presently she came upon a baker’s oven
+full of bread, and the loaves cried out to her, ‘Take us out, take us
+out, or alas! we shall be burnt to a cinder; we were baked through long
+ago.’ So she took the bread-shovel and drew them all out.
+
+She went on a little farther, till she came to a tree full of apples.
+‘Shake me, shake me, I pray,’ cried the tree; ‘my apples, one and all,
+are ripe.’ So she shook the tree, and the apples came falling down upon
+her like rain; but she continued shaking until there was not a single
+apple left upon it. Then she carefully gathered the apples together in a
+heap and walked on again.
+
+The next thing she came to was a little house, and there she saw an old
+woman looking out, with such large teeth, that she was terrified, and
+turned to run away. But the old woman called after her, ‘What are you
+afraid of, dear child? Stay with me; if you will do the work of my house
+properly for me, I will make you very happy. You must be very careful,
+however, to make my bed in the right way, for I wish you always to shake
+it thoroughly, so that the feathers fly about; then they say, down there
+in the world, that it is snowing; for I am Mother Holle.’ The old woman
+spoke so kindly, that the girl summoned up courage and agreed to enter
+into her service.
+
+She took care to do everything according to the old woman’s bidding and
+every time she made the bed she shook it with all her might, so that the
+feathers flew about like so many snowflakes. The old woman was as good
+as her word: she never spoke angrily to her, and gave her roast and
+boiled meats every day.
+
+So she stayed on with Mother Holle for some time, and then she began
+to grow unhappy. She could not at first tell why she felt sad, but she
+became conscious at last of great longing to go home; then she knew she
+was homesick, although she was a thousand times better off with Mother
+Holle than with her mother and sister. After waiting awhile, she went
+to Mother Holle and said, ‘I am so homesick, that I cannot stay with
+you any longer, for although I am so happy here, I must return to my own
+people.’
+
+Then Mother Holle said, ‘I am pleased that you should want to go back
+to your own people, and as you have served me so well and faithfully, I
+will take you home myself.’
+
+Thereupon she led the girl by the hand up to a broad gateway. The gate
+was opened, and as the girl passed through, a shower of gold fell upon
+her, and the gold clung to her, so that she was covered with it from
+head to foot.
+
+‘That is a reward for your industry,’ said Mother Holle, and as she
+spoke she handed her the spindle which she had dropped into the well.
+
+The gate was then closed, and the girl found herself back in the old
+world close to her mother’s house. As she entered the courtyard, the
+cock who was perched on the well, called out:
+
+ ‘Cock-a-doodle-doo!
+  Your golden daughter’s come back to you.’
+
+Then she went in to her mother and sister, and as she was so richly
+covered with gold, they gave her a warm welcome. She related to them
+all that had happened, and when the mother heard how she had come by her
+great riches, she thought she should like her ugly, lazy daughter to go
+and try her fortune. So she made the sister go and sit by the well
+and spin, and the girl pricked her finger and thrust her hand into a
+thorn-bush, so that she might drop some blood on to the spindle; then
+she threw it into the well, and jumped in herself.
+
+Like her sister she awoke in the beautiful meadow, and walked over it
+till she came to the oven. ‘Take us out, take us out, or alas! we shall
+be burnt to a cinder; we were baked through long ago,’ cried the loaves
+as before. But the lazy girl answered, ‘Do you think I am going to dirty
+my hands for you?’ and walked on.
+
+Presently she came to the apple-tree. ‘Shake me, shake me, I pray; my
+apples, one and all, are ripe,’ it cried. But she only answered, ‘A nice
+thing to ask me to do, one of the apples might fall on my head,’ and
+passed on.
+
+At last she came to Mother Holle’s house, and as she had heard all about
+the large teeth from her sister, she was not afraid of them, and engaged
+herself without delay to the old woman.
+
+The first day she was very obedient and industrious, and exerted herself
+to please Mother Holle, for she thought of the gold she should get in
+return. The next day, however, she began to dawdle over her work, and
+the third day she was more idle still; then she began to lie in bed in
+the mornings and refused to get up. Worse still, she neglected to
+make the old woman’s bed properly, and forgot to shake it so that the
+feathers might fly about. So Mother Holle very soon got tired of her,
+and told her she might go. The lazy girl was delighted at this, and
+thought to herself, ‘The gold will soon be mine.’ Mother Holle led her,
+as she had led her sister, to the broad gateway; but as she was passing
+through, instead of the shower of gold, a great bucketful of pitch came
+pouring over her.
+
+‘That is in return for your services,’ said the old woman, and she shut
+the gate.
+
+So the lazy girl had to go home covered with pitch, and the cock on the
+well called out as she saw her:
+
+ ‘Cock-a-doodle-doo!
+  Your dirty daughter’s come back to you.’
+
+But, try what she would, she could not get the pitch off and it stuck to
+her as long as she lived.
+
+
+
+
+LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+
+Once upon a time there was a dear little girl who was loved by everyone
+who looked at her, but most of all by her grandmother, and there was
+nothing that she would not have given to the child. Once she gave her a
+little cap of red velvet, which suited her so well that she would never
+wear anything else; so she was always called ‘Little Red-Cap.’
+
+One day her mother said to her: ‘Come, Little Red-Cap, here is a piece
+of cake and a bottle of wine; take them to your grandmother, she is ill
+and weak, and they will do her good. Set out before it gets hot, and
+when you are going, walk nicely and quietly and do not run off the path,
+or you may fall and break the bottle, and then your grandmother will
+get nothing; and when you go into her room, don’t forget to say, “Good
+morning”, and don’t peep into every corner before you do it.’
+
+‘I will take great care,’ said Little Red-Cap to her mother, and gave
+her hand on it.
+
+The grandmother lived out in the wood, half a league from the village,
+and just as Little Red-Cap entered the wood, a wolf met her. Red-Cap
+did not know what a wicked creature he was, and was not at all afraid of
+him.
+
+‘Good day, Little Red-Cap,’ said he.
+
+‘Thank you kindly, wolf.’
+
+‘Whither away so early, Little Red-Cap?’
+
+‘To my grandmother’s.’
+
+‘What have you got in your apron?’
+
+‘Cake and wine; yesterday was baking-day, so poor sick grandmother is to
+have something good, to make her stronger.’
+
+‘Where does your grandmother live, Little Red-Cap?’
+
+‘A good quarter of a league farther on in the wood; her house stands
+under the three large oak-trees, the nut-trees are just below; you
+surely must know it,’ replied Little Red-Cap.
+
+The wolf thought to himself: ‘What a tender young creature! what a nice
+plump mouthful--she will be better to eat than the old woman. I must
+act craftily, so as to catch both.’ So he walked for a short time by
+the side of Little Red-Cap, and then he said: ‘See, Little Red-Cap, how
+pretty the flowers are about here--why do you not look round? I believe,
+too, that you do not hear how sweetly the little birds are singing; you
+walk gravely along as if you were going to school, while everything else
+out here in the wood is merry.’
+
+Little Red-Cap raised her eyes, and when she saw the sunbeams dancing
+here and there through the trees, and pretty flowers growing everywhere,
+she thought: ‘Suppose I take grandmother a fresh nosegay; that would
+please her too. It is so early in the day that I shall still get there
+in good time’; and so she ran from the path into the wood to look for
+flowers. And whenever she had picked one, she fancied that she saw a
+still prettier one farther on, and ran after it, and so got deeper and
+deeper into the wood.
+
+Meanwhile the wolf ran straight to the grandmother’s house and knocked
+at the door.
+
+‘Who is there?’
+
+‘Little Red-Cap,’ replied the wolf. ‘She is bringing cake and wine; open
+the door.’
+
+‘Lift the latch,’ called out the grandmother, ‘I am too weak, and cannot
+get up.’
+
+The wolf lifted the latch, the door sprang open, and without saying a
+word he went straight to the grandmother’s bed, and devoured her. Then
+he put on her clothes, dressed himself in her cap laid himself in bed
+and drew the curtains.
+
+Little Red-Cap, however, had been running about picking flowers,
+and when she had gathered so many that she could carry no more, she
+remembered her grandmother, and set out on the way to her.
+
+She was surprised to find the cottage-door standing open, and when she
+went into the room, she had such a strange feeling that she said to
+herself: ‘Oh dear! how uneasy I feel today, and at other times I like
+being with grandmother so much.’ She called out: ‘Good morning,’ but
+received no answer; so she went to the bed and drew back the curtains.
+There lay her grandmother with her cap pulled far over her face, and
+looking very strange.
+
+‘Oh! grandmother,’ she said, ‘what big ears you have!’
+
+‘The better to hear you with, my child,’ was the reply.
+
+‘But, grandmother, what big eyes you have!’ she said.
+
+‘The better to see you with, my dear.’
+
+‘But, grandmother, what large hands you have!’
+
+‘The better to hug you with.’
+
+‘Oh! but, grandmother, what a terrible big mouth you have!’
+
+‘The better to eat you with!’
+
+And scarcely had the wolf said this, than with one bound he was out of
+bed and swallowed up Red-Cap.
+
+When the wolf had appeased his appetite, he lay down again in the bed,
+fell asleep and began to snore very loud. The huntsman was just passing
+the house, and thought to himself: ‘How the old woman is snoring! I must
+just see if she wants anything.’ So he went into the room, and when he
+came to the bed, he saw that the wolf was lying in it. ‘Do I find you
+here, you old sinner!’ said he. ‘I have long sought you!’ Then just as
+he was going to fire at him, it occurred to him that the wolf might have
+devoured the grandmother, and that she might still be saved, so he did
+not fire, but took a pair of scissors, and began to cut open the stomach
+of the sleeping wolf. When he had made two snips, he saw the little
+Red-Cap shining, and then he made two snips more, and the little girl
+sprang out, crying: ‘Ah, how frightened I have been! How dark it was
+inside the wolf’; and after that the aged grandmother came out alive
+also, but scarcely able to breathe. Red-Cap, however, quickly fetched
+great stones with which they filled the wolf’s belly, and when he awoke,
+he wanted to run away, but the stones were so heavy that he collapsed at
+once, and fell dead.
+
+Then all three were delighted. The huntsman drew off the wolf’s skin and
+went home with it; the grandmother ate the cake and drank the wine which
+Red-Cap had brought, and revived, but Red-Cap thought to herself: ‘As
+long as I live, I will never by myself leave the path, to run into the
+wood, when my mother has forbidden me to do so.’
+
+
+
+
+It also related that once when Red-Cap was again taking cakes to the old
+grandmother, another wolf spoke to her, and tried to entice her from the
+path. Red-Cap, however, was on her guard, and went straight forward on
+her way, and told her grandmother that she had met the wolf, and that he
+had said ‘good morning’ to her, but with such a wicked look in his eyes,
+that if they had not been on the public road she was certain he would
+have eaten her up. ‘Well,’ said the grandmother, ‘we will shut the door,
+that he may not come in.’ Soon afterwards the wolf knocked, and cried:
+‘Open the door, grandmother, I am Little Red-Cap, and am bringing you
+some cakes.’ But they did not speak, or open the door, so the grey-beard
+stole twice or thrice round the house, and at last jumped on the roof,
+intending to wait until Red-Cap went home in the evening, and then to
+steal after her and devour her in the darkness. But the grandmother
+saw what was in his thoughts. In front of the house was a great stone
+trough, so she said to the child: ‘Take the pail, Red-Cap; I made some
+sausages yesterday, so carry the water in which I boiled them to the
+trough.’ Red-Cap carried until the great trough was quite full. Then the
+smell of the sausages reached the wolf, and he sniffed and peeped down,
+and at last stretched out his neck so far that he could no longer keep
+his footing and began to slip, and slipped down from the roof straight
+into the great trough, and was drowned. But Red-Cap went joyously home,
+and no one ever did anything to harm her again.
+
+
+
+
+THE ROBBER BRIDEGROOM
+
+There was once a miller who had one beautiful daughter, and as she was
+grown up, he was anxious that she should be well married and provided
+for. He said to himself, ‘I will give her to the first suitable man who
+comes and asks for her hand.’ Not long after a suitor appeared, and as
+he appeared to be very rich and the miller could see nothing in him with
+which to find fault, he betrothed his daughter to him. But the girl did
+not care for the man as a girl ought to care for her betrothed husband.
+She did not feel that she could trust him, and she could not look at him
+nor think of him without an inward shudder. One day he said to her, ‘You
+have not yet paid me a visit, although we have been betrothed for some
+time.’ ‘I do not know where your house is,’ she answered. ‘My house is
+out there in the dark forest,’ he said. She tried to excuse herself by
+saying that she would not be able to find the way thither. Her betrothed
+only replied, ‘You must come and see me next Sunday; I have already
+invited guests for that day, and that you may not mistake the way, I
+will strew ashes along the path.’
+
+When Sunday came, and it was time for the girl to start, a feeling of
+dread came over her which she could not explain, and that she might
+be able to find her path again, she filled her pockets with peas and
+lentils to sprinkle on the ground as she went along. On reaching the
+entrance to the forest she found the path strewed with ashes, and these
+she followed, throwing down some peas on either side of her at every
+step she took. She walked the whole day until she came to the deepest,
+darkest part of the forest. There she saw a lonely house, looking so
+grim and mysterious, that it did not please her at all. She stepped
+inside, but not a soul was to be seen, and a great silence reigned
+throughout. Suddenly a voice cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl looked up and saw that the voice came from a bird hanging in a
+cage on the wall. Again it cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl passed on, going from room to room of the house, but they were
+all empty, and still she saw no one. At last she came to the cellar,
+and there sat a very, very old woman, who could not keep her head from
+shaking. ‘Can you tell me,’ asked the girl, ‘if my betrothed husband
+lives here?’
+
+‘Ah, you poor child,’ answered the old woman, ‘what a place for you to
+come to! This is a murderers’ den. You think yourself a promised bride,
+and that your marriage will soon take place, but it is with death that
+you will keep your marriage feast. Look, do you see that large cauldron
+of water which I am obliged to keep on the fire! As soon as they have
+you in their power they will kill you without mercy, and cook and eat
+you, for they are eaters of men. If I did not take pity on you and save
+you, you would be lost.’
+
+Thereupon the old woman led her behind a large cask, which quite hid her
+from view. ‘Keep as still as a mouse,’ she said; ‘do not move or speak,
+or it will be all over with you. Tonight, when the robbers are
+all asleep, we will flee together. I have long been waiting for an
+opportunity to escape.’
+
+The words were hardly out of her mouth when the godless crew returned,
+dragging another young girl along with them. They were all drunk, and
+paid no heed to her cries and lamentations. They gave her wine to drink,
+three glasses full, one of white wine, one of red, and one of yellow,
+and with that her heart gave way and she died. Then they tore off her
+dainty clothing, laid her on a table, and cut her beautiful body into
+pieces, and sprinkled salt upon it.
+
+The poor betrothed girl crouched trembling and shuddering behind the
+cask, for she saw what a terrible fate had been intended for her by
+the robbers. One of them now noticed a gold ring still remaining on
+the little finger of the murdered girl, and as he could not draw it off
+easily, he took a hatchet and cut off the finger; but the finger sprang
+into the air, and fell behind the cask into the lap of the girl who was
+hiding there. The robber took a light and began looking for it, but he
+could not find it. ‘Have you looked behind the large cask?’ said one of
+the others. But the old woman called out, ‘Come and eat your suppers,
+and let the thing be till tomorrow; the finger won’t run away.’
+
+‘The old woman is right,’ said the robbers, and they ceased looking for
+the finger and sat down.
+
+The old woman then mixed a sleeping draught with their wine, and before
+long they were all lying on the floor of the cellar, fast asleep and
+snoring. As soon as the girl was assured of this, she came from behind
+the cask. She was obliged to step over the bodies of the sleepers, who
+were lying close together, and every moment she was filled with renewed
+dread lest she should awaken them. But God helped her, so that she
+passed safely over them, and then she and the old woman went upstairs,
+opened the door, and hastened as fast as they could from the murderers’
+den. They found the ashes scattered by the wind, but the peas and
+lentils had sprouted, and grown sufficiently above the ground, to guide
+them in the moonlight along the path. All night long they walked, and it
+was morning before they reached the mill. Then the girl told her father
+all that had happened.
+
+The day came that had been fixed for the marriage. The bridegroom
+arrived and also a large company of guests, for the miller had taken
+care to invite all his friends and relations. As they sat at the feast,
+each guest in turn was asked to tell a tale; the bride sat still and did
+not say a word.
+
+‘And you, my love,’ said the bridegroom, turning to her, ‘is there no
+tale you know? Tell us something.’
+
+‘I will tell you a dream, then,’ said the bride. ‘I went alone through a
+forest and came at last to a house; not a soul could I find within, but
+a bird that was hanging in a cage on the wall cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+and again a second time it said these words.’
+
+‘My darling, this is only a dream.’
+
+‘I went on through the house from room to room, but they were all empty,
+and everything was so grim and mysterious. At last I went down to the
+cellar, and there sat a very, very old woman, who could not keep her
+head still. I asked her if my betrothed lived here, and she answered,
+“Ah, you poor child, you are come to a murderers’ den; your betrothed
+does indeed live here, but he will kill you without mercy and afterwards
+cook and eat you.”’
+
+‘My darling, this is only a dream.’
+
+‘The old woman hid me behind a large cask, and scarcely had she done
+this when the robbers returned home, dragging a young girl along with
+them. They gave her three kinds of wine to drink, white, red, and
+yellow, and with that she died.’
+
+‘My darling, this is only a dream.’
+
+‘Then they tore off her dainty clothing, and cut her beautiful body into
+pieces and sprinkled salt upon it.’
+
+‘My darling, this is only a dream.’
+
+‘And one of the robbers saw that there was a gold ring still left on her
+finger, and as it was difficult to draw off, he took a hatchet and cut
+off her finger; but the finger sprang into the air and fell behind the
+great cask into my lap. And here is the finger with the ring.’ And
+with these words the bride drew forth the finger and shewed it to the
+assembled guests.
+
+The bridegroom, who during this recital had grown deadly pale, up and
+tried to escape, but the guests seized him and held him fast. They
+delivered him up to justice, and he and all his murderous band were
+condemned to death for their wicked deeds.
+
+
+
+
+TOM THUMB
+
+A poor woodman sat in his cottage one night, smoking his pipe by the
+fireside, while his wife sat by his side spinning. ‘How lonely it is,
+wife,’ said he, as he puffed out a long curl of smoke, ‘for you and me
+to sit here by ourselves, without any children to play about and amuse
+us while other people seem so happy and merry with their children!’
+‘What you say is very true,’ said the wife, sighing, and turning round
+her wheel; ‘how happy should I be if I had but one child! If it were
+ever so small--nay, if it were no bigger than my thumb--I should be very
+happy, and love it dearly.’ Now--odd as you may think it--it came to
+pass that this good woman’s wish was fulfilled, just in the very way she
+had wished it; for, not long afterwards, she had a little boy, who was
+quite healthy and strong, but was not much bigger than my thumb. So
+they said, ‘Well, we cannot say we have not got what we wished for, and,
+little as he is, we will love him dearly.’ And they called him Thomas
+Thumb.
+
+They gave him plenty of food, yet for all they could do he never grew
+bigger, but kept just the same size as he had been when he was born.
+Still, his eyes were sharp and sparkling, and he soon showed himself to
+be a clever little fellow, who always knew well what he was about.
+
+One day, as the woodman was getting ready to go into the wood to cut
+fuel, he said, ‘I wish I had someone to bring the cart after me, for I
+want to make haste.’ ‘Oh, father,’ cried Tom, ‘I will take care of that;
+the cart shall be in the wood by the time you want it.’ Then the woodman
+laughed, and said, ‘How can that be? you cannot reach up to the horse’s
+bridle.’ ‘Never mind that, father,’ said Tom; ‘if my mother will only
+harness the horse, I will get into his ear and tell him which way to
+go.’ ‘Well,’ said the father, ‘we will try for once.’
+
+When the time came the mother harnessed the horse to the cart, and put
+Tom into his ear; and as he sat there the little man told the beast how
+to go, crying out, ‘Go on!’ and ‘Stop!’ as he wanted: and thus the horse
+went on just as well as if the woodman had driven it himself into the
+wood. It happened that as the horse was going a little too fast, and Tom
+was calling out, ‘Gently! gently!’ two strangers came up. ‘What an odd
+thing that is!’ said one: ‘there is a cart going along, and I hear a
+carter talking to the horse, but yet I can see no one.’ ‘That is queer,
+indeed,’ said the other; ‘let us follow the cart, and see where it
+goes.’ So they went on into the wood, till at last they came to the
+place where the woodman was. Then Tom Thumb, seeing his father, cried
+out, ‘See, father, here I am with the cart, all right and safe! now take
+me down!’ So his father took hold of the horse with one hand, and with
+the other took his son out of the horse’s ear, and put him down upon a
+straw, where he sat as merry as you please.
+
+The two strangers were all this time looking on, and did not know what
+to say for wonder. At last one took the other aside, and said, ‘That
+little urchin will make our fortune, if we can get him, and carry him
+about from town to town as a show; we must buy him.’ So they went up to
+the woodman, and asked him what he would take for the little man. ‘He
+will be better off,’ said they, ‘with us than with you.’ ‘I won’t sell
+him at all,’ said the father; ‘my own flesh and blood is dearer to me
+than all the silver and gold in the world.’ But Tom, hearing of the
+bargain they wanted to make, crept up his father’s coat to his shoulder
+and whispered in his ear, ‘Take the money, father, and let them have me;
+I’ll soon come back to you.’
+
+So the woodman at last said he would sell Tom to the strangers for a
+large piece of gold, and they paid the price. ‘Where would you like to
+sit?’ said one of them. ‘Oh, put me on the rim of your hat; that will be
+a nice gallery for me; I can walk about there and see the country as we
+go along.’ So they did as he wished; and when Tom had taken leave of his
+father they took him away with them.
+
+They journeyed on till it began to be dusky, and then the little man
+said, ‘Let me get down, I’m tired.’ So the man took off his hat, and
+put him down on a clod of earth, in a ploughed field by the side of the
+road. But Tom ran about amongst the furrows, and at last slipped into
+an old mouse-hole. ‘Good night, my masters!’ said he, ‘I’m off! mind and
+look sharp after me the next time.’ Then they ran at once to the place,
+and poked the ends of their sticks into the mouse-hole, but all in vain;
+Tom only crawled farther and farther in; and at last it became quite
+dark, so that they were forced to go their way without their prize, as
+sulky as could be.
+
+When Tom found they were gone, he came out of his hiding-place. ‘What
+dangerous walking it is,’ said he, ‘in this ploughed field! If I were to
+fall from one of these great clods, I should undoubtedly break my neck.’
+At last, by good luck, he found a large empty snail-shell. ‘This is
+lucky,’ said he, ‘I can sleep here very well’; and in he crept.
+
+Just as he was falling asleep, he heard two men passing by, chatting
+together; and one said to the other, ‘How can we rob that rich parson’s
+house of his silver and gold?’ ‘I’ll tell you!’ cried Tom. ‘What noise
+was that?’ said the thief, frightened; ‘I’m sure I heard someone speak.’
+They stood still listening, and Tom said, ‘Take me with you, and I’ll
+soon show you how to get the parson’s money.’ ‘But where are you?’ said
+they. ‘Look about on the ground,’ answered he, ‘and listen where the
+sound comes from.’ At last the thieves found him out, and lifted him
+up in their hands. ‘You little urchin!’ they said, ‘what can you do for
+us?’ ‘Why, I can get between the iron window-bars of the parson’s house,
+and throw you out whatever you want.’ ‘That’s a good thought,’ said the
+thieves; ‘come along, we shall see what you can do.’
+
+When they came to the parson’s house, Tom slipped through the
+window-bars into the room, and then called out as loud as he could bawl,
+‘Will you have all that is here?’ At this the thieves were frightened,
+and said, ‘Softly, softly! Speak low, that you may not awaken anybody.’
+But Tom seemed as if he did not understand them, and bawled out again,
+‘How much will you have? Shall I throw it all out?’ Now the cook lay in
+the next room; and hearing a noise she raised herself up in her bed and
+listened. Meantime the thieves were frightened, and ran off a little
+way; but at last they plucked up their hearts, and said, ‘The little
+urchin is only trying to make fools of us.’ So they came back and
+whispered softly to him, saying, ‘Now let us have no more of your
+roguish jokes; but throw us out some of the money.’ Then Tom called out
+as loud as he could, ‘Very well! hold your hands! here it comes.’
+
+The cook heard this quite plain, so she sprang out of bed, and ran to
+open the door. The thieves ran off as if a wolf was at their tails: and
+the maid, having groped about and found nothing, went away for a light.
+By the time she came back, Tom had slipped off into the barn; and when
+she had looked about and searched every hole and corner, and found
+nobody, she went to bed, thinking she must have been dreaming with her
+eyes open.
+
+The little man crawled about in the hay-loft, and at last found a snug
+place to finish his night’s rest in; so he laid himself down, meaning
+to sleep till daylight, and then find his way home to his father and
+mother. But alas! how woefully he was undone! what crosses and sorrows
+happen to us all in this world! The cook got up early, before daybreak,
+to feed the cows; and going straight to the hay-loft, carried away
+a large bundle of hay, with the little man in the middle of it, fast
+asleep. He still, however, slept on, and did not awake till he found
+himself in the mouth of the cow; for the cook had put the hay into the
+cow’s rick, and the cow had taken Tom up in a mouthful of it. ‘Good
+lack-a-day!’ said he, ‘how came I to tumble into the mill?’ But he soon
+found out where he really was; and was forced to have all his wits about
+him, that he might not get between the cow’s teeth, and so be crushed to
+death. At last down he went into her stomach. ‘It is rather dark,’ said
+he; ‘they forgot to build windows in this room to let the sun in; a
+candle would be no bad thing.’
+
+Though he made the best of his bad luck, he did not like his quarters at
+all; and the worst of it was, that more and more hay was always coming
+down, and the space left for him became smaller and smaller. At last he
+cried out as loud as he could, ‘Don’t bring me any more hay! Don’t bring
+me any more hay!’
+
+The maid happened to be just then milking the cow; and hearing someone
+speak, but seeing nobody, and yet being quite sure it was the same voice
+that she had heard in the night, she was so frightened that she fell off
+her stool, and overset the milk-pail. As soon as she could pick herself
+up out of the dirt, she ran off as fast as she could to her master the
+parson, and said, ‘Sir, sir, the cow is talking!’ But the parson
+said, ‘Woman, thou art surely mad!’ However, he went with her into the
+cow-house, to try and see what was the matter.
+
+Scarcely had they set foot on the threshold, when Tom called out, ‘Don’t
+bring me any more hay!’ Then the parson himself was frightened; and
+thinking the cow was surely bewitched, told his man to kill her on the
+spot. So the cow was killed, and cut up; and the stomach, in which Tom
+lay, was thrown out upon a dunghill.
+
+Tom soon set himself to work to get out, which was not a very easy
+task; but at last, just as he had made room to get his head out, fresh
+ill-luck befell him. A hungry wolf sprang out, and swallowed up the
+whole stomach, with Tom in it, at one gulp, and ran away.
+
+Tom, however, was still not disheartened; and thinking the wolf would
+not dislike having some chat with him as he was going along, he called
+out, ‘My good friend, I can show you a famous treat.’ ‘Where’s that?’
+said the wolf. ‘In such and such a house,’ said Tom, describing his own
+father’s house. ‘You can crawl through the drain into the kitchen and
+then into the pantry, and there you will find cakes, ham, beef, cold
+chicken, roast pig, apple-dumplings, and everything that your heart can
+wish.’
+
+The wolf did not want to be asked twice; so that very night he went to
+the house and crawled through the drain into the kitchen, and then into
+the pantry, and ate and drank there to his heart’s content. As soon as
+he had had enough he wanted to get away; but he had eaten so much that
+he could not go out by the same way he came in.
+
+This was just what Tom had reckoned upon; and now he began to set up a
+great shout, making all the noise he could. ‘Will you be easy?’ said the
+wolf; ‘you’ll awaken everybody in the house if you make such a clatter.’
+‘What’s that to me?’ said the little man; ‘you have had your frolic, now
+I’ve a mind to be merry myself’; and he began, singing and shouting as
+loud as he could.
+
+The woodman and his wife, being awakened by the noise, peeped through
+a crack in the door; but when they saw a wolf was there, you may well
+suppose that they were sadly frightened; and the woodman ran for his
+axe, and gave his wife a scythe. ‘Do you stay behind,’ said the woodman,
+‘and when I have knocked him on the head you must rip him up with the
+scythe.’ Tom heard all this, and cried out, ‘Father, father! I am here,
+the wolf has swallowed me.’ And his father said, ‘Heaven be praised! we
+have found our dear child again’; and he told his wife not to use the
+scythe for fear she should hurt him. Then he aimed a great blow, and
+struck the wolf on the head, and killed him on the spot! and when he was
+dead they cut open his body, and set Tommy free. ‘Ah!’ said the father,
+‘what fears we have had for you!’ ‘Yes, father,’ answered he; ‘I have
+travelled all over the world, I think, in one way or other, since we
+parted; and now I am very glad to come home and get fresh air again.’
+‘Why, where have you been?’ said his father. ‘I have been in a
+mouse-hole--and in a snail-shell--and down a cow’s throat--and in the
+wolf’s belly; and yet here I am again, safe and sound.’
+
+‘Well,’ said they, ‘you are come back, and we will not sell you again
+for all the riches in the world.’
+
+Then they hugged and kissed their dear little son, and gave him plenty
+to eat and drink, for he was very hungry; and then they fetched new
+clothes for him, for his old ones had been quite spoiled on his journey.
+So Master Thumb stayed at home with his father and mother, in peace; for
+though he had been so great a traveller, and had done and seen so many
+fine things, and was fond enough of telling the whole story, he always
+agreed that, after all, there’s no place like HOME!
+
+
+
+
+RUMPELSTILTSKIN
+
+By the side of a wood, in a country a long way off, ran a fine stream
+of water; and upon the stream there stood a mill. The miller’s house was
+close by, and the miller, you must know, had a very beautiful daughter.
+She was, moreover, very shrewd and clever; and the miller was so proud
+of her, that he one day told the king of the land, who used to come and
+hunt in the wood, that his daughter could spin gold out of straw. Now
+this king was very fond of money; and when he heard the miller’s boast
+his greediness was raised, and he sent for the girl to be brought before
+him. Then he led her to a chamber in his palace where there was a great
+heap of straw, and gave her a spinning-wheel, and said, ‘All this must
+be spun into gold before morning, as you love your life.’ It was in vain
+that the poor maiden said that it was only a silly boast of her father,
+for that she could do no such thing as spin straw into gold: the chamber
+door was locked, and she was left alone.
+
+She sat down in one corner of the room, and began to bewail her hard
+fate; when on a sudden the door opened, and a droll-looking little man
+hobbled in, and said, ‘Good morrow to you, my good lass; what are you
+weeping for?’ ‘Alas!’ said she, ‘I must spin this straw into gold, and
+I know not how.’ ‘What will you give me,’ said the hobgoblin, ‘to do it
+for you?’ ‘My necklace,’ replied the maiden. He took her at her word,
+and sat himself down to the wheel, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+And round about the wheel went merrily; the work was quickly done, and
+the straw was all spun into gold.
+
+When the king came and saw this, he was greatly astonished and pleased;
+but his heart grew still more greedy of gain, and he shut up the poor
+miller’s daughter again with a fresh task. Then she knew not what to do,
+and sat down once more to weep; but the dwarf soon opened the door, and
+said, ‘What will you give me to do your task?’ ‘The ring on my finger,’
+said she. So her little friend took the ring, and began to work at the
+wheel again, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+till, long before morning, all was done again.
+
+The king was greatly delighted to see all this glittering treasure;
+but still he had not enough: so he took the miller’s daughter to a yet
+larger heap, and said, ‘All this must be spun tonight; and if it is,
+you shall be my queen.’ As soon as she was alone that dwarf came in, and
+said, ‘What will you give me to spin gold for you this third time?’
+‘I have nothing left,’ said she. ‘Then say you will give me,’ said
+the little man, ‘the first little child that you may have when you are
+queen.’ ‘That may never be,’ thought the miller’s daughter: and as she
+knew no other way to get her task done, she said she would do what he
+asked. Round went the wheel again to the old song, and the manikin once
+more spun the heap into gold. The king came in the morning, and, finding
+all he wanted, was forced to keep his word; so he married the miller’s
+daughter, and she really became queen.
+
+At the birth of her first little child she was very glad, and forgot the
+dwarf, and what she had said. But one day he came into her room, where
+she was sitting playing with her baby, and put her in mind of it. Then
+she grieved sorely at her misfortune, and said she would give him all
+the wealth of the kingdom if he would let her off, but in vain; till at
+last her tears softened him, and he said, ‘I will give you three days’
+grace, and if during that time you tell me my name, you shall keep your
+child.’
+
+Now the queen lay awake all night, thinking of all the odd names that
+she had ever heard; and she sent messengers all over the land to find
+out new ones. The next day the little man came, and she began with
+TIMOTHY, ICHABOD, BENJAMIN, JEREMIAH, and all the names she could
+remember; but to all and each of them he said, ‘Madam, that is not my
+name.’
+
+The second day she began with all the comical names she could hear of,
+BANDY-LEGS, HUNCHBACK, CROOK-SHANKS, and so on; but the little gentleman
+still said to every one of them, ‘Madam, that is not my name.’
+
+The third day one of the messengers came back, and said, ‘I have
+travelled two days without hearing of any other names; but yesterday, as
+I was climbing a high hill, among the trees of the forest where the fox
+and the hare bid each other good night, I saw a little hut; and before
+the hut burnt a fire; and round about the fire a funny little dwarf was
+dancing upon one leg, and singing:
+
+ “Merrily the feast I’ll make.
+  Today I’ll brew, tomorrow bake;
+  Merrily I’ll dance and sing,
+  For next day will a stranger bring.
+  Little does my lady dream
+  Rumpelstiltskin is my name!”
+
+When the queen heard this she jumped for joy, and as soon as her little
+friend came she sat down upon her throne, and called all her court round
+to enjoy the fun; and the nurse stood by her side with the baby in her
+arms, as if it was quite ready to be given up. Then the little man began
+to chuckle at the thought of having the poor child, to take home with
+him to his hut in the woods; and he cried out, ‘Now, lady, what is my
+name?’ ‘Is it JOHN?’ asked she. ‘No, madam!’ ‘Is it TOM?’ ‘No, madam!’
+‘Is it JEMMY?’ ‘It is not.’ ‘Can your name be RUMPELSTILTSKIN?’ said the
+lady slyly. ‘Some witch told you that!--some witch told you that!’ cried
+the little man, and dashed his right foot in a rage so deep into the
+floor, that he was forced to lay hold of it with both hands to pull it
+out.
+
+Then he made the best of his way off, while the nurse laughed and the
+baby crowed; and all the court jeered at him for having had so much
+trouble for nothing, and said, ‘We wish you a very good morning, and a
+merry feast, Mr RUMPLESTILTSKIN!’
+
+
+
+
+CLEVER GRETEL
+
+There was once a cook named Gretel, who wore shoes with red heels, and
+when she walked out with them on, she turned herself this way and that,
+was quite happy and thought: ‘You certainly are a pretty girl!’ And when
+she came home she drank, in her gladness of heart, a draught of wine,
+and as wine excites a desire to eat, she tasted the best of whatever she
+was cooking until she was satisfied, and said: ‘The cook must know what
+the food is like.’
+
+It came to pass that the master one day said to her: ‘Gretel, there is a
+guest coming this evening; prepare me two fowls very daintily.’ ‘I will
+see to it, master,’ answered Gretel. She killed two fowls, scalded them,
+plucked them, put them on the spit, and towards evening set them before
+the fire, that they might roast. The fowls began to turn brown, and were
+nearly ready, but the guest had not yet arrived. Then Gretel called out
+to her master: ‘If the guest does not come, I must take the fowls away
+from the fire, but it will be a sin and a shame if they are not eaten
+the moment they are at their juiciest.’ The master said: ‘I will run
+myself, and fetch the guest.’ When the master had turned his back,
+Gretel laid the spit with the fowls on one side, and thought: ‘Standing
+so long by the fire there, makes one sweat and thirsty; who knows
+when they will come? Meanwhile, I will run into the cellar, and take a
+drink.’ She ran down, set a jug, said: ‘God bless it for you, Gretel,’
+and took a good drink, and thought that wine should flow on, and should
+not be interrupted, and took yet another hearty draught.
+
+Then she went and put the fowls down again to the fire, basted them,
+and drove the spit merrily round. But as the roast meat smelt so good,
+Gretel thought: ‘Something might be wrong, it ought to be tasted!’
+She touched it with her finger, and said: ‘Ah! how good fowls are! It
+certainly is a sin and a shame that they are not eaten at the right
+time!’ She ran to the window, to see if the master was not coming with
+his guest, but she saw no one, and went back to the fowls and thought:
+‘One of the wings is burning! I had better take it off and eat it.’
+So she cut it off, ate it, and enjoyed it, and when she had done, she
+thought: ‘The other must go down too, or else master will observe that
+something is missing.’ When the two wings were eaten, she went and
+looked for her master, and did not see him. It suddenly occurred to
+her: ‘Who knows? They are perhaps not coming at all, and have turned in
+somewhere.’ Then she said: ‘Well, Gretel, enjoy yourself, one fowl has
+been cut into, take another drink, and eat it up entirely; when it is
+eaten you will have some peace, why should God’s good gifts be spoilt?’
+So she ran into the cellar again, took an enormous drink and ate up the
+one chicken in great glee. When one of the chickens was swallowed down,
+and still her master did not come, Gretel looked at the other and said:
+‘What one is, the other should be likewise, the two go together; what’s
+right for the one is right for the other; I think if I were to take
+another draught it would do me no harm.’ So she took another hearty
+drink, and let the second chicken follow the first.
+
+While she was making the most of it, her master came and cried: ‘Hurry
+up, Gretel, the guest is coming directly after me!’ ‘Yes, sir, I will
+soon serve up,’ answered Gretel. Meantime the master looked to see that
+the table was properly laid, and took the great knife, wherewith he was
+going to carve the chickens, and sharpened it on the steps. Presently
+the guest came, and knocked politely and courteously at the house-door.
+Gretel ran, and looked to see who was there, and when she saw the guest,
+she put her finger to her lips and said: ‘Hush! hush! go away as quickly
+as you can, if my master catches you it will be the worse for you; he
+certainly did ask you to supper, but his intention is to cut off your
+two ears. Just listen how he is sharpening the knife for it!’ The guest
+heard the sharpening, and hurried down the steps again as fast as he
+could. Gretel was not idle; she ran screaming to her master, and cried:
+‘You have invited a fine guest!’ ‘Why, Gretel? What do you mean by
+that?’ ‘Yes,’ said she, ‘he has taken the chickens which I was just
+going to serve up, off the dish, and has run away with them!’ ‘That’s a
+nice trick!’ said her master, and lamented the fine chickens. ‘If he had
+but left me one, so that something remained for me to eat.’ He called to
+him to stop, but the guest pretended not to hear. Then he ran after him
+with the knife still in his hand, crying: ‘Just one, just one,’ meaning
+that the guest should leave him just one chicken, and not take both. The
+guest, however, thought no otherwise than that he was to give up one of
+his ears, and ran as if fire were burning under him, in order to take
+them both with him.
+
+
+
+
+THE OLD MAN AND HIS GRANDSON
+
+There was once a very old man, whose eyes had become dim, his ears dull
+of hearing, his knees trembled, and when he sat at table he could hardly
+hold the spoon, and spilt the broth upon the table-cloth or let it run
+out of his mouth. His son and his son’s wife were disgusted at this, so
+the old grandfather at last had to sit in the corner behind the stove,
+and they gave him his food in an earthenware bowl, and not even enough
+of it. And he used to look towards the table with his eyes full of
+tears. Once, too, his trembling hands could not hold the bowl, and it
+fell to the ground and broke. The young wife scolded him, but he said
+nothing and only sighed. Then they brought him a wooden bowl for a few
+half-pence, out of which he had to eat.
+
+They were once sitting thus when the little grandson of four years old
+began to gather together some bits of wood upon the ground. ‘What are
+you doing there?’ asked the father. ‘I am making a little trough,’
+answered the child, ‘for father and mother to eat out of when I am big.’
+
+The man and his wife looked at each other for a while, and presently
+began to cry. Then they took the old grandfather to the table, and
+henceforth always let him eat with them, and likewise said nothing if he
+did spill a little of anything.
+
+
+
+
+THE LITTLE PEASANT
+
+There was a certain village wherein no one lived but really rich
+peasants, and just one poor one, whom they called the little peasant. He
+had not even so much as a cow, and still less money to buy one, and
+yet he and his wife did so wish to have one. One day he said to her:
+‘Listen, I have a good idea, there is our gossip the carpenter, he shall
+make us a wooden calf, and paint it brown, so that it looks like any
+other, and in time it will certainly get big and be a cow.’ the woman
+also liked the idea, and their gossip the carpenter cut and planed
+the calf, and painted it as it ought to be, and made it with its head
+hanging down as if it were eating.
+
+Next morning when the cows were being driven out, the little peasant
+called the cow-herd in and said: ‘Look, I have a little calf there,
+but it is still small and has to be carried.’ The cow-herd said: ‘All
+right,’ and took it in his arms and carried it to the pasture, and set
+it among the grass. The little calf always remained standing like one
+which was eating, and the cow-herd said: ‘It will soon run by itself,
+just look how it eats already!’ At night when he was going to drive the
+herd home again, he said to the calf: ‘If you can stand there and eat
+your fill, you can also go on your four legs; I don’t care to drag you
+home again in my arms.’ But the little peasant stood at his door, and
+waited for his little calf, and when the cow-herd drove the cows through
+the village, and the calf was missing, he inquired where it was. The
+cow-herd answered: ‘It is still standing out there eating. It would not
+stop and come with us.’ But the little peasant said: ‘Oh, but I must
+have my beast back again.’ Then they went back to the meadow together,
+but someone had stolen the calf, and it was gone. The cow-herd said: ‘It
+must have run away.’ The peasant, however, said: ‘Don’t tell me
+that,’ and led the cow-herd before the mayor, who for his carelessness
+condemned him to give the peasant a cow for the calf which had run away.
+
+And now the little peasant and his wife had the cow for which they had
+so long wished, and they were heartily glad, but they had no food for
+it, and could give it nothing to eat, so it soon had to be killed. They
+salted the flesh, and the peasant went into the town and wanted to sell
+the skin there, so that he might buy a new calf with the proceeds. On
+the way he passed by a mill, and there sat a raven with broken wings,
+and out of pity he took him and wrapped him in the skin. But as the
+weather grew so bad and there was a storm of rain and wind, he could
+go no farther, and turned back to the mill and begged for shelter. The
+miller’s wife was alone in the house, and said to the peasant: ‘Lay
+yourself on the straw there,’ and gave him a slice of bread and cheese.
+The peasant ate it, and lay down with his skin beside him, and the woman
+thought: ‘He is tired and has gone to sleep.’ In the meantime came the
+parson; the miller’s wife received him well, and said: ‘My husband is
+out, so we will have a feast.’ The peasant listened, and when he heard
+them talk about feasting he was vexed that he had been forced to make
+shift with a slice of bread and cheese. Then the woman served up four
+different things, roast meat, salad, cakes, and wine.
+
+Just as they were about to sit down and eat, there was a knocking
+outside. The woman said: ‘Oh, heavens! It is my husband!’ she quickly
+hid the roast meat inside the tiled stove, the wine under the pillow,
+the salad on the bed, the cakes under it, and the parson in the closet
+on the porch. Then she opened the door for her husband, and said: ‘Thank
+heaven, you are back again! There is such a storm, it looks as if the
+world were coming to an end.’ The miller saw the peasant lying on the
+straw, and asked, ‘What is that fellow doing there?’ ‘Ah,’ said the
+wife, ‘the poor knave came in the storm and rain, and begged for
+shelter, so I gave him a bit of bread and cheese, and showed him where
+the straw was.’ The man said: ‘I have no objection, but be quick and get
+me something to eat.’ The woman said: ‘But I have nothing but bread and
+cheese.’ ‘I am contented with anything,’ replied the husband, ‘so far as
+I am concerned, bread and cheese will do,’ and looked at the peasant and
+said: ‘Come and eat some more with me.’ The peasant did not require to
+be invited twice, but got up and ate. After this the miller saw the skin
+in which the raven was, lying on the ground, and asked: ‘What have you
+there?’ The peasant answered: ‘I have a soothsayer inside it.’ ‘Can
+he foretell anything to me?’ said the miller. ‘Why not?’ answered
+the peasant: ‘but he only says four things, and the fifth he keeps to
+himself.’ The miller was curious, and said: ‘Let him foretell something
+for once.’ Then the peasant pinched the raven’s head, so that he croaked
+and made a noise like krr, krr. The miller said: ‘What did he say?’ The
+peasant answered: ‘In the first place, he says that there is some wine
+hidden under the pillow.’ ‘Bless me!’ cried the miller, and went there
+and found the wine. ‘Now go on,’ said he. The peasant made the raven
+croak again, and said: ‘In the second place, he says that there is some
+roast meat in the tiled stove.’ ‘Upon my word!’ cried the miller, and
+went thither, and found the roast meat. The peasant made the raven
+prophesy still more, and said: ‘Thirdly, he says that there is some
+salad on the bed.’ ‘That would be a fine thing!’ cried the miller, and
+went there and found the salad. At last the peasant pinched the raven
+once more till he croaked, and said: ‘Fourthly, he says that there
+are some cakes under the bed.’ ‘That would be a fine thing!’ cried the
+miller, and looked there, and found the cakes.
+
+And now the two sat down to the table together, but the miller’s wife
+was frightened to death, and went to bed and took all the keys with
+her. The miller would have liked much to know the fifth, but the little
+peasant said: ‘First, we will quickly eat the four things, for the fifth
+is something bad.’ So they ate, and after that they bargained how much
+the miller was to give for the fifth prophecy, until they agreed on
+three hundred talers. Then the peasant once more pinched the raven’s
+head till he croaked loudly. The miller asked: ‘What did he say?’ The
+peasant replied: ‘He says that the Devil is hiding outside there in
+the closet on the porch.’ The miller said: ‘The Devil must go out,’ and
+opened the house-door; then the woman was forced to give up the keys,
+and the peasant unlocked the closet. The parson ran out as fast as he
+could, and the miller said: ‘It was true; I saw the black rascal with my
+own eyes.’ The peasant, however, made off next morning by daybreak with
+the three hundred talers.
+
+At home the small peasant gradually launched out; he built a beautiful
+house, and the peasants said: ‘The small peasant has certainly been to
+the place where golden snow falls, and people carry the gold home in
+shovels.’ Then the small peasant was brought before the mayor, and
+bidden to say from whence his wealth came. He answered: ‘I sold my cow’s
+skin in the town, for three hundred talers.’ When the peasants heard
+that, they too wished to enjoy this great profit, and ran home, killed
+all their cows, and stripped off their skins in order to sell them in
+the town to the greatest advantage. The mayor, however, said: ‘But my
+servant must go first.’ When she came to the merchant in the town, he
+did not give her more than two talers for a skin, and when the others
+came, he did not give them so much, and said: ‘What can I do with all
+these skins?’
+
+Then the peasants were vexed that the small peasant should have thus
+outwitted them, wanted to take vengeance on him, and accused him of this
+treachery before the mayor. The innocent little peasant was unanimously
+sentenced to death, and was to be rolled into the water, in a barrel
+pierced full of holes. He was led forth, and a priest was brought who
+was to say a mass for his soul. The others were all obliged to retire to
+a distance, and when the peasant looked at the priest, he recognized the
+man who had been with the miller’s wife. He said to him: ‘I set you free
+from the closet, set me free from the barrel.’ At this same moment up
+came, with a flock of sheep, the very shepherd whom the peasant knew had
+long been wishing to be mayor, so he cried with all his might: ‘No, I
+will not do it; if the whole world insists on it, I will not do it!’ The
+shepherd hearing that, came up to him, and asked: ‘What are you about?
+What is it that you will not do?’ The peasant said: ‘They want to make
+me mayor, if I will but put myself in the barrel, but I will not do it.’
+The shepherd said: ‘If nothing more than that is needful in order to be
+mayor, I would get into the barrel at once.’ The peasant said: ‘If you
+will get in, you will be mayor.’ The shepherd was willing, and got in,
+and the peasant shut the top down on him; then he took the shepherd’s
+flock for himself, and drove it away. The parson went to the crowd,
+and declared that the mass had been said. Then they came and rolled the
+barrel towards the water. When the barrel began to roll, the shepherd
+cried: ‘I am quite willing to be mayor.’ They believed no otherwise than
+that it was the peasant who was saying this, and answered: ‘That is
+what we intend, but first you shall look about you a little down below
+there,’ and they rolled the barrel down into the water.
+
+After that the peasants went home, and as they were entering the
+village, the small peasant also came quietly in, driving a flock of
+sheep and looking quite contented. Then the peasants were astonished,
+and said: ‘Peasant, from whence do you come? Have you come out of the
+water?’ ‘Yes, truly,’ replied the peasant, ‘I sank deep, deep down,
+until at last I got to the bottom; I pushed the bottom out of the
+barrel, and crept out, and there were pretty meadows on which a number
+of lambs were feeding, and from thence I brought this flock away with
+me.’ Said the peasants: ‘Are there any more there?’ ‘Oh, yes,’ said he,
+‘more than I could want.’ Then the peasants made up their minds that
+they too would fetch some sheep for themselves, a flock apiece, but the
+mayor said: ‘I come first.’ So they went to the water together, and just
+then there were some of the small fleecy clouds in the blue sky, which
+are called little lambs, and they were reflected in the water, whereupon
+the peasants cried: ‘We already see the sheep down below!’ The mayor
+pressed forward and said: ‘I will go down first, and look about me, and
+if things promise well I’ll call you.’ So he jumped in; splash! went
+the water; it sounded as if he were calling them, and the whole crowd
+plunged in after him as one man. Then the entire village was dead, and
+the small peasant, as sole heir, became a rich man.
+
+
+
+
+FREDERICK AND CATHERINE
+
+There was once a man called Frederick: he had a wife whose name was
+Catherine, and they had not long been married. One day Frederick said.
+‘Kate! I am going to work in the fields; when I come back I shall be
+hungry so let me have something nice cooked, and a good draught of ale.’
+‘Very well,’ said she, ‘it shall all be ready.’ When dinner-time drew
+nigh, Catherine took a nice steak, which was all the meat she had, and
+put it on the fire to fry. The steak soon began to look brown, and to
+crackle in the pan; and Catherine stood by with a fork and turned it:
+then she said to herself, ‘The steak is almost ready, I may as well go
+to the cellar for the ale.’ So she left the pan on the fire and took a
+large jug and went into the cellar and tapped the ale cask. The beer ran
+into the jug and Catherine stood looking on. At last it popped into her
+head, ‘The dog is not shut up--he may be running away with the steak;
+that’s well thought of.’ So up she ran from the cellar; and sure enough
+the rascally cur had got the steak in his mouth, and was making off with
+it.
+
+Away ran Catherine, and away ran the dog across the field: but he ran
+faster than she, and stuck close to the steak. ‘It’s all gone, and “what
+can’t be cured must be endured”,’ said Catherine. So she turned round;
+and as she had run a good way and was tired, she walked home leisurely
+to cool herself.
+
+Now all this time the ale was running too, for Catherine had not turned
+the cock; and when the jug was full the liquor ran upon the floor till
+the cask was empty. When she got to the cellar stairs she saw what had
+happened. ‘My stars!’ said she, ‘what shall I do to keep Frederick from
+seeing all this slopping about?’ So she thought a while; and at last
+remembered that there was a sack of fine meal bought at the last fair,
+and that if she sprinkled this over the floor it would suck up the ale
+nicely. ‘What a lucky thing,’ said she, ‘that we kept that meal! we have
+now a good use for it.’ So away she went for it: but she managed to set
+it down just upon the great jug full of beer, and upset it; and thus
+all the ale that had been saved was set swimming on the floor also. ‘Ah!
+well,’ said she, ‘when one goes another may as well follow.’ Then she
+strewed the meal all about the cellar, and was quite pleased with her
+cleverness, and said, ‘How very neat and clean it looks!’
+
+At noon Frederick came home. ‘Now, wife,’ cried he, ‘what have you for
+dinner?’ ‘O Frederick!’ answered she, ‘I was cooking you a steak; but
+while I went down to draw the ale, the dog ran away with it; and while
+I ran after him, the ale ran out; and when I went to dry up the ale
+with the sack of meal that we got at the fair, I upset the jug: but the
+cellar is now quite dry, and looks so clean!’ ‘Kate, Kate,’ said he,
+‘how could you do all this?’ Why did you leave the steak to fry, and the
+ale to run, and then spoil all the meal?’ ‘Why, Frederick,’ said she, ‘I
+did not know I was doing wrong; you should have told me before.’
+
+The husband thought to himself, ‘If my wife manages matters thus, I must
+look sharp myself.’ Now he had a good deal of gold in the house: so he
+said to Catherine, ‘What pretty yellow buttons these are! I shall put
+them into a box and bury them in the garden; but take care that you
+never go near or meddle with them.’ ‘No, Frederick,’ said she, ‘that
+I never will.’ As soon as he was gone, there came by some pedlars with
+earthenware plates and dishes, and they asked her whether she would buy.
+‘Oh dear me, I should like to buy very much, but I have no money: if
+you had any use for yellow buttons, I might deal with you.’ ‘Yellow
+buttons!’ said they: ‘let us have a look at them.’ ‘Go into the garden
+and dig where I tell you, and you will find the yellow buttons: I dare
+not go myself.’ So the rogues went: and when they found what these
+yellow buttons were, they took them all away, and left her plenty of
+plates and dishes. Then she set them all about the house for a show:
+and when Frederick came back, he cried out, ‘Kate, what have you been
+doing?’ ‘See,’ said she, ‘I have bought all these with your yellow
+buttons: but I did not touch them myself; the pedlars went themselves
+and dug them up.’ ‘Wife, wife,’ said Frederick, ‘what a pretty piece of
+work you have made! those yellow buttons were all my money: how came you
+to do such a thing?’ ‘Why,’ answered she, ‘I did not know there was any
+harm in it; you should have told me.’
+
+Catherine stood musing for a while, and at last said to her husband,
+‘Hark ye, Frederick, we will soon get the gold back: let us run after
+the thieves.’ ‘Well, we will try,’ answered he; ‘but take some butter
+and cheese with you, that we may have something to eat by the way.’
+‘Very well,’ said she; and they set out: and as Frederick walked the
+fastest, he left his wife some way behind. ‘It does not matter,’ thought
+she: ‘when we turn back, I shall be so much nearer home than he.’
+
+Presently she came to the top of a hill, down the side of which there
+was a road so narrow that the cart wheels always chafed the trees
+on each side as they passed. ‘Ah, see now,’ said she, ‘how they have
+bruised and wounded those poor trees; they will never get well.’ So she
+took pity on them, and made use of the butter to grease them all, so
+that the wheels might not hurt them so much. While she was doing this
+kind office one of her cheeses fell out of the basket, and rolled down
+the hill. Catherine looked, but could not see where it had gone; so she
+said, ‘Well, I suppose the other will go the same way and find you; he
+has younger legs than I have.’ Then she rolled the other cheese after
+it; and away it went, nobody knows where, down the hill. But she said
+she supposed that they knew the road, and would follow her, and she
+could not stay there all day waiting for them.
+
+At last she overtook Frederick, who desired her to give him something to
+eat. Then she gave him the dry bread. ‘Where are the butter and cheese?’
+said he. ‘Oh!’ answered she, ‘I used the butter to grease those poor
+trees that the wheels chafed so: and one of the cheeses ran away so I
+sent the other after it to find it, and I suppose they are both on
+the road together somewhere.’ ‘What a goose you are to do such silly
+things!’ said the husband. ‘How can you say so?’ said she; ‘I am sure
+you never told me not.’
+
+They ate the dry bread together; and Frederick said, ‘Kate, I hope you
+locked the door safe when you came away.’ ‘No,’ answered she, ‘you did
+not tell me.’ ‘Then go home, and do it now before we go any farther,’
+said Frederick, ‘and bring with you something to eat.’
+
+Catherine did as he told her, and thought to herself by the way,
+‘Frederick wants something to eat; but I don’t think he is very fond of
+butter and cheese: I’ll bring him a bag of fine nuts, and the vinegar,
+for I have often seen him take some.’
+
+When she reached home, she bolted the back door, but the front door she
+took off the hinges, and said, ‘Frederick told me to lock the door, but
+surely it can nowhere be so safe if I take it with me.’ So she took
+her time by the way; and when she overtook her husband she cried
+out, ‘There, Frederick, there is the door itself, you may watch it as
+carefully as you please.’ ‘Alas! alas!’ said he, ‘what a clever wife I
+have! I sent you to make the house fast, and you take the door away, so
+that everybody may go in and out as they please--however, as you have
+brought the door, you shall carry it about with you for your pains.’
+‘Very well,’ answered she, ‘I’ll carry the door; but I’ll not carry the
+nuts and vinegar bottle also--that would be too much of a load; so if
+you please, I’ll fasten them to the door.’
+
+Frederick of course made no objection to that plan, and they set off
+into the wood to look for the thieves; but they could not find them: and
+when it grew dark, they climbed up into a tree to spend the night there.
+Scarcely were they up, than who should come by but the very rogues they
+were looking for. They were in truth great rascals, and belonged to that
+class of people who find things before they are lost; they were tired;
+so they sat down and made a fire under the very tree where Frederick and
+Catherine were. Frederick slipped down on the other side, and picked up
+some stones. Then he climbed up again, and tried to hit the thieves on
+the head with them: but they only said, ‘It must be near morning, for
+the wind shakes the fir-apples down.’
+
+Catherine, who had the door on her shoulder, began to be very tired;
+but she thought it was the nuts upon it that were so heavy: so she said
+softly, ‘Frederick, I must let the nuts go.’ ‘No,’ answered he, ‘not
+now, they will discover us.’ ‘I can’t help that: they must go.’ ‘Well,
+then, make haste and throw them down, if you will.’ Then away rattled
+the nuts down among the boughs and one of the thieves cried, ‘Bless me,
+it is hailing.’
+
+A little while after, Catherine thought the door was still very heavy:
+so she whispered to Frederick, ‘I must throw the vinegar down.’ ‘Pray
+don’t,’ answered he, ‘it will discover us.’ ‘I can’t help that,’ said
+she, ‘go it must.’ So she poured all the vinegar down; and the thieves
+said, ‘What a heavy dew there is!’
+
+At last it popped into Catherine’s head that it was the door itself that
+was so heavy all the time: so she whispered, ‘Frederick, I must throw
+the door down soon.’ But he begged and prayed her not to do so, for he
+was sure it would betray them. ‘Here goes, however,’ said she: and down
+went the door with such a clatter upon the thieves, that they cried
+out ‘Murder!’ and not knowing what was coming, ran away as fast as they
+could, and left all the gold. So when Frederick and Catherine came down,
+there they found all their money safe and sound.
+
+
+
+
+SWEETHEART ROLAND
+
+There was once upon a time a woman who was a real witch and had two
+daughters, one ugly and wicked, and this one she loved because she was
+her own daughter, and one beautiful and good, and this one she hated,
+because she was her stepdaughter. The stepdaughter once had a pretty
+apron, which the other fancied so much that she became envious, and
+told her mother that she must and would have that apron. ‘Be quiet, my
+child,’ said the old woman, ‘and you shall have it. Your stepsister has
+long deserved death; tonight when she is asleep I will come and cut her
+head off. Only be careful that you are at the far side of the bed, and
+push her well to the front.’ It would have been all over with the poor
+girl if she had not just then been standing in a corner, and heard
+everything. All day long she dared not go out of doors, and when bedtime
+had come, the witch’s daughter got into bed first, so as to lie at the
+far side, but when she was asleep, the other pushed her gently to the
+front, and took for herself the place at the back, close by the wall. In
+the night, the old woman came creeping in, she held an axe in her right
+hand, and felt with her left to see if anyone were lying at the outside,
+and then she grasped the axe with both hands, and cut her own child’s
+head off.
+
+When she had gone away, the girl got up and went to her sweetheart, who
+was called Roland, and knocked at his door. When he came out, she said
+to him: ‘Listen, dearest Roland, we must fly in all haste; my stepmother
+wanted to kill me, but has struck her own child. When daylight comes,
+and she sees what she has done, we shall be lost.’ ‘But,’ said Roland,
+‘I counsel you first to take away her magic wand, or we cannot escape
+if she pursues us.’ The maiden fetched the magic wand, and she took the
+dead girl’s head and dropped three drops of blood on the ground, one in
+front of the bed, one in the kitchen, and one on the stairs. Then she
+hurried away with her lover.
+
+When the old witch got up next morning, she called her daughter, and
+wanted to give her the apron, but she did not come. Then the witch
+cried: ‘Where are you?’ ‘Here, on the stairs, I am sweeping,’ answered
+the first drop of blood. The old woman went out, but saw no one on the
+stairs, and cried again: ‘Where are you?’ ‘Here in the kitchen, I am
+warming myself,’ cried the second drop of blood. She went into the
+kitchen, but found no one. Then she cried again: ‘Where are you?’ ‘Ah,
+here in the bed, I am sleeping,’ cried the third drop of blood. She went
+into the room to the bed. What did she see there? Her own child,
+whose head she had cut off, bathed in her blood. The witch fell into
+a passion, sprang to the window, and as she could look forth quite far
+into the world, she perceived her stepdaughter hurrying away with her
+sweetheart Roland. ‘That shall not help you,’ cried she, ‘even if you
+have got a long way off, you shall still not escape me.’ She put on her
+many-league boots, in which she covered an hour’s walk at every step,
+and it was not long before she overtook them. The girl, however, when
+she saw the old woman striding towards her, changed, with her magic
+wand, her sweetheart Roland into a lake, and herself into a duck
+swimming in the middle of it. The witch placed herself on the shore,
+threw breadcrumbs in, and went to endless trouble to entice the duck;
+but the duck did not let herself be enticed, and the old woman had to
+go home at night as she had come. At this the girl and her sweetheart
+Roland resumed their natural shapes again, and they walked on the whole
+night until daybreak. Then the maiden changed herself into a beautiful
+flower which stood in the midst of a briar hedge, and her sweetheart
+Roland into a fiddler. It was not long before the witch came striding up
+towards them, and said to the musician: ‘Dear musician, may I pluck that
+beautiful flower for myself?’ ‘Oh, yes,’ he replied, ‘I will play to
+you while you do it.’ As she was hastily creeping into the hedge and was
+just going to pluck the flower, knowing perfectly well who the flower
+was, he began to play, and whether she would or not, she was forced
+to dance, for it was a magical dance. The faster he played, the more
+violent springs was she forced to make, and the thorns tore her clothes
+from her body, and pricked her and wounded her till she bled, and as he
+did not stop, she had to dance till she lay dead on the ground.
+
+As they were now set free, Roland said: ‘Now I will go to my father and
+arrange for the wedding.’ ‘Then in the meantime I will stay here and
+wait for you,’ said the girl, ‘and that no one may recognize me, I will
+change myself into a red stone landmark.’ Then Roland went away, and the
+girl stood like a red landmark in the field and waited for her beloved.
+But when Roland got home, he fell into the snares of another, who so
+fascinated him that he forgot the maiden. The poor girl remained there a
+long time, but at length, as he did not return at all, she was sad, and
+changed herself into a flower, and thought: ‘Someone will surely come
+this way, and trample me down.’
+
+It befell, however, that a shepherd kept his sheep in the field and saw
+the flower, and as it was so pretty, plucked it, took it with him, and
+laid it away in his chest. From that time forth, strange things happened
+in the shepherd’s house. When he arose in the morning, all the work was
+already done, the room was swept, the table and benches cleaned, the
+fire in the hearth was lighted, and the water was fetched, and at noon,
+when he came home, the table was laid, and a good dinner served. He
+could not conceive how this came to pass, for he never saw a human being
+in his house, and no one could have concealed himself in it. He was
+certainly pleased with this good attendance, but still at last he was so
+afraid that he went to a wise woman and asked for her advice. The wise
+woman said: ‘There is some enchantment behind it, listen very early some
+morning if anything is moving in the room, and if you see anything, no
+matter what it is, throw a white cloth over it, and then the magic will
+be stopped.’
+
+The shepherd did as she bade him, and next morning just as day dawned,
+he saw the chest open, and the flower come out. Swiftly he
+sprang towards it, and threw a white cloth over it. Instantly the
+transformation came to an end, and a beautiful girl stood before him,
+who admitted to him that she had been the flower, and that up to this
+time she had attended to his house-keeping. She told him her story,
+and as she pleased him he asked her if she would marry him, but she
+answered: ‘No,’ for she wanted to remain faithful to her sweetheart
+Roland, although he had deserted her. Nevertheless, she promised not to
+go away, but to continue keeping house for the shepherd.
+
+And now the time drew near when Roland’s wedding was to be celebrated,
+and then, according to an old custom in the country, it was announced
+that all the girls were to be present at it, and sing in honour of the
+bridal pair. When the faithful maiden heard of this, she grew so sad
+that she thought her heart would break, and she would not go thither,
+but the other girls came and took her. When it came to her turn to sing,
+she stepped back, until at last she was the only one left, and then she
+could not refuse. But when she began her song, and it reached Roland’s
+ears, he sprang up and cried: ‘I know the voice, that is the true
+bride, I will have no other!’ Everything he had forgotten, and which had
+vanished from his mind, had suddenly come home again to his heart. Then
+the faithful maiden held her wedding with her sweetheart Roland, and
+grief came to an end and joy began.
+
+
+
+
+SNOWDROP
+
+It was the middle of winter, when the broad flakes of snow were falling
+around, that the queen of a country many thousand miles off sat working
+at her window. The frame of the window was made of fine black ebony, and
+as she sat looking out upon the snow, she pricked her finger, and three
+drops of blood fell upon it. Then she gazed thoughtfully upon the red
+drops that sprinkled the white snow, and said, ‘Would that my little
+daughter may be as white as that snow, as red as that blood, and as
+black as this ebony windowframe!’ And so the little girl really did grow
+up; her skin was as white as snow, her cheeks as rosy as the blood, and
+her hair as black as ebony; and she was called Snowdrop.
+
+But this queen died; and the king soon married another wife, who became
+queen, and was very beautiful, but so vain that she could not bear
+to think that anyone could be handsomer than she was. She had a fairy
+looking-glass, to which she used to go, and then she would gaze upon
+herself in it, and say:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass had always answered:
+
+ ‘Thou, queen, art the fairest in all the land.’
+
+But Snowdrop grew more and more beautiful; and when she was seven years
+old she was as bright as the day, and fairer than the queen herself.
+Then the glass one day answered the queen, when she went to look in it
+as usual:
+
+ ‘Thou, queen, art fair, and beauteous to see,
+  But Snowdrop is lovelier far than thee!’
+
+When she heard this she turned pale with rage and envy, and called to
+one of her servants, and said, ‘Take Snowdrop away into the wide wood,
+that I may never see her any more.’ Then the servant led her away; but
+his heart melted when Snowdrop begged him to spare her life, and he
+said, ‘I will not hurt you, thou pretty child.’ So he left her by
+herself; and though he thought it most likely that the wild beasts would
+tear her in pieces, he felt as if a great weight were taken off his
+heart when he had made up his mind not to kill her but to leave her to
+her fate, with the chance of someone finding and saving her.
+
+Then poor Snowdrop wandered along through the wood in great fear; and
+the wild beasts roared about her, but none did her any harm. In the
+evening she came to a cottage among the hills, and went in to rest, for
+her little feet would carry her no further. Everything was spruce and
+neat in the cottage: on the table was spread a white cloth, and there
+were seven little plates, seven little loaves, and seven little glasses
+with wine in them; and seven knives and forks laid in order; and by
+the wall stood seven little beds. As she was very hungry, she picked
+a little piece of each loaf and drank a very little wine out of each
+glass; and after that she thought she would lie down and rest. So she
+tried all the little beds; but one was too long, and another was too
+short, till at last the seventh suited her: and there she laid herself
+down and went to sleep.
+
+By and by in came the masters of the cottage. Now they were seven little
+dwarfs, that lived among the mountains, and dug and searched for gold.
+They lighted up their seven lamps, and saw at once that all was not
+right. The first said, ‘Who has been sitting on my stool?’ The second,
+‘Who has been eating off my plate?’ The third, ‘Who has been picking my
+bread?’ The fourth, ‘Who has been meddling with my spoon?’ The fifth,
+‘Who has been handling my fork?’ The sixth, ‘Who has been cutting with
+my knife?’ The seventh, ‘Who has been drinking my wine?’ Then the first
+looked round and said, ‘Who has been lying on my bed?’ And the rest came
+running to him, and everyone cried out that somebody had been upon his
+bed. But the seventh saw Snowdrop, and called all his brethren to come
+and see her; and they cried out with wonder and astonishment and brought
+their lamps to look at her, and said, ‘Good heavens! what a lovely child
+she is!’ And they were very glad to see her, and took care not to wake
+her; and the seventh dwarf slept an hour with each of the other dwarfs
+in turn, till the night was gone.
+
+In the morning Snowdrop told them all her story; and they pitied her,
+and said if she would keep all things in order, and cook and wash and
+knit and spin for them, she might stay where she was, and they would
+take good care of her. Then they went out all day long to their work,
+seeking for gold and silver in the mountains: but Snowdrop was left at
+home; and they warned her, and said, ‘The queen will soon find out where
+you are, so take care and let no one in.’
+
+But the queen, now that she thought Snowdrop was dead, believed that she
+must be the handsomest lady in the land; and she went to her glass and
+said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the queen was very much frightened; for she knew that the glass
+always spoke the truth, and was sure that the servant had betrayed her.
+And she could not bear to think that anyone lived who was more beautiful
+than she was; so she dressed herself up as an old pedlar, and went
+her way over the hills, to the place where the dwarfs dwelt. Then she
+knocked at the door, and cried, ‘Fine wares to sell!’ Snowdrop looked
+out at the window, and said, ‘Good day, good woman! what have you to
+sell?’ ‘Good wares, fine wares,’ said she; ‘laces and bobbins of all
+colours.’ ‘I will let the old lady in; she seems to be a very good
+sort of body,’ thought Snowdrop, as she ran down and unbolted the door.
+‘Bless me!’ said the old woman, ‘how badly your stays are laced! Let me
+lace them up with one of my nice new laces.’ Snowdrop did not dream of
+any mischief; so she stood before the old woman; but she set to work
+so nimbly, and pulled the lace so tight, that Snowdrop’s breath was
+stopped, and she fell down as if she were dead. ‘There’s an end to all
+thy beauty,’ said the spiteful queen, and went away home.
+
+In the evening the seven dwarfs came home; and I need not say how
+grieved they were to see their faithful Snowdrop stretched out upon the
+ground, as if she was quite dead. However, they lifted her up, and when
+they found what ailed her, they cut the lace; and in a little time she
+began to breathe, and very soon came to life again. Then they said, ‘The
+old woman was the queen herself; take care another time, and let no one
+in when we are away.’
+
+When the queen got home, she went straight to her glass, and spoke to it
+as before; but to her great grief it still said:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the blood ran cold in her heart with spite and malice, to see that
+Snowdrop still lived; and she dressed herself up again, but in quite
+another dress from the one she wore before, and took with her a poisoned
+comb. When she reached the dwarfs’ cottage, she knocked at the door, and
+cried, ‘Fine wares to sell!’ But Snowdrop said, ‘I dare not let anyone
+in.’ Then the queen said, ‘Only look at my beautiful combs!’ and gave
+her the poisoned one. And it looked so pretty, that she took it up and
+put it into her hair to try it; but the moment it touched her head,
+the poison was so powerful that she fell down senseless. ‘There you may
+lie,’ said the queen, and went her way. But by good luck the dwarfs
+came in very early that evening; and when they saw Snowdrop lying on
+the ground, they thought what had happened, and soon found the poisoned
+comb. And when they took it away she got well, and told them all that
+had passed; and they warned her once more not to open the door to
+anyone.
+
+Meantime the queen went home to her glass, and shook with rage when she
+read the very same answer as before; and she said, ‘Snowdrop shall die,
+if it cost me my life.’ So she went by herself into her chamber, and got
+ready a poisoned apple: the outside looked very rosy and tempting, but
+whoever tasted it was sure to die. Then she dressed herself up as a
+peasant’s wife, and travelled over the hills to the dwarfs’ cottage,
+and knocked at the door; but Snowdrop put her head out of the window and
+said, ‘I dare not let anyone in, for the dwarfs have told me not.’ ‘Do
+as you please,’ said the old woman, ‘but at any rate take this pretty
+apple; I will give it you.’ ‘No,’ said Snowdrop, ‘I dare not take it.’
+‘You silly girl!’ answered the other, ‘what are you afraid of? Do you
+think it is poisoned? Come! do you eat one part, and I will eat the
+other.’ Now the apple was so made up that one side was good, though the
+other side was poisoned. Then Snowdrop was much tempted to taste, for
+the apple looked so very nice; and when she saw the old woman eat, she
+could wait no longer. But she had scarcely put the piece into her mouth,
+when she fell down dead upon the ground. ‘This time nothing will save
+thee,’ said the queen; and she went home to her glass, and at last it
+said:
+
+ ‘Thou, queen, art the fairest of all the fair.’
+
+And then her wicked heart was glad, and as happy as such a heart could
+be.
+
+When evening came, and the dwarfs had gone home, they found Snowdrop
+lying on the ground: no breath came from her lips, and they were afraid
+that she was quite dead. They lifted her up, and combed her hair, and
+washed her face with wine and water; but all was in vain, for the little
+girl seemed quite dead. So they laid her down upon a bier, and all seven
+watched and bewailed her three whole days; and then they thought they
+would bury her: but her cheeks were still rosy; and her face looked just
+as it did while she was alive; so they said, ‘We will never bury her in
+the cold ground.’ And they made a coffin of glass, so that they might
+still look at her, and wrote upon it in golden letters what her name
+was, and that she was a king’s daughter. And the coffin was set among
+the hills, and one of the dwarfs always sat by it and watched. And the
+birds of the air came too, and bemoaned Snowdrop; and first of all came
+an owl, and then a raven, and at last a dove, and sat by her side.
+
+And thus Snowdrop lay for a long, long time, and still only looked as
+though she was asleep; for she was even now as white as snow, and as red
+as blood, and as black as ebony. At last a prince came and called at the
+dwarfs’ house; and he saw Snowdrop, and read what was written in golden
+letters. Then he offered the dwarfs money, and prayed and besought them
+to let him take her away; but they said, ‘We will not part with her for
+all the gold in the world.’ At last, however, they had pity on him, and
+gave him the coffin; but the moment he lifted it up to carry it home
+with him, the piece of apple fell from between her lips, and Snowdrop
+awoke, and said, ‘Where am I?’ And the prince said, ‘Thou art quite safe
+with me.’
+
+Then he told her all that had happened, and said, ‘I love you far better
+than all the world; so come with me to my father’s palace, and you shall
+be my wife.’ And Snowdrop consented, and went home with the prince;
+and everything was got ready with great pomp and splendour for their
+wedding.
+
+To the feast was asked, among the rest, Snowdrop’s old enemy the queen;
+and as she was dressing herself in fine rich clothes, she looked in the
+glass and said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, lady, art loveliest here, I ween;
+  But lovelier far is the new-made queen.’
+
+When she heard this she started with rage; but her envy and curiosity
+were so great, that she could not help setting out to see the bride. And
+when she got there, and saw that it was no other than Snowdrop, who, as
+she thought, had been dead a long while, she choked with rage, and fell
+down and died: but Snowdrop and the prince lived and reigned happily
+over that land many, many years; and sometimes they went up into the
+mountains, and paid a visit to the little dwarfs, who had been so kind
+to Snowdrop in her time of need.
+
+
+
+
+THE PINK
+
+There was once upon a time a queen to whom God had given no children.
+Every morning she went into the garden and prayed to God in heaven to
+bestow on her a son or a daughter. Then an angel from heaven came to her
+and said: ‘Be at rest, you shall have a son with the power of wishing,
+so that whatsoever in the world he wishes for, that shall he have.’ Then
+she went to the king, and told him the joyful tidings, and when the time
+was come she gave birth to a son, and the king was filled with gladness.
+
+Every morning she went with the child to the garden where the wild
+beasts were kept, and washed herself there in a clear stream. It
+happened once when the child was a little older, that it was lying in
+her arms and she fell asleep. Then came the old cook, who knew that the
+child had the power of wishing, and stole it away, and he took a hen,
+and cut it in pieces, and dropped some of its blood on the queen’s apron
+and on her dress. Then he carried the child away to a secret place,
+where a nurse was obliged to suckle it, and he ran to the king and
+accused the queen of having allowed her child to be taken from her by
+the wild beasts. When the king saw the blood on her apron, he believed
+this, fell into such a passion that he ordered a high tower to be built,
+in which neither sun nor moon could be seen and had his wife put into
+it, and walled up. Here she was to stay for seven years without meat
+or drink, and die of hunger. But God sent two angels from heaven in the
+shape of white doves, which flew to her twice a day, and carried her
+food until the seven years were over.
+
+The cook, however, thought to himself: ‘If the child has the power of
+wishing, and I am here, he might very easily get me into trouble.’ So
+he left the palace and went to the boy, who was already big enough to
+speak, and said to him: ‘Wish for a beautiful palace for yourself with
+a garden, and all else that pertains to it.’ Scarcely were the words out
+of the boy’s mouth, when everything was there that he had wished for.
+After a while the cook said to him: ‘It is not well for you to be so
+alone, wish for a pretty girl as a companion.’ Then the king’s son
+wished for one, and she immediately stood before him, and was more
+beautiful than any painter could have painted her. The two played
+together, and loved each other with all their hearts, and the old cook
+went out hunting like a nobleman. The thought occurred to him, however,
+that the king’s son might some day wish to be with his father, and thus
+bring him into great peril. So he went out and took the maiden aside,
+and said: ‘Tonight when the boy is asleep, go to his bed and plunge this
+knife into his heart, and bring me his heart and tongue, and if you do
+not do it, you shall lose your life.’ Thereupon he went away, and when
+he returned next day she had not done it, and said: ‘Why should I shed
+the blood of an innocent boy who has never harmed anyone?’ The cook once
+more said: ‘If you do not do it, it shall cost you your own life.’ When
+he had gone away, she had a little hind brought to her, and ordered her
+to be killed, and took her heart and tongue, and laid them on a plate,
+and when she saw the old man coming, she said to the boy: ‘Lie down in
+your bed, and draw the clothes over you.’ Then the wicked wretch came in
+and said: ‘Where are the boy’s heart and tongue?’ The girl reached the
+plate to him, but the king’s son threw off the quilt, and said: ‘You old
+sinner, why did you want to kill me? Now will I pronounce thy sentence.
+You shall become a black poodle and have a gold collar round your neck,
+and shall eat burning coals, till the flames burst forth from your
+throat.’ And when he had spoken these words, the old man was changed
+into a poodle dog, and had a gold collar round his neck, and the cooks
+were ordered to bring up some live coals, and these he ate, until the
+flames broke forth from his throat. The king’s son remained there a
+short while longer, and he thought of his mother, and wondered if she
+were still alive. At length he said to the maiden: ‘I will go home to my
+own country; if you will go with me, I will provide for you.’ ‘Ah,’
+she replied, ‘the way is so long, and what shall I do in a strange land
+where I am unknown?’ As she did not seem quite willing, and as they
+could not be parted from each other, he wished that she might be changed
+into a beautiful pink, and took her with him. Then he went away to his
+own country, and the poodle had to run after him. He went to the tower
+in which his mother was confined, and as it was so high, he wished for
+a ladder which would reach up to the very top. Then he mounted up and
+looked inside, and cried: ‘Beloved mother, Lady Queen, are you still
+alive, or are you dead?’ She answered: ‘I have just eaten, and am still
+satisfied,’ for she thought the angels were there. Said he: ‘I am your
+dear son, whom the wild beasts were said to have torn from your arms;
+but I am alive still, and will soon set you free.’ Then he descended
+again, and went to his father, and caused himself to be announced as a
+strange huntsman, and asked if he could offer him service. The king said
+yes, if he was skilful and could get game for him, he should come to
+him, but that deer had never taken up their quarters in any part of the
+district or country. Then the huntsman promised to procure as much game
+for him as he could possibly use at the royal table. So he summoned all
+the huntsmen together, and bade them go out into the forest with him.
+And he went with them and made them form a great circle, open at one end
+where he stationed himself, and began to wish. Two hundred deer and more
+came running inside the circle at once, and the huntsmen shot them.
+Then they were all placed on sixty country carts, and driven home to the
+king, and for once he was able to deck his table with game, after having
+had none at all for years.
+
+Now the king felt great joy at this, and commanded that his entire
+household should eat with him next day, and made a great feast. When
+they were all assembled together, he said to the huntsman: ‘As you are
+so clever, you shall sit by me.’ He replied: ‘Lord King, your majesty
+must excuse me, I am a poor huntsman.’ But the king insisted on it,
+and said: ‘You shall sit by me,’ until he did it. Whilst he was sitting
+there, he thought of his dearest mother, and wished that one of the
+king’s principal servants would begin to speak of her, and would ask how
+it was faring with the queen in the tower, and if she were alive still,
+or had perished. Hardly had he formed the wish than the marshal began,
+and said: ‘Your majesty, we live joyously here, but how is the queen
+living in the tower? Is she still alive, or has she died?’ But the king
+replied: ‘She let my dear son be torn to pieces by wild beasts; I will
+not have her named.’ Then the huntsman arose and said: ‘Gracious lord
+father she is alive still, and I am her son, and I was not carried away
+by wild beasts, but by that wretch the old cook, who tore me from her
+arms when she was asleep, and sprinkled her apron with the blood of a
+chicken.’ Thereupon he took the dog with the golden collar, and said:
+‘That is the wretch!’ and caused live coals to be brought, and these the
+dog was compelled to devour before the sight of all, until flames burst
+forth from its throat. On this the huntsman asked the king if he would
+like to see the dog in his true shape, and wished him back into the form
+of the cook, in the which he stood immediately, with his white apron,
+and his knife by his side. When the king saw him he fell into a passion,
+and ordered him to be cast into the deepest dungeon. Then the huntsman
+spoke further and said: ‘Father, will you see the maiden who brought me
+up so tenderly and who was afterwards to murder me, but did not do it,
+though her own life depended on it?’ The king replied: ‘Yes, I would
+like to see her.’ The son said: ‘Most gracious father, I will show her
+to you in the form of a beautiful flower,’ and he thrust his hand into
+his pocket and brought forth the pink, and placed it on the royal table,
+and it was so beautiful that the king had never seen one to equal it.
+Then the son said: ‘Now will I show her to you in her own form,’ and
+wished that she might become a maiden, and she stood there looking so
+beautiful that no painter could have made her look more so.
+
+And the king sent two waiting-maids and two attendants into the tower,
+to fetch the queen and bring her to the royal table. But when she was
+led in she ate nothing, and said: ‘The gracious and merciful God who has
+supported me in the tower, will soon set me free.’ She lived three days
+more, and then died happily, and when she was buried, the two white
+doves which had brought her food to the tower, and were angels of
+heaven, followed her body and seated themselves on her grave. The aged
+king ordered the cook to be torn in four pieces, but grief consumed the
+king’s own heart, and he soon died. His son married the beautiful maiden
+whom he had brought with him as a flower in his pocket, and whether they
+are still alive or not, is known to God.
+
+
+
+
+CLEVER ELSIE
+
+There was once a man who had a daughter who was called Clever Elsie. And
+when she had grown up her father said: ‘We will get her married.’ ‘Yes,’
+said the mother, ‘if only someone would come who would have her.’ At
+length a man came from a distance and wooed her, who was called Hans;
+but he stipulated that Clever Elsie should be really smart. ‘Oh,’ said
+the father, ‘she has plenty of good sense’; and the mother said: ‘Oh,
+she can see the wind coming up the street, and hear the flies coughing.’
+‘Well,’ said Hans, ‘if she is not really smart, I won’t have her.’ When
+they were sitting at dinner and had eaten, the mother said: ‘Elsie, go
+into the cellar and fetch some beer.’ Then Clever Elsie took the pitcher
+from the wall, went into the cellar, and tapped the lid briskly as she
+went, so that the time might not appear long. When she was below she
+fetched herself a chair, and set it before the barrel so that she had
+no need to stoop, and did not hurt her back or do herself any unexpected
+injury. Then she placed the can before her, and turned the tap, and
+while the beer was running she would not let her eyes be idle, but
+looked up at the wall, and after much peering here and there, saw a
+pick-axe exactly above her, which the masons had accidentally left
+there.
+
+Then Clever Elsie began to weep and said: ‘If I get Hans, and we have
+a child, and he grows big, and we send him into the cellar here to draw
+beer, then the pick-axe will fall on his head and kill him.’ Then she
+sat and wept and screamed with all the strength of her body, over the
+misfortune which lay before her. Those upstairs waited for the drink,
+but Clever Elsie still did not come. Then the woman said to the servant:
+‘Just go down into the cellar and see where Elsie is.’ The maid went and
+found her sitting in front of the barrel, screaming loudly. ‘Elsie why
+do you weep?’ asked the maid. ‘Ah,’ she answered, ‘have I not reason to
+weep? If I get Hans, and we have a child, and he grows big, and has to
+draw beer here, the pick-axe will perhaps fall on his head, and kill
+him.’ Then said the maid: ‘What a clever Elsie we have!’ and sat down
+beside her and began loudly to weep over the misfortune. After a while,
+as the maid did not come back, and those upstairs were thirsty for the
+beer, the man said to the boy: ‘Just go down into the cellar and see
+where Elsie and the girl are.’ The boy went down, and there sat Clever
+Elsie and the girl both weeping together. Then he asked: ‘Why are you
+weeping?’ ‘Ah,’ said Elsie, ‘have I not reason to weep? If I get Hans,
+and we have a child, and he grows big, and has to draw beer here, the
+pick-axe will fall on his head and kill him.’ Then said the boy: ‘What
+a clever Elsie we have!’ and sat down by her, and likewise began to
+howl loudly. Upstairs they waited for the boy, but as he still did not
+return, the man said to the woman: ‘Just go down into the cellar and see
+where Elsie is!’ The woman went down, and found all three in the midst
+of their lamentations, and inquired what was the cause; then Elsie told
+her also that her future child was to be killed by the pick-axe, when it
+grew big and had to draw beer, and the pick-axe fell down. Then said the
+mother likewise: ‘What a clever Elsie we have!’ and sat down and wept
+with them. The man upstairs waited a short time, but as his wife did not
+come back and his thirst grew ever greater, he said: ‘I must go into the
+cellar myself and see where Elsie is.’ But when he got into the cellar,
+and they were all sitting together crying, and he heard the reason, and
+that Elsie’s child was the cause, and the Elsie might perhaps bring one
+into the world some day, and that he might be killed by the pick-axe, if
+he should happen to be sitting beneath it, drawing beer just at the very
+time when it fell down, he cried: ‘Oh, what a clever Elsie!’ and sat
+down, and likewise wept with them. The bridegroom stayed upstairs alone
+for a long time; then as no one would come back he thought: ‘They must be
+waiting for me below: I too must go there and see what they are about.’
+When he got down, the five of them were sitting screaming and lamenting
+quite piteously, each out-doing the other. ‘What misfortune has happened
+then?’ asked he. ‘Ah, dear Hans,’ said Elsie, ‘if we marry each other
+and have a child, and he is big, and we perhaps send him here to draw
+something to drink, then the pick-axe which has been left up there might
+dash his brains out if it were to fall down, so have we not reason to
+weep?’ ‘Come,’ said Hans, ‘more understanding than that is not needed
+for my household, as you are such a clever Elsie, I will have you,’ and
+seized her hand, took her upstairs with him, and married her.
+
+After Hans had had her some time, he said: ‘Wife, I am going out to work
+and earn some money for us; go into the field and cut the corn that we
+may have some bread.’ ‘Yes, dear Hans, I will do that.’ After Hans had
+gone away, she cooked herself some good broth and took it into the field
+with her. When she came to the field she said to herself: ‘What shall I
+do; shall I cut first, or shall I eat first? Oh, I will eat first.’ Then
+she drank her cup of broth and when she was fully satisfied, she once
+more said: ‘What shall I do? Shall I cut first, or shall I sleep first?
+I will sleep first.’ Then she lay down among the corn and fell asleep.
+Hans had been at home for a long time, but Elsie did not come; then said
+he: ‘What a clever Elsie I have; she is so industrious that she does not
+even come home to eat.’ But when evening came and she still stayed away,
+Hans went out to see what she had cut, but nothing was cut, and she
+was lying among the corn asleep. Then Hans hastened home and brought
+a fowler’s net with little bells and hung it round about her, and she
+still went on sleeping. Then he ran home, shut the house-door, and sat
+down in his chair and worked. At length, when it was quite dark, Clever
+Elsie awoke and when she got up there was a jingling all round about
+her, and the bells rang at each step which she took. Then she was
+alarmed, and became uncertain whether she really was Clever Elsie or
+not, and said: ‘Is it I, or is it not I?’ But she knew not what answer
+to make to this, and stood for a time in doubt; at length she thought:
+‘I will go home and ask if it be I, or if it be not I, they will be sure
+to know.’ She ran to the door of her own house, but it was shut; then
+she knocked at the window and cried: ‘Hans, is Elsie within?’ ‘Yes,’
+answered Hans, ‘she is within.’ Hereupon she was terrified, and said:
+‘Ah, heavens! Then it is not I,’ and went to another door; but when the
+people heard the jingling of the bells they would not open it, and she
+could get in nowhere. Then she ran out of the village, and no one has
+seen her since.
+
+
+
+
+THE MISER IN THE BUSH
+
+A farmer had a faithful and diligent servant, who had worked hard for
+him three years, without having been paid any wages. At last it came
+into the man’s head that he would not go on thus without pay any longer;
+so he went to his master, and said, ‘I have worked hard for you a long
+time, I will trust to you to give me what I deserve to have for my
+trouble.’ The farmer was a sad miser, and knew that his man was very
+simple-hearted; so he took out threepence, and gave him for every year’s
+service a penny. The poor fellow thought it was a great deal of money to
+have, and said to himself, ‘Why should I work hard, and live here on bad
+fare any longer? I can now travel into the wide world, and make myself
+merry.’ With that he put his money into his purse, and set out, roaming
+over hill and valley.
+
+As he jogged along over the fields, singing and dancing, a little dwarf
+met him, and asked him what made him so merry. ‘Why, what should make
+me down-hearted?’ said he; ‘I am sound in health and rich in purse, what
+should I care for? I have saved up my three years’ earnings and have it
+all safe in my pocket.’ ‘How much may it come to?’ said the little man.
+‘Full threepence,’ replied the countryman. ‘I wish you would give them
+to me,’ said the other; ‘I am very poor.’ Then the man pitied him, and
+gave him all he had; and the little dwarf said in return, ‘As you have
+such a kind honest heart, I will grant you three wishes--one for every
+penny; so choose whatever you like.’ Then the countryman rejoiced at
+his good luck, and said, ‘I like many things better than money: first, I
+will have a bow that will bring down everything I shoot at; secondly,
+a fiddle that will set everyone dancing that hears me play upon it; and
+thirdly, I should like that everyone should grant what I ask.’ The dwarf
+said he should have his three wishes; so he gave him the bow and fiddle,
+and went his way.
+
+Our honest friend journeyed on his way too; and if he was merry before,
+he was now ten times more so. He had not gone far before he met an old
+miser: close by them stood a tree, and on the topmost twig sat a thrush
+singing away most joyfully. ‘Oh, what a pretty bird!’ said the miser; ‘I
+would give a great deal of money to have such a one.’ ‘If that’s all,’
+said the countryman, ‘I will soon bring it down.’ Then he took up his
+bow, and down fell the thrush into the bushes at the foot of the tree.
+The miser crept into the bush to find it; but directly he had got into
+the middle, his companion took up his fiddle and played away, and the
+miser began to dance and spring about, capering higher and higher in
+the air. The thorns soon began to tear his clothes till they all hung
+in rags about him, and he himself was all scratched and wounded, so that
+the blood ran down. ‘Oh, for heaven’s sake!’ cried the miser, ‘Master!
+master! pray let the fiddle alone. What have I done to deserve this?’
+‘Thou hast shaved many a poor soul close enough,’ said the other; ‘thou
+art only meeting thy reward’: so he played up another tune. Then the
+miser began to beg and promise, and offered money for his liberty; but
+he did not come up to the musician’s price for some time, and he danced
+him along brisker and brisker, and the miser bid higher and higher, till
+at last he offered a round hundred of florins that he had in his purse,
+and had just gained by cheating some poor fellow. When the countryman
+saw so much money, he said, ‘I will agree to your proposal.’ So he took
+the purse, put up his fiddle, and travelled on very pleased with his
+bargain.
+
+Meanwhile the miser crept out of the bush half-naked and in a piteous
+plight, and began to ponder how he should take his revenge, and serve
+his late companion some trick. At last he went to the judge, and
+complained that a rascal had robbed him of his money, and beaten him
+into the bargain; and that the fellow who did it carried a bow at his
+back and a fiddle hung round his neck. Then the judge sent out his
+officers to bring up the accused wherever they should find him; and he
+was soon caught and brought up to be tried.
+
+The miser began to tell his tale, and said he had been robbed of
+his money. ‘No, you gave it me for playing a tune to you.’ said the
+countryman; but the judge told him that was not likely, and cut the
+matter short by ordering him off to the gallows.
+
+So away he was taken; but as he stood on the steps he said, ‘My Lord
+Judge, grant me one last request.’ ‘Anything but thy life,’ replied the
+other. ‘No,’ said he, ‘I do not ask my life; only to let me play upon
+my fiddle for the last time.’ The miser cried out, ‘Oh, no! no! for
+heaven’s sake don’t listen to him! don’t listen to him!’ But the judge
+said, ‘It is only this once, he will soon have done.’ The fact was, he
+could not refuse the request, on account of the dwarf’s third gift.
+
+Then the miser said, ‘Bind me fast, bind me fast, for pity’s sake.’ But
+the countryman seized his fiddle, and struck up a tune, and at the first
+note judge, clerks, and jailer were in motion; all began capering, and
+no one could hold the miser. At the second note the hangman let his
+prisoner go, and danced also, and by the time he had played the first
+bar of the tune, all were dancing together--judge, court, and miser, and
+all the people who had followed to look on. At first the thing was merry
+and pleasant enough; but when it had gone on a while, and there seemed
+to be no end of playing or dancing, they began to cry out, and beg him
+to leave off; but he stopped not a whit the more for their entreaties,
+till the judge not only gave him his life, but promised to return him
+the hundred florins.
+
+Then he called to the miser, and said, ‘Tell us now, you vagabond, where
+you got that gold, or I shall play on for your amusement only,’ ‘I stole
+it,’ said the miser in the presence of all the people; ‘I acknowledge
+that I stole it, and that you earned it fairly.’ Then the countryman
+stopped his fiddle, and left the miser to take his place at the gallows.
+
+
+
+
+ASHPUTTEL
+
+The wife of a rich man fell sick; and when she felt that her end drew
+nigh, she called her only daughter to her bed-side, and said, ‘Always be
+a good girl, and I will look down from heaven and watch over you.’ Soon
+afterwards she shut her eyes and died, and was buried in the garden;
+and the little girl went every day to her grave and wept, and was always
+good and kind to all about her. And the snow fell and spread a beautiful
+white covering over the grave; but by the time the spring came, and the
+sun had melted it away again, her father had married another wife. This
+new wife had two daughters of her own, that she brought home with her;
+they were fair in face but foul at heart, and it was now a sorry time
+for the poor little girl. ‘What does the good-for-nothing want in the
+parlour?’ said they; ‘they who would eat bread should first earn it;
+away with the kitchen-maid!’ Then they took away her fine clothes, and
+gave her an old grey frock to put on, and laughed at her, and turned her
+into the kitchen.
+
+There she was forced to do hard work; to rise early before daylight, to
+bring the water, to make the fire, to cook and to wash. Besides that,
+the sisters plagued her in all sorts of ways, and laughed at her. In the
+evening when she was tired, she had no bed to lie down on, but was made
+to lie by the hearth among the ashes; and as this, of course, made her
+always dusty and dirty, they called her Ashputtel.
+
+It happened once that the father was going to the fair, and asked his
+wife’s daughters what he should bring them. ‘Fine clothes,’ said the
+first; ‘Pearls and diamonds,’ cried the second. ‘Now, child,’ said he
+to his own daughter, ‘what will you have?’ ‘The first twig, dear
+father, that brushes against your hat when you turn your face to come
+homewards,’ said she. Then he bought for the first two the fine clothes
+and pearls and diamonds they had asked for: and on his way home, as he
+rode through a green copse, a hazel twig brushed against him, and almost
+pushed off his hat: so he broke it off and brought it away; and when he
+got home he gave it to his daughter. Then she took it, and went to
+her mother’s grave and planted it there; and cried so much that it was
+watered with her tears; and there it grew and became a fine tree. Three
+times every day she went to it and cried; and soon a little bird came
+and built its nest upon the tree, and talked with her, and watched over
+her, and brought her whatever she wished for.
+
+Now it happened that the king of that land held a feast, which was to
+last three days; and out of those who came to it his son was to choose
+a bride for himself. Ashputtel’s two sisters were asked to come; so they
+called her up, and said, ‘Now, comb our hair, brush our shoes, and tie
+our sashes for us, for we are going to dance at the king’s feast.’
+Then she did as she was told; but when all was done she could not help
+crying, for she thought to herself, she should so have liked to have
+gone with them to the ball; and at last she begged her mother very hard
+to let her go. ‘You, Ashputtel!’ said she; ‘you who have nothing to
+wear, no clothes at all, and who cannot even dance--you want to go to
+the ball? And when she kept on begging, she said at last, to get rid of
+her, ‘I will throw this dishful of peas into the ash-heap, and if in
+two hours’ time you have picked them all out, you shall go to the feast
+too.’
+
+Then she threw the peas down among the ashes, but the little maiden ran
+out at the back door into the garden, and cried out:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves, flying in at the kitchen window; next
+came two turtle-doves; and after them came all the little birds under
+heaven, chirping and fluttering in: and they flew down into the ashes.
+And the little doves stooped their heads down and set to work, pick,
+pick, pick; and then the others began to pick, pick, pick: and among
+them all they soon picked out all the good grain, and put it into a dish
+but left the ashes. Long before the end of the hour the work was quite
+done, and all flew out again at the windows.
+
+Then Ashputtel brought the dish to her mother, overjoyed at the thought
+that now she should go to the ball. But the mother said, ‘No, no! you
+slut, you have no clothes, and cannot dance; you shall not go.’ And when
+Ashputtel begged very hard to go, she said, ‘If you can in one hour’s
+time pick two of those dishes of peas out of the ashes, you shall go
+too.’ And thus she thought she should at least get rid of her. So she
+shook two dishes of peas into the ashes.
+
+But the little maiden went out into the garden at the back of the house,
+and cried out as before:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves in at the kitchen window; next came two
+turtle-doves; and after them came all the little birds under heaven,
+chirping and hopping about. And they flew down into the ashes; and the
+little doves put their heads down and set to work, pick, pick, pick; and
+then the others began pick, pick, pick; and they put all the good grain
+into the dishes, and left all the ashes. Before half an hour’s time all
+was done, and out they flew again. And then Ashputtel took the dishes to
+her mother, rejoicing to think that she should now go to the ball.
+But her mother said, ‘It is all of no use, you cannot go; you have no
+clothes, and cannot dance, and you would only put us to shame’: and off
+she went with her two daughters to the ball.
+
+Now when all were gone, and nobody left at home, Ashputtel went
+sorrowfully and sat down under the hazel-tree, and cried out:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her friend the bird flew out of the tree, and brought a gold and
+silver dress for her, and slippers of spangled silk; and she put them
+on, and followed her sisters to the feast. But they did not know her,
+and thought it must be some strange princess, she looked so fine and
+beautiful in her rich clothes; and they never once thought of Ashputtel,
+taking it for granted that she was safe at home in the dirt.
+
+The king’s son soon came up to her, and took her by the hand and danced
+with her, and no one else: and he never left her hand; but when anyone
+else came to ask her to dance, he said, ‘This lady is dancing with me.’
+
+Thus they danced till a late hour of the night; and then she wanted to
+go home: and the king’s son said, ‘I shall go and take care of you to
+your home’; for he wanted to see where the beautiful maiden lived. But
+she slipped away from him, unawares, and ran off towards home; and as
+the prince followed her, she jumped up into the pigeon-house and shut
+the door. Then he waited till her father came home, and told him that
+the unknown maiden, who had been at the feast, had hid herself in the
+pigeon-house. But when they had broken open the door they found no one
+within; and as they came back into the house, Ashputtel was lying, as
+she always did, in her dirty frock by the ashes, and her dim little
+lamp was burning in the chimney. For she had run as quickly as she could
+through the pigeon-house and on to the hazel-tree, and had there taken
+off her beautiful clothes, and put them beneath the tree, that the bird
+might carry them away, and had lain down again amid the ashes in her
+little grey frock.
+
+The next day when the feast was again held, and her father, mother, and
+sisters were gone, Ashputtel went to the hazel-tree, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+And the bird came and brought a still finer dress than the one she
+had worn the day before. And when she came in it to the ball, everyone
+wondered at her beauty: but the king’s son, who was waiting for her,
+took her by the hand, and danced with her; and when anyone asked her to
+dance, he said as before, ‘This lady is dancing with me.’
+
+When night came she wanted to go home; and the king’s son followed here
+as before, that he might see into what house she went: but she sprang
+away from him all at once into the garden behind her father’s house.
+In this garden stood a fine large pear-tree full of ripe fruit; and
+Ashputtel, not knowing where to hide herself, jumped up into it without
+being seen. Then the king’s son lost sight of her, and could not find
+out where she was gone, but waited till her father came home, and said
+to him, ‘The unknown lady who danced with me has slipped away, and I
+think she must have sprung into the pear-tree.’ The father thought to
+himself, ‘Can it be Ashputtel?’ So he had an axe brought; and they cut
+down the tree, but found no one upon it. And when they came back into
+the kitchen, there lay Ashputtel among the ashes; for she had slipped
+down on the other side of the tree, and carried her beautiful clothes
+back to the bird at the hazel-tree, and then put on her little grey
+frock.
+
+The third day, when her father and mother and sisters were gone, she
+went again into the garden, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her kind friend the bird brought a dress still finer than the
+former one, and slippers which were all of gold: so that when she came
+to the feast no one knew what to say, for wonder at her beauty: and the
+king’s son danced with nobody but her; and when anyone else asked her to
+dance, he said, ‘This lady is _my_ partner, sir.’
+
+When night came she wanted to go home; and the king’s son would go with
+her, and said to himself, ‘I will not lose her this time’; but, however,
+she again slipped away from him, though in such a hurry that she dropped
+her left golden slipper upon the stairs.
+
+The prince took the shoe, and went the next day to the king his father,
+and said, ‘I will take for my wife the lady that this golden slipper
+fits.’ Then both the sisters were overjoyed to hear it; for they
+had beautiful feet, and had no doubt that they could wear the golden
+slipper. The eldest went first into the room where the slipper was, and
+wanted to try it on, and the mother stood by. But her great toe could
+not go into it, and the shoe was altogether much too small for her. Then
+the mother gave her a knife, and said, ‘Never mind, cut it off; when you
+are queen you will not care about toes; you will not want to walk.’ So
+the silly girl cut off her great toe, and thus squeezed on the shoe,
+and went to the king’s son. Then he took her for his bride, and set her
+beside him on his horse, and rode away with her homewards.
+
+But on their way home they had to pass by the hazel-tree that Ashputtel
+had planted; and on the branch sat a little dove singing:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then the prince got down and looked at her foot; and he saw, by the
+blood that streamed from it, what a trick she had played him. So he
+turned his horse round, and brought the false bride back to her home,
+and said, ‘This is not the right bride; let the other sister try and put
+on the slipper.’ Then she went into the room and got her foot into the
+shoe, all but the heel, which was too large. But her mother squeezed it
+in till the blood came, and took her to the king’s son: and he set her
+as his bride by his side on his horse, and rode away with her.
+
+But when they came to the hazel-tree the little dove sat there still,
+and sang:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then he looked down, and saw that the blood streamed so much from the
+shoe, that her white stockings were quite red. So he turned his horse
+and brought her also back again. ‘This is not the true bride,’ said he
+to the father; ‘have you no other daughters?’ ‘No,’ said he; ‘there is
+only a little dirty Ashputtel here, the child of my first wife; I am
+sure she cannot be the bride.’ The prince told him to send her. But the
+mother said, ‘No, no, she is much too dirty; she will not dare to show
+herself.’ However, the prince would have her come; and she first washed
+her face and hands, and then went in and curtsied to him, and he reached
+her the golden slipper. Then she took her clumsy shoe off her left foot,
+and put on the golden slipper; and it fitted her as if it had been made
+for her. And when he drew near and looked at her face he knew her, and
+said, ‘This is the right bride.’ But the mother and both the sisters
+were frightened, and turned pale with anger as he took Ashputtel on his
+horse, and rode away with her. And when they came to the hazel-tree, the
+white dove sang:
+
+ ‘Home! home! look at the shoe!
+  Princess! the shoe was made for you!
+  Prince! prince! take home thy bride,
+  For she is the true one that sits by thy side!’
+
+And when the dove had done its song, it came flying, and perched upon
+her right shoulder, and so went home with her.
+
+
+
+
+THE WHITE SNAKE
+
+A long time ago there lived a king who was famed for his wisdom through
+all the land. Nothing was hidden from him, and it seemed as if news of
+the most secret things was brought to him through the air. But he had a
+strange custom; every day after dinner, when the table was cleared,
+and no one else was present, a trusty servant had to bring him one more
+dish. It was covered, however, and even the servant did not know what
+was in it, neither did anyone know, for the king never took off the
+cover to eat of it until he was quite alone.
+
+This had gone on for a long time, when one day the servant, who took
+away the dish, was overcome with such curiosity that he could not help
+carrying the dish into his room. When he had carefully locked the door,
+he lifted up the cover, and saw a white snake lying on the dish. But
+when he saw it he could not deny himself the pleasure of tasting it,
+so he cut of a little bit and put it into his mouth. No sooner had it
+touched his tongue than he heard a strange whispering of little voices
+outside his window. He went and listened, and then noticed that it was
+the sparrows who were chattering together, and telling one another of
+all kinds of things which they had seen in the fields and woods. Eating
+the snake had given him power of understanding the language of animals.
+
+Now it so happened that on this very day the queen lost her most
+beautiful ring, and suspicion of having stolen it fell upon this trusty
+servant, who was allowed to go everywhere. The king ordered the man to
+be brought before him, and threatened with angry words that unless he
+could before the morrow point out the thief, he himself should be looked
+upon as guilty and executed. In vain he declared his innocence; he was
+dismissed with no better answer.
+
+In his trouble and fear he went down into the courtyard and took thought
+how to help himself out of his trouble. Now some ducks were sitting
+together quietly by a brook and taking their rest; and, whilst they
+were making their feathers smooth with their bills, they were having a
+confidential conversation together. The servant stood by and listened.
+They were telling one another of all the places where they had been
+waddling about all the morning, and what good food they had found; and
+one said in a pitiful tone: ‘Something lies heavy on my stomach; as
+I was eating in haste I swallowed a ring which lay under the queen’s
+window.’ The servant at once seized her by the neck, carried her to the
+kitchen, and said to the cook: ‘Here is a fine duck; pray, kill her.’
+‘Yes,’ said the cook, and weighed her in his hand; ‘she has spared
+no trouble to fatten herself, and has been waiting to be roasted long
+enough.’ So he cut off her head, and as she was being dressed for the
+spit, the queen’s ring was found inside her.
+
+The servant could now easily prove his innocence; and the king, to make
+amends for the wrong, allowed him to ask a favour, and promised him
+the best place in the court that he could wish for. The servant refused
+everything, and only asked for a horse and some money for travelling, as
+he had a mind to see the world and go about a little. When his request
+was granted he set out on his way, and one day came to a pond, where he
+saw three fishes caught in the reeds and gasping for water. Now, though
+it is said that fishes are dumb, he heard them lamenting that they must
+perish so miserably, and, as he had a kind heart, he got off his
+horse and put the three prisoners back into the water. They leapt with
+delight, put out their heads, and cried to him: ‘We will remember you
+and repay you for saving us!’
+
+He rode on, and after a while it seemed to him that he heard a voice in
+the sand at his feet. He listened, and heard an ant-king complain: ‘Why
+cannot folks, with their clumsy beasts, keep off our bodies? That stupid
+horse, with his heavy hoofs, has been treading down my people without
+mercy!’ So he turned on to a side path and the ant-king cried out to
+him: ‘We will remember you--one good turn deserves another!’
+
+The path led him into a wood, and there he saw two old ravens standing
+by their nest, and throwing out their young ones. ‘Out with you, you
+idle, good-for-nothing creatures!’ cried they; ‘we cannot find food for
+you any longer; you are big enough, and can provide for yourselves.’
+But the poor young ravens lay upon the ground, flapping their wings, and
+crying: ‘Oh, what helpless chicks we are! We must shift for ourselves,
+and yet we cannot fly! What can we do, but lie here and starve?’ So the
+good young fellow alighted and killed his horse with his sword, and gave
+it to them for food. Then they came hopping up to it, satisfied their
+hunger, and cried: ‘We will remember you--one good turn deserves
+another!’
+
+And now he had to use his own legs, and when he had walked a long
+way, he came to a large city. There was a great noise and crowd in
+the streets, and a man rode up on horseback, crying aloud: ‘The king’s
+daughter wants a husband; but whoever seeks her hand must perform a hard
+task, and if he does not succeed he will forfeit his life.’ Many had
+already made the attempt, but in vain; nevertheless when the youth
+saw the king’s daughter he was so overcome by her great beauty that he
+forgot all danger, went before the king, and declared himself a suitor.
+
+So he was led out to the sea, and a gold ring was thrown into it, before
+his eyes; then the king ordered him to fetch this ring up from the
+bottom of the sea, and added: ‘If you come up again without it you will
+be thrown in again and again until you perish amid the waves.’ All the
+people grieved for the handsome youth; then they went away, leaving him
+alone by the sea.
+
+He stood on the shore and considered what he should do, when suddenly
+he saw three fishes come swimming towards him, and they were the very
+fishes whose lives he had saved. The one in the middle held a mussel in
+its mouth, which it laid on the shore at the youth’s feet, and when he
+had taken it up and opened it, there lay the gold ring in the shell.
+Full of joy he took it to the king and expected that he would grant him
+the promised reward.
+
+But when the proud princess perceived that he was not her equal in
+birth, she scorned him, and required him first to perform another
+task. She went down into the garden and strewed with her own hands ten
+sacksful of millet-seed on the grass; then she said: ‘Tomorrow morning
+before sunrise these must be picked up, and not a single grain be
+wanting.’
+
+The youth sat down in the garden and considered how it might be possible
+to perform this task, but he could think of nothing, and there he sat
+sorrowfully awaiting the break of day, when he should be led to death.
+But as soon as the first rays of the sun shone into the garden he saw
+all the ten sacks standing side by side, quite full, and not a single
+grain was missing. The ant-king had come in the night with thousands
+and thousands of ants, and the grateful creatures had by great industry
+picked up all the millet-seed and gathered them into the sacks.
+
+Presently the king’s daughter herself came down into the garden, and was
+amazed to see that the young man had done the task she had given him.
+But she could not yet conquer her proud heart, and said: ‘Although he
+has performed both the tasks, he shall not be my husband until he had
+brought me an apple from the Tree of Life.’ The youth did not know where
+the Tree of Life stood, but he set out, and would have gone on for ever,
+as long as his legs would carry him, though he had no hope of finding
+it. After he had wandered through three kingdoms, he came one evening to
+a wood, and lay down under a tree to sleep. But he heard a rustling in
+the branches, and a golden apple fell into his hand. At the same time
+three ravens flew down to him, perched themselves upon his knee, and
+said: ‘We are the three young ravens whom you saved from starving; when
+we had grown big, and heard that you were seeking the Golden Apple,
+we flew over the sea to the end of the world, where the Tree of Life
+stands, and have brought you the apple.’ The youth, full of joy, set out
+homewards, and took the Golden Apple to the king’s beautiful daughter,
+who had now no more excuses left to make. They cut the Apple of Life in
+two and ate it together; and then her heart became full of love for him,
+and they lived in undisturbed happiness to a great age.
+
+
+
+
+THE WOLF AND THE SEVEN LITTLE KIDS
+
+There was once upon a time an old goat who had seven little kids, and
+loved them with all the love of a mother for her children. One day she
+wanted to go into the forest and fetch some food. So she called all
+seven to her and said: ‘Dear children, I have to go into the forest,
+be on your guard against the wolf; if he comes in, he will devour you
+all--skin, hair, and everything. The wretch often disguises himself, but
+you will know him at once by his rough voice and his black feet.’ The
+kids said: ‘Dear mother, we will take good care of ourselves; you may go
+away without any anxiety.’ Then the old one bleated, and went on her way
+with an easy mind.
+
+It was not long before someone knocked at the house-door and called:
+‘Open the door, dear children; your mother is here, and has brought
+something back with her for each of you.’ But the little kids knew that
+it was the wolf, by the rough voice. ‘We will not open the door,’ cried
+they, ‘you are not our mother. She has a soft, pleasant voice, but
+your voice is rough; you are the wolf!’ Then the wolf went away to a
+shopkeeper and bought himself a great lump of chalk, ate this and made
+his voice soft with it. Then he came back, knocked at the door of the
+house, and called: ‘Open the door, dear children, your mother is here
+and has brought something back with her for each of you.’ But the wolf
+had laid his black paws against the window, and the children saw them
+and cried: ‘We will not open the door, our mother has not black feet
+like you: you are the wolf!’ Then the wolf ran to a baker and said: ‘I
+have hurt my feet, rub some dough over them for me.’ And when the baker
+had rubbed his feet over, he ran to the miller and said: ‘Strew some
+white meal over my feet for me.’ The miller thought to himself: ‘The
+wolf wants to deceive someone,’ and refused; but the wolf said: ‘If you
+will not do it, I will devour you.’ Then the miller was afraid, and made
+his paws white for him. Truly, this is the way of mankind.
+
+So now the wretch went for the third time to the house-door, knocked at
+it and said: ‘Open the door for me, children, your dear little mother
+has come home, and has brought every one of you something back from the
+forest with her.’ The little kids cried: ‘First show us your paws that
+we may know if you are our dear little mother.’ Then he put his paws
+in through the window and when the kids saw that they were white, they
+believed that all he said was true, and opened the door. But who should
+come in but the wolf! They were terrified and wanted to hide themselves.
+One sprang under the table, the second into the bed, the third into the
+stove, the fourth into the kitchen, the fifth into the cupboard, the
+sixth under the washing-bowl, and the seventh into the clock-case. But
+the wolf found them all, and used no great ceremony; one after the
+other he swallowed them down his throat. The youngest, who was in
+the clock-case, was the only one he did not find. When the wolf had
+satisfied his appetite he took himself off, laid himself down under a
+tree in the green meadow outside, and began to sleep. Soon afterwards
+the old goat came home again from the forest. Ah! what a sight she saw
+there! The house-door stood wide open. The table, chairs, and benches
+were thrown down, the washing-bowl lay broken to pieces, and the quilts
+and pillows were pulled off the bed. She sought her children, but they
+were nowhere to be found. She called them one after another by name, but
+no one answered. At last, when she came to the youngest, a soft voice
+cried: ‘Dear mother, I am in the clock-case.’ She took the kid out, and
+it told her that the wolf had come and had eaten all the others. Then
+you may imagine how she wept over her poor children.
+
+At length in her grief she went out, and the youngest kid ran with her.
+When they came to the meadow, there lay the wolf by the tree and snored
+so loud that the branches shook. She looked at him on every side and
+saw that something was moving and struggling in his gorged belly. ‘Ah,
+heavens,’ she said, ‘is it possible that my poor children whom he has
+swallowed down for his supper, can be still alive?’ Then the kid had to
+run home and fetch scissors, and a needle and thread, and the goat cut
+open the monster’s stomach, and hardly had she made one cut, than one
+little kid thrust its head out, and when she had cut farther, all six
+sprang out one after another, and were all still alive, and had suffered
+no injury whatever, for in his greediness the monster had swallowed them
+down whole. What rejoicing there was! They embraced their dear mother,
+and jumped like a tailor at his wedding. The mother, however, said: ‘Now
+go and look for some big stones, and we will fill the wicked beast’s
+stomach with them while he is still asleep.’ Then the seven kids dragged
+the stones thither with all speed, and put as many of them into this
+stomach as they could get in; and the mother sewed him up again in the
+greatest haste, so that he was not aware of anything and never once
+stirred.
+
+When the wolf at length had had his fill of sleep, he got on his legs,
+and as the stones in his stomach made him very thirsty, he wanted to
+go to a well to drink. But when he began to walk and to move about, the
+stones in his stomach knocked against each other and rattled. Then cried
+he:
+
+ ‘What rumbles and tumbles
+  Against my poor bones?
+  I thought ‘twas six kids,
+  But it feels like big stones.’
+
+And when he got to the well and stooped over the water to drink, the
+heavy stones made him fall in, and he drowned miserably. When the seven
+kids saw that, they came running to the spot and cried aloud: ‘The wolf
+is dead! The wolf is dead!’ and danced for joy round about the well with
+their mother.
+
+
+
+
+THE QUEEN BEE
+
+Two kings’ sons once upon a time went into the world to seek their
+fortunes; but they soon fell into a wasteful foolish way of living, so
+that they could not return home again. Then their brother, who was a
+little insignificant dwarf, went out to seek for his brothers: but when
+he had found them they only laughed at him, to think that he, who was so
+young and simple, should try to travel through the world, when they, who
+were so much wiser, had been unable to get on. However, they all set
+out on their journey together, and came at last to an ant-hill. The two
+elder brothers would have pulled it down, in order to see how the poor
+ants in their fright would run about and carry off their eggs. But the
+little dwarf said, ‘Let the poor things enjoy themselves, I will not
+suffer you to trouble them.’
+
+So on they went, and came to a lake where many many ducks were swimming
+about. The two brothers wanted to catch two, and roast them. But the
+dwarf said, ‘Let the poor things enjoy themselves, you shall not kill
+them.’ Next they came to a bees’-nest in a hollow tree, and there was
+so much honey that it ran down the trunk; and the two brothers wanted to
+light a fire under the tree and kill the bees, so as to get their honey.
+But the dwarf held them back, and said, ‘Let the pretty insects enjoy
+themselves, I cannot let you burn them.’
+
+At length the three brothers came to a castle: and as they passed by the
+stables they saw fine horses standing there, but all were of marble, and
+no man was to be seen. Then they went through all the rooms, till they
+came to a door on which were three locks: but in the middle of the door
+was a wicket, so that they could look into the next room. There they saw
+a little grey old man sitting at a table; and they called to him once or
+twice, but he did not hear: however, they called a third time, and then
+he rose and came out to them.
+
+He said nothing, but took hold of them and led them to a beautiful
+table covered with all sorts of good things: and when they had eaten and
+drunk, he showed each of them to a bed-chamber.
+
+The next morning he came to the eldest and took him to a marble table,
+where there were three tablets, containing an account of the means by
+which the castle might be disenchanted. The first tablet said: ‘In the
+wood, under the moss, lie the thousand pearls belonging to the king’s
+daughter; they must all be found: and if one be missing by set of sun,
+he who seeks them will be turned into marble.’
+
+The eldest brother set out, and sought for the pearls the whole day:
+but the evening came, and he had not found the first hundred: so he was
+turned into stone as the tablet had foretold.
+
+The next day the second brother undertook the task; but he succeeded no
+better than the first; for he could only find the second hundred of the
+pearls; and therefore he too was turned into stone.
+
+At last came the little dwarf’s turn; and he looked in the moss; but it
+was so hard to find the pearls, and the job was so tiresome!--so he sat
+down upon a stone and cried. And as he sat there, the king of the ants
+(whose life he had saved) came to help him, with five thousand ants; and
+it was not long before they had found all the pearls and laid them in a
+heap.
+
+The second tablet said: ‘The key of the princess’s bed-chamber must be
+fished up out of the lake.’ And as the dwarf came to the brink of it,
+he saw the two ducks whose lives he had saved swimming about; and they
+dived down and soon brought in the key from the bottom.
+
+The third task was the hardest. It was to choose out the youngest and
+the best of the king’s three daughters. Now they were all beautiful, and
+all exactly alike: but he was told that the eldest had eaten a piece of
+sugar, the next some sweet syrup, and the youngest a spoonful of honey;
+so he was to guess which it was that had eaten the honey.
+
+Then came the queen of the bees, who had been saved by the little dwarf
+from the fire, and she tried the lips of all three; but at last she sat
+upon the lips of the one that had eaten the honey: and so the dwarf knew
+which was the youngest. Thus the spell was broken, and all who had been
+turned into stones awoke, and took their proper forms. And the dwarf
+married the youngest and the best of the princesses, and was king after
+her father’s death; but his two brothers married the other two sisters.
+
+
+
+
+THE ELVES AND THE SHOEMAKER
+
+There was once a shoemaker, who worked very hard and was very honest:
+but still he could not earn enough to live upon; and at last all he
+had in the world was gone, save just leather enough to make one pair of
+shoes.
+
+Then he cut his leather out, all ready to make up the next day, meaning
+to rise early in the morning to his work. His conscience was clear and
+his heart light amidst all his troubles; so he went peaceably to bed,
+left all his cares to Heaven, and soon fell asleep. In the morning after
+he had said his prayers, he sat himself down to his work; when, to his
+great wonder, there stood the shoes all ready made, upon the table. The
+good man knew not what to say or think at such an odd thing happening.
+He looked at the workmanship; there was not one false stitch in the
+whole job; all was so neat and true, that it was quite a masterpiece.
+
+The same day a customer came in, and the shoes suited him so well that
+he willingly paid a price higher than usual for them; and the poor
+shoemaker, with the money, bought leather enough to make two pairs more.
+In the evening he cut out the work, and went to bed early, that he might
+get up and begin betimes next day; but he was saved all the trouble, for
+when he got up in the morning the work was done ready to his hand. Soon
+in came buyers, who paid him handsomely for his goods, so that he bought
+leather enough for four pair more. He cut out the work again overnight
+and found it done in the morning, as before; and so it went on for some
+time: what was got ready in the evening was always done by daybreak, and
+the good man soon became thriving and well off again.
+
+One evening, about Christmas-time, as he and his wife were sitting over
+the fire chatting together, he said to her, ‘I should like to sit up and
+watch tonight, that we may see who it is that comes and does my work for
+me.’ The wife liked the thought; so they left a light burning, and hid
+themselves in a corner of the room, behind a curtain that was hung up
+there, and watched what would happen.
+
+As soon as it was midnight, there came in two little naked dwarfs; and
+they sat themselves upon the shoemaker’s bench, took up all the work
+that was cut out, and began to ply with their little fingers, stitching
+and rapping and tapping away at such a rate, that the shoemaker was all
+wonder, and could not take his eyes off them. And on they went, till the
+job was quite done, and the shoes stood ready for use upon the table.
+This was long before daybreak; and then they bustled away as quick as
+lightning.
+
+The next day the wife said to the shoemaker. ‘These little wights have
+made us rich, and we ought to be thankful to them, and do them a good
+turn if we can. I am quite sorry to see them run about as they do; and
+indeed it is not very decent, for they have nothing upon their backs to
+keep off the cold. I’ll tell you what, I will make each of them a shirt,
+and a coat and waistcoat, and a pair of pantaloons into the bargain; and
+do you make each of them a little pair of shoes.’
+
+The thought pleased the good cobbler very much; and one evening, when
+all the things were ready, they laid them on the table, instead of the
+work that they used to cut out, and then went and hid themselves, to
+watch what the little elves would do.
+
+About midnight in they came, dancing and skipping, hopped round the
+room, and then went to sit down to their work as usual; but when they
+saw the clothes lying for them, they laughed and chuckled, and seemed
+mightily delighted.
+
+Then they dressed themselves in the twinkling of an eye, and danced and
+capered and sprang about, as merry as could be; till at last they danced
+out at the door, and away over the green.
+
+The good couple saw them no more; but everything went well with them
+from that time forward, as long as they lived.
+
+
+
+
+THE JUNIPER-TREE
+
+Long, long ago, some two thousand years or so, there lived a rich
+man with a good and beautiful wife. They loved each other dearly, but
+sorrowed much that they had no children. So greatly did they desire
+to have one, that the wife prayed for it day and night, but still they
+remained childless.
+
+In front of the house there was a court, in which grew a juniper-tree.
+One winter’s day the wife stood under the tree to peel some apples, and
+as she was peeling them, she cut her finger, and the blood fell on the
+snow. ‘Ah,’ sighed the woman heavily, ‘if I had but a child, as red as
+blood and as white as snow,’ and as she spoke the words, her heart grew
+light within her, and it seemed to her that her wish was granted, and
+she returned to the house feeling glad and comforted. A month passed,
+and the snow had all disappeared; then another month went by, and all
+the earth was green. So the months followed one another, and first the
+trees budded in the woods, and soon the green branches grew thickly
+intertwined, and then the blossoms began to fall. Once again the wife
+stood under the juniper-tree, and it was so full of sweet scent that her
+heart leaped for joy, and she was so overcome with her happiness, that
+she fell on her knees. Presently the fruit became round and firm, and
+she was glad and at peace; but when they were fully ripe she picked the
+berries and ate eagerly of them, and then she grew sad and ill. A little
+while later she called her husband, and said to him, weeping. ‘If I
+die, bury me under the juniper-tree.’ Then she felt comforted and happy
+again, and before another month had passed she had a little child, and
+when she saw that it was as white as snow and as red as blood, her joy
+was so great that she died.
+
+Her husband buried her under the juniper-tree, and wept bitterly for
+her. By degrees, however, his sorrow grew less, and although at times he
+still grieved over his loss, he was able to go about as usual, and later
+on he married again.
+
+He now had a little daughter born to him; the child of his first wife
+was a boy, who was as red as blood and as white as snow. The mother
+loved her daughter very much, and when she looked at her and then looked
+at the boy, it pierced her heart to think that he would always stand in
+the way of her own child, and she was continually thinking how she could
+get the whole of the property for her. This evil thought took possession
+of her more and more, and made her behave very unkindly to the boy. She
+drove him from place to place with cuffings and buffetings, so that the
+poor child went about in fear, and had no peace from the time he left
+school to the time he went back.
+
+One day the little daughter came running to her mother in the
+store-room, and said, ‘Mother, give me an apple.’ ‘Yes, my child,’ said
+the wife, and she gave her a beautiful apple out of the chest; the chest
+had a very heavy lid and a large iron lock.
+
+‘Mother,’ said the little daughter again, ‘may not brother have one
+too?’ The mother was angry at this, but she answered, ‘Yes, when he
+comes out of school.’
+
+Just then she looked out of the window and saw him coming, and it seemed
+as if an evil spirit entered into her, for she snatched the apple out
+of her little daughter’s hand, and said, ‘You shall not have one before
+your brother.’ She threw the apple into the chest and shut it to. The
+little boy now came in, and the evil spirit in the wife made her say
+kindly to him, ‘My son, will you have an apple?’ but she gave him a
+wicked look. ‘Mother,’ said the boy, ‘how dreadful you look! Yes, give
+me an apple.’ The thought came to her that she would kill him. ‘Come
+with me,’ she said, and she lifted up the lid of the chest; ‘take one
+out for yourself.’ And as he bent over to do so, the evil spirit urged
+her, and crash! down went the lid, and off went the little boy’s head.
+Then she was overwhelmed with fear at the thought of what she had done.
+‘If only I can prevent anyone knowing that I did it,’ she thought. So
+she went upstairs to her room, and took a white handkerchief out of
+her top drawer; then she set the boy’s head again on his shoulders, and
+bound it with the handkerchief so that nothing could be seen, and placed
+him on a chair by the door with an apple in his hand.
+
+Soon after this, little Marleen came up to her mother who was stirring
+a pot of boiling water over the fire, and said, ‘Mother, brother is
+sitting by the door with an apple in his hand, and he looks so pale;
+and when I asked him to give me the apple, he did not answer, and that
+frightened me.’
+
+‘Go to him again,’ said her mother, ‘and if he does not answer, give him
+a box on the ear.’ So little Marleen went, and said, ‘Brother, give me
+that apple,’ but he did not say a word; then she gave him a box on the
+ear, and his head rolled off. She was so terrified at this, that she ran
+crying and screaming to her mother. ‘Oh!’ she said, ‘I have knocked off
+brother’s head,’ and then she wept and wept, and nothing would stop her.
+
+‘What have you done!’ said her mother, ‘but no one must know about it,
+so you must keep silence; what is done can’t be undone; we will make
+him into puddings.’ And she took the little boy and cut him up, made him
+into puddings, and put him in the pot. But Marleen stood looking on,
+and wept and wept, and her tears fell into the pot, so that there was no
+need of salt.
+
+Presently the father came home and sat down to his dinner; he asked,
+‘Where is my son?’ The mother said nothing, but gave him a large dish of
+black pudding, and Marleen still wept without ceasing.
+
+The father again asked, ‘Where is my son?’
+
+‘Oh,’ answered the wife, ‘he is gone into the country to his mother’s
+great uncle; he is going to stay there some time.’
+
+‘What has he gone there for, and he never even said goodbye to me!’
+
+‘Well, he likes being there, and he told me he should be away quite six
+weeks; he is well looked after there.’
+
+‘I feel very unhappy about it,’ said the husband, ‘in case it should not
+be all right, and he ought to have said goodbye to me.’
+
+With this he went on with his dinner, and said, ‘Little Marleen, why do
+you weep? Brother will soon be back.’ Then he asked his wife for more
+pudding, and as he ate, he threw the bones under the table.
+
+Little Marleen went upstairs and took her best silk handkerchief out of
+her bottom drawer, and in it she wrapped all the bones from under the
+table and carried them outside, and all the time she did nothing but
+weep. Then she laid them in the green grass under the juniper-tree, and
+she had no sooner done so, then all her sadness seemed to leave her,
+and she wept no more. And now the juniper-tree began to move, and the
+branches waved backwards and forwards, first away from one another, and
+then together again, as it might be someone clapping their hands for
+joy. After this a mist came round the tree, and in the midst of it there
+was a burning as of fire, and out of the fire there flew a beautiful
+bird, that rose high into the air, singing magnificently, and when it
+could no more be seen, the juniper-tree stood there as before, and the
+silk handkerchief and the bones were gone.
+
+Little Marleen now felt as lighthearted and happy as if her brother were
+still alive, and she went back to the house and sat down cheerfully to
+the table and ate.
+
+The bird flew away and alighted on the house of a goldsmith and began to
+sing:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The goldsmith was in his workshop making a gold chain, when he heard the
+song of the bird on his roof. He thought it so beautiful that he got
+up and ran out, and as he crossed the threshold he lost one of his
+slippers. But he ran on into the middle of the street, with a slipper on
+one foot and a sock on the other; he still had on his apron, and still
+held the gold chain and the pincers in his hands, and so he stood gazing
+up at the bird, while the sun came shining brightly down on the street.
+
+‘Bird,’ he said, ‘how beautifully you sing! Sing me that song again.’
+
+‘Nay,’ said the bird, ‘I do not sing twice for nothing. Give that gold
+chain, and I will sing it you again.’
+
+‘Here is the chain, take it,’ said the goldsmith. ‘Only sing me that
+again.’
+
+The bird flew down and took the gold chain in his right claw, and then
+he alighted again in front of the goldsmith and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+Then he flew away, and settled on the roof of a shoemaker’s house and
+sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The shoemaker heard him, and he jumped up and ran out in his
+shirt-sleeves, and stood looking up at the bird on the roof with his
+hand over his eyes to keep himself from being blinded by the sun.
+
+‘Bird,’ he said, ‘how beautifully you sing!’ Then he called through the
+door to his wife: ‘Wife, come out; here is a bird, come and look at it
+and hear how beautifully it sings.’ Then he called his daughter and the
+children, then the apprentices, girls and boys, and they all ran up the
+street to look at the bird, and saw how splendid it was with its red
+and green feathers, and its neck like burnished gold, and eyes like two
+bright stars in its head.
+
+‘Bird,’ said the shoemaker, ‘sing me that song again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; you must
+give me something.’
+
+‘Wife,’ said the man, ‘go into the garret; on the upper shelf you will
+see a pair of red shoes; bring them to me.’ The wife went in and fetched
+the shoes.
+
+‘There, bird,’ said the shoemaker, ‘now sing me that song again.’
+
+The bird flew down and took the red shoes in his left claw, and then he
+went back to the roof and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+When he had finished, he flew away. He had the chain in his right claw
+and the shoes in his left, and he flew right away to a mill, and the
+mill went ‘Click clack, click clack, click clack.’ Inside the mill were
+twenty of the miller’s men hewing a stone, and as they went ‘Hick hack,
+hick hack, hick hack,’ the mill went ‘Click clack, click clack, click
+clack.’
+
+The bird settled on a lime-tree in front of the mill and sang:
+
+ ‘My mother killed her little son;
+
+then one of the men left off,
+
+  My father grieved when I was gone;
+
+two more men left off and listened,
+
+  My sister loved me best of all;
+
+then four more left off,
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+now there were only eight at work,
+
+  Underneath
+
+And now only five,
+
+  the juniper-tree.
+
+And now only one,
+
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+then he looked up and the last one had left off work.
+
+‘Bird,’ he said, ‘what a beautiful song that is you sing! Let me hear it
+too; sing it again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; give me that
+millstone, and I will sing it again.’
+
+‘If it belonged to me alone,’ said the man, ‘you should have it.’
+
+‘Yes, yes,’ said the others: ‘if he will sing again, he can have it.’
+
+The bird came down, and all the twenty millers set to and lifted up the
+stone with a beam; then the bird put his head through the hole and took
+the stone round his neck like a collar, and flew back with it to the
+tree and sang--
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And when he had finished his song, he spread his wings, and with the
+chain in his right claw, the shoes in his left, and the millstone round
+his neck, he flew right away to his father’s house.
+
+The father, the mother, and little Marleen were having their dinner.
+
+‘How lighthearted I feel,’ said the father, ‘so pleased and cheerful.’
+
+‘And I,’ said the mother, ‘I feel so uneasy, as if a heavy thunderstorm
+were coming.’
+
+But little Marleen sat and wept and wept.
+
+Then the bird came flying towards the house and settled on the roof.
+
+‘I do feel so happy,’ said the father, ‘and how beautifully the sun
+shines; I feel just as if I were going to see an old friend again.’
+
+‘Ah!’ said the wife, ‘and I am so full of distress and uneasiness that
+my teeth chatter, and I feel as if there were a fire in my veins,’ and
+she tore open her dress; and all the while little Marleen sat in the
+corner and wept, and the plate on her knees was wet with her tears.
+
+The bird now flew to the juniper-tree and began singing:
+
+ ‘My mother killed her little son;
+
+the mother shut her eyes and her ears, that she might see and hear
+nothing, but there was a roaring sound in her ears like that of a
+violent storm, and in her eyes a burning and flashing like lightning:
+
+  My father grieved when I was gone;
+
+‘Look, mother,’ said the man, ‘at the beautiful bird that is singing so
+magnificently; and how warm and bright the sun is, and what a delicious
+scent of spice in the air!’
+
+  My sister loved me best of all;
+
+then little Marleen laid her head down on her knees and sobbed.
+
+‘I must go outside and see the bird nearer,’ said the man.
+
+‘Ah, do not go!’ cried the wife. ‘I feel as if the whole house were in
+flames!’
+
+But the man went out and looked at the bird.
+
+ She laid her kerchief over me,
+ And took my bones that they might lie
+ Underneath the juniper-tree
+ Kywitt, Kywitt, what a beautiful bird am I!’
+
+With that the bird let fall the gold chain, and it fell just round the
+man’s neck, so that it fitted him exactly.
+
+He went inside, and said, ‘See, what a splendid bird that is; he has
+given me this beautiful gold chain, and looks so beautiful himself.’
+
+But the wife was in such fear and trouble, that she fell on the floor,
+and her cap fell from her head.
+
+Then the bird began again:
+
+ ‘My mother killed her little son;
+
+‘Ah me!’ cried the wife, ‘if I were but a thousand feet beneath the
+earth, that I might not hear that song.’
+
+  My father grieved when I was gone;
+
+then the woman fell down again as if dead.
+
+  My sister loved me best of all;
+
+‘Well,’ said little Marleen, ‘I will go out too and see if the bird will
+give me anything.’
+
+So she went out.
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+and he threw down the shoes to her,
+
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And she now felt quite happy and lighthearted; she put on the shoes and
+danced and jumped about in them. ‘I was so miserable,’ she said, ‘when I
+came out, but that has all passed away; that is indeed a splendid bird,
+and he has given me a pair of red shoes.’
+
+The wife sprang up, with her hair standing out from her head like flames
+of fire. ‘Then I will go out too,’ she said, ‘and see if it will lighten
+my misery, for I feel as if the world were coming to an end.’
+
+But as she crossed the threshold, crash! the bird threw the millstone
+down on her head, and she was crushed to death.
+
+The father and little Marleen heard the sound and ran out, but they only
+saw mist and flame and fire rising from the spot, and when these had
+passed, there stood the little brother, and he took the father and
+little Marleen by the hand; then they all three rejoiced, and went
+inside together and sat down to their dinners and ate.
+
+
+
+
+THE TURNIP
+
+There were two brothers who were both soldiers; the one was rich and
+the other poor. The poor man thought he would try to better himself; so,
+pulling off his red coat, he became a gardener, and dug his ground well,
+and sowed turnips.
+
+When the seed came up, there was one plant bigger than all the rest; and
+it kept getting larger and larger, and seemed as if it would never cease
+growing; so that it might have been called the prince of turnips for
+there never was such a one seen before, and never will again. At last it
+was so big that it filled a cart, and two oxen could hardly draw it; and
+the gardener knew not what in the world to do with it, nor whether it
+would be a blessing or a curse to him. One day he said to himself, ‘What
+shall I do with it? if I sell it, it will bring no more than another;
+and for eating, the little turnips are better than this; the best thing
+perhaps is to carry it and give it to the king as a mark of respect.’
+
+Then he yoked his oxen, and drew the turnip to the court, and gave it
+to the king. ‘What a wonderful thing!’ said the king; ‘I have seen many
+strange things, but such a monster as this I never saw. Where did you
+get the seed? or is it only your good luck? If so, you are a true child
+of fortune.’ ‘Ah, no!’ answered the gardener, ‘I am no child of fortune;
+I am a poor soldier, who never could get enough to live upon; so I
+laid aside my red coat, and set to work, tilling the ground. I have a
+brother, who is rich, and your majesty knows him well, and all the world
+knows him; but because I am poor, everybody forgets me.’
+
+The king then took pity on him, and said, ‘You shall be poor no
+longer. I will give you so much that you shall be even richer than your
+brother.’ Then he gave him gold and lands and flocks, and made him so
+rich that his brother’s fortune could not at all be compared with his.
+
+When the brother heard of all this, and how a turnip had made the
+gardener so rich, he envied him sorely, and bethought himself how he
+could contrive to get the same good fortune for himself. However, he
+determined to manage more cleverly than his brother, and got together a
+rich present of gold and fine horses for the king; and thought he must
+have a much larger gift in return; for if his brother had received so
+much for only a turnip, what must his present be worth?
+
+The king took the gift very graciously, and said he knew not what to
+give in return more valuable and wonderful than the great turnip; so
+the soldier was forced to put it into a cart, and drag it home with him.
+When he reached home, he knew not upon whom to vent his rage and spite;
+and at length wicked thoughts came into his head, and he resolved to
+kill his brother.
+
+So he hired some villains to murder him; and having shown them where to
+lie in ambush, he went to his brother, and said, ‘Dear brother, I have
+found a hidden treasure; let us go and dig it up, and share it between
+us.’ The other had no suspicions of his roguery: so they went out
+together, and as they were travelling along, the murderers rushed out
+upon him, bound him, and were going to hang him on a tree.
+
+But whilst they were getting all ready, they heard the trampling of a
+horse at a distance, which so frightened them that they pushed their
+prisoner neck and shoulders together into a sack, and swung him up by a
+cord to the tree, where they left him dangling, and ran away. Meantime
+he worked and worked away, till he made a hole large enough to put out
+his head.
+
+When the horseman came up, he proved to be a student, a merry fellow,
+who was journeying along on his nag, and singing as he went. As soon as
+the man in the sack saw him passing under the tree, he cried out, ‘Good
+morning! good morning to thee, my friend!’ The student looked about
+everywhere; and seeing no one, and not knowing where the voice came
+from, cried out, ‘Who calls me?’
+
+Then the man in the tree answered, ‘Lift up thine eyes, for behold here
+I sit in the sack of wisdom; here have I, in a short time, learned great
+and wondrous things. Compared to this seat, all the learning of the
+schools is as empty air. A little longer, and I shall know all that man
+can know, and shall come forth wiser than the wisest of mankind. Here
+I discern the signs and motions of the heavens and the stars; the laws
+that control the winds; the number of the sands on the seashore; the
+healing of the sick; the virtues of all simples, of birds, and of
+precious stones. Wert thou but once here, my friend, though wouldst feel
+and own the power of knowledge.
+
+The student listened to all this and wondered much; at last he said,
+‘Blessed be the day and hour when I found you; cannot you contrive to
+let me into the sack for a little while?’ Then the other answered, as if
+very unwillingly, ‘A little space I may allow thee to sit here, if thou
+wilt reward me well and entreat me kindly; but thou must tarry yet an
+hour below, till I have learnt some little matters that are yet unknown
+to me.’
+
+So the student sat himself down and waited a while; but the time hung
+heavy upon him, and he begged earnestly that he might ascend forthwith,
+for his thirst for knowledge was great. Then the other pretended to give
+way, and said, ‘Thou must let the sack of wisdom descend, by untying
+yonder cord, and then thou shalt enter.’ So the student let him down,
+opened the sack, and set him free. ‘Now then,’ cried he, ‘let me ascend
+quickly.’ As he began to put himself into the sack heels first, ‘Wait a
+while,’ said the gardener, ‘that is not the way.’ Then he pushed him
+in head first, tied up the sack, and soon swung up the searcher after
+wisdom dangling in the air. ‘How is it with thee, friend?’ said he,
+‘dost thou not feel that wisdom comes unto thee? Rest there in peace,
+till thou art a wiser man than thou wert.’
+
+So saying, he trotted off on the student’s nag, and left the poor fellow
+to gather wisdom till somebody should come and let him down.
+
+
+
+
+CLEVER HANS
+
+The mother of Hans said: ‘Whither away, Hans?’ Hans answered: ‘To
+Gretel.’ ‘Behave well, Hans.’ ‘Oh, I’ll behave well. Goodbye, mother.’
+‘Goodbye, Hans.’ Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day,
+Hans. What do you bring that is good?’ ‘I bring nothing, I want to have
+something given me.’ Gretel presents Hans with a needle, Hans says:
+‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the needle, sticks it into a hay-cart, and follows the cart
+home. ‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’
+‘With Gretel.’ ‘What did you take her?’ ‘Took nothing; had something
+given me.’ ‘What did Gretel give you?’ ‘Gave me a needle.’ ‘Where is the
+needle, Hans?’ ‘Stuck in the hay-cart.’ ‘That was ill done, Hans. You
+should have stuck the needle in your sleeve.’ ‘Never mind, I’ll do
+better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What do you bring that is
+good?’ ‘I bring nothing. I want to have something given to me.’ Gretel
+presents Hans with a knife. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans
+takes the knife, sticks it in his sleeve, and goes home. ‘Good evening,
+mother.’ ‘Good evening, Hans. Where have you been?’ ‘With Gretel.’ What
+did you take her?’ ‘Took her nothing, she gave me something.’ ‘What did
+Gretel give you?’ ‘Gave me a knife.’ ‘Where is the knife, Hans?’ ‘Stuck
+in my sleeve.’ ‘That’s ill done, Hans, you should have put the knife in
+your pocket.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a young goat. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans takes
+the goat, ties its legs, and puts it in his pocket. When he gets home it
+is suffocated. ‘Good evening, mother.’ ‘Good evening, Hans. Where have
+you been?’ ‘With Gretel.’ ‘What did you take her?’ ‘Took nothing, she
+gave me something.’ ‘What did Gretel give you?’ ‘She gave me a goat.’
+‘Where is the goat, Hans?’ ‘Put it in my pocket.’ ‘That was ill done,
+Hans, you should have put a rope round the goat’s neck.’ ‘Never mind,
+will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a piece of bacon. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the bacon, ties it to a rope, and drags it away behind him.
+The dogs come and devour the bacon. When he gets home, he has the rope
+in his hand, and there is no longer anything hanging on to it. ‘Good
+evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took her nothing, she gave me
+something.’ ‘What did Gretel give you?’ ‘Gave me a bit of bacon.’ ‘Where
+is the bacon, Hans?’ ‘I tied it to a rope, brought it home, dogs took
+it.’ ‘That was ill done, Hans, you should have carried the bacon on your
+head.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to Gretel.
+‘Good day, Gretel.’ ‘Good day, Hans, What good thing do you bring?’ ‘I
+bring nothing, but would have something given.’ Gretel presents Hans
+with a calf. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the calf, puts it on his head, and the calf kicks his face.
+‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took nothing, but had something
+given me.’ ‘What did Gretel give you?’ ‘A calf.’ ‘Where have you the
+calf, Hans?’ ‘I set it on my head and it kicked my face.’ ‘That was
+ill done, Hans, you should have led the calf, and put it in the stall.’
+‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’
+
+Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good
+thing do you bring?’ ‘I bring nothing, but would have something given.’
+Gretel says to Hans: ‘I will go with you.’
+
+Hans takes Gretel, ties her to a rope, leads her to the rack, and binds
+her fast. Then Hans goes to his mother. ‘Good evening, mother.’ ‘Good
+evening, Hans. Where have you been?’ ‘With Gretel.’ ‘What did you take
+her?’ ‘I took her nothing.’ ‘What did Gretel give you?’ ‘She gave me
+nothing, she came with me.’ ‘Where have you left Gretel?’ ‘I led her by
+the rope, tied her to the rack, and scattered some grass for her.’ ‘That
+was ill done, Hans, you should have cast friendly eyes on her.’ ‘Never
+mind, will do better.’
+
+Hans went into the stable, cut out all the calves’ and sheep’s eyes,
+and threw them in Gretel’s face. Then Gretel became angry, tore herself
+loose and ran away, and was no longer the bride of Hans.
+
+
+
+
+THE THREE LANGUAGES
+
+An aged count once lived in Switzerland, who had an only son, but he
+was stupid, and could learn nothing. Then said the father: ‘Hark you,
+my son, try as I will I can get nothing into your head. You must go from
+hence, I will give you into the care of a celebrated master, who shall
+see what he can do with you.’ The youth was sent into a strange town,
+and remained a whole year with the master. At the end of this time,
+he came home again, and his father asked: ‘Now, my son, what have you
+learnt?’ ‘Father, I have learnt what the dogs say when they bark.’ ‘Lord
+have mercy on us!’ cried the father; ‘is that all you have learnt? I
+will send you into another town, to another master.’ The youth was taken
+thither, and stayed a year with this master likewise. When he came back
+the father again asked: ‘My son, what have you learnt?’ He answered:
+‘Father, I have learnt what the birds say.’ Then the father fell into a
+rage and said: ‘Oh, you lost man, you have spent the precious time and
+learnt nothing; are you not ashamed to appear before my eyes? I will
+send you to a third master, but if you learn nothing this time also, I
+will no longer be your father.’ The youth remained a whole year with the
+third master also, and when he came home again, and his father inquired:
+‘My son, what have you learnt?’ he answered: ‘Dear father, I have this
+year learnt what the frogs croak.’ Then the father fell into the most
+furious anger, sprang up, called his people thither, and said: ‘This man
+is no longer my son, I drive him forth, and command you to take him
+out into the forest, and kill him.’ They took him forth, but when they
+should have killed him, they could not do it for pity, and let him go,
+and they cut the eyes and tongue out of a deer that they might carry
+them to the old man as a token.
+
+The youth wandered on, and after some time came to a fortress where he
+begged for a night’s lodging. ‘Yes,’ said the lord of the castle, ‘if
+you will pass the night down there in the old tower, go thither; but I
+warn you, it is at the peril of your life, for it is full of wild dogs,
+which bark and howl without stopping, and at certain hours a man has to
+be given to them, whom they at once devour.’ The whole district was in
+sorrow and dismay because of them, and yet no one could do anything to
+stop this. The youth, however, was without fear, and said: ‘Just let me
+go down to the barking dogs, and give me something that I can throw to
+them; they will do nothing to harm me.’ As he himself would have it so,
+they gave him some food for the wild animals, and led him down to the
+tower. When he went inside, the dogs did not bark at him, but wagged
+their tails quite amicably around him, ate what he set before them, and
+did not hurt one hair of his head. Next morning, to the astonishment of
+everyone, he came out again safe and unharmed, and said to the lord of
+the castle: ‘The dogs have revealed to me, in their own language, why
+they dwell there, and bring evil on the land. They are bewitched, and
+are obliged to watch over a great treasure which is below in the tower,
+and they can have no rest until it is taken away, and I have likewise
+learnt, from their discourse, how that is to be done.’ Then all who
+heard this rejoiced, and the lord of the castle said he would adopt him
+as a son if he accomplished it successfully. He went down again, and
+as he knew what he had to do, he did it thoroughly, and brought a chest
+full of gold out with him. The howling of the wild dogs was henceforth
+heard no more; they had disappeared, and the country was freed from the
+trouble.
+
+After some time he took it in his head that he would travel to Rome. On
+the way he passed by a marsh, in which a number of frogs were sitting
+croaking. He listened to them, and when he became aware of what they
+were saying, he grew very thoughtful and sad. At last he arrived in
+Rome, where the Pope had just died, and there was great doubt among
+the cardinals as to whom they should appoint as his successor. They at
+length agreed that the person should be chosen as pope who should be
+distinguished by some divine and miraculous token. And just as that was
+decided on, the young count entered into the church, and suddenly two
+snow-white doves flew on his shoulders and remained sitting there. The
+ecclesiastics recognized therein the token from above, and asked him on
+the spot if he would be pope. He was undecided, and knew not if he were
+worthy of this, but the doves counselled him to do it, and at length he
+said yes. Then was he anointed and consecrated, and thus was fulfilled
+what he had heard from the frogs on his way, which had so affected him,
+that he was to be his Holiness the Pope. Then he had to sing a mass, and
+did not know one word of it, but the two doves sat continually on his
+shoulders, and said it all in his ear.
+
+
+
+
+THE FOX AND THE CAT
+
+It happened that the cat met the fox in a forest, and as she thought to
+herself: ‘He is clever and full of experience, and much esteemed in the
+world,’ she spoke to him in a friendly way. ‘Good day, dear Mr Fox,
+how are you? How is all with you? How are you getting on in these hard
+times?’ The fox, full of all kinds of arrogance, looked at the cat from
+head to foot, and for a long time did not know whether he would give
+any answer or not. At last he said: ‘Oh, you wretched beard-cleaner, you
+piebald fool, you hungry mouse-hunter, what can you be thinking of? Have
+you the cheek to ask how I am getting on? What have you learnt? How
+many arts do you understand?’ ‘I understand but one,’ replied the
+cat, modestly. ‘What art is that?’ asked the fox. ‘When the hounds are
+following me, I can spring into a tree and save myself.’ ‘Is that all?’
+said the fox. ‘I am master of a hundred arts, and have into the bargain
+a sackful of cunning. You make me sorry for you; come with me, I will
+teach you how people get away from the hounds.’ Just then came a hunter
+with four dogs. The cat sprang nimbly up a tree, and sat down at the top
+of it, where the branches and foliage quite concealed her. ‘Open your
+sack, Mr Fox, open your sack,’ cried the cat to him, but the dogs had
+already seized him, and were holding him fast. ‘Ah, Mr Fox,’ cried the
+cat. ‘You with your hundred arts are left in the lurch! Had you been
+able to climb like me, you would not have lost your life.’
+
+
+
+
+THE FOUR CLEVER BROTHERS
+
+‘Dear children,’ said a poor man to his four sons, ‘I have nothing to
+give you; you must go out into the wide world and try your luck. Begin
+by learning some craft or another, and see how you can get on.’ So the
+four brothers took their walking-sticks in their hands, and their little
+bundles on their shoulders, and after bidding their father goodbye, went
+all out at the gate together. When they had got on some way they came
+to four crossways, each leading to a different country. Then the eldest
+said, ‘Here we must part; but this day four years we will come back
+to this spot, and in the meantime each must try what he can do for
+himself.’
+
+So each brother went his way; and as the eldest was hastening on a man
+met him, and asked him where he was going, and what he wanted. ‘I am
+going to try my luck in the world, and should like to begin by learning
+some art or trade,’ answered he. ‘Then,’ said the man, ‘go with me, and
+I will teach you to become the cunningest thief that ever was.’ ‘No,’
+said the other, ‘that is not an honest calling, and what can one look
+to earn by it in the end but the gallows?’ ‘Oh!’ said the man, ‘you need
+not fear the gallows; for I will only teach you to steal what will be
+fair game: I meddle with nothing but what no one else can get or care
+anything about, and where no one can find you out.’ So the young man
+agreed to follow his trade, and he soon showed himself so clever, that
+nothing could escape him that he had once set his mind upon.
+
+The second brother also met a man, who, when he found out what he was
+setting out upon, asked him what craft he meant to follow. ‘I do not
+know yet,’ said he. ‘Then come with me, and be a star-gazer. It is a
+noble art, for nothing can be hidden from you, when once you understand
+the stars.’ The plan pleased him much, and he soon became such a skilful
+star-gazer, that when he had served out his time, and wanted to leave
+his master, he gave him a glass, and said, ‘With this you can see all
+that is passing in the sky and on earth, and nothing can be hidden from
+you.’
+
+The third brother met a huntsman, who took him with him, and taught him
+so well all that belonged to hunting, that he became very clever in the
+craft of the woods; and when he left his master he gave him a bow, and
+said, ‘Whatever you shoot at with this bow you will be sure to hit.’
+
+The youngest brother likewise met a man who asked him what he wished to
+do. ‘Would not you like,’ said he, ‘to be a tailor?’ ‘Oh, no!’ said
+the young man; ‘sitting cross-legged from morning to night, working
+backwards and forwards with a needle and goose, will never suit me.’
+‘Oh!’ answered the man, ‘that is not my sort of tailoring; come with me,
+and you will learn quite another kind of craft from that.’ Not knowing
+what better to do, he came into the plan, and learnt tailoring from the
+beginning; and when he left his master, he gave him a needle, and said,
+‘You can sew anything with this, be it as soft as an egg or as hard as
+steel; and the joint will be so fine that no seam will be seen.’
+
+After the space of four years, at the time agreed upon, the four
+brothers met at the four cross-roads; and having welcomed each other,
+set off towards their father’s home, where they told him all that had
+happened to them, and how each had learned some craft.
+
+Then, one day, as they were sitting before the house under a very high
+tree, the father said, ‘I should like to try what each of you can do in
+this way.’ So he looked up, and said to the second son, ‘At the top of
+this tree there is a chaffinch’s nest; tell me how many eggs there are
+in it.’ The star-gazer took his glass, looked up, and said, ‘Five.’
+‘Now,’ said the father to the eldest son, ‘take away the eggs without
+letting the bird that is sitting upon them and hatching them know
+anything of what you are doing.’ So the cunning thief climbed up the
+tree, and brought away to his father the five eggs from under the bird;
+and it never saw or felt what he was doing, but kept sitting on at its
+ease. Then the father took the eggs, and put one on each corner of the
+table, and the fifth in the middle, and said to the huntsman, ‘Cut all
+the eggs in two pieces at one shot.’ The huntsman took up his bow, and
+at one shot struck all the five eggs as his father wished.
+
+‘Now comes your turn,’ said he to the young tailor; ‘sew the eggs and
+the young birds in them together again, so neatly that the shot shall
+have done them no harm.’ Then the tailor took his needle, and sewed the
+eggs as he was told; and when he had done, the thief was sent to take
+them back to the nest, and put them under the bird without its knowing
+it. Then she went on sitting, and hatched them: and in a few days they
+crawled out, and had only a little red streak across their necks, where
+the tailor had sewn them together.
+
+‘Well done, sons!’ said the old man; ‘you have made good use of your
+time, and learnt something worth the knowing; but I am sure I do not
+know which ought to have the prize. Oh, that a time might soon come for
+you to turn your skill to some account!’
+
+Not long after this there was a great bustle in the country; for the
+king’s daughter had been carried off by a mighty dragon, and the king
+mourned over his loss day and night, and made it known that whoever
+brought her back to him should have her for a wife. Then the four
+brothers said to each other, ‘Here is a chance for us; let us try
+what we can do.’ And they agreed to see whether they could not set the
+princess free. ‘I will soon find out where she is, however,’ said the
+star-gazer, as he looked through his glass; and he soon cried out, ‘I
+see her afar off, sitting upon a rock in the sea, and I can spy the
+dragon close by, guarding her.’ Then he went to the king, and asked for
+a ship for himself and his brothers; and they sailed together over the
+sea, till they came to the right place. There they found the princess
+sitting, as the star-gazer had said, on the rock; and the dragon was
+lying asleep, with his head upon her lap. ‘I dare not shoot at him,’
+said the huntsman, ‘for I should kill the beautiful young lady also.’
+‘Then I will try my skill,’ said the thief, and went and stole her away
+from under the dragon, so quietly and gently that the beast did not know
+it, but went on snoring.
+
+Then away they hastened with her full of joy in their boat towards the
+ship; but soon came the dragon roaring behind them through the air; for
+he awoke and missed the princess. But when he got over the boat, and
+wanted to pounce upon them and carry off the princess, the huntsman took
+up his bow and shot him straight through the heart so that he fell down
+dead. They were still not safe; for he was such a great beast that in
+his fall he overset the boat, and they had to swim in the open sea
+upon a few planks. So the tailor took his needle, and with a few large
+stitches put some of the planks together; and he sat down upon these,
+and sailed about and gathered up all pieces of the boat; and then tacked
+them together so quickly that the boat was soon ready, and they then
+reached the ship and got home safe.
+
+When they had brought home the princess to her father, there was great
+rejoicing; and he said to the four brothers, ‘One of you shall marry
+her, but you must settle amongst yourselves which it is to be.’ Then
+there arose a quarrel between them; and the star-gazer said, ‘If I had
+not found the princess out, all your skill would have been of no use;
+therefore she ought to be mine.’ ‘Your seeing her would have been of
+no use,’ said the thief, ‘if I had not taken her away from the dragon;
+therefore she ought to be mine.’ ‘No, she is mine,’ said the huntsman;
+‘for if I had not killed the dragon, he would, after all, have torn you
+and the princess into pieces.’ ‘And if I had not sewn the boat together
+again,’ said the tailor, ‘you would all have been drowned, therefore she
+is mine.’ Then the king put in a word, and said, ‘Each of you is right;
+and as all cannot have the young lady, the best way is for neither of
+you to have her: for the truth is, there is somebody she likes a great
+deal better. But to make up for your loss, I will give each of you, as a
+reward for his skill, half a kingdom.’ So the brothers agreed that this
+plan would be much better than either quarrelling or marrying a lady who
+had no mind to have them. And the king then gave to each half a kingdom,
+as he had said; and they lived very happily the rest of their days, and
+took good care of their father; and somebody took better care of the
+young lady, than to let either the dragon or one of the craftsmen have
+her again.
+
+
+
+
+LILY AND THE LION
+
+A merchant, who had three daughters, was once setting out upon a
+journey; but before he went he asked each daughter what gift he should
+bring back for her. The eldest wished for pearls; the second for jewels;
+but the third, who was called Lily, said, ‘Dear father, bring me a
+rose.’ Now it was no easy task to find a rose, for it was the middle
+of winter; yet as she was his prettiest daughter, and was very fond of
+flowers, her father said he would try what he could do. So he kissed all
+three, and bid them goodbye.
+
+And when the time came for him to go home, he had bought pearls and
+jewels for the two eldest, but he had sought everywhere in vain for the
+rose; and when he went into any garden and asked for such a thing, the
+people laughed at him, and asked him whether he thought roses grew in
+snow. This grieved him very much, for Lily was his dearest child; and as
+he was journeying home, thinking what he should bring her, he came to a
+fine castle; and around the castle was a garden, in one half of which it
+seemed to be summer-time and in the other half winter. On one side the
+finest flowers were in full bloom, and on the other everything looked
+dreary and buried in the snow. ‘A lucky hit!’ said he, as he called to
+his servant, and told him to go to a beautiful bed of roses that was
+there, and bring him away one of the finest flowers.
+
+This done, they were riding away well pleased, when up sprang a fierce
+lion, and roared out, ‘Whoever has stolen my roses shall be eaten up
+alive!’ Then the man said, ‘I knew not that the garden belonged to you;
+can nothing save my life?’ ‘No!’ said the lion, ‘nothing, unless you
+undertake to give me whatever meets you on your return home; if you
+agree to this, I will give you your life, and the rose too for your
+daughter.’ But the man was unwilling to do so and said, ‘It may be my
+youngest daughter, who loves me most, and always runs to meet me when
+I go home.’ Then the servant was greatly frightened, and said, ‘It may
+perhaps be only a cat or a dog.’ And at last the man yielded with a
+heavy heart, and took the rose; and said he would give the lion whatever
+should meet him first on his return.
+
+And as he came near home, it was Lily, his youngest and dearest
+daughter, that met him; she came running, and kissed him, and welcomed
+him home; and when she saw that he had brought her the rose, she was
+still more glad. But her father began to be very sorrowful, and to weep,
+saying, ‘Alas, my dearest child! I have bought this flower at a high
+price, for I have said I would give you to a wild lion; and when he has
+you, he will tear you in pieces, and eat you.’ Then he told her all that
+had happened, and said she should not go, let what would happen.
+
+But she comforted him, and said, ‘Dear father, the word you have given
+must be kept; I will go to the lion, and soothe him: perhaps he will let
+me come safe home again.’
+
+The next morning she asked the way she was to go, and took leave of her
+father, and went forth with a bold heart into the wood. But the lion was
+an enchanted prince. By day he and all his court were lions, but in the
+evening they took their right forms again. And when Lily came to the
+castle, he welcomed her so courteously that she agreed to marry him. The
+wedding-feast was held, and they lived happily together a long time. The
+prince was only to be seen as soon as evening came, and then he held his
+court; but every morning he left his bride, and went away by himself,
+she knew not whither, till the night came again.
+
+After some time he said to her, ‘Tomorrow there will be a great feast in
+your father’s house, for your eldest sister is to be married; and if
+you wish to go and visit her my lions shall lead you thither.’ Then she
+rejoiced much at the thoughts of seeing her father once more, and set
+out with the lions; and everyone was overjoyed to see her, for they had
+thought her dead long since. But she told them how happy she was, and
+stayed till the feast was over, and then went back to the wood.
+
+Her second sister was soon after married, and when Lily was asked to
+go to the wedding, she said to the prince, ‘I will not go alone this
+time--you must go with me.’ But he would not, and said that it would be
+a very hazardous thing; for if the least ray of the torch-light should
+fall upon him his enchantment would become still worse, for he should be
+changed into a dove, and be forced to wander about the world for seven
+long years. However, she gave him no rest, and said she would take care
+no light should fall upon him. So at last they set out together, and
+took with them their little child; and she chose a large hall with thick
+walls for him to sit in while the wedding-torches were lighted; but,
+unluckily, no one saw that there was a crack in the door. Then the
+wedding was held with great pomp, but as the train came from the church,
+and passed with the torches before the hall, a very small ray of light
+fell upon the prince. In a moment he disappeared, and when his wife came
+in and looked for him, she found only a white dove; and it said to her,
+‘Seven years must I fly up and down over the face of the earth, but
+every now and then I will let fall a white feather, that will show you
+the way I am going; follow it, and at last you may overtake and set me
+free.’
+
+This said, he flew out at the door, and poor Lily followed; and every
+now and then a white feather fell, and showed her the way she was to
+journey. Thus she went roving on through the wide world, and looked
+neither to the right hand nor to the left, nor took any rest, for seven
+years. Then she began to be glad, and thought to herself that the time
+was fast coming when all her troubles should end; yet repose was still
+far off, for one day as she was travelling on she missed the white
+feather, and when she lifted up her eyes she could nowhere see the dove.
+‘Now,’ thought she to herself, ‘no aid of man can be of use to me.’ So
+she went to the sun and said, ‘Thou shinest everywhere, on the hill’s
+top and the valley’s depth--hast thou anywhere seen my white dove?’
+‘No,’ said the sun, ‘I have not seen it; but I will give thee a
+casket--open it when thy hour of need comes.’
+
+So she thanked the sun, and went on her way till eventide; and when
+the moon arose, she cried unto it, and said, ‘Thou shinest through the
+night, over field and grove--hast thou nowhere seen my white dove?’
+‘No,’ said the moon, ‘I cannot help thee but I will give thee an
+egg--break it when need comes.’
+
+Then she thanked the moon, and went on till the night-wind blew; and she
+raised up her voice to it, and said, ‘Thou blowest through every tree
+and under every leaf--hast thou not seen my white dove?’ ‘No,’ said the
+night-wind, ‘but I will ask three other winds; perhaps they have seen
+it.’ Then the east wind and the west wind came, and said they too had
+not seen it, but the south wind said, ‘I have seen the white dove--he
+has fled to the Red Sea, and is changed once more into a lion, for the
+seven years are passed away, and there he is fighting with a dragon;
+and the dragon is an enchanted princess, who seeks to separate him from
+you.’ Then the night-wind said, ‘I will give thee counsel. Go to the
+Red Sea; on the right shore stand many rods--count them, and when thou
+comest to the eleventh, break it off, and smite the dragon with it; and
+so the lion will have the victory, and both of them will appear to you
+in their own forms. Then look round and thou wilt see a griffin, winged
+like bird, sitting by the Red Sea; jump on to his back with thy beloved
+one as quickly as possible, and he will carry you over the waters to
+your home. I will also give thee this nut,’ continued the night-wind.
+‘When you are half-way over, throw it down, and out of the waters will
+immediately spring up a high nut-tree on which the griffin will be able
+to rest, otherwise he would not have the strength to bear you the whole
+way; if, therefore, thou dost forget to throw down the nut, he will let
+you both fall into the sea.’
+
+So our poor wanderer went forth, and found all as the night-wind had
+said; and she plucked the eleventh rod, and smote the dragon, and the
+lion forthwith became a prince, and the dragon a princess again. But
+no sooner was the princess released from the spell, than she seized
+the prince by the arm and sprang on to the griffin’s back, and went off
+carrying the prince away with her.
+
+Thus the unhappy traveller was again forsaken and forlorn; but she
+took heart and said, ‘As far as the wind blows, and so long as the cock
+crows, I will journey on, till I find him once again.’ She went on for
+a long, long way, till at length she came to the castle whither the
+princess had carried the prince; and there was a feast got ready, and
+she heard that the wedding was about to be held. ‘Heaven aid me now!’
+said she; and she took the casket that the sun had given her, and found
+that within it lay a dress as dazzling as the sun itself. So she put it
+on, and went into the palace, and all the people gazed upon her; and
+the dress pleased the bride so much that she asked whether it was to be
+sold. ‘Not for gold and silver.’ said she, ‘but for flesh and blood.’
+The princess asked what she meant, and she said, ‘Let me speak with the
+bridegroom this night in his chamber, and I will give thee the dress.’
+At last the princess agreed, but she told her chamberlain to give the
+prince a sleeping draught, that he might not hear or see her. When
+evening came, and the prince had fallen asleep, she was led into
+his chamber, and she sat herself down at his feet, and said: ‘I have
+followed thee seven years. I have been to the sun, the moon, and the
+night-wind, to seek thee, and at last I have helped thee to overcome
+the dragon. Wilt thou then forget me quite?’ But the prince all the time
+slept so soundly, that her voice only passed over him, and seemed like
+the whistling of the wind among the fir-trees.
+
+Then poor Lily was led away, and forced to give up the golden dress; and
+when she saw that there was no help for her, she went out into a meadow,
+and sat herself down and wept. But as she sat she bethought herself of
+the egg that the moon had given her; and when she broke it, there ran
+out a hen and twelve chickens of pure gold, that played about, and then
+nestled under the old one’s wings, so as to form the most beautiful
+sight in the world. And she rose up and drove them before her, till the
+bride saw them from her window, and was so pleased that she came forth
+and asked her if she would sell the brood. ‘Not for gold or silver, but
+for flesh and blood: let me again this evening speak with the bridegroom
+in his chamber, and I will give thee the whole brood.’
+
+Then the princess thought to betray her as before, and agreed to
+what she asked: but when the prince went to his chamber he asked
+the chamberlain why the wind had whistled so in the night. And the
+chamberlain told him all--how he had given him a sleeping draught, and
+how a poor maiden had come and spoken to him in his chamber, and was
+to come again that night. Then the prince took care to throw away the
+sleeping draught; and when Lily came and began again to tell him what
+woes had befallen her, and how faithful and true to him she had been,
+he knew his beloved wife’s voice, and sprang up, and said, ‘You have
+awakened me as from a dream, for the strange princess had thrown a spell
+around me, so that I had altogether forgotten you; but Heaven hath sent
+you to me in a lucky hour.’
+
+And they stole away out of the palace by night unawares, and seated
+themselves on the griffin, who flew back with them over the Red Sea.
+When they were half-way across Lily let the nut fall into the water,
+and immediately a large nut-tree arose from the sea, whereon the griffin
+rested for a while, and then carried them safely home. There they found
+their child, now grown up to be comely and fair; and after all their
+troubles they lived happily together to the end of their days.
+
+
+
+
+THE FOX AND THE HORSE
+
+A farmer had a horse that had been an excellent faithful servant to
+him: but he was now grown too old to work; so the farmer would give him
+nothing more to eat, and said, ‘I want you no longer, so take yourself
+off out of my stable; I shall not take you back again until you are
+stronger than a lion.’ Then he opened the door and turned him adrift.
+
+The poor horse was very melancholy, and wandered up and down in the
+wood, seeking some little shelter from the cold wind and rain. Presently
+a fox met him: ‘What’s the matter, my friend?’ said he, ‘why do you hang
+down your head and look so lonely and woe-begone?’ ‘Ah!’ replied the
+horse, ‘justice and avarice never dwell in one house; my master has
+forgotten all that I have done for him so many years, and because I
+can no longer work he has turned me adrift, and says unless I become
+stronger than a lion he will not take me back again; what chance can I
+have of that? he knows I have none, or he would not talk so.’
+
+However, the fox bid him be of good cheer, and said, ‘I will help you;
+lie down there, stretch yourself out quite stiff, and pretend to be
+dead.’ The horse did as he was told, and the fox went straight to the
+lion who lived in a cave close by, and said to him, ‘A little way off
+lies a dead horse; come with me and you may make an excellent meal of
+his carcase.’ The lion was greatly pleased, and set off immediately; and
+when they came to the horse, the fox said, ‘You will not be able to eat
+him comfortably here; I’ll tell you what--I will tie you fast to
+his tail, and then you can draw him to your den, and eat him at your
+leisure.’
+
+This advice pleased the lion, so he laid himself down quietly for the
+fox to make him fast to the horse. But the fox managed to tie his legs
+together and bound all so hard and fast that with all his strength he
+could not set himself free. When the work was done, the fox clapped the
+horse on the shoulder, and said, ‘Jip! Dobbin! Jip!’ Then up he sprang,
+and moved off, dragging the lion behind him. The beast began to roar
+and bellow, till all the birds of the wood flew away for fright; but the
+horse let him sing on, and made his way quietly over the fields to his
+master’s house.
+
+‘Here he is, master,’ said he, ‘I have got the better of him’: and when
+the farmer saw his old servant, his heart relented, and he said. ‘Thou
+shalt stay in thy stable and be well taken care of.’ And so the poor old
+horse had plenty to eat, and lived--till he died.
+
+
+
+
+THE BLUE LIGHT
+
+There was once upon a time a soldier who for many years had served the
+king faithfully, but when the war came to an end could serve no longer
+because of the many wounds which he had received. The king said to him:
+‘You may return to your home, I need you no longer, and you will not
+receive any more money, for he only receives wages who renders me
+service for them.’ Then the soldier did not know how to earn a living,
+went away greatly troubled, and walked the whole day, until in the
+evening he entered a forest. When darkness came on, he saw a light,
+which he went up to, and came to a house wherein lived a witch. ‘Do give
+me one night’s lodging, and a little to eat and drink,’ said he to
+her, ‘or I shall starve.’ ‘Oho!’ she answered, ‘who gives anything to a
+run-away soldier? Yet will I be compassionate, and take you in, if you
+will do what I wish.’ ‘What do you wish?’ said the soldier. ‘That you
+should dig all round my garden for me, tomorrow.’ The soldier consented,
+and next day laboured with all his strength, but could not finish it by
+the evening. ‘I see well enough,’ said the witch, ‘that you can do no
+more today, but I will keep you yet another night, in payment for
+which you must tomorrow chop me a load of wood, and chop it small.’ The
+soldier spent the whole day in doing it, and in the evening the witch
+proposed that he should stay one night more. ‘Tomorrow, you shall only
+do me a very trifling piece of work. Behind my house, there is an old
+dry well, into which my light has fallen, it burns blue, and never goes
+out, and you shall bring it up again.’ Next day the old woman took him
+to the well, and let him down in a basket. He found the blue light, and
+made her a signal to draw him up again. She did draw him up, but when he
+came near the edge, she stretched down her hand and wanted to take the
+blue light away from him. ‘No,’ said he, perceiving her evil intention,
+‘I will not give you the light until I am standing with both feet upon
+the ground.’ The witch fell into a passion, let him fall again into the
+well, and went away.
+
+The poor soldier fell without injury on the moist ground, and the blue
+light went on burning, but of what use was that to him? He saw very well
+that he could not escape death. He sat for a while very sorrowfully,
+then suddenly he felt in his pocket and found his tobacco pipe, which
+was still half full. ‘This shall be my last pleasure,’ thought he,
+pulled it out, lit it at the blue light and began to smoke. When the
+smoke had circled about the cavern, suddenly a little black dwarf stood
+before him, and said: ‘Lord, what are your commands?’ ‘What my commands
+are?’ replied the soldier, quite astonished. ‘I must do everything you
+bid me,’ said the little man. ‘Good,’ said the soldier; ‘then in the
+first place help me out of this well.’ The little man took him by the
+hand, and led him through an underground passage, but he did not forget
+to take the blue light with him. On the way the dwarf showed him the
+treasures which the witch had collected and hidden there, and the
+soldier took as much gold as he could carry. When he was above, he said
+to the little man: ‘Now go and bind the old witch, and carry her before
+the judge.’ In a short time she came by like the wind, riding on a wild
+tom-cat and screaming frightfully. Nor was it long before the little man
+reappeared. ‘It is all done,’ said he, ‘and the witch is already hanging
+on the gallows. What further commands has my lord?’ inquired the dwarf.
+‘At this moment, none,’ answered the soldier; ‘you can return home, only
+be at hand immediately, if I summon you.’ ‘Nothing more is needed than
+that you should light your pipe at the blue light, and I will appear
+before you at once.’ Thereupon he vanished from his sight.
+
+The soldier returned to the town from which he came. He went to the
+best inn, ordered himself handsome clothes, and then bade the landlord
+furnish him a room as handsome as possible. When it was ready and the
+soldier had taken possession of it, he summoned the little black manikin
+and said: ‘I have served the king faithfully, but he has dismissed me,
+and left me to hunger, and now I want to take my revenge.’ ‘What am I to
+do?’ asked the little man. ‘Late at night, when the king’s daughter is
+in bed, bring her here in her sleep, she shall do servant’s work for
+me.’ The manikin said: ‘That is an easy thing for me to do, but a very
+dangerous thing for you, for if it is discovered, you will fare ill.’
+When twelve o’clock had struck, the door sprang open, and the manikin
+carried in the princess. ‘Aha! are you there?’ cried the soldier, ‘get
+to your work at once! Fetch the broom and sweep the chamber.’ When
+she had done this, he ordered her to come to his chair, and then he
+stretched out his feet and said: ‘Pull off my boots,’ and then he
+threw them in her face, and made her pick them up again, and clean
+and brighten them. She, however, did everything he bade her, without
+opposition, silently and with half-shut eyes. When the first cock
+crowed, the manikin carried her back to the royal palace, and laid her
+in her bed.
+
+Next morning when the princess arose she went to her father, and told
+him that she had had a very strange dream. ‘I was carried through the
+streets with the rapidity of lightning,’ said she, ‘and taken into a
+soldier’s room, and I had to wait upon him like a servant, sweep his
+room, clean his boots, and do all kinds of menial work. It was only a
+dream, and yet I am just as tired as if I really had done everything.’
+‘The dream may have been true,’ said the king. ‘I will give you a piece
+of advice. Fill your pocket full of peas, and make a small hole in the
+pocket, and then if you are carried away again, they will fall out and
+leave a track in the streets.’ But unseen by the king, the manikin was
+standing beside him when he said that, and heard all. At night when
+the sleeping princess was again carried through the streets, some peas
+certainly did fall out of her pocket, but they made no track, for the
+crafty manikin had just before scattered peas in every street there
+was. And again the princess was compelled to do servant’s work until
+cock-crow.
+
+Next morning the king sent his people out to seek the track, but it was
+all in vain, for in every street poor children were sitting, picking up
+peas, and saying: ‘It must have rained peas, last night.’ ‘We must think
+of something else,’ said the king; ‘keep your shoes on when you go to
+bed, and before you come back from the place where you are taken, hide
+one of them there, I will soon contrive to find it.’ The black manikin
+heard this plot, and at night when the soldier again ordered him to
+bring the princess, revealed it to him, and told him that he knew of no
+expedient to counteract this stratagem, and that if the shoe were found
+in the soldier’s house it would go badly with him. ‘Do what I bid you,’
+replied the soldier, and again this third night the princess was obliged
+to work like a servant, but before she went away, she hid her shoe under
+the bed.
+
+Next morning the king had the entire town searched for his daughter’s
+shoe. It was found at the soldier’s, and the soldier himself, who at the
+entreaty of the dwarf had gone outside the gate, was soon brought back,
+and thrown into prison. In his flight he had forgotten the most valuable
+things he had, the blue light and the gold, and had only one ducat in
+his pocket. And now loaded with chains, he was standing at the window of
+his dungeon, when he chanced to see one of his comrades passing by. The
+soldier tapped at the pane of glass, and when this man came up, said to
+him: ‘Be so kind as to fetch me the small bundle I have left lying in
+the inn, and I will give you a ducat for doing it.’ His comrade ran
+thither and brought him what he wanted. As soon as the soldier was alone
+again, he lighted his pipe and summoned the black manikin. ‘Have no
+fear,’ said the latter to his master. ‘Go wheresoever they take you, and
+let them do what they will, only take the blue light with you.’ Next day
+the soldier was tried, and though he had done nothing wicked, the judge
+condemned him to death. When he was led forth to die, he begged a last
+favour of the king. ‘What is it?’ asked the king. ‘That I may smoke one
+more pipe on my way.’ ‘You may smoke three,’ answered the king, ‘but do
+not imagine that I will spare your life.’ Then the soldier pulled out
+his pipe and lighted it at the blue light, and as soon as a few wreaths
+of smoke had ascended, the manikin was there with a small cudgel in his
+hand, and said: ‘What does my lord command?’ ‘Strike down to earth that
+false judge there, and his constable, and spare not the king who has
+treated me so ill.’ Then the manikin fell on them like lightning,
+darting this way and that way, and whosoever was so much as touched by
+his cudgel fell to earth, and did not venture to stir again. The king
+was terrified; he threw himself on the soldier’s mercy, and merely to
+be allowed to live at all, gave him his kingdom for his own, and his
+daughter to wife.
+
+
+
+
+THE RAVEN
+
+There was once a queen who had a little daughter, still too young to run
+alone. One day the child was very troublesome, and the mother could not
+quiet it, do what she would. She grew impatient, and seeing the ravens
+flying round the castle, she opened the window, and said: ‘I wish you
+were a raven and would fly away, then I should have a little peace.’
+Scarcely were the words out of her mouth, when the child in her arms was
+turned into a raven, and flew away from her through the open window. The
+bird took its flight to a dark wood and remained there for a long time,
+and meanwhile the parents could hear nothing of their child.
+
+Long after this, a man was making his way through the wood when he heard
+a raven calling, and he followed the sound of the voice. As he drew
+near, the raven said, ‘I am by birth a king’s daughter, but am now under
+the spell of some enchantment; you can, however, set me free.’ ‘What
+am I to do?’ he asked. She replied, ‘Go farther into the wood until you
+come to a house, wherein lives an old woman; she will offer you food and
+drink, but you must not take of either; if you do, you will fall into
+a deep sleep, and will not be able to help me. In the garden behind the
+house is a large tan-heap, and on that you must stand and watch for me.
+I shall drive there in my carriage at two o’clock in the afternoon for
+three successive days; the first day it will be drawn by four white, the
+second by four chestnut, and the last by four black horses; but if you
+fail to keep awake and I find you sleeping, I shall not be set free.’
+
+The man promised to do all that she wished, but the raven said, ‘Alas! I
+know even now that you will take something from the woman and be unable
+to save me.’ The man assured her again that he would on no account touch
+a thing to eat or drink.
+
+When he came to the house and went inside, the old woman met him, and
+said, ‘Poor man! how tired you are! Come in and rest and let me give you
+something to eat and drink.’
+
+‘No,’ answered the man, ‘I will neither eat not drink.’
+
+But she would not leave him alone, and urged him saying, ‘If you will
+not eat anything, at least you might take a draught of wine; one drink
+counts for nothing,’ and at last he allowed himself to be persuaded, and
+drank.
+
+As it drew towards the appointed hour, he went outside into the garden
+and mounted the tan-heap to await the raven. Suddenly a feeling of
+fatigue came over him, and unable to resist it, he lay down for a little
+while, fully determined, however, to keep awake; but in another minute
+his eyes closed of their own accord, and he fell into such a deep sleep,
+that all the noises in the world would not have awakened him. At two
+o’clock the raven came driving along, drawn by her four white horses;
+but even before she reached the spot, she said to herself, sighing, ‘I
+know he has fallen asleep.’ When she entered the garden, there she found
+him as she had feared, lying on the tan-heap, fast asleep. She got out
+of her carriage and went to him; she called him and shook him, but it
+was all in vain, he still continued sleeping.
+
+The next day at noon, the old woman came to him again with food and
+drink which he at first refused. At last, overcome by her persistent
+entreaties that he would take something, he lifted the glass and drank
+again.
+
+Towards two o’clock he went into the garden and on to the tan-heap to
+watch for the raven. He had not been there long before he began to feel
+so tired that his limbs seemed hardly able to support him, and he could
+not stand upright any longer; so again he lay down and fell fast asleep.
+As the raven drove along her four chestnut horses, she said sorrowfully
+to herself, ‘I know he has fallen asleep.’ She went as before to look
+for him, but he slept, and it was impossible to awaken him.
+
+The following day the old woman said to him, ‘What is this? You are not
+eating or drinking anything, do you want to kill yourself?’
+
+He answered, ‘I may not and will not either eat or drink.’
+
+But she put down the dish of food and the glass of wine in front of him,
+and when he smelt the wine, he was unable to resist the temptation, and
+took a deep draught.
+
+When the hour came round again he went as usual on to the tan-heap in
+the garden to await the king’s daughter, but he felt even more overcome
+with weariness than on the two previous days, and throwing himself down,
+he slept like a log. At two o’clock the raven could be seen approaching,
+and this time her coachman and everything about her, as well as her
+horses, were black.
+
+She was sadder than ever as she drove along, and said mournfully, ‘I
+know he has fallen asleep, and will not be able to set me free.’ She
+found him sleeping heavily, and all her efforts to awaken him were of no
+avail. Then she placed beside him a loaf, and some meat, and a flask
+of wine, of such a kind, that however much he took of them, they would
+never grow less. After that she drew a gold ring, on which her name was
+engraved, off her finger, and put it upon one of his. Finally, she laid
+a letter near him, in which, after giving him particulars of the food
+and drink she had left for him, she finished with the following words:
+‘I see that as long as you remain here you will never be able to set me
+free; if, however, you still wish to do so, come to the golden castle
+of Stromberg; this is well within your power to accomplish.’ She then
+returned to her carriage and drove to the golden castle of Stromberg.
+
+When the man awoke and found that he had been sleeping, he was grieved
+at heart, and said, ‘She has no doubt been here and driven away again,
+and it is now too late for me to save her.’ Then his eyes fell on the
+things which were lying beside him; he read the letter, and knew from it
+all that had happened. He rose up without delay, eager to start on his
+way and to reach the castle of Stromberg, but he had no idea in which
+direction he ought to go. He travelled about a long time in search of it
+and came at last to a dark forest, through which he went on walking for
+fourteen days and still could not find a way out. Once more the night
+came on, and worn out he lay down under a bush and fell asleep. Again
+the next day he pursued his way through the forest, and that evening,
+thinking to rest again, he lay down as before, but he heard such a
+howling and wailing that he found it impossible to sleep. He waited till
+it was darker and people had begun to light up their houses, and then
+seeing a little glimmer ahead of him, he went towards it.
+
+He found that the light came from a house which looked smaller than
+it really was, from the contrast of its height with that of an immense
+giant who stood in front of it. He thought to himself, ‘If the giant
+sees me going in, my life will not be worth much.’ However, after a
+while he summoned up courage and went forward. When the giant saw him,
+he called out, ‘It is lucky for that you have come, for I have not had
+anything to eat for a long time. I can have you now for my supper.’ ‘I
+would rather you let that alone,’ said the man, ‘for I do not willingly
+give myself up to be eaten; if you are wanting food I have enough to
+satisfy your hunger.’ ‘If that is so,’ replied the giant, ‘I will leave
+you in peace; I only thought of eating you because I had nothing else.’
+
+So they went indoors together and sat down, and the man brought out the
+bread, meat, and wine, which although he had eaten and drunk of them,
+were still unconsumed. The giant was pleased with the good cheer, and
+ate and drank to his heart’s content. When he had finished his supper
+the man asked him if he could direct him to the castle of Stromberg.
+The giant said, ‘I will look on my map; on it are marked all the towns,
+villages, and houses.’ So he fetched his map, and looked for the castle,
+but could not find it. ‘Never mind,’ he said, ‘I have larger maps
+upstairs in the cupboard, we will look on those,’ but they searched in
+vain, for the castle was not marked even on these. The man now thought
+he should like to continue his journey, but the giant begged him to
+remain for a day or two longer until the return of his brother, who was
+away in search of provisions. When the brother came home, they asked him
+about the castle of Stromberg, and he told them he would look on his own
+maps as soon as he had eaten and appeased his hunger. Accordingly, when
+he had finished his supper, they all went up together to his room and
+looked through his maps, but the castle was not to be found. Then he
+fetched other older maps, and they went on looking for the castle until
+at last they found it, but it was many thousand miles away. ‘How shall I
+be able to get there?’ asked the man. ‘I have two hours to spare,’ said
+the giant, ‘and I will carry you into the neighbourhood of the castle; I
+must then return to look after the child who is in our care.’
+
+The giant, thereupon, carried the man to within about a hundred leagues
+of the castle, where he left him, saying, ‘You will be able to walk the
+remainder of the way yourself.’ The man journeyed on day and night
+till he reached the golden castle of Stromberg. He found it situated,
+however, on a glass mountain, and looking up from the foot he saw the
+enchanted maiden drive round her castle and then go inside. He was
+overjoyed to see her, and longed to get to the top of the mountain, but
+the sides were so slippery that every time he attempted to climb he
+fell back again. When he saw that it was impossible to reach her, he was
+greatly grieved, and said to himself, ‘I will remain here and wait for
+her,’ so he built himself a little hut, and there he sat and watched for
+a whole year, and every day he saw the king’s daughter driving round her
+castle, but still was unable to get nearer to her.
+
+Looking out from his hut one day he saw three robbers fighting and he
+called out to them, ‘God be with you.’ They stopped when they heard the
+call, but looking round and seeing nobody, they went on again with their
+fighting, which now became more furious. ‘God be with you,’ he cried
+again, and again they paused and looked about, but seeing no one went
+back to their fighting. A third time he called out, ‘God be with you,’
+and then thinking he should like to know the cause of dispute between
+the three men, he went out and asked them why they were fighting so
+angrily with one another. One of them said that he had found a stick,
+and that he had but to strike it against any door through which he
+wished to pass, and it immediately flew open. Another told him that he
+had found a cloak which rendered its wearer invisible; and the third had
+caught a horse which would carry its rider over any obstacle, and even
+up the glass mountain. They had been unable to decide whether they
+would keep together and have the things in common, or whether they would
+separate. On hearing this, the man said, ‘I will give you something in
+exchange for those three things; not money, for that I have not got,
+but something that is of far more value. I must first, however, prove
+whether all you have told me about your three things is true.’ The
+robbers, therefore, made him get on the horse, and handed him the stick
+and the cloak, and when he had put this round him he was no longer
+visible. Then he fell upon them with the stick and beat them one after
+another, crying, ‘There, you idle vagabonds, you have got what you
+deserve; are you satisfied now!’
+
+After this he rode up the glass mountain. When he reached the gate of
+the castle, he found it closed, but he gave it a blow with his stick,
+and it flew wide open at once and he passed through. He mounted the
+steps and entered the room where the maiden was sitting, with a golden
+goblet full of wine in front of her. She could not see him for he still
+wore his cloak. He took the ring which she had given him off his finger,
+and threw it into the goblet, so that it rang as it touched the bottom.
+‘That is my own ring,’ she exclaimed, ‘and if that is so the man must
+also be here who is coming to set me free.’
+
+She sought for him about the castle, but could find him nowhere.
+Meanwhile he had gone outside again and mounted his horse and thrown off
+the cloak. When therefore she came to the castle gate she saw him, and
+cried aloud for joy. Then he dismounted and took her in his arms; and
+she kissed him, and said, ‘Now you have indeed set me free, and tomorrow
+we will celebrate our marriage.’
+
+
+
+
+THE GOLDEN GOOSE
+
+There was a man who had three sons, the youngest of whom was called
+Dummling,[*] and was despised, mocked, and sneered at on every occasion.
+
+It happened that the eldest wanted to go into the forest to hew wood,
+and before he went his mother gave him a beautiful sweet cake and a
+bottle of wine in order that he might not suffer from hunger or thirst.
+
+When he entered the forest he met a little grey-haired old man who bade
+him good day, and said: ‘Do give me a piece of cake out of your pocket,
+and let me have a draught of your wine; I am so hungry and thirsty.’ But
+the clever son answered: ‘If I give you my cake and wine, I shall have
+none for myself; be off with you,’ and he left the little man standing
+and went on.
+
+But when he began to hew down a tree, it was not long before he made a
+false stroke, and the axe cut him in the arm, so that he had to go home
+and have it bound up. And this was the little grey man’s doing.
+
+After this the second son went into the forest, and his mother gave him,
+like the eldest, a cake and a bottle of wine. The little old grey man
+met him likewise, and asked him for a piece of cake and a drink of wine.
+But the second son, too, said sensibly enough: ‘What I give you will be
+taken away from myself; be off!’ and he left the little man standing and
+went on. His punishment, however, was not delayed; when he had made a
+few blows at the tree he struck himself in the leg, so that he had to be
+carried home.
+
+Then Dummling said: ‘Father, do let me go and cut wood.’ The father
+answered: ‘Your brothers have hurt themselves with it, leave it alone,
+you do not understand anything about it.’ But Dummling begged so long
+that at last he said: ‘Just go then, you will get wiser by hurting
+yourself.’ His mother gave him a cake made with water and baked in the
+cinders, and with it a bottle of sour beer.
+
+When he came to the forest the little old grey man met him likewise,
+and greeting him, said: ‘Give me a piece of your cake and a drink out
+of your bottle; I am so hungry and thirsty.’ Dummling answered: ‘I have
+only cinder-cake and sour beer; if that pleases you, we will sit
+down and eat.’ So they sat down, and when Dummling pulled out his
+cinder-cake, it was a fine sweet cake, and the sour beer had become good
+wine. So they ate and drank, and after that the little man said: ‘Since
+you have a good heart, and are willing to divide what you have, I will
+give you good luck. There stands an old tree, cut it down, and you will
+find something at the roots.’ Then the little man took leave of him.
+
+Dummling went and cut down the tree, and when it fell there was a goose
+sitting in the roots with feathers of pure gold. He lifted her up, and
+taking her with him, went to an inn where he thought he would stay the
+night. Now the host had three daughters, who saw the goose and were
+curious to know what such a wonderful bird might be, and would have
+liked to have one of its golden feathers.
+
+The eldest thought: ‘I shall soon find an opportunity of pulling out a
+feather,’ and as soon as Dummling had gone out she seized the goose by
+the wing, but her finger and hand remained sticking fast to it.
+
+The second came soon afterwards, thinking only of how she might get a
+feather for herself, but she had scarcely touched her sister than she
+was held fast.
+
+At last the third also came with the like intent, and the others
+screamed out: ‘Keep away; for goodness’ sake keep away!’ But she did
+not understand why she was to keep away. ‘The others are there,’ she
+thought, ‘I may as well be there too,’ and ran to them; but as soon as
+she had touched her sister, she remained sticking fast to her. So they
+had to spend the night with the goose.
+
+The next morning Dummling took the goose under his arm and set out,
+without troubling himself about the three girls who were hanging on to
+it. They were obliged to run after him continually, now left, now right,
+wherever his legs took him.
+
+In the middle of the fields the parson met them, and when he saw the
+procession he said: ‘For shame, you good-for-nothing girls, why are you
+running across the fields after this young man? Is that seemly?’ At the
+same time he seized the youngest by the hand in order to pull her away,
+but as soon as he touched her he likewise stuck fast, and was himself
+obliged to run behind.
+
+Before long the sexton came by and saw his master, the parson, running
+behind three girls. He was astonished at this and called out: ‘Hi!
+your reverence, whither away so quickly? Do not forget that we have a
+christening today!’ and running after him he took him by the sleeve, but
+was also held fast to it.
+
+Whilst the five were trotting thus one behind the other, two labourers
+came with their hoes from the fields; the parson called out to them
+and begged that they would set him and the sexton free. But they had
+scarcely touched the sexton when they were held fast, and now there were
+seven of them running behind Dummling and the goose.
+
+Soon afterwards he came to a city, where a king ruled who had a daughter
+who was so serious that no one could make her laugh. So he had put forth
+a decree that whosoever should be able to make her laugh should marry
+her. When Dummling heard this, he went with his goose and all her train
+before the king’s daughter, and as soon as she saw the seven people
+running on and on, one behind the other, she began to laugh quite
+loudly, and as if she would never stop. Thereupon Dummling asked to have
+her for his wife; but the king did not like the son-in-law, and made all
+manner of excuses and said he must first produce a man who could drink
+a cellarful of wine. Dummling thought of the little grey man, who could
+certainly help him; so he went into the forest, and in the same place
+where he had felled the tree, he saw a man sitting, who had a very
+sorrowful face. Dummling asked him what he was taking to heart so
+sorely, and he answered: ‘I have such a great thirst and cannot quench
+it; cold water I cannot stand, a barrel of wine I have just emptied, but
+that to me is like a drop on a hot stone!’
+
+‘There, I can help you,’ said Dummling, ‘just come with me and you shall
+be satisfied.’
+
+He led him into the king’s cellar, and the man bent over the huge
+barrels, and drank and drank till his loins hurt, and before the day was
+out he had emptied all the barrels. Then Dummling asked once more
+for his bride, but the king was vexed that such an ugly fellow, whom
+everyone called Dummling, should take away his daughter, and he made a
+new condition; he must first find a man who could eat a whole mountain
+of bread. Dummling did not think long, but went straight into the
+forest, where in the same place there sat a man who was tying up his
+body with a strap, and making an awful face, and saying: ‘I have eaten a
+whole ovenful of rolls, but what good is that when one has such a hunger
+as I? My stomach remains empty, and I must tie myself up if I am not to
+die of hunger.’
+
+At this Dummling was glad, and said: ‘Get up and come with me; you shall
+eat yourself full.’ He led him to the king’s palace where all the
+flour in the whole Kingdom was collected, and from it he caused a huge
+mountain of bread to be baked. The man from the forest stood before it,
+began to eat, and by the end of one day the whole mountain had vanished.
+Then Dummling for the third time asked for his bride; but the king again
+sought a way out, and ordered a ship which could sail on land and on
+water. ‘As soon as you come sailing back in it,’ said he, ‘you shall
+have my daughter for wife.’
+
+Dummling went straight into the forest, and there sat the little grey
+man to whom he had given his cake. When he heard what Dummling wanted,
+he said: ‘Since you have given me to eat and to drink, I will give you
+the ship; and I do all this because you once were kind to me.’ Then he
+gave him the ship which could sail on land and water, and when the king
+saw that, he could no longer prevent him from having his daughter. The
+wedding was celebrated, and after the king’s death, Dummling inherited
+his kingdom and lived for a long time contentedly with his wife.
+
+     [*] Simpleton
+
+
+
+
+THE WATER OF LIFE
+
+Long before you or I were born, there reigned, in a country a great way
+off, a king who had three sons. This king once fell very ill--so ill
+that nobody thought he could live. His sons were very much grieved
+at their father’s sickness; and as they were walking together very
+mournfully in the garden of the palace, a little old man met them and
+asked what was the matter. They told him that their father was very ill,
+and that they were afraid nothing could save him. ‘I know what would,’
+said the little old man; ‘it is the Water of Life. If he could have a
+draught of it he would be well again; but it is very hard to get.’ Then
+the eldest son said, ‘I will soon find it’: and he went to the sick
+king, and begged that he might go in search of the Water of Life, as
+it was the only thing that could save him. ‘No,’ said the king. ‘I had
+rather die than place you in such great danger as you must meet with in
+your journey.’ But he begged so hard that the king let him go; and the
+prince thought to himself, ‘If I bring my father this water, he will
+make me sole heir to his kingdom.’
+
+Then he set out: and when he had gone on his way some time he came to a
+deep valley, overhung with rocks and woods; and as he looked around, he
+saw standing above him on one of the rocks a little ugly dwarf, with a
+sugarloaf cap and a scarlet cloak; and the dwarf called to him and said,
+‘Prince, whither so fast?’ ‘What is that to thee, you ugly imp?’ said
+the prince haughtily, and rode on.
+
+But the dwarf was enraged at his behaviour, and laid a fairy spell
+of ill-luck upon him; so that as he rode on the mountain pass became
+narrower and narrower, and at last the way was so straitened that he
+could not go to step forward: and when he thought to have turned his
+horse round and go back the way he came, he heard a loud laugh ringing
+round him, and found that the path was closed behind him, so that he was
+shut in all round. He next tried to get off his horse and make his way
+on foot, but again the laugh rang in his ears, and he found himself
+unable to move a step, and thus he was forced to abide spellbound.
+
+Meantime the old king was lingering on in daily hope of his son’s
+return, till at last the second son said, ‘Father, I will go in search
+of the Water of Life.’ For he thought to himself, ‘My brother is surely
+dead, and the kingdom will fall to me if I find the water.’ The king was
+at first very unwilling to let him go, but at last yielded to his wish.
+So he set out and followed the same road which his brother had done,
+and met with the same elf, who stopped him at the same spot in the
+mountains, saying, as before, ‘Prince, prince, whither so fast?’ ‘Mind
+your own affairs, busybody!’ said the prince scornfully, and rode on.
+
+But the dwarf put the same spell upon him as he put on his elder
+brother, and he, too, was at last obliged to take up his abode in the
+heart of the mountains. Thus it is with proud silly people, who think
+themselves above everyone else, and are too proud to ask or take advice.
+
+When the second prince had thus been gone a long time, the youngest son
+said he would go and search for the Water of Life, and trusted he should
+soon be able to make his father well again. So he set out, and the dwarf
+met him too at the same spot in the valley, among the mountains, and
+said, ‘Prince, whither so fast?’ And the prince said, ‘I am going in
+search of the Water of Life, because my father is ill, and like to die:
+can you help me? Pray be kind, and aid me if you can!’ ‘Do you know
+where it is to be found?’ asked the dwarf. ‘No,’ said the prince, ‘I do
+not. Pray tell me if you know.’ ‘Then as you have spoken to me kindly,
+and are wise enough to seek for advice, I will tell you how and where to
+go. The water you seek springs from a well in an enchanted castle; and,
+that you may be able to reach it in safety, I will give you an iron wand
+and two little loaves of bread; strike the iron door of the castle three
+times with the wand, and it will open: two hungry lions will be lying
+down inside gaping for their prey, but if you throw them the bread they
+will let you pass; then hasten on to the well, and take some of the
+Water of Life before the clock strikes twelve; for if you tarry longer
+the door will shut upon you for ever.’
+
+Then the prince thanked his little friend with the scarlet cloak for his
+friendly aid, and took the wand and the bread, and went travelling on
+and on, over sea and over land, till he came to his journey’s end, and
+found everything to be as the dwarf had told him. The door flew open at
+the third stroke of the wand, and when the lions were quieted he went on
+through the castle and came at length to a beautiful hall. Around it he
+saw several knights sitting in a trance; then he pulled off their rings
+and put them on his own fingers. In another room he saw on a table a
+sword and a loaf of bread, which he also took. Further on he came to a
+room where a beautiful young lady sat upon a couch; and she welcomed him
+joyfully, and said, if he would set her free from the spell that bound
+her, the kingdom should be his, if he would come back in a year and
+marry her. Then she told him that the well that held the Water of Life
+was in the palace gardens; and bade him make haste, and draw what he
+wanted before the clock struck twelve.
+
+He walked on; and as he walked through beautiful gardens he came to a
+delightful shady spot in which stood a couch; and he thought to himself,
+as he felt tired, that he would rest himself for a while, and gaze on
+the lovely scenes around him. So he laid himself down, and sleep
+fell upon him unawares, so that he did not wake up till the clock was
+striking a quarter to twelve. Then he sprang from the couch dreadfully
+frightened, ran to the well, filled a cup that was standing by him full
+of water, and hastened to get away in time. Just as he was going out of
+the iron door it struck twelve, and the door fell so quickly upon him
+that it snapped off a piece of his heel.
+
+When he found himself safe, he was overjoyed to think that he had got
+the Water of Life; and as he was going on his way homewards, he passed
+by the little dwarf, who, when he saw the sword and the loaf, said, ‘You
+have made a noble prize; with the sword you can at a blow slay whole
+armies, and the bread will never fail you.’ Then the prince thought
+to himself, ‘I cannot go home to my father without my brothers’; so he
+said, ‘My dear friend, cannot you tell me where my two brothers are, who
+set out in search of the Water of Life before me, and never came back?’
+‘I have shut them up by a charm between two mountains,’ said the dwarf,
+‘because they were proud and ill-behaved, and scorned to ask advice.’
+The prince begged so hard for his brothers, that the dwarf at last set
+them free, though unwillingly, saying, ‘Beware of them, for they have
+bad hearts.’ Their brother, however, was greatly rejoiced to see them,
+and told them all that had happened to him; how he had found the Water
+of Life, and had taken a cup full of it; and how he had set a beautiful
+princess free from a spell that bound her; and how she had engaged to
+wait a whole year, and then to marry him, and to give him the kingdom.
+
+Then they all three rode on together, and on their way home came to a
+country that was laid waste by war and a dreadful famine, so that it was
+feared all must die for want. But the prince gave the king of the land
+the bread, and all his kingdom ate of it. And he lent the king the
+wonderful sword, and he slew the enemy’s army with it; and thus the
+kingdom was once more in peace and plenty. In the same manner he
+befriended two other countries through which they passed on their way.
+
+When they came to the sea, they got into a ship and during their voyage
+the two eldest said to themselves, ‘Our brother has got the water which
+we could not find, therefore our father will forsake us and give him the
+kingdom, which is our right’; so they were full of envy and revenge, and
+agreed together how they could ruin him. Then they waited till he was
+fast asleep, and poured the Water of Life out of the cup, and took it
+for themselves, giving him bitter sea-water instead.
+
+When they came to their journey’s end, the youngest son brought his cup
+to the sick king, that he might drink and be healed. Scarcely, however,
+had he tasted the bitter sea-water when he became worse even than he was
+before; and then both the elder sons came in, and blamed the youngest
+for what they had done; and said that he wanted to poison their father,
+but that they had found the Water of Life, and had brought it with them.
+He no sooner began to drink of what they brought him, than he felt his
+sickness leave him, and was as strong and well as in his younger days.
+Then they went to their brother, and laughed at him, and said, ‘Well,
+brother, you found the Water of Life, did you? You have had the trouble
+and we shall have the reward. Pray, with all your cleverness, why did
+not you manage to keep your eyes open? Next year one of us will take
+away your beautiful princess, if you do not take care. You had better
+say nothing about this to our father, for he does not believe a word you
+say; and if you tell tales, you shall lose your life into the bargain:
+but be quiet, and we will let you off.’
+
+The old king was still very angry with his youngest son, and thought
+that he really meant to have taken away his life; so he called his court
+together, and asked what should be done, and all agreed that he ought to
+be put to death. The prince knew nothing of what was going on, till one
+day, when the king’s chief huntsmen went a-hunting with him, and they
+were alone in the wood together, the huntsman looked so sorrowful that
+the prince said, ‘My friend, what is the matter with you?’ ‘I cannot and
+dare not tell you,’ said he. But the prince begged very hard, and said,
+‘Only tell me what it is, and do not think I shall be angry, for I will
+forgive you.’ ‘Alas!’ said the huntsman; ‘the king has ordered me to
+shoot you.’ The prince started at this, and said, ‘Let me live, and I
+will change dresses with you; you shall take my royal coat to show to my
+father, and do you give me your shabby one.’ ‘With all my heart,’ said
+the huntsman; ‘I am sure I shall be glad to save you, for I could not
+have shot you.’ Then he took the prince’s coat, and gave him the shabby
+one, and went away through the wood.
+
+Some time after, three grand embassies came to the old king’s court,
+with rich gifts of gold and precious stones for his youngest son; now
+all these were sent from the three kings to whom he had lent his sword
+and loaf of bread, in order to rid them of their enemy and feed their
+people. This touched the old king’s heart, and he thought his son might
+still be guiltless, and said to his court, ‘O that my son were still
+alive! how it grieves me that I had him killed!’ ‘He is still alive,’
+said the huntsman; ‘and I am glad that I had pity on him, but let him
+go in peace, and brought home his royal coat.’ At this the king was
+overwhelmed with joy, and made it known throughout all his kingdom, that
+if his son would come back to his court he would forgive him.
+
+Meanwhile the princess was eagerly waiting till her deliverer should
+come back; and had a road made leading up to her palace all of shining
+gold; and told her courtiers that whoever came on horseback, and rode
+straight up to the gate upon it, was her true lover; and that they must
+let him in: but whoever rode on one side of it, they must be sure was
+not the right one; and that they must send him away at once.
+
+The time soon came, when the eldest brother thought that he would make
+haste to go to the princess, and say that he was the one who had set
+her free, and that he should have her for his wife, and the kingdom with
+her. As he came before the palace and saw the golden road, he stopped to
+look at it, and he thought to himself, ‘It is a pity to ride upon this
+beautiful road’; so he turned aside and rode on the right-hand side of
+it. But when he came to the gate, the guards, who had seen the road
+he took, said to him, he could not be what he said he was, and must go
+about his business.
+
+The second prince set out soon afterwards on the same errand; and when
+he came to the golden road, and his horse had set one foot upon it,
+he stopped to look at it, and thought it very beautiful, and said to
+himself, ‘What a pity it is that anything should tread here!’ Then he
+too turned aside and rode on the left side of it. But when he came to
+the gate the guards said he was not the true prince, and that he too
+must go away about his business; and away he went.
+
+Now when the full year was come round, the third brother left the forest
+in which he had lain hid for fear of his father’s anger, and set out in
+search of his betrothed bride. So he journeyed on, thinking of her all
+the way, and rode so quickly that he did not even see what the road was
+made of, but went with his horse straight over it; and as he came to the
+gate it flew open, and the princess welcomed him with joy, and said
+he was her deliverer, and should now be her husband and lord of the
+kingdom. When the first joy at their meeting was over, the princess told
+him she had heard of his father having forgiven him, and of his wish to
+have him home again: so, before his wedding with the princess, he went
+to visit his father, taking her with him. Then he told him everything;
+how his brothers had cheated and robbed him, and yet that he had borne
+all those wrongs for the love of his father. And the old king was very
+angry, and wanted to punish his wicked sons; but they made their escape,
+and got into a ship and sailed away over the wide sea, and where they
+went to nobody knew and nobody cared.
+
+And now the old king gathered together his court, and asked all his
+kingdom to come and celebrate the wedding of his son and the princess.
+And young and old, noble and squire, gentle and simple, came at once
+on the summons; and among the rest came the friendly dwarf, with the
+sugarloaf hat, and a new scarlet cloak.
+
+  And the wedding was held, and the merry bells run.
+  And all the good people they danced and they sung,
+  And feasted and frolick’d I can’t tell how long.
+
+
+
+
+THE TWELVE HUNTSMEN
+
+There was once a king’s son who had a bride whom he loved very much. And
+when he was sitting beside her and very happy, news came that his father
+lay sick unto death, and desired to see him once again before his end.
+Then he said to his beloved: ‘I must now go and leave you, I give you
+a ring as a remembrance of me. When I am king, I will return and fetch
+you.’ So he rode away, and when he reached his father, the latter was
+dangerously ill, and near his death. He said to him: ‘Dear son, I wished
+to see you once again before my end, promise me to marry as I wish,’ and
+he named a certain king’s daughter who was to be his wife. The son was
+in such trouble that he did not think what he was doing, and said: ‘Yes,
+dear father, your will shall be done,’ and thereupon the king shut his
+eyes, and died.
+
+When therefore the son had been proclaimed king, and the time of
+mourning was over, he was forced to keep the promise which he had given
+his father, and caused the king’s daughter to be asked in marriage, and
+she was promised to him. His first betrothed heard of this, and fretted
+so much about his faithfulness that she nearly died. Then her father
+said to her: ‘Dearest child, why are you so sad? You shall have
+whatsoever you will.’ She thought for a moment and said: ‘Dear father,
+I wish for eleven girls exactly like myself in face, figure, and size.’
+The father said: ‘If it be possible, your desire shall be fulfilled,’
+and he caused a search to be made in his whole kingdom, until eleven
+young maidens were found who exactly resembled his daughter in face,
+figure, and size.
+
+When they came to the king’s daughter, she had twelve suits of
+huntsmen’s clothes made, all alike, and the eleven maidens had to put
+on the huntsmen’s clothes, and she herself put on the twelfth suit.
+Thereupon she took her leave of her father, and rode away with them,
+and rode to the court of her former betrothed, whom she loved so dearly.
+Then she asked if he required any huntsmen, and if he would take all of
+them into his service. The king looked at her and did not know her, but
+as they were such handsome fellows, he said: ‘Yes,’ and that he would
+willingly take them, and now they were the king’s twelve huntsmen.
+
+The king, however, had a lion which was a wondrous animal, for he knew
+all concealed and secret things. It came to pass that one evening he
+said to the king: ‘You think you have twelve huntsmen?’ ‘Yes,’ said the
+king, ‘they are twelve huntsmen.’ The lion continued: ‘You are mistaken,
+they are twelve girls.’ The king said: ‘That cannot be true! How
+will you prove that to me?’ ‘Oh, just let some peas be strewn in the
+ante-chamber,’ answered the lion, ‘and then you will soon see. Men have
+a firm step, and when they walk over peas none of them stir, but girls
+trip and skip, and drag their feet, and the peas roll about.’ The king
+was well pleased with the counsel, and caused the peas to be strewn.
+
+There was, however, a servant of the king’s who favoured the huntsmen,
+and when he heard that they were going to be put to this test he went to
+them and repeated everything, and said: ‘The lion wants to make the king
+believe that you are girls.’ Then the king’s daughter thanked him, and
+said to her maidens: ‘Show some strength, and step firmly on the peas.’
+So next morning when the king had the twelve huntsmen called before
+him, and they came into the ante-chamber where the peas were lying, they
+stepped so firmly on them, and had such a strong, sure walk, that not
+one of the peas either rolled or stirred. Then they went away again,
+and the king said to the lion: ‘You have lied to me, they walk just like
+men.’ The lion said: ‘They have been informed that they were going to
+be put to the test, and have assumed some strength. Just let twelve
+spinning-wheels be brought into the ante-chamber, and they will go to
+them and be pleased with them, and that is what no man would do.’
+The king liked the advice, and had the spinning-wheels placed in the
+ante-chamber.
+
+But the servant, who was well disposed to the huntsmen, went to them,
+and disclosed the project. So when they were alone the king’s daughter
+said to her eleven girls: ‘Show some constraint, and do not look round
+at the spinning-wheels.’ And next morning when the king had his twelve
+huntsmen summoned, they went through the ante-chamber, and never once
+looked at the spinning-wheels. Then the king again said to the lion:
+‘You have deceived me, they are men, for they have not looked at the
+spinning-wheels.’ The lion replied: ‘They have restrained themselves.’
+The king, however, would no longer believe the lion.
+
+The twelve huntsmen always followed the king to the chase, and his
+liking for them continually increased. Now it came to pass that
+once when they were out hunting, news came that the king’s bride was
+approaching. When the true bride heard that, it hurt her so much that
+her heart was almost broken, and she fell fainting to the ground. The
+king thought something had happened to his dear huntsman, ran up to him,
+wanted to help him, and drew his glove off. Then he saw the ring which
+he had given to his first bride, and when he looked in her face he
+recognized her. Then his heart was so touched that he kissed her, and
+when she opened her eyes he said: ‘You are mine, and I am yours, and
+no one in the world can alter that.’ He sent a messenger to the other
+bride, and entreated her to return to her own kingdom, for he had a wife
+already, and someone who had just found an old key did not require a new
+one. Thereupon the wedding was celebrated, and the lion was again taken
+into favour, because, after all, he had told the truth.
+
+
+
+
+THE KING OF THE GOLDEN MOUNTAIN
+
+There was once a merchant who had only one child, a son, that was very
+young, and barely able to run alone. He had two richly laden ships then
+making a voyage upon the seas, in which he had embarked all his wealth,
+in the hope of making great gains, when the news came that both were
+lost. Thus from being a rich man he became all at once so very poor that
+nothing was left to him but one small plot of land; and there he often
+went in an evening to take his walk, and ease his mind of a little of
+his trouble.
+
+One day, as he was roaming along in a brown study, thinking with no
+great comfort on what he had been and what he now was, and was like
+to be, all on a sudden there stood before him a little, rough-looking,
+black dwarf. ‘Prithee, friend, why so sorrowful?’ said he to the
+merchant; ‘what is it you take so deeply to heart?’ ‘If you would do me
+any good I would willingly tell you,’ said the merchant. ‘Who knows but
+I may?’ said the little man: ‘tell me what ails you, and perhaps you
+will find I may be of some use.’ Then the merchant told him how all his
+wealth was gone to the bottom of the sea, and how he had nothing left
+but that little plot of land. ‘Oh, trouble not yourself about that,’
+said the dwarf; ‘only undertake to bring me here, twelve years hence,
+whatever meets you first on your going home, and I will give you as much
+as you please.’ The merchant thought this was no great thing to ask;
+that it would most likely be his dog or his cat, or something of that
+sort, but forgot his little boy Heinel; so he agreed to the bargain, and
+signed and sealed the bond to do what was asked of him.
+
+But as he drew near home, his little boy was so glad to see him that he
+crept behind him, and laid fast hold of his legs, and looked up in
+his face and laughed. Then the father started, trembling with fear and
+horror, and saw what it was that he had bound himself to do; but as no
+gold was come, he made himself easy by thinking that it was only a joke
+that the dwarf was playing him, and that, at any rate, when the money
+came, he should see the bearer, and would not take it in.
+
+About a month afterwards he went upstairs into a lumber-room to look
+for some old iron, that he might sell it and raise a little money; and
+there, instead of his iron, he saw a large pile of gold lying on the
+floor. At the sight of this he was overjoyed, and forgetting all about
+his son, went into trade again, and became a richer merchant than
+before.
+
+Meantime little Heinel grew up, and as the end of the twelve years drew
+near the merchant began to call to mind his bond, and became very sad
+and thoughtful; so that care and sorrow were written upon his face. The
+boy one day asked what was the matter, but his father would not tell for
+some time; at last, however, he said that he had, without knowing it,
+sold him for gold to a little, ugly-looking, black dwarf, and that the
+twelve years were coming round when he must keep his word. Then Heinel
+said, ‘Father, give yourself very little trouble about that; I shall be
+too much for the little man.’
+
+When the time came, the father and son went out together to the place
+agreed upon: and the son drew a circle on the ground, and set himself
+and his father in the middle of it. The little black dwarf soon came,
+and walked round and round about the circle, but could not find any way
+to get into it, and he either could not, or dared not, jump over it. At
+last the boy said to him. ‘Have you anything to say to us, my friend, or
+what do you want?’ Now Heinel had found a friend in a good fairy, that
+was fond of him, and had told him what to do; for this fairy knew what
+good luck was in store for him. ‘Have you brought me what you said you
+would?’ said the dwarf to the merchant. The old man held his tongue, but
+Heinel said again, ‘What do you want here?’ The dwarf said, ‘I come to
+talk with your father, not with you.’ ‘You have cheated and taken in my
+father,’ said the son; ‘pray give him up his bond at once.’ ‘Fair and
+softly,’ said the little old man; ‘right is right; I have paid my money,
+and your father has had it, and spent it; so be so good as to let me
+have what I paid it for.’ ‘You must have my consent to that first,’ said
+Heinel, ‘so please to step in here, and let us talk it over.’ The old
+man grinned, and showed his teeth, as if he should have been very glad
+to get into the circle if he could. Then at last, after a long talk,
+they came to terms. Heinel agreed that his father must give him up, and
+that so far the dwarf should have his way: but, on the other hand, the
+fairy had told Heinel what fortune was in store for him, if he followed
+his own course; and he did not choose to be given up to his hump-backed
+friend, who seemed so anxious for his company.
+
+So, to make a sort of drawn battle of the matter, it was settled that
+Heinel should be put into an open boat, that lay on the sea-shore hard
+by; that the father should push him off with his own hand, and that he
+should thus be set adrift, and left to the bad or good luck of wind and
+weather. Then he took leave of his father, and set himself in the boat,
+but before it got far off a wave struck it, and it fell with one side
+low in the water, so the merchant thought that poor Heinel was lost, and
+went home very sorrowful, while the dwarf went his way, thinking that at
+any rate he had had his revenge.
+
+The boat, however, did not sink, for the good fairy took care of her
+friend, and soon raised the boat up again, and it went safely on. The
+young man sat safe within, till at length it ran ashore upon an unknown
+land. As he jumped upon the shore he saw before him a beautiful castle
+but empty and dreary within, for it was enchanted. ‘Here,’ said he to
+himself, ‘must I find the prize the good fairy told me of.’ So he once
+more searched the whole palace through, till at last he found a white
+snake, lying coiled up on a cushion in one of the chambers.
+
+Now the white snake was an enchanted princess; and she was very glad
+to see him, and said, ‘Are you at last come to set me free? Twelve
+long years have I waited here for the fairy to bring you hither as she
+promised, for you alone can save me. This night twelve men will come:
+their faces will be black, and they will be dressed in chain armour.
+They will ask what you do here, but give no answer; and let them do
+what they will--beat, whip, pinch, prick, or torment you--bear all; only
+speak not a word, and at twelve o’clock they must go away. The second
+night twelve others will come: and the third night twenty-four, who
+will even cut off your head; but at the twelfth hour of that night their
+power is gone, and I shall be free, and will come and bring you the
+Water of Life, and will wash you with it, and bring you back to life
+and health.’ And all came to pass as she had said; Heinel bore all, and
+spoke not a word; and the third night the princess came, and fell on his
+neck and kissed him. Joy and gladness burst forth throughout the castle,
+the wedding was celebrated, and he was crowned king of the Golden
+Mountain.
+
+They lived together very happily, and the queen had a son. And thus
+eight years had passed over their heads, when the king thought of his
+father; and he began to long to see him once again. But the queen was
+against his going, and said, ‘I know well that misfortunes will come
+upon us if you go.’ However, he gave her no rest till she agreed. At his
+going away she gave him a wishing-ring, and said, ‘Take this ring, and
+put it on your finger; whatever you wish it will bring you; only promise
+never to make use of it to bring me hence to your father’s house.’ Then
+he said he would do what she asked, and put the ring on his finger, and
+wished himself near the town where his father lived.
+
+Heinel found himself at the gates in a moment; but the guards would
+not let him go in, because he was so strangely clad. So he went up to a
+neighbouring hill, where a shepherd dwelt, and borrowed his old frock,
+and thus passed unknown into the town. When he came to his father’s
+house, he said he was his son; but the merchant would not believe him,
+and said he had had but one son, his poor Heinel, who he knew was long
+since dead: and as he was only dressed like a poor shepherd, he would
+not even give him anything to eat. The king, however, still vowed that
+he was his son, and said, ‘Is there no mark by which you would know me
+if I am really your son?’ ‘Yes,’ said his mother, ‘our Heinel had a mark
+like a raspberry on his right arm.’ Then he showed them the mark, and
+they knew that what he had said was true.
+
+He next told them how he was king of the Golden Mountain, and was
+married to a princess, and had a son seven years old. But the merchant
+said, ‘that can never be true; he must be a fine king truly who travels
+about in a shepherd’s frock!’ At this the son was vexed; and forgetting
+his word, turned his ring, and wished for his queen and son. In an
+instant they stood before him; but the queen wept, and said he had
+broken his word, and bad luck would follow. He did all he could to
+soothe her, and she at last seemed to be appeased; but she was not so in
+truth, and was only thinking how she should punish him.
+
+One day he took her to walk with him out of the town, and showed her
+the spot where the boat was set adrift upon the wide waters. Then he sat
+himself down, and said, ‘I am very much tired; sit by me, I will rest my
+head in your lap, and sleep a while.’ As soon as he had fallen asleep,
+however, she drew the ring from his finger, and crept softly away, and
+wished herself and her son at home in their kingdom. And when he awoke
+he found himself alone, and saw that the ring was gone from his finger.
+‘I can never go back to my father’s house,’ said he; ‘they would say I
+am a sorcerer: I will journey forth into the world, till I come again to
+my kingdom.’
+
+So saying he set out and travelled till he came to a hill, where three
+giants were sharing their father’s goods; and as they saw him pass they
+cried out and said, ‘Little men have sharp wits; he shall part the goods
+between us.’ Now there was a sword that cut off an enemy’s head whenever
+the wearer gave the words, ‘Heads off!’; a cloak that made the owner
+invisible, or gave him any form he pleased; and a pair of boots that
+carried the wearer wherever he wished. Heinel said they must first let
+him try these wonderful things, then he might know how to set a value
+upon them. Then they gave him the cloak, and he wished himself a fly,
+and in a moment he was a fly. ‘The cloak is very well,’ said he: ‘now
+give me the sword.’ ‘No,’ said they; ‘not unless you undertake not to
+say, “Heads off!” for if you do we are all dead men.’ So they gave it
+him, charging him to try it on a tree. He next asked for the boots also;
+and the moment he had all three in his power, he wished himself at
+the Golden Mountain; and there he was at once. So the giants were left
+behind with no goods to share or quarrel about.
+
+As Heinel came near his castle he heard the sound of merry music; and
+the people around told him that his queen was about to marry another
+husband. Then he threw his cloak around him, and passed through the
+castle hall, and placed himself by the side of the queen, where no one
+saw him. But when anything to eat was put upon her plate, he took it
+away and ate it himself; and when a glass of wine was handed to her, he
+took it and drank it; and thus, though they kept on giving her meat and
+drink, her plate and cup were always empty.
+
+Upon this, fear and remorse came over her, and she went into her chamber
+alone, and sat there weeping; and he followed her there. ‘Alas!’ said
+she to herself, ‘was I not once set free? Why then does this enchantment
+still seem to bind me?’
+
+‘False and fickle one!’ said he. ‘One indeed came who set thee free, and
+he is now near thee again; but how have you used him? Ought he to
+have had such treatment from thee?’ Then he went out and sent away the
+company, and said the wedding was at an end, for that he was come back
+to the kingdom. But the princes, peers, and great men mocked at him.
+However, he would enter into no parley with them, but only asked them
+if they would go in peace or not. Then they turned upon him and tried
+to seize him; but he drew his sword. ‘Heads Off!’ cried he; and with the
+word the traitors’ heads fell before him, and Heinel was once more king
+of the Golden Mountain.
+
+
+
+
+DOCTOR KNOWALL
+
+There was once upon a time a poor peasant called Crabb, who drove with
+two oxen a load of wood to the town, and sold it to a doctor for two
+talers. When the money was being counted out to him, it so happened that
+the doctor was sitting at table, and when the peasant saw how well he
+ate and drank, his heart desired what he saw, and would willingly
+have been a doctor too. So he remained standing a while, and at length
+inquired if he too could not be a doctor. ‘Oh, yes,’ said the doctor,
+‘that is soon managed.’ ‘What must I do?’ asked the peasant. ‘In the
+first place buy yourself an A B C book of the kind which has a cock on
+the frontispiece; in the second, turn your cart and your two oxen into
+money, and get yourself some clothes, and whatsoever else pertains to
+medicine; thirdly, have a sign painted for yourself with the words: “I
+am Doctor Knowall,” and have that nailed up above your house-door.’ The
+peasant did everything that he had been told to do. When he had doctored
+people awhile, but not long, a rich and great lord had some money
+stolen. Then he was told about Doctor Knowall who lived in such and such
+a village, and must know what had become of the money. So the lord had
+the horses harnessed to his carriage, drove out to the village, and
+asked Crabb if he were Doctor Knowall. Yes, he was, he said. Then he was
+to go with him and bring back the stolen money. ‘Oh, yes, but Grete, my
+wife, must go too.’ The lord was willing, and let both of them have a
+seat in the carriage, and they all drove away together. When they came
+to the nobleman’s castle, the table was spread, and Crabb was told to
+sit down and eat. ‘Yes, but my wife, Grete, too,’ said he, and he seated
+himself with her at the table. And when the first servant came with a
+dish of delicate fare, the peasant nudged his wife, and said: ‘Grete,
+that was the first,’ meaning that was the servant who brought the first
+dish. The servant, however, thought he intended by that to say: ‘That is
+the first thief,’ and as he actually was so, he was terrified, and said
+to his comrade outside: ‘The doctor knows all: we shall fare ill, he
+said I was the first.’ The second did not want to go in at all, but was
+forced. So when he went in with his dish, the peasant nudged his wife,
+and said: ‘Grete, that is the second.’ This servant was equally alarmed,
+and he got out as fast as he could. The third fared no better, for the
+peasant again said: ‘Grete, that is the third.’ The fourth had to carry
+in a dish that was covered, and the lord told the doctor that he was to
+show his skill, and guess what was beneath the cover. Actually, there
+were crabs. The doctor looked at the dish, had no idea what to say, and
+cried: ‘Ah, poor Crabb.’ When the lord heard that, he cried: ‘There! he
+knows it; he must also know who has the money!’
+
+On this the servants looked terribly uneasy, and made a sign to the
+doctor that they wished him to step outside for a moment. When therefore
+he went out, all four of them confessed to him that they had stolen
+the money, and said that they would willingly restore it and give him a
+heavy sum into the bargain, if he would not denounce them, for if he
+did they would be hanged. They led him to the spot where the money was
+concealed. With this the doctor was satisfied, and returned to the hall,
+sat down to the table, and said: ‘My lord, now will I search in my book
+where the gold is hidden.’ The fifth servant, however, crept into the
+stove to hear if the doctor knew still more. But the doctor sat still
+and opened his A B C book, turned the pages backwards and forwards, and
+looked for the cock. As he could not find it immediately he said: ‘I
+know you are there, so you had better come out!’ Then the fellow in the
+stove thought that the doctor meant him, and full of terror, sprang out,
+crying: ‘That man knows everything!’ Then Doctor Knowall showed the lord
+where the money was, but did not say who had stolen it, and received
+from both sides much money in reward, and became a renowned man.
+
+
+
+
+THE SEVEN RAVENS
+
+There was once a man who had seven sons, and last of all one daughter.
+Although the little girl was very pretty, she was so weak and small that
+they thought she could not live; but they said she should at once be
+christened.
+
+So the father sent one of his sons in haste to the spring to get some
+water, but the other six ran with him. Each wanted to be first at
+drawing the water, and so they were in such a hurry that all let their
+pitchers fall into the well, and they stood very foolishly looking at
+one another, and did not know what to do, for none dared go home. In the
+meantime the father was uneasy, and could not tell what made the
+young men stay so long. ‘Surely,’ said he, ‘the whole seven must have
+forgotten themselves over some game of play’; and when he had waited
+still longer and they yet did not come, he flew into a rage and wished
+them all turned into ravens. Scarcely had he spoken these words when he
+heard a croaking over his head, and looked up and saw seven ravens as
+black as coal flying round and round. Sorry as he was to see his wish
+so fulfilled, he did not know how what was done could be undone, and
+comforted himself as well as he could for the loss of his seven sons
+with his dear little daughter, who soon became stronger and every day
+more beautiful.
+
+For a long time she did not know that she had ever had any brothers; for
+her father and mother took care not to speak of them before her: but one
+day by chance she heard the people about her speak of them. ‘Yes,’ said
+they, ‘she is beautiful indeed, but still ‘tis a pity that her brothers
+should have been lost for her sake.’ Then she was much grieved, and went
+to her father and mother, and asked if she had any brothers, and what
+had become of them. So they dared no longer hide the truth from her, but
+said it was the will of Heaven, and that her birth was only the innocent
+cause of it; but the little girl mourned sadly about it every day, and
+thought herself bound to do all she could to bring her brothers back;
+and she had neither rest nor ease, till at length one day she stole
+away, and set out into the wide world to find her brothers, wherever
+they might be, and free them, whatever it might cost her.
+
+She took nothing with her but a little ring which her father and mother
+had given her, a loaf of bread in case she should be hungry, a little
+pitcher of water in case she should be thirsty, and a little stool
+to rest upon when she should be weary. Thus she went on and on, and
+journeyed till she came to the world’s end; then she came to the sun,
+but the sun looked much too hot and fiery; so she ran away quickly to
+the moon, but the moon was cold and chilly, and said, ‘I smell flesh
+and blood this way!’ so she took herself away in a hurry and came to the
+stars, and the stars were friendly and kind to her, and each star sat
+upon his own little stool; but the morning star rose up and gave her a
+little piece of wood, and said, ‘If you have not this little piece of
+wood, you cannot unlock the castle that stands on the glass-mountain,
+and there your brothers live.’ The little girl took the piece of wood,
+rolled it up in a little cloth, and went on again until she came to the
+glass-mountain, and found the door shut. Then she felt for the little
+piece of wood; but when she unwrapped the cloth it was not there, and
+she saw she had lost the gift of the good stars. What was to be done?
+She wanted to save her brothers, and had no key of the castle of the
+glass-mountain; so this faithful little sister took a knife out of her
+pocket and cut off her little finger, that was just the size of the
+piece of wood she had lost, and put it in the door and opened it.
+
+As she went in, a little dwarf came up to her, and said, ‘What are you
+seeking for?’ ‘I seek for my brothers, the seven ravens,’ answered she.
+Then the dwarf said, ‘My masters are not at home; but if you will wait
+till they come, pray step in.’ Now the little dwarf was getting their
+dinner ready, and he brought their food upon seven little plates, and
+their drink in seven little glasses, and set them upon the table, and
+out of each little plate their sister ate a small piece, and out of each
+little glass she drank a small drop; but she let the ring that she had
+brought with her fall into the last glass.
+
+On a sudden she heard a fluttering and croaking in the air, and the
+dwarf said, ‘Here come my masters.’ When they came in, they wanted to
+eat and drink, and looked for their little plates and glasses. Then said
+one after the other,
+
+‘Who has eaten from my little plate? And who has been drinking out of my
+little glass?’
+
+ ‘Caw! Caw! well I ween
+  Mortal lips have this way been.’
+
+When the seventh came to the bottom of his glass, and found there the
+ring, he looked at it, and knew that it was his father’s and mother’s,
+and said, ‘O that our little sister would but come! then we should be
+free.’ When the little girl heard this (for she stood behind the door
+all the time and listened), she ran forward, and in an instant all
+the ravens took their right form again; and all hugged and kissed each
+other, and went merrily home.
+
+
+
+
+THE WEDDING OF MRS FOX
+
+
+FIRST STORY
+
+There was once upon a time an old fox with nine tails, who believed that
+his wife was not faithful to him, and wished to put her to the test. He
+stretched himself out under the bench, did not move a limb, and behaved
+as if he were stone dead. Mrs Fox went up to her room, shut herself in,
+and her maid, Miss Cat, sat by the fire, and did the cooking. When it
+became known that the old fox was dead, suitors presented themselves.
+The maid heard someone standing at the house-door, knocking. She went
+and opened it, and it was a young fox, who said:
+
+ ‘What may you be about, Miss Cat?
+  Do you sleep or do you wake?’
+
+She answered:
+
+ ‘I am not sleeping, I am waking,
+  Would you know what I am making?
+  I am boiling warm beer with butter,
+  Will you be my guest for supper?’
+
+‘No, thank you, miss,’ said the fox, ‘what is Mrs Fox doing?’ The maid
+replied:
+
+ ‘She is sitting in her room,
+  Moaning in her gloom,
+  Weeping her little eyes quite red,
+  Because old Mr Fox is dead.’
+
+‘Do just tell her, miss, that a young fox is here, who would like to woo
+her.’ ‘Certainly, young sir.’
+
+  The cat goes up the stairs trip, trap,
+  The door she knocks at tap, tap, tap,
+ ‘Mistress Fox, are you inside?’
+ ‘Oh, yes, my little cat,’ she cried.
+ ‘A wooer he stands at the door out there.’
+ ‘What does he look like, my dear?’
+
+‘Has he nine as beautiful tails as the late Mr Fox?’ ‘Oh, no,’ answered
+the cat, ‘he has only one.’ ‘Then I will not have him.’
+
+Miss Cat went downstairs and sent the wooer away. Soon afterwards there
+was another knock, and another fox was at the door who wished to woo Mrs
+Fox. He had two tails, but he did not fare better than the first. After
+this still more came, each with one tail more than the other, but they
+were all turned away, until at last one came who had nine tails, like
+old Mr Fox. When the widow heard that, she said joyfully to the cat:
+
+ ‘Now open the gates and doors all wide,
+  And carry old Mr Fox outside.’
+
+But just as the wedding was going to be solemnized, old Mr Fox stirred
+under the bench, and cudgelled all the rabble, and drove them and Mrs
+Fox out of the house.
+
+
+SECOND STORY
+
+When old Mr Fox was dead, the wolf came as a suitor, and knocked at the
+door, and the cat who was servant to Mrs Fox, opened it for him. The
+wolf greeted her, and said:
+
+ ‘Good day, Mrs Cat of Kehrewit,
+  How comes it that alone you sit?
+  What are you making good?’
+
+The cat replied:
+
+ ‘In milk I’m breaking bread so sweet,
+  Will you be my guest, and eat?’
+
+‘No, thank you, Mrs Cat,’ answered the wolf. ‘Is Mrs Fox not at home?’
+
+The cat said:
+
+ ‘She sits upstairs in her room,
+  Bewailing her sorrowful doom,
+  Bewailing her trouble so sore,
+  For old Mr Fox is no more.’
+
+The wolf answered:
+
+ ‘If she’s in want of a husband now,
+  Then will it please her to step below?’
+  The cat runs quickly up the stair,
+  And lets her tail fly here and there,
+  Until she comes to the parlour door.
+  With her five gold rings at the door she knocks:
+ ‘Are you within, good Mistress Fox?
+  If you’re in want of a husband now,
+  Then will it please you to step below?
+
+Mrs Fox asked: ‘Has the gentleman red stockings on, and has he a pointed
+mouth?’ ‘No,’ answered the cat. ‘Then he won’t do for me.’
+
+When the wolf was gone, came a dog, a stag, a hare, a bear, a lion, and
+all the beasts of the forest, one after the other. But one of the good
+qualities which old Mr Fox had possessed, was always lacking, and the
+cat had continually to send the suitors away. At length came a young
+fox. Then Mrs Fox said: ‘Has the gentleman red stockings on, and has a
+little pointed mouth?’ ‘Yes,’ said the cat, ‘he has.’ ‘Then let him come
+upstairs,’ said Mrs Fox, and ordered the servant to prepare the wedding
+feast.
+
+ ‘Sweep me the room as clean as you can,
+  Up with the window, fling out my old man!
+  For many a fine fat mouse he brought,
+  Yet of his wife he never thought,
+  But ate up every one he caught.’
+
+Then the wedding was solemnized with young Mr Fox, and there was much
+rejoicing and dancing; and if they have not left off, they are dancing
+still.
+
+
+
+
+THE SALAD
+
+As a merry young huntsman was once going briskly along through a wood,
+there came up a little old woman, and said to him, ‘Good day, good day;
+you seem merry enough, but I am hungry and thirsty; do pray give me
+something to eat.’ The huntsman took pity on her, and put his hand in
+his pocket and gave her what he had. Then he wanted to go his way; but
+she took hold of him, and said, ‘Listen, my friend, to what I am going
+to tell you; I will reward you for your kindness; go your way, and after
+a little time you will come to a tree where you will see nine birds
+sitting on a cloak. Shoot into the midst of them, and one will fall down
+dead: the cloak will fall too; take it, it is a wishing-cloak, and when
+you wear it you will find yourself at any place where you may wish to
+be. Cut open the dead bird, take out its heart and keep it, and you will
+find a piece of gold under your pillow every morning when you rise. It
+is the bird’s heart that will bring you this good luck.’
+
+The huntsman thanked her, and thought to himself, ‘If all this does
+happen, it will be a fine thing for me.’ When he had gone a hundred
+steps or so, he heard a screaming and chirping in the branches over him,
+and looked up and saw a flock of birds pulling a cloak with their bills
+and feet; screaming, fighting, and tugging at each other as if
+each wished to have it himself. ‘Well,’ said the huntsman, ‘this is
+wonderful; this happens just as the old woman said’; then he shot into
+the midst of them so that their feathers flew all about. Off went the
+flock chattering away; but one fell down dead, and the cloak with it.
+Then the huntsman did as the old woman told him, cut open the bird, took
+out the heart, and carried the cloak home with him.
+
+The next morning when he awoke he lifted up his pillow, and there lay
+the piece of gold glittering underneath; the same happened next day, and
+indeed every day when he arose. He heaped up a great deal of gold, and
+at last thought to himself, ‘Of what use is this gold to me whilst I am
+at home? I will go out into the world and look about me.’
+
+Then he took leave of his friends, and hung his bag and bow about his
+neck, and went his way. It so happened that his road one day led through
+a thick wood, at the end of which was a large castle in a green meadow,
+and at one of the windows stood an old woman with a very beautiful young
+lady by her side looking about them. Now the old woman was a witch, and
+said to the young lady, ‘There is a young man coming out of the wood who
+carries a wonderful prize; we must get it away from him, my dear child,
+for it is more fit for us than for him. He has a bird’s heart that
+brings a piece of gold under his pillow every morning.’ Meantime the
+huntsman came nearer and looked at the lady, and said to himself, ‘I
+have been travelling so long that I should like to go into this castle
+and rest myself, for I have money enough to pay for anything I want’;
+but the real reason was, that he wanted to see more of the beautiful
+lady. Then he went into the house, and was welcomed kindly; and it was
+not long before he was so much in love that he thought of nothing else
+but looking at the lady’s eyes, and doing everything that she wished.
+Then the old woman said, ‘Now is the time for getting the bird’s heart.’
+So the lady stole it away, and he never found any more gold under his
+pillow, for it lay now under the young lady’s, and the old woman took it
+away every morning; but he was so much in love that he never missed his
+prize.
+
+‘Well,’ said the old witch, ‘we have got the bird’s heart, but not the
+wishing-cloak yet, and that we must also get.’ ‘Let us leave him that,’
+said the young lady; ‘he has already lost his wealth.’ Then the witch
+was very angry, and said, ‘Such a cloak is a very rare and wonderful
+thing, and I must and will have it.’ So she did as the old woman told
+her, and set herself at the window, and looked about the country and
+seemed very sorrowful; then the huntsman said, ‘What makes you so sad?’
+‘Alas! dear sir,’ said she, ‘yonder lies the granite rock where all the
+costly diamonds grow, and I want so much to go there, that whenever I
+think of it I cannot help being sorrowful, for who can reach it? only
+the birds and the flies--man cannot.’ ‘If that’s all your grief,’ said
+the huntsman, ‘I’ll take you there with all my heart’; so he drew her under
+his cloak, and the moment he wished to be on the granite mountain they
+were both there. The diamonds glittered so on all sides that they were
+delighted with the sight and picked up the finest. But the old witch
+made a deep sleep come upon him, and he said to the young lady, ‘Let us
+sit down and rest ourselves a little, I am so tired that I cannot stand
+any longer.’ So they sat down, and he laid his head in her lap and
+fell asleep; and whilst he was sleeping on she took the cloak from
+his shoulders, hung it on her own, picked up the diamonds, and wished
+herself home again.
+
+When he awoke and found that his lady had tricked him, and left him
+alone on the wild rock, he said, ‘Alas! what roguery there is in the
+world!’ and there he sat in great grief and fear, not knowing what to
+do. Now this rock belonged to fierce giants who lived upon it; and as
+he saw three of them striding about, he thought to himself, ‘I can only
+save myself by feigning to be asleep’; so he laid himself down as if he
+were in a sound sleep. When the giants came up to him, the first pushed
+him with his foot, and said, ‘What worm is this that lies here curled
+up?’ ‘Tread upon him and kill him,’ said the second. ‘It’s not worth the
+trouble,’ said the third; ‘let him live, he’ll go climbing higher up the
+mountain, and some cloud will come rolling and carry him away.’ And they
+passed on. But the huntsman had heard all they said; and as soon as they
+were gone, he climbed to the top of the mountain, and when he had sat
+there a short time a cloud came rolling around him, and caught him in a
+whirlwind and bore him along for some time, till it settled in a garden,
+and he fell quite gently to the ground amongst the greens and cabbages.
+
+Then he looked around him, and said, ‘I wish I had something to eat, if
+not I shall be worse off than before; for here I see neither apples
+nor pears, nor any kind of fruits, nothing but vegetables.’ At last he
+thought to himself, ‘I can eat salad, it will refresh and strengthen
+me.’ So he picked out a fine head and ate of it; but scarcely had he
+swallowed two bites when he felt himself quite changed, and saw with
+horror that he was turned into an ass. However, he still felt very
+hungry, and the salad tasted very nice; so he ate on till he came
+to another kind of salad, and scarcely had he tasted it when he felt
+another change come over him, and soon saw that he was lucky enough to
+have found his old shape again.
+
+Then he laid himself down and slept off a little of his weariness; and
+when he awoke the next morning he broke off a head both of the good and
+the bad salad, and thought to himself, ‘This will help me to my fortune
+again, and enable me to pay off some folks for their treachery.’ So he
+went away to try and find the castle of his friends; and after wandering
+about a few days he luckily found it. Then he stained his face all over
+brown, so that even his mother would not have known him, and went into
+the castle and asked for a lodging; ‘I am so tired,’ said he, ‘that I
+can go no farther.’ ‘Countryman,’ said the witch, ‘who are you? and what
+is your business?’ ‘I am,’ said he, ‘a messenger sent by the king to
+find the finest salad that grows under the sun. I have been lucky
+enough to find it, and have brought it with me; but the heat of the sun
+scorches so that it begins to wither, and I don’t know that I can carry
+it farther.’
+
+When the witch and the young lady heard of his beautiful salad, they
+longed to taste it, and said, ‘Dear countryman, let us just taste it.’
+‘To be sure,’ answered he; ‘I have two heads of it with me, and will
+give you one’; so he opened his bag and gave them the bad. Then the
+witch herself took it into the kitchen to be dressed; and when it was
+ready she could not wait till it was carried up, but took a few leaves
+immediately and put them in her mouth, and scarcely were they swallowed
+when she lost her own form and ran braying down into the court in the
+form of an ass. Now the servant-maid came into the kitchen, and seeing
+the salad ready, was going to carry it up; but on the way she too felt a
+wish to taste it as the old woman had done, and ate some leaves; so she
+also was turned into an ass and ran after the other, letting the dish
+with the salad fall on the ground. The messenger sat all this time with
+the beautiful young lady, and as nobody came with the salad and she
+longed to taste it, she said, ‘I don’t know where the salad can be.’
+Then he thought something must have happened, and said, ‘I will go
+into the kitchen and see.’ And as he went he saw two asses in the court
+running about, and the salad lying on the ground. ‘All right!’ said
+he; ‘those two have had their share.’ Then he took up the rest of
+the leaves, laid them on the dish and brought them to the young lady,
+saying, ‘I bring you the dish myself that you may not wait any longer.’
+So she ate of it, and like the others ran off into the court braying
+away.
+
+Then the huntsman washed his face and went into the court that they
+might know him. ‘Now you shall be paid for your roguery,’ said he; and
+tied them all three to a rope and took them along with him till he
+came to a mill and knocked at the window. ‘What’s the matter?’ said the
+miller. ‘I have three tiresome beasts here,’ said the other; ‘if you
+will take them, give them food and room, and treat them as I tell you,
+I will pay you whatever you ask.’ ‘With all my heart,’ said the miller;
+‘but how shall I treat them?’ Then the huntsman said, ‘Give the old
+one stripes three times a day and hay once; give the next (who was
+the servant-maid) stripes once a day and hay three times; and give
+the youngest (who was the beautiful lady) hay three times a day and
+no stripes’: for he could not find it in his heart to have her beaten.
+After this he went back to the castle, where he found everything he
+wanted.
+
+Some days after, the miller came to him and told him that the old ass
+was dead; ‘The other two,’ said he, ‘are alive and eat, but are so
+sorrowful that they cannot last long.’ Then the huntsman pitied them,
+and told the miller to drive them back to him, and when they came, he
+gave them some of the good salad to eat. And the beautiful young lady
+fell upon her knees before him, and said, ‘O dearest huntsman! forgive
+me all the ill I have done you; my mother forced me to it, it was
+against my will, for I always loved you very much. Your wishing-cloak
+hangs up in the closet, and as for the bird’s heart, I will give it you
+too.’ But he said, ‘Keep it, it will be just the same thing, for I mean
+to make you my wife.’ So they were married, and lived together very
+happily till they died.
+
+
+
+
+THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+
+A certain father had two sons, the elder of who was smart and sensible,
+and could do everything, but the younger was stupid and could neither
+learn nor understand anything, and when people saw him they said:
+‘There’s a fellow who will give his father some trouble!’ When anything
+had to be done, it was always the elder who was forced to do it; but
+if his father bade him fetch anything when it was late, or in the
+night-time, and the way led through the churchyard, or any other dismal
+place, he answered: ‘Oh, no father, I’ll not go there, it makes me
+shudder!’ for he was afraid. Or when stories were told by the fire at
+night which made the flesh creep, the listeners sometimes said: ‘Oh,
+it makes us shudder!’ The younger sat in a corner and listened with
+the rest of them, and could not imagine what they could mean. ‘They are
+always saying: “It makes me shudder, it makes me shudder!” It does not
+make me shudder,’ thought he. ‘That, too, must be an art of which I
+understand nothing!’
+
+Now it came to pass that his father said to him one day: ‘Hearken to me,
+you fellow in the corner there, you are growing tall and strong, and you
+too must learn something by which you can earn your bread. Look how your
+brother works, but you do not even earn your salt.’ ‘Well, father,’ he
+replied, ‘I am quite willing to learn something--indeed, if it could but
+be managed, I should like to learn how to shudder. I don’t understand
+that at all yet.’ The elder brother smiled when he heard that, and
+thought to himself: ‘Goodness, what a blockhead that brother of mine is!
+He will never be good for anything as long as he lives! He who wants to
+be a sickle must bend himself betimes.’
+
+The father sighed, and answered him: ‘You shall soon learn what it is to
+shudder, but you will not earn your bread by that.’
+
+Soon after this the sexton came to the house on a visit, and the father
+bewailed his trouble, and told him how his younger son was so backward
+in every respect that he knew nothing and learnt nothing. ‘Just think,’
+said he, ‘when I asked him how he was going to earn his bread, he
+actually wanted to learn to shudder.’ ‘If that be all,’ replied the
+sexton, ‘he can learn that with me. Send him to me, and I will soon
+polish him.’ The father was glad to do it, for he thought: ‘It will
+train the boy a little.’ The sexton therefore took him into his house,
+and he had to ring the church bell. After a day or two, the sexton awoke
+him at midnight, and bade him arise and go up into the church tower and
+ring the bell. ‘You shall soon learn what shuddering is,’ thought he,
+and secretly went there before him; and when the boy was at the top of
+the tower and turned round, and was just going to take hold of the bell
+rope, he saw a white figure standing on the stairs opposite the sounding
+hole. ‘Who is there?’ cried he, but the figure made no reply, and did
+not move or stir. ‘Give an answer,’ cried the boy, ‘or take yourself
+off, you have no business here at night.’
+
+The sexton, however, remained standing motionless that the boy might
+think he was a ghost. The boy cried a second time: ‘What do you want
+here?--speak if you are an honest fellow, or I will throw you down the
+steps!’ The sexton thought: ‘He can’t mean to be as bad as his words,’
+uttered no sound and stood as if he were made of stone. Then the boy
+called to him for the third time, and as that was also to no purpose,
+he ran against him and pushed the ghost down the stairs, so that it fell
+down the ten steps and remained lying there in a corner. Thereupon he
+rang the bell, went home, and without saying a word went to bed, and
+fell asleep. The sexton’s wife waited a long time for her husband, but
+he did not come back. At length she became uneasy, and wakened the boy,
+and asked: ‘Do you know where my husband is? He climbed up the tower
+before you did.’ ‘No, I don’t know,’ replied the boy, ‘but someone was
+standing by the sounding hole on the other side of the steps, and as he
+would neither gave an answer nor go away, I took him for a scoundrel,
+and threw him downstairs. Just go there and you will see if it was he.
+I should be sorry if it were.’ The woman ran away and found her husband,
+who was lying moaning in the corner, and had broken his leg.
+
+She carried him down, and then with loud screams she hastened to the
+boy’s father, ‘Your boy,’ cried she, ‘has been the cause of a great
+misfortune! He has thrown my husband down the steps so that he broke his
+leg. Take the good-for-nothing fellow out of our house.’ The father was
+terrified, and ran thither and scolded the boy. ‘What wicked tricks
+are these?’ said he. ‘The devil must have put them into your head.’
+‘Father,’ he replied, ‘do listen to me. I am quite innocent. He was
+standing there by night like one intent on doing evil. I did not know
+who it was, and I entreated him three times either to speak or to go
+away.’ ‘Ah,’ said the father, ‘I have nothing but unhappiness with you.
+Go out of my sight. I will see you no more.’
+
+‘Yes, father, right willingly, wait only until it is day. Then will I
+go forth and learn how to shudder, and then I shall, at any rate,
+understand one art which will support me.’ ‘Learn what you will,’ spoke
+the father, ‘it is all the same to me. Here are fifty talers for you.
+Take these and go into the wide world, and tell no one from whence you
+come, and who is your father, for I have reason to be ashamed of you.’
+‘Yes, father, it shall be as you will. If you desire nothing more than
+that, I can easily keep it in mind.’
+
+When the day dawned, therefore, the boy put his fifty talers into his
+pocket, and went forth on the great highway, and continually said to
+himself: ‘If I could but shudder! If I could but shudder!’ Then a man
+approached who heard this conversation which the youth was holding with
+himself, and when they had walked a little farther to where they could
+see the gallows, the man said to him: ‘Look, there is the tree where
+seven men have married the ropemaker’s daughter, and are now learning
+how to fly. Sit down beneath it, and wait till night comes, and you will
+soon learn how to shudder.’ ‘If that is all that is wanted,’ answered
+the youth, ‘it is easily done; but if I learn how to shudder as fast as
+that, you shall have my fifty talers. Just come back to me early in the
+morning.’ Then the youth went to the gallows, sat down beneath it, and
+waited till evening came. And as he was cold, he lighted himself a fire,
+but at midnight the wind blew so sharply that in spite of his fire, he
+could not get warm. And as the wind knocked the hanged men against each
+other, and they moved backwards and forwards, he thought to himself:
+‘If you shiver below by the fire, how those up above must freeze and
+suffer!’ And as he felt pity for them, he raised the ladder, and climbed
+up, unbound one of them after the other, and brought down all seven.
+Then he stoked the fire, blew it, and set them all round it to warm
+themselves. But they sat there and did not stir, and the fire caught
+their clothes. So he said: ‘Take care, or I will hang you up again.’ The
+dead men, however, did not hear, but were quite silent, and let their
+rags go on burning. At this he grew angry, and said: ‘If you will not
+take care, I cannot help you, I will not be burnt with you,’ and he hung
+them up again each in his turn. Then he sat down by his fire and fell
+asleep, and the next morning the man came to him and wanted to have
+the fifty talers, and said: ‘Well do you know how to shudder?’ ‘No,’
+answered he, ‘how should I know? Those fellows up there did not open
+their mouths, and were so stupid that they let the few old rags which
+they had on their bodies get burnt.’ Then the man saw that he would not
+get the fifty talers that day, and went away saying: ‘Such a youth has
+never come my way before.’
+
+The youth likewise went his way, and once more began to mutter to
+himself: ‘Ah, if I could but shudder! Ah, if I could but shudder!’ A
+waggoner who was striding behind him heard this and asked: ‘Who are
+you?’ ‘I don’t know,’ answered the youth. Then the waggoner asked: ‘From
+whence do you come?’ ‘I know not.’ ‘Who is your father?’ ‘That I may
+not tell you.’ ‘What is it that you are always muttering between your
+teeth?’ ‘Ah,’ replied the youth, ‘I do so wish I could shudder, but
+no one can teach me how.’ ‘Enough of your foolish chatter,’ said the
+waggoner. ‘Come, go with me, I will see about a place for you.’ The
+youth went with the waggoner, and in the evening they arrived at an inn
+where they wished to pass the night. Then at the entrance of the parlour
+the youth again said quite loudly: ‘If I could but shudder! If I could
+but shudder!’ The host who heard this, laughed and said: ‘If that is
+your desire, there ought to be a good opportunity for you here.’ ‘Ah,
+be silent,’ said the hostess, ‘so many prying persons have already lost
+their lives, it would be a pity and a shame if such beautiful eyes as
+these should never see the daylight again.’
+
+But the youth said: ‘However difficult it may be, I will learn it. For
+this purpose indeed have I journeyed forth.’ He let the host have
+no rest, until the latter told him, that not far from thence stood a
+haunted castle where anyone could very easily learn what shuddering was,
+if he would but watch in it for three nights. The king had promised that
+he who would venture should have his daughter to wife, and she was the
+most beautiful maiden the sun shone on. Likewise in the castle lay great
+treasures, which were guarded by evil spirits, and these treasures would
+then be freed, and would make a poor man rich enough. Already many men
+had gone into the castle, but as yet none had come out again. Then the
+youth went next morning to the king, and said: ‘If it be allowed, I will
+willingly watch three nights in the haunted castle.’
+
+The king looked at him, and as the youth pleased him, he said: ‘You may
+ask for three things to take into the castle with you, but they must
+be things without life.’ Then he answered: ‘Then I ask for a fire, a
+turning lathe, and a cutting-board with the knife.’
+
+The king had these things carried into the castle for him during the
+day. When night was drawing near, the youth went up and made himself
+a bright fire in one of the rooms, placed the cutting-board and knife
+beside it, and seated himself by the turning-lathe. ‘Ah, if I could
+but shudder!’ said he, ‘but I shall not learn it here either.’ Towards
+midnight he was about to poke his fire, and as he was blowing it,
+something cried suddenly from one corner: ‘Au, miau! how cold we are!’
+‘You fools!’ cried he, ‘what are you crying about? If you are cold, come
+and take a seat by the fire and warm yourselves.’ And when he had said
+that, two great black cats came with one tremendous leap and sat down
+on each side of him, and looked savagely at him with their fiery
+eyes. After a short time, when they had warmed themselves, they said:
+‘Comrade, shall we have a game of cards?’ ‘Why not?’ he replied, ‘but
+just show me your paws.’ Then they stretched out their claws. ‘Oh,’ said
+he, ‘what long nails you have! Wait, I must first cut them for you.’
+Thereupon he seized them by the throats, put them on the cutting-board
+and screwed their feet fast. ‘I have looked at your fingers,’ said he,
+‘and my fancy for card-playing has gone,’ and he struck them dead and
+threw them out into the water. But when he had made away with these two,
+and was about to sit down again by his fire, out from every hole and
+corner came black cats and black dogs with red-hot chains, and more
+and more of them came until he could no longer move, and they yelled
+horribly, and got on his fire, pulled it to pieces, and tried to put
+it out. He watched them for a while quietly, but at last when they were
+going too far, he seized his cutting-knife, and cried: ‘Away with you,
+vermin,’ and began to cut them down. Some of them ran away, the others
+he killed, and threw out into the fish-pond. When he came back he fanned
+the embers of his fire again and warmed himself. And as he thus sat, his
+eyes would keep open no longer, and he felt a desire to sleep. Then he
+looked round and saw a great bed in the corner. ‘That is the very thing
+for me,’ said he, and got into it. When he was just going to shut his
+eyes, however, the bed began to move of its own accord, and went over
+the whole of the castle. ‘That’s right,’ said he, ‘but go faster.’ Then
+the bed rolled on as if six horses were harnessed to it, up and down,
+over thresholds and stairs, but suddenly hop, hop, it turned over upside
+down, and lay on him like a mountain. But he threw quilts and pillows up
+in the air, got out and said: ‘Now anyone who likes, may drive,’ and
+lay down by his fire, and slept till it was day. In the morning the king
+came, and when he saw him lying there on the ground, he thought the evil
+spirits had killed him and he was dead. Then said he: ‘After all it is a
+pity,--for so handsome a man.’ The youth heard it, got up, and said: ‘It
+has not come to that yet.’ Then the king was astonished, but very glad,
+and asked how he had fared. ‘Very well indeed,’ answered he; ‘one
+night is past, the two others will pass likewise.’ Then he went to the
+innkeeper, who opened his eyes very wide, and said: ‘I never expected to
+see you alive again! Have you learnt how to shudder yet?’ ‘No,’ said he,
+‘it is all in vain. If someone would but tell me!’
+
+The second night he again went up into the old castle, sat down by the
+fire, and once more began his old song: ‘If I could but shudder!’ When
+midnight came, an uproar and noise of tumbling about was heard; at
+first it was low, but it grew louder and louder. Then it was quiet for
+a while, and at length with a loud scream, half a man came down the
+chimney and fell before him. ‘Hullo!’ cried he, ‘another half belongs
+to this. This is not enough!’ Then the uproar began again, there was a
+roaring and howling, and the other half fell down likewise. ‘Wait,’ said
+he, ‘I will just stoke up the fire a little for you.’ When he had done
+that and looked round again, the two pieces were joined together, and a
+hideous man was sitting in his place. ‘That is no part of our bargain,’
+said the youth, ‘the bench is mine.’ The man wanted to push him away;
+the youth, however, would not allow that, but thrust him off with all
+his strength, and seated himself again in his own place. Then still more
+men fell down, one after the other; they brought nine dead men’s legs
+and two skulls, and set them up and played at nine-pins with them. The
+youth also wanted to play and said: ‘Listen you, can I join you?’ ‘Yes,
+if you have any money.’ ‘Money enough,’ replied he, ‘but your balls are
+not quite round.’ Then he took the skulls and put them in the lathe and
+turned them till they were round. ‘There, now they will roll better!’
+said he. ‘Hurrah! now we’ll have fun!’ He played with them and lost some
+of his money, but when it struck twelve, everything vanished from his
+sight. He lay down and quietly fell asleep. Next morning the king came
+to inquire after him. ‘How has it fared with you this time?’ asked he.
+‘I have been playing at nine-pins,’ he answered, ‘and have lost a couple
+of farthings.’ ‘Have you not shuddered then?’ ‘What?’ said he, ‘I have
+had a wonderful time! If I did but know what it was to shudder!’
+
+The third night he sat down again on his bench and said quite sadly:
+‘If I could but shudder.’ When it grew late, six tall men came in and
+brought a coffin. Then he said: ‘Ha, ha, that is certainly my little
+cousin, who died only a few days ago,’ and he beckoned with his finger,
+and cried: ‘Come, little cousin, come.’ They placed the coffin on the
+ground, but he went to it and took the lid off, and a dead man lay
+therein. He felt his face, but it was cold as ice. ‘Wait,’ said he, ‘I
+will warm you a little,’ and went to the fire and warmed his hand and
+laid it on the dead man’s face, but he remained cold. Then he took him
+out, and sat down by the fire and laid him on his breast and rubbed his
+arms that the blood might circulate again. As this also did no good, he
+thought to himself: ‘When two people lie in bed together, they warm each
+other,’ and carried him to the bed, covered him over and lay down by
+him. After a short time the dead man became warm too, and began to move.
+Then said the youth, ‘See, little cousin, have I not warmed you?’ The
+dead man, however, got up and cried: ‘Now will I strangle you.’
+
+‘What!’ said he, ‘is that the way you thank me? You shall at once go
+into your coffin again,’ and he took him up, threw him into it, and shut
+the lid. Then came the six men and carried him away again. ‘I cannot
+manage to shudder,’ said he. ‘I shall never learn it here as long as I
+live.’
+
+Then a man entered who was taller than all others, and looked terrible.
+He was old, however, and had a long white beard. ‘You wretch,’ cried he,
+‘you shall soon learn what it is to shudder, for you shall die.’ ‘Not so
+fast,’ replied the youth. ‘If I am to die, I shall have to have a say
+in it.’ ‘I will soon seize you,’ said the fiend. ‘Softly, softly, do not
+talk so big. I am as strong as you are, and perhaps even stronger.’
+‘We shall see,’ said the old man. ‘If you are stronger, I will let you
+go--come, we will try.’ Then he led him by dark passages to a smith’s
+forge, took an axe, and with one blow struck an anvil into the ground.
+‘I can do better than that,’ said the youth, and went to the other
+anvil. The old man placed himself near and wanted to look on, and his
+white beard hung down. Then the youth seized the axe, split the anvil
+with one blow, and in it caught the old man’s beard. ‘Now I have you,’
+said the youth. ‘Now it is your turn to die.’ Then he seized an iron bar
+and beat the old man till he moaned and entreated him to stop, when he
+would give him great riches. The youth drew out the axe and let him go.
+The old man led him back into the castle, and in a cellar showed him
+three chests full of gold. ‘Of these,’ said he, ‘one part is for the
+poor, the other for the king, the third yours.’ In the meantime it
+struck twelve, and the spirit disappeared, so that the youth stood in
+darkness. ‘I shall still be able to find my way out,’ said he, and felt
+about, found the way into the room, and slept there by his fire.
+Next morning the king came and said: ‘Now you must have learnt what
+shuddering is?’ ‘No,’ he answered; ‘what can it be? My dead cousin was
+here, and a bearded man came and showed me a great deal of money down
+below, but no one told me what it was to shudder.’ ‘Then,’ said the
+king, ‘you have saved the castle, and shall marry my daughter.’ ‘That
+is all very well,’ said he, ‘but still I do not know what it is to
+shudder!’
+
+Then the gold was brought up and the wedding celebrated; but howsoever
+much the young king loved his wife, and however happy he was, he still
+said always: ‘If I could but shudder--if I could but shudder.’ And this
+at last angered her. Her waiting-maid said: ‘I will find a cure for him;
+he shall soon learn what it is to shudder.’ She went out to the stream
+which flowed through the garden, and had a whole bucketful of gudgeons
+brought to her. At night when the young king was sleeping, his wife was
+to draw the clothes off him and empty the bucket full of cold water
+with the gudgeons in it over him, so that the little fishes would
+sprawl about him. Then he woke up and cried: ‘Oh, what makes me shudder
+so?--what makes me shudder so, dear wife? Ah! now I know what it is to
+shudder!’
+
+
+
+
+KING GRISLY-BEARD
+
+A great king of a land far away in the East had a daughter who was very
+beautiful, but so proud, and haughty, and conceited, that none of the
+princes who came to ask her in marriage was good enough for her, and she
+only made sport of them.
+
+Once upon a time the king held a great feast, and asked thither all
+her suitors; and they all sat in a row, ranged according to their
+rank--kings, and princes, and dukes, and earls, and counts, and barons,
+and knights. Then the princess came in, and as she passed by them she
+had something spiteful to say to every one. The first was too fat: ‘He’s
+as round as a tub,’ said she. The next was too tall: ‘What a maypole!’
+said she. The next was too short: ‘What a dumpling!’ said she. The
+fourth was too pale, and she called him ‘Wallface.’ The fifth was too
+red, so she called him ‘Coxcomb.’ The sixth was not straight enough;
+so she said he was like a green stick, that had been laid to dry over
+a baker’s oven. And thus she had some joke to crack upon every one: but
+she laughed more than all at a good king who was there. ‘Look at
+him,’ said she; ‘his beard is like an old mop; he shall be called
+Grisly-beard.’ So the king got the nickname of Grisly-beard.
+
+But the old king was very angry when he saw how his daughter behaved,
+and how she ill-treated all his guests; and he vowed that, willing or
+unwilling, she should marry the first man, be he prince or beggar, that
+came to the door.
+
+Two days after there came by a travelling fiddler, who began to play
+under the window and beg alms; and when the king heard him, he said,
+‘Let him come in.’ So they brought in a dirty-looking fellow; and when
+he had sung before the king and the princess, he begged a boon. Then the
+king said, ‘You have sung so well, that I will give you my daughter for
+your wife.’ The princess begged and prayed; but the king said, ‘I have
+sworn to give you to the first comer, and I will keep my word.’ So words
+and tears were of no avail; the parson was sent for, and she was married
+to the fiddler. When this was over the king said, ‘Now get ready to
+go--you must not stay here--you must travel on with your husband.’
+
+Then the fiddler went his way, and took her with him, and they soon came
+to a great wood. ‘Pray,’ said she, ‘whose is this wood?’ ‘It belongs
+to King Grisly-beard,’ answered he; ‘hadst thou taken him, all had been
+thine.’ ‘Ah! unlucky wretch that I am!’ sighed she; ‘would that I had
+married King Grisly-beard!’ Next they came to some fine meadows. ‘Whose
+are these beautiful green meadows?’ said she. ‘They belong to King
+Grisly-beard, hadst thou taken him, they had all been thine.’ ‘Ah!
+unlucky wretch that I am!’ said she; ‘would that I had married King
+Grisly-beard!’
+
+Then they came to a great city. ‘Whose is this noble city?’ said she.
+‘It belongs to King Grisly-beard; hadst thou taken him, it had all been
+thine.’ ‘Ah! wretch that I am!’ sighed she; ‘why did I not marry King
+Grisly-beard?’ ‘That is no business of mine,’ said the fiddler: ‘why
+should you wish for another husband? Am not I good enough for you?’
+
+At last they came to a small cottage. ‘What a paltry place!’ said she;
+‘to whom does that little dirty hole belong?’ Then the fiddler said,
+‘That is your and my house, where we are to live.’ ‘Where are your
+servants?’ cried she. ‘What do we want with servants?’ said he; ‘you
+must do for yourself whatever is to be done. Now make the fire, and put
+on water and cook my supper, for I am very tired.’ But the princess knew
+nothing of making fires and cooking, and the fiddler was forced to help
+her. When they had eaten a very scanty meal they went to bed; but the
+fiddler called her up very early in the morning to clean the house. Thus
+they lived for two days: and when they had eaten up all there was in the
+cottage, the man said, ‘Wife, we can’t go on thus, spending money and
+earning nothing. You must learn to weave baskets.’ Then he went out and
+cut willows, and brought them home, and she began to weave; but it made
+her fingers very sore. ‘I see this work won’t do,’ said he: ‘try and
+spin; perhaps you will do that better.’ So she sat down and tried to
+spin; but the threads cut her tender fingers till the blood ran. ‘See
+now,’ said the fiddler, ‘you are good for nothing; you can do no work:
+what a bargain I have got! However, I’ll try and set up a trade in pots
+and pans, and you shall stand in the market and sell them.’ ‘Alas!’
+sighed she, ‘if any of my father’s court should pass by and see me
+standing in the market, how they will laugh at me!’
+
+But her husband did not care for that, and said she must work, if she
+did not wish to die of hunger. At first the trade went well; for many
+people, seeing such a beautiful woman, went to buy her wares, and paid
+their money without thinking of taking away the goods. They lived on
+this as long as it lasted; and then her husband bought a fresh lot of
+ware, and she sat herself down with it in the corner of the market; but
+a drunken soldier soon came by, and rode his horse against her stall,
+and broke all her goods into a thousand pieces. Then she began to cry,
+and knew not what to do. ‘Ah! what will become of me?’ said she; ‘what
+will my husband say?’ So she ran home and told him all. ‘Who would
+have thought you would have been so silly,’ said he, ‘as to put an
+earthenware stall in the corner of the market, where everybody passes?
+but let us have no more crying; I see you are not fit for this sort of
+work, so I have been to the king’s palace, and asked if they did not
+want a kitchen-maid; and they say they will take you, and there you will
+have plenty to eat.’
+
+Thus the princess became a kitchen-maid, and helped the cook to do all
+the dirtiest work; but she was allowed to carry home some of the meat
+that was left, and on this they lived.
+
+She had not been there long before she heard that the king’s eldest son
+was passing by, going to be married; and she went to one of the windows
+and looked out. Everything was ready, and all the pomp and brightness of
+the court was there. Then she bitterly grieved for the pride and folly
+which had brought her so low. And the servants gave her some of the rich
+meats, which she put into her basket to take home.
+
+All on a sudden, as she was going out, in came the king’s son in golden
+clothes; and when he saw a beautiful woman at the door, he took her
+by the hand, and said she should be his partner in the dance; but she
+trembled for fear, for she saw that it was King Grisly-beard, who was
+making sport of her. However, he kept fast hold, and led her in; and the
+cover of the basket came off, so that the meats in it fell about. Then
+everybody laughed and jeered at her; and she was so abashed, that she
+wished herself a thousand feet deep in the earth. She sprang to the
+door to run away; but on the steps King Grisly-beard overtook her, and
+brought her back and said, ‘Fear me not! I am the fiddler who has lived
+with you in the hut. I brought you there because I really loved you. I
+am also the soldier that overset your stall. I have done all this only
+to cure you of your silly pride, and to show you the folly of your
+ill-treatment of me. Now all is over: you have learnt wisdom, and it is
+time to hold our marriage feast.’
+
+Then the chamberlains came and brought her the most beautiful robes; and
+her father and his whole court were there already, and welcomed her home
+on her marriage. Joy was in every face and every heart. The feast was
+grand; they danced and sang; all were merry; and I only wish that you
+and I had been of the party.
+
+
+
+
+IRON HANS
+
+There was once upon a time a king who had a great forest near his
+palace, full of all kinds of wild animals. One day he sent out a
+huntsman to shoot him a roe, but he did not come back. ‘Perhaps some
+accident has befallen him,’ said the king, and the next day he sent out
+two more huntsmen who were to search for him, but they too stayed away.
+Then on the third day, he sent for all his huntsmen, and said: ‘Scour
+the whole forest through, and do not give up until you have found all
+three.’ But of these also, none came home again, none were seen again.
+From that time forth, no one would any longer venture into the forest,
+and it lay there in deep stillness and solitude, and nothing was seen
+of it, but sometimes an eagle or a hawk flying over it. This lasted for
+many years, when an unknown huntsman announced himself to the king as
+seeking a situation, and offered to go into the dangerous forest. The
+king, however, would not give his consent, and said: ‘It is not safe in
+there; I fear it would fare with you no better than with the others,
+and you would never come out again.’ The huntsman replied: ‘Lord, I will
+venture it at my own risk, of fear I know nothing.’
+
+The huntsman therefore betook himself with his dog to the forest. It was
+not long before the dog fell in with some game on the way, and wanted to
+pursue it; but hardly had the dog run two steps when it stood before a
+deep pool, could go no farther, and a naked arm stretched itself out of
+the water, seized it, and drew it under. When the huntsman saw that, he
+went back and fetched three men to come with buckets and bale out the
+water. When they could see to the bottom there lay a wild man whose body
+was brown like rusty iron, and whose hair hung over his face down to his
+knees. They bound him with cords, and led him away to the castle. There
+was great astonishment over the wild man; the king, however, had him put
+in an iron cage in his courtyard, and forbade the door to be opened
+on pain of death, and the queen herself was to take the key into her
+keeping. And from this time forth everyone could again go into the
+forest with safety.
+
+The king had a son of eight years, who was once playing in the
+courtyard, and while he was playing, his golden ball fell into the cage.
+The boy ran thither and said: ‘Give me my ball out.’ ‘Not till you have
+opened the door for me,’ answered the man. ‘No,’ said the boy, ‘I will
+not do that; the king has forbidden it,’ and ran away. The next day he
+again went and asked for his ball; the wild man said: ‘Open my door,’
+but the boy would not. On the third day the king had ridden out hunting,
+and the boy went once more and said: ‘I cannot open the door even if I
+wished, for I have not the key.’ Then the wild man said: ‘It lies under
+your mother’s pillow, you can get it there.’ The boy, who wanted to have
+his ball back, cast all thought to the winds, and brought the key. The
+door opened with difficulty, and the boy pinched his fingers. When it
+was open the wild man stepped out, gave him the golden ball, and hurried
+away. The boy had become afraid; he called and cried after him: ‘Oh,
+wild man, do not go away, or I shall be beaten!’ The wild man turned
+back, took him up, set him on his shoulder, and went with hasty steps
+into the forest. When the king came home, he observed the empty cage,
+and asked the queen how that had happened. She knew nothing about it,
+and sought the key, but it was gone. She called the boy, but no one
+answered. The king sent out people to seek for him in the fields, but
+they did not find him. Then he could easily guess what had happened, and
+much grief reigned in the royal court.
+
+When the wild man had once more reached the dark forest, he took the boy
+down from his shoulder, and said to him: ‘You will never see your father
+and mother again, but I will keep you with me, for you have set me free,
+and I have compassion on you. If you do all I bid you, you shall fare
+well. Of treasure and gold have I enough, and more than anyone in the
+world.’ He made a bed of moss for the boy on which he slept, and the
+next morning the man took him to a well, and said: ‘Behold, the gold
+well is as bright and clear as crystal, you shall sit beside it, and
+take care that nothing falls into it, or it will be polluted. I will
+come every evening to see if you have obeyed my order.’ The boy placed
+himself by the brink of the well, and often saw a golden fish or a
+golden snake show itself therein, and took care that nothing fell in.
+As he was thus sitting, his finger hurt him so violently that he
+involuntarily put it in the water. He drew it quickly out again, but saw
+that it was quite gilded, and whatsoever pains he took to wash the gold
+off again, all was to no purpose. In the evening Iron Hans came back,
+looked at the boy, and said: ‘What has happened to the well?’ ‘Nothing
+nothing,’ he answered, and held his finger behind his back, that the
+man might not see it. But he said: ‘You have dipped your finger into
+the water, this time it may pass, but take care you do not again let
+anything go in.’ By daybreak the boy was already sitting by the well and
+watching it. His finger hurt him again and he passed it over his head,
+and then unhappily a hair fell down into the well. He took it quickly
+out, but it was already quite gilded. Iron Hans came, and already knew
+what had happened. ‘You have let a hair fall into the well,’ said he.
+‘I will allow you to watch by it once more, but if this happens for the
+third time then the well is polluted and you can no longer remain with
+me.’
+
+On the third day, the boy sat by the well, and did not stir his finger,
+however much it hurt him. But the time was long to him, and he looked at
+the reflection of his face on the surface of the water. And as he
+still bent down more and more while he was doing so, and trying to look
+straight into the eyes, his long hair fell down from his shoulders into
+the water. He raised himself up quickly, but the whole of the hair of
+his head was already golden and shone like the sun. You can imagine how
+terrified the poor boy was! He took his pocket-handkerchief and tied it
+round his head, in order that the man might not see it. When he came he
+already knew everything, and said: ‘Take the handkerchief off.’ Then the
+golden hair streamed forth, and let the boy excuse himself as he might,
+it was of no use. ‘You have not stood the trial and can stay here no
+longer. Go forth into the world, there you will learn what poverty is.
+But as you have not a bad heart, and as I mean well by you, there is
+one thing I will grant you; if you fall into any difficulty, come to the
+forest and cry: “Iron Hans,” and then I will come and help you. My
+power is great, greater than you think, and I have gold and silver in
+abundance.’
+
+Then the king’s son left the forest, and walked by beaten and unbeaten
+paths ever onwards until at length he reached a great city. There he
+looked for work, but could find none, and he learnt nothing by which he
+could help himself. At length he went to the palace, and asked if they
+would take him in. The people about court did not at all know what use
+they could make of him, but they liked him, and told him to stay. At
+length the cook took him into his service, and said he might carry wood
+and water, and rake the cinders together. Once when it so happened that
+no one else was at hand, the cook ordered him to carry the food to the
+royal table, but as he did not like to let his golden hair be seen, he
+kept his little cap on. Such a thing as that had never yet come under
+the king’s notice, and he said: ‘When you come to the royal table you
+must take your hat off.’ He answered: ‘Ah, Lord, I cannot; I have a bad
+sore place on my head.’ Then the king had the cook called before him
+and scolded him, and asked how he could take such a boy as that into his
+service; and that he was to send him away at once. The cook, however,
+had pity on him, and exchanged him for the gardener’s boy.
+
+And now the boy had to plant and water the garden, hoe and dig, and bear
+the wind and bad weather. Once in summer when he was working alone in
+the garden, the day was so warm he took his little cap off that the air
+might cool him. As the sun shone on his hair it glittered and flashed so
+that the rays fell into the bedroom of the king’s daughter, and up she
+sprang to see what that could be. Then she saw the boy, and cried to
+him: ‘Boy, bring me a wreath of flowers.’ He put his cap on with all
+haste, and gathered wild field-flowers and bound them together. When he
+was ascending the stairs with them, the gardener met him, and said: ‘How
+can you take the king’s daughter a garland of such common flowers? Go
+quickly, and get another, and seek out the prettiest and rarest.’ ‘Oh,
+no,’ replied the boy, ‘the wild ones have more scent, and will please
+her better.’ When he got into the room, the king’s daughter said: ‘Take
+your cap off, it is not seemly to keep it on in my presence.’ He again
+said: ‘I may not, I have a sore head.’ She, however, caught at his
+cap and pulled it off, and then his golden hair rolled down on his
+shoulders, and it was splendid to behold. He wanted to run out, but she
+held him by the arm, and gave him a handful of ducats. With these he
+departed, but he cared nothing for the gold pieces. He took them to the
+gardener, and said: ‘I present them to your children, they can play with
+them.’ The following day the king’s daughter again called to him that he
+was to bring her a wreath of field-flowers, and then he went in with it,
+she instantly snatched at his cap, and wanted to take it away from him,
+but he held it fast with both hands. She again gave him a handful of
+ducats, but he would not keep them, and gave them to the gardener for
+playthings for his children. On the third day things went just the
+same; she could not get his cap away from him, and he would not have her
+money.
+
+Not long afterwards, the country was overrun by war. The king gathered
+together his people, and did not know whether or not he could offer any
+opposition to the enemy, who was superior in strength and had a mighty
+army. Then said the gardener’s boy: ‘I am grown up, and will go to the
+wars also, only give me a horse.’ The others laughed, and said: ‘Seek
+one for yourself when we are gone, we will leave one behind us in the
+stable for you.’ When they had gone forth, he went into the stable, and
+led the horse out; it was lame of one foot, and limped hobblety jib,
+hobblety jib; nevertheless he mounted it, and rode away to the dark
+forest. When he came to the outskirts, he called ‘Iron Hans’ three
+times so loudly that it echoed through the trees. Thereupon the wild man
+appeared immediately, and said: ‘What do you desire?’ ‘I want a strong
+steed, for I am going to the wars.’ ‘That you shall have, and still more
+than you ask for.’ Then the wild man went back into the forest, and it
+was not long before a stable-boy came out of it, who led a horse that
+snorted with its nostrils, and could hardly be restrained, and behind
+them followed a great troop of warriors entirely equipped in iron, and
+their swords flashed in the sun. The youth made over his three-legged
+horse to the stable-boy, mounted the other, and rode at the head of the
+soldiers. When he got near the battlefield a great part of the king’s
+men had already fallen, and little was wanting to make the rest give
+way. Then the youth galloped thither with his iron soldiers, broke like
+a hurricane over the enemy, and beat down all who opposed him. They
+began to flee, but the youth pursued, and never stopped, until there
+was not a single man left. Instead of returning to the king, however, he
+conducted his troop by byways back to the forest, and called forth Iron
+Hans. ‘What do you desire?’ asked the wild man. ‘Take back your horse
+and your troops, and give me my three-legged horse again.’ All that he
+asked was done, and soon he was riding on his three-legged horse. When
+the king returned to his palace, his daughter went to meet him, and
+wished him joy of his victory. ‘I am not the one who carried away the
+victory,’ said he, ‘but a strange knight who came to my assistance with
+his soldiers.’ The daughter wanted to hear who the strange knight was,
+but the king did not know, and said: ‘He followed the enemy, and I did
+not see him again.’ She inquired of the gardener where his boy was, but
+he smiled, and said: ‘He has just come home on his three-legged horse,
+and the others have been mocking him, and crying: “Here comes our
+hobblety jib back again!” They asked, too: “Under what hedge have you
+been lying sleeping all the time?” So he said: “I did the best of all,
+and it would have gone badly without me.” And then he was still more
+ridiculed.’
+
+The king said to his daughter: ‘I will proclaim a great feast that shall
+last for three days, and you shall throw a golden apple. Perhaps the
+unknown man will show himself.’ When the feast was announced, the youth
+went out to the forest, and called Iron Hans. ‘What do you desire?’
+asked he. ‘That I may catch the king’s daughter’s golden apple.’ ‘It is
+as safe as if you had it already,’ said Iron Hans. ‘You shall likewise
+have a suit of red armour for the occasion, and ride on a spirited
+chestnut-horse.’ When the day came, the youth galloped to the spot, took
+his place amongst the knights, and was recognized by no one. The king’s
+daughter came forward, and threw a golden apple to the knights, but none
+of them caught it but he, only as soon as he had it he galloped away.
+
+On the second day Iron Hans equipped him as a white knight, and gave him
+a white horse. Again he was the only one who caught the apple, and
+he did not linger an instant, but galloped off with it. The king grew
+angry, and said: ‘That is not allowed; he must appear before me and tell
+his name.’ He gave the order that if the knight who caught the apple,
+should go away again they should pursue him, and if he would not come
+back willingly, they were to cut him down and stab him.
+
+On the third day, he received from Iron Hans a suit of black armour and
+a black horse, and again he caught the apple. But when he was riding off
+with it, the king’s attendants pursued him, and one of them got so near
+him that he wounded the youth’s leg with the point of his sword. The
+youth nevertheless escaped from them, but his horse leapt so violently
+that the helmet fell from the youth’s head, and they could see that he
+had golden hair. They rode back and announced this to the king.
+
+The following day the king’s daughter asked the gardener about his
+boy. ‘He is at work in the garden; the queer creature has been at the
+festival too, and only came home yesterday evening; he has likewise
+shown my children three golden apples which he has won.’
+
+The king had him summoned into his presence, and he came and again had
+his little cap on his head. But the king’s daughter went up to him and
+took it off, and then his golden hair fell down over his shoulders, and
+he was so handsome that all were amazed. ‘Are you the knight who came
+every day to the festival, always in different colours, and who caught
+the three golden apples?’ asked the king. ‘Yes,’ answered he, ‘and here
+the apples are,’ and he took them out of his pocket, and returned them
+to the king. ‘If you desire further proof, you may see the wound which
+your people gave me when they followed me. But I am likewise the knight
+who helped you to your victory over your enemies.’ ‘If you can perform
+such deeds as that, you are no gardener’s boy; tell me, who is your
+father?’ ‘My father is a mighty king, and gold have I in plenty as great
+as I require.’ ‘I well see,’ said the king, ‘that I owe my thanks to
+you; can I do anything to please you?’ ‘Yes,’ answered he, ‘that indeed
+you can. Give me your daughter to wife.’ The maiden laughed, and said:
+‘He does not stand much on ceremony, but I have already seen by his
+golden hair that he was no gardener’s boy,’ and then she went and
+kissed him. His father and mother came to the wedding, and were in great
+delight, for they had given up all hope of ever seeing their dear
+son again. And as they were sitting at the marriage-feast, the music
+suddenly stopped, the doors opened, and a stately king came in with a
+great retinue. He went up to the youth, embraced him and said: ‘I am
+Iron Hans, and was by enchantment a wild man, but you have set me free;
+all the treasures which I possess, shall be your property.’
+
+
+
+
+CAT-SKIN
+
+There was once a king, whose queen had hair of the purest gold, and was
+so beautiful that her match was not to be met with on the whole face of
+the earth. But this beautiful queen fell ill, and when she felt that her
+end drew near she called the king to her and said, ‘Promise me that you
+will never marry again, unless you meet with a wife who is as beautiful
+as I am, and who has golden hair like mine.’ Then when the king in his
+grief promised all she asked, she shut her eyes and died. But the king
+was not to be comforted, and for a long time never thought of taking
+another wife. At last, however, his wise men said, ‘this will not do;
+the king must marry again, that we may have a queen.’ So messengers were
+sent far and wide, to seek for a bride as beautiful as the late queen.
+But there was no princess in the world so beautiful; and if there had
+been, still there was not one to be found who had golden hair. So the
+messengers came home, and had had all their trouble for nothing.
+
+Now the king had a daughter, who was just as beautiful as her mother,
+and had the same golden hair. And when she was grown up, the king looked
+at her and saw that she was just like this late queen: then he said to
+his courtiers, ‘May I not marry my daughter? She is the very image of my
+dead wife: unless I have her, I shall not find any bride upon the whole
+earth, and you say there must be a queen.’ When the courtiers heard this
+they were shocked, and said, ‘Heaven forbid that a father should marry
+his daughter! Out of so great a sin no good can come.’ And his daughter
+was also shocked, but hoped the king would soon give up such thoughts;
+so she said to him, ‘Before I marry anyone I must have three dresses:
+one must be of gold, like the sun; another must be of shining silver,
+like the moon; and a third must be dazzling as the stars: besides this,
+I want a mantle of a thousand different kinds of fur put together, to
+which every beast in the kingdom must give a part of his skin.’ And thus
+she thought he would think of the matter no more. But the king made the
+most skilful workmen in his kingdom weave the three dresses: one golden,
+like the sun; another silvery, like the moon; and a third sparkling,
+like the stars: and his hunters were told to hunt out all the beasts in
+his kingdom, and to take the finest fur out of their skins: and thus a
+mantle of a thousand furs was made.
+
+When all were ready, the king sent them to her; but she got up in the
+night when all were asleep, and took three of her trinkets, a golden
+ring, a golden necklace, and a golden brooch, and packed the three
+dresses--of the sun, the moon, and the stars--up in a nutshell, and
+wrapped herself up in the mantle made of all sorts of fur, and besmeared
+her face and hands with soot. Then she threw herself upon Heaven for
+help in her need, and went away, and journeyed on the whole night, till
+at last she came to a large wood. As she was very tired, she sat herself
+down in the hollow of a tree and soon fell asleep: and there she slept
+on till it was midday.
+
+Now as the king to whom the wood belonged was hunting in it, his dogs
+came to the tree, and began to snuff about, and run round and round, and
+bark. ‘Look sharp!’ said the king to the huntsmen, ‘and see what sort
+of game lies there.’ And the huntsmen went up to the tree, and when they
+came back again said, ‘In the hollow tree there lies a most wonderful
+beast, such as we never saw before; its skin seems to be of a thousand
+kinds of fur, but there it lies fast asleep.’ ‘See,’ said the king, ‘if
+you can catch it alive, and we will take it with us.’ So the huntsmen
+took it up, and the maiden awoke and was greatly frightened, and said,
+‘I am a poor child that has neither father nor mother left; have pity on
+me and take me with you.’ Then they said, ‘Yes, Miss Cat-skin, you will
+do for the kitchen; you can sweep up the ashes, and do things of that
+sort.’ So they put her into the coach, and took her home to the king’s
+palace. Then they showed her a little corner under the staircase, where
+no light of day ever peeped in, and said, ‘Cat-skin, you may lie and
+sleep there.’ And she was sent into the kitchen, and made to fetch wood
+and water, to blow the fire, pluck the poultry, pick the herbs, sift the
+ashes, and do all the dirty work.
+
+Thus Cat-skin lived for a long time very sorrowfully. ‘Ah! pretty
+princess!’ thought she, ‘what will now become of thee?’ But it happened
+one day that a feast was to be held in the king’s castle, so she said to
+the cook, ‘May I go up a little while and see what is going on? I will
+take care and stand behind the door.’ And the cook said, ‘Yes, you may
+go, but be back again in half an hour’s time, to rake out the ashes.’
+Then she took her little lamp, and went into her cabin, and took off the
+fur skin, and washed the soot from off her face and hands, so that her
+beauty shone forth like the sun from behind the clouds. She next opened
+her nutshell, and brought out of it the dress that shone like the sun,
+and so went to the feast. Everyone made way for her, for nobody knew
+her, and they thought she could be no less than a king’s daughter. But
+the king came up to her, and held out his hand and danced with her; and
+he thought in his heart, ‘I never saw any one half so beautiful.’
+
+When the dance was at an end she curtsied; and when the king looked
+round for her, she was gone, no one knew wither. The guards that stood
+at the castle gate were called in: but they had seen no one. The truth
+was, that she had run into her little cabin, pulled off her dress,
+blackened her face and hands, put on the fur-skin cloak, and was
+Cat-skin again. When she went into the kitchen to her work, and began
+to rake the ashes, the cook said, ‘Let that alone till the morning, and
+heat the king’s soup; I should like to run up now and give a peep: but
+take care you don’t let a hair fall into it, or you will run a chance of
+never eating again.’
+
+As soon as the cook went away, Cat-skin heated the king’s soup, and
+toasted a slice of bread first, as nicely as ever she could; and when it
+was ready, she went and looked in the cabin for her little golden ring,
+and put it into the dish in which the soup was. When the dance was over,
+the king ordered his soup to be brought in; and it pleased him so well,
+that he thought he had never tasted any so good before. At the bottom
+he saw a gold ring lying; and as he could not make out how it had got
+there, he ordered the cook to be sent for. The cook was frightened when
+he heard the order, and said to Cat-skin, ‘You must have let a hair fall
+into the soup; if it be so, you will have a good beating.’ Then he went
+before the king, and he asked him who had cooked the soup. ‘I did,’
+answered the cook. But the king said, ‘That is not true; it was better
+done than you could do it.’ Then he answered, ‘To tell the truth I did
+not cook it, but Cat-skin did.’ ‘Then let Cat-skin come up,’ said the
+king: and when she came he said to her, ‘Who are you?’ ‘I am a poor
+child,’ said she, ‘that has lost both father and mother.’ ‘How came you
+in my palace?’ asked he. ‘I am good for nothing,’ said she, ‘but to be
+scullion-girl, and to have boots and shoes thrown at my head.’ ‘But how
+did you get the ring that was in the soup?’ asked the king. Then she
+would not own that she knew anything about the ring; so the king sent
+her away again about her business.
+
+After a time there was another feast, and Cat-skin asked the cook to let
+her go up and see it as before. ‘Yes,’ said he, ‘but come again in half
+an hour, and cook the king the soup that he likes so much.’ Then she
+ran to her little cabin, washed herself quickly, and took her dress
+out which was silvery as the moon, and put it on; and when she went in,
+looking like a king’s daughter, the king went up to her, and rejoiced at
+seeing her again, and when the dance began he danced with her. After the
+dance was at an end she managed to slip out, so slyly that the king did
+not see where she was gone; but she sprang into her little cabin, and
+made herself into Cat-skin again, and went into the kitchen to cook the
+soup. Whilst the cook was above stairs, she got the golden necklace and
+dropped it into the soup; then it was brought to the king, who ate it,
+and it pleased him as well as before; so he sent for the cook, who
+was again forced to tell him that Cat-skin had cooked it. Cat-skin was
+brought again before the king, but she still told him that she was only
+fit to have boots and shoes thrown at her head.
+
+But when the king had ordered a feast to be got ready for the third
+time, it happened just the same as before. ‘You must be a witch,
+Cat-skin,’ said the cook; ‘for you always put something into your soup,
+so that it pleases the king better than mine.’ However, he let her go up
+as before. Then she put on her dress which sparkled like the stars, and
+went into the ball-room in it; and the king danced with her again, and
+thought she had never looked so beautiful as she did then. So whilst
+he was dancing with her, he put a gold ring on her finger without her
+seeing it, and ordered that the dance should be kept up a long time.
+When it was at an end, he would have held her fast by the hand, but she
+slipped away, and sprang so quickly through the crowd that he lost sight
+of her: and she ran as fast as she could into her little cabin under
+the stairs. But this time she kept away too long, and stayed beyond the
+half-hour; so she had not time to take off her fine dress, and threw her
+fur mantle over it, and in her haste did not blacken herself all over
+with soot, but left one of her fingers white.
+
+Then she ran into the kitchen, and cooked the king’s soup; and as soon
+as the cook was gone, she put the golden brooch into the dish. When the
+king got to the bottom, he ordered Cat-skin to be called once more, and
+soon saw the white finger, and the ring that he had put on it whilst
+they were dancing: so he seized her hand, and kept fast hold of it, and
+when she wanted to loose herself and spring away, the fur cloak fell off
+a little on one side, and the starry dress sparkled underneath it.
+
+Then he got hold of the fur and tore it off, and her golden hair and
+beautiful form were seen, and she could no longer hide herself: so she
+washed the soot and ashes from her face, and showed herself to be the
+most beautiful princess upon the face of the earth. But the king said,
+‘You are my beloved bride, and we will never more be parted from each
+other.’ And the wedding feast was held, and a merry day it was, as ever
+was heard of or seen in that country, or indeed in any other.
+
+
+
+
+SNOW-WHITE AND ROSE-RED
+
+There was once a poor widow who lived in a lonely cottage. In front of
+the cottage was a garden wherein stood two rose-trees, one of which bore
+white and the other red roses. She had two children who were like the
+two rose-trees, and one was called Snow-white, and the other Rose-red.
+They were as good and happy, as busy and cheerful as ever two children
+in the world were, only Snow-white was more quiet and gentle than
+Rose-red. Rose-red liked better to run about in the meadows and fields
+seeking flowers and catching butterflies; but Snow-white sat at home
+with her mother, and helped her with her housework, or read to her when
+there was nothing to do.
+
+The two children were so fond of one another that they always held each
+other by the hand when they went out together, and when Snow-white said:
+‘We will not leave each other,’ Rose-red answered: ‘Never so long as we
+live,’ and their mother would add: ‘What one has she must share with the
+other.’
+
+They often ran about the forest alone and gathered red berries, and no
+beasts did them any harm, but came close to them trustfully. The little
+hare would eat a cabbage-leaf out of their hands, the roe grazed by
+their side, the stag leapt merrily by them, and the birds sat still upon
+the boughs, and sang whatever they knew.
+
+No mishap overtook them; if they had stayed too late in the forest, and
+night came on, they laid themselves down near one another upon the moss,
+and slept until morning came, and their mother knew this and did not
+worry on their account.
+
+Once when they had spent the night in the wood and the dawn had roused
+them, they saw a beautiful child in a shining white dress sitting near
+their bed. He got up and looked quite kindly at them, but said nothing
+and went into the forest. And when they looked round they found that
+they had been sleeping quite close to a precipice, and would certainly
+have fallen into it in the darkness if they had gone only a few paces
+further. And their mother told them that it must have been the angel who
+watches over good children.
+
+Snow-white and Rose-red kept their mother’s little cottage so neat that
+it was a pleasure to look inside it. In the summer Rose-red took care
+of the house, and every morning laid a wreath of flowers by her mother’s
+bed before she awoke, in which was a rose from each tree. In the winter
+Snow-white lit the fire and hung the kettle on the hob. The kettle
+was of brass and shone like gold, so brightly was it polished. In the
+evening, when the snowflakes fell, the mother said: ‘Go, Snow-white, and
+bolt the door,’ and then they sat round the hearth, and the mother took
+her spectacles and read aloud out of a large book, and the two girls
+listened as they sat and spun. And close by them lay a lamb upon the
+floor, and behind them upon a perch sat a white dove with its head
+hidden beneath its wings.
+
+One evening, as they were thus sitting comfortably together, someone
+knocked at the door as if he wished to be let in. The mother said:
+‘Quick, Rose-red, open the door, it must be a traveller who is seeking
+shelter.’ Rose-red went and pushed back the bolt, thinking that it was a
+poor man, but it was not; it was a bear that stretched his broad, black
+head within the door.
+
+Rose-red screamed and sprang back, the lamb bleated, the dove fluttered,
+and Snow-white hid herself behind her mother’s bed. But the bear began
+to speak and said: ‘Do not be afraid, I will do you no harm! I am
+half-frozen, and only want to warm myself a little beside you.’
+
+‘Poor bear,’ said the mother, ‘lie down by the fire, only take care that
+you do not burn your coat.’ Then she cried: ‘Snow-white, Rose-red, come
+out, the bear will do you no harm, he means well.’ So they both came
+out, and by-and-by the lamb and dove came nearer, and were not afraid
+of him. The bear said: ‘Here, children, knock the snow out of my coat a
+little’; so they brought the broom and swept the bear’s hide clean;
+and he stretched himself by the fire and growled contentedly and
+comfortably. It was not long before they grew quite at home, and played
+tricks with their clumsy guest. They tugged his hair with their hands,
+put their feet upon his back and rolled him about, or they took a
+hazel-switch and beat him, and when he growled they laughed. But the
+bear took it all in good part, only when they were too rough he called
+out: ‘Leave me alive, children,
+
+  Snow-white, Rose-red,
+  Will you beat your wooer dead?’
+
+When it was bed-time, and the others went to bed, the mother said to the
+bear: ‘You can lie there by the hearth, and then you will be safe from
+the cold and the bad weather.’ As soon as day dawned the two children
+let him out, and he trotted across the snow into the forest.
+
+Henceforth the bear came every evening at the same time, laid himself
+down by the hearth, and let the children amuse themselves with him as
+much as they liked; and they got so used to him that the doors were
+never fastened until their black friend had arrived.
+
+When spring had come and all outside was green, the bear said one
+morning to Snow-white: ‘Now I must go away, and cannot come back for the
+whole summer.’ ‘Where are you going, then, dear bear?’ asked Snow-white.
+‘I must go into the forest and guard my treasures from the wicked
+dwarfs. In the winter, when the earth is frozen hard, they are obliged
+to stay below and cannot work their way through; but now, when the sun
+has thawed and warmed the earth, they break through it, and come out to
+pry and steal; and what once gets into their hands, and in their caves,
+does not easily see daylight again.’
+
+Snow-white was quite sorry at his departure, and as she unbolted the
+door for him, and the bear was hurrying out, he caught against the bolt
+and a piece of his hairy coat was torn off, and it seemed to Snow-white
+as if she had seen gold shining through it, but she was not sure about
+it. The bear ran away quickly, and was soon out of sight behind the
+trees.
+
+A short time afterwards the mother sent her children into the forest
+to get firewood. There they found a big tree which lay felled on the
+ground, and close by the trunk something was jumping backwards and
+forwards in the grass, but they could not make out what it was. When
+they came nearer they saw a dwarf with an old withered face and a
+snow-white beard a yard long. The end of the beard was caught in a
+crevice of the tree, and the little fellow was jumping about like a dog
+tied to a rope, and did not know what to do.
+
+He glared at the girls with his fiery red eyes and cried: ‘Why do you
+stand there? Can you not come here and help me?’ ‘What are you up to,
+little man?’ asked Rose-red. ‘You stupid, prying goose!’ answered the
+dwarf: ‘I was going to split the tree to get a little wood for cooking.
+The little bit of food that we people get is immediately burnt up with
+heavy logs; we do not swallow so much as you coarse, greedy folk. I had
+just driven the wedge safely in, and everything was going as I wished;
+but the cursed wedge was too smooth and suddenly sprang out, and the
+tree closed so quickly that I could not pull out my beautiful white
+beard; so now it is tight and I cannot get away, and the silly, sleek,
+milk-faced things laugh! Ugh! how odious you are!’
+
+The children tried very hard, but they could not pull the beard out, it
+was caught too fast. ‘I will run and fetch someone,’ said Rose-red. ‘You
+senseless goose!’ snarled the dwarf; ‘why should you fetch someone? You
+are already two too many for me; can you not think of something better?’
+‘Don’t be impatient,’ said Snow-white, ‘I will help you,’ and she pulled
+her scissors out of her pocket, and cut off the end of the beard.
+
+As soon as the dwarf felt himself free he laid hold of a bag which lay
+amongst the roots of the tree, and which was full of gold, and lifted it
+up, grumbling to himself: ‘Uncouth people, to cut off a piece of my fine
+beard. Bad luck to you!’ and then he swung the bag upon his back, and
+went off without even once looking at the children.
+
+Some time afterwards Snow-white and Rose-red went to catch a dish
+of fish. As they came near the brook they saw something like a large
+grasshopper jumping towards the water, as if it were going to leap in.
+They ran to it and found it was the dwarf. ‘Where are you going?’ said
+Rose-red; ‘you surely don’t want to go into the water?’ ‘I am not such
+a fool!’ cried the dwarf; ‘don’t you see that the accursed fish wants
+to pull me in?’ The little man had been sitting there fishing, and
+unluckily the wind had tangled up his beard with the fishing-line; a
+moment later a big fish made a bite and the feeble creature had not
+strength to pull it out; the fish kept the upper hand and pulled the
+dwarf towards him. He held on to all the reeds and rushes, but it was of
+little good, for he was forced to follow the movements of the fish, and
+was in urgent danger of being dragged into the water.
+
+The girls came just in time; they held him fast and tried to free his
+beard from the line, but all in vain, beard and line were entangled fast
+together. There was nothing to do but to bring out the scissors and cut
+the beard, whereby a small part of it was lost. When the dwarf saw that
+he screamed out: ‘Is that civil, you toadstool, to disfigure a man’s
+face? Was it not enough to clip off the end of my beard? Now you have
+cut off the best part of it. I cannot let myself be seen by my people.
+I wish you had been made to run the soles off your shoes!’ Then he took
+out a sack of pearls which lay in the rushes, and without another word
+he dragged it away and disappeared behind a stone.
+
+It happened that soon afterwards the mother sent the two children to the
+town to buy needles and thread, and laces and ribbons. The road led them
+across a heath upon which huge pieces of rock lay strewn about. There
+they noticed a large bird hovering in the air, flying slowly round and
+round above them; it sank lower and lower, and at last settled near a
+rock not far away. Immediately they heard a loud, piteous cry. They ran
+up and saw with horror that the eagle had seized their old acquaintance
+the dwarf, and was going to carry him off.
+
+The children, full of pity, at once took tight hold of the little man,
+and pulled against the eagle so long that at last he let his booty go.
+As soon as the dwarf had recovered from his first fright he cried
+with his shrill voice: ‘Could you not have done it more carefully! You
+dragged at my brown coat so that it is all torn and full of holes, you
+clumsy creatures!’ Then he took up a sack full of precious stones, and
+slipped away again under the rock into his hole. The girls, who by
+this time were used to his ingratitude, went on their way and did their
+business in town.
+
+As they crossed the heath again on their way home they surprised the
+dwarf, who had emptied out his bag of precious stones in a clean spot,
+and had not thought that anyone would come there so late. The evening
+sun shone upon the brilliant stones; they glittered and sparkled with
+all colours so beautifully that the children stood still and stared
+at them. ‘Why do you stand gaping there?’ cried the dwarf, and his
+ashen-grey face became copper-red with rage. He was still cursing when a
+loud growling was heard, and a black bear came trotting towards them out
+of the forest. The dwarf sprang up in a fright, but he could not reach
+his cave, for the bear was already close. Then in the dread of his heart
+he cried: ‘Dear Mr Bear, spare me, I will give you all my treasures;
+look, the beautiful jewels lying there! Grant me my life; what do you
+want with such a slender little fellow as I? you would not feel me
+between your teeth. Come, take these two wicked girls, they are tender
+morsels for you, fat as young quails; for mercy’s sake eat them!’ The
+bear took no heed of his words, but gave the wicked creature a single
+blow with his paw, and he did not move again.
+
+The girls had run away, but the bear called to them: ‘Snow-white and
+Rose-red, do not be afraid; wait, I will come with you.’ Then they
+recognized his voice and waited, and when he came up to them suddenly
+his bearskin fell off, and he stood there a handsome man, clothed all in
+gold. ‘I am a king’s son,’ he said, ‘and I was bewitched by that wicked
+dwarf, who had stolen my treasures; I have had to run about the forest
+as a savage bear until I was freed by his death. Now he has got his
+well-deserved punishment.
+
+Snow-white was married to him, and Rose-red to his brother, and they
+divided between them the great treasure which the dwarf had gathered
+together in his cave. The old mother lived peacefully and happily with
+her children for many years. She took the two rose-trees with her, and
+they stood before her window, and every year bore the most beautiful
+roses, white and red.
+
+
+*****
+
+
+The Brothers Grimm, Jacob (1785-1863) and Wilhelm (1786-1859), were born
+in Hanau, near Frankfurt, in the German state of Hesse. Throughout
+their lives they remained close friends, and both studied law at Marburg
+University. Jacob was a pioneer in the study of German philology,
+and although Wilhelm’s work was hampered by poor health the brothers
+collaborated in the creation of a German dictionary, not completed until
+a century after their deaths. But they were best (and universally) known
+for the collection of over two hundred folk tales they made from oral
+sources and published in two volumes of ‘Nursery and Household Tales’ in
+1812 and 1814. Although their intention was to preserve such material as
+part of German cultural and literary history, and their collection was
+first published with scholarly notes and no illustration, the tales soon
+came into the possession of young readers. This was in part due to Edgar
+Taylor, who made the first English translation in 1823, selecting about
+fifty stories ‘with the amusement of some young friends principally in
+view.’ They have been an essential ingredient of children’s reading ever
+since.
+
+
+
+
+
+End of Project Gutenberg’s Grimms’ Fairy Tales, by The Brothers Grimm
+
+*** END OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+***** This file should be named 2591-0.txt or 2591-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/5/9/2591/
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/huckleberry-finn.txt
+++ b/jet/source-sink-builder/src/main/resources/books/huckleberry-finn.txt
@@ -1,0 +1,12363 @@
+﻿
+
+The Project Gutenberg EBook of Adventures of Huckleberry Finn, Complete
+by Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: Adventures of Huckleberry Finn, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #76]
+
+Last Updated: August 17, 2016]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+Produced by David Widger
+
+
+
+
+
+ADVENTURES
+
+OF
+
+HUCKLEBERRY FINN
+
+(Tom Sawyer’s Comrade)
+
+By Mark Twain
+
+Complete
+
+
+
+
+CONTENTS.
+
+CHAPTER I. Civilizing Huck.--Miss Watson.--Tom Sawyer Waits.
+
+CHAPTER II. The Boys Escape Jim.--Torn Sawyer’s Gang.--Deep-laid Plans.
+
+CHAPTER III. A Good Going-over.--Grace Triumphant.--“One of Tom Sawyers’s
+Lies”.
+
+CHAPTER IV. Huck and the Judge.--Superstition.
+
+CHAPTER V. Huck’s Father.--The Fond Parent.--Reform.
+
+CHAPTER VI. He Went for Judge Thatcher.--Huck Decided to Leave.--Political
+Economy.--Thrashing Around.
+
+CHAPTER VII. Laying for Him.--Locked in the Cabin.--Sinking the
+Body.--Resting.
+
+CHAPTER VIII. Sleeping in the Woods.--Raising the Dead.--Exploring the
+Island.--Finding Jim.--Jim’s Escape.--Signs.--Balum.
+
+CHAPTER IX. The Cave.--The Floating House.
+
+CHAPTER X. The Find.--Old Hank Bunker.--In Disguise.
+
+CHAPTER XI. Huck and the Woman.--The Search.--Prevarication.--Going to
+Goshen.
+
+CHAPTER XII. Slow Navigation.--Borrowing Things.--Boarding the Wreck.--The
+Plotters.--Hunting for the Boat.
+
+CHAPTER XIII. Escaping from the Wreck.--The Watchman.--Sinking.
+
+CHAPTER XIV. A General Good Time.--The Harem.--French.
+
+CHAPTER XV. Huck Loses the Raft.--In the Fog.--Huck Finds the Raft.--Trash.
+
+CHAPTER XVI. Expectation.--A White Lie.--Floating Currency.--Running by
+Cairo.--Swimming Ashore.
+
+CHAPTER XVII. An Evening Call.--The Farm in Arkansaw.--Interior
+Decorations.--Stephen Dowling Bots.--Poetical Effusions.
+
+CHAPTER XVIII. Col. Grangerford.--Aristocracy.--Feuds.--The
+Testament.--Recovering the Raft.--The Wood--pile.--Pork and Cabbage.
+
+CHAPTER XIX. Tying Up Day--times.--An Astronomical Theory.--Running a
+Temperance Revival.--The Duke of Bridgewater.--The Troubles of Royalty.
+
+CHAPTER XX. Huck Explains.--Laying Out a Campaign.--Working the
+Camp--meeting.--A Pirate at the Camp--meeting.--The Duke as a Printer.
+
+CHAPTER XXI. Sword Exercise.--Hamlet’s Soliloquy.--They Loafed Around
+Town.--A Lazy Town.--Old Boggs.--Dead.
+
+CHAPTER XXII. Sherburn.--Attending the Circus.--Intoxication in the
+Ring.--The Thrilling Tragedy.
+
+CHAPTER XXIII. Sold.--Royal Comparisons.--Jim Gets Home-sick.
+
+CHAPTER XXIV. Jim in Royal Robes.--They Take a Passenger.--Getting
+Information.--Family Grief.
+
+CHAPTER XXV. Is It Them?--Singing the “Doxologer.”--Awful Square--Funeral
+Orgies.--A Bad Investment .
+
+CHAPTER XXVI. A Pious King.--The King’s Clergy.--She Asked His
+Pardon.--Hiding in the Room.--Huck Takes the Money.
+
+CHAPTER XXVII. The Funeral.--Satisfying Curiosity.--Suspicious of
+Huck,--Quick Sales and Small.
+
+CHAPTER XXVIII. The Trip to England.--“The Brute!”--Mary Jane Decides to
+Leave.--Huck Parting with Mary Jane.--Mumps.--The Opposition Line.
+
+CHAPTER XXIX. Contested Relationship.--The King Explains the Loss.--A
+Question of Handwriting.--Digging up the Corpse.--Huck Escapes.
+
+CHAPTER XXX. The King Went for Him.--A Royal Row.--Powerful Mellow.
+
+CHAPTER XXXI. Ominous Plans.--News from Jim.--Old Recollections.--A Sheep
+Story.--Valuable Information.
+
+CHAPTER XXXII. Still and Sunday--like.--Mistaken Identity.--Up a Stump.--In
+a Dilemma.
+
+CHAPTER XXXIII. A Nigger Stealer.--Southern Hospitality.--A Pretty Long
+Blessing.--Tar and Feathers.
+
+CHAPTER XXXIV. The Hut by the Ash Hopper.--Outrageous.--Climbing the
+Lightning Rod.--Troubled with Witches.
+
+CHAPTER XXXV. Escaping Properly.--Dark Schemes.--Discrimination in
+Stealing.--A Deep Hole.
+
+CHAPTER XXXVI. The Lightning Rod.--His Level Best.--A Bequest to
+Posterity.--A High Figure.
+
+CHAPTER XXXVII. The Last Shirt.--Mooning Around.--Sailing Orders.--The
+Witch Pie.
+
+CHAPTER XXXVIII. The Coat of Arms.--A Skilled Superintendent.--Unpleasant
+Glory.--A Tearful Subject.
+
+CHAPTER XXXIX. Rats.--Lively Bed--fellows.--The Straw Dummy.
+
+CHAPTER XL. Fishing.--The Vigilance Committee.--A Lively Run.--Jim Advises
+a Doctor.
+
+CHAPTER XLI. The Doctor.--Uncle Silas.--Sister Hotchkiss.--Aunt Sally in
+Trouble.
+
+CHAPTER XLII. Tom Sawyer Wounded.--The Doctor’s Story.--Tom
+Confesses.--Aunt Polly Arrives.--Hand Out Them Letters    .
+
+CHAPTER THE LAST. Out of Bondage.--Paying the Captive.--Yours Truly, Huck
+Finn.
+
+
+
+
+ILLUSTRATIONS.
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+Getting out of the Way
+
+Solid Comfort
+
+Thinking it Over
+
+Raising a Howl
+
+“Git Up”
+
+The Shanty
+
+Shooting the Pig
+
+Taking a Rest
+
+In the Woods
+
+Watching the Boat
+
+Discovering the Camp Fire
+
+Jim and the Ghost
+
+Misto Bradish’s Nigger
+
+Exploring the Cave
+
+In the Cave
+
+Jim sees a Dead Man
+
+They Found Eight Dollars
+
+Jim and the Snake
+
+Old Hank Bunker
+
+“A Fair Fit”
+
+“Come In”
+
+“Him and another Man”
+
+She puts up a Snack
+
+“Hump Yourself”
+
+On the Raft
+
+He sometimes Lifted a Chicken
+
+“Please don’t, Bill”
+
+“It ain’t Good Morals”
+
+“Oh! Lordy, Lordy!”
+
+In a Fix
+
+“Hello, What’s Up?”
+
+The Wreck
+
+We turned in and Slept
+
+Turning over the Truck
+
+Solomon and his Million Wives
+
+The story of “Sollermun”
+
+“We Would Sell the Raft”
+
+Among the Snags
+
+Asleep on the Raft
+
+“Something being Raftsman”
+
+“Boy, that’s a Lie”
+
+“Here I is, Huck”
+
+Climbing up the Bank
+
+“Who’s There?”
+
+“Buck”
+
+“It made Her look Spidery”
+
+“They got him out and emptied Him”  
+
+The House
+
+Col. Grangerford
+
+Young Harney Shepherdson
+
+Miss Charlotte
+
+“And asked me if I Liked Her”
+
+“Behind the Wood-pile”
+
+Hiding Day-times
+
+“And Dogs a-Coming”
+
+“By rights I am a Duke!”
+
+“I am the Late Dauphin”
+
+Tail Piece
+
+On the Raft
+
+The King as Juliet
+
+“Courting on the Sly”
+
+“A Pirate for Thirty Years”
+
+Another little Job
+
+Practizing
+
+Hamlet’s Soliloquy
+
+“Gimme a Chaw”
+
+A Little Monthly Drunk
+
+The Death of Boggs
+
+Sherburn steps out
+
+A Dead Head
+
+He shed Seventeen Suits
+
+Tragedy
+
+Their Pockets Bulged
+
+Henry the Eighth in Boston Harbor
+
+Harmless
+
+Adolphus
+
+He fairly emptied that Young Fellow
+
+“Alas, our Poor Brother”
+
+“You Bet it is”
+
+Leaking
+
+Making up the “Deffisit”
+
+Going for him
+
+The Doctor
+
+The Bag of Money
+
+The Cubby
+
+Supper with the Hare-Lip
+
+Honest Injun
+
+The Duke looks under the Bed
+
+Huck takes the Money
+
+A Crack in the Dining-room Door
+
+The Undertaker
+
+“He had a Rat!”
+
+“Was you in my Room?”
+
+Jawing
+
+In Trouble
+
+Indignation
+
+How to Find Them
+
+He Wrote
+
+Hannah with the Mumps
+
+The Auction
+
+The True Brothers
+
+The Doctor leads Huck
+
+The Duke Wrote
+
+“Gentlemen, Gentlemen!”
+
+“Jim Lit Out”
+
+The King shakes Huck
+
+The Duke went for Him
+
+Spanish Moss
+
+“Who Nailed Him?”
+
+Thinking
+
+He gave him Ten Cents
+
+Striking for the Back Country
+
+Still and Sunday-like
+
+She hugged him tight
+
+“Who do you reckon it is?”
+
+“It was Tom Sawyer”
+
+“Mr. Archibald Nichols, I presume?”
+
+A pretty long Blessing
+
+Traveling By Rail
+
+Vittles
+
+A Simple Job
+
+Witches
+
+Getting Wood
+
+One of the Best Authorities
+
+The Breakfast-Horn
+
+Smouching the Knives
+
+Going down the Lightning-Rod
+
+Stealing spoons
+
+Tom advises a Witch Pie
+
+The Rubbage-Pile
+
+“Missus, dey’s a Sheet Gone”
+
+In a Tearing Way
+
+One of his Ancestors
+
+Jim’s Coat of Arms
+
+A Tough Job
+
+Buttons on their Tails
+
+Irrigation
+
+Keeping off Dull Times
+
+Sawdust Diet
+
+Trouble is Brewing
+
+Fishing
+
+Every one had a Gun
+
+Tom caught on a Splinter
+
+Jim advises a Doctor
+
+The Doctor
+
+Uncle Silas in Danger
+
+Old Mrs. Hotchkiss
+
+Aunt Sally talks to Huck
+
+Tom Sawyer wounded
+
+The Doctor speaks for Jim
+
+Tom rose square up in Bed
+
+“Hand out them Letters”
+
+Out of Bondage
+
+Tom’s Liberality
+
+Yours Truly
+
+
+
+
+EXPLANATORY
+
+IN this book a number of dialects are used, to wit:  the Missouri negro
+dialect; the extremest form of the backwoods Southwestern dialect; the
+ordinary “Pike County” dialect; and four modified varieties of this
+last. The shadings have not been done in a haphazard fashion, or by
+guesswork; but painstakingly, and with the trustworthy guidance and
+support of personal familiarity with these several forms of speech.
+
+I make this explanation for the reason that without it many readers
+would suppose that all these characters were trying to talk alike and
+not succeeding.
+
+THE AUTHOR.
+
+
+
+
+HUCKLEBERRY FINN
+
+Scene:  The Mississippi Valley Time:  Forty to fifty years ago
+
+
+
+
+CHAPTER I.
+
+YOU don’t know about me without you have read a book by the name of The
+Adventures of Tom Sawyer; but that ain’t no matter.  That book was made
+by Mr. Mark Twain, and he told the truth, mainly.  There was things
+which he stretched, but mainly he told the truth.  That is nothing.  I
+never seen anybody but lied one time or another, without it was Aunt
+Polly, or the widow, or maybe Mary.  Aunt Polly--Tom’s Aunt Polly, she
+is--and Mary, and the Widow Douglas is all told about in that book, which
+is mostly a true book, with some stretchers, as I said before.
+
+Now the way that the book winds up is this:  Tom and me found the money
+that the robbers hid in the cave, and it made us rich.  We got six
+thousand dollars apiece--all gold.  It was an awful sight of money when
+it was piled up.  Well, Judge Thatcher he took it and put it out
+at interest, and it fetched us a dollar a day apiece all the year
+round--more than a body could tell what to do with.  The Widow Douglas
+she took me for her son, and allowed she would sivilize me; but it was
+rough living in the house all the time, considering how dismal regular
+and decent the widow was in all her ways; and so when I couldn’t stand
+it no longer I lit out.  I got into my old rags and my sugar-hogshead
+again, and was free and satisfied.  But Tom Sawyer he hunted me up and
+said he was going to start a band of robbers, and I might join if I
+would go back to the widow and be respectable.  So I went back.
+
+The widow she cried over me, and called me a poor lost lamb, and she
+called me a lot of other names, too, but she never meant no harm by
+it. She put me in them new clothes again, and I couldn’t do nothing but
+sweat and sweat, and feel all cramped up.  Well, then, the old thing
+commenced again.  The widow rung a bell for supper, and you had to come
+to time. When you got to the table you couldn’t go right to eating, but
+you had to wait for the widow to tuck down her head and grumble a little
+over the victuals, though there warn’t really anything the matter with
+them,--that is, nothing only everything was cooked by itself.  In a
+barrel of odds and ends it is different; things get mixed up, and the
+juice kind of swaps around, and the things go better.
+
+After supper she got out her book and learned me about Moses and the
+Bulrushers, and I was in a sweat to find out all about him; but by and
+by she let it out that Moses had been dead a considerable long time; so
+then I didn’t care no more about him, because I don’t take no stock in
+dead people.
+
+Pretty soon I wanted to smoke, and asked the widow to let me.  But she
+wouldn’t.  She said it was a mean practice and wasn’t clean, and I must
+try to not do it any more.  That is just the way with some people.  They
+get down on a thing when they don’t know nothing about it.  Here she was
+a-bothering about Moses, which was no kin to her, and no use to anybody,
+being gone, you see, yet finding a power of fault with me for doing a
+thing that had some good in it.  And she took snuff, too; of course that
+was all right, because she done it herself.
+
+Her sister, Miss Watson, a tolerable slim old maid, with goggles on,
+had just come to live with her, and took a set at me now with a
+spelling-book. She worked me middling hard for about an hour, and then
+the widow made her ease up.  I couldn’t stood it much longer.  Then for
+an hour it was deadly dull, and I was fidgety.  Miss Watson would say,
+“Don’t put your feet up there, Huckleberry;” and “Don’t scrunch up
+like that, Huckleberry--set up straight;” and pretty soon she would
+say, “Don’t gap and stretch like that, Huckleberry--why don’t you try to
+behave?”  Then she told me all about the bad place, and I said I wished
+I was there. She got mad then, but I didn’t mean no harm.  All I wanted
+was to go somewheres; all I wanted was a change, I warn’t particular.
+ She said it was wicked to say what I said; said she wouldn’t say it for
+the whole world; she was going to live so as to go to the good place.
+ Well, I couldn’t see no advantage in going where she was going, so I
+made up my mind I wouldn’t try for it.  But I never said so, because it
+would only make trouble, and wouldn’t do no good.
+
+Now she had got a start, and she went on and told me all about the good
+place.  She said all a body would have to do there was to go around all
+day long with a harp and sing, forever and ever.  So I didn’t think
+much of it. But I never said so.  I asked her if she reckoned Tom Sawyer
+would go there, and she said not by a considerable sight.  I was glad
+about that, because I wanted him and me to be together.
+
+Miss Watson she kept pecking at me, and it got tiresome and lonesome.
+ By and by they fetched the niggers in and had prayers, and then
+everybody was off to bed.  I went up to my room with a piece of candle,
+and put it on the table.  Then I set down in a chair by the window and
+tried to think of something cheerful, but it warn’t no use.  I felt
+so lonesome I most wished I was dead.  The stars were shining, and the
+leaves rustled in the woods ever so mournful; and I heard an owl, away
+off, who-whooing about somebody that was dead, and a whippowill and a
+dog crying about somebody that was going to die; and the wind was trying
+to whisper something to me, and I couldn’t make out what it was, and so
+it made the cold shivers run over me. Then away out in the woods I heard
+that kind of a sound that a ghost makes when it wants to tell about
+something that’s on its mind and can’t make itself understood, and so
+can’t rest easy in its grave, and has to go about that way every night
+grieving.  I got so down-hearted and scared I did wish I had some
+company.  Pretty soon a spider went crawling up my shoulder, and I
+flipped it off and it lit in the candle; and before I could budge it
+was all shriveled up.  I didn’t need anybody to tell me that that was
+an awful bad sign and would fetch me some bad luck, so I was scared
+and most shook the clothes off of me. I got up and turned around in my
+tracks three times and crossed my breast every time; and then I tied
+up a little lock of my hair with a thread to keep witches away.  But
+I hadn’t no confidence.  You do that when you’ve lost a horseshoe that
+you’ve found, instead of nailing it up over the door, but I hadn’t ever
+heard anybody say it was any way to keep off bad luck when you’d killed
+a spider.
+
+I set down again, a-shaking all over, and got out my pipe for a smoke;
+for the house was all as still as death now, and so the widow wouldn’t
+know. Well, after a long time I heard the clock away off in the town
+go boom--boom--boom--twelve licks; and all still again--stiller than
+ever. Pretty soon I heard a twig snap down in the dark amongst the
+trees--something was a stirring.  I set still and listened.  Directly I
+could just barely hear a “me-yow! me-yow!” down there.  That was good!
+ Says I, “me-yow! me-yow!” as soft as I could, and then I put out the
+light and scrambled out of the window on to the shed.  Then I slipped
+down to the ground and crawled in among the trees, and, sure enough,
+there was Tom Sawyer waiting for me.
+
+
+
+
+CHAPTER II.
+
+WE went tiptoeing along a path amongst the trees back towards the end of
+the widow’s garden, stooping down so as the branches wouldn’t scrape our
+heads. When we was passing by the kitchen I fell over a root and made
+a noise.  We scrouched down and laid still.  Miss Watson’s big nigger,
+named Jim, was setting in the kitchen door; we could see him pretty
+clear, because there was a light behind him.  He got up and stretched
+his neck out about a minute, listening.  Then he says:
+
+“Who dah?”
+
+He listened some more; then he come tiptoeing down and stood right
+between us; we could a touched him, nearly.  Well, likely it was
+minutes and minutes that there warn’t a sound, and we all there so close
+together.  There was a place on my ankle that got to itching, but I
+dasn’t scratch it; and then my ear begun to itch; and next my back,
+right between my shoulders.  Seemed like I’d die if I couldn’t scratch.
+ Well, I’ve noticed that thing plenty times since.  If you are with
+the quality, or at a funeral, or trying to go to sleep when you ain’t
+sleepy--if you are anywheres where it won’t do for you to scratch, why
+you will itch all over in upwards of a thousand places. Pretty soon Jim
+says:
+
+“Say, who is you?  Whar is you?  Dog my cats ef I didn’ hear sumf’n.
+Well, I know what I’s gwyne to do:  I’s gwyne to set down here and
+listen tell I hears it agin.”
+
+So he set down on the ground betwixt me and Tom.  He leaned his back up
+against a tree, and stretched his legs out till one of them most touched
+one of mine.  My nose begun to itch.  It itched till the tears come into
+my eyes.  But I dasn’t scratch.  Then it begun to itch on the inside.
+Next I got to itching underneath.  I didn’t know how I was going to set
+still. This miserableness went on as much as six or seven minutes; but
+it seemed a sight longer than that.  I was itching in eleven different
+places now.  I reckoned I couldn’t stand it more’n a minute longer,
+but I set my teeth hard and got ready to try.  Just then Jim begun
+to breathe heavy; next he begun to snore--and then I was pretty soon
+comfortable again.
+
+Tom he made a sign to me--kind of a little noise with his mouth--and we
+went creeping away on our hands and knees.  When we was ten foot off Tom
+whispered to me, and wanted to tie Jim to the tree for fun.  But I said
+no; he might wake and make a disturbance, and then they’d find out I
+warn’t in. Then Tom said he hadn’t got candles enough, and he would slip
+in the kitchen and get some more.  I didn’t want him to try.  I said Jim
+might wake up and come.  But Tom wanted to resk it; so we slid in there
+and got three candles, and Tom laid five cents on the table for pay.
+Then we got out, and I was in a sweat to get away; but nothing would do
+Tom but he must crawl to where Jim was, on his hands and knees, and play
+something on him.  I waited, and it seemed a good while, everything was
+so still and lonesome.
+
+As soon as Tom was back we cut along the path, around the garden fence,
+and by and by fetched up on the steep top of the hill the other side of
+the house.  Tom said he slipped Jim’s hat off of his head and hung it
+on a limb right over him, and Jim stirred a little, but he didn’t wake.
+Afterwards Jim said the witches be witched him and put him in a trance,
+and rode him all over the State, and then set him under the trees again,
+and hung his hat on a limb to show who done it.  And next time Jim told
+it he said they rode him down to New Orleans; and, after that, every
+time he told it he spread it more and more, till by and by he said they
+rode him all over the world, and tired him most to death, and his back
+was all over saddle-boils.  Jim was monstrous proud about it, and he
+got so he wouldn’t hardly notice the other niggers.  Niggers would come
+miles to hear Jim tell about it, and he was more looked up to than any
+nigger in that country.  Strange niggers would stand with their mouths
+open and look him all over, same as if he was a wonder.  Niggers is
+always talking about witches in the dark by the kitchen fire; but
+whenever one was talking and letting on to know all about such things,
+Jim would happen in and say, “Hm!  What you know ‘bout witches?” and
+that nigger was corked up and had to take a back seat.  Jim always kept
+that five-center piece round his neck with a string, and said it was a
+charm the devil give to him with his own hands, and told him he could
+cure anybody with it and fetch witches whenever he wanted to just by
+saying something to it; but he never told what it was he said to it.
+ Niggers would come from all around there and give Jim anything they
+had, just for a sight of that five-center piece; but they wouldn’t touch
+it, because the devil had had his hands on it.  Jim was most ruined for
+a servant, because he got stuck up on account of having seen the devil
+and been rode by witches.
+
+Well, when Tom and me got to the edge of the hilltop we looked away down
+into the village and could see three or four lights twinkling, where
+there was sick folks, maybe; and the stars over us was sparkling ever
+so fine; and down by the village was the river, a whole mile broad, and
+awful still and grand.  We went down the hill and found Jo Harper and
+Ben Rogers, and two or three more of the boys, hid in the old tanyard.
+ So we unhitched a skiff and pulled down the river two mile and a half,
+to the big scar on the hillside, and went ashore.
+
+We went to a clump of bushes, and Tom made everybody swear to keep the
+secret, and then showed them a hole in the hill, right in the thickest
+part of the bushes.  Then we lit the candles, and crawled in on our
+hands and knees.  We went about two hundred yards, and then the cave
+opened up. Tom poked about amongst the passages, and pretty soon ducked
+under a wall where you wouldn’t a noticed that there was a hole.  We
+went along a narrow place and got into a kind of room, all damp and
+sweaty and cold, and there we stopped.  Tom says:
+
+“Now, we’ll start this band of robbers and call it Tom Sawyer’s Gang.
+Everybody that wants to join has got to take an oath, and write his name
+in blood.”
+
+Everybody was willing.  So Tom got out a sheet of paper that he had
+wrote the oath on, and read it.  It swore every boy to stick to the
+band, and never tell any of the secrets; and if anybody done anything to
+any boy in the band, whichever boy was ordered to kill that person and
+his family must do it, and he mustn’t eat and he mustn’t sleep till he
+had killed them and hacked a cross in their breasts, which was the sign
+of the band. And nobody that didn’t belong to the band could use that
+mark, and if he did he must be sued; and if he done it again he must be
+killed.  And if anybody that belonged to the band told the secrets, he
+must have his throat cut, and then have his carcass burnt up and the
+ashes scattered all around, and his name blotted off of the list with
+blood and never mentioned again by the gang, but have a curse put on it
+and be forgot forever.
+
+Everybody said it was a real beautiful oath, and asked Tom if he got
+it out of his own head.  He said, some of it, but the rest was out of
+pirate-books and robber-books, and every gang that was high-toned had
+it.
+
+Some thought it would be good to kill the _families_ of boys that told
+the secrets.  Tom said it was a good idea, so he took a pencil and wrote
+it in. Then Ben Rogers says:
+
+“Here’s Huck Finn, he hain’t got no family; what you going to do ‘bout
+him?”
+
+“Well, hain’t he got a father?” says Tom Sawyer.
+
+“Yes, he’s got a father, but you can’t never find him these days.  He
+used to lay drunk with the hogs in the tanyard, but he hain’t been seen
+in these parts for a year or more.”
+
+They talked it over, and they was going to rule me out, because they
+said every boy must have a family or somebody to kill, or else it
+wouldn’t be fair and square for the others.  Well, nobody could think of
+anything to do--everybody was stumped, and set still.  I was most ready
+to cry; but all at once I thought of a way, and so I offered them Miss
+Watson--they could kill her.  Everybody said:
+
+“Oh, she’ll do.  That’s all right.  Huck can come in.”
+
+Then they all stuck a pin in their fingers to get blood to sign with,
+and I made my mark on the paper.
+
+“Now,” says Ben Rogers, “what’s the line of business of this Gang?”
+
+“Nothing only robbery and murder,” Tom said.
+
+“But who are we going to rob?--houses, or cattle, or--”
+
+“Stuff! stealing cattle and such things ain’t robbery; it’s burglary,”
+ says Tom Sawyer.  “We ain’t burglars.  That ain’t no sort of style.  We
+are highwaymen.  We stop stages and carriages on the road, with masks
+on, and kill the people and take their watches and money.”
+
+“Must we always kill the people?”
+
+“Oh, certainly.  It’s best.  Some authorities think different, but
+mostly it’s considered best to kill them--except some that you bring to
+the cave here, and keep them till they’re ransomed.”
+
+“Ransomed?  What’s that?”
+
+“I don’t know.  But that’s what they do.  I’ve seen it in books; and so
+of course that’s what we’ve got to do.”
+
+“But how can we do it if we don’t know what it is?”
+
+“Why, blame it all, we’ve _got_ to do it.  Don’t I tell you it’s in the
+books?  Do you want to go to doing different from what’s in the books,
+and get things all muddled up?”
+
+“Oh, that’s all very fine to _say_, Tom Sawyer, but how in the nation
+are these fellows going to be ransomed if we don’t know how to do it
+to them?--that’s the thing I want to get at.  Now, what do you reckon it
+is?”
+
+“Well, I don’t know.  But per’aps if we keep them till they’re ransomed,
+it means that we keep them till they’re dead.”
+
+“Now, that’s something _like_.  That’ll answer.  Why couldn’t you said
+that before?  We’ll keep them till they’re ransomed to death; and a
+bothersome lot they’ll be, too--eating up everything, and always trying
+to get loose.”
+
+“How you talk, Ben Rogers.  How can they get loose when there’s a guard
+over them, ready to shoot them down if they move a peg?”
+
+“A guard!  Well, that _is_ good.  So somebody’s got to set up all night
+and never get any sleep, just so as to watch them.  I think that’s
+foolishness. Why can’t a body take a club and ransom them as soon as
+they get here?”
+
+“Because it ain’t in the books so--that’s why.  Now, Ben Rogers, do you
+want to do things regular, or don’t you?--that’s the idea.  Don’t you
+reckon that the people that made the books knows what’s the correct
+thing to do?  Do you reckon _you_ can learn ‘em anything?  Not by a good
+deal. No, sir, we’ll just go on and ransom them in the regular way.”
+
+“All right.  I don’t mind; but I say it’s a fool way, anyhow.  Say, do
+we kill the women, too?”
+
+“Well, Ben Rogers, if I was as ignorant as you I wouldn’t let on.  Kill
+the women?  No; nobody ever saw anything in the books like that.  You
+fetch them to the cave, and you’re always as polite as pie to them;
+and by and by they fall in love with you, and never want to go home any
+more.”
+
+“Well, if that’s the way I’m agreed, but I don’t take no stock in it.
+Mighty soon we’ll have the cave so cluttered up with women, and fellows
+waiting to be ransomed, that there won’t be no place for the robbers.
+But go ahead, I ain’t got nothing to say.”
+
+Little Tommy Barnes was asleep now, and when they waked him up he was
+scared, and cried, and said he wanted to go home to his ma, and didn’t
+want to be a robber any more.
+
+So they all made fun of him, and called him cry-baby, and that made him
+mad, and he said he would go straight and tell all the secrets.  But
+Tom give him five cents to keep quiet, and said we would all go home and
+meet next week, and rob somebody and kill some people.
+
+Ben Rogers said he couldn’t get out much, only Sundays, and so he wanted
+to begin next Sunday; but all the boys said it would be wicked to do it
+on Sunday, and that settled the thing.  They agreed to get together and
+fix a day as soon as they could, and then we elected Tom Sawyer first
+captain and Jo Harper second captain of the Gang, and so started home.
+
+I clumb up the shed and crept into my window just before day was
+breaking. My new clothes was all greased up and clayey, and I was
+dog-tired.
+
+
+
+
+CHAPTER III.
+
+WELL, I got a good going-over in the morning from old Miss Watson on
+account of my clothes; but the widow she didn’t scold, but only cleaned
+off the grease and clay, and looked so sorry that I thought I would
+behave awhile if I could.  Then Miss Watson she took me in the closet
+and prayed, but nothing come of it.  She told me to pray every day, and
+whatever I asked for I would get it.  But it warn’t so.  I tried it.
+Once I got a fish-line, but no hooks.  It warn’t any good to me without
+hooks.  I tried for the hooks three or four times, but somehow I
+couldn’t make it work.  By and by, one day, I asked Miss Watson to
+try for me, but she said I was a fool.  She never told me why, and I
+couldn’t make it out no way.
+
+I set down one time back in the woods, and had a long think about it.
+ I says to myself, if a body can get anything they pray for, why don’t
+Deacon Winn get back the money he lost on pork?  Why can’t the widow get
+back her silver snuffbox that was stole?  Why can’t Miss Watson fat up?
+No, says I to my self, there ain’t nothing in it.  I went and told the
+widow about it, and she said the thing a body could get by praying for
+it was “spiritual gifts.”  This was too many for me, but she told me
+what she meant--I must help other people, and do everything I could for
+other people, and look out for them all the time, and never think about
+myself. This was including Miss Watson, as I took it.  I went out in the
+woods and turned it over in my mind a long time, but I couldn’t see no
+advantage about it--except for the other people; so at last I reckoned
+I wouldn’t worry about it any more, but just let it go.  Sometimes the
+widow would take me one side and talk about Providence in a way to make
+a body’s mouth water; but maybe next day Miss Watson would take hold
+and knock it all down again.  I judged I could see that there was two
+Providences, and a poor chap would stand considerable show with the
+widow’s Providence, but if Miss Watson’s got him there warn’t no help
+for him any more.  I thought it all out, and reckoned I would belong
+to the widow’s if he wanted me, though I couldn’t make out how he was
+a-going to be any better off then than what he was before, seeing I was
+so ignorant, and so kind of low-down and ornery.
+
+Pap he hadn’t been seen for more than a year, and that was comfortable
+for me; I didn’t want to see him no more.  He used to always whale me
+when he was sober and could get his hands on me; though I used to take
+to the woods most of the time when he was around.  Well, about this time
+he was found in the river drownded, about twelve mile above town, so
+people said.  They judged it was him, anyway; said this drownded man was
+just his size, and was ragged, and had uncommon long hair, which was all
+like pap; but they couldn’t make nothing out of the face, because it had
+been in the water so long it warn’t much like a face at all.  They said
+he was floating on his back in the water.  They took him and buried him
+on the bank.  But I warn’t comfortable long, because I happened to think
+of something.  I knowed mighty well that a drownded man don’t float on
+his back, but on his face.  So I knowed, then, that this warn’t pap, but
+a woman dressed up in a man’s clothes.  So I was uncomfortable again.
+ I judged the old man would turn up again by and by, though I wished he
+wouldn’t.
+
+We played robber now and then about a month, and then I resigned.  All
+the boys did.  We hadn’t robbed nobody, hadn’t killed any people, but
+only just pretended.  We used to hop out of the woods and go charging
+down on hog-drivers and women in carts taking garden stuff to market,
+but we never hived any of them.  Tom Sawyer called the hogs “ingots,”
+ and he called the turnips and stuff “julery,” and we would go to the
+cave and powwow over what we had done, and how many people we had killed
+and marked.  But I couldn’t see no profit in it.  One time Tom sent a
+boy to run about town with a blazing stick, which he called a slogan
+(which was the sign for the Gang to get together), and then he said he
+had got secret news by his spies that next day a whole parcel of Spanish
+merchants and rich A-rabs was going to camp in Cave Hollow with two
+hundred elephants, and six hundred camels, and over a thousand “sumter”
+ mules, all loaded down with di’monds, and they didn’t have only a guard
+of four hundred soldiers, and so we would lay in ambuscade, as he called
+it, and kill the lot and scoop the things.  He said we must slick up
+our swords and guns, and get ready.  He never could go after even a
+turnip-cart but he must have the swords and guns all scoured up for it,
+though they was only lath and broomsticks, and you might scour at them
+till you rotted, and then they warn’t worth a mouthful of ashes more
+than what they was before.  I didn’t believe we could lick such a crowd
+of Spaniards and A-rabs, but I wanted to see the camels and elephants,
+so I was on hand next day, Saturday, in the ambuscade; and when we got
+the word we rushed out of the woods and down the hill.  But there warn’t
+no Spaniards and A-rabs, and there warn’t no camels nor no elephants.
+ It warn’t anything but a Sunday-school picnic, and only a primer-class
+at that.  We busted it up, and chased the children up the hollow; but we
+never got anything but some doughnuts and jam, though Ben Rogers got
+a rag doll, and Jo Harper got a hymn-book and a tract; and then the
+teacher charged in, and made us drop everything and cut.
+
+ I didn’t see no di’monds, and I told Tom Sawyer so.  He said there was
+loads of them there, anyway; and he said there was A-rabs there, too,
+and elephants and things.  I said, why couldn’t we see them, then?  He
+said if I warn’t so ignorant, but had read a book called Don Quixote, I
+would know without asking.  He said it was all done by enchantment.  He
+said there was hundreds of soldiers there, and elephants and treasure,
+and so on, but we had enemies which he called magicians; and they had
+turned the whole thing into an infant Sunday-school, just out of spite.
+ I said, all right; then the thing for us to do was to go for the
+magicians.  Tom Sawyer said I was a numskull.
+
+“Why,” said he, “a magician could call up a lot of genies, and they
+would hash you up like nothing before you could say Jack Robinson.  They
+are as tall as a tree and as big around as a church.”
+
+“Well,” I says, “s’pose we got some genies to help _us_--can’t we lick
+the other crowd then?”
+
+“How you going to get them?”
+
+“I don’t know.  How do _they_ get them?”
+
+“Why, they rub an old tin lamp or an iron ring, and then the genies
+come tearing in, with the thunder and lightning a-ripping around and the
+smoke a-rolling, and everything they’re told to do they up and do it.
+ They don’t think nothing of pulling a shot-tower up by the roots, and
+belting a Sunday-school superintendent over the head with it--or any
+other man.”
+
+“Who makes them tear around so?”
+
+“Why, whoever rubs the lamp or the ring.  They belong to whoever rubs
+the lamp or the ring, and they’ve got to do whatever he says.  If he
+tells them to build a palace forty miles long out of di’monds, and fill
+it full of chewing-gum, or whatever you want, and fetch an emperor’s
+daughter from China for you to marry, they’ve got to do it--and they’ve
+got to do it before sun-up next morning, too.  And more:  they’ve got
+to waltz that palace around over the country wherever you want it, you
+understand.”
+
+“Well,” says I, “I think they are a pack of flat-heads for not keeping
+the palace themselves ‘stead of fooling them away like that.  And what’s
+more--if I was one of them I would see a man in Jericho before I would
+drop my business and come to him for the rubbing of an old tin lamp.”
+
+“How you talk, Huck Finn.  Why, you’d _have_ to come when he rubbed it,
+whether you wanted to or not.”
+
+“What! and I as high as a tree and as big as a church?  All right, then;
+I _would_ come; but I lay I’d make that man climb the highest tree there
+was in the country.”
+
+“Shucks, it ain’t no use to talk to you, Huck Finn.  You don’t seem to
+know anything, somehow--perfect saphead.”
+
+I thought all this over for two or three days, and then I reckoned I
+would see if there was anything in it.  I got an old tin lamp and an
+iron ring, and went out in the woods and rubbed and rubbed till I sweat
+like an Injun, calculating to build a palace and sell it; but it warn’t
+no use, none of the genies come.  So then I judged that all that stuff
+was only just one of Tom Sawyer’s lies.  I reckoned he believed in the
+A-rabs and the elephants, but as for me I think different.  It had all
+the marks of a Sunday-school.
+
+
+
+
+CHAPTER IV.
+
+WELL, three or four months run along, and it was well into the winter
+now. I had been to school most all the time and could spell and read and
+write just a little, and could say the multiplication table up to six
+times seven is thirty-five, and I don’t reckon I could ever get any
+further than that if I was to live forever.  I don’t take no stock in
+mathematics, anyway.
+
+At first I hated the school, but by and by I got so I could stand it.
+Whenever I got uncommon tired I played hookey, and the hiding I got next
+day done me good and cheered me up.  So the longer I went to school the
+easier it got to be.  I was getting sort of used to the widow’s ways,
+too, and they warn’t so raspy on me.  Living in a house and sleeping in
+a bed pulled on me pretty tight mostly, but before the cold weather I
+used to slide out and sleep in the woods sometimes, and so that was a
+rest to me.  I liked the old ways best, but I was getting so I liked the
+new ones, too, a little bit. The widow said I was coming along slow but
+sure, and doing very satisfactory.  She said she warn’t ashamed of me.
+
+One morning I happened to turn over the salt-cellar at breakfast.
+ I reached for some of it as quick as I could to throw over my left
+shoulder and keep off the bad luck, but Miss Watson was in ahead of me,
+and crossed me off. She says, “Take your hands away, Huckleberry; what
+a mess you are always making!”  The widow put in a good word for me, but
+that warn’t going to keep off the bad luck, I knowed that well enough.
+ I started out, after breakfast, feeling worried and shaky, and
+wondering where it was going to fall on me, and what it was going to be.
+ There is ways to keep off some kinds of bad luck, but this wasn’t one
+of them kind; so I never tried to do anything, but just poked along
+low-spirited and on the watch-out.
+
+I went down to the front garden and clumb over the stile where you go
+through the high board fence.  There was an inch of new snow on the
+ground, and I seen somebody’s tracks.  They had come up from the quarry
+and stood around the stile a while, and then went on around the garden
+fence.  It was funny they hadn’t come in, after standing around so.  I
+couldn’t make it out.  It was very curious, somehow.  I was going to
+follow around, but I stooped down to look at the tracks first.  I didn’t
+notice anything at first, but next I did.  There was a cross in the left
+boot-heel made with big nails, to keep off the devil.
+
+I was up in a second and shinning down the hill.  I looked over my
+shoulder every now and then, but I didn’t see nobody.  I was at Judge
+Thatcher’s as quick as I could get there.  He said:
+
+“Why, my boy, you are all out of breath.  Did you come for your
+interest?”
+
+“No, sir,” I says; “is there some for me?”
+
+“Oh, yes, a half-yearly is in last night--over a hundred and fifty
+dollars.  Quite a fortune for you.  You had better let me invest it
+along with your six thousand, because if you take it you’ll spend it.”
+
+“No, sir,” I says, “I don’t want to spend it.  I don’t want it at
+all--nor the six thousand, nuther.  I want you to take it; I want to give
+it to you--the six thousand and all.”
+
+He looked surprised.  He couldn’t seem to make it out.  He says:
+
+“Why, what can you mean, my boy?”
+
+I says, “Don’t you ask me no questions about it, please.  You’ll take
+it--won’t you?”
+
+He says:
+
+“Well, I’m puzzled.  Is something the matter?”
+
+“Please take it,” says I, “and don’t ask me nothing--then I won’t have to
+tell no lies.”
+
+He studied a while, and then he says:
+
+“Oho-o!  I think I see.  You want to _sell_ all your property to me--not
+give it.  That’s the correct idea.”
+
+Then he wrote something on a paper and read it over, and says:
+
+“There; you see it says ‘for a consideration.’  That means I have bought
+it of you and paid you for it.  Here’s a dollar for you.  Now you sign
+it.”
+
+So I signed it, and left.
+
+Miss Watson’s nigger, Jim, had a hair-ball as big as your fist, which
+had been took out of the fourth stomach of an ox, and he used to do
+magic with it.  He said there was a spirit inside of it, and it knowed
+everything.  So I went to him that night and told him pap was here
+again, for I found his tracks in the snow.  What I wanted to know was,
+what he was going to do, and was he going to stay?  Jim got out his
+hair-ball and said something over it, and then he held it up and dropped
+it on the floor.  It fell pretty solid, and only rolled about an inch.
+ Jim tried it again, and then another time, and it acted just the same.
+ Jim got down on his knees, and put his ear against it and listened.
+ But it warn’t no use; he said it wouldn’t talk. He said sometimes it
+wouldn’t talk without money.  I told him I had an old slick counterfeit
+quarter that warn’t no good because the brass showed through the silver
+a little, and it wouldn’t pass nohow, even if the brass didn’t show,
+because it was so slick it felt greasy, and so that would tell on it
+every time.  (I reckoned I wouldn’t say nothing about the dollar I got
+from the judge.) I said it was pretty bad money, but maybe the hair-ball
+would take it, because maybe it wouldn’t know the difference.  Jim smelt
+it and bit it and rubbed it, and said he would manage so the hair-ball
+would think it was good.  He said he would split open a raw Irish potato
+and stick the quarter in between and keep it there all night, and next
+morning you couldn’t see no brass, and it wouldn’t feel greasy no more,
+and so anybody in town would take it in a minute, let alone a hair-ball.
+ Well, I knowed a potato would do that before, but I had forgot it.
+
+Jim put the quarter under the hair-ball, and got down and listened
+again. This time he said the hair-ball was all right.  He said it
+would tell my whole fortune if I wanted it to.  I says, go on.  So the
+hair-ball talked to Jim, and Jim told it to me.  He says:
+
+“Yo’ ole father doan’ know yit what he’s a-gwyne to do.  Sometimes he
+spec he’ll go ‘way, en den agin he spec he’ll stay.  De bes’ way is to
+res’ easy en let de ole man take his own way.  Dey’s two angels hoverin’
+roun’ ‘bout him.  One uv ‘em is white en shiny, en t’other one is black.
+De white one gits him to go right a little while, den de black one sail
+in en bust it all up.  A body can’t tell yit which one gwyne to fetch
+him at de las’.  But you is all right.  You gwyne to have considable
+trouble in yo’ life, en considable joy.  Sometimes you gwyne to git
+hurt, en sometimes you gwyne to git sick; but every time you’s gwyne
+to git well agin.  Dey’s two gals flyin’ ‘bout you in yo’ life.  One
+uv ‘em’s light en t’other one is dark. One is rich en t’other is po’.
+ You’s gwyne to marry de po’ one fust en de rich one by en by.  You
+wants to keep ‘way fum de water as much as you kin, en don’t run no
+resk, ‘kase it’s down in de bills dat you’s gwyne to git hung.”
+
+When I lit my candle and went up to my room that night there sat pap his
+own self!
+
+
+
+
+CHAPTER V.
+
+I had shut the door to.  Then I turned around and there he was.  I used
+to be scared of him all the time, he tanned me so much.  I reckoned I
+was scared now, too; but in a minute I see I was mistaken--that is, after
+the first jolt, as you may say, when my breath sort of hitched, he being
+so unexpected; but right away after I see I warn’t scared of him worth
+bothring about.
+
+He was most fifty, and he looked it.  His hair was long and tangled and
+greasy, and hung down, and you could see his eyes shining through
+like he was behind vines.  It was all black, no gray; so was his long,
+mixed-up whiskers.  There warn’t no color in his face, where his face
+showed; it was white; not like another man’s white, but a white to make
+a body sick, a white to make a body’s flesh crawl--a tree-toad white, a
+fish-belly white.  As for his clothes--just rags, that was all.  He had
+one ankle resting on t’other knee; the boot on that foot was busted, and
+two of his toes stuck through, and he worked them now and then.  His hat
+was laying on the floor--an old black slouch with the top caved in, like
+a lid.
+
+I stood a-looking at him; he set there a-looking at me, with his chair
+tilted back a little.  I set the candle down.  I noticed the window was
+up; so he had clumb in by the shed.  He kept a-looking me all over.  By
+and by he says:
+
+“Starchy clothes--very.  You think you’re a good deal of a big-bug,
+_don’t_ you?”
+
+“Maybe I am, maybe I ain’t,” I says.
+
+“Don’t you give me none o’ your lip,” says he.  “You’ve put on
+considerable many frills since I been away.  I’ll take you down a peg
+before I get done with you.  You’re educated, too, they say--can read and
+write.  You think you’re better’n your father, now, don’t you, because
+he can’t?  _I’ll_ take it out of you.  Who told you you might meddle
+with such hifalut’n foolishness, hey?--who told you you could?”
+
+“The widow.  She told me.”
+
+“The widow, hey?--and who told the widow she could put in her shovel
+about a thing that ain’t none of her business?”
+
+“Nobody never told her.”
+
+“Well, I’ll learn her how to meddle.  And looky here--you drop that
+school, you hear?  I’ll learn people to bring up a boy to put on airs
+over his own father and let on to be better’n what _he_ is.  You lemme
+catch you fooling around that school again, you hear?  Your mother
+couldn’t read, and she couldn’t write, nuther, before she died.  None
+of the family couldn’t before _they_ died.  I can’t; and here you’re
+a-swelling yourself up like this.  I ain’t the man to stand it--you hear?
+Say, lemme hear you read.”
+
+I took up a book and begun something about General Washington and the
+wars. When I’d read about a half a minute, he fetched the book a whack
+with his hand and knocked it across the house.  He says:
+
+“It’s so.  You can do it.  I had my doubts when you told me.  Now looky
+here; you stop that putting on frills.  I won’t have it.  I’ll lay for
+you, my smarty; and if I catch you about that school I’ll tan you good.
+First you know you’ll get religion, too.  I never see such a son.”
+
+He took up a little blue and yaller picture of some cows and a boy, and
+says:
+
+“What’s this?”
+
+“It’s something they give me for learning my lessons good.”
+
+He tore it up, and says:
+
+“I’ll give you something better--I’ll give you a cowhide.”
+
+He set there a-mumbling and a-growling a minute, and then he says:
+
+“_Ain’t_ you a sweet-scented dandy, though?  A bed; and bedclothes; and
+a look’n’-glass; and a piece of carpet on the floor--and your own father
+got to sleep with the hogs in the tanyard.  I never see such a son.  I
+bet I’ll take some o’ these frills out o’ you before I’m done with you.
+Why, there ain’t no end to your airs--they say you’re rich.  Hey?--how’s
+that?”
+
+“They lie--that’s how.”
+
+“Looky here--mind how you talk to me; I’m a-standing about all I can
+stand now--so don’t gimme no sass.  I’ve been in town two days, and I
+hain’t heard nothing but about you bein’ rich.  I heard about it
+away down the river, too.  That’s why I come.  You git me that money
+to-morrow--I want it.”
+
+“I hain’t got no money.”
+
+“It’s a lie.  Judge Thatcher’s got it.  You git it.  I want it.”
+
+“I hain’t got no money, I tell you.  You ask Judge Thatcher; he’ll tell
+you the same.”
+
+“All right.  I’ll ask him; and I’ll make him pungle, too, or I’ll know
+the reason why.  Say, how much you got in your pocket?  I want it.”
+
+“I hain’t got only a dollar, and I want that to--”
+
+“It don’t make no difference what you want it for--you just shell it
+out.”
+
+He took it and bit it to see if it was good, and then he said he was
+going down town to get some whisky; said he hadn’t had a drink all day.
+When he had got out on the shed he put his head in again, and cussed
+me for putting on frills and trying to be better than him; and when I
+reckoned he was gone he come back and put his head in again, and told me
+to mind about that school, because he was going to lay for me and lick
+me if I didn’t drop that.
+
+Next day he was drunk, and he went to Judge Thatcher’s and bullyragged
+him, and tried to make him give up the money; but he couldn’t, and then
+he swore he’d make the law force him.
+
+The judge and the widow went to law to get the court to take me away
+from him and let one of them be my guardian; but it was a new judge that
+had just come, and he didn’t know the old man; so he said courts mustn’t
+interfere and separate families if they could help it; said he’d druther
+not take a child away from its father.  So Judge Thatcher and the widow
+had to quit on the business.
+
+That pleased the old man till he couldn’t rest.  He said he’d cowhide
+me till I was black and blue if I didn’t raise some money for him.  I
+borrowed three dollars from Judge Thatcher, and pap took it and got
+drunk, and went a-blowing around and cussing and whooping and carrying
+on; and he kept it up all over town, with a tin pan, till most midnight;
+then they jailed him, and next day they had him before court, and jailed
+him again for a week.  But he said _he_ was satisfied; said he was boss
+of his son, and he’d make it warm for _him_.
+
+When he got out the new judge said he was a-going to make a man of him.
+So he took him to his own house, and dressed him up clean and nice, and
+had him to breakfast and dinner and supper with the family, and was just
+old pie to him, so to speak.  And after supper he talked to him about
+temperance and such things till the old man cried, and said he’d been
+a fool, and fooled away his life; but now he was a-going to turn over
+a new leaf and be a man nobody wouldn’t be ashamed of, and he hoped the
+judge would help him and not look down on him.  The judge said he could
+hug him for them words; so he cried, and his wife she cried again; pap
+said he’d been a man that had always been misunderstood before, and the
+judge said he believed it.  The old man said that what a man wanted
+that was down was sympathy, and the judge said it was so; so they cried
+again.  And when it was bedtime the old man rose up and held out his
+hand, and says:
+
+“Look at it, gentlemen and ladies all; take a-hold of it; shake it.
+There’s a hand that was the hand of a hog; but it ain’t so no more; it’s
+the hand of a man that’s started in on a new life, and’ll die before
+he’ll go back.  You mark them words--don’t forget I said them.  It’s a
+clean hand now; shake it--don’t be afeard.”
+
+So they shook it, one after the other, all around, and cried.  The
+judge’s wife she kissed it.  Then the old man he signed a pledge--made
+his mark. The judge said it was the holiest time on record, or something
+like that. Then they tucked the old man into a beautiful room, which was
+the spare room, and in the night some time he got powerful thirsty and
+clumb out on to the porch-roof and slid down a stanchion and traded his
+new coat for a jug of forty-rod, and clumb back again and had a good old
+time; and towards daylight he crawled out again, drunk as a fiddler, and
+rolled off the porch and broke his left arm in two places, and was most
+froze to death when somebody found him after sun-up.  And when they come
+to look at that spare room they had to take soundings before they could
+navigate it.
+
+The judge he felt kind of sore.  He said he reckoned a body could reform
+the old man with a shotgun, maybe, but he didn’t know no other way.
+
+
+
+
+CHAPTER VI.
+
+WELL, pretty soon the old man was up and around again, and then he went
+for Judge Thatcher in the courts to make him give up that money, and he
+went for me, too, for not stopping school.  He catched me a couple of
+times and thrashed me, but I went to school just the same, and dodged
+him or outrun him most of the time.  I didn’t want to go to school much
+before, but I reckoned I’d go now to spite pap.  That law trial was a
+slow business--appeared like they warn’t ever going to get started on it;
+so every now and then I’d borrow two or three dollars off of the judge
+for him, to keep from getting a cowhiding.  Every time he got money he
+got drunk; and every time he got drunk he raised Cain around town; and
+every time he raised Cain he got jailed.  He was just suited--this kind
+of thing was right in his line.
+
+He got to hanging around the widow’s too much and so she told him at
+last that if he didn’t quit using around there she would make trouble
+for him. Well, _wasn’t_ he mad?  He said he would show who was Huck
+Finn’s boss.  So he watched out for me one day in the spring, and
+catched me, and took me up the river about three mile in a skiff, and
+crossed over to the Illinois shore where it was woody and there warn’t
+no houses but an old log hut in a place where the timber was so thick
+you couldn’t find it if you didn’t know where it was.
+
+He kept me with him all the time, and I never got a chance to run off.
+We lived in that old cabin, and he always locked the door and put the
+key under his head nights.  He had a gun which he had stole, I reckon,
+and we fished and hunted, and that was what we lived on.  Every little
+while he locked me in and went down to the store, three miles, to the
+ferry, and traded fish and game for whisky, and fetched it home and got
+drunk and had a good time, and licked me.  The widow she found out where
+I was by and by, and she sent a man over to try to get hold of me; but
+pap drove him off with the gun, and it warn’t long after that till I was
+used to being where I was, and liked it--all but the cowhide part.
+
+It was kind of lazy and jolly, laying off comfortable all day, smoking
+and fishing, and no books nor study.  Two months or more run along, and
+my clothes got to be all rags and dirt, and I didn’t see how I’d ever
+got to like it so well at the widow’s, where you had to wash, and eat on
+a plate, and comb up, and go to bed and get up regular, and be forever
+bothering over a book, and have old Miss Watson pecking at you all the
+time.  I didn’t want to go back no more.  I had stopped cussing, because
+the widow didn’t like it; but now I took to it again because pap hadn’t
+no objections.  It was pretty good times up in the woods there, take it
+all around.
+
+But by and by pap got too handy with his hick’ry, and I couldn’t stand
+it. I was all over welts.  He got to going away so much, too, and
+locking me in.  Once he locked me in and was gone three days.  It was
+dreadful lonesome.  I judged he had got drownded, and I wasn’t ever
+going to get out any more.  I was scared.  I made up my mind I would fix
+up some way to leave there.  I had tried to get out of that cabin many
+a time, but I couldn’t find no way.  There warn’t a window to it big
+enough for a dog to get through.  I couldn’t get up the chimbly; it
+was too narrow.  The door was thick, solid oak slabs.  Pap was pretty
+careful not to leave a knife or anything in the cabin when he was away;
+I reckon I had hunted the place over as much as a hundred times; well, I
+was most all the time at it, because it was about the only way to put in
+the time.  But this time I found something at last; I found an old rusty
+wood-saw without any handle; it was laid in between a rafter and the
+clapboards of the roof. I greased it up and went to work.  There was an
+old horse-blanket nailed against the logs at the far end of the cabin
+behind the table, to keep the wind from blowing through the chinks and
+putting the candle out.  I got under the table and raised the blanket,
+and went to work to saw a section of the big bottom log out--big enough
+to let me through.  Well, it was a good long job, but I was getting
+towards the end of it when I heard pap’s gun in the woods.  I got rid of
+the signs of my work, and dropped the blanket and hid my saw, and pretty
+soon pap come in.
+
+Pap warn’t in a good humor--so he was his natural self.  He said he was
+down town, and everything was going wrong.  His lawyer said he reckoned
+he would win his lawsuit and get the money if they ever got started on
+the trial; but then there was ways to put it off a long time, and Judge
+Thatcher knowed how to do it. And he said people allowed there’d be
+another trial to get me away from him and give me to the widow for my
+guardian, and they guessed it would win this time.  This shook me up
+considerable, because I didn’t want to go back to the widow’s any more
+and be so cramped up and sivilized, as they called it.  Then the old man
+got to cussing, and cussed everything and everybody he could think of,
+and then cussed them all over again to make sure he hadn’t skipped any,
+and after that he polished off with a kind of a general cuss all round,
+including a considerable parcel of people which he didn’t know the names
+of, and so called them what’s-his-name when he got to them, and went
+right along with his cussing.
+
+He said he would like to see the widow get me.  He said he would watch
+out, and if they tried to come any such game on him he knowed of a place
+six or seven mile off to stow me in, where they might hunt till they
+dropped and they couldn’t find me.  That made me pretty uneasy again,
+but only for a minute; I reckoned I wouldn’t stay on hand till he got
+that chance.
+
+The old man made me go to the skiff and fetch the things he had
+got. There was a fifty-pound sack of corn meal, and a side of bacon,
+ammunition, and a four-gallon jug of whisky, and an old book and two
+newspapers for wadding, besides some tow.  I toted up a load, and went
+back and set down on the bow of the skiff to rest.  I thought it all
+over, and I reckoned I would walk off with the gun and some lines, and
+take to the woods when I run away.  I guessed I wouldn’t stay in one
+place, but just tramp right across the country, mostly night times, and
+hunt and fish to keep alive, and so get so far away that the old man nor
+the widow couldn’t ever find me any more.  I judged I would saw out and
+leave that night if pap got drunk enough, and I reckoned he would.  I
+got so full of it I didn’t notice how long I was staying till the old
+man hollered and asked me whether I was asleep or drownded.
+
+I got the things all up to the cabin, and then it was about dark.  While
+I was cooking supper the old man took a swig or two and got sort of
+warmed up, and went to ripping again.  He had been drunk over in town,
+and laid in the gutter all night, and he was a sight to look at.  A body
+would a thought he was Adam--he was just all mud.  Whenever his liquor
+begun to work he most always went for the govment, this time he says:
+
+“Call this a govment! why, just look at it and see what it’s like.
+Here’s the law a-standing ready to take a man’s son away from him--a
+man’s own son, which he has had all the trouble and all the anxiety
+and all the expense of raising.  Yes, just as that man has got that
+son raised at last, and ready to go to work and begin to do suthin’ for
+_him_ and give him a rest, the law up and goes for him.  And they call
+_that_ govment!  That ain’t all, nuther.  The law backs that old Judge
+Thatcher up and helps him to keep me out o’ my property.  Here’s what
+the law does:  The law takes a man worth six thousand dollars and
+up’ards, and jams him into an old trap of a cabin like this, and lets
+him go round in clothes that ain’t fitten for a hog. They call that
+govment!  A man can’t get his rights in a govment like this. Sometimes
+I’ve a mighty notion to just leave the country for good and all. Yes,
+and I _told_ ‘em so; I told old Thatcher so to his face.  Lots of ‘em
+heard me, and can tell what I said.  Says I, for two cents I’d leave the
+blamed country and never come a-near it agin.  Them’s the very words.  I
+says look at my hat--if you call it a hat--but the lid raises up and the
+rest of it goes down till it’s below my chin, and then it ain’t rightly
+a hat at all, but more like my head was shoved up through a jint o’
+stove-pipe.  Look at it, says I--such a hat for me to wear--one of the
+wealthiest men in this town if I could git my rights.
+
+“Oh, yes, this is a wonderful govment, wonderful.  Why, looky here.
+There was a free nigger there from Ohio--a mulatter, most as white as
+a white man.  He had the whitest shirt on you ever see, too, and the
+shiniest hat; and there ain’t a man in that town that’s got as fine
+clothes as what he had; and he had a gold watch and chain, and a
+silver-headed cane--the awfulest old gray-headed nabob in the State.  And
+what do you think?  They said he was a p’fessor in a college, and could
+talk all kinds of languages, and knowed everything.  And that ain’t the
+wust. They said he could _vote_ when he was at home.  Well, that let me
+out. Thinks I, what is the country a-coming to?  It was ‘lection day,
+and I was just about to go and vote myself if I warn’t too drunk to get
+there; but when they told me there was a State in this country where
+they’d let that nigger vote, I drawed out.  I says I’ll never vote agin.
+ Them’s the very words I said; they all heard me; and the country may
+rot for all me--I’ll never vote agin as long as I live.  And to see the
+cool way of that nigger--why, he wouldn’t a give me the road if I hadn’t
+shoved him out o’ the way.  I says to the people, why ain’t this nigger
+put up at auction and sold?--that’s what I want to know.  And what do you
+reckon they said? Why, they said he couldn’t be sold till he’d been in
+the State six months, and he hadn’t been there that long yet.  There,
+now--that’s a specimen.  They call that a govment that can’t sell a free
+nigger till he’s been in the State six months.  Here’s a govment that
+calls itself a govment, and lets on to be a govment, and thinks it is a
+govment, and yet’s got to set stock-still for six whole months before
+it can take a hold of a prowling, thieving, infernal, white-shirted free
+nigger, and--”
+
+Pap was agoing on so he never noticed where his old limber legs was
+taking him to, so he went head over heels over the tub of salt pork and
+barked both shins, and the rest of his speech was all the hottest kind
+of language--mostly hove at the nigger and the govment, though he give
+the tub some, too, all along, here and there.  He hopped around the
+cabin considerable, first on one leg and then on the other, holding
+first one shin and then the other one, and at last he let out with his
+left foot all of a sudden and fetched the tub a rattling kick.  But it
+warn’t good judgment, because that was the boot that had a couple of his
+toes leaking out of the front end of it; so now he raised a howl that
+fairly made a body’s hair raise, and down he went in the dirt, and
+rolled there, and held his toes; and the cussing he done then laid over
+anything he had ever done previous.  He said so his own self afterwards.
+ He had heard old Sowberry Hagan in his best days, and he said it laid
+over him, too; but I reckon that was sort of piling it on, maybe.
+
+After supper pap took the jug, and said he had enough whisky there
+for two drunks and one delirium tremens.  That was always his word.  I
+judged he would be blind drunk in about an hour, and then I would steal
+the key, or saw myself out, one or t’other.  He drank and drank, and
+tumbled down on his blankets by and by; but luck didn’t run my way.
+ He didn’t go sound asleep, but was uneasy.  He groaned and moaned and
+thrashed around this way and that for a long time.  At last I got so
+sleepy I couldn’t keep my eyes open all I could do, and so before I
+knowed what I was about I was sound asleep, and the candle burning.
+
+I don’t know how long I was asleep, but all of a sudden there was an
+awful scream and I was up.  There was pap looking wild, and skipping
+around every which way and yelling about snakes.  He said they was
+crawling up his legs; and then he would give a jump and scream, and say
+one had bit him on the cheek--but I couldn’t see no snakes.  He started
+and run round and round the cabin, hollering “Take him off! take him
+off! he’s biting me on the neck!”  I never see a man look so wild in the
+eyes. Pretty soon he was all fagged out, and fell down panting; then he
+rolled over and over wonderful fast, kicking things every which way,
+and striking and grabbing at the air with his hands, and screaming and
+saying there was devils a-hold of him.  He wore out by and by, and laid
+still a while, moaning.  Then he laid stiller, and didn’t make a sound.
+ I could hear the owls and the wolves away off in the woods, and it
+seemed terrible still.  He was laying over by the corner. By and by he
+raised up part way and listened, with his head to one side.  He says,
+very low:
+
+“Tramp--tramp--tramp; that’s the dead; tramp--tramp--tramp; they’re coming
+after me; but I won’t go.  Oh, they’re here! don’t touch me--don’t! hands
+off--they’re cold; let go.  Oh, let a poor devil alone!”
+
+Then he went down on all fours and crawled off, begging them to let him
+alone, and he rolled himself up in his blanket and wallowed in under the
+old pine table, still a-begging; and then he went to crying.  I could
+hear him through the blanket.
+
+By and by he rolled out and jumped up on his feet looking wild, and he
+see me and went for me.  He chased me round and round the place with a
+clasp-knife, calling me the Angel of Death, and saying he would kill me,
+and then I couldn’t come for him no more.  I begged, and told him I
+was only Huck; but he laughed _such_ a screechy laugh, and roared and
+cussed, and kept on chasing me up.  Once when I turned short and
+dodged under his arm he made a grab and got me by the jacket between my
+shoulders, and I thought I was gone; but I slid out of the jacket quick
+as lightning, and saved myself. Pretty soon he was all tired out, and
+dropped down with his back against the door, and said he would rest a
+minute and then kill me. He put his knife under him, and said he would
+sleep and get strong, and then he would see who was who.
+
+So he dozed off pretty soon.  By and by I got the old split-bottom chair
+and clumb up as easy as I could, not to make any noise, and got down the
+gun.  I slipped the ramrod down it to make sure it was loaded, then I
+laid it across the turnip barrel, pointing towards pap, and set down
+behind it to wait for him to stir.  And how slow and still the time did
+drag along.
+
+
+
+
+CHAPTER VII.
+
+“GIT up!  What you ‘bout?”
+
+I opened my eyes and looked around, trying to make out where I was.  It
+was after sun-up, and I had been sound asleep.  Pap was standing over me
+looking sour and sick, too.  He says:
+
+“What you doin’ with this gun?”
+
+I judged he didn’t know nothing about what he had been doing, so I says:
+
+“Somebody tried to get in, so I was laying for him.”
+
+“Why didn’t you roust me out?”
+
+“Well, I tried to, but I couldn’t; I couldn’t budge you.”
+
+“Well, all right.  Don’t stand there palavering all day, but out with
+you and see if there’s a fish on the lines for breakfast.  I’ll be along
+in a minute.”
+
+He unlocked the door, and I cleared out up the river-bank.  I noticed
+some pieces of limbs and such things floating down, and a sprinkling of
+bark; so I knowed the river had begun to rise.  I reckoned I would have
+great times now if I was over at the town.  The June rise used to be
+always luck for me; because as soon as that rise begins here comes
+cordwood floating down, and pieces of log rafts--sometimes a dozen logs
+together; so all you have to do is to catch them and sell them to the
+wood-yards and the sawmill.
+
+I went along up the bank with one eye out for pap and t’other one out
+for what the rise might fetch along.  Well, all at once here comes a
+canoe; just a beauty, too, about thirteen or fourteen foot long, riding
+high like a duck.  I shot head-first off of the bank like a frog,
+clothes and all on, and struck out for the canoe.  I just expected
+there’d be somebody laying down in it, because people often done that
+to fool folks, and when a chap had pulled a skiff out most to it they’d
+raise up and laugh at him.  But it warn’t so this time.  It was a
+drift-canoe sure enough, and I clumb in and paddled her ashore.  Thinks
+I, the old man will be glad when he sees this--she’s worth ten dollars.
+ But when I got to shore pap wasn’t in sight yet, and as I was running
+her into a little creek like a gully, all hung over with vines and
+willows, I struck another idea:  I judged I’d hide her good, and then,
+‘stead of taking to the woods when I run off, I’d go down the river
+about fifty mile and camp in one place for good, and not have such a
+rough time tramping on foot.
+
+It was pretty close to the shanty, and I thought I heard the old man
+coming all the time; but I got her hid; and then I out and looked around
+a bunch of willows, and there was the old man down the path a piece just
+drawing a bead on a bird with his gun.  So he hadn’t seen anything.
+
+When he got along I was hard at it taking up a “trot” line.  He abused
+me a little for being so slow; but I told him I fell in the river, and
+that was what made me so long.  I knowed he would see I was wet, and
+then he would be asking questions.  We got five catfish off the lines
+and went home.
+
+While we laid off after breakfast to sleep up, both of us being about
+wore out, I got to thinking that if I could fix up some way to keep pap
+and the widow from trying to follow me, it would be a certainer thing
+than trusting to luck to get far enough off before they missed me; you
+see, all kinds of things might happen.  Well, I didn’t see no way for a
+while, but by and by pap raised up a minute to drink another barrel of
+water, and he says:
+
+“Another time a man comes a-prowling round here you roust me out, you
+hear? That man warn’t here for no good.  I’d a shot him.  Next time you
+roust me out, you hear?”
+
+Then he dropped down and went to sleep again; but what he had been
+saying give me the very idea I wanted.  I says to myself, I can fix it
+now so nobody won’t think of following me.
+
+About twelve o’clock we turned out and went along up the bank.  The
+river was coming up pretty fast, and lots of driftwood going by on the
+rise. By and by along comes part of a log raft--nine logs fast together.
+ We went out with the skiff and towed it ashore.  Then we had dinner.
+Anybody but pap would a waited and seen the day through, so as to catch
+more stuff; but that warn’t pap’s style.  Nine logs was enough for one
+time; he must shove right over to town and sell.  So he locked me in and
+took the skiff, and started off towing the raft about half-past three.
+ I judged he wouldn’t come back that night.  I waited till I reckoned he
+had got a good start; then I out with my saw, and went to work on that
+log again.  Before he was t’other side of the river I was out of the
+hole; him and his raft was just a speck on the water away off yonder.
+
+I took the sack of corn meal and took it to where the canoe was hid, and
+shoved the vines and branches apart and put it in; then I done the same
+with the side of bacon; then the whisky-jug.  I took all the coffee and
+sugar there was, and all the ammunition; I took the wadding; I took the
+bucket and gourd; I took a dipper and a tin cup, and my old saw and two
+blankets, and the skillet and the coffee-pot.  I took fish-lines and
+matches and other things--everything that was worth a cent.  I cleaned
+out the place.  I wanted an axe, but there wasn’t any, only the one out
+at the woodpile, and I knowed why I was going to leave that.  I fetched
+out the gun, and now I was done.
+
+I had wore the ground a good deal crawling out of the hole and dragging
+out so many things.  So I fixed that as good as I could from the outside
+by scattering dust on the place, which covered up the smoothness and the
+sawdust.  Then I fixed the piece of log back into its place, and put two
+rocks under it and one against it to hold it there, for it was bent up
+at that place and didn’t quite touch ground.  If you stood four or five
+foot away and didn’t know it was sawed, you wouldn’t never notice
+it; and besides, this was the back of the cabin, and it warn’t likely
+anybody would go fooling around there.
+
+It was all grass clear to the canoe, so I hadn’t left a track.  I
+followed around to see.  I stood on the bank and looked out over the
+river.  All safe.  So I took the gun and went up a piece into the woods,
+and was hunting around for some birds when I see a wild pig; hogs soon
+went wild in them bottoms after they had got away from the prairie
+farms. I shot this fellow and took him into camp.
+
+I took the axe and smashed in the door.  I beat it and hacked it
+considerable a-doing it.  I fetched the pig in, and took him back nearly
+to the table and hacked into his throat with the axe, and laid him down
+on the ground to bleed; I say ground because it was ground--hard packed,
+and no boards.  Well, next I took an old sack and put a lot of big rocks
+in it--all I could drag--and I started it from the pig, and dragged it to
+the door and through the woods down to the river and dumped it in, and
+down it sunk, out of sight.  You could easy see that something had been
+dragged over the ground.  I did wish Tom Sawyer was there; I knowed he
+would take an interest in this kind of business, and throw in the fancy
+touches.  Nobody could spread himself like Tom Sawyer in such a thing as
+that.
+
+Well, last I pulled out some of my hair, and blooded the axe good, and
+stuck it on the back side, and slung the axe in the corner.  Then I
+took up the pig and held him to my breast with my jacket (so he couldn’t
+drip) till I got a good piece below the house and then dumped him into
+the river.  Now I thought of something else.  So I went and got the bag
+of meal and my old saw out of the canoe, and fetched them to the house.
+ I took the bag to where it used to stand, and ripped a hole in the
+bottom of it with the saw, for there warn’t no knives and forks on the
+place--pap done everything with his clasp-knife about the cooking.  Then
+I carried the sack about a hundred yards across the grass and through
+the willows east of the house, to a shallow lake that was five mile wide
+and full of rushes--and ducks too, you might say, in the season.  There
+was a slough or a creek leading out of it on the other side that went
+miles away, I don’t know where, but it didn’t go to the river.  The meal
+sifted out and made a little track all the way to the lake.  I dropped
+pap’s whetstone there too, so as to look like it had been done by
+accident. Then I tied up the rip in the meal sack with a string, so it
+wouldn’t leak no more, and took it and my saw to the canoe again.
+
+It was about dark now; so I dropped the canoe down the river under some
+willows that hung over the bank, and waited for the moon to rise.  I
+made fast to a willow; then I took a bite to eat, and by and by laid
+down in the canoe to smoke a pipe and lay out a plan.  I says to myself,
+they’ll follow the track of that sackful of rocks to the shore and then
+drag the river for me.  And they’ll follow that meal track to the lake
+and go browsing down the creek that leads out of it to find the robbers
+that killed me and took the things.  They won’t ever hunt the river for
+anything but my dead carcass. They’ll soon get tired of that, and won’t
+bother no more about me.  All right; I can stop anywhere I want to.
+Jackson’s Island is good enough for me; I know that island pretty well,
+and nobody ever comes there.  And then I can paddle over to town nights,
+and slink around and pick up things I want. Jackson’s Island’s the
+place.
+
+I was pretty tired, and the first thing I knowed I was asleep.  When
+I woke up I didn’t know where I was for a minute.  I set up and looked
+around, a little scared.  Then I remembered.  The river looked miles and
+miles across.  The moon was so bright I could a counted the drift logs
+that went a-slipping along, black and still, hundreds of yards out from
+shore. Everything was dead quiet, and it looked late, and _smelt_ late.
+You know what I mean--I don’t know the words to put it in.
+
+I took a good gap and a stretch, and was just going to unhitch and start
+when I heard a sound away over the water.  I listened.  Pretty soon I
+made it out.  It was that dull kind of a regular sound that comes from
+oars working in rowlocks when it’s a still night.  I peeped out through
+the willow branches, and there it was--a skiff, away across the water.
+ I couldn’t tell how many was in it.  It kept a-coming, and when it was
+abreast of me I see there warn’t but one man in it.  Think’s I, maybe
+it’s pap, though I warn’t expecting him.  He dropped below me with the
+current, and by and by he came a-swinging up shore in the easy water,
+and he went by so close I could a reached out the gun and touched him.
+ Well, it _was_ pap, sure enough--and sober, too, by the way he laid his
+oars.
+
+I didn’t lose no time.  The next minute I was a-spinning down stream
+soft but quick in the shade of the bank.  I made two mile and a half,
+and then struck out a quarter of a mile or more towards the middle of
+the river, because pretty soon I would be passing the ferry landing, and
+people might see me and hail me.  I got out amongst the driftwood, and
+then laid down in the bottom of the canoe and let her float.
+
+ I laid there, and had a good rest and a smoke out of my pipe, looking
+away into the sky; not a cloud in it.  The sky looks ever so deep when
+you lay down on your back in the moonshine; I never knowed it before.
+ And how far a body can hear on the water such nights!  I heard people
+talking at the ferry landing. I heard what they said, too--every word
+of it.  One man said it was getting towards the long days and the short
+nights now.  T’other one said _this_ warn’t one of the short ones, he
+reckoned--and then they laughed, and he said it over again, and they
+laughed again; then they waked up another fellow and told him, and
+laughed, but he didn’t laugh; he ripped out something brisk, and said
+let him alone.  The first fellow said he ‘lowed to tell it to his
+old woman--she would think it was pretty good; but he said that warn’t
+nothing to some things he had said in his time. I heard one man say it
+was nearly three o’clock, and he hoped daylight wouldn’t wait more than
+about a week longer.  After that the talk got further and further away,
+and I couldn’t make out the words any more; but I could hear the mumble,
+and now and then a laugh, too, but it seemed a long ways off.
+
+I was away below the ferry now.  I rose up, and there was Jackson’s
+Island, about two mile and a half down stream, heavy timbered and
+standing up out of the middle of the river, big and dark and solid, like
+a steamboat without any lights.  There warn’t any signs of the bar at
+the head--it was all under water now.
+
+It didn’t take me long to get there.  I shot past the head at a ripping
+rate, the current was so swift, and then I got into the dead water and
+landed on the side towards the Illinois shore.  I run the canoe into
+a deep dent in the bank that I knowed about; I had to part the willow
+branches to get in; and when I made fast nobody could a seen the canoe
+from the outside.
+
+I went up and set down on a log at the head of the island, and looked
+out on the big river and the black driftwood and away over to the town,
+three mile away, where there was three or four lights twinkling.  A
+monstrous big lumber-raft was about a mile up stream, coming along down,
+with a lantern in the middle of it.  I watched it come creeping down,
+and when it was most abreast of where I stood I heard a man say, “Stern
+oars, there! heave her head to stabboard!”  I heard that just as plain
+as if the man was by my side.
+
+There was a little gray in the sky now; so I stepped into the woods, and
+laid down for a nap before breakfast.
+
+
+
+
+CHAPTER VIII.
+
+THE sun was up so high when I waked that I judged it was after eight
+o’clock.  I laid there in the grass and the cool shade thinking about
+things, and feeling rested and ruther comfortable and satisfied.  I
+could see the sun out at one or two holes, but mostly it was big trees
+all about, and gloomy in there amongst them.  There was freckled places
+on the ground where the light sifted down through the leaves, and the
+freckled places swapped about a little, showing there was a little
+breeze up there.  A couple of squirrels set on a limb and jabbered at me
+very friendly.
+
+I was powerful lazy and comfortable--didn’t want to get up and cook
+breakfast.  Well, I was dozing off again when I thinks I hears a deep
+sound of “boom!” away up the river.  I rouses up, and rests on my elbow
+and listens; pretty soon I hears it again.  I hopped up, and went and
+looked out at a hole in the leaves, and I see a bunch of smoke laying
+on the water a long ways up--about abreast the ferry.  And there was the
+ferryboat full of people floating along down.  I knowed what was the
+matter now.  “Boom!” I see the white smoke squirt out of the ferryboat’s
+side.  You see, they was firing cannon over the water, trying to make my
+carcass come to the top.
+
+I was pretty hungry, but it warn’t going to do for me to start a fire,
+because they might see the smoke.  So I set there and watched the
+cannon-smoke and listened to the boom.  The river was a mile wide there,
+and it always looks pretty on a summer morning--so I was having a good
+enough time seeing them hunt for my remainders if I only had a bite to
+eat. Well, then I happened to think how they always put quicksilver in
+loaves of bread and float them off, because they always go right to the
+drownded carcass and stop there.  So, says I, I’ll keep a lookout, and
+if any of them’s floating around after me I’ll give them a show.  I
+changed to the Illinois edge of the island to see what luck I could
+have, and I warn’t disappointed.  A big double loaf come along, and I
+most got it with a long stick, but my foot slipped and she floated out
+further.  Of course I was where the current set in the closest to the
+shore--I knowed enough for that.  But by and by along comes another one,
+and this time I won.  I took out the plug and shook out the little dab
+of quicksilver, and set my teeth in.  It was “baker’s bread”--what the
+quality eat; none of your low-down corn-pone.
+
+I got a good place amongst the leaves, and set there on a log, munching
+the bread and watching the ferry-boat, and very well satisfied.  And
+then something struck me.  I says, now I reckon the widow or the parson
+or somebody prayed that this bread would find me, and here it has gone
+and done it.  So there ain’t no doubt but there is something in that
+thing--that is, there’s something in it when a body like the widow or the
+parson prays, but it don’t work for me, and I reckon it don’t work for
+only just the right kind.
+
+I lit a pipe and had a good long smoke, and went on watching.  The
+ferryboat was floating with the current, and I allowed I’d have a chance
+to see who was aboard when she come along, because she would come in
+close, where the bread did.  When she’d got pretty well along down
+towards me, I put out my pipe and went to where I fished out the bread,
+and laid down behind a log on the bank in a little open place.  Where
+the log forked I could peep through.
+
+By and by she come along, and she drifted in so close that they could
+a run out a plank and walked ashore.  Most everybody was on the boat.
+ Pap, and Judge Thatcher, and Bessie Thatcher, and Jo Harper, and Tom
+Sawyer, and his old Aunt Polly, and Sid and Mary, and plenty more.
+ Everybody was talking about the murder, but the captain broke in and
+says:
+
+“Look sharp, now; the current sets in the closest here, and maybe he’s
+washed ashore and got tangled amongst the brush at the water’s edge.  I
+hope so, anyway.”
+
+I didn’t hope so.  They all crowded up and leaned over the rails, nearly
+in my face, and kept still, watching with all their might.  I could see
+them first-rate, but they couldn’t see me.  Then the captain sung out:
+
+“Stand away!” and the cannon let off such a blast right before me that
+it made me deef with the noise and pretty near blind with the smoke, and
+I judged I was gone.  If they’d a had some bullets in, I reckon they’d
+a got the corpse they was after.  Well, I see I warn’t hurt, thanks to
+goodness. The boat floated on and went out of sight around the shoulder
+of the island.  I could hear the booming now and then, further and
+further off, and by and by, after an hour, I didn’t hear it no more.
+ The island was three mile long.  I judged they had got to the foot, and
+was giving it up.  But they didn’t yet a while.  They turned around
+the foot of the island and started up the channel on the Missouri side,
+under steam, and booming once in a while as they went.  I crossed over
+to that side and watched them. When they got abreast the head of the
+island they quit shooting and dropped over to the Missouri shore and
+went home to the town.
+
+I knowed I was all right now.  Nobody else would come a-hunting after
+me. I got my traps out of the canoe and made me a nice camp in the thick
+woods.  I made a kind of a tent out of my blankets to put my things
+under so the rain couldn’t get at them.  I catched a catfish and haggled
+him open with my saw, and towards sundown I started my camp fire and had
+supper.  Then I set out a line to catch some fish for breakfast.
+
+When it was dark I set by my camp fire smoking, and feeling pretty well
+satisfied; but by and by it got sort of lonesome, and so I went and set
+on the bank and listened to the current swashing along, and counted the
+stars and drift logs and rafts that come down, and then went to bed;
+there ain’t no better way to put in time when you are lonesome; you
+can’t stay so, you soon get over it.
+
+And so for three days and nights.  No difference--just the same thing.
+But the next day I went exploring around down through the island.  I was
+boss of it; it all belonged to me, so to say, and I wanted to know
+all about it; but mainly I wanted to put in the time.  I found plenty
+strawberries, ripe and prime; and green summer grapes, and green
+razberries; and the green blackberries was just beginning to show.  They
+would all come handy by and by, I judged.
+
+Well, I went fooling along in the deep woods till I judged I warn’t
+far from the foot of the island.  I had my gun along, but I hadn’t shot
+nothing; it was for protection; thought I would kill some game nigh
+home. About this time I mighty near stepped on a good-sized snake,
+and it went sliding off through the grass and flowers, and I after
+it, trying to get a shot at it. I clipped along, and all of a sudden I
+bounded right on to the ashes of a camp fire that was still smoking.
+
+My heart jumped up amongst my lungs.  I never waited for to look
+further, but uncocked my gun and went sneaking back on my tiptoes as
+fast as ever I could.  Every now and then I stopped a second amongst the
+thick leaves and listened, but my breath come so hard I couldn’t hear
+nothing else.  I slunk along another piece further, then listened again;
+and so on, and so on.  If I see a stump, I took it for a man; if I trod
+on a stick and broke it, it made me feel like a person had cut one of my
+breaths in two and I only got half, and the short half, too.
+
+When I got to camp I warn’t feeling very brash, there warn’t much sand
+in my craw; but I says, this ain’t no time to be fooling around.  So I
+got all my traps into my canoe again so as to have them out of sight,
+and I put out the fire and scattered the ashes around to look like an
+old last year’s camp, and then clumb a tree.
+
+I reckon I was up in the tree two hours; but I didn’t see nothing,
+I didn’t hear nothing--I only _thought_ I heard and seen as much as a
+thousand things.  Well, I couldn’t stay up there forever; so at last I
+got down, but I kept in the thick woods and on the lookout all the
+time. All I could get to eat was berries and what was left over from
+breakfast.
+
+By the time it was night I was pretty hungry.  So when it was good
+and dark I slid out from shore before moonrise and paddled over to the
+Illinois bank--about a quarter of a mile.  I went out in the woods and
+cooked a supper, and I had about made up my mind I would stay there
+all night when I hear a _plunkety-plunk, plunkety-plunk_, and says
+to myself, horses coming; and next I hear people’s voices.  I got
+everything into the canoe as quick as I could, and then went creeping
+through the woods to see what I could find out.  I hadn’t got far when I
+hear a man say:
+
+“We better camp here if we can find a good place; the horses is about
+beat out.  Let’s look around.”
+
+I didn’t wait, but shoved out and paddled away easy.  I tied up in the
+old place, and reckoned I would sleep in the canoe.
+
+I didn’t sleep much.  I couldn’t, somehow, for thinking.  And every time
+I waked up I thought somebody had me by the neck.  So the sleep didn’t
+do me no good.  By and by I says to myself, I can’t live this way; I’m
+a-going to find out who it is that’s here on the island with me; I’ll
+find it out or bust.  Well, I felt better right off.
+
+So I took my paddle and slid out from shore just a step or two, and
+then let the canoe drop along down amongst the shadows.  The moon was
+shining, and outside of the shadows it made it most as light as day.
+ I poked along well on to an hour, everything still as rocks and sound
+asleep. Well, by this time I was most down to the foot of the island.  A
+little ripply, cool breeze begun to blow, and that was as good as saying
+the night was about done.  I give her a turn with the paddle and brung
+her nose to shore; then I got my gun and slipped out and into the edge
+of the woods.  I sat down there on a log, and looked out through the
+leaves.  I see the moon go off watch, and the darkness begin to blanket
+the river. But in a little while I see a pale streak over the treetops,
+and knowed the day was coming.  So I took my gun and slipped off towards
+where I had run across that camp fire, stopping every minute or two
+to listen.  But I hadn’t no luck somehow; I couldn’t seem to find the
+place.  But by and by, sure enough, I catched a glimpse of fire away
+through the trees.  I went for it, cautious and slow.  By and by I was
+close enough to have a look, and there laid a man on the ground.  It
+most give me the fan-tods. He had a blanket around his head, and his
+head was nearly in the fire.  I set there behind a clump of bushes, in
+about six foot of him, and kept my eyes on him steady.  It was getting
+gray daylight now.  Pretty soon he gapped and stretched himself and hove
+off the blanket, and it was Miss Watson’s Jim!  I bet I was glad to see
+him.  I says:
+
+“Hello, Jim!” and skipped out.
+
+He bounced up and stared at me wild.  Then he drops down on his knees,
+and puts his hands together and says:
+
+“Doan’ hurt me--don’t!  I hain’t ever done no harm to a ghos’.  I alwuz
+liked dead people, en done all I could for ‘em.  You go en git in de
+river agin, whah you b’longs, en doan’ do nuffn to Ole Jim, ‘at ‘uz
+awluz yo’ fren’.”
+
+Well, I warn’t long making him understand I warn’t dead.  I was ever so
+glad to see Jim.  I warn’t lonesome now.  I told him I warn’t afraid of
+_him_ telling the people where I was.  I talked along, but he only set
+there and looked at me; never said nothing.  Then I says:
+
+“It’s good daylight.  Le’s get breakfast.  Make up your camp fire good.”
+
+“What’s de use er makin’ up de camp fire to cook strawbries en sich
+truck? But you got a gun, hain’t you?  Den we kin git sumfn better den
+strawbries.”
+
+“Strawberries and such truck,” I says.  “Is that what you live on?”
+
+“I couldn’ git nuffn else,” he says.
+
+“Why, how long you been on the island, Jim?”
+
+“I come heah de night arter you’s killed.”
+
+“What, all that time?”
+
+“Yes--indeedy.”
+
+“And ain’t you had nothing but that kind of rubbage to eat?”
+
+“No, sah--nuffn else.”
+
+“Well, you must be most starved, ain’t you?”
+
+“I reck’n I could eat a hoss.  I think I could. How long you ben on de
+islan’?”
+
+“Since the night I got killed.”
+
+“No!  W’y, what has you lived on?  But you got a gun.  Oh, yes, you got
+a gun.  Dat’s good.  Now you kill sumfn en I’ll make up de fire.”
+
+So we went over to where the canoe was, and while he built a fire in
+a grassy open place amongst the trees, I fetched meal and bacon and
+coffee, and coffee-pot and frying-pan, and sugar and tin cups, and the
+nigger was set back considerable, because he reckoned it was all done
+with witchcraft. I catched a good big catfish, too, and Jim cleaned him
+with his knife, and fried him.
+
+When breakfast was ready we lolled on the grass and eat it smoking hot.
+Jim laid it in with all his might, for he was most about starved.  Then
+when we had got pretty well stuffed, we laid off and lazied.  By and by
+Jim says:
+
+“But looky here, Huck, who wuz it dat ‘uz killed in dat shanty ef it
+warn’t you?”
+
+Then I told him the whole thing, and he said it was smart.  He said Tom
+Sawyer couldn’t get up no better plan than what I had.  Then I says:
+
+“How do you come to be here, Jim, and how’d you get here?”
+
+He looked pretty uneasy, and didn’t say nothing for a minute.  Then he
+says:
+
+“Maybe I better not tell.”
+
+“Why, Jim?”
+
+“Well, dey’s reasons.  But you wouldn’ tell on me ef I uz to tell you,
+would you, Huck?”
+
+“Blamed if I would, Jim.”
+
+“Well, I b’lieve you, Huck.  I--_I run off_.”
+
+“Jim!”
+
+“But mind, you said you wouldn’ tell--you know you said you wouldn’ tell,
+Huck.”
+
+“Well, I did.  I said I wouldn’t, and I’ll stick to it.  Honest _injun_,
+I will.  People would call me a low-down Abolitionist and despise me for
+keeping mum--but that don’t make no difference.  I ain’t a-going to tell,
+and I ain’t a-going back there, anyways.  So, now, le’s know all about
+it.”
+
+“Well, you see, it ‘uz dis way.  Ole missus--dat’s Miss Watson--she pecks
+on me all de time, en treats me pooty rough, but she awluz said she
+wouldn’ sell me down to Orleans.  But I noticed dey wuz a nigger trader
+roun’ de place considable lately, en I begin to git oneasy.  Well, one
+night I creeps to de do’ pooty late, en de do’ warn’t quite shet, en I
+hear old missus tell de widder she gwyne to sell me down to Orleans, but
+she didn’ want to, but she could git eight hund’d dollars for me, en it
+‘uz sich a big stack o’ money she couldn’ resis’.  De widder she try to
+git her to say she wouldn’ do it, but I never waited to hear de res’.  I
+lit out mighty quick, I tell you.
+
+“I tuck out en shin down de hill, en ‘spec to steal a skift ‘long de
+sho’ som’ers ‘bove de town, but dey wuz people a-stirring yit, so I hid
+in de ole tumble-down cooper-shop on de bank to wait for everybody to
+go ‘way. Well, I wuz dah all night.  Dey wuz somebody roun’ all de time.
+ ‘Long ‘bout six in de mawnin’ skifts begin to go by, en ‘bout eight er
+nine every skift dat went ‘long wuz talkin’ ‘bout how yo’ pap come over
+to de town en say you’s killed.  Dese las’ skifts wuz full o’ ladies en
+genlmen a-goin’ over for to see de place.  Sometimes dey’d pull up at
+de sho’ en take a res’ b’fo’ dey started acrost, so by de talk I got to
+know all ‘bout de killin’.  I ‘uz powerful sorry you’s killed, Huck, but
+I ain’t no mo’ now.
+
+“I laid dah under de shavin’s all day.  I ‘uz hungry, but I warn’t
+afeard; bekase I knowed ole missus en de widder wuz goin’ to start to
+de camp-meet’n’ right arter breakfas’ en be gone all day, en dey knows
+I goes off wid de cattle ‘bout daylight, so dey wouldn’ ‘spec to see me
+roun’ de place, en so dey wouldn’ miss me tell arter dark in de evenin’.
+De yuther servants wouldn’ miss me, kase dey’d shin out en take holiday
+soon as de ole folks ‘uz out’n de way.
+
+“Well, when it come dark I tuck out up de river road, en went ‘bout two
+mile er more to whah dey warn’t no houses.  I’d made up my mine ‘bout
+what I’s agwyne to do.  You see, ef I kep’ on tryin’ to git away afoot,
+de dogs ‘ud track me; ef I stole a skift to cross over, dey’d miss dat
+skift, you see, en dey’d know ‘bout whah I’d lan’ on de yuther side, en
+whah to pick up my track.  So I says, a raff is what I’s arter; it doan’
+_make_ no track.
+
+“I see a light a-comin’ roun’ de p’int bymeby, so I wade’ in en shove’
+a log ahead o’ me en swum more’n half way acrost de river, en got in
+‘mongst de drift-wood, en kep’ my head down low, en kinder swum agin de
+current tell de raff come along.  Den I swum to de stern uv it en tuck
+a-holt.  It clouded up en ‘uz pooty dark for a little while.  So I clumb
+up en laid down on de planks.  De men ‘uz all ‘way yonder in de middle,
+whah de lantern wuz.  De river wuz a-risin’, en dey wuz a good current;
+so I reck’n’d ‘at by fo’ in de mawnin’ I’d be twenty-five mile down de
+river, en den I’d slip in jis b’fo’ daylight en swim asho’, en take to
+de woods on de Illinois side.
+
+“But I didn’ have no luck.  When we ‘uz mos’ down to de head er de
+islan’ a man begin to come aft wid de lantern, I see it warn’t no use
+fer to wait, so I slid overboard en struck out fer de islan’.  Well, I
+had a notion I could lan’ mos’ anywhers, but I couldn’t--bank too bluff.
+ I ‘uz mos’ to de foot er de islan’ b’fo’ I found’ a good place.  I went
+into de woods en jedged I wouldn’ fool wid raffs no mo’, long as dey
+move de lantern roun’ so.  I had my pipe en a plug er dog-leg, en some
+matches in my cap, en dey warn’t wet, so I ‘uz all right.”
+
+“And so you ain’t had no meat nor bread to eat all this time?  Why
+didn’t you get mud-turkles?”
+
+“How you gwyne to git ‘m?  You can’t slip up on um en grab um; en how’s
+a body gwyne to hit um wid a rock?  How could a body do it in de night?
+ En I warn’t gwyne to show mysef on de bank in de daytime.”
+
+“Well, that’s so.  You’ve had to keep in the woods all the time, of
+course. Did you hear ‘em shooting the cannon?”
+
+“Oh, yes.  I knowed dey was arter you.  I see um go by heah--watched um
+thoo de bushes.”
+
+Some young birds come along, flying a yard or two at a time and
+lighting. Jim said it was a sign it was going to rain.  He said it was
+a sign when young chickens flew that way, and so he reckoned it was the
+same way when young birds done it.  I was going to catch some of them,
+but Jim wouldn’t let me.  He said it was death.  He said his father laid
+mighty sick once, and some of them catched a bird, and his old granny
+said his father would die, and he did.
+
+And Jim said you mustn’t count the things you are going to cook for
+dinner, because that would bring bad luck.  The same if you shook the
+table-cloth after sundown.  And he said if a man owned a beehive
+and that man died, the bees must be told about it before sun-up next
+morning, or else the bees would all weaken down and quit work and die.
+ Jim said bees wouldn’t sting idiots; but I didn’t believe that, because
+I had tried them lots of times myself, and they wouldn’t sting me.
+
+I had heard about some of these things before, but not all of them.  Jim
+knowed all kinds of signs.  He said he knowed most everything.  I said
+it looked to me like all the signs was about bad luck, and so I asked
+him if there warn’t any good-luck signs.  He says:
+
+“Mighty few--an’ _dey_ ain’t no use to a body.  What you want to know
+when good luck’s a-comin’ for?  Want to keep it off?”  And he said:  “Ef
+you’s got hairy arms en a hairy breas’, it’s a sign dat you’s agwyne
+to be rich. Well, dey’s some use in a sign like dat, ‘kase it’s so fur
+ahead. You see, maybe you’s got to be po’ a long time fust, en so you
+might git discourage’ en kill yo’sef ‘f you didn’ know by de sign dat
+you gwyne to be rich bymeby.”
+
+“Have you got hairy arms and a hairy breast, Jim?”
+
+“What’s de use to ax dat question?  Don’t you see I has?”
+
+“Well, are you rich?”
+
+“No, but I ben rich wunst, and gwyne to be rich agin.  Wunst I had
+foteen dollars, but I tuck to specalat’n’, en got busted out.”
+
+“What did you speculate in, Jim?”
+
+“Well, fust I tackled stock.”
+
+“What kind of stock?”
+
+“Why, live stock--cattle, you know.  I put ten dollars in a cow.  But
+I ain’ gwyne to resk no mo’ money in stock.  De cow up ‘n’ died on my
+han’s.”
+
+“So you lost the ten dollars.”
+
+“No, I didn’t lose it all.  I on’y los’ ‘bout nine of it.  I sole de
+hide en taller for a dollar en ten cents.”
+
+“You had five dollars and ten cents left.  Did you speculate any more?”
+
+“Yes.  You know that one-laigged nigger dat b’longs to old Misto
+Bradish? Well, he sot up a bank, en say anybody dat put in a dollar
+would git fo’ dollars mo’ at de en’ er de year.  Well, all de niggers
+went in, but dey didn’t have much.  I wuz de on’y one dat had much.  So
+I stuck out for mo’ dan fo’ dollars, en I said ‘f I didn’ git it I’d
+start a bank mysef. Well, o’ course dat nigger want’ to keep me out er
+de business, bekase he says dey warn’t business ‘nough for two banks, so
+he say I could put in my five dollars en he pay me thirty-five at de en’
+er de year.
+
+“So I done it.  Den I reck’n’d I’d inves’ de thirty-five dollars right
+off en keep things a-movin’.  Dey wuz a nigger name’ Bob, dat had
+ketched a wood-flat, en his marster didn’ know it; en I bought it off’n
+him en told him to take de thirty-five dollars when de en’ er de
+year come; but somebody stole de wood-flat dat night, en nex day de
+one-laigged nigger say de bank’s busted.  So dey didn’ none uv us git no
+money.”
+
+“What did you do with the ten cents, Jim?”
+
+“Well, I ‘uz gwyne to spen’ it, but I had a dream, en de dream tole me
+to give it to a nigger name’ Balum--Balum’s Ass dey call him for short;
+he’s one er dem chuckleheads, you know.  But he’s lucky, dey say, en I
+see I warn’t lucky.  De dream say let Balum inves’ de ten cents en he’d
+make a raise for me.  Well, Balum he tuck de money, en when he wuz in
+church he hear de preacher say dat whoever give to de po’ len’ to de
+Lord, en boun’ to git his money back a hund’d times.  So Balum he tuck
+en give de ten cents to de po’, en laid low to see what wuz gwyne to
+come of it.”
+
+“Well, what did come of it, Jim?”
+
+“Nuffn never come of it.  I couldn’ manage to k’leck dat money no way;
+en Balum he couldn’.  I ain’ gwyne to len’ no mo’ money ‘dout I see de
+security.  Boun’ to git yo’ money back a hund’d times, de preacher says!
+Ef I could git de ten _cents_ back, I’d call it squah, en be glad er de
+chanst.”
+
+“Well, it’s all right anyway, Jim, long as you’re going to be rich again
+some time or other.”
+
+“Yes; en I’s rich now, come to look at it.  I owns mysef, en I’s wuth
+eight hund’d dollars.  I wisht I had de money, I wouldn’ want no mo’.”
+
+
+
+
+CHAPTER IX.
+
+I wanted to go and look at a place right about the middle of the island
+that I’d found when I was exploring; so we started and soon got to it,
+because the island was only three miles long and a quarter of a mile
+wide.
+
+This place was a tolerable long, steep hill or ridge about forty foot
+high. We had a rough time getting to the top, the sides was so steep and
+the bushes so thick.  We tramped and clumb around all over it, and by
+and by found a good big cavern in the rock, most up to the top on the
+side towards Illinois.  The cavern was as big as two or three rooms
+bunched together, and Jim could stand up straight in it.  It was cool in
+there. Jim was for putting our traps in there right away, but I said we
+didn’t want to be climbing up and down there all the time.
+
+Jim said if we had the canoe hid in a good place, and had all the traps
+in the cavern, we could rush there if anybody was to come to the island,
+and they would never find us without dogs.  And, besides, he said them
+little birds had said it was going to rain, and did I want the things to
+get wet?
+
+So we went back and got the canoe, and paddled up abreast the cavern,
+and lugged all the traps up there.  Then we hunted up a place close by
+to hide the canoe in, amongst the thick willows.  We took some fish off
+of the lines and set them again, and begun to get ready for dinner.
+
+The door of the cavern was big enough to roll a hogshead in, and on one
+side of the door the floor stuck out a little bit, and was flat and a
+good place to build a fire on.  So we built it there and cooked dinner.
+
+We spread the blankets inside for a carpet, and eat our dinner in there.
+We put all the other things handy at the back of the cavern.  Pretty
+soon it darkened up, and begun to thunder and lighten; so the birds was
+right about it.  Directly it begun to rain, and it rained like all fury,
+too, and I never see the wind blow so.  It was one of these regular
+summer storms.  It would get so dark that it looked all blue-black
+outside, and lovely; and the rain would thrash along by so thick that
+the trees off a little ways looked dim and spider-webby; and here would
+come a blast of wind that would bend the trees down and turn up the
+pale underside of the leaves; and then a perfect ripper of a gust would
+follow along and set the branches to tossing their arms as if they
+was just wild; and next, when it was just about the bluest and
+blackest--_FST_! it was as bright as glory, and you’d have a little
+glimpse of tree-tops a-plunging about away off yonder in the storm,
+hundreds of yards further than you could see before; dark as sin again
+in a second, and now you’d hear the thunder let go with an awful crash,
+and then go rumbling, grumbling, tumbling, down the sky towards the
+under side of the world, like rolling empty barrels down stairs--where
+it’s long stairs and they bounce a good deal, you know.
+
+“Jim, this is nice,” I says.  “I wouldn’t want to be nowhere else but
+here. Pass me along another hunk of fish and some hot corn-bread.”
+
+“Well, you wouldn’t a ben here ‘f it hadn’t a ben for Jim.  You’d a ben
+down dah in de woods widout any dinner, en gittn’ mos’ drownded, too;
+dat you would, honey.  Chickens knows when it’s gwyne to rain, en so do
+de birds, chile.”
+
+The river went on raising and raising for ten or twelve days, till at
+last it was over the banks.  The water was three or four foot deep on
+the island in the low places and on the Illinois bottom.  On that side
+it was a good many miles wide, but on the Missouri side it was the same
+old distance across--a half a mile--because the Missouri shore was just a
+wall of high bluffs.
+
+Daytimes we paddled all over the island in the canoe, It was mighty cool
+and shady in the deep woods, even if the sun was blazing outside.  We
+went winding in and out amongst the trees, and sometimes the vines hung
+so thick we had to back away and go some other way.  Well, on every old
+broken-down tree you could see rabbits and snakes and such things; and
+when the island had been overflowed a day or two they got so tame, on
+account of being hungry, that you could paddle right up and put your
+hand on them if you wanted to; but not the snakes and turtles--they would
+slide off in the water.  The ridge our cavern was in was full of them.
+We could a had pets enough if we’d wanted them.
+
+One night we catched a little section of a lumber raft--nice pine planks.
+It was twelve foot wide and about fifteen or sixteen foot long, and
+the top stood above water six or seven inches--a solid, level floor.  We
+could see saw-logs go by in the daylight sometimes, but we let them go;
+we didn’t show ourselves in daylight.
+
+Another night when we was up at the head of the island, just before
+daylight, here comes a frame-house down, on the west side.  She was
+a two-story, and tilted over considerable.  We paddled out and got
+aboard--clumb in at an upstairs window.  But it was too dark to see yet,
+so we made the canoe fast and set in her to wait for daylight.
+
+The light begun to come before we got to the foot of the island.  Then
+we looked in at the window.  We could make out a bed, and a table, and
+two old chairs, and lots of things around about on the floor, and there
+was clothes hanging against the wall.  There was something laying on the
+floor in the far corner that looked like a man.  So Jim says:
+
+“Hello, you!”
+
+But it didn’t budge.  So I hollered again, and then Jim says:
+
+“De man ain’t asleep--he’s dead.  You hold still--I’ll go en see.”
+
+He went, and bent down and looked, and says:
+
+“It’s a dead man.  Yes, indeedy; naked, too.  He’s ben shot in de back.
+I reck’n he’s ben dead two er three days.  Come in, Huck, but doan’ look
+at his face--it’s too gashly.”
+
+I didn’t look at him at all.  Jim throwed some old rags over him, but
+he needn’t done it; I didn’t want to see him.  There was heaps of old
+greasy cards scattered around over the floor, and old whisky bottles,
+and a couple of masks made out of black cloth; and all over the walls
+was the ignorantest kind of words and pictures made with charcoal.
+ There was two old dirty calico dresses, and a sun-bonnet, and some
+women’s underclothes hanging against the wall, and some men’s clothing,
+too.  We put the lot into the canoe--it might come good.  There was a
+boy’s old speckled straw hat on the floor; I took that, too.  And there
+was a bottle that had had milk in it, and it had a rag stopper for a
+baby to suck.  We would a took the bottle, but it was broke.  There was
+a seedy old chest, and an old hair trunk with the hinges broke.  They
+stood open, but there warn’t nothing left in them that was any account.
+ The way things was scattered about we reckoned the people left in a
+hurry, and warn’t fixed so as to carry off most of their stuff.
+
+We got an old tin lantern, and a butcher-knife without any handle, and
+a bran-new Barlow knife worth two bits in any store, and a lot of tallow
+candles, and a tin candlestick, and a gourd, and a tin cup, and a ratty
+old bedquilt off the bed, and a reticule with needles and pins and
+beeswax and buttons and thread and all such truck in it, and a hatchet
+and some nails, and a fishline as thick as my little finger with some
+monstrous hooks on it, and a roll of buckskin, and a leather dog-collar,
+and a horseshoe, and some vials of medicine that didn’t have no label
+on them; and just as we was leaving I found a tolerable good curry-comb,
+and Jim he found a ratty old fiddle-bow, and a wooden leg.  The straps
+was broke off of it, but, barring that, it was a good enough leg, though
+it was too long for me and not long enough for Jim, and we couldn’t find
+the other one, though we hunted all around.
+
+And so, take it all around, we made a good haul.  When we was ready to
+shove off we was a quarter of a mile below the island, and it was pretty
+broad day; so I made Jim lay down in the canoe and cover up with the
+quilt, because if he set up people could tell he was a nigger a good
+ways off.  I paddled over to the Illinois shore, and drifted down most
+a half a mile doing it.  I crept up the dead water under the bank, and
+hadn’t no accidents and didn’t see nobody.  We got home all safe.
+
+
+
+
+CHAPTER X.
+
+AFTER breakfast I wanted to talk about the dead man and guess out how he
+come to be killed, but Jim didn’t want to.  He said it would fetch bad
+luck; and besides, he said, he might come and ha’nt us; he said a man
+that warn’t buried was more likely to go a-ha’nting around than one
+that was planted and comfortable.  That sounded pretty reasonable, so
+I didn’t say no more; but I couldn’t keep from studying over it and
+wishing I knowed who shot the man, and what they done it for.
+
+We rummaged the clothes we’d got, and found eight dollars in silver
+sewed up in the lining of an old blanket overcoat.  Jim said he reckoned
+the people in that house stole the coat, because if they’d a knowed the
+money was there they wouldn’t a left it.  I said I reckoned they killed
+him, too; but Jim didn’t want to talk about that.  I says:
+
+“Now you think it’s bad luck; but what did you say when I fetched in the
+snake-skin that I found on the top of the ridge day before yesterday?
+You said it was the worst bad luck in the world to touch a snake-skin
+with my hands.  Well, here’s your bad luck!  We’ve raked in all this
+truck and eight dollars besides.  I wish we could have some bad luck
+like this every day, Jim.”
+
+“Never you mind, honey, never you mind.  Don’t you git too peart.  It’s
+a-comin’.  Mind I tell you, it’s a-comin’.”
+
+It did come, too.  It was a Tuesday that we had that talk.  Well, after
+dinner Friday we was laying around in the grass at the upper end of the
+ridge, and got out of tobacco.  I went to the cavern to get some, and
+found a rattlesnake in there.  I killed him, and curled him up on the
+foot of Jim’s blanket, ever so natural, thinking there’d be some fun
+when Jim found him there.  Well, by night I forgot all about the snake,
+and when Jim flung himself down on the blanket while I struck a light
+the snake’s mate was there, and bit him.
+
+He jumped up yelling, and the first thing the light showed was the
+varmint curled up and ready for another spring.  I laid him out in a
+second with a stick, and Jim grabbed pap’s whisky-jug and begun to pour
+it down.
+
+He was barefooted, and the snake bit him right on the heel.  That all
+comes of my being such a fool as to not remember that wherever you leave
+a dead snake its mate always comes there and curls around it.  Jim told
+me to chop off the snake’s head and throw it away, and then skin the
+body and roast a piece of it.  I done it, and he eat it and said it
+would help cure him. He made me take off the rattles and tie them around
+his wrist, too.  He said that that would help.  Then I slid out quiet
+and throwed the snakes clear away amongst the bushes; for I warn’t going
+to let Jim find out it was all my fault, not if I could help it.
+
+Jim sucked and sucked at the jug, and now and then he got out of his
+head and pitched around and yelled; but every time he come to himself he
+went to sucking at the jug again.  His foot swelled up pretty big, and
+so did his leg; but by and by the drunk begun to come, and so I judged
+he was all right; but I’d druther been bit with a snake than pap’s
+whisky.
+
+Jim was laid up for four days and nights.  Then the swelling was all
+gone and he was around again.  I made up my mind I wouldn’t ever take
+a-holt of a snake-skin again with my hands, now that I see what had come
+of it. Jim said he reckoned I would believe him next time.  And he said
+that handling a snake-skin was such awful bad luck that maybe we hadn’t
+got to the end of it yet.  He said he druther see the new moon over his
+left shoulder as much as a thousand times than take up a snake-skin
+in his hand.  Well, I was getting to feel that way myself, though I’ve
+always reckoned that looking at the new moon over your left shoulder is
+one of the carelessest and foolishest things a body can do.  Old Hank
+Bunker done it once, and bragged about it; and in less than two years he
+got drunk and fell off of the shot-tower, and spread himself out so
+that he was just a kind of a layer, as you may say; and they slid him
+edgeways between two barn doors for a coffin, and buried him so, so
+they say, but I didn’t see it.  Pap told me.  But anyway it all come of
+looking at the moon that way, like a fool.
+
+Well, the days went along, and the river went down between its banks
+again; and about the first thing we done was to bait one of the big
+hooks with a skinned rabbit and set it and catch a catfish that was
+as big as a man, being six foot two inches long, and weighed over two
+hundred pounds. We couldn’t handle him, of course; he would a flung us
+into Illinois.  We just set there and watched him rip and tear around
+till he drownded.  We found a brass button in his stomach and a round
+ball, and lots of rubbage.  We split the ball open with the hatchet,
+and there was a spool in it.  Jim said he’d had it there a long time, to
+coat it over so and make a ball of it.  It was as big a fish as was ever
+catched in the Mississippi, I reckon.  Jim said he hadn’t ever seen
+a bigger one.  He would a been worth a good deal over at the village.
+ They peddle out such a fish as that by the pound in the market-house
+there; everybody buys some of him; his meat’s as white as snow and makes
+a good fry.
+
+Next morning I said it was getting slow and dull, and I wanted to get a
+stirring up some way.  I said I reckoned I would slip over the river and
+find out what was going on.  Jim liked that notion; but he said I
+must go in the dark and look sharp.  Then he studied it over and said,
+couldn’t I put on some of them old things and dress up like a girl?
+ That was a good notion, too.  So we shortened up one of the calico
+gowns, and I turned up my trouser-legs to my knees and got into it.  Jim
+hitched it behind with the hooks, and it was a fair fit.  I put on the
+sun-bonnet and tied it under my chin, and then for a body to look in
+and see my face was like looking down a joint of stove-pipe.  Jim said
+nobody would know me, even in the daytime, hardly.  I practiced around
+all day to get the hang of the things, and by and by I could do pretty
+well in them, only Jim said I didn’t walk like a girl; and he said
+I must quit pulling up my gown to get at my britches-pocket.  I took
+notice, and done better.
+
+I started up the Illinois shore in the canoe just after dark.
+
+I started across to the town from a little below the ferry-landing, and
+the drift of the current fetched me in at the bottom of the town.  I
+tied up and started along the bank.  There was a light burning in a
+little shanty that hadn’t been lived in for a long time, and I wondered
+who had took up quarters there.  I slipped up and peeped in at the
+window.  There was a woman about forty year old in there knitting by
+a candle that was on a pine table.  I didn’t know her face; she was a
+stranger, for you couldn’t start a face in that town that I didn’t know.
+ Now this was lucky, because I was weakening; I was getting afraid I had
+come; people might know my voice and find me out.  But if this woman had
+been in such a little town two days she could tell me all I wanted to
+know; so I knocked at the door, and made up my mind I wouldn’t forget I
+was a girl.
+
+
+
+
+CHAPTER XI.
+
+“COME in,” says the woman, and I did.  She says:  “Take a cheer.”
+
+I done it.  She looked me all over with her little shiny eyes, and says:
+
+“What might your name be?”
+
+“Sarah Williams.”
+
+“Where ‘bouts do you live?  In this neighborhood?’
+
+“No’m.  In Hookerville, seven mile below.  I’ve walked all the way and
+I’m all tired out.”
+
+“Hungry, too, I reckon.  I’ll find you something.”
+
+“No’m, I ain’t hungry.  I was so hungry I had to stop two miles below
+here at a farm; so I ain’t hungry no more.  It’s what makes me so late.
+My mother’s down sick, and out of money and everything, and I come to
+tell my uncle Abner Moore.  He lives at the upper end of the town, she
+says.  I hain’t ever been here before.  Do you know him?”
+
+“No; but I don’t know everybody yet.  I haven’t lived here quite two
+weeks. It’s a considerable ways to the upper end of the town.  You
+better stay here all night.  Take off your bonnet.”
+
+“No,” I says; “I’ll rest a while, I reckon, and go on.  I ain’t afeared
+of the dark.”
+
+She said she wouldn’t let me go by myself, but her husband would be in
+by and by, maybe in a hour and a half, and she’d send him along with me.
+Then she got to talking about her husband, and about her relations up
+the river, and her relations down the river, and about how much better
+off they used to was, and how they didn’t know but they’d made a mistake
+coming to our town, instead of letting well alone--and so on and so on,
+till I was afeard I had made a mistake coming to her to find out what
+was going on in the town; but by and by she dropped on to pap and the
+murder, and then I was pretty willing to let her clatter right along.
+ She told about me and Tom Sawyer finding the six thousand dollars (only
+she got it ten) and all about pap and what a hard lot he was, and what
+a hard lot I was, and at last she got down to where I was murdered.  I
+says:
+
+“Who done it?  We’ve heard considerable about these goings on down in
+Hookerville, but we don’t know who ‘twas that killed Huck Finn.”
+
+“Well, I reckon there’s a right smart chance of people _here_ that’d
+like to know who killed him.  Some think old Finn done it himself.”
+
+“No--is that so?”
+
+“Most everybody thought it at first.  He’ll never know how nigh he come
+to getting lynched.  But before night they changed around and judged it
+was done by a runaway nigger named Jim.”
+
+“Why _he_--”
+
+I stopped.  I reckoned I better keep still.  She run on, and never
+noticed I had put in at all:
+
+“The nigger run off the very night Huck Finn was killed.  So there’s a
+reward out for him--three hundred dollars.  And there’s a reward out for
+old Finn, too--two hundred dollars.  You see, he come to town the
+morning after the murder, and told about it, and was out with ‘em on the
+ferryboat hunt, and right away after he up and left.  Before night they
+wanted to lynch him, but he was gone, you see.  Well, next day they
+found out the nigger was gone; they found out he hadn’t ben seen sence
+ten o’clock the night the murder was done.  So then they put it on him,
+you see; and while they was full of it, next day, back comes old Finn,
+and went boo-hooing to Judge Thatcher to get money to hunt for the
+nigger all over Illinois with. The judge gave him some, and that evening
+he got drunk, and was around till after midnight with a couple of mighty
+hard-looking strangers, and then went off with them.  Well, he hain’t
+come back sence, and they ain’t looking for him back till this thing
+blows over a little, for people thinks now that he killed his boy and
+fixed things so folks would think robbers done it, and then he’d get
+Huck’s money without having to bother a long time with a lawsuit.
+ People do say he warn’t any too good to do it.  Oh, he’s sly, I reckon.
+ If he don’t come back for a year he’ll be all right.  You can’t prove
+anything on him, you know; everything will be quieted down then, and
+he’ll walk in Huck’s money as easy as nothing.”
+
+“Yes, I reckon so, ‘m.  I don’t see nothing in the way of it.  Has
+everybody quit thinking the nigger done it?”
+
+“Oh, no, not everybody.  A good many thinks he done it.  But they’ll get
+the nigger pretty soon now, and maybe they can scare it out of him.”
+
+“Why, are they after him yet?”
+
+“Well, you’re innocent, ain’t you!  Does three hundred dollars lay
+around every day for people to pick up?  Some folks think the nigger
+ain’t far from here.  I’m one of them--but I hain’t talked it around.  A
+few days ago I was talking with an old couple that lives next door in
+the log shanty, and they happened to say hardly anybody ever goes to
+that island over yonder that they call Jackson’s Island.  Don’t anybody
+live there? says I. No, nobody, says they.  I didn’t say any more, but
+I done some thinking.  I was pretty near certain I’d seen smoke over
+there, about the head of the island, a day or two before that, so I says
+to myself, like as not that nigger’s hiding over there; anyway, says
+I, it’s worth the trouble to give the place a hunt.  I hain’t seen any
+smoke sence, so I reckon maybe he’s gone, if it was him; but husband’s
+going over to see--him and another man.  He was gone up the river; but he
+got back to-day, and I told him as soon as he got here two hours ago.”
+
+I had got so uneasy I couldn’t set still.  I had to do something with my
+hands; so I took up a needle off of the table and went to threading
+it. My hands shook, and I was making a bad job of it.  When the woman
+stopped talking I looked up, and she was looking at me pretty curious
+and smiling a little.  I put down the needle and thread, and let on to
+be interested--and I was, too--and says:
+
+“Three hundred dollars is a power of money.  I wish my mother could get
+it. Is your husband going over there to-night?”
+
+“Oh, yes.  He went up-town with the man I was telling you of, to get a
+boat and see if they could borrow another gun.  They’ll go over after
+midnight.”
+
+“Couldn’t they see better if they was to wait till daytime?”
+
+“Yes.  And couldn’t the nigger see better, too?  After midnight he’ll
+likely be asleep, and they can slip around through the woods and hunt up
+his camp fire all the better for the dark, if he’s got one.”
+
+“I didn’t think of that.”
+
+The woman kept looking at me pretty curious, and I didn’t feel a bit
+comfortable.  Pretty soon she says,
+
+“What did you say your name was, honey?”
+
+“M--Mary Williams.”
+
+Somehow it didn’t seem to me that I said it was Mary before, so I didn’t
+look up--seemed to me I said it was Sarah; so I felt sort of cornered,
+and was afeared maybe I was looking it, too.  I wished the woman would
+say something more; the longer she set still the uneasier I was.  But
+now she says:
+
+“Honey, I thought you said it was Sarah when you first come in?”
+
+“Oh, yes’m, I did.  Sarah Mary Williams.  Sarah’s my first name.  Some
+calls me Sarah, some calls me Mary.”
+
+“Oh, that’s the way of it?”
+
+“Yes’m.”
+
+I was feeling better then, but I wished I was out of there, anyway.  I
+couldn’t look up yet.
+
+Well, the woman fell to talking about how hard times was, and how poor
+they had to live, and how the rats was as free as if they owned the
+place, and so forth and so on, and then I got easy again.  She was right
+about the rats. You’d see one stick his nose out of a hole in the corner
+every little while.  She said she had to have things handy to throw at
+them when she was alone, or they wouldn’t give her no peace.  She showed
+me a bar of lead twisted up into a knot, and said she was a good shot
+with it generly, but she’d wrenched her arm a day or two ago, and didn’t
+know whether she could throw true now.  But she watched for a chance,
+and directly banged away at a rat; but she missed him wide, and said
+“Ouch!” it hurt her arm so.  Then she told me to try for the next one.
+ I wanted to be getting away before the old man got back, but of course
+I didn’t let on.  I got the thing, and the first rat that showed his
+nose I let drive, and if he’d a stayed where he was he’d a been a
+tolerable sick rat.  She said that was first-rate, and she reckoned I
+would hive the next one.  She went and got the lump of lead and fetched
+it back, and brought along a hank of yarn which she wanted me to help
+her with.  I held up my two hands and she put the hank over them, and
+went on talking about her and her husband’s matters.  But she broke off
+to say:
+
+“Keep your eye on the rats.  You better have the lead in your lap,
+handy.”
+
+So she dropped the lump into my lap just at that moment, and I clapped
+my legs together on it and she went on talking.  But only about a
+minute. Then she took off the hank and looked me straight in the face,
+and very pleasant, and says:
+
+“Come, now, what’s your real name?”
+
+“Wh--what, mum?”
+
+“What’s your real name?  Is it Bill, or Tom, or Bob?--or what is it?”
+
+I reckon I shook like a leaf, and I didn’t know hardly what to do.  But
+I says:
+
+“Please to don’t poke fun at a poor girl like me, mum.  If I’m in the
+way here, I’ll--”
+
+“No, you won’t.  Set down and stay where you are.  I ain’t going to hurt
+you, and I ain’t going to tell on you, nuther.  You just tell me your
+secret, and trust me.  I’ll keep it; and, what’s more, I’ll help
+you. So’ll my old man if you want him to.  You see, you’re a runaway
+‘prentice, that’s all.  It ain’t anything.  There ain’t no harm in it.
+You’ve been treated bad, and you made up your mind to cut.  Bless you,
+child, I wouldn’t tell on you.  Tell me all about it now, that’s a good
+boy.”
+
+So I said it wouldn’t be no use to try to play it any longer, and I
+would just make a clean breast and tell her everything, but she musn’t
+go back on her promise.  Then I told her my father and mother was dead,
+and the law had bound me out to a mean old farmer in the country thirty
+mile back from the river, and he treated me so bad I couldn’t stand it
+no longer; he went away to be gone a couple of days, and so I took my
+chance and stole some of his daughter’s old clothes and cleared out, and
+I had been three nights coming the thirty miles.  I traveled nights,
+and hid daytimes and slept, and the bag of bread and meat I carried from
+home lasted me all the way, and I had a-plenty.  I said I believed my
+uncle Abner Moore would take care of me, and so that was why I struck
+out for this town of Goshen.
+
+“Goshen, child?  This ain’t Goshen.  This is St. Petersburg.  Goshen’s
+ten mile further up the river.  Who told you this was Goshen?”
+
+“Why, a man I met at daybreak this morning, just as I was going to turn
+into the woods for my regular sleep.  He told me when the roads forked I
+must take the right hand, and five mile would fetch me to Goshen.”
+
+“He was drunk, I reckon.  He told you just exactly wrong.”
+
+“Well, he did act like he was drunk, but it ain’t no matter now.  I got
+to be moving along.  I’ll fetch Goshen before daylight.”
+
+“Hold on a minute.  I’ll put you up a snack to eat.  You might want it.”
+
+So she put me up a snack, and says:
+
+“Say, when a cow’s laying down, which end of her gets up first?  Answer
+up prompt now--don’t stop to study over it.  Which end gets up first?”
+
+“The hind end, mum.”
+
+“Well, then, a horse?”
+
+“The for’rard end, mum.”
+
+“Which side of a tree does the moss grow on?”
+
+“North side.”
+
+“If fifteen cows is browsing on a hillside, how many of them eats with
+their heads pointed the same direction?”
+
+“The whole fifteen, mum.”
+
+“Well, I reckon you _have_ lived in the country.  I thought maybe you
+was trying to hocus me again.  What’s your real name, now?”
+
+“George Peters, mum.”
+
+“Well, try to remember it, George.  Don’t forget and tell me it’s
+Elexander before you go, and then get out by saying it’s George
+Elexander when I catch you.  And don’t go about women in that old
+calico.  You do a girl tolerable poor, but you might fool men, maybe.
+ Bless you, child, when you set out to thread a needle don’t hold the
+thread still and fetch the needle up to it; hold the needle still and
+poke the thread at it; that’s the way a woman most always does, but a
+man always does t’other way.  And when you throw at a rat or anything,
+hitch yourself up a tiptoe and fetch your hand up over your head as
+awkward as you can, and miss your rat about six or seven foot. Throw
+stiff-armed from the shoulder, like there was a pivot there for it to
+turn on, like a girl; not from the wrist and elbow, with your arm out
+to one side, like a boy.  And, mind you, when a girl tries to catch
+anything in her lap she throws her knees apart; she don’t clap them
+together, the way you did when you catched the lump of lead.  Why, I
+spotted you for a boy when you was threading the needle; and I contrived
+the other things just to make certain.  Now trot along to your uncle,
+Sarah Mary Williams George Elexander Peters, and if you get into trouble
+you send word to Mrs. Judith Loftus, which is me, and I’ll do what I can
+to get you out of it.  Keep the river road all the way, and next time
+you tramp take shoes and socks with you. The river road’s a rocky one,
+and your feet’ll be in a condition when you get to Goshen, I reckon.”
+
+I went up the bank about fifty yards, and then I doubled on my tracks
+and slipped back to where my canoe was, a good piece below the house.  I
+jumped in, and was off in a hurry.  I went up-stream far enough to
+make the head of the island, and then started across.  I took off the
+sun-bonnet, for I didn’t want no blinders on then.  When I was about the
+middle I heard the clock begin to strike, so I stops and listens; the
+sound come faint over the water but clear--eleven.  When I struck the
+head of the island I never waited to blow, though I was most winded, but
+I shoved right into the timber where my old camp used to be, and started
+a good fire there on a high and dry spot.
+
+Then I jumped in the canoe and dug out for our place, a mile and a half
+below, as hard as I could go.  I landed, and slopped through the timber
+and up the ridge and into the cavern.  There Jim laid, sound asleep on
+the ground.  I roused him out and says:
+
+“Git up and hump yourself, Jim!  There ain’t a minute to lose.  They’re
+after us!”
+
+Jim never asked no questions, he never said a word; but the way he
+worked for the next half an hour showed about how he was scared.  By
+that time everything we had in the world was on our raft, and she was
+ready to be shoved out from the willow cove where she was hid.  We
+put out the camp fire at the cavern the first thing, and didn’t show a
+candle outside after that.
+
+I took the canoe out from the shore a little piece, and took a look;
+but if there was a boat around I couldn’t see it, for stars and shadows
+ain’t good to see by.  Then we got out the raft and slipped along down
+in the shade, past the foot of the island dead still--never saying a
+word.
+
+
+
+
+CHAPTER XII.
+
+IT must a been close on to one o’clock when we got below the island at
+last, and the raft did seem to go mighty slow.  If a boat was to come
+along we was going to take to the canoe and break for the Illinois
+shore; and it was well a boat didn’t come, for we hadn’t ever thought to
+put the gun in the canoe, or a fishing-line, or anything to eat.  We
+was in ruther too much of a sweat to think of so many things.  It warn’t
+good judgment to put _everything_ on the raft.
+
+If the men went to the island I just expect they found the camp fire I
+built, and watched it all night for Jim to come.  Anyways, they stayed
+away from us, and if my building the fire never fooled them it warn’t no
+fault of mine.  I played it as low down on them as I could.
+
+When the first streak of day began to show we tied up to a towhead in a
+big bend on the Illinois side, and hacked off cottonwood branches with
+the hatchet, and covered up the raft with them so she looked like there
+had been a cave-in in the bank there.  A tow-head is a sandbar that has
+cottonwoods on it as thick as harrow-teeth.
+
+We had mountains on the Missouri shore and heavy timber on the Illinois
+side, and the channel was down the Missouri shore at that place, so we
+warn’t afraid of anybody running across us.  We laid there all day,
+and watched the rafts and steamboats spin down the Missouri shore, and
+up-bound steamboats fight the big river in the middle.  I told Jim all
+about the time I had jabbering with that woman; and Jim said she was
+a smart one, and if she was to start after us herself she wouldn’t set
+down and watch a camp fire--no, sir, she’d fetch a dog.  Well, then, I
+said, why couldn’t she tell her husband to fetch a dog?  Jim said he
+bet she did think of it by the time the men was ready to start, and he
+believed they must a gone up-town to get a dog and so they lost all that
+time, or else we wouldn’t be here on a towhead sixteen or seventeen mile
+below the village--no, indeedy, we would be in that same old town again.
+ So I said I didn’t care what was the reason they didn’t get us as long
+as they didn’t.
+
+When it was beginning to come on dark we poked our heads out of the
+cottonwood thicket, and looked up and down and across; nothing in sight;
+so Jim took up some of the top planks of the raft and built a snug
+wigwam to get under in blazing weather and rainy, and to keep the things
+dry. Jim made a floor for the wigwam, and raised it a foot or more above
+the level of the raft, so now the blankets and all the traps was out of
+reach of steamboat waves.  Right in the middle of the wigwam we made a
+layer of dirt about five or six inches deep with a frame around it for
+to hold it to its place; this was to build a fire on in sloppy weather
+or chilly; the wigwam would keep it from being seen.  We made an extra
+steering-oar, too, because one of the others might get broke on a snag
+or something. We fixed up a short forked stick to hang the old lantern
+on, because we must always light the lantern whenever we see a steamboat
+coming down-stream, to keep from getting run over; but we wouldn’t have
+to light it for up-stream boats unless we see we was in what they call
+a “crossing”; for the river was pretty high yet, very low banks being
+still a little under water; so up-bound boats didn’t always run the
+channel, but hunted easy water.
+
+This second night we run between seven and eight hours, with a current
+that was making over four mile an hour.  We catched fish and talked,
+and we took a swim now and then to keep off sleepiness.  It was kind of
+solemn, drifting down the big, still river, laying on our backs looking
+up at the stars, and we didn’t ever feel like talking loud, and it
+warn’t often that we laughed--only a little kind of a low chuckle.  We
+had mighty good weather as a general thing, and nothing ever happened to
+us at all--that night, nor the next, nor the next.
+
+Every night we passed towns, some of them away up on black hillsides,
+nothing but just a shiny bed of lights; not a house could you see.  The
+fifth night we passed St. Louis, and it was like the whole world lit up.
+In St. Petersburg they used to say there was twenty or thirty thousand
+people in St. Louis, but I never believed it till I see that wonderful
+spread of lights at two o’clock that still night.  There warn’t a sound
+there; everybody was asleep.
+
+Every night now I used to slip ashore towards ten o’clock at some little
+village, and buy ten or fifteen cents’ worth of meal or bacon or other
+stuff to eat; and sometimes I lifted a chicken that warn’t roosting
+comfortable, and took him along.  Pap always said, take a chicken when
+you get a chance, because if you don’t want him yourself you can easy
+find somebody that does, and a good deed ain’t ever forgot.  I never see
+pap when he didn’t want the chicken himself, but that is what he used to
+say, anyway.
+
+Mornings before daylight I slipped into cornfields and borrowed a
+watermelon, or a mushmelon, or a punkin, or some new corn, or things of
+that kind.  Pap always said it warn’t no harm to borrow things if you
+was meaning to pay them back some time; but the widow said it warn’t
+anything but a soft name for stealing, and no decent body would do it.
+ Jim said he reckoned the widow was partly right and pap was partly
+right; so the best way would be for us to pick out two or three things
+from the list and say we wouldn’t borrow them any more--then he reckoned
+it wouldn’t be no harm to borrow the others.  So we talked it over all
+one night, drifting along down the river, trying to make up our minds
+whether to drop the watermelons, or the cantelopes, or the mushmelons,
+or what.  But towards daylight we got it all settled satisfactory, and
+concluded to drop crabapples and p’simmons.  We warn’t feeling just
+right before that, but it was all comfortable now.  I was glad the way
+it come out, too, because crabapples ain’t ever good, and the p’simmons
+wouldn’t be ripe for two or three months yet.
+
+We shot a water-fowl now and then that got up too early in the morning
+or didn’t go to bed early enough in the evening.  Take it all round, we
+lived pretty high.
+
+The fifth night below St. Louis we had a big storm after midnight, with
+a power of thunder and lightning, and the rain poured down in a solid
+sheet. We stayed in the wigwam and let the raft take care of itself.
+When the lightning glared out we could see a big straight river ahead,
+and high, rocky bluffs on both sides.  By and by says I, “Hel-_lo_, Jim,
+looky yonder!” It was a steamboat that had killed herself on a rock.
+ We was drifting straight down for her.  The lightning showed her very
+distinct.  She was leaning over, with part of her upper deck above
+water, and you could see every little chimbly-guy clean and clear, and a
+chair by the big bell, with an old slouch hat hanging on the back of it,
+when the flashes come.
+
+Well, it being away in the night and stormy, and all so mysterious-like,
+I felt just the way any other boy would a felt when I see that wreck
+laying there so mournful and lonesome in the middle of the river.  I
+wanted to get aboard of her and slink around a little, and see what
+there was there.  So I says:
+
+“Le’s land on her, Jim.”
+
+But Jim was dead against it at first.  He says:
+
+“I doan’ want to go fool’n ‘long er no wrack.  We’s doin’ blame’ well,
+en we better let blame’ well alone, as de good book says.  Like as not
+dey’s a watchman on dat wrack.”
+
+“Watchman your grandmother,” I says; “there ain’t nothing to watch but
+the texas and the pilot-house; and do you reckon anybody’s going to resk
+his life for a texas and a pilot-house such a night as this, when
+it’s likely to break up and wash off down the river any minute?”  Jim
+couldn’t say nothing to that, so he didn’t try.  “And besides,” I says,
+“we might borrow something worth having out of the captain’s stateroom.
+ Seegars, I bet you--and cost five cents apiece, solid cash.  Steamboat
+captains is always rich, and get sixty dollars a month, and _they_ don’t
+care a cent what a thing costs, you know, long as they want it.  Stick a
+candle in your pocket; I can’t rest, Jim, till we give her a rummaging.
+ Do you reckon Tom Sawyer would ever go by this thing?  Not for pie, he
+wouldn’t. He’d call it an adventure--that’s what he’d call it; and he’d
+land on that wreck if it was his last act.  And wouldn’t he throw style
+into it?--wouldn’t he spread himself, nor nothing?  Why, you’d think it
+was Christopher C’lumbus discovering Kingdom-Come.  I wish Tom Sawyer
+_was_ here.”
+
+Jim he grumbled a little, but give in.  He said we mustn’t talk any more
+than we could help, and then talk mighty low.  The lightning showed us
+the wreck again just in time, and we fetched the stabboard derrick, and
+made fast there.
+
+The deck was high out here.  We went sneaking down the slope of it to
+labboard, in the dark, towards the texas, feeling our way slow with our
+feet, and spreading our hands out to fend off the guys, for it was so
+dark we couldn’t see no sign of them.  Pretty soon we struck the forward
+end of the skylight, and clumb on to it; and the next step fetched us in
+front of the captain’s door, which was open, and by Jimminy, away down
+through the texas-hall we see a light! and all in the same second we
+seem to hear low voices in yonder!
+
+Jim whispered and said he was feeling powerful sick, and told me to come
+along.  I says, all right, and was going to start for the raft; but just
+then I heard a voice wail out and say:
+
+“Oh, please don’t, boys; I swear I won’t ever tell!”
+
+Another voice said, pretty loud:
+
+“It’s a lie, Jim Turner.  You’ve acted this way before.  You always want
+more’n your share of the truck, and you’ve always got it, too, because
+you’ve swore ‘t if you didn’t you’d tell.  But this time you’ve said
+it jest one time too many.  You’re the meanest, treacherousest hound in
+this country.”
+
+By this time Jim was gone for the raft.  I was just a-biling with
+curiosity; and I says to myself, Tom Sawyer wouldn’t back out now,
+and so I won’t either; I’m a-going to see what’s going on here.  So I
+dropped on my hands and knees in the little passage, and crept aft
+in the dark till there warn’t but one stateroom betwixt me and the
+cross-hall of the texas.  Then in there I see a man stretched on the
+floor and tied hand and foot, and two men standing over him, and one
+of them had a dim lantern in his hand, and the other one had a pistol.
+ This one kept pointing the pistol at the man’s head on the floor, and
+saying:
+
+“I’d _like_ to!  And I orter, too--a mean skunk!”
+
+The man on the floor would shrivel up and say, “Oh, please don’t, Bill;
+I hain’t ever goin’ to tell.”
+
+And every time he said that the man with the lantern would laugh and
+say:
+
+“‘Deed you _ain’t!_  You never said no truer thing ‘n that, you bet
+you.” And once he said:  “Hear him beg! and yit if we hadn’t got the
+best of him and tied him he’d a killed us both.  And what _for_?  Jist
+for noth’n. Jist because we stood on our _rights_--that’s what for.  But
+I lay you ain’t a-goin’ to threaten nobody any more, Jim Turner.  Put
+_up_ that pistol, Bill.”
+
+Bill says:
+
+“I don’t want to, Jake Packard.  I’m for killin’ him--and didn’t he kill
+old Hatfield jist the same way--and don’t he deserve it?”
+
+“But I don’t _want_ him killed, and I’ve got my reasons for it.”
+
+“Bless yo’ heart for them words, Jake Packard!  I’ll never forgit you
+long’s I live!” says the man on the floor, sort of blubbering.
+
+Packard didn’t take no notice of that, but hung up his lantern on a nail
+and started towards where I was there in the dark, and motioned Bill
+to come.  I crawfished as fast as I could about two yards, but the boat
+slanted so that I couldn’t make very good time; so to keep from getting
+run over and catched I crawled into a stateroom on the upper side.
+ The man came a-pawing along in the dark, and when Packard got to my
+stateroom, he says:
+
+“Here--come in here.”
+
+And in he come, and Bill after him.  But before they got in I was up
+in the upper berth, cornered, and sorry I come.  Then they stood there,
+with their hands on the ledge of the berth, and talked.  I couldn’t see
+them, but I could tell where they was by the whisky they’d been having.
+ I was glad I didn’t drink whisky; but it wouldn’t made much difference
+anyway, because most of the time they couldn’t a treed me because I
+didn’t breathe.  I was too scared.  And, besides, a body _couldn’t_
+breathe and hear such talk.  They talked low and earnest.  Bill wanted
+to kill Turner.  He says:
+
+“He’s said he’ll tell, and he will.  If we was to give both our shares
+to him _now_ it wouldn’t make no difference after the row and the way
+we’ve served him.  Shore’s you’re born, he’ll turn State’s evidence; now
+you hear _me_.  I’m for putting him out of his troubles.”
+
+“So’m I,” says Packard, very quiet.
+
+“Blame it, I’d sorter begun to think you wasn’t.  Well, then, that’s all
+right.  Le’s go and do it.”
+
+“Hold on a minute; I hain’t had my say yit.  You listen to me.
+Shooting’s good, but there’s quieter ways if the thing’s _got_ to be
+done. But what I say is this:  it ain’t good sense to go court’n around
+after a halter if you can git at what you’re up to in some way that’s
+jist as good and at the same time don’t bring you into no resks.  Ain’t
+that so?”
+
+“You bet it is.  But how you goin’ to manage it this time?”
+
+“Well, my idea is this:  we’ll rustle around and gather up whatever
+pickins we’ve overlooked in the staterooms, and shove for shore and hide
+the truck. Then we’ll wait.  Now I say it ain’t a-goin’ to be more’n two
+hours befo’ this wrack breaks up and washes off down the river.  See?
+He’ll be drownded, and won’t have nobody to blame for it but his own
+self.  I reckon that’s a considerble sight better ‘n killin’ of him.
+ I’m unfavorable to killin’ a man as long as you can git aroun’ it; it
+ain’t good sense, it ain’t good morals.  Ain’t I right?”
+
+“Yes, I reck’n you are.  But s’pose she _don’t_ break up and wash off?”
+
+“Well, we can wait the two hours anyway and see, can’t we?”
+
+“All right, then; come along.”
+
+So they started, and I lit out, all in a cold sweat, and scrambled
+forward. It was dark as pitch there; but I said, in a kind of a coarse
+whisper, “Jim!” and he answered up, right at my elbow, with a sort of a
+moan, and I says:
+
+“Quick, Jim, it ain’t no time for fooling around and moaning; there’s a
+gang of murderers in yonder, and if we don’t hunt up their boat and set
+her drifting down the river so these fellows can’t get away from the
+wreck there’s one of ‘em going to be in a bad fix.  But if we find their
+boat we can put _all_ of ‘em in a bad fix--for the sheriff ‘ll get ‘em.
+Quick--hurry!  I’ll hunt the labboard side, you hunt the stabboard. You
+start at the raft, and--”
+
+“Oh, my lordy, lordy!  _raf’_?  Dey ain’ no raf’ no mo’; she done broke
+loose en gone I--en here we is!”
+
+
+
+
+CHAPTER XIII.
+
+WELL, I catched my breath and most fainted.  Shut up on a wreck with
+such a gang as that!  But it warn’t no time to be sentimentering.  We’d
+_got_ to find that boat now--had to have it for ourselves.  So we went
+a-quaking and shaking down the stabboard side, and slow work it was,
+too--seemed a week before we got to the stern.  No sign of a boat.  Jim
+said he didn’t believe he could go any further--so scared he hadn’t
+hardly any strength left, he said.  But I said, come on, if we get left
+on this wreck we are in a fix, sure.  So on we prowled again.  We struck
+for the stern of the texas, and found it, and then scrabbled along
+forwards on the skylight, hanging on from shutter to shutter, for the
+edge of the skylight was in the water.  When we got pretty close to the
+cross-hall door there was the skiff, sure enough!  I could just barely
+see her.  I felt ever so thankful.  In another second I would a been
+aboard of her, but just then the door opened.  One of the men stuck his
+head out only about a couple of foot from me, and I thought I was gone;
+but he jerked it in again, and says:
+
+“Heave that blame lantern out o’ sight, Bill!”
+
+He flung a bag of something into the boat, and then got in himself and
+set down.  It was Packard.  Then Bill _he_ come out and got in.  Packard
+says, in a low voice:
+
+“All ready--shove off!”
+
+I couldn’t hardly hang on to the shutters, I was so weak.  But Bill
+says:
+
+“Hold on--‘d you go through him?”
+
+“No.  Didn’t you?”
+
+“No.  So he’s got his share o’ the cash yet.”
+
+“Well, then, come along; no use to take truck and leave money.”
+
+“Say, won’t he suspicion what we’re up to?”
+
+“Maybe he won’t.  But we got to have it anyway. Come along.”
+
+So they got out and went in.
+
+The door slammed to because it was on the careened side; and in a half
+second I was in the boat, and Jim come tumbling after me.  I out with my
+knife and cut the rope, and away we went!
+
+We didn’t touch an oar, and we didn’t speak nor whisper, nor hardly even
+breathe.  We went gliding swift along, dead silent, past the tip of the
+paddle-box, and past the stern; then in a second or two more we was a
+hundred yards below the wreck, and the darkness soaked her up, every
+last sign of her, and we was safe, and knowed it.
+
+When we was three or four hundred yards down-stream we see the lantern
+show like a little spark at the texas door for a second, and we knowed
+by that that the rascals had missed their boat, and was beginning to
+understand that they was in just as much trouble now as Jim Turner was.
+
+Then Jim manned the oars, and we took out after our raft.  Now was the
+first time that I begun to worry about the men--I reckon I hadn’t
+had time to before.  I begun to think how dreadful it was, even for
+murderers, to be in such a fix.  I says to myself, there ain’t no
+telling but I might come to be a murderer myself yet, and then how would
+I like it?  So says I to Jim:
+
+“The first light we see we’ll land a hundred yards below it or above
+it, in a place where it’s a good hiding-place for you and the skiff, and
+then I’ll go and fix up some kind of a yarn, and get somebody to go for
+that gang and get them out of their scrape, so they can be hung when
+their time comes.”
+
+But that idea was a failure; for pretty soon it begun to storm again,
+and this time worse than ever.  The rain poured down, and never a light
+showed; everybody in bed, I reckon.  We boomed along down the river,
+watching for lights and watching for our raft.  After a long time the
+rain let up, but the clouds stayed, and the lightning kept whimpering,
+and by and by a flash showed us a black thing ahead, floating, and we
+made for it.
+
+It was the raft, and mighty glad was we to get aboard of it again.  We
+seen a light now away down to the right, on shore.  So I said I would
+go for it. The skiff was half full of plunder which that gang had stole
+there on the wreck.  We hustled it on to the raft in a pile, and I told
+Jim to float along down, and show a light when he judged he had gone
+about two mile, and keep it burning till I come; then I manned my oars
+and shoved for the light.  As I got down towards it three or four more
+showed--up on a hillside.  It was a village.  I closed in above the shore
+light, and laid on my oars and floated.  As I went by I see it was a
+lantern hanging on the jackstaff of a double-hull ferryboat.  I skimmed
+around for the watchman, a-wondering whereabouts he slept; and by and
+by I found him roosting on the bitts forward, with his head down between
+his knees.  I gave his shoulder two or three little shoves, and begun to
+cry.
+
+He stirred up in a kind of a startlish way; but when he see it was only
+me he took a good gap and stretch, and then he says:
+
+“Hello, what’s up?  Don’t cry, bub.  What’s the trouble?”
+
+I says:
+
+“Pap, and mam, and sis, and--”
+
+Then I broke down.  He says:
+
+“Oh, dang it now, _don’t_ take on so; we all has to have our troubles,
+and this ‘n ‘ll come out all right.  What’s the matter with ‘em?”
+
+“They’re--they’re--are you the watchman of the boat?”
+
+“Yes,” he says, kind of pretty-well-satisfied like.  “I’m the captain
+and the owner and the mate and the pilot and watchman and head
+deck-hand; and sometimes I’m the freight and passengers.  I ain’t as
+rich as old Jim Hornback, and I can’t be so blame’ generous and good
+to Tom, Dick, and Harry as what he is, and slam around money the way he
+does; but I’ve told him a many a time ‘t I wouldn’t trade places with
+him; for, says I, a sailor’s life’s the life for me, and I’m derned if
+_I’d_ live two mile out o’ town, where there ain’t nothing ever goin’
+on, not for all his spondulicks and as much more on top of it.  Says I--”
+
+I broke in and says:
+
+“They’re in an awful peck of trouble, and--”
+
+“_Who_ is?”
+
+“Why, pap and mam and sis and Miss Hooker; and if you’d take your
+ferryboat and go up there--”
+
+“Up where?  Where are they?”
+
+“On the wreck.”
+
+“What wreck?”
+
+“Why, there ain’t but one.”
+
+“What, you don’t mean the Walter Scott?”
+
+“Yes.”
+
+“Good land! what are they doin’ _there_, for gracious sakes?”
+
+“Well, they didn’t go there a-purpose.”
+
+“I bet they didn’t!  Why, great goodness, there ain’t no chance for ‘em
+if they don’t git off mighty quick!  Why, how in the nation did they
+ever git into such a scrape?”
+
+“Easy enough.  Miss Hooker was a-visiting up there to the town--”
+
+“Yes, Booth’s Landing--go on.”
+
+“She was a-visiting there at Booth’s Landing, and just in the edge of
+the evening she started over with her nigger woman in the horse-ferry
+to stay all night at her friend’s house, Miss What-you-may-call-her I
+disremember her name--and they lost their steering-oar, and swung
+around and went a-floating down, stern first, about two mile, and
+saddle-baggsed on the wreck, and the ferryman and the nigger woman and
+the horses was all lost, but Miss Hooker she made a grab and got aboard
+the wreck.  Well, about an hour after dark we come along down in our
+trading-scow, and it was so dark we didn’t notice the wreck till we was
+right on it; and so _we_ saddle-baggsed; but all of us was saved but
+Bill Whipple--and oh, he _was_ the best cretur!--I most wish ‘t it had
+been me, I do.”
+
+“My George!  It’s the beatenest thing I ever struck.  And _then_ what
+did you all do?”
+
+“Well, we hollered and took on, but it’s so wide there we couldn’t
+make nobody hear.  So pap said somebody got to get ashore and get help
+somehow. I was the only one that could swim, so I made a dash for it,
+and Miss Hooker she said if I didn’t strike help sooner, come here and
+hunt up her uncle, and he’d fix the thing.  I made the land about a mile
+below, and been fooling along ever since, trying to get people to do
+something, but they said, ‘What, in such a night and such a current?
+There ain’t no sense in it; go for the steam ferry.’  Now if you’ll go
+and--”
+
+“By Jackson, I’d _like_ to, and, blame it, I don’t know but I will; but
+who in the dingnation’s a-going’ to _pay_ for it?  Do you reckon your
+pap--”
+
+“Why _that’s_ all right.  Miss Hooker she tole me, _particular_, that
+her uncle Hornback--”
+
+“Great guns! is _he_ her uncle?  Looky here, you break for that light
+over yonder-way, and turn out west when you git there, and about a
+quarter of a mile out you’ll come to the tavern; tell ‘em to dart you
+out to Jim Hornback’s, and he’ll foot the bill.  And don’t you fool
+around any, because he’ll want to know the news.  Tell him I’ll have
+his niece all safe before he can get to town.  Hump yourself, now; I’m
+a-going up around the corner here to roust out my engineer.”
+
+I struck for the light, but as soon as he turned the corner I went back
+and got into my skiff and bailed her out, and then pulled up shore in
+the easy water about six hundred yards, and tucked myself in among
+some woodboats; for I couldn’t rest easy till I could see the ferryboat
+start. But take it all around, I was feeling ruther comfortable on
+accounts of taking all this trouble for that gang, for not many would
+a done it.  I wished the widow knowed about it.  I judged she would be
+proud of me for helping these rapscallions, because rapscallions and
+dead beats is the kind the widow and good people takes the most interest
+in.
+
+Well, before long here comes the wreck, dim and dusky, sliding along
+down! A kind of cold shiver went through me, and then I struck out for
+her.  She was very deep, and I see in a minute there warn’t much chance
+for anybody being alive in her.  I pulled all around her and hollered
+a little, but there wasn’t any answer; all dead still.  I felt a little
+bit heavy-hearted about the gang, but not much, for I reckoned if they
+could stand it I could.
+
+Then here comes the ferryboat; so I shoved for the middle of the river
+on a long down-stream slant; and when I judged I was out of eye-reach
+I laid on my oars, and looked back and see her go and smell around the
+wreck for Miss Hooker’s remainders, because the captain would know her
+uncle Hornback would want them; and then pretty soon the ferryboat give
+it up and went for the shore, and I laid into my work and went a-booming
+down the river.
+
+It did seem a powerful long time before Jim’s light showed up; and when
+it did show it looked like it was a thousand mile off.  By the time I
+got there the sky was beginning to get a little gray in the east; so we
+struck for an island, and hid the raft, and sunk the skiff, and turned
+in and slept like dead people.
+
+
+
+
+CHAPTER XIV.
+
+BY and by, when we got up, we turned over the truck the gang had stole
+off of the wreck, and found boots, and blankets, and clothes, and all
+sorts of other things, and a lot of books, and a spyglass, and three
+boxes of seegars.  We hadn’t ever been this rich before in neither of
+our lives.  The seegars was prime.  We laid off all the afternoon in the
+woods talking, and me reading the books, and having a general good
+time. I told Jim all about what happened inside the wreck and at the
+ferryboat, and I said these kinds of things was adventures; but he said
+he didn’t want no more adventures.  He said that when I went in the
+texas and he crawled back to get on the raft and found her gone he
+nearly died, because he judged it was all up with _him_ anyway it could
+be fixed; for if he didn’t get saved he would get drownded; and if he
+did get saved, whoever saved him would send him back home so as to get
+the reward, and then Miss Watson would sell him South, sure.  Well, he
+was right; he was most always right; he had an uncommon level head for a
+nigger.
+
+I read considerable to Jim about kings and dukes and earls and such, and
+how gaudy they dressed, and how much style they put on, and called each
+other your majesty, and your grace, and your lordship, and so on, ‘stead
+of mister; and Jim’s eyes bugged out, and he was interested.  He says:
+
+“I didn’ know dey was so many un um.  I hain’t hearn ‘bout none un um,
+skasely, but ole King Sollermun, onless you counts dem kings dat’s in a
+pack er k’yards.  How much do a king git?”
+
+“Get?”  I says; “why, they get a thousand dollars a month if they want
+it; they can have just as much as they want; everything belongs to
+them.”
+
+“_Ain’_ dat gay?  En what dey got to do, Huck?”
+
+“_They_ don’t do nothing!  Why, how you talk! They just set around.”
+
+“No; is dat so?”
+
+“Of course it is.  They just set around--except, maybe, when there’s a
+war; then they go to the war.  But other times they just lazy around; or
+go hawking--just hawking and sp--Sh!--d’ you hear a noise?”
+
+We skipped out and looked; but it warn’t nothing but the flutter of a
+steamboat’s wheel away down, coming around the point; so we come back.
+
+“Yes,” says I, “and other times, when things is dull, they fuss with the
+parlyment; and if everybody don’t go just so he whacks their heads off.
+But mostly they hang round the harem.”
+
+“Roun’ de which?”
+
+“Harem.”
+
+“What’s de harem?”
+
+“The place where he keeps his wives.  Don’t you know about the harem?
+Solomon had one; he had about a million wives.”
+
+“Why, yes, dat’s so; I--I’d done forgot it.  A harem’s a bo’d’n-house, I
+reck’n.  Mos’ likely dey has rackety times in de nussery.  En I reck’n
+de wives quarrels considable; en dat ‘crease de racket.  Yit dey say
+Sollermun de wises’ man dat ever live’.  I doan’ take no stock in
+dat. Bekase why: would a wise man want to live in de mids’ er sich a
+blim-blammin’ all de time?  No--‘deed he wouldn’t.  A wise man ‘ud take
+en buil’ a biler-factry; en den he could shet _down_ de biler-factry
+when he want to res’.”
+
+“Well, but he _was_ the wisest man, anyway; because the widow she told
+me so, her own self.”
+
+“I doan k’yer what de widder say, he _warn’t_ no wise man nuther.  He
+had some er de dad-fetchedes’ ways I ever see.  Does you know ‘bout dat
+chile dat he ‘uz gwyne to chop in two?”
+
+“Yes, the widow told me all about it.”
+
+“_Well_, den!  Warn’ dat de beatenes’ notion in de worl’?  You jes’
+take en look at it a minute.  Dah’s de stump, dah--dat’s one er de women;
+heah’s you--dat’s de yuther one; I’s Sollermun; en dish yer dollar bill’s
+de chile.  Bofe un you claims it.  What does I do?  Does I shin aroun’
+mongs’ de neighbors en fine out which un you de bill _do_ b’long to, en
+han’ it over to de right one, all safe en soun’, de way dat anybody dat
+had any gumption would?  No; I take en whack de bill in _two_, en give
+half un it to you, en de yuther half to de yuther woman.  Dat’s de way
+Sollermun was gwyne to do wid de chile.  Now I want to ast you:  what’s
+de use er dat half a bill?--can’t buy noth’n wid it.  En what use is a
+half a chile?  I wouldn’ give a dern for a million un um.”
+
+“But hang it, Jim, you’ve clean missed the point--blame it, you’ve missed
+it a thousand mile.”
+
+“Who?  Me?  Go ‘long.  Doan’ talk to me ‘bout yo’ pints.  I reck’n I
+knows sense when I sees it; en dey ain’ no sense in sich doin’s as
+dat. De ‘spute warn’t ‘bout a half a chile, de ‘spute was ‘bout a whole
+chile; en de man dat think he kin settle a ‘spute ‘bout a whole chile
+wid a half a chile doan’ know enough to come in out’n de rain.  Doan’
+talk to me ‘bout Sollermun, Huck, I knows him by de back.”
+
+“But I tell you you don’t get the point.”
+
+“Blame de point!  I reck’n I knows what I knows.  En mine you, de _real_
+pint is down furder--it’s down deeper.  It lays in de way Sollermun was
+raised.  You take a man dat’s got on’y one or two chillen; is dat man
+gwyne to be waseful o’ chillen?  No, he ain’t; he can’t ‘ford it.  _He_
+know how to value ‘em.  But you take a man dat’s got ‘bout five million
+chillen runnin’ roun’ de house, en it’s diffunt.  _He_ as soon chop a
+chile in two as a cat. Dey’s plenty mo’.  A chile er two, mo’ er less,
+warn’t no consekens to Sollermun, dad fatch him!”
+
+I never see such a nigger.  If he got a notion in his head once, there
+warn’t no getting it out again.  He was the most down on Solomon of
+any nigger I ever see.  So I went to talking about other kings, and let
+Solomon slide.  I told about Louis Sixteenth that got his head cut off
+in France long time ago; and about his little boy the dolphin, that
+would a been a king, but they took and shut him up in jail, and some say
+he died there.
+
+“Po’ little chap.”
+
+“But some says he got out and got away, and come to America.”
+
+“Dat’s good!  But he’ll be pooty lonesome--dey ain’ no kings here, is
+dey, Huck?”
+
+“No.”
+
+“Den he cain’t git no situation.  What he gwyne to do?”
+
+“Well, I don’t know.  Some of them gets on the police, and some of them
+learns people how to talk French.”
+
+“Why, Huck, doan’ de French people talk de same way we does?”
+
+“_No_, Jim; you couldn’t understand a word they said--not a single word.”
+
+“Well, now, I be ding-busted!  How do dat come?”
+
+“I don’t know; but it’s so.  I got some of their jabber out of a book.
+S’pose a man was to come to you and say Polly-voo-franzy--what would you
+think?”
+
+“I wouldn’ think nuff’n; I’d take en bust him over de head--dat is, if he
+warn’t white.  I wouldn’t ‘low no nigger to call me dat.”
+
+“Shucks, it ain’t calling you anything.  It’s only saying, do you know
+how to talk French?”
+
+“Well, den, why couldn’t he _say_ it?”
+
+“Why, he _is_ a-saying it.  That’s a Frenchman’s _way_ of saying it.”
+
+“Well, it’s a blame ridicklous way, en I doan’ want to hear no mo’ ‘bout
+it.  Dey ain’ no sense in it.”
+
+“Looky here, Jim; does a cat talk like we do?”
+
+“No, a cat don’t.”
+
+“Well, does a cow?”
+
+“No, a cow don’t, nuther.”
+
+“Does a cat talk like a cow, or a cow talk like a cat?”
+
+“No, dey don’t.”
+
+“It’s natural and right for ‘em to talk different from each other, ain’t
+it?”
+
+“Course.”
+
+“And ain’t it natural and right for a cat and a cow to talk different
+from _us_?”
+
+“Why, mos’ sholy it is.”
+
+“Well, then, why ain’t it natural and right for a _Frenchman_ to talk
+different from us?  You answer me that.”
+
+“Is a cat a man, Huck?”
+
+“No.”
+
+“Well, den, dey ain’t no sense in a cat talkin’ like a man.  Is a cow a
+man?--er is a cow a cat?”
+
+“No, she ain’t either of them.”
+
+“Well, den, she ain’t got no business to talk like either one er the
+yuther of ‘em.  Is a Frenchman a man?”
+
+“Yes.”
+
+“_Well_, den!  Dad blame it, why doan’ he _talk_ like a man?  You answer
+me _dat_!”
+
+I see it warn’t no use wasting words--you can’t learn a nigger to argue.
+So I quit.
+
+
+
+
+CHAPTER XV.
+
+WE judged that three nights more would fetch us to Cairo, at the bottom
+of Illinois, where the Ohio River comes in, and that was what we was
+after.  We would sell the raft and get on a steamboat and go way up the
+Ohio amongst the free States, and then be out of trouble.
+
+Well, the second night a fog begun to come on, and we made for a towhead
+to tie to, for it wouldn’t do to try to run in a fog; but when I paddled
+ahead in the canoe, with the line to make fast, there warn’t anything
+but little saplings to tie to.  I passed the line around one of them
+right on the edge of the cut bank, but there was a stiff current, and
+the raft come booming down so lively she tore it out by the roots and
+away she went.  I see the fog closing down, and it made me so sick and
+scared I couldn’t budge for most a half a minute it seemed to me--and
+then there warn’t no raft in sight; you couldn’t see twenty yards.  I
+jumped into the canoe and run back to the stern, and grabbed the paddle
+and set her back a stroke.  But she didn’t come.  I was in such a hurry
+I hadn’t untied her.  I got up and tried to untie her, but I was so
+excited my hands shook so I couldn’t hardly do anything with them.
+
+As soon as I got started I took out after the raft, hot and heavy, right
+down the towhead.  That was all right as far as it went, but the towhead
+warn’t sixty yards long, and the minute I flew by the foot of it I shot
+out into the solid white fog, and hadn’t no more idea which way I was
+going than a dead man.
+
+Thinks I, it won’t do to paddle; first I know I’ll run into the bank
+or a towhead or something; I got to set still and float, and yet it’s
+mighty fidgety business to have to hold your hands still at such a time.
+ I whooped and listened.  Away down there somewheres I hears a small
+whoop, and up comes my spirits.  I went tearing after it, listening
+sharp to hear it again.  The next time it come I see I warn’t heading
+for it, but heading away to the right of it.  And the next time I was
+heading away to the left of it--and not gaining on it much either, for
+I was flying around, this way and that and t’other, but it was going
+straight ahead all the time.
+
+I did wish the fool would think to beat a tin pan, and beat it all the
+time, but he never did, and it was the still places between the whoops
+that was making the trouble for me.  Well, I fought along, and directly
+I hears the whoop _behind_ me.  I was tangled good now.  That was
+somebody else’s whoop, or else I was turned around.
+
+I throwed the paddle down.  I heard the whoop again; it was behind me
+yet, but in a different place; it kept coming, and kept changing its
+place, and I kept answering, till by and by it was in front of me again,
+and I knowed the current had swung the canoe’s head down-stream, and I
+was all right if that was Jim and not some other raftsman hollering.
+ I couldn’t tell nothing about voices in a fog, for nothing don’t look
+natural nor sound natural in a fog.
+
+The whooping went on, and in about a minute I come a-booming down on a
+cut bank with smoky ghosts of big trees on it, and the current throwed
+me off to the left and shot by, amongst a lot of snags that fairly
+roared, the currrent was tearing by them so swift.
+
+In another second or two it was solid white and still again.  I set
+perfectly still then, listening to my heart thump, and I reckon I didn’t
+draw a breath while it thumped a hundred.
+
+I just give up then.  I knowed what the matter was.  That cut bank
+was an island, and Jim had gone down t’other side of it.  It warn’t no
+towhead that you could float by in ten minutes.  It had the big timber
+of a regular island; it might be five or six miles long and more than
+half a mile wide.
+
+I kept quiet, with my ears cocked, about fifteen minutes, I reckon.  I
+was floating along, of course, four or five miles an hour; but you don’t
+ever think of that.  No, you _feel_ like you are laying dead still on
+the water; and if a little glimpse of a snag slips by you don’t think to
+yourself how fast _you’re_ going, but you catch your breath and think,
+my! how that snag’s tearing along.  If you think it ain’t dismal and
+lonesome out in a fog that way by yourself in the night, you try it
+once--you’ll see.
+
+Next, for about a half an hour, I whoops now and then; at last I hears
+the answer a long ways off, and tries to follow it, but I couldn’t do
+it, and directly I judged I’d got into a nest of towheads, for I had
+little dim glimpses of them on both sides of me--sometimes just a narrow
+channel between, and some that I couldn’t see I knowed was there because
+I’d hear the wash of the current against the old dead brush and trash
+that hung over the banks.  Well, I warn’t long loosing the whoops down
+amongst the towheads; and I only tried to chase them a little while,
+anyway, because it was worse than chasing a Jack-o’-lantern.  You never
+knowed a sound dodge around so, and swap places so quick and so much.
+
+I had to claw away from the bank pretty lively four or five times, to
+keep from knocking the islands out of the river; and so I judged the
+raft must be butting into the bank every now and then, or else it would
+get further ahead and clear out of hearing--it was floating a little
+faster than what I was.
+
+Well, I seemed to be in the open river again by and by, but I couldn’t
+hear no sign of a whoop nowheres.  I reckoned Jim had fetched up on a
+snag, maybe, and it was all up with him.  I was good and tired, so I
+laid down in the canoe and said I wouldn’t bother no more.  I didn’t
+want to go to sleep, of course; but I was so sleepy I couldn’t help it;
+so I thought I would take jest one little cat-nap.
+
+But I reckon it was more than a cat-nap, for when I waked up the stars
+was shining bright, the fog was all gone, and I was spinning down a
+big bend stern first.  First I didn’t know where I was; I thought I was
+dreaming; and when things began to come back to me they seemed to come
+up dim out of last week.
+
+It was a monstrous big river here, with the tallest and the thickest
+kind of timber on both banks; just a solid wall, as well as I could see
+by the stars.  I looked away down-stream, and seen a black speck on the
+water. I took after it; but when I got to it it warn’t nothing but a
+couple of sawlogs made fast together.  Then I see another speck, and
+chased that; then another, and this time I was right.  It was the raft.
+
+When I got to it Jim was setting there with his head down between his
+knees, asleep, with his right arm hanging over the steering-oar.  The
+other oar was smashed off, and the raft was littered up with leaves and
+branches and dirt.  So she’d had a rough time.
+
+I made fast and laid down under Jim’s nose on the raft, and began to
+gap, and stretch my fists out against Jim, and says:
+
+“Hello, Jim, have I been asleep?  Why didn’t you stir me up?”
+
+“Goodness gracious, is dat you, Huck?  En you ain’ dead--you ain’
+drownded--you’s back agin?  It’s too good for true, honey, it’s too good
+for true. Lemme look at you chile, lemme feel o’ you.  No, you ain’
+dead! you’s back agin, ‘live en soun’, jis de same ole Huck--de same ole
+Huck, thanks to goodness!”
+
+“What’s the matter with you, Jim?  You been a-drinking?”
+
+“Drinkin’?  Has I ben a-drinkin’?  Has I had a chance to be a-drinkin’?”
+
+“Well, then, what makes you talk so wild?”
+
+“How does I talk wild?”
+
+“_How_?  Why, hain’t you been talking about my coming back, and all that
+stuff, as if I’d been gone away?”
+
+“Huck--Huck Finn, you look me in de eye; look me in de eye.  _Hain’t_ you
+ben gone away?”
+
+“Gone away?  Why, what in the nation do you mean?  I hain’t been gone
+anywheres.  Where would I go to?”
+
+“Well, looky here, boss, dey’s sumf’n wrong, dey is.  Is I _me_, or who
+_is_ I? Is I heah, or whah _is_ I?  Now dat’s what I wants to know.”
+
+“Well, I think you’re here, plain enough, but I think you’re a
+tangle-headed old fool, Jim.”
+
+“I is, is I?  Well, you answer me dis:  Didn’t you tote out de line in
+de canoe fer to make fas’ to de tow-head?”
+
+“No, I didn’t.  What tow-head?  I hain’t see no tow-head.”
+
+“You hain’t seen no towhead?  Looky here, didn’t de line pull loose en
+de raf’ go a-hummin’ down de river, en leave you en de canoe behine in
+de fog?”
+
+“What fog?”
+
+“Why, de fog!--de fog dat’s been aroun’ all night.  En didn’t you whoop,
+en didn’t I whoop, tell we got mix’ up in de islands en one un us got
+los’ en t’other one was jis’ as good as los’, ‘kase he didn’ know whah
+he wuz? En didn’t I bust up agin a lot er dem islands en have a turrible
+time en mos’ git drownded?  Now ain’ dat so, boss--ain’t it so?  You
+answer me dat.”
+
+“Well, this is too many for me, Jim.  I hain’t seen no fog, nor no
+islands, nor no troubles, nor nothing.  I been setting here talking with
+you all night till you went to sleep about ten minutes ago, and I reckon
+I done the same.  You couldn’t a got drunk in that time, so of course
+you’ve been dreaming.”
+
+“Dad fetch it, how is I gwyne to dream all dat in ten minutes?”
+
+“Well, hang it all, you did dream it, because there didn’t any of it
+happen.”
+
+“But, Huck, it’s all jis’ as plain to me as--”
+
+“It don’t make no difference how plain it is; there ain’t nothing in it.
+I know, because I’ve been here all the time.”
+
+Jim didn’t say nothing for about five minutes, but set there studying
+over it.  Then he says:
+
+“Well, den, I reck’n I did dream it, Huck; but dog my cats ef it ain’t
+de powerfullest dream I ever see.  En I hain’t ever had no dream b’fo’
+dat’s tired me like dis one.”
+
+“Oh, well, that’s all right, because a dream does tire a body like
+everything sometimes.  But this one was a staving dream; tell me all
+about it, Jim.”
+
+So Jim went to work and told me the whole thing right through, just as
+it happened, only he painted it up considerable.  Then he said he must
+start in and “‘terpret” it, because it was sent for a warning.  He said
+the first towhead stood for a man that would try to do us some good, but
+the current was another man that would get us away from him.  The whoops
+was warnings that would come to us every now and then, and if we didn’t
+try hard to make out to understand them they’d just take us into bad
+luck, ‘stead of keeping us out of it.  The lot of towheads was troubles
+we was going to get into with quarrelsome people and all kinds of mean
+folks, but if we minded our business and didn’t talk back and aggravate
+them, we would pull through and get out of the fog and into the big
+clear river, which was the free States, and wouldn’t have no more
+trouble.
+
+It had clouded up pretty dark just after I got on to the raft, but it
+was clearing up again now.
+
+“Oh, well, that’s all interpreted well enough as far as it goes, Jim,” I
+says; “but what does _these_ things stand for?”
+
+It was the leaves and rubbish on the raft and the smashed oar.  You
+could see them first-rate now.
+
+Jim looked at the trash, and then looked at me, and back at the trash
+again.  He had got the dream fixed so strong in his head that he
+couldn’t seem to shake it loose and get the facts back into its place
+again right away.  But when he did get the thing straightened around he
+looked at me steady without ever smiling, and says:
+
+“What do dey stan’ for?  I’se gwyne to tell you.  When I got all wore
+out wid work, en wid de callin’ for you, en went to sleep, my heart wuz
+mos’ broke bekase you wuz los’, en I didn’ k’yer no’ mo’ what become
+er me en de raf’.  En when I wake up en fine you back agin, all safe
+en soun’, de tears come, en I could a got down on my knees en kiss yo’
+foot, I’s so thankful. En all you wuz thinkin’ ‘bout wuz how you could
+make a fool uv ole Jim wid a lie.  Dat truck dah is _trash_; en trash
+is what people is dat puts dirt on de head er dey fren’s en makes ‘em
+ashamed.”
+
+Then he got up slow and walked to the wigwam, and went in there without
+saying anything but that.  But that was enough.  It made me feel so mean
+I could almost kissed _his_ foot to get him to take it back.
+
+It was fifteen minutes before I could work myself up to go and humble
+myself to a nigger; but I done it, and I warn’t ever sorry for it
+afterwards, neither.  I didn’t do him no more mean tricks, and I
+wouldn’t done that one if I’d a knowed it would make him feel that way.
+
+
+
+
+CHAPTER XVI.
+
+WE slept most all day, and started out at night, a little ways behind a
+monstrous long raft that was as long going by as a procession.  She had
+four long sweeps at each end, so we judged she carried as many as thirty
+men, likely.  She had five big wigwams aboard, wide apart, and an open
+camp fire in the middle, and a tall flag-pole at each end.  There was a
+power of style about her.  It _amounted_ to something being a raftsman
+on such a craft as that.
+
+We went drifting down into a big bend, and the night clouded up and got
+hot.  The river was very wide, and was walled with solid timber on
+both sides; you couldn’t see a break in it hardly ever, or a light.  We
+talked about Cairo, and wondered whether we would know it when we got to
+it.  I said likely we wouldn’t, because I had heard say there warn’t but
+about a dozen houses there, and if they didn’t happen to have them lit
+up, how was we going to know we was passing a town?  Jim said if the two
+big rivers joined together there, that would show.  But I said maybe
+we might think we was passing the foot of an island and coming into the
+same old river again. That disturbed Jim--and me too.  So the question
+was, what to do?  I said, paddle ashore the first time a light showed,
+and tell them pap was behind, coming along with a trading-scow, and
+was a green hand at the business, and wanted to know how far it was to
+Cairo.  Jim thought it was a good idea, so we took a smoke on it and
+waited.
+
+There warn’t nothing to do now but to look out sharp for the town, and
+not pass it without seeing it.  He said he’d be mighty sure to see it,
+because he’d be a free man the minute he seen it, but if he missed it
+he’d be in a slave country again and no more show for freedom.  Every
+little while he jumps up and says:
+
+“Dah she is?”
+
+But it warn’t.  It was Jack-o’-lanterns, or lightning bugs; so he set
+down again, and went to watching, same as before.  Jim said it made him
+all over trembly and feverish to be so close to freedom.  Well, I can
+tell you it made me all over trembly and feverish, too, to hear him,
+because I begun to get it through my head that he _was_ most free--and
+who was to blame for it?  Why, _me_.  I couldn’t get that out of my
+conscience, no how nor no way. It got to troubling me so I couldn’t
+rest; I couldn’t stay still in one place.  It hadn’t ever come home to
+me before, what this thing was that I was doing.  But now it did; and it
+stayed with me, and scorched me more and more.  I tried to make out to
+myself that I warn’t to blame, because I didn’t run Jim off from his
+rightful owner; but it warn’t no use, conscience up and says, every
+time, “But you knowed he was running for his freedom, and you could a
+paddled ashore and told somebody.”  That was so--I couldn’t get around
+that noway.  That was where it pinched.  Conscience says to me, “What
+had poor Miss Watson done to you that you could see her nigger go off
+right under your eyes and never say one single word?  What did that poor
+old woman do to you that you could treat her so mean?  Why, she tried to
+learn you your book, she tried to learn you your manners, she tried to
+be good to you every way she knowed how.  _That’s_ what she done.”
+
+I got to feeling so mean and so miserable I most wished I was dead.  I
+fidgeted up and down the raft, abusing myself to myself, and Jim was
+fidgeting up and down past me.  We neither of us could keep still.
+ Every time he danced around and says, “Dah’s Cairo!” it went through me
+like a shot, and I thought if it _was_ Cairo I reckoned I would die of
+miserableness.
+
+Jim talked out loud all the time while I was talking to myself.  He was
+saying how the first thing he would do when he got to a free State he
+would go to saving up money and never spend a single cent, and when he
+got enough he would buy his wife, which was owned on a farm close to
+where Miss Watson lived; and then they would both work to buy the
+two children, and if their master wouldn’t sell them, they’d get an
+Ab’litionist to go and steal them.
+
+It most froze me to hear such talk.  He wouldn’t ever dared to talk such
+talk in his life before.  Just see what a difference it made in him the
+minute he judged he was about free.  It was according to the old saying,
+“Give a nigger an inch and he’ll take an ell.”  Thinks I, this is what
+comes of my not thinking.  Here was this nigger, which I had as good
+as helped to run away, coming right out flat-footed and saying he would
+steal his children--children that belonged to a man I didn’t even know; a
+man that hadn’t ever done me no harm.
+
+I was sorry to hear Jim say that, it was such a lowering of him.  My
+conscience got to stirring me up hotter than ever, until at last I says
+to it, “Let up on me--it ain’t too late yet--I’ll paddle ashore at the
+first light and tell.”  I felt easy and happy and light as a feather
+right off.  All my troubles was gone.  I went to looking out sharp for a
+light, and sort of singing to myself.  By and by one showed.  Jim sings
+out:
+
+“We’s safe, Huck, we’s safe!  Jump up and crack yo’ heels!  Dat’s de
+good ole Cairo at las’, I jis knows it!”
+
+I says:
+
+“I’ll take the canoe and go and see, Jim.  It mightn’t be, you know.”
+
+He jumped and got the canoe ready, and put his old coat in the bottom
+for me to set on, and give me the paddle; and as I shoved off, he says:
+
+“Pooty soon I’ll be a-shout’n’ for joy, en I’ll say, it’s all on
+accounts o’ Huck; I’s a free man, en I couldn’t ever ben free ef it
+hadn’ ben for Huck; Huck done it.  Jim won’t ever forgit you, Huck;
+you’s de bes’ fren’ Jim’s ever had; en you’s de _only_ fren’ ole Jim’s
+got now.”
+
+I was paddling off, all in a sweat to tell on him; but when he says
+this, it seemed to kind of take the tuck all out of me.  I went along
+slow then, and I warn’t right down certain whether I was glad I started
+or whether I warn’t.  When I was fifty yards off, Jim says:
+
+“Dah you goes, de ole true Huck; de on’y white genlman dat ever kep’ his
+promise to ole Jim.”
+
+Well, I just felt sick.  But I says, I _got_ to do it--I can’t get _out_
+of it.  Right then along comes a skiff with two men in it with guns, and
+they stopped and I stopped.  One of them says:
+
+“What’s that yonder?”
+
+“A piece of a raft,” I says.
+
+“Do you belong on it?”
+
+“Yes, sir.”
+
+“Any men on it?”
+
+“Only one, sir.”
+
+“Well, there’s five niggers run off to-night up yonder, above the head
+of the bend.  Is your man white or black?”
+
+I didn’t answer up prompt.  I tried to, but the words wouldn’t come. I
+tried for a second or two to brace up and out with it, but I warn’t man
+enough--hadn’t the spunk of a rabbit.  I see I was weakening; so I just
+give up trying, and up and says:
+
+“He’s white.”
+
+“I reckon we’ll go and see for ourselves.”
+
+“I wish you would,” says I, “because it’s pap that’s there, and maybe
+you’d help me tow the raft ashore where the light is.  He’s sick--and so
+is mam and Mary Ann.”
+
+“Oh, the devil! we’re in a hurry, boy.  But I s’pose we’ve got to.
+ Come, buckle to your paddle, and let’s get along.”
+
+I buckled to my paddle and they laid to their oars.  When we had made a
+stroke or two, I says:
+
+“Pap’ll be mighty much obleeged to you, I can tell you.  Everybody goes
+away when I want them to help me tow the raft ashore, and I can’t do it
+by myself.”
+
+“Well, that’s infernal mean.  Odd, too.  Say, boy, what’s the matter
+with your father?”
+
+“It’s the--a--the--well, it ain’t anything much.”
+
+They stopped pulling.  It warn’t but a mighty little ways to the raft
+now. One says:
+
+“Boy, that’s a lie.  What _is_ the matter with your pap?  Answer up
+square now, and it’ll be the better for you.”
+
+“I will, sir, I will, honest--but don’t leave us, please.  It’s
+the--the--Gentlemen, if you’ll only pull ahead, and let me heave you the
+headline, you won’t have to come a-near the raft--please do.”
+
+“Set her back, John, set her back!” says one.  They backed water.  “Keep
+away, boy--keep to looard.  Confound it, I just expect the wind has
+blowed it to us.  Your pap’s got the small-pox, and you know it precious
+well.  Why didn’t you come out and say so?  Do you want to spread it all
+over?”
+
+“Well,” says I, a-blubbering, “I’ve told everybody before, and they just
+went away and left us.”
+
+“Poor devil, there’s something in that.  We are right down sorry for
+you, but we--well, hang it, we don’t want the small-pox, you see.  Look
+here, I’ll tell you what to do.  Don’t you try to land by yourself, or
+you’ll smash everything to pieces.  You float along down about twenty
+miles, and you’ll come to a town on the left-hand side of the river.  It
+will be long after sun-up then, and when you ask for help you tell them
+your folks are all down with chills and fever.  Don’t be a fool again,
+and let people guess what is the matter.  Now we’re trying to do you a
+kindness; so you just put twenty miles between us, that’s a good boy.
+ It wouldn’t do any good to land yonder where the light is--it’s only a
+wood-yard. Say, I reckon your father’s poor, and I’m bound to say he’s
+in pretty hard luck.  Here, I’ll put a twenty-dollar gold piece on this
+board, and you get it when it floats by.  I feel mighty mean to leave
+you; but my kingdom! it won’t do to fool with small-pox, don’t you see?”
+
+“Hold on, Parker,” says the other man, “here’s a twenty to put on the
+board for me.  Good-bye, boy; you do as Mr. Parker told you, and you’ll
+be all right.”
+
+“That’s so, my boy--good-bye, good-bye.  If you see any runaway niggers
+you get help and nab them, and you can make some money by it.”
+
+“Good-bye, sir,” says I; “I won’t let no runaway niggers get by me if I
+can help it.”
+
+They went off and I got aboard the raft, feeling bad and low, because I
+knowed very well I had done wrong, and I see it warn’t no use for me
+to try to learn to do right; a body that don’t get _started_ right when
+he’s little ain’t got no show--when the pinch comes there ain’t nothing
+to back him up and keep him to his work, and so he gets beat.  Then I
+thought a minute, and says to myself, hold on; s’pose you’d a done right
+and give Jim up, would you felt better than what you do now?  No, says
+I, I’d feel bad--I’d feel just the same way I do now.  Well, then, says
+I, what’s the use you learning to do right when it’s troublesome to do
+right and ain’t no trouble to do wrong, and the wages is just the same?
+ I was stuck.  I couldn’t answer that.  So I reckoned I wouldn’t bother
+no more about it, but after this always do whichever come handiest at
+the time.
+
+I went into the wigwam; Jim warn’t there.  I looked all around; he
+warn’t anywhere.  I says:
+
+“Jim!”
+
+“Here I is, Huck.  Is dey out o’ sight yit?  Don’t talk loud.”
+
+He was in the river under the stern oar, with just his nose out.  I told
+him they were out of sight, so he come aboard.  He says:
+
+“I was a-listenin’ to all de talk, en I slips into de river en was gwyne
+to shove for sho’ if dey come aboard.  Den I was gwyne to swim to de
+raf’ agin when dey was gone.  But lawsy, how you did fool ‘em, Huck!
+ Dat _wuz_ de smartes’ dodge!  I tell you, chile, I’spec it save’ ole
+Jim--ole Jim ain’t going to forgit you for dat, honey.”
+
+Then we talked about the money.  It was a pretty good raise--twenty
+dollars apiece.  Jim said we could take deck passage on a steamboat
+now, and the money would last us as far as we wanted to go in the free
+States. He said twenty mile more warn’t far for the raft to go, but he
+wished we was already there.
+
+Towards daybreak we tied up, and Jim was mighty particular about hiding
+the raft good.  Then he worked all day fixing things in bundles, and
+getting all ready to quit rafting.
+
+That night about ten we hove in sight of the lights of a town away down
+in a left-hand bend.
+
+I went off in the canoe to ask about it.  Pretty soon I found a man out
+in the river with a skiff, setting a trot-line.  I ranged up and says:
+
+“Mister, is that town Cairo?”
+
+“Cairo? no.  You must be a blame’ fool.”
+
+“What town is it, mister?”
+
+“If you want to know, go and find out.  If you stay here botherin’
+around me for about a half a minute longer you’ll get something you
+won’t want.”
+
+I paddled to the raft.  Jim was awful disappointed, but I said never
+mind, Cairo would be the next place, I reckoned.
+
+We passed another town before daylight, and I was going out again; but
+it was high ground, so I didn’t go.  No high ground about Cairo, Jim
+said. I had forgot it.  We laid up for the day on a towhead tolerable
+close to the left-hand bank.  I begun to suspicion something.  So did
+Jim.  I says:
+
+“Maybe we went by Cairo in the fog that night.”
+
+He says:
+
+“Doan’ le’s talk about it, Huck.  Po’ niggers can’t have no luck.  I
+awluz ‘spected dat rattlesnake-skin warn’t done wid its work.”
+
+“I wish I’d never seen that snake-skin, Jim--I do wish I’d never laid
+eyes on it.”
+
+“It ain’t yo’ fault, Huck; you didn’ know.  Don’t you blame yo’self
+‘bout it.”
+
+When it was daylight, here was the clear Ohio water inshore, sure
+enough, and outside was the old regular Muddy!  So it was all up with
+Cairo.
+
+We talked it all over.  It wouldn’t do to take to the shore; we couldn’t
+take the raft up the stream, of course.  There warn’t no way but to wait
+for dark, and start back in the canoe and take the chances.  So we slept
+all day amongst the cottonwood thicket, so as to be fresh for the work,
+and when we went back to the raft about dark the canoe was gone!
+
+We didn’t say a word for a good while.  There warn’t anything to
+say.  We both knowed well enough it was some more work of the
+rattlesnake-skin; so what was the use to talk about it?  It would only
+look like we was finding fault, and that would be bound to fetch more
+bad luck--and keep on fetching it, too, till we knowed enough to keep
+still.
+
+By and by we talked about what we better do, and found there warn’t no
+way but just to go along down with the raft till we got a chance to buy
+a canoe to go back in.  We warn’t going to borrow it when there warn’t
+anybody around, the way pap would do, for that might set people after
+us.
+
+So we shoved out after dark on the raft.
+
+Anybody that don’t believe yet that it’s foolishness to handle a
+snake-skin, after all that that snake-skin done for us, will believe it
+now if they read on and see what more it done for us.
+
+The place to buy canoes is off of rafts laying up at shore.  But we
+didn’t see no rafts laying up; so we went along during three hours and
+more.  Well, the night got gray and ruther thick, which is the next
+meanest thing to fog.  You can’t tell the shape of the river, and you
+can’t see no distance. It got to be very late and still, and then along
+comes a steamboat up the river.  We lit the lantern, and judged she
+would see it.  Up-stream boats didn’t generly come close to us; they
+go out and follow the bars and hunt for easy water under the reefs; but
+nights like this they bull right up the channel against the whole river.
+
+We could hear her pounding along, but we didn’t see her good till she
+was close.  She aimed right for us.  Often they do that and try to see
+how close they can come without touching; sometimes the wheel bites off
+a sweep, and then the pilot sticks his head out and laughs, and thinks
+he’s mighty smart.  Well, here she comes, and we said she was going to
+try and shave us; but she didn’t seem to be sheering off a bit.  She
+was a big one, and she was coming in a hurry, too, looking like a black
+cloud with rows of glow-worms around it; but all of a sudden she bulged
+out, big and scary, with a long row of wide-open furnace doors shining
+like red-hot teeth, and her monstrous bows and guards hanging right
+over us.  There was a yell at us, and a jingling of bells to stop the
+engines, a powwow of cussing, and whistling of steam--and as Jim went
+overboard on one side and I on the other, she come smashing straight
+through the raft.
+
+I dived--and I aimed to find the bottom, too, for a thirty-foot wheel
+had got to go over me, and I wanted it to have plenty of room.  I could
+always stay under water a minute; this time I reckon I stayed under a
+minute and a half.  Then I bounced for the top in a hurry, for I was
+nearly busting.  I popped out to my armpits and blowed the water out of
+my nose, and puffed a bit.  Of course there was a booming current; and
+of course that boat started her engines again ten seconds after she
+stopped them, for they never cared much for raftsmen; so now she was
+churning along up the river, out of sight in the thick weather, though I
+could hear her.
+
+I sung out for Jim about a dozen times, but I didn’t get any answer;
+so I grabbed a plank that touched me while I was “treading water,” and
+struck out for shore, shoving it ahead of me.  But I made out to see
+that the drift of the current was towards the left-hand shore, which
+meant that I was in a crossing; so I changed off and went that way.
+
+It was one of these long, slanting, two-mile crossings; so I was a good
+long time in getting over.  I made a safe landing, and clumb up the
+bank. I couldn’t see but a little ways, but I went poking along over
+rough ground for a quarter of a mile or more, and then I run across a
+big old-fashioned double log-house before I noticed it.  I was going to
+rush by and get away, but a lot of dogs jumped out and went to howling
+and barking at me, and I knowed better than to move another peg.
+
+
+
+
+CHAPTER XVII.
+
+IN about a minute somebody spoke out of a window without putting his
+head out, and says:
+
+“Be done, boys!  Who’s there?”
+
+I says:
+
+“It’s me.”
+
+“Who’s me?”
+
+“George Jackson, sir.”
+
+“What do you want?”
+
+“I don’t want nothing, sir.  I only want to go along by, but the dogs
+won’t let me.”
+
+“What are you prowling around here this time of night for--hey?”
+
+“I warn’t prowling around, sir, I fell overboard off of the steamboat.”
+
+“Oh, you did, did you?  Strike a light there, somebody.  What did you
+say your name was?”
+
+“George Jackson, sir.  I’m only a boy.”
+
+“Look here, if you’re telling the truth you needn’t be afraid--nobody’ll
+hurt you.  But don’t try to budge; stand right where you are.  Rouse out
+Bob and Tom, some of you, and fetch the guns.  George Jackson, is there
+anybody with you?”
+
+“No, sir, nobody.”
+
+I heard the people stirring around in the house now, and see a light.
+The man sung out:
+
+“Snatch that light away, Betsy, you old fool--ain’t you got any sense?
+Put it on the floor behind the front door.  Bob, if you and Tom are
+ready, take your places.”
+
+“All ready.”
+
+“Now, George Jackson, do you know the Shepherdsons?”
+
+“No, sir; I never heard of them.”
+
+“Well, that may be so, and it mayn’t.  Now, all ready.  Step forward,
+George Jackson.  And mind, don’t you hurry--come mighty slow.  If there’s
+anybody with you, let him keep back--if he shows himself he’ll be shot.
+Come along now.  Come slow; push the door open yourself--just enough to
+squeeze in, d’ you hear?”
+
+I didn’t hurry; I couldn’t if I’d a wanted to.  I took one slow step at
+a time and there warn’t a sound, only I thought I could hear my heart.
+ The dogs were as still as the humans, but they followed a little behind
+me. When I got to the three log doorsteps I heard them unlocking and
+unbarring and unbolting.  I put my hand on the door and pushed it a
+little and a little more till somebody said, “There, that’s enough--put
+your head in.” I done it, but I judged they would take it off.
+
+The candle was on the floor, and there they all was, looking at me, and
+me at them, for about a quarter of a minute:  Three big men with guns
+pointed at me, which made me wince, I tell you; the oldest, gray
+and about sixty, the other two thirty or more--all of them fine and
+handsome--and the sweetest old gray-headed lady, and back of her two
+young women which I couldn’t see right well.  The old gentleman says:
+
+“There; I reckon it’s all right.  Come in.”
+
+As soon as I was in the old gentleman he locked the door and barred it
+and bolted it, and told the young men to come in with their guns, and
+they all went in a big parlor that had a new rag carpet on the floor,
+and got together in a corner that was out of the range of the front
+windows--there warn’t none on the side.  They held the candle, and took a
+good look at me, and all said, “Why, _he_ ain’t a Shepherdson--no, there
+ain’t any Shepherdson about him.”  Then the old man said he hoped I
+wouldn’t mind being searched for arms, because he didn’t mean no harm by
+it--it was only to make sure.  So he didn’t pry into my pockets, but only
+felt outside with his hands, and said it was all right.  He told me to
+make myself easy and at home, and tell all about myself; but the old
+lady says:
+
+“Why, bless you, Saul, the poor thing’s as wet as he can be; and don’t
+you reckon it may be he’s hungry?”
+
+“True for you, Rachel--I forgot.”
+
+So the old lady says:
+
+“Betsy” (this was a nigger woman), “you fly around and get him something
+to eat as quick as you can, poor thing; and one of you girls go and wake
+up Buck and tell him--oh, here he is himself.  Buck, take this little
+stranger and get the wet clothes off from him and dress him up in some
+of yours that’s dry.”
+
+Buck looked about as old as me--thirteen or fourteen or along there,
+though he was a little bigger than me.  He hadn’t on anything but a
+shirt, and he was very frowzy-headed.  He came in gaping and digging one
+fist into his eyes, and he was dragging a gun along with the other one.
+He says:
+
+“Ain’t they no Shepherdsons around?”
+
+They said, no, ‘twas a false alarm.
+
+“Well,” he says, “if they’d a ben some, I reckon I’d a got one.”
+
+They all laughed, and Bob says:
+
+“Why, Buck, they might have scalped us all, you’ve been so slow in
+coming.”
+
+“Well, nobody come after me, and it ain’t right I’m always kept down; I
+don’t get no show.”
+
+“Never mind, Buck, my boy,” says the old man, “you’ll have show enough,
+all in good time, don’t you fret about that.  Go ‘long with you now, and
+do as your mother told you.”
+
+When we got up-stairs to his room he got me a coarse shirt and a
+roundabout and pants of his, and I put them on.  While I was at it he
+asked me what my name was, but before I could tell him he started to
+tell me about a bluejay and a young rabbit he had catched in the woods
+day before yesterday, and he asked me where Moses was when the candle
+went out.  I said I didn’t know; I hadn’t heard about it before, no way.
+
+“Well, guess,” he says.
+
+“How’m I going to guess,” says I, “when I never heard tell of it
+before?”
+
+“But you can guess, can’t you?  It’s just as easy.”
+
+“_Which_ candle?”  I says.
+
+“Why, any candle,” he says.
+
+“I don’t know where he was,” says I; “where was he?”
+
+“Why, he was in the _dark_!  That’s where he was!”
+
+“Well, if you knowed where he was, what did you ask me for?”
+
+“Why, blame it, it’s a riddle, don’t you see?  Say, how long are you
+going to stay here?  You got to stay always.  We can just have booming
+times--they don’t have no school now.  Do you own a dog?  I’ve got a
+dog--and he’ll go in the river and bring out chips that you throw in.  Do
+you like to comb up Sundays, and all that kind of foolishness?  You bet
+I don’t, but ma she makes me.  Confound these ole britches!  I reckon
+I’d better put ‘em on, but I’d ruther not, it’s so warm.  Are you all
+ready? All right.  Come along, old hoss.”
+
+Cold corn-pone, cold corn-beef, butter and buttermilk--that is what they
+had for me down there, and there ain’t nothing better that ever I’ve
+come across yet.  Buck and his ma and all of them smoked cob pipes,
+except the nigger woman, which was gone, and the two young women.  They
+all smoked and talked, and I eat and talked.  The young women had
+quilts around them, and their hair down their backs.  They all asked me
+questions, and I told them how pap and me and all the family was living
+on a little farm down at the bottom of Arkansaw, and my sister Mary Ann
+run off and got married and never was heard of no more, and Bill went
+to hunt them and he warn’t heard of no more, and Tom and Mort died,
+and then there warn’t nobody but just me and pap left, and he was just
+trimmed down to nothing, on account of his troubles; so when he died
+I took what there was left, because the farm didn’t belong to us, and
+started up the river, deck passage, and fell overboard; and that was how
+I come to be here.  So they said I could have a home there as long as I
+wanted it.  Then it was most daylight and everybody went to bed, and I
+went to bed with Buck, and when I waked up in the morning, drat it all,
+I had forgot what my name was. So I laid there about an hour trying to
+think, and when Buck waked up I says:
+
+“Can you spell, Buck?”
+
+“Yes,” he says.
+
+“I bet you can’t spell my name,” says I.
+
+“I bet you what you dare I can,” says he.
+
+“All right,” says I, “go ahead.”
+
+“G-e-o-r-g-e J-a-x-o-n--there now,” he says.
+
+“Well,” says I, “you done it, but I didn’t think you could.  It ain’t no
+slouch of a name to spell--right off without studying.”
+
+I set it down, private, because somebody might want _me_ to spell it
+next, and so I wanted to be handy with it and rattle it off like I was
+used to it.
+
+It was a mighty nice family, and a mighty nice house, too.  I hadn’t
+seen no house out in the country before that was so nice and had so much
+style.  It didn’t have an iron latch on the front door, nor a wooden one
+with a buckskin string, but a brass knob to turn, the same as houses in
+town. There warn’t no bed in the parlor, nor a sign of a bed; but heaps
+of parlors in towns has beds in them.  There was a big fireplace that
+was bricked on the bottom, and the bricks was kept clean and red by
+pouring water on them and scrubbing them with another brick; sometimes
+they wash them over with red water-paint that they call Spanish-brown,
+same as they do in town.  They had big brass dog-irons that could hold
+up a saw-log. There was a clock on the middle of the mantelpiece, with
+a picture of a town painted on the bottom half of the glass front, and
+a round place in the middle of it for the sun, and you could see the
+pendulum swinging behind it.  It was beautiful to hear that clock tick;
+and sometimes when one of these peddlers had been along and scoured her
+up and got her in good shape, she would start in and strike a hundred
+and fifty before she got tuckered out.  They wouldn’t took any money for
+her.
+
+Well, there was a big outlandish parrot on each side of the clock,
+made out of something like chalk, and painted up gaudy.  By one of the
+parrots was a cat made of crockery, and a crockery dog by the other;
+and when you pressed down on them they squeaked, but didn’t open
+their mouths nor look different nor interested.  They squeaked through
+underneath.  There was a couple of big wild-turkey-wing fans spread out
+behind those things.  On the table in the middle of the room was a kind
+of a lovely crockery basket that had apples and oranges and peaches and
+grapes piled up in it, which was much redder and yellower and prettier
+than real ones is, but they warn’t real because you could see where
+pieces had got chipped off and showed the white chalk, or whatever it
+was, underneath.
+
+This table had a cover made out of beautiful oilcloth, with a red and
+blue spread-eagle painted on it, and a painted border all around.  It
+come all the way from Philadelphia, they said.  There was some books,
+too, piled up perfectly exact, on each corner of the table.  One was a
+big family Bible full of pictures.  One was Pilgrim’s Progress, about a
+man that left his family, it didn’t say why.  I read considerable in it
+now and then.  The statements was interesting, but tough.  Another was
+Friendship’s Offering, full of beautiful stuff and poetry; but I didn’t
+read the poetry.  Another was Henry Clay’s Speeches, and another was Dr.
+Gunn’s Family Medicine, which told you all about what to do if a body
+was sick or dead.  There was a hymn book, and a lot of other books.  And
+there was nice split-bottom chairs, and perfectly sound, too--not bagged
+down in the middle and busted, like an old basket.
+
+They had pictures hung on the walls--mainly Washingtons and Lafayettes,
+and battles, and Highland Marys, and one called “Signing the
+Declaration.” There was some that they called crayons, which one of the
+daughters which was dead made her own self when she was only
+fifteen years old.  They was different from any pictures I ever see
+before--blacker, mostly, than is common.  One was a woman in a slim black
+dress, belted small under the armpits, with bulges like a cabbage in
+the middle of the sleeves, and a large black scoop-shovel bonnet with
+a black veil, and white slim ankles crossed about with black tape, and
+very wee black slippers, like a chisel, and she was leaning pensive on a
+tombstone on her right elbow, under a weeping willow, and her other hand
+hanging down her side holding a white handkerchief and a reticule,
+and underneath the picture it said “Shall I Never See Thee More Alas.”
+  Another one was a young lady with her hair all combed up straight
+to the top of her head, and knotted there in front of a comb like a
+chair-back, and she was crying into a handkerchief and had a dead bird
+laying on its back in her other hand with its heels up, and underneath
+the picture it said “I Shall Never Hear Thy Sweet Chirrup More Alas.”
+  There was one where a young lady was at a window looking up at the
+moon, and tears running down her cheeks; and she had an open letter in
+one hand with black sealing wax showing on one edge of it, and she was
+mashing a locket with a chain to it against her mouth, and underneath
+the picture it said “And Art Thou Gone Yes Thou Art Gone Alas.”  These
+was all nice pictures, I reckon, but I didn’t somehow seem to take
+to them, because if ever I was down a little they always give me the
+fan-tods.  Everybody was sorry she died, because she had laid out a lot
+more of these pictures to do, and a body could see by what she had done
+what they had lost.  But I reckoned that with her disposition she was
+having a better time in the graveyard.  She was at work on what they
+said was her greatest picture when she took sick, and every day and
+every night it was her prayer to be allowed to live till she got it
+done, but she never got the chance.  It was a picture of a young woman
+in a long white gown, standing on the rail of a bridge all ready to jump
+off, with her hair all down her back, and looking up to the moon, with
+the tears running down her face, and she had two arms folded across her
+breast, and two arms stretched out in front, and two more reaching up
+towards the moon--and the idea was to see which pair would look best,
+and then scratch out all the other arms; but, as I was saying, she died
+before she got her mind made up, and now they kept this picture over the
+head of the bed in her room, and every time her birthday come they hung
+flowers on it.  Other times it was hid with a little curtain.  The young
+woman in the picture had a kind of a nice sweet face, but there was so
+many arms it made her look too spidery, seemed to me.
+
+This young girl kept a scrap-book when she was alive, and used to paste
+obituaries and accidents and cases of patient suffering in it out of the
+Presbyterian Observer, and write poetry after them out of her own head.
+It was very good poetry. This is what she wrote about a boy by the name
+of Stephen Dowling Bots that fell down a well and was drownded:
+
+ODE TO STEPHEN DOWLING BOTS, DEC’D
+
+And did young Stephen sicken,    And did young Stephen die? And did the
+sad hearts thicken,    And did the mourners cry?
+
+No; such was not the fate of    Young Stephen Dowling Bots; Though sad
+hearts round him thickened,    ‘Twas not from sickness’ shots.
+
+No whooping-cough did rack his frame,    Nor measles drear with spots;
+Not these impaired the sacred name    Of Stephen Dowling Bots.
+
+Despised love struck not with woe    That head of curly knots, Nor
+stomach troubles laid him low,    Young Stephen Dowling Bots.
+
+O no. Then list with tearful eye,    Whilst I his fate do tell. His soul
+did from this cold world fly    By falling down a well.
+
+They got him out and emptied him;    Alas it was too late; His spirit
+was gone for to sport aloft    In the realms of the good and great.
+
+If Emmeline Grangerford could make poetry like that before she was
+fourteen, there ain’t no telling what she could a done by and by.  Buck
+said she could rattle off poetry like nothing.  She didn’t ever have to
+stop to think.  He said she would slap down a line, and if she couldn’t
+find anything to rhyme with it would just scratch it out and slap down
+another one, and go ahead. She warn’t particular; she could write about
+anything you choose to give her to write about just so it was sadful.
+Every time a man died, or a woman died, or a child died, she would be on
+hand with her “tribute” before he was cold.  She called them tributes.
+The neighbors said it was the doctor first, then Emmeline, then the
+undertaker--the undertaker never got in ahead of Emmeline but once, and
+then she hung fire on a rhyme for the dead person’s name, which was
+Whistler.  She warn’t ever the same after that; she never complained,
+but she kinder pined away and did not live long.  Poor thing, many’s the
+time I made myself go up to the little room that used to be hers and get
+out her poor old scrap-book and read in it when her pictures had been
+aggravating me and I had soured on her a little.  I liked all that
+family, dead ones and all, and warn’t going to let anything come between
+us.  Poor Emmeline made poetry about all the dead people when she was
+alive, and it didn’t seem right that there warn’t nobody to make some
+about her now she was gone; so I tried to sweat out a verse or two
+myself, but I couldn’t seem to make it go somehow.  They kept Emmeline’s
+room trim and nice, and all the things fixed in it just the way she
+liked to have them when she was alive, and nobody ever slept there.
+ The old lady took care of the room herself, though there was plenty
+of niggers, and she sewed there a good deal and read her Bible there
+mostly.
+
+Well, as I was saying about the parlor, there was beautiful curtains on
+the windows:  white, with pictures painted on them of castles with vines
+all down the walls, and cattle coming down to drink.  There was a little
+old piano, too, that had tin pans in it, I reckon, and nothing was ever
+so lovely as to hear the young ladies sing “The Last Link is Broken”
+ and play “The Battle of Prague” on it.  The walls of all the rooms was
+plastered, and most had carpets on the floors, and the whole house was
+whitewashed on the outside.
+
+It was a double house, and the big open place betwixt them was roofed
+and floored, and sometimes the table was set there in the middle of the
+day, and it was a cool, comfortable place.  Nothing couldn’t be better.
+ And warn’t the cooking good, and just bushels of it too!
+
+
+
+
+CHAPTER XVIII.
+
+COL.  Grangerford was a gentleman, you see.  He was a gentleman all
+over; and so was his family.  He was well born, as the saying is, and
+that’s worth as much in a man as it is in a horse, so the Widow Douglas
+said, and nobody ever denied that she was of the first aristocracy
+in our town; and pap he always said it, too, though he warn’t no more
+quality than a mudcat himself.  Col.  Grangerford was very tall and
+very slim, and had a darkish-paly complexion, not a sign of red in it
+anywheres; he was clean shaved every morning all over his thin face, and
+he had the thinnest kind of lips, and the thinnest kind of nostrils, and
+a high nose, and heavy eyebrows, and the blackest kind of eyes, sunk so
+deep back that they seemed like they was looking out of caverns at
+you, as you may say.  His forehead was high, and his hair was black and
+straight and hung to his shoulders. His hands was long and thin, and
+every day of his life he put on a clean shirt and a full suit from head
+to foot made out of linen so white it hurt your eyes to look at it;
+and on Sundays he wore a blue tail-coat with brass buttons on it.  He
+carried a mahogany cane with a silver head to it.  There warn’t no
+frivolishness about him, not a bit, and he warn’t ever loud.  He was
+as kind as he could be--you could feel that, you know, and so you had
+confidence.  Sometimes he smiled, and it was good to see; but when he
+straightened himself up like a liberty-pole, and the lightning begun to
+flicker out from under his eyebrows, you wanted to climb a tree first,
+and find out what the matter was afterwards.  He didn’t ever have to
+tell anybody to mind their manners--everybody was always good-mannered
+where he was.  Everybody loved to have him around, too; he was sunshine
+most always--I mean he made it seem like good weather.  When he turned
+into a cloudbank it was awful dark for half a minute, and that was
+enough; there wouldn’t nothing go wrong again for a week.
+
+When him and the old lady come down in the morning all the family got
+up out of their chairs and give them good-day, and didn’t set down again
+till they had set down.  Then Tom and Bob went to the sideboard where
+the decanter was, and mixed a glass of bitters and handed it to him, and
+he held it in his hand and waited till Tom’s and Bob’s was mixed, and
+then they bowed and said, “Our duty to you, sir, and madam;” and _they_
+bowed the least bit in the world and said thank you, and so they drank,
+all three, and Bob and Tom poured a spoonful of water on the sugar and
+the mite of whisky or apple brandy in the bottom of their tumblers, and
+give it to me and Buck, and we drank to the old people too.
+
+Bob was the oldest and Tom next--tall, beautiful men with very broad
+shoulders and brown faces, and long black hair and black eyes.  They
+dressed in white linen from head to foot, like the old gentleman, and
+wore broad Panama hats.
+
+Then there was Miss Charlotte; she was twenty-five, and tall and proud
+and grand, but as good as she could be when she warn’t stirred up; but
+when she was she had a look that would make you wilt in your tracks,
+like her father.  She was beautiful.
+
+So was her sister, Miss Sophia, but it was a different kind.  She was
+gentle and sweet like a dove, and she was only twenty.
+
+Each person had their own nigger to wait on them--Buck too.  My nigger
+had a monstrous easy time, because I warn’t used to having anybody do
+anything for me, but Buck’s was on the jump most of the time.
+
+This was all there was of the family now, but there used to be
+more--three sons; they got killed; and Emmeline that died.
+
+The old gentleman owned a lot of farms and over a hundred niggers.
+Sometimes a stack of people would come there, horseback, from ten or
+fifteen mile around, and stay five or six days, and have such junketings
+round about and on the river, and dances and picnics in the woods
+daytimes, and balls at the house nights.  These people was mostly
+kinfolks of the family.  The men brought their guns with them.  It was a
+handsome lot of quality, I tell you.
+
+There was another clan of aristocracy around there--five or six
+families--mostly of the name of Shepherdson.  They was as high-toned
+and well born and rich and grand as the tribe of Grangerfords.  The
+Shepherdsons and Grangerfords used the same steamboat landing, which was
+about two mile above our house; so sometimes when I went up there with a
+lot of our folks I used to see a lot of the Shepherdsons there on their
+fine horses.
+
+One day Buck and me was away out in the woods hunting, and heard a horse
+coming.  We was crossing the road.  Buck says:
+
+“Quick!  Jump for the woods!”
+
+We done it, and then peeped down the woods through the leaves.  Pretty
+soon a splendid young man come galloping down the road, setting his
+horse easy and looking like a soldier.  He had his gun across his
+pommel.  I had seen him before.  It was young Harney Shepherdson.  I
+heard Buck’s gun go off at my ear, and Harney’s hat tumbled off from his
+head.  He grabbed his gun and rode straight to the place where we was
+hid.  But we didn’t wait.  We started through the woods on a run.  The
+woods warn’t thick, so I looked over my shoulder to dodge the bullet,
+and twice I seen Harney cover Buck with his gun; and then he rode away
+the way he come--to get his hat, I reckon, but I couldn’t see.  We never
+stopped running till we got home.  The old gentleman’s eyes blazed a
+minute--‘twas pleasure, mainly, I judged--then his face sort of smoothed
+down, and he says, kind of gentle:
+
+“I don’t like that shooting from behind a bush.  Why didn’t you step
+into the road, my boy?”
+
+“The Shepherdsons don’t, father.  They always take advantage.”
+
+Miss Charlotte she held her head up like a queen while Buck was telling
+his tale, and her nostrils spread and her eyes snapped.  The two young
+men looked dark, but never said nothing.  Miss Sophia she turned pale,
+but the color come back when she found the man warn’t hurt.
+
+Soon as I could get Buck down by the corn-cribs under the trees by
+ourselves, I says:
+
+“Did you want to kill him, Buck?”
+
+“Well, I bet I did.”
+
+“What did he do to you?”
+
+“Him?  He never done nothing to me.”
+
+“Well, then, what did you want to kill him for?”
+
+“Why, nothing--only it’s on account of the feud.”
+
+“What’s a feud?”
+
+“Why, where was you raised?  Don’t you know what a feud is?”
+
+“Never heard of it before--tell me about it.”
+
+“Well,” says Buck, “a feud is this way:  A man has a quarrel with
+another man, and kills him; then that other man’s brother kills _him_;
+then the other brothers, on both sides, goes for one another; then the
+_cousins_ chip in--and by and by everybody’s killed off, and there ain’t
+no more feud.  But it’s kind of slow, and takes a long time.”
+
+“Has this one been going on long, Buck?”
+
+“Well, I should _reckon_!  It started thirty year ago, or som’ers along
+there.  There was trouble ‘bout something, and then a lawsuit to settle
+it; and the suit went agin one of the men, and so he up and shot the
+man that won the suit--which he would naturally do, of course.  Anybody
+would.”
+
+“What was the trouble about, Buck?--land?”
+
+“I reckon maybe--I don’t know.”
+
+“Well, who done the shooting?  Was it a Grangerford or a Shepherdson?”
+
+“Laws, how do I know?  It was so long ago.”
+
+“Don’t anybody know?”
+
+“Oh, yes, pa knows, I reckon, and some of the other old people; but they
+don’t know now what the row was about in the first place.”
+
+“Has there been many killed, Buck?”
+
+“Yes; right smart chance of funerals.  But they don’t always kill.  Pa’s
+got a few buckshot in him; but he don’t mind it ‘cuz he don’t weigh
+much, anyway.  Bob’s been carved up some with a bowie, and Tom’s been
+hurt once or twice.”
+
+“Has anybody been killed this year, Buck?”
+
+“Yes; we got one and they got one.  ‘Bout three months ago my cousin
+Bud, fourteen year old, was riding through the woods on t’other side
+of the river, and didn’t have no weapon with him, which was blame’
+foolishness, and in a lonesome place he hears a horse a-coming behind
+him, and sees old Baldy Shepherdson a-linkin’ after him with his gun in
+his hand and his white hair a-flying in the wind; and ‘stead of jumping
+off and taking to the brush, Bud ‘lowed he could out-run him; so they
+had it, nip and tuck, for five mile or more, the old man a-gaining all
+the time; so at last Bud seen it warn’t any use, so he stopped and faced
+around so as to have the bullet holes in front, you know, and the old
+man he rode up and shot him down.  But he didn’t git much chance to
+enjoy his luck, for inside of a week our folks laid _him_ out.”
+
+“I reckon that old man was a coward, Buck.”
+
+“I reckon he _warn’t_ a coward.  Not by a blame’ sight.  There ain’t a
+coward amongst them Shepherdsons--not a one.  And there ain’t no cowards
+amongst the Grangerfords either.  Why, that old man kep’ up his end in a
+fight one day for half an hour against three Grangerfords, and come
+out winner.  They was all a-horseback; he lit off of his horse and got
+behind a little woodpile, and kep’ his horse before him to stop the
+bullets; but the Grangerfords stayed on their horses and capered around
+the old man, and peppered away at him, and he peppered away at them.
+ Him and his horse both went home pretty leaky and crippled, but the
+Grangerfords had to be _fetched_ home--and one of ‘em was dead, and
+another died the next day.  No, sir; if a body’s out hunting for cowards
+he don’t want to fool away any time amongst them Shepherdsons, becuz
+they don’t breed any of that _kind_.”
+
+Next Sunday we all went to church, about three mile, everybody
+a-horseback. The men took their guns along, so did Buck, and kept
+them between their knees or stood them handy against the wall.  The
+Shepherdsons done the same.  It was pretty ornery preaching--all about
+brotherly love, and such-like tiresomeness; but everybody said it was
+a good sermon, and they all talked it over going home, and had such
+a powerful lot to say about faith and good works and free grace and
+preforeordestination, and I don’t know what all, that it did seem to me
+to be one of the roughest Sundays I had run across yet.
+
+About an hour after dinner everybody was dozing around, some in their
+chairs and some in their rooms, and it got to be pretty dull.  Buck and
+a dog was stretched out on the grass in the sun sound asleep.  I went up
+to our room, and judged I would take a nap myself.  I found that sweet
+Miss Sophia standing in her door, which was next to ours, and she took
+me in her room and shut the door very soft, and asked me if I liked her,
+and I said I did; and she asked me if I would do something for her and
+not tell anybody, and I said I would.  Then she said she’d forgot her
+Testament, and left it in the seat at church between two other books,
+and would I slip out quiet and go there and fetch it to her, and not say
+nothing to nobody.  I said I would. So I slid out and slipped off up the
+road, and there warn’t anybody at the church, except maybe a hog or two,
+for there warn’t any lock on the door, and hogs likes a puncheon floor
+in summer-time because it’s cool.  If you notice, most folks don’t go to
+church only when they’ve got to; but a hog is different.
+
+Says I to myself, something’s up; it ain’t natural for a girl to be in
+such a sweat about a Testament.  So I give it a shake, and out drops a
+little piece of paper with “HALF-PAST TWO” wrote on it with a pencil.  I
+ransacked it, but couldn’t find anything else.  I couldn’t make anything
+out of that, so I put the paper in the book again, and when I got home
+and upstairs there was Miss Sophia in her door waiting for me.  She
+pulled me in and shut the door; then she looked in the Testament till
+she found the paper, and as soon as she read it she looked glad; and
+before a body could think she grabbed me and give me a squeeze, and
+said I was the best boy in the world, and not to tell anybody.  She was
+mighty red in the face for a minute, and her eyes lighted up, and it
+made her powerful pretty.  I was a good deal astonished, but when I got
+my breath I asked her what the paper was about, and she asked me if I
+had read it, and I said no, and she asked me if I could read writing,
+and I told her “no, only coarse-hand,” and then she said the paper
+warn’t anything but a book-mark to keep her place, and I might go and
+play now.
+
+I went off down to the river, studying over this thing, and pretty soon
+I noticed that my nigger was following along behind.  When we was out
+of sight of the house he looked back and around a second, and then comes
+a-running, and says:
+
+“Mars Jawge, if you’ll come down into de swamp I’ll show you a whole
+stack o’ water-moccasins.”
+
+Thinks I, that’s mighty curious; he said that yesterday.  He oughter
+know a body don’t love water-moccasins enough to go around hunting for
+them. What is he up to, anyway?  So I says:
+
+“All right; trot ahead.”
+
+I followed a half a mile; then he struck out over the swamp, and waded
+ankle deep as much as another half-mile.  We come to a little flat piece
+of land which was dry and very thick with trees and bushes and vines,
+and he says:
+
+“You shove right in dah jist a few steps, Mars Jawge; dah’s whah dey is.
+I’s seed ‘m befo’; I don’t k’yer to see ‘em no mo’.”
+
+Then he slopped right along and went away, and pretty soon the trees hid
+him.  I poked into the place a-ways and come to a little open patch
+as big as a bedroom all hung around with vines, and found a man laying
+there asleep--and, by jings, it was my old Jim!
+
+I waked him up, and I reckoned it was going to be a grand surprise to
+him to see me again, but it warn’t.  He nearly cried he was so glad, but
+he warn’t surprised.  Said he swum along behind me that night, and heard
+me yell every time, but dasn’t answer, because he didn’t want nobody to
+pick _him_ up and take him into slavery again.  Says he:
+
+“I got hurt a little, en couldn’t swim fas’, so I wuz a considable ways
+behine you towards de las’; when you landed I reck’ned I could ketch
+up wid you on de lan’ ‘dout havin’ to shout at you, but when I see dat
+house I begin to go slow.  I ‘uz off too fur to hear what dey say to
+you--I wuz ‘fraid o’ de dogs; but when it ‘uz all quiet agin I knowed
+you’s in de house, so I struck out for de woods to wait for day.  Early
+in de mawnin’ some er de niggers come along, gwyne to de fields, en dey
+tuk me en showed me dis place, whah de dogs can’t track me on accounts
+o’ de water, en dey brings me truck to eat every night, en tells me how
+you’s a-gitt’n along.”
+
+“Why didn’t you tell my Jack to fetch me here sooner, Jim?”
+
+“Well, ‘twarn’t no use to ‘sturb you, Huck, tell we could do sumfn--but
+we’s all right now.  I ben a-buyin’ pots en pans en vittles, as I got a
+chanst, en a-patchin’ up de raf’ nights when--”
+
+“_What_ raft, Jim?”
+
+“Our ole raf’.”
+
+“You mean to say our old raft warn’t smashed all to flinders?”
+
+“No, she warn’t.  She was tore up a good deal--one en’ of her was; but
+dey warn’t no great harm done, on’y our traps was mos’ all los’.  Ef we
+hadn’ dive’ so deep en swum so fur under water, en de night hadn’ ben
+so dark, en we warn’t so sk’yerd, en ben sich punkin-heads, as de sayin’
+is, we’d a seed de raf’.  But it’s jis’ as well we didn’t, ‘kase now
+she’s all fixed up agin mos’ as good as new, en we’s got a new lot o’
+stuff, in de place o’ what ‘uz los’.”
+
+“Why, how did you get hold of the raft again, Jim--did you catch her?”
+
+“How I gwyne to ketch her en I out in de woods?  No; some er de niggers
+foun’ her ketched on a snag along heah in de ben’, en dey hid her in a
+crick ‘mongst de willows, en dey wuz so much jawin’ ‘bout which un ‘um
+she b’long to de mos’ dat I come to heah ‘bout it pooty soon, so I ups
+en settles de trouble by tellin’ ‘um she don’t b’long to none uv um, but
+to you en me; en I ast ‘m if dey gwyne to grab a young white genlman’s
+propaty, en git a hid’n for it?  Den I gin ‘m ten cents apiece, en dey
+‘uz mighty well satisfied, en wisht some mo’ raf’s ‘ud come along en
+make ‘m rich agin. Dey’s mighty good to me, dese niggers is, en whatever
+I wants ‘m to do fur me I doan’ have to ast ‘m twice, honey.  Dat Jack’s
+a good nigger, en pooty smart.”
+
+“Yes, he is.  He ain’t ever told me you was here; told me to come, and
+he’d show me a lot of water-moccasins.  If anything happens _he_ ain’t
+mixed up in it.  He can say he never seen us together, and it ‘ll be the
+truth.”
+
+I don’t want to talk much about the next day.  I reckon I’ll cut it
+pretty short.  I waked up about dawn, and was a-going to turn over and
+go to sleep again when I noticed how still it was--didn’t seem to be
+anybody stirring.  That warn’t usual.  Next I noticed that Buck was
+up and gone. Well, I gets up, a-wondering, and goes down stairs--nobody
+around; everything as still as a mouse.  Just the same outside.  Thinks
+I, what does it mean?  Down by the wood-pile I comes across my Jack, and
+says:
+
+“What’s it all about?”
+
+Says he:
+
+“Don’t you know, Mars Jawge?”
+
+“No,” says I, “I don’t.”
+
+“Well, den, Miss Sophia’s run off! ‘deed she has.  She run off in de
+night some time--nobody don’t know jis’ when; run off to get married
+to dat young Harney Shepherdson, you know--leastways, so dey ‘spec.  De
+fambly foun’ it out ‘bout half an hour ago--maybe a little mo’--en’ I
+_tell_ you dey warn’t no time los’.  Sich another hurryin’ up guns
+en hosses _you_ never see!  De women folks has gone for to stir up de
+relations, en ole Mars Saul en de boys tuck dey guns en rode up de
+river road for to try to ketch dat young man en kill him ‘fo’ he kin
+git acrost de river wid Miss Sophia.  I reck’n dey’s gwyne to be mighty
+rough times.”
+
+“Buck went off ‘thout waking me up.”
+
+“Well, I reck’n he _did_!  Dey warn’t gwyne to mix you up in it.
+ Mars Buck he loaded up his gun en ‘lowed he’s gwyne to fetch home a
+Shepherdson or bust. Well, dey’ll be plenty un ‘m dah, I reck’n, en you
+bet you he’ll fetch one ef he gits a chanst.”
+
+I took up the river road as hard as I could put.  By and by I begin to
+hear guns a good ways off.  When I come in sight of the log store and
+the woodpile where the steamboats lands I worked along under the trees
+and brush till I got to a good place, and then I clumb up into the
+forks of a cottonwood that was out of reach, and watched.  There was a
+wood-rank four foot high a little ways in front of the tree, and first I
+was going to hide behind that; but maybe it was luckier I didn’t.
+
+There was four or five men cavorting around on their horses in the open
+place before the log store, cussing and yelling, and trying to get at
+a couple of young chaps that was behind the wood-rank alongside of the
+steamboat landing; but they couldn’t come it.  Every time one of them
+showed himself on the river side of the woodpile he got shot at.  The
+two boys was squatting back to back behind the pile, so they could watch
+both ways.
+
+By and by the men stopped cavorting around and yelling.  They started
+riding towards the store; then up gets one of the boys, draws a steady
+bead over the wood-rank, and drops one of them out of his saddle.  All
+the men jumped off of their horses and grabbed the hurt one and started
+to carry him to the store; and that minute the two boys started on the
+run.  They got half way to the tree I was in before the men noticed.
+Then the men see them, and jumped on their horses and took out after
+them.  They gained on the boys, but it didn’t do no good, the boys had
+too good a start; they got to the woodpile that was in front of my tree,
+and slipped in behind it, and so they had the bulge on the men again.
+One of the boys was Buck, and the other was a slim young chap about
+nineteen years old.
+
+The men ripped around awhile, and then rode away.  As soon as they was
+out of sight I sung out to Buck and told him.  He didn’t know what
+to make of my voice coming out of the tree at first.  He was awful
+surprised.  He told me to watch out sharp and let him know when the
+men come in sight again; said they was up to some devilment or
+other--wouldn’t be gone long.  I wished I was out of that tree, but I
+dasn’t come down.  Buck begun to cry and rip, and ‘lowed that him and
+his cousin Joe (that was the other young chap) would make up for this
+day yet.  He said his father and his two brothers was killed, and two
+or three of the enemy.  Said the Shepherdsons laid for them in
+ambush.  Buck said his father and brothers ought to waited for their
+relations--the Shepherdsons was too strong for them.  I asked him what
+was become of young Harney and Miss Sophia.  He said they’d got across
+the river and was safe.  I was glad of that; but the way Buck did take
+on because he didn’t manage to kill Harney that day he shot at him--I
+hain’t ever heard anything like it.
+
+All of a sudden, bang! bang! bang! goes three or four guns--the men had
+slipped around through the woods and come in from behind without their
+horses!  The boys jumped for the river--both of them hurt--and as they
+swum down the current the men run along the bank shooting at them and
+singing out, “Kill them, kill them!”  It made me so sick I most fell out
+of the tree.  I ain’t a-going to tell _all_ that happened--it would make
+me sick again if I was to do that.  I wished I hadn’t ever come ashore
+that night to see such things.  I ain’t ever going to get shut of
+them--lots of times I dream about them.
+
+I stayed in the tree till it begun to get dark, afraid to come down.
+Sometimes I heard guns away off in the woods; and twice I seen little
+gangs of men gallop past the log store with guns; so I reckoned the
+trouble was still a-going on.  I was mighty downhearted; so I made up my
+mind I wouldn’t ever go anear that house again, because I reckoned I
+was to blame, somehow. I judged that that piece of paper meant that Miss
+Sophia was to meet Harney somewheres at half-past two and run off; and
+I judged I ought to told her father about that paper and the curious way
+she acted, and then maybe he would a locked her up, and this awful mess
+wouldn’t ever happened.
+
+When I got down out of the tree I crept along down the river bank a
+piece, and found the two bodies laying in the edge of the water, and
+tugged at them till I got them ashore; then I covered up their faces,
+and got away as quick as I could.  I cried a little when I was covering
+up Buck’s face, for he was mighty good to me.
+
+It was just dark now.  I never went near the house, but struck through
+the woods and made for the swamp.  Jim warn’t on his island, so I
+tramped off in a hurry for the crick, and crowded through the willows,
+red-hot to jump aboard and get out of that awful country.  The raft was
+gone!  My souls, but I was scared!  I couldn’t get my breath for most
+a minute. Then I raised a yell.  A voice not twenty-five foot from me
+says:
+
+“Good lan’! is dat you, honey?  Doan’ make no noise.”
+
+It was Jim’s voice--nothing ever sounded so good before.  I run along the
+bank a piece and got aboard, and Jim he grabbed me and hugged me, he was
+so glad to see me.  He says:
+
+“Laws bless you, chile, I ‘uz right down sho’ you’s dead agin.  Jack’s
+been heah; he say he reck’n you’s ben shot, kase you didn’ come home no
+mo’; so I’s jes’ dis minute a startin’ de raf’ down towards de mouf er
+de crick, so’s to be all ready for to shove out en leave soon as Jack
+comes agin en tells me for certain you _is_ dead.  Lawsy, I’s mighty
+glad to git you back again, honey.”
+
+I says:
+
+“All right--that’s mighty good; they won’t find me, and they’ll think
+I’ve been killed, and floated down the river--there’s something up there
+that ‘ll help them think so--so don’t you lose no time, Jim, but just
+shove off for the big water as fast as ever you can.”
+
+I never felt easy till the raft was two mile below there and out in
+the middle of the Mississippi.  Then we hung up our signal lantern, and
+judged that we was free and safe once more.  I hadn’t had a bite to eat
+since yesterday, so Jim he got out some corn-dodgers and buttermilk,
+and pork and cabbage and greens--there ain’t nothing in the world so good
+when it’s cooked right--and whilst I eat my supper we talked and had a
+good time.  I was powerful glad to get away from the feuds, and so was
+Jim to get away from the swamp.  We said there warn’t no home like a
+raft, after all.  Other places do seem so cramped up and smothery, but a
+raft don’t.  You feel mighty free and easy and comfortable on a raft.
+
+
+
+
+CHAPTER XIX.
+
+TWO or three days and nights went by; I reckon I might say they swum by,
+they slid along so quiet and smooth and lovely.  Here is the way we put
+in the time.  It was a monstrous big river down there--sometimes a mile
+and a half wide; we run nights, and laid up and hid daytimes; soon as
+night was most gone we stopped navigating and tied up--nearly always
+in the dead water under a towhead; and then cut young cottonwoods and
+willows, and hid the raft with them.  Then we set out the lines.  Next
+we slid into the river and had a swim, so as to freshen up and cool
+off; then we set down on the sandy bottom where the water was about knee
+deep, and watched the daylight come.  Not a sound anywheres--perfectly
+still--just like the whole world was asleep, only sometimes the bullfrogs
+a-cluttering, maybe.  The first thing to see, looking away over the
+water, was a kind of dull line--that was the woods on t’other side; you
+couldn’t make nothing else out; then a pale place in the sky; then more
+paleness spreading around; then the river softened up away off, and
+warn’t black any more, but gray; you could see little dark spots
+drifting along ever so far away--trading scows, and such things; and
+long black streaks--rafts; sometimes you could hear a sweep screaking; or
+jumbled up voices, it was so still, and sounds come so far; and by and
+by you could see a streak on the water which you know by the look of the
+streak that there’s a snag there in a swift current which breaks on it
+and makes that streak look that way; and you see the mist curl up off
+of the water, and the east reddens up, and the river, and you make out a
+log-cabin in the edge of the woods, away on the bank on t’other side of
+the river, being a woodyard, likely, and piled by them cheats so you can
+throw a dog through it anywheres; then the nice breeze springs up, and
+comes fanning you from over there, so cool and fresh and sweet to smell
+on account of the woods and the flowers; but sometimes not that way,
+because they’ve left dead fish laying around, gars and such, and they
+do get pretty rank; and next you’ve got the full day, and everything
+smiling in the sun, and the song-birds just going it!
+
+A little smoke couldn’t be noticed now, so we would take some fish off
+of the lines and cook up a hot breakfast.  And afterwards we would watch
+the lonesomeness of the river, and kind of lazy along, and by and by
+lazy off to sleep.  Wake up by and by, and look to see what done it, and
+maybe see a steamboat coughing along up-stream, so far off towards the
+other side you couldn’t tell nothing about her only whether she was
+a stern-wheel or side-wheel; then for about an hour there wouldn’t be
+nothing to hear nor nothing to see--just solid lonesomeness.  Next
+you’d see a raft sliding by, away off yonder, and maybe a galoot on it
+chopping, because they’re most always doing it on a raft; you’d see the
+axe flash and come down--you don’t hear nothing; you see that axe go
+up again, and by the time it’s above the man’s head then you hear the
+_k’chunk_!--it had took all that time to come over the water.  So we
+would put in the day, lazying around, listening to the stillness.  Once
+there was a thick fog, and the rafts and things that went by was beating
+tin pans so the steamboats wouldn’t run over them.  A scow or a
+raft went by so close we could hear them talking and cussing and
+laughing--heard them plain; but we couldn’t see no sign of them; it made
+you feel crawly; it was like spirits carrying on that way in the air.
+ Jim said he believed it was spirits; but I says:
+
+“No; spirits wouldn’t say, ‘Dern the dern fog.’”
+
+Soon as it was night out we shoved; when we got her out to about the
+middle we let her alone, and let her float wherever the current wanted
+her to; then we lit the pipes, and dangled our legs in the water, and
+talked about all kinds of things--we was always naked, day and night,
+whenever the mosquitoes would let us--the new clothes Buck’s folks made
+for me was too good to be comfortable, and besides I didn’t go much on
+clothes, nohow.
+
+Sometimes we’d have that whole river all to ourselves for the longest
+time. Yonder was the banks and the islands, across the water; and maybe
+a spark--which was a candle in a cabin window; and sometimes on the water
+you could see a spark or two--on a raft or a scow, you know; and maybe
+you could hear a fiddle or a song coming over from one of them crafts.
+It’s lovely to live on a raft.  We had the sky up there, all speckled
+with stars, and we used to lay on our backs and look up at them, and
+discuss about whether they was made or only just happened.  Jim he
+allowed they was made, but I allowed they happened; I judged it would
+have took too long to _make_ so many.  Jim said the moon could a _laid_
+them; well, that looked kind of reasonable, so I didn’t say nothing
+against it, because I’ve seen a frog lay most as many, so of course it
+could be done. We used to watch the stars that fell, too, and see them
+streak down.  Jim allowed they’d got spoiled and was hove out of the
+nest.
+
+Once or twice of a night we would see a steamboat slipping along in the
+dark, and now and then she would belch a whole world of sparks up out
+of her chimbleys, and they would rain down in the river and look awful
+pretty; then she would turn a corner and her lights would wink out and
+her powwow shut off and leave the river still again; and by and by her
+waves would get to us, a long time after she was gone, and joggle the
+raft a bit, and after that you wouldn’t hear nothing for you couldn’t
+tell how long, except maybe frogs or something.
+
+After midnight the people on shore went to bed, and then for two or
+three hours the shores was black--no more sparks in the cabin windows.
+ These sparks was our clock--the first one that showed again meant
+morning was coming, so we hunted a place to hide and tie up right away.
+
+One morning about daybreak I found a canoe and crossed over a chute to
+the main shore--it was only two hundred yards--and paddled about a mile
+up a crick amongst the cypress woods, to see if I couldn’t get some
+berries. Just as I was passing a place where a kind of a cowpath crossed
+the crick, here comes a couple of men tearing up the path as tight as
+they could foot it.  I thought I was a goner, for whenever anybody was
+after anybody I judged it was _me_--or maybe Jim.  I was about to dig out
+from there in a hurry, but they was pretty close to me then, and sung
+out and begged me to save their lives--said they hadn’t been doing
+nothing, and was being chased for it--said there was men and dogs
+a-coming.  They wanted to jump right in, but I says:
+
+“Don’t you do it.  I don’t hear the dogs and horses yet; you’ve got time
+to crowd through the brush and get up the crick a little ways; then you
+take to the water and wade down to me and get in--that’ll throw the dogs
+off the scent.”
+
+They done it, and soon as they was aboard I lit out for our towhead,
+and in about five or ten minutes we heard the dogs and the men away off,
+shouting. We heard them come along towards the crick, but couldn’t
+see them; they seemed to stop and fool around a while; then, as we got
+further and further away all the time, we couldn’t hardly hear them at
+all; by the time we had left a mile of woods behind us and struck the
+river, everything was quiet, and we paddled over to the towhead and hid
+in the cottonwoods and was safe.
+
+One of these fellows was about seventy or upwards, and had a bald head
+and very gray whiskers.  He had an old battered-up slouch hat on, and
+a greasy blue woollen shirt, and ragged old blue jeans britches stuffed
+into his boot-tops, and home-knit galluses--no, he only had one.  He had
+an old long-tailed blue jeans coat with slick brass buttons flung over
+his arm, and both of them had big, fat, ratty-looking carpet-bags.
+
+The other fellow was about thirty, and dressed about as ornery.  After
+breakfast we all laid off and talked, and the first thing that come out
+was that these chaps didn’t know one another.
+
+“What got you into trouble?” says the baldhead to t’other chap.
+
+“Well, I’d been selling an article to take the tartar off the teeth--and
+it does take it off, too, and generly the enamel along with it--but I
+stayed about one night longer than I ought to, and was just in the act
+of sliding out when I ran across you on the trail this side of town, and
+you told me they were coming, and begged me to help you to get off.  So
+I told you I was expecting trouble myself, and would scatter out _with_
+you. That’s the whole yarn--what’s yourn?
+
+“Well, I’d ben a-running’ a little temperance revival thar ‘bout a week,
+and was the pet of the women folks, big and little, for I was makin’ it
+mighty warm for the rummies, I _tell_ you, and takin’ as much as five
+or six dollars a night--ten cents a head, children and niggers free--and
+business a-growin’ all the time, when somehow or another a little report
+got around last night that I had a way of puttin’ in my time with a
+private jug on the sly.  A nigger rousted me out this mornin’, and told
+me the people was getherin’ on the quiet with their dogs and horses, and
+they’d be along pretty soon and give me ‘bout half an hour’s start,
+and then run me down if they could; and if they got me they’d tar
+and feather me and ride me on a rail, sure.  I didn’t wait for no
+breakfast--I warn’t hungry.”
+
+“Old man,” said the young one, “I reckon we might double-team it
+together; what do you think?”
+
+“I ain’t undisposed.  What’s your line--mainly?”
+
+“Jour printer by trade; do a little in patent medicines;
+theater-actor--tragedy, you know; take a turn to mesmerism and phrenology
+when there’s a chance; teach singing-geography school for a change;
+sling a lecture sometimes--oh, I do lots of things--most anything that
+comes handy, so it ain’t work.  What’s your lay?”
+
+“I’ve done considerble in the doctoring way in my time.  Layin’ on o’
+hands is my best holt--for cancer and paralysis, and sich things; and I
+k’n tell a fortune pretty good when I’ve got somebody along to find out
+the facts for me.  Preachin’s my line, too, and workin’ camp-meetin’s,
+and missionaryin’ around.”
+
+Nobody never said anything for a while; then the young man hove a sigh
+and says:
+
+“Alas!”
+
+“What ‘re you alassin’ about?” says the bald-head.
+
+“To think I should have lived to be leading such a life, and be degraded
+down into such company.”  And he begun to wipe the corner of his eye
+with a rag.
+
+“Dern your skin, ain’t the company good enough for you?” says the
+baldhead, pretty pert and uppish.
+
+“Yes, it _is_ good enough for me; it’s as good as I deserve; for who
+fetched me so low when I was so high?  I did myself.  I don’t blame
+_you_, gentlemen--far from it; I don’t blame anybody.  I deserve it
+all.  Let the cold world do its worst; one thing I know--there’s a grave
+somewhere for me. The world may go on just as it’s always done, and take
+everything from me--loved ones, property, everything; but it can’t take
+that. Some day I’ll lie down in it and forget it all, and my poor broken
+heart will be at rest.”  He went on a-wiping.
+
+“Drot your pore broken heart,” says the baldhead; “what are you heaving
+your pore broken heart at _us_ f’r?  _we_ hain’t done nothing.”
+
+“No, I know you haven’t.  I ain’t blaming you, gentlemen.  I brought
+myself down--yes, I did it myself.  It’s right I should suffer--perfectly
+right--I don’t make any moan.”
+
+“Brought you down from whar?  Whar was you brought down from?”
+
+“Ah, you would not believe me; the world never believes--let it pass--‘tis
+no matter.  The secret of my birth--”
+
+“The secret of your birth!  Do you mean to say--”
+
+“Gentlemen,” says the young man, very solemn, “I will reveal it to you,
+for I feel I may have confidence in you.  By rights I am a duke!”
+
+Jim’s eyes bugged out when he heard that; and I reckon mine did, too.
+Then the baldhead says:  “No! you can’t mean it?”
+
+“Yes.  My great-grandfather, eldest son of the Duke of Bridgewater, fled
+to this country about the end of the last century, to breathe the pure
+air of freedom; married here, and died, leaving a son, his own father
+dying about the same time.  The second son of the late duke seized the
+titles and estates--the infant real duke was ignored.  I am the lineal
+descendant of that infant--I am the rightful Duke of Bridgewater; and
+here am I, forlorn, torn from my high estate, hunted of men, despised
+by the cold world, ragged, worn, heart-broken, and degraded to the
+companionship of felons on a raft!”
+
+Jim pitied him ever so much, and so did I. We tried to comfort him, but
+he said it warn’t much use, he couldn’t be much comforted; said if we
+was a mind to acknowledge him, that would do him more good than most
+anything else; so we said we would, if he would tell us how.  He said we
+ought to bow when we spoke to him, and say “Your Grace,” or “My Lord,”
+ or “Your Lordship”--and he wouldn’t mind it if we called him plain
+“Bridgewater,” which, he said, was a title anyway, and not a name; and
+one of us ought to wait on him at dinner, and do any little thing for
+him he wanted done.
+
+Well, that was all easy, so we done it.  All through dinner Jim stood
+around and waited on him, and says, “Will yo’ Grace have some o’ dis or
+some o’ dat?” and so on, and a body could see it was mighty pleasing to
+him.
+
+But the old man got pretty silent by and by--didn’t have much to say, and
+didn’t look pretty comfortable over all that petting that was going on
+around that duke.  He seemed to have something on his mind.  So, along
+in the afternoon, he says:
+
+“Looky here, Bilgewater,” he says, “I’m nation sorry for you, but you
+ain’t the only person that’s had troubles like that.”
+
+“No?”
+
+“No you ain’t.  You ain’t the only person that’s ben snaked down
+wrongfully out’n a high place.”
+
+“Alas!”
+
+“No, you ain’t the only person that’s had a secret of his birth.”  And,
+by jings, _he_ begins to cry.
+
+“Hold!  What do you mean?”
+
+“Bilgewater, kin I trust you?” says the old man, still sort of sobbing.
+
+“To the bitter death!”  He took the old man by the hand and squeezed it,
+and says, “That secret of your being:  speak!”
+
+“Bilgewater, I am the late Dauphin!”
+
+You bet you, Jim and me stared this time.  Then the duke says:
+
+“You are what?”
+
+“Yes, my friend, it is too true--your eyes is lookin’ at this very moment
+on the pore disappeared Dauphin, Looy the Seventeen, son of Looy the
+Sixteen and Marry Antonette.”
+
+“You!  At your age!  No!  You mean you’re the late Charlemagne; you must
+be six or seven hundred years old, at the very least.”
+
+“Trouble has done it, Bilgewater, trouble has done it; trouble has brung
+these gray hairs and this premature balditude.  Yes, gentlemen, you
+see before you, in blue jeans and misery, the wanderin’, exiled,
+trampled-on, and sufferin’ rightful King of France.”
+
+Well, he cried and took on so that me and Jim didn’t know hardly what to
+do, we was so sorry--and so glad and proud we’d got him with us, too.
+ So we set in, like we done before with the duke, and tried to comfort
+_him_. But he said it warn’t no use, nothing but to be dead and done
+with it all could do him any good; though he said it often made him feel
+easier and better for a while if people treated him according to his
+rights, and got down on one knee to speak to him, and always called him
+“Your Majesty,” and waited on him first at meals, and didn’t set down
+in his presence till he asked them. So Jim and me set to majestying him,
+and doing this and that and t’other for him, and standing up till he
+told us we might set down.  This done him heaps of good, and so he
+got cheerful and comfortable.  But the duke kind of soured on him, and
+didn’t look a bit satisfied with the way things was going; still,
+the king acted real friendly towards him, and said the duke’s
+great-grandfather and all the other Dukes of Bilgewater was a good
+deal thought of by _his_ father, and was allowed to come to the palace
+considerable; but the duke stayed huffy a good while, till by and by the
+king says:
+
+“Like as not we got to be together a blamed long time on this h-yer
+raft, Bilgewater, and so what’s the use o’ your bein’ sour?  It ‘ll only
+make things oncomfortable.  It ain’t my fault I warn’t born a duke,
+it ain’t your fault you warn’t born a king--so what’s the use to worry?
+ Make the best o’ things the way you find ‘em, says I--that’s my motto.
+ This ain’t no bad thing that we’ve struck here--plenty grub and an easy
+life--come, give us your hand, duke, and le’s all be friends.”
+
+The duke done it, and Jim and me was pretty glad to see it.  It took
+away all the uncomfortableness and we felt mighty good over it, because
+it would a been a miserable business to have any unfriendliness on the
+raft; for what you want, above all things, on a raft, is for everybody
+to be satisfied, and feel right and kind towards the others.
+
+It didn’t take me long to make up my mind that these liars warn’t no
+kings nor dukes at all, but just low-down humbugs and frauds.  But I
+never said nothing, never let on; kept it to myself; it’s the best way;
+then you don’t have no quarrels, and don’t get into no trouble.  If they
+wanted us to call them kings and dukes, I hadn’t no objections, ‘long as
+it would keep peace in the family; and it warn’t no use to tell Jim, so
+I didn’t tell him.  If I never learnt nothing else out of pap, I learnt
+that the best way to get along with his kind of people is to let them
+have their own way.
+
+
+
+
+CHAPTER XX.
+
+THEY asked us considerable many questions; wanted to know what we
+covered up the raft that way for, and laid by in the daytime instead of
+running--was Jim a runaway nigger?  Says I:
+
+“Goodness sakes! would a runaway nigger run _south_?”
+
+No, they allowed he wouldn’t.  I had to account for things some way, so
+I says:
+
+“My folks was living in Pike County, in Missouri, where I was born, and
+they all died off but me and pa and my brother Ike.  Pa, he ‘lowed
+he’d break up and go down and live with Uncle Ben, who’s got a little
+one-horse place on the river, forty-four mile below Orleans.  Pa was
+pretty poor, and had some debts; so when he’d squared up there warn’t
+nothing left but sixteen dollars and our nigger, Jim.  That warn’t
+enough to take us fourteen hundred mile, deck passage nor no other way.
+ Well, when the river rose pa had a streak of luck one day; he ketched
+this piece of a raft; so we reckoned we’d go down to Orleans on it.
+ Pa’s luck didn’t hold out; a steamboat run over the forrard corner of
+the raft one night, and we all went overboard and dove under the wheel;
+Jim and me come up all right, but pa was drunk, and Ike was only four
+years old, so they never come up no more.  Well, for the next day or
+two we had considerable trouble, because people was always coming out in
+skiffs and trying to take Jim away from me, saying they believed he was
+a runaway nigger.  We don’t run daytimes no more now; nights they don’t
+bother us.”
+
+The duke says:
+
+“Leave me alone to cipher out a way so we can run in the daytime if we
+want to.  I’ll think the thing over--I’ll invent a plan that’ll fix it.
+We’ll let it alone for to-day, because of course we don’t want to go by
+that town yonder in daylight--it mightn’t be healthy.”
+
+Towards night it begun to darken up and look like rain; the heat
+lightning was squirting around low down in the sky, and the leaves was
+beginning to shiver--it was going to be pretty ugly, it was easy to see
+that.  So the duke and the king went to overhauling our wigwam, to see
+what the beds was like.  My bed was a straw tick better than Jim’s,
+which was a corn-shuck tick; there’s always cobs around about in a shuck
+tick, and they poke into you and hurt; and when you roll over the dry
+shucks sound like you was rolling over in a pile of dead leaves; it
+makes such a rustling that you wake up.  Well, the duke allowed he would
+take my bed; but the king allowed he wouldn’t.  He says:
+
+“I should a reckoned the difference in rank would a sejested to you that
+a corn-shuck bed warn’t just fitten for me to sleep on.  Your Grace ‘ll
+take the shuck bed yourself.”
+
+Jim and me was in a sweat again for a minute, being afraid there was
+going to be some more trouble amongst them; so we was pretty glad when
+the duke says:
+
+“‘Tis my fate to be always ground into the mire under the iron heel of
+oppression.  Misfortune has broken my once haughty spirit; I yield, I
+submit; ‘tis my fate.  I am alone in the world--let me suffer; can bear
+it.”
+
+We got away as soon as it was good and dark.  The king told us to stand
+well out towards the middle of the river, and not show a light till we
+got a long ways below the town.  We come in sight of the little bunch of
+lights by and by--that was the town, you know--and slid by, about a half
+a mile out, all right.  When we was three-quarters of a mile below we
+hoisted up our signal lantern; and about ten o’clock it come on to rain
+and blow and thunder and lighten like everything; so the king told us
+to both stay on watch till the weather got better; then him and the duke
+crawled into the wigwam and turned in for the night.  It was my watch
+below till twelve, but I wouldn’t a turned in anyway if I’d had a bed,
+because a body don’t see such a storm as that every day in the week, not
+by a long sight.  My souls, how the wind did scream along!  And every
+second or two there’d come a glare that lit up the white-caps for a half
+a mile around, and you’d see the islands looking dusty through the rain,
+and the trees thrashing around in the wind; then comes a H-WHACK!--bum!
+bum! bumble-umble-um-bum-bum-bum-bum--and the thunder would go rumbling
+and grumbling away, and quit--and then RIP comes another flash and
+another sockdolager.  The waves most washed me off the raft sometimes,
+but I hadn’t any clothes on, and didn’t mind.  We didn’t have no trouble
+about snags; the lightning was glaring and flittering around so constant
+that we could see them plenty soon enough to throw her head this way or
+that and miss them.
+
+I had the middle watch, you know, but I was pretty sleepy by that time,
+so Jim he said he would stand the first half of it for me; he was always
+mighty good that way, Jim was.  I crawled into the wigwam, but the king
+and the duke had their legs sprawled around so there warn’t no show for
+me; so I laid outside--I didn’t mind the rain, because it was warm, and
+the waves warn’t running so high now.  About two they come up again,
+though, and Jim was going to call me; but he changed his mind, because
+he reckoned they warn’t high enough yet to do any harm; but he was
+mistaken about that, for pretty soon all of a sudden along comes a
+regular ripper and washed me overboard.  It most killed Jim a-laughing.
+ He was the easiest nigger to laugh that ever was, anyway.
+
+I took the watch, and Jim he laid down and snored away; and by and by
+the storm let up for good and all; and the first cabin-light that showed
+I rousted him out, and we slid the raft into hiding quarters for the
+day.
+
+The king got out an old ratty deck of cards after breakfast, and him
+and the duke played seven-up a while, five cents a game.  Then they got
+tired of it, and allowed they would “lay out a campaign,” as they called
+it. The duke went down into his carpet-bag, and fetched up a lot of
+little printed bills and read them out loud.  One bill said, “The
+celebrated Dr. Armand de Montalban, of Paris,” would “lecture on the
+Science of Phrenology” at such and such a place, on the blank day of
+blank, at ten cents admission, and “furnish charts of character at
+twenty-five cents apiece.”  The duke said that was _him_.  In another
+bill he was the “world-renowned Shakespearian tragedian, Garrick the
+Younger, of Drury Lane, London.”  In other bills he had a lot of other
+names and done other wonderful things, like finding water and gold with
+a “divining-rod,” “dissipating witch spells,” and so on.  By and by he
+says:
+
+“But the histrionic muse is the darling.  Have you ever trod the boards,
+Royalty?”
+
+“No,” says the king.
+
+“You shall, then, before you’re three days older, Fallen Grandeur,” says
+the duke.  “The first good town we come to we’ll hire a hall and do the
+sword fight in Richard III. and the balcony scene in Romeo and Juliet.
+How does that strike you?”
+
+“I’m in, up to the hub, for anything that will pay, Bilgewater; but, you
+see, I don’t know nothing about play-actin’, and hain’t ever seen much
+of it.  I was too small when pap used to have ‘em at the palace.  Do you
+reckon you can learn me?”
+
+“Easy!”
+
+“All right.  I’m jist a-freezn’ for something fresh, anyway.  Le’s
+commence right away.”
+
+So the duke he told him all about who Romeo was and who Juliet was, and
+said he was used to being Romeo, so the king could be Juliet.
+
+“But if Juliet’s such a young gal, duke, my peeled head and my white
+whiskers is goin’ to look oncommon odd on her, maybe.”
+
+“No, don’t you worry; these country jakes won’t ever think of that.
+Besides, you know, you’ll be in costume, and that makes all the
+difference in the world; Juliet’s in a balcony, enjoying the moonlight
+before she goes to bed, and she’s got on her night-gown and her ruffled
+nightcap.  Here are the costumes for the parts.”
+
+He got out two or three curtain-calico suits, which he said was
+meedyevil armor for Richard III. and t’other chap, and a long white
+cotton nightshirt and a ruffled nightcap to match.  The king was
+satisfied; so the duke got out his book and read the parts over in the
+most splendid spread-eagle way, prancing around and acting at the same
+time, to show how it had got to be done; then he give the book to the
+king and told him to get his part by heart.
+
+There was a little one-horse town about three mile down the bend, and
+after dinner the duke said he had ciphered out his idea about how to run
+in daylight without it being dangersome for Jim; so he allowed he would
+go down to the town and fix that thing.  The king allowed he would go,
+too, and see if he couldn’t strike something.  We was out of coffee, so
+Jim said I better go along with them in the canoe and get some.
+
+When we got there there warn’t nobody stirring; streets empty, and
+perfectly dead and still, like Sunday.  We found a sick nigger sunning
+himself in a back yard, and he said everybody that warn’t too young or
+too sick or too old was gone to camp-meeting, about two mile back in the
+woods.  The king got the directions, and allowed he’d go and work that
+camp-meeting for all it was worth, and I might go, too.
+
+The duke said what he was after was a printing-office.  We found it;
+a little bit of a concern, up over a carpenter shop--carpenters and
+printers all gone to the meeting, and no doors locked.  It was a dirty,
+littered-up place, and had ink marks, and handbills with pictures of
+horses and runaway niggers on them, all over the walls.  The duke shed
+his coat and said he was all right now.  So me and the king lit out for
+the camp-meeting.
+
+We got there in about a half an hour fairly dripping, for it was a most
+awful hot day.  There was as much as a thousand people there from
+twenty mile around.  The woods was full of teams and wagons, hitched
+everywheres, feeding out of the wagon-troughs and stomping to keep
+off the flies.  There was sheds made out of poles and roofed over with
+branches, where they had lemonade and gingerbread to sell, and piles of
+watermelons and green corn and such-like truck.
+
+The preaching was going on under the same kinds of sheds, only they was
+bigger and held crowds of people.  The benches was made out of outside
+slabs of logs, with holes bored in the round side to drive sticks into
+for legs. They didn’t have no backs.  The preachers had high platforms
+to stand on at one end of the sheds.  The women had on sun-bonnets;
+and some had linsey-woolsey frocks, some gingham ones, and a few of the
+young ones had on calico.  Some of the young men was barefooted, and
+some of the children didn’t have on any clothes but just a tow-linen
+shirt.  Some of the old women was knitting, and some of the young folks
+was courting on the sly.
+
+The first shed we come to the preacher was lining out a hymn.  He lined
+out two lines, everybody sung it, and it was kind of grand to hear it,
+there was so many of them and they done it in such a rousing way; then
+he lined out two more for them to sing--and so on.  The people woke up
+more and more, and sung louder and louder; and towards the end some
+begun to groan, and some begun to shout.  Then the preacher begun to
+preach, and begun in earnest, too; and went weaving first to one side of
+the platform and then the other, and then a-leaning down over the front
+of it, with his arms and his body going all the time, and shouting his
+words out with all his might; and every now and then he would hold up
+his Bible and spread it open, and kind of pass it around this way and
+that, shouting, “It’s the brazen serpent in the wilderness!  Look upon
+it and live!”  And people would shout out, “Glory!--A-a-_men_!”  And so
+he went on, and the people groaning and crying and saying amen:
+
+“Oh, come to the mourners’ bench! come, black with sin! (_Amen_!) come,
+sick and sore! (_Amen_!) come, lame and halt and blind! (_Amen_!) come,
+pore and needy, sunk in shame! (_A-A-Men_!) come, all that’s worn and
+soiled and suffering!--come with a broken spirit! come with a contrite
+heart! come in your rags and sin and dirt! the waters that cleanse
+is free, the door of heaven stands open--oh, enter in and be at rest!”
+ (_A-A-Men_!  _Glory, Glory Hallelujah!_)
+
+And so on.  You couldn’t make out what the preacher said any more, on
+account of the shouting and crying.  Folks got up everywheres in the
+crowd, and worked their way just by main strength to the mourners’
+bench, with the tears running down their faces; and when all the
+mourners had got up there to the front benches in a crowd, they sung and
+shouted and flung themselves down on the straw, just crazy and wild.
+
+Well, the first I knowed the king got a-going, and you could hear him
+over everybody; and next he went a-charging up on to the platform, and
+the preacher he begged him to speak to the people, and he done it.  He
+told them he was a pirate--been a pirate for thirty years out in the
+Indian Ocean--and his crew was thinned out considerable last spring in
+a fight, and he was home now to take out some fresh men, and thanks to
+goodness he’d been robbed last night and put ashore off of a steamboat
+without a cent, and he was glad of it; it was the blessedest thing that
+ever happened to him, because he was a changed man now, and happy for
+the first time in his life; and, poor as he was, he was going to start
+right off and work his way back to the Indian Ocean, and put in the rest
+of his life trying to turn the pirates into the true path; for he could
+do it better than anybody else, being acquainted with all pirate crews
+in that ocean; and though it would take him a long time to get there
+without money, he would get there anyway, and every time he convinced
+a pirate he would say to him, “Don’t you thank me, don’t you give me no
+credit; it all belongs to them dear people in Pokeville camp-meeting,
+natural brothers and benefactors of the race, and that dear preacher
+there, the truest friend a pirate ever had!”
+
+And then he busted into tears, and so did everybody.  Then somebody
+sings out, “Take up a collection for him, take up a collection!”  Well,
+a half a dozen made a jump to do it, but somebody sings out, “Let _him_
+pass the hat around!”  Then everybody said it, the preacher too.
+
+So the king went all through the crowd with his hat swabbing his eyes,
+and blessing the people and praising them and thanking them for being
+so good to the poor pirates away off there; and every little while the
+prettiest kind of girls, with the tears running down their cheeks, would
+up and ask him would he let them kiss him for to remember him by; and he
+always done it; and some of them he hugged and kissed as many as five or
+six times--and he was invited to stay a week; and everybody wanted him to
+live in their houses, and said they’d think it was an honor; but he said
+as this was the last day of the camp-meeting he couldn’t do no good, and
+besides he was in a sweat to get to the Indian Ocean right off and go to
+work on the pirates.
+
+When we got back to the raft and he come to count up he found he had
+collected eighty-seven dollars and seventy-five cents.  And then he had
+fetched away a three-gallon jug of whisky, too, that he found under a
+wagon when he was starting home through the woods.  The king said,
+take it all around, it laid over any day he’d ever put in in the
+missionarying line.  He said it warn’t no use talking, heathens don’t
+amount to shucks alongside of pirates to work a camp-meeting with.
+
+The duke was thinking _he’d_ been doing pretty well till the king come
+to show up, but after that he didn’t think so so much.  He had set
+up and printed off two little jobs for farmers in that
+printing-office--horse bills--and took the money, four dollars.  And he
+had got in ten dollars’ worth of advertisements for the paper, which he
+said he would put in for four dollars if they would pay in advance--so
+they done it. The price of the paper was two dollars a year, but he took
+in three subscriptions for half a dollar apiece on condition of them
+paying him in advance; they were going to pay in cordwood and onions as
+usual, but he said he had just bought the concern and knocked down the
+price as low as he could afford it, and was going to run it for cash.
+ He set up a little piece of poetry, which he made, himself, out of
+his own head--three verses--kind of sweet and saddish--the name of it was,
+“Yes, crush, cold world, this breaking heart”--and he left that all set
+up and ready to print in the paper, and didn’t charge nothing for it.
+ Well, he took in nine dollars and a half, and said he’d done a pretty
+square day’s work for it.
+
+Then he showed us another little job he’d printed and hadn’t charged
+for, because it was for us.  It had a picture of a runaway nigger with
+a bundle on a stick over his shoulder, and “$200 reward” under it.  The
+reading was all about Jim, and just described him to a dot.  It said
+he run away from St. Jacques’ plantation, forty mile below New Orleans,
+last winter, and likely went north, and whoever would catch him and send
+him back he could have the reward and expenses.
+
+“Now,” says the duke, “after to-night we can run in the daytime if we
+want to.  Whenever we see anybody coming we can tie Jim hand and foot
+with a rope, and lay him in the wigwam and show this handbill and say we
+captured him up the river, and were too poor to travel on a steamboat,
+so we got this little raft on credit from our friends and are going down
+to get the reward.  Handcuffs and chains would look still better on Jim,
+but it wouldn’t go well with the story of us being so poor.  Too much
+like jewelry.  Ropes are the correct thing--we must preserve the unities,
+as we say on the boards.”
+
+We all said the duke was pretty smart, and there couldn’t be no trouble
+about running daytimes.  We judged we could make miles enough that night
+to get out of the reach of the powwow we reckoned the duke’s work in
+the printing office was going to make in that little town; then we could
+boom right along if we wanted to.
+
+We laid low and kept still, and never shoved out till nearly ten
+o’clock; then we slid by, pretty wide away from the town, and didn’t
+hoist our lantern till we was clear out of sight of it.
+
+When Jim called me to take the watch at four in the morning, he says:
+
+“Huck, does you reck’n we gwyne to run acrost any mo’ kings on dis
+trip?”
+
+“No,” I says, “I reckon not.”
+
+“Well,” says he, “dat’s all right, den.  I doan’ mine one er two kings,
+but dat’s enough.  Dis one’s powerful drunk, en de duke ain’ much
+better.”
+
+I found Jim had been trying to get him to talk French, so he could hear
+what it was like; but he said he had been in this country so long, and
+had so much trouble, he’d forgot it.
+
+
+
+
+CHAPTER XXI.
+
+IT was after sun-up now, but we went right on and didn’t tie up.  The
+king and the duke turned out by and by looking pretty rusty; but after
+they’d jumped overboard and took a swim it chippered them up a good
+deal. After breakfast the king he took a seat on the corner of the raft,
+and pulled off his boots and rolled up his britches, and let his legs
+dangle in the water, so as to be comfortable, and lit his pipe, and went
+to getting his Romeo and Juliet by heart.  When he had got it pretty
+good him and the duke begun to practice it together.  The duke had to
+learn him over and over again how to say every speech; and he made him
+sigh, and put his hand on his heart, and after a while he said he done
+it pretty well; “only,” he says, “you mustn’t bellow out _Romeo_!
+that way, like a bull--you must say it soft and sick and languishy,
+so--R-o-o-meo! that is the idea; for Juliet’s a dear sweet mere child of
+a girl, you know, and she doesn’t bray like a jackass.”
+
+Well, next they got out a couple of long swords that the duke made out
+of oak laths, and begun to practice the sword fight--the duke called
+himself Richard III.; and the way they laid on and pranced around
+the raft was grand to see.  But by and by the king tripped and fell
+overboard, and after that they took a rest, and had a talk about all
+kinds of adventures they’d had in other times along the river.
+
+After dinner the duke says:
+
+“Well, Capet, we’ll want to make this a first-class show, you know, so
+I guess we’ll add a little more to it.  We want a little something to
+answer encores with, anyway.”
+
+“What’s onkores, Bilgewater?”
+
+The duke told him, and then says:
+
+“I’ll answer by doing the Highland fling or the sailor’s hornpipe; and
+you--well, let me see--oh, I’ve got it--you can do Hamlet’s soliloquy.”
+
+“Hamlet’s which?”
+
+“Hamlet’s soliloquy, you know; the most celebrated thing in Shakespeare.
+Ah, it’s sublime, sublime!  Always fetches the house.  I haven’t got
+it in the book--I’ve only got one volume--but I reckon I can piece it out
+from memory.  I’ll just walk up and down a minute, and see if I can call
+it back from recollection’s vaults.”
+
+So he went to marching up and down, thinking, and frowning horrible
+every now and then; then he would hoist up his eyebrows; next he would
+squeeze his hand on his forehead and stagger back and kind of moan; next
+he would sigh, and next he’d let on to drop a tear.  It was beautiful
+to see him. By and by he got it.  He told us to give attention.  Then
+he strikes a most noble attitude, with one leg shoved forwards, and his
+arms stretched away up, and his head tilted back, looking up at the sky;
+and then he begins to rip and rave and grit his teeth; and after that,
+all through his speech, he howled, and spread around, and swelled up his
+chest, and just knocked the spots out of any acting ever I see before.
+ This is the speech--I learned it, easy enough, while he was learning it
+to the king:
+
+To be, or not to be; that is the bare bodkin That makes calamity of
+so long life; For who would fardels bear, till Birnam Wood do come
+to Dunsinane, But that the fear of something after death Murders the
+innocent sleep, Great nature’s second course, And makes us rather sling
+the arrows of outrageous fortune Than fly to others that we know not of.
+There’s the respect must give us pause: Wake Duncan with thy knocking! I
+would thou couldst; For who would bear the whips and scorns of time, The
+oppressor’s wrong, the proud man’s contumely, The law’s delay, and the
+quietus which his pangs might take. In the dead waste and middle of the
+night, when churchyards yawn In customary suits of solemn black, But
+that the undiscovered country from whose bourne no traveler returns,
+Breathes forth contagion on the world, And thus the native hue of
+resolution, like the poor cat i’ the adage, Is sicklied o’er with care.
+And all the clouds that lowered o’er our housetops, With this
+regard their currents turn awry, And lose the name of action. ‘Tis a
+consummation devoutly to be wished. But soft you, the fair Ophelia: Ope
+not thy ponderous and marble jaws. But get thee to a nunnery&mdash;go!
+
+Well, the old man he liked that speech, and he mighty soon got it so he
+could do it first rate. It seemed like he was just born for it; and when
+he had his hand in and was excited, it was perfectly lovely the way he
+would rip and tear and rair up behind when he was getting it off.
+
+The first chance we got, the duke he had some show bills printed; and
+after that, for two or three days as we floated along, the raft was a
+most uncommon lively place, for there warn’t nothing but sword-fighting
+and rehearsing--as the duke called it--going on all the time. One morning,
+when we was pretty well down the State of Arkansaw, we come in sight
+of a little one-horse town in a big bend; so we tied up about
+three-quarters of a mile above it, in the mouth of a crick which was
+shut in like a tunnel by the cypress trees, and all of us but Jim took
+the canoe and went down there to see if there was any chance in that
+place for our show.
+
+We struck it mighty lucky; there was going to be a circus there that
+afternoon, and the country people was already beginning to come in, in
+all kinds of old shackly wagons, and on horses. The circus would leave
+before night, so our show would have a pretty good chance. The duke he
+hired the court house, and we went around and stuck up our bills. They
+read like this:
+
+Shaksperean Revival!!!
+
+Wonderful Attraction!
+
+For One Night Only! The world renowned tragedians,
+
+David Garrick the younger, of Drury Lane Theatre, London,
+
+and
+
+Edmund Kean the elder, of the Royal Haymarket Theatre, Whitechapel,
+Pudding Lane, Piccadilly, London, and the Royal Continental Theatres, in
+their sublime Shaksperean Spectacle entitled The Balcony Scene in
+
+Romeo and Juliet!!!
+
+Romeo...................................... Mr. Garrick.
+
+Juliet..................................... Mr. Kean.
+
+Assisted by the whole strength of the company!
+
+New costumes, new scenery, new appointments!
+
+Also:
+
+The thrilling, masterly, and blood-curdling Broad-sword conflict In
+Richard III.!!!
+
+Richard III................................ Mr. Garrick.
+
+Richmond................................... Mr. Kean.
+
+also:
+
+(by special request,)
+
+Hamlet’s Immortal Soliloquy!!
+
+By the Illustrious Kean!
+
+Done by him 300 consecutive nights in Paris!
+
+For One Night Only,
+
+On account of imperative European engagements!
+
+Admission 25 cents; children and servants, 10 cents.
+
+Then we went loafing around the town. The stores and houses was most all
+old shackly dried-up frame concerns that hadn’t ever been painted; they
+was set up three or four foot above ground on stilts, so as to be out of
+reach of the water when the river was overflowed. The houses had little
+gardens around them, but they didn’t seem to raise hardly anything in
+them but jimpson weeds, and sunflowers, and ash-piles, and old curled-up
+boots and shoes, and pieces of bottles, and rags, and played-out
+tin-ware. The fences was made of different kinds of boards, nailed on
+at different times; and they leaned every which-way, and had gates that
+didn’t generly have but one hinge--a leather one. Some of the fences
+had been whitewashed, some time or another, but the duke said it was in
+Clumbus’s time, like enough. There was generly hogs in the garden, and
+people driving them out.
+
+All the stores was along one street.  They had white domestic awnings in
+front, and the country people hitched their horses to the awning-posts.
+There was empty drygoods boxes under the awnings, and loafers roosting
+on them all day long, whittling them with their Barlow knives; and
+chawing tobacco, and gaping and yawning and stretching--a mighty ornery
+lot. They generly had on yellow straw hats most as wide as an umbrella,
+but didn’t wear no coats nor waistcoats, they called one another Bill,
+and Buck, and Hank, and Joe, and Andy, and talked lazy and drawly, and
+used considerable many cuss words.  There was as many as one loafer
+leaning up against every awning-post, and he most always had his hands
+in his britches-pockets, except when he fetched them out to lend a chaw
+of tobacco or scratch.  What a body was hearing amongst them all the
+time was:
+
+“Gimme a chaw ‘v tobacker, Hank.”
+
+“Cain’t; I hain’t got but one chaw left.  Ask Bill.”
+
+Maybe Bill he gives him a chaw; maybe he lies and says he ain’t got
+none. Some of them kinds of loafers never has a cent in the world, nor a
+chaw of tobacco of their own.  They get all their chawing by borrowing;
+they say to a fellow, “I wisht you’d len’ me a chaw, Jack, I jist this
+minute give Ben Thompson the last chaw I had”--which is a lie pretty
+much everytime; it don’t fool nobody but a stranger; but Jack ain’t no
+stranger, so he says:
+
+“_You_ give him a chaw, did you?  So did your sister’s cat’s
+grandmother. You pay me back the chaws you’ve awready borry’d off’n me,
+Lafe Buckner, then I’ll loan you one or two ton of it, and won’t charge
+you no back intrust, nuther.”
+
+“Well, I _did_ pay you back some of it wunst.”
+
+“Yes, you did--‘bout six chaws.  You borry’d store tobacker and paid back
+nigger-head.”
+
+Store tobacco is flat black plug, but these fellows mostly chaws the
+natural leaf twisted.  When they borrow a chaw they don’t generly cut it
+off with a knife, but set the plug in between their teeth, and gnaw with
+their teeth and tug at the plug with their hands till they get it in
+two; then sometimes the one that owns the tobacco looks mournful at it
+when it’s handed back, and says, sarcastic:
+
+“Here, gimme the _chaw_, and you take the _plug_.”
+
+All the streets and lanes was just mud; they warn’t nothing else _but_
+mud--mud as black as tar and nigh about a foot deep in some places,
+and two or three inches deep in _all_ the places.  The hogs loafed and
+grunted around everywheres.  You’d see a muddy sow and a litter of pigs
+come lazying along the street and whollop herself right down in the way,
+where folks had to walk around her, and she’d stretch out and shut her
+eyes and wave her ears whilst the pigs was milking her, and look as
+happy as if she was on salary. And pretty soon you’d hear a loafer
+sing out, “Hi!  _so_ boy! sick him, Tige!” and away the sow would go,
+squealing most horrible, with a dog or two swinging to each ear, and
+three or four dozen more a-coming; and then you would see all the
+loafers get up and watch the thing out of sight, and laugh at the fun
+and look grateful for the noise.  Then they’d settle back again till
+there was a dog fight.  There couldn’t anything wake them up all over,
+and make them happy all over, like a dog fight--unless it might be
+putting turpentine on a stray dog and setting fire to him, or tying a
+tin pan to his tail and see him run himself to death.
+
+On the river front some of the houses was sticking out over the bank,
+and they was bowed and bent, and about ready to tumble in. The people
+had moved out of them.  The bank was caved away under one corner of some
+others, and that corner was hanging over.  People lived in them yet, but
+it was dangersome, because sometimes a strip of land as wide as a house
+caves in at a time.  Sometimes a belt of land a quarter of a mile deep
+will start in and cave along and cave along till it all caves into the
+river in one summer. Such a town as that has to be always moving back,
+and back, and back, because the river’s always gnawing at it.
+
+The nearer it got to noon that day the thicker and thicker was the
+wagons and horses in the streets, and more coming all the time.
+ Families fetched their dinners with them from the country, and eat them
+in the wagons.  There was considerable whisky drinking going on, and I
+seen three fights.  By and by somebody sings out:
+
+“Here comes old Boggs!--in from the country for his little old monthly
+drunk; here he comes, boys!”
+
+All the loafers looked glad; I reckoned they was used to having fun out
+of Boggs.  One of them says:
+
+“Wonder who he’s a-gwyne to chaw up this time.  If he’d a-chawed up all
+the men he’s ben a-gwyne to chaw up in the last twenty year he’d have
+considerable ruputation now.”
+
+Another one says, “I wisht old Boggs ‘d threaten me, ‘cuz then I’d know
+I warn’t gwyne to die for a thousan’ year.”
+
+Boggs comes a-tearing along on his horse, whooping and yelling like an
+Injun, and singing out:
+
+“Cler the track, thar.  I’m on the waw-path, and the price uv coffins is
+a-gwyne to raise.”
+
+He was drunk, and weaving about in his saddle; he was over fifty year
+old, and had a very red face.  Everybody yelled at him and laughed at
+him and sassed him, and he sassed back, and said he’d attend to them and
+lay them out in their regular turns, but he couldn’t wait now because
+he’d come to town to kill old Colonel Sherburn, and his motto was, “Meat
+first, and spoon vittles to top off on.”
+
+He see me, and rode up and says:
+
+“Whar’d you come f’m, boy?  You prepared to die?”
+
+Then he rode on.  I was scared, but a man says:
+
+“He don’t mean nothing; he’s always a-carryin’ on like that when he’s
+drunk.  He’s the best naturedest old fool in Arkansaw--never hurt nobody,
+drunk nor sober.”
+
+Boggs rode up before the biggest store in town, and bent his head down
+so he could see under the curtain of the awning and yells:
+
+“Come out here, Sherburn! Come out and meet the man you’ve swindled.
+You’re the houn’ I’m after, and I’m a-gwyne to have you, too!”
+
+And so he went on, calling Sherburn everything he could lay his tongue
+to, and the whole street packed with people listening and laughing and
+going on.  By and by a proud-looking man about fifty-five--and he was a
+heap the best dressed man in that town, too--steps out of the store, and
+the crowd drops back on each side to let him come.  He says to Boggs,
+mighty ca’m and slow--he says:
+
+“I’m tired of this, but I’ll endure it till one o’clock.  Till one
+o’clock, mind--no longer.  If you open your mouth against me only once
+after that time you can’t travel so far but I will find you.”
+
+Then he turns and goes in.  The crowd looked mighty sober; nobody
+stirred, and there warn’t no more laughing.  Boggs rode off
+blackguarding Sherburn as loud as he could yell, all down the street;
+and pretty soon back he comes and stops before the store, still keeping
+it up.  Some men crowded around him and tried to get him to shut up,
+but he wouldn’t; they told him it would be one o’clock in about fifteen
+minutes, and so he _must_ go home--he must go right away.  But it didn’t
+do no good.  He cussed away with all his might, and throwed his hat down
+in the mud and rode over it, and pretty soon away he went a-raging down
+the street again, with his gray hair a-flying. Everybody that could get
+a chance at him tried their best to coax him off of his horse so they
+could lock him up and get him sober; but it warn’t no use--up the street
+he would tear again, and give Sherburn another cussing.  By and by
+somebody says:
+
+“Go for his daughter!--quick, go for his daughter; sometimes he’ll listen
+to her.  If anybody can persuade him, she can.”
+
+So somebody started on a run.  I walked down street a ways and stopped.
+In about five or ten minutes here comes Boggs again, but not on his
+horse.  He was a-reeling across the street towards me, bare-headed, with
+a friend on both sides of him a-holt of his arms and hurrying him along.
+He was quiet, and looked uneasy; and he warn’t hanging back any, but was
+doing some of the hurrying himself.  Somebody sings out:
+
+“Boggs!”
+
+I looked over there to see who said it, and it was that Colonel
+Sherburn. He was standing perfectly still in the street, and had a
+pistol raised in his right hand--not aiming it, but holding it out with
+the barrel tilted up towards the sky.  The same second I see a young
+girl coming on the run, and two men with her.  Boggs and the men turned
+round to see who called him, and when they see the pistol the men
+jumped to one side, and the pistol-barrel come down slow and steady to
+a level--both barrels cocked. Boggs throws up both of his hands and says,
+“O Lord, don’t shoot!”  Bang! goes the first shot, and he staggers back,
+clawing at the air--bang! goes the second one, and he tumbles backwards
+on to the ground, heavy and solid, with his arms spread out.  That young
+girl screamed out and comes rushing, and down she throws herself on her
+father, crying, and saying, “Oh, he’s killed him, he’s killed him!”  The
+crowd closed up around them, and shouldered and jammed one another, with
+their necks stretched, trying to see, and people on the inside trying to
+shove them back and shouting, “Back, back! give him air, give him air!”
+
+Colonel Sherburn he tossed his pistol on to the ground, and turned
+around on his heels and walked off.
+
+They took Boggs to a little drug store, the crowd pressing around just
+the same, and the whole town following, and I rushed and got a good
+place at the window, where I was close to him and could see in.  They
+laid him on the floor and put one large Bible under his head, and opened
+another one and spread it on his breast; but they tore open his shirt
+first, and I seen where one of the bullets went in.  He made about a
+dozen long gasps, his breast lifting the Bible up when he drawed in his
+breath, and letting it down again when he breathed it out--and after that
+he laid still; he was dead.  Then they pulled his daughter away from
+him, screaming and crying, and took her off.  She was about sixteen, and
+very sweet and gentle looking, but awful pale and scared.
+
+Well, pretty soon the whole town was there, squirming and scrouging and
+pushing and shoving to get at the window and have a look, but people
+that had the places wouldn’t give them up, and folks behind them was
+saying all the time, “Say, now, you’ve looked enough, you fellows;
+‘tain’t right and ‘tain’t fair for you to stay thar all the time, and
+never give nobody a chance; other folks has their rights as well as
+you.”
+
+There was considerable jawing back, so I slid out, thinking maybe
+there was going to be trouble.  The streets was full, and everybody was
+excited. Everybody that seen the shooting was telling how it happened,
+and there was a big crowd packed around each one of these fellows,
+stretching their necks and listening.  One long, lanky man, with long
+hair and a big white fur stovepipe hat on the back of his head, and a
+crooked-handled cane, marked out the places on the ground where Boggs
+stood and where Sherburn stood, and the people following him around from
+one place to t’other and watching everything he done, and bobbing their
+heads to show they understood, and stooping a little and resting their
+hands on their thighs to watch him mark the places on the ground with
+his cane; and then he stood up straight and stiff where Sherburn had
+stood, frowning and having his hat-brim down over his eyes, and sung
+out, “Boggs!” and then fetched his cane down slow to a level, and says
+“Bang!” staggered backwards, says “Bang!” again, and fell down flat on
+his back. The people that had seen the thing said he done it perfect;
+said it was just exactly the way it all happened.  Then as much as a
+dozen people got out their bottles and treated him.
+
+Well, by and by somebody said Sherburn ought to be lynched.  In about a
+minute everybody was saying it; so away they went, mad and yelling, and
+snatching down every clothes-line they come to to do the hanging with.
+
+
+
+
+CHAPTER XXII.
+
+THEY swarmed up towards Sherburn’s house, a-whooping and raging like
+Injuns, and everything had to clear the way or get run over and tromped
+to mush, and it was awful to see.  Children was heeling it ahead of the
+mob, screaming and trying to get out of the way; and every window along
+the road was full of women’s heads, and there was nigger boys in every
+tree, and bucks and wenches looking over every fence; and as soon as the
+mob would get nearly to them they would break and skaddle back out of
+reach.  Lots of the women and girls was crying and taking on, scared
+most to death.
+
+They swarmed up in front of Sherburn’s palings as thick as they could
+jam together, and you couldn’t hear yourself think for the noise.  It
+was a little twenty-foot yard.  Some sung out “Tear down the fence! tear
+down the fence!”  Then there was a racket of ripping and tearing and
+smashing, and down she goes, and the front wall of the crowd begins to
+roll in like a wave.
+
+Just then Sherburn steps out on to the roof of his little front porch,
+with a double-barrel gun in his hand, and takes his stand, perfectly
+ca’m and deliberate, not saying a word.  The racket stopped, and the
+wave sucked back.
+
+Sherburn never said a word--just stood there, looking down.  The
+stillness was awful creepy and uncomfortable.  Sherburn run his eye slow
+along the crowd; and wherever it struck the people tried a little to
+out-gaze him, but they couldn’t; they dropped their eyes and looked
+sneaky. Then pretty soon Sherburn sort of laughed; not the pleasant
+kind, but the kind that makes you feel like when you are eating bread
+that’s got sand in it.
+
+Then he says, slow and scornful:
+
+“The idea of _you_ lynching anybody!  It’s amusing.  The idea of you
+thinking you had pluck enough to lynch a _man_!  Because you’re brave
+enough to tar and feather poor friendless cast-out women that come along
+here, did that make you think you had grit enough to lay your hands on a
+_man_?  Why, a _man’s_ safe in the hands of ten thousand of your kind--as
+long as it’s daytime and you’re not behind him.
+
+“Do I know you?  I know you clear through. I was born and raised in the
+South, and I’ve lived in the North; so I know the average all around.
+The average man’s a coward.  In the North he lets anybody walk over him
+that wants to, and goes home and prays for a humble spirit to bear it.
+In the South one man all by himself, has stopped a stage full of men
+in the daytime, and robbed the lot.  Your newspapers call you a
+brave people so much that you think you are braver than any other
+people--whereas you’re just _as_ brave, and no braver.  Why don’t your
+juries hang murderers?  Because they’re afraid the man’s friends will
+shoot them in the back, in the dark--and it’s just what they _would_ do.
+
+“So they always acquit; and then a _man_ goes in the night, with a
+hundred masked cowards at his back and lynches the rascal.  Your mistake
+is, that you didn’t bring a man with you; that’s one mistake, and the
+other is that you didn’t come in the dark and fetch your masks.  You
+brought _part_ of a man--Buck Harkness, there--and if you hadn’t had him
+to start you, you’d a taken it out in blowing.
+
+“You didn’t want to come.  The average man don’t like trouble and
+danger. _You_ don’t like trouble and danger.  But if only _half_ a
+man--like Buck Harkness, there--shouts ‘Lynch him! lynch him!’ you’re
+afraid to back down--afraid you’ll be found out to be what you
+are--_cowards_--and so you raise a yell, and hang yourselves on to that
+half-a-man’s coat-tail, and come raging up here, swearing what big
+things you’re going to do. The pitifulest thing out is a mob; that’s
+what an army is--a mob; they don’t fight with courage that’s born in
+them, but with courage that’s borrowed from their mass, and from their
+officers.  But a mob without any _man_ at the head of it is _beneath_
+pitifulness.  Now the thing for _you_ to do is to droop your tails and
+go home and crawl in a hole.  If any real lynching’s going to be done it
+will be done in the dark, Southern fashion; and when they come they’ll
+bring their masks, and fetch a _man_ along.  Now _leave_--and take your
+half-a-man with you”--tossing his gun up across his left arm and cocking
+it when he says this.
+
+The crowd washed back sudden, and then broke all apart, and went tearing
+off every which way, and Buck Harkness he heeled it after them, looking
+tolerable cheap.  I could a stayed if I wanted to, but I didn’t want to.
+
+I went to the circus and loafed around the back side till the watchman
+went by, and then dived in under the tent.  I had my twenty-dollar gold
+piece and some other money, but I reckoned I better save it, because
+there ain’t no telling how soon you are going to need it, away from
+home and amongst strangers that way.  You can’t be too careful.  I ain’t
+opposed to spending money on circuses when there ain’t no other way, but
+there ain’t no use in _wasting_ it on them.
+
+It was a real bully circus.  It was the splendidest sight that ever was
+when they all come riding in, two and two, a gentleman and lady, side
+by side, the men just in their drawers and undershirts, and no shoes
+nor stirrups, and resting their hands on their thighs easy and
+comfortable--there must a been twenty of them--and every lady with a
+lovely complexion, and perfectly beautiful, and looking just like a gang
+of real sure-enough queens, and dressed in clothes that cost millions of
+dollars, and just littered with diamonds.  It was a powerful fine sight;
+I never see anything so lovely.  And then one by one they got up
+and stood, and went a-weaving around the ring so gentle and wavy and
+graceful, the men looking ever so tall and airy and straight, with their
+heads bobbing and skimming along, away up there under the tent-roof, and
+every lady’s rose-leafy dress flapping soft and silky around her hips,
+and she looking like the most loveliest parasol.
+
+And then faster and faster they went, all of them dancing, first one
+foot out in the air and then the other, the horses leaning more and
+more, and the ringmaster going round and round the center-pole, cracking
+his whip and shouting “Hi!--hi!” and the clown cracking jokes behind
+him; and by and by all hands dropped the reins, and every lady put her
+knuckles on her hips and every gentleman folded his arms, and then how
+the horses did lean over and hump themselves!  And so one after the
+other they all skipped off into the ring, and made the sweetest bow I
+ever see, and then scampered out, and everybody clapped their hands and
+went just about wild.
+
+Well, all through the circus they done the most astonishing things; and
+all the time that clown carried on so it most killed the people.  The
+ringmaster couldn’t ever say a word to him but he was back at him quick
+as a wink with the funniest things a body ever said; and how he ever
+_could_ think of so many of them, and so sudden and so pat, was what I
+couldn’t noway understand. Why, I couldn’t a thought of them in a year.
+And by and by a drunk man tried to get into the ring--said he wanted to
+ride; said he could ride as well as anybody that ever was.  They argued
+and tried to keep him out, but he wouldn’t listen, and the whole show
+come to a standstill.  Then the people begun to holler at him and make
+fun of him, and that made him mad, and he begun to rip and tear; so that
+stirred up the people, and a lot of men begun to pile down off of the
+benches and swarm towards the ring, saying, “Knock him down! throw him
+out!” and one or two women begun to scream.  So, then, the ringmaster
+he made a little speech, and said he hoped there wouldn’t be no
+disturbance, and if the man would promise he wouldn’t make no more
+trouble he would let him ride if he thought he could stay on the horse.
+ So everybody laughed and said all right, and the man got on. The minute
+he was on, the horse begun to rip and tear and jump and cavort around,
+with two circus men hanging on to his bridle trying to hold him, and the
+drunk man hanging on to his neck, and his heels flying in the air every
+jump, and the whole crowd of people standing up shouting and laughing
+till tears rolled down.  And at last, sure enough, all the circus men
+could do, the horse broke loose, and away he went like the very nation,
+round and round the ring, with that sot laying down on him and hanging
+to his neck, with first one leg hanging most to the ground on one side,
+and then t’other one on t’other side, and the people just crazy.  It
+warn’t funny to me, though; I was all of a tremble to see his danger.
+ But pretty soon he struggled up astraddle and grabbed the bridle,
+a-reeling this way and that; and the next minute he sprung up and
+dropped the bridle and stood! and the horse a-going like a house afire
+too.  He just stood up there, a-sailing around as easy and comfortable
+as if he warn’t ever drunk in his life--and then he begun to pull off his
+clothes and sling them.  He shed them so thick they kind of clogged up
+the air, and altogether he shed seventeen suits. And, then, there he
+was, slim and handsome, and dressed the gaudiest and prettiest you
+ever saw, and he lit into that horse with his whip and made him fairly
+hum--and finally skipped off, and made his bow and danced off to
+the dressing-room, and everybody just a-howling with pleasure and
+astonishment.
+
+Then the ringmaster he see how he had been fooled, and he _was_ the
+sickest ringmaster you ever see, I reckon.  Why, it was one of his own
+men!  He had got up that joke all out of his own head, and never let on
+to nobody. Well, I felt sheepish enough to be took in so, but I wouldn’t
+a been in that ringmaster’s place, not for a thousand dollars.  I don’t
+know; there may be bullier circuses than what that one was, but I
+never struck them yet. Anyways, it was plenty good enough for _me_; and
+wherever I run across it, it can have all of _my_ custom every time.
+
+Well, that night we had _our_ show; but there warn’t only about twelve
+people there--just enough to pay expenses.  And they laughed all the
+time, and that made the duke mad; and everybody left, anyway, before
+the show was over, but one boy which was asleep.  So the duke said these
+Arkansaw lunkheads couldn’t come up to Shakespeare; what they wanted
+was low comedy--and maybe something ruther worse than low comedy, he
+reckoned.  He said he could size their style.  So next morning he got
+some big sheets of wrapping paper and some black paint, and drawed off
+some handbills, and stuck them up all over the village.  The bills said:
+
+
+
+
+CHAPTER XXIII.
+
+WELL, all day him and the king was hard at it, rigging up a stage and
+a curtain and a row of candles for footlights; and that night the house
+was jam full of men in no time.  When the place couldn’t hold no more,
+the duke he quit tending door and went around the back way and come on
+to the stage and stood up before the curtain and made a little speech,
+and praised up this tragedy, and said it was the most thrillingest one
+that ever was; and so he went on a-bragging about the tragedy, and about
+Edmund Kean the Elder, which was to play the main principal part in it;
+and at last when he’d got everybody’s expectations up high enough, he
+rolled up the curtain, and the next minute the king come a-prancing
+out on all fours, naked; and he was painted all over,
+ring-streaked-and-striped, all sorts of colors, as splendid as a
+rainbow.  And--but never mind the rest of his outfit; it was just wild,
+but it was awful funny. The people most killed themselves laughing; and
+when the king got done capering and capered off behind the scenes, they
+roared and clapped and stormed and haw-hawed till he come back and done
+it over again, and after that they made him do it another time. Well, it
+would make a cow laugh to see the shines that old idiot cut.
+
+Then the duke he lets the curtain down, and bows to the people, and says
+the great tragedy will be performed only two nights more, on accounts of
+pressing London engagements, where the seats is all sold already for it
+in Drury Lane; and then he makes them another bow, and says if he has
+succeeded in pleasing them and instructing them, he will be deeply
+obleeged if they will mention it to their friends and get them to come
+and see it.
+
+Twenty people sings out:
+
+“What, is it over?  Is that _all_?”
+
+The duke says yes.  Then there was a fine time.  Everybody sings
+out, “Sold!” and rose up mad, and was a-going for that stage and them
+tragedians.  But a big, fine looking man jumps up on a bench and shouts:
+
+“Hold on!  Just a word, gentlemen.”  They stopped to listen.  “We are
+sold--mighty badly sold.  But we don’t want to be the laughing stock of
+this whole town, I reckon, and never hear the last of this thing as long
+as we live.  _No_.  What we want is to go out of here quiet, and talk
+this show up, and sell the _rest_ of the town!  Then we’ll all be in the
+same boat.  Ain’t that sensible?” (“You bet it is!--the jedge is right!”
+ everybody sings out.) “All right, then--not a word about any sell.  Go
+along home, and advise everybody to come and see the tragedy.”
+
+Next day you couldn’t hear nothing around that town but how splendid
+that show was.  House was jammed again that night, and we sold this
+crowd the same way.  When me and the king and the duke got home to the
+raft we all had a supper; and by and by, about midnight, they made Jim
+and me back her out and float her down the middle of the river, and
+fetch her in and hide her about two mile below town.
+
+The third night the house was crammed again--and they warn’t new-comers
+this time, but people that was at the show the other two nights.  I
+stood by the duke at the door, and I see that every man that went in had
+his pockets bulging, or something muffled up under his coat--and I see it
+warn’t no perfumery, neither, not by a long sight.  I smelt sickly eggs
+by the barrel, and rotten cabbages, and such things; and if I know the
+signs of a dead cat being around, and I bet I do, there was sixty-four
+of them went in.  I shoved in there for a minute, but it was too various
+for me; I couldn’t stand it.  Well, when the place couldn’t hold no more
+people the duke he give a fellow a quarter and told him to tend door
+for him a minute, and then he started around for the stage door, I after
+him; but the minute we turned the corner and was in the dark he says:
+
+“Walk fast now till you get away from the houses, and then shin for the
+raft like the dickens was after you!”
+
+I done it, and he done the same.  We struck the raft at the same time,
+and in less than two seconds we was gliding down stream, all dark and
+still, and edging towards the middle of the river, nobody saying a
+word. I reckoned the poor king was in for a gaudy time of it with the
+audience, but nothing of the sort; pretty soon he crawls out from under
+the wigwam, and says:
+
+“Well, how’d the old thing pan out this time, duke?”  He hadn’t been
+up-town at all.
+
+We never showed a light till we was about ten mile below the village.
+Then we lit up and had a supper, and the king and the duke fairly
+laughed their bones loose over the way they’d served them people.  The
+duke says:
+
+“Greenhorns, flatheads!  I knew the first house would keep mum and let
+the rest of the town get roped in; and I knew they’d lay for us the
+third night, and consider it was _their_ turn now.  Well, it _is_ their
+turn, and I’d give something to know how much they’d take for it.  I
+_would_ just like to know how they’re putting in their opportunity.
+ They can turn it into a picnic if they want to--they brought plenty
+provisions.”
+
+Them rapscallions took in four hundred and sixty-five dollars in that
+three nights.  I never see money hauled in by the wagon-load like that
+before.  By and by, when they was asleep and snoring, Jim says:
+
+“Don’t it s’prise you de way dem kings carries on, Huck?”
+
+“No,” I says, “it don’t.”
+
+“Why don’t it, Huck?”
+
+“Well, it don’t, because it’s in the breed.  I reckon they’re all
+alike.”
+
+“But, Huck, dese kings o’ ourn is reglar rapscallions; dat’s jist what
+dey is; dey’s reglar rapscallions.”
+
+“Well, that’s what I’m a-saying; all kings is mostly rapscallions, as
+fur as I can make out.”
+
+“Is dat so?”
+
+“You read about them once--you’ll see.  Look at Henry the Eight; this ‘n
+‘s a Sunday-school Superintendent to _him_.  And look at Charles Second,
+and Louis Fourteen, and Louis Fifteen, and James Second, and Edward
+Second, and Richard Third, and forty more; besides all them Saxon
+heptarchies that used to rip around so in old times and raise Cain.  My,
+you ought to seen old Henry the Eight when he was in bloom.  He _was_ a
+blossom.  He used to marry a new wife every day, and chop off her head
+next morning.  And he would do it just as indifferent as if he was
+ordering up eggs.  ‘Fetch up Nell Gwynn,’ he says.  They fetch her up.
+Next morning, ‘Chop off her head!’  And they chop it off.  ‘Fetch up
+Jane Shore,’ he says; and up she comes, Next morning, ‘Chop off her
+head’--and they chop it off.  ‘Ring up Fair Rosamun.’  Fair Rosamun
+answers the bell.  Next morning, ‘Chop off her head.’  And he made every
+one of them tell him a tale every night; and he kept that up till he had
+hogged a thousand and one tales that way, and then he put them all in a
+book, and called it Domesday Book--which was a good name and stated the
+case.  You don’t know kings, Jim, but I know them; and this old rip
+of ourn is one of the cleanest I’ve struck in history.  Well, Henry he
+takes a notion he wants to get up some trouble with this country. How
+does he go at it--give notice?--give the country a show?  No.  All of a
+sudden he heaves all the tea in Boston Harbor overboard, and whacks
+out a declaration of independence, and dares them to come on.  That was
+_his_ style--he never give anybody a chance.  He had suspicions of his
+father, the Duke of Wellington.  Well, what did he do?  Ask him to show
+up?  No--drownded him in a butt of mamsey, like a cat.  S’pose people
+left money laying around where he was--what did he do?  He collared it.
+ S’pose he contracted to do a thing, and you paid him, and didn’t set
+down there and see that he done it--what did he do?  He always done the
+other thing. S’pose he opened his mouth--what then?  If he didn’t shut it
+up powerful quick he’d lose a lie every time.  That’s the kind of a bug
+Henry was; and if we’d a had him along ‘stead of our kings he’d a fooled
+that town a heap worse than ourn done.  I don’t say that ourn is lambs,
+because they ain’t, when you come right down to the cold facts; but they
+ain’t nothing to _that_ old ram, anyway.  All I say is, kings is kings,
+and you got to make allowances.  Take them all around, they’re a mighty
+ornery lot. It’s the way they’re raised.”
+
+“But dis one do _smell_ so like de nation, Huck.”
+
+“Well, they all do, Jim.  We can’t help the way a king smells; history
+don’t tell no way.”
+
+“Now de duke, he’s a tolerble likely man in some ways.”
+
+“Yes, a duke’s different.  But not very different.  This one’s
+a middling hard lot for a duke.  When he’s drunk there ain’t no
+near-sighted man could tell him from a king.”
+
+“Well, anyways, I doan’ hanker for no mo’ un um, Huck.  Dese is all I
+kin stan’.”
+
+“It’s the way I feel, too, Jim.  But we’ve got them on our hands, and we
+got to remember what they are, and make allowances.  Sometimes I wish we
+could hear of a country that’s out of kings.”
+
+What was the use to tell Jim these warn’t real kings and dukes?  It
+wouldn’t a done no good; and, besides, it was just as I said:  you
+couldn’t tell them from the real kind.
+
+I went to sleep, and Jim didn’t call me when it was my turn.  He often
+done that.  When I waked up just at daybreak he was sitting there with
+his head down betwixt his knees, moaning and mourning to himself.  I
+didn’t take notice nor let on.  I knowed what it was about.  He was
+thinking about his wife and his children, away up yonder, and he was low
+and homesick; because he hadn’t ever been away from home before in his
+life; and I do believe he cared just as much for his people as white
+folks does for their’n.  It don’t seem natural, but I reckon it’s so.
+ He was often moaning and mourning that way nights, when he judged I
+was asleep, and saying, “Po’ little ‘Lizabeth! po’ little Johnny! it’s
+mighty hard; I spec’ I ain’t ever gwyne to see you no mo’, no mo’!”  He
+was a mighty good nigger, Jim was.
+
+But this time I somehow got to talking to him about his wife and young
+ones; and by and by he says:
+
+“What makes me feel so bad dis time ‘uz bekase I hear sumpn over yonder
+on de bank like a whack, er a slam, while ago, en it mine me er de time
+I treat my little ‘Lizabeth so ornery.  She warn’t on’y ‘bout fo’ year
+ole, en she tuck de sk’yarlet fever, en had a powful rough spell; but
+she got well, en one day she was a-stannin’ aroun’, en I says to her, I
+says:
+
+“‘Shet de do’.’
+
+“She never done it; jis’ stood dah, kiner smilin’ up at me.  It make me
+mad; en I says agin, mighty loud, I says:
+
+“‘Doan’ you hear me?  Shet de do’!’
+
+“She jis stood de same way, kiner smilin’ up.  I was a-bilin’!  I says:
+
+“‘I lay I _make_ you mine!’
+
+“En wid dat I fetch’ her a slap side de head dat sont her a-sprawlin’.
+Den I went into de yuther room, en ‘uz gone ‘bout ten minutes; en when
+I come back dah was dat do’ a-stannin’ open _yit_, en dat chile stannin’
+mos’ right in it, a-lookin’ down and mournin’, en de tears runnin’ down.
+ My, but I _wuz_ mad!  I was a-gwyne for de chile, but jis’ den--it was a
+do’ dat open innerds--jis’ den, ‘long come de wind en slam it to, behine
+de chile, ker-BLAM!--en my lan’, de chile never move’!  My breff mos’
+hop outer me; en I feel so--so--I doan’ know HOW I feel.  I crope out,
+all a-tremblin’, en crope aroun’ en open de do’ easy en slow, en poke my
+head in behine de chile, sof’ en still, en all uv a sudden I says POW!
+jis’ as loud as I could yell.  _She never budge!_  Oh, Huck, I bust out
+a-cryin’ en grab her up in my arms, en say, ‘Oh, de po’ little thing!
+ De Lord God Amighty fogive po’ ole Jim, kaze he never gwyne to fogive
+hisself as long’s he live!’  Oh, she was plumb deef en dumb, Huck, plumb
+deef en dumb--en I’d ben a-treat’n her so!”
+
+
+
+
+CHAPTER XXIV.
+
+NEXT day, towards night, we laid up under a little willow towhead out in
+the middle, where there was a village on each side of the river, and the
+duke and the king begun to lay out a plan for working them towns.  Jim
+he spoke to the duke, and said he hoped it wouldn’t take but a few
+hours, because it got mighty heavy and tiresome to him when he had to
+lay all day in the wigwam tied with the rope.  You see, when we left him
+all alone we had to tie him, because if anybody happened on to him all
+by himself and not tied it wouldn’t look much like he was a runaway
+nigger, you know. So the duke said it _was_ kind of hard to have to lay
+roped all day, and he’d cipher out some way to get around it.
+
+He was uncommon bright, the duke was, and he soon struck it.  He dressed
+Jim up in King Lear’s outfit--it was a long curtain-calico gown, and a
+white horse-hair wig and whiskers; and then he took his theater paint
+and painted Jim’s face and hands and ears and neck all over a dead,
+dull, solid blue, like a man that’s been drownded nine days.  Blamed if
+he warn’t the horriblest looking outrage I ever see.  Then the duke took
+and wrote out a sign on a shingle so:
+
+Sick Arab--but harmless when not out of his head.
+
+And he nailed that shingle to a lath, and stood the lath up four or five
+foot in front of the wigwam.  Jim was satisfied.  He said it was a sight
+better than lying tied a couple of years every day, and trembling all
+over every time there was a sound.  The duke told him to make himself
+free and easy, and if anybody ever come meddling around, he must hop
+out of the wigwam, and carry on a little, and fetch a howl or two like
+a wild beast, and he reckoned they would light out and leave him alone.
+ Which was sound enough judgment; but you take the average man, and he
+wouldn’t wait for him to howl.  Why, he didn’t only look like he was
+dead, he looked considerable more than that.
+
+These rapscallions wanted to try the Nonesuch again, because there was
+so much money in it, but they judged it wouldn’t be safe, because maybe
+the news might a worked along down by this time.  They couldn’t hit no
+project that suited exactly; so at last the duke said he reckoned he’d
+lay off and work his brains an hour or two and see if he couldn’t put up
+something on the Arkansaw village; and the king he allowed he would drop
+over to t’other village without any plan, but just trust in Providence
+to lead him the profitable way--meaning the devil, I reckon.  We had all
+bought store clothes where we stopped last; and now the king put his’n
+on, and he told me to put mine on.  I done it, of course.  The king’s
+duds was all black, and he did look real swell and starchy.  I never
+knowed how clothes could change a body before.  Why, before, he looked
+like the orneriest old rip that ever was; but now, when he’d take off
+his new white beaver and make a bow and do a smile, he looked that grand
+and good and pious that you’d say he had walked right out of the ark,
+and maybe was old Leviticus himself.  Jim cleaned up the canoe, and I
+got my paddle ready.  There was a big steamboat laying at the shore away
+up under the point, about three mile above the town--been there a couple
+of hours, taking on freight.  Says the king:
+
+“Seein’ how I’m dressed, I reckon maybe I better arrive down from St.
+Louis or Cincinnati, or some other big place.  Go for the steamboat,
+Huckleberry; we’ll come down to the village on her.”
+
+I didn’t have to be ordered twice to go and take a steamboat ride.
+ I fetched the shore a half a mile above the village, and then went
+scooting along the bluff bank in the easy water.  Pretty soon we come to
+a nice innocent-looking young country jake setting on a log swabbing the
+sweat off of his face, for it was powerful warm weather; and he had a
+couple of big carpet-bags by him.
+
+“Run her nose in shore,” says the king.  I done it.  “Wher’ you bound
+for, young man?”
+
+“For the steamboat; going to Orleans.”
+
+“Git aboard,” says the king.  “Hold on a minute, my servant ‘ll he’p you
+with them bags.  Jump out and he’p the gentleman, Adolphus”--meaning me,
+I see.
+
+I done so, and then we all three started on again.  The young chap was
+mighty thankful; said it was tough work toting his baggage such weather.
+He asked the king where he was going, and the king told him he’d come
+down the river and landed at the other village this morning, and now he
+was going up a few mile to see an old friend on a farm up there.  The
+young fellow says:
+
+“When I first see you I says to myself, ‘It’s Mr. Wilks, sure, and he
+come mighty near getting here in time.’  But then I says again, ‘No, I
+reckon it ain’t him, or else he wouldn’t be paddling up the river.’  You
+_ain’t_ him, are you?”
+
+“No, my name’s Blodgett--Elexander Blodgett--_Reverend_ Elexander
+Blodgett, I s’pose I must say, as I’m one o’ the Lord’s poor servants.
+ But still I’m jist as able to be sorry for Mr. Wilks for not arriving
+in time, all the same, if he’s missed anything by it--which I hope he
+hasn’t.”
+
+“Well, he don’t miss any property by it, because he’ll get that all
+right; but he’s missed seeing his brother Peter die--which he mayn’t
+mind, nobody can tell as to that--but his brother would a give anything
+in this world to see _him_ before he died; never talked about nothing
+else all these three weeks; hadn’t seen him since they was boys
+together--and hadn’t ever seen his brother William at all--that’s the deef
+and dumb one--William ain’t more than thirty or thirty-five.  Peter and
+George were the only ones that come out here; George was the married
+brother; him and his wife both died last year.  Harvey and William’s the
+only ones that’s left now; and, as I was saying, they haven’t got here
+in time.”
+
+“Did anybody send ‘em word?”
+
+“Oh, yes; a month or two ago, when Peter was first took; because Peter
+said then that he sorter felt like he warn’t going to get well this
+time. You see, he was pretty old, and George’s g’yirls was too young to
+be much company for him, except Mary Jane, the red-headed one; and so he
+was kinder lonesome after George and his wife died, and didn’t seem
+to care much to live.  He most desperately wanted to see Harvey--and
+William, too, for that matter--because he was one of them kind that can’t
+bear to make a will.  He left a letter behind for Harvey, and said he’d
+told in it where his money was hid, and how he wanted the rest of the
+property divided up so George’s g’yirls would be all right--for George
+didn’t leave nothing.  And that letter was all they could get him to put
+a pen to.”
+
+“Why do you reckon Harvey don’t come?  Wher’ does he live?”
+
+“Oh, he lives in England--Sheffield--preaches there--hasn’t ever been in
+this country.  He hasn’t had any too much time--and besides he mightn’t a
+got the letter at all, you know.”
+
+“Too bad, too bad he couldn’t a lived to see his brothers, poor soul.
+You going to Orleans, you say?”
+
+“Yes, but that ain’t only a part of it.  I’m going in a ship, next
+Wednesday, for Ryo Janeero, where my uncle lives.”
+
+“It’s a pretty long journey.  But it’ll be lovely; wisht I was a-going.
+Is Mary Jane the oldest?  How old is the others?”
+
+“Mary Jane’s nineteen, Susan’s fifteen, and Joanna’s about
+fourteen--that’s the one that gives herself to good works and has a
+hare-lip.”
+
+“Poor things! to be left alone in the cold world so.”
+
+“Well, they could be worse off.  Old Peter had friends, and they
+ain’t going to let them come to no harm.  There’s Hobson, the Babtis’
+preacher; and Deacon Lot Hovey, and Ben Rucker, and Abner Shackleford,
+and Levi Bell, the lawyer; and Dr. Robinson, and their wives, and the
+widow Bartley, and--well, there’s a lot of them; but these are the ones
+that Peter was thickest with, and used to write about sometimes, when
+he wrote home; so Harvey ‘ll know where to look for friends when he gets
+here.”
+
+Well, the old man went on asking questions till he just fairly emptied
+that young fellow.  Blamed if he didn’t inquire about everybody and
+everything in that blessed town, and all about the Wilkses; and about
+Peter’s business--which was a tanner; and about George’s--which was a
+carpenter; and about Harvey’s--which was a dissentering minister; and so
+on, and so on.  Then he says:
+
+“What did you want to walk all the way up to the steamboat for?”
+
+“Because she’s a big Orleans boat, and I was afeard she mightn’t stop
+there.  When they’re deep they won’t stop for a hail.  A Cincinnati boat
+will, but this is a St. Louis one.”
+
+“Was Peter Wilks well off?”
+
+“Oh, yes, pretty well off.  He had houses and land, and it’s reckoned he
+left three or four thousand in cash hid up som’ers.”
+
+“When did you say he died?”
+
+“I didn’t say, but it was last night.”
+
+“Funeral to-morrow, likely?”
+
+“Yes, ‘bout the middle of the day.”
+
+“Well, it’s all terrible sad; but we’ve all got to go, one time or
+another. So what we want to do is to be prepared; then we’re all right.”
+
+“Yes, sir, it’s the best way.  Ma used to always say that.”
+
+When we struck the boat she was about done loading, and pretty soon she
+got off.  The king never said nothing about going aboard, so I lost
+my ride, after all.  When the boat was gone the king made me paddle up
+another mile to a lonesome place, and then he got ashore and says:
+
+“Now hustle back, right off, and fetch the duke up here, and the new
+carpet-bags.  And if he’s gone over to t’other side, go over there and
+git him.  And tell him to git himself up regardless.  Shove along, now.”
+
+I see what _he_ was up to; but I never said nothing, of course.  When
+I got back with the duke we hid the canoe, and then they set down on a
+log, and the king told him everything, just like the young fellow had
+said it--every last word of it.  And all the time he was a-doing it he
+tried to talk like an Englishman; and he done it pretty well, too, for
+a slouch. I can’t imitate him, and so I ain’t a-going to try to; but he
+really done it pretty good.  Then he says:
+
+“How are you on the deef and dumb, Bilgewater?”
+
+The duke said, leave him alone for that; said he had played a deef
+and dumb person on the histronic boards.  So then they waited for a
+steamboat.
+
+About the middle of the afternoon a couple of little boats come along,
+but they didn’t come from high enough up the river; but at last there
+was a big one, and they hailed her.  She sent out her yawl, and we went
+aboard, and she was from Cincinnati; and when they found we only wanted
+to go four or five mile they was booming mad, and gave us a cussing, and
+said they wouldn’t land us.  But the king was ca’m.  He says:
+
+“If gentlemen kin afford to pay a dollar a mile apiece to be took on and
+put off in a yawl, a steamboat kin afford to carry ‘em, can’t it?”
+
+So they softened down and said it was all right; and when we got to the
+village they yawled us ashore.  About two dozen men flocked down when
+they see the yawl a-coming, and when the king says:
+
+“Kin any of you gentlemen tell me wher’ Mr. Peter Wilks lives?” they
+give a glance at one another, and nodded their heads, as much as to say,
+“What d’ I tell you?”  Then one of them says, kind of soft and gentle:
+
+“I’m sorry sir, but the best we can do is to tell you where he _did_
+live yesterday evening.”
+
+Sudden as winking the ornery old cretur went an to smash, and fell up
+against the man, and put his chin on his shoulder, and cried down his
+back, and says:
+
+“Alas, alas, our poor brother--gone, and we never got to see him; oh,
+it’s too, too hard!”
+
+Then he turns around, blubbering, and makes a lot of idiotic signs to
+the duke on his hands, and blamed if he didn’t drop a carpet-bag and
+bust out a-crying.  If they warn’t the beatenest lot, them two frauds,
+that ever I struck.
+
+Well, the men gathered around and sympathized with them, and said all
+sorts of kind things to them, and carried their carpet-bags up the hill
+for them, and let them lean on them and cry, and told the king all about
+his brother’s last moments, and the king he told it all over again on
+his hands to the duke, and both of them took on about that dead tanner
+like they’d lost the twelve disciples.  Well, if ever I struck anything
+like it, I’m a nigger. It was enough to make a body ashamed of the human
+race.
+
+
+
+
+CHAPTER XXV.
+
+THE news was all over town in two minutes, and you could see the people
+tearing down on the run from every which way, some of them putting on
+their coats as they come.  Pretty soon we was in the middle of a crowd,
+and the noise of the tramping was like a soldier march.  The windows and
+dooryards was full; and every minute somebody would say, over a fence:
+
+“Is it _them_?”
+
+And somebody trotting along with the gang would answer back and say:
+
+“You bet it is.”
+
+When we got to the house the street in front of it was packed, and the
+three girls was standing in the door.  Mary Jane _was_ red-headed, but
+that don’t make no difference, she was most awful beautiful, and her
+face and her eyes was all lit up like glory, she was so glad her uncles
+was come. The king he spread his arms, and Mary Jane she jumped for
+them, and the hare-lip jumped for the duke, and there they had it!
+ Everybody most, leastways women, cried for joy to see them meet again
+at last and have such good times.
+
+Then the king he hunched the duke private--I see him do it--and then he
+looked around and see the coffin, over in the corner on two chairs; so
+then him and the duke, with a hand across each other’s shoulder, and
+t’other hand to their eyes, walked slow and solemn over there, everybody
+dropping back to give them room, and all the talk and noise stopping,
+people saying “Sh!” and all the men taking their hats off and drooping
+their heads, so you could a heard a pin fall.  And when they got there
+they bent over and looked in the coffin, and took one sight, and then
+they bust out a-crying so you could a heard them to Orleans, most; and
+then they put their arms around each other’s necks, and hung their chins
+over each other’s shoulders; and then for three minutes, or maybe four,
+I never see two men leak the way they done.  And, mind you, everybody
+was doing the same; and the place was that damp I never see anything
+like it. Then one of them got on one side of the coffin, and t’other on
+t’other side, and they kneeled down and rested their foreheads on the
+coffin, and let on to pray all to themselves.  Well, when it come
+to that it worked the crowd like you never see anything like it, and
+everybody broke down and went to sobbing right out loud--the poor girls,
+too; and every woman, nearly, went up to the girls, without saying a
+word, and kissed them, solemn, on the forehead, and then put their hand
+on their head, and looked up towards the sky, with the tears running
+down, and then busted out and went off sobbing and swabbing, and give
+the next woman a show.  I never see anything so disgusting.
+
+Well, by and by the king he gets up and comes forward a little, and
+works himself up and slobbers out a speech, all full of tears and
+flapdoodle about its being a sore trial for him and his poor brother
+to lose the diseased, and to miss seeing diseased alive after the long
+journey of four thousand mile, but it’s a trial that’s sweetened and
+sanctified to us by this dear sympathy and these holy tears, and so he
+thanks them out of his heart and out of his brother’s heart, because out
+of their mouths they can’t, words being too weak and cold, and all that
+kind of rot and slush, till it was just sickening; and then he blubbers
+out a pious goody-goody Amen, and turns himself loose and goes to crying
+fit to bust.
+
+And the minute the words were out of his mouth somebody over in the
+crowd struck up the doxolojer, and everybody joined in with all their
+might, and it just warmed you up and made you feel as good as church
+letting out. Music is a good thing; and after all that soul-butter and
+hogwash I never see it freshen up things so, and sound so honest and
+bully.
+
+Then the king begins to work his jaw again, and says how him and his
+nieces would be glad if a few of the main principal friends of the
+family would take supper here with them this evening, and help set up
+with the ashes of the diseased; and says if his poor brother laying
+yonder could speak he knows who he would name, for they was names that
+was very dear to him, and mentioned often in his letters; and so he will
+name the same, to wit, as follows, vizz.:--Rev. Mr. Hobson, and Deacon
+Lot Hovey, and Mr. Ben Rucker, and Abner Shackleford, and Levi Bell, and
+Dr. Robinson, and their wives, and the widow Bartley.
+
+Rev. Hobson and Dr. Robinson was down to the end of the town a-hunting
+together--that is, I mean the doctor was shipping a sick man to t’other
+world, and the preacher was pinting him right.  Lawyer Bell was away up
+to Louisville on business.  But the rest was on hand, and so they all
+come and shook hands with the king and thanked him and talked to him;
+and then they shook hands with the duke and didn’t say nothing, but just
+kept a-smiling and bobbing their heads like a passel of sapheads whilst
+he made all sorts of signs with his hands and said “Goo-goo--goo-goo-goo”
+ all the time, like a baby that can’t talk.
+
+So the king he blattered along, and managed to inquire about pretty
+much everybody and dog in town, by his name, and mentioned all sorts
+of little things that happened one time or another in the town, or to
+George’s family, or to Peter.  And he always let on that Peter wrote him
+the things; but that was a lie:  he got every blessed one of them out of
+that young flathead that we canoed up to the steamboat.
+
+Then Mary Jane she fetched the letter her father left behind, and the
+king he read it out loud and cried over it.  It give the dwelling-house
+and three thousand dollars, gold, to the girls; and it give the tanyard
+(which was doing a good business), along with some other houses and
+land (worth about seven thousand), and three thousand dollars in gold
+to Harvey and William, and told where the six thousand cash was hid down
+cellar.  So these two frauds said they’d go and fetch it up, and have
+everything square and above-board; and told me to come with a candle.
+ We shut the cellar door behind us, and when they found the bag
+they spilt it out on the floor, and it was a lovely sight, all them
+yaller-boys.  My, the way the king’s eyes did shine!  He slaps the duke
+on the shoulder and says:
+
+“Oh, _this_ ain’t bully nor noth’n!  Oh, no, I reckon not!  Why,
+_bully_, it beats the Nonesuch, _don’t_ it?”
+
+The duke allowed it did.  They pawed the yaller-boys, and sifted them
+through their fingers and let them jingle down on the floor; and the
+king says:
+
+“It ain’t no use talkin’; bein’ brothers to a rich dead man and
+representatives of furrin heirs that’s got left is the line for you and
+me, Bilge.  Thish yer comes of trust’n to Providence.  It’s the best
+way, in the long run.  I’ve tried ‘em all, and ther’ ain’t no better
+way.”
+
+Most everybody would a been satisfied with the pile, and took it on
+trust; but no, they must count it.  So they counts it, and it comes out
+four hundred and fifteen dollars short.  Says the king:
+
+“Dern him, I wonder what he done with that four hundred and fifteen
+dollars?”
+
+They worried over that awhile, and ransacked all around for it.  Then
+the duke says:
+
+“Well, he was a pretty sick man, and likely he made a mistake--I reckon
+that’s the way of it.  The best way’s to let it go, and keep still about
+it.  We can spare it.”
+
+“Oh, shucks, yes, we can _spare_ it.  I don’t k’yer noth’n ‘bout
+that--it’s the _count_ I’m thinkin’ about.  We want to be awful square
+and open and above-board here, you know.  We want to lug this h-yer
+money up stairs and count it before everybody--then ther’ ain’t noth’n
+suspicious.  But when the dead man says ther’s six thous’n dollars, you
+know, we don’t want to--”
+
+“Hold on,” says the duke.  “Le’s make up the deffisit,” and he begun to
+haul out yaller-boys out of his pocket.
+
+“It’s a most amaz’n’ good idea, duke--you _have_ got a rattlin’ clever
+head on you,” says the king.  “Blest if the old Nonesuch ain’t a heppin’
+us out agin,” and _he_ begun to haul out yaller-jackets and stack them
+up.
+
+It most busted them, but they made up the six thousand clean and clear.
+
+“Say,” says the duke, “I got another idea.  Le’s go up stairs and count
+this money, and then take and _give it to the girls_.”
+
+“Good land, duke, lemme hug you!  It’s the most dazzling idea ‘at ever a
+man struck.  You have cert’nly got the most astonishin’ head I ever see.
+Oh, this is the boss dodge, ther’ ain’t no mistake ‘bout it.  Let ‘em
+fetch along their suspicions now if they want to--this ‘ll lay ‘em out.”
+
+When we got up-stairs everybody gethered around the table, and the king
+he counted it and stacked it up, three hundred dollars in a pile--twenty
+elegant little piles.  Everybody looked hungry at it, and licked their
+chops.  Then they raked it into the bag again, and I see the king begin
+to swell himself up for another speech.  He says:
+
+“Friends all, my poor brother that lays yonder has done generous by
+them that’s left behind in the vale of sorrers.  He has done generous by
+these yer poor little lambs that he loved and sheltered, and that’s left
+fatherless and motherless.  Yes, and we that knowed him knows that he
+would a done _more_ generous by ‘em if he hadn’t ben afeard o’ woundin’
+his dear William and me.  Now, _wouldn’t_ he?  Ther’ ain’t no question
+‘bout it in _my_ mind.  Well, then, what kind o’ brothers would it be
+that ‘d stand in his way at sech a time?  And what kind o’ uncles would
+it be that ‘d rob--yes, _rob_--sech poor sweet lambs as these ‘at he loved
+so at sech a time?  If I know William--and I _think_ I do--he--well, I’ll
+jest ask him.” He turns around and begins to make a lot of signs to
+the duke with his hands, and the duke he looks at him stupid and
+leather-headed a while; then all of a sudden he seems to catch his
+meaning, and jumps for the king, goo-gooing with all his might for joy,
+and hugs him about fifteen times before he lets up.  Then the king says,
+“I knowed it; I reckon _that ‘ll_ convince anybody the way _he_ feels
+about it.  Here, Mary Jane, Susan, Joanner, take the money--take it
+_all_.  It’s the gift of him that lays yonder, cold but joyful.”
+
+Mary Jane she went for him, Susan and the hare-lip went for the
+duke, and then such another hugging and kissing I never see yet.  And
+everybody crowded up with the tears in their eyes, and most shook the
+hands off of them frauds, saying all the time:
+
+“You _dear_ good souls!--how _lovely_!--how _could_ you!”
+
+Well, then, pretty soon all hands got to talking about the diseased
+again, and how good he was, and what a loss he was, and all that; and
+before long a big iron-jawed man worked himself in there from outside,
+and stood a-listening and looking, and not saying anything; and nobody
+saying anything to him either, because the king was talking and they was
+all busy listening.  The king was saying--in the middle of something he’d
+started in on--
+
+“--they bein’ partickler friends o’ the diseased.  That’s why they’re
+invited here this evenin’; but tomorrow we want _all_ to come--everybody;
+for he respected everybody, he liked everybody, and so it’s fitten that
+his funeral orgies sh’d be public.”
+
+And so he went a-mooning on and on, liking to hear himself talk, and
+every little while he fetched in his funeral orgies again, till the duke
+he couldn’t stand it no more; so he writes on a little scrap of paper,
+“_Obsequies_, you old fool,” and folds it up, and goes to goo-gooing and
+reaching it over people’s heads to him.  The king he reads it and puts
+it in his pocket, and says:
+
+“Poor William, afflicted as he is, his _heart’s_ aluz right.  Asks me
+to invite everybody to come to the funeral--wants me to make ‘em all
+welcome.  But he needn’t a worried--it was jest what I was at.”
+
+Then he weaves along again, perfectly ca’m, and goes to dropping in his
+funeral orgies again every now and then, just like he done before.  And
+when he done it the third time he says:
+
+“I say orgies, not because it’s the common term, because it
+ain’t--obsequies bein’ the common term--but because orgies is the right
+term. Obsequies ain’t used in England no more now--it’s gone out.  We
+say orgies now in England.  Orgies is better, because it means the thing
+you’re after more exact.  It’s a word that’s made up out’n the Greek
+_orgo_, outside, open, abroad; and the Hebrew _jeesum_, to plant, cover
+up; hence in_ter._  So, you see, funeral orgies is an open er public
+funeral.”
+
+He was the _worst_ I ever struck.  Well, the iron-jawed man he laughed
+right in his face.  Everybody was shocked.  Everybody says, “Why,
+_doctor_!” and Abner Shackleford says:
+
+“Why, Robinson, hain’t you heard the news?  This is Harvey Wilks.”
+
+The king he smiled eager, and shoved out his flapper, and says:
+
+“Is it my poor brother’s dear good friend and physician?  I--”
+
+“Keep your hands off of me!” says the doctor.  “_You_ talk like an
+Englishman, _don’t_ you?  It’s the worst imitation I ever heard.  _You_
+Peter Wilks’s brother!  You’re a fraud, that’s what you are!”
+
+Well, how they all took on!  They crowded around the doctor and tried to
+quiet him down, and tried to explain to him and tell him how Harvey ‘d
+showed in forty ways that he _was_ Harvey, and knowed everybody by name,
+and the names of the very dogs, and begged and _begged_ him not to hurt
+Harvey’s feelings and the poor girl’s feelings, and all that.  But it
+warn’t no use; he stormed right along, and said any man that pretended
+to be an Englishman and couldn’t imitate the lingo no better than what
+he did was a fraud and a liar.  The poor girls was hanging to the king
+and crying; and all of a sudden the doctor ups and turns on _them_.  He
+says:
+
+“I was your father’s friend, and I’m your friend; and I warn you as a
+friend, and an honest one that wants to protect you and keep you out of
+harm and trouble, to turn your backs on that scoundrel and have nothing
+to do with him, the ignorant tramp, with his idiotic Greek and Hebrew,
+as he calls it.  He is the thinnest kind of an impostor--has come here
+with a lot of empty names and facts which he picked up somewheres, and
+you take them for _proofs_, and are helped to fool yourselves by these
+foolish friends here, who ought to know better.  Mary Jane Wilks, you
+know me for your friend, and for your unselfish friend, too.  Now listen
+to me; turn this pitiful rascal out--I _beg_ you to do it.  Will you?”
+
+Mary Jane straightened herself up, and my, but she was handsome!  She
+says:
+
+“_Here_ is my answer.”  She hove up the bag of money and put it in the
+king’s hands, and says, “Take this six thousand dollars, and invest for
+me and my sisters any way you want to, and don’t give us no receipt for
+it.”
+
+Then she put her arm around the king on one side, and Susan and the
+hare-lip done the same on the other.  Everybody clapped their hands and
+stomped on the floor like a perfect storm, whilst the king held up his
+head and smiled proud.  The doctor says:
+
+“All right; I wash _my_ hands of the matter.  But I warn you all that a
+time ‘s coming when you’re going to feel sick whenever you think of this
+day.” And away he went.
+
+“All right, doctor,” says the king, kinder mocking him; “we’ll try and
+get ‘em to send for you;” which made them all laugh, and they said it
+was a prime good hit.
+
+
+
+
+CHAPTER XXVI.
+
+WELL, when they was all gone the king he asks Mary Jane how they was off
+for spare rooms, and she said she had one spare room, which would do for
+Uncle William, and she’d give her own room to Uncle Harvey, which was
+a little bigger, and she would turn into the room with her sisters and
+sleep on a cot; and up garret was a little cubby, with a pallet in it.
+The king said the cubby would do for his valley--meaning me.
+
+So Mary Jane took us up, and she showed them their rooms, which was
+plain but nice.  She said she’d have her frocks and a lot of other traps
+took out of her room if they was in Uncle Harvey’s way, but he said
+they warn’t.  The frocks was hung along the wall, and before them was
+a curtain made out of calico that hung down to the floor.  There was an
+old hair trunk in one corner, and a guitar-box in another, and all sorts
+of little knickknacks and jimcracks around, like girls brisken up a room
+with.  The king said it was all the more homely and more pleasanter for
+these fixings, and so don’t disturb them.  The duke’s room was pretty
+small, but plenty good enough, and so was my cubby.
+
+That night they had a big supper, and all them men and women was there,
+and I stood behind the king and the duke’s chairs and waited on them,
+and the niggers waited on the rest.  Mary Jane she set at the head of
+the table, with Susan alongside of her, and said how bad the biscuits
+was, and how mean the preserves was, and how ornery and tough the fried
+chickens was--and all that kind of rot, the way women always do for to
+force out compliments; and the people all knowed everything was tiptop,
+and said so--said “How _do_ you get biscuits to brown so nice?” and
+“Where, for the land’s sake, _did_ you get these amaz’n pickles?” and
+all that kind of humbug talky-talk, just the way people always does at a
+supper, you know.
+
+And when it was all done me and the hare-lip had supper in the kitchen
+off of the leavings, whilst the others was helping the niggers clean up
+the things.  The hare-lip she got to pumping me about England, and blest
+if I didn’t think the ice was getting mighty thin sometimes.  She says:
+
+“Did you ever see the king?”
+
+“Who?  William Fourth?  Well, I bet I have--he goes to our church.”  I
+knowed he was dead years ago, but I never let on.  So when I says he
+goes to our church, she says:
+
+“What--regular?”
+
+“Yes--regular.  His pew’s right over opposite ourn--on t’other side the
+pulpit.”
+
+“I thought he lived in London?”
+
+“Well, he does.  Where _would_ he live?”
+
+“But I thought _you_ lived in Sheffield?”
+
+I see I was up a stump.  I had to let on to get choked with a chicken
+bone, so as to get time to think how to get down again.  Then I says:
+
+“I mean he goes to our church regular when he’s in Sheffield.  That’s
+only in the summer time, when he comes there to take the sea baths.”
+
+“Why, how you talk--Sheffield ain’t on the sea.”
+
+“Well, who said it was?”
+
+“Why, you did.”
+
+“I _didn’t_ nuther.”
+
+“You did!”
+
+“I didn’t.”
+
+“You did.”
+
+“I never said nothing of the kind.”
+
+“Well, what _did_ you say, then?”
+
+“Said he come to take the sea _baths_--that’s what I said.”
+
+“Well, then, how’s he going to take the sea baths if it ain’t on the
+sea?”
+
+“Looky here,” I says; “did you ever see any Congress-water?”
+
+“Yes.”
+
+“Well, did you have to go to Congress to get it?”
+
+“Why, no.”
+
+“Well, neither does William Fourth have to go to the sea to get a sea
+bath.”
+
+“How does he get it, then?”
+
+“Gets it the way people down here gets Congress-water--in barrels.  There
+in the palace at Sheffield they’ve got furnaces, and he wants his water
+hot.  They can’t bile that amount of water away off there at the sea.
+They haven’t got no conveniences for it.”
+
+“Oh, I see, now.  You might a said that in the first place and saved
+time.”
+
+When she said that I see I was out of the woods again, and so I was
+comfortable and glad.  Next, she says:
+
+“Do you go to church, too?”
+
+“Yes--regular.”
+
+“Where do you set?”
+
+“Why, in our pew.”
+
+“_Whose_ pew?”
+
+“Why, _ourn_--your Uncle Harvey’s.”
+
+“His’n?  What does _he_ want with a pew?”
+
+“Wants it to set in.  What did you _reckon_ he wanted with it?”
+
+“Why, I thought he’d be in the pulpit.”
+
+Rot him, I forgot he was a preacher.  I see I was up a stump again, so I
+played another chicken bone and got another think.  Then I says:
+
+“Blame it, do you suppose there ain’t but one preacher to a church?”
+
+“Why, what do they want with more?”
+
+“What!--to preach before a king?  I never did see such a girl as you.
+They don’t have no less than seventeen.”
+
+“Seventeen!  My land!  Why, I wouldn’t set out such a string as that,
+not if I _never_ got to glory.  It must take ‘em a week.”
+
+“Shucks, they don’t _all_ of ‘em preach the same day--only _one_ of ‘em.”
+
+“Well, then, what does the rest of ‘em do?”
+
+“Oh, nothing much.  Loll around, pass the plate--and one thing or
+another.  But mainly they don’t do nothing.”
+
+“Well, then, what are they _for_?”
+
+“Why, they’re for _style_.  Don’t you know nothing?”
+
+“Well, I don’t _want_ to know no such foolishness as that.  How is
+servants treated in England?  Do they treat ‘em better ‘n we treat our
+niggers?”
+
+“_No_!  A servant ain’t nobody there.  They treat them worse than dogs.”
+
+“Don’t they give ‘em holidays, the way we do, Christmas and New Year’s
+week, and Fourth of July?”
+
+“Oh, just listen!  A body could tell _you_ hain’t ever been to England
+by that.  Why, Hare-l--why, Joanna, they never see a holiday from year’s
+end to year’s end; never go to the circus, nor theater, nor nigger
+shows, nor nowheres.”
+
+“Nor church?”
+
+“Nor church.”
+
+“But _you_ always went to church.”
+
+Well, I was gone up again.  I forgot I was the old man’s servant.  But
+next minute I whirled in on a kind of an explanation how a valley was
+different from a common servant and _had_ to go to church whether he
+wanted to or not, and set with the family, on account of its being the
+law.  But I didn’t do it pretty good, and when I got done I see she
+warn’t satisfied.  She says:
+
+“Honest injun, now, hain’t you been telling me a lot of lies?”
+
+“Honest injun,” says I.
+
+“None of it at all?”
+
+“None of it at all.  Not a lie in it,” says I.
+
+“Lay your hand on this book and say it.”
+
+I see it warn’t nothing but a dictionary, so I laid my hand on it and
+said it.  So then she looked a little better satisfied, and says:
+
+“Well, then, I’ll believe some of it; but I hope to gracious if I’ll
+believe the rest.”
+
+“What is it you won’t believe, Joe?” says Mary Jane, stepping in with
+Susan behind her.  “It ain’t right nor kind for you to talk so to him,
+and him a stranger and so far from his people.  How would you like to be
+treated so?”
+
+“That’s always your way, Maim--always sailing in to help somebody before
+they’re hurt.  I hain’t done nothing to him.  He’s told some stretchers,
+I reckon, and I said I wouldn’t swallow it all; and that’s every bit
+and grain I _did_ say.  I reckon he can stand a little thing like that,
+can’t he?”
+
+“I don’t care whether ‘twas little or whether ‘twas big; he’s here in
+our house and a stranger, and it wasn’t good of you to say it.  If you
+was in his place it would make you feel ashamed; and so you oughtn’t to
+say a thing to another person that will make _them_ feel ashamed.”
+
+“Why, Mam, he said--”
+
+“It don’t make no difference what he _said_--that ain’t the thing.  The
+thing is for you to treat him _kind_, and not be saying things to make
+him remember he ain’t in his own country and amongst his own folks.”
+
+I says to myself, _this_ is a girl that I’m letting that old reptile rob
+her of her money!
+
+Then Susan _she_ waltzed in; and if you’ll believe me, she did give
+Hare-lip hark from the tomb!
+
+Says I to myself, and this is _another_ one that I’m letting him rob her
+of her money!
+
+Then Mary Jane she took another inning, and went in sweet and lovely
+again--which was her way; but when she got done there warn’t hardly
+anything left o’ poor Hare-lip.  So she hollered.
+
+“All right, then,” says the other girls; “you just ask his pardon.”
+
+She done it, too; and she done it beautiful.  She done it so beautiful
+it was good to hear; and I wished I could tell her a thousand lies, so
+she could do it again.
+
+I says to myself, this is _another_ one that I’m letting him rob her of
+her money.  And when she got through they all jest laid theirselves
+out to make me feel at home and know I was amongst friends.  I felt so
+ornery and low down and mean that I says to myself, my mind’s made up;
+I’ll hive that money for them or bust.
+
+So then I lit out--for bed, I said, meaning some time or another.  When
+I got by myself I went to thinking the thing over.  I says to myself,
+shall I go to that doctor, private, and blow on these frauds?  No--that
+won’t do. He might tell who told him; then the king and the duke would
+make it warm for me.  Shall I go, private, and tell Mary Jane?  No--I
+dasn’t do it. Her face would give them a hint, sure; they’ve got the
+money, and they’d slide right out and get away with it.  If she was to
+fetch in help I’d get mixed up in the business before it was done with,
+I judge.  No; there ain’t no good way but one.  I got to steal that
+money, somehow; and I got to steal it some way that they won’t suspicion
+that I done it. They’ve got a good thing here, and they ain’t a-going
+to leave till they’ve played this family and this town for all they’re
+worth, so I’ll find a chance time enough. I’ll steal it and hide it; and
+by and by, when I’m away down the river, I’ll write a letter and tell
+Mary Jane where it’s hid.  But I better hive it tonight if I can,
+because the doctor maybe hasn’t let up as much as he lets on he has; he
+might scare them out of here yet.
+
+So, thinks I, I’ll go and search them rooms.  Upstairs the hall was
+dark, but I found the duke’s room, and started to paw around it with
+my hands; but I recollected it wouldn’t be much like the king to let
+anybody else take care of that money but his own self; so then I went to
+his room and begun to paw around there.  But I see I couldn’t do nothing
+without a candle, and I dasn’t light one, of course.  So I judged I’d
+got to do the other thing--lay for them and eavesdrop.  About that time
+I hears their footsteps coming, and was going to skip under the bed; I
+reached for it, but it wasn’t where I thought it would be; but I touched
+the curtain that hid Mary Jane’s frocks, so I jumped in behind that and
+snuggled in amongst the gowns, and stood there perfectly still.
+
+They come in and shut the door; and the first thing the duke done was to
+get down and look under the bed.  Then I was glad I hadn’t found the bed
+when I wanted it.  And yet, you know, it’s kind of natural to hide under
+the bed when you are up to anything private.  They sets down then, and
+the king says:
+
+“Well, what is it?  And cut it middlin’ short, because it’s better for
+us to be down there a-whoopin’ up the mournin’ than up here givin’ ‘em a
+chance to talk us over.”
+
+“Well, this is it, Capet.  I ain’t easy; I ain’t comfortable.  That
+doctor lays on my mind.  I wanted to know your plans.  I’ve got a
+notion, and I think it’s a sound one.”
+
+“What is it, duke?”
+
+“That we better glide out of this before three in the morning, and clip
+it down the river with what we’ve got.  Specially, seeing we got it so
+easy--_given_ back to us, flung at our heads, as you may say, when of
+course we allowed to have to steal it back.  I’m for knocking off and
+lighting out.”
+
+That made me feel pretty bad.  About an hour or two ago it would a been
+a little different, but now it made me feel bad and disappointed, The
+king rips out and says:
+
+“What!  And not sell out the rest o’ the property?  March off like
+a passel of fools and leave eight or nine thous’n’ dollars’ worth o’
+property layin’ around jest sufferin’ to be scooped in?--and all good,
+salable stuff, too.”
+
+The duke he grumbled; said the bag of gold was enough, and he didn’t
+want to go no deeper--didn’t want to rob a lot of orphans of _everything_
+they had.
+
+“Why, how you talk!” says the king.  “We sha’n’t rob ‘em of nothing at
+all but jest this money.  The people that _buys_ the property is the
+suff’rers; because as soon ‘s it’s found out ‘at we didn’t own it--which
+won’t be long after we’ve slid--the sale won’t be valid, and it ‘ll all
+go back to the estate.  These yer orphans ‘ll git their house back agin,
+and that’s enough for _them_; they’re young and spry, and k’n easy
+earn a livin’.  _they_ ain’t a-goin to suffer.  Why, jest think--there’s
+thous’n’s and thous’n’s that ain’t nigh so well off.  Bless you, _they_
+ain’t got noth’n’ to complain of.”
+
+Well, the king he talked him blind; so at last he give in, and said all
+right, but said he believed it was blamed foolishness to stay, and that
+doctor hanging over them.  But the king says:
+
+“Cuss the doctor!  What do we k’yer for _him_?  Hain’t we got all the
+fools in town on our side?  And ain’t that a big enough majority in any
+town?”
+
+So they got ready to go down stairs again.  The duke says:
+
+“I don’t think we put that money in a good place.”
+
+That cheered me up.  I’d begun to think I warn’t going to get a hint of
+no kind to help me.  The king says:
+
+“Why?”
+
+“Because Mary Jane ‘ll be in mourning from this out; and first you know
+the nigger that does up the rooms will get an order to box these duds
+up and put ‘em away; and do you reckon a nigger can run across money and
+not borrow some of it?”
+
+“Your head’s level agin, duke,” says the king; and he comes a-fumbling
+under the curtain two or three foot from where I was.  I stuck tight to
+the wall and kept mighty still, though quivery; and I wondered what them
+fellows would say to me if they catched me; and I tried to think what
+I’d better do if they did catch me.  But the king he got the bag before
+I could think more than about a half a thought, and he never suspicioned
+I was around.  They took and shoved the bag through a rip in the straw
+tick that was under the feather-bed, and crammed it in a foot or two
+amongst the straw and said it was all right now, because a nigger only
+makes up the feather-bed, and don’t turn over the straw tick only about
+twice a year, and so it warn’t in no danger of getting stole now.
+
+But I knowed better.  I had it out of there before they was half-way
+down stairs.  I groped along up to my cubby, and hid it there till I
+could get a chance to do better.  I judged I better hide it outside
+of the house somewheres, because if they missed it they would give the
+house a good ransacking:  I knowed that very well.  Then I turned in,
+with my clothes all on; but I couldn’t a gone to sleep if I’d a wanted
+to, I was in such a sweat to get through with the business.  By and by I
+heard the king and the duke come up; so I rolled off my pallet and laid
+with my chin at the top of my ladder, and waited to see if anything was
+going to happen.  But nothing did.
+
+So I held on till all the late sounds had quit and the early ones hadn’t
+begun yet; and then I slipped down the ladder.
+
+
+
+
+CHAPTER XXVII.
+
+I crept to their doors and listened; they was snoring.  So I tiptoed
+along, and got down stairs all right.  There warn’t a sound anywheres.
+ I peeped through a crack of the dining-room door, and see the men that
+was watching the corpse all sound asleep on their chairs.  The door
+was open into the parlor, where the corpse was laying, and there was a
+candle in both rooms. I passed along, and the parlor door was open; but
+I see there warn’t nobody in there but the remainders of Peter; so I
+shoved on by; but the front door was locked, and the key wasn’t there.
+ Just then I heard somebody coming down the stairs, back behind me.  I
+run in the parlor and took a swift look around, and the only place I
+see to hide the bag was in the coffin.  The lid was shoved along about
+a foot, showing the dead man’s face down in there, with a wet cloth over
+it, and his shroud on.  I tucked the money-bag in under the lid, just
+down beyond where his hands was crossed, which made me creep, they was
+so cold, and then I run back across the room and in behind the door.
+
+The person coming was Mary Jane.  She went to the coffin, very soft, and
+kneeled down and looked in; then she put up her handkerchief, and I see
+she begun to cry, though I couldn’t hear her, and her back was to me.  I
+slid out, and as I passed the dining-room I thought I’d make sure them
+watchers hadn’t seen me; so I looked through the crack, and everything
+was all right.  They hadn’t stirred.
+
+I slipped up to bed, feeling ruther blue, on accounts of the thing
+playing out that way after I had took so much trouble and run so much
+resk about it.  Says I, if it could stay where it is, all right; because
+when we get down the river a hundred mile or two I could write back to
+Mary Jane, and she could dig him up again and get it; but that ain’t the
+thing that’s going to happen; the thing that’s going to happen is, the
+money ‘ll be found when they come to screw on the lid.  Then the king
+‘ll get it again, and it ‘ll be a long day before he gives anybody
+another chance to smouch it from him. Of course I _wanted_ to slide
+down and get it out of there, but I dasn’t try it.  Every minute it was
+getting earlier now, and pretty soon some of them watchers would begin
+to stir, and I might get catched--catched with six thousand dollars in my
+hands that nobody hadn’t hired me to take care of.  I don’t wish to be
+mixed up in no such business as that, I says to myself.
+
+When I got down stairs in the morning the parlor was shut up, and the
+watchers was gone.  There warn’t nobody around but the family and the
+widow Bartley and our tribe.  I watched their faces to see if anything
+had been happening, but I couldn’t tell.
+
+Towards the middle of the day the undertaker come with his man, and they
+set the coffin in the middle of the room on a couple of chairs, and then
+set all our chairs in rows, and borrowed more from the neighbors till
+the hall and the parlor and the dining-room was full.  I see the coffin
+lid was the way it was before, but I dasn’t go to look in under it, with
+folks around.
+
+Then the people begun to flock in, and the beats and the girls took
+seats in the front row at the head of the coffin, and for a half an hour
+the people filed around slow, in single rank, and looked down at the
+dead man’s face a minute, and some dropped in a tear, and it was
+all very still and solemn, only the girls and the beats holding
+handkerchiefs to their eyes and keeping their heads bent, and sobbing a
+little.  There warn’t no other sound but the scraping of the feet on
+the floor and blowing noses--because people always blows them more at a
+funeral than they do at other places except church.
+
+When the place was packed full the undertaker he slid around in his
+black gloves with his softy soothering ways, putting on the last
+touches, and getting people and things all ship-shape and comfortable,
+and making no more sound than a cat.  He never spoke; he moved people
+around, he squeezed in late ones, he opened up passageways, and done
+it with nods, and signs with his hands.  Then he took his place over
+against the wall. He was the softest, glidingest, stealthiest man I ever
+see; and there warn’t no more smile to him than there is to a ham.
+
+They had borrowed a melodeum--a sick one; and when everything was ready
+a young woman set down and worked it, and it was pretty skreeky and
+colicky, and everybody joined in and sung, and Peter was the only one
+that had a good thing, according to my notion.  Then the Reverend Hobson
+opened up, slow and solemn, and begun to talk; and straight off the most
+outrageous row busted out in the cellar a body ever heard; it was only
+one dog, but he made a most powerful racket, and he kept it up right
+along; the parson he had to stand there, over the coffin, and wait--you
+couldn’t hear yourself think.  It was right down awkward, and nobody
+didn’t seem to know what to do.  But pretty soon they see that
+long-legged undertaker make a sign to the preacher as much as to say,
+“Don’t you worry--just depend on me.”  Then he stooped down and begun
+to glide along the wall, just his shoulders showing over the people’s
+heads.  So he glided along, and the powwow and racket getting more and
+more outrageous all the time; and at last, when he had gone around two
+sides of the room, he disappears down cellar.  Then in about two seconds
+we heard a whack, and the dog he finished up with a most amazing howl or
+two, and then everything was dead still, and the parson begun his solemn
+talk where he left off.  In a minute or two here comes this undertaker’s
+back and shoulders gliding along the wall again; and so he glided and
+glided around three sides of the room, and then rose up, and shaded his
+mouth with his hands, and stretched his neck out towards the preacher,
+over the people’s heads, and says, in a kind of a coarse whisper, “_He
+had a rat_!”  Then he drooped down and glided along the wall again to
+his place.  You could see it was a great satisfaction to the people,
+because naturally they wanted to know.  A little thing like that don’t
+cost nothing, and it’s just the little things that makes a man to be
+looked up to and liked.  There warn’t no more popular man in town than
+what that undertaker was.
+
+Well, the funeral sermon was very good, but pison long and tiresome; and
+then the king he shoved in and got off some of his usual rubbage, and
+at last the job was through, and the undertaker begun to sneak up on the
+coffin with his screw-driver.  I was in a sweat then, and watched him
+pretty keen. But he never meddled at all; just slid the lid along as
+soft as mush, and screwed it down tight and fast.  So there I was!  I
+didn’t know whether the money was in there or not.  So, says I, s’pose
+somebody has hogged that bag on the sly?--now how do I know whether
+to write to Mary Jane or not? S’pose she dug him up and didn’t find
+nothing, what would she think of me? Blame it, I says, I might get
+hunted up and jailed; I’d better lay low and keep dark, and not write at
+all; the thing’s awful mixed now; trying to better it, I’ve worsened it
+a hundred times, and I wish to goodness I’d just let it alone, dad fetch
+the whole business!
+
+They buried him, and we come back home, and I went to watching faces
+again--I couldn’t help it, and I couldn’t rest easy.  But nothing come of
+it; the faces didn’t tell me nothing.
+
+The king he visited around in the evening, and sweetened everybody up,
+and made himself ever so friendly; and he give out the idea that his
+congregation over in England would be in a sweat about him, so he must
+hurry and settle up the estate right away and leave for home.  He was
+very sorry he was so pushed, and so was everybody; they wished he could
+stay longer, but they said they could see it couldn’t be done.  And he
+said of course him and William would take the girls home with them; and
+that pleased everybody too, because then the girls would be well fixed
+and amongst their own relations; and it pleased the girls, too--tickled
+them so they clean forgot they ever had a trouble in the world; and told
+him to sell out as quick as he wanted to, they would be ready.  Them
+poor things was that glad and happy it made my heart ache to see them
+getting fooled and lied to so, but I didn’t see no safe way for me to
+chip in and change the general tune.
+
+Well, blamed if the king didn’t bill the house and the niggers and all
+the property for auction straight off--sale two days after the funeral;
+but anybody could buy private beforehand if they wanted to.
+
+So the next day after the funeral, along about noon-time, the girls’ joy
+got the first jolt.  A couple of nigger traders come along, and the king
+sold them the niggers reasonable, for three-day drafts as they called
+it, and away they went, the two sons up the river to Memphis, and their
+mother down the river to Orleans.  I thought them poor girls and them
+niggers would break their hearts for grief; they cried around each
+other, and took on so it most made me down sick to see it.  The girls
+said they hadn’t ever dreamed of seeing the family separated or sold
+away from the town.  I can’t ever get it out of my memory, the sight of
+them poor miserable girls and niggers hanging around each other’s necks
+and crying; and I reckon I couldn’t a stood it all, but would a had
+to bust out and tell on our gang if I hadn’t knowed the sale warn’t no
+account and the niggers would be back home in a week or two.
+
+The thing made a big stir in the town, too, and a good many come out
+flatfooted and said it was scandalous to separate the mother and the
+children that way.  It injured the frauds some; but the old fool he
+bulled right along, spite of all the duke could say or do, and I tell
+you the duke was powerful uneasy.
+
+Next day was auction day.  About broad day in the morning the king and
+the duke come up in the garret and woke me up, and I see by their look
+that there was trouble.  The king says:
+
+“Was you in my room night before last?”
+
+“No, your majesty”--which was the way I always called him when nobody but
+our gang warn’t around.
+
+“Was you in there yisterday er last night?”
+
+“No, your majesty.”
+
+“Honor bright, now--no lies.”
+
+“Honor bright, your majesty, I’m telling you the truth.  I hain’t been
+a-near your room since Miss Mary Jane took you and the duke and showed
+it to you.”
+
+The duke says:
+
+“Have you seen anybody else go in there?”
+
+“No, your grace, not as I remember, I believe.”
+
+“Stop and think.”
+
+I studied awhile and see my chance; then I says:
+
+“Well, I see the niggers go in there several times.”
+
+Both of them gave a little jump, and looked like they hadn’t ever
+expected it, and then like they _had_.  Then the duke says:
+
+“What, all of them?”
+
+“No--leastways, not all at once--that is, I don’t think I ever see them
+all come _out_ at once but just one time.”
+
+“Hello!  When was that?”
+
+“It was the day we had the funeral.  In the morning.  It warn’t early,
+because I overslept.  I was just starting down the ladder, and I see
+them.”
+
+“Well, go on, _go_ on!  What did they do?  How’d they act?”
+
+“They didn’t do nothing.  And they didn’t act anyway much, as fur as I
+see. They tiptoed away; so I seen, easy enough, that they’d shoved in
+there to do up your majesty’s room, or something, s’posing you was up;
+and found you _warn’t_ up, and so they was hoping to slide out of the
+way of trouble without waking you up, if they hadn’t already waked you
+up.”
+
+“Great guns, _this_ is a go!” says the king; and both of them looked
+pretty sick and tolerable silly.  They stood there a-thinking and
+scratching their heads a minute, and the duke he bust into a kind of a
+little raspy chuckle, and says:
+
+“It does beat all how neat the niggers played their hand.  They let on
+to be _sorry_ they was going out of this region!  And I believed they
+_was_ sorry, and so did you, and so did everybody.  Don’t ever tell _me_
+any more that a nigger ain’t got any histrionic talent.  Why, the way
+they played that thing it would fool _anybody_.  In my opinion, there’s
+a fortune in ‘em.  If I had capital and a theater, I wouldn’t want a
+better lay-out than that--and here we’ve gone and sold ‘em for a song.
+ Yes, and ain’t privileged to sing the song yet.  Say, where _is_ that
+song--that draft?”
+
+“In the bank for to be collected.  Where _would_ it be?”
+
+“Well, _that’s_ all right then, thank goodness.”
+
+Says I, kind of timid-like:
+
+“Is something gone wrong?”
+
+The king whirls on me and rips out:
+
+“None o’ your business!  You keep your head shet, and mind y’r own
+affairs--if you got any.  Long as you’re in this town don’t you forgit
+_that_--you hear?”  Then he says to the duke, “We got to jest swaller it
+and say noth’n’:  mum’s the word for _us_.”
+
+As they was starting down the ladder the duke he chuckles again, and
+says:
+
+“Quick sales _and_ small profits!  It’s a good business--yes.”
+
+The king snarls around on him and says:
+
+“I was trying to do for the best in sellin’ ‘em out so quick.  If the
+profits has turned out to be none, lackin’ considable, and none to
+carry, is it my fault any more’n it’s yourn?”
+
+“Well, _they’d_ be in this house yet and we _wouldn’t_ if I could a got
+my advice listened to.”
+
+The king sassed back as much as was safe for him, and then swapped
+around and lit into _me_ again.  He give me down the banks for not
+coming and _telling_ him I see the niggers come out of his room acting
+that way--said any fool would a _knowed_ something was up.  And then
+waltzed in and cussed _himself_ awhile, and said it all come of him not
+laying late and taking his natural rest that morning, and he’d be
+blamed if he’d ever do it again.  So they went off a-jawing; and I felt
+dreadful glad I’d worked it all off on to the niggers, and yet hadn’t
+done the niggers no harm by it.
+
+
+
+
+CHAPTER XXVIII.
+
+BY and by it was getting-up time.  So I come down the ladder and started
+for down-stairs; but as I come to the girls’ room the door was open, and
+I see Mary Jane setting by her old hair trunk, which was open and she’d
+been packing things in it--getting ready to go to England.  But she
+had stopped now with a folded gown in her lap, and had her face in her
+hands, crying.  I felt awful bad to see it; of course anybody would.  I
+went in there and says:
+
+“Miss Mary Jane, you can’t a-bear to see people in trouble, and I
+can’t--most always.  Tell me about it.”
+
+So she done it.  And it was the niggers--I just expected it.  She said
+the beautiful trip to England was most about spoiled for her; she didn’t
+know _how_ she was ever going to be happy there, knowing the mother and
+the children warn’t ever going to see each other no more--and then busted
+out bitterer than ever, and flung up her hands, and says:
+
+“Oh, dear, dear, to think they ain’t _ever_ going to see each other any
+more!”
+
+“But they _will_--and inside of two weeks--and I _know_ it!” says I.
+
+Laws, it was out before I could think!  And before I could budge she
+throws her arms around my neck and told me to say it _again_, say it
+_again_, say it _again_!
+
+I see I had spoke too sudden and said too much, and was in a close
+place. I asked her to let me think a minute; and she set there, very
+impatient and excited and handsome, but looking kind of happy and
+eased-up, like a person that’s had a tooth pulled out.  So I went to
+studying it out.  I says to myself, I reckon a body that ups and tells
+the truth when he is in a tight place is taking considerable many resks,
+though I ain’t had no experience, and can’t say for certain; but it
+looks so to me, anyway; and yet here’s a case where I’m blest if it
+don’t look to me like the truth is better and actuly _safer_ than a lie.
+ I must lay it by in my mind, and think it over some time or other, it’s
+so kind of strange and unregular. I never see nothing like it.  Well, I
+says to myself at last, I’m a-going to chance it; I’ll up and tell the
+truth this time, though it does seem most like setting down on a kag of
+powder and touching it off just to see where you’ll go to. Then I says:
+
+“Miss Mary Jane, is there any place out of town a little ways where you
+could go and stay three or four days?”
+
+“Yes; Mr. Lothrop’s.  Why?”
+
+“Never mind why yet.  If I’ll tell you how I know the niggers will see
+each other again inside of two weeks--here in this house--and _prove_ how
+I know it--will you go to Mr. Lothrop’s and stay four days?”
+
+“Four days!” she says; “I’ll stay a year!”
+
+“All right,” I says, “I don’t want nothing more out of _you_ than just
+your word--I druther have it than another man’s kiss-the-Bible.”  She
+smiled and reddened up very sweet, and I says, “If you don’t mind it,
+I’ll shut the door--and bolt it.”
+
+Then I come back and set down again, and says:
+
+“Don’t you holler.  Just set still and take it like a man.  I got to
+tell the truth, and you want to brace up, Miss Mary, because it’s a
+bad kind, and going to be hard to take, but there ain’t no help for
+it.  These uncles of yourn ain’t no uncles at all; they’re a couple of
+frauds--regular dead-beats.  There, now we’re over the worst of it, you
+can stand the rest middling easy.”
+
+It jolted her up like everything, of course; but I was over the shoal
+water now, so I went right along, her eyes a-blazing higher and higher
+all the time, and told her every blame thing, from where we first struck
+that young fool going up to the steamboat, clear through to where she
+flung herself on to the king’s breast at the front door and he kissed
+her sixteen or seventeen times--and then up she jumps, with her face
+afire like sunset, and says:
+
+“The brute!  Come, don’t waste a minute--not a _second_--we’ll have them
+tarred and feathered, and flung in the river!”
+
+Says I:
+
+“Cert’nly.  But do you mean _before_ you go to Mr. Lothrop’s, or--”
+
+“Oh,” she says, “what am I _thinking_ about!” she says, and set right
+down again.  “Don’t mind what I said--please don’t--you _won’t,_ now,
+_will_ you?” Laying her silky hand on mine in that kind of a way that
+I said I would die first.  “I never thought, I was so stirred up,” she
+says; “now go on, and I won’t do so any more.  You tell me what to do,
+and whatever you say I’ll do it.”
+
+“Well,” I says, “it’s a rough gang, them two frauds, and I’m fixed so
+I got to travel with them a while longer, whether I want to or not--I
+druther not tell you why; and if you was to blow on them this town would
+get me out of their claws, and I’d be all right; but there’d be another
+person that you don’t know about who’d be in big trouble.  Well, we
+got to save _him_, hain’t we?  Of course.  Well, then, we won’t blow on
+them.”
+
+Saying them words put a good idea in my head.  I see how maybe I could
+get me and Jim rid of the frauds; get them jailed here, and then leave.
+But I didn’t want to run the raft in the daytime without anybody aboard
+to answer questions but me; so I didn’t want the plan to begin working
+till pretty late to-night.  I says:
+
+“Miss Mary Jane, I’ll tell you what we’ll do, and you won’t have to stay
+at Mr. Lothrop’s so long, nuther.  How fur is it?”
+
+“A little short of four miles--right out in the country, back here.”
+
+“Well, that ‘ll answer.  Now you go along out there, and lay low
+till nine or half-past to-night, and then get them to fetch you home
+again--tell them you’ve thought of something.  If you get here before
+eleven put a candle in this window, and if I don’t turn up wait _till_
+eleven, and _then_ if I don’t turn up it means I’m gone, and out of the
+way, and safe. Then you come out and spread the news around, and get
+these beats jailed.”
+
+“Good,” she says, “I’ll do it.”
+
+“And if it just happens so that I don’t get away, but get took up along
+with them, you must up and say I told you the whole thing beforehand,
+and you must stand by me all you can.”
+
+“Stand by you! indeed I will.  They sha’n’t touch a hair of your head!”
+ she says, and I see her nostrils spread and her eyes snap when she said
+it, too.
+
+“If I get away I sha’n’t be here,” I says, “to prove these rapscallions
+ain’t your uncles, and I couldn’t do it if I _was_ here.  I could swear
+they was beats and bummers, that’s all, though that’s worth something.
+Well, there’s others can do that better than what I can, and they’re
+people that ain’t going to be doubted as quick as I’d be.  I’ll tell you
+how to find them.  Gimme a pencil and a piece of paper.  There--‘Royal
+Nonesuch, Bricksville.’  Put it away, and don’t lose it.  When the
+court wants to find out something about these two, let them send up to
+Bricksville and say they’ve got the men that played the Royal Nonesuch,
+and ask for some witnesses--why, you’ll have that entire town down here
+before you can hardly wink, Miss Mary.  And they’ll come a-biling, too.”
+
+I judged we had got everything fixed about right now.  So I says:
+
+“Just let the auction go right along, and don’t worry.  Nobody don’t
+have to pay for the things they buy till a whole day after the auction
+on accounts of the short notice, and they ain’t going out of this till
+they get that money; and the way we’ve fixed it the sale ain’t going to
+count, and they ain’t going to get no money.  It’s just like the way
+it was with the niggers--it warn’t no sale, and the niggers will be
+back before long.  Why, they can’t collect the money for the _niggers_
+yet--they’re in the worst kind of a fix, Miss Mary.”
+
+“Well,” she says, “I’ll run down to breakfast now, and then I’ll start
+straight for Mr. Lothrop’s.”
+
+“‘Deed, _that_ ain’t the ticket, Miss Mary Jane,” I says, “by no manner
+of means; go _before_ breakfast.”
+
+“Why?”
+
+“What did you reckon I wanted you to go at all for, Miss Mary?”
+
+“Well, I never thought--and come to think, I don’t know.  What was it?”
+
+“Why, it’s because you ain’t one of these leather-face people.  I don’t
+want no better book than what your face is.  A body can set down and
+read it off like coarse print.  Do you reckon you can go and face your
+uncles when they come to kiss you good-morning, and never--”
+
+“There, there, don’t!  Yes, I’ll go before breakfast--I’ll be glad to.
+And leave my sisters with them?”
+
+“Yes; never mind about them.  They’ve got to stand it yet a while.  They
+might suspicion something if all of you was to go.  I don’t want you to
+see them, nor your sisters, nor nobody in this town; if a neighbor was
+to ask how is your uncles this morning your face would tell something.
+ No, you go right along, Miss Mary Jane, and I’ll fix it with all of
+them. I’ll tell Miss Susan to give your love to your uncles and say
+you’ve went away for a few hours for to get a little rest and change, or
+to see a friend, and you’ll be back to-night or early in the morning.”
+
+“Gone to see a friend is all right, but I won’t have my love given to
+them.”
+
+“Well, then, it sha’n’t be.”  It was well enough to tell _her_ so--no
+harm in it.  It was only a little thing to do, and no trouble; and it’s
+the little things that smooths people’s roads the most, down here below;
+it would make Mary Jane comfortable, and it wouldn’t cost nothing.  Then
+I says:  “There’s one more thing--that bag of money.”
+
+“Well, they’ve got that; and it makes me feel pretty silly to think
+_how_ they got it.”
+
+“No, you’re out, there.  They hain’t got it.”
+
+“Why, who’s got it?”
+
+“I wish I knowed, but I don’t.  I _had_ it, because I stole it from
+them; and I stole it to give to you; and I know where I hid it, but I’m
+afraid it ain’t there no more.  I’m awful sorry, Miss Mary Jane, I’m
+just as sorry as I can be; but I done the best I could; I did honest.  I
+come nigh getting caught, and I had to shove it into the first place I
+come to, and run--and it warn’t a good place.”
+
+“Oh, stop blaming yourself--it’s too bad to do it, and I won’t allow
+it--you couldn’t help it; it wasn’t your fault.  Where did you hide it?”
+
+I didn’t want to set her to thinking about her troubles again; and I
+couldn’t seem to get my mouth to tell her what would make her see that
+corpse laying in the coffin with that bag of money on his stomach.  So
+for a minute I didn’t say nothing; then I says:
+
+“I’d ruther not _tell_ you where I put it, Miss Mary Jane, if you don’t
+mind letting me off; but I’ll write it for you on a piece of paper, and
+you can read it along the road to Mr. Lothrop’s, if you want to.  Do you
+reckon that ‘ll do?”
+
+“Oh, yes.”
+
+So I wrote:  “I put it in the coffin.  It was in there when you was
+crying there, away in the night.  I was behind the door, and I was
+mighty sorry for you, Miss Mary Jane.”
+
+It made my eyes water a little to remember her crying there all by
+herself in the night, and them devils laying there right under her own
+roof, shaming her and robbing her; and when I folded it up and give it
+to her I see the water come into her eyes, too; and she shook me by the
+hand, hard, and says:
+
+“_Good_-bye.  I’m going to do everything just as you’ve told me; and if
+I don’t ever see you again, I sha’n’t ever forget you and I’ll think of
+you a many and a many a time, and I’ll _pray_ for you, too!”--and she was
+gone.
+
+Pray for me!  I reckoned if she knowed me she’d take a job that was more
+nearer her size.  But I bet she done it, just the same--she was just that
+kind.  She had the grit to pray for Judus if she took the notion--there
+warn’t no back-down to her, I judge.  You may say what you want to, but
+in my opinion she had more sand in her than any girl I ever see; in
+my opinion she was just full of sand.  It sounds like flattery, but it
+ain’t no flattery.  And when it comes to beauty--and goodness, too--she
+lays over them all.  I hain’t ever seen her since that time that I see
+her go out of that door; no, I hain’t ever seen her since, but I reckon
+I’ve thought of her a many and a many a million times, and of her saying
+she would pray for me; and if ever I’d a thought it would do any good
+for me to pray for _her_, blamed if I wouldn’t a done it or bust.
+
+Well, Mary Jane she lit out the back way, I reckon; because nobody see
+her go.  When I struck Susan and the hare-lip, I says:
+
+“What’s the name of them people over on t’other side of the river that
+you all goes to see sometimes?”
+
+They says:
+
+“There’s several; but it’s the Proctors, mainly.”
+
+“That’s the name,” I says; “I most forgot it.  Well, Miss Mary Jane she
+told me to tell you she’s gone over there in a dreadful hurry--one of
+them’s sick.”
+
+“Which one?”
+
+“I don’t know; leastways, I kinder forget; but I thinks it’s--”
+
+“Sakes alive, I hope it ain’t _Hanner_?”
+
+“I’m sorry to say it,” I says, “but Hanner’s the very one.”
+
+“My goodness, and she so well only last week!  Is she took bad?”
+
+“It ain’t no name for it.  They set up with her all night, Miss Mary
+Jane said, and they don’t think she’ll last many hours.”
+
+“Only think of that, now!  What’s the matter with her?”
+
+I couldn’t think of anything reasonable, right off that way, so I says:
+
+“Mumps.”
+
+“Mumps your granny!  They don’t set up with people that’s got the
+mumps.”
+
+“They don’t, don’t they?  You better bet they do with _these_ mumps.
+ These mumps is different.  It’s a new kind, Miss Mary Jane said.”
+
+“How’s it a new kind?”
+
+“Because it’s mixed up with other things.”
+
+“What other things?”
+
+“Well, measles, and whooping-cough, and erysiplas, and consumption, and
+yaller janders, and brain-fever, and I don’t know what all.”
+
+“My land!  And they call it the _mumps_?”
+
+“That’s what Miss Mary Jane said.”
+
+“Well, what in the nation do they call it the _mumps_ for?”
+
+“Why, because it _is_ the mumps.  That’s what it starts with.”
+
+“Well, ther’ ain’t no sense in it.  A body might stump his toe, and take
+pison, and fall down the well, and break his neck, and bust his brains
+out, and somebody come along and ask what killed him, and some numskull
+up and say, ‘Why, he stumped his _toe_.’  Would ther’ be any sense
+in that? _No_.  And ther’ ain’t no sense in _this_, nuther.  Is it
+ketching?”
+
+“Is it _ketching_?  Why, how you talk.  Is a _harrow_ catching--in the
+dark? If you don’t hitch on to one tooth, you’re bound to on another,
+ain’t you? And you can’t get away with that tooth without fetching the
+whole harrow along, can you?  Well, these kind of mumps is a kind of a
+harrow, as you may say--and it ain’t no slouch of a harrow, nuther, you
+come to get it hitched on good.”
+
+“Well, it’s awful, I think,” says the hare-lip.  “I’ll go to Uncle
+Harvey and--”
+
+“Oh, yes,” I says, “I _would_.  Of _course_ I would.  I wouldn’t lose no
+time.”
+
+“Well, why wouldn’t you?”
+
+“Just look at it a minute, and maybe you can see.  Hain’t your uncles
+obleegd to get along home to England as fast as they can?  And do you
+reckon they’d be mean enough to go off and leave you to go all that
+journey by yourselves?  _you_ know they’ll wait for you.  So fur, so
+good. Your uncle Harvey’s a preacher, ain’t he?  Very well, then; is a
+_preacher_ going to deceive a steamboat clerk? is he going to deceive
+a _ship clerk?_--so as to get them to let Miss Mary Jane go aboard?  Now
+_you_ know he ain’t.  What _will_ he do, then?  Why, he’ll say, ‘It’s a
+great pity, but my church matters has got to get along the best way they
+can; for my niece has been exposed to the dreadful pluribus-unum mumps,
+and so it’s my bounden duty to set down here and wait the three months
+it takes to show on her if she’s got it.’  But never mind, if you think
+it’s best to tell your uncle Harvey--”
+
+“Shucks, and stay fooling around here when we could all be having good
+times in England whilst we was waiting to find out whether Mary Jane’s
+got it or not?  Why, you talk like a muggins.”
+
+“Well, anyway, maybe you’d better tell some of the neighbors.”
+
+“Listen at that, now.  You do beat all for natural stupidness.  Can’t
+you _see_ that _they’d_ go and tell?  Ther’ ain’t no way but just to not
+tell anybody at _all_.”
+
+“Well, maybe you’re right--yes, I judge you _are_ right.”
+
+“But I reckon we ought to tell Uncle Harvey she’s gone out a while,
+anyway, so he won’t be uneasy about her?”
+
+“Yes, Miss Mary Jane she wanted you to do that.  She says, ‘Tell them to
+give Uncle Harvey and William my love and a kiss, and say I’ve run over
+the river to see Mr.’--Mr.--what _is_ the name of that rich family your
+uncle Peter used to think so much of?--I mean the one that--”
+
+“Why, you must mean the Apthorps, ain’t it?”
+
+“Of course; bother them kind of names, a body can’t ever seem to
+remember them, half the time, somehow.  Yes, she said, say she has run
+over for to ask the Apthorps to be sure and come to the auction and buy
+this house, because she allowed her uncle Peter would ruther they had
+it than anybody else; and she’s going to stick to them till they say
+they’ll come, and then, if she ain’t too tired, she’s coming home; and
+if she is, she’ll be home in the morning anyway.  She said, don’t say
+nothing about the Proctors, but only about the Apthorps--which ‘ll be
+perfectly true, because she is going there to speak about their buying
+the house; I know it, because she told me so herself.”
+
+“All right,” they said, and cleared out to lay for their uncles, and
+give them the love and the kisses, and tell them the message.
+
+Everything was all right now.  The girls wouldn’t say nothing because
+they wanted to go to England; and the king and the duke would ruther
+Mary Jane was off working for the auction than around in reach of
+Doctor Robinson.  I felt very good; I judged I had done it pretty neat--I
+reckoned Tom Sawyer couldn’t a done it no neater himself.  Of course he
+would a throwed more style into it, but I can’t do that very handy, not
+being brung up to it.
+
+Well, they held the auction in the public square, along towards the end
+of the afternoon, and it strung along, and strung along, and the old man
+he was on hand and looking his level pisonest, up there longside of the
+auctioneer, and chipping in a little Scripture now and then, or a little
+goody-goody saying of some kind, and the duke he was around goo-gooing
+for sympathy all he knowed how, and just spreading himself generly.
+
+But by and by the thing dragged through, and everything was
+sold--everything but a little old trifling lot in the graveyard.  So
+they’d got to work that off--I never see such a girafft as the king was
+for wanting to swallow _everything_.  Well, whilst they was at it a
+steamboat landed, and in about two minutes up comes a crowd a-whooping
+and yelling and laughing and carrying on, and singing out:
+
+“_Here’s_ your opposition line! here’s your two sets o’ heirs to old
+Peter Wilks--and you pays your money and you takes your choice!”
+
+
+
+
+CHAPTER XXIX.
+
+THEY was fetching a very nice-looking old gentleman along, and a
+nice-looking younger one, with his right arm in a sling.  And, my souls,
+how the people yelled and laughed, and kept it up.  But I didn’t see no
+joke about it, and I judged it would strain the duke and the king some
+to see any.  I reckoned they’d turn pale.  But no, nary a pale did
+_they_ turn. The duke he never let on he suspicioned what was up, but
+just went a goo-gooing around, happy and satisfied, like a jug that’s
+googling out buttermilk; and as for the king, he just gazed and gazed
+down sorrowful on them new-comers like it give him the stomach-ache in
+his very heart to think there could be such frauds and rascals in the
+world.  Oh, he done it admirable.  Lots of the principal people
+gethered around the king, to let him see they was on his side.  That old
+gentleman that had just come looked all puzzled to death.  Pretty
+soon he begun to speak, and I see straight off he pronounced _like_ an
+Englishman--not the king’s way, though the king’s _was_ pretty good for
+an imitation.  I can’t give the old gent’s words, nor I can’t imitate
+him; but he turned around to the crowd, and says, about like this:
+
+“This is a surprise to me which I wasn’t looking for; and I’ll
+acknowledge, candid and frank, I ain’t very well fixed to meet it and
+answer it; for my brother and me has had misfortunes; he’s broke his
+arm, and our baggage got put off at a town above here last night in the
+night by a mistake.  I am Peter Wilks’ brother Harvey, and this is his
+brother William, which can’t hear nor speak--and can’t even make signs to
+amount to much, now’t he’s only got one hand to work them with.  We are
+who we say we are; and in a day or two, when I get the baggage, I can
+prove it. But up till then I won’t say nothing more, but go to the hotel
+and wait.”
+
+So him and the new dummy started off; and the king he laughs, and
+blethers out:
+
+“Broke his arm--_very_ likely, _ain’t_ it?--and very convenient, too,
+for a fraud that’s got to make signs, and ain’t learnt how.  Lost
+their baggage! That’s _mighty_ good!--and mighty ingenious--under the
+_circumstances_!”
+
+So he laughed again; and so did everybody else, except three or four,
+or maybe half a dozen.  One of these was that doctor; another one was
+a sharp-looking gentleman, with a carpet-bag of the old-fashioned kind
+made out of carpet-stuff, that had just come off of the steamboat and
+was talking to him in a low voice, and glancing towards the king now and
+then and nodding their heads--it was Levi Bell, the lawyer that was gone
+up to Louisville; and another one was a big rough husky that come along
+and listened to all the old gentleman said, and was listening to the
+king now. And when the king got done this husky up and says:
+
+“Say, looky here; if you are Harvey Wilks, when’d you come to this
+town?”
+
+“The day before the funeral, friend,” says the king.
+
+“But what time o’ day?”
+
+“In the evenin’--‘bout an hour er two before sundown.”
+
+“_How’d_ you come?”
+
+“I come down on the Susan Powell from Cincinnati.”
+
+“Well, then, how’d you come to be up at the Pint in the _mornin_’--in a
+canoe?”
+
+“I warn’t up at the Pint in the mornin’.”
+
+“It’s a lie.”
+
+Several of them jumped for him and begged him not to talk that way to an
+old man and a preacher.
+
+“Preacher be hanged, he’s a fraud and a liar.  He was up at the Pint
+that mornin’.  I live up there, don’t I?  Well, I was up there, and
+he was up there.  I see him there.  He come in a canoe, along with Tim
+Collins and a boy.”
+
+The doctor he up and says:
+
+“Would you know the boy again if you was to see him, Hines?”
+
+“I reckon I would, but I don’t know.  Why, yonder he is, now.  I know
+him perfectly easy.”
+
+It was me he pointed at.  The doctor says:
+
+“Neighbors, I don’t know whether the new couple is frauds or not; but if
+_these_ two ain’t frauds, I am an idiot, that’s all.  I think it’s our
+duty to see that they don’t get away from here till we’ve looked into
+this thing. Come along, Hines; come along, the rest of you.  We’ll take
+these fellows to the tavern and affront them with t’other couple, and I
+reckon we’ll find out _something_ before we get through.”
+
+It was nuts for the crowd, though maybe not for the king’s friends; so
+we all started.  It was about sundown.  The doctor he led me along by
+the hand, and was plenty kind enough, but he never let go my hand.
+
+We all got in a big room in the hotel, and lit up some candles, and
+fetched in the new couple.  First, the doctor says:
+
+“I don’t wish to be too hard on these two men, but I think they’re
+frauds, and they may have complices that we don’t know nothing about.
+ If they have, won’t the complices get away with that bag of gold Peter
+Wilks left?  It ain’t unlikely.  If these men ain’t frauds, they won’t
+object to sending for that money and letting us keep it till they prove
+they’re all right--ain’t that so?”
+
+Everybody agreed to that.  So I judged they had our gang in a pretty
+tight place right at the outstart.  But the king he only looked
+sorrowful, and says:
+
+“Gentlemen, I wish the money was there, for I ain’t got no disposition
+to throw anything in the way of a fair, open, out-and-out investigation
+o’ this misable business; but, alas, the money ain’t there; you k’n send
+and see, if you want to.”
+
+“Where is it, then?”
+
+“Well, when my niece give it to me to keep for her I took and hid it
+inside o’ the straw tick o’ my bed, not wishin’ to bank it for the few
+days we’d be here, and considerin’ the bed a safe place, we not bein’
+used to niggers, and suppos’n’ ‘em honest, like servants in England.
+ The niggers stole it the very next mornin’ after I had went down
+stairs; and when I sold ‘em I hadn’t missed the money yit, so they got
+clean away with it.  My servant here k’n tell you ‘bout it, gentlemen.”
+
+The doctor and several said “Shucks!” and I see nobody didn’t altogether
+believe him.  One man asked me if I see the niggers steal it.  I said
+no, but I see them sneaking out of the room and hustling away, and I
+never thought nothing, only I reckoned they was afraid they had waked up
+my master and was trying to get away before he made trouble with them.
+ That was all they asked me.  Then the doctor whirls on me and says:
+
+“Are _you_ English, too?”
+
+I says yes; and him and some others laughed, and said, “Stuff!”
+
+Well, then they sailed in on the general investigation, and there we had
+it, up and down, hour in, hour out, and nobody never said a word about
+supper, nor ever seemed to think about it--and so they kept it up, and
+kept it up; and it _was_ the worst mixed-up thing you ever see.  They
+made the king tell his yarn, and they made the old gentleman tell his’n;
+and anybody but a lot of prejudiced chuckleheads would a _seen_ that the
+old gentleman was spinning truth and t’other one lies.  And by and by
+they had me up to tell what I knowed.  The king he give me a left-handed
+look out of the corner of his eye, and so I knowed enough to talk on the
+right side.  I begun to tell about Sheffield, and how we lived there,
+and all about the English Wilkses, and so on; but I didn’t get pretty
+fur till the doctor begun to laugh; and Levi Bell, the lawyer, says:
+
+“Set down, my boy; I wouldn’t strain myself if I was you.  I reckon
+you ain’t used to lying, it don’t seem to come handy; what you want is
+practice.  You do it pretty awkward.”
+
+I didn’t care nothing for the compliment, but I was glad to be let off,
+anyway.
+
+The doctor he started to say something, and turns and says:
+
+“If you’d been in town at first, Levi Bell--” The king broke in and
+reached out his hand, and says:
+
+“Why, is this my poor dead brother’s old friend that he’s wrote so often
+about?”
+
+The lawyer and him shook hands, and the lawyer smiled and looked
+pleased, and they talked right along awhile, and then got to one side
+and talked low; and at last the lawyer speaks up and says:
+
+“That ‘ll fix it.  I’ll take the order and send it, along with your
+brother’s, and then they’ll know it’s all right.”
+
+So they got some paper and a pen, and the king he set down and twisted
+his head to one side, and chawed his tongue, and scrawled off something;
+and then they give the pen to the duke--and then for the first time the
+duke looked sick.  But he took the pen and wrote.  So then the lawyer
+turns to the new old gentleman and says:
+
+“You and your brother please write a line or two and sign your names.”
+
+The old gentleman wrote, but nobody couldn’t read it.  The lawyer looked
+powerful astonished, and says:
+
+“Well, it beats _me_”--and snaked a lot of old letters out of his pocket,
+and examined them, and then examined the old man’s writing, and then
+_them_ again; and then says:  “These old letters is from Harvey Wilks;
+and here’s _these_ two handwritings, and anybody can see they didn’t
+write them” (the king and the duke looked sold and foolish, I tell
+you, to see how the lawyer had took them in), “and here’s _this_ old
+gentleman’s hand writing, and anybody can tell, easy enough, _he_ didn’t
+write them--fact is, the scratches he makes ain’t properly _writing_ at
+all.  Now, here’s some letters from--”
+
+The new old gentleman says:
+
+“If you please, let me explain.  Nobody can read my hand but my brother
+there--so he copies for me.  It’s _his_ hand you’ve got there, not mine.”
+
+“_Well_!” says the lawyer, “this _is_ a state of things.  I’ve got some
+of William’s letters, too; so if you’ll get him to write a line or so we
+can com--”
+
+“He _can’t_ write with his left hand,” says the old gentleman.  “If he
+could use his right hand, you would see that he wrote his own letters
+and mine too.  Look at both, please--they’re by the same hand.”
+
+The lawyer done it, and says:
+
+“I believe it’s so--and if it ain’t so, there’s a heap stronger
+resemblance than I’d noticed before, anyway.  Well, well, well!  I
+thought we was right on the track of a solution, but it’s gone to grass,
+partly.  But anyway, one thing is proved--_these_ two ain’t either of ‘em
+Wilkses”--and he wagged his head towards the king and the duke.
+
+Well, what do you think?  That muleheaded old fool wouldn’t give in
+_then_! Indeed he wouldn’t.  Said it warn’t no fair test.  Said his
+brother William was the cussedest joker in the world, and hadn’t tried
+to write--_he_ see William was going to play one of his jokes the minute
+he put the pen to paper.  And so he warmed up and went warbling and
+warbling right along till he was actuly beginning to believe what he was
+saying _himself_; but pretty soon the new gentleman broke in, and says:
+
+“I’ve thought of something.  Is there anybody here that helped to lay
+out my br--helped to lay out the late Peter Wilks for burying?”
+
+“Yes,” says somebody, “me and Ab Turner done it.  We’re both here.”
+
+Then the old man turns towards the king, and says:
+
+“Perhaps this gentleman can tell me what was tattooed on his breast?”
+
+Blamed if the king didn’t have to brace up mighty quick, or he’d a
+squshed down like a bluff bank that the river has cut under, it took
+him so sudden; and, mind you, it was a thing that was calculated to make
+most _anybody_ sqush to get fetched such a solid one as that without any
+notice, because how was _he_ going to know what was tattooed on the man?
+ He whitened a little; he couldn’t help it; and it was mighty still in
+there, and everybody bending a little forwards and gazing at him.  Says
+I to myself, _now_ he’ll throw up the sponge--there ain’t no more use.
+ Well, did he?  A body can’t hardly believe it, but he didn’t.  I reckon
+he thought he’d keep the thing up till he tired them people out, so
+they’d thin out, and him and the duke could break loose and get away.
+ Anyway, he set there, and pretty soon he begun to smile, and says:
+
+“Mf!  It’s a _very_ tough question, _ain’t_ it!  _yes_, sir, I k’n
+tell you what’s tattooed on his breast.  It’s jest a small, thin, blue
+arrow--that’s what it is; and if you don’t look clost, you can’t see it.
+ _now_ what do you say--hey?”
+
+Well, I never see anything like that old blister for clean out-and-out
+cheek.
+
+The new old gentleman turns brisk towards Ab Turner and his pard, and
+his eye lights up like he judged he’d got the king _this_ time, and
+says:
+
+“There--you’ve heard what he said!  Was there any such mark on Peter
+Wilks’ breast?”
+
+Both of them spoke up and says:
+
+“We didn’t see no such mark.”
+
+“Good!” says the old gentleman.  “Now, what you _did_ see on his breast
+was a small dim P, and a B (which is an initial he dropped when he was
+young), and a W, with dashes between them, so:  P--B--W”--and he marked
+them that way on a piece of paper.  “Come, ain’t that what you saw?”
+
+Both of them spoke up again, and says:
+
+“No, we _didn’t_.  We never seen any marks at all.”
+
+Well, everybody _was_ in a state of mind now, and they sings out:
+
+“The whole _bilin_’ of ‘m ‘s frauds!  Le’s duck ‘em! le’s drown ‘em!
+le’s ride ‘em on a rail!” and everybody was whooping at once, and there
+was a rattling powwow.  But the lawyer he jumps on the table and yells,
+and says:
+
+“Gentlemen--gentle_men!_  Hear me just a word--just a _single_ word--if you
+_please_!  There’s one way yet--let’s go and dig up the corpse and look.”
+
+That took them.
+
+“Hooray!” they all shouted, and was starting right off; but the lawyer
+and the doctor sung out:
+
+“Hold on, hold on!  Collar all these four men and the boy, and fetch
+_them_ along, too!”
+
+“We’ll do it!” they all shouted; “and if we don’t find them marks we’ll
+lynch the whole gang!”
+
+I _was_ scared, now, I tell you.  But there warn’t no getting away, you
+know. They gripped us all, and marched us right along, straight for the
+graveyard, which was a mile and a half down the river, and the whole
+town at our heels, for we made noise enough, and it was only nine in the
+evening.
+
+As we went by our house I wished I hadn’t sent Mary Jane out of town;
+because now if I could tip her the wink she’d light out and save me, and
+blow on our dead-beats.
+
+Well, we swarmed along down the river road, just carrying on like
+wildcats; and to make it more scary the sky was darking up, and the
+lightning beginning to wink and flitter, and the wind to shiver amongst
+the leaves. This was the most awful trouble and most dangersome I ever
+was in; and I was kinder stunned; everything was going so different from
+what I had allowed for; stead of being fixed so I could take my own time
+if I wanted to, and see all the fun, and have Mary Jane at my back to
+save me and set me free when the close-fit come, here was nothing in the
+world betwixt me and sudden death but just them tattoo-marks.  If they
+didn’t find them--
+
+I couldn’t bear to think about it; and yet, somehow, I couldn’t think
+about nothing else.  It got darker and darker, and it was a beautiful
+time to give the crowd the slip; but that big husky had me by the
+wrist--Hines--and a body might as well try to give Goliar the slip.  He
+dragged me right along, he was so excited, and I had to run to keep up.
+
+When they got there they swarmed into the graveyard and washed over it
+like an overflow.  And when they got to the grave they found they had
+about a hundred times as many shovels as they wanted, but nobody hadn’t
+thought to fetch a lantern.  But they sailed into digging anyway by the
+flicker of the lightning, and sent a man to the nearest house, a half a
+mile off, to borrow one.
+
+So they dug and dug like everything; and it got awful dark, and the rain
+started, and the wind swished and swushed along, and the lightning come
+brisker and brisker, and the thunder boomed; but them people never took
+no notice of it, they was so full of this business; and one minute
+you could see everything and every face in that big crowd, and the
+shovelfuls of dirt sailing up out of the grave, and the next second the
+dark wiped it all out, and you couldn’t see nothing at all.
+
+At last they got out the coffin and begun to unscrew the lid, and then
+such another crowding and shouldering and shoving as there was, to
+scrouge in and get a sight, you never see; and in the dark, that way, it
+was awful.  Hines he hurt my wrist dreadful pulling and tugging so,
+and I reckon he clean forgot I was in the world, he was so excited and
+panting.
+
+All of a sudden the lightning let go a perfect sluice of white glare,
+and somebody sings out:
+
+“By the living jingo, here’s the bag of gold on his breast!”
+
+Hines let out a whoop, like everybody else, and dropped my wrist and
+give a big surge to bust his way in and get a look, and the way I lit
+out and shinned for the road in the dark there ain’t nobody can tell.
+
+I had the road all to myself, and I fairly flew--leastways, I had it all
+to myself except the solid dark, and the now-and-then glares, and the
+buzzing of the rain, and the thrashing of the wind, and the splitting of
+the thunder; and sure as you are born I did clip it along!
+
+When I struck the town I see there warn’t nobody out in the storm, so
+I never hunted for no back streets, but humped it straight through the
+main one; and when I begun to get towards our house I aimed my eye and
+set it. No light there; the house all dark--which made me feel sorry and
+disappointed, I didn’t know why.  But at last, just as I was sailing by,
+_flash_ comes the light in Mary Jane’s window! and my heart swelled up
+sudden, like to bust; and the same second the house and all was behind
+me in the dark, and wasn’t ever going to be before me no more in this
+world. She _was_ the best girl I ever see, and had the most sand.
+
+The minute I was far enough above the town to see I could make the
+towhead, I begun to look sharp for a boat to borrow, and the first
+time the lightning showed me one that wasn’t chained I snatched it and
+shoved. It was a canoe, and warn’t fastened with nothing but a rope.
+ The towhead was a rattling big distance off, away out there in the
+middle of the river, but I didn’t lose no time; and when I struck the
+raft at last I was so fagged I would a just laid down to blow and gasp
+if I could afforded it.  But I didn’t.  As I sprung aboard I sung out:
+
+“Out with you, Jim, and set her loose!  Glory be to goodness, we’re shut
+of them!”
+
+Jim lit out, and was a-coming for me with both arms spread, he was so
+full of joy; but when I glimpsed him in the lightning my heart shot up
+in my mouth and I went overboard backwards; for I forgot he was old King
+Lear and a drownded A-rab all in one, and it most scared the livers and
+lights out of me.  But Jim fished me out, and was going to hug me and
+bless me, and so on, he was so glad I was back and we was shut of the
+king and the duke, but I says:
+
+“Not now; have it for breakfast, have it for breakfast!  Cut loose and
+let her slide!”
+
+So in two seconds away we went a-sliding down the river, and it _did_
+seem so good to be free again and all by ourselves on the big river, and
+nobody to bother us.  I had to skip around a bit, and jump up and crack
+my heels a few times--I couldn’t help it; but about the third crack
+I noticed a sound that I knowed mighty well, and held my breath and
+listened and waited; and sure enough, when the next flash busted out
+over the water, here they come!--and just a-laying to their oars and
+making their skiff hum!  It was the king and the duke.
+
+So I wilted right down on to the planks then, and give up; and it was
+all I could do to keep from crying.
+
+
+
+
+CHAPTER XXX.
+
+WHEN they got aboard the king went for me, and shook me by the collar,
+and says:
+
+“Tryin’ to give us the slip, was ye, you pup!  Tired of our company,
+hey?”
+
+I says:
+
+“No, your majesty, we warn’t--_please_ don’t, your majesty!”
+
+“Quick, then, and tell us what _was_ your idea, or I’ll shake the
+insides out o’ you!”
+
+“Honest, I’ll tell you everything just as it happened, your majesty.
+ The man that had a-holt of me was very good to me, and kept saying he
+had a boy about as big as me that died last year, and he was sorry
+to see a boy in such a dangerous fix; and when they was all took by
+surprise by finding the gold, and made a rush for the coffin, he lets go
+of me and whispers, ‘Heel it now, or they’ll hang ye, sure!’ and I lit
+out.  It didn’t seem no good for _me_ to stay--I couldn’t do nothing,
+and I didn’t want to be hung if I could get away.  So I never stopped
+running till I found the canoe; and when I got here I told Jim to hurry,
+or they’d catch me and hang me yet, and said I was afeard you and the
+duke wasn’t alive now, and I was awful sorry, and so was Jim, and was
+awful glad when we see you coming; you may ask Jim if I didn’t.”
+
+Jim said it was so; and the king told him to shut up, and said, “Oh,
+yes, it’s _mighty_ likely!” and shook me up again, and said he reckoned
+he’d drownd me.  But the duke says:
+
+“Leggo the boy, you old idiot!  Would _you_ a done any different?  Did
+you inquire around for _him_ when you got loose?  I don’t remember it.”
+
+So the king let go of me, and begun to cuss that town and everybody in
+it. But the duke says:
+
+“You better a blame’ sight give _yourself_ a good cussing, for you’re
+the one that’s entitled to it most.  You hain’t done a thing from the
+start that had any sense in it, except coming out so cool and cheeky
+with that imaginary blue-arrow mark.  That _was_ bright--it was right
+down bully; and it was the thing that saved us.  For if it hadn’t been
+for that they’d a jailed us till them Englishmen’s baggage come--and
+then--the penitentiary, you bet! But that trick took ‘em to the
+graveyard, and the gold done us a still bigger kindness; for if the
+excited fools hadn’t let go all holts and made that rush to get a
+look we’d a slept in our cravats to-night--cravats warranted to _wear_,
+too--longer than _we’d_ need ‘em.”
+
+They was still a minute--thinking; then the king says, kind of
+absent-minded like:
+
+“Mf!  And we reckoned the _niggers_ stole it!”
+
+That made me squirm!
+
+“Yes,” says the duke, kinder slow and deliberate and sarcastic, “_we_
+did.”
+
+After about a half a minute the king drawls out:
+
+“Leastways, I did.”
+
+The duke says, the same way:
+
+“On the contrary, I did.”
+
+The king kind of ruffles up, and says:
+
+“Looky here, Bilgewater, what’r you referrin’ to?”
+
+The duke says, pretty brisk:
+
+“When it comes to that, maybe you’ll let me ask, what was _you_
+referring to?”
+
+“Shucks!” says the king, very sarcastic; “but I don’t know--maybe you was
+asleep, and didn’t know what you was about.”
+
+The duke bristles up now, and says:
+
+“Oh, let _up_ on this cussed nonsense; do you take me for a blame’ fool?
+Don’t you reckon I know who hid that money in that coffin?”
+
+“_Yes_, sir!  I know you _do_ know, because you done it yourself!”
+
+“It’s a lie!”--and the duke went for him.  The king sings out:
+
+“Take y’r hands off!--leggo my throat!--I take it all back!”
+
+The duke says:
+
+“Well, you just own up, first, that you _did_ hide that money there,
+intending to give me the slip one of these days, and come back and dig
+it up, and have it all to yourself.”
+
+“Wait jest a minute, duke--answer me this one question, honest and fair;
+if you didn’t put the money there, say it, and I’ll b’lieve you, and
+take back everything I said.”
+
+“You old scoundrel, I didn’t, and you know I didn’t.  There, now!”
+
+“Well, then, I b’lieve you.  But answer me only jest this one more--now
+_don’t_ git mad; didn’t you have it in your mind to hook the money and
+hide it?”
+
+The duke never said nothing for a little bit; then he says:
+
+“Well, I don’t care if I _did_, I didn’t _do_ it, anyway.  But you not
+only had it in mind to do it, but you _done_ it.”
+
+“I wisht I never die if I done it, duke, and that’s honest.  I won’t say
+I warn’t goin’ to do it, because I _was_; but you--I mean somebody--got in
+ahead o’ me.”
+
+“It’s a lie!  You done it, and you got to _say_ you done it, or--”
+
+The king began to gurgle, and then he gasps out:
+
+“‘Nough!--I _own up!_”
+
+I was very glad to hear him say that; it made me feel much more easier
+than what I was feeling before.  So the duke took his hands off and
+says:
+
+“If you ever deny it again I’ll drown you.  It’s _well_ for you to set
+there and blubber like a baby--it’s fitten for you, after the way
+you’ve acted. I never see such an old ostrich for wanting to gobble
+everything--and I a-trusting you all the time, like you was my own
+father.  You ought to been ashamed of yourself to stand by and hear it
+saddled on to a lot of poor niggers, and you never say a word for ‘em.
+ It makes me feel ridiculous to think I was soft enough to _believe_
+that rubbage.  Cuss you, I can see now why you was so anxious to make
+up the deffisit--you wanted to get what money I’d got out of the Nonesuch
+and one thing or another, and scoop it _all_!”
+
+The king says, timid, and still a-snuffling:
+
+“Why, duke, it was you that said make up the deffisit; it warn’t me.”
+
+“Dry up!  I don’t want to hear no more out of you!” says the duke.  “And
+_now_ you see what you GOT by it.  They’ve got all their own money back,
+and all of _ourn_ but a shekel or two _besides_.  G’long to bed, and
+don’t you deffersit _me_ no more deffersits, long ‘s _you_ live!”
+
+So the king sneaked into the wigwam and took to his bottle for comfort,
+and before long the duke tackled HIS bottle; and so in about a half an
+hour they was as thick as thieves again, and the tighter they got the
+lovinger they got, and went off a-snoring in each other’s arms.  They
+both got powerful mellow, but I noticed the king didn’t get mellow
+enough to forget to remember to not deny about hiding the money-bag
+again.  That made me feel easy and satisfied.  Of course when they got
+to snoring we had a long gabble, and I told Jim everything.
+
+
+
+
+CHAPTER XXXI.
+
+WE dasn’t stop again at any town for days and days; kept right along
+down the river.  We was down south in the warm weather now, and a mighty
+long ways from home.  We begun to come to trees with Spanish moss on
+them, hanging down from the limbs like long, gray beards.  It was the
+first I ever see it growing, and it made the woods look solemn and
+dismal.  So now the frauds reckoned they was out of danger, and they
+begun to work the villages again.
+
+First they done a lecture on temperance; but they didn’t make enough
+for them both to get drunk on.  Then in another village they started
+a dancing-school; but they didn’t know no more how to dance than a
+kangaroo does; so the first prance they made the general public jumped
+in and pranced them out of town.  Another time they tried to go at
+yellocution; but they didn’t yellocute long till the audience got up and
+give them a solid good cussing, and made them skip out.  They tackled
+missionarying, and mesmerizing, and doctoring, and telling fortunes, and
+a little of everything; but they couldn’t seem to have no luck.  So at
+last they got just about dead broke, and laid around the raft as she
+floated along, thinking and thinking, and never saying nothing, by the
+half a day at a time, and dreadful blue and desperate.
+
+And at last they took a change and begun to lay their heads together in
+the wigwam and talk low and confidential two or three hours at a time.
+Jim and me got uneasy.  We didn’t like the look of it.  We judged they
+was studying up some kind of worse deviltry than ever.  We turned it
+over and over, and at last we made up our minds they was going to break
+into somebody’s house or store, or was going into the counterfeit-money
+business, or something. So then we was pretty scared, and made up an
+agreement that we wouldn’t have nothing in the world to do with such
+actions, and if we ever got the least show we would give them the cold
+shake and clear out and leave them behind. Well, early one morning we
+hid the raft in a good, safe place about two mile below a little bit of
+a shabby village named Pikesville, and the king he went ashore and told
+us all to stay hid whilst he went up to town and smelt around to see
+if anybody had got any wind of the Royal Nonesuch there yet. (“House to
+rob, you _mean_,” says I to myself; “and when you get through robbing it
+you’ll come back here and wonder what has become of me and Jim and the
+raft--and you’ll have to take it out in wondering.”) And he said if he
+warn’t back by midday the duke and me would know it was all right, and
+we was to come along.
+
+So we stayed where we was.  The duke he fretted and sweated around, and
+was in a mighty sour way.  He scolded us for everything, and we couldn’t
+seem to do nothing right; he found fault with every little thing.
+Something was a-brewing, sure.  I was good and glad when midday come
+and no king; we could have a change, anyway--and maybe a chance for _the_
+change on top of it.  So me and the duke went up to the village, and
+hunted around there for the king, and by and by we found him in the
+back room of a little low doggery, very tight, and a lot of loafers
+bullyragging him for sport, and he a-cussing and a-threatening with all
+his might, and so tight he couldn’t walk, and couldn’t do nothing to
+them.  The duke he begun to abuse him for an old fool, and the king
+begun to sass back, and the minute they was fairly at it I lit out and
+shook the reefs out of my hind legs, and spun down the river road like
+a deer, for I see our chance; and I made up my mind that it would be a
+long day before they ever see me and Jim again.  I got down there all
+out of breath but loaded up with joy, and sung out:
+
+“Set her loose, Jim! we’re all right now!”
+
+But there warn’t no answer, and nobody come out of the wigwam.  Jim was
+gone!  I set up a shout--and then another--and then another one; and run
+this way and that in the woods, whooping and screeching; but it warn’t
+no use--old Jim was gone.  Then I set down and cried; I couldn’t help
+it. But I couldn’t set still long.  Pretty soon I went out on the road,
+trying to think what I better do, and I run across a boy walking, and
+asked him if he’d seen a strange nigger dressed so and so, and he says:
+
+“Yes.”
+
+“Whereabouts?” says I.
+
+“Down to Silas Phelps’ place, two mile below here.  He’s a runaway
+nigger, and they’ve got him.  Was you looking for him?”
+
+“You bet I ain’t!  I run across him in the woods about an hour or two
+ago, and he said if I hollered he’d cut my livers out--and told me to lay
+down and stay where I was; and I done it.  Been there ever since; afeard
+to come out.”
+
+“Well,” he says, “you needn’t be afeard no more, becuz they’ve got him.
+He run off f’m down South, som’ers.”
+
+“It’s a good job they got him.”
+
+“Well, I _reckon_!  There’s two hunderd dollars reward on him.  It’s
+like picking up money out’n the road.”
+
+“Yes, it is--and I could a had it if I’d been big enough; I see him
+_first_. Who nailed him?”
+
+“It was an old fellow--a stranger--and he sold out his chance in him for
+forty dollars, becuz he’s got to go up the river and can’t wait.  Think
+o’ that, now!  You bet _I’d_ wait, if it was seven year.”
+
+“That’s me, every time,” says I.  “But maybe his chance ain’t worth
+no more than that, if he’ll sell it so cheap.  Maybe there’s something
+ain’t straight about it.”
+
+“But it _is_, though--straight as a string.  I see the handbill myself.
+ It tells all about him, to a dot--paints him like a picture, and tells
+the plantation he’s frum, below Newr_leans_.  No-sirree-_bob_, they
+ain’t no trouble ‘bout _that_ speculation, you bet you.  Say, gimme a
+chaw tobacker, won’t ye?”
+
+I didn’t have none, so he left.  I went to the raft, and set down in the
+wigwam to think.  But I couldn’t come to nothing.  I thought till I wore
+my head sore, but I couldn’t see no way out of the trouble.  After all
+this long journey, and after all we’d done for them scoundrels, here it
+was all come to nothing, everything all busted up and ruined, because
+they could have the heart to serve Jim such a trick as that, and make
+him a slave again all his life, and amongst strangers, too, for forty
+dirty dollars.
+
+Once I said to myself it would be a thousand times better for Jim to
+be a slave at home where his family was, as long as he’d _got_ to be a
+slave, and so I’d better write a letter to Tom Sawyer and tell him to
+tell Miss Watson where he was.  But I soon give up that notion for two
+things: she’d be mad and disgusted at his rascality and ungratefulness
+for leaving her, and so she’d sell him straight down the river again;
+and if she didn’t, everybody naturally despises an ungrateful nigger,
+and they’d make Jim feel it all the time, and so he’d feel ornery and
+disgraced. And then think of _me_!  It would get all around that Huck
+Finn helped a nigger to get his freedom; and if I was ever to see
+anybody from that town again I’d be ready to get down and lick his boots
+for shame.  That’s just the way:  a person does a low-down thing, and
+then he don’t want to take no consequences of it. Thinks as long as he
+can hide it, it ain’t no disgrace.  That was my fix exactly. The more I
+studied about this the more my conscience went to grinding me, and the
+more wicked and low-down and ornery I got to feeling. And at last, when
+it hit me all of a sudden that here was the plain hand of Providence
+slapping me in the face and letting me know my wickedness was being
+watched all the time from up there in heaven, whilst I was stealing a
+poor old woman’s nigger that hadn’t ever done me no harm, and now was
+showing me there’s One that’s always on the lookout, and ain’t a-going
+to allow no such miserable doings to go only just so fur and no further,
+I most dropped in my tracks I was so scared.  Well, I tried the best I
+could to kinder soften it up somehow for myself by saying I was brung
+up wicked, and so I warn’t so much to blame; but something inside of me
+kept saying, “There was the Sunday-school, you could a gone to it; and
+if you’d a done it they’d a learnt you there that people that acts as
+I’d been acting about that nigger goes to everlasting fire.”
+
+It made me shiver.  And I about made up my mind to pray, and see if I
+couldn’t try to quit being the kind of a boy I was and be better.  So
+I kneeled down.  But the words wouldn’t come.  Why wouldn’t they?  It
+warn’t no use to try and hide it from Him.  Nor from _me_, neither.  I
+knowed very well why they wouldn’t come.  It was because my heart warn’t
+right; it was because I warn’t square; it was because I was playing
+double.  I was letting _on_ to give up sin, but away inside of me I was
+holding on to the biggest one of all.  I was trying to make my mouth
+_say_ I would do the right thing and the clean thing, and go and write
+to that nigger’s owner and tell where he was; but deep down in me I
+knowed it was a lie, and He knowed it.  You can’t pray a lie--I found
+that out.
+
+So I was full of trouble, full as I could be; and didn’t know what to
+do. At last I had an idea; and I says, I’ll go and write the letter--and
+then see if I can pray.  Why, it was astonishing, the way I felt as
+light as a feather right straight off, and my troubles all gone.  So I
+got a piece of paper and a pencil, all glad and excited, and set down
+and wrote:
+
+Miss Watson, your runaway nigger Jim is down here two mile below
+Pikesville, and Mr. Phelps has got him and he will give him up for the
+reward if you send.
+
+_Huck Finn._
+
+I felt good and all washed clean of sin for the first time I had ever
+felt so in my life, and I knowed I could pray now.  But I didn’t do it
+straight off, but laid the paper down and set there thinking--thinking
+how good it was all this happened so, and how near I come to being lost
+and going to hell.  And went on thinking.  And got to thinking over our
+trip down the river; and I see Jim before me all the time:  in the day
+and in the night-time, sometimes moonlight, sometimes storms, and we
+a-floating along, talking and singing and laughing.  But somehow I
+couldn’t seem to strike no places to harden me against him, but only the
+other kind.  I’d see him standing my watch on top of his’n, ‘stead of
+calling me, so I could go on sleeping; and see him how glad he was when
+I come back out of the fog; and when I come to him again in the swamp,
+up there where the feud was; and such-like times; and would always call
+me honey, and pet me and do everything he could think of for me, and how
+good he always was; and at last I struck the time I saved him by telling
+the men we had small-pox aboard, and he was so grateful, and said I was
+the best friend old Jim ever had in the world, and the _only_ one he’s
+got now; and then I happened to look around and see that paper.
+
+It was a close place.  I took it up, and held it in my hand.  I was
+a-trembling, because I’d got to decide, forever, betwixt two things, and
+I knowed it.  I studied a minute, sort of holding my breath, and then
+says to myself:
+
+“All right, then, I’ll _go_ to hell”--and tore it up.
+
+It was awful thoughts and awful words, but they was said.  And I let
+them stay said; and never thought no more about reforming.  I shoved the
+whole thing out of my head, and said I would take up wickedness again,
+which was in my line, being brung up to it, and the other warn’t.  And
+for a starter I would go to work and steal Jim out of slavery again;
+and if I could think up anything worse, I would do that, too; because as
+long as I was in, and in for good, I might as well go the whole hog.
+
+Then I set to thinking over how to get at it, and turned over some
+considerable many ways in my mind; and at last fixed up a plan that
+suited me.  So then I took the bearings of a woody island that was down
+the river a piece, and as soon as it was fairly dark I crept out with my
+raft and went for it, and hid it there, and then turned in.  I slept the
+night through, and got up before it was light, and had my breakfast,
+and put on my store clothes, and tied up some others and one thing or
+another in a bundle, and took the canoe and cleared for shore.  I landed
+below where I judged was Phelps’s place, and hid my bundle in the woods,
+and then filled up the canoe with water, and loaded rocks into her and
+sunk her where I could find her again when I wanted her, about a quarter
+of a mile below a little steam sawmill that was on the bank.
+
+Then I struck up the road, and when I passed the mill I see a sign on
+it, “Phelps’s Sawmill,” and when I come to the farm-houses, two or
+three hundred yards further along, I kept my eyes peeled, but didn’t
+see nobody around, though it was good daylight now.  But I didn’t mind,
+because I didn’t want to see nobody just yet--I only wanted to get the
+lay of the land. According to my plan, I was going to turn up there from
+the village, not from below.  So I just took a look, and shoved along,
+straight for town. Well, the very first man I see when I got there was
+the duke.  He was sticking up a bill for the Royal Nonesuch--three-night
+performance--like that other time.  They had the cheek, them frauds!  I
+was right on him before I could shirk.  He looked astonished, and says:
+
+“Hel-_lo_!  Where’d _you_ come from?”  Then he says, kind of glad and
+eager, “Where’s the raft?--got her in a good place?”
+
+I says:
+
+“Why, that’s just what I was going to ask your grace.”
+
+Then he didn’t look so joyful, and says:
+
+“What was your idea for asking _me_?” he says.
+
+“Well,” I says, “when I see the king in that doggery yesterday I says
+to myself, we can’t get him home for hours, till he’s soberer; so I went
+a-loafing around town to put in the time and wait.  A man up and offered
+me ten cents to help him pull a skiff over the river and back to fetch
+a sheep, and so I went along; but when we was dragging him to the boat,
+and the man left me a-holt of the rope and went behind him to shove him
+along, he was too strong for me and jerked loose and run, and we after
+him.  We didn’t have no dog, and so we had to chase him all over the
+country till we tired him out.  We never got him till dark; then we
+fetched him over, and I started down for the raft.  When I got there and
+see it was gone, I says to myself, ‘They’ve got into trouble and had to
+leave; and they’ve took my nigger, which is the only nigger I’ve got in
+the world, and now I’m in a strange country, and ain’t got no property
+no more, nor nothing, and no way to make my living;’ so I set down and
+cried.  I slept in the woods all night.  But what _did_ become of the
+raft, then?--and Jim--poor Jim!”
+
+“Blamed if I know--that is, what’s become of the raft.  That old fool had
+made a trade and got forty dollars, and when we found him in the doggery
+the loafers had matched half-dollars with him and got every cent but
+what he’d spent for whisky; and when I got him home late last night and
+found the raft gone, we said, ‘That little rascal has stole our raft and
+shook us, and run off down the river.’”
+
+“I wouldn’t shake my _nigger_, would I?--the only nigger I had in the
+world, and the only property.”
+
+“We never thought of that.  Fact is, I reckon we’d come to consider him
+_our_ nigger; yes, we did consider him so--goodness knows we had trouble
+enough for him.  So when we see the raft was gone and we flat broke,
+there warn’t anything for it but to try the Royal Nonesuch another
+shake. And I’ve pegged along ever since, dry as a powder-horn.  Where’s
+that ten cents? Give it here.”
+
+I had considerable money, so I give him ten cents, but begged him to
+spend it for something to eat, and give me some, because it was all the
+money I had, and I hadn’t had nothing to eat since yesterday.  He never
+said nothing.  The next minute he whirls on me and says:
+
+“Do you reckon that nigger would blow on us?  We’d skin him if he done
+that!”
+
+“How can he blow?  Hain’t he run off?”
+
+“No!  That old fool sold him, and never divided with me, and the money’s
+gone.”
+
+“_Sold_ him?”  I says, and begun to cry; “why, he was _my_ nigger, and
+that was my money.  Where is he?--I want my nigger.”
+
+“Well, you can’t _get_ your nigger, that’s all--so dry up your
+blubbering. Looky here--do you think _you’d_ venture to blow on us?
+ Blamed if I think I’d trust you.  Why, if you _was_ to blow on us--”
+
+He stopped, but I never see the duke look so ugly out of his eyes
+before. I went on a-whimpering, and says:
+
+“I don’t want to blow on nobody; and I ain’t got no time to blow, nohow.
+I got to turn out and find my nigger.”
+
+He looked kinder bothered, and stood there with his bills fluttering on
+his arm, thinking, and wrinkling up his forehead.  At last he says:
+
+“I’ll tell you something.  We got to be here three days.  If you’ll
+promise you won’t blow, and won’t let the nigger blow, I’ll tell you
+where to find him.”
+
+So I promised, and he says:
+
+“A farmer by the name of Silas Ph--” and then he stopped.  You see, he
+started to tell me the truth; but when he stopped that way, and begun to
+study and think again, I reckoned he was changing his mind.  And so he
+was. He wouldn’t trust me; he wanted to make sure of having me out of
+the way the whole three days.  So pretty soon he says:
+
+“The man that bought him is named Abram Foster--Abram G. Foster--and he
+lives forty mile back here in the country, on the road to Lafayette.”
+
+“All right,” I says, “I can walk it in three days.  And I’ll start this
+very afternoon.”
+
+“No you wont, you’ll start _now_; and don’t you lose any time about it,
+neither, nor do any gabbling by the way.  Just keep a tight tongue in
+your head and move right along, and then you won’t get into trouble with
+_us_, d’ye hear?”
+
+That was the order I wanted, and that was the one I played for.  I
+wanted to be left free to work my plans.
+
+“So clear out,” he says; “and you can tell Mr. Foster whatever you want
+to. Maybe you can get him to believe that Jim _is_ your nigger--some
+idiots don’t require documents--leastways I’ve heard there’s such down
+South here.  And when you tell him the handbill and the reward’s bogus,
+maybe he’ll believe you when you explain to him what the idea was for
+getting ‘em out.  Go ‘long now, and tell him anything you want to; but
+mind you don’t work your jaw any _between_ here and there.”
+
+So I left, and struck for the back country.  I didn’t look around, but I
+kinder felt like he was watching me.  But I knowed I could tire him out
+at that.  I went straight out in the country as much as a mile before
+I stopped; then I doubled back through the woods towards Phelps’.  I
+reckoned I better start in on my plan straight off without fooling
+around, because I wanted to stop Jim’s mouth till these fellows could
+get away.  I didn’t want no trouble with their kind.  I’d seen all I
+wanted to of them, and wanted to get entirely shut of them.
+
+
+
+
+CHAPTER XXXII.
+
+WHEN I got there it was all still and Sunday-like, and hot and sunshiny;
+the hands was gone to the fields; and there was them kind of faint
+dronings of bugs and flies in the air that makes it seem so lonesome and
+like everybody’s dead and gone; and if a breeze fans along and quivers
+the leaves it makes you feel mournful, because you feel like it’s
+spirits whispering--spirits that’s been dead ever so many years--and you
+always think they’re talking about _you_.  As a general thing it makes a
+body wish _he_ was dead, too, and done with it all.
+
+Phelps’ was one of these little one-horse cotton plantations, and they
+all look alike.  A rail fence round a two-acre yard; a stile made out
+of logs sawed off and up-ended in steps, like barrels of a different
+length, to climb over the fence with, and for the women to stand on when
+they are going to jump on to a horse; some sickly grass-patches in the
+big yard, but mostly it was bare and smooth, like an old hat with the
+nap rubbed off; big double log-house for the white folks--hewed logs,
+with the chinks stopped up with mud or mortar, and these mud-stripes
+been whitewashed some time or another; round-log kitchen, with a big
+broad, open but roofed passage joining it to the house; log smoke-house
+back of the kitchen; three little log nigger-cabins in a row t’other
+side the smoke-house; one little hut all by itself away down against
+the back fence, and some outbuildings down a piece the other side;
+ash-hopper and big kettle to bile soap in by the little hut; bench by
+the kitchen door, with bucket of water and a gourd; hound asleep there
+in the sun; more hounds asleep round about; about three shade trees away
+off in a corner; some currant bushes and gooseberry bushes in one place
+by the fence; outside of the fence a garden and a watermelon patch; then
+the cotton fields begins, and after the fields the woods.
+
+I went around and clumb over the back stile by the ash-hopper, and
+started for the kitchen.  When I got a little ways I heard the dim hum
+of a spinning-wheel wailing along up and sinking along down again;
+and then I knowed for certain I wished I was dead--for that _is_ the
+lonesomest sound in the whole world.
+
+I went right along, not fixing up any particular plan, but just trusting
+to Providence to put the right words in my mouth when the time come; for
+I’d noticed that Providence always did put the right words in my mouth
+if I left it alone.
+
+When I got half-way, first one hound and then another got up and went
+for me, and of course I stopped and faced them, and kept still.  And
+such another powwow as they made!  In a quarter of a minute I was a kind
+of a hub of a wheel, as you may say--spokes made out of dogs--circle of
+fifteen of them packed together around me, with their necks and noses
+stretched up towards me, a-barking and howling; and more a-coming; you
+could see them sailing over fences and around corners from everywheres.
+
+A nigger woman come tearing out of the kitchen with a rolling-pin in her
+hand, singing out, “Begone _you_ Tige! you Spot! begone sah!” and she
+fetched first one and then another of them a clip and sent them howling,
+and then the rest followed; and the next second half of them come back,
+wagging their tails around me, and making friends with me.  There ain’t
+no harm in a hound, nohow.
+
+And behind the woman comes a little nigger girl and two little nigger
+boys without anything on but tow-linen shirts, and they hung on to their
+mother’s gown, and peeped out from behind her at me, bashful, the way
+they always do.  And here comes the white woman running from the house,
+about forty-five or fifty year old, bareheaded, and her spinning-stick
+in her hand; and behind her comes her little white children, acting the
+same way the little niggers was doing.  She was smiling all over so she
+could hardly stand--and says:
+
+“It’s _you_, at last!--_ain’t_ it?”
+
+I out with a “Yes’m” before I thought.
+
+She grabbed me and hugged me tight; and then gripped me by both hands
+and shook and shook; and the tears come in her eyes, and run down over;
+and she couldn’t seem to hug and shake enough, and kept saying, “You
+don’t look as much like your mother as I reckoned you would; but law
+sakes, I don’t care for that, I’m so glad to see you!  Dear, dear, it
+does seem like I could eat you up!  Children, it’s your cousin Tom!--tell
+him howdy.”
+
+But they ducked their heads, and put their fingers in their mouths, and
+hid behind her.  So she run on:
+
+“Lize, hurry up and get him a hot breakfast right away--or did you get
+your breakfast on the boat?”
+
+I said I had got it on the boat.  So then she started for the house,
+leading me by the hand, and the children tagging after.  When we got
+there she set me down in a split-bottomed chair, and set herself down on
+a little low stool in front of me, holding both of my hands, and says:
+
+“Now I can have a _good_ look at you; and, laws-a-me, I’ve been hungry
+for it a many and a many a time, all these long years, and it’s come
+at last! We been expecting you a couple of days and more.  What kep’
+you?--boat get aground?”
+
+“Yes’m--she--”
+
+“Don’t say yes’m--say Aunt Sally.  Where’d she get aground?”
+
+I didn’t rightly know what to say, because I didn’t know whether the
+boat would be coming up the river or down.  But I go a good deal on
+instinct; and my instinct said she would be coming up--from down towards
+Orleans. That didn’t help me much, though; for I didn’t know the names
+of bars down that way.  I see I’d got to invent a bar, or forget the
+name of the one we got aground on--or--Now I struck an idea, and fetched
+it out:
+
+“It warn’t the grounding--that didn’t keep us back but a little.  We
+blowed out a cylinder-head.”
+
+“Good gracious! anybody hurt?”
+
+“No’m.  Killed a nigger.”
+
+“Well, it’s lucky; because sometimes people do get hurt.  Two years ago
+last Christmas your uncle Silas was coming up from Newrleans on the old
+Lally Rook, and she blowed out a cylinder-head and crippled a man.  And
+I think he died afterwards.  He was a Baptist.  Your uncle Silas knowed
+a family in Baton Rouge that knowed his people very well.  Yes, I
+remember now, he _did_ die.  Mortification set in, and they had to
+amputate him. But it didn’t save him.  Yes, it was mortification--that
+was it.  He turned blue all over, and died in the hope of a glorious
+resurrection. They say he was a sight to look at.  Your uncle’s been up
+to the town every day to fetch you. And he’s gone again, not more’n an
+hour ago; he’ll be back any minute now. You must a met him on the road,
+didn’t you?--oldish man, with a--”
+
+“No, I didn’t see nobody, Aunt Sally.  The boat landed just at daylight,
+and I left my baggage on the wharf-boat and went looking around the town
+and out a piece in the country, to put in the time and not get here too
+soon; and so I come down the back way.”
+
+“Who’d you give the baggage to?”
+
+“Nobody.”
+
+“Why, child, it ‘ll be stole!”
+
+“Not where I hid it I reckon it won’t,” I says.
+
+“How’d you get your breakfast so early on the boat?”
+
+It was kinder thin ice, but I says:
+
+“The captain see me standing around, and told me I better have something
+to eat before I went ashore; so he took me in the texas to the officers’
+lunch, and give me all I wanted.”
+
+I was getting so uneasy I couldn’t listen good.  I had my mind on the
+children all the time; I wanted to get them out to one side and pump
+them a little, and find out who I was.  But I couldn’t get no show, Mrs.
+Phelps kept it up and run on so.  Pretty soon she made the cold chills
+streak all down my back, because she says:
+
+“But here we’re a-running on this way, and you hain’t told me a word
+about Sis, nor any of them.  Now I’ll rest my works a little, and you
+start up yourn; just tell me _everything_--tell me all about ‘m all every
+one of ‘m; and how they are, and what they’re doing, and what they told
+you to tell me; and every last thing you can think of.”
+
+Well, I see I was up a stump--and up it good.  Providence had stood by
+me this fur all right, but I was hard and tight aground now.  I see it
+warn’t a bit of use to try to go ahead--I’d got to throw up my hand.  So
+I says to myself, here’s another place where I got to resk the truth.
+ I opened my mouth to begin; but she grabbed me and hustled me in behind
+the bed, and says:
+
+“Here he comes!  Stick your head down lower--there, that’ll do; you can’t
+be seen now.  Don’t you let on you’re here.  I’ll play a joke on him.
+Children, don’t you say a word.”
+
+I see I was in a fix now.  But it warn’t no use to worry; there warn’t
+nothing to do but just hold still, and try and be ready to stand from
+under when the lightning struck.
+
+I had just one little glimpse of the old gentleman when he come in; then
+the bed hid him.  Mrs. Phelps she jumps for him, and says:
+
+“Has he come?”
+
+“No,” says her husband.
+
+“Good-_ness_ gracious!” she says, “what in the warld can have become of
+him?”
+
+“I can’t imagine,” says the old gentleman; “and I must say it makes me
+dreadful uneasy.”
+
+“Uneasy!” she says; “I’m ready to go distracted!  He _must_ a come; and
+you’ve missed him along the road.  I _know_ it’s so--something tells me
+so.”
+
+“Why, Sally, I _couldn’t_ miss him along the road--_you_ know that.”
+
+“But oh, dear, dear, what _will_ Sis say!  He must a come!  You must a
+missed him.  He--”
+
+“Oh, don’t distress me any more’n I’m already distressed.  I don’t know
+what in the world to make of it.  I’m at my wit’s end, and I don’t mind
+acknowledging ‘t I’m right down scared.  But there’s no hope that he’s
+come; for he _couldn’t_ come and me miss him.  Sally, it’s terrible--just
+terrible--something’s happened to the boat, sure!”
+
+“Why, Silas!  Look yonder!--up the road!--ain’t that somebody coming?”
+
+He sprung to the window at the head of the bed, and that give Mrs.
+Phelps the chance she wanted.  She stooped down quick at the foot of the
+bed and give me a pull, and out I come; and when he turned back from the
+window there she stood, a-beaming and a-smiling like a house afire, and
+I standing pretty meek and sweaty alongside.  The old gentleman stared,
+and says:
+
+“Why, who’s that?”
+
+“Who do you reckon ‘t is?”
+
+“I hain’t no idea.  Who _is_ it?”
+
+“It’s _Tom Sawyer!_”
+
+By jings, I most slumped through the floor!  But there warn’t no time to
+swap knives; the old man grabbed me by the hand and shook, and kept on
+shaking; and all the time how the woman did dance around and laugh and
+cry; and then how they both did fire off questions about Sid, and Mary,
+and the rest of the tribe.
+
+But if they was joyful, it warn’t nothing to what I was; for it was like
+being born again, I was so glad to find out who I was.  Well, they froze
+to me for two hours; and at last, when my chin was so tired it couldn’t
+hardly go any more, I had told them more about my family--I mean the
+Sawyer family--than ever happened to any six Sawyer families.  And I
+explained all about how we blowed out a cylinder-head at the mouth of
+White River, and it took us three days to fix it.  Which was all right,
+and worked first-rate; because _they_ didn’t know but what it would take
+three days to fix it.  If I’d a called it a bolthead it would a done
+just as well.
+
+Now I was feeling pretty comfortable all down one side, and pretty
+uncomfortable all up the other.  Being Tom Sawyer was easy and
+comfortable, and it stayed easy and comfortable till by and by I hear a
+steamboat coughing along down the river.  Then I says to myself, s’pose
+Tom Sawyer comes down on that boat?  And s’pose he steps in here any
+minute, and sings out my name before I can throw him a wink to keep
+quiet?
+
+Well, I couldn’t _have_ it that way; it wouldn’t do at all.  I must go
+up the road and waylay him.  So I told the folks I reckoned I would go
+up to the town and fetch down my baggage.  The old gentleman was for
+going along with me, but I said no, I could drive the horse myself, and
+I druther he wouldn’t take no trouble about me.
+
+
+
+
+CHAPTER XXXIII.
+
+SO I started for town in the wagon, and when I was half-way I see a
+wagon coming, and sure enough it was Tom Sawyer, and I stopped and
+waited till he come along.  I says “Hold on!” and it stopped alongside,
+and his mouth opened up like a trunk, and stayed so; and he swallowed
+two or three times like a person that’s got a dry throat, and then says:
+
+“I hain’t ever done you no harm.  You know that.  So, then, what you
+want to come back and ha’nt _me_ for?”
+
+I says:
+
+“I hain’t come back--I hain’t been _gone_.”
+
+When he heard my voice it righted him up some, but he warn’t quite
+satisfied yet.  He says:
+
+“Don’t you play nothing on me, because I wouldn’t on you.  Honest injun
+now, you ain’t a ghost?”
+
+“Honest injun, I ain’t,” I says.
+
+“Well--I--I--well, that ought to settle it, of course; but I can’t somehow
+seem to understand it no way.  Looky here, warn’t you ever murdered _at
+all?_”
+
+“No.  I warn’t ever murdered at all--I played it on them.  You come in
+here and feel of me if you don’t believe me.”
+
+So he done it; and it satisfied him; and he was that glad to see me
+again he didn’t know what to do.  And he wanted to know all about it
+right off, because it was a grand adventure, and mysterious, and so it
+hit him where he lived.  But I said, leave it alone till by and by; and
+told his driver to wait, and we drove off a little piece, and I told
+him the kind of a fix I was in, and what did he reckon we better do?  He
+said, let him alone a minute, and don’t disturb him.  So he thought and
+thought, and pretty soon he says:
+
+“It’s all right; I’ve got it.  Take my trunk in your wagon, and let on
+it’s your’n; and you turn back and fool along slow, so as to get to the
+house about the time you ought to; and I’ll go towards town a piece, and
+take a fresh start, and get there a quarter or a half an hour after you;
+and you needn’t let on to know me at first.”
+
+I says:
+
+“All right; but wait a minute.  There’s one more thing--a thing that
+_nobody_ don’t know but me.  And that is, there’s a nigger here that
+I’m a-trying to steal out of slavery, and his name is _Jim_--old Miss
+Watson’s Jim.”
+
+He says:
+
+“What!  Why, Jim is--”
+
+He stopped and went to studying.  I says:
+
+“I know what you’ll say.  You’ll say it’s dirty, low-down business; but
+what if it is?  I’m low down; and I’m a-going to steal him, and I want
+you keep mum and not let on.  Will you?”
+
+His eye lit up, and he says:
+
+“I’ll _help_ you steal him!”
+
+Well, I let go all holts then, like I was shot.  It was the most
+astonishing speech I ever heard--and I’m bound to say Tom Sawyer fell
+considerable in my estimation.  Only I couldn’t believe it.  Tom Sawyer
+a _nigger-stealer!_
+
+“Oh, shucks!”  I says; “you’re joking.”
+
+“I ain’t joking, either.”
+
+“Well, then,” I says, “joking or no joking, if you hear anything said
+about a runaway nigger, don’t forget to remember that _you_ don’t know
+nothing about him, and I don’t know nothing about him.”
+
+Then we took the trunk and put it in my wagon, and he drove off his
+way and I drove mine.  But of course I forgot all about driving slow on
+accounts of being glad and full of thinking; so I got home a heap too
+quick for that length of a trip.  The old gentleman was at the door, and
+he says:
+
+“Why, this is wonderful!  Whoever would a thought it was in that mare
+to do it?  I wish we’d a timed her.  And she hain’t sweated a hair--not
+a hair. It’s wonderful.  Why, I wouldn’t take a hundred dollars for that
+horse now--I wouldn’t, honest; and yet I’d a sold her for fifteen before,
+and thought ‘twas all she was worth.”
+
+That’s all he said.  He was the innocentest, best old soul I ever see.
+But it warn’t surprising; because he warn’t only just a farmer, he was
+a preacher, too, and had a little one-horse log church down back of the
+plantation, which he built it himself at his own expense, for a church
+and schoolhouse, and never charged nothing for his preaching, and it was
+worth it, too.  There was plenty other farmer-preachers like that, and
+done the same way, down South.
+
+In about half an hour Tom’s wagon drove up to the front stile, and Aunt
+Sally she see it through the window, because it was only about fifty
+yards, and says:
+
+“Why, there’s somebody come!  I wonder who ‘tis?  Why, I do believe it’s
+a stranger.  Jimmy” (that’s one of the children) “run and tell Lize to
+put on another plate for dinner.”
+
+Everybody made a rush for the front door, because, of course, a stranger
+don’t come _every_ year, and so he lays over the yaller-fever, for
+interest, when he does come.  Tom was over the stile and starting for
+the house; the wagon was spinning up the road for the village, and we
+was all bunched in the front door.  Tom had his store clothes on, and an
+audience--and that was always nuts for Tom Sawyer.  In them circumstances
+it warn’t no trouble to him to throw in an amount of style that was
+suitable.  He warn’t a boy to meeky along up that yard like a sheep; no,
+he come ca’m and important, like the ram.  When he got a-front of us he
+lifts his hat ever so gracious and dainty, like it was the lid of a box
+that had butterflies asleep in it and he didn’t want to disturb them,
+and says:
+
+“Mr. Archibald Nichols, I presume?”
+
+“No, my boy,” says the old gentleman, “I’m sorry to say ‘t your driver
+has deceived you; Nichols’s place is down a matter of three mile more.
+Come in, come in.”
+
+Tom he took a look back over his shoulder, and says, “Too late--he’s out
+of sight.”
+
+“Yes, he’s gone, my son, and you must come in and eat your dinner with
+us; and then we’ll hitch up and take you down to Nichols’s.”
+
+“Oh, I _can’t_ make you so much trouble; I couldn’t think of it.  I’ll
+walk--I don’t mind the distance.”
+
+“But we won’t _let_ you walk--it wouldn’t be Southern hospitality to do
+it. Come right in.”
+
+“Oh, _do_,” says Aunt Sally; “it ain’t a bit of trouble to us, not a
+bit in the world.  You must stay.  It’s a long, dusty three mile, and
+we can’t let you walk.  And, besides, I’ve already told ‘em to put on
+another plate when I see you coming; so you mustn’t disappoint us.  Come
+right in and make yourself at home.”
+
+So Tom he thanked them very hearty and handsome, and let himself be
+persuaded, and come in; and when he was in he said he was a stranger
+from Hicksville, Ohio, and his name was William Thompson--and he made
+another bow.
+
+Well, he run on, and on, and on, making up stuff about Hicksville and
+everybody in it he could invent, and I getting a little nervious, and
+wondering how this was going to help me out of my scrape; and at last,
+still talking along, he reached over and kissed Aunt Sally right on the
+mouth, and then settled back again in his chair comfortable, and was
+going on talking; but she jumped up and wiped it off with the back of
+her hand, and says:
+
+“You owdacious puppy!”
+
+He looked kind of hurt, and says:
+
+“I’m surprised at you, m’am.”
+
+“You’re s’rp--Why, what do you reckon I am?  I’ve a good notion to take
+and--Say, what do you mean by kissing me?”
+
+He looked kind of humble, and says:
+
+“I didn’t mean nothing, m’am.  I didn’t mean no harm.  I--I--thought you’d
+like it.”
+
+“Why, you born fool!”  She took up the spinning stick, and it looked
+like it was all she could do to keep from giving him a crack with it.
+ “What made you think I’d like it?”
+
+“Well, I don’t know.  Only, they--they--told me you would.”
+
+“_They_ told you I would.  Whoever told you’s _another_ lunatic.  I
+never heard the beat of it.  Who’s _they_?”
+
+“Why, everybody.  They all said so, m’am.”
+
+It was all she could do to hold in; and her eyes snapped, and her
+fingers worked like she wanted to scratch him; and she says:
+
+“Who’s ‘everybody’?  Out with their names, or ther’ll be an idiot
+short.”
+
+He got up and looked distressed, and fumbled his hat, and says:
+
+“I’m sorry, and I warn’t expecting it.  They told me to.  They all told
+me to.  They all said, kiss her; and said she’d like it.  They all said
+it--every one of them.  But I’m sorry, m’am, and I won’t do it no more--I
+won’t, honest.”
+
+“You won’t, won’t you?  Well, I sh’d _reckon_ you won’t!”
+
+“No’m, I’m honest about it; I won’t ever do it again--till you ask me.”
+
+“Till I _ask_ you!  Well, I never see the beat of it in my born days!
+ I lay you’ll be the Methusalem-numskull of creation before ever I ask
+you--or the likes of you.”
+
+“Well,” he says, “it does surprise me so.  I can’t make it out, somehow.
+They said you would, and I thought you would.  But--” He stopped and
+looked around slow, like he wished he could run across a friendly eye
+somewheres, and fetched up on the old gentleman’s, and says, “Didn’t
+_you_ think she’d like me to kiss her, sir?”
+
+“Why, no; I--I--well, no, I b’lieve I didn’t.”
+
+Then he looks on around the same way to me, and says:
+
+“Tom, didn’t _you_ think Aunt Sally ‘d open out her arms and say, ‘Sid
+Sawyer--’”
+
+“My land!” she says, breaking in and jumping for him, “you impudent
+young rascal, to fool a body so--” and was going to hug him, but he
+fended her off, and says:
+
+“No, not till you’ve asked me first.”
+
+So she didn’t lose no time, but asked him; and hugged him and kissed
+him over and over again, and then turned him over to the old man, and he
+took what was left.  And after they got a little quiet again she says:
+
+“Why, dear me, I never see such a surprise.  We warn’t looking for _you_
+at all, but only Tom.  Sis never wrote to me about anybody coming but
+him.”
+
+“It’s because it warn’t _intended_ for any of us to come but Tom,” he
+says; “but I begged and begged, and at the last minute she let me
+come, too; so, coming down the river, me and Tom thought it would be a
+first-rate surprise for him to come here to the house first, and for me
+to by and by tag along and drop in, and let on to be a stranger.  But it
+was a mistake, Aunt Sally.  This ain’t no healthy place for a stranger
+to come.”
+
+“No--not impudent whelps, Sid.  You ought to had your jaws boxed; I
+hain’t been so put out since I don’t know when.  But I don’t care, I
+don’t mind the terms--I’d be willing to stand a thousand such jokes to
+have you here. Well, to think of that performance!  I don’t deny it, I
+was most putrified with astonishment when you give me that smack.”
+
+We had dinner out in that broad open passage betwixt the house and
+the kitchen; and there was things enough on that table for seven
+families--and all hot, too; none of your flabby, tough meat that’s laid
+in a cupboard in a damp cellar all night and tastes like a hunk of
+old cold cannibal in the morning.  Uncle Silas he asked a pretty long
+blessing over it, but it was worth it; and it didn’t cool it a bit,
+neither, the way I’ve seen them kind of interruptions do lots of times.
+ There was a considerable good deal of talk all the afternoon, and me
+and Tom was on the lookout all the time; but it warn’t no use, they
+didn’t happen to say nothing about any runaway nigger, and we was afraid
+to try to work up to it.  But at supper, at night, one of the little
+boys says:
+
+“Pa, mayn’t Tom and Sid and me go to the show?”
+
+“No,” says the old man, “I reckon there ain’t going to be any; and you
+couldn’t go if there was; because the runaway nigger told Burton and
+me all about that scandalous show, and Burton said he would tell the
+people; so I reckon they’ve drove the owdacious loafers out of town
+before this time.”
+
+So there it was!--but I couldn’t help it.  Tom and me was to sleep in the
+same room and bed; so, being tired, we bid good-night and went up to
+bed right after supper, and clumb out of the window and down the
+lightning-rod, and shoved for the town; for I didn’t believe anybody was
+going to give the king and the duke a hint, and so if I didn’t hurry up
+and give them one they’d get into trouble sure.
+
+On the road Tom he told me all about how it was reckoned I was murdered,
+and how pap disappeared pretty soon, and didn’t come back no more, and
+what a stir there was when Jim run away; and I told Tom all about our
+Royal Nonesuch rapscallions, and as much of the raft voyage as I had
+time to; and as we struck into the town and up through the the middle of
+it--it was as much as half-after eight, then--here comes a raging rush of
+people with torches, and an awful whooping and yelling, and banging tin
+pans and blowing horns; and we jumped to one side to let them go by;
+and as they went by I see they had the king and the duke astraddle of a
+rail--that is, I knowed it _was_ the king and the duke, though they was
+all over tar and feathers, and didn’t look like nothing in the
+world that was human--just looked like a couple of monstrous big
+soldier-plumes.  Well, it made me sick to see it; and I was sorry for
+them poor pitiful rascals, it seemed like I couldn’t ever feel any
+hardness against them any more in the world.  It was a dreadful thing to
+see.  Human beings _can_ be awful cruel to one another.
+
+We see we was too late--couldn’t do no good.  We asked some stragglers
+about it, and they said everybody went to the show looking very
+innocent; and laid low and kept dark till the poor old king was in the
+middle of his cavortings on the stage; then somebody give a signal, and
+the house rose up and went for them.
+
+So we poked along back home, and I warn’t feeling so brash as I was
+before, but kind of ornery, and humble, and to blame, somehow--though
+I hadn’t done nothing.  But that’s always the way; it don’t make no
+difference whether you do right or wrong, a person’s conscience ain’t
+got no sense, and just goes for him anyway.  If I had a yaller dog that
+didn’t know no more than a person’s conscience does I would pison him.
+It takes up more room than all the rest of a person’s insides, and yet
+ain’t no good, nohow.  Tom Sawyer he says the same.
+
+
+
+
+CHAPTER XXXIV.
+
+WE stopped talking, and got to thinking.  By and by Tom says:
+
+“Looky here, Huck, what fools we are to not think of it before!  I bet I
+know where Jim is.”
+
+“No!  Where?”
+
+“In that hut down by the ash-hopper.  Why, looky here.  When we was at
+dinner, didn’t you see a nigger man go in there with some vittles?”
+
+“Yes.”
+
+“What did you think the vittles was for?”
+
+“For a dog.”
+
+“So ‘d I. Well, it wasn’t for a dog.”
+
+“Why?”
+
+“Because part of it was watermelon.”
+
+“So it was--I noticed it.  Well, it does beat all that I never thought
+about a dog not eating watermelon.  It shows how a body can see and
+don’t see at the same time.”
+
+“Well, the nigger unlocked the padlock when he went in, and he locked it
+again when he came out.  He fetched uncle a key about the time we got up
+from table--same key, I bet.  Watermelon shows man, lock shows prisoner;
+and it ain’t likely there’s two prisoners on such a little plantation,
+and where the people’s all so kind and good.  Jim’s the prisoner.  All
+right--I’m glad we found it out detective fashion; I wouldn’t give shucks
+for any other way.  Now you work your mind, and study out a plan to
+steal Jim, and I will study out one, too; and we’ll take the one we like
+the best.”
+
+What a head for just a boy to have!  If I had Tom Sawyer’s head I
+wouldn’t trade it off to be a duke, nor mate of a steamboat, nor clown
+in a circus, nor nothing I can think of.  I went to thinking out a plan,
+but only just to be doing something; I knowed very well where the right
+plan was going to come from.  Pretty soon Tom says:
+
+“Ready?”
+
+“Yes,” I says.
+
+“All right--bring it out.”
+
+“My plan is this,” I says.  “We can easy find out if it’s Jim in there.
+Then get up my canoe to-morrow night, and fetch my raft over from the
+island.  Then the first dark night that comes steal the key out of the
+old man’s britches after he goes to bed, and shove off down the river
+on the raft with Jim, hiding daytimes and running nights, the way me and
+Jim used to do before.  Wouldn’t that plan work?”
+
+“_Work_?  Why, cert’nly it would work, like rats a-fighting.  But it’s
+too blame’ simple; there ain’t nothing _to_ it.  What’s the good of a
+plan that ain’t no more trouble than that?  It’s as mild as goose-milk.
+ Why, Huck, it wouldn’t make no more talk than breaking into a soap
+factory.”
+
+I never said nothing, because I warn’t expecting nothing different; but
+I knowed mighty well that whenever he got _his_ plan ready it wouldn’t
+have none of them objections to it.
+
+And it didn’t.  He told me what it was, and I see in a minute it was
+worth fifteen of mine for style, and would make Jim just as free a man
+as mine would, and maybe get us all killed besides.  So I was satisfied,
+and said we would waltz in on it.  I needn’t tell what it was here,
+because I knowed it wouldn’t stay the way, it was.  I knowed he would be
+changing it around every which way as we went along, and heaving in new
+bullinesses wherever he got a chance.  And that is what he done.
+
+Well, one thing was dead sure, and that was that Tom Sawyer was in
+earnest, and was actuly going to help steal that nigger out of slavery.
+That was the thing that was too many for me.  Here was a boy that was
+respectable and well brung up; and had a character to lose; and folks at
+home that had characters; and he was bright and not leather-headed; and
+knowing and not ignorant; and not mean, but kind; and yet here he was,
+without any more pride, or rightness, or feeling, than to stoop to
+this business, and make himself a shame, and his family a shame,
+before everybody.  I _couldn’t_ understand it no way at all.  It was
+outrageous, and I knowed I ought to just up and tell him so; and so be
+his true friend, and let him quit the thing right where he was and save
+himself. And I _did_ start to tell him; but he shut me up, and says:
+
+“Don’t you reckon I know what I’m about?  Don’t I generly know what I’m
+about?”
+
+“Yes.”
+
+“Didn’t I _say_ I was going to help steal the nigger?”
+
+“Yes.”
+
+“_Well_, then.”
+
+That’s all he said, and that’s all I said.  It warn’t no use to say any
+more; because when he said he’d do a thing, he always done it.  But I
+couldn’t make out how he was willing to go into this thing; so I just
+let it go, and never bothered no more about it.  If he was bound to have
+it so, I couldn’t help it.
+
+When we got home the house was all dark and still; so we went on down to
+the hut by the ash-hopper for to examine it.  We went through the yard
+so as to see what the hounds would do.  They knowed us, and didn’t make
+no more noise than country dogs is always doing when anything comes by
+in the night.  When we got to the cabin we took a look at the front and
+the two sides; and on the side I warn’t acquainted with--which was the
+north side--we found a square window-hole, up tolerable high, with just
+one stout board nailed across it.  I says:
+
+“Here’s the ticket.  This hole’s big enough for Jim to get through if we
+wrench off the board.”
+
+Tom says:
+
+“It’s as simple as tit-tat-toe, three-in-a-row, and as easy as
+playing hooky.  I should _hope_ we can find a way that’s a little more
+complicated than _that_, Huck Finn.”
+
+“Well, then,” I says, “how ‘ll it do to saw him out, the way I done
+before I was murdered that time?”
+
+“That’s more _like_,” he says.  “It’s real mysterious, and troublesome,
+and good,” he says; “but I bet we can find a way that’s twice as long.
+ There ain’t no hurry; le’s keep on looking around.”
+
+Betwixt the hut and the fence, on the back side, was a lean-to that
+joined the hut at the eaves, and was made out of plank.  It was as long
+as the hut, but narrow--only about six foot wide.  The door to it was at
+the south end, and was padlocked.  Tom he went to the soap-kettle and
+searched around, and fetched back the iron thing they lift the lid with;
+so he took it and prized out one of the staples.  The chain fell down,
+and we opened the door and went in, and shut it, and struck a match,
+and see the shed was only built against a cabin and hadn’t no connection
+with it; and there warn’t no floor to the shed, nor nothing in it but
+some old rusty played-out hoes and spades and picks and a crippled plow.
+ The match went out, and so did we, and shoved in the staple again, and
+the door was locked as good as ever. Tom was joyful.  He says;
+
+“Now we’re all right.  We’ll _dig_ him out.  It ‘ll take about a week!”
+
+Then we started for the house, and I went in the back door--you only have
+to pull a buckskin latch-string, they don’t fasten the doors--but that
+warn’t romantical enough for Tom Sawyer; no way would do him but he must
+climb up the lightning-rod.  But after he got up half way about three
+times, and missed fire and fell every time, and the last time most
+busted his brains out, he thought he’d got to give it up; but after he
+was rested he allowed he would give her one more turn for luck, and this
+time he made the trip.
+
+In the morning we was up at break of day, and down to the nigger cabins
+to pet the dogs and make friends with the nigger that fed Jim--if it
+_was_ Jim that was being fed.  The niggers was just getting through
+breakfast and starting for the fields; and Jim’s nigger was piling up
+a tin pan with bread and meat and things; and whilst the others was
+leaving, the key come from the house.
+
+This nigger had a good-natured, chuckle-headed face, and his wool was
+all tied up in little bunches with thread.  That was to keep witches
+off.  He said the witches was pestering him awful these nights, and
+making him see all kinds of strange things, and hear all kinds of
+strange words and noises, and he didn’t believe he was ever witched so
+long before in his life.  He got so worked up, and got to running on so
+about his troubles, he forgot all about what he’d been a-going to do.
+ So Tom says:
+
+“What’s the vittles for?  Going to feed the dogs?”
+
+The nigger kind of smiled around gradually over his face, like when you
+heave a brickbat in a mud-puddle, and he says:
+
+“Yes, Mars Sid, A dog.  Cur’us dog, too.  Does you want to go en look at
+‘im?”
+
+“Yes.”
+
+I hunched Tom, and whispers:
+
+“You going, right here in the daybreak?  _that_ warn’t the plan.”
+
+“No, it warn’t; but it’s the plan _now_.”
+
+So, drat him, we went along, but I didn’t like it much.  When we got in
+we couldn’t hardly see anything, it was so dark; but Jim was there, sure
+enough, and could see us; and he sings out:
+
+“Why, _Huck_!  En good _lan_’! ain’ dat Misto Tom?”
+
+I just knowed how it would be; I just expected it.  I didn’t know
+nothing to do; and if I had I couldn’t a done it, because that nigger
+busted in and says:
+
+“Why, de gracious sakes! do he know you genlmen?”
+
+We could see pretty well now.  Tom he looked at the nigger, steady and
+kind of wondering, and says:
+
+“Does _who_ know us?”
+
+“Why, dis-yer runaway nigger.”
+
+“I don’t reckon he does; but what put that into your head?”
+
+“What _put_ it dar?  Didn’ he jis’ dis minute sing out like he knowed
+you?”
+
+Tom says, in a puzzled-up kind of way:
+
+“Well, that’s mighty curious.  _Who_ sung out? _when_ did he sing out?
+ _what_ did he sing out?” And turns to me, perfectly ca’m, and says,
+“Did _you_ hear anybody sing out?”
+
+Of course there warn’t nothing to be said but the one thing; so I says:
+
+“No; I ain’t heard nobody say nothing.”
+
+Then he turns to Jim, and looks him over like he never see him before,
+and says:
+
+“Did you sing out?”
+
+“No, sah,” says Jim; “I hain’t said nothing, sah.”
+
+“Not a word?”
+
+“No, sah, I hain’t said a word.”
+
+“Did you ever see us before?”
+
+“No, sah; not as I knows on.”
+
+So Tom turns to the nigger, which was looking wild and distressed, and
+says, kind of severe:
+
+“What do you reckon’s the matter with you, anyway?  What made you think
+somebody sung out?”
+
+“Oh, it’s de dad-blame’ witches, sah, en I wisht I was dead, I do.
+ Dey’s awluz at it, sah, en dey do mos’ kill me, dey sk’yers me so.
+ Please to don’t tell nobody ‘bout it sah, er ole Mars Silas he’ll scole
+me; ‘kase he say dey _ain’t_ no witches.  I jis’ wish to goodness he was
+heah now--_den_ what would he say!  I jis’ bet he couldn’ fine no way to
+git aroun’ it _dis_ time.  But it’s awluz jis’ so; people dat’s _sot_,
+stays sot; dey won’t look into noth’n’en fine it out f’r deyselves, en
+when _you_ fine it out en tell um ‘bout it, dey doan’ b’lieve you.”
+
+Tom give him a dime, and said we wouldn’t tell nobody; and told him to
+buy some more thread to tie up his wool with; and then looks at Jim, and
+says:
+
+“I wonder if Uncle Silas is going to hang this nigger.  If I was to
+catch a nigger that was ungrateful enough to run away, I wouldn’t give
+him up, I’d hang him.”  And whilst the nigger stepped to the door to
+look at the dime and bite it to see if it was good, he whispers to Jim
+and says:
+
+“Don’t ever let on to know us.  And if you hear any digging going on
+nights, it’s us; we’re going to set you free.”
+
+Jim only had time to grab us by the hand and squeeze it; then the nigger
+come back, and we said we’d come again some time if the nigger wanted
+us to; and he said he would, more particular if it was dark, because the
+witches went for him mostly in the dark, and it was good to have folks
+around then.
+
+
+
+
+CHAPTER XXXV.
+
+IT would be most an hour yet till breakfast, so we left and struck down
+into the woods; because Tom said we got to have _some_ light to see how
+to dig by, and a lantern makes too much, and might get us into trouble;
+what we must have was a lot of them rotten chunks that’s called
+fox-fire, and just makes a soft kind of a glow when you lay them in a
+dark place.  We fetched an armful and hid it in the weeds, and set down
+to rest, and Tom says, kind of dissatisfied:
+
+“Blame it, this whole thing is just as easy and awkward as it can be.
+And so it makes it so rotten difficult to get up a difficult plan.
+ There ain’t no watchman to be drugged--now there _ought_ to be a
+watchman.  There ain’t even a dog to give a sleeping-mixture to.  And
+there’s Jim chained by one leg, with a ten-foot chain, to the leg of his
+bed:  why, all you got to do is to lift up the bedstead and slip off
+the chain.  And Uncle Silas he trusts everybody; sends the key to the
+punkin-headed nigger, and don’t send nobody to watch the nigger.  Jim
+could a got out of that window-hole before this, only there wouldn’t be
+no use trying to travel with a ten-foot chain on his leg.  Why, drat it,
+Huck, it’s the stupidest arrangement I ever see. You got to invent _all_
+the difficulties.  Well, we can’t help it; we got to do the best we can
+with the materials we’ve got. Anyhow, there’s one thing--there’s more
+honor in getting him out through a lot of difficulties and dangers,
+where there warn’t one of them furnished to you by the people who it was
+their duty to furnish them, and you had to contrive them all out of your
+own head.  Now look at just that one thing of the lantern.  When you
+come down to the cold facts, we simply got to _let on_ that a lantern’s
+resky.  Why, we could work with a torchlight procession if we wanted to,
+I believe.  Now, whilst I think of it, we got to hunt up something to
+make a saw out of the first chance we get.”
+
+“What do we want of a saw?”
+
+“What do we _want_ of it?  Hain’t we got to saw the leg of Jim’s bed
+off, so as to get the chain loose?”
+
+“Why, you just said a body could lift up the bedstead and slip the chain
+off.”
+
+“Well, if that ain’t just like you, Huck Finn.  You _can_ get up the
+infant-schooliest ways of going at a thing.  Why, hain’t you ever read
+any books at all?--Baron Trenck, nor Casanova, nor Benvenuto Chelleeny,
+nor Henri IV., nor none of them heroes?  Who ever heard of getting a
+prisoner loose in such an old-maidy way as that?  No; the way all the
+best authorities does is to saw the bed-leg in two, and leave it just
+so, and swallow the sawdust, so it can’t be found, and put some dirt and
+grease around the sawed place so the very keenest seneskal can’t see
+no sign of it’s being sawed, and thinks the bed-leg is perfectly sound.
+Then, the night you’re ready, fetch the leg a kick, down she goes; slip
+off your chain, and there you are.  Nothing to do but hitch your
+rope ladder to the battlements, shin down it, break your leg in the
+moat--because a rope ladder is nineteen foot too short, you know--and
+there’s your horses and your trusty vassles, and they scoop you up and
+fling you across a saddle, and away you go to your native Langudoc, or
+Navarre, or wherever it is. It’s gaudy, Huck.  I wish there was a moat
+to this cabin. If we get time, the night of the escape, we’ll dig one.”
+
+I says:
+
+“What do we want of a moat when we’re going to snake him out from under
+the cabin?”
+
+But he never heard me.  He had forgot me and everything else.  He had
+his chin in his hand, thinking.  Pretty soon he sighs and shakes his
+head; then sighs again, and says:
+
+“No, it wouldn’t do--there ain’t necessity enough for it.”
+
+“For what?”  I says.
+
+“Why, to saw Jim’s leg off,” he says.
+
+“Good land!”  I says; “why, there ain’t _no_ necessity for it.  And what
+would you want to saw his leg off for, anyway?”
+
+“Well, some of the best authorities has done it.  They couldn’t get the
+chain off, so they just cut their hand off and shoved.  And a leg would
+be better still.  But we got to let that go.  There ain’t necessity
+enough in this case; and, besides, Jim’s a nigger, and wouldn’t
+understand the reasons for it, and how it’s the custom in Europe; so
+we’ll let it go.  But there’s one thing--he can have a rope ladder; we
+can tear up our sheets and make him a rope ladder easy enough.  And we
+can send it to him in a pie; it’s mostly done that way.  And I’ve et
+worse pies.”
+
+“Why, Tom Sawyer, how you talk,” I says; “Jim ain’t got no use for a
+rope ladder.”
+
+“He _has_ got use for it.  How _you_ talk, you better say; you don’t
+know nothing about it.  He’s _got_ to have a rope ladder; they all do.”
+
+“What in the nation can he _do_ with it?”
+
+“_Do_ with it?  He can hide it in his bed, can’t he?”  That’s what they
+all do; and _he’s_ got to, too.  Huck, you don’t ever seem to want to do
+anything that’s regular; you want to be starting something fresh all the
+time. S’pose he _don’t_ do nothing with it? ain’t it there in his bed,
+for a clew, after he’s gone? and don’t you reckon they’ll want clews?
+ Of course they will.  And you wouldn’t leave them any?  That would be a
+_pretty_ howdy-do, _wouldn’t_ it!  I never heard of such a thing.”
+
+“Well,” I says, “if it’s in the regulations, and he’s got to have
+it, all right, let him have it; because I don’t wish to go back on no
+regulations; but there’s one thing, Tom Sawyer--if we go to tearing up
+our sheets to make Jim a rope ladder, we’re going to get into trouble
+with Aunt Sally, just as sure as you’re born.  Now, the way I look at
+it, a hickry-bark ladder don’t cost nothing, and don’t waste nothing,
+and is just as good to load up a pie with, and hide in a straw tick,
+as any rag ladder you can start; and as for Jim, he ain’t had no
+experience, and so he don’t care what kind of a--”
+
+“Oh, shucks, Huck Finn, if I was as ignorant as you I’d keep
+still--that’s what I’D do.  Who ever heard of a state prisoner escaping
+by a hickry-bark ladder?  Why, it’s perfectly ridiculous.”
+
+“Well, all right, Tom, fix it your own way; but if you’ll take my
+advice, you’ll let me borrow a sheet off of the clothesline.”
+
+He said that would do.  And that gave him another idea, and he says:
+
+“Borrow a shirt, too.”
+
+“What do we want of a shirt, Tom?”
+
+“Want it for Jim to keep a journal on.”
+
+“Journal your granny--_Jim_ can’t write.”
+
+“S’pose he _can’t_ write--he can make marks on the shirt, can’t he, if
+we make him a pen out of an old pewter spoon or a piece of an old iron
+barrel-hoop?”
+
+“Why, Tom, we can pull a feather out of a goose and make him a better
+one; and quicker, too.”
+
+“_Prisoners_ don’t have geese running around the donjon-keep to pull
+pens out of, you muggins.  They _always_ make their pens out of the
+hardest, toughest, troublesomest piece of old brass candlestick or
+something like that they can get their hands on; and it takes them weeks
+and weeks and months and months to file it out, too, because they’ve got
+to do it by rubbing it on the wall.  _They_ wouldn’t use a goose-quill
+if they had it. It ain’t regular.”
+
+“Well, then, what’ll we make him the ink out of?”
+
+“Many makes it out of iron-rust and tears; but that’s the common sort
+and women; the best authorities uses their own blood.  Jim can do that;
+and when he wants to send any little common ordinary mysterious message
+to let the world know where he’s captivated, he can write it on the
+bottom of a tin plate with a fork and throw it out of the window.  The
+Iron Mask always done that, and it’s a blame’ good way, too.”
+
+“Jim ain’t got no tin plates.  They feed him in a pan.”
+
+“That ain’t nothing; we can get him some.”
+
+“Can’t nobody _read_ his plates.”
+
+“That ain’t got anything to _do_ with it, Huck Finn.  All _he’s_ got to
+do is to write on the plate and throw it out.  You don’t _have_ to be
+able to read it. Why, half the time you can’t read anything a prisoner
+writes on a tin plate, or anywhere else.”
+
+“Well, then, what’s the sense in wasting the plates?”
+
+“Why, blame it all, it ain’t the _prisoner’s_ plates.”
+
+“But it’s _somebody’s_ plates, ain’t it?”
+
+“Well, spos’n it is?  What does the _prisoner_ care whose--”
+
+He broke off there, because we heard the breakfast-horn blowing.  So we
+cleared out for the house.
+
+Along during the morning I borrowed a sheet and a white shirt off of the
+clothes-line; and I found an old sack and put them in it, and we went
+down and got the fox-fire, and put that in too.  I called it borrowing,
+because that was what pap always called it; but Tom said it warn’t
+borrowing, it was stealing.  He said we was representing prisoners; and
+prisoners don’t care how they get a thing so they get it, and nobody
+don’t blame them for it, either.  It ain’t no crime in a prisoner to
+steal the thing he needs to get away with, Tom said; it’s his right; and
+so, as long as we was representing a prisoner, we had a perfect right to
+steal anything on this place we had the least use for to get ourselves
+out of prison with.  He said if we warn’t prisoners it would be a very
+different thing, and nobody but a mean, ornery person would steal when
+he warn’t a prisoner.  So we allowed we would steal everything there was
+that come handy.  And yet he made a mighty fuss, one day, after that,
+when I stole a watermelon out of the nigger-patch and eat it; and he
+made me go and give the niggers a dime without telling them what it
+was for. Tom said that what he meant was, we could steal anything we
+_needed_. Well, I says, I needed the watermelon.  But he said I didn’t
+need it to get out of prison with; there’s where the difference was.
+ He said if I’d a wanted it to hide a knife in, and smuggle it to Jim
+to kill the seneskal with, it would a been all right.  So I let it go at
+that, though I couldn’t see no advantage in my representing a prisoner
+if I got to set down and chaw over a lot of gold-leaf distinctions like
+that every time I see a chance to hog a watermelon.
+
+Well, as I was saying, we waited that morning till everybody was settled
+down to business, and nobody in sight around the yard; then Tom he
+carried the sack into the lean-to whilst I stood off a piece to keep
+watch.  By and by he come out, and we went and set down on the woodpile
+to talk.  He says:
+
+“Everything’s all right now except tools; and that’s easy fixed.”
+
+“Tools?”  I says.
+
+“Yes.”
+
+“Tools for what?”
+
+“Why, to dig with.  We ain’t a-going to _gnaw_ him out, are we?”
+
+“Ain’t them old crippled picks and things in there good enough to dig a
+nigger out with?”  I says.
+
+He turns on me, looking pitying enough to make a body cry, and says:
+
+“Huck Finn, did you _ever_ hear of a prisoner having picks and shovels,
+and all the modern conveniences in his wardrobe to dig himself out with?
+ Now I want to ask you--if you got any reasonableness in you at all--what
+kind of a show would _that_ give him to be a hero?  Why, they might as
+well lend him the key and done with it.  Picks and shovels--why, they
+wouldn’t furnish ‘em to a king.”
+
+“Well, then,” I says, “if we don’t want the picks and shovels, what do
+we want?”
+
+“A couple of case-knives.”
+
+“To dig the foundations out from under that cabin with?”
+
+“Yes.”
+
+“Confound it, it’s foolish, Tom.”
+
+“It don’t make no difference how foolish it is, it’s the _right_ way--and
+it’s the regular way.  And there ain’t no _other_ way, that ever I heard
+of, and I’ve read all the books that gives any information about these
+things. They always dig out with a case-knife--and not through dirt, mind
+you; generly it’s through solid rock.  And it takes them weeks and weeks
+and weeks, and for ever and ever.  Why, look at one of them prisoners in
+the bottom dungeon of the Castle Deef, in the harbor of Marseilles, that
+dug himself out that way; how long was _he_ at it, you reckon?”
+
+“I don’t know.”
+
+“Well, guess.”
+
+“I don’t know.  A month and a half.”
+
+“_Thirty-seven year_--and he come out in China.  _That’s_ the kind.  I
+wish the bottom of _this_ fortress was solid rock.”
+
+“_Jim_ don’t know nobody in China.”
+
+“What’s _that_ got to do with it?  Neither did that other fellow.  But
+you’re always a-wandering off on a side issue.  Why can’t you stick to
+the main point?”
+
+“All right--I don’t care where he comes out, so he _comes_ out; and Jim
+don’t, either, I reckon.  But there’s one thing, anyway--Jim’s too old to
+be dug out with a case-knife.  He won’t last.”
+
+“Yes he will _last_, too.  You don’t reckon it’s going to take
+thirty-seven years to dig out through a _dirt_ foundation, do you?”
+
+“How long will it take, Tom?”
+
+“Well, we can’t resk being as long as we ought to, because it mayn’t
+take very long for Uncle Silas to hear from down there by New Orleans.
+ He’ll hear Jim ain’t from there.  Then his next move will be to
+advertise Jim, or something like that.  So we can’t resk being as long
+digging him out as we ought to.  By rights I reckon we ought to be
+a couple of years; but we can’t.  Things being so uncertain, what I
+recommend is this:  that we really dig right in, as quick as we can;
+and after that, we can _let on_, to ourselves, that we was at it
+thirty-seven years.  Then we can snatch him out and rush him away the
+first time there’s an alarm.  Yes, I reckon that ‘ll be the best way.”
+
+“Now, there’s _sense_ in that,” I says.  “Letting on don’t cost nothing;
+letting on ain’t no trouble; and if it’s any object, I don’t mind
+letting on we was at it a hundred and fifty year.  It wouldn’t strain
+me none, after I got my hand in.  So I’ll mosey along now, and smouch a
+couple of case-knives.”
+
+“Smouch three,” he says; “we want one to make a saw out of.”
+
+“Tom, if it ain’t unregular and irreligious to sejest it,” I says,
+“there’s an old rusty saw-blade around yonder sticking under the
+weather-boarding behind the smoke-house.”
+
+He looked kind of weary and discouraged-like, and says:
+
+“It ain’t no use to try to learn you nothing, Huck.  Run along and
+smouch the knives--three of them.”  So I done it.
+
+
+
+
+CHAPTER XXXVI.
+
+AS soon as we reckoned everybody was asleep that night we went down the
+lightning-rod, and shut ourselves up in the lean-to, and got out our
+pile of fox-fire, and went to work.  We cleared everything out of the
+way, about four or five foot along the middle of the bottom log.  Tom
+said he was right behind Jim’s bed now, and we’d dig in under it, and
+when we got through there couldn’t nobody in the cabin ever know there
+was any hole there, because Jim’s counter-pin hung down most to the
+ground, and you’d have to raise it up and look under to see the hole.
+ So we dug and dug with the case-knives till most midnight; and then
+we was dog-tired, and our hands was blistered, and yet you couldn’t see
+we’d done anything hardly.  At last I says:
+
+“This ain’t no thirty-seven year job; this is a thirty-eight year job,
+Tom Sawyer.”
+
+He never said nothing.  But he sighed, and pretty soon he stopped
+digging, and then for a good little while I knowed that he was thinking.
+Then he says:
+
+“It ain’t no use, Huck, it ain’t a-going to work.  If we was prisoners
+it would, because then we’d have as many years as we wanted, and no
+hurry; and we wouldn’t get but a few minutes to dig, every day, while
+they was changing watches, and so our hands wouldn’t get blistered, and
+we could keep it up right along, year in and year out, and do it right,
+and the way it ought to be done.  But _we_ can’t fool along; we got to
+rush; we ain’t got no time to spare.  If we was to put in another
+night this way we’d have to knock off for a week to let our hands get
+well--couldn’t touch a case-knife with them sooner.”
+
+“Well, then, what we going to do, Tom?”
+
+“I’ll tell you.  It ain’t right, and it ain’t moral, and I wouldn’t like
+it to get out; but there ain’t only just the one way:  we got to dig him
+out with the picks, and _let on_ it’s case-knives.”
+
+“_Now_ you’re _talking_!”  I says; “your head gets leveler and leveler
+all the time, Tom Sawyer,” I says.  “Picks is the thing, moral or no
+moral; and as for me, I don’t care shucks for the morality of it, nohow.
+ When I start in to steal a nigger, or a watermelon, or a Sunday-school
+book, I ain’t no ways particular how it’s done so it’s done.  What I
+want is my nigger; or what I want is my watermelon; or what I want is my
+Sunday-school book; and if a pick’s the handiest thing, that’s the thing
+I’m a-going to dig that nigger or that watermelon or that Sunday-school
+book out with; and I don’t give a dead rat what the authorities thinks
+about it nuther.”
+
+“Well,” he says, “there’s excuse for picks and letting-on in a case like
+this; if it warn’t so, I wouldn’t approve of it, nor I wouldn’t stand by
+and see the rules broke--because right is right, and wrong is wrong,
+and a body ain’t got no business doing wrong when he ain’t ignorant and
+knows better.  It might answer for _you_ to dig Jim out with a pick,
+_without_ any letting on, because you don’t know no better; but it
+wouldn’t for me, because I do know better.  Gimme a case-knife.”
+
+He had his own by him, but I handed him mine.  He flung it down, and
+says:
+
+“Gimme a _case-knife_.”
+
+I didn’t know just what to do--but then I thought.  I scratched around
+amongst the old tools, and got a pickaxe and give it to him, and he took
+it and went to work, and never said a word.
+
+He was always just that particular.  Full of principle.
+
+So then I got a shovel, and then we picked and shoveled, turn about,
+and made the fur fly.  We stuck to it about a half an hour, which was as
+long as we could stand up; but we had a good deal of a hole to show for
+it. When I got up stairs I looked out at the window and see Tom doing
+his level best with the lightning-rod, but he couldn’t come it, his
+hands was so sore.  At last he says:
+
+“It ain’t no use, it can’t be done.  What you reckon I better do?  Can’t
+you think of no way?”
+
+“Yes,” I says, “but I reckon it ain’t regular.  Come up the stairs, and
+let on it’s a lightning-rod.”
+
+So he done it.
+
+Next day Tom stole a pewter spoon and a brass candlestick in the house,
+for to make some pens for Jim out of, and six tallow candles; and I
+hung around the nigger cabins and laid for a chance, and stole three tin
+plates.  Tom says it wasn’t enough; but I said nobody wouldn’t ever see
+the plates that Jim throwed out, because they’d fall in the dog-fennel
+and jimpson weeds under the window-hole--then we could tote them back and
+he could use them over again.  So Tom was satisfied.  Then he says:
+
+“Now, the thing to study out is, how to get the things to Jim.”
+
+“Take them in through the hole,” I says, “when we get it done.”
+
+He only just looked scornful, and said something about nobody ever heard
+of such an idiotic idea, and then he went to studying.  By and by he
+said he had ciphered out two or three ways, but there warn’t no need to
+decide on any of them yet.  Said we’d got to post Jim first.
+
+That night we went down the lightning-rod a little after ten, and took
+one of the candles along, and listened under the window-hole, and heard
+Jim snoring; so we pitched it in, and it didn’t wake him.  Then we
+whirled in with the pick and shovel, and in about two hours and a half
+the job was done.  We crept in under Jim’s bed and into the cabin, and
+pawed around and found the candle and lit it, and stood over Jim awhile,
+and found him looking hearty and healthy, and then we woke him up gentle
+and gradual.  He was so glad to see us he most cried; and called us
+honey, and all the pet names he could think of; and was for having us
+hunt up a cold-chisel to cut the chain off of his leg with right away,
+and clearing out without losing any time.  But Tom he showed him how
+unregular it would be, and set down and told him all about our plans,
+and how we could alter them in a minute any time there was an alarm; and
+not to be the least afraid, because we would see he got away, _sure_.
+ So Jim he said it was all right, and we set there and talked over old
+times awhile, and then Tom asked a lot of questions, and when Jim told
+him Uncle Silas come in every day or two to pray with him, and Aunt
+Sally come in to see if he was comfortable and had plenty to eat, and
+both of them was kind as they could be, Tom says:
+
+“_Now_ I know how to fix it.  We’ll send you some things by them.”
+
+I said, “Don’t do nothing of the kind; it’s one of the most jackass
+ideas I ever struck;” but he never paid no attention to me; went right
+on.  It was his way when he’d got his plans set.
+
+So he told Jim how we’d have to smuggle in the rope-ladder pie and other
+large things by Nat, the nigger that fed him, and he must be on the
+lookout, and not be surprised, and not let Nat see him open them; and
+we would put small things in uncle’s coat-pockets and he must steal them
+out; and we would tie things to aunt’s apron-strings or put them in her
+apron-pocket, if we got a chance; and told him what they would be and
+what they was for.  And told him how to keep a journal on the shirt with
+his blood, and all that. He told him everything.  Jim he couldn’t see
+no sense in the most of it, but he allowed we was white folks and knowed
+better than him; so he was satisfied, and said he would do it all just
+as Tom said.
+
+Jim had plenty corn-cob pipes and tobacco; so we had a right down good
+sociable time; then we crawled out through the hole, and so home to
+bed, with hands that looked like they’d been chawed.  Tom was in high
+spirits. He said it was the best fun he ever had in his life, and the
+most intellectural; and said if he only could see his way to it we would
+keep it up all the rest of our lives and leave Jim to our children to
+get out; for he believed Jim would come to like it better and better the
+more he got used to it.  He said that in that way it could be strung out
+to as much as eighty year, and would be the best time on record.  And he
+said it would make us all celebrated that had a hand in it.
+
+In the morning we went out to the woodpile and chopped up the brass
+candlestick into handy sizes, and Tom put them and the pewter spoon in
+his pocket.  Then we went to the nigger cabins, and while I got Nat’s
+notice off, Tom shoved a piece of candlestick into the middle of a
+corn-pone that was in Jim’s pan, and we went along with Nat to see how
+it would work, and it just worked noble; when Jim bit into it it most
+mashed all his teeth out; and there warn’t ever anything could a worked
+better. Tom said so himself. Jim he never let on but what it was only
+just a piece of rock or something like that that’s always getting into
+bread, you know; but after that he never bit into nothing but what he
+jabbed his fork into it in three or four places first.
+
+And whilst we was a-standing there in the dimmish light, here comes a
+couple of the hounds bulging in from under Jim’s bed; and they kept on
+piling in till there was eleven of them, and there warn’t hardly room
+in there to get your breath.  By jings, we forgot to fasten that lean-to
+door!  The nigger Nat he only just hollered “Witches” once, and keeled
+over on to the floor amongst the dogs, and begun to groan like he was
+dying.  Tom jerked the door open and flung out a slab of Jim’s meat,
+and the dogs went for it, and in two seconds he was out himself and back
+again and shut the door, and I knowed he’d fixed the other door too.
+Then he went to work on the nigger, coaxing him and petting him, and
+asking him if he’d been imagining he saw something again.  He raised up,
+and blinked his eyes around, and says:
+
+“Mars Sid, you’ll say I’s a fool, but if I didn’t b’lieve I see most a
+million dogs, er devils, er some’n, I wisht I may die right heah in dese
+tracks.  I did, mos’ sholy.  Mars Sid, I _felt_ um--I _felt_ um, sah; dey
+was all over me.  Dad fetch it, I jis’ wisht I could git my han’s on one
+er dem witches jis’ wunst--on’y jis’ wunst--it’s all I’d ast.  But mos’ly
+I wisht dey’d lemme ‘lone, I does.”
+
+Tom says:
+
+“Well, I tell you what I think.  What makes them come here just at this
+runaway nigger’s breakfast-time?  It’s because they’re hungry; that’s
+the reason.  You make them a witch pie; that’s the thing for _you_ to
+do.”
+
+“But my lan’, Mars Sid, how’s I gwyne to make ‘m a witch pie?  I doan’
+know how to make it.  I hain’t ever hearn er sich a thing b’fo’.”
+
+“Well, then, I’ll have to make it myself.”
+
+“Will you do it, honey?--will you?  I’ll wusshup de groun’ und’ yo’ foot,
+I will!”
+
+“All right, I’ll do it, seeing it’s you, and you’ve been good to us and
+showed us the runaway nigger.  But you got to be mighty careful.  When
+we come around, you turn your back; and then whatever we’ve put in the
+pan, don’t you let on you see it at all.  And don’t you look when Jim
+unloads the pan--something might happen, I don’t know what.  And above
+all, don’t you _handle_ the witch-things.”
+
+“_Hannel ‘M_, Mars Sid?  What _is_ you a-talkin’ ‘bout?  I wouldn’
+lay de weight er my finger on um, not f’r ten hund’d thous’n billion
+dollars, I wouldn’t.”
+
+
+
+
+CHAPTER XXXVII.
+
+THAT was all fixed.  So then we went away and went to the rubbage-pile
+in the back yard, where they keep the old boots, and rags, and pieces
+of bottles, and wore-out tin things, and all such truck, and scratched
+around and found an old tin washpan, and stopped up the holes as well as
+we could, to bake the pie in, and took it down cellar and stole it full
+of flour and started for breakfast, and found a couple of shingle-nails
+that Tom said would be handy for a prisoner to scrabble his name and
+sorrows on the dungeon walls with, and dropped one of them in Aunt
+Sally’s apron-pocket which was hanging on a chair, and t’other we stuck
+in the band of Uncle Silas’s hat, which was on the bureau, because we
+heard the children say their pa and ma was going to the runaway nigger’s
+house this morning, and then went to breakfast, and Tom dropped the
+pewter spoon in Uncle Silas’s coat-pocket, and Aunt Sally wasn’t come
+yet, so we had to wait a little while.
+
+And when she come she was hot and red and cross, and couldn’t hardly
+wait for the blessing; and then she went to sluicing out coffee with one
+hand and cracking the handiest child’s head with her thimble with the
+other, and says:
+
+“I’ve hunted high and I’ve hunted low, and it does beat all what _has_
+become of your other shirt.”
+
+My heart fell down amongst my lungs and livers and things, and a hard
+piece of corn-crust started down my throat after it and got met on the
+road with a cough, and was shot across the table, and took one of the
+children in the eye and curled him up like a fishing-worm, and let a cry
+out of him the size of a warwhoop, and Tom he turned kinder blue around
+the gills, and it all amounted to a considerable state of things for
+about a quarter of a minute or as much as that, and I would a sold out
+for half price if there was a bidder.  But after that we was all right
+again--it was the sudden surprise of it that knocked us so kind of cold.
+Uncle Silas he says:
+
+“It’s most uncommon curious, I can’t understand it.  I know perfectly
+well I took it _off_, because--”
+
+“Because you hain’t got but one _on_.  Just _listen_ at the man!  I know
+you took it off, and know it by a better way than your wool-gethering
+memory, too, because it was on the clo’s-line yesterday--I see it there
+myself. But it’s gone, that’s the long and the short of it, and you’ll
+just have to change to a red flann’l one till I can get time to make a
+new one. And it ‘ll be the third I’ve made in two years.  It just keeps
+a body on the jump to keep you in shirts; and whatever you do manage to
+_do_ with ‘m all is more’n I can make out.  A body ‘d think you _would_
+learn to take some sort of care of ‘em at your time of life.”
+
+“I know it, Sally, and I do try all I can.  But it oughtn’t to be
+altogether my fault, because, you know, I don’t see them nor have
+nothing to do with them except when they’re on me; and I don’t believe
+I’ve ever lost one of them _off_ of me.”
+
+“Well, it ain’t _your_ fault if you haven’t, Silas; you’d a done it
+if you could, I reckon.  And the shirt ain’t all that’s gone, nuther.
+ Ther’s a spoon gone; and _that_ ain’t all.  There was ten, and now
+ther’s only nine. The calf got the shirt, I reckon, but the calf never
+took the spoon, _that’s_ certain.”
+
+“Why, what else is gone, Sally?”
+
+“Ther’s six _candles_ gone--that’s what.  The rats could a got the
+candles, and I reckon they did; I wonder they don’t walk off with the
+whole place, the way you’re always going to stop their holes and don’t
+do it; and if they warn’t fools they’d sleep in your hair, Silas--_you’d_
+never find it out; but you can’t lay the _spoon_ on the rats, and that I
+know.”
+
+“Well, Sally, I’m in fault, and I acknowledge it; I’ve been remiss; but
+I won’t let to-morrow go by without stopping up them holes.”
+
+“Oh, I wouldn’t hurry; next year ‘ll do.  Matilda Angelina Araminta
+_Phelps!_”
+
+Whack comes the thimble, and the child snatches her claws out of the
+sugar-bowl without fooling around any.  Just then the nigger woman steps
+on to the passage, and says:
+
+“Missus, dey’s a sheet gone.”
+
+“A _sheet_ gone!  Well, for the land’s sake!”
+
+“I’ll stop up them holes to-day,” says Uncle Silas, looking sorrowful.
+
+“Oh, _do_ shet up!--s’pose the rats took the _sheet_?  _where’s_ it gone,
+Lize?”
+
+“Clah to goodness I hain’t no notion, Miss’ Sally.  She wuz on de
+clo’sline yistiddy, but she done gone:  she ain’ dah no mo’ now.”
+
+“I reckon the world _is_ coming to an end.  I _never_ see the beat of it
+in all my born days.  A shirt, and a sheet, and a spoon, and six can--”
+
+“Missus,” comes a young yaller wench, “dey’s a brass cannelstick
+miss’n.”
+
+“Cler out from here, you hussy, er I’ll take a skillet to ye!”
+
+Well, she was just a-biling.  I begun to lay for a chance; I reckoned
+I would sneak out and go for the woods till the weather moderated.  She
+kept a-raging right along, running her insurrection all by herself, and
+everybody else mighty meek and quiet; and at last Uncle Silas, looking
+kind of foolish, fishes up that spoon out of his pocket.  She stopped,
+with her mouth open and her hands up; and as for me, I wished I was in
+Jeruslem or somewheres. But not long, because she says:
+
+“It’s _just_ as I expected.  So you had it in your pocket all the time;
+and like as not you’ve got the other things there, too.  How’d it get
+there?”
+
+“I reely don’t know, Sally,” he says, kind of apologizing, “or you know
+I would tell.  I was a-studying over my text in Acts Seventeen before
+breakfast, and I reckon I put it in there, not noticing, meaning to put
+my Testament in, and it must be so, because my Testament ain’t in; but
+I’ll go and see; and if the Testament is where I had it, I’ll know I
+didn’t put it in, and that will show that I laid the Testament down and
+took up the spoon, and--”
+
+“Oh, for the land’s sake!  Give a body a rest!  Go ‘long now, the whole
+kit and biling of ye; and don’t come nigh me again till I’ve got back my
+peace of mind.”
+
+I’D a heard her if she’d a said it to herself, let alone speaking it
+out; and I’d a got up and obeyed her if I’d a been dead.  As we was
+passing through the setting-room the old man he took up his hat, and the
+shingle-nail fell out on the floor, and he just merely picked it up and
+laid it on the mantel-shelf, and never said nothing, and went out.  Tom
+see him do it, and remembered about the spoon, and says:
+
+“Well, it ain’t no use to send things by _him_ no more, he ain’t
+reliable.” Then he says:  “But he done us a good turn with the spoon,
+anyway, without knowing it, and so we’ll go and do him one without _him_
+knowing it--stop up his rat-holes.”
+
+There was a noble good lot of them down cellar, and it took us a whole
+hour, but we done the job tight and good and shipshape.  Then we heard
+steps on the stairs, and blowed out our light and hid; and here comes
+the old man, with a candle in one hand and a bundle of stuff in t’other,
+looking as absent-minded as year before last.  He went a mooning around,
+first to one rat-hole and then another, till he’d been to them all.
+ Then he stood about five minutes, picking tallow-drip off of his candle
+and thinking.  Then he turns off slow and dreamy towards the stairs,
+saying:
+
+“Well, for the life of me I can’t remember when I done it.  I could
+show her now that I warn’t to blame on account of the rats.  But never
+mind--let it go.  I reckon it wouldn’t do no good.”
+
+And so he went on a-mumbling up stairs, and then we left.  He was a
+mighty nice old man.  And always is.
+
+Tom was a good deal bothered about what to do for a spoon, but he said
+we’d got to have it; so he took a think.  When he had ciphered it out
+he told me how we was to do; then we went and waited around the
+spoon-basket till we see Aunt Sally coming, and then Tom went to
+counting the spoons and laying them out to one side, and I slid one of
+them up my sleeve, and Tom says:
+
+“Why, Aunt Sally, there ain’t but nine spoons _yet_.”
+
+She says:
+
+“Go ‘long to your play, and don’t bother me.  I know better, I counted
+‘m myself.”
+
+“Well, I’ve counted them twice, Aunty, and I can’t make but nine.”
+
+She looked out of all patience, but of course she come to count--anybody
+would.
+
+“I declare to gracious ther’ _ain’t_ but nine!” she says.  “Why, what in
+the world--plague _take_ the things, I’ll count ‘m again.”
+
+So I slipped back the one I had, and when she got done counting, she
+says:
+
+“Hang the troublesome rubbage, ther’s _ten_ now!” and she looked huffy
+and bothered both.  But Tom says:
+
+“Why, Aunty, I don’t think there’s ten.”
+
+“You numskull, didn’t you see me _count ‘m?_”
+
+“I know, but--”
+
+“Well, I’ll count ‘m _again_.”
+
+So I smouched one, and they come out nine, same as the other time.
+ Well, she _was_ in a tearing way--just a-trembling all over, she was so
+mad.  But she counted and counted till she got that addled she’d start
+to count in the basket for a spoon sometimes; and so, three times they
+come out right, and three times they come out wrong.  Then she grabbed
+up the basket and slammed it across the house and knocked the cat
+galley-west; and she said cle’r out and let her have some peace, and if
+we come bothering around her again betwixt that and dinner she’d skin
+us.  So we had the odd spoon, and dropped it in her apron-pocket whilst
+she was a-giving us our sailing orders, and Jim got it all right, along
+with her shingle nail, before noon.  We was very well satisfied with
+this business, and Tom allowed it was worth twice the trouble it took,
+because he said _now_ she couldn’t ever count them spoons twice alike
+again to save her life; and wouldn’t believe she’d counted them right if
+she _did_; and said that after she’d about counted her head off for the
+next three days he judged she’d give it up and offer to kill anybody
+that wanted her to ever count them any more.
+
+So we put the sheet back on the line that night, and stole one out of
+her closet; and kept on putting it back and stealing it again for a
+couple of days till she didn’t know how many sheets she had any more,
+and she didn’t _care_, and warn’t a-going to bullyrag the rest of her
+soul out about it, and wouldn’t count them again not to save her life;
+she druther die first.
+
+So we was all right now, as to the shirt and the sheet and the spoon
+and the candles, by the help of the calf and the rats and the mixed-up
+counting; and as to the candlestick, it warn’t no consequence, it would
+blow over by and by.
+
+But that pie was a job; we had no end of trouble with that pie.  We
+fixed it up away down in the woods, and cooked it there; and we got it
+done at last, and very satisfactory, too; but not all in one day; and we
+had to use up three wash-pans full of flour before we got through, and
+we got burnt pretty much all over, in places, and eyes put out with
+the smoke; because, you see, we didn’t want nothing but a crust, and we
+couldn’t prop it up right, and she would always cave in.  But of course
+we thought of the right way at last--which was to cook the ladder, too,
+in the pie.  So then we laid in with Jim the second night, and tore
+up the sheet all in little strings and twisted them together, and long
+before daylight we had a lovely rope that you could a hung a person
+with.  We let on it took nine months to make it.
+
+And in the forenoon we took it down to the woods, but it wouldn’t go
+into the pie.  Being made of a whole sheet, that way, there was rope
+enough for forty pies if we’d a wanted them, and plenty left over
+for soup, or sausage, or anything you choose.  We could a had a whole
+dinner.
+
+But we didn’t need it.  All we needed was just enough for the pie, and
+so we throwed the rest away.  We didn’t cook none of the pies in the
+wash-pan--afraid the solder would melt; but Uncle Silas he had a noble
+brass warming-pan which he thought considerable of, because it belonged
+to one of his ancesters with a long wooden handle that come over from
+England with William the Conqueror in the Mayflower or one of them early
+ships and was hid away up garret with a lot of other old pots and things
+that was valuable, not on account of being any account, because they
+warn’t, but on account of them being relicts, you know, and we snaked
+her out, private, and took her down there, but she failed on the first
+pies, because we didn’t know how, but she come up smiling on the last
+one.  We took and lined her with dough, and set her in the coals, and
+loaded her up with rag rope, and put on a dough roof, and shut down the
+lid, and put hot embers on top, and stood off five foot, with the long
+handle, cool and comfortable, and in fifteen minutes she turned out a
+pie that was a satisfaction to look at. But the person that et it would
+want to fetch a couple of kags of toothpicks along, for if that rope
+ladder wouldn’t cramp him down to business I don’t know nothing what I’m
+talking about, and lay him in enough stomach-ache to last him till next
+time, too.
+
+Nat didn’t look when we put the witch pie in Jim’s pan; and we put the
+three tin plates in the bottom of the pan under the vittles; and so Jim
+got everything all right, and as soon as he was by himself he busted
+into the pie and hid the rope ladder inside of his straw tick,
+and scratched some marks on a tin plate and throwed it out of the
+window-hole.
+
+
+
+
+CHAPTER XXXVIII.
+
+MAKING them pens was a distressid tough job, and so was the saw; and Jim
+allowed the inscription was going to be the toughest of all.  That’s the
+one which the prisoner has to scrabble on the wall.  But he had to have
+it; Tom said he’d _got_ to; there warn’t no case of a state prisoner not
+scrabbling his inscription to leave behind, and his coat of arms.
+
+“Look at Lady Jane Grey,” he says; “look at Gilford Dudley; look at old
+Northumberland!  Why, Huck, s’pose it _is_ considerble trouble?--what
+you going to do?--how you going to get around it?  Jim’s _got_ to do his
+inscription and coat of arms.  They all do.”
+
+Jim says:
+
+“Why, Mars Tom, I hain’t got no coat o’ arm; I hain’t got nuffn but dish
+yer ole shirt, en you knows I got to keep de journal on dat.”
+
+“Oh, you don’t understand, Jim; a coat of arms is very different.”
+
+“Well,” I says, “Jim’s right, anyway, when he says he ain’t got no coat
+of arms, because he hain’t.”
+
+“I reckon I knowed that,” Tom says, “but you bet he’ll have one before
+he goes out of this--because he’s going out _right_, and there ain’t
+going to be no flaws in his record.”
+
+So whilst me and Jim filed away at the pens on a brickbat apiece, Jim
+a-making his’n out of the brass and I making mine out of the spoon,
+Tom set to work to think out the coat of arms.  By and by he said he’d
+struck so many good ones he didn’t hardly know which to take, but there
+was one which he reckoned he’d decide on.  He says:
+
+“On the scutcheon we’ll have a bend _or_ in the dexter base, a saltire
+_murrey_ in the fess, with a dog, couchant, for common charge, and under
+his foot a chain embattled, for slavery, with a chevron _vert_ in a
+chief engrailed, and three invected lines on a field _azure_, with the
+nombril points rampant on a dancette indented; crest, a runaway nigger,
+_sable_, with his bundle over his shoulder on a bar sinister; and a
+couple of gules for supporters, which is you and me; motto, _Maggiore
+Fretta, Minore Otto._  Got it out of a book--means the more haste the
+less speed.”
+
+“Geewhillikins,” I says, “but what does the rest of it mean?”
+
+“We ain’t got no time to bother over that,” he says; “we got to dig in
+like all git-out.”
+
+“Well, anyway,” I says, “what’s _some_ of it?  What’s a fess?”
+
+“A fess--a fess is--_you_ don’t need to know what a fess is.  I’ll show
+him how to make it when he gets to it.”
+
+“Shucks, Tom,” I says, “I think you might tell a person.  What’s a bar
+sinister?”
+
+“Oh, I don’t know.  But he’s got to have it.  All the nobility does.”
+
+That was just his way.  If it didn’t suit him to explain a thing to you,
+he wouldn’t do it.  You might pump at him a week, it wouldn’t make no
+difference.
+
+He’d got all that coat of arms business fixed, so now he started in to
+finish up the rest of that part of the work, which was to plan out a
+mournful inscription--said Jim got to have one, like they all done.  He
+made up a lot, and wrote them out on a paper, and read them off, so:
+
+1.  Here a captive heart busted. 2.  Here a poor prisoner, forsook by
+the world and friends, fretted his sorrowful life. 3.  Here a lonely
+heart broke, and a worn spirit went to its rest, after thirty-seven
+years of solitary captivity. 4.  Here, homeless and friendless, after
+thirty-seven years of bitter captivity, perished a noble stranger,
+natural son of Louis XIV.
+
+Tom’s voice trembled whilst he was reading them, and he most broke down.
+When he got done he couldn’t no way make up his mind which one for Jim
+to scrabble on to the wall, they was all so good; but at last he allowed
+he would let him scrabble them all on.  Jim said it would take him a
+year to scrabble such a lot of truck on to the logs with a nail, and he
+didn’t know how to make letters, besides; but Tom said he would block
+them out for him, and then he wouldn’t have nothing to do but just
+follow the lines.  Then pretty soon he says:
+
+“Come to think, the logs ain’t a-going to do; they don’t have log walls
+in a dungeon:  we got to dig the inscriptions into a rock.  We’ll fetch
+a rock.”
+
+Jim said the rock was worse than the logs; he said it would take him
+such a pison long time to dig them into a rock he wouldn’t ever get out.
+ But Tom said he would let me help him do it.  Then he took a look to
+see how me and Jim was getting along with the pens.  It was most pesky
+tedious hard work and slow, and didn’t give my hands no show to get
+well of the sores, and we didn’t seem to make no headway, hardly; so Tom
+says:
+
+“I know how to fix it.  We got to have a rock for the coat of arms and
+mournful inscriptions, and we can kill two birds with that same rock.
+There’s a gaudy big grindstone down at the mill, and we’ll smouch it,
+and carve the things on it, and file out the pens and the saw on it,
+too.”
+
+It warn’t no slouch of an idea; and it warn’t no slouch of a grindstone
+nuther; but we allowed we’d tackle it.  It warn’t quite midnight yet,
+so we cleared out for the mill, leaving Jim at work.  We smouched the
+grindstone, and set out to roll her home, but it was a most nation tough
+job. Sometimes, do what we could, we couldn’t keep her from falling
+over, and she come mighty near mashing us every time.  Tom said she was
+going to get one of us, sure, before we got through.  We got her half
+way; and then we was plumb played out, and most drownded with sweat.  We
+see it warn’t no use; we got to go and fetch Jim. So he raised up his
+bed and slid the chain off of the bed-leg, and wrapt it round and round
+his neck, and we crawled out through our hole and down there, and Jim
+and me laid into that grindstone and walked her along like nothing; and
+Tom superintended.  He could out-superintend any boy I ever see.  He
+knowed how to do everything.
+
+Our hole was pretty big, but it warn’t big enough to get the grindstone
+through; but Jim he took the pick and soon made it big enough.  Then Tom
+marked out them things on it with the nail, and set Jim to work on them,
+with the nail for a chisel and an iron bolt from the rubbage in the
+lean-to for a hammer, and told him to work till the rest of his candle
+quit on him, and then he could go to bed, and hide the grindstone under
+his straw tick and sleep on it.  Then we helped him fix his chain back
+on the bed-leg, and was ready for bed ourselves.  But Tom thought of
+something, and says:
+
+“You got any spiders in here, Jim?”
+
+“No, sah, thanks to goodness I hain’t, Mars Tom.”
+
+“All right, we’ll get you some.”
+
+“But bless you, honey, I doan’ _want_ none.  I’s afeard un um.  I jis’
+‘s soon have rattlesnakes aroun’.”
+
+Tom thought a minute or two, and says:
+
+“It’s a good idea.  And I reckon it’s been done.  It _must_ a been done;
+it stands to reason.  Yes, it’s a prime good idea.  Where could you keep
+it?”
+
+“Keep what, Mars Tom?”
+
+“Why, a rattlesnake.”
+
+“De goodness gracious alive, Mars Tom!  Why, if dey was a rattlesnake to
+come in heah I’d take en bust right out thoo dat log wall, I would, wid
+my head.”
+
+“Why, Jim, you wouldn’t be afraid of it after a little.  You could tame
+it.”
+
+“_Tame_ it!”
+
+“Yes--easy enough.  Every animal is grateful for kindness and petting,
+and they wouldn’t _think_ of hurting a person that pets them.  Any book
+will tell you that.  You try--that’s all I ask; just try for two or three
+days. Why, you can get him so, in a little while, that he’ll love you;
+and sleep with you; and won’t stay away from you a minute; and will let
+you wrap him round your neck and put his head in your mouth.”
+
+“_Please_, Mars Tom--_doan_’ talk so!  I can’t _stan_’ it!  He’d _let_
+me shove his head in my mouf--fer a favor, hain’t it?  I lay he’d wait a
+pow’ful long time ‘fo’ I _ast_ him.  En mo’ en dat, I doan’ _want_ him
+to sleep wid me.”
+
+“Jim, don’t act so foolish.  A prisoner’s _got_ to have some kind of a
+dumb pet, and if a rattlesnake hain’t ever been tried, why, there’s more
+glory to be gained in your being the first to ever try it than any other
+way you could ever think of to save your life.”
+
+“Why, Mars Tom, I doan’ _want_ no sich glory.  Snake take ‘n bite
+Jim’s chin off, den _whah_ is de glory?  No, sah, I doan’ want no sich
+doin’s.”
+
+“Blame it, can’t you _try_?  I only _want_ you to try--you needn’t keep
+it up if it don’t work.”
+
+“But de trouble all _done_ ef de snake bite me while I’s a tryin’ him.
+Mars Tom, I’s willin’ to tackle mos’ anything ‘at ain’t onreasonable,
+but ef you en Huck fetches a rattlesnake in heah for me to tame, I’s
+gwyne to _leave_, dat’s _shore_.”
+
+“Well, then, let it go, let it go, if you’re so bull-headed about it.
+ We can get you some garter-snakes, and you can tie some buttons on
+their tails, and let on they’re rattlesnakes, and I reckon that ‘ll have
+to do.”
+
+“I k’n stan’ _dem_, Mars Tom, but blame’ ‘f I couldn’ get along widout
+um, I tell you dat.  I never knowed b’fo’ ‘t was so much bother and
+trouble to be a prisoner.”
+
+“Well, it _always_ is when it’s done right.  You got any rats around
+here?”
+
+“No, sah, I hain’t seed none.”
+
+“Well, we’ll get you some rats.”
+
+“Why, Mars Tom, I doan’ _want_ no rats.  Dey’s de dadblamedest creturs
+to ‘sturb a body, en rustle roun’ over ‘im, en bite his feet, when he’s
+tryin’ to sleep, I ever see.  No, sah, gimme g’yarter-snakes, ‘f I’s
+got to have ‘m, but doan’ gimme no rats; I hain’ got no use f’r um,
+skasely.”
+
+“But, Jim, you _got_ to have ‘em--they all do.  So don’t make no more
+fuss about it.  Prisoners ain’t ever without rats.  There ain’t no
+instance of it.  And they train them, and pet them, and learn them
+tricks, and they get to be as sociable as flies.  But you got to play
+music to them.  You got anything to play music on?”
+
+“I ain’ got nuffn but a coase comb en a piece o’ paper, en a juice-harp;
+but I reck’n dey wouldn’ take no stock in a juice-harp.”
+
+“Yes they would _they_ don’t care what kind of music ‘tis.  A
+jews-harp’s plenty good enough for a rat.  All animals like music--in a
+prison they dote on it.  Specially, painful music; and you can’t get no
+other kind out of a jews-harp.  It always interests them; they come out
+to see what’s the matter with you.  Yes, you’re all right; you’re fixed
+very well.  You want to set on your bed nights before you go to sleep,
+and early in the mornings, and play your jews-harp; play ‘The Last Link
+is Broken’--that’s the thing that ‘ll scoop a rat quicker ‘n anything
+else; and when you’ve played about two minutes you’ll see all the rats,
+and the snakes, and spiders, and things begin to feel worried about you,
+and come.  And they’ll just fairly swarm over you, and have a noble good
+time.”
+
+“Yes, _dey_ will, I reck’n, Mars Tom, but what kine er time is _Jim_
+havin’? Blest if I kin see de pint.  But I’ll do it ef I got to.  I
+reck’n I better keep de animals satisfied, en not have no trouble in de
+house.”
+
+Tom waited to think it over, and see if there wasn’t nothing else; and
+pretty soon he says:
+
+“Oh, there’s one thing I forgot.  Could you raise a flower here, do you
+reckon?”
+
+“I doan know but maybe I could, Mars Tom; but it’s tolable dark in heah,
+en I ain’ got no use f’r no flower, nohow, en she’d be a pow’ful sight
+o’ trouble.”
+
+“Well, you try it, anyway.  Some other prisoners has done it.”
+
+“One er dem big cat-tail-lookin’ mullen-stalks would grow in heah, Mars
+Tom, I reck’n, but she wouldn’t be wuth half de trouble she’d coss.”
+
+“Don’t you believe it.  We’ll fetch you a little one and you plant it in
+the corner over there, and raise it.  And don’t call it mullen, call it
+Pitchiola--that’s its right name when it’s in a prison.  And you want to
+water it with your tears.”
+
+“Why, I got plenty spring water, Mars Tom.”
+
+“You don’t _want_ spring water; you want to water it with your tears.
+ It’s the way they always do.”
+
+“Why, Mars Tom, I lay I kin raise one er dem mullen-stalks twyste wid
+spring water whiles another man’s a _start’n_ one wid tears.”
+
+“That ain’t the idea.  You _got_ to do it with tears.”
+
+“She’ll die on my han’s, Mars Tom, she sholy will; kase I doan’ skasely
+ever cry.”
+
+So Tom was stumped.  But he studied it over, and then said Jim would
+have to worry along the best he could with an onion.  He promised
+he would go to the nigger cabins and drop one, private, in Jim’s
+coffee-pot, in the morning. Jim said he would “jis’ ‘s soon have
+tobacker in his coffee;” and found so much fault with it, and with the
+work and bother of raising the mullen, and jews-harping the rats, and
+petting and flattering up the snakes and spiders and things, on top of
+all the other work he had to do on pens, and inscriptions, and journals,
+and things, which made it more trouble and worry and responsibility to
+be a prisoner than anything he ever undertook, that Tom most lost all
+patience with him; and said he was just loadened down with more gaudier
+chances than a prisoner ever had in the world to make a name for
+himself, and yet he didn’t know enough to appreciate them, and they was
+just about wasted on him.  So Jim he was sorry, and said he wouldn’t
+behave so no more, and then me and Tom shoved for bed.
+
+
+
+
+CHAPTER XXXIX.
+
+IN the morning we went up to the village and bought a wire rat-trap and
+fetched it down, and unstopped the best rat-hole, and in about an hour
+we had fifteen of the bulliest kind of ones; and then we took it and put
+it in a safe place under Aunt Sally’s bed.  But while we was gone for
+spiders little Thomas Franklin Benjamin Jefferson Elexander Phelps found
+it there, and opened the door of it to see if the rats would come out,
+and they did; and Aunt Sally she come in, and when we got back she was
+a-standing on top of the bed raising Cain, and the rats was doing what
+they could to keep off the dull times for her.  So she took and dusted
+us both with the hickry, and we was as much as two hours catching
+another fifteen or sixteen, drat that meddlesome cub, and they warn’t
+the likeliest, nuther, because the first haul was the pick of the flock.
+ I never see a likelier lot of rats than what that first haul was.
+
+We got a splendid stock of sorted spiders, and bugs, and frogs, and
+caterpillars, and one thing or another; and we like to got a hornet’s
+nest, but we didn’t.  The family was at home.  We didn’t give it right
+up, but stayed with them as long as we could; because we allowed we’d
+tire them out or they’d got to tire us out, and they done it.  Then we
+got allycumpain and rubbed on the places, and was pretty near all right
+again, but couldn’t set down convenient.  And so we went for the snakes,
+and grabbed a couple of dozen garters and house-snakes, and put them in
+a bag, and put it in our room, and by that time it was supper-time, and
+a rattling good honest day’s work:  and hungry?--oh, no, I reckon not!
+ And there warn’t a blessed snake up there when we went back--we didn’t
+half tie the sack, and they worked out somehow, and left.  But it didn’t
+matter much, because they was still on the premises somewheres.  So
+we judged we could get some of them again.  No, there warn’t no real
+scarcity of snakes about the house for a considerable spell.  You’d see
+them dripping from the rafters and places every now and then; and they
+generly landed in your plate, or down the back of your neck, and most
+of the time where you didn’t want them.  Well, they was handsome and
+striped, and there warn’t no harm in a million of them; but that never
+made no difference to Aunt Sally; she despised snakes, be the breed what
+they might, and she couldn’t stand them no way you could fix it; and
+every time one of them flopped down on her, it didn’t make no difference
+what she was doing, she would just lay that work down and light out.  I
+never see such a woman.  And you could hear her whoop to Jericho.  You
+couldn’t get her to take a-holt of one of them with the tongs.  And if
+she turned over and found one in bed she would scramble out and lift a
+howl that you would think the house was afire.  She disturbed the old
+man so that he said he could most wish there hadn’t ever been no snakes
+created.  Why, after every last snake had been gone clear out of the
+house for as much as a week Aunt Sally warn’t over it yet; she warn’t
+near over it; when she was setting thinking about something you could
+touch her on the back of her neck with a feather and she would jump
+right out of her stockings.  It was very curious.  But Tom said all
+women was just so.  He said they was made that way for some reason or
+other.
+
+We got a licking every time one of our snakes come in her way, and she
+allowed these lickings warn’t nothing to what she would do if we ever
+loaded up the place again with them.  I didn’t mind the lickings,
+because they didn’t amount to nothing; but I minded the trouble we
+had to lay in another lot.  But we got them laid in, and all the other
+things; and you never see a cabin as blithesome as Jim’s was when they’d
+all swarm out for music and go for him.  Jim didn’t like the spiders,
+and the spiders didn’t like Jim; and so they’d lay for him, and make it
+mighty warm for him.  And he said that between the rats and the snakes
+and the grindstone there warn’t no room in bed for him, skasely; and
+when there was, a body couldn’t sleep, it was so lively, and it was
+always lively, he said, because _they_ never all slept at one time, but
+took turn about, so when the snakes was asleep the rats was on deck, and
+when the rats turned in the snakes come on watch, so he always had one
+gang under him, in his way, and t’other gang having a circus over him,
+and if he got up to hunt a new place the spiders would take a chance at
+him as he crossed over. He said if he ever got out this time he wouldn’t
+ever be a prisoner again, not for a salary.
+
+Well, by the end of three weeks everything was in pretty good shape.
+ The shirt was sent in early, in a pie, and every time a rat bit Jim he
+would get up and write a little in his journal whilst the ink was fresh;
+the pens was made, the inscriptions and so on was all carved on the
+grindstone; the bed-leg was sawed in two, and we had et up the sawdust,
+and it give us a most amazing stomach-ache.  We reckoned we was all
+going to die, but didn’t.  It was the most undigestible sawdust I ever
+see; and Tom said the same.
+
+But as I was saying, we’d got all the work done now, at last; and we was
+all pretty much fagged out, too, but mainly Jim.  The old man had wrote
+a couple of times to the plantation below Orleans to come and get their
+runaway nigger, but hadn’t got no answer, because there warn’t no such
+plantation; so he allowed he would advertise Jim in the St. Louis and
+New Orleans papers; and when he mentioned the St. Louis ones it give me
+the cold shivers, and I see we hadn’t no time to lose. So Tom said, now
+for the nonnamous letters.
+
+“What’s them?”  I says.
+
+“Warnings to the people that something is up.  Sometimes it’s done one
+way, sometimes another.  But there’s always somebody spying around that
+gives notice to the governor of the castle.  When Louis XVI. was going
+to light out of the Tooleries, a servant-girl done it.  It’s a very good
+way, and so is the nonnamous letters.  We’ll use them both.  And it’s
+usual for the prisoner’s mother to change clothes with him, and she
+stays in, and he slides out in her clothes.  We’ll do that, too.”
+
+“But looky here, Tom, what do we want to _warn_ anybody for that
+something’s up?  Let them find it out for themselves--it’s their
+lookout.”
+
+“Yes, I know; but you can’t depend on them.  It’s the way they’ve acted
+from the very start--left us to do _everything_.  They’re so confiding
+and mullet-headed they don’t take notice of nothing at all.  So if we
+don’t _give_ them notice there won’t be nobody nor nothing to interfere
+with us, and so after all our hard work and trouble this escape ‘ll go
+off perfectly flat; won’t amount to nothing--won’t be nothing _to_ it.”
+
+“Well, as for me, Tom, that’s the way I’d like.”
+
+“Shucks!” he says, and looked disgusted.  So I says:
+
+“But I ain’t going to make no complaint.  Any way that suits you suits
+me. What you going to do about the servant-girl?”
+
+“You’ll be her.  You slide in, in the middle of the night, and hook that
+yaller girl’s frock.”
+
+“Why, Tom, that ‘ll make trouble next morning; because, of course, she
+prob’bly hain’t got any but that one.”
+
+“I know; but you don’t want it but fifteen minutes, to carry the
+nonnamous letter and shove it under the front door.”
+
+“All right, then, I’ll do it; but I could carry it just as handy in my
+own togs.”
+
+“You wouldn’t look like a servant-girl _then_, would you?”
+
+“No, but there won’t be nobody to see what I look like, _anyway_.”
+
+“That ain’t got nothing to do with it.  The thing for us to do is just
+to do our _duty_, and not worry about whether anybody _sees_ us do it or
+not. Hain’t you got no principle at all?”
+
+“All right, I ain’t saying nothing; I’m the servant-girl.  Who’s Jim’s
+mother?”
+
+“I’m his mother.  I’ll hook a gown from Aunt Sally.”
+
+“Well, then, you’ll have to stay in the cabin when me and Jim leaves.”
+
+“Not much.  I’ll stuff Jim’s clothes full of straw and lay it on his bed
+to represent his mother in disguise, and Jim ‘ll take the nigger woman’s
+gown off of me and wear it, and we’ll all evade together.  When a
+prisoner of style escapes it’s called an evasion.  It’s always called
+so when a king escapes, f’rinstance.  And the same with a king’s son;
+it don’t make no difference whether he’s a natural one or an unnatural
+one.”
+
+So Tom he wrote the nonnamous letter, and I smouched the yaller wench’s
+frock that night, and put it on, and shoved it under the front door, the
+way Tom told me to.  It said:
+
+Beware.  Trouble is brewing.  Keep a sharp lookout. _Unknown_ _Friend_.
+
+Next night we stuck a picture, which Tom drawed in blood, of a skull and
+crossbones on the front door; and next night another one of a coffin on
+the back door.  I never see a family in such a sweat.  They couldn’t a
+been worse scared if the place had a been full of ghosts laying for them
+behind everything and under the beds and shivering through the air.  If
+a door banged, Aunt Sally she jumped and said “ouch!” if anything fell,
+she jumped and said “ouch!” if you happened to touch her, when she
+warn’t noticing, she done the same; she couldn’t face noway and be
+satisfied, because she allowed there was something behind her every
+time--so she was always a-whirling around sudden, and saying “ouch,” and
+before she’d got two-thirds around she’d whirl back again, and say it
+again; and she was afraid to go to bed, but she dasn’t set up.  So the
+thing was working very well, Tom said; he said he never see a thing work
+more satisfactory. He said it showed it was done right.
+
+So he said, now for the grand bulge!  So the very next morning at the
+streak of dawn we got another letter ready, and was wondering what we
+better do with it, because we heard them say at supper they was going
+to have a nigger on watch at both doors all night.  Tom he went down the
+lightning-rod to spy around; and the nigger at the back door was asleep,
+and he stuck it in the back of his neck and come back.  This letter
+said:
+
+Don’t betray me, I wish to be your friend.  There is a desprate gang of
+cutthroats from over in the Indian Territory going to steal your runaway
+nigger to-night, and they have been trying to scare you so as you will
+stay in the house and not bother them.  I am one of the gang, but have
+got religgion and wish to quit it and lead an honest life again, and
+will betray the helish design. They will sneak down from northards,
+along the fence, at midnight exact, with a false key, and go in the
+nigger’s cabin to get him. I am to be off a piece and blow a tin horn
+if I see any danger; but stead of that I will _baa_ like a sheep soon as
+they get in and not blow at all; then whilst they are getting his
+chains loose, you slip there and lock them in, and can kill them at your
+leasure.  Don’t do anything but just the way I am telling you, if you do
+they will suspicion something and raise whoop-jamboreehoo. I do not wish
+any reward but to know I have done the right thing. _Unknown Friend._
+
+
+
+
+CHAPTER XL.
+
+WE was feeling pretty good after breakfast, and took my canoe and went
+over the river a-fishing, with a lunch, and had a good time, and took a
+look at the raft and found her all right, and got home late to supper,
+and found them in such a sweat and worry they didn’t know which end they
+was standing on, and made us go right off to bed the minute we was done
+supper, and wouldn’t tell us what the trouble was, and never let on a
+word about the new letter, but didn’t need to, because we knowed as much
+about it as anybody did, and as soon as we was half up stairs and her
+back was turned we slid for the cellar cupboard and loaded up a good
+lunch and took it up to our room and went to bed, and got up about
+half-past eleven, and Tom put on Aunt Sally’s dress that he stole and
+was going to start with the lunch, but says:
+
+“Where’s the butter?”
+
+“I laid out a hunk of it,” I says, “on a piece of a corn-pone.”
+
+“Well, you _left_ it laid out, then--it ain’t here.”
+
+“We can get along without it,” I says.
+
+“We can get along _with_ it, too,” he says; “just you slide down cellar
+and fetch it.  And then mosey right down the lightning-rod and come
+along. I’ll go and stuff the straw into Jim’s clothes to represent his
+mother in disguise, and be ready to _baa_ like a sheep and shove soon as
+you get there.”
+
+So out he went, and down cellar went I. The hunk of butter, big as
+a person’s fist, was where I had left it, so I took up the slab of
+corn-pone with it on, and blowed out my light, and started up stairs
+very stealthy, and got up to the main floor all right, but here comes
+Aunt Sally with a candle, and I clapped the truck in my hat, and clapped
+my hat on my head, and the next second she see me; and she says:
+
+“You been down cellar?”
+
+“Yes’m.”
+
+“What you been doing down there?”
+
+“Noth’n.”
+
+“_Noth’n!_”
+
+“No’m.”
+
+“Well, then, what possessed you to go down there this time of night?”
+
+“I don’t know ‘m.”
+
+“You don’t _know_?  Don’t answer me that way. Tom, I want to know what
+you been _doing_ down there.”
+
+“I hain’t been doing a single thing, Aunt Sally, I hope to gracious if I
+have.”
+
+I reckoned she’d let me go now, and as a generl thing she would; but I
+s’pose there was so many strange things going on she was just in a sweat
+about every little thing that warn’t yard-stick straight; so she says,
+very decided:
+
+“You just march into that setting-room and stay there till I come.  You
+been up to something you no business to, and I lay I’ll find out what it
+is before I’M done with you.”
+
+So she went away as I opened the door and walked into the setting-room.
+My, but there was a crowd there!  Fifteen farmers, and every one of them
+had a gun.  I was most powerful sick, and slunk to a chair and set down.
+They was setting around, some of them talking a little, in a low voice,
+and all of them fidgety and uneasy, but trying to look like they warn’t;
+but I knowed they was, because they was always taking off their hats,
+and putting them on, and scratching their heads, and changing their
+seats, and fumbling with their buttons.  I warn’t easy myself, but I
+didn’t take my hat off, all the same.
+
+I did wish Aunt Sally would come, and get done with me, and lick me, if
+she wanted to, and let me get away and tell Tom how we’d overdone this
+thing, and what a thundering hornet’s-nest we’d got ourselves into, so
+we could stop fooling around straight off, and clear out with Jim before
+these rips got out of patience and come for us.
+
+At last she come and begun to ask me questions, but I _couldn’t_ answer
+them straight, I didn’t know which end of me was up; because these men
+was in such a fidget now that some was wanting to start right NOW and
+lay for them desperadoes, and saying it warn’t but a few minutes to
+midnight; and others was trying to get them to hold on and wait for the
+sheep-signal; and here was Aunty pegging away at the questions, and
+me a-shaking all over and ready to sink down in my tracks I was
+that scared; and the place getting hotter and hotter, and the butter
+beginning to melt and run down my neck and behind my ears; and pretty
+soon, when one of them says, “I’M for going and getting in the cabin
+_first_ and right _now_, and catching them when they come,” I most
+dropped; and a streak of butter come a-trickling down my forehead, and
+Aunt Sally she see it, and turns white as a sheet, and says:
+
+“For the land’s sake, what _is_ the matter with the child?  He’s got the
+brain-fever as shore as you’re born, and they’re oozing out!”
+
+And everybody runs to see, and she snatches off my hat, and out comes
+the bread and what was left of the butter, and she grabbed me, and
+hugged me, and says:
+
+“Oh, what a turn you did give me! and how glad and grateful I am it
+ain’t no worse; for luck’s against us, and it never rains but it pours,
+and when I see that truck I thought we’d lost you, for I knowed by
+the color and all it was just like your brains would be if--Dear,
+dear, whyd’nt you _tell_ me that was what you’d been down there for, I
+wouldn’t a cared.  Now cler out to bed, and don’t lemme see no more of
+you till morning!”
+
+I was up stairs in a second, and down the lightning-rod in another one,
+and shinning through the dark for the lean-to.  I couldn’t hardly get my
+words out, I was so anxious; but I told Tom as quick as I could we must
+jump for it now, and not a minute to lose--the house full of men, yonder,
+with guns!
+
+His eyes just blazed; and he says:
+
+“No!--is that so?  _ain’t_ it bully!  Why, Huck, if it was to do over
+again, I bet I could fetch two hundred!  If we could put it off till--”
+
+“Hurry!  _Hurry_!”  I says.  “Where’s Jim?”
+
+“Right at your elbow; if you reach out your arm you can touch him.
+ He’s dressed, and everything’s ready.  Now we’ll slide out and give the
+sheep-signal.”
+
+But then we heard the tramp of men coming to the door, and heard them
+begin to fumble with the pad-lock, and heard a man say:
+
+“I _told_ you we’d be too soon; they haven’t come--the door is locked.
+Here, I’ll lock some of you into the cabin, and you lay for ‘em in the
+dark and kill ‘em when they come; and the rest scatter around a piece,
+and listen if you can hear ‘em coming.”
+
+So in they come, but couldn’t see us in the dark, and most trod on
+us whilst we was hustling to get under the bed.  But we got under all
+right, and out through the hole, swift but soft--Jim first, me next,
+and Tom last, which was according to Tom’s orders.  Now we was in the
+lean-to, and heard trampings close by outside.  So we crept to the door,
+and Tom stopped us there and put his eye to the crack, but couldn’t make
+out nothing, it was so dark; and whispered and said he would listen
+for the steps to get further, and when he nudged us Jim must glide out
+first, and him last.  So he set his ear to the crack and listened, and
+listened, and listened, and the steps a-scraping around out there all
+the time; and at last he nudged us, and we slid out, and stooped down,
+not breathing, and not making the least noise, and slipped stealthy
+towards the fence in Injun file, and got to it all right, and me and Jim
+over it; but Tom’s britches catched fast on a splinter on the top
+rail, and then he hear the steps coming, so he had to pull loose, which
+snapped the splinter and made a noise; and as he dropped in our tracks
+and started somebody sings out:
+
+“Who’s that?  Answer, or I’ll shoot!”
+
+But we didn’t answer; we just unfurled our heels and shoved.  Then there
+was a rush, and a _Bang, Bang, Bang!_ and the bullets fairly whizzed
+around us! We heard them sing out:
+
+“Here they are!  They’ve broke for the river!  After ‘em, boys, and turn
+loose the dogs!”
+
+So here they come, full tilt.  We could hear them because they wore
+boots and yelled, but we didn’t wear no boots and didn’t yell.  We was
+in the path to the mill; and when they got pretty close on to us we
+dodged into the bush and let them go by, and then dropped in behind
+them.  They’d had all the dogs shut up, so they wouldn’t scare off the
+robbers; but by this time somebody had let them loose, and here they
+come, making powwow enough for a million; but they was our dogs; so we
+stopped in our tracks till they catched up; and when they see it warn’t
+nobody but us, and no excitement to offer them, they only just said
+howdy, and tore right ahead towards the shouting and clattering; and
+then we up-steam again, and whizzed along after them till we was nearly
+to the mill, and then struck up through the bush to where my canoe was
+tied, and hopped in and pulled for dear life towards the middle of the
+river, but didn’t make no more noise than we was obleeged to. Then we
+struck out, easy and comfortable, for the island where my raft was; and
+we could hear them yelling and barking at each other all up and down the
+bank, till we was so far away the sounds got dim and died out.  And when
+we stepped on to the raft I says:
+
+“_Now_, old Jim, you’re a free man again, and I bet you won’t ever be a
+slave no more.”
+
+“En a mighty good job it wuz, too, Huck.  It ‘uz planned beautiful, en
+it ‘uz done beautiful; en dey ain’t _nobody_ kin git up a plan dat’s mo’
+mixed-up en splendid den what dat one wuz.”
+
+We was all glad as we could be, but Tom was the gladdest of all because
+he had a bullet in the calf of his leg.
+
+When me and Jim heard that we didn’t feel so brash as what we did
+before. It was hurting him considerable, and bleeding; so we laid him in
+the wigwam and tore up one of the duke’s shirts for to bandage him, but
+he says:
+
+“Gimme the rags; I can do it myself.  Don’t stop now; don’t fool around
+here, and the evasion booming along so handsome; man the sweeps, and set
+her loose!  Boys, we done it elegant!--‘deed we did.  I wish _we’d_ a
+had the handling of Louis XVI., there wouldn’t a been no ‘Son of Saint
+Louis, ascend to heaven!’ wrote down in _his_ biography; no, sir, we’d
+a whooped him over the _border_--that’s what we’d a done with _him_--and
+done it just as slick as nothing at all, too.  Man the sweeps--man the
+sweeps!”
+
+But me and Jim was consulting--and thinking.  And after we’d thought a
+minute, I says:
+
+“Say it, Jim.”
+
+So he says:
+
+“Well, den, dis is de way it look to me, Huck.  Ef it wuz _him_ dat ‘uz
+bein’ sot free, en one er de boys wuz to git shot, would he say, ‘Go on
+en save me, nemmine ‘bout a doctor f’r to save dis one?’  Is dat like
+Mars Tom Sawyer?  Would he say dat?  You _bet_ he wouldn’t!  _well_,
+den, is _Jim_ gywne to say it?  No, sah--I doan’ budge a step out’n dis
+place ‘dout a _doctor_, not if it’s forty year!”
+
+I knowed he was white inside, and I reckoned he’d say what he did say--so
+it was all right now, and I told Tom I was a-going for a doctor.
+ He raised considerable row about it, but me and Jim stuck to it and
+wouldn’t budge; so he was for crawling out and setting the raft loose
+himself; but we wouldn’t let him.  Then he give us a piece of his mind,
+but it didn’t do no good.
+
+So when he sees me getting the canoe ready, he says:
+
+“Well, then, if you’re bound to go, I’ll tell you the way to do when you
+get to the village.  Shut the door and blindfold the doctor tight and
+fast, and make him swear to be silent as the grave, and put a purse
+full of gold in his hand, and then take and lead him all around the
+back alleys and everywheres in the dark, and then fetch him here in the
+canoe, in a roundabout way amongst the islands, and search him and take
+his chalk away from him, and don’t give it back to him till you get him
+back to the village, or else he will chalk this raft so he can find it
+again. It’s the way they all do.”
+
+So I said I would, and left, and Jim was to hide in the woods when he
+see the doctor coming till he was gone again.
+
+
+
+
+CHAPTER XLI.
+
+THE doctor was an old man; a very nice, kind-looking old man when I got
+him up.  I told him me and my brother was over on Spanish Island hunting
+yesterday afternoon, and camped on a piece of a raft we found, and about
+midnight he must a kicked his gun in his dreams, for it went off and
+shot him in the leg, and we wanted him to go over there and fix it and
+not say nothing about it, nor let anybody know, because we wanted to
+come home this evening and surprise the folks.
+
+“Who is your folks?” he says.
+
+“The Phelpses, down yonder.”
+
+“Oh,” he says.  And after a minute, he says:
+
+“How’d you say he got shot?”
+
+“He had a dream,” I says, “and it shot him.”
+
+“Singular dream,” he says.
+
+So he lit up his lantern, and got his saddle-bags, and we started.  But
+when he sees the canoe he didn’t like the look of her--said she was big
+enough for one, but didn’t look pretty safe for two.  I says:
+
+“Oh, you needn’t be afeard, sir, she carried the three of us easy
+enough.”
+
+“What three?”
+
+“Why, me and Sid, and--and--and _the guns_; that’s what I mean.”
+
+“Oh,” he says.
+
+But he put his foot on the gunnel and rocked her, and shook his head,
+and said he reckoned he’d look around for a bigger one.  But they was
+all locked and chained; so he took my canoe, and said for me to wait
+till he come back, or I could hunt around further, or maybe I better
+go down home and get them ready for the surprise if I wanted to.  But
+I said I didn’t; so I told him just how to find the raft, and then he
+started.
+
+I struck an idea pretty soon.  I says to myself, spos’n he can’t fix
+that leg just in three shakes of a sheep’s tail, as the saying is?
+spos’n it takes him three or four days?  What are we going to do?--lay
+around there till he lets the cat out of the bag?  No, sir; I know what
+_I’ll_ do.  I’ll wait, and when he comes back if he says he’s got to
+go any more I’ll get down there, too, if I swim; and we’ll take and tie
+him, and keep him, and shove out down the river; and when Tom’s done
+with him we’ll give him what it’s worth, or all we got, and then let him
+get ashore.
+
+So then I crept into a lumber-pile to get some sleep; and next time I
+waked up the sun was away up over my head!  I shot out and went for the
+doctor’s house, but they told me he’d gone away in the night some time
+or other, and warn’t back yet.  Well, thinks I, that looks powerful bad
+for Tom, and I’ll dig out for the island right off.  So away I shoved,
+and turned the corner, and nearly rammed my head into Uncle Silas’s
+stomach! He says:
+
+“Why, _Tom!_  Where you been all this time, you rascal?”
+
+“I hain’t been nowheres,” I says, “only just hunting for the runaway
+nigger--me and Sid.”
+
+“Why, where ever did you go?” he says.  “Your aunt’s been mighty
+uneasy.”
+
+“She needn’t,” I says, “because we was all right.  We followed the men
+and the dogs, but they outrun us, and we lost them; but we thought we
+heard them on the water, so we got a canoe and took out after them and
+crossed over, but couldn’t find nothing of them; so we cruised along
+up-shore till we got kind of tired and beat out; and tied up the canoe
+and went to sleep, and never waked up till about an hour ago; then we
+paddled over here to hear the news, and Sid’s at the post-office to see
+what he can hear, and I’m a-branching out to get something to eat for
+us, and then we’re going home.”
+
+So then we went to the post-office to get “Sid”; but just as I
+suspicioned, he warn’t there; so the old man he got a letter out of the
+office, and we waited awhile longer, but Sid didn’t come; so the old man
+said, come along, let Sid foot it home, or canoe it, when he got done
+fooling around--but we would ride.  I couldn’t get him to let me stay
+and wait for Sid; and he said there warn’t no use in it, and I must come
+along, and let Aunt Sally see we was all right.
+
+When we got home Aunt Sally was that glad to see me she laughed and
+cried both, and hugged me, and give me one of them lickings of hern that
+don’t amount to shucks, and said she’d serve Sid the same when he come.
+
+And the place was plum full of farmers and farmers’ wives, to dinner;
+and such another clack a body never heard.  Old Mrs. Hotchkiss was the
+worst; her tongue was a-going all the time.  She says:
+
+“Well, Sister Phelps, I’ve ransacked that-air cabin over, an’ I b’lieve
+the nigger was crazy.  I says to Sister Damrell--didn’t I, Sister
+Damrell?--s’I, he’s crazy, s’I--them’s the very words I said.  You all
+hearn me: he’s crazy, s’I; everything shows it, s’I.  Look at that-air
+grindstone, s’I; want to tell _me_’t any cretur ‘t’s in his right mind
+‘s a goin’ to scrabble all them crazy things onto a grindstone, s’I?
+ Here sich ‘n’ sich a person busted his heart; ‘n’ here so ‘n’ so
+pegged along for thirty-seven year, ‘n’ all that--natcherl son o’ Louis
+somebody, ‘n’ sich everlast’n rubbage.  He’s plumb crazy, s’I; it’s what
+I says in the fust place, it’s what I says in the middle, ‘n’ it’s what
+I says last ‘n’ all the time--the nigger’s crazy--crazy ‘s Nebokoodneezer,
+s’I.”
+
+“An’ look at that-air ladder made out’n rags, Sister Hotchkiss,” says
+old Mrs. Damrell; “what in the name o’ goodness _could_ he ever want
+of--”
+
+“The very words I was a-sayin’ no longer ago th’n this minute to Sister
+Utterback, ‘n’ she’ll tell you so herself.  Sh-she, look at that-air rag
+ladder, sh-she; ‘n’ s’I, yes, _look_ at it, s’I--what _could_ he a-wanted
+of it, s’I.  Sh-she, Sister Hotchkiss, sh-she--”
+
+“But how in the nation’d they ever _git_ that grindstone _in_ there,
+_anyway_? ‘n’ who dug that-air _hole_? ‘n’ who--”
+
+“My very _words_, Brer Penrod!  I was a-sayin’--pass that-air sasser o’
+m’lasses, won’t ye?--I was a-sayin’ to Sister Dunlap, jist this minute,
+how _did_ they git that grindstone in there, s’I.  Without _help_, mind
+you--‘thout _help_!  _that’s_ wher ‘tis.  Don’t tell _me_, s’I; there
+_wuz_ help, s’I; ‘n’ ther’ wuz a _plenty_ help, too, s’I; ther’s ben a
+_dozen_ a-helpin’ that nigger, ‘n’ I lay I’d skin every last nigger on
+this place but _I’d_ find out who done it, s’I; ‘n’ moreover, s’I--”
+
+“A _dozen_ says you!--_forty_ couldn’t a done every thing that’s been
+done. Look at them case-knife saws and things, how tedious they’ve been
+made; look at that bed-leg sawed off with ‘m, a week’s work for six men;
+look at that nigger made out’n straw on the bed; and look at--”
+
+“You may _well_ say it, Brer Hightower!  It’s jist as I was a-sayin’
+to Brer Phelps, his own self.  S’e, what do _you_ think of it, Sister
+Hotchkiss, s’e? Think o’ what, Brer Phelps, s’I?  Think o’ that bed-leg
+sawed off that a way, s’e?  _think_ of it, s’I?  I lay it never sawed
+_itself_ off, s’I--somebody _sawed_ it, s’I; that’s my opinion, take it
+or leave it, it mayn’t be no ‘count, s’I, but sich as ‘t is, it’s my
+opinion, s’I, ‘n’ if any body k’n start a better one, s’I, let him _do_
+it, s’I, that’s all.  I says to Sister Dunlap, s’I--”
+
+“Why, dog my cats, they must a ben a house-full o’ niggers in there
+every night for four weeks to a done all that work, Sister Phelps.  Look
+at that shirt--every last inch of it kivered over with secret African
+writ’n done with blood!  Must a ben a raft uv ‘m at it right along, all
+the time, amost.  Why, I’d give two dollars to have it read to me; ‘n’
+as for the niggers that wrote it, I ‘low I’d take ‘n’ lash ‘m t’ll--”
+
+“People to _help_ him, Brother Marples!  Well, I reckon you’d _think_
+so if you’d a been in this house for a while back.  Why, they’ve stole
+everything they could lay their hands on--and we a-watching all the time,
+mind you. They stole that shirt right off o’ the line! and as for that
+sheet they made the rag ladder out of, ther’ ain’t no telling how
+many times they _didn’t_ steal that; and flour, and candles, and
+candlesticks, and spoons, and the old warming-pan, and most a thousand
+things that I disremember now, and my new calico dress; and me and
+Silas and my Sid and Tom on the constant watch day _and_ night, as I was
+a-telling you, and not a one of us could catch hide nor hair nor sight
+nor sound of them; and here at the last minute, lo and behold you, they
+slides right in under our noses and fools us, and not only fools _us_
+but the Injun Territory robbers too, and actuly gets _away_ with that
+nigger safe and sound, and that with sixteen men and twenty-two dogs
+right on their very heels at that very time!  I tell you, it just bangs
+anything I ever _heard_ of. Why, _sperits_ couldn’t a done better and
+been no smarter. And I reckon they must a _been_ sperits--because, _you_
+know our dogs, and ther’ ain’t no better; well, them dogs never even got
+on the _track_ of ‘m once!  You explain _that_ to me if you can!--_any_
+of you!”
+
+“Well, it does beat--”
+
+“Laws alive, I never--”
+
+“So help me, I wouldn’t a be--”
+
+“_House_-thieves as well as--”
+
+“Goodnessgracioussakes, I’d a ben afeard to live in sich a--”
+
+“‘Fraid to _live_!--why, I was that scared I dasn’t hardly go to bed, or
+get up, or lay down, or _set_ down, Sister Ridgeway.  Why, they’d steal
+the very--why, goodness sakes, you can guess what kind of a fluster I was
+in by the time midnight come last night.  I hope to gracious if I warn’t
+afraid they’d steal some o’ the family!  I was just to that pass I
+didn’t have no reasoning faculties no more.  It looks foolish enough
+_now_, in the daytime; but I says to myself, there’s my two poor boys
+asleep, ‘way up stairs in that lonesome room, and I declare to goodness
+I was that uneasy ‘t I crep’ up there and locked ‘em in!  I _did_.  And
+anybody would. Because, you know, when you get scared that way, and it
+keeps running on, and getting worse and worse all the time, and your
+wits gets to addling, and you get to doing all sorts o’ wild things,
+and by and by you think to yourself, spos’n I was a boy, and was away up
+there, and the door ain’t locked, and you--” She stopped, looking kind
+of wondering, and then she turned her head around slow, and when her eye
+lit on me--I got up and took a walk.
+
+Says I to myself, I can explain better how we come to not be in that
+room this morning if I go out to one side and study over it a little.
+ So I done it.  But I dasn’t go fur, or she’d a sent for me.  And when
+it was late in the day the people all went, and then I come in and
+told her the noise and shooting waked up me and “Sid,” and the door was
+locked, and we wanted to see the fun, so we went down the lightning-rod,
+and both of us got hurt a little, and we didn’t never want to try _that_
+no more.  And then I went on and told her all what I told Uncle Silas
+before; and then she said she’d forgive us, and maybe it was all right
+enough anyway, and about what a body might expect of boys, for all boys
+was a pretty harum-scarum lot as fur as she could see; and so, as long
+as no harm hadn’t come of it, she judged she better put in her time
+being grateful we was alive and well and she had us still, stead of
+fretting over what was past and done.  So then she kissed me, and patted
+me on the head, and dropped into a kind of a brown study; and pretty
+soon jumps up, and says:
+
+“Why, lawsamercy, it’s most night, and Sid not come yet!  What _has_
+become of that boy?”
+
+I see my chance; so I skips up and says:
+
+“I’ll run right up to town and get him,” I says.
+
+“No you won’t,” she says.  “You’ll stay right wher’ you are; _one’s_
+enough to be lost at a time.  If he ain’t here to supper, your uncle ‘ll
+go.”
+
+Well, he warn’t there to supper; so right after supper uncle went.
+
+He come back about ten a little bit uneasy; hadn’t run across Tom’s
+track. Aunt Sally was a good _deal_ uneasy; but Uncle Silas he said
+there warn’t no occasion to be--boys will be boys, he said, and you’ll
+see this one turn up in the morning all sound and right.  So she had
+to be satisfied.  But she said she’d set up for him a while anyway, and
+keep a light burning so he could see it.
+
+And then when I went up to bed she come up with me and fetched her
+candle, and tucked me in, and mothered me so good I felt mean, and like
+I couldn’t look her in the face; and she set down on the bed and talked
+with me a long time, and said what a splendid boy Sid was, and didn’t
+seem to want to ever stop talking about him; and kept asking me every
+now and then if I reckoned he could a got lost, or hurt, or maybe
+drownded, and might be laying at this minute somewheres suffering or
+dead, and she not by him to help him, and so the tears would drip down
+silent, and I would tell her that Sid was all right, and would be home
+in the morning, sure; and she would squeeze my hand, or maybe kiss me,
+and tell me to say it again, and keep on saying it, because it done her
+good, and she was in so much trouble.  And when she was going away she
+looked down in my eyes so steady and gentle, and says:
+
+“The door ain’t going to be locked, Tom, and there’s the window and
+the rod; but you’ll be good, _won’t_ you?  And you won’t go?  For _my_
+sake.”
+
+Laws knows I _wanted_ to go bad enough to see about Tom, and was all
+intending to go; but after that I wouldn’t a went, not for kingdoms.
+
+But she was on my mind and Tom was on my mind, so I slept very restless.
+And twice I went down the rod away in the night, and slipped around
+front, and see her setting there by her candle in the window with her
+eyes towards the road and the tears in them; and I wished I could do
+something for her, but I couldn’t, only to swear that I wouldn’t never
+do nothing to grieve her any more.  And the third time I waked up at
+dawn, and slid down, and she was there yet, and her candle was most out,
+and her old gray head was resting on her hand, and she was asleep.
+
+
+
+
+CHAPTER XLII.
+
+THE old man was uptown again before breakfast, but couldn’t get no
+track of Tom; and both of them set at the table thinking, and not saying
+nothing, and looking mournful, and their coffee getting cold, and not
+eating anything. And by and by the old man says:
+
+“Did I give you the letter?”
+
+“What letter?”
+
+“The one I got yesterday out of the post-office.”
+
+“No, you didn’t give me no letter.”
+
+“Well, I must a forgot it.”
+
+So he rummaged his pockets, and then went off somewheres where he had
+laid it down, and fetched it, and give it to her.  She says:
+
+“Why, it’s from St. Petersburg--it’s from Sis.”
+
+I allowed another walk would do me good; but I couldn’t stir.  But
+before she could break it open she dropped it and run--for she see
+something. And so did I. It was Tom Sawyer on a mattress; and that old
+doctor; and Jim, in _her_ calico dress, with his hands tied behind him;
+and a lot of people.  I hid the letter behind the first thing that come
+handy, and rushed.  She flung herself at Tom, crying, and says:
+
+“Oh, he’s dead, he’s dead, I know he’s dead!”
+
+And Tom he turned his head a little, and muttered something or other,
+which showed he warn’t in his right mind; then she flung up her hands,
+and says:
+
+“He’s alive, thank God!  And that’s enough!” and she snatched a kiss of
+him, and flew for the house to get the bed ready, and scattering orders
+right and left at the niggers and everybody else, as fast as her tongue
+could go, every jump of the way.
+
+I followed the men to see what they was going to do with Jim; and the
+old doctor and Uncle Silas followed after Tom into the house.  The men
+was very huffy, and some of them wanted to hang Jim for an example to
+all the other niggers around there, so they wouldn’t be trying to run
+away like Jim done, and making such a raft of trouble, and keeping a
+whole family scared most to death for days and nights.  But the others
+said, don’t do it, it wouldn’t answer at all; he ain’t our nigger, and
+his owner would turn up and make us pay for him, sure.  So that cooled
+them down a little, because the people that’s always the most anxious
+for to hang a nigger that hain’t done just right is always the very
+ones that ain’t the most anxious to pay for him when they’ve got their
+satisfaction out of him.
+
+They cussed Jim considerble, though, and give him a cuff or two side the
+head once in a while, but Jim never said nothing, and he never let on to
+know me, and they took him to the same cabin, and put his own clothes
+on him, and chained him again, and not to no bed-leg this time, but to
+a big staple drove into the bottom log, and chained his hands, too, and
+both legs, and said he warn’t to have nothing but bread and water to
+eat after this till his owner come, or he was sold at auction because
+he didn’t come in a certain length of time, and filled up our hole, and
+said a couple of farmers with guns must stand watch around about the
+cabin every night, and a bulldog tied to the door in the daytime; and
+about this time they was through with the job and was tapering off with
+a kind of generl good-bye cussing, and then the old doctor comes and
+takes a look, and says:
+
+“Don’t be no rougher on him than you’re obleeged to, because he ain’t
+a bad nigger.  When I got to where I found the boy I see I couldn’t cut
+the bullet out without some help, and he warn’t in no condition for
+me to leave to go and get help; and he got a little worse and a little
+worse, and after a long time he went out of his head, and wouldn’t let
+me come a-nigh him any more, and said if I chalked his raft he’d kill
+me, and no end of wild foolishness like that, and I see I couldn’t do
+anything at all with him; so I says, I got to have _help_ somehow; and
+the minute I says it out crawls this nigger from somewheres and says
+he’ll help, and he done it, too, and done it very well.  Of course I
+judged he must be a runaway nigger, and there I _was_! and there I had
+to stick right straight along all the rest of the day and all night.  It
+was a fix, I tell you! I had a couple of patients with the chills, and
+of course I’d of liked to run up to town and see them, but I dasn’t,
+because the nigger might get away, and then I’d be to blame; and yet
+never a skiff come close enough for me to hail.  So there I had to stick
+plumb until daylight this morning; and I never see a nigger that was a
+better nuss or faithfuller, and yet he was risking his freedom to do it,
+and was all tired out, too, and I see plain enough he’d been worked
+main hard lately.  I liked the nigger for that; I tell you, gentlemen, a
+nigger like that is worth a thousand dollars--and kind treatment, too.  I
+had everything I needed, and the boy was doing as well there as he
+would a done at home--better, maybe, because it was so quiet; but there I
+_was_, with both of ‘m on my hands, and there I had to stick till about
+dawn this morning; then some men in a skiff come by, and as good luck
+would have it the nigger was setting by the pallet with his head propped
+on his knees sound asleep; so I motioned them in quiet, and they slipped
+up on him and grabbed him and tied him before he knowed what he was
+about, and we never had no trouble. And the boy being in a kind of a
+flighty sleep, too, we muffled the oars and hitched the raft on, and
+towed her over very nice and quiet, and the nigger never made the least
+row nor said a word from the start.  He ain’t no bad nigger, gentlemen;
+that’s what I think about him.”
+
+Somebody says:
+
+“Well, it sounds very good, doctor, I’m obleeged to say.”
+
+Then the others softened up a little, too, and I was mighty thankful
+to that old doctor for doing Jim that good turn; and I was glad it was
+according to my judgment of him, too; because I thought he had a good
+heart in him and was a good man the first time I see him.  Then they
+all agreed that Jim had acted very well, and was deserving to have some
+notice took of it, and reward.  So every one of them promised, right out
+and hearty, that they wouldn’t cuss him no more.
+
+Then they come out and locked him up.  I hoped they was going to say he
+could have one or two of the chains took off, because they was rotten
+heavy, or could have meat and greens with his bread and water; but they
+didn’t think of it, and I reckoned it warn’t best for me to mix in, but
+I judged I’d get the doctor’s yarn to Aunt Sally somehow or other as
+soon as I’d got through the breakers that was laying just ahead of
+me--explanations, I mean, of how I forgot to mention about Sid being shot
+when I was telling how him and me put in that dratted night paddling
+around hunting the runaway nigger.
+
+But I had plenty time.  Aunt Sally she stuck to the sick-room all day
+and all night, and every time I see Uncle Silas mooning around I dodged
+him.
+
+Next morning I heard Tom was a good deal better, and they said Aunt
+Sally was gone to get a nap.  So I slips to the sick-room, and if I
+found him awake I reckoned we could put up a yarn for the family that
+would wash. But he was sleeping, and sleeping very peaceful, too; and
+pale, not fire-faced the way he was when he come.  So I set down and
+laid for him to wake.  In about half an hour Aunt Sally comes gliding
+in, and there I was, up a stump again!  She motioned me to be still, and
+set down by me, and begun to whisper, and said we could all be joyful
+now, because all the symptoms was first-rate, and he’d been sleeping
+like that for ever so long, and looking better and peacefuller all the
+time, and ten to one he’d wake up in his right mind.
+
+So we set there watching, and by and by he stirs a bit, and opened his
+eyes very natural, and takes a look, and says:
+
+“Hello!--why, I’m at _home_!  How’s that?  Where’s the raft?”
+
+“It’s all right,” I says.
+
+“And _Jim_?”
+
+“The same,” I says, but couldn’t say it pretty brash.  But he never
+noticed, but says:
+
+“Good!  Splendid!  _Now_ we’re all right and safe! Did you tell Aunty?”
+
+I was going to say yes; but she chipped in and says:  “About what, Sid?”
+
+“Why, about the way the whole thing was done.”
+
+“What whole thing?”
+
+“Why, _the_ whole thing.  There ain’t but one; how we set the runaway
+nigger free--me and Tom.”
+
+“Good land!  Set the run--What _is_ the child talking about!  Dear, dear,
+out of his head again!”
+
+“_No_, I ain’t out of my _head_; I know all what I’m talking about.  We
+_did_ set him free--me and Tom.  We laid out to do it, and we _done_ it.
+ And we done it elegant, too.”  He’d got a start, and she never checked
+him up, just set and stared and stared, and let him clip along, and
+I see it warn’t no use for _me_ to put in.  “Why, Aunty, it cost us a
+power of work--weeks of it--hours and hours, every night, whilst you was
+all asleep. And we had to steal candles, and the sheet, and the shirt,
+and your dress, and spoons, and tin plates, and case-knives, and the
+warming-pan, and the grindstone, and flour, and just no end of things,
+and you can’t think what work it was to make the saws, and pens, and
+inscriptions, and one thing or another, and you can’t think _half_ the
+fun it was.  And we had to make up the pictures of coffins and things,
+and nonnamous letters from the robbers, and get up and down the
+lightning-rod, and dig the hole into the cabin, and made the rope ladder
+and send it in cooked up in a pie, and send in spoons and things to work
+with in your apron pocket--”
+
+“Mercy sakes!”
+
+“--and load up the cabin with rats and snakes and so on, for company for
+Jim; and then you kept Tom here so long with the butter in his hat that
+you come near spiling the whole business, because the men come before
+we was out of the cabin, and we had to rush, and they heard us and let
+drive at us, and I got my share, and we dodged out of the path and let
+them go by, and when the dogs come they warn’t interested in us, but
+went for the most noise, and we got our canoe, and made for the
+raft, and was all safe, and Jim was a free man, and we done it all by
+ourselves, and _wasn’t_ it bully, Aunty!”
+
+“Well, I never heard the likes of it in all my born days!  So it was
+_you_, you little rapscallions, that’s been making all this trouble,
+and turned everybody’s wits clean inside out and scared us all most to
+death.  I’ve as good a notion as ever I had in my life to take it out
+o’ you this very minute.  To think, here I’ve been, night after night,
+a--_you_ just get well once, you young scamp, and I lay I’ll tan the Old
+Harry out o’ both o’ ye!”
+
+But Tom, he _was_ so proud and joyful, he just _couldn’t_ hold in,
+and his tongue just _went_ it--she a-chipping in, and spitting fire all
+along, and both of them going it at once, like a cat convention; and she
+says:
+
+“_Well_, you get all the enjoyment you can out of it _now_, for mind I
+tell you if I catch you meddling with him again--”
+
+“Meddling with _who_?”  Tom says, dropping his smile and looking
+surprised.
+
+“With _who_?  Why, the runaway nigger, of course.  Who’d you reckon?”
+
+Tom looks at me very grave, and says:
+
+“Tom, didn’t you just tell me he was all right?  Hasn’t he got away?”
+
+“_Him_?” says Aunt Sally; “the runaway nigger?  ‘Deed he hasn’t.
+ They’ve got him back, safe and sound, and he’s in that cabin again,
+on bread and water, and loaded down with chains, till he’s claimed or
+sold!”
+
+Tom rose square up in bed, with his eye hot, and his nostrils opening
+and shutting like gills, and sings out to me:
+
+“They hain’t no _right_ to shut him up!  SHOVE!--and don’t you lose a
+minute.  Turn him loose! he ain’t no slave; he’s as free as any cretur
+that walks this earth!”
+
+“What _does_ the child mean?”
+
+“I mean every word I _say_, Aunt Sally, and if somebody don’t go, _I’ll_
+go. I’ve knowed him all his life, and so has Tom, there.  Old Miss
+Watson died two months ago, and she was ashamed she ever was going to
+sell him down the river, and _said_ so; and she set him free in her
+will.”
+
+“Then what on earth did _you_ want to set him free for, seeing he was
+already free?”
+
+“Well, that _is_ a question, I must say; and just like women!  Why,
+I wanted the _adventure_ of it; and I’d a waded neck-deep in blood
+to--goodness alive, _Aunt Polly!_”
+
+If she warn’t standing right there, just inside the door, looking as
+sweet and contented as an angel half full of pie, I wish I may never!
+
+Aunt Sally jumped for her, and most hugged the head off of her, and
+cried over her, and I found a good enough place for me under the bed,
+for it was getting pretty sultry for us, seemed to me.  And I peeped
+out, and in a little while Tom’s Aunt Polly shook herself loose and
+stood there looking across at Tom over her spectacles--kind of grinding
+him into the earth, you know.  And then she says:
+
+“Yes, you _better_ turn y’r head away--I would if I was you, Tom.”
+
+“Oh, deary me!” says Aunt Sally; “_Is_ he changed so?  Why, that ain’t
+_Tom_, it’s Sid; Tom’s--Tom’s--why, where is Tom?  He was here a minute
+ago.”
+
+“You mean where’s Huck _Finn_--that’s what you mean!  I reckon I hain’t
+raised such a scamp as my Tom all these years not to know him when I
+_see_ him.  That _would_ be a pretty howdy-do. Come out from under that
+bed, Huck Finn.”
+
+So I done it.  But not feeling brash.
+
+Aunt Sally she was one of the mixed-upest-looking persons I ever
+see--except one, and that was Uncle Silas, when he come in and they told
+it all to him.  It kind of made him drunk, as you may say, and he didn’t
+know nothing at all the rest of the day, and preached a prayer-meeting
+sermon that night that gave him a rattling ruputation, because the
+oldest man in the world couldn’t a understood it.  So Tom’s Aunt Polly,
+she told all about who I was, and what; and I had to up and tell how
+I was in such a tight place that when Mrs. Phelps took me for Tom
+Sawyer--she chipped in and says, “Oh, go on and call me Aunt Sally, I’m
+used to it now, and ‘tain’t no need to change”--that when Aunt Sally took
+me for Tom Sawyer I had to stand it--there warn’t no other way, and
+I knowed he wouldn’t mind, because it would be nuts for him, being
+a mystery, and he’d make an adventure out of it, and be perfectly
+satisfied.  And so it turned out, and he let on to be Sid, and made
+things as soft as he could for me.
+
+And his Aunt Polly she said Tom was right about old Miss Watson setting
+Jim free in her will; and so, sure enough, Tom Sawyer had gone and took
+all that trouble and bother to set a free nigger free! and I couldn’t
+ever understand before, until that minute and that talk, how he _could_
+help a body set a nigger free with his bringing-up.
+
+Well, Aunt Polly she said that when Aunt Sally wrote to her that Tom and
+_Sid_ had come all right and safe, she says to herself:
+
+“Look at that, now!  I might have expected it, letting him go off that
+way without anybody to watch him.  So now I got to go and trapse all
+the way down the river, eleven hundred mile, and find out what that
+creetur’s up to _this_ time, as long as I couldn’t seem to get any
+answer out of you about it.”
+
+“Why, I never heard nothing from you,” says Aunt Sally.
+
+“Well, I wonder!  Why, I wrote you twice to ask you what you could mean
+by Sid being here.”
+
+“Well, I never got ‘em, Sis.”
+
+Aunt Polly she turns around slow and severe, and says:
+
+“You, Tom!”
+
+“Well--_what_?” he says, kind of pettish.
+
+“Don’t you what _me_, you impudent thing--hand out them letters.”
+
+“What letters?”
+
+“_Them_ letters.  I be bound, if I have to take a-holt of you I’ll--”
+
+“They’re in the trunk.  There, now.  And they’re just the same as they
+was when I got them out of the office.  I hain’t looked into them, I
+hain’t touched them.  But I knowed they’d make trouble, and I thought if
+you warn’t in no hurry, I’d--”
+
+“Well, you _do_ need skinning, there ain’t no mistake about it.  And I
+wrote another one to tell you I was coming; and I s’pose he--”
+
+“No, it come yesterday; I hain’t read it yet, but _it’s_ all right, I’ve
+got that one.”
+
+I wanted to offer to bet two dollars she hadn’t, but I reckoned maybe it
+was just as safe to not to.  So I never said nothing.
+
+
+
+
+CHAPTER THE LAST
+
+THE first time I catched Tom private I asked him what was his idea, time
+of the evasion?--what it was he’d planned to do if the evasion worked all
+right and he managed to set a nigger free that was already free before?
+And he said, what he had planned in his head from the start, if we got
+Jim out all safe, was for us to run him down the river on the raft, and
+have adventures plumb to the mouth of the river, and then tell him about
+his being free, and take him back up home on a steamboat, in style,
+and pay him for his lost time, and write word ahead and get out all
+the niggers around, and have them waltz him into town with a torchlight
+procession and a brass-band, and then he would be a hero, and so would
+we.  But I reckoned it was about as well the way it was.
+
+We had Jim out of the chains in no time, and when Aunt Polly and Uncle
+Silas and Aunt Sally found out how good he helped the doctor nurse Tom,
+they made a heap of fuss over him, and fixed him up prime, and give him
+all he wanted to eat, and a good time, and nothing to do.  And we had
+him up to the sick-room, and had a high talk; and Tom give Jim forty
+dollars for being prisoner for us so patient, and doing it up so good,
+and Jim was pleased most to death, and busted out, and says:
+
+“Dah, now, Huck, what I tell you?--what I tell you up dah on Jackson
+islan’?  I _tole_ you I got a hairy breas’, en what’s de sign un it; en
+I _tole_ you I ben rich wunst, en gwineter to be rich _agin_; en it’s
+come true; en heah she is!  _dah_, now! doan’ talk to _me_--signs is
+_signs_, mine I tell you; en I knowed jis’ ‘s well ‘at I ‘uz gwineter be
+rich agin as I’s a-stannin’ heah dis minute!”
+
+And then Tom he talked along and talked along, and says, le’s all three
+slide out of here one of these nights and get an outfit, and go for
+howling adventures amongst the Injuns, over in the Territory, for a
+couple of weeks or two; and I says, all right, that suits me, but I
+ain’t got no money for to buy the outfit, and I reckon I couldn’t get
+none from home, because it’s likely pap’s been back before now, and got
+it all away from Judge Thatcher and drunk it up.
+
+“No, he hain’t,” Tom says; “it’s all there yet--six thousand dollars
+and more; and your pap hain’t ever been back since.  Hadn’t when I come
+away, anyhow.”
+
+Jim says, kind of solemn:
+
+“He ain’t a-comin’ back no mo’, Huck.”
+
+I says:
+
+“Why, Jim?”
+
+“Nemmine why, Huck--but he ain’t comin’ back no mo.”
+
+But I kept at him; so at last he says:
+
+“Doan’ you ‘member de house dat was float’n down de river, en dey wuz a
+man in dah, kivered up, en I went in en unkivered him and didn’ let you
+come in?  Well, den, you kin git yo’ money when you wants it, kase dat
+wuz him.”
+
+Tom’s most well now, and got his bullet around his neck on a watch-guard
+for a watch, and is always seeing what time it is, and so there ain’t
+nothing more to write about, and I am rotten glad of it, because if I’d
+a knowed what a trouble it was to make a book I wouldn’t a tackled it,
+and ain’t a-going to no more.  But I reckon I got to light out for the
+Territory ahead of the rest, because Aunt Sally she’s going to adopt me
+and sivilize me, and I can’t stand it.  I been there before.
+
+THE END. YOURS TRULY, _HUCK FINN_.
+
+
+
+
+
+End of the Project Gutenberg EBook of Adventures of Huckleberry Finn,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+***** This file should be named 76-0.htm or 76-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/76/
+
+Produced by David Widger. Previous editions produced by Ron Burkey and
+Internet Wiretap
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/source-sink-builder/src/main/resources/books/land-of-oz.txt
+++ b/jet/source-sink-builder/src/main/resources/books/land-of-oz.txt
@@ -1,0 +1,6638 @@
+﻿The Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+This eBook is for the use of anyone anywhere in the United States and most
+other parts of the world at no cost and with almost no restrictions
+whatsoever.  You may copy it, give it away or re-use it under the terms of
+the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org.  If you are not located in the United States, you'll have
+to check the laws of the country where you are located before using this ebook.
+
+Title: The Land of Oz
+
+Author: L. Frank Baum
+
+Illustrator: John Neill
+
+Release Date: December 30, 2016 [EBook #53844]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+
+
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+
+
+
+
+
+
+
+
+
+    The
+    Land of Oz
+
+    The Further Adventures of
+
+    A Sequel to
+    THE WIZARD OF OZ
+
+    by
+
+    L. Frank Baum
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration]
+
+The Famous Oz Books
+
+
+Since 1900 when L. Frank Baum introduced to the children of America
+THE WONDERFUL WIZARD OF OZ and all the other exciting characters who
+inhabit the land of Oz, these delightful fairy tales have stimulated
+the imagination of millions of young readers.
+
+These are stories which are genuine fantasy--creative, funny, tender,
+exciting and surprising. Filled with the rarest and most absurd
+creatures, each of the =14= volumes which now comprise the series, has
+been eagerly sought out by generation after generation until today they
+are known to all except the very young or those who were never young at
+all.
+
+When, in a recent survey, =The New York Times= polled a group of
+teenagers on the books they liked best when they were young, the Oz
+books topped the list.
+
+
+
+
+_THE FAMOUS OZ BOOKS_
+
+By L. Frank Baum:
+
+
+    THE WIZARD OF OZ
+    THE LAND OF OZ
+    OZMA OF OZ
+    DOROTHY AND THE WIZARD IN OZ
+    THE ROAD TO OZ
+    THE EMERALD CITY OF OZ
+    THE PATCHWORK GIRL OF OZ
+    TIK-TOK OF OZ
+    THE SCARECROW OF OZ
+    RINKITINK IN OZ
+    THE LOST PRINCESS OF OZ
+    THE TIN WOODMAN OF OZ
+    THE MAGIC OF OZ
+    GLINDA OF OZ
+
+
+    CHICAGO      THE REILLY & LEE CO.      _Publishers_
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration: TIP MANUFACTURES A PUMPKINHEAD]
+
+
+
+
+    The
+    Land of Oz
+
+    Being an account of the
+    further adventures of the
+
+    Scarecrow
+    and Tin Woodman
+
+    and also the strange experiences
+    of the Highly Magnified
+    Woggle-Bug, Jack Pumpkinhead,
+    the Animated Saw-Horse
+    and the Gump;
+    the story being
+
+    A Sequel _to_ The Wizard _of_ Oz
+
+    By
+
+    L. Frank Baum
+
+    Author of Father Goose--His Book; The Wizard of Oz; The Magical Monarch
+    of Mo; The Enchanted Isle of Yew, The Life and Adventures _of_
+    Santa Claus; Dot and Tot of Merryland etc., etc.
+
+    PICTURED BY
+
+    John R. Neill
+
+    CHICAGO
+
+    THE REILLY & LEE COMPANY
+
+
+
+
+[Illustration:
+
+    Copyright 1904
+
+    by
+
+    L. Frank Baum
+
+    All rights reserved
+]
+
+
+
+
+[Illustration:
+
+    Author's Note
+
+
+    After the publication of "The Wonderful Wizard of Oz" I began to
+    receive letters from children, telling me of their pleasure in
+    reading the story and asking me to "write something more" about the
+    Scarecrow and the Tin Woodman. At first I considered these little
+    letters, frank and earnest though they were, in the light of pretty
+    compliments; but the letters continued to come during succeeding
+    months, and even years.
+
+    Finally I promised one little girl, who made a long journey to
+    see me and prefer her request,--and she is a "Dorothy," by the
+    way--that when a thousand little girls had written me a thousand
+    little letters asking for another story of the Scarecrow and the
+    Tin Woodman, I would write the book. Either little Dorothy was a
+    fairy in disguise, and waved her magic wand, or the success of the
+    stage production of "The Wizard of Oz" made new friends for the
+    story. For the thousand letters reached their destination long
+    since--and many more followed them.
+
+    And now, although pleading guilty to a long delay, I have kept my
+    promise in this book.
+
+    L. FRANK BAUM.
+
+        Chicago, June, 1904.
+]
+
+
+
+
+[Illustration:
+
+    To those excellent good fellows and eminent comedians =David C.
+    Montgomery= and =Fred A. Stone= whose clever personations of the
+    Tin Woodman and the Scarecrow have delighted thousands of children
+    throughout the land, this book is gratefully dedicated
+                           by
+                       THE AUTHOR
+]
+
+
+
+
+[Illustration:
+
+    TIP.
+
+    JACK
+
+    MOMBI
+
+    SCARECROW
+
+    TIN WOODMAN
+
+    WOGGLE-BUG
+
+    GUMP
+]
+
+LIST OF CHAPTERS
+
+
+                                     PAGE
+
+    Tip Manufactures a Pumpkinhead            1
+    The Marvelous Powder of Life              9
+    The Flight of the Fugitives              23
+    Tip Makes an Experiment in Magic         33
+    The Awakening of the Saw-Horse           41
+    Jack Pumpkinhead's Ride                  53
+    His Majesty, the Scarecrow               65
+    General Jinjur's Army of Revolt          77
+    The Scarecrow Plans an Escape            91
+    The Journey to the Tin Woodman          103
+    A Nickel-Plated Emperor                 115
+    Mr. H. M. Woggle-Bug, T. E.             129
+    A Highly Magnified History              141
+    Old Mombi Indulges in Witchcraft        153
+    The Prisoners of the Queen              163
+    The Scarecrow Takes Time to Think       175
+    The Astonishing Flight of the Gump      185
+    In the Jackdaws' Nest                   195
+    Dr. Nikidik's Famous Wishing Pills      213
+    The Scarecrow Appeals to Glinda         225
+    The Tin Woodman Plucks a Rose           241
+    The Transformation of Old Mombi         251
+    Princess Ozma of Oz                     259
+    The Riches of Content                   273
+
+[Illustration]
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Manufactures
+    a Pumpkinhead
+]
+
+
+In the Country of the Gillikins, which is at the North of the Land of
+Oz, lived a youth called Tip. There was more to his name than that, for
+old Mombi often declared that his whole name was Tippetarius; but no
+one was expected to say such a long word when "Tip" would do just as
+well.
+
+This boy remembered nothing of his parents, for he had been brought
+when quite young to be reared by the old woman known as Mombi, whose
+reputation, I am sorry to say, was none of the best. For the Gillikin
+people had reason to suspect her of indulging in magical arts, and
+therefore hesitated to associate with her.
+
+Mombi was not exactly a Witch, because the Good Witch who ruled that
+part of the Land of Oz had forbidden any other Witch to exist in her
+dominions. So Tip's guardian, however much she might aspire to working
+magic, realized it was unlawful to be more than a Sorceress, or at most
+a Wizardess.
+
+[Illustration]
+
+Tip was made to carry wood from the forest, that the old woman might
+boil her pot. He also worked in the corn-fields, hoeing and husking;
+and he fed the pigs and milked the four-horned cow that was Mombi's
+especial pride.
+
+But you must not suppose he worked all the time, for he felt that
+would be bad for him. When sent to the forest Tip often climbed trees
+for birds' eggs or amused himself chasing the fleet white rabbits or
+fishing in the brooks with bent pins. Then he would hastily gather
+his armful of wood and carry it home. And when he was supposed to be
+working in the corn-fields, and the tall stalks hid him from Mombi's
+view, Tip would often dig in the gopher holes, or--if the mood seized
+him--lie upon his back between the rows of corn and take a nap. So, by
+taking care not to exhaust his strength, he grew as strong and rugged
+as a boy may be.
+
+Mombi's curious magic often frightened her neighbors, and they treated
+her shyly, yet respectfully, because of her weird powers. But Tip
+frankly hated her, and took no pains to hide his feelings. Indeed, he
+sometimes showed less respect for the old woman than he should have
+done, considering she was his guardian.
+
+[Illustration]
+
+There were pumpkins in Mombi's corn-fields, lying golden red among the
+rows of green stalks; and these had been planted and carefully tended
+that the four-horned cow might eat of them in the winter time. But one
+day, after the corn had all been cut and stacked, and Tip was carrying
+the pumpkins to the stable, he took a notion to make a "Jack Lantern"
+and try to give the old woman a fright with it.
+
+So he selected a fine, big pumpkin--one with a lustrous, orange-red
+color--and began carving it. With the point of his knife he made two
+round eyes, a three-cornered nose, and a mouth shaped like a new moon.
+The face, when completed, could not have been considered strictly
+beautiful; but it wore a smile so big and broad, and was so jolly in
+expression, that even Tip laughed as he looked admiringly at his work.
+
+The child had no playmates, so he did not know that boys often dig
+out the inside of a "pumpkin-jack," and in the space thus made put a
+lighted candle to render the face more startling; but he conceived an
+idea of his own that promised to be quite as effective. He decided to
+manufacture the form of a man, who would wear this pumpkin head, and to
+stand it in a place where old Mombi would meet it face to face.
+
+"And then," said Tip to himself, with a laugh, "she'll squeal louder
+than the brown pig does when I pull her tail, and shiver with fright
+worse than I did last year when I had the ague!"
+
+He had plenty of time to accomplish this task, for Mombi had gone to a
+village--to buy groceries, she said--and it was a journey of at least
+two days.
+
+So he took his axe to the forest, and selected some stout, straight
+saplings, which he cut down and trimmed of all their twigs and leaves.
+From these he would make the arms, and legs, and feet of his man. For
+the body he stripped a sheet of thick bark from around a big tree, and
+with much labor fashioned it into a cylinder of about the right size,
+pinning the edges together with wooden pegs. Then, whistling happily as
+he worked, he carefully jointed the limbs and fastened them to the body
+with pegs whittled into shape with his knife.
+
+By the time this feat had been accomplished it began to grow dark, and
+Tip remembered he must milk the cow and feed the pigs. So he picked up
+his wooden man and carried it back to the house with him.
+
+During the evening, by the light of the fire in the kitchen, Tip
+carefully rounded all the edges of the joints and smoothed the rough
+places in a neat and workmanlike manner. Then he stood the figure up
+against the wall and admired it. It seemed remarkably tall, even for a
+full-grown man; but that was a good point in a small boy's eyes, and
+Tip did not object at all to the size of his creation.
+
+Next morning, when he looked at his work again, Tip saw he had
+forgotten to give the dummy a neck, by means of which he might fasten
+the pumpkinhead to the body. So he went again to the forest, which was
+not far away, and chopped from a tree several pieces of wood with which
+to complete his work. When he returned he fastened a cross-piece to
+the upper end of the body, making a hole through the center to hold
+upright the neck. The bit of wood which formed this neck was also
+sharpened at the upper end, and when all was ready Tip put on the
+pumpkin head, pressing it well down onto the neck, and found that it
+fitted very well. The head could be turned to one side or the other, as
+he pleased, and the hinges of the arms and legs allowed him to place
+the dummy in any position he desired.
+
+"Now, that," declared Tip, proudly, "is really a very fine man, and it
+ought to frighten several screeches out of old Mombi! But it would be
+much more lifelike if it were properly dressed."
+
+To find clothing seemed no easy task; but Tip boldly ransacked the
+great chest in which Mombi kept all her keepsakes and treasures, and
+at the very bottom he discovered some purple trousers, a red shirt
+and a pink vest which was dotted with white spots. These he carried
+away to his man and succeeded, although the garments did not fit very
+well, in dressing the creature in a jaunty fashion. Some knit stockings
+belonging to Mombi and a much worn pair of his own shoes completed the
+man's apparel, and Tip was so delighted that he danced up and down and
+laughed aloud in boyish ecstasy.
+
+"I must give him a name!" he cried. "So good a man as this must surely
+have a name. I believe," he added, after a moment's thought, "I will
+name the fellow 'Jack Pumpkinhead!'"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Marvelous
+    Powder of Life
+]
+
+
+After considering the matter carefully, Tip decided that the best
+place to locate Jack would be at the bend in the road, a little way
+from the house. So he started to carry his man there, but found him
+heavy and rather awkward to handle. After dragging the creature a short
+distance Tip stood him on his feet, and by first bending the joints of
+one leg, and then those of the other,--at the same time pushing from
+behind,--the boy managed to induce Jack to walk to the bend in the
+road. It was not accomplished without a few tumbles, and Tip really
+worked harder than he ever had in the fields or forest; but a love of
+mischief urged him on, and it pleased him to test the cleverness of his
+workmanship.
+
+"Jack's all right, and works fine!" he said to himself, panting with
+the unusual exertion. But just then he discovered the man's left
+arm had fallen off in the journey; so he went back to find it, and
+afterward, by whittling a new and stouter pin for the shoulder-joint,
+he repaired the injury so successfully that the arm was stronger than
+before. Tip also noticed that Jack's pumpkin head had twisted around
+until it faced his back; but this was easily remedied. When, at last,
+the man was set up facing the turn in the path where old Mombi was to
+appear, he looked natural enough to be a fair imitation of a Gillikin
+farmer,--and unnatural enough to startle anyone that came on him
+unawares.
+
+As it was yet too early in the day to expect the old woman to return
+home, Tip went down into the valley below the farm-house and began to
+gather nuts from the trees that grew there.
+
+However, old Mombi returned earlier than usual. She had met a crooked
+wizard who resided in a lonely cave in the mountains, and had traded
+several important secrets of magic with him. Having in this way
+secured three new recipes, four magical powders and a selection of
+herbs of wonderful power and potency, she hobbled home as fast as she
+could, in order to test her new sorceries.
+
+So intent was Mombi on the treasures she had gained that when she
+turned the bend in the road and caught a glimpse of the man, she merely
+nodded and said:
+
+"Good evening, sir."
+
+But, a moment after, noting that the person did not move or reply,
+she cast a shrewd glance into his face and discovered his pumpkin
+head--elaborately carved by Tip's jack-knife.
+
+"Heh!" ejaculated Mombi, giving a sort of grunt; "that rascally boy
+has been playing tricks again! Very good! ve--ry _good_! I'll beat him
+black-and-blue for trying to scare me in this fashion!"
+
+Angrily she raised her stick to smash in the grinning pumpkin head of
+the dummy; but a sudden thought made her pause, the uplifted stick left
+motionless in the air.
+
+"Why, here is a good chance to try my new powder!" said she, eagerly.
+"And then I can tell whether that crooked wizard has fairly traded
+secrets, or whether he has fooled me as wickedly as I fooled him."
+
+So she set down her basket and began fumbling in it for one of the
+precious powders she had obtained.
+
+While Mombi was thus occupied Tip strolled back, with his pockets full
+of nuts, and discovered the old woman standing beside his man and
+apparently not the least bit frightened by it.
+
+At first he was greatly disappointed; but the next moment he became
+curious to know what Mombi was going to do. So he hid behind a hedge,
+where he could see without being seen, and prepared to watch.
+
+After some search the woman drew from her basket an old pepper-box,
+upon the faded label of which the wizard had written with a
+lead-pencil: "Powder of Life."
+
+"Ah--here it is!" she cried, joyfully. "And now let us see if it is
+potent. The stingy wizard didn't give me much of it, but I guess
+there's enough for two or three doses."
+
+[Illustration: "OLD MOMBI DANCED AROUND HIM"]
+
+Tip was much surprised when he overheard this speech. Then he saw old
+Mombi raise her arm and sprinkle the powder from the box over the
+pumpkin head of his man Jack. She did this in the same way one would
+pepper a baked potato, and the powder sifted down from Jack's head and
+scattered over the red shirt and pink waistcoat and purple trousers
+Tip had dressed him in, and a portion even fell upon the patched and
+worn shoes.
+
+Then, putting the pepper-box back into the basket, Mombi lifted her
+left hand, with its little finger pointed upward, and said:
+
+"Weaugh!"
+
+Then she lifted her right hand, with the thumb pointed upward, and said:
+
+"Teaugh!"
+
+Then she lifted both hands, with all the fingers and thumbs spread out,
+and cried:
+
+"Peaugh!"
+
+Jack Pumpkinhead stepped back a pace, at this, and said in a
+reproachful voice:
+
+"Don't yell like that! Do you think I'm deaf?"
+
+Old Mombi danced around him, frantic with delight.
+
+"He lives!" she screamed: "he lives! he lives!"
+
+Then she threw her stick into the air and caught it as it came down;
+and she hugged herself with both arms, and tried to do a step of a jig;
+and all the time she repeated, rapturously:
+
+"He lives!--he lives!--he lives!"
+
+Now you may well suppose that Tip observed all this with amazement.
+
+At first he was so frightened and horrified that he wanted to run
+away, but his legs trembled and shook so badly that he couldn't.
+Then it struck him as a very funny thing for Jack to come to life,
+especially as the expression on his pumpkin face was so droll and
+comical it excited laughter on the instant. So, recovering from his
+first fear, Tip began to laugh; and the merry peals reached old Mombi's
+ears and made her hobble quickly to the hedge, where she seized Tip's
+collar and dragged him back to where she had left her basket and the
+pumpkin-headed man.
+
+"You naughty, sneaking, wicked boy!" she exclaimed, furiously; "I'll
+teach you to spy out my secrets and to make fun of me!"
+
+"I wasn't making fun of you," protested Tip. "I was laughing at old
+Pumpkinhead! Look at him! Isn't he a picture, though?"
+
+"I hope you are not reflecting on my personal appearance," said Jack;
+and it was so funny to hear his grave voice, while his face continued
+to wear its jolly smile, that Tip again burst into a peal of laughter.
+
+Even Mombi was not without a curious interest in the man her magic had
+brought to life; for, after staring at him intently, she presently
+asked:
+
+[Illustration: OLD MOMBI PUTS JACK IN THE STABLE]
+
+"What do you know?"
+
+"Well, that is hard to tell," replied Jack. "For although I feel that
+I know a tremendous lot, I am not yet aware how much there is in the
+world to find out about. It will take me a little time to discover
+whether I am very wise or very foolish."
+
+"To be sure," said Mombi, thoughtfully.
+
+"But what are you going to do with him, now he is alive?" asked Tip,
+wondering.
+
+"I must think it over," answered Mombi. "But we must get home at once,
+for it is growing dark. Help the Pumpkinhead to walk."
+
+"Never mind me," said Jack; "I can walk as well as you can. Haven't I
+got legs and feet, and aren't they jointed?"
+
+"Are they?" asked the woman, turning to Tip.
+
+"Of course they are; I made 'em myself," returned the boy, with pride.
+
+So they started for the house; but when they reached the farm yard old
+Mombi led the pumpkin man to the cow stable and shut him up in an empty
+stall, fastening the door securely on the outside.
+
+"I've got to attend to you, first," she said, nodding her head at Tip.
+
+Hearing this, the boy became uneasy; for he knew Mombi had a bad and
+revengeful heart, and would not hesitate to do any evil thing.
+
+They entered the house. It was a round, dome-shaped structure, as are
+nearly all the farm houses in the Land of Oz.
+
+Mombi bade the boy light a candle, while she put her basket in a
+cupboard and hung her cloak on a peg. Tip obeyed quickly, for he was
+afraid of her.
+
+After the candle had been lighted Mombi ordered him to build a fire
+in the hearth, and while Tip was thus engaged the old woman ate her
+supper. When the flames began to crackle the boy came to her and asked
+a share of the bread and cheese; but Mombi refused him.
+
+"I'm hungry!" said Tip, in a sulky tone.
+
+"You won't be hungry long," replied Mombi, with a grim look.
+
+The boy didn't like this speech, for it sounded like a threat; but he
+happened to remember he had nuts in his pocket, so he cracked some of
+those and ate them while the woman rose, shook the crumbs from her
+apron, and hung above the fire a small black kettle.
+
+Then she measured out equal parts of milk and vinegar and poured them
+into the kettle. Next she produced several packets of herbs and
+powders and began adding a portion of each to the contents of the
+kettle. Occasionally she would draw near the candle and read from a
+yellow paper the recipe of the mess she was concocting.
+
+As Tip watched her his uneasiness increased.
+
+"What is that for?" he asked.
+
+"For you," returned Mombi, briefly.
+
+Tip wriggled around upon his stool and stared awhile at the kettle,
+which was beginning to bubble. Then he would glance at the stern and
+wrinkled features of the witch and wish he were any place but in that
+dim and smoky kitchen, where even the shadows cast by the candle upon
+the wall were enough to give one the horrors. So an hour passed away,
+during which the silence was only broken by the bubbling of the pot and
+the hissing of the flames.
+
+Finally, Tip spoke again.
+
+"Have I got to drink that stuff?" he asked, nodding toward the pot.
+
+"Yes," said Mombi.
+
+"What'll it do to me?" asked Tip.
+
+"If it's properly made," replied Mombi, "it will change or transform
+you into a marble statue."
+
+Tip groaned, and wiped the perspiration from his forehead with his
+sleeve.
+
+"I don't want to be a marble statue!" he protested.
+
+"That doesn't matter; I want you to be one," said the old woman,
+looking at him severely.
+
+"What use'll I be then?" asked Tip. "There won't be any one to work for
+you."
+
+"I'll make the Pumpkinhead work for me," said Mombi.
+
+Again Tip groaned.
+
+"Why don't you change me into a goat, or a chicken?" he asked,
+anxiously. "You can't do anything with a marble statue."
+
+"Oh, yes; I can," returned Mombi. "I'm going to plant a flower garden,
+next Spring, and I'll put you in the middle of it, for an ornament. I
+wonder I haven't thought of that before; you've been a bother to me for
+years."
+
+At this terrible speech Tip felt the beads of perspiration starting all
+over his body; but he sat still and shivered and looked anxiously at
+the kettle.
+
+"Perhaps it won't work," he muttered, in a voice that sounded weak and
+discouraged.
+
+"Oh, I think it will," answered Mombi, cheerfully. "I seldom make a
+mistake."
+
+Again there was a period of silence--a silence so long and gloomy that
+when Mombi finally lifted the kettle from the fire it was close to
+midnight.
+
+[Illustration: "I DON'T WANT TO BE A MARBLE STATUE."]
+
+"You cannot drink it until it has become quite cold," announced the
+old witch--for in spite of the law she had acknowledged practising
+witchcraft. "We must both go to bed now, and at daybreak I will call
+you and at once complete your transformation into a marble statue."
+
+With this she hobbled into her room, bearing the steaming kettle with
+her, and Tip heard her close and lock the door.
+
+The boy did not go to bed, as he had been commanded to do, but still
+sat glaring at the embers of the dying fire.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Flight of the
+    Fugitives
+]
+
+
+Tip reflected.
+
+"It's a hard thing, to be a marble statue," he thought, rebelliously,
+"and I'm not going to stand it. For years I've been a bother to her,
+she says; so she's going to get rid of me. Well, there's an easier way
+than to become a statue. No boy could have any fun forever standing in
+the middle of a flower garden! I'll run away, that's what I'll do--and
+I may as well go before she makes me drink that nasty stuff in the
+kettle."
+
+He waited until the snores of the old witch announced she was fast
+asleep, and then he arose softly and went to the cupboard to find
+something to eat.
+
+"No use starting on a journey without food," he decided, searching upon
+the narrow shelves.
+
+He found some crusts of bread; but he had to look into Mombi's basket
+to find the cheese she had brought from the village. While turning over
+the contents of the basket he came upon the pepper-box which contained
+the "Powder of Life."
+
+"I may as well take this with me," he thought, "or Mombi'll be using it
+to make more mischief with." So he put the box in his pocket, together
+with the bread and cheese.
+
+Then he cautiously left the house and latched the door behind him.
+Outside both moon and stars shone brightly, and the night seemed
+peaceful and inviting after the close and ill-smelling kitchen.
+
+"I'll be glad to get away," said Tip, softly; "for I never did like
+that old woman. I wonder how I ever came to live with her."
+
+He was walking slowly toward the road when a thought made him pause.
+
+"I don't like to leave Jack Pumpkinhead to the tender mercies of old
+Mombi," he muttered. "And Jack belongs to me, for I made him--even if
+the old witch did bring him to life."
+
+He retraced his steps to the cow-stable and opened the door of the
+stall where the pumpkin-headed man had been left.
+
+[Illustration: "TIP LED HIM ALONG THE PATH."]
+
+Jack was standing in the middle of the stall, and by the moonlight Tip
+could see he was smiling just as jovially as ever.
+
+"Come on!" said the boy, beckoning.
+
+"Where to?" asked Jack.
+
+"You'll know as soon as I do," answered Tip, smiling sympathetically
+into the pumpkin face. "All we've got to do now is to tramp."
+
+"Very well," returned Jack, and walked awkwardly out of the stable and
+into the moonlight.
+
+Tip turned toward the road and the man followed him. Jack walked with a
+sort of limp, and occasionally one of the joints of his legs would turn
+backward, instead of frontwise, almost causing him to tumble. But the
+Pumpkinhead was quick to notice this, and began to take more pains to
+step carefully; so that he met with few accidents.
+
+Tip led him along the path without stopping an instant. They could not
+go very fast, but they walked steadily; and by the time the moon sank
+away and the sun peeped over the hills they had travelled so great a
+distance that the boy had no reason to fear pursuit from the old witch.
+Moreover, he had turned first into one path, and then into another, so
+that should anyone follow them it would prove very difficult to guess
+which way they had gone, or where to seek them.
+
+[Illustration]
+
+Fairly satisfied that he had escaped--for a time, at least--being
+turned into a marble statue, the boy stopped his companion and seated
+himself upon a rock by the roadside.
+
+"Let's have some breakfast," he said.
+
+Jack Pumpkinhead watched Tip curiously, but refused to join in the
+repast.
+
+"I don't seem to be made the same way you are," he said.
+
+"I know you are not," returned Tip; "for I made you."
+
+"Oh! Did you?" asked Jack.
+
+"Certainly. And put you together. And carved your eyes and nose and
+ears and mouth," said Tip proudly. "And dressed you."
+
+Jack looked at his body and limbs critically.
+
+"It strikes me you made a very good job of it," he remarked.
+
+"Just so-so," replied Tip, modestly; for he began to see certain
+defects in the construction of his man. "If I'd known we were going to
+travel together I might have been a little more particular."
+
+"Why, then," said the Pumpkinhead, in a tone that expressed surprise,
+"you must be my creator--my parent--my father!"
+
+"Or your inventor," replied the boy with a laugh. "Yes, my son; I
+really believe I am!"
+
+"Then I owe you obedience," continued the man, "and you owe
+me--support."
+
+"That's it, exactly," declared Tip, jumping up. "So let us be off."
+
+"Where are we going?" asked Jack, when they had resumed their journey.
+
+"I'm not exactly sure," said the boy; "but I believe we are headed
+South, and that will bring us, sooner or later, to the Emerald City."
+
+"What city is that?" enquired the Pumpkinhead.
+
+"Why, it's the center of the Land of Oz, and the biggest town in all
+the country. I've never been there, myself, but I've heard all about
+its history. It was built by a mighty and wonderful Wizard named Oz,
+and everything there is of a green color--just as everything in this
+Country of the Gillikins is of a purple color."
+
+"Is everything here purple?" asked Jack.
+
+"Of course it is. Can't you see?" returned the boy.
+
+"I believe I must be color-blind," said the Pumpkinhead, after staring
+about him.
+
+"Well, the grass is purple, and the trees are purple, and the houses
+and fences are purple," explained Tip. "Even the mud in the roads is
+purple. But in the Emerald City everything is green that is purple
+here. And in the Country of the Munchkins, over at the East, everything
+is blue; and in the South country of the Quadlings everything is red;
+and in the West country of the Winkies, where the Tin Woodman rules,
+everything is yellow."
+
+"Oh!" said Jack. Then, after a pause, he asked: "Did you say a Tin
+Woodman rules the Winkies?"
+
+"Yes; he was one of those who helped Dorothy to destroy the Wicked
+Witch of the West, and the Winkies were so grateful that they invited
+him to become their ruler,--just as the people of the Emerald City
+invited the Scarecrow to rule them."
+
+"Dear me!" said Jack. "I'm getting confused with all this history. Who
+is the Scarecrow?"
+
+"Another friend of Dorothy's," replied Tip.
+
+"And who is Dorothy?"
+
+"She was a girl that came here from Kansas, a place in the big, outside
+World. She got blown to the Land of Oz by a cyclone, and while she was
+here the Scarecrow and the Tin Woodman accompanied her on her travels."
+
+"And where is she now?" inquired the Pumpkinhead.
+
+"Glinda the Good, who rules the Quadlings, sent her home again," said
+the boy.
+
+"Oh. And what became of the Scarecrow?"
+
+"I told you. He rules the Emerald City," answered Tip.
+
+"I thought you said it was ruled by a wonderful Wizard," objected Jack,
+seeming more and more confused.
+
+"Well, so I did. Now, pay attention, and I'll explain it," said Tip,
+speaking slowly and looking the smiling Pumpkinhead squarely in the
+eye. "Dorothy went to the Emerald City to ask the Wizard to send her
+back to Kansas; and the Scarecrow and the Tin Woodman went with her.
+But the Wizard couldn't send her back, because he wasn't so much of a
+Wizard as he might have been. And then they got angry at the Wizard,
+and threatened to expose him; so the Wizard made a big balloon and
+escaped in it, and no one has ever seen him since."
+
+"Now, that is very interesting history," said Jack, well pleased; "and
+I understand it perfectly--all but the explanation."
+
+"I'm glad you do," responded Tip. "After the Wizard was gone, the
+people of the Emerald City made His Majesty, the Scarecrow, their King;
+and I have heard that he became a very popular ruler."
+
+"Are we going to see this queer King?" asked Jack, with interest.
+
+"I think we may as well," replied the boy; "unless you have something
+better to do."
+
+"Oh, no, dear father," said the Pumpkinhead. "I am quite willing to go
+wherever you please."
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Makes an
+    Experiment in Magic
+]
+
+
+The boy, small and rather delicate in appearance, seemed somewhat
+embarrassed at being called "father" by the tall, awkward,
+pumpkin-headed man; but to deny the relationship would involve another
+long and tedious explanation; so he changed the subject by asking,
+abruptly:
+
+"Are you tired?"
+
+"Of course not!" replied the other. "But," he continued, after a pause,
+"it is quite certain I shall wear out my wooden joints if I keep on
+walking."
+
+Tip reflected, as they journeyed on, that this was true. He began to
+regret that he had not constructed the wooden limbs more carefully and
+substantially. Yet how could he ever have guessed that the man he had
+made merely to scare old Mombi with would be brought to life by means
+of a magical powder contained in an old pepper-box?
+
+So he ceased to reproach himself, and began to think how he might yet
+remedy the deficiencies of Jack's weak joints.
+
+While thus engaged they came to the edge of a wood, and the boy sat
+down to rest upon an old saw-horse that some woodcutter had left there.
+
+[Illustration]
+
+"Why don't you sit down?" he asked the Pumpkinhead.
+
+"Won't it strain my joints?" inquired the other.
+
+"Of course not. It'll rest them," declared the boy.
+
+So Jack tried to sit down; but as soon as he bent his joints farther
+than usual they gave way altogether, and he came clattering to the
+ground with such a crash that Tip feared he was entirely ruined.
+
+He rushed to the man, lifted him to his feet, straightened his arms and
+legs, and felt of his head to see if by chance it had become cracked.
+But Jack seemed to be in pretty good shape, after all, and Tip said to
+him:
+
+"I guess you'd better remain standing, hereafter. It seems the safest
+way."
+
+"Very well, dear father; just as you say," replied the smiling Jack,
+who had been in no wise confused by his tumble.
+
+Tip sat down again. Presently the Pumpkinhead asked:
+
+"What is that thing you are sitting on?"
+
+"Oh, this is a horse," replied the boy, carelessly.
+
+"What is a horse?" demanded Jack.
+
+"A horse? Why, there are two kinds of horses," returned Tip, slightly
+puzzled how to explain. "One kind of horse is alive, and has four legs
+and a head and a tail. And people ride upon its back."
+
+"I understand," said Jack, cheerfully. "That's the kind of horse you
+are now sitting on."
+
+"No, it isn't," answered Tip, promptly.
+
+"Why not? That one has four legs, and a head, and a tail."
+
+Tip looked at the saw-horse more carefully, and found that the
+Pumpkinhead was right. The body had been formed from a tree-trunk, and
+a branch had been left sticking up at one end that looked very much
+like a tail. In the other end were two big knots that resembled eyes,
+and a place had been chopped away that might easily be mistaken for the
+horse's mouth. As for the legs, they were four straight limbs cut from
+trees and stuck fast into the body, being spread wide apart so that the
+saw-horse would stand firmly when a log was laid across it to be sawed.
+
+"This thing resembles a real horse more than I imagined," said Tip,
+trying to explain. "But a real horse is alive, and trots and prances
+and eats oats, while this is nothing more than a dead horse, made of
+wood, and used to saw logs upon."
+
+"If it were alive, wouldn't it trot, and prance, and eat oats?"
+inquired the Pumpkinhead.
+
+"It would trot and prance, perhaps; but it wouldn't eat oats," replied
+the boy, laughing at the idea. "And of course it can't ever be alive,
+because it is made of wood."
+
+"So am I," answered the man.
+
+Tip looked at him in surprise.
+
+"Why, so you are!" he exclaimed. "And the magic powder that brought you
+to life is here in my pocket."
+
+[Illustration: THE MAGICAL POWDER OF LIFE]
+
+He brought out the pepper box, and eyed it curiously.
+
+"I wonder," said he, musingly, "if it would bring the saw-horse to
+life."
+
+"If it would," returned Jack, calmly--for nothing seemed to surprise
+him--"I could ride on its back, and that would save my joints from
+wearing out."
+
+"I'll try it!" cried the boy, jumping up. "But I wonder if I can
+remember the words old Mombi said, and the way she held her hands up."
+
+He thought it over for a minute, and as he had watched carefully from
+the hedge every motion of the old witch, and listened to her words, he
+believed he could repeat exactly what she had said and done.
+
+So he began by sprinkling some of the magic Powder of Life from the
+pepper-box upon the body of the saw-horse. Then he lifted his left
+hand, with the little finger pointing upward, and said "Weaugh!"
+
+"What does that mean, dear father?" asked Jack, curiously.
+
+"I don't know," answered Tip. Then he lifted his right hand, with the
+thumb pointing upward, and said: "Teaugh!"
+
+"What's that, dear father?" inquired Jack.
+
+"It means you must keep quiet!" replied the boy, provoked at being
+interrupted at so important a moment.
+
+"How fast I am learning!" remarked the Pumpkinhead, with his eternal
+smile.
+
+Tip now lifted both hands above his head, with all the fingers and
+thumbs spread out, and cried in a loud voice: "Peaugh!"
+
+Immediately the saw-horse moved, stretched its legs, yawned with its
+chopped-out mouth, and shook a few grains of the powder off its back.
+The rest of the powder seemed to have vanished into the body of the
+horse.
+
+"Good!" called Jack, while the boy looked on in astonishment. "You are
+a very clever sorcerer, dear father!"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Awakening
+    of the Saw-Horse
+]
+
+
+The Saw-Horse, finding himself alive, seemed even more astonished
+than Tip. He rolled his knotty eyes from side to side, taking a first
+wondering view of the world in which he had now so important an
+existence. Then he tried to look at himself; but he had, indeed, no
+neck to turn; so that in the endeavor to see his body he kept circling
+around and around, without catching even a glimpse of it. His legs
+were stiff and awkward, for there were no knee-joints in them; so that
+presently he bumped against Jack Pumpkinhead and sent that personage
+tumbling upon the moss that lined the roadside.
+
+Tip became alarmed at this accident, as well as at the persistence of
+the Saw-Horse in prancing around in a circle; so he called out:
+
+"Whoa! Whoa, there!"
+
+The Saw-Horse paid no attention whatever to this command, and the next
+instant brought one of his wooden legs down upon Tip's foot so forcibly
+that the boy danced away in pain to a safer distance, from where he
+again yelled:
+
+"Whoa! Whoa, I say!"
+
+Jack had now managed to raise himself to a sitting position, and he
+looked at the Saw-Horse with much interest.
+
+"I don't believe the animal can hear you," he remarked.
+
+"I shout loud enough, don't I?" answered Tip, angrily.
+
+"Yes; but the horse has no ears," said the smiling Pumpkinhead.
+
+"Sure enough!" exclaimed Tip, noting the fact for the first time. "How,
+then, am I going to stop him?"
+
+But at that instant the Saw-Horse stopped himself, having concluded it
+was impossible to see his own body. He saw Tip, however, and came close
+to the boy to observe him more fully.
+
+It was really comical to see the creature walk; for it moved the legs
+on its right side together, and those on its left side together, as a
+pacing horse does; and that made its body rock sidewise, like a cradle.
+
+Tip patted it upon the head, and said "Good boy! Good boy!" in a
+coaxing tone; and the Saw-Horse pranced away to examine with its
+bulging eyes the form of Jack Pumpkinhead.
+
+"I must find a halter for him," said Tip; and having made a search
+in his pocket he produced a roll of strong cord. Unwinding this,
+he approached the Saw-Horse and tied the cord around its neck,
+afterward fastening the other end to a large tree. The Saw-Horse, not
+understanding the action, stepped backward and snapped the string
+easily; but it made no attempt to run away.
+
+"He's stronger than I thought," said the boy, "and rather obstinate,
+too."
+
+"Why don't you make him some ears?" asked Jack. "Then you can tell him
+what to do."
+
+"That's a splendid idea!" said Tip. "How did you happen to think of it?"
+
+"Why, I didn't think of it," answered the Pumpkinhead; "I didn't need
+to, for it's the simplest and easiest thing to do."
+
+So Tip got out his knife and fashioned some ears out of the bark of a
+small tree.
+
+"I mustn't make them too big," he said, as he whittled, "or our horse
+would become a donkey."
+
+"How is that?" inquired Jack, from the roadside.
+
+"Why, a horse has bigger ears than a man; and a donkey has bigger ears
+than a horse," explained Tip.
+
+"Then, if my ears were longer, would I be a horse?" asked Jack.
+
+"My friend," said Tip, gravely, "you'll never be anything but a
+Pumpkinhead, no matter how big your ears are."
+
+"Oh," returned Jack, nodding; "I think I understand."
+
+"If you do, you're a wonder," remarked the boy; "but there's no harm in
+_thinking_ you understand. I guess these ears are ready now. Will you
+hold the horse while I stick them on?"
+
+"Certainly, if you'll help me up," said Jack.
+
+So Tip raised him to his feet, and the Pumpkinhead went to the horse
+and held its head while the boy bored two holes in it with his
+knife-blade and inserted the ears.
+
+"They make him look very handsome," said Jack, admiringly.
+
+But those words, spoken close to the Saw-Horse, and being the first
+sounds he had ever heard, so startled the animal that he made a bound
+forward and tumbled Tip on one side and Jack on the other. Then he
+continued to rush forward as if frightened by the clatter of his own
+footsteps.
+
+"Whoa!" shouted Tip, picking himself up; "whoa! you idiot--whoa!"
+
+The Saw-Horse would probably have paid no attention to this, but just
+then it stepped a leg into a gopher-hole and stumbled head-over-heels
+to the ground, where it lay upon its back, frantically waving its four
+legs in the air.
+
+Tip ran up to it.
+
+"You're a nice sort of a horse, I must say!" he exclaimed. "Why didn't
+you stop when I yelled 'whoa?'"
+
+"Does 'whoa' mean to stop?" asked the Saw-Horse, in a surprised voice,
+as it rolled its eyes upward to look at the boy.
+
+"Of course it does," answered Tip.
+
+"And a hole in the ground means to stop, also, doesn't it?" continued
+the horse.
+
+"To be sure; unless you step over it," said Tip.
+
+"What a strange place this is," the creature exclaimed, as if amazed.
+"What am I doing here, anyway?"
+
+[Illustration: "DO KEEP THOSE LEGS STILL."]
+
+"Why, I've brought you to life," answered the boy; "but it won't hurt
+you any, if you mind me and do as I tell you."
+
+"Then I will do as you tell me," replied the Saw-Horse, humbly. "But
+what happened to me, a moment ago? I don't seem to be just right,
+someway."
+
+"You're upside down," explained Tip. "But just keep those legs still a
+minute and I'll set you right side up again."
+
+"How many sides have I?" asked the creature, wonderingly.
+
+"Several," said Tip, briefly. "But do keep those legs still."
+
+The Saw-Horse now became quiet, and held its legs rigid; so that Tip,
+after several efforts, was able to roll him over and set him upright.
+
+"Ah, I seem all right now," said the queer animal, with a sigh.
+
+"One of your ears is broken," Tip announced, after a careful
+examination. "I'll have to make a new one."
+
+Then he led the Saw-Horse back to where Jack was vainly struggling to
+regain his feet, and after assisting the Pumpkinhead to stand upright
+Tip whittled out a new ear and fastened it to the horse's head.
+
+"Now," said he, addressing his steed, "pay attention to what I'm going
+to tell you. 'Whoa!' means to stop; 'Get-Up!' means to walk forward;
+'Trot!' means to go as fast as you can. Understand?"
+
+"I believe I do," returned the horse.
+
+"Very good. We are all going on a journey to the Emerald City, to see
+His Majesty, the Scarecrow; and Jack Pumpkinhead is going to ride on
+your back, so he won't wear out his joints."
+
+"I don't mind," said the Saw-Horse. "Anything that suits you suits me."
+
+Then Tip assisted Jack to get upon the horse.
+
+"Hold on tight," he cautioned, "or you may fall off and crack your
+pumpkin head."
+
+"That would be horrible!" said Jack, with a shudder. "What shall I hold
+on to?"
+
+"Why, hold on to his ears," replied Tip, after a moment's hesitation.
+
+"Don't do that!" remonstrated the Saw-Horse; "for then I can't hear."
+
+That seemed reasonable, so Tip tried to think of something else.
+
+"I'll fix it!" said he, at length. He went into the wood and cut a
+short length of limb from a young, stout tree. One end of this he
+sharpened to a point, and then he dug a hole in the back of the
+Saw-Horse, just behind its head. Next he brought a piece of rock from
+the road and hammered the post firmly into the animal's back.
+
+[Illustration: "DOES IT HURT?" ASKED THE BOY.]
+
+"Stop! Stop!" shouted the horse; "you're jarring me terribly."
+
+"Does it hurt?" asked the boy.
+
+"Not exactly hurt," answered the animal; "but it makes me quite nervous
+to be jarred."
+
+"Well, it's all over now," said Tip, encouragingly. "Now, Jack, be sure
+to hold fast to this post, and then you can't fall off and get smashed."
+
+So Jack held on tight, and Tip said to the horse:
+
+"Get-up."
+
+The obedient creature at once walked forward, rocking from side to side
+as he raised his feet from the ground.
+
+Tip walked beside the Saw-Horse, quite content with this addition to
+their party. Presently he began to whistle.
+
+"What does that sound mean?" asked the horse.
+
+"Don't pay any attention to it," said Tip. "I'm just whistling, and
+that only means I'm pretty well satisfied."
+
+"I'd whistle myself, if I could push my lips together," remarked Jack.
+"I fear, dear father, that in some respects I am sadly lacking."
+
+After journeying on for some distance the narrow path they were
+following turned into a broad road-way, paved with yellow brick. By the
+side of the road Tip noticed a sign-post that read:
+
+"NINE MILES TO THE EMERALD CITY."
+
+But it was now growing dark, so he decided to camp for the night by the
+roadside and to resume the journey next morning by daybreak. He led the
+Saw-Horse to a grassy mound upon which grew several bushy trees, and
+carefully assisted the Pumpkinhead to alight.
+
+"I think I'll lay you upon the ground, overnight," said the boy. "You
+will be safer that way."
+
+"How about me?" asked the Saw-Horse.
+
+"It won't hurt you to stand," replied Tip; "and, as you can't sleep,
+you may as well watch out and see that no one comes near to disturb us."
+
+Then the boy stretched himself upon the grass beside the Pumpkinhead,
+and being greatly wearied by the journey was soon fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Jack Pumpkinhead's Ride
+    to the Emerald City
+]
+
+
+At daybreak Tip was awakened by the Pumpkinhead. He rubbed the sleep
+from his eyes, bathed in a little brook, and then ate a portion of his
+bread and cheese. Having thus prepared for a new day the boy said:
+
+"Let us start at once. Nine miles is quite a distance, but we ought to
+reach the Emerald City by noon if no accidents happen."
+
+So the Pumpkinhead was again perched upon the back of the Saw-Horse and
+the journey was resumed.
+
+Tip noticed that the purple tint of the grass and trees had now faded
+to a dull lavender, and before long this lavender appeared to take on
+a greenish tinge that gradually brightened as they drew nearer to the
+great City where the Scarecrow ruled.
+
+The little party had traveled but a short two miles upon their way when
+the road of yellow brick was parted by a broad and swift river. Tip was
+puzzled how to cross over; but after a time he discovered a man in a
+ferry-boat approaching from the other side of the stream.
+
+When the man reached the bank Tip asked:
+
+"Will you row us to the other side?"
+
+"Yes, if you have money," returned the ferryman, whose face looked
+cross and disagreeable.
+
+"But I have no money," said Tip.
+
+"None at all?" inquired the man.
+
+"None at all," answered the boy.
+
+"Then I'll not break my back rowing you over," said the ferryman,
+decidedly.
+
+"What a nice man!" remarked the Pumpkinhead, smilingly.
+
+The ferryman stared at him, but made no reply. Tip was trying to
+think, for it was a great disappointment to him to find his journey so
+suddenly brought to an end.
+
+"I must certainly get to the Emerald City," he said to the boatman;
+"but how can I cross the river if you do not take me?"
+
+The man laughed, and it was not a nice laugh.
+
+"That wooden horse will float," said he; "and you can ride him across.
+As for the pumpkin-headed loon who accompanies you, let him sink or
+swim--it won't matter greatly which."
+
+[Illustration]
+
+"Don't worry about me," said Jack, smiling pleasantly upon the crabbed
+ferryman; "I'm sure I ought to float beautifully."
+
+Tip thought the experiment was worth making, and the Saw-Horse, who did
+not know what danger meant, offered no objections whatever. So the boy
+led it down into the water and climbed upon its back. Jack also waded
+in up to his knees and grasped the tail of the horse so that he might
+keep his pumpkin head above the water.
+
+"Now," said Tip, instructing the Saw-Horse, "if you wiggle your legs
+you will probably swim; and if you swim we shall probably reach the
+other side."
+
+The Saw-Horse at once began to wiggle its legs, which acted as oars and
+moved the adventurers slowly across the river to the opposite side.
+So successful was the trip that presently they were climbing, wet and
+dripping, up the grassy bank.
+
+Tip's trouser-legs and shoes were thoroughly soaked; but the Saw-Horse
+had floated so perfectly that from his knees up the boy was entirely
+dry. As for the Pumpkinhead, every stitch of his gorgeous clothing
+dripped water.
+
+"The sun will soon dry us," said Tip; "and, anyhow, we are now safely
+across, in spite of the ferryman, and can continue our journey."
+
+"I didn't mind swimming, at all," remarked the horse.
+
+"Nor did I," added Jack.
+
+They soon regained the road of yellow brick, which proved to be a
+continuation of the road they had left on the other side, and then Tip
+once more mounted the Pumpkinhead upon the back of the Saw-Horse.
+
+"If you ride fast," said he, "the wind will help to dry your clothing.
+I will hold on to the horse's tail and run after you. In this way we
+all will become dry in a very short time."
+
+"Then the horse must step lively," said Jack.
+
+"I'll do my best," returned the Saw-Horse, cheerfully.
+
+Tip grasped the end of the branch that served as tail to the Saw-Horse,
+and called loudly: "Get-up!"
+
+The horse started at a good pace, and Tip followed behind. Then he
+decided they could go faster, so he shouted: "Trot!"
+
+[Illustration]
+
+Now, the Saw-Horse remembered that this word was the command to go as
+fast as he could; so he began rocking along the road at a tremendous
+pace, and Tip had hard work--running faster than he ever had before in
+his life--to keep his feet.
+
+Soon he was out of breath, and although he wanted to call "Whoa!" to
+the horse, he found he could not get the word out of his throat. Then
+the end of the tail he was clutching, being nothing more than a dead
+branch, suddenly broke away, and the next minute the boy was rolling
+in the dust of the road, while the horse and its pumpkin-headed rider
+dashed on and quickly disappeared in the distance.
+
+By the time Tip had picked himself up and cleared the dust from his
+throat so he could say "Whoa!" there was no further need of saying it,
+for the horse was long since out of sight.
+
+So he did the only sensible thing he could do. He sat down and took a
+good rest, and afterward began walking along the road.
+
+"Some time I will surely overtake them," he reflected; "for the road
+will end at the gates of the Emerald City, and they can go no further
+than that."
+
+Meantime Jack was holding fast to the post and the Saw-Horse was
+tearing along the road like a racer. Neither of them knew Tip was left
+behind, for the Pumpkinhead did not look around and the Saw-Horse
+couldn't.
+
+As he rode, Jack noticed that the grass and trees had become a bright
+emerald-green in color, so he guessed they were nearing the Emerald
+City even before the tall spires and domes came into sight.
+
+At length a high wall of green stone, studded thick with emeralds,
+loomed up before them; and fearing the Saw-Horse would not know enough
+to stop and so might smash them both against this wall, Jack ventured
+to cry "Whoa!" as loud as he could.
+
+So suddenly did the horse obey that had it not been for his post Jack
+would have been pitched off head foremost, and his beautiful face
+ruined.
+
+"That was a fast ride, dear father!" he exclaimed; and then, hearing no
+reply, he turned around and discovered for the first time that Tip was
+not there.
+
+This apparent desertion puzzled the Pumpkinhead, and made him uneasy.
+And while he was wondering what had become of the boy, and what he
+ought to do next under such trying circumstances, the gateway in the
+green wall opened and a man came out.
+
+This man was short and round, with a fat face that seemed remarkably
+good-natured. He was clothed all in green and wore a high, peaked green
+hat upon his head and green spectacles over his eyes. Bowing before the
+Pumpkinhead he said:
+
+"I am the Guardian of the Gates of the Emerald City. May I inquire who
+you are, and what is your business?"
+
+"My name is Jack Pumpkinhead," returned the other, smilingly; "but as
+to my business, I haven't the least idea in the world what it is."
+
+The Guardian of the Gates looked surprised, and shook his head as if
+dissatisfied with the reply.
+
+"What are you, a man or a pumpkin?" he asked, politely.
+
+"Both, if you please," answered Jack.
+
+"And this wooden horse--is it alive?" questioned the Guardian.
+
+The horse rolled one knotty eye upward and winked at Jack. Then it gave
+a prance and brought one leg down on the Guardian's toes.
+
+"Ouch!" cried the man; "I'm sorry I asked that question. But the answer
+is most convincing. Have you any errand, sir, in the Emerald City?"
+
+"It seems to me that I have," replied the Pumpkinhead, seriously; "but
+I cannot think what it is. My father knows all about it, but he is not
+here."
+
+"This is a strange affair--very strange!" declared the Guardian. "But
+you seem harmless. Folks do not smile so delightfully when they mean
+mischief."
+
+"As for that," said Jack, "I cannot help my smile, for it is carved on
+my face with a jack-knife."
+
+"Well, come with me into my room," resumed the Guardian, "and I will
+see what can be done for you."
+
+So Jack rode the Saw-Horse through the gate-way into a little room
+built into the wall. The Guardian pulled a bell-cord, and presently
+a very tall soldier--clothed in a green uniform--entered from the
+opposite door. This soldier carried a long green gun over his shoulder
+and had lovely green whiskers that fell quite to his knees. The
+Guardian at once addressed him, saying:
+
+"Here is a strange gentleman who doesn't know why he has come to the
+Emerald City, or what he wants. Tell me, what shall we do with him?"
+
+The Soldier with the Green Whiskers looked at Jack with much care and
+curiosity. Finally he shook his head so positively that little waves
+rippled down his whiskers, and then he said:
+
+"I must take him to His Majesty, the Scarecrow."
+
+"But what will His Majesty, the Scarecrow, do with him?" asked the
+Guardian of the Gates.
+
+"That is His Majesty's business," returned the soldier. "I have
+troubles enough of my own. All outside troubles must be turned over to
+His Majesty. So put the spectacles on this fellow, and I'll take him to
+the royal palace."
+
+So the Guardian opened a big box of spectacles and tried to fit a pair
+to Jack's great round eyes.
+
+"I haven't a pair in stock that will really cover those eyes up," said
+the little man, with a sigh; "and your head is so big that I shall be
+obliged to tie the spectacles on."
+
+"But why need I wear spectacles?" asked Jack.
+
+"It's the fashion here," said the Soldier, "and they will keep you from
+being blinded by the glitter and glare of the gorgeous Emerald City."
+
+"Oh!" exclaimed Jack. "Tie them on, by all means. I don't wish to be
+blinded."
+
+"Nor I!" broke in the Saw-Horse; so a pair of green spectacles was
+quickly fastened over the bulging knots that served it for eyes.
+
+Then the Soldier with the Green Whiskers led them through the inner
+gate and they at once found themselves in the main street of the
+magnificent Emerald City.
+
+Sparkling green gems ornamented the fronts of the beautiful houses and
+the towers and turrets were all faced with emeralds. Even the green
+marble pavement glittered with precious stones, and it was indeed a
+grand and marvelous sight to one who beheld it for the first time.
+
+However, the Pumpkinhead and the Saw-Horse, knowing nothing of wealth
+and beauty, paid little attention to the wonderful sights they saw
+through their green spectacles. They calmly followed after the green
+soldier and scarcely noticed the crowds of green people who stared
+at them in surprise. When a green dog ran out and barked at them the
+Saw-Horse promptly kicked at it with its wooden leg and sent the little
+animal howling into one of the houses; but nothing more serious than
+this happened to interrupt their progress to the royal palace.
+
+The Pumpkinhead wanted to ride up the green marble steps and straight
+into the Scarecrow's presence; but the soldier would not permit that.
+So Jack dismounted, with much difficulty, and a servant led the
+Saw-Horse around to the rear while the Soldier with the Green Whiskers
+escorted the Pumpkinhead into the palace, by the front entrance.
+
+The stranger was left in a handsomely furnished waiting room while the
+soldier went to announce him. It so happened that at this hour His
+Majesty was at leisure and greatly bored for want of something to do,
+so he ordered his visitor to be shown at once into his throne room.
+
+Jack felt no fear or embarrassment at meeting the ruler of this
+magnificent city, for he was entirely ignorant of all worldly customs.
+But when he entered the room and saw for the first time His Majesty
+the Scarecrow seated upon his glittering throne, he stopped short in
+amazement.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    His majesty the Scarecrow
+]
+
+
+I suppose every reader of this book knows what a scarecrow is; but Jack
+Pumpkinhead, never having seen such a creation, was more surprised at
+meeting the remarkable King of the Emerald City than by any other one
+experience of his brief life.
+
+His Majesty the Scarecrow was dressed in a suit of faded blue clothes,
+and his head was merely a small sack stuffed with straw, upon which
+eyes, ears, a nose and a mouth had been rudely painted to represent a
+face. The clothes were also stuffed with straw, and that so unevenly
+or carelessly that his Majesty's legs and arms seemed more bumpy
+than was necessary. Upon his hands were gloves with long fingers,
+and these were padded with cotton. Wisps of straw stuck out from the
+monarch's coat and also from his neck and boot-tops. Upon his head
+he wore a heavy golden crown set thick with sparkling jewels, and
+the weight of this crown caused his brow to sag in wrinkles, giving
+a thoughtful expression to the painted face. Indeed, the crown alone
+betokened majesty; in all else the Scarecrow King was but a simple
+scarecrow--flimsy, awkward, and unsubstantial.
+
+But if the strange appearance of his Majesty the Scarecrow seemed
+startling to Jack, no less wonderful was the form of the Pumpkinhead
+to the Scarecrow. The purple trousers and pink waistcoat and red
+shirt hung loosely over the wooden joints Tip had manufactured, and
+the carved face on the pumpkin grinned perpetually, as if its wearer
+considered life the jolliest thing imaginable.
+
+At first, indeed, His Majesty thought his queer visitor was laughing at
+him, and was inclined to resent such a liberty; but it was not without
+reason that the Scarecrow had attained the reputation of being the
+wisest personage in the Land of Oz. He made a more careful examination
+of his visitor, and soon discovered that Jack's features were carved
+into a smile and that he could not look grave if he wished to.
+
+The King was the first to speak. After regarding
+
+[Illustration]
+
+Jack for some minutes he said, in a tone of wonder:
+
+"Where on earth did you come from, and how do you happen to be alive?"
+
+"I beg your Majesty's pardon," returned the Pumpkinhead; "but I do not
+understand you."
+
+"What don't you understand?" asked the Scarecrow.
+
+"Why, I don't understand your language. You see, I came from the
+Country of the Gillikins, so that I am a foreigner."
+
+"Ah, to be sure!" exclaimed the Scarecrow. "I myself speak the language
+of the Munchkins, which is also the language of the Emerald City. But
+you, I suppose, speak the language of the Pumpkinheads?"
+
+"Exactly so, your Majesty," replied the other, bowing; "so it will be
+impossible for us to understand one another."
+
+"That is unfortunate, certainly," said the Scarecrow, thoughtfully. "We
+must have an interpreter."
+
+"What is an interpreter?" asked Jack.
+
+"A person who understands both my language and your own. When I say
+anything, the interpreter can tell you what I mean; and when you
+say anything the interpreter can tell me what _you_ mean. For the
+interpreter can speak both languages as well as understand them."
+
+"That is certainly clever," said Jack, greatly pleased at finding so
+simple a way out of the difficulty.
+
+So the Scarecrow commanded the Soldier with the Green Whiskers to
+search among his people until he found one who understood the language
+of the Gillikins as well as the language of the Emerald City, and to
+bring that person to him at once.
+
+When the Soldier had departed the Scarecrow said:
+
+"Won't you take a chair while we are waiting?"
+
+"Your Majesty forgets that I cannot understand you," replied the
+Pumpkinhead. "If you wish me to sit down you must make a sign for me to
+do so."
+
+The Scarecrow came down from his throne and rolled an armchair to a
+position behind the Pumpkinhead. Then he gave Jack a sudden push that
+sent him sprawling upon the cushions in so awkward a fashion that he
+doubled up like a jack-knife, and had hard work to untangle himself.
+
+"Did you understand that sign?" asked His Majesty, politely.
+
+"Perfectly," declared Jack, reaching up his arms to turn his head
+to the front, the pumpkin having twisted around upon the stick that
+supported it.
+
+"You seem hastily made," remarked the Scarecrow, watching Jack's
+efforts to straighten himself.
+
+"Not more so than your Majesty," was the frank reply.
+
+"There is this difference between us," said the Scarecrow, "that
+whereas I will bend, but not break, you will break, but not bend."
+
+[Illustration: "HE GAVE JACK A SUDDEN PUSH."]
+
+At this moment the soldier returned leading a young girl by the hand.
+She seemed very sweet and modest, having a pretty face and beautiful
+green eyes and hair. A dainty green silk skirt reached to her knees,
+showing silk stockings embroidered with pea-pods, and green satin
+slippers with bunches of lettuce for decorations instead of bows or
+buckles. Upon her silken waist clover leaves were embroidered, and
+she wore a jaunty little jacket trimmed with sparkling emeralds of a
+uniform size.
+
+"Why, it's little Jellia Jamb!" exclaimed the Scarecrow, as the green
+maiden bowed her pretty head before him. "Do you understand the
+language of the Gillikins, my dear?"
+
+"Yes, your Majesty," she answered, "for I was born in the North
+Country."
+
+"Then you shall be our interpreter," said the Scarecrow, "and explain
+to this Pumpkinhead all that I say, and also explain to me all that
+_he_ says. Is this arrangement satisfactory?" he asked, turning toward
+his guest.
+
+"Very satisfactory indeed," was the reply.
+
+"Then ask him, to begin with," resumed the Scarecrow, turning to
+Jellia, "what brought him to the Emerald City."
+
+But instead of this the girl, who had been staring at Jack, said to
+him:
+
+"You are certainly a wonderful creature. Who made you?"
+
+"A boy named Tip," answered Jack.
+
+"What does he say?" inquired the Scarecrow. "My ears must have deceived
+me. What did he say?"
+
+"He says that your Majesty's brains seem to have come loose," replied
+the girl, demurely.
+
+The Scarecrow moved uneasily upon his throne, and felt of his head with
+his left hand.
+
+"What a fine thing it is to understand two different languages," he
+said, with a perplexed sigh. "Ask him, my dear, if he has any objection
+to being put in jail for insulting the ruler of the Emerald City.
+
+"I didn't insult you!" protested Jack, indignantly.
+
+"Tut--tut!" cautioned the Scarecrow; "wait until Jellia translates my
+speech. What have we got an interpreter for, if you break out in this
+rash way?"
+
+"All right, I'll wait," replied the Pumpkinhead, in a surly
+tone--although his face smiled as genially as ever. "Translate the
+speech, young woman."
+
+"His Majesty inquires if you are hungry," said Jellia.
+
+"Oh, not at all!" answered Jack, more pleasantly. "for it is impossible
+for me to eat."
+
+"It's the same way with me," remarked the Scarecrow. "What did he say,
+Jellia, my dear?"
+
+"He asked if you were aware that one of your eyes is painted larger
+than the other," said the girl, mischievously.
+
+"Don't you believe her, your Majesty," cried Jack.
+
+"Oh, I don't," answered the Scarecrow, calmly. Then, casting a sharp
+look at the girl, he asked:
+
+"Are you quite certain you understand the languages of both the
+Gillikins and the Munchkins?"
+
+"Quite certain, your Majesty," said Jellia Jamb, trying hard not to
+laugh in the face of royalty.
+
+"Then how is it that I seem to understand them myself?" inquired the
+Scarecrow.
+
+"Because they are one and the same!" declared the girl, now laughing
+merrily. "Does not your Majesty know that in all the land of Oz but one
+language is spoken?"
+
+"Is it indeed so?" cried the Scarecrow, much relieved to hear this;
+"then I might easily have been my own interpreter!"
+
+"It was all my fault, your Majesty," said Jack, looking rather foolish,
+"I thought we must surely speak different languages, since we came from
+different countries."
+
+"This should be a warning to you never to think," returned the
+Scarecrow, severely. "For unless one can think wisely it is better to
+remain a dummy--which you most certainly are."
+
+"I am!--I surely am!" agreed the Pumpkinhead.
+
+"It seems to me," continued the Scarecrow, more mildly, "that your
+manufacturer spoiled some good pies to create an indifferent man."
+
+"I assure your Majesty that I did not ask to be created," answered Jack.
+
+"Ah! It was the same in my case," said the King, pleasantly. "And so,
+as we differ from all ordinary people, let us become friends."
+
+"With all my heart!" exclaimed Jack.
+
+"What! Have you a heart?" asked the Scarecrow, surprised.
+
+"No; that was only imaginative--I might say, a figure of speech," said
+the other.
+
+"Well, your most prominent figure seems to be a figure of wood; so I
+must beg you to restrain an imagination which, having no brains, you
+have no right to exercise," suggested the Scarecrow, warningly.
+
+"To be sure!" said Jack, without in the least comprehending.
+
+His Majesty then dismissed Jellia Jamb and the Soldier with the Green
+Whiskers, and when they were gone he took his new friend by the arm and
+led him into the courtyard to play a game of quoits.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Gen. Jinjur's Army
+    of Revolt
+]
+
+
+Tip was so anxious to rejoin his man Jack and the Saw-Horse that he
+walked a full half the distance to the Emerald City without stopping to
+rest. Then he discovered that he was hungry and the crackers and cheese
+he had provided for the journey had all been eaten.
+
+While wondering what he should do in this emergency he came upon a
+girl sitting by the roadside. She wore a costume that struck the boy
+as being remarkably brilliant: her silken waist being of emerald green
+and her skirt of four distinct colors--blue in front, yellow at the
+left side, red at the back and purple at the right side. Fastening the
+waist in front were four buttons--the top one blue, the next yellow, a
+third red and the last purple.
+
+[Illustration]
+
+The splendor of this dress was almost barbaric; so Tip was fully
+justified in staring at the gown for some moments before his eyes
+were attracted by the pretty face above it. Yes, the face was pretty
+enough, he decided; but it wore an expression of discontent coupled to
+a shade of defiance or audacity.
+
+While the boy stared the girl looked upon him calmly. A lunch basket
+stood beside her, and she held a dainty sandwich in one hand and a
+hard-boiled egg in the other, eating with an evident appetite that
+aroused Tip's sympathy.
+
+He was just about to ask a share of the luncheon when the girl stood up
+and brushed the crumbs from her lap.
+
+"There!" said she; "it is time for me to go. Carry that basket for me
+and help yourself to its contents if you are hungry."
+
+Tip seized the basket eagerly and began to eat, following for a time
+the strange girl without bothering to ask questions. She walked along
+before him with swift strides, and there was about her an air of
+decision and importance that led him to suspect she was some great
+personage.
+
+Finally, when he had satisfied his hunger, he ran up beside her and
+tried to keep pace with her swift footsteps--a very difficult feat, for
+she was much taller than he, and evidently in a hurry.
+
+"Thank you very much for the sandwiches," said Tip, as he trotted
+along. "May I ask your name?"
+
+"I am General Jinjur," was the brief reply.
+
+"Oh!" said the boy, surprised. "What sort of a General?"
+
+"I command the Army of Revolt in this war," answered the General, with
+unnecessary sharpness.
+
+"Oh!" he again exclaimed. "I didn't know there was a war."
+
+"You were not supposed to know it," she returned, "for we have kept it
+a secret; and considering that our army is composed entirely of girls,"
+she added, with some pride, "it is surely a remarkable thing that our
+Revolt is not yet discovered."
+
+"It is, indeed," acknowledged Tip. "But where is your army?"
+
+"About a mile from here," said General Jinjur. "The forces have
+assembled from all parts of the Land of Oz, at my express command. For
+this is the day we are to conquer His Majesty the Scarecrow, and wrest
+from him the throne. The Army of Revolt only awaits my coming to march
+upon the Emerald City."
+
+"Well!" declared Tip, drawing a long breath, "this is certainly a
+surprising thing! May I ask why you wish to conquer His Majesty the
+Scarecrow?"
+
+"Because the Emerald City has been ruled by men long enough, for one
+reason," said the girl. "Moreover, the City glitters with beautiful
+gems, which might far better be used for rings, bracelets and
+necklaces; and there is enough money in the King's treasury to buy
+every girl in our Army a dozen new gowns. So we intend to conquer the
+City and run the government to suit ourselves."
+
+Jinjur spoke these words with an eagerness and decision that proved she
+was in earnest.
+
+"But war is a terrible thing," said Tip, thoughtfully.
+
+"This war will be pleasant," replied the girl, cheerfully.
+
+"Many of you will be slain!" continued the boy, in an awed voice.
+
+"Oh, no," said Jinjur. "What man would oppose a girl, or dare to harm
+her? And there is not an ugly face in my entire Army."
+
+Tip laughed.
+
+"Perhaps you are right," said he. "But the Guardian of the Gate is
+considered a faithful Guardian, and the King's Army will not let the
+City be conquered without a struggle."
+
+"The Army is old and feeble," replied General Jinjur, scornfully. "His
+strength has all been used to grow whiskers, and his wife has such a
+temper that she has already pulled more than half of them out by the
+roots. When the Wonderful Wizard reigned the Soldier with the Green
+Whiskers was a very good Royal Army, for people feared the Wizard. But
+no one is afraid of the Scarecrow, so his Royal Army don't count for
+much in time of war."
+
+After this conversation they proceeded some distance in silence, and
+before long reached a large clearing in the forest where fully four
+hundred young women were assembled. These were laughing and talking
+together as gaily as if they had gathered for a picnic instead of a war
+of conquest.
+
+They were divided into four companies, and Tip noticed that all were
+dressed in costumes similar to that worn by General Jinjur. The only
+real difference was that while those girls from the Munchkin country
+had the blue strip in front of their skirts, those from the country of
+the Quadlings had the red strip in front; and those from the country
+of the Winkies had the yellow strip in front, and the Gillikin girls
+wore the purple strip in front. All had green waists, representing the
+Emerald City they intended to conquer, and the top button on each waist
+indicated by its color which country the wearer came from. The uniforms
+were jaunty and becoming, and quite effective when massed together.
+
+Tip thought this strange Army bore no weapons whatever; but in this he
+was wrong. For each girl had stuck through the knot of her back hair
+two long, glittering knitting-needles.
+
+[Illustration]
+
+General Jinjur immediately mounted the stump of a tree and addressed
+her army.
+
+"Friends, fellow-citizens, and girls!" she said; "we are about to begin
+our great Revolt against the men of Oz! We march to conquer the Emerald
+City--to dethrone the Scarecrow King--to acquire thousands of gorgeous
+gems--to rifle the royal treasury--and to obtain power over our former
+oppressors!"
+
+"Hurrah!" said those who had listened; but Tip thought most of the Army
+was too much engaged in chattering to pay attention to the words of the
+General.
+
+The command to march was now given, and the girls formed themselves
+into four bands, or companies, and set off with eager strides toward
+the Emerald City.
+
+[Illustration]
+
+The boy followed after them, carrying several baskets and wraps and
+packages which various members of the Army of Revolt had placed in his
+care. It was not long before they came to the green granite walls of
+the City and halted before the gateway.
+
+The Guardian of the Gate at once came out and looked at them curiously,
+as if a circus had come to town. He carried a bunch of keys swung round
+his neck by a golden chain; his hands were thrust carelessly into
+his pockets, and he seemed to have no idea at all that the City was
+threatened by rebels. Speaking pleasantly to the girls, he said:
+
+"Good morning, my dears! What can I do for you?"
+
+[Illustration]
+
+"Surrender instantly!" answered General Jinjur, standing before him and
+frowning as terribly as her pretty face would allow her to.
+
+"Surrender!" echoed the man, astounded. "Why, it's impossible. It's
+against the law! I never heard of such a thing in my life."
+
+"Still, you must surrender!" exclaimed the General, fiercely. "We are
+revolting!"
+
+"You don't look it," said the Guardian, gazing from one to another,
+admiringly.
+
+"But we are!" cried Jinjur, stamping her foot, impatiently; "and we
+mean to conquer the Emerald City!"
+
+"Good gracious!" returned the surprised Guardian of the Gates; "what
+a nonsensical idea! Go home to your mothers, my good girls, and milk
+the cows and bake the bread. Don't you know it's a dangerous thing to
+conquer a city?"
+
+"We are not afraid!" responded the General; and she looked so
+determined that it made the Guardian uneasy.
+
+So he rang the bell for the Soldier with the Green Whiskers, and the
+next minute was sorry he had done so. For immediately he was surrounded
+by a crowd of girls who drew the knitting-needles from their hair and
+began jabbing them at the Guardian with the sharp points dangerously
+near his fat cheeks and blinking eyes.
+
+The poor man howled loudly for mercy and made no resistance when Jinjur
+drew the bunch of keys from around his neck.
+
+[Illustration: GENERAL JINJUR AND HER ARMY CAPTURE THE CITY.]
+
+Followed by her Army the General now rushed to the gateway, where she
+was confronted by the Royal Army of Oz--which was the other name for
+the Soldier with the Green Whiskers.
+
+"Halt!" he cried, and pointed his long gun full in the face of the
+leader.
+
+Some of the girls screamed and ran back, but General Jinjur bravely
+stood her ground and said, reproachfully:
+
+"Why, how now? Would you shoot a poor, defenceless girl?"
+
+"No," replied the soldier; "for my gun isn't loaded."
+
+"Not loaded?"
+
+"No; for fear of accidents. And I've forgotten where I hid the powder
+and shot to load it with. But if you'll wait a short time I'll try to
+hunt them up."
+
+"Don't trouble yourself," said Jinjur, cheerfully. Then she turned to
+her Army and cried:
+
+"Girls, the gun isn't loaded!"
+
+"Hooray," shrieked the rebels, delighted at this good news, and they
+proceeded to rush upon the Soldier with the Green Whiskers in such a
+crowd that it was a wonder they didn't stick the knitting-needles into
+one another.
+
+But the Royal Army of Oz was too much afraid of women to meet the
+onslaught. He simply turned about and ran with all his might through
+the gate and toward the royal palace, while General Jinjur and her mob
+flocked into the unprotected City.
+
+In this way was the Emerald City captured without a drop of blood being
+spilled. The Army of Revolt had become an Army of Conquerors!
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Plans an escape
+]
+
+
+Tip slipped away from the girls and followed swiftly after the
+Soldier with the Green Whiskers. The invading army entered the City
+more slowly, for they stopped to dig emeralds out of the walls and
+paving-stones with the points of their knitting-needles. So the Soldier
+and the boy reached the palace before the news had spread that the City
+was conquered.
+
+The Scarecrow and Jack Pumpkinhead were still playing at quoits in
+the courtyard when the game was interrupted by the abrupt entrance of
+the Royal Army of Oz, who came flying in without his hat or gun, his
+clothes in sad disarray and his long beard floating a yard behind him
+as he ran.
+
+"Tally one for me," said the Scarecrow, calmly. "What's wrong, my man?"
+he added, addressing the Soldier.
+
+"Oh! your Majesty--your Majesty! The City is conquered!" gasped the
+Royal Army, who was all out of breath.
+
+"This is quite sudden," said the Scarecrow. "But please go and bar all
+the doors and windows of the palace, while I show this Pumpkinhead how
+to throw a quoit."
+
+The Soldier hastened to do this, while Tip, who had arrived at his
+heels, remained in the courtyard to look at the Scarecrow with
+wondering eyes.
+
+His Majesty continued to throw the quoits as coolly as if no danger
+threatened his throne, but the Pumpkinhead, having caught sight of Tip,
+ambled toward the boy as fast as his wooden legs would go.
+
+"Good afternoon, noble parent!" he cried, delightedly. "I'm glad to see
+you are here. That terrible Saw-Horse ran away with me."
+
+"I suspected it," said Tip. "Did you get hurt? Are you cracked at all?"
+
+"No, I arrived safely," answered Jack, "and his Majesty has been very
+kind indeed to me."
+
+At this moment the Soldier with the Green Whiskers returned, and the
+Scarecrow asked:
+
+"By the way, who has conquered me?"
+
+"A regiment of girls, gathered from the four corners of the Land of
+Oz," replied the Soldier, still pale with fear.
+
+"But where was my Standing Army at the time?" inquired his Majesty,
+looking at the Soldier, gravely.
+
+"Your Standing Army was running," answered the fellow, honestly; "for
+no man could face the terrible weapons of the invaders."
+
+"Well," said the Scarecrow, after a moment's thought, "I don't mind
+much the loss of my throne, for it's a tiresome job to rule over the
+Emerald City. And this crown is so heavy that it makes my head ache.
+But I hope the Conquerors have no intention of injuring me, just
+because I happen to be the King."
+
+"I heard them say," remarked Tip, with some hesitation, "that
+they intend to make a rag carpet of your outside and stuff their
+sofa-cushions with your inside."
+
+"Then I am really in danger," declared his Majesty, positively, "and it
+will be wise for me to consider a means to escape."
+
+"Where can you go?" asked Jack Pumpkinhead.
+
+"Why, to my friend the Tin Woodman, who rules over the Winkies, and
+calls himself their Emperor," was the answer. "I am sure he will
+protect me."
+
+[Illustration]
+
+Tip was looking out of the window.
+
+"The palace is surrounded by the enemy," said he. "It is too late to
+escape. They would soon tear you to pieces."
+
+The Scarecrow sighed.
+
+"In an emergency," he announced, "it is always a good thing to pause
+and reflect. Please excuse me while I pause and reflect."
+
+"But we also are in danger," said the Pumpkinhead, anxiously. "If any
+of these girls understand cooking, my end is not far off!"
+
+"Nonsense!" exclaimed the Scarecrow; "they're too busy to cook, even if
+they know how!"
+
+"But should I remain here a prisoner for any length of time," protested
+Jack, "I'm liable to spoil."
+
+"Ah! then you would not be fit to associate with," returned the
+Scarecrow. "The matter is more serious than I suspected."
+
+"You," said the Pumpkinhead, gloomily, "are liable to live for many
+years. My life is necessarily short. So I must take advantage of the
+few days that remain to me."
+
+"There, there! Don't worry," answered the Scarecrow, soothingly; "if
+you'll keep quiet long enough for me to think, I'll try to find some
+way for us all to escape."
+
+So the others waited in patient silence while the Scarecrow walked to
+a corner and stood with his face to the wall for a good five minutes.
+At the end of that time he faced them with a more cheerful expression
+upon his painted face.
+
+"Where is the Saw-Horse you rode here?" he asked the Pumpkinhead.
+
+"Why, I said he was a jewel, and so your man locked him up in the royal
+treasury," said Jack.
+
+"It was the only place I could think of, your Majesty," added the
+Soldier, fearing he had made a blunder.
+
+"It pleases me very much," said the Scarecrow. "Has the animal been
+fed?"
+
+"Oh, yes; I gave him a heaping peck of sawdust."
+
+"Excellent!" cried the Scarecrow. "Bring the horse here at once."
+
+The Soldier hastened away, and presently they heard the clattering
+of the horse's wooden legs upon the pavement as he was led into the
+courtyard.
+
+His Majesty regarded the steed critically.
+
+"He doesn't seem especially graceful," he remarked, musingly; "but I
+suppose he can run?"
+
+"He can, indeed," said Tip, gazing upon the Saw-Horse admiringly.
+
+"Then, bearing us upon his back, he must make a dash through the ranks
+of the rebels and carry us to my friend the Tin Woodman," announced the
+Scarecrow.
+
+"He can't carry four!" objected Tip.
+
+"No, but he may be induced to carry three," said his Majesty. "I shall
+therefore leave my Royal Army behind. For, from the ease with which he
+was conquered, I have little confidence in his powers."
+
+"Still, he can run," declared Tip, laughing.
+
+"I expected this blow," said the Soldier, sulkily; "but I can bear it.
+I shall disguise myself by cutting off my lovely green whiskers. And,
+after all, it is no more dangerous to face those reckless girls than to
+ride this fiery, untamed wooden horse!"
+
+"Perhaps you are right," observed his Majesty. "But, for my part, not
+being a soldier, I am fond of danger. Now, my boy, you must mount
+first. And please sit as close to the horse's neck as possible."
+
+Tip climbed quickly to his place, and the Soldier and the Scarecrow
+managed to hoist the Pumpkinhead to a seat just behind him. There
+remained so little space for the King that he was liable to fall off as
+soon as the horse started.
+
+"Fetch a clothesline," said the King to his Army, "and tie us all
+together. Then if one falls off we will all fall off."
+
+And while the Soldier was gone for the clothesline his Majesty
+continued, "it is well for me to be careful, for my very existence is
+in danger."
+
+"I have to be as careful as you do," said Jack.
+
+"Not exactly," replied the Scarecrow; "for if anything happened to me,
+that would be the end of me. But if anything happened to you, they
+could use you for seed."
+
+The Soldier now returned with a long line and tied all three firmly
+together, also lashing them to the body of the Saw-Horse; so there
+seemed little danger of their tumbling off.
+
+"Now throw open the gates," commanded the Scarecrow, "and we will make
+a dash to liberty or to death."
+
+The courtyard in which they were standing was located in the center of
+the great palace, which surrounded it on all sides. But in one place a
+passage led to an outer gateway, which the Soldier had barred by order
+of his sovereign. It was through this gateway his Majesty proposed to
+escape, and the Royal Army now led the Saw-Horse along the passage and
+unbarred the gate, which swung backward with a loud crash.
+
+"Now," said Tip to the horse, "you must save us all. Run as fast as you
+can for the gate of the City, and don't let anything stop you."
+
+"All right!" answered the Saw-Horse, gruffly, and dashed away so
+suddenly that Tip had to gasp for breath and hold firmly to the post
+he had driven into the creature's neck.
+
+[Illustration: "WE WILL MAKE A DASH TO LIBERTY OR TO DEATH."]
+
+Several of the girls, who stood outside guarding the palace, were
+knocked over by the Saw-Horse's mad rush. Others ran screaming out of
+the way, and only one or two jabbed their knitting-needles frantically
+at the escaping prisoners. Tip got one small prick in his left arm,
+which smarted for an hour afterward; but the needles had no effect upon
+the Scarecrow or Jack Pumpkinhead, who never even suspected they were
+being prodded.
+
+As for the Saw-Horse, he made a wonderful record, upsetting a fruit
+cart, overturning several meek looking men, and finally bowling over
+the new Guardian of the Gate--a fussy little fat woman appointed by
+General Jinjur.
+
+Nor did the impetuous charger stop then. Once outside the walls of the
+Emerald City he dashed along the road to the West with fast and violent
+leaps that shook the breath out of the boy and filled the Scarecrow
+with wonder.
+
+Jack had ridden at this mad rate once before, so he devoted every
+effort to holding, with both hands, his pumpkin head upon its
+stick, enduring meantime the dreadful jolting with the courage of a
+philosopher.
+
+[Illustration: THE WOODEN STEED GAVE ONE FINAL LEAP.]
+
+"Slow him up! Slow him up!" shouted the Scarecrow. "My straw is all
+shaking down into my legs."
+
+But Tip had no breath to speak, so the Saw-Horse continued his wild
+career unchecked and with unabated speed.
+
+Presently they came to the banks of a wide river, and without a pause
+the wooden steed gave one final leap and launched them all in mid-air.
+
+A second later they were rolling, splashing and bobbing about in the
+water, the horse struggling frantically to find a rest for its feet
+and its riders being first plunged beneath the rapid current and then
+floating upon the surface like corks.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Journey to the
+    Tin Woodman
+]
+
+
+Tip was well soaked and dripping water from every angle of his body;
+but he managed to lean forward and shout in the ear of the Saw-Horse:
+
+"Keep still, you fool! Keep still!"
+
+The horse at once ceased struggling and floated calmly upon the
+surface, its wooden body being as buoyant as a raft.
+
+"What does that word 'fool' mean?" enquired the horse.
+
+"It is a term of reproach," answered Tip, somewhat ashamed of the
+expression. "I only use it when I am angry."
+
+"Then it pleases me to be able to call you a fool, in return," said the
+horse. "For I did not make the river, nor put it in our way; so only a
+term of reproach is fit for one who becomes angry with me for falling
+into the water."
+
+"That is quite evident," replied Tip; "so I will acknowledge myself in
+the wrong." Then he called out to the Pumpkinhead: "are you all right,
+Jack?"
+
+There was no reply. So the boy called to the King: "are you all right,
+your majesty?"
+
+The Scarecrow groaned.
+
+"I'm all wrong, somehow," he said, in a weak voice. "How very wet this
+water is!"
+
+Tip was bound so tightly by the cord that he could not turn his head to
+look at his companions; so he said to the Saw-Horse:
+
+"Paddle with your legs toward the shore."
+
+The horse obeyed, and although their progress was slow they finally
+reached the opposite river bank at a place where it was low enough to
+enable the creature to scramble upon dry land.
+
+With some difficulty the boy managed to get his knife out of his pocket
+and cut the cords that bound the riders to one another and to the
+wooden horse. He heard the Scarecrow fall to the ground with a mushy
+sound, and then he himself quickly dismounted and looked at his friend
+Jack.
+
+The wooden body, with its gorgeous clothing, still sat upright upon
+the horse's back; but the pumpkin head was gone, and only the sharpened
+stick that served for a neck was visible. As for the Scarecrow, the
+straw in his body had shaken down with the jolting and packed itself
+into his legs and the lower part of his body--which appeared very plump
+and round while his upper half seemed like an empty sack. Upon his head
+the Scarecrow still wore the heavy crown, which had been sewed on to
+prevent his losing it; but the head was now so damp and limp that the
+weight of the gold and jewels sagged forward and crushed the painted
+face into a mass of wrinkles that made him look exactly like a Japanese
+pug dog.
+
+Tip would have laughed--had he not been so anxious about his man Jack.
+But the Scarecrow, however damaged, was all there, while the pumpkin
+head that was so necessary to Jack's existence was missing; so the boy
+seized a long pole that fortunately lay near at hand and anxiously
+turned again toward the river.
+
+Far out upon the waters he sighted the golden hue of the pumpkin, which
+gently bobbed up and down with the motion of the waves. At that moment
+it was quite out of Tip's reach, but after a time it floated nearer
+and still nearer until the boy was able to reach it with his pole
+and draw it to the shore. Then he brought it to the top of the bank,
+carefully wiped the water from its pumpkin face with his handkerchief,
+and ran with it to Jack and replaced the head upon the man's neck.
+
+[Illustration: TIP RESCUES JACK'S PUMPKIN HEAD.]
+
+"Dear me!" were Jack's first words. "What a dreadful experience! I
+wonder if water is liable to spoil pumpkins?"
+
+Tip did not think a reply was necessary, for he knew that the Scarecrow
+also stood in need of his help. So he carefully removed the straw from
+the King's body and legs, and spread it out in the sun to dry. The wet
+clothing he hung over the body of the Saw-Horse.
+
+"If water spoils pumpkins," observed Jack, with a deep sigh, "then my
+days are numbered."
+
+"I've never noticed that water spoils pumpkins," returned Tip; "unless
+the water happens to be boiling. If your head isn't cracked, my friend,
+you must be in fairly good condition."
+
+"Oh, my head isn't cracked in the least," declared Jack, more
+cheerfully.
+
+"Then don't worry," retorted the boy. "Care once killed a cat."
+
+"Then," said Jack, seriously, "I am very glad indeed that I am not a
+cat."
+
+The sun was fast drying their clothing, and Tip stirred up his
+Majesty's straw so that the warm rays might absorb the moisture and
+make it as crisp and dry as ever. When this had been accomplished he
+stuffed the Scarecrow into symmetrical shape and smoothed out his face
+so that he wore his usual gay and charming expression.
+
+"Thank you very much," said the monarch, brightly, as he walked about
+and found himself to be well balanced. "There are several distinct
+advantages in being a Scarecrow. For if one has friends near at hand to
+repair damages, nothing very serious can happen to you."
+
+"I wonder if hot sunshine is liable to crack pumpkins," said Jack, with
+an anxious ring in his voice.
+
+"Not at all--not at all!" replied the Scarecrow, gaily. "All you
+need fear, my boy, is old age. When your golden youth has decayed we
+shall quickly part company--but you needn't look forward to it; we'll
+discover the fact ourselves, and notify you. But come! Let us resume
+our journey. I am anxious to greet my friend the Tin Woodman."
+
+So they remounted the Saw-Horse, Tip holding to the post, the
+Pumpkinhead clinging to Tip, and the Scarecrow with both arms around
+the wooden form of Jack.
+
+[Illustration: TIP STUFFS THE SCARECROW WITH DRY STRAW.]
+
+"Go slowly, for now there is no danger of pursuit," said Tip to his
+steed.
+
+"All right!" responded the creature, in a voice rather gruff.
+
+"Aren't you a little hoarse?" asked the Pumpkinhead, politely.
+
+The Saw-Horse gave an angry prance and rolled one knotty eye backward
+toward Tip.
+
+"See here," he growled, "can't you protect me from insult?"
+
+"To be sure!" answered Tip, soothingly. "I am sure Jack meant no harm.
+And it will not do for us to quarrel, you know; we must all remain good
+friends."
+
+"I'll have nothing more to do with that Pumpkinhead," declared the
+Saw-Horse, viciously; "he loses his head too easily to suit me."
+
+There seemed no fitting reply to this speech, so for a time they rode
+along in silence.
+
+After a while the Scarecrow remarked:
+
+"This reminds me of old times. It was upon this grassy knoll that I
+once saved Dorothy from the Stinging Bees of the Wicked Witch of the
+West."
+
+"Do Stinging Bees injure pumpkins?" asked Jack, glancing around
+fearfully.
+
+"They are all dead, so it doesn't matter," replied the Scarecrow. "And
+here is where Nick Chopper destroyed the Wicked Witch's Grey Wolves."
+
+"Who was Nick Chopper?" asked Tip.
+
+"That is the name of my friend the Tin Woodman," answered his Majesty.
+"And here is where the Winged Monkeys captured and bound us, and flew
+away with little Dorothy," he continued, after they had traveled a
+little way farther.
+
+"Do Winged Monkeys ever eat pumpkins?" asked Jack, with a shiver of
+fear.
+
+"I do not know; but you have little cause to worry, for the Winged
+Monkeys are now the slaves of Glinda the Good, who owns the Golden Cap
+that commands their services," said the Scarecrow, reflectively.
+
+Then the stuffed monarch became lost in thought, recalling the days
+of past adventures. And the Saw-Horse rocked and rolled over the
+flower-strewn fields and carried its riders swiftly upon their way.
+
+       *       *       *       *       *
+
+Twilight fell, bye and bye, and then the dark shadows of night. So Tip
+stopped the horse and they all proceeded to dismount.
+
+"I'm tired out," said the boy, yawning wearily; "and the grass is soft
+and cool. Let us lie down here and sleep until morning."
+
+"I can't sleep," said Jack.
+
+"I never do," said the Scarecrow.
+
+"I do not even know what sleep is," said the Saw-Horse.
+
+"Still, we must have consideration for this poor boy, who is made of
+flesh and blood and bone, and gets tired," suggested the Scarecrow,
+in his usual thoughtful manner. "I remember it was the same way with
+little Dorothy. We always had to sit through the night while she slept."
+
+"I'm sorry," said Tip, meekly, "but I can't help it. And I'm dreadfully
+hungry, too!"
+
+"Here is a new danger!" remarked Jack, gloomily. "I hope you are not
+fond of eating pumpkins."
+
+"Not unless they're stewed and made into pies," answered the boy,
+laughing. "So have no fears of me, friend Jack."
+
+"What a coward that Pumpkinhead is!" said the Saw-Horse, scornfully.
+
+"You might be a coward yourself, if you knew you were liable to spoil!"
+retorted Jack, angrily.
+
+"There!--there!" interrupted the Scarecrow; "don't let us quarrel.
+We all have our weaknesses, dear friends; so we must strive to be
+considerate of one another. And since this poor boy is hungry and has
+nothing whatever to eat, let us all remain quiet and allow him to
+sleep; for it is said that in sleep a mortal may forget even hunger."
+
+"Thank you!" exclaimed Tip, gratefully. "Your Majesty is fully as good
+as you are wise--and that is saying a good deal!"
+
+He then stretched himself upon the grass and, using the stuffed form of
+the Scarecrow for a pillow, was presently fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Nickel-Plated Emperor
+]
+
+
+Tip awoke soon after dawn, but the Scarecrow had already risen and
+plucked, with his clumsy fingers, a double-handful of ripe berries from
+some bushes near by. These the boy ate greedily, finding them an ample
+breakfast, and afterward the little party resumed its journey.
+
+After an hour's ride they reached the summit of a hill from whence
+they espied the City of the Winkies and noted the tall domes of the
+Emperor's palace rising from the clusters of more modest dwellings.
+
+The Scarecrow became greatly animated at this sight, and exclaimed:
+
+"How delighted I shall be to see my old friend the Tin Woodman again! I
+hope that he rules his people more successfully than I have ruled mine!"
+
+"Is the Tin Woodman the Emperor of the Winkies?" asked the horse.
+
+"Yes, indeed. They invited him to rule over them soon after the Wicked
+Witch was destroyed; and as Nick Chopper has the best heart in all the
+world I am sure he has proved an excellent and able emperor."
+
+"I thought that 'Emperor' was the title of a person who rules an
+empire," said Tip, "and the Country of the Winkies is only a Kingdom."
+
+"Don't mention that to the Tin Woodman!" exclaimed the Scarecrow,
+earnestly. "You would hurt his feelings terribly. He is a proud man,
+as he has every reason to be, and it pleases him to be termed Emperor
+rather than King."
+
+"I'm sure it makes no difference to me," replied the boy.
+
+The Saw-Horse now ambled forward at a pace so fast that its riders
+had hard work to stick upon its back; so there was little further
+conversation until they drew up beside the palace steps.
+
+An aged Winkie, dressed in a uniform of silver cloth, came forward to
+assist them to alight. Said the Scarecrow to this personage:
+
+"Show us at once to your master, the Emperor."
+
+The man looked from one to another of the party in an embarrassed way,
+and finally answered:
+
+"I fear I must ask you to wait for a time. The Emperor is not receiving
+this morning."
+
+"How is that?" enquired the Scarecrow, anxiously. "I hope nothing has
+happened to him."
+
+"Oh, no; nothing serious," returned the man. "But this is his Majesty's
+day for being polished, and just now his august presence is thickly
+smeared with putz-pomade."
+
+"Oh, I see!" cried the Scarecrow, greatly reassured. "My friend was
+ever inclined to be a dandy, and I suppose he is now more proud than
+ever of his personal appearance."
+
+"He is, indeed," said the man, with a polite bow. "Our mighty Emperor
+has lately caused himself to be nickel-plated."
+
+"Good Gracious!" the Scarecrow exclaimed at hearing this. "If his wit
+bears the same polish, how sparkling it must be! But show us in--I'm
+sure the Emperor will receive us, even in his present state."
+
+"The Emperor's state is always magnificent," said the man. "But I will
+venture to tell him of your arrival, and will receive his commands
+concerning you."
+
+So the party followed the servant into a splendid ante-room, and the
+Saw-Horse ambled awkwardly after them, having no knowledge that a horse
+might be expected to remain outside.
+
+The travelers were at first somewhat awed by their surroundings, and
+even the Scarecrow seemed impressed as he examined the rich hangings
+of silver cloth caught up into knots and fastened with tiny silver
+axes. Upon a handsome center-table stood a large silver oil-can,
+richly engraved with scenes from the past adventures of the Tin
+Woodman, Dorothy, the Cowardly Lion and the Scarecrow: the lines of the
+engraving being traced upon the silver in yellow gold. On the walls
+hung several portraits, that of the Scarecrow seeming to be the most
+prominent and carefully executed, while a large painting of the famous
+Wizard of Oz, in the act of presenting the Tin Woodman with a heart,
+covered almost one entire end of the room.
+
+While the visitors gazed at these things in silent admiration they
+suddenly heard a loud voice in the next room exclaim:
+
+"Well! well! well! What a great surprise!"
+
+And then the door burst open and Nick Chopper rushed into their midst
+and caught the Scarecrow in a close and loving embrace that creased him
+into many folds and wrinkles.
+
+"My dear old friend! My noble comrade!" cried the Tin Woodman,
+joyfully; "how delighted I am to meet you once again!"
+
+[Illustration: CAUGHT THE SCARECROW IN A CLOSE AND LOVING EMBRACE.]
+
+And then he released the Scarecrow and held him at arms' length while
+he surveyed the beloved, painted features.
+
+But, alas! the face of the Scarecrow and many portions of his body bore
+great blotches of putz-pomade; for the Tin Woodman, in his eagerness to
+welcome his friend, had quite forgotten the condition of his toilet and
+had rubbed the thick coating of paste from his own body to that of his
+comrade.
+
+"Dear me!" said the Scarecrow, dolefully. "What a mess I'm in!"
+
+"Never mind, my friend," returned the Tin Woodman, "I'll send you to my
+Imperial Laundry, and you'll come out as good as new."
+
+"Won't I be mangled?" asked the Scarecrow.
+
+"No, indeed!" was the reply. "But tell me, how came your Majesty here?
+and who are your companions?"
+
+The Scarecrow, with great politeness, introduced Tip and Jack
+Pumpkinhead, and the latter personage seemed to interest the Tin
+Woodman greatly.
+
+"You are not very substantial, I must admit," said the Emperor; "but
+you are certainly unusual, and therefore worthy to become a member of
+our select society."
+
+"I thank your Majesty," said Jack, humbly.
+
+[Illustration]
+
+"I hope you are enjoying good health?" continued the Woodman.
+
+"At present, yes;" replied the Pumpkinhead, with a sigh; "but I am in
+constant terror of the day when I shall spoil."
+
+"Nonsense!" said the Emperor--but in a kindly, sympathetic tone. "Do
+not, I beg of you, dampen today's sun with the showers of tomorrow. For
+before your head has time to spoil you can have it canned, and in that
+way it may be preserved indefinitely."
+
+Tip, during this conversation, was looking at the Woodman with
+undisguised amazement, and noticed that the celebrated Emperor of
+the Winkies was composed entirely of pieces of tin, neatly soldered
+and riveted together into the form of a man. He rattled and clanked
+a little, as he moved, but in the main he seemed to be most cleverly
+constructed, and his appearance was only marred by the thick coating of
+polishing-paste that covered him from head to foot.
+
+The boy's intent gaze caused the Tin Woodman to remember that he was
+not in the most presentable condition, so he begged his friends to
+excuse him while he retired to his private apartment and allowed his
+servants to polish him. This was accomplished in a short time, and when
+the Emperor returned his nickel-plated body shone so magnificently that
+the Scarecrow heartily congratulated him on his improved appearance.
+
+"That nickel-plate was, I confess, a happy thought," said Nick; "and it
+was the more necessary because I had become somewhat scratched during
+my adventurous experiences. You will observe this engraved star upon
+my left breast. It not only indicates where my excellent heart lies,
+but covers very neatly the patch made by the Wonderful Wizard when he
+placed that valued organ in my breast with his own skillful hands."
+
+"Is your heart, then, a hand-organ?" asked the Pumpkinhead, curiously.
+
+"By no means," responded the Emperor, with dignity. "It is, I am
+convinced, a strictly orthodox heart, although somewhat larger and
+warmer than most people possess."
+
+Then he turned to the Scarecrow and asked:
+
+"Are your subjects happy and contented, my dear friend?"
+
+"I cannot say," was the reply; "for the girls of Oz have risen in
+revolt and driven me out of the Emerald City."
+
+"Great Goodness!" cried the Tin Woodman. "What a calamity! They surely
+do not complain of your wise and gracious rule?"
+
+"No; but they say it is a poor rule that don't work both ways,"
+answered the Scarecrow; "and these females are also of the opinion that
+men have ruled the land long enough. So they have captured my city,
+robbed the treasury of all its jewels, and are running things to suit
+themselves."
+
+"Dear me! What an extraordinary idea!" cried the Emperor, who was both
+shocked and surprised.
+
+"And I heard some of them say," said Tip, "that they intend to march
+here and capture the castle and city of the Tin Woodman."
+
+"Ah! we must not give them time to do that," said the Emperor, quickly;
+"we will go at once and recapture the Emerald City and place the
+Scarecrow again upon his throne."
+
+[Illustration: RENOVATING HIS MAJESTY, THE SCARECROW.]
+
+"I was sure you would help me," remarked the Scarecrow in a pleased
+voice. "How large an army can you assemble?"
+
+"We do not need an army," replied the Woodman. "We four, with the aid
+of my gleaming axe, are enough to strike terror into the hearts of the
+rebels."
+
+"We five," corrected the Pumpkinhead.
+
+"Five?" repeated the Tin Woodman.
+
+"Yes; the Saw-Horse is brave and fearless," answered Jack, forgetting
+his recent quarrel with the quadruped.
+
+The Tin Woodman looked around him in a puzzled way, for the Saw-Horse
+had until now remained quietly standing in a corner, where the Emperor
+had not noticed him. Tip immediately called the odd-looking creature to
+them, and it approached so awkwardly that it nearly upset the beautiful
+center-table and the engraved oil-can.
+
+"I begin to think," remarked the Tin Woodman as he looked earnestly at
+the Saw-Horse, "that wonders will never cease! How came this creature
+alive?"
+
+"I did it with a magic powder," modestly asserted the boy; "and the
+Saw-Horse has been very useful to us."
+
+"He enabled us to escape the rebels," added the Scarecrow.
+
+"Then we must surely accept him as a comrade," declared the Emperor. "A
+live Saw-Horse is a distinct novelty, and should prove an interesting
+study. Does he know anything?"
+
+"Well, I cannot claim any great experience in life," the Saw-Horse
+answered for himself; "but I seem to learn very quickly, and often it
+occurs to me that I know more than any of those around me."
+
+"Perhaps you do," said the Emperor; "for experience does not always
+mean wisdom. But time is precious just now, so let us quickly make
+preparations to start upon our journey."
+
+The Emperor called his Lord High Chancellor and instructed him how to
+run the kingdom during his absence. Meanwhile the Scarecrow was taken
+apart and the painted sack that served him for a head was carefully
+laundered and restuffed with the brains originally given him by the
+great Wizard. His clothes were also cleaned and pressed by the Imperial
+tailors, and his crown polished and again sewed upon his head, for the
+Tin Woodman insisted he should not renounce this badge of royalty. The
+Scarecrow now presented a very respectable appearance, and although
+in no way addicted to vanity he was quite pleased with himself and
+strutted a trifle as he walked. While this was being done Tip mended
+the wooden limbs of Jack Pumpkinhead and made them stronger than
+before, and the Saw-Horse was also inspected to see if he was in good
+working order.
+
+Then bright and early the next morning they set out upon the return
+journey to the Emerald City, the Tin Woodman bearing upon his shoulder
+a gleaming axe and leading the way, while the Pumpkinhead rode upon the
+Saw-Horse and Tip and the Scarecrow walked upon either side to make
+sure that he didn't fall off or become damaged.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Mr. H. M. Woggle-Bug, T. E.
+]
+
+
+Now, General Jinjur--who, you will remember, commanded the Army of
+Revolt--was rendered very uneasy by the escape of the Scarecrow from
+the Emerald City. She feared, and with good reason, that if his Majesty
+and the Tin Woodman joined forces, it would mean danger to her and
+her entire army; for the people of Oz had not yet forgotten the deeds
+of these famous heroes, who had passed successfully through so many
+startling adventures.
+
+So Jinjur sent post-haste for old Mombi, the witch, and promised her
+large rewards if she would come to the assistance of the rebel army.
+
+Mombi was furious at the trick Tip had played upon her, as well as at
+his escape and the theft of the precious Powder of Life; so she needed
+no urging to induce her to travel to the Emerald City to assist Jinjur
+in defeating the Scarecrow and the Tin Woodman, who had made Tip one of
+their friends.
+
+Mombi had no sooner arrived at the royal palace than she discovered,
+by means of her secret magic, that the adventurers were starting upon
+their journey to the Emerald City; so she retired to a small room high
+up in a tower and locked herself in while she practised such arts
+as she could command to prevent the return of the Scarecrow and his
+companions.
+
+That was why the Tin Woodman presently stopped and said:
+
+"Something very curious has happened. I ought to know by heart every
+step of this journey, and yet I fear we have already lost our way."
+
+"That is quite impossible!" protested the Scarecrow. "Why do you think,
+my dear friend, that we have gone astray?"
+
+"Why, here before us is a great field of sunflowers--and I never saw
+this field before in all my life."
+
+At these words they all looked around, only to find that they were
+indeed surrounded by a field of tall stalks, every stalk bearing at
+its top a gigantic sunflower. And not only were these flowers almost
+blinding in their vivid hues of red and gold, but each one whirled
+around upon its stalk like a miniature wind-mill, completely dazzling
+the vision of the beholders and so mystifying them that they knew not
+which way to turn.
+
+"It's witchcraft!" exclaimed Tip.
+
+While they paused, hesitating and wondering, the Tin Woodman uttered
+a cry of impatience and advanced with swinging axe to cut down the
+stalks before him. But now the sunflowers suddenly stopped their rapid
+whirling, and the travelers plainly saw a girl's face appear in the
+center of each flower. These lovely faces looked upon the astonished
+band with mocking smiles, and then burst into a chorus of merry
+laughter at the dismay their appearance caused.
+
+"Stop! stop!" cried Tip, seizing the Woodman's arm; "they're alive!
+they're girls!"
+
+At that moment the flowers began whirling again, and the faces faded
+away and were lost in the rapid revolutions.
+
+The Tin Woodman dropped his axe and sat down upon the ground.
+
+"It would be heartless to chop down those pretty creatures," said he,
+despondently; "and yet I do not know how else we can proceed upon our
+way."
+
+"They looked to me strangely like the faces of the Army of Revolt,"
+mused the Scarecrow. "But I cannot conceive how the girls could have
+followed us here so quickly."
+
+"I believe it's magic," said Tip, positively, "and that someone is
+playing a trick upon us. I've known old Mombi do things like that
+before. Probably it's nothing more than an illusion, and there are no
+sunflowers here at all."
+
+"Then let us shut our eyes and walk forward," suggested the Woodman.
+
+"Excuse me," replied the Scarecrow. "My eyes are not painted to shut.
+Because you happen to have tin eyelids, you must not imagine we are all
+built in the same way."
+
+"And the eyes of the Saw-Horse are knot eyes," said Jack, leaning
+forward to examine them.
+
+"Nevertheless, you must ride quickly forward," commanded Tip, "and we
+will follow after you and so try to escape. My eyes are already so
+dazzled that I can scarcely see."
+
+So the Pumpkinhead rode boldly forward, and Tip grasped the stub tail
+of the Saw-Horse and followed with closed eyes. The Scarecrow and the
+Tin Woodman brought up the rear, and before they had gone many yards a
+joyful shout from Jack announced that the way was clear before them.
+
+Then all paused to look backward, but not a trace of the field of
+sunflowers remained.
+
+More cheerfully, now, they proceeded upon their journey; but old Mombi
+had so changed the appearance of the landscape that they would surely
+have been lost had not the Scarecrow wisely concluded to take their
+direction from the sun. For no witchcraft could change the course of
+the sun, and it was therefore a safe guide.
+
+However, other difficulties lay before them. The Saw-Horse stepped into
+a rabbit hole and fell to the ground. The Pumpkinhead was pitched high
+into the air, and his history would probably have ended at that exact
+moment had not the Tin Woodman skillfully caught the pumpkin as it
+descended and saved it from injury.
+
+Tip soon had it fitted to the neck again and replaced Jack upon his
+feet. But the Saw-Horse did not escape so easily. For when his leg was
+pulled from the rabbit hole it was found to be broken short off, and
+must be replaced or repaired before he could go a step farther.
+
+"This is quite serious," said the Tin Woodman. "If there were trees
+near by I might soon manufacture another leg for this animal; but I
+cannot see even a shrub for miles around."
+
+[Illustration: THE TIN WOODMAN SKILLFULLY CAUGHT THE PUMPKIN]
+
+"And there are neither fences nor houses in this part of the land of
+Oz," added the Scarecrow, disconsolately.
+
+"Then what shall we do?" enquired the boy.
+
+"I suppose I must start my brains working," replied his Majesty the
+Scarecrow; "for experience has taught me that I can do anything if I
+but take time to think it out."
+
+"Let us all think," said Tip; "and perhaps we shall find a way to
+repair the Saw-Horse."
+
+So they sat in a row upon the grass and began to think, while the
+Saw-Horse occupied itself by gazing curiously upon its broken limb.
+
+"Does it hurt?" asked the Tin Woodman, in a soft, sympathetic voice.
+
+"Not in the least," returned the Saw-Horse; "but my pride is injured to
+find that my anatomy is so brittle."
+
+For a time the little group remained in silent thought. Presently the
+Tin Woodman raised his head and looked over the fields.
+
+"What sort of creature is that which approaches us?" he asked,
+wonderingly.
+
+The others followed his gaze, and discovered coming toward them the
+most extraordinary object they had ever beheld. It advanced quickly
+and noiselessly over the soft grass and in a few minutes stood before
+the adventurers and regarded them with an astonishment equal to their
+own.
+
+The Scarecrow was calm under all circumstances.
+
+"Good morning!" he said, politely.
+
+The stranger removed his hat with a flourish, bowed very low, and then
+responded:
+
+[Illustration]
+
+"Good morning, one and all. I hope you are, as an aggregation, enjoying
+excellent health. Permit me to present my card."
+
+With this courteous speech it extended a card toward the Scarecrow, who
+accepted it, turned it over and over, and then handed it with a shake
+of his head to Tip.
+
+The boy read aloud:
+
+"MR. H. M. WOGGLE-BUG, T. E."
+
+"Dear me!" ejaculated the Pumpkinhead, staring somewhat intently.
+
+"How very peculiar!" said the Tin Woodman.
+
+Tip's eyes were round and wondering, and the Saw-Horse uttered a sigh
+and turned away its head.
+
+"Are you really a Woggle-Bug?" enquired the Scarecrow.
+
+"Most certainly, my dear sir!" answered the stranger, briskly. "Is not
+my name upon the card?"
+
+"It is," said the Scarecrow. "But may I ask what 'H. M.' stands for?"
+
+"'H. M.' means Highly Magnified," returned the Woggle-Bug, proudly.
+
+"Oh, I see." The Scarecrow viewed the stranger critically. "And are
+you, in truth, highly magnified?"
+
+"Sir," said the Woggle-Bug, "I take you for a gentleman of judgment
+and discernment. Does it not occur to you that I am several thousand
+times greater than any Woggle-Bug you ever saw before? Therefore it is
+plainly evident that I am Highly Magnified, and there is no good reason
+why you should doubt the fact."
+
+"Pardon me," returned the Scarecrow. "My brains are slightly mixed
+since I was last laundered. Would it be improper for me to ask, also,
+what the 'T. E.' at the end of your name stands for?"
+
+"Those letters express my degree," answered the Woggle-Bug, with a
+condescending smile. "To be more explicit, the initials mean that I am
+Thoroughly Educated."
+
+"Oh!" said the Scarecrow, much relieved.
+
+Tip had not yet taken his eyes off this wonderful personage. What he
+saw was a great, round, bug-like body supported upon two slender legs
+which ended in delicate feet--the toes curling upward. The body of the
+Woggle-Bug was rather flat, and judging from what could be seen of it
+was of a glistening dark brown color upon the back, while the front
+was striped with alternate bands of light brown and white, blending
+together at the edges. Its arms were fully as slender as its legs, and
+upon a rather long neck was perched its head--not unlike the head of a
+man, except that its nose ended in a curling antenna, or "feeler," and
+its ears from the upper points bore antennæ that decorated the sides
+of its head like two miniature, curling pig tails. It must be admitted
+that the round, black eyes were rather bulging in appearance; but the
+expression upon the Woggle-Bug's face was by no means unpleasant.
+
+For dress the insect wore a dark-blue swallow-tail coat with a yellow
+silk lining and a flower in the button-hole; a vest of white duck that
+stretched tightly across the wide body; knickerbockers of fawn-colored
+plush, fastened at the knees with gilt buckles; and, perched upon its
+small head, was jauntily set a tall silk hat.
+
+Standing upright before our amazed friends the Woggle-Bug appeared to
+be fully as tall as the Tin Woodman; and surely no bug in all the Land
+of Oz had ever before attained so enormous a size.
+
+"I confess," said the Scarecrow, "that your abrupt appearance has
+caused me surprise, and no doubt has startled my companions. I hope,
+however, that this circumstance will not distress you. We shall
+probably get used to you in time."
+
+"Do not apologize, I beg of you!" returned the Woggle-Bug, earnestly.
+"It affords me great pleasure to surprise people; for surely I cannot
+be classed with ordinary insects and am entitled to both curiosity and
+admiration from those I meet."
+
+"You are, indeed," agreed his Majesty.
+
+"If you will permit me to seat myself in your august company,"
+continued the stranger, "I will gladly relate my history, so
+that you will be better able to comprehend my unusual--may I say
+remarkable?--appearance."
+
+"You may say what you please," answered the Tin Woodman, briefly.
+
+So the Woggle-Bug sat down upon the grass, facing the little group of
+wanderers, and told them the following story:
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Highly Magnified
+    History
+]
+
+
+"It is but honest that I should acknowledge at the beginning of my
+recital that I was born an ordinary Woggle-Bug," began the creature, in
+a frank and friendly tone. "Knowing no better, I used my arms as well
+as my legs for walking, and crawled under the edges of stones or hid
+among the roots of grasses with no thought beyond finding a few insects
+smaller than myself to feed upon.
+
+"The chill nights rendered me stiff and motionless, for I wore no
+clothing, but each morning the warm rays of the sun gave me new life
+and restored me to activity. A horrible existence is this, but you must
+remember it is the regularly ordained existence of Woggle-Bugs, as well
+as of many other tiny creatures that inhabit the earth.
+
+"But Destiny had singled me out, humble though I was, for a grander
+fate! One day I crawled near to a country school house, and my
+curiosity being excited by the monotonous hum of the students within,
+I made bold to enter and creep along a crack between two boards until
+I reached the far end, where, in front of a hearth of glowing embers,
+sat the master at his desk.
+
+"No one noticed so small a creature as a Woggle-Bug, and when I found
+that the hearth was even warmer and more comfortable than the sunshine,
+I resolved to establish my future home beside it. So I found a charming
+nest between two bricks and hid myself therein for many, many months.
+
+"Professor Nowitall is, doubtless, the most famous scholar in the land
+of Oz, and after a few days I began to listen to the lectures and
+discourses he gave his pupils. Not one of them was more attentive than
+the humble, unnoticed Woggle-Bug, and I acquired in this way a fund of
+knowledge that I will myself confess is simply marvelous. That is why
+I place 'T. E.'--Thoroughly Educated--upon my cards; for my greatest
+pride lies in the fact that the world cannot produce another Woggle-Bug
+with a tenth part of my own culture and erudition."
+
+"I do not blame you," said the Scarecrow. "Education is a thing to
+be proud of. I'm educated myself. The mess of brains given me by the
+Great Wizard is considered by my friends to be unexcelled."
+
+"Nevertheless," interrupted the Tin Woodman, "a good heart is, I
+believe, much more desirable than education or brains."
+
+"To me," said the Saw-Horse, "a good leg is more desirable than either."
+
+"Could seeds be considered in the light of brains?" enquired the
+Pumpkinhead, abruptly.
+
+"Keep quiet!" commanded Tip, sternly.
+
+"Very well, dear father," answered the obedient Jack.
+
+The Woggle-Bug listened patiently--even respectfully--to these remarks,
+and then resumed his story.
+
+"I must have lived fully three years in that secluded school-house
+hearth," said he, "drinking thirstily of the ever-flowing fount of
+limpid knowledge before me."
+
+"Quite poetical," commented the Scarecrow, nodding his head approvingly.
+
+[Illustration: "Caught me between his thumb and forefinger."]
+
+"But one day," continued the Bug, "a marvelous circumstance occurred
+that altered my very existence and brought me to my present pinnacle of
+greatness. The Professor discovered me in the act of crawling across
+the hearth, and before I could escape he had caught me between his
+thumb and forefinger.
+
+"'My dear children,' said he, 'I have captured a Woggle-Bug--a very
+rare and interesting specimen. Do any of you know what a Woggle-Bug is?'
+
+"'No!' yelled the scholars, in chorus.
+
+"'Then,' said the Professor, 'I will get out my famous magnifying-glass
+and throw the insect upon a screen in a highly-magnified condition,
+that you may all study carefully its peculiar construction and become
+acquainted with its habits and manner of life.'
+
+"He then brought from a cupboard a most curious instrument, and before
+I could realize what had happened I found myself thrown upon a screen
+in a highly-magnified state--even as you now behold me.
+
+"The students stood up on their stools and craned their heads forward
+to get a better view of me, and two little girls jumped upon the sill
+of an open window where they could see more plainly.
+
+"'Behold!' cried the Professor, in a loud voice, 'this highly-magnified
+Woggle-Bug; one of the most curious insects in existence!'
+
+"Being Thoroughly Educated, and knowing what is required of a cultured
+gentleman, at this juncture I stood upright and, placing my hand upon
+my bosom, made a very polite bow. My action, being unexpected, must
+have startled them, for one of the little girls perched upon the
+window-sill gave a scream and fell backward out the window, drawing her
+companion with her as she disappeared.
+
+[Illustration: "THE STUDENTS STOOD UP ON THEIR STOOLS."]
+
+"The Professor uttered a cry of horror and rushed away through the
+door to see if the poor children were injured by the fall. The
+scholars followed after him in a wild mob, and I was left alone in the
+school-room, still in a Highly-Magnified state and free to do as I
+pleased.
+
+"It immediately occurred to me that this was a good opportunity to
+escape. I was proud of my great size, and realized that now I could
+safely travel anywhere in the world, while my superior culture would
+make me a fit associate for the most learned person I might chance to
+meet.
+
+"So, while the Professor picked the little girls--who were more
+frightened than hurt--off the ground, and the pupils clustered around
+him closely grouped, I calmly walked out of the school-house, turned a
+corner, and escaped unnoticed to a grove of trees that stood near."
+
+"Wonderful!" exclaimed the Pumpkinhead, admiringly.
+
+"It was, indeed," agreed the Woggle-Bug. "I have never ceased to
+congratulate myself for escaping while I was Highly Magnified; for
+even my excessive knowledge would have proved of little use to me had
+I remained a tiny, insignificant insect."
+
+[Illustration]
+
+"I didn't know before," said Tip, looking at the Woggle-Bug with a
+puzzled expression, "that insects wore clothes."
+
+"Nor do they, in their natural state," returned the stranger. "But
+in the course of my wanderings I had the good fortune to save the
+ninth life of a tailor--tailors having, like cats, nine lives, as
+you probably know. The fellow was exceedingly grateful, for had he
+lost that ninth life it would have been the end of him; so he begged
+permission to furnish me with the stylish costume I now wear. It fits
+very nicely, does it not?" and the Woggle-Bug stood up and turned
+himself around slowly, that all might examine his person.
+
+"He must have been a good tailor," said the Scarecrow, somewhat
+enviously.
+
+"He was a good-hearted tailor, at any rate," observed Nick Chopper.
+
+"But where were you going, when you met us?" Tip asked the Woggle-Bug.
+
+"Nowhere in particular," was the reply, "although it is my intention
+soon to visit the Emerald City and arrange to give a course of lectures
+to select audiences on the 'Advantages of Magnification.'"
+
+"We are bound for the Emerald City now," said the Tin Woodman; "so, if
+it pleases you to do so, you are welcome to travel in our company."
+
+The Woggle-Bug bowed with profound grace.
+
+"It will give me great pleasure," said he, "to accept your kind
+invitation; for nowhere in the Land of Oz could I hope to meet with so
+congenial a company."
+
+"That is true," acknowledged the Pumpkinhead. "We are quite as
+congenial as flies and honey."
+
+"But--pardon me if I seem inquisitive--are you not all
+rather--ahem!--rather unusual?" asked the Woggle-Bug, looking from one
+to another with unconcealed interest.
+
+"Not more so than yourself," answered the Scarecrow. "Everything in
+life is unusual until you get accustomed to it."
+
+"What rare philosophy!" exclaimed the Woggle-Bug, admiringly.
+
+"Yes; my brains are working well today," admitted the Scarecrow, an
+accent of pride in his voice.
+
+"Then, if you are sufficiently rested and refreshed, let us bend our
+steps toward the Emerald City," suggested the magnified one.
+
+"We can't," said Tip. "The Saw-Horse has broken a leg, so he can't bend
+his steps. And there is no wood around to make him a new limb from. And
+we can't leave the horse behind because the Pumpkinhead is so stiff in
+his joints that he has to ride."
+
+"How very unfortunate!" cried the Woggle-Bug. Then he looked the party
+over carefully and said:
+
+"If the Pumpkinhead is to ride, why not use one of his legs to make a
+leg for the horse that carries him? I judge that both are made of wood."
+
+"Now, that is what I call real cleverness," said the Scarecrow,
+approvingly. "I wonder my brains did not think of that long ago! Get to
+work, my dear Nick, and fit the Pumpkinhead's leg to the Saw-Horse."
+
+Jack was not especially pleased with this idea; but he submitted to
+having his left leg amputated by the Tin Woodman and whittled down to
+fit the left leg of the Saw-Horse. Nor was the Saw-Horse especially
+pleased with the operation, either; for he growled a good deal about
+being "butchered," as he called it, and afterward declared that the new
+leg was a disgrace to a respectable Saw-Horse.
+
+"I beg you to be more careful in your speech," said the Pumpkinhead,
+sharply. "Remember, if you please, that it is my leg you are abusing."
+
+"I cannot forget it," retorted the Saw-Horse, "for it is quite as
+flimsy as the rest of your person."
+
+"Flimsy! me flimsy!" cried Jack, in a rage. "How dare you call me
+flimsy?"
+
+"Because you are built as absurdly as a jumping-jack," sneered the
+horse, rolling his knotty eyes in a vicious manner. "Even your head
+won't stay straight, and you never can tell whether you are looking
+backwards or forward!"
+
+"Friends, I entreat you not to quarrel!" pleaded the Tin Woodman,
+anxiously. "As a matter of fact, we are none of us above criticism; so
+let us bear with each others' faults."
+
+"An excellent suggestion," said the Woggle-Bug, approvingly. "You must
+have an excellent heart, my metallic friend."
+
+"I have," returned Nick, well pleased. "My heart is quite the best part
+of me. But now let us start upon our journey."
+
+They perched the one-legged Pumpkinhead upon the Saw-Horse, and tied
+him to his seat with cords, so that he could not possibly fall off.
+
+And then, following the lead of the Scarecrow, they all advanced in the
+direction of the Emerald City.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Old Mombi indulges
+    in Witchcraft
+]
+
+
+They soon discovered that the Saw-Horse limped, for his new leg was a
+trifle too long. So they were obliged to halt while the Tin Woodman
+chopped it down with his axe, after which the wooden steed paced along
+more comfortably. But the Saw-Horse was not entirely satisfied, even
+yet.
+
+"It was a shame that I broke my other leg!" it growled.
+
+"On the contrary," airily remarked the Woggle-Bug, who was walking
+alongside, "you should consider the accident most fortunate. For a
+horse is never of much use until he has been broken."
+
+"I beg your pardon," said Tip, rather provoked, for he felt a warm
+interest in both the Saw-Horse and his man Jack; "but permit me to say
+that your joke is a poor one, and as old as it is poor."
+
+"Still, it is a joke," declared the Woggle-Bug, firmly, "and a joke
+derived from a play upon words is considered among educated people to
+be eminently proper."
+
+"What does that mean?" enquired the Pumpkinhead, stupidly.
+
+"It means, my dear friend," explained the Woggle-Bug, "that our
+language contains many words having a double meaning; and that to
+pronounce a joke that allows both meanings of a certain word, proves
+the joker a person of culture and refinement, who has, moreover, a
+thorough command of the language."
+
+"I don't believe that," said Tip, plainly; "anybody can make a pun."
+
+"Not so," rejoined the Woggle-Bug, stiffly. "It requires education of
+a high order. Are you educated, young sir?"
+
+"Not especially," admitted Tip.
+
+"Then you cannot judge the matter. I myself am Thoroughly Educated, and
+I say that puns display genius. For instance, were I to ride upon this
+Saw-Horse, he would not only be an animal--he would become an equipage.
+For he would then be a horse-and-buggy."
+
+At this the Scarecrow gave a gasp and the Tin Woodman stopped short
+and looked reproachfully at the Woggle-Bug. At the same time the
+Saw-Horse loudly snorted his derision; and even the Pumpkinhead put up
+his hand to hide the smile which, because it was carved upon his face,
+he could not change to a frown.
+
+But the Woggle-Bug strutted along as if he had made some brilliant
+remark, and the Scarecrow was obliged to say:
+
+"I have heard, my dear friend, that a person can become over-educated;
+and although I have a high respect for brains, no matter how they may
+be arranged or classified, I begin to suspect that yours are slightly
+tangled. In any event, I must beg you to restrain your superior
+education while in our society."
+
+"We are not very particular," added the Tin Woodman; "and we are
+exceedingly kind hearted. But if your superior culture gets leaky
+again--" He did not complete the sentence, but he twirled his gleaming
+axe so carelessly that the Woggle-Bug looked frightened, and shrank
+away to a safe distance.
+
+The others marched on in silence, and the Highly-Magnified one, after
+a period of deep thought, said in an humble voice:
+
+"I will endeavor to restrain myself."
+
+"That is all we can expect," returned the Scarecrow, pleasantly; and
+good nature being thus happily restored to the party, they proceeded
+upon their way.
+
+When they again stopped to allow Tip to rest--the boy being the only
+one that seemed to tire--the Tin Woodman noticed many small, round
+holes in the grassy meadow.
+
+"This must be a village of the Field Mice," he said to the Scarecrow.
+"I wonder if my old friend, the Queen of the Mice, is in this
+neighborhood."
+
+"If she is, she may be of great service to us," answered the Scarecrow,
+who was impressed by a sudden thought. "See if you can call her, my
+dear Nick."
+
+So the Tin Woodman blew a shrill note upon a silver whistle that hung
+around his neck, and presently a tiny grey mouse popped from a near-by
+hole and advanced fearlessly toward them. For the Tin Woodman had once
+saved her life, and the Queen of the Field Mice knew he was to be
+trusted.
+
+"Good day, your Majesty," said Nick, politely addressing the mouse; "I
+trust you are enjoying good health?"
+
+"Thank you, I am quite well," answered the Queen, demurely, as she
+sat up and displayed the tiny golden crown upon her head. "Can I do
+anything to assist my old friends?"
+
+"You can, indeed," replied the Scarecrow, eagerly. "Let me, I intreat
+you, take a dozen of your subjects with me to the Emerald City."
+
+"Will they be injured in any way?" asked the Queen, doubtfully.
+
+"I think not," replied the Scarecrow. "I will carry them hidden in
+the straw which stuffs my body, and when I give them the signal by
+unbuttoning my jacket, they have only to rush out and scamper home
+again as fast as they can. By doing this they will assist me to regain
+my throne, which the Army of Revolt has taken from me."
+
+"In that case," said the Queen, "I will not refuse your request.
+Whenever you are ready, I will call twelve of my most intelligent
+subjects."
+
+"I am ready now," returned the Scarecrow. Then he lay flat upon the
+ground and unbuttoned his jacket, displaying the mass of straw with
+which he was stuffed.
+
+The Queen uttered a little piping call, and in an instant a dozen
+pretty field mice had emerged from their holes and stood before their
+ruler, awaiting her orders.
+
+What the Queen said to them none of our travelers could understand,
+for it was in the mouse language; but the field mice obeyed without
+hesitation, running one after the other to the Scarecrow and hiding
+themselves in the straw of his breast.
+
+When all of the twelve mice had thus concealed themselves, the
+Scarecrow buttoned his jacket securely and then arose and thanked the
+Queen for her kindness.
+
+"One thing more you might do to serve us," suggested the Tin Woodman;
+"and that is to run ahead and show us the way to the Emerald City. For
+some enemy is evidently trying to prevent us from reaching it."
+
+"I will do that gladly," returned the Queen. "Are you ready?"
+
+The Tin Woodman looked at Tip.
+
+"I'm rested," said the boy. "Let us start."
+
+Then they resumed their journey, the little grey Queen of the Field
+Mice running swiftly ahead and then pausing until the travelers drew
+near, when away she would dart again.
+
+Without this unerring guide the Scarecrow and his comrades might never
+have gained the Emerald City; for many were the obstacles thrown in
+their way by the arts of old Mombi. Yet not one of the obstacles really
+existed--all were cleverly contrived deceptions. For when they came
+to the banks of a rushing river that threatened to bar their way the
+little Queen kept steadily on, passing through the seeming flood in
+safety; and our travelers followed her without encountering a single
+drop of water.
+
+Again, a high wall of granite towered high above their heads and
+opposed their advance. But the grey Field Mouse walked straight through
+it, and the others did the same, the wall melting into mist as they
+passed it.
+
+Afterward, when they had stopped for a moment to allow Tip to rest,
+they saw forty roads branching off from their feet in forty different
+directions; and soon these forty roads began whirling around like a
+mighty wheel, first in one direction and then in the other, completely
+bewildering their vision.
+
+But the Queen called for them to follow her and darted off in a
+straight line; and when they had gone a few paces the whirling pathways
+vanished and were seen no more.
+
+Mombi's last trick was most fearful of all. She sent a sheet of
+crackling flame rushing over the meadow to consume them; and for the
+first time the Scarecrow became afraid and turned to fly.
+
+"If that fire reaches me I will be gone in no time!" said he, trembling
+until his straw rattled. "It's the most dangerous thing I ever
+encountered."
+
+"I'm off, too!" cried the Saw-Horse, turning and prancing with
+agitation; "for my wood is so dry it would burn like kindlings."
+
+"Is fire dangerous to pumpkins?" asked Jack, fearfully.
+
+[Illustration]
+
+"You'll be baked like a tart--and so will I!" answered the Woggle-Bug,
+getting down on all fours so he could run the faster.
+
+But the Tin Woodman, having no fear of fire, averted the stampede by a
+few sensible words.
+
+"Look at the Field Mouse!" he shouted. "The fire does not burn her in
+the least. In fact, it is no fire at all, but only a deception."
+
+Indeed, to watch the little Queen march calmly through the advancing
+flames restored courage to every member of the party, and they followed
+her without being even scorched.
+
+"This is surely a most extraordinary adventure," said the Woggle-Bug,
+who was greatly amazed; "for it upsets all the Natural Laws that I
+heard Professor Nowitall teach in the school-house."
+
+"Of course it does," said the Scarecrow, wisely. "All magic is
+unnatural, and for that reason is to be feared and avoided. But I see
+before us the gates of the Emerald City, so I imagine we have now
+overcome all the magical obstacles that seemed to oppose us."
+
+Indeed, the walls of the City were plainly visible, and the Queen of
+the Field Mice, who had guided them so faithfully, came near to bid
+them good-bye.
+
+"We are very grateful to your Majesty for your kind assistance," said
+the Tin Woodman, bowing before the pretty creature.
+
+"I am always pleased to be of service to my friends," answered the
+Queen, and in a flash she had darted away upon her journey home.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Prisoners of the Queen
+]
+
+
+Approaching the gateway of the Emerald City the travelers found it
+guarded by two girls of the Army of Revolt, who opposed their entrance
+by drawing the knitting-needles from their hair and threatening to prod
+the first that came near.
+
+But the Tin Woodman was not afraid.
+
+"At the worst they can but scratch my beautiful nickel-plate," he said.
+"But there will be no 'worst,' for I think I can manage to frighten
+these absurd soldiers very easily. Follow me closely, all of you!"
+
+Then, swinging his axe in a great circle to right and left before
+him, he advanced upon the gate, and the others followed him without
+hesitation.
+
+The girls, who had expected no resistance whatever, were terrified by
+the sweep of the glittering axe and fled screaming into the city; so
+that our travelers passed the gates in safety and marched down the
+green marble pavement of the wide street toward the royal palace.
+
+"At this rate we will soon have your Majesty upon the throne again,"
+said the Tin Woodman, laughing at his easy conquest of the guards.
+
+"Thank you, friend Nick," returned the Scarecrow, gratefully. "Nothing
+can resist your kind heart and your sharp axe."
+
+As they passed the rows of houses they saw through the open doors that
+men were sweeping and dusting and washing dishes, while the women sat
+around in groups, gossiping and laughing.
+
+"What has happened?" the Scarecrow asked a sad-looking man with a bushy
+beard, who wore an apron and was wheeling a baby-carriage along the
+sidewalk.
+
+"Why, we've had a revolution, your Majesty--as you ought to know very
+well," replied the man; "and since you went away the women have been
+running things to suit themselves. I'm glad you have decided to come
+back and restore order, for doing housework and minding the children is
+wearing out the strength of every man in the Emerald City."
+
+"Hm!" said the Scarecrow, thoughtfully. "If it is such hard work as
+you say, how did the women manage it so easily?"
+
+"I really do not know," replied the man, with a deep sigh. "Perhaps the
+women are made of cast-iron."
+
+No movement was made, as they passed along the street, to oppose their
+progress. Several of the women stopped their gossip long enough to cast
+curious looks upon our friends, but immediately they would turn away
+with a laugh or a sneer and resume their chatter. And when they met
+with several girls belonging to the Army of Revolt, those soldiers,
+instead of being alarmed or appearing surprised, merely stepped out of
+the way and allowed them to advance without protest.
+
+This action rendered the Scarecrow uneasy.
+
+"I'm afraid we are walking into a trap," said he.
+
+"Nonsense!" returned Nick Chopper, confidently; "the silly creatures
+are conquered already!"
+
+But the Scarecrow shook his head in a way that expressed doubt, and Tip
+said:
+
+"It's too easy, altogether. Look out for trouble ahead."
+
+"I will," returned his Majesty.
+
+[Illustration: "IT'S TOO EASY, ALTOGETHER."]
+
+Unopposed they reached the royal palace and marched up the marble
+steps, which had once been thickly encrusted with emeralds but were
+now filled with tiny holes where the jewels had been ruthlessly torn
+from their settings by the Army of Revolt. And so far not a rebel
+barred their way.
+
+Through the arched hallways and into the magnificent throne room
+marched the Tin Woodman and his followers, and here, when the green
+silken curtains fell behind them, they saw a curious sight.
+
+Seated within the glittering throne was General Jinjur, with the
+Scarecrow's second-best crown upon her head, and the royal sceptre in
+her right hand. A box of caramels, from which she was eating, rested in
+her lap, and the girl seemed entirely at ease in her royal surroundings.
+
+The Scarecrow stepped forward and confronted her, while the Tin Woodman
+leaned upon his axe and the others formed a half-circle back of his
+Majesty's person.
+
+"How dare you sit in my throne?" demanded the Scarecrow, sternly eyeing
+the intruder. "Don't you know you are guilty of treason, and that there
+is a law against treason?"
+
+"The throne belongs to whoever is able to take it," answered Jinjur, as
+she slowly ate another caramel. "I have taken it, as you see; so just
+now I am the Queen, and all who oppose me are guilty of treason, and
+must be punished by the law you have just mentioned."
+
+This view of the case puzzled the Scarecrow.
+
+"How is it, friend Nick?" he asked, turning to the Tin Woodman.
+
+"Why, when it comes to Law, I have nothing to say," answered that
+personage; "for laws were never meant to be understood, and it is
+foolish to make the attempt."
+
+"Then what shall we do?" asked the Scarecrow, in dismay.
+
+"Why don't you marry the Queen? And then you can both rule," suggested
+the Woggle-Bug.
+
+Jinjur glared at the insect fiercely.
+
+"Why don't you send her back to her mother, where she belongs?" asked
+Jack Pumpkinhead.
+
+Jinjur frowned.
+
+"Why don't you shut her up in a closet until she behaves herself, and
+promises to be good?" enquired Tip. Jinjur's lip curled scornfully.
+
+"Or give her a good shaking!" added the Saw-Horse.
+
+"No," said the Tin Woodman, "we must treat the poor girl with
+gentleness. Let us give her all the jewels she can carry, and send her
+away happy and contented."
+
+At this Queen Jinjur laughed aloud, and the next minute clapped her
+pretty hands together thrice, as if for a signal.
+
+"You are very absurd creatures," said she; "but I am tired of your
+nonsense and have no time to bother with you longer."
+
+While the monarch and his friends listened in amazement to this
+impudent speech, a startling thing happened. The Tin Woodman's axe was
+snatched from his grasp by some person behind him, and he found himself
+disarmed and helpless. At the same instant a shout of laughter rang in
+the ears of the devoted band, and turning to see whence this came they
+found themselves surrounded by the Army of Revolt, the girls bearing in
+either hand their glistening knitting-needles. The entire throne room
+seemed to be filled with the rebels, and the Scarecrow and his comrades
+realized that they were prisoners.
+
+"You see how foolish it is to oppose a woman's wit," said Jinjur,
+gaily; "and this event only proves that I am more fit to rule the
+Emerald City than a Scarecrow. I bear you no ill will, I assure you;
+but lest you should prove troublesome to me in the future I shall order
+you all to be destroyed. That is, all except the boy, who belongs
+to old Mombi and must be restored to her keeping. The rest of you
+are not human, and therefore it will not be wicked to demolish you.
+The Saw-Horse and the Pumpkinhead's body I will have chopped up for
+kindling-wood; and the pumpkin shall be made into tarts. The Scarecrow
+will do nicely to start a bonfire, and the tin man can be cut into
+small pieces and fed to the goats. As for this immense Woggle-Bug--"
+
+"Highly Magnified, if you please!" interrupted the insect.
+
+"I think I will ask the cook to make green-turtle soup of you,"
+continued the Queen, reflectively.
+
+The Woggle-Bug shuddered.
+
+"Or, if that won't do, we might use you for a Hungarian goulash, stewed
+and highly spiced," she added, cruelly.
+
+This programme of extermination was so terrible that the prisoners
+looked upon one another in a panic of fear. The Scarecrow alone did not
+give way to despair. He stood quietly before the Queen and his brow was
+wrinkled in deep thought as he strove to find some means to escape.
+
+While thus engaged he felt the straw within his breast move gently. At
+once his expression changed from sadness to joy, and raising his hand
+he quickly unbuttoned the front of his jacket.
+
+[Illustration]
+
+This action did not pass unnoticed by the crowd of girls clustering
+about him, but none of them suspected what he was doing until a tiny
+grey mouse leaped from his bosom to the floor and scampered away
+between the feet of the Army of Revolt. Another mouse quickly followed;
+then another and another, in rapid succession. And suddenly such a
+scream of terror went up from the Army that it might easily have filled
+the stoutest heart with consternation. The flight that ensued turned to
+a stampede, and the stampede to a panic.
+
+For while the startled mice rushed wildly about the room the Scarecrow
+had only time to note a whirl of skirts and a twinkling of feet as the
+girls disappeared from the palace--pushing and crowding one another in
+their mad efforts to escape.
+
+The Queen, at the first alarm, stood up on the cushions of the throne
+and began to dance frantically upon her tiptoes. Then a mouse ran up
+the cushions, and with a terrified leap poor Jinjur shot clear over the
+head of the Scarecrow and escaped through an archway--never pausing in
+her wild career until she had reached the city gates.
+
+So, in less time than I can explain, the throne room was deserted by
+all save the Scarecrow and his friends, and the Woggle-Bug heaved a
+deep sigh of relief as he exclaimed:
+
+"Thank goodness, we are saved!"
+
+"For a time, yes;" answered the Tin Woodman. "But the enemy will soon
+return, I fear."
+
+"Let us bar all the entrances to the palace!" said the Scarecrow. "Then
+we shall have time to think what is best to be done."
+
+So all except Jack Pumpkinhead, who was still tied fast to the
+Saw-Horse, ran to the various entrances of the royal palace and closed
+the heavy doors, bolting and locking them securely. Then, knowing that
+the Army of Revolt could not batter down the barriers in several days,
+the adventurers gathered once more in the throne room for a council of
+war.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Takes Time to Think
+]
+
+
+"It seems to me," began the Scarecrow, when all were again assembled in
+the throne room, "that the girl Jinjur is quite right in claiming to be
+Queen. And if she is right, then I am wrong, and we have no business to
+be occupying her palace."
+
+"But you were the King until she came," said the Woggle-Bug, strutting
+up and down with his hands in his pockets; "so it appears to me that
+she is the interloper instead of you."
+
+"Especially as we have just conquered her and put her to flight," added
+the Pumpkinhead, as he raised his hands to turn his face toward the
+Scarecrow.
+
+"Have we really conquered her?" asked the Scarecrow, quietly. "Look out
+of the window, and tell me what you see."
+
+Tip ran to the window and looked out.
+
+"The palace is surrounded by a double row of girl soldiers," he
+announced.
+
+"I thought so," returned the Scarecrow. "We are as truly their
+prisoners as we were before the mice frightened them from the palace."
+
+"My friend is right," said Nick Chopper, who had been polishing his
+breast with a bit of chamois-leather. "Jinjur is still the Queen, and
+we are her prisoners."
+
+"But I hope she cannot get at us," exclaimed the Pumpkinhead, with a
+shiver of fear. "She threatened to make tarts of me, you know."
+
+"Don't worry," said the Tin Woodman. "It cannot matter greatly. If you
+stay shut up here you will spoil in time, anyway. A good tart is far
+more admirable than a decayed intellect."
+
+"Very true," agreed the Scarecrow.
+
+"Oh, dear!" moaned Jack; "what an unhappy lot is mine! Why, dear
+father, did you not make me out of tin--or even out of straw--so that
+I would keep indefinitely."
+
+"Shucks!" returned Tip, indignantly. "You ought to be glad that I made
+you at all." Then he added, reflectively, "everything has to come to an
+end, some time."
+
+"But I beg to remind you," broke in the Woggle-Bug, who had a
+distressed look in his bulging, round eyes, "that this terrible Queen
+Jinjur suggested making a goulash of me--Me! the only Highly Magnified
+and Thoroughly Educated Woggle-Bug in the wide, wide world!"
+
+"I think it was a brilliant idea," remarked the Scarecrow, approvingly.
+
+"Don't you imagine he would make a better soup?" asked the Tin Woodman,
+turning toward his friend.
+
+"Well, perhaps," acknowledged the Scarecrow.
+
+The Woggle-Bug groaned.
+
+"I can see, in my mind's eye," said he, mournfully, "the goats eating
+small pieces of my dear comrade, the Tin Woodman, while my soup is
+being cooked on a bonfire built of the Saw-Horse and Jack Pumpkinhead's
+body, and Queen Jinjur watches me boil while she feeds the flames with
+my friend the Scarecrow!"
+
+This morbid picture cast a gloom over the entire party, making them
+restless and anxious.
+
+"It can't happen for some time," said the Tin Woodman, trying to speak
+cheerfully; "for we shall be able to keep Jinjur out of the palace
+until she manages to break down the doors."
+
+"And in the meantime I am liable to starve to death, and so is the
+Woggle-Bug," announced Tip.
+
+"As for me," said the Woggle-Bug, "I think that I could live for some
+time on Jack Pumpkinhead. Not that I prefer pumpkins for food; but I
+believe they are somewhat nutritious, and Jack's head is large and
+plump."
+
+"How heartless!" exclaimed the Tin Woodman, greatly shocked. "Are we
+cannibals, let me ask? Or are we faithful friends?"
+
+"I see very clearly that we cannot stay shut up in this palace," said
+the Scarecrow, with decision. "So let us end this mournful talk and try
+to discover a means to escape."
+
+At this suggestion they all gathered eagerly around the throne, wherein
+was seated the Scarecrow, and as Tip sat down upon a stool there fell
+from his pocket a pepper-box, which rolled upon the floor.
+
+"What is this?" asked Nick Chopper, picking up the box.
+
+"Be careful!" cried the boy. "That's my Powder of Life. Don't spill it,
+for it is nearly gone."
+
+"And what is the Powder of Life?" enquired the Scarecrow, as Tip
+replaced the box carefully in his pocket.
+
+"It's some magical stuff old Mombi got from a crooked sorcerer,"
+explained the boy. "She brought Jack to life with it, and afterward I
+used it to bring the Saw-Horse to life. I guess it will make anything
+live that is sprinkled with it; but there's only about one dose left."
+
+"Then it is very precious," said the Tin Woodman.
+
+"Indeed it is," agreed the Scarecrow. "It may prove our best means of
+escape from our difficulties. I believe I will think for a few minutes;
+so I will thank you, friend Tip, to get out your knife and rip this
+heavy crown from my forehead."
+
+Tip soon cut the stitches that had fastened the crown to the
+Scarecrow's head, and the former monarch of the Emerald City removed it
+with a sigh of relief and hung it on a peg beside the throne.
+
+[Illustration]
+
+"That is my last memento of royalty," said he; "and I'm glad to get rid
+of it. The former King of this City, who was named Pastoria, lost the
+crown to the Wonderful Wizard, who passed it on to me. Now the girl
+Jinjur claims it, and I sincerely hope it will not give her a headache."
+
+"A kindly thought, which I greatly admire," said the Tin Woodman,
+nodding approvingly.
+
+"And now I will indulge in a quiet think," continued the Scarecrow,
+lying back in the throne.
+
+The others remained as silent and still as possible, so as not to
+disturb him; for all had great confidence in the extraordinary brains
+of the Scarecrow.
+
+And, after what seemed a very long time indeed to the anxious watchers,
+the thinker sat up, looked upon his friends with his most whimsical
+expression, and said:
+
+"My brains work beautifully today. I'm quite proud of them. Now,
+listen! If we attempt to escape through the doors of the palace we
+shall surely be captured. And, as we can't escape through the ground,
+there is only one other thing to be done. We must escape through the
+air!"
+
+He paused to note the effect of these words; but all his hearers seemed
+puzzled and unconvinced.
+
+"The Wonderful Wizard escaped in a balloon," he continued. "We don't
+know how to make a balloon, of course; but any sort of thing that can
+fly through the air can carry us easily. So I suggest that my friend
+the Tin Woodman, who is a skillful mechanic, shall build some sort of
+a machine, with good strong wings, to carry us; and our friend Tip can
+then bring the Thing to life with his magical powder."
+
+"Bravo!" cried Nick Chopper.
+
+"What splendid brains!" murmured Jack.
+
+"Really quite clever!" said the Educated Woggle-Bug.
+
+[Illustration]
+
+"I believe it can be done," declared Tip; "that is, if the Tin Woodman
+is equal to making the Thing."
+
+"I'll do my best," said Nick, cheerily; "and, as a matter of fact, I do
+not often fail in what I attempt. But the Thing will have to be built
+on the roof of the palace, so it can rise comfortably into the air."
+
+"To be sure," said the Scarecrow.
+
+"Then let us search through the palace," continued the Tin Woodman,
+"and carry all the material we can find to the roof, where I will begin
+my work."
+
+"First, however," said the Pumpkinhead, "I beg you will release me from
+this horse, and make me another leg to walk with. For in my present
+condition I am of no use to myself or to anyone else."
+
+So the Tin Woodman knocked a mahogany center-table to pieces with his
+axe and fitted one of the legs, which was beautifully carved, on to the
+body of Jack Pumpkinhead, who was very proud of the acquisition.
+
+"It seems strange," said he, as he watched the Tin Woodman work, "that
+my left leg should be the most elegant and substantial part of me."
+
+"That proves you are unusual," returned the Scarecrow; "and I am
+convinced that the only people worthy of consideration in this world
+are the unusual ones. For the common folks are like the leaves of a
+tree, and live and die unnoticed."
+
+"Spoken like a philosopher!" cried the Woggle-Bug, as he assisted the
+Tin Woodman to set Jack upon his feet.
+
+"How do you feel now?" asked Tip, watching the Pumpkinhead stump
+around to try his new leg.
+
+"As good as new," answered Jack, joyfully, "and quite ready to assist
+you all to escape."
+
+"Then let us get to work," said the Scarecrow, in a business-like tone.
+
+So, glad to be doing anything that might lead to the end of their
+captivity, the friends separated to wander over the palace in search of
+fitting material to use in the construction of their aerial machine.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Astonishing Flight
+    of the Gump
+]
+
+
+When the adventurers reassembled upon the roof it was found that a
+remarkably queer assortment of articles had been selected by the
+various members of the party. No one seemed to have a very clear idea
+of what was required, but all had brought something.
+
+The Woggle-Bug had taken from its position over the mantle-piece in the
+great hallway the head of a Gump, which was adorned with wide-spreading
+antlers; and this, with great care and greater difficulty, the insect
+had carried up the stairs to the roof. This Gump resembled an Elk's
+head, only the nose turned upward in a saucy manner and there were
+whiskers upon its chin, like those of a billy-goat. Why the Woggle-Bug
+selected this article he could not have explained, except that it had
+aroused his curiosity.
+
+Tip, with the aid of the Saw-Horse, had brought a large, upholstered
+sofa to the roof. It was an old-fashioned piece of furniture, with high
+back and ends, and it was so heavy that even by resting the greatest
+weight upon the back of the Saw-Horse, the boy found himself out of
+breath when at last the clumsy sofa was dumped upon the roof.
+
+The Pumpkinhead had brought a broom, which was the first thing he saw.
+The Scarecrow arrived with a coil of clotheslines and ropes which he
+had taken from the courtyard, and in his trip up the stairs he had
+become so entangled in the loose ends of the ropes that both he and his
+burden tumbled in a heap upon the roof and might have rolled off if Tip
+had not rescued him.
+
+The Tin Woodman appeared last. He also had been to the courtyard, where
+he had cut four great, spreading leaves from a huge palm-tree that was
+the pride of all the inhabitants of the Emerald City.
+
+"My dear Nick!" exclaimed the Scarecrow, seeing what his friend had
+done; "you have been guilty of the greatest crime any person can
+commit in the Emerald City. If I remember rightly, the penalty for
+chopping leaves from the royal palm-tree is to be killed seven times
+and afterward imprisoned for life."
+
+[Illustration: ALL BROUGHT SOMETHING TO THE ROOF.]
+
+"It cannot be helped now," answered the Tin Woodman, throwing down the
+big leaves upon the roof. "But it may be one more reason why it is
+necessary for us to escape. And now let us see what you have found for
+me to work with."
+
+Many were the doubtful looks cast upon the heap of miscellaneous
+material that now cluttered the roof, and finally the Scarecrow shook
+his head and remarked:
+
+"Well, if friend Nick can manufacture, from this mess of rubbish, a
+Thing that will fly through the air and carry us to safety, then I will
+acknowledge him to be a better mechanic than I suspected."
+
+But the Tin Woodman seemed at first by no means sure of his powers, and
+only after polishing his forehead vigorously with the chamois-leather
+did he resolve to undertake the task.
+
+"The first thing required for the machine," said he, "is a body big
+enough to carry the entire party. This sofa is the biggest thing we
+have, and might be used for a body. But, should the machine ever tip
+sideways, we would all slide off and fall to the ground."
+
+"Why not use two sofas?" asked Tip. "There's another one just like this
+down stairs."
+
+"That is a very sensible suggestion," exclaimed the Tin Woodman. "You
+must fetch the other sofa at once."
+
+So Tip and the Saw-Horse managed, with much labor, to get the second
+sofa to the roof; and when the two were placed together, edge to edge,
+the backs and ends formed a protecting rampart all around the seats.
+
+"Excellent!" cried the Scarecrow. "We can ride within this snug nest
+quite at our ease."
+
+The two sofas were now bound firmly together with ropes and
+clotheslines, and then Nick Chopper fastened the Gump's head to one end.
+
+"That will show which is the front end of the Thing," said he, greatly
+pleased with the idea. "And, really, if you examine it critically, the
+Gump looks very well as a figure-head. These great palm-leaves, for
+which I have endangered my life seven times, must serve us as wings."
+
+"Are they strong enough?" asked the boy.
+
+"They are as strong as anything we can get," answered the Woodman; "and
+although they are not in proportion to the Thing's body, we are not in
+a position to be very particular."
+
+So he fastened the palm-leaves to the sofas, two on each side.
+
+Said the Woggle-Bug, with considerable admiration:
+
+"The Thing is now complete, and only needs to be brought to life."
+
+"Stop a moment!" exclaimed Jack. "Are you not going to use my broom?"
+
+"What for?" asked the Scarecrow.
+
+"Why, it can be fastened to the back end for a tail," answered the
+Pumpkinhead. "Surely you would not call the Thing complete without a
+tail."
+
+"Hm!" said the Tin Woodman; "I do not see the use of a tail. We are not
+trying to copy a beast, or a fish, or a bird. All we ask of the Thing
+is to carry us through the air."
+
+"Perhaps, after the Thing is brought to life, it can use a tail to
+steer with," suggested the Scarecrow. "For if it flies through the air
+it will not be unlike a bird, and I've noticed that all birds have
+tails, which they use for a rudder while flying."
+
+"Very well," answered Nick, "the broom shall be used for a tail," and
+he fastened it firmly to the back end of the sofa body.
+
+Tip took the pepper-box from his pocket.
+
+"The Thing looks very big," said he, anxiously; "and I am not sure
+there is enough powder left to bring all of it to life. But I'll make
+it go as far as possible."
+
+"Put most on the wings," said Nick Chopper; "for they must be made as
+strong as possible."
+
+"And don't forget the head!" exclaimed the Woggle-Bug.
+
+"Or the tail!" added Jack Pumpkinhead.
+
+"Do be quiet," said Tip, nervously; "you must give me a chance to work
+the magic charm in the proper manner."
+
+Very carefully he began sprinkling the Thing with the precious powder.
+Each of the four wings was first lightly covered with a layer; then the
+sofas were sprinkled, and the broom given a slight coating.
+
+"The head! The head! Don't, I beg of you, forget the head!" cried the
+Woggle-Bug, excitedly.
+
+"There's only a little of the powder left," announced Tip, looking
+within the box. "And it seems to me it is more important to bring the
+legs of the sofas to life than the head."
+
+"Not so," decided the Scarecrow. "Every thing must have a head to
+direct it; and since this creature is to fly, and not walk, it is
+really unimportant whether its legs are alive or not."
+
+So Tip abided by this decision and sprinkled the Gump's head with the
+remainder of the powder.
+
+"Now," said he, "keep silence while I work the charm!"
+
+Having heard old Mombi pronounce the magic words, and having also
+succeeded in bringing the Saw-Horse to life, Tip did not hesitate an
+instant in speaking the three cabalistic words, each accompanied by the
+peculiar gesture of the hands.
+
+It was a grave and impressive ceremony.
+
+As he finished the incantation the Thing shuddered throughout its
+huge bulk, the Gump gave the screeching cry that is familiar to those
+animals, and then the four wings began flopping furiously.
+
+[Illustration]
+
+Tip managed to grasp a chimney, else he would have been blown off the
+roof by the terrible breeze raised by the wings. The Scarecrow, being
+light in weight, was caught up bodily and borne through the air until
+Tip luckily seized him by one leg and held him fast. The Woggle-Bug
+lay flat upon the roof and so escaped harm, and the Tin Woodman,
+whose weight of tin anchored him firmly, threw both arms around Jack
+Pumpkinhead and managed to save him. The Saw-Horse toppled over upon
+his back and lay with his legs waving helplessly above him.
+
+And now, while all were struggling to recover themselves, the Thing
+rose slowly from the roof and mounted into the air.
+
+"Here! Come back!" cried Tip, in a frightened voice, as he clung to the
+chimney with one hand and the Scarecrow with the other. "Come back at
+once, I command you!"
+
+It was now that the wisdom of the Scarecrow, in bringing the head of
+the Thing to life instead of the legs, was proved beyond a doubt. For
+the Gump, already high in the air, turned its head at Tip's command and
+gradually circled around until it could view the roof of the palace.
+
+"Come back!" shouted the boy, again.
+
+And the Gump obeyed, slowly and gracefully waving its four wings in
+the air until the Thing had settled once more upon the roof and become
+still.
+
+[Illustration: "COME BACK!"]
+
+
+
+
+[Illustration:
+
+    In the Jackdaws' Nest
+]
+
+
+"This," said the Gump, in a squeaky voice not at all proportioned to
+the size of its great body, "is the most novel experience I ever heard
+of. The last thing I remember distinctly is walking through the forest
+and hearing a loud noise. Something probably killed me then, and it
+certainly ought to have been the end of me. Yet here I am, alive again,
+with four monstrous wings and a body which I venture to say would make
+any respectable animal or fowl weep with shame to own. What does it all
+mean? Am I a Gump, or am I a juggernaut?" The creature, as it spoke,
+wiggled its chin whiskers in a very comical manner.
+
+"You're just a Thing," answered Tip, "with a Gump's head on it. And we
+have made you and brought you to life so that you may carry us through
+the air wherever we wish to go."
+
+"Very good!" said the Thing. "As I am not a Gump, I cannot have a
+Gump's pride or independent spirit. So I may as well become your
+servant as anything else. My only satisfaction is that I do not seem
+to have a very strong constitution, and am not likely to live long in
+a state of slavery."
+
+"Don't say that, I beg of you!" cried the Tin Woodman, whose excellent
+heart was strongly affected by this sad speech. "Are you not feeling
+well today?"
+
+"Oh, as for that," returned the Gump, "it is my first day of existence;
+so I cannot judge whether I am feeling well or ill." And it waved its
+broom tail to and fro in a pensive manner.
+
+"Come, come!" said the Scarecrow, kindly; "do try to be more cheerful
+and take life as you find it. We shall be kind masters, and will strive
+to render your existence as pleasant as possible. Are you willing to
+carry us through the air wherever we wish to go?"
+
+"Certainly," answered the Gump. "I greatly prefer to navigate the air.
+For should I travel on the earth and meet with one of my own species,
+my embarrassment would be something awful!"
+
+"I can appreciate that," said the Tin Woodman, sympathetically.
+
+"And yet," continued the Thing, "when I carefully look you over, my
+masters, none of you seems to be constructed much more artistically
+than I am."
+
+"Appearances are deceitful," said the Woggle-Bug, earnestly. "I am both
+Highly Magnified and Thoroughly Educated."
+
+"Indeed!" murmured the Gump, indifferently.
+
+"And my brains are considered remarkably rare specimens," added the
+Scarecrow, proudly.
+
+"How strange!" remarked the Gump.
+
+"Although I am of tin," said the Woodman, "I own a heart altogether the
+warmest and most admirable in the whole world."
+
+"I'm delighted to hear it," replied the Gump, with a slight cough.
+
+"My smile," said Jack Pumpkinhead, "is worthy your best attention. It
+is always the same."
+
+"_Semper idem_," explained the Woggle-Bug, pompously; and the Gump
+turned to stare at him.
+
+"And I," declared the Saw-Horse, filling in an awkward pause, "am only
+remarkable because I can't help it."
+
+"I am proud, indeed, to meet with such exceptional masters," said
+the Gump, in a careless tone. "If I could but secure so complete an
+introduction to myself, I would be more than satisfied."
+
+"That will come in time," remarked the Scarecrow. "To 'Know Thyself'
+is considered quite an accomplishment, which it has taken us, who are
+your elders, months to perfect. But now," he added, turning to the
+others, "let us get aboard and start upon our journey."
+
+"Where shall we go?" asked Tip, as he clambered to a seat on the sofas
+and assisted the Pumpkinhead to follow him.
+
+"In the South Country rules a very delightful Queen called Glinda
+the Good, who I am sure will gladly receive us," said the Scarecrow,
+getting into the Thing clumsily. "Let us go to her and ask her advice."
+
+"That is cleverly thought of," declared Nick Chopper, giving the
+Woggle-Bug a boost and then toppling the Saw-Horse into the rear end
+of the cushioned seats. "I know Glinda the Good, and believe she will
+prove a friend indeed."
+
+"Are we all ready?" asked the boy.
+
+"Yes," announced the Tin Woodman, seating himself beside the Scarecrow.
+
+"Then," said Tip, addressing the Gump, "be kind enough to fly with us
+to the Southward; and do not go higher than to escape the houses and
+trees, for it makes me dizzy to be up so far."
+
+"All right," answered the Gump, briefly.
+
+It flopped its four huge wings and rose slowly into the air; and then,
+while our little band of adventurers clung to the backs and sides of
+the sofas for support, the Gump turned toward the South and soared
+swiftly and majestically away.
+
+"The scenic effect, from this altitude, is marvelous," commented the
+educated Woggle-Bug, as they rode along.
+
+"Never mind the scenery," said the Scarecrow. "Hold on tight, or you
+may get a tumble. The Thing seems to rock badly."
+
+"It will be dark soon," said Tip, observing that the sun was low on the
+horizon. "Perhaps we should have waited until morning. I wonder if the
+Gump can fly in the night."
+
+"I've been wondering that myself," returned the Gump, quietly. "You
+see, this is a new experience to me. I used to have legs that carried
+me swiftly over the ground. But now my legs feel as if they were
+asleep."
+
+"They are," said Tip. "We didn't bring 'em to life."
+
+"You're expected to fly," explained the Scarecrow; "not to walk."
+
+"We can walk ourselves," said the Woggle-Bug.
+
+"I begin to understand what is required of me," remarked the Gump; "so
+I will do my best to please you," and he flew on for a time in silence.
+
+Presently Jack Pumpkinhead became uneasy.
+
+"I wonder if riding through the air is liable to spoil pumpkins," he
+said.
+
+"Not unless you carelessly drop your head over the side," answered the
+Woggle-Bug. "In that event your head would no longer be a pumpkin, for
+it would become a squash."
+
+"Have I not asked you to restrain these unfeeling jokes?" demanded Tip,
+looking at the Woggle-Bug with a severe expression.
+
+"You have; and I've restrained a good many of them," replied the
+insect. "But there are opportunities for so many excellent puns in our
+language that, to an educated person like myself, the temptation to
+express them is almost irresistible."
+
+"People with more or less education discovered those puns centuries
+ago," said Tip.
+
+"Are you sure?" asked the Woggle-Bug, with a startled look.
+
+"Of course I am," answered the boy. "An educated Woggle-Bug may be a
+new thing; but a Woggle-Bug education is as old as the hills, judging
+from the display you make of it."
+
+The insect seemed much impressed by this remark, and for a time
+maintained a meek silence.
+
+The Scarecrow, in shifting his seat, saw upon the cushions the
+pepper-box which Tip had cast aside, and began to examine it.
+
+"Throw it overboard," said the boy; "it's quite empty now, and there's
+no use keeping it."
+
+"Is it really empty?" asked the Scarecrow, looking curiously into the
+box.
+
+"Of course it is," answered Tip. "I shook out every grain of the
+powder."
+
+"Then the box has two bottoms," announced the Scarecrow; "for the
+bottom on the inside is fully an inch away from the bottom on the
+outside."
+
+"Let me see," said the Tin Woodman, taking the box from his friend.
+"Yes," he declared, after looking it over, "the thing certainly has a
+false bottom. Now, I wonder what that is for?"
+
+"Can't you get it apart, and find out?" enquired Tip, now quite
+interested in the mystery.
+
+"Why, yes; the lower bottom unscrews," said the Tin Woodman. "My
+fingers are rather stiff; please see if you can open it."
+
+He handed the pepper-box to Tip, who had no difficulty in unscrewing
+the bottom. And in the cavity below were three silver pills, with a
+carefully folded paper lying underneath them.
+
+This paper the boy proceeded to unfold, taking care not to spill the
+pills, and found several lines clearly written in red ink.
+
+"Read it aloud," said the Scarecrow; so Tip read as follows:
+
+    "DR. NIKIDIK'S CELEBRATED WISHING PILLS.
+
+    "_Directions for Use_: Swallow one pill; count seventeen by twos;
+    then make a Wish.--The Wish will immediately be granted.
+
+    "CAUTION: Keep in a Dry and Dark Place."
+
+"Why, this is a very valuable discovery!" cried the Scarecrow.
+
+"It is, indeed," replied Tip, gravely. "These pills may be of great
+use to us. I wonder if old Mombi knew they were in the bottom of the
+pepper-box. I remember hearing her say that she got the Powder of Life
+from this same Nikidik."
+
+"He must be a powerful Sorcerer!" exclaimed the Tin Woodman; "and since
+the powder proved a success we ought to have confidence in the pills."
+
+"But how," asked the Scarecrow, "can anyone count seventeen by twos?
+Seventeen is an odd number.
+
+"That is true," replied Tip, greatly disappointed. "No one can possibly
+count seventeen by twos."
+
+"Then the pills are of no use to us," wailed the Pumpkinhead; "and this
+fact overwhelms me with grief. For I had intended wishing that my head
+would never spoil."
+
+"Nonsense!" said the Scarecrow, sharply. "If we could use the pills at
+all we would make far better wishes than that."
+
+"I do not see how anything could be better," protested poor Jack. "If
+you were liable to spoil at any time you could understand my anxiety."
+
+"For my part," said the Tin Woodman, "I sympathize with you in every
+respect. But since we cannot count seventeen by twos, sympathy is all
+you are liable to get."
+
+By this time it had become quite dark, and the voyagers found above
+them a cloudy sky, through which the rays of the moon could not
+penetrate.
+
+The Gump flew steadily on, and for some reason the huge sofa-body
+rocked more and more dizzily every hour.
+
+The Woggle-Bug declared he was sea-sick; and Tip was also pale and
+somewhat distressed. But the others clung to the backs of the sofas and
+did not seem to mind the motion as long as they were not tipped out.
+
+Darker and darker grew the night, and on and on sped the Gump through
+the black heavens. The travelers could not even see one another, and
+an oppressive silence settled down upon them.
+
+After a long time Tip, who had been thinking deeply, spoke.
+
+"How are we to know when we come to the palace of Glinda the Good?" he
+asked.
+
+"It's a long way to Glinda's palace," answered the Woodman; "I've
+traveled it."
+
+"But how are we to know how fast the Gump is flying?" persisted the
+boy. "We cannot see a single thing down on the earth, and before
+morning we may be far beyond the place we want to reach."
+
+"That is all true enough," the Scarecrow replied, a little uneasily.
+"But I do not see how we can stop just now; for we might alight in a
+river, or on the top of a steeple; and that would be a great disaster."
+
+So they permitted the Gump to fly on, with regular flops of its great
+wings, and waited patiently for morning.
+
+Then Tip's fears were proven to be well founded; for with the first
+streaks of gray dawn they looked over the sides of the sofas and
+discovered rolling plains dotted with queer villages, where the houses,
+instead of being dome-shaped--as they all are in the Land of Oz--had
+slanting roofs that rose to a peak in the center. Odd looking animals
+were also moving about upon the open plains, and the country was
+unfamiliar to both the Tin Woodman and the Scarecrow, who had formerly
+visited Glinda the Good's domain and knew it well.
+
+"We are lost!" said the Scarecrow, dolefully. "The Gump must have
+carried us entirely out of the Land of Oz and over the sandy deserts
+and into the terrible outside world that Dorothy told us about."
+
+"We must get back," exclaimed the Tin Woodman, earnestly; "we must get
+back as soon as possible!"
+
+"Turn around!" cried Tip to the Gump; "turn as quickly as you can!"
+
+"If I do I shall upset," answered the Gump. "I'm not at all used to
+flying, and the best plan would be for me to alight in some place, and
+then I can turn around and take a fresh start."
+
+Just then, however, there seemed to be no stopping-place that would
+answer their purpose. They flew over a village so big that the
+Woggle-Bug declared it was a city; and then they came to a range of
+high mountains with many deep gorges and steep cliffs showing plainly.
+
+"Now is our chance to stop," said the boy, finding they were very
+close to the mountain tops. Then he turned to the Gump and commanded:
+"Stop at the first level place you see!"
+
+"Very well," answered the Gump, and settled down upon a table of rock
+that stood between two cliffs.
+
+But not being experienced in such matters, the Gump did not judge his
+speed correctly; and instead of coming to a stop upon the flat rock he
+missed it by half the width of his body, breaking off both his right
+wings against the sharp edge of the rock and then tumbling over and
+over down the cliff.
+
+Our friends held on to the sofas as long as they could, but when the
+Gump caught on a projecting rock the Thing stopped suddenly--bottom
+side up--and all were immediately dumped out.
+
+By good fortune they fell only a few feet; for underneath them was a
+monster nest, built by a colony of Jackdaws in a hollow ledge of rock;
+so none of them--not even the Pumpkinhead--was injured by the fall.
+For Jack found his precious head resting on the soft breast of the
+Scarecrow, which made an excellent cushion; and Tip fell on a mass of
+leaves and papers, which saved him from injury. The Woggle-Bug had
+bumped his round head against the Saw-Horse, but without causing him
+more than a moment's inconvenience.
+
+[Illustration: ALL WERE IMMEDIATELY DUMPED OUT.]
+
+The Tin Woodman was at first much alarmed; but finding he had escaped
+without even a scratch upon his beautiful nickel-plate he at once
+regained his accustomed cheerfulness and turned to address his comrades.
+
+"Our journey has ended rather suddenly," said he, "and we cannot justly
+blame our friend the Gump for our accident, because he did the best he
+could under the circumstances. But how we are ever to escape from this
+nest I must leave to someone with better brains than I possess."
+
+Here he gazed at the Scarecrow; who crawled to the edge of the nest and
+looked over. Below them was a sheer precipice several hundred feet in
+depth. Above them was a smooth cliff unbroken save by the point of rock
+where the wrecked body of the Gump still hung suspended from the end of
+one of the sofas. There really seemed to be no means of escape, and as
+they realized their helpless plight the little band of adventurers gave
+way to their bewilderment.
+
+"This is a worse prison than the palace," sadly remarked the Woggle-Bug.
+
+"I wish we had stayed there," moaned Jack. "I'm afraid the mountain
+air isn't good for pumpkins."
+
+"It won't be when the Jackdaws come back," growled the Saw-Horse, which
+lay waving its legs in a vain endeavor to get upon its feet again.
+"Jackdaws are especially fond of pumpkins."
+
+"Do you think the birds will come here?" asked Jack, much distressed.
+
+"Of course they will," said Tip; "for this is their nest. And there
+must be hundreds of them," he continued, "for see what a lot of things
+they have brought here!"
+
+Indeed, the nest was half filled with a most curious collection of
+small articles for which the birds could have no use, but which the
+thieving Jackdaws had stolen during many years from the homes of men.
+And as the nest was safely hidden where no human being could reach it,
+this lost property would never be recovered.
+
+The Woggle-Bug, searching among the rubbish--for the Jackdaws stole
+useless things as well as valuable ones--turned up with his foot a
+beautiful diamond necklace. This was so greatly admired by the Tin
+Woodman that the Woggle-Bug presented it to him with a graceful speech,
+after which the Woodman hung it around his neck with much pride,
+rejoicing exceedingly when the big diamonds glittered in the sun's
+rays.
+
+[Illustration: TURNED UP A BEAUTIFUL DIAMOND NECKLACE.]
+
+But now they heard a great jabbering and flopping of wings, and as the
+sound grew nearer to them Tip exclaimed:
+
+"The Jackdaws are coming! And if they find us here they will surely
+kill us in their anger."
+
+"I was afraid of this!" moaned the Pumpkinhead. "My time has come!"
+
+"And mine, also!" said the Woggle-Bug; "for Jackdaws are the greatest
+enemies of my race."
+
+The others were not at all afraid; but the Scarecrow at once decided
+to save those of the party who were liable to be injured by the angry
+birds. So he commanded Tip to take off Jack's head and lie down with
+it in the bottom of the nest, and when this was done he ordered
+the Woggle-Bug to lie beside Tip. Nick Chopper, who knew from past
+experience just what to do, then took the Scarecrow to pieces--(all
+except his head)--and scattered the straw over Tip and the Woggle-Bug,
+completely covering their bodies.
+
+Hardly had this been accomplished when the flock of Jackdaws reached
+them. Perceiving the intruders in their nest the birds flew down upon
+them with screams of rage.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Dr. Nikidik's
+    Famous Wishing Pills
+]
+
+
+The Tin Woodman was usually a peaceful man, but when occasion required
+he could fight as fiercely as a Roman gladiator. So, when the Jackdaws
+nearly knocked him down in their rush of wings, and their sharp beaks
+and claws threatened to damage his brilliant plating, the Woodman
+picked up his axe and made it whirl swiftly around his head.
+
+But although many were beaten off in this way, the birds were so
+numerous and so brave that they continued the attack as furiously as
+before. Some of them pecked at the eyes of the Gump, which hung over
+the nest in a helpless condition; but the Gump's eyes were of glass and
+could not be injured. Others of the Jackdaws rushed at the Saw-Horse;
+but that animal, being still upon his back, kicked out so viciously
+with his wooden legs that he beat off as many assailants as did the
+Woodman's axe.
+
+Finding themselves thus opposed, the birds fell upon the Scarecrow's
+straw, which lay at the center of the nest, covering Tip and the
+Woggle-Bug and Jack's pumpkin head, and began tearing it away and
+flying off with it, only to let it drop, straw by straw into the great
+gulf beneath.
+
+The Scarecrow's head, noting with dismay this wanton destruction of
+his interior, cried to the Tin Woodman to save him; and that good
+friend responded with renewed energy. His axe fairly flashed among
+the Jackdaws, and fortunately the Gump began wildly waving the two
+wings remaining on the left side of its body. The flutter of these
+great wings filled the Jackdaws with terror, and when the Gump by its
+exertions freed itself from the peg of rock on which it hung, and sank
+flopping into the nest, the alarm of the birds knew no bounds and they
+fled screaming over the mountains.
+
+When the last foe had disappeared, Tip crawled from under the sofas and
+assisted the Woggle-Bug to follow him.
+
+"We are saved!" shouted the boy, delightedly.
+
+"We are, indeed!" responded the Educated Insect, fairly hugging the
+stiff head of the Gump in his joy; "and we owe it all to the flopping
+of the Thing and the good axe of the Woodman!"
+
+"If I am saved, get me out of here!" called Jack, whose head was still
+beneath the sofas; and Tip managed to roll the pumpkin out and place it
+upon its neck again. He also set the Saw-Horse upright, and said to it:
+
+"We owe you many thanks for the gallant fight you made."
+
+"I really think we have escaped very nicely," remarked the Tin Woodman,
+in a tone of pride.
+
+"Not so!" exclaimed a hollow voice.
+
+At this they all turned in surprise to look at the Scarecrow's head,
+which lay at the back of the nest.
+
+[Illustration]
+
+"I am completely ruined!" declared the Scarecrow, as he noted their
+astonishment. "For where is the straw that stuffs my body?"
+
+The awful question startled them all. They gazed around the nest with
+horror, for not a vestige of straw remained. The Jackdaws had stolen
+it to the last wisp and flung it all into the chasm that yawned for
+hundreds of feet beneath the nest.
+
+"My poor, poor friend!" said the Tin Woodman, taking up the Scarecrow's
+head and caressing it tenderly; "whoever could imagine you would come
+to this untimely end?"
+
+"I did it to save my friends," returned the head; "and I am glad that
+I perished in so noble and unselfish a manner."
+
+"But why are you all so despondent?" inquired the Woggle-Bug. "The
+Scarecrow's clothing is still safe."
+
+"Yes," answered the Tin Woodman; "but our friend's clothes are useless
+without stuffing."
+
+"Why not stuff him with money?" asked Tip.
+
+"Money!" they all cried, in an amazed chorus.
+
+"To be sure," said the boy. "In the bottom of the nest are thousands of
+dollar bills--and two-dollar bills--and five-dollar bills--and tens,
+and twenties, and fifties. There are enough of them to stuff a dozen
+Scarecrows. Why not use the money?"
+
+The Tin Woodman began to turn over the rubbish with the handle of his
+axe; and, sure enough, what they had first thought only worthless
+papers were found to be all bills of various denominations, which the
+mischievous Jackdaws had for years been engaged in stealing from the
+villages and cities they visited.
+
+[Illustration]
+
+There was an immense fortune lying in that inaccessible nest; and Tip's
+suggestion was, with the Scarecrow's consent, quickly acted upon.
+
+They selected all the newest and cleanest bills and assorted them
+into various piles. The Scarecrow's left leg boot were stuffed with
+five-dollar bills; his right leg was stuffed with ten-dollar bills, and
+his body so closely filled with fifties, one-hundreds and one-thousands
+that he could scarcely button his jacket with comfort.
+
+"You are now," said the Woggle-Bug, impressively, when the task had
+been completed, "the most valuable member of our party; and as you are
+among faithful friends there is little danger of your being spent."
+
+"Thank you," returned the Scarecrow, gratefully. "I feel like a new
+man; and although at first glance I might be mistaken for a Safety
+Deposit Vault, I beg you to remember that my Brains are still composed
+of the same old material. And these are the possessions that have
+always made me a person to be depended upon in an emergency."
+
+"Well, the emergency is here," observed Tip; "and unless your brains
+help us out of it we shall be compelled to pass the remainder of our
+lives in this nest."
+
+"How about these wishing pills?" enquired the Scarecrow, taking the box
+from his jacket pocket. "Can't we use them to escape?"
+
+"Not unless we can count seventeen by twos," answered the Tin Woodman.
+"But our friend the Woggle-Bug claims to be highly educated, so he
+ought easily to figure out how that can be done."
+
+"It isn't a question of education," returned the Insect; "it's merely a
+question of mathematics. I've seen the Professor work lots of sums on
+the black-board, and he claimed anything could be done with x's and y's
+and a's, and such things, by mixing them up with plenty of plusses and
+minuses and equals, and so forth. But he never said anything, so far
+as I can remember, about counting up to the odd number of seventeen by
+the even numbers of twos."
+
+"Stop! stop!" cried the Pumpkinhead. "You're making my head ache."
+
+"And mine," added the Scarecrow. "Your mathematics seem to me very like
+a bottle of mixed pickles--the more you fish for what you want the less
+chance you have of getting it. I am certain that if the thing can be
+accomplished at all, it is in a very simple manner."
+
+"Yes," said Tip; "old Mombi couldn't use x's and minuses, for she never
+went to school."
+
+"Why not start counting at a half of one?" asked the Saw-Horse,
+abruptly. "Then anyone can count up to seventeen by twos very easily."
+
+They looked at each other in surprise, for the Saw-Horse was considered
+the most stupid of the entire party.
+
+"You make me quite ashamed of myself," said the Scarecrow, bowing low
+to the Saw-Horse.
+
+"Nevertheless, the creature is right," declared the Woggle-Bug; "for
+twice one-half is one, and if you get to one it is easy to count from
+one up to seventeen by twos."
+
+"I wonder I didn't think of that myself," said the Pumpkinhead.
+
+"I don't," returned the Scarecrow. "You're no wiser than the rest of
+us, are you? But let us make a wish at once. Who will swallow the first
+pill?"
+
+"Suppose you do it," suggested Tip.
+
+"I can't," said the Scarecrow.
+
+"Why not? You've a mouth, haven't you?" asked the boy.
+
+"Yes; but my mouth is painted on, and there's no swallow connected with
+it," answered the Scarecrow. "In fact," he continued, looking from one
+to another critically, "I believe the boy and the Woggle-Bug are the
+only ones in our party that are able to swallow."
+
+Observing the truth of this remark, Tip said:
+
+"Then I will undertake to make the first wish. Give me one of the
+Silver Pills."
+
+This the Scarecrow tried to do; but his padded gloves were too clumsy
+to clutch so small an object, and he held the box toward the boy while
+Tip selected one of the pills and swallowed it.
+
+"Count!" cried the Scarecrow.
+
+"One-half, one, three, five, seven, nine, eleven, thirteen, fifteen,
+seventeen!" counted Tip.
+
+"Now wish!" said the Tin Woodman anxiously.
+
+But just then the boy began to suffer such fearful pains that he became
+alarmed.
+
+"The pill has poisoned me!" he gasped; "O--h! O-o-o-o-o! Ouch! Murder!
+Fire! O-o-h!" and here he rolled upon the bottom of the nest in such
+contortions that he frightened them all.
+
+"What can we do for you? Speak, I beg!" entreated the Tin Woodman,
+tears of sympathy running down his nickel cheeks.
+
+"I--I don't know!" answered Tip. "O--h! I wish I'd never swallowed that
+pill!"
+
+Then at once the pain stopped, and the boy rose to his feet again and
+found the Scarecrow looking with amazement at the end of the pepper-box.
+
+"What's happened?" asked the boy, a little ashamed of his recent
+exhibition.
+
+"Why, the three pills are in the box again!" said the Scarecrow.
+
+[Illustration]
+
+"Of course they are," the Woggle-Bug declared. "Didn't Tip wish that
+he'd never swallowed one of them? Well, the wish came true, and he
+_didn't_ swallow one of them. So of course they are all three in the
+box."
+
+"That may be; but the pill gave me a dreadful pain, just the same,"
+said the boy.
+
+"Impossible!" declared the Woggle-Bug. "If you have never swallowed
+it, the pill can not have given you a pain. And as your wish, being
+granted, proves you did not swallow the pill, it is also plain that you
+suffered no pain."
+
+"Then it was a splendid imitation of a pain," retorted Tip, angrily.
+"Suppose you try the next pill yourself. We've wasted one wish already."
+
+"Oh, no, we haven't!" protested the Scarecrow. "Here are still three
+pills in the box, and each pill is good for a wish."
+
+"Now you're making _my_ head ache," said Tip. "I can't understand the
+thing at all. But I won't take another pill, I promise you!" and with
+this remark he retired sulkily to the back of the nest.
+
+"Well," said the Woggle-Bug, "it remains for me to save us in my most
+Highly Magnified and Thoroughly Educated manner; for I seem to be the
+only one able and willing to make a wish. Let me have one of the pills."
+
+He swallowed it without hesitation, and they all stood admiring his
+courage while the Insect counted seventeen by twos in the same way
+that Tip had done. And for some reason--perhaps because Woggle-Bugs
+have stronger stomachs than boys--the silver pellet caused it no pain
+whatever.
+
+"I wish the Gump's broken wings mended, and as good as new!" said the
+Woggle-Bug, in a slow, impressive voice.
+
+All turned to look at the Thing, and so quickly had the wish been
+granted that the Gump lay before them in perfect repair, and as well
+able to fly through the air as when it had first been brought to life
+on the roof of the palace.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow Appeals
+    to Glinda the Good
+]
+
+
+"Hooray!" shouted the Scarecrow, gaily. "We can now leave this
+miserable Jackdaws' nest whenever we please."
+
+"But it is nearly dark," said the Tin Woodman; "and unless we wait
+until morning to make our flight we may get into more trouble. I don't
+like these night trips, for one never knows what will happen."
+
+So it was decided to wait until daylight, and the adventurers amused
+themselves in the twilight by searching the Jackdaws' nest for
+treasures.
+
+The Woggle-Bug found two handsome bracelets of wrought gold, which
+fitted his slender arms very well. The Scarecrow took a fancy for
+rings, of which there were many in the nest. Before long he had fitted
+a ring to each finger of his padded gloves, and not being content
+with that display he added one more to each thumb. As he carefully
+chose those rings set with sparkling stones, such as rubies, amethysts
+and sapphires, the Scarecrow's hands now presented a most brilliant
+appearance.
+
+"This nest would be a picnic for Queen Jinjur," said he, musingly; "for
+as nearly as I can make out she and her girls conquered me merely to
+rob my city of its emeralds."
+
+The Tin Woodman was content with his diamond necklace and refused
+to accept any additional decorations; but Tip secured a fine gold
+watch, which was attached to a heavy fob, and placed it in his pocket
+with much pride. He also pinned several jeweled brooches to Jack
+Pumpkinhead's red waistcoat, and attached a lorgnette, by means of a
+fine chain, to the neck of the Saw-Horse.
+
+"It's very pretty," said the creature, regarding the lorgnette
+approvingly; "but what is it for?"
+
+None of them could answer that question, however; so the Saw-Horse
+decided it was some rare decoration and became very fond of it.
+
+That none of the party might be slighted, they ended by placing several
+large seal rings upon the points of the Gump's antlers, although that
+odd personage seemed by no means gratified by the attention.
+
+Darkness soon fell upon them, and Tip and the Woggle-Bug went to sleep
+while the others sat down to wait patiently for the day.
+
+Next morning they had cause to congratulate themselves upon the useful
+condition of the Gump; for with daylight a great flock of Jackdaws
+approached to engage in one more battle for the possession of the nest.
+
+But our adventurers did not wait for the assault. They tumbled into the
+cushioned seats of the sofas as quickly as possible, and Tip gave the
+word to the Gump to start.
+
+At once it rose into the air, the great wings flopping strongly and
+with regular motions, and in a few moments they were so far from the
+nest that the chattering Jackdaws took possession without any attempt
+at pursuit.
+
+The Thing flew due North, going in the same direction from whence
+it had come. At least, that was the Scarecrow's opinion, and the
+others agreed that the Scarecrow was the best judge of direction.
+After passing over several cities and villages the Gump carried them
+high above a broad plain where houses became more and more scattered
+until they disappeared altogether. Next came the wide, sandy desert
+separating the rest of the world from the Land of Oz, and before noon
+they saw the dome-shaped houses that proved they were once more within
+the borders of their native land.
+
+"But the houses and fences are blue," said the Tin Woodman, "and that
+indicates we are in the land of the Munchkins, and therefore a long
+distance from Glinda the Good."
+
+"What shall we do?" asked the boy, turning to their guide.
+
+"I don't know," replied the Scarecrow, frankly. "If we were at the
+Emerald City we could then move directly southward, and so reach our
+destination. But we dare not go to the Emerald City, and the Gump is
+probably carrying us further in the wrong direction with every flop of
+its wings."
+
+"Then the Woggle-Bug must swallow another pill," said Tip, decidedly,
+"and wish us headed in the right direction."
+
+"Very well," returned the Highly Magnified one; "I'm willing."
+
+But when the Scarecrow searched in his pocket for the pepper-box
+containing the two silver Wishing Pills, it was not to be found. Filled
+with anxiety, the voyagers hunted throughout every inch of the Thing
+for the precious box; but it had disappeared entirely.
+
+And still the Gump flew onward, carrying them they knew not where.
+
+"I must have left the pepper-box in the Jackdaws' nest," said the
+Scarecrow, at length.
+
+"It is a great misfortune," the Tin Woodman declared. "But we are no
+worse off than before we discovered the Wishing Pills."
+
+"We are better off," replied Tip; "for the one pill we used has enabled
+us to escape from that horrible nest."
+
+"Yet the loss of the other two is serious, and I deserve a good
+scolding for my carelessness," the Scarecrow rejoined, penitently. "For
+in such an unusual party as this accidents are liable to happen any
+moment, and even now we may be approaching a new danger."
+
+No one dared contradict this, and a dismal silence ensued.
+
+The Gump flew steadily on.
+
+Suddenly Tip uttered an exclamation of surprise.
+
+"We must have reached the South Country," he cried, "for below us
+everything is red!"
+
+[Illustration]
+
+Immediately they all leaned over the backs of the sofas to look--all
+except Jack, who was too careful of his pumpkin head to risk its
+slipping off his neck. Sure enough; the red houses and fences and
+trees indicated they were within the domain of Glinda the Good; and
+presently, as they glided rapidly on, the Tin Woodman recognized the
+roads and buildings they passed, and altered slightly the flight
+of the Gump so that they might reach the palace of the celebrated
+Sorceress.
+
+"Good!" cried the Scarecrow, delightedly. "We do not need the lost
+Wishing Pills now, for we have arrived at our destination."
+
+Gradually the Thing sank lower and nearer to the ground until at length
+it came to rest within the beautiful gardens of Glinda, settling upon
+a velvety green lawn close by a fountain which sent sprays of flashing
+gems, instead of water, high into the air, whence they fell with a
+soft, tinkling sound into the carved marble basin placed to receive
+them.
+
+Everything was very gorgeous in Glinda's gardens, and while our
+voyagers gazed about with admiring eyes a company of soldiers silently
+appeared and surrounded them. But these soldiers of the great Sorceress
+were entirely different from those of Jinjur's Army of Revolt, although
+they were likewise girls. For Glinda's soldiers wore neat uniforms and
+bore swords and spears; and they marched with a skill and precision
+that proved them well trained in the arts of war.
+
+The Captain commanding this troop--which was Glinda's private Body
+Guard--recognized the Scarecrow and the Tin Woodman at once, and
+greeted them with respectful salutations.
+
+"Good day!" said the Scarecrow, gallantly removing his hat, while the
+Woodman gave a soldierly salute; "we have come to request an audience
+with your fair Ruler."
+
+"Glinda is now within her palace, awaiting you," returned the Captain;
+"for she saw you coming long before you arrived."
+
+"That is strange!" said Tip, wondering.
+
+"Not at all," answered the Scarecrow; "for Glinda the Good is a mighty
+Sorceress, and nothing that goes on in the Land of Oz escapes her
+notice. I suppose she knows why we came as well as we do ourselves."
+
+"Then what was the use of our coming?" asked Jack, stupidly.
+
+[Illustration]
+
+"To prove you are a Pumpkinhead!" retorted the Scarecrow. "But, if the
+Sorceress expects us, we must not keep her waiting."
+
+So they all clambered out of the sofas and followed the Captain toward
+the palace--even the Saw-Horse taking his place in the queer procession.
+
+Upon her throne of finely wrought gold sat Glinda, and she could
+scarcely repress a smile as her peculiar visitors entered and bowed
+before her. Both the Scarecrow and the Tin Woodman she knew and
+liked; but the awkward Pumpkinhead and Highly Magnified Woggle-Bug
+were creatures she had never seen before, and they seemed even more
+curious than the others. As for the Saw-Horse, he looked to be nothing
+more than an animated chunk of wood; and he bowed so stiffly that his
+head bumped against the floor, causing a ripple of laughter among the
+soldiers, in which Glinda frankly joined.
+
+"I beg to announce to your glorious highness," began the Scarecrow, in
+a solemn voice, "that my Emerald City has been overrun by a crowd of
+impudent girls with knitting-needles, who have enslaved all the men,
+robbed the streets and public buildings of all their emerald jewels,
+and usurped my throne."
+
+"I know it," said Glinda.
+
+"They also threatened to destroy me, as well as all the good friends
+and allies you see before you," continued the Scarecrow; "and had we
+not managed to escape their clutches our days would long since have
+ended."
+
+"I know it," repeated Glinda.
+
+"Therefore I have come to beg your assistance," resumed the Scarecrow,
+"for I believe you are always glad to succor the unfortunate and
+oppressed."
+
+"That is true," replied the Sorceress, slowly. "But the Emerald City is
+now ruled by General Jinjur, who has caused herself to be proclaimed
+Queen. What right have I to oppose her?"
+
+"Why, she stole the throne from me," said the Scarecrow.
+
+"And how came you to possess the throne?" asked Glinda.
+
+"I got it from the Wizard of Oz, and by the choice of the people,"
+returned the Scarecrow, uneasy at such questioning.
+
+"And where did the Wizard get it?" she continued, gravely.
+
+"I am told he took it from Pastoria, the former King," said the
+Scarecrow, becoming confused under the intent look of the Sorceress.
+
+"Then," declared Glinda, "the throne of the Emerald City belongs
+neither to you nor to Jinjur, but to this Pastoria from whom the Wizard
+usurped it."
+
+"That is true," acknowledged the Scarecrow, humbly; "but Pastoria is
+now dead and gone, and some one must rule in his place."
+
+"Pastoria had a daughter, who is the rightful heir to the throne of the
+Emerald City. Did you know that?" questioned the Sorceress.
+
+"No," replied the Scarecrow. "But if the girl still lives I will not
+stand in her way. It will satisfy me as well to have Jinjur turned out,
+as an impostor, as to regain the throne myself. In fact, it isn't much
+fun to be King, especially if one has good brains. I have known for
+some time that I am fitted to occupy a far more exalted position. But
+where is this girl who owns the throne, and what is her name?"
+
+"Her name is Ozma," answered Glinda. "But where she is I have tried in
+vain to discover. For the Wizard of Oz, when he stole the throne from
+Ozma's father, hid the girl in some secret place; and by means of a
+magical trick with which I am not familiar he also managed to prevent
+her being discovered--even by so experienced a Sorceress as myself."
+
+"That is strange," interrupted the Woggle-Bug, pompously. "I have
+been informed that the Wonderful Wizard of Oz was nothing more than a
+humbug!"
+
+"Nonsense!" exclaimed the Scarecrow, much provoked by this speech.
+"Didn't he give me a wonderful set of brains?"
+
+"There's no humbug about my heart," announced the Tin Woodman, glaring
+indignantly at the Woggle-Bug.
+
+"Perhaps I was misinformed," stammered the Insect, shrinking back; "I
+never knew the Wizard personally."
+
+"Well, we did," retorted the Scarecrow, "and he was a very great
+Wizard, I assure you. It is true he was guilty of some slight
+impostures, but unless he was a great Wizard how--let me ask--could he
+have hidden this girl Ozma so securely that no one can find her?"
+
+"I--I give it up!" replied the Woggle-Bug, meekly.
+
+"That is the most sensible speech you've made," said the Tin Woodman.
+
+"I must really make another effort to discover where this girl is
+hidden," resumed the Sorceress, thoughtfully. "I have in my library a
+book in which is inscribed every action of the Wizard while he was in
+our land of Oz--or, at least, every action that could be observed by
+my spies. This book I will read carefully tonight, and try to single
+out the acts that may guide us in discovering the lost Ozma. In the
+meantime, pray amuse yourselves in my palace and command my servants as
+if they were your own. I will grant you another audience tomorrow."
+
+With this gracious speech Glinda dismissed the adventurers, and they
+wandered away through the beautiful gardens, where they passed several
+hours enjoying all the delightful things with which the Queen of the
+Southland had surrounded her royal palace.
+
+On the following morning they again appeared before Glinda, who said to
+them:
+
+"I have searched carefully through the records of the Wizard's
+actions, and among them I can find but three that appear to have been
+suspicious. He ate beans with a knife, made three secret visits to old
+Mombi, and limped slightly on his left foot."
+
+"Ah! that last is certainly suspicious!" exclaimed the Pumpkinhead.
+
+"Not necessarily," said the Scarecrow; "he may have had corns. Now, it
+seems to me his eating beans with a knife is more suspicious."
+
+"Perhaps it is a polite custom in Omaha, from which great country the
+Wizard originally came," suggested the Tin Woodman.
+
+"It may be," admitted the Scarecrow.
+
+"But why," asked Glinda, "did he make three secret visits to old Mombi?"
+
+"Ah! Why, indeed!" echoed the Woggle-Bug, impressively.
+
+"We know that the Wizard taught the old woman many of his tricks of
+magic," continued Glinda; "and this he would not have done had she not
+assisted him in some way. So we may suspect with good reason that Mombi
+aided him to hide the girl Ozma, who was the real heir to the throne
+of the Emerald City, and a constant danger to the usurper. For, if the
+people knew that she lived, they would quickly make her their Queen and
+restore her to her rightful position."
+
+"An able argument!" cried the Scarecrow. "I have no doubt that Mombi
+was mixed up in this wicked business. But how does that knowledge help
+us?"
+
+"We must find Mombi," replied Glinda, "and force her to tell where the
+girl is hidden."
+
+"Mombi is now with Queen Jinjur, in the Emerald City," said Tip. "It
+was she who threw so many obstacles in our pathway, and made Jinjur
+threaten to destroy my friends and give me back into the old witch's
+power."
+
+"Then," decided Glinda, "I will march with my army to the Emerald
+City, and take Mombi prisoner. After that we can, perhaps, force her to
+tell the truth about Ozma."
+
+"She is a terrible old woman!" remarked Tip, with a shudder at the
+thought of Mombi's black kettle; "and obstinate, too."
+
+"I am quite obstinate myself," returned the Sorceress, with a sweet
+smile; "so I do not fear Mombi in the least. Today I will make all
+necessary preparations, and we will march upon the Emerald City at
+daybreak tomorrow."
+
+[Illustration: "She is a terrible old woman."]
+
+[Illustration: Jinjur]
+
+
+
+
+[Illustration:
+
+    The Tin-Woodman
+    Plucks a Rose
+]
+
+[Illustration]
+
+The Army of Glinda the Good looked very grand and imposing when it
+assembled at daybreak before the palace gates. The uniforms of the
+girl soldiers were pretty and of gay colors, and their silver-tipped
+spears were bright and glistening, the long shafts being inlaid with
+mother-of-pearl. All the officers wore sharp, gleaming swords, and
+shields edged with peacock-feathers; and it really seemed that no foe
+could by any possibility defeat such a brilliant army.
+
+The Sorceress rode in a beautiful palanquin which was like the body of
+a coach, having doors and windows with silken curtains; but instead
+of wheels, which a coach has, the palanquin rested upon two long,
+horizontal bars, which were borne upon the shoulders of twelve servants.
+
+The Scarecrow and his comrades decided to ride in the Gump, in order
+to keep up with the swift march of the army; so, as soon as Glinda had
+started and her soldiers had marched away to the inspiring strains of
+music played by the royal band, our friends climbed into the sofas
+and followed. The Gump flew along slowly at a point directly over the
+palanquin in which rode the Sorceress.
+
+[Illustration]
+
+"Be careful," said the Tin Woodman to the Scarecrow, who was leaning
+far over the side to look at the army below. "You might fall."
+
+"It wouldn't matter," remarked the educated Woggle-Bug; "he can't get
+broke so long as he is stuffed with money."
+
+"Didn't I ask you--" began Tip, in a reproachful voice.
+
+"You did!" said the Woggle-Bug, promptly. "And I beg your pardon. I
+will really try to restrain myself."
+
+"You'd better," declared the boy. "That is, if you wish to travel in
+our company."
+
+"Ah! I couldn't bear to part with you now," murmured the Insect,
+feelingly; so Tip let the subject drop.
+
+The army moved steadily on, but night had fallen before they came
+to the walls of the Emerald City. By the dim light of the new moon,
+however, Glinda's forces silently surrounded the city and pitched their
+tents of scarlet silk upon the greensward. The tent of the Sorceress
+was larger than the others, and was composed of pure white silk, with
+scarlet banners flying above it. A tent was also pitched for the
+Scarecrow's party; and when these preparations had been made, with
+military precision and quickness, the army retired to rest.
+
+Great was the amazement of Queen Jinjur next morning when her soldiers
+came running to inform her of the vast army surrounding them. She at
+once climbed to a high tower of the royal palace and saw banners waving
+in every direction and the great white tent of Glinda standing directly
+before the gates.
+
+[Illustration]
+
+"We are surely lost!" cried Jinjur, in despair; "for how can our
+knitting-needles avail against the long spears and terrible swords of
+our foes?"
+
+"The best thing we can do," said one of the girls, "is to surrender as
+quickly as possible, before we get hurt."
+
+"Not so," returned Jinjur, more bravely. "The enemy is still outside
+the walls, so we must try to gain time by engaging them in parley. Go
+you with a flag of truce to Glinda and ask her why she has dared to
+invade my dominions, and what are her demands."
+
+So the girl passed through the gates, bearing a white flag to show she
+was on a mission of peace, and came to Glinda's tent.
+
+"Tell your Queen," said the Sorceress to the girl, "that she must
+deliver up to me old Mombi, to be my prisoner. If this is done I will
+not molest her farther."
+
+Now when this message was delivered to the Queen it filled her with
+dismay, for Mombi was her chief counsellor, and Jinjur was terribly
+afraid of the old hag. But she sent for Mombi, and told her what Glinda
+had said.
+
+"I see trouble ahead for all of us," muttered the old witch, after
+glancing into a magic mirror she carried in her pocket. "But we may
+even yet escape by deceiving this sorceress, clever as she thinks
+herself."
+
+"Don't you think it will be safer for me to deliver you into her
+hands?" asked Jinjur, nervously.
+
+"If you do, it will cost you the throne of the Emerald City!" answered
+the witch, positively. "But, if you will let me have my own way, I can
+save us both very easily."
+
+"Then do as you please," replied Jinjur, "for it is so aristocratic to
+be a Queen that I do not wish to be obliged to return home again, to
+make beds and wash dishes for my mother."
+
+So Mombi called Jellia Jamb to her, and performed a certain magical
+rite with which she was familiar. As a result of the enchantment Jellia
+took on the form and features of Mombi, while the old witch grew to
+resemble the girl so closely that it seemed impossible anyone could
+guess the deception.
+
+"Now," said old Mombi to the Queen, "let your soldiers deliver up this
+girl to Glinda. She will think she has the real Mombi in her power, and
+so will return immediately to her own country in the South."
+
+[Illustration]
+
+Therefore Jellia, hobbling along like an aged woman, was led from the
+city gates and taken before Glinda.
+
+"Here is the person you demanded," said one of the guards, "and our
+Queen now begs you will go away, as you promised, and leave us in
+peace."
+
+"That I will surely do," replied Glinda, much pleased; "if this is
+really the person she seems to be."
+
+"It is certainly old Mombi," said the guard, who believed she was
+speaking the truth; and then Jinjur's soldiers returned within the
+city's gates.
+
+The Sorceress quickly summoned the Scarecrow and his friends to her
+tent, and began to question the supposed Mombi about the lost girl
+Ozma. But Jellia knew nothing at all of this affair, and presently she
+grew so nervous under the questioning that she gave way and began to
+weep, to Glinda's great astonishment.
+
+"Here is some foolish trickery!" said the Sorceress, her eyes flashing
+with anger. "This is not Mombi at all, but some other person who has
+been made to resemble her! Tell me," she demanded, turning to the
+trembling girl, "what is your name?"
+
+This Jellia dared not tell, having been threatened with death by the
+witch if she confessed the fraud. But Glinda, sweet and fair though she
+was, understood magic better than any other person in the Land of Oz.
+So, by uttering a few potent words and making a peculiar gesture, she
+quickly transformed the girl into her proper shape, while at the same
+time old Mombi, far away in Jinjur's palace, suddenly resumed her own
+crooked form and evil features.
+
+"Why, it's Jellia Jamb!" cried the Scarecrow, recognizing in the girl
+one of his old friends.
+
+"It's our interpreter!" said the Pumpkinhead, smiling pleasantly.
+
+Then Jellia was forced to tell of the trick Mombi had played, and she
+also begged Glinda's protection, which the Sorceress readily granted.
+But Glinda was now really angry, and sent word to Jinjur that the
+fraud was discovered and she must deliver up the real Mombi or suffer
+terrible consequences. Jinjur was prepared for this message, for the
+witch well understood, when her natural form was thrust upon her, that
+Glinda had discovered her trickery. But the wicked old creature had
+already thought up a new deception, and had made Jinjur promise to
+carry it out. So the Queen said to Glinda's messenger:
+
+[Illustration]
+
+"Tell your mistress that I cannot find Mombi anywhere; but that Glinda
+is welcome to enter the city and search herself for the old woman. She
+may also bring her friends with her, if she likes; but if she does not
+find Mombi by sundown, the Sorceress must promise to go away peaceably
+and bother us no more."
+
+Glinda agreed to these terms, well knowing that Mombi was somewhere
+within the city walls. So Jinjur caused the gates to be thrown open,
+and Glinda marched in at the head of a company of soldiers, followed by
+the Scarecrow and the Tin Woodman, while Jack Pumpkinhead rode astride
+the Saw-Horse, and the Educated, Highly Magnified Woggle-Bug sauntered
+behind in a dignified manner. Tip walked by the side of the Sorceress,
+for Glinda had conceived a great liking for the boy.
+
+Of course old Mombi had no intention of being found by Glinda; so,
+while her enemies were marching up the street, the witch transformed
+herself into a red rose growing upon a bush in the garden of the
+palace. It was a clever idea, and a trick Glinda did not suspect; so
+several precious hours were spent in a vain search for Mombi.
+
+As sundown approached the Sorceress realized she had been defeated by
+the superior cunning of the aged witch; so she gave the command to her
+people to march out of the city and back to their tents.
+
+The Scarecrow and his comrades happened to be searching in the garden
+of the palace just then, and they turned with disappointment to obey
+Glinda's command. But before they left the garden the Tin Woodman,
+who was fond of flowers, chanced to espy a big red rose growing upon
+a bush; so he plucked the flower and fastened it securely in the tin
+button-hole of his tin bosom.
+
+As he did this he fancied he heard a low moan proceed from the rose;
+but he paid no attention to the sound, and Mombi was thus carried out
+of the city and into Glinda's camp without anyone having a suspicion
+that they had succeeded in their quest.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Transformation
+    of Old Mombi
+]
+
+
+The Witch was at first frightened at finding herself captured by the
+enemy; but soon she decided that she was exactly as safe in the Tin
+Woodman's button-hole as growing upon the bush. For no one knew the
+rose and Mombi to be one, and now that she was without the gates of the
+City her chances of escaping altogether from Glinda were much improved.
+
+"But there is no hurry," thought Mombi. "I will wait awhile and enjoy
+the humiliation of this Sorceress when she finds I have outwitted her."
+
+So throughout the night the rose lay quietly on the Woodman's bosom,
+and in the morning, when Glinda summoned our friends to a consultation,
+Nick Chopper carried his pretty flower with him to the white silk tent.
+
+[Illustration]
+
+"For some reason," said Glinda, "we have failed to find this cunning
+old Mombi; so I fear our expedition will prove a failure. And for that
+I am sorry, because without our assistance little Ozma will never be
+rescued and restored to her rightful position as Queen of the Emerald
+City."
+
+"Do not let us give up so easily," said the Pumpkinhead. "Let us do
+something else."
+
+"Something else must really be done," replied Glinda, with a smile;
+"yet I cannot understand how I have been defeated so easily by an old
+Witch who knows far less of magic than I do myself."
+
+"While we are on the ground I believe it would be wise for us to
+conquer the Emerald City for Princess Ozma, and find the girl
+afterward," said the Scarecrow. "And while the girl remains hidden I
+will gladly rule in her place, for I understand the business of ruling
+much better than Jinjur does."
+
+"But I have promised not to molest Jinjur," objected Glinda.
+
+"Suppose you all return with me to my kingdom--or Empire, rather," said
+the Tin Woodman, politely including the entire party in a royal wave of
+his arm. "It will give me great pleasure to entertain you in my castle,
+where there is room enough and to spare. And if any of you wish to be
+nickel-plated, my valet will do it free of all expense."
+
+While the Woodman was speaking Glinda's eyes had been noting the rose
+in his button-hole, and now she imagined she saw the big red leaves of
+the flower tremble slightly. This quickly aroused her suspicions, and
+in a moment more the Sorceress had decided that the seeming rose was
+nothing else than a transformation of old Mombi. At the same instant
+Mombi knew she was discovered and must quickly plan an escape, and
+as transformations were easy to her she immediately took the form of
+a Shadow and glided along the wall of the tent toward the entrance,
+thinking thus to disappear.
+
+But Glinda had not only equal cunning, but far more experience than
+the Witch. So the Sorceress reached the opening of the tent before the
+Shadow, and with a wave of her hand closed the entrance so securely
+that Mombi could not find a crack big enough to creep through. The
+Scarecrow and his friends were greatly surprised at Glinda's actions;
+for none of them had noted the Shadow. But the Sorceress said to them:
+
+"Remain perfectly quiet, all of you! For the old Witch is even now with
+us in this tent, and I hope to capture her."
+
+These words so alarmed Mombi that she quickly transformed herself from
+a shadow to a Black Ant, in which shape she crawled along the ground,
+seeking a crack or crevice in which to hide her tiny body.
+
+Fortunately, the ground where the tent had been pitched, being just
+before the city gates, was hard and smooth; and while the Ant still
+crawled about, Glinda discovered it and ran quickly forward to effect
+its capture. But, just as her hand was descending, the Witch, now
+fairly frantic with fear, made her last transformation, and in the form
+of a huge Griffin sprang through the wall of the tent--tearing the silk
+asunder in her rush--and in a moment had darted away with the speed of
+a whirlwind.
+
+Glinda did not hesitate to follow. She sprang upon the back of the
+Saw-Horse and cried:
+
+"Now you shall prove that you have a right to be alive! Run--run--run!"
+
+The Saw-Horse ran. Like a flash he followed the Griffin, his wooden
+legs moving so fast that they twinkled like the rays of a star. Before
+our friends could recover from their surprise both the Griffin and the
+Saw-Horse had dashed out of sight.
+
+"Come! Let us follow!" cried the Scarecrow.
+
+They ran to the place where the Gump was lying and quickly tumbled
+aboard.
+
+"Fly!" commanded Tip, eagerly.
+
+"Where to?" asked the Gump, in its calm voice.
+
+"I don't know," returned Tip, who was very nervous at the delay; "but
+if you will mount into the air I think we can discover which way Glinda
+has gone."
+
+[Illustration]
+
+"Very well," returned the Gump, quietly; and it spread its great wings
+and mounted high into the air.
+
+Far away, across the meadows, they could now see two tiny specks,
+speeding one after the other; and they knew these specks must be the
+Griffin and the Saw-Horse. So Tip called the Gump's attention to them
+and bade the creature try to overtake the Witch and the Sorceress. But,
+swift as was the Gump's flight, the pursued and pursuer moved more
+swiftly yet, and within a few moments were blotted out against the dim
+horizon.
+
+"Let us continue to follow them, nevertheless," said the Scarecrow;
+"for the Land of Oz is of small extent, and sooner or later they must
+both come to a halt."
+
+Old Mombi had thought herself very wise to choose the form of a
+Griffin, for its legs were exceedingly fleet and its strength more
+enduring than that of other animals. But she had not reckoned on the
+untiring energy of the Saw-Horse, whose wooden limbs could run for days
+without slacking their speed. Therefore, after an hour's hard running,
+the Griffin's breath began to fail, and it panted and gasped painfully,
+and moved more slowly than before. Then it reached the edge of the
+desert and began racing across the deep sands. But its tired feet sank
+far into the sand, and in a few minutes the Griffin fell forward,
+completely exhausted, and lay still upon the desert waste.
+
+Glinda came up a moment later, riding the still vigorous Saw-Horse; and
+having unwound a slender golden thread from her girdle the Sorceress
+threw it over the head of the panting and helpless Griffin, and so
+destroyed the magical power of Mombi's transformation.
+
+For the animal, with one fierce shudder, disappeared from view, while
+in its place was discovered the form of the old Witch, glaring savagely
+at the serene and beautiful face of the Sorceress.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Princess Ozma of Oz
+]
+
+
+"You are my prisoner, and it is useless for you to struggle any
+longer," said Glinda, in her soft, sweet voice. "Lie still a moment,
+and rest yourself, and then I will carry you back to my tent."
+
+"Why do you seek me?" asked Mombi, still scarce able to speak plainly
+for lack of breath. "What have I done to you, to be so persecuted?"
+
+"You have done nothing to me," answered the gentle Sorceress; "but I
+suspect you have been guilty of several wicked actions; and if I find
+it is true that you have so abused your knowledge of magic, I intend to
+punish you severely."
+
+"I defy you!" croaked the old hag. "You dare not harm me!"
+
+Just then the Gump flew up to them and alighted upon the desert sands
+beside Glinda. Our friends were delighted to find that Mombi had
+finally been captured, and after a hurried consultation it was decided
+they should all return to the camp in the Gump. So the Saw-Horse was
+tossed aboard, and then Glinda, still holding an end of the golden
+thread that was around Mombi's neck, forced her prisoner to climb into
+the sofas. The others now followed, and Tip gave the word to the Gump
+to return.
+
+The journey was made in safety, Mombi sitting in her place with a grim
+and sullen air; for the old hag was absolutely helpless so long as the
+magical thread encircled her throat. The army hailed Glinda's return
+with loud cheers, and the party of friends soon gathered again in the
+royal tent, which had been neatly repaired during their absence.
+
+"Now," said the Sorceress to Mombi, "I want you to tell us why the
+Wonderful Wizard of Oz paid you three visits, and what became of the
+child, Ozma, which so curiously disappeared."
+
+The Witch looked at Glinda defiantly, but said not a word.
+
+"Answer me!" cried the Sorceress.
+
+But still Mombi remained silent.
+
+"Perhaps she doesn't know," remarked Jack.
+
+"I beg you will keep quiet," said Tip. "You might spoil everything with
+your foolishness."
+
+"Very well, dear father!" returned the Pumpkinhead, meekly.
+
+"How glad I am to be a Woggle-Bug!" murmured the Highly Magnified
+Insect, softly. "No one can expect wisdom to flow from a pumpkin."
+
+"Well," said the Scarecrow, "what shall we do to make Mombi speak?
+Unless she tells us what we wish to know her capture will do us no good
+at all."
+
+"Suppose we try kindness," suggested the Tin Woodman. "I've heard that
+anyone can be conquered with kindness, no matter how ugly they may be."
+
+At this the Witch turned to glare upon him so horribly that the Tin
+Woodman shrank back abashed.
+
+Glinda had been carefully considering what to do, and now she turned to
+Mombi and said:
+
+"You will gain nothing, I assure you, by thus defying us. For I am
+determined to learn the truth about the girl Ozma, and unless you tell
+me all that you know, I will certainly put you to death."
+
+"Oh, no! Don't do that!" exclaimed the Tin Woodman. "It would be an
+awful thing to kill anyone--even old Mombi!"
+
+"But it is merely a threat," returned Glinda. "I shall not put Mombi to
+death, because she will prefer to tell me the truth."
+
+"Oh, I see!" said the tin man, much relieved.
+
+"Suppose I tell you all that you wish to know," said Mombi, speaking so
+suddenly that she startled them all. "What will you do with me then?"
+
+"In that case," replied Glinda, "I shall merely ask you to drink a
+powerful draught which will cause you to forget all the magic you have
+ever learned."
+
+"Then I would become a helpless old woman!"
+
+"But you would be alive," suggested the Pumpkinhead, consolingly.
+
+"Do try to keep silent!" said Tip, nervously.
+
+"I'll try," responded Jack; "but you will admit that it's a good thing
+to be alive."
+
+"Especially if one happens to be Thoroughly Educated," added the
+Woggle-Bug, nodding approval.
+
+"You may make your choice," Glinda said to old Mombi, "between death if
+you remain silent, and the loss of your magical powers if you tell me
+the truth. But I think you will prefer to live."
+
+Mombi cast an uneasy glance at the Sorceress, and saw that she was in
+earnest, and not to be trifled with. So she replied, slowly:
+
+"I will answer your questions."
+
+"That is what I expected," said Glinda, pleasantly. "You have chosen
+wisely, I assure you."
+
+She then motioned to one of her Captains, who brought her a beautiful
+golden casket. From this the Sorceress drew an immense white pearl,
+attached to a slender chain which she placed around her neck in such a
+way that the pearl rested upon her bosom, directly over her heart.
+
+"Now," said she, "I will ask my first question: Why did the Wizard pay
+you three visits?"
+
+"Because I would not come to him," answered Mombi.
+
+"That is no answer," said Glinda, sternly. "Tell me the truth."
+
+"Well," returned Mombi, with downcast eyes, "he visited me to learn the
+way I make tea-biscuits."
+
+"Look up!" commanded the Sorceress.
+
+Mombi obeyed.
+
+"What is the color of my pearl?" demanded Glinda.
+
+"Why--it is black!" replied the old Witch, in a tone of wonder.
+
+"Then you have told me a falsehood!" cried Glinda, angrily. "Only when
+the truth is spoken will my magic pearl remain a pure white in color."
+
+Mombi now saw how useless it was to try to deceive the Sorceress; so
+she said, meanwhile scowling at her defeat:
+
+"The Wizard brought to me the girl Ozma, who was then no more than a
+baby, and begged me to conceal the child."
+
+"That is what I thought," declared Glinda, calmly. "What did he give
+you for thus serving him?"
+
+"He taught me all the magical tricks he knew. Some were good tricks,
+and some were only frauds; but I have remained faithful to my promise."
+
+"What did you do with the girl?" asked Glinda; and at this question
+everyone bent forward and listened eagerly for the reply.
+
+"I enchanted her," answered Mombi.
+
+"In what way?"
+
+"I transformed her into--into--"
+
+"Into what?" demanded Glinda, as the Witch hesitated.
+
+"_Into a boy!_" said Mombi, in a low tone.
+
+"A boy!" echoed every voice; and then, because they knew that this old
+woman had reared Tip from childhood, all eyes were turned to where the
+boy stood.
+
+"Yes," said the old Witch, nodding her head; "that is the Princess
+Ozma--the child brought to me by the Wizard who stole her father's
+throne. That is the rightful ruler of the Emerald City!" and she
+pointed her long bony finger straight at the boy.
+
+"I!" cried Tip, in amazement. "Why, I'm no Princess Ozma--I'm not a
+girl!"
+
+Glinda smiled, and going to Tip she took his small brown hand within
+her dainty white one.
+
+[Illustration: MOMBI POINTED HER LONG, BONY FINGER AT THE BOY.]
+
+"You are not a girl just now," said she, gently, "because Mombi
+transformed you into a boy. But you were born a girl, and also a
+Princess; so you must resume your proper form, that you may become
+Queen of the Emerald City."
+
+"Oh, let Jinjur be the Queen!" exclaimed Tip, ready to cry. "I want to
+stay a boy, and travel with the Scarecrow and the Tin Woodman, and the
+Woggle-Bug, and Jack--yes! and my friend the Saw-Horse--and the Gump!
+I don't want to be a girl!"
+
+"Never mind, old chap," said the Tin Woodman, soothingly; "it don't
+hurt to be a girl, I'm told; and we will all remain your faithful
+friends just the same. And, to be honest with you, I've always
+considered girls nicer than boys."
+
+"They're just as nice, anyway," added the Scarecrow, patting Tip
+affectionately upon the head.
+
+"And they are equally good students," proclaimed the Woggle-Bug. "I
+should like to become your tutor, when you are transformed into a girl
+again."
+
+"But--see here!" said Jack Pumpkinhead, with a gasp: "if you become a
+girl, you can't be my dear father any more!"
+
+"No," answered Tip, laughing in spite of his anxiety; "and I shall not
+be sorry to escape the relationship." Then he added, hesitatingly, as
+he turned to Glinda: "I might try it for awhile,--just to see how it
+seems, you know. But if I don't like being a girl you must promise to
+change me into a boy again."
+
+[Illustration]
+
+"Really," said the Sorceress, "that is beyond my magic. I never deal in
+transformations, for they are not honest, and no respectable sorceress
+likes to make things appear to be what they are not. Only unscrupulous
+witches use the art, and therefore I must ask Mombi to effect your
+release from her charm, and restore you to your proper form. It will be
+the last opportunity she will have to practice magic."
+
+Now that the truth about Princess Ozma had been discovered, Mombi did
+not care what became of Tip; but she feared Glinda's anger, and the boy
+generously promised to provide for Mombi in her old age if he became
+the ruler of the Emerald City. So the Witch consented to effect the
+transformation, and preparations for the event were at once made.
+
+Glinda ordered her own royal couch to be placed in the center of the
+tent. It was piled high with cushions covered with rose-colored silk,
+and from a golden railing above hung many folds of pink gossamer,
+completely concealing the interior of the couch.
+
+The first act of the Witch was to make the boy drink a potion which
+quickly sent him into a deep and dreamless sleep. Then the Tin Woodman
+and the Woggle-Bug bore him gently to the couch, placed him upon the
+soft cushions, and drew the gossamer hangings to shut him from all
+earthly view.
+
+The Witch squatted upon the ground and kindled a tiny fire of dried
+herbs, which she drew from her bosom. When the blaze shot up and burned
+clearly old Mombi scattered a handful of magical powder over the fire,
+which straightway gave off a rich violet vapor, filling all the tent
+with its fragrance and forcing the Saw-Horse to sneeze--although he had
+been warned to keep quiet.
+
+[Illustration: MOMBI AT HER MAGICAL INCANTATIONS.]
+
+Then, while the others watched her curiously, the hag chanted a
+rhythmical verse in words which no one understood, and bent her lean
+body seven times back and forth over the fire. And now the incantation
+seemed complete, for the Witch stood upright and cried the one word
+"Yeowa!" in a loud voice.
+
+The vapor floated away; the atmosphere became clear again; a whiff of
+fresh air filled the tent, and the pink curtains of the couch trembled
+slightly, as if stirred from within.
+
+Glinda walked to the canopy and parted the silken hangings. Then she
+bent over the cushions, reached out her hand, and from the couch
+arose the form of a young girl, fresh and beautiful as a May morning.
+Her eyes sparkled as two diamonds, and her lips were tinted like a
+tourmaline. All adown her back floated tresses of ruddy gold, with a
+slender jeweled circlet confining them at the brow. Her robes of silken
+gauze floated around her like a cloud, and dainty satin slippers shod
+her feet.
+
+At this exquisite vision Tip's old comrades stared in wonder for
+the space of a full minute, and then every head bent low in honest
+admiration of the lovely Princess Ozma. The girl herself cast one look
+into Glinda's bright face, which glowed with pleasure and satisfaction,
+and then turned upon the others. Speaking the words with sweet
+diffidence, she said:
+
+"I hope none of you will care less for me than you did before. I'm just
+the same Tip, you know; only--only--"
+
+"Only you're different!" said the Pumpkinhead; and everyone thought it
+was the wisest speech he had ever made.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Riches of
+    Content
+]
+
+
+When the wonderful tidings reached the ears of Queen Jinjur--how Mombi
+the Witch had been captured; how she had confessed her crime to Glinda;
+and how the long-lost Princess Ozma had been discovered in no less a
+personage than the boy Tip--she wept real tears of grief and despair.
+
+"To think," she moaned, "that after having ruled as Queen, and lived in
+a palace, I must go back to scrubbing floors and churning butter again!
+It is too horrible to think of! I will never consent!"
+
+So when her soldiers, who spent most of their time making fudge in the
+palace kitchens, counseled Jinjur to resist, she listened to their
+foolish prattle and sent a sharp defiance to Glinda the Good and the
+Princess Ozma. The result was a declaration of war, and the very next
+day Glinda marched upon the Emerald City with pennants flying and bands
+playing, and a forest of shining spears sparkling brightly beneath the
+sun's rays.
+
+But when it came to the walls this brave assembly made a sudden halt;
+for Jinjur had closed and barred every gateway, and the walls of the
+Emerald City were builded high and thick with many blocks of green
+marble. Finding her advance thus baffled, Glinda bent her brows in deep
+thought, while the Woggle-Bug said, in his most positive tone:
+
+"We must lay siege to the city, and starve it into submission. It is
+the only thing we can do."
+
+"Not so," answered the Scarecrow. "We still have the Gump, and the Gump
+can still fly."
+
+The Sorceress turned quickly at this speech, and her face now wore a
+bright smile.
+
+"You are right," she exclaimed, "and certainly have reason to be proud
+of your brains. Let us go to the Gump at once!"
+
+So they passed through the ranks of the army until they came to the
+place, near the Scarecrow's tent, where the Gump lay. Glinda and
+Princess Ozma mounted first, and sat upon the sofas. Then the Scarecrow
+and his friends climbed aboard, and still there was room for a Captain
+and three soldiers, which Glinda considered sufficient for a guard.
+
+[Illustration]
+
+Now, at a word from the Princess, the queer Thing they had called
+the Gump flopped its palm-leaf wings and rose into the air, carrying
+the party of adventurers high above the walls. They hovered over
+the palace, and soon perceived Jinjur reclining in a hammock in the
+courtyard, where she was comfortably reading a novel with a green cover
+and eating green chocolates, confident that the walls would protect her
+from her enemies. Obeying a quick command, the Gump alighted safely in
+this very courtyard, and before Jinjur had time to do more than scream,
+the Captain and three soldiers leaped out and made the former Queen a
+prisoner, locking strong chains upon both her wrists.
+
+That act really ended the war; for the Army of Revolt submitted as
+soon as they knew Jinjur to be a captive, and the Captain marched in
+safety through the streets and up to the gates of the city, which
+she threw wide open. Then the bands played their most stirring music
+while Glinda's army marched into the city, and heralds proclaimed the
+conquest of the audacious Jinjur and the accession of the beautiful
+Princess Ozma to the throne of her royal ancestors.
+
+[Illustration]
+
+At once the men of the Emerald City cast off their aprons. And it is
+said that the women were so tired eating of their husbands' cooking
+that they all hailed the conquest of Jinjur with joy. Certain it is
+that, rushing one and all to the kitchens of their houses, the good
+wives prepared so delicious a feast for the weary men that harmony was
+immediately restored in every family.
+
+Ozma's first act was to oblige the Army of Revolt to return to
+her every emerald or other gem stolen from the public streets and
+buildings; and so great was the number of precious stones picked
+from their settings by these vain girls, that every one of the royal
+jewelers worked steadily for more than a month to replace them in their
+settings.
+
+Meantime the Army of Revolt was disbanded and the girls sent home to
+their mothers. On promise of good behavior Jinjur was likewise released.
+
+Ozma made the loveliest Queen the Emerald City had ever known; and,
+although she was so young and inexperienced, she ruled her people with
+wisdom and justice. For Glinda gave her good advice on all occasions;
+and the Woggle-Bug, who was appointed to the important post of Public
+Educator, was quite helpful to Ozma when her royal duties grew
+perplexing.
+
+The girl, in her gratitude to the Gump for its services, offered the
+creature any reward it might name.
+
+"Then," replied the Gump, "please take me to pieces. I did not wish
+to be brought to life, and I am greatly ashamed of my conglomerate
+personality. Once I was a monarch of the forest, as my antlers fully
+prove; but now, in my present upholstered condition of servitude, I
+am compelled to fly through the air--my legs being of no use to me
+whatever. Therefore I beg to be dispersed."
+
+So Ozma ordered the Gump taken apart. The antlered head was again
+hung over the mantle-piece in the hall, and the sofas were untied and
+placed in the reception parlors. The broom tail resumed its accustomed
+duties in the kitchen, and finally, the Scarecrow replaced all the
+clotheslines and ropes on the pegs from which he had taken them on the
+eventful day when the Thing was constructed.
+
+You might think that was the end of the Gump; and so it was, as a
+flying-machine. But the head over the mantle-piece continued to talk
+whenever it took a notion to do so, and it frequently startled, with
+its abrupt questions, the people who waited in the hall for an audience
+with the Queen.
+
+The Saw-Horse, being Ozma's personal property, was tenderly cared for;
+and often she rode the queer creature along the streets of the Emerald
+City. She had its wooden legs shod with gold, to keep them from
+wearing out, and the tinkle of these golden shoes upon the pavement
+always filled the Queen's subjects with awe as they thought upon this
+evidence of her magical powers.
+
+"The Wonderful Wizard was never so wonderful as Queen Ozma," the people
+said to one another, in whispers; "for he claimed to do many things he
+could not do; whereas our new Queen does many things no one would ever
+expect her to accomplish."
+
+Jack Pumpkinhead remained with Ozma to the end of his days; and he
+did not spoil as soon as he had feared, although he always remained
+as stupid as ever. The Woggle-Bug tried to teach him several arts and
+sciences; but Jack was so poor a student that any attempt to educate
+him was soon abandoned.
+
+After Glinda's army had marched back home, and peace was restored to
+the Emerald City, the Tin Woodman announced his intention to return to
+his own Kingdom of the Winkies.
+
+"It isn't a very big Kingdom," said he to Ozma, "but for that very
+reason it is easier to rule; and I have called myself an Emperor
+because I am an Absolute Monarch, and no one interferes in any way
+with my conduct of public or personal affairs. When I get home I shall
+have a new coat of nickel plate; for I have become somewhat marred and
+scratched lately; and then I shall be glad to have you pay me a visit."
+
+"Thank you," replied Ozma. "Some day I may accept the invitation. But
+what is to become of the Scarecrow?"
+
+"I shall return with my friend the Tin Woodman," said the stuffed one,
+seriously. "We have decided never to be parted in the future."
+
+"And I have made the Scarecrow my Royal Treasurer," explained the Tin
+Woodman. "For it has occurred to me that it is a good thing to have a
+Royal Treasurer who is made of money. What do you think?"
+
+"I think," said the little Queen, smiling, "that your friend must be
+the richest man in all the world."
+
+"I am," returned the Scarecrow; "but not on account of my money. For
+I consider brains far superior to money, in every way. You may have
+noticed that if one has money without brains, he cannot use it to
+advantage; but if one has brains without money, they will enable him to
+live comfortably to the end of his days."
+
+"At the same time," declared the Tin Woodman, "you must acknowledge
+that a good heart is a thing that brains can not create, and that money
+can not buy. Perhaps, after all, it is I who am the richest man in all
+the world."
+
+"You are both rich, my friends," said Ozma, gently; "and your riches
+are the only riches worth having--the riches of content!"
+
+[Illustration:
+
+    The End
+]
+
+
+
+
+THE OZ BOOKS
+
+BY
+
+L. FRANK BAUM
+
+
+_The Wizard of Oz_
+
+[Originally published as _The Wonderful Wizard of Oz_]
+
+It is in this book that Oz is "discovered." A little Kansas
+girl--Dorothy Gale--is carried in her house to Oz when a cyclone whisks
+it through the sky. As the house lands in the Munchkin Country (one of
+the four great countries of Oz) it destroys a wicked witch and sends
+Dorothy off on her first adventure in Oz. She finds the Scarecrow,
+meets the Tin Woodman and the Cowardly Lion, melts a second wicked
+witch with a pail of water and finds her way home. Since this book
+appeared a half-century ago, we have learned many marvelous things
+about the Land of Oz.
+
+
+_The Land of Oz_
+
+[Originally published as _The Marvelous Land of Oz_]
+
+This sequel to _The Wizard of Oz_ deals entirely with the early history
+of Oz. No one from the United States or any other part of the "great
+outside world" appears in it. It takes its readers on a series of
+incredible adventures with Tip, a small boy who runs away from old
+Mombi, the witch, taking with him Jack Pumpkinhead and the wooden
+Saw-Horse. The Scarecrow is King of the Emerald City until he, Tip,
+Jack, and the Tin Woodman are forced to flee the royal palace when it
+is invaded by General Jinjur and her army of rebelling girls. The _Land
+of Oz_ ends with an amazing surprise, and from that moment on Ozma is
+princess of all Oz.
+
+
+_Ozma of Oz_
+
+Few of the Oz books are as crowded with exciting Oz happenings as this
+one. Not only does it bring Dorothy back to Oz on her second visit,
+but it introduces Dorothy to Ozma, relates Ozma's first important
+adventure, and introduces for the first time such famous Oz characters
+as Tik-Tok, the mechanical man, Billina the hen, the Hungry Tiger,
+and--_the Nome King_! Most of the adventures in this book take place
+outside Oz, in the Land of Ev and the Nome Kingdom. Scarcely a page
+fails to quiver with excitement, magic and adventure.
+
+
+_Dorothy and the Wizard in Oz_
+
+Of course, everyone always predicted it would happen! And in this book
+it does--the Wizard comes back to Oz to stay. Best of all, he comes
+with Dorothy, who is having adventure number three that leads her
+to Oz, this time via a California earthquake. In this book we meet
+Dorothy's pink kitten, Eureka, whose manners need adjusting badly,
+and two good friends who we are sorry did not remain in Oz--Jim the
+cabhorse, and Zeb, Dorothy's young cousin, who works on a ranch as a
+hired boy.
+
+
+_The Road to Oz_
+
+We like to think of this volume as "The Party Book of Oz." Almost
+everyone loves a party, and when Ozma has a birthday party with
+notables from every part of fairyland attending--well! It is just like
+attending Ozma's party in person. You meet the famous of Oz, and lots
+of others, such as Queen Zixi of Ix, John Dough, Chick the Cherub, the
+Queen of Merryland, Para Bruin the rubber bear and--best of all--Santa
+Claus himself! Of course there are lots of adventures on that famous
+road to Oz before the party, during which Dorothy, on her way to Oz for
+the fourth time, meets such heart-warming characters as the Shaggy Man,
+Button-Bright, and lovely Polychrome, daughter of the rainbow.
+
+
+_The Emerald City of Oz_
+
+Here is a "double" story of Oz. While Dorothy, her Aunt Em and Uncle
+Henry experience the events that lead to their going to Oz to make
+their home in the Emerald City, the wicked Nome King is plotting to
+conquer Oz and enslave its people. Later we go with Dorothy and her
+friends in the Red Wagon on a grand tour of Oz that is simply packed
+with excitement and events. While this transpires, we learn also of the
+Nome King's elaborate preparations to conquer Oz. As Dorothy and her
+friends return to the Emerald City, the Nome King and his hordes of
+warriors are about to invade it. How Oz is saved is an ending that will
+amaze and delight you.
+
+
+_The Patchwork Girl of Oz_
+
+Here, the Patchwork Girl is brought to life by Dr. Pipt's magic Powder
+of Life. From that moment on the action never slows down in this
+exciting book. It tells of Ojo's quest for the strange ingredients
+necessary to brew a magic liquid that will release his Unk Nunkie from
+a spell--the spell cast by the Liquid of Petrifaction, which has turned
+him into a marble statue. In addition to the Patchwork Girl, Ojo and
+Unk Nunkie, this book introduces those famous Oz creatures, the Woozy,
+and Bungle the glass cat. Oz certainly has become a merrier, happier
+land since the Patchwork Girl came to life, and this is the book that
+tells how Scraps came to be made, how she was brought to life, and all
+about her early adventures.
+
+
+_Tik-Tok of Oz_
+
+For the second time a little girl from the United States comes to Oz.
+Betsy Bobbin is shipwrecked in the Nonestic Ocean with her friend Hank
+the mule. The two drift to shore in the Rose Kingdom on a fragment of
+wreckage. Betsy meets the Shaggy Man and accompanies him to the Nome
+Kingdom, where Shaggy hopes to release his brother, a prisoner of the
+Nome King. On their way to the Nome Kingdom, one fascinating adventure
+follows another. They meet Queen Ann Soforth of Oogaboo and her army,
+and lovely Polychrome, who had lost her rainbow again; they rescue
+Tik-Tok from a well; and are dropped through a Hollow Tube to the other
+side of the world where they meet Quox, the dragon. You'll find it one
+of the most exciting of all the Oz books.
+
+
+_The Scarecrow of Oz_
+
+This is the Oz book which L. Frank Baum considered his best. It starts
+quietly enough with Trot and Cap'n Bill rowing along a shore of the
+Pacific Ocean to visit one of the many caves near their home on the
+California coast. Suddenly, a mighty whirlpool engulfs them. The
+old sailorman and the little girl are miraculously saved and regain
+consciousness to find themselves in a sea cavern. (To this day, Trot
+asserts she felt mermaid arms about her during those terrible moments
+under water.) From here on, one perilous adventure crowds in upon
+another. In Jinxland they meet the Scarecrow who takes charge of things
+once Cap'n Bill is transformed into a tiny grasshopper with a wooden
+leg. An exciting royal reception greets the adventurers upon their
+return to the Emerald City.
+
+
+_Rinkitink in Oz_
+
+Prince Inga of Pingaree is the boy hero of this fine story of
+peril-filled adventure in the islands of the Nonestic Ocean. King
+Rinkitink provides comic relief, and by the time you reach the final
+page you will love this fat, jolly little king. Bilbil the goat,
+with his surly disposition, provides a fine contrast to Rinkitink's
+merriment and Prince Inga's bravery and courage in the face of
+danger. Some may say that the three magic pearls are the real heroes
+of this story, but the pearls would have been of little use to King
+Kitticut and Queen Garee if Prince Inga hadn't used them wisely and
+courageously.
+
+
+_The Lost Princess of Oz_
+
+Talk about _Button-Bright_ getting lost--_Ozma_ is almost as bad! This
+is actually the second time Ozma has been lost. As you know, once
+she was "lost" for many years. But in this book she is lost for only
+a short time. As soon as it is discovered that the ruler of Oz is
+lost--and with her all the important magical instruments in Oz--search
+parties, one for each of the four countries of Oz, set out to find her.
+We follow the adventures of the party headed by Dorothy and the Wizard,
+who explore unknown parts of the Winkie Country in search of Ozma. How
+Ozma is found, and where she has been, will surprise you. Frogman, a
+new character, is introduced in this book.
+
+
+_The Tin Woodman of Oz_
+
+Woot the Wanderer causes this chapter of Oz history to transpire. When
+Woot wanders into the splendid tin castle of Nick Chopper, the Tin
+Woodman and Emperor of the Winkies, he meets the Scarecrow, who is
+visiting his old friend. The Tin Woodman tells Woot the story of how
+he had once been a flesh-and-blood woodman in love with a maiden named
+Nimmie Aimee. Woot suggests that since the Tin Woodman now has a kind
+and loving heart, it is his duty to find Nimmie Aimee and make her
+Empress of the Winkies. The Scarecrow agrees, so the three set off to
+search for the girl. No less surprising than the adventures encountered
+on the journey is Nimmie Aimee's reception of her former suitor.
+
+
+_The Magic of Oz_
+
+Old Ruggedo, the former Nome King, comes to Oz for the second time,
+and makes more trouble than he did on his first visit. Ruggedo never
+gives up the idea of conquering Oz, and this time he has the advantage
+of being in the country without Ozma's knowledge. Also, he has the
+magic and somewhat grudging help of Kiki Aru, the Munchkin boy who
+is illegally practicing the art. If you like magic, then this is a
+book for you. There's magic on every page, and everyone in the story
+eventually is transformed into something else, or bewitched in one way
+or another. Even the wild animals in the great Forest of Gugu do not
+escape.
+
+
+_Glinda of Oz_
+
+This is the last Oz book written by L. Frank Baum. It is one of the
+best in the series, with Dorothy, Ozma, and Glinda in an adventure that
+takes them to an amazing crystal-domed city on an enchanted island.
+This island is situated in a lake in the Gillikin Country. Ozma and
+Glinda are confronted by powerful magic and determined enemies. For a
+time Dorothy and Ozma are prisoners in the crystal-domed city which is
+able to submerge below the surface of the lake. Few of the Oz books
+equal this one in suspense and mystery--a story that is truly "out of
+this world."
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+       *       *       *       *       *
+  +---------------------------------------------------------------------+
+  |                                                                     |
+  |                       Transcriber notes:                            |
+  |                                                                     |
+  | P.6. 'ecstacy.' changed to 'ecstasy.'                               |
+  | P.208. 'nickle-plate' changed to 'nickel-plate'                     |
+  | P.285. 'Liquid of Petrefaction' changed to 'Liquid of Petrifaction'.|
+  | Taken hypen out of pumpkinhead or pumpkinheads.                     |
+  | Fixed various punctuation.                                          |
+  |                                                                     |
+  | Text surrounded by _this_ indicated italics, and text surrounded    |
+  |   by =this= indicates bold.                                         |
+  |                                                                     |
+  +---------------------------------------------------------------------+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+***** This file should be named 53844-8.txt or 53844-8.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/5/3/8/4/53844/
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for the eBooks, unless you receive
+specific permission. If you do not charge anything for copies of this
+eBook, complying with the rules is very easy. You may use this eBook
+for nearly any purpose such as creation of derivative works, reports,
+performances and research. They may be modified and printed and given
+away--you may do practically ANYTHING in the United States with eBooks
+not protected by U.S. copyright law. Redistribution is subject to the
+trademark license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country outside the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you'll have to check the laws of the country where you
+  are located before using this ebook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from both the Project Gutenberg Literary Archive Foundation and The
+Project Gutenberg Trademark LLC, the owner of the Project Gutenberg-tm
+trademark. Contact the Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's principal office is in Fairbanks, Alaska, with the
+mailing address: PO Box 750175, Fairbanks, AK 99775, but its
+volunteers and employees are scattered throughout numerous
+locations. Its business office is located at 809 North 1500 West, Salt
+Lake City, UT 84116, (801) 596-1887. Email contact links and up to
+date contact information can be found at the Foundation's web site and
+official page at www.gutenberg.org/contact
+
+For additional contact information:
+
+    Dr. Gregory B. Newby
+    Chief Executive and Director
+    gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works.
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our Web site which has the main PG search
+facility: www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/madame-bovary.txt
+++ b/jet/source-sink-builder/src/main/resources/books/madame-bovary.txt
@@ -1,0 +1,13856 @@
+﻿The Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Madame Bovary
+
+Author: Gustave Flaubert
+
+Translator: Eleanor Marx-Aveling
+
+Release Date: February 25, 2006 [EBook #2413]
+Last Updated: September 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+
+
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+
+
+
+
+MADAME BOVARY
+
+By Gustave Flaubert
+
+Translated from the French by Eleanor Marx-Aveling
+
+
+To Marie-Antoine-Jules Senard Member of the Paris Bar, Ex-President
+of the National Assembly, and Former Minister of the Interior Dear and
+Illustrious Friend, Permit me to inscribe your name at the head of this
+book, and above its dedication; for it is to you, before all, that I
+owe its publication. Reading over your magnificent defence, my work has
+acquired for myself, as it were, an unexpected authority.
+
+Accept, then, here, the homage of my gratitude, which, how great soever
+it is, will never attain the height of your eloquence and your devotion.
+
+Gustave Flaubert Paris, 12 April 1857
+
+
+
+
+MADAME BOVARY
+
+
+
+
+Part I
+
+
+
+Chapter One
+
+We were in class when the head-master came in, followed by a “new
+fellow,” not wearing the school uniform, and a school servant carrying a
+large desk. Those who had been asleep woke up, and every one rose as if
+just surprised at his work.
+
+The head-master made a sign to us to sit down. Then, turning to the
+class-master, he said to him in a low voice--
+
+“Monsieur Roger, here is a pupil whom I recommend to your care; he’ll be
+in the second. If his work and conduct are satisfactory, he will go into
+one of the upper classes, as becomes his age.”
+
+The “new fellow,” standing in the corner behind the door so that he
+could hardly be seen, was a country lad of about fifteen, and taller
+than any of us. His hair was cut square on his forehead like a village
+chorister’s; he looked reliable, but very ill at ease. Although he was
+not broad-shouldered, his short school jacket of green cloth with black
+buttons must have been tight about the arm-holes, and showed at the
+opening of the cuffs red wrists accustomed to being bare. His legs, in
+blue stockings, looked out from beneath yellow trousers, drawn tight by
+braces, He wore stout, ill-cleaned, hob-nailed boots.
+
+We began repeating the lesson. He listened with all his ears, as
+attentive as if at a sermon, not daring even to cross his legs or lean
+on his elbow; and when at two o’clock the bell rang, the master was
+obliged to tell him to fall into line with the rest of us.
+
+When we came back to work, we were in the habit of throwing our caps on
+the ground so as to have our hands more free; we used from the door to
+toss them under the form, so that they hit against the wall and made a
+lot of dust: it was “the thing.”
+
+But, whether he had not noticed the trick, or did not dare to attempt
+it, the “new fellow,” was still holding his cap on his knees even after
+prayers were over. It was one of those head-gears of composite order, in
+which we can find traces of the bearskin, shako, billycock hat, sealskin
+cap, and cotton night-cap; one of those poor things, in fine, whose
+dumb ugliness has depths of expression, like an imbecile’s face. Oval,
+stiffened with whalebone, it began with three round knobs; then came in
+succession lozenges of velvet and rabbit-skin separated by a red band;
+after that a sort of bag that ended in a cardboard polygon covered with
+complicated braiding, from which hung, at the end of a long thin cord,
+small twisted gold threads in the manner of a tassel. The cap was new;
+its peak shone.
+
+“Rise,” said the master.
+
+He stood up; his cap fell. The whole class began to laugh. He stooped to
+pick it up. A neighbor knocked it down again with his elbow; he picked
+it up once more.
+
+“Get rid of your helmet,” said the master, who was a bit of a wag.
+
+There was a burst of laughter from the boys, which so thoroughly put the
+poor lad out of countenance that he did not know whether to keep his cap
+in his hand, leave it on the ground, or put it on his head. He sat down
+again and placed it on his knee.
+
+“Rise,” repeated the master, “and tell me your name.”
+
+The new boy articulated in a stammering voice an unintelligible name.
+
+“Again!”
+
+The same sputtering of syllables was heard, drowned by the tittering of
+the class.
+
+“Louder!” cried the master; “louder!”
+
+The “new fellow” then took a supreme resolution, opened an inordinately
+large mouth, and shouted at the top of his voice as if calling someone
+in the word “Charbovari.”
+
+A hubbub broke out, rose in crescendo with bursts of shrill voices (they
+yelled, barked, stamped, repeated “Charbovari! Charbovari”), then died
+away into single notes, growing quieter only with great difficulty, and
+now and again suddenly recommencing along the line of a form whence rose
+here and there, like a damp cracker going off, a stifled laugh.
+
+However, amid a rain of impositions, order was gradually re-established
+in the class; and the master having succeeded in catching the name of
+“Charles Bovary,” having had it dictated to him, spelt out, and re-read,
+at once ordered the poor devil to go and sit down on the punishment form
+at the foot of the master’s desk. He got up, but before going hesitated.
+
+“What are you looking for?” asked the master.
+
+“My c-a-p,” timidly said the “new fellow,” casting troubled looks round
+him.
+
+“Five hundred lines for all the class!” shouted in a furious voice
+stopped, like the Quos ego*, a fresh outburst. “Silence!” continued the
+master indignantly, wiping his brow with his handkerchief, which he
+had just taken from his cap. “As to you, ‘new boy,’ you will conjugate
+‘ridiculus sum’ ** twenty times.”
+
+Then, in a gentler tone, “Come, you’ll find your cap again; it hasn’t
+been stolen.”
+
+     *A quotation from the Aeneid signifying a threat.
+
+     **I am ridiculous.
+
+Quiet was restored. Heads bent over desks, and the “new fellow” remained
+for two hours in an exemplary attitude, although from time to time some
+paper pellet flipped from the tip of a pen came bang in his face. But he
+wiped his face with one hand and continued motionless, his eyes lowered.
+
+In the evening, at preparation, he pulled out his pens from his desk,
+arranged his small belongings, and carefully ruled his paper. We saw him
+working conscientiously, looking up every word in the dictionary, and
+taking the greatest pains. Thanks, no doubt, to the willingness he
+showed, he had not to go down to the class below. But though he knew his
+rules passably, he had little finish in composition. It was the cure
+of his village who had taught him his first Latin; his parents, from
+motives of economy, having sent him to school as late as possible.
+
+His father, Monsieur Charles Denis Bartolome Bovary, retired
+assistant-surgeon-major, compromised about 1812 in certain conscription
+scandals, and forced at this time to leave the service, had taken
+advantage of his fine figure to get hold of a dowry of sixty thousand
+francs that offered in the person of a hosier’s daughter who had fallen
+in love with his good looks. A fine man, a great talker, making his
+spurs ring as he walked, wearing whiskers that ran into his moustache,
+his fingers always garnished with rings and dressed in loud colours,
+he had the dash of a military man with the easy go of a commercial
+traveller.
+
+Once married, he lived for three or four years on his wife’s fortune,
+dining well, rising late, smoking long porcelain pipes, not coming in
+at night till after the theatre, and haunting cafes. The father-in-law
+died, leaving little; he was indignant at this, “went in for the
+business,” lost some money in it, then retired to the country, where he
+thought he would make money.
+
+But, as he knew no more about farming than calico, as he rode his horses
+instead of sending them to plough, drank his cider in bottle instead of
+selling it in cask, ate the finest poultry in his farmyard, and greased
+his hunting-boots with the fat of his pigs, he was not long in finding
+out that he would do better to give up all speculation.
+
+For two hundred francs a year he managed to live on the border of
+the provinces of Caux and Picardy, in a kind of place half farm, half
+private house; and here, soured, eaten up with regrets, cursing his
+luck, jealous of everyone, he shut himself up at the age of forty-five,
+sick of men, he said, and determined to live at peace.
+
+His wife had adored him once on a time; she had bored him with a
+thousand servilities that had only estranged him the more. Lively once,
+expansive and affectionate, in growing older she had become (after the
+fashion of wine that, exposed to air, turns to vinegar) ill-tempered,
+grumbling, irritable. She had suffered so much without complaint at
+first, until she had seem him going after all the village drabs, and
+until a score of bad houses sent him back to her at night, weary,
+stinking drunk. Then her pride revolted. After that she was silent,
+burying her anger in a dumb stoicism that she maintained till her death.
+She was constantly going about looking after business matters. She
+called on the lawyers, the president, remembered when bills fell due,
+got them renewed, and at home ironed, sewed, washed, looked after the
+workmen, paid the accounts, while he, troubling himself about nothing,
+eternally besotted in sleepy sulkiness, whence he only roused himself
+to say disagreeable things to her, sat smoking by the fire and spitting
+into the cinders.
+
+When she had a child, it had to be sent out to nurse. When he came home,
+the lad was spoilt as if he were a prince. His mother stuffed him
+with jam; his father let him run about barefoot, and, playing the
+philosopher, even said he might as well go about quite naked like the
+young of animals. As opposed to the maternal ideas, he had a certain
+virile idea of childhood on which he sought to mould his son, wishing
+him to be brought up hardily, like a Spartan, to give him a strong
+constitution. He sent him to bed without any fire, taught him to drink
+off large draughts of rum and to jeer at religious processions. But,
+peaceable by nature, the lad answered only poorly to his notions. His
+mother always kept him near her; she cut out cardboard for him, told him
+tales, entertained him with endless monologues full of melancholy gaiety
+and charming nonsense. In her life’s isolation she centered on the
+child’s head all her shattered, broken little vanities. She dreamed of
+high station; she already saw him, tall, handsome, clever, settled as
+an engineer or in the law. She taught him to read, and even, on an old
+piano, she had taught him two or three little songs. But to all this
+Monsieur Bovary, caring little for letters, said, “It was not worth
+while. Would they ever have the means to send him to a public school, to
+buy him a practice, or start him in business? Besides, with cheek a man
+always gets on in the world.” Madame Bovary bit her lips, and the child
+knocked about the village.
+
+He went after the labourers, drove away with clods of earth the ravens
+that were flying about. He ate blackberries along the hedges, minded the
+geese with a long switch, went haymaking during harvest, ran about in
+the woods, played hop-scotch under the church porch on rainy days, and
+at great fetes begged the beadle to let him toll the bells, that he
+might hang all his weight on the long rope and feel himself borne upward
+by it in its swing. Meanwhile he grew like an oak; he was strong on
+hand, fresh of colour.
+
+When he was twelve years old his mother had her own way; he began
+lessons. The cure took him in hand; but the lessons were so short and
+irregular that they could not be of much use. They were given at spare
+moments in the sacristy, standing up, hurriedly, between a baptism and
+a burial; or else the cure, if he had not to go out, sent for his pupil
+after the Angelus*. They went up to his room and settled down; the
+flies and moths fluttered round the candle. It was close, the child
+fell asleep, and the good man, beginning to doze with his hands on his
+stomach, was soon snoring with his mouth wide open. On other occasions,
+when Monsieur le Cure, on his way back after administering the viaticum
+to some sick person in the neighbourhood, caught sight of Charles
+playing about the fields, he called him, lectured him for a quarter of
+an hour and took advantage of the occasion to make him conjugate his
+verb at the foot of a tree. The rain interrupted them or an acquaintance
+passed. All the same he was always pleased with him, and even said the
+“young man” had a very good memory.
+
+     *A devotion said at morning, noon, and evening, at the sound
+     of a bell. Here, the evening prayer.
+
+Charles could not go on like this. Madame Bovary took strong steps.
+Ashamed, or rather tired out, Monsieur Bovary gave in without a
+struggle, and they waited one year longer, so that the lad should take
+his first communion.
+
+Six months more passed, and the year after Charles was finally sent to
+school at Rouen, where his father took him towards the end of October,
+at the time of the St. Romain fair.
+
+It would now be impossible for any of us to remember anything about him.
+He was a youth of even temperament, who played in playtime, worked in
+school-hours, was attentive in class, slept well in the dormitory,
+and ate well in the refectory. He had in loco parentis* a wholesale
+ironmonger in the Rue Ganterie, who took him out once a month on Sundays
+after his shop was shut, sent him for a walk on the quay to look at
+the boats, and then brought him back to college at seven o’clock before
+supper. Every Thursday evening he wrote a long letter to his mother with
+red ink and three wafers; then he went over his history note-books, or
+read an old volume of “Anarchasis” that was knocking about the study.
+When he went for walks he talked to the servant, who, like himself, came
+from the country.
+
+     *In place of a parent.
+
+By dint of hard work he kept always about the middle of the class; once
+even he got a certificate in natural history. But at the end of his
+third year his parents withdrew him from the school to make him study
+medicine, convinced that he could even take his degree by himself.
+
+His mother chose a room for him on the fourth floor of a dyer’s she
+knew, overlooking the Eau-de-Robec. She made arrangements for his
+board, got him furniture, table and two chairs, sent home for an old
+cherry-tree bedstead, and bought besides a small cast-iron stove with
+the supply of wood that was to warm the poor child.
+
+Then at the end of a week she departed, after a thousand injunctions to
+be good now that he was going to be left to himself.
+
+The syllabus that he read on the notice-board stunned him; lectures
+on anatomy, lectures on pathology, lectures on physiology, lectures on
+pharmacy, lectures on botany and clinical medicine, and therapeutics,
+without counting hygiene and materia medica--all names of whose
+etymologies he was ignorant, and that were to him as so many doors to
+sanctuaries filled with magnificent darkness.
+
+He understood nothing of it all; it was all very well to listen--he did
+not follow. Still he worked; he had bound note-books, he attended all
+the courses, never missed a single lecture. He did his little daily task
+like a mill-horse, who goes round and round with his eyes bandaged, not
+knowing what work he is doing.
+
+To spare him expense his mother sent him every week by the carrier a
+piece of veal baked in the oven, with which he lunched when he came back
+from the hospital, while he sat kicking his feet against the wall.
+After this he had to run off to lectures, to the operation-room, to the
+hospital, and return to his home at the other end of the town. In the
+evening, after the poor dinner of his landlord, he went back to his
+room and set to work again in his wet clothes, which smoked as he sat in
+front of the hot stove.
+
+On the fine summer evenings, at the time when the close streets are
+empty, when the servants are playing shuttle-cock at the doors, he
+opened his window and leaned out. The river, that makes of this quarter
+of Rouen a wretched little Venice, flowed beneath him, between the
+bridges and the railings, yellow, violet, or blue. Working men, kneeling
+on the banks, washed their bare arms in the water. On poles projecting
+from the attics, skeins of cotton were drying in the air. Opposite,
+beyond the roots spread the pure heaven with the red sun setting. How
+pleasant it must be at home! How fresh under the beech-tree! And he
+expanded his nostrils to breathe in the sweet odours of the country
+which did not reach him.
+
+He grew thin, his figure became taller, his face took a saddened look
+that made it nearly interesting. Naturally, through indifference, he
+abandoned all the resolutions he had made. Once he missed a lecture; the
+next day all the lectures; and, enjoying his idleness, little by little,
+he gave up work altogether. He got into the habit of going to the
+public-house, and had a passion for dominoes. To shut himself up every
+evening in the dirty public room, to push about on marble tables the
+small sheep bones with black dots, seemed to him a fine proof of his
+freedom, which raised him in his own esteem. It was beginning to see
+life, the sweetness of stolen pleasures; and when he entered, he put
+his hand on the door-handle with a joy almost sensual. Then many things
+hidden within him came out; he learnt couplets by heart and sang them to
+his boon companions, became enthusiastic about Beranger, learnt how to
+make punch, and, finally, how to make love.
+
+Thanks to these preparatory labours, he failed completely in his
+examination for an ordinary degree. He was expected home the same night
+to celebrate his success. He started on foot, stopped at the beginning
+of the village, sent for his mother, and told her all. She excused
+him, threw the blame of his failure on the injustice of the examiners,
+encouraged him a little, and took upon herself to set matters straight.
+It was only five years later that Monsieur Bovary knew the truth; it was
+old then, and he accepted it. Moreover, he could not believe that a man
+born of him could be a fool.
+
+So Charles set to work again and crammed for his examination,
+ceaselessly learning all the old questions by heart. He passed pretty
+well. What a happy day for his mother! They gave a grand dinner.
+
+Where should he go to practice? To Tostes, where there was only one old
+doctor. For a long time Madame Bovary had been on the look-out for his
+death, and the old fellow had barely been packed off when Charles was
+installed, opposite his place, as his successor.
+
+But it was not everything to have brought up a son, to have had him
+taught medicine, and discovered Tostes, where he could practice it;
+he must have a wife. She found him one--the widow of a bailiff at
+Dieppe--who was forty-five and had an income of twelve hundred francs.
+Though she was ugly, as dry as a bone, her face with as many pimples as
+the spring has buds, Madame Dubuc had no lack of suitors. To attain her
+ends Madame Bovary had to oust them all, and she even succeeded in
+very cleverly baffling the intrigues of a port-butcher backed up by the
+priests.
+
+Charles had seen in marriage the advent of an easier life, thinking he
+would be more free to do as he liked with himself and his money. But his
+wife was master; he had to say this and not say that in company, to fast
+every Friday, dress as she liked, harass at her bidding those patients
+who did not pay. She opened his letter, watched his comings and goings,
+and listened at the partition-wall when women came to consult him in his
+surgery.
+
+She must have her chocolate every morning, attentions without end. She
+constantly complained of her nerves, her chest, her liver. The noise of
+footsteps made her ill; when people left her, solitude became odious to
+her; if they came back, it was doubtless to see her die. When Charles
+returned in the evening, she stretched forth two long thin arms from
+beneath the sheets, put them round his neck, and having made him sit
+down on the edge of the bed, began to talk to him of her troubles: he
+was neglecting her, he loved another. She had been warned she would be
+unhappy; and she ended by asking him for a dose of medicine and a little
+more love.
+
+
+
+Chapter Two
+
+One night towards eleven o’clock they were awakened by the noise of
+a horse pulling up outside their door. The servant opened the
+garret-window and parleyed for some time with a man in the street below.
+He came for the doctor, had a letter for him. Natasie came downstairs
+shivering and undid the bars and bolts one after the other. The man left
+his horse, and, following the servant, suddenly came in behind her. He
+pulled out from his wool cap with grey top-knots a letter wrapped up in
+a rag and presented it gingerly to Charles, who rested on his elbow on
+the pillow to read it. Natasie, standing near the bed, held the light.
+Madame in modesty had turned to the wall and showed only her back.
+
+This letter, sealed with a small seal in blue wax, begged Monsieur
+Bovary to come immediately to the farm of the Bertaux to set a broken
+leg. Now from Tostes to the Bertaux was a good eighteen miles across
+country by way of Longueville and Saint-Victor. It was a dark night;
+Madame Bovary junior was afraid of accidents for her husband. So it was
+decided the stable-boy should go on first; Charles would start three
+hours later when the moon rose. A boy was to be sent to meet him, and
+show him the way to the farm, and open the gates for him.
+
+Towards four o’clock in the morning, Charles, well wrapped up in his
+cloak, set out for the Bertaux. Still sleepy from the warmth of his bed,
+he let himself be lulled by the quiet trot of his horse. When it stopped
+of its own accord in front of those holes surrounded with thorns that
+are dug on the margin of furrows, Charles awoke with a start, suddenly
+remembered the broken leg, and tried to call to mind all the fractures
+he knew. The rain had stopped, day was breaking, and on the branches
+of the leafless trees birds roosted motionless, their little feathers
+bristling in the cold morning wind. The flat country stretched as far as
+eye could see, and the tufts of trees round the farms at long intervals
+seemed like dark violet stains on the cast grey surface, that on the
+horizon faded into the gloom of the sky.
+
+Charles from time to time opened his eyes, his mind grew weary, and,
+sleep coming upon him, he soon fell into a doze wherein, his recent
+sensations blending with memories, he became conscious of a double
+self, at once student and married man, lying in his bed as but now, and
+crossing the operation theatre as of old. The warm smell of poultices
+mingled in his brain with the fresh odour of dew; he heard the iron
+rings rattling along the curtain-rods of the bed and saw his wife
+sleeping. As he passed Vassonville he came upon a boy sitting on the
+grass at the edge of a ditch.
+
+“Are you the doctor?” asked the child.
+
+And on Charles’s answer he took his wooden shoes in his hands and ran on
+in front of him.
+
+The general practitioner, riding along, gathered from his guide’s talk
+that Monsieur Rouault must be one of the well-to-do farmers.
+
+He had broken his leg the evening before on his way home from a
+Twelfth-night feast at a neighbour’s. His wife had been dead for two
+years. There was with him only his daughter, who helped him to keep
+house.
+
+The ruts were becoming deeper; they were approaching the Bertaux.
+
+The little lad, slipping through a hole in the hedge, disappeared;
+then he came back to the end of a courtyard to open the gate. The
+horse slipped on the wet grass; Charles had to stoop to pass under
+the branches. The watchdogs in their kennels barked, dragging at their
+chains. As he entered the Bertaux, the horse took fright and stumbled.
+
+It was a substantial-looking farm. In the stables, over the top of the
+open doors, one could see great cart-horses quietly feeding from new
+racks. Right along the outbuildings extended a large dunghill, from
+which manure liquid oozed, while amidst fowls and turkeys, five or six
+peacocks, a luxury in Chauchois farmyards, were foraging on the top of
+it. The sheepfold was long, the barn high, with walls smooth as your
+hand. Under the cart-shed were two large carts and four ploughs, with
+their whips, shafts and harnesses complete, whose fleeces of blue wool
+were getting soiled by the fine dust that fell from the granaries. The
+courtyard sloped upwards, planted with trees set out symmetrically, and
+the chattering noise of a flock of geese was heard near the pond.
+
+A young woman in a blue merino dress with three flounces came to the
+threshold of the door to receive Monsieur Bovary, whom she led to the
+kitchen, where a large fire was blazing. The servant’s breakfast was
+boiling beside it in small pots of all sizes. Some damp clothes were
+drying inside the chimney-corner. The shovel, tongs, and the nozzle
+of the bellows, all of colossal size, shone like polished steel, while
+along the walls hung many pots and pans in which the clear flame of the
+hearth, mingling with the first rays of the sun coming in through the
+window, was mirrored fitfully.
+
+Charles went up the first floor to see the patient. He found him in his
+bed, sweating under his bed-clothes, having thrown his cotton nightcap
+right away from him. He was a fat little man of fifty, with white skin
+and blue eyes, the forepart of his head bald, and he wore earrings. By
+his side on a chair stood a large decanter of brandy, whence he poured
+himself a little from time to time to keep up his spirits; but as soon
+as he caught sight of the doctor his elation subsided, and instead of
+swearing, as he had been doing for the last twelve hours, began to groan
+freely.
+
+The fracture was a simple one, without any kind of complication.
+
+Charles could not have hoped for an easier case. Then calling to mind
+the devices of his masters at the bedsides of patients, he comforted the
+sufferer with all sorts of kindly remarks, those caresses of the surgeon
+that are like the oil they put on bistouries. In order to make some
+splints a bundle of laths was brought up from the cart-house. Charles
+selected one, cut it into two pieces and planed it with a fragment
+of windowpane, while the servant tore up sheets to make bandages, and
+Mademoiselle Emma tried to sew some pads. As she was a long time before
+she found her work-case, her father grew impatient; she did not answer,
+but as she sewed she pricked her fingers, which she then put to her
+mouth to suck them. Charles was surprised at the whiteness of her nails.
+They were shiny, delicate at the tips, more polished than the ivory of
+Dieppe, and almond-shaped. Yet her hand was not beautiful, perhaps not
+white enough, and a little hard at the knuckles; besides, it was too
+long, with no soft inflections in the outlines. Her real beauty was in
+her eyes. Although brown, they seemed black because of the lashes, and
+her look came at you frankly, with a candid boldness.
+
+The bandaging over, the doctor was invited by Monsieur Rouault himself
+to “pick a bit” before he left.
+
+Charles went down into the room on the ground floor. Knives and forks
+and silver goblets were laid for two on a little table at the foot of a
+huge bed that had a canopy of printed cotton with figures representing
+Turks. There was an odour of iris-root and damp sheets that escaped
+from a large oak chest opposite the window. On the floor in corners were
+sacks of flour stuck upright in rows. These were the overflow from
+the neighbouring granary, to which three stone steps led. By way of
+decoration for the apartment, hanging to a nail in the middle of the
+wall, whose green paint scaled off from the effects of the saltpetre,
+was a crayon head of Minerva in gold frame, underneath which was written
+in Gothic letters “To dear Papa.”
+
+First they spoke of the patient, then of the weather, of the great cold,
+of the wolves that infested the fields at night.
+
+Mademoiselle Rouault did not at all like the country, especially now
+that she had to look after the farm almost alone. As the room was
+chilly, she shivered as she ate. This showed something of her full lips,
+that she had a habit of biting when silent.
+
+Her neck stood out from a white turned-down collar. Her hair, whose
+two black folds seemed each of a single piece, so smooth were they, was
+parted in the middle by a delicate line that curved slightly with the
+curve of the head; and, just showing the tip of the ear, it was joined
+behind in a thick chignon, with a wavy movement at the temples that the
+country doctor saw now for the first time in his life. The upper part of
+her cheek was rose-coloured. She had, like a man, thrust in between two
+buttons of her bodice a tortoise-shell eyeglass.
+
+When Charles, after bidding farewell to old Rouault, returned to the
+room before leaving, he found her standing, her forehead against the
+window, looking into the garden, where the bean props had been knocked
+down by the wind. She turned round. “Are you looking for anything?” she
+asked.
+
+“My whip, if you please,” he answered.
+
+He began rummaging on the bed, behind the doors, under the chairs. It
+had fallen to the floor, between the sacks and the wall. Mademoiselle
+Emma saw it, and bent over the flour sacks.
+
+Charles out of politeness made a dash also, and as he stretched out his
+arm, at the same moment felt his breast brush against the back of the
+young girl bending beneath him. She drew herself up, scarlet, and looked
+at him over her shoulder as she handed him his whip.
+
+Instead of returning to the Bertaux in three days as he had promised,
+he went back the very next day, then regularly twice a week, without
+counting the visits he paid now and then as if by accident.
+
+Everything, moreover, went well; the patient progressed favourably; and
+when, at the end of forty-six days, old Rouault was seen trying to walk
+alone in his “den,” Monsieur Bovary began to be looked upon as a man
+of great capacity. Old Rouault said that he could not have been cured
+better by the first doctor of Yvetot, or even of Rouen.
+
+As to Charles, he did not stop to ask himself why it was a pleasure
+to him to go to the Bertaux. Had he done so, he would, no doubt, have
+attributed his zeal to the importance of the case, or perhaps to the
+money he hoped to make by it. Was it for this, however, that his visits
+to the farm formed a delightful exception to the meagre occupations of
+his life? On these days he rose early, set off at a gallop, urging on
+his horse, then got down to wipe his boots in the grass and put on black
+gloves before entering. He liked going into the courtyard, and noticing
+the gate turn against his shoulder, the cock crow on the wall, the lads
+run to meet him. He liked the granary and the stables; he liked old
+Rouault, who pressed his hand and called him his saviour; he liked the
+small wooden shoes of Mademoiselle Emma on the scoured flags of the
+kitchen--her high heels made her a little taller; and when she walked in
+front of him, the wooden soles springing up quickly struck with a sharp
+sound against the leather of her boots.
+
+She always accompanied him to the first step of the stairs. When his
+horse had not yet been brought round she stayed there. They had said
+“Good-bye”; there was no more talking. The open air wrapped her round,
+playing with the soft down on the back of her neck, or blew to and fro
+on her hips the apron-strings, that fluttered like streamers. Once,
+during a thaw the bark of the trees in the yard was oozing, the snow on
+the roofs of the outbuildings was melting; she stood on the threshold,
+and went to fetch her sunshade and opened it. The sunshade of silk of
+the colour of pigeons’ breasts, through which the sun shone, lighted
+up with shifting hues the white skin of her face. She smiled under the
+tender warmth, and drops of water could be heard falling one by one on
+the stretched silk.
+
+During the first period of Charles’s visits to the Bertaux, Madame
+Bovary junior never failed to inquire after the invalid, and she had
+even chosen in the book that she kept on a system of double entry a
+clean blank page for Monsieur Rouault. But when she heard he had a
+daughter, she began to make inquiries, and she learnt the Mademoiselle
+Rouault, brought up at the Ursuline Convent, had received what is called
+“a good education”; and so knew dancing, geography, drawing, how to
+embroider and play the piano. That was the last straw.
+
+“So it is for this,” she said to herself, “that his face beams when he
+goes to see her, and that he puts on his new waistcoat at the risk of
+spoiling it with the rain. Ah! that woman! That woman!”
+
+And she detested her instinctively. At first she solaced herself by
+allusions that Charles did not understand, then by casual observations
+that he let pass for fear of a storm, finally by open apostrophes to
+which he knew not what to answer. “Why did he go back to the Bertaux now
+that Monsieur Rouault was cured and that these folks hadn’t paid yet?
+Ah! it was because a young lady was there, some one who know how to
+talk, to embroider, to be witty. That was what he cared about; he wanted
+town misses.” And she went on--
+
+“The daughter of old Rouault a town miss! Get out! Their grandfather was
+a shepherd, and they have a cousin who was almost had up at the assizes
+for a nasty blow in a quarrel. It is not worth while making such a fuss,
+or showing herself at church on Sundays in a silk gown like a countess.
+Besides, the poor old chap, if it hadn’t been for the colza last year,
+would have had much ado to pay up his arrears.”
+
+For very weariness Charles left off going to the Bertaux. Heloise made
+him swear, his hand on the prayer-book, that he would go there no more
+after much sobbing and many kisses, in a great outburst of love. He
+obeyed then, but the strength of his desire protested against the
+servility of his conduct; and he thought, with a kind of naive
+hypocrisy, that his interdict to see her gave him a sort of right to
+love her. And then the widow was thin; she had long teeth; wore in all
+weathers a little black shawl, the edge of which hung down between her
+shoulder-blades; her bony figure was sheathed in her clothes as if they
+were a scabbard; they were too short, and displayed her ankles with the
+laces of her large boots crossed over grey stockings.
+
+Charles’s mother came to see them from time to time, but after a few
+days the daughter-in-law seemed to put her own edge on her, and
+then, like two knives, they scarified him with their reflections and
+observations. It was wrong of him to eat so much.
+
+Why did he always offer a glass of something to everyone who came?
+What obstinacy not to wear flannels! In the spring it came about that a
+notary at Ingouville, the holder of the widow Dubuc’s property, one fine
+day went off, taking with him all the money in his office. Heloise,
+it is true, still possessed, besides a share in a boat valued at six
+thousand francs, her house in the Rue St. Francois; and yet, with all
+this fortune that had been so trumpeted abroad, nothing, excepting
+perhaps a little furniture and a few clothes, had appeared in the
+household. The matter had to be gone into. The house at Dieppe was found
+to be eaten up with mortgages to its foundations; what she had placed
+with the notary God only knew, and her share in the boat did not exceed
+one thousand crowns. She had lied, the good lady! In his exasperation,
+Monsieur Bovary the elder, smashing a chair on the flags, accused his
+wife of having caused misfortune to the son by harnessing him to such
+a harridan, whose harness wasn’t worth her hide. They came to Tostes.
+Explanations followed. There were scenes. Heloise in tears, throwing her
+arms about her husband, implored him to defend her from his parents.
+
+Charles tried to speak up for her. They grew angry and left the house.
+
+But “the blow had struck home.” A week after, as she was hanging up some
+washing in her yard, she was seized with a spitting of blood, and
+the next day, while Charles had his back turned to her drawing the
+window-curtain, she said, “O God!” gave a sigh and fainted. She was
+dead! What a surprise! When all was over at the cemetery Charles went
+home. He found no one downstairs; he went up to the first floor to
+their room; saw her dress still hanging at the foot of the alcove; then,
+leaning against the writing-table, he stayed until the evening, buried
+in a sorrowful reverie. She had loved him after all!
+
+
+
+Chapter Three
+
+One morning old Rouault brought Charles the money for setting his
+leg--seventy-five francs in forty-sou pieces, and a turkey. He had heard
+of his loss, and consoled him as well as he could.
+
+“I know what it is,” said he, clapping him on the shoulder; “I’ve been
+through it. When I lost my dear departed, I went into the fields to be
+quite alone. I fell at the foot of a tree; I cried; I called on God; I
+talked nonsense to Him. I wanted to be like the moles that I saw on the
+branches, their insides swarming with worms, dead, and an end of it.
+And when I thought that there were others at that very moment with their
+nice little wives holding them in their embrace, I struck great blows on
+the earth with my stick. I was pretty well mad with not eating; the very
+idea of going to a cafe disgusted me--you wouldn’t believe it. Well,
+quite softly, one day following another, a spring on a winter, and an
+autumn after a summer, this wore away, piece by piece, crumb by crumb;
+it passed away, it is gone, I should say it has sunk; for something
+always remains at the bottom as one would say--a weight here, at one’s
+heart. But since it is the lot of all of us, one must not give way
+altogether, and, because others have died, want to die too. You must
+pull yourself together, Monsieur Bovary. It will pass away. Come to see
+us; my daughter thinks of you now and again, d’ye know, and she says
+you are forgetting her. Spring will soon be here. We’ll have some
+rabbit-shooting in the warrens to amuse you a bit.”
+
+Charles followed his advice. He went back to the Bertaux. He found all
+as he had left it, that is to say, as it was five months ago. The pear
+trees were already in blossom, and Farmer Rouault, on his legs again,
+came and went, making the farm more full of life.
+
+Thinking it his duty to heap the greatest attention upon the doctor
+because of his sad position, he begged him not to take his hat off,
+spoke to him in an undertone as if he had been ill, and even pretended
+to be angry because nothing rather lighter had been prepared for him
+than for the others, such as a little clotted cream or stewed pears. He
+told stories. Charles found himself laughing, but the remembrance of his
+wife suddenly coming back to him depressed him. Coffee was brought in;
+he thought no more about her.
+
+He thought less of her as he grew accustomed to living alone. The new
+delight of independence soon made his loneliness bearable. He could now
+change his meal-times, go in or out without explanation, and when he was
+very tired stretch himself at full length on his bed. So he nursed and
+coddled himself and accepted the consolations that were offered him.
+On the other hand, the death of his wife had not served him ill in his
+business, since for a month people had been saying, “The poor young
+man! what a loss!” His name had been talked about, his practice had
+increased; and moreover, he could go to the Bertaux just as he liked.
+He had an aimless hope, and was vaguely happy; he thought himself better
+looking as he brushed his whiskers before the looking-glass.
+
+One day he got there about three o’clock. Everybody was in the fields.
+He went into the kitchen, but did not at once catch sight of Emma; the
+outside shutters were closed. Through the chinks of the wood the sun
+sent across the flooring long fine rays that were broken at the corners
+of the furniture and trembled along the ceiling. Some flies on the table
+were crawling up the glasses that had been used, and buzzing as they
+drowned themselves in the dregs of the cider. The daylight that came in
+by the chimney made velvet of the soot at the back of the fireplace, and
+touched with blue the cold cinders. Between the window and the hearth
+Emma was sewing; she wore no fichu; he could see small drops of
+perspiration on her bare shoulders.
+
+After the fashion of country folks she asked him to have something to
+drink. He said no; she insisted, and at last laughingly offered to have
+a glass of liqueur with him. So she went to fetch a bottle of curacao
+from the cupboard, reached down two small glasses, filled one to the
+brim, poured scarcely anything into the other, and, after having clinked
+glasses, carried hers to her mouth. As it was almost empty she bent
+back to drink, her head thrown back, her lips pouting, her neck on the
+strain. She laughed at getting none of it, while with the tip of her
+tongue passing between her small teeth she licked drop by drop the
+bottom of her glass.
+
+She sat down again and took up her work, a white cotton stocking she was
+darning. She worked with her head bent down; she did not speak, nor did
+Charles. The air coming in under the door blew a little dust over the
+flags; he watched it drift along, and heard nothing but the throbbing
+in his head and the faint clucking of a hen that had laid an egg in the
+yard. Emma from time to time cooled her cheeks with the palms of her
+hands, and cooled these again on the knobs of the huge fire-dogs.
+
+She complained of suffering since the beginning of the season from
+giddiness; she asked if sea-baths would do her any good; she began
+talking of her convent, Charles of his school; words came to them. They
+went up into her bedroom. She showed him her old music-books, the little
+prizes she had won, and the oak-leaf crowns, left at the bottom of a
+cupboard. She spoke to him, too, of her mother, of the country, and even
+showed him the bed in the garden where, on the first Friday of every
+month, she gathered flowers to put on her mother’s tomb. But the
+gardener they had never knew anything about it; servants are so stupid!
+She would have dearly liked, if only for the winter, to live in town,
+although the length of the fine days made the country perhaps even more
+wearisome in the summer. And, according to what she was saying, her
+voice was clear, sharp, or, on a sudden all languor, drawn out in
+modulations that ended almost in murmurs as she spoke to herself, now
+joyous, opening big naive eyes, then with her eyelids half closed, her
+look full of boredom, her thoughts wandering.
+
+Going home at night, Charles went over her words one by one, trying to
+recall them, to fill out their sense, that he might piece out the life
+she had lived before he knew her. But he never saw her in his thoughts
+other than he had seen her the first time, or as he had just left her.
+Then he asked himself what would become of her--if she would be married,
+and to whom! Alas! Old Rouault was rich, and she!--so beautiful! But
+Emma’s face always rose before his eyes, and a monotone, like the
+humming of a top, sounded in his ears, “If you should marry after
+all! If you should marry!” At night he could not sleep; his throat was
+parched; he was athirst. He got up to drink from the water-bottle and
+opened the window. The night was covered with stars, a warm wind blowing
+in the distance; the dogs were barking. He turned his head towards the
+Bertaux.
+
+Thinking that, after all, he should lose nothing, Charles promised
+himself to ask her in marriage as soon as occasion offered, but each
+time such occasion did offer the fear of not finding the right words
+sealed his lips.
+
+Old Rouault would not have been sorry to be rid of his daughter, who was
+of no use to him in the house. In his heart he excused her, thinking
+her too clever for farming, a calling under the ban of Heaven, since one
+never saw a millionaire in it. Far from having made a fortune by it,
+the good man was losing every year; for if he was good in bargaining, in
+which he enjoyed the dodges of the trade, on the other hand, agriculture
+properly so called, and the internal management of the farm, suited him
+less than most people. He did not willingly take his hands out of his
+pockets, and did not spare expense in all that concerned himself, liking
+to eat well, to have good fires, and to sleep well. He liked old cider,
+underdone legs of mutton, glorias* well beaten up. He took his meals in
+the kitchen alone, opposite the fire, on a little table brought to him
+all ready laid as on the stage.
+
+     *A mixture of coffee and spirits.
+
+When, therefore, he perceived that Charles’s cheeks grew red if near his
+daughter, which meant that he would propose for her one of these days,
+he chewed the cud of the matter beforehand. He certainly thought him a
+little meagre, and not quite the son-in-law he would have liked, but he
+was said to be well brought-up, economical, very learned, and no doubt
+would not make too many difficulties about the dowry. Now, as old
+Rouault would soon be forced to sell twenty-two acres of “his property,”
+ as he owed a good deal to the mason, to the harness-maker, and as the
+shaft of the cider-press wanted renewing, “If he asks for her,” he said
+to himself, “I’ll give her to him.”
+
+At Michaelmas Charles went to spend three days at the Bertaux.
+
+The last had passed like the others in procrastinating from hour to
+hour. Old Rouault was seeing him off; they were walking along the road
+full of ruts; they were about to part. This was the time. Charles gave
+himself as far as to the corner of the hedge, and at last, when past
+it--
+
+“Monsieur Rouault,” he murmured, “I should like to say something to
+you.”
+
+They stopped. Charles was silent.
+
+“Well, tell me your story. Don’t I know all about it?” said old Rouault,
+laughing softly.
+
+“Monsieur Rouault--Monsieur Rouault,” stammered Charles.
+
+“I ask nothing better”, the farmer went on. “Although, no doubt, the
+little one is of my mind, still we must ask her opinion. So you get
+off--I’ll go back home. If it is ‘yes’, you needn’t return because of
+all the people about, and besides it would upset her too much. But so
+that you mayn’t be eating your heart, I’ll open wide the outer shutter
+of the window against the wall; you can see it from the back by leaning
+over the hedge.”
+
+And he went off.
+
+Charles fastened his horse to a tree; he ran into the road and waited.
+Half an hour passed, then he counted nineteen minutes by his watch.
+Suddenly a noise was heard against the wall; the shutter had been thrown
+back; the hook was still swinging.
+
+The next day by nine o’clock he was at the farm. Emma blushed as
+he entered, and she gave a little forced laugh to keep herself in
+countenance. Old Rouault embraced his future son-in-law. The discussion
+of money matters was put off; moreover, there was plenty of time before
+them, as the marriage could not decently take place till Charles was out
+of mourning, that is to say, about the spring of the next year.
+
+The winter passed waiting for this. Mademoiselle Rouault was busy with
+her trousseau. Part of it was ordered at Rouen, and she made herself
+chemises and nightcaps after fashion-plates that she borrowed. When
+Charles visited the farmer, the preparations for the wedding were talked
+over; they wondered in what room they should have dinner; they dreamed
+of the number of dishes that would be wanted, and what should be
+entrees.
+
+Emma would, on the contrary, have preferred to have a midnight wedding
+with torches, but old Rouault could not understand such an idea. So
+there was a wedding at which forty-three persons were present, at which
+they remained sixteen hours at table, began again the next day, and to
+some extent on the days following.
+
+
+
+Chapter Four
+
+The guests arrived early in carriages, in one-horse chaises, two-wheeled
+cars, old open gigs, waggonettes with leather hoods, and the young
+people from the nearer villages in carts, in which they stood up in
+rows, holding on to the sides so as not to fall, going at a trot
+and well shaken up. Some came from a distance of thirty miles, from
+Goderville, from Normanville, and from Cany.
+
+All the relatives of both families had been invited, quarrels between
+friends arranged, acquaintances long since lost sight of written to.
+
+From time to time one heard the crack of a whip behind the hedge; then
+the gates opened, a chaise entered. Galloping up to the foot of the
+steps, it stopped short and emptied its load. They got down from all
+sides, rubbing knees and stretching arms. The ladies, wearing bonnets,
+had on dresses in the town fashion, gold watch chains, pelerines with
+the ends tucked into belts, or little coloured fichus fastened down
+behind with a pin, and that left the back of the neck bare. The lads,
+dressed like their papas, seemed uncomfortable in their new clothes
+(many that day hand-sewed their first pair of boots), and by their
+sides, speaking never a work, wearing the white dress of their first
+communion lengthened for the occasion were some big girls of fourteen or
+sixteen, cousins or elder sisters no doubt, rubicund, bewildered, their
+hair greasy with rose pomade, and very much afraid of dirtying their
+gloves. As there were not enough stable-boys to unharness all the
+carriages, the gentlemen turned up their sleeves and set about it
+themselves. According to their different social positions they wore
+tail-coats, overcoats, shooting jackets, cutaway-coats; fine tail-coats,
+redolent of family respectability, that only came out of the wardrobe
+on state occasions; overcoats with long tails flapping in the wind and
+round capes and pockets like sacks; shooting jackets of coarse
+cloth, generally worn with a cap with a brass-bound peak; very short
+cutaway-coats with two small buttons in the back, close together like
+a pair of eyes, and the tails of which seemed cut out of one piece by a
+carpenter’s hatchet. Some, too (but these, you may be sure, would sit at
+the bottom of the table), wore their best blouses--that is to say,
+with collars turned down to the shoulders, the back gathered into small
+plaits and the waist fastened very low down with a worked belt.
+
+And the shirts stood out from the chests like cuirasses! Everyone had
+just had his hair cut; ears stood out from the heads; they had been
+close-shaved; a few, even, who had had to get up before daybreak, and
+not been able to see to shave, had diagonal gashes under their noses or
+cuts the size of a three-franc piece along the jaws, which the fresh
+air en route had enflamed, so that the great white beaming faces were
+mottled here and there with red dabs.
+
+The mairie was a mile and a half from the farm, and they went thither
+on foot, returning in the same way after the ceremony in the church.
+The procession, first united like one long coloured scarf that undulated
+across the fields, along the narrow path winding amid the green corn,
+soon lengthened out, and broke up into different groups that loitered to
+talk. The fiddler walked in front with his violin, gay with ribbons at
+its pegs. Then came the married pair, the relations, the friends, all
+following pell-mell; the children stayed behind amusing themselves
+plucking the bell-flowers from oat-ears, or playing amongst themselves
+unseen. Emma’s dress, too long, trailed a little on the ground; from
+time to time she stopped to pull it up, and then delicately, with her
+gloved hands, she picked off the coarse grass and the thistledowns,
+while Charles, empty handed, waited till she had finished. Old Rouault,
+with a new silk hat and the cuffs of his black coat covering his hands
+up to the nails, gave his arm to Madame Bovary senior. As to Monsieur
+Bovary senior, who, heartily despising all these folk, had come simply
+in a frock-coat of military cut with one row of buttons--he was passing
+compliments of the bar to a fair young peasant. She bowed, blushed,
+and did not know what to say. The other wedding guests talked of their
+business or played tricks behind each other’s backs, egging one another
+on in advance to be jolly. Those who listened could always catch the
+squeaking of the fiddler, who went on playing across the fields. When
+he saw that the rest were far behind he stopped to take breath, slowly
+rosined his bow, so that the strings should sound more shrilly, then set
+off again, by turns lowering and raising his neck, the better to mark
+time for himself. The noise of the instrument drove away the little
+birds from afar.
+
+The table was laid under the cart-shed. On it were four sirloins, six
+chicken fricassees, stewed veal, three legs of mutton, and in the middle
+a fine roast suckling pig, flanked by four chitterlings with sorrel. At
+the corners were decanters of brandy. Sweet bottled-cider frothed round
+the corks, and all the glasses had been filled to the brim with wine
+beforehand. Large dishes of yellow cream, that trembled with the least
+shake of the table, had designed on their smooth surface the initials of
+the newly wedded pair in nonpareil arabesques. A confectioner of Yvetot
+had been intrusted with the tarts and sweets. As he had only just set up
+on the place, he had taken a lot of trouble, and at dessert he himself
+brought in a set dish that evoked loud cries of wonderment. To begin
+with, at its base there was a square of blue cardboard, representing a
+temple with porticoes, colonnades, and stucco statuettes all round, and
+in the niches constellations of gilt paper stars; then on the second
+stage was a dungeon of Savoy cake, surrounded by many fortifications
+in candied angelica, almonds, raisins, and quarters of oranges; and
+finally, on the upper platform a green field with rocks set in lakes of
+jam, nutshell boats, and a small Cupid balancing himself in a chocolate
+swing whose two uprights ended in real roses for balls at the top.
+
+Until night they ate. When any of them were too tired of sitting, they
+went out for a stroll in the yard, or for a game with corks in the
+granary, and then returned to table. Some towards the finish went to
+sleep and snored. But with the coffee everyone woke up. Then they began
+songs, showed off tricks, raised heavy weights, performed feats with
+their fingers, then tried lifting carts on their shoulders, made broad
+jokes, kissed the women. At night when they left, the horses, stuffed
+up to the nostrils with oats, could hardly be got into the shafts; they
+kicked, reared, the harness broke, their masters laughed or swore;
+and all night in the light of the moon along country roads there were
+runaway carts at full gallop plunging into the ditches, jumping over
+yard after yard of stones, clambering up the hills, with women leaning
+out from the tilt to catch hold of the reins.
+
+Those who stayed at the Bertaux spent the night drinking in the kitchen.
+The children had fallen asleep under the seats.
+
+The bride had begged her father to be spared the usual marriage
+pleasantries. However, a fishmonger, one of their cousins (who had even
+brought a pair of soles for his wedding present), began to squirt water
+from his mouth through the keyhole, when old Rouault came up just in
+time to stop him, and explain to him that the distinguished position
+of his son-in-law would not allow of such liberties. The cousin all the
+same did not give in to these reasons readily. In his heart he accused
+old Rouault of being proud, and he joined four or five other guests in
+a corner, who having, through mere chance, been several times running
+served with the worst helps of meat, also were of opinion they had been
+badly used, and were whispering about their host, and with covered hints
+hoping he would ruin himself.
+
+Madame Bovary, senior, had not opened her mouth all day. She had been
+consulted neither as to the dress of her daughter-in-law nor as to the
+arrangement of the feast; she went to bed early. Her husband, instead
+of following her, sent to Saint-Victor for some cigars, and smoked till
+daybreak, drinking kirsch-punch, a mixture unknown to the company. This
+added greatly to the consideration in which he was held.
+
+Charles, who was not of a facetious turn, did not shine at the wedding.
+He answered feebly to the puns, doubles entendres*, compliments, and
+chaff that it was felt a duty to let off at him as soon as the soup
+appeared.
+
+     *Double meanings.
+
+The next day, on the other hand, he seemed another man. It was he who
+might rather have been taken for the virgin of the evening before,
+whilst the bride gave no sign that revealed anything. The shrewdest did
+not know what to make of it, and they looked at her when she passed
+near them with an unbounded concentration of mind. But Charles concealed
+nothing. He called her “my wife”, tutoyed* her, asked for her of
+everyone, looked for her everywhere, and often he dragged her into the
+yards, where he could be seen from far between the trees, putting his
+arm around her waist, and walking half-bending over her, ruffling the
+chemisette of her bodice with his head.
+
+     *Used the familiar form of address.
+
+Two days after the wedding the married pair left. Charles, on account of
+his patients, could not be away longer. Old Rouault had them driven back
+in his cart, and himself accompanied them as far as Vassonville. Here
+he embraced his daughter for the last time, got down, and went his way.
+When he had gone about a hundred paces he stopped, and as he saw the
+cart disappearing, its wheels turning in the dust, he gave a deep sigh.
+Then he remembered his wedding, the old times, the first pregnancy of
+his wife; he, too, had been very happy the day when he had taken her
+from her father to his home, and had carried her off on a pillion,
+trotting through the snow, for it was near Christmas-time, and the
+country was all white. She held him by one arm, her basket hanging from
+the other; the wind blew the long lace of her Cauchois headdress so that
+it sometimes flapped across his mouth, and when he turned his head he
+saw near him, on his shoulder, her little rosy face, smiling silently
+under the gold bands of her cap. To warm her hands she put them from
+time to time in his breast. How long ago it all was! Their son would
+have been thirty by now. Then he looked back and saw nothing on the
+road. He felt dreary as an empty house; and tender memories mingling
+with the sad thoughts in his brain, addled by the fumes of the feast, he
+felt inclined for a moment to take a turn towards the church. As he was
+afraid, however, that this sight would make him yet more sad, he went
+right away home.
+
+Monsieur and Madame Charles arrived at Tostes about six o’clock.
+
+The neighbors came to the windows to see their doctor’s new wife.
+
+The old servant presented herself, curtsied to her, apologised for not
+having dinner ready, and suggested that madame, in the meantime, should
+look over her house.
+
+
+
+Chapter Five
+
+The brick front was just in a line with the street, or rather the road.
+Behind the door hung a cloak with a small collar, a bridle, and a black
+leather cap, and on the floor, in a corner, were a pair of leggings,
+still covered with dry mud. On the right was the one apartment, that was
+both dining and sitting room. A canary yellow paper, relieved at the
+top by a garland of pale flowers, was puckered everywhere over the badly
+stretched canvas; white calico curtains with a red border hung crossways
+at the length of the window; and on the narrow mantelpiece a clock with
+a head of Hippocrates shone resplendent between two plate candlesticks
+under oval shades. On the other side of the passage was Charles’s
+consulting room, a little room about six paces wide, with a table,
+three chairs, and an office chair. Volumes of the “Dictionary of Medical
+Science,” uncut, but the binding rather the worse for the successive
+sales through which they had gone, occupied almost along the six shelves
+of a deal bookcase.
+
+The smell of melted butter penetrated through the walls when he saw
+patients, just as in the kitchen one could hear the people coughing in
+the consulting room and recounting their histories.
+
+Then, opening on the yard, where the stable was, came a large
+dilapidated room with a stove, now used as a wood-house, cellar, and
+pantry, full of old rubbish, of empty casks, agricultural implements
+past service, and a mass of dusty things whose use it was impossible to
+guess.
+
+The garden, longer than wide, ran between two mud walls with espaliered
+apricots, to a hawthorn hedge that separated it from the field. In the
+middle was a slate sundial on a brick pedestal; four flower beds with
+eglantines surrounded symmetrically the more useful kitchen garden bed.
+Right at the bottom, under the spruce bushes, was a cure in plaster
+reading his breviary.
+
+Emma went upstairs. The first room was not furnished, but in the second,
+which was their bedroom, was a mahogany bedstead in an alcove with red
+drapery. A shell box adorned the chest of drawers, and on the secretary
+near the window a bouquet of orange blossoms tied with white satin
+ribbons stood in a bottle. It was a bride’s bouquet; it was the other
+one’s. She looked at it. Charles noticed it; he took it and carried it
+up to the attic, while Emma seated in an arm-chair (they were putting
+her things down around her) thought of her bridal flowers packed up in
+a bandbox, and wondered, dreaming, what would be done with them if she
+were to die.
+
+During the first days she occupied herself in thinking about changes in
+the house. She took the shades off the candlesticks, had new wallpaper
+put up, the staircase repainted, and seats made in the garden round the
+sundial; she even inquired how she could get a basin with a jet fountain
+and fishes. Finally her husband, knowing that she liked to drive out,
+picked up a second-hand dogcart, which, with new lamps and splashboard
+in striped leather, looked almost like a tilbury.
+
+He was happy then, and without a care in the world. A meal together,
+a walk in the evening on the highroad, a gesture of her hands over her
+hair, the sight of her straw hat hanging from the window-fastener, and
+many another thing in which Charles had never dreamed of pleasure, now
+made up the endless round of his happiness. In bed, in the morning, by
+her side, on the pillow, he watched the sunlight sinking into the down
+on her fair cheek, half hidden by the lappets of her night-cap. Seen
+thus closely, her eyes looked to him enlarged, especially when, on
+waking up, she opened and shut them rapidly many times. Black in the
+shade, dark blue in broad daylight, they had, as it were, depths of
+different colours, that, darker in the centre, grew paler towards the
+surface of the eye. His own eyes lost themselves in these depths; he saw
+himself in miniature down to the shoulders, with his handkerchief round
+his head and the top of his shirt open. He rose. She came to the window
+to see him off, and stayed leaning on the sill between two pots of
+geranium, clad in her dressing gown hanging loosely about her. Charles,
+in the street buckled his spurs, his foot on the mounting stone, while
+she talked to him from above, picking with her mouth some scrap of
+flower or leaf that she blew out at him. Then this, eddying, floating,
+described semicircles in the air like a bird, and was caught before
+it reached the ground in the ill-groomed mane of the old white mare
+standing motionless at the door. Charles from horseback threw her a
+kiss; she answered with a nod; she shut the window, and he set off. And
+then along the highroad, spreading out its long ribbon of dust, along
+the deep lanes that the trees bent over as in arbours, along paths where
+the corn reached to the knees, with the sun on his back and the morning
+air in his nostrils, his heart full of the joys of the past night, his
+mind at rest, his flesh at ease, he went on, re-chewing his happiness,
+like those who after dinner taste again the truffles which they are
+digesting.
+
+Until now what good had he had of his life? His time at school, when
+he remained shut up within the high walls, alone, in the midst of
+companions richer than he or cleverer at their work, who laughed at his
+accent, who jeered at his clothes, and whose mothers came to the school
+with cakes in their muffs? Later on, when he studied medicine, and never
+had his purse full enough to treat some little work-girl who would have
+become his mistress? Afterwards, he had lived fourteen months with the
+widow, whose feet in bed were cold as icicles. But now he had for life
+this beautiful woman whom he adored. For him the universe did not extend
+beyond the circumference of her petticoat, and he reproached himself
+with not loving her. He wanted to see her again; he turned back quickly,
+ran up the stairs with a beating heart. Emma, in her room, was dressing;
+he came up on tiptoe, kissed her back; she gave a cry.
+
+He could not keep from constantly touching her comb, her ring, her
+fichu; sometimes he gave her great sounding kisses with all his mouth on
+her cheeks, or else little kisses in a row all along her bare arm
+from the tip of her fingers up to her shoulder, and she put him away
+half-smiling, half-vexed, as you do a child who hangs about you.
+
+Before marriage she thought herself in love; but the happiness that
+should have followed this love not having come, she must, she thought,
+have been mistaken. And Emma tried to find out what one meant exactly in
+life by the words felicity, passion, rapture, that had seemed to her so
+beautiful in books.
+
+
+
+Chapter Six
+
+She had read “Paul and Virginia,” and she had dreamed of the little
+bamboo-house, the nigger Domingo, the dog Fidele, but above all of the
+sweet friendship of some dear little brother, who seeks red fruit for
+you on trees taller than steeples, or who runs barefoot over the sand,
+bringing you a bird’s nest.
+
+When she was thirteen, her father himself took her to town to place
+her in the convent. They stopped at an inn in the St. Gervais quarter,
+where, at their supper, they used painted plates that set forth the
+story of Mademoiselle de la Valliere. The explanatory legends, chipped
+here and there by the scratching of knives, all glorified religion, the
+tendernesses of the heart, and the pomps of court.
+
+Far from being bored at first at the convent, she took pleasure in the
+society of the good sisters, who, to amuse her, took her to the chapel,
+which one entered from the refectory by a long corridor. She played very
+little during recreation hours, knew her catechism well, and it was she
+who always answered Monsieur le Vicaire’s difficult questions. Living
+thus, without ever leaving the warm atmosphere of the classrooms, and
+amid these pale-faced women wearing rosaries with brass crosses, she
+was softly lulled by the mystic languor exhaled in the perfumes of the
+altar, the freshness of the holy water, and the lights of the tapers.
+Instead of attending to mass, she looked at the pious vignettes with
+their azure borders in her book, and she loved the sick lamb, the sacred
+heart pierced with sharp arrows, or the poor Jesus sinking beneath the
+cross he carries. She tried, by way of mortification, to eat nothing a
+whole day. She puzzled her head to find some vow to fulfil.
+
+When she went to confession, she invented little sins in order that she
+might stay there longer, kneeling in the shadow, her hands joined,
+her face against the grating beneath the whispering of the priest.
+The comparisons of betrothed, husband, celestial lover, and eternal
+marriage, that recur in sermons, stirred within her soul depths of
+unexpected sweetness.
+
+In the evening, before prayers, there was some religious reading in
+the study. On week-nights it was some abstract of sacred history or
+the Lectures of the Abbe Frayssinous, and on Sundays passages from the
+“Genie du Christianisme,” as a recreation. How she listened at first to
+the sonorous lamentations of its romantic melancholies reechoing
+through the world and eternity! If her childhood had been spent in the
+shop-parlour of some business quarter, she might perhaps have opened
+her heart to those lyrical invasions of Nature, which usually come to
+us only through translation in books. But she knew the country too well;
+she knew the lowing of cattle, the milking, the ploughs.
+
+Accustomed to calm aspects of life, she turned, on the contrary, to
+those of excitement. She loved the sea only for the sake of its storms,
+and the green fields only when broken up by ruins.
+
+She wanted to get some personal profit out of things, and she rejected
+as useless all that did not contribute to the immediate desires of her
+heart, being of a temperament more sentimental than artistic, looking
+for emotions, not landscapes.
+
+At the convent there was an old maid who came for a week each month to
+mend the linen. Patronized by the clergy, because she belonged to an
+ancient family of noblemen ruined by the Revolution, she dined in the
+refectory at the table of the good sisters, and after the meal had a bit
+of chat with them before going back to her work. The girls often slipped
+out from the study to go and see her. She knew by heart the love songs
+of the last century, and sang them in a low voice as she stitched away.
+
+She told stories, gave them news, went errands in the town, and on
+the sly lent the big girls some novel, that she always carried in the
+pockets of her apron, and of which the good lady herself swallowed
+long chapters in the intervals of her work. They were all love, lovers,
+sweethearts, persecuted ladies fainting in lonely pavilions, postilions
+killed at every stage, horses ridden to death on every page, sombre
+forests, heartaches, vows, sobs, tears and kisses, little skiffs by
+moonlight, nightingales in shady groves, “gentlemen” brave as lions,
+gentle as lambs, virtuous as no one ever was, always well dressed, and
+weeping like fountains. For six months, then, Emma, at fifteen years of
+age, made her hands dirty with books from old lending libraries.
+
+Through Walter Scott, later on, she fell in love with historical events,
+dreamed of old chests, guard-rooms and minstrels. She would have liked
+to live in some old manor-house, like those long-waisted chatelaines
+who, in the shade of pointed arches, spent their days leaning on the
+stone, chin in hand, watching a cavalier with white plume galloping on
+his black horse from the distant fields. At this time she had a cult
+for Mary Stuart and enthusiastic veneration for illustrious or unhappy
+women. Joan of Arc, Heloise, Agnes Sorel, the beautiful Ferroniere, and
+Clemence Isaure stood out to her like comets in the dark immensity of
+heaven, where also were seen, lost in shadow, and all unconnected, St.
+Louis with his oak, the dying Bayard, some cruelties of Louis XI, a
+little of St. Bartholomew’s Day, the plume of the Bearnais, and always
+the remembrance of the plates painted in honour of Louis XIV.
+
+In the music class, in the ballads she sang, there was nothing but
+little angels with golden wings, madonnas, lagunes, gondoliers;-mild
+compositions that allowed her to catch a glimpse athwart the obscurity
+of style and the weakness of the music of the attractive phantasmagoria
+of sentimental realities. Some of her companions brought “keepsakes”
+ given them as new year’s gifts to the convent. These had to be hidden;
+it was quite an undertaking; they were read in the dormitory. Delicately
+handling the beautiful satin bindings, Emma looked with dazzled eyes at
+the names of the unknown authors, who had signed their verses for the
+most part as counts or viscounts.
+
+She trembled as she blew back the tissue paper over the engraving and
+saw it folded in two and fall gently against the page. Here behind the
+balustrade of a balcony was a young man in a short cloak, holding in his
+arms a young girl in a white dress wearing an alms-bag at her belt; or
+there were nameless portraits of English ladies with fair curls, who
+looked at you from under their round straw hats with their large clear
+eyes. Some there were lounging in their carriages, gliding through
+parks, a greyhound bounding along in front of the equipage driven at
+a trot by two midget postilions in white breeches. Others, dreaming on
+sofas with an open letter, gazed at the moon through a slightly open
+window half draped by a black curtain. The naive ones, a tear on their
+cheeks, were kissing doves through the bars of a Gothic cage, or,
+smiling, their heads on one side, were plucking the leaves of a
+marguerite with their taper fingers, that curved at the tips like peaked
+shoes. And you, too, were there, Sultans with long pipes reclining
+beneath arbours in the arms of Bayaderes; Djiaours, Turkish sabres,
+Greek caps; and you especially, pale landscapes of dithyrambic lands,
+that often show us at once palm trees and firs, tigers on the right, a
+lion to the left, Tartar minarets on the horizon; the whole framed by
+a very neat virgin forest, and with a great perpendicular sunbeam
+trembling in the water, where, standing out in relief like white
+excoriations on a steel-grey ground, swans are swimming about.
+
+And the shade of the argand lamp fastened to the wall above Emma’s head
+lighted up all these pictures of the world, that passed before her one
+by one in the silence of the dormitory, and to the distant noise of some
+belated carriage rolling over the Boulevards.
+
+When her mother died she cried much the first few days. She had a
+funeral picture made with the hair of the deceased, and, in a letter
+sent to the Bertaux full of sad reflections on life, she asked to be
+buried later on in the same grave. The goodman thought she must be ill,
+and came to see her. Emma was secretly pleased that she had reached at
+a first attempt the rare ideal of pale lives, never attained by mediocre
+hearts. She let herself glide along with Lamartine meanderings, listened
+to harps on lakes, to all the songs of dying swans, to the falling of
+the leaves, the pure virgins ascending to heaven, and the voice of
+the Eternal discoursing down the valleys. She wearied of it, would not
+confess it, continued from habit, and at last was surprised to feel
+herself soothed, and with no more sadness at heart than wrinkles on her
+brow.
+
+The good nuns, who had been so sure of her vocation, perceived with
+great astonishment that Mademoiselle Rouault seemed to be slipping
+from them. They had indeed been so lavish to her of prayers, retreats,
+novenas, and sermons, they had so often preached the respect due to
+saints and martyrs, and given so much good advice as to the modesty of
+the body and the salvation of her soul, that she did as tightly reined
+horses; she pulled up short and the bit slipped from her teeth. This
+nature, positive in the midst of its enthusiasms, that had loved the
+church for the sake of the flowers, and music for the words of the
+songs, and literature for its passional stimulus, rebelled against
+the mysteries of faith as it grew irritated by discipline, a thing
+antipathetic to her constitution. When her father took her from school,
+no one was sorry to see her go. The Lady Superior even thought that she
+had latterly been somewhat irreverent to the community.
+
+Emma, at home once more, first took pleasure in looking after the
+servants, then grew disgusted with the country and missed her convent.
+When Charles came to the Bertaux for the first time, she thought herself
+quite disillusioned, with nothing more to learn, and nothing more to
+feel.
+
+But the uneasiness of her new position, or perhaps the disturbance
+caused by the presence of this man, had sufficed to make her believe
+that she at last felt that wondrous passion which, till then, like a
+great bird with rose-coloured wings, hung in the splendour of the skies
+of poesy; and now she could not think that the calm in which she lived
+was the happiness she had dreamed.
+
+
+
+Chapter Seven
+
+She thought, sometimes, that, after all, this was the happiest time
+of her life--the honeymoon, as people called it. To taste the full
+sweetness of it, it would have been necessary doubtless to fly to those
+lands with sonorous names where the days after marriage are full of
+laziness most suave. In post chaises behind blue silken curtains to ride
+slowly up steep road, listening to the song of the postilion re-echoed
+by the mountains, along with the bells of goats and the muffled sound of
+a waterfall; at sunset on the shores of gulfs to breathe in the perfume
+of lemon trees; then in the evening on the villa-terraces above, hand in
+hand to look at the stars, making plans for the future. It seemed to her
+that certain places on earth must bring happiness, as a plant peculiar
+to the soil, and that cannot thrive elsewhere. Why could not she lean
+over balconies in Swiss chalets, or enshrine her melancholy in a Scotch
+cottage, with a husband dressed in a black velvet coat with long tails,
+and thin shoes, a pointed hat and frills? Perhaps she would have liked
+to confide all these things to someone. But how tell an undefinable
+uneasiness, variable as the clouds, unstable as the winds? Words failed
+her--the opportunity, the courage.
+
+If Charles had but wished it, if he had guessed it, if his look had but
+once met her thought, it seemed to her that a sudden plenty would have
+gone out from her heart, as the fruit falls from a tree when shaken by
+a hand. But as the intimacy of their life became deeper, the greater
+became the gulf that separated her from him.
+
+Charles’s conversation was commonplace as a street pavement, and
+everyone’s ideas trooped through it in their everyday garb, without
+exciting emotion, laughter, or thought. He had never had the curiosity,
+he said, while he lived at Rouen, to go to the theatre to see the actors
+from Paris. He could neither swim, nor fence, nor shoot, and one day
+he could not explain some term of horsemanship to her that she had come
+across in a novel.
+
+A man, on the contrary, should he not know everything, excel in manifold
+activities, initiate you into the energies of passion, the refinements
+of life, all mysteries? But this one taught nothing, knew nothing,
+wished nothing. He thought her happy; and she resented this easy calm,
+this serene heaviness, the very happiness she gave him.
+
+Sometimes she would draw; and it was great amusement to Charles to stand
+there bolt upright and watch her bend over her cardboard, with eyes
+half-closed the better to see her work, or rolling, between her fingers,
+little bread-pellets. As to the piano, the more quickly her fingers
+glided over it the more he wondered. She struck the notes with aplomb,
+and ran from top to bottom of the keyboard without a break. Thus shaken
+up, the old instrument, whose strings buzzed, could be heard at the
+other end of the village when the window was open, and often the
+bailiff’s clerk, passing along the highroad bare-headed and in list
+slippers, stopped to listen, his sheet of paper in his hand.
+
+Emma, on the other hand, knew how to look after her house. She sent the
+patients’ accounts in well-phrased letters that had no suggestion of
+a bill. When they had a neighbour to dinner on Sundays, she managed to
+have some tasty dish--piled up pyramids of greengages on vine leaves,
+served up preserves turned out into plates--and even spoke of buying
+finger-glasses for dessert. From all this much consideration was
+extended to Bovary.
+
+Charles finished by rising in his own esteem for possessing such a wife.
+He showed with pride in the sitting room two small pencil sketches by
+her that he had had framed in very large frames, and hung up against the
+wallpaper by long green cords. People returning from mass saw him at his
+door in his wool-work slippers.
+
+He came home late--at ten o’clock, at midnight sometimes. Then he asked
+for something to eat, and as the servant had gone to bed, Emma waited
+on him. He took off his coat to dine more at his ease. He told her, one
+after the other, the people he had met, the villages where he had been,
+the prescriptions he had written, and, well pleased with himself, he
+finished the remainder of the boiled beef and onions, picked pieces off
+the cheese, munched an apple, emptied his water-bottle, and then went to
+bed, and lay on his back and snored.
+
+As he had been for a time accustomed to wear nightcaps, his handkerchief
+would not keep down over his ears, so that his hair in the morning was
+all tumbled pell-mell about his face and whitened with the feathers of
+the pillow, whose strings came untied during the night. He always wore
+thick boots that had two long creases over the instep running obliquely
+towards the ankle, while the rest of the upper continued in a straight
+line as if stretched on a wooden foot. He said that “was quite good
+enough for the country.”
+
+His mother approved of his economy, for she came to see him as formerly
+when there had been some violent row at her place; and yet Madame Bovary
+senior seemed prejudiced against her daughter-in-law. She thought “her
+ways too fine for their position”; the wood, the sugar, and the candles
+disappeared as “at a grand establishment,” and the amount of firing in
+the kitchen would have been enough for twenty-five courses. She put her
+linen in order for her in the presses, and taught her to keep an eye on
+the butcher when he brought the meat. Emma put up with these lessons.
+Madame Bovary was lavish of them; and the words “daughter” and “mother”
+ were exchanged all day long, accompanied by little quiverings of the
+lips, each one uttering gentle words in a voice trembling with anger.
+
+In Madame Dubuc’s time the old woman felt that she was still the
+favorite; but now the love of Charles for Emma seemed to her a desertion
+from her tenderness, an encroachment upon what was hers, and she watched
+her son’s happiness in sad silence, as a ruined man looks through
+the windows at people dining in his old house. She recalled to him as
+remembrances her troubles and her sacrifices, and, comparing these with
+Emma’s negligence, came to the conclusion that it was not reasonable to
+adore her so exclusively.
+
+Charles knew not what to answer: he respected his mother, and he loved
+his wife infinitely; he considered the judgment of the one infallible,
+and yet he thought the conduct of the other irreproachable. When Madam
+Bovary had gone, he tried timidly and in the same terms to hazard one or
+two of the more anodyne observations he had heard from his mamma. Emma
+proved to him with a word that he was mistaken, and sent him off to his
+patients.
+
+And yet, in accord with theories she believed right, she wanted to make
+herself in love with him. By moonlight in the garden she recited all
+the passionate rhymes she knew by heart, and, sighing, sang to him many
+melancholy adagios; but she found herself as calm after as before, and
+Charles seemed no more amorous and no more moved.
+
+When she had thus for a while struck the flint on her heart without
+getting a spark, incapable, moreover, of understanding what she did
+not experience as of believing anything that did not present itself
+in conventional forms, she persuaded herself without difficulty that
+Charles’s passion was nothing very exorbitant. His outbursts became
+regular; he embraced her at certain fixed times. It was one habit among
+other habits, and, like a dessert, looked forward to after the monotony
+of dinner.
+
+A gamekeeper, cured by the doctor of inflammation of the lungs, had
+given madame a little Italian greyhound; she took her out walking, for
+she went out sometimes in order to be alone for a moment, and not to see
+before her eyes the eternal garden and the dusty road. She went as far
+as the beeches of Banneville, near the deserted pavilion which forms an
+angle of the wall on the side of the country. Amidst the vegetation of
+the ditch there are long reeds with leaves that cut you.
+
+She began by looking round her to see if nothing had changed since last
+she had been there. She found again in the same places the foxgloves and
+wallflowers, the beds of nettles growing round the big stones, and
+the patches of lichen along the three windows, whose shutters, always
+closed, were rotting away on their rusty iron bars. Her thoughts,
+aimless at first, wandered at random, like her greyhound, who ran round
+and round in the fields, yelping after the yellow butterflies, chasing
+the shrew-mice, or nibbling the poppies on the edge of a cornfield.
+
+Then gradually her ideas took definite shape, and, sitting on the grass
+that she dug up with little prods of her sunshade, Emma repeated to
+herself, “Good heavens! Why did I marry?”
+
+She asked herself if by some other chance combination it would have not
+been possible to meet another man; and she tried to imagine what would
+have been these unrealised events, this different life, this unknown
+husband. All, surely, could not be like this one. He might have been
+handsome, witty, distinguished, attractive, such as, no doubt, her old
+companions of the convent had married. What were they doing now? In
+town, with the noise of the streets, the buzz of the theatres and the
+lights of the ballroom, they were living lives where the heart expands,
+the senses bourgeon out. But she--her life was cold as a garret whose
+dormer window looks on the north, and ennui, the silent spider, was
+weaving its web in the darkness in every corner of her heart.
+
+She recalled the prize days, when she mounted the platform to receive
+her little crowns, with her hair in long plaits. In her white frock and
+open prunella shoes she had a pretty way, and when she went back to her
+seat, the gentlemen bent over her to congratulate her; the courtyard was
+full of carriages; farewells were called to her through their windows;
+the music master with his violin case bowed in passing by. How far all
+of this! How far away! She called Djali, took her between her knees, and
+smoothed the long delicate head, saying, “Come, kiss mistress; you have
+no troubles.”
+
+Then noting the melancholy face of the graceful animal, who yawned
+slowly, she softened, and comparing her to herself, spoke to her aloud
+as to somebody in trouble whom one is consoling.
+
+Occasionally there came gusts of winds, breezes from the sea rolling in
+one sweep over the whole plateau of the Caux country, which brought
+even to these fields a salt freshness. The rushes, close to the ground,
+whistled; the branches trembled in a swift rustling, while their
+summits, ceaselessly swaying, kept up a deep murmur. Emma drew her shawl
+round her shoulders and rose.
+
+In the avenue a green light dimmed by the leaves lit up the short moss
+that crackled softly beneath her feet. The sun was setting; the sky
+showed red between the branches, and the trunks of the trees, uniform,
+and planted in a straight line, seemed a brown colonnade standing out
+against a background of gold. A fear took hold of her; she called Djali,
+and hurriedly returned to Tostes by the high road, threw herself into an
+armchair, and for the rest of the evening did not speak.
+
+But towards the end of September something extraordinary fell upon her
+life; she was invited by the Marquis d’Andervilliers to Vaubyessard.
+
+Secretary of State under the Restoration, the Marquis, anxious to
+re-enter political life, set about preparing for his candidature to
+the Chamber of Deputies long beforehand. In the winter he distributed a
+great deal of wood, and in the Conseil General always enthusiastically
+demanded new roads for his arrondissement. During the dog-days he had
+suffered from an abscess, which Charles had cured as if by miracle by
+giving a timely little touch with the lancet. The steward sent to Tostes
+to pay for the operation reported in the evening that he had seen some
+superb cherries in the doctor’s little garden. Now cherry trees did not
+thrive at Vaubyessard; the Marquis asked Bovary for some slips; made it
+his business to thank his personally; saw Emma; thought she had a pretty
+figure, and that she did not bow like a peasant; so that he did not
+think he was going beyond the bounds of condescension, nor, on the other
+hand, making a mistake, in inviting the young couple.
+
+On Wednesday at three o’clock, Monsieur and Madame Bovary, seated in
+their dog-cart, set out for Vaubyessard, with a great trunk strapped
+on behind and a bonnet-box in front of the apron. Besides these Charles
+held a bandbox between his knees.
+
+They arrived at nightfall, just as the lamps in the park were being lit
+to show the way for the carriages.
+
+
+
+Chapter Eight
+
+The chateau, a modern building in Italian style, with two projecting
+wings and three flights of steps, lay at the foot of an immense
+green-sward, on which some cows were grazing among groups of large trees
+set out at regular intervals, while large beds of arbutus, rhododendron,
+syringas, and guelder roses bulged out their irregular clusters of
+green along the curve of the gravel path. A river flowed under a bridge;
+through the mist one could distinguish buildings with thatched roofs
+scattered over the field bordered by two gently sloping, well timbered
+hillocks, and in the background amid the trees rose in two parallel
+lines the coach houses and stables, all that was left of the ruined old
+chateau.
+
+Charles’s dog-cart pulled up before the middle flight of steps; servants
+appeared; the Marquis came forward, and, offering his arm to the
+doctor’s wife, conducted her to the vestibule.
+
+It was paved with marble slabs, was very lofty, and the sound of
+footsteps and that of voices re-echoed through it as in a church.
+
+Opposite rose a straight staircase, and on the left a gallery
+overlooking the garden led to the billiard room, through whose door one
+could hear the click of the ivory balls. As she crossed it to go to the
+drawing room, Emma saw standing round the table men with grave faces,
+their chins resting on high cravats. They all wore orders, and smiled
+silently as they made their strokes.
+
+On the dark wainscoting of the walls large gold frames bore at
+the bottom names written in black letters. She read: “Jean-Antoine
+d’Andervilliers d’Yvervonbille, Count de la Vaubyessard and Baron de la
+Fresnay, killed at the battle of Coutras on the 20th of October,
+1587.” And on another: “Jean-Antoine-Henry-Guy d’Andervilliers de
+la Vaubyessard, Admiral of France and Chevalier of the Order of St.
+Michael, wounded at the battle of the Hougue-Saint-Vaast on the 29th of
+May, 1692; died at Vaubyessard on the 23rd of January 1693.” One could
+hardly make out those that followed, for the light of the lamps lowered
+over the green cloth threw a dim shadow round the room. Burnishing the
+horizontal pictures, it broke up against these in delicate lines where
+there were cracks in the varnish, and from all these great black squares
+framed in with gold stood out here and there some lighter portion of the
+painting--a pale brow, two eyes that looked at you, perukes flowing over
+and powdering red-coated shoulders, or the buckle of a garter above a
+well-rounded calf.
+
+The Marquis opened the drawing room door; one of the ladies (the
+Marchioness herself) came to meet Emma. She made her sit down by her on
+an ottoman, and began talking to her as amicably as if she had known her
+a long time. She was a woman of about forty, with fine shoulders, a hook
+nose, a drawling voice, and on this evening she wore over her brown hair
+a simple guipure fichu that fell in a point at the back. A fair young
+woman sat in a high-backed chair in a corner; and gentlemen with flowers
+in their buttonholes were talking to ladies round the fire.
+
+At seven dinner was served. The men, who were in the majority, sat down
+at the first table in the vestibule; the ladies at the second in the
+dining room with the Marquis and Marchioness.
+
+Emma, on entering, felt herself wrapped round by the warm air, a
+blending of the perfume of flowers and of the fine linen, of the fumes
+of the viands, and the odour of the truffles. The silver dish covers
+reflected the lighted wax candles in the candelabra, the cut crystal
+covered with light steam reflected from one to the other pale rays;
+bouquets were placed in a row the whole length of the table; and in
+the large-bordered plates each napkin, arranged after the fashion of a
+bishop’s mitre, held between its two gaping folds a small oval shaped
+roll. The red claws of lobsters hung over the dishes; rich fruit in open
+baskets was piled up on moss; there were quails in their plumage; smoke
+was rising; and in silk stockings, knee-breeches, white cravat, and
+frilled shirt, the steward, grave as a judge, offering ready carved
+dishes between the shoulders of the guests, with a touch of the spoon
+gave you the piece chosen. On the large stove of porcelain inlaid
+with copper baguettes the statue of a woman, draped to the chin, gazed
+motionless on the room full of life.
+
+Madame Bovary noticed that many ladies had not put their gloves in their
+glasses.
+
+But at the upper end of the table, alone amongst all these women, bent
+over his full plate, and his napkin tied round his neck like a child, an
+old man sat eating, letting drops of gravy drip from his mouth. His eyes
+were bloodshot, and he wore a little queue tied with black ribbon. He
+was the Marquis’s father-in-law, the old Duke de Laverdiere, once on
+a time favourite of the Count d’Artois, in the days of the Vaudreuil
+hunting-parties at the Marquis de Conflans’, and had been, it was said,
+the lover of Queen Marie Antoinette, between Monsieur de Coigny and
+Monsieur de Lauzun. He had lived a life of noisy debauch, full of duels,
+bets, elopements; he had squandered his fortune and frightened all his
+family. A servant behind his chair named aloud to him in his ear the
+dishes that he pointed to stammering, and constantly Emma’s eyes
+turned involuntarily to this old man with hanging lips, as to something
+extraordinary. He had lived at court and slept in the bed of queens!
+Iced champagne was poured out. Emma shivered all over as she felt
+it cold in her mouth. She had never seen pomegranates nor tasted
+pineapples. The powdered sugar even seemed to her whiter and finer than
+elsewhere.
+
+The ladies afterwards went to their rooms to prepare for the ball.
+
+Emma made her toilet with the fastidious care of an actress on her
+debut. She did her hair according to the directions of the hairdresser,
+and put on the barege dress spread out upon the bed.
+
+Charles’s trousers were tight across the belly.
+
+“My trouser-straps will be rather awkward for dancing,” he said.
+
+“Dancing?” repeated Emma.
+
+“Yes!”
+
+“Why, you must be mad! They would make fun of you; keep your place.
+Besides, it is more becoming for a doctor,” she added.
+
+Charles was silent. He walked up and down waiting for Emma to finish
+dressing.
+
+He saw her from behind in the glass between two lights. Her black eyes
+seemed blacker than ever. Her hair, undulating towards the ears, shone
+with a blue lustre; a rose in her chignon trembled on its mobile stalk,
+with artificial dewdrops on the tip of the leaves. She wore a gown of
+pale saffron trimmed with three bouquets of pompon roses mixed with
+green.
+
+Charles came and kissed her on her shoulder.
+
+“Let me alone!” she said; “you are tumbling me.”
+
+One could hear the flourish of the violin and the notes of a horn. She
+went downstairs restraining herself from running.
+
+Dancing had begun. Guests were arriving. There was some crushing.
+
+She sat down on a form near the door.
+
+The quadrille over, the floor was occupied by groups of men standing up
+and talking and servants in livery bearing large trays. Along the line
+of seated women painted fans were fluttering, bouquets half hid smiling
+faces, and gold stoppered scent-bottles were turned in partly-closed
+hands, whose white gloves outlined the nails and tightened on the flesh
+at the wrists. Lace trimmings, diamond brooches, medallion bracelets
+trembled on bodices, gleamed on breasts, clinked on bare arms.
+
+The hair, well-smoothed over the temples and knotted at the nape,
+bore crowns, or bunches, or sprays of mytosotis, jasmine, pomegranate
+blossoms, ears of corn, and corn-flowers. Calmly seated in their places,
+mothers with forbidding countenances were wearing red turbans.
+
+Emma’s heart beat rather faster when, her partner holding her by the
+tips of the fingers, she took her place in a line with the dancers, and
+waited for the first note to start. But her emotion soon vanished, and,
+swaying to the rhythm of the orchestra, she glided forward with slight
+movements of the neck. A smile rose to her lips at certain delicate
+phrases of the violin, that sometimes played alone while the other
+instruments were silent; one could hear the clear clink of the louis
+d’or that were being thrown down upon the card tables in the next room;
+then all struck again, the cornet-a-piston uttered its sonorous note,
+feet marked time, skirts swelled and rustled, hands touched and parted;
+the same eyes falling before you met yours again.
+
+A few men (some fifteen or so), of twenty-five to forty, scattered here
+and there among the dancers or talking at the doorways, distinguished
+themselves from the crowd by a certain air of breeding, whatever their
+differences in age, dress, or face.
+
+Their clothes, better made, seemed of finer cloth, and their hair,
+brought forward in curls towards the temples, glossy with more delicate
+pomades. They had the complexion of wealth--that clear complexion that
+is heightened by the pallor of porcelain, the shimmer of satin, the
+veneer of old furniture, and that an ordered regimen of exquisite
+nurture maintains at its best. Their necks moved easily in their low
+cravats, their long whiskers fell over their turned-down collars, they
+wiped their lips upon handkerchiefs with embroidered initials that gave
+forth a subtle perfume. Those who were beginning to grow old had an air
+of youth, while there was something mature in the faces of the young.
+In their unconcerned looks was the calm of passions daily satiated, and
+through all their gentleness of manner pierced that peculiar brutality,
+the result of a command of half-easy things, in which force is exercised
+and vanity amused--the management of thoroughbred horses and the society
+of loose women.
+
+A few steps from Emma a gentleman in a blue coat was talking of Italy
+with a pale young woman wearing a parure of pearls.
+
+They were praising the breadth of the columns of St. Peter’s, Tivoly,
+Vesuvius, Castellamare, and Cassines, the roses of Genoa, the Coliseum
+by moonlight. With her other ear Emma was listening to a conversation
+full of words she did not understand. A circle gathered round a very
+young man who the week before had beaten “Miss Arabella” and “Romolus,”
+ and won two thousand louis jumping a ditch in England. One complained
+that his racehorses were growing fat; another of the printers’ errors
+that had disfigured the name of his horse.
+
+The atmosphere of the ball was heavy; the lamps were growing dim.
+
+Guests were flocking to the billiard room. A servant got upon a chair
+and broke the window-panes. At the crash of the glass Madame Bovary
+turned her head and saw in the garden the faces of peasants pressed
+against the window looking in at them. Then the memory of the Bertaux
+came back to her. She saw the farm again, the muddy pond, her father in
+a blouse under the apple trees, and she saw herself again as formerly,
+skimming with her finger the cream off the milk-pans in the dairy. But
+in the refulgence of the present hour her past life, so distinct until
+then, faded away completely, and she almost doubted having lived it. She
+was there; beyond the ball was only shadow overspreading all the rest.
+She was just eating a maraschino ice that she held with her left hand
+in a silver-gilt cup, her eyes half-closed, and the spoon between her
+teeth.
+
+A lady near her dropped her fan. A gentlemen was passing.
+
+“Would you be so good,” said the lady, “as to pick up my fan that has
+fallen behind the sofa?”
+
+The gentleman bowed, and as he moved to stretch out his arm, Emma saw
+the hand of a young woman throw something white, folded in a triangle,
+into his hat. The gentleman, picking up the fan, offered it to the lady
+respectfully; she thanked him with an inclination of the head, and began
+smelling her bouquet.
+
+After supper, where were plenty of Spanish and Rhine wines, soups a la
+bisque and au lait d’amandes*, puddings a la Trafalgar, and all sorts of
+cold meats with jellies that trembled in the dishes, the carriages one
+after the other began to drive off. Raising the corners of the muslin
+curtain, one could see the light of their lanterns glimmering through
+the darkness. The seats began to empty, some card-players were still
+left; the musicians were cooling the tips of their fingers on their
+tongues. Charles was half asleep, his back propped against a door.
+
+     *With almond milk
+
+At three o’clock the cotillion began. Emma did not know how to waltz.
+Everyone was waltzing, Mademoiselle d’Andervilliers herself and the
+Marquis; only the guests staying at the castle were still there, about a
+dozen persons.
+
+One of the waltzers, however, who was familiarly called Viscount, and
+whose low cut waistcoat seemed moulded to his chest, came a second time
+to ask Madame Bovary to dance, assuring her that he would guide her, and
+that she would get through it very well.
+
+They began slowly, then went more rapidly. They turned; all around them
+was turning--the lamps, the furniture, the wainscoting, the floor, like
+a disc on a pivot. On passing near the doors the bottom of Emma’s dress
+caught against his trousers.
+
+Their legs commingled; he looked down at her; she raised her eyes to
+his. A torpor seized her; she stopped. They started again, and with a
+more rapid movement; the Viscount, dragging her along disappeared with
+her to the end of the gallery, where panting, she almost fell, and for
+a moment rested her head upon his breast. And then, still turning, but
+more slowly, he guided her back to her seat. She leaned back against the
+wall and covered her eyes with her hands.
+
+When she opened them again, in the middle of the drawing room three
+waltzers were kneeling before a lady sitting on a stool.
+
+She chose the Viscount, and the violin struck up once more.
+
+Everyone looked at them. They passed and re-passed, she with rigid body,
+her chin bent down, and he always in the same pose, his figure curved,
+his elbow rounded, his chin thrown forward. That woman knew how to
+waltz! They kept up a long time, and tired out all the others.
+
+Then they talked a few moments longer, and after the goodnights, or
+rather good mornings, the guests of the chateau retired to bed.
+
+Charles dragged himself up by the balusters. His “knees were going
+up into his body.” He had spent five consecutive hours standing
+bolt upright at the card tables, watching them play whist, without
+understanding anything about it, and it was with a deep sigh of relief
+that he pulled off his boots.
+
+Emma threw a shawl over her shoulders, opened the window, and leant out.
+
+The night was dark; some drops of rain were falling. She breathed in the
+damp wind that refreshed her eyelids. The music of the ball was still
+murmuring in her ears. And she tried to keep herself awake in order to
+prolong the illusion of this luxurious life that she would soon have to
+give up.
+
+Day began to break. She looked long at the windows of the chateau,
+trying to guess which were the rooms of all those she had noticed the
+evening before. She would fain have known their lives, have penetrated,
+blended with them. But she was shivering with cold. She undressed, and
+cowered down between the sheets against Charles, who was asleep.
+
+There were a great many people to luncheon. The repast lasted ten
+minutes; no liqueurs were served, which astonished the doctor.
+
+Next, Mademoiselle d’Andervilliers collected some pieces of roll in a
+small basket to take them to the swans on the ornamental waters, and
+they went to walk in the hot-houses, where strange plants, bristling
+with hairs, rose in pyramids under hanging vases, whence, as from
+over-filled nests of serpents, fell long green cords interlacing.
+The orangery, which was at the other end, led by a covered way to the
+outhouses of the chateau. The Marquis, to amuse the young woman, took
+her to see the stables.
+
+Above the basket-shaped racks porcelain slabs bore the names of the
+horses in black letters. Each animal in its stall whisked its tail when
+anyone went near and said “Tchk! tchk!” The boards of the harness room
+shone like the flooring of a drawing room. The carriage harness was
+piled up in the middle against two twisted columns, and the bits, the
+whips, the spurs, the curbs, were ranged in a line all along the wall.
+
+Charles, meanwhile, went to ask a groom to put his horse to. The
+dog-cart was brought to the foot of the steps, and, all the parcels
+being crammed in, the Bovarys paid their respects to the Marquis and
+Marchioness and set out again for Tostes.
+
+Emma watched the turning wheels in silence. Charles, on the extreme edge
+of the seat, held the reins with his two arms wide apart, and the little
+horse ambled along in the shafts that were too big for him. The loose
+reins hanging over his crupper were wet with foam, and the box fastened
+on behind the chaise gave great regular bumps against it.
+
+They were on the heights of Thibourville when suddenly some horsemen
+with cigars between their lips passed laughing. Emma thought she
+recognized the Viscount, turned back, and caught on the horizon only the
+movement of the heads rising or falling with the unequal cadence of the
+trot or gallop.
+
+A mile farther on they had to stop to mend with some string the traces
+that had broken.
+
+But Charles, giving a last look to the harness, saw something on the
+ground between his horse’s legs, and he picked up a cigar-case with
+a green silk border and beblazoned in the centre like the door of a
+carriage.
+
+“There are even two cigars in it,” said he; “they’ll do for this evening
+after dinner.”
+
+“Why, do you smoke?” she asked.
+
+“Sometimes, when I get a chance.”
+
+He put his find in his pocket and whipped up the nag.
+
+When they reached home the dinner was not ready. Madame lost her temper.
+Nastasie answered rudely.
+
+“Leave the room!” said Emma. “You are forgetting yourself. I give you
+warning.”
+
+For dinner there was onion soup and a piece of veal with sorrel.
+
+Charles, seated opposite Emma, rubbed his hands gleefully.
+
+“How good it is to be at home again!”
+
+Nastasie could be heard crying. He was rather fond of the poor girl.
+She had formerly, during the wearisome time of his widowhood, kept him
+company many an evening. She had been his first patient, his oldest
+acquaintance in the place.
+
+“Have you given her warning for good?” he asked at last.
+
+“Yes. Who is to prevent me?” she replied.
+
+Then they warmed themselves in the kitchen while their room was being
+made ready. Charles began to smoke. He smoked with lips protruding,
+spitting every moment, recoiling at every puff.
+
+“You’ll make yourself ill,” she said scornfully.
+
+He put down his cigar and ran to swallow a glass of cold water at the
+pump. Emma seizing hold of the cigar case threw it quickly to the back
+of the cupboard.
+
+The next day was a long one. She walked about her little garden, up
+and down the same walks, stopping before the beds, before the espalier,
+before the plaster curate, looking with amazement at all these things
+of once-on-a-time that she knew so well. How far off the ball seemed
+already! What was it that thus set so far asunder the morning of the day
+before yesterday and the evening of to-day? Her journey to Vaubyessard
+had made a hole in her life, like one of those great crevices that
+a storm will sometimes make in one night in mountains. Still she was
+resigned. She devoutly put away in her drawers her beautiful dress, down
+to the satin shoes whose soles were yellowed with the slippery wax of
+the dancing floor. Her heart was like these. In its friction against
+wealth something had come over it that could not be effaced.
+
+The memory of this ball, then, became an occupation for Emma.
+
+Whenever the Wednesday came round she said to herself as she awoke, “Ah!
+I was there a week--a fortnight--three weeks ago.”
+
+And little by little the faces grew confused in her remembrance.
+
+She forgot the tune of the quadrilles; she no longer saw the liveries
+and appointments so distinctly; some details escaped her, but the regret
+remained with her.
+
+
+
+Chapter Nine
+
+Often when Charles was out she took from the cupboard, between the
+folds of the linen where she had left it, the green silk cigar case.
+She looked at it, opened it, and even smelt the odour of the lining--a
+mixture of verbena and tobacco. Whose was it? The Viscount’s? Perhaps
+it was a present from his mistress. It had been embroidered on some
+rosewood frame, a pretty little thing, hidden from all eyes, that had
+occupied many hours, and over which had fallen the soft curls of the
+pensive worker. A breath of love had passed over the stitches on the
+canvas; each prick of the needle had fixed there a hope or a memory, and
+all those interwoven threads of silk were but the continuity of the same
+silent passion. And then one morning the Viscount had taken it away
+with him. Of what had they spoken when it lay upon the wide-mantelled
+chimneys between flower-vases and Pompadour clocks? She was at Tostes;
+he was at Paris now, far away! What was this Paris like? What a vague
+name! She repeated it in a low voice, for the mere pleasure of it; it
+rang in her ears like a great cathedral bell; it shone before her eyes,
+even on the labels of her pomade-pots.
+
+At night, when the carriers passed under her windows in their carts
+singing the “Marjolaine,” she awoke, and listened to the noise of the
+iron-bound wheels, which, as they gained the country road, was soon
+deadened by the soil. “They will be there to-morrow!” she said to
+herself.
+
+And she followed them in thought up and down the hills, traversing
+villages, gliding along the highroads by the light of the stars. At the
+end of some indefinite distance there was always a confused spot, into
+which her dream died.
+
+She bought a plan of Paris, and with the tip of her finger on the map
+she walked about the capital. She went up the boulevards, stopping at
+every turning, between the lines of the streets, in front of the white
+squares that represented the houses. At last she would close the lids of
+her weary eyes, and see in the darkness the gas jets flaring in the wind
+and the steps of carriages lowered with much noise before the peristyles
+of theatres.
+
+She took in “La Corbeille,” a lady’s journal, and the “Sylphe des
+Salons.” She devoured, without skipping a word, all the accounts of
+first nights, races, and soirees, took interest in the debut of a
+singer, in the opening of a new shop. She knew the latest fashions, the
+addresses of the best tailors, the days of the Bois and the Opera. In
+Eugene Sue she studied descriptions of furniture; she read Balzac and
+George Sand, seeking in them imaginary satisfaction for her own desires.
+Even at table she had her book by her, and turned over the pages
+while Charles ate and talked to her. The memory of the Viscount always
+returned as she read. Between him and the imaginary personages she made
+comparisons. But the circle of which he was the centre gradually widened
+round him, and the aureole that he bore, fading from his form, broadened
+out beyond, lighting up her other dreams.
+
+Paris, more vague than the ocean, glimmered before Emma’s eyes in an
+atmosphere of vermilion. The many lives that stirred amid this tumult
+were, however, divided into parts, classed as distinct pictures. Emma
+perceived only two or three that hid from her all the rest, and in
+themselves represented all humanity. The world of ambassadors moved over
+polished floors in drawing rooms lined with mirrors, round oval tables
+covered with velvet and gold-fringed cloths. There were dresses with
+trains, deep mysteries, anguish hidden beneath smiles. Then came the
+society of the duchesses; all were pale; all got up at four o’clock; the
+women, poor angels, wore English point on their petticoats; and the men,
+unappreciated geniuses under a frivolous outward seeming, rode horses to
+death at pleasure parties, spent the summer season at Baden, and towards
+the forties married heiresses. In the private rooms of restaurants,
+where one sups after midnight by the light of wax candles, laughed the
+motley crowd of men of letters and actresses. They were prodigal as
+kings, full of ideal, ambitious, fantastic frenzy. This was an existence
+outside that of all others, between heaven and earth, in the midst of
+storms, having something of the sublime. For the rest of the world it
+was lost, with no particular place and as if non-existent. The nearer
+things were, moreover, the more her thoughts turned away from them.
+All her immediate surroundings, the wearisome country, the middle-class
+imbeciles, the mediocrity of existence, seemed to her exceptional, a
+peculiar chance that had caught hold of her, while beyond stretched, as
+far as eye could see, an immense land of joys and passions. She confused
+in her desire the sensualities of luxury with the delights of the heart,
+elegance of manners with delicacy of sentiment. Did not love, like
+Indian plants, need a special soil, a particular temperature? Signs
+by moonlight, long embraces, tears flowing over yielded hands, all
+the fevers of the flesh and the languors of tenderness could not be
+separated from the balconies of great castles full of indolence,
+from boudoirs with silken curtains and thick carpets, well-filled
+flower-stands, a bed on a raised dias, nor from the flashing of precious
+stones and the shoulder-knots of liveries.
+
+The lad from the posting house who came to groom the mare every morning
+passed through the passage with his heavy wooden shoes; there were holes
+in his blouse; his feet were bare in list slippers. And this was the
+groom in knee-britches with whom she had to be content! His work done,
+he did not come back again all day, for Charles on his return put up
+his horse himself, unsaddled him and put on the halter, while the
+servant-girl brought a bundle of straw and threw it as best she could
+into the manger.
+
+To replace Nastasie (who left Tostes shedding torrents of tears) Emma
+took into her service a young girl of fourteen, an orphan with a sweet
+face. She forbade her wearing cotton caps, taught her to address her in
+the third person, to bring a glass of water on a plate, to knock before
+coming into a room, to iron, starch, and to dress her--wanted to make a
+lady’s-maid of her. The new servant obeyed without a murmur, so as not
+to be sent away; and as madame usually left the key in the sideboard,
+Felicite every evening took a small supply of sugar that she ate alone
+in her bed after she had said her prayers.
+
+Sometimes in the afternoon she went to chat with the postilions.
+
+Madame was in her room upstairs. She wore an open dressing gown that
+showed between the shawl facings of her bodice a pleated chamisette with
+three gold buttons. Her belt was a corded girdle with great tassels, and
+her small garnet coloured slippers had a large knot of ribbon that fell
+over her instep. She had bought herself a blotting book, writing case,
+pen-holder, and envelopes, although she had no one to write to; she
+dusted her what-not, looked at herself in the glass, picked up a book,
+and then, dreaming between the lines, let it drop on her knees. She
+longed to travel or to go back to her convent. She wished at the same
+time to die and to live in Paris.
+
+Charles in snow and rain trotted across country. He ate omelettes on
+farmhouse tables, poked his arm into damp beds, received the tepid
+spurt of blood-lettings in his face, listened to death-rattles, examined
+basins, turned over a good deal of dirty linen; but every evening he
+found a blazing fire, his dinner ready, easy-chairs, and a well-dressed
+woman, charming with an odour of freshness, though no one could say
+whence the perfume came, or if it were not her skin that made odorous
+her chemise.
+
+She charmed him by numerous attentions; now it was some new way of
+arranging paper sconces for the candles, a flounce that she altered on
+her gown, or an extraordinary name for some very simple dish that the
+servant had spoilt, but that Charles swallowed with pleasure to the last
+mouthful. At Rouen she saw some ladies who wore a bunch of charms on the
+watch-chains; she bought some charms. She wanted for her mantelpiece two
+large blue glass vases, and some time after an ivory necessaire with a
+silver-gilt thimble. The less Charles understood these refinements
+the more they seduced him. They added something to the pleasure of the
+senses and to the comfort of his fireside. It was like a golden dust
+sanding all along the narrow path of his life.
+
+He was well, looked well; his reputation was firmly established.
+
+The country-folk loved him because he was not proud. He petted the
+children, never went to the public house, and, moreover, his morals
+inspired confidence. He was specially successful with catarrhs and chest
+complaints. Being much afraid of killing his patients, Charles, in fact
+only prescribed sedatives, from time to time and emetic, a footbath,
+or leeches. It was not that he was afraid of surgery; he bled people
+copiously like horses, and for the taking out of teeth he had the
+“devil’s own wrist.”
+
+Finally, to keep up with the times, he took in “La Ruche Medicale,”
+ a new journal whose prospectus had been sent him. He read it a little
+after dinner, but in about five minutes the warmth of the room added to
+the effect of his dinner sent him to sleep; and he sat there, his chin
+on his two hands and his hair spreading like a mane to the foot of the
+lamp. Emma looked at him and shrugged her shoulders. Why, at least, was
+not her husband one of those men of taciturn passions who work at their
+books all night, and at last, when about sixty, the age of rheumatism
+sets in, wear a string of orders on their ill-fitting black coat?
+She could have wished this name of Bovary, which was hers, had been
+illustrious, to see it displayed at the booksellers’, repeated in the
+newspapers, known to all France. But Charles had no ambition.
+
+An Yvetot doctor whom he had lately met in consultation had somewhat
+humiliated him at the very bedside of the patient, before the assembled
+relatives. When, in the evening, Charles told her this anecdote, Emma
+inveighed loudly against his colleague. Charles was much touched. He
+kissed her forehead with a tear in his eyes. But she was angered with
+shame; she felt a wild desire to strike him; she went to open the window
+in the passage and breathed in the fresh air to calm herself.
+
+“What a man! What a man!” she said in a low voice, biting her lips.
+
+Besides, she was becoming more irritated with him. As he grew older his
+manner grew heavier; at dessert he cut the corks of the empty bottles;
+after eating he cleaned his teeth with his tongue; in taking soup
+he made a gurgling noise with every spoonful; and, as he was getting
+fatter, the puffed-out cheeks seemed to push the eyes, always small, up
+to the temples.
+
+Sometimes Emma tucked the red borders of his under-vest unto his
+waistcoat, rearranged his cravat, and threw away the dirty gloves he was
+going to put on; and this was not, as he fancied, for himself; it
+was for herself, by a diffusion of egotism, of nervous irritation.
+Sometimes, too, she told him of what she had read, such as a passage in
+a novel, of a new play, or an anecdote of the “upper ten” that she
+had seen in a feuilleton; for, after all, Charles was something, an
+ever-open ear, and ever-ready approbation. She confided many a thing to
+her greyhound. She would have done so to the logs in the fireplace or to
+the pendulum of the clock.
+
+At the bottom of her heart, however, she was waiting for something to
+happen. Like shipwrecked sailors, she turned despairing eyes upon the
+solitude of her life, seeking afar off some white sail in the mists of
+the horizon. She did not know what this chance would be, what wind would
+bring it her, towards what shore it would drive her, if it would be a
+shallop or a three-decker, laden with anguish or full of bliss to the
+portholes. But each morning, as she awoke, she hoped it would come that
+day; she listened to every sound, sprang up with a start, wondered that
+it did not come; then at sunset, always more saddened, she longed for
+the morrow.
+
+Spring came round. With the first warm weather, when the pear trees
+began to blossom, she suffered from dyspnoea.
+
+From the beginning of July she counted how many weeks there were to
+October, thinking that perhaps the Marquis d’Andervilliers would give
+another ball at Vaubyessard. But all September passed without letters or
+visits.
+
+After the ennui of this disappointment her heart once more remained
+empty, and then the same series of days recommenced. So now they would
+thus follow one another, always the same, immovable, and bringing
+nothing. Other lives, however flat, had at least the chance of some
+event. One adventure sometimes brought with it infinite consequences and
+the scene changed. But nothing happened to her; God had willed it so!
+The future was a dark corridor, with its door at the end shut fast.
+
+She gave up music. What was the good of playing? Who would hear her?
+Since she could never, in a velvet gown with short sleeves, striking
+with her light fingers the ivory keys of an Erard at a concert, feel
+the murmur of ecstasy envelop her like a breeze, it was not worth while
+boring herself with practicing. Her drawing cardboard and her embroidery
+she left in the cupboard. What was the good? What was the good? Sewing
+irritated her. “I have read everything,” she said to herself. And she
+sat there making the tongs red-hot, or looked at the rain falling.
+
+How sad she was on Sundays when vespers sounded! She listened with dull
+attention to each stroke of the cracked bell. A cat slowly walking over
+some roof put up his back in the pale rays of the sun. The wind on the
+highroad blew up clouds of dust. Afar off a dog sometimes howled; and
+the bell, keeping time, continued its monotonous ringing that died away
+over the fields.
+
+But the people came out from church. The women in waxed clogs, the
+peasants in new blouses, the little bare-headed children skipping along
+in front of them, all were going home. And till nightfall, five or six
+men, always the same, stayed playing at corks in front of the large door
+of the inn.
+
+The winter was severe. The windows every morning were covered with
+rime, and the light shining through them, dim as through ground-glass,
+sometimes did not change the whole day long. At four o’clock the lamp
+had to be lighted.
+
+On fine days she went down into the garden. The dew had left on the
+cabbages a silver lace with long transparent threads spreading from one
+to the other. No birds were to be heard; everything seemed asleep, the
+espalier covered with straw, and the vine, like a great sick serpent
+under the coping of the wall, along which, on drawing near, one saw the
+many-footed woodlice crawling. Under the spruce by the hedgerow, the
+curie in the three-cornered hat reading his breviary had lost his right
+foot, and the very plaster, scaling off with the frost, had left white
+scabs on his face.
+
+Then she went up again, shut her door, put on coals, and fainting with
+the heat of the hearth, felt her boredom weigh more heavily than ever.
+She would have liked to go down and talk to the servant, but a sense of
+shame restrained her.
+
+Every day at the same time the schoolmaster in a black skullcap opened
+the shutters of his house, and the rural policeman, wearing his sabre
+over his blouse, passed by. Night and morning the post-horses, three by
+three, crossed the street to water at the pond. From time to time the
+bell of a public house door rang, and when it was windy one could hear
+the little brass basins that served as signs for the hairdresser’s shop
+creaking on their two rods. This shop had as decoration an old engraving
+of a fashion-plate stuck against a windowpane and the wax bust of a
+woman with yellow hair. He, too, the hairdresser, lamented his wasted
+calling, his hopeless future, and dreaming of some shop in a big
+town--at Rouen, for example, overlooking the harbour, near the
+theatre--he walked up and down all day from the mairie to the church,
+sombre and waiting for customers. When Madame Bovary looked up, she
+always saw him there, like a sentinel on duty, with his skullcap over
+his ears and his vest of lasting.
+
+Sometimes in the afternoon outside the window of her room, the head of a
+man appeared, a swarthy head with black whiskers, smiling slowly, with
+a broad, gentle smile that showed his white teeth. A waltz immediately
+began and on the organ, in a little drawing room, dancers the size of
+a finger, women in pink turbans, Tyrolians in jackets, monkeys in frock
+coats, gentlemen in knee-breeches, turned and turned between the sofas,
+the consoles, multiplied in the bits of looking glass held together
+at their corners by a piece of gold paper. The man turned his handle,
+looking to the right and left, and up at the windows. Now and again,
+while he shot out a long squirt of brown saliva against the milestone,
+with his knee raised his instrument, whose hard straps tired his
+shoulder; and now, doleful and drawling, or gay and hurried, the music
+escaped from the box, droning through a curtain of pink taffeta under
+a brass claw in arabesque. They were airs played in other places at
+the theatres, sung in drawing rooms, danced to at night under lighted
+lustres, echoes of the world that reached even to Emma. Endless
+sarabands ran through her head, and, like an Indian dancing girl on the
+flowers of a carpet, her thoughts leapt with the notes, swung from dream
+to dream, from sadness to sadness. When the man had caught some coppers
+in his cap, he drew down an old cover of blue cloth, hitched his organ
+on to his back, and went off with a heavy tread. She watched him going.
+
+But it was above all the meal-times that were unbearable to her, in this
+small room on the ground floor, with its smoking stove, its creaking
+door, the walls that sweated, the damp flags; all the bitterness in life
+seemed served up on her plate, and with smoke of the boiled beef there
+rose from her secret soul whiffs of sickliness. Charles was a slow
+eater; she played with a few nuts, or, leaning on her elbow, amused
+herself with drawing lines along the oilcloth table cover with the point
+of her knife.
+
+She now let everything in her household take care of itself, and Madame
+Bovary senior, when she came to spend part of Lent at Tostes, was much
+surprised at the change. She who was formerly so careful, so dainty,
+now passed whole days without dressing, wore grey cotton stockings, and
+burnt tallow candles. She kept saying they must be economical since
+they were not rich, adding that she was very contented, very happy, that
+Tostes pleased her very much, with other speeches that closed the mouth
+of her mother-in-law. Besides, Emma no longer seemed inclined to follow
+her advice; once even, Madame Bovary having thought fit to maintain that
+mistresses ought to keep an eye on the religion of their servants, she
+had answered with so angry a look and so cold a smile that the good
+woman did not interfere again.
+
+Emma was growing difficult, capricious. She ordered dishes for herself,
+then she did not touch them; one day drank only pure milk, the next
+cups of tea by the dozen. Often she persisted in not going out, then,
+stifling, threw open the windows and put on light dresses. After she had
+well scolded her servant she gave her presents or sent her out to see
+neighbours, just as she sometimes threw beggars all the silver in her
+purse, although she was by no means tender-hearted or easily accessible
+to the feelings of others, like most country-bred people, who always
+retain in their souls something of the horny hardness of the paternal
+hands.
+
+Towards the end of February old Rouault, in memory of his cure, himself
+brought his son-in-law a superb turkey, and stayed three days at Tostes.
+Charles being with his patients, Emma kept him company. He smoked in the
+room, spat on the firedogs, talked farming, calves, cows, poultry, and
+municipal council, so that when he left she closed the door on him with
+a feeling of satisfaction that surprised even herself. Moreover she no
+longer concealed her contempt for anything or anybody, and at times she
+set herself to express singular opinions, finding fault with that which
+others approved, and approving things perverse and immoral, all of which
+made her husband open his eyes widely.
+
+Would this misery last for ever? Would she never issue from it? Yet
+she was as good as all the women who were living happily. She had seen
+duchesses at Vaubyessard with clumsier waists and commoner ways, and she
+execrated the injustice of God. She leant her head against the walls
+to weep; she envied lives of stir; longed for masked balls, for violent
+pleasures, with all the wildness that she did not know, but that these
+must surely yield.
+
+She grew pale and suffered from palpitations of the heart.
+
+Charles prescribed valerian and camphor baths. Everything that was tried
+only seemed to irritate her the more.
+
+On certain days she chatted with feverish rapidity, and this
+over-excitement was suddenly followed by a state of torpor, in which
+she remained without speaking, without moving. What then revived her was
+pouring a bottle of eau-de-cologne over her arms.
+
+As she was constantly complaining about Tostes, Charles fancied that her
+illness was no doubt due to some local cause, and fixing on this idea,
+began to think seriously of setting up elsewhere.
+
+From that moment she drank vinegar, contracted a sharp little cough, and
+completely lost her appetite.
+
+It cost Charles much to give up Tostes after living there four years and
+“when he was beginning to get on there.” Yet if it must be! He took her
+to Rouen to see his old master. It was a nervous complaint: change of
+air was needed.
+
+After looking about him on this side and on that, Charles learnt that
+in the Neufchatel arrondissement there was a considerable market town
+called Yonville-l’Abbaye, whose doctor, a Polish refugee, had decamped a
+week before. Then he wrote to the chemist of the place to ask the
+number of the population, the distance from the nearest doctor, what
+his predecessor had made a year, and so forth; and the answer being
+satisfactory, he made up his mind to move towards the spring, if Emma’s
+health did not improve.
+
+One day when, in view of her departure, she was tidying a drawer,
+something pricked her finger. It was a wire of her wedding bouquet.
+The orange blossoms were yellow with dust and the silver bordered satin
+ribbons frayed at the edges. She threw it into the fire. It flared
+up more quickly than dry straw. Then it was, like a red bush in the
+cinders, slowly devoured. She watched it burn.
+
+The little pasteboard berries burst, the wire twisted, the gold
+lace melted; and the shriveled paper corollas, fluttering like black
+butterflies at the back of the stove, at last flew up the chimney.
+
+When they left Tostes at the month of March, Madame Bovary was pregnant.
+
+
+
+
+
+Part II
+
+
+
+Chapter One
+
+Yonville-l’Abbaye (so called from an old Capuchin abbey of which not
+even the ruins remain) is a market-town twenty-four miles from Rouen,
+between the Abbeville and Beauvais roads, at the foot of a valley
+watered by the Rieule, a little river that runs into the Andelle after
+turning three water-mills near its mouth, where there are a few trout
+that the lads amuse themselves by fishing for on Sundays.
+
+We leave the highroad at La Boissiere and keep straight on to the top of
+the Leux hill, whence the valley is seen. The river that runs through it
+makes of it, as it were, two regions with distinct physiognomies--all on
+the left is pasture land, all of the right arable. The meadow stretches
+under a bulge of low hills to join at the back with the pasture land of
+the Bray country, while on the eastern side, the plain, gently rising,
+broadens out, showing as far as eye can follow its blond cornfields. The
+water, flowing by the grass, divides with a white line the colour of the
+roads and of the plains, and the country is like a great unfolded mantle
+with a green velvet cape bordered with a fringe of silver.
+
+Before us, on the verge of the horizon, lie the oaks of the forest of
+Argueil, with the steeps of the Saint-Jean hills scarred from top
+to bottom with red irregular lines; they are rain tracks, and these
+brick-tones standing out in narrow streaks against the grey colour of
+the mountain are due to the quantity of iron springs that flow beyond in
+the neighboring country.
+
+Here we are on the confines of Normandy, Picardy, and the Ile-de-France,
+a bastard land whose language is without accent and its landscape is
+without character. It is there that they make the worst Neufchatel
+cheeses of all the arrondissement; and, on the other hand, farming is
+costly because so much manure is needed to enrich this friable soil full
+of sand and flints.
+
+Up to 1835 there was no practicable road for getting to Yonville, but
+about this time a cross-road was made which joins that of Abbeville to
+that of Amiens, and is occasionally used by the Rouen wagoners on their
+way to Flanders. Yonville-l’Abbaye has remained stationary in spite of
+its “new outlet.” Instead of improving the soil, they persist in keeping
+up the pasture lands, however depreciated they may be in value, and
+the lazy borough, growing away from the plain, has naturally spread
+riverwards. It is seem from afar sprawling along the banks like a
+cowherd taking a siesta by the water-side.
+
+At the foot of the hill beyond the bridge begins a roadway, planted with
+young aspens, that leads in a straight line to the first houses in the
+place. These, fenced in by hedges, are in the middle of courtyards
+full of straggling buildings, wine-presses, cart-sheds and distilleries
+scattered under thick trees, with ladders, poles, or scythes hung on to
+the branches. The thatched roofs, like fur caps drawn over eyes, reach
+down over about a third of the low windows, whose coarse convex glasses
+have knots in the middle like the bottoms of bottles. Against the
+plaster wall diagonally crossed by black joists, a meagre pear-tree
+sometimes leans and the ground-floors have at their door a small
+swing-gate to keep out the chicks that come pilfering crumbs of bread
+steeped in cider on the threshold. But the courtyards grow narrower,
+the houses closer together, and the fences disappear; a bundle of
+ferns swings under a window from the end of a broomstick; there is a
+blacksmith’s forge and then a wheelwright’s, with two or three new carts
+outside that partly block the way. Then across an open space appears a
+white house beyond a grass mound ornamented by a Cupid, his finger
+on his lips; two brass vases are at each end of a flight of steps;
+scutcheons* blaze upon the door. It is the notary’s house, and the
+finest in the place.
+
+     *The panonceaux that have to be hung over the doors of
+     notaries.
+
+The Church is on the other side of the street, twenty paces farther
+down, at the entrance of the square. The little cemetery that surrounds
+it, closed in by a wall breast high, is so full of graves that the old
+stones, level with the ground, form a continuous pavement, on which the
+grass of itself has marked out regular green squares. The church was
+rebuilt during the last years of the reign of Charles X. The wooden roof
+is beginning to rot from the top, and here and there has black hollows
+in its blue colour. Over the door, where the organ should be, is a
+loft for the men, with a spiral staircase that reverberates under their
+wooden shoes.
+
+The daylight coming through the plain glass windows falls obliquely upon
+the pews ranged along the walls, which are adorned here and there with
+a straw mat bearing beneath it the words in large letters, “Mr.
+So-and-so’s pew.” Farther on, at a spot where the building narrows, the
+confessional forms a pendant to a statuette of the Virgin, clothed in
+a satin robe, coifed with a tulle veil sprinkled with silver stars, and
+with red cheeks, like an idol of the Sandwich Islands; and, finally, a
+copy of the “Holy Family, presented by the Minister of the Interior,”
+ overlooking the high altar, between four candlesticks, closes in the
+perspective. The choir stalls, of deal wood, have been left unpainted.
+
+The market, that is to say, a tiled roof supported by some twenty posts,
+occupies of itself about half the public square of Yonville. The town
+hall, constructed “from the designs of a Paris architect,” is a sort of
+Greek temple that forms the corner next to the chemist’s shop. On
+the ground-floor are three Ionic columns and on the first floor a
+semicircular gallery, while the dome that crowns it is occupied by a
+Gallic cock, resting one foot upon the “Charte” and holding in the other
+the scales of Justice.
+
+But that which most attracts the eye is opposite the Lion d’Or inn, the
+chemist’s shop of Monsieur Homais. In the evening especially its argand
+lamp is lit up and the red and green jars that embellish his shop-front
+throw far across the street their two streams of colour; then across
+them as if in Bengal lights is seen the shadow of the chemist
+leaning over his desk. His house from top to bottom is placarded with
+inscriptions written in large hand, round hand, printed hand: “Vichy,
+Seltzer, Barege waters, blood purifiers, Raspail patent medicine,
+Arabian racahout, Darcet lozenges, Regnault paste, trusses, baths,
+hygienic chocolate,” etc. And the signboard, which takes up all the
+breadth of the shop, bears in gold letters, “Homais, Chemist.” Then at
+the back of the shop, behind the great scales fixed to the counter, the
+word “Laboratory” appears on a scroll above a glass door, which about
+half-way up once more repeats “Homais” in gold letters on a black
+ground.
+
+Beyond this there is nothing to see at Yonville. The street (the only
+one) a gunshot in length and flanked by a few shops on either side stops
+short at the turn of the highroad. If it is left on the right hand and
+the foot of the Saint-Jean hills followed the cemetery is soon reached.
+
+At the time of the cholera, in order to enlarge this, a piece of wall
+was pulled down, and three acres of land by its side purchased; but all
+the new portion is almost tenantless; the tombs, as heretofore,
+continue to crowd together towards the gate. The keeper, who is at once
+gravedigger and church beadle (thus making a double profit out of the
+parish corpses), has taken advantage of the unused plot of ground to
+plant potatoes there. From year to year, however, his small field grows
+smaller, and when there is an epidemic, he does not know whether to
+rejoice at the deaths or regret the burials.
+
+“You live on the dead, Lestiboudois!” the curie at last said to him one
+day. This grim remark made him reflect; it checked him for some time;
+but to this day he carries on the cultivation of his little tubers, and
+even maintains stoutly that they grow naturally.
+
+Since the events about to be narrated, nothing in fact has changed
+at Yonville. The tin tricolour flag still swings at the top of the
+church-steeple; the two chintz streamers still flutter in the wind from
+the linen-draper’s; the chemist’s fetuses, like lumps of white amadou,
+rot more and more in their turbid alcohol, and above the big door of
+the inn the old golden lion, faded by rain, still shows passers-by its
+poodle mane.
+
+On the evening when the Bovarys were to arrive at Yonville, Widow
+Lefrancois, the landlady of this inn, was so very busy that she sweated
+great drops as she moved her saucepans. To-morrow was market-day. The
+meat had to be cut beforehand, the fowls drawn, the soup and coffee
+made. Moreover, she had the boarders’ meal to see to, and that of the
+doctor, his wife, and their servant; the billiard-room was echoing with
+bursts of laughter; three millers in a small parlour were calling for
+brandy; the wood was blazing, the brazen pan was hissing, and on the
+long kitchen table, amid the quarters of raw mutton, rose piles of
+plates that rattled with the shaking of the block on which spinach was
+being chopped.
+
+From the poultry-yard was heard the screaming of the fowls whom the
+servant was chasing in order to wring their necks.
+
+A man slightly marked with small-pox, in green leather slippers, and
+wearing a velvet cap with a gold tassel, was warming his back at the
+chimney. His face expressed nothing but self-satisfaction, and he
+appeared to take life as calmly as the goldfinch suspended over his head
+in its wicker cage: this was the chemist.
+
+“Artemise!” shouted the landlady, “chop some wood, fill the water
+bottles, bring some brandy, look sharp! If only I knew what dessert to
+offer the guests you are expecting! Good heavens! Those furniture-movers
+are beginning their racket in the billiard-room again; and their van has
+been left before the front door! The ‘Hirondelle’ might run into it when
+it draws up. Call Polyte and tell him to put it up. Only think, Monsieur
+Homais, that since morning they have had about fifteen games, and drunk
+eight jars of cider! Why, they’ll tear my cloth for me,” she went on,
+looking at them from a distance, her strainer in her hand.
+
+“That wouldn’t be much of a loss,” replied Monsieur Homais. “You would
+buy another.”
+
+“Another billiard-table!” exclaimed the widow.
+
+“Since that one is coming to pieces, Madame Lefrancois. I tell you again
+you are doing yourself harm, much harm! And besides, players now want
+narrow pockets and heavy cues. Hazards aren’t played now; everything is
+changed! One must keep pace with the times! Just look at Tellier!”
+
+The hostess reddened with vexation. The chemist went on--
+
+“You may say what you like; his table is better than yours; and if one
+were to think, for example, of getting up a patriotic pool for Poland or
+the sufferers from the Lyons floods--”
+
+“It isn’t beggars like him that’ll frighten us,” interrupted the
+landlady, shrugging her fat shoulders. “Come, come, Monsieur Homais; as
+long as the ‘Lion d’Or’ exists people will come to it. We’ve feathered
+our nest; while one of these days you’ll find the ‘Cafe Francais’ closed
+with a big placard on the shutters. Change my billiard-table!” she went
+on, speaking to herself, “the table that comes in so handy for folding
+the washing, and on which, in the hunting season, I have slept six
+visitors! But that dawdler, Hivert, doesn’t come!”
+
+“Are you waiting for him for your gentlemen’s dinner?”
+
+“Wait for him! And what about Monsieur Binet? As the clock strikes
+six you’ll see him come in, for he hasn’t his equal under the sun for
+punctuality. He must always have his seat in the small parlour. He’d
+rather die than dine anywhere else. And so squeamish as he is, and so
+particular about the cider! Not like Monsieur Leon; he sometimes comes
+at seven, or even half-past, and he doesn’t so much as look at what he
+eats. Such a nice young man! Never speaks a rough word!”
+
+“Well, you see, there’s a great difference between an educated man and
+an old carabineer who is now a tax-collector.”
+
+Six o’clock struck. Binet came in.
+
+He wore a blue frock-coat falling in a straight line round his thin
+body, and his leather cap, with its lappets knotted over the top of
+his head with string, showed under the turned-up peak a bald forehead,
+flattened by the constant wearing of a helmet. He wore a black cloth
+waistcoat, a hair collar, grey trousers, and, all the year round,
+well-blacked boots, that had two parallel swellings due to the sticking
+out of his big-toes. Not a hair stood out from the regular line of fair
+whiskers, which, encircling his jaws, framed, after the fashion of a
+garden border, his long, wan face, whose eyes were small and the nose
+hooked. Clever at all games of cards, a good hunter, and writing a
+fine hand, he had at home a lathe, and amused himself by turning napkin
+rings, with which he filled up his house, with the jealousy of an artist
+and the egotism of a bourgeois.
+
+He went to the small parlour, but the three millers had to be got out
+first, and during the whole time necessary for laying the cloth, Binet
+remained silent in his place near the stove. Then he shut the door and
+took off his cap in his usual way.
+
+“It isn’t with saying civil things that he’ll wear out his tongue,” said
+the chemist, as soon as he was along with the landlady.
+
+“He never talks more,” she replied. “Last week two travelers in the
+cloth line were here--such clever chaps who told such jokes in the
+evening, that I fairly cried with laughing; and he stood there like a
+dab fish and never said a word.”
+
+“Yes,” observed the chemist; “no imagination, no sallies, nothing that
+makes the society-man.”
+
+“Yet they say he has parts,” objected the landlady.
+
+“Parts!” replied Monsieur Homais; “he, parts! In his own line it is
+possible,” he added in a calmer tone. And he went on--
+
+“Ah! That a merchant, who has large connections, a jurisconsult, a
+doctor, a chemist, should be thus absent-minded, that they should become
+whimsical or even peevish, I can understand; such cases are cited in
+history. But at least it is because they are thinking of something.
+Myself, for example, how often has it happened to me to look on the
+bureau for my pen to write a label, and to find, after all, that I had
+put it behind my ear!”
+
+Madame Lefrancois just then went to the door to see if the “Hirondelle”
+ were not coming. She started. A man dressed in black suddenly came into
+the kitchen. By the last gleam of the twilight one could see that his
+face was rubicund and his form athletic.
+
+“What can I do for you, Monsieur le Curie?” asked the landlady, as she
+reached down from the chimney one of the copper candlesticks placed
+with their candles in a row. “Will you take something? A thimbleful of
+Cassis*? A glass of wine?”
+
+     *Black currant liqueur.
+
+The priest declined very politely. He had come for his umbrella, that
+he had forgotten the other day at the Ernemont convent, and after
+asking Madame Lefrancois to have it sent to him at the presbytery in the
+evening, he left for the church, from which the Angelus was ringing.
+
+When the chemist no longer heard the noise of his boots along the
+square, he thought the priest’s behaviour just now very unbecoming. This
+refusal to take any refreshment seemed to him the most odious hypocrisy;
+all priests tippled on the sly, and were trying to bring back the days
+of the tithe.
+
+The landlady took up the defence of her curie.
+
+“Besides, he could double up four men like you over his knee. Last year
+he helped our people to bring in the straw; he carried as many as six
+trusses at once, he is so strong.”
+
+“Bravo!” said the chemist. “Now just send your daughters to confess to
+fellows which such a temperament! I, if I were the Government, I’d have
+the priests bled once a month. Yes, Madame Lefrancois, every month--a
+good phlebotomy, in the interests of the police and morals.”
+
+“Be quiet, Monsieur Homais. You are an infidel; you’ve no religion.”
+
+The chemist answered: “I have a religion, my religion, and I even have
+more than all these others with their mummeries and their juggling.
+I adore God, on the contrary. I believe in the Supreme Being, in a
+Creator, whatever he may be. I care little who has placed us here below
+to fulfil our duties as citizens and fathers of families; but I don’t
+need to go to church to kiss silver plates, and fatten, out of my
+pocket, a lot of good-for-nothings who live better than we do. For one
+can know Him as well in a wood, in a field, or even contemplating the
+eternal vault like the ancients. My God! Mine is the God of Socrates, of
+Franklin, of Voltaire, and of Beranger! I am for the profession of faith
+of the ‘Savoyard Vicar,’ and the immortal principles of ‘89! And I can’t
+admit of an old boy of a God who takes walks in his garden with a
+cane in his hand, who lodges his friends in the belly of whales, dies
+uttering a cry, and rises again at the end of three days; things absurd
+in themselves, and completely opposed, moreover, to all physical laws,
+which prove to us, by the way, that priests have always wallowed in
+turpid ignorance, in which they would fain engulf the people with them.”
+
+He ceased, looking round for an audience, for in his bubbling over
+the chemist had for a moment fancied himself in the midst of the town
+council. But the landlady no longer heeded him; she was listening to a
+distant rolling. One could distinguish the noise of a carriage mingled
+with the clattering of loose horseshoes that beat against the ground,
+and at last the “Hirondelle” stopped at the door.
+
+It was a yellow box on two large wheels, that, reaching to the tilt,
+prevented travelers from seeing the road and dirtied their shoulders.
+The small panes of the narrow windows rattled in their sashes when the
+coach was closed, and retained here and there patches of mud amid the
+old layers of dust, that not even storms of rain had altogether washed
+away. It was drawn by three horses, the first a leader, and when it came
+down-hill its bottom jolted against the ground.
+
+Some of the inhabitants of Yonville came out into the square; they all
+spoke at once, asking for news, for explanations, for hampers. Hivert
+did not know whom to answer. It was he who did the errands of the place
+in town. He went to the shops and brought back rolls of leather for
+the shoemaker, old iron for the farrier, a barrel of herrings for his
+mistress, caps from the milliner’s, locks from the hair-dresser’s and
+all along the road on his return journey he distributed his parcels,
+which he threw, standing upright on his seat and shouting at the top of
+his voice, over the enclosures of the yards.
+
+An accident had delayed him. Madame Bovary’s greyhound had run across
+the field. They had whistled for him a quarter of an hour; Hivert had
+even gone back a mile and a half expecting every moment to catch sight
+of her; but it had been necessary to go on.
+
+Emma had wept, grown angry; she had accused Charles of this misfortune.
+Monsieur Lheureux, a draper, who happened to be in the coach with
+her, had tried to console her by a number of examples of lost dogs
+recognizing their masters at the end of long years. One, he said had
+been told of, who had come back to Paris from Constantinople. Another
+had gone one hundred and fifty miles in a straight line, and swum four
+rivers; and his own father had possessed a poodle, which, after twelve
+years of absence, had all of a sudden jumped on his back in the street
+as he was going to dine in town.
+
+
+
+Chapter Two
+
+Emma got out first, then Felicite, Monsieur Lheureux, and a nurse, and
+they had to wake up Charles in his corner, where he had slept soundly
+since night set in.
+
+Homais introduced himself; he offered his homages to madame and his
+respects to monsieur; said he was charmed to have been able to render
+them some slight service, and added with a cordial air that he had
+ventured to invite himself, his wife being away.
+
+When Madame Bovary was in the kitchen she went up to the chimney.
+
+With the tips of her fingers she caught her dress at the knee, and
+having thus pulled it up to her ankle, held out her foot in its black
+boot to the fire above the revolving leg of mutton. The flame lit up the
+whole of her, penetrating with a crude light the woof of her gowns, the
+fine pores of her fair skin, and even her eyelids, which she blinked now
+and again. A great red glow passed over her with the blowing of the wind
+through the half-open door.
+
+On the other side of the chimney a young man with fair hair watched her
+silently.
+
+As he was a good deal bored at Yonville, where he was a clerk at the
+notary’s, Monsieur Guillaumin, Monsieur Leon Dupuis (it was he who
+was the second habitue of the “Lion d’Or”) frequently put back his
+dinner-hour in hope that some traveler might come to the inn, with whom
+he could chat in the evening. On the days when his work was done early,
+he had, for want of something else to do, to come punctually, and endure
+from soup to cheese a tete-a-tete with Binet. It was therefore with
+delight that he accepted the landlady’s suggestion that he should dine
+in company with the newcomers, and they passed into the large parlour
+where Madame Lefrancois, for the purpose of showing off, had had the
+table laid for four.
+
+Homais asked to be allowed to keep on his skull-cap, for fear of coryza;
+then, turning to his neighbour--
+
+“Madame is no doubt a little fatigued; one gets jolted so abominably in
+our ‘Hirondelle.’”
+
+“That is true,” replied Emma; “but moving about always amuses me. I like
+change of place.”
+
+“It is so tedious,” sighed the clerk, “to be always riveted to the same
+places.”
+
+“If you were like me,” said Charles, “constantly obliged to be in the
+saddle”--
+
+“But,” Leon went on, addressing himself to Madame Bovary, “nothing, it
+seems to me, is more pleasant--when one can,” he added.
+
+“Moreover,” said the druggist, “the practice of medicine is not very
+hard work in our part of the world, for the state of our roads allows us
+the use of gigs, and generally, as the farmers are prosperous, they pay
+pretty well. We have, medically speaking, besides the ordinary cases
+of enteritis, bronchitis, bilious affections, etc., now and then a
+few intermittent fevers at harvest-time; but on the whole, little of a
+serious nature, nothing special to note, unless it be a great deal of
+scrofula, due, no doubt, to the deplorable hygienic conditions of our
+peasant dwellings. Ah! you will find many prejudices to combat, Monsieur
+Bovary, much obstinacy of routine, with which all the efforts of your
+science will daily come into collision; for people still have recourse
+to novenas, to relics, to the priest, rather than come straight to the
+doctor or the chemist. The climate, however, is not, truth to tell, bad,
+and we even have a few nonagenarians in our parish. The thermometer (I
+have made some observations) falls in winter to 4 degrees Centigrade
+at the outside, which gives us 24 degrees Reaumur as the maximum, or
+otherwise 54 degrees Fahrenheit (English scale), not more. And, as a
+matter of fact, we are sheltered from the north winds by the forest of
+Argueil on the one side, from the west winds by the St. Jean range on
+the other; and this heat, moreover, which, on account of the aqueous
+vapours given off by the river and the considerable number of cattle
+in the fields, which, as you know, exhale much ammonia, that is to say,
+nitrogen, hydrogen and oxygen (no, nitrogen and hydrogen alone), and
+which sucking up into itself the humus from the ground, mixing together
+all those different emanations, unites them into a stack, so to say,
+and combining with the electricity diffused through the atmosphere, when
+there is any, might in the long run, as in tropical countries, engender
+insalubrious miasmata--this heat, I say, finds itself perfectly tempered
+on the side whence it comes, or rather whence it should come--that is to
+say, the southern side--by the south-eastern winds, which, having cooled
+themselves passing over the Seine, reach us sometimes all at once like
+breezes from Russia.”
+
+“At any rate, you have some walks in the neighbourhood?” continued
+Madame Bovary, speaking to the young man.
+
+“Oh, very few,” he answered. “There is a place they call La Pature, on
+the top of the hill, on the edge of the forest. Sometimes, on Sundays, I
+go and stay there with a book, watching the sunset.”
+
+“I think there is nothing so admirable as sunsets,” she resumed; “but
+especially by the side of the sea.”
+
+“Oh, I adore the sea!” said Monsieur Leon.
+
+“And then, does it not seem to you,” continued Madame Bovary, “that the
+mind travels more freely on this limitless expanse, the contemplation of
+which elevates the soul, gives ideas of the infinite, the ideal?”
+
+“It is the same with mountainous landscapes,” continued Leon. “A cousin
+of mine who travelled in Switzerland last year told me that one could
+not picture to oneself the poetry of the lakes, the charm of the
+waterfalls, the gigantic effect of the glaciers. One sees pines of
+incredible size across torrents, cottages suspended over precipices,
+and, a thousand feet below one, whole valleys when the clouds open. Such
+spectacles must stir to enthusiasm, incline to prayer, to ecstasy; and I
+no longer marvel at that celebrated musician who, the better to inspire
+his imagination, was in the habit of playing the piano before some
+imposing site.”
+
+“You play?” she asked.
+
+“No, but I am very fond of music,” he replied.
+
+“Ah! don’t you listen to him, Madame Bovary,” interrupted Homais,
+bending over his plate. “That’s sheer modesty. Why, my dear fellow, the
+other day in your room you were singing ‘L’Ange Gardien’ ravishingly. I
+heard you from the laboratory. You gave it like an actor.”
+
+Leon, in fact, lodged at the chemist’s where he had a small room on the
+second floor, overlooking the Place. He blushed at the compliment of his
+landlord, who had already turned to the doctor, and was enumerating to
+him, one after the other, all the principal inhabitants of Yonville. He
+was telling anecdotes, giving information; the fortune of the notary
+was not known exactly, and “there was the Tuvache household,” who made a
+good deal of show.
+
+Emma continued, “And what music do you prefer?”
+
+“Oh, German music; that which makes you dream.”
+
+“Have you been to the opera?”
+
+“Not yet; but I shall go next year, when I am living at Paris to finish
+reading for the bar.”
+
+“As I had the honour of putting it to your husband,” said the chemist,
+“with regard to this poor Yanoda who has run away, you will find
+yourself, thanks to his extravagance, in the possession of one of the
+most comfortable houses of Yonville. Its greatest convenience for a
+doctor is a door giving on the Walk, where one can go in and out unseen.
+Moreover, it contains everything that is agreeable in a household--a
+laundry, kitchen with offices, sitting-room, fruit-room, and so on. He
+was a gay dog, who didn’t care what he spent. At the end of the garden,
+by the side of the water, he had an arbour built just for the purpose of
+drinking beer in summer; and if madame is fond of gardening she will be
+able--”
+
+“My wife doesn’t care about it,” said Charles; “although she has
+been advised to take exercise, she prefers always sitting in her room
+reading.”
+
+“Like me,” replied Leon. “And indeed, what is better than to sit by
+one’s fireside in the evening with a book, while the wind beats against
+the window and the lamp is burning?”
+
+“What, indeed?” she said, fixing her large black eyes wide open upon
+him.
+
+“One thinks of nothing,” he continued; “the hours slip by. Motionless we
+traverse countries we fancy we see, and your thought, blending with
+the fiction, playing with the details, follows the outline of the
+adventures. It mingles with the characters, and it seems as if it were
+yourself palpitating beneath their costumes.”
+
+“That is true! That is true?” she said.
+
+“Has it ever happened to you,” Leon went on, “to come across some vague
+idea of one’s own in a book, some dim image that comes back to you from
+afar, and as the completest expression of your own slightest sentiment?”
+
+“I have experienced it,” she replied.
+
+“That is why,” he said, “I especially love the poets. I think verse more
+tender than prose, and that it moves far more easily to tears.”
+
+“Still in the long run it is tiring,” continued Emma. “Now I, on the
+contrary, adore stories that rush breathlessly along, that frighten one.
+I detest commonplace heroes and moderate sentiments, such as there are
+in nature.”
+
+“In fact,” observed the clerk, “these works, not touching the heart,
+miss, it seems to me, the true end of art. It is so sweet, amid all
+the disenchantments of life, to be able to dwell in thought upon noble
+characters, pure affections, and pictures of happiness. For myself,
+living here far from the world, this is my one distraction; but Yonville
+affords so few resources.”
+
+“Like Tostes, no doubt,” replied Emma; “and so I always subscribed to a
+lending library.”
+
+“If madame will do me the honour of making use of it”, said the chemist,
+who had just caught the last words, “I have at her disposal a library
+composed of the best authors, Voltaire, Rousseau, Delille, Walter
+Scott, the ‘Echo des Feuilletons’; and in addition I receive various
+periodicals, among them the ‘Fanal de Rouen’ daily, having the advantage
+to be its correspondent for the districts of Buchy, Forges, Neufchatel,
+Yonville, and vicinity.”
+
+For two hours and a half they had been at table; for the servant
+Artemis, carelessly dragging her old list slippers over the flags,
+brought one plate after the other, forgot everything, and constantly
+left the door of the billiard-room half open, so that it beat against
+the wall with its hooks.
+
+Unconsciously, Leon, while talking, had placed his foot on one of the
+bars of the chair on which Madame Bovary was sitting. She wore a small
+blue silk necktie, that kept up like a ruff a gauffered cambric collar,
+and with the movements of her head the lower part of her face gently
+sunk into the linen or came out from it. Thus side by side, while
+Charles and the chemist chatted, they entered into one of those vague
+conversations where the hazard of all that is said brings you back to
+the fixed centre of a common sympathy. The Paris theatres, titles of
+novels, new quadrilles, and the world they did not know; Tostes, where
+she had lived, and Yonville, where they were; they examined all, talked
+of everything till to the end of dinner.
+
+When coffee was served Felicite went away to get ready the room in the
+new house, and the guests soon raised the siege. Madame Lefrancois was
+asleep near the cinders, while the stable-boy, lantern in hand, was
+waiting to show Monsieur and Madame Bovary the way home. Bits of straw
+stuck in his red hair, and he limped with his left leg. When he had
+taken in his other hand the cure’s umbrella, they started.
+
+The town was asleep; the pillars of the market threw great shadows; the
+earth was all grey as on a summer’s night. But as the doctor’s house was
+only some fifty paces from the inn, they had to say good-night almost
+immediately, and the company dispersed.
+
+As soon as she entered the passage, Emma felt the cold of the plaster
+fall about her shoulders like damp linen. The walls were new and the
+wooden stairs creaked. In their bedroom, on the first floor, a whitish
+light passed through the curtainless windows.
+
+She could catch glimpses of tree tops, and beyond, the fields,
+half-drowned in the fog that lay reeking in the moonlight along
+the course of the river. In the middle of the room, pell-mell, were
+scattered drawers, bottles, curtain-rods, gilt poles, with mattresses
+on the chairs and basins on the ground--the two men who had brought the
+furniture had left everything about carelessly.
+
+This was the fourth time that she had slept in a strange place.
+
+The first was the day of her going to the convent; the second, of her
+arrival at Tostes; the third, at Vaubyessard; and this was the fourth.
+And each one had marked, as it were, the inauguration of a new phase in
+her life. She did not believe that things could present themselves in
+the same way in different places, and since the portion of her life
+lived had been bad, no doubt that which remained to be lived would be
+better.
+
+
+
+Chapter Three
+
+The next day, as she was getting up, she saw the clerk on the Place. She
+had on a dressing-gown. He looked up and bowed. She nodded quickly and
+reclosed the window.
+
+Leon waited all day for six o’clock in the evening to come, but on going
+to the inn, he found no one but Monsieur Binet, already at table. The
+dinner of the evening before had been a considerable event for him; he
+had never till then talked for two hours consecutively to a “lady.” How
+then had he been able to explain, and in such language, the number of
+things that he could not have said so well before? He was usually
+shy, and maintained that reserve which partakes at once of modesty and
+dissimulation.
+
+At Yonville he was considered “well-bred.” He listened to the arguments
+of the older people, and did not seem hot about politics--a remarkable
+thing for a young man. Then he had some accomplishments; he painted in
+water-colours, could read the key of G, and readily talked literature
+after dinner when he did not play cards. Monsieur Homais respected him
+for his education; Madame Homais liked him for his good-nature, for
+he often took the little Homais into the garden--little brats who were
+always dirty, very much spoilt, and somewhat lymphatic, like their
+mother. Besides the servant to look after them, they had Justin, the
+chemist’s apprentice, a second cousin of Monsieur Homais, who had been
+taken into the house from charity, and who was useful at the same time
+as a servant.
+
+The druggist proved the best of neighbours. He gave Madame Bovary
+information as to the trades-people, sent expressly for his own cider
+merchant, tasted the drink himself, and saw that the casks were properly
+placed in the cellar; he explained how to set about getting in a
+supply of butter cheap, and made an arrangement with Lestiboudois, the
+sacristan, who, besides his sacerdotal and funeral functions, looked
+after the principal gardens at Yonville by the hour or the year,
+according to the taste of the customers.
+
+The need of looking after others was not the only thing that urged the
+chemist to such obsequious cordiality; there was a plan underneath it
+all.
+
+He had infringed the law of the 19th Ventose, year xi., article I, which
+forbade all persons not having a diploma to practise medicine; so that,
+after certain anonymous denunciations, Homais had been summoned to Rouen
+to see the procurer of the king in his own private room; the magistrate
+receiving him standing up, ermine on shoulder and cap on head. It was
+in the morning, before the court opened. In the corridors one heard
+the heavy boots of the gendarmes walking past, and like a far-off noise
+great locks that were shut. The druggist’s ears tingled as if he were
+about to have an apoplectic stroke; he saw the depths of dungeons,
+his family in tears, his shop sold, all the jars dispersed; and he was
+obliged to enter a cafe and take a glass of rum and seltzer to recover
+his spirits.
+
+Little by little the memory of this reprimand grew fainter, and
+he continued, as heretofore, to give anodyne consultations in his
+back-parlour. But the mayor resented it, his colleagues were jealous,
+everything was to be feared; gaining over Monsieur Bovary by his
+attentions was to earn his gratitude, and prevent his speaking out later
+on, should he notice anything. So every morning Homais brought him “the
+paper,” and often in the afternoon left his shop for a few moments to
+have a chat with the Doctor.
+
+Charles was dull: patients did not come. He remained seated for hours
+without speaking, went into his consulting room to sleep, or watched
+his wife sewing. Then for diversion he employed himself at home as a
+workman; he even tried to do up the attic with some paint which had been
+left behind by the painters. But money matters worried him. He had
+spent so much for repairs at Tostes, for madame’s toilette, and for the
+moving, that the whole dowry, over three thousand crowns, had slipped
+away in two years.
+
+Then how many things had been spoilt or lost during their carriage from
+Tostes to Yonville, without counting the plaster cure, who falling out
+of the coach at an over-severe jolt, had been dashed into a thousand
+fragments on the pavements of Quincampoix! A pleasanter trouble came
+to distract him, namely, the pregnancy of his wife. As the time of her
+confinement approached he cherished her the more. It was another bond of
+the flesh establishing itself, and, as it were, a continued sentiment
+of a more complex union. When from afar he saw her languid walk, and
+her figure without stays turning softly on her hips; when opposite one
+another he looked at her at his ease, while she took tired poses in her
+armchair, then his happiness knew no bounds; he got up, embraced her,
+passed his hands over her face, called her little mamma, wanted to
+make her dance, and half-laughing, half-crying, uttered all kinds of
+caressing pleasantries that came into his head. The idea of having
+begotten a child delighted him. Now he wanted nothing. He knew human
+life from end to end, and he sat down to it with serenity.
+
+Emma at first felt a great astonishment; then was anxious to be
+delivered that she might know what it was to be a mother. But not
+being able to spend as much as she would have liked, to have a
+swing-bassinette with rose silk curtains, and embroidered caps, in a fit
+of bitterness she gave up looking after the trousseau, and ordered the
+whole of it from a village needlewoman, without choosing or discussing
+anything. Thus she did not amuse herself with those preparations that
+stimulate the tenderness of mothers, and so her affection was from the
+very outset, perhaps, to some extent attenuated.
+
+As Charles, however, spoke of the boy at every meal, she soon began to
+think of him more consecutively.
+
+She hoped for a son; he would be strong and dark; she would call him
+George; and this idea of having a male child was like an expected
+revenge for all her impotence in the past. A man, at least, is free; he
+may travel over passions and over countries, overcome obstacles, taste
+of the most far-away pleasures. But a woman is always hampered. At once
+inert and flexible, she has against her the weakness of the flesh and
+legal dependence. Her will, like the veil of her bonnet, held by a
+string, flutters in every wind; there is always some desire that draws
+her, some conventionality that restrains.
+
+She was confined on a Sunday at about six o’clock, as the sun was
+rising.
+
+“It is a girl!” said Charles.
+
+She turned her head away and fainted.
+
+Madame Homais, as well as Madame Lefrancois of the Lion d’Or, almost
+immediately came running in to embrace her. The chemist, as man of
+discretion, only offered a few provincial felicitations through the
+half-opened door. He wished to see the child and thought it well made.
+
+Whilst she was getting well she occupied herself much in seeking a
+name for her daughter. First she went over all those that have Italian
+endings, such as Clara, Louisa, Amanda, Atala; she liked Galsuinde
+pretty well, and Yseult or Leocadie still better.
+
+Charles wanted the child to be called after her mother; Emma opposed
+this. They ran over the calendar from end to end, and then consulted
+outsiders.
+
+“Monsieur Leon,” said the chemist, “with whom I was talking about it
+the other day, wonders you do not chose Madeleine. It is very much in
+fashion just now.”
+
+But Madame Bovary, senior, cried out loudly against this name of a
+sinner. As to Monsieur Homais, he had a preference for all those that
+recalled some great man, an illustrious fact, or a generous idea, and it
+was on this system that he had baptized his four children. Thus Napoleon
+represented glory and Franklin liberty; Irma was perhaps a concession to
+romanticism, but Athalie was a homage to the greatest masterpiece of the
+French stage. For his philosophical convictions did not interfere
+with his artistic tastes; in him the thinker did not stifle the man of
+sentiment; he could make distinctions, make allowances for imagination
+and fanaticism. In this tragedy, for example, he found fault with the
+ideas, but admired the style; he detested the conception, but applauded
+all the details, and loathed the characters while he grew enthusiastic
+over their dialogue. When he read the fine passages he was transported,
+but when he thought that mummers would get something out of them for
+their show, he was disconsolate; and in this confusion of sentiments in
+which he was involved he would have liked at once to crown Racine with
+both his hands and discuss with him for a good quarter of an hour.
+
+At last Emma remembered that at the chateau of Vaubyessard she had heard
+the Marchioness call a young lady Berthe; from that moment this name was
+chosen; and as old Rouault could not come, Monsieur Homais was requested
+to stand godfather. His gifts were all products from his establishment,
+to wit: six boxes of jujubes, a whole jar of racahout, three cakes of
+marshmallow paste, and six sticks of sugar-candy into the bargain that
+he had come across in a cupboard. On the evening of the ceremony there
+was a grand dinner; the cure was present; there was much excitement.
+Monsieur Homais towards liqueur-time began singing “Le Dieu des bonnes
+gens.” Monsieur Leon sang a barcarolle, and Madame Bovary, senior, who
+was godmother, a romance of the time of the Empire; finally, M. Bovary,
+senior, insisted on having the child brought down, and began baptizing
+it with a glass of champagne that he poured over its head. This mockery
+of the first of the sacraments made the Abbe Bournisien angry; old
+Bovary replied by a quotation from “La Guerre des Dieux”; the cure
+wanted to leave; the ladies implored, Homais interfered; and they
+succeeded in making the priest sit down again, and he quietly went on
+with the half-finished coffee in his saucer.
+
+Monsieur Bovary, senior, stayed at Yonville a month, dazzling the
+natives by a superb policeman’s cap with silver tassels that he wore
+in the morning when he smoked his pipe in the square. Being also in the
+habit of drinking a good deal of brandy, he often sent the servant
+to the Lion d’Or to buy him a bottle, which was put down to his
+son’s account, and to perfume his handkerchiefs he used up his
+daughter-in-law’s whole supply of eau-de-cologne.
+
+The latter did not at all dislike his company. He had knocked about the
+world, he talked about Berlin, Vienna, and Strasbourg, of his soldier
+times, of the mistresses he had had, the grand luncheons of which he had
+partaken; then he was amiable, and sometimes even, either on the stairs,
+or in the garden, would seize hold of her waist, crying, “Charles, look
+out for yourself.”
+
+Then Madame Bovary, senior, became alarmed for her son’s happiness, and
+fearing that her husband might in the long-run have an immoral influence
+upon the ideas of the young woman, took care to hurry their departure.
+Perhaps she had more serious reasons for uneasiness. Monsieur Bovary was
+not the man to respect anything.
+
+One day Emma was suddenly seized with the desire to see her little
+girl, who had been put to nurse with the carpenter’s wife, and, without
+looking at the calendar to see whether the six weeks of the Virgin were
+yet passed, she set out for the Rollets’ house, situated at the extreme
+end of the village, between the highroad and the fields.
+
+It was mid-day, the shutters of the houses were closed and the slate
+roofs that glittered beneath the fierce light of the blue sky seemed to
+strike sparks from the crest of the gables. A heavy wind was blowing;
+Emma felt weak as she walked; the stones of the pavement hurt her; she
+was doubtful whether she would not go home again, or go in somewhere to
+rest.
+
+At this moment Monsieur Leon came out from a neighbouring door with a
+bundle of papers under his arm. He came to greet her, and stood in the
+shade in front of the Lheureux’s shop under the projecting grey awning.
+
+Madame Bovary said she was going to see her baby, but that she was
+beginning to grow tired.
+
+“If--” said Leon, not daring to go on.
+
+“Have you any business to attend to?” she asked.
+
+And on the clerk’s answer, she begged him to accompany her. That same
+evening this was known in Yonville, and Madame Tuvache, the mayor’s
+wife, declared in the presence of her servant that “Madame Bovary was
+compromising herself.”
+
+To get to the nurse’s it was necessary to turn to the left on leaving
+the street, as if making for the cemetery, and to follow between little
+houses and yards a small path bordered with privet hedges. They were
+in bloom, and so were the speedwells, eglantines, thistles, and the
+sweetbriar that sprang up from the thickets. Through openings in
+the hedges one could see into the huts, some pigs on a dung-heap, or
+tethered cows rubbing their horns against the trunk of trees. The two,
+side by side walked slowly, she leaning upon him, and he restraining
+his pace, which he regulated by hers; in front of them a swarm of midges
+fluttered, buzzing in the warm air.
+
+They recognized the house by an old walnut-tree which shaded it.
+
+Low and covered with brown tiles, there hung outside it, beneath the
+dormer-window of the garret, a string of onions. Faggots upright
+against a thorn fence surrounded a bed of lettuce, a few square feet of
+lavender, and sweet peas strung on sticks. Dirty water was running here
+and there on the grass, and all round were several indefinite rags,
+knitted stockings, a red calico jacket, and a large sheet of coarse
+linen spread over the hedge. At the noise of the gate the nurse appeared
+with a baby she was suckling on one arm. With her other hand she was
+pulling along a poor puny little fellow, his face covered with scrofula,
+the son of a Rouen hosier, whom his parents, too taken up with their
+business, left in the country.
+
+“Go in,” she said; “your little one is there asleep.”
+
+The room on the ground-floor, the only one in the dwelling, had at its
+farther end, against the wall, a large bed without curtains, while a
+kneading-trough took up the side by the window, one pane of which
+was mended with a piece of blue paper. In the corner behind the door,
+shining hob-nailed shoes stood in a row under the slab of the washstand,
+near a bottle of oil with a feather stuck in its mouth; a Matthieu
+Laensberg lay on the dusty mantelpiece amid gunflints, candle-ends, and
+bits of amadou.
+
+Finally, the last luxury in the apartment was a “Fame” blowing her
+trumpets, a picture cut out, no doubt, from some perfumer’s prospectus
+and nailed to the wall with six wooden shoe-pegs.
+
+Emma’s child was asleep in a wicker-cradle. She took it up in the
+wrapping that enveloped it and began singing softly as she rocked
+herself to and fro.
+
+Leon walked up and down the room; it seemed strange to him to see this
+beautiful woman in her nankeen dress in the midst of all this poverty.
+Madam Bovary reddened; he turned away, thinking perhaps there had been
+an impertinent look in his eyes. Then she put back the little girl, who
+had just been sick over her collar.
+
+The nurse at once came to dry her, protesting that it wouldn’t show.
+
+“She gives me other doses,” she said: “I am always a-washing of her. If
+you would have the goodness to order Camus, the grocer, to let me have
+a little soap, it would really be more convenient for you, as I needn’t
+trouble you then.”
+
+“Very well! very well!” said Emma. “Good morning, Madame Rollet,” and
+she went out, wiping her shoes at the door.
+
+The good woman accompanied her to the end of the garden, talking all the
+time of the trouble she had getting up of nights.
+
+“I’m that worn out sometimes as I drop asleep on my chair. I’m sure you
+might at least give me just a pound of ground coffee; that’d last me a
+month, and I’d take it of a morning with some milk.”
+
+After having submitted to her thanks, Madam Bovary left. She had gone a
+little way down the path when, at the sound of wooden shoes, she turned
+round. It was the nurse.
+
+“What is it?”
+
+Then the peasant woman, taking her aside behind an elm tree, began
+talking to her of her husband, who with his trade and six francs a year
+that the captain--
+
+“Oh, be quick!” said Emma.
+
+“Well,” the nurse went on, heaving sighs between each word, “I’m afraid
+he’ll be put out seeing me have coffee alone, you know men--”
+
+“But you are to have some,” Emma repeated; “I will give you some. You
+bother me!”
+
+“Oh, dear! my poor, dear lady! you see in consequence of his wounds he
+has terrible cramps in the chest. He even says that cider weakens him.”
+
+“Do make haste, Mere Rollet!”
+
+“Well,” the latter continued, making a curtsey, “if it weren’t asking
+too much,” and she curtsied once more, “if you would”--and her eyes
+begged--“a jar of brandy,” she said at last, “and I’d rub your little
+one’s feet with it; they’re as tender as one’s tongue.”
+
+Once rid of the nurse, Emma again took Monsieur Leon’s arm. She walked
+fast for some time, then more slowly, and looking straight in front of
+her, her eyes rested on the shoulder of the young man, whose frock-coat
+had a black-velvety collar. His brown hair fell over it, straight and
+carefully arranged. She noticed his nails which were longer than one
+wore them at Yonville. It was one of the clerk’s chief occupations to
+trim them, and for this purpose he kept a special knife in his writing
+desk.
+
+They returned to Yonville by the water-side. In the warm season the
+bank, wider than at other times, showed to their foot the garden walls
+whence a few steps led to the river. It flowed noiselessly, swift,
+and cold to the eye; long, thin grasses huddled together in it as the
+current drove them, and spread themselves upon the limpid water like
+streaming hair; sometimes at the tip of the reeds or on the leaf of a
+water-lily an insect with fine legs crawled or rested. The sun pierced
+with a ray the small blue bubbles of the waves that, breaking, followed
+each other; branchless old willows mirrored their grey backs in
+the water; beyond, all around, the meadows seemed empty. It was the
+dinner-hour at the farms, and the young woman and her companion heard
+nothing as they walked but the fall of their steps on the earth of the
+path, the words they spoke, and the sound of Emma’s dress rustling round
+her.
+
+The walls of the gardens with pieces of bottle on their coping were
+hot as the glass windows of a conservatory. Wallflowers had sprung up
+between the bricks, and with the tip of her open sunshade Madame Bovary,
+as she passed, made some of their faded flowers crumble into a yellow
+dust, or a spray of overhanging honeysuckle and clematis caught in its
+fringe and dangled for a moment over the silk.
+
+They were talking of a troupe of Spanish dancers who were expected
+shortly at the Rouen theatre.
+
+“Are you going?” she asked.
+
+“If I can,” he answered.
+
+Had they nothing else to say to one another? Yet their eyes were full
+of more serious speech, and while they forced themselves to find trivial
+phrases, they felt the same languor stealing over them both. It was the
+whisper of the soul, deep, continuous, dominating that of their voices.
+Surprised with wonder at this strange sweetness, they did not think of
+speaking of the sensation or of seeking its cause. Coming joys, like
+tropical shores, throw over the immensity before them their inborn
+softness, an odorous wind, and we are lulled by this intoxication
+without a thought of the horizon that we do not even know.
+
+In one place the ground had been trodden down by the cattle; they had to
+step on large green stones put here and there in the mud.
+
+She often stopped a moment to look where to place her foot, and
+tottering on a stone that shook, her arms outspread, her form bent
+forward with a look of indecision, she would laugh, afraid of falling
+into the puddles of water.
+
+When they arrived in front of her garden, Madame Bovary opened the
+little gate, ran up the steps and disappeared.
+
+Leon returned to his office. His chief was away; he just glanced at the
+briefs, then cut himself a pen, and at last took up his hat and went
+out.
+
+He went to La Pature at the top of the Argueil hills at the beginning of
+the forest; he threw himself upon the ground under the pines and watched
+the sky through his fingers.
+
+“How bored I am!” he said to himself, “how bored I am!”
+
+He thought he was to be pitied for living in this village, with Homais
+for a friend and Monsieru Guillaumin for master. The latter, entirely
+absorbed by his business, wearing gold-rimmed spectacles and red
+whiskers over a white cravat, understood nothing of mental refinements,
+although he affected a stiff English manner, which in the beginning had
+impressed the clerk.
+
+As to the chemist’s spouse, she was the best wife in Normandy, gentle
+as a sheep, loving her children, her father, her mother, her cousins,
+weeping for other’s woes, letting everything go in her household, and
+detesting corsets; but so slow of movement, such a bore to listen to, so
+common in appearance, and of such restricted conversation, that although
+she was thirty, he only twenty, although they slept in rooms next each
+other and he spoke to her daily, he never thought that she might be a
+woman for another, or that she possessed anything else of her sex than
+the gown.
+
+And what else was there? Binet, a few shopkeepers, two or three
+publicans, the cure, and finally, Monsieur Tuvache, the mayor, with his
+two sons, rich, crabbed, obtuse persons, who farmed their own lands
+and had feasts among themselves, bigoted to boot, and quite unbearable
+companions.
+
+But from the general background of all these human faces Emma’s stood
+out isolated and yet farthest off; for between her and him he seemed to
+see a vague abyss.
+
+In the beginning he had called on her several times along with the
+druggist. Charles had not appeared particularly anxious to see him
+again, and Leon did not know what to do between his fear of being
+indiscreet and the desire for an intimacy that seemed almost impossible.
+
+
+
+Chapter Four
+
+When the first cold days set in Emma left her bedroom for the
+sitting-room, a long apartment with a low ceiling, in which there was
+on the mantelpiece a large bunch of coral spread out against the
+looking-glass. Seated in her arm chair near the window, she could see
+the villagers pass along the pavement.
+
+Twice a day Leon went from his office to the Lion d’Or. Emma could hear
+him coming from afar; she leant forward listening, and the young man
+glided past the curtain, always dressed in the same way, and without
+turning his head. But in the twilight, when, her chin resting on her
+left hand, she let the embroidery she had begun fall on her knees, she
+often shuddered at the apparition of this shadow suddenly gliding past.
+She would get up and order the table to be laid.
+
+Monsieur Homais called at dinner-time. Skull-cap in hand, he came in on
+tiptoe, in order to disturb no one, always repeating the same phrase,
+“Good evening, everybody.” Then, when he had taken his seat at the table
+between the pair, he asked the doctor about his patients, and the latter
+consulted his as to the probability of their payment. Next they talked
+of “what was in the paper.”
+
+Homais by this hour knew it almost by heart, and he repeated it from end
+to end, with the reflections of the penny-a-liners, and all the stories
+of individual catastrophes that had occurred in France or abroad. But
+the subject becoming exhausted, he was not slow in throwing out some
+remarks on the dishes before him.
+
+Sometimes even, half-rising, he delicately pointed out to madame the
+tenderest morsel, or turning to the servant, gave her some advice on the
+manipulation of stews and the hygiene of seasoning.
+
+He talked aroma, osmazome, juices, and gelatine in a bewildering manner.
+Moreover, Homais, with his head fuller of recipes than his shop of jars,
+excelled in making all kinds of preserves, vinegars, and sweet liqueurs;
+he knew also all the latest inventions in economic stoves, together with
+the art of preserving cheese and of curing sick wines.
+
+At eight o’clock Justin came to fetch him to shut up the shop.
+
+Then Monsieur Homais gave him a sly look, especially if Felicite was
+there, for he half noticed that his apprentice was fond of the doctor’s
+house.
+
+“The young dog,” he said, “is beginning to have ideas, and the devil
+take me if I don’t believe he’s in love with your servant!”
+
+But a more serious fault with which he reproached Justin was his
+constantly listening to conversation. On Sunday, for example, one could
+not get him out of the drawing-room, whither Madame Homais had called
+him to fetch the children, who were falling asleep in the arm-chairs,
+and dragging down with their backs calico chair-covers that were too
+large.
+
+Not many people came to these soirees at the chemist’s, his
+scandal-mongering and political opinions having successfully alienated
+various respectable persons from him. The clerk never failed to be
+there. As soon as he heard the bell he ran to meet Madame Bovary, took
+her shawl, and put away under the shop-counter the thick list shoes that
+she wore over her boots when there was snow.
+
+First they played some hands at trente-et-un; next Monsieur Homais
+played ecarte with Emma; Leon behind her gave her advice.
+
+Standing up with his hands on the back of her chair he saw the teeth of
+her comb that bit into her chignon. With every movement that she made
+to throw her cards the right side of her dress was drawn up. From her
+turned-up hair a dark colour fell over her back, and growing gradually
+paler, lost itself little by little in the shade. Then her dress fell
+on both sides of her chair, puffing out full of folds, and reached the
+ground. When Leon occasionally felt the sole of his boot resting on it,
+he drew back as if he had trodden upon some one.
+
+When the game of cards was over, the druggist and the Doctor played
+dominoes, and Emma, changing her place, leant her elbow on the table,
+turning over the leaves of “L’Illustration”. She had brought her ladies’
+journal with her. Leon sat down near her; they looked at the engravings
+together, and waited for one another at the bottom of the pages. She
+often begged him to read her the verses; Leon declaimed them in a
+languid voice, to which he carefully gave a dying fall in the love
+passages. But the noise of the dominoes annoyed him. Monsieur Homais
+was strong at the game; he could beat Charles and give him a double-six.
+Then the three hundred finished, they both stretched themselves out in
+front of the fire, and were soon asleep. The fire was dying out in the
+cinders; the teapot was empty, Leon was still reading.
+
+Emma listened to him, mechanically turning around the lampshade, on the
+gauze of which were painted clowns in carriages, and tight-rope dances
+with their balancing-poles. Leon stopped, pointing with a gesture to his
+sleeping audience; then they talked in low tones, and their conversation
+seemed the more sweet to them because it was unheard.
+
+Thus a kind of bond was established between them, a constant commerce
+of books and of romances. Monsieur Bovary, little given to jealousy, did
+not trouble himself about it.
+
+On his birthday he received a beautiful phrenological head, all marked
+with figures to the thorax and painted blue. This was an attention of
+the clerk’s. He showed him many others, even to doing errands for him
+at Rouen; and the book of a novelist having made the mania for cactuses
+fashionable, Leon bought some for Madame Bovary, bringing them back on
+his knees in the “Hirondelle,” pricking his fingers on their hard hairs.
+
+She had a board with a balustrade fixed against her window to hold the
+pots. The clerk, too, had his small hanging garden; they saw each other
+tending their flowers at their windows.
+
+Of the windows of the village there was one yet more often occupied; for
+on Sundays from morning to night, and every morning when the weather was
+bright, one could see at the dormer-window of the garret the profile of
+Monsieur Binet bending over his lathe, whose monotonous humming could be
+heard at the Lion d’Or.
+
+One evening on coming home Leon found in his room a rug in velvet and
+wool with leaves on a pale ground. He called Madame Homais, Monsieur
+Homais, Justin, the children, the cook; he spoke of it to his chief;
+every one wanted to see this rug. Why did the doctor’s wife give the
+clerk presents? It looked queer. They decided that she must be his
+lover.
+
+He made this seem likely, so ceaselessly did he talk of her charms and
+of her wit; so much so, that Binet once roughly answered him--
+
+“What does it matter to me since I’m not in her set?”
+
+He tortured himself to find out how he could make his declaration to
+her, and always halting between the fear of displeasing her and the
+shame of being such a coward, he wept with discouragement and desire.
+Then he took energetic resolutions, wrote letters that he tore up, put
+it off to times that he again deferred.
+
+Often he set out with the determination to dare all; but this resolution
+soon deserted him in Emma’s presence, and when Charles, dropping in,
+invited him to jump into his chaise to go with him to see some patient
+in the neighbourhood, he at once accepted, bowed to madame, and went
+out. Her husband, was he not something belonging to her? As to Emma,
+she did not ask herself whether she loved. Love, she thought, must come
+suddenly, with great outbursts and lightnings--a hurricane of the skies,
+which falls upon life, revolutionises it, roots up the will like a leaf,
+and sweeps the whole heart into the abyss. She did not know that on
+the terrace of houses it makes lakes when the pipes are choked, and she
+would thus have remained in her security when she suddenly discovered a
+rent in the wall of it.
+
+
+
+Chapter Five
+
+It was a Sunday in February, an afternoon when the snow was falling.
+
+They had all, Monsieur and Madame Bovary, Homais, and Monsieur Leon,
+gone to see a yarn-mill that was being built in the valley a mile and a
+half from Yonville. The druggist had taken Napoleon and Athalie to give
+them some exercise, and Justin accompanied them, carrying the umbrellas
+on his shoulder.
+
+Nothing, however, could be less curious than this curiosity. A great
+piece of waste ground, on which pell-mell, amid a mass of sand and
+stones, were a few break-wheels, already rusty, surrounded by a
+quadrangular building pierced by a number of little windows. The
+building was unfinished; the sky could be seen through the joists of the
+roofing. Attached to the stop-plank of the gable a bunch of straw mixed
+with corn-ears fluttered its tricoloured ribbons in the wind.
+
+Homais was talking. He explained to the company the future importance
+of this establishment, computed the strength of the floorings, the
+thickness of the walls, and regretted extremely not having a yard-stick
+such as Monsieur Binet possessed for his own special use.
+
+Emma, who had taken his arm, bent lightly against his shoulder, and
+she looked at the sun’s disc shedding afar through the mist his pale
+splendour. She turned. Charles was there. His cap was drawn down over
+his eyebrows, and his two thick lips were trembling, which added a look
+of stupidity to his face; his very back, his calm back, was irritating
+to behold, and she saw written upon his coat all the platitude of the
+bearer.
+
+While she was considering him thus, tasting in her irritation a sort of
+depraved pleasure, Leon made a step forward. The cold that made him pale
+seemed to add a more gentle languor to his face; between his cravat and
+his neck the somewhat loose collar of his shirt showed the skin; the
+lobe of his ear looked out from beneath a lock of hair, and his large
+blue eyes, raised to the clouds, seemed to Emma more limpid and more
+beautiful than those mountain-lakes where the heavens are mirrored.
+
+“Wretched boy!” suddenly cried the chemist.
+
+And he ran to his son, who had just precipitated himself into a heap of
+lime in order to whiten his boots. At the reproaches with which he was
+being overwhelmed Napoleon began to roar, while Justin dried his shoes
+with a wisp of straw. But a knife was wanted; Charles offered his.
+
+“Ah!” she said to herself, “he carried a knife in his pocket like a
+peasant.”
+
+The hoar-frost was falling, and they turned back to Yonville.
+
+In the evening Madame Bovary did not go to her neighbour’s, and when
+Charles had left and she felt herself alone, the comparison re-began
+with the clearness of a sensation almost actual, and with that
+lengthening of perspective which memory gives to things. Looking from
+her bed at the clean fire that was burning, she still saw, as she had
+down there, Leon standing up with one hand behind his cane, and with
+the other holding Athalie, who was quietly sucking a piece of ice. She
+thought him charming; she could not tear herself away from him; she
+recalled his other attitudes on other days, the words he had spoken, the
+sound of his voice, his whole person; and she repeated, pouting out her
+lips as if for a kiss--
+
+“Yes, charming! charming! Is he not in love?” she asked herself; “but
+with whom? With me?”
+
+All the proofs arose before her at once; her heart leapt. The flame of
+the fire threw a joyous light upon the ceiling; she turned on her back,
+stretching out her arms.
+
+Then began the eternal lamentation: “Oh, if Heaven had not willed it!
+And why not? What prevented it?”
+
+When Charles came home at midnight, she seemed to have just awakened,
+and as he made a noise undressing, she complained of a headache, then
+asked carelessly what had happened that evening.
+
+“Monsieur Leon,” he said, “went to his room early.”
+
+She could not help smiling, and she fell asleep, her soul filled with a
+new delight.
+
+The next day, at dusk, she received a visit from Monsieur Lherueux, the
+draper. He was a man of ability, was this shopkeeper. Born a Gascon but
+bred a Norman, he grafted upon his southern volubility the cunning of
+the Cauchois. His fat, flabby, beardless face seemed dyed by a
+decoction of liquorice, and his white hair made even more vivid the
+keen brilliance of his small black eyes. No one knew what he had been
+formerly; a pedlar said some, a banker at Routot according to others.
+What was certain was that he made complex calculations in his head that
+would have frightened Binet himself. Polite to obsequiousness, he always
+held himself with his back bent in the position of one who bows or who
+invites.
+
+After leaving at the door his hat surrounded with crape, he put down
+a green bandbox on the table, and began by complaining to madame, with
+many civilities, that he should have remained till that day without
+gaining her confidence. A poor shop like his was not made to attract
+a “fashionable lady”; he emphasized the words; yet she had only to
+command, and he would undertake to provide her with anything she might
+wish, either in haberdashery or linen, millinery or fancy goods, for
+he went to town regularly four times a month. He was connected with the
+best houses. You could speak of him at the “Trois Freres,” at the “Barbe
+d’Or,” or at the “Grand Sauvage”; all these gentlemen knew him as
+well as the insides of their pockets. To-day, then he had come to show
+madame, in passing, various articles he happened to have, thanks to
+the most rare opportunity. And he pulled out half-a-dozen embroidered
+collars from the box.
+
+Madame Bovary examined them. “I do not require anything,” she said.
+
+Then Monsieur Lheureux delicately exhibited three Algerian scarves,
+several packets of English needles, a pair of straw slippers, and
+finally, four eggcups in cocoanut wood, carved in open work by convicts.
+Then, with both hands on the table, his neck stretched out, his figure
+bent forward, open-mouthed, he watched Emma’s look, who was walking up
+and down undecided amid these goods. From time to time, as if to remove
+some dust, he filliped with his nail the silk of the scarves spread
+out at full length, and they rustled with a little noise, making in the
+green twilight the gold spangles of their tissue scintillate like little
+stars.
+
+“How much are they?”
+
+“A mere nothing,” he replied, “a mere nothing. But there’s no hurry;
+whenever it’s convenient. We are not Jews.”
+
+She reflected for a few moments, and ended by again declining Monsieur
+Lheureux’s offer. He replied quite unconcernedly--
+
+“Very well. We shall understand one another by and by. I have always got
+on with ladies--if I didn’t with my own!”
+
+Emma smiled.
+
+“I wanted to tell you,” he went on good-naturedly, after his joke, “that
+it isn’t the money I should trouble about. Why, I could give you some,
+if need be.”
+
+She made a gesture of surprise.
+
+“Ah!” said he quickly and in a low voice, “I shouldn’t have to go far to
+find you some, rely on that.”
+
+And he began asking after Pere Tellier, the proprietor of the “Cafe
+Francais,” whom Monsieur Bovary was then attending.
+
+“What’s the matter with Pere Tellier? He coughs so that he shakes his
+whole house, and I’m afraid he’ll soon want a deal covering rather than
+a flannel vest. He was such a rake as a young man! Those sort of people,
+madame, have not the least regularity; he’s burnt up with brandy. Still
+it’s sad, all the same, to see an acquaintance go off.”
+
+And while he fastened up his box he discoursed about the doctor’s
+patients.
+
+“It’s the weather, no doubt,” he said, looking frowningly at the floor,
+“that causes these illnesses. I, too, don’t feel the thing. One of these
+days I shall even have to consult the doctor for a pain I have in my
+back. Well, good-bye, Madame Bovary. At your service; your very humble
+servant.” And he closed the door gently.
+
+Emma had her dinner served in her bedroom on a tray by the fireside; she
+was a long time over it; everything was well with her.
+
+“How good I was!” she said to herself, thinking of the scarves.
+
+She heard some steps on the stairs. It was Leon. She got up and took
+from the chest of drawers the first pile of dusters to be hemmed. When
+he came in she seemed very busy.
+
+The conversation languished; Madame Bovary gave it up every few minutes,
+whilst he himself seemed quite embarrassed. Seated on a low chair near
+the fire, he turned round in his fingers the ivory thimble-case. She
+stitched on, or from time to time turned down the hem of the cloth with
+her nail. She did not speak; he was silent, captivated by her silence,
+as he would have been by her speech.
+
+“Poor fellow!” she thought.
+
+“How have I displeased her?” he asked himself.
+
+At last, however, Leon said that he should have, one of these days, to
+go to Rouen on some office business.
+
+“Your music subscription is out; am I to renew it?”
+
+“No,” she replied.
+
+“Why?”
+
+“Because--”
+
+And pursing her lips she slowly drew a long stitch of grey thread.
+
+This work irritated Leon. It seemed to roughen the ends of her fingers.
+A gallant phrase came into his head, but he did not risk it.
+
+“Then you are giving it up?” he went on.
+
+“What?” she asked hurriedly. “Music? Ah! yes! Have I not my house to
+look after, my husband to attend to, a thousand things, in fact, many
+duties that must be considered first?”
+
+She looked at the clock. Charles was late. Then, she affected anxiety.
+Two or three times she even repeated, “He is so good!”
+
+The clerk was fond of Monsieur Bovary. But this tenderness on his behalf
+astonished him unpleasantly; nevertheless he took up on his praises,
+which he said everyone was singing, especially the chemist.
+
+“Ah! he is a good fellow,” continued Emma.
+
+“Certainly,” replied the clerk.
+
+And he began talking of Madame Homais, whose very untidy appearance
+generally made them laugh.
+
+“What does it matter?” interrupted Emma. “A good housewife does not
+trouble about her appearance.”
+
+Then she relapsed into silence.
+
+It was the same on the following days; her talks, her manners,
+everything changed. She took interest in the housework, went to church
+regularly, and looked after her servant with more severity.
+
+She took Berthe from nurse. When visitors called, Felicite brought her
+in, and Madame Bovary undressed her to show off her limbs. She declared
+she adored children; this was her consolation, her joy, her passion,
+and she accompanied her caresses with lyrical outburst which would have
+reminded anyone but the Yonville people of Sachette in “Notre Dame de
+Paris.”
+
+When Charles came home he found his slippers put to warm near the fire.
+His waistcoat now never wanted lining, nor his shirt buttons, and it was
+quite a pleasure to see in the cupboard the night-caps arranged in piles
+of the same height. She no longer grumbled as formerly at taking a turn
+in the garden; what he proposed was always done, although she did not
+understand the wishes to which she submitted without a murmur; and when
+Leon saw him by his fireside after dinner, his two hands on his stomach,
+his two feet on the fender, his two cheeks red with feeding, his eyes
+moist with happiness, the child crawling along the carpet, and this
+woman with the slender waist who came behind his arm-chair to kiss his
+forehead: “What madness!” he said to himself. “And how to reach her!”
+
+And thus she seemed so virtuous and inaccessible to him that he lost all
+hope, even the faintest. But by this renunciation he placed her on
+an extraordinary pinnacle. To him she stood outside those fleshly
+attributes from which he had nothing to obtain, and in his heart she
+rose ever, and became farther removed from him after the magnificent
+manner of an apotheosis that is taking wing. It was one of those pure
+feelings that do not interfere with life, that are cultivated because
+they are rare, and whose loss would afflict more than their passion
+rejoices.
+
+Emma grew thinner, her cheeks paler, her face longer. With her black
+hair, her large eyes, her aquiline nose, her birdlike walk, and always
+silent now, did she not seem to be passing through life scarcely
+touching it, and to bear on her brow the vague impress of some divine
+destiny? She was so sad and so calm, at once so gentle and so reserved,
+that near her one felt oneself seized by an icy charm, as we shudder
+in churches at the perfume of the flowers mingling with the cold of the
+marble. The others even did not escape from this seduction. The chemist
+said--
+
+“She is a woman of great parts, who wouldn’t be misplaced in a
+sub-prefecture.”
+
+The housewives admired her economy, the patients her politeness, the
+poor her charity.
+
+But she was eaten up with desires, with rage, with hate. That dress with
+the narrow folds hid a distracted fear, of whose torment those chaste
+lips said nothing. She was in love with Leon, and sought solitude that
+she might with the more ease delight in his image. The sight of his
+form troubled the voluptuousness of this mediation. Emma thrilled at
+the sound of his step; then in his presence the emotion subsided, and
+afterwards there remained to her only an immense astonishment that ended
+in sorrow.
+
+Leon did not know that when he left her in despair she rose after he had
+gone to see him in the street. She concerned herself about his comings
+and goings; she watched his face; she invented quite a history to find
+an excuse for going to his room. The chemist’s wife seemed happy to her
+to sleep under the same roof, and her thoughts constantly centered upon
+this house, like the “Lion d’Or” pigeons, who came there to dip their
+red feet and white wings in its gutters. But the more Emma recognised
+her love, the more she crushed it down, that it might not be evident,
+that she might make it less. She would have liked Leon to guess it, and
+she imagined chances, catastrophes that should facilitate this.
+
+What restrained her was, no doubt, idleness and fear, and a sense of
+shame also. She thought she had repulsed him too much, that the time was
+past, that all was lost. Then, pride, and joy of being able to say to
+herself, “I am virtuous,” and to look at herself in the glass taking
+resigned poses, consoled her a little for the sacrifice she believed she
+was making.
+
+Then the lusts of the flesh, the longing for money, and the melancholy
+of passion all blended themselves into one suffering, and instead of
+turning her thoughts from it, she clave to it the more, urging herself
+to pain, and seeking everywhere occasion for it. She was irritated by
+an ill-served dish or by a half-open door; bewailed the velvets she had
+not, the happiness she had missed, her too exalted dreams, her narrow
+home.
+
+What exasperated her was that Charles did not seem to notice her
+anguish. His conviction that he was making her happy seemed to her an
+imbecile insult, and his sureness on this point ingratitude. For whose
+sake, then was she virtuous? Was it not for him, the obstacle to all
+felicity, the cause of all misery, and, as it were, the sharp clasp of
+that complex strap that bucked her in on all sides.
+
+On him alone, then, she concentrated all the various hatreds that
+resulted from her boredom, and every effort to diminish only augmented
+it; for this useless trouble was added to the other reasons for despair,
+and contributed still more to the separation between them. Her own
+gentleness to herself made her rebel against him. Domestic mediocrity
+drove her to lewd fancies, marriage tenderness to adulterous desires.
+She would have liked Charles to beat her, that she might have a better
+right to hate him, to revenge herself upon him. She was surprised
+sometimes at the atrocious conjectures that came into her thoughts, and
+she had to go on smiling, to hear repeated to her at all hours that she
+was happy, to pretend to be happy, to let it be believed.
+
+Yet she had loathing of this hypocrisy. She was seized with the
+temptation to flee somewhere with Leon to try a new life; but at once a
+vague chasm full of darkness opened within her soul.
+
+“Besides, he no longer loves me,” she thought. “What is to become of me?
+What help is to be hoped for, what consolation, what solace?”
+
+She was left broken, breathless, inert, sobbing in a low voice, with
+flowing tears.
+
+“Why don’t you tell master?” the servant asked her when she came in
+during these crises.
+
+“It is the nerves,” said Emma. “Do not speak to him of it; it would
+worry him.”
+
+“Ah! yes,” Felicite went on, “you are just like La Guerine, Pere
+Guerin’s daughter, the fisherman at Pollet, that I used to know at
+Dieppe before I came to you. She was so sad, so sad, to see her
+standing upright on the threshold of her house, she seemed to you like a
+winding-sheet spread out before the door. Her illness, it appears, was
+a kind of fog that she had in her head, and the doctors could not do
+anything, nor the priest either. When she was taken too bad she went
+off quite alone to the sea-shore, so that the customs officer, going his
+rounds, often found her lying flat on her face, crying on the shingle.
+Then, after her marriage, it went off, they say.”
+
+“But with me,” replied Emma, “it was after marriage that it began.”
+
+
+
+Chapter Six
+
+One evening when the window was open, and she, sitting by it, had been
+watching Lestiboudois, the beadle, trimming the box, she suddenly heard
+the Angelus ringing.
+
+It was the beginning of April, when the primroses are in bloom, and a
+warm wind blows over the flower-beds newly turned, and the gardens, like
+women, seem to be getting ready for the summer fetes. Through the bars
+of the arbour and away beyond the river seen in the fields, meandering
+through the grass in wandering curves. The evening vapours rose between
+the leafless poplars, touching their outlines with a violet tint, paler
+and more transparent than a subtle gauze caught athwart their branches.
+In the distance cattle moved about; neither their steps nor their lowing
+could be heard; and the bell, still ringing through the air, kept up its
+peaceful lamentation.
+
+With this repeated tinkling the thoughts of the young woman lost
+themselves in old memories of her youth and school-days. She remembered
+the great candlesticks that rose above the vases full of flowers on the
+altar, and the tabernacle with its small columns. She would have liked
+to be once more lost in the long line of white veils, marked off here
+and there by the stuff black hoods of the good sisters bending over
+their prie-Dieu. At mass on Sundays, when she looked up, she saw the
+gentle face of the Virgin amid the blue smoke of the rising incense.
+Then she was moved; she felt herself weak and quite deserted, like the
+down of a bird whirled by the tempest, and it was unconsciously that she
+went towards the church, included to no matter what devotions, so that
+her soul was absorbed and all existence lost in it.
+
+On the Place she met Lestivoudois on his way back, for, in order not
+to shorten his day’s labour, he preferred interrupting his work,
+then beginning it again, so that he rang the Angelus to suit his own
+convenience. Besides, the ringing over a little earlier warned the lads
+of catechism hour.
+
+Already a few who had arrived were playing marbles on the stones of the
+cemetery. Others, astride the wall, swung their legs, kicking with their
+clogs the large nettles growing between the little enclosure and the
+newest graves. This was the only green spot. All the rest was but
+stones, always covered with a fine powder, despite the vestry-broom.
+
+The children in list shoes ran about there as if it were an enclosure
+made for them. The shouts of their voices could be heard through the
+humming of the bell. This grew less and less with the swinging of the
+great rope that, hanging from the top of the belfry, dragged its end on
+the ground. Swallows flitted to and fro uttering little cries, cut the
+air with the edge of their wings, and swiftly returned to their yellow
+nests under the tiles of the coping. At the end of the church a lamp was
+burning, the wick of a night-light in a glass hung up. Its light from a
+distance looked like a white stain trembling in the oil. A long ray of
+the sun fell across the nave and seemed to darken the lower sides and
+the corners.
+
+“Where is the cure?” asked Madame Bovary of one of the lads, who was
+amusing himself by shaking a swivel in a hole too large for it.
+
+“He is just coming,” he answered.
+
+And in fact the door of the presbytery grated; Abbe Bournisien appeared;
+the children, pell-mell, fled into the church.
+
+“These young scamps!” murmured the priest, “always the same!”
+
+Then, picking up a catechism all in rags that he had struck with is
+foot, “They respect nothing!” But as soon as he caught sight of Madame
+Bovary, “Excuse me,” he said; “I did not recognise you.”
+
+He thrust the catechism into his pocket, and stopped short, balancing
+the heavy vestry key between his two fingers.
+
+The light of the setting sun that fell full upon his face paled the
+lasting of his cassock, shiny at the elbows, unravelled at the hem.
+Grease and tobacco stains followed along his broad chest the lines
+of the buttons, and grew more numerous the farther they were from his
+neckcloth, in which the massive folds of his red chin rested; this was
+dotted with yellow spots, that disappeared beneath the coarse hair of
+his greyish beard. He had just dined and was breathing noisily.
+
+“How are you?” he added.
+
+“Not well,” replied Emma; “I am ill.”
+
+“Well, and so am I,” answered the priest. “These first warm days weaken
+one most remarkably, don’t they? But, after all, we are born to suffer,
+as St. Paul says. But what does Monsieur Bovary think of it?”
+
+“He!” she said with a gesture of contempt.
+
+“What!” replied the good fellow, quite astonished, “doesn’t he prescribe
+something for you?”
+
+“Ah!” said Emma, “it is no earthly remedy I need.”
+
+But the cure from time to time looked into the church, where the
+kneeling boys were shouldering one another, and tumbling over like packs
+of cards.
+
+“I should like to know--” she went on.
+
+“You look out, Riboudet,” cried the priest in an angry voice; “I’ll warm
+your ears, you imp!” Then turning to Emma, “He’s Boudet the carpenter’s
+son; his parents are well off, and let him do just as he pleases. Yet he
+could learn quickly if he would, for he is very sharp. And so sometimes
+for a joke I call him Riboudet (like the road one takes to go to
+Maromme) and I even say ‘Mon Riboudet.’ Ha! Ha! ‘Mont Riboudet.’ The
+other day I repeated that just to Monsignor, and he laughed at it; he
+condescended to laugh at it. And how is Monsieur Bovary?”
+
+She seemed not to hear him. And he went on--
+
+“Always very busy, no doubt; for he and I are certainly the busiest
+people in the parish. But he is doctor of the body,” he added with a
+thick laugh, “and I of the soul.”
+
+She fixed her pleading eyes upon the priest. “Yes,” she said, “you
+solace all sorrows.”
+
+“Ah! don’t talk to me of it, Madame Bovary. This morning I had to go to
+Bas-Diauville for a cow that was ill; they thought it was under a spell.
+All their cows, I don’t know how it is--But pardon me! Longuemarre and
+Boudet! Bless me! Will you leave off?”
+
+And with a bound he ran into the church.
+
+The boys were just then clustering round the large desk, climbing over
+the precentor’s footstool, opening the missal; and others on tiptoe were
+just about to venture into the confessional. But the priest suddenly
+distributed a shower of cuffs among them. Seizing them by the collars of
+their coats, he lifted them from the ground, and deposited them on their
+knees on the stones of the choir, firmly, as if he meant planting them
+there.
+
+“Yes,” said he, when he returned to Emma, unfolding his large cotton
+handkerchief, one corner of which he put between his teeth, “farmers are
+much to be pitied.”
+
+“Others, too,” she replied.
+
+“Assuredly. Town-labourers, for example.”
+
+“It is not they--”
+
+“Pardon! I’ve there known poor mothers of families, virtuous women, I
+assure you, real saints, who wanted even bread.”
+
+“But those,” replied Emma, and the corners of her mouth twitched as she
+spoke, “those, Monsieur le Cure, who have bread and have no--”
+
+“Fire in the winter,” said the priest.
+
+“Oh, what does that matter?”
+
+“What! What does it matter? It seems to me that when one has firing and
+food--for, after all--”
+
+“My God! my God!” she sighed.
+
+“It is indigestion, no doubt? You must get home, Madame Bovary; drink
+a little tea, that will strengthen you, or else a glass of fresh water
+with a little moist sugar.”
+
+“Why?” And she looked like one awaking from a dream.
+
+“Well, you see, you were putting your hand to your forehead. I thought
+you felt faint.” Then, bethinking himself, “But you were asking me
+something? What was it? I really don’t remember.”
+
+“I? Nothing! nothing!” repeated Emma.
+
+And the glance she cast round her slowly fell upon the old man in the
+cassock. They looked at one another face to face without speaking.
+
+“Then, Madame Bovary,” he said at last, “excuse me, but duty first, you
+know; I must look after my good-for-nothings. The first communion will
+soon be upon us, and I fear we shall be behind after all. So after
+Ascension Day I keep them recta* an extra hour every Wednesday. Poor
+children! One cannot lead them too soon into the path of the Lord, as,
+moreover, he has himself recommended us to do by the mouth of his Divine
+Son. Good health to you, madame; my respects to your husband.”
+
+     *On the straight and narrow path.
+
+And he went into the church making a genuflexion as soon as he reached
+the door.
+
+Emma saw him disappear between the double row of forms, walking with a
+heavy tread, his head a little bent over his shoulder, and with his two
+hands half-open behind him.
+
+Then she turned on her heel all of one piece, like a statue on a pivot,
+and went homewards. But the loud voice of the priest, the clear voices
+of the boys still reached her ears, and went on behind her.
+
+“Are you a Christian?”
+
+“Yes, I am a Christian.”
+
+“What is a Christian?”
+
+“He who, being baptized-baptized-baptized--”
+
+She went up the steps of the staircase holding on to the banisters, and
+when she was in her room threw herself into an arm-chair.
+
+The whitish light of the window-panes fell with soft undulations.
+
+The furniture in its place seemed to have become more immobile, and to
+lose itself in the shadow as in an ocean of darkness. The fire was out,
+the clock went on ticking, and Emma vaguely marvelled at this calm of
+all things while within herself was such tumult. But little Berthe was
+there, between the window and the work-table, tottering on her knitted
+shoes, and trying to come to her mother to catch hold of the ends of her
+apron-strings.
+
+“Leave me alone,” said the latter, putting her from her with her hand.
+
+The little girl soon came up closer against her knees, and leaning on
+them with her arms, she looked up with her large blue eyes, while a
+small thread of pure saliva dribbled from her lips on to the silk apron.
+
+“Leave me alone,” repeated the young woman quite irritably.
+
+Her face frightened the child, who began to scream.
+
+“Will you leave me alone?” she said, pushing her with her elbow.
+
+Berthe fell at the foot of the drawers against the brass handle, cutting
+her cheek, which began to bleed, against it. Madame Bovary sprang to
+lift her up, broke the bell-rope, called for the servant with all her
+might, and she was just going to curse herself when Charles appeared. It
+was the dinner-hour; he had come home.
+
+“Look, dear!” said Emma, in a calm voice, “the little one fell down
+while she was playing, and has hurt herself.”
+
+Charles reassured her; the case was not a serious one, and he went for
+some sticking plaster.
+
+Madame Bovary did not go downstairs to the dining-room; she wished
+to remain alone to look after the child. Then watching her sleep, the
+little anxiety she felt gradually wore off, and she seemed very stupid
+to herself, and very good to have been so worried just now at so little.
+Berthe, in fact, no longer sobbed.
+
+Her breathing now imperceptibly raised the cotton covering. Big tears
+lay in the corner of the half-closed eyelids, through whose lashes one
+could see two pale sunken pupils; the plaster stuck on her cheek drew
+the skin obliquely.
+
+“It is very strange,” thought Emma, “how ugly this child is!”
+
+When at eleven o’clock Charles came back from the chemist’s shop,
+whither he had gone after dinner to return the remainder of the
+sticking-plaster, he found his wife standing by the cradle.
+
+“I assure you it’s nothing.” he said, kissing her on the forehead.
+“Don’t worry, my poor darling; you will make yourself ill.”
+
+He had stayed a long time at the chemist’s. Although he had not seemed
+much moved, Homais, nevertheless, had exerted himself to buoy him up, to
+“keep up his spirits.” Then they had talked of the various dangers that
+threaten childhood, of the carelessness of servants. Madame Homais knew
+something of it, having still upon her chest the marks left by a basin
+full of soup that a cook had formerly dropped on her pinafore, and
+her good parents took no end of trouble for her. The knives were not
+sharpened, nor the floors waxed; there were iron gratings to the windows
+and strong bars across the fireplace; the little Homais, in spite of
+their spirit, could not stir without someone watching them; at the
+slightest cold their father stuffed them with pectorals; and until
+they were turned four they all, without pity, had to wear wadded
+head-protectors. This, it is true, was a fancy of Madame Homais’; her
+husband was inwardly afflicted at it. Fearing the possible consequences
+of such compression to the intellectual organs. He even went so far as
+to say to her, “Do you want to make Caribs or Botocudos of them?”
+
+Charles, however, had several times tried to interrupt the conversation.
+“I should like to speak to you,” he had whispered in the clerk’s ear,
+who went upstairs in front of him.
+
+“Can he suspect anything?” Leon asked himself. His heart beat, and he
+racked his brain with surmises.
+
+At last, Charles, having shut the door, asked him to see himself
+what would be the price at Rouen of a fine daguerreotypes. It was a
+sentimental surprise he intended for his wife, a delicate attention--his
+portrait in a frock-coat. But he wanted first to know “how much it would
+be.” The inquiries would not put Monsieur Leon out, since he went to
+town almost every week.
+
+Why? Monsieur Homais suspected some “young man’s affair” at the bottom
+of it, an intrigue. But he was mistaken. Leon was after no love-making.
+He was sadder than ever, as Madame Lefrancois saw from the amount of
+food he left on his plate. To find out more about it she questioned
+the tax-collector. Binet answered roughly that he “wasn’t paid by the
+police.”
+
+All the same, his companion seemed very strange to him, for Leon often
+threw himself back in his chair, and stretching out his arms, complained vaguely of life.
+
+“It’s because you don’t take enough recreation,” said the collector.
+
+“What recreation?”
+
+“If I were you I’d have a lathe.”
+
+“But I don’t know how to turn,” answered the clerk.
+
+“Ah! that’s true,” said the other, rubbing his chin with an air of
+mingled contempt and satisfaction.
+
+Leon was weary of loving without any result; moreover he was beginning
+to feel that depression caused by the repetition of the same kind of
+life, when no interest inspires and no hope sustains it. He was so bored
+with Yonville and its inhabitants, that the sight of certain persons,
+of certain houses, irritated him beyond endurance; and the chemist, good
+fellow though he was, was becoming absolutely unbearable to him. Yet
+the prospect of a new condition of life frightened as much as it seduced
+him.
+
+This apprehension soon changed into impatience, and then Paris from afar
+sounded its fanfare of masked balls with the laugh of grisettes. As he
+was to finish reading there, why not set out at once? What prevented
+him? And he began making home-preparations; he arranged his occupations
+beforehand. He furnished in his head an apartment. He would lead an
+artist’s life there! He would take lessons on the guitar! He would have
+a dressing-gown, a Basque cap, blue velvet slippers! He even already was
+admiring two crossed foils over his chimney-piece, with a death’s head
+on the guitar above them.
+
+The difficulty was the consent of his mother; nothing, however, seemed
+more reasonable. Even his employer advised him to go to some other
+chambers where he could advance more rapidly. Taking a middle course,
+then, Leon looked for some place as second clerk at Rouen; found none,
+and at last wrote his mother a long letter full of details, in which
+he set forth the reasons for going to live at Paris immediately. She
+consented.
+
+He did not hurry. Every day for a month Hivert carried boxes, valises,
+parcels for him from Yonville to Rouen and from Rouen to Yonville;
+and when Leon had packed up his wardrobe, had his three arm-chairs
+restuffed, bought a stock of neckties, in a word, had made more
+preparations than for a voyage around the world, he put it off from week
+to week, until he received a second letter from his mother urging him to
+leave, since he wanted to pass his examination before the vacation.
+
+When the moment for the farewells had come, Madame Homais wept, Justin
+sobbed; Homais, as a man of nerve, concealed his emotion; he wished to
+carry his friend’s overcoat himself as far as the gate of the notary,
+who was taking Leon to Rouen in his carriage.
+
+The latter had just time to bid farewell to Monsieur Bovary.
+
+When he reached the head of the stairs, he stopped, he was so out of
+breath. As he came in, Madame Bovary arose hurriedly.
+
+“It is I again!” said Leon.
+
+“I was sure of it!”
+
+She bit her lips, and a rush of blood flowing under her skin made her
+red from the roots of her hair to the top of her collar. She remained
+standing, leaning with her shoulder against the wainscot.
+
+“The doctor is not here?” he went on.
+
+“He is out.” She repeated, “He is out.”
+
+Then there was silence. They looked at one another and their thoughts,
+confounded in the same agony, clung close together like two throbbing
+breasts.
+
+“I should like to kiss Berthe,” said Leon.
+
+Emma went down a few steps and called Felicite.
+
+He threw one long look around him that took in the walls, the
+decorations, the fireplace, as if to penetrate everything, carry away
+everything. But she returned, and the servant brought Berthe, who was
+swinging a windmill roof downwards at the end of a string. Leon kissed
+her several times on the neck.
+
+“Good-bye, poor child! good-bye, dear little one! good-bye!” And he gave
+her back to her mother.
+
+“Take her away,” she said.
+
+They remained alone--Madame Bovary, her back turned, her face pressed
+against a window-pane; Leon held his cap in his hand, knocking it softly
+against his thigh.
+
+“It is going to rain,” said Emma.
+
+“I have a cloak,” he answered.
+
+“Ah!”
+
+She turned around, her chin lowered, her forehead bent forward.
+
+The light fell on it as on a piece of marble, to the curve of the
+eyebrows, without one’s being able to guess what Emma was seeing on the
+horizon or what she was thinking within herself.
+
+“Well, good-bye,” he sighed.
+
+She raised her head with a quick movement.
+
+“Yes, good-bye--go!”
+
+They advanced towards each other; he held out his hand; she hesitated.
+
+“In the English fashion, then,” she said, giving her own hand wholly to
+him, and forcing a laugh.
+
+Leon felt it between his fingers, and the very essence of all his being
+seemed to pass down into that moist palm. Then he opened his hand; their
+eyes met again, and he disappeared.
+
+When he reached the market-place, he stopped and hid behind a pillar to
+look for the last time at this white house with the four green blinds.
+He thought he saw a shadow behind the window in the room; but the
+curtain, sliding along the pole as though no one were touching it,
+slowly opened its long oblique folds that spread out with a single
+movement, and thus hung straight and motionless as a plaster wall. Leon
+set off running.
+
+From afar he saw his employer’s gig in the road, and by it a man in
+a coarse apron holding the horse. Homais and Monsieur Guillaumin were
+talking. They were waiting for him.
+
+“Embrace me,” said the druggist with tears in his eyes. “Here is your
+coat, my good friend. Mind the cold; take care of yourself; look after
+yourself.”
+
+“Come, Leon, jump in,” said the notary.
+
+Homais bent over the splash-board, and in a voice broken by sobs uttered
+these three sad words--
+
+“A pleasant journey!”
+
+“Good-night,” said Monsieur Guillaumin. “Give him his head.” They set
+out, and Homais went back.
+
+Madame Bovary had opened her window overlooking the garden and watched
+the clouds. They gathered around the sunset on the side of Rouen and
+then swiftly rolled back their black columns, behind which the great
+rays of the sun looked out like the golden arrows of a suspended trophy,
+while the rest of the empty heavens was white as porcelain. But a gust
+of wind bowed the poplars, and suddenly the rain fell; it pattered
+against the green leaves.
+
+Then the sun reappeared, the hens clucked, sparrows shook their wings in
+the damp thickets, and the pools of water on the gravel as they flowed
+away carried off the pink flowers of an acacia.
+
+“Ah! how far off he must be already!” she thought.
+
+Monsieur Homais, as usual, came at half-past six during dinner.
+
+“Well,” said he, “so we’ve sent off our young friend!”
+
+“So it seems,” replied the doctor. Then turning on his chair; “Any news
+at home?”
+
+“Nothing much. Only my wife was a little moved this afternoon. You know
+women--a nothing upsets them, especially my wife. And we should be
+wrong to object to that, since their nervous organization is much more
+malleable than ours.”
+
+“Poor Leon!” said Charles. “How will he live at Paris? Will he get used
+to it?”
+
+Madame Bovary sighed.
+
+“Get along!” said the chemist, smacking his lips. “The outings at
+restaurants, the masked balls, the champagne--all that’ll be jolly
+enough, I assure you.”
+
+“I don’t think he’ll go wrong,” objected Bovary.
+
+“Nor do I,” said Monsieur Homais quickly; “although he’ll have to do
+like the rest for fear of passing for a Jesuit. And you don’t know what
+a life those dogs lead in the Latin quarter with actresses. Besides,
+students are thought a great deal of in Paris. Provided they have a few
+accomplishments, they are received in the best society; there are even
+ladies of the Faubourg Saint-Germain who fall in love with them, which
+subsequently furnishes them opportunities for making very good matches.”
+
+“But,” said the doctor, “I fear for him that down there--”
+
+“You are right,” interrupted the chemist; “that is the reverse of the
+medal. And one is constantly obliged to keep one’s hand in one’s pocket
+there. Thus, we will suppose you are in a public garden. An individual
+presents himself, well dressed, even wearing an order, and whom one
+would take for a diplomatist. He approaches you, he insinuates himself;
+offers you a pinch of snuff, or picks up your hat. Then you become more
+intimate; he takes you to a cafe, invites you to his country-house,
+introduces you, between two drinks, to all sorts of people; and
+three-fourths of the time it’s only to plunder your watch or lead you
+into some pernicious step.
+
+“That is true,” said Charles; “but I was thinking especially of
+illnesses--of typhoid fever, for example, that attacks students from the
+provinces.”
+
+Emma shuddered.
+
+“Because of the change of regimen,” continued the chemist, “and of the
+perturbation that results therefrom in the whole system. And then the
+water at Paris, don’t you know! The dishes at restaurants, all the
+spiced food, end by heating the blood, and are not worth, whatever
+people may say of them, a good soup. For my own part, I have always
+preferred plain living; it is more healthy. So when I was studying
+pharmacy at Rouen, I boarded in a boarding house; I dined with the
+professors.”
+
+And thus he went on, expounding his opinions generally and his personal
+likings, until Justin came to fetch him for a mulled egg that was
+wanted.
+
+“Not a moment’s peace!” he cried; “always at it! I can’t go out for a
+minute! Like a plough-horse, I have always to be moiling and toiling.
+What drudgery!” Then, when he was at the door, “By the way, do you know
+the news?”
+
+“What news?”
+
+“That it is very likely,” Homais went on, raising his eyebrows and
+assuming one of his most serious expression, “that the agricultural
+meeting of the Seine-Inferieure will be held this year at
+Yonville-l’Abbaye. The rumour, at all events, is going the round. This
+morning the paper alluded to it. It would be of the utmost importance
+for our district. But we’ll talk it over later on. I can see, thank you;
+Justin has the lantern.”
+
+
+
+Chapter Seven
+
+The next day was a dreary one for Emma. Everything seemed to her
+enveloped in a black atmosphere floating confusedly over the exterior of
+things, and sorrow was engulfed within her soul with soft shrieks such
+as the winter wind makes in ruined castles. It was that reverie which we
+give to things that will not return, the lassitude that seizes you after
+everything was done; that pain, in fine, that the interruption of every
+wonted movement, the sudden cessation of any prolonged vibration, brings
+on.
+
+As on the return from Vaubyessard, when the quadrilles were running in
+her head, she was full of a gloomy melancholy, of a numb despair.
+Leon reappeared, taller, handsomer, more charming, more vague. Though
+separated from her, he had not left her; he was there, and the walls of
+the house seemed to hold his shadow.
+
+She could not detach her eyes from the carpet where he had walked, from
+those empty chairs where he had sat. The river still flowed on, and
+slowly drove its ripples along the slippery banks.
+
+They had often walked there to the murmur of the waves over the
+moss-covered pebbles. How bright the sun had been! What happy afternoons
+they had seen alone in the shade at the end of the garden! He read
+aloud, bareheaded, sitting on a footstool of dry sticks; the fresh wind
+of the meadow set trembling the leaves of the book and the nasturtiums
+of the arbour. Ah! he was gone, the only charm of her life, the only
+possible hope of joy. Why had she not seized this happiness when it came
+to her? Why not have kept hold of it with both hands, with both knees,
+when it was about to flee from her? And she cursed herself for not
+having loved Leon. She thirsted for his lips. The wish took possession
+of her to run after and rejoin him, throw herself into his arms and
+say to him, “It is I; I am yours.” But Emma recoiled beforehand at the
+difficulties of the enterprise, and her desires, increased by regret,
+became only the more acute.
+
+Henceforth the memory of Leon was the centre of her boredom; it burnt
+there more brightly than the fire travellers have left on the snow of
+a Russian steppe. She sprang towards him, she pressed against him, she
+stirred carefully the dying embers, sought all around her anything
+that could revive it; and the most distant reminiscences, like the most
+immediate occasions, what she experienced as well as what she imagined,
+her voluptuous desires that were unsatisfied, her projects of happiness
+that crackled in the wind like dead boughs, her sterile virtue, her
+lost hopes, the domestic tete-a-tete--she gathered it all up, took
+everything, and made it all serve as fuel for her melancholy.
+
+The flames, however, subsided, either because the supply had exhausted
+itself, or because it had been piled up too much. Love, little by
+little, was quelled by absence; regret stifled beneath habit; and this
+incendiary light that had empurpled her pale sky was overspread and
+faded by degrees. In the supineness of her conscience she even took her
+repugnance towards her husband for aspirations towards her lover, the
+burning of hate for the warmth of tenderness; but as the tempest still
+raged, and as passion burnt itself down to the very cinders, and no help
+came, no sun rose, there was night on all sides, and she was lost in the
+terrible cold that pierced her.
+
+Then the evil days of Tostes began again. She thought herself now far
+more unhappy; for she had the experience of grief, with the certainty
+that it would not end.
+
+A woman who had laid on herself such sacrifices could well allow herself
+certain whims. She bought a Gothic prie-dieu, and in a month spent
+fourteen francs on lemons for polishing her nails; she wrote to Rouen
+for a blue cashmere gown; she chose one of Lheureux’s finest scarves,
+and wore it knotted around her waist over her dressing-gown; and, with
+closed blinds and a book in her hand, she lay stretched out on a couch
+in this garb.
+
+She often changed her coiffure; she did her hair a la Chinoise, in
+flowing curls, in plaited coils; she parted in on one side and rolled it
+under like a man’s.
+
+She wanted to learn Italian; she bought dictionaries, a grammar, and
+a supply of white paper. She tried serious reading, history, and
+philosophy. Sometimes in the night Charles woke up with a start,
+thinking he was being called to a patient. “I’m coming,” he stammered;
+and it was the noise of a match Emma had struck to relight the lamp. But
+her reading fared like her piece of embroidery, all of which, only just
+begun, filled her cupboard; she took it up, left it, passed on to other
+books.
+
+She had attacks in which she could easily have been driven to commit any
+folly. She maintained one day, in opposition to her husband, that she
+could drink off a large glass of brandy, and, as Charles was stupid
+enough to dare her to, she swallowed the brandy to the last drop.
+
+In spite of her vapourish airs (as the housewives of Yonville called
+them), Emma, all the same, never seemed gay, and usually she had at the
+corners of her mouth that immobile contraction that puckers the faces of
+old maids, and those of men whose ambition has failed. She was pale all
+over, white as a sheet; the skin of her nose was drawn at the nostrils,
+her eyes looked at you vaguely. After discovering three grey hairs on
+her temples, she talked much of her old age.
+
+She often fainted. One day she even spat blood, and, as Charles fussed
+around her showing his anxiety--
+
+“Bah!” she answered, “what does it matter?”
+
+Charles fled to his study and wept there, both his elbows on the table,
+sitting in an arm-chair at his bureau under the phrenological head.
+
+Then he wrote to his mother begging her to come, and they had many long
+consultations together on the subject of Emma.
+
+What should they decide? What was to be done since she rejected all
+medical treatment? “Do you know what your wife wants?” replied Madame
+Bovary senior.
+
+“She wants to be forced to occupy herself with some manual work. If she
+were obliged, like so many others, to earn her living, she wouldn’t have
+these vapours, that come to her from a lot of ideas she stuffs into her
+head, and from the idleness in which she lives.”
+
+“Yet she is always busy,” said Charles.
+
+“Ah! always busy at what? Reading novels, bad books, works against
+religion, and in which they mock at priests in speeches taken from
+Voltaire. But all that leads you far astray, my poor child. Anyone who
+has no religion always ends by turning out badly.”
+
+So it was decided to stop Emma reading novels. The enterprise did not
+seem easy. The good lady undertook it. She was, when she passed through
+Rouen, to go herself to the lending-library and represent that Emma had
+discontinued her subscription. Would they not have a right to apply
+to the police if the librarian persisted all the same in his poisonous
+trade? The farewells of mother and daughter-in-law were cold. During
+the three weeks that they had been together they had not exchanged
+half-a-dozen words apart from the inquiries and phrases when they met at
+table and in the evening before going to bed.
+
+Madame Bovary left on a Wednesday, the market-day at Yonville.
+
+The Place since morning had been blocked by a row of carts, which, on
+end and their shafts in the air, spread all along the line of houses
+from the church to the inn. On the other side there were canvas booths,
+where cotton checks, blankets, and woollen stockings were sold,
+together with harness for horses, and packets of blue ribbon, whose ends
+fluttered in the wind. The coarse hardware was spread out on the ground
+between pyramids of eggs and hampers of cheeses, from which sticky straw
+stuck out.
+
+Near the corn-machines clucking hens passed their necks through the bars
+of flat cages. The people, crowding in the same place and unwilling
+to move thence, sometimes threatened to smash the shop front of the
+chemist. On Wednesdays his shop was never empty, and the people pushed
+in less to buy drugs than for consultations. So great was Homais’
+reputation in the neighbouring villages. His robust aplomb had
+fascinated the rustics. They considered him a greater doctor than all
+the doctors.
+
+Emma was leaning out at the window; she was often there. The window in
+the provinces replaces the theatre and the promenade, she was amusing
+herself with watching the crowd of boors when she saw a gentleman in
+a green velvet coat. He had on yellow gloves, although he wore heavy
+gaiters; he was coming towards the doctor’s house, followed by a peasant
+walking with a bent head and quite a thoughtful air.
+
+“Can I see the doctor?” he asked Justin, who was talking on the
+doorsteps with Felicite, and, taking him for a servant of the
+house--“Tell him that Monsieur Rodolphe Boulanger of La Huchette is
+here.”
+
+It was not from territorial vanity that the new arrival added “of La
+Huchette” to his name, but to make himself the better known.
+
+La Huchette, in fact, was an estate near Yonville, where he had just
+bought the chateau and two farms that he cultivated himself, without,
+however, troubling very much about them. He lived as a bachelor, and was
+supposed to have “at least fifteen thousand francs a year.”
+
+Charles came into the room. Monsieur Boulanger introduced his man, who
+wanted to be bled because he felt “a tingling all over.”
+
+“That’ll purge me,” he urged as an objection to all reasoning.
+
+So Bovary ordered a bandage and a basin, and asked Justin to hold it.
+Then addressing the peasant, who was already pale--
+
+“Don’t be afraid, my lad.”
+
+“No, no, sir,” said the other; “get on.”
+
+And with an air of bravado he held out his great arm. At the prick of
+the lancet the blood spurted out, splashing against the looking-glass.
+
+“Hold the basin nearer,” exclaimed Charles.
+
+“Lor!” said the peasant, “one would swear it was a little fountain
+flowing. How red my blood is! That’s a good sign, isn’t it?”
+
+“Sometimes,” answered the doctor, “one feels nothing at first, and then
+syncope sets in, and more especially with people of strong constitution
+like this man.”
+
+At these words the rustic let go the lancet-case he was twisting between
+his fingers. A shudder of his shoulders made the chair-back creak. His
+hat fell off.
+
+“I thought as much,” said Bovary, pressing his finger on the vein.
+
+The basin was beginning to tremble in Justin’s hands; his knees shook,
+he turned pale.
+
+“Emma! Emma!” called Charles.
+
+With one bound she came down the staircase.
+
+“Some vinegar,” he cried. “O dear! two at once!”
+
+And in his emotion he could hardly put on the compress.
+
+“It is nothing,” said Monsieur Boulanger quietly, taking Justin in his
+arms. He seated him on the table with his back resting against the wall.
+
+Madame Bovary began taking off his cravat. The strings of his shirt had
+got into a knot, and she was for some minutes moving her light fingers
+about the young fellow’s neck. Then she poured some vinegar on her
+cambric handkerchief; she moistened his temples with little dabs, and
+then blew upon them softly. The ploughman revived, but Justin’s syncope
+still lasted, and his eyeballs disappeared in the pale sclerotics like
+blue flowers in milk.
+
+“We must hide this from him,” said Charles.
+
+Madame Bovary took the basin to put it under the table. With the
+movement she made in bending down, her dress (it was a summer dress with
+four flounces, yellow, long in the waist and wide in the skirt) spread
+out around her on the flags of the room; and as Emma stooping, staggered
+a little as she stretched out her arms.
+
+The stuff here and there gave with the inflections of her bust.
+
+Then she went to fetch a bottle of water, and she was melting some
+pieces of sugar when the chemist arrived. The servant had been to
+fetch him in the tumult. Seeing his pupil’s eyes staring he drew a long
+breath; then going around him he looked at him from head to foot.
+
+“Fool!” he said, “really a little fool! A fool in four letters! A
+phlebotomy’s a big affair, isn’t it! And a fellow who isn’t afraid of
+anything; a kind of squirrel, just as he is who climbs to vertiginous
+heights to shake down nuts. Oh, yes! you just talk to me, boast about
+yourself! Here’s a fine fitness for practising pharmacy later on; for
+under serious circumstances you may be called before the tribunals in
+order to enlighten the minds of the magistrates, and you would have to
+keep your head then, to reason, show yourself a man, or else pass for an
+imbecile.”
+
+Justin did not answer. The chemist went on--
+
+“Who asked you to come? You are always pestering the doctor and madame.
+On Wednesday, moreover, your presence is indispensable to me. There are
+now twenty people in the shop. I left everything because of the interest
+I take in you. Come, get along! Sharp! Wait for me, and keep an eye on
+the jars.”
+
+When Justin, who was rearranging his dress, had gone, they talked for a
+little while about fainting-fits. Madame Bovary had never fainted.
+
+“That is extraordinary for a lady,” said Monsieur Boulanger; “but some
+people are very susceptible. Thus in a duel, I have seen a second lose
+consciousness at the mere sound of the loading of pistols.”
+
+“For my part,” said the chemist, “the sight of other people’s blood
+doesn’t affect me at all, but the mere thought of my own flowing would
+make me faint if I reflected upon it too much.”
+
+Monsieur Boulanger, however, dismissed his servant, advising him to calm
+himself, since his fancy was over.
+
+“It procured me the advantage of making your acquaintance,” he added,
+and he looked at Emma as he said this. Then he put three francs on the
+corner of the table, bowed negligently, and went out.
+
+He was soon on the other side of the river (this was his way back to La
+Huchette), and Emma saw him in the meadow, walking under the poplars,
+slackening his pace now and then as one who reflects.
+
+“She is very pretty,” he said to himself; “she is very pretty, this
+doctor’s wife. Fine teeth, black eyes, a dainty foot, a figure like a
+Parisienne’s. Where the devil does she come from? Wherever did that fat
+fellow pick her up?”
+
+Monsieur Rodolphe Boulanger was thirty-four; he was of brutal
+temperament and intelligent perspicacity, having, moreover, had much to
+do with women, and knowing them well. This one had seemed pretty to him;
+so he was thinking about her and her husband.
+
+“I think he is very stupid. She is tired of him, no doubt. He has dirty
+nails, and hasn’t shaved for three days. While he is trotting after his
+patients, she sits there botching socks. And she gets bored! She would
+like to live in town and dance polkas every evening. Poor little woman!
+She is gaping after love like a carp after water on a kitchen-table.
+With three words of gallantry she’d adore one, I’m sure of it. She’d be
+tender, charming. Yes; but how to get rid of her afterwards?”
+
+Then the difficulties of love-making seen in the distance made him by
+contrast think of his mistress. She was an actress at Rouen, whom he
+kept; and when he had pondered over this image, with which, even in
+remembrance, he was satiated--
+
+“Ah! Madame Bovary,” he thought, “is much prettier, especially fresher.
+Virginie is decidedly beginning to grow fat. She is so finiky about her
+pleasures; and, besides, she has a mania for prawns.”
+
+The fields were empty, and around him Rodolphe only heard the regular
+beating of the grass striking against his boots, with a cry of the
+grasshopper hidden at a distance among the oats. He again saw Emma in
+her room, dressed as he had seen her, and he undressed her.
+
+“Oh, I will have her,” he cried, striking a blow with his stick at a
+clod in front of him. And he at once began to consider the political
+part of the enterprise. He asked himself--
+
+“Where shall we meet? By what means? We shall always be having the brat
+on our hands, and the servant, the neighbours, and husband, all sorts of
+worries. Pshaw! one would lose too much time over it.”
+
+Then he resumed, “She really has eyes that pierce one’s heart like a
+gimlet. And that pale complexion! I adore pale women!”
+
+When he reached the top of the Arguiel hills he had made up his mind.
+“It’s only finding the opportunities. Well, I will call in now and then.
+I’ll send them venison, poultry; I’ll have myself bled, if need be. We
+shall become friends; I’ll invite them to my place. By Jove!” added he,
+“there’s the agricultural show coming on. She’ll be there. I shall see
+her. We’ll begin boldly, for that’s the surest way.”
+
+
+
+Chapter Eight
+
+At last it came, the famous agricultural show. On the morning of the
+solemnity all the inhabitants at their doors were chatting over the
+preparations. The pediment of the town hall had been hung with garlands
+of ivy; a tent had been erected in a meadow for the banquet; and in the
+middle of the Place, in front of the church, a kind of bombarde was
+to announce the arrival of the prefect and the names of the successful
+farmers who had obtained prizes. The National Guard of Buchy (there was
+none at Yonville) had come to join the corps of firemen, of whom Binet
+was captain. On that day he wore a collar even higher than usual; and,
+tightly buttoned in his tunic, his figure was so stiff and motionless
+that the whole vital portion of his person seemed to have descended into
+his legs, which rose in a cadence of set steps with a single movement.
+As there was some rivalry between the tax-collector and the colonel,
+both, to show off their talents, drilled their men separately. One
+saw the red epaulettes and the black breastplates pass and re-pass
+alternately; there was no end to it, and it constantly began again.
+There had never been such a display of pomp. Several citizens had
+scoured their houses the evening before; tri-coloured flags hung from
+half-open windows; all the public-houses were full; and in the lovely
+weather the starched caps, the golden crosses, and the coloured
+neckerchiefs seemed whiter than snow, shone in the sun, and relieved
+with the motley colours the sombre monotony of the frock-coats and blue
+smocks. The neighbouring farmers’ wives, when they got off their horses,
+pulled out the long pins that fastened around them their dresses, turned
+up for fear of mud; and the husbands, for their part, in order to save
+their hats, kept their handkerchiefs around them, holding one corner
+between their teeth.
+
+The crowd came into the main street from both ends of the village.
+People poured in from the lanes, the alleys, the houses; and from time
+to time one heard knockers banging against doors closing behind women
+with their gloves, who were going out to see the fete. What was most
+admired were two long lamp-stands covered with lanterns, that flanked a
+platform on which the authorities were to sit. Besides this there were
+against the four columns of the town hall four kinds of poles,
+each bearing a small standard of greenish cloth, embellished with
+inscriptions in gold letters.
+
+On one was written, “To Commerce”; on the other, “To Agriculture”; on
+the third, “To Industry”; and on the fourth, “To the Fine Arts.”
+
+But the jubilation that brightened all faces seemed to darken that of
+Madame Lefrancois, the innkeeper. Standing on her kitchen-steps she
+muttered to herself, “What rubbish! what rubbish! With their canvas
+booth! Do they think the prefect will be glad to dine down there under
+a tent like a gipsy? They call all this fussing doing good to the place!
+Then it wasn’t worth while sending to Neufchatel for the keeper of a
+cookshop! And for whom? For cowherds! tatterdemalions!”
+
+The druggist was passing. He had on a frock-coat, nankeen trousers,
+beaver shoes, and, for a wonder, a hat with a low crown.
+
+“Your servant! Excuse me, I am in a hurry.” And as the fat widow asked
+where he was going--
+
+“It seems odd to you, doesn’t it, I who am always more cooped up in my
+laboratory than the man’s rat in his cheese.”
+
+“What cheese?” asked the landlady.
+
+“Oh, nothing! nothing!” Homais continued. “I merely wished to convey
+to you, Madame Lefrancois, that I usually live at home like a recluse.
+To-day, however, considering the circumstances, it is necessary--”
+
+“Oh, you’re going down there!” she said contemptuously.
+
+“Yes, I am going,” replied the druggist, astonished. “Am I not a member
+of the consulting commission?”
+
+Mere Lefrancois looked at him for a few moments, and ended by saying
+with a smile--
+
+“That’s another pair of shoes! But what does agriculture matter to you?
+Do you understand anything about it?”
+
+“Certainly I understand it, since I am a druggist--that is to say,
+a chemist. And the object of chemistry, Madame Lefrancois, being the
+knowledge of the reciprocal and molecular action of all natural bodies,
+it follows that agriculture is comprised within its domain. And, in
+fact, the composition of the manure, the fermentation of liquids, the
+analyses of gases, and the influence of miasmata, what, I ask you, is
+all this, if it isn’t chemistry, pure and simple?”
+
+The landlady did not answer. Homais went on--
+
+“Do you think that to be an agriculturist it is necessary to have tilled
+the earth or fattened fowls oneself? It is necessary rather to know the
+composition of the substances in question--the geological strata, the
+atmospheric actions, the quality of the soil, the minerals, the waters,
+the density of the different bodies, their capillarity, and what not.
+And one must be master of all the principles of hygiene in order to
+direct, criticize the construction of buildings, the feeding of animals,
+the diet of domestics. And, moreover, Madame Lefrancois, one must know
+botany, be able to distinguish between plants, you understand, which are
+the wholesome and those that are deleterious, which are unproductive
+and which nutritive, if it is well to pull them up here and re-sow them
+there, to propagate some, destroy others; in brief, one must keep pace
+with science by means of pamphlets and public papers, be always on the
+alert to find out improvements.”
+
+The landlady never took her eyes off the “Cafe Francois” and the chemist
+went on--
+
+“Would to God our agriculturists were chemists, or that at least they
+would pay more attention to the counsels of science. Thus lately I
+myself wrote a considerable tract, a memoir of over seventy-two pages,
+entitled, ‘Cider, its Manufacture and its Effects, together with some
+New Reflections on the Subject,’ that I sent to the Agricultural Society
+of Rouen, and which even procured me the honour of being received among
+its members--Section, Agriculture; Class, Pomological. Well, if my
+work had been given to the public--” But the druggist stopped, Madame
+Lefrancois seemed so preoccupied.
+
+“Just look at them!” she said. “It’s past comprehension! Such a cookshop
+as that!” And with a shrug of the shoulders that stretched out over her
+breast the stitches of her knitted bodice, she pointed with both hands
+at her rival’s inn, whence songs were heard issuing. “Well, it won’t
+last long,” she added. “It’ll be over before a week.”
+
+Homais drew back with stupefaction. She came down three steps and
+whispered in his ear--
+
+“What! you didn’t know it? There is to be an execution in next week.
+It’s Lheureux who is selling him out; he has killed him with bills.”
+
+“What a terrible catastrophe!” cried the druggist, who always found
+expressions in harmony with all imaginable circumstances.
+
+Then the landlady began telling him the story that she had heard from
+Theodore, Monsieur Guillaumin’s servant, and although she detested
+Tellier, she blamed Lheureux. He was “a wheedler, a sneak.”
+
+“There!” she said. “Look at him! he is in the market; he is bowing to
+Madame Bovary, who’s got on a green bonnet. Why, she’s taking Monsieur
+Boulanger’s arm.”
+
+“Madame Bovary!” exclaimed Homais. “I must go at once and pay her my
+respects. Perhaps she’ll be very glad to have a seat in the enclosure
+under the peristyle.” And, without heeding Madame Lefrancois, who was
+calling him back to tell him more about it, the druggist walked off
+rapidly with a smile on his lips, with straight knees, bowing copiously
+to right and left, and taking up much room with the large tails of his
+frock-coat that fluttered behind him in the wind.
+
+Rodolphe, having caught sight of him from afar, hurried on, but Madame
+Bovary lost her breath; so he walked more slowly, and, smiling at her,
+said in a rough tone--
+
+“It’s only to get away from that fat fellow, you know, the druggist.”
+ She pressed his elbow.
+
+“What’s the meaning of that?” he asked himself. And he looked at her out
+of the corner of his eyes.
+
+Her profile was so calm that one could guess nothing from it. It stood
+out in the light from the oval of her bonnet, with pale ribbons on it
+like the leaves of weeds. Her eyes with their long curved lashes looked
+straight before her, and though wide open, they seemed slightly puckered
+by the cheek-bones, because of the blood pulsing gently under the
+delicate skin. A pink line ran along the partition between her nostrils.
+Her head was bent upon her shoulder, and the pearl tips of her white
+teeth were seen between her lips.
+
+“Is she making fun of me?” thought Rodolphe.
+
+Emma’s gesture, however, had only been meant for a warning; for Monsieur
+Lheureux was accompanying them, and spoke now and again as if to enter
+into the conversation.
+
+“What a superb day! Everybody is out! The wind is east!”
+
+And neither Madame Bovary nor Rodolphe answered him, whilst at the
+slightest movement made by them he drew near, saying, “I beg your
+pardon!” and raised his hat.
+
+When they reached the farrier’s house, instead of following the road
+up to the fence, Rodolphe suddenly turned down a path, drawing with him
+Madame Bovary. He called out--
+
+“Good evening, Monsieur Lheureux! See you again presently.”
+
+“How you got rid of him!” she said, laughing.
+
+“Why,” he went on, “allow oneself to be intruded upon by others? And as
+to-day I have the happiness of being with you--”
+
+Emma blushed. He did not finish his sentence. Then he talked of the fine
+weather and of the pleasure of walking on the grass. A few daisies had
+sprung up again.
+
+“Here are some pretty Easter daisies,” he said, “and enough of them to
+furnish oracles to all the amorous maids in the place.”
+
+He added, “Shall I pick some? What do you think?”
+
+“Are you in love?” she asked, coughing a little.
+
+“H’m, h’m! who knows?” answered Rodolphe.
+
+The meadow began to fill, and the housewives hustled you with their
+great umbrellas, their baskets, and their babies. One had often to get
+out of the way of a long file of country folk, servant-maids with blue
+stockings, flat shoes, silver rings, and who smelt of milk, when one
+passed close to them. They walked along holding one another by the hand,
+and thus they spread over the whole field from the row of open trees to
+the banquet tent.
+
+But this was the examination time, and the farmers one after the other
+entered a kind of enclosure formed by a long cord supported on sticks.
+
+The beasts were there, their noses towards the cord, and making a
+confused line with their unequal rumps. Drowsy pigs were burrowing in
+the earth with their snouts, calves were bleating, lambs baaing; the
+cows, on knees folded in, were stretching their bellies on the grass,
+slowly chewing the cud, and blinking their heavy eyelids at the gnats
+that buzzed round them. Plough-men with bare arms were holding by the
+halter prancing stallions that neighed with dilated nostrils looking
+towards the mares. These stood quietly, stretching out their heads and
+flowing manes, while their foals rested in their shadow, or now and then
+came and sucked them. And above the long undulation of these crowded
+animals one saw some white mane rising in the wind like a wave, or some
+sharp horns sticking out, and the heads of men running about. Apart,
+outside the enclosure, a hundred paces off, was a large black bull,
+muzzled, with an iron ring in its nostrils, and who moved no more than
+if he had been in bronze. A child in rags was holding him by a rope.
+
+Between the two lines the committee-men were walking with heavy steps,
+examining each animal, then consulting one another in a low voice. One
+who seemed of more importance now and then took notes in a book as he
+walked along. This was the president of the jury, Monsieur Derozerays de
+la Panville. As soon as he recognised Rodolphe he came forward quickly,
+and smiling amiably, said--
+
+“What! Monsieur Boulanger, you are deserting us?”
+
+Rodolphe protested that he was just coming. But when the president had
+disappeared--
+
+“Ma foi!*” said he, “I shall not go. Your company is better than his.”
+
+     *Upon my word!
+
+And while poking fun at the show, Rodolphe, to move about more easily,
+showed the gendarme his blue card, and even stopped now and then in
+front of some fine beast, which Madame Bovary did not at all admire.
+He noticed this, and began jeering at the Yonville ladies and their
+dresses; then he apologised for the negligence of his own. He had that
+incongruity of common and elegant in which the habitually vulgar think
+they see the revelation of an eccentric existence, of the perturbations
+of sentiment, the tyrannies of art, and always a certain contempt for
+social conventions, that seduces or exasperates them. Thus his cambric
+shirt with plaited cuffs was blown out by the wind in the opening of his
+waistcoat of grey ticking, and his broad-striped trousers disclosed at
+the ankle nankeen boots with patent leather gaiters.
+
+These were so polished that they reflected the grass. He trampled on
+horses’s dung with them, one hand in the pocket of his jacket and his
+straw hat on one side.
+
+“Besides,” added he, “when one lives in the country--”
+
+“It’s waste of time,” said Emma.
+
+“That is true,” replied Rodolphe. “To think that not one of these people
+is capable of understanding even the cut of a coat!”
+
+Then they talked about provincial mediocrity, of the lives it crushed,
+the illusions lost there.
+
+“And I too,” said Rodolphe, “am drifting into depression.”
+
+“You!” she said in astonishment; “I thought you very light-hearted.”
+
+“Ah! yes. I seem so, because in the midst of the world I know how to
+wear the mask of a scoffer upon my face; and yet, how many a time at the
+sight of a cemetery by moonlight have I not asked myself whether it were
+not better to join those sleeping there!”
+
+“Oh! and your friends?” she said. “You do not think of them.”
+
+“My friends! What friends? Have I any? Who cares for me?” And he
+accompanied the last words with a kind of whistling of the lips.
+
+But they were obliged to separate from each other because of a great
+pile of chairs that a man was carrying behind them. He was so overladen
+with them that one could only see the tips of his wooden shoes and the
+ends of his two outstretched arms. It was Lestiboudois, the gravedigger,
+who was carrying the church chairs about amongst the people. Alive to
+all that concerned his interests, he had hit upon this means of turning
+the show to account; and his idea was succeeding, for he no longer knew
+which way to turn. In fact, the villagers, who were hot, quarreled for
+these seats, whose straw smelt of incense, and they leant against the
+thick backs, stained with the wax of candles, with a certain veneration.
+
+Madame Bovary again took Rodolphe’s arm; he went on as if speaking to
+himself--
+
+“Yes, I have missed so many things. Always alone! Ah! if I had some aim
+in life, if I had met some love, if I had found someone! Oh, how I would
+have spent all the energy of which I am capable, surmounted everything,
+overcome everything!”
+
+“Yet it seems to me,” said Emma, “that you are not to be pitied.”
+
+“Ah! you think so?” said Rodolphe.
+
+“For, after all,” she went on, “you are free--” she hesitated, “rich--”
+
+“Do not mock me,” he replied.
+
+And she protested that she was not mocking him, when the report of a
+cannon resounded. Immediately all began hustling one another pell-mell
+towards the village.
+
+It was a false alarm. The prefect seemed not to be coming, and the
+members of the jury felt much embarrassed, not knowing if they ought to
+begin the meeting or still wait.
+
+At last at the end of the Place a large hired landau appeared, drawn by
+two thin horses, which a coachman in a white hat was whipping lustily.
+Binet had only just time to shout, “Present arms!” and the colonel to
+imitate him. All ran towards the enclosure; everyone pushed forward. A
+few even forgot their collars; but the equipage of the prefect seemed
+to anticipate the crowd, and the two yoked jades, trapesing in their
+harness, came up at a little trot in front of the peristyle of the town
+hall at the very moment when the National Guard and firemen deployed,
+beating drums and marking time.
+
+“Present!” shouted Binet.
+
+“Halt!” shouted the colonel. “Left about, march.”
+
+And after presenting arms, during which the clang of the band, letting
+loose, rang out like a brass kettle rolling downstairs, all the guns
+were lowered. Then was seen stepping down from the carriage a gentleman
+in a short coat with silver braiding, with bald brow, and wearing a tuft
+of hair at the back of his head, of a sallow complexion and the most
+benign appearance. His eyes, very large and covered by heavy lids, were
+half-closed to look at the crowd, while at the same time he raised his
+sharp nose, and forced a smile upon his sunken mouth. He recognised the
+mayor by his scarf, and explained to him that the prefect was not able
+to come. He himself was a councillor at the prefecture; then he added
+a few apologies. Monsieur Tuvache answered them with compliments; the
+other confessed himself nervous; and they remained thus, face to face,
+their foreheads almost touching, with the members of the jury all round,
+the municipal council, the notable personages, the National Guard and
+the crowd. The councillor pressing his little cocked hat to his
+breast repeated his bows, while Tuvache, bent like a bow, also smiled,
+stammered, tried to say something, protested his devotion to the
+monarchy and the honour that was being done to Yonville.
+
+Hippolyte, the groom from the inn, took the head of the horses from the
+coachman, and, limping along with his club-foot, led them to the door
+of the “Lion d’Or”, where a number of peasants collected to look at the
+carriage. The drum beat, the howitzer thundered, and the gentlemen one
+by one mounted the platform, where they sat down in red utrecht velvet
+arm-chairs that had been lent by Madame Tuvache.
+
+All these people looked alike. Their fair flabby faces, somewhat tanned
+by the sun, were the colour of sweet cider, and their puffy whiskers
+emerged from stiff collars, kept up by white cravats with broad bows.
+All the waist-coats were of velvet, double-breasted; all the watches
+had, at the end of a long ribbon, an oval cornelian seal; everyone
+rested his two hands on his thighs, carefully stretching the stride of
+their trousers, whose unsponged glossy cloth shone more brilliantly than
+the leather of their heavy boots.
+
+The ladies of the company stood at the back under the vestibule between
+the pillars while the common herd was opposite, standing up or sitting
+on chairs. As a matter of fact, Lestiboudois had brought thither all
+those that he had moved from the field, and he even kept running back
+every minute to fetch others from the church. He caused such confusion
+with this piece of business that one had great difficulty in getting to
+the small steps of the platform.
+
+“I think,” said Monsieur Lheureux to the chemist, who was passing to his
+place, “that they ought to have put up two Venetian masts with something
+rather severe and rich for ornaments; it would have been a very pretty
+effect.”
+
+“To be sure,” replied Homais; “but what can you expect? The mayor took
+everything on his own shoulders. He hasn’t much taste. Poor Tuvache! and
+he is even completely destitute of what is called the genius of art.”
+
+Rodolphe, meanwhile, with Madame Bovary, had gone up to the first
+floor of the town hall, to the “council-room,” and, as it was empty,
+he declared that they could enjoy the sight there more comfortably. He
+fetched three stools from the round table under the bust of the monarch,
+and having carried them to one of the windows, they sat down by each
+other.
+
+There was commotion on the platform, long whisperings, much parleying.
+At last the councillor got up. They knew now that his name was Lieuvain,
+and in the crowd the name was passed from one to the other. After he had
+collated a few pages, and bent over them to see better, he began--
+
+“Gentlemen! May I be permitted first of all (before addressing you on
+the object of our meeting to-day, and this sentiment will, I am sure, be
+shared by you all), may I be permitted, I say, to pay a tribute to the
+higher administration, to the government to the monarch, gentle men, our
+sovereign, to that beloved king, to whom no branch of public or private
+prosperity is a matter of indifference, and who directs with a hand at
+once so firm and wise the chariot of the state amid the incessant perils
+of a stormy sea, knowing, moreover, how to make peace respected as well
+as war, industry, commerce, agriculture, and the fine arts?”
+
+“I ought,” said Rodolphe, “to get back a little further.”
+
+“Why?” said Emma.
+
+But at this moment the voice of the councillor rose to an extraordinary
+pitch. He declaimed--
+
+“This is no longer the time, gentlemen, when civil discord ensanguined
+our public places, when the landlord, the business-man, the working-man
+himself, falling asleep at night, lying down to peaceful sleep, trembled
+lest he should be awakened suddenly by the noise of incendiary tocsins,
+when the most subversive doctrines audaciously sapped foundations.”
+
+“Well, someone down there might see me,” Rodolphe resumed, “then
+I should have to invent excuses for a fortnight; and with my bad
+reputation--”
+
+“Oh, you are slandering yourself,” said Emma.
+
+“No! It is dreadful, I assure you.”
+
+“But, gentlemen,” continued the councillor, “if, banishing from my
+memory the remembrance of these sad pictures, I carry my eyes back
+to the actual situation of our dear country, what do I see there?
+Everywhere commerce and the arts are flourishing; everywhere new means
+of communication, like so many new arteries in the body of the state,
+establish within it new relations. Our great industrial centres have
+recovered all their activity; religion, more consolidated, smiles in
+all hearts; our ports are full, confidence is born again, and France
+breathes once more!”
+
+“Besides,” added Rodolphe, “perhaps from the world’s point of view they
+are right.”
+
+“How so?” she asked.
+
+“What!” said he. “Do you not know that there are souls constantly
+tormented? They need by turns to dream and to act, the purest passions
+and the most turbulent joys, and thus they fling themselves into all
+sorts of fantasies, of follies.”
+
+Then she looked at him as one looks at a traveller who has voyaged over
+strange lands, and went on--
+
+“We have not even this distraction, we poor women!”
+
+“A sad distraction, for happiness isn’t found in it.”
+
+“But is it ever found?” she asked.
+
+“Yes; one day it comes,” he answered.
+
+“And this is what you have understood,” said the councillor.
+
+“You, farmers, agricultural labourers! you pacific pioneers of a work
+that belongs wholly to civilization! you, men of progress and morality,
+you have understood, I say, that political storms are even more
+redoubtable than atmospheric disturbances!”
+
+“It comes one day,” repeated Rodolphe, “one day suddenly, and when
+one is despairing of it. Then the horizon expands; it is as if a voice
+cried, ‘It is here!’ You feel the need of confiding the whole of your
+life, of giving everything, sacrificing everything to this being. There
+is no need for explanations; they understand one another. They have seen
+each other in dreams!”
+
+(And he looked at her.) “In fine, here it is, this treasure so sought
+after, here before you. It glitters, it flashes; yet one still doubts,
+one does not believe it; one remains dazzled, as if one went out from
+darkness into light.”
+
+And as he ended Rodolphe suited the action to the word. He passed his
+hand over his face, like a man seized with giddiness. Then he let it
+fall on Emma’s. She took hers away.
+
+“And who would be surprised at it, gentlemen? He only who is so blind,
+so plunged (I do not fear to say it), so plunged in the prejudices
+of another age as still to misunderstand the spirit of agricultural
+populations. Where, indeed, is to be found more patriotism than in the
+country, greater devotion to the public welfare, more intelligence, in a
+word? And, gentlemen, I do not mean that superficial intelligence,
+vain ornament of idle minds, but rather that profound and balanced
+intelligence that applies itself above all else to useful objects, thus
+contributing to the good of all, to the common amelioration and to
+the support of the state, born of respect for law and the practice of
+duty--”
+
+“Ah! again!” said Rodolphe. “Always ‘duty.’ I am sick of the word.
+They are a lot of old blockheads in flannel vests and of old women with
+foot-warmers and rosaries who constantly drone into our ears ‘Duty,
+duty!’ Ah! by Jove! one’s duty is to feel what is great, cherish the
+beautiful, and not accept all the conventions of society with the
+ignominy that it imposes upon us.”
+
+“Yet--yet--” objected Madame Bovary.
+
+“No, no! Why cry out against the passions? Are they not the one
+beautiful thing on the earth, the source of heroism, of enthusiasm, of
+poetry, music, the arts, of everything, in a word?”
+
+“But one must,” said Emma, “to some extent bow to the opinion of the
+world and accept its moral code.”
+
+“Ah! but there are two,” he replied. “The small, the conventional, that
+of men, that which constantly changes, that brays out so loudly, that
+makes such a commotion here below, of the earth earthly, like the mass
+of imbeciles you see down there. But the other, the eternal, that is
+about us and above, like the landscape that surrounds us, and the blue
+heavens that give us light.”
+
+Monsieur Lieuvain had just wiped his mouth with a pocket-handkerchief.
+He continued--
+
+“And what should I do here gentlemen, pointing out to you the uses
+of agriculture? Who supplies our wants? Who provides our means of
+subsistence? Is it not the agriculturist? The agriculturist, gentlemen,
+who, sowing with laborious hand the fertile furrows of the country,
+brings forth the corn, which, being ground, is made into a powder by
+means of ingenious machinery, comes out thence under the name of flour,
+and from there, transported to our cities, is soon delivered at the
+baker’s, who makes it into food for poor and rich alike. Again, is it
+not the agriculturist who fattens, for our clothes, his abundant
+flocks in the pastures? For how should we clothe ourselves, how nourish
+ourselves, without the agriculturist? And, gentlemen, is it even
+necessary to go so far for examples? Who has not frequently reflected
+on all the momentous things that we get out of that modest animal, the
+ornament of poultry-yards, that provides us at once with a soft pillow
+for our bed, with succulent flesh for our tables, and eggs? But I should
+never end if I were to enumerate one after the other all the different
+products which the earth, well cultivated, like a generous mother,
+lavishes upon her children. Here it is the vine, elsewhere the apple
+tree for cider, there colza, farther on cheeses and flax. Gentlemen, let
+us not forget flax, which has made such great strides of late years, and
+to which I will more particularly call your attention.”
+
+He had no need to call it, for all the mouths of the multitude were wide
+open, as if to drink in his words. Tuvache by his side listened to him
+with staring eyes. Monsieur Derozerays from time to time softly closed
+his eyelids, and farther on the chemist, with his son Napoleon between
+his knees, put his hand behind his ear in order not to lose a syllable.
+The chins of the other members of the jury went slowly up and down in
+their waistcoats in sign of approval. The firemen at the foot of the
+platform rested on their bayonets; and Binet, motionless, stood with
+out-turned elbows, the point of his sabre in the air. Perhaps he could
+hear, but certainly he could see nothing, because of the visor of his
+helmet, that fell down on his nose. His lieutenant, the youngest son of
+Monsieur Tuvache, had a bigger one, for his was enormous, and shook on
+his head, and from it an end of his cotton scarf peeped out. He smiled
+beneath it with a perfectly infantine sweetness, and his pale little
+face, whence drops were running, wore an expression of enjoyment and
+sleepiness.
+
+The square as far as the houses was crowded with people. One saw folk
+leaning on their elbows at all the windows, others standing at doors,
+and Justin, in front of the chemist’s shop, seemed quite transfixed by
+the sight of what he was looking at. In spite of the silence Monsieur
+Lieuvain’s voice was lost in the air. It reached you in fragments of
+phrases, and interrupted here and there by the creaking of chairs in the
+crowd; then you suddenly heard the long bellowing of an ox, or else the
+bleating of the lambs, who answered one another at street corners. In
+fact, the cowherds and shepherds had driven their beasts thus far, and
+these lowed from time to time, while with their tongues they tore down
+some scrap of foliage that hung above their mouths.
+
+Rodolphe had drawn nearer to Emma, and said to her in a low voice,
+speaking rapidly--
+
+“Does not this conspiracy of the world revolt you? Is there a single
+sentiment it does not condemn? The noblest instincts, the purest
+sympathies are persecuted, slandered; and if at length two poor souls do
+meet, all is so organised that they cannot blend together. Yet they will
+make the attempt; they will flutter their wings; they will call upon
+each other. Oh! no matter. Sooner or later, in six months, ten years,
+they will come together, will love; for fate has decreed it, and they
+are born one for the other.”
+
+His arms were folded across his knees, and thus lifting his face towards
+Emma, close by her, he looked fixedly at her. She noticed in his eyes
+small golden lines radiating from black pupils; she even smelt the
+perfume of the pomade that made his hair glossy.
+
+Then a faintness came over her; she recalled the Viscount who had
+waltzed with her at Vaubyessard, and his beard exhaled like this air an
+odour of vanilla and citron, and mechanically she half-closed her eyes
+the better to breathe it in. But in making this movement, as she leant
+back in her chair, she saw in the distance, right on the line of the
+horizon, the old diligence, the “Hirondelle,” that was slowly descending
+the hill of Leux, dragging after it a long trail of dust. It was in this
+yellow carriage that Leon had so often come back to her, and by this
+route down there that he had gone for ever. She fancied she saw him
+opposite at his windows; then all grew confused; clouds gathered; it
+seemed to her that she was again turning in the waltz under the light of
+the lustres on the arm of the Viscount, and that Leon was not far away,
+that he was coming; and yet all the time she was conscious of the scent
+of Rodolphe’s head by her side. This sweetness of sensation pierced
+through her old desires, and these, like grains of sand under a gust
+of wind, eddied to and fro in the subtle breath of the perfume which
+suffused her soul. She opened wide her nostrils several times to drink
+in the freshness of the ivy round the capitals. She took off her gloves,
+she wiped her hands, then fanned her face with her handkerchief, while
+athwart the throbbing of her temples she heard the murmur of the
+crowd and the voice of the councillor intoning his phrases. He
+said--“Continue, persevere; listen neither to the suggestions of
+routine, nor to the over-hasty councils of a rash empiricism.
+
+“Apply yourselves, above all, to the amelioration of the soil, to good
+manures, to the development of the equine, bovine, ovine, and porcine
+races. Let these shows be to you pacific arenas, where the victor in
+leaving it will hold forth a hand to the vanquished, and will fraternise
+with him in the hope of better success. And you, aged servants, humble
+domestics, whose hard labour no Government up to this day has taken into
+consideration, come hither to receive the reward of your silent virtues,
+and be assured that the state henceforward has its eye upon you; that it
+encourages you, protects you; that it will accede to your just
+demands, and alleviate as much as in it lies the burden of your painful
+sacrifices.”
+
+Monsieur Lieuvain then sat down; Monsieur Derozerays got up, beginning
+another speech. His was not perhaps so florid as that of the councillor,
+but it recommended itself by a more direct style, that is to say, by
+more special knowledge and more elevated considerations. Thus the praise
+of the Government took up less space in it; religion and agriculture
+more. He showed in it the relations of these two, and how they had
+always contributed to civilisation. Rodolphe with Madame Bovary was
+talking dreams, presentiments, magnetism. Going back to the cradle of
+society, the orator painted those fierce times when men lived on acorns
+in the heart of woods. Then they had left off the skins of beasts, had
+put on cloth, tilled the soil, planted the vine. Was this a good, and
+in this discovery was there not more of injury than of gain? Monsieur
+Derozerays set himself this problem. From magnetism little by little
+Rodolphe had come to affinities, and while the president was citing
+Cincinnatus and his plough, Diocletian, planting his cabbages, and the
+Emperors of China inaugurating the year by the sowing of seed, the
+young man was explaining to the young woman that these irresistible
+attractions find their cause in some previous state of existence.
+
+“Thus we,” he said, “why did we come to know one another? What chance
+willed it? It was because across the infinite, like two streams that
+flow but to unite; our special bents of mind had driven us towards each
+other.”
+
+And he seized her hand; she did not withdraw it.
+
+“For good farming generally!” cried the president.
+
+“Just now, for example, when I went to your house.”
+
+“To Monsieur Bizat of Quincampoix.”
+
+“Did I know I should accompany you?”
+
+“Seventy francs.”
+
+“A hundred times I wished to go; and I followed you--I remained.”
+
+“Manures!”
+
+“And I shall remain to-night, to-morrow, all other days, all my life!”
+
+“To Monsieur Caron of Argueil, a gold medal!”
+
+“For I have never in the society of any other person found so complete a
+charm.”
+
+“To Monsieur Bain of Givry-Saint-Martin.”
+
+“And I shall carry away with me the remembrance of you.”
+
+“For a merino ram!”
+
+“But you will forget me; I shall pass away like a shadow.”
+
+“To Monsieur Belot of Notre-Dame.”
+
+“Oh, no! I shall be something in your thought, in your life, shall I
+not?”
+
+“Porcine race; prizes--equal, to Messrs. Leherisse and Cullembourg,
+sixty francs!”
+
+Rodolphe was pressing her hand, and he felt it all warm and quivering
+like a captive dove that wants to fly away; but, whether she was trying
+to take it away or whether she was answering his pressure; she made a
+movement with her fingers. He exclaimed--
+
+“Oh, I thank you! You do not repulse me! You are good! You understand
+that I am yours! Let me look at you; let me contemplate you!”
+
+A gust of wind that blew in at the window ruffled the cloth on the
+table, and in the square below all the great caps of the peasant women
+were uplifted by it like the wings of white butterflies fluttering.
+
+“Use of oil-cakes,” continued the president. He was hurrying on:
+“Flemish manure-flax-growing-drainage-long leases-domestic service.”
+
+Rodolphe was no longer speaking. They looked at one another. A supreme
+desire made their dry lips tremble, and wearily, without an effort,
+their fingers intertwined.
+
+“Catherine Nicaise Elizabeth Leroux, of Sassetot-la-Guerriere, for
+fifty-four years of service at the same farm, a silver medal--value,
+twenty-five francs!”
+
+“Where is Catherine Leroux?” repeated the councillor.
+
+She did not present herself, and one could hear voices whispering--
+
+“Go up!”
+
+“Don’t be afraid!”
+
+“Oh, how stupid she is!”
+
+“Well, is she there?” cried Tuvache.
+
+“Yes; here she is.”
+
+“Then let her come up!”
+
+Then there came forward on the platform a little old woman with timid
+bearing, who seemed to shrink within her poor clothes. On her feet she
+wore heavy wooden clogs, and from her hips hung a large blue apron. Her
+pale face framed in a borderless cap was more wrinkled than a withered
+russet apple. And from the sleeves of her red jacket looked out two
+large hands with knotty joints, the dust of barns, the potash of washing
+the grease of wools had so encrusted, roughened, hardened these that
+they seemed dirty, although they had been rinsed in clear water; and
+by dint of long service they remained half open, as if to bear humble
+witness for themselves of so much suffering endured. Something of
+monastic rigidity dignified her face. Nothing of sadness or of emotion
+weakened that pale look. In her constant living with animals she had
+caught their dumbness and their calm. It was the first time that she
+found herself in the midst of so large a company, and inwardly scared by
+the flags, the drums, the gentlemen in frock-coats, and the order of the
+councillor, she stood motionless, not knowing whether to advance or run
+away, nor why the crowd was pushing her and the jury were smiling at
+her.
+
+Thus stood before these radiant bourgeois this half-century of
+servitude.
+
+“Approach, venerable Catherine Nicaise Elizabeth Leroux!” said the
+councillor, who had taken the list of prize-winners from the president;
+and, looking at the piece of paper and the old woman by turns, he
+repeated in a fatherly tone--“Approach! approach!”
+
+“Are you deaf?” said Tuvache, fidgeting in his armchair; and he began
+shouting in her ear, “Fifty-four years of service. A silver medal!
+Twenty-five francs! For you!”
+
+Then, when she had her medal, she looked at it, and a smile of beatitude
+spread over her face; and as she walked away they could hear her
+muttering “I’ll give it to our cure up home, to say some masses for me!”
+
+“What fanaticism!” exclaimed the chemist, leaning across to the notary.
+
+The meeting was over, the crowd dispersed, and now that the speeches had
+been read, each one fell back into his place again, and everything into
+the old grooves; the masters bullied the servants, and these struck the
+animals, indolent victors, going back to the stalls, a green-crown on
+their horns.
+
+The National Guards, however, had gone up to the first floor of the
+town hall with buns spitted on their bayonets, and the drummer of the
+battalion carried a basket with bottles. Madame Bovary took Rodolphe’s
+arm; he saw her home; they separated at her door; then he walked about
+alone in the meadow while he waited for the time of the banquet.
+
+The feast was long, noisy, ill served; the guests were so crowded that
+they could hardly move their elbows; and the narrow planks used for
+forms almost broke down under their weight. They ate hugely. Each one
+stuffed himself on his own account. Sweat stood on every brow, and a
+whitish steam, like the vapour of a stream on an autumn morning, floated
+above the table between the hanging lamps. Rodolphe, leaning against
+the calico of the tent was thinking so earnestly of Emma that he heard
+nothing. Behind him on the grass the servants were piling up the dirty
+plates, his neighbours were talking; he did not answer them; they filled
+his glass, and there was silence in his thoughts in spite of the growing
+noise. He was dreaming of what she had said, of the line of her lips;
+her face, as in a magic mirror, shone on the plates of the shakos, the
+folds of her gown fell along the walls, and days of love unrolled to all
+infinity before him in the vistas of the future.
+
+He saw her again in the evening during the fireworks, but she was with
+her husband, Madame Homais, and the druggist, who was worrying about the
+danger of stray rockets, and every moment he left the company to go and
+give some advice to Binet.
+
+The pyrotechnic pieces sent to Monsieur Tuvache had, through an excess
+of caution, been shut up in his cellar, and so the damp powder would
+not light, and the principal set piece, that was to represent a dragon
+biting his tail, failed completely. Now and then a meagre Roman-candle
+went off; then the gaping crowd sent up a shout that mingled with the
+cry of the women, whose waists were being squeezed in the darkness. Emma
+silently nestled against Charles’s shoulder; then, raising her chin, she
+watched the luminous rays of the rockets against the dark sky. Rodolphe
+gazed at her in the light of the burning lanterns.
+
+They went out one by one. The stars shone out. A few crops of rain began
+to fall. She knotted her fichu round her bare head.
+
+At this moment the councillor’s carriage came out from the inn.
+
+His coachman, who was drunk, suddenly dozed off, and one could see from
+the distance, above the hood, between the two lanterns, the mass of his
+body, that swayed from right to left with the giving of the traces.
+
+“Truly,” said the druggist, “one ought to proceed most rigorously
+against drunkenness! I should like to see written up weekly at the door
+of the town hall on a board ad hoc* the names of all those who during
+the week got intoxicated on alcohol. Besides, with regard to statistics,
+one would thus have, as it were, public records that one could refer to
+in case of need. But excuse me!”
+
+     *Specifically for that.
+
+And he once more ran off to the captain. The latter was going back to
+see his lathe again.
+
+“Perhaps you would not do ill,” Homais said to him, “to send one of your
+men, or to go yourself--”
+
+“Leave me alone!” answered the tax-collector. “It’s all right!”
+
+“Do not be uneasy,” said the druggist, when he returned to his friends.
+“Monsieur Binet has assured me that all precautions have been taken. No
+sparks have fallen; the pumps are full. Let us go to rest.”
+
+“Ma foi! I want it,” said Madame Homais, yawning at large. “But never
+mind; we’ve had a beautiful day for our fete.”
+
+Rodolphe repeated in a low voice, and with a tender look, “Oh, yes! very
+beautiful!”
+
+And having bowed to one another, they separated.
+
+Two days later, in the “Final de Rouen,” there was a long article on the
+show. Homais had composed it with verve the very next morning.
+
+“Why these festoons, these flowers, these garlands? Whither hurries this
+crowd like the waves of a furious sea under the torrents of a tropical
+sun pouring its heat upon our heads?”
+
+Then he spoke of the condition of the peasants. Certainly the Government
+was doing much, but not enough. “Courage!” he cried to it; “a thousand
+reforms are indispensable; let us accomplish them!” Then touching on
+the entry of the councillor, he did not forget “the martial air of our
+militia;” nor “our most merry village maidens;” nor the “bald-headed old
+men like patriarchs who were there, and of whom some, the remnants of
+our phalanxes, still felt their hearts beat at the manly sound of the
+drums.” He cited himself among the first of the members of the jury,
+and he even called attention in a note to the fact that Monsieur Homais,
+chemist, had sent a memoir on cider to the agricultural society.
+
+When he came to the distribution of the prizes, he painted the joy of
+the prize-winners in dithyrambic strophes. “The father embraced the son,
+the brother the brother, the husband his consort. More than one showed
+his humble medal with pride; and no doubt when he got home to his good
+housewife, he hung it up weeping on the modest walls of his cot.
+
+“About six o’clock a banquet prepared in the meadow of Monsieur Leigeard
+brought together the principal personages of the fete. The greatest
+cordiality reigned here. Divers toasts were proposed: Monsieur
+Lieuvain, the King; Monsieur Tuvache, the Prefect; Monsieur Derozerays,
+Agriculture; Monsieur Homais, Industry and the Fine Arts, those twin
+sisters; Monsieur Leplichey, Progress. In the evening some brilliant
+fireworks on a sudden illumined the air. One would have called it a
+veritable kaleidoscope, a real operatic scene; and for a moment our
+little locality might have thought itself transported into the midst of
+a dream of the ‘Thousand and One Nights.’ Let us state that no untoward
+event disturbed this family meeting.” And he added “Only the absence
+of the clergy was remarked. No doubt the priests understand progress in
+another fashion. Just as you please, messieurs the followers of Loyola!”
+
+
+
+Chapter Nine
+
+Six weeks passed. Rodolphe did not come again. At last one evening he
+appeared.
+
+The day after the show he had said to himself--“We mustn’t go back too
+soon; that would be a mistake.”
+
+And at the end of a week he had gone off hunting. After the hunting he
+had thought it was too late, and then he reasoned thus--
+
+“If from the first day she loved me, she must from impatience to see me
+again love me more. Let’s go on with it!”
+
+And he knew that his calculation had been right when, on entering the
+room, he saw Emma turn pale.
+
+She was alone. The day was drawing in. The small muslin curtain along
+the windows deepened the twilight, and the gilding of the barometer, on
+which the rays of the sun fell, shone in the looking-glass between the
+meshes of the coral.
+
+Rodolphe remained standing, and Emma hardly answered his first
+conventional phrases.
+
+“I,” he said, “have been busy. I have been ill.”
+
+“Seriously?” she cried.
+
+“Well,” said Rodolphe, sitting down at her side on a footstool, “no; it
+was because I did not want to come back.”
+
+“Why?”
+
+“Can you not guess?”
+
+He looked at her again, but so hard that she lowered her head, blushing.
+He went on--
+
+“Emma!”
+
+“Sir,” she said, drawing back a little.
+
+“Ah! you see,” replied he in a melancholy voice, “that I was right not
+to come back; for this name, this name that fills my whole soul, and
+that escaped me, you forbid me to use! Madame Bovary! why all the
+world calls you thus! Besides, it is not your name; it is the name of
+another!”
+
+He repeated, “of another!” And he hid his face in his hands.
+
+“Yes, I think of you constantly. The memory of you drives me to despair.
+Ah! forgive me! I will leave you! Farewell! I will go far away, so far
+that you will never hear of me again; and yet--to-day--I know not what
+force impelled me towards you. For one does not struggle against Heaven;
+one cannot resist the smile of angels; one is carried away by that which
+is beautiful, charming, adorable.”
+
+It was the first time that Emma had heard such words spoken to herself,
+and her pride, like one who reposes bathed in warmth, expanded softly
+and fully at this glowing language.
+
+“But if I did not come,” he continued, “if I could not see you, at least
+I have gazed long on all that surrounds you. At night-every night-I
+arose; I came hither; I watched your house, its glimmering in the moon,
+the trees in the garden swaying before your window, and the little lamp,
+a gleam shining through the window-panes in the darkness. Ah! you never
+knew that there, so near you, so far from you, was a poor wretch!”
+
+She turned towards him with a sob.
+
+“Oh, you are good!” she said.
+
+“No, I love you, that is all! You do not doubt that! Tell me--one
+word--only one word!”
+
+And Rodolphe imperceptibly glided from the footstool to the ground; but
+a sound of wooden shoes was heard in the kitchen, and he noticed the
+door of the room was not closed.
+
+“How kind it would be of you,” he went on, rising, “if you would humour
+a whim of mine.” It was to go over her house; he wanted to know it; and
+Madame Bovary seeing no objection to this, they both rose, when Charles
+came in.
+
+“Good morning, doctor,” Rodolphe said to him.
+
+The doctor, flattered at this unexpected title, launched out into
+obsequious phrases. Of this the other took advantage to pull himself
+together a little.
+
+“Madame was speaking to me,” he then said, “about her health.”
+
+Charles interrupted him; he had indeed a thousand anxieties; his wife’s
+palpitations of the heart were beginning again. Then Rodolphe asked if
+riding would not be good.
+
+“Certainly! excellent! just the thing! There’s an idea! You ought to
+follow it up.”
+
+And as she objected that she had no horse, Monsieur Rodolphe offered
+one. She refused his offer; he did not insist. Then to explain his visit
+he said that his ploughman, the man of the blood-letting, still suffered
+from giddiness.
+
+“I’ll call around,” said Bovary.
+
+“No, no! I’ll send him to you; we’ll come; that will be more convenient
+for you.”
+
+“Ah! very good! I thank you.”
+
+And as soon as they were alone, “Why don’t you accept Monsieur
+Boulanger’s kind offer?”
+
+She assumed a sulky air, invented a thousand excuses, and finally
+declared that perhaps it would look odd.
+
+“Well, what the deuce do I care for that?” said Charles, making a
+pirouette. “Health before everything! You are wrong.”
+
+“And how do you think I can ride when I haven’t got a habit?”
+
+“You must order one,” he answered.
+
+The riding-habit decided her.
+
+When the habit was ready, Charles wrote to Monsieur Boulanger that his
+wife was at his command, and that they counted on his good-nature.
+
+The next day at noon Rodolphe appeared at Charles’s door with two
+saddle-horses. One had pink rosettes at his ears and a deerskin
+side-saddle.
+
+Rodolphe had put on high soft boots, saying to himself that no doubt she
+had never seen anything like them. In fact, Emma was charmed with his
+appearance as he stood on the landing in his great velvet coat and white
+corduroy breeches. She was ready; she was waiting for him.
+
+Justin escaped from the chemist’s to see her start, and the chemist also
+came out. He was giving Monsieur Boulanger a little good advice.
+
+“An accident happens so easily. Be careful! Your horses perhaps are
+mettlesome.”
+
+She heard a noise above her; it was Felicite drumming on the windowpanes
+to amuse little Berthe. The child blew her a kiss; her mother answered
+with a wave of her whip.
+
+“A pleasant ride!” cried Monsieur Homais. “Prudence! above all,
+prudence!” And he flourished his newspaper as he saw them disappear.
+
+As soon as he felt the ground, Emma’s horse set off at a gallop.
+
+Rodolphe galloped by her side. Now and then they exchanged a word. Her
+figure slightly bent, her hand well up, and her right arm stretched out,
+she gave herself up to the cadence of the movement that rocked her in
+her saddle. At the bottom of the hill Rodolphe gave his horse its head;
+they started together at a bound, then at the top suddenly the horses
+stopped, and her large blue veil fell about her.
+
+It was early in October. There was fog over the land. Hazy clouds
+hovered on the horizon between the outlines of the hills; others, rent
+asunder, floated up and disappeared. Sometimes through a rift in the
+clouds, beneath a ray of sunshine, gleamed from afar the roots of
+Yonville, with the gardens at the water’s edge, the yards, the walls and
+the church steeple. Emma half closed her eyes to pick out her house, and
+never had this poor village where she lived appeared so small. From the
+height on which they were the whole valley seemed an immense pale lake
+sending off its vapour into the air. Clumps of trees here and there
+stood out like black rocks, and the tall lines of the poplars that rose
+above the mist were like a beach stirred by the wind.
+
+By the side, on the turf between the pines, a brown light shimmered
+in the warm atmosphere. The earth, ruddy like the powder of tobacco,
+deadened the noise of their steps, and with the edge of their shoes the
+horses as they walked kicked the fallen fir cones in front of them.
+
+Rodolphe and Emma thus went along the skirt of the wood. She turned
+away from time to time to avoid his look, and then she saw only the pine
+trunks in lines, whose monotonous succession made her a little giddy.
+The horses were panting; the leather of the saddles creaked.
+
+Just as they were entering the forest the sun shone out.
+
+“God protects us!” said Rodolphe.
+
+“Do you think so?” she said.
+
+“Forward! forward!” he continued.
+
+He “tchk’d” with his tongue. The two beasts set off at a trot.
+
+Long ferns by the roadside caught in Emma’s stirrup.
+
+Rodolphe leant forward and removed them as they rode along. At other
+times, to turn aside the branches, he passed close to her, and Emma felt
+his knee brushing against her leg. The sky was now blue, the leaves no
+longer stirred. There were spaces full of heather in flower, and plots
+of violets alternated with the confused patches of the trees that were
+grey, fawn, or golden coloured, according to the nature of their leaves.
+Often in the thicket was heard the fluttering of wings, or else the
+hoarse, soft cry of the ravens flying off amidst the oaks.
+
+They dismounted. Rodolphe fastened up the horses. She walked on in
+front on the moss between the paths. But her long habit got in her way,
+although she held it up by the skirt; and Rodolphe, walking behind her,
+saw between the black cloth and the black shoe the fineness of her white
+stocking, that seemed to him as if it were a part of her nakedness.
+
+She stopped. “I am tired,” she said.
+
+“Come, try again,” he went on. “Courage!”
+
+Then some hundred paces farther on she again stopped, and through her
+veil, that fell sideways from her man’s hat over her hips, her face
+appeared in a bluish transparency as if she were floating under azure
+waves.
+
+“But where are we going?”
+
+He did not answer. She was breathing irregularly. Rodolphe looked round
+him biting his moustache. They came to a larger space where the coppice
+had been cut. They sat down on the trunk of a fallen tree, and Rodolphe
+began speaking to her of his love. He did not begin by frightening her
+with compliments. He was calm, serious, melancholy.
+
+Emma listened to him with bowed head, and stirred the bits of wood on
+the ground with the tip of her foot. But at the words, “Are not our
+destinies now one?”
+
+“Oh, no!” she replied. “You know that well. It is impossible!” She rose
+to go. He seized her by the wrist. She stopped. Then, having gazed
+at him for a few moments with an amorous and humid look, she said
+hurriedly--
+
+“Ah! do not speak of it again! Where are the horses? Let us go back.”
+
+He made a gesture of anger and annoyance. She repeated:
+
+“Where are the horses? Where are the horses?”
+
+Then smiling a strange smile, his pupil fixed, his teeth set, he
+advanced with outstretched arms. She recoiled trembling. She stammered:
+
+“Oh, you frighten me! You hurt me! Let me go!”
+
+“If it must be,” he went on, his face changing; and he again became
+respectful, caressing, timid. She gave him her arm. They went back. He
+said--
+
+“What was the matter with you? Why? I do not understand. You were
+mistaken, no doubt. In my soul you are as a Madonna on a pedestal, in
+a place lofty, secure, immaculate. But I need you to live! I must have
+your eyes, your voice, your thought! Be my friend, my sister, my angel!”
+
+And he put out his arm round her waist. She feebly tried to disengage
+herself. He supported her thus as they walked along.
+
+But they heard the two horses browsing on the leaves.
+
+“Oh! one moment!” said Rodolphe. “Do not let us go! Stay!”
+
+He drew her farther on to a small pool where duckweeds made a greenness
+on the water. Faded water lilies lay motionless between the reeds.
+At the noise of their steps in the grass, frogs jumped away to hide
+themselves.
+
+“I am wrong! I am wrong!” she said. “I am mad to listen to you!”
+
+“Why? Emma! Emma!”
+
+“Oh, Rodolphe!” said the young woman slowly, leaning on his shoulder.
+
+The cloth of her habit caught against the velvet of his coat. She threw
+back her white neck, swelling with a sigh, and faltering, in tears, with
+a long shudder and hiding her face, she gave herself up to him--
+
+The shades of night were falling; the horizontal sun passing between the
+branches dazzled the eyes. Here and there around her, in the leaves
+or on the ground, trembled luminous patches, as it hummingbirds flying
+about had scattered their feathers. Silence was everywhere; something
+sweet seemed to come forth from the trees; she felt her heart, whose
+beating had begun again, and the blood coursing through her flesh like a
+stream of milk. Then far away, beyond the wood, on the other hills, she
+heard a vague prolonged cry, a voice which lingered, and in silence she
+heard it mingling like music with the last pulsations of her throbbing
+nerves. Rodolphe, a cigar between his lips, was mending with his
+penknife one of the two broken bridles.
+
+They returned to Yonville by the same road. On the mud they saw again
+the traces of their horses side by side, the same thickets, the same
+stones to the grass; nothing around them seemed changed; and yet for her
+something had happened more stupendous than if the mountains had moved
+in their places. Rodolphe now and again bent forward and took her hand
+to kiss it.
+
+She was charming on horseback--upright, with her slender waist, her knee
+bent on the mane of her horse, her face somewhat flushed by the fresh
+air in the red of the evening.
+
+On entering Yonville she made her horse prance in the road. People
+looked at her from the windows.
+
+At dinner her husband thought she looked well, but she pretended not to
+hear him when he inquired about her ride, and she remained sitting there
+with her elbow at the side of her plate between the two lighted candles.
+
+“Emma!” he said.
+
+“What?”
+
+“Well, I spent the afternoon at Monsieur Alexandre’s. He has an old cob,
+still very fine, only a little broken-kneed, and that could be bought; I
+am sure, for a hundred crowns.” He added, “And thinking it might please
+you, I have bespoken it--bought it. Have I done right? Do tell me?”
+
+She nodded her head in assent; then a quarter of an hour later--
+
+“Are you going out to-night?” she asked.
+
+“Yes. Why?”
+
+“Oh, nothing, nothing, my dear!”
+
+And as soon as she had got rid of Charles she went and shut herself up
+in her room.
+
+At first she felt stunned; she saw the trees, the paths, the ditches,
+Rodolphe, and she again felt the pressure of his arm, while the leaves
+rustled and the reeds whistled.
+
+But when she saw herself in the glass she wondered at her face. Never
+had her eyes been so large, so black, of so profound a depth. Something
+subtle about her being transfigured her. She repeated, “I have a lover!
+a lover!” delighting at the idea as if a second puberty had come to her.
+So at last she was to know those joys of love, that fever of happiness
+of which she had despaired! She was entering upon marvels where all
+would be passion, ecstasy, delirium. An azure infinity encompassed
+her, the heights of sentiment sparkled under her thought, and ordinary
+existence appeared only afar off, down below in the shade, through the
+interspaces of these heights.
+
+Then she recalled the heroines of the books that she had read, and the
+lyric legion of these adulterous women began to sing in her memory with
+the voice of sisters that charmed her. She became herself, as it were,
+an actual part of these imaginings, and realised the love-dream of her
+youth as she saw herself in this type of amorous women whom she had
+so envied. Besides, Emma felt a satisfaction of revenge. Had she not
+suffered enough? But now she triumphed, and the love so long pent up
+burst forth in full joyous bubblings. She tasted it without remorse,
+without anxiety, without trouble.
+
+The day following passed with a new sweetness. They made vows to one
+another She told him of her sorrows. Rodolphe interrupted her with
+kisses; and she looking at him through half-closed eyes, asked him to
+call her again by her name--to say that he loved her They were in the
+forest, as yesterday, in the shed of some woodenshoe maker. The walls
+were of straw, and the roof so low they had to stoop. They were seated
+side by side on a bed of dry leaves.
+
+From that day forth they wrote to one another regularly every evening.
+Emma placed her letter at the end of the garden, by the river, in a
+fissure of the wall. Rodolphe came to fetch it, and put another there,
+that she always found fault with as too short.
+
+One morning, when Charles had gone out before day break, she was seized
+with the fancy to see Rodolphe at once. She would go quickly to La
+Huchette, stay there an hour, and be back again at Yonville while
+everyone was still asleep. This idea made her pant with desire, and she
+soon found herself in the middle of the field, walking with rapid steps,
+without looking behind her.
+
+Day was just breaking. Emma from afar recognised her lover’s house. Its
+two dove-tailed weathercocks stood out black against the pale dawn.
+
+Beyond the farmyard there was a detached building that she thought must
+be the chateau She entered--it was if the doors at her approach had
+opened wide of their own accord. A large straight staircase led up to
+the corridor. Emma raised the latch of a door, and suddenly at the end
+of the room she saw a man sleeping. It was Rodolphe. She uttered a cry.
+
+“You here? You here?” he repeated. “How did you manage to come? Ah! your
+dress is damp.”
+
+“I love you,” she answered, throwing her arms about his neck.
+
+This first piece of daring successful, now every time Charles went out
+early Emma dressed quickly and slipped on tiptoe down the steps that led
+to the waterside.
+
+But when the plank for the cows was taken up, she had to go by the walls
+alongside of the river; the bank was slippery; in order not to fall
+she caught hold of the tufts of faded wallflowers. Then she went across
+ploughed fields, in which she sank, stumbling; and clogging her thin
+shoes. Her scarf, knotted round her head, fluttered to the wind in the
+meadows. She was afraid of the oxen; she began to run; she arrived out
+of breath, with rosy cheeks, and breathing out from her whole person a
+fresh perfume of sap, of verdure, of the open air. At this hour Rodolphe
+still slept. It was like a spring morning coming into his room.
+
+The yellow curtains along the windows let a heavy, whitish light enter
+softly. Emma felt about, opening and closing her eyes, while the drops
+of dew hanging from her hair formed, as it were, a topaz aureole around
+her face. Rodolphe, laughing, drew her to him, and pressed her to his
+breast.
+
+Then she examined the apartment, opened the drawers of the tables,
+combed her hair with his comb, and looked at herself in his
+shaving-glass. Often she even put between her teeth the big pipe that
+lay on the table by the bed, amongst lemons and pieces of sugar near a
+bottle of water.
+
+It took them a good quarter of an hour to say goodbye. Then Emma cried.
+She would have wished never to leave Rodolphe. Something stronger than
+herself forced her to him; so much so, that one day, seeing her come
+unexpectedly, he frowned as one put out.
+
+“What is the matter with you?” she said. “Are you ill? Tell me!”
+
+At last he declared with a serious air that her visits were becoming
+imprudent--that she was compromising herself.
+
+
+
+Chapter Ten
+
+Gradually Rodolphe’s fears took possession of her. At first, love had
+intoxicated her; and she had thought of nothing beyond. But now that he
+was indispensable to her life, she feared to lose anything of this, or
+even that it should be disturbed. When she came back from his house she
+looked all about her, anxiously watching every form that passed in the
+horizon, and every village window from which she could be seen. She
+listened for steps, cries, the noise of the ploughs, and she stopped
+short, white, and trembling more than the aspen leaves swaying overhead.
+
+One morning as she was thus returning, she suddenly thought she saw the
+long barrel of a carbine that seemed to be aimed at her. It stuck out
+sideways from the end of a small tub half-buried in the grass on the
+edge of a ditch. Emma, half-fainting with terror, nevertheless walked
+on, and a man stepped out of the tub like a Jack-in-the-box. He had
+gaiters buckled up to the knees, his cap pulled down over his eyes,
+trembling lips, and a red nose. It was Captain Binet lying in ambush for
+wild ducks.
+
+“You ought to have called out long ago!” he exclaimed; “When one sees a
+gun, one should always give warning.”
+
+The tax-collector was thus trying to hide the fright he had had, for
+a prefectorial order having prohibited duckhunting except in boats,
+Monsieur Binet, despite his respect for the laws, was infringing them,
+and so he every moment expected to see the rural guard turn up. But
+this anxiety whetted his pleasure, and, all alone in his tub, he
+congratulated himself on his luck and on his cuteness. At sight of
+Emma he seemed relieved from a great weight, and at once entered upon a
+conversation.
+
+“It isn’t warm; it’s nipping.”
+
+Emma answered nothing. He went on--
+
+“And you’re out so early?”
+
+“Yes,” she said stammering; “I am just coming from the nurse where my
+child is.”
+
+“Ah! very good! very good! For myself, I am here, just as you see me,
+since break of day; but the weather is so muggy, that unless one had the
+bird at the mouth of the gun--”
+
+“Good evening, Monsieur Binet,” she interrupted him, turning on her
+heel.
+
+“Your servant, madame,” he replied drily; and he went back into his tub.
+
+Emma regretted having left the tax-collector so abruptly. No doubt he
+would form unfavourable conjectures. The story about the nurse was the
+worst possible excuse, everyone at Yonville knowing that the little
+Bovary had been at home with her parents for a year. Besides, no one
+was living in this direction; this path led only to La Huchette. Binet,
+then, would guess whence she came, and he would not keep silence; he
+would talk, that was certain. She remained until evening racking her
+brain with every conceivable lying project, and had constantly before
+her eyes that imbecile with the game-bag.
+
+Charles after dinner, seeing her gloomy, proposed, by way of
+distraction, to take her to the chemist’s, and the first person she
+caught sight of in the shop was the taxcollector again. He was standing
+in front of the counter, lit up by the gleams of the red bottle, and was
+saying--
+
+“Please give me half an ounce of vitriol.”
+
+“Justin,” cried the druggist, “bring us the sulphuric acid.” Then to
+Emma, who was going up to Madame Homais’ room, “No, stay here; it isn’t
+worth while going up; she is just coming down. Warm yourself at the
+stove in the meantime. Excuse me. Good-day, doctor,” (for the chemist
+much enjoyed pronouncing the word “doctor,” as if addressing another by
+it reflected on himself some of the grandeur that he found in it). “Now,
+take care not to upset the mortars! You’d better fetch some chairs from
+the little room; you know very well that the arm-chairs are not to be
+taken out of the drawing-room.”
+
+And to put his arm-chair back in its place he was darting away from the
+counter, when Binet asked him for half an ounce of sugar acid.
+
+“Sugar acid!” said the chemist contemptuously, “don’t know it; I’m
+ignorant of it! But perhaps you want oxalic acid. It is oxalic acid,
+isn’t it?”
+
+Binet explained that he wanted a corrosive to make himself some
+copperwater with which to remove rust from his hunting things.
+
+Emma shuddered. The chemist began saying--
+
+“Indeed the weather is not propitious on account of the damp.”
+
+“Nevertheless,” replied the tax-collector, with a sly look, “there are
+people who like it.”
+
+She was stifling.
+
+“And give me--”
+
+“Will he never go?” thought she.
+
+“Half an ounce of resin and turpentine, four ounces of yellow wax,
+and three half ounces of animal charcoal, if you please, to clean the
+varnished leather of my togs.”
+
+The druggist was beginning to cut the wax when Madame Homais appeared,
+Irma in her arms, Napoleon by her side, and Athalie following. She sat
+down on the velvet seat by the window, and the lad squatted down on a
+footstool, while his eldest sister hovered round the jujube box near
+her papa. The latter was filling funnels and corking phials, sticking on
+labels, making up parcels. Around him all were silent; only from time
+to time, were heard the weights jingling in the balance, and a few low
+words from the chemist giving directions to his pupil.
+
+“And how’s the little woman?” suddenly asked Madame Homais.
+
+“Silence!” exclaimed her husband, who was writing down some figures in
+his waste-book.
+
+“Why didn’t you bring her?” she went on in a low voice.
+
+“Hush! hush!” said Emma, pointing with her finger to the druggist.
+
+But Binet, quite absorbed in looking over his bill, had probably heard
+nothing. At last he went out. Then Emma, relieved, uttered a deep sigh.
+
+“How hard you are breathing!” said Madame Homais.
+
+“Well, you see, it’s rather warm,” she replied.
+
+So the next day they talked over how to arrange their rendezvous. Emma
+wanted to bribe her servant with a present, but it would be better to
+find some safe house at Yonville. Rodolphe promised to look for one.
+
+All through the winter, three or four times a week, in the dead of night
+he came to the garden. Emma had on purpose taken away the key of the
+gate, which Charles thought lost.
+
+To call her, Rodolphe threw a sprinkle of sand at the shutters. She
+jumped up with a start; but sometimes he had to wait, for Charles had a
+mania for chatting by the fireside, and he would not stop. She was wild
+with impatience; if her eyes could have done it, she would have hurled
+him out at the window. At last she would begin to undress, then take up
+a book, and go on reading very quietly as if the book amused her. But
+Charles, who was in bed, called to her to come too.
+
+“Come, now, Emma,” he said, “it is time.”
+
+“Yes, I am coming,” she answered.
+
+Then, as the candles dazzled him; he turned to the wall and fell asleep.
+She escaped, smiling, palpitating, undressed. Rodolphe had a large
+cloak; he wrapped her in it, and putting his arm round her waist, he
+drew her without a word to the end of the garden.
+
+It was in the arbour, on the same seat of old sticks where formerly Leon
+had looked at her so amorously on the summer evenings. She never thought
+of him now.
+
+The stars shone through the leafless jasmine branches. Behind them they
+heard the river flowing, and now and again on the bank the rustling
+of the dry reeds. Masses of shadow here and there loomed out in the
+darkness, and sometimes, vibrating with one movement, they rose up and
+swayed like immense black waves pressing forward to engulf them. The
+cold of the nights made them clasp closer; the sighs of their lips
+seemed to them deeper; their eyes that they could hardly see, larger;
+and in the midst of the silence low words were spoken that fell on
+their souls sonorous, crystalline, and that reverberated in multiplied
+vibrations.
+
+When the night was rainy, they took refuge in the consulting-room
+between the cart-shed and the stable. She lighted one of the kitchen
+candles that she had hidden behind the books. Rodolphe settled down
+there as if at home. The sight of the library, of the bureau, of the
+whole apartment, in fine, excited his merriment, and he could not
+refrain from making jokes about Charles, which rather embarrassed Emma.
+She would have liked to see him more serious, and even on occasions
+more dramatic; as, for example, when she thought she heard a noise of
+approaching steps in the alley.
+
+“Someone is coming!” she said.
+
+He blew out the light.
+
+“Have you your pistols?”
+
+“Why?”
+
+“Why, to defend yourself,” replied Emma.
+
+“From your husband? Oh, poor devil!” And Rodolphe finished his sentence
+with a gesture that said, “I could crush him with a flip of my finger.”
+
+She was wonder-stricken at his bravery, although she felt in it a sort
+of indecency and a naive coarseness that scandalised her.
+
+Rodolphe reflected a good deal on the affair of the pistols. If she had
+spoken seriously, it was very ridiculous, he thought, even odious; for
+he had no reason to hate the good Charles, not being what is called
+devoured by jealousy; and on this subject Emma had taken a great vow
+that he did not think in the best of taste.
+
+Besides, she was growing very sentimental. She had insisted on
+exchanging miniatures; they had cut off handfuls of hair, and now she
+was asking for a ring--a real wedding-ring, in sign of an eternal union.
+She often spoke to him of the evening chimes, of the voices of nature.
+Then she talked to him of her mother--hers! and of his mother--his!
+Rodolphe had lost his twenty years ago. Emma none the less consoled
+him with caressing words as one would have done a lost child, and she
+sometimes even said to him, gazing at the moon--
+
+“I am sure that above there together they approve of our love.”
+
+But she was so pretty. He had possessed so few women of such
+ingenuousness. This love without debauchery was a new experience for
+him, and, drawing him out of his lazy habits, caressed at once his pride
+and his sensuality. Emma’s enthusiasm, which his bourgeois good sense
+disdained, seemed to him in his heart of hearts charming, since it
+was lavished on him. Then, sure of being loved, he no longer kept up
+appearances, and insensibly his ways changed.
+
+He had no longer, as formerly, words so gentle that they made her cry,
+nor passionate caresses that made her mad, so that their great love,
+which engrossed her life, seemed to lessen beneath her like the water of
+a stream absorbed into its channel, and she could see the bed of it.
+She would not believe it; she redoubled in tenderness, and Rodolphe
+concealed his indifference less and less.
+
+She did not know if she regretted having yielded to him, or whether she
+did not wish, on the contrary, to enjoy him the more. The humiliation
+of feeling herself weak was turning to rancour, tempered by their
+voluptuous pleasures. It was not affection; it was like a continual
+seduction. He subjugated her; she almost feared him.
+
+Appearances, nevertheless, were calmer than ever, Rodolphe having
+succeeded in carrying out the adultery after his own fancy; and at the
+end of six months, when the spring-time came, they were to one another
+like a married couple, tranquilly keeping up a domestic flame.
+
+It was the time of year when old Rouault sent his turkey in remembrance
+of the setting of his leg. The present always arrived with a letter.
+Emma cut the string that tied it to the basket, and read the following
+lines:--
+
+“My Dear Children--I hope this will find you well, and that this one
+will be as good as the others. For it seems to me a little more tender,
+if I may venture to say so, and heavier. But next time, for a change,
+I’ll give you a turkeycock, unless you have a preference for some dabs;
+and send me back the hamper, if you please, with the two old ones. I
+have had an accident with my cart-sheds, whose covering flew off one
+windy night among the trees. The harvest has not been overgood either.
+Finally, I don’t know when I shall come to see you. It is so difficult
+now to leave the house since I am alone, my poor Emma.”
+
+Here there was a break in the lines, as if the old fellow had dropped
+his pen to dream a little while.
+
+“For myself, I am very well, except for a cold I caught the other day at
+the fair at Yvetot, where I had gone to hire a shepherd, having turned
+away mine because he was too dainty. How we are to be pitied with such
+a lot of thieves! Besides, he was also rude. I heard from a pedlar, who,
+travelling through your part of the country this winter, had a tooth
+drawn, that Bovary was as usual working hard. That doesn’t surprise me;
+and he showed me his tooth; we had some coffee together. I asked him if
+he had seen you, and he said not, but that he had seen two horses in the
+stables, from which I conclude that business is looking up. So much
+the better, my dear children, and may God send you every imaginable
+happiness! It grieves me not yet to have seen my dear little
+grand-daughter, Berthe Bovary. I have planted an Orleans plum-tree for
+her in the garden under your room, and I won’t have it touched unless it
+is to have jam made for her by and bye, that I will keep in the cupboard
+for her when she comes.
+
+“Good-bye, my dear children. I kiss you, my girl, you too, my
+son-in-law, and the little one on both cheeks. I am, with best
+compliments, your loving father.
+
+“Theodore Rouault.”
+
+She held the coarse paper in her fingers for some minutes. The spelling
+mistakes were interwoven one with the other, and Emma followed the
+kindly thought that cackled right through it like a hen half hidden
+in the hedge of thorns. The writing had been dried with ashes from
+the hearth, for a little grey powder slipped from the letter on to her
+dress, and she almost thought she saw her father bending over the hearth
+to take up the tongs. How long since she had been with him, sitting on
+the footstool in the chimney-corner, where she used to burn the end of
+a bit of wood in the great flame of the sea-sedges! She remembered the
+summer evenings all full of sunshine. The colts neighed when anyone
+passed by, and galloped, galloped. Under her window there was a beehive,
+and sometimes the bees wheeling round in the light struck against her
+window like rebounding balls of gold. What happiness there had been
+at that time, what freedom, what hope! What an abundance of illusions!
+Nothing was left of them now. She had got rid of them all in her soul’s
+life, in all her successive conditions of life, maidenhood, her marriage,
+and her love--thus constantly losing them all her life through, like
+a traveller who leaves something of his wealth at every inn along his
+road.
+
+But what then, made her so unhappy? What was the extraordinary
+catastrophe that had transformed her? And she raised her head, looking
+round as if to seek the cause of that which made her suffer.
+
+An April ray was dancing on the china of the whatnot; the fire burned;
+beneath her slippers she felt the softness of the carpet; the day was
+bright, the air warm, and she heard her child shouting with laughter.
+
+In fact, the little girl was just then rolling on the lawn in the midst
+of the grass that was being turned. She was lying flat on her stomach
+at the top of a rick. The servant was holding her by her skirt.
+Lestiboudois was raking by her side, and every time he came near she
+lent forward, beating the air with both her arms.
+
+“Bring her to me,” said her mother, rushing to embrace her. “How I love
+you, my poor child! How I love you!”
+
+Then noticing that the tips of her ears were rather dirty, she rang at
+once for warm water, and washed her, changed her linen, her stockings,
+her shoes, asked a thousand questions about her health, as if on the
+return from a long journey, and finally, kissing her again and crying
+a little, she gave her back to the servant, who stood quite
+thunderstricken at this excess of tenderness.
+
+That evening Rodolphe found her more serious than usual.
+
+“That will pass over,” he concluded; “it’s a whim:”
+
+And he missed three rendezvous running. When he did come, she showed
+herself cold and almost contemptuous.
+
+“Ah! you’re losing your time, my lady!”
+
+And he pretended not to notice her melancholy sighs, nor the
+handkerchief she took out.
+
+Then Emma repented. She even asked herself why she detested Charles; if
+it had not been better to have been able to love him? But he gave her
+no opportunities for such a revival of sentiment, so that she was much
+embarrassed by her desire for sacrifice, when the druggist came just in
+time to provide her with an opportunity.
+
+
+
+Chapter Eleven
+
+He had recently read a eulogy on a new method for curing club-foot, and
+as he was a partisan of progress, he conceived the patriotic idea that
+Yonville, in order to keep to the fore, ought to have some operations
+for strephopody or club-foot.
+
+“For,” said he to Emma, “what risk is there? See--” (and he enumerated
+on his fingers the advantages of the attempt), “success, almost certain
+relief and beautifying of the patient, celebrity acquired by the
+operator. Why, for example, should not your husband relieve poor
+Hippolyte of the ‘Lion d’Or’? Note that he would not fail to tell about
+his cure to all the travellers, and then” (Homais lowered his voice and
+looked round him) “who is to prevent me from sending a short paragraph
+on the subject to the paper? Eh! goodness me! an article gets about; it
+is talked of; it ends by making a snowball! And who knows? who knows?”
+
+In fact, Bovary might succeed. Nothing proved to Emma that he was not
+clever; and what a satisfaction for her to have urged him to a step by
+which his reputation and fortune would be increased! She only wished to
+lean on something more solid than love.
+
+Charles, urged by the druggist and by her, allowed himself to be
+persuaded. He sent to Rouen for Dr. Duval’s volume, and every evening,
+holding his head between both hands, plunged into the reading of it.
+
+While he was studying equinus, varus, and valgus, that is to say,
+katastrephopody, endostrephopody, and exostrephopody (or better, the
+various turnings of the foot downwards, inwards, and outwards, with the
+hypostrephopody and anastrephopody), otherwise torsion downwards and
+upwards, Monsier Homais, with all sorts of arguments, was exhorting the
+lad at the inn to submit to the operation.
+
+“You will scarcely feel, probably, a slight pain; it is a simple prick,
+like a little blood-letting, less than the extraction of certain corns.”
+
+Hippolyte, reflecting, rolled his stupid eyes.
+
+“However,” continued the chemist, “it doesn’t concern me. It’s for your
+sake, for pure humanity! I should like to see you, my friend, rid of
+your hideous caudication, together with that waddling of the lumbar
+regions which, whatever you say, must considerably interfere with you in
+the exercise of your calling.”
+
+Then Homais represented to him how much jollier and brisker he would
+feel afterwards, and even gave him to understand that he would be more
+likely to please the women; and the stable-boy began to smile heavily.
+Then he attacked him through his vanity:
+
+“Aren’t you a man? Hang it! what would you have done if you had had to
+go into the army, to go and fight beneath the standard? Ah! Hippolyte!”
+
+And Homais retired, declaring that he could not understand this
+obstinacy, this blindness in refusing the benefactions of science.
+
+The poor fellow gave way, for it was like a conspiracy. Binet, who never
+interfered with other people’s business, Madame Lefrancois, Artemise,
+the neighbours, even the mayor, Monsieur Tuvache--everyone persuaded
+him, lectured him, shamed him; but what finally decided him was that it
+would cost him nothing. Bovary even undertook to provide the machine
+for the operation. This generosity was an idea of Emma’s, and Charles
+consented to it, thinking in his heart of hearts that his wife was an
+angel.
+
+So by the advice of the chemist, and after three fresh starts, he had a
+kind of box made by the carpenter, with the aid of the locksmith,
+that weighed about eight pounds, and in which iron, wood, sheer-iron,
+leather, screws, and nuts had not been spared.
+
+But to know which of Hippolyte’s tendons to cut, it was necessary first
+of all to find out what kind of club-foot he had.
+
+He had a foot forming almost a straight line with the leg, which,
+however, did not prevent it from being turned in, so that it was an
+equinus together with something of a varus, or else a slight varus with
+a strong tendency to equinus. But with this equinus, wide in foot like
+a horse’s hoof, with rugose skin, dry tendons, and large toes, on which
+the black nails looked as if made of iron, the clubfoot ran about like
+a deer from morn till night. He was constantly to be seen on the Place,
+jumping round the carts, thrusting his limping foot forwards. He seemed
+even stronger on that leg than the other. By dint of hard service it had
+acquired, as it were, moral qualities of patience and energy; and
+when he was given some heavy work, he stood on it in preference to its
+fellow.
+
+Now, as it was an equinus, it was necessary to cut the tendon of
+Achilles, and, if need were, the anterior tibial muscle could be seen to
+afterwards for getting rid of the varus; for the doctor did not dare to
+risk both operations at once; he was even trembling already for fear of
+injuring some important region that he did not know.
+
+Neither Ambrose Pare, applying for the first time since Celsus, after an
+interval of fifteen centuries, a ligature to an artery, nor Dupuytren,
+about to open an abscess in the brain, nor Gensoul when he first took
+away the superior maxilla, had hearts that trembled, hands that shook,
+minds so strained as Monsieur Bovary when he approached Hippolyte, his
+tenotome between his fingers. And as at hospitals, near by on a table
+lay a heap of lint, with waxed thread, many bandages--a pyramid of
+bandages--every bandage to be found at the druggist’s. It was Monsieur
+Homais who since morning had been organising all these preparations,
+as much to dazzle the multitude as to keep up his illusions. Charles
+pierced the skin; a dry crackling was heard. The tendon was cut, the
+operation over. Hippolyte could not get over his surprise, but bent over
+Bovary’s hands to cover them with kisses.
+
+“Come, be calm,” said the druggist; “later on you will show your
+gratitude to your benefactor.”
+
+And he went down to tell the result to five or six inquirers who were
+waiting in the yard, and who fancied that Hippolyte would reappear
+walking properly. Then Charles, having buckled his patient into the
+machine, went home, where Emma, all anxiety, awaited him at the door.
+She threw herself on his neck; they sat down to table; he ate much,
+and at dessert he even wanted to take a cup of coffee, a luxury he only
+permitted himself on Sundays when there was company.
+
+The evening was charming, full of prattle, of dreams together. They
+talked about their future fortune, of the improvements to be made in
+their house; he saw people’s estimation of him growing, his comforts
+increasing, his wife always loving him; and she was happy to refresh
+herself with a new sentiment, healthier, better, to feel at last some
+tenderness for this poor fellow who adored her. The thought of Rodolphe
+for one moment passed through her mind, but her eyes turned again to
+Charles; she even noticed with surprise that he had not bad teeth.
+
+They were in bed when Monsieur Homais, in spite of the servant, suddenly
+entered the room, holding in his hand a sheet of paper just written. It
+was the paragraph he intended for the “Fanal de Rouen.” He brought it
+for them to read.
+
+“Read it yourself,” said Bovary.
+
+He read--
+
+“‘Despite the prejudices that still invest a part of the face of Europe
+like a net, the light nevertheless begins to penetrate our country
+places. Thus on Tuesday our little town of Yonville found itself the
+scene of a surgical operation which is at the same time an act of
+loftiest philanthropy. Monsieur Bovary, one of our most distinguished
+practitioners--’”
+
+“Oh, that is too much! too much!” said Charles, choking with emotion.
+
+“No, no! not at all! What next!”
+
+“‘--Performed an operation on a club-footed man.’ I have not used the
+scientific term, because you know in a newspaper everyone would not
+perhaps understand. The masses must--’”
+
+“No doubt,” said Bovary; “go on!”
+
+“I proceed,” said the chemist. “‘Monsieur Bovary, one of our most
+distinguished practitioners, performed an operation on a club-footed man
+called Hippolyte Tautain, stableman for the last twenty-five years at
+the hotel of the “Lion d’Or,” kept by Widow Lefrancois, at the Place
+d’Armes. The novelty of the attempt, and the interest incident to the
+subject, had attracted such a concourse of persons that there was
+a veritable obstruction on the threshold of the establishment. The
+operation, moreover, was performed as if by magic, and barely a
+few drops of blood appeared on the skin, as though to say that the
+rebellious tendon had at last given way beneath the efforts of art. The
+patient, strangely enough--we affirm it as an eye-witness--complained
+of no pain. His condition up to the present time leaves nothing to be
+desired. Everything tends to show that his convelescence will be brief;
+and who knows even if at our next village festivity we shall not see our
+good Hippolyte figuring in the bacchic dance in the midst of a chorus
+of joyous boon-companions, and thus proving to all eyes by his verve
+and his capers his complete cure? Honour, then, to the generous savants!
+Honour to those indefatigable spirits who consecrate their vigils to the
+amelioration or to the alleviation of their kind! Honour, thrice honour!
+Is it not time to cry that the blind shall see, the deaf hear, the lame
+walk? But that which fanaticism formerly promised to its elect, science
+now accomplishes for all men. We shall keep our readers informed as to
+the successive phases of this remarkable cure.’”
+
+This did not prevent Mere Lefrancois, from coming five days after,
+scared, and crying out--
+
+“Help! he is dying! I am going crazy!”
+
+Charles rushed to the “Lion d’Or,” and the chemist, who caught sight
+of him passing along the Place hatless, abandoned his shop. He appeared
+himself breathless, red, anxious, and asking everyone who was going up
+the stairs--
+
+“Why, what’s the matter with our interesting strephopode?”
+
+The strephopode was writhing in hideous convulsions, so that the machine
+in which his leg was enclosed was knocked against the wall enough to
+break it.
+
+With many precautions, in order not to disturb the position of the limb,
+the box was removed, and an awful sight presented itself. The outlines
+of the foot disappeared in such a swelling that the entire skin seemed
+about to burst, and it was covered with ecchymosis, caused by the famous
+machine. Hippolyte had already complained of suffering from it. No
+attention had been paid to him; they had to acknowledge that he had not
+been altogether wrong, and he was freed for a few hours. But, hardly had
+the oedema gone down to some extent, than the two savants thought fit
+to put back the limb in the apparatus, strapping it tighter to hasten
+matters. At last, three days after, Hippolyte being unable to endure it
+any longer, they once more removed the machine, and were much surprised
+at the result they saw. The livid tumefaction spread over the leg, with
+blisters here and there, whence there oozed a black liquid. Matters
+were taking a serious turn. Hippolyte began to worry himself, and Mere
+Lefrancois, had him installed in the little room near the kitchen, so
+that he might at least have some distraction.
+
+But the tax-collector, who dined there every day, complained bitterly of
+such companionship. Then Hippolyte was removed to the billiard-room.
+He lay there moaning under his heavy coverings, pale with long beard,
+sunken eyes, and from time to time turning his perspiring head on the
+dirty pillow, where the flies alighted. Madame Bovary went to see him.
+She brought him linen for his poultices; she comforted, and encouraged
+him. Besides, he did not want for company, especially on market-days,
+when the peasants were knocking about the billiard-balls round him,
+fenced with the cues, smoked, drank, sang, and brawled.
+
+“How are you?” they said, clapping him on the shoulder. “Ah! you’re not
+up to much, it seems, but it’s your own fault. You should do this! do
+that!” And then they told him stories of people who had all been cured
+by other remedies than his. Then by way of consolation they added--
+
+“You give way too much! Get up! You coddle yourself like a king! All the
+same, old chap, you don’t smell nice!”
+
+Gangrene, in fact, was spreading more and more. Bovary himself turned
+sick at it. He came every hour, every moment. Hippolyte looked at him
+with eyes full of terror, sobbing--
+
+“When shall I get well? Oh, save me! How unfortunate I am! How
+unfortunate I am!”
+
+And the doctor left, always recommending him to diet himself.
+
+“Don’t listen to him, my lad,” said Mere Lefrancois, “Haven’t they
+tortured you enough already? You’ll grow still weaker. Here! swallow
+this.”
+
+And she gave him some good beef-tea, a slice of mutton, a piece of
+bacon, and sometimes small glasses of brandy, that he had not the
+strength to put to his lips.
+
+Abbe Bournisien, hearing that he was growing worse, asked to see him.
+He began by pitying his sufferings, declaring at the same time that he
+ought to rejoice at them since it was the will of the Lord, and take
+advantage of the occasion to reconcile himself to Heaven.
+
+“For,” said the ecclesiastic in a paternal tone, “you rather neglected
+your duties; you were rarely seen at divine worship. How many years is
+it since you approached the holy table? I understand that your work,
+that the whirl of the world may have kept you from care for your
+salvation. But now is the time to reflect. Yet don’t despair. I have
+known great sinners, who, about to appear before God (you are not yet
+at this point I know), had implored His mercy, and who certainly died in
+the best frame of mind. Let us hope that, like them, you will set us a
+good example. Thus, as a precaution, what is to prevent you from saying
+morning and evening a ‘Hail Mary, full of grace,’ and ‘Our Father which
+art in heaven’? Yes, do that, for my sake, to oblige me. That won’t cost
+you anything. Will you promise me?”
+
+The poor devil promised. The cure came back day after day. He chatted
+with the landlady; and even told anecdotes interspersed with jokes and
+puns that Hippolyte did not understand. Then, as soon as he could, he
+fell back upon matters of religion, putting on an appropriate expression
+of face.
+
+His zeal seemed successful, for the club-foot soon manifested a desire
+to go on a pilgrimage to Bon-Secours if he were cured; to which Monsieur
+Bournisien replied that he saw no objection; two precautions were better
+than one; it was no risk anyhow.
+
+The druggist was indignant at what he called the manoeuvres of the
+priest; they were prejudicial, he said, to Hippolyte’s convalescence,
+and he kept repeating to Madame Lefrancois, “Leave him alone! leave him
+alone! You perturb his morals with your mysticism.” But the good woman
+would no longer listen to him; he was the cause of it all. From a spirit
+of contradiction she hung up near the bedside of the patient a basin
+filled with holy-water and a branch of box.
+
+Religion, however, seemed no more able to succour him than surgery, and
+the invincible gangrene still spread from the extremities towards
+the stomach. It was all very well to vary the potions and change the
+poultices; the muscles each day rotted more and more; and at last
+Charles replied by an affirmative nod of the head when Mere Lefrancois,
+asked him if she could not, as a forlorn hope, send for Monsieur Canivet
+of Neufchatel, who was a celebrity.
+
+A doctor of medicine, fifty years of age, enjoying a good position
+and self-possessed, Charles’s colleague did not refrain from laughing
+disdainfully when he had uncovered the leg, mortified to the knee. Then
+having flatly declared that it must be amputated, he went off to the
+chemist’s to rail at the asses who could have reduced a poor man to such
+a state. Shaking Monsieur Homais by the button of his coat, he shouted
+out in the shop--
+
+“These are the inventions of Paris! These are the ideas of those gentry
+of the capital! It is like strabismus, chloroform, lithotrity, a heap of
+monstrosities that the Government ought to prohibit. But they want to do
+the clever, and they cram you with remedies without, troubling about
+the consequences. We are not so clever, not we! We are not savants,
+coxcombs, fops! We are practitioners; we cure people, and we should
+not dream of operating on anyone who is in perfect health. Straighten
+club-feet! As if one could straighten club-feet! It is as if one wished,
+for example, to make a hunchback straight!”
+
+Homais suffered as he listened to this discourse, and he concealed his
+discomfort beneath a courtier’s smile; for he needed to humour Monsier
+Canivet, whose prescriptions sometimes came as far as Yonville. So he
+did not take up the defence of Bovary; he did not even make a single
+remark, and, renouncing his principles, he sacrificed his dignity to the
+more serious interests of his business.
+
+This amputation of the thigh by Doctor Canivet was a great event in the
+village. On that day all the inhabitants got up earlier, and the Grande
+Rue, although full of people, had something lugubrious about it, as
+if an execution had been expected. At the grocer’s they discussed
+Hippolyte’s illness; the shops did no business, and Madame Tuvache, the
+mayor’s wife, did not stir from her window, such was her impatience to
+see the operator arrive.
+
+He came in his gig, which he drove himself. But the springs of the right
+side having at length given way beneath the weight of his corpulence, it
+happened that the carriage as it rolled along leaned over a little, and
+on the other cushion near him could be seen a large box covered in red
+sheep-leather, whose three brass clasps shone grandly.
+
+After he had entered like a whirlwind the porch of the “Lion d’Or,” the
+doctor, shouting very loud, ordered them to unharness his horse. Then he
+went into the stable to see that she was eating her oats all right; for
+on arriving at a patient’s he first of all looked after his mare and his
+gig. People even said about this--
+
+“Ah! Monsieur Canivet’s a character!”
+
+And he was the more esteemed for this imperturbable coolness. The
+universe to the last man might have died, and he would not have missed
+the smallest of his habits.
+
+Homais presented himself.
+
+“I count on you,” said the doctor. “Are we ready? Come along!”
+
+But the druggist, turning red, confessed that he was too sensitive to
+assist at such an operation.
+
+“When one is a simple spectator,” he said, “the imagination, you know,
+is impressed. And then I have such a nervous system!”
+
+“Pshaw!” interrupted Canivet; “on the contrary, you seem to me inclined
+to apoplexy. Besides, that doesn’t astonish me, for you chemist fellows
+are always poking about your kitchens, which must end by spoiling your
+constitutions. Now just look at me. I get up every day at four o’clock;
+I shave with cold water (and am never cold). I don’t wear flannels, and
+I never catch cold; my carcass is good enough! I live now in one way,
+now in another, like a philosopher, taking pot-luck; that is why I
+am not squeamish like you, and it is as indifferent to me to carve a
+Christian as the first fowl that turns up. Then, perhaps, you will say,
+habit! habit!”
+
+Then, without any consideration for Hippolyte, who was sweating with
+agony between his sheets, these gentlemen entered into a conversation,
+in which the druggist compared the coolness of a surgeon to that of a
+general; and this comparison was pleasing to Canivet, who launched out
+on the exigencies of his art. He looked upon, it as a sacred office,
+although the ordinary practitioners dishonoured it. At last, coming back
+to the patient, he examined the bandages brought by Homais, the same
+that had appeared for the club-foot, and asked for someone to hold the
+limb for him. Lestiboudois was sent for, and Monsieur Canivet having
+turned up his sleeves, passed into the billiard-room, while the druggist
+stayed with Artemise and the landlady, both whiter than their aprons,
+and with ears strained towards the door.
+
+Bovary during this time did not dare to stir from his house.
+
+He kept downstairs in the sitting-room by the side of the fireless
+chimney, his chin on his breast, his hands clasped, his eyes staring.
+“What a mishap!” he thought, “what a mishap!” Perhaps, after all, he had
+made some slip. He thought it over, but could hit upon nothing. But the
+most famous surgeons also made mistakes; and that is what no one would
+ever believe! People, on the contrary, would laugh, jeer! It would
+spread as far as Forges, as Neufchatel, as Rouen, everywhere! Who could
+say if his colleagues would not write against him. Polemics would ensue;
+he would have to answer in the papers. Hippolyte might even prosecute
+him. He saw himself dishonoured, ruined, lost; and his imagination,
+assailed by a world of hypotheses, tossed amongst them like an empty
+cask borne by the sea and floating upon the waves.
+
+Emma, opposite, watched him; she did not share his humiliation; she felt
+another--that of having supposed such a man was worth anything. As if
+twenty times already she had not sufficiently perceived his mediocrity.
+
+Charles was walking up and down the room; his boots creaked on the
+floor.
+
+“Sit down,” she said; “you fidget me.”
+
+He sat down again.
+
+How was it that she--she, who was so intelligent--could have allowed
+herself to be deceived again? and through what deplorable madness had
+she thus ruined her life by continual sacrifices? She recalled all her
+instincts of luxury, all the privations of her soul, the sordidness of
+marriage, of the household, her dream sinking into the mire like wounded
+swallows; all that she had longed for, all that she had denied herself,
+all that she might have had! And for what? for what?
+
+In the midst of the silence that hung over the village a heart-rending
+cry rose on the air. Bovary turned white to fainting. She knit her
+brows with a nervous gesture, then went on. And it was for him, for this
+creature, for this man, who understood nothing, who felt nothing! For he
+was there quite quiet, not even suspecting that the ridicule of his name
+would henceforth sully hers as well as his. She had made efforts to love
+him, and she had repented with tears for having yielded to another!
+
+“But it was perhaps a valgus!” suddenly exclaimed Bovary, who was
+meditating.
+
+At the unexpected shock of this phrase falling on her thought like a
+leaden bullet on a silver plate, Emma, shuddering, raised her head in
+order to find out what he meant to say; and they looked at the other in
+silence, almost amazed to see each other, so far sundered were they
+by their inner thoughts. Charles gazed at her with the dull look of
+a drunken man, while he listened motionless to the last cries of the
+sufferer, that followed each other in long-drawn modulations, broken by
+sharp spasms like the far-off howling of some beast being slaughtered.
+Emma bit her wan lips, and rolling between her fingers a piece of coral
+that she had broken, fixed on Charles the burning glance of her eyes
+like two arrows of fire about to dart forth. Everything in him irritated
+her now; his face, his dress, what he did not say, his whole person, his
+existence, in fine. She repented of her past virtue as of a crime, and
+what still remained of it rumbled away beneath the furious blows of her
+pride. She revelled in all the evil ironies of triumphant adultery.
+The memory of her lover came back to her with dazzling attractions; she
+threw her whole soul into it, borne away towards this image with a fresh
+enthusiasm; and Charles seemed to her as much removed from her life, as
+absent forever, as impossible and annihilated, as if he had been about
+to die and were passing under her eyes.
+
+There was a sound of steps on the pavement. Charles looked up, and
+through the lowered blinds he saw at the corner of the market in
+the broad sunshine Dr. Canivet, who was wiping his brow with his
+handkerchief. Homais, behind him, was carrying a large red box in his
+hand, and both were going towards the chemist’s.
+
+Then with a feeling of sudden tenderness and discouragement Charles
+turned to his wife saying to her--
+
+“Oh, kiss me, my own!”
+
+“Leave me!” she said, red with anger.
+
+“What is the matter?” he asked, stupefied. “Be calm; compose yourself.
+You know well enough that I love you. Come!”
+
+“Enough!” she cried with a terrible look.
+
+And escaping from the room, Emma closed the door so violently that the
+barometer fell from the wall and smashed on the floor.
+
+Charles sank back into his arm-chair overwhelmed, trying to discover
+what could be wrong with her, fancying some nervous illness, weeping,
+and vaguely feeling something fatal and incomprehensible whirling round
+him.
+
+When Rodolphe came to the garden that evening, he found his mistress
+waiting for him at the foot of the steps on the lowest stair. They threw
+their arms round one another, and all their rancour melted like snow
+beneath the warmth of that kiss.
+
+
+
+Chapter Twelve
+
+They began to love one another again. Often, even in the middle of the
+day, Emma suddenly wrote to him, then from the window made a sign to
+Justin, who, taking his apron off, quickly ran to La Huchette. Rodolphe
+would come; she had sent for him to tell him that she was bored, that
+her husband was odious, her life frightful.
+
+“But what can I do?” he cried one day impatiently.
+
+“Ah! if you would--”
+
+She was sitting on the floor between his knees, her hair loose, her look
+lost.
+
+“Why, what?” said Rodolphe.
+
+She sighed.
+
+“We would go and live elsewhere--somewhere!”
+
+“You are really mad!” he said laughing. “How could that be possible?”
+
+She returned to the subject; he pretended not to understand, and turned
+the conversation.
+
+What he did not understand was all this worry about so simple an affair
+as love. She had a motive, a reason, and, as it were, a pendant to her
+affection.
+
+Her tenderness, in fact, grew each day with her repulsion to her
+husband. The more she gave up herself to the one, the more she loathed
+the other. Never had Charles seemed to her so disagreeable, to have
+such stodgy fingers, such vulgar ways, to be so dull as when they found
+themselves together after her meeting with Rodolphe. Then, while playing
+the spouse and virtue, she was burning at the thought of that head whose
+black hair fell in a curl over the sunburnt brow, of that form at once
+so strong and elegant, of that man, in a word, who had such experience
+in his reasoning, such passion in his desires. It was for him that she
+filed her nails with the care of a chaser, and that there was never
+enough cold-cream for her skin, nor of patchouli for her handkerchiefs.
+She loaded herself with bracelets, rings, and necklaces. When he
+was coming she filled the two large blue glass vases with roses, and
+prepared her room and her person like a courtesan expecting a prince.
+The servant had to be constantly washing linen, and all day Felicite
+did not stir from the kitchen, where little Justin, who often kept her
+company, watched her at work.
+
+With his elbows on the long board on which she was ironing, he
+greedily watched all these women’s clothes spread about him, the dimity
+petticoats, the fichus, the collars, and the drawers with running
+strings, wide at the hips and growing narrower below.
+
+“What is that for?” asked the young fellow, passing his hand over the
+crinoline or the hooks and eyes.
+
+“Why, haven’t you ever seen anything?” Felicite answered laughing. “As
+if your mistress, Madame Homais, didn’t wear the same.”
+
+“Oh, I daresay! Madame Homais!” And he added with a meditative air, “As
+if she were a lady like madame!”
+
+But Felicite grew impatient of seeing him hanging round her. She was six
+years older than he, and Theodore, Monsieur Guillaumin’s servant, was
+beginning to pay court to her.
+
+“Let me alone,” she said, moving her pot of starch. “You’d better be
+off and pound almonds; you are always dangling about women. Before you
+meddle with such things, bad boy, wait till you’ve got a beard to your
+chin.”
+
+“Oh, don’t be cross! I’ll go and clean her boots.”
+
+And he at once took down from the shelf Emma’s boots, all coated with
+mud, the mud of the rendezvous, that crumbled into powder beneath his
+fingers, and that he watched as it gently rose in a ray of sunlight.
+
+“How afraid you are of spoiling them!” said the servant, who wasn’t so
+particular when she cleaned them herself, because as soon as the stuff
+of the boots was no longer fresh madame handed them over to her.
+
+Emma had a number in her cupboard that she squandered one after the
+other, without Charles allowing himself the slightest observation. So
+also he disbursed three hundred francs for a wooden leg that she thought
+proper to make a present of to Hippolyte. Its top was covered with cork,
+and it had spring joints, a complicated mechanism, covered over by black
+trousers ending in a patent-leather boot. But Hippolyte, not daring
+to use such a handsome leg every day, begged Madame Bovary to get him
+another more convenient one. The doctor, of course, had again to defray
+the expense of this purchase.
+
+So little by little the stable-man took up his work again. One saw him
+running about the village as before, and when Charles heard from afar
+the sharp noise of the wooden leg, he at once went in another direction.
+
+It was Monsieur Lheureux, the shopkeeper, who had undertaken the order;
+this provided him with an excuse for visiting Emma. He chatted with her
+about the new goods from Paris, about a thousand feminine trifles, made
+himself very obliging, and never asked for his money. Emma yielded to
+this lazy mode of satisfying all her caprices. Thus she wanted to have
+a very handsome ridding-whip that was at an umbrella-maker’s at Rouen
+to give to Rodolphe. The week after Monsieur Lheureux placed it on her
+table.
+
+But the next day he called on her with a bill for two hundred and
+seventy francs, not counting the centimes. Emma was much embarrassed;
+all the drawers of the writing-table were empty; they owed over a
+fortnight’s wages to Lestiboudois, two quarters to the servant, for any
+quantity of other things, and Bovary was impatiently expecting Monsieur
+Derozeray’s account, which he was in the habit of paying every year
+about Midsummer.
+
+She succeeded at first in putting off Lheureux. At last he lost
+patience; he was being sued; his capital was out, and unless he got some
+in he should be forced to take back all the goods she had received.
+
+“Oh, very well, take them!” said Emma.
+
+“I was only joking,” he replied; “the only thing I regret is the whip.
+My word! I’ll ask monsieur to return it to me.”
+
+“No, no!” she said.
+
+“Ah! I’ve got you!” thought Lheureux.
+
+And, certain of his discovery, he went out repeating to himself in an
+undertone, and with his usual low whistle--
+
+“Good! we shall see! we shall see!”
+
+She was thinking how to get out of this when the servant coming in
+put on the mantelpiece a small roll of blue paper “from Monsieur
+Derozeray’s.” Emma pounced upon and opened it. It contained fifteen
+napoleons; it was the account. She heard Charles on the stairs; threw
+the gold to the back of her drawer, and took out the key.
+
+Three days after Lheureux reappeared.
+
+“I have an arrangement to suggest to you,” he said. “If, instead of the
+sum agreed on, you would take--”
+
+“Here it is,” she said placing fourteen napoleons in his hand.
+
+The tradesman was dumfounded. Then, to conceal his disappointment, he
+was profuse in apologies and proffers of service, all of which Emma
+declined; then she remained a few moments fingering in the pocket of
+her apron the two five-franc pieces that he had given her in change.
+She promised herself she would economise in order to pay back later on.
+“Pshaw!” she thought, “he won’t think about it again.”
+
+Besides the riding-whip with its silver-gilt handle, Rodolphe had
+received a seal with the motto Amor nel cor* furthermore, a scarf for
+a muffler, and, finally, a cigar-case exactly like the Viscount’s, that
+Charles had formerly picked up in the road, and that Emma had kept.
+These presents, however, humiliated him; he refused several; she
+insisted, and he ended by obeying, thinking her tyrannical and
+overexacting.
+
+     *A loving heart.
+
+Then she had strange ideas.
+
+“When midnight strikes,” she said, “you must think of me.”
+
+And if he confessed that he had not thought of her, there were floods of
+reproaches that always ended with the eternal question--
+
+“Do you love me?”
+
+“Why, of course I love you,” he answered.
+
+“A great deal?”
+
+“Certainly!”
+
+“You haven’t loved any others?”
+
+“Did you think you’d got a virgin?” he exclaimed laughing.
+
+Emma cried, and he tried to console her, adorning his protestations with
+puns.
+
+“Oh,” she went on, “I love you! I love you so that I could not live
+without you, do you see? There are times when I long to see you again,
+when I am torn by all the anger of love. I ask myself, Where is
+he? Perhaps he is talking to other women. They smile upon him; he
+approaches. Oh no; no one else pleases you. There are some more
+beautiful, but I love you best. I know how to love best. I am your
+servant, your concubine! You are my king, my idol! You are good, you are
+beautiful, you are clever, you are strong!”
+
+He had so often heard these things said that they did not strike him as
+original. Emma was like all his mistresses; and the charm of novelty,
+gradually falling away like a garment, laid bare the eternal monotony
+of passion, that has always the same forms and the same language. He
+did not distinguish, this man of so much experience, the difference of
+sentiment beneath the sameness of expression. Because lips libertine
+and venal had murmured such words to him, he believed but little in the
+candour of hers; exaggerated speeches hiding mediocre affections must be
+discounted; as if the fullness of the soul did not sometimes overflow in
+the emptiest metaphors, since no one can ever give the exact measure of
+his needs, nor of his conceptions, nor of his sorrows; and since human
+speech is like a cracked tin kettle, on which we hammer out tunes to
+make bears dance when we long to move the stars.
+
+But with that superior critical judgment that belongs to him who, in no
+matter what circumstance, holds back, Rodolphe saw other delights to be
+got out of this love. He thought all modesty in the way. He treated her
+quite sans facon.* He made of her something supple and corrupt. Hers
+was an idiotic sort of attachment, full of admiration for him, of
+voluptuousness for her, a beatitude that benumbed her; her soul sank
+into this drunkenness, shrivelled up, drowned in it, like Clarence in
+his butt of Malmsey.
+
+     *Off-handedly.
+
+
+By the mere effect of her love Madame Bovary’s manners changed.
+Her looks grew bolder, her speech more free; she even committed the
+impropriety of walking out with Monsieur Rodolphe, a cigarette in her
+mouth, “as if to defy the people.” At last, those who still doubted
+doubted no longer when one day they saw her getting out of the
+“Hirondelle,” her waist squeezed into a waistcoat like a man; and Madame
+Bovary senior, who, after a fearful scene with her husband, had taken
+refuge at her son’s, was not the least scandalised of the women-folk.
+Many other things displeased her. First, Charles had not attended to
+her advice about the forbidding of novels; then the “ways of the house”
+ annoyed her; she allowed herself to make some remarks, and there were
+quarrels, especially one on account of Felicite.
+
+Madame Bovary senior, the evening before, passing along the passage,
+had surprised her in company of a man--a man with a brown collar, about
+forty years old, who, at the sound of her step, had quickly escaped
+through the kitchen. Then Emma began to laugh, but the good lady grew
+angry, declaring that unless morals were to be laughed at one ought to
+look after those of one’s servants.
+
+“Where were you brought up?” asked the daughter-in-law, with so
+impertinent a look that Madame Bovary asked her if she were not perhaps
+defending her own case.
+
+“Leave the room!” said the young woman, springing up with a bound.
+
+“Emma! Mamma!” cried Charles, trying to reconcile them.
+
+But both had fled in their exasperation. Emma was stamping her feet as
+she repeated--
+
+“Oh! what manners! What a peasant!”
+
+He ran to his mother; she was beside herself. She stammered
+
+“She is an insolent, giddy-headed thing, or perhaps worse!”
+
+And she was for leaving at once if the other did not apologise. So
+Charles went back again to his wife and implored her to give way; he
+knelt to her; she ended by saying--
+
+“Very well! I’ll go to her.”
+
+And in fact she held out her hand to her mother-in-law with the dignity
+of a marchioness as she said--
+
+“Excuse me, madame.”
+
+Then, having gone up again to her room, she threw herself flat on her
+bed and cried there like a child, her face buried in the pillow.
+
+She and Rodolphe had agreed that in the event of anything extraordinary
+occurring, she should fasten a small piece of white paper to the blind,
+so that if by chance he happened to be in Yonville, he could hurry to
+the lane behind the house. Emma made the signal; she had been waiting
+three-quarters of an hour when she suddenly caught sight of Rodolphe at
+the corner of the market. She felt tempted to open the window and call
+him, but he had already disappeared. She fell back in despair.
+
+Soon, however, it seemed to her that someone was walking on the
+pavement. It was he, no doubt. She went downstairs, crossed the yard. He
+was there outside. She threw herself into his arms.
+
+“Do take care!” he said.
+
+“Ah! if you knew!” she replied.
+
+And she began telling him everything, hurriedly, disjointedly,
+exaggerating the facts, inventing many, and so prodigal of parentheses
+that he understood nothing of it.
+
+“Come, my poor angel, courage! Be comforted! be patient!”
+
+“But I have been patient; I have suffered for four years. A love like
+ours ought to show itself in the face of heaven. They torture me! I can
+bear it no longer! Save me!”
+
+She clung to Rodolphe. Her eyes, full of tears, flashed like flames
+beneath a wave; her breast heaved; he had never loved her so much, so
+that he lost his head and said “What is, it? What do you wish?”
+
+“Take me away,” she cried, “carry me off! Oh, I pray you!”
+
+And she threw herself upon his mouth, as if to seize there the
+unexpected consent if breathed forth in a kiss.
+
+“But--” Rodolphe resumed.
+
+“What?”
+
+“Your little girl!”
+
+She reflected a few moments, then replied--
+
+“We will take her! It can’t be helped!”
+
+“What a woman!” he said to himself, watching her as she went. For she
+had run into the garden. Someone was calling her.
+
+On the following days Madame Bovary senior was much surprised at the
+change in her daughter-in-law. Emma, in fact, was showing herself more
+docile, and even carried her deference so far as to ask for a recipe for
+pickling gherkins.
+
+Was it the better to deceive them both? Or did she wish by a sort of
+voluptuous stoicism to feel the more profoundly the bitterness of the
+things she was about to leave?
+
+But she paid no heed to them; on the contrary, she lived as lost in the
+anticipated delight of her coming happiness.
+
+It was an eternal subject for conversation with Rodolphe. She leant on
+his shoulder murmuring--
+
+“Ah! when we are in the mail-coach! Do you think about it? Can it be? It
+seems to me that the moment I feel the carriage start, it will be as if
+we were rising in a balloon, as if we were setting out for the clouds.
+Do you know that I count the hours? And you?”
+
+Never had Madame Bovary been so beautiful as at this period; she had
+that indefinable beauty that results from joy, from enthusiasm, from
+success, and that is only the harmony of temperament with circumstances.
+Her desires, her sorrows, the experience of pleasure, and her ever-young
+illusions, that had, as soil and rain and winds and the sun make flowers
+grow, gradually developed her, and she at length blossomed forth in all
+the plenitude of her nature. Her eyelids seemed chiselled expressly for
+her long amorous looks in which the pupil disappeared, while a strong
+inspiration expanded her delicate nostrils and raised the fleshy corner
+of her lips, shaded in the light by a little black down. One would have
+thought that an artist apt in conception had arranged the curls of hair
+upon her neck; they fell in a thick mass, negligently, and with the
+changing chances of their adultery, that unbound them every day. Her
+voice now took more mellow infections, her figure also; something subtle
+and penetrating escaped even from the folds of her gown and from the
+line of her foot. Charles, as when they were first married, thought her
+delicious and quite irresistible.
+
+When he came home in the middle of the night, he did not dare to wake
+her. The porcelain night-light threw a round trembling gleam upon the
+ceiling, and the drawn curtains of the little cot formed as it were a
+white hut standing out in the shade, and by the bedside Charles looked
+at them. He seemed to hear the light breathing of his child. She would
+grow big now; every season would bring rapid progress. He already saw
+her coming from school as the day drew in, laughing, with ink-stains on
+her jacket, and carrying her basket on her arm. Then she would have to
+be sent to the boarding-school; that would cost much; how was it to
+be done? Then he reflected. He thought of hiring a small farm in the
+neighbourhood, that he would superintend every morning on his way to his
+patients. He would save up what he brought in; he would put it in the
+savings-bank. Then he would buy shares somewhere, no matter where;
+besides, his practice would increase; he counted upon that, for he
+wanted Berthe to be well-educated, to be accomplished, to learn to play
+the piano. Ah! how pretty she would be later on when she was fifteen,
+when, resembling her mother, she would, like her, wear large straw hats
+in the summer-time; from a distance they would be taken for two sisters.
+He pictured her to himself working in the evening by their side beneath
+the light of the lamp; she would embroider him slippers; she would look
+after the house; she would fill all the home with her charm and her
+gaiety. At last, they would think of her marriage; they would find her
+some good young fellow with a steady business; he would make her happy;
+this would last for ever.
+
+Emma was not asleep; she pretended to be; and while he dozed off by her
+side she awakened to other dreams.
+
+To the gallop of four horses she was carried away for a week towards a
+new land, whence they would return no more. They went on and on, their
+arms entwined, without a word. Often from the top of a mountain there
+suddenly glimpsed some splendid city with domes, and bridges, and
+ships, forests of citron trees, and cathedrals of white marble, on whose
+pointed steeples were storks’ nests. They went at a walking-pace because
+of the great flag-stones, and on the ground there were bouquets of
+flowers, offered you by women dressed in red bodices. They heard the
+chiming of bells, the neighing of mules, together with the murmur of
+guitars and the noise of fountains, whose rising spray refreshed heaps
+of fruit arranged like a pyramid at the foot of pale statues that smiled
+beneath playing waters. And then, one night they came to a fishing
+village, where brown nets were drying in the wind along the cliffs and
+in front of the huts. It was there that they would stay; they would live
+in a low, flat-roofed house, shaded by a palm-tree, in the heart of a
+gulf, by the sea. They would row in gondolas, swing in hammocks, and
+their existence would be easy and large as their silk gowns, warm and
+star-spangled as the nights they would contemplate. However, in the
+immensity of this future that she conjured up, nothing special stood
+forth; the days, all magnificent, resembled each other like waves; and
+it swayed in the horizon, infinite, harmonised, azure, and bathed in
+sunshine. But the child began to cough in her cot or Bovary snored
+more loudly, and Emma did not fall asleep till morning, when the dawn
+whitened the windows, and when little Justin was already in the square
+taking down the shutters of the chemist’s shop.
+
+She had sent for Monsieur Lheureux, and had said to him--
+
+“I want a cloak--a large lined cloak with a deep collar.”
+
+“You are going on a journey?” he asked.
+
+“No; but--never mind. I may count on you, may I not, and quickly?”
+
+He bowed.
+
+“Besides, I shall want,” she went on, “a trunk--not too heavy--handy.”
+
+“Yes, yes, I understand. About three feet by a foot and a half, as they
+are being made just now.”
+
+“And a travelling bag.”
+
+“Decidedly,” thought Lheureux, “there’s a row on here.”
+
+“And,” said Madame Bovary, taking her watch from her belt, “take this;
+you can pay yourself out of it.”
+
+But the tradesman cried out that she was wrong; they knew one another;
+did he doubt her? What childishness!
+
+She insisted, however, on his taking at least the chain, and Lheureux
+had already put it in his pocket and was going, when she called him
+back.
+
+“You will leave everything at your place. As to the cloak”--she seemed
+to be reflecting--“do not bring it either; you can give me the maker’s
+address, and tell him to have it ready for me.”
+
+It was the next month that they were to run away. She was to leave
+Yonville as if she was going on some business to Rouen. Rodolphe would
+have booked the seats, procured the passports, and even have written to
+Paris in order to have the whole mail-coach reserved for them as far as
+Marseilles, where they would buy a carriage, and go on thence without
+stopping to Genoa. She would take care to send her luggage to Lheureux
+whence it would be taken direct to the “Hirondelle,” so that no one
+would have any suspicion. And in all this there never was any allusion
+to the child. Rodolphe avoided speaking of her; perhaps he no longer
+thought about it.
+
+He wished to have two more weeks before him to arrange some affairs;
+then at the end of a week he wanted two more; then he said he was ill;
+next he went on a journey. The month of August passed, and, after all
+these delays, they decided that it was to be irrevocably fixed for the
+4th September--a Monday.
+
+At length the Saturday before arrived.
+
+Rodolphe came in the evening earlier than usual.
+
+“Everything is ready?” she asked him.
+
+“Yes.”
+
+Then they walked round a garden-bed, and went to sit down near the
+terrace on the kerb-stone of the wall.
+
+“You are sad,” said Emma.
+
+“No; why?”
+
+And yet he looked at her strangely in a tender fashion.
+
+“It is because you are going away?” she went on; “because you are
+leaving what is dear to you--your life? Ah! I understand. I have nothing
+in the world! you are all to me; so shall I be to you. I will be your
+people, your country; I will tend, I will love you!”
+
+“How sweet you are!” he said, seizing her in his arms.
+
+“Really!” she said with a voluptuous laugh. “Do you love me? Swear it
+then!”
+
+“Do I love you--love you? I adore you, my love.”
+
+The moon, full and purple-coloured, was rising right out of the earth
+at the end of the meadow. She rose quickly between the branches of the
+poplars, that hid her here and there like a black curtain pierced with
+holes. Then she appeared dazzling with whiteness in the empty heavens
+that she lit up, and now sailing more slowly along, let fall upon the
+river a great stain that broke up into an infinity of stars; and the
+silver sheen seemed to writhe through the very depths like a heedless
+serpent covered with luminous scales; it also resembled some monster
+candelabra all along which sparkled drops of diamonds running together.
+The soft night was about them; masses of shadow filled the branches.
+Emma, her eyes half closed, breathed in with deep sighs the fresh wind
+that was blowing. They did not speak, lost as they were in the rush of
+their reverie. The tenderness of the old days came back to their hearts,
+full and silent as the flowing river, with the softness of the perfume
+of the syringas, and threw across their memories shadows more immense
+and more sombre than those of the still willows that lengthened out over
+the grass. Often some night-animal, hedgehog or weasel, setting out on
+the hunt, disturbed the lovers, or sometimes they heard a ripe peach
+falling all alone from the espalier.
+
+“Ah! what a lovely night!” said Rodolphe.
+
+“We shall have others,” replied Emma; and, as if speaking to herself:
+“Yet, it will be good to travel. And yet, why should my heart be
+so heavy? Is it dread of the unknown? The effect of habits left? Or
+rather--? No; it is the excess of happiness. How weak I am, am I not?
+Forgive me!”
+
+“There is still time!” he cried. “Reflect! perhaps you may repent!”
+
+“Never!” she cried impetuously. And coming closer to him: “What ill
+could come to me? There is no desert, no precipice, no ocean I would not
+traverse with you. The longer we live together the more it will be like
+an embrace, every day closer, more heart to heart. There will be
+nothing to trouble us, no cares, no obstacle. We shall be alone, all to
+ourselves eternally. Oh, speak! Answer me!”
+
+At regular intervals he answered, “Yes--Yes--” She had passed her hands
+through his hair, and she repeated in a childlike voice, despite the big
+tears which were falling, “Rodolphe! Rodolphe! Ah! Rodolphe! dear little
+Rodolphe!”
+
+Midnight struck.
+
+“Midnight!” said she. “Come, it is to-morrow. One day more!”
+
+He rose to go; and as if the movement he made had been the signal for
+their flight, Emma said, suddenly assuming a gay air--
+
+“You have the passports?”
+
+“Yes.”
+
+“You are forgetting nothing?”
+
+“No.”
+
+“Are you sure?”
+
+“Certainly.”
+
+“It is at the Hotel de Provence, is it not, that you will wait for me at
+midday?”
+
+He nodded.
+
+“Till to-morrow then!” said Emma in a last caress; and she watched him
+go.
+
+He did not turn round. She ran after him, and, leaning over the water’s
+edge between the bulrushes--
+
+“To-morrow!” she cried.
+
+He was already on the other side of the river and walking fast across
+the meadow.
+
+After a few moments Rodolphe stopped; and when he saw her with her white
+gown gradually fade away in the shade like a ghost, he was seized with
+such a beating of the heart that he leant against a tree lest he should
+fall.
+
+“What an imbecile I am!” he said with a fearful oath. “No matter! She
+was a pretty mistress!”
+
+And immediately Emma’s beauty, with all the pleasures of their love,
+came back to him. For a moment he softened; then he rebelled against
+her.
+
+“For, after all,” he exclaimed, gesticulating, “I can’t exile
+myself--have a child on my hands.”
+
+He was saying these things to give himself firmness.
+
+“And besides, the worry, the expense! Ah! no, no, no, no! a thousand
+times no! That would be too stupid.”
+
+
+
+Chapter Thirteen
+
+No sooner was Rodolphe at home than he sat down quickly at his bureau
+under the stag’s head that hung as a trophy on the wall. But when he had
+the pen between his fingers, he could think of nothing, so that, resting
+on his elbows, he began to reflect. Emma seemed to him to have receded
+into a far-off past, as if the resolution he had taken had suddenly
+placed a distance between them.
+
+To get back something of her, he fetched from the cupboard at the
+bedside an old Rheims biscuit-box, in which he usually kept his letters
+from women, and from it came an odour of dry dust and withered
+roses. First he saw a handkerchief with pale little spots. It was a
+handkerchief of hers. Once when they were walking her nose had bled; he
+had forgotten it. Near it, chipped at all the corners, was a miniature
+given him by Emma: her toilette seemed to him pretentious, and her
+languishing look in the worst possible taste. Then, from looking at this
+image and recalling the memory of its original, Emma’s features little
+by little grew confused in his remembrance, as if the living and the
+painted face, rubbing one against the other, had effaced each other.
+Finally, he read some of her letters; they were full of explanations
+relating to their journey, short, technical, and urgent, like business
+notes. He wanted to see the long ones again, those of old times. In
+order to find them at the bottom of the box, Rodolphe disturbed all the
+others, and mechanically began rummaging amidst this mass of papers and
+things, finding pell-mell bouquets, garters, a black mask, pins, and
+hair--hair! dark and fair, some even, catching in the hinges of the box,
+broke when it was opened.
+
+Thus dallying with his souvenirs, he examined the writing and the style
+of the letters, as varied as their orthography. They were tender or
+jovial, facetious, melancholy; there were some that asked for love,
+others that asked for money. A word recalled faces to him, certain
+gestures, the sound of a voice; sometimes, however, he remembered
+nothing at all.
+
+In fact, these women, rushing at once into his thoughts, cramped each
+other and lessened, as reduced to a uniform level of love that equalised
+them all. So taking handfuls of the mixed-up letters, he amused himself
+for some moments with letting them fall in cascades from his right into
+his left hand. At last, bored and weary, Rodolphe took back the box to
+the cupboard, saying to himself, “What a lot of rubbish!” Which summed
+up his opinion; for pleasures, like schoolboys in a school courtyard,
+had so trampled upon his heart that no green thing grew there, and that
+which passed through it, more heedless than children, did not even, like
+them, leave a name carved upon the wall.
+
+“Come,” said he, “let’s begin.”
+
+He wrote--
+
+“Courage, Emma! courage! I would not bring misery into your life.”
+
+“After all, that’s true,” thought Rodolphe. “I am acting in her
+interest; I am honest.”
+
+“Have you carefully weighed your resolution? Do you know to what an
+abyss I was dragging you, poor angel? No, you do not, do you? You were
+coming confident and fearless, believing in happiness in the future. Ah!
+unhappy that we are--insensate!”
+
+Rodolphe stopped here to think of some good excuse.
+
+“If I told her all my fortune is lost? No! Besides, that would stop
+nothing. It would all have to be begun over again later on. As if one
+could make women like that listen to reason!” He reflected, then went
+on--
+
+“I shall not forget you, oh believe it; and I shall ever have a profound
+devotion for you; but some day, sooner or later, this ardour (such is
+the fate of human things) would have grown less, no doubt. Lassitude
+would have come to us, and who knows if I should not even have had the
+atrocious pain of witnessing your remorse, of sharing it myself, since
+I should have been its cause? The mere idea of the grief that would come
+to you tortures me, Emma. Forget me! Why did I ever know you? Why were
+you so beautiful? Is it my fault? O my God! No, no! Accuse only fate.”
+
+“That’s a word that always tells,” he said to himself.
+
+“Ah, if you had been one of those frivolous women that one sees,
+certainly I might, through egotism, have tried an experiment, in that
+case without danger for you. But that delicious exaltation, at once your
+charm and your torment, has prevented you from understanding, adorable
+woman that you are, the falseness of our future position. Nor had I
+reflected upon this at first, and I rested in the shade of that ideal
+happiness as beneath that of the manchineel tree, without foreseeing the
+consequences.”
+
+“Perhaps she’ll think I’m giving it up from avarice. Ah, well! so much
+the worse; it must be stopped!”
+
+“The world is cruel, Emma. Wherever we might have gone, it would have
+persecuted us. You would have had to put up with indiscreet questions,
+calumny, contempt, insult perhaps. Insult to you! Oh! And I, who would
+place you on a throne! I who bear with me your memory as a talisman! For
+I am going to punish myself by exile for all the ill I have done you.
+I am going away. Whither I know not. I am mad. Adieu! Be good always.
+Preserve the memory of the unfortunate who has lost you. Teach my name
+to your child; let her repeat it in her prayers.”
+
+The wicks of the candles flickered. Rodolphe got up to, shut the window,
+and when he had sat down again--
+
+“I think it’s all right. Ah! and this for fear she should come and hunt
+me up.”
+
+“I shall be far away when you read these sad lines, for I have wished to
+flee as quickly as possible to shun the temptation of seeing you again.
+No weakness! I shall return, and perhaps later on we shall talk together
+very coldly of our old love. Adieu!”
+
+And there was a last “adieu” divided into two words! “A Dieu!” which he
+thought in very excellent taste.
+
+“Now how am I to sign?” he said to himself. “‘Yours devotedly?’ No!
+‘Your friend?’ Yes, that’s it.”
+
+“Your friend.”
+
+He re-read his letter. He considered it very good.
+
+“Poor little woman!” he thought with emotion. “She’ll think me harder
+than a rock. There ought to have been some tears on this; but I can’t
+cry; it isn’t my fault.” Then, having emptied some water into a glass,
+Rodolphe dipped his finger into it, and let a big drop fall on the
+paper, that made a pale stain on the ink. Then looking for a seal, he
+came upon the one “Amor nel cor.”
+
+“That doesn’t at all fit in with the circumstances. Pshaw! never mind!”
+
+After which he smoked three pipes and went to bed.
+
+The next day when he was up (at about two o’clock--he had slept late),
+Rodolphe had a basket of apricots picked. He put his letter at
+the bottom under some vine leaves, and at once ordered Girard, his
+ploughman, to take it with care to Madame Bovary. He made use of this
+means for corresponding with her, sending according to the season fruits
+or game.
+
+“If she asks after me,” he said, “you will tell her that I have gone on
+a journey. You must give the basket to her herself, into her own hands.
+Get along and take care!”
+
+Girard put on his new blouse, knotted his handkerchief round the
+apricots, and walking with great heavy steps in his thick iron-bound
+galoshes, made his way to Yonville.
+
+Madame Bovary, when he got to her house, was arranging a bundle of linen
+on the kitchen-table with Felicite.
+
+“Here,” said the ploughboy, “is something for you--from the master.”
+
+She was seized with apprehension, and as she sought in her pocket for
+some coppers, she looked at the peasant with haggard eyes, while he
+himself looked at her with amazement, not understanding how such a
+present could so move anyone. At last he went out. Felicite remained.
+She could bear it no longer; she ran into the sitting room as if to take
+the apricots there, overturned the basket, tore away the leaves, found
+the letter, opened it, and, as if some fearful fire were behind her,
+Emma flew to her room terrified.
+
+Charles was there; she saw him; he spoke to her; she heard nothing, and
+she went on quickly up the stairs, breathless, distraught, dumb, and
+ever holding this horrible piece of paper, that crackled between her
+fingers like a plate of sheet-iron. On the second floor she stopped
+before the attic door, which was closed.
+
+Then she tried to calm herself; she recalled the letter; she must finish
+it; she did not dare to. And where? How? She would be seen! “Ah, no!
+here,” she thought, “I shall be all right.”
+
+Emma pushed open the door and went in.
+
+The slates threw straight down a heavy heat that gripped her temples,
+stifled her; she dragged herself to the closed garret-window. She drew
+back the bolt, and the dazzling light burst in with a leap.
+
+Opposite, beyond the roofs, stretched the open country till it was lost
+to sight. Down below, underneath her, the village square was empty; the
+stones of the pavement glittered, the weathercocks on the houses were
+motionless. At the corner of the street, from a lower storey, rose a
+kind of humming with strident modulations. It was Binet turning.
+
+She leant against the embrasure of the window, and reread the letter
+with angry sneers. But the more she fixed her attention upon it, the
+more confused were her ideas. She saw him again, heard him, encircled
+him with her arms, and throbs of her heart, that beat against her breast
+like blows of a sledge-hammer, grew faster and faster, with uneven
+intervals. She looked about her with the wish that the earth might
+crumble into pieces. Why not end it all? What restrained her? She was
+free. She advanced, looking at the paving-stones, saying to herself,
+“Come! come!”
+
+The luminous ray that came straight up from below drew the weight of
+her body towards the abyss. It seemed to her that the ground of the
+oscillating square went up the walls and that the floor dipped on
+end like a tossing boat. She was right at the edge, almost hanging,
+surrounded by vast space. The blue of the heavens suffused her, the air
+was whirling in her hollow head; she had but to yield, to let herself
+be taken; and the humming of the lathe never ceased, like an angry voice
+calling her.
+
+“Emma! Emma!” cried Charles.
+
+She stopped.
+
+“Wherever are you? Come!”
+
+The thought that she had just escaped from death almost made her faint
+with terror. She closed her eyes; then she shivered at the touch of a
+hand on her sleeve; it was Felicite.
+
+“Master is waiting for you, madame; the soup is on the table.”
+
+And she had to go down to sit at table.
+
+She tried to eat. The food choked her. Then she unfolded her napkin as
+if to examine the darns, and she really thought of applying herself to
+this work, counting the threads in the linen. Suddenly the remembrance
+of the letter returned to her. How had she lost it? Where could she find
+it? But she felt such weariness of spirit that she could not even invent
+a pretext for leaving the table. Then she became a coward; she was
+afraid of Charles; he knew all, that was certain! Indeed he pronounced
+these words in a strange manner:
+
+“We are not likely to see Monsieur Rodolphe soon again, it seems.”
+
+“Who told you?” she said, shuddering.
+
+“Who told me!” he replied, rather astonished at her abrupt tone. “Why,
+Girard, whom I met just now at the door of the Cafe Francais. He has
+gone on a journey, or is to go.”
+
+She gave a sob.
+
+“What surprises you in that? He absents himself like that from time
+to time for a change, and, ma foi, I think he’s right, when one has a
+fortune and is a bachelor. Besides, he has jolly times, has our friend.
+He’s a bit of a rake. Monsieur Langlois told me--”
+
+He stopped for propriety’s sake because the servant came in. She put
+back into the basket the apricots scattered on the sideboard. Charles,
+without noticing his wife’s colour, had them brought to him, took one,
+and bit into it.
+
+“Ah! perfect!” said he; “just taste!”
+
+And he handed her the basket, which she put away from her gently.
+
+“Do just smell! What an odour!” he remarked, passing it under her nose
+several times.
+
+“I am choking,” she cried, leaping up. But by an effort of will the
+spasm passed; then--
+
+“It is nothing,” she said, “it is nothing! It is nervousness. Sit down
+and go on eating.” For she dreaded lest he should begin questioning her,
+attending to her, that she should not be left alone.
+
+Charles, to obey her, sat down again, and he spat the stones of the
+apricots into his hands, afterwards putting them on his plate.
+
+Suddenly a blue tilbury passed across the square at a rapid trot. Emma
+uttered a cry and fell back rigid to the ground.
+
+In fact, Rodolphe, after many reflections, had decided to set out for
+Rouen. Now, as from La Huchette to Buchy there is no other way than by
+Yonville, he had to go through the village, and Emma had recognised him
+by the rays of the lanterns, which like lightning flashed through the
+twilight.
+
+The chemist, at the tumult which broke out in the house ran thither. The
+table with all the plates was upset; sauce, meat, knives, the salt, and
+cruet-stand were strewn over the room; Charles was calling for help;
+Berthe, scared, was crying; and Felicite, whose hands trembled, was
+unlacing her mistress, whose whole body shivered convulsively.
+
+“I’ll run to my laboratory for some aromatic vinegar,” said the
+druggist.
+
+Then as she opened her eyes on smelling the bottle--
+
+“I was sure of it,” he remarked; “that would wake any dead person for
+you!”
+
+“Speak to us,” said Charles; “collect yourself; it is your Charles, who
+loves you. Do you know me? See! here is your little girl! Oh, kiss her!”
+
+The child stretched out her arms to her mother to cling to her neck. But
+turning away her head, Emma said in a broken voice “No, no! no one!”
+
+She fainted again. They carried her to her bed. She lay there stretched
+at full length, her lips apart, her eyelids closed, her hands open,
+motionless, and white as a waxen image. Two streams of tears flowed from
+her eyes and fell slowly upon the pillow.
+
+Charles, standing up, was at the back of the alcove, and the chemist,
+near him, maintained that meditative silence that is becoming on the
+serious occasions of life.
+
+“Do not be uneasy,” he said, touching his elbow; “I think the paroxysm
+is past.”
+
+“Yes, she is resting a little now,” answered Charles, watching her
+sleep. “Poor girl! poor girl! She had gone off now!”
+
+Then Homais asked how the accident had come about. Charles answered that
+she had been taken ill suddenly while she was eating some apricots.
+
+“Extraordinary!” continued the chemist. “But it might be that the
+apricots had brought on the syncope. Some natures are so sensitive to
+certain smells; and it would even be a very fine question to study both
+in its pathological and physiological relation. The priests know the
+importance of it, they who have introduced aromatics into all their
+ceremonies. It is to stupefy the senses and to bring on ecstasies--a
+thing, moreover, very easy in persons of the weaker sex, who are more
+delicate than the other. Some are cited who faint at the smell of burnt
+hartshorn, of new bread--”
+
+“Take care; you’ll wake her!” said Bovary in a low voice.
+
+“And not only,” the druggist went on, “are human beings subject to such
+anomalies, but animals also. Thus you are not ignorant of the singularly
+aphrodisiac effect produced by the Nepeta cataria, vulgarly called
+catmint, on the feline race; and, on the other hand, to quote an example
+whose authenticity I can answer for. Bridaux (one of my old comrades, at
+present established in the Rue Malpalu) possesses a dog that falls into
+convulsions as soon as you hold out a snuff-box to him. He often even
+makes the experiment before his friends at his summer-house at Guillaume
+Wood. Would anyone believe that a simple sternutation could produce such
+ravages on a quadrupedal organism? It is extremely curious, is it not?”
+
+“Yes,” said Charles, who was not listening to him.
+
+“This shows us,” went on the other, smiling with benign
+self-sufficiency, “the innumerable irregularities of the nervous system.
+With regard to madame, she has always seemed to me, I confess, very
+susceptible. And so I should by no means recommend to you, my dear
+friend, any of those so-called remedies that, under the pretence
+of attacking the symptoms, attack the constitution. No; no useless
+physicking! Diet, that is all; sedatives, emollients, dulcification.
+Then, don’t you think that perhaps her imagination should be worked
+upon?”
+
+“In what way? How?” said Bovary.
+
+“Ah! that is it. Such is indeed the question. ‘That is the question,’ as
+I lately read in a newspaper.”
+
+But Emma, awaking, cried out--
+
+“The letter! the letter!”
+
+They thought she was delirious; and she was by midnight. Brain-fever had
+set in.
+
+For forty-three days Charles did not leave her. He gave up all his
+patients; he no longer went to bed; he was constantly feeling her pulse,
+putting on sinapisms and cold-water compresses. He sent Justin as far as
+Neufchatel for ice; the ice melted on the way; he sent him back again.
+He called Monsieur Canivet into consultation; he sent for Dr. Lariviere,
+his old master, from Rouen; he was in despair. What alarmed him most was
+Emma’s prostration, for she did not speak, did not listen, did not even
+seem to suffer, as if her body and soul were both resting together after
+all their troubles.
+
+About the middle of October she could sit up in bed supported by
+pillows. Charles wept when he saw her eat her first bread-and-jelly. Her
+strength returned to her; she got up for a few hours of an afternoon,
+and one day, when she felt better, he tried to take her, leaning on his
+arm, for a walk round the garden. The sand of the paths was disappearing
+beneath the dead leaves; she walked slowly, dragging along her slippers,
+and leaning against Charles’s shoulder. She smiled all the time.
+
+They went thus to the bottom of the garden near the terrace. She drew
+herself up slowly, shading her eyes with her hand to look. She looked
+far off, as far as she could, but on the horizon were only great
+bonfires of grass smoking on the hills.
+
+“You will tire yourself, my darling!” said Bovary. And, pushing her
+gently to make her go into the arbour, “Sit down on this seat; you’ll be
+comfortable.”
+
+“Oh! no; not there!” she said in a faltering voice.
+
+She was seized with giddiness, and from that evening her illness
+recommenced, with a more uncertain character, it is true, and more
+complex symptoms. Now she suffered in her heart, then in the chest, the
+head, the limbs; she had vomitings, in which Charles thought he saw the
+first signs of cancer.
+
+And besides this, the poor fellow was worried about money matters.
+
+
+
+Chapter Fourteen
+
+To begin with, he did not know how he could pay Monsieur Homais for all
+the physic supplied by him, and though, as a medical man, he was not
+obliged to pay for it, he nevertheless blushed a little at such an
+obligation. Then the expenses of the household, now that the servant was
+mistress, became terrible. Bills rained in upon the house; the tradesmen
+grumbled; Monsieur Lheureux especially harassed him. In fact, at
+the height of Emma’s illness, the latter, taking advantage of the
+circumstances to make his bill larger, had hurriedly brought the cloak,
+the travelling-bag, two trunks instead of one, and a number of other
+things. It was very well for Charles to say he did not want them. The
+tradesman answered arrogantly that these articles had been ordered, and
+that he would not take them back; besides, it would vex madame in her
+convalescence; the doctor had better think it over; in short, he was
+resolved to sue him rather than give up his rights and take back his
+goods. Charles subsequently ordered them to be sent back to the shop.
+Felicite forgot; he had other things to attend to; then thought no more
+about them. Monsieur Lheureux returned to the charge, and, by turns
+threatening and whining, so managed that Bovary ended by signing a
+bill at six months. But hardly had he signed this bill than a bold idea
+occurred to him: it was to borrow a thousand francs from Lheureux.
+So, with an embarrassed air, he asked if it were possible to get them,
+adding that it would be for a year, at any interest he wished. Lheureux
+ran off to his shop, brought back the money, and dictated another bill,
+by which Bovary undertook to pay to his order on the 1st of September
+next the sum of one thousand and seventy francs, which, with the hundred
+and eighty already agreed to, made just twelve hundred and fifty, thus
+lending at six per cent in addition to one-fourth for commission: and
+the things bringing him in a good third at the least, this ought in
+twelve months to give him a profit of a hundred and thirty francs. He
+hoped that the business would not stop there; that the bills would not
+be paid; that they would be renewed; and that his poor little money,
+having thriven at the doctor’s as at a hospital, would come back to him
+one day considerably more plump, and fat enough to burst his bag.
+
+Everything, moreover, succeeded with him. He was adjudicator for a
+supply of cider to the hospital at Neufchatel; Monsieur Guillaumin
+promised him some shares in the turf-pits of Gaumesnil, and he dreamt of
+establishing a new diligence service between Arcueil and Rouen, which
+no doubt would not be long in ruining the ramshackle van of the “Lion
+d’Or,” and that, travelling faster, at a cheaper rate, and carrying more
+luggage, would thus put into his hands the whole commerce of Yonville.
+
+Charles several times asked himself by what means he should next year be
+able to pay back so much money. He reflected, imagined expedients, such
+as applying to his father or selling something. But his father would be
+deaf, and he--he had nothing to sell. Then he foresaw such worries that
+he quickly dismissed so disagreeable a subject of meditation from
+his mind. He reproached himself with forgetting Emma, as if, all his
+thoughts belonging to this woman, it was robbing her of something not to
+be constantly thinking of her.
+
+The winter was severe, Madame Bovary’s convalescence slow. When it
+was fine they wheeled her arm-chair to the window that overlooked the
+square, for she now had an antipathy to the garden, and the blinds on
+that side were always down. She wished the horse to be sold; what she
+formerly liked now displeased her. All her ideas seemed to be limited to
+the care of herself. She stayed in bed taking little meals, rang for the
+servant to inquire about her gruel or to chat with her. The snow on
+the market-roof threw a white, still light into the room; then the rain
+began to fall; and Emma waited daily with a mind full of eagerness for
+the inevitable return of some trifling events which nevertheless had no
+relation to her. The most important was the arrival of the “Hirondelle”
+ in the evening. Then the landlady shouted out, and other voices
+answered, while Hippolyte’s lantern, as he fetched the boxes from the
+boot, was like a star in the darkness. At mid-day Charles came in;
+then he went out again; next she took some beef-tea, and towards five
+o’clock, as the day drew in, the children coming back from school,
+dragging their wooden shoes along the pavement, knocked the clapper of
+the shutters with their rulers one after the other.
+
+It was at this hour that Monsieur Bournisien came to see her. He
+inquired after her health, gave her news, exhorted her to religion, in a
+coaxing little prattle that was not without its charm. The mere thought
+of his cassock comforted her.
+
+One day, when at the height of her illness, she had thought herself
+dying, and had asked for the communion; and, while they were making the
+preparations in her room for the sacrament, while they were turning the
+night table covered with syrups into an altar, and while Felicite was
+strewing dahlia flowers on the floor, Emma felt some power passing
+over her that freed her from her pains, from all perception, from
+all feeling. Her body, relieved, no longer thought; another life was
+beginning; it seemed to her that her being, mounting toward God, would
+be annihilated in that love like a burning incense that melts into
+vapour. The bed-clothes were sprinkled with holy water, the priest drew
+from the holy pyx the white wafer; and it was fainting with a celestial
+joy that she put out her lips to accept the body of the Saviour
+presented to her. The curtains of the alcove floated gently round her
+like clouds, and the rays of the two tapers burning on the night-table
+seemed to shine like dazzling halos. Then she let her head fall back,
+fancying she heard in space the music of seraphic harps, and perceived
+in an azure sky, on a golden throne in the midst of saints holding green
+palms, God the Father, resplendent with majesty, who with a sign sent to
+earth angels with wings of fire to carry her away in their arms.
+
+This splendid vision dwelt in her memory as the most beautiful thing
+that it was possible to dream, so that now she strove to recall her
+sensation. That still lasted, however, but in a less exclusive fashion
+and with a deeper sweetness. Her soul, tortured by pride, at length
+found rest in Christian humility, and, tasting the joy of weakness, she
+saw within herself the destruction of her will, that must have left a
+wide entrance for the inroads of heavenly grace. There existed, then,
+in the place of happiness, still greater joys--another love beyond all
+loves, without pause and without end, one that would grow eternally! She
+saw amid the illusions of her hope a state of purity floating above the
+earth mingling with heaven, to which she aspired. She wanted to become
+a saint. She bought chaplets and wore amulets; she wished to have in her
+room, by the side of her bed, a reliquary set in emeralds that she might
+kiss it every evening.
+
+The cure marvelled at this humour, although Emma’s religion, he thought,
+might, from its fervour, end by touching on heresy, extravagance. But
+not being much versed in these matters, as soon as they went beyond a
+certain limit he wrote to Monsieur Boulard, bookseller to Monsignor,
+to send him “something good for a lady who was very clever.” The
+bookseller, with as much indifference as if he had been sending off
+hardware to niggers, packed up, pellmell, everything that was then the
+fashion in the pious book trade. There were little manuals in questions
+and answers, pamphlets of aggressive tone after the manner of Monsieur
+de Maistre, and certain novels in rose-coloured bindings and with
+a honied style, manufactured by troubadour seminarists or penitent
+blue-stockings. There were the “Think of it; the Man of the World at
+Mary’s Feet, by Monsieur de ***, decorated with many Orders”; “The
+Errors of Voltaire, for the Use of the Young,” etc.
+
+Madame Bovary’s mind was not yet sufficiently clear to apply herself
+seriously to anything; moreover, she began this reading in too much
+hurry. She grew provoked at the doctrines of religion; the arrogance
+of the polemic writings displeased her by their inveteracy in attacking
+people she did not know; and the secular stories, relieved with
+religion, seemed to her written in such ignorance of the world, that
+they insensibly estranged her from the truths for whose proof she was
+looking. Nevertheless, she persevered; and when the volume slipped
+from her hands, she fancied herself seized with the finest Catholic
+melancholy that an ethereal soul could conceive.
+
+As for the memory of Rodolphe, she had thrust it back to the bottom of
+her heart, and it remained there more solemn and more motionless than
+a king’s mummy in a catacomb. An exhalation escaped from this embalmed
+love, that, penetrating through everything, perfumed with tenderness the
+immaculate atmosphere in which she longed to live. When she knelt on her
+Gothic prie-Dieu, she addressed to the Lord the same suave words that
+she had murmured formerly to her lover in the outpourings of adultery.
+It was to make faith come; but no delights descended from the heavens,
+and she arose with tired limbs and with a vague feeling of a gigantic
+dupery.
+
+This searching after faith, she thought, was only one merit the more,
+and in the pride of her devoutness Emma compared herself to those grand
+ladies of long ago whose glory she had dreamed of over a portrait of La
+Valliere, and who, trailing with so much majesty the lace-trimmed trains
+of their long gowns, retired into solitudes to shed at the feet of
+Christ all the tears of hearts that life had wounded.
+
+Then she gave herself up to excessive charity. She sewed clothes for the
+poor, she sent wood to women in childbed; and Charles one day, on coming
+home, found three good-for-nothings in the kitchen seated at the table
+eating soup. She had her little girl, whom during her illness her
+husband had sent back to the nurse, brought home. She wanted to teach
+her to read; even when Berthe cried, she was not vexed. She had made
+up her mind to resignation, to universal indulgence. Her language about
+everything was full of ideal expressions. She said to her child, “Is
+your stomach-ache better, my angel?”
+
+Madame Bovary senior found nothing to censure except perhaps this mania
+of knitting jackets for orphans instead of mending her own house-linen;
+but, harassed with domestic quarrels, the good woman took pleasure in
+this quiet house, and she even stayed there till after Easter, to escape
+the sarcasms of old Bovary, who never failed on Good Friday to order
+chitterlings.
+
+Besides the companionship of her mother-in-law, who strengthened her a
+little by the rectitude of her judgment and her grave ways, Emma almost
+every day had other visitors. These were Madame Langlois, Madame Caron,
+Madame Dubreuil, Madame Tuvache, and regularly from two to five o’clock
+the excellent Madame Homais, who, for her part, had never believed any
+of the tittle-tattle about her neighbour. The little Homais also came to
+see her; Justin accompanied them. He went up with them to her bedroom,
+and remained standing near the door, motionless and mute. Often even
+Madame Bovary; taking no heed of him, began her toilette. She began by
+taking out her comb, shaking her head with a quick movement, and when
+he for the first time saw all this mass of hair that fell to her knees
+unrolling in black ringlets, it was to him, poor child! like a sudden
+entrance into something new and strange, whose splendour terrified him.
+
+Emma, no doubt, did not notice his silent attentions or his timidity.
+She had no suspicion that the love vanished from her life was there,
+palpitating by her side, beneath that coarse holland shirt, in that
+youthful heart open to the emanations of her beauty. Besides, she
+now enveloped all things with such indifference, she had words so
+affectionate with looks so haughty, such contradictory ways, that one
+could no longer distinguish egotism from charity, or corruption from
+virtue. One evening, for example, she was angry with the servant, who
+had asked to go out, and stammered as she tried to find some pretext.
+Then suddenly--
+
+“So you love him?” she said.
+
+And without waiting for any answer from Felicite, who was blushing, she
+added, “There! run along; enjoy yourself!”
+
+In the beginning of spring she had the garden turned up from end to end,
+despite Bovary’s remonstrances. However, he was glad to see her at last
+manifest a wish of any kind. As she grew stronger she displayed more
+wilfulness. First, she found occasion to expel Mere Rollet, the nurse,
+who during her convalescence had contracted the habit of coming too
+often to the kitchen with her two nurslings and her boarder, better
+off for teeth than a cannibal. Then she got rid of the Homais family,
+successively dismissed all the other visitors, and even frequented
+church less assiduously, to the great approval of the druggist, who said
+to her in a friendly way--
+
+“You were going in a bit for the cassock!”
+
+As formerly, Monsieur Bournisien dropped in every day when he came out
+after catechism class. He preferred staying out of doors to taking the
+air “in the grove,” as he called the arbour. This was the time when
+Charles came home. They were hot; some sweet cider was brought out, and
+they drank together to madame’s complete restoration.
+
+Binet was there; that is to say, a little lower down against the terrace
+wall, fishing for crayfish. Bovary invited him to have a drink, and he
+thoroughly understood the uncorking of the stone bottles.
+
+“You must,” he said, throwing a satisfied glance all round him, even to
+the very extremity of the landscape, “hold the bottle perpendicularly on
+the table, and after the strings are cut, press up the cork with
+little thrusts, gently, gently, as indeed they do seltzer-water at
+restaurants.”
+
+But during his demonstration the cider often spurted right into their
+faces, and then the ecclesiastic, with a thick laugh, never missed this
+joke--
+
+“Its goodness strikes the eye!”
+
+He was, in fact, a good fellow and one day he was not even scandalised
+at the chemist, who advised Charles to give madame some distraction
+by taking her to the theatre at Rouen to hear the illustrious tenor,
+Lagardy. Homais, surprised at this silence, wanted to know his opinion,
+and the priest declared that he considered music less dangerous for
+morals than literature.
+
+But the chemist took up the defence of letters. The theatre, he
+contended, served for railing at prejudices, and, beneath a mask of
+pleasure, taught virtue.
+
+“‘Castigat ridendo mores,’ * Monsieur Bournisien! Thus consider the
+greater part of Voltaire’s tragedies; they are cleverly strewn with
+philosophical reflections, that made them a vast school of morals and
+diplomacy for the people.”
+
+     *It corrects customs through laughter.
+
+
+“I,” said Binet, “once saw a piece called the ‘Gamin de Paris,’ in which
+there was the character of an old general that is really hit off to a
+T. He sets down a young swell who had seduced a working girl, who at the
+ending--”
+
+“Certainly,” continued Homais, “there is bad literature as there is bad
+pharmacy, but to condemn in a lump the most important of the fine arts
+seems to me a stupidity, a Gothic idea, worthy of the abominable times
+that imprisoned Galileo.”
+
+“I know very well,” objected the cure, “that there are good works,
+good authors. However, if it were only those persons of different sexes
+united in a bewitching apartment, decorated rouge, those lights, those
+effeminate voices, all this must, in the long-run, engender a
+certain mental libertinage, give rise to immodest thoughts and impure
+temptations. Such, at any rate, is the opinion of all the Fathers.
+Finally,” he added, suddenly assuming a mystic tone of voice while
+he rolled a pinch of snuff between his fingers, “if the Church has
+condemned the theatre, she must be right; we must submit to her
+decrees.”
+
+“Why,” asked the druggist, “should she excommunicate actors? For
+formerly they openly took part in religious ceremonies. Yes, in the
+middle of the chancel they acted; they performed a kind of farce called
+‘Mysteries,’ which often offended against the laws of decency.”
+
+The ecclesiastic contented himself with uttering a groan, and the
+chemist went on--
+
+“It’s like it is in the Bible; there there are, you know, more than one
+piquant detail, matters really libidinous!”
+
+And on a gesture of irritation from Monsieur Bournisien--
+
+“Ah! you’ll admit that it is not a book to place in the hands of a young
+girl, and I should be sorry if Athalie--”
+
+“But it is the Protestants, and not we,” cried the other impatiently,
+“who recommend the Bible.”
+
+“No matter,” said Homais. “I am surprised that in our days, in this
+century of enlightenment, anyone should still persist in proscribing an
+intellectual relaxation that is inoffensive, moralising, and sometimes
+even hygienic; is it not, doctor?”
+
+“No doubt,” replied the doctor carelessly, either because, sharing the
+same ideas, he wished to offend no one, or else because he had not any
+ideas.
+
+The conversation seemed at an end when the chemist thought fit to shoot
+a Parthian arrow.
+
+“I’ve known priests who put on ordinary clothes to go and see dancers
+kicking about.”
+
+“Come, come!” said the cure.
+
+“Ah! I’ve known some!” And separating the words of his sentence, Homais
+repeated, “I--have--known--some!”
+
+“Well, they were wrong,” said Bournisien, resigned to anything.
+
+“By Jove! they go in for more than that,” exclaimed the druggist.
+
+“Sir!” replied the ecclesiastic, with such angry eyes that the druggist
+was intimidated by them.
+
+“I only mean to say,” he replied in less brutal a tone, “that toleration
+is the surest way to draw people to religion.”
+
+“That is true! that is true!” agreed the good fellow, sitting down again
+on his chair. But he stayed only a few moments.
+
+Then, as soon as he had gone, Monsieur Homais said to the doctor--
+
+“That’s what I call a cock-fight. I beat him, did you see, in a
+way!--Now take my advice. Take madame to the theatre, if it were only
+for once in your life, to enrage one of these ravens, hang it! If anyone
+could take my place, I would accompany you myself. Be quick about it.
+Lagardy is only going to give one performance; he’s engaged to go to
+England at a high salary. From what I hear, he’s a regular dog; he’s
+rolling in money; he’s taking three mistresses and a cook along with
+him. All these great artists burn the candle at both ends; they require
+a dissolute life, that suits the imagination to some extent. But they
+die at the hospital, because they haven’t the sense when young to lay
+by. Well, a pleasant dinner! Goodbye till to-morrow.”
+
+The idea of the theatre quickly germinated in Bovary’s head, for he at
+once communicated it to his wife, who at first refused, alleging the
+fatigue, the worry, the expense; but, for a wonder, Charles did not give
+in, so sure was he that this recreation would be good for her. He saw
+nothing to prevent it: his mother had sent them three hundred francs
+which he had no longer expected; the current debts were not very large,
+and the falling in of Lheureux’s bills was still so far off that
+there was no need to think about them. Besides, imagining that she
+was refusing from delicacy, he insisted the more; so that by dint of
+worrying her she at last made up her mind, and the next day at eight
+o’clock they set out in the “Hirondelle.”
+
+The druggist, whom nothing whatever kept at Yonville, but who thought
+himself bound not to budge from it, sighed as he saw them go.
+
+“Well, a pleasant journey!” he said to them; “happy mortals that you
+are!”
+
+Then addressing himself to Emma, who was wearing a blue silk gown with
+four flounces--
+
+“You are as lovely as a Venus. You’ll cut a figure at Rouen.”
+
+The diligence stopped at the “Croix-Rouge” in the Place Beauvoisine. It
+was the inn that is in every provincial faubourg, with large stables
+and small bedrooms, where one sees in the middle of the court chickens
+pilfering the oats under the muddy gigs of the commercial travellers--a
+good old house, with worm-eaten balconies that creak in the wind on
+winter nights, always full of people, noise, and feeding, whose black
+tables are sticky with coffee and brandy, the thick windows made yellow
+by the flies, the damp napkins stained with cheap wine, and that always
+smells of the village, like ploughboys dressed in Sundayclothes, has
+a cafe on the street, and towards the countryside a kitchen-garden.
+Charles at once set out. He muddled up the stage-boxes with the gallery,
+the pit with the boxes; asked for explanations, did not understand them;
+was sent from the box-office to the acting-manager; came back to the
+inn, returned to the theatre, and thus several times traversed the whole
+length of the town from the theatre to the boulevard.
+
+Madame Bovary bought a bonnet, gloves, and a bouquet. The doctor was
+much afraid of missing the beginning, and, without having had time to
+swallow a plate of soup, they presented themselves at the doors of the
+theatre, which were still closed.
+
+
+
+
+Chapter Fifteen
+
+The crowd was waiting against the wall, symmetrically enclosed between
+the balustrades. At the corner of the neighbouring streets huge bills
+repeated in quaint letters “Lucie de Lammermoor-Lagardy-Opera-etc.” The
+weather was fine, the people were hot, perspiration trickled amid the
+curls, and handkerchiefs taken from pockets were mopping red foreheads;
+and now and then a warm wind that blew from the river gently stirred the
+border of the tick awnings hanging from the doors of the public-houses.
+A little lower down, however, one was refreshed by a current of icy air
+that smelt of tallow, leather, and oil. This was an exhalation from
+the Rue des Charrettes, full of large black warehouses where they made
+casks.
+
+For fear of seeming ridiculous, Emma before going in wished to have a
+little stroll in the harbour, and Bovary prudently kept his tickets in
+his hand, in the pocket of his trousers, which he pressed against his
+stomach.
+
+Her heart began to beat as soon as she reached the vestibule. She
+involuntarily smiled with vanity on seeing the crowd rushing to the
+right by the other corridor while she went up the staircase to the
+reserved seats. She was as pleased as a child to push with her finger
+the large tapestried door. She breathed in with all her might the
+dusty smell of the lobbies, and when she was seated in her box she bent
+forward with the air of a duchess.
+
+The theatre was beginning to fill; opera-glasses were taken from their
+cases, and the subscribers, catching sight of one another, were bowing.
+They came to seek relaxation in the fine arts after the anxieties of
+business; but “business” was not forgotten; they still talked cottons,
+spirits of wine, or indigo. The heads of old men were to be seen,
+inexpressive and peaceful, with their hair and complexions looking like
+silver medals tarnished by steam of lead. The young beaux were strutting
+about in the pit, showing in the opening of their waistcoats their pink
+or applegreen cravats, and Madame Bovary from above admired them leaning
+on their canes with golden knobs in the open palm of their yellow
+gloves.
+
+Now the lights of the orchestra were lit, the lustre, let down from the
+ceiling, throwing by the glimmering of its facets a sudden gaiety over
+the theatre; then the musicians came in one after the other; and
+first there was the protracted hubbub of the basses grumbling, violins
+squeaking, cornets trumpeting, flutes and flageolets fifing. But three
+knocks were heard on the stage, a rolling of drums began, the brass
+instruments played some chords, and the curtain rising, discovered a
+country-scene.
+
+It was the cross-roads of a wood, with a fountain shaded by an oak to
+the left. Peasants and lords with plaids on their shoulders were singing
+a hunting-song together; then a captain suddenly came on, who evoked
+the spirit of evil by lifting both his arms to heaven. Another appeared;
+they went away, and the hunters started afresh. She felt herself
+transported to the reading of her youth, into the midst of Walter Scott.
+She seemed to hear through the mist the sound of the Scotch bagpipes
+re-echoing over the heather. Then her remembrance of the novel helping
+her to understand the libretto, she followed the story phrase by phrase,
+while vague thoughts that came back to her dispersed at once again with
+the bursts of music. She gave herself up to the lullaby of the melodies,
+and felt all her being vibrate as if the violin bows were drawn over her
+nerves. She had not eyes enough to look at the costumes, the scenery,
+the actors, the painted trees that shook when anyone walked, and the
+velvet caps, cloaks, swords--all those imaginary things that floated
+amid the harmony as in the atmosphere of another world. But a young
+woman stepped forward, throwing a purse to a squire in green. She was
+left alone, and the flute was heard like the murmur of a fountain or the
+warbling of birds. Lucie attacked her cavatina in G major bravely. She
+plained of love; she longed for wings. Emma, too, fleeing from life,
+would have liked to fly away in an embrace. Suddenly Edgar-Lagardy
+appeared.
+
+He had that splendid pallor that gives something of the majesty of
+marble to the ardent races of the South. His vigorous form was tightly
+clad in a brown-coloured doublet; a small chiselled poniard hung against
+his left thigh, and he cast round laughing looks showing his white
+teeth. They said that a Polish princess having heard him sing one night
+on the beach at Biarritz, where he mended boats, had fallen in love
+with him. She had ruined herself for him. He had deserted her for
+other women, and this sentimental celebrity did not fail to enhance his
+artistic reputation. The diplomatic mummer took care always to slip into
+his advertisements some poetic phrase on the fascination of his
+person and the susceptibility of his soul. A fine organ, imperturbable
+coolness, more temperament than intelligence, more power of emphasis
+than of real singing, made up the charm of this admirable charlatan
+nature, in which there was something of the hairdresser and the
+toreador.
+
+From the first scene he evoked enthusiasm. He pressed Lucy in his arms,
+he left her, he came back, he seemed desperate; he had outbursts of
+rage, then elegiac gurglings of infinite sweetness, and the notes
+escaped from his bare neck full of sobs and kisses. Emma leant forward
+to see him, clutching the velvet of the box with her nails. She was
+filling her heart with these melodious lamentations that were drawn
+out to the accompaniment of the double-basses, like the cries of the
+drowning in the tumult of a tempest. She recognised all the intoxication
+and the anguish that had almost killed her. The voice of a prima donna
+seemed to her to be but echoes of her conscience, and this illusion that
+charmed her as some very thing of her own life. But no one on earth had
+loved her with such love. He had not wept like Edgar that last moonlit
+night when they said, “To-morrow! to-morrow!” The theatre rang with
+cheers; they recommenced the entire movement; the lovers spoke of
+the flowers on their tomb, of vows, exile, fate, hopes; and when they
+uttered the final adieu, Emma gave a sharp cry that mingled with the
+vibrations of the last chords.
+
+“But why,” asked Bovary, “does that gentleman persecute her?”
+
+“No, no!” she answered; “he is her lover!”
+
+“Yet he vows vengeance on her family, while the other one who came on
+before said, ‘I love Lucie and she loves me!’ Besides, he went off with
+her father arm in arm. For he certainly is her father, isn’t he--the
+ugly little man with a cock’s feather in his hat?”
+
+Despite Emma’s explanations, as soon as the recitative duet began
+in which Gilbert lays bare his abominable machinations to his master
+Ashton, Charles, seeing the false troth-ring that is to deceive Lucie,
+thought it was a love-gift sent by Edgar. He confessed, moreover, that
+he did not understand the story because of the music, which interfered
+very much with the words.
+
+“What does it matter?” said Emma. “Do be quiet!”
+
+“Yes, but you know,” he went on, leaning against her shoulder, “I like
+to understand things.”
+
+“Be quiet! be quiet!” she cried impatiently.
+
+Lucie advanced, half supported by her women, a wreath of orange blossoms
+in her hair, and paler than the white satin of her gown. Emma dreamed
+of her marriage day; she saw herself at home again amid the corn in the
+little path as they walked to the church. Oh, why had not she, like
+this woman, resisted, implored? She, on the contrary, had been joyous,
+without seeing the abyss into which she was throwing herself. Ah! if
+in the freshness of her beauty, before the soiling of marriage and the
+disillusions of adultery, she could have anchored her life upon some
+great, strong heart, then virtue, tenderness, voluptuousness, and duty
+blending, she would never have fallen from so high a happiness. But that
+happiness, no doubt, was a lie invented for the despair of all desire.
+She now knew the smallness of the passions that art exaggerated. So,
+striving to divert her thoughts, Emma determined now to see in this
+reproduction of her sorrows only a plastic fantasy, well enough to
+please the eye, and she even smiled internally with disdainful pity when
+at the back of the stage under the velvet hangings a man appeared in a
+black cloak.
+
+His large Spanish hat fell at a gesture he made, and immediately the
+instruments and the singers began the sextet. Edgar, flashing with fury,
+dominated all the others with his clearer voice; Ashton hurled homicidal
+provocations at him in deep notes; Lucie uttered her shrill plaint,
+Arthur at one side, his modulated tones in the middle register, and the
+bass of the minister pealed forth like an organ, while the voices of the
+women repeating his words took them up in chorus delightfully. They were
+all in a row gesticulating, and anger, vengeance, jealousy, terror, and
+stupefaction breathed forth at once from their half-opened mouths. The
+outraged lover brandished his naked sword; his guipure ruffle rose with
+jerks to the movements of his chest, and he walked from right to left
+with long strides, clanking against the boards the silver-gilt spurs of
+his soft boots, widening out at the ankles. He, she thought must have an
+inexhaustible love to lavish it upon the crowd with such effusion.
+All her small fault-findings faded before the poetry of the part
+that absorbed her; and, drawn towards this man by the illusion of the
+character, she tried to imagine to herself his life--that life resonant,
+extraordinary, splendid, and that might have been hers if fate had
+willed it. They would have known one another, loved one another. With
+him, through all the kingdoms of Europe she would have travelled from
+capital to capital, sharing his fatigues and his pride, picking up the
+flowers thrown to him, herself embroidering his costumes. Then each
+evening, at the back of a box, behind the golden trellis-work she would
+have drunk in eagerly the expansions of this soul that would have sung
+for her alone; from the stage, even as he acted, he would have looked
+at her. But the mad idea seized her that he was looking at her; it was
+certain. She longed to run to his arms, to take refuge in his strength,
+as in the incarnation of love itself, and to say to him, to cry out,
+“Take me away! carry me with you! let us go! Thine, thine! all my ardour
+and all my dreams!”
+
+The curtain fell.
+
+The smell of the gas mingled with that of the breaths, the waving of the
+fans, made the air more suffocating. Emma wanted to go out; the
+crowd filled the corridors, and she fell back in her arm-chair with
+palpitations that choked her. Charles, fearing that she would faint, ran
+to the refreshment-room to get a glass of barley-water.
+
+He had great difficulty in getting back to his seat, for his elbows were
+jerked at every step because of the glass he held in his hands, and
+he even spilt three-fourths on the shoulders of a Rouen lady in short
+sleeves, who feeling the cold liquid running down to her loins, uttered
+cries like a peacock, as if she were being assassinated. Her husband,
+who was a millowner, railed at the clumsy fellow, and while she was with
+her handkerchief wiping up the stains from her handsome cherry-coloured
+taffeta gown, he angrily muttered about indemnity, costs, reimbursement.
+At last Charles reached his wife, saying to her, quite out of breath--
+
+“Ma foi! I thought I should have had to stay there. There is such a
+crowd--SUCH a crowd!”
+
+He added--
+
+“Just guess whom I met up there! Monsieur Leon!”
+
+“Leon?”
+
+“Himself! He’s coming along to pay his respects.” And as he finished
+these words the ex-clerk of Yonville entered the box.
+
+He held out his hand with the ease of a gentleman; and Madame Bovary
+extended hers, without doubt obeying the attraction of a stronger will.
+She had not felt it since that spring evening when the rain fell upon
+the green leaves, and they had said good-bye standing at the window.
+But soon recalling herself to the necessities of the situation, with an
+effort she shook off the torpor of her memories, and began stammering a
+few hurried words.
+
+“Ah, good-day! What! you here?”
+
+“Silence!” cried a voice from the pit, for the third act was beginning.
+
+“So you are at Rouen?”
+
+“Yes.”
+
+“And since when?”
+
+“Turn them out! turn them out!” People were looking at them. They were
+silent.
+
+But from that moment she listened no more; and the chorus of the guests,
+the scene between Ashton and his servant, the grand duet in D major, all
+were for her as far off as if the instruments had grown less sonorous
+and the characters more remote. She remembered the games at cards at the
+druggist’s, and the walk to the nurse’s, the reading in the arbour,
+the tete-a-tete by the fireside--all that poor love, so calm and so
+protracted, so discreet, so tender, and that she had nevertheless
+forgotten. And why had he come back? What combination of circumstances
+had brought him back into her life? He was standing behind her, leaning
+with his shoulder against the wall of the box; now and again she felt
+herself shuddering beneath the hot breath from his nostrils falling upon
+her hair.
+
+“Does this amuse you?” said he, bending over her so closely that the end
+of his moustache brushed her cheek. She replied carelessly--
+
+“Oh, dear me, no, not much.”
+
+Then he proposed that they should leave the theatre and go and take an
+ice somewhere.
+
+“Oh, not yet; let us stay,” said Bovary. “Her hair’s undone; this is
+going to be tragic.”
+
+But the mad scene did not at all interest Emma, and the acting of the
+singer seemed to her exaggerated.
+
+“She screams too loud,” said she, turning to Charles, who was listening.
+
+“Yes--a little,” he replied, undecided between the frankness of his
+pleasure and his respect for his wife’s opinion.
+
+Then with a sigh Leon said--
+
+“The heat is--”
+
+“Unbearable! Yes!”
+
+“Do you feel unwell?” asked Bovary.
+
+“Yes, I am stifling; let us go.”
+
+Monsieur Leon put her long lace shawl carefully about her shoulders, and
+all three went off to sit down in the harbour, in the open air, outside
+the windows of a cafe.
+
+First they spoke of her illness, although Emma interrupted Charles
+from time to time, for fear, she said, of boring Monsieur Leon; and the
+latter told them that he had come to spend two years at Rouen in a large
+office, in order to get practice in his profession, which was different
+in Normandy and Paris. Then he inquired after Berthe, the Homais, Mere
+Lefrancois, and as they had, in the husband’s presence, nothing more to
+say to one another, the conversation soon came to an end.
+
+People coming out of the theatre passed along the pavement, humming or
+shouting at the top of their voices, “O bel ange, ma Lucie!*” Then Leon,
+playing the dilettante, began to talk music. He had seen Tambourini,
+Rubini, Persiani, Grisi, and, compared with them, Lagardy, despite his
+grand outbursts, was nowhere.
+
+     *Oh beautiful angel, my Lucie.
+
+
+“Yet,” interrupted Charles, who was slowly sipping his rum-sherbet,
+“they say that he is quite admirable in the last act. I regret leaving
+before the end, because it was beginning to amuse me.”
+
+“Why,” said the clerk, “he will soon give another performance.”
+
+But Charles replied that they were going back next day. “Unless,” he
+added, turning to his wife, “you would like to stay alone, kitten?”
+
+And changing his tactics at this unexpected opportunity that presented
+itself to his hopes, the young man sang the praises of Lagardy in the
+last number. It was really superb, sublime. Then Charles insisted--
+
+“You would get back on Sunday. Come, make up your mind. You are wrong if
+you feel that this is doing you the least good.”
+
+The tables round them, however, were emptying; a waiter came and stood
+discreetly near them. Charles, who understood, took out his purse; the
+clerk held back his arm, and did not forget to leave two more pieces of
+silver that he made chink on the marble.
+
+“I am really sorry,” said Bovary, “about the money which you are--”
+
+The other made a careless gesture full of cordiality, and taking his hat
+said--
+
+“It is settled, isn’t it? To-morrow at six o’clock?”
+
+Charles explained once more that he could not absent himself longer, but
+that nothing prevented Emma--
+
+“But,” she stammered, with a strange smile, “I am not sure--”
+
+“Well, you must think it over. We’ll see. Night brings counsel.” Then to
+Leon, who was walking along with them, “Now that you are in our part of
+the world, I hope you’ll come and ask us for some dinner now and then.”
+
+The clerk declared he would not fail to do so, being obliged, moreover,
+to go to Yonville on some business for his office. And they parted
+before the Saint-Herbland Passage just as the clock in the cathedral
+struck half-past eleven.
+
+
+
+
+Part III
+
+
+
+Chapter One
+
+Monsieur Leon, while studying law, had gone pretty often to the
+dancing-rooms, where he was even a great success amongst the grisettes,
+who thought he had a distinguished air. He was the best-mannered of the
+students; he wore his hair neither too long nor too short, didn’t spend
+all his quarter’s money on the first day of the month, and kept on good
+terms with his professors. As for excesses, he had always abstained from
+them, as much from cowardice as from refinement.
+
+Often when he stayed in his room to read, or else when sitting of an
+evening under the lime-trees of the Luxembourg, he let his Code fall to
+the ground, and the memory of Emma came back to him. But gradually this
+feeling grew weaker, and other desires gathered over it, although it
+still persisted through them all. For Leon did not lose all hope; there
+was for him, as it were, a vague promise floating in the future, like a
+golden fruit suspended from some fantastic tree.
+
+Then, seeing her again after three years of absence his passion
+reawakened. He must, he thought, at last make up his mind to possess
+her. Moreover, his timidity had worn off by contact with his gay
+companions, and he returned to the provinces despising everyone who had
+not with varnished shoes trodden the asphalt of the boulevards. By
+the side of a Parisienne in her laces, in the drawing-room of some
+illustrious physician, a person driving his carriage and wearing many
+orders, the poor clerk would no doubt have trembled like a child; but
+here, at Rouen, on the harbour, with the wife of this small doctor
+he felt at his ease, sure beforehand he would shine. Self-possession
+depends on its environment. We don’t speak on the first floor as on the
+fourth; and the wealthy woman seems to have, about her, to guard her
+virtue, all her banknotes, like a cuirass in the lining of her corset.
+
+On leaving the Bovarys the night before, Leon had followed them
+through the streets at a distance; then having seen them stop at the
+“Croix-Rouge,” he turned on his heel, and spent the night meditating a
+plan.
+
+So the next day about five o’clock he walked into the kitchen of the
+inn, with a choking sensation in his throat, pale cheeks, and that
+resolution of cowards that stops at nothing.
+
+“The gentleman isn’t in,” answered a servant.
+
+This seemed to him a good omen. He went upstairs.
+
+She was not disturbed at his approach; on the contrary, she apologised
+for having neglected to tell him where they were staying.
+
+“Oh, I divined it!” said Leon.
+
+He pretended he had been guided towards her by chance, by, instinct. She
+began to smile; and at once, to repair his folly, Leon told her that he
+had spent his morning in looking for her in all the hotels in the town
+one after the other.
+
+“So you have made up your mind to stay?” he added.
+
+“Yes,” she said, “and I am wrong. One ought not to accustom oneself to
+impossible pleasures when there are a thousand demands upon one.”
+
+“Oh, I can imagine!”
+
+“Ah! no; for you, you are a man!”
+
+But men too had had their trials, and the conversation went off into
+certain philosophical reflections. Emma expatiated much on the misery of
+earthly affections, and the eternal isolation in which the heart remains
+entombed.
+
+To show off, or from a naive imitation of this melancholy which called
+forth his, the young man declared that he had been awfully bored during
+the whole course of his studies. The law irritated him, other vocations
+attracted him, and his mother never ceased worrying him in every one
+of her letters. As they talked they explained more and more fully the
+motives of their sadness, working themselves up in their progressive
+confidence. But they sometimes stopped short of the complete exposition
+of their thought, and then sought to invent a phrase that might express
+it all the same. She did not confess her passion for another; he did not
+say that he had forgotten her.
+
+Perhaps he no longer remembered his suppers with girls after masked
+balls; and no doubt she did not recollect the rendezvous of old when she
+ran across the fields in the morning to her lover’s house. The noises
+of the town hardly reached them, and the room seemed small, as if
+on purpose to hem in their solitude more closely. Emma, in a dimity
+dressing-gown, leant her head against the back of the old arm-chair; the
+yellow wall-paper formed, as it were, a golden background behind her,
+and her bare head was mirrored in the glass with the white parting in
+the middle, and the tip of her ears peeping out from the folds of her
+hair.
+
+“But pardon me!” she said. “It is wrong of me. I weary you with my
+eternal complaints.”
+
+“No, never, never!”
+
+“If you knew,” she went on, raising to the ceiling her beautiful eyes,
+in which a tear was trembling, “all that I had dreamed!”
+
+“And I! Oh, I too have suffered! Often I went out; I went away. I
+dragged myself along the quays, seeking distraction amid the din of the
+crowd without being able to banish the heaviness that weighed upon me.
+In an engraver’s shop on the boulevard there is an Italian print of one
+of the Muses. She is draped in a tunic, and she is looking at the
+moon, with forget-me-nots in her flowing hair. Something drove me there
+continually; I stayed there hours together.” Then in a trembling voice,
+“She resembled you a little.”
+
+Madame Bovary turned away her head that he might not see the
+irrepressible smile she felt rising to her lips.
+
+“Often,” he went on, “I wrote you letters that I tore up.”
+
+She did not answer. He continued--
+
+“I sometimes fancied that some chance would bring you. I thought I
+recognised you at street-corners, and I ran after all the carriages
+through whose windows I saw a shawl fluttering, a veil like yours.”
+
+She seemed resolved to let him go on speaking without interruption.
+Crossing her arms and bending down her face, she looked at the rosettes
+on her slippers, and at intervals made little movements inside the satin
+of them with her toes.
+
+At last she sighed.
+
+“But the most wretched thing, is it not--is to drag out, as I do, a
+useless existence. If our pains were only of some use to someone, we
+should find consolation in the thought of the sacrifice.”
+
+He started off in praise of virtue, duty, and silent immolation, having
+himself an incredible longing for self-sacrifice that he could not
+satisfy.
+
+“I should much like,” she said, “to be a nurse at a hospital.”
+
+“Alas! men have none of these holy missions, and I see nowhere any
+calling--unless perhaps that of a doctor.”
+
+With a slight shrug of her shoulders, Emma interrupted him to speak of
+her illness, which had almost killed her. What a pity! She should not be
+suffering now! Leon at once envied the calm of the tomb, and one evening
+he had even made his will, asking to be buried in that beautiful rug
+with velvet stripes he had received from her. For this was how they
+would have wished to be, each setting up an ideal to which they were now
+adapting their past life. Besides, speech is a rolling-mill that always
+thins out the sentiment.
+
+But at this invention of the rug she asked, “But why?”
+
+“Why?” He hesitated. “Because I loved you so!” And congratulating
+himself at having surmounted the difficulty, Leon watched her face out
+of the corner of his eyes.
+
+It was like the sky when a gust of wind drives the clouds across. The
+mass of sad thoughts that darkened them seemed to be lifted from her
+blue eyes; her whole face shone. He waited. At last she replied--
+
+“I always suspected it.”
+
+Then they went over all the trifling events of that far-off existence,
+whose joys and sorrows they had just summed up in one word. They
+recalled the arbour with clematis, the dresses she had worn, the
+furniture of her room, the whole of her house.
+
+“And our poor cactuses, where are they?”
+
+“The cold killed them this winter.”
+
+“Ah! how I have thought of them, do you know? I often saw them again as
+of yore, when on the summer mornings the sun beat down upon your blinds,
+and I saw your two bare arms passing out amongst the flowers.”
+
+“Poor friend!” she said, holding out her hand to him.
+
+Leon swiftly pressed his lips to it. Then, when he had taken a deep
+breath--
+
+“At that time you were to me I know not what incomprehensible force that
+took captive my life. Once, for instance, I went to see you; but you, no
+doubt, do not remember it.”
+
+“I do,” she said; “go on.”
+
+“You were downstairs in the ante-room, ready to go out, standing on
+the last stair; you were wearing a bonnet with small blue flowers; and
+without any invitation from you, in spite of myself, I went with you.
+Every moment, however, I grew more and more conscious of my folly, and
+I went on walking by you, not daring to follow you completely, and
+unwilling to leave you. When you went into a shop, I waited in the
+street, and I watched you through the window taking off your gloves and
+counting the change on the counter. Then you rang at Madame Tuvache’s;
+you were let in, and I stood like an idiot in front of the great heavy
+door that had closed after you.”
+
+Madame Bovary, as she listened to him, wondered that she was so old. All
+these things reappearing before her seemed to widen out her life; it was
+like some sentimental immensity to which she returned; and from time to
+time she said in a low voice, her eyes half closed--
+
+“Yes, it is true--true--true!”
+
+They heard eight strike on the different clocks of the Beauvoisine
+quarter, which is full of schools, churches, and large empty hotels.
+They no longer spoke, but they felt as they looked upon each other a
+buzzing in their heads, as if something sonorous had escaped from the
+fixed eyes of each of them. They were hand in hand now, and the past,
+the future, reminiscences and dreams, all were confounded in the
+sweetness of this ecstasy. Night was darkening over the walls, on which
+still shone, half hidden in the shade, the coarse colours of four bills
+representing four scenes from the “Tour de Nesle,” with a motto in
+Spanish and French at the bottom. Through the sash-window a patch of
+dark sky was seen between the pointed roofs.
+
+She rose to light two wax-candles on the drawers, then she sat down
+again.
+
+“Well!” said Leon.
+
+“Well!” she replied.
+
+He was thinking how to resume the interrupted conversation, when she
+said to him--
+
+“How is it that no one until now has ever expressed such sentiments to
+me?”
+
+The clerk said that ideal natures were difficult to understand. He from
+the first moment had loved her, and he despaired when he thought of the
+happiness that would have been theirs, if thanks to fortune, meeting her
+earlier, they had been indissolubly bound to one another.
+
+“I have sometimes thought of it,” she went on.
+
+“What a dream!” murmured Leon. And fingering gently the blue binding of
+her long white sash, he added, “And who prevents us from beginning now?”
+
+“No, my friend,” she replied; “I am too old; you are too young. Forget
+me! Others will love you; you will love them.”
+
+“Not as you!” he cried.
+
+“What a child you are! Come, let us be sensible. I wish it.”
+
+She showed him the impossibility of their love, and that they must
+remain, as formerly, on the simple terms of a fraternal friendship.
+
+Was she speaking thus seriously? No doubt Emma did not herself know,
+quite absorbed as she was by the charm of the seduction, and the
+necessity of defending herself from it; and contemplating the young
+man with a moved look, she gently repulsed the timid caresses that his
+trembling hands attempted.
+
+“Ah! forgive me!” he cried, drawing back.
+
+Emma was seized with a vague fear at this shyness, more dangerous to her
+than the boldness of Rodolphe when he advanced to her open-armed. No man
+had ever seemed to her so beautiful. An exquisite candour emanated from
+his being. He lowered his long fine eyelashes, that curled upwards.
+His cheek, with the soft skin reddened, she thought, with desire of her
+person, and Emma felt an invincible longing to press her lips to it.
+Then, leaning towards the clock as if to see the time--
+
+“Ah! how late it is!” she said; “how we do chatter!”
+
+He understood the hint and took up his hat.
+
+“It has even made me forget the theatre. And poor Bovary has left me
+here especially for that. Monsieur Lormeaux, of the Rue Grand-Pont, was
+to take me and his wife.”
+
+And the opportunity was lost, as she was to leave the next day.
+
+“Really!” said Leon.
+
+“Yes.”
+
+“But I must see you again,” he went on. “I wanted to tell you--”
+
+“What?”
+
+“Something--important--serious. Oh, no! Besides, you will not go; it is
+impossible. If you should--listen to me. Then you have not understood
+me; you have not guessed--”
+
+“Yet you speak plainly,” said Emma.
+
+“Ah! you can jest. Enough! enough! Oh, for pity’s sake, let me see you
+once--only once!”
+
+“Well--” She stopped; then, as if thinking better of it, “Oh, not here!”
+
+“Where you will.”
+
+“Will you--” She seemed to reflect; then abruptly, “To-morrow at eleven
+o’clock in the cathedral.”
+
+“I shall be there,” he cried, seizing her hands, which she disengaged.
+
+And as they were both standing up, he behind her, and Emma with her head
+bent, he stooped over her and pressed long kisses on her neck.
+
+“You are mad! Ah! you are mad!” she said, with sounding little laughs,
+while the kisses multiplied.
+
+Then bending his head over her shoulder, he seemed to beg the consent of
+her eyes. They fell upon him full of an icy dignity.
+
+Leon stepped back to go out. He stopped on the threshold; then he
+whispered with a trembling voice, “Tomorrow!”
+
+She answered with a nod, and disappeared like a bird into the next room.
+
+In the evening Emma wrote the clerk an interminable letter, in which she
+cancelled the rendezvous; all was over; they must not, for the sake of
+their happiness, meet again. But when the letter was finished, as she
+did not know Leon’s address, she was puzzled.
+
+“I’ll give it to him myself,” she said; “he will come.”
+
+The next morning, at the open window, and humming on his balcony, Leon
+himself varnished his pumps with several coatings. He put on white
+trousers, fine socks, a green coat, emptied all the scent he had into
+his handkerchief, then having had his hair curled, he uncurled it again,
+in order to give it a more natural elegance.
+
+“It is still too early,” he thought, looking at the hairdresser’s
+cuckoo-clock, that pointed to the hour of nine. He read an old fashion
+journal, went out, smoked a cigar, walked up three streets, thought it
+was time, and went slowly towards the porch of Notre Dame.
+
+It was a beautiful summer morning. Silver plate sparkled in the
+jeweller’s windows, and the light falling obliquely on the cathedral
+made mirrors of the corners of the grey stones; a flock of birds
+fluttered in the grey sky round the trefoil bell-turrets; the square,
+resounding with cries, was fragrant with the flowers that bordered its
+pavement, roses, jasmines, pinks, narcissi, and tube-roses, unevenly
+spaced out between moist grasses, catmint, and chickweed for the birds;
+the fountains gurgled in the centre, and under large umbrellas, amidst
+melons, piled up in heaps, flower-women, bare-headed, were twisting
+paper round bunches of violets.
+
+The young man took one. It was the first time that he had bought flowers
+for a woman, and his breast, as he smelt them, swelled with pride, as if
+this homage that he meant for another had recoiled upon himself.
+
+But he was afraid of being seen; he resolutely entered the church. The
+beadle, who was just then standing on the threshold in the middle of the
+left doorway, under the “Dancing Marianne,” with feather cap, and rapier
+dangling against his calves, came in, more majestic than a cardinal, and
+as shining as a saint on a holy pyx.
+
+He came towards Leon, and, with that smile of wheedling benignity
+assumed by ecclesiastics when they question children--
+
+“The gentleman, no doubt, does not belong to these parts? The gentleman
+would like to see the curiosities of the church?”
+
+“No!” said the other.
+
+And he first went round the lower aisles. Then he went out to look at
+the Place. Emma was not coming yet. He went up again to the choir.
+
+The nave was reflected in the full fonts with the beginning of the
+arches and some portions of the glass windows. But the reflections of
+the paintings, broken by the marble rim, were continued farther on upon
+the flag-stones, like a many-coloured carpet. The broad daylight from
+without streamed into the church in three enormous rays from the three
+opened portals. From time to time at the upper end a sacristan passed,
+making the oblique genuflexion of devout persons in a hurry. The crystal
+lustres hung motionless. In the choir a silver lamp was burning, and
+from the side chapels and dark places of the church sometimes rose
+sounds like sighs, with the clang of a closing grating, its echo
+reverberating under the lofty vault.
+
+Leon with solemn steps walked along by the walls. Life had never seemed
+so good to him. She would come directly, charming, agitated, looking
+back at the glances that followed her, and with her flounced dress, her
+gold eyeglass, her thin shoes, with all sorts of elegant trifles that he
+had never enjoyed, and with the ineffable seduction of yielding virtue.
+The church like a huge boudoir spread around her; the arches bent down
+to gather in the shade the confession of her love; the windows shone
+resplendent to illumine her face, and the censers would burn that she
+might appear like an angel amid the fumes of the sweet-smelling odours.
+
+But she did not come. He sat down on a chair, and his eyes fell upon a
+blue stained window representing boatmen carrying baskets. He looked at
+it long, attentively, and he counted the scales of the fishes and the
+button-holes of the doublets, while his thoughts wandered off towards
+Emma.
+
+The beadle, standing aloof, was inwardly angry at this individual who
+took the liberty of admiring the cathedral by himself. He seemed to him
+to be conducting himself in a monstrous fashion, to be robbing him in a
+sort, and almost committing sacrilege.
+
+But a rustle of silk on the flags, the tip of a bonnet, a lined
+cloak--it was she! Leon rose and ran to meet her.
+
+Emma was pale. She walked fast.
+
+“Read!” she said, holding out a paper to him. “Oh, no!”
+
+And she abruptly withdrew her hand to enter the chapel of the Virgin,
+where, kneeling on a chair, she began to pray.
+
+The young man was irritated at this bigot fancy; then he nevertheless
+experienced a certain charm in seeing her, in the middle of a
+rendezvous, thus lost in her devotions, like an Andalusian marchioness;
+then he grew bored, for she seemed never coming to an end.
+
+Emma prayed, or rather strove to pray, hoping that some sudden
+resolution might descend to her from heaven; and to draw down divine
+aid she filled full her eyes with the splendours of the tabernacle. She
+breathed in the perfumes of the full-blown flowers in the large vases,
+and listened to the stillness of the church, that only heightened the
+tumult of her heart.
+
+She rose, and they were about to leave, when the beadle came forward,
+hurriedly saying--
+
+“Madame, no doubt, does not belong to these parts? Madame would like to
+see the curiosities of the church?”
+
+“Oh, no!” cried the clerk.
+
+“Why not?” said she. For she clung with her expiring virtue to the
+Virgin, the sculptures, the tombs--anything.
+
+Then, in order to proceed “by rule,” the beadle conducted them right to
+the entrance near the square, where, pointing out with his cane a large
+circle of block-stones without inscription or carving--
+
+“This,” he said majestically, “is the circumference of the beautiful
+bell of Ambroise. It weighed forty thousand pounds. There was not its
+equal in all Europe. The workman who cast it died of the joy--”
+
+“Let us go on,” said Leon.
+
+The old fellow started off again; then, having got back to the chapel of
+the Virgin, he stretched forth his arm with an all-embracing gesture
+of demonstration, and, prouder than a country squire showing you his
+espaliers, went on--
+
+“This simple stone covers Pierre de Breze, lord of Varenne and of
+Brissac, grand marshal of Poitou, and governor of Normandy, who died at
+the battle of Montlhery on the 16th of July, 1465.”
+
+Leon bit his lips, fuming.
+
+“And on the right, this gentleman all encased in iron, on the
+prancing horse, is his grandson, Louis de Breze, lord of Breval and of
+Montchauvet, Count de Maulevrier, Baron de Mauny, chamberlain to the
+king, Knight of the Order, and also governor of Normandy; died on the
+23rd of July, 1531--a Sunday, as the inscription specifies; and below,
+this figure, about to descend into the tomb, portrays the same person.
+It is not possible, is it, to see a more perfect representation of
+annihilation?”
+
+Madame Bovary put up her eyeglasses. Leon, motionless, looked at her,
+no longer even attempting to speak a single word, to make a gesture,
+so discouraged was he at this two-fold obstinacy of gossip and
+indifference.
+
+The everlasting guide went on--
+
+“Near him, this kneeling woman who weeps is his spouse, Diane de
+Poitiers, Countess de Breze, Duchess de Valentinois, born in 1499, died
+in 1566, and to the left, the one with the child is the Holy Virgin. Now
+turn to this side; here are the tombs of the Ambroise. They were both
+cardinals and archbishops of Rouen. That one was minister under Louis
+XII. He did a great deal for the cathedral. In his will he left thirty
+thousand gold crowns for the poor.”
+
+And without stopping, still talking, he pushed them into a chapel
+full of balustrades, some put away, and disclosed a kind of block that
+certainly might once have been an ill-made statue.
+
+“Truly,” he said with a groan, “it adorned the tomb of Richard Coeur de
+Lion, King of England and Duke of Normandy. It was the Calvinists, sir,
+who reduced it to this condition. They had buried it for spite in the
+earth, under the episcopal seat of Monsignor. See! this is the door by
+which Monsignor passes to his house. Let us pass on quickly to see the
+gargoyle windows.”
+
+But Leon hastily took some silver from his pocket and seized Emma’s
+arm. The beadle stood dumfounded, not able to understand this untimely
+munificence when there were still so many things for the stranger to
+see. So calling him back, he cried--
+
+“Sir! sir! The steeple! the steeple!”
+
+“No, thank you!” said Leon.
+
+“You are wrong, sir! It is four hundred and forty feet high, nine less
+than the great pyramid of Egypt. It is all cast; it--”
+
+Leon was fleeing, for it seemed to him that his love, that for nearly
+two hours now had become petrified in the church like the stones, would
+vanish like a vapour through that sort of truncated funnel, of oblong
+cage, of open chimney that rises so grotesquely from the cathedral like
+the extravagant attempt of some fantastic brazier.
+
+“But where are we going?” she said.
+
+Making no answer, he walked on with a rapid step; and Madame Bovary
+was already, dipping her finger in the holy water when behind them they
+heard a panting breath interrupted by the regular sound of a cane. Leon
+turned back.
+
+“Sir!”
+
+“What is it?”
+
+And he recognised the beadle, holding under his arms and balancing
+against his stomach some twenty large sewn volumes. They were works
+“which treated of the cathedral.”
+
+“Idiot!” growled Leon, rushing out of the church.
+
+A lad was playing about the close.
+
+“Go and get me a cab!”
+
+The child bounded off like a ball by the Rue Quatre-Vents; then they
+were alone a few minutes, face to face, and a little embarrassed.
+
+“Ah! Leon! Really--I don’t know--if I ought,” she whispered. Then with a
+more serious air, “Do you know, it is very improper--”
+
+“How so?” replied the clerk. “It is done at Paris.”
+
+And that, as an irresistible argument, decided her.
+
+Still the cab did not come. Leon was afraid she might go back into the
+church. At last the cab appeared.
+
+“At all events, go out by the north porch,” cried the beadle, who was
+left alone on the threshold, “so as to see the Resurrection, the Last
+Judgment, Paradise, King David, and the Condemned in Hell-flames.”
+
+“Where to, sir?” asked the coachman.
+
+“Where you like,” said Leon, forcing Emma into the cab.
+
+And the lumbering machine set out. It went down the Rue Grand-Pont,
+crossed the Place des Arts, the Quai Napoleon, the Pont Neuf, and
+stopped short before the statue of Pierre Corneille.
+
+“Go on,” cried a voice that came from within.
+
+The cab went on again, and as soon as it reached the Carrefour
+Lafayette, set off down-hill, and entered the station at a gallop.
+
+“No, straight on!” cried the same voice.
+
+The cab came out by the gate, and soon having reached the Cours, trotted
+quietly beneath the elm-trees. The coachman wiped his brow, put his
+leather hat between his knees, and drove his carriage beyond the side
+alley by the meadow to the margin of the waters.
+
+It went along by the river, along the towing-path paved with sharp
+pebbles, and for a long while in the direction of Oyssel, beyond the
+isles.
+
+But suddenly it turned with a dash across Quatremares, Sotteville, La
+Grande-Chaussee, the Rue d’Elbeuf, and made its third halt in front of
+the Jardin des Plantes.
+
+“Get on, will you?” cried the voice more furiously.
+
+And at once resuming its course, it passed by Saint-Sever, by the
+Quai’des Curandiers, the Quai aux Meules, once more over the bridge, by
+the Place du Champ de Mars, and behind the hospital gardens, where old
+men in black coats were walking in the sun along the terrace all green
+with ivy. It went up the Boulevard Bouvreuil, along the Boulevard
+Cauchoise, then the whole of Mont-Riboudet to the Deville hills.
+
+It came back; and then, without any fixed plan or direction, wandered
+about at hazard. The cab was seen at Saint-Pol, at Lescure, at Mont
+Gargan, at La Rougue-Marc and Place du Gaillardbois; in the Rue
+Maladrerie, Rue Dinanderie, before Saint-Romain, Saint-Vivien,
+Saint-Maclou, Saint-Nicaise--in front of the Customs, at the “Vieille
+Tour,” the “Trois Pipes,” and the Monumental Cemetery. From time to time
+the coachman, on his box cast despairing eyes at the public-houses.
+He could not understand what furious desire for locomotion urged these
+individuals never to wish to stop. He tried to now and then, and at
+once exclamations of anger burst forth behind him. Then he lashed his
+perspiring jades afresh, but indifferent to their jolting, running up
+against things here and there, not caring if he did, demoralised, and
+almost weeping with thirst, fatigue, and depression.
+
+And on the harbour, in the midst of the drays and casks, and in the
+streets, at the corners, the good folk opened large wonder-stricken
+eyes at this sight, so extraordinary in the provinces, a cab with blinds
+drawn, and which appeared thus constantly shut more closely than a tomb,
+and tossing about like a vessel.
+
+Once in the middle of the day, in the open country, just as the sun
+beat most fiercely against the old plated lanterns, a bared hand passed
+beneath the small blinds of yellow canvas, and threw out some scraps
+of paper that scattered in the wind, and farther off lighted like white
+butterflies on a field of red clover all in bloom.
+
+At about six o’clock the carriage stopped in a back street of the
+Beauvoisine Quarter, and a woman got out, who walked with her veil down,
+and without turning her head.
+
+
+
+Chapter Two
+
+On reaching the inn, Madame Bovary was surprised not to see the
+diligence. Hivert, who had waited for her fifty-three minutes, had at
+last started.
+
+Yet nothing forced her to go; but she had given her word that she would
+return that same evening. Moreover, Charles expected her, and in her
+heart she felt already that cowardly docility that is for some women at
+once the chastisement and atonement of adultery.
+
+She packed her box quickly, paid her bill, took a cab in the yard,
+hurrying on the driver, urging him on, every moment inquiring about
+the time and the miles traversed. He succeeded in catching up the
+“Hirondelle” as it neared the first houses of Quincampoix.
+
+Hardly was she seated in her corner than she closed her eyes, and opened
+them at the foot of the hill, when from afar she recognised Felicite,
+who was on the lookout in front of the farrier’s shop. Hivert pulled
+in his horses and, the servant, climbing up to the window, said
+mysteriously--
+
+“Madame, you must go at once to Monsieur Homais. It’s for something
+important.”
+
+The village was silent as usual. At the corner of the streets were small
+pink heaps that smoked in the air, for this was the time for jam-making,
+and everyone at Yonville prepared his supply on the same day. But in
+front of the chemist’s shop one might admire a far larger heap, and that
+surpassed the others with the superiority that a laboratory must have
+over ordinary stores, a general need over individual fancy.
+
+She went in. The large arm-chair was upset, and even the “Fanal de
+Rouen” lay on the ground, outspread between two pestles. She pushed open
+the lobby door, and in the middle of the kitchen, amid brown jars full
+of picked currants, of powdered sugar and lump sugar, of the scales on
+the table, and of the pans on the fire, she saw all the Homais, small
+and large, with aprons reaching to their chins, and with forks in their
+hands. Justin was standing up with bowed head, and the chemist was
+screaming--
+
+“Who told you to go and fetch it in the Capharnaum.”
+
+“What is it? What is the matter?”
+
+“What is it?” replied the druggist. “We are making preserves; they are
+simmering; but they were about to boil over, because there is too
+much juice, and I ordered another pan. Then he, from indolence, from
+laziness, went and took, hanging on its nail in my laboratory, the key
+of the Capharnaum.”
+
+It was thus the druggist called a small room under the leads, full of
+the utensils and the goods of his trade. He often spent long hours there
+alone, labelling, decanting, and doing up again; and he looked upon
+it not as a simple store, but as a veritable sanctuary, whence there
+afterwards issued, elaborated by his hands, all sorts of pills, boluses,
+infusions, lotions, and potions, that would bear far and wide his
+celebrity. No one in the world set foot there, and he respected it so,
+that he swept it himself. Finally, if the pharmacy, open to all comers,
+was the spot where he displayed his pride, the Capharnaum was the refuge
+where, egoistically concentrating himself, Homais delighted in the
+exercise of his predilections, so that Justin’s thoughtlessness seemed
+to him a monstrous piece of irreverence, and, redder than the currants,
+he repeated--
+
+“Yes, from the Capharnaum! The key that locks up the acids and caustic
+alkalies! To go and get a spare pan! a pan with a lid! and that I
+shall perhaps never use! Everything is of importance in the delicate
+operations of our art! But, devil take it! one must make distinctions,
+and not employ for almost domestic purposes that which is meant for
+pharmaceutical! It is as if one were to carve a fowl with a scalpel; as
+if a magistrate--”
+
+“Now be calm,” said Madame Homais.
+
+And Athalie, pulling at his coat, cried “Papa! papa!”
+
+“No, let me alone,” went on the druggist “let me alone, hang it! My
+word! One might as well set up for a grocer. That’s it! go it! respect
+nothing! break, smash, let loose the leeches, burn the mallow-paste,
+pickle the gherkins in the window jars, tear up the bandages!”
+
+“I thought you had--” said Emma.
+
+“Presently! Do you know to what you exposed yourself? Didn’t you see
+anything in the corner, on the left, on the third shelf? Speak, answer,
+articulate something.”
+
+“I--don’t--know,” stammered the young fellow.
+
+“Ah! you don’t know! Well, then, I do know! You saw a bottle of blue
+glass, sealed with yellow wax, that contains a white powder, on which I
+have even written ‘Dangerous!’ And do you know what is in it? Arsenic!
+And you go and touch it! You take a pan that was next to it!”
+
+“Next to it!” cried Madame Homais, clasping her hands. “Arsenic! You
+might have poisoned us all.”
+
+And the children began howling as if they already had frightful pains in
+their entrails.
+
+“Or poison a patient!” continued the druggist. “Do you want to see me
+in the prisoner’s dock with criminals, in a court of justice? To see
+me dragged to the scaffold? Don’t you know what care I take in managing
+things, although I am so thoroughly used to it? Often I am horrified
+myself when I think of my responsibility; for the Government persecutes
+us, and the absurd legislation that rules us is a veritable Damocles’
+sword over our heads.”
+
+Emma no longer dreamed of asking what they wanted her for, and the
+druggist went on in breathless phrases--
+
+“That is your return for all the kindness we have shown you! That is how
+you recompense me for the really paternal care that I lavish on you! For
+without me where would you be? What would you be doing? Who provides
+you with food, education, clothes, and all the means of figuring one day
+with honour in the ranks of society? But you must pull hard at the oar
+if you’re to do that, and get, as, people say, callosities upon your
+hands. Fabricando fit faber, age quod agis.*”
+
+     * The worker lives by working, do what he will.
+
+
+He was so exasperated he quoted Latin. He would have quoted Chinese
+or Greenlandish had he known those two languages, for he was in one
+of those crises in which the whole soul shows indistinctly what it
+contains, like the ocean, which, in the storm, opens itself from the
+seaweeds on its shores down to the sands of its abysses.
+
+And he went on--
+
+“I am beginning to repent terribly of having taken you up! I should
+certainly have done better to have left you to rot in your poverty and
+the dirt in which you were born. Oh, you’ll never be fit for anything
+but to herd animals with horns! You have no aptitude for science! You
+hardly know how to stick on a label! And there you are, dwelling with me
+snug as a parson, living in clover, taking your ease!”
+
+But Emma, turning to Madame Homais, “I was told to come here--”
+
+“Oh, dear me!” interrupted the good woman, with a sad air, “how am I to
+tell you? It is a misfortune!”
+
+She could not finish, the druggist was thundering--“Empty it! Clean it!
+Take it back! Be quick!”
+
+And seizing Justin by the collar of his blouse, he shook a book out of
+his pocket. The lad stooped, but Homais was the quicker, and, having
+picked up the volume, contemplated it with staring eyes and open mouth.
+
+“CONJUGAL--LOVE!” he said, slowly separating the two words. “Ah! very
+good! very good! very pretty! And illustrations! Oh, this is too much!”
+
+Madame Homais came forward.
+
+“No, do not touch it!”
+
+The children wanted to look at the pictures.
+
+“Leave the room,” he said imperiously; and they went out.
+
+First he walked up and down with the open volume in his hand, rolling
+his eyes, choking, tumid, apoplectic. Then he came straight to his
+pupil, and, planting himself in front of him with crossed arms--
+
+“Have you every vice, then, little wretch? Take care! you are on a
+downward path. Did not you reflect that this infamous book might fall
+in the hands of my children, kindle a spark in their minds, tarnish the
+purity of Athalie, corrupt Napoleon. He is already formed like a man.
+Are you quite sure, anyhow, that they have not read it? Can you certify
+to me--”
+
+“But really, sir,” said Emma, “you wished to tell me--”
+
+“Ah, yes! madame. Your father-in-law is dead.”
+
+In fact, Monsieur Bovary senior had expired the evening before suddenly
+from an attack of apoplexy as he got up from table, and by way of
+greater precaution, on account of Emma’s sensibility, Charles had begged
+Homais to break the horrible news to her gradually. Homais had thought
+over his speech; he had rounded, polished it, made it rhythmical; it was
+a masterpiece of prudence and transitions, of subtle turns and delicacy;
+but anger had got the better of rhetoric.
+
+Emma, giving up all chance of hearing any details, left the pharmacy;
+for Monsieur Homais had taken up the thread of his vituperations.
+However, he was growing calmer, and was now grumbling in a paternal tone
+whilst he fanned himself with his skull-cap.
+
+“It is not that I entirely disapprove of the work. Its author was a
+doctor! There are certain scientific points in it that it is not ill a
+man should know, and I would even venture to say that a man must know.
+But later--later! At any rate, not till you are man yourself and your
+temperament is formed.”
+
+When Emma knocked at the door. Charles, who was waiting for her, came
+forward with open arms and said to her with tears in his voice--
+
+“Ah! my dear!”
+
+And he bent over her gently to kiss her. But at the contact of his lips
+the memory of the other seized her, and she passed her hand over her
+face shuddering.
+
+But she made answer, “Yes, I know, I know!”
+
+He showed her the letter in which his mother told the event without any
+sentimental hypocrisy. She only regretted her husband had not received
+the consolations of religion, as he had died at Daudeville, in the
+street, at the door of a cafe after a patriotic dinner with some
+ex-officers.
+
+Emma gave him back the letter; then at dinner, for appearance’s sake,
+she affected a certain repugnance. But as he urged her to try, she
+resolutely began eating, while Charles opposite her sat motionless in a
+dejected attitude.
+
+Now and then he raised his head and gave her a long look full of
+distress. Once he sighed, “I should have liked to see him again!”
+
+She was silent. At last, understanding that she must say something, “How
+old was your father?” she asked.
+
+“Fifty-eight.”
+
+“Ah!”
+
+And that was all.
+
+A quarter of an hour after he added, “My poor mother! what will become
+of her now?”
+
+She made a gesture that signified she did not know. Seeing her so
+taciturn, Charles imagined her much affected, and forced himself to say
+nothing, not to reawaken this sorrow which moved him. And, shaking off
+his own--
+
+“Did you enjoy yourself yesterday?” he asked.
+
+“Yes.”
+
+When the cloth was removed, Bovary did not rise, nor did Emma; and as
+she looked at him, the monotony of the spectacle drove little by little
+all pity from her heart. He seemed to her paltry, weak, a cipher--in
+a word, a poor thing in every way. How to get rid of him? What an
+interminable evening! Something stupefying like the fumes of opium
+seized her.
+
+They heard in the passage the sharp noise of a wooden leg on the boards.
+It was Hippolyte bringing back Emma’s luggage. In order to put it down
+he described painfully a quarter of a circle with his stump.
+
+“He doesn’t even remember any more about it,” she thought, looking at
+the poor devil, whose coarse red hair was wet with perspiration.
+
+Bovary was searching at the bottom of his purse for a centime, and
+without appearing to understand all there was of humiliation for him
+in the mere presence of this man, who stood there like a personified
+reproach to his incurable incapacity.
+
+“Hallo! you’ve a pretty bouquet,” he said, noticing Leon’s violets on
+the chimney.
+
+“Yes,” she replied indifferently; “it’s a bouquet I bought just now from
+a beggar.”
+
+Charles picked up the flowers, and freshening his eyes, red with tears,
+against them, smelt them delicately.
+
+She took them quickly from his hand and put them in a glass of water.
+
+The next day Madame Bovary senior arrived. She and her son wept much.
+Emma, on the pretext of giving orders, disappeared. The following day
+they had a talk over the mourning. They went and sat down with their
+workboxes by the waterside under the arbour.
+
+Charles was thinking of his father, and was surprised to feel so much
+affection for this man, whom till then he had thought he cared little
+about. Madame Bovary senior was thinking of her husband. The worst
+days of the past seemed enviable to her. All was forgotten beneath the
+instinctive regret of such a long habit, and from time to time whilst
+she sewed, a big tear rolled along her nose and hung suspended there a
+moment. Emma was thinking that it was scarcely forty-eight hours since
+they had been together, far from the world, all in a frenzy of joy, and
+not having eyes enough to gaze upon each other. She tried to recall the
+slightest details of that past day. But the presence of her husband and
+mother-in-law worried her. She would have liked to hear nothing, to see
+nothing, so as not to disturb the meditation on her love, that, do what
+she would, became lost in external sensations.
+
+She was unpicking the lining of a dress, and the strips were scattered
+around her. Madame Bovary senior was plying her scissor without looking
+up, and Charles, in his list slippers and his old brown surtout that he
+used as a dressing-gown, sat with both hands in his pockets, and did not
+speak either; near them Berthe, in a little white pinafore, was raking
+sand in the walks with her spade. Suddenly she saw Monsieur Lheureux,
+the linendraper, come in through the gate.
+
+He came to offer his services “under the sad circumstances.” Emma
+answered that she thought she could do without. The shopkeeper was not
+to be beaten.
+
+“I beg your pardon,” he said, “but I should like to have a private talk
+with you.” Then in a low voice, “It’s about that affair--you know.”
+
+Charles crimsoned to his ears. “Oh, yes! certainly.” And in his
+confusion, turning to his wife, “Couldn’t you, my darling?”
+
+She seemed to understand him, for she rose; and Charles said to his
+mother, “It is nothing particular. No doubt, some household trifle.” He
+did not want her to know the story of the bill, fearing her reproaches.
+
+As soon as they were alone, Monsieur Lheureux in sufficiently clear
+terms began to congratulate Emma on the inheritance, then to talk of
+indifferent matters, of the espaliers, of the harvest, and of his own
+health, which was always so-so, always having ups and downs. In fact, he
+had to work devilish hard, although he didn’t make enough, in spite of
+all people said, to find butter for his bread.
+
+Emma let him talk on. She had bored herself so prodigiously the last two
+days.
+
+“And so you’re quite well again?” he went on. “Ma foi! I saw your
+husband in a sad state. He’s a good fellow, though we did have a little
+misunderstanding.”
+
+She asked what misunderstanding, for Charles had said nothing of the
+dispute about the goods supplied to her.
+
+“Why, you know well enough,” cried Lheureux. “It was about your little
+fancies--the travelling trunks.”
+
+He had drawn his hat over his eyes, and, with his hands behind his
+back, smiling and whistling, he looked straight at her in an unbearable
+manner. Did he suspect anything?
+
+She was lost in all kinds of apprehensions. At last, however, he went
+on--
+
+“We made it up, all the same, and I’ve come again to propose another
+arrangement.”
+
+This was to renew the bill Bovary had signed. The doctor, of course,
+would do as he pleased; he was not to trouble himself, especially just
+now, when he would have a lot of worry. “And he would do better to give
+it over to someone else--to you, for example. With a power of attorney
+it could be easily managed, and then we (you and I) would have our
+little business transactions together.”
+
+She did not understand. He was silent. Then, passing to his trade,
+Lheureux declared that madame must require something. He would send her
+a black barege, twelve yards, just enough to make a gown.
+
+“The one you’ve on is good enough for the house, but you want another
+for calls. I saw that the very moment that I came in. I’ve the eye of an
+American!”
+
+He did not send the stuff; he brought it. Then he came again to measure
+it; he came again on other pretexts, always trying to make himself
+agreeable, useful, “enfeoffing himself,” as Homais would have said, and
+always dropping some hint to Emma about the power of attorney. He never
+mentioned the bill; she did not think of it. Charles, at the beginning
+of her convalescence, had certainly said something about it to her,
+but so many emotions had passed through her head that she no longer
+remembered it. Besides, she took care not to talk of any money
+questions. Madame Bovary seemed surprised at this, and attributed the
+change in her ways to the religious sentiments she had contracted during
+her illness.
+
+But as soon as she was gone, Emma greatly astounded Bovary by her
+practical good sense. It would be necessary to make inquiries, to look
+into mortgages, and see if there were any occasion for a sale by auction
+or a liquidation. She quoted technical terms casually, pronounced the
+grand words of order, the future, foresight, and constantly exaggerated
+the difficulties of settling his father’s affairs so much, that at last
+one day she showed him the rough draft of a power of attorney to manage
+and administer his business, arrange all loans, sign and endorse all
+bills, pay all sums, etc. She had profited by Lheureux’s lessons.
+Charles naively asked her where this paper came from.
+
+“Monsieur Guillaumin”; and with the utmost coolness she added, “I don’t
+trust him overmuch. Notaries have such a bad reputation. Perhaps we
+ought to consult--we only know--no one.”
+
+“Unless Leon--” replied Charles, who was reflecting. But it was
+difficult to explain matters by letter. Then she offered to make the
+journey, but he thanked her. She insisted. It was quite a contest of
+mutual consideration. At last she cried with affected waywardness--
+
+“No, I will go!”
+
+“How good you are!” he said, kissing her forehead.
+
+The next morning she set out in the “Hirondelle” to go to Rouen to
+consult Monsieur Leon, and she stayed there three days.
+
+
+
+Chapter Three
+
+They were three full, exquisite days--a true honeymoon. They were at
+the Hotel-de-Boulogne, on the harbour; and they lived there, with drawn
+blinds and closed doors, with flowers on the floor, and iced syrups were
+brought them early in the morning.
+
+Towards evening they took a covered boat and went to dine on one of the
+islands. It was the time when one hears by the side of the dockyard the
+caulking-mallets sounding against the hull of vessels. The smoke of
+the tar rose up between the trees; there were large fatty drops on the
+water, undulating in the purple colour of the sun, like floating plaques
+of Florentine bronze.
+
+They rowed down in the midst of moored boats, whose long oblique cables
+grazed lightly against the bottom of the boat. The din of the town
+gradually grew distant; the rolling of carriages, the tumult of voices,
+the yelping of dogs on the decks of vessels. She took off her bonnet,
+and they landed on their island.
+
+They sat down in the low-ceilinged room of a tavern, at whose door hung
+black nets. They ate fried smelts, cream and cherries. They lay down
+upon the grass; they kissed behind the poplars; and they would fain,
+like two Robinsons, have lived for ever in this little place, which
+seemed to them in their beatitude the most magnificent on earth. It was
+not the first time that they had seen trees, a blue sky, meadows; that
+they had heard the water flowing and the wind blowing in the leaves;
+but, no doubt, they had never admired all this, as if Nature had
+not existed before, or had only begun to be beautiful since the
+gratification of their desires.
+
+At night they returned. The boat glided along the shores of the islands.
+They sat at the bottom, both hidden by the shade, in silence. The square
+oars rang in the iron thwarts, and, in the stillness, seemed to mark
+time, like the beating of a metronome, while at the stern the rudder
+that trailed behind never ceased its gentle splash against the water.
+
+Once the moon rose; they did not fail to make fine phrases, finding the
+orb melancholy and full of poetry. She even began to sing--
+
+“One night, do you remember, we were sailing,” etc.
+
+Her musical but weak voice died away along the waves, and the winds
+carried off the trills that Leon heard pass like the flapping of wings
+about him.
+
+She was opposite him, leaning against the partition of the shallop,
+through one of whose raised blinds the moon streamed in. Her black
+dress, whose drapery spread out like a fan, made her seem more slender,
+taller. Her head was raised, her hands clasped, her eyes turned towards
+heaven. At times the shadow of the willows hid her completely; then she
+reappeared suddenly, like a vision in the moonlight.
+
+Leon, on the floor by her side, found under his hand a ribbon of scarlet
+silk. The boatman looked at it, and at last said--
+
+“Perhaps it belongs to the party I took out the other day. A lot
+of jolly folk, gentlemen and ladies, with cakes, champagne,
+cornets--everything in style! There was one especially, a tall handsome
+man with small moustaches, who was that funny! And they all kept saying,
+‘Now tell us something, Adolphe--Dolpe,’ I think.”
+
+She shivered.
+
+“You are in pain?” asked Leon, coming closer to her.
+
+“Oh, it’s nothing! No doubt, it is only the night air.”
+
+“And who doesn’t want for women, either,” softly added the sailor,
+thinking he was paying the stranger a compliment.
+
+Then, spitting on his hands, he took the oars again.
+
+Yet they had to part. The adieux were sad. He was to send his letters to
+Mere Rollet, and she gave him such precise instructions about a double
+envelope that he admired greatly her amorous astuteness.
+
+“So you can assure me it is all right?” she said with her last kiss.
+
+“Yes, certainly.”
+
+“But why,” he thought afterwards as he came back through the streets
+alone, “is she so very anxious to get this power of attorney?”
+
+
+
+Chapter Four
+
+Leon soon put on an air of superiority before his comrades, avoided
+their company, and completely neglected his work.
+
+He waited for her letters; he re-read them; he wrote to her. He called
+her to mind with all the strength of his desires and of his memories.
+Instead of lessening with absence, this longing to see her again grew,
+so that at last on Saturday morning he escaped from his office.
+
+When, from the summit of the hill, he saw in the valley below the
+church-spire with its tin flag swinging in the wind, he felt that
+delight mingled with triumphant vanity and egoistic tenderness that
+millionaires must experience when they come back to their native
+village.
+
+He went rambling round her house. A light was burning in the kitchen. He
+watched for her shadow behind the curtains, but nothing appeared.
+
+Mere Lefrancois, when she saw him, uttered many exclamations. She
+thought he “had grown and was thinner,” while Artemise, on the contrary,
+thought him stouter and darker.
+
+He dined in the little room as of yore, but alone, without the
+tax-gatherer; for Binet, tired of waiting for the “Hirondelle,” had
+definitely put forward his meal one hour, and now he dined punctually at
+five, and yet he declared usually the rickety old concern “was late.”
+
+Leon, however, made up his mind, and knocked at the doctor’s door.
+Madame was in her room, and did not come down for a quarter of an hour.
+The doctor seemed delighted to see him, but he never stirred out that
+evening, nor all the next day.
+
+He saw her alone in the evening, very late, behind the garden in the
+lane; in the lane, as she had the other one! It was a stormy night, and
+they talked under an umbrella by lightning flashes.
+
+Their separation was becoming intolerable. “I would rather die!” said
+Emma. She was writhing in his arms, weeping. “Adieu! adieu! When shall I
+see you again?”
+
+They came back again to embrace once more, and it was then that
+she promised him to find soon, by no matter what means, a regular
+opportunity for seeing one another in freedom at least once a week. Emma
+never doubted she should be able to do this. Besides, she was full of
+hope. Some money was coming to her.
+
+On the strength of it she bought a pair of yellow curtains with large
+stripes for her room, whose cheapness Monsieur Lheureux had commended;
+she dreamed of getting a carpet, and Lheureux, declaring that it wasn’t
+“drinking the sea,” politely undertook to supply her with one. She could
+no longer do without his services. Twenty times a day she sent for him,
+and he at once put by his business without a murmur. People could not
+understand either why Mere Rollet breakfasted with her every day, and
+even paid her private visits.
+
+It was about this time, that is to say, the beginning of winter, that
+she seemed seized with great musical fervour.
+
+One evening when Charles was listening to her, she began the same piece
+four times over, each time with much vexation, while he, not noticing
+any difference, cried--
+
+“Bravo! very goodl You are wrong to stop. Go on!”
+
+“Oh, no; it is execrable! My fingers are quite rusty.”
+
+The next day he begged her to play him something again.
+
+“Very well; to please you!”
+
+And Charles confessed she had gone off a little. She played wrong notes
+and blundered; then, stopping short--
+
+“Ah! it is no use. I ought to take some lessons; but--” She bit her lips
+and added, “Twenty francs a lesson, that’s too dear!”
+
+“Yes, so it is--rather,” said Charles, giggling stupidly. “But it seems
+to me that one might be able to do it for less; for there are artists of
+no reputation, and who are often better than the celebrities.”
+
+“Find them!” said Emma.
+
+The next day when he came home he looked at her shyly, and at last could
+no longer keep back the words.
+
+“How obstinate you are sometimes! I went to Barfucheres to-day. Well,
+Madame Liegard assured me that her three young ladies who are at
+La Misericorde have lessons at fifty sous apiece, and that from an
+excellent mistress!”
+
+She shrugged her shoulders and did not open her piano again. But when
+she passed by it (if Bovary were there), she sighed--
+
+“Ah! my poor piano!”
+
+And when anyone came to see her, she did not fail to inform them she
+had given up music, and could not begin again now for important reasons.
+Then people commiserated her--
+
+“What a pity! she had so much talent!”
+
+They even spoke to Bovary about it. They put him to shame, and
+especially the chemist.
+
+“You are wrong. One should never let any of the faculties of nature lie
+fallow. Besides, just think, my good friend, that by inducing madame to
+study; you are economising on the subsequent musical education of
+your child. For my own part, I think that mothers ought themselves to
+instruct their children. That is an idea of Rousseau’s, still rather
+new perhaps, but that will end by triumphing, I am certain of it, like
+mothers nursing their own children and vaccination.”
+
+So Charles returned once more to this question of the piano. Emma
+replied bitterly that it would be better to sell it. This poor piano,
+that had given her vanity so much satisfaction--to see it go was to
+Bovary like the indefinable suicide of a part of herself.
+
+“If you liked,” he said, “a lesson from time to time, that wouldn’t
+after all be very ruinous.”
+
+“But lessons,” she replied, “are only of use when followed up.”
+
+And thus it was she set about obtaining her husband’s permission to go
+to town once a week to see her lover. At the end of a month she was even
+considered to have made considerable progress.
+
+
+
+Chapter Five
+
+She went on Thursdays. She got up and dressed silently, in order not to
+awaken Charles, who would have made remarks about her getting ready too
+early. Next she walked up and down, went to the windows, and looked out
+at the Place. The early dawn was broadening between the pillars of the
+market, and the chemist’s shop, with the shutters still up, showed in
+the pale light of the dawn the large letters of his signboard.
+
+When the clock pointed to a quarter past seven, she went off to the
+“Lion d’Or,” whose door Artemise opened yawning. The girl then made
+up the coals covered by the cinders, and Emma remained alone in the
+kitchen. Now and again she went out. Hivert was leisurely harnessing his
+horses, listening, moreover, to Mere Lefrancois, who, passing her head
+and nightcap through a grating, was charging him with commissions and
+giving him explanations that would have confused anyone else. Emma kept
+beating the soles of her boots against the pavement of the yard.
+
+At last, when he had eaten his soup, put on his cloak, lighted his pipe,
+and grasped his whip, he calmly installed himself on his seat.
+
+The “Hirondelle” started at a slow trot, and for about a mile stopped
+here and there to pick up passengers who waited for it, standing at the
+border of the road, in front of their yard gates.
+
+Those who had secured seats the evening before kept it waiting; some
+even were still in bed in their houses. Hivert called, shouted, swore;
+then he got down from his seat and went and knocked loudly at the doors.
+The wind blew through the cracked windows.
+
+The four seats, however, filled up. The carriage rolled off; rows of
+apple-trees followed one upon another, and the road between its two long
+ditches, full of yellow water, rose, constantly narrowing towards the
+horizon.
+
+Emma knew it from end to end; she knew that after a meadow there was
+a sign-post, next an elm, a barn, or the hut of a lime-kiln tender.
+Sometimes even, in the hope of getting some surprise, she shut her eyes,
+but she never lost the clear perception of the distance to be traversed.
+
+At last the brick houses began to follow one another more closely, the
+earth resounded beneath the wheels, the “Hirondelle” glided between the
+gardens, where through an opening one saw statues, a periwinkle plant,
+clipped yews, and a swing. Then on a sudden the town appeared. Sloping
+down like an amphitheatre, and drowned in the fog, it widened out
+beyond the bridges confusedly. Then the open country spread away with
+a monotonous movement till it touched in the distance the vague line of
+the pale sky. Seen thus from above, the whole landscape looked immovable
+as a picture; the anchored ships were massed in one corner, the river
+curved round the foot of the green hills, and the isles, oblique in
+shape, lay on the water, like large, motionless, black fishes. The
+factory chimneys belched forth immense brown fumes that were blown away
+at the top. One heard the rumbling of the foundries, together with the
+clear chimes of the churches that stood out in the mist. The leafless
+trees on the boulevards made violet thickets in the midst of the
+houses, and the roofs, all shining with the rain, threw back unequal
+reflections, according to the height of the quarters in which they were.
+Sometimes a gust of wind drove the clouds towards the Saint Catherine
+hills, like aerial waves that broke silently against a cliff.
+
+A giddiness seemed to her to detach itself from this mass of existence,
+and her heart swelled as if the hundred and twenty thousand souls that
+palpitated there had all at once sent into it the vapour of the passions
+she fancied theirs. Her love grew in the presence of this vastness, and
+expanded with tumult to the vague murmurings that rose towards her. She
+poured it out upon the square, on the walks, on the streets, and the
+old Norman city outspread before her eyes as an enormous capital, as a
+Babylon into which she was entering. She leant with both hands against
+the window, drinking in the breeze; the three horses galloped, the
+stones grated in the mud, the diligence rocked, and Hivert, from afar,
+hailed the carts on the road, while the bourgeois who had spent the
+night at the Guillaume woods came quietly down the hill in their little
+family carriages.
+
+They stopped at the barrier; Emma undid her overshoes, put on other
+gloves, rearranged her shawl, and some twenty paces farther she got down
+from the “Hirondelle.”
+
+The town was then awakening. Shop-boys in caps were cleaning up the
+shop-fronts, and women with baskets against their hips, at intervals
+uttered sonorous cries at the corners of streets. She walked with
+downcast eyes, close to the walls, and smiling with pleasure under her
+lowered black veil.
+
+For fear of being seen, she did not usually take the most direct road.
+She plunged into dark alleys, and, all perspiring, reached the bottom
+of the Rue Nationale, near the fountain that stands there. It is the
+quarter for theatres, public-houses, and whores. Often a cart would
+pass near her, bearing some shaking scenery. Waiters in aprons were
+sprinkling sand on the flagstones between green shrubs. It all smelt of
+absinthe, cigars, and oysters.
+
+She turned down a street; she recognised him by his curling hair that
+escaped from beneath his hat.
+
+Leon walked along the pavement. She followed him to the hotel. He went
+up, opened the door, entered--What an embrace!
+
+Then, after the kisses, the words gushed forth. They told each other the
+sorrows of the week, the presentiments, the anxiety for the letters; but
+now everything was forgotten; they gazed into each other’s faces with
+voluptuous laughs, and tender names.
+
+The bed was large, of mahogany, in the shape of a boat. The curtains
+were in red levantine, that hung from the ceiling and bulged out too
+much towards the bell-shaped bedside; and nothing in the world was so
+lovely as her brown head and white skin standing out against this purple
+colour, when, with a movement of shame, she crossed her bare arms,
+hiding her face in her hands.
+
+The warm room, with its discreet carpet, its gay ornaments, and its
+calm light, seemed made for the intimacies of passion. The curtain-rods,
+ending in arrows, their brass pegs, and the great balls of the fire-dogs
+shone suddenly when the sun came in. On the chimney between the
+candelabra there were two of those pink shells in which one hears the
+murmur of the sea if one holds them to the ear.
+
+How they loved that dear room, so full of gaiety, despite its rather
+faded splendour! They always found the furniture in the same place, and
+sometimes hairpins, that she had forgotten the Thursday before, under
+the pedestal of the clock. They lunched by the fireside on a little
+round table, inlaid with rosewood. Emma carved, put bits on his plate
+with all sorts of coquettish ways, and she laughed with a sonorous and
+libertine laugh when the froth of the champagne ran over from the
+glass to the rings on her fingers. They were so completely lost in
+the possession of each other that they thought themselves in their
+own house, and that they would live there till death, like two spouses
+eternally young. They said “our room,” “our carpet,” she even said “my
+slippers,” a gift of Leon’s, a whim she had had. They were pink satin,
+bordered with swansdown. When she sat on his knees, her leg, then too
+short, hung in the air, and the dainty shoe, that had no back to it, was
+held only by the toes to her bare foot.
+
+He for the first time enjoyed the inexpressible delicacy of feminine
+refinements. He had never met this grace of language, this reserve of
+clothing, these poses of the weary dove. He admired the exaltation of
+her soul and the lace on her petticoat. Besides, was she not “a lady”
+ and a married woman--a real mistress, in fine?
+
+By the diversity of her humour, in turn mystical or mirthful, talkative,
+taciturn, passionate, careless, she awakened in him a thousand desires,
+called up instincts or memories. She was the mistress of all the novels,
+the heroine of all the dramas, the vague “she” of all the volumes
+of verse. He found again on her shoulder the amber colouring of the
+“Odalisque Bathing”; she had the long waist of feudal chatelaines, and
+she resembled the “Pale Woman of Barcelona.” But above all she was the
+Angel!
+
+Often looking at her, it seemed to him that his soul, escaping towards
+her, spread like a wave about the outline of her head, and descended
+drawn down into the whiteness of her breast. He knelt on the ground
+before her, and with both elbows on her knees looked at her with a
+smile, his face upturned.
+
+She bent over him, and murmured, as if choking with intoxication--
+
+“Oh, do not move! do not speak! look at me! Something so sweet comes
+from your eyes that helps me so much!”
+
+She called him “child.” “Child, do you love me?”
+
+And she did not listen for his answer in the haste of her lips that
+fastened to his mouth.
+
+On the clock there was a bronze cupid, who smirked as he bent his arm
+beneath a golden garland. They had laughed at it many a time, but when
+they had to part everything seemed serious to them.
+
+Motionless in front of each other, they kept repeating, “Till Thursday,
+till Thursday.”
+
+Suddenly she seized his head between her hands, kissed him hurriedly on
+the forehead, crying, “Adieu!” and rushed down the stairs.
+
+She went to a hairdresser’s in the Rue de la Comedie to have her hair
+arranged. Night fell; the gas was lighted in the shop. She heard the
+bell at the theatre calling the mummers to the performance, and she saw,
+passing opposite, men with white faces and women in faded gowns going in
+at the stage-door.
+
+It was hot in the room, small, and too low where the stove was hissing
+in the midst of wigs and pomades. The smell of the tongs, together with
+the greasy hands that handled her head, soon stunned her, and she dozed
+a little in her wrapper. Often, as he did her hair, the man offered her
+tickets for a masked ball.
+
+Then she went away. She went up the streets; reached the Croix-Rouge,
+put on her overshoes, that she had hidden in the morning under the seat,
+and sank into her place among the impatient passengers. Some got out
+at the foot of the hill. She remained alone in the carriage. At every
+turning all the lights of the town were seen more and more completely,
+making a great luminous vapour about the dim houses. Emma knelt on the
+cushions and her eyes wandered over the dazzling light. She sobbed;
+called on Leon, sent him tender words and kisses lost in the wind.
+
+On the hillside a poor devil wandered about with his stick in the midst
+of the diligences. A mass of rags covered his shoulders, and an old
+staved-in beaver, turned out like a basin, hid his face; but when he
+took it off he discovered in the place of eyelids empty and bloody
+orbits. The flesh hung in red shreds, and there flowed from it liquids
+that congealed into green scale down to the nose, whose black nostrils
+sniffed convulsively. To speak to you he threw back his head with an
+idiotic laugh; then his bluish eyeballs, rolling constantly, at the
+temples beat against the edge of the open wound. He sang a little song
+as he followed the carriages--
+
+“Maids an the warmth of a summer day Dream of love, and of love always”
+
+And all the rest was about birds and sunshine and green leaves.
+
+Sometimes he appeared suddenly behind Emma, bareheaded, and she drew
+back with a cry. Hivert made fun of him. He would advise him to get a
+booth at the Saint Romain fair, or else ask him, laughing, how his young
+woman was.
+
+Often they had started when, with a sudden movement, his hat entered the
+diligence through the small window, while he clung with his other arm
+to the footboard, between the wheels splashing mud. His voice, feeble
+at first and quavering, grew sharp; it resounded in the night like the
+indistinct moan of a vague distress; and through the ringing of the
+bells, the murmur of the trees, and the rumbling of the empty vehicle,
+it had a far-off sound that disturbed Emma. It went to the bottom of
+her soul, like a whirlwind in an abyss, and carried her away into the
+distances of a boundless melancholy. But Hivert, noticing a weight
+behind, gave the blind man sharp cuts with his whip. The thong lashed
+his wounds, and he fell back into the mud with a yell. Then the
+passengers in the “Hirondelle” ended by falling asleep, some with open
+mouths, others with lowered chins, leaning against their neighbour’s
+shoulder, or with their arm passed through the strap, oscillating
+regularly with the jolting of the carriage; and the reflection of the
+lantern swinging without, on the crupper of the wheeler; penetrating
+into the interior through the chocolate calico curtains, threw
+sanguineous shadows over all these motionless people. Emma, drunk with
+grief, shivered in her clothes, feeling her feet grow colder and colder,
+and death in her soul.
+
+Charles at home was waiting for her; the “Hirondelle” was always late
+on Thursdays. Madame arrived at last, and scarcely kissed the child. The
+dinner was not ready. No matter! She excused the servant. This girl now
+seemed allowed to do just as she liked.
+
+Often her husband, noting her pallor, asked if she were unwell.
+
+“No,” said Emma.
+
+“But,” he replied, “you seem so strange this evening.”
+
+“Oh, it’s nothing! nothing!”
+
+There were even days when she had no sooner come in than she went up to
+her room; and Justin, happening to be there, moved about noiselessly,
+quicker at helping her than the best of maids. He put the matches
+ready, the candlestick, a book, arranged her nightgown, turned back the
+bedclothes.
+
+“Come!” said she, “that will do. Now you can go.”
+
+For he stood there, his hands hanging down and his eyes wide open, as if
+enmeshed in the innumerable threads of a sudden reverie.
+
+The following day was frightful, and those that came after still more
+unbearable, because of her impatience to once again seize her happiness;
+an ardent lust, inflamed by the images of past experience, and that
+burst forth freely on the seventh day beneath Leon’s caresses. His
+ardours were hidden beneath outbursts of wonder and gratitude. Emma
+tasted this love in a discreet, absorbed fashion, maintained it by all
+the artifices of her tenderness, and trembled a little lest it should be
+lost later on.
+
+She often said to him, with her sweet, melancholy voice--
+
+“Ah! you too, you will leave me! You will marry! You will be like all
+the others.”
+
+He asked, “What others?”
+
+“Why, like all men,” she replied. Then added, repulsing him with a
+languid movement--
+
+“You are all evil!”
+
+One day, as they were talking philosophically of earthly disillusions,
+to experiment on his jealousy, or yielding, perhaps, to an over-strong
+need to pour out her heart, she told him that formerly, before him, she
+had loved someone.
+
+“Not like you,” she went on quickly, protesting by the head of her child
+that “nothing had passed between them.”
+
+The young man believed her, but none the less questioned her to find out
+what he was.
+
+“He was a ship’s captain, my dear.”
+
+Was this not preventing any inquiry, and, at the same time, assuming a
+higher ground through this pretended fascination exercised over a man
+who must have been of warlike nature and accustomed to receive homage?
+
+The clerk then felt the lowliness of his position; he longed for
+epaulettes, crosses, titles. All that would please her--he gathered that
+from her spendthrift habits.
+
+Emma nevertheless concealed many of these extravagant fancies, such as
+her wish to have a blue tilbury to drive into Rouen, drawn by an English
+horse and driven by a groom in top-boots. It was Justin who had inspired
+her with this whim, by begging her to take him into her service as
+valet-de-chambre*, and if the privation of it did not lessen the
+pleasure of her arrival at each rendezvous, it certainly augmented the
+bitterness of the return.
+
+     * Manservant.
+
+
+Often, when they talked together of Paris, she ended by murmuring, “Ah!
+how happy we should be there!”
+
+“Are we not happy?” gently answered the young man passing his hands over
+her hair.
+
+“Yes, that is true,” she said. “I am mad. Kiss me!”
+
+To her husband she was more charming than ever. She made him
+pistachio-creams, and played him waltzes after dinner. So he thought
+himself the most fortunate of men and Emma was without uneasiness, when,
+one evening suddenly he said--
+
+“It is Mademoiselle Lempereur, isn’t it, who gives you lessons?”
+
+“Yes.”
+
+“Well, I saw her just now,” Charles went on, “at Madame Liegeard’s. I
+spoke to her about you, and she doesn’t know you.”
+
+This was like a thunderclap. However, she replied quite naturally--
+
+“Ah! no doubt she forgot my name.”
+
+“But perhaps,” said the doctor, “there are several Demoiselles Lempereur
+at Rouen who are music-mistresses.”
+
+“Possibly!” Then quickly--“But I have my receipts here. See!”
+
+And she went to the writing-table, ransacked all the drawers, rummaged
+the papers, and at last lost her head so completely that Charles
+earnestly begged her not to take so much trouble about those wretched
+receipts.
+
+“Oh, I will find them,” she said.
+
+And, in fact, on the following Friday, as Charles was putting on one
+of his boots in the dark cabinet where his clothes were kept, he felt
+a piece of paper between the leather and his sock. He took it out and
+read--
+
+“Received, for three months’ lessons and several pieces of music, the
+sum of sixty-three francs.--Felicie Lempereur, professor of music.”
+
+“How the devil did it get into my boots?”
+
+“It must,” she replied, “have fallen from the old box of bills that is
+on the edge of the shelf.”
+
+From that moment her existence was but one long tissue of lies, in which
+she enveloped her love as in veils to hide it. It was a want, a mania,
+a pleasure carried to such an extent that if she said she had the day
+before walked on the right side of a road, one might know she had taken
+the left.
+
+One morning, when she had gone, as usual, rather lightly clothed, it
+suddenly began to snow, and as Charles was watching the weather from the
+window, he caught sight of Monsieur Bournisien in the chaise of Monsieur
+Tuvache, who was driving him to Rouen. Then he went down to give the
+priest a thick shawl that he was to hand over to Emma as soon as he
+reached the “Croix-Rouge.” When he got to the inn, Monsieur Bournisien
+asked for the wife of the Yonville doctor. The landlady replied that
+she very rarely came to her establishment. So that evening, when he
+recognised Madame Bovary in the “Hirondelle,” the cure told her his
+dilemma, without, however, appearing to attach much importance to it,
+for he began praising a preacher who was doing wonders at the Cathedral,
+and whom all the ladies were rushing to hear.
+
+Still, if he did not ask for any explanation, others, later on, might
+prove less discreet. So she thought well to get down each time at the
+“Croix-Rouge,” so that the good folk of her village who saw her on the
+stairs should suspect nothing.
+
+One day, however, Monsieur Lheureux met her coming out of the Hotel
+de Boulogne on Leon’s arm; and she was frightened, thinking he would
+gossip. He was not such a fool. But three days after he came to her
+room, shut the door, and said, “I must have some money.”
+
+She declared she could not give him any. Lheureux burst into
+lamentations and reminded her of all the kindnesses he had shown her.
+
+In fact, of the two bills signed by Charles, Emma up to the present had
+paid only one. As to the second, the shopkeeper, at her request, had
+consented to replace it by another, which again had been renewed for a
+long date. Then he drew from his pocket a list of goods not paid for; to
+wit, the curtains, the carpet, the material for the armchairs, several
+dresses, and divers articles of dress, the bills for which amounted to
+about two thousand francs.
+
+She bowed her head. He went on--
+
+“But if you haven’t any ready money, you have an estate.” And he
+reminded her of a miserable little hovel situated at Barneville, near
+Aumale, that brought in almost nothing. It had formerly been part of a
+small farm sold by Monsieur Bovary senior; for Lheureux knew everything,
+even to the number of acres and the names of the neighbours.
+
+“If I were in your place,” he said, “I should clear myself of my debts,
+and have money left over.”
+
+She pointed out the difficulty of getting a purchaser. He held out the
+hope of finding one; but she asked him how she should manage to sell it.
+
+“Haven’t you your power of attorney?” he replied.
+
+The phrase came to her like a breath of fresh air. “Leave me the bill,”
+ said Emma.
+
+“Oh, it isn’t worth while,” answered Lheureux.
+
+He came back the following week and boasted of having, after much
+trouble, at last discovered a certain Langlois, who, for a long time,
+had had an eye on the property, but without mentioning his price.
+
+“Never mind the price!” she cried.
+
+But they would, on the contrary, have to wait, to sound the fellow.
+The thing was worth a journey, and, as she could not undertake it, he
+offered to go to the place to have an interview with Langlois. On his
+return he announced that the purchaser proposed four thousand francs.
+
+Emma was radiant at this news.
+
+“Frankly,” he added, “that’s a good price.”
+
+She drew half the sum at once, and when she was about to pay her account
+the shopkeeper said--
+
+“It really grieves me, on my word! to see you depriving yourself all at
+once of such a big sum as that.”
+
+Then she looked at the bank-notes, and dreaming of the unlimited number
+of rendezvous represented by those two thousand francs, she stammered--
+
+“What! what!”
+
+“Oh!” he went on, laughing good-naturedly, “one puts anything one likes
+on receipts. Don’t you think I know what household affairs are?” And he
+looked at her fixedly, while in his hand he held two long papers that he
+slid between his nails. At last, opening his pocket-book, he spread out
+on the table four bills to order, each for a thousand francs.
+
+“Sign these,” he said, “and keep it all!”
+
+She cried out, scandalised.
+
+“But if I give you the surplus,” replied Monsieur Lheureux impudently,
+“is that not helping you?”
+
+And taking a pen he wrote at the bottom of the account, “Received of
+Madame Bovary four thousand francs.”
+
+“Now who can trouble you, since in six months you’ll draw the arrears
+for your cottage, and I don’t make the last bill due till after you’ve
+been paid?”
+
+Emma grew rather confused in her calculations, and her ears tingled
+as if gold pieces, bursting from their bags, rang all round her on
+the floor. At last Lheureux explained that he had a very good friend,
+Vincart, a broker at Rouen, who would discount these four bills. Then
+he himself would hand over to madame the remainder after the actual debt
+was paid.
+
+But instead of two thousand francs he brought only eighteen hundred, for
+the friend Vincart (which was only fair) had deducted two hundred francs
+for commission and discount. Then he carelessly asked for a receipt.
+
+“You understand--in business--sometimes. And with the date, if you
+please, with the date.”
+
+A horizon of realisable whims opened out before Emma. She was prudent
+enough to lay by a thousand crowns, with which the first three bills
+were paid when they fell due; but the fourth, by chance, came to the
+house on a Thursday, and Charles, quite upset, patiently awaited his
+wife’s return for an explanation.
+
+If she had not told him about this bill, it was only to spare him such
+domestic worries; she sat on his knees, caressed him, cooed to him, gave
+him a long enumeration of all the indispensable things that had been got
+on credit.
+
+“Really, you must confess, considering the quantity, it isn’t too dear.”
+
+Charles, at his wit’s end, soon had recourse to the eternal Lheureux,
+who swore he would arrange matters if the doctor would sign him two
+bills, one of which was for seven hundred francs, payable in three
+months. In order to arrange for this he wrote his mother a pathetic
+letter. Instead of sending a reply she came herself; and when Emma
+wanted to know whether he had got anything out of her, “Yes,” he
+replied; “but she wants to see the account.” The next morning at
+daybreak Emma ran to Lheureux to beg him to make out another account for
+not more than a thousand francs, for to show the one for four thousand
+it would be necessary to say that she had paid two-thirds, and confess,
+consequently, the sale of the estate--a negotiation admirably carried
+out by the shopkeeper, and which, in fact, was only actually known later
+on.
+
+Despite the low price of each article, Madame Bovary senior, of course,
+thought the expenditure extravagant.
+
+“Couldn’t you do without a carpet? Why have recovered the arm-chairs? In
+my time there was a single arm-chair in a house, for elderly persons--at
+any rate it was so at my mother’s, who was a good woman, I can tell you.
+Everybody can’t be rich! No fortune can hold out against waste! I should
+be ashamed to coddle myself as you do! And yet I am old. I need looking
+after. And there! there! fitting up gowns! fallals! What! silk for
+lining at two francs, when you can get jaconet for ten sous, or even for
+eight, that would do well enough!”
+
+Emma, lying on a lounge, replied as quietly as possible--“Ah! Madame,
+enough! enough!”
+
+The other went on lecturing her, predicting they would end in the
+workhouse. But it was Bovary’s fault. Luckily he had promised to destroy
+that power of attorney.
+
+“What?”
+
+“Ah! he swore he would,” went on the good woman.
+
+Emma opened the window, called Charles, and the poor fellow was obliged
+to confess the promise torn from him by his mother.
+
+Emma disappeared, then came back quickly, and majestically handed her a
+thick piece of paper.
+
+“Thank you,” said the old woman. And she threw the power of attorney
+into the fire.
+
+Emma began to laugh, a strident, piercing, continuous laugh; she had an
+attack of hysterics.
+
+“Oh, my God!” cried Charles. “Ah! you really are wrong! You come here
+and make scenes with her!”
+
+His mother, shrugging her shoulders, declared it was “all put on.”
+
+But Charles, rebelling for the first time, took his wife’s part, so that
+Madame Bovary, senior, said she would leave. She went the very next day,
+and on the threshold, as he was trying to detain her, she replied--
+
+“No, no! You love her better than me, and you are right. It is natural.
+For the rest, so much the worse! You will see. Good day--for I am not
+likely to come soon again, as you say, to make scenes.”
+
+Charles nevertheless was very crestfallen before Emma, who did not hide
+the resentment she still felt at his want of confidence, and it needed
+many prayers before she would consent to have another power of attorney.
+He even accompanied her to Monsieur Guillaumin to have a second one,
+just like the other, drawn up.
+
+“I understand,” said the notary; “a man of science can’t be worried with
+the practical details of life.”
+
+And Charles felt relieved by this comfortable reflection, which gave his
+weakness the flattering appearance of higher pre-occupation.
+
+And what an outburst the next Thursday at the hotel in their room with
+Leon! She laughed, cried, sang, sent for sherbets, wanted to smoke
+cigarettes, seemed to him wild and extravagant, but adorable, superb.
+
+He did not know what recreation of her whole being drove her more and
+more to plunge into the pleasures of life. She was becoming irritable,
+greedy, voluptuous; and she walked about the streets with him carrying
+her head high, without fear, so she said, of compromising herself.
+At times, however, Emma shuddered at the sudden thought of meeting
+Rodolphe, for it seemed to her that, although they were separated
+forever, she was not completely free from her subjugation to him.
+
+One night she did not return to Yonville at all. Charles lost his head
+with anxiety, and little Berthe would not go to bed without her mamma,
+and sobbed enough to break her heart. Justin had gone out searching the
+road at random. Monsieur Homais even had left his pharmacy.
+
+At last, at eleven o’clock, able to bear it no longer, Charles
+harnessed his chaise, jumped in, whipped up his horse, and reached the
+“Croix-Rouge” about two o’clock in the morning. No one there! He thought
+that the clerk had perhaps seen her; but where did he live? Happily,
+Charles remembered his employer’s address, and rushed off there.
+
+Day was breaking, and he could distinguish the escutcheons over the
+door, and knocked. Someone, without opening the door, shouted out the
+required information, adding a few insults to those who disturb people
+in the middle of the night.
+
+The house inhabited by the clerk had neither bell, knocker, nor porter.
+Charles knocked loudly at the shutters with his hands. A policeman
+happened to pass by. Then he was frightened, and went away.
+
+“I am mad,” he said; “no doubt they kept her to dinner at Monsieur
+Lormeaux’.” But the Lormeaux no longer lived at Rouen.
+
+“She probably stayed to look after Madame Dubreuil. Why, Madame Dubreuil
+has been dead these ten months! Where can she be?”
+
+An idea occurred to him. At a cafe he asked for a Directory, and
+hurriedly looked for the name of Mademoiselle Lempereur, who lived at
+No. 74 Rue de la Renelle-des-Maroquiniers.
+
+As he was turning into the street, Emma herself appeared at the other
+end of it. He threw himself upon her rather than embraced her, crying--
+
+“What kept you yesterday?”
+
+“I was not well.”
+
+“What was it? Where? How?”
+
+She passed her hand over her forehead and answered, “At Mademoiselle
+Lempereur’s.”
+
+“I was sure of it! I was going there.”
+
+“Oh, it isn’t worth while,” said Emma. “She went out just now; but for
+the future don’t worry. I do not feel free, you see, if I know that the
+least delay upsets you like this.”
+
+This was a sort of permission that she gave herself, so as to get
+perfect freedom in her escapades. And she profited by it freely, fully.
+When she was seized with the desire to see Leon, she set out upon any
+pretext; and as he was not expecting her on that day, she went to fetch
+him at his office.
+
+It was a great delight at first, but soon he no longer concealed the
+truth, which was, that his master complained very much about these
+interruptions.
+
+“Pshaw! come along,” she said.
+
+And he slipped out.
+
+She wanted him to dress all in black, and grow a pointed beard, to
+look like the portraits of Louis XIII. She wanted to see his lodgings;
+thought them poor. He blushed at them, but she did not notice this, then
+advised him to buy some curtains like hers, and as he objected to the
+expense--
+
+“Ah! ah! you care for your money,” she said laughing.
+
+Each time Leon had to tell her everything that he had done since their
+last meeting. She asked him for some verses--some verses “for herself,”
+ a “love poem” in honour of her. But he never succeeded in getting a
+rhyme for the second verse; and at last ended by copying a sonnet in
+a “Keepsake.” This was less from vanity than from the one desire of
+pleasing her. He did not question her ideas; he accepted all her tastes;
+he was rather becoming her mistress than she his. She had tender words
+and kisses that thrilled his soul. Where could she have learnt this
+corruption almost incorporeal in the strength of its profanity and
+dissimulation?
+
+
+
+Chapter Six
+
+During the journeys he made to see her, Leon had often dined at the
+chemist’s, and he felt obliged from politeness to invite him in turn.
+
+“With pleasure!” Monsieur Homais replied; “besides, I must invigorate
+my mind, for I am getting rusty here. We’ll go to the theatre, to the
+restaurant; we’ll make a night of it.”
+
+“Oh, my dear!” tenderly murmured Madame Homais, alarmed at the vague
+perils he was preparing to brave.
+
+“Well, what? Do you think I’m not sufficiently ruining my health living
+here amid the continual emanations of the pharmacy? But there! that is
+the way with women! They are jealous of science, and then are opposed to
+our taking the most legitimate distractions. No matter! Count upon
+me. One of these days I shall turn up at Rouen, and we’ll go the pace
+together.”
+
+The druggist would formerly have taken good care not to use such an
+expression, but he was cultivating a gay Parisian style, which he
+thought in the best taste; and, like his neighbour, Madame Bovary, he
+questioned the clerk curiously about the customs of the capital; he
+even talked slang to dazzle the bourgeois, saying bender, crummy, dandy,
+macaroni, the cheese, cut my stick and “I’ll hook it,” for “I am going.”
+
+So one Thursday Emma was surprised to meet Monsieur Homais in the
+kitchen of the “Lion d’Or,” wearing a traveller’s costume, that is to
+say, wrapped in an old cloak which no one knew he had, while he carried
+a valise in one hand and the foot-warmer of his establishment in the
+other. He had confided his intentions to no one, for fear of causing the
+public anxiety by his absence.
+
+The idea of seeing again the place where his youth had been spent no
+doubt excited him, for during the whole journey he never ceased talking,
+and as soon as he had arrived, he jumped quickly out of the diligence
+to go in search of Leon. In vain the clerk tried to get rid of him.
+Monsieur Homais dragged him off to the large Cafe de la Normandie,
+which he entered majestically, not raising his hat, thinking it very
+provincial to uncover in any public place.
+
+Emma waited for Leon three quarters of an hour. At last she ran to
+his office; and, lost in all sorts of conjectures, accusing him of
+indifference, and reproaching herself for her weakness, she spent the
+afternoon, her face pressed against the window-panes.
+
+At two o’clock they were still at a table opposite each other. The large
+room was emptying; the stove-pipe, in the shape of a palm-tree, spread
+its gilt leaves over the white ceiling, and near them, outside the
+window, in the bright sunshine, a little fountain gurgled in a white
+basin, where; in the midst of watercress and asparagus, three torpid
+lobsters stretched across to some quails that lay heaped up in a pile on
+their sides.
+
+Homais was enjoying himself. Although he was even more intoxicated with
+the luxury than the rich fare, the Pommard wine all the same rather
+excited his faculties; and when the omelette au rhum* appeared, he began
+propounding immoral theories about women. What seduced him above all
+else was chic. He admired an elegant toilette in a well-furnished
+apartment, and as to bodily qualities, he didn’t dislike a young girl.
+
+     * In rum.
+
+
+Leon watched the clock in despair. The druggist went on drinking,
+eating, and talking.
+
+“You must be very lonely,” he said suddenly, “here at Rouen. To be sure
+your lady-love doesn’t live far away.”
+
+And the other blushed--
+
+“Come now, be frank. Can you deny that at Yonville--”
+
+The young man stammered something.
+
+“At Madame Bovary’s, you’re not making love to--”
+
+“To whom?”
+
+“The servant!”
+
+He was not joking; but vanity getting the better of all prudence, Leon,
+in spite of himself protested. Besides, he only liked dark women.
+
+“I approve of that,” said the chemist; “they have more passion.”
+
+And whispering into his friend’s ear, he pointed out the symptoms by
+which one could find out if a woman had passion. He even launched into
+an ethnographic digression: the German was vapourish, the French woman
+licentious, the Italian passionate.
+
+“And negresses?” asked the clerk.
+
+“They are an artistic taste!” said Homais. “Waiter! two cups of coffee!”
+
+“Are we going?” at last asked Leon impatiently.
+
+“Ja!”
+
+But before leaving he wanted to see the proprietor of the establishment
+and made him a few compliments. Then the young man, to be alone, alleged
+he had some business engagement.
+
+“Ah! I will escort you,” said Homais.
+
+And all the while he was walking through the streets with him he talked
+of his wife, his children; of their future, and of his business; told
+him in what a decayed condition it had formerly been, and to what a
+degree of perfection he had raised it.
+
+Arrived in front of the Hotel de Boulogne, Leon left him abruptly, ran
+up the stairs, and found his mistress in great excitement. At mention of
+the chemist she flew into a passion. He, however, piled up good reasons;
+it wasn’t his fault; didn’t she know Homais--did she believe that he
+would prefer his company? But she turned away; he drew her back, and,
+sinking on his knees, clasped her waist with his arms in a languorous
+pose, full of concupiscence and supplication.
+
+She was standing up, her large flashing eyes looked at him seriously,
+almost terribly. Then tears obscured them, her red eyelids were lowered,
+she gave him her hands, and Leon was pressing them to his lips when a
+servant appeared to tell the gentleman that he was wanted.
+
+“You will come back?” she said.
+
+“Yes.”
+
+“But when?”
+
+“Immediately.”
+
+“It’s a trick,” said the chemist, when he saw Leon. “I wanted to
+interrupt this visit, that seemed to me to annoy you. Let’s go and have
+a glass of garus at Bridoux’.”
+
+Leon vowed that he must get back to his office. Then the druggist joked
+him about quill-drivers and the law.
+
+“Leave Cujas and Barthole alone a bit. Who the devil prevents you? Be a
+man! Let’s go to Bridoux’. You’ll see his dog. It’s very interesting.”
+
+And as the clerk still insisted--
+
+“I’ll go with you. I’ll read a paper while I wait for you, or turn over
+the leaves of a ‘Code.’”
+
+Leon, bewildered by Emma’s anger, Monsieur Homais’ chatter, and,
+perhaps, by the heaviness of the luncheon, was undecided, and, as it
+were, fascinated by the chemist, who kept repeating--
+
+“Let’s go to Bridoux’. It’s just by here, in the Rue Malpalu.”
+
+Then, through cowardice, through stupidity, through that indefinable
+feeling that drags us into the most distasteful acts, he allowed
+himself to be led off to Bridoux’, whom they found in his small yard,
+superintending three workmen, who panted as they turned the large
+wheel of a machine for making seltzer-water. Homais gave them some good
+advice. He embraced Bridoux; they took some garus. Twenty times Leon
+tried to escape, but the other seized him by the arm saying--
+
+“Presently! I’m coming! We’ll go to the ‘Fanal de Rouen’ to see the
+fellows there. I’ll introduce you to Thornassin.”
+
+At last he managed to get rid of him, and rushed straight to the hotel.
+Emma was no longer there. She had just gone in a fit of anger. She
+detested him now. This failing to keep their rendezvous seemed to her an
+insult, and she tried to rake up other reasons to separate herself from
+him. He was incapable of heroism, weak, banal, more spiritless than a
+woman, avaricious too, and cowardly.
+
+Then, growing calmer, she at length discovered that she had, no doubt,
+calumniated him. But the disparaging of those we love always alienates
+us from them to some extent. We must not touch our idols; the gilt
+sticks to our fingers.
+
+They gradually came to talking more frequently of matters outside their
+love, and in the letters that Emma wrote him she spoke of flowers,
+verses, the moon and the stars, naive resources of a waning passion
+striving to keep itself alive by all external aids. She was constantly
+promising herself a profound felicity on her next journey. Then
+she confessed to herself that she felt nothing extraordinary. This
+disappointment quickly gave way to a new hope, and Emma returned to him
+more inflamed, more eager than ever. She undressed brutally, tearing off
+the thin laces of her corset that nestled around her hips like a gliding
+snake. She went on tiptoe, barefooted, to see once more that the
+door was closed, then, pale, serious, and, without speaking, with one
+movement, she threw herself upon his breast with a long shudder.
+
+Yet there was upon that brow covered with cold drops, on those quivering
+lips, in those wild eyes, in the strain of those arms, something vague
+and dreary that seemed to Leon to glide between them subtly as if to
+separate them.
+
+He did not dare to question her; but, seeing her so skilled, she must
+have passed, he thought, through every experience of suffering and of
+pleasure. What had once charmed now frightened him a little. Besides, he
+rebelled against his absorption, daily more marked, by her personality.
+He begrudged Emma this constant victory. He even strove not to love her;
+then, when he heard the creaking of her boots, he turned coward, like
+drunkards at the sight of strong drinks.
+
+She did not fail, in truth, to lavish all sorts of attentions upon him,
+from the delicacies of food to the coquettries of dress and languishing
+looks. She brought roses to her breast from Yonville, which she threw
+into his face; was anxious about his health, gave him advice as to his
+conduct; and, in order the more surely to keep her hold on him, hoping
+perhaps that heaven would take her part, she tied a medal of the
+Virgin round his neck. She inquired like a virtuous mother about his
+companions. She said to him--
+
+“Don’t see them; don’t go out; think only of ourselves; love me!”
+
+She would have liked to be able to watch over his life; and the idea
+occurred to her of having him followed in the streets. Near the hotel
+there was always a kind of loafer who accosted travellers, and who would
+not refuse. But her pride revolted at this.
+
+“Bah! so much the worse. Let him deceive me! What does it matter to me?
+As If I cared for him!”
+
+One day, when they had parted early and she was returning alone along
+the boulevard, she saw the walls of her convent; then she sat down on a
+form in the shade of the elm-trees. How calm that time had been! How she
+longed for the ineffable sentiments of love that she had tried to figure
+to herself out of books! The first month of her marriage, her rides in
+the wood, the viscount that waltzed, and Lagardy singing, all repassed
+before her eyes. And Leon suddenly appeared to her as far off as the
+others.
+
+“Yet I love him,” she said to herself.
+
+No matter! She was not happy--she never had been. Whence came this
+insufficiency in life--this instantaneous turning to decay of everything
+on which she leant? But if there were somewhere a being strong and
+beautiful, a valiant nature, full at once of exaltation and refinement,
+a poet’s heart in an angel’s form, a lyre with sounding chords ringing
+out elegiac epithalamia to heaven, why, perchance, should she not find
+him? Ah! how impossible! Besides, nothing was worth the trouble of
+seeking it; everything was a lie. Every smile hid a yawn of boredom,
+every joy a curse, all pleasure satiety, and the sweetest kisses left
+upon your lips only the unattainable desire for a greater delight.
+
+A metallic clang droned through the air, and four strokes were heard
+from the convent-clock. Four o’clock! And it seemed to her that she had
+been there on that form an eternity. But an infinity of passions may be
+contained in a minute, like a crowd in a small space.
+
+Emma lived all absorbed in hers, and troubled no more about money
+matters than an archduchess.
+
+Once, however, a wretched-looking man, rubicund and bald, came to her
+house, saying he had been sent by Monsieur Vincart of Rouen. He took out
+the pins that held together the side-pockets of his long green overcoat,
+stuck them into his sleeve, and politely handed her a paper.
+
+It was a bill for seven hundred francs, signed by her, and which
+Lheureux, in spite of all his professions, had paid away to Vincart. She
+sent her servant for him. He could not come. Then the stranger, who
+had remained standing, casting right and left curious glances, that his
+thick, fair eyebrows hid, asked with a naive air--
+
+“What answer am I to take Monsieur Vincart?”
+
+“Oh,” said Emma, “tell him that I haven’t it. I will send next week; he
+must wait; yes, till next week.”
+
+And the fellow went without another word.
+
+But the next day at twelve o’clock she received a summons, and the sight
+of the stamped paper, on which appeared several times in large letters,
+“Maitre Hareng, bailiff at Buchy,” so frightened her that she rushed in
+hot haste to the linendraper’s. She found him in his shop, doing up a
+parcel.
+
+“Your obedient!” he said; “I am at your service.”
+
+But Lheureux, all the same, went on with his work, helped by a young
+girl of about thirteen, somewhat hunch-backed, who was at once his clerk
+and his servant.
+
+Then, his clogs clattering on the shop-boards, he went up in front
+of Madame Bovary to the first door, and introduced her into a narrow
+closet, where, in a large bureau in sapon-wood, lay some ledgers,
+protected by a horizontal padlocked iron bar. Against the wall, under
+some remnants of calico, one glimpsed a safe, but of such dimensions
+that it must contain something besides bills and money. Monsieur
+Lheureux, in fact, went in for pawnbroking, and it was there that he had
+put Madame Bovary’s gold chain, together with the earrings of poor old
+Tellier, who, at last forced to sell out, had bought a meagre store
+of grocery at Quincampoix, where he was dying of catarrh amongst his
+candles, that were less yellow than his face.
+
+Lheureux sat down in a large cane arm-chair, saying: “What news?”
+
+“See!”
+
+And she showed him the paper.
+
+“Well how can I help it?”
+
+Then she grew angry, reminding him of the promise he had given not to
+pay away her bills. He acknowledged it.
+
+“But I was pressed myself; the knife was at my own throat.”
+
+“And what will happen now?” she went on.
+
+“Oh, it’s very simple; a judgment and then a distraint--that’s about
+it!”
+
+Emma kept down a desire to strike him, and asked gently if there was no
+way of quieting Monsieur Vincart.
+
+“I dare say! Quiet Vincart! You don’t know him; he’s more ferocious than
+an Arab!”
+
+Still Monsieur Lheureux must interfere.
+
+“Well, listen. It seems to me so far I’ve been very good to you.” And
+opening one of his ledgers, “See,” he said. Then running up the page
+with his finger, “Let’s see! let’s see! August 3d, two hundred francs;
+June 17th, a hundred and fifty; March 23d, forty-six. In April--”
+
+He stopped, as if afraid of making some mistake.
+
+“Not to speak of the bills signed by Monsieur Bovary, one for seven
+hundred francs, and another for three hundred. As to your little
+installments, with the interest, why, there’s no end to ‘em; one gets
+quite muddled over ‘em. I’ll have nothing more to do with it.”
+
+She wept; she even called him “her good Monsieur Lheureux.” But he
+always fell back upon “that rascal Vincart.” Besides, he hadn’t a brass
+farthing; no one was paying him now-a-days; they were eating his coat
+off his back; a poor shopkeeper like him couldn’t advance money.
+
+Emma was silent, and Monsieur Lheureux, who was biting the feathers of a
+quill, no doubt became uneasy at her silence, for he went on--
+
+“Unless one of these days I have something coming in, I might--”
+
+“Besides,” said she, “as soon as the balance of Barneville--”
+
+“What!”
+
+And on hearing that Langlois had not yet paid he seemed much surprised.
+Then in a honied voice--
+
+“And we agree, you say?”
+
+“Oh! to anything you like.”
+
+On this he closed his eyes to reflect, wrote down a few figures, and
+declaring it would be very difficult for him, that the affair was shady,
+and that he was being bled, he wrote out four bills for two hundred and
+fifty francs each, to fall due month by month.
+
+“Provided that Vincart will listen to me! However, it’s settled. I don’t
+play the fool; I’m straight enough.”
+
+Next he carelessly showed her several new goods, not one of which,
+however, was in his opinion worthy of madame.
+
+“When I think that there’s a dress at threepence-halfpenny a yard, and
+warranted fast colours! And yet they actually swallow it! Of course you
+understand one doesn’t tell them what it really is!” He hoped by this
+confession of dishonesty to others to quite convince her of his probity
+to her.
+
+Then he called her back to show her three yards of guipure that he had
+lately picked up “at a sale.”
+
+“Isn’t it lovely?” said Lheureux. “It is very much used now for the
+backs of arm-chairs. It’s quite the rage.”
+
+And, more ready than a juggler, he wrapped up the guipure in some blue
+paper and put it in Emma’s hands.
+
+“But at least let me know--”
+
+“Yes, another time,” he replied, turning on his heel.
+
+That same evening she urged Bovary to write to his mother, to ask her
+to send as quickly as possible the whole of the balance due from the
+father’s estate. The mother-in-law replied that she had nothing more,
+the winding up was over, and there was due to them besides Barneville an
+income of six hundred francs, that she would pay them punctually.
+
+Then Madame Bovary sent in accounts to two or three patients, and she
+made large use of this method, which was very successful. She was always
+careful to add a postscript: “Do not mention this to my husband; you
+know how proud he is. Excuse me. Yours obediently.” There were some
+complaints; she intercepted them.
+
+To get money she began selling her old gloves, her old hats, the old
+odds and ends, and she bargained rapaciously, her peasant blood standing
+her in good stead. Then on her journey to town she picked up nick-nacks
+secondhand, that, in default of anyone else, Monsieur Lheureux would
+certainly take off her hands. She bought ostrich feathers, Chinese
+porcelain, and trunks; she borrowed from Felicite, from Madame
+Lefrancois, from the landlady at the Croix-Rouge, from everybody, no
+matter where.
+
+With the money she at last received from Barneville she paid two bills;
+the other fifteen hundred francs fell due. She renewed the bills, and
+thus it was continually.
+
+Sometimes, it is true, she tried to make a calculation, but she
+discovered things so exorbitant that she could not believe them
+possible. Then she recommenced, soon got confused, gave it all up, and
+thought no more about it.
+
+The house was very dreary now. Tradesmen were seen leaving it with angry
+faces. Handkerchiefs were lying about on the stoves, and little Berthe,
+to the great scandal of Madame Homais, wore stockings with holes in
+them. If Charles timidly ventured a remark, she answered roughly that it
+wasn’t her fault.
+
+What was the meaning of all these fits of temper? He explained
+everything through her old nervous illness, and reproaching himself with
+having taken her infirmities for faults, accused himself of egotism, and
+longed to go and take her in his arms.
+
+“Ah, no!” he said to himself; “I should worry her.”
+
+And he did not stir.
+
+After dinner he walked about alone in the garden; he took little Berthe
+on his knees, and unfolding his medical journal, tried to teach her
+to read. But the child, who never had any lessons, soon looked up with
+large, sad eyes and began to cry. Then he comforted her; went to fetch
+water in her can to make rivers on the sand path, or broke off branches
+from the privet hedges to plant trees in the beds. This did not spoil
+the garden much, all choked now with long weeds. They owed Lestiboudois
+for so many days. Then the child grew cold and asked for her mother.
+
+“Call the servant,” said Charles. “You know, dearie, that mamma does not
+like to be disturbed.”
+
+Autumn was setting in, and the leaves were already falling, as they did
+two years ago when she was ill. Where would it all end? And he walked up
+and down, his hands behind his back.
+
+Madame was in her room, which no one entered. She stayed there all
+day long, torpid, half dressed, and from time to time burning Turkish
+pastilles which she had bought at Rouen in an Algerian’s shop. In order
+not to have at night this sleeping man stretched at her side, by dint of
+manoeuvring, she at last succeeded in banishing him to the second floor,
+while she read till morning extravagant books, full of pictures of
+orgies and thrilling situations. Often, seized with fear, she cried out,
+and Charles hurried to her.
+
+“Oh, go away!” she would say.
+
+Or at other times, consumed more ardently than ever by that inner flame
+to which adultery added fuel, panting, tremulous, all desire, she threw
+open her window, breathed in the cold air, shook loose in the wind her
+masses of hair, too heavy, and, gazing upon the stars, longed for some
+princely love. She thought of him, of Leon. She would then have given
+anything for a single one of those meetings that surfeited her.
+
+These were her gala days. She wanted them to be sumptuous, and when he
+alone could not pay the expenses, she made up the deficit liberally,
+which happened pretty well every time. He tried to make her understand
+that they would be quite as comfortable somewhere else, in a smaller
+hotel, but she always found some objection.
+
+One day she drew six small silver-gilt spoons from her bag (they were
+old Roualt’s wedding present), begging him to pawn them at once for her,
+and Leon obeyed, though the proceeding annoyed him. He was afraid of
+compromising himself.
+
+Then, on, reflection, he began to think his mistress’s ways were growing
+odd, and that they were perhaps not wrong in wishing to separate him
+from her.
+
+In fact someone had sent his mother a long anonymous letter to warn her
+that he was “ruining himself with a married woman,” and the good lady at
+once conjuring up the eternal bugbear of families, the vague pernicious
+creature, the siren, the monster, who dwells fantastically in depths of
+love, wrote to Lawyer Dubocage, his employer, who behaved perfectly in
+the affair. He kept him for three quarters of an hour trying to open
+his eyes, to warn him of the abyss into which he was falling. Such
+an intrigue would damage him later on, when he set up for himself. He
+implored him to break with her, and, if he would not make this sacrifice
+in his own interest, to do it at least for his, Dubocage’s sake.
+
+At last Leon swore he would not see Emma again, and he reproached
+himself with not having kept his word, considering all the worry and
+lectures this woman might still draw down upon him, without reckoning
+the jokes made by his companions as they sat round the stove in the
+morning. Besides, he was soon to be head clerk; it was time to settle
+down. So he gave up his flute, exalted sentiments, and poetry; for every
+bourgeois in the flush of his youth, were it but for a day, a moment,
+has believed himself capable of immense passions, of lofty enterprises.
+The most mediocre libertine has dreamed of sultanas; every notary bears
+within him the debris of a poet.
+
+He was bored now when Emma suddenly began to sob on his breast, and his
+heart, like the people who can only stand a certain amount of music,
+dozed to the sound of a love whose delicacies he no longer noted.
+
+They knew one another too well for any of those surprises of possession
+that increase its joys a hundred-fold. She was as sick of him as he
+was weary of her. Emma found again in adultery all the platitudes of
+marriage.
+
+But how to get rid of him? Then, though she might feel humiliated at
+the baseness of such enjoyment, she clung to it from habit or from
+corruption, and each day she hungered after them the more, exhausting
+all felicity in wishing for too much of it. She accused Leon of her
+baffled hopes, as if he had betrayed her; and she even longed for some
+catastrophe that would bring about their separation, since she had not
+the courage to make up her mind to it herself.
+
+She none the less went on writing him love letters, in virtue of the
+notion that a woman must write to her lover.
+
+But whilst she wrote it was another man she saw, a phantom fashioned out
+of her most ardent memories, of her finest reading, her strongest
+lusts, and at last he became so real, so tangible, that she palpitated
+wondering, without, however, the power to imagine him clearly, so lost
+was he, like a god, beneath the abundance of his attributes. He dwelt in
+that azure land where silk ladders hang from balconies under the breath
+of flowers, in the light of the moon. She felt him near her; he was
+coming, and would carry her right away in a kiss.
+
+Then she fell back exhausted, for these transports of vague love wearied
+her more than great debauchery.
+
+She now felt constant ache all over her. Often she even received
+summonses, stamped paper that she barely looked at. She would have liked
+not to be alive, or to be always asleep.
+
+On Mid-Lent she did not return to Yonville, but in the evening went to
+a masked ball. She wore velvet breeches, red stockings, a club wig, and
+three-cornered hat cocked on one side. She danced all night to the wild
+tones of the trombones; people gathered round her, and in the morning
+she found herself on the steps of the theatre together with five or six
+masks, debardeuses* and sailors, Leon’s comrades, who were talking about
+having supper.
+
+     * People dressed as longshoremen.
+
+
+The neighbouring cafes were full. They caught sight of one on the
+harbour, a very indifferent restaurant, whose proprietor showed them to
+a little room on the fourth floor.
+
+The men were whispering in a corner, no doubt consorting about expenses.
+There were a clerk, two medical students, and a shopman--what company
+for her! As to the women, Emma soon perceived from the tone of their
+voices that they must almost belong to the lowest class. Then she was
+frightened, pushed back her chair, and cast down her eyes.
+
+The others began to eat; she ate nothing. Her head was on fire, her eyes
+smarted, and her skin was ice-cold. In her head she seemed to feel the
+floor of the ball-room rebounding again beneath the rhythmical pulsation
+of the thousands of dancing feet. And now the smell of the punch, the
+smoke of the cigars, made her giddy. She fainted, and they carried her
+to the window.
+
+Day was breaking, and a great stain of purple colour broadened out
+in the pale horizon over the St. Catherine hills. The livid river was
+shivering in the wind; there was no one on the bridges; the street lamps
+were going out.
+
+She revived, and began thinking of Berthe asleep yonder in the servant’s
+room. Then a cart filled with long strips of iron passed by, and made a
+deafening metallic vibration against the walls of the houses.
+
+She slipped away suddenly, threw off her costume, told Leon she must get
+back, and at last was alone at the Hotel de Boulogne. Everything, even
+herself, was now unbearable to her. She wished that, taking wing like a
+bird, she could fly somewhere, far away to regions of purity, and there
+grow young again.
+
+She went out, crossed the Boulevard, the Place Cauchoise, and the
+Faubourg, as far as an open street that overlooked some gardens. She
+walked rapidly; the fresh air calming her; and, little by little, the
+faces of the crowd, the masks, the quadrilles, the lights, the supper,
+those women, all disappeared like mists fading away. Then, reaching the
+“Croix-Rouge,” she threw herself on the bed in her little room on the
+second floor, where there were pictures of the “Tour de Nesle.” At four
+o’clock Hivert awoke her.
+
+When she got home, Felicite showed her behind the clock a grey paper.
+She read--
+
+“In virtue of the seizure in execution of a judgment.”
+
+What judgment? As a matter of fact, the evening before another paper
+had been brought that she had not yet seen, and she was stunned by these
+words--
+
+“By order of the king, law, and justice, to Madame Bovary.” Then,
+skipping several lines, she read, “Within twenty-four hours, without
+fail--” But what? “To pay the sum of eight thousand francs.” And there
+was even at the bottom, “She will be constrained thereto by every
+form of law, and notably by a writ of distraint on her furniture and
+effects.”
+
+What was to be done? In twenty-four hours--tomorrow. Lheureux, she
+thought, wanted to frighten her again; for she saw through all his
+devices, the object of his kindnesses. What reassured her was the very
+magnitude of the sum.
+
+However, by dint of buying and not paying, of borrowing, signing bills,
+and renewing these bills that grew at each new falling-in, she had ended
+by preparing a capital for Monsieur Lheureux which he was impatiently
+awaiting for his speculations.
+
+She presented herself at his place with an offhand air.
+
+“You know what has happened to me? No doubt it’s a joke!”
+
+“How so?”
+
+He turned away slowly, and, folding his arms, said to her--
+
+“My good lady, did you think I should go on to all eternity being your
+purveyor and banker, for the love of God? Now be just. I must get back
+what I’ve laid out. Now be just.”
+
+She cried out against the debt.
+
+“Ah! so much the worse. The court has admitted it. There’s a judgment.
+It’s been notified to you. Besides, it isn’t my fault. It’s Vincart’s.”
+
+“Could you not--?”
+
+“Oh, nothing whatever.”
+
+“But still, now talk it over.”
+
+And she began beating about the bush; she had known nothing about it; it
+was a surprise.
+
+“Whose fault is that?” said Lheureux, bowing ironically. “While I’m
+slaving like a nigger, you go gallivanting about.”
+
+“Ah! no lecturing.”
+
+“It never does any harm,” he replied.
+
+She turned coward; she implored him; she even pressed her pretty white
+and slender hand against the shopkeeper’s knee.
+
+“There, that’ll do! Anyone’d think you wanted to seduce me!”
+
+“You are a wretch!” she cried.
+
+“Oh, oh! go it! go it!”
+
+“I will show you up. I shall tell my husband.”
+
+“All right! I too. I’ll show your husband something.”
+
+And Lheureux drew from his strong box the receipt for eighteen hundred
+francs that she had given him when Vincart had discounted the bills.
+
+“Do you think,” he added, “that he’ll not understand your little theft,
+the poor dear man?”
+
+She collapsed, more overcome than if felled by the blow of a pole-axe.
+He was walking up and down from the window to the bureau, repeating all
+the while--
+
+“Ah! I’ll show him! I’ll show him!” Then he approached her, and in a
+soft voice said--
+
+“It isn’t pleasant, I know; but, after all, no bones are broken, and,
+since that is the only way that is left for you paying back my money--”
+
+“But where am I to get any?” said Emma, wringing her hands.
+
+“Bah! when one has friends like you!”
+
+And he looked at her in so keen, so terrible a fashion, that she
+shuddered to her very heart.
+
+“I promise you,” she said, “to sign--”
+
+“I’ve enough of your signatures.”
+
+“I will sell something.”
+
+“Get along!” he said, shrugging his shoulders; “you’ve not got
+anything.”
+
+And he called through the peep-hole that looked down into the shop--
+
+“Annette, don’t forget the three coupons of No. 14.”
+
+The servant appeared. Emma understood, and asked how much money would be
+wanted to put a stop to the proceedings.
+
+“It is too late.”
+
+“But if I brought you several thousand francs--a quarter of the sum--a
+third--perhaps the whole?”
+
+“No; it’s no use!”
+
+And he pushed her gently towards the staircase.
+
+“I implore you, Monsieur Lheureux, just a few days more!” She was
+sobbing.
+
+“There! tears now!”
+
+“You are driving me to despair!”
+
+“What do I care?” said he, shutting the door.
+
+
+
+Chapter Seven
+
+She was stoical the next day when Maitre Hareng, the bailiff, with two
+assistants, presented himself at her house to draw up the inventory for
+the distraint.
+
+They began with Bovary’s consulting-room, and did not write down
+the phrenological head, which was considered an “instrument of his
+profession”; but in the kitchen they counted the plates; the saucepans,
+the chairs, the candlesticks, and in the bedroom all the nick-nacks on
+the whatnot. They examined her dresses, the linen, the dressing-room;
+and her whole existence to its most intimate details, was, like a corpse
+on whom a post-mortem is made, outspread before the eyes of these three
+men.
+
+Maitre Hareng, buttoned up in his thin black coat, wearing a white
+choker and very tight foot-straps, repeated from time to time--“Allow
+me, madame. You allow me?” Often he uttered exclamations. “Charming!
+very pretty.” Then he began writing again, dipping his pen into the horn
+inkstand in his left hand.
+
+When they had done with the rooms they went up to the attic. She kept a
+desk there in which Rodolphe’s letters were locked. It had to be opened.
+
+“Ah! a correspondence,” said Maitre Hareng, with a discreet smile. “But
+allow me, for I must make sure the box contains nothing else.” And he
+tipped up the papers lightly, as if to shake out napoleons. Then she
+grew angered to see this coarse hand, with fingers red and pulpy like
+slugs, touching these pages against which her heart had beaten.
+
+They went at last. Felicite came back. Emma had sent her out to watch
+for Bovary in order to keep him off, and they hurriedly installed the
+man in possession under the roof, where he swore he would remain.
+
+During the evening Charles seemed to her careworn. Emma watched him with
+a look of anguish, fancying she saw an accusation in every line of his
+face. Then, when her eyes wandered over the chimney-piece ornamented
+with Chinese screens, over the large curtains, the armchairs, all
+those things, in a word, that had, softened the bitterness of her life,
+remorse seized her or rather an immense regret, that, far from crushing,
+irritated her passion. Charles placidly poked the fire, both his feet on
+the fire-dogs.
+
+Once the man, no doubt bored in his hiding-place, made a slight noise.
+
+“Is anyone walking upstairs?” said Charles.
+
+“No,” she replied; “it is a window that has been left open, and is
+rattling in the wind.”
+
+The next day, Sunday, she went to Rouen to call on all the brokers whose
+names she knew. They were at their country-places or on journeys. She
+was not discouraged; and those whom she did manage to see she asked for
+money, declaring she must have some, and that she would pay it back.
+Some laughed in her face; all refused.
+
+At two o’clock she hurried to Leon, and knocked at the door. No one
+answered. At length he appeared.
+
+“What brings you here?”
+
+“Do I disturb you?”
+
+“No; but--” And he admitted that his landlord didn’t like his having
+“women” there.
+
+“I must speak to you,” she went on.
+
+Then he took down the key, but she stopped him.
+
+“No, no! Down there, in our home!”
+
+And they went to their room at the Hotel de Boulogne.
+
+On arriving she drank off a large glass of water. She was very pale. She
+said to him--
+
+“Leon, you will do me a service?”
+
+And, shaking him by both hands that she grasped tightly, she added--
+
+“Listen, I want eight thousand francs.”
+
+“But you are mad!”
+
+“Not yet.”
+
+And thereupon, telling him the story of the distraint, she explained
+her distress to him; for Charles knew nothing of it; her mother-in-law
+detested her; old Rouault could do nothing; but he, Leon, he would set
+about finding this indispensable sum.
+
+“How on earth can I?”
+
+“What a coward you are!” she cried.
+
+Then he said stupidly, “You are exaggerating the difficulty. Perhaps,
+with a thousand crowns or so the fellow could be stopped.”
+
+All the greater reason to try and do something; it was impossible that
+they could not find three thousand francs. Besides, Leon, could be
+security instead of her.
+
+“Go, try, try! I will love you so!”
+
+He went out, and came back at the end of an hour, saying, with solemn
+face--
+
+“I have been to three people with no success.”
+
+Then they remained sitting face to face at the two chimney corners,
+motionless, in silence. Emma shrugged her shoulders as she stamped her
+feet. He heard her murmuring--
+
+“If I were in your place _I_ should soon get some.”
+
+“But where?”
+
+“At your office.” And she looked at him.
+
+An infernal boldness looked out from her burning eyes, and their lids
+drew close together with a lascivious and encouraging look, so that the
+young man felt himself growing weak beneath the mute will of this woman
+who was urging him to a crime. Then he was afraid, and to avoid any
+explanation he smote his forehead, crying--
+
+“Morel is to come back to-night; he will not refuse me, I hope” (this
+was one of his friends, the son of a very rich merchant); “and I will
+bring it you to-morrow,” he added.
+
+Emma did not seem to welcome this hope with all the joy he had expected.
+Did she suspect the lie? He went on, blushing--
+
+“However, if you don’t see me by three o’clock do not wait for me, my
+darling. I must be off now; forgive me! Goodbye!”
+
+He pressed her hand, but it felt quite lifeless. Emma had no strength
+left for any sentiment.
+
+Four o’clock struck, and she rose to return to Yonville, mechanically
+obeying the force of old habits.
+
+The weather was fine. It was one of those March days, clear and sharp,
+when the sun shines in a perfectly white sky. The Rouen folk, in
+Sunday-clothes, were walking about with happy looks. She reached the
+Place du Parvis. People were coming out after vespers; the crowd flowed
+out through the three doors like a stream through the three arches of
+a bridge, and in the middle one, more motionless than a rock, stood the
+beadle.
+
+Then she remembered the day when, all anxious and full of hope, she had
+entered beneath this large nave, that had opened out before her, less
+profound than her love; and she walked on weeping beneath her veil,
+giddy, staggering, almost fainting.
+
+“Take care!” cried a voice issuing from the gate of a courtyard that was
+thrown open.
+
+She stopped to let pass a black horse, pawing the ground between the
+shafts of a tilbury, driven by a gentleman in sable furs. Who was it?
+She knew him. The carriage darted by and disappeared.
+
+Why, it was he--the Viscount. She turned away; the street was empty. She
+was so overwhelmed, so sad, that she had to lean against a wall to keep
+herself from falling.
+
+Then she thought she had been mistaken. Anyhow, she did not know. All
+within her and around her was abandoning her. She felt lost, sinking
+at random into indefinable abysses, and it was almost with joy that, on
+reaching the “Croix-Rouge,” she saw the good Homais, who was watching
+a large box full of pharmaceutical stores being hoisted on to the
+“Hirondelle.” In his hand he held tied in a silk handkerchief six
+cheminots for his wife.
+
+Madame Homais was very fond of these small, heavy turban-shaped loaves,
+that are eaten in Lent with salt butter; a last vestige of Gothic food
+that goes back, perhaps, to the time of the Crusades, and with which
+the robust Normans gorged themselves of yore, fancying they saw on the
+table, in the light of the yellow torches, between tankards of hippocras
+and huge boars’ heads, the heads of Saracens to be devoured. The
+druggist’s wife crunched them up as they had done--heroically, despite
+her wretched teeth. And so whenever Homais journeyed to town, he never
+failed to bring her home some that he bought at the great baker’s in the
+Rue Massacre.
+
+“Charmed to see you,” he said, offering Emma a hand to help her into the
+“Hirondelle.” Then he hung up his cheminots to the cords of the netting,
+and remained bare-headed in an attitude pensive and Napoleonic.
+
+But when the blind man appeared as usual at the foot of the hill he
+exclaimed--
+
+“I can’t understand why the authorities tolerate such culpable
+industries. Such unfortunates should be locked up and forced to work.
+Progress, my word! creeps at a snail’s pace. We are floundering about in
+mere barbarism.”
+
+The blind man held out his hat, that flapped about at the door, as if it
+were a bag in the lining that had come unnailed.
+
+“This,” said the chemist, “is a scrofulous affection.”
+
+And though he knew the poor devil, he pretended to see him for the first
+time, murmured something about “cornea,” “opaque cornea,” “sclerotic,”
+ “facies,” then asked him in a paternal tone--
+
+“My friend, have you long had this terrible infirmity? Instead of
+getting drunk at the public, you’d do better to die yourself.”
+
+He advised him to take good wine, good beer, and good joints. The blind
+man went on with his song; he seemed, moreover, almost idiotic. At last
+Monsieur Homais opened his purse--
+
+“Now there’s a sou; give me back two lairds, and don’t forget my advice:
+you’ll be the better for it.”
+
+Hivert openly cast some doubt on the efficacy of it. But the druggist
+said that he would cure himself with an antiphlogistic pomade of his own
+composition, and he gave his address--“Monsieur Homais, near the market,
+pretty well known.”
+
+“Now,” said Hivert, “for all this trouble you’ll give us your
+performance.”
+
+The blind man sank down on his haunches, with his head thrown back,
+whilst he rolled his greenish eyes, lolled out his tongue, and rubbed
+his stomach with both hands as he uttered a kind of hollow yell like a
+famished dog. Emma, filled with disgust, threw him over her shoulder
+a five-franc piece. It was all her fortune. It seemed to her very fine
+thus to throw it away.
+
+The coach had gone on again when suddenly Monsieur Homais leant out
+through the window, crying--
+
+“No farinaceous or milk food, wear wool next the skin, and expose the
+diseased parts to the smoke of juniper berries.”
+
+The sight of the well-known objects that defiled before her eyes
+gradually diverted Emma from her present trouble. An intolerable fatigue
+overwhelmed her, and she reached her home stupefied, discouraged, almost
+asleep.
+
+“Come what may come!” she said to herself. “And then, who knows? Why, at
+any moment could not some extraordinary event occur? Lheureux even might
+die!”
+
+At nine o’clock in the morning she was awakened by the sound of voices
+in the Place. There was a crowd round the market reading a large bill
+fixed to one of the posts, and she saw Justin, who was climbing on to
+a stone and tearing down the bill. But at this moment the rural guard
+seized him by the collar. Monsieur Homais came out of his shop, and Mere
+Lefrangois, in the midst of the crowd, seemed to be perorating.
+
+“Madame! madame!” cried Felicite, running in, “it’s abominable!”
+
+And the poor girl, deeply moved, handed her a yellow paper that she had
+just torn off the door. Emma read with a glance that all her furniture
+was for sale.
+
+Then they looked at one another silently. The servant and mistress had
+no secret one from the other. At last Felicite sighed--
+
+“If I were you, madame, I should go to Monsieur Guillaumin.”
+
+“Do you think--”
+
+And this question meant to say--
+
+“You who know the house through the servant, has the master spoken
+sometimes of me?”
+
+“Yes, you’d do well to go there.”
+
+She dressed, put on her black gown, and her hood with jet beads, and
+that she might not be seen (there was still a crowd on the Place), she
+took the path by the river, outside the village.
+
+She reached the notary’s gate quite breathless. The sky was sombre, and
+a little snow was falling. At the sound of the bell, Theodore in a
+red waistcoat appeared on the steps; he came to open the door almost
+familiarly, as to an acquaintance, and showed her into the dining-room.
+
+A large porcelain stove crackled beneath a cactus that filled up the
+niche in the wall, and in black wood frames against the oak-stained
+paper hung Steuben’s “Esmeralda” and Schopin’s “Potiphar.” The
+ready-laid table, the two silver chafing-dishes, the crystal door-knobs,
+the parquet and the furniture, all shone with a scrupulous, English
+cleanliness; the windows were ornamented at each corner with stained
+glass.
+
+“Now this,” thought Emma, “is the dining-room I ought to have.”
+
+The notary came in pressing his palm-leaf dressing-gown to his breast
+with his left arm, while with the other hand he raised and quickly put
+on again his brown velvet cap, pretentiously cocked on the right side,
+whence looked out the ends of three fair curls drawn from the back of
+the head, following the line of his bald skull.
+
+After he had offered her a seat he sat down to breakfast, apologising
+profusely for his rudeness.
+
+“I have come,” she said, “to beg you, sir--”
+
+“What, madame? I am listening.”
+
+And she began explaining her position to him. Monsieur Guillaumin knew
+it, being secretly associated with the linendraper, from whom he always
+got capital for the loans on mortgages that he was asked to make.
+
+So he knew (and better than she herself) the long story of the bills,
+small at first, bearing different names as endorsers, made out at long
+dates, and constantly renewed up to the day, when, gathering together
+all the protested bills, the shopkeeper had bidden his friend Vincart
+take in his own name all the necessary proceedings, not wishing to pass
+for a tiger with his fellow-citizens.
+
+She mingled her story with recriminations against Lheureux, to which the
+notary replied from time to time with some insignificant word. Eating
+his cutlet and drinking his tea, he buried his chin in his sky-blue
+cravat, into which were thrust two diamond pins, held together by a
+small gold chain; and he smiled a singular smile, in a sugary, ambiguous
+fashion. But noticing that her feet were damp, he said--
+
+“Do get closer to the stove; put your feet up against the porcelain.”
+
+She was afraid of dirtying it. The notary replied in a gallant tone--
+
+“Beautiful things spoil nothing.”
+
+Then she tried to move him, and, growing moved herself, she began
+telling him about the poorness of her home, her worries, her wants.
+He could understand that; an elegant woman! and, without leaving off
+eating, he had turned completely round towards her, so that his knee
+brushed against her boot, whose sole curled round as it smoked against
+the stove.
+
+But when she asked for a thousand sous, he closed his lips, and declared
+he was very sorry he had not had the management of her fortune before,
+for there were hundreds of ways very convenient, even for a lady, of
+turning her money to account. They might, either in the turf-peats
+of Grumesnil or building-ground at Havre, almost without risk, have
+ventured on some excellent speculations; and he let her consume herself
+with rage at the thought of the fabulous sums that she would certainly
+have made.
+
+“How was it,” he went on, “that you didn’t come to me?”
+
+“I hardly know,” she said.
+
+“Why, hey? Did I frighten you so much? It is I, on the contrary, who
+ought to complain. We hardly know one another; yet I am very devoted to
+you. You do not doubt that, I hope?”
+
+He held out his hand, took hers, covered it with a greedy kiss, then
+held it on his knee; and he played delicately with her fingers whilst
+he murmured a thousand blandishments. His insipid voice murmured like a
+running brook; a light shone in his eyes through the glimmering of his
+spectacles, and his hand was advancing up Emma’s sleeve to press her
+arm. She felt against her cheek his panting breath. This man oppressed
+her horribly.
+
+She sprang up and said to him--
+
+“Sir, I am waiting.”
+
+“For what?” said the notary, who suddenly became very pale.
+
+“This money.”
+
+“But--” Then, yielding to the outburst of too powerful a desire, “Well,
+yes!”
+
+He dragged himself towards her on his knees, regardless of his
+dressing-gown.
+
+“For pity’s sake, stay. I love you!”
+
+He seized her by her waist. Madame Bovary’s face flushed purple. She
+recoiled with a terrible look, crying--
+
+“You are taking a shameless advantage of my distress, sir! I am to be
+pitied--not to be sold.”
+
+And she went out.
+
+The notary remained quite stupefied, his eyes fixed on his fine
+embroidered slippers. They were a love gift, and the sight of them at
+last consoled him. Besides, he reflected that such an adventure might
+have carried him too far.
+
+“What a wretch! what a scoundrel! what an infamy!” she said to herself,
+as she fled with nervous steps beneath the aspens of the path. The
+disappointment of her failure increased the indignation of her outraged
+modesty; it seemed to her that Providence pursued her implacably, and,
+strengthening herself in her pride, she had never felt so much esteem
+for herself nor so much contempt for others. A spirit of warfare
+transformed her. She would have liked to strike all men, to spit in
+their faces, to crush them, and she walked rapidly straight on, pale,
+quivering, maddened, searching the empty horizon with tear-dimmed eyes,
+and as it were rejoicing in the hate that was choking her.
+
+When she saw her house a numbness came over her. She could not go on;
+and yet she must. Besides, whither could she flee?
+
+Felicite was waiting for her at the door. “Well?”
+
+“No!” said Emma.
+
+And for a quarter of an hour the two of them went over the various
+persons in Yonville who might perhaps be inclined to help her. But each
+time that Felicite named someone Emma replied--
+
+“Impossible! they will not!”
+
+“And the master’ll soon be in.”
+
+“I know that well enough. Leave me alone.”
+
+She had tried everything; there was nothing more to be done now; and
+when Charles came in she would have to say to him--
+
+“Go away! This carpet on which you are walking is no longer ours. In
+your own house you do not possess a chair, a pin, a straw, and it is I,
+poor man, who have ruined you.”
+
+Then there would be a great sob; next he would weep abundantly, and at
+last, the surprise past, he would forgive her.
+
+“Yes,” she murmured, grinding her teeth, “he will forgive me, he who
+would give a million if I would forgive him for having known me! Never!
+never!”
+
+This thought of Bovary’s superiority to her exasperated her. Then,
+whether she confessed or did not confess, presently, immediately,
+to-morrow, he would know the catastrophe all the same; so she must wait
+for this horrible scene, and bear the weight of his magnanimity. The
+desire to return to Lheureux’s seized her--what would be the use? To
+write to her father--it was too late; and perhaps, she began to repent
+now that she had not yielded to that other, when she heard the trot of
+a horse in the alley. It was he; he was opening the gate; he was whiter
+than the plaster wall. Rushing to the stairs, she ran out quickly to the
+square; and the wife of the mayor, who was talking to Lestiboudois in
+front of the church, saw her go in to the tax-collector’s.
+
+She hurried off to tell Madame Caron, and the two ladies went up to
+the attic, and, hidden by some linen spread across props, stationed
+themselves comfortably for overlooking the whole of Binet’s room.
+
+He was alone in his garret, busy imitating in wood one of those
+indescribable bits of ivory, composed of crescents, of spheres hollowed
+out one within the other, the whole as straight as an obelisk, and of no
+use whatever; and he was beginning on the last piece--he was nearing his
+goal. In the twilight of the workshop the white dust was flying from his
+tools like a shower of sparks under the hoofs of a galloping horse; the
+two wheels were turning, droning; Binet smiled, his chin lowered, his
+nostrils distended, and, in a word, seemed lost in one of those complete
+happinesses that, no doubt, belong only to commonplace occupations,
+which amuse the mind with facile difficulties, and satisfy by a
+realisation of that beyond which such minds have not a dream.
+
+“Ah! there she is!” exclaimed Madame Tuvache.
+
+But it was impossible because of the lathe to hear what she was saying.
+
+At last these ladies thought they made out the word “francs,” and Madame
+Tuvache whispered in a low voice--
+
+“She is begging him to give her time for paying her taxes.”
+
+“Apparently!” replied the other.
+
+They saw her walking up and down, examining the napkin-rings, the
+candlesticks, the banister rails against the walls, while Binet stroked
+his beard with satisfaction.
+
+“Do you think she wants to order something of him?” said Madame Tuvache.
+
+“Why, he doesn’t sell anything,” objected her neighbour.
+
+The tax-collector seemed to be listening with wide-open eyes, as if he
+did not understand. She went on in a tender, suppliant manner. She came
+nearer to him, her breast heaving; they no longer spoke.
+
+“Is she making him advances?” said Madame Tuvache. Binet was scarlet to
+his very ears. She took hold of his hands.
+
+“Oh, it’s too much!”
+
+And no doubt she was suggesting something abominable to him; for the
+tax-collector--yet he was brave, had fought at Bautzen and at Lutzen,
+had been through the French campaign, and had even been recommended for
+the cross--suddenly, as at the sight of a serpent, recoiled as far as he
+could from her, crying--
+
+“Madame! what do you mean?”
+
+“Women like that ought to be whipped,” said Madame Tuvache.
+
+“But where is she?” continued Madame Caron, for she had disappeared
+whilst they spoke; then catching sight of her going up the Grande Rue,
+and turning to the right as if making for the cemetery, they were lost
+in conjectures.
+
+“Nurse Rollet,” she said on reaching the nurse’s, “I am choking; unlace
+me!” She fell on the bed sobbing. Nurse Rollet covered her with a
+petticoat and remained standing by her side. Then, as she did not
+answer, the good woman withdrew, took her wheel and began spinning flax.
+
+“Oh, leave off!” she murmured, fancying she heard Binet’s lathe.
+
+“What’s bothering her?” said the nurse to herself. “Why has she come
+here?”
+
+She had rushed thither; impelled by a kind of horror that drove her from
+her home.
+
+Lying on her back, motionless, and with staring eyes, she saw things but
+vaguely, although she tried to with idiotic persistence. She looked
+at the scales on the walls, two brands smoking end to end, and a long
+spider crawling over her head in a rent in the beam. At last she began
+to collect her thoughts. She remembered--one day--Leon--Oh! how long
+ago that was--the sun was shining on the river, and the clematis were
+perfuming the air. Then, carried away as by a rushing torrent, she soon
+began to recall the day before.
+
+“What time is it?” she asked.
+
+Mere Rollet went out, raised the fingers of her right hand to that side
+of the sky that was brightest, and came back slowly, saying--
+
+“Nearly three.”
+
+“Ah! thanks, thanks!”
+
+For he would come; he would have found some money. But he would,
+perhaps, go down yonder, not guessing she was here, and she told the
+nurse to run to her house to fetch him.
+
+“Be quick!”
+
+“But, my dear lady, I’m going, I’m going!”
+
+She wondered now that she had not thought of him from the first.
+Yesterday he had given his word; he would not break it. And she already
+saw herself at Lheureux’s spreading out her three bank-notes on his
+bureau. Then she would have to invent some story to explain matters to
+Bovary. What should it be?
+
+The nurse, however, was a long while gone. But, as there was no clock
+in the cot, Emma feared she was perhaps exaggerating the length of time.
+She began walking round the garden, step by step; she went into the path
+by the hedge, and returned quickly, hoping that the woman would have
+come back by another road. At last, weary of waiting, assailed by fears
+that she thrust from her, no longer conscious whether she had been here
+a century or a moment, she sat down in a corner, closed her eyes, and
+stopped her ears. The gate grated; she sprang up. Before she had spoken
+Mere Rollet said to her--
+
+“There is no one at your house!”
+
+“What?”
+
+“Oh, no one! And the doctor is crying. He is calling for you; they’re
+looking for you.”
+
+Emma answered nothing. She gasped as she turned her eyes about
+her, while the peasant woman, frightened at her face, drew back
+instinctively, thinking her mad. Suddenly she struck her brow and
+uttered a cry; for the thought of Rodolphe, like a flash of lightning in
+a dark night, had passed into her soul. He was so good, so delicate, so
+generous! And besides, should he hesitate to do her this service, she
+would know well enough how to constrain him to it by re-waking, in a
+single moment, their lost love. So she set out towards La Huchette, not
+seeing that she was hastening to offer herself to that which but a while
+ago had so angered her, not in the least conscious of her prostitution.
+
+
+
+Chapter Eight
+
+She asked herself as she walked along, “What am I going to say? How
+shall I begin?” And as she went on she recognised the thickets,
+the trees, the sea-rushes on the hill, the chateau yonder. All the
+sensations of her first tenderness came back to her, and her poor aching
+heart opened out amorously. A warm wind blew in her face; the melting
+snow fell drop by drop from the buds to the grass.
+
+She entered, as she used to, through the small park-gate. She reached
+the avenue bordered by a double row of dense lime-trees. They were
+swaying their long whispering branches to and fro. The dogs in their
+kennels all barked, and the noise of their voices resounded, but brought
+out no one.
+
+She went up the large straight staircase with wooden balusters that led
+to the corridor paved with dusty flags, into which several doors in a
+row opened, as in a monastery or an inn. His was at the top, right
+at the end, on the left. When she placed her fingers on the lock her
+strength suddenly deserted her. She was afraid, almost wished he
+would not be there, though this was her only hope, her last chance of
+salvation. She collected her thoughts for one moment, and, strengthening
+herself by the feeling of present necessity, went in.
+
+He was in front of the fire, both his feet on the mantelpiece, smoking a
+pipe.
+
+“What! it is you!” he said, getting up hurriedly.
+
+“Yes, it is I, Rodolphe. I should like to ask your advice.”
+
+And, despite all her efforts, it was impossible for her to open her
+lips.
+
+“You have not changed; you are charming as ever!”
+
+“Oh,” she replied bitterly, “they are poor charms since you disdained
+them.”
+
+Then he began a long explanation of his conduct, excusing himself in
+vague terms, in default of being able to invent better.
+
+She yielded to his words, still more to his voice and the sight of him,
+so that, she pretended to believe, or perhaps believed; in the pretext
+he gave for their rupture; this was a secret on which depended the
+honour, the very life of a third person.
+
+“No matter!” she said, looking at him sadly. “I have suffered much.”
+
+He replied philosophically--
+
+“Such is life!”
+
+“Has life,” Emma went on, “been good to you at least, since our
+separation?”
+
+“Oh, neither good nor bad.”
+
+“Perhaps it would have been better never to have parted.”
+
+“Yes, perhaps.”
+
+“You think so?” she said, drawing nearer, and she sighed. “Oh, Rodolphe!
+if you but knew! I loved you so!”
+
+It was then that she took his hand, and they remained some time, their
+fingers intertwined, like that first day at the Show. With a gesture of
+pride he struggled against this emotion. But sinking upon his breast she
+said to him--
+
+“How did you think I could live without you? One cannot lose the habit
+of happiness. I was desolate. I thought I should die. I will tell you
+about all that and you will see. And you--you fled from me!”
+
+For, all the three years, he had carefully avoided her in consequence
+of that natural cowardice that characterises the stronger sex. Emma went
+on, with dainty little nods, more coaxing than an amorous kitten--
+
+“You love others, confess it! Oh, I understand them, dear! I excuse
+them. You probably seduced them as you seduced me. You are indeed a man;
+you have everything to make one love you. But we’ll begin again, won’t
+we? We will love one another. See! I am laughing; I am happy! Oh,
+speak!”
+
+And she was charming to see, with her eyes, in which trembled a tear,
+like the rain of a storm in a blue corolla.
+
+He had drawn her upon his knees, and with the back of his hand was
+caressing her smooth hair, where in the twilight was mirrored like a
+golden arrow one last ray of the sun. She bent down her brow; at last he
+kissed her on the eyelids quite gently with the tips of his lips.
+
+“Why, you have been crying! What for?”
+
+She burst into tears. Rodolphe thought this was an outburst of her
+love. As she did not speak, he took this silence for a last remnant of
+resistance, and then he cried out--
+
+“Oh, forgive me! You are the only one who pleases me. I was imbecile and
+cruel. I love you. I will love you always. What is it. Tell me!” He was
+kneeling by her.
+
+“Well, I am ruined, Rodolphe! You must lend me three thousand francs.”
+
+“But--but--” said he, getting up slowly, while his face assumed a grave
+expression.
+
+“You know,” she went on quickly, “that my husband had placed his whole
+fortune at a notary’s. He ran away. So we borrowed; the patients don’t
+pay us. Moreover, the settling of the estate is not yet done; we shall
+have the money later on. But to-day, for want of three thousand francs,
+we are to be sold up. It is to be at once, this very moment, and,
+counting upon your friendship, I have come to you.”
+
+“Ah!” thought Rodolphe, turning very pale, “that was what she came for.”
+ At last he said with a calm air--
+
+“Dear madame, I have not got them.”
+
+He did not lie. If he had had them, he would, no doubt, have given them,
+although it is generally disagreeable to do such fine things: a demand
+for money being, of all the winds that blow upon love, the coldest and
+most destructive.
+
+First she looked at him for some moments.
+
+“You have not got them!” she repeated several times. “You have not got
+them! I ought to have spared myself this last shame. You never loved me.
+You are no better than the others.”
+
+She was betraying, ruining herself.
+
+Rodolphe interrupted her, declaring he was “hard up” himself.
+
+“Ah! I pity you,” said Emma. “Yes--very much.”
+
+And fixing her eyes upon an embossed carabine, that shone against its
+panoply, “But when one is so poor one doesn’t have silver on the butt of
+one’s gun. One doesn’t buy a clock inlaid with tortoise shell,” she went
+on, pointing to a buhl timepiece, “nor silver-gilt whistles for one’s
+whips,” and she touched them, “nor charms for one’s watch. Oh, he wants
+for nothing! even to a liqueur-stand in his room! For you love yourself;
+you live well. You have a chateau, farms, woods; you go hunting; you
+travel to Paris. Why, if it were but that,” she cried, taking up two
+studs from the mantelpiece, “but the least of these trifles, one can get
+money for them. Oh, I do not want them, keep them!”
+
+And she threw the two links away from her, their gold chain breaking as
+it struck against the wall.
+
+“But I! I would have given you everything. I would have sold all, worked
+for you with my hands, I would have begged on the highroads for a smile,
+for a look, to hear you say ‘Thanks!’ And you sit there quietly in your
+arm-chair, as if you had not made me suffer enough already! But for you,
+and you know it, I might have lived happily. What made you do it? Was
+it a bet? Yet you loved me--you said so. And but a moment since--Ah!
+it would have been better to have driven me away. My hands are hot with
+your kisses, and there is the spot on the carpet where at my knees you
+swore an eternity of love! You made me believe you; for two years you
+held me in the most magnificent, the sweetest dream! Eh! Our plans for
+the journey, do you remember? Oh, your letter! your letter! it tore my
+heart! And then when I come back to him--to him, rich, happy, free--to
+implore the help the first stranger would give, a suppliant, and
+bringing back to him all my tenderness, he repulses me because it would
+cost him three thousand francs!”
+
+“I haven’t got them,” replied Rodolphe, with that perfect calm with
+which resigned rage covers itself as with a shield.
+
+She went out. The walls trembled, the ceiling was crushing her, and she
+passed back through the long alley, stumbling against the heaps of dead
+leaves scattered by the wind. At last she reached the ha-ha hedge in
+front of the gate; she broke her nails against the lock in her haste to
+open it. Then a hundred steps farther on, breathless, almost falling,
+she stopped. And now turning round, she once more saw the impassive
+chateau, with the park, the gardens, the three courts, and all the
+windows of the facade.
+
+She remained lost in stupor, and having no more consciousness of herself
+than through the beating of her arteries, that she seemed to hear
+bursting forth like a deafening music filling all the fields. The earth
+beneath her feet was more yielding than the sea, and the furrows seemed
+to her immense brown waves breaking into foam. Everything in her
+head, of memories, ideas, went off at once like a thousand pieces of
+fireworks. She saw her father, Lheureux’s closet, their room at home,
+another landscape. Madness was coming upon her; she grew afraid, and
+managed to recover herself, in a confused way, it is true, for she did
+not in the least remember the cause of the terrible condition she was
+in, that is to say, the question of money. She suffered only in her
+love, and felt her soul passing from her in this memory; as wounded men,
+dying, feel their life ebb from their bleeding wounds.
+
+Night was falling, crows were flying about.
+
+Suddenly it seemed to her that fiery spheres were exploding in the air
+like fulminating balls when they strike, and were whirling, whirling,
+to melt at last upon the snow between the branches of the trees. In the
+midst of each of them appeared the face of Rodolphe. They multiplied and
+drew near her, penetrating, her. It all disappeared; she recognised the
+lights of the houses that shone through the fog.
+
+Now her situation, like an abyss, rose up before her. She was panting as
+if her heart would burst. Then in an ecstasy of heroism, that made
+her almost joyous, she ran down the hill, crossed the cow-plank, the
+foot-path, the alley, the market, and reached the chemist’s shop. She
+was about to enter, but at the sound of the bell someone might come, and
+slipping in by the gate, holding her breath, feeling her way along the
+walls, she went as far as the door of the kitchen, where a candle stuck
+on the stove was burning. Justin in his shirt-sleeves was carrying out a
+dish.
+
+“Ah! they are dining; I will wait.”
+
+He returned; she tapped at the window. He went out.
+
+“The key! the one for upstairs where he keeps the--”
+
+“What?”
+
+And he looked at her, astonished at the pallor of her face, that stood
+out white against the black background of the night. She seemed to
+him extraordinarily beautiful and majestic as a phantom. Without
+understanding what she wanted, he had the presentiment of something
+terrible.
+
+But she went on quickly in a love voice; in a sweet, melting voice, “I
+want it; give it to me.”
+
+As the partition wall was thin, they could hear the clatter of the forks
+on the plates in the dining-room.
+
+She pretended that she wanted to kill the rats that kept her from
+sleeping.
+
+“I must tell master.”
+
+“No, stay!” Then with an indifferent air, “Oh, it’s not worth while;
+I’ll tell him presently. Come, light me upstairs.”
+
+She entered the corridor into which the laboratory door opened. Against
+the wall was a key labelled Capharnaum.
+
+“Justin!” called the druggist impatiently.
+
+“Let us go up.”
+
+And he followed her. The key turned in the lock, and she went straight
+to the third shelf, so well did her memory guide her, seized the blue
+jar, tore out the cork, plunged in her hand, and withdrawing it full of
+a white powder, she began eating it.
+
+“Stop!” he cried, rushing at her.
+
+“Hush! someone will come.”
+
+He was in despair, was calling out.
+
+“Say nothing, or all the blame will fall on your master.”
+
+Then she went home, suddenly calmed, and with something of the serenity
+of one that had performed a duty.
+
+When Charles, distracted by the news of the distraint, returned home,
+Emma had just gone out. He cried aloud, wept, fainted, but she did not
+return. Where could she be? He sent Felicite to Homais, to Monsieur
+Tuvache, to Lheureux, to the “Lion d’Or,” everywhere, and in the
+intervals of his agony he saw his reputation destroyed, their fortune
+lost, Berthe’s future ruined. By what?--Not a word! He waited till six
+in the evening. At last, unable to bear it any longer, and fancying she
+had gone to Rouen, he set out along the highroad, walked a mile, met no
+one, again waited, and returned home. She had come back.
+
+“What was the matter? Why? Explain to me.”
+
+She sat down at her writing-table and wrote a letter, which she sealed
+slowly, adding the date and the hour. Then she said in a solemn tone:
+
+“You are to read it to-morrow; till then, I pray you, do not ask me a
+single question. No, not one!”
+
+“But--”
+
+“Oh, leave me!”
+
+She lay down full length on her bed. A bitter taste that she felt in her
+mouth awakened her. She saw Charles, and again closed her eyes.
+
+She was studying herself curiously, to see if she were not suffering.
+But no! nothing as yet. She heard the ticking of the clock, the
+crackling of the fire, and Charles breathing as he stood upright by her
+bed.
+
+“Ah! it is but a little thing, death!” she thought. “I shall fall asleep
+and all will be over.”
+
+She drank a mouthful of water and turned to the wall. The frightful
+taste of ink continued.
+
+“I am thirsty; oh! so thirsty,” she sighed.
+
+“What is it?” said Charles, who was handing her a glass.
+
+“It is nothing! Open the window; I am choking.”
+
+She was seized with a sickness so sudden that she had hardly time to
+draw out her handkerchief from under the pillow.
+
+“Take it away,” she said quickly; “throw it away.”
+
+He spoke to her; she did not answer. She lay motionless, afraid that
+the slightest movement might make her vomit. But she felt an icy cold
+creeping from her feet to her heart.
+
+“Ah! it is beginning,” she murmured.
+
+“What did you say?”
+
+She turned her head from side to side with a gentle movement full of
+agony, while constantly opening her mouth as if something very heavy
+were weighing upon her tongue. At eight o’clock the vomiting began
+again.
+
+Charles noticed that at the bottom of the basin there was a sort of
+white sediment sticking to the sides of the porcelain.
+
+“This is extraordinary--very singular,” he repeated.
+
+But she said in a firm voice, “No, you are mistaken.”
+
+Then gently, and almost as caressing her, he passed his hand over her
+stomach. She uttered a sharp cry. He fell back terror-stricken.
+
+Then she began to groan, faintly at first. Her shoulders were shaken by
+a strong shuddering, and she was growing paler than the sheets in which
+her clenched fingers buried themselves. Her unequal pulse was now almost
+imperceptible.
+
+Drops of sweat oozed from her bluish face, that seemed as if rigid in
+the exhalations of a metallic vapour. Her teeth chattered, her dilated
+eyes looked vaguely about her, and to all questions she replied only
+with a shake of the head; she even smiled once or twice. Gradually, her
+moaning grew louder; a hollow shriek burst from her; she pretended she
+was better and that she would get up presently. But she was seized with
+convulsions and cried out--
+
+“Ah! my God! It is horrible!”
+
+He threw himself on his knees by her bed.
+
+“Tell me! what have you eaten? Answer, for heaven’s sake!”
+
+And he looked at her with a tenderness in his eyes such as she had never
+seen.
+
+“Well, there--there!” she said in a faint voice. He flew to the
+writing-table, tore open the seal, and read aloud: “Accuse no one.” He
+stopped, passed his hands across his eyes, and read it over again.
+
+“What! help--help!”
+
+He could only keep repeating the word: “Poisoned! poisoned!” Felicite
+ran to Homais, who proclaimed it in the market-place; Madame Lefrancois
+heard it at the “Lion d’Or”; some got up to go and tell their
+neighbours, and all night the village was on the alert.
+
+Distraught, faltering, reeling, Charles wandered about the room. He
+knocked against the furniture, tore his hair, and the chemist had never
+believed that there could be so terrible a sight.
+
+He went home to write to Monsieur Canivet and to Doctor Lariviere. He
+lost his head, and made more than fifteen rough copies. Hippolyte went
+to Neufchatel, and Justin so spurred Bovary’s horse that he left it
+foundered and three parts dead by the hill at Bois-Guillaume.
+
+Charles tried to look up his medical dictionary, but could not read it;
+the lines were dancing.
+
+“Be calm,” said the druggist; “we have only to administer a powerful
+antidote. What is the poison?”
+
+Charles showed him the letter. It was arsenic.
+
+“Very well,” said Homais, “we must make an analysis.”
+
+For he knew that in cases of poisoning an analysis must be made; and the
+other, who did not understand, answered--
+
+“Oh, do anything! save her!”
+
+Then going back to her, he sank upon the carpet, and lay there with his
+head leaning against the edge of her bed, sobbing.
+
+“Don’t cry,” she said to him. “Soon I shall not trouble you any more.”
+
+“Why was it? Who drove you to it?”
+
+She replied. “It had to be, my dear!”
+
+“Weren’t you happy? Is it my fault? I did all I could!”
+
+“Yes, that is true--you are good--you.”
+
+And she passed her hand slowly over his hair. The sweetness of this
+sensation deepened his sadness; he felt his whole being dissolving
+in despair at the thought that he must lose her, just when she was
+confessing more love for him than ever. And he could think of nothing;
+he did not know, he did not dare; the urgent need for some immediate
+resolution gave the finishing stroke to the turmoil of his mind.
+
+So she had done, she thought, with all the treachery; and meanness,
+and numberless desires that had tortured her. She hated no one now; a
+twilight dimness was settling upon her thoughts, and, of all earthly
+noises, Emma heard none but the intermittent lamentations of this poor
+heart, sweet and indistinct like the echo of a symphony dying away.
+
+“Bring me the child,” she said, raising herself on her elbow.
+
+“You are not worse, are you?” asked Charles.
+
+“No, no!”
+
+The child, serious, and still half-asleep, was carried in on the
+servant’s arm in her long white nightgown, from which her bare
+feet peeped out. She looked wonderingly at the disordered room, and
+half-closed her eyes, dazzled by the candles burning on the table. They
+reminded her, no doubt, of the morning of New Year’s day and Mid-Lent,
+when thus awakened early by candle-light she came to her mother’s bed to
+fetch her presents, for she began saying--
+
+“But where is it, mamma?” And as everybody was silent, “But I can’t see
+my little stocking.”
+
+Felicite held her over the bed while she still kept looking towards the
+mantelpiece.
+
+“Has nurse taken it?” she asked.
+
+And at this name, that carried her back to the memory of her adulteries
+and her calamities, Madame Bovary turned away her head, as at the
+loathing of another bitterer poison that rose to her mouth. But Berthe
+remained perched on the bed.
+
+“Oh, how big your eyes are, mamma! How pale you are! how hot you are!”
+
+Her mother looked at her. “I am frightened!” cried the child, recoiling.
+
+Emma took her hand to kiss it; the child struggled.
+
+“That will do. Take her away,” cried Charles, who was sobbing in the
+alcove.
+
+Then the symptoms ceased for a moment; she seemed less agitated; and at
+every insignificant word, at every respiration a little more easy, he
+regained hope. At last, when Canivet came in, he threw himself into his
+arms.
+
+“Ah! it is you. Thanks! You are good! But she is better. See! look at
+her.”
+
+His colleague was by no means of this opinion, and, as he said of
+himself, “never beating about the bush,” he prescribed, an emetic in
+order to empty the stomach completely.
+
+She soon began vomiting blood. Her lips became drawn. Her limbs were
+convulsed, her whole body covered with brown spots, and her pulse
+slipped beneath the fingers like a stretched thread, like a harp-string
+nearly breaking.
+
+After this she began to scream horribly. She cursed the poison, railed
+at it, and implored it to be quick, and thrust away with her stiffened
+arms everything that Charles, in more agony than herself, tried to make
+her drink. He stood up, his handkerchief to his lips, with a rattling
+sound in his throat, weeping, and choked by sobs that shook his whole
+body. Felicite was running hither and thither in the room. Homais,
+motionless, uttered great sighs; and Monsieur Canivet, always retaining
+his self-command, nevertheless began to feel uneasy.
+
+“The devil! yet she has been purged, and from the moment that the cause
+ceases--”
+
+“The effect must cease,” said Homais, “that is evident.”
+
+“Oh, save her!” cried Bovary.
+
+And, without listening to the chemist, who was still venturing the
+hypothesis, “It is perhaps a salutary paroxysm,” Canivet was about to
+administer some theriac, when they heard the cracking of a whip; all the
+windows rattled, and a post-chaise drawn by three horses abreast, up to
+their ears in mud, drove at a gallop round the corner of the market. It
+was Doctor Lariviere.
+
+The apparition of a god would not have caused more commotion. Bovary
+raised his hands; Canivet stopped short; and Homais pulled off his
+skull-cap long before the doctor had come in.
+
+He belonged to that great school of surgery begotten of Bichat, to that
+generation, now extinct, of philosophical practitioners, who, loving
+their art with a fanatical love, exercised it with enthusiasm and
+wisdom. Everyone in his hospital trembled when he was angry; and his
+students so revered him that they tried, as soon as they were themselves
+in practice, to imitate him as much as possible. So that in all the
+towns about they were found wearing his long wadded merino overcoat
+and black frock-coat, whose buttoned cuffs slightly covered his brawny
+hands--very beautiful hands, and that never knew gloves, as though to be
+more ready to plunge into suffering. Disdainful of honours, of titles,
+and of academies, like one of the old Knight-Hospitallers, generous,
+fatherly to the poor, and practising virtue without believing in it, he
+would almost have passed for a saint if the keenness of his intellect
+had not caused him to be feared as a demon. His glance, more penetrating
+than his bistouries, looked straight into your soul, and dissected every
+lie athwart all assertions and all reticences. And thus he went along,
+full of that debonair majesty that is given by the consciousness
+of great talent, of fortune, and of forty years of a labourious and
+irreproachable life.
+
+He frowned as soon as he had passed the door when he saw the cadaverous
+face of Emma stretched out on her back with her mouth open. Then, while
+apparently listening to Canivet, he rubbed his fingers up and down
+beneath his nostrils, and repeated--
+
+“Good! good!”
+
+But he made a slow gesture with his shoulders. Bovary watched him; they
+looked at one another; and this man, accustomed as he was to the sight
+of pain, could not keep back a tear that fell on his shirt-frill.
+
+He tried to take Canivet into the next room. Charles followed him.
+
+“She is very ill, isn’t she? If we put on sinapisms? Anything! Oh, think
+of something, you who have saved so many!”
+
+Charles caught him in both his arms, and gazed at him wildly,
+imploringly, half-fainting against his breast.
+
+“Come, my poor fellow, courage! There is nothing more to be done.”
+
+And Doctor Lariviere turned away.
+
+“You are going?”
+
+“I will come back.”
+
+He went out only to give an order to the coachman, with Monsieur
+Canivet, who did not care either to have Emma die under his hands.
+
+The chemist rejoined them on the Place. He could not by temperament keep
+away from celebrities, so he begged Monsieur Lariviere to do him the
+signal honour of accepting some breakfast.
+
+He sent quickly to the “Lion d’Or” for some pigeons; to the butcher’s
+for all the cutlets that were to be had; to Tuvache for cream; and
+to Lestiboudois for eggs; and the druggist himself aided in the
+preparations, while Madame Homais was saying as she pulled together the
+strings of her jacket--
+
+“You must excuse us, sir, for in this poor place, when one hasn’t been
+told the night before--”
+
+“Wine glasses!” whispered Homais.
+
+“If only we were in town, we could fall back upon stuffed trotters.”
+
+“Be quiet! Sit down, doctor!”
+
+He thought fit, after the first few mouthfuls, to give some details as
+to the catastrophe.
+
+“We first had a feeling of siccity in the pharynx, then intolerable
+pains at the epigastrium, super purgation, coma.”
+
+“But how did she poison herself?”
+
+“I don’t know, doctor, and I don’t even know where she can have procured
+the arsenious acid.”
+
+Justin, who was just bringing in a pile of plates, began to tremble.
+
+“What’s the matter?” said the chemist.
+
+At this question the young man dropped the whole lot on the ground with
+a crash.
+
+“Imbecile!” cried Homais, “awkward lout! block-head! confounded ass!”
+
+But suddenly controlling himself--
+
+“I wished, doctor, to make an analysis, and primo I delicately
+introduced a tube--”
+
+“You would have done better,” said the physician, “to introduce your
+fingers into her throat.”
+
+His colleague was silent, having just before privately received a severe
+lecture about his emetic, so that this good Canivet, so arrogant and so
+verbose at the time of the clubfoot, was to-day very modest. He smiled
+without ceasing in an approving manner.
+
+Homais dilated in Amphytrionic pride, and the affecting thought of
+Bovary vaguely contributed to his pleasure by a kind of egotistic
+reflex upon himself. Then the presence of the doctor transported him.
+He displayed his erudition, cited pell-mell cantharides, upas, the
+manchineel, vipers.
+
+“I have even read that various persons have found themselves
+under toxicological symptoms, and, as it were, thunderstricken by
+black-pudding that had been subjected to a too vehement fumigation.
+At least, this was stated in a very fine report drawn up by one of our
+pharmaceutical chiefs, one of our masters, the illustrious Cadet de
+Gassicourt!”
+
+Madame Homais reappeared, carrying one of those shaky machines that
+are heated with spirits of wine; for Homais liked to make his coffee
+at table, having, moreover, torrefied it, pulverised it, and mixed it
+himself.
+
+“Saccharum, doctor?” said he, offering the sugar.
+
+Then he had all his children brought down, anxious to have the
+physician’s opinion on their constitutions.
+
+At last Monsieur Lariviere was about to leave, when Madame Homais asked
+for a consultation about her husband. He was making his blood too thick
+by going to sleep every evening after dinner.
+
+“Oh, it isn’t his blood that’s too thick,” said the physician.
+
+And, smiling a little at his unnoticed joke, the doctor opened the
+door. But the chemist’s shop was full of people; he had the greatest
+difficulty in getting rid of Monsieur Tuvache, who feared his spouse
+would get inflammation of the lungs, because she was in the habit of
+spitting on the ashes; then of Monsieur Binet, who sometimes experienced
+sudden attacks of great hunger; and of Madame Caron, who suffered
+from tinglings; of Lheureux, who had vertigo; of Lestiboudois, who had
+rheumatism; and of Madame Lefrancois, who had heartburn. At last the
+three horses started; and it was the general opinion that he had not
+shown himself at all obliging.
+
+Public attention was distracted by the appearance of Monsieur
+Bournisien, who was going across the market with the holy oil.
+
+Homais, as was due to his principles, compared priests to ravens
+attracted by the odour of death. The sight of an ecclesiastic was
+personally disagreeable to him, for the cassock made him think of the
+shroud, and he detested the one from some fear of the other.
+
+Nevertheless, not shrinking from what he called his mission, he returned
+to Bovary’s in company with Canivet whom Monsieur Lariviere, before
+leaving, had strongly urged to make this visit; and he would, but for
+his wife’s objections, have taken his two sons with him, in order
+to accustom them to great occasions; that this might be a lesson, an
+example, a solemn picture, that should remain in their heads later on.
+
+The room when they went in was full of mournful solemnity. On the
+work-table, covered over with a white cloth, there were five or six
+small balls of cotton in a silver dish, near a large crucifix between
+two lighted candles.
+
+Emma, her chin sunken upon her breast, had her eyes inordinately wide
+open, and her poor hands wandered over the sheets with that hideous
+and soft movement of the dying, that seems as if they wanted already to
+cover themselves with the shroud. Pale as a statue and with eyes red as
+fire, Charles, not weeping, stood opposite her at the foot of the bed,
+while the priest, bending one knee, was muttering words in a low voice.
+
+She turned her face slowly, and seemed filled with joy on seeing
+suddenly the violet stole, no doubt finding again, in the midst of
+a temporary lull in her pain, the lost voluptuousness of her first
+mystical transports, with the visions of eternal beatitude that were
+beginning.
+
+The priest rose to take the crucifix; then she stretched forward her
+neck as one who is athirst, and glueing her lips to the body of the
+Man-God, she pressed upon it with all her expiring strength the fullest
+kiss of love that she had ever given. Then he recited the Misereatur and
+the Indulgentiam, dipped his right thumb in the oil, and began to give
+extreme unction. First upon the eyes, that had so coveted all worldly
+pomp; then upon the nostrils, that had been greedy of the warm breeze
+and amorous odours; then upon the mouth, that had uttered lies, that had
+curled with pride and cried out in lewdness; then upon the hands that
+had delighted in sensual touches; and finally upon the soles of the
+feet, so swift of yore, when she was running to satisfy her desires, and
+that would now walk no more.
+
+The cure wiped his fingers, threw the bit of cotton dipped in oil into
+the fire, and came and sat down by the dying woman, to tell her that
+she must now blend her sufferings with those of Jesus Christ and abandon
+herself to the divine mercy.
+
+Finishing his exhortations, he tried to place in her hand a blessed
+candle, symbol of the celestial glory with which she was soon to be
+surrounded. Emma, too weak, could not close her fingers, and the taper,
+but for Monsieur Bournisien would have fallen to the ground.
+
+However, she was not quite so pale, and her face had an expression of
+serenity as if the sacrament had cured her.
+
+The priest did not fail to point this out; he even explained to Bovary
+that the Lord sometimes prolonged the life of persons when he thought it
+meet for their salvation; and Charles remembered the day when, so near
+death, she had received the communion. Perhaps there was no need to
+despair, he thought.
+
+In fact, she looked around her slowly, as one awakening from a dream;
+then in a distinct voice she asked for her looking-glass, and remained
+some time bending over it, until the big tears fell from her eyes. Then
+she turned away her head with a sigh and fell back upon the pillows.
+
+Her chest soon began panting rapidly; the whole of her tongue protruded
+from her mouth; her eyes, as they rolled, grew paler, like the two
+globes of a lamp that is going out, so that one might have thought
+her already dead but for the fearful labouring of her ribs, shaken
+by violent breathing, as if the soul were struggling to free itself.
+Felicite knelt down before the crucifix, and the druggist himself
+slightly bent his knees, while Monsieur Canivet looked out vaguely at
+the Place. Bournisien had again begun to pray, his face bowed against
+the edge of the bed, his long black cassock trailing behind him in the
+room. Charles was on the other side, on his knees, his arms outstretched
+towards Emma. He had taken her hands and pressed them, shuddering at
+every beat of her heart, as at the shaking of a falling ruin. As the
+death-rattle became stronger the priest prayed faster; his prayers
+mingled with the stifled sobs of Bovary, and sometimes all seemed lost
+in the muffled murmur of the Latin syllables that tolled like a passing
+bell.
+
+Suddenly on the pavement was heard a loud noise of clogs and the
+clattering of a stick; and a voice rose--a raucous voice--that sang--
+
+“Maids in the warmth of a summer day Dream of love and of love always”
+
+Emma raised herself like a galvanised corpse, her hair undone, her eyes
+fixed, staring.
+
+“Where the sickle blades have been, Nannette, gathering ears of corn,
+Passes bending down, my queen, To the earth where they were born.”
+
+“The blind man!” she cried. And Emma began to laugh, an atrocious,
+frantic, despairing laugh, thinking she saw the hideous face of the poor
+wretch that stood out against the eternal night like a menace.
+
+“The wind is strong this summer day, Her petticoat has flown away.”
+
+She fell back upon the mattress in a convulsion. They all drew near. She
+was dead.
+
+
+
+Chapter Nine
+
+There is always after the death of anyone a kind of stupefaction;
+so difficult is it to grasp this advent of nothingness and to resign
+ourselves to believe in it. But still, when he saw that she did not
+move, Charles threw himself upon her, crying--
+
+“Farewell! farewell!”
+
+Homais and Canivet dragged him from the room.
+
+“Restrain yourself!”
+
+“Yes.” said he, struggling, “I’ll be quiet. I’ll not do anything. But
+leave me alone. I want to see her. She is my wife!”
+
+And he wept.
+
+“Cry,” said the chemist; “let nature take her course; that will solace
+you.”
+
+Weaker than a child, Charles let himself be led downstairs into the
+sitting-room, and Monsieur Homais soon went home. On the Place he
+was accosted by the blind man, who, having dragged himself as far as
+Yonville, in the hope of getting the antiphlogistic pomade, was asking
+every passer-by where the druggist lived.
+
+“There now! as if I hadn’t got other fish to fry. Well, so much the
+worse; you must come later on.”
+
+And he entered the shop hurriedly.
+
+He had to write two letters, to prepare a soothing potion for Bovary, to
+invent some lie that would conceal the poisoning, and work it up into an
+article for the “Fanal,” without counting the people who were waiting to
+get the news from him; and when the Yonvillers had all heard his story
+of the arsenic that she had mistaken for sugar in making a vanilla
+cream. Homais once more returned to Bovary’s.
+
+He found him alone (Monsieur Canivet had left), sitting in an arm-chair
+near the window, staring with an idiotic look at the flags of the floor.
+
+“Now,” said the chemist, “you ought yourself to fix the hour for the
+ceremony.”
+
+“Why? What ceremony?” Then, in a stammering, frightened voice, “Oh, no!
+not that. No! I want to see her here.”
+
+Homais, to keep himself in countenance, took up a water-bottle on the
+whatnot to water the geraniums.
+
+“Ah! thanks,” said Charles; “you are good.”
+
+But he did not finish, choking beneath the crowd of memories that this
+action of the druggist recalled to him.
+
+Then to distract him, Homais thought fit to talk a little horticulture:
+plants wanted humidity. Charles bowed his head in sign of approbation.
+
+“Besides, the fine days will soon be here again.”
+
+“Ah!” said Bovary.
+
+The druggist, at his wit’s end, began softly to draw aside the small
+window-curtain.
+
+“Hallo! there’s Monsieur Tuvache passing.”
+
+Charles repeated like a machine---
+
+“Monsieur Tuvache passing!”
+
+Homais did not dare to speak to him again about the funeral
+arrangements; it was the priest who succeeded in reconciling him to
+them.
+
+He shut himself up in his consulting-room, took a pen, and after sobbing
+for some time, wrote--
+
+“I wish her to be buried in her wedding-dress, with white shoes, and a
+wreath. Her hair is to be spread out over her shoulders. Three coffins,
+one of oak, one of mahogany, one of lead. Let no one say anything to me.
+I shall have strength. Over all there is to be placed a large piece of
+green velvet. This is my wish; see that it is done.”
+
+The two men were much surprised at Bovary’s romantic ideas. The chemist
+at once went to him and said--
+
+“This velvet seems to me a superfetation. Besides, the expense--”
+
+“What’s that to you?” cried Charles. “Leave me! You did not love her.
+Go!”
+
+The priest took him by the arm for a turn in the garden. He discoursed
+on the vanity of earthly things. God was very great, was very good: one
+must submit to his decrees without a murmur; nay, must even thank him.
+
+Charles burst out into blasphemies: “I hate your God!”
+
+“The spirit of rebellion is still upon you,” sighed the ecclesiastic.
+
+Bovary was far away. He was walking with great strides along by the
+wall, near the espalier, and he ground his teeth; he raised to heaven
+looks of malediction, but not so much as a leaf stirred.
+
+A fine rain was falling: Charles, whose chest was bare, at last began to
+shiver; he went in and sat down in the kitchen.
+
+At six o’clock a noise like a clatter of old iron was heard on the
+Place; it was the “Hirondelle” coming in, and he remained with his
+forehead against the windowpane, watching all the passengers get
+out, one after the other. Felicite put down a mattress for him in the
+drawing-room. He threw himself upon it and fell asleep.
+
+Although a philosopher, Monsieur Homais respected the dead. So bearing
+no grudge to poor Charles, he came back again in the evening to sit up
+with the body; bringing with him three volumes and a pocket-book for
+taking notes.
+
+Monsieur Bournisien was there, and two large candles were burning at the
+head of the bed, that had been taken out of the alcove. The druggist, on
+whom the silence weighed, was not long before he began formulating some
+regrets about this “unfortunate young woman.” and the priest replied
+that there was nothing to do now but pray for her.
+
+“Yet,” Homais went on, “one of two things; either she died in a state of
+grace (as the Church has it), and then she has no need of our prayers;
+or else she departed impertinent (that is, I believe, the ecclesiastical
+expression), and then--”
+
+Bournisien interrupted him, replying testily that it was none the less
+necessary to pray.
+
+“But,” objected the chemist, “since God knows all our needs, what can be
+the good of prayer?”
+
+“What!” cried the ecclesiastic, “prayer! Why, aren’t you a Christian?”
+
+“Excuse me,” said Homais; “I admire Christianity. To begin with, it
+enfranchised the slaves, introduced into the world a morality--”
+
+“That isn’t the question. All the texts-”
+
+“Oh! oh! As to texts, look at history; it, is known that all the texts
+have been falsified by the Jesuits.”
+
+Charles came in, and advancing towards the bed, slowly drew the
+curtains.
+
+Emma’s head was turned towards her right shoulder, the corner of her
+mouth, which was open, seemed like a black hole at the lower part of her
+face; her two thumbs were bent into the palms of her hands; a kind
+of white dust besprinkled her lashes, and her eyes were beginning to
+disappear in that viscous pallor that looks like a thin web, as if
+spiders had spun it over. The sheet sunk in from her breast to her
+knees, and then rose at the tips of her toes, and it seemed to Charles
+that infinite masses, an enormous load, were weighing upon her.
+
+The church clock struck two. They could hear the loud murmur of the
+river flowing in the darkness at the foot of the terrace. Monsieur
+Bournisien from time to time blew his nose noisily, and Homais’ pen was
+scratching over the paper.
+
+“Come, my good friend,” he said, “withdraw; this spectacle is tearing
+you to pieces.”
+
+Charles once gone, the chemist and the cure recommenced their
+discussions.
+
+“Read Voltaire,” said the one, “read D’Holbach, read the
+‘Encyclopaedia’!”
+
+“Read the ‘Letters of some Portuguese Jews,’” said the other; “read ‘The
+Meaning of Christianity,’ by Nicolas, formerly a magistrate.”
+
+They grew warm, they grew red, they both talked at once without
+listening to each other. Bournisien was scandalized at such audacity;
+Homais marvelled at such stupidity; and they were on the point of
+insulting one another when Charles suddenly reappeared. A fascination
+drew him. He was continually coming upstairs.
+
+He stood opposite her, the better to see her, and he lost himself in a
+contemplation so deep that it was no longer painful.
+
+He recalled stories of catalepsy, the marvels of magnetism, and he
+said to himself that by willing it with all his force he might perhaps
+succeed in reviving her. Once he even bent towards he, and cried in a
+low voice, “Emma! Emma!” His strong breathing made the flames of the
+candles tremble against the wall.
+
+At daybreak Madame Bovary senior arrived. Charles as he embraced her
+burst into another flood of tears. She tried, as the chemist had done,
+to make some remarks to him on the expenses of the funeral. He became so
+angry that she was silent, and he even commissioned her to go to town at
+once and buy what was necessary.
+
+Charles remained alone the whole afternoon; they had taken Berthe
+to Madame Homais’; Felicite was in the room upstairs with Madame
+Lefrancois.
+
+In the evening he had some visitors. He rose, pressed their hands,
+unable to speak. Then they sat down near one another, and formed a large
+semicircle in front of the fire. With lowered faces, and swinging one
+leg crossed over the other knee, they uttered deep sighs at intervals;
+each one was inordinately bored, and yet none would be the first to go.
+
+Homais, when he returned at nine o’clock (for the last two days only
+Homais seemed to have been on the Place), was laden with a stock of
+camphor, of benzine, and aromatic herbs. He also carried a large jar
+full of chlorine water, to keep off all miasmata. Just then the servant,
+Madame Lefrancois, and Madame Bovary senior were busy about Emma,
+finishing dressing her, and they were drawing down the long stiff veil
+that covered her to her satin shoes.
+
+Felicite was sobbing--“Ah! my poor mistress! my poor mistress!”
+
+“Look at her,” said the landlady, sighing; “how pretty she still is!
+Now, couldn’t you swear she was going to get up in a minute?”
+
+Then they bent over her to put on her wreath. They had to raise the head
+a little, and a rush of black liquid issued, as if she were vomiting,
+from her mouth.
+
+“Oh, goodness! The dress; take care!” cried Madame Lefrancois. “Now,
+just come and help,” she said to the chemist. “Perhaps you’re afraid?”
+
+“I afraid?” replied he, shrugging his shoulders. “I dare say! I’ve seen
+all sorts of things at the hospital when I was studying pharmacy. We
+used to make punch in the dissecting room! Nothingness does not terrify
+a philosopher; and, as I often say, I even intend to leave my body to
+the hospitals, in order, later on, to serve science.”
+
+The cure on his arrival inquired how Monsieur Bovary was, and, on
+the reply of the druggist, went on--“The blow, you see, is still too
+recent.”
+
+Then Homais congratulated him on not being exposed, like other people,
+to the loss of a beloved companion; whence there followed a discussion
+on the celibacy of priests.
+
+“For,” said the chemist, “it is unnatural that a man should do without
+women! There have been crimes--”
+
+“But, good heaven!” cried the ecclesiastic, “how do you expect an
+individual who is married to keep the secrets of the confessional, for
+example?”
+
+Homais fell foul of the confessional. Bournisien defended it; he
+enlarged on the acts of restitution that it brought about. He cited
+various anecdotes about thieves who had suddenly become honest. Military
+men on approaching the tribunal of penitence had felt the scales fall
+from their eyes. At Fribourg there was a minister--
+
+His companion was asleep. Then he felt somewhat stifled by the
+over-heavy atmosphere of the room; he opened the window; this awoke the
+chemist.
+
+“Come, take a pinch of snuff,” he said to him. “Take it; it’ll relieve
+you.”
+
+A continual barking was heard in the distance. “Do you hear that dog
+howling?” said the chemist.
+
+“They smell the dead,” replied the priest. “It’s like bees; they leave
+their hives on the decease of any person.”
+
+Homais made no remark upon these prejudices, for he had again dropped
+asleep. Monsieur Bournisien, stronger than he, went on moving his lips
+gently for some time, then insensibly his chin sank down, he let fall
+his big black boot, and began to snore.
+
+They sat opposite one another, with protruding stomachs, puffed-up
+faces, and frowning looks, after so much disagreement uniting at last in
+the same human weakness, and they moved no more than the corpse by their
+side, that seemed to be sleeping.
+
+Charles coming in did not wake them. It was the last time; he came to
+bid her farewell.
+
+The aromatic herbs were still smoking, and spirals of bluish vapour
+blended at the window-sash with the fog that was coming in. There were
+few stars, and the night was warm. The wax of the candles fell in great
+drops upon the sheets of the bed. Charles watched them burn, tiring his
+eyes against the glare of their yellow flame.
+
+The watering on the satin gown shimmered white as moonlight. Emma was
+lost beneath it; and it seemed to him that, spreading beyond her own
+self, she blended confusedly with everything around her--the silence,
+the night, the passing wind, the damp odours rising from the ground.
+
+Then suddenly he saw her in the garden at Tostes, on a bench against the
+thorn hedge, or else at Rouen in the streets, on the threshold of their
+house, in the yard at Bertaux. He again heard the laughter of the happy
+boys beneath the apple-trees: the room was filled with the perfume
+of her hair; and her dress rustled in his arms with a noise like
+electricity. The dress was still the same.
+
+For a long while he thus recalled all his lost joys, her attitudes,
+her movements, the sound of her voice. Upon one fit of despair followed
+another, and even others, inexhaustible as the waves of an overflowing
+sea.
+
+A terrible curiosity seized him. Slowly, with the tips of his fingers,
+palpitating, he lifted her veil. But he uttered a cry of horror that
+awoke the other two.
+
+They dragged him down into the sitting-room. Then Felicite came up to
+say that he wanted some of her hair.
+
+“Cut some off,” replied the druggist.
+
+And as she did not dare to, he himself stepped forward, scissors in
+hand. He trembled so that he pierced the skin of the temple in several
+places. At last, stiffening himself against emotion, Homais gave two
+or three great cuts at random that left white patches amongst that
+beautiful black hair.
+
+The chemist and the cure plunged anew into their occupations, not
+without sleeping from time to time, of which they accused each other
+reciprocally at each fresh awakening. Then Monsieur Bournisien sprinkled
+the room with holy water and Homais threw a little chlorine water on the
+floor.
+
+Felicite had taken care to put on the chest of drawers, for each
+of them, a bottle of brandy, some cheese, and a large roll. And the
+druggist, who could not hold out any longer, about four in the morning
+sighed--
+
+“My word! I should like to take some sustenance.”
+
+The priest did not need any persuading; he went out to go and say mass,
+came back, and then they ate and hobnobbed, giggling a little without
+knowing why, stimulated by that vague gaiety that comes upon us after
+times of sadness, and at the last glass the priest said to the druggist,
+as he clapped him on the shoulder--
+
+“We shall end by understanding one another.”
+
+In the passage downstairs they met the undertaker’s men, who were coming
+in. Then Charles for two hours had to suffer the torture of hearing the
+hammer resound against the wood. Next day they lowered her into her
+oak coffin, that was fitted into the other two; but as the bier was
+too large, they had to fill up the gaps with the wool of a mattress. At
+last, when the three lids had been planed down, nailed, soldered, it was
+placed outside in front of the door; the house was thrown open, and the
+people of Yonville began to flock round.
+
+Old Rouault arrived, and fainted on the Place when he saw the black
+cloth!
+
+
+
+Chapter Ten
+
+He had only received the chemist’s letter thirty-six hours after the
+event; and, from consideration for his feelings, Homais had so worded it
+that it was impossible to make out what it was all about.
+
+First, the old fellow had fallen as if struck by apoplexy. Next, he
+understood that she was not dead, but she might be. At last, he had put
+on his blouse, taken his hat, fastened his spurs to his boots, and set
+out at full speed; and the whole of the way old Rouault, panting, was
+torn by anguish. Once even he was obliged to dismount. He was dizzy; he
+heard voices round about him; he felt himself going mad.
+
+Day broke. He saw three black hens asleep in a tree. He shuddered,
+horrified at this omen. Then he promised the Holy Virgin three chasubles
+for the church, and that he would go barefooted from the cemetery at
+Bertaux to the chapel of Vassonville.
+
+He entered Maromme shouting for the people of the inn, burst open the
+door with a thrust of his shoulder, made for a sack of oats, emptied a
+bottle of sweet cider into the manger, and again mounted his nag, whose
+feet struck fire as it dashed along.
+
+He said to himself that no doubt they would save her; the doctors would
+discover some remedy surely. He remembered all the miraculous cures
+he had been told about. Then she appeared to him dead. She was there;
+before his eyes, lying on her back in the middle of the road. He reined
+up, and the hallucination disappeared.
+
+At Quincampoix, to give himself heart, he drank three cups of coffee
+one after the other. He fancied they had made a mistake in the name in
+writing. He looked for the letter in his pocket, felt it there, but did
+not dare to open it.
+
+At last he began to think it was all a joke; someone’s spite, the jest
+of some wag; and besides, if she were dead, one would have known it. But
+no! There was nothing extraordinary about the country; the sky was blue,
+the trees swayed; a flock of sheep passed. He saw the village; he was
+seen coming bending forward upon his horse, belabouring it with great
+blows, the girths dripping with blood.
+
+When he had recovered consciousness, he fell, weeping, into Bovary’s
+arms: “My girl! Emma! my child! tell me--”
+
+The other replied, sobbing, “I don’t know! I don’t know! It’s a curse!”
+
+The druggist separated them. “These horrible details are useless. I will
+tell this gentleman all about it. Here are the people coming. Dignity!
+Come now! Philosophy!”
+
+The poor fellow tried to show himself brave, and repeated several times.
+“Yes! courage!”
+
+“Oh,” cried the old man, “so I will have, by God! I’ll go along o’ her
+to the end!”
+
+The bell began tolling. All was ready; they had to start. And seated in
+a stall of the choir, side by side, they saw pass and repass in front of
+them continually the three chanting choristers.
+
+The serpent-player was blowing with all his might. Monsieur Bournisien,
+in full vestments, was singing in a shrill voice. He bowed before the
+tabernacle, raising his hands, stretched out his arms. Lestiboudois
+went about the church with his whalebone stick. The bier stood near the
+lectern, between four rows of candles. Charles felt inclined to get up
+and put them out.
+
+Yet he tried to stir himself to a feeling of devotion, to throw himself
+into the hope of a future life in which he should see her again. He
+imagined to himself she had gone on a long journey, far away, for a long
+time. But when he thought of her lying there, and that all was over,
+that they would lay her in the earth, he was seized with a fierce,
+gloomy, despairful rage. At times he thought he felt nothing more, and
+he enjoyed this lull in his pain, whilst at the same time he reproached
+himself for being a wretch.
+
+The sharp noise of an iron-ferruled stick was heard on the stones,
+striking them at irregular intervals. It came from the end of the
+church, and stopped short at the lower aisles. A man in a coarse brown
+jacket knelt down painfully. It was Hippolyte, the stable-boy at the
+“Lion d’Or.” He had put on his new leg.
+
+One of the choristers went round the nave making a collection, and the
+coppers chinked one after the other on the silver plate.
+
+“Oh, make haste! I am in pain!” cried Bovary, angrily throwing him a
+five-franc piece. The churchman thanked him with a deep bow.
+
+They sang, they knelt, they stood up; it was endless! He remembered that
+once, in the early times, they had been to mass together, and they had
+sat down on the other side, on the right, by the wall. The bell began
+again. There was a great moving of chairs; the bearers slipped their
+three staves under the coffin, and everyone left the church.
+
+Then Justin appeared at the door of the shop. He suddenly went in again,
+pale, staggering.
+
+People were at the windows to see the procession pass. Charles at the
+head walked erect. He affected a brave air, and saluted with a nod those
+who, coming out from the lanes or from their doors, stood amidst the
+crowd.
+
+The six men, three on either side, walked slowly, panting a little.
+The priests, the choristers, and the two choirboys recited the De
+profundis*, and their voices echoed over the fields, rising and falling
+with their undulations. Sometimes they disappeared in the windings of
+the path; but the great silver cross rose always before the trees.
+
+     *Psalm CXXX.
+
+
+The women followed in black cloaks with turned-down hoods; each of them
+carried in her hands a large lighted candle, and Charles felt himself
+growing weaker at this continual repetition of prayers and torches,
+beneath this oppressive odour of wax and of cassocks. A fresh breeze was
+blowing; the rye and colza were sprouting, little dewdrops trembled at
+the roadsides and on the hawthorn hedges. All sorts of joyous sounds
+filled the air; the jolting of a cart rolling afar off in the ruts, the
+crowing of a cock, repeated again and again, or the gambling of a foal
+running away under the apple-trees: The pure sky was fretted with rosy
+clouds; a bluish haze rested upon the cots covered with iris. Charles as
+he passed recognised each courtyard. He remembered mornings like this,
+when, after visiting some patient, he came out from one and returned to
+her.
+
+The black cloth bestrewn with white beads blew up from time to time,
+laying bare the coffin. The tired bearers walked more slowly, and it
+advanced with constant jerks, like a boat that pitches with every wave.
+
+They reached the cemetery. The men went right down to a place in the
+grass where a grave was dug. They ranged themselves all round; and while
+the priest spoke, the red soil thrown up at the sides kept noiselessly
+slipping down at the corners.
+
+Then when the four ropes were arranged the coffin was placed upon them.
+He watched it descend; it seemed descending for ever. At last a thud was
+heard; the ropes creaked as they were drawn up. Then Bournisien took
+the spade handed to him by Lestiboudois; with his left hand all the
+time sprinkling water, with the right he vigorously threw in a large
+spadeful; and the wood of the coffin, struck by the pebbles, gave forth
+that dread sound that seems to us the reverberation of eternity.
+
+The ecclesiastic passed the holy water sprinkler to his neighbour. This
+was Homais. He swung it gravely, then handed it to Charles, who sank to
+his knees in the earth and threw in handfuls of it, crying, “Adieu!” He
+sent her kisses; he dragged himself towards the grave, to engulf himself
+with her. They led him away, and he soon grew calmer, feeling perhaps,
+like the others, a vague satisfaction that it was all over.
+
+Old Rouault on his way back began quietly smoking a pipe, which Homais
+in his innermost conscience thought not quite the thing. He also noticed
+that Monsieur Binet had not been present, and that Tuvache had “made
+off” after mass, and that Theodore, the notary’s servant wore a blue
+coat, “as if one could not have got a black coat, since that is the
+custom, by Jove!” And to share his observations with others he went from
+group to group. They were deploring Emma’s death, especially Lheureux,
+who had not failed to come to the funeral.
+
+“Poor little woman! What a trouble for her husband!”
+
+The druggist continued, “Do you know that but for me he would have
+committed some fatal attempt upon himself?”
+
+“Such a good woman! To think that I saw her only last Saturday in my
+shop.”
+
+“I haven’t had leisure,” said Homais, “to prepare a few words that I
+would have cast upon her tomb.”
+
+Charles on getting home undressed, and old Rouault put on his blue
+blouse. It was a new one, and as he had often during the journey wiped
+his eyes on the sleeves, the dye had stained his face, and the traces of
+tears made lines in the layer of dust that covered it.
+
+Madame Bovary senior was with them. All three were silent. At last the
+old fellow sighed--
+
+“Do you remember, my friend, that I went to Tostes once when you had
+just lost your first deceased? I consoled you at that time. I thought of
+something to say then, but now--” Then, with a loud groan that shook his
+whole chest, “Ah! this is the end for me, do you see! I saw my wife go,
+then my son, and now to-day it’s my daughter.”
+
+He wanted to go back at once to Bertaux, saying that he could not sleep
+in this house. He even refused to see his granddaughter.
+
+“No, no! It would grieve me too much. Only you’ll kiss her many times
+for me. Good-bye! you’re a good fellow! And then I shall never forget
+that,” he said, slapping his thigh. “Never fear, you shall always have
+your turkey.”
+
+But when he reached the top of the hill he turned back, as he had turned
+once before on the road of Saint-Victor when he had parted from her. The
+windows of the village were all on fire beneath the slanting rays of the
+sun sinking behind the field. He put his hand over his eyes, and saw
+in the horizon an enclosure of walls, where trees here and there formed
+black clusters between white stones; then he went on his way at a gentle
+trot, for his nag had gone lame.
+
+Despite their fatigue, Charles and his mother stayed very long that
+evening talking together. They spoke of the days of the past and of the
+future. She would come to live at Yonville; she would keep house for
+him; they would never part again. She was ingenious and caressing,
+rejoicing in her heart at gaining once more an affection that had
+wandered from her for so many years. Midnight struck. The village as
+usual was silent, and Charles, awake, thought always of her.
+
+Rodolphe, who, to distract himself, had been rambling about the wood all
+day, was sleeping quietly in his chateau, and Leon, down yonder, always
+slept.
+
+There was another who at that hour was not asleep.
+
+On the grave between the pine-trees a child was on his knees weeping,
+and his heart, rent by sobs, was beating in the shadow beneath the load
+of an immense regret, sweeter than the moon and fathomless as the night.
+The gate suddenly grated. It was Lestiboudois; he came to fetch his
+spade, that he had forgotten. He recognised Justin climbing over the
+wall, and at last knew who was the culprit who stole his potatoes.
+
+
+
+Chapter Eleven
+
+The next day Charles had the child brought back. She asked for her
+mamma. They told her she was away; that she would bring her back some
+playthings. Berthe spoke of her again several times, then at last
+thought no more of her. The child’s gaiety broke Bovary’s heart, and he
+had to bear besides the intolerable consolations of the chemist.
+
+Money troubles soon began again, Monsieur Lheureux urging on anew his
+friend Vincart, and Charles pledged himself for exorbitant sums; for he
+would never consent to let the smallest of the things that had belonged
+to HER be sold. His mother was exasperated with him; he grew even more
+angry than she did. He had altogether changed. She left the house.
+
+Then everyone began “taking advantage” of him. Mademoiselle Lempereur
+presented a bill for six months’ teaching, although Emma had never taken
+a lesson (despite the receipted bill she had shown Bovary); it was an
+arrangement between the two women. The man at the circulating library
+demanded three years’ subscriptions; Mere Rollet claimed the postage due
+for some twenty letters, and when Charles asked for an explanation, she
+had the delicacy to reply--
+
+“Oh, I don’t know. It was for her business affairs.”
+
+With every debt he paid Charles thought he had come to the end of them.
+But others followed ceaselessly. He sent in accounts for professional
+attendance. He was shown the letters his wife had written. Then he had
+to apologise.
+
+Felicite now wore Madame Bovary’s gowns; not all, for he had kept some
+of them, and he went to look at them in her dressing-room, locking
+himself up there; she was about her height, and often Charles, seeing
+her from behind, was seized with an illusion, and cried out--
+
+“Oh, stay, stay!”
+
+But at Whitsuntide she ran away from Yonville, carried off by Theodore,
+stealing all that was left of the wardrobe.
+
+It was about this time that the widow Dupuis had the honour to inform
+him of the “marriage of Monsieur Leon Dupuis her son, notary at Yvetot,
+to Mademoiselle Leocadie Leboeuf of Bondeville.” Charles, among the
+other congratulations he sent him, wrote this sentence--
+
+“How glad my poor wife would have been!”
+
+One day when, wandering aimlessly about the house, he had gone up to the
+attic, he felt a pellet of fine paper under his slipper. He opened it
+and read: “Courage, Emma, courage. I would not bring misery into your
+life.” It was Rodolphe’s letter, fallen to the ground between the boxes,
+where it had remained, and that the wind from the dormer window had just
+blown towards the door. And Charles stood, motionless and staring, in
+the very same place where, long ago, Emma, in despair, and paler even
+than he, had thought of dying. At last he discovered a small R at the
+bottom of the second page. What did this mean? He remembered Rodolphe’s
+attentions, his sudden, disappearance, his constrained air when they
+had met two or three times since. But the respectful tone of the letter
+deceived him.
+
+“Perhaps they loved one another platonically,” he said to himself.
+
+Besides, Charles was not of those who go to the bottom of things; he
+shrank from the proofs, and his vague jealousy was lost in the immensity
+of his woe.
+
+Everyone, he thought, must have adored her; all men assuredly must have
+coveted her. She seemed but the more beautiful to him for this; he
+was seized with a lasting, furious desire for her, that inflamed his
+despair, and that was boundless, because it was now unrealisable.
+
+To please her, as if she were still living, he adopted her
+predilections, her ideas; he bought patent leather boots and took to
+wearing white cravats. He put cosmetics on his moustache, and, like her,
+signed notes of hand. She corrupted him from beyond the grave.
+
+He was obliged to sell his silver piece by piece; next he sold the
+drawing-room furniture. All the rooms were stripped; but the bedroom,
+her own room, remained as before. After his dinner Charles went up
+there. He pushed the round table in front of the fire, and drew up her
+armchair. He sat down opposite it. A candle burnt in one of the gilt
+candlesticks. Berthe by his side was painting prints.
+
+He suffered, poor man, at seeing her so badly dressed, with laceless
+boots, and the arm-holes of her pinafore torn down to the hips; for the
+charwoman took no care of her. But she was so sweet, so pretty, and her
+little head bent forward so gracefully, letting the dear fair hair fall
+over her rosy cheeks, that an infinite joy came upon him, a happiness
+mingled with bitterness, like those ill-made wines that taste of
+resin. He mended her toys, made her puppets from cardboard, or sewed up
+half-torn dolls. Then, if his eyes fell upon the workbox, a ribbon lying
+about, or even a pin left in a crack of the table, he began to dream,
+and looked so sad that she became as sad as he.
+
+No one now came to see them, for Justin had run away to Rouen, where he
+was a grocer’s assistant, and the druggist’s children saw less and less
+of the child, Monsieur Homais not caring, seeing the difference of their
+social position, to continue the intimacy.
+
+The blind man, whom he had not been able to cure with the pomade, had
+gone back to the hill of Bois-Guillaume, where he told the travellers of
+the vain attempt of the druggist, to such an extent, that Homais when
+he went to town hid himself behind the curtains of the “Hirondelle” to
+avoid meeting him. He detested him, and wishing, in the interests of his
+own reputation, to get rid of him at all costs, he directed against
+him a secret battery, that betrayed the depth of his intellect and the
+baseness of his vanity. Thus, for six consecutive months, one could read
+in the “Fanal de Rouen” editorials such as these--
+
+“All who bend their steps towards the fertile plains of Picardy have, no
+doubt, remarked, by the Bois-Guillaume hill, a wretch suffering from
+a horrible facial wound. He importunes, persecutes one, and levies a
+regular tax on all travellers. Are we still living in the monstrous
+times of the Middle Ages, when vagabonds were permitted to display in
+our public places leprosy and scrofulas they had brought back from the
+Crusades?”
+
+Or--
+
+“In spite of the laws against vagabondage, the approaches to our great
+towns continue to be infected by bands of beggars. Some are seen going
+about alone, and these are not, perhaps, the least dangerous. What are
+our ediles about?”
+
+Then Homais invented anecdotes--
+
+“Yesterday, by the Bois-Guillaume hill, a skittish horse--” And then
+followed the story of an accident caused by the presence of the blind
+man.
+
+He managed so well that the fellow was locked up. But he was released.
+He began again, and Homais began again. It was a struggle. Homais won
+it, for his foe was condemned to life-long confinement in an asylum.
+
+This success emboldened him, and henceforth there was no longer a dog
+run over, a barn burnt down, a woman beaten in the parish, of which
+he did not immediately inform the public, guided always by the love of
+progress and the hate of priests. He instituted comparisons between the
+elementary and clerical schools to the detriment of the latter; called
+to mind the massacre of St. Bartholomew a propos of a grant of one
+hundred francs to the church, and denounced abuses, aired new views.
+That was his phrase. Homais was digging and delving; he was becoming
+dangerous.
+
+However, he was stifling in the narrow limits of journalism, and soon a
+book, a work was necessary to him. Then he composed “General Statistics
+of the Canton of Yonville, followed by Climatological Remarks.” The
+statistics drove him to philosophy. He busied himself with great
+questions: the social problem, moralisation of the poorer classes,
+pisciculture, caoutchouc, railways, etc. He even began to blush at being
+a bourgeois. He affected the artistic style, he smoked. He bought two
+chic Pompadour statuettes to adorn his drawing-room.
+
+He by no means gave up his shop. On the contrary, he kept well abreast
+of new discoveries. He followed the great movement of chocolates; he
+was the first to introduce “cocoa” and “revalenta” into the
+Seine-Inferieure. He was enthusiastic about the hydro-electric
+Pulvermacher chains; he wore one himself, and when at night he took off
+his flannel vest, Madame Homais stood quite dazzled before the golden
+spiral beneath which he was hidden, and felt her ardour redouble for
+this man more bandaged than a Scythian, and splendid as one of the Magi.
+
+He had fine ideas about Emma’s tomb. First he proposed a broken column
+with some drapery, next a pyramid, then a Temple of Vesta, a sort of
+rotunda, or else a “mass of ruins.” And in all his plans Homais always
+stuck to the weeping willow, which he looked upon as the indispensable
+symbol of sorrow.
+
+Charles and he made a journey to Rouen together to look at some tombs
+at a funeral furnisher’s, accompanied by an artist, one Vaufrylard, a
+friend of Bridoux’s, who made puns all the time. At last, after having
+examined some hundred designs, having ordered an estimate and made
+another journey to Rouen, Charles decided in favour of a mausoleum,
+which on the two principal sides was to have a “spirit bearing an
+extinguished torch.”
+
+As to the inscription, Homais could think of nothing so fine as Sta
+viator*, and he got no further; he racked his brain, he constantly
+repeated Sta viator. At last he hit upon Amabilen conjugem calcas**,
+which was adopted.
+
+     * Rest traveler.
+
+     ** Tread upon a loving wife.
+
+A strange thing was that Bovary, while continually thinking of Emma, was
+forgetting her. He grew desperate as he felt this image fading from his
+memory in spite of all efforts to retain it. Yet every night he dreamt
+of her; it was always the same dream. He drew near her, but when he was
+about to clasp her she fell into decay in his arms.
+
+For a week he was seen going to church in the evening. Monsieur
+Bournisien even paid him two or three visits, then gave him up.
+Moreover, the old fellow was growing intolerant, fanatic, said Homais.
+He thundered against the spirit of the age, and never failed, every
+other week, in his sermon, to recount the death agony of Voltaire, who
+died devouring his excrements, as everyone knows.
+
+In spite of the economy with which Bovary lived, he was far from being
+able to pay off his old debts. Lheureux refused to renew any more
+bills. A distraint became imminent. Then he appealed to his mother, who
+consented to let him take a mortgage on her property, but with a great
+many recriminations against Emma; and in return for her sacrifice she
+asked for a shawl that had escaped the depredations of Felicite. Charles
+refused to give it her; they quarrelled.
+
+She made the first overtures of reconciliation by offering to have the
+little girl, who could help her in the house, to live with her. Charles
+consented to this, but when the time for parting came, all his courage
+failed him. Then there was a final, complete rupture.
+
+As his affections vanished, he clung more closely to the love of his
+child. She made him anxious, however, for she coughed sometimes, and had
+red spots on her cheeks.
+
+Opposite his house, flourishing and merry, was the family of the
+chemist, with whom everything was prospering. Napoleon helped him in the
+laboratory, Athalie embroidered him a skullcap, Irma cut out rounds of
+paper to cover the preserves, and Franklin recited Pythagoras’ table in
+a breath. He was the happiest of fathers, the most fortunate of men.
+
+Not so! A secret ambition devoured him. Homais hankered after the cross
+of the Legion of Honour. He had plenty of claims to it.
+
+“First, having at the time of the cholera distinguished myself by a
+boundless devotion; second, by having published, at my expense,
+various works of public utility, such as” (and he recalled his pamphlet
+entitled, “Cider, its manufacture and effects,” besides observation
+on the lanigerous plant-louse, sent to the Academy; his volume of
+statistics, and down to his pharmaceutical thesis); “without counting
+that I am a member of several learned societies” (he was member of a
+single one).
+
+“In short!” he cried, making a pirouette, “if it were only for
+distinguishing myself at fires!”
+
+Then Homais inclined towards the Government. He secretly did the
+prefect great service during the elections. He sold himself--in a word,
+prostituted himself. He even addressed a petition to the sovereign
+in which he implored him to “do him justice”; he called him “our good
+king,” and compared him to Henri IV.
+
+And every morning the druggist rushed for the paper to see if his
+nomination were in it. It was never there. At last, unable to bear it
+any longer, he had a grass plot in his garden designed to represent the
+Star of the Cross of Honour with two little strips of grass running from
+the top to imitate the ribband. He walked round it with folded arms,
+meditating on the folly of the Government and the ingratitude of men.
+
+From respect, or from a sort of sensuality that made him carry on his
+investigations slowly, Charles had not yet opened the secret drawer of
+a rosewood desk which Emma had generally used. One day, however, he
+sat down before it, turned the key, and pressed the spring. All Leon’s
+letters were there. There could be no doubt this time. He devoured them
+to the very last, ransacked every corner, all the furniture, all the
+drawers, behind the walls, sobbing, crying aloud, distraught, mad. He
+found a box and broke it open with a kick. Rodolphe’s portrait flew full
+in his face in the midst of the overturned love-letters.
+
+People wondered at his despondency. He never went out, saw no one,
+refused even to visit his patients. Then they said “he shut himself up
+to drink.”
+
+Sometimes, however, some curious person climbed on to the garden hedge,
+and saw with amazement this long-bearded, shabbily clothed, wild man,
+who wept aloud as he walked up and down.
+
+In the evening in summer he took his little girl with him and led her to
+the cemetery. They came back at nightfall, when the only light left in
+the Place was that in Binet’s window.
+
+The voluptuousness of his grief was, however, incomplete, for he had no
+one near him to share it, and he paid visits to Madame Lefrancois to be
+able to speak of her.
+
+But the landlady only listened with half an ear, having troubles
+like himself. For Lheureux had at last established the “Favorites du
+Commerce,” and Hivert, who enjoyed a great reputation for doing errands,
+insisted on a rise of wages, and was threatening to go over “to the
+opposition shop.”
+
+One day when he had gone to the market at Argueil to sell his horse--his
+last resource--he met Rodolphe.
+
+They both turned pale when they caught sight of one another. Rodolphe,
+who had only sent his card, first stammered some apologies, then grew
+bolder, and even pushed his assurance (it was in the month of August and
+very hot) to the length of inviting him to have a bottle of beer at the
+public-house.
+
+Leaning on the table opposite him, he chewed his cigar as he talked, and
+Charles was lost in reverie at this face that she had loved. He seemed
+to see again something of her in it. It was a marvel to him. He would
+have liked to have been this man.
+
+The other went on talking agriculture, cattle, pasturage, filling out
+with banal phrases all the gaps where an allusion might slip in. Charles
+was not listening to him; Rodolphe noticed it, and he followed the
+succession of memories that crossed his face. This gradually grew
+redder; the nostrils throbbed fast, the lips quivered. There was at
+last a moment when Charles, full of a sombre fury, fixed his eyes on
+Rodolphe, who, in something of fear, stopped talking. But soon the same
+look of weary lassitude came back to his face.
+
+“I don’t blame you,” he said.
+
+Rodolphe was dumb. And Charles, his head in his hands, went on in a
+broken voice, and with the resigned accent of infinite sorrow--
+
+“No, I don’t blame you now.”
+
+He even added a fine phrase, the only one he ever made--
+
+“It is the fault of fatality!”
+
+Rodolphe, who had managed the fatality, thought the remark very offhand
+from a man in his position, comic even, and a little mean.
+
+The next day Charles went to sit down on the seat in the arbour. Rays
+of light were straying through the trellis, the vine leaves threw their
+shadows on the sand, the jasmines perfumed the air, the heavens were
+blue, Spanish flies buzzed round the lilies in bloom, and Charles was
+suffocating like a youth beneath the vague love influences that filled
+his aching heart.
+
+At seven o’clock little Berthe, who had not seen him all the afternoon,
+went to fetch him to dinner.
+
+His head was thrown back against the wall, his eyes closed, his mouth
+open, and in his hand was a long tress of black hair.
+
+“Come along, papa,” she said.
+
+And thinking he wanted to play; she pushed him gently. He fell to the
+ground. He was dead.
+
+Thirty-six hours after, at the druggist’s request, Monsieur Canivet came
+thither. He made a post-mortem and found nothing.
+
+When everything had been sold, twelve francs seventy-five centimes
+remained, that served to pay for Mademoiselle Bovary’s going to
+her grandmother. The good woman died the same year; old Rouault was
+paralysed, and it was an aunt who took charge of her. She is poor, and
+sends her to a cotton-factory to earn a living.
+
+Since Bovary’s death three doctors have followed one another at Yonville
+without any success, so severely did Homais attack them. He has an
+enormous practice; the authorities treat him with consideration, and
+public opinion protects him.
+
+He has just received the cross of the Legion of Honour.
+
+
+
+
+
+End of the Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+*** END OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+***** This file should be named 2413-0.txt or 2413-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/4/1/2413/
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/odyssey.txt
+++ b/jet/source-sink-builder/src/main/resources/books/odyssey.txt
@@ -1,0 +1,11984 @@
+﻿The Project Gutenberg EBook of The Odyssey, by Homer
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Odyssey
+
+Author: Homer
+
+Translator: Samuel Butler
+
+
+Release Date: April, 1999 [EBook #1727]
+Last Updated: April 9, 2013
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+
+
+
+Produced by Jim Tinsley
+
+
+
+
+
+
+
+
+
+THE ODYSSEY
+
+
+  rendered into English
+  prose for the use of
+  those who cannot
+  read the original
+
+
+By Samuel Butler
+
+
+
+
+PREFACE TO FIRST EDITION
+
+This translation is intended to supplement a work entitled "The
+Authoress of the Odyssey", which I published in 1897. I could not give
+the whole "Odyssey" in that book without making it unwieldy, I therefore
+epitomised my translation, which was already completed and which I now
+publish in full.
+
+I shall not here argue the two main points dealt with in the work just
+mentioned; I have nothing either to add to, or to withdraw from, what I
+have there written. The points in question are:
+
+(1) that the "Odyssey" was written entirely at, and drawn entirely
+from, the place now called Trapani on the West Coast of Sicily, alike
+as regards the Phaeacian and the Ithaca scenes; while the voyages of
+Ulysses, when once he is within easy reach of Sicily, solve themselves
+into a periplus of the island, practically from Trapani back to Trapani,
+via the Lipari islands, the Straits of Messina, and the island of
+Pantellaria.
+
+(2) That the poem was entirely written by a very young woman, who lived
+at the place now called Trapani, and introduced herself into her work
+under the name of Nausicaa.
+
+The main arguments on which I base the first of these somewhat startling
+contentions, have been prominently and repeatedly before the English
+and Italian public ever since they appeared (without rejoinder) in the
+"Athenaeum" for January 30 and February 20, 1892. Both contentions were
+urged (also without rejoinder) in the Johnian "Eagle" for the Lent and
+October terms of the same year. Nothing to which I should reply
+has reached me from any quarter, and knowing how anxiously I have
+endeavoured to learn the existence of any flaws in my argument, I begin
+to feel some confidence that, did such flaws exist, I should have heard,
+at any rate about some of them, before now. Without, therefore, for
+a moment pretending to think that scholars generally acquiesce in my
+conclusions, I shall act as thinking them little likely so to gainsay me
+as that it will be incumbent upon me to reply, and shall confine myself
+to translating the "Odyssey" for English readers, with such notes as
+I think will be found useful. Among these I would especially call
+attention to one on xxii. 465-473 which Lord Grimthorpe has kindly
+allowed me to make public.
+
+I have repeated several of the illustrations used in "The Authoress of
+the Odyssey", and have added two which I hope may bring the outer court
+of Ulysses' house more vividly before the reader. I should like to
+explain that the presence of a man and a dog in one illustration is
+accidental, and was not observed by me till I developed the negative. In
+an appendix I have also reprinted the paragraphs explanatory of the
+plan of Ulysses' house, together with the plan itself. The reader is
+recommended to study this plan with some attention.
+
+In the preface to my translation of the "Iliad" I have given my views as
+to the main principles by which a translator should be guided, and need
+not repeat them here, beyond pointing out that the initial liberty of
+translating poetry into prose involves the continual taking of more
+or less liberty throughout the translation; for much that is right in
+poetry is wrong in prose, and the exigencies of readable prose are the
+first things to be considered in a prose translation. That the reader,
+however, may see how far I have departed from strict construe, I will
+print here Messrs. Butcher and Lang's translation of the sixty lines or
+so of the "Odyssey." Their translation runs:
+
+  Tell me, Muse, of that man, so ready at need, who wandered
+  far and wide, after he had sacked the sacred citadel of
+  Troy, and many were the men whose towns he saw and whose
+  mind he learnt, yea, and many the woes he suffered in his
+  heart on the deep, striving to win his own life and the
+  return of his company. Nay, but even so he saved not his
+  company, though he desired it sore. For through the
+  blindness of their own hearts they perished, fools, who
+  devoured the oxen of Helios Hyperion: but the god took from
+  them their day of returning. Of these things, goddess,
+  daughter of Zeus, whencesoever thou hast heard thereof,
+  declare thou even unto us.
+
+  Now all the rest, as many as fled from sheer destruction,
+  were at home, and had escaped both war and sea, but
+  Odysseus only, craving for his wife and for his homeward
+  path, the lady nymph Calypso held, that fair goddess, in her
+  hollow caves, longing to have him for her lord. But when
+  now the year had come in the courses of the seasons,
+  wherein the gods had ordained that he should return home to
+  Ithaca, not even there was he quit of labours, not even
+  among his own; but all the gods had pity on him save
+  Poseidon, who raged continually against godlike Odysseus,
+  till he came to his own country. Howbeit Poseidon had now
+  departed for the distant Ethiopians, the Ethiopians that are
+  sundered in twain, the uttermost of men, abiding some where
+  Hyperion sinks and some where he rises. There he looked to
+  receive his hecatomb of bulls and rams, there he made merry
+  sitting at the feast, but the other gods were gathered in
+  the halls of Olympian Zeus. Then among them the father of
+  men and gods began to speak, for he bethought him in his
+  heart of noble Aegisthus, whom the son of Agamemnon,
+  far-famed Orestes, slew. Thinking upon him he spake out among
+  the Immortals:
+
+  'Lo you now, how vainly mortal men do blame the gods! For of
+  us they say comes evil, whereas they even of themselves,
+  through the blindness of their own hearts, have sorrows
+  beyond that which is ordained. Even as of late Aegisthus,
+  beyond that which was ordained, took to him the wedded wife
+  of the son of Atreus, and killed her lord on his return,
+  and that with sheer doom before his eyes, since we had
+  warned him by the embassy of Hermes the keen-sighted, the
+  slayer of Argos, that he should neither kill the man, nor
+  woo his wife. For the son of Atreus shall be avenged at the
+  hand of Orestes, so soon as he shall come to man's estate
+  and long for his own country. So spake Hermes, yet he
+  prevailed not on the heart of Aegisthus, for all his good
+  will; but now hath he paid one price for all.'
+
+  And the goddess, grey-eyed Athene, answered him, saying: 'O
+  father, our father Cronides, throned in the highest; that
+  man assuredly lies in a death that is his due; so perish
+  likewise all who work such deeds! But my heart is rent for
+  wise Odysseus, the hapless one, who far from his friends
+  this long while suffereth affliction in a sea-girt isle,
+  where is the navel of the sea, a woodland isle, and
+  therein a goddess hath her habitation, the daughter of the
+  wizard Atlas, who knows the depths of every sea, and
+  himself upholds the tall pillars which keep earth and sky
+  asunder. His daughter it is that holds the hapless man in
+  sorrow: and ever with soft and guileful tales she is
+  wooing him to forgetfulness of Ithaca. But Odysseus
+  yearning to see if it were but the smoke leap upwards from
+  his own land, hath a desire to die. As for thee, thine
+  heart regardeth it not at all, Olympian! What! Did not
+  Odysseus by the ships of the Argives make thee free
+  offering of sacrifice in the wide Trojan land? Wherefore
+  wast thou then so wroth with him, O Zeus?'
+
+The "Odyssey" (as every one knows) abounds in passages borrowed from the
+"Iliad"; I had wished to print these in a slightly different type, with
+marginal references to the "Iliad," and had marked them to this end in
+my MS. I found, however, that the translation would be thus hopelessly
+scholasticised, and abandoned my intention. I would nevertheless urge on
+those who have the management of our University presses, that they would
+render a great service to students if they would publish a Greek text of
+the "Odyssey" with the Iliadic passages printed in a different type, and
+with marginal references. I have given the British Museum a copy of the
+"Odyssey" with the Iliadic passages underlined and referred to in MS.;
+I have also given an "Iliad" marked with all the Odyssean passages, and
+their references; but copies of both the "Iliad" and "Odyssey" so marked
+ought to be within easy reach of all students.
+
+Any one who at the present day discusses the questions that have arisen
+round the "Iliad" since Wolf's time, without keeping it well before
+his reader's mind that the "Odyssey" was demonstrably written from one
+single neighbourhood, and hence (even though nothing else pointed to
+this conclusion) presumably by one person only--that it was written
+certainly before 750, and in all probability before 1000 B.C.--that
+the writer of this very early poem was demonstrably familiar with the
+"Iliad" as we now have it, borrowing as freely from those books whose
+genuineness has been most impugned, as from those which are admitted to
+be by Homer--any one who fails to keep these points before his readers,
+is hardly dealing equitably by them. Any one on the other hand, who will
+mark his "Iliad" and his "Odyssey" from the copies in the British Museum
+above referred to, and who will draw the only inference that common
+sense can draw from the presence of so many identical passages in both
+poems, will, I believe, find no difficulty in assigning their proper
+value to a large number of books here and on the Continent that at
+present enjoy considerable reputations. Furthermore, and this perhaps
+is an advantage better worth securing, he will find that many puzzles of
+the "Odyssey" cease to puzzle him on the discovery that they arise from
+over-saturation with the "Iliad."
+
+Other difficulties will also disappear as soon as the development of the
+poem in the writer's mind is understood. I have dealt with this at some
+length in pp. 251-261 of "The Authoress of the Odyssey". Briefly, the
+"Odyssey" consists of two distinct poems: (1) The Return of Ulysses,
+which alone the Muse is asked to sing in the opening lines of the poem.
+This poem includes the Phaeacian episode, and the account of Ulysses'
+adventures as told by himself in Books ix.-xii. It consists of lines
+1-79 (roughly) of Book i., of line 28 of Book v., and thence without
+intermission to the middle of line 187 of Book xiii., at which point the
+original scheme was abandoned.
+
+(2) The story of Penelope and the suitors, with the episode of
+Telemachus' voyage to Pylos. This poem begins with line 80 (roughly)
+of Book i., is continued to the end of Book iv., and not resumed till
+Ulysses wakes in the middle of line 187, Book xiii., from whence it
+continues to the end of Book xxiv.
+
+In "The Authoress of the Odyssey", I wrote:
+
+   the introduction of lines xi., 115-137 and of line ix.,
+   535, with the writing a new council of the gods at the
+   beginning of Book v., to take the place of the one that was
+   removed to Book i., 1-79, were the only things that were
+   done to give even a semblance of unity to the old scheme
+   and the new, and to conceal the fact that the Muse, after
+   being asked to sing of one subject, spend two-thirds of her
+   time in singing a very different one, with a climax for
+   which no-one has asked her. For roughly the Return occupies
+   eight Books, and Penelope and the Suitors sixteen.
+
+I believe this to be substantially correct.
+
+Lastly, to deal with a very unimportant point, I observe that the
+Leipsic Teubner edition of 894 makes Books ii. and iii. end with a
+comma. Stops are things of such far more recent date than the "Odyssey,"
+that there does not seem much use in adhering to the text in so small a
+matter; still, from a spirit of mere conservatism, I have preferred
+to do so. Why [Greek] at the beginnings of Books ii. and viii., and
+[Greek], at the beginning of Book vii. should have initial capitals in
+an edition far too careful to admit a supposition of inadvertence, when
+[Greek] at the beginning of Books vi. and xiii., and [Greek] at the
+beginning of Book xvii. have no initial capitals, I cannot determine.
+No other Books of the "Odyssey" have initial capitals except the three
+mentioned unless the first word of the Book is a proper name.
+
+S. BUTLER.
+
+July 25, 1900.
+
+
+
+
+PREFACE TO SECOND EDITION
+
+Butler's Translation of the "Odyssey" appeared originally in 1900, and
+The Authoress of the Odyssey in 1897. In the preface to the new edition
+of "The Authoress", which is published simultaneously with this new
+edition of the Translation, I have given some account of the genesis of
+the two books.
+
+The size of the original page has been reduced so as to make both
+books uniform with Butler's other works; and, fortunately, it has been
+possible, by using a smaller type, to get the same number of words into
+each page, so that the references remain good, and, with the exception
+of a few minor alterations and rearrangements now to be enumerated
+so far as they affect the Translation, the new editions are faithful
+reprints of the original editions, with misprints and obvious errors
+corrected--no attempt having been made to edit them or to bring them up
+to date.
+
+(a) The Index has been revised.
+
+(b) Owing to the reduction in the size of the page it has been necessary
+to shorten some of the headlines, and here advantage has been taken of
+various corrections of and additions to the headlines and shoulder-notes
+made by Butler in his own copies of the two books.
+
+(c) For the most part each of the illustrations now occupies a page,
+whereas in the original editions they generally appeared two on the
+page. It has been necessary to reduce the plan of the House of Ulysses.
+
+On page 153 of "The Authoress" Butler says: "No great poet would compare
+his hero to a paunch full of blood and fat, cooking before the fire
+(xx, 24-28)." This passage is not given in the abridged Story of the
+"Odyssey" at the beginning of the book, but in the Translation it occurs
+in these words:
+
+"Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side then on the other, that he
+may get it cooked as soon as possible; even so did he turn himself about
+from side to side, thinking all the time how, single-handed as he
+was, he should contrive to kill so large a body of men as the wicked
+suitors."
+
+It looks as though in the interval between the publication of "The
+Authoress" (1897) and of the Translation (1900) Butler had changed his
+mind; for in the first case the comparison is between Ulysses and a
+paunch full, etc., and in the second it is between Ulysses and a man who
+turns a paunch full, etc. The second comparison is perhaps one which a
+great poet might make.
+
+In seeing the works through the press I have had the invaluable
+assistance of Mr. A. T. Bartholomew of the University Library,
+Cambridge, and of Mr. Donald S. Robertson, Fellow of Trinity College,
+Cambridge. To both these friends I give my most cordial thanks for the
+care and skill exercised by them. Mr. Robertson has found time for the
+labour of checking and correcting all the quotations from and references
+to the "Iliad" and "Odyssey," and I believe that it could not have been
+better performed. It was, I know, a pleasure for him; and it would have
+been a pleasure also for Butler if he could have known that his work was
+being shepherded by the son of his old friend, Mr. H. R. Robertson, who
+more than half a century ago was a fellow-student with him at Cary's
+School of Art in Streatham Street, Bloomsbury.
+
+HENRY FESTING JONES.
+
+120 MAIDA VALE, W.9.
+
+4th December, 1921.
+
+
+
+
+THE ODYSSEY
+
+
+Book I
+
+THE GODS IN COUNCIL--MINERVA'S VISIT TO ITHACA--THE CHALLENGE FROM
+TELEMACHUS TO THE SUITORS.
+
+Tell me, O Muse, of that ingenious hero who travelled far and wide after
+he had sacked the famous town of Troy. Many cities did he visit, and
+many were the nations with whose manners and customs he was acquainted;
+moreover he suffered much by sea while trying to save his own life and
+bring his men safely home; but do what he might he could not save his
+men, for they perished through their own sheer folly in eating the
+cattle of the Sun-god Hyperion; so the god prevented them from ever
+reaching home. Tell me, too, about all these things, oh daughter of
+Jove, from whatsoever source you may know them.
+
+So now all who escaped death in battle or by shipwreck had got safely
+home except Ulysses, and he, though he was longing to return to his wife
+and country, was detained by the goddess Calypso, who had got him into
+a large cave and wanted to marry him. But as years went by, there came a
+time when the gods settled that he should go back to Ithaca; even then,
+however, when he was among his own people, his troubles were not
+yet over; nevertheless all the gods had now begun to pity him except
+Neptune, who still persecuted him without ceasing and would not let him
+get home.
+
+Now Neptune had gone off to the Ethiopians, who are at the world's end,
+and lie in two halves, the one looking West and the other East. {1} He
+had gone there to accept a hecatomb of sheep and oxen, and was enjoying
+himself at his festival; but the other gods met in the house of Olympian
+Jove, and the sire of gods and men spoke first. At that moment he was
+thinking of Aegisthus, who had been killed by Agamemnon's son Orestes;
+so he said to the other gods:
+
+"See now, how men lay blame upon us gods for what is after all nothing
+but their own folly. Look at Aegisthus; he must needs make love to
+Agamemnon's wife unrighteously and then kill Agamemnon, though he knew
+it would be the death of him; for I sent Mercury to warn him not to do
+either of these things, inasmuch as Orestes would be sure to take his
+revenge when he grew up and wanted to return home. Mercury told him
+this in all good will but he would not listen, and now he has paid for
+everything in full."
+
+Then Minerva said, "Father, son of Saturn, King of kings, it served
+Aegisthus right, and so it would any one else who does as he did; but
+Aegisthus is neither here nor there; it is for Ulysses that my heart
+bleeds, when I think of his sufferings in that lonely sea-girt island,
+far away, poor man, from all his friends. It is an island covered
+with forest, in the very middle of the sea, and a goddess lives there,
+daughter of the magician Atlas, who looks after the bottom of the ocean,
+and carries the great columns that keep heaven and earth asunder. This
+daughter of Atlas has got hold of poor unhappy Ulysses, and keeps trying
+by every kind of blandishment to make him forget his home, so that he
+is tired of life, and thinks of nothing but how he may once more see the
+smoke of his own chimneys. You, sir, take no heed of this, and yet when
+Ulysses was before Troy did he not propitiate you with many a burnt
+sacrifice? Why then should you keep on being so angry with him?"
+
+And Jove said, "My child, what are you talking about? How can I forget
+Ulysses than whom there is no more capable man on earth, nor more
+liberal in his offerings to the immortal gods that live in heaven? Bear
+in mind, however, that Neptune is still furious with Ulysses for having
+blinded an eye of Polyphemus king of the Cyclopes. Polyphemus is son to
+Neptune by the nymph Thoosa, daughter to the sea-king Phorcys; therefore
+though he will not kill Ulysses outright, he torments him by preventing
+him from getting home. Still, let us lay our heads together and see how
+we can help him to return; Neptune will then be pacified, for if we are
+all of a mind he can hardly stand out against us."
+
+And Minerva said, "Father, son of Saturn, King of kings, if, then, the
+gods now mean that Ulysses should get home, we should first send Mercury
+to the Ogygian island to tell Calypso that we have made up our minds and
+that he is to return. In the meantime I will go to Ithaca, to put heart
+into Ulysses' son Telemachus; I will embolden him to call the Achaeans
+in assembly, and speak out to the suitors of his mother Penelope, who
+persist in eating up any number of his sheep and oxen; I will also
+conduct him to Sparta and to Pylos, to see if he can hear anything about
+the return of his dear father--for this will make people speak well of
+him."
+
+So saying she bound on her glittering golden sandals, imperishable,
+with which she can fly like the wind over land or sea; she grasped the
+redoubtable bronze-shod spear, so stout and sturdy and strong, wherewith
+she quells the ranks of heroes who have displeased her, and down she
+darted from the topmost summits of Olympus, whereon forthwith she was
+in Ithaca, at the gateway of Ulysses' house, disguised as a visitor,
+Mentes, chief of the Taphians, and she held a bronze spear in her hand.
+There she found the lordly suitors seated on hides of the oxen which
+they had killed and eaten, and playing draughts in front of the house.
+Men-servants and pages were bustling about to wait upon them, some
+mixing wine with water in the mixing-bowls, some cleaning down the
+tables with wet sponges and laying them out again, and some cutting up
+great quantities of meat.
+
+Telemachus saw her long before any one else did. He was sitting moodily
+among the suitors thinking about his brave father, and how he would send
+them flying out of the house, if he were to come to his own again and
+be honoured as in days gone by. Thus brooding as he sat among them, he
+caught sight of Minerva and went straight to the gate, for he was vexed
+that a stranger should be kept waiting for admittance. He took her right
+hand in his own, and bade her give him her spear. "Welcome," said he,
+"to our house, and when you have partaken of food you shall tell us what
+you have come for."
+
+He led the way as he spoke, and Minerva followed him. When they were
+within he took her spear and set it in the spear-stand against a strong
+bearing-post along with the many other spears of his unhappy father, and
+he conducted her to a richly decorated seat under which he threw a
+cloth of damask. There was a footstool also for her feet,{2} and he set
+another seat near her for himself, away from the suitors, that she might
+not be annoyed while eating by their noise and insolence, and that he
+might ask her more freely about his father.
+
+A maid servant then brought them water in a beautiful golden ewer and
+poured it into a silver basin for them to wash their hands, and she
+drew a clean table beside them. An upper servant brought them bread, and
+offered them many good things of what there was in the house, the carver
+fetched them plates of all manner of meats and set cups of gold by their
+side, and a manservant brought them wine and poured it out for them.
+
+Then the suitors came in and took their places on the benches and seats.
+{3} Forthwith men servants poured water over their hands, maids went
+round with the bread-baskets, pages filled the mixing-bowls with wine
+and water, and they laid their hands upon the good things that were
+before them. As soon as they had had enough to eat and drink they wanted
+music and dancing, which are the crowning embellishments of a banquet,
+so a servant brought a lyre to Phemius, whom they compelled perforce
+to sing to them. As soon as he touched his lyre and began to sing
+Telemachus spoke low to Minerva, with his head close to hers that no man
+might hear.
+
+"I hope, sir," said he, "that you will not be offended with what I am
+going to say. Singing comes cheap to those who do not pay for it, and
+all this is done at the cost of one whose bones lie rotting in some
+wilderness or grinding to powder in the surf. If these men were to see
+my father come back to Ithaca they would pray for longer legs rather
+than a longer purse, for money would not serve them; but he, alas, has
+fallen on an ill fate, and even when people do sometimes say that he is
+coming, we no longer heed them; we shall never see him again. And now,
+sir, tell me and tell me true, who you are and where you come from. Tell
+me of your town and parents, what manner of ship you came in, how your
+crew brought you to Ithaca, and of what nation they declared themselves
+to be--for you cannot have come by land. Tell me also truly, for I want
+to know, are you a stranger to this house, or have you been here in my
+father's time? In the old days we had many visitors for my father went
+about much himself."
+
+And Minerva answered, "I will tell you truly and particularly all about
+it. I am Mentes, son of Anchialus, and I am King of the Taphians. I have
+come here with my ship and crew, on a voyage to men of a foreign tongue
+being bound for Temesa {4} with a cargo of iron, and I shall bring back
+copper. As for my ship, it lies over yonder off the open country away
+from the town, in the harbour Rheithron {5} under the wooded mountain
+Neritum. {6} Our fathers were friends before us, as old Laertes will
+tell you, if you will go and ask him. They say, however, that he never
+comes to town now, and lives by himself in the country, faring hardly,
+with an old woman to look after him and get his dinner for him, when
+he comes in tired from pottering about his vineyard. They told me your
+father was at home again, and that was why I came, but it seems the gods
+are still keeping him back, for he is not dead yet not on the mainland.
+It is more likely he is on some sea-girt island in mid ocean, or a
+prisoner among savages who are detaining him against his will. I am no
+prophet, and know very little about omens, but I speak as it is borne
+in upon me from heaven, and assure you that he will not be away much
+longer; for he is a man of such resource that even though he were in
+chains of iron he would find some means of getting home again. But tell
+me, and tell me true, can Ulysses really have such a fine looking fellow
+for a son? You are indeed wonderfully like him about the head and eyes,
+for we were close friends before he set sail for Troy where the flower
+of all the Argives went also. Since that time we have never either of us
+seen the other."
+
+"My mother," answered Telemachus, "tells me I am son to Ulysses, but it
+is a wise child that knows his own father. Would that I were son to one
+who had grown old upon his own estates, for, since you ask me, there
+is no more ill-starred man under heaven than he who they tell me is my
+father."
+
+And Minerva said, "There is no fear of your race dying out yet, while
+Penelope has such a fine son as you are. But tell me, and tell me true,
+what is the meaning of all this feasting, and who are these people? What
+is it all about? Have you some banquet, or is there a wedding in the
+family--for no one seems to be bringing any provisions of his own? And
+the guests--how atrociously they are behaving; what riot they make over
+the whole house; it is enough to disgust any respectable person who
+comes near them."
+
+"Sir," said Telemachus, "as regards your question, so long as my father
+was here it was well with us and with the house, but the gods in their
+displeasure have willed it otherwise, and have hidden him away more
+closely than mortal man was ever yet hidden. I could have borne it
+better even though he were dead, if he had fallen with his men before
+Troy, or had died with friends around him when the days of his fighting
+were done; for then the Achaeans would have built a mound over his
+ashes, and I should myself have been heir to his renown; but now the
+storm-winds have spirited him away we know not whither; he is gone
+without leaving so much as a trace behind him, and I inherit nothing
+but dismay. Nor does the matter end simply with grief for the loss of
+my father; heaven has laid sorrows upon me of yet another kind; for the
+chiefs from all our islands, Dulichium, Same, and the woodland island of
+Zacynthus, as also all the principal men of Ithaca itself, are eating up
+my house under the pretext of paying their court to my mother, who
+will neither point blank say that she will not marry, {7} nor yet bring
+matters to an end; so they are making havoc of my estate, and before
+long will do so also with myself."
+
+"Is that so?" exclaimed Minerva, "then you do indeed want Ulysses home
+again. Give him his helmet, shield, and a couple of lances, and if he is
+the man he was when I first knew him in our house, drinking and making
+merry, he would soon lay his hands about these rascally suitors, were
+he to stand once more upon his own threshold. He was then coming from
+Ephyra, where he had been to beg poison for his arrows from Ilus, son of
+Mermerus. Ilus feared the ever-living gods and would not give him any,
+but my father let him have some, for he was very fond of him. If Ulysses
+is the man he then was these suitors will have a short shrift and a
+sorry wedding.
+
+"But there! It rests with heaven to determine whether he is to return,
+and take his revenge in his own house or no; I would, however, urge you
+to set about trying to get rid of these suitors at once. Take my advice,
+call the Achaean heroes in assembly to-morrow morning--lay your case
+before them, and call heaven to bear you witness. Bid the suitors take
+themselves off, each to his own place, and if your mother's mind is set
+on marrying again, let her go back to her father, who will find her
+a husband and provide her with all the marriage gifts that so dear a
+daughter may expect. As for yourself, let me prevail upon you to take
+the best ship you can get, with a crew of twenty men, and go in quest
+of your father who has so long been missing. Some one may tell
+you something, or (and people often hear things in this way) some
+heaven-sent message may direct you. First go to Pylos and ask Nestor;
+thence go on to Sparta and visit Menelaus, for he got home last of all
+the Achaeans; if you hear that your father is alive and on his way home,
+you can put up with the waste these suitors will make for yet another
+twelve months. If on the other hand you hear of his death, come home at
+once, celebrate his funeral rites with all due pomp, build a barrow
+to his memory, and make your mother marry again. Then, having done all
+this, think it well over in your mind how, by fair means or foul, you
+may kill these suitors in your own house. You are too old to plead
+infancy any longer; have you not heard how people are singing Orestes'
+praises for having killed his father's murderer Aegisthus? You are a
+fine, smart looking fellow; show your mettle, then, and make yourself a
+name in story. Now, however, I must go back to my ship and to my crew,
+who will be impatient if I keep them waiting longer; think the matter
+over for yourself, and remember what I have said to you."
+
+"Sir," answered Telemachus, "it has been very kind of you to talk to me
+in this way, as though I were your own son, and I will do all you tell
+me; I know you want to be getting on with your voyage, but stay a little
+longer till you have taken a bath and refreshed yourself. I will then
+give you a present, and you shall go on your way rejoicing; I will give
+you one of great beauty and value--a keepsake such as only dear friends
+give to one another."
+
+Minerva answered, "Do not try to keep me, for I would be on my way at
+once. As for any present you may be disposed to make me, keep it till
+I come again, and I will take it home with me. You shall give me a very
+good one, and I will give you one of no less value in return."
+
+With these words she flew away like a bird into the air, but she had
+given Telemachus courage, and had made him think more than ever about
+his father. He felt the change, wondered at it, and knew that the
+stranger had been a god, so he went straight to where the suitors were
+sitting.
+
+Phemius was still singing, and his hearers sat rapt in silence as he
+told the sad tale of the return from Troy, and the ills Minerva had laid
+upon the Achaeans. Penelope, daughter of Icarius, heard his song from
+her room upstairs, and came down by the great staircase, not alone, but
+attended by two of her handmaids. When she reached the suitors she stood
+by one of the bearing posts that supported the roof of the cloisters {8}
+with a staid maiden on either side of her. She held a veil, moreover,
+before her face, and was weeping bitterly.
+
+"Phemius," she cried, "you know many another feat of gods and heroes,
+such as poets love to celebrate. Sing the suitors some one of these, and
+let them drink their wine in silence, but cease this sad tale, for it
+breaks my sorrowful heart, and reminds me of my lost husband whom I
+mourn ever without ceasing, and whose name was great over all Hellas and
+middle Argos." {9}
+
+"Mother," answered Telemachus, "let the bard sing what he has a mind to;
+bards do not make the ills they sing of; it is Jove, not they, who makes
+them, and who sends weal or woe upon mankind according to his own good
+pleasure. This fellow means no harm by singing the ill-fated return of
+the Danaans, for people always applaud the latest songs most warmly.
+Make up your mind to it and bear it; Ulysses is not the only man who
+never came back from Troy, but many another went down as well as he. Go,
+then, within the house and busy yourself with your daily duties, your
+loom, your distaff, and the ordering of your servants; for speech is
+man's matter, and mine above all others {10}--for it is I who am master
+here."
+
+She went wondering back into the house, and laid her son's saying in
+her heart. Then, going upstairs with her handmaids into her room, she
+mourned her dear husband till Minerva shed sweet sleep over her eyes.
+But the suitors were clamorous throughout the covered cloisters {11},
+and prayed each one that he might be her bed fellow.
+
+Then Telemachus spoke, "Shameless," he cried, "and insolent suitors, let
+us feast at our pleasure now, and let there be no brawling, for it is a
+rare thing to hear a man with such a divine voice as Phemius has; but in
+the morning meet me in full assembly that I may give you formal notice
+to depart, and feast at one another's houses, turn and turn about, at
+your own cost. If on the other hand you choose to persist in spunging
+upon one man, heaven help me, but Jove shall reckon with you in full,
+and when you fall in my father's house there shall be no man to avenge
+you."
+
+The suitors bit their lips as they heard him, and marvelled at the
+boldness of his speech. Then, Antinous, son of Eupeithes, said, "The
+gods seem to have given you lessons in bluster and tall talking; may
+Jove never grant you to be chief in Ithaca as your father was before
+you."
+
+Telemachus answered, "Antinous, do not chide with me, but, god willing,
+I will be chief too if I can. Is this the worst fate you can think of
+for me? It is no bad thing to be a chief, for it brings both riches
+and honour. Still, now that Ulysses is dead there are many great men in
+Ithaca both old and young, and some other may take the lead among them;
+nevertheless I will be chief in my own house, and will rule those whom
+Ulysses has won for me."
+
+Then Eurymachus, son of Polybus, answered, "It rests with heaven to
+decide who shall be chief among us, but you shall be master in your
+own house and over your own possessions; no one while there is a man
+in Ithaca shall do you violence nor rob you. And now, my good fellow,
+I want to know about this stranger. What country does he come from?
+Of what family is he, and where is his estate? Has he brought you news
+about the return of your father, or was he on business of his own? He
+seemed a well to do man, but he hurried off so suddenly that he was gone
+in a moment before we could get to know him."
+
+"My father is dead and gone," answered Telemachus, "and even if some
+rumour reaches me I put no more faith in it now. My mother does indeed
+sometimes send for a soothsayer and question him, but I give his
+prophecyings no heed. As for the stranger, he was Mentes, son of
+Anchialus, chief of the Taphians, an old friend of my father's." But in
+his heart he knew that it had been the goddess.
+
+The suitors then returned to their singing and dancing until the
+evening; but when night fell upon their pleasuring they went home to
+bed each in his own abode. {12} Telemachus's room was high up in a tower
+{13} that looked on to the outer court; hither, then, he hied, brooding
+and full of thought. A good old woman, Euryclea, daughter of Ops,
+the son of Pisenor, went before him with a couple of blazing torches.
+Laertes had bought her with his own money when she was quite young; he
+gave the worth of twenty oxen for her, and shewed as much respect to her
+in his household as he did to his own wedded wife, but he did not take
+her to his bed for he feared his wife's resentment. {14} She it was who
+now lighted Telemachus to his room, and she loved him better than any of
+the other women in the house did, for she had nursed him when he was a
+baby. He opened the door of his bed room and sat down upon the bed; as
+he took off his shirt {15} he gave it to the good old woman, who folded
+it tidily up, and hung it for him over a peg by his bed side, after
+which she went out, pulled the door to by a silver catch, and drew the
+bolt home by means of the strap. {16} But Telemachus as he lay covered
+with a woollen fleece kept thinking all night through of his intended
+voyage and of the counsel that Minerva had given him.
+
+
+Book II
+
+ASSEMBLY OF THE PEOPLE OF ITHACA--SPEECHES OF TELEMACHUS AND OF THE
+SUITORS--TELEMACHUS MAKES HIS PREPARATIONS AND STARTS FOR PYLOS WITH
+MINERVA DISGUISED AS MENTOR.
+
+Now when the child of morning, rosy-fingered Dawn, appeared Telemachus
+rose and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulder, and left his room looking like an
+immortal god. He at once sent the criers round to call the people in
+assembly, so they called them and the people gathered thereon; then,
+when they were got together, he went to the place of assembly spear in
+hand--not alone, for his two hounds went with him. Minerva endowed him
+with a presence of such divine comeliness that all marvelled at him as
+he went by, and when he took his place in his father's seat even the
+oldest councillors made way for him.
+
+Aegyptius, a man bent double with age, and of infinite experience, was
+the first to speak. His son Antiphus had gone with Ulysses to Ilius,
+land of noble steeds, but the savage Cyclops had killed him when they
+were all shut up in the cave, and had cooked his last dinner for him.
+{17} He had three sons left, of whom two still worked on their father's
+land, while the third, Eurynomus, was one of the suitors; nevertheless
+their father could not get over the loss of Antiphus, and was still
+weeping for him when he began his speech.
+
+"Men of Ithaca," he said, "hear my words. From the day Ulysses left us
+there has been no meeting of our councillors until now; who then can it
+be, whether old or young, that finds it so necessary to convene us? Has
+he got wind of some host approaching, and does he wish to warn us, or
+would he speak upon some other matter of public moment? I am sure he is
+an excellent person, and I hope Jove will grant him his heart's desire."
+
+Telemachus took this speech as of good omen and rose at once, for he was
+bursting with what he had to say. He stood in the middle of the assembly
+and the good herald Pisenor brought him his staff. Then, turning to
+Aegyptius, "Sir," said he, "it is I, as you will shortly learn, who have
+convened you, for it is I who am the most aggrieved. I have not got wind
+of any host approaching about which I would warn you, nor is there any
+matter of public moment on which I would speak. My grievance is purely
+personal, and turns on two great misfortunes which have fallen upon my
+house. The first of these is the loss of my excellent father, who was
+chief among all you here present, and was like a father to every one
+of you; the second is much more serious, and ere long will be the utter
+ruin of my estate. The sons of all the chief men among you are pestering
+my mother to marry them against her will. They are afraid to go to
+her father Icarius, asking him to choose the one he likes best, and
+to provide marriage gifts for his daughter, but day by day they keep
+hanging about my father's house, sacrificing our oxen, sheep, and fat
+goats for their banquets, and never giving so much as a thought to the
+quantity of wine they drink. No estate can stand such recklessness; we
+have now no Ulysses to ward off harm from our doors, and I cannot hold
+my own against them. I shall never all my days be as good a man as he
+was, still I would indeed defend myself if I had power to do so, for I
+cannot stand such treatment any longer; my house is being disgraced and
+ruined. Have respect, therefore, to your own consciences and to public
+opinion. Fear, too, the wrath of heaven, lest the gods should be
+displeased and turn upon you. I pray you by Jove and Themis, who is the
+beginning and the end of councils, [do not] hold back, my friends, and
+leave me singlehanded {18}--unless it be that my brave father Ulysses
+did some wrong to the Achaeans which you would now avenge on me, by
+aiding and abetting these suitors. Moreover, if I am to be eaten out of
+house and home at all, I had rather you did the eating yourselves, for
+I could then take action against you to some purpose, and serve you with
+notices from house to house till I got paid in full, whereas now I have
+no remedy." {19}
+
+With this Telemachus dashed his staff to the ground and burst into
+tears. Every one was very sorry for him, but they all sat still and no
+one ventured to make him an angry answer, save only Antinous, who spoke
+thus:
+
+"Telemachus, insolent braggart that you are, how dare you try to throw
+the blame upon us suitors? It is your mother's fault not ours, for she
+is a very artful woman. This three years past, and close on four, she
+had been driving us out of our minds, by encouraging each one of us, and
+sending him messages without meaning one word of what she says. And then
+there was that other trick she played us. She set up a great tambour
+frame in her room, and began to work on an enormous piece of fine
+needlework. 'Sweet hearts,' said she, 'Ulysses is indeed dead, still
+do not press me to marry again immediately, wait--for I would not have
+skill in needlework perish unrecorded--till I have completed a pall for
+the hero Laertes, to be in readiness against the time when death shall
+take him. He is very rich, and the women of the place will talk if he is
+laid out without a pall.'
+
+"This was what she said, and we assented; whereon we could see her
+working on her great web all day long, but at night she would unpick the
+stitches again by torchlight. She fooled us in this way for three years
+and we never found her out, but as time wore on and she was now in her
+fourth year, one of her maids who knew what she was doing told us, and
+we caught her in the act of undoing her work, so she had to finish it
+whether she would or no. The suitors, therefore, make you this answer,
+that both you and the Achaeans may understand-'Send your mother away,
+and bid her marry the man of her own and of her father's choice'; for I
+do not know what will happen if she goes on plaguing us much longer with
+the airs she gives herself on the score of the accomplishments Minerva
+has taught her, and because she is so clever. We never yet heard of such
+a woman; we know all about Tyro, Alcmena, Mycene, and the famous women
+of old, but they were nothing to your mother any one of them. It was not
+fair of her to treat us in that way, and as long as she continues in
+the mind with which heaven has now endowed her, so long shall we go on
+eating up your estate; and I do not see why she should change, for she
+gets all the honour and glory, and it is you who pay for it, not she.
+Understand, then, that we will not go back to our lands, neither here
+nor elsewhere, till she has made her choice and married some one or
+other of us."
+
+Telemachus answered, "Antinous, how can I drive the mother who bore me
+from my father's house? My father is abroad and we do not know whether
+he is alive or dead. It will be hard on me if I have to pay Icarius the
+large sum which I must give him if I insist on sending his daughter back
+to him. Not only will he deal rigorously with me, but heaven will also
+punish me; for my mother when she leaves the house will call on the
+Erinyes to avenge her; besides, it would not be a creditable thing to
+do, and I will have nothing to say to it. If you choose to take offence
+at this, leave the house and feast elsewhere at one another's houses at
+your own cost turn and turn about. If, on the other hand, you elect to
+persist in spunging upon one man, heaven help me, but Jove shall reckon
+with you in full, and when you fall in my father's house there shall be
+no man to avenge you."
+
+As he spoke Jove sent two eagles from the top of the mountain, and they
+flew on and on with the wind, sailing side by side in their own lordly
+flight. When they were right over the middle of the assembly they
+wheeled and circled about, beating the air with their wings and glaring
+death into the eyes of them that were below; then, fighting fiercely and
+tearing at one another, they flew off towards the right over the town.
+The people wondered as they saw them, and asked each other what all this
+might be; whereon Halitherses, who was the best prophet and reader of
+omens among them, spoke to them plainly and in all honesty, saying:
+
+"Hear me, men of Ithaca, and I speak more particularly to the suitors,
+for I see mischief brewing for them. Ulysses is not going to be
+away much longer; indeed he is close at hand to deal out death and
+destruction, not on them alone, but on many another of us who live in
+Ithaca. Let us then be wise in time, and put a stop to this wickedness
+before he comes. Let the suitors do so of their own accord; it will
+be better for them, for I am not prophesying without due knowledge;
+everything has happened to Ulysses as I foretold when the Argives set
+out for Troy, and he with them. I said that after going through much
+hardship and losing all his men he should come home again in the
+twentieth year and that no one would know him; and now all this is
+coming true."
+
+Eurymachus son of Polybus then said, "Go home, old man, and prophesy to
+your own children, or it may be worse for them. I can read these omens
+myself much better than you can; birds are always flying about in the
+sunshine somewhere or other, but they seldom mean anything. Ulysses has
+died in a far country, and it is a pity you are not dead along with
+him, instead of prating here about omens and adding fuel to the anger of
+Telemachus which is fierce enough as it is. I suppose you think he will
+give you something for your family, but I tell you--and it shall surely
+be--when an old man like you, who should know better, talks a young one
+over till he becomes troublesome, in the first place his young friend
+will only fare so much the worse--he will take nothing by it, for the
+suitors will prevent this--and in the next, we will lay a heavier fine,
+sir, upon yourself than you will at all like paying, for it will bear
+hardly upon you. As for Telemachus, I warn him in the presence of you
+all to send his mother back to her father, who will find her a husband
+and provide her with all the marriage gifts so dear a daughter may
+expect. Till then we shall go on harassing him with our suit; for we
+fear no man, and care neither for him, with all his fine speeches, nor
+for any fortune-telling of yours. You may preach as much as you please,
+but we shall only hate you the more. We shall go back and continue to
+eat up Telemachus's estate without paying him, till such time as his
+mother leaves off tormenting us by keeping us day after day on the
+tiptoe of expectation, each vying with the other in his suit for a prize
+of such rare perfection. Besides we cannot go after the other women whom
+we should marry in due course, but for the way in which she treats us."
+
+Then Telemachus said, "Eurymachus, and you other suitors, I shall say no
+more, and entreat you no further, for the gods and the people of Ithaca
+now know my story. Give me, then, a ship and a crew of twenty men to
+take me hither and thither, and I will go to Sparta and to Pylos in
+quest of my father who has so long been missing. Some one may tell
+me something, or (and people often hear things in this way) some
+heaven-sent message may direct me. If I can hear of him as alive and on
+his way home I will put up with the waste you suitors will make for yet
+another twelve months. If on the other hand I hear of his death, I will
+return at once, celebrate his funeral rites with all due pomp, build a
+barrow to his memory, and make my mother marry again."
+
+With these words he sat down, and Mentor {20} who had been a friend of
+Ulysses, and had been left in charge of everything with full authority
+over the servants, rose to speak. He, then, plainly and in all honesty
+addressed them thus:
+
+"Hear me, men of Ithaca, I hope that you may never have a kind and
+well-disposed ruler any more, nor one who will govern you equitably;
+I hope that all your chiefs henceforward may be cruel and unjust, for
+there is not one of you but has forgotten Ulysses, who ruled you as
+though he were your father. I am not half so angry with the suitors, for
+if they choose to do violence in the naughtiness of their hearts, and
+wager their heads that Ulysses will not return, they can take the high
+hand and eat up his estate, but as for you others I am shocked at
+the way in which you all sit still without even trying to stop such
+scandalous goings on--which you could do if you chose, for you are many
+and they are few."
+
+Leiocritus, son of Evenor, answered him saying, "Mentor, what folly is
+all this, that you should set the people to stay us? It is a hard thing
+for one man to fight with many about his victuals. Even though Ulysses
+himself were to set upon us while we are feasting in his house, and do
+his best to oust us, his wife, who wants him back so very badly, would
+have small cause for rejoicing, and his blood would be upon his own head
+if he fought against such great odds. There is no sense in what you have
+been saying. Now, therefore, do you people go about your business, and
+let his father's old friends, Mentor and Halitherses, speed this boy on
+his journey, if he goes at all--which I do not think he will, for he
+is more likely to stay where he is till some one comes and tells him
+something."
+
+On this he broke up the assembly, and every man went back to his own
+abode, while the suitors returned to the house of Ulysses.
+
+Then Telemachus went all alone by the sea side, washed his hands in the
+grey waves, and prayed to Minerva.
+
+"Hear me," he cried, "you god who visited me yesterday, and bade me sail
+the seas in search of my father who has so long been missing. I would
+obey you, but the Achaeans, and more particularly the wicked suitors,
+are hindering me that I cannot do so."
+
+As he thus prayed, Minerva came close up to him in the likeness and with
+the voice of Mentor. "Telemachus," said she, "if you are made of
+the same stuff as your father you will be neither fool nor coward
+henceforward, for Ulysses never broke his word nor left his work half
+done. If, then, you take after him, your voyage will not be fruitless,
+but unless you have the blood of Ulysses and of Penelope in your veins
+I see no likelihood of your succeeding. Sons are seldom as good men as
+their fathers; they are generally worse, not better; still, as you are
+not going to be either fool or coward henceforward, and are not entirely
+without some share of your father's wise discernment, I look with hope
+upon your undertaking. But mind you never make common cause with any of
+those foolish suitors, for they have neither sense nor virtue, and give
+no thought to death and to the doom that will shortly fall on one and
+all of them, so that they shall perish on the same day. As for your
+voyage, it shall not be long delayed; your father was such an old friend
+of mine that I will find you a ship, and will come with you myself.
+Now, however, return home, and go about among the suitors; begin getting
+provisions ready for your voyage; see everything well stowed, the wine
+in jars, and the barley meal, which is the staff of life, in leathern
+bags, while I go round the town and beat up volunteers at once. There
+are many ships in Ithaca both old and new; I will run my eye over them
+for you and will choose the best; we will get her ready and will put out
+to sea without delay."
+
+Thus spoke Minerva daughter of Jove, and Telemachus lost no time in
+doing as the goddess told him. He went moodily home, and found the
+suitors flaying goats and singeing pigs in the outer court. Antinous
+came up to him at once and laughed as he took his hand in his own,
+saying, "Telemachus, my fine fire-eater, bear no more ill blood neither
+in word nor deed, but eat and drink with us as you used to do. The
+Achaeans will find you in everything--a ship and a picked crew to
+boot--so that you can set sail for Pylos at once and get news of your
+noble father."
+
+"Antinous," answered Telemachus, "I cannot eat in peace, nor take
+pleasure of any kind with such men as you are. Was it not enough that
+you should waste so much good property of mine while I was yet a boy?
+Now that I am older and know more about it, I am also stronger, and
+whether here among this people, or by going to Pylos, I will do you all
+the harm I can. I shall go, and my going will not be in vain--though,
+thanks to you suitors, I have neither ship nor crew of my own, and must
+be passenger not captain."
+
+As he spoke he snatched his hand from that of Antinous. Meanwhile the
+others went on getting dinner ready about the buildings, {21} jeering at
+him tauntingly as they did so.
+
+"Telemachus," said one youngster, "means to be the death of us; I
+suppose he thinks he can bring friends to help him from Pylos, or again
+from Sparta, where he seems bent on going. Or will he go to Ephyra as
+well, for poison to put in our wine and kill us?"
+
+Another said, "Perhaps if Telemachus goes on board ship, he will be like
+his father and perish far from his friends. In this case we should have
+plenty to do, for we could then divide up his property amongst us: as
+for the house we can let his mother and the man who marries her have
+that."
+
+This was how they talked. But Telemachus went down into the lofty and
+spacious store-room where his father's treasure of gold and bronze lay
+heaped up upon the floor, and where the linen and spare clothes were
+kept in open chests. Here, too, there was a store of fragrant olive oil,
+while casks of old, well-ripened wine, unblended and fit for a god to
+drink, were ranged against the wall in case Ulysses should come home
+again after all. The room was closed with well-made doors opening in the
+middle; moreover the faithful old house-keeper Euryclea, daughter of
+Ops the son of Pisenor, was in charge of everything both night and day.
+Telemachus called her to the store-room and said:
+
+"Nurse, draw me off some of the best wine you have, after what you
+are keeping for my father's own drinking, in case, poor man, he should
+escape death, and find his way home again after all. Let me have twelve
+jars, and see that they all have lids; also fill me some well-sewn
+leathern bags with barley meal--about twenty measures in all. Get these
+things put together at once, and say nothing about it. I will take
+everything away this evening as soon as my mother has gone upstairs
+for the night. I am going to Sparta and to Pylos to see if I can hear
+anything about the return of my dear father."
+
+When Euryclea heard this she began to cry, and spoke fondly to him,
+saying, "My dear child, what ever can have put such notion as that into
+your head? Where in the world do you want to go to--you, who are the
+one hope of the house? Your poor father is dead and gone in some foreign
+country nobody knows where, and as soon as your back is turned these
+wicked ones here will be scheming to get you put out of the way, and
+will share all your possessions among themselves; stay where you are
+among your own people, and do not go wandering and worrying your life
+out on the barren ocean."
+
+"Fear not, nurse," answered Telemachus, "my scheme is not without
+heaven's sanction; but swear that you will say nothing about all this
+to my mother, till I have been away some ten or twelve days, unless she
+hears of my having gone, and asks you; for I do not want her to spoil
+her beauty by crying."
+
+The old woman swore most solemnly that she would not, and when she
+had completed her oath, she began drawing off the wine into jars, and
+getting the barley meal into the bags, while Telemachus went back to the
+suitors.
+
+Then Minerva bethought her of another matter. She took his shape, and
+went round the town to each one of the crew, telling them to meet at the
+ship by sundown. She went also to Noemon son of Phronius, and asked him
+to let her have a ship--which he was very ready to do. When the sun had
+set and darkness was over all the land, she got the ship into the
+water, put all the tackle on board her that ships generally carry, and
+stationed her at the end of the harbour. Presently the crew came up, and
+the goddess spoke encouragingly to each of them.
+
+Furthermore she went to the house of Ulysses, and threw the suitors into
+a deep slumber. She caused their drink to fuddle them, and made them
+drop their cups from their hands, so that instead of sitting over their
+wine, they went back into the town to sleep, with their eyes heavy and
+full of drowsiness. Then she took the form and voice of Mentor, and
+called Telemachus to come outside.
+
+"Telemachus," said she, "the men are on board and at their oars, waiting
+for you to give your orders, so make haste and let us be off."
+
+On this she led the way, while Telemachus followed in her steps. When
+they got to the ship they found the crew waiting by the water side, and
+Telemachus said, "Now my men, help me to get the stores on board;
+they are all put together in the cloister, and my mother does not know
+anything about it, nor any of the maid servants except one."
+
+With these words he led the way and the others followed after. When
+they had brought the things as he told them, Telemachus went on board,
+Minerva going before him and taking her seat in the stern of the vessel,
+while Telemachus sat beside her. Then the men loosed the hawsers and
+took their places on the benches. Minerva sent them a fair wind from
+the West, {22} that whistled over the deep blue waves {23} whereon
+Telemachus told them to catch hold of the ropes and hoist sail, and they
+did as he told them. They set the mast in its socket in the cross plank,
+raised it, and made it fast with the forestays; then they hoisted their
+white sails aloft with ropes of twisted ox hide. As the sail bellied out
+with the wind, the ship flew through the deep blue water, and the foam
+hissed against her bows as she sped onward. Then they made all fast
+throughout the ship, filled the mixing bowls to the brim, and made
+drink offerings to the immortal gods that are from everlasting, but more
+particularly to the grey-eyed daughter of Jove.
+
+Thus, then, the ship sped on her way through the watches of the night
+from dark till dawn,
+
+
+Book III
+
+TELEMACHUS VISITS NESTOR AT PYLOS.
+
+but as the sun was rising from the fair sea {24} into the firmament of
+heaven to shed light on mortals and immortals, they reached Pylos the
+city of Neleus. Now the people of Pylos were gathered on the sea shore
+to offer sacrifice of black bulls to Neptune lord of the Earthquake.
+There were nine guilds with five hundred men in each, and there were
+nine bulls to each guild. As they were eating the inward meats {25}
+and burning the thigh bones [on the embers] in the name of Neptune,
+Telemachus and his crew arrived, furled their sails, brought their ship
+to anchor, and went ashore.
+
+Minerva led the way and Telemachus followed her. Presently she said,
+"Telemachus, you must not be in the least shy or nervous; you have taken
+this voyage to try and find out where your father is buried and how he
+came by his end; so go straight up to Nestor that we may see what he has
+got to tell us. Beg of him to speak the truth, and he will tell no lies,
+for he is an excellent person."
+
+"But how, Mentor," replied Telemachus, "dare I go up to Nestor, and
+how am I to address him? I have never yet been used to holding long
+conversations with people, and am ashamed to begin questioning one who
+is so much older than myself."
+
+"Some things, Telemachus," answered Minerva, "will be suggested to
+you by your own instinct, and heaven will prompt you further; for I am
+assured that the gods have been with you from the time of your birth
+until now."
+
+She then went quickly on, and Telemachus followed in her steps till they
+reached the place where the guilds of the Pylian people were assembled.
+There they found Nestor sitting with his sons, while his company round
+him were busy getting dinner ready, and putting pieces of meat on to the
+spits {26} while other pieces were cooking. When they saw the strangers
+they crowded round them, took them by the hand and bade them take their
+places. Nestor's son Pisistratus at once offered his hand to each of
+them, and seated them on some soft sheepskins that were lying on the
+sands near his father and his brother Thrasymedes. Then he gave them
+their portions of the inward meats and poured wine for them into a
+golden cup, handing it to Minerva first, and saluting her at the same
+time.
+
+"Offer a prayer, sir," said he, "to King Neptune, for it is his feast
+that you are joining; when you have duly prayed and made your drink
+offering, pass the cup to your friend that he may do so also. I doubt
+not that he too lifts his hands in prayer, for man cannot live without
+God in the world. Still he is younger than you are, and is much of an
+age with myself, so I will give you the precedence."
+
+As he spoke he handed her the cup. Minerva thought it very right and
+proper of him to have given it to herself first; {27} she accordingly
+began praying heartily to Neptune. "O thou," she cried, "that encirclest
+the earth, vouchsafe to grant the prayers of thy servants that call upon
+thee. More especially we pray thee send down thy grace on Nestor and
+on his sons; thereafter also make the rest of the Pylian people some
+handsome return for the goodly hecatomb they are offering you. Lastly,
+grant Telemachus and myself a happy issue, in respect of the matter that
+has brought us in our ship to Pylos."
+
+When she had thus made an end of praying, she handed the cup to
+Telemachus and he prayed likewise. By and by, when the outer meats were
+roasted and had been taken off the spits, the carvers gave every man his
+portion and they all made an excellent dinner. As soon as they had had
+enough to eat and drink, Nestor, knight of Gerene, began to speak.
+
+"Now," said he, "that our guests have done their dinner, it will be best
+to ask them who they are. Who, then, sir strangers, are you, and from
+what port have you sailed? Are you traders? or do you sail the seas as
+rovers with your hand against every man, and every man's hand against
+you?"
+
+Telemachus answered boldly, for Minerva had given him courage to ask
+about his father and get himself a good name.
+
+"Nestor," said he, "son of Neleus, honour to the Achaean name, you ask
+whence we come, and I will tell you. We come from Ithaca under Neritum,
+{28} and the matter about which I would speak is of private not public
+import. I seek news of my unhappy father Ulysses, who is said to have
+sacked the town of Troy in company with yourself. We know what fate
+befell each one of the other heroes who fought at Troy, but as regards
+Ulysses heaven has hidden from us the knowledge even that he is dead
+at all, for no one can certify us in what place he perished, nor say
+whether he fell in battle on the mainland, or was lost at sea amid the
+waves of Amphitrite. Therefore I am suppliant at your knees, if haply
+you may be pleased to tell me of his melancholy end, whether you saw it
+with your own eyes, or heard it from some other traveller, for he was
+a man born to trouble. Do not soften things out of any pity for me,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service, either by word or deed, when you
+Achaeans were harassed among the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+"My friend," answered Nestor, "you recall a time of much sorrow to
+my mind, for the brave Achaeans suffered much both at sea, while
+privateering under Achilles, and when fighting before the great city
+of king Priam. Our best men all of them fell there--Ajax, Achilles,
+Patroclus peer of gods in counsel, and my own dear son Antilochus, a man
+singularly fleet of foot and in fight valiant. But we suffered much more
+than this; what mortal tongue indeed could tell the whole story? Though
+you were to stay here and question me for five years, or even six, I
+could not tell you all that the Achaeans suffered, and you would turn
+homeward weary of my tale before it ended. Nine long years did we try
+every kind of stratagem, but the hand of heaven was against us; during
+all this time there was no one who could compare with your father in
+subtlety--if indeed you are his son--I can hardly believe my eyes--and
+you talk just like him too--no one would say that people of such
+different ages could speak so much alike. He and I never had any kind
+of difference from first to last neither in camp nor council, but in
+singleness of heart and purpose we advised the Argives how all might be
+ordered for the best.
+
+"When, however, we had sacked the city of Priam, and were setting sail
+in our ships as heaven had dispersed us, then Jove saw fit to vex the
+Argives on their homeward voyage; for they had not all been either
+wise or understanding, and hence many came to a bad end through the
+displeasure of Jove's daughter Minerva, who brought about a quarrel
+between the two sons of Atreus.
+
+"The sons of Atreus called a meeting which was not as it should be, for
+it was sunset and the Achaeans were heavy with wine. When they explained
+why they had called the people together, it seemed that Menelaus was
+for sailing homeward at once, and this displeased Agamemnon, who thought
+that we should wait till we had offered hecatombs to appease the anger
+of Minerva. Fool that he was, he might have known that he would not
+prevail with her, for when the gods have made up their minds they do not
+change them lightly. So the two stood bandying hard words, whereon the
+Achaeans sprang to their feet with a cry that rent the air, and were of
+two minds as to what they should do.
+
+"That night we rested and nursed our anger, for Jove was hatching
+mischief against us. But in the morning some of us drew our ships into
+the water and put our goods with our women on board, while the rest,
+about half in number, stayed behind with Agamemnon. We--the other
+half--embarked and sailed; and the ships went well, for heaven had
+smoothed the sea. When we reached Tenedos we offered sacrifices to the
+gods, for we were longing to get home; cruel Jove, however, did not yet
+mean that we should do so, and raised a second quarrel in the course of
+which some among us turned their ships back again, and sailed away under
+Ulysses to make their peace with Agamemnon; but I, and all the ships
+that were with me pressed forward, for I saw that mischief was brewing.
+The son of Tydeus went on also with me, and his crews with him. Later on
+Menelaus joined us at Lesbos, and found us making up our minds about our
+course--for we did not know whether to go outside Chios by the island
+of Psyra, keeping this to our left, or inside Chios, over against the
+stormy headland of Mimas. So we asked heaven for a sign, and were shown
+one to the effect that we should be soonest out of danger if we headed
+our ships across the open sea to Euboea. This we therefore did, and a
+fair wind sprang up which gave us a quick passage during the night to
+Geraestus, {29} where we offered many sacrifices to Neptune for
+having helped us so far on our way. Four days later Diomed and his men
+stationed their ships in Argos, but I held on for Pylos, and the wind
+never fell light from the day when heaven first made it fair for me.
+
+"Therefore, my dear young friend, I returned without hearing anything
+about the others. I know neither who got home safely nor who were lost
+but, as in duty bound, I will give you without reserve the reports that
+have reached me since I have been here in my own house. They say the
+Myrmidons returned home safely under Achilles' son Neoptolemus; so also
+did the valiant son of Poias, Philoctetes. Idomeneus, again, lost no men
+at sea, and all his followers who escaped death in the field got safe
+home with him to Crete. No matter how far out of the world you live, you
+will have heard of Agamemnon and the bad end he came to at the hands of
+Aegisthus--and a fearful reckoning did Aegisthus presently pay. See what
+a good thing it is for a man to leave a son behind him to do as Orestes
+did, who killed false Aegisthus the murderer of his noble father. You
+too, then--for you are a tall smart-looking fellow--show your mettle and
+make yourself a name in story."
+
+"Nestor son of Neleus," answered Telemachus, "honour to the Achaean
+name, the Achaeans applaud Orestes and his name will live through all
+time for he has avenged his father nobly. Would that heaven might grant
+me to do like vengeance on the insolence of the wicked suitors, who
+are ill treating me and plotting my ruin; but the gods have no such
+happiness in store for me and for my father, so we must bear it as best
+we may."
+
+"My friend," said Nestor, "now that you remind me, I remember to have
+heard that your mother has many suitors, who are ill disposed towards
+you and are making havoc of your estate. Do you submit to this tamely,
+or are public feeling and the voice of heaven against you? Who knows but
+what Ulysses may come back after all, and pay these scoundrels in full,
+either single-handed or with a force of Achaeans behind him? If Minerva
+were to take as great a liking to you as she did to Ulysses when we were
+fighting before Troy (for I never yet saw the gods so openly fond of any
+one as Minerva then was of your father), if she would take as good care
+of you as she did of him, these wooers would soon some of them forget
+their wooing."
+
+Telemachus answered, "I can expect nothing of the kind; it would be far
+too much to hope for. I dare not let myself think of it. Even though the
+gods themselves willed it no such good fortune could befall me."
+
+On this Minerva said, "Telemachus, what are you talking about? Heaven
+has a long arm if it is minded to save a man; and if it were me, I
+should not care how much I suffered before getting home, provided I
+could be safe when I was once there. I would rather this, than get home
+quickly, and then be killed in my own house as Agamemnon was by the
+treachery of Aegisthus and his wife. Still, death is certain, and when
+a man's hour is come, not even the gods can save him, no matter how fond
+they are of him."
+
+"Mentor," answered Telemachus, "do not let us talk about it any more.
+There is no chance of my father's ever coming back; the gods have long
+since counselled his destruction. There is something else, however,
+about which I should like to ask Nestor, for he knows much more than any
+one else does. They say he has reigned for three generations so that it
+is like talking to an immortal. Tell me, therefore, Nestor, and tell
+me true; how did Agamemnon come to die in that way? What was Menelaus
+doing? And how came false Aegisthus to kill so far better a man than
+himself? Was Menelaus away from Achaean Argos, voyaging elsewhither
+among mankind, that Aegisthus took heart and killed Agamemnon?"
+
+"I will tell you truly," answered Nestor, "and indeed you have yourself
+divined how it all happened. If Menelaus when he got back from Troy
+had found Aegisthus still alive in his house, there would have been no
+barrow heaped up for him, not even when he was dead, but he would have
+been thrown outside the city to dogs and vultures, and not a woman would
+have mourned him, for he had done a deed of great wickedness; but we
+were over there, fighting hard at Troy, and Aegisthus, who was taking
+his ease quietly in the heart of Argos, cajoled Agamemnon's wife
+Clytemnestra with incessant flattery.
+
+"At first she would have nothing to do with his wicked scheme, for she
+was of a good natural disposition; {30} moreover there was a bard with
+her, to whom Agamemnon had given strict orders on setting out for Troy,
+that he was to keep guard over his wife; but when heaven had counselled
+her destruction, Aegisthus carried this bard off to a desert island and
+left him there for crows and seagulls to batten upon--after which she
+went willingly enough to the house of Aegisthus. Then he offered many
+burnt sacrifices to the gods, and decorated many temples with tapestries
+and gilding, for he had succeeded far beyond his expectations.
+
+"Meanwhile Menelaus and I were on our way home from Troy, on good terms
+with one another. When we got to Sunium, which is the point of Athens,
+Apollo with his painless shafts killed Phrontis the steersman of
+Menelaus' ship (and never man knew better how to handle a vessel in
+rough weather) so that he died then and there with the helm in his hand,
+and Menelaus, though very anxious to press forward, had to wait in order
+to bury his comrade and give him his due funeral rites. Presently, when
+he too could put to sea again, and had sailed on as far as the Malean
+heads, Jove counselled evil against him and made it blow hard till the
+waves ran mountains high. Here he divided his fleet and took the one
+half towards Crete where the Cydonians dwell round about the waters of
+the river Iardanus. There is a high headland hereabouts stretching out
+into the sea from a place called Gortyn, and all along this part of the
+coast as far as Phaestus the sea runs high when there is a south wind
+blowing, but after Phaestus the coast is more protected, for a small
+headland can make a great shelter. Here this part of the fleet was
+driven on to the rocks and wrecked; but the crews just managed to save
+themselves. As for the other five ships, they were taken by winds and
+seas to Egypt, where Menelaus gathered much gold and substance among
+people of an alien speech. Meanwhile Aegisthus here at home plotted his
+evil deed. For seven years after he had killed Agamemnon he ruled in
+Mycene, and the people were obedient under him, but in the eighth year
+Orestes came back from Athens to be his bane, and killed the murderer
+of his father. Then he celebrated the funeral rites of his mother and
+of false Aegisthus by a banquet to the people of Argos, and on that very
+day Menelaus came home, {31} with as much treasure as his ships could
+carry.
+
+"Take my advice then, and do not go travelling about for long so far
+from home, nor leave your property with such dangerous people in your
+house; they will eat up everything you have among them, and you will
+have been on a fool's errand. Still, I should advise you by all means
+to go and visit Menelaus, who has lately come off a voyage among such
+distant peoples as no man could ever hope to get back from, when the
+winds had once carried him so far out of his reckoning; even birds
+cannot fly the distance in a twelve-month, so vast and terrible are the
+seas that they must cross. Go to him, therefore, by sea, and take your
+own men with you; or if you would rather travel by land you can have a
+chariot, you can have horses, and here are my sons who can escort you to
+Lacedaemon where Menelaus lives. Beg of him to speak the truth, and he
+will tell you no lies, for he is an excellent person."
+
+As he spoke the sun set and it came on dark, whereon Minerva said, "Sir,
+all that you have said is well; now, however, order the tongues of the
+victims to be cut, and mix wine that we may make drink-offerings to
+Neptune, and the other immortals, and then go to bed, for it is bed
+time. People should go away early and not keep late hours at a religious
+festival."
+
+Thus spoke the daughter of Jove, and they obeyed her saying. Men
+servants poured water over the hands of the guests, while pages filled
+the mixing-bowls with wine and water, and handed it round after giving
+every man his drink offering; then they threw the tongues of the victims
+into the fire, and stood up to make their drink offerings. When they
+had made their offerings and had drunk each as much as he was minded,
+Minerva and Telemachus were for going on board their ship, but Nestor
+caught them up at once and stayed them.
+
+"Heaven and the immortal gods," he exclaimed, "forbid that you should
+leave my house to go on board of a ship. Do you think I am so poor and
+short of clothes, or that I have so few cloaks and as to be unable to
+find comfortable beds both for myself and for my guests? Let me tell you
+I have store both of rugs and cloaks, and shall not permit the son of
+my old friend Ulysses to camp down on the deck of a ship--not while I
+live--nor yet will my sons after me, but they will keep open house as I
+have done."
+
+Then Minerva answered, "Sir, you have spoken well, and it will be much
+better that Telemachus should do as you have said; he, therefore, shall
+return with you and sleep at your house, but I must go back to give
+orders to my crew, and keep them in good heart. I am the only older
+person among them; the rest are all young men of Telemachus' own age,
+who have taken this voyage out of friendship; so I must return to the
+ship and sleep there. Moreover to-morrow I must go to the Cauconians
+where I have a large sum of money long owing to me. As for Telemachus,
+now that he is your guest, send him to Lacedaemon in a chariot, and let
+one of your sons go with him. Be pleased to also provide him with your
+best and fleetest horses."
+
+When she had thus spoken, she flew away in the form of an eagle, and all
+marvelled as they beheld it. Nestor was astonished, and took Telemachus
+by the hand. "My friend," said he, "I see that you are going to be a
+great hero some day, since the gods wait upon you thus while you are
+still so young. This can have been none other of those who dwell in
+heaven than Jove's redoubtable daughter, the Trito-born, who shewed
+such favour towards your brave father among the Argives. Holy queen," he
+continued, "vouchsafe to send down thy grace upon myself, my good wife,
+and my children. In return, I will offer you in sacrifice a broad-browed
+heifer of a year old, unbroken, and never yet brought by man under the
+yoke. I will gild her horns, and will offer her up to you in sacrifice."
+
+Thus did he pray, and Minerva heard his prayer. He then led the way to
+his own house, followed by his sons and sons in law. When they had got
+there and had taken their places on the benches and seats, he mixed them
+a bowl of sweet wine that was eleven years old when the housekeeper took
+the lid off the jar that held it. As he mixed the wine, he prayed much
+and made drink offerings to Minerva, daughter of Aegis-bearing Jove.
+Then, when they had made their drink offerings and had drunk each as
+much as he was minded, the others went home to bed each in his own
+abode; but Nestor put Telemachus to sleep in the room that was over the
+gateway along with Pisistratus, who was the only unmarried son now left
+him. As for himself, he slept in an inner room of the house, with the
+queen his wife by his side.
+
+Now when the child of morning rosy-fingered Dawn appeared, Nestor left
+his couch and took his seat on the benches of white and polished marble
+that stood in front of his house. Here aforetime sat Neleus, peer of
+gods in counsel, but he was now dead, and had gone to the house of
+Hades; so Nestor sat in his seat sceptre in hand, as guardian of the
+public weal. His sons as they left their rooms gathered round him,
+Echephron, Stratius, Perseus, Aretus, and Thrasymedes; the sixth son
+was Pisistratus, and when Telemachus joined them they made him sit with
+them. Nestor then addressed them.
+
+"My sons," said he, "make haste to do as I shall bid you. I wish first
+and foremost to propitiate the great goddess Minerva, who manifested
+herself visibly to me during yesterday's festivities. Go, then, one or
+other of you to the plain, tell the stockman to look me out a heifer,
+and come on here with it at once. Another must go to Telemachus' ship,
+and invite all the crew, leaving two men only in charge of the vessel.
+Some one else will run and fetch Laerceus the goldsmith to gild the
+horns of the heifer. The rest, stay all of you where you are; tell the
+maids in the house to prepare an excellent dinner, and to fetch seats,
+and logs of wood for a burnt offering. Tell them also to bring me some
+clear spring water."
+
+On this they hurried off on their several errands. The heifer was
+brought in from the plain, and Telemachus's crew came from the ship; the
+goldsmith brought the anvil, hammer, and tongs, with which he worked his
+gold, and Minerva herself came to accept the sacrifice. Nestor gave out
+the gold, and the smith gilded the horns of the heifer that the goddess
+might have pleasure in their beauty. Then Stratius and Echephron brought
+her in by the horns; Aretus fetched water from the house in a ewer that
+had a flower pattern on it, and in his other hand he held a basket of
+barley meal; sturdy Thrasymedes stood by with a sharp axe, ready to
+strike the heifer, while Perseus held a bucket. Then Nestor began with
+washing his hands and sprinkling the barley meal, and he offered many
+a prayer to Minerva as he threw a lock from the heifer's head upon the
+fire.
+
+When they had done praying and sprinkling the barley meal {32}
+Thrasymedes dealt his blow, and brought the heifer down with a stroke
+that cut through the tendons at the base of her neck, whereon the
+daughters and daughters in law of Nestor, and his venerable wife
+Eurydice (she was eldest daughter to Clymenus) screamed with delight.
+Then they lifted the heifer's head from off the ground, and Pisistratus
+cut her throat. When she had done bleeding and was quite dead, they cut
+her up. They cut out the thigh bones all in due course, wrapped them
+round in two layers of fat, and set some pieces of raw meat on the top
+of them; then Nestor laid them upon the wood fire and poured wine over
+them, while the young men stood near him with five-pronged spits in
+their hands. When the thighs were burned and they had tasted the inward
+meats, they cut the rest of the meat up small, put the pieces on the
+spits and toasted them over the fire.
+
+Meanwhile lovely Polycaste, Nestor's youngest daughter, washed
+Telemachus. When she had washed him and anointed him with oil, she
+brought him a fair mantle and shirt, {33} and he looked like a god as
+he came from the bath and took his seat by the side of Nestor. When
+the outer meats were done they drew them off the spits and sat down to
+dinner where they were waited upon by some worthy henchmen, who kept
+pouring them out their wine in cups of gold. As soon as they had had
+enough to eat and drink Nestor said, "Sons, put Telemachus's horses to
+the chariot that he may start at once."
+
+Thus did he speak, and they did even as he had said, and yoked the fleet
+horses to the chariot. The housekeeper packed them up a provision
+of bread, wine, and sweet meats fit for the sons of princes. Then
+Telemachus got into the chariot, while Pisistratus gathered up the reins
+and took his seat beside him. He lashed the horses on and they flew
+forward nothing loth into the open country, leaving the high citadel of
+Pylos behind them. All that day did they travel, swaying the yoke upon
+their necks till the sun went down and darkness was over all the land.
+Then they reached Pherae where Diocles lived, who was son to Ortilochus
+and grandson to Alpheus. Here they passed the night and Diocles
+entertained them hospitably. When the child of morning, rosy-fingered
+Dawn, appeared, they again yoked their horses and drove out through the
+gateway under the echoing gatehouse. {34} Pisistratus lashed the horses
+on and they flew forward nothing loth; presently they came to the corn
+lands of the open country, and in the course of time completed their
+journey, so well did their steeds take them. {35}
+
+Now when the sun had set and darkness was over the land,
+
+
+Book IV
+
+THE VISIT TO KING MENELAUS, WHO TELLS HIS STORY--MEANWHILE THE SUITORS
+IN ITHACA PLOT AGAINST TELEMACHUS.
+
+they reached the low lying city of Lacedaemon, where they drove straight
+to the abode of Menelaus {36} [and found him in his own house, feasting
+with his many clansmen in honour of the wedding of his son, and also of
+his daughter, whom he was marrying to the son of that valiant warrior
+Achilles. He had given his consent and promised her to him while he was
+still at Troy, and now the gods were bringing the marriage about; so he
+was sending her with chariots and horses to the city of the Myrmidons
+over whom Achilles' son was reigning. For his only son he had found a
+bride from Sparta, {37} the daughter of Alector. This son, Megapenthes,
+was born to him of a bondwoman, for heaven vouchsafed Helen no more
+children after she had borne Hermione, who was fair as golden Venus
+herself.
+
+So the neighbours and kinsmen of Menelaus were feasting and making merry
+in his house. There was a bard also to sing to them and play his lyre,
+while two tumblers went about performing in the midst of them when the
+man struck up with his tune.] {38}
+
+Telemachus and the son of Nestor stayed their horses at the gate,
+whereon Eteoneus servant to Menelaus came out, and as soon as he saw
+them ran hurrying back into the house to tell his Master. He went close
+up to him and said, "Menelaus, there are some strangers come here, two
+men, who look like sons of Jove. What are we to do? Shall we take their
+horses out, or tell them to find friends elsewhere as they best can?"
+
+Menelaus was very angry and said, "Eteoneus, son of Boethous, you never
+used to be a fool, but now you talk like a simpleton. Take their horses
+out, of course, and show the strangers in that they may have supper;
+you and I have staid often enough at other people's houses before we got
+back here, where heaven grant that we may rest in peace henceforward."
+
+So Eteoneus bustled back and bade the other servants come with him. They
+took their sweating steeds from under the yoke, made them fast to the
+mangers, and gave them a feed of oats and barley mixed. Then they leaned
+the chariot against the end wall of the courtyard, and led the way into
+the house. Telemachus and Pisistratus were astonished when they saw it,
+for its splendour was as that of the sun and moon; then, when they had
+admired everything to their heart's content, they went into the bath
+room and washed themselves.
+
+When the servants had washed them and anointed them with oil, they
+brought them woollen cloaks and shirts, and the two took their seats by
+the side of Menelaus. A maid-servant brought them water in a beautiful
+golden ewer, and poured it into a silver basin for them to wash their
+hands; and she drew a clean table beside them. An upper servant brought
+them bread, and offered them many good things of what there was in the
+house, while the carver fetched them plates of all manner of meats and
+set cups of gold by their side.
+
+Menelaus then greeted them saying, "Fall to, and welcome; when you have
+done supper I shall ask who you are, for the lineage of such men as
+you cannot have been lost. You must be descended from a line of
+sceptre-bearing kings, for poor people do not have such sons as you
+are."
+
+On this he handed them {39} a piece of fat roast loin, which had been
+set near him as being a prime part, and they laid their hands on the
+good things that were before them; as soon as they had had enough to eat
+and drink, Telemachus said to the son of Nestor, with his head so close
+that no one might hear, "Look, Pisistratus, man after my own heart,
+see the gleam of bronze and gold--of amber, {40} ivory, and silver.
+Everything is so splendid that it is like seeing the palace of Olympian
+Jove. I am lost in admiration."
+
+Menelaus overheard him and said, "No one, my sons, can hold his own
+with Jove, for his house and everything about him is immortal; but among
+mortal men--well, there may be another who has as much wealth as I
+have, or there may not; but at all events I have travelled much and have
+undergone much hardship, for it was nearly eight years before I could
+get home with my fleet. I went to Cyprus, Phoenicia and the Egyptians;
+I went also to the Ethiopians, the Sidonians, and the Erembians, and to
+Libya where the lambs have horns as soon as they are born, and the sheep
+lamb down three times a year. Every one in that country, whether master
+or man, has plenty of cheese, meat, and good milk, for the ewes yield
+all the year round. But while I was travelling and getting great riches
+among these people, my brother was secretly and shockingly murdered
+through the perfidy of his wicked wife, so that I have no pleasure in
+being lord of all this wealth. Whoever your parents may be they must
+have told you about all this, and of my heavy loss in the ruin {41} of a
+stately mansion fully and magnificently furnished. Would that I had only
+a third of what I now have so that I had stayed at home, and all those
+were living who perished on the plain of Troy, far from Argos. I often
+grieve, as I sit here in my house, for one and all of them. At times
+I cry aloud for sorrow, but presently I leave off again, for crying is
+cold comfort and one soon tires of it. Yet grieve for these as I may,
+I do so for one man more than for them all. I cannot even think of him
+without loathing both food and sleep, so miserable does he make me, for
+no one of all the Achaeans worked so hard or risked so much as he did.
+He took nothing by it, and has left a legacy of sorrow to myself, for he
+has been gone a long time, and we know not whether he is alive or
+dead. His old father, his long-suffering wife Penelope, and his son
+Telemachus, whom he left behind him an infant in arms, are plunged in
+grief on his account."
+
+Thus spoke Menelaus, and the heart of Telemachus yearned as he bethought
+him of his father. Tears fell from his eyes as he heard him thus
+mentioned, so that he held his cloak before his face with both hands.
+When Menelaus saw this he doubted whether to let him choose his own time
+for speaking, or to ask him at once and find what it was all about.
+
+While he was thus in two minds Helen came down from her high vaulted and
+perfumed room, looking as lovely as Diana herself. Adraste brought her
+a seat, Alcippe a soft woollen rug while Phylo fetched her the silver
+work-box which Alcandra wife of Polybus had given her. Polybus lived in
+Egyptian Thebes, which is the richest city in the whole world; he gave
+Menelaus two baths, both of pure silver, two tripods, and ten talents of
+gold; besides all this, his wife gave Helen some beautiful presents, to
+wit, a golden distaff, and a silver work box that ran on wheels, with a
+gold band round the top of it. Phylo now placed this by her side, full
+of fine spun yarn, and a distaff charged with violet coloured wool was
+laid upon the top of it. Then Helen took her seat, put her feet upon the
+footstool, and began to question her husband. {42}
+
+"Do we know, Menelaus," said she, "the names of these strangers who
+have come to visit us? Shall I guess right or wrong?--but I cannot help
+saying what I think. Never yet have I seen either man or woman so like
+somebody else (indeed when I look at him I hardly know what to think)
+as this young man is like Telemachus, whom Ulysses left as a baby behind
+him, when you Achaeans went to Troy with battle in your hearts, on
+account of my most shameless self."
+
+"My dear wife," replied Menelaus, "I see the likeness just as you do.
+His hands and feet are just like Ulysses; so is his hair, with the shape
+of his head and the expression of his eyes. Moreover, when I was talking
+about Ulysses, and saying how much he had suffered on my account, tears
+fell from his eyes, and he hid his face in his mantle."
+
+Then Pisistratus said, "Menelaus, son of Atreus, you are right in
+thinking that this young man is Telemachus, but he is very modest, and
+is ashamed to come here and begin opening up discourse with one whose
+conversation is so divinely interesting as your own. My father, Nestor,
+sent me to escort him hither, for he wanted to know whether you could
+give him any counsel or suggestion. A son has always trouble at home
+when his father has gone away leaving him without supporters; and this
+is how Telemachus is now placed, for his father is absent, and there is
+no one among his own people to stand by him."
+
+"Bless my heart," replied Menelaus, "then I am receiving a visit from
+the son of a very dear friend, who suffered much hardship for my sake.
+I had always hoped to entertain him with most marked distinction when
+heaven had granted us a safe return from beyond the seas. I should have
+founded a city for him in Argos, and built him a house. I should have
+made him leave Ithaca with his goods, his son, and all his people, and
+should have sacked for them some one of the neighbouring cities that
+are subject to me. We should thus have seen one another continually,
+and nothing but death could have interrupted so close and happy an
+intercourse. I suppose, however, that heaven grudged us such great good
+fortune, for it has prevented the poor fellow from ever getting home at
+all."
+
+Thus did he speak, and his words set them all a weeping. Helen wept,
+Telemachus wept, and so did Menelaus, nor could Pisistratus keep his
+eyes from filling, when he remembered his dear brother Antilochus whom
+the son of bright Dawn had killed. Thereon he said to Menelaus,
+
+"Sir, my father Nestor, when we used to talk about you at home, told me
+you were a person of rare and excellent understanding. If, then, it be
+possible, do as I would urge you. I am not fond of crying while I am
+getting my supper. Morning will come in due course, and in the forenoon
+I care not how much I cry for those that are dead and gone. This is all
+we can do for the poor things. We can only shave our heads for them and
+wring the tears from our cheeks. I had a brother who died at Troy; he
+was by no means the worst man there; you are sure to have known him--his
+name was Antilochus; I never set eyes upon him myself, but they say that
+he was singularly fleet of foot and in fight valiant."
+
+"Your discretion, my friend," answered Menelaus, "is beyond your years.
+It is plain you take after your father. One can soon see when a man
+is son to one whom heaven has blessed both as regards wife and
+offspring--and it has blessed Nestor from first to last all his days,
+giving him a green old age in his own house, with sons about him who are
+both well disposed and valiant. We will put an end therefore to all this
+weeping, and attend to our supper again. Let water be poured over our
+hands. Telemachus and I can talk with one another fully in the morning."
+
+On this Asphalion, one of the servants, poured water over their hands
+and they laid their hands on the good things that were before them.
+
+Then Jove's daughter Helen bethought her of another matter. She drugged
+the wine with an herb that banishes all care, sorrow, and ill humour.
+Whoever drinks wine thus drugged cannot shed a single tear all the rest
+of the day, not even though his father and mother both of them drop down
+dead, or he sees a brother or a son hewn in pieces before his very eyes.
+This drug, of such sovereign power and virtue, had been given to Helen
+by Polydamna wife of Thon, a woman of Egypt, where there grow all sorts
+of herbs, some good to put into the mixing bowl and others poisonous.
+Moreover, every one in the whole country is a skilled physician, for
+they are of the race of Paeeon. When Helen had put this drug in the
+bowl, and had told the servants to serve the wine round, she said:
+
+"Menelaus, son of Atreus, and you my good friends, sons of honourable
+men (which is as Jove wills, for he is the giver both of good and evil,
+and can do what he chooses), feast here as you will, and listen while I
+tell you a tale in season. I cannot indeed name every single one of the
+exploits of Ulysses, but I can say what he did when he was before Troy,
+and you Achaeans were in all sorts of difficulties. He covered himself
+with wounds and bruises, dressed himself all in rags, and entered the
+enemy's city looking like a menial or a beggar, and quite different
+from what he did when he was among his own people. In this disguise
+he entered the city of Troy, and no one said anything to him. I alone
+recognised him and began to question him, but he was too cunning for me.
+When, however, I had washed and anointed him and had given him clothes,
+and after I had sworn a solemn oath not to betray him to the Trojans
+till he had got safely back to his own camp and to the ships, he told me
+all that the Achaeans meant to do. He killed many Trojans and got much
+information before he reached the Argive camp, for all which things the
+Trojan women made lamentation, but for my own part I was glad, for my
+heart was beginning to yearn after my home, and I was unhappy about
+the wrong that Venus had done me in taking me over there, away from
+my country, my girl, and my lawful wedded husband, who is indeed by no
+means deficient either in person or understanding."
+
+Then Menelaus said, "All that you have been saying, my dear wife, is
+true. I have travelled much, and have had much to do with heroes, but
+I have never seen such another man as Ulysses. What endurance too,
+and what courage he displayed within the wooden horse, wherein all the
+bravest of the Argives were lying in wait to bring death and destruction
+upon the Trojans. {43} At that moment you came up to us; some god
+who wished well to the Trojans must have set you on to it and you had
+Deiphobus with you. Three times did you go all round our hiding place
+and pat it; you called our chiefs each by his own name, and mimicked
+all our wives--Diomed, Ulysses, and I from our seats inside heard what
+a noise you made. Diomed and I could not make up our minds whether to
+spring out then and there, or to answer you from inside, but Ulysses
+held us all in check, so we sat quite still, all except Anticlus, who
+was beginning to answer you, when Ulysses clapped his two brawny hands
+over his mouth, and kept them there. It was this that saved us all, for
+he muzzled Anticlus till Minerva took you away again."
+
+"How sad," exclaimed Telemachus, "that all this was of no avail to save
+him, nor yet his own iron courage. But now, sir, be pleased to send us
+all to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+On this Helen told the maid servants to set beds in the room that was in
+the gatehouse, and to make them with good red rugs, and spread coverlets
+on the top of them with woollen cloaks for the guests to wear. So
+the maids went out, carrying a torch, and made the beds, to which
+a man-servant presently conducted the strangers. Thus, then, did
+Telemachus and Pisistratus sleep there in the forecourt, while the son
+of Atreus lay in an inner room with lovely Helen by his side.
+
+When the child of morning, rosy-fingered Dawn appeared, Menelaus rose
+and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulders, and left his room looking like an
+immortal god. Then, taking a seat near Telemachus he said:
+
+"And what, Telemachus, has led you to take this long sea voyage to
+Lacedaemon? Are you on public, or private business? Tell me all about
+it."
+
+"I have come, sir," replied Telemachus, "to see if you can tell me
+anything about my father. I am being eaten out of house and home; my
+fair estate is being wasted, and my house is full of miscreants who keep
+killing great numbers of my sheep and oxen, on the pretence of paying
+their addresses to my mother. Therefore, I am suppliant at your knees if
+haply you may tell me about my father's melancholy end, whether you saw
+it with your own eyes, or heard it from some other traveller; for he was
+a man born to trouble. Do not soften things out of any pity for myself,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service either by word or deed, when you
+Achaeans were harassed by the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+Menelaus on hearing this was very much shocked. "So," he exclaimed,
+"these cowards would usurp a brave man's bed? A hind might as well lay
+her new born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell: the lion when he comes back to his lair
+will make short work with the pair of them--and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Achaeans cheered him--if he is still
+such and were to come near these suitors, they would have a short shrift
+and a sorry wedding. As regards your questions, however, I will not
+prevaricate nor deceive you, but will tell you without concealment all
+that the old man of the sea told me.
+
+"I was trying to come on here, but the gods detained me in Egypt, for
+my hecatombs had not given them full satisfaction, and the gods are very
+strict about having their dues. Now off Egypt, about as far as a ship
+can sail in a day with a good stiff breeze behind her, there is an
+island called Pharos--it has a good harbour from which vessels can
+get out into open sea when they have taken in water--and here the gods
+becalmed me twenty days without so much as a breath of fair wind to help
+me forward. We should have run clean out of provisions and my men would
+have starved, if a goddess had not taken pity upon me and saved me in
+the person of Idothea, daughter to Proteus, the old man of the sea, for
+she had taken a great fancy to me.
+
+"She came to me one day when I was by myself, as I often was, for the
+men used to go with their barbed hooks, all over the island in the
+hope of catching a fish or two to save them from the pangs of hunger.
+'Stranger,' said she, 'it seems to me that you like starving in this
+way--at any rate it does not greatly trouble you, for you stick here day
+after day, without even trying to get away though your men are dying by
+inches.'
+
+"'Let me tell you,' said I, 'whichever of the goddesses you may happen
+to be, that I am not staying here of my own accord, but must have
+offended the gods that live in heaven. Tell me, therefore, for the gods
+know everything, which of the immortals it is that is hindering me in
+this way, and tell me also how I may sail the sea so as to reach my
+home.'
+
+"'Stranger,' replied she, 'I will make it all quite clear to you. There
+is an old immortal who lives under the sea hereabouts and whose name
+is Proteus. He is an Egyptian, and people say he is my father; he is
+Neptune's head man and knows every inch of ground all over the bottom of
+the sea. If you can snare him and hold him tight, he will tell you about
+your voyage, what courses you are to take, and how you are to sail the
+sea so as to reach your home. He will also tell you, if you so will, all
+that has been going on at your house both good and bad, while you have
+been away on your long and dangerous journey.'
+
+"'Can you show me,' said I, 'some stratagem by means of which I may
+catch this old god without his suspecting it and finding me out? For a
+god is not easily caught--not by a mortal man.'
+
+"'Stranger,' said she, 'I will make it all quite clear to you. About the
+time when the sun shall have reached mid heaven, the old man of the sea
+comes up from under the waves, heralded by the West wind that furs the
+water over his head. As soon as he has come up he lies down, and goes to
+sleep in a great sea cave, where the seals--Halosydne's chickens as they
+call them--come up also from the grey sea, and go to sleep in shoals
+all round him; and a very strong and fish-like smell do they bring with
+them. {44} Early to-morrow morning I will take you to this place and
+will lay you in ambush. Pick out, therefore, the three best men you have
+in your fleet, and I will tell you all the tricks that the old man will
+play you.
+
+"'First he will look over all his seals, and count them; then, when he
+has seen them and tallied them on his five fingers, he will go to sleep
+among them, as a shepherd among his sheep. The moment you see that he is
+asleep seize him; put forth all your strength and hold him fast, for he
+will do his very utmost to get away from you. He will turn himself into
+every kind of creature that goes upon the earth, and will become also
+both fire and water; but you must hold him fast and grip him tighter
+and tighter, till he begins to talk to you and comes back to what he was
+when you saw him go to sleep; then you may slacken your hold and let him
+go; and you can ask him which of the gods it is that is angry with you,
+and what you must do to reach your home over the seas.'
+
+"Having so said she dived under the waves, whereon I turned back to
+the place where my ships were ranged upon the shore; and my heart was
+clouded with care as I went along. When I reached my ship we got supper
+ready, for night was falling, and camped down upon the beach.
+
+"When the child of morning rosy-fingered Dawn appeared, I took the three
+men on whose prowess of all kinds I could most rely, and went along by
+the sea-side, praying heartily to heaven. Meanwhile the goddess fetched
+me up four seal skins from the bottom of the sea, all of them just
+skinned, for she meant playing a trick upon her father. Then she dug
+four pits for us to lie in, and sat down to wait till we should come up.
+When we were close to her, she made us lie down in the pits one after
+the other, and threw a seal skin over each of us. Our ambuscade would
+have been intolerable, for the stench of the fishy seals was most
+distressing {45}--who would go to bed with a sea monster if he could
+help it?--but here, too, the goddess helped us, and thought of something
+that gave us great relief, for she put some ambrosia under each man's
+nostrils, which was so fragrant that it killed the smell of the seals.
+{46}
+
+"We waited the whole morning and made the best of it, watching the seals
+come up in hundreds to bask upon the sea shore, till at noon the old man
+of the sea came up too, and when he had found his fat seals he went over
+them and counted them. We were among the first he counted, and he never
+suspected any guile, but laid himself down to sleep as soon as he had
+done counting. Then we rushed upon him with a shout and seized him; on
+which he began at once with his old tricks, and changed himself first
+into a lion with a great mane; then all of a sudden he became a dragon,
+a leopard, a wild boar; the next moment he was running water, and then
+again directly he was a tree, but we stuck to him and never lost hold,
+till at last the cunning old creature became distressed, and said,
+'Which of the gods was it, Son of Atreus, that hatched this plot with
+you for snaring me and seizing me against my will? What do you want?'
+
+"'You know that yourself, old man,' I answered, 'you will gain nothing
+by trying to put me off. It is because I have been kept so long in this
+island, and see no sign of my being able to get away. I am losing
+all heart; tell me, then, for you gods know everything, which of the
+immortals it is that is hindering me, and tell me also how I may sail
+the sea so as to reach my home?'
+
+"Then,' he said, 'if you would finish your voyage and get home quickly,
+you must offer sacrifices to Jove and to the rest of the gods before
+embarking; for it is decreed that you shall not get back to your
+friends, and to your own house, till you have returned to the heaven-fed
+stream of Egypt, and offered holy hecatombs to the immortal gods that
+reign in heaven. When you have done this they will let you finish your
+voyage.'
+
+"I was broken hearted when I heard that I must go back all that long and
+terrible voyage to Egypt; {47} nevertheless, I answered, 'I will do all,
+old man, that you have laid upon me; but now tell me, and tell me true,
+whether all the Achaeans whom Nestor and I left behind us when we set
+sail from Troy have got home safely, or whether any one of them came
+to a bad end either on board his own ship or among his friends when the
+days of his fighting were done.'
+
+"'Son of Atreus,' he answered, 'why ask me? You had better not know what
+I can tell you, for your eyes will surely fill when you have heard my
+story. Many of those about whom you ask are dead and gone, but many
+still remain, and only two of the chief men among the Achaeans
+perished during their return home. As for what happened on the field of
+battle--you were there yourself. A third Achaean leader is still at sea,
+alive, but hindered from returning. Ajax was wrecked, for Neptune drove
+him on to the great rocks of Gyrae; nevertheless, he let him get safe
+out of the water, and in spite of all Minerva's hatred he would have
+escaped death, if he had not ruined himself by boasting. He said the
+gods could not drown him even though they had tried to do so, and when
+Neptune heard this large talk, he seized his trident in his two brawny
+hands, and split the rock of Gyrae in two pieces. The base remained
+where it was, but the part on which Ajax was sitting fell headlong
+into the sea and carried Ajax with it; so he drank salt water and was
+drowned.
+
+"'Your brother and his ships escaped, for Juno protected him, but when
+he was just about to reach the high promontory of Malea, he was caught
+by a heavy gale which carried him out to sea again sorely against his
+will, and drove him to the foreland where Thyestes used to dwell, but
+where Aegisthus was then living. By and by, however, it seemed as though
+he was to return safely after all, for the gods backed the wind into its
+old quarter and they reached home; whereon Agamemnon kissed his native
+soil, and shed tears of joy at finding himself in his own country.
+
+"'Now there was a watchman whom Aegisthus kept always on the watch, and
+to whom he had promised two talents of gold. This man had been looking
+out for a whole year to make sure that Agamemnon did not give him the
+slip and prepare war; when, therefore, this man saw Agamemnon go by,
+he went and told Aegisthus, who at once began to lay a plot for him. He
+picked twenty of his bravest warriors and placed them in ambuscade on
+one side the cloister, while on the opposite side he prepared a banquet.
+Then he sent his chariots and horsemen to Agamemnon, and invited him to
+the feast, but he meant foul play. He got him there, all unsuspicious of
+the doom that was awaiting him, and killed him when the banquet was
+over as though he were butchering an ox in the shambles; not one of
+Agamemnon's followers was left alive, nor yet one of Aegisthus', but
+they were all killed there in the cloisters.'
+
+"Thus spoke Proteus, and I was broken hearted as I heard him. I sat down
+upon the sands and wept; I felt as though I could no longer bear to live
+nor look upon the light of the sun. Presently, when I had had my fill of
+weeping and writhing upon the ground, the old man of the sea said, 'Son
+of Atreus, do not waste any more time in crying so bitterly; it can
+do no manner of good; find your way home as fast as ever you can,
+for Aegisthus may be still alive, and even though Orestes has been
+beforehand with you in killing him, you may yet come in for his
+funeral.'
+
+"On this I took comfort in spite of all my sorrow, and said, 'I know,
+then, about these two; tell me, therefore, about the third man of whom
+you spoke; is he still alive, but at sea, and unable to get home? or is
+he dead? Tell me, no matter how much it may grieve me.'
+
+"'The third man,' he answered, 'is Ulysses who dwells in Ithaca. I
+can see him in an island sorrowing bitterly in the house of the nymph
+Calypso, who is keeping him prisoner, and he cannot reach his home for
+he has no ships nor sailors to take him over the sea. As for your own
+end, Menelaus, you shall not die in Argos, but the gods will take you to
+the Elysian plain, which is at the ends of the world. There fair-haired
+Rhadamanthus reigns, and men lead an easier life than any where else in
+the world, for in Elysium there falls not rain, nor hail, nor snow, but
+Oceanus breathes ever with a West wind that sings softly from the sea,
+and gives fresh life to all men. This will happen to you because you
+have married Helen, and are Jove's son-in-law.'
+
+"As he spoke he dived under the waves, whereon I turned back to the
+ships with my companions, and my heart was clouded with care as I went
+along. When we reached the ships we got supper ready, for night was
+falling, and camped down upon the beach. When the child of morning,
+rosy-fingered Dawn appeared, we drew our ships into the water, and put
+our masts and sails within them; then we went on board ourselves, took
+our seats on the benches, and smote the grey sea with our oars. I
+again stationed my ships in the heaven-fed stream of Egypt, and offered
+hecatombs that were full and sufficient. When I had thus appeased
+heaven's anger, I raised a barrow to the memory of Agamemnon that his
+name might live for ever, after which I had a quick passage home, for
+the gods sent me a fair wind.
+
+"And now for yourself--stay here some ten or twelve days longer, and I
+will then speed you on your way. I will make you a noble present of a
+chariot and three horses. I will also give you a beautiful chalice
+that so long as you live you may think of me whenever you make a
+drink-offering to the immortal gods."
+
+"Son of Atreus," replied Telemachus, "do not press me to stay longer; I
+should be contented to remain with you for another twelve months; I find
+your conversation so delightful that I should never once wish myself at
+home with my parents; but my crew whom I have left at Pylos are already
+impatient, and you are detaining me from them. As for any present you
+may be disposed to make me, I had rather that it should be a piece of
+plate. I will take no horses back with me to Ithaca, but will leave them
+to adorn your own stables, for you have much flat ground in your kingdom
+where lotus thrives, as also meadow-sweet and wheat and barley, and oats
+with their white and spreading ears; whereas in Ithaca we have neither
+open fields nor racecourses, and the country is more fit for goats than
+horses, and I like it the better for that. {48} None of our islands have
+much level ground, suitable for horses, and Ithaca least of all."
+
+Menelaus smiled and took Telemachus's hand within his own. "What you
+say," said he, "shows that you come of good family. I both can, and
+will, make this exchange for you, by giving you the finest and most
+precious piece of plate in all my house. It is a mixing bowl by Vulcan's
+own hand, of pure silver, except the rim, which is inlaid with gold.
+Phaedimus, king of the Sidonians, gave it me in the course of a visit
+which I paid him when I returned thither on my homeward journey. I will
+make you a present of it."
+
+Thus did they converse [and guests kept coming to the king's house. They
+brought sheep and wine, while their wives had put up bread for them to
+take with them; so they were busy cooking their dinners in the courts].
+{49}
+
+Meanwhile the suitors were throwing discs or aiming with spears at
+a mark on the levelled ground in front of Ulysses' house, and were
+behaving with all their old insolence. Antinous and Eurymachus, who were
+their ringleaders and much the foremost among them all, were sitting
+together when Noemon son of Phronius came up and said to Antinous,
+
+"Have we any idea, Antinous, on what day Telemachus returns from Pylos?
+He has a ship of mine, and I want it, to cross over to Elis: I have
+twelve brood mares there with yearling mule foals by their side not yet
+broken in, and I want to bring one of them over here and break him."
+
+They were astounded when they heard this, for they had made sure that
+Telemachus had not gone to the city of Neleus. They thought he was
+only away somewhere on the farms, and was with the sheep, or with the
+swineherd; so Antinous said, "When did he go? Tell me truly, and
+what young men did he take with him? Were they freemen or his own
+bondsmen--for he might manage that too? Tell me also, did you let him
+have the ship of your own free will because he asked you, or did he take
+it without your leave?"
+
+"I lent it him," answered Noemon, "what else could I do when a man of
+his position said he was in a difficulty, and asked me to oblige him? I
+could not possibly refuse. As for those who went with him they were the
+best young men we have, and I saw Mentor go on board as captain--or some
+god who was exactly like him. I cannot understand it, for I saw Mentor
+here myself yesterday morning, and yet he was then setting out for
+Pylos."
+
+Noemon then went back to his father's house, but Antinous and Eurymachus
+were very angry. They told the others to leave off playing, and to come
+and sit down along with themselves. When they came, Antinous son of
+Eupeithes spoke in anger. His heart was black with rage, and his eyes
+flashed fire as he said:
+
+"Good heavens, this voyage of Telemachus is a very serious matter; we
+had made sure that it would come to nothing, but the young fellow has
+got away in spite of us, and with a picked crew too. He will be giving
+us trouble presently; may Jove take him before he is full grown. Find me
+a ship, therefore, with a crew of twenty men, and I will lie in wait for
+him in the straits between Ithaca and Samos; he will then rue the day
+that he set out to try and get news of his father."
+
+Thus did he speak, and the others applauded his saying; they then all of
+them went inside the buildings.
+
+It was not long ere Penelope came to know what the suitors were
+plotting; for a man servant, Medon, overheard them from outside the
+outer court as they were laying their schemes within, and went to tell
+his mistress. As he crossed the threshold of her room Penelope said:
+"Medon, what have the suitors sent you here for? Is it to tell the maids
+to leave their master's business and cook dinner for them? I wish they
+may neither woo nor dine henceforward, neither here nor anywhere else,
+but let this be the very last time, for the waste you all make of my
+son's estate. Did not your fathers tell you when you were children, how
+good Ulysses had been to them--never doing anything high-handed, nor
+speaking harshly to anybody? Kings may say things sometimes, and they
+may take a fancy to one man and dislike another, but Ulysses never did
+an unjust thing by anybody--which shows what bad hearts you have, and
+that there is no such thing as gratitude left in this world."
+
+Then Medon said, "I wish, Madam, that this were all; but they are
+plotting something much more dreadful now--may heaven frustrate their
+design. They are going to try and murder Telemachus as he is coming home
+from Pylos and Lacedaemon, where he has been to get news of his father."
+
+Then Penelope's heart sank within her, and for a long time she was
+speechless; her eyes filled with tears, and she could find no utterance.
+At last, however, she said, "Why did my son leave me? What business had
+he to go sailing off in ships that make long voyages over the ocean like
+sea-horses? Does he want to die without leaving any one behind him to
+keep up his name?"
+
+"I do not know," answered Medon, "whether some god set him on to it, or
+whether he went on his own impulse to see if he could find out if his
+father was dead, or alive and on his way home."
+
+Then he went downstairs again, leaving Penelope in an agony of grief.
+There were plenty of seats in the house, but she had no heart for
+sitting on any one of them; she could only fling herself on the floor of
+her own room and cry; whereon all the maids in the house, both old
+and young, gathered round her and began to cry too, till at last in a
+transport of sorrow she exclaimed,
+
+"My dears, heaven has been pleased to try me with more affliction
+than any other woman of my age and country. First I lost my brave and
+lion-hearted husband, who had every good quality under heaven, and whose
+name was great over all Hellas and middle Argos, and now my darling son
+is at the mercy of the winds and waves, without my having heard one word
+about his leaving home. You hussies, there was not one of you would so
+much as think of giving me a call out of my bed, though you all of you
+very well knew when he was starting. If I had known he meant taking this
+voyage, he would have had to give it up, no matter how much he was bent
+upon it, or leave me a corpse behind him--one or other. Now, however,
+go some of you and call old Dolius, who was given me by my father on my
+marriage, and who is my gardener. Bid him go at once and tell everything
+to Laertes, who may be able to hit on some plan for enlisting public
+sympathy on our side, as against those who are trying to exterminate his
+own race and that of Ulysses."
+
+Then the dear old nurse Euryclea said, "You may kill me, Madam, or let
+me live on in your house, whichever you please, but I will tell you the
+real truth. I knew all about it, and gave him everything he wanted in
+the way of bread and wine, but he made me take my solemn oath that I
+would not tell you anything for some ten or twelve days, unless you
+asked or happened to hear of his having gone, for he did not want you to
+spoil your beauty by crying. And now, Madam, wash your face, change
+your dress, and go upstairs with your maids to offer prayers to Minerva,
+daughter of Aegis-bearing Jove, for she can save him even though he
+be in the jaws of death. Do not trouble Laertes: he has trouble enough
+already. Besides, I cannot think that the gods hate the race of the son
+of Arceisius so much, but there will be a son left to come up after him,
+and inherit both the house and the fair fields that lie far all round
+it."
+
+With these words she made her mistress leave off crying, and dried the
+tears from her eyes. Penelope washed her face, changed her dress, and
+went upstairs with her maids. She then put some bruised barley into a
+basket and began praying to Minerva.
+
+"Hear me," she cried, "Daughter of Aegis-bearing Jove, unweariable. If
+ever Ulysses while he was here burned you fat thigh bones of sheep or
+heifer, bear it in mind now as in my favour, and save my darling son
+from the villainy of the suitors."
+
+She cried aloud as she spoke, and the goddess heard her prayer;
+meanwhile the suitors were clamorous throughout the covered cloister,
+and one of them said:
+
+"The queen is preparing for her marriage with one or other of us. Little
+does she dream that her son has now been doomed to die."
+
+This was what they said, but they did not know what was going to happen.
+Then Antinous said, "Comrades, let there be no loud talking, lest some
+of it get carried inside. Let us be up and do that in silence, about
+which we are all of a mind."
+
+He then chose twenty men, and they went down to their ship and to the
+sea side; they drew the vessel into the water and got her mast and sails
+inside her; they bound the oars to the thole-pins with twisted thongs
+of leather, all in due course, and spread the white sails aloft, while
+their fine servants brought them their armour. Then they made the ship
+fast a little way out, came on shore again, got their suppers, and
+waited till night should fall.
+
+But Penelope lay in her own room upstairs unable to eat or drink, and
+wondering whether her brave son would escape, or be overpowered by the
+wicked suitors. Like a lioness caught in the toils with huntsmen hemming
+her in on every side she thought and thought till she sank into a
+slumber, and lay on her bed bereft of thought and motion.
+
+Then Minerva bethought her of another matter, and made a vision in
+the likeness of Penelope's sister Iphthime daughter of Icarius who had
+married Eumelus and lived in Pherae. She told the vision to go to the
+house of Ulysses, and to make Penelope leave off crying, so it came into
+her room by the hole through which the thong went for pulling the door
+to, and hovered over her head saying,
+
+"You are asleep, Penelope: the gods who live at ease will not suffer you
+to weep and be so sad. Your son has done them no wrong, so he will yet
+come back to you."
+
+Penelope, who was sleeping sweetly at the gates of dreamland, answered,
+"Sister, why have you come here? You do not come very often, but I
+suppose that is because you live such a long way off. Am I, then, to
+leave off crying and refrain from all the sad thoughts that torture me?
+I, who have lost my brave and lion-hearted husband, who had every good
+quality under heaven, and whose name was great over all Hellas and
+middle Argos; and now my darling son has gone off on board of a ship--a
+foolish fellow who has never been used to roughing it, nor to going
+about among gatherings of men. I am even more anxious about him than
+about my husband; I am all in a tremble when I think of him, lest
+something should happen to him, either from the people among whom he has
+gone, or by sea, for he has many enemies who are plotting against him,
+and are bent on killing him before he can return home."
+
+Then the vision said, "Take heart, and be not so much dismayed. There is
+one gone with him whom many a man would be glad enough to have stand by
+his side, I mean Minerva; it is she who has compassion upon you, and who
+has sent me to bear you this message."
+
+"Then," said Penelope, "if you are a god or have been sent here by
+divine commission, tell me also about that other unhappy one--is he
+still alive, or is he already dead and in the house of Hades?"
+
+And the vision said, "I shall not tell you for certain whether he is
+alive or dead, and there is no use in idle conversation."
+
+Then it vanished through the thong-hole of the door and was dissipated
+into thin air; but Penelope rose from her sleep refreshed and comforted,
+so vivid had been her dream.
+
+Meantime the suitors went on board and sailed their ways over the
+sea, intent on murdering Telemachus. Now there is a rocky islet called
+Asteris, of no great size, in mid channel between Ithaca and Samos, and
+there is a harbour on either side of it where a ship can lie. Here then
+the Achaeans placed themselves in ambush.
+
+
+Book V
+
+CALYPSO--ULYSSES REACHES SCHERIA ON A RAFT.
+
+And now, as Dawn rose from her couch beside Tithonus--harbinger of light
+alike to mortals and immortals--the gods met in council and with them,
+Jove the lord of thunder, who is their king. Thereon Minerva began to
+tell them of the many sufferings of Ulysses, for she pitied him away
+there in the house of the nymph Calypso.
+
+"Father Jove," said she, "and all you other gods that live in
+everlasting bliss, I hope there may never be such a thing as a kind and
+well-disposed ruler any more, nor one who will govern equitably. I hope
+they will be all henceforth cruel and unjust, for there is not one of
+his subjects but has forgotten Ulysses, who ruled them as though he were
+their father. There he is, lying in great pain in an island where dwells
+the nymph Calypso, who will not let him go; and he cannot get back to
+his own country, for he can find neither ships nor sailors to take him
+over the sea. Furthermore, wicked people are now trying to murder his
+only son Telemachus, who is coming home from Pylos and Lacedaemon, where
+he has been to see if he can get news of his father."
+
+"What, my dear, are you talking about?" replied her father, "did you not
+send him there yourself, because you thought it would help Ulysses to
+get home and punish the suitors? Besides, you are perfectly able to
+protect Telemachus, and to see him safely home again, while the suitors
+have to come hurry-skurrying back without having killed him."
+
+When he had thus spoken, he said to his son Mercury, "Mercury, you are
+our messenger, go therefore and tell Calypso we have decreed that poor
+Ulysses is to return home. He is to be convoyed neither by gods nor men,
+but after a perilous voyage of twenty days upon a raft he is to reach
+fertile Scheria, {50} the land of the Phaeacians, who are near of kin to
+the gods, and will honour him as though he were one of ourselves. They
+will send him in a ship to his own country, and will give him more
+bronze and gold and raiment than he would have brought back from Troy,
+if he had had all his prize money and had got home without disaster.
+This is how we have settled that he shall return to his country and his
+friends."
+
+Thus he spoke, and Mercury, guide and guardian, slayer of Argus, did as
+he was told. Forthwith he bound on his glittering golden sandals with
+which he could fly like the wind over land and sea. He took the wand
+with which he seals men's eyes in sleep or wakes them just as he
+pleases, and flew holding it in his hand over Pieria; then he swooped
+down through the firmament till he reached the level of the sea, whose
+waves he skimmed like a cormorant that flies fishing every hole and
+corner of the ocean, and drenching its thick plumage in the spray. He
+flew and flew over many a weary wave, but when at last he got to the
+island which was his journey's end, he left the sea and went on by land
+till he came to the cave where the nymph Calypso lived.
+
+He found her at home. There was a large fire burning on the hearth, and
+one could smell from far the fragrant reek of burning cedar and sandal
+wood. As for herself, she was busy at her loom, shooting her golden
+shuttle through the warp and singing beautifully. Round her cave there
+was a thick wood of alder, poplar, and sweet smelling cypress trees,
+wherein all kinds of great birds had built their nests--owls, hawks, and
+chattering sea-crows that occupy their business in the waters. A vine
+loaded with grapes was trained and grew luxuriantly about the mouth of
+the cave; there were also four running rills of water in channels cut
+pretty close together, and turned hither and thither so as to irrigate
+the beds of violets and luscious herbage over which they flowed. {51}
+Even a god could not help being charmed with such a lovely spot,
+so Mercury stood still and looked at it; but when he had admired it
+sufficiently he went inside the cave.
+
+Calypso knew him at once--for the gods all know each other, no matter
+how far they live from one another--but Ulysses was not within; he was
+on the sea-shore as usual, looking out upon the barren ocean with tears
+in his eyes, groaning and breaking his heart for sorrow. Calypso
+gave Mercury a seat and said: "Why have you come to see me,
+Mercury--honoured, and ever welcome--for you do not visit me often? Say
+what you want; I will do it for you at once if I can, and if it can be
+done at all; but come inside, and let me set refreshment before you."
+
+As she spoke she drew a table loaded with ambrosia beside him and mixed
+him some red nectar, so Mercury ate and drank till he had had enough,
+and then said:
+
+"We are speaking god and goddess to one another, and you ask me why I
+have come here, and I will tell you truly as you would have me do. Jove
+sent me; it was no doing of mine; who could possibly want to come all
+this way over the sea where there are no cities full of people to offer
+me sacrifices or choice hecatombs? Nevertheless I had to come, for none
+of us other gods can cross Jove, nor transgress his orders. He says that
+you have here the most ill-starred of all those who fought nine years
+before the city of King Priam and sailed home in the tenth year after
+having sacked it. On their way home they sinned against Minerva, {52}
+who raised both wind and waves against them, so that all his brave
+companions perished, and he alone was carried hither by wind and tide.
+Jove says that you are to let this man go at once, for it is decreed
+that he shall not perish here, far from his own people, but shall return
+to his house and country and see his friends again."
+
+Calypso trembled with rage when she heard this, "You gods," she
+exclaimed, "ought to be ashamed of yourselves. You are always jealous
+and hate seeing a goddess take a fancy to a mortal man, and live with
+him in open matrimony. So when rosy-fingered Dawn made love to Orion,
+you precious gods were all of you furious till Diana went and killed him
+in Ortygia. So again when Ceres fell in love with Iasion, and yielded to
+him in a thrice-ploughed fallow field, Jove came to hear of it before so
+very long and killed Iasion with his thunderbolts. And now you are angry
+with me too because I have a man here. I found the poor creature sitting
+all alone astride of a keel, for Jove had struck his ship with lightning
+and sunk it in mid ocean, so that all his crew were drowned, while he
+himself was driven by wind and waves on to my island. I got fond of him
+and cherished him, and had set my heart on making him immortal, so that
+he should never grow old all his days; still I cannot cross Jove, nor
+bring his counsels to nothing; therefore, if he insists upon it, let the
+man go beyond the seas again; but I cannot send him anywhere myself
+for I have neither ships nor men who can take him. Nevertheless I will
+readily give him such advice, in all good faith, as will be likely to
+bring him safely to his own country."
+
+"Then send him away," said Mercury, "or Jove will be angry with you and
+punish you".
+
+On this he took his leave, and Calypso went out to look for Ulysses, for
+she had heard Jove's message. She found him sitting upon the beach with
+his eyes ever filled with tears, and dying of sheer home sickness; for
+he had got tired of Calypso, and though he was forced to sleep with her
+in the cave by night, it was she, not he, that would have it so. As for
+the day time, he spent it on the rocks and on the sea shore, weeping,
+crying aloud for his despair, and always looking out upon the sea.
+Calypso then went close up to him said:
+
+"My poor fellow, you shall not stay here grieving and fretting your life
+out any longer. I am going to send you away of my own free will; so go,
+cut some beams of wood, and make yourself a large raft with an upper
+deck that it may carry you safely over the sea. I will put bread, wine,
+and water on board to save you from starving. I will also give you
+clothes, and will send you a fair wind to take you home, if the gods in
+heaven so will it--for they know more about these things, and can settle
+them better than I can."
+
+Ulysses shuddered as he heard her. "Now goddess," he answered, "there is
+something behind all this; you cannot be really meaning to help me home
+when you bid me do such a dreadful thing as put to sea on a raft. Not
+even a well found ship with a fair wind could venture on such a distant
+voyage: nothing that you can say or do shall make me go on board a raft
+unless you first solemnly swear that you mean me no mischief."
+
+Calypso smiled at this and caressed him with her hand: "You know a great
+deal," said she, "but you are quite wrong here. May heaven above and
+earth below be my witnesses, with the waters of the river Styx--and this
+is the most solemn oath which a blessed god can take--that I mean you
+no sort of harm, and am only advising you to do exactly what I should do
+myself in your place. I am dealing with you quite straightforwardly; my
+heart is not made of iron, and I am very sorry for you."
+
+When she had thus spoken she led the way rapidly before him, and Ulysses
+followed in her steps; so the pair, goddess and man, went on and on till
+they came to Calypso's cave, where Ulysses took the seat that Mercury
+had just left. Calypso set meat and drink before him of the food that
+mortals eat; but her maids brought ambrosia and nectar for herself, and
+they laid their hands on the good things that were before them. When
+they had satisfied themselves with meat and drink, Calypso spoke,
+saying:
+
+"Ulysses, noble son of Laertes, so you would start home to your own
+land at once? Good luck go with you, but if you could only know how much
+suffering is in store for you before you get back to your own country,
+you would stay where you are, keep house along with me, and let me
+make you immortal, no matter how anxious you may be to see this wife
+of yours, of whom you are thinking all the time day after day; yet I
+flatter myself that I am no whit less tall or well-looking than she
+is, for it is not to be expected that a mortal woman should compare in
+beauty with an immortal."
+
+"Goddess," replied Ulysses, "do not be angry with me about this. I
+am quite aware that my wife Penelope is nothing like so tall or so
+beautiful as yourself. She is only a woman, whereas you are an immortal.
+Nevertheless, I want to get home, and can think of nothing else. If some
+god wrecks me when I am on the sea, I will bear it and make the best
+of it. I have had infinite trouble both by land and sea already, so let
+this go with the rest."
+
+Presently the sun set and it became dark, whereon the pair retired into
+the inner part of the cave and went to bed.
+
+When the child of morning rosy-fingered Dawn appeared, Ulysses put on
+his shirt and cloak, while the goddess wore a dress of a light gossamer
+fabric, very fine and graceful, with a beautiful golden girdle about her
+waist and a veil to cover her head. She at once set herself to think how
+she could speed Ulysses on his way. So she gave him a great bronze
+axe that suited his hands; it was sharpened on both sides, and had a
+beautiful olive-wood handle fitted firmly on to it. She also gave him a
+sharp adze, and then led the way to the far end of the island where the
+largest trees grew--alder, poplar and pine, that reached the sky--very
+dry and well seasoned, so as to sail light for him in the water. {53}
+Then, when she had shown him where the best trees grew, Calypso went
+home, leaving him to cut them, which he soon finished doing. He cut down
+twenty trees in all and adzed them smooth, squaring them by rule in good
+workmanlike fashion. Meanwhile Calypso came back with some augers, so
+he bored holes with them and fitted the timbers together with bolts and
+rivets. He made the raft as broad as a skilled shipwright makes the beam
+of a large vessel, and he fixed a deck on top of the ribs, and ran a
+gunwale all round it. He also made a mast with a yard arm, and a rudder
+to steer with. He fenced the raft all round with wicker hurdles as a
+protection against the waves, and then he threw on a quantity of wood.
+By and by Calypso brought him some linen to make the sails, and he made
+these too, excellently, making them fast with braces and sheets. Last of
+all, with the help of levers, he drew the raft down into the water.
+
+In four days he had completed the whole work, and on the fifth Calypso
+sent him from the island after washing him and giving him some clean
+clothes. She gave him a goat skin full of black wine, and another larger
+one of water; she also gave him a wallet full of provisions, and found
+him in much good meat. Moreover, she made the wind fair and warm for
+him, and gladly did Ulysses spread his sail before it, while he sat and
+guided the raft skilfully by means of the rudder. He never closed his
+eyes, but kept them fixed on the Pleiads, on late-setting Bootes, and on
+the Bear--which men also call the wain, and which turns round and round
+where it is, facing Orion, and alone never dipping into the stream of
+Oceanus--for Calypso had told him to keep this to his left. Days seven
+and ten did he sail over the sea, and on the eighteenth the dim outlines
+of the mountains on the nearest part of the Phaeacian coast appeared,
+rising like a shield on the horizon.
+
+But King Neptune, who was returning from the Ethiopians, caught sight of
+Ulysses a long way off, from the mountains of the Solymi. He could see
+him sailing upon the sea, and it made him very angry, so he wagged his
+head and muttered to himself, saying, "Good heavens, so the gods have
+been changing their minds about Ulysses while I was away in Ethiopia,
+and now he is close to the land of the Phaeacians, where it is decreed
+that he shall escape from the calamities that have befallen him. Still,
+he shall have plenty of hardship yet before he has done with it."
+
+Thereon he gathered his clouds together, grasped his trident, stirred
+it round in the sea, and roused the rage of every wind that blows till
+earth, sea, and sky were hidden in cloud, and night sprang forth out of
+the heavens. Winds from East, South, North, and West fell upon him all
+at the same time, and a tremendous sea got up, so that Ulysses' heart
+began to fail him. "Alas," he said to himself in his dismay, "what ever
+will become of me? I am afraid Calypso was right when she said I should
+have trouble by sea before I got back home. It is all coming true. How
+black is Jove making heaven with his clouds, and what a sea the winds
+are raising from every quarter at once. I am now safe to perish. Blest
+and thrice blest were those Danaans who fell before Troy in the cause
+of the sons of Atreus. Would that I had been killed on the day when the
+Trojans were pressing me so sorely about the dead body of Achilles, for
+then I should have had due burial and the Achaeans would have honoured
+my name; but now it seems that I shall come to a most pitiable end."
+
+As he spoke a sea broke over him with such terrific fury that the raft
+reeled again, and he was carried overboard a long way off. He let go the
+helm, and the force of the hurricane was so great that it broke the mast
+half way up, and both sail and yard went over into the sea. For a long
+time Ulysses was under water, and it was all he could do to rise to the
+surface again, for the clothes Calypso had given him weighed him down;
+but at last he got his head above water and spat out the bitter brine
+that was running down his face in streams. In spite of all this,
+however, he did not lose sight of his raft, but swam as fast as he could
+towards it, got hold of it, and climbed on board again so as to escape
+drowning. The sea took the raft and tossed it about as Autumn winds
+whirl thistledown round and round upon a road. It was as though the
+South, North, East, and West winds were all playing battledore and
+shuttlecock with it at once.
+
+When he was in this plight, Ino daughter of Cadmus, also called
+Leucothea, saw him. She had formerly been a mere mortal, but had been
+since raised to the rank of a marine goddess. Seeing in what great
+distress Ulysses now was, she had compassion upon him, and, rising like
+a sea-gull from the waves, took her seat upon the raft.
+
+"My poor good man," said she, "why is Neptune so furiously angry with
+you? He is giving you a great deal of trouble, but for all his bluster
+he will not kill you. You seem to be a sensible person, do then as I bid
+you; strip, leave your raft to drive before the wind, and swim to the
+Phaeacian coast where better luck awaits you. And here, take my veil and
+put it round your chest; it is enchanted, and you can come to no harm
+so long as you wear it. As soon as you touch land take it off, throw it
+back as far as you can into the sea, and then go away again." With these
+words she took off her veil and gave it him. Then she dived down again
+like a sea-gull and vanished beneath the dark blue waters.
+
+But Ulysses did not know what to think. "Alas," he said to himself in
+his dismay, "this is only some one or other of the gods who is luring me
+to ruin by advising me to quit my raft. At any rate I will not do so at
+present, for the land where she said I should be quit of all troubles
+seemed to be still a good way off. I know what I will do--I am sure it
+will be best--no matter what happens I will stick to the raft as long
+as her timbers hold together, but when the sea breaks her up I will swim
+for it; I do not see how I can do any better than this."
+
+While he was thus in two minds, Neptune sent a terrible great wave that
+seemed to rear itself above his head till it broke right over the raft,
+which then went to pieces as though it were a heap of dry chaff tossed
+about by a whirlwind. Ulysses got astride of one plank and rode upon
+it as if he were on horseback; he then took off the clothes Calypso
+had given him, bound Ino's veil under his arms, and plunged into the
+sea--meaning to swim on shore. King Neptune watched him as he did so,
+and wagged his head, muttering to himself and saying, "There now, swim
+up and down as you best can till you fall in with well-to-do people.
+I do not think you will be able to say that I have let you off too
+lightly." On this he lashed his horses and drove to Aegae where his
+palace is.
+
+But Minerva resolved to help Ulysses, so she bound the ways of all the
+winds except one, and made them lie quite still; but she roused a good
+stiff breeze from the North that should lay the waters till Ulysses
+reached the land of the Phaeacians where he would be safe.
+
+Thereon he floated about for two nights and two days in the water, with
+a heavy swell on the sea and death staring him in the face; but when the
+third day broke, the wind fell and there was a dead calm without so much
+as a breath of air stirring. As he rose on the swell he looked eagerly
+ahead, and could see land quite near. Then, as children rejoice when
+their dear father begins to get better after having for a long time
+borne sore affliction sent him by some angry spirit, but the gods
+deliver him from evil, so was Ulysses thankful when he again saw land
+and trees, and swam on with all his strength that he might once more set
+foot upon dry ground. When, however, he got within earshot, he began to
+hear the surf thundering up against the rocks, for the swell still broke
+against them with a terrific roar. Everything was enveloped in spray;
+there were no harbours where a ship might ride, nor shelter of any kind,
+but only headlands, low-lying rocks, and mountain tops.
+
+Ulysses' heart now began to fail him, and he said despairingly to
+himself, "Alas, Jove has let me see land after swimming so far that I
+had given up all hope, but I can find no landing place, for the coast is
+rocky and surf-beaten, the rocks are smooth and rise sheer from the sea,
+with deep water close under them so that I cannot climb out for want of
+foot hold. I am afraid some great wave will lift me off my legs and dash
+me against the rocks as I leave the water--which would give me a
+sorry landing. If, on the other hand, I swim further in search of some
+shelving beach or harbour, a hurricane may carry me out to sea again
+sorely against my will, or heaven may send some great monster of the
+deep to attack me; for Amphitrite breeds many such, and I know that
+Neptune is very angry with me."
+
+While he was thus in two minds a wave caught him and took him with such
+force against the rocks that he would have been smashed and torn to
+pieces if Minerva had not shown him what to do. He caught hold of the
+rock with both hands and clung to it groaning with pain till the wave
+retired, so he was saved that time; but presently the wave came on again
+and carried him back with it far into the sea--tearing his hands as the
+suckers of a polypus are torn when some one plucks it from its bed, and
+the stones come up along with it--even so did the rocks tear the skin
+from his strong hands, and then the wave drew him deep down under the
+water.
+
+Here poor Ulysses would have certainly perished even in spite of his own
+destiny, if Minerva had not helped him to keep his wits about him. He
+swam seaward again, beyond reach of the surf that was beating against
+the land, and at the same time he kept looking towards the shore to
+see if he could find some haven, or a spit that should take the waves
+aslant. By and by, as he swam on, he came to the mouth of a river, and
+here he thought would be the best place, for there were no rocks, and it
+afforded shelter from the wind. He felt that there was a current, so he
+prayed inwardly and said:
+
+"Hear me, O King, whoever you may be, and save me from the anger of the
+sea-god Neptune, for I approach you prayerfully. Any one who has lost
+his way has at all times a claim even upon the gods, wherefore in my
+distress I draw near to your stream, and cling to the knees of your
+riverhood. Have mercy upon me, O king, for I declare myself your
+suppliant."
+
+Then the god staid his stream and stilled the waves, making all calm
+before him, and bringing him safely into the mouth of the river. Here
+at last Ulysses' knees and strong hands failed him, for the sea had
+completely broken him. His body was all swollen, and his mouth and
+nostrils ran down like a river with sea-water, so that he could neither
+breathe nor speak, and lay swooning from sheer exhaustion; presently,
+when he had got his breath and came to himself again, he took off the
+scarf that Ino had given him and threw it back into the salt {54} stream
+of the river, whereon Ino received it into her hands from the wave that
+bore it towards her. Then he left the river, laid himself down among the
+rushes, and kissed the bounteous earth.
+
+"Alas," he cried to himself in his dismay, "what ever will become of me,
+and how is it all to end? If I stay here upon the river bed through the
+long watches of the night, I am so exhausted that the bitter cold and
+damp may make an end of me--for towards sunrise there will be a keen
+wind blowing from off the river. If, on the other hand, I climb the hill
+side, find shelter in the woods, and sleep in some thicket, I may escape
+the cold and have a good night's rest, but some savage beast may take
+advantage of me and devour me."
+
+In the end he deemed it best to take to the woods, and he found one
+upon some high ground not far from the water. There he crept beneath
+two shoots of olive that grew from a single stock--the one an ungrafted
+sucker, while the other had been grafted. No wind, however squally,
+could break through the cover they afforded, nor could the sun's rays
+pierce them, nor the rain get through them, so closely did they grow
+into one another. Ulysses crept under these and began to make himself
+a bed to lie on, for there was a great litter of dead leaves lying
+about--enough to make a covering for two or three men even in hard
+winter weather. He was glad enough to see this, so he laid himself down
+and heaped the leaves all round him. Then, as one who lives alone in the
+country, far from any neighbor, hides a brand as fire-seed in the
+ashes to save himself from having to get a light elsewhere, even so did
+Ulysses cover himself up with leaves; and Minerva shed a sweet sleep
+upon his eyes, closed his eyelids, and made him lose all memories of his
+sorrows.
+
+
+Book VI
+
+THE MEETING BETWEEN NAUSICAA AND ULYSSES.
+
+So here Ulysses slept, overcome by sleep and toil; but Minerva went off
+to the country and city of the Phaeacians--a people who used to live in
+the fair town of Hypereia, near the lawless Cyclopes. Now the Cyclopes
+were stronger than they and plundered them, so their king Nausithous
+moved them thence and settled them in Scheria, far from all other
+people. He surrounded the city with a wall, built houses and temples,
+and divided the lands among his people; but he was dead and gone to
+the house of Hades, and King Alcinous, whose counsels were inspired
+of heaven, was now reigning. To his house, then, did Minerva hie in
+furtherance of the return of Ulysses.
+
+She went straight to the beautifully decorated bedroom in which there
+slept a girl who was as lovely as a goddess, Nausicaa, daughter to King
+Alcinous. Two maid servants were sleeping near her, both very pretty,
+one on either side of the doorway, which was closed with well made
+folding doors. Minerva took the form of the famous sea captain Dymas's
+daughter, who was a bosom friend of Nausicaa and just her own age; then,
+coming up to the girl's bedside like a breath of wind, she hovered over
+her head and said:
+
+"Nausicaa, what can your mother have been about, to have such a lazy
+daughter? Here are your clothes all lying in disorder, yet you are going
+to be married almost immediately, and should not only be well dressed
+yourself, but should find good clothes for those who attend you. This is
+the way to get yourself a good name, and to make your father and mother
+proud of you. Suppose, then, that we make tomorrow a washing day,
+and start at daybreak. I will come and help you so that you may have
+everything ready as soon as possible, for all the best young men among
+your own people are courting you, and you are not going to remain a
+maid much longer. Ask your father, therefore, to have a waggon and mules
+ready for us at daybreak, to take the rugs, robes, and girdles, and you
+can ride, too, which will be much pleasanter for you than walking, for
+the washing-cisterns are some way from the town."
+
+When she had said this Minerva went away to Olympus, which they say
+is the everlasting home of the gods. Here no wind beats roughly, and
+neither rain nor snow can fall; but it abides in everlasting sunshine
+and in a great peacefulness of light, wherein the blessed gods are
+illumined for ever and ever. This was the place to which the goddess
+went when she had given instructions to the girl.
+
+By and by morning came and woke Nausicaa, who began wondering about
+her dream; she therefore went to the other end of the house to tell her
+father and mother all about it, and found them in their own room. Her
+mother was sitting by the fireside spinning her purple yarn with her
+maids around her, and she happened to catch her father just as he was
+going out to attend a meeting of the town council, which the Phaeacian
+aldermen had convened. She stopped him and said:
+
+"Papa dear, could you manage to let me have a good big waggon? I want to
+take all our dirty clothes to the river and wash them. You are the chief
+man here, so it is only right that you should have a clean shirt when
+you attend meetings of the council. Moreover, you have five sons at
+home, two of them married, while the other three are good looking
+bachelors; you know they always like to have clean linen when they go to
+a dance, and I have been thinking about all this."
+
+She did not say a word about her own wedding, for she did not like to,
+but her father knew and said, "You shall have the mules, my love, and
+whatever else you have a mind for. Be off with you, and the men shall
+get you a good strong waggon with a body to it that will hold all your
+clothes."
+
+On this he gave his orders to the servants, who got the waggon out,
+harnessed the mules, and put them to, while the girl brought the clothes
+down from the linen room and placed them on the waggon. Her mother
+prepared her a basket of provisions with all sorts of good things, and a
+goat skin full of wine; the girl now got into the waggon, and her mother
+gave her also a golden cruse of oil, that she and her women might anoint
+themselves. Then she took the whip and reins and lashed the mules on,
+whereon they set off, and their hoofs clattered on the road. They pulled
+without flagging, and carried not only Nausicaa and her wash of clothes,
+but the maids also who were with her.
+
+When they reached the water side they went to the washing cisterns,
+through which there ran at all times enough pure water to wash any
+quantity of linen, no matter how dirty. Here they unharnessed the mules
+and turned them out to feed on the sweet juicy herbage that grew by the
+water side. They took the clothes out of the waggon, put them in the
+water, and vied with one another in treading them in the pits to get the
+dirt out. After they had washed them and got them quite clean, they laid
+them out by the sea side, where the waves had raised a high beach of
+shingle, and set about washing themselves and anointing themselves with
+olive oil. Then they got their dinner by the side of the stream, and
+waited for the sun to finish drying the clothes. When they had done
+dinner they threw off the veils that covered their heads and began to
+play at ball, while Nausicaa sang for them. As the huntress Diana goes
+forth upon the mountains of Taygetus or Erymanthus to hunt wild boars or
+deer, and the wood nymphs, daughters of Aegis-bearing Jove, take their
+sport along with her (then is Leto proud at seeing her daughter stand a
+full head taller than the others, and eclipse the loveliest amid a whole
+bevy of beauties), even so did the girl outshine her handmaids.
+
+When it was time for them to start home, and they were folding the
+clothes and putting them into the waggon, Minerva began to consider how
+Ulysses should wake up and see the handsome girl who was to conduct him
+to the city of the Phaeacians. The girl, therefore, threw a ball at one
+of the maids, which missed her and fell into deep water. On this they
+all shouted, and the noise they made woke Ulysses, who sat up in his bed
+of leaves and began to wonder what it might all be.
+
+"Alas," said he to himself, "what kind of people have I come amongst?
+Are they cruel, savage, and uncivilised, or hospitable and humane? I
+seem to hear the voices of young women, and they sound like those of
+the nymphs that haunt mountain tops, or springs of rivers and meadows of
+green grass. At any rate I am among a race of men and women. Let me try
+if I cannot manage to get a look at them."
+
+As he said this he crept from under his bush, and broke off a bough
+covered with thick leaves to hide his nakedness. He looked like some
+lion of the wilderness that stalks about exulting in his strength and
+defying both wind and rain; his eyes glare as he prowls in quest of
+oxen, sheep, or deer, for he is famished, and will dare break even
+into a well fenced homestead, trying to get at the sheep--even such did
+Ulysses seem to the young women, as he drew near to them all naked as he
+was, for he was in great want. On seeing one so unkempt and so begrimed
+with salt water, the others scampered off along the spits that jutted
+out into the sea, but the daughter of Alcinous stood firm, for Minerva
+put courage into her heart and took away all fear from her. She stood
+right in front of Ulysses, and he doubted whether he should go up to
+her, throw himself at her feet, and embrace her knees as a suppliant, or
+stay where he was and entreat her to give him some clothes and show him
+the way to the town. In the end he deemed it best to entreat her from a
+distance in case the girl should take offence at his coming near enough
+to clasp her knees, so he addressed her in honeyed and persuasive
+language.
+
+"O queen," he said, "I implore your aid--but tell me, are you a goddess
+or are you a mortal woman? If you are a goddess and dwell in heaven, I
+can only conjecture that you are Jove's daughter Diana, for your face
+and figure resemble none but hers; if on the other hand you are a mortal
+and live on earth, thrice happy are your father and mother--thrice
+happy, too, are your brothers and sisters; how proud and delighted
+they must feel when they see so fair a scion as yourself going out to a
+dance; most happy, however, of all will he be whose wedding gifts have
+been the richest, and who takes you to his own home. I never yet saw any
+one so beautiful, neither man nor woman, and am lost in admiration as I
+behold you. I can only compare you to a young palm tree which I saw when
+I was at Delos growing near the altar of Apollo--for I was there, too,
+with much people after me, when I was on that journey which has been the
+source of all my troubles. Never yet did such a young plant shoot out
+of the ground as that was, and I admired and wondered at it exactly as I
+now admire and wonder at yourself. I dare not clasp your knees, but I
+am in great distress; yesterday made the twentieth day that I had been
+tossing about upon the sea. The winds and waves have taken me all the
+way from the Ogygian island, {55} and now fate has flung me upon this
+coast that I may endure still further suffering; for I do not think that
+I have yet come to the end of it, but rather that heaven has still much
+evil in store for me.
+
+"And now, O queen, have pity upon me, for you are the first person I
+have met, and I know no one else in this country. Show me the way to
+your town, and let me have anything that you may have brought hither to
+wrap your clothes in. May heaven grant you in all things your heart's
+desire--husband, house, and a happy, peaceful home; for there is nothing
+better in this world than that man and wife should be of one mind in a
+house. It discomfits their enemies, makes the hearts of their friends
+glad, and they themselves know more about it than any one."
+
+To this Nausicaa answered, "Stranger, you appear to be a sensible,
+well-disposed person. There is no accounting for luck; Jove gives
+prosperity to rich and poor just as he chooses, so you must take what
+he has seen fit to send you, and make the best of it. Now, however, that
+you have come to this our country, you shall not want for clothes nor
+for anything else that a foreigner in distress may reasonably look for.
+I will show you the way to the town, and will tell you the name of our
+people; we are called Phaeacians, and I am daughter to Alcinous, in whom
+the whole power of the state is vested."
+
+Then she called her maids and said, "Stay where you are, you girls. Can
+you not see a man without running away from him? Do you take him for a
+robber or a murderer? Neither he nor any one else can come here to do
+us Phaeacians any harm, for we are dear to the gods, and live apart on a
+land's end that juts into the sounding sea, and have nothing to do with
+any other people. This is only some poor man who has lost his way, and
+we must be kind to him, for strangers and foreigners in distress
+are under Jove's protection, and will take what they can get and be
+thankful; so, girls, give the poor fellow something to eat and drink,
+and wash him in the stream at some place that is sheltered from the
+wind."
+
+On this the maids left off running away and began calling one another
+back. They made Ulysses sit down in the shelter as Nausicaa had told
+them, and brought him a shirt and cloak. They also brought him the
+little golden cruse of oil, and told him to go and wash in the stream.
+But Ulysses said, "Young women, please to stand a little on one side
+that I may wash the brine from my shoulders and anoint myself with oil,
+for it is long enough since my skin has had a drop of oil upon it. I
+cannot wash as long as you all keep standing there. I am ashamed to
+strip {56} before a number of good looking young women."
+
+Then they stood on one side and went to tell the girl, while Ulysses
+washed himself in the stream and scrubbed the brine from his back and
+from his broad shoulders. When he had thoroughly washed himself, and had
+got the brine out of his hair, he anointed himself with oil, and put
+on the clothes which the girl had given him; Minerva then made him look
+taller and stronger than before, she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders as a skilful workman who has
+studied art of all kinds under Vulcan and Minerva enriches a piece of
+silver plate by gilding it--and his work is full of beauty. Then he went
+and sat down a little way off upon the beach, looking quite young and
+handsome, and the girl gazed on him with admiration; then she said to
+her maids:
+
+"Hush, my dears, for I want to say something. I believe the gods who
+live in heaven have sent this man to the Phaeacians. When I first saw
+him I thought him plain, but now his appearance is like that of the gods
+who dwell in heaven. I should like my future husband to be just such
+another as he is, if he would only stay here and not want to go away.
+However, give him something to eat and drink."
+
+They did as they were told, and set food before Ulysses, who ate and
+drank ravenously, for it was long since he had had food of any kind.
+Meanwhile, Nausicaa bethought her of another matter. She got the linen
+folded and placed in the waggon, she then yoked the mules, and, as she
+took her seat, she called Ulysses:
+
+"Stranger," said she, "rise and let us be going back to the town; I will
+introduce you at the house of my excellent father, where I can tell you
+that you will meet all the best people among the Phaeacians. But be sure
+and do as I bid you, for you seem to be a sensible person. As long as
+we are going past the fields and farm lands, follow briskly behind the
+waggon along with the maids and I will lead the way myself. Presently,
+however, we shall come to the town, where you will find a high wall
+running all round it, and a good harbour on either side with a narrow
+entrance into the city, and the ships will be drawn up by the road side,
+for every one has a place where his own ship can lie. You will see the
+market place with a temple of Neptune in the middle of it, and paved
+with large stones bedded in the earth. Here people deal in ship's gear
+of all kinds, such as cables and sails, and here, too, are the places
+where oars are made, for the Phaeacians are not a nation of archers;
+they know nothing about bows and arrows, but are a sea-faring folk, and
+pride themselves on their masts, oars, and ships, with which they travel
+far over the sea.
+
+"I am afraid of the gossip and scandal that may be set on foot against
+me later on; for the people here are very ill-natured, and some low
+fellow, if he met us, might say, 'Who is this fine-looking stranger that
+is going about with Nausicaa? Where did she find him? I suppose she is
+going to marry him. Perhaps he is a vagabond sailor whom she has taken
+from some foreign vessel, for we have no neighbours; or some god has at
+last come down from heaven in answer to her prayers, and she is going to
+live with him all the rest of her life. It would be a good thing if she
+would take herself off and find a husband somewhere else, for she will
+not look at one of the many excellent young Phaeacians who are in love
+with her.' This is the kind of disparaging remark that would be made
+about me, and I could not complain, for I should myself be scandalised
+at seeing any other girl do the like, and go about with men in spite
+of everybody, while her father and mother were still alive, and without
+having been married in the face of all the world.
+
+"If, therefore, you want my father to give you an escort and to help you
+home, do as I bid you; you will see a beautiful grove of poplars by the
+road side dedicated to Minerva; it has a well in it and a meadow all
+round it. Here my father has a field of rich garden ground, about as far
+from the town as a man's voice will carry. Sit down there and wait for
+a while till the rest of us can get into the town and reach my father's
+house. Then, when you think we must have done this, come into the town
+and ask the way to the house of my father Alcinous. You will have no
+difficulty in finding it; any child will point it out to you, for no one
+else in the whole town has anything like such a fine house as he has.
+When you have got past the gates and through the outer court, go right
+across the inner court till you come to my mother. You will find her
+sitting by the fire and spinning her purple wool by firelight. It is a
+fine sight to see her as she leans back against one of the bearing-posts
+with her maids all ranged behind her. Close to her seat stands that of
+my father, on which he sits and topes like an immortal god. Never mind
+him, but go up to my mother, and lay your hands upon her knees if you
+would get home quickly. If you can gain her over, you may hope to see
+your own country again, no matter how distant it may be."
+
+So saying she lashed the mules with her whip and they left the river.
+The mules drew well, and their hoofs went up and down upon the road.
+She was careful not to go too fast for Ulysses and the maids who were
+following on foot along with the waggon, so she plied her whip with
+judgement. As the sun was going down they came to the sacred grove of
+Minerva, and there Ulysses sat down and prayed to the mighty daughter of
+Jove.
+
+"Hear me," he cried, "daughter of Aegis-bearing Jove, unweariable, hear
+me now, for you gave no heed to my prayers when Neptune was wrecking me.
+Now, therefore, have pity upon me and grant that I may find friends and
+be hospitably received by the Phaeacians."
+
+Thus did he pray, and Minerva heard his prayer, but she would not show
+herself to him openly, for she was afraid of her uncle Neptune, who was
+still furious in his endeavors to prevent Ulysses from getting home.
+
+
+Book VII
+
+RECEPTION OF ULYSSES AT THE PALACE OF KING ALCINOUS.
+
+Thus, then, did Ulysses wait and pray; but the girl drove on to the
+town. When she reached her father's house she drew up at the gateway,
+and her brothers--comely as the gods--gathered round her, took the mules
+out of the waggon, and carried the clothes into the house, while she
+went to her own room, where an old servant, Eurymedusa of Apeira, lit
+the fire for her. This old woman had been brought by sea from Apeira,
+and had been chosen as a prize for Alcinous because he was king over the
+Phaeacians, and the people obeyed him as though he were a god. {57}
+She had been nurse to Nausicaa, and had now lit the fire for her, and
+brought her supper for her into her own room.
+
+Presently Ulysses got up to go towards the town; and Minerva shed a
+thick mist all round him to hide him in case any of the proud Phaeacians
+who met him should be rude to him, or ask him who he was. Then, as he
+was just entering the town, she came towards him in the likeness of a
+little girl carrying a pitcher. She stood right in front of him, and
+Ulysses said:
+
+"My dear, will you be so kind as to show me the house of king Alcinous?
+I am an unfortunate foreigner in distress, and do not know one in your
+town and country."
+
+Then Minerva said, "Yes, father stranger, I will show you the house you
+want, for Alcinous lives quite close to my own father. I will go before
+you and show the way, but say not a word as you go, and do not look
+at any man, nor ask him questions; for the people here cannot abide
+strangers, and do not like men who come from some other place. They are
+a sea-faring folk, and sail the seas by the grace of Neptune in ships
+that glide along like thought, or as a bird in the air."
+
+On this she led the way, and Ulysses followed in her steps; but not one
+of the Phaeacians could see him as he passed through the city in the
+midst of them; for the great goddess Minerva in her good will towards
+him had hidden him in a thick cloud of darkness. He admired their
+harbours, ships, places of assembly, and the lofty walls of the city,
+which, with the palisade on top of them, were very striking, and when
+they reached the king's house Minerva said:
+
+"This is the house, father stranger, which you would have me show you.
+You will find a number of great people sitting at table, but do not be
+afraid; go straight in, for the bolder a man is the more likely he is to
+carry his point, even though he is a stranger. First find the queen. Her
+name is Arete, and she comes of the same family as her husband Alcinous.
+They both descend originally from Neptune, who was father to Nausithous
+by Periboea, a woman of great beauty. Periboea was the youngest daughter
+of Eurymedon, who at one time reigned over the giants, but he ruined his
+ill-fated people and lost his own life to boot.
+
+"Neptune, however, lay with his daughter, and she had a son by him, the
+great Nausithous, who reigned over the Phaeacians. Nausithous had two
+sons Rhexenor and Alcinous; {58} Apollo killed the first of them while
+he was still a bridegroom and without male issue; but he left a daughter
+Arete, whom Alcinous married, and honours as no other woman is honoured
+of all those that keep house along with their husbands.
+
+"Thus she both was, and still is, respected beyond measure by her
+children, by Alcinous himself, and by the whole people, who look upon
+her as a goddess, and greet her whenever she goes about the city, for
+she is a thoroughly good woman both in head and heart, and when any
+women are friends of hers, she will help their husbands also to settle
+their disputes. If you can gain her good will, you may have every hope
+of seeing your friends again, and getting safely back to your home and
+country."
+
+Then Minerva left Scheria and went away over the sea. She went to
+Marathon {59} and to the spacious streets of Athens, where she entered
+the abode of Erechtheus; but Ulysses went on to the house of Alcinous,
+and he pondered much as he paused a while before reaching the threshold
+of bronze, for the splendour of the palace was like that of the sun or
+moon. The walls on either side were of bronze from end to end, and the
+cornice was of blue enamel. The doors were gold, and hung on pillars of
+silver that rose from a floor of bronze, while the lintel was silver and
+the hook of the door was of gold.
+
+On either side there stood gold and silver mastiffs which Vulcan, with
+his consummate skill, had fashioned expressly to keep watch over the
+palace of king Alcinous; so they were immortal and could never grow old.
+Seats were ranged all along the wall, here and there from one end to the
+other, with coverings of fine woven work which the women of the house
+had made. Here the chief persons of the Phaeacians used to sit and eat
+and drink, for there was abundance at all seasons; and there were golden
+figures of young men with lighted torches in their hands, raised on
+pedestals, to give light by night to those who were at table. There are
+{60} fifty maid servants in the house, some of whom are always grinding
+rich yellow grain at the mill, while others work at the loom, or sit and
+spin, and their shuttles go backwards and forwards like the fluttering
+of aspen leaves, while the linen is so closely woven that it will turn
+oil. As the Phaeacians are the best sailors in the world, so their women
+excel all others in weaving, for Minerva has taught them all manner of
+useful arts, and they are very intelligent.
+
+Outside the gate of the outer court there is a large garden of
+about four acres with a wall all round it. It is full of beautiful
+trees--pears, pomegranates, and the most delicious apples. There are
+luscious figs also, and olives in full growth. The fruits never rot nor
+fail all the year round, neither winter nor summer, for the air is so
+soft that a new crop ripens before the old has dropped. Pear grows on
+pear, apple on apple, and fig on fig, and so also with the grapes, for
+there is an excellent vineyard: on the level ground of a part of this,
+the grapes are being made into raisins; in another part they are being
+gathered; some are being trodden in the wine tubs, others further on
+have shed their blossom and are beginning to show fruit, others again
+are just changing colour. In the furthest part of the ground there are
+beautifully arranged beds of flowers that are in bloom all the year
+round. Two streams go through it, the one turned in ducts throughout the
+whole garden, while the other is carried under the ground of the outer
+court to the house itself, and the town's people draw water from it.
+Such, then, were the splendours with which the gods had endowed the
+house of king Alcinous.
+
+So here Ulysses stood for a while and looked about him, but when he
+had looked long enough he crossed the threshold and went within the
+precincts of the house. There he found all the chief people among the
+Phaeacians making their drink offerings to Mercury, which they always
+did the last thing before going away for the night. {61} He went
+straight through the court, still hidden by the cloak of darkness
+in which Minerva had enveloped him, till he reached Arete and King
+Alcinous; then he laid his hands upon the knees of the queen, and at
+that moment the miraculous darkness fell away from him and he became
+visible. Every one was speechless with surprise at seeing a man there,
+but Ulysses began at once with his petition.
+
+"Queen Arete," he exclaimed, "daughter of great Rhexenor, in my distress
+I humbly pray you, as also your husband and these your guests (whom may
+heaven prosper with long life and happiness, and may they leave their
+possessions to their children, and all the honours conferred upon them
+by the state) to help me home to my own country as soon as possible; for
+I have been long in trouble and away from my friends."
+
+Then he sat down on the hearth among the ashes and they all held their
+peace, till presently the old hero Echeneus, who was an excellent
+speaker and an elder among the Phaeacians, plainly and in all honesty
+addressed them thus:
+
+"Alcinous," said he, "it is not creditable to you that a stranger should
+be seen sitting among the ashes of your hearth; every one is waiting to
+hear what you are about to say; tell him, then, to rise and take a seat
+on a stool inlaid with silver, and bid your servants mix some wine and
+water that we may make a drink offering to Jove the lord of thunder,
+who takes all well disposed suppliants under his protection; and let
+the housekeeper give him some supper, of whatever there may be in the
+house."
+
+When Alcinous heard this he took Ulysses by the hand, raised him from
+the hearth, and bade him take the seat of Laodamas, who had been sitting
+beside him, and was his favourite son. A maid servant then brought him
+water in a beautiful golden ewer and poured it into a silver basin for
+him to wash his hands, and she drew a clean table beside him; an upper
+servant brought him bread and offered him many good things of what there
+was in the house, and Ulysses ate and drank. Then Alcinous said to one
+of the servants, "Pontonous, mix a cup of wine and hand it round that
+we may make drink-offerings to Jove the lord of thunder, who is the
+protector of all well-disposed suppliants."
+
+Pontonous then mixed wine and water, and handed it round after giving
+every man his drink-offering. When they had made their offerings, and
+had drunk each as much as he was minded, Alcinous said:
+
+"Aldermen and town councillors of the Phaeacians, hear my words. You
+have had your supper, so now go home to bed. To-morrow morning I shall
+invite a still larger number of aldermen, and will give a sacrificial
+banquet in honour of our guest; we can then discuss the question of his
+escort, and consider how we may at once send him back rejoicing to his
+own country without trouble or inconvenience to himself, no matter how
+distant it may be. We must see that he comes to no harm while on his
+homeward journey, but when he is once at home he will have to take
+the luck he was born with for better or worse like other people. It is
+possible, however, that the stranger is one of the immortals who
+has come down from heaven to visit us; but in this case the gods
+are departing from their usual practice, for hitherto they have made
+themselves perfectly clear to us when we have been offering them
+hecatombs. They come and sit at our feasts just like one of our selves,
+and if any solitary wayfarer happens to stumble upon some one or other
+of them, they affect no concealment, for we are as near of kin to the
+gods as the Cyclopes and the savage giants are." {62}
+
+Then Ulysses said: "Pray, Alcinous, do not take any such notion into
+your head. I have nothing of the immortal about me, neither in body
+nor mind, and most resemble those among you who are the most afflicted.
+Indeed, were I to tell you all that heaven has seen fit to lay upon me,
+you would say that I was still worse off than they are. Nevertheless,
+let me sup in spite of sorrow, for an empty stomach is a very
+importunate thing, and thrusts itself on a man's notice no matter how
+dire is his distress. I am in great trouble, yet it insists that I shall
+eat and drink, bids me lay aside all memory of my sorrows and dwell only
+on the due replenishing of itself. As for yourselves, do as you propose,
+and at break of day set about helping me to get home. I shall be content
+to die if I may first once more behold my property, my bondsmen, and all
+the greatness of my house." {63}
+
+Thus did he speak. Every one approved his saying, and agreed that he
+should have his escort inasmuch as he had spoken reasonably. Then when
+they had made their drink offerings, and had drunk each as much as he
+was minded they went home to bed every man in his own abode, leaving
+Ulysses in the cloister with Arete and Alcinous while the servants were
+taking the things away after supper. Arete was the first to speak,
+for she recognised the shirt, cloak, and good clothes that Ulysses
+was wearing, as the work of herself and of her maids; so she said,
+"Stranger, before we go any further, there is a question I should like
+to ask you. Who, and whence are you, and who gave you those clothes? Did
+you not say you had come here from beyond the sea?"
+
+And Ulysses answered, "It would be a long story Madam, were I to relate
+in full the tale of my misfortunes, for the hand of heaven has been laid
+heavy upon me; but as regards your question, there is an island far away
+in the sea which is called 'the Ogygian.' Here dwells the cunning and
+powerful goddess Calypso, daughter of Atlas. She lives by herself far
+from all neighbours human or divine. Fortune, however, brought me to
+her hearth all desolate and alone, for Jove struck my ship with his
+thunderbolts, and broke it up in mid-ocean. My brave comrades were
+drowned every man of them, but I stuck to the keel and was carried
+hither and thither for the space of nine days, till at last during the
+darkness of the tenth night the gods brought me to the Ogygian island
+where the great goddess Calypso lives. She took me in and treated me
+with the utmost kindness; indeed she wanted to make me immortal that I
+might never grow old, but she could not persuade me to let her do so.
+
+"I stayed with Calypso seven years straight on end, and watered the good
+clothes she gave me with my tears during the whole time; but at last
+when the eighth year came round she bade me depart of her own free will,
+either because Jove had told her she must, or because she had changed
+her mind. She sent me from her island on a raft, which she provisioned
+with abundance of bread and wine. Moreover she gave me good stout
+clothing, and sent me a wind that blew both warm and fair. Days seven
+and ten did I sail over the sea, and on the eighteenth I caught sight of
+the first outlines of the mountains upon your coast--and glad indeed was
+I to set eyes upon them. Nevertheless there was still much trouble in
+store for me, for at this point Neptune would let me go no further, and
+raised a great storm against me; the sea was so terribly high that I
+could no longer keep to my raft, which went to pieces under the fury of
+the gale, and I had to swim for it, till wind and current brought me to
+your shores.
+
+"There I tried to land, but could not, for it was a bad place and the
+waves dashed me against the rocks, so I again took to the sea and swam
+on till I came to a river that seemed the most likely landing place, for
+there were no rocks and it was sheltered from the wind. Here, then, I
+got out of the water and gathered my senses together again. Night was
+coming on, so I left the river, and went into a thicket, where I covered
+myself all over with leaves, and presently heaven sent me off into a
+very deep sleep. Sick and sorry as I was I slept among the leaves all
+night, and through the next day till afternoon, when I woke as the sun
+was westering, and saw your daughter's maid servants playing upon the
+beach, and your daughter among them looking like a goddess. I besought
+her aid, and she proved to be of an excellent disposition, much more so
+than could be expected from so young a person--for young people are apt
+to be thoughtless. She gave me plenty of bread and wine, and when she
+had had me washed in the river she also gave me the clothes in which you
+see me. Now, therefore, though it has pained me to do so, I have told
+you the whole truth."
+
+Then Alcinous said, "Stranger, it was very wrong of my daughter not to
+bring you on at once to my house along with the maids, seeing that she
+was the first person whose aid you asked."
+
+"Pray do not scold her," replied Ulysses; "she is not to blame. She did
+tell me to follow along with the maids, but I was ashamed and afraid,
+for I thought you might perhaps be displeased if you saw me. Every human
+being is sometimes a little suspicious and irritable."
+
+"Stranger," replied Alcinous, "I am not the kind of man to get angry
+about nothing; it is always better to be reasonable; but by Father Jove,
+Minerva, and Apollo, now that I see what kind of person you are, and how
+much you think as I do, I wish you would stay here, marry my daughter,
+and become my son-in-law. If you will stay I will give you a house and
+an estate, but no one (heaven forbid) shall keep you here against your
+own wish, and that you may be sure of this I will attend tomorrow to the
+matter of your escort. You can sleep {64} during the whole voyage if you
+like, and the men shall sail you over smooth waters either to your own
+home, or wherever you please, even though it be a long way further
+off than Euboea, which those of my people who saw it when they took
+yellow-haired Rhadamanthus to see Tityus the son of Gaia, tell me is the
+furthest of any place--and yet they did the whole voyage in a single day
+without distressing themselves, and came back again afterwards. You
+will thus see how much my ships excel all others, and what magnificent
+oarsmen my sailors are."
+
+Then was Ulysses glad and prayed aloud saying, "Father Jove, grant that
+Alcinous may do all as he has said, for so he will win an imperishable
+name among mankind, and at the same time I shall return to my country."
+
+Thus did they converse. Then Arete told her maids to set a bed in the
+room that was in the gatehouse, and make it with good red rugs, and to
+spread coverlets on the top of them with woollen cloaks for Ulysses to
+wear. The maids thereon went out with torches in their hands, and when
+they had made the bed they came up to Ulysses and said, "Rise, sir
+stranger, and come with us for your bed is ready," and glad indeed was
+he to go to his rest.
+
+So Ulysses slept in a bed placed in a room over the echoing gateway; but
+Alcinous lay in the inner part of the house, with the queen his wife by
+his side.
+
+
+Book VIII
+
+BANQUET IN THE HOUSE OF ALCINOUS--THE GAMES.
+
+Now when the child of morning, rosy-fingered Dawn, appeared, Alcinous
+and Ulysses both rose, and Alcinous led the way to the Phaeacian place
+of assembly, which was near the ships. When they got there they sat down
+side by side on a seat of polished stone, while Minerva took the form
+of one of Alcinous' servants, and went round the town in order to help
+Ulysses to get home. She went up to the citizens, man by man, and said,
+"Aldermen and town councillors of the Phaeacians, come to the assembly
+all of you and listen to the stranger who has just come off a long
+voyage to the house of King Alcinous; he looks like an immortal god."
+
+With these words she made them all want to come, and they flocked to the
+assembly till seats and standing room were alike crowded. Every one was
+struck with the appearance of Ulysses, for Minerva had beautified him
+about the head and shoulders, making him look taller and stouter than he
+really was, that he might impress the Phaeacians favourably as being a
+very remarkable man, and might come off well in the many trials of skill
+to which they would challenge him. Then, when they were got together,
+Alcinous spoke:
+
+"Hear me," said he, "aldermen and town councillors of the Phaeacians,
+that I may speak even as I am minded. This stranger, whoever he may be,
+has found his way to my house from somewhere or other either East or
+West. He wants an escort and wishes to have the matter settled. Let
+us then get one ready for him, as we have done for others before him;
+indeed, no one who ever yet came to my house has been able to complain
+of me for not speeding on his way soon enough. Let us draw a ship into
+the sea--one that has never yet made a voyage--and man her with two and
+fifty of our smartest young sailors. Then when you have made fast
+your oars each by his own seat, leave the ship and come to my house to
+prepare a feast. {65} I will find you in everything. I am giving these
+instructions to the young men who will form the crew, for as regards
+you aldermen and town councillors, you will join me in entertaining
+our guest in the cloisters. I can take no excuses, and we will have
+Demodocus to sing to us; for there is no bard like him whatever he may
+choose to sing about."
+
+Alcinous then led the way, and the others followed after, while a
+servant went to fetch Demodocus. The fifty-two picked oarsmen went to
+the sea shore as they had been told, and when they got there they drew
+the ship into the water, got her mast and sails inside her, bound
+the oars to the thole-pins with twisted thongs of leather, all in due
+course, and spread the white sails aloft. They moored the vessel a
+little way out from land, and then came on shore and went to the house
+of King Alcinous. The out houses, {66} yards, and all the precincts were
+filled with crowds of men in great multitudes both old and young; and
+Alcinous killed them a dozen sheep, eight full grown pigs, and two oxen.
+These they skinned and dressed so as to provide a magnificent banquet.
+
+A servant presently led in the famous bard Demodocus, whom the muse had
+dearly loved, but to whom she had given both good and evil, for though
+she had endowed him with a divine gift of song, she had robbed him of
+his eyesight. Pontonous set a seat for him among the guests, leaning it
+up against a bearing-post. He hung the lyre for him on a peg over his
+head, and showed him where he was to feel for it with his hands. He also
+set a fair table with a basket of victuals by his side, and a cup of
+wine from which he might drink whenever he was so disposed.
+
+The company then laid their hands upon the good things that were before
+them, but as soon as they had had enough to eat and drink, the muse
+inspired Demodocus to sing the feats of heroes, and more especially
+a matter that was then in the mouths of all men, to wit, the quarrel
+between Ulysses and Achilles, and the fierce words that they heaped on
+one another as they sat together at a banquet. But Agamemnon was glad
+when he heard his chieftains quarrelling with one another, for Apollo
+had foretold him this at Pytho when he crossed the stone floor to
+consult the oracle. Here was the beginning of the evil that by the will
+of Jove fell both upon Danaans and Trojans.
+
+Thus sang the bard, but Ulysses drew his purple mantle over his head and
+covered his face, for he was ashamed to let the Phaeacians see that he
+was weeping. When the bard left off singing he wiped the tears from his
+eyes, uncovered his face, and, taking his cup, made a drink-offering to
+the gods; but when the Phaeacians pressed Demodocus to sing further, for
+they delighted in his lays, then Ulysses again drew his mantle over his
+head and wept bitterly. No one noticed his distress except Alcinous, who
+was sitting near him, and heard the heavy sighs that he was heaving. So
+he at once said, "Aldermen and town councillors of the Phaeacians, we
+have had enough now, both of the feast, and of the minstrelsy that is
+its due accompaniment; let us proceed therefore to the athletic sports,
+so that our guest on his return home may be able to tell his friends
+how much we surpass all other nations as boxers, wrestlers, jumpers, and
+runners."
+
+With these words he led the way, and the others followed after. A
+servant hung Demodocus's lyre on its peg for him, led him out of the
+cloister, and set him on the same way as that along which all the chief
+men of the Phaeacians were going to see the sports; a crowd of several
+thousands of people followed them, and there were many excellent
+competitors for all the prizes. Acroneos, Ocyalus, Elatreus, Nauteus,
+Prymneus, Anchialus, Eretmeus, Ponteus, Proreus, Thoon, Anabesineus, and
+Amphialus son of Polyneus son of Tecton. There was also Euryalus son of
+Naubolus, who was like Mars himself, and was the best looking man
+among the Phaeacians except Laodamas. Three sons of Alcinous, Laodamas,
+Halios, and Clytoneus, competed also.
+
+The foot races came first. The course was set out for them from the
+starting post, and they raised a dust upon the plain as they all flew
+forward at the same moment. Clytoneus came in first by a long way; he
+left every one else behind him by the length of the furrow that a couple
+of mules can plough in a fallow field. {67} They then turned to the
+painful art of wrestling, and here Euryalus proved to be the best man.
+Amphialus excelled all the others in jumping, while at throwing the disc
+there was no one who could approach Elatreus. Alcinous's son Laodamas
+was the best boxer, and he it was who presently said, when they had all
+been diverted with the games, "Let us ask the stranger whether he excels
+in any of these sports; he seems very powerfully built; his thighs,
+calves, hands, and neck are of prodigious strength, nor is he at all
+old, but he has suffered much lately, and there is nothing like the sea
+for making havoc with a man, no matter how strong he is."
+
+"You are quite right, Laodamas," replied Euryalus, "go up to your guest
+and speak to him about it yourself."
+
+When Laodamas heard this he made his way into the middle of the crowd
+and said to Ulysses, "I hope, Sir, that you will enter yourself for some
+one or other of our competitions if you are skilled in any of them--and
+you must have gone in for many a one before now. There is nothing that
+does any one so much credit all his life long as the showing himself a
+proper man with his hands and feet. Have a try therefore at something,
+and banish all sorrow from your mind. Your return home will not be long
+delayed, for the ship is already drawn into the water, and the crew is
+found."
+
+Ulysses answered, "Laodamas, why do you taunt me in this way? my mind is
+set rather on cares than contests; I have been through infinite trouble,
+and am come among you now as a suppliant, praying your king and people
+to further me on my return home."
+
+Then Euryalus reviled him outright and said, "I gather, then, that you
+are unskilled in any of the many sports that men generally delight in. I
+suppose you are one of those grasping traders that go about in ships
+as captains or merchants, and who think of nothing but of their outward
+freights and homeward cargoes. There does not seem to be much of the
+athlete about you."
+
+"For shame, Sir," answered Ulysses, fiercely, "you are an insolent
+fellow--so true is it that the gods do not grace all men alike in
+speech, person, and understanding. One man may be of weak presence, but
+heaven has adorned this with such a good conversation that he charms
+every one who sees him; his honeyed moderation carries his hearers with
+him so that he is leader in all assemblies of his fellows, and wherever
+he goes he is looked up to. Another may be as handsome as a god, but his
+good looks are not crowned with discretion. This is your case. No god
+could make a finer looking fellow than you are, but you are a fool. Your
+ill-judged remarks have made me exceedingly angry, and you are quite
+mistaken, for I excel in a great many athletic exercises; indeed, so
+long as I had youth and strength, I was among the first athletes of the
+age. Now, however, I am worn out by labour and sorrow, for I have gone
+through much both on the field of battle and by the waves of the weary
+sea; still, in spite of all this I will compete, for your taunts have
+stung me to the quick."
+
+So he hurried up without even taking his cloak off, and seized a disc,
+larger, more massive and much heavier than those used by the Phaeacians
+when disc-throwing among themselves. {68} Then, swinging it back, he
+threw it from his brawny hand, and it made a humming sound in the air as
+he did so. The Phaeacians quailed beneath the rushing of its flight as
+it sped gracefully from his hand, and flew beyond any mark that had been
+made yet. Minerva, in the form of a man, came and marked the place where
+it had fallen. "A blind man, Sir," said she, "could easily tell your
+mark by groping for it--it is so far ahead of any other. You may make
+your mind easy about this contest, for no Phaeacian can come near to
+such a throw as yours."
+
+Ulysses was glad when he found he had a friend among the lookers-on,
+so he began to speak more pleasantly. "Young men," said he, "come up to
+that throw if you can, and I will throw another disc as heavy or even
+heavier. If anyone wants to have a bout with me let him come on, for I
+am exceedingly angry; I will box, wrestle, or run, I do not care what it
+is, with any man of you all except Laodamas, but not with him because I
+am his guest, and one cannot compete with one's own personal friend.
+At least I do not think it a prudent or a sensible thing for a guest
+to challenge his host's family at any game, especially when he is in a
+foreign country. He will cut the ground from under his own feet if he
+does; but I make no exception as regards any one else, for I want to
+have the matter out and know which is the best man. I am a good hand
+at every kind of athletic sport known among mankind. I am an excellent
+archer. In battle I am always the first to bring a man down with my
+arrow, no matter how many more are taking aim at him alongside of me.
+Philoctetes was the only man who could shoot better than I could when we
+Achaeans were before Troy and in practice. I far excel every one else
+in the whole world, of those who still eat bread upon the face of the
+earth, but I should not like to shoot against the mighty dead, such as
+Hercules, or Eurytus the Oechalian--men who could shoot against the gods
+themselves. This in fact was how Eurytus came prematurely by his end,
+for Apollo was angry with him and killed him because he challenged him
+as an archer. I can throw a dart farther than any one else can shoot an
+arrow. Running is the only point in respect of which I am afraid some of
+the Phaeacians might beat me, for I have been brought down very low at
+sea; my provisions ran short, and therefore I am still weak."
+
+They all held their peace except King Alcinous, who began, "Sir, we have
+had much pleasure in hearing all that you have told us, from which I
+understand that you are willing to show your prowess, as having been
+displeased with some insolent remarks that have been made to you by one
+of our athletes, and which could never have been uttered by any one who
+knows how to talk with propriety. I hope you will apprehend my meaning,
+and will explain to any one of your chief men who may be dining with
+yourself and your family when you get home, that we have an hereditary
+aptitude for accomplishments of all kinds. We are not particularly
+remarkable for our boxing, nor yet as wrestlers, but we are singularly
+fleet of foot and are excellent sailors. We are extremely fond of good
+dinners, music, and dancing; we also like frequent changes of linen,
+warm baths, and good beds, so now, please, some of you who are the best
+dancers set about dancing, that our guest on his return home may be able
+to tell his friends how much we surpass all other nations as sailors,
+runners, dancers, and minstrels. Demodocus has left his lyre at my
+house, so run some one or other of you and fetch it for him."
+
+On this a servant hurried off to bring the lyre from the king's house,
+and the nine men who had been chosen as stewards stood forward. It was
+their business to manage everything connected with the sports, so
+they made the ground smooth and marked a wide space for the dancers.
+Presently the servant came back with Demodocus's lyre, and he took his
+place in the midst of them, whereon the best young dancers in the town
+began to foot and trip it so nimbly that Ulysses was delighted with the
+merry twinkling of their feet.
+
+Meanwhile the bard began to sing the loves of Mars and Venus, and how
+they first began their intrigue in the house of Vulcan. Mars made Venus
+many presents, and defiled King Vulcan's marriage bed, so the sun, who
+saw what they were about, told Vulcan. Vulcan was very angry when he
+heard such dreadful news, so he went to his smithy brooding mischief,
+got his great anvil into its place, and began to forge some chains which
+none could either unloose or break, so that they might stay there in
+that place. {69} When he had finished his snare he went into his bedroom
+and festooned the bed-posts all over with chains like cobwebs; he also
+let many hang down from the great beam of the ceiling. Not even a god
+could see them so fine and subtle were they. As soon as he had spread
+the chains all over the bed, he made as though he were setting out for
+the fair state of Lemnos, which of all places in the world was the one
+he was most fond of. But Mars kept no blind look out, and as soon as he
+saw him start, hurried off to his house, burning with love for Venus.
+
+Now Venus was just come in from a visit to her father Jove, and was
+about sitting down when Mars came inside the house, and said as he took
+her hand in his own, "Let us go to the couch of Vulcan: he is not at
+home, but is gone off to Lemnos among the Sintians, whose speech is
+barbarous."
+
+She was nothing loth, so they went to the couch to take their rest,
+whereon they were caught in the toils which cunning Vulcan had spread
+for them, and could neither get up nor stir hand or foot, but found too
+late that they were in a trap. Then Vulcan came up to them, for he had
+turned back before reaching Lemnos, when his scout the sun told him what
+was going on. He was in a furious passion, and stood in the vestibule
+making a dreadful noise as he shouted to all the gods.
+
+"Father Jove," he cried, "and all you other blessed gods who live for
+ever, come here and see the ridiculous and disgraceful sight that I will
+show you. Jove's daughter Venus is always dishonouring me because I am
+lame. She is in love with Mars, who is handsome and clean built, whereas
+I am a cripple--but my parents are to blame for that, not I; they ought
+never to have begotten me. Come and see the pair together asleep on
+my bed. It makes me furious to look at them. They are very fond of one
+another, but I do not think they will lie there longer than they can
+help, nor do I think that they will sleep much; there, however, they
+shall stay till her father has repaid me the sum I gave him for his
+baggage of a daughter, who is fair but not honest."
+
+On this the gods gathered to the house of Vulcan. Earth-encircling
+Neptune came, and Mercury the bringer of luck, and King Apollo, but the
+goddesses staid at home all of them for shame. Then the givers of all
+good things stood in the doorway, and the blessed gods roared with
+inextinguishable laughter, as they saw how cunning Vulcan had been,
+whereon one would turn towards his neighbour saying:
+
+"Ill deeds do not prosper, and the weak confound the strong. See how
+limping Vulcan, lame as he is, has caught Mars who is the fleetest god
+in heaven; and now Mars will be cast in heavy damages."
+
+Thus did they converse, but King Apollo said to Mercury, "Messenger
+Mercury, giver of good things, you would not care how strong the chains
+were, would you, if you could sleep with Venus?"
+
+"King Apollo," answered Mercury, "I only wish I might get the chance,
+though there were three times as many chains--and you might look on, all
+of you, gods and goddesses, but I would sleep with her if I could."
+
+The immortal gods burst out laughing as they heard him, but Neptune took
+it all seriously, and kept on imploring Vulcan to set Mars free again.
+"Let him go," he cried, "and I will undertake, as you require, that
+he shall pay you all the damages that are held reasonable among the
+immortal gods."
+
+"Do not," replied Vulcan, "ask me to do this; a bad man's bond is bad
+security; what remedy could I enforce against you if Mars should go away
+and leave his debts behind him along with his chains?"
+
+"Vulcan," said Neptune, "if Mars goes away without paying his damages,
+I will pay you myself." So Vulcan answered, "In this case I cannot and
+must not refuse you."
+
+Thereon he loosed the bonds that bound them, and as soon as they were
+free they scampered off, Mars to Thrace and laughter-loving Venus to
+Cyprus and to Paphos, where is her grove and her altar fragrant with
+burnt offerings. Here the Graces bathed her, and anointed her with oil
+of ambrosia such as the immortal gods make use of, and they clothed her
+in raiment of the most enchanting beauty.
+
+Thus sang the bard, and both Ulysses and the seafaring Phaeacians were
+charmed as they heard him.
+
+Then Alcinous told Laodamas and Halius to dance alone, for there was no
+one to compete with them. So they took a red ball which Polybus had made
+for them, and one of them bent himself backwards and threw it up towards
+the clouds, while the other jumped from off the ground and caught it
+with ease before it came down again. When they had done throwing the
+ball straight up into the air they began to dance, and at the same time
+kept on throwing it backwards and forwards to one another, while all
+the young men in the ring applauded and made a great stamping with their
+feet. Then Ulysses said:
+
+"King Alcinous, you said your people were the nimblest dancers in the
+world, and indeed they have proved themselves to be so. I was astonished
+as I saw them."
+
+The king was delighted at this, and exclaimed to the Phaeacians,
+"Aldermen and town councillors, our guest seems to be a person of
+singular judgement; let us give him such proof of our hospitality as
+he may reasonably expect. There are twelve chief men among you, and
+counting myself there are thirteen; contribute, each of you, a clean
+cloak, a shirt, and a talent of fine gold; let us give him all this in
+a lump down at once, so that when he gets his supper he may do so with a
+light heart. As for Euryalus he will have to make a formal apology and a
+present too, for he has been rude."
+
+Thus did he speak. The others all of them applauded his saying, and
+sent their servants to fetch the presents. Then Euryalus said, "King
+Alcinous, I will give the stranger all the satisfaction you require. He
+shall have my sword, which is of bronze, all but the hilt, which is of
+silver. I will also give him the scabbard of newly sawn ivory into which
+it fits. It will be worth a great deal to him."
+
+As he spoke he placed the sword in the hands of Ulysses and said, "Good
+luck to you, father stranger; if anything has been said amiss may the
+winds blow it away with them, and may heaven grant you a safe return,
+for I understand you have been long away from home, and have gone
+through much hardship."
+
+To which Ulysses answered, "Good luck to you too my friend, and may the
+gods grant you every happiness. I hope you will not miss the sword you
+have given me along with your apology."
+
+With these words he girded the sword about his shoulders and towards
+sundown the presents began to make their appearance, as the servants of
+the donors kept bringing them to the house of King Alcinous; here his
+sons received them, and placed them under their mother's charge. Then
+Alcinous led the way to the house and bade his guests take their seats.
+
+"Wife," said he, turning to Queen Arete, "Go, fetch the best chest we
+have, and put a clean cloak and shirt in it. Also, set a copper on the
+fire and heat some water; our guest will take a warm bath; see also to
+the careful packing of the presents that the noble Phaeacians have made
+him; he will thus better enjoy both his supper and the singing that
+will follow. I shall myself give him this golden goblet--which is of
+exquisite workmanship--that he may be reminded of me for the rest of his
+life whenever he makes a drink offering to Jove, or to any of the gods."
+{70}
+
+Then Arete told her maids to set a large tripod upon the fire as fast as
+they could, whereon they set a tripod full of bath water on to a clear
+fire; they threw on sticks to make it blaze, and the water became hot
+as the flame played about the belly of the tripod. {71} Meanwhile Arete
+brought a magnificent chest from her own room, and inside it she packed
+all the beautiful presents of gold and raiment which the Phaeacians had
+brought. Lastly she added a cloak and a good shirt from Alcinous, and
+said to Ulysses:
+
+"See to the lid yourself, and have the whole bound round at once, for
+fear any one should rob you by the way when you are asleep in your
+ship." {72}
+
+When Ulysses heard this he put the lid on the chest and made it fast
+with a bond that Circe had taught him. He had done so before an upper
+servant told him to come to the bath and wash himself. He was very glad
+of a warm bath, for he had had no one to wait upon him ever since he
+left the house of Calypso, who as long as he remained with her had taken
+as good care of him as though he had been a god. When the servants had
+done washing and anointing him with oil, and had given him a clean cloak
+and shirt, he left the bath room and joined the guests who were sitting
+over their wine. Lovely Nausicaa stood by one of the bearing-posts
+supporting the roof of the cloister, and admired him as she saw him
+pass. "Farewell stranger," said she, "do not forget me when you are safe
+at home again, for it is to me first that you owe a ransom for having
+saved your life."
+
+And Ulysses said, "Nausicaa, daughter of great Alcinous, may Jove the
+mighty husband of Juno, grant that I may reach my home; so shall I bless
+you as my guardian angel all my days, for it was you who saved me."
+
+When he had said this, he seated himself beside Alcinous. Supper was
+then served, and the wine was mixed for drinking. A servant led in the
+favourite bard Demodocus, and set him in the midst of the company, near
+one of the bearing-posts supporting the cloister, that he might lean
+against it. Then Ulysses cut off a piece of roast pork with plenty of
+fat (for there was abundance left on the joint) and said to a servant,
+"Take this piece of pork over to Demodocus and tell him to eat it; for
+all the pain his lays may cause me I will salute him none the less;
+bards are honoured and respected throughout the world, for the muse
+teaches them their songs and loves them."
+
+The servant carried the pork in his fingers over to Demodocus, who took
+it and was very much pleased. They then laid their hands on the good
+things that were before them, and as soon as they had had to eat and
+drink, Ulysses said to Demodocus, "Demodocus, there is no one in the
+world whom I admire more than I do you. You must have studied under the
+Muse, Jove's daughter, and under Apollo, so accurately do you sing the
+return of the Achaeans with all their sufferings and adventures. If you
+were not there yourself, you must have heard it all from some one who
+was. Now, however, change your song and tell us of the wooden horse
+which Epeus made with the assistance of Minerva, and which Ulysses got
+by stratagem into the fort of Troy after freighting it with the men who
+afterwards sacked the city. If you will sing this tale aright I will
+tell all the world how magnificently heaven has endowed you."
+
+The bard inspired of heaven took up the story at the point where some of
+the Argives set fire to their tents and sailed away while others, hidden
+within the horse, {73} were waiting with Ulysses in the Trojan place
+of assembly. For the Trojans themselves had drawn the horse into their
+fortress, and it stood there while they sat in council round it, and
+were in three minds as to what they should do. Some were for breaking it
+up then and there; others would have it dragged to the top of the rock
+on which the fortress stood, and then thrown down the precipice; while
+yet others were for letting it remain as an offering and propitiation
+for the gods. And this was how they settled it in the end, for the city
+was doomed when it took in that horse, within which were all the bravest
+of the Argives waiting to bring death and destruction on the Trojans.
+Anon he sang how the sons of the Achaeans issued from the horse, and
+sacked the town, breaking out from their ambuscade. He sang how they
+overran the city hither and thither and ravaged it, and how Ulysses went
+raging like Mars along with Menelaus to the house of Deiphobus. It was
+there that the fight raged most furiously, nevertheless by Minerva's
+help he was victorious.
+
+All this he told, but Ulysses was overcome as he heard him, and his
+cheeks were wet with tears. He wept as a woman weeps when she throws
+herself on the body of her husband who has fallen before his own city
+and people, fighting bravely in defence of his home and children. She
+screams aloud and flings her arms about him as he lies gasping for
+breath and dying, but her enemies beat her from behind about the back
+and shoulders, and carry her off into slavery, to a life of labour and
+sorrow, and the beauty fades from her cheeks--even so piteously did
+Ulysses weep, but none of those present perceived his tears except
+Alcinous, who was sitting near him, and could hear the sobs and sighs
+that he was heaving. The king, therefore, at once rose and said:
+
+"Aldermen and town councillors of the Phaeacians, let Demodocus cease
+his song, for there are those present who do not seem to like it. From
+the moment that we had done supper and Demodocus began to sing, our
+guest has been all the time groaning and lamenting. He is evidently
+in great trouble, so let the bard leave off, that we may all enjoy
+ourselves, hosts and guest alike. This will be much more as it should
+be, for all these festivities, with the escort and the presents that we
+are making with so much good will are wholly in his honour, and any
+one with even a moderate amount of right feeling knows that he ought to
+treat a guest and a suppliant as though he were his own brother.
+
+"Therefore, Sir, do you on your part affect no more concealment nor
+reserve in the matter about which I shall ask you; it will be more
+polite in you to give me a plain answer; tell me the name by which your
+father and mother over yonder used to call you, and by which you were
+known among your neighbours and fellow-citizens. There is no one,
+neither rich nor poor, who is absolutely without any name whatever, for
+people's fathers and mothers give them names as soon as they are born.
+Tell me also your country, nation, and city, that our ships may shape
+their purpose accordingly and take you there. For the Phaeacians have
+no pilots; their vessels have no rudders as those of other nations have,
+but the ships themselves understand what it is that we are thinking
+about and want; they know all the cities and countries in the whole
+world, and can traverse the sea just as well even when it is covered
+with mist and cloud, so that there is no danger of being wrecked or
+coming to any harm. Still I do remember hearing my father say that
+Neptune was angry with us for being too easy-going in the matter of
+giving people escorts. He said that one of these days he should wreck a
+ship of ours as it was returning from having escorted some one, {74} and
+bury our city under a high mountain. This is what my father used to say,
+but whether the god will carry out his threat or no is a matter which he
+will decide for himself.
+
+"And now, tell me and tell me true. Where have you been wandering, and
+in what countries have you travelled? Tell us of the peoples themselves,
+and of their cities--who were hostile, savage and uncivilised, and who,
+on the other hand, hospitable and humane. Tell us also why you are made
+so unhappy on hearing about the return of the Argive Danaans from Troy.
+The gods arranged all this, and sent them their misfortunes in order
+that future generations might have something to sing about. Did you
+lose some brave kinsman of your wife's when you were before Troy? a
+son-in-law or father-in-law--which are the nearest relations a man has
+outside his own flesh and blood? or was it some brave and kindly-natured
+comrade--for a good friend is as dear to a man as his own brother?"
+
+
+Book IX
+
+ULYSSES DECLARES HIMSELF AND BEGINS HIS STORY---THE CICONS, LOTOPHAGI,
+AND CYCLOPES.
+
+
+And Ulysses answered, "King Alcinous, it is a good thing to hear a bard
+with such a divine voice as this man has. There is nothing better or
+more delightful than when a whole people make merry together, with the
+guests sitting orderly to listen, while the table is loaded with bread
+and meats, and the cup-bearer draws wine and fills his cup for every
+man. This is indeed as fair a sight as a man can see. Now, however,
+since you are inclined to ask the story of my sorrows, and rekindle my
+own sad memories in respect of them, I do not know how to begin, nor yet
+how to continue and conclude my tale, for the hand of heaven has been
+laid heavily upon me.
+
+"Firstly, then, I will tell you my name that you too may know it, and
+one day, if I outlive this time of sorrow, may become my guests though I
+live so far away from all of you. I am Ulysses son of Laertes, renowned
+among mankind for all manner of subtlety, so that my fame ascends to
+heaven. I live in Ithaca, where there is a high mountain called Neritum,
+covered with forests; and not far from it there is a group of islands
+very near to one another--Dulichium, Same, and the wooded island of
+Zacynthus. It lies squat on the horizon, all highest up in the sea
+towards the sunset, while the others lie away from it towards dawn. {75}
+It is a rugged island, but it breeds brave men, and my eyes know none
+that they better love to look upon. The goddess Calypso kept me with her
+in her cave, and wanted me to marry her, as did also the cunning Aeaean
+goddess Circe; but they could neither of them persuade me, for there
+is nothing dearer to a man than his own country and his parents, and
+however splendid a home he may have in a foreign country, if it be far
+from father or mother, he does not care about it. Now, however, I will
+tell you of the many hazardous adventures which by Jove's will I met
+with on my return from Troy.
+
+"When I had set sail thence the wind took me first to Ismarus, which is
+the city of the Cicons. There I sacked the town and put the people to
+the sword. We took their wives and also much booty, which we divided
+equitably amongst us, so that none might have reason to complain. I
+then said that we had better make off at once, but my men very foolishly
+would not obey me, so they staid there drinking much wine and killing
+great numbers of sheep and oxen on the sea shore. Meanwhile the Cicons
+cried out for help to other Cicons who lived inland. These were more in
+number, and stronger, and they were more skilled in the art of war,
+for they could fight, either from chariots or on foot as the occasion
+served; in the morning, therefore, they came as thick as leaves and
+bloom in summer, and the hand of heaven was against us, so that we were
+hard pressed. They set the battle in array near the ships, and the hosts
+aimed their bronze-shod spears at one another. {76} So long as the day
+waxed and it was still morning, we held our own against them, though
+they were more in number than we; but as the sun went down, towards the
+time when men loose their oxen, the Cicons got the better of us, and we
+lost half a dozen men from every ship we had; so we got away with those
+that were left.
+
+"Thence we sailed onward with sorrow in our hearts, but glad to have
+escaped death though we had lost our comrades, nor did we leave till we
+had thrice invoked each one of the poor fellows who had perished by the
+hands of the Cicons. Then Jove raised the North wind against us till it
+blew a hurricane, so that land and sky were hidden in thick clouds, and
+night sprang forth out of the heavens. We let the ships run before the
+gale, but the force of the wind tore our sails to tatters, so we took
+them down for fear of shipwreck, and rowed our hardest towards the land.
+There we lay two days and two nights suffering much alike from toil and
+distress of mind, but on the morning of the third day we again raised
+our masts, set sail, and took our places, letting the wind and steersmen
+direct our ship. I should have got home at that time unharmed had not
+the North wind and the currents been against me as I was doubling Cape
+Malea, and set me off my course hard by the island of Cythera.
+
+"I was driven thence by foul winds for a space of nine days upon the
+sea, but on the tenth day we reached the land of the Lotus-eaters, who
+live on a food that comes from a kind of flower. Here we landed to take
+in fresh water, and our crews got their mid-day meal on the shore near
+the ships. When they had eaten and drunk I sent two of my company to
+see what manner of men the people of the place might be, and they had
+a third man under them. They started at once, and went about among the
+Lotus-eaters, who did them no hurt, but gave them to eat of the lotus,
+which was so delicious that those who ate of it left off caring about
+home, and did not even want to go back and say what had happened to
+them, but were for staying and munching lotus {77} with the Lotus-eaters
+without thinking further of their return; nevertheless, though they wept
+bitterly I forced them back to the ships and made them fast under the
+benches. Then I told the rest to go on board at once, lest any of them
+should taste of the lotus and leave off wanting to get home, so they
+took their places and smote the grey sea with their oars.
+
+"We sailed hence, always in much distress, till we came to the land of
+the lawless and inhuman Cyclopes. Now the Cyclopes neither plant nor
+plough, but trust in providence, and live on such wheat, barley, and
+grapes as grow wild without any kind of tillage, and their wild grapes
+yield them wine as the sun and the rain may grow them. They have no
+laws nor assemblies of the people, but live in caves on the tops of
+high mountains; each is lord and master in his family, and they take no
+account of their neighbours.
+
+"Now off their harbour there lies a wooded and fertile island not quite
+close to the land of the Cyclopes, but still not far. It is over-run
+with wild goats, that breed there in great numbers and are never
+disturbed by foot of man; for sportsmen--who as a rule will suffer so
+much hardship in forest or among mountain precipices--do not go there,
+nor yet again is it ever ploughed or fed down, but it lies a wilderness
+untilled and unsown from year to year, and has no living thing upon it
+but only goats. For the Cyclopes have no ships, nor yet shipwrights who
+could make ships for them; they cannot therefore go from city to city,
+or sail over the sea to one another's country as people who have ships
+can do; if they had had these they would have colonised the island, {78}
+for it is a very good one, and would yield everything in due season.
+There are meadows that in some places come right down to the sea
+shore, well watered and full of luscious grass; grapes would do there
+excellently; there is level land for ploughing, and it would always
+yield heavily at harvest time, for the soil is deep. There is a good
+harbour where no cables are wanted, nor yet anchors, nor need a ship be
+moored, but all one has to do is to beach one's vessel and stay there
+till the wind becomes fair for putting out to sea again. At the head of
+the harbour there is a spring of clear water coming out of a cave, and
+there are poplars growing all round it.
+
+"Here we entered, but so dark was the night that some god must have
+brought us in, for there was nothing whatever to be seen. A thick mist
+hung all round our ships; {79} the moon was hidden behind a mass of
+clouds so that no one could have seen the island if he had looked for
+it, nor were there any breakers to tell us we were close in shore before
+we found ourselves upon the land itself; when, however, we had beached
+the ships, we took down the sails, went ashore and camped upon the beach
+till daybreak.
+
+"When the child of morning, rosy-fingered Dawn appeared, we admired
+the island and wandered all over it, while the nymphs Jove's daughters
+roused the wild goats that we might get some meat for our dinner. On
+this we fetched our spears and bows and arrows from the ships, and
+dividing ourselves into three bands began to shoot the goats. Heaven
+sent us excellent sport; I had twelve ships with me, and each ship got
+nine goats, while my own ship had ten; thus through the livelong day to
+the going down of the sun we ate and drank our fill, and we had plenty
+of wine left, for each one of us had taken many jars full when we sacked
+the city of the Cicons, and this had not yet run out. While we were
+feasting we kept turning our eyes towards the land of the Cyclopes,
+which was hard by, and saw the smoke of their stubble fires. We could
+almost fancy we heard their voices and the bleating of their sheep and
+goats, but when the sun went down and it came on dark, we camped down
+upon the beach, and next morning I called a council.
+
+"'Stay here, my brave fellows,' said I, 'all the rest of you, while I go
+with my ship and exploit these people myself: I want to see if they are
+uncivilised savages, or a hospitable and humane race.'
+
+"I went on board, bidding my men to do so also and loose the hawsers; so
+they took their places and smote the grey sea with their oars. When we
+got to the land, which was not far, there, on the face of a cliff near
+the sea, we saw a great cave overhung with laurels. It was a station for
+a great many sheep and goats, and outside there was a large yard, with
+a high wall round it made of stones built into the ground and of trees
+both pine and oak. This was the abode of a huge monster who was then
+away from home shepherding his flocks. He would have nothing to do with
+other people, but led the life of an outlaw. He was a horrid creature,
+not like a human being at all, but resembling rather some crag that
+stands out boldly against the sky on the top of a high mountain.
+
+"I told my men to draw the ship ashore, and stay where they were, all
+but the twelve best among them, who were to go along with myself. I also
+took a goatskin of sweet black wine which had been given me by Maron,
+son of Euanthes, who was priest of Apollo the patron god of Ismarus, and
+lived within the wooded precincts of the temple. When we were sacking
+the city we respected him, and spared his life, as also his wife and
+child; so he made me some presents of great value--seven talents of fine
+gold, and a bowl of silver, with twelve jars of sweet wine, unblended,
+and of the most exquisite flavour. Not a man nor maid in the house knew
+about it, but only himself, his wife, and one housekeeper: when he drank
+it he mixed twenty parts of water to one of wine, and yet the fragrance
+from the mixing-bowl was so exquisite that it was impossible to refrain
+from drinking. I filled a large skin with this wine, and took a wallet
+full of provisions with me, for my mind misgave me that I might have to
+deal with some savage who would be of great strength, and would respect
+neither right nor law.
+
+"We soon reached his cave, but he was out shepherding, so we went inside
+and took stock of all that we could see. His cheese-racks were loaded
+with cheeses, and he had more lambs and kids than his pens could hold.
+They were kept in separate flocks; first there were the hoggets, then
+the oldest of the younger lambs and lastly the very young ones {80} all
+kept apart from one another; as for his dairy, all the vessels, bowls,
+and milk pails into which he milked, were swimming with whey. When they
+saw all this, my men begged me to let them first steal some cheeses, and
+make off with them to the ship; they would then return, drive down the
+lambs and kids, put them on board and sail away with them. It would have
+been indeed better if we had done so but I would not listen to them, for
+I wanted to see the owner himself, in the hope that he might give me
+a present. When, however, we saw him my poor men found him ill to deal
+with.
+
+"We lit a fire, offered some of the cheeses in sacrifice, ate others
+of them, and then sat waiting till the Cyclops should come in with his
+sheep. When he came, he brought in with him a huge load of dry firewood
+to light the fire for his supper, and this he flung with such a noise on
+to the floor of his cave that we hid ourselves for fear at the far end
+of the cavern. Meanwhile he drove all the ewes inside, as well as the
+she-goats that he was going to milk, leaving the males, both rams and
+he-goats, outside in the yards. Then he rolled a huge stone to the mouth
+of the cave--so huge that two and twenty strong four-wheeled waggons
+would not be enough to draw it from its place against the doorway. When
+he had so done he sat down and milked his ewes and goats, all in due
+course, and then let each of them have her own young. He curdled half
+the milk and set it aside in wicker strainers, but the other half he
+poured into bowls that he might drink it for his supper. When he had got
+through with all his work, he lit the fire, and then caught sight of us,
+whereon he said:
+
+"'Strangers, who are you? Where do sail from? Are you traders, or do
+you sail the sea as rovers, with your hands against every man, and every
+man's hand against you?'
+
+"We were frightened out of our senses by his loud voice and monstrous
+form, but I managed to say, 'We are Achaeans on our way home from Troy,
+but by the will of Jove, and stress of weather, we have been driven far
+out of our course. We are the people of Agamemnon, son of Atreus, who
+has won infinite renown throughout the whole world, by sacking so great
+a city and killing so many people. We therefore humbly pray you to show
+us some hospitality, and otherwise make us such presents as visitors may
+reasonably expect. May your excellency fear the wrath of heaven, for we
+are your suppliants, and Jove takes all respectable travellers under his
+protection, for he is the avenger of all suppliants and foreigners in
+distress.'
+
+"To this he gave me but a pitiless answer, 'Stranger,' said he, 'you are
+a fool, or else you know nothing of this country. Talk to me, indeed,
+about fearing the gods or shunning their anger? We Cyclopes do not care
+about Jove or any of your blessed gods, for we are ever so much stronger
+than they. I shall not spare either yourself or your companions out of
+any regard for Jove, unless I am in the humour for doing so. And now
+tell me where you made your ship fast when you came on shore. Was it
+round the point, or is she lying straight off the land?'
+
+"He said this to draw me out, but I was too cunning to be caught in that
+way, so I answered with a lie; 'Neptune,' said I, 'sent my ship on to
+the rocks at the far end of your country, and wrecked it. We were driven
+on to them from the open sea, but I and those who are with me escaped
+the jaws of death.'
+
+"The cruel wretch vouchsafed me not one word of answer, but with a
+sudden clutch he gripped up two of my men at once and dashed them down
+upon the ground as though they had been puppies. Their brains were shed
+upon the ground, and the earth was wet with their blood. Then he tore
+them limb from limb and supped upon them. He gobbled them up like a lion
+in the wilderness, flesh, bones, marrow, and entrails, without leaving
+anything uneaten. As for us, we wept and lifted up our hands to heaven
+on seeing such a horrid sight, for we did not know what else to do; but
+when the Cyclops had filled his huge paunch, and had washed down his
+meal of human flesh with a drink of neat milk, he stretched himself
+full length upon the ground among his sheep, and went to sleep. I was at
+first inclined to seize my sword, draw it, and drive it into his vitals,
+but I reflected that if I did we should all certainly be lost, for we
+should never be able to shift the stone which the monster had put in
+front of the door. So we stayed sobbing and sighing where we were till
+morning came.
+
+"When the child of morning, rosy-fingered dawn, appeared, he again lit
+his fire, milked his goats and ewes, all quite rightly, and then let
+each have her own young one; as soon as he had got through with all his
+work, he clutched up two more of my men, and began eating them for his
+morning's meal. Presently, with the utmost ease, he rolled the stone
+away from the door and drove out his sheep, but he at once put it back
+again--as easily as though he were merely clapping the lid on to a
+quiver full of arrows. As soon as he had done so he shouted, and cried
+'Shoo, shoo,' after his sheep to drive them on to the mountain; so I was
+left to scheme some way of taking my revenge and covering myself with
+glory.
+
+"In the end I deemed it would be the best plan to do as follows: The
+Cyclops had a great club which was lying near one of the sheep pens;
+it was of green olive wood, and he had cut it intending to use it for
+a staff as soon as it should be dry. It was so huge that we could
+only compare it to the mast of a twenty-oared merchant vessel of large
+burden, and able to venture out into open sea. I went up to this club
+and cut off about six feet of it; I then gave this piece to the men and
+told them to fine it evenly off at one end, which they proceeded to do,
+and lastly I brought it to a point myself, charring the end in the fire
+to make it harder. When I had done this I hid it under dung, which was
+lying about all over the cave, and told the men to cast lots which of
+them should venture along with myself to lift it and bore it into the
+monster's eye while he was asleep. The lot fell upon the very four whom
+I should have chosen, and I myself made five. In the evening the wretch
+came back from shepherding, and drove his flocks into the cave--this
+time driving them all inside, and not leaving any in the yards; I
+suppose some fancy must have taken him, or a god must have prompted him
+to do so. As soon as he had put the stone back to its place against the
+door, he sat down, milked his ewes and his goats all quite rightly, and
+then let each have her own young one; when he had got through with all
+this work, he gripped up two more of my men, and made his supper off
+them. So I went up to him with an ivy-wood bowl of black wine in my
+hands:
+
+"'Look here, Cyclops,' said I, you have been eating a great deal of
+man's flesh, so take this and drink some wine, that you may see what
+kind of liquor we had on board my ship. I was bringing it to you as a
+drink-offering, in the hope that you would take compassion upon me and
+further me on my way home, whereas all you do is to go on ramping and
+raving most intolerably. You ought to be ashamed of yourself; how can
+you expect people to come see you any more if you treat them in this
+way?'
+
+"He then took the cup and drank. He was so delighted with the taste of
+the wine that he begged me for another bowl full. 'Be so kind,' he said,
+'as to give me some more, and tell me your name at once. I want to make
+you a present that you will be glad to have. We have wine even in this
+country, for our soil grows grapes and the sun ripens them, but this
+drinks like Nectar and Ambrosia all in one.'
+
+"I then gave him some more; three times did I fill the bowl for him, and
+three times did he drain it without thought or heed; then, when I saw
+that the wine had got into his head, I said to him as plausibly as
+I could: 'Cyclops, you ask my name and I will tell it you; give me,
+therefore, the present you promised me; my name is Noman; this is what
+my father and mother and my friends have always called me.'
+
+"But the cruel wretch said, 'Then I will eat all Noman's comrades before
+Noman himself, and will keep Noman for the last. This is the present
+that I will make him.'
+
+"As he spoke he reeled, and fell sprawling face upwards on the ground.
+His great neck hung heavily backwards and a deep sleep took hold upon
+him. Presently he turned sick, and threw up both wine and the gobbets of
+human flesh on which he had been gorging, for he was very drunk. Then I
+thrust the beam of wood far into the embers to heat it, and encouraged
+my men lest any of them should turn faint-hearted. When the wood, green
+though it was, was about to blaze, I drew it out of the fire glowing
+with heat, and my men gathered round me, for heaven had filled their
+hearts with courage. We drove the sharp end of the beam into the
+monster's eye, and bearing upon it with all my weight I kept turning it
+round and round as though I were boring a hole in a ship's plank with an
+auger, which two men with a wheel and strap can keep on turning as long
+as they choose. Even thus did we bore the red hot beam into his eye,
+till the boiling blood bubbled all over it as we worked it round and
+round, so that the steam from the burning eyeball scalded his eyelids
+and eyebrows, and the roots of the eye sputtered in the fire. As a
+blacksmith plunges an axe or hatchet into cold water to temper it--for
+it is this that gives strength to the iron--and it makes a great hiss as
+he does so, even thus did the Cyclops' eye hiss round the beam of olive
+wood, and his hideous yells made the cave ring again. We ran away in a
+fright, but he plucked the beam all besmirched with gore from his eye,
+and hurled it from him in a frenzy of rage and pain, shouting as he did
+so to the other Cyclopes who lived on the bleak headlands near him;
+so they gathered from all quarters round his cave when they heard him
+crying, and asked what was the matter with him.
+
+"'What ails you, Polyphemus,' said they, 'that you make such a noise,
+breaking the stillness of the night, and preventing us from being able
+to sleep? Surely no man is carrying off your sheep? Surely no man is
+trying to kill you either by fraud or by force?'
+
+"But Polyphemus shouted to them from inside the cave, 'Noman is killing
+me by fraud; no man is killing me by force.'
+
+"'Then,' said they, 'if no man is attacking you, you must be ill; when
+Jove makes people ill, there is no help for it, and you had better pray
+to your father Neptune.'
+
+"Then they went away, and I laughed inwardly at the success of my clever
+stratagem, but the Cyclops, groaning and in an agony of pain, felt about
+with his hands till he found the stone and took it from the door; then
+he sat in the doorway and stretched his hands in front of it to catch
+anyone going out with the sheep, for he thought I might be foolish
+enough to attempt this.
+
+"As for myself I kept on puzzling to think how I could best save my own
+life and those of my companions; I schemed and schemed, as one who knows
+that his life depends upon it, for the danger was very great. In the
+end I deemed that this plan would be the best; the male sheep were well
+grown, and carried a heavy black fleece, so I bound them noiselessly in
+threes together, with some of the withies on which the wicked monster
+used to sleep. There was to be a man under the middle sheep, and the two
+on either side were to cover him, so that there were three sheep to each
+man. As for myself there was a ram finer than any of the others, so I
+caught hold of him by the back, esconced myself in the thick wool under
+his belly, and hung on patiently to his fleece, face upwards, keeping a
+firm hold on it all the time.
+
+"Thus, then, did we wait in great fear of mind till morning came, but
+when the child of morning, rosy-fingered Dawn, appeared, the male sheep
+hurried out to feed, while the ewes remained bleating about the pens
+waiting to be milked, for their udders were full to bursting; but their
+master in spite of all his pain felt the backs of all the sheep as they
+stood upright, without being sharp enough to find out that the men were
+underneath their bellies. As the ram was going out, last of all, heavy
+with its fleece and with the weight of my crafty self, Polyphemus laid
+hold of it and said:
+
+"'My good ram, what is it that makes you the last to leave my cave this
+morning? You are not wont to let the ewes go before you, but lead the
+mob with a run whether to flowery mead or bubbling fountain, and are the
+first to come home again at night; but now you lag last of all. Is it
+because you know your master has lost his eye, and are sorry because
+that wicked Noman and his horrid crew has got him down in his drink and
+blinded him? But I will have his life yet. If you could understand and
+talk, you would tell me where the wretch is hiding, and I would dash his
+brains upon the ground till they flew all over the cave. I should thus
+have some satisfaction for the harm this no-good Noman has done me.'
+
+"As he spoke he drove the ram outside, but when we were a little way
+out from the cave and yards, I first got from under the ram's belly,
+and then freed my comrades; as for the sheep, which were very fat, by
+constantly heading them in the right direction we managed to drive them
+down to the ship. The crew rejoiced greatly at seeing those of us who
+had escaped death, but wept for the others whom the Cyclops had killed.
+However, I made signs to them by nodding and frowning that they were to
+hush their crying, and told them to get all the sheep on board at once
+and put out to sea; so they went aboard, took their places, and smote
+the grey sea with their oars. Then, when I had got as far out as my
+voice would reach, I began to jeer at the Cyclops.
+
+"'Cyclops,' said I, 'you should have taken better measure of your man
+before eating up his comrades in your cave. You wretch, eat up your
+visitors in your own house? You might have known that your sin would
+find you out, and now Jove and the other gods have punished you.'
+
+"He got more and more furious as he heard me, so he tore the top from
+off a high mountain, and flung it just in front of my ship so that
+it was within a little of hitting the end of the rudder. {81} The sea
+quaked as the rock fell into it, and the wash of the wave it raised
+carried us back towards the mainland, and forced us towards the shore.
+But I snatched up a long pole and kept the ship off, making signs to my
+men by nodding my head, that they must row for their lives, whereon they
+laid out with a will. When we had got twice as far as we were before, I
+was for jeering at the Cyclops again, but the men begged and prayed of
+me to hold my tongue.
+
+"'Do not,' they exclaimed, 'be mad enough to provoke this savage
+creature further; he has thrown one rock at us already which drove us
+back again to the mainland, and we made sure it had been the death
+of us; if he had then heard any further sound of voices he would have
+pounded our heads and our ship's timbers into a jelly with the rugged
+rocks he would have heaved at us, for he can throw them a long way.'
+
+"But I would not listen to them, and shouted out to him in my rage,
+'Cyclops, if any one asks you who it was that put your eye out and
+spoiled your beauty, say it was the valiant warrior Ulysses, son of
+Laertes, who lives in Ithaca.'
+
+"On this he groaned, and cried out, 'Alas, alas, then the old prophecy
+about me is coming true. There was a prophet here, at one time, a man
+both brave and of great stature, Telemus son of Eurymus, who was an
+excellent seer, and did all the prophesying for the Cyclopes till he
+grew old; he told me that all this would happen to me some day, and said
+I should lose my sight by the hand of Ulysses. I have been all along
+expecting some one of imposing presence and superhuman strength, whereas
+he turns out to be a little insignificant weakling, who has managed to
+blind my eye by taking advantage of me in my drink; come here, then,
+Ulysses, that I may make you presents to show my hospitality, and urge
+Neptune to help you forward on your journey--for Neptune and I are
+father and son. He, if he so will, shall heal me, which no one else
+neither god nor man can do.'
+
+"Then I said, 'I wish I could be as sure of killing you outright and
+sending you down to the house of Hades, as I am that it will take more
+than Neptune to cure that eye of yours.'
+
+"On this he lifted up his hands to the firmament of heaven and prayed,
+saying, 'Hear me, great Neptune; if I am indeed your own true begotten
+son, grant that Ulysses may never reach his home alive; or if he must
+get back to his friends at last, let him do so late and in sore plight
+after losing all his men [let him reach his home in another man's ship
+and find trouble in his house.'] {82}
+
+"Thus did he pray, and Neptune heard his prayer. Then he picked up
+a rock much larger than the first, swung it aloft and hurled it with
+prodigious force. It fell just short of the ship, but was within a
+little of hitting the end of the rudder. The sea quaked as the rock fell
+into it, and the wash of the wave it raised drove us onwards on our way
+towards the shore of the island.
+
+"When at last we got to the island where we had left the rest of our
+ships, we found our comrades lamenting us, and anxiously awaiting our
+return. We ran our vessel upon the sands and got out of her on to the
+sea shore; we also landed the Cyclops' sheep, and divided them equitably
+amongst us so that none might have reason to complain. As for the ram,
+my companions agreed that I should have it as an extra share; so I
+sacrificed it on the sea shore, and burned its thigh bones to Jove, who
+is the lord of all. But he heeded not my sacrifice, and only thought how
+he might destroy both my ships and my comrades.
+
+"Thus through the livelong day to the going down of the sun we feasted
+our fill on meat and drink, but when the sun went down and it came on
+dark, we camped upon the beach. When the child of morning rosy-fingered
+Dawn appeared, I bade my men on board and loose the hawsers. Then they
+took their places and smote the grey sea with their oars; so we sailed
+on with sorrow in our hearts, but glad to have escaped death though we
+had lost our comrades.
+
+
+Book X
+
+AEOLUS, THE LAESTRYGONES, CIRCE.
+
+"Thence we went on to the Aeolian island where lives Aeolus son of
+Hippotas, dear to the immortal gods. It is an island that floats (as
+it were) upon the sea, {83} iron bound with a wall that girds it. Now,
+Aeolus has six daughters and six lusty sons, so he made the sons marry
+the daughters, and they all live with their dear father and mother,
+feasting and enjoying every conceivable kind of luxury. All day long the
+atmosphere of the house is loaded with the savour of roasting meats till
+it groans again, yard and all; but by night they sleep on their well
+made bedsteads, each with his own wife between the blankets. These were
+the people among whom we had now come.
+
+"Aeolus entertained me for a whole month asking me questions all the
+time about Troy, the Argive fleet, and the return of the Achaeans. I
+told him exactly how everything had happened, and when I said I must go,
+and asked him to further me on my way, he made no sort of difficulty,
+but set about doing so at once. Moreover, he flayed me a prime ox-hide
+to hold the ways of the roaring winds, which he shut up in the hide as
+in a sack--for Jove had made him captain over the winds, and he could
+stir or still each one of them according to his own pleasure. He put
+the sack in the ship and bound the mouth so tightly with a silver thread
+that not even a breath of a side-wind could blow from any quarter. The
+West wind which was fair for us did he alone let blow as it chose; but
+it all came to nothing, for we were lost through our own folly.
+
+"Nine days and nine nights did we sail, and on the tenth day our native
+land showed on the horizon. We got so close in that we could see the
+stubble fires burning, and I, being then dead beat, fell into a light
+sleep, for I had never let the rudder out of my own hands, that we might
+get home the faster. On this the men fell to talking among themselves,
+and said I was bringing back gold and silver in the sack that Aeolus
+had given me. 'Bless my heart,' would one turn to his neighbour, saying,
+'how this man gets honoured and makes friends to whatever city or
+country he may go. See what fine prizes he is taking home from Troy,
+while we, who have travelled just as far as he has, come back with hands
+as empty as we set out with--and now Aeolus has given him ever so much
+more. Quick--let us see what it all is, and how much gold and silver
+there is in the sack he gave him.'
+
+"Thus they talked and evil counsels prevailed. They loosed the sack,
+whereupon the wind flew howling forth and raised a storm that carried us
+weeping out to sea and away from our own country. Then I awoke, and knew
+not whether to throw myself into the sea or to live on and make the best
+of it; but I bore it, covered myself up, and lay down in the ship, while
+the men lamented bitterly as the fierce winds bore our fleet back to the
+Aeolian island.
+
+"When we reached it we went ashore to take in water, and dined hard by
+the ships. Immediately after dinner I took a herald and one of my men
+and went straight to the house of Aeolus, where I found him feasting
+with his wife and family; so we sat down as suppliants on the threshold.
+They were astounded when they saw us and said, 'Ulysses, what brings you
+here? What god has been ill-treating you? We took great pains to further
+you on your way home to Ithaca, or wherever it was that you wanted to go
+to.'
+
+"Thus did they speak, but I answered sorrowfully, 'My men have undone
+me; they, and cruel sleep, have ruined me. My friends, mend me this
+mischief, for you can if you will.'
+
+"I spoke as movingly as I could, but they said nothing, till their
+father answered, 'Vilest of mankind, get you gone at once out of the
+island; him whom heaven hates will I in no wise help. Be off, for you
+come here as one abhorred of heaven.' And with these words he sent me
+sorrowing from his door.
+
+"Thence we sailed sadly on till the men were worn out with long and
+fruitless rowing, for there was no longer any wind to help them. Six
+days, night and day did we toil, and on the seventh day we reached the
+rocky stronghold of Lamus--Telepylus, the city of the Laestrygonians,
+where the shepherd who is driving in his sheep and goats [to be milked]
+salutes him who is driving out his flock [to feed] and this last answers
+the salute. In that country a man who could do without sleep might earn
+double wages, one as a herdsman of cattle, and another as a shepherd,
+for they work much the same by night as they do by day. {84}
+
+"When we reached the harbour we found it land-locked under steep cliffs,
+with a narrow entrance between two headlands. My captains took all their
+ships inside, and made them fast close to one another, for there was
+never so much as a breath of wind inside, but it was always dead calm. I
+kept my own ship outside, and moored it to a rock at the very end of the
+point; then I climbed a high rock to reconnoitre, but could see no sign
+neither of man nor cattle, only some smoke rising from the ground. So I
+sent two of my company with an attendant to find out what sort of people
+the inhabitants were.
+
+"The men when they got on shore followed a level road by which the
+people draw their firewood from the mountains into the town, till
+presently they met a young woman who had come outside to fetch water,
+and who was daughter to a Laestrygonian named Antiphates. She was going
+to the fountain Artacia from which the people bring in their water, and
+when my men had come close up to her, they asked her who the king of
+that country might be, and over what kind of people he ruled; so she
+directed them to her father's house, but when they got there they found
+his wife to be a giantess as huge as a mountain, and they were horrified
+at the sight of her.
+
+"She at once called her husband Antiphates from the place of assembly,
+and forthwith he set about killing my men. He snatched up one of them,
+and began to make his dinner off him then and there, whereon the other
+two ran back to the ships as fast as ever they could. But Antiphates
+raised a hue-and-cry after them, and thousands of sturdy Laestrygonians
+sprang up from every quarter--ogres, not men. They threw vast rocks at
+us from the cliffs as though they had been mere stones, and I heard
+the horrid sound of the ships crunching up against one another, and the
+death cries of my men, as the Laestrygonians speared them like fishes
+and took them home to eat them. While they were thus killing my men
+within the harbour I drew my sword, cut the cable of my own ship, and
+told my men to row with all their might if they too would not fare like
+the rest; so they laid out for their lives, and we were thankful enough
+when we got into open water out of reach of the rocks they hurled at us.
+As for the others there was not one of them left.
+
+"Thence we sailed sadly on, glad to have escaped death, though we had
+lost our comrades, and came to the Aeaean island, where Circe lives--a
+great and cunning goddess who is own sister to the magician Aeetes--for
+they are both children of the sun by Perse, who is daughter to Oceanus.
+We brought our ship into a safe harbour without a word, for some god
+guided us thither, and having landed we lay there for two days and two
+nights, worn out in body and mind. When the morning of the third day
+came I took my spear and my sword, and went away from the ship to
+reconnoitre, and see if I could discover signs of human handiwork,
+or hear the sound of voices. Climbing to the top of a high look-out I
+espied the smoke of Circe's house rising upwards amid a dense forest of
+trees, and when I saw this I doubted whether, having seen the smoke, I
+would not go on at once and find out more, but in the end I deemed it
+best to go back to the ship, give the men their dinners, and send some
+of them instead of going myself.
+
+"When I had nearly got back to the ship some god took pity upon my
+solitude, and sent a fine antlered stag right into the middle of my
+path. He was coming down his pasture in the forest to drink of the
+river, for the heat of the sun drove him, and as he passed I struck
+him in the middle of the back; the bronze point of the spear went clean
+through him, and he lay groaning in the dust until the life went out of
+him. Then I set my foot upon him, drew my spear from the wound, and laid
+it down; I also gathered rough grass and rushes and twisted them into a
+fathom or so of good stout rope, with which I bound the four feet of
+the noble creature together; having so done I hung him round my neck and
+walked back to the ship leaning upon my spear, for the stag was much too
+big for me to be able to carry him on my shoulder, steadying him with
+one hand. As I threw him down in front of the ship, I called the men
+and spoke cheeringly man by man to each of them. 'Look here my friends,'
+said I, 'we are not going to die so much before our time after all, and
+at any rate we will not starve so long as we have got something to eat
+and drink on board.' On this they uncovered their heads upon the sea
+shore and admired the stag, for he was indeed a splendid fellow. Then,
+when they had feasted their eyes upon him sufficiently, they washed
+their hands and began to cook him for dinner.
+
+"Thus through the livelong day to the going down of the sun we stayed
+there eating and drinking our fill, but when the sun went down and it
+came on dark, we camped upon the sea shore. When the child of morning,
+rosy-fingered Dawn, appeared, I called a council and said, 'My friends,
+we are in very great difficulties; listen therefore to me. We have no
+idea where the sun either sets or rises, {85} so that we do not even
+know East from West. I see no way out of it; nevertheless, we must try
+and find one. We are certainly on an island, for I went as high as
+I could this morning, and saw the sea reaching all round it to the
+horizon; it lies low, but towards the middle I saw smoke rising from out
+of a thick forest of trees.'
+
+"Their hearts sank as they heard me, for they remembered how they had
+been treated by the Laestrygonian Antiphates, and by the savage ogre
+Polyphemus. They wept bitterly in their dismay, but there was nothing to
+be got by crying, so I divided them into two companies and set a captain
+over each; I gave one company to Eurylochus, while I took command of
+the other myself. Then we cast lots in a helmet, and the lot fell upon
+Eurylochus; so he set out with his twenty-two men, and they wept, as
+also did we who were left behind.
+
+"When they reached Circe's house they found it built of cut stones, on
+a site that could be seen from far, in the middle of the forest.
+There were wild mountain wolves and lions prowling all round it--poor
+bewitched creatures whom she had tamed by her enchantments and drugged
+into subjection. They did not attack my men, but wagged their great
+tails, fawned upon them, and rubbed their noses lovingly against them.
+{86} As hounds crowd round their master when they see him coming from
+dinner--for they know he will bring them something--even so did these
+wolves and lions with their great claws fawn upon my men, but the men
+were terribly frightened at seeing such strange creatures. Presently
+they reached the gates of the goddess's house, and as they stood there
+they could hear Circe within, singing most beautifully as she worked at
+her loom, making a web so fine, so soft, and of such dazzling colours
+as no one but a goddess could weave. On this Polites, whom I valued and
+trusted more than any other of my men, said, 'There is some one inside
+working at a loom and singing most beautifully; the whole place resounds
+with it, let us call her and see whether she is woman or goddess.'
+
+"They called her and she came down, unfastened the door, and bade them
+enter. They, thinking no evil, followed her, all except Eurylochus, who
+suspected mischief and staid outside. When she had got them into her
+house, she set them upon benches and seats and mixed them a mess with
+cheese, honey, meal, and Pramnian wine, but she drugged it with wicked
+poisons to make them forget their homes, and when they had drunk she
+turned them into pigs by a stroke of her wand, and shut them up in her
+pig-styes. They were like pigs--head, hair, and all, and they grunted
+just as pigs do; but their senses were the same as before, and they
+remembered everything.
+
+"Thus then were they shut up squealing, and Circe threw them some acorns
+and beech masts such as pigs eat, but Eurylochus hurried back to tell me
+about the sad fate of our comrades. He was so overcome with dismay
+that though he tried to speak he could find no words to do so; his eyes
+filled with tears and he could only sob and sigh, till at last we forced
+his story out of him, and he told us what had happened to the others.
+
+"'We went,' said he, 'as you told us, through the forest, and in the
+middle of it there was a fine house built with cut stones in a place
+that could be seen from far. There we found a woman, or else she was a
+goddess, working at her loom and singing sweetly; so the men shouted to
+her and called her, whereon she at once came down, opened the door, and
+invited us in. The others did not suspect any mischief so they followed
+her into the house, but I staid where I was, for I thought there might
+be some treachery. From that moment I saw them no more, for not one of
+them ever came out, though I sat a long time watching for them.'
+
+"Then I took my sword of bronze and slung it over my shoulders; I also
+took my bow, and told Eurylochus to come back with me and shew me the
+way. But he laid hold of me with both his hands and spoke piteously,
+saying, 'Sir, do not force me to go with you, but let me stay here, for
+I know you will not bring one of them back with you, nor even return
+alive yourself; let us rather see if we cannot escape at any rate with
+the few that are left us, for we may still save our lives.'
+
+"'Stay where you are, then,' answered I, 'eating and drinking at the
+ship, but I must go, for I am most urgently bound to do so.'
+
+"With this I left the ship and went up inland. When I got through the
+charmed grove, and was near the great house of the enchantress Circe,
+I met Mercury with his golden wand, disguised as a young man in the
+hey-day of his youth and beauty with the down just coming upon his
+face. He came up to me and took my hand within his own, saying, 'My poor
+unhappy man, whither are you going over this mountain top, alone and
+without knowing the way? Your men are shut up in Circe's pigstyes, like
+so many wild boars in their lairs. You surely do not fancy that you can
+set them free? I can tell you that you will never get back and will have
+to stay there with the rest of them. But never mind, I will protect
+you and get you out of your difficulty. Take this herb, which is one
+of great virtue, and keep it about you when you go to Circe's house, it
+will be a talisman to you against every kind of mischief.
+
+"'And I will tell you of all the wicked witchcraft that Circe will try
+to practice upon you. She will mix a mess for you to drink, and she will
+drug the meal with which she makes it, but she will not be able to charm
+you, for the virtue of the herb that I shall give you will prevent her
+spells from working. I will tell you all about it. When Circe strikes
+you with her wand, draw your sword and spring upon her as though you
+were going to kill her. She will then be frightened, and will desire you
+to go to bed with her; on this you must not point blank refuse her, for
+you want her to set your companions free, and to take good care also of
+yourself, but you must make her swear solemnly by all the blessed gods
+that she will plot no further mischief against you, or else when she has
+got you naked she will unman you and make you fit for nothing.'
+
+"As he spoke he pulled the herb out of the ground and shewed me what it
+was like. The root was black, while the flower was as white as milk; the
+gods call it Moly, and mortal men cannot uproot it, but the gods can do
+whatever they like.
+
+"Then Mercury went back to high Olympus passing over the wooded island;
+but I fared onward to the house of Circe, and my heart was clouded with
+care as I walked along. When I got to the gates I stood there and called
+the goddess, and as soon as she heard me she came down, opened the door,
+and asked me to come in; so I followed her--much troubled in my mind.
+She set me on a richly decorated seat inlaid with silver, there was a
+footstool also under my feet, and she mixed a mess in a golden goblet
+for me to drink; but she drugged it, for she meant me mischief. When she
+had given it me, and I had drunk it without its charming me, she struck
+me with her wand. 'There now,' she cried, 'be off to the pigstye, and
+make your lair with the rest of them.'
+
+"But I rushed at her with my sword drawn as though I would kill her,
+whereon she fell with a loud scream, clasped my knees, and spoke
+piteously, saying, 'Who and whence are you? from what place and people
+have you come? How can it be that my drugs have no power to charm you?
+Never yet was any man able to stand so much as a taste of the herb I
+gave you; you must be spell-proof; surely you can be none other than the
+bold hero Ulysses, who Mercury always said would come here some day with
+his ship while on his way home from Troy; so be it then; sheathe your
+sword and let us go to bed, that we may make friends and learn to trust
+each other.'
+
+"And I answered, 'Circe, how can you expect me to be friendly with you
+when you have just been turning all my men into pigs? And now that you
+have got me here myself, you mean me mischief when you ask me to go to
+bed with you, and will unman me and make me fit for nothing. I shall
+certainly not consent to go to bed with you unless you will first take
+your solemn oath to plot no further harm against me.'
+
+"So she swore at once as I had told her, and when she had completed her
+oath then I went to bed with her.
+
+"Meanwhile her four servants, who are her housemaids, set about their
+work. They are the children of the groves and fountains, and of the
+holy waters that run down into the sea. One of them spread a fair purple
+cloth over a seat, and laid a carpet underneath it. Another brought
+tables of silver up to the seats, and set them with baskets of gold. A
+third mixed some sweet wine with water in a silver bowl and put golden
+cups upon the tables, while the fourth brought in water and set it to
+boil in a large cauldron over a good fire which she had lighted. When
+the water in the cauldron was boiling, {87} she poured cold into it
+till it was just as I liked it, and then she set me in a bath and began
+washing me from the cauldron about the head and shoulders, to take the
+tire and stiffness out of my limbs. As soon as she had done washing me
+and anointing me with oil, she arrayed me in a good cloak and shirt
+and led me to a richly decorated seat inlaid with silver; there was a
+footstool also under my feet. A maid servant then brought me water in a
+beautiful golden ewer and poured it into a silver basin for me to wash
+my hands, and she drew a clean table beside me; an upper servant brought
+me bread and offered me many things of what there was in the house, and
+then Circe bade me eat, but I would not, and sat without heeding what
+was before me, still moody and suspicious.
+
+"When Circe saw me sitting there without eating, and in great grief, she
+came to me and said, 'Ulysses, why do you sit like that as though you
+were dumb, gnawing at your own heart, and refusing both meat and drink?
+Is it that you are still suspicious? You ought not to be, for I have
+already sworn solemnly that I will not hurt you.'
+
+"And I said, 'Circe, no man with any sense of what is right can think of
+either eating or drinking in your house until you have set his friends
+free and let him see them. If you want me to eat and drink, you must
+free my men and bring them to me that I may see them with my own eyes.'
+
+"When I had said this she went straight through the court with her wand
+in her hand and opened the pigstye doors. My men came out like so many
+prime hogs and stood looking at her, but she went about among them and
+anointed each with a second drug, whereon the bristles that the bad drug
+had given them fell off, and they became men again, younger than they
+were before, and much taller and better looking. They knew me at once,
+seized me each of them by the hand, and wept for joy till the whole
+house was filled with the sound of their halloa-ballooing, and Circe
+herself was so sorry for them that she came up to me and said, 'Ulysses,
+noble son of Laertes, go back at once to the sea where you have left
+your ship, and first draw it on to the land. Then, hide all your ship's
+gear and property in some cave, and come back here with your men.'
+
+"I agreed to this, so I went back to the sea shore, and found the men at
+the ship weeping and wailing most piteously. When they saw me the silly
+blubbering fellows began frisking round me as calves break out and
+gambol round their mothers, when they see them coming home to be milked
+after they have been feeding all day, and the homestead resounds with
+their lowing. They seemed as glad to see me as though they had got back
+to their own rugged Ithaca, where they had been born and bred. 'Sir,'
+said the affectionate creatures, 'we are as glad to see you back as
+though we had got safe home to Ithaca; but tell us all about the fate of
+our comrades.'
+
+"I spoke comfortingly to them and said, 'We must draw our ship on to the
+land, and hide the ship's gear with all our property in some cave; then
+come with me all of you as fast as you can to Circe's house, where
+you will find your comrades eating and drinking in the midst of great
+abundance.'
+
+"On this the men would have come with me at once, but Eurylochus tried
+to hold them back and said, 'Alas, poor wretches that we are, what will
+become of us? Rush not on your ruin by going to the house of Circe, who
+will turn us all into pigs or wolves or lions, and we shall have to
+keep guard over her house. Remember how the Cyclops treated us when our
+comrades went inside his cave, and Ulysses with them. It was all through
+his sheer folly that those men lost their lives.'
+
+"When I heard him I was in two minds whether or no to draw the keen
+blade that hung by my sturdy thigh and cut his head off in spite of
+his being a near relation of my own; but the men interceded for him
+and said, 'Sir, if it may so be, let this fellow stay here and mind the
+ship, but take the rest of us with you to Circe's house.'
+
+"On this we all went inland, and Eurylochus was not left behind after
+all, but came on too, for he was frightened by the severe reprimand that
+I had given him.
+
+"Meanwhile Circe had been seeing that the men who had been left behind
+were washed and anointed with olive oil; she had also given them woollen
+cloaks and shirts, and when we came we found them all comfortably at
+dinner in her house. As soon as the men saw each other face to face
+and knew one another, they wept for joy and cried aloud till the whole
+palace rang again. Thereon Circe came up to me and said, 'Ulysses, noble
+son of Laertes, tell your men to leave off crying; I know how much you
+have all of you suffered at sea, and how ill you have fared among cruel
+savages on the mainland, but that is over now, so stay here, and eat and
+drink till you are once more as strong and hearty as you were when you
+left Ithaca; for at present you are weakened both in body and mind; you
+keep all the time thinking of the hardships you have suffered during
+your travels, so that you have no more cheerfulness left in you.'
+
+"Thus did she speak and we assented. We stayed with Circe for a whole
+twelvemonth feasting upon an untold quantity both of meat and wine. But
+when the year had passed in the waning of moons and the long days had
+come round, my men called me apart and said, 'Sir, it is time you began
+to think about going home, if so be you are to be spared to see your
+house and native country at all.'
+
+"Thus did they speak and I assented. Thereon through the livelong day to
+the going down of the sun we feasted our fill on meat and wine, but when
+the sun went down and it came on dark the men laid themselves down to
+sleep in the covered cloisters. I, however, after I had got into bed
+with Circe, besought her by her knees, and the goddess listened to what
+I had got to say. 'Circe,' said I, 'please to keep the promise you made
+me about furthering me on my homeward voyage. I want to get back and so
+do my men, they are always pestering me with their complaints as soon as
+ever your back is turned.'
+
+"And the goddess answered, 'Ulysses, noble son of Laertes, you shall
+none of you stay here any longer if you do not want to, but there
+is another journey which you have got to take before you can sail
+homewards. You must go to the house of Hades and of dread Proserpine to
+consult the ghost of the blind Theban prophet Teiresias, whose reason is
+still unshaken. To him alone has Proserpine left his understanding even
+in death, but the other ghosts flit about aimlessly.'
+
+"I was dismayed when I heard this. I sat up in bed and wept, and would
+gladly have lived no longer to see the light of the sun, but presently
+when I was tired of weeping and tossing myself about, I said, 'And who
+shall guide me upon this voyage--for the house of Hades is a port that
+no ship can reach.'
+
+"'You will want no guide,' she answered; 'raise your mast, set your
+white sails, sit quite still, and the North Wind will blow you there
+of itself. When your ship has traversed the waters of Oceanus, you will
+reach the fertile shore of Proserpine's country with its groves of tall
+poplars and willows that shed their fruit untimely; here beach your
+ship upon the shore of Oceanus, and go straight on to the dark abode of
+Hades. You will find it near the place where the rivers Pyriphlegethon
+and Cocytus (which is a branch of the river Styx) flow into Acheron, and
+you will see a rock near it, just where the two roaring rivers run into
+one another.
+
+"'When you have reached this spot, as I now tell you, dig a trench
+a cubit or so in length, breadth, and depth, and pour into it as a
+drink-offering to all the dead, first, honey mixed with milk, then wine,
+and in the third place water--sprinkling white barley meal over the
+whole. Moreover you must offer many prayers to the poor feeble ghosts,
+and promise them that when you get back to Ithaca you will sacrifice a
+barren heifer to them, the best you have, and will load the pyre with
+good things. More particularly you must promise that Teiresias shall
+have a black sheep all to himself, the finest in all your flocks.
+
+"'When you shall have thus besought the ghosts with your prayers, offer
+them a ram and a black ewe, bending their heads towards Erebus; but
+yourself turn away from them as though you would make towards the river.
+On this, many dead men's ghosts will come to you, and you must tell your
+men to skin the two sheep that you have just killed, and offer them as a
+burnt sacrifice with prayers to Hades and to Proserpine. Then draw your
+sword and sit there, so as to prevent any other poor ghost from
+coming near the spilt blood before Teiresias shall have answered your
+questions. The seer will presently come to you, and will tell you about
+your voyage--what stages you are to make, and how you are to sail the
+sea so as to reach your home.'
+
+"It was day-break by the time she had done speaking, so she dressed
+me in my shirt and cloak. As for herself she threw a beautiful light
+gossamer fabric over her shoulders, fastening it with a golden girdle
+round her waist, and she covered her head with a mantle. Then I went
+about among the men everywhere all over the house, and spoke kindly to
+each of them man by man: 'You must not lie sleeping here any longer,'
+said I to them, 'we must be going, for Circe has told me all about it.'
+And on this they did as I bade them.
+
+"Even so, however, I did not get them away without misadventure. We had
+with us a certain youth named Elpenor, not very remarkable for sense or
+courage, who had got drunk and was lying on the house-top away from the
+rest of the men, to sleep off his liquor in the cool. When he heard the
+noise of the men bustling about, he jumped up on a sudden and forgot
+all about coming down by the main staircase, so he tumbled right off the
+roof and broke his neck, and his soul went down to the house of Hades.
+
+"When I had got the men together I said to them, 'You think you are
+about to start home again, but Circe has explained to me that instead of
+this, we have got to go to the house of Hades and Proserpine to consult
+the ghost of the Theban prophet Teiresias.'
+
+"The men were broken-hearted as they heard me, and threw themselves
+on the ground groaning and tearing their hair, but they did not mend
+matters by crying. When we reached the sea shore, weeping and lamenting
+our fate, Circe brought the ram and the ewe, and we made them fast hard
+by the ship. She passed through the midst of us without our knowing it,
+for who can see the comings and goings of a god, if the god does not
+wish to be seen?
+
+
+Book XI
+
+THE VISIT TO THE DEAD. {88}
+
+"Then, when we had got down to the sea shore we drew our ship into the
+water and got her mast and sails into her; we also put the sheep on
+board and took our places, weeping and in great distress of mind. Circe,
+that great and cunning goddess, sent us a fair wind that blew dead aft
+and staid steadily with us keeping our sails all the time well filled;
+so we did whatever wanted doing to the ship's gear and let her go as the
+wind and helmsman headed her. All day long her sails were full as she
+held her course over the sea, but when the sun went down and darkness
+was over all the earth, we got into the deep waters of the river
+Oceanus, where lie the land and city of the Cimmerians who live
+enshrouded in mist and darkness which the rays of the sun never pierce
+neither at his rising nor as he goes down again out of the heavens, but
+the poor wretches live in one long melancholy night. When we got there
+we beached the ship, took the sheep out of her, and went along by the
+waters of Oceanus till we came to the place of which Circe had told us.
+
+"Here Perimedes and Eurylochus held the victims, while I drew my sword
+and dug the trench a cubit each way. I made a drink-offering to all the
+dead, first with honey and milk, then with wine, and thirdly with water,
+and I sprinkled white barley meal over the whole, praying earnestly to
+the poor feckless ghosts, and promising them that when I got back to
+Ithaca I would sacrifice a barren heifer for them, the best I had, and
+would load the pyre with good things. I also particularly promised
+that Teiresias should have a black sheep to himself, the best in all my
+flocks. When I had prayed sufficiently to the dead, I cut the throats of
+the two sheep and let the blood run into the trench, whereon the ghosts
+came trooping up from Erebus--brides, {89} young bachelors, old men worn
+out with toil, maids who had been crossed in love, and brave men who had
+been killed in battle, with their armour still smirched with blood; they
+came from every quarter and flitted round the trench with a strange kind
+of screaming sound that made me turn pale with fear. When I saw them
+coming I told the men to be quick and flay the carcasses of the two dead
+sheep and make burnt offerings of them, and at the same time to repeat
+prayers to Hades and to Proserpine; but I sat where I was with my sword
+drawn and would not let the poor feckless ghosts come near the blood
+till Teiresias should have answered my questions.
+
+"The first ghost that came was that of my comrade Elpenor, for he had
+not yet been laid beneath the earth. We had left his body unwaked and
+unburied in Circe's house, for we had had too much else to do. I was
+very sorry for him, and cried when I saw him: 'Elpenor,' said I, 'how
+did you come down here into this gloom and darkness? You have got here
+on foot quicker than I have with my ship.'
+
+"'Sir,' he answered with a groan, 'it was all bad luck, and my own
+unspeakable drunkenness. I was lying asleep on the top of Circe's house,
+and never thought of coming down again by the great staircase but fell
+right off the roof and broke my neck, so my soul came down to the house
+of Hades. And now I beseech you by all those whom you have left behind
+you, though they are not here, by your wife, by the father who brought
+you up when you were a child, and by Telemachus who is the one hope of
+your house, do what I shall now ask you. I know that when you leave this
+limbo you will again hold your ship for the Aeaean island. Do not
+go thence leaving me unwaked and unburied behind you, or I may bring
+heaven's anger upon you; but burn me with whatever armour I have, build
+a barrow for me on the sea shore, that may tell people in days to come
+what a poor unlucky fellow I was, and plant over my grave the oar I used
+to row with when I was yet alive and with my messmates.' And I said, 'My
+poor fellow, I will do all that you have asked of me.'
+
+"Thus, then, did we sit and hold sad talk with one another, I on the one
+side of the trench with my sword held over the blood, and the ghost
+of my comrade saying all this to me from the other side. Then came the
+ghost of my dead mother Anticlea, daughter to Autolycus. I had left her
+alive when I set out for Troy and was moved to tears when I saw her, but
+even so, for all my sorrow I would not let her come near the blood till
+I had asked my questions of Teiresias.
+
+"Then came also the ghost of Theban Teiresias, with his golden sceptre
+in his hand. He knew me and said, 'Ulysses, noble son of Laertes, why,
+poor man, have you left the light of day and come down to visit the dead
+in this sad place? Stand back from the trench and withdraw your sword
+that I may drink of the blood and answer your questions truly.'
+
+"So I drew back, and sheathed my sword, whereon when he had drank of the
+blood he began with his prophecy.
+
+"'You want to know,' said he, 'about your return home, but heaven will
+make this hard for you. I do not think that you will escape the eye
+of Neptune, who still nurses his bitter grudge against you for having
+blinded his son. Still, after much suffering you may get home if you
+can restrain yourself and your companions when your ship reaches the
+Thrinacian island, where you will find the sheep and cattle belonging to
+the sun, who sees and gives ear to everything. If you leave these flocks
+unharmed and think of nothing but of getting home, you may yet after
+much hardship reach Ithaca; but if you harm them, then I forewarn you of
+the destruction both of your ship and of your men. Even though you may
+yourself escape, you will return in bad plight after losing all your
+men, [in another man's ship, and you will find trouble in your house,
+which will be overrun by high-handed people, who are devouring your
+substance under the pretext of paying court and making presents to your
+wife.
+
+"'When you get home you will take your revenge on these suitors; and
+after you have killed them by force or fraud in your own house, you must
+take a well made oar and carry it on and on, till you come to a country
+where the people have never heard of the sea and do not even mix salt
+with their food, nor do they know anything about ships, and oars that
+are as the wings of a ship. I will give you this certain token which
+cannot escape your notice. A wayfarer will meet you and will say it must
+be a winnowing shovel that you have got upon your shoulder; on this you
+must fix the oar in the ground and sacrifice a ram, a bull, and a boar
+to Neptune. {90} Then go home and offer hecatombs to all the gods in
+heaven one after the other. As for yourself, death shall come to you
+from the sea, and your life shall ebb away very gently when you are full
+of years and peace of mind, and your people shall bless you. All that I
+have said will come true].' {91}
+
+"'This,' I answered, 'must be as it may please heaven, but tell me and
+tell me and tell me true, I see my poor mother's ghost close by us; she
+is sitting by the blood without saying a word, and though I am her own
+son she does not remember me and speak to me; tell me, Sir, how I can
+make her know me.'
+
+"'That,' said he, 'I can soon do. Any ghost that you let taste of the
+blood will talk with you like a reasonable being, but if you do not let
+them have any blood they will go away again.'
+
+"On this the ghost of Teiresias went back to the house of Hades, for his
+prophecyings had now been spoken, but I sat still where I was until my
+mother came up and tasted the blood. Then she knew me at once and spoke
+fondly to me, saying, 'My son, how did you come down to this abode of
+darkness while you are still alive? It is a hard thing for the living to
+see these places, for between us and them there are great and terrible
+waters, and there is Oceanus, which no man can cross on foot, but he
+must have a good ship to take him. Are you all this time trying to find
+your way home from Troy, and have you never yet got back to Ithaca nor
+seen your wife in your own house?'
+
+"'Mother,' said I, 'I was forced to come here to consult the ghost of
+the Theban prophet Teiresias. I have never yet been near the Achaean
+land nor set foot on my native country, and I have had nothing but one
+long series of misfortunes from the very first day that I set out with
+Agamemnon for Ilius, the land of noble steeds, to fight the Trojans. But
+tell me, and tell me true, in what way did you die? Did you have a long
+illness, or did heaven vouchsafe you a gentle easy passage to eternity?
+Tell me also about my father, and the son whom I left behind me, is my
+property still in their hands, or has some one else got hold of it, who
+thinks that I shall not return to claim it? Tell me again what my wife
+intends doing, and in what mind she is; does she live with my son and
+guard my estate securely, or has she made the best match she could and
+married again?'
+
+"My mother answered, 'Your wife still remains in your house, but she is
+in great distress of mind and spends her whole time in tears both night
+and day. No one as yet has got possession of your fine property, and
+Telemachus still holds your lands undisturbed. He has to entertain
+largely, as of course he must, considering his position as a magistrate,
+{92} and how every one invites him; your father remains at his old place
+in the country and never goes near the town. He has no comfortable bed
+nor bedding; in the winter he sleeps on the floor in front of the fire
+with the men and goes about all in rags, but in summer, when the warm
+weather comes on again, he lies out in the vineyard on a bed of vine
+leaves thrown any how upon the ground. He grieves continually about your
+never having come home, and suffers more and more as he grows older. As
+for my own end it was in this wise: heaven did not take me swiftly and
+painlessly in my own house, nor was I attacked by any illness such as
+those that generally wear people out and kill them, but my longing to
+know what you were doing and the force of my affection for you--this it
+was that was the death of me.' {93}
+
+"Then I tried to find some way of embracing my poor mother's ghost.
+Thrice I sprang towards her and tried to clasp her in my arms, but each
+time she flitted from my embrace as it were a dream or phantom, and
+being touched to the quick I said to her, 'Mother, why do you not stay
+still when I would embrace you? If we could throw our arms around one
+another we might find sad comfort in the sharing of our sorrows even in
+the house of Hades; does Proserpine want to lay a still further load of
+grief upon me by mocking me with a phantom only?'
+
+"'My son,' she answered, 'most ill-fated of all mankind, it is not
+Proserpine that is beguiling you, but all people are like this when they
+are dead. The sinews no longer hold the flesh and bones together; these
+perish in the fierceness of consuming fire as soon as life has left the
+body, and the soul flits away as though it were a dream. Now, however,
+go back to the light of day as soon as you can, and note all these
+things that you may tell them to your wife hereafter.'
+
+"Thus did we converse, and anon Proserpine sent up the ghosts of the
+wives and daughters of all the most famous men. They gathered in crowds
+about the blood, and I considered how I might question them severally.
+In the end I deemed that it would be best to draw the keen blade that
+hung by my sturdy thigh, and keep them from all drinking the blood at
+once. So they came up one after the other, and each one as I questioned
+her told me her race and lineage.
+
+"The first I saw was Tyro. She was daughter of Salmoneus and wife of
+Cretheus the son of Aeolus. {94} She fell in love with the river Enipeus
+who is much the most beautiful river in the whole world. Once when she
+was taking a walk by his side as usual, Neptune, disguised as her lover,
+lay with her at the mouth of the river, and a huge blue wave arched
+itself like a mountain over them to hide both woman and god, whereon he
+loosed her virgin girdle and laid her in a deep slumber. When the god
+had accomplished the deed of love, he took her hand in his own and
+said, 'Tyro, rejoice in all good will; the embraces of the gods are not
+fruitless, and you will have fine twins about this time twelve months.
+Take great care of them. I am Neptune, so now go home, but hold your
+tongue and do not tell any one.'
+
+"Then he dived under the sea, and she in due course bore Pelias and
+Neleus, who both of them served Jove with all their might. Pelias was
+a great breeder of sheep and lived in Iolcus, but the other lived in
+Pylos. The rest of her children were by Cretheus, namely, Aeson, Pheres,
+and Amythaon, who was a mighty warrior and charioteer.
+
+"Next to her I saw Antiope, daughter to Asopus, who could boast of
+having slept in the arms of even Jove himself, and who bore him two sons
+Amphion and Zethus. These founded Thebes with its seven gates, and built
+a wall all round it; for strong though they were they could not hold
+Thebes till they had walled it.
+
+"Then I saw Alcmena, the wife of Amphitryon, who also bore to Jove
+indomitable Hercules; and Megara who was daughter to great King Creon,
+and married the redoubtable son of Amphitryon.
+
+"I also saw fair Epicaste mother of king Oedipodes whose awful lot it
+was to marry her own son without suspecting it. He married her after
+having killed his father, but the gods proclaimed the whole story to the
+world; whereon he remained king of Thebes, in great grief for the spite
+the gods had borne him; but Epicaste went to the house of the mighty
+jailor Hades, having hanged herself for grief, and the avenging spirits
+haunted him as for an outraged mother--to his ruing bitterly thereafter.
+
+"Then I saw Chloris, whom Neleus married for her beauty, having given
+priceless presents for her. She was youngest daughter to Amphion son of
+Iasus and king of Minyan Orchomenus, and was Queen in Pylos. She bore
+Nestor, Chromius, and Periclymenus, and she also bore that marvellously
+lovely woman Pero, who was wooed by all the country round; but Neleus
+would only give her to him who should raid the cattle of Iphicles from
+the grazing grounds of Phylace, and this was a hard task. The only man
+who would undertake to raid them was a certain excellent seer, {95} but
+the will of heaven was against him, for the rangers of the cattle caught
+him and put him in prison; nevertheless when a full year had passed and
+the same season came round again, Iphicles set him at liberty, after
+he had expounded all the oracles of heaven. Thus, then, was the will of
+Jove accomplished.
+
+"And I saw Leda the wife of Tyndarus, who bore him two famous sons,
+Castor breaker of horses, and Pollux the mighty boxer. Both these heroes
+are lying under the earth, though they are still alive, for by a special
+dispensation of Jove, they die and come to life again, each one of them
+every other day throughout all time, and they have the rank of gods.
+
+"After her I saw Iphimedeia wife of Aloeus who boasted the embrace
+of Neptune. She bore two sons Otus and Ephialtes, but both were short
+lived. They were the finest children that were ever born in this world,
+and the best looking, Orion only excepted; for at nine years old they
+were nine fathoms high, and measured nine cubits round the chest. They
+threatened to make war with the gods in Olympus, and tried to set Mount
+Ossa on the top of Mount Olympus, and Mount Pelion on the top of Ossa,
+that they might scale heaven itself, and they would have done it too if
+they had been grown up, but Apollo, son of Leto, killed both of them,
+before they had got so much as a sign of hair upon their cheeks or chin.
+
+"Then I saw Phaedra, and Procris, and fair Ariadne daughter of the
+magician Minos, whom Theseus was carrying off from Crete to Athens, but
+he did not enjoy her, for before he could do so Diana killed her in the
+island of Dia on account of what Bacchus had said against her.
+
+"I also saw Maera and Clymene and hateful Eriphyle, who sold her own
+husband for gold. But it would take me all night if I were to name every
+single one of the wives and daughters of heroes whom I saw, and it is
+time for me to go to bed, either on board ship with my crew, or here. As
+for my escort, heaven and yourselves will see to it."
+
+Here he ended, and the guests sat all of them enthralled and speechless
+throughout the covered cloister. Then Arete said to them:--
+
+"What do you think of this man, O Phaeacians? Is he not tall and good
+looking, and is he not clever? True, he is my own guest, but all of you
+share in the distinction. Do not be in a hurry to send him away, nor
+niggardly in the presents you make to one who is in such great need, for
+heaven has blessed all of you with great abundance."
+
+Then spoke the aged hero Echeneus who was one of the oldest men among
+them, "My friends," said he, "what our august queen has just said to us
+is both reasonable and to the purpose, therefore be persuaded by it;
+but the decision whether in word or deed rests ultimately with King
+Alcinous."
+
+"The thing shall be done," exclaimed Alcinous, "as surely as I still
+live and reign over the Phaeacians. Our guest is indeed very anxious to
+get home, still we must persuade him to remain with us until to-morrow,
+by which time I shall be able to get together the whole sum that I mean
+to give him. As regards his escort it will be a matter for you all, and
+mine above all others as the chief person among you."
+
+And Ulysses answered, "King Alcinous, if you were to bid me to stay here
+for a whole twelve months, and then speed me on my way, loaded with your
+noble gifts, I should obey you gladly and it would redound greatly to
+my advantage, for I should return fuller-handed to my own people, and
+should thus be more respected and beloved by all who see me when I get
+back to Ithaca."
+
+"Ulysses," replied Alcinous, "not one of us who sees you has any idea
+that you are a charlatan or a swindler. I know there are many people
+going about who tell such plausible stories that it is very hard to see
+through them, but there is a style about your language which assures me
+of your good disposition. Moreover you have told the story of your own
+misfortunes, and those of the Argives, as though you were a practiced
+bard; but tell me, and tell me true, whether you saw any of the mighty
+heroes who went to Troy at the same time with yourself, and perished
+there. The evenings are still at their longest, and it is not yet bed
+time--go on, therefore, with your divine story, for I could stay here
+listening till tomorrow morning, so long as you will continue to tell us
+of your adventures."
+
+"Alcinous," answered Ulysses, "there is a time for making speeches, and
+a time for going to bed; nevertheless, since you so desire, I will not
+refrain from telling you the still sadder tale of those of my comrades
+who did not fall fighting with the Trojans, but perished on their
+return, through the treachery of a wicked woman.
+
+"When Proserpine had dismissed the female ghosts in all directions,
+the ghost of Agamemnon son of Atreus came sadly up to me, surrounded by
+those who had perished with him in the house of Aegisthus. As soon as he
+had tasted the blood, he knew me, and weeping bitterly stretched out his
+arms towards me to embrace me; but he had no strength nor substance any
+more, and I too wept and pitied him as I beheld him. 'How did you come
+by your death,' said I, 'King Agamemnon? Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the main land when you were cattle-lifting or sheep-stealing,
+or while they were fighting in defence of their wives and city?'
+
+"'Ulysses,' he answered, 'noble son of Laertes, I was not lost at sea
+in any storm of Neptune's raising, nor did my foes despatch me upon the
+mainland, but Aegisthus and my wicked wife were the death of me between
+them. He asked me to his house, feasted me, and then butchered me most
+miserably as though I were a fat beast in a slaughter house, while all
+around me my comrades were slain like sheep or pigs for the wedding
+breakfast, or picnic, or gorgeous banquet of some great nobleman. You
+must have seen numbers of men killed either in a general engagement, or
+in single combat, but you never saw anything so truly pitiable as the
+way in which we fell in that cloister, with the mixing bowl and the
+loaded tables lying all about, and the ground reeking with our blood. I
+heard Priam's daughter Cassandra scream as Clytemnestra killed her close
+beside me. I lay dying upon the earth with the sword in my body, and
+raised my hands to kill the slut of a murderess, but she slipped away
+from me; she would not even close my lips nor my eyes when I was dying,
+for there is nothing in this world so cruel and so shameless as a woman
+when she has fallen into such guilt as hers was. Fancy murdering her own
+husband! I thought I was going to be welcomed home by my children and my
+servants, but her abominable crime has brought disgrace on herself and
+all women who shall come after--even on the good ones.'
+
+"And I said, 'In truth Jove has hated the house of Atreus from first to
+last in the matter of their women's counsels. See how many of us fell
+for Helen's sake, and now it seems that Clytemnestra hatched mischief
+against you too during your absence.'
+
+"'Be sure, therefore,' continued Agamemnon, 'and not be too friendly
+even with your own wife. Do not tell her all that you know perfectly
+well yourself. Tell her a part only, and keep your own counsel about the
+rest. Not that your wife, Ulysses, is likely to murder you, for Penelope
+is a very admirable woman, and has an excellent nature. We left her a
+young bride with an infant at her breast when we set out for Troy. This
+child no doubt is now grown up happily to man's estate, {96} and he and
+his father will have a joyful meeting and embrace one another as it is
+right they should do, whereas my wicked wife did not even allow me
+the happiness of looking upon my son, but killed me ere I could do so.
+Furthermore I say--and lay my saying to your heart--do not tell people
+when you are bringing your ship to Ithaca, but steal a march upon them,
+for after all this there is no trusting women. But now tell me, and
+tell me true, can you give me any news of my son Orestes? Is he in
+Orchomenus, or at Pylos, or is he at Sparta with Menelaus--for I presume
+that he is still living.'
+
+"And I said, 'Agamemnon, why do you ask me? I do not know whether your
+son is alive or dead, and it is not right to talk when one does not
+know.'
+
+"As we two sat weeping and talking thus sadly with one another the ghost
+of Achilles came up to us with Patroclus, Antilochus, and Ajax who was
+the finest and goodliest man of all the Danaans after the son of Peleus.
+The fleet descendant of Aeacus knew me and spoke piteously, saying,
+'Ulysses, noble son of Laertes, what deed of daring will you undertake
+next, that you venture down to the house of Hades among us silly dead,
+who are but the ghosts of them that can labour no more?'
+
+"And I said, 'Achilles, son of Peleus, foremost champion of the
+Achaeans, I came to consult Teiresias, and see if he could advise me
+about my return home to Ithaca, for I have never yet been able to get
+near the Achaean land, nor to set foot in my own country, but have been
+in trouble all the time. As for you, Achilles, no one was ever yet so
+fortunate as you have been, nor ever will be, for you were adored by all
+us Argives as long as you were alive, and now that you are here you are
+a great prince among the dead. Do not, therefore, take it so much to
+heart even if you are dead.'
+
+"'Say not a word,' he answered, 'in death's favour; I would rather be
+a paid servant in a poor man's house and be above ground than king of
+kings among the dead. But give me news about my son; is he gone to the
+wars and will he be a great soldier, or is this not so? Tell me also if
+you have heard anything about my father Peleus--does he still rule among
+the Myrmidons, or do they show him no respect throughout Hellas and
+Phthia now that he is old and his limbs fail him? Could I but stand by
+his side, in the light of day, with the same strength that I had when I
+killed the bravest of our foes upon the plain of Troy--could I but be
+as I then was and go even for a short time to my father's house, any one
+who tried to do him violence or supersede him would soon rue it.'
+
+"'I have heard nothing,' I answered, 'of Peleus, but I can tell you all
+about your son Neoptolemus, for I took him in my own ship from Scyros
+with the Achaeans. In our councils of war before Troy he was always
+first to speak, and his judgement was unerring. Nestor and I were the
+only two who could surpass him; and when it came to fighting on the
+plain of Troy, he would never remain with the body of his men, but would
+dash on far in front, foremost of them all in valour. Many a man did
+he kill in battle--I cannot name every single one of those whom he slew
+while fighting on the side of the Argives, but will only say how
+he killed that valiant hero Eurypylus son of Telephus, who was the
+handsomest man I ever saw except Memnon; many others also of the
+Ceteians fell around him by reason of a woman's bribes. Moreover, when
+all the bravest of the Argives went inside the horse that Epeus had
+made, and it was left to me to settle when we should either open the
+door of our ambuscade, or close it, though all the other leaders and
+chief men among the Danaans were drying their eyes and quaking in every
+limb, I never once saw him turn pale nor wipe a tear from his cheek;
+he was all the time urging me to break out from the horse--grasping
+the handle of his sword and his bronze-shod spear, and breathing fury
+against the foe. Yet when we had sacked the city of Priam he got his
+handsome share of the prize money and went on board (such is the fortune
+of war) without a wound upon him, neither from a thrown spear nor in
+close combat, for the rage of Mars is a matter of great chance.'
+
+"When I had told him this, the ghost of Achilles strode off across a
+meadow full of asphodel, exulting over what I had said concerning the
+prowess of his son.
+
+"The ghosts of other dead men stood near me and told me each his own
+melancholy tale; but that of Ajax son of Telamon alone held aloof--still
+angry with me for having won the cause in our dispute about the armour
+of Achilles. Thetis had offered it as a prize, but the Trojan prisoners
+and Minerva were the judges. Would that I had never gained the day in
+such a contest, for it cost the life of Ajax, who was foremost of all
+the Danaans after the son of Peleus, alike in stature and prowess.
+
+"When I saw him I tried to pacify him and said, 'Ajax, will you not
+forget and forgive even in death, but must the judgement about that
+hateful armour still rankle with you? It cost us Argives dear enough to
+lose such a tower of strength as you were to us. We mourned you as much
+as we mourned Achilles son of Peleus himself, nor can the blame be laid
+on anything but on the spite which Jove bore against the Danaans, for it
+was this that made him counsel your destruction--come hither, therefore,
+bring your proud spirit into subjection, and hear what I can tell you.'
+
+"He would not answer, but turned away to Erebus and to the other ghosts;
+nevertheless, I should have made him talk to me in spite of his being
+so angry, or I should have gone on talking to him, {97} only that there
+were still others among the dead whom I desired to see.
+
+"Then I saw Minos son of Jove with his golden sceptre in his hand
+sitting in judgement on the dead, and the ghosts were gathered sitting
+and standing round him in the spacious house of Hades, to learn his
+sentences upon them.
+
+"After him I saw huge Orion in a meadow full of asphodel driving the
+ghosts of the wild beasts that he had killed upon the mountains, and he
+had a great bronze club in his hand, unbreakable for ever and ever.
+
+"And I saw Tityus son of Gaia stretched upon the plain and covering some
+nine acres of ground. Two vultures on either side of him were digging
+their beaks into his liver, and he kept on trying to beat them off with
+his hands, but could not; for he had violated Jove's mistress Leto as
+she was going through Panopeus on her way to Pytho.
+
+"I saw also the dreadful fate of Tantalus, who stood in a lake that
+reached his chin; he was dying to quench his thirst, but could never
+reach the water, for whenever the poor creature stooped to drink, it
+dried up and vanished, so that there was nothing but dry ground--parched
+by the spite of heaven. There were tall trees, moreover, that shed their
+fruit over his head--pears, pomegranates, apples, sweet figs and juicy
+olives, but whenever the poor creature stretched out his hand to take
+some, the wind tossed the branches back again to the clouds.
+
+"And I saw Sisyphus at his endless task raising his prodigious stone
+with both his hands. With hands and feet he tried to roll it up to the
+top of the hill, but always, just before he could roll it over on to the
+other side, its weight would be too much for him, and the pitiless stone
+{98} would come thundering down again on to the plain. Then he would
+begin trying to push it up hill again, and the sweat ran off him and the
+steam rose after him.
+
+"After him I saw mighty Hercules, but it was his phantom only, for he is
+feasting ever with the immortal gods, and has lovely Hebe to wife, who
+is daughter of Jove and Juno. The ghosts were screaming round him like
+scared birds flying all whithers. He looked black as night with his bare
+bow in his hands and his arrow on the string, glaring around as though
+ever on the point of taking aim. About his breast there was a wondrous
+golden belt adorned in the most marvellous fashion with bears, wild
+boars, and lions with gleaming eyes; there was also war, battle, and
+death. The man who made that belt, do what he might, would never be able
+to make another like it. Hercules knew me at once when he saw me, and
+spoke piteously, saying, 'My poor Ulysses, noble son of Laertes, are
+you too leading the same sorry kind of life that I did when I was above
+ground? I was son of Jove, but I went through an infinity of suffering,
+for I became bondsman to one who was far beneath me--a low fellow
+who set me all manner of labours. He once sent me here to fetch the
+hell-hound--for he did not think he could find anything harder for me
+than this, but I got the hound out of Hades and brought him to him, for
+Mercury and Minerva helped me.'
+
+"On this Hercules went down again into the house of Hades, but I stayed
+where I was in case some other of the mighty dead should come to me.
+And I should have seen still other of them that are gone before, whom
+I would fain have seen--Theseus and Pirithous--glorious children of the
+gods, but so many thousands of ghosts came round me and uttered such
+appalling cries, that I was panic stricken lest Proserpine should send
+up from the house of Hades the head of that awful monster Gorgon. On
+this I hastened back to my ship and ordered my men to go on board at
+once and loose the hawsers; so they embarked and took their places,
+whereon the ship went down the stream of the river Oceanus. We had to
+row at first, but presently a fair wind sprang up.
+
+
+Book XII
+
+THE SIRENS, SCYLLA AND CHARYBDIS, THE CATTLE OF THE SUN.
+
+"After we were clear of the river Oceanus, and had got out into the open
+sea, we went on till we reached the Aeaean island where there is dawn
+and sun-rise as in other places. We then drew our ship on to the sands
+and got out of her on to the shore, where we went to sleep and waited
+till day should break.
+
+"Then, when the child of morning, rosy-fingered Dawn, appeared, I sent
+some men to Circe's house to fetch the body of Elpenor. We cut firewood
+from a wood where the headland jutted out into the sea, and after we had
+wept over him and lamented him we performed his funeral rites. When his
+body and armour had been burned to ashes, we raised a cairn, set a stone
+over it, and at the top of the cairn we fixed the oar that he had been
+used to row with.
+
+"While we were doing all this, Circe, who knew that we had got back from
+the house of Hades, dressed herself and came to us as fast as she could;
+and her maid servants came with her bringing us bread, meat, and wine.
+Then she stood in the midst of us and said, 'You have done a bold thing
+in going down alive to the house of Hades, and you will have died twice,
+to other people's once; now, then, stay here for the rest of the
+day, feast your fill, and go on with your voyage at daybreak tomorrow
+morning. In the meantime I will tell Ulysses about your course, and
+will explain everything to him so as to prevent your suffering from
+misadventure either by land or sea.'
+
+"We agreed to do as she had said, and feasted through the livelong day
+to the going down of the sun, but when the sun had set and it came on
+dark, the men laid themselves down to sleep by the stern cables of the
+ship. Then Circe took me by the hand and bade me be seated away from
+the others, while she reclined by my side and asked me all about our
+adventures.
+
+"'So far so good,' said she, when I had ended my story, 'and now pay
+attention to what I am about to tell you--heaven itself, indeed, will
+recall it to your recollection. First you will come to the Sirens who
+enchant all who come near them. If any one unwarily draws in too close
+and hears the singing of the Sirens, his wife and children will never
+welcome him home again, for they sit in a green field and warble him to
+death with the sweetness of their song. There is a great heap of dead
+men's bones lying all around, with the flesh still rotting off them.
+Therefore pass these Sirens by, and stop your men's ears with wax that
+none of them may hear; but if you like you can listen yourself, for you
+may get the men to bind you as you stand upright on a cross piece half
+way up the mast, {99} and they must lash the rope's ends to the mast
+itself, that you may have the pleasure of listening. If you beg and pray
+the men to unloose you, then they must bind you faster.
+
+"'When your crew have taken you past these Sirens, I cannot give you
+coherent directions {100} as to which of two courses you are to take; I
+will lay the two alternatives before you, and you must consider them for
+yourself. On the one hand there are some overhanging rocks against which
+the deep blue waves of Amphitrite beat with terrific fury; the blessed
+gods call these rocks the Wanderers. Here not even a bird may pass, no,
+not even the timid doves that bring ambrosia to Father Jove, but the
+sheer rock always carries off one of them, and Father Jove has to send
+another to make up their number; no ship that ever yet came to these
+rocks has got away again, but the waves and whirlwinds of fire are
+freighted with wreckage and with the bodies of dead men. The only vessel
+that ever sailed and got through, was the famous Argo on her way from
+the house of Aetes, and she too would have gone against these great
+rocks, only that Juno piloted her past them for the love she bore to
+Jason.
+
+"'Of these two rocks the one reaches heaven and its peak is lost in a
+dark cloud. This never leaves it, so that the top is never clear not
+even in summer and early autumn. No man though he had twenty hands and
+twenty feet could get a foothold on it and climb it, for it runs sheer
+up, as smooth as though it had been polished. In the middle of it there
+is a large cavern, looking West and turned towards Erebus; you must
+take your ship this way, but the cave is so high up that not even the
+stoutest archer could send an arrow into it. Inside it Scylla sits and
+yelps with a voice that you might take to be that of a young hound, but
+in truth she is a dreadful monster and no one--not even a god--could
+face her without being terror-struck. She has twelve mis-shapen feet,
+and six necks of the most prodigious length; and at the end of each neck
+she has a frightful head with three rows of teeth in each, all set very
+close together, so that they would crunch any one to death in a moment,
+and she sits deep within her shady cell thrusting out her heads and
+peering all round the rock, fishing for dolphins or dogfish or
+any larger monster that she can catch, of the thousands with which
+Amphitrite teems. No ship ever yet got past her without losing some men,
+for she shoots out all her heads at once, and carries off a man in each
+mouth.
+
+"'You will find the other rock lie lower, but they are so close together
+that there is not more than a bow-shot between them. [A large fig
+tree in full leaf {101} grows upon it], and under it lies the sucking
+whirlpool of Charybdis. Three times in the day does she vomit forth her
+waters, and three times she sucks them down again; see that you be not
+there when she is sucking, for if you are, Neptune himself could not
+save you; you must hug the Scylla side and drive ship by as fast as you
+can, for you had better lose six men than your whole crew.'
+
+"'Is there no way,' said I, 'of escaping Charybdis, and at the same time
+keeping Scylla off when she is trying to harm my men?'
+
+"'You dare devil,' replied the goddess, 'you are always wanting to fight
+somebody or something; you will not let yourself be beaten even by the
+immortals. For Scylla is not mortal; moreover she is savage, extreme,
+rude, cruel and invincible. There is no help for it; your best chance
+will be to get by her as fast as ever you can, for if you dawdle about
+her rock while you are putting on your armour, she may catch you with
+a second cast of her six heads, and snap up another half dozen of your
+men; so drive your ship past her at full speed, and roar out lustily to
+Crataiis who is Scylla's dam, bad luck to her; she will then stop her
+from making a second raid upon you.'
+
+"'You will now come to the Thrinacian island, and here you will see
+many herds of cattle and flocks of sheep belonging to the sun-god--seven
+herds of cattle and seven flocks of sheep, with fifty head in each
+flock. They do not breed, nor do they become fewer in number, and they
+are tended by the goddesses Phaethusa and Lampetie, who are children of
+the sun-god Hyperion by Neaera. Their mother when she had borne them and
+had done suckling them sent them to the Thrinacian island, which was
+a long way off, to live there and look after their father's flocks and
+herds. If you leave these flocks unharmed, and think of nothing but
+getting home, you may yet after much hardship reach Ithaca; but if you
+harm them, then I forewarn you of the destruction both of your ship
+and of your comrades; and even though you may yourself escape, you will
+return late, in bad plight, after losing all your men.'
+
+"Here she ended, and dawn enthroned in gold began to show in heaven,
+whereon she returned inland. I then went on board and told my men to
+loose the ship from her moorings; so they at once got into her, took
+their places, and began to smite the grey sea with their oars. Presently
+the great and cunning goddess Circe befriended us with a fair wind
+that blew dead aft, and staid steadily with us, keeping our sails well
+filled, so we did whatever wanted doing to the ship's gear, and let her
+go as wind and helmsman headed her.
+
+"Then, being much troubled in mind, I said to my men, 'My friends, it
+is not right that one or two of us alone should know the prophecies that
+Circe has made me, I will therefore tell you about them, so that whether
+we live or die we may do so with our eyes open. First she said we were
+to keep clear of the Sirens, who sit and sing most beautifully in a
+field of flowers; but she said I might hear them myself so long as no
+one else did. Therefore, take me and bind me to the crosspiece half
+way up the mast; bind me as I stand upright, with a bond so fast that I
+cannot possibly break away, and lash the rope's ends to the mast itself.
+If I beg and pray you to set me free, then bind me more tightly still.'
+
+"I had hardly finished telling everything to the men before we
+reached the island of the two Sirens, {102} for the wind had been very
+favourable. Then all of a sudden it fell dead calm; there was not a
+breath of wind nor a ripple upon the water, so the men furled the sails
+and stowed them; then taking to their oars they whitened the water with
+the foam they raised in rowing. Meanwhile I look a large wheel of wax
+and cut it up small with my sword. Then I kneaded the wax in my strong
+hands till it became soft, which it soon did between the kneading and
+the rays of the sun-god son of Hyperion. Then I stopped the ears of all
+my men, and they bound me hands and feet to the mast as I stood upright
+on the cross piece; but they went on rowing themselves. When we had got
+within earshot of the land, and the ship was going at a good rate, the
+Sirens saw that we were getting in shore and began with their singing.
+
+"'Come here,' they sang, 'renowned Ulysses, honour to the Achaean name,
+and listen to our two voices. No one ever sailed past us without staying
+to hear the enchanting sweetness of our song--and he who listens will
+go on his way not only charmed, but wiser, for we know all the ills that
+the gods laid upon the Argives and Trojans before Troy, and can tell you
+everything that is going to happen over the whole world.'
+
+"They sang these words most musically, and as I longed to hear them
+further I made signs by frowning to my men that they should set me free;
+but they quickened their stroke, and Eurylochus and Perimedes bound me
+with still stronger bonds till we had got out of hearing of the Sirens'
+voices. Then my men took the wax from their ears and unbound me.
+
+"Immediately after we had got past the island I saw a great wave from
+which spray was rising, and I heard a loud roaring sound. The men were
+so frightened that they loosed hold of their oars, for the whole sea
+resounded with the rushing of the waters, {103} but the ship stayed
+where it was, for the men had left off rowing. I went round, therefore,
+and exhorted them man by man not to lose heart.
+
+"'My friends,' said I, 'this is not the first time that we have been
+in danger, and we are in nothing like so bad a case as when the Cyclops
+shut us up in his cave; nevertheless, my courage and wise counsel
+saved us then, and we shall live to look back on all this as well. Now,
+therefore, let us all do as I say, trust in Jove and row on with might
+and main. As for you, coxswain, these are your orders; attend to them,
+for the ship is in your hands; turn her head away from these steaming
+rapids and hug the rock, or she will give you the slip and be over
+yonder before you know where you are, and you will be the death of us.'
+
+"So they did as I told them; but I said nothing about the awful monster
+Scylla, for I knew the men would not go on rowing if I did, but would
+huddle together in the hold. In one thing only did I disobey Circe's
+strict instructions--I put on my armour. Then seizing two strong spears
+I took my stand on the ship's bows, for it was there that I expected
+first to see the monster of the rock, who was to do my men so much harm;
+but I could not make her out anywhere, though I strained my eyes with
+looking the gloomy rock all over and over.
+
+"Then we entered the Straits in great fear of mind, for on the one hand
+was Scylla, and on the other dread Charybdis kept sucking up the salt
+water. As she vomited it up, it was like the water in a cauldron when it
+is boiling over upon a great fire, and the spray reached the top of the
+rocks on either side. When she began to suck again, we could see the
+water all inside whirling round and round, and it made a deafening sound
+as it broke against the rocks. We could see the bottom of the whirlpool
+all black with sand and mud, and the men were at their wits ends for
+fear. While we were taken up with this, and were expecting each moment
+to be our last, Scylla pounced down suddenly upon us and snatched up my
+six best men. I was looking at once after both ship and men, and in a
+moment I saw their hands and feet ever so high above me, struggling in
+the air as Scylla was carrying them off, and I heard them call out my
+name in one last despairing cry. As a fisherman, seated, spear in hand,
+upon some jutting rock {104} throws bait into the water to deceive the
+poor little fishes, and spears them with the ox's horn with which his
+spear is shod, throwing them gasping on to the land as he catches them
+one by one--even so did Scylla land these panting creatures on her
+rock and munch them up at the mouth of her den, while they screamed and
+stretched out their hands to me in their mortal agony. This was the most
+sickening sight that I saw throughout all my voyages.
+
+"When we had passed the [Wandering] rocks, with Scylla and terrible
+Charybdis, we reached the noble island of the sun-god, where were the
+goodly cattle and sheep belonging to the sun Hyperion. While still at
+sea in my ship I could bear the cattle lowing as they came home to the
+yards, and the sheep bleating. Then I remembered what the blind Theban
+prophet Teiresias had told me, and how carefully Aeaean Circe had warned
+me to shun the island of the blessed sun-god. So being much troubled I
+said to the men, 'My men, I know you are hard pressed, but listen while
+I tell you the prophecy that Teiresias made me, and how carefully Aeaean
+Circe warned me to shun the island of the blessed sun-god, for it
+was here, she said, that our worst danger would lie. Head the ship,
+therefore, away from the island.'
+
+"The men were in despair at this, and Eurylochus at once gave me an
+insolent answer. 'Ulysses,' said he, 'you are cruel; you are very strong
+yourself and never get worn out; you seem to be made of iron, and now,
+though your men are exhausted with toil and want of sleep, you will not
+let them land and cook themselves a good supper upon this island, but
+bid them put out to sea and go faring fruitlessly on through the watches
+of the flying night. It is by night that the winds blow hardest and do
+so much damage; how can we escape should one of those sudden squalls
+spring up from South West or West, which so often wreck a vessel when
+our lords the gods are unpropitious? Now, therefore, let us obey the
+behests of night and prepare our supper here hard by the ship; to-morrow
+morning we will go on board again and put out to sea.'
+
+"Thus spoke Eurylochus, and the men approved his words. I saw that
+heaven meant us a mischief and said, 'You force me to yield, for you are
+many against one, but at any rate each one of you must take his solemn
+oath that if he meet with a herd of cattle or a large flock of sheep,
+he will not be so mad as to kill a single head of either, but will be
+satisfied with the food that Circe has given us.'
+
+"They all swore as I bade them, and when they had completed their oath
+we made the ship fast in a harbour that was near a stream of fresh
+water, and the men went ashore and cooked their suppers. As soon as they
+had had enough to eat and drink, they began talking about their poor
+comrades whom Scylla had snatched up and eaten; this set them weeping
+and they went on crying till they fell off into a sound sleep.
+
+"In the third watch of the night when the stars had shifted their
+places, Jove raised a great gale of wind that flew a hurricane so that
+land and sea were covered with thick clouds, and night sprang forth out
+of the heavens. When the child of morning, rosy-fingered Dawn, appeared,
+we brought the ship to land and drew her into a cave wherein the
+sea-nymphs hold their courts and dances, and I called the men together
+in council.
+
+"'My friends,' said I, 'we have meat and drink in the ship, let us mind,
+therefore, and not touch the cattle, or we shall suffer for it; for
+these cattle and sheep belong to the mighty sun, who sees and gives ear
+to everything.' And again they promised that they would obey.
+
+"For a whole month the wind blew steadily from the South, and there was
+no other wind, but only South and East. {105} As long as corn and wine
+held out the men did not touch the cattle when they were hungry; when,
+however, they had eaten all there was in the ship, they were forced
+to go further afield, with hook and line, catching birds, and taking
+whatever they could lay their hands on; for they were starving. One day,
+therefore, I went up inland that I might pray heaven to show me some
+means of getting away. When I had gone far enough to be clear of all
+my men, and had found a place that was well sheltered from the wind,
+I washed my hands and prayed to all the gods in Olympus till by and by
+they sent me off into a sweet sleep.
+
+"Meanwhile Eurylochus had been giving evil counsel to the men, 'Listen
+to me,' said he, 'my poor comrades. All deaths are bad enough but there
+is none so bad as famine. Why should not we drive in the best of these
+cows and offer them in sacrifice to the immortal gods? If we ever get
+back to Ithaca, we can build a fine temple to the sun-god and enrich it
+with every kind of ornament; if, however, he is determined to sink our
+ship out of revenge for these homed cattle, and the other gods are of
+the same mind, I for one would rather drink salt water once for all and
+have done with it, than be starved to death by inches in such a desert
+island as this is.'
+
+"Thus spoke Eurylochus, and the men approved his words. Now the cattle,
+so fair and goodly, were feeding not far from the ship; the men,
+therefore, drove in the best of them, and they all stood round them
+saying their prayers, and using young oak-shoots instead of barley-meal,
+for there was no barley left. When they had done praying they killed the
+cows and dressed their carcasses; they cut out the thigh bones, wrapped
+them round in two layers of fat, and set some pieces of raw meat on top
+of them. They had no wine with which to make drink-offerings over the
+sacrifice while it was cooking, so they kept pouring on a little water
+from time to time while the inward meats were being grilled; then, when
+the thigh bones were burned and they had tasted the inward meats, they
+cut the rest up small and put the pieces upon the spits.
+
+"By this time my deep sleep had left me, and I turned back to the ship
+and to the sea shore. As I drew near I began to smell hot roast meat, so
+I groaned out a prayer to the immortal gods. 'Father Jove,' I exclaimed,
+'and all you other gods who live in everlasting bliss, you have done me
+a cruel mischief by the sleep into which you have sent me; see what fine
+work these men of mine have been making in my absence.'
+
+"Meanwhile Lampetie went straight off to the sun and told him we had
+been killing his cows, whereon he flew into a great rage, and said
+to the immortals, 'Father Jove, and all you other gods who live in
+everlasting bliss, I must have vengeance on the crew of Ulysses' ship:
+they have had the insolence to kill my cows, which were the one thing I
+loved to look upon, whether I was going up heaven or down again. If they
+do not square accounts with me about my cows, I will go down to Hades
+and shine there among the dead.'
+
+"'Sun,' said Jove, 'go on shining upon us gods and upon mankind over the
+fruitful earth. I will shiver their ship into little pieces with a bolt
+of white lightning as soon as they get out to sea.'
+
+"I was told all this by Calypso, who said she had heard it from the
+mouth of Mercury.
+
+"As soon as I got down to my ship and to the sea shore I rebuked each
+one of the men separately, but we could see no way out of it, for the
+cows were dead already. And indeed the gods began at once to show signs
+and wonders among us, for the hides of the cattle crawled about, and
+the joints upon the spits began to low like cows, and the meat, whether
+cooked or raw, kept on making a noise just as cows do.
+
+"For six days my men kept driving in the best cows and feasting upon
+them, but when Jove the son of Saturn had added a seventh day, the fury
+of the gale abated; we therefore went on board, raised our masts, spread
+sail, and put out to sea. As soon as we were well away from the island,
+and could see nothing but sky and sea, the son of Saturn raised a black
+cloud over our ship, and the sea grew dark beneath it. We did not get on
+much further, for in another moment we were caught by a terrific squall
+from the West that snapped the forestays of the mast so that it fell
+aft, while all the ship's gear tumbled about at the bottom of the
+vessel. The mast fell upon the head of the helmsman in the ship's
+stern, so that the bones of his head were crushed to pieces, and he fell
+overboard as though he were diving, with no more life left in him.
+
+"Then Jove let fly with his thunderbolts, and the ship went round and
+round, and was filled with fire and brimstone as the lightning struck
+it. The men all fell into the sea; they were carried about in the water
+round the ship, looking like so many sea-gulls, but the god presently
+deprived them of all chance of getting home again.
+
+"I stuck to the ship till the sea knocked her sides from her keel (which
+drifted about by itself) and struck the mast out of her in the direction
+of the keel; but there was a backstay of stout ox-thong still hanging
+about it, and with this I lashed the mast and keel together, and getting
+astride of them was carried wherever the winds chose to take me.
+
+"[The gale from the West had now spent its force, and the wind got into
+the South again, which frightened me lest I should be taken back to the
+terrible whirlpool of Charybdis. This indeed was what actually happened,
+for I was borne along by the waves all night, and by sunrise had reached
+the rock of Scylla, and the whirlpool. She was then sucking down the
+salt sea water, {106} but I was carried aloft toward the fig tree, which
+I caught hold of and clung on to like a bat. I could not plant my feet
+anywhere so as to stand securely, for the roots were a long way off and
+the boughs that overshadowed the whole pool were too high, too vast, and
+too far apart for me to reach them; so I hung patiently on, waiting till
+the pool should discharge my mast and raft again--and a very long while
+it seemed. A jury-man is not more glad to get home to supper, after
+having been long detained in court by troublesome cases, than I was to
+see my raft beginning to work its way out of the whirlpool again. At
+last I let go with my hands and feet, and fell heavily into the sea,
+hard by my raft on to which I then got, and began to row with my hands.
+As for Scylla, the father of gods and men would not let her get further
+sight of me--otherwise I should have certainly been lost.] {107}
+
+"Hence I was carried along for nine days till on the tenth night the
+gods stranded me on the Ogygian island, where dwells the great and
+powerful goddess Calypso. She took me in and was kind to me, but I need
+say no more about this, for I told you and your noble wife all about it
+yesterday, and I hate saying the same thing over and over again."
+
+
+Book XIII
+
+ULYSSES LEAVES SCHERIA AND RETURNS TO ITHACA.
+
+Thus did he speak, and they all held their peace throughout the covered
+cloister, enthralled by the charm of his story, till presently Alcinous
+began to speak.
+
+"Ulysses," said he, "now that you have reached my house I doubt not you
+will get home without further misadventure no matter how much you have
+suffered in the past. To you others, however, who come here night after
+night to drink my choicest wine and listen to my bard, I would insist
+as follows. Our guest has already packed up the clothes, wrought gold,
+{108} and other valuables which you have brought for his acceptance;
+let us now, therefore, present him further, each one of us, with a large
+tripod and a cauldron. We will recoup ourselves by the levy of a general
+rate; for private individuals cannot be expected to bear the burden of
+such a handsome present."
+
+Every one approved of this, and then they went home to bed each in his
+own abode. When the child of morning, rosy-fingered Dawn, appeared they
+hurried down to the ship and brought their cauldrons with them. Alcinous
+went on board and saw everything so securely stowed under the ship's
+benches that nothing could break adrift and injure the rowers. Then they
+went to the house of Alcinous to get dinner, and he sacrificed a bull
+for them in honour of Jove who is the lord of all. They set the steaks
+to grill and made an excellent dinner, after which the inspired bard,
+Demodocus, who was a favourite with every one, sang to them; but Ulysses
+kept on turning his eyes towards the sun, as though to hasten his
+setting, for he was longing to be on his way. As one who has been all
+day ploughing a fallow field with a couple of oxen keeps thinking about
+his supper and is glad when night comes that he may go and get it, for
+it is all his legs can do to carry him, even so did Ulysses rejoice when
+the sun went down, and he at once said to the Phaeacians, addressing
+himself more particularly to King Alcinous:
+
+"Sir, and all of you, farewell. Make your drink-offerings and send me on
+my way rejoicing, for you have fulfilled my heart's desire by giving me
+an escort, and making me presents, which heaven grant that I may turn
+to good account; may I find my admirable wife living in peace among
+friends, {109} and may you whom I leave behind me give satisfaction
+to your wives and children; {110} may heaven vouchsafe you every good
+grace, and may no evil thing come among your people."
+
+Thus did he speak. His hearers all of them approved his saying and
+agreed that he should have his escort inasmuch as he had spoken
+reasonably. Alcinous therefore said to his servant, "Pontonous, mix
+some wine and hand it round to everybody, that we may offer a prayer to
+father Jove, and speed our guest upon his way."
+
+Pontonous mixed the wine and handed it to every one in turn; the others
+each from his own seat made a drink-offering to the blessed gods that
+live in heaven, but Ulysses rose and placed the double cup in the hands
+of queen Arete.
+
+"Farewell, queen," said he, "henceforward and for ever, till age and
+death, the common lot of mankind, lay their hands upon you. I now take
+my leave; be happy in this house with your children, your people, and
+with king Alcinous."
+
+As he spoke he crossed the threshold, and Alcinous sent a man to conduct
+him to his ship and to the sea shore. Arete also sent some maidservants
+with him--one with a clean shirt and cloak, another to carry his strong
+box, and a third with corn and wine. When they got to the water side
+the crew took these things and put them on board, with all the meat and
+drink; but for Ulysses they spread a rug and a linen sheet on deck that
+he might sleep soundly in the stern of the ship. Then he too went on
+board and lay down without a word, but the crew took every man his place
+and loosed the hawser from the pierced stone to which it had been bound.
+Thereon, when they began rowing out to sea, Ulysses fell into a deep,
+sweet, and almost deathlike slumber. {111}
+
+The ship bounded forward on her way as a four in hand chariot flies over
+the course when the horses feel the whip. Her prow curvetted as it were
+the neck of a stallion, and a great wave of dark blue water seethed in
+her wake. She held steadily on her course, and even a falcon, swiftest
+of all birds, could not have kept pace with her. Thus, then, she cut her
+way through the water, carrying one who was as cunning as the gods, but
+who was now sleeping peacefully, forgetful of all that he had suffered
+both on the field of battle and by the waves of the weary sea.
+
+When the bright star that heralds the approach of dawn began to show,
+the ship drew near to land. {112} Now there is in Ithaca a haven of the
+old merman Phorcys, which lies between two points that break the line
+of the sea and shut the harbour in. These shelter it from the storms of
+wind and sea that rage outside, so that, when once within it, a ship may
+lie without being even moored. At the head of this harbour there is a
+large olive tree, and at no great distance a fine overarching cavern
+sacred to the nymphs who are called Naiads. {113} There are mixing bowls
+within it and wine-jars of stone, and the bees hive there. Moreover,
+there are great looms of stone on which the nymphs weave their robes of
+sea purple--very curious to see--and at all times there is water within
+it. It has two entrances, one facing North by which mortals can go
+down into the cave, while the other comes from the South and is more
+mysterious; mortals cannot possibly get in by it, it is the way taken by
+the gods.
+
+Into this harbour, then, they took their ship, for they knew the place.
+{114} She had so much way upon her that she ran half her own length on
+to the shore; {115} when, however, they had landed, the first thing they
+did was to lift Ulysses with his rug and linen sheet out of the ship,
+and lay him down upon the sand still fast asleep. Then they took out the
+presents which Minerva had persuaded the Phaeacians to give him when he
+was setting out on his voyage homewards. They put these all together by
+the root of the olive tree, away from the road, for fear some passer by
+{116} might come and steal them before Ulysses awoke; and then they made
+the best of their way home again.
+
+But Neptune did not forget the threats with which he had already
+threatened Ulysses, so he took counsel with Jove. "Father Jove," said
+he, "I shall no longer be held in any sort of respect among you gods, if
+mortals like the Phaeacians, who are my own flesh and blood, show such
+small regard for me. I said I would let Ulysses get home when he had
+suffered sufficiently. I did not say that he should never get home at
+all, for I knew you had already nodded your head about it, and promised
+that he should do so; but now they have brought him in a ship fast
+asleep and have landed him in Ithaca after loading him with more
+magnificent presents of bronze, gold, and raiment than he would ever
+have brought back from Troy, if he had had his share of the spoil and
+got home without misadventure."
+
+And Jove answered, "What, O Lord of the Earthquake, are you talking
+about? The gods are by no means wanting in respect for you. It would
+be monstrous were they to insult one so old and honoured as you are. As
+regards mortals, however, if any of them is indulging in insolence and
+treating you disrespectfully, it will always rest with yourself to deal
+with him as you may think proper, so do just as you please."
+
+"I should have done so at once," replied Neptune, "if I were not anxious
+to avoid anything that might displease you; now, therefore, I should
+like to wreck the Phaeacian ship as it is returning from its escort.
+This will stop them from escorting people in future; and I should also
+like to bury their city under a huge mountain."
+
+"My good friend," answered Jove, "I should recommend you at the very
+moment when the people from the city are watching the ship on her way,
+to turn it into a rock near the land and looking like a ship. This
+will astonish everybody, and you can then bury their city under the
+mountain."
+
+When earth-encircling Neptune heard this he went to Scheria where the
+Phaeacians live, and stayed there till the ship, which was making rapid
+way, had got close in. Then he went up to it, turned it into stone, and
+drove it down with the flat of his hand so as to root it in the ground.
+After this he went away.
+
+The Phaeacians then began talking among themselves, and one would turn
+towards his neighbour, saying, "Bless my heart, who is it that can have
+rooted the ship in the sea just as she was getting into port? We could
+see the whole of her only a moment ago."
+
+This was how they talked, but they knew nothing about it; and Alcinous
+said, "I remember now the old prophecy of my father. He said that
+Neptune would be angry with us for taking every one so safely over the
+sea, and would one day wreck a Phaeacian ship as it was returning from
+an escort, and bury our city under a high mountain. This was what my old
+father used to say, and now it is all coming true. {117} Now therefore
+let us all do as I say; in the first place we must leave off giving
+people escorts when they come here, and in the next let us sacrifice
+twelve picked bulls to Neptune that he may have mercy upon us, and not
+bury our city under the high mountain." When the people heard this they
+were afraid and got ready the bulls.
+
+Thus did the chiefs and rulers of the Phaeacians pray to king Neptune,
+standing round his altar; and at the same time {118} Ulysses woke up
+once more upon his own soil. He had been so long away that he did not
+know it again; moreover, Jove's daughter Minerva had made it a foggy
+day, so that people might not know of his having come, and that she
+might tell him everything without either his wife or his fellow citizens
+and friends recognising him {119} until he had taken his revenge upon
+the wicked suitors. Everything, therefore, seemed quite different to
+him--the long straight tracks, the harbours, the precipices, and the
+goodly trees, appeared all changed as he started up and looked upon his
+native land. So he smote his thighs with the flat of his hands and cried
+aloud despairingly.
+
+"Alas," he exclaimed, "among what manner of people am I fallen? Are they
+savage and uncivilised or hospitable and humane? Where shall I put all
+this treasure, and which way shall I go? I wish I had staid over there
+with the Phaeacians; or I could have gone to some other great chief who
+would have been good to me and given me an escort. As it is I do not
+know where to put my treasure, and I cannot leave it here for fear
+somebody else should get hold of it. In good truth the chiefs and rulers
+of the Phaeacians have not been dealing fairly by me, and have left me
+in the wrong country; they said they would take me back to Ithaca and
+they have not done so: may Jove the protector of suppliants chastise
+them, for he watches over everybody and punishes those who do wrong.
+Still, I suppose I must count my goods and see if the crew have gone off
+with any of them."
+
+He counted his goodly coppers and cauldrons, his gold and all his
+clothes, but there was nothing missing; still he kept grieving about not
+being in his own country, and wandered up and down by the shore of
+the sounding sea bewailing his hard fate. Then Minerva came up to him
+disguised as a young shepherd of delicate and princely mien, with a good
+cloak folded double about her shoulders; she had sandals on her comely
+feet and held a javelin in her hand. Ulysses was glad when he saw her,
+and went straight up to her.
+
+"My friend," said he, "you are the first person whom I have met with in
+this country; I salute you, therefore, and beg you to be well disposed
+towards me. Protect these my goods, and myself too, for I embrace your
+knees and pray to you as though you were a god. Tell me, then, and tell
+me truly, what land and country is this? Who are its inhabitants? Am I
+on an island, or is this the sea board of some continent?"
+
+Minerva answered, "Stranger, you must be very simple, or must have come
+from somewhere a long way off, not to know what country this is. It is
+a very celebrated place, and everybody knows it East and West. It is
+rugged and not a good driving country, but it is by no means a bad
+island for what there is of it. It grows any quantity of corn and also
+wine, for it is watered both by rain and dew; it breeds cattle also
+and goats; all kinds of timber grow here, and there are watering places
+where the water never runs dry; so, sir, the name of Ithaca is known
+even as far as Troy, which I understand to be a long way off from this
+Achaean country."
+
+Ulysses was glad at finding himself, as Minerva told him, in his own
+country, and he began to answer, but he did not speak the truth, and
+made up a lying story in the instinctive wiliness of his heart.
+
+"I heard of Ithaca," said he, "when I was in Crete beyond the seas, and
+now it seems I have reached it with all these treasures. I have left
+as much more behind me for my children, but am flying because I killed
+Orsilochus son of Idomeneus, the fleetest runner in Crete. I killed him
+because he wanted to rob me of the spoils I had got from Troy with so
+much trouble and danger both on the field of battle and by the waves of
+the weary sea; he said I had not served his father loyally at Troy as
+vassal, but had set myself up as an independent ruler, so I lay in wait
+for him with one of my followers by the road side, and speared him as
+he was coming into town from the country. It was a very dark night and
+nobody saw us; it was not known, therefore, that I had killed him, but
+as soon as I had done so I went to a ship and besought the owners, who
+were Phoenicians, to take me on board and set me in Pylos or in Elis
+where the Epeans rule, giving them as much spoil as satisfied them. They
+meant no guile, but the wind drove them off their course, and we sailed
+on till we came hither by night. It was all we could do to get inside
+the harbour, and none of us said a word about supper though we wanted it
+badly, but we all went on shore and lay down just as we were. I was very
+tired and fell asleep directly, so they took my goods out of the ship,
+and placed them beside me where I was lying upon the sand. Then they
+sailed away to Sidonia, and I was left here in great distress of mind."
+
+Such was his story, but Minerva smiled and caressed him with her hand.
+Then she took the form of a woman, fair, stately, and wise, "He must be
+indeed a shifty lying fellow," said she, "who could surpass you in all
+manner of craft even though you had a god for your antagonist. Dare
+devil that you are, full of guile, unwearying in deceit, can you not
+drop your tricks and your instinctive falsehood, even now that you are
+in your own country again? We will say no more, however, about this, for
+we can both of us deceive upon occasion--you are the most accomplished
+counsellor and orator among all mankind, while I for diplomacy and
+subtlety have no equal among the gods. Did you not know Jove's daughter
+Minerva--me, who have been ever with you, who kept watch over you in
+all your troubles, and who made the Phaeacians take so great a liking
+to you? And now, again, I am come here to talk things over with you, and
+help you to hide the treasure I made the Phaeacians give you; I want to
+tell you about the troubles that await you in your own house; you have
+got to face them, but tell no one, neither man nor woman, that you have
+come home again. Bear everything, and put up with every man's insolence,
+without a word."
+
+And Ulysses answered, "A man, goddess, may know a great deal, but you
+are so constantly changing your appearance that when he meets you it
+is a hard matter for him to know whether it is you or not. This much,
+however, I know exceedingly well; you were very kind to me as long as we
+Achaeans were fighting before Troy, but from the day on which we went on
+board ship after having sacked the city of Priam, and heaven dispersed
+us--from that day, Minerva, I saw no more of you, and cannot ever
+remember your coming to my ship to help me in a difficulty; I had to
+wander on sick and sorry till the gods delivered me from evil and I
+reached the city of the Phaeacians, where you encouraged me and took me
+into the town. {120} And now, I beseech you in your father's name, tell
+me the truth, for I do not believe I am really back in Ithaca. I am in
+some other country and you are mocking me and deceiving me in all you
+have been saying. Tell me then truly, have I really got back to my own
+country?"
+
+"You are always taking something of that sort in your head," replied
+Minerva, "and that is why I cannot desert you in your afflictions; you
+are so plausible, shrewd and shifty. Any one but yourself on returning
+from so long a voyage would at once have gone home to see his wife and
+children, but you do not seem to care about asking after them or hearing
+any news about them till you have exploited your wife, who remains at
+home vainly grieving for you, and having no peace night or day for the
+tears she sheds on your behalf. As for my not coming near you, I was
+never uneasy about you, for I was certain you would get back safely
+though you would lose all your men, and I did not wish to quarrel with
+my uncle Neptune, who never forgave you for having blinded his son.
+{121} I will now, however, point out to you the lie of the land, and
+you will then perhaps believe me. This is the haven of the old merman
+Phorcys, and here is the olive tree that grows at the head of it; [near
+it is the cave sacred to the Naiads;] {122} here too is the overarching
+cavern in which you have offered many an acceptable hecatomb to the
+nymphs, and this is the wooded mountain Neritum."
+
+As she spoke the goddess dispersed the mist and the land appeared. Then
+Ulysses rejoiced at finding himself again in his own land, and kissed
+the bounteous soil; he lifted up his hands and prayed to the nymphs,
+saying, "Naiad nymphs, daughters of Jove, I made sure that I was never
+again to see you, now therefore I greet you with all loving salutations,
+and I will bring you offerings as in the old days, if Jove's redoubtable
+daughter will grant me life, and bring my son to manhood."
+
+"Take heart, and do not trouble yourself about that," rejoined Minerva,
+"let us rather set about stowing your things at once in the cave, where
+they will be quite safe. Let us see how we can best manage it all."
+
+Therewith she went down into the cave to look for the safest hiding
+places, while Ulysses brought up all the treasure of gold, bronze, and
+good clothing which the Phaeacians had given him. They stowed everything
+carefully away, and Minerva set a stone against the door of the cave.
+Then the two sat down by the root of the great olive, and consulted how
+to compass the destruction of the wicked suitors.
+
+"Ulysses," said Minerva, "noble son of Laertes, think how you can lay
+hands on these disreputable people who have been lording it in your
+house these three years, courting your wife and making wedding presents
+to her, while she does nothing but lament your absence, giving hope and
+sending encouraging messages {123} to every one of them, but meaning the
+very opposite of all she says."
+
+And Ulysses answered, "In good truth, goddess, it seems I should have
+come to much the same bad end in my own house as Agamemnon did, if you
+had not given me such timely information. Advise me how I shall best
+avenge myself. Stand by my side and put your courage into my heart as on
+the day when we loosed Troy's fair diadem from her brow. Help me now as
+you did then, and I will fight three hundred men, if you, goddess, will
+be with me."
+
+"Trust me for that," said she, "I will not lose sight of you when once
+we set about it, and I imagine that some of those who are devouring your
+substance will then bespatter the pavement with their blood and brains.
+I will begin by disguising you so that no human being shall know you; I
+will cover your body with wrinkles; you shall lose all your yellow
+hair; I will clothe you in a garment that shall fill all who see it with
+loathing; I will blear your fine eyes for you, and make you an unseemly
+object in the sight of the suitors, of your wife, and of the son whom
+you left behind you. Then go at once to the swineherd who is in charge
+of your pigs; he has been always well affected towards you, and is
+devoted to Penelope and your son; you will find him feeding his pigs
+near the rock that is called Raven {124} by the fountain Arethusa, where
+they are fattening on beechmast and spring water after their manner.
+Stay with him and find out how things are going, while I proceed to
+Sparta and see your son, who is with Menelaus at Lacedaemon, where he
+has gone to try and find out whether you are still alive." {125}
+
+"But why," said Ulysses, "did you not tell him, for you knew all about
+it? Did you want him too to go sailing about amid all kinds of hardship
+while others are eating up his estate?"
+
+Minerva answered, "Never mind about him, I sent him that he might be
+well spoken of for having gone. He is in no sort of difficulty, but
+is staying quite comfortably with Menelaus, and is surrounded with
+abundance of every kind. The suitors have put out to sea and are lying
+in wait for him, for they mean to kill him before he can get home. I do
+not much think they will succeed, but rather that some of those who are
+now eating up your estate will first find a grave themselves."
+
+As she spoke Minerva touched him with her wand and covered him with
+wrinkles, took away all his yellow hair, and withered the flesh over his
+whole body; she bleared his eyes, which were naturally very fine ones;
+she changed his clothes and threw an old rag of a wrap about him, and a
+tunic, tattered, filthy, and begrimed with smoke; she also gave him an
+undressed deer skin as an outer garment, and furnished him with a staff
+and a wallet all in holes, with a twisted thong for him to sling it over
+his shoulder.
+
+When the pair had thus laid their plans they parted, and the goddess
+went straight to Lacedaemon to fetch Telemachus.
+
+
+Book XIV
+
+ULYSSES IN THE HUT WITH EUMAEUS.
+
+Ulysses now left the haven, and took the rough track up through the
+wooded country and over the crest of the mountain till he reached the
+place where Minerva had said that he would find the swineherd, who was
+the most thrifty servant he had. He found him sitting in front of his
+hut, which was by the yards that he had built on a site which could be
+seen from far. He had made them spacious {126} and fair to see, with
+a free run for the pigs all round them; he had built them during his
+master's absence, of stones which he had gathered out of the ground,
+without saying anything to Penelope or Laertes, and he had fenced them
+on top with thorn bushes. Outside the yard he had run a strong fence of
+oaken posts, split, and set pretty close together, while inside he had
+built twelve styes near one another for the sows to lie in. There were
+fifty pigs wallowing in each stye, all of them breeding sows; but the
+boars slept outside and were much fewer in number, for the suitors
+kept on eating them, and the swineherd had to send them the best he
+had continually. There were three hundred and sixty boar pigs, and the
+herdsman's four hounds, which were as fierce as wolves, slept always
+with them. The swineherd was at that moment cutting out a pair of
+sandals {127} from a good stout ox hide. Three of his men were out
+herding the pigs in one place or another, and he had sent the fourth to
+town with a boar that he had been forced to send the suitors that they
+might sacrifice it and have their fill of meat.
+
+When the hounds saw Ulysses they set up a furious barking and flew at
+him, but Ulysses was cunning enough to sit down and loose his hold of
+the stick that he had in his hand: still, he would have been torn by
+them in his own homestead had not the swineherd dropped his ox hide,
+rushed full speed through the gate of the yard and driven the dogs off
+by shouting and throwing stones at them. Then he said to Ulysses, "Old
+man, the dogs were likely to have made short work of you, and then you
+would have got me into trouble. The gods have given me quite enough
+worries without that, for I have lost the best of masters, and am in
+continual grief on his account. I have to attend swine for other people
+to eat, while he, if he yet lives to see the light of day, is starving
+in some distant land. But come inside, and when you have had your fill
+of bread and wine, tell me where you come from, and all about your
+misfortunes."
+
+On this the swineherd led the way into the hut and bade him sit down.
+He strewed a good thick bed of rushes upon the floor, and on the top of
+this he threw the shaggy chamois skin--a great thick one--on which he
+used to sleep by night. Ulysses was pleased at being made thus welcome,
+and said "May Jove, sir, and the rest of the gods grant you your heart's
+desire in return for the kind way in which you have received me."
+
+To this you answered, O swineherd Eumaeus, "Stranger, though a still
+poorer man should come here, it would not be right for me to insult him,
+for all strangers and beggars are from Jove. You must take what you
+can get and be thankful, for servants live in fear when they have young
+lords for their masters; and this is my misfortune now, for heaven has
+hindered the return of him who would have been always good to me and
+given me something of my own--a house, a piece of land, a good looking
+wife, and all else that a liberal master allows a servant who has worked
+hard for him, and whose labour the gods have prospered as they have mine
+in the situation which I hold. If my master had grown old here he would
+have done great things by me, but he is gone, and I wish that Helen's
+whole race were utterly destroyed, for she has been the death of many a
+good man. It was this matter that took my master to Ilius, the land of
+noble steeds, to fight the Trojans in the cause of king Agamemnon."
+
+As he spoke he bound his girdle round him and went to the styes where
+the young sucking pigs were penned. He picked out two which he brought
+back with him and sacrificed. He singed them, cut them up, and spitted
+them; when the meat was cooked he brought it all in and set it before
+Ulysses, hot and still on the spit, whereon Ulysses sprinkled it over
+with white barley meal. The swineherd then mixed wine in a bowl of
+ivy-wood, and taking a seat opposite Ulysses told him to begin.
+
+"Fall to, stranger," said he, "on a dish of servant's pork. The fat pigs
+have to go to the suitors, who eat them up without shame or scruple; but
+the blessed gods love not such shameful doings, and respect those who do
+what is lawful and right. Even the fierce freebooters who go raiding on
+other people's land, and Jove gives them their spoil--even they,
+when they have filled their ships and got home again live
+conscience-stricken, and look fearfully for judgement; but some god
+seems to have told these people that Ulysses is dead and gone; they
+will not, therefore, go back to their own homes and make their offers of
+marriage in the usual way, but waste his estate by force, without fear
+or stint. Not a day or night comes out of heaven, but they sacrifice not
+one victim nor two only, and they take the run of his wine, for he was
+exceedingly rich. No other great man either in Ithaca or on the mainland
+is as rich as he was; he had as much as twenty men put together. I will
+tell you what he had. There are twelve herds of cattle upon the main
+land, and as many flocks of sheep, there are also twelve droves of pigs,
+while his own men and hired strangers feed him twelve widely spreading
+herds of goats. Here in Ithaca he runs even large flocks of goats on
+the far end of the island, and they are in the charge of excellent goat
+herds. Each one of these sends the suitors the best goat in the flock
+every day. As for myself, I am in charge of the pigs that you see here,
+and I have to keep picking out the best I have and sending it to them."
+
+This was his story, but Ulysses went on eating and drinking ravenously
+without a word, brooding his revenge. When he had eaten enough and was
+satisfied, the swineherd took the bowl from which he usually drank,
+filled it with wine, and gave it to Ulysses, who was pleased, and said
+as he took it in his hands, "My friend, who was this master of yours
+that bought you and paid for you, so rich and so powerful as you tell
+me? You say he perished in the cause of King Agamemnon; tell me who he
+was, in case I may have met with such a person. Jove and the other gods
+know, but I may be able to give you news of him, for I have travelled
+much."
+
+Eumaeus answered, "Old man, no traveller who comes here with news will
+get Ulysses' wife and son to believe his story. Nevertheless, tramps in
+want of a lodging keep coming with their mouths full of lies, and not a
+word of truth; every one who finds his way to Ithaca goes to my mistress
+and tells her falsehoods, whereon she takes them in, makes much of them,
+and asks them all manner of questions, crying all the time as women will
+when they have lost their husbands. And you too, old man, for a shirt
+and a cloak would doubtless make up a very pretty story. But the wolves
+and birds of prey have long since torn Ulysses to pieces, or the fishes
+of the sea have eaten him, and his bones are lying buried deep in sand
+upon some foreign shore; he is dead and gone, and a bad business it is
+for all his friends--for me especially; go where I may I shall never
+find so good a master, not even if I were to go home to my mother and
+father where I was bred and born. I do not so much care, however, about
+my parents now, though I should dearly like to see them again in my own
+country; it is the loss of Ulysses that grieves me most; I cannot speak
+of him without reverence though he is here no longer, for he was very
+fond of me, and took such care of me that wherever he may be I shall
+always honour his memory."
+
+"My friend," replied Ulysses, "you are very positive, and very hard of
+belief about your master's coming home again, nevertheless I will not
+merely say, but will swear, that he is coming. Do not give me anything
+for my news till he has actually come, you may then give me a shirt and
+cloak of good wear if you will. I am in great want, but I will not take
+anything at all till then, for I hate a man, even as I hate hell fire,
+who lets his poverty tempt him into lying. I swear by king Jove, by the
+rites of hospitality, and by that hearth of Ulysses to which I have now
+come, that all will surely happen as I have said it will. Ulysses
+will return in this self same year; with the end of this moon and the
+beginning of the next he will be here to do vengeance on all those who
+are ill treating his wife and son."
+
+To this you answered, O swineherd Eumaeus, "Old man, you will neither
+get paid for bringing good news, nor will Ulysses ever come home; drink
+your wine in peace, and let us talk about something else. Do not keep on
+reminding me of all this; it always pains me when any one speaks about
+my honoured master. As for your oath we will let it alone, but I only
+wish he may come, as do Penelope, his old father Laertes, and his son
+Telemachus. I am terribly unhappy too about this same boy of his; he was
+running up fast into manhood, and bade fare to be no worse man, face
+and figure, than his father, but some one, either god or man, has been
+unsettling his mind, so he has gone off to Pylos to try and get news of
+his father, and the suitors are lying in wait for him as he is coming
+home, in the hope of leaving the house of Arceisius without a name in
+Ithaca. But let us say no more about him, and leave him to be taken, or
+else to escape if the son of Saturn holds his hand over him to protect
+him. And now, old man, tell me your own story; tell me also, for I want
+to know, who you are and where you come from. Tell me of your town
+and parents, what manner of ship you came in, how crew brought you to
+Ithaca, and from what country they professed to come--for you cannot
+have come by land."
+
+And Ulysses answered, "I will tell you all about it. If there were meat
+and wine enough, and we could stay here in the hut with nothing to do
+but to eat and drink while the others go to their work, I could easily
+talk on for a whole twelve months without ever finishing the story of
+the sorrows with which it has pleased heaven to visit me.
+
+"I am by birth a Cretan; my father was a well to do man, who had many
+sons born in marriage, whereas I was the son of a slave whom he had
+purchased for a concubine; nevertheless, my father Castor son of Hylax
+(whose lineage I claim, and who was held in the highest honour among the
+Cretans for his wealth, prosperity, and the valour of his sons) put me
+on the same level with my brothers who had been born in wedlock. When,
+however, death took him to the house of Hades, his sons divided his
+estate and cast lots for their shares, but to me they gave a holding
+and little else; nevertheless, my valour enabled me to marry into a rich
+family, for I was not given to bragging, or shirking on the field of
+battle. It is all over now; still, if you look at the straw you can see
+what the ear was, for I have had trouble enough and to spare. Mars and
+Minerva made me doughty in war; when I had picked my men to surprise the
+enemy with an ambuscade I never gave death so much as a thought, but was
+the first to leap forward and spear all whom I could overtake. Such was
+I in battle, but I did not care about farm work, nor the frugal home
+life of those who would bring up children. My delight was in ships,
+fighting, javelins, and arrows--things that most men shudder to think
+of; but one man likes one thing and another another, and this was what
+I was most naturally inclined to. Before the Achaeans went to Troy,
+nine times was I in command of men and ships on foreign service, and I
+amassed much wealth. I had my pick of the spoil in the first instance,
+and much more was allotted to me later on.
+
+"My house grew apace and I became a great man among the Cretans,
+but when Jove counselled that terrible expedition, in which so many
+perished, the people required me and Idomeneus to lead their ships to
+Troy, and there was no way out of it, for they insisted on our doing
+so. There we fought for nine whole years, but in the tenth we sacked the
+city of Priam and sailed home again as heaven dispersed us. Then it was
+that Jove devised evil against me. I spent but one month happily with my
+children, wife, and property, and then I conceived the idea of making a
+descent on Egypt, so I fitted out a fine fleet and manned it. I had nine
+ships, and the people flocked to fill them. For six days I and my men
+made feast, and I found them many victims both for sacrifice to the gods
+and for themselves, but on the seventh day we went on board and set sail
+from Crete with a fair North wind behind us though we were going down a
+river. Nothing went ill with any of our ships, and we had no sickness
+on board, but sat where we were and let the ships go as the wind and
+steersmen took them. On the fifth day we reached the river Aegyptus;
+there I stationed my ships in the river, bidding my men stay by them and
+keep guard over them while I sent out scouts to reconnoitre from every
+point of vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captive. The alarm was soon carried to the city, and when they
+heard the war cry, the people came out at daybreak till the plain was
+filled with horsemen and foot soldiers and with the gleam of armour.
+Then Jove spread panic among my men, and they would no longer face the
+enemy, for they found themselves surrounded. The Egyptians killed many
+of us, and took the rest alive to do forced labour for them. Jove,
+however, put it in my mind to do thus--and I wish I had died then and
+there in Egypt instead, for there was much sorrow in store for me--I
+took off my helmet and shield and dropped my spear from my hand; then
+I went straight up to the king's chariot, clasped his knees and kissed
+them, whereon he spared my life, bade me get into his chariot, and took
+me weeping to his own home. Many made at me with their ashen spears and
+tried to kill me in their fury, but the king protected me, for he feared
+the wrath of Jove the protector of strangers, who punishes those who do
+evil.
+
+"I stayed there for seven years and got together much money among the
+Egyptians, for they all gave me something; but when it was now going on
+for eight years there came a certain Phoenician, a cunning rascal, who
+had already committed all sorts of villainy, and this man talked me over
+into going with him to Phoenicia, where his house and his possessions
+lay. I stayed there for a whole twelve months, but at the end of that
+time when months and days had gone by till the same season had come
+round again, he set me on board a ship bound for Libya, on a pretence
+that I was to take a cargo along with him to that place, but really that
+he might sell me as a slave and take the money I fetched. I suspected
+his intention, but went on board with him, for I could not help it.
+
+"The ship ran before a fresh North wind till we had reached the sea
+that lies between Crete and Libya; there, however, Jove counselled their
+destruction, for as soon as we were well out from Crete and could see
+nothing but sea and sky, he raised a black cloud over our ship and the
+sea grew dark beneath it. Then Jove let fly with his thunderbolts and
+the ship went round and round and was filled with fire and brimstone
+as the lightning struck it. The men fell all into the sea; they
+were carried about in the water round the ship looking like so many
+sea-gulls, but the god presently deprived them of all chance of getting
+home again. I was all dismayed. Jove, however, sent the ship's mast
+within my reach, which saved my life, for I clung to it, and drifted
+before the fury of the gale. Nine days did I drift but in the darkness
+of the tenth night a great wave bore me on to the Thesprotian coast.
+There Pheidon king of the Thesprotians entertained me hospitably without
+charging me anything at all--for his son found me when I was nearly dead
+with cold and fatigue, whereon he raised me by the hand, took me to his
+father's house and gave me clothes to wear.
+
+"There it was that I heard news of Ulysses, for the king told me he
+had entertained him, and shown him much hospitality while he was on his
+homeward journey. He showed me also the treasure of gold, and wrought
+iron that Ulysses had got together. There was enough to keep his family
+for ten generations, so much had he left in the house of king Pheidon.
+But the king said Ulysses had gone to Dodona that he might learn Jove's
+mind from the god's high oak tree, and know whether after so long an
+absence he should return to Ithaca openly, or in secret. Moreover the
+king swore in my presence, making drink-offerings in his own house as
+he did so, that the ship was by the water side, and the crew found,
+that should take him to his own country. He sent me off however before
+Ulysses returned, for there happened to be a Thesprotian ship sailing
+for the wheat-growing island of Dulichium, and he told those in charge
+of her to be sure and take me safely to King Acastus.
+
+"These men hatched a plot against me that would have reduced me to the
+very extreme of misery, for when the ship had got some way out from land
+they resolved on selling me as a slave. They stripped me of the shirt
+and cloak that I was wearing, and gave me instead the tattered old
+clouts in which you now see me; then, towards nightfall, they reached
+the tilled lands of Ithaca, and there they bound me with a strong rope
+fast in the ship, while they went on shore to get supper by the sea
+side. But the gods soon undid my bonds for me, and having drawn my rags
+over my head I slid down the rudder into the sea, where I struck out and
+swam till I was well clear of them, and came ashore near a thick wood
+in which I lay concealed. They were very angry at my having escaped and
+went searching about for me, till at last they thought it was no further
+use and went back to their ship. The gods, having hidden me thus easily,
+then took me to a good man's door--for it seems that I am not to die yet
+awhile."
+
+To this you answered, O swineherd Eumaeus, "Poor unhappy stranger, I
+have found the story of your misfortunes extremely interesting, but that
+part about Ulysses is not right; and you will never get me to believe
+it. Why should a man like you go about telling lies in this way? I know
+all about the return of my master. The gods one and all of them detest
+him, or they would have taken him before Troy, or let him die with
+friends around him when the days of his fighting were done; for then the
+Achaeans would have built a mound over his ashes and his son would have
+been heir to his renown, but now the storm winds have spirited him away
+we know not whither.
+
+"As for me I live out of the way here with the pigs, and never go to the
+town unless when Penelope sends for me on the arrival of some news
+about Ulysses. Then they all sit round and ask questions, both those who
+grieve over the king's absence, and those who rejoice at it because they
+can eat up his property without paying for it. For my own part I have
+never cared about asking anyone else since the time when I was taken in
+by an Aetolian, who had killed a man and come a long way till at last
+he reached my station, and I was very kind to him. He said he had seen
+Ulysses with Idomeneus among the Cretans, refitting his ships which had
+been damaged in a gale. He said Ulysses would return in the following
+summer or autumn with his men, and that he would bring back much wealth.
+And now you, you unfortunate old man, since fate has brought you to my
+door, do not try to flatter me in this way with vain hopes. It is not
+for any such reason that I shall treat you kindly, but only out of
+respect for Jove the god of hospitality, as fearing him and pitying
+you."
+
+Ulysses answered, "I see that you are of an unbelieving mind; I have
+given you my oath, and yet you will not credit me; let us then make a
+bargain, and call all the gods in heaven to witness it. If your master
+comes home, give me a cloak and shirt of good wear, and send me to
+Dulichium where I want to go; but if he does not come as I say he will,
+set your men on to me, and tell them to throw me from yonder precipice,
+as a warning to tramps not to go about the country telling lies."
+
+"And a pretty figure I should cut then," replied Eumaeus, "both now and
+hereafter, if I were to kill you after receiving you into my hut and
+showing you hospitality. I should have to say my prayers in good earnest
+if I did; but it is just supper time and I hope my men will come in
+directly, that we may cook something savoury for supper."
+
+Thus did they converse, and presently the swineherds came up with
+the pigs, which were then shut up for the night in their styes, and a
+tremendous squealing they made as they were being driven into them. But
+Eumaeus called to his men and said, "Bring in the best pig you have,
+that I may sacrifice him for this stranger, and we will take toll of him
+ourselves. We have had trouble enough this long time feeding pigs, while
+others reap the fruit of our labour."
+
+On this he began chopping firewood, while the others brought in a fine
+fat five year old boar pig, and set it at the altar. Eumaeus did not
+forget the gods, for he was a man of good principles, so the first thing
+he did was to cut bristles from the pig's face and throw them into the
+fire, praying to all the gods as he did so that Ulysses might return
+home again. Then he clubbed the pig with a billet of oak which he had
+kept back when he was chopping the firewood, and stunned it, while the
+others slaughtered and singed it. Then they cut it up, and Eumaeus began
+by putting raw pieces from each joint on to some of the fat; these he
+sprinkled with barley meal, and laid upon the embers; they cut the rest
+of the meat up small, put the pieces upon the spits and roasted them
+till they were done; when they had taken them off the spits they
+threw them on to the dresser in a heap. The swineherd, who was a most
+equitable man, then stood up to give every one his share. He made seven
+portions; one of these he set apart for Mercury the son of Maia and the
+nymphs, praying to them as he did so; the others he dealt out to the men
+man by man. He gave Ulysses some slices cut lengthways down the loin
+as a mark of especial honour, and Ulysses was much pleased. "I hope,
+Eumaeus," said he, "that Jove will be as well disposed towards you as I
+am, for the respect you are showing to an outcast like myself."
+
+To this you answered, O swineherd Eumaeus, "Eat, my good fellow, and
+enjoy your supper, such as it is. God grants this, and withholds that,
+just as he thinks right, for he can do whatever he chooses."
+
+As he spoke he cut off the first piece and offered it as a burnt
+sacrifice to the immortal gods; then he made them a drink-offering,
+put the cup in the hands of Ulysses, and sat down to his own portion.
+Mesaulius brought them their bread; the swineherd had brought this man
+on his own account from among the Taphians during his master's absence,
+and had paid for him with his own money without saying anything either
+to his mistress or Laertes. They then laid their hands upon the good
+things that were before them, and when they had had enough to eat and
+drink, Mesaulius took away what was left of the bread, and they all went
+to bed after having made a hearty supper.
+
+Now the night came on stormy and very dark, for there was no moon. It
+poured without ceasing, and the wind blew strong from the West, which is
+a wet quarter, so Ulysses thought he would see whether Eumaeus, in the
+excellent care he took of him, would take off his own cloak and give
+it him, or make one of his men give him one. "Listen to me," said he,
+"Eumaeus and the rest of you; when I have said a prayer I will tell you
+something. It is the wine that makes me talk in this way; wine will make
+even a wise man fall to singing; it will make him chuckle and dance
+and say many a word that he had better leave unspoken; still, as I have
+begun, I will go on. Would that I were still young and strong as when we
+got up an ambuscade before Troy. Menelaus and Ulysses were the leaders,
+but I was in command also, for the other two would have it so. When we
+had come up to the wall of the city we crouched down beneath our armour
+and lay there under cover of the reeds and thick brushwood that grew
+about the swamp. It came on to freeze with a North wind blowing; the
+snow fell small and fine like hoar frost, and our shields were coated
+thick with rime. The others had all got cloaks and shirts, and slept
+comfortably enough with their shields about their shoulders, but I had
+carelessly left my cloak behind me, not thinking that I should be too
+cold, and had gone off in nothing but my shirt and shield. When the
+night was two-thirds through and the stars had shifted their places, I
+nudged Ulysses who was close to me with my elbow, and he at once gave me
+his ear.
+
+"'Ulysses,' said I, 'this cold will be the death of me, for I have no
+cloak; some god fooled me into setting off with nothing on but my shirt,
+and I do not know what to do.'
+
+"Ulysses, who was as crafty as he was valiant, hit upon the following
+plan:
+
+"'Keep still,' said he in a low voice, 'or the others will hear you.'
+Then he raised his head on his elbow.
+
+"'My friends,' said he, 'I have had a dream from heaven in my sleep. We
+are a long way from the ships; I wish some one would go down and tell
+Agamemnon to send us up more men at once.'
+
+"On this Thoas son of Andraemon threw off his cloak and set out running
+to the ships, whereon I took the cloak and lay in it comfortably enough
+till morning. Would that I were still young and strong as I was in those
+days, for then some one of you swineherds would give me a cloak both out
+of good will and for the respect due to a brave soldier; but now people
+look down upon me because my clothes are shabby."
+
+And Eumaeus answered, "Old man, you have told us an excellent story,
+and have said nothing so far but what is quite satisfactory; for the
+present, therefore, you shall want neither clothing nor anything else
+that a stranger in distress may reasonably expect, but to-morrow morning
+you have to shake your own old rags about your body again, for we have
+not many spare cloaks nor shirts up here, but every man has only one.
+When Ulysses' son comes home again he will give you both cloak and
+shirt, and send you wherever you may want to go."
+
+With this he got up and made a bed for Ulysses by throwing some
+goatskins and sheepskins on the ground in front of the fire. Here
+Ulysses lay down, and Eumaeus covered him over with a great heavy cloak
+that he kept for a change in case of extraordinarily bad weather.
+
+Thus did Ulysses sleep, and the young men slept beside him. But the
+swineherd did not like sleeping away from his pigs, so he got ready
+to go outside, and Ulysses was glad to see that he looked after his
+property during his master's absence. First he slung his sword over his
+brawny shoulders and put on a thick cloak to keep out the wind. He also
+took the skin of a large and well fed goat, and a javelin in case of
+attack from men or dogs. Thus equipped he went to his rest where the
+pigs were camping under an overhanging rock that gave them shelter from
+the North wind.
+
+
+Book XV
+
+MINERVA SUMMONS TELEMACHUS FROM LACEDAEMON--HE MEETS WITH THEOCLYMENUS
+AT PYLOS AND BRINGS HIM TO ITHACA--ON LANDING HE GOES TO THE HUT OF
+EUMAEUS.
+
+But Minerva went to the fair city of Lacedaemon to tell Ulysses' son
+that he was to return at once. She found him and Pisistratus sleeping
+in the forecourt of Menelaus's house; Pisistratus was fast asleep,
+but Telemachus could get no rest all night for thinking of his unhappy
+father, so Minerva went close up to him and said:
+
+"Telemachus, you should not remain so far away from home any longer, nor
+leave your property with such dangerous people in your house; they
+will eat up everything you have among them, and you will have been on a
+fool's errand. Ask Menelaus to send you home at once if you wish to
+find your excellent mother still there when you get back. Her father and
+brothers are already urging her to marry Eurymachus, who has given her
+more than any of the others, and has been greatly increasing his wedding
+presents. I hope nothing valuable may have been taken from the house in
+spite of you, but you know what women are--they always want to do the
+best they can for the man who marries them, and never give another
+thought to the children of their first husband, nor to their father
+either when he is dead and done with. Go home, therefore, and put
+everything in charge of the most respectable woman servant that you
+have, until it shall please heaven to send you a wife of your own. Let
+me tell you also of another matter which you had better attend to. The
+chief men among the suitors are lying in wait for you in the Strait
+{128} between Ithaca and Samos, and they mean to kill you before you
+can reach home. I do not much think they will succeed; it is more likely
+that some of those who are now eating up your property will find a grave
+themselves. Sail night and day, and keep your ship well away from the
+islands; the god who watches over you and protects you will send you a
+fair wind. As soon as you get to Ithaca send your ship and men on to the
+town, but yourself go straight to the swineherd who has charge of your
+pigs; he is well disposed towards you, stay with him, therefore, for the
+night, and then send him to Penelope to tell her that you have got back
+safe from Pylos."
+
+Then she went back to Olympus; but Telemachus stirred Pisistratus with
+his heel to rouse him, and said, "Wake up Pisistratus, and yoke the
+horses to the chariot, for we must set off home." {129}
+
+But Pisistratus said, "No matter what hurry we are in we cannot drive
+in the dark. It will be morning soon; wait till Menelaus has brought his
+presents and put them in the chariot for us; and let him say good bye to
+us in the usual way. So long as he lives a guest should never forget a
+host who has shown him kindness."
+
+As he spoke day began to break, and Menelaus, who had already risen,
+leaving Helen in bed, came towards them. When Telemachus saw him he
+put on his shirt as fast as he could, threw a great cloak over his
+shoulders, and went out to meet him. "Menelaus," said he, "let me go
+back now to my own country, for I want to get home."
+
+And Menelaus answered, "Telemachus, if you insist on going I will not
+detain you. I do not like to see a host either too fond of his guest or
+too rude to him. Moderation is best in all things, and not letting a
+man go when he wants to do so is as bad as telling him to go if he would
+like to stay. One should treat a guest well as long as he is in the
+house and speed him when he wants to leave it. Wait, then, till I
+can get your beautiful presents into your chariot, and till you have
+yourself seen them. I will tell the women to prepare a sufficient dinner
+for you of what there may be in the house; it will be at once more
+proper and cheaper for you to get your dinner before setting out on
+such a long journey. If, moreover, you have a fancy for making a tour
+in Hellas or in the Peloponnese, I will yoke my horses, and will conduct
+you myself through all our principal cities. No one will send us away
+empty handed; every one will give us something--a bronze tripod, a
+couple of mules, or a gold cup."
+
+"Menelaus," replied Telemachus, "I want to go home at once, for when
+I came away I left my property without protection, and fear that
+while looking for my father I shall come to ruin myself, or find that
+something valuable has been stolen during my absence."
+
+When Menelaus heard this he immediately told his wife and servants to
+prepare a sufficient dinner from what there might be in the house. At
+this moment Eteoneus joined him, for he lived close by and had just got
+up; so Menelaus told him to light the fire and cook some meat, which he
+at once did. Then Menelaus went down into his fragrant store room, {130}
+not alone, but Helen went too, with Megapenthes. When he reached the
+place where the treasures of his house were kept, he selected a double
+cup, and told his son Megapenthes to bring also a silver mixing bowl.
+Meanwhile Helen went to the chest where she kept the lovely dresses
+which she had made with her own hands, and took out one that was largest
+and most beautifully enriched with embroidery; it glittered like a star,
+and lay at the very bottom of the chest. {131} Then they all came back
+through the house again till they got to Telemachus, and Menelaus said,
+"Telemachus, may Jove, the mighty husband of Juno, bring you safely home
+according to your desire. I will now present you with the finest and
+most precious piece of plate in all my house. It is a mixing bowl of
+pure silver, except the rim, which is inlaid with gold, and it is the
+work of Vulcan. Phaedimus king of the Sidonians made me a present of it
+in the course of a visit that I paid him while I was on my return home.
+I should like to give it to you."
+
+With these words he placed the double cup in the hands of Telemachus,
+while Megapenthes brought the beautiful mixing bowl and set it before
+him. Hard by stood lovely Helen with the robe ready in her hand.
+
+"I too, my son," said she, "have something for you as a keepsake from
+the hand of Helen; it is for your bride to wear upon her wedding day.
+Till then, get your dear mother to keep it for you; thus may you go back
+rejoicing to your own country and to your home."
+
+So saying she gave the robe over to him and he received it gladly. Then
+Pisistratus put the presents into the chariot, and admired them all as
+he did so. Presently Menelaus took Telemachus and Pisistratus into the
+house, and they both of them sat down to table. A maid servant brought
+them water in a beautiful golden ewer, and poured it into a silver basin
+for them to wash their hands, and she drew a clean table beside them;
+an upper servant brought them bread and offered them many good things of
+what there was in the house. Eteoneus carved the meat and gave them each
+their portions, while Megapenthes poured out the wine. Then they laid
+their hands upon the good things that were before them, but as soon as
+they had had enough to eat and drink Telemachus and Pisistratus yoked
+the horses, and took their places in the chariot. They drove out through
+the inner gateway and under the echoing gatehouse of the outer court,
+and Menelaus came after them with a golden goblet of wine in his right
+hand that they might make a drink-offering before they set out. He stood
+in front of the horses and pledged them, saying, "Farewell to both of
+you; see that you tell Nestor how I have treated you, for he was as
+kind to me as any father could be while we Achaeans were fighting before
+Troy."
+
+"We will be sure, sir," answered Telemachus, "to tell him everything as
+soon as we see him. I wish I were as certain of finding Ulysses returned
+when I get back to Ithaca, that I might tell him of the very great
+kindness you have shown me and of the many beautiful presents I am
+taking with me."
+
+As he was thus speaking a bird flew on his right hand--an eagle with a
+great white goose in its talons which it had carried off from the farm
+yard--and all the men and women were running after it and shouting. It
+came quite close up to them and flew away on their right hands in front
+of the horses. When they saw it they were glad, and their hearts took
+comfort within them, whereon Pisistratus said, "Tell me, Menelaus, has
+heaven sent this omen for us or for you?"
+
+Menelaus was thinking what would be the most proper answer for him to
+make, but Helen was too quick for him and said, "I will read this matter
+as heaven has put it in my heart, and as I doubt not that it will come
+to pass. The eagle came from the mountain where it was bred and has
+its nest, and in like manner Ulysses, after having travelled far and
+suffered much, will return to take his revenge--if indeed he is not back
+already and hatching mischief for the suitors."
+
+"May Jove so grant it," replied Telemachus, "if it should prove to be
+so, I will make vows to you as though you were a god, even when I am at
+home."
+
+As he spoke he lashed his horses and they started off at full speed
+through the town towards the open country. They swayed the yoke upon
+their necks and travelled the whole day long till the sun set and
+darkness was over all the land. Then they reached Pherae, where Diocles
+lived who was son of Ortilochus, the son of Alpheus. There they passed
+the night and were treated hospitably. When the child of morning,
+rosy-fingered Dawn, appeared, they again yoked their horses and their
+places in the chariot. They drove out through the inner gateway and
+under the echoing gatehouse of the outer court. Then Pisistratus lashed
+his horses on and they flew forward nothing loath; ere long they came to
+Pylos, and then Telemachus said:
+
+"Pisistratus, I hope you will promise to do what I am going to ask you.
+You know our fathers were old friends before us; moreover, we are both
+of an age, and this journey has brought us together still more closely;
+do not, therefore, take me past my ship, but leave me there, for if I go
+to your father's house he will try to keep me in the warmth of his good
+will towards me, and I must go home at once."
+
+Pisistratus thought how he should do as he was asked, and in the end he
+deemed it best to turn his horses towards the ship, and put Menelaus's
+beautiful presents of gold and raiment in the stern of the vessel. Then
+he said, "Go on board at once and tell your men to do so also before
+I can reach home to tell my father. I know how obstinate he is, and am
+sure he will not let you go; he will come down here to fetch you, and he
+will not go back without you. But he will be very angry."
+
+With this he drove his goodly steeds back to the city of the Pylians and
+soon reached his home, but Telemachus called the men together and gave
+his orders. "Now, my men," said he, "get everything in order on board
+the ship, and let us set out home."
+
+Thus did he speak, and they went on board even as he had said. But as
+Telemachus was thus busied, praying also and sacrificing to Minerva
+in the ship's stern, there came to him a man from a distant country,
+a seer, who was flying from Argos because he had killed a man. He was
+descended from Melampus, who used to live in Pylos, the land of sheep;
+he was rich and owned a great house, but he was driven into exile by the
+great and powerful king Neleus. Neleus seized his goods and held them
+for a whole year, during which he was a close prisoner in the house
+of king Phylacus, and in much distress of mind both on account of the
+daughter of Neleus and because he was haunted by a great sorrow that
+dread Erinys had laid upon him. In the end, however, he escaped with his
+life, drove the cattle from Phylace to Pylos, avenged the wrong that had
+been done him, and gave the daughter of Neleus to his brother. Then he
+left the country and went to Argos, where it was ordained that he should
+reign over much people. There he married, established himself, and had
+two famous sons Antiphates and Mantius. Antiphates became father of
+Oicleus, and Oicleus of Amphiaraus, who was dearly loved both by Jove
+and by Apollo, but he did not live to old age, for he was killed
+in Thebes by reason of a woman's gifts. His sons were Alcmaeon
+and Amphilochus. Mantius, the other son of Melampus, was father to
+Polypheides and Cleitus. Aurora, throned in gold, carried off Cleitus
+for his beauty's sake, that he might dwell among the immortals, but
+Apollo made Polypheides the greatest seer in the whole world now that
+Amphiaraus was dead. He quarrelled with his father and went to live in
+Hyperesia, where he remained and prophesied for all men.
+
+His son, Theoclymenus, it was who now came up to Telemachus as he was
+making drink-offerings and praying in his ship. "Friend," said he,
+"now that I find you sacrificing in this place, I beseech you by your
+sacrifices themselves, and by the god to whom you make them, I pray you
+also by your own head and by those of your followers tell me the truth
+and nothing but the truth. Who and whence are you? Tell me also of your
+town and parents."
+
+Telemachus said, "I will answer you quite truly. I am from Ithaca, and
+my father is Ulysses, as surely as that he ever lived. But he has come
+to some miserable end. Therefore I have taken this ship and got my crew
+together to see if I can hear any news of him, for he has been away a
+long time."
+
+"I too," answered Theoclymenus, "am an exile, for I have killed a man
+of my own race. He has many brothers and kinsmen in Argos, and they
+have great power among the Argives. I am flying to escape death at their
+hands, and am thus doomed to be a wanderer on the face of the earth. I
+am your suppliant; take me, therefore, on board your ship that they may
+not kill me, for I know they are in pursuit."
+
+"I will not refuse you," replied Telemachus, "if you wish to join us.
+Come, therefore, and in Ithaca we will treat you hospitably according to
+what we have."
+
+On this he received Theoclymenus' spear and laid it down on the deck of
+the ship. He went on board and sat in the stern, bidding Theoclymenus
+sit beside him; then the men let go the hawsers. Telemachus told them to
+catch hold of the ropes, and they made all haste to do so. They set the
+mast in its socket in the cross plank, raised it and made it fast with
+the forestays, and they hoisted their white sails with sheets of twisted
+ox hide. Minerva sent them a fair wind that blew fresh and strong to
+take the ship on her course as fast as possible. Thus then they passed
+by Crouni and Chalcis.
+
+Presently the sun set and darkness was over all the land. The vessel
+made a quick passage to Pheae and thence on to Elis, where the Epeans
+rule. Telemachus then headed her for the flying islands, {132} wondering
+within himself whether he should escape death or should be taken
+prisoner.
+
+Meanwhile Ulysses and the swineherd were eating their supper in the hut,
+and the men supped with them. As soon as they had had to eat and drink,
+Ulysses began trying to prove the swineherd and see whether he would
+continue to treat him kindly, and ask him to stay on at the station or
+pack him off to the city; so he said:
+
+"Eumaeus, and all of you, to-morrow I want to go away and begin begging
+about the town, so as to be no more trouble to you or to your men. Give
+me your advice therefore, and let me have a good guide to go with me
+and show me the way. I will go the round of the city begging as I needs
+must, to see if any one will give me a drink and a piece of bread. I
+should like also to go to the house of Ulysses and bring news of her
+husband to Queen Penelope. I could then go about among the suitors and
+see if out of all their abundance they will give me a dinner. I should
+soon make them an excellent servant in all sorts of ways. Listen and
+believe when I tell you that by the blessing of Mercury who gives grace
+and good name to the works of all men, there is no one living who would
+make a more handy servant than I should--to put fresh wood on the fire,
+chop fuel, carve, cook, pour out wine, and do all those services that
+poor men have to do for their betters."
+
+The swineherd was very much disturbed when he heard this. "Heaven help
+me," he exclaimed, "what ever can have put such a notion as that into
+your head? If you go near the suitors you will be undone to a certainty,
+for their pride and insolence reach the very heavens. They would never
+think of taking a man like you for a servant. Their servants are all
+young men, well dressed, wearing good cloaks and shirts, with well
+looking faces and their hair always tidy, the tables are kept quite
+clean and are loaded with bread, meat, and wine. Stay where you are,
+then; you are not in anybody's way; I do not mind your being here, no
+more do any of the others, and when Telemachus comes home he will give
+you a shirt and cloak and will send you wherever you want to go."
+
+Ulysses answered, "I hope you may be as dear to the gods as you are to
+me, for having saved me from going about and getting into trouble; there
+is nothing worse than being always on the tramp; still, when men have
+once got low down in the world they will go through a great deal on
+behalf of their miserable bellies. Since, however, you press me to stay
+here and await the return of Telemachus, tell me about Ulysses' mother,
+and his father whom he left on the threshold of old age when he set
+out for Troy. Are they still living or are they already dead and in the
+house of Hades?"
+
+"I will tell you all about them," replied Eumaeus, "Laertes is still
+living and prays heaven to let him depart peacefully in his own house,
+for he is terribly distressed about the absence of his son, and also
+about the death of his wife, which grieved him greatly and aged him more
+than anything else did. She came to an unhappy end {133} through sorrow
+for her son: may no friend or neighbour who has dealt kindly by me come
+to such an end as she did. As long as she was still living, though she
+was always grieving, I used to like seeing her and asking her how she
+did, for she brought me up along with her daughter Ctimene, the youngest
+of her children; we were boy and girl together, and she made little
+difference between us. When, however, we both grew up, they sent Ctimene
+to Same and received a splendid dowry for her. As for me, my mistress
+gave me a good shirt and cloak with a pair of sandals for my feet, and
+sent me off into the country, but she was just as fond of me as ever.
+This is all over now. Still it has pleased heaven to prosper my work in
+the situation which I now hold. I have enough to eat and drink, and can
+find something for any respectable stranger who comes here; but there
+is no getting a kind word or deed out of my mistress, for the house has
+fallen into the hands of wicked people. Servants want sometimes to see
+their mistress and have a talk with her; they like to have something
+to eat and drink at the house, and something too to take back with them
+into the country. This is what will keep servants in a good humour."
+
+Ulysses answered, "Then you must have been a very little fellow,
+Eumaeus, when you were taken so far away from your home and parents.
+Tell me, and tell me true, was the city in which your father and mother
+lived sacked and pillaged, or did some enemies carry you off when you
+were alone tending sheep or cattle, ship you off here, and sell you for
+whatever your master gave them?"
+
+"Stranger," replied Eumaeus, "as regards your question: sit still, make
+yourself comfortable, drink your wine, and listen to me. The nights
+are now at their longest; there is plenty of time both for sleeping and
+sitting up talking together; you ought not to go to bed till bed time,
+too much sleep is as bad as too little; if any one of the others wishes
+to go to bed let him leave us and do so; he can then take my master's
+pigs out when he has done breakfast in the morning. We too will sit here
+eating and drinking in the hut, and telling one another stories about
+our misfortunes; for when a man has suffered much, and been buffeted
+about in the world, he takes pleasure in recalling the memory of sorrows
+that have long gone by. As regards your question, then, my tale is as
+follows:
+
+"You may have heard of an island called Syra that lies over above
+Ortygia, {134} where the land begins to turn round and look in another
+direction. {135} It is not very thickly peopled, but the soil is good,
+with much pasture fit for cattle and sheep, and it abounds with wine
+and wheat. Dearth never comes there, nor are the people plagued by any
+sickness, but when they grow old Apollo comes with Diana and kills them
+with his painless shafts. It contains two communities, and the whole
+country is divided between these two. My father Ctesius son of Ormenus,
+a man comparable to the gods, reigned over both.
+
+"Now to this place there came some cunning traders from Phoenicia (for
+the Phoenicians are great mariners) in a ship which they had freighted
+with gewgaws of all kinds. There happened to be a Phoenician woman in
+my father's house, very tall and comely, and an excellent servant; these
+scoundrels got hold of her one day when she was washing near their ship,
+seduced her, and cajoled her in ways that no woman can resist, no matter
+how good she may be by nature. The man who had seduced her asked her who
+she was and where she came from, and on this she told him her father's
+name. 'I come from Sidon,' said she, 'and am daughter to Arybas, a
+man rolling in wealth. One day as I was coming into the town from the
+country, some Taphian pirates seized me and took me here over the sea,
+where they sold me to the man who owns this house, and he gave them
+their price for me.'
+
+"The man who had seduced her then said, 'Would you like to come along
+with us to see the house of your parents and your parents themselves?
+They are both alive and are said to be well off.'
+
+"'I will do so gladly,' answered she, 'if you men will first swear me a
+solemn oath that you will do me no harm by the way.'
+
+"They all swore as she told them, and when they had completed their oath
+the woman said, 'Hush; and if any of your men meets me in the street or
+at the well, do not let him speak to me, for fear some one should go and
+tell my master, in which case he would suspect something. He would put
+me in prison, and would have all of you murdered; keep your own counsel
+therefore; buy your merchandise as fast as you can, and send me word
+when you have done loading. I will bring as much gold as I can lay my
+hands on, and there is something else also that I can do towards paying
+my fare. I am nurse to the son of the good man of the house, a funny
+little fellow just able to run about. I will carry him off in your ship,
+and you will get a great deal of money for him if you take him and sell
+him in foreign parts.'
+
+"On this she went back to the house. The Phoenicians stayed a whole
+year till they had loaded their ship with much precious merchandise,
+and then, when they had got freight enough, they sent to tell the
+woman. Their messenger, a very cunning fellow, came to my father's house
+bringing a necklace of gold with amber beads strung among it; and
+while my mother and the servants had it in their hands admiring it and
+bargaining about it, he made a sign quietly to the woman and then went
+back to the ship, whereon she took me by the hand and led me out of the
+house. In the fore part of the house she saw the tables set with
+the cups of guests who had been feasting with my father, as being in
+attendance on him; these were now all gone to a meeting of the public
+assembly, so she snatched up three cups and carried them off in the
+bosom of her dress, while I followed her, for I knew no better. The sun
+was now set, and darkness was over all the land, so we hurried on as
+fast as we could till we reached the harbour, where the Phoenician ship
+was lying. When they had got on board they sailed their ways over the
+sea, taking us with them, and Jove sent then a fair wind; six days did
+we sail both night and day, but on the seventh day Diana struck the
+woman and she fell heavily down into the ship's hold as though she were
+a sea gull alighting on the water; so they threw her overboard to the
+seals and fishes, and I was left all sorrowful and alone. Presently the
+winds and waves took the ship to Ithaca, where Laertes gave sundry of
+his chattels for me, and thus it was that ever I came to set eyes upon
+this country."
+
+Ulysses answered, "Eumaeus, I have heard the story of your misfortunes
+with the most lively interest and pity, but Jove has given you good as
+well as evil, for in spite of everything you have a good master, who
+sees that you always have enough to eat and drink; and you lead a good
+life, whereas I am still going about begging my way from city to city."
+
+Thus did they converse, and they had only a very little time left for
+sleep, for it was soon daybreak. In the mean time Telemachus and his
+crew were nearing land, so they loosed the sails, took down the mast,
+and rowed the ship into the harbour. {136} They cast out their mooring
+stones and made fast the hawsers; they then got out upon the sea shore,
+mixed their wine, and got dinner ready. As soon as they had had enough
+to eat and drink Telemachus said, "Take the ship on to the town, but
+leave me here, for I want to look after the herdsmen on one of my farms.
+In the evening, when I have seen all I want, I will come down to the
+city, and to-morrow morning in return for your trouble I will give you
+all a good dinner with meat and wine." {137}
+
+Then Theoclymenus said, "And what, my dear young friend, is to become of
+me? To whose house, among all your chief men, am I to repair? or shall I
+go straight to your own house and to your mother?"
+
+"At any other time," replied Telemachus, "I should have bidden you go to
+my own house, for you would find no want of hospitality; at the present
+moment, however, you would not be comfortable there, for I shall be
+away, and my mother will not see you; she does not often show herself
+even to the suitors, but sits at her loom weaving in an upper chamber,
+out of their way; but I can tell you a man whose house you can go
+to--I mean Eurymachus the son of Polybus, who is held in the highest
+estimation by every one in Ithaca. He is much the best man and the most
+persistent wooer, of all those who are paying court to my mother and
+trying to take Ulysses' place. Jove, however, in heaven alone knows
+whether or no they will come to a bad end before the marriage takes
+place."
+
+As he was speaking a bird flew by upon his right hand--a hawk, Apollo's
+messenger. It held a dove in its talons, and the feathers, as it tore
+them off, {138} fell to the ground midway between Telemachus and the
+ship. On this Theoclymenus called him apart and caught him by the hand.
+"Telemachus," said he, "that bird did not fly on your right hand without
+having been sent there by some god. As soon as I saw it I knew it was an
+omen; it means that you will remain powerful and that there will be no
+house in Ithaca more royal than your own."
+
+"I wish it may prove so," answered Telemachus. "If it does, I will show
+you so much good will and give you so many presents that all who meet
+you will congratulate you."
+
+Then he said to his friend Piraeus, "Piraeus, son of Clytius, you have
+throughout shown yourself the most willing to serve me of all those who
+have accompanied me to Pylos; I wish you would take this stranger to
+your own house and entertain him hospitably till I can come for him."
+
+And Piraeus answered, "Telemachus, you may stay away as long as you
+please, but I will look after him for you, and he shall find no lack of
+hospitality."
+
+As he spoke he went on board, and bade the others do so also and loose
+the hawsers, so they took their places in the ship. But Telemachus
+bound on his sandals, and took a long and doughty spear with a head
+of sharpened bronze from the deck of the ship. Then they loosed the
+hawsers, thrust the ship off from land, and made on towards the city
+as they had been told to do, while Telemachus strode on as fast as he
+could, till he reached the homestead where his countless herds of
+swine were feeding, and where dwelt the excellent swineherd, who was so
+devoted a servant to his master.
+
+
+Book XVI
+
+ULYSSES REVEALS HIMSELF TO TELEMACHUS.
+
+Meanwhile Ulysses and the swineherd had lit a fire in the hut and were
+were getting breakfast ready at daybreak, for they had sent the men out
+with the pigs. When Telemachus came up, the dogs did not bark but fawned
+upon him, so Ulysses, hearing the sound of feet and noticing that the
+dogs did not bark, said to Eumaeus:
+
+"Eumaeus, I hear footsteps; I suppose one of your men or some one of
+your acquaintance is coming here, for the dogs are fawning upon him and
+not barking."
+
+The words were hardly out of his mouth before his son stood at the door.
+Eumaeus sprang to his feet, and the bowls in which he was mixing wine
+fell from his hands, as he made towards his master. He kissed his head
+and both his beautiful eyes, and wept for joy. A father could not be
+more delighted at the return of an only son, the child of his old age,
+after ten years' absence in a foreign country and after having gone
+through much hardship. He embraced him, kissed him all over as though he
+had come back from the dead, and spoke fondly to him saying:
+
+"So you are come, Telemachus, light of my eyes that you are. When I
+heard you had gone to Pylos I made sure I was never going to see you any
+more. Come in, my dear child, and sit down, that I may have a good look
+at you now you are home again; it is not very often you come into
+the country to see us herdsmen; you stick pretty close to the town
+generally. I suppose you think it better to keep an eye on what the
+suitors are doing."
+
+"So be it, old friend," answered Telemachus, "but I am come now because
+I want to see you, and to learn whether my mother is still at her
+old home or whether some one else has married her, so that the bed of
+Ulysses is without bedding and covered with cobwebs."
+
+"She is still at the house," replied Eumaeus, "grieving and breaking her
+heart, and doing nothing but weep, both night and day continually."
+
+As he spoke he took Telemachus' spear, whereon he crossed the stone
+threshold and came inside. Ulysses rose from his seat to give him place
+as he entered, but Telemachus checked him; "Sit down, stranger," said
+he, "I can easily find another seat, and there is one here who will lay
+it for me."
+
+Ulysses went back to his own place, and Eumaeus strewed some green
+brushwood on the floor and threw a sheepskin on top of it for Telemachus
+to sit upon. Then the swineherd brought them platters of cold meat, the
+remains from what they had eaten the day before, and he filled the bread
+baskets with bread as fast as he could. He mixed wine also in bowls of
+ivy-wood, and took his seat facing Ulysses. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Telemachus said to Eumaeus, "Old friend, where
+does this stranger come from? How did his crew bring him to Ithaca, and
+who were they?--for assuredly he did not come here by land."
+
+To this you answered, O swineherd Eumaeus, "My son, I will tell you
+the real truth. He says he is a Cretan, and that he has been a great
+traveller. At this moment he is running away from a Thesprotian ship,
+and has taken refuge at my station, so I will put him into your hands.
+Do whatever you like with him, only remember that he is your suppliant."
+
+"I am very much distressed," said Telemachus, "by what you have just
+told me. How can I take this stranger into my house? I am as yet young,
+and am not strong enough to hold my own if any man attacks me. My mother
+cannot make up her mind whether to stay where she is and look after the
+house out of respect for public opinion and the memory of her husband,
+or whether the time is now come for her to take the best man of those
+who are wooing her, and the one who will make her the most advantageous
+offer; still, as the stranger has come to your station I will find him
+a cloak and shirt of good wear, with a sword and sandals, and will send
+him wherever he wants to go. Or if you like you can keep him here at the
+station, and I will send him clothes and food that he may be no burden
+on you and on your men; but I will not have him go near the suitors,
+for they are very insolent, and are sure to ill treat him in a way that
+would greatly grieve me; no matter how valiant a man may be he can do
+nothing against numbers, for they will be too strong for him."
+
+Then Ulysses said, "Sir, it is right that I should say something myself.
+I am much shocked about what you have said about the insolent way in
+which the suitors are behaving in despite of such a man as you are. Tell
+me, do you submit to such treatment tamely, or has some god set your
+people against you? May you not complain of your brothers--for it is to
+these that a man may look for support, however great his quarrel may be?
+I wish I were as young as you are and in my present mind; if I were son
+to Ulysses, or, indeed, Ulysses himself, I would rather some one came
+and cut my head off, but I would go to the house and be the bane of
+every one of these men. {139} If they were too many for me--I being
+single-handed--I would rather die fighting in my own house than see such
+disgraceful sights day after day, strangers grossly maltreated, and men
+dragging the women servants about the house in an unseemly way, wine
+drawn recklessly, and bread wasted all to no purpose for an end that
+shall never be accomplished."
+
+And Telemachus answered, "I will tell you truly everything. There is no
+enmity between me and my people, nor can I complain of brothers, to whom
+a man may look for support however great his quarrel may be. Jove has
+made us a race of only sons. Laertes was the only son of Arceisius, and
+Ulysses only son of Laertes. I am myself the only son of Ulysses who
+left me behind him when he went away, so that I have never been of any
+use to him. Hence it comes that my house is in the hands of numberless
+marauders; for the chiefs from all the neighbouring islands, Dulichium,
+Same, Zacynthus, as also all the principal men of Ithaca itself, are
+eating up my house under the pretext of paying court to my mother, who
+will neither say point blank that she will not marry, nor yet bring
+matters to an end, so they are making havoc of my estate, and before
+long will do so with myself into the bargain. The issue, however,
+rests with heaven. But do you, old friend Eumaeus, go at once and tell
+Penelope that I am safe and have returned from Pylos. Tell it to herself
+alone, and then come back here without letting any one else know, for
+there are many who are plotting mischief against me."
+
+"I understand and heed you," replied Eumaeus; "you need instruct me no
+further, only as I am going that way say whether I had not better let
+poor Laertes know that you are returned. He used to superintend the work
+on his farm in spite of his bitter sorrow about Ulysses, and he would
+eat and drink at will along with his servants; but they tell me that
+from the day on which you set out for Pylos he has neither eaten nor
+drunk as he ought to do, nor does he look after his farm, but sits
+weeping and wasting the flesh from off his bones."
+
+"More's the pity," answered Telemachus, "I am sorry for him, but we must
+leave him to himself just now. If people could have everything their own
+way, the first thing I should choose would be the return of my father;
+but go, and give your message; then make haste back again, and do not
+turn out of your way to tell Laertes. Tell my mother to send one of her
+women secretly with the news at once, and let him hear it from her."
+
+Thus did he urge the swineherd; Eumaeus, therefore, took his sandals,
+bound them to his feet, and started for the town. Minerva watched
+him well off the station, and then came up to it in the form of a
+woman--fair, stately, and wise. She stood against the side of the entry,
+and revealed herself to Ulysses, but Telemachus could not see her, and
+knew not that she was there, for the gods do not let themselves be seen
+by everybody. Ulysses saw her, and so did the dogs, for they did not
+bark, but went scared and whining off to the other side of the yards.
+She nodded her head and motioned to Ulysses with her eyebrows; whereon
+he left the hut and stood before her outside the main wall of the yards.
+Then she said to him:
+
+"Ulysses, noble son of Laertes, it is now time for you to tell your
+son: do not keep him in the dark any longer, but lay your plans for the
+destruction of the suitors, and then make for the town. I will not be
+long in joining you, for I too am eager for the fray."
+
+As she spoke she touched him with her golden wand. First she threw
+a fair clean shirt and cloak about his shoulders; then she made him
+younger and of more imposing presence; she gave him back his colour,
+filled out his cheeks, and let his beard become dark again. Then she
+went away and Ulysses came back inside the hut. His son was astounded
+when he saw him, and turned his eyes away for fear he might be looking
+upon a god.
+
+"Stranger," said he, "how suddenly you have changed from what you were
+a moment or two ago. You are dressed differently and your colour is not
+the same. Are you some one or other of the gods that live in heaven? If
+so, be propitious to me till I can make you due sacrifice and offerings
+of wrought gold. Have mercy upon me."
+
+And Ulysses said, "I am no god, why should you take me for one? I am
+your father, on whose account you grieve and suffer so much at the hands
+of lawless men."
+
+As he spoke he kissed his son, and a tear fell from his cheek on to the
+ground, for he had restrained all tears till now. But Telemachus could
+not yet believe that it was his father, and said:
+
+"You are not my father, but some god is flattering me with vain hopes
+that I may grieve the more hereafter; no mortal man could of himself
+contrive to do as you have been doing, and make yourself old and young
+at a moment's notice, unless a god were with him. A second ago you
+were old and all in rags, and now you are like some god come down from
+heaven."
+
+Ulysses answered, "Telemachus, you ought not to be so immeasurably
+astonished at my being really here. There is no other Ulysses who will
+come hereafter. Such as I am, it is I, who after long wandering and much
+hardship have got home in the twentieth year to my own country. What you
+wonder at is the work of the redoubtable goddess Minerva, who does with
+me whatever she will, for she can do what she pleases. At one moment she
+makes me like a beggar, and the next I am a young man with good clothes
+on my back; it is an easy matter for the gods who live in heaven to make
+any man look either rich or poor."
+
+As he spoke he sat down, and Telemachus threw his arms about his father
+and wept. They were both so much moved that they cried aloud like eagles
+or vultures with crooked talons that have been robbed of their half
+fledged young by peasants. Thus piteously did they weep, and the sun
+would have gone down upon their mourning if Telemachus had not suddenly
+said, "In what ship, my dear father, did your crew bring you to Ithaca?
+Of what nation did they declare themselves to be--for you cannot have
+come by land?"
+
+"I will tell you the truth, my son," replied Ulysses. "It was the
+Phaeacians who brought me here. They are great sailors, and are in the
+habit of giving escorts to any one who reaches their coasts. They took
+me over the sea while I was fast asleep, and landed me in Ithaca, after
+giving me many presents in bronze, gold, and raiment. These things by
+heaven's mercy are lying concealed in a cave, and I am now come here on
+the suggestion of Minerva that we may consult about killing our enemies.
+First, therefore, give me a list of the suitors, with their number, that
+I may learn who, and how many, they are. I can then turn the matter
+over in my mind, and see whether we two can fight the whole body of them
+ourselves, or whether we must find others to help us."
+
+To this Telemachus answered, "Father, I have always heard of your renown
+both in the field and in council, but the task you talk of is a very
+great one: I am awed at the mere thought of it; two men cannot stand
+against many and brave ones. There are not ten suitors only, nor twice
+ten, but ten many times over; you shall learn their number at once.
+There are fifty-two chosen youths from Dulichium, and they have six
+servants; from Same there are twenty-four; twenty young Achaeans from
+Zacynthus, and twelve from Ithaca itself, all of them well born. They
+have with them a servant Medon, a bard, and two men who can carve at
+table. If we face such numbers as this, you may have bitter cause to rue
+your coming, and your revenge. See whether you cannot think of some one
+who would be willing to come and help us."
+
+"Listen to me," replied Ulysses, "and think whether Minerva and her
+father Jove may seem sufficient, or whether I am to try and find some
+one else as well."
+
+"Those whom you have named," answered Telemachus, "are a couple of good
+allies, for though they dwell high up among the clouds they have power
+over both gods and men."
+
+"These two," continued Ulysses, "will not keep long out of the fray,
+when the suitors and we join fight in my house. Now, therefore, return
+home early to-morrow morning, and go about among the suitors as
+before. Later on the swineherd will bring me to the city disguised as a
+miserable old beggar. If you see them ill treating me, steel your heart
+against my sufferings; even though they drag me feet foremost out of
+the house, or throw things at me, look on and do nothing beyond gently
+trying to make them behave more reasonably; but they will not listen to
+you, for the day of their reckoning is at hand. Furthermore I say, and
+lay my saying to your heart; when Minerva shall put it in my mind, I
+will nod my head to you, and on seeing me do this you must collect all
+the armour that is in the house and hide it in the strong store room.
+Make some excuse when the suitors ask you why you are removing it; say
+that you have taken it to be out of the way of the smoke, inasmuch as it
+is no longer what it was when Ulysses went away, but has become soiled
+and begrimed with soot. Add to this more particularly that you are
+afraid Jove may set them on to quarrel over their wine, and that they
+may do each other some harm which may disgrace both banquet and wooing,
+for the sight of arms sometimes tempts people to use them. But leave
+a sword and a spear apiece for yourself and me, and a couple of oxhide
+shields so that we can snatch them up at any moment; Jove and Minerva
+will then soon quiet these people. There is also another matter; if you
+are indeed my son and my blood runs in your veins, let no one know that
+Ulysses is within the house--neither Laertes, nor yet the swineherd, nor
+any of the servants, nor even Penelope herself. Let you and me exploit
+the women alone, and let us also make trial of some other of the men
+servants, to see who is on our side and whose hand is against us."
+
+"Father," replied Telemachus, "you will come to know me by and by, and
+when you do you will find that I can keep your counsel. I do not think,
+however, the plan you propose will turn out well for either of us. Think
+it over. It will take us a long time to go the round of the farms and
+exploit the men, and all the time the suitors will be wasting your
+estate with impunity and without compunction. Prove the women by all
+means, to see who are disloyal and who guiltless, but I am not in favour
+of going round and trying the men. We can attend to that later on, if
+you really have some sign from Jove that he will support you."
+
+Thus did they converse, and meanwhile the ship which had brought
+Telemachus and his crew from Pylos had reached the town of Ithaca. When
+they had come inside the harbour they drew the ship on to the land;
+their servants came and took their armour from them, and they left all
+the presents at the house of Clytius. Then they sent a servant to tell
+Penelope that Telemachus had gone into the country, but had sent the
+ship to the town to prevent her from being alarmed and made unhappy.
+This servant and Eumaeus happened to meet when they were both on the
+same errand of going to tell Penelope. When they reached the House, the
+servant stood up and said to the queen in the presence of the waiting
+women, "Your son, Madam, is now returned from Pylos"; but Eumaeus went
+close up to Penelope, and said privately all that her son had bidden
+him tell her. When he had given his message he left the house with its
+outbuildings and went back to his pigs again.
+
+The suitors were surprised and angry at what had happened, so they
+went outside the great wall that ran round the outer court, and held
+a council near the main entrance. Eurymachus, son of Polybus, was the
+first to speak.
+
+"My friends," said he, "this voyage of Telemachus's is a very serious
+matter; we had made sure that it would come to nothing. Now, however,
+let us draw a ship into the water, and get a crew together to send after
+the others and tell them to come back as fast as they can."
+
+He had hardly done speaking when Amphinomus turned in his place and
+saw the ship inside the harbour, with the crew lowering her sails, and
+putting by their oars; so he laughed, and said to the others, "We need
+not send them any message, for they are here. Some god must have told
+them, or else they saw the ship go by, and could not overtake her."
+
+On this they rose and went to the water side. The crew then drew the
+ship on shore; their servants took their armour from them, and they went
+up in a body to the place of assembly, but they would not let any one
+old or young sit along with them, and Antinous, son of Eupeithes, spoke
+first.
+
+"Good heavens," said he, "see how the gods have saved this man from
+destruction. We kept a succession of scouts upon the headlands all day
+long, and when the sun was down we never went on shore to sleep, but
+waited in the ship all night till morning in the hope of capturing and
+killing him; but some god has conveyed him home in spite of us. Let
+us consider how we can make an end of him. He must not escape us; our
+affair is never likely to come off while he is alive, for he is very
+shrewd, and public feeling is by no means all on our side. We must make
+haste before he can call the Achaeans in assembly; he will lose no time
+in doing so, for he will be furious with us, and will tell all the world
+how we plotted to kill him, but failed to take him. The people will not
+like this when they come to know of it; we must see that they do us no
+hurt, nor drive us from our own country into exile. Let us try and
+lay hold of him either on his farm away from the town, or on the road
+hither. Then we can divide up his property amongst us, and let his
+mother and the man who marries her have the house. If this does not
+please you, and you wish Telemachus to live on and hold his father's
+property, then we must not gather here and eat up his goods in this way,
+but must make our offers to Penelope each from his own house, and she
+can marry the man who will give the most for her, and whose lot it is to
+win her."
+
+They all held their peace until Amphinomus rose to speak. He was the son
+of Nisus, who was son to king Aretias, and he was foremost among all the
+suitors from the wheat-growing and well grassed island of Dulichium; his
+conversation, moreover, was more agreeable to Penelope than that of any
+of the other suitors, for he was a man of good natural disposition. "My
+friends," said he, speaking to them plainly and in all honestly, "I am
+not in favour of killing Telemachus. It is a heinous thing to kill one
+who is of noble blood. Let us first take counsel of the gods, and if the
+oracles of Jove advise it, I will both help to kill him myself, and will
+urge everyone else to do so; but if they dissuade us, I would have you
+hold your hands."
+
+Thus did he speak, and his words pleased them well, so they rose
+forthwith and went to the house of Ulysses, where they took their
+accustomed seats.
+
+Then Penelope resolved that she would show herself to the suitors. She
+knew of the plot against Telemachus, for the servant Medon had overheard
+their counsels and had told her; she went down therefore to the court
+attended by her maidens, and when she reached the suitors she stood by
+one of the bearing-posts supporting the roof of the cloister holding a
+veil before her face, and rebuked Antinous saying:
+
+"Antinous, insolent and wicked schemer, they say you are the best
+speaker and counsellor of any man your own age in Ithaca, but you are
+nothing of the kind. Madman, why should you try to compass the death
+of Telemachus, and take no heed of suppliants, whose witness is Jove
+himself? It is not right for you to plot thus against one another.
+Do you not remember how your father fled to this house in fear of the
+people, who were enraged against him for having gone with some Taphian
+pirates and plundered the Thesprotians who were at peace with us? They
+wanted to tear him in pieces and eat up everything he had, but Ulysses
+stayed their hands although they were infuriated, and now you devour his
+property without paying for it, and break my heart by wooing his wife
+and trying to kill his son. Leave off doing so, and stop the others
+also."
+
+To this Eurymachus son of Polybus answered, "Take heart, Queen Penelope
+daughter of Icarius, and do not trouble yourself about these matters.
+The man is not yet born, nor never will be, who shall lay hands upon
+your son Telemachus, while I yet live to look upon the face of the
+earth. I say--and it shall surely be--that my spear shall be reddened
+with his blood; for many a time has Ulysses taken me on his knees,
+held wine up to my lips to drink, and put pieces of meat into my hands.
+Therefore Telemachus is much the dearest friend I have, and has nothing
+to fear from the hands of us suitors. Of course, if death comes to him
+from the gods, he cannot escape it." He said this to quiet her, but in
+reality he was plotting against Telemachus.
+
+Then Penelope went upstairs again and mourned her husband till Minerva
+shed sleep over her eyes. In the evening Eumaeus got back to Ulysses
+and his son, who had just sacrificed a young pig of a year old and were
+helping one another to get supper ready; Minerva therefore came up to
+Ulysses, turned him into an old man with a stroke of her wand, and
+clad him in his old clothes again, for fear that the swineherd might
+recognise him and not keep the secret, but go and tell Penelope.
+
+Telemachus was the first to speak. "So you have got back, Eumaeus," said
+he. "What is the news of the town? Have the suitors returned, or are
+they still waiting over yonder, to take me on my way home?"
+
+"I did not think of asking about that," replied Eumaeus, "when I was in
+the town. I thought I would give my message and come back as soon as I
+could. I met a man sent by those who had gone with you to Pylos, and he
+was the first to tell the news to your mother, but I can say what I saw
+with my own eyes; I had just got on to the crest of the hill of Mercury
+above the town when I saw a ship coming into harbour with a number of
+men in her. They had many shields and spears, and I thought it was the
+suitors, but I cannot be sure."
+
+On hearing this Telemachus smiled to his father, but so that Eumaeus
+could not see him.
+
+Then, when they had finished their work and the meal was ready, they ate
+it, and every man had his full share so that all were satisfied. As
+soon as they had had enough to eat and drink, they laid down to rest and
+enjoyed the boon of sleep.
+
+
+Book XVII
+
+TELEMACHUS AND HIS MOTHER MEET--ULYSSES AND EUMAEUS COME DOWN TO THE
+TOWN, AND ULYSSES IS INSULTED BY MELANTHIUS--HE IS RECOGNISED BY THE
+DOG ARGOS--HE IS INSULTED AND PRESENTLY STRUCK BY ANTINOUS WITH A
+STOOL--PENELOPE DESIRES THAT HE SHALL BE SENT TO HER.
+
+When the child of morning, rosy-fingered Dawn, appeared, Telemachus
+bound on his sandals and took a strong spear that suited his hands, for
+he wanted to go into the city. "Old friend," said he to the swineherd,
+"I will now go to the town and show myself to my mother, for she will
+never leave off grieving till she has seen me. As for this unfortunate
+stranger, take him to the town and let him beg there of any one who will
+give him a drink and a piece of bread. I have trouble enough of my own,
+and cannot be burdened with other people. If this makes him angry so
+much the worse for him, but I like to say what I mean."
+
+Then Ulysses said, "Sir, I do not want to stay here; a beggar can always
+do better in town than country, for any one who likes can give him
+something. I am too old to care about remaining here at the beck and
+call of a master. Therefore let this man do as you have just told him,
+and take me to the town as soon as I have had a warm by the fire, and
+the day has got a little heat in it. My clothes are wretchedly thin, and
+this frosty morning I shall be perished with cold, for you say the city
+is some way off."
+
+On this Telemachus strode off through the yards, brooding his revenge
+upon the suitors. When he reached home he stood his spear against a
+bearing-post of the cloister, crossed the stone floor of the cloister
+itself, and went inside.
+
+Nurse Euryclea saw him long before any one else did. She was putting the
+fleeces on to the seats, and she burst out crying as she ran up to him;
+all the other maids came up too, and covered his head and shoulders with
+their kisses. Penelope came out of her room looking like Diana or Venus,
+and wept as she flung her arms about her son. She kissed his forehead
+and both his beautiful eyes, "Light of my eyes," she cried as she spoke
+fondly to him, "so you are come home again; I made sure I was never
+going to see you any more. To think of your having gone off to Pylos
+without saying anything about it or obtaining my consent. But come, tell
+me what you saw."
+
+"Do not scold me, mother," answered Telemachus, "nor vex me, seeing what
+a narrow escape I have had, but wash your face, change your dress, go
+upstairs with your maids, and promise full and sufficient hecatombs to
+all the gods if Jove will only grant us our revenge upon the suitors. I
+must now go to the place of assembly to invite a stranger who has come
+back with me from Pylos. I sent him on with my crew, and told Piraeus to
+take him home and look after him till I could come for him myself."
+
+She heeded her son's words, washed her face, changed her dress, and
+vowed full and sufficient hecatombs to all the gods if they would only
+vouchsafe her revenge upon the suitors.
+
+Telemachus went through, and out of, the cloisters spear in hand--not
+alone, for his two fleet dogs went with him. Minerva endowed him with a
+presence of such divine comeliness that all marvelled at him as he went
+by, and the suitors gathered round him with fair words in their mouths
+and malice in their hearts; but he avoided them, and went to sit with
+Mentor, Antiphus, and Halitherses, old friends of his father's house,
+and they made him tell them all that had happened to him. Then Piraeus
+came up with Theoclymenus, whom he had escorted through the town to the
+place of assembly, whereon Telemachus at once joined them. Piraeus was
+first to speak: "Telemachus," said he, "I wish you would send some of
+your women to my house to take away the presents Menelaus gave you."
+
+"We do not know, Piraeus," answered Telemachus, "what may happen. If
+the suitors kill me in my own house and divide my property among them,
+I would rather you had the presents than that any of those people should
+get hold of them. If on the other hand I managed to kill them, I shall
+be much obliged if you will kindly bring me my presents."
+
+With these words he took Theoclymenus to his own house. When they got
+there they laid their cloaks on the benches and seats, went into the
+baths, and washed themselves. When the maids had washed and anointed
+them, and had given them cloaks and shirts, they took their seats at
+table. A maid servant then brought them water in a beautiful golden
+ewer, and poured it into a silver basin for them to wash their hands;
+and she drew a clean table beside them. An upper servant brought them
+bread and offered them many good things of what there was in the
+house. Opposite them sat Penelope, reclining on a couch by one of the
+bearing-posts of the cloister, and spinning. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Penelope said:
+
+"Telemachus, I shall go upstairs and lie down on that sad couch, which I
+have not ceased to water with my tears, from the day Ulysses set out for
+Troy with the sons of Atreus. You failed, however, to make it clear to
+me before the suitors came back to the house, whether or no you had been
+able to hear anything about the return of your father."
+
+"I will tell you then truth," replied her son. "We went to Pylos and saw
+Nestor, who took me to his house and treated me as hospitably as though
+I were a son of his own who had just returned after a long absence; so
+also did his sons; but he said he had not heard a word from any
+human being about Ulysses, whether he was alive or dead. He sent me,
+therefore, with a chariot and horses to Menelaus. There I saw Helen, for
+whose sake so many, both Argives and Trojans, were in heaven's wisdom
+doomed to suffer. Menelaus asked me what it was that had brought me to
+Lacedaemon, and I told him the whole truth, whereon he said, 'So, then,
+these cowards would usurp a brave man's bed? A hind might as well lay
+her new-born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell. The lion, when he comes back to his lair,
+will make short work with the pair of them, and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Greeks cheered him--if he is still
+such, and were to come near these suitors, they would have a short
+shrift and a sorry wedding. As regards your question, however, I will
+not prevaricate nor deceive you, but what the old man of the sea told
+me, so much will I tell you in full. He said he could see Ulysses on
+an island sorrowing bitterly in the house of the nymph Calypso, who was
+keeping him prisoner, and he could not reach his home, for he had no
+ships nor sailors to take him over the sea.' This was what Menelaus told
+me, and when I had heard his story I came away; the gods then gave me a
+fair wind and soon brought me safe home again."
+
+With these words he moved the heart of Penelope. Then Theoclymenus said
+to her:
+
+"Madam, wife of Ulysses, Telemachus does not understand these things;
+listen therefore to me, for I can divine them surely, and will hide
+nothing from you. May Jove the king of heaven be my witness, and the
+rites of hospitality, with that hearth of Ulysses to which I now come,
+that Ulysses himself is even now in Ithaca, and, either going about the
+country or staying in one place, is enquiring into all these evil deeds
+and preparing a day of reckoning for the suitors. I saw an omen when I
+was on the ship which meant this, and I told Telemachus about it."
+
+"May it be even so," answered Penelope; "if your words come true, you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you."
+
+Thus did they converse. Meanwhile the suitors were throwing discs, or
+aiming with spears at a mark on the levelled ground in front of the
+house, and behaving with all their old insolence. But when it was now
+time for dinner, and the flock of sheep and goats had come into the town
+from all the country round, {140} with their shepherds as usual, then
+Medon, who was their favourite servant, and who waited upon them at
+table, said, "Now then, my young masters, you have had enough sport, so
+come inside that we may get dinner ready. Dinner is not a bad thing, at
+dinner time."
+
+They left their sports as he told them, and when they were within the
+house, they laid their cloaks on the benches and seats inside, and then
+sacrificed some sheep, goats, pigs, and a heifer, all of them fat and
+well grown. {141} Thus they made ready for their meal. In the meantime
+Ulysses and the swineherd were about starting for the town, and the
+swineherd said, "Stranger, I suppose you still want to go to town
+to-day, as my master said you were to do; for my own part I should have
+liked you to stay here as a station hand, but I must do as my master
+tells me, or he will scold me later on, and a scolding from one's master
+is a very serious thing. Let us then be off, for it is now broad day; it
+will be night again directly and then you will find it colder." {142}
+
+"I know, and understand you," replied Ulysses; "you need say no more.
+Let us be going, but if you have a stick ready cut, let me have it to
+walk with, for you say the road is a very rough one."
+
+As he spoke he threw his shabby old tattered wallet over his shoulders,
+by the cord from which it hung, and Eumaeus gave him a stick to his
+liking. The two then started, leaving the station in charge of the dogs
+and herdsmen who remained behind; the swineherd led the way and his
+master followed after, looking like some broken down old tramp as he
+leaned upon his staff, and his clothes were all in rags. When they had
+got over the rough steep ground and were nearing the city, they reached
+the fountain from which the citizens drew their water. This had
+been made by Ithacus, Neritus, and Polyctor. There was a grove of
+water-loving poplars planted in a circle all round it, and the clear
+cold water came down to it from a rock high up, {143} while above the
+fountain there was an altar to the nymphs, at which all wayfarers used
+to sacrifice. Here Melanthius son of Dolius overtook them as he was
+driving down some goats, the best in his flock, for the suitors' dinner,
+and there were two shepherds with him. When he saw Eumaeus and Ulysses
+he reviled them with outrageous and unseemly language, which made
+Ulysses very angry.
+
+"There you go," cried he, "and a precious pair you are. See how heaven
+brings birds of the same feather to one another. Where, pray, master
+swineherd, are you taking this poor miserable object? It would make any
+one sick to see such a creature at table. A fellow like this never won a
+prize for anything in his life, but will go about rubbing his shoulders
+against every man's door post, and begging, not for swords and cauldrons
+{144} like a man, but only for a few scraps not worth begging for. If
+you would give him to me for a hand on my station, he might do to clean
+out the folds, or bring a bit of sweet feed to the kids, and he could
+fatten his thighs as much as he pleased on whey; but he has taken to bad
+ways and will not go about any kind of work; he will do nothing but
+beg victuals all the town over, to feed his insatiable belly. I say,
+therefore--and it shall surely be--if he goes near Ulysses' house he
+will get his head broken by the stools they will fling at him, till they
+turn him out."
+
+On this, as he passed, he gave Ulysses a kick on the hip out of pure
+wantonness, but Ulysses stood firm, and did not budge from the path. For
+a moment he doubted whether or no to fly at Melanthius and kill him
+with his staff, or fling him to the ground and beat his brains out;
+he resolved, however, to endure it and keep himself in check, but the
+swineherd looked straight at Melanthius and rebuked him, lifting up his
+hands and praying to heaven as he did so.
+
+"Fountain nymphs," he cried, "children of Jove, if ever Ulysses burned
+you thigh bones covered with fat whether of lambs or kids, grant my
+prayer that heaven may send him home. He would soon put an end to
+the swaggering threats with which such men as you go about insulting
+people--gadding all over the town while your flocks are going to ruin
+through bad shepherding."
+
+Then Melanthius the goatherd answered, "You ill conditioned cur, what
+are you talking about? Some day or other I will put you on board ship
+and take you to a foreign country, where I can sell you and pocket the
+money you will fetch. I wish I were as sure that Apollo would strike
+Telemachus dead this very day, or that the suitors would kill him, as I
+am that Ulysses will never come home again."
+
+With this he left them to come on at their leisure, while he went
+quickly forward and soon reached the house of his master. When he
+got there he went in and took his seat among the suitors opposite
+Eurymachus, who liked him better than any of the others. The servants
+brought him a portion of meat, and an upper woman servant set bread
+before him that he might eat. Presently Ulysses and the swineherd came
+up to the house and stood by it, amid a sound of music, for Phemius was
+just beginning to sing to the suitors. Then Ulysses took hold of the
+swineherd's hand, and said:
+
+"Eumaeus, this house of Ulysses is a very fine place. No matter how far
+you go, you will find few like it. One building keeps following on after
+another. The outer court has a wall with battlements all round it; the
+doors are double folding, and of good workmanship; it would be a hard
+matter to take it by force of arms. I perceive, too, that there are many
+people banqueting within it, for there is a smell of roast meat, and
+I hear a sound of music, which the gods have made to go along with
+feasting."
+
+Then Eumaeus said, "You have perceived aright, as indeed you generally
+do; but let us think what will be our best course. Will you go inside
+first and join the suitors, leaving me here behind you, or will you wait
+here and let me go in first? But do not wait long, or some one may see
+you loitering about outside, and throw something at you. Consider this
+matter I pray you."
+
+And Ulysses answered, "I understand and heed. Go in first and leave
+me here where I am. I am quite used to being beaten and having things
+thrown at me. I have been so much buffeted about in war and by sea that
+I am case-hardened, and this too may go with the rest. But a man cannot
+hide away the cravings of a hungry belly; this is an enemy which gives
+much trouble to all men; it is because of this that ships are fitted out
+to sail the seas, and to make war upon other people."
+
+As they were thus talking, a dog that had been lying asleep raised his
+head and pricked up his ears. This was Argos, whom Ulysses had bred
+before setting out for Troy, but he had never had any work out of him.
+In the old days he used to be taken out by the young men when they went
+hunting wild goats, or deer, or hares, but now that his master was gone
+he was lying neglected on the heaps of mule and cow dung that lay in
+front of the stable doors till the men should come and draw it away
+to manure the great close; and he was full of fleas. As soon as he saw
+Ulysses standing there, he dropped his ears and wagged his tail, but he
+could not get close up to his master. When Ulysses saw the dog on the
+other side of the yard, he dashed a tear from his eyes without Eumaeus
+seeing it, and said:
+
+"Eumaeus, what a noble hound that is over yonder on the manure heap: his
+build is splendid; is he as fine a fellow as he looks, or is he only one
+of those dogs that come begging about a table, and are kept merely for
+show?"
+
+"This hound," answered Eumaeus, "belonged to him who has died in a far
+country. If he were what he was when Ulysses left for Troy, he would
+soon show you what he could do. There was not a wild beast in the forest
+that could get away from him when he was once on its tracks. But now he
+has fallen on evil times, for his master is dead and gone, and the women
+take no care of him. Servants never do their work when their master's
+hand is no longer over them, for Jove takes half the goodness out of a
+man when he makes a slave of him."
+
+As he spoke he went inside the buildings to the cloister where the
+suitors were, but Argos died as soon as he had recognised his master.
+
+Telemachus saw Eumaeus long before any one else did, and beckoned him
+to come and sit beside him; so he looked about and saw a seat lying
+near where the carver sat serving out their portions to the suitors; he
+picked it up, brought it to Telemachus's table, and sat down opposite
+him. Then the servant brought him his portion, and gave him bread from
+the bread-basket.
+
+Immediately afterwards Ulysses came inside, looking like a poor
+miserable old beggar, leaning on his staff and with his clothes all in
+rags. He sat down upon the threshold of ash-wood just inside the doors
+leading from the outer to the inner court, and against a bearing-post of
+cypress-wood which the carpenter had skilfully planed, and had made to
+join truly with rule and line. Telemachus took a whole loaf from the
+bread-basket, with as much meat as he could hold in his two hands, and
+said to Eumaeus, "Take this to the stranger, and tell him to go
+the round of the suitors, and beg from them; a beggar must not be
+shamefaced."
+
+So Eumaeus went up to him and said, "Stranger, Telemachus sends you
+this, and says you are to go the round of the suitors begging, for
+beggars must not be shamefaced."
+
+Ulysses answered, "May King Jove grant all happiness to Telemachus, and
+fulfil the desire of his heart."
+
+Then with both hands he took what Telemachus had sent him, and laid it
+on the dirty old wallet at his feet. He went on eating it while the
+bard was singing, and had just finished his dinner as he left off.
+The suitors applauded the bard, whereon Minerva went up to Ulysses and
+prompted him to beg pieces of bread from each one of the suitors, that
+he might see what kind of people they were, and tell the good from the
+bad; but come what might she was not going to save a single one of them.
+Ulysses, therefore, went on his round, going from left to right, and
+stretched out his hands to beg as though he were a real beggar. Some of
+them pitied him, and were curious about him, asking one another who
+he was and where he came from; whereon the goatherd Melanthius said,
+"Suitors of my noble mistress, I can tell you something about him, for I
+have seen him before. The swineherd brought him here, but I know nothing
+about the man himself, nor where he comes from."
+
+On this Antinous began to abuse the swineherd. "You precious idiot," he
+cried, "what have you brought this man to town for? Have we not tramps
+and beggars enough already to pester us as we sit at meat? Do you think
+it a small thing that such people gather here to waste your master's
+property--and must you needs bring this man as well?"
+
+And Eumaeus answered, "Antinous, your birth is good but your words evil.
+It was no doing of mine that he came here. Who is likely to invite a
+stranger from a foreign country, unless it be one of those who can do
+public service as a seer, a healer of hurts, a carpenter, or a bard who
+can charm us with his singing? Such men are welcome all the world over,
+but no one is likely to ask a beggar who will only worry him. You are
+always harder on Ulysses' servants than any of the other suitors
+are, and above all on me, but I do not care so long as Telemachus and
+Penelope are alive and here."
+
+But Telemachus said, "Hush, do not answer him; Antinous has the
+bitterest tongue of all the suitors, and he makes the others worse."
+
+Then turning to Antinous he said, "Antinous, you take as much care of
+my interests as though I were your son. Why should you want to see this
+stranger turned out of the house? Heaven forbid; take something and give
+it him yourself; I do not grudge it; I bid you take it. Never mind my
+mother, nor any of the other servants in the house; but I know you will
+not do what I say, for you are more fond of eating things yourself than
+of giving them to other people."
+
+"What do you mean, Telemachus," replied Antinous, "by this swaggering
+talk? If all the suitors were to give him as much as I will, he would
+not come here again for another three months."
+
+As he spoke he drew the stool on which he rested his dainty feet from
+under the table, and made as though he would throw it at Ulysses, but
+the other suitors all gave him something, and filled his wallet with
+bread and meat; he was about, therefore, to go back to the threshold and
+eat what the suitors had given him, but he first went up to Antinous and
+said:
+
+"Sir, give me something; you are not, surely, the poorest man here; you
+seem to be a chief, foremost among them all; therefore you should be the
+better giver, and I will tell far and wide of your bounty. I too was a
+rich man once, and had a fine house of my own; in those days I gave to
+many a tramp such as I now am, no matter who he might be nor what he
+wanted. I had any number of servants, and all the other things which
+people have who live well and are accounted wealthy, but it pleased Jove
+to take all away from me. He sent me with a band of roving robbers to
+Egypt; it was a long voyage and I was undone by it. I stationed my ships
+in the river Aegyptus, and bade my men stay by them and keep guard
+over them, while I sent out scouts to reconnoitre from every point of
+vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captives. The alarm was soon carried to the city, and when they
+heard the war-cry, the people came out at daybreak till the plain was
+filled with soldiers horse and foot, and with the gleam of armour. Then
+Jove spread panic among my men, and they would no longer face the enemy,
+for they found themselves surrounded. The Egyptians killed many of us,
+and took the rest alive to do forced labour for them; as for myself,
+they gave me to a friend who met them, to take to Cyprus, Dmetor by
+name, son of Iasus, who was a great man in Cyprus. Thence I am come
+hither in a state of great misery."
+
+Then Antinous said, "What god can have sent such a pestilence to plague
+us during our dinner? Get out, into the open part of the court, {145}
+or I will give you Egypt and Cyprus over again for your insolence and
+importunity; you have begged of all the others, and they have given you
+lavishly, for they have abundance round them, and it is easy to be free
+with other people's property when there is plenty of it."
+
+On this Ulysses began to move off, and said, "Your looks, my fine sir,
+are better than your breeding; if you were in your own house you would
+not spare a poor man so much as a pinch of salt, for though you are in
+another man's, and surrounded with abundance, you cannot find it in you
+to give him even a piece of bread."
+
+This made Antinous very angry, and he scowled at him saying, "You shall
+pay for this before you get clear of the court." With these words he
+threw a footstool at him, and hit him on the right shoulder blade near
+the top of his back. Ulysses stood firm as a rock and the blow did not
+even stagger him, but he shook his head in silence as he brooded on his
+revenge. Then he went back to the threshold and sat down there, laying
+his well filled wallet at his feet.
+
+"Listen to me," he cried, "you suitors of Queen Penelope, that I may
+speak even as I am minded. A man knows neither ache nor pain if he gets
+hit while fighting for his money, or for his sheep or his cattle; and
+even so Antinous has hit me while in the service of my miserable belly,
+which is always getting people into trouble. Still, if the poor have
+gods and avenging deities at all, I pray them that Antinous may come to
+a bad end before his marriage."
+
+"Sit where you are, and eat your victuals in silence, or be off
+elsewhere," shouted Antinous. "If you say more I will have you dragged
+hand and foot through the courts, and the servants shall flay you
+alive."
+
+The other suitors were much displeased at this, and one of the young men
+said, "Antinous, you did ill in striking that poor wretch of a tramp: it
+will be worse for you if he should turn out to be some god--and we know
+the gods go about disguised in all sorts of ways as people from foreign
+countries, and travel about the world to see who do amiss and who
+righteously." {146}
+
+Thus said the suitors, but Antinous paid them no heed. Meanwhile
+Telemachus was furious about the blow that had been given to his father,
+and though no tear fell from him, he shook his head in silence and
+brooded on his revenge.
+
+Now when Penelope heard that the beggar had been struck in the
+banqueting-cloister, she said before her maids, "Would that Apollo would
+so strike you, Antinous," and her waiting woman Eurynome answered, "If
+our prayers were answered not one of the suitors would ever again see
+the sun rise." Then Penelope said, "Nurse, {147} I hate every single one
+of them, for they mean nothing but mischief, but I hate Antinous like
+the darkness of death itself. A poor unfortunate tramp has come begging
+about the house for sheer want. Every one else has given him
+something to put in his wallet, but Antinous has hit him on the right
+shoulder-blade with a footstool."
+
+Thus did she talk with her maids as she sat in her own room, and in
+the meantime Ulysses was getting his dinner. Then she called for the
+swineherd and said, "Eumaeus, go and tell the stranger to come here, I
+want to see him and ask him some questions. He seems to have travelled
+much, and he may have seen or heard something of my unhappy husband."
+
+To this you answered, O swineherd Eumaeus, "If these Achaeans, Madam,
+would only keep quiet, you would be charmed with the history of his
+adventures. I had him three days and three nights with me in my hut,
+which was the first place he reached after running away from his ship,
+and he has not yet completed the story of his misfortunes. If he had
+been the most heaven-taught minstrel in the whole world, on whose lips
+all hearers hang entranced, I could not have been more charmed as I
+sat in my hut and listened to him. He says there is an old friendship
+between his house and that of Ulysses, and that he comes from Crete
+where the descendants of Minos live, after having been driven hither and
+thither by every kind of misfortune; he also declares that he has heard
+of Ulysses as being alive and near at hand among the Thesprotians, and
+that he is bringing great wealth home with him."
+
+"Call him here, then," said Penelope, "that I too may hear his story.
+As for the suitors, let them take their pleasure indoors or out as they
+will, for they have nothing to fret about. Their corn and wine remain
+unwasted in their houses with none but servants to consume them, while
+they keep hanging about our house day after day sacrificing our oxen,
+sheep, and fat goats for their banquets, and never giving so much as
+a thought to the quantity of wine they drink. No estate can stand such
+recklessness, for we have now no Ulysses to protect us. If he were to
+come again, he and his son would soon have their revenge."
+
+As she spoke Telemachus sneezed so loudly that the whole house resounded
+with it. Penelope laughed when she heard this, and said to Eumaeus, "Go
+and call the stranger; did you not hear how my son sneezed just as I
+was speaking? This can only mean that all the suitors are going to be
+killed, and that not one of them shall escape. Furthermore I say, and
+lay my saying to your heart: if I am satisfied that the stranger is
+speaking the truth I shall give him a shirt and cloak of good wear."
+
+When Eumaeus heard this he went straight to Ulysses and said, "Father
+stranger, my mistress Penelope, mother of Telemachus, has sent for you;
+she is in great grief, but she wishes to hear anything you can tell her
+about her husband, and if she is satisfied that you are speaking the
+truth, she will give you a shirt and cloak, which are the very things
+that you are most in want of. As for bread, you can get enough of that
+to fill your belly, by begging about the town, and letting those give
+that will."
+
+"I will tell Penelope," answered Ulysses, "nothing but what is strictly
+true. I know all about her husband, and have been partner with him
+in affliction, but I am afraid of passing through this crowd of cruel
+suitors, for their pride and insolence reach heaven. Just now, moreover,
+as I was going about the house without doing any harm, a man gave me
+a blow that hurt me very much, but neither Telemachus nor any one else
+defended me. Tell Penelope, therefore, to be patient and wait till
+sundown. Let her give me a seat close up to the fire, for my clothes are
+worn very thin--you know they are, for you have seen them ever since I
+first asked you to help me--she can then ask me about the return of her
+husband."
+
+The swineherd went back when he heard this, and Penelope said as she saw
+him cross the threshold, "Why do you not bring him here, Eumaeus? Is he
+afraid that some one will ill-treat him, or is he shy of coming inside
+the house at all? Beggars should not be shamefaced."
+
+To this you answered, O swineherd Eumaeus, "The stranger is quite
+reasonable. He is avoiding the suitors, and is only doing what any one
+else would do. He asks you to wait till sundown, and it will be much
+better, madam, that you should have him all to yourself, when you can
+hear him and talk to him as you will."
+
+"The man is no fool," answered Penelope, "it would very likely be as
+he says, for there are no such abominable people in the whole world as
+these men are."
+
+When she had done speaking Eumaeus went back to the suitors, for he had
+explained everything. Then he went up to Telemachus and said in his ear
+so that none could overhear him, "My dear sir, I will now go back to the
+pigs, to see after your property and my own business. You will look to
+what is going on here, but above all be careful to keep out of danger,
+for there are many who bear you ill will. May Jove bring them to a bad
+end before they do us a mischief."
+
+"Very well," replied Telemachus, "go home when you have had your dinner,
+and in the morning come here with the victims we are to sacrifice for
+the day. Leave the rest to heaven and me."
+
+On this Eumaeus took his seat again, and when he had finished his dinner
+he left the courts and the cloister with the men at table, and went
+back to his pigs. As for the suitors, they presently began to amuse
+themselves with singing and dancing, for it was now getting on towards
+evening.
+
+
+Book XVIII
+
+THE FIGHT WITH IRUS--ULYSSES WARNS AMPHINOMUS--PENELOPE GETS PRESENTS
+FROM THE SUITORS--THE BRAZIERS--ULYSSES REBUKES EURYMACHUS.
+
+Now there came a certain common tramp who used to go begging all over
+the city of Ithaca, and was notorious as an incorrigible glutton and
+drunkard. This man had no strength nor stay in him, but he was a great
+hulking fellow to look at; his real name, the one his mother gave him,
+was Arnaeus, but the young men of the place called him Irus, {148}
+because he used to run errands for any one who would send him. As soon
+as he came he began to insult Ulysses, and to try and drive him out of
+his own house.
+
+"Be off, old man," he cried, "from the doorway, or you shall be dragged
+out neck and heels. Do you not see that they are all giving me the wink,
+and wanting me to turn you out by force, only I do not like to do so?
+Get up then, and go of yourself, or we shall come to blows."
+
+Ulysses frowned on him and said, "My friend, I do you no manner of harm;
+people give you a great deal, but I am not jealous. There is room enough
+in this doorway for the pair of us, and you need not grudge me things
+that are not yours to give. You seem to be just such another tramp as
+myself, but perhaps the gods will give us better luck by and by. Do not,
+however, talk too much about fighting or you will incense me, and old
+though I am, I shall cover your mouth and chest with blood. I shall
+have more peace tomorrow if I do, for you will not come to the house of
+Ulysses any more."
+
+Irus was very angry and answered, "You filthy glutton, you run on
+trippingly like an old fish-fag. I have a good mind to lay both hands
+about you, and knock your teeth out of your head like so many boar's
+tusks. Get ready, therefore, and let these people here stand by and
+look on. You will never be able to fight one who is so much younger than
+yourself."
+
+Thus roundly did they rate one another on the smooth pavement in front
+of the doorway, {149} and when Antinous saw what was going on he laughed
+heartily and said to the others, "This is the finest sport that you
+ever saw; heaven never yet sent anything like it into this house. The
+stranger and Irus have quarreled and are going to fight, let us set them
+on to do so at once."
+
+The suitors all came up laughing, and gathered round the two ragged
+tramps. "Listen to me," said Antinous, "there are some goats' paunches
+down at the fire, which we have filled with blood and fat, and set aside
+for supper; he who is victorious and proves himself to be the better
+man shall have his pick of the lot; he shall be free of our table and we
+will not allow any other beggar about the house at all."
+
+The others all agreed, but Ulysses, to throw them off the scent, said,
+"Sirs, an old man like myself, worn out with suffering, cannot hold his
+own against a young one; but my irrepressible belly urges me on, though
+I know it can only end in my getting a drubbing. You must swear, however
+that none of you will give me a foul blow to favour Irus and secure him
+the victory."
+
+They swore as he told them, and when they had completed their oath
+Telemachus put in a word and said, "Stranger, if you have a mind to
+settle with this fellow, you need not be afraid of any one here. Whoever
+strikes you will have to fight more than one. I am host, and the other
+chiefs, Antinous and Eurymachus, both of them men of understanding, are
+of the same mind as I am."
+
+Every one assented, and Ulysses girded his old rags about his loins,
+thus baring his stalwart thighs, his broad chest and shoulders, and his
+mighty arms; but Minerva came up to him and made his limbs even stronger
+still. The suitors were beyond measure astonished, and one would turn
+towards his neighbour saying, "The stranger has brought such a thigh out
+of his old rags that there will soon be nothing left of Irus."
+
+Irus began to be very uneasy as he heard them, but the servants girded
+him by force, and brought him [into the open part of the court] in such
+a fright that his limbs were all of a tremble. Antinous scolded him and
+said, "You swaggering bully, you ought never to have been born at all if
+you are afraid of such an old broken down creature as this tramp is.
+I say, therefore--and it shall surely be--if he beats you and proves
+himself the better man, I shall pack you off on board ship to the
+mainland and send you to king Echetus, who kills every one that comes
+near him. He will cut off your nose and ears, and draw out your entrails
+for the dogs to eat."
+
+This frightened Irus still more, but they brought him into the middle
+of the court, and the two men raised their hands to fight. Then Ulysses
+considered whether he should let drive so hard at him as to make an end
+of him then and there, or whether he should give him a lighter blow that
+should only knock him down; in the end he deemed it best to give the
+lighter blow for fear the Achaeans should begin to suspect who he was.
+Then they began to fight, and Irus hit Ulysses on the right shoulder;
+but Ulysses gave Irus a blow on the neck under the ear that broke in the
+bones of his skull, and the blood came gushing out of his mouth; he fell
+groaning in the dust, gnashing his teeth and kicking on the ground, but
+the suitors threw up their hands and nearly died of laughter, as Ulysses
+caught hold of him by the foot and dragged him into the outer court as
+far as the gate-house. There he propped him up against the wall and put
+his staff in his hands. "Sit here," said he, "and keep the dogs and pigs
+off; you are a pitiful creature, and if you try to make yourself king of
+the beggars any more you shall fare still worse."
+
+Then he threw his dirty old wallet, all tattered and torn over his
+shoulder with the cord by which it hung, and went back to sit down upon
+the threshold; but the suitors went within the cloisters, laughing and
+saluting him, "May Jove, and all the other gods," said they, "grant
+you whatever you want for having put an end to the importunity of this
+insatiable tramp. We will take him over to the mainland presently, to
+king Echetus, who kills every one that comes near him."
+
+Ulysses hailed this as of good omen, and Antinous set a great goat's
+paunch before him filled with blood and fat. Amphinomus took two loaves
+out of the bread-basket and brought them to him, pledging him as he
+did so in a golden goblet of wine. "Good luck to you," he said, "father
+stranger, you are very badly off at present, but I hope you will have
+better times by and by."
+
+To this Ulysses answered, "Amphinomus, you seem to be a man of good
+understanding, as indeed you may well be, seeing whose son you are. I
+have heard your father well spoken of; he is Nisus of Dulichium, a man
+both brave and wealthy. They tell me you are his son, and you appear to
+be a considerable person; listen, therefore, and take heed to what I am
+saying. Man is the vainest of all creatures that have their being upon
+earth. As long as heaven vouchsafes him health and strength, he thinks
+that he shall come to no harm hereafter, and even when the blessed gods
+bring sorrow upon him, he bears it as he needs must, and makes the best
+of it; for God almighty gives men their daily minds day by day. I know
+all about it, for I was a rich man once, and did much wrong in the
+stubbornness of my pride, and in the confidence that my father and my
+brothers would support me; therefore let a man fear God in all things
+always, and take the good that heaven may see fit to send him without
+vain glory. Consider the infamy of what these suitors are doing; see how
+they are wasting the estate, and doing dishonour to the wife, of one who
+is certain to return some day, and that, too, not long hence. Nay, he
+will be here soon; may heaven send you home quietly first that you may
+not meet with him in the day of his coming, for once he is here the
+suitors and he will not part bloodlessly."
+
+With these words he made a drink-offering, and when he had drunk he put
+the gold cup again into the hands of Amphinomus, who walked away serious
+and bowing his head, for he foreboded evil. But even so he did not
+escape destruction, for Minerva had doomed him to fall by the hand of
+Telemachus. So he took his seat again at the place from which he had
+come.
+
+Then Minerva put it into the mind of Penelope to show herself to the
+suitors, that she might make them still more enamoured of her, and win
+still further honour from her son and husband. So she feigned a mocking
+laugh and said, "Eurynome, I have changed my mind, and have a fancy to
+show myself to the suitors although I detest them. I should like also to
+give my son a hint that he had better not have anything more to do with
+them. They speak fairly enough but they mean mischief."
+
+"My dear child," answered Eurynome, "all that you have said is true,
+go and tell your son about it, but first wash yourself and anoint your
+face. Do not go about with your cheeks all covered with tears; it is not
+right that you should grieve so incessantly; for Telemachus, whom you
+always prayed that you might live to see with a beard, is already grown
+up."
+
+"I know, Eurynome," replied Penelope, "that you mean well, but do not
+try and persuade me to wash and to anoint myself, for heaven robbed
+me of all my beauty on the day my husband sailed; nevertheless, tell
+Autonoe and Hippodamia that I want them. They must be with me when I
+am in the cloister; I am not going among the men alone; it would not be
+proper for me to do so."
+
+On this the old woman {150} went out of the room to bid the maids go to
+their mistress. In the meantime Minerva bethought her of another matter,
+and sent Penelope off into a sweet slumber; so she lay down on her couch
+and her limbs became heavy with sleep. Then the goddess shed grace and
+beauty over her that all the Achaeans might admire her. She washed
+her face with the ambrosial loveliness that Venus wears when she goes
+dancing with the Graces; she made her taller and of a more commanding
+figure, while as for her complexion it was whiter than sawn ivory. When
+Minerva had done all this she went away, whereon the maids came in from
+the women's room and woke Penelope with the sound of their talking.
+
+"What an exquisitely delicious sleep I have been having," said she, as
+she passed her hands over her face, "in spite of all my misery. I wish
+Diana would let me die so sweetly now at this very moment, that I
+might no longer waste in despair for the loss of my dear husband, who
+possessed every kind of good quality and was the most distinguished man
+among the Achaeans."
+
+With these words she came down from her upper room, not alone but
+attended by two of her maidens, and when she reached the suitors she
+stood by one of the bearing-posts supporting the roof of the cloister,
+holding a veil before her face, and with a staid maid servant on either
+side of her. As they beheld her the suitors were so overpowered and
+became so desperately enamoured of her, that each one prayed he might
+win her for his own bed fellow.
+
+"Telemachus," said she, addressing her son, "I fear you are no longer so
+discreet and well conducted as you used to be. When you were younger you
+had a greater sense of propriety; now, however, that you are grown up,
+though a stranger to look at you would take you for the son of a well to
+do father as far as size and good looks go, your conduct is by no means
+what it should be. What is all this disturbance that has been going on,
+and how came you to allow a stranger to be so disgracefully ill-treated?
+What would have happened if he had suffered serious injury while a
+suppliant in our house? Surely this would have been very discreditable
+to you."
+
+"I am not surprised, my dear mother, at your displeasure," replied
+Telemachus, "I understand all about it and know when things are not
+as they should be, which I could not do when I was younger; I cannot,
+however, behave with perfect propriety at all times. First one and then
+another of these wicked people here keeps driving me out of my mind,
+and I have no one to stand by me. After all, however, this fight between
+Irus and the stranger did not turn out as the suitors meant it to do,
+for the stranger got the best of it. I wish Father Jove, Minerva, and
+Apollo would break the neck of every one of these wooers of yours, some
+inside the house and some out; and I wish they might all be as limp as
+Irus is over yonder in the gate of the outer court. See how he nods
+his head like a drunken man; he has had such a thrashing that he cannot
+stand on his feet nor get back to his home, wherever that may be, for he
+has no strength left in him."
+
+Thus did they converse. Eurymachus then came up and said, "Queen
+Penelope, daughter of Icarius, if all the Achaeans in Iasian Argos could
+see you at this moment, you would have still more suitors in your house
+by tomorrow morning, for you are the most admirable woman in the whole
+world both as regards personal beauty and strength of understanding."
+
+To this Penelope replied, "Eurymachus, heaven robbed me of all my beauty
+whether of face or figure when the Argives set sail for Troy and my dear
+husband with them. If he were to return and look after my affairs, I
+should both be more respected and show a better presence to the world.
+As it is, I am oppressed with care, and with the afflictions which
+heaven has seen fit to heap upon me. My husband foresaw it all, and when
+he was leaving home he took my right wrist in his hand--'Wife,' he said,
+'we shall not all of us come safe home from Troy, for the Trojans fight
+well both with bow and spear. They are excellent also at fighting from
+chariots, and nothing decides the issue of a fight sooner than this. I
+know not, therefore, whether heaven will send me back to you, or whether
+I may not fall over there at Troy. In the meantime do you look after
+things here. Take care of my father and mother as at present, and even
+more so during my absence, but when you see our son growing a beard,
+then marry whom you will, and leave this your present home.' This is
+what he said and now it is all coming true. A night will come when I
+shall have to yield myself to a marriage which I detest, for Jove has
+taken from me all hope of happiness. This further grief, moreover, cuts
+me to the very heart. You suitors are not wooing me after the custom of
+my country. When men are courting a woman who they think will be a good
+wife to them and who is of noble birth, and when they are each trying
+to win her for himself, they usually bring oxen and sheep to feast the
+friends of the lady, and they make her magnificent presents, instead of
+eating up other people's property without paying for it."
+
+This was what she said, and Ulysses was glad when he heard her trying
+to get presents out of the suitors, and flattering them with fair words
+which he knew she did not mean.
+
+Then Antinous said, "Queen Penelope, daughter of Icarius, take as many
+presents as you please from any one who will give them to you; it is not
+well to refuse a present; but we will not go about our business nor stir
+from where we are, till you have married the best man among us whoever
+he may be."
+
+The others applauded what Antinous had said, and each one sent his
+servant to bring his present. Antinous's man returned with a large and
+lovely dress most exquisitely embroidered. It had twelve beautifully
+made brooch pins of pure gold with which to fasten it. Eurymachus
+immediately brought her a magnificent chain of gold and amber beads that
+gleamed like sunlight. Eurydamas's two men returned with some
+earrings fashioned into three brilliant pendants which glistened most
+beautifully; while king Pisander son of Polyctor gave her a necklace
+of the rarest workmanship, and every one else brought her a beautiful
+present of some kind.
+
+Then the queen went back to her room upstairs, and her maids brought the
+presents after her. Meanwhile the suitors took to singing and dancing,
+and stayed till evening came. They danced and sang till it grew dark;
+they then brought in three braziers {151} to give light, and piled them
+up with chopped firewood very old and dry, and they lit torches from
+them, which the maids held up turn and turn about. Then Ulysses said:
+
+"Maids, servants of Ulysses who has so long been absent, go to the queen
+inside the house; sit with her and amuse her, or spin, and pick wool.
+I will hold the light for all these people. They may stay till morning,
+but shall not beat me, for I can stand a great deal."
+
+The maids looked at one another and laughed, while pretty Melantho began
+to gibe at him contemptuously. She was daughter to Dolius, but had been
+brought up by Penelope, who used to give her toys to play with, and
+looked after her when she was a child; but in spite of all this she
+showed no consideration for the sorrows of her mistress, and used to
+misconduct herself with Eurymachus, with whom she was in love.
+
+"Poor wretch," said she, "are you gone clean out of your mind? Go and
+sleep in some smithy, or place of public gossips, instead of chattering
+here. Are you not ashamed of opening your mouth before your betters--so
+many of them too? Has the wine been getting into your head, or do you
+always babble in this way? You seem to have lost your wits because you
+beat the tramp Irus; take care that a better man than he does not come
+and cudgel you about the head till he pack you bleeding out of the
+house."
+
+"Vixen," replied Ulysses, scowling at her, "I will go and tell
+Telemachus what you have been saying, and he will have you torn limb
+from limb."
+
+With these words he scared the women, and they went off into the body
+of the house. They trembled all over, for they thought he would do as he
+said. But Ulysses took his stand near the burning braziers, holding up
+torches and looking at the people--brooding the while on things that
+should surely come to pass.
+
+But Minerva would not let the suitors for one moment cease their
+insolence, for she wanted Ulysses to become even more bitter against
+them; she therefore set Eurymachus son of Polybus on to gibe at him,
+which made the others laugh. "Listen to me," said he, "you suitors of
+Queen Penelope, that I may speak even as I am minded. It is not for
+nothing that this man has come to the house of Ulysses; I believe the
+light has not been coming from the torches, but from his own head--for
+his hair is all gone, every bit of it."
+
+Then turning to Ulysses he said, "Stranger, will you work as a servant,
+if I send you to the wolds and see that you are well paid? Can you build
+a stone fence, or plant trees? I will have you fed all the year round,
+and will find you in shoes and clothing. Will you go, then? Not you; for
+you have got into bad ways, and do not want to work; you had rather fill
+your belly by going round the country begging."
+
+"Eurymachus," answered Ulysses, "if you and I were to work one against
+the other in early summer when the days are at their longest--give me a
+good scythe, and take another yourself, and let us see which will last
+the longer or mow the stronger, from dawn till dark when the mowing
+grass is about. Or if you will plough against me, let us each take a
+yoke of tawny oxen, well-mated and of great strength and endurance:
+turn me into a four acre field, and see whether you or I can drive the
+straighter furrow. If, again, war were to break out this day, give me
+a shield, a couple of spears and a helmet fitting well upon my
+temples--you would find me foremost in the fray, and would cease your
+gibes about my belly. You are insolent and cruel, and think yourself
+a great man because you live in a little world, and that a bad one. If
+Ulysses comes to his own again, the doors of his house are wide, but you
+will find them narrow when you try to fly through them."
+
+Eurymachus was furious at all this. He scowled at him and cried, "You
+wretch, I will soon pay you out for daring to say such things to me, and
+in public too. Has the wine been getting into your head or do you always
+babble in this way? You seem to have lost your wits because you beat the
+tramp Irus." With this he caught hold of a footstool, but Ulysses sought
+protection at the knees of Amphinomus of Dulichium, for he was afraid.
+The stool hit the cupbearer on his right hand and knocked him down: the
+man fell with a cry flat on his back, and his wine-jug fell ringing to
+the ground. The suitors in the covered cloister were now in an uproar,
+and one would turn towards his neighbour, saying, "I wish the stranger
+had gone somewhere else, bad luck to him, for all the trouble he gives
+us. We cannot permit such disturbance about a beggar; if such ill
+counsels are to prevail we shall have no more pleasure at our banquet."
+
+On this Telemachus came forward and said, "Sirs, are you mad? Can you
+not carry your meat and your liquor decently? Some evil spirit has
+possessed you. I do not wish to drive any of you away, but you have had
+your suppers, and the sooner you all go home to bed the better."
+
+The suitors bit their lips and marvelled at the boldness of his speech;
+but Amphinomus the son of Nisus, who was son to Aretias, said, "Do not
+let us take offence; it is reasonable, so let us make no answer. Neither
+let us do violence to the stranger nor to any of Ulysses' servants. Let
+the cupbearer go round with the drink-offerings, that we may make them
+and go home to our rest. As for the stranger, let us leave Telemachus to
+deal with him, for it is to his house that he has come."
+
+Thus did he speak, and his saying pleased them well, so Mulius of
+Dulichium, servant to Amphinomus, mixed them a bowl of wine and water
+and handed it round to each of them man by man, whereon they made their
+drink-offerings to the blessed gods: Then, when they had made their
+drink-offerings and had drunk each one as he was minded, they took their
+several ways each of them to his own abode.
+
+
+Book XIX
+
+TELEMACHUS AND ULYSSES REMOVE THE ARMOUR--ULYSSES INTERVIEWS
+PENELOPE--EURYCLEA WASHES HIS FEET AND RECOGNISES THE SCAR ON HIS
+LEG--PENELOPE TELLS HER DREAM TO ULYSSES.
+
+Ulysses was left in the cloister, pondering on the means whereby with
+Minerva's help he might be able to kill the suitors. Presently he said
+to Telemachus, "Telemachus, we must get the armour together and take
+it down inside. Make some excuse when the suitors ask you why you have
+removed it. Say that you have taken it to be out of the way of the
+smoke, inasmuch as it is no longer what it was when Ulysses went
+away, but has become soiled and begrimed with soot. Add to this more
+particularly that you are afraid Jove may set them on to quarrel over
+their wine, and that they may do each other some harm which may disgrace
+both banquet and wooing, for the sight of arms sometimes tempts people
+to use them."
+
+Telemachus approved of what his father had said, so he called nurse
+Euryclea and said, "Nurse, shut the women up in their room, while I take
+the armour that my father left behind him down into the store room. No
+one looks after it now my father is gone, and it has got all smirched
+with soot during my own boyhood. I want to take it down where the smoke
+cannot reach it."
+
+"I wish, child," answered Euryclea, "that you would take the management
+of the house into your own hands altogether, and look after all the
+property yourself. But who is to go with you and light you to the
+store-room? The maids would have done so, but you would not let them."
+
+"The stranger," said Telemachus, "shall show me a light; when people eat
+my bread they must earn it, no matter where they come from."
+
+Euryclea did as she was told, and bolted the women inside their room.
+Then Ulysses and his son made all haste to take the helmets, shields,
+and spears inside; and Minerva went before them with a gold lamp in her
+hand that shed a soft and brilliant radiance, whereon Telemachus said,
+"Father, my eyes behold a great marvel: the walls, with the rafters,
+crossbeams, and the supports on which they rest are all aglow as with
+a flaming fire. Surely there is some god here who has come down from
+heaven."
+
+"Hush," answered Ulysses, "hold your peace and ask no questions, for
+this is the manner of the gods. Get you to your bed, and leave me here
+to talk with your mother and the maids. Your mother in her grief will
+ask me all sorts of questions."
+
+On this Telemachus went by torch-light to the other side of the inner
+court, to the room in which he always slept. There he lay in his bed
+till morning, while Ulysses was left in the cloister pondering on the
+means whereby with Minerva's help he might be able to kill the suitors.
+
+Then Penelope came down from her room looking like Venus or Diana, and
+they set her a seat inlaid with scrolls of silver and ivory near the
+fire in her accustomed place. It had been made by Icmalius and had a
+footstool all in one piece with the seat itself; and it was covered with
+a thick fleece: on this she now sat, and the maids came from the women's
+room to join her. They set about removing the tables at which the wicked
+suitors had been dining, and took away the bread that was left, with
+the cups from which they had drunk. They emptied the embers out of the
+braziers, and heaped much wood upon them to give both light and heat;
+but Melantho began to rail at Ulysses a second time and said, "Stranger,
+do you mean to plague us by hanging about the house all night and spying
+upon the women? Be off, you wretch, outside, and eat your supper there,
+or you shall be driven out with a firebrand."
+
+Ulysses scowled at her and answered, "My good woman, why should you be
+so angry with me? Is it because I am not clean, and my clothes are all
+in rags, and because I am obliged to go begging about after the manner
+of tramps and beggars generally? I too was a rich man once, and had a
+fine house of my own; in those days I gave to many a tramp such as I now
+am, no matter who he might be nor what he wanted. I had any number of
+servants, and all the other things which people have who live well and
+are accounted wealthy, but it pleased Jove to take all away from me;
+therefore, woman, beware lest you too come to lose that pride and place
+in which you now wanton above your fellows; have a care lest you get
+out of favour with your mistress, and lest Ulysses should come home, for
+there is still a chance that he may do so. Moreover, though he be dead
+as you think he is, yet by Apollo's will he has left a son behind him,
+Telemachus, who will note anything done amiss by the maids in the house,
+for he is now no longer in his boyhood."
+
+Penelope heard what he was saying and scolded the maid, "Impudent
+baggage," said she, "I see how abominably you are behaving, and you
+shall smart for it. You knew perfectly well, for I told you myself, that
+I was going to see the stranger and ask him about my husband, for whose
+sake I am in such continual sorrow."
+
+Then she said to her head waiting woman Eurynome, "Bring a seat with a
+fleece upon it, for the stranger to sit upon while he tells his story,
+and listens to what I have to say. I wish to ask him some questions."
+
+Eurynome brought the seat at once and set a fleece upon it, and as soon
+as Ulysses had sat down Penelope began by saying, "Stranger, I shall
+first ask you who and whence are you? Tell me of your town and parents."
+
+"Madam," answered Ulysses, "who on the face of the whole earth can dare
+to chide with you? Your fame reaches the firmament of heaven itself; you
+are like some blameless king, who upholds righteousness, as the monarch
+over a great and valiant nation: the earth yields its wheat and barley,
+the trees are loaded with fruit, the ewes bring forth lambs, and the sea
+abounds with fish by reason of his virtues, and his people do good deeds
+under him. Nevertheless, as I sit here in your house, ask me some other
+question and do not seek to know my race and family, or you will recall
+memories that will yet more increase my sorrow. I am full of heaviness,
+but I ought not to sit weeping and wailing in another person's house,
+nor is it well to be thus grieving continually. I shall have one of the
+servants or even yourself complaining of me, and saying that my eyes
+swim with tears because I am heavy with wine."
+
+Then Penelope answered, "Stranger, heaven robbed me of all beauty,
+whether of face or figure, when the Argives set sail for Troy and my
+dear husband with them. If he were to return and look after my affairs
+I should be both more respected and should show a better presence to
+the world. As it is, I am oppressed with care, and with the afflictions
+which heaven has seen fit to heap upon me. The chiefs from all our
+islands--Dulichium, Same, and Zacynthus, as also from Ithaca itself,
+are wooing me against my will and are wasting my estate. I can therefore
+show no attention to strangers, nor suppliants, nor to people who say
+that they are skilled artisans, but am all the time broken-hearted
+about Ulysses. They want me to marry again at once, and I have to invent
+stratagems in order to deceive them. In the first place heaven put it in
+my mind to set up a great tambour-frame in my room, and to begin
+working upon an enormous piece of fine needlework. Then I said to them,
+'Sweethearts, Ulysses is indeed dead, still, do not press me to marry
+again immediately; wait--for I would not have my skill in needlework
+perish unrecorded--till I have finished making a pall for the hero
+Laertes, to be ready against the time when death shall take him. He
+is very rich, and the women of the place will talk if he is laid out
+without a pall.' This was what I said, and they assented; whereon I
+used to keep working at my great web all day long, but at night I would
+unpick the stitches again by torch light. I fooled them in this way for
+three years without their finding it out, but as time wore on and I was
+now in my fourth year, in the waning of moons, and many days had been
+accomplished, those good for nothing hussies my maids betrayed me to the
+suitors, who broke in upon me and caught me; they were very angry with
+me, so I was forced to finish my work whether I would or no. And now
+I do not see how I can find any further shift for getting out of this
+marriage. My parents are putting great pressure upon me, and my son
+chafes at the ravages the suitors are making upon his estate, for he is
+now old enough to understand all about it and is perfectly able to look
+after his own affairs, for heaven has blessed him with an excellent
+disposition. Still, notwithstanding all this, tell me who you are and
+where you come from--for you must have had father and mother of some
+sort; you cannot be the son of an oak or of a rock."
+
+Then Ulysses answered, "Madam, wife of Ulysses, since you persist in
+asking me about my family, I will answer, no matter what it costs me:
+people must expect to be pained when they have been exiles as long as
+I have, and suffered as much among as many peoples. Nevertheless, as
+regards your question I will tell you all you ask. There is a fair and
+fruitful island in mid-ocean called Crete; it is thickly peopled and
+there are ninety cities in it: the people speak many different languages
+which overlap one another, for there are Achaeans, brave Eteocretans,
+Dorians of three-fold race, and noble Pelasgi. There is a great
+town there, Cnossus, where Minos reigned who every nine years had a
+conference with Jove himself. {152} Minos was father to Deucalion, whose
+son I am, for Deucalion had two sons Idomeneus and myself. Idomeneus
+sailed for Troy, and I, who am the younger, am called Aethon; my
+brother, however, was at once the older and the more valiant of the two;
+hence it was in Crete that I saw Ulysses and showed him hospitality, for
+the winds took him there as he was on his way to Troy, carrying him out
+of his course from cape Malea and leaving him in Amnisus off the cave of
+Ilithuia, where the harbours are difficult to enter and he could hardly
+find shelter from the winds that were then raging. As soon as he got
+there he went into the town and asked for Idomeneus, claiming to be his
+old and valued friend, but Idomeneus had already set sail for Troy some
+ten or twelve days earlier, so I took him to my own house and showed him
+every kind of hospitality, for I had abundance of everything. Moreover,
+I fed the men who were with him with barley meal from the public store,
+and got subscriptions of wine and oxen for them to sacrifice to their
+heart's content. They stayed with me twelve days, for there was a gale
+blowing from the North so strong that one could hardly keep one's feet
+on land. I suppose some unfriendly god had raised it for them, but on
+the thirteenth day the wind dropped, and they got away."
+
+Many a plausible tale did Ulysses further tell her, and Penelope wept
+as she listened, for her heart was melted. As the snow wastes upon the
+mountain tops when the winds from South East and West have breathed upon
+it and thawed it till the rivers run bank full with water, even so did
+her cheeks overflow with tears for the husband who was all the time
+sitting by her side. Ulysses felt for her and was sorry for her, but he
+kept his eyes as hard as horn or iron without letting them so much
+as quiver, so cunningly did he restrain his tears. Then, when she had
+relieved herself by weeping, she turned to him again and said: "Now,
+stranger, I shall put you to the test and see whether or no you really
+did entertain my husband and his men, as you say you did. Tell me, then,
+how he was dressed, what kind of a man he was to look at, and so also
+with his companions."
+
+"Madam," answered Ulysses, "it is such a long time ago that I can hardly
+say. Twenty years are come and gone since he left my home, and went
+elsewhither; but I will tell you as well as I can recollect. Ulysses
+wore a mantle of purple wool, double lined, and it was fastened by a
+gold brooch with two catches for the pin. On the face of this there was
+a device that shewed a dog holding a spotted fawn between his fore paws,
+and watching it as it lay panting upon the ground. Every one marvelled
+at the way in which these things had been done in gold, the dog
+looking at the fawn, and strangling it, while the fawn was struggling
+convulsively to escape. {153} As for the shirt that he wore next his
+skin, it was so soft that it fitted him like the skin of an onion, and
+glistened in the sunlight to the admiration of all the women who beheld
+it. Furthermore I say, and lay my saying to your heart, that I do not
+know whether Ulysses wore these clothes when he left home, or whether
+one of his companions had given them to him while he was on his voyage;
+or possibly some one at whose house he was staying made him a present
+of them, for he was a man of many friends and had few equals among the
+Achaeans. I myself gave him a sword of bronze and a beautiful purple
+mantle, double lined, with a shirt that went down to his feet, and I
+sent him on board his ship with every mark of honour. He had a servant
+with him, a little older than himself, and I can tell you what he was
+like; his shoulders were hunched, {154} he was dark, and he had thick
+curly hair. His name was Eurybates, and Ulysses treated him with greater
+familiarity than he did any of the others, as being the most like-minded
+with himself."
+
+Penelope was moved still more deeply as she heard the indisputable
+proofs that Ulysses laid before her; and when she had again found relief
+in tears she said to him, "Stranger, I was already disposed to pity you,
+but henceforth you shall be honoured and made welcome in my house. It
+was I who gave Ulysses the clothes you speak of. I took them out of
+the store room and folded them up myself, and I gave him also the gold
+brooch to wear as an ornament. Alas! I shall never welcome him home
+again. It was by an ill fate that he ever set out for that detested city
+whose very name I cannot bring myself even to mention."
+
+Then Ulysses answered, "Madam, wife of Ulysses, do not disfigure
+yourself further by grieving thus bitterly for your loss, though I can
+hardly blame you for doing so. A woman who has loved her husband and
+borne him children, would naturally be grieved at losing him, even
+though he were a worse man than Ulysses, who they say was like a god.
+Still, cease your tears and listen to what I can tell you. I will hide
+nothing from you, and can say with perfect truth that I have lately
+heard of Ulysses as being alive and on his way home; he is among the
+Thesprotians, and is bringing back much valuable treasure that he has
+begged from one and another of them; but his ship and all his crew
+were lost as they were leaving the Thrinacian island, for Jove and
+the sun-god were angry with him because his men had slaughtered the
+sun-god's cattle, and they were all drowned to a man. But Ulysses
+stuck to the keel of the ship and was drifted on to the land of the
+Phaeacians, who are near of kin to the immortals, and who treated him
+as though he had been a god, giving him many presents, and wishing to
+escort him home safe and sound. In fact Ulysses would have been here
+long ago, had he not thought better to go from land to land gathering
+wealth; for there is no man living who is so wily as he is; there is no
+one can compare with him. Pheidon king of the Thesprotians told me all
+this, and he swore to me--making drink-offerings in his house as he did
+so--that the ship was by the water side and the crew found who would
+take Ulysses to his own country. He sent me off first, for there
+happened to be a Thesprotian ship sailing for the wheat-growing
+island of Dulichium, but he showed me all the treasure Ulysses had got
+together, and he had enough lying in the house of king Pheidon to keep
+his family for ten generations; but the king said Ulysses had gone to
+Dodona that he might learn Jove's mind from the high oak tree, and know
+whether after so long an absence he should return to Ithaca openly or in
+secret. So you may know he is safe and will be here shortly; he is close
+at hand and cannot remain away from home much longer; nevertheless I
+will confirm my words with an oath, and call Jove who is the first and
+mightiest of all gods to witness, as also that hearth of Ulysses to
+which I have now come, that all I have spoken shall surely come to pass.
+Ulysses will return in this self same year; with the end of this moon
+and the beginning of the next he will be here."
+
+"May it be even so," answered Penelope; "if your words come true you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you; but I know very well how it will be. Ulysses
+will not return, neither will you get your escort hence, for so surely
+as that Ulysses ever was, there are now no longer any such masters in
+the house as he was, to receive honourable strangers or to further them
+on their way home. And now, you maids, wash his feet for him, and make
+him a bed on a couch with rugs and blankets, that he may be warm and
+quiet till morning. Then, at day break wash him and anoint him again,
+that he may sit in the cloister and take his meals with Telemachus. It
+shall be the worse for any one of these hateful people who is uncivil to
+him; like it or not, he shall have no more to do in this house. For how,
+sir, shall you be able to learn whether or no I am superior to others of
+my sex both in goodness of heart and understanding, if I let you dine in
+my cloisters squalid and ill clad? Men live but for a little season; if
+they are hard, and deal hardly, people wish them ill so long as they are
+alive, and speak contemptuously of them when they are dead, but he that
+is righteous and deals righteously, the people tell of his praise among
+all lands, and many shall call him blessed."
+
+Ulysses answered, "Madam, I have foresworn rugs and blankets from the
+day that I left the snowy ranges of Crete to go on shipboard. I will
+lie as I have lain on many a sleepless night hitherto. Night after night
+have I passed in any rough sleeping place, and waited for morning. Nor,
+again, do I like having my feet washed; I shall not let any of the young
+hussies about your house touch my feet; but, if you have any old and
+respectable woman who has gone through as much trouble as I have, I will
+allow her to wash them."
+
+To this Penelope said, "My dear sir, of all the guests who ever yet
+came to my house there never was one who spoke in all things with such
+admirable propriety as you do. There happens to be in the house a most
+respectable old woman--the same who received my poor dear husband in
+her arms the night he was born, and nursed him in infancy. She is
+very feeble now, but she shall wash your feet." "Come here," said she,
+"Euryclea, and wash your master's age-mate; I suppose Ulysses' hands and
+feet are very much the same now as his are, for trouble ages all of us
+dreadfully fast."
+
+On these words the old woman covered her face with her hands; she began
+to weep and made lamentation saying, "My dear child, I cannot think
+whatever I am to do with you. I am certain no one was ever more
+god-fearing than yourself, and yet Jove hates you. No one in the whole
+world ever burned him more thigh bones, nor gave him finer hecatombs
+when you prayed you might come to a green old age yourself and see your
+son grow up to take after you: yet see how he has prevented you alone
+from ever getting back to your own home. I have no doubt the women in
+some foreign palace which Ulysses has got to are gibing at him as all
+these sluts here have been gibing at you. I do not wonder at your
+not choosing to let them wash you after the manner in which they have
+insulted you; I will wash your feet myself gladly enough, as Penelope
+has said that I am to do so; I will wash them both for Penelope's
+sake and for your own, for you have raised the most lively feelings of
+compassion in my mind; and let me say this moreover, which pray attend
+to; we have had all kinds of strangers in distress come here before now,
+but I make bold to say that no one ever yet came who was so like Ulysses
+in figure, voice, and feet as you are."
+
+"Those who have seen us both," answered Ulysses, "have always said we
+were wonderfully like each other, and now you have noticed it too."
+
+Then the old woman took the cauldron in which she was going to wash his
+feet, and poured plenty of cold water into it, adding hot till the bath
+was warm enough. Ulysses sat by the fire, but ere long he turned away
+from the light, for it occurred to him that when the old woman had hold
+of his leg she would recognise a certain scar which it bore, whereon the
+whole truth would come out. And indeed as soon as she began washing her
+master, she at once knew the scar as one that had been given him by
+a wild boar when he was hunting on Mt. Parnassus with his excellent
+grandfather Autolycus--who was the most accomplished thief and perjurer
+in the whole world--and with the sons of Autolycus. Mercury himself had
+endowed him with this gift, for he used to burn the thigh bones of goats
+and kids to him, so he took pleasure in his companionship. It happened
+once that Autolycus had gone to Ithaca and had found the child of his
+daughter just born. As soon as he had done supper Euryclea set the
+infant upon his knees and said, "Autolycus, you must find a name for
+your grandson; you greatly wished that you might have one."
+
+"Son-in-law and daughter," replied Autolycus, "call the child thus: I
+am highly displeased with a large number of people in one place and
+another, both men and women; so name the child 'Ulysses,' or the child
+of anger. When he grows up and comes to visit his mother's family on Mt.
+Parnassus, where my possessions lie, I will make him a present and will
+send him on his way rejoicing."
+
+Ulysses, therefore, went to Parnassus to get the presents from
+Autolycus, who with his sons shook hands with him and gave him welcome.
+His grandmother Amphithea threw her arms about him, and kissed his head,
+and both his beautiful eyes, while Autolycus desired his sons to get
+dinner ready, and they did as he told them. They brought in a five year
+old bull, flayed it, made it ready and divided it into joints; these
+they then cut carefully up into smaller pieces and spitted them; they
+roasted them sufficiently and served the portions round. Thus through
+the livelong day to the going down of the sun they feasted, and every
+man had his full share so that all were satisfied; but when the sun set
+and it came on dark, they went to bed and enjoyed the boon of sleep.
+
+When the child of morning, rosy-fingered Dawn, appeared, the sons of
+Autolycus went out with their hounds hunting, and Ulysses went too.
+They climbed the wooded slopes of Parnassus and soon reached its breezy
+upland valleys; but as the sun was beginning to beat upon the fields,
+fresh-risen from the slow still currents of Oceanus, they came to a
+mountain dell. The dogs were in front searching for the tracks of the
+beast they were chasing, and after them came the sons of Autolycus,
+among whom was Ulysses, close behind the dogs, and he had a long
+spear in his hand. Here was the lair of a huge boar among some thick
+brushwood, so dense that the wind and rain could not get through it, nor
+could the sun's rays pierce it, and the ground underneath lay thick
+with fallen leaves. The boar heard the noise of the men's feet, and the
+hounds baying on every side as the huntsmen came up to him, so he rushed
+from his lair, raised the bristles on his neck, and stood at bay with
+fire flashing from his eyes. Ulysses was the first to raise his spear
+and try to drive it into the brute, but the boar was too quick for him,
+and charged him sideways, ripping him above the knee with a gash that
+tore deep though it did not reach the bone. As for the boar, Ulysses hit
+him on the right shoulder, and the point of the spear went right through
+him, so that he fell groaning in the dust until the life went out of
+him. The sons of Autolycus busied themselves with the carcass of the
+boar, and bound Ulysses' wound; then, after saying a spell to stop the
+bleeding, they went home as fast as they could. But when Autolycus and
+his sons had thoroughly healed Ulysses, they made him some splendid
+presents, and sent him back to Ithaca with much mutual good will. When
+he got back, his father and mother were rejoiced to see him, and asked
+him all about it, and how he had hurt himself to get the scar; so he
+told them how the boar had ripped him when he was out hunting with
+Autolycus and his sons on Mt. Parnassus.
+
+As soon as Euryclea had got the scarred limb in her hands and had well
+hold of it, she recognised it and dropped the foot at once. The leg fell
+into the bath, which rang out and was overturned, so that all the water
+was spilt on the ground; Euryclea's eyes between her joy and her grief
+filled with tears, and she could not speak, but she caught Ulysses
+by the beard and said, "My dear child, I am sure you must be Ulysses
+himself, only I did not know you till I had actually touched and handled
+you."
+
+As she spoke she looked towards Penelope, as though wanting to tell her
+that her dear husband was in the house, but Penelope was unable to
+look in that direction and observe what was going on, for Minerva had
+diverted her attention; so Ulysses caught Euryclea by the throat with
+his right hand and with his left drew her close to him, and said,
+"Nurse, do you wish to be the ruin of me, you who nursed me at your own
+breast, now that after twenty years of wandering I am at last come to
+my own home again? Since it has been borne in upon you by heaven to
+recognise me, hold your tongue, and do not say a word about it to any
+one else in the house, for if you do I tell you--and it shall surely
+be--that if heaven grants me to take the lives of these suitors, I will
+not spare you, though you are my own nurse, when I am killing the other
+women."
+
+"My child," answered Euryclea, "what are you talking about? You know
+very well that nothing can either bend or break me. I will hold my
+tongue like a stone or a piece of iron; furthermore let me say, and lay
+my saying to your heart, when heaven has delivered the suitors into your
+hand, I will give you a list of the women in the house who have been
+ill-behaved, and of those who are guiltless."
+
+And Ulysses answered, "Nurse, you ought not to speak in that way; I am
+well able to form my own opinion about one and all of them; hold your
+tongue and leave everything to heaven."
+
+As he said this Euryclea left the cloister to fetch some more water, for
+the first had been all spilt; and when she had washed him and anointed
+him with oil, Ulysses drew his seat nearer to the fire to warm himself,
+and hid the scar under his rags. Then Penelope began talking to him and
+said:
+
+"Stranger, I should like to speak with you briefly about another matter.
+It is indeed nearly bed time--for those, at least, who can sleep in
+spite of sorrow. As for myself, heaven has given me a life of such
+unmeasurable woe, that even by day when I am attending to my duties and
+looking after the servants, I am still weeping and lamenting during the
+whole time; then, when night comes, and we all of us go to bed, I lie
+awake thinking, and my heart becomes a prey to the most incessant and
+cruel tortures. As the dun nightingale, daughter of Pandareus, sings in
+the early spring from her seat in shadiest covert hid, and with many
+a plaintive trill pours out the tale how by mishap she killed her own
+child Itylus, son of king Zethus, even so does my mind toss and turn in
+its uncertainty whether I ought to stay with my son here, and safeguard
+my substance, my bondsmen, and the greatness of my house, out of regard
+to public opinion and the memory of my late husband, or whether it is
+not now time for me to go with the best of these suitors who are wooing
+me and making me such magnificent presents. As long as my son was still
+young, and unable to understand, he would not hear of my leaving my
+husband's house, but now that he is full grown he begs and prays me to
+do so, being incensed at the way in which the suitors are eating up his
+property. Listen, then, to a dream that I have had and interpret it for
+me if you can. I have twenty geese about the house that eat mash out
+of a trough, {155} and of which I am exceedingly fond. I dreamed that a
+great eagle came swooping down from a mountain, and dug his curved beak
+into the neck of each of them till he had killed them all. Presently
+he soared off into the sky, and left them lying dead about the yard;
+whereon I wept in my dream till all my maids gathered round me, so
+piteously was I grieving because the eagle had killed my geese. Then he
+came back again, and perching on a projecting rafter spoke to me with
+human voice, and told me to leave off crying. 'Be of good courage,' he
+said, 'daughter of Icarius; this is no dream, but a vision of good omen
+that shall surely come to pass. The geese are the suitors, and I am no
+longer an eagle, but your own husband, who am come back to you, and who
+will bring these suitors to a disgraceful end.' On this I woke, and when
+I looked out I saw my geese at the trough eating their mash as usual."
+
+"This dream, Madam," replied Ulysses, "can admit but of one
+interpretation, for had not Ulysses himself told you how it shall be
+fulfilled? The death of the suitors is portended, and not one single one
+of them will escape."
+
+And Penelope answered, "Stranger, dreams are very curious and
+unaccountable things, and they do not by any means invariably come true.
+There are two gates through which these unsubstantial fancies proceed;
+the one is of horn, and the other ivory. Those that come through
+the gate of ivory are fatuous, but those from the gate of horn mean
+something to those that see them. I do not think, however, that my own
+dream came through the gate of horn, though I and my son should be most
+thankful if it proves to have done so. Furthermore I say--and lay my
+saying to your heart--the coming dawn will usher in the ill-omened day
+that is to sever me from the house of Ulysses, for I am about to hold a
+tournament of axes. My husband used to set up twelve axes in the court,
+one in front of the other, like the stays upon which a ship is built;
+he would then go back from them and shoot an arrow through the whole
+twelve. I shall make the suitors try to do the same thing, and whichever
+of them can string the bow most easily, and send his arrow through all
+the twelve axes, him will I follow, and quit this house of my lawful
+husband, so goodly and so abounding in wealth. But even so, I doubt not
+that I shall remember it in my dreams."
+
+Then Ulysses answered, "Madam, wife of Ulysses, you need not defer your
+tournament, for Ulysses will return ere ever they can string the bow,
+handle it how they will, and send their arrows through the iron."
+
+To this Penelope said, "As long, sir, as you will sit here and talk
+to me, I can have no desire to go to bed. Still, people cannot do
+permanently without sleep, and heaven has appointed us dwellers on earth
+a time for all things. I will therefore go upstairs and recline upon
+that couch which I have never ceased to flood with my tears from the day
+Ulysses set out for the city with a hateful name."
+
+She then went upstairs to her own room, not alone, but attended by her
+maidens, and when there, she lamented her dear husband till Minerva shed
+sweet sleep over her eyelids.
+
+
+Book XX
+
+ULYSSES CANNOT SLEEP--PENELOPE'S PRAYER TO DIANA--THE TWO SIGNS FROM
+HEAVEN--EUMAEUS AND PHILOETIUS ARRIVE--THE SUITORS DINE--CTESIPPUS
+THROWS AN OX'S FOOT AT ULYSSES--THEOCLYMENUS FORETELLS DISASTER AND
+LEAVES THE HOUSE.
+
+Ulysses slept in the cloister upon an undressed bullock's hide, on the
+top of which he threw several skins of the sheep the suitors had eaten,
+and Eurynome {156} threw a cloak over him after he had laid himself
+down. There, then, Ulysses lay wakefully brooding upon the way in which
+he should kill the suitors; and by and by, the women who had been in the
+habit of misconducting themselves with them, left the house giggling and
+laughing with one another. This made Ulysses very angry, and he doubted
+whether to get up and kill every single one of them then and there, or
+to let them sleep one more and last time with the suitors. His heart
+growled within him, and as a bitch with puppies growls and shows her
+teeth when she sees a stranger, so did his heart growl with anger at
+the evil deeds that were being done: but he beat his breast and said,
+"Heart, be still, you had worse than this to bear on the day when the
+terrible Cyclops ate your brave companions; yet you bore it in silence
+till your cunning got you safe out of the cave, though you made sure of
+being killed."
+
+Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side and then on the other, that he
+may get it cooked as soon as possible, even so did he turn himself about
+from side to side, thinking all the time how, single handed as he was,
+he should contrive to kill so large a body of men as the wicked suitors.
+But by and by Minerva came down from heaven in the likeness of a woman,
+and hovered over his head saying, "My poor unhappy man, why do you lie
+awake in this way? This is your house: your wife is safe inside it, and
+so is your son who is just such a young man as any father may be proud
+of."
+
+"Goddess," answered Ulysses, "all that you have said is true, but I am
+in some doubt as to how I shall be able to kill these wicked suitors
+single handed, seeing what a number of them there always are. And there
+is this further difficulty, which is still more considerable. Supposing
+that with Jove's and your assistance I succeed in killing them, I must
+ask you to consider where I am to escape to from their avengers when it
+is all over."
+
+"For shame," replied Minerva, "why, any one else would trust a worse
+ally than myself, even though that ally were only a mortal and less wise
+than I am. Am I not a goddess, and have I not protected you throughout
+in all your troubles? I tell you plainly that even though there were
+fifty bands of men surrounding us and eager to kill us, you should take
+all their sheep and cattle, and drive them away with you. But go to
+sleep; it is a very bad thing to lie awake all night, and you shall be
+out of your troubles before long."
+
+As she spoke she shed sleep over his eyes, and then went back to
+Olympus.
+
+While Ulysses was thus yielding himself to a very deep slumber that
+eased the burden of his sorrows, his admirable wife awoke, and sitting
+up in her bed began to cry. When she had relieved herself by weeping she
+prayed to Diana saying, "Great Goddess Diana, daughter of Jove, drive an
+arrow into my heart and slay me; or let some whirlwind snatch me up and
+bear me through paths of darkness till it drop me into the mouths
+of over-flowing Oceanus, as it did the daughters of Pandareus. The
+daughters of Pandareus lost their father and mother, for the gods killed
+them, so they were left orphans. But Venus took care of them, and fed
+them on cheese, honey, and sweet wine. Juno taught them to excel all
+women in beauty of form and understanding; Diana gave them an imposing
+presence, and Minerva endowed them with every kind of accomplishment;
+but one day when Venus had gone up to Olympus to see Jove about getting
+them married (for well does he know both what shall happen and what
+not happen to every one) the storm winds came and spirited them away to
+become handmaids to the dread Erinyes. Even so I wish that the gods who
+live in heaven would hide me from mortal sight, or that fair Diana might
+strike me, for I would fain go even beneath the sad earth if I might
+do so still looking towards Ulysses only, and without having to yield
+myself to a worse man than he was. Besides, no matter how much people
+may grieve by day, they can put up with it so long as they can sleep at
+night, for when the eyes are closed in slumber people forget good and
+ill alike; whereas my misery haunts me even in my dreams. This very
+night methought there was one lying by my side who was like Ulysses as
+he was when he went away with his host, and I rejoiced, for I believed
+that it was no dream, but the very truth itself."
+
+On this the day broke, but Ulysses heard the sound of her weeping, and
+it puzzled him, for it seemed as though she already knew him and was by
+his side. Then he gathered up the cloak and the fleeces on which he had
+lain, and set them on a seat in the cloister, but he took the bullock's
+hide out into the open. He lifted up his hands to heaven, and prayed,
+saying "Father Jove, since you have seen fit to bring me over land and
+sea to my own home after all the afflictions you have laid upon me, give
+me a sign out of the mouth of some one or other of those who are now
+waking within the house, and let me have another sign of some kind from
+outside."
+
+Thus did he pray. Jove heard his prayer and forthwith thundered high
+up among the clouds from the splendour of Olympus, and Ulysses was glad
+when he heard it. At the same time within the house, a miller-woman from
+hard by in the mill room lifted up her voice and gave him another sign.
+There were twelve miller-women whose business it was to grind wheat and
+barley which are the staff of life. The others had ground their task and
+had gone to take their rest, but this one had not yet finished, for
+she was not so strong as they were, and when she heard the thunder she
+stopped grinding and gave the sign to her master. "Father Jove," said
+she, "you, who rule over heaven and earth, you have thundered from a
+clear sky without so much as a cloud in it, and this means something for
+somebody; grant the prayer, then, of me your poor servant who calls
+upon you, and let this be the very last day that the suitors dine in the
+house of Ulysses. They have worn me out with labour of grinding meal for
+them, and I hope they may never have another dinner anywhere at all."
+
+Ulysses was glad when he heard the omens conveyed to him by the woman's
+speech, and by the thunder, for he knew they meant that he should avenge
+himself on the suitors.
+
+Then the other maids in the house rose and lit the fire on the hearth;
+Telemachus also rose and put on his clothes. He girded his sword about
+his shoulder, bound his sandals on to his comely feet, and took a
+doughty spear with a point of sharpened bronze; then he went to the
+threshold of the cloister and said to Euryclea, "Nurse, did you make the
+stranger comfortable both as regards bed and board, or did you let him
+shift for himself?--for my mother, good woman though she is, has a
+way of paying great attention to second-rate people, and of neglecting
+others who are in reality much better men."
+
+"Do not find fault child," said Euryclea, "when there is no one to find
+fault with. The stranger sat and drank his wine as long as he liked:
+your mother did ask him if he would take any more bread and he said he
+would not. When he wanted to go to bed she told the servants to make one
+for him, but he said he was such a wretched outcast that he would not
+sleep on a bed and under blankets; he insisted on having an undressed
+bullock's hide and some sheepskins put for him in the cloister and I
+threw a cloak over him myself." {157}
+
+Then Telemachus went out of the court to the place where the Achaeans
+were meeting in assembly; he had his spear in his hand, and he was not
+alone, for his two dogs went with him. But Euryclea called the maids and
+said, "Come, wake up; set about sweeping the cloisters and sprinkling
+them with water to lay the dust; put the covers on the seats; wipe down
+the tables, some of you, with a wet sponge; clean out the mixing-jugs
+and the cups, and go for water from the fountain at once; the suitors
+will be here directly; they will be here early, for it is a feast day."
+
+Thus did she speak, and they did even as she had said: twenty of them
+went to the fountain for water, and the others set themselves busily to
+work about the house. The men who were in attendance on the suitors also
+came up and began chopping firewood. By and by the women returned from
+the fountain, and the swineherd came after them with the three best pigs
+he could pick out. These he let feed about the premises, and then he
+said good-humouredly to Ulysses, "Stranger, are the suitors treating you
+any better now, or are they as insolent as ever?"
+
+"May heaven," answered Ulysses, "requite to them the wickedness with
+which they deal high-handedly in another man's house without any sense
+of shame."
+
+Thus did they converse; meanwhile Melanthius the goatherd came up, for
+he too was bringing in his best goats for the suitors' dinner; and he
+had two shepherds with him. They tied the goats up under the gatehouse,
+and then Melanthius began gibing at Ulysses. "Are you still here,
+stranger," said he, "to pester people by begging about the house? Why
+can you not go elsewhere? You and I shall not come to an understanding
+before we have given each other a taste of our fists. You beg without
+any sense of decency: are there not feasts elsewhere among the Achaeans,
+as well as here?"
+
+Ulysses made no answer, but bowed his head and brooded. Then a third
+man, Philoetius, joined them, who was bringing in a barren heifer and
+some goats. These were brought over by the boatmen who are there to take
+people over when any one comes to them. So Philoetius made his heifer
+and his goats secure under the gatehouse, and then went up to the
+swineherd. "Who, Swineherd," said he, "is this stranger that is lately
+come here? Is he one of your men? What is his family? Where does he come
+from? Poor fellow, he looks as if he had been some great man, but the
+gods give sorrow to whom they will--even to kings if it so pleases
+them."
+
+As he spoke he went up to Ulysses and saluted him with his right hand;
+"Good day to you, father stranger," said he, "you seem to be very poorly
+off now, but I hope you will have better times by and by. Father Jove,
+of all gods you are the most malicious. We are your own children, yet
+you show us no mercy in all our misery and afflictions. A sweat came
+over me when I saw this man, and my eyes filled with tears, for he
+reminds me of Ulysses, who I fear is going about in just such rags as
+this man's are, if indeed he is still among the living. If he is already
+dead and in the house of Hades, then, alas! for my good master, who made
+me his stockman when I was quite young among the Cephallenians, and now
+his cattle are countless; no one could have done better with them than I
+have, for they have bred like ears of corn; nevertheless I have to keep
+bringing them in for others to eat, who take no heed to his son though
+he is in the house, and fear not the wrath of heaven, but are already
+eager to divide Ulysses' property among them because he has been away so
+long. I have often thought--only it would not be right while his son
+is living--of going off with the cattle to some foreign country; bad as
+this would be, it is still harder to stay here and be ill-treated about
+other people's herds. My position is intolerable, and I should long
+since have run away and put myself under the protection of some other
+chief, only that I believe my poor master will yet return, and send all
+these suitors flying out of the house."
+
+"Stockman," answered Ulysses, "you seem to be a very well-disposed
+person, and I can see that you are a man of sense. Therefore I will tell
+you, and will confirm my words with an oath. By Jove, the chief of all
+gods, and by that hearth of Ulysses to which I am now come, Ulysses
+shall return before you leave this place, and if you are so minded you
+shall see him killing the suitors who are now masters here."
+
+"If Jove were to bring this to pass," replied the stockman, "you should
+see how I would do my very utmost to help him."
+
+And in like manner Eumaeus prayed that Ulysses might return home.
+
+Thus did they converse. Meanwhile the suitors were hatching a plot to
+murder Telemachus: but a bird flew near them on their left hand--an
+eagle with a dove in its talons. On this Amphinomus said, "My friends,
+this plot of ours to murder Telemachus will not succeed; let us go to
+dinner instead."
+
+The others assented, so they went inside and laid their cloaks on the
+benches and seats. They sacrificed the sheep, goats, pigs, and the
+heifer, and when the inward meats were cooked they served them round.
+They mixed the wine in the mixing-bowls, and the swineherd gave every
+man his cup, while Philoetius handed round the bread in the bread
+baskets, and Melanthius poured them out their wine. Then they laid their
+hands upon the good things that were before them.
+
+Telemachus purposely made Ulysses sit in the part of the cloister that
+was paved with stone; {158} he gave him a shabby looking seat at a
+little table to himself, and had his portion of the inward meats brought
+to him, with his wine in a gold cup. "Sit there," said he, "and drink
+your wine among the great people. I will put a stop to the gibes and
+blows of the suitors, for this is no public house, but belongs to
+Ulysses, and has passed from him to me. Therefore, suitors, keep your
+hands and your tongues to yourselves, or there will be mischief."
+
+The suitors bit their lips, and marvelled at the boldness of his speech;
+then Antinous said, "We do not like such language but we will put up
+with it, for Telemachus is threatening us in good earnest. If Jove had
+let us we should have put a stop to his brave talk ere now."
+
+Thus spoke Antinous, but Telemachus heeded him not. Meanwhile the
+heralds were bringing the holy hecatomb through the city, and the
+Achaeans gathered under the shady grove of Apollo.
+
+Then they roasted the outer meat, drew it off the spits, gave every man
+his portion, and feasted to their heart's content; those who waited
+at table gave Ulysses exactly the same portion as the others had, for
+Telemachus had told them to do so.
+
+But Minerva would not let the suitors for one moment drop their
+insolence, for she wanted Ulysses to become still more bitter against
+them. Now there happened to be among them a ribald fellow, whose name
+was Ctesippus, and who came from Same. This man, confident in his
+great wealth, was paying court to the wife of Ulysses, and said to the
+suitors, "Hear what I have to say. The stranger has already had as
+large a portion as any one else; this is well, for it is not right nor
+reasonable to ill-treat any guest of Telemachus who comes here. I
+will, however, make him a present on my own account, that he may have
+something to give to the bath-woman, or to some other of Ulysses'
+servants."
+
+As he spoke he picked up a heifer's foot from the meat-basket in which
+it lay, and threw it at Ulysses, but Ulysses turned his head a little
+aside, and avoided it, smiling grimly Sardinian fashion {159} as he did
+so, and it hit the wall, not him. On this Telemachus spoke fiercely to
+Ctesippus, "It is a good thing for you," said he, "that the stranger
+turned his head so that you missed him. If you had hit him I should have
+run you through with my spear, and your father would have had to see
+about getting you buried rather than married in this house. So let me
+have no more unseemly behaviour from any of you, for I am grown up
+now to the knowledge of good and evil and understand what is going on,
+instead of being the child that I have been heretofore. I have long seen
+you killing my sheep and making free with my corn and wine: I have put
+up with this, for one man is no match for many, but do me no further
+violence. Still, if you wish to kill me, kill me; I would far rather die
+than see such disgraceful scenes day after day--guests insulted, and men
+dragging the women servants about the house in an unseemly way."
+
+They all held their peace till at last Agelaus son of Damastor said, "No
+one should take offence at what has just been said, nor gainsay it, for
+it is quite reasonable. Leave off, therefore, ill-treating the stranger,
+or any one else of the servants who are about the house; I would say,
+however, a friendly word to Telemachus and his mother, which I trust may
+commend itself to both. 'As long,' I would say, 'as you had ground for
+hoping that Ulysses would one day come home, no one could complain of
+your waiting and suffering {160} the suitors to be in your house. It
+would have been better that he should have returned, but it is now
+sufficiently clear that he will never do so; therefore talk all this
+quietly over with your mother, and tell her to marry the best man,
+and the one who makes her the most advantageous offer. Thus you will
+yourself be able to manage your own inheritance, and to eat and drink
+in peace, while your mother will look after some other man's house, not
+yours.'"
+
+To this Telemachus answered, "By Jove, Agelaus, and by the sorrows of my
+unhappy father, who has either perished far from Ithaca, or is wandering
+in some distant land, I throw no obstacles in the way of my mother's
+marriage; on the contrary I urge her to choose whomsoever she will, and
+I will give her numberless gifts into the bargain, but I dare not insist
+point blank that she shall leave the house against her own wishes.
+Heaven forbid that I should do this."
+
+Minerva now made the suitors fall to laughing immoderately, and set
+their wits wandering; but they were laughing with a forced laughter.
+Their meat became smeared with blood; their eyes filled with tears,
+and their hearts were heavy with forebodings. Theoclymenus saw this
+and said, "Unhappy men, what is it that ails you? There is a shroud
+of darkness drawn over you from head to foot, your cheeks are wet with
+tears; the air is alive with wailing voices; the walls and roof-beams
+drip blood; the gate of the cloisters and the court beyond them are full
+of ghosts trooping down into the night of hell; the sun is blotted out
+of heaven, and a blighting gloom is over all the land."
+
+Thus did he speak, and they all of them laughed heartily. Eurymachus
+then said, "This stranger who has lately come here has lost his senses.
+Servants, turn him out into the streets, since he finds it so dark
+here."
+
+But Theoclymenus said, "Eurymachus, you need not send any one with me.
+I have eyes, ears, and a pair of feet of my own, to say nothing of an
+understanding mind. I will take these out of the house with me, for
+I see mischief overhanging you, from which not one of you men who are
+insulting people and plotting ill deeds in the house of Ulysses will be
+able to escape."
+
+He left the house as he spoke, and went back to Piraeus who gave him
+welcome, but the suitors kept looking at one another and provoking
+Telemachus by laughing at the strangers. One insolent fellow said to
+him, "Telemachus, you are not happy in your guests; first you have this
+importunate tramp, who comes begging bread and wine and has no skill
+for work or for hard fighting, but is perfectly useless, and now here is
+another fellow who is setting himself up as a prophet. Let me persuade
+you, for it will be much better to put them on board ship and send them
+off to the Sicels to sell for what they will bring."
+
+Telemachus gave him no heed, but sate silently watching his father,
+expecting every moment that he would begin his attack upon the suitors.
+
+Meanwhile the daughter of Icarius, wise Penelope, had had a rich seat
+placed for her facing the court and cloisters, so that she could hear
+what every one was saying. The dinner indeed had been prepared amid much
+merriment; it had been both good and abundant, for they had sacrificed
+many victims; but the supper was yet to come, and nothing can be
+conceived more gruesome than the meal which a goddess and a brave man
+were soon to lay before them--for they had brought their doom upon
+themselves.
+
+
+Book XXI
+
+THE TRIAL OF THE AXES, DURING WHICH ULYSSES REVEALS HIMSELF TO EUMAEUS
+AND PHILOETIUS
+
+Minerva now put it in Penelope's mind to make the suitors try their
+skill with the bow and with the iron axes, in contest among themselves,
+as a means of bringing about their destruction. She went upstairs and
+got the store-room key, which was made of bronze and had a handle of
+ivory; she then went with her maidens into the store-room at the end of
+the house, where her husband's treasures of gold, bronze, and wrought
+iron were kept, and where was also his bow, and the quiver full of
+deadly arrows that had been given him by a friend whom he had met in
+Lacedaemon--Iphitus the son of Eurytus. The two fell in with one another
+in Messene at the house of Ortilochus, where Ulysses was staying in
+order to recover a debt that was owing from the whole people; for the
+Messenians had carried off three hundred sheep from Ithaca, and had
+sailed away with them and with their shepherds. In quest of these
+Ulysses took a long journey while still quite young, for his father and
+the other chieftains sent him on a mission to recover them. Iphitus had
+gone there also to try and get back twelve brood mares that he had lost,
+and the mule foals that were running with them. These mares were the
+death of him in the end, for when he went to the house of Jove's son,
+mighty Hercules, who performed such prodigies of valour, Hercules to his
+shame killed him, though he was his guest, for he feared not heaven's
+vengeance, nor yet respected his own table which he had set before
+Iphitus, but killed him in spite of everything, and kept the mares
+himself. It was when claiming these that Iphitus met Ulysses, and gave
+him the bow which mighty Eurytus had been used to carry, and which on
+his death had been left by him to his son. Ulysses gave him in return
+a sword and a spear, and this was the beginning of a fast friendship,
+although they never visited at one another's houses, for Jove's son
+Hercules killed Iphitus ere they could do so. This bow, then, given him
+by Iphitus, had not been taken with him by Ulysses when he sailed for
+Troy; he had used it so long as he had been at home, but had left it
+behind as having been a keepsake from a valued friend.
+
+Penelope presently reached the oak threshold of the store-room; the
+carpenter had planed this duly, and had drawn a line on it so as to get
+it quite straight; he had then set the door posts into it and hung the
+doors. She loosed the strap from the handle of the door, put in the key,
+and drove it straight home to shoot back the bolts that held the doors;
+{161} these flew open with a noise like a bull bellowing in a meadow,
+and Penelope stepped upon the raised platform, where the chests stood in
+which the fair linen and clothes were laid by along with fragrant herbs:
+reaching thence, she took down the bow with its bow case from the peg
+on which it hung. She sat down with it on her knees, weeping bitterly as
+she took the bow out of its case, and when her tears had relieved her,
+she went to the cloister where the suitors were, carrying the bow and
+the quiver, with the many deadly arrows that were inside it. Along
+with her came her maidens, bearing a chest that contained much iron
+and bronze which her husband had won as prizes. When she reached the
+suitors, she stood by one of the bearing-posts supporting the roof of
+the cloister, holding a veil before her face, and with a maid on either
+side of her. Then she said:
+
+"Listen to me you suitors, who persist in abusing the hospitality of
+this house because its owner has been long absent, and without other
+pretext than that you want to marry me; this, then, being the prize that
+you are contending for, I will bring out the mighty bow of Ulysses, and
+whomsoever of you shall string it most easily and send his arrow through
+each one of twelve axes, him will I follow and quit this house of my
+lawful husband, so goodly, and so abounding in wealth. But even so I
+doubt not that I shall remember it in my dreams."
+
+As she spoke, she told Eumaeus to set the bow and the pieces of iron
+before the suitors, and Eumaeus wept as he took them to do as she had
+bidden him. Hard by, the stockman wept also when he saw his master's
+bow, but Antinous scolded them. "You country louts," said he, "silly
+simpletons; why should you add to the sorrows of your mistress by crying
+in this way? She has enough to grieve her in the loss of her husband;
+sit still, therefore, and eat your dinners in silence, or go outside if
+you want to cry, and leave the bow behind you. We suitors shall have to
+contend for it with might and main, for we shall find it no light matter
+to string such a bow as this is. There is not a man of us all who is
+such another as Ulysses; for I have seen him and remember him, though I
+was then only a child."
+
+This was what he said, but all the time he was expecting to be able to
+string the bow and shoot through the iron, whereas in fact he was to
+be the first that should taste of the arrows from the hands of Ulysses,
+whom he was dishonouring in his own house--egging the others on to do so
+also.
+
+Then Telemachus spoke. "Great heavens!" he exclaimed, "Jove must have
+robbed me of my senses. Here is my dear and excellent mother saying she
+will quit this house and marry again, yet I am laughing and enjoying
+myself as though there were nothing happening. But, suitors, as the
+contest has been agreed upon, let it go forward. It is for a woman whose
+peer is not to be found in Pylos, Argos, or Mycene, nor yet in Ithaca
+nor on the mainland. You know this as well as I do; what need have I to
+speak in praise of my mother? Come on, then, make no excuses for delay,
+but let us see whether you can string the bow or no. I too will make
+trial of it, for if I can string it and shoot through the iron, I shall
+not suffer my mother to quit this house with a stranger, not if I can
+win the prizes which my father won before me."
+
+As he spoke he sprang from his seat, threw his crimson cloak from him,
+and took his sword from his shoulder. First he set the axes in a row, in
+a long groove which he had dug for them, and had made straight by line.
+{162} Then he stamped the earth tight round them, and everyone was
+surprised when they saw him set them up so orderly, though he had never
+seen anything of the kind before. This done, he went on to the pavement
+to make trial of the bow; thrice did he tug at it, trying with all his
+might to draw the string, and thrice he had to leave off, though he had
+hoped to string the bow and shoot through the iron. He was trying for
+the fourth time, and would have strung it had not Ulysses made a sign to
+check him in spite of all his eagerness. So he said:
+
+"Alas! I shall either be always feeble and of no prowess, or I am too
+young, and have not yet reached my full strength so as to be able
+to hold my own if any one attacks me. You others, therefore, who are
+stronger than I, make trial of the bow and get this contest settled."
+
+On this he put the bow down, letting it lean against the door [that led
+into the house] with the arrow standing against the top of the bow. Then
+he sat down on the seat from which he had risen, and Antinous said:
+
+"Come on each of you in his turn, going towards the right from the place
+at which the cupbearer begins when he is handing round the wine."
+
+The rest agreed, and Leiodes son of Oenops was the first to rise. He
+was sacrificial priest to the suitors, and sat in the corner near the
+mixing-bowl. {163} He was the only man who hated their evil deeds and
+was indignant with the others. He was now the first to take the bow and
+arrow, so he went on to the pavement to make his trial, but he could not
+string the bow, for his hands were weak and unused to hard work, they
+therefore soon grew tired, and he said to the suitors, "My friends, I
+cannot string it; let another have it, this bow shall take the life and
+soul out of many a chief among us, for it is better to die than to live
+after having missed the prize that we have so long striven for, and
+which has brought us so long together. Some one of us is even now hoping
+and praying that he may marry Penelope, but when he has seen this bow
+and tried it, let him woo and make bridal offerings to some other woman,
+and let Penelope marry whoever makes her the best offer and whose lot it
+is to win her."
+
+On this he put the bow down, letting it lean against the door, {164}
+with the arrow standing against the tip of the bow. Then he took his
+seat again on the seat from which he had risen; and Antinous rebuked him
+saying:
+
+"Leiodes, what are you talking about? Your words are monstrous and
+intolerable; it makes me angry to listen to you. Shall, then, this bow
+take the life of many a chief among us, merely because you cannot bend
+it yourself? True, you were not born to be an archer, but there are
+others who will soon string it."
+
+Then he said to Melanthius the goatherd, "Look sharp, light a fire in
+the court, and set a seat hard by with a sheep skin on it; bring us also
+a large ball of lard, from what they have in the house. Let us warm the
+bow and grease it--we will then make trial of it again, and bring the
+contest to an end."
+
+Melanthius lit the fire, and set a seat covered with sheep skins beside
+it. He also brought a great ball of lard from what they had in the
+house, and the suitors warmed the bow and again made trial of it, but
+they were none of them nearly strong enough to string it. Nevertheless
+there still remained Antinous and Eurymachus, who were the ringleaders
+among the suitors and much the foremost among them all.
+
+Then the swineherd and the stockman left the cloisters together, and
+Ulysses followed them. When they had got outside the gates and the outer
+yard, Ulysses said to them quietly:
+
+"Stockman, and you swineherd, I have something in my mind which I am in
+doubt whether to say or no; but I think I will say it. What manner of
+men would you be to stand by Ulysses, if some god should bring him back
+here all of a sudden? Say which you are disposed to do--to side with the
+suitors, or with Ulysses?"
+
+"Father Jove," answered the stockman, "would indeed that you might so
+ordain it. If some god were but to bring Ulysses back, you should see
+with what might and main I would fight for him."
+
+In like words Eumaeus prayed to all the gods that Ulysses might return;
+when, therefore, he saw for certain what mind they were of, Ulysses
+said, "It is I, Ulysses, who am here. I have suffered much, but at last,
+in the twentieth year, I am come back to my own country. I find that you
+two alone of all my servants are glad that I should do so, for I
+have not heard any of the others praying for my return. To you two,
+therefore, will I unfold the truth as it shall be. If heaven shall
+deliver the suitors into my hands, I will find wives for both of you,
+will give you house and holding close to my own, and you shall be to me
+as though you were brothers and friends of Telemachus. I will now give
+you convincing proofs that you may know me and be assured. See, here is
+the scar from the boar's tooth that ripped me when I was out hunting on
+Mt. Parnassus with the sons of Autolycus."
+
+As he spoke he drew his rags aside from the great scar, and when they
+had examined it thoroughly, they both of them wept about Ulysses, threw
+their arms round him, and kissed his head and shoulders, while Ulysses
+kissed their hands and faces in return. The sun would have gone down
+upon their mourning if Ulysses had not checked them and said:
+
+"Cease your weeping, lest some one should come outside and see us, and
+tell those who are within. When you go in, do so separately, not both
+together; I will go first, and do you follow afterwards; let this
+moreover be the token between us; the suitors will all of them try to
+prevent me from getting hold of the bow and quiver; do you, therefore,
+Eumaeus, place it in my hands when you are carrying it about, and
+tell the women to close the doors of their apartment. If they hear any
+groaning or uproar as of men fighting about the house, they must not
+come out; they must keep quiet, and stay where they are at their work.
+And I charge you, Philoetius, to make fast the doors of the outer court,
+and to bind them securely at once."
+
+When he had thus spoken, he went back to the house and took the seat
+that he had left. Presently, his two servants followed him inside.
+
+At this moment the bow was in the hands of Eurymachus, who was warming
+it by the fire, but even so he could not string it, and he was greatly
+grieved. He heaved a deep sigh and said, "I grieve for myself and for us
+all; I grieve that I shall have to forgo the marriage, but I do not care
+nearly so much about this, for there are plenty of other women in Ithaca
+and elsewhere; what I feel most is the fact of our being so inferior to
+Ulysses in strength that we cannot string his bow. This will disgrace us
+in the eyes of those who are yet unborn."
+
+"It shall not be so, Eurymachus," said Antinous, "and you know it
+yourself. Today is the feast of Apollo throughout all the land; who can
+string a bow on such a day as this? Put it on one side--as for the axes
+they can stay where they are, for no one is likely to come to the house
+and take them away: let the cupbearer go round with his cups, that we
+may make our drink-offerings and drop this matter of the bow; we will
+tell Melanthius to bring us in some goats tomorrow--the best he has; we
+can then offer thigh bones to Apollo the mighty archer, and again make
+trial of the bow, so as to bring the contest to an end."
+
+The rest approved his words, and thereon men servants poured water over
+the hands of the guests, while pages filled the mixing-bowls with wine
+and water and handed it round after giving every man his drink-offering.
+Then, when they had made their offerings and had drunk each as much as
+he desired, Ulysses craftily said:--
+
+"Suitors of the illustrious queen, listen that I may speak even as I am
+minded. I appeal more especially to Eurymachus, and to Antinous who
+has just spoken with so much reason. Cease shooting for the present and
+leave the matter to the gods, but in the morning let heaven give victory
+to whom it will. For the moment, however, give me the bow that I may
+prove the power of my hands among you all, and see whether I still have
+as much strength as I used to have, or whether travel and neglect have
+made an end of it."
+
+This made them all very angry, for they feared he might string the bow,
+Antinous therefore rebuked him fiercely saying, "Wretched creature, you
+have not so much as a grain of sense in your whole body; you ought
+to think yourself lucky in being allowed to dine unharmed among your
+betters, without having any smaller portion served you than we others
+have had, and in being allowed to hear our conversation. No other beggar
+or stranger has been allowed to hear what we say among ourselves; the
+wine must have been doing you a mischief, as it does with all those who
+drink immoderately. It was wine that inflamed the Centaur Eurytion when
+he was staying with Peirithous among the Lapithae. When the wine had
+got into his head, he went mad and did ill deeds about the house of
+Peirithous; this angered the heroes who were there assembled, so they
+rushed at him and cut off his ears and nostrils; then they dragged him
+through the doorway out of the house, so he went away crazed, and bore
+the burden of his crime, bereft of understanding. Henceforth, therefore,
+there was war between mankind and the centaurs, but he brought it upon
+himself through his own drunkenness. In like manner I can tell you that
+it will go hardly with you if you string the bow: you will find no mercy
+from any one here, for we shall at once ship you off to king Echetus,
+who kills every one that comes near him: you will never get away alive,
+so drink and keep quiet without getting into a quarrel with men younger
+than yourself."
+
+Penelope then spoke to him. "Antinous," said she, "it is not right that
+you should ill-treat any guest of Telemachus who comes to this house.
+If the stranger should prove strong enough to string the mighty bow of
+Ulysses, can you suppose that he would take me home with him and make me
+his wife? Even the man himself can have no such idea in his mind:
+none of you need let that disturb his feasting; it would be out of all
+reason."
+
+"Queen Penelope," answered Eurymachus, "we do not suppose that this man
+will take you away with him; it is impossible; but we are afraid lest
+some of the baser sort, men or women among the Achaeans, should go
+gossiping about and say, 'These suitors are a feeble folk; they are
+paying court to the wife of a brave man whose bow not one of them was
+able to string, and yet a beggarly tramp who came to the house strung it
+at once and sent an arrow through the iron.' This is what will be said,
+and it will be a scandal against us."
+
+"Eurymachus," Penelope answered, "people who persist in eating up the
+estate of a great chieftain and dishonouring his house must not expect
+others to think well of them. Why then should you mind if men talk as
+you think they will? This stranger is strong and well-built, he says
+moreover that he is of noble birth. Give him the bow, and let us see
+whether he can string it or no. I say--and it shall surely be--that if
+Apollo vouchsafes him the glory of stringing it, I will give him a cloak
+and shirt of good wear, with a javelin to keep off dogs and robbers,
+and a sharp sword. I will also give him sandals, and will see him sent
+safely wherever he wants to go."
+
+Then Telemachus said, "Mother, I am the only man either in Ithaca or in
+the islands that are over against Elis who has the right to let any
+one have the bow or to refuse it. No one shall force me one way or the
+other, not even though I choose to make the stranger a present of the
+bow outright, and let him take it away with him. Go, then, within the
+house and busy yourself with your daily duties, your loom, your distaff,
+and the ordering of your servants. This bow is a man's matter, and mine
+above all others, for it is I who am master here."
+
+She went wondering back into the house, and laid her son's saying in her
+heart. Then going upstairs with her handmaids into her room, she mourned
+her dear husband till Minerva sent sweet sleep over her eyelids.
+
+The swineherd now took up the bow and was for taking it to Ulysses, but
+the suitors clamoured at him from all parts of the cloisters, and one of
+them said, "You idiot, where are you taking the bow to? Are you out of
+your wits? If Apollo and the other gods will grant our prayer, your own
+boarhounds shall get you into some quiet little place, and worry you to
+death."
+
+Eumaeus was frightened at the outcry they all raised, so he put the bow
+down then and there, but Telemachus shouted out at him from the other
+side of the cloisters, and threatened him saying, "Father Eumaeus,
+bring the bow on in spite of them, or young as I am I will pelt you with
+stones back to the country, for I am the better man of the two. I wish
+I was as much stronger than all the other suitors in the house as I am
+than you, I would soon send some of them off sick and sorry, for they
+mean mischief."
+
+Thus did he speak, and they all of them laughed heartily, which put them
+in a better humour with Telemachus; so Eumaeus brought the bow on and
+placed it in the hands of Ulysses. When he had done this, he called
+Euryclea apart and said to her, "Euryclea, Telemachus says you are to
+close the doors of the women's apartments. If they hear any groaning or
+uproar as of men fighting about the house, they are not to come out, but
+are to keep quiet and stay where they are at their work."
+
+Euryclea did as she was told and closed the doors of the women's
+apartments.
+
+Meanwhile Philoetius slipped quietly out and made fast the gates of
+the outer court. There was a ship's cable of byblus fibre lying in the
+gatehouse, so he made the gates fast with it and then came in again,
+resuming the seat that he had left, and keeping an eye on Ulysses, who
+had now got the bow in his hands, and was turning it every way about,
+and proving it all over to see whether the worms had been eating into
+its two horns during his absence. Then would one turn towards his
+neighbour saying, "This is some tricky old bow-fancier; either he has
+got one like it at home, or he wants to make one, in such workmanlike
+style does the old vagabond handle it."
+
+Another said, "I hope he may be no more successful in other things than
+he is likely to be in stringing this bow."
+
+But Ulysses, when he had taken it up and examined it all over, strung it
+as easily as a skilled bard strings a new peg of his lyre and makes
+the twisted gut fast at both ends. Then he took it in his right hand
+to prove the string, and it sang sweetly under his touch like the
+twittering of a swallow. The suitors were dismayed, and turned colour
+as they heard it; at that moment, moreover, Jove thundered loudly as a
+sign, and the heart of Ulysses rejoiced as he heard the omen that the
+son of scheming Saturn had sent him.
+
+He took an arrow that was lying upon the table {165}--for those
+which the Achaeans were so shortly about to taste were all inside the
+quiver--he laid it on the centre-piece of the bow, and drew the notch of
+the arrow and the string toward him, still seated on his seat. When
+he had taken aim he let fly, and his arrow pierced every one of the
+handle-holes of the axes from the first onwards till it had gone right
+through them, and into the outer courtyard. Then he said to Telemachus:
+
+"Your guest has not disgraced you, Telemachus. I did not miss what I
+aimed at, and I was not long in stringing my bow. I am still strong, and
+not as the suitors twit me with being. Now, however, it is time for
+the Achaeans to prepare supper while there is still daylight, and
+then otherwise to disport themselves with song and dance which are the
+crowning ornaments of a banquet."
+
+As he spoke he made a sign with his eyebrows, and Telemachus girded on
+his sword, grasped his spear, and stood armed beside his father's seat.
+
+
+Book XXII
+
+THE KILLING OF THE SUITORS--THE MAIDS WHO HAVE MISCONDUCTED THEMSELVES
+ARE MADE TO CLEANSE THE CLOISTERS AND ARE THEN HANGED.
+
+Then Ulysses tore off his rags, and sprang on to the broad pavement
+with his bow and his quiver full of arrows. He shed the arrows on to the
+ground at his feet and said, "The mighty contest is at an end. I will
+now see whether Apollo will vouchsafe it to me to hit another mark which
+no man has yet hit."
+
+On this he aimed a deadly arrow at Antinous, who was about to take up a
+two-handled gold cup to drink his wine and already had it in his hands.
+He had no thought of death--who amongst all the revellers would think
+that one man, however brave, would stand alone among so many and kill
+him? The arrow struck Antinous in the throat, and the point went clean
+through his neck, so that he fell over and the cup dropped from his
+hand, while a thick stream of blood gushed from his nostrils. He kicked
+the table from him and upset the things on it, so that the bread and
+roasted meats were all soiled as they fell over on to the ground. {166}
+The suitors were in an uproar when they saw that a man had been hit;
+they sprang in dismay one and all of them from their seats and looked
+everywhere towards the walls, but there was neither shield nor spear,
+and they rebuked Ulysses very angrily. "Stranger," said they, "you shall
+pay for shooting people in this way: you shall see no other contest;
+you are a doomed man; he whom you have slain was the foremost youth in
+Ithaca, and the vultures shall devour you for having killed him."
+
+Thus they spoke, for they thought that he had killed Antinous by
+mistake, and did not perceive that death was hanging over the head of
+every one of them. But Ulysses glared at them and said:
+
+"Dogs, did you think that I should not come back from Troy? You have
+wasted my substance, {167} have forced my women servants to lie with
+you, and have wooed my wife while I was still living. You have feared
+neither God nor man, and now you shall die."
+
+They turned pale with fear as he spoke, and every man looked round about
+to see whither he might fly for safety, but Eurymachus alone spoke.
+
+"If you are Ulysses," said he, "then what you have said is just. We have
+done much wrong on your lands and in your house. But Antinous who was
+the head and front of the offending lies low already. It was all his
+doing. It was not that he wanted to marry Penelope; he did not so much
+care about that; what he wanted was something quite different, and Jove
+has not vouchsafed it to him; he wanted to kill your son and to be chief
+man in Ithaca. Now, therefore, that he has met the death which was his
+due, spare the lives of your people. We will make everything good among
+ourselves, and pay you in full for all that we have eaten and drunk.
+Each one of us shall pay you a fine worth twenty oxen, and we will keep
+on giving you gold and bronze till your heart is softened. Until we have
+done this no one can complain of your being enraged against us."
+
+Ulysses again glared at him and said, "Though you should give me all
+that you have in the world both now and all that you ever shall have,
+I will not stay my hand till I have paid all of you in full. You must
+fight, or fly for your lives; and fly, not a man of you shall."
+
+Their hearts sank as they heard him, but Eurymachus again spoke saying:
+
+"My friends, this man will give us no quarter. He will stand where he
+is and shoot us down till he has killed every man among us. Let us then
+show fight; draw your swords, and hold up the tables to shield you
+from his arrows. Let us have at him with a rush, to drive him from the
+pavement and doorway: we can then get through into the town, and raise
+such an alarm as shall soon stay his shooting."
+
+As he spoke he drew his keen blade of bronze, sharpened on both sides,
+and with a loud cry sprang towards Ulysses, but Ulysses instantly shot
+an arrow into his breast that caught him by the nipple and fixed itself
+in his liver. He dropped his sword and fell doubled up over his table.
+The cup and all the meats went over on to the ground as he smote the
+earth with his forehead in the agonies of death, and he kicked the stool
+with his feet until his eyes were closed in darkness.
+
+Then Amphinomus drew his sword and made straight at Ulysses to try and
+get him away from the door; but Telemachus was too quick for him, and
+struck him from behind; the spear caught him between the shoulders and
+went right through his chest, so that he fell heavily to the ground and
+struck the earth with his forehead. Then Telemachus sprang away from
+him, leaving his spear still in the body, for he feared that if he
+stayed to draw it out, some one of the Achaeans might come up and hack
+at him with his sword, or knock him down, so he set off at a run, and
+immediately was at his father's side. Then he said:
+
+"Father, let me bring you a shield, two spears, and a brass helmet for
+your temples. I will arm myself as well, and will bring other armour for
+the swineherd and the stockman, for we had better be armed."
+
+"Run and fetch them," answered Ulysses, "while my arrows hold out, or
+when I am alone they may get me away from the door."
+
+Telemachus did as his father said, and went off to the store room where
+the armour was kept. He chose four shields, eight spears, and four brass
+helmets with horse-hair plumes. He brought them with all speed to his
+father, and armed himself first, while the stockman and the swineherd
+also put on their armour, and took their places near Ulysses. Meanwhile
+Ulysses, as long as his arrows lasted, had been shooting the suitors one
+by one, and they fell thick on one another: when his arrows gave out, he
+set the bow to stand against the end wall of the house by the door post,
+and hung a shield four hides thick about his shoulders; on his comely
+head he set his helmet, well wrought with a crest of horse-hair that
+nodded menacingly above it, {168} and he grasped two redoubtable
+bronze-shod spears.
+
+Now there was a trap door {169} on the wall, while at one end of the
+pavement {170} there was an exit leading to a narrow passage, and this
+exit was closed by a well-made door. Ulysses told Philoetius to stand by
+this door and guard it, for only one person could attack it at a time.
+But Agelaus shouted out, "Cannot some one go up to the trap door and
+tell the people what is going on? Help would come at once, and we should
+soon make an end of this man and his shooting."
+
+"This may not be, Agelaus," answered Melanthius, "the mouth of the
+narrow passage is dangerously near the entrance to the outer court. One
+brave man could prevent any number from getting in. But I know what I
+will do, I will bring you arms from the store-room, for I am sure it is
+there that Ulysses and his son have put them."
+
+On this the goatherd Melanthius went by back passages to the store-room
+of Ulysses' house. There he chose twelve shields, with as many helmets
+and spears, and brought them back as fast as he could to give them to
+the suitors. Ulysses' heart began to fail him when he saw the suitors
+{171} putting on their armour and brandishing their spears. He saw the
+greatness of the danger, and said to Telemachus, "Some one of the women
+inside is helping the suitors against us, or it may be Melanthius."
+
+Telemachus answered, "The fault, father, is mine, and mine only; I left
+the store room door open, and they have kept a sharper look out than
+I have. Go, Eumaeus, put the door to, and see whether it is one of the
+women who is doing this, or whether, as I suspect, it is Melanthius the
+son of Dolius."
+
+Thus did they converse. Meanwhile Melanthius was again going to the
+store room to fetch more armour, but the swineherd saw him and said to
+Ulysses who was beside him, "Ulysses, noble son of Laertes, it is that
+scoundrel Melanthius, just as we suspected, who is going to the store
+room. Say, shall I kill him, if I can get the better of him, or shall
+I bring him here that you may take your own revenge for all the many
+wrongs that he has done in your house?"
+
+Ulysses answered, "Telemachus and I will hold these suitors in check, no
+matter what they do; go back both of you and bind Melanthius' hands and
+feet behind him. Throw him into the store room and make the door fast
+behind you; then fasten a noose about his body, and string him close up
+to the rafters from a high bearing-post, {172} that he may linger on in
+an agony."
+
+Thus did he speak, and they did even as he had said; they went to the
+store room, which they entered before Melanthius saw them, for he was
+busy searching for arms in the innermost part of the room, so the
+two took their stand on either side of the door and waited. By and by
+Melanthius came out with a helmet in one hand, and an old dry-rotted
+shield in the other, which had been borne by Laertes when he was young,
+but which had been long since thrown aside, and the straps had become
+unsewn; on this the two seized him, dragged him back by the hair, and
+threw him struggling to the ground. They bent his hands and feet well
+behind his back, and bound them tight with a painful bond as Ulysses had
+told them; then they fastened a noose about his body and strung him up
+from a high pillar till he was close up to the rafters, and over him did
+you then vaunt, O swineherd Eumaeus saying, "Melanthius, you will pass
+the night on a soft bed as you deserve. You will know very well when
+morning comes from the streams of Oceanus, and it is time for you to be
+driving in your goats for the suitors to feast on."
+
+There, then, they left him in very cruel bondage, and having put on
+their armour they closed the door behind them and went back to take
+their places by the side of Ulysses; whereon the four men stood in the
+cloister, fierce and full of fury; nevertheless, those who were in the
+body of the court were still both brave and many. Then Jove's daughter
+Minerva came up to them, having assumed the voice and form of Mentor.
+Ulysses was glad when he saw her and said, "Mentor, lend me your help,
+and forget not your old comrade, nor the many good turns he has done
+you. Besides, you are my age-mate."
+
+But all the time he felt sure it was Minerva, and the suitors from the
+other side raised an uproar when they saw her. Agelaus was the first to
+reproach her. "Mentor," he cried, "do not let Ulysses beguile you into
+siding with him and fighting the suitors. This is what we will do: when
+we have killed these people, father and son, we will kill you too. You
+shall pay for it with your head, and when we have killed you, we will
+take all you have, in doors or out, and bring it into hotch-pot with
+Ulysses' property; we will not let your sons live in your house, nor
+your daughters, nor shall your widow continue to live in the city of
+Ithaca."
+
+This made Minerva still more furious, so she scolded Ulysses very
+angrily. {173} "Ulysses," said she, "your strength and prowess are no
+longer what they were when you fought for nine long years among the
+Trojans about the noble lady Helen. You killed many a man in those days,
+and it was through your stratagem that Priam's city was taken. How comes
+it that you are so lamentably less valiant now that you are on your own
+ground, face to face with the suitors in your own house? Come on, my
+good fellow, stand by my side and see how Mentor, son of Alcimus shall
+fight your foes and requite your kindnesses conferred upon him."
+
+But she would not give him full victory as yet, for she wished still
+further to prove his own prowess and that of his brave son, so she flew
+up to one of the rafters in the roof of the cloister and sat upon it in
+the form of a swallow.
+
+Meanwhile Agelaus son of Damastor, Eurynomus, Amphimedon, Demoptolemus,
+Pisander, and Polybus son of Polyctor bore the brunt of the fight upon
+the suitors' side; of all those who were still fighting for their lives
+they were by far the most valiant, for the others had already fallen
+under the arrows of Ulysses. Agelaus shouted to them and said, "My
+friends, he will soon have to leave off, for Mentor has gone away after
+having done nothing for him but brag. They are standing at the doors
+unsupported. Do not aim at him all at once, but six of you throw your
+spears first, and see if you cannot cover yourselves with glory by
+killing him. When he has fallen we need not be uneasy about the others."
+
+They threw their spears as he bade them, but Minerva made them all of
+no effect. One hit the door post; another went against the door; the
+pointed shaft of another struck the wall; and as soon as they had
+avoided all the spears of the suitors Ulysses said to his own men, "My
+friends, I should say we too had better let drive into the middle of
+them, or they will crown all the harm they have done us by killing us
+outright."
+
+They therefore aimed straight in front of them and threw their spears.
+Ulysses killed Demoptolemus, Telemachus Euryades, Eumaeus Elatus, while
+the stockman killed Pisander. These all bit the dust, and as the others
+drew back into a corner Ulysses and his men rushed forward and regained
+their spears by drawing them from the bodies of the dead.
+
+The suitors now aimed a second time, but again Minerva made their
+weapons for the most part without effect. One hit a bearing-post of
+the cloister; another went against the door; while the pointed shaft of
+another struck the wall. Still, Amphimedon just took a piece of the
+top skin from off Telemachus's wrist, and Ctesippus managed to graze
+Eumaeus's shoulder above his shield; but the spear went on and fell
+to the ground. Then Ulysses and his men let drive into the crowd of
+suitors. Ulysses hit Eurydamas, Telemachus Amphimedon, and Eumaeus
+Polybus. After this the stockman hit Ctesippus in the breast, and
+taunted him saying, "Foul-mouthed son of Polytherses, do not be so
+foolish as to talk wickedly another time, but let heaven direct your
+speech, for the gods are far stronger than men. I make you a present of
+this advice to repay you for the foot which you gave Ulysses when he was
+begging about in his own house."
+
+Thus spoke the stockman, and Ulysses struck the son of Damastor with a
+spear in close fight, while Telemachus hit Leocritus son of Evenor in
+the belly, and the dart went clean through him, so that he fell forward
+full on his face upon the ground. Then Minerva from her seat on the
+rafter held up her deadly aegis, and the hearts of the suitors quailed.
+They fled to the other end of the court like a herd of cattle maddened
+by the gadfly in early summer when the days are at their longest. As
+eagle-beaked, crook-taloned vultures from the mountains swoop down on
+the smaller birds that cower in flocks upon the ground, and kill
+them, for they cannot either fight or fly, and lookers on enjoy the
+sport--even so did Ulysses and his men fall upon the suitors and smite
+them on every side. They made a horrible groaning as their brains were
+being battered in, and the ground seethed with their blood.
+
+Leiodes then caught the knees of Ulysses and said, "Ulysses I beseech
+you have mercy upon me and spare me. I never wronged any of the women in
+your house either in word or deed, and I tried to stop the others. I
+saw them, but they would not listen, and now they are paying for their
+folly. I was their sacrificing priest; if you kill me, I shall die
+without having done anything to deserve it, and shall have got no thanks
+for all the good that I did."
+
+Ulysses looked sternly at him and answered, "If you were their
+sacrificing priest, you must have prayed many a time that it might be
+long before I got home again, and that you might marry my wife and have
+children by her. Therefore you shall die."
+
+With these words he picked up the sword that Agelaus had dropped when
+he was being killed, and which was lying upon the ground. Then he struck
+Leiodes on the back of his neck, so that his head fell rolling in the
+dust while he was yet speaking.
+
+The minstrel Phemius son of Terpes--he who had been forced by the
+suitors to sing to them--now tried to save his life. He was standing
+near towards the trap door, {174} and held his lyre in his hand. He did
+not know whether to fly out of the cloister and sit down by the altar of
+Jove that was in the outer court, and on which both Laertes and Ulysses
+had offered up the thigh bones of many an ox, or whether to go straight
+up to Ulysses and embrace his knees, but in the end he deemed it best
+to embrace Ulysses' knees. So he laid his lyre on the ground between the
+mixing bowl {175} and the silver-studded seat; then going up to Ulysses
+he caught hold of his knees and said, "Ulysses, I beseech you have mercy
+on me and spare me. You will be sorry for it afterwards if you kill a
+bard who can sing both for gods and men as I can. I make all my lays
+myself, and heaven visits me with every kind of inspiration. I would
+sing to you as though you were a god, do not therefore be in such a
+hurry to cut my head off. Your own son Telemachus will tell you that I
+did not want to frequent your house and sing to the suitors after their
+meals, but they were too many and too strong for me, so they made me."
+
+Telemachus heard him, and at once went up to his father. "Hold!" he
+cried, "the man is guiltless, do him no hurt; and we will spare Medon
+too, who was always good to me when I was a boy, unless Philoetius or
+Eumaeus has already killed him, or he has fallen in your way when you
+were raging about the court."
+
+Medon caught these words of Telemachus, for he was crouching under a
+seat beneath which he had hidden by covering himself up with a freshly
+flayed heifer's hide, so he threw off the hide, went up to Telemachus,
+and laid hold of his knees.
+
+"Here I am, my dear sir," said he, "stay your hand therefore, and tell
+your father, or he will kill me in his rage against the suitors for
+having wasted his substance and been so foolishly disrespectful to
+yourself."
+
+Ulysses smiled at him and answered, "Fear not; Telemachus has saved your
+life, that you may know in future, and tell other people, how greatly
+better good deeds prosper than evil ones. Go, therefore, outside
+the cloisters into the outer court, and be out of the way of the
+slaughter--you and the bard--while I finish my work here inside."
+
+The pair went into the outer court as fast as they could, and sat down
+by Jove's great altar, looking fearfully round, and still expecting that
+they would be killed. Then Ulysses searched the whole court carefully
+over, to see if anyone had managed to hide himself and was still living,
+but he found them all lying in the dust and weltering in their blood.
+They were like fishes which fishermen have netted out of the sea, and
+thrown upon the beach to lie gasping for water till the heat of the sun
+makes an end of them. Even so were the suitors lying all huddled up one
+against the other.
+
+Then Ulysses said to Telemachus, "Call nurse Euryclea; I have something
+to say to her."
+
+Telemachus went and knocked at the door of the women's room. "Make
+haste," said he, "you old woman who have been set over all the other
+women in the house. Come outside; my father wishes to speak to you."
+
+When Euryclea heard this she unfastened the door of the women's room
+and came out, following Telemachus. She found Ulysses among the
+corpses bespattered with blood and filth like a lion that has just been
+devouring an ox, and his breast and both his cheeks are all bloody, so
+that he is a fearful sight; even so was Ulysses besmirched from head
+to foot with gore. When she saw all the corpses and such a quantity of
+blood, she was beginning to cry out for joy, for she saw that a great
+deed had been done; but Ulysses checked her, "Old woman," said he,
+"rejoice in silence; restrain yourself, and do not make any noise about
+it; it is an unholy thing to vaunt over dead men. Heaven's doom and
+their own evil deeds have brought these men to destruction, for they
+respected no man in the whole world, neither rich nor poor, who came
+near them, and they have come to a bad end as a punishment for their
+wickedness and folly. Now, however, tell me which of the women in the
+house have misconducted themselves, and who are innocent." {176}
+
+"I will tell you the truth, my son," answered Euryclea. "There are fifty
+women in the house whom we teach to do things, such as carding wool,
+and all kinds of household work. Of these, twelve in all {177} have
+misbehaved, and have been wanting in respect to me, and also to
+Penelope. They showed no disrespect to Telemachus, for he has only
+lately grown and his mother never permitted him to give orders to the
+female servants; but let me go upstairs and tell your wife all that has
+happened, for some god has been sending her to sleep."
+
+"Do not wake her yet," answered Ulysses, "but tell the women who have
+misconducted themselves to come to me."
+
+Euryclea left the cloister to tell the women, and make them come to
+Ulysses; in the meantime he called Telemachus, the stockman, and the
+swineherd. "Begin," said he, "to remove the dead, and make the women
+help you. Then, get sponges and clean water to swill down the tables and
+seats. When you have thoroughly cleansed the whole cloisters, take the
+women into the space between the domed room and the wall of the outer
+court, and run them through with your swords till they are quite dead,
+and have forgotten all about love and the way in which they used to lie
+in secret with the suitors."
+
+On this the women came down in a body, weeping and wailing bitterly.
+First they carried the dead bodies out, and propped them up against one
+another in the gatehouse. Ulysses ordered them about and made them do
+their work quickly, so they had to carry the bodies out. When they had
+done this, they cleaned all the tables and seats with sponges and water,
+while Telemachus and the two others shovelled up the blood and dirt from
+the ground, and the women carried it all away and put it out of doors.
+Then when they had made the whole place quite clean and orderly, they
+took the women out and hemmed them in the narrow space between the wall
+of the domed room and that of the yard, so that they could not get away:
+and Telemachus said to the other two, "I shall not let these women die
+a clean death, for they were insolent to me and my mother, and used to
+sleep with the suitors."
+
+So saying he made a ship's cable fast to one of the bearing-posts that
+supported the roof of the domed room, and secured it all around the
+building, at a good height, lest any of the women's feet should touch
+the ground; and as thrushes or doves beat against a net that has been
+set for them in a thicket just as they were getting to their nest, and a
+terrible fate awaits them, even so did the women have to put their heads
+in nooses one after the other and die most miserably. {178} Their feet
+moved convulsively for a while, but not for very long.
+
+As for Melanthius, they took him through the cloister into the inner
+court. There they cut off his nose and his ears; they drew out his
+vitals and gave them to the dogs raw, and then in their fury they cut
+off his hands and his feet.
+
+When they had done this they washed their hands and feet and went back
+into the house, for all was now over; and Ulysses said to the dear old
+nurse Euryclea, "Bring me sulphur, which cleanses all pollution, and
+fetch fire also that I may burn it, and purify the cloisters. Go,
+moreover, and tell Penelope to come here with her attendants, and also
+all the maidservants that are in the house."
+
+"All that you have said is true," answered Euryclea, "but let me bring
+you some clean clothes--a shirt and cloak. Do not keep these rags on
+your back any longer. It is not right."
+
+"First light me a fire," replied Ulysses.
+
+She brought the fire and sulphur, as he had bidden her, and Ulysses
+thoroughly purified the cloisters and both the inner and outer courts.
+Then she went inside to call the women and tell them what had happened;
+whereon they came from their apartment with torches in their hands, and
+pressed round Ulysses to embrace him, kissing his head and shoulders and
+taking hold of his hands. It made him feel as if he should like to weep,
+for he remembered every one of them. {179}
+
+
+Book XXIII
+
+PENELOPE EVENTUALLY RECOGNISES HER HUSBAND--EARLY IN THE MORNING
+ULYSSES, TELEMACHUS, EUMAEUS, AND PHILOETIUS LEAVE THE TOWN.
+
+Euryclea now went upstairs laughing to tell her mistress that her dear
+husband had come home. Her aged knees became young again and her feet
+were nimble for joy as she went up to her mistress and bent over her
+head to speak to her. "Wake up Penelope, my dear child," she exclaimed,
+"and see with your own eyes something that you have been wanting this
+long time past. Ulysses has at last indeed come home again, and has
+killed the suitors who were giving so much trouble in his house, eating
+up his estate and ill treating his son."
+
+"My good nurse," answered Penelope, "you must be mad. The gods sometimes
+send some very sensible people out of their minds, and make foolish
+people become sensible. This is what they must have been doing to you;
+for you always used to be a reasonable person. Why should you thus mock
+me when I have trouble enough already--talking such nonsense, and waking
+me up out of a sweet sleep that had taken possession of my eyes and
+closed them? I have never slept so soundly from the day my poor husband
+went to that city with the ill-omened name. Go back again into the
+women's room; if it had been any one else who had woke me up to bring me
+such absurd news I should have sent her away with a severe scolding. As
+it is your age shall protect you."
+
+"My dear child," answered Euryclea, "I am not mocking you. It is quite
+true as I tell you that Ulysses is come home again. He was the stranger
+whom they all kept on treating so badly in the cloister. Telemachus knew
+all the time that he was come back, but kept his father's secret that he
+might have his revenge on all these wicked people."
+
+Then Penelope sprang up from her couch, threw her arms round Euryclea,
+and wept for joy. "But my dear nurse," said she, "explain this to me;
+if he has really come home as you say, how did he manage to overcome the
+wicked suitors single handed, seeing what a number of them there always
+were?"
+
+"I was not there," answered Euryclea, "and do not know; I only heard
+them groaning while they were being killed. We sat crouching and huddled
+up in a corner of the women's room with the doors closed, till your
+son came to fetch me because his father sent him. Then I found Ulysses
+standing over the corpses that were lying on the ground all round him,
+one on top of the other. You would have enjoyed it if you could have
+seen him standing there all bespattered with blood and filth, and
+looking just like a lion. But the corpses are now all piled up in the
+gatehouse that is in the outer court, and Ulysses has lit a great fire
+to purify the house with sulphur. He has sent me to call you, so come
+with me that you may both be happy together after all; for now at last
+the desire of your heart has been fulfilled; your husband is come home
+to find both wife and son alive and well, and to take his revenge in his
+own house on the suitors who behaved so badly to him."
+
+"My dear nurse," said Penelope, "do not exult too confidently over all
+this. You know how delighted every one would be to see Ulysses come
+home--more particularly myself, and the son who has been born to both
+of us; but what you tell me cannot be really true. It is some god who is
+angry with the suitors for their great wickedness, and has made an end
+of them; for they respected no man in the whole world, neither rich nor
+poor, who came near them, and they have come to a bad end in consequence
+of their iniquity; Ulysses is dead far away from the Achaean land; he
+will never return home again."
+
+Then nurse Euryclea said, "My child, what are you talking about? but you
+were all hard of belief and have made up your mind that your husband is
+never coming, although he is in the house and by his own fire side
+at this very moment. Besides I can give you another proof; when I was
+washing him I perceived the scar which the wild boar gave him, and I
+wanted to tell you about it, but in his wisdom he would not let me, and
+clapped his hands over my mouth; so come with me and I will make this
+bargain with you--if I am deceiving you, you may have me killed by the
+most cruel death you can think of."
+
+"My dear nurse," said Penelope, "however wise you may be you can hardly
+fathom the counsels of the gods. Nevertheless, we will go in search of
+my son, that I may see the corpses of the suitors, and the man who has
+killed them."
+
+On this she came down from her upper room, and while doing so she
+considered whether she should keep at a distance from her husband and
+question him, or whether she should at once go up to him and embrace
+him. When, however, she had crossed the stone floor of the cloister, she
+sat down opposite Ulysses by the fire, against the wall at right angles
+{180} [to that by which she had entered], while Ulysses sat near one of
+the bearing-posts, looking upon the ground, and waiting to see what his
+brave wife would say to him when she saw him. For a long time she sat
+silent and as one lost in amazement. At one moment she looked him full
+in the face, but then again directly, she was misled by his shabby
+clothes and failed to recognise him, {181} till Telemachus began to
+reproach her and said:
+
+"Mother--but you are so hard that I cannot call you by such a name--why
+do you keep away from my father in this way? Why do you not sit by his
+side and begin talking to him and asking him questions? No other woman
+could bear to keep away from her husband when he had come back to her
+after twenty years of absence, and after having gone through so much;
+but your heart always was as hard as a stone."
+
+Penelope answered, "My son, I am so lost in astonishment that I can find
+no words in which either to ask questions or to answer them. I cannot
+even look him straight in the face. Still, if he really is Ulysses
+come back to his own home again, we shall get to understand one another
+better by and by, for there are tokens with which we two are alone
+acquainted, and which are hidden from all others."
+
+Ulysses smiled at this, and said to Telemachus, "Let your mother put me
+to any proof she likes; she will make up her mind about it presently.
+She rejects me for the moment and believes me to be somebody else,
+because I am covered with dirt and have such bad clothes on; let us,
+however, consider what we had better do next. When one man has killed
+another--even though he was not one who would leave many friends to take
+up his quarrel--the man who has killed him must still say good bye to
+his friends and fly the country; whereas we have been killing the stay
+of a whole town, and all the picked youth of Ithaca. I would have you
+consider this matter."
+
+"Look to it yourself, father," answered Telemachus, "for they say you
+are the wisest counsellor in the world, and that there is no other
+mortal man who can compare with you. We will follow you with right good
+will, nor shall you find us fail you in so far as our strength holds
+out."
+
+"I will say what I think will be best," answered Ulysses. "First wash
+and put your shirts on; tell the maids also to go to their own room and
+dress; Phemius shall then strike up a dance tune on his lyre, so that if
+people outside hear, or any of the neighbours, or some one going along
+the street happens to notice it, they may think there is a wedding in
+the house, and no rumours about the death of the suitors will get about
+in the town, before we can escape to the woods upon my own land. Once
+there, we will settle which of the courses heaven vouchsafes us shall
+seem wisest."
+
+Thus did he speak, and they did even as he had said. First they washed
+and put their shirts on, while the women got ready. Then Phemius took
+his lyre and set them all longing for sweet song and stately dance. The
+house re-echoed with the sound of men and women dancing, and the people
+outside said, "I suppose the queen has been getting married at last.
+She ought to be ashamed of herself for not continuing to protect her
+husband's property until he comes home." {182}
+
+This was what they said, but they did not know what it was that had been
+happening. The upper servant Eurynome washed and anointed Ulysses in his
+own house and gave him a shirt and cloak, while Minerva made him look
+taller and stronger than before; she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders just as a skilful workman who
+has studied art of all kinds under Vulcan or Minerva--and his work is
+full of beauty--enriches a piece of silver plate by gilding it. He came
+from the bath looking like one of the immortals, and sat down opposite
+his wife on the seat he had left. "My dear," said he, "heaven has
+endowed you with a heart more unyielding than woman ever yet had. No
+other woman could bear to keep away from her husband when he had come
+back to her after twenty years of absence, and after having gone through
+so much. But come, nurse, get a bed ready for me; I will sleep alone,
+for this woman has a heart as hard as iron."
+
+"My dear," answered Penelope, "I have no wish to set myself up, nor to
+depreciate you; but I am not struck by your appearance, for I very well
+remember what kind of a man you were when you set sail from Ithaca.
+Nevertheless, Euryclea, take his bed outside the bed chamber that he
+himself built. Bring the bed outside this room, and put bedding upon it
+with fleeces, good coverlets, and blankets."
+
+She said this to try him, but Ulysses was very angry and said, "Wife,
+I am much displeased at what you have just been saying. Who has been
+taking my bed from the place in which I left it? He must have found it a
+hard task, no matter how skilled a workman he was, unless some god came
+and helped him to shift it. There is no man living, however strong and
+in his prime, who could move it from its place, for it is a marvellous
+curiosity which I made with my very own hands. There was a young olive
+growing within the precincts of the house, in full vigour, and about as
+thick as a bearing-post. I built my room round this with strong walls
+of stone and a roof to cover them, and I made the doors strong and
+well-fitting. Then I cut off the top boughs of the olive tree and left
+the stump standing. This I dressed roughly from the root upwards and
+then worked with carpenter's tools well and skilfully, straightening
+my work by drawing a line on the wood, and making it into a bed-prop.
+I then bored a hole down the middle, and made it the centre-post of my
+bed, at which I worked till I had finished it, inlaying it with gold and
+silver; after this I stretched a hide of crimson leather from one side
+of it to the other. So you see I know all about it, and I desire to
+learn whether it is still there, or whether any one has been removing it
+by cutting down the olive tree at its roots."
+
+When she heard the sure proofs Ulysses now gave her, she fairly broke
+down. She flew weeping to his side, flung her arms about his neck, and
+kissed him. "Do not be angry with me Ulysses," she cried, "you, who are
+the wisest of mankind. We have suffered, both of us. Heaven has denied
+us the happiness of spending our youth, and of growing old, together; do
+not then be aggrieved or take it amiss that I did not embrace you thus
+as soon as I saw you. I have been shuddering all the time through fear
+that someone might come here and deceive me with a lying story; for
+there are many very wicked people going about. Jove's daughter Helen
+would never have yielded herself to a man from a foreign country, if she
+had known that the sons of Achaeans would come after her and bring her
+back. Heaven put it in her heart to do wrong, and she gave no thought
+to that sin, which has been the source of all our sorrows. Now, however,
+that you have convinced me by showing that you know all about our
+bed (which no human being has ever seen but you and I and a single
+maidservant, the daughter of Actor, who was given me by my father on my
+marriage, and who keeps the doors of our room) hard of belief though I
+have been I can mistrust no longer."
+
+Then Ulysses in his turn melted, and wept as he clasped his dear and
+faithful wife to his bosom. As the sight of land is welcome to men who
+are swimming towards the shore, when Neptune has wrecked their ship with
+the fury of his winds and waves; a few alone reach the land, and these,
+covered with brine, are thankful when they find themselves on firm
+ground and out of danger--even so was her husband welcome to her as she
+looked upon him, and she could not tear her two fair arms from about
+his neck. Indeed they would have gone on indulging their sorrow till
+rosy-fingered morn appeared, had not Minerva determined otherwise, and
+held night back in the far west, while she would not suffer Dawn to
+leave Oceanus, nor to yoke the two steeds Lampus and Phaethon that bear
+her onward to break the day upon mankind.
+
+At last, however, Ulysses said, "Wife, we have not yet reached the end
+of our troubles. I have an unknown amount of toil still to undergo. It
+is long and difficult, but I must go through with it, for thus the shade
+of Teiresias prophesied concerning me, on the day when I went down into
+Hades to ask about my return and that of my companions. But now let us
+go to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+"You shall go to bed as soon as you please," replied Penelope, "now that
+the gods have sent you home to your own good house and to your country.
+But as heaven has put it in your mind to speak of it, tell me about the
+task that lies before you. I shall have to hear about it later, so it is
+better that I should be told at once."
+
+"My dear," answered Ulysses, "why should you press me to tell you?
+Still, I will not conceal it from you, though you will not like it. I do
+not like it myself, for Teiresias bade me travel far and wide, carrying
+an oar, till I came to a country where the people have never heard of
+the sea, and do not even mix salt with their food. They know nothing
+about ships, nor oars that are as the wings of a ship. He gave me this
+certain token which I will not hide from you. He said that a wayfarer
+should meet me and ask me whether it was a winnowing shovel that I had
+on my shoulder. On this, I was to fix my oar in the ground and sacrifice
+a ram, a bull, and a boar to Neptune; after which I was to go home and
+offer hecatombs to all the gods in heaven, one after the other. As for
+myself, he said that death should come to me from the sea, and that my
+life should ebb away very gently when I was full of years and peace of
+mind, and my people should bless me. All this, he said, should surely
+come to pass."
+
+And Penelope said, "If the gods are going to vouchsafe you a happier
+time in your old age, you may hope then to have some respite from
+misfortune."
+
+Thus did they converse. Meanwhile Eurynome and the nurse took torches
+and made the bed ready with soft coverlets; as soon as they had laid
+them, the nurse went back into the house to go to her rest, leaving the
+bed chamber woman Eurynome {183} to show Ulysses and Penelope to bed by
+torch light. When she had conducted them to their room she went
+back, and they then came joyfully to the rites of their own old bed.
+Telemachus, Philoetius, and the swineherd now left off dancing, and made
+the women leave off also. They then laid themselves down to sleep in the
+cloisters.
+
+When Ulysses and Penelope had had their fill of love they fell talking
+with one another. She told him how much she had had to bear in seeing
+the house filled with a crowd of wicked suitors who had killed so many
+sheep and oxen on her account, and had drunk so many casks of wine.
+Ulysses in his turn told her what he had suffered, and how much trouble
+he had himself given to other people. He told her everything, and she
+was so delighted to listen that she never went to sleep till he had
+ended his whole story.
+
+He began with his victory over the Cicons, and how he thence reached the
+fertile land of the Lotus-eaters. He told her all about the Cyclops
+and how he had punished him for having so ruthlessly eaten his brave
+comrades; how he then went on to Aeolus, who received him hospitably and
+furthered him on his way, but even so he was not to reach home, for to
+his great grief a hurricane carried him out to sea again; how he went on
+to the Laestrygonian city Telepylos, where the people destroyed all his
+ships with their crews, save himself and his own ship only. Then he told
+of cunning Circe and her craft, and how he sailed to the chill house of
+Hades, to consult the ghost of the Theban prophet Teiresias, and how he
+saw his old comrades in arms, and his mother who bore him and brought
+him up when he was a child; how he then heard the wondrous singing of
+the Sirens, and went on to the wandering rocks and terrible Charybdis
+and to Scylla, whom no man had ever yet passed in safety; how his men
+then ate the cattle of the sun-god, and how Jove therefore struck the
+ship with his thunderbolts, so that all his men perished together,
+himself alone being left alive; how at last he reached the Ogygian
+island and the nymph Calypso, who kept him there in a cave, and fed
+him, and wanted him to marry her, in which case she intended making him
+immortal so that he should never grow old, but she could not persuade
+him to let her do so; and how after much suffering he had found his way
+to the Phaeacians, who had treated him as though he had been a god, and
+sent him back in a ship to his own country after having given him gold,
+bronze, and raiment in great abundance. This was the last thing about
+which he told her, for here a deep sleep took hold upon him and eased
+the burden of his sorrows.
+
+Then Minerva bethought her of another matter. When she deemed that
+Ulysses had had both of his wife and of repose, she bade gold-enthroned
+Dawn rise out of Oceanus that she might shed light upon mankind. On
+this, Ulysses rose from his comfortable bed and said to Penelope,
+"Wife, we have both of us had our full share of troubles, you, here, in
+lamenting my absence, and I in being prevented from getting home though
+I was longing all the time to do so. Now, however, that we have at last
+come together, take care of the property that is in the house. As for
+the sheep and goats which the wicked suitors have eaten, I will take
+many myself by force from other people, and will compel the Achaeans to
+make good the rest till they shall have filled all my yards. I am now
+going to the wooded lands out in the country to see my father who has
+so long been grieved on my account, and to yourself I will give these
+instructions, though you have little need of them. At sunrise it will
+at once get abroad that I have been killing the suitors; go upstairs,
+therefore, {184} and stay there with your women. See nobody and ask no
+questions." {185}
+
+As he spoke he girded on his armour. Then he roused Telemachus,
+Philoetius, and Eumaeus, and told them all to put on their armour also.
+This they did, and armed themselves. When they had done so, they
+opened the gates and sallied forth, Ulysses leading the way. It was now
+daylight, but Minerva nevertheless concealed them in darkness and led
+them quickly out of the town.
+
+
+Book XXIV
+
+THE GHOSTS OF THE SUITORS IN HADES--ULYSSES AND HIS MEN GO TO THE HOUSE
+OF LAERTES--THE PEOPLE OF ITHACA COME OUT TO ATTACK ULYSSES, BUT MINERVA
+CONCLUDES A PEACE.
+
+Then Mercury of Cyllene summoned the ghosts of the suitors, and in his
+hand he held the fair golden wand with which he seals men's eyes in
+sleep or wakes them just as he pleases; with this he roused the ghosts
+and led them, while they followed whining and gibbering behind him. As
+bats fly squealing in the hollow of some great cave, when one of them
+has fallen out of the cluster in which they hang, even so did the ghosts
+whine and squeal as Mercury the healer of sorrow led them down into the
+dark abode of death. When they had passed the waters of Oceanus and the
+rock Leucas, they came to the gates of the sun and the land of dreams,
+whereon they reached the meadow of asphodel where dwell the souls and
+shadows of them that can labour no more.
+
+Here they found the ghost of Achilles son of Peleus, with those of
+Patroclus, Antilochus, and Ajax, who was the finest and handsomest man
+of all the Danaans after the son of Peleus himself.
+
+They gathered round the ghost of the son of Peleus, and the ghost of
+Agamemnon joined them, sorrowing bitterly. Round him were gathered also
+the ghosts of those who had perished with him in the house of Aegisthus;
+and the ghost of Achilles spoke first.
+
+"Son of Atreus," it said, "we used to say that Jove had loved you better
+from first to last than any other hero, for you were captain over many
+and brave men, when we were all fighting together before Troy; yet the
+hand of death, which no mortal can escape, was laid upon you all too
+early. Better for you had you fallen at Troy in the hey-day of your
+renown, for the Achaeans would have built a mound over your ashes, and
+your son would have been heir to your good name, whereas it has now been
+your lot to come to a most miserable end."
+
+"Happy son of Peleus," answered the ghost of Agamemnon, "for having
+died at Troy far from Argos, while the bravest of the Trojans and the
+Achaeans fell round you fighting for your body. There you lay in the
+whirling clouds of dust, all huge and hugely, heedless now of your
+chivalry. We fought the whole of the livelong day, nor should we ever
+have left off if Jove had not sent a hurricane to stay us. Then, when we
+had borne you to the ships out of the fray, we laid you on your bed and
+cleansed your fair skin with warm water and with ointments. The Danaans
+tore their hair and wept bitterly round about you. Your mother, when she
+heard, came with her immortal nymphs from out of the sea, and the sound
+of a great wailing went forth over the waters so that the Achaeans
+quaked for fear. They would have fled panic-stricken to their ships had
+not wise old Nestor whose counsel was ever truest checked them saying,
+'Hold, Argives, fly not sons of the Achaeans, this is his mother coming
+from the sea with her immortal nymphs to view the body of her son.'
+
+"Thus he spoke, and the Achaeans feared no more. The daughters of the
+old man of the sea stood round you weeping bitterly, and clothed you
+in immortal raiment. The nine muses also came and lifted up their sweet
+voices in lament--calling and answering one another; there was not an
+Argive but wept for pity of the dirge they chaunted. Days and nights
+seven and ten we mourned you, mortals and immortals, but on the
+eighteenth day we gave you to the flames, and many a fat sheep with many
+an ox did we slay in sacrifice around you. You were burnt in raiment of
+the gods, with rich resins and with honey, while heroes, horse and foot,
+clashed their armour round the pile as you were burning, with the tramp
+as of a great multitude. But when the flames of heaven had done
+their work, we gathered your white bones at daybreak and laid them in
+ointments and in pure wine. Your mother brought us a golden vase to hold
+them--gift of Bacchus, and work of Vulcan himself; in this we mingled
+your bleached bones with those of Patroclus who had gone before you, and
+separate we enclosed also those of Antilochus, who had been closer to
+you than any other of your comrades now that Patroclus was no more.
+
+"Over these the host of the Argives built a noble tomb, on a point
+jutting out over the open Hellespont, that it might be seen from far
+out upon the sea by those now living and by them that shall be born
+hereafter. Your mother begged prizes from the gods, and offered them
+to be contended for by the noblest of the Achaeans. You must have
+been present at the funeral of many a hero, when the young men gird
+themselves and make ready to contend for prizes on the death of some
+great chieftain, but you never saw such prizes as silver-footed Thetis
+offered in your honour; for the gods loved you well. Thus even in death
+your fame, Achilles, has not been lost, and your name lives evermore
+among all mankind. But as for me, what solace had I when the days of my
+fighting were done? For Jove willed my destruction on my return, by the
+hands of Aegisthus and those of my wicked wife."
+
+Thus did they converse, and presently Mercury came up to them with the
+ghosts of the suitors who had been killed by Ulysses. The ghosts of
+Agamemnon and Achilles were astonished at seeing them, and went up
+to them at once. The ghost of Agamemnon recognised Amphimedon son of
+Melaneus, who lived in Ithaca and had been his host, so it began to talk
+to him.
+
+"Amphimedon," it said, "what has happened to all you fine young men--all
+of an age too--that you are come down here under the ground? One could
+pick no finer body of men from any city. Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the mainland when you were cattle-lifting or sheep-stealing,
+or while fighting in defence of their wives and city? Answer my
+question, for I have been your guest. Do you not remember how I came to
+your house with Menelaus, to persuade Ulysses to join us with his ships
+against Troy? It was a whole month ere we could resume our voyage, for
+we had hard work to persuade Ulysses to come with us."
+
+And the ghost of Amphimedon answered, "Agamemnon, son of Atreus, king of
+men, I remember everything that you have said, and will tell you fully
+and accurately about the way in which our end was brought about. Ulysses
+had been long gone, and we were courting his wife, who did not say point
+blank that she would not marry, nor yet bring matters to an end, for she
+meant to compass our destruction: this, then, was the trick she played
+us. She set up a great tambour frame in her room and began to work on an
+enormous piece of fine needlework. 'Sweethearts,' said she, 'Ulysses
+is indeed dead, still, do not press me to marry again immediately;
+wait--for I would not have my skill in needlework perish
+unrecorded--till I have completed a pall for the hero Laertes, against
+the time when death shall take him. He is very rich, and the women of
+the place will talk if he is laid out without a pall.' This is what she
+said, and we assented; whereupon we could see her working upon her great
+web all day long, but at night she would unpick the stitches again
+by torchlight. She fooled us in this way for three years without our
+finding it out, but as time wore on and she was now in her fourth year,
+in the waning of moons and many days had been accomplished, one of her
+maids who knew what she was doing told us, and we caught her in the act
+of undoing her work, so she had to finish it whether she would or no;
+and when she showed us the robe she had made, after she had had it
+washed, {186} its splendour was as that of the sun or moon.
+
+"Then some malicious god conveyed Ulysses to the upland farm where his
+swineherd lives. Thither presently came also his son, returning from
+a voyage to Pylos, and the two came to the town when they had hatched
+their plot for our destruction. Telemachus came first, and then after
+him, accompanied by the swineherd, came Ulysses, clad in rags and
+leaning on a staff as though he were some miserable old beggar. He came
+so unexpectedly that none of us knew him, not even the older ones among
+us, and we reviled him and threw things at him. He endured both being
+struck and insulted without a word, though he was in his own house; but
+when the will of Aegis-bearing Jove inspired him, he and Telemachus
+took the armour and hid it in an inner chamber, bolting the doors behind
+them. Then he cunningly made his wife offer his bow and a quantity
+of iron to be contended for by us ill-fated suitors; and this was the
+beginning of our end, for not one of us could string the bow--nor nearly
+do so. When it was about to reach the hands of Ulysses, we all of us
+shouted out that it should not be given him, no matter what he might
+say, but Telemachus insisted on his having it. When he had got it in his
+hands he strung it with ease and sent his arrow through the iron. Then
+he stood on the floor of the cloister and poured his arrows on the
+ground, glaring fiercely about him. First he killed Antinous, and then,
+aiming straight before him, he let fly his deadly darts and they fell
+thick on one another. It was plain that some one of the gods was
+helping them, for they fell upon us with might and main throughout the
+cloisters, and there was a hideous sound of groaning as our brains
+were being battered in, and the ground seethed with our blood. This,
+Agamemnon, is how we came by our end, and our bodies are lying still
+uncared for in the house of Ulysses, for our friends at home do not
+yet know what has happened, so that they cannot lay us out and wash
+the black blood from our wounds, making moan over us according to the
+offices due to the departed."
+
+"Happy Ulysses, son of Laertes," replied the ghost of Agamemnon, "you
+are indeed blessed in the possession of a wife endowed with such rare
+excellence of understanding, and so faithful to her wedded lord as
+Penelope the daughter of Icarius. The fame, therefore, of her virtue
+shall never die, and the immortals shall compose a song that shall be
+welcome to all mankind in honour of the constancy of Penelope. How far
+otherwise was the wickedness of the daughter of Tyndareus who killed her
+lawful husband; her song shall be hateful among men, for she has brought
+disgrace on all womankind even on the good ones."
+
+Thus did they converse in the house of Hades deep down within the bowels
+of the earth. Meanwhile Ulysses and the others passed out of the town
+and soon reached the fair and well-tilled farm of Laertes, which he
+had reclaimed with infinite labour. Here was his house, with a lean-to
+running all round it, where the slaves who worked for him slept and sat
+and ate, while inside the house there was an old Sicel woman, who looked
+after him in this his country-farm. When Ulysses got there, he said to
+his son and to the other two:
+
+"Go to the house, and kill the best pig that you can find for dinner.
+Meanwhile I want to see whether my father will know me, or fail to
+recognise me after so long an absence."
+
+He then took off his armour and gave it to Eumaeus and Philoetius, who
+went straight on to the house, while he turned off into the vineyard to
+make trial of his father. As he went down into the great orchard, he did
+not see Dolius, nor any of his sons nor of the other bondsmen, for they
+were all gathering thorns to make a fence for the vineyard, at the place
+where the old man had told them; he therefore found his father alone,
+hoeing a vine. He had on a dirty old shirt, patched and very shabby;
+his legs were bound round with thongs of oxhide to save him from the
+brambles, and he also wore sleeves of leather; he had a goat skin cap on
+his head, and was looking very woe-begone. When Ulysses saw him so worn,
+so old and full of sorrow, he stood still under a tall pear tree and
+began to weep. He doubted whether to embrace him, kiss him, and tell him
+all about his having come home, or whether he should first question him
+and see what he would say. In the end he deemed it best to be crafty
+with him, so in this mind he went up to his father, who was bending down
+and digging about a plant.
+
+"I see, sir," said Ulysses, "that you are an excellent gardener--what
+pains you take with it, to be sure. There is not a single plant, not a
+fig tree, vine, olive, pear, nor flower bed, but bears the trace of your
+attention. I trust, however, that you will not be offended if I say
+that you take better care of your garden than of yourself. You are old,
+unsavoury, and very meanly clad. It cannot be because you are idle that
+your master takes such poor care of you, indeed your face and figure
+have nothing of the slave about them, and proclaim you of noble birth.
+I should have said that you were one of those who should wash well, eat
+well, and lie soft at night as old men have a right to do; but tell me,
+and tell me true, whose bondman are you, and in whose garden are you
+working? Tell me also about another matter. Is this place that I have
+come to really Ithaca? I met a man just now who said so, but he was a
+dull fellow, and had not the patience to hear my story out when I was
+asking him about an old friend of mine, whether he was still living, or
+was already dead and in the house of Hades. Believe me when I tell you
+that this man came to my house once when I was in my own country and
+never yet did any stranger come to me whom I liked better. He said that
+his family came from Ithaca and that his father was Laertes, son of
+Arceisius. I received him hospitably, making him welcome to all the
+abundance of my house, and when he went away I gave him all customary
+presents. I gave him seven talents of fine gold, and a cup of solid
+silver with flowers chased upon it. I gave him twelve light cloaks,
+and as many pieces of tapestry; I also gave him twelve cloaks of single
+fold, twelve rugs, twelve fair mantles, and an equal number of shirts.
+To all this I added four good looking women skilled in all useful arts,
+and I let him take his choice."
+
+His father shed tears and answered, "Sir, you have indeed come to the
+country that you have named, but it is fallen into the hands of wicked
+people. All this wealth of presents has been given to no purpose. If
+you could have found your friend here alive in Ithaca, he would have
+entertained you hospitably and would have requited your presents amply
+when you left him--as would have been only right considering what you
+had already given him. But tell me, and tell me true, how many years is
+it since you entertained this guest--my unhappy son, as ever was? Alas!
+He has perished far from his own country; the fishes of the sea have
+eaten him, or he has fallen a prey to the birds and wild beasts of some
+continent. Neither his mother, nor I his father, who were his parents,
+could throw our arms about him and wrap him in his shroud, nor could
+his excellent and richly dowered wife Penelope bewail her husband as was
+natural upon his death bed, and close his eyes according to the offices
+due to the departed. But now, tell me truly for I want to know. Who
+and whence are you--tell me of your town and parents? Where is the
+ship lying that has brought you and your men to Ithaca? Or were you a
+passenger on some other man's ship, and those who brought you here have
+gone on their way and left you?"
+
+"I will tell you everything," answered Ulysses, "quite truly. I come
+from Alybas, where I have a fine house. I am son of king Apheidas, who
+is the son of Polypemon. My own name is Eperitus; heaven drove me off my
+course as I was leaving Sicania, and I have been carried here against
+my will. As for my ship it is lying over yonder, off the open country
+outside the town, and this is the fifth year since Ulysses left my
+country. Poor fellow, yet the omens were good for him when he left me.
+The birds all flew on our right hands, and both he and I rejoiced to
+see them as we parted, for we had every hope that we should have another
+friendly meeting and exchange presents."
+
+A dark cloud of sorrow fell upon Laertes as he listened. He filled both
+hands with the dust from off the ground and poured it over his grey
+head, groaning heavily as he did so. The heart of Ulysses was touched,
+and his nostrils quivered as he looked upon his father; then he sprang
+towards him, flung his arms about him and kissed him, saying, "I am he,
+father, about whom you are asking--I have returned after having been
+away for twenty years. But cease your sighing and lamentation--we have
+no time to lose, for I should tell you that I have been killing the
+suitors in my house, to punish them for their insolence and crimes."
+
+"If you really are my son Ulysses," replied Laertes, "and have come back
+again, you must give me such manifest proof of your identity as shall
+convince me."
+
+"First observe this scar," answered Ulysses, "which I got from a boar's
+tusk when I was hunting on Mt. Parnassus. You and my mother had sent me
+to Autolycus, my mother's father, to receive the presents which when he
+was over here he had promised to give me. Furthermore I will point out
+to you the trees in the vineyard which you gave me, and I asked you all
+about them as I followed you round the garden. We went over them all,
+and you told me their names and what they all were. You gave me thirteen
+pear trees, ten apple trees, and forty fig trees; you also said you
+would give me fifty rows of vines; there was corn planted between each
+row, and they yield grapes of every kind when the heat of heaven has
+been laid heavy upon them."
+
+Laertes' strength failed him when he heard the convincing proofs which
+his son had given him. He threw his arms about him, and Ulysses had to
+support him, or he would have gone off into a swoon; but as soon as he
+came to, and was beginning to recover his senses, he said, "O father
+Jove, then you gods are still in Olympus after all, if the suitors have
+really been punished for their insolence and folly. Nevertheless, I
+am much afraid that I shall have all the townspeople of Ithaca up here
+directly, and they will be sending messengers everywhere throughout the
+cities of the Cephallenians."
+
+Ulysses answered, "Take heart and do not trouble yourself about that,
+but let us go into the house hard by your garden. I have already told
+Telemachus, Philoetius, and Eumaeus to go on there and get dinner ready
+as soon as possible."
+
+Thus conversing the two made their way towards the house. When they got
+there they found Telemachus with the stockman and the swineherd cutting
+up meat and mixing wine with water. Then the old Sicel woman took
+Laertes inside and washed him and anointed him with oil. She put him on
+a good cloak, and Minerva came up to him and gave him a more imposing
+presence, making him taller and stouter than before. When he came back
+his son was surprised to see him looking so like an immortal, and said
+to him, "My dear father, some one of the gods has been making you much
+taller and better-looking."
+
+Laertes answered, "Would, by Father Jove, Minerva, and Apollo, that
+I were the man I was when I ruled among the Cephallenians, and took
+Nericum, that strong fortress on the foreland. If I were still what I
+then was and had been in our house yesterday with my armour on, I should
+have been able to stand by you and help you against the suitors. I
+should have killed a great many of them, and you would have rejoiced to
+see it."
+
+Thus did they converse; but the others, when they had finished their
+work and the feast was ready, left off working, and took each his proper
+place on the benches and seats. Then they began eating; by and by old
+Dolius and his sons left their work and came up, for their mother, the
+Sicel woman who looked after Laertes now that he was growing old, had
+been to fetch them. When they saw Ulysses and were certain it was he,
+they stood there lost in astonishment; but Ulysses scolded them good
+naturedly and said, "Sit down to your dinner, old man, and never mind
+about your surprise; we have been wanting to begin for some time and
+have been waiting for you."
+
+Then Dolius put out both his hands and went up to Ulysses. "Sir," said
+he, seizing his master's hand and kissing it at the wrist, "we have long
+been wishing you home: and now heaven has restored you to us after we
+had given up hoping. All hail, therefore, and may the gods prosper you.
+{187} But tell me, does Penelope already know of your return, or shall
+we send some one to tell her?"
+
+"Old man," answered Ulysses, "she knows already, so you need not trouble
+about that." On this he took his seat, and the sons of Dolius gathered
+round Ulysses to give him greeting and embrace him one after the other;
+then they took their seats in due order near Dolius their father.
+
+While they were thus busy getting their dinner ready, Rumour went round
+the town, and noised abroad the terrible fate that had befallen the
+suitors; as soon, therefore, as the people heard of it they gathered
+from every quarter, groaning and hooting before the house of Ulysses.
+They took the dead away, buried every man his own, and put the bodies
+of those who came from elsewhere on board the fishing vessels, for the
+fishermen to take each of them to his own place. They then met angrily
+in the place of assembly, and when they were got together Eupeithes
+rose to speak. He was overwhelmed with grief for the death of his son
+Antinous, who had been the first man killed by Ulysses, so he said,
+weeping bitterly, "My friends, this man has done the Achaeans great
+wrong. He took many of our best men away with him in his fleet, and he
+has lost both ships and men; now, moreover, on his return he has been
+killing all the foremost men among the Cephallenians. Let us be up and
+doing before he can get away to Pylos or to Elis where the Epeans rule,
+or we shall be ashamed of ourselves for ever afterwards. It will be an
+everlasting disgrace to us if we do not avenge the murder of our sons
+and brothers. For my own part I should have no more pleasure in life,
+but had rather die at once. Let us be up, then, and after them, before
+they can cross over to the main land."
+
+He wept as he spoke and every one pitied him. But Medon and the bard
+Phemius had now woke up, and came to them from the house of Ulysses.
+Every one was astonished at seeing them, but they stood in the middle of
+the assembly, and Medon said, "Hear me, men of Ithaca. Ulysses did not
+do these things against the will of heaven. I myself saw an immortal god
+take the form of Mentor and stand beside him. This god appeared, now in
+front of him encouraging him, and now going furiously about the court
+and attacking the suitors whereon they fell thick on one another."
+
+On this pale fear laid hold of them, and old Halitherses, son of Mastor,
+rose to speak, for he was the only man among them who knew both past and
+future; so he spoke to them plainly and in all honesty, saying,
+
+"Men of Ithaca, it is all your own fault that things have turned out as
+they have; you would not listen to me, nor yet to Mentor, when we
+bade you check the folly of your sons who were doing much wrong in the
+wantonness of their hearts--wasting the substance and dishonouring the
+wife of a chieftain who they thought would not return. Now, however, let
+it be as I say, and do as I tell you. Do not go out against Ulysses, or
+you may find that you have been drawing down evil on your own heads."
+
+This was what he said, and more than half raised a loud shout, and at
+once left the assembly. But the rest stayed where they were, for the
+speech of Halitherses displeased them, and they sided with Eupeithes;
+they therefore hurried off for their armour, and when they had armed
+themselves, they met together in front of the city, and Eupeithes led
+them on in their folly. He thought he was going to avenge the murder
+of his son, whereas in truth he was never to return, but was himself to
+perish in his attempt.
+
+Then Minerva said to Jove, "Father, son of Saturn, king of kings, answer
+me this question--What do you propose to do? Will you set them fighting
+still further, or will you make peace between them?"
+
+And Jove answered, "My child, why should you ask me? Was it not by your
+own arrangement that Ulysses came home and took his revenge upon the
+suitors? Do whatever you like, but I will tell you what I think will
+be most reasonable arrangement. Now that Ulysses is revenged, let them
+swear to a solemn covenant, in virtue of which he shall continue to
+rule, while we cause the others to forgive and forget the massacre of
+their sons and brothers. Let them then all become friends as heretofore,
+and let peace and plenty reign."
+
+This was what Minerva was already eager to bring about, so down she
+darted from off the topmost summits of Olympus.
+
+Now when Laertes and the others had done dinner, Ulysses began by
+saying, "Some of you go out and see if they are not getting close up
+to us." So one of Dolius's sons went as he was bid. Standing on the
+threshold he could see them all quite near, and said to Ulysses, "Here
+they are, let us put on our armour at once."
+
+They put on their armour as fast as they could--that is to say Ulysses,
+his three men, and the six sons of Dolius. Laertes also and Dolius did
+the same--warriors by necessity in spite of their grey hair. When they
+had all put on their armour, they opened the gate and sallied forth,
+Ulysses leading the way.
+
+Then Jove's daughter Minerva came up to them, having assumed the form
+and voice of Mentor. Ulysses was glad when he saw her, and said to
+his son Telemachus, "Telemachus, now that you are about to fight in an
+engagement, which will show every man's mettle, be sure not to disgrace
+your ancestors, who were eminent for their strength and courage all the
+world over."
+
+"You say truly, my dear father," answered Telemachus, "and you shall
+see, if you will, that I am in no mind to disgrace your family."
+
+Laertes was delighted when he heard this. "Good heavens," he exclaimed,
+"what a day I am enjoying: I do indeed rejoice at it. My son and
+grandson are vying with one another in the matter of valour."
+
+On this Minerva came close up to him and said, "Son of Arceisius---best
+friend I have in the world--pray to the blue-eyed damsel, and to Jove
+her father; then poise your spear and hurl it."
+
+As she spoke she infused fresh vigour into him, and when he had prayed
+to her he poised his spear and hurled it. He hit Eupeithes' helmet, and
+the spear went right through it, for the helmet stayed it not, and
+his armour rang rattling round him as he fell heavily to the ground.
+Meantime Ulysses and his son fell upon the front line of the foe and
+smote them with their swords and spears; indeed, they would have killed
+every one of them, and prevented them from ever getting home again,
+only Minerva raised her voice aloud, and made every one pause. "Men of
+Ithaca," she cried, "cease this dreadful war, and settle the matter at
+once without further bloodshed."
+
+On this pale fear seized every one; they were so frightened that their
+arms dropped from their hands and fell upon the ground at the sound of
+the goddess' voice, and they fled back to the city for their lives. But
+Ulysses gave a great cry, and gathering himself together swooped down
+like a soaring eagle. Then the son of Saturn sent a thunderbolt of fire
+that fell just in front of Minerva, so she said to Ulysses, "Ulysses,
+noble son of Laertes, stop this warful strife, or Jove will be angry
+with you."
+
+Thus spoke Minerva, and Ulysses obeyed her gladly. Then Minerva assumed
+the form and voice of Mentor, and presently made a covenant of peace
+between the two contending parties.
+
+
+
+                        FOOTNOTES
+
+{1} Black races are evidently known to the writer as stretching all
+across Africa, one half looking West on to the Atlantic, and the other
+East on to the Indian Ocean.
+
+{2} The original use of the footstool was probably less to rest the feet
+than to keep them (especially when bare) from a floor which was often
+wet and dirty.
+
+{3} The [Greek] or seat, is occasionally called "high," as being higher
+than the [Greek] or low footstool. It was probably no higher than an
+ordinary chair is now, and seems to have had no back.
+
+{4} Temesa was on the West Coast of the toe of Italy, in what is now the
+gulf of Sta Eufemia. It was famous in remote times for its copper mines,
+which, however, were worked out when Strabo wrote.
+
+{5} i.e. "with a current in it"--see illustrations and map near the end
+of bks. v. and vi. respectively.
+
+{6} Reading [Greek] for [Greek], cf. "Od." iii. 81 where the same
+mistake is made, and xiii. 351 where the mountain is called Neritum, the
+same place being intended both here and in book xiii.
+
+{7} It is never plausibly explained why Penelope cannot do this, and
+from bk. ii. it is clear that she kept on deliberately encouraging the
+suitors, though we are asked to believe that she was only fooling them.
+
+{8} See note on "Od." i. 365.
+
+{9} Middle Argos means the Peleponnese which, however, is never so
+called in the "Iliad". I presume "middle" means "middle between the two
+Greek-speaking countries of Asia Minor and Sicily, with South Italy";
+for that parts of Sicily and also large parts, though not the whole of
+South Italy, were inhabited by Greek-speaking races centuries before the
+Dorian colonisations can hardly be doubted. The Sicians, and also the
+Sicels, both of them probably spoke Greek.
+
+{10} cf. "Il." vi. 490-495. In the "Iliad" it is "war," not "speech,"
+that is a man's matter. It argues a certain hardness, or at any rate
+dislike of the "Iliad" on the part of the writer of the "Odyssey,"
+that she should have adopted Hector's farewell to Andromache here, as
+elsewhere in the poem, for a scene of such inferior pathos.
+
+{11} [Greek] The whole open court with the covered cloister running
+round it was called [Greek], or [Greek], but the covered part was
+distinguished by being called "shady" or "shadow-giving". It was in this
+part that the tables for the suitors were laid. The Fountain Court at
+Hampton Court may serve as an illustration (save as regards the use of
+arches instead of wooden supports and rafters) and the arrangement
+is still common in Sicily. The usual translation "shadowy" or "dusky"
+halls, gives a false idea of the scene.
+
+{12} The reader will note the extreme care which the writer takes to
+make it clear that none of the suitors were allowed to sleep in Ulysses'
+house.
+
+{13} See Appendix; g, in plan of Ulysses' house.
+
+{14} I imagine this passage to be a rejoinder to "Il." xxiii. 702-705 in
+which a tripod is valued at twelve oxen, and a good useful maid of
+all work at only four. The scrupulous regard of Laertes for his wife's
+feelings is of a piece with the extreme jealousy for the honour of
+woman, which is manifest throughout the "Odyssey".
+
+{15} [Greek] "The [Greek], or tunica, was a shirt or shift, and served
+as the chief under garment of the Greeks and Romans, whether men
+or women." Smith's Dictionary of Greek and Roman Antiquities, under
+"Tunica".
+
+{16} Doors fastened to all intents and purposes as here described may be
+seen in the older houses at Trapani. There is a slot on the outer side
+of the door by means of which a person who has left the room can shoot
+the bolt. My bedroom at the Albergo Centrale was fastened in this way.
+
+{17} [Greek] So we vulgarly say "had cooked his goose," or "had settled
+his hash." Aegyptus cannot of course know of the fate Antiphus had met
+with, for there had as yet been no news of or from Ulysses.
+
+{18} "Il." xxii. 416. [Greek] The authoress has bungled by borrowing
+these words verbatim from the "Iliad", without prefixing the necessary
+"do not," which I have supplied.
+
+{19} i.e. you have money, and could pay when I got judgment, whereas the
+suitors are men of straw.
+
+{20} cf. "Il." ii. 76. [Greek]. The Odyssean passage runs [Greek]. Is
+it possible not to suspect that the name Mentor was coined upon that of
+Nestor?
+
+{21} i.e. in the outer court, and in the uncovered part of the inner
+house.
+
+{22} This would be fair from Sicily, which was doing duty for Ithaca in
+the mind of the writer, but a North wind would have been preferable for
+a voyage from the real Ithaca to Pylos.
+
+{23} [Greek] The wind does not whistle over waves. It only whistles
+through rigging or some other obstacle that cuts it.
+
+{24} cf. "Il." v.20. [Greek] The Odyssean line is [Greek]. There can
+be no doubt that the Odyssean line was suggested by the Iliadic, but
+nothing can explain why Idaeus jumping from his chariot should suggest
+to the writer of the "Odyssey" the sun jumping from the sea. The
+probability is that she never gave the matter a thought, but took the
+line in question as an effect of saturation with the "Iliad," and of
+unconscious cerebration. The "Odyssey" contains many such examples.
+
+{25} The heart, liver, lights, kidneys, etc. were taken out from the
+inside and eaten first as being more readily cooked; the [Greek], or
+bone meat, was cooking while the [Greek] or inward parts were being
+eaten. I imagine that the thigh bones made a kind of gridiron, while at
+the same time the marrow inside them got cooked.
+
+{26} i.e. skewers, either single, double, or even five pronged. The meat
+would be pierced with the skewer, and laid over the ashes to grill--the
+two ends of the skewer being supported in whatever way convenient. Meat
+so cooking may be seen in any eating house in Smyrna, or any Eastern
+town. When I rode across the Troad from the Dardanelles to Hissarlik and
+Mount Ida, I noticed that my dragoman and his men did all our outdoor
+cooking exactly in the Odyssean and Iliadic fashion.
+
+{27} cf. "Il." xvii. 567. [Greek] The Odyssean lines are--[Greek]
+
+{28} Reading [Greek] for [Greek], cf. "Od." i.186.
+
+{29} The geography of the Aegean as above described is correct, but is
+probably taken from the lost poem, the Nosti, the existence of which is
+referred to "Od." i.326,327 and 350, etc. A glance at the map will show
+that heaven advised its supplicants quite correctly.
+
+{30} The writer--ever jealous for the honour of women--extenuates
+Clytemnestra's guilt as far as possible, and explains it as due to her
+having been left unprotected, and fallen into the hands of a wicked man.
+
+{31} The Greek is [Greek] cf. "Iliad" ii. 408 [Greek] Surely the [Greek]
+of the Odyssean passage was due to the [Greek] of the "Iliad." No other
+reason suggests itself for the making Menelaus return on the very day of
+the feast given by Orestes. The fact that in the "Iliad" Menelaus came
+to a banquet without waiting for an invitation, determines the writer
+of the "Odyssey" to make him come to a banquet, also uninvited, but
+as circumstances did not permit of his having been invited, his coming
+uninvited is shown to have been due to chance. I do not think the
+authoress thought all this out, but attribute the strangeness of the
+coincidence to unconscious cerebration and saturation.
+
+{32} cf. "Il." i.458, ii. 421. The writer here interrupts an Iliadic
+passage (to which she returns immediately) for the double purpose of
+dwelling upon the slaughter of the heifer, and of letting Nestor's wife
+and daughter enjoy it also. A male writer, if he was borrowing from the
+"Iliad," would have stuck to his borrowing.
+
+{33} cf. "Il." xxiv. 587,588 where the lines refer to the washing the
+dead body of Hector.
+
+{34} See illustration on opposite page. The yard is typical of many that
+may be seen in Sicily. The existing ground-plan is probably unmodified
+from Odyssean, and indeed long pre-Odyssean times, but the earlier
+buildings would have no arches, and would, one would suppose, be mainly
+timber. The Odyssean [Greek] were the sheds that ran round the yard
+as the arches do now. The [Greek] was the one through which the main
+entrance passed, and which was hence "noisy," or reverberating. It had
+an upper story in which visitors were often lodged.
+
+{35} This journey is an impossible one. Telemachus and Pisistratus would
+have been obliged to drive over the Taygetus range, over which there has
+never yet been a road for wheeled vehicles. It is plain therefore that
+the audience for whom the "Odyssey" was written was one that would be
+unlikely to know anything about the topography of the Peloponnese, so
+that the writer might take what liberties she chose.
+
+{36} The lines which I have enclosed in brackets are evidently an
+afterthought--added probably by the writer herself--for they evince
+the same instinctively greater interest in anything that may concern a
+woman, which is so noticeable throughout the poem. There is no further
+sign of any special festivities nor of any other guests than Telemachus
+and Pisistratus, until lines 621-624 (ordinarily enclosed in brackets)
+are abruptly introduced, probably with a view of trying to carry off the
+introduction of the lines now in question.
+
+The addition was, I imagine, suggested by a desire to excuse and explain
+the non-appearance of Hermione in bk. xv., as also of both Hermione and
+Megapenthes in the rest of bk. iv. Megapenthes in bk. xv. seems to be
+still a bachelor: the presumption therefore is that bk. xv. was written
+before the story of his marriage here given. I take it he is only
+married here because his sister is being married. She having been
+properly attended to, Megapenthes might as well be married at the same
+time. Hermione could not now be less than thirty.
+
+I have dealt with this passage somewhat more fully in my "Authoress of
+the Odyssey", p.136-138. See also p. 256 of the same book.
+
+{37} Sparta and Lacedaemon are here treated as two different places,
+though in other parts of the poem it is clear that the writer
+understands them as one. The catalogue in the "Iliad," which the writer
+is here presumably following, makes the same mistake ("Il." ii. 581,582)
+
+{38} These last three lines are identical with "Il." vxiii. 604-606.
+
+{39} From the Greek [Greek] it is plain that Menelaus took up the piece
+of meat with his fingers.
+
+{40} Amber is never mentioned in the "Iliad." Sicily, where I suppose
+the "Odyssey" to have been written, has always been, and still is, one
+of the principal amber producing countries. It was probably the only one
+known in the Odyssean age. See "The Authoress of the Odyssey", p260.
+
+{41} This no doubt refers to the story told in the last poem of the
+Cypria about Paris and Helen robbing Menelaus of the greater part of his
+treasures, when they sailed together for Troy.
+
+{42} It is inconceivable that Helen should enter thus, in the middle of
+supper, intending to work with her distaff, if great festivities were
+going on. Telemachus and Pisistratus are evidently dining en famille.
+
+{43} In the Italian insurrection of 1848, eight young men who were being
+hotly pursued by the Austrian police hid themselves inside Donatello's
+colossal wooden horse in the Salone at Padua, and remained there for
+a week being fed by their confederates. In 1898 the last survivor was
+carried round Padua in triumph.
+
+{44} The Greek is [Greek]. Is it unfair to argue that the writer is a
+person of somewhat delicate sensibility, to whom a strong smell of fish
+is distasteful?
+
+{45} The Greek is [Greek]. I believe this to be a hit at the writer's
+own countrymen who were of Phocaean descent, and the next following line
+to be a rejoinder to complaints made against her in bk. vi. 273-288, to
+the effect that she gave herself airs and would marry none of her own
+people. For that the writer of the "Odyssey" was the person who has
+been introduced into the poem under the name of Nausicaa, I cannot bring
+myself to question. I may remind English readers that [Greek] (i.e.
+phoca) means "seal." Seals almost always appear on Phocaean coins.
+
+{46} Surely here again we are in the hands of a writer of delicate
+sensibility. It is not as though the seals were stale; they had only
+just been killed. The writer, however is obviously laughing at her own
+countrymen, and insulting them as openly as she dares.
+
+{47} We were told above (lines 357,357) that it was only one day's sail.
+
+{48} I give the usual translation, but I do not believe the Greek will
+warrant it. The Greek reads [Greek].
+
+This is usually held to mean that Ithaca is an island fit for breeding
+goats, and on that account more delectable to the speaker than it would
+have been if it were fit for breeding horses. I find little authority
+for such a translation; the most equitable translation of the text as it
+stands is, "Ithaca is an island fit for breeding goats, and delectable
+rather than fit for breeding horses; for not one of the islands is good
+driving ground, nor well meadowed." Surely the writer does not mean that
+a pleasant or delectable island would not be fit for breeding horses?
+The most equitable translation, therefore, of the present text being
+thus halt and impotent, we may suspect corruption, and I hazard the
+following emendation, though I have not adopted it in my translation, as
+fearing that it would be deemed too fanciful. I would read:--[Greek].
+
+As far as scanning goes the [Greek] is not necessary; [Greek] iv. 72,
+[Greek] iv. 233, to go no further afield than earlier lines of the same
+book, give sufficient authority for [Greek], but the [Greek] would not
+be redundant; it would emphasise the surprise of the contrast, and I
+should prefer to have it, though it is not very important either way.
+This reading of course should be translated "Ithaca is an island fit for
+breeding goats, and (by your leave) itself a horseman rather than
+fit for breeding horses--for not one of the islands is good and well
+meadowed ground."
+
+This would be sure to baffle the Alexandrian editors. "How," they would
+ask themselves, "could an island be a horseman?" and they would cast
+about for an emendation. A visit to the top of Mt. Eryx might perhaps
+make the meaning intelligible, and suggest my proposed restoration of
+the text to the reader as readily as it did to myself.
+
+I have elsewhere stated my conviction that the writer of the "Odyssey"
+was familiar with the old Sican city at the top of Mt. Eryx, and that
+the Aegadean islands which are so striking when seen thence did duty
+with her for the Ionian islands--Marettimo, the highest and most
+westerly of the group, standing for Ithaca. When seen from the top of
+Mt. Eryx Marettimo shows as it should do according to "Od." ix. 25,26,
+"on the horizon, all highest up in the sea towards the West," while
+the other islands lie "some way off it to the East." As we descend
+to Trapani, Marettimo appears to sink on to the top of the island of
+Levanzo, behind which it disappears. My friend, the late Signor E.
+Biaggini, pointed to it once as it was just standing on the top of
+Levanzo, and said to me "Come cavalca bene" ("How well it rides"), and
+this immediately suggested my emendation to me. Later on I found in
+the hymn to the Pythian Apollo (which abounds with tags taken from the
+"Odyssey") a line ending [Greek] which strengthened my suspicion that
+this was the original ending of the second of the two lines above under
+consideration.
+
+{49} See note on line 3 of this book. The reader will observe that
+the writer has been unable to keep the women out of an interpolation
+consisting only of four lines.
+
+{50} Scheria means a piece of land jutting out into the sea. In my
+"Authoress of the Odyssey" I thought "Jutland" would be a suitable
+translation, but it has been pointed out to me that "Jutland" only means
+the land of the Jutes.
+
+{51} Irrigation as here described is common in gardens near Trapani. The
+water that supplies the ducts is drawn from wells by a mule who turns a
+wheel with buckets on it.
+
+{52} There is not a word here about the cattle of the sun-god.
+
+{53} The writer evidently thought that green, growing wood might also be
+well seasoned.
+
+{54} The reader will note that the river was flowing with salt water
+i.e. that it was tidal.
+
+{55} Then the Ogygian island was not so far off, but that Nausicaa might
+be assumed to know where it was.
+
+{56} Greek [Greek]
+
+{57} I suspect a family joke, or sly allusion to some thing of which
+we know nothing, in this story of Eurymedusa's having been brought from
+Apeira. The Greek word "apeiros" means "inexperienced," "ignorant." Is
+it possible that Eurymedusa was notoriously incompetent?
+
+{58} Polyphemus was also son to Neptune, see "Od." ix. 412,529. he was
+therefore half brother to Nausithous, half uncle to King Alcinous, and
+half great uncle to Nausicaa.
+
+{59} It would seem as though the writer thought that Marathon was close
+to Athens.
+
+{60} Here the writer, knowing that she is drawing (with embellishments)
+from things actually existing, becomes impatient of past tenses and
+slides into the present.
+
+{61} This is hidden malice, implying that the Phaeacian magnates were
+no better than they should be. The final drink-offering should have been
+made to Jove or Neptune, not to the god of thievishness and rascality
+of all kinds. In line 164 we do indeed find Echeneus proposing that
+a drink-offering should be made to Jove, but Mercury is evidently,
+according to our authoress, the god who was most likely to be of use to
+them.
+
+{62} The fact of Alcinous knowing anything about the Cyclopes suggests
+that in the writer's mind Scheria and the country of the Cyclopes were
+not very far from one another. I take the Cyclopes and the giants to be
+one and the same people.
+
+{63} "My property, etc." The authoress is here adopting an Iliadic line
+(xix. 333), and this must account for the absence of all reference
+to Penelope. If she had happened to remember "Il." v.213, she would
+doubtless have appropriated it by preference, for that line reads "my
+country, my wife, and all the greatness of my house."
+
+{64} The at first inexplicable sleep of Ulysses (bk. xiii. 79, etc.)
+is here, as also in viii. 445, being obviously prepared. The writer
+evidently attached the utmost importance to it. Those who know that the
+harbour which did duty with the writer of the "Odyssey" for the one in
+which Ulysses landed in Ithaca, was only about 2 miles from the place
+in which Ulysses is now talking with Alcinous, will understand why the
+sleep was so necessary.
+
+{65} There were two classes--the lower who were found in provisions
+which they had to cook for themselves in the yards and outer precincts,
+where they would also eat--and the upper who would eat in the cloisters
+of the inner court, and have their cooking done for them.
+
+{66} Translation very dubious. I suppose the [Greek] here to be the
+covered sheds that ran round the outer courtyard. See illustrations at
+the end of bk. iii.
+
+{67} The writer apparently deems that the words "as compared with what
+oxen can plough in the same time" go without saying. Not so the writer
+of the "Iliad" from which the Odyssean passage is probably taken. He
+explains that mules can plough quicker than oxen ("Il." x.351-353)
+
+{68} It was very fortunate that such a disc happened to be there, seeing
+that none like it were in common use.
+
+{69} "Il." xiii. 37. Here, as so often elsewhere in the "Odyssey," the
+appropriation of an Iliadic line which is not quite appropriate puzzles
+the reader. The "they" is not the chains, nor yet Mars and Venus. It is
+an overflow from the Iliadic passage in which Neptune hobbles his horses
+in bonds "which none could either unloose or break so that they might
+stay there in that place." If the line would have scanned without the
+addition of the words "so that they might stay there in that place,"
+they would have been omitted in the "Odyssey."
+
+{70} The reader will note that Alcinous never goes beyond saying that
+he is going to give the goblet; he never gives it. Elsewhere in both
+"Iliad" and "Odyssey" the offer of a present is immediately followed by
+the statement that it was given and received gladly--Alcinous actually
+does give a chest and a cloak and shirt--probably also some of the corn
+and wine for the long two-mile voyage was provided by him--but it is
+quite plain that he gave no talent and no cup.
+
+{71} "Il." xviii, 344-349. These lines in the "Iliad" tell of the
+preparation for washing the body of Patroclus, and I am not pleased that
+the writer of the "Odyssey" should have adopted them here.
+
+{72} see note {64}
+
+{73} see note {43}
+
+{74} The reader will find this threat fulfilled in bk. xiii
+
+{75} If the other islands lay some distance away from Ithaca (which
+the word [Greek] suggests), what becomes of the [Greek] or gut between
+Ithaca and Samos which we hear of in Bks. iv. and xv.? I suspect that
+the authoress in her mind makes Telemachus come back from Pylos to the
+Lilybaean promontory and thence to Trapani through the strait between
+the Isola Grande and the mainland--the island of Asteria being the one
+on which Motya afterwards stood.
+
+{76} "Il." xviii. 533-534. The sudden lapse into the third person here
+for a couple of lines is due to the fact that the two Iliadic lines
+taken are in the third person.
+
+{77} cf. "Il." ii. 776. The words in both "Iliad" and "Odyssey" are
+[Greek]. In the "Iliad" they are used of the horses of Achilles'
+followers as they stood idle, "champing lotus."
+
+{78} I take all this passage about the Cyclopes having no ships to
+be sarcastic--meaning, "You people of Drepanum have no excuse for not
+colonising the island of Favognana, which you could easily do, for you
+have plenty of ships, and the island is a very good one." For that
+the island so fully described here is the Aegadean or "goat" island of
+Favognana, and that the Cyclopes are the old Sican inhabitants of Mt.
+Eryx should not be doubted.
+
+{79} For the reasons why it was necessary that the night should be so
+exceptionally dark see "The Authoress of the Odyssey" pp. 188-189.
+
+{80} None but such lambs as would suck if they were with their mothers
+would be left in the yard. The older lambs should have been out feeding.
+The authoress has got it all wrong, but it does not matter. See "The
+Authoress of the Odyssey" p.148.
+
+{81} This line is enclosed in brackets in the received text, and is
+omitted (with note) by Messrs. Butcher & Lang. But lines enclosed in
+brackets are almost always genuine; all that brackets mean is that the
+bracketed passage puzzled some early editor, who nevertheless found
+it too well established in the text to venture on omitting it. In the
+present case the line bracketed is the very last which a full-grown male
+editor would be likely to interpolate. It is safer to infer that the
+writer, a young woman, not knowing or caring at which end of the ship
+the rudder should be, determined to make sure by placing it at both
+ends, which we shall find she presently does by repeating it (line 340)
+at the stern of the ship. As for the two rocks thrown, the first I take
+to be the Asinelli, see map facing p.80. The second I see as the two
+contiguous islands of the Formiche, which are treated as one, see map
+facing p.108. The Asinelli is an island shaped like a boat, and pointing
+to the island of Favognana. I think the authoress's compatriots, who
+probably did not like her much better that she did them, jeered at the
+absurdity of Ulysses' conduct, and saw the Asinelli or "donkeys," not as
+the rock thrown by Polyphemus, but as the boat itself containing Ulysses
+and his men.
+
+{82} This line exists in the text here but not in the corresponding
+passage xii. 141. I am inclined to think it is interpolated (probably
+by the poetess herself) from the first of lines xi. 115-137, which I can
+hardly doubt were added by the writer when the scheme of the work was
+enlarged and altered. See "The Authoress of the Odyssey" pp. 254-255.
+
+{83} "Floating" ([Greek]) is not to be taken literally. The island
+itself, as apart from its inhabitants, was quite normal. There is no
+indication of its moving during the month that Ulysses stayed with
+Aeolus, and on his return from his unfortunate voyage, he seems to
+have found it in the same place. The [Greek] in fact should no more be
+pressed than [Greek] as applied to islands, "Odyssey" xv. 299--where
+they are called "flying" because the ship would fly past them. So also
+the "Wanderers," as explained by Buttmann; see note on "Odyssey" xii.
+57.
+
+{84} Literally "for the ways of the night and of the day are near." I
+have seen what Mr. Andrew Lang says ("Homer and the Epic," p.236, and
+"Longman's Magazine" for January, 1898, p.277) about the "amber route"
+and the "Sacred Way" in this connection; but until he gives his grounds
+for holding that the Mediterranean peoples in the Odyssean age used to
+go far North for their amber instead of getting it in Sicily, where it
+is still found in considerable quantities, I do not know what weight I
+ought to attach to his opinion. I have been unable to find grounds
+for asserting that B.C. 1000 there was any commerce between the
+Mediterranean and the "Far North," but I shall be very ready to learn
+if Mr. Lang will enlighten me. See "The Authoress of the Odyssey" pp.
+185-186.
+
+{85} One would have thought that when the sun was driving the stag down
+to the water, Ulysses might have observed its whereabouts.
+
+{86} See Hobbes of Malmesbury's translation.
+
+{87} "Il." vxiii. 349. Again the writer draws from the washing the body
+of Patroclus--which offends.
+
+{88} This visit is wholly without topographical significance.
+
+{89} Brides presented themselves instinctively to the imagination of the
+writer, as the phase of humanity which she found most interesting.
+
+{90} Ulysses was, in fact, to become a missionary and preach Neptune to
+people who knew not his name. I was fortunate enough to meet in Sicily
+a woman carrying one of these winnowing shovels; it was not much shorter
+than an oar, and I was able at once to see what the writer of the
+"Odyssey" intended.
+
+{91} I suppose the lines I have enclosed in brackets to have been added
+by the author when she enlarged her original scheme by the addition of
+books i.-iv. and xiii. (from line 187)-xxiv. The reader will observe
+that in the corresponding passage (xii. 137-141) the prophecy ends with
+"after losing all your comrades," and that there is no allusion to the
+suitors. For fuller explanation see "The Authoress of the Odyssey" pp.
+254-255.
+
+{92} The reader will remember that we are in the first year of Ulysses'
+wanderings, Telemachus therefore was only eleven years old. The same
+anachronism is made later on in this book. See "The Authoress of the
+Odyssey" pp. 132-133.
+
+{93} Tradition says that she had hanged herself. Cf. "Odyssey" xv. 355,
+etc.
+
+{94} Not to be confounded with Aeolus king of the winds.
+
+{95} Melampus, vide book xv. 223, etc.
+
+{96} I have already said in a note on bk. xi. 186 that at this point of
+Ulysses' voyage Telemachus could only be between eleven and twelve years
+old.
+
+{97} Is the writer a man or a woman?
+
+{98} Cf. "Il." iv. 521, [Greek]. The Odyssean line reads, [Greek]. The
+famous dactylism, therefore, of the Odyssean line was probably suggested
+by that of the Ileadic rather than by a desire to accommodate sound to
+sense. At any rate the double coincidence of a dactylic line, and an
+ending [Greek], seems conclusive as to the familiarity of the writer of
+the "Odyssey" with the Iliadic line.
+
+{99} Off the coast of Sicily and South Italy, in the month of May, I
+have seen men fastened half way up a boat's mast with their feet resting
+on a crosspiece, just large enough to support them. From this point
+of vantage they spear sword-fish. When I saw men thus employed I could
+hardly doubt that the writer of the "Odyssey" had seen others like them,
+and had them in her mind when describing the binding of Ulysses. I have
+therefore with some diffidence ventured to depart from the received
+translation of [Greek] (cf. Alcaeus frag. 18, where, however, it is
+very hard to say what [Greek] means). In Sophocles' Lexicon I find a
+reference to Chrysostom (l, 242, A. Ed. Benedictine Paris 1834-1839)
+for the word [Greek], which is probably the same as [Greek], but I have
+looked for the passage in vain.
+
+{100} The writer is at fault here and tries to put it off on Circe. When
+Ulysses comes to take the route prescribed by Circe, he ought to pass
+either the Wanderers or some other difficulty of which we are not told,
+but he does not do so. The Planctae, or Wanderers, merge into Scylla and
+Charybdis, and the alternative between them and something untold
+merges into the alternative whether Ulysses had better choose Scylla or
+Charybdis. Yet from line 260, it seems we are to consider the Wanderers
+as having been passed by Ulysses; this appears even more plainly from
+xxiii. 327, in which Ulysses expressly mentions the Wandering rocks as
+having been between the Sirens and Scylla and Charybdis. The writer,
+however, is evidently unaware that she does not quite understand her own
+story; her difficulty was perhaps due to the fact that though Trapanese
+sailors had given her a fair idea as to where all her other localities
+really were, no one in those days more than in our own could localise
+the Planctae, which in fact, as Buttmann has argued, were derived not
+from any particular spot, but from sailors' tales about the difficulties
+of navigating the group of the Aeolian islands as a whole (see note on
+"Od." x. 3). Still the matter of the poor doves caught her fancy, so she
+would not forgo them. The whirlwinds of fire and the smoke that hangs on
+Scylla suggests allusion to Stromboli and perhaps even Etna. Scylla is
+on the Italian side, and therefore may be said to look West. It is about
+8 miles thence to the Sicilian coast, so Ulysses may be perfectly well
+told that after passing Scylla he will come to the Thrinacian island or
+Sicily. Charybdis is transposed to a site some few miles to the north of
+its actual position.
+
+{101} I suppose this line to have been intercalated by the author when
+lines 426-446 were added.
+
+{102} For the reasons which enable us to identify the island of the two
+Sirens with the Lipari island now Salinas--the ancient Didyme, or "twin"
+island--see The Authoress of the Odyssey, pp. 195, 196. The two
+Sirens doubtless were, as their name suggests, the whistling gusts, or
+avalanches of air that at times descend without a moment's warning from
+the two lofty mountains of Salinas--as also from all high points in the
+neighbourhood.
+
+{103} See Admiral Smyth on the currents in the Straits of Messina,
+quoted in "The Authoress of the Odyssey," p. 197.
+
+{104} In the islands of Favognana and Marettimo off Trapani I have seen
+men fish exactly as here described. They chew bread into a paste and
+throw it into the sea to attract the fish, which they then spear. No
+line is used.
+
+{105} The writer evidently regards Ulysses as on a coast that looked
+East at no great distance south of the Straits of Messina somewhere,
+say, near Tauromenium, now Taormina.
+
+{106} Surely there must be a line missing here to tell us that the keel
+and mast were carried down into Charybdis. Besides, the aorist [Greek]
+in its present surrounding is perplexing. I have translated it as though
+it were an imperfect; I see Messrs. Butcher and Lang translate it as
+a pluperfect, but surely Charybdis was in the act of sucking down the
+water when Ulysses arrived.
+
+{107} I suppose the passage within brackets to have been an afterthought
+but to have been written by the same hand as the rest of the poem. I
+suppose xii. 103 to have been also added by the writer when she decided
+on sending Ulysses back to Charybdis. The simile suggests the hand of
+the wife or daughter of a magistrate who had often seen her father come
+in cross and tired.
+
+{108} Gr. [Greek]. This puts coined money out of the question, but
+nevertheless implies that the gold had been worked into ornaments of
+some kind.
+
+{109} I suppose Teiresias' prophecy of bk. xi. 114-120 had made no
+impression on Ulysses. More probably the prophecy was an afterthought,
+intercalated, as I have already said, by the authoress when she changed
+her scheme.
+
+{110} A male writer would have made Ulysses say, not "may you give
+satisfaction to your wives," but "may your wives give satisfaction to
+you."
+
+{111} See note {64}.
+
+{112} The land was in reality the shallow inlet, now the salt works of
+S. Cusumano--the neighbourhood of Trapani and Mt. Eryx being made to do
+double duty, both as Scheria and Ithaca. Hence the necessity for making
+Ulysses set out after dark, fall instantly into a profound sleep, and
+wake up on a morning so foggy that he could not see anything till the
+interviews between Neptune and Jove and between Ulysses and Minerva
+should have given the audience time to accept the situation. See
+illustrations and map near the end of bks. v. and vi. respectively.
+
+{113} This cave, which is identifiable with singular completeness, is
+now called the "grotta del toro," probably a corruption of "tesoro," for
+it is held to contain a treasure. See The Authoress of the Odyssey, pp.
+167-170.
+
+{114} Probably they would.
+
+{115} Then it had a shallow shelving bottom.
+
+{116} Doubtless the road would pass the harbour in Odyssean times as it
+passes the salt works now; indeed, if there is to be a road at all there
+is no other level ground which it could take. See map above referred to.
+
+{117} The rock at the end of the Northern harbour of Trapani, to which
+I suppose the writer of the "Odyssey" to be here referring, still bears
+the name Malconsiglio--"the rock of evil counsel." There is a legend
+that it was a ship of Turkish pirates who were intending to attack
+Trapani, but the "Madonna di Trapani" crushed them under this rock just
+as they were coming into port. My friend Cavaliere Giannitrapani of
+Trapani told me that his father used to tell him when he was a boy that
+if he would drop exactly three drops of oil on to the water near the
+rock, he would see the ship still at the bottom. The legend is evidently
+a Christianised version of the Odyssean story, while the name supplies
+the additional detail that the disaster happened in consequence of an
+evil counsel.
+
+{118} It would seem then that the ship had got all the way back from
+Ithaca in about a quarter of an hour.
+
+{119} And may we not add "and also to prevent his recognising that he
+was only in the place where he had met Nausicaa two days earlier."
+
+{120} All this is to excuse the entire absence of Minerva from books
+ix.-xii., which I suppose had been written already, before the authoress
+had determined on making Minerva so prominent a character.
+
+{121} We have met with this somewhat lame attempt to cover the writer's
+change of scheme at the end of bk. vi.
+
+{122} I take the following from The Authoress of the Odyssey, p. 167.
+"It is clear from the text that there were two [caves] not one, but some
+one has enclosed in brackets the two lines in which the second cave is
+mentioned, I presume because he found himself puzzled by having a second
+cave sprung upon him when up to this point he had only been told of one.
+
+"I venture to think that if he had known the ground he would not have
+been puzzled, for there are two caves, distant about 80 or 100 yards
+from one another." The cave in which Ulysses hid his treasure is, as I
+have already said, identifiable with singular completeness. The other
+cave presents no special features, neither in the poem nor in nature.
+
+{123} There is no attempt to disguise the fact that Penelope had long
+given encouragement to the suitors. The only defence set up is that she
+did not really mean to encourage them. Would it not have been wiser to
+have tried a little discouragement?
+
+{124} See map near the end of bk. vi. Ruccazzu dei corvi of course means
+"the rock of the ravens." Both name and ravens still exist.
+
+{125} See The Authoress of the Odyssey, pp. 140, 141. The real reason
+for sending Telemachus to Pylos and Lacedaemon was that the authoress
+might get Helen of Troy into her poem. He was sent at the only point in
+the story at which he could be sent, so he must have gone then or not at
+all.
+
+{126} The site I assign to Eumaeus's hut, close to the Ruccazzu dei
+Corvi, is about 2,000 feet above the sea, and commands an extensive
+view.
+
+{127} Sandals such as Eumaeus was making are still worn in the Abruzzi
+and elsewhere. An oblong piece of leather forms the sole: holes are cut
+at the four corners, and through these holes leathern straps are passed,
+which are bound round the foot and cross-gartered up the calf.
+
+{128} See note {75}
+
+{129} Telemachus like many another good young man seems to expect every
+one to fetch and carry for him.
+
+{130} "Il." vi. 288. The store room was fragrant because it was made of
+cedar wood. See "Il." xxiv. 192.
+
+{131} cf. "Il." vi. 289 and 293-296. The dress was kept at the bottom
+of the chest as one that would only be wanted on the greatest occasions;
+but surely the marriage of Hermione and of Megapenthes (bk, iv. ad
+init.) might have induced Helen to wear it on the preceding evening,
+in which case it could hardly have got back. We find no hint here of
+Megapenthes' recent marriage.
+
+{132} See note {83}.
+
+{133} cf. "Od." xi. 196, etc.
+
+{134} The names Syra and Ortygia, on which island a great part of the
+Doric Syracuse was originally built, suggest that even in Odyssean times
+there was a prehistoric Syracuse, the existence of which was known to
+the writer of the poem.
+
+{135} Literally "where are the turnings of the sun." Assuming, as we may
+safely do, that the Syra and Ortygia of the "Odyssey" refer to Syracuse,
+it is the fact that not far to the South of these places the land turns
+sharply round, so that mariners following the coast would find the
+sun upon the other side of their ship to that on which they'd had it
+hitherto.
+
+Mr. A. S. Griffith has kindly called my attention to Herod iv. 42,
+where, speaking of the circumnavigation of Africa by Phoenician mariners
+under Necos, he writes:
+
+"On their return they declared--I for my part do not believe them, but
+perhaps others may--that in sailing round Libya [i.e. Africa] they had
+the sun upon their right hand. In this way was the extent of Libya first
+discovered.
+
+"I take it that Eumaeus was made to have come from Syracuse because
+the writer thought she rather ought to have made something happen at
+Syracuse during her account of the voyages of Ulysses. She could
+not, however, break his long drift from Charybdis to the island of
+Pantellaria; she therefore resolved to make it up to Syracuse in another
+way."
+
+{135} Modern excavations establish the existence of two and only two
+pre-Dorian communities at Syracuse; they were, so Dr. Orsi informed me,
+at Plemmirio and Cozzo Pantano. See The Authoress of the Odyssey, pp.
+211-213.
+
+{136} This harbour is again evidently the harbour in which Ulysses had
+landed, i.e. the harbour that is now the salt works of S. Cusumano.
+
+{137} This never can have been anything but very niggardly pay for some
+eight or nine days' service. I suppose the crew were to consider the
+pleasure of having had a trip to Pylos as a set off. There is no trace
+of the dinner as having been actually given, either on the following or
+any other morning.
+
+{138} No hawk can tear its prey while it is on the wing.
+
+{139} The text is here apparently corrupt, and will not make sense as it
+stands. I follow Messrs. Butcher and Lang in omitting line 101.
+
+{140} i.e. to be milked, as in South Italian and Sicilian towns at the
+present day.
+
+{141} The butchering and making ready the carcases took place partly in
+the outer yard and partly in the open part of the inner court.
+
+{142} These words cannot mean that it would be afternoon soon after they
+were spoken. Ulysses and Eumaeus reached the town which was "some way
+off" (xvii. 25) in time for the suitor's early meal (xvii. 170 and 176)
+say at ten or eleven o' clock. The context of the rest of the book shows
+this. Eumaeus and Ulysses, therefore, cannot have started later than
+eight or nine, and Eumaeus's words must be taken as an exaggeration for
+the purpose of making Ulysses bestir himself.
+
+{143} I imagine the fountain to have been somewhere about where the
+church of the Madonna di Trapani now stands, and to have been fed with
+water from what is now called the Fontana Diffali on Mt. Eryx.
+
+{144} From this and other passages in the "Odyssey" it appears that
+we are in an age anterior to the use of coined money--an age when
+cauldrons, tripods, swords, cattle, chattels of all kinds, measures
+of corn, wine, or oil, etc. etc., not to say pieces of gold, silver,
+bronze, or even iron, wrought more or less, but unstamped, were the
+nearest approach to a currency that had as yet been reached.
+
+{145} Gr. is [Greek]
+
+{146} I correct these proofs abroad and am not within reach of Hesiod,
+but surely this passage suggests acquaintance with the Works and Ways,
+though it by no means compels it.
+
+{147} It would seem as though Eurynome and Euryclea were the same
+person. See note {156}
+
+{148} It is plain, therefore, that Iris was commonly accepted as the
+messenger of the gods, though our authoress will never permit her to
+fetch or carry for any one.
+
+{149} i.e. the doorway leading from the inner to the outer court.
+
+{150} Surely in this scene, again, Eurynome is in reality Euryclea. See
+note {156}
+
+{151} These, I imagine, must have been in the open part of the inner
+courtyard, where the maids also stood, and threw the light of their
+torches into the covered cloister that ran all round it. The smoke would
+otherwise have been intolerable.
+
+{152} Translation very uncertain; vide Liddell and Scott, under [Greek]
+
+{153} See photo on opposite page.
+
+{154} cf. "Il." ii. 184, and 217, 218. An additional and well-marked
+feature being wanted to convince Penelope, the writer has taken the
+hunched shoulders of Thersites (who is mentioned immediately after
+Eurybates in the "Iliad") and put them on to Eurybates' back.
+
+{155} This is how geese are now fed in Sicily, at any rate in summer,
+when the grass is all burnt up. I have never seen them grazing.
+
+{156} Lower down (line 143) Euryclea says it was herself that had thrown
+the cloak over Ulysses--for the plural should not be taken as implying
+more than one person. The writer is evidently still fluctuating between
+Euryclea and Eurynome as the name for the old nurse. She probably
+originally meant to call her Euryclea, but finding it not immediately
+easy to make Euryclea scan in xvii. 495, she hastily called her
+Eurynome, intending either to alter this name later or to change the
+earlier Euryclea's into Eurynome. She then drifted in to Eurynome
+as convenience further directed, still nevertheless hankering after
+Euryclea, till at last she found that the path of least resistance
+would lie in the direction of making Eurynome and Euryclea two persons.
+Therefore in xxiii. 289-292 both Eurynome and "the nurse" (who can be
+none other than Euryclea) come on together. I do not say that this is
+feminine, but it is not unfeminine.
+
+{157} See note {156}
+
+{158} This, I take it, was immediately in front of the main entrance of
+the inner courtyard into the body of the house.
+
+{159} This is the only allusion to Sardinia in either "Iliad" or
+"Odyssey."
+
+{160} The normal translation of the Greek word would be "holding back,"
+"curbing," "restraining," but I cannot think that the writer meant
+this--she must have been using the word in its other sense of "having,"
+"holding," "keeping," "maintaining."
+
+{161} I have vainly tried to realise the construction of the fastening
+here described.
+
+{162} See plan of Ulysses' house in the appendix. It is evident that the
+open part of the court had no flooring but the natural soil.
+
+{163} See plan of Ulysses' house, and note {175}.
+
+{164} i.e. the door that led into the body of the house.
+
+{165} This was, no doubt, the little table that was set for Ulysses,
+"Od." xx. 259.
+
+Surely the difficulty of this passage has been overrated. I suppose
+the iron part of the axe to have been wedged into the handle, or bound
+securely to it--the handle being half buried in the ground. The axe
+would be placed edgeways towards the archer, and he would have to shoot
+his arrow through the hole into which the handle was fitted when the axe
+was in use. Twelve axes were placed in a row all at the same height,
+all exactly in front of one another, all edgeways to Ulysses whose arrow
+passed through all the holes from the first onward. I cannot see how the
+Greek can bear any other interpretation, the words being, [Greek]
+
+"He did not miss a single hole from the first onwards." [Greek]
+according to Liddell and Scott being "the hole for the handle of an
+axe, etc.," while [Greek] ("Od." v. 236) is, according to the same
+authorities, the handle itself. The feat is absurdly impossible, but our
+authoress sometimes has a soul above impossibilities.
+
+{166} The reader will note how the spoiling of good food distresses the
+writer even in such a supreme moment as this.
+
+{167} Here we have it again. Waste of substance comes first.
+
+{168} cf. "Il." iii. 337 and three other places. It is strange that
+the author of the "Iliad" should find a little horse-hair so alarming.
+Possibly enough she was merely borrowing a common form line from some
+earlier poet--or poetess--for this is a woman's line rather than a
+man's.
+
+{169} Or perhaps simply "window." See plan in the appendix.
+
+{170} i.e. the pavement on which Ulysses was standing.
+
+{171} The interpretation of lines 126-143 is most dubious, and at best
+we are in a region of melodrama: cf., however, i.425, etc. from which it
+appears that there was a tower in the outer court, and that Telemachus
+used to sleep in it. The [Greek] I take to be a door, or trap door,
+leading on to the roof above Telemachus's bed room, which we are told
+was in a place that could be seen from all round--or it might be simply
+a window in Telemachus's room looking out into the street. From the
+top of the tower the outer world was to be told what was going on, but
+people could not get in by the [Greek]: they would have to come in by
+the main entrance, and Melanthius explains that the mouth of the narrow
+passage (which was in the lands of Ulysses and his friends) commanded
+the only entrance by which help could come, so that there would be
+nothing gained by raising an alarm. As for the [Greek] of line 143,
+no commentator ancient or modern has been able to say what was
+intended--but whatever they were, Melanthius could never carry twelve
+shields, twelve helmets, and twelve spears. Moreover, where he could
+go the others could go also. If a dozen suitors had followed Melanthius
+into the house they could have attacked Ulysses in the rear, in which
+case, unless Minerva had intervened promptly, the "Odyssey" would have
+had a different ending. But throughout the scene we are in a region of
+extravagance rather than of true fiction--it cannot be taken seriously
+by any but the very serious, until we come to the episode of Phemius and
+Medon, where the writer begins to be at home again.
+
+{172} I presume it was intended that there should be a hook driven into
+the bearing-post.
+
+{173} What for?
+
+{174} Gr: [Greek]. This is not [Greek].
+
+{175} From lines 333 and 341 of this book, and lines 145 and 146 of bk.
+xxi we can locate the approach to the [Greek] with some certainty.
+
+{176} But in xix. 500-502 Ulysses scolded Euryclea for offering
+information on this very point, and declared himself quite able to
+settle it for himself.
+
+{177} There were a hundred and eight Suitors.
+
+{178} Lord Grimthorpe, whose understanding does not lend itself to easy
+imposition, has been good enough to write to me about my conviction that
+the "Odyssey" was written by a woman, and to send me remarks upon the
+gross absurdity of the incident here recorded. It is plain that all
+the authoress cared about was that the women should be hanged: as for
+attempting to realise, or to make her readers realise, how the hanging
+was done, this was of no consequence. The reader must take her word for
+it and ask no questions. Lord Grimthorpe wrote:
+
+"I had better send you my ideas about Nausicaa's hanging of the
+maids (not 'maidens,' of whom Froude wrote so well in his 'Science of
+History') before I forget it all. Luckily for me Liddell & Scott have
+specially translated most of the doubtful words, referring to this very
+place.
+
+"A ship's cable. I don't know how big a ship she meant, but it must have
+been a very small one indeed if its 'cable' could be used to tie tightly
+round a woman's neck, and still more round a dozen of them 'in a row,'
+besides being strong enough to hold them and pull them all up.
+
+"A dozen average women would need the weight and strength of more than
+a dozen strong heavy men even over the best pulley hung to the roof
+over them; and the idea of pulling them up by a rope hung anyhow round a
+pillar [Greek] is absurdly impossible; and how a dozen of them could be
+hung dangling round one post is a problem which a senior wrangler would
+be puzzled to answer... She had better have let Telemachus use his sword
+as he had intended till she changed his mind for him."
+
+{179} Then they had all been in Ulysses' service over twenty years;
+perhaps the twelve guilty ones had been engaged more recently.
+
+{180} Translation very doubtful--cf. "It." xxiv. 598.
+
+{181} But why could she not at once ask to see the scar, of which
+Euryclea had told her, or why could not Ulysses have shown it to her?
+
+{182} The people of Ithaca seem to have been as fond of carping as the
+Phaeacians were in vi. 273, etc.
+
+{183} See note {156}. Ulysses's bed room does not appear to have been
+upstairs, nor yet quite within the house. Is it possible that it was
+"the domed room" round the outside of which the erring maids were, for
+aught we have heard to the contrary, still hanging?
+
+{184} Ulysses bedroom in the mind of the writer is here too apparently
+down stairs.
+
+{185} Penelope having been now sufficiently whitewashed, disappears from
+the poem.
+
+{186} So practised a washerwoman as our authoress doubtless knew that by
+this time the web must have become such a wreck that it would have gone
+to pieces in the wash.
+
+A lady points out to me, just as these sheets are leaving my hands, that
+no really good needlewoman--no one, indeed, whose work or character was
+worth consideration--could have endured, no matter for what reason, the
+unpicking of her day's work, day after day for between three and four
+years.
+
+{187} We must suppose Dolius not yet to know that his son Melanthius
+had been tortured, mutilated, and left to die by Ulysses' orders on the
+preceding day, and that his daughter Melantho had been hanged. Dolius
+was probably exceptionally simple-minded, and his name was ironical.
+So on Mt. Eryx I was shown a man who was always called Sonza Malizia or
+"Guileless"--he being held exceptionally cunning.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Odyssey, by Homer
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+***** This file should be named 1727.txt or 1727.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/2/1727/
+
+Produced by Jim Tinsley
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License available with this file or online at
+  www.gutenberg.org/license.
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation information page at www.gutenberg.org
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at 809
+North 1500 West, Salt Lake City, UT 84116, (801) 596-1887.  Email
+contact links and up to date contact information can be found at the
+Foundation's web site and official page at www.gutenberg.org/contact
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit:  www.gutenberg.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart was the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For forty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/peter-pan.txt
+++ b/jet/source-sink-builder/src/main/resources/books/peter-pan.txt
@@ -1,0 +1,6649 @@
+﻿The Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+** This is a COPYRIGHTED Project Gutenberg eBook, Details Below **
+**     Please follow the copyright guidelines in this file.     **
+
+Title: Peter Pan
+       Peter Pan and Wendy
+
+Author: James M. Barrie
+
+Posting Date: June 25, 2008 [EBook #16]
+Release Date: July, 1991
+Last Updated: October 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+
+
+
+
+
+
+
+
+
+PETER PAN
+
+[PETER AND WENDY]
+
+By J. M. Barrie [James Matthew Barrie]
+
+A Millennium Fulcrum Edition (c)1991 by Duncan Research
+
+
+
+
+Contents:
+
+Chapter 1 PETER BREAKS THROUGH
+
+Chapter 2 THE SHADOW
+
+Chapter 3 COME AWAY, COME AWAY!
+
+Chapter 4 THE FLIGHT
+
+Chapter 5 THE ISLAND COME TRUE
+
+Chapter 6 THE LITTLE HOUSE
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+Chapter 8 THE MERMAID’S LAGOON
+
+Chapter 9 THE NEVER BIRD
+
+Chapter 10 THE HAPPY HOME
+
+Chapter 11 WENDY’S STORY
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+Chapter 14 THE PIRATE SHIP
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Chapter 16 THE RETURN HOME
+
+Chapter 17 WHEN WENDY GREW UP
+
+
+
+
+Chapter 1 PETER BREAKS THROUGH
+
+All children, except one, grow up. They soon know that they will grow
+up, and the way Wendy knew was this. One day when she was two years old
+she was playing in a garden, and she plucked another flower and ran with
+it to her mother. I suppose she must have looked rather delightful, for
+Mrs. Darling put her hand to her heart and cried, “Oh, why can’t you
+remain like this for ever!” This was all that passed between them on
+the subject, but henceforth Wendy knew that she must grow up. You always
+know after you are two. Two is the beginning of the end.
+
+Of course they lived at 14 [their house number on their street], and
+until Wendy came her mother was the chief one. She was a lovely lady,
+with a romantic mind and such a sweet mocking mouth. Her romantic
+mind was like the tiny boxes, one within the other, that come from the
+puzzling East, however many you discover there is always one more; and
+her sweet mocking mouth had one kiss on it that Wendy could never get,
+though there it was, perfectly conspicuous in the right-hand corner.
+
+The way Mr. Darling won her was this: the many gentlemen who had been
+boys when she was a girl discovered simultaneously that they loved her,
+and they all ran to her house to propose to her except Mr. Darling, who
+took a cab and nipped in first, and so he got her. He got all of her,
+except the innermost box and the kiss. He never knew about the box, and
+in time he gave up trying for the kiss. Wendy thought Napoleon could
+have got it, but I can picture him trying, and then going off in a
+passion, slamming the door.
+
+Mr. Darling used to boast to Wendy that her mother not only loved him
+but respected him. He was one of those deep ones who know about stocks
+and shares. Of course no one really knows, but he quite seemed to know,
+and he often said stocks were up and shares were down in a way that
+would have made any woman respect him.
+
+Mrs. Darling was married in white, and at first she kept the books
+perfectly, almost gleefully, as if it were a game, not so much as a
+Brussels sprout was missing; but by and by whole cauliflowers dropped
+out, and instead of them there were pictures of babies without faces.
+She drew them when she should have been totting up. They were Mrs.
+Darling’s guesses.
+
+Wendy came first, then John, then Michael.
+
+For a week or two after Wendy came it was doubtful whether they would
+be able to keep her, as she was another mouth to feed. Mr. Darling was
+frightfully proud of her, but he was very honourable, and he sat on the
+edge of Mrs. Darling’s bed, holding her hand and calculating expenses,
+while she looked at him imploringly. She wanted to risk it, come what
+might, but that was not his way; his way was with a pencil and a piece
+of paper, and if she confused him with suggestions he had to begin at
+the beginning again.
+
+“Now don’t interrupt,” he would beg of her.
+
+“I have one pound seventeen here, and two and six at the office; I can
+cut off my coffee at the office, say ten shillings, making two nine
+and six, with your eighteen and three makes three nine seven, with five
+naught naught in my cheque-book makes eight nine seven--who is that
+moving?--eight nine seven, dot and carry seven--don’t speak, my own--and
+the pound you lent to that man who came to the door--quiet, child--dot
+and carry child--there, you’ve done it!--did I say nine nine seven? yes,
+I said nine nine seven; the question is, can we try it for a year on
+nine nine seven?”
+
+“Of course we can, George,” she cried. But she was prejudiced in Wendy’s
+favour, and he was really the grander character of the two.
+
+“Remember mumps,” he warned her almost threateningly, and off he went
+again. “Mumps one pound, that is what I have put down, but I daresay
+it will be more like thirty shillings--don’t speak--measles one five,
+German measles half a guinea, makes two fifteen six--don’t waggle your
+finger--whooping-cough, say fifteen shillings”--and so on it went, and
+it added up differently each time; but at last Wendy just got through,
+with mumps reduced to twelve six, and the two kinds of measles treated
+as one.
+
+There was the same excitement over John, and Michael had even a narrower
+squeak; but both were kept, and soon, you might have seen the three of
+them going in a row to Miss Fulsom’s Kindergarten school, accompanied by
+their nurse.
+
+Mrs. Darling loved to have everything just so, and Mr. Darling had a
+passion for being exactly like his neighbours; so, of course, they had
+a nurse. As they were poor, owing to the amount of milk the children
+drank, this nurse was a prim Newfoundland dog, called Nana, who had
+belonged to no one in particular until the Darlings engaged her. She had
+always thought children important, however, and the Darlings had become
+acquainted with her in Kensington Gardens, where she spent most of her
+spare time peeping into perambulators, and was much hated by careless
+nursemaids, whom she followed to their homes and complained of to their
+mistresses. She proved to be quite a treasure of a nurse. How thorough
+she was at bath-time, and up at any moment of the night if one of her
+charges made the slightest cry. Of course her kennel was in the nursery.
+She had a genius for knowing when a cough is a thing to have no patience
+with and when it needs stocking around your throat. She believed to her
+last day in old-fashioned remedies like rhubarb leaf, and made sounds of
+contempt over all this new-fangled talk about germs, and so on. It was a
+lesson in propriety to see her escorting the children to school, walking
+sedately by their side when they were well behaved, and butting them
+back into line if they strayed. On John’s footer [in England soccer
+was called football, “footer” for short] days she never once forgot his
+sweater, and she usually carried an umbrella in her mouth in case of
+rain. There is a room in the basement of Miss Fulsom’s school where the
+nurses wait. They sat on forms, while Nana lay on the floor, but that
+was the only difference. They affected to ignore her as of an inferior
+social status to themselves, and she despised their light talk. She
+resented visits to the nursery from Mrs. Darling’s friends, but if they
+did come she first whipped off Michael’s pinafore and put him into the
+one with blue braiding, and smoothed out Wendy and made a dash at John’s
+hair.
+
+No nursery could possibly have been conducted more correctly, and
+Mr. Darling knew it, yet he sometimes wondered uneasily whether the
+neighbours talked.
+
+He had his position in the city to consider.
+
+Nana also troubled him in another way. He had sometimes a feeling that
+she did not admire him. “I know she admires you tremendously, George,”
+ Mrs. Darling would assure him, and then she would sign to the children
+to be specially nice to father. Lovely dances followed, in which the
+only other servant, Liza, was sometimes allowed to join. Such a midget
+she looked in her long skirt and maid’s cap, though she had sworn, when
+engaged, that she would never see ten again. The gaiety of those romps!
+And gayest of all was Mrs. Darling, who would pirouette so wildly that
+all you could see of her was the kiss, and then if you had dashed at her
+you might have got it. There never was a simpler happier family until
+the coming of Peter Pan.
+
+Mrs. Darling first heard of Peter when she was tidying up her children’s
+minds. It is the nightly custom of every good mother after her children
+are asleep to rummage in their minds and put things straight for next
+morning, repacking into their proper places the many articles that have
+wandered during the day. If you could keep awake (but of course you
+can’t) you would see your own mother doing this, and you would find it
+very interesting to watch her. It is quite like tidying up drawers. You
+would see her on her knees, I expect, lingering humorously over some of
+your contents, wondering where on earth you had picked this thing up,
+making discoveries sweet and not so sweet, pressing this to her cheek as
+if it were as nice as a kitten, and hurriedly stowing that out of sight.
+When you wake in the morning, the naughtiness and evil passions with
+which you went to bed have been folded up small and placed at the bottom
+of your mind and on the top, beautifully aired, are spread out your
+prettier thoughts, ready for you to put on.
+
+I don’t know whether you have ever seen a map of a person’s mind.
+Doctors sometimes draw maps of other parts of you, and your own map can
+become intensely interesting, but catch them trying to draw a map of a
+child’s mind, which is not only confused, but keeps going round all
+the time. There are zigzag lines on it, just like your temperature on a
+card, and these are probably roads in the island, for the Neverland is
+always more or less an island, with astonishing splashes of colour here
+and there, and coral reefs and rakish-looking craft in the offing, and
+savages and lonely lairs, and gnomes who are mostly tailors, and caves
+through which a river runs, and princes with six elder brothers, and a
+hut fast going to decay, and one very small old lady with a hooked nose.
+It would be an easy map if that were all, but there is also first day
+at school, religion, fathers, the round pond, needle-work, murders,
+hangings, verbs that take the dative, chocolate pudding day, getting
+into braces, say ninety-nine, three-pence for pulling out your tooth
+yourself, and so on, and either these are part of the island or they are
+another map showing through, and it is all rather confusing, especially
+as nothing will stand still.
+
+Of course the Neverlands vary a good deal. John’s, for instance, had a
+lagoon with flamingoes flying over it at which John was shooting, while
+Michael, who was very small, had a flamingo with lagoons flying over
+it. John lived in a boat turned upside down on the sands, Michael in
+a wigwam, Wendy in a house of leaves deftly sewn together. John had no
+friends, Michael had friends at night, Wendy had a pet wolf forsaken by
+its parents, but on the whole the Neverlands have a family resemblance,
+and if they stood still in a row you could say of them that they have
+each other’s nose, and so forth. On these magic shores children at play
+are for ever beaching their coracles [simple boat]. We too have been
+there; we can still hear the sound of the surf, though we shall land no
+more.
+
+Of all delectable islands the Neverland is the snuggest and most
+compact, not large and sprawly, you know, with tedious distances between
+one adventure and another, but nicely crammed. When you play at it by
+day with the chairs and table-cloth, it is not in the least alarming,
+but in the two minutes before you go to sleep it becomes very real. That
+is why there are night-lights.
+
+Occasionally in her travels through her children’s minds Mrs. Darling
+found things she could not understand, and of these quite the most
+perplexing was the word Peter. She knew of no Peter, and yet he was
+here and there in John and Michael’s minds, while Wendy’s began to be
+scrawled all over with him. The name stood out in bolder letters than
+any of the other words, and as Mrs. Darling gazed she felt that it had
+an oddly cocky appearance.
+
+“Yes, he is rather cocky,” Wendy admitted with regret. Her mother had
+been questioning her.
+
+“But who is he, my pet?”
+
+“He is Peter Pan, you know, mother.”
+
+At first Mrs. Darling did not know, but after thinking back into her
+childhood she just remembered a Peter Pan who was said to live with the
+fairies. There were odd stories about him, as that when children died he
+went part of the way with them, so that they should not be frightened.
+She had believed in him at the time, but now that she was married and
+full of sense she quite doubted whether there was any such person.
+
+“Besides,” she said to Wendy, “he would be grown up by this time.”
+
+“Oh no, he isn’t grown up,” Wendy assured her confidently, “and he is
+just my size.” She meant that he was her size in both mind and body; she
+didn’t know how she knew, she just knew it.
+
+Mrs. Darling consulted Mr. Darling, but he smiled pooh-pooh. “Mark my
+words,” he said, “it is some nonsense Nana has been putting into their
+heads; just the sort of idea a dog would have. Leave it alone, and it
+will blow over.”
+
+But it would not blow over and soon the troublesome boy gave Mrs.
+Darling quite a shock.
+
+Children have the strangest adventures without being troubled by them.
+For instance, they may remember to mention, a week after the event
+happened, that when they were in the wood they had met their dead
+father and had a game with him. It was in this casual way that Wendy one
+morning made a disquieting revelation. Some leaves of a tree had been
+found on the nursery floor, which certainly were not there when the
+children went to bed, and Mrs. Darling was puzzling over them when Wendy
+said with a tolerant smile:
+
+“I do believe it is that Peter again!”
+
+“Whatever do you mean, Wendy?”
+
+“It is so naughty of him not to wipe his feet,” Wendy said, sighing. She
+was a tidy child.
+
+She explained in quite a matter-of-fact way that she thought Peter
+sometimes came to the nursery in the night and sat on the foot of her
+bed and played on his pipes to her. Unfortunately she never woke, so she
+didn’t know how she knew, she just knew.
+
+“What nonsense you talk, precious. No one can get into the house without
+knocking.”
+
+“I think he comes in by the window,” she said.
+
+“My love, it is three floors up.”
+
+“Were not the leaves at the foot of the window, mother?”
+
+It was quite true; the leaves had been found very near the window.
+
+Mrs. Darling did not know what to think, for it all seemed so natural to
+Wendy that you could not dismiss it by saying she had been dreaming.
+
+“My child,” the mother cried, “why did you not tell me of this before?”
+
+“I forgot,” said Wendy lightly. She was in a hurry to get her breakfast.
+
+Oh, surely she must have been dreaming.
+
+But, on the other hand, there were the leaves. Mrs. Darling examined
+them very carefully; they were skeleton leaves, but she was sure they
+did not come from any tree that grew in England. She crawled about the
+floor, peering at it with a candle for marks of a strange foot. She
+rattled the poker up the chimney and tapped the walls. She let down a
+tape from the window to the pavement, and it was a sheer drop of thirty
+feet, without so much as a spout to climb up by.
+
+Certainly Wendy had been dreaming.
+
+But Wendy had not been dreaming, as the very next night showed, the
+night on which the extraordinary adventures of these children may be
+said to have begun.
+
+On the night we speak of all the children were once more in bed. It
+happened to be Nana’s evening off, and Mrs. Darling had bathed them and
+sung to them till one by one they had let go her hand and slid away into
+the land of sleep.
+
+All were looking so safe and cosy that she smiled at her fears now and
+sat down tranquilly by the fire to sew.
+
+It was something for Michael, who on his birthday was getting into
+shirts. The fire was warm, however, and the nursery dimly lit by three
+night-lights, and presently the sewing lay on Mrs. Darling’s lap. Then
+her head nodded, oh, so gracefully. She was asleep. Look at the four of
+them, Wendy and Michael over there, John here, and Mrs. Darling by the
+fire. There should have been a fourth night-light.
+
+While she slept she had a dream. She dreamt that the Neverland had come
+too near and that a strange boy had broken through from it. He did not
+alarm her, for she thought she had seen him before in the faces of many
+women who have no children. Perhaps he is to be found in the faces of
+some mothers also. But in her dream he had rent the film that obscures
+the Neverland, and she saw Wendy and John and Michael peeping through
+the gap.
+
+The dream by itself would have been a trifle, but while she was dreaming
+the window of the nursery blew open, and a boy did drop on the floor.
+He was accompanied by a strange light, no bigger than your fist, which
+darted about the room like a living thing and I think it must have been
+this light that wakened Mrs. Darling.
+
+She started up with a cry, and saw the boy, and somehow she knew at once
+that he was Peter Pan. If you or I or Wendy had been there we should
+have seen that he was very like Mrs. Darling’s kiss. He was a lovely
+boy, clad in skeleton leaves and the juices that ooze out of trees but
+the most entrancing thing about him was that he had all his first teeth.
+When he saw she was a grown-up, he gnashed the little pearls at her.
+
+
+
+
+Chapter 2 THE SHADOW
+
+Mrs. Darling screamed, and, as if in answer to a bell, the door opened,
+and Nana entered, returned from her evening out. She growled and sprang
+at the boy, who leapt lightly through the window. Again Mrs. Darling
+screamed, this time in distress for him, for she thought he was killed,
+and she ran down into the street to look for his little body, but it
+was not there; and she looked up, and in the black night she could see
+nothing but what she thought was a shooting star.
+
+She returned to the nursery, and found Nana with something in her mouth,
+which proved to be the boy’s shadow. As he leapt at the window Nana had
+closed it quickly, too late to catch him, but his shadow had not had
+time to get out; slam went the window and snapped it off.
+
+You may be sure Mrs. Darling examined the shadow carefully, but it was
+quite the ordinary kind.
+
+Nana had no doubt of what was the best thing to do with this shadow. She
+hung it out at the window, meaning “He is sure to come back for it; let
+us put it where he can get it easily without disturbing the children.”
+
+But unfortunately Mrs. Darling could not leave it hanging out at the
+window, it looked so like the washing and lowered the whole tone of the
+house. She thought of showing it to Mr. Darling, but he was totting up
+winter great-coats for John and Michael, with a wet towel around his
+head to keep his brain clear, and it seemed a shame to trouble him;
+besides, she knew exactly what he would say: “It all comes of having a
+dog for a nurse.”
+
+She decided to roll the shadow up and put it away carefully in a drawer,
+until a fitting opportunity came for telling her husband. Ah me!
+
+The opportunity came a week later, on that never-to-be-forgotten Friday.
+Of course it was a Friday.
+
+“I ought to have been specially careful on a Friday,” she used to say
+afterwards to her husband, while perhaps Nana was on the other side of
+her, holding her hand.
+
+“No, no,” Mr. Darling always said, “I am responsible for it all. I,
+George Darling, did it. MEA CULPA, MEA CULPA.” He had had a classical
+education.
+
+They sat thus night after night recalling that fatal Friday, till every
+detail of it was stamped on their brains and came through on the other
+side like the faces on a bad coinage.
+
+“If only I had not accepted that invitation to dine at 27,” Mrs. Darling
+said.
+
+“If only I had not poured my medicine into Nana’s bowl,” said Mr.
+Darling.
+
+“If only I had pretended to like the medicine,” was what Nana’s wet eyes
+said.
+
+“My liking for parties, George.”
+
+“My fatal gift of humour, dearest.”
+
+“My touchiness about trifles, dear master and mistress.”
+
+Then one or more of them would break down altogether; Nana at the
+thought, “It’s true, it’s true, they ought not to have had a dog for
+a nurse.” Many a time it was Mr. Darling who put the handkerchief to
+Nana’s eyes.
+
+“That fiend!” Mr. Darling would cry, and Nana’s bark was the echo of
+it, but Mrs. Darling never upbraided Peter; there was something in the
+right-hand corner of her mouth that wanted her not to call Peter names.
+
+They would sit there in the empty nursery, recalling fondly every
+smallest detail of that dreadful evening. It had begun so uneventfully,
+so precisely like a hundred other evenings, with Nana putting on the
+water for Michael’s bath and carrying him to it on her back.
+
+“I won’t go to bed,” he had shouted, like one who still believed that he
+had the last word on the subject, “I won’t, I won’t. Nana, it isn’t six
+o’clock yet. Oh dear, oh dear, I shan’t love you any more, Nana. I tell
+you I won’t be bathed, I won’t, I won’t!”
+
+Then Mrs. Darling had come in, wearing her white evening-gown. She had
+dressed early because Wendy so loved to see her in her evening-gown,
+with the necklace George had given her. She was wearing Wendy’s bracelet
+on her arm; she had asked for the loan of it. Wendy loved to lend her
+bracelet to her mother.
+
+She had found her two older children playing at being herself and father
+on the occasion of Wendy’s birth, and John was saying:
+
+“I am happy to inform you, Mrs. Darling, that you are now a mother,”
+ in just such a tone as Mr. Darling himself may have used on the real
+occasion.
+
+Wendy had danced with joy, just as the real Mrs. Darling must have done.
+
+Then John was born, with the extra pomp that he conceived due to the
+birth of a male, and Michael came from his bath to ask to be born also,
+but John said brutally that they did not want any more.
+
+Michael had nearly cried. “Nobody wants me,” he said, and of course the
+lady in the evening-dress could not stand that.
+
+“I do,” she said, “I so want a third child.”
+
+“Boy or girl?” asked Michael, not too hopefully.
+
+“Boy.”
+
+Then he had leapt into her arms. Such a little thing for Mr. and Mrs.
+Darling and Nana to recall now, but not so little if that was to be
+Michael’s last night in the nursery.
+
+They go on with their recollections.
+
+“It was then that I rushed in like a tornado, wasn’t it?” Mr. Darling
+would say, scorning himself; and indeed he had been like a tornado.
+
+Perhaps there was some excuse for him. He, too, had been dressing for
+the party, and all had gone well with him until he came to his tie. It
+is an astounding thing to have to tell, but this man, though he knew
+about stocks and shares, had no real mastery of his tie. Sometimes the
+thing yielded to him without a contest, but there were occasions when it
+would have been better for the house if he had swallowed his pride and
+used a made-up tie.
+
+This was such an occasion. He came rushing into the nursery with the
+crumpled little brute of a tie in his hand.
+
+“Why, what is the matter, father dear?”
+
+“Matter!” he yelled; he really yelled. “This tie, it will not tie.” He
+became dangerously sarcastic. “Not round my neck! Round the bed-post!
+Oh yes, twenty times have I made it up round the bed-post, but round my
+neck, no! Oh dear no! begs to be excused!”
+
+He thought Mrs. Darling was not sufficiently impressed, and he went on
+sternly, “I warn you of this, mother, that unless this tie is round my
+neck we don’t go out to dinner to-night, and if I don’t go out to dinner
+to-night, I never go to the office again, and if I don’t go to the
+office again, you and I starve, and our children will be flung into the
+streets.”
+
+Even then Mrs. Darling was placid. “Let me try, dear,” she said, and
+indeed that was what he had come to ask her to do, and with her nice
+cool hands she tied his tie for him, while the children stood around to
+see their fate decided. Some men would have resented her being able to
+do it so easily, but Mr. Darling had far too fine a nature for that; he
+thanked her carelessly, at once forgot his rage, and in another moment
+was dancing round the room with Michael on his back.
+
+“How wildly we romped!” says Mrs. Darling now, recalling it.
+
+“Our last romp!” Mr. Darling groaned.
+
+“O George, do you remember Michael suddenly said to me, ‘How did you get
+to know me, mother?’”
+
+“I remember!”
+
+“They were rather sweet, don’t you think, George?”
+
+“And they were ours, ours! and now they are gone.”
+
+The romp had ended with the appearance of Nana, and most unluckily Mr.
+Darling collided against her, covering his trousers with hairs. They
+were not only new trousers, but they were the first he had ever had
+with braid on them, and he had had to bite his lip to prevent the tears
+coming. Of course Mrs. Darling brushed him, but he began to talk again
+about its being a mistake to have a dog for a nurse.
+
+“George, Nana is a treasure.”
+
+“No doubt, but I have an uneasy feeling at times that she looks upon the
+children as puppies.”
+
+“Oh no, dear one, I feel sure she knows they have souls.”
+
+“I wonder,” Mr. Darling said thoughtfully, “I wonder.” It was an
+opportunity, his wife felt, for telling him about the boy. At first he
+pooh-poohed the story, but he became thoughtful when she showed him the
+shadow.
+
+“It is nobody I know,” he said, examining it carefully, “but it does
+look a scoundrel.”
+
+“We were still discussing it, you remember,” says Mr. Darling, “when
+Nana came in with Michael’s medicine. You will never carry the bottle in
+your mouth again, Nana, and it is all my fault.”
+
+Strong man though he was, there is no doubt that he had behaved rather
+foolishly over the medicine. If he had a weakness, it was for thinking
+that all his life he had taken medicine boldly, and so now, when Michael
+dodged the spoon in Nana’s mouth, he had said reprovingly, “Be a man,
+Michael.”
+
+“Won’t; won’t!” Michael cried naughtily. Mrs. Darling left the room to
+get a chocolate for him, and Mr. Darling thought this showed want of
+firmness.
+
+“Mother, don’t pamper him,” he called after her. “Michael, when I was
+your age I took medicine without a murmur. I said, ‘Thank you, kind
+parents, for giving me bottles to make me well.’”
+
+He really thought this was true, and Wendy, who was now in her
+night-gown, believed it also, and she said, to encourage Michael, “That
+medicine you sometimes take, father, is much nastier, isn’t it?”
+
+“Ever so much nastier,” Mr. Darling said bravely, “and I would take it
+now as an example to you, Michael, if I hadn’t lost the bottle.”
+
+He had not exactly lost it; he had climbed in the dead of night to the
+top of the wardrobe and hidden it there. What he did not know was that
+the faithful Liza had found it, and put it back on his wash-stand.
+
+“I know where it is, father,” Wendy cried, always glad to be of service.
+“I’ll bring it,” and she was off before he could stop her. Immediately
+his spirits sank in the strangest way.
+
+“John,” he said, shuddering, “it’s most beastly stuff. It’s that nasty,
+sticky, sweet kind.”
+
+“It will soon be over, father,” John said cheerily, and then in rushed
+Wendy with the medicine in a glass.
+
+“I have been as quick as I could,” she panted.
+
+“You have been wonderfully quick,” her father retorted, with a
+vindictive politeness that was quite thrown away upon her. “Michael
+first,” he said doggedly.
+
+“Father first,” said Michael, who was of a suspicious nature.
+
+“I shall be sick, you know,” Mr. Darling said threateningly.
+
+“Come on, father,” said John.
+
+“Hold your tongue, John,” his father rapped out.
+
+Wendy was quite puzzled. “I thought you took it quite easily, father.”
+
+“That is not the point,” he retorted. “The point is, that there is
+more in my glass than in Michael’s spoon.” His proud heart was nearly
+bursting. “And it isn’t fair: I would say it though it were with my last
+breath; it isn’t fair.”
+
+“Father, I am waiting,” said Michael coldly.
+
+“It’s all very well to say you are waiting; so am I waiting.”
+
+“Father’s a cowardly custard.”
+
+“So are you a cowardly custard.”
+
+“I’m not frightened.”
+
+“Neither am I frightened.”
+
+“Well, then, take it.”
+
+“Well, then, you take it.”
+
+Wendy had a splendid idea. “Why not both take it at the same time?”
+
+“Certainly,” said Mr. Darling. “Are you ready, Michael?”
+
+Wendy gave the words, one, two, three, and Michael took his medicine,
+but Mr. Darling slipped his behind his back.
+
+There was a yell of rage from Michael, and “O father!” Wendy exclaimed.
+
+“What do you mean by ‘O father’?” Mr. Darling demanded. “Stop that row,
+Michael. I meant to take mine, but I--I missed it.”
+
+It was dreadful the way all the three were looking at him, just as if
+they did not admire him. “Look here, all of you,” he said entreatingly,
+as soon as Nana had gone into the bathroom. “I have just thought of a
+splendid joke. I shall pour my medicine into Nana’s bowl, and she will
+drink it, thinking it is milk!”
+
+It was the colour of milk; but the children did not have their father’s
+sense of humour, and they looked at him reproachfully as he poured the
+medicine into Nana’s bowl. “What fun!” he said doubtfully, and they did
+not dare expose him when Mrs. Darling and Nana returned.
+
+“Nana, good dog,” he said, patting her, “I have put a little milk into
+your bowl, Nana.”
+
+Nana wagged her tail, ran to the medicine, and began lapping it. Then
+she gave Mr. Darling such a look, not an angry look: she showed him the
+great red tear that makes us so sorry for noble dogs, and crept into her
+kennel.
+
+Mr. Darling was frightfully ashamed of himself, but he would not give
+in. In a horrid silence Mrs. Darling smelt the bowl. “O George,” she
+said, “it’s your medicine!”
+
+“It was only a joke,” he roared, while she comforted her boys, and Wendy
+hugged Nana. “Much good,” he said bitterly, “my wearing myself to the
+bone trying to be funny in this house.”
+
+And still Wendy hugged Nana. “That’s right,” he shouted. “Coddle her!
+Nobody coddles me. Oh dear no! I am only the breadwinner, why should I
+be coddled--why, why, why!”
+
+“George,” Mrs. Darling entreated him, “not so loud; the servants
+will hear you.” Somehow they had got into the way of calling Liza the
+servants.
+
+“Let them!” he answered recklessly. “Bring in the whole world. But I
+refuse to allow that dog to lord it in my nursery for an hour longer.”
+
+The children wept, and Nana ran to him beseechingly, but he waved her
+back. He felt he was a strong man again. “In vain, in vain,” he cried;
+“the proper place for you is the yard, and there you go to be tied up
+this instant.”
+
+“George, George,” Mrs. Darling whispered, “remember what I told you
+about that boy.”
+
+Alas, he would not listen. He was determined to show who was master in
+that house, and when commands would not draw Nana from the kennel, he
+lured her out of it with honeyed words, and seizing her roughly, dragged
+her from the nursery. He was ashamed of himself, and yet he did it.
+It was all owing to his too affectionate nature, which craved for
+admiration. When he had tied her up in the back-yard, the wretched
+father went and sat in the passage, with his knuckles to his eyes.
+
+In the meantime Mrs. Darling had put the children to bed in unwonted
+silence and lit their night-lights. They could hear Nana barking, and
+John whimpered, “It is because he is chaining her up in the yard,” but
+Wendy was wiser.
+
+“That is not Nana’s unhappy bark,” she said, little guessing what was
+about to happen; “that is her bark when she smells danger.”
+
+Danger!
+
+“Are you sure, Wendy?”
+
+“Oh, yes.”
+
+Mrs. Darling quivered and went to the window. It was securely fastened.
+She looked out, and the night was peppered with stars. They were
+crowding round the house, as if curious to see what was to take place
+there, but she did not notice this, nor that one or two of the smaller
+ones winked at her. Yet a nameless fear clutched at her heart and made
+her cry, “Oh, how I wish that I wasn’t going to a party to-night!”
+
+Even Michael, already half asleep, knew that she was perturbed, and he
+asked, “Can anything harm us, mother, after the night-lights are lit?”
+
+“Nothing, precious,” she said; “they are the eyes a mother leaves behind
+her to guard her children.”
+
+She went from bed to bed singing enchantments over them, and little
+Michael flung his arms round her. “Mother,” he cried, “I’m glad of you.”
+ They were the last words she was to hear from him for a long time.
+
+No. 27 was only a few yards distant, but there had been a slight fall of
+snow, and Father and Mother Darling picked their way over it deftly not
+to soil their shoes. They were already the only persons in the street,
+and all the stars were watching them. Stars are beautiful, but they may
+not take an active part in anything, they must just look on for ever. It
+is a punishment put on them for something they did so long ago that no
+star now knows what it was. So the older ones have become glassy-eyed
+and seldom speak (winking is the star language), but the little
+ones still wonder. They are not really friendly to Peter, who had a
+mischievous way of stealing up behind them and trying to blow them out;
+but they are so fond of fun that they were on his side to-night, and
+anxious to get the grown-ups out of the way. So as soon as the door
+of 27 closed on Mr. and Mrs. Darling there was a commotion in the
+firmament, and the smallest of all the stars in the Milky Way screamed
+out:
+
+“Now, Peter!”
+
+
+
+
+Chapter 3 COME AWAY, COME AWAY!
+
+For a moment after Mr. and Mrs. Darling left the house the night-lights
+by the beds of the three children continued to burn clearly. They were
+awfully nice little night-lights, and one cannot help wishing that they
+could have kept awake to see Peter; but Wendy’s light blinked and gave
+such a yawn that the other two yawned also, and before they could close
+their mouths all the three went out.
+
+There was another light in the room now, a thousand times brighter than
+the night-lights, and in the time we have taken to say this, it had been
+in all the drawers in the nursery, looking for Peter’s shadow, rummaged
+the wardrobe and turned every pocket inside out. It was not really a
+light; it made this light by flashing about so quickly, but when it came
+to rest for a second you saw it was a fairy, no longer than your hand,
+but still growing. It was a girl called Tinker Bell exquisitely gowned
+in a skeleton leaf, cut low and square, through which her figure could
+be seen to the best advantage. She was slightly inclined to EMBONPOINT.
+[plump hourglass figure]
+
+A moment after the fairy’s entrance the window was blown open by the
+breathing of the little stars, and Peter dropped in. He had carried
+Tinker Bell part of the way, and his hand was still messy with the fairy
+dust.
+
+“Tinker Bell,” he called softly, after making sure that the children
+were asleep, “Tink, where are you?” She was in a jug for the moment, and
+liking it extremely; she had never been in a jug before.
+
+“Oh, do come out of that jug, and tell me, do you know where they put my
+shadow?”
+
+The loveliest tinkle as of golden bells answered him. It is the fairy
+language. You ordinary children can never hear it, but if you were to
+hear it you would know that you had heard it once before.
+
+Tink said that the shadow was in the big box. She meant the chest of
+drawers, and Peter jumped at the drawers, scattering their contents to
+the floor with both hands, as kings toss ha’pence to the crowd. In a
+moment he had recovered his shadow, and in his delight he forgot that he
+had shut Tinker Bell up in the drawer.
+
+If he thought at all, but I don’t believe he ever thought, it was that
+he and his shadow, when brought near each other, would join like drops
+of water, and when they did not he was appalled. He tried to stick it
+on with soap from the bathroom, but that also failed. A shudder passed
+through Peter, and he sat on the floor and cried.
+
+His sobs woke Wendy, and she sat up in bed. She was not alarmed to see
+a stranger crying on the nursery floor; she was only pleasantly
+interested.
+
+“Boy,” she said courteously, “why are you crying?”
+
+Peter could be exceeding polite also, having learned the grand manner at
+fairy ceremonies, and he rose and bowed to her beautifully. She was much
+pleased, and bowed beautifully to him from the bed.
+
+“What’s your name?” he asked.
+
+“Wendy Moira Angela Darling,” she replied with some satisfaction. “What
+is your name?”
+
+“Peter Pan.”
+
+She was already sure that he must be Peter, but it did seem a
+comparatively short name.
+
+“Is that all?”
+
+“Yes,” he said rather sharply. He felt for the first time that it was a
+shortish name.
+
+“I’m so sorry,” said Wendy Moira Angela.
+
+“It doesn’t matter,” Peter gulped.
+
+She asked where he lived.
+
+“Second to the right,” said Peter, “and then straight on till morning.”
+
+“What a funny address!”
+
+Peter had a sinking. For the first time he felt that perhaps it was a
+funny address.
+
+“No, it isn’t,” he said.
+
+“I mean,” Wendy said nicely, remembering that she was hostess, “is that
+what they put on the letters?”
+
+He wished she had not mentioned letters.
+
+“Don’t get any letters,” he said contemptuously.
+
+“But your mother gets letters?”
+
+“Don’t have a mother,” he said. Not only had he no mother, but he had
+not the slightest desire to have one. He thought them very over-rated
+persons. Wendy, however, felt at once that she was in the presence of a
+tragedy.
+
+“O Peter, no wonder you were crying,” she said, and got out of bed and
+ran to him.
+
+“I wasn’t crying about mothers,” he said rather indignantly. “I was
+crying because I can’t get my shadow to stick on. Besides, I wasn’t
+crying.”
+
+“It has come off?”
+
+“Yes.”
+
+Then Wendy saw the shadow on the floor, looking so draggled, and she was
+frightfully sorry for Peter. “How awful!” she said, but she could not
+help smiling when she saw that he had been trying to stick it on with
+soap. How exactly like a boy!
+
+Fortunately she knew at once what to do. “It must be sewn on,” she said,
+just a little patronisingly.
+
+“What’s sewn?” he asked.
+
+“You’re dreadfully ignorant.”
+
+“No, I’m not.”
+
+But she was exulting in his ignorance. “I shall sew it on for you, my
+little man,” she said, though he was tall as herself, and she got out
+her housewife [sewing bag], and sewed the shadow on to Peter’s foot.
+
+“I daresay it will hurt a little,” she warned him.
+
+“Oh, I shan’t cry,” said Peter, who was already of the opinion that he
+had never cried in his life. And he clenched his teeth and did not
+cry, and soon his shadow was behaving properly, though still a little
+creased.
+
+“Perhaps I should have ironed it,” Wendy said thoughtfully, but Peter,
+boylike, was indifferent to appearances, and he was now jumping about in
+the wildest glee. Alas, he had already forgotten that he owed his bliss
+to Wendy. He thought he had attached the shadow himself. “How clever I
+am!” he crowed rapturously, “oh, the cleverness of me!”
+
+It is humiliating to have to confess that this conceit of Peter was
+one of his most fascinating qualities. To put it with brutal frankness,
+there never was a cockier boy.
+
+But for the moment Wendy was shocked. “You conceit [braggart],” she
+exclaimed, with frightful sarcasm; “of course I did nothing!”
+
+“You did a little,” Peter said carelessly, and continued to dance.
+
+“A little!” she replied with hauteur [pride]; “if I am no use I can at
+least withdraw,” and she sprang in the most dignified way into bed and
+covered her face with the blankets.
+
+To induce her to look up he pretended to be going away, and when this
+failed he sat on the end of the bed and tapped her gently with his foot.
+“Wendy,” he said, “don’t withdraw. I can’t help crowing, Wendy, when
+I’m pleased with myself.” Still she would not look up, though she was
+listening eagerly. “Wendy,” he continued, in a voice that no woman has
+ever yet been able to resist, “Wendy, one girl is more use than twenty
+boys.”
+
+Now Wendy was every inch a woman, though there were not very many
+inches, and she peeped out of the bed-clothes.
+
+“Do you really think so, Peter?”
+
+“Yes, I do.”
+
+“I think it’s perfectly sweet of you,” she declared, “and I’ll get up
+again,” and she sat with him on the side of the bed. She also said
+she would give him a kiss if he liked, but Peter did not know what she
+meant, and he held out his hand expectantly.
+
+“Surely you know what a kiss is?” she asked, aghast.
+
+“I shall know when you give it to me,” he replied stiffly, and not to
+hurt his feeling she gave him a thimble.
+
+“Now,” said he, “shall I give you a kiss?” and she replied with a slight
+primness, “If you please.” She made herself rather cheap by inclining
+her face toward him, but he merely dropped an acorn button into her
+hand, so she slowly returned her face to where it had been before, and
+said nicely that she would wear his kiss on the chain around her neck.
+It was lucky that she did put it on that chain, for it was afterwards to
+save her life.
+
+When people in our set are introduced, it is customary for them to
+ask each other’s age, and so Wendy, who always liked to do the correct
+thing, asked Peter how old he was. It was not really a happy question to
+ask him; it was like an examination paper that asks grammar, when what
+you want to be asked is Kings of England.
+
+“I don’t know,” he replied uneasily, “but I am quite young.” He really
+knew nothing about it, he had merely suspicions, but he said at a
+venture, “Wendy, I ran away the day I was born.”
+
+Wendy was quite surprised, but interested; and she indicated in the
+charming drawing-room manner, by a touch on her night-gown, that he
+could sit nearer her.
+
+“It was because I heard father and mother,” he explained in a low
+voice, “talking about what I was to be when I became a man.” He was
+extraordinarily agitated now. “I don’t want ever to be a man,” he said
+with passion. “I want always to be a little boy and to have fun. So
+I ran away to Kensington Gardens and lived a long long time among the
+fairies.”
+
+She gave him a look of the most intense admiration, and he thought it
+was because he had run away, but it was really because he knew fairies.
+Wendy had lived such a home life that to know fairies struck her as
+quite delightful. She poured out questions about them, to his surprise,
+for they were rather a nuisance to him, getting in his way and so on,
+and indeed he sometimes had to give them a hiding [spanking]. Still, he
+liked them on the whole, and he told her about the beginning of fairies.
+
+“You see, Wendy, when the first baby laughed for the first time, its
+laugh broke into a thousand pieces, and they all went skipping about,
+and that was the beginning of fairies.”
+
+Tedious talk this, but being a stay-at-home she liked it.
+
+“And so,” he went on good-naturedly, “there ought to be one fairy for
+every boy and girl.”
+
+“Ought to be? Isn’t there?”
+
+“No. You see children know such a lot now, they soon don’t believe in
+fairies, and every time a child says, ‘I don’t believe in fairies,’
+there is a fairy somewhere that falls down dead.”
+
+Really, he thought they had now talked enough about fairies, and it
+struck him that Tinker Bell was keeping very quiet. “I can’t think where
+she has gone to,” he said, rising, and he called Tink by name. Wendy’s
+heart went flutter with a sudden thrill.
+
+“Peter,” she cried, clutching him, “you don’t mean to tell me that there
+is a fairy in this room!”
+
+“She was here just now,” he said a little impatiently. “You don’t hear
+her, do you?” and they both listened.
+
+“The only sound I hear,” said Wendy, “is like a tinkle of bells.”
+
+“Well, that’s Tink, that’s the fairy language. I think I hear her too.”
+
+The sound came from the chest of drawers, and Peter made a merry face.
+No one could ever look quite so merry as Peter, and the loveliest of
+gurgles was his laugh. He had his first laugh still.
+
+“Wendy,” he whispered gleefully, “I do believe I shut her up in the
+drawer!”
+
+He let poor Tink out of the drawer, and she flew about the nursery
+screaming with fury. “You shouldn’t say such things,” Peter retorted.
+“Of course I’m very sorry, but how could I know you were in the drawer?”
+
+Wendy was not listening to him. “O Peter,” she cried, “if she would only
+stand still and let me see her!”
+
+“They hardly ever stand still,” he said, but for one moment Wendy saw
+the romantic figure come to rest on the cuckoo clock. “O the lovely!”
+ she cried, though Tink’s face was still distorted with passion.
+
+“Tink,” said Peter amiably, “this lady says she wishes you were her
+fairy.”
+
+Tinker Bell answered insolently.
+
+“What does she say, Peter?”
+
+He had to translate. “She is not very polite. She says you are a great
+[huge] ugly girl, and that she is my fairy.”
+
+He tried to argue with Tink. “You know you can’t be my fairy, Tink,
+because I am an gentleman and you are a lady.”
+
+To this Tink replied in these words, “You silly ass,” and disappeared
+into the bathroom. “She is quite a common fairy,” Peter explained
+apologetically, “she is called Tinker Bell because she mends the pots
+and kettles [tinker = tin worker].” [Similar to “cinder” plus “elle” to
+get Cinderella]
+
+They were together in the armchair by this time, and Wendy plied him
+with more questions.
+
+“If you don’t live in Kensington Gardens now--”
+
+“Sometimes I do still.”
+
+“But where do you live mostly now?”
+
+“With the lost boys.”
+
+“Who are they?”
+
+“They are the children who fall out of their perambulators when the
+nurse is looking the other way. If they are not claimed in seven
+days they are sent far away to the Neverland to defray expenses. I’m
+captain.”
+
+“What fun it must be!”
+
+“Yes,” said cunning Peter, “but we are rather lonely. You see we have no
+female companionship.”
+
+“Are none of the others girls?”
+
+“Oh, no; girls, you know, are much too clever to fall out of their
+prams.”
+
+This flattered Wendy immensely. “I think,” she said, “it is perfectly
+lovely the way you talk about girls; John there just despises us.”
+
+For reply Peter rose and kicked John out of bed, blankets and all; one
+kick. This seemed to Wendy rather forward for a first meeting, and she
+told him with spirit that he was not captain in her house. However,
+John continued to sleep so placidly on the floor that she allowed him
+to remain there. “And I know you meant to be kind,” she said, relenting,
+“so you may give me a kiss.”
+
+For the moment she had forgotten his ignorance about kisses. “I thought
+you would want it back,” he said a little bitterly, and offered to
+return her the thimble.
+
+“Oh dear,” said the nice Wendy, “I don’t mean a kiss, I mean a thimble.”
+
+“What’s that?”
+
+“It’s like this.” She kissed him.
+
+“Funny!” said Peter gravely. “Now shall I give you a thimble?”
+
+“If you wish to,” said Wendy, keeping her head erect this time.
+
+Peter thimbled her, and almost immediately she screeched. “What is it,
+Wendy?”
+
+“It was exactly as if someone were pulling my hair.”
+
+“That must have been Tink. I never knew her so naughty before.”
+
+And indeed Tink was darting about again, using offensive language.
+
+“She says she will do that to you, Wendy, every time I give you a
+thimble.”
+
+“But why?”
+
+“Why, Tink?”
+
+Again Tink replied, “You silly ass.” Peter could not understand why,
+but Wendy understood, and she was just slightly disappointed when he
+admitted that he came to the nursery window not to see her but to listen
+to stories.
+
+“You see, I don’t know any stories. None of the lost boys knows any
+stories.”
+
+“How perfectly awful,” Wendy said.
+
+“Do you know,” Peter asked “why swallows build in the eaves of houses?
+It is to listen to the stories. O Wendy, your mother was telling you
+such a lovely story.”
+
+“Which story was it?”
+
+“About the prince who couldn’t find the lady who wore the glass
+slipper.”
+
+“Peter,” said Wendy excitedly, “that was Cinderella, and he found her,
+and they lived happily ever after.”
+
+Peter was so glad that he rose from the floor, where they had been
+sitting, and hurried to the window.
+
+“Where are you going?” she cried with misgiving.
+
+“To tell the other boys.”
+
+“Don’t go Peter,” she entreated, “I know such lots of stories.”
+
+Those were her precise words, so there can be no denying that it was she
+who first tempted him.
+
+He came back, and there was a greedy look in his eyes now which ought to
+have alarmed her, but did not.
+
+“Oh, the stories I could tell to the boys!” she cried, and then Peter
+gripped her and began to draw her toward the window.
+
+“Let me go!” she ordered him.
+
+“Wendy, do come with me and tell the other boys.”
+
+Of course she was very pleased to be asked, but she said, “Oh dear, I
+can’t. Think of mummy! Besides, I can’t fly.”
+
+“I’ll teach you.”
+
+“Oh, how lovely to fly.”
+
+“I’ll teach you how to jump on the wind’s back, and then away we go.”
+
+“Oo!” she exclaimed rapturously.
+
+“Wendy, Wendy, when you are sleeping in your silly bed you might be
+flying about with me saying funny things to the stars.”
+
+“Oo!”
+
+“And, Wendy, there are mermaids.”
+
+“Mermaids! With tails?”
+
+“Such long tails.”
+
+“Oh,” cried Wendy, “to see a mermaid!”
+
+He had become frightfully cunning. “Wendy,” he said, “how we should all
+respect you.”
+
+She was wriggling her body in distress. It was quite as if she were
+trying to remain on the nursery floor.
+
+But he had no pity for her.
+
+“Wendy,” he said, the sly one, “you could tuck us in at night.”
+
+“Oo!”
+
+“None of us has ever been tucked in at night.”
+
+“Oo,” and her arms went out to him.
+
+“And you could darn our clothes, and make pockets for us. None of us has
+any pockets.”
+
+How could she resist. “Of course it’s awfully fascinating!” she cried.
+“Peter, would you teach John and Michael to fly too?”
+
+“If you like,” he said indifferently, and she ran to John and Michael
+and shook them. “Wake up,” she cried, “Peter Pan has come and he is to
+teach us to fly.”
+
+John rubbed his eyes. “Then I shall get up,” he said. Of course he was
+on the floor already. “Hallo,” he said, “I am up!”
+
+Michael was up by this time also, looking as sharp as a knife with six
+blades and a saw, but Peter suddenly signed silence. Their faces assumed
+the awful craftiness of children listening for sounds from the grown-up
+world. All was as still as salt. Then everything was right. No, stop!
+Everything was wrong. Nana, who had been barking distressfully all the
+evening, was quiet now. It was her silence they had heard.
+
+“Out with the light! Hide! Quick!” cried John, taking command for the
+only time throughout the whole adventure. And thus when Liza entered,
+holding Nana, the nursery seemed quite its old self, very dark, and
+you would have sworn you heard its three wicked inmates breathing
+angelically as they slept. They were really doing it artfully from
+behind the window curtains.
+
+Liza was in a bad temper, for she was mixing the Christmas puddings in
+the kitchen, and had been drawn from them, with a raisin still on her
+cheek, by Nana’s absurd suspicions. She thought the best way of getting
+a little quiet was to take Nana to the nursery for a moment, but in
+custody of course.
+
+“There, you suspicious brute,” she said, not sorry that Nana was in
+disgrace. “They are perfectly safe, aren’t they? Every one of the little
+angels sound asleep in bed. Listen to their gentle breathing.”
+
+Here Michael, encouraged by his success, breathed so loudly that they
+were nearly detected. Nana knew that kind of breathing, and she tried to
+drag herself out of Liza’s clutches.
+
+But Liza was dense. “No more of it, Nana,” she said sternly, pulling
+her out of the room. “I warn you if you bark again I shall go straight
+for master and missus and bring them home from the party, and then, oh,
+won’t master whip you, just.”
+
+She tied the unhappy dog up again, but do you think Nana ceased to bark?
+Bring master and missus home from the party! Why, that was just what she
+wanted. Do you think she cared whether she was whipped so long as her
+charges were safe? Unfortunately Liza returned to her puddings, and
+Nana, seeing that no help would come from her, strained and strained at
+the chain until at last she broke it. In another moment she had burst
+into the dining-room of 27 and flung up her paws to heaven, her most
+expressive way of making a communication. Mr. and Mrs. Darling knew at
+once that something terrible was happening in their nursery, and without
+a good-bye to their hostess they rushed into the street.
+
+But it was now ten minutes since three scoundrels had been breathing
+behind the curtains, and Peter Pan can do a great deal in ten minutes.
+
+We now return to the nursery.
+
+“It’s all right,” John announced, emerging from his hiding-place. “I
+say, Peter, can you really fly?”
+
+Instead of troubling to answer him Peter flew around the room, taking
+the mantelpiece on the way.
+
+“How topping!” said John and Michael.
+
+“How sweet!” cried Wendy.
+
+“Yes, I’m sweet, oh, I am sweet!” said Peter, forgetting his manners
+again.
+
+It looked delightfully easy, and they tried it first from the floor and
+then from the beds, but they always went down instead of up.
+
+“I say, how do you do it?” asked John, rubbing his knee. He was quite a
+practical boy.
+
+“You just think lovely wonderful thoughts,” Peter explained, “and they
+lift you up in the air.”
+
+He showed them again.
+
+“You’re so nippy at it,” John said, “couldn’t you do it very slowly
+once?”
+
+Peter did it both slowly and quickly. “I’ve got it now, Wendy!” cried
+John, but soon he found he had not. Not one of them could fly an inch,
+though even Michael was in words of two syllables, and Peter did not
+know A from Z.
+
+Of course Peter had been trifling with them, for no one can fly unless
+the fairy dust has been blown on him. Fortunately, as we have mentioned,
+one of his hands was messy with it, and he blew some on each of them,
+with the most superb results.
+
+“Now just wiggle your shoulders this way,” he said, “and let go.”
+
+They were all on their beds, and gallant Michael let go first. He did
+not quite mean to let go, but he did it, and immediately he was borne
+across the room.
+
+“I flewed!” he screamed while still in mid-air.
+
+John let go and met Wendy near the bathroom.
+
+“Oh, lovely!”
+
+“Oh, ripping!”
+
+“Look at me!”
+
+“Look at me!”
+
+“Look at me!”
+
+They were not nearly so elegant as Peter, they could not help kicking a
+little, but their heads were bobbing against the ceiling, and there is
+almost nothing so delicious as that. Peter gave Wendy a hand at first,
+but had to desist, Tink was so indignant.
+
+Up and down they went, and round and round. Heavenly was Wendy’s word.
+
+“I say,” cried John, “why shouldn’t we all go out?”
+
+Of course it was to this that Peter had been luring them.
+
+Michael was ready: he wanted to see how long it took him to do a billion
+miles. But Wendy hesitated.
+
+“Mermaids!” said Peter again.
+
+“Oo!”
+
+“And there are pirates.”
+
+“Pirates,” cried John, seizing his Sunday hat, “let us go at once.”
+
+It was just at this moment that Mr. and Mrs. Darling hurried with Nana
+out of 27. They ran into the middle of the street to look up at the
+nursery window; and, yes, it was still shut, but the room was ablaze
+with light, and most heart-gripping sight of all, they could see in
+shadow on the curtain three little figures in night attire circling
+round and round, not on the floor but in the air.
+
+Not three figures, four!
+
+In a tremble they opened the street door. Mr. Darling would have rushed
+upstairs, but Mrs. Darling signed him to go softly. She even tried to
+make her heart go softly.
+
+Will they reach the nursery in time? If so, how delightful for them, and
+we shall all breathe a sigh of relief, but there will be no story. On
+the other hand, if they are not in time, I solemnly promise that it will
+all come right in the end.
+
+They would have reached the nursery in time had it not been that the
+little stars were watching them. Once again the stars blew the window
+open, and that smallest star of all called out:
+
+“Cave, Peter!”
+
+Then Peter knew that there was not a moment to lose. “Come,” he cried
+imperiously, and soared out at once into the night, followed by John and
+Michael and Wendy.
+
+Mr. and Mrs. Darling and Nana rushed into the nursery too late. The
+birds were flown.
+
+
+
+
+Chapter 4 THE FLIGHT
+
+“Second to the right, and straight on till morning.”
+
+That, Peter had told Wendy, was the way to the Neverland; but even
+birds, carrying maps and consulting them at windy corners, could not
+have sighted it with these instructions. Peter, you see, just said
+anything that came into his head.
+
+At first his companions trusted him implicitly, and so great were the
+delights of flying that they wasted time circling round church spires or
+any other tall objects on the way that took their fancy.
+
+John and Michael raced, Michael getting a start.
+
+They recalled with contempt that not so long ago they had thought
+themselves fine fellows for being able to fly round a room.
+
+Not long ago. But how long ago? They were flying over the sea before
+this thought began to disturb Wendy seriously. John thought it was their
+second sea and their third night.
+
+Sometimes it was dark and sometimes light, and now they were very cold
+and again too warm. Did they really feel hungry at times, or were they
+merely pretending, because Peter had such a jolly new way of feeding
+them? His way was to pursue birds who had food in their mouths suitable
+for humans and snatch it from them; then the birds would follow and
+snatch it back; and they would all go chasing each other gaily for
+miles, parting at last with mutual expressions of good-will. But Wendy
+noticed with gentle concern that Peter did not seem to know that this
+was rather an odd way of getting your bread and butter, nor even that
+there are other ways.
+
+Certainly they did not pretend to be sleepy, they were sleepy; and that
+was a danger, for the moment they popped off, down they fell. The awful
+thing was that Peter thought this funny.
+
+“There he goes again!” he would cry gleefully, as Michael suddenly
+dropped like a stone.
+
+“Save him, save him!” cried Wendy, looking with horror at the cruel
+sea far below. Eventually Peter would dive through the air, and catch
+Michael just before he could strike the sea, and it was lovely the way
+he did it; but he always waited till the last moment, and you felt it
+was his cleverness that interested him and not the saving of human life.
+Also he was fond of variety, and the sport that engrossed him one moment
+would suddenly cease to engage him, so there was always the possibility
+that the next time you fell he would let you go.
+
+He could sleep in the air without falling, by merely lying on his back
+and floating, but this was, partly at least, because he was so light
+that if you got behind him and blew he went faster.
+
+“Do be more polite to him,” Wendy whispered to John, when they were
+playing “Follow my Leader.”
+
+“Then tell him to stop showing off,” said John.
+
+When playing Follow my Leader, Peter would fly close to the water and
+touch each shark’s tail in passing, just as in the street you may run
+your finger along an iron railing. They could not follow him in this
+with much success, so perhaps it was rather like showing off, especially
+as he kept looking behind to see how many tails they missed.
+
+“You must be nice to him,” Wendy impressed on her brothers. “What could
+we do if he were to leave us!”
+
+“We could go back,” Michael said.
+
+“How could we ever find our way back without him?”
+
+“Well, then, we could go on,” said John.
+
+“That is the awful thing, John. We should have to go on, for we don’t
+know how to stop.”
+
+This was true, Peter had forgotten to show them how to stop.
+
+John said that if the worst came to the worst, all they had to do was to
+go straight on, for the world was round, and so in time they must come
+back to their own window.
+
+“And who is to get food for us, John?”
+
+“I nipped a bit out of that eagle’s mouth pretty neatly, Wendy.”
+
+“After the twentieth try,” Wendy reminded him. “And even though we
+became good at picking up food, see how we bump against clouds and things
+if he is not near to give us a hand.”
+
+Indeed they were constantly bumping. They could now fly strongly, though
+they still kicked far too much; but if they saw a cloud in front of
+them, the more they tried to avoid it, the more certainly did they bump
+into it. If Nana had been with them, she would have had a bandage round
+Michael’s forehead by this time.
+
+Peter was not with them for the moment, and they felt rather lonely up
+there by themselves. He could go so much faster than they that he would
+suddenly shoot out of sight, to have some adventure in which they had no
+share. He would come down laughing over something fearfully funny he had
+been saying to a star, but he had already forgotten what it was, or he
+would come up with mermaid scales still sticking to him, and yet not be
+able to say for certain what had been happening. It was really rather
+irritating to children who had never seen a mermaid.
+
+“And if he forgets them so quickly,” Wendy argued, “how can we expect
+that he will go on remembering us?”
+
+Indeed, sometimes when he returned he did not remember them, at least
+not well. Wendy was sure of it. She saw recognition come into his eyes
+as he was about to pass them the time of day and go on; once even she
+had to call him by name.
+
+“I’m Wendy,” she said agitatedly.
+
+He was very sorry. “I say, Wendy,” he whispered to her, “always if you
+see me forgetting you, just keep on saying ‘I’m Wendy,’ and then I’ll
+remember.”
+
+Of course this was rather unsatisfactory. However, to make amends he
+showed them how to lie out flat on a strong wind that was going their
+way, and this was such a pleasant change that they tried it several
+times and found that they could sleep thus with security. Indeed they
+would have slept longer, but Peter tired quickly of sleeping, and soon
+he would cry in his captain voice, “We get off here.” So with occasional
+tiffs, but on the whole rollicking, they drew near the Neverland; for
+after many moons they did reach it, and, what is more, they had been
+going pretty straight all the time, not perhaps so much owing to the
+guidance of Peter or Tink as because the island was looking for them. It
+is only thus that any one may sight those magic shores.
+
+“There it is,” said Peter calmly.
+
+“Where, where?”
+
+“Where all the arrows are pointing.”
+
+Indeed a million golden arrows were pointing it out to the children, all
+directed by their friend the sun, who wanted them to be sure of their
+way before leaving them for the night.
+
+Wendy and John and Michael stood on tip-toe in the air to get their
+first sight of the island. Strange to say, they all recognized it at
+once, and until fear fell upon them they hailed it, not as something
+long dreamt of and seen at last, but as a familiar friend to whom they
+were returning home for the holidays.
+
+“John, there’s the lagoon.”
+
+“Wendy, look at the turtles burying their eggs in the sand.”
+
+“I say, John, I see your flamingo with the broken leg!”
+
+“Look, Michael, there’s your cave!”
+
+“John, what’s that in the brushwood?”
+
+“It’s a wolf with her whelps. Wendy, I do believe that’s your little
+whelp!”
+
+“There’s my boat, John, with her sides stove in!”
+
+“No, it isn’t. Why, we burned your boat.”
+
+“That’s her, at any rate. I say, John, I see the smoke of the redskin
+camp!”
+
+“Where? Show me, and I’ll tell you by the way smoke curls whether they
+are on the war-path.”
+
+“There, just across the Mysterious River.”
+
+“I see now. Yes, they are on the war-path right enough.”
+
+Peter was a little annoyed with them for knowing so much, but if he
+wanted to lord it over them his triumph was at hand, for have I not told
+you that anon fear fell upon them?
+
+It came as the arrows went, leaving the island in gloom.
+
+In the old days at home the Neverland had always begun to look a little
+dark and threatening by bedtime. Then unexplored patches arose in it
+and spread, black shadows moved about in them, the roar of the beasts of
+prey was quite different now, and above all, you lost the certainty that
+you would win. You were quite glad that the night-lights were on. You
+even liked Nana to say that this was just the mantelpiece over here, and
+that the Neverland was all make-believe.
+
+Of course the Neverland had been make-believe in those days, but it
+was real now, and there were no night-lights, and it was getting darker
+every moment, and where was Nana?
+
+They had been flying apart, but they huddled close to Peter now. His
+careless manner had gone at last, his eyes were sparkling, and a tingle
+went through them every time they touched his body. They were now over
+the fearsome island, flying so low that sometimes a tree grazed their
+feet. Nothing horrid was visible in the air, yet their progress had
+become slow and laboured, exactly as if they were pushing their way
+through hostile forces. Sometimes they hung in the air until Peter had
+beaten on it with his fists.
+
+“They don’t want us to land,” he explained.
+
+“Who are they?” Wendy whispered, shuddering.
+
+But he could not or would not say. Tinker Bell had been asleep on his
+shoulder, but now he wakened her and sent her on in front.
+
+Sometimes he poised himself in the air, listening intently, with his
+hand to his ear, and again he would stare down with eyes so bright that
+they seemed to bore two holes to earth. Having done these things, he
+went on again.
+
+His courage was almost appalling. “Would you like an adventure now,” he
+said casually to John, “or would you like to have your tea first?”
+
+Wendy said “tea first” quickly, and Michael pressed her hand in
+gratitude, but the braver John hesitated.
+
+“What kind of adventure?” he asked cautiously.
+
+“There’s a pirate asleep in the pampas just beneath us,” Peter told him.
+“If you like, we’ll go down and kill him.”
+
+“I don’t see him,” John said after a long pause.
+
+“I do.”
+
+“Suppose,” John said, a little huskily, “he were to wake up.”
+
+Peter spoke indignantly. “You don’t think I would kill him while he was
+sleeping! I would wake him first, and then kill him. That’s the way I
+always do.”
+
+“I say! Do you kill many?”
+
+“Tons.”
+
+John said “How ripping,” but decided to have tea first. He asked if
+there were many pirates on the island just now, and Peter said he had
+never known so many.
+
+“Who is captain now?”
+
+“Hook,” answered Peter, and his face became very stern as he said that
+hated word.
+
+“Jas. Hook?”
+
+“Ay.”
+
+Then indeed Michael began to cry, and even John could speak in gulps
+only, for they knew Hook’s reputation.
+
+“He was Blackbeard’s bo’sun,” John whispered huskily. “He is the worst
+of them all. He is the only man of whom Barbecue was afraid.”
+
+“That’s him,” said Peter.
+
+“What is he like? Is he big?”
+
+“He is not so big as he was.”
+
+“How do you mean?”
+
+“I cut off a bit of him.”
+
+“You!”
+
+“Yes, me,” said Peter sharply.
+
+“I wasn’t meaning to be disrespectful.”
+
+“Oh, all right.”
+
+“But, I say, what bit?”
+
+“His right hand.”
+
+“Then he can’t fight now?”
+
+“Oh, can’t he just!”
+
+“Left-hander?”
+
+“He has an iron hook instead of a right hand, and he claws with it.”
+
+“Claws!”
+
+“I say, John,” said Peter.
+
+“Yes.”
+
+“Say, ‘Ay, ay, sir.’”
+
+“Ay, ay, sir.”
+
+“There is one thing,” Peter continued, “that every boy who serves under
+me has to promise, and so must you.”
+
+John paled.
+
+“It is this, if we meet Hook in open fight, you must leave him to me.”
+
+“I promise,” John said loyally.
+
+For the moment they were feeling less eerie, because Tink was flying
+with them, and in her light they could distinguish each other.
+Unfortunately she could not fly so slowly as they, and so she had to go
+round and round them in a circle in which they moved as in a halo. Wendy
+quite liked it, until Peter pointed out the drawbacks.
+
+“She tells me,” he said, “that the pirates sighted us before the
+darkness came, and got Long Tom out.”
+
+“The big gun?”
+
+“Yes. And of course they must see her light, and if they guess we are
+near it they are sure to let fly.”
+
+“Wendy!”
+
+“John!”
+
+“Michael!”
+
+“Tell her to go away at once, Peter,” the three cried simultaneously,
+but he refused.
+
+“She thinks we have lost the way,” he replied stiffly, “and she is
+rather frightened. You don’t think I would send her away all by herself
+when she is frightened!”
+
+For a moment the circle of light was broken, and something gave Peter a
+loving little pinch.
+
+“Then tell her,” Wendy begged, “to put out her light.”
+
+“She can’t put it out. That is about the only thing fairies can’t do. It
+just goes out of itself when she falls asleep, same as the stars.”
+
+“Then tell her to sleep at once,” John almost ordered.
+
+“She can’t sleep except when she’s sleepy. It is the only other thing
+fairies can’t do.”
+
+“Seems to me,” growled John, “these are the only two things worth
+doing.”
+
+Here he got a pinch, but not a loving one.
+
+“If only one of us had a pocket,” Peter said, “we could carry her in
+it.” However, they had set off in such a hurry that there was not a
+pocket between the four of them.
+
+He had a happy idea. John’s hat!
+
+Tink agreed to travel by hat if it was carried in the hand. John carried
+it, though she had hoped to be carried by Peter. Presently Wendy took
+the hat, because John said it struck against his knee as he flew; and
+this, as we shall see, led to mischief, for Tinker Bell hated to be
+under an obligation to Wendy.
+
+In the black topper the light was completely hidden, and they flew on in
+silence. It was the stillest silence they had ever known, broken once by
+a distant lapping, which Peter explained was the wild beasts drinking at
+the ford, and again by a rasping sound that might have been the branches
+of trees rubbing together, but he said it was the redskins sharpening
+their knives.
+
+Even these noises ceased. To Michael the loneliness was dreadful. “If
+only something would make a sound!” he cried.
+
+As if in answer to his request, the air was rent by the most tremendous
+crash he had ever heard. The pirates had fired Long Tom at them.
+
+The roar of it echoed through the mountains, and the echoes seemed to
+cry savagely, “Where are they, where are they, where are they?”
+
+Thus sharply did the terrified three learn the difference between an
+island of make-believe and the same island come true.
+
+When at last the heavens were steady again, John and Michael
+found themselves alone in the darkness. John was treading the air
+mechanically, and Michael without knowing how to float was floating.
+
+“Are you shot?” John whispered tremulously.
+
+“I haven’t tried [myself out] yet,” Michael whispered back.
+
+We know now that no one had been hit. Peter, however, had been carried
+by the wind of the shot far out to sea, while Wendy was blown upwards
+with no companion but Tinker Bell.
+
+It would have been well for Wendy if at that moment she had dropped the
+hat.
+
+I don’t know whether the idea came suddenly to Tink, or whether she had
+planned it on the way, but she at once popped out of the hat and began
+to lure Wendy to her destruction.
+
+Tink was not all bad; or, rather, she was all bad just now, but, on the
+other hand, sometimes she was all good. Fairies have to be one thing or
+the other, because being so small they unfortunately have room for one
+feeling only at a time. They are, however, allowed to change, only it
+must be a complete change. At present she was full of jealousy of Wendy.
+What she said in her lovely tinkle Wendy could not of course understand,
+and I believe some of it was bad words, but it sounded kind, and she
+flew back and forward, plainly meaning “Follow me, and all will be
+well.”
+
+What else could poor Wendy do? She called to Peter and John and Michael,
+and got only mocking echoes in reply. She did not yet know that Tink
+hated her with the fierce hatred of a very woman. And so, bewildered,
+and now staggering in her flight, she followed Tink to her doom.
+
+
+
+
+Chapter 5 THE ISLAND COME TRUE
+
+Feeling that Peter was on his way back, the Neverland had again woke
+into life. We ought to use the pluperfect and say wakened, but woke is
+better and was always used by Peter.
+
+In his absence things are usually quiet on the island. The fairies take
+an hour longer in the morning, the beasts attend to their young, the
+redskins feed heavily for six days and nights, and when pirates and
+lost boys meet they merely bite their thumbs at each other. But with the
+coming of Peter, who hates lethargy, they are under way again: if you
+put your ear to the ground now, you would hear the whole island seething
+with life.
+
+On this evening the chief forces of the island were disposed as follows.
+The lost boys were out looking for Peter, the pirates were out looking
+for the lost boys, the redskins were out looking for the pirates, and
+the beasts were out looking for the redskins. They were going round and
+round the island, but they did not meet because all were going at the
+same rate.
+
+All wanted blood except the boys, who liked it as a rule, but to-night
+were out to greet their captain. The boys on the island vary, of course,
+in numbers, according as they get killed and so on; and when they seem
+to be growing up, which is against the rules, Peter thins them out; but
+at this time there were six of them, counting the twins as two. Let us
+pretend to lie here among the sugar-cane and watch them as they steal by
+in single file, each with his hand on his dagger.
+
+They are forbidden by Peter to look in the least like him, and they wear
+the skins of the bears slain by themselves, in which they are so round
+and furry that when they fall they roll. They have therefore become very
+sure-footed.
+
+The first to pass is Tootles, not the least brave but the most
+unfortunate of all that gallant band. He had been in fewer adventures
+than any of them, because the big things constantly happened just when
+he had stepped round the corner; all would be quiet, he would take the
+opportunity of going off to gather a few sticks for firewood, and
+then when he returned the others would be sweeping up the blood. This
+ill-luck had given a gentle melancholy to his countenance, but instead
+of souring his nature had sweetened it, so that he was quite the
+humblest of the boys. Poor kind Tootles, there is danger in the air for
+you to-night. Take care lest an adventure is now offered you, which, if
+accepted, will plunge you in deepest woe. Tootles, the fairy Tink, who
+is bent on mischief this night is looking for a tool [for doing her
+mischief], and she thinks you are the most easily tricked of the boys.
+‘Ware Tinker Bell.
+
+Would that he could hear us, but we are not really on the island, and he
+passes by, biting his knuckles.
+
+Next comes Nibs, the gay and debonair, followed by Slightly, who cuts
+whistles out of the trees and dances ecstatically to his own tunes.
+Slightly is the most conceited of the boys. He thinks he remembers the
+days before he was lost, with their manners and customs, and this has
+given his nose an offensive tilt. Curly is fourth; he is a pickle, [a
+person who gets in pickles-predicaments] and so often has he had to
+deliver up his person when Peter said sternly, “Stand forth the one who
+did this thing,” that now at the command he stands forth automatically
+whether he has done it or not. Last come the Twins, who cannot be
+described because we should be sure to be describing the wrong one.
+Peter never quite knew what twins were, and his band were not allowed
+to know anything he did not know, so these two were always vague about
+themselves, and did their best to give satisfaction by keeping close
+together in an apologetic sort of way.
+
+The boys vanish in the gloom, and after a pause, but not a long pause,
+for things go briskly on the island, come the pirates on their track. We
+hear them before they are seen, and it is always the same dreadful song:
+
+     “Avast belay, yo ho, heave to,
+     A-pirating we go,
+     And if we’re parted by a shot
+     We’re sure to meet below!”
+
+A more villainous-looking lot never hung in a row on Execution dock.
+Here, a little in advance, ever and again with his head to the
+ground listening, his great arms bare, pieces of eight in his ears as
+ornaments, is the handsome Italian Cecco, who cut his name in letters
+of blood on the back of the governor of the prison at Gao. That gigantic
+black behind him has had many names since he dropped the one with
+which dusky mothers still terrify their children on the banks of the
+Guadjo-mo. Here is Bill Jukes, every inch of him tattooed, the same Bill
+Jukes who got six dozen on the WALRUS from Flint before he would drop
+the bag of moidores [Portuguese gold pieces]; and Cookson, said to
+be Black Murphy’s brother (but this was never proved), and Gentleman
+Starkey, once an usher in a public school and still dainty in his ways
+of killing; and Skylights (Morgan’s Skylights); and the Irish bo’sun
+Smee, an oddly genial man who stabbed, so to speak, without offence,
+and was the only Non-conformist in Hook’s crew; and Noodler, whose
+hands were fixed on backwards; and Robt. Mullins and Alf Mason and many
+another ruffian long known and feared on the Spanish Main.
+
+In the midst of them, the blackest and largest in that dark setting,
+reclined James Hook, or as he wrote himself, Jas. Hook, of whom it is
+said he was the only man that the Sea-Cook feared. He lay at his ease in
+a rough chariot drawn and propelled by his men, and instead of a right
+hand he had the iron hook with which ever and anon he encouraged them
+to increase their pace. As dogs this terrible man treated and addressed
+them, and as dogs they obeyed him. In person he was cadaverous [dead
+looking] and blackavized [dark faced], and his hair was dressed in long
+curls, which at a little distance looked like black candles, and gave a
+singularly threatening expression to his handsome countenance. His eyes
+were of the blue of the forget-me-not, and of a profound melancholy,
+save when he was plunging his hook into you, at which time two red spots
+appeared in them and lit them up horribly. In manner, something of the
+grand seigneur still clung to him, so that he even ripped you up with
+an air, and I have been told that he was a RACONTEUR [storyteller] of
+repute. He was never more sinister than when he was most polite,
+which is probably the truest test of breeding; and the elegance of his
+diction, even when he was swearing, no less than the distinction of his
+demeanour, showed him one of a different cast from his crew. A man of
+indomitable courage, it was said that the only thing he shied at was
+the sight of his own blood, which was thick and of an unusual colour.
+In dress he somewhat aped the attire associated with the name of Charles
+II, having heard it said in some earlier period of his career that he
+bore a strange resemblance to the ill-fated Stuarts; and in his mouth
+he had a holder of his own contrivance which enabled him to smoke two
+cigars at once. But undoubtedly the grimmest part of him was his iron
+claw.
+
+Let us now kill a pirate, to show Hook’s method. Skylights will do. As
+they pass, Skylights lurches clumsily against him, ruffling his lace
+collar; the hook shoots forth, there is a tearing sound and one screech,
+then the body is kicked aside, and the pirates pass on. He has not even
+taken the cigars from his mouth.
+
+Such is the terrible man against whom Peter Pan is pitted. Which will
+win?
+
+On the trail of the pirates, stealing noiselessly down the war-path,
+which is not visible to inexperienced eyes, come the redskins, every one
+of them with his eyes peeled. They carry tomahawks and knives, and their
+naked bodies gleam with paint and oil. Strung around them are scalps, of
+boys as well as of pirates, for these are the Piccaninny tribe, and not
+to be confused with the softer-hearted Delawares or the Hurons. In
+the van, on all fours, is Great Big Little Panther, a brave of so many
+scalps that in his present position they somewhat impede his progress.
+Bringing up the rear, the place of greatest danger, comes Tiger Lily,
+proudly erect, a princess in her own right. She is the most beautiful
+of dusky Dianas [Diana = goddess of the woods] and the belle of the
+Piccaninnies, coquettish [flirting], cold and amorous [loving] by turns;
+there is not a brave who would not have the wayward thing to wife, but
+she staves off the altar with a hatchet. Observe how they pass over
+fallen twigs without making the slightest noise. The only sound to be
+heard is their somewhat heavy breathing. The fact is that they are all a
+little fat just now after the heavy gorging, but in time they will work
+this off. For the moment, however, it constitutes their chief danger.
+
+The redskins disappear as they have come like shadows, and soon their
+place is taken by the beasts, a great and motley procession: lions,
+tigers, bears, and the innumerable smaller savage things that flee
+from them, for every kind of beast, and, more particularly, all the
+man-eaters, live cheek by jowl on the favoured island. Their tongues are
+hanging out, they are hungry to-night.
+
+When they have passed, comes the last figure of all, a gigantic
+crocodile. We shall see for whom she is looking presently.
+
+The crocodile passes, but soon the boys appear again, for the procession
+must continue indefinitely until one of the parties stops or changes its
+pace. Then quickly they will be on top of each other.
+
+All are keeping a sharp look-out in front, but none suspects that the
+danger may be creeping up from behind. This shows how real the island
+was.
+
+The first to fall out of the moving circle was the boys. They flung
+themselves down on the sward [turf], close to their underground home.
+
+“I do wish Peter would come back,” every one of them said nervously,
+though in height and still more in breadth they were all larger than
+their captain.
+
+“I am the only one who is not afraid of the pirates,” Slightly said, in
+the tone that prevented his being a general favourite; but perhaps some
+distant sound disturbed him, for he added hastily, “but I wish he
+would come back, and tell us whether he has heard anything more about
+Cinderella.”
+
+They talked of Cinderella, and Tootles was confident that his mother
+must have been very like her.
+
+It was only in Peter’s absence that they could speak of mothers, the
+subject being forbidden by him as silly.
+
+“All I remember about my mother,” Nibs told them, “is that she often
+said to my father, ‘Oh, how I wish I had a cheque-book of my own!’ I
+don’t know what a cheque-book is, but I should just love to give my
+mother one.”
+
+While they talked they heard a distant sound. You or I, not being wild
+things of the woods, would have heard nothing, but they heard it, and it
+was the grim song:
+
+     “Yo ho, yo ho, the pirate life,
+     The flag o’ skull and bones,
+     A merry hour, a hempen rope,
+     And hey for Davy Jones.”
+
+At once the lost boys--but where are they? They are no longer there.
+Rabbits could not have disappeared more quickly.
+
+I will tell you where they are. With the exception of Nibs, who has
+darted away to reconnoitre [look around], they are already in their home
+under the ground, a very delightful residence of which we shall see
+a good deal presently. But how have they reached it? for there is no
+entrance to be seen, not so much as a large stone, which if rolled away,
+would disclose the mouth of a cave. Look closely, however, and you may
+note that there are here seven large trees, each with a hole in its
+hollow trunk as large as a boy. These are the seven entrances to the
+home under the ground, for which Hook has been searching in vain these
+many moons. Will he find it tonight?
+
+As the pirates advanced, the quick eye of Starkey sighted Nibs
+disappearing through the wood, and at once his pistol flashed out. But
+an iron claw gripped his shoulder.
+
+“Captain, let go!” he cried, writhing.
+
+Now for the first time we hear the voice of Hook. It was a black voice.
+“Put back that pistol first,” it said threateningly.
+
+“It was one of those boys you hate. I could have shot him dead.”
+
+“Ay, and the sound would have brought Tiger Lily’s redskins upon us. Do
+you want to lose your scalp?”
+
+“Shall I after him, Captain,” asked pathetic Smee, “and tickle him
+with Johnny Corkscrew?” Smee had pleasant names for everything, and his
+cutlass was Johnny Corkscrew, because he wiggled it in the wound. One
+could mention many lovable traits in Smee. For instance, after killing,
+it was his spectacles he wiped instead of his weapon.
+
+“Johnny’s a silent fellow,” he reminded Hook.
+
+“Not now, Smee,” Hook said darkly. “He is only one, and I want to
+mischief all the seven. Scatter and look for them.”
+
+The pirates disappeared among the trees, and in a moment their Captain
+and Smee were alone. Hook heaved a heavy sigh, and I know not why it
+was, perhaps it was because of the soft beauty of the evening, but there
+came over him a desire to confide to his faithful bo’sun the story of
+his life. He spoke long and earnestly, but what it was all about Smee,
+who was rather stupid, did not know in the least.
+
+Anon [later] he caught the word Peter.
+
+“Most of all,” Hook was saying passionately, “I want their captain,
+Peter Pan. ‘Twas he cut off my arm.” He brandished the hook
+threateningly. “I’ve waited long to shake his hand with this. Oh, I’ll
+tear him!”
+
+“And yet,” said Smee, “I have often heard you say that hook was worth a
+score of hands, for combing the hair and other homely uses.”
+
+“Ay,” the captain answered, “if I was a mother I would pray to have my
+children born with this instead of that,” and he cast a look of pride
+upon his iron hand and one of scorn upon the other. Then again he
+frowned.
+
+“Peter flung my arm,” he said, wincing, “to a crocodile that happened to
+be passing by.”
+
+“I have often,” said Smee, “noticed your strange dread of crocodiles.”
+
+“Not of crocodiles,” Hook corrected him, “but of that one crocodile.” He
+lowered his voice. “It liked my arm so much, Smee, that it has followed
+me ever since, from sea to sea and from land to land, licking its lips
+for the rest of me.”
+
+“In a way,” said Smee, “it’s sort of a compliment.”
+
+“I want no such compliments,” Hook barked petulantly. “I want Peter Pan,
+who first gave the brute its taste for me.”
+
+He sat down on a large mushroom, and now there was a quiver in his
+voice. “Smee,” he said huskily, “that crocodile would have had me before
+this, but by a lucky chance it swallowed a clock which goes tick tick
+inside it, and so before it can reach me I hear the tick and bolt.” He
+laughed, but in a hollow way.
+
+“Some day,” said Smee, “the clock will run down, and then he’ll get
+you.”
+
+Hook wetted his dry lips. “Ay,” he said, “that’s the fear that haunts
+me.”
+
+Since sitting down he had felt curiously warm. “Smee,” he said, “this
+seat is hot.” He jumped up. “Odds bobs, hammer and tongs I’m burning.”
+
+They examined the mushroom, which was of a size and solidity unknown
+on the mainland; they tried to pull it up, and it came away at once in
+their hands, for it had no root. Stranger still, smoke began at once
+to ascend. The pirates looked at each other. “A chimney!” they both
+exclaimed.
+
+They had indeed discovered the chimney of the home under the ground. It
+was the custom of the boys to stop it with a mushroom when enemies were
+in the neighbourhood.
+
+Not only smoke came out of it. There came also children’s voices, for
+so safe did the boys feel in their hiding-place that they were gaily
+chattering. The pirates listened grimly, and then replaced the mushroom.
+They looked around them and noted the holes in the seven trees.
+
+“Did you hear them say Peter Pan’s from home?” Smee whispered, fidgeting
+with Johnny Corkscrew.
+
+Hook nodded. He stood for a long time lost in thought, and at last a
+curdling smile lit up his swarthy face. Smee had been waiting for it.
+“Unrip your plan, captain,” he cried eagerly.
+
+“To return to the ship,” Hook replied slowly through his teeth, “and
+cook a large rich cake of a jolly thickness with green sugar on it.
+There can be but one room below, for there is but one chimney. The silly
+moles had not the sense to see that they did not need a door apiece.
+That shows they have no mother. We will leave the cake on the shore
+of the Mermaids’ Lagoon. These boys are always swimming about there,
+playing with the mermaids. They will find the cake and they will gobble
+it up, because, having no mother, they don’t know how dangerous ‘tis to
+eat rich damp cake.” He burst into laughter, not hollow laughter now,
+but honest laughter. “Aha, they will die.”
+
+Smee had listened with growing admiration.
+
+“It’s the wickedest, prettiest policy ever I heard of!” he cried, and in
+their exultation they danced and sang:
+
+     “Avast, belay, when I appear,
+     By fear they’re overtook;
+     Nought’s left upon your bones when you
+     Have shaken claws with Hook.”
+
+They began the verse, but they never finished it, for another sound
+broke in and stilled them. There was at first such a tiny sound that a
+leaf might have fallen on it and smothered it, but as it came nearer it
+was more distinct.
+
+Tick tick tick tick!
+
+Hook stood shuddering, one foot in the air.
+
+“The crocodile!” he gasped, and bounded away, followed by his bo’sun.
+
+It was indeed the crocodile. It had passed the redskins, who were now on
+the trail of the other pirates. It oozed on after Hook.
+
+Once more the boys emerged into the open; but the dangers of the night
+were not yet over, for presently Nibs rushed breathless into their
+midst, pursued by a pack of wolves. The tongues of the pursuers were
+hanging out; the baying of them was horrible.
+
+“Save me, save me!” cried Nibs, falling on the ground.
+
+“But what can we do, what can we do?”
+
+It was a high compliment to Peter that at that dire moment their
+thoughts turned to him.
+
+“What would Peter do?” they cried simultaneously.
+
+Almost in the same breath they cried, “Peter would look at them through
+his legs.”
+
+And then, “Let us do what Peter would do.”
+
+It is quite the most successful way of defying wolves, and as one boy
+they bent and looked through their legs. The next moment is the long
+one, but victory came quickly, for as the boys advanced upon them in the
+terrible attitude, the wolves dropped their tails and fled.
+
+Now Nibs rose from the ground, and the others thought that his staring
+eyes still saw the wolves. But it was not wolves he saw.
+
+“I have seen a wonderfuller thing,” he cried, as they gathered round him
+eagerly. “A great white bird. It is flying this way.”
+
+“What kind of a bird, do you think?”
+
+“I don’t know,” Nibs said, awestruck, “but it looks so weary, and as it
+flies it moans, ‘Poor Wendy.’”
+
+“Poor Wendy?”
+
+“I remember,” said Slightly instantly, “there are birds called Wendies.”
+
+“See, it comes!” cried Curly, pointing to Wendy in the heavens.
+
+Wendy was now almost overhead, and they could hear her plaintive cry.
+But more distinct came the shrill voice of Tinker Bell. The jealous
+fairy had now cast off all disguise of friendship, and was darting
+at her victim from every direction, pinching savagely each time she
+touched.
+
+“Hullo, Tink,” cried the wondering boys.
+
+Tink’s reply rang out: “Peter wants you to shoot the Wendy.”
+
+It was not in their nature to question when Peter ordered. “Let us do
+what Peter wishes!” cried the simple boys. “Quick, bows and arrows!”
+
+All but Tootles popped down their trees. He had a bow and arrow with
+him, and Tink noted it, and rubbed her little hands.
+
+“Quick, Tootles, quick,” she screamed. “Peter will be so pleased.”
+
+Tootles excitedly fitted the arrow to his bow. “Out of the way, Tink,”
+ he shouted, and then he fired, and Wendy fluttered to the ground with an
+arrow in her breast.
+
+
+
+
+Chapter 6 THE LITTLE HOUSE
+
+Foolish Tootles was standing like a conqueror over Wendy’s body when the
+other boys sprang, armed, from their trees.
+
+“You are too late,” he cried proudly, “I have shot the Wendy. Peter will
+be so pleased with me.”
+
+Overhead Tinker Bell shouted “Silly ass!” and darted into hiding. The
+others did not hear her. They had crowded round Wendy, and as they
+looked a terrible silence fell upon the wood. If Wendy’s heart had been
+beating they would all have heard it.
+
+Slightly was the first to speak. “This is no bird,” he said in a scared
+voice. “I think this must be a lady.”
+
+“A lady?” said Tootles, and fell a-trembling.
+
+“And we have killed her,” Nibs said hoarsely.
+
+They all whipped off their caps.
+
+“Now I see,” Curly said: “Peter was bringing her to us.” He threw
+himself sorrowfully on the ground.
+
+“A lady to take care of us at last,” said one of the twins, “and you
+have killed her!”
+
+They were sorry for him, but sorrier for themselves, and when he took a
+step nearer them they turned from him.
+
+Tootles’ face was very white, but there was a dignity about him now that
+had never been there before.
+
+“I did it,” he said, reflecting. “When ladies used to come to me in
+dreams, I said, ‘Pretty mother, pretty mother.’ But when at last she
+really came, I shot her.”
+
+He moved slowly away.
+
+“Don’t go,” they called in pity.
+
+“I must,” he answered, shaking; “I am so afraid of Peter.”
+
+It was at this tragic moment that they heard a sound which made the
+heart of every one of them rise to his mouth. They heard Peter crow.
+
+“Peter!” they cried, for it was always thus that he signalled his
+return.
+
+“Hide her,” they whispered, and gathered hastily around Wendy. But
+Tootles stood aloof.
+
+Again came that ringing crow, and Peter dropped in front of them.
+“Greetings, boys,” he cried, and mechanically they saluted, and then
+again was silence.
+
+He frowned.
+
+“I am back,” he said hotly, “why do you not cheer?”
+
+They opened their mouths, but the cheers would not come. He overlooked
+it in his haste to tell the glorious tidings.
+
+“Great news, boys,” he cried, “I have brought at last a mother for you
+all.”
+
+Still no sound, except a little thud from Tootles as he dropped on his
+knees.
+
+“Have you not seen her?” asked Peter, becoming troubled. “She flew this
+way.”
+
+“Ah me!” one voice said, and another said, “Oh, mournful day.”
+
+Tootles rose. “Peter,” he said quietly, “I will show her to you,” and
+when the others would still have hidden her he said, “Back, twins, let
+Peter see.”
+
+So they all stood back, and let him see, and after he had looked for a
+little time he did not know what to do next.
+
+“She is dead,” he said uncomfortably. “Perhaps she is frightened at
+being dead.”
+
+He thought of hopping off in a comic sort of way till he was out of
+sight of her, and then never going near the spot any more. They would
+all have been glad to follow if he had done this.
+
+But there was the arrow. He took it from her heart and faced his band.
+
+“Whose arrow?” he demanded sternly.
+
+“Mine, Peter,” said Tootles on his knees.
+
+“Oh, dastard hand,” Peter said, and he raised the arrow to use it as a
+dagger.
+
+Tootles did not flinch. He bared his breast. “Strike, Peter,” he said
+firmly, “strike true.”
+
+Twice did Peter raise the arrow, and twice did his hand fall. “I cannot
+strike,” he said with awe, “there is something stays my hand.”
+
+All looked at him in wonder, save Nibs, who fortunately looked at Wendy.
+
+“It is she,” he cried, “the Wendy lady, see, her arm!”
+
+Wonderful to relate [tell], Wendy had raised her arm. Nibs bent over
+her and listened reverently. “I think she said, ‘Poor Tootles,’” he
+whispered.
+
+“She lives,” Peter said briefly.
+
+Slightly cried instantly, “The Wendy lady lives.”
+
+Then Peter knelt beside her and found his button. You remember she had
+put it on a chain that she wore round her neck.
+
+“See,” he said, “the arrow struck against this. It is the kiss I gave
+her. It has saved her life.”
+
+“I remember kisses,” Slightly interposed quickly, “let me see it. Ay,
+that’s a kiss.”
+
+Peter did not hear him. He was begging Wendy to get better quickly, so
+that he could show her the mermaids. Of course she could not answer yet,
+being still in a frightful faint; but from overhead came a wailing note.
+
+“Listen to Tink,” said Curly, “she is crying because the Wendy lives.”
+
+Then they had to tell Peter of Tink’s crime, and almost never had they
+seen him look so stern.
+
+“Listen, Tinker Bell,” he cried, “I am your friend no more. Begone from
+me for ever.”
+
+She flew on to his shoulder and pleaded, but he brushed her off. Not
+until Wendy again raised her arm did he relent sufficiently to say,
+“Well, not for ever, but for a whole week.”
+
+Do you think Tinker Bell was grateful to Wendy for raising her arm? Oh
+dear no, never wanted to pinch her so much. Fairies indeed are strange,
+and Peter, who understood them best, often cuffed [slapped] them.
+
+But what to do with Wendy in her present delicate state of health?
+
+“Let us carry her down into the house,” Curly suggested.
+
+“Ay,” said Slightly, “that is what one does with ladies.”
+
+“No, no,” Peter said, “you must not touch her. It would not be
+sufficiently respectful.”
+
+“That,” said Slightly, “is what I was thinking.”
+
+“But if she lies there,” Tootles said, “she will die.”
+
+“Ay, she will die,” Slightly admitted, “but there is no way out.”
+
+“Yes, there is,” cried Peter. “Let us build a little house round her.”
+
+They were all delighted. “Quick,” he ordered them, “bring me each of you
+the best of what we have. Gut our house. Be sharp.”
+
+In a moment they were as busy as tailors the night before a wedding.
+They skurried this way and that, down for bedding, up for firewood, and
+while they were at it, who should appear but John and Michael. As they
+dragged along the ground they fell asleep standing, stopped, woke up,
+moved another step and slept again.
+
+“John, John,” Michael would cry, “wake up! Where is Nana, John, and
+mother?”
+
+And then John would rub his eyes and mutter, “It is true, we did fly.”
+
+You may be sure they were very relieved to find Peter.
+
+“Hullo, Peter,” they said.
+
+“Hullo,” replied Peter amicably, though he had quite forgotten them.
+He was very busy at the moment measuring Wendy with his feet to see
+how large a house she would need. Of course he meant to leave room for
+chairs and a table. John and Michael watched him.
+
+“Is Wendy asleep?” they asked.
+
+“Yes.”
+
+“John,” Michael proposed, “let us wake her and get her to make supper
+for us,” but as he said it some of the other boys rushed on carrying
+branches for the building of the house. “Look at them!” he cried.
+
+“Curly,” said Peter in his most captainy voice, “see that these boys
+help in the building of the house.”
+
+“Ay, ay, sir.”
+
+“Build a house?” exclaimed John.
+
+“For the Wendy,” said Curly.
+
+“For Wendy?” John said, aghast. “Why, she is only a girl!”
+
+“That,” explained Curly, “is why we are her servants.”
+
+“You? Wendy’s servants!”
+
+“Yes,” said Peter, “and you also. Away with them.”
+
+The astounded brothers were dragged away to hack and hew and carry.
+“Chairs and a fender [fireplace] first,” Peter ordered. “Then we shall
+build a house round them.”
+
+“Ay,” said Slightly, “that is how a house is built; it all comes back to
+me.”
+
+Peter thought of everything. “Slightly,” he cried, “fetch a doctor.”
+
+“Ay, ay,” said Slightly at once, and disappeared, scratching his head.
+But he knew Peter must be obeyed, and he returned in a moment, wearing
+John’s hat and looking solemn.
+
+“Please, sir,” said Peter, going to him, “are you a doctor?”
+
+The difference between him and the other boys at such a time was that
+they knew it was make-believe, while to him make-believe and true were
+exactly the same thing. This sometimes troubled them, as when they had
+to make-believe that they had had their dinners.
+
+If they broke down in their make-believe he rapped them on the knuckles.
+
+“Yes, my little man,” Slightly anxiously replied, who had chapped
+knuckles.
+
+“Please, sir,” Peter explained, “a lady lies very ill.”
+
+She was lying at their feet, but Slightly had the sense not to see her.
+
+“Tut, tut, tut,” he said, “where does she lie?”
+
+“In yonder glade.”
+
+“I will put a glass thing in her mouth,” said Slightly, and he
+made-believe to do it, while Peter waited. It was an anxious moment when
+the glass thing was withdrawn.
+
+“How is she?” inquired Peter.
+
+“Tut, tut, tut,” said Slightly, “this has cured her.”
+
+“I am glad!” Peter cried.
+
+“I will call again in the evening,” Slightly said; “give her beef tea
+out of a cup with a spout to it;” but after he had returned the hat
+to John he blew big breaths, which was his habit on escaping from a
+difficulty.
+
+In the meantime the wood had been alive with the sound of axes; almost
+everything needed for a cosy dwelling already lay at Wendy’s feet.
+
+“If only we knew,” said one, “the kind of house she likes best.”
+
+“Peter,” shouted another, “she is moving in her sleep.”
+
+“Her mouth opens,” cried a third, looking respectfully into it. “Oh,
+lovely!”
+
+“Perhaps she is going to sing in her sleep,” said Peter. “Wendy, sing
+the kind of house you would like to have.”
+
+Immediately, without opening her eyes, Wendy began to sing:
+
+     “I wish I had a pretty house,
+     The littlest ever seen,
+     With funny little red walls
+     And roof of mossy green.”
+
+They gurgled with joy at this, for by the greatest good luck the
+branches they had brought were sticky with red sap, and all the ground
+was carpeted with moss. As they rattled up the little house they broke
+into song themselves:
+
+     “We’ve built the little walls and roof
+     And made a lovely door,
+     So tell us, mother Wendy,
+     What are you wanting more?”
+
+To this she answered greedily:
+
+     “Oh, really next I think I’ll have
+     Gay windows all about,
+     With roses peeping in, you know,
+     And babies peeping out.”
+
+With a blow of their fists they made windows, and large yellow leaves
+were the blinds. But roses--?
+
+“Roses,” cried Peter sternly.
+
+Quickly they made-believe to grow the loveliest roses up the walls.
+
+Babies?
+
+To prevent Peter ordering babies they hurried into song again:
+
+     “We’ve made the roses peeping out,
+     The babes are at the door,
+     We cannot make ourselves, you know,
+     ‘cos we’ve been made before.”
+
+Peter, seeing this to be a good idea, at once pretended that it was his
+own. The house was quite beautiful, and no doubt Wendy was very cosy
+within, though, of course, they could no longer see her. Peter strode
+up and down, ordering finishing touches. Nothing escaped his eagle eyes.
+Just when it seemed absolutely finished:
+
+“There’s no knocker on the door,” he said.
+
+They were very ashamed, but Tootles gave the sole of his shoe, and it
+made an excellent knocker.
+
+Absolutely finished now, they thought.
+
+Not of bit of it. “There’s no chimney,” Peter said; “we must have a
+chimney.”
+
+“It certainly does need a chimney,” said John importantly. This gave
+Peter an idea. He snatched the hat off John’s head, knocked out the
+bottom [top], and put the hat on the roof. The little house was so
+pleased to have such a capital chimney that, as if to say thank you,
+smoke immediately began to come out of the hat.
+
+Now really and truly it was finished. Nothing remained to do but to
+knock.
+
+“All look your best,” Peter warned them; “first impressions are awfully
+important.”
+
+He was glad no one asked him what first impressions are; they were all
+too busy looking their best.
+
+He knocked politely, and now the wood was as still as the children, not
+a sound to be heard except from Tinker Bell, who was watching from a
+branch and openly sneering.
+
+What the boys were wondering was, would any one answer the knock? If a
+lady, what would she be like?
+
+The door opened and a lady came out. It was Wendy. They all whipped off
+their hats.
+
+She looked properly surprised, and this was just how they had hoped she
+would look.
+
+“Where am I?” she said.
+
+Of course Slightly was the first to get his word in. “Wendy lady,” he
+said rapidly, “for you we built this house.”
+
+“Oh, say you’re pleased,” cried Nibs.
+
+“Lovely, darling house,” Wendy said, and they were the very words they
+had hoped she would say.
+
+“And we are your children,” cried the twins.
+
+Then all went on their knees, and holding out their arms cried, “O Wendy
+lady, be our mother.”
+
+“Ought I?” Wendy said, all shining. “Of course it’s frightfully
+fascinating, but you see I am only a little girl. I have no real
+experience.”
+
+“That doesn’t matter,” said Peter, as if he were the only person present
+who knew all about it, though he was really the one who knew least.
+“What we need is just a nice motherly person.”
+
+“Oh dear!” Wendy said, “you see, I feel that is exactly what I am.”
+
+“It is, it is,” they all cried; “we saw it at once.”
+
+“Very well,” she said, “I will do my best. Come inside at once, you
+naughty children; I am sure your feet are damp. And before I put you to
+bed I have just time to finish the story of Cinderella.”
+
+In they went; I don’t know how there was room for them, but you can
+squeeze very tight in the Neverland. And that was the first of the many
+joyous evenings they had with Wendy. By and by she tucked them up in the
+great bed in the home under the trees, but she herself slept that night
+in the little house, and Peter kept watch outside with drawn sword, for
+the pirates could be heard carousing far away and the wolves were on the
+prowl. The little house looked so cosy and safe in the darkness, with
+a bright light showing through its blinds, and the chimney smoking
+beautifully, and Peter standing on guard. After a time he fell asleep,
+and some unsteady fairies had to climb over him on their way home from
+an orgy. Any of the other boys obstructing the fairy path at night they
+would have mischiefed, but they just tweaked Peter’s nose and passed on.
+
+
+
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+One of the first things Peter did next day was to measure Wendy and John
+and Michael for hollow trees. Hook, you remember, had sneered at the
+boys for thinking they needed a tree apiece, but this was ignorance, for
+unless your tree fitted you it was difficult to go up and down, and no
+two of the boys were quite the same size. Once you fitted, you drew in
+[let out] your breath at the top, and down you went at exactly the
+right speed, while to ascend you drew in and let out alternately, and so
+wriggled up. Of course, when you have mastered the action you are able
+to do these things without thinking of them, and nothing can be more
+graceful.
+
+But you simply must fit, and Peter measures you for your tree as
+carefully as for a suit of clothes: the only difference being that the
+clothes are made to fit you, while you have to be made to fit the tree.
+Usually it is done quite easily, as by your wearing too many garments
+or too few, but if you are bumpy in awkward places or the only available
+tree is an odd shape, Peter does some things to you, and after that you
+fit. Once you fit, great care must be taken to go on fitting, and this,
+as Wendy was to discover to her delight, keeps a whole family in perfect
+condition.
+
+Wendy and Michael fitted their trees at the first try, but John had to
+be altered a little.
+
+After a few days’ practice they could go up and down as gaily as buckets
+in a well. And how ardently they grew to love their home under the
+ground; especially Wendy. It consisted of one large room, as all houses
+should do, with a floor in which you could dig [for worms] if you wanted
+to go fishing, and in this floor grew stout mushrooms of a charming
+colour, which were used as stools. A Never tree tried hard to grow in
+the centre of the room, but every morning they sawed the trunk through,
+level with the floor. By tea-time it was always about two feet high, and
+then they put a door on top of it, the whole thus becoming a table;
+as soon as they cleared away, they sawed off the trunk again, and thus
+there was more room to play. There was an enormous fireplace which was
+in almost any part of the room where you cared to light it, and across
+this Wendy stretched strings, made of fibre, from which she suspended
+her washing. The bed was tilted against the wall by day, and let down at
+6:30, when it filled nearly half the room; and all the boys slept in it,
+except Michael, lying like sardines in a tin. There was a strict rule
+against turning round until one gave the signal, when all turned at
+once. Michael should have used it also, but Wendy would have [desired]
+a baby, and he was the littlest, and you know what women are, and the
+short and long of it is that he was hung up in a basket.
+
+It was rough and simple, and not unlike what baby bears would have made
+of an underground house in the same circumstances. But there was one
+recess in the wall, no larger than a bird-cage, which was the private
+apartment of Tinker Bell. It could be shut off from the rest of
+the house by a tiny curtain, which Tink, who was most fastidious
+[particular], always kept drawn when dressing or undressing. No woman,
+however large, could have had a more exquisite boudoir [dressing room]
+and bed-chamber combined. The couch, as she always called it, was
+a genuine Queen Mab, with club legs; and she varied the bedspreads
+according to what fruit-blossom was in season. Her mirror was a
+Puss-in-Boots, of which there are now only three, unchipped, known to
+fairy dealers; the washstand was Pie-crust and reversible, the chest
+of drawers an authentic Charming the Sixth, and the carpet and rugs the
+best (the early) period of Margery and Robin. There was a chandelier
+from Tiddlywinks for the look of the thing, but of course she lit the
+residence herself. Tink was very contemptuous of the rest of the house,
+as indeed was perhaps inevitable, and her chamber, though beautiful,
+looked rather conceited, having the appearance of a nose permanently
+turned up.
+
+I suppose it was all especially entrancing to Wendy, because those
+rampagious boys of hers gave her so much to do. Really there were whole
+weeks when, except perhaps with a stocking in the evening, she was never
+above ground. The cooking, I can tell you, kept her nose to the pot, and
+even if there was nothing in it, even if there was no pot, she had to
+keep watching that it came aboil just the same. You never exactly
+knew whether there would be a real meal or just a make-believe, it all
+depended upon Peter’s whim: he could eat, really eat, if it was part of
+a game, but he could not stodge [cram down the food] just to feel
+stodgy [stuffed with food], which is what most children like better than
+anything else; the next best thing being to talk about it. Make-believe
+was so real to him that during a meal of it you could see him getting
+rounder. Of course it was trying, but you simply had to follow his lead,
+and if you could prove to him that you were getting loose for your tree
+he let you stodge.
+
+Wendy’s favourite time for sewing and darning was after they had all
+gone to bed. Then, as she expressed it, she had a breathing time for
+herself; and she occupied it in making new things for them, and putting
+double pieces on the knees, for they were all most frightfully hard on
+their knees.
+
+When she sat down to a basketful of their stockings, every heel with a
+hole in it, she would fling up her arms and exclaim, “Oh dear, I am sure
+I sometimes think spinsters are to be envied!”
+
+Her face beamed when she exclaimed this.
+
+You remember about her pet wolf. Well, it very soon discovered that she
+had come to the island and it found her out, and they just ran into each
+other’s arms. After that it followed her about everywhere.
+
+As time wore on did she think much about the beloved parents she had
+left behind her? This is a difficult question, because it is quite
+impossible to say how time does wear on in the Neverland, where it is
+calculated by moons and suns, and there are ever so many more of them
+than on the mainland. But I am afraid that Wendy did not really worry
+about her father and mother; she was absolutely confident that they
+would always keep the window open for her to fly back by, and this gave
+her complete ease of mind. What did disturb her at times was that John
+remembered his parents vaguely only, as people he had once known, while
+Michael was quite willing to believe that she was really his mother.
+These things scared her a little, and nobly anxious to do her duty, she
+tried to fix the old life in their minds by setting them examination
+papers on it, as like as possible to the ones she used to do at school.
+The other boys thought this awfully interesting, and insisted on
+joining, and they made slates for themselves, and sat round the table,
+writing and thinking hard about the questions she had written on another
+slate and passed round. They were the most ordinary questions--“What
+was the colour of Mother’s eyes? Which was taller, Father or Mother? Was
+Mother blonde or brunette? Answer all three questions if possible.”
+ “(A) Write an essay of not less than 40 words on How I spent my last
+Holidays, or The Characters of Father and Mother compared. Only one of
+these to be attempted.” Or “(1) Describe Mother’s laugh; (2) Describe
+Father’s laugh; (3) Describe Mother’s Party Dress; (4) Describe the
+Kennel and its Inmate.”
+
+They were just everyday questions like these, and when you could not
+answer them you were told to make a cross; and it was really dreadful
+what a number of crosses even John made. Of course the only boy who
+replied to every question was Slightly, and no one could have been more
+hopeful of coming out first, but his answers were perfectly ridiculous,
+and he really came out last: a melancholy thing.
+
+Peter did not compete. For one thing he despised all mothers except
+Wendy, and for another he was the only boy on the island who could
+neither write nor spell; not the smallest word. He was above all that
+sort of thing.
+
+By the way, the questions were all written in the past tense. What
+was the colour of Mother’s eyes, and so on. Wendy, you see, had been
+forgetting, too.
+
+Adventures, of course, as we shall see, were of daily occurrence; but
+about this time Peter invented, with Wendy’s help, a new game that
+fascinated him enormously, until he suddenly had no more interest in it,
+which, as you have been told, was what always happened with his games.
+It consisted in pretending not to have adventures, in doing the sort of
+thing John and Michael had been doing all their lives, sitting on stools
+flinging balls in the air, pushing each other, going out for walks and
+coming back without having killed so much as a grizzly. To see Peter
+doing nothing on a stool was a great sight; he could not help looking
+solemn at such times, to sit still seemed to him such a comic thing to
+do. He boasted that he had gone walking for the good of his health. For
+several suns these were the most novel of all adventures to him; and
+John and Michael had to pretend to be delighted also; otherwise he would
+have treated them severely.
+
+He often went out alone, and when he came back you were never absolutely
+certain whether he had had an adventure or not. He might have forgotten
+it so completely that he said nothing about it; and then when you went
+out you found the body; and, on the other hand, he might say a great
+deal about it, and yet you could not find the body. Sometimes he came
+home with his head bandaged, and then Wendy cooed over him and bathed
+it in lukewarm water, while he told a dazzling tale. But she was never
+quite sure, you know. There were, however, many adventures which she
+knew to be true because she was in them herself, and there were still
+more that were at least partly true, for the other boys were in them and
+said they were wholly true. To describe them all would require a book as
+large as an English-Latin, Latin-English Dictionary, and the most we can
+do is to give one as a specimen of an average hour on the island. The
+difficulty is which one to choose. Should we take the brush with the
+redskins at Slightly Gulch? It was a sanguinary affair, and
+especially interesting as showing one of Peter’s peculiarities, which
+was that in the middle of a fight he would suddenly change sides. At the
+Gulch, when victory was still in the balance, sometimes leaning this way
+and sometimes that, he called out, “I’m redskin to-day; what are you,
+Tootles?” And Tootles answered, “Redskin; what are you, Nibs?” and
+Nibs said, “Redskin; what are you Twin?” and so on; and they were all
+redskins; and of course this would have ended the fight had not the real
+redskins fascinated by Peter’s methods, agreed to be lost boys for that
+once, and so at it they all went again, more fiercely than ever.
+
+The extraordinary upshot of this adventure was--but we have not decided
+yet that this is the adventure we are to narrate. Perhaps a better one
+would be the night attack by the redskins on the house under the ground,
+when several of them stuck in the hollow trees and had to be pulled out
+like corks. Or we might tell how Peter saved Tiger Lily’s life in the
+Mermaids’ Lagoon, and so made her his ally.
+
+Or we could tell of that cake the pirates cooked so that the boys might
+eat it and perish; and how they placed it in one cunning spot after
+another; but always Wendy snatched it from the hands of her children, so
+that in time it lost its succulence, and became as hard as a stone, and
+was used as a missile, and Hook fell over it in the dark.
+
+Or suppose we tell of the birds that were Peter’s friends, particularly
+of the Never bird that built in a tree overhanging the lagoon, and how
+the nest fell into the water, and still the bird sat on her eggs, and
+Peter gave orders that she was not to be disturbed. That is a pretty
+story, and the end shows how grateful a bird can be; but if we tell
+it we must also tell the whole adventure of the lagoon, which would
+of course be telling two adventures rather than just one. A shorter
+adventure, and quite as exciting, was Tinker Bell’s attempt, with the
+help of some street fairies, to have the sleeping Wendy conveyed on a
+great floating leaf to the mainland. Fortunately the leaf gave way and
+Wendy woke, thinking it was bath-time, and swam back. Or again, we might
+choose Peter’s defiance of the lions, when he drew a circle round him
+on the ground with an arrow and dared them to cross it; and though he
+waited for hours, with the other boys and Wendy looking on breathlessly
+from trees, not one of them dared to accept his challenge.
+
+Which of these adventures shall we choose? The best way will be to toss
+for it.
+
+I have tossed, and the lagoon has won. This almost makes one wish that
+the gulch or the cake or Tink’s leaf had won. Of course I could do it
+again, and make it best out of three; however, perhaps fairest to stick
+to the lagoon.
+
+
+
+
+Chapter 8 THE MERMAIDS’ LAGOON
+
+If you shut your eyes and are a lucky one, you may see at times a
+shapeless pool of lovely pale colours suspended in the darkness; then
+if you squeeze your eyes tighter, the pool begins to take shape, and the
+colours become so vivid that with another squeeze they must go on fire.
+But just before they go on fire you see the lagoon. This is the nearest
+you ever get to it on the mainland, just one heavenly moment; if there
+could be two moments you might see the surf and hear the mermaids
+singing.
+
+The children often spent long summer days on this lagoon, swimming or
+floating most of the time, playing the mermaid games in the water,
+and so forth. You must not think from this that the mermaids were on
+friendly terms with them: on the contrary, it was among Wendy’s lasting
+regrets that all the time she was on the island she never had a civil
+word from one of them. When she stole softly to the edge of the lagoon
+she might see them by the score, especially on Marooners’ Rock, where
+they loved to bask, combing out their hair in a lazy way that quite
+irritated her; or she might even swim, on tiptoe as it were, to within
+a yard of them, but then they saw her and dived, probably splashing her
+with their tails, not by accident, but intentionally.
+
+They treated all the boys in the same way, except of course Peter, who
+chatted with them on Marooners’ Rock by the hour, and sat on their tails
+when they got cheeky. He gave Wendy one of their combs.
+
+The most haunting time at which to see them is at the turn of the moon,
+when they utter strange wailing cries; but the lagoon is dangerous for
+mortals then, and until the evening of which we have now to tell, Wendy
+had never seen the lagoon by moonlight, less from fear, for of course
+Peter would have accompanied her, than because she had strict rules
+about every one being in bed by seven. She was often at the lagoon,
+however, on sunny days after rain, when the mermaids come up in
+extraordinary numbers to play with their bubbles. The bubbles of many
+colours made in rainbow water they treat as balls, hitting them gaily
+from one to another with their tails, and trying to keep them in the
+rainbow till they burst. The goals are at each end of the rainbow, and
+the keepers only are allowed to use their hands. Sometimes a dozen of
+these games will be going on in the lagoon at a time, and it is quite a
+pretty sight.
+
+But the moment the children tried to join in they had to play by
+themselves, for the mermaids immediately disappeared. Nevertheless we
+have proof that they secretly watched the interlopers, and were not
+above taking an idea from them; for John introduced a new way of hitting
+the bubble, with the head instead of the hand, and the mermaids adopted
+it. This is the one mark that John has left on the Neverland.
+
+It must also have been rather pretty to see the children resting on a
+rock for half an hour after their mid-day meal. Wendy insisted on
+their doing this, and it had to be a real rest even though the meal was
+make-believe. So they lay there in the sun, and their bodies glistened
+in it, while she sat beside them and looked important.
+
+It was one such day, and they were all on Marooners’ Rock. The rock was
+not much larger than their great bed, but of course they all knew how
+not to take up much room, and they were dozing, or at least lying with
+their eyes shut, and pinching occasionally when they thought Wendy was
+not looking. She was very busy, stitching.
+
+While she stitched a change came to the lagoon. Little shivers ran over
+it, and the sun went away and shadows stole across the water, turning
+it cold. Wendy could no longer see to thread her needle, and when she
+looked up, the lagoon that had always hitherto been such a laughing
+place seemed formidable and unfriendly.
+
+It was not, she knew, that night had come, but something as dark as
+night had come. No, worse than that. It had not come, but it had sent
+that shiver through the sea to say that it was coming. What was it?
+
+There crowded upon her all the stories she had been told of Marooners’
+Rock, so called because evil captains put sailors on it and leave
+them there to drown. They drown when the tide rises, for then it is
+submerged.
+
+Of course she should have roused the children at once; not merely
+because of the unknown that was stalking toward them, but because it was
+no longer good for them to sleep on a rock grown chilly. But she was
+a young mother and she did not know this; she thought you simply must
+stick to your rule about half an hour after the mid-day meal. So, though
+fear was upon her, and she longed to hear male voices, she would not
+waken them. Even when she heard the sound of muffled oars, though her
+heart was in her mouth, she did not waken them. She stood over them to
+let them have their sleep out. Was it not brave of Wendy?
+
+It was well for those boys then that there was one among them who could
+sniff danger even in his sleep. Peter sprang erect, as wide awake at
+once as a dog, and with one warning cry he roused the others.
+
+He stood motionless, one hand to his ear.
+
+“Pirates!” he cried. The others came closer to him. A strange smile was
+playing about his face, and Wendy saw it and shuddered. While that smile
+was on his face no one dared address him; all they could do was to stand
+ready to obey. The order came sharp and incisive.
+
+“Dive!”
+
+There was a gleam of legs, and instantly the lagoon seemed deserted.
+Marooners’ Rock stood alone in the forbidding waters as if it were
+itself marooned.
+
+The boat drew nearer. It was the pirate dinghy, with three figures in
+her, Smee and Starkey, and the third a captive, no other than Tiger
+Lily. Her hands and ankles were tied, and she knew what was to be her
+fate. She was to be left on the rock to perish, an end to one of her
+race more terrible than death by fire or torture, for is it not written
+in the book of the tribe that there is no path through water to the
+happy hunting-ground? Yet her face was impassive; she was the daughter
+of a chief, she must die as a chief’s daughter, it is enough.
+
+They had caught her boarding the pirate ship with a knife in her mouth.
+No watch was kept on the ship, it being Hook’s boast that the wind of
+his name guarded the ship for a mile around. Now her fate would help to
+guard it also. One more wail would go the round in that wind by night.
+
+In the gloom that they brought with them the two pirates did not see the
+rock till they crashed into it.
+
+“Luff, you lubber,” cried an Irish voice that was Smee’s; “here’s the
+rock. Now, then, what we have to do is to hoist the redskin on to it and
+leave her here to drown.”
+
+It was the work of one brutal moment to land the beautiful girl on the
+rock; she was too proud to offer a vain resistance.
+
+Quite near the rock, but out of sight, two heads were bobbing up and
+down, Peter’s and Wendy’s. Wendy was crying, for it was the first
+tragedy she had seen. Peter had seen many tragedies, but he had
+forgotten them all. He was less sorry than Wendy for Tiger Lily: it was
+two against one that angered him, and he meant to save her. An easy way
+would have been to wait until the pirates had gone, but he was never one
+to choose the easy way.
+
+There was almost nothing he could not do, and he now imitated the voice
+of Hook.
+
+“Ahoy there, you lubbers!” he called. It was a marvellous imitation.
+
+“The captain!” said the pirates, staring at each other in surprise.
+
+“He must be swimming out to us,” Starkey said, when they had looked for
+him in vain.
+
+“We are putting the redskin on the rock,” Smee called out.
+
+“Set her free,” came the astonishing answer.
+
+“Free!”
+
+“Yes, cut her bonds and let her go.”
+
+“But, captain--”
+
+“At once, d’ye hear,” cried Peter, “or I’ll plunge my hook in you.”
+
+“This is queer!” Smee gasped.
+
+“Better do what the captain orders,” said Starkey nervously.
+
+“Ay, ay,” Smee said, and he cut Tiger Lily’s cords. At once like an eel
+she slid between Starkey’s legs into the water.
+
+Of course Wendy was very elated over Peter’s cleverness; but she knew
+that he would be elated also and very likely crow and thus betray
+himself, so at once her hand went out to cover his mouth. But it was
+stayed even in the act, for “Boat ahoy!” rang over the lagoon in Hook’s
+voice, and this time it was not Peter who had spoken.
+
+Peter may have been about to crow, but his face puckered in a whistle of
+surprise instead.
+
+“Boat ahoy!” again came the voice.
+
+Now Wendy understood. The real Hook was also in the water.
+
+He was swimming to the boat, and as his men showed a light to guide him
+he had soon reached them. In the light of the lantern Wendy saw his hook
+grip the boat’s side; she saw his evil swarthy face as he rose dripping
+from the water, and, quaking, she would have liked to swim away, but
+Peter would not budge. He was tingling with life and also top-heavy with
+conceit. “Am I not a wonder, oh, I am a wonder!” he whispered to her,
+and though she thought so also, she was really glad for the sake of his
+reputation that no one heard him except herself.
+
+He signed to her to listen.
+
+The two pirates were very curious to know what had brought their captain
+to them, but he sat with his head on his hook in a position of profound
+melancholy.
+
+“Captain, is all well?” they asked timidly, but he answered with a
+hollow moan.
+
+“He sighs,” said Smee.
+
+“He sighs again,” said Starkey.
+
+“And yet a third time he sighs,” said Smee.
+
+Then at last he spoke passionately.
+
+“The game’s up,” he cried, “those boys have found a mother.”
+
+Affrighted though she was, Wendy swelled with pride.
+
+“O evil day!” cried Starkey.
+
+“What’s a mother?” asked the ignorant Smee.
+
+Wendy was so shocked that she exclaimed. “He doesn’t know!” and always
+after this she felt that if you could have a pet pirate Smee would be
+her one.
+
+Peter pulled her beneath the water, for Hook had started up, crying,
+“What was that?”
+
+“I heard nothing,” said Starkey, raising the lantern over the waters,
+and as the pirates looked they saw a strange sight. It was the nest I
+have told you of, floating on the lagoon, and the Never bird was sitting
+on it.
+
+“See,” said Hook in answer to Smee’s question, “that is a mother. What
+a lesson! The nest must have fallen into the water, but would the mother
+desert her eggs? No.”
+
+There was a break in his voice, as if for a moment he recalled innocent
+days when--but he brushed away this weakness with his hook.
+
+Smee, much impressed, gazed at the bird as the nest was borne past, but
+the more suspicious Starkey said, “If she is a mother, perhaps she is
+hanging about here to help Peter.”
+
+Hook winced. “Ay,” he said, “that is the fear that haunts me.”
+
+He was roused from this dejection by Smee’s eager voice.
+
+“Captain,” said Smee, “could we not kidnap these boys’ mother and make
+her our mother?”
+
+“It is a princely scheme,” cried Hook, and at once it took practical
+shape in his great brain. “We will seize the children and carry them to
+the boat: the boys we will make walk the plank, and Wendy shall be our
+mother.”
+
+Again Wendy forgot herself.
+
+“Never!” she cried, and bobbed.
+
+“What was that?”
+
+But they could see nothing. They thought it must have been a leaf in the
+wind. “Do you agree, my bullies?” asked Hook.
+
+“There is my hand on it,” they both said.
+
+“And there is my hook. Swear.”
+
+They all swore. By this time they were on the rock, and suddenly Hook
+remembered Tiger Lily.
+
+“Where is the redskin?” he demanded abruptly.
+
+He had a playful humour at moments, and they thought this was one of the
+moments.
+
+“That is all right, captain,” Smee answered complacently; “we let her
+go.”
+
+“Let her go!” cried Hook.
+
+“‘Twas your own orders,” the bo’sun faltered.
+
+“You called over the water to us to let her go,” said Starkey.
+
+“Brimstone and gall,” thundered Hook, “what cozening [cheating] is
+going on here!” His face had gone black with rage, but he saw that they
+believed their words, and he was startled. “Lads,” he said, shaking a
+little, “I gave no such order.”
+
+“It is passing queer,” Smee said, and they all fidgeted uncomfortably.
+Hook raised his voice, but there was a quiver in it.
+
+“Spirit that haunts this dark lagoon to-night,” he cried, “dost hear
+me?”
+
+Of course Peter should have kept quiet, but of course he did not. He
+immediately answered in Hook’s voice:
+
+“Odds, bobs, hammer and tongs, I hear you.”
+
+In that supreme moment Hook did not blanch, even at the gills, but Smee
+and Starkey clung to each other in terror.
+
+“Who are you, stranger? Speak!” Hook demanded.
+
+“I am James Hook,” replied the voice, “captain of the JOLLY ROGER.”
+
+“You are not; you are not,” Hook cried hoarsely.
+
+“Brimstone and gall,” the voice retorted, “say that again, and I’ll cast
+anchor in you.”
+
+Hook tried a more ingratiating manner. “If you are Hook,” he said almost
+humbly, “come tell me, who am I?”
+
+“A codfish,” replied the voice, “only a codfish.”
+
+“A codfish!” Hook echoed blankly, and it was then, but not till then,
+that his proud spirit broke. He saw his men draw back from him.
+
+“Have we been captained all this time by a codfish!” they muttered. “It
+is lowering to our pride.”
+
+They were his dogs snapping at him, but, tragic figure though he had
+become, he scarcely heeded them. Against such fearful evidence it was
+not their belief in him that he needed, it was his own. He felt his ego
+slipping from him. “Don’t desert me, bully,” he whispered hoarsely to
+it.
+
+In his dark nature there was a touch of the feminine, as in all the
+great pirates, and it sometimes gave him intuitions. Suddenly he tried
+the guessing game.
+
+“Hook,” he called, “have you another voice?”
+
+Now Peter could never resist a game, and he answered blithely in his own
+voice, “I have.”
+
+“And another name?”
+
+“Ay, ay.”
+
+“Vegetable?” asked Hook.
+
+“No.”
+
+“Mineral?”
+
+“No.”
+
+“Animal?”
+
+“Yes.”
+
+“Man?”
+
+“No!” This answer rang out scornfully.
+
+“Boy?”
+
+“Yes.”
+
+“Ordinary boy?”
+
+“No!”
+
+“Wonderful boy?”
+
+To Wendy’s pain the answer that rang out this time was “Yes.”
+
+“Are you in England?”
+
+“No.”
+
+“Are you here?”
+
+“Yes.”
+
+Hook was completely puzzled. “You ask him some questions,” he said to
+the others, wiping his damp brow.
+
+Smee reflected. “I can’t think of a thing,” he said regretfully.
+
+“Can’t guess, can’t guess!” crowed Peter. “Do you give it up?”
+
+Of course in his pride he was carrying the game too far, and the
+miscreants [villains] saw their chance.
+
+“Yes, yes,” they answered eagerly.
+
+“Well, then,” he cried, “I am Peter Pan.”
+
+Pan!
+
+In a moment Hook was himself again, and Smee and Starkey were his
+faithful henchmen.
+
+“Now we have him,” Hook shouted. “Into the water, Smee. Starkey, mind
+the boat. Take him dead or alive!”
+
+He leaped as he spoke, and simultaneously came the gay voice of Peter.
+
+“Are you ready, boys?”
+
+“Ay, ay,” from various parts of the lagoon.
+
+“Then lam into the pirates.”
+
+The fight was short and sharp. First to draw blood was John, who
+gallantly climbed into the boat and held Starkey. There was fierce
+struggle, in which the cutlass was torn from the pirate’s grasp. He
+wriggled overboard and John leapt after him. The dinghy drifted away.
+
+Here and there a head bobbed up in the water, and there was a flash
+of steel followed by a cry or a whoop. In the confusion some struck at
+their own side. The corkscrew of Smee got Tootles in the fourth rib, but
+he was himself pinked [nicked] in turn by Curly. Farther from the rock
+Starkey was pressing Slightly and the twins hard.
+
+Where all this time was Peter? He was seeking bigger game.
+
+The others were all brave boys, and they must not be blamed for backing
+from the pirate captain. His iron claw made a circle of dead water round
+him, from which they fled like affrighted fishes.
+
+But there was one who did not fear him: there was one prepared to enter
+that circle.
+
+Strangely, it was not in the water that they met. Hook rose to the rock
+to breathe, and at the same moment Peter scaled it on the opposite
+side. The rock was slippery as a ball, and they had to crawl rather than
+climb. Neither knew that the other was coming. Each feeling for a grip
+met the other’s arm: in surprise they raised their heads; their faces
+were almost touching; so they met.
+
+Some of the greatest heroes have confessed that just before they fell to
+[began combat] they had a sinking [feeling in the stomach]. Had it been
+so with Peter at that moment I would admit it. After all, he was the
+only man that the Sea-Cook had feared. But Peter had no sinking, he had
+one feeling only, gladness; and he gnashed his pretty teeth with joy.
+Quick as thought he snatched a knife from Hook’s belt and was about to
+drive it home, when he saw that he was higher up the rock than his foe.
+It would not have been fighting fair. He gave the pirate a hand to help
+him up.
+
+It was then that Hook bit him.
+
+Not the pain of this but its unfairness was what dazed Peter. It made
+him quite helpless. He could only stare, horrified. Every child is
+affected thus the first time he is treated unfairly. All he thinks he
+has a right to when he comes to you to be yours is fairness. After
+you have been unfair to him he will love you again, but will never
+afterwards be quite the same boy. No one ever gets over the first
+unfairness; no one except Peter. He often met it, but he always forgot
+it. I suppose that was the real difference between him and all the rest.
+
+So when he met it now it was like the first time; and he could just
+stare, helpless. Twice the iron hand clawed him.
+
+A few moments afterwards the other boys saw Hook in the water striking
+wildly for the ship; no elation on the pestilent face now, only white
+fear, for the crocodile was in dogged pursuit of him. On ordinary
+occasions the boys would have swum alongside cheering; but now they were
+uneasy, for they had lost both Peter and Wendy, and were scouring the
+lagoon for them, calling them by name. They found the dinghy and went
+home in it, shouting “Peter, Wendy” as they went, but no answer came
+save mocking laughter from the mermaids. “They must be swimming back or
+flying,” the boys concluded. They were not very anxious, because they
+had such faith in Peter. They chuckled, boylike, because they would be
+late for bed; and it was all mother Wendy’s fault!
+
+When their voices died away there came cold silence over the lagoon, and
+then a feeble cry.
+
+“Help, help!”
+
+Two small figures were beating against the rock; the girl had fainted
+and lay on the boy’s arm. With a last effort Peter pulled her up the
+rock and then lay down beside her. Even as he also fainted he saw that
+the water was rising. He knew that they would soon be drowned, but he
+could do no more.
+
+As they lay side by side a mermaid caught Wendy by the feet, and began
+pulling her softly into the water. Peter, feeling her slip from him,
+woke with a start, and was just in time to draw her back. But he had to
+tell her the truth.
+
+“We are on the rock, Wendy,” he said, “but it is growing smaller. Soon
+the water will be over it.”
+
+She did not understand even now.
+
+“We must go,” she said, almost brightly.
+
+“Yes,” he answered faintly.
+
+“Shall we swim or fly, Peter?”
+
+He had to tell her.
+
+“Do you think you could swim or fly as far as the island, Wendy, without
+my help?”
+
+She had to admit that she was too tired.
+
+He moaned.
+
+“What is it?” she asked, anxious about him at once.
+
+“I can’t help you, Wendy. Hook wounded me. I can neither fly nor swim.”
+
+“Do you mean we shall both be drowned?”
+
+“Look how the water is rising.”
+
+They put their hands over their eyes to shut out the sight. They thought
+they would soon be no more. As they sat thus something brushed against
+Peter as light as a kiss, and stayed there, as if saying timidly, “Can I
+be of any use?”
+
+It was the tail of a kite, which Michael had made some days before. It
+had torn itself out of his hand and floated away.
+
+“Michael’s kite,” Peter said without interest, but next moment he had
+seized the tail, and was pulling the kite toward him.
+
+“It lifted Michael off the ground,” he cried; “why should it not carry
+you?”
+
+“Both of us!”
+
+“It can’t lift two; Michael and Curly tried.”
+
+“Let us draw lots,” Wendy said bravely.
+
+“And you a lady; never.” Already he had tied the tail round her. She
+clung to him; she refused to go without him; but with a “Good-bye,
+Wendy,” he pushed her from the rock; and in a few minutes she was borne
+out of his sight. Peter was alone on the lagoon.
+
+The rock was very small now; soon it would be submerged. Pale rays of
+light tiptoed across the waters; and by and by there was to be heard a
+sound at once the most musical and the most melancholy in the world: the
+mermaids calling to the moon.
+
+Peter was not quite like other boys; but he was afraid at last. A
+tremour ran through him, like a shudder passing over the sea; but on
+the sea one shudder follows another till there are hundreds of them, and
+Peter felt just the one. Next moment he was standing erect on the rock
+again, with that smile on his face and a drum beating within him. It was
+saying, “To die will be an awfully big adventure.”
+
+
+
+
+Chapter 9 THE NEVER BIRD
+
+The last sound Peter heard before he was quite alone were the mermaids
+retiring one by one to their bedchambers under the sea. He was too far
+away to hear their doors shut; but every door in the coral caves where
+they live rings a tiny bell when it opens or closes (as in all the
+nicest houses on the mainland), and he heard the bells.
+
+Steadily the waters rose till they were nibbling at his feet; and to
+pass the time until they made their final gulp, he watched the only
+thing on the lagoon. He thought it was a piece of floating paper,
+perhaps part of the kite, and wondered idly how long it would take to
+drift ashore.
+
+Presently he noticed as an odd thing that it was undoubtedly out upon
+the lagoon with some definite purpose, for it was fighting the tide,
+and sometimes winning; and when it won, Peter, always sympathetic to
+the weaker side, could not help clapping; it was such a gallant piece of
+paper.
+
+It was not really a piece of paper; it was the Never bird, making
+desperate efforts to reach Peter on the nest. By working her wings, in a
+way she had learned since the nest fell into the water, she was able to
+some extent to guide her strange craft, but by the time Peter recognised
+her she was very exhausted. She had come to save him, to give him her
+nest, though there were eggs in it. I rather wonder at the bird, for
+though he had been nice to her, he had also sometimes tormented her. I
+can suppose only that, like Mrs. Darling and the rest of them, she was
+melted because he had all his first teeth.
+
+She called out to him what she had come for, and he called out to her
+what she was doing there; but of course neither of them understood
+the other’s language. In fanciful stories people can talk to the birds
+freely, and I wish for the moment I could pretend that this were such a
+story, and say that Peter replied intelligently to the Never bird; but
+truth is best, and I want to tell you only what really happened. Well,
+not only could they not understand each other, but they forgot their
+manners.
+
+“I--want--you--to--get--into--the--nest,” the bird called, speaking as
+slowly and distinctly as possible, “and--then--you--can--drift--ashore,
+but--I--am--too--tired--to--bring--it--any--nearer--so--you--must--try
+to--swim--to--it.”
+
+“What are you quacking about?” Peter answered. “Why don’t you let the
+nest drift as usual?”
+
+“I--want--you--” the bird said, and repeated it all over.
+
+Then Peter tried slow and distinct.
+
+“What--are--you--quacking--about?” and so on.
+
+The Never bird became irritated; they have very short tempers.
+
+“You dunderheaded little jay!” she screamed, “Why don’t you do as I tell
+you?”
+
+Peter felt that she was calling him names, and at a venture he retorted
+hotly:
+
+“So are you!”
+
+Then rather curiously they both snapped out the same remark:
+
+“Shut up!”
+
+“Shut up!”
+
+Nevertheless the bird was determined to save him if she could, and by
+one last mighty effort she propelled the nest against the rock. Then up
+she flew; deserting her eggs, so as to make her meaning clear.
+
+Then at last he understood, and clutched the nest and waved his thanks
+to the bird as she fluttered overhead. It was not to receive his thanks,
+however, that she hung there in the sky; it was not even to watch him
+get into the nest; it was to see what he did with her eggs.
+
+There were two large white eggs, and Peter lifted them up and reflected.
+The bird covered her face with her wings, so as not to see the last of
+them; but she could not help peeping between the feathers.
+
+I forget whether I have told you that there was a stave on the rock,
+driven into it by some buccaneers of long ago to mark the site of buried
+treasure. The children had discovered the glittering hoard, and when in
+a mischievous mood used to fling showers of moidores, diamonds, pearls
+and pieces of eight to the gulls, who pounced upon them for food, and
+then flew away, raging at the scurvy trick that had been played upon
+them. The stave was still there, and on it Starkey had hung his hat, a
+deep tarpaulin, watertight, with a broad brim. Peter put the eggs into
+this hat and set it on the lagoon. It floated beautifully.
+
+The Never bird saw at once what he was up to, and screamed her
+admiration of him; and, alas, Peter crowed his agreement with her. Then
+he got into the nest, reared the stave in it as a mast, and hung up his
+shirt for a sail. At the same moment the bird fluttered down upon the
+hat and once more sat snugly on her eggs. She drifted in one direction,
+and he was borne off in another, both cheering.
+
+Of course when Peter landed he beached his barque [small ship, actually
+the Never Bird’s nest in this particular case in point] in a place where
+the bird would easily find it; but the hat was such a great success that
+she abandoned the nest. It drifted about till it went to pieces, and
+often Starkey came to the shore of the lagoon, and with many bitter
+feelings watched the bird sitting on his hat. As we shall not see her
+again, it may be worth mentioning here that all Never birds now build
+in that shape of nest, with a broad brim on which the youngsters take an
+airing.
+
+Great were the rejoicings when Peter reached the home under the ground
+almost as soon as Wendy, who had been carried hither and thither by
+the kite. Every boy had adventures to tell; but perhaps the biggest
+adventure of all was that they were several hours late for bed. This so
+inflated them that they did various dodgy things to get staying up still
+longer, such as demanding bandages; but Wendy, though glorying in having
+them all home again safe and sound, was scandalised by the lateness of
+the hour, and cried, “To bed, to bed,” in a voice that had to be obeyed.
+Next day, however, she was awfully tender, and gave out bandages to
+every one, and they played till bed-time at limping about and carrying
+their arms in slings.
+
+
+
+
+Chapter 10 THE HAPPY HOME
+
+One important result of the brush [with the pirates] on the lagoon was
+that it made the redskins their friends. Peter had saved Tiger Lily from
+a dreadful fate, and now there was nothing she and her braves would not
+do for him. All night they sat above, keeping watch over the home under
+the ground and awaiting the big attack by the pirates which obviously
+could not be much longer delayed. Even by day they hung about, smoking
+the pipe of peace, and looking almost as if they wanted tit-bits to eat.
+
+They called Peter the Great White Father, prostrating themselves [lying
+down] before him; and he liked this tremendously, so that it was not
+really good for him.
+
+“The great white father,” he would say to them in a very lordly manner,
+as they grovelled at his feet, “is glad to see the Piccaninny warriors
+protecting his wigwam from the pirates.”
+
+“Me Tiger Lily,” that lovely creature would reply. “Peter Pan save me,
+me his velly nice friend. Me no let pirates hurt him.”
+
+She was far too pretty to cringe in this way, but Peter thought it his
+due, and he would answer condescendingly, “It is good. Peter Pan has
+spoken.”
+
+Always when he said, “Peter Pan has spoken,” it meant that they must now
+shut up, and they accepted it humbly in that spirit; but they were by
+no means so respectful to the other boys, whom they looked upon as just
+ordinary braves. They said “How-do?” to them, and things like that; and
+what annoyed the boys was that Peter seemed to think this all right.
+
+Secretly Wendy sympathised with them a little, but she was far too loyal
+a housewife to listen to any complaints against father. “Father knows
+best,” she always said, whatever her private opinion must be. Her
+private opinion was that the redskins should not call her a squaw.
+
+We have now reached the evening that was to be known among them as the
+Night of Nights, because of its adventures and their upshot. The day, as
+if quietly gathering its forces, had been almost uneventful, and now the
+redskins in their blankets were at their posts above, while, below, the
+children were having their evening meal; all except Peter, who had gone
+out to get the time. The way you got the time on the island was to find
+the crocodile, and then stay near him till the clock struck.
+
+The meal happened to be a make-believe tea, and they sat around the
+board, guzzling in their greed; and really, what with their chatter and
+recriminations, the noise, as Wendy said, was positively deafening.
+To be sure, she did not mind noise, but she simply would not have them
+grabbing things, and then excusing themselves by saying that Tootles had
+pushed their elbow. There was a fixed rule that they must never hit back
+at meals, but should refer the matter of dispute to Wendy by raising
+the right arm politely and saying, “I complain of so-and-so;” but what
+usually happened was that they forgot to do this or did it too much.
+
+“Silence,” cried Wendy when for the twentieth time she had told them
+that they were not all to speak at once. “Is your mug empty, Slightly
+darling?”
+
+“Not quite empty, mummy,” Slightly said, after looking into an imaginary
+mug.
+
+“He hasn’t even begun to drink his milk,” Nibs interposed.
+
+This was telling, and Slightly seized his chance.
+
+“I complain of Nibs,” he cried promptly.
+
+John, however, had held up his hand first.
+
+“Well, John?”
+
+“May I sit in Peter’s chair, as he is not here?”
+
+“Sit in father’s chair, John!” Wendy was scandalised. “Certainly not.”
+
+“He is not really our father,” John answered. “He didn’t even know how a
+father does till I showed him.”
+
+This was grumbling. “We complain of John,” cried the twins.
+
+Tootles held up his hand. He was so much the humblest of them, indeed he
+was the only humble one, that Wendy was specially gentle with him.
+
+“I don’t suppose,” Tootles said diffidently [bashfully or timidly],
+“that I could be father.”
+
+“No, Tootles.”
+
+Once Tootles began, which was not very often, he had a silly way of
+going on.
+
+“As I can’t be father,” he said heavily, “I don’t suppose, Michael, you
+would let me be baby?”
+
+“No, I won’t,” Michael rapped out. He was already in his basket.
+
+“As I can’t be baby,” Tootles said, getting heavier and heavier and
+heavier, “do you think I could be a twin?”
+
+“No, indeed,” replied the twins; “it’s awfully difficult to be a twin.”
+
+“As I can’t be anything important,” said Tootles, “would any of you like
+to see me do a trick?”
+
+“No,” they all replied.
+
+Then at last he stopped. “I hadn’t really any hope,” he said.
+
+The hateful telling broke out again.
+
+“Slightly is coughing on the table.”
+
+“The twins began with cheese-cakes.”
+
+“Curly is taking both butter and honey.”
+
+“Nibs is speaking with his mouth full.”
+
+“I complain of the twins.”
+
+“I complain of Curly.”
+
+“I complain of Nibs.”
+
+“Oh dear, oh dear,” cried Wendy, “I’m sure I sometimes think that
+spinsters are to be envied.”
+
+She told them to clear away, and sat down to her work-basket, a heavy
+load of stockings and every knee with a hole in it as usual.
+
+“Wendy,” remonstrated [scolded] Michael, “I’m too big for a cradle.”
+
+“I must have somebody in a cradle,” she said almost tartly, “and you
+are the littlest. A cradle is such a nice homely thing to have about a
+house.”
+
+While she sewed they played around her; such a group of happy faces
+and dancing limbs lit up by that romantic fire. It had become a very
+familiar scene, this, in the home under the ground, but we are looking
+on it for the last time.
+
+There was a step above, and Wendy, you may be sure, was the first to
+recognize it.
+
+“Children, I hear your father’s step. He likes you to meet him at the
+door.”
+
+Above, the redskins crouched before Peter.
+
+“Watch well, braves. I have spoken.”
+
+And then, as so often before, the gay children dragged him from his
+tree. As so often before, but never again.
+
+He had brought nuts for the boys as well as the correct time for Wendy.
+
+“Peter, you just spoil them, you know,” Wendy simpered [exaggerated a
+smile].
+
+“Ah, old lady,” said Peter, hanging up his gun.
+
+“It was me told him mothers are called old lady,” Michael whispered to
+Curly.
+
+“I complain of Michael,” said Curly instantly.
+
+The first twin came to Peter. “Father, we want to dance.”
+
+“Dance away, my little man,” said Peter, who was in high good humour.
+
+“But we want you to dance.”
+
+Peter was really the best dancer among them, but he pretended to be
+scandalised.
+
+“Me! My old bones would rattle!”
+
+“And mummy too.”
+
+“What,” cried Wendy, “the mother of such an armful, dance!”
+
+“But on a Saturday night,” Slightly insinuated.
+
+It was not really Saturday night, at least it may have been, for
+they had long lost count of the days; but always if they wanted to do
+anything special they said this was Saturday night, and then they did
+it.
+
+“Of course it is Saturday night, Peter,” Wendy said, relenting.
+
+“People of our figure, Wendy!”
+
+“But it is only among our own progeny [children].”
+
+“True, true.”
+
+So they were told they could dance, but they must put on their nighties
+first.
+
+“Ah, old lady,” Peter said aside to Wendy, warming himself by the fire
+and looking down at her as she sat turning a heel, “there is nothing
+more pleasant of an evening for you and me when the day’s toil is over
+than to rest by the fire with the little ones near by.”
+
+“It is sweet, Peter, isn’t it?” Wendy said, frightfully gratified.
+“Peter, I think Curly has your nose.”
+
+“Michael takes after you.”
+
+She went to him and put her hand on his shoulder.
+
+“Dear Peter,” she said, “with such a large family, of course, I have now
+passed my best, but you don’t want to [ex]change me, do you?”
+
+“No, Wendy.”
+
+Certainly he did not want a change, but he looked at her uncomfortably,
+blinking, you know, like one not sure whether he was awake or asleep.
+
+“Peter, what is it?”
+
+“I was just thinking,” he said, a little scared. “It is only
+make-believe, isn’t it, that I am their father?”
+
+“Oh yes,” Wendy said primly [formally and properly].
+
+“You see,” he continued apologetically, “it would make me seem so old to
+be their real father.”
+
+“But they are ours, Peter, yours and mine.”
+
+“But not really, Wendy?” he asked anxiously.
+
+“Not if you don’t wish it,” she replied; and she distinctly heard his
+sigh of relief. “Peter,” she asked, trying to speak firmly, “what are
+your exact feelings to [about] me?”
+
+“Those of a devoted son, Wendy.”
+
+“I thought so,” she said, and went and sat by herself at the extreme end
+of the room.
+
+“You are so queer,” he said, frankly puzzled, “and Tiger Lily is just
+the same. There is something she wants to be to me, but she says it is
+not my mother.”
+
+“No, indeed, it is not,” Wendy replied with frightful emphasis. Now we
+know why she was prejudiced against the redskins.
+
+“Then what is it?”
+
+“It isn’t for a lady to tell.”
+
+“Oh, very well,” Peter said, a little nettled. “Perhaps Tinker Bell will
+tell me.”
+
+“Oh yes, Tinker Bell will tell you,” Wendy retorted scornfully. “She is
+an abandoned little creature.”
+
+Here Tink, who was in her bedroom, eavesdropping, squeaked out something
+impudent.
+
+“She says she glories in being abandoned,” Peter interpreted.
+
+He had a sudden idea. “Perhaps Tink wants to be my mother?”
+
+“You silly ass!” cried Tinker Bell in a passion.
+
+She had said it so often that Wendy needed no translation.
+
+“I almost agree with her,” Wendy snapped. Fancy Wendy snapping! But she
+had been much tried, and she little knew what was to happen before the
+night was out. If she had known she would not have snapped.
+
+None of them knew. Perhaps it was best not to know. Their ignorance
+gave them one more glad hour; and as it was to be their last hour on the
+island, let us rejoice that there were sixty glad minutes in it. They
+sang and danced in their night-gowns. Such a deliciously creepy song
+it was, in which they pretended to be frightened at their own shadows,
+little witting that so soon shadows would close in upon them, from whom
+they would shrink in real fear. So uproariously gay was the dance, and
+how they buffeted each other on the bed and out of it! It was a pillow
+fight rather than a dance, and when it was finished, the pillows
+insisted on one bout more, like partners who know that they may never
+meet again. The stories they told, before it was time for Wendy’s
+good-night story! Even Slightly tried to tell a story that night, but
+the beginning was so fearfully dull that it appalled not only the others
+but himself, and he said happily:
+
+“Yes, it is a dull beginning. I say, let us pretend that it is the end.”
+
+And then at last they all got into bed for Wendy’s story, the story they
+loved best, the story Peter hated. Usually when she began to tell this
+story he left the room or put his hands over his ears; and possibly if
+he had done either of those things this time they might all still be on
+the island. But to-night he remained on his stool; and we shall see what
+happened.
+
+
+
+
+Chapter 11 WENDY’S STORY
+
+“Listen, then,” said Wendy, settling down to her story, with Michael at
+her feet and seven boys in the bed. “There was once a gentleman--”
+
+“I had rather he had been a lady,” Curly said.
+
+“I wish he had been a white rat,” said Nibs.
+
+“Quiet,” their mother admonished [cautioned] them. “There was a lady
+also, and--”
+
+“Oh, mummy,” cried the first twin, “you mean that there is a lady also,
+don’t you? She is not dead, is she?”
+
+“Oh, no.”
+
+“I am awfully glad she isn’t dead,” said Tootles. “Are you glad, John?”
+
+“Of course I am.”
+
+“Are you glad, Nibs?”
+
+“Rather.”
+
+“Are you glad, Twins?”
+
+“We are glad.”
+
+“Oh dear,” sighed Wendy.
+
+“Little less noise there,” Peter called out, determined that she should
+have fair play, however beastly a story it might be in his opinion.
+
+“The gentleman’s name,” Wendy continued, “was Mr. Darling, and her name
+was Mrs. Darling.”
+
+“I knew them,” John said, to annoy the others.
+
+“I think I knew them,” said Michael rather doubtfully.
+
+“They were married, you know,” explained Wendy, “and what do you think
+they had?”
+
+“White rats,” cried Nibs, inspired.
+
+“No.”
+
+“It’s awfully puzzling,” said Tootles, who knew the story by heart.
+
+“Quiet, Tootles. They had three descendants.”
+
+“What is descendants?”
+
+“Well, you are one, Twin.”
+
+“Did you hear that, John? I am a descendant.”
+
+“Descendants are only children,” said John.
+
+“Oh dear, oh dear,” sighed Wendy. “Now these three children had a
+faithful nurse called Nana; but Mr. Darling was angry with her and
+chained her up in the yard, and so all the children flew away.”
+
+“It’s an awfully good story,” said Nibs.
+
+“They flew away,” Wendy continued, “to the Neverland, where the lost
+children are.”
+
+“I just thought they did,” Curly broke in excitedly. “I don’t know how
+it is, but I just thought they did!”
+
+“O Wendy,” cried Tootles, “was one of the lost children called Tootles?”
+
+“Yes, he was.”
+
+“I am in a story. Hurrah, I am in a story, Nibs.”
+
+“Hush. Now I want you to consider the feelings of the unhappy parents
+with all their children flown away.”
+
+“Oo!” they all moaned, though they were not really considering the
+feelings of the unhappy parents one jot.
+
+“Think of the empty beds!”
+
+“Oo!”
+
+“It’s awfully sad,” the first twin said cheerfully.
+
+“I don’t see how it can have a happy ending,” said the second twin. “Do
+you, Nibs?”
+
+“I’m frightfully anxious.”
+
+“If you knew how great is a mother’s love,” Wendy told them
+triumphantly, “you would have no fear.” She had now come to the part
+that Peter hated.
+
+“I do like a mother’s love,” said Tootles, hitting Nibs with a pillow.
+“Do you like a mother’s love, Nibs?”
+
+“I do just,” said Nibs, hitting back.
+
+“You see,” Wendy said complacently, “our heroine knew that the mother
+would always leave the window open for her children to fly back by; so
+they stayed away for years and had a lovely time.”
+
+“Did they ever go back?”
+
+“Let us now,” said Wendy, bracing herself up for her finest effort,
+“take a peep into the future;” and they all gave themselves the twist
+that makes peeps into the future easier. “Years have rolled by, and who
+is this elegant lady of uncertain age alighting at London Station?”
+
+“O Wendy, who is she?” cried Nibs, every bit as excited as if he didn’t
+know.
+
+“Can it be--yes--no--it is--the fair Wendy!”
+
+“Oh!”
+
+“And who are the two noble portly figures accompanying her, now grown to
+man’s estate? Can they be John and Michael? They are!”
+
+“Oh!”
+
+“‘See, dear brothers,’ says Wendy pointing upwards, ‘there is the window
+still standing open. Ah, now we are rewarded for our sublime faith in a
+mother’s love.’ So up they flew to their mummy and daddy, and pen cannot
+describe the happy scene, over which we draw a veil.”
+
+That was the story, and they were as pleased with it as the fair
+narrator herself. Everything just as it should be, you see. Off we skip
+like the most heartless things in the world, which is what children are,
+but so attractive; and we have an entirely selfish time, and then when
+we have need of special attention we nobly return for it, confident that
+we shall be rewarded instead of smacked.
+
+So great indeed was their faith in a mother’s love that they felt they
+could afford to be callous for a bit longer.
+
+But there was one there who knew better, and when Wendy finished he
+uttered a hollow groan.
+
+“What is it, Peter?” she cried, running to him, thinking he was ill. She
+felt him solicitously, lower down than his chest. “Where is it, Peter?”
+
+“It isn’t that kind of pain,” Peter replied darkly.
+
+“Then what kind is it?”
+
+“Wendy, you are wrong about mothers.”
+
+They all gathered round him in affright, so alarming was his agitation;
+and with a fine candour he told them what he had hitherto concealed.
+
+“Long ago,” he said, “I thought like you that my mother would always
+keep the window open for me, so I stayed away for moons and moons and
+moons, and then flew back; but the window was barred, for mother had
+forgotten all about me, and there was another little boy sleeping in my
+bed.”
+
+I am not sure that this was true, but Peter thought it was true; and it
+scared them.
+
+“Are you sure mothers are like that?”
+
+“Yes.”
+
+So this was the truth about mothers. The toads!
+
+Still it is best to be careful; and no one knows so quickly as a child
+when he should give in. “Wendy, let us [let’s] go home,” cried John and
+Michael together.
+
+“Yes,” she said, clutching them.
+
+“Not to-night?” asked the lost boys bewildered. They knew in what they
+called their hearts that one can get on quite well without a mother, and
+that it is only the mothers who think you can’t.
+
+“At once,” Wendy replied resolutely, for the horrible thought had come
+to her: “Perhaps mother is in half mourning by this time.”
+
+This dread made her forgetful of what must be Peter’s feelings, and
+she said to him rather sharply, “Peter, will you make the necessary
+arrangements?”
+
+“If you wish it,” he replied, as coolly as if she had asked him to pass
+the nuts.
+
+Not so much as a sorry-to-lose-you between them! If she did not mind the
+parting, he was going to show her, was Peter, that neither did he.
+
+But of course he cared very much; and he was so full of wrath against
+grown-ups, who, as usual, were spoiling everything, that as soon as he
+got inside his tree he breathed intentionally quick short breaths at the
+rate of about five to a second. He did this because there is a saying in
+the Neverland that, every time you breathe, a grown-up dies; and Peter
+was killing them off vindictively as fast as possible.
+
+Then having given the necessary instructions to the redskins he returned
+to the home, where an unworthy scene had been enacted in his absence.
+Panic-stricken at the thought of losing Wendy the lost boys had advanced
+upon her threateningly.
+
+“It will be worse than before she came,” they cried.
+
+“We shan’t let her go.”
+
+“Let’s keep her prisoner.”
+
+“Ay, chain her up.”
+
+In her extremity an instinct told her to which of them to turn.
+
+“Tootles,” she cried, “I appeal to you.”
+
+Was it not strange? She appealed to Tootles, quite the silliest one.
+
+Grandly, however, did Tootles respond. For that one moment he dropped
+his silliness and spoke with dignity.
+
+“I am just Tootles,” he said, “and nobody minds me. But the first who
+does not behave to Wendy like an English gentleman I will blood him
+severely.”
+
+He drew back his hanger; and for that instant his sun was at noon. The
+others held back uneasily. Then Peter returned, and they saw at once
+that they would get no support from him. He would keep no girl in the
+Neverland against her will.
+
+“Wendy,” he said, striding up and down, “I have asked the redskins to
+guide you through the wood, as flying tires you so.”
+
+“Thank you, Peter.”
+
+“Then,” he continued, in the short sharp voice of one accustomed to be
+obeyed, “Tinker Bell will take you across the sea. Wake her, Nibs.”
+
+Nibs had to knock twice before he got an answer, though Tink had really
+been sitting up in bed listening for some time.
+
+“Who are you? How dare you? Go away,” she cried.
+
+“You are to get up, Tink,” Nibs called, “and take Wendy on a journey.”
+
+Of course Tink had been delighted to hear that Wendy was going; but
+she was jolly well determined not to be her courier, and she said so in
+still more offensive language. Then she pretended to be asleep again.
+
+“She says she won’t!” Nibs exclaimed, aghast at such insubordination,
+whereupon Peter went sternly toward the young lady’s chamber.
+
+“Tink,” he rapped out, “if you don’t get up and dress at once I will
+open the curtains, and then we shall all see you in your negligee
+[nightgown].”
+
+This made her leap to the floor. “Who said I wasn’t getting up?” she
+cried.
+
+In the meantime the boys were gazing very forlornly at Wendy, now
+equipped with John and Michael for the journey. By this time they were
+dejected, not merely because they were about to lose her, but also
+because they felt that she was going off to something nice to which they
+had not been invited. Novelty was beckoning to them as usual.
+
+Crediting them with a nobler feeling Wendy melted.
+
+“Dear ones,” she said, “if you will all come with me I feel almost sure
+I can get my father and mother to adopt you.”
+
+The invitation was meant specially for Peter, but each of the boys was
+thinking exclusively of himself, and at once they jumped with joy.
+
+“But won’t they think us rather a handful?” Nibs asked in the middle of
+his jump.
+
+“Oh no,” said Wendy, rapidly thinking it out, “it will only mean having
+a few beds in the drawing-room; they can be hidden behind the screens on
+first Thursdays.”
+
+“Peter, can we go?” they all cried imploringly. They took it for granted
+that if they went he would go also, but really they scarcely cared. Thus
+children are ever ready, when novelty knocks, to desert their dearest
+ones.
+
+“All right,” Peter replied with a bitter smile, and immediately they
+rushed to get their things.
+
+“And now, Peter,” Wendy said, thinking she had put everything right,
+“I am going to give you your medicine before you go.” She loved to give
+them medicine, and undoubtedly gave them too much. Of course it was only
+water, but it was out of a bottle, and she always shook the bottle and
+counted the drops, which gave it a certain medicinal quality. On this
+occasion, however, she did not give Peter his draught [portion], for
+just as she had prepared it, she saw a look on his face that made her
+heart sink.
+
+“Get your things, Peter,” she cried, shaking.
+
+“No,” he answered, pretending indifference, “I am not going with you,
+Wendy.”
+
+“Yes, Peter.”
+
+“No.”
+
+To show that her departure would leave him unmoved, he skipped up and
+down the room, playing gaily on his heartless pipes. She had to run
+about after him, though it was rather undignified.
+
+“To find your mother,” she coaxed.
+
+Now, if Peter had ever quite had a mother, he no longer missed her. He
+could do very well without one. He had thought them out, and remembered
+only their bad points.
+
+“No, no,” he told Wendy decisively; “perhaps she would say I was old,
+and I just want always to be a little boy and to have fun.”
+
+“But, Peter--”
+
+“No.”
+
+And so the others had to be told.
+
+“Peter isn’t coming.”
+
+Peter not coming! They gazed blankly at him, their sticks over their
+backs, and on each stick a bundle. Their first thought was that if Peter
+was not going he had probably changed his mind about letting them go.
+
+But he was far too proud for that. “If you find your mothers,” he said
+darkly, “I hope you will like them.”
+
+The awful cynicism of this made an uncomfortable impression, and most
+of them began to look rather doubtful. After all, their faces said, were
+they not noodles to want to go?
+
+“Now then,” cried Peter, “no fuss, no blubbering; good-bye, Wendy;” and
+he held out his hand cheerily, quite as if they must really go now, for
+he had something important to do.
+
+She had to take his hand, and there was no indication that he would
+prefer a thimble.
+
+“You will remember about changing your flannels, Peter?” she said,
+lingering over him. She was always so particular about their flannels.
+
+“Yes.”
+
+“And you will take your medicine?”
+
+“Yes.”
+
+That seemed to be everything, and an awkward pause followed. Peter,
+however, was not the kind that breaks down before other people. “Are you
+ready, Tinker Bell?” he called out.
+
+“Ay, ay.”
+
+“Then lead the way.”
+
+Tink darted up the nearest tree; but no one followed her, for it was
+at this moment that the pirates made their dreadful attack upon the
+redskins. Above, where all had been so still, the air was rent with
+shrieks and the clash of steel. Below, there was dead silence. Mouths
+opened and remained open. Wendy fell on her knees, but her arms were
+extended toward Peter. All arms were extended to him, as if suddenly
+blown in his direction; they were beseeching him mutely not to desert
+them. As for Peter, he seized his sword, the same he thought he had
+slain Barbecue with, and the lust of battle was in his eye.
+
+
+
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+The pirate attack had been a complete surprise: a sure proof that the
+unscrupulous Hook had conducted it improperly, for to surprise redskins
+fairly is beyond the wit of the white man.
+
+By all the unwritten laws of savage warfare it is always the redskin who
+attacks, and with the wiliness of his race he does it just before the
+dawn, at which time he knows the courage of the whites to be at its
+lowest ebb. The white men have in the meantime made a rude stockade on
+the summit of yonder undulating ground, at the foot of which a stream
+runs, for it is destruction to be too far from water. There they await
+the onslaught, the inexperienced ones clutching their revolvers and
+treading on twigs, but the old hands sleeping tranquilly until just
+before the dawn. Through the long black night the savage scouts wriggle,
+snake-like, among the grass without stirring a blade. The brushwood
+closes behind them, as silently as sand into which a mole has dived.
+Not a sound is to be heard, save when they give vent to a wonderful
+imitation of the lonely call of the coyote. The cry is answered by other
+braves; and some of them do it even better than the coyotes, who are not
+very good at it. So the chill hours wear on, and the long suspense is
+horribly trying to the paleface who has to live through it for the first
+time; but to the trained hand those ghastly calls and still ghastlier
+silences are but an intimation of how the night is marching.
+
+That this was the usual procedure was so well known to Hook that in
+disregarding it he cannot be excused on the plea of ignorance.
+
+The Piccaninnies, on their part, trusted implicitly to his honour, and
+their whole action of the night stands out in marked contrast to his.
+They left nothing undone that was consistent with the reputation of
+their tribe. With that alertness of the senses which is at once the
+marvel and despair of civilised peoples, they knew that the pirates were
+on the island from the moment one of them trod on a dry stick; and in
+an incredibly short space of time the coyote cries began. Every foot of
+ground between the spot where Hook had landed his forces and the
+home under the trees was stealthily examined by braves wearing their
+mocassins with the heels in front. They found only one hillock with a
+stream at its base, so that Hook had no choice; here he must establish
+himself and wait for just before the dawn. Everything being thus mapped
+out with almost diabolical cunning, the main body of the redskins folded
+their blankets around them, and in the phlegmatic manner that is to
+them, the pearl of manhood squatted above the children’s home, awaiting
+the cold moment when they should deal pale death.
+
+Here dreaming, though wide-awake, of the exquisite tortures to which
+they were to put him at break of day, those confiding savages were found
+by the treacherous Hook. From the accounts afterwards supplied by such
+of the scouts as escaped the carnage, he does not seem even to have
+paused at the rising ground, though it is certain that in that grey
+light he must have seen it: no thought of waiting to be attacked appears
+from first to last to have visited his subtle mind; he would not even
+hold off till the night was nearly spent; on he pounded with no policy
+but to fall to [get into combat]. What could the bewildered scouts do,
+masters as they were of every war-like artifice save this one, but trot
+helplessly after him, exposing themselves fatally to view, while they
+gave pathetic utterance to the coyote cry.
+
+Around the brave Tiger Lily were a dozen of her stoutest warriors, and
+they suddenly saw the perfidious pirates bearing down upon them. Fell
+from their eyes then the film through which they had looked at
+victory. No more would they torture at the stake. For them the happy
+hunting-grounds was now. They knew it; but as their father’s sons they
+acquitted themselves. Even then they had time to gather in a phalanx
+[dense formation] that would have been hard to break had they risen
+quickly, but this they were forbidden to do by the traditions of their
+race. It is written that the noble savage must never express surprise in
+the presence of the white. Thus terrible as the sudden appearance of the
+pirates must have been to them, they remained stationary for a moment,
+not a muscle moving; as if the foe had come by invitation. Then, indeed,
+the tradition gallantly upheld, they seized their weapons, and the air
+was torn with the war-cry; but it was now too late.
+
+It is no part of ours to describe what was a massacre rather than a
+fight. Thus perished many of the flower of the Piccaninny tribe. Not all
+unavenged did they die, for with Lean Wolf fell Alf Mason, to disturb
+the Spanish Main no more, and among others who bit the dust were Geo.
+Scourie, Chas. Turley, and the Alsatian Foggerty. Turley fell to the
+tomahawk of the terrible Panther, who ultimately cut a way through the
+pirates with Tiger Lily and a small remnant of the tribe.
+
+To what extent Hook is to blame for his tactics on this occasion is for
+the historian to decide. Had he waited on the rising ground till the
+proper hour he and his men would probably have been butchered; and in
+judging him it is only fair to take this into account. What he should
+perhaps have done was to acquaint his opponents that he proposed to
+follow a new method. On the other hand, this, as destroying the element
+of surprise, would have made his strategy of no avail, so that the whole
+question is beset with difficulties. One cannot at least withhold a
+reluctant admiration for the wit that had conceived so bold a scheme,
+and the fell [deadly] genius with which it was carried out.
+
+What were his own feelings about himself at that triumphant moment?
+Fain [gladly] would his dogs have known, as breathing heavily and wiping
+their cutlasses, they gathered at a discreet distance from his hook, and
+squinted through their ferret eyes at this extraordinary man. Elation
+must have been in his heart, but his face did not reflect it: ever a
+dark and solitary enigma, he stood aloof from his followers in spirit as
+in substance.
+
+The night’s work was not yet over, for it was not the redskins he had
+come out to destroy; they were but the bees to be smoked, so that he
+should get at the honey. It was Pan he wanted, Pan and Wendy and their
+band, but chiefly Pan.
+
+Peter was such a small boy that one tends to wonder at the man’s hatred
+of him. True he had flung Hook’s arm to the crocodile, but even this
+and the increased insecurity of life to which it led, owing to
+the crocodile’s pertinacity [persistance], hardly account for a
+vindictiveness so relentless and malignant. The truth is that there was
+a something about Peter which goaded the pirate captain to frenzy. It
+was not his courage, it was not his engaging appearance, it was not--.
+There is no beating about the bush, for we know quite well what it was,
+and have got to tell. It was Peter’s cockiness.
+
+This had got on Hook’s nerves; it made his iron claw twitch, and at
+night it disturbed him like an insect. While Peter lived, the tortured
+man felt that he was a lion in a cage into which a sparrow had come.
+
+The question now was how to get down the trees, or how to get his dogs
+down? He ran his greedy eyes over them, searching for the thinnest
+ones. They wriggled uncomfortably, for they knew he would not scruple
+[hesitate] to ram them down with poles.
+
+In the meantime, what of the boys? We have seen them at the first clang
+of the weapons, turned as it were into stone figures, open-mouthed,
+all appealing with outstretched arms to Peter; and we return to them as
+their mouths close, and their arms fall to their sides. The pandemonium
+above has ceased almost as suddenly as it arose, passed like a fierce
+gust of wind; but they know that in the passing it has determined their
+fate.
+
+Which side had won?
+
+The pirates, listening avidly at the mouths of the trees, heard the
+question put by every boy, and alas, they also heard Peter’s answer.
+
+“If the redskins have won,” he said, “they will beat the tom-tom; it is
+always their sign of victory.”
+
+Now Smee had found the tom-tom, and was at that moment sitting on it.
+“You will never hear the tom-tom again,” he muttered, but inaudibly of
+course, for strict silence had been enjoined [urged]. To his amazement
+Hook signed him to beat the tom-tom, and slowly there came to Smee an
+understanding of the dreadful wickedness of the order. Never, probably,
+had this simple man admired Hook so much.
+
+Twice Smee beat upon the instrument, and then stopped to listen
+gleefully.
+
+“The tom-tom,” the miscreants heard Peter cry; “an Indian victory!”
+
+The doomed children answered with a cheer that was music to the black
+hearts above, and almost immediately they repeated their good-byes
+to Peter. This puzzled the pirates, but all their other feelings were
+swallowed by a base delight that the enemy were about to come up the
+trees. They smirked at each other and rubbed their hands. Rapidly and
+silently Hook gave his orders: one man to each tree, and the others to
+arrange themselves in a line two yards apart.
+
+
+
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+The more quickly this horror is disposed of the better. The first to
+emerge from his tree was Curly. He rose out of it into the arms of
+Cecco, who flung him to Smee, who flung him to Starkey, who flung him to
+Bill Jukes, who flung him to Noodler, and so he was tossed from one to
+another till he fell at the feet of the black pirate. All the boys were
+plucked from their trees in this ruthless manner; and several of them
+were in the air at a time, like bales of goods flung from hand to hand.
+
+A different treatment was accorded to Wendy, who came last. With
+ironical politeness Hook raised his hat to her, and, offering her his
+arm, escorted her to the spot where the others were being gagged. He
+did it with such an air, he was so frightfully DISTINGUE [imposingly
+distinguished], that she was too fascinated to cry out. She was only a
+little girl.
+
+Perhaps it is tell-tale to divulge that for a moment Hook entranced her,
+and we tell on her only because her slip led to strange results. Had she
+haughtily unhanded him (and we should have loved to write it of her),
+she would have been hurled through the air like the others, and then
+Hook would probably not have been present at the tying of the children;
+and had he not been at the tying he would not have discovered Slightly’s
+secret, and without the secret he could not presently have made his foul
+attempt on Peter’s life.
+
+They were tied to prevent their flying away, doubled up with their knees
+close to their ears; and for the trussing of them the black pirate had
+cut a rope into nine equal pieces. All went well until Slightly’s turn
+came, when he was found to be like those irritating parcels that use up
+all the string in going round and leave no tags [ends] with which to
+tie a knot. The pirates kicked him in their rage, just as you kick the
+parcel (though in fairness you should kick the string); and strange
+to say it was Hook who told them to belay their violence. His lip was
+curled with malicious triumph. While his dogs were merely sweating
+because every time they tried to pack the unhappy lad tight in one
+part he bulged out in another, Hook’s master mind had gone far beneath
+Slightly’s surface, probing not for effects but for causes; and his
+exultation showed that he had found them. Slightly, white to the gills,
+knew that Hook had surprised [discovered] his secret, which was this,
+that no boy so blown out could use a tree wherein an average man need
+stick. Poor Slightly, most wretched of all the children now, for he
+was in a panic about Peter, bitterly regretted what he had done. Madly
+addicted to the drinking of water when he was hot, he had swelled in
+consequence to his present girth, and instead of reducing himself to fit
+his tree he had, unknown to the others, whittled his tree to make it fit
+him.
+
+Sufficient of this Hook guessed to persuade him that Peter at last lay
+at his mercy, but no word of the dark design that now formed in the
+subterranean caverns of his mind crossed his lips; he merely signed
+that the captives were to be conveyed to the ship, and that he would be
+alone.
+
+How to convey them? Hunched up in their ropes they might indeed be
+rolled down hill like barrels, but most of the way lay through a morass.
+Again Hook’s genius surmounted difficulties. He indicated that the
+little house must be used as a conveyance. The children were flung into
+it, four stout pirates raised it on their shoulders, the others fell in
+behind, and singing the hateful pirate chorus the strange procession
+set off through the wood. I don’t know whether any of the children were
+crying; if so, the singing drowned the sound; but as the little house
+disappeared in the forest, a brave though tiny jet of smoke issued from
+its chimney as if defying Hook.
+
+Hook saw it, and it did Peter a bad service. It dried up any trickle of
+pity for him that may have remained in the pirate’s infuriated breast.
+
+The first thing he did on finding himself alone in the fast falling
+night was to tiptoe to Slightly’s tree, and make sure that it provided
+him with a passage. Then for long he remained brooding; his hat of ill
+omen on the sward, so that any gentle breeze which had arisen might play
+refreshingly through his hair. Dark as were his thoughts his blue eyes
+were as soft as the periwinkle. Intently he listened for any sound from
+the nether world, but all was as silent below as above; the house under
+the ground seemed to be but one more empty tenement in the void. Was
+that boy asleep, or did he stand waiting at the foot of Slightly’s tree,
+with his dagger in his hand?
+
+There was no way of knowing, save by going down. Hook let his cloak slip
+softly to the ground, and then biting his lips till a lewd blood stood
+on them, he stepped into the tree. He was a brave man, but for a moment
+he had to stop there and wipe his brow, which was dripping like a
+candle. Then, silently, he let himself go into the unknown.
+
+He arrived unmolested at the foot of the shaft, and stood still again,
+biting at his breath, which had almost left him. As his eyes became
+accustomed to the dim light various objects in the home under the trees
+took shape; but the only one on which his greedy gaze rested, long
+sought for and found at last, was the great bed. On the bed lay Peter
+fast asleep.
+
+Unaware of the tragedy being enacted above, Peter had continued, for
+a little time after the children left, to play gaily on his pipes: no
+doubt rather a forlorn attempt to prove to himself that he did not care.
+Then he decided not to take his medicine, so as to grieve Wendy. Then he
+lay down on the bed outside the coverlet, to vex her still more; for she
+had always tucked them inside it, because you never know that you may
+not grow chilly at the turn of the night. Then he nearly cried; but
+it struck him how indignant she would be if he laughed instead; so he
+laughed a haughty laugh and fell asleep in the middle of it.
+
+Sometimes, though not often, he had dreams, and they were more painful
+than the dreams of other boys. For hours he could not be separated from
+these dreams, though he wailed piteously in them. They had to do, I
+think, with the riddle of his existence. At such times it had been
+Wendy’s custom to take him out of bed and sit with him on her lap,
+soothing him in dear ways of her own invention, and when he grew calmer
+to put him back to bed before he quite woke up, so that he should
+not know of the indignity to which she had subjected him. But on this
+occasion he had fallen at once into a dreamless sleep. One arm dropped
+over the edge of the bed, one leg was arched, and the unfinished part of
+his laugh was stranded on his mouth, which was open, showing the little
+pearls.
+
+Thus defenceless Hook found him. He stood silent at the foot of the tree
+looking across the chamber at his enemy. Did no feeling of compassion
+disturb his sombre breast? The man was not wholly evil; he loved flowers
+(I have been told) and sweet music (he was himself no mean performer on
+the harpsichord); and, let it be frankly admitted, the idyllic nature of
+the scene stirred him profoundly. Mastered by his better self he would
+have returned reluctantly up the tree, but for one thing.
+
+What stayed him was Peter’s impertinent appearance as he slept. The
+open mouth, the drooping arm, the arched knee: they were such a
+personification of cockiness as, taken together, will never again, one
+may hope, be presented to eyes so sensitive to their offensiveness. They
+steeled Hook’s heart. If his rage had broken him into a hundred pieces
+every one of them would have disregarded the incident, and leapt at the
+sleeper.
+
+Though a light from the one lamp shone dimly on the bed, Hook stood in
+darkness himself, and at the first stealthy step forward he discovered
+an obstacle, the door of Slightly’s tree. It did not entirely fill the
+aperture, and he had been looking over it. Feeling for the catch,
+he found to his fury that it was low down, beyond his reach. To his
+disordered brain it seemed then that the irritating quality in Peter’s
+face and figure visibly increased, and he rattled the door and flung
+himself against it. Was his enemy to escape him after all?
+
+But what was that? The red in his eye had caught sight of Peter’s
+medicine standing on a ledge within easy reach. He fathomed what it was
+straightaway, and immediately knew that the sleeper was in his power.
+
+Lest he should be taken alive, Hook always carried about his person a
+dreadful drug, blended by himself of all the death-dealing rings that
+had come into his possession. These he had boiled down into a yellow
+liquid quite unknown to science, which was probably the most virulent
+poison in existence.
+
+Five drops of this he now added to Peter’s cup. His hand shook, but it
+was in exultation rather than in shame. As he did it he avoided glancing
+at the sleeper, but not lest pity should unnerve him; merely to avoid
+spilling. Then one long gloating look he cast upon his victim, and
+turning, wormed his way with difficulty up the tree. As he emerged
+at the top he looked the very spirit of evil breaking from its hole.
+Donning his hat at its most rakish angle, he wound his cloak around him,
+holding one end in front as if to conceal his person from the night,
+of which it was the blackest part, and muttering strangely to himself,
+stole away through the trees.
+
+Peter slept on. The light guttered [burned to edges] and went out,
+leaving the tenement in darkness; but still he slept. It must have been
+not less than ten o’clock by the crocodile, when he suddenly sat up in
+his bed, wakened by he knew not what. It was a soft cautious tapping on
+the door of his tree.
+
+Soft and cautious, but in that stillness it was sinister. Peter felt for
+his dagger till his hand gripped it. Then he spoke.
+
+“Who is that?”
+
+For long there was no answer: then again the knock.
+
+“Who are you?”
+
+No answer.
+
+He was thrilled, and he loved being thrilled. In two strides he reached
+the door. Unlike Slightly’s door, it filled the aperture [opening], so
+that he could not see beyond it, nor could the one knocking see him.
+
+“I won’t open unless you speak,” Peter cried.
+
+Then at last the visitor spoke, in a lovely bell-like voice.
+
+“Let me in, Peter.”
+
+It was Tink, and quickly he unbarred to her. She flew in excitedly, her
+face flushed and her dress stained with mud.
+
+“What is it?”
+
+“Oh, you could never guess!” she cried, and offered him three guesses.
+“Out with it!” he shouted, and in one ungrammatical sentence, as long as
+the ribbons that conjurers [magicians] pull from their mouths, she told
+of the capture of Wendy and the boys.
+
+Peter’s heart bobbed up and down as he listened. Wendy bound, and on the
+pirate ship; she who loved everything to be just so!
+
+“I’ll rescue her!” he cried, leaping at his weapons. As he leapt he
+thought of something he could do to please her. He could take his
+medicine.
+
+His hand closed on the fatal draught.
+
+“No!” shrieked Tinker Bell, who had heard Hook mutter about his deed as
+he sped through the forest.
+
+“Why not?”
+
+“It is poisoned.”
+
+“Poisoned? Who could have poisoned it?”
+
+“Hook.”
+
+“Don’t be silly. How could Hook have got down here?”
+
+Alas, Tinker Bell could not explain this, for even she did not know the
+dark secret of Slightly’s tree. Nevertheless Hook’s words had left no
+room for doubt. The cup was poisoned.
+
+“Besides,” said Peter, quite believing himself, “I never fell asleep.”
+
+He raised the cup. No time for words now; time for deeds; and with one
+of her lightning movements Tink got between his lips and the draught,
+and drained it to the dregs.
+
+“Why, Tink, how dare you drink my medicine?”
+
+But she did not answer. Already she was reeling in the air.
+
+“What is the matter with you?” cried Peter, suddenly afraid.
+
+“It was poisoned, Peter,” she told him softly; “and now I am going to be
+dead.”
+
+“O Tink, did you drink it to save me?”
+
+“Yes.”
+
+“But why, Tink?”
+
+Her wings would scarcely carry her now, but in reply she alighted on his
+shoulder and gave his nose a loving bite. She whispered in his ear “You
+silly ass,” and then, tottering to her chamber, lay down on the bed.
+
+His head almost filled the fourth wall of her little room as he knelt
+near her in distress. Every moment her light was growing fainter; and
+he knew that if it went out she would be no more. She liked his tears so
+much that she put out her beautiful finger and let them run over it.
+
+Her voice was so low that at first he could not make out what she said.
+Then he made it out. She was saying that she thought she could get well
+again if children believed in fairies.
+
+Peter flung out his arms. There were no children there, and it was night
+time; but he addressed all who might be dreaming of the Neverland, and
+who were therefore nearer to him than you think: boys and girls in their
+nighties, and naked papooses in their baskets hung from trees.
+
+“Do you believe?” he cried.
+
+Tink sat up in bed almost briskly to listen to her fate.
+
+She fancied she heard answers in the affirmative, and then again she
+wasn’t sure.
+
+“What do you think?” she asked Peter.
+
+“If you believe,” he shouted to them, “clap your hands; don’t let Tink
+die.”
+
+Many clapped.
+
+Some didn’t.
+
+A few beasts hissed.
+
+The clapping stopped suddenly; as if countless mothers had rushed to
+their nurseries to see what on earth was happening; but already Tink was
+saved. First her voice grew strong, then she popped out of bed, then
+she was flashing through the room more merry and impudent than ever. She
+never thought of thanking those who believed, but she would have liked to
+get at the ones who had hissed.
+
+“And now to rescue Wendy!”
+
+The moon was riding in a cloudy heaven when Peter rose from his tree,
+begirt [belted] with weapons and wearing little else, to set out upon
+his perilous quest. It was not such a night as he would have chosen.
+He had hoped to fly, keeping not far from the ground so that nothing
+unwonted should escape his eyes; but in that fitful light to have
+flown low would have meant trailing his shadow through the trees, thus
+disturbing birds and acquainting a watchful foe that he was astir.
+
+He regretted now that he had given the birds of the island such strange
+names that they are very wild and difficult of approach.
+
+There was no other course but to press forward in redskin fashion, at
+which happily he was an adept [expert]. But in what direction, for he
+could not be sure that the children had been taken to the ship? A
+light fall of snow had obliterated all footmarks; and a deathly silence
+pervaded the island, as if for a space Nature stood still in horror of
+the recent carnage. He had taught the children something of the forest
+lore that he had himself learned from Tiger Lily and Tinker Bell,
+and knew that in their dire hour they were not likely to forget it.
+Slightly, if he had an opportunity, would blaze [cut a mark in] the
+trees, for instance, Curly would drop seeds, and Wendy would leave her
+handkerchief at some important place. The morning was needed to search
+for such guidance, and he could not wait. The upper world had called
+him, but would give no help.
+
+The crocodile passed him, but not another living thing, not a sound, not
+a movement; and yet he knew well that sudden death might be at the next
+tree, or stalking him from behind.
+
+He swore this terrible oath: “Hook or me this time.”
+
+Now he crawled forward like a snake, and again erect, he darted across
+a space on which the moonlight played, one finger on his lip and his
+dagger at the ready. He was frightfully happy.
+
+
+
+
+Chapter 14 THE PIRATE SHIP
+
+One green light squinting over Kidd’s Creek, which is near the mouth of
+the pirate river, marked where the brig, the JOLLY ROGER, lay, low in
+the water; a rakish-looking [speedy-looking] craft foul to the hull,
+every beam in her detestable, like ground strewn with mangled feathers.
+She was the cannibal of the seas, and scarce needed that watchful eye,
+for she floated immune in the horror of her name.
+
+She was wrapped in the blanket of night, through which no sound from her
+could have reached the shore. There was little sound, and none agreeable
+save the whir of the ship’s sewing machine at which Smee sat, ever
+industrious and obliging, the essence of the commonplace, pathetic Smee.
+I know not why he was so infinitely pathetic, unless it were because
+he was so pathetically unaware of it; but even strong men had to turn
+hastily from looking at him, and more than once on summer evenings he
+had touched the fount of Hook’s tears and made it flow. Of this, as of
+almost everything else, Smee was quite unconscious.
+
+A few of the pirates leant over the bulwarks, drinking in the miasma
+[putrid mist] of the night; others sprawled by barrels over games of
+dice and cards; and the exhausted four who had carried the little house
+lay prone on the deck, where even in their sleep they rolled skillfully
+to this side or that out of Hook’s reach, lest he should claw them
+mechanically in passing.
+
+Hook trod the deck in thought. O man unfathomable. It was his hour of
+triumph. Peter had been removed for ever from his path, and all the
+other boys were in the brig, about to walk the plank. It was his
+grimmest deed since the days when he had brought Barbecue to heel; and
+knowing as we do how vain a tabernacle is man, could we be surprised
+had he now paced the deck unsteadily, bellied out by the winds of his
+success?
+
+But there was no elation in his gait, which kept pace with the action of
+his sombre mind. Hook was profoundly dejected.
+
+He was often thus when communing with himself on board ship in the
+quietude of the night. It was because he was so terribly alone. This
+inscrutable man never felt more alone than when surrounded by his dogs.
+They were socially inferior to him.
+
+Hook was not his true name. To reveal who he really was would even at
+this date set the country in a blaze; but as those who read between the
+lines must already have guessed, he had been at a famous public school;
+and its traditions still clung to him like garments, with which indeed
+they are largely concerned. Thus it was offensive to him even now to
+board a ship in the same dress in which he grappled [attacked] her, and
+he still adhered in his walk to the school’s distinguished slouch. But
+above all he retained the passion for good form.
+
+Good form! However much he may have degenerated, he still knew that this
+is all that really matters.
+
+From far within him he heard a creaking as of rusty portals, and through
+them came a stern tap-tap-tap, like hammering in the night when one
+cannot sleep. “Have you been good form to-day?” was their eternal
+question.
+
+“Fame, fame, that glittering bauble, it is mine,” he cried.
+
+“Is it quite good form to be distinguished at anything?” the tap-tap
+from his school replied.
+
+“I am the only man whom Barbecue feared,” he urged, “and Flint feared
+Barbecue.”
+
+“Barbecue, Flint--what house?” came the cutting retort.
+
+Most disquieting reflection of all, was it not bad form to think about
+good form?
+
+His vitals were tortured by this problem. It was a claw within him
+sharper than the iron one; and as it tore him, the perspiration dripped
+down his tallow [waxy] countenance and streaked his doublet. Ofttimes he
+drew his sleeve across his face, but there was no damming that trickle.
+
+Ah, envy not Hook.
+
+There came to him a presentiment of his early dissolution [death]. It
+was as if Peter’s terrible oath had boarded the ship. Hook felt a gloomy
+desire to make his dying speech, lest presently there should be no time
+for it.
+
+“Better for Hook,” he cried, “if he had had less ambition!” It was in
+his darkest hours only that he referred to himself in the third person.
+
+“No little children to love me!”
+
+Strange that he should think of this, which had never troubled him
+before; perhaps the sewing machine brought it to his mind. For long he
+muttered to himself, staring at Smee, who was hemming placidly, under
+the conviction that all children feared him.
+
+Feared him! Feared Smee! There was not a child on board the brig that
+night who did not already love him. He had said horrid things to them
+and hit them with the palm of his hand, because he could not hit with
+his fist, but they had only clung to him the more. Michael had tried on
+his spectacles.
+
+To tell poor Smee that they thought him lovable! Hook itched to do it,
+but it seemed too brutal. Instead, he revolved this mystery in his
+mind: why do they find Smee lovable? He pursued the problem like the
+sleuth-hound that he was. If Smee was lovable, what was it that made him
+so? A terrible answer suddenly presented itself--“Good form?”
+
+Had the bo’sun good form without knowing it, which is the best form of
+all?
+
+He remembered that you have to prove you don’t know you have it before
+you are eligible for Pop [an elite social club at Eton].
+
+With a cry of rage he raised his iron hand over Smee’s head; but he did
+not tear. What arrested him was this reflection:
+
+“To claw a man because he is good form, what would that be?”
+
+“Bad form!”
+
+The unhappy Hook was as impotent [powerless] as he was damp, and he fell
+forward like a cut flower.
+
+His dogs thinking him out of the way for a time, discipline instantly
+relaxed; and they broke into a bacchanalian [drunken] dance, which
+brought him to his feet at once, all traces of human weakness gone, as
+if a bucket of water had passed over him.
+
+“Quiet, you scugs,” he cried, “or I’ll cast anchor in you;” and at once
+the din was hushed. “Are all the children chained, so that they cannot
+fly away?”
+
+“Ay, ay.”
+
+“Then hoist them up.”
+
+The wretched prisoners were dragged from the hold, all except Wendy,
+and ranged in line in front of him. For a time he seemed unconscious
+of their presence. He lolled at his ease, humming, not unmelodiously,
+snatches of a rude song, and fingering a pack of cards. Ever and anon
+the light from his cigar gave a touch of colour to his face.
+
+“Now then, bullies,” he said briskly, “six of you walk the plank
+to-night, but I have room for two cabin boys. Which of you is it to be?”
+
+“Don’t irritate him unnecessarily,” had been Wendy’s instructions in
+the hold; so Tootles stepped forward politely. Tootles hated the idea
+of signing under such a man, but an instinct told him that it would
+be prudent to lay the responsibility on an absent person; and though a
+somewhat silly boy, he knew that mothers alone are always willing to be
+the buffer. All children know this about mothers, and despise them for
+it, but make constant use of it.
+
+So Tootles explained prudently, “You see, sir, I don’t think my mother
+would like me to be a pirate. Would your mother like you to be a pirate,
+Slightly?”
+
+He winked at Slightly, who said mournfully, “I don’t think so,” as if
+he wished things had been otherwise. “Would your mother like you to be a
+pirate, Twin?”
+
+“I don’t think so,” said the first twin, as clever as the others. “Nibs,
+would--”
+
+“Stow this gab,” roared Hook, and the spokesmen were dragged back. “You,
+boy,” he said, addressing John, “you look as if you had a little pluck
+in you. Didst never want to be a pirate, my hearty?”
+
+Now John had sometimes experienced this hankering at maths. prep.; and
+he was struck by Hook’s picking him out.
+
+“I once thought of calling myself Red-handed Jack,” he said diffidently.
+
+“And a good name too. We’ll call you that here, bully, if you join.”
+
+“What do you think, Michael?” asked John.
+
+“What would you call me if I join?” Michael demanded.
+
+“Blackbeard Joe.”
+
+Michael was naturally impressed. “What do you think, John?” He wanted
+John to decide, and John wanted him to decide.
+
+“Shall we still be respectful subjects of the King?” John inquired.
+
+Through Hook’s teeth came the answer: “You would have to swear, ‘Down
+with the King.’”
+
+Perhaps John had not behaved very well so far, but he shone out now.
+
+“Then I refuse,” he cried, banging the barrel in front of Hook.
+
+“And I refuse,” cried Michael.
+
+“Rule Britannia!” squeaked Curly.
+
+The infuriated pirates buffeted them in the mouth; and Hook roared out,
+“That seals your doom. Bring up their mother. Get the plank ready.”
+
+They were only boys, and they went white as they saw Jukes and Cecco
+preparing the fatal plank. But they tried to look brave when Wendy was
+brought up.
+
+No words of mine can tell you how Wendy despised those pirates. To the
+boys there was at least some glamour in the pirate calling; but all that
+she saw was that the ship had not been tidied for years. There was not
+a porthole on the grimy glass of which you might not have written with
+your finger “Dirty pig”; and she had already written it on several. But
+as the boys gathered round her she had no thought, of course, save for
+them.
+
+“So, my beauty,” said Hook, as if he spoke in syrup, “you are to see
+your children walk the plank.”
+
+Fine gentlemen though he was, the intensity of his communings had soiled
+his ruff, and suddenly he knew that she was gazing at it. With a hasty
+gesture he tried to hide it, but he was too late.
+
+“Are they to die?” asked Wendy, with a look of such frightful contempt
+that he nearly fainted.
+
+“They are,” he snarled. “Silence all,” he called gloatingly, “for a
+mother’s last words to her children.”
+
+At this moment Wendy was grand. “These are my last words, dear boys,”
+ she said firmly. “I feel that I have a message to you from your real
+mothers, and it is this: ‘We hope our sons will die like English
+gentlemen.’”
+
+Even the pirates were awed, and Tootles cried out hysterically, “I am
+going to do what my mother hopes. What are you to do, Nibs?”
+
+“What my mother hopes. What are you to do, Twin?”
+
+“What my mother hopes. John, what are--”
+
+But Hook had found his voice again.
+
+“Tie her up!” he shouted.
+
+It was Smee who tied her to the mast. “See here, honey,” he whispered,
+“I’ll save you if you promise to be my mother.”
+
+But not even for Smee would she make such a promise. “I would almost
+rather have no children at all,” she said disdainfully [scornfully].
+
+It is sad to know that not a boy was looking at her as Smee tied her to
+the mast; the eyes of all were on the plank: that last little walk they
+were about to take. They were no longer able to hope that they would
+walk it manfully, for the capacity to think had gone from them; they
+could stare and shiver only.
+
+Hook smiled on them with his teeth closed, and took a step toward Wendy.
+His intention was to turn her face so that she should see the boys
+walking the plank one by one. But he never reached her, he never heard
+the cry of anguish he hoped to wring from her. He heard something else
+instead.
+
+It was the terrible tick-tick of the crocodile.
+
+They all heard it--pirates, boys, Wendy; and immediately every head was
+blown in one direction; not to the water whence the sound proceeded, but
+toward Hook. All knew that what was about to happen concerned him alone,
+and that from being actors they were suddenly become spectators.
+
+Very frightful was it to see the change that came over him. It was as if
+he had been clipped at every joint. He fell in a little heap.
+
+The sound came steadily nearer; and in advance of it came this ghastly
+thought, “The crocodile is about to board the ship!”
+
+Even the iron claw hung inactive; as if knowing that it was no intrinsic
+part of what the attacking force wanted. Left so fearfully alone, any
+other man would have lain with his eyes shut where he fell: but the
+gigantic brain of Hook was still working, and under its guidance he
+crawled on the knees along the deck as far from the sound as he could
+go. The pirates respectfully cleared a passage for him, and it was only
+when he brought up against the bulwarks that he spoke.
+
+“Hide me!” he cried hoarsely.
+
+They gathered round him, all eyes averted from the thing that was coming
+aboard. They had no thought of fighting it. It was Fate.
+
+Only when Hook was hidden from them did curiosity loosen the limbs of
+the boys so that they could rush to the ship’s side to see the crocodile
+climbing it. Then they got the strangest surprise of the Night of
+Nights; for it was no crocodile that was coming to their aid. It was
+Peter.
+
+He signed to them not to give vent to any cry of admiration that might
+rouse suspicion. Then he went on ticking.
+
+
+
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Odd things happen to all of us on our way through life without our
+noticing for a time that they have happened. Thus, to take an instance,
+we suddenly discover that we have been deaf in one ear for we don’t know
+how long, but, say, half an hour. Now such an experience had come that
+night to Peter. When last we saw him he was stealing across the island
+with one finger to his lips and his dagger at the ready. He had seen the
+crocodile pass by without noticing anything peculiar about it, but by
+and by he remembered that it had not been ticking. At first he thought
+this eerie, but soon concluded rightly that the clock had run down.
+
+Without giving a thought to what might be the feelings of a
+fellow-creature thus abruptly deprived of its closest companion, Peter
+began to consider how he could turn the catastrophe to his own use;
+and he decided to tick, so that wild beasts should believe he was the
+crocodile and let him pass unmolested. He ticked superbly, but with one
+unforeseen result. The crocodile was among those who heard the sound,
+and it followed him, though whether with the purpose of regaining what
+it had lost, or merely as a friend under the belief that it was again
+ticking itself, will never be certainly known, for, like slaves to a
+fixed idea, it was a stupid beast.
+
+Peter reached the shore without mishap, and went straight on, his legs
+encountering the water as if quite unaware that they had entered a new
+element. Thus many animals pass from land to water, but no other human
+of whom I know. As he swam he had but one thought: “Hook or me this
+time.” He had ticked so long that he now went on ticking without knowing
+that he was doing it. Had he known he would have stopped, for to board
+the brig by help of the tick, though an ingenious idea, had not occurred
+to him.
+
+On the contrary, he thought he had scaled her side as noiseless as a
+mouse; and he was amazed to see the pirates cowering from him, with Hook
+in their midst as abject as if he had heard the crocodile.
+
+The crocodile! No sooner did Peter remember it than he heard the
+ticking. At first he thought the sound did come from the crocodile,
+and he looked behind him swiftly. Then he realised that he was doing it
+himself, and in a flash he understood the situation. “How clever of me!”
+ he thought at once, and signed to the boys not to burst into applause.
+
+It was at this moment that Ed Teynte the quartermaster emerged from the
+forecastle and came along the deck. Now, reader, time what happened by
+your watch. Peter struck true and deep. John clapped his hands on the
+ill-fated pirate’s mouth to stifle the dying groan. He fell forward.
+Four boys caught him to prevent the thud. Peter gave the signal, and the
+carrion was cast overboard. There was a splash, and then silence. How
+long has it taken?
+
+“One!” (Slightly had begun to count.)
+
+None too soon, Peter, every inch of him on tiptoe, vanished into the
+cabin; for more than one pirate was screwing up his courage to look
+round. They could hear each other’s distressed breathing now, which
+showed them that the more terrible sound had passed.
+
+“It’s gone, captain,” Smee said, wiping off his spectacles. “All’s still
+again.”
+
+Slowly Hook let his head emerge from his ruff, and listened so intently
+that he could have caught the echo of the tick. There was not a sound,
+and he drew himself up firmly to his full height.
+
+“Then here’s to Johnny Plank!” he cried brazenly, hating the boys more
+than ever because they had seen him unbend. He broke into the villainous
+ditty:
+
+     “Yo ho, yo ho, the frisky plank,
+     You walks along it so,
+     Till it goes down and you goes down
+     To Davy Jones below!”
+
+To terrorize the prisoners the more, though with a certain loss of
+dignity, he danced along an imaginary plank, grimacing at them as he
+sang; and when he finished he cried, “Do you want a touch of the cat [o’
+nine tails] before you walk the plank?”
+
+At that they fell on their knees. “No, no!” they cried so piteously that
+every pirate smiled.
+
+“Fetch the cat, Jukes,” said Hook; “it’s in the cabin.”
+
+The cabin! Peter was in the cabin! The children gazed at each other.
+
+“Ay, ay,” said Jukes blithely, and he strode into the cabin. They
+followed him with their eyes; they scarce knew that Hook had resumed his
+song, his dogs joining in with him:
+
+     “Yo ho, yo ho, the scratching cat,
+     Its tails are nine, you know,
+     And when they’re writ upon your back--”
+
+What was the last line will never be known, for of a sudden the song was
+stayed by a dreadful screech from the cabin. It wailed through the ship,
+and died away. Then was heard a crowing sound which was well understood
+by the boys, but to the pirates was almost more eerie than the screech.
+
+“What was that?” cried Hook.
+
+“Two,” said Slightly solemnly.
+
+The Italian Cecco hesitated for a moment and then swung into the cabin.
+He tottered out, haggard.
+
+“What’s the matter with Bill Jukes, you dog?” hissed Hook, towering over
+him.
+
+“The matter wi’ him is he’s dead, stabbed,” replied Cecco in a hollow
+voice.
+
+“Bill Jukes dead!” cried the startled pirates.
+
+“The cabin’s as black as a pit,” Cecco said, almost gibbering, “but
+there is something terrible in there: the thing you heard crowing.”
+
+The exultation of the boys, the lowering looks of the pirates, both were
+seen by Hook.
+
+“Cecco,” he said in his most steely voice, “go back and fetch me out
+that doodle-doo.”
+
+Cecco, bravest of the brave, cowered before his captain, crying “No,
+no”; but Hook was purring to his claw.
+
+“Did you say you would go, Cecco?” he said musingly.
+
+Cecco went, first flinging his arms despairingly. There was no more
+singing, all listened now; and again came a death-screech and again a
+crow.
+
+No one spoke except Slightly. “Three,” he said.
+
+Hook rallied his dogs with a gesture. “‘S’death and odds fish,” he
+thundered, “who is to bring me that doodle-doo?”
+
+“Wait till Cecco comes out,” growled Starkey, and the others took up the
+cry.
+
+“I think I heard you volunteer, Starkey,” said Hook, purring again.
+
+“No, by thunder!” Starkey cried.
+
+“My hook thinks you did,” said Hook, crossing to him. “I wonder if it
+would not be advisable, Starkey, to humour the hook?”
+
+“I’ll swing before I go in there,” replied Starkey doggedly, and again
+he had the support of the crew.
+
+“Is this mutiny?” asked Hook more pleasantly than ever. “Starkey’s
+ringleader!”
+
+“Captain, mercy!” Starkey whimpered, all of a tremble now.
+
+“Shake hands, Starkey,” said Hook, proffering his claw.
+
+Starkey looked round for help, but all deserted him. As he backed up
+Hook advanced, and now the red spark was in his eye. With a despairing
+scream the pirate leapt upon Long Tom and precipitated himself into the
+sea.
+
+“Four,” said Slightly.
+
+“And now,” Hook said courteously, “did any other gentlemen say mutiny?”
+ Seizing a lantern and raising his claw with a menacing gesture, “I’ll
+bring out that doodle-doo myself,” he said, and sped into the cabin.
+
+“Five.” How Slightly longed to say it. He wetted his lips to be ready,
+but Hook came staggering out, without his lantern.
+
+“Something blew out the light,” he said a little unsteadily.
+
+“Something!” echoed Mullins.
+
+“What of Cecco?” demanded Noodler.
+
+“He’s as dead as Jukes,” said Hook shortly.
+
+His reluctance to return to the cabin impressed them all unfavourably,
+and the mutinous sounds again broke forth. All pirates are
+superstitious, and Cookson cried, “They do say the surest sign a ship’s
+accurst is when there’s one on board more than can be accounted for.”
+
+“I’ve heard,” muttered Mullins, “he always boards the pirate craft last.
+Had he a tail, captain?”
+
+“They say,” said another, looking viciously at Hook, “that when he comes
+it’s in the likeness of the wickedest man aboard.”
+
+“Had he a hook, captain?” asked Cookson insolently; and one after
+another took up the cry, “The ship’s doomed!” At this the children could
+not resist raising a cheer. Hook had well-nigh forgotten his prisoners,
+but as he swung round on them now his face lit up again.
+
+“Lads,” he cried to his crew, “now here’s a notion. Open the cabin door
+and drive them in. Let them fight the doodle-doo for their lives. If
+they kill him, we’re so much the better; if he kills them, we’re none
+the worse.”
+
+For the last time his dogs admired Hook, and devotedly they did his
+bidding. The boys, pretending to struggle, were pushed into the cabin
+and the door was closed on them.
+
+“Now, listen!” cried Hook, and all listened. But not one dared to face
+the door. Yes, one, Wendy, who all this time had been bound to the mast.
+It was for neither a scream nor a crow that she was watching, it was for
+the reappearance of Peter.
+
+She had not long to wait. In the cabin he had found the thing for which
+he had gone in search: the key that would free the children of their
+manacles, and now they all stole forth, armed with such weapons as they
+could find. First signing them to hide, Peter cut Wendy’s bonds,
+and then nothing could have been easier than for them all to fly off
+together; but one thing barred the way, an oath, “Hook or me this time.”
+ So when he had freed Wendy, he whispered for her to conceal herself with
+the others, and himself took her place by the mast, her cloak around him
+so that he should pass for her. Then he took a great breath and crowed.
+
+To the pirates it was a voice crying that all the boys lay slain in the
+cabin; and they were panic-stricken. Hook tried to hearten them; but
+like the dogs he had made them they showed him their fangs, and he knew
+that if he took his eyes off them now they would leap at him.
+
+“Lads,” he said, ready to cajole or strike as need be, but never
+quailing for an instant, “I’ve thought it out. There’s a Jonah aboard.”
+
+“Ay,” they snarled, “a man wi’ a hook.”
+
+“No, lads, no, it’s the girl. Never was luck on a pirate ship wi’ a
+woman on board. We’ll right the ship when she’s gone.”
+
+Some of them remembered that this had been a saying of Flint’s. “It’s
+worth trying,” they said doubtfully.
+
+“Fling the girl overboard,” cried Hook; and they made a rush at the
+figure in the cloak.
+
+“There’s none can save you now, missy,” Mullins hissed jeeringly.
+
+“There’s one,” replied the figure.
+
+“Who’s that?”
+
+“Peter Pan the avenger!” came the terrible answer; and as he spoke Peter
+flung off his cloak. Then they all knew who ‘twas that had been undoing
+them in the cabin, and twice Hook essayed to speak and twice he failed.
+In that frightful moment I think his fierce heart broke.
+
+At last he cried, “Cleave him to the brisket!” but without conviction.
+
+“Down, boys, and at them!” Peter’s voice rang out; and in another moment
+the clash of arms was resounding through the ship. Had the pirates kept
+together it is certain that they would have won; but the onset came
+when they were still unstrung, and they ran hither and thither, striking
+wildly, each thinking himself the last survivor of the crew. Man to man
+they were the stronger; but they fought on the defensive only, which
+enabled the boys to hunt in pairs and choose their quarry. Some of the
+miscreants leapt into the sea; others hid in dark recesses, where they
+were found by Slightly, who did not fight, but ran about with a lantern
+which he flashed in their faces, so that they were half blinded and
+fell as an easy prey to the reeking swords of the other boys. There was
+little sound to be heard but the clang of weapons, an occasional
+screech or splash, and Slightly monotonously counting--five--six--seven
+eight--nine--ten--eleven.
+
+I think all were gone when a group of savage boys surrounded Hook, who
+seemed to have a charmed life, as he kept them at bay in that circle
+of fire. They had done for his dogs, but this man alone seemed to be a
+match for them all. Again and again they closed upon him, and again and
+again he hewed a clear space. He had lifted up one boy with his hook,
+and was using him as a buckler [shield], when another, who had just
+passed his sword through Mullins, sprang into the fray.
+
+“Put up your swords, boys,” cried the newcomer, “this man is mine.”
+
+Thus suddenly Hook found himself face to face with Peter. The others
+drew back and formed a ring around them.
+
+For long the two enemies looked at one another, Hook shuddering
+slightly, and Peter with the strange smile upon his face.
+
+“So, Pan,” said Hook at last, “this is all your doing.”
+
+“Ay, James Hook,” came the stern answer, “it is all my doing.”
+
+“Proud and insolent youth,” said Hook, “prepare to meet thy doom.”
+
+“Dark and sinister man,” Peter answered, “have at thee.”
+
+Without more words they fell to, and for a space there was no advantage
+to either blade. Peter was a superb swordsman, and parried with dazzling
+rapidity; ever and anon he followed up a feint with a lunge that got
+past his foe’s defence, but his shorter reach stood him in ill stead,
+and he could not drive the steel home. Hook, scarcely his inferior in
+brilliancy, but not quite so nimble in wrist play, forced him back by
+the weight of his onset, hoping suddenly to end all with a favourite
+thrust, taught him long ago by Barbecue at Rio; but to his astonishment
+he found this thrust turned aside again and again. Then he sought to
+close and give the quietus with his iron hook, which all this time had
+been pawing the air; but Peter doubled under it and, lunging fiercely,
+pierced him in the ribs. At the sight of his own blood, whose peculiar
+colour, you remember, was offensive to him, the sword fell from Hook’s
+hand, and he was at Peter’s mercy.
+
+“Now!” cried all the boys, but with a magnificent gesture Peter invited
+his opponent to pick up his sword. Hook did so instantly, but with a
+tragic feeling that Peter was showing good form.
+
+Hitherto he had thought it was some fiend fighting him, but darker
+suspicions assailed him now.
+
+“Pan, who and what art thou?” he cried huskily.
+
+“I’m youth, I’m joy,” Peter answered at a venture, “I’m a little bird
+that has broken out of the egg.”
+
+This, of course, was nonsense; but it was proof to the unhappy Hook that
+Peter did not know in the least who or what he was, which is the very
+pinnacle of good form.
+
+“To’t again,” he cried despairingly.
+
+He fought now like a human flail, and every sweep of that terrible sword
+would have severed in twain any man or boy who obstructed it; but Peter
+fluttered round him as if the very wind it made blew him out of the
+danger zone. And again and again he darted in and pricked.
+
+Hook was fighting now without hope. That passionate breast no longer
+asked for life; but for one boon it craved: to see Peter show bad form
+before it was cold forever.
+
+Abandoning the fight he rushed into the powder magazine and fired it.
+
+“In two minutes,” he cried, “the ship will be blown to pieces.”
+
+Now, now, he thought, true form will show.
+
+But Peter issued from the powder magazine with the shell in his hands,
+and calmly flung it overboard.
+
+What sort of form was Hook himself showing? Misguided man though he was,
+we may be glad, without sympathising with him, that in the end he was
+true to the traditions of his race. The other boys were flying around
+him now, flouting, scornful; and he staggered about the deck striking up
+at them impotently, his mind was no longer with them; it was slouching
+in the playing fields of long ago, or being sent up [to the headmaster]
+for good, or watching the wall-game from a famous wall. And his shoes
+were right, and his waistcoat was right, and his tie was right, and his
+socks were right.
+
+James Hook, thou not wholly unheroic figure, farewell.
+
+For we have come to his last moment.
+
+Seeing Peter slowly advancing upon him through the air with dagger
+poised, he sprang upon the bulwarks to cast himself into the sea. He
+did not know that the crocodile was waiting for him; for we purposely
+stopped the clock that this knowledge might be spared him: a little mark
+of respect from us at the end.
+
+He had one last triumph, which I think we need not grudge him. As he
+stood on the bulwark looking over his shoulder at Peter gliding through
+the air, he invited him with a gesture to use his foot. It made Peter
+kick instead of stab.
+
+At last Hook had got the boon for which he craved.
+
+“Bad form,” he cried jeeringly, and went content to the crocodile.
+
+Thus perished James Hook.
+
+“Seventeen,” Slightly sang out; but he was not quite correct in his
+figures. Fifteen paid the penalty for their crimes that night; but two
+reached the shore: Starkey to be captured by the redskins, who made him
+nurse for all their papooses, a melancholy come-down for a pirate; and
+Smee, who henceforth wandered about the world in his spectacles, making
+a precarious living by saying he was the only man that Jas. Hook had
+feared.
+
+Wendy, of course, had stood by taking no part in the fight, though
+watching Peter with glistening eyes; but now that all was over she
+became prominent again. She praised them equally, and shuddered
+delightfully when Michael showed her the place where he had killed one;
+and then she took them into Hook’s cabin and pointed to his watch which
+was hanging on a nail. It said “half-past one!”
+
+The lateness of the hour was almost the biggest thing of all. She got
+them to bed in the pirates’ bunks pretty quickly, you may be sure; all
+but Peter, who strutted up and down on the deck, until at last he fell
+asleep by the side of Long Tom. He had one of his dreams that night, and
+cried in his sleep for a long time, and Wendy held him tightly.
+
+
+
+
+Chapter 16 THE RETURN HOME
+
+By three bells that morning they were all stirring their stumps [legs];
+for there was a big sea running; and Tootles, the bo’sun, was among
+them, with a rope’s end in his hand and chewing tobacco. They all donned
+pirate clothes cut off at the knee, shaved smartly, and tumbled up, with
+the true nautical roll and hitching their trousers.
+
+It need not be said who was the captain. Nibs and John were first and
+second mate. There was a woman aboard. The rest were tars [sailors]
+before the mast, and lived in the fo’c’sle. Peter had already lashed
+himself to the wheel; but he piped all hands and delivered a short
+address to them; said he hoped they would do their duty like gallant
+hearties, but that he knew they were the scum of Rio and the Gold Coast,
+and if they snapped at him he would tear them. The bluff strident words
+struck the note sailors understood, and they cheered him lustily. Then
+a few sharp orders were given, and they turned the ship round, and nosed
+her for the mainland.
+
+Captain Pan calculated, after consulting the ship’s chart, that if this
+weather lasted they should strike the Azores about the 21st of June,
+after which it would save time to fly.
+
+Some of them wanted it to be an honest ship and others were in favour
+of keeping it a pirate; but the captain treated them as dogs, and they
+dared not express their wishes to him even in a round robin [one person
+after another, as they had to Cpt. Hook]. Instant obedience was the only
+safe thing. Slightly got a dozen for looking perplexed when told to take
+soundings. The general feeling was that Peter was honest just now to
+lull Wendy’s suspicions, but that there might be a change when the new
+suit was ready, which, against her will, she was making for him out of
+some of Hook’s wickedest garments. It was afterwards whispered among
+them that on the first night he wore this suit he sat long in the cabin
+with Hook’s cigar-holder in his mouth and one hand clenched, all but for
+the forefinger, which he bent and held threateningly aloft like a hook.
+
+Instead of watching the ship, however, we must now return to that
+desolate home from which three of our characters had taken heartless
+flight so long ago. It seems a shame to have neglected No. 14 all this
+time; and yet we may be sure that Mrs. Darling does not blame us. If we
+had returned sooner to look with sorrowful sympathy at her, she would
+probably have cried, “Don’t be silly; what do I matter? Do go back and
+keep an eye on the children.” So long as mothers are like this their
+children will take advantage of them; and they may lay to [bet on] that.
+
+Even now we venture into that familiar nursery only because its lawful
+occupants are on their way home; we are merely hurrying on in advance
+of them to see that their beds are properly aired and that Mr. and Mrs.
+Darling do not go out for the evening. We are no more than servants. Why
+on earth should their beds be properly aired, seeing that they left them
+in such a thankless hurry? Would it not serve them jolly well right if
+they came back and found that their parents were spending the week-end
+in the country? It would be the moral lesson they have been in need
+of ever since we met them; but if we contrived things in this way Mrs.
+Darling would never forgive us.
+
+One thing I should like to do immensely, and that is to tell her, in the
+way authors have, that the children are coming back, that indeed they
+will be here on Thursday week. This would spoil so completely the
+surprise to which Wendy and John and Michael are looking forward. They
+have been planning it out on the ship: mother’s rapture, father’s shout
+of joy, Nana’s leap through the air to embrace them first, when what
+they ought to be prepared for is a good hiding. How delicious to spoil
+it all by breaking the news in advance; so that when they enter grandly
+Mrs. Darling may not even offer Wendy her mouth, and Mr. Darling may
+exclaim pettishly, “Dash it all, here are those boys again.” However,
+we should get no thanks even for this. We are beginning to know Mrs.
+Darling by this time, and may be sure that she would upbraid us for
+depriving the children of their little pleasure.
+
+“But, my dear madam, it is ten days till Thursday week; so that by
+telling you what’s what, we can save you ten days of unhappiness.”
+
+“Yes, but at what a cost! By depriving the children of ten minutes of
+delight.”
+
+“Oh, if you look at it in that way!”
+
+“What other way is there in which to look at it?”
+
+You see, the woman had no proper spirit. I had meant to say
+extraordinarily nice things about her; but I despise her, and not one of
+them will I say now. She does not really need to be told to have things
+ready, for they are ready. All the beds are aired, and she never leaves
+the house, and observe, the window is open. For all the use we are to
+her, we might well go back to the ship. However, as we are here we may
+as well stay and look on. That is all we are, lookers-on. Nobody really
+wants us. So let us watch and say jaggy things, in the hope that some of
+them will hurt.
+
+The only change to be seen in the night-nursery is that between nine
+and six the kennel is no longer there. When the children flew away, Mr.
+Darling felt in his bones that all the blame was his for having chained
+Nana up, and that from first to last she had been wiser than he. Of
+course, as we have seen, he was quite a simple man; indeed he might have
+passed for a boy again if he had been able to take his baldness off;
+but he had also a noble sense of justice and a lion’s courage to do what
+seemed right to him; and having thought the matter out with anxious care
+after the flight of the children, he went down on all fours and crawled
+into the kennel. To all Mrs. Darling’s dear invitations to him to come
+out he replied sadly but firmly:
+
+“No, my own one, this is the place for me.”
+
+In the bitterness of his remorse he swore that he would never leave
+the kennel until his children came back. Of course this was a pity; but
+whatever Mr. Darling did he had to do in excess, otherwise he soon gave
+up doing it. And there never was a more humble man than the once proud
+George Darling, as he sat in the kennel of an evening talking with his
+wife of their children and all their pretty ways.
+
+Very touching was his deference to Nana. He would not let her come into
+the kennel, but on all other matters he followed her wishes implicitly.
+
+Every morning the kennel was carried with Mr. Darling in it to a cab,
+which conveyed him to his office, and he returned home in the same way
+at six. Something of the strength of character of the man will be seen
+if we remember how sensitive he was to the opinion of neighbours: this
+man whose every movement now attracted surprised attention. Inwardly he
+must have suffered torture; but he preserved a calm exterior even when
+the young criticised his little home, and he always lifted his hat
+courteously to any lady who looked inside.
+
+It may have been Quixotic, but it was magnificent. Soon the inward
+meaning of it leaked out, and the great heart of the public was touched.
+Crowds followed the cab, cheering it lustily; charming girls scaled it
+to get his autograph; interviews appeared in the better class of papers,
+and society invited him to dinner and added, “Do come in the kennel.”
+
+On that eventful Thursday week, Mrs. Darling was in the night-nursery
+awaiting George’s return home; a very sad-eyed woman. Now that we look
+at her closely and remember the gaiety of her in the old days, all gone
+now just because she has lost her babes, I find I won’t be able to say
+nasty things about her after all. If she was too fond of her rubbishy
+children, she couldn’t help it. Look at her in her chair, where she has
+fallen asleep. The corner of her mouth, where one looks first, is almost
+withered up. Her hand moves restlessly on her breast as if she had a
+pain there. Some like Peter best, and some like Wendy best, but I like
+her best. Suppose, to make her happy, we whisper to her in her sleep
+that the brats are coming back. They are really within two miles of the
+window now, and flying strong, but all we need whisper is that they are
+on the way. Let’s.
+
+It is a pity we did it, for she has started up, calling their names; and
+there is no one in the room but Nana.
+
+“O Nana, I dreamt my dear ones had come back.”
+
+Nana had filmy eyes, but all she could do was put her paw gently on her
+mistress’s lap; and they were sitting together thus when the kennel was
+brought back. As Mr. Darling puts his head out to kiss his wife, we see
+that his face is more worn than of yore, but has a softer expression.
+
+He gave his hat to Liza, who took it scornfully; for she had no
+imagination, and was quite incapable of understanding the motives of
+such a man. Outside, the crowd who had accompanied the cab home were
+still cheering, and he was naturally not unmoved.
+
+“Listen to them,” he said; “it is very gratifying.”
+
+“Lots of little boys,” sneered Liza.
+
+“There were several adults to-day,” he assured her with a faint flush;
+but when she tossed her head he had not a word of reproof for her.
+Social success had not spoilt him; it had made him sweeter. For some
+time he sat with his head out of the kennel, talking with Mrs. Darling
+of this success, and pressing her hand reassuringly when she said she
+hoped his head would not be turned by it.
+
+“But if I had been a weak man,” he said. “Good heavens, if I had been a
+weak man!”
+
+“And, George,” she said timidly, “you are as full of remorse as ever,
+aren’t you?”
+
+“Full of remorse as ever, dearest! See my punishment: living in a
+kennel.”
+
+“But it is punishment, isn’t it, George? You are sure you are not
+enjoying it?”
+
+“My love!”
+
+You may be sure she begged his pardon; and then, feeling drowsy, he
+curled round in the kennel.
+
+“Won’t you play me to sleep,” he asked, “on the nursery piano?” and as
+she was crossing to the day-nursery he added thoughtlessly, “And shut
+that window. I feel a draught.”
+
+“O George, never ask me to do that. The window must always be left open
+for them, always, always.”
+
+Now it was his turn to beg her pardon; and she went into the day-nursery
+and played, and soon he was asleep; and while he slept, Wendy and John
+and Michael flew into the room.
+
+Oh no. We have written it so, because that was the charming arrangement
+planned by them before we left the ship; but something must have
+happened since then, for it is not they who have flown in, it is Peter
+and Tinker Bell.
+
+Peter’s first words tell all.
+
+“Quick Tink,” he whispered, “close the window; bar it! That’s right. Now
+you and I must get away by the door; and when Wendy comes she will think
+her mother has barred her out; and she will have to go back with me.”
+
+Now I understand what had hitherto puzzled me, why when Peter had
+exterminated the pirates he did not return to the island and leave Tink
+to escort the children to the mainland. This trick had been in his head
+all the time.
+
+Instead of feeling that he was behaving badly he danced with glee; then
+he peeped into the day-nursery to see who was playing. He whispered to
+Tink, “It’s Wendy’s mother! She is a pretty lady, but not so pretty as
+my mother. Her mouth is full of thimbles, but not so full as my mother’s
+was.”
+
+Of course he knew nothing whatever about his mother; but he sometimes
+bragged about her.
+
+He did not know the tune, which was “Home, Sweet Home,” but he knew it
+was saying, “Come back, Wendy, Wendy, Wendy”; and he cried exultantly,
+“You will never see Wendy again, lady, for the window is barred!”
+
+He peeped in again to see why the music had stopped, and now he saw
+that Mrs. Darling had laid her head on the box, and that two tears were
+sitting on her eyes.
+
+“She wants me to unbar the window,” thought Peter, “but I won’t, not I!”
+
+He peeped again, and the tears were still there, or another two had
+taken their place.
+
+“She’s awfully fond of Wendy,” he said to himself. He was angry with her
+now for not seeing why she could not have Wendy.
+
+The reason was so simple: “I’m fond of her too. We can’t both have her,
+lady.”
+
+But the lady would not make the best of it, and he was unhappy. He
+ceased to look at her, but even then she would not let go of him. He
+skipped about and made funny faces, but when he stopped it was just as
+if she were inside him, knocking.
+
+“Oh, all right,” he said at last, and gulped. Then he unbarred the
+window. “Come on, Tink,” he cried, with a frightful sneer at the laws of
+nature; “we don’t want any silly mothers;” and he flew away.
+
+Thus Wendy and John and Michael found the window open for them after
+all, which of course was more than they deserved. They alighted on the
+floor, quite unashamed of themselves, and the youngest one had already
+forgotten his home.
+
+“John,” he said, looking around him doubtfully, “I think I have been
+here before.”
+
+“Of course you have, you silly. There is your old bed.”
+
+“So it is,” Michael said, but not with much conviction.
+
+“I say,” cried John, “the kennel!” and he dashed across to look into it.
+
+“Perhaps Nana is inside it,” Wendy said.
+
+But John whistled. “Hullo,” he said, “there’s a man inside it.”
+
+“It’s father!” exclaimed Wendy.
+
+“Let me see father,” Michael begged eagerly, and he took a good look.
+“He is not so big as the pirate I killed,” he said with such frank
+disappointment that I am glad Mr. Darling was asleep; it would have been
+sad if those had been the first words he heard his little Michael say.
+
+Wendy and John had been taken aback somewhat at finding their father in
+the kennel.
+
+“Surely,” said John, like one who had lost faith in his memory, “he used
+not to sleep in the kennel?”
+
+“John,” Wendy said falteringly, “perhaps we don’t remember the old life
+as well as we thought we did.”
+
+A chill fell upon them; and serve them right.
+
+“It is very careless of mother,” said that young scoundrel John, “not to
+be here when we come back.”
+
+It was then that Mrs. Darling began playing again.
+
+“It’s mother!” cried Wendy, peeping.
+
+“So it is!” said John.
+
+“Then are you not really our mother, Wendy?” asked Michael, who was
+surely sleepy.
+
+“Oh dear!” exclaimed Wendy, with her first real twinge of remorse [for
+having gone], “it was quite time we came back.”
+
+“Let us creep in,” John suggested, “and put our hands over her eyes.”
+
+But Wendy, who saw that they must break the joyous news more gently, had
+a better plan.
+
+“Let us all slip into our beds, and be there when she comes in, just as
+if we had never been away.”
+
+And so when Mrs. Darling went back to the night-nursery to see if her
+husband was asleep, all the beds were occupied. The children waited
+for her cry of joy, but it did not come. She saw them, but she did not
+believe they were there. You see, she saw them in their beds so often in
+her dreams that she thought this was just the dream hanging around her
+still.
+
+She sat down in the chair by the fire, where in the old days she had
+nursed them.
+
+They could not understand this, and a cold fear fell upon all the three
+of them.
+
+“Mother!” Wendy cried.
+
+“That’s Wendy,” she said, but still she was sure it was the dream.
+
+“Mother!”
+
+“That’s John,” she said.
+
+“Mother!” cried Michael. He knew her now.
+
+“That’s Michael,” she said, and she stretched out her arms for the three
+little selfish children they would never envelop again. Yes, they did,
+they went round Wendy and John and Michael, who had slipped out of bed
+and run to her.
+
+“George, George!” she cried when she could speak; and Mr. Darling woke
+to share her bliss, and Nana came rushing in. There could not have been
+a lovelier sight; but there was none to see it except a little boy who
+was staring in at the window. He had had ecstasies innumerable that
+other children can never know; but he was looking through the window at
+the one joy from which he must be for ever barred.
+
+
+
+
+Chapter 17 WHEN WENDY GREW UP
+
+I hope you want to know what became of the other boys. They were waiting
+below to give Wendy time to explain about them; and when they had
+counted five hundred they went up. They went up by the stair, because
+they thought this would make a better impression. They stood in a row
+in front of Mrs. Darling, with their hats off, and wishing they were not
+wearing their pirate clothes. They said nothing, but their eyes asked
+her to have them. They ought to have looked at Mr. Darling also, but
+they forgot about him.
+
+Of course Mrs. Darling said at once that she would have them; but Mr.
+Darling was curiously depressed, and they saw that he considered six a
+rather large number.
+
+“I must say,” he said to Wendy, “that you don’t do things by halves,” a
+grudging remark which the twins thought was pointed at them.
+
+The first twin was the proud one, and he asked, flushing, “Do you think
+we should be too much of a handful, sir? Because, if so, we can go
+away.”
+
+“Father!” Wendy cried, shocked; but still the cloud was on him. He knew
+he was behaving unworthily, but he could not help it.
+
+“We could lie doubled up,” said Nibs.
+
+“I always cut their hair myself,” said Wendy.
+
+“George!” Mrs. Darling exclaimed, pained to see her dear one showing
+himself in such an unfavourable light.
+
+Then he burst into tears, and the truth came out. He was as glad to
+have them as she was, he said, but he thought they should have asked his
+consent as well as hers, instead of treating him as a cypher [zero] in
+his own house.
+
+“I don’t think he is a cypher,” Tootles cried instantly. “Do you think
+he is a cypher, Curly?”
+
+“No, I don’t. Do you think he is a cypher, Slightly?”
+
+“Rather not. Twin, what do you think?”
+
+It turned out that not one of them thought him a cypher; and he was
+absurdly gratified, and said he would find space for them all in the
+drawing-room if they fitted in.
+
+“We’ll fit in, sir,” they assured him.
+
+“Then follow the leader,” he cried gaily. “Mind you, I am not sure that
+we have a drawing-room, but we pretend we have, and it’s all the same.
+Hoop la!”
+
+He went off dancing through the house, and they all cried “Hoop la!” and
+danced after him, searching for the drawing-room; and I forget whether
+they found it, but at any rate they found corners, and they all fitted
+in.
+
+As for Peter, he saw Wendy once again before he flew away. He did not
+exactly come to the window, but he brushed against it in passing so that
+she could open it if she liked and call to him. That is what she did.
+
+“Hullo, Wendy, good-bye,” he said.
+
+“Oh dear, are you going away?”
+
+“Yes.”
+
+“You don’t feel, Peter,” she said falteringly, “that you would like to
+say anything to my parents about a very sweet subject?”
+
+“No.”
+
+“About me, Peter?”
+
+“No.”
+
+Mrs. Darling came to the window, for at present she was keeping a sharp
+eye on Wendy. She told Peter that she had adopted all the other boys,
+and would like to adopt him also.
+
+“Would you send me to school?” he inquired craftily.
+
+“Yes.”
+
+“And then to an office?”
+
+“I suppose so.”
+
+“Soon I would be a man?”
+
+“Very soon.”
+
+“I don’t want to go to school and learn solemn things,” he told her
+passionately. “I don’t want to be a man. O Wendy’s mother, if I was to
+wake up and feel there was a beard!”
+
+“Peter,” said Wendy the comforter, “I should love you in a beard;” and
+Mrs. Darling stretched out her arms to him, but he repulsed her.
+
+“Keep back, lady, no one is going to catch me and make me a man.”
+
+“But where are you going to live?”
+
+“With Tink in the house we built for Wendy. The fairies are to put it
+high up among the tree tops where they sleep at nights.”
+
+“How lovely,” cried Wendy so longingly that Mrs. Darling tightened her
+grip.
+
+“I thought all the fairies were dead,” Mrs. Darling said.
+
+“There are always a lot of young ones,” explained Wendy, who was now
+quite an authority, “because you see when a new baby laughs for the
+first time a new fairy is born, and as there are always new babies there
+are always new fairies. They live in nests on the tops of trees; and the
+mauve ones are boys and the white ones are girls, and the blue ones are
+just little sillies who are not sure what they are.”
+
+“I shall have such fun,” said Peter, with eye on Wendy.
+
+“It will be rather lonely in the evening,” she said, “sitting by the
+fire.”
+
+“I shall have Tink.”
+
+“Tink can’t go a twentieth part of the way round,” she reminded him a
+little tartly.
+
+“Sneaky tell-tale!” Tink called out from somewhere round the corner.
+
+“It doesn’t matter,” Peter said.
+
+“O Peter, you know it matters.”
+
+“Well, then, come with me to the little house.”
+
+“May I, mummy?”
+
+“Certainly not. I have got you home again, and I mean to keep you.”
+
+“But he does so need a mother.”
+
+“So do you, my love.”
+
+“Oh, all right,” Peter said, as if he had asked her from politeness
+merely; but Mrs. Darling saw his mouth twitch, and she made this
+handsome offer: to let Wendy go to him for a week every year to do
+his spring cleaning. Wendy would have preferred a more permanent
+arrangement; and it seemed to her that spring would be long in coming;
+but this promise sent Peter away quite gay again. He had no sense of
+time, and was so full of adventures that all I have told you about him
+is only a halfpenny-worth of them. I suppose it was because Wendy knew
+this that her last words to him were these rather plaintive ones:
+
+“You won’t forget me, Peter, will you, before spring cleaning time
+comes?”
+
+Of course Peter promised; and then he flew away. He took Mrs. Darling’s
+kiss with him. The kiss that had been for no one else, Peter took quite
+easily. Funny. But she seemed satisfied.
+
+Of course all the boys went to school; and most of them got into Class
+III, but Slightly was put first into Class IV and then into Class V.
+Class I is the top class. Before they had attended school a week they
+saw what goats they had been not to remain on the island; but it was too
+late now, and soon they settled down to being as ordinary as you or me
+or Jenkins minor [the younger Jenkins]. It is sad to have to say that
+the power to fly gradually left them. At first Nana tied their feet to
+the bed-posts so that they should not fly away in the night; and one of
+their diversions by day was to pretend to fall off buses [the English
+double-deckers]; but by and by they ceased to tug at their bonds in bed,
+and found that they hurt themselves when they let go of the bus. In time
+they could not even fly after their hats. Want of practice, they called
+it; but what it really meant was that they no longer believed.
+
+Michael believed longer than the other boys, though they jeered at him;
+so he was with Wendy when Peter came for her at the end of the first
+year. She flew away with Peter in the frock she had woven from leaves
+and berries in the Neverland, and her one fear was that he might notice
+how short it had become; but he never noticed, he had so much to say
+about himself.
+
+She had looked forward to thrilling talks with him about old times, but
+new adventures had crowded the old ones from his mind.
+
+“Who is Captain Hook?” he asked with interest when she spoke of the arch
+enemy.
+
+“Don’t you remember,” she asked, amazed, “how you killed him and saved
+all our lives?”
+
+“I forget them after I kill them,” he replied carelessly.
+
+When she expressed a doubtful hope that Tinker Bell would be glad to see
+her he said, “Who is Tinker Bell?”
+
+“O Peter,” she said, shocked; but even when she explained he could not
+remember.
+
+“There are such a lot of them,” he said. “I expect she is no more.”
+
+I expect he was right, for fairies don’t live long, but they are so
+little that a short time seems a good while to them.
+
+Wendy was pained too to find that the past year was but as yesterday
+to Peter; it had seemed such a long year of waiting to her. But he was
+exactly as fascinating as ever, and they had a lovely spring cleaning in
+the little house on the tree tops.
+
+Next year he did not come for her. She waited in a new frock because the
+old one simply would not meet; but he never came.
+
+“Perhaps he is ill,” Michael said.
+
+“You know he is never ill.”
+
+Michael came close to her and whispered, with a shiver, “Perhaps there
+is no such person, Wendy!” and then Wendy would have cried if Michael
+had not been crying.
+
+Peter came next spring cleaning; and the strange thing was that he never
+knew he had missed a year.
+
+That was the last time the girl Wendy ever saw him. For a little longer
+she tried for his sake not to have growing pains; and she felt she was
+untrue to him when she got a prize for general knowledge. But the years
+came and went without bringing the careless boy; and when they met again
+Wendy was a married woman, and Peter was no more to her than a little
+dust in the box in which she had kept her toys. Wendy was grown up. You
+need not be sorry for her. She was one of the kind that likes to grow
+up. In the end she grew up of her own free will a day quicker than other
+girls.
+
+All the boys were grown up and done for by this time; so it is scarcely
+worth while saying anything more about them. You may see the twins and
+Nibs and Curly any day going to an office, each carrying a little bag
+and an umbrella. Michael is an engine-driver [train engineer]. Slightly
+married a lady of title, and so he became a lord. You see that judge in
+a wig coming out at the iron door? That used to be Tootles. The bearded
+man who doesn’t know any story to tell his children was once John.
+
+Wendy was married in white with a pink sash. It is strange to think
+that Peter did not alight in the church and forbid the banns [formal
+announcement of a marriage].
+
+Years rolled on again, and Wendy had a daughter. This ought not to be
+written in ink but in a golden splash.
+
+She was called Jane, and always had an odd inquiring look, as if from
+the moment she arrived on the mainland she wanted to ask questions. When
+she was old enough to ask them they were mostly about Peter Pan. She
+loved to hear of Peter, and Wendy told her all she could remember in the
+very nursery from which the famous flight had taken place. It was
+Jane’s nursery now, for her father had bought it at the three per cents
+[mortgage rate] from Wendy’s father, who was no longer fond of stairs.
+Mrs. Darling was now dead and forgotten.
+
+There were only two beds in the nursery now, Jane’s and her nurse’s; and
+there was no kennel, for Nana also had passed away. She died of old age,
+and at the end she had been rather difficult to get on with; being very
+firmly convinced that no one knew how to look after children except
+herself.
+
+Once a week Jane’s nurse had her evening off; and then it was Wendy’s
+part to put Jane to bed. That was the time for stories. It was Jane’s
+invention to raise the sheet over her mother’s head and her own, thus
+making a tent, and in the awful darkness to whisper:
+
+“What do we see now?”
+
+“I don’t think I see anything to-night,” says Wendy, with a feeling that
+if Nana were here she would object to further conversation.
+
+“Yes, you do,” says Jane, “you see when you were a little girl.”
+
+“That is a long time ago, sweetheart,” says Wendy. “Ah me, how time
+flies!”
+
+“Does it fly,” asks the artful child, “the way you flew when you were a
+little girl?”
+
+“The way I flew? Do you know, Jane, I sometimes wonder whether I ever
+did really fly.”
+
+“Yes, you did.”
+
+“The dear old days when I could fly!”
+
+“Why can’t you fly now, mother?”
+
+“Because I am grown up, dearest. When people grow up they forget the
+way.”
+
+“Why do they forget the way?”
+
+“Because they are no longer gay and innocent and heartless. It is only
+the gay and innocent and heartless who can fly.”
+
+“What is gay and innocent and heartless? I do wish I were gay and
+innocent and heartless.”
+
+Or perhaps Wendy admits she does see something.
+
+“I do believe,” she says, “that it is this nursery.”
+
+“I do believe it is,” says Jane. “Go on.”
+
+They are now embarked on the great adventure of the night when Peter
+flew in looking for his shadow.
+
+“The foolish fellow,” says Wendy, “tried to stick it on with soap, and
+when he could not he cried, and that woke me, and I sewed it on for
+him.”
+
+“You have missed a bit,” interrupts Jane, who now knows the story better
+than her mother. “When you saw him sitting on the floor crying, what did
+you say?”
+
+“I sat up in bed and I said, ‘Boy, why are you crying?’”
+
+“Yes, that was it,” says Jane, with a big breath.
+
+“And then he flew us all away to the Neverland and the fairies and the
+pirates and the redskins and the mermaids’ lagoon, and the home under
+the ground, and the little house.”
+
+“Yes! which did you like best of all?”
+
+“I think I liked the home under the ground best of all.”
+
+“Yes, so do I. What was the last thing Peter ever said to you?”
+
+“The last thing he ever said to me was, ‘Just always be waiting for me,
+and then some night you will hear me crowing.’”
+
+“Yes.”
+
+“But, alas, he forgot all about me,” Wendy said it with a smile. She was
+as grown up as that.
+
+“What did his crow sound like?” Jane asked one evening.
+
+“It was like this,” Wendy said, trying to imitate Peter’s crow.
+
+“No, it wasn’t,” Jane said gravely, “it was like this;” and she did it
+ever so much better than her mother.
+
+Wendy was a little startled. “My darling, how can you know?”
+
+“I often hear it when I am sleeping,” Jane said.
+
+“Ah yes, many girls hear it when they are sleeping, but I was the only
+one who heard it awake.”
+
+“Lucky you,” said Jane.
+
+And then one night came the tragedy. It was the spring of the year, and
+the story had been told for the night, and Jane was now asleep in her
+bed. Wendy was sitting on the floor, very close to the fire, so as to
+see to darn, for there was no other light in the nursery; and while she
+sat darning she heard a crow. Then the window blew open as of old, and
+Peter dropped in on the floor.
+
+He was exactly the same as ever, and Wendy saw at once that he still had
+all his first teeth.
+
+He was a little boy, and she was grown up. She huddled by the fire not
+daring to move, helpless and guilty, a big woman.
+
+“Hullo, Wendy,” he said, not noticing any difference, for he was
+thinking chiefly of himself; and in the dim light her white dress might
+have been the nightgown in which he had seen her first.
+
+“Hullo, Peter,” she replied faintly, squeezing herself as small as
+possible. Something inside her was crying “Woman, Woman, let go of me.”
+
+“Hullo, where is John?” he asked, suddenly missing the third bed.
+
+“John is not here now,” she gasped.
+
+“Is Michael asleep?” he asked, with a careless glance at Jane.
+
+“Yes,” she answered; and now she felt that she was untrue to Jane as
+well as to Peter.
+
+“That is not Michael,” she said quickly, lest a judgment should fall on
+her.
+
+Peter looked. “Hullo, is it a new one?”
+
+“Yes.”
+
+“Boy or girl?”
+
+“Girl.”
+
+Now surely he would understand; but not a bit of it.
+
+“Peter,” she said, faltering, “are you expecting me to fly away with
+you?”
+
+“Of course; that is why I have come.” He added a little sternly, “Have
+you forgotten that this is spring cleaning time?”
+
+She knew it was useless to say that he had let many spring cleaning
+times pass.
+
+“I can’t come,” she said apologetically, “I have forgotten how to fly.”
+
+“I’ll soon teach you again.”
+
+“O Peter, don’t waste the fairy dust on me.”
+
+She had risen; and now at last a fear assailed him. “What is it?” he
+cried, shrinking.
+
+“I will turn up the light,” she said, “and then you can see for
+yourself.”
+
+For almost the only time in his life that I know of, Peter was afraid.
+“Don’t turn up the light,” he cried.
+
+She let her hands play in the hair of the tragic boy. She was not a
+little girl heart-broken about him; she was a grown woman smiling at it
+all, but they were wet-eyed smiles.
+
+Then she turned up the light, and Peter saw. He gave a cry of pain; and
+when the tall beautiful creature stooped to lift him in her arms he drew
+back sharply.
+
+“What is it?” he cried again.
+
+She had to tell him.
+
+“I am old, Peter. I am ever so much more than twenty. I grew up long
+ago.”
+
+“You promised not to!”
+
+“I couldn’t help it. I am a married woman, Peter.”
+
+“No, you’re not.”
+
+“Yes, and the little girl in the bed is my baby.”
+
+“No, she’s not.”
+
+But he supposed she was; and he took a step towards the sleeping child
+with his dagger upraised. Of course he did not strike. He sat down on
+the floor instead and sobbed; and Wendy did not know how to comfort him,
+though she could have done it so easily once. She was only a woman now,
+and she ran out of the room to try to think.
+
+Peter continued to cry, and soon his sobs woke Jane. She sat up in bed,
+and was interested at once.
+
+“Boy,” she said, “why are you crying?”
+
+Peter rose and bowed to her, and she bowed to him from the bed.
+
+“Hullo,” he said.
+
+“Hullo,” said Jane.
+
+“My name is Peter Pan,” he told her.
+
+“Yes, I know.”
+
+“I came back for my mother,” he explained, “to take her to the
+Neverland.”
+
+“Yes, I know,” Jane said, “I have been waiting for you.”
+
+When Wendy returned diffidently she found Peter sitting on the bed-post
+crowing gloriously, while Jane in her nighty was flying round the room
+in solemn ecstasy.
+
+“She is my mother,” Peter explained; and Jane descended and stood by his
+side, with the look in her face that he liked to see on ladies when they
+gazed at him.
+
+“He does so need a mother,” Jane said.
+
+“Yes, I know,” Wendy admitted rather forlornly; “no one knows it so well
+as I.”
+
+“Good-bye,” said Peter to Wendy; and he rose in the air, and the
+shameless Jane rose with him; it was already her easiest way of moving
+about.
+
+Wendy rushed to the window.
+
+“No, no,” she cried.
+
+“It is just for spring cleaning time,” Jane said, “he wants me always to
+do his spring cleaning.”
+
+“If only I could go with you,” Wendy sighed.
+
+“You see you can’t fly,” said Jane.
+
+Of course in the end Wendy let them fly away together. Our last glimpse
+of her shows her at the window, watching them receding into the sky
+until they were as small as stars.
+
+As you look at Wendy, you may see her hair becoming white, and her
+figure little again, for all this happened long ago. Jane is now a
+common grown-up, with a daughter called Margaret; and every spring
+cleaning time, except when he forgets, Peter comes for Margaret and
+takes her to the Neverland, where she tells him stories about himself,
+to which he listens eagerly. When Margaret grows up she will have a
+daughter, who is to be Peter’s mother in turn; and thus it will go on,
+so long as children are gay and innocent and heartless.
+
+
+THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+***** This file should be named 16-0.txt or 16-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/16/
+
+
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in the
+General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You may
+use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://www.gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+This particular work is one of the few copyrighted individual works
+included with the permission of the copyright holder.  Information on
+the copyright owner for this particular work and the terms of use
+imposed by the copyright holder on this work are set forth at the
+beginning of this work.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS,’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Each eBook is in a subdirectory of the same number as the eBook’s
+eBook number, often in several formats including plain vanilla ASCII,
+compressed (zipped), HTML and others.
+
+Corrected EDITIONS of our eBooks replace the old file and take over
+the old filename and etext number.  The replaced older file is renamed.
+VERSIONS based on separate sources are treated as new eBooks receiving
+new filenames and etext numbers.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+EBooks posted prior to November 2003, with eBook numbers BELOW #10000,
+are filed in directories based on their release date.  If you want to
+download any of these eBooks directly, rather than using the regular
+search system you may utilize the following addresses and just
+download by the etext year.
+
+http://www.ibiblio.org/gutenberg/etext06
+
+    (Or /etext 05, 04, 03, 02, 01, 00, 99,
+     98, 97, 96, 95, 94, 93, 92, 92, 91 or 90)
+
+EBooks posted since November 2003, with etext numbers OVER #10000, are
+filed in a different way.  The year of a release date is no longer part
+of the directory path.  The path is based on the etext number (which is
+identical to the filename).  The path to the file is made up of single
+digits corresponding to all but the last digit in the filename.  For
+example an eBook of filename 10234 would be found at:
+
+http://www.gutenberg.org/1/0/2/3/10234
+
+or filename 24689 would be found at:
+http://www.gutenberg.org/2/4/6/8/24689
+
+An alternative method of locating eBooks:
+http://www.gutenberg.org/GUTINDEX.ALL
+
+*** END: FULL LICENSE ***

--- a/jet/source-sink-builder/src/main/resources/books/pride-and-prejudice.txt
+++ b/jet/source-sink-builder/src/main/resources/books/pride-and-prejudice.txt
@@ -1,0 +1,13427 @@
+﻿The Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Pride and Prejudice
+
+Author: Jane Austen
+
+Posting Date: August 26, 2008 [EBook #1342]
+Release Date: June, 1998
+Last Updated: October 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+
+
+
+Produced by Anonymous Volunteers
+
+
+
+
+
+PRIDE AND PREJUDICE
+
+By Jane Austen
+
+
+
+Chapter 1
+
+
+It is a truth universally acknowledged, that a single man in possession
+of a good fortune, must be in want of a wife.
+
+However little known the feelings or views of such a man may be on his
+first entering a neighbourhood, this truth is so well fixed in the minds
+of the surrounding families, that he is considered the rightful property
+of some one or other of their daughters.
+
+“My dear Mr. Bennet,” said his lady to him one day, “have you heard that
+Netherfield Park is let at last?”
+
+Mr. Bennet replied that he had not.
+
+“But it is,” returned she; “for Mrs. Long has just been here, and she
+told me all about it.”
+
+Mr. Bennet made no answer.
+
+“Do you not want to know who has taken it?” cried his wife impatiently.
+
+“_You_ want to tell me, and I have no objection to hearing it.”
+
+This was invitation enough.
+
+“Why, my dear, you must know, Mrs. Long says that Netherfield is taken
+by a young man of large fortune from the north of England; that he came
+down on Monday in a chaise and four to see the place, and was so much
+delighted with it, that he agreed with Mr. Morris immediately; that he
+is to take possession before Michaelmas, and some of his servants are to
+be in the house by the end of next week.”
+
+“What is his name?”
+
+“Bingley.”
+
+“Is he married or single?”
+
+“Oh! Single, my dear, to be sure! A single man of large fortune; four or
+five thousand a year. What a fine thing for our girls!”
+
+“How so? How can it affect them?”
+
+“My dear Mr. Bennet,” replied his wife, “how can you be so tiresome! You
+must know that I am thinking of his marrying one of them.”
+
+“Is that his design in settling here?”
+
+“Design! Nonsense, how can you talk so! But it is very likely that he
+_may_ fall in love with one of them, and therefore you must visit him as
+soon as he comes.”
+
+“I see no occasion for that. You and the girls may go, or you may send
+them by themselves, which perhaps will be still better, for as you are
+as handsome as any of them, Mr. Bingley may like you the best of the
+party.”
+
+“My dear, you flatter me. I certainly _have_ had my share of beauty, but
+I do not pretend to be anything extraordinary now. When a woman has five
+grown-up daughters, she ought to give over thinking of her own beauty.”
+
+“In such cases, a woman has not often much beauty to think of.”
+
+“But, my dear, you must indeed go and see Mr. Bingley when he comes into
+the neighbourhood.”
+
+“It is more than I engage for, I assure you.”
+
+“But consider your daughters. Only think what an establishment it would
+be for one of them. Sir William and Lady Lucas are determined to
+go, merely on that account, for in general, you know, they visit no
+newcomers. Indeed you must go, for it will be impossible for _us_ to
+visit him if you do not.”
+
+“You are over-scrupulous, surely. I dare say Mr. Bingley will be very
+glad to see you; and I will send a few lines by you to assure him of my
+hearty consent to his marrying whichever he chooses of the girls; though
+I must throw in a good word for my little Lizzy.”
+
+“I desire you will do no such thing. Lizzy is not a bit better than the
+others; and I am sure she is not half so handsome as Jane, nor half so
+good-humoured as Lydia. But you are always giving _her_ the preference.”
+
+“They have none of them much to recommend them,” replied he; “they are
+all silly and ignorant like other girls; but Lizzy has something more of
+quickness than her sisters.”
+
+“Mr. Bennet, how _can_ you abuse your own children in such a way? You
+take delight in vexing me. You have no compassion for my poor nerves.”
+
+“You mistake me, my dear. I have a high respect for your nerves. They
+are my old friends. I have heard you mention them with consideration
+these last twenty years at least.”
+
+“Ah, you do not know what I suffer.”
+
+“But I hope you will get over it, and live to see many young men of four
+thousand a year come into the neighbourhood.”
+
+“It will be no use to us, if twenty such should come, since you will not
+visit them.”
+
+“Depend upon it, my dear, that when there are twenty, I will visit them
+all.”
+
+Mr. Bennet was so odd a mixture of quick parts, sarcastic humour,
+reserve, and caprice, that the experience of three-and-twenty years had
+been insufficient to make his wife understand his character. _Her_ mind
+was less difficult to develop. She was a woman of mean understanding,
+little information, and uncertain temper. When she was discontented,
+she fancied herself nervous. The business of her life was to get her
+daughters married; its solace was visiting and news.
+
+
+
+Chapter 2
+
+
+Mr. Bennet was among the earliest of those who waited on Mr. Bingley. He
+had always intended to visit him, though to the last always assuring
+his wife that he should not go; and till the evening after the visit was
+paid she had no knowledge of it. It was then disclosed in the following
+manner. Observing his second daughter employed in trimming a hat, he
+suddenly addressed her with:
+
+“I hope Mr. Bingley will like it, Lizzy.”
+
+“We are not in a way to know _what_ Mr. Bingley likes,” said her mother
+resentfully, “since we are not to visit.”
+
+“But you forget, mamma,” said Elizabeth, “that we shall meet him at the
+assemblies, and that Mrs. Long promised to introduce him.”
+
+“I do not believe Mrs. Long will do any such thing. She has two nieces
+of her own. She is a selfish, hypocritical woman, and I have no opinion
+of her.”
+
+“No more have I,” said Mr. Bennet; “and I am glad to find that you do
+not depend on her serving you.”
+
+Mrs. Bennet deigned not to make any reply, but, unable to contain
+herself, began scolding one of her daughters.
+
+“Don’t keep coughing so, Kitty, for Heaven’s sake! Have a little
+compassion on my nerves. You tear them to pieces.”
+
+“Kitty has no discretion in her coughs,” said her father; “she times
+them ill.”
+
+“I do not cough for my own amusement,” replied Kitty fretfully. “When is
+your next ball to be, Lizzy?”
+
+“To-morrow fortnight.”
+
+“Aye, so it is,” cried her mother, “and Mrs. Long does not come back
+till the day before; so it will be impossible for her to introduce him,
+for she will not know him herself.”
+
+“Then, my dear, you may have the advantage of your friend, and introduce
+Mr. Bingley to _her_.”
+
+“Impossible, Mr. Bennet, impossible, when I am not acquainted with him
+myself; how can you be so teasing?”
+
+“I honour your circumspection. A fortnight’s acquaintance is certainly
+very little. One cannot know what a man really is by the end of a
+fortnight. But if _we_ do not venture somebody else will; and after all,
+Mrs. Long and her neices must stand their chance; and, therefore, as
+she will think it an act of kindness, if you decline the office, I will
+take it on myself.”
+
+The girls stared at their father. Mrs. Bennet said only, “Nonsense,
+nonsense!”
+
+“What can be the meaning of that emphatic exclamation?” cried he. “Do
+you consider the forms of introduction, and the stress that is laid on
+them, as nonsense? I cannot quite agree with you _there_. What say you,
+Mary? For you are a young lady of deep reflection, I know, and read
+great books and make extracts.”
+
+Mary wished to say something sensible, but knew not how.
+
+“While Mary is adjusting her ideas,” he continued, “let us return to Mr.
+Bingley.”
+
+“I am sick of Mr. Bingley,” cried his wife.
+
+“I am sorry to hear _that_; but why did not you tell me that before? If
+I had known as much this morning I certainly would not have called
+on him. It is very unlucky; but as I have actually paid the visit, we
+cannot escape the acquaintance now.”
+
+The astonishment of the ladies was just what he wished; that of Mrs.
+Bennet perhaps surpassing the rest; though, when the first tumult of joy
+was over, she began to declare that it was what she had expected all the
+while.
+
+“How good it was in you, my dear Mr. Bennet! But I knew I should
+persuade you at last. I was sure you loved your girls too well to
+neglect such an acquaintance. Well, how pleased I am! and it is such a
+good joke, too, that you should have gone this morning and never said a
+word about it till now.”
+
+“Now, Kitty, you may cough as much as you choose,” said Mr. Bennet; and,
+as he spoke, he left the room, fatigued with the raptures of his wife.
+
+“What an excellent father you have, girls!” said she, when the door was
+shut. “I do not know how you will ever make him amends for his kindness;
+or me, either, for that matter. At our time of life it is not so
+pleasant, I can tell you, to be making new acquaintances every day; but
+for your sakes, we would do anything. Lydia, my love, though you _are_
+the youngest, I dare say Mr. Bingley will dance with you at the next
+ball.”
+
+“Oh!” said Lydia stoutly, “I am not afraid; for though I _am_ the
+youngest, I’m the tallest.”
+
+The rest of the evening was spent in conjecturing how soon he would
+return Mr. Bennet’s visit, and determining when they should ask him to
+dinner.
+
+
+
+Chapter 3
+
+
+Not all that Mrs. Bennet, however, with the assistance of her five
+daughters, could ask on the subject, was sufficient to draw from her
+husband any satisfactory description of Mr. Bingley. They attacked him
+in various ways--with barefaced questions, ingenious suppositions, and
+distant surmises; but he eluded the skill of them all, and they were at
+last obliged to accept the second-hand intelligence of their neighbour,
+Lady Lucas. Her report was highly favourable. Sir William had been
+delighted with him. He was quite young, wonderfully handsome, extremely
+agreeable, and, to crown the whole, he meant to be at the next assembly
+with a large party. Nothing could be more delightful! To be fond of
+dancing was a certain step towards falling in love; and very lively
+hopes of Mr. Bingley’s heart were entertained.
+
+“If I can but see one of my daughters happily settled at Netherfield,”
+ said Mrs. Bennet to her husband, “and all the others equally well
+married, I shall have nothing to wish for.”
+
+In a few days Mr. Bingley returned Mr. Bennet’s visit, and sat about
+ten minutes with him in his library. He had entertained hopes of being
+admitted to a sight of the young ladies, of whose beauty he had
+heard much; but he saw only the father. The ladies were somewhat more
+fortunate, for they had the advantage of ascertaining from an upper
+window that he wore a blue coat, and rode a black horse.
+
+An invitation to dinner was soon afterwards dispatched; and already
+had Mrs. Bennet planned the courses that were to do credit to her
+housekeeping, when an answer arrived which deferred it all. Mr. Bingley
+was obliged to be in town the following day, and, consequently, unable
+to accept the honour of their invitation, etc. Mrs. Bennet was quite
+disconcerted. She could not imagine what business he could have in town
+so soon after his arrival in Hertfordshire; and she began to fear that
+he might be always flying about from one place to another, and never
+settled at Netherfield as he ought to be. Lady Lucas quieted her fears
+a little by starting the idea of his being gone to London only to get
+a large party for the ball; and a report soon followed that Mr. Bingley
+was to bring twelve ladies and seven gentlemen with him to the assembly.
+The girls grieved over such a number of ladies, but were comforted the
+day before the ball by hearing, that instead of twelve he brought only
+six with him from London--his five sisters and a cousin. And when
+the party entered the assembly room it consisted of only five
+altogether--Mr. Bingley, his two sisters, the husband of the eldest, and
+another young man.
+
+Mr. Bingley was good-looking and gentlemanlike; he had a pleasant
+countenance, and easy, unaffected manners. His sisters were fine women,
+with an air of decided fashion. His brother-in-law, Mr. Hurst, merely
+looked the gentleman; but his friend Mr. Darcy soon drew the attention
+of the room by his fine, tall person, handsome features, noble mien, and
+the report which was in general circulation within five minutes
+after his entrance, of his having ten thousand a year. The gentlemen
+pronounced him to be a fine figure of a man, the ladies declared he
+was much handsomer than Mr. Bingley, and he was looked at with great
+admiration for about half the evening, till his manners gave a disgust
+which turned the tide of his popularity; for he was discovered to be
+proud; to be above his company, and above being pleased; and not all
+his large estate in Derbyshire could then save him from having a most
+forbidding, disagreeable countenance, and being unworthy to be compared
+with his friend.
+
+Mr. Bingley had soon made himself acquainted with all the principal
+people in the room; he was lively and unreserved, danced every dance,
+was angry that the ball closed so early, and talked of giving
+one himself at Netherfield. Such amiable qualities must speak for
+themselves. What a contrast between him and his friend! Mr. Darcy danced
+only once with Mrs. Hurst and once with Miss Bingley, declined being
+introduced to any other lady, and spent the rest of the evening in
+walking about the room, speaking occasionally to one of his own party.
+His character was decided. He was the proudest, most disagreeable man
+in the world, and everybody hoped that he would never come there again.
+Amongst the most violent against him was Mrs. Bennet, whose dislike of
+his general behaviour was sharpened into particular resentment by his
+having slighted one of her daughters.
+
+Elizabeth Bennet had been obliged, by the scarcity of gentlemen, to sit
+down for two dances; and during part of that time, Mr. Darcy had been
+standing near enough for her to hear a conversation between him and Mr.
+Bingley, who came from the dance for a few minutes, to press his friend
+to join it.
+
+“Come, Darcy,” said he, “I must have you dance. I hate to see you
+standing about by yourself in this stupid manner. You had much better
+dance.”
+
+“I certainly shall not. You know how I detest it, unless I am
+particularly acquainted with my partner. At such an assembly as this
+it would be insupportable. Your sisters are engaged, and there is not
+another woman in the room whom it would not be a punishment to me to
+stand up with.”
+
+“I would not be so fastidious as you are,” cried Mr. Bingley, “for a
+kingdom! Upon my honour, I never met with so many pleasant girls in
+my life as I have this evening; and there are several of them you see
+uncommonly pretty.”
+
+“_You_ are dancing with the only handsome girl in the room,” said Mr.
+Darcy, looking at the eldest Miss Bennet.
+
+“Oh! She is the most beautiful creature I ever beheld! But there is one
+of her sisters sitting down just behind you, who is very pretty, and I
+dare say very agreeable. Do let me ask my partner to introduce you.”
+
+“Which do you mean?” and turning round he looked for a moment at
+Elizabeth, till catching her eye, he withdrew his own and coldly said:
+“She is tolerable, but not handsome enough to tempt _me_; I am in no
+humour at present to give consequence to young ladies who are slighted
+by other men. You had better return to your partner and enjoy her
+smiles, for you are wasting your time with me.”
+
+Mr. Bingley followed his advice. Mr. Darcy walked off; and Elizabeth
+remained with no very cordial feelings toward him. She told the story,
+however, with great spirit among her friends; for she had a lively,
+playful disposition, which delighted in anything ridiculous.
+
+The evening altogether passed off pleasantly to the whole family. Mrs.
+Bennet had seen her eldest daughter much admired by the Netherfield
+party. Mr. Bingley had danced with her twice, and she had been
+distinguished by his sisters. Jane was as much gratified by this as
+her mother could be, though in a quieter way. Elizabeth felt Jane’s
+pleasure. Mary had heard herself mentioned to Miss Bingley as the most
+accomplished girl in the neighbourhood; and Catherine and Lydia had been
+fortunate enough never to be without partners, which was all that they
+had yet learnt to care for at a ball. They returned, therefore, in good
+spirits to Longbourn, the village where they lived, and of which they
+were the principal inhabitants. They found Mr. Bennet still up. With
+a book he was regardless of time; and on the present occasion he had a
+good deal of curiosity as to the event of an evening which had raised
+such splendid expectations. He had rather hoped that his wife’s views on
+the stranger would be disappointed; but he soon found out that he had a
+different story to hear.
+
+“Oh! my dear Mr. Bennet,” as she entered the room, “we have had a most
+delightful evening, a most excellent ball. I wish you had been there.
+Jane was so admired, nothing could be like it. Everybody said how well
+she looked; and Mr. Bingley thought her quite beautiful, and danced with
+her twice! Only think of _that_, my dear; he actually danced with her
+twice! and she was the only creature in the room that he asked a second
+time. First of all, he asked Miss Lucas. I was so vexed to see him stand
+up with her! But, however, he did not admire her at all; indeed, nobody
+can, you know; and he seemed quite struck with Jane as she was going
+down the dance. So he inquired who she was, and got introduced, and
+asked her for the two next. Then the two third he danced with Miss King,
+and the two fourth with Maria Lucas, and the two fifth with Jane again,
+and the two sixth with Lizzy, and the _Boulanger_--”
+
+“If he had had any compassion for _me_,” cried her husband impatiently,
+“he would not have danced half so much! For God’s sake, say no more of
+his partners. Oh that he had sprained his ankle in the first dance!”
+
+“Oh! my dear, I am quite delighted with him. He is so excessively
+handsome! And his sisters are charming women. I never in my life saw
+anything more elegant than their dresses. I dare say the lace upon Mrs.
+Hurst’s gown--”
+
+Here she was interrupted again. Mr. Bennet protested against any
+description of finery. She was therefore obliged to seek another branch
+of the subject, and related, with much bitterness of spirit and some
+exaggeration, the shocking rudeness of Mr. Darcy.
+
+“But I can assure you,” she added, “that Lizzy does not lose much by not
+suiting _his_ fancy; for he is a most disagreeable, horrid man, not at
+all worth pleasing. So high and so conceited that there was no enduring
+him! He walked here, and he walked there, fancying himself so very
+great! Not handsome enough to dance with! I wish you had been there, my
+dear, to have given him one of your set-downs. I quite detest the man.”
+
+
+
+Chapter 4
+
+
+When Jane and Elizabeth were alone, the former, who had been cautious in
+her praise of Mr. Bingley before, expressed to her sister just how very
+much she admired him.
+
+“He is just what a young man ought to be,” said she, “sensible,
+good-humoured, lively; and I never saw such happy manners!--so much
+ease, with such perfect good breeding!”
+
+“He is also handsome,” replied Elizabeth, “which a young man ought
+likewise to be, if he possibly can. His character is thereby complete.”
+
+“I was very much flattered by his asking me to dance a second time. I
+did not expect such a compliment.”
+
+“Did not you? I did for you. But that is one great difference between
+us. Compliments always take _you_ by surprise, and _me_ never. What
+could be more natural than his asking you again? He could not help
+seeing that you were about five times as pretty as every other woman
+in the room. No thanks to his gallantry for that. Well, he certainly is
+very agreeable, and I give you leave to like him. You have liked many a
+stupider person.”
+
+“Dear Lizzy!”
+
+“Oh! you are a great deal too apt, you know, to like people in general.
+You never see a fault in anybody. All the world are good and agreeable
+in your eyes. I never heard you speak ill of a human being in your
+life.”
+
+“I would not wish to be hasty in censuring anyone; but I always speak
+what I think.”
+
+“I know you do; and it is _that_ which makes the wonder. With _your_
+good sense, to be so honestly blind to the follies and nonsense of
+others! Affectation of candour is common enough--one meets with it
+everywhere. But to be candid without ostentation or design--to take the
+good of everybody’s character and make it still better, and say nothing
+of the bad--belongs to you alone. And so you like this man’s sisters,
+too, do you? Their manners are not equal to his.”
+
+“Certainly not--at first. But they are very pleasing women when you
+converse with them. Miss Bingley is to live with her brother, and keep
+his house; and I am much mistaken if we shall not find a very charming
+neighbour in her.”
+
+Elizabeth listened in silence, but was not convinced; their behaviour at
+the assembly had not been calculated to please in general; and with more
+quickness of observation and less pliancy of temper than her sister,
+and with a judgement too unassailed by any attention to herself, she
+was very little disposed to approve them. They were in fact very fine
+ladies; not deficient in good humour when they were pleased, nor in the
+power of making themselves agreeable when they chose it, but proud and
+conceited. They were rather handsome, had been educated in one of the
+first private seminaries in town, had a fortune of twenty thousand
+pounds, were in the habit of spending more than they ought, and of
+associating with people of rank, and were therefore in every respect
+entitled to think well of themselves, and meanly of others. They were of
+a respectable family in the north of England; a circumstance more deeply
+impressed on their memories than that their brother’s fortune and their
+own had been acquired by trade.
+
+Mr. Bingley inherited property to the amount of nearly a hundred
+thousand pounds from his father, who had intended to purchase an
+estate, but did not live to do it. Mr. Bingley intended it likewise, and
+sometimes made choice of his county; but as he was now provided with a
+good house and the liberty of a manor, it was doubtful to many of those
+who best knew the easiness of his temper, whether he might not spend the
+remainder of his days at Netherfield, and leave the next generation to
+purchase.
+
+His sisters were anxious for his having an estate of his own; but,
+though he was now only established as a tenant, Miss Bingley was by no
+means unwilling to preside at his table--nor was Mrs. Hurst, who had
+married a man of more fashion than fortune, less disposed to consider
+his house as her home when it suited her. Mr. Bingley had not been of
+age two years, when he was tempted by an accidental recommendation
+to look at Netherfield House. He did look at it, and into it for
+half-an-hour--was pleased with the situation and the principal
+rooms, satisfied with what the owner said in its praise, and took it
+immediately.
+
+Between him and Darcy there was a very steady friendship, in spite of
+great opposition of character. Bingley was endeared to Darcy by the
+easiness, openness, and ductility of his temper, though no disposition
+could offer a greater contrast to his own, and though with his own he
+never appeared dissatisfied. On the strength of Darcy’s regard, Bingley
+had the firmest reliance, and of his judgement the highest opinion.
+In understanding, Darcy was the superior. Bingley was by no means
+deficient, but Darcy was clever. He was at the same time haughty,
+reserved, and fastidious, and his manners, though well-bred, were not
+inviting. In that respect his friend had greatly the advantage. Bingley
+was sure of being liked wherever he appeared, Darcy was continually
+giving offense.
+
+The manner in which they spoke of the Meryton assembly was sufficiently
+characteristic. Bingley had never met with more pleasant people or
+prettier girls in his life; everybody had been most kind and attentive
+to him; there had been no formality, no stiffness; he had soon felt
+acquainted with all the room; and, as to Miss Bennet, he could not
+conceive an angel more beautiful. Darcy, on the contrary, had seen a
+collection of people in whom there was little beauty and no fashion, for
+none of whom he had felt the smallest interest, and from none received
+either attention or pleasure. Miss Bennet he acknowledged to be pretty,
+but she smiled too much.
+
+Mrs. Hurst and her sister allowed it to be so--but still they admired
+her and liked her, and pronounced her to be a sweet girl, and one
+whom they would not object to know more of. Miss Bennet was therefore
+established as a sweet girl, and their brother felt authorized by such
+commendation to think of her as he chose.
+
+
+
+Chapter 5
+
+
+Within a short walk of Longbourn lived a family with whom the Bennets
+were particularly intimate. Sir William Lucas had been formerly in trade
+in Meryton, where he had made a tolerable fortune, and risen to the
+honour of knighthood by an address to the king during his mayoralty.
+The distinction had perhaps been felt too strongly. It had given him a
+disgust to his business, and to his residence in a small market town;
+and, in quitting them both, he had removed with his family to a house
+about a mile from Meryton, denominated from that period Lucas Lodge,
+where he could think with pleasure of his own importance, and,
+unshackled by business, occupy himself solely in being civil to all
+the world. For, though elated by his rank, it did not render him
+supercilious; on the contrary, he was all attention to everybody. By
+nature inoffensive, friendly, and obliging, his presentation at St.
+James’s had made him courteous.
+
+Lady Lucas was a very good kind of woman, not too clever to be a
+valuable neighbour to Mrs. Bennet. They had several children. The eldest
+of them, a sensible, intelligent young woman, about twenty-seven, was
+Elizabeth’s intimate friend.
+
+That the Miss Lucases and the Miss Bennets should meet to talk over
+a ball was absolutely necessary; and the morning after the assembly
+brought the former to Longbourn to hear and to communicate.
+
+“_You_ began the evening well, Charlotte,” said Mrs. Bennet with civil
+self-command to Miss Lucas. “_You_ were Mr. Bingley’s first choice.”
+
+“Yes; but he seemed to like his second better.”
+
+“Oh! you mean Jane, I suppose, because he danced with her twice. To be
+sure that _did_ seem as if he admired her--indeed I rather believe he
+_did_--I heard something about it--but I hardly know what--something
+about Mr. Robinson.”
+
+“Perhaps you mean what I overheard between him and Mr. Robinson; did not
+I mention it to you? Mr. Robinson’s asking him how he liked our Meryton
+assemblies, and whether he did not think there were a great many
+pretty women in the room, and _which_ he thought the prettiest? and his
+answering immediately to the last question: ‘Oh! the eldest Miss Bennet,
+beyond a doubt; there cannot be two opinions on that point.’”
+
+“Upon my word! Well, that is very decided indeed--that does seem as
+if--but, however, it may all come to nothing, you know.”
+
+“_My_ overhearings were more to the purpose than _yours_, Eliza,” said
+Charlotte. “Mr. Darcy is not so well worth listening to as his friend,
+is he?--poor Eliza!--to be only just _tolerable_.”
+
+“I beg you would not put it into Lizzy’s head to be vexed by his
+ill-treatment, for he is such a disagreeable man, that it would be quite
+a misfortune to be liked by him. Mrs. Long told me last night that he
+sat close to her for half-an-hour without once opening his lips.”
+
+“Are you quite sure, ma’am?--is not there a little mistake?” said Jane.
+“I certainly saw Mr. Darcy speaking to her.”
+
+“Aye--because she asked him at last how he liked Netherfield, and he
+could not help answering her; but she said he seemed quite angry at
+being spoke to.”
+
+“Miss Bingley told me,” said Jane, “that he never speaks much,
+unless among his intimate acquaintances. With _them_ he is remarkably
+agreeable.”
+
+“I do not believe a word of it, my dear. If he had been so very
+agreeable, he would have talked to Mrs. Long. But I can guess how it
+was; everybody says that he is eat up with pride, and I dare say he had
+heard somehow that Mrs. Long does not keep a carriage, and had come to
+the ball in a hack chaise.”
+
+“I do not mind his not talking to Mrs. Long,” said Miss Lucas, “but I
+wish he had danced with Eliza.”
+
+“Another time, Lizzy,” said her mother, “I would not dance with _him_,
+if I were you.”
+
+“I believe, ma’am, I may safely promise you _never_ to dance with him.”
+
+“His pride,” said Miss Lucas, “does not offend _me_ so much as pride
+often does, because there is an excuse for it. One cannot wonder that so
+very fine a young man, with family, fortune, everything in his favour,
+should think highly of himself. If I may so express it, he has a _right_
+to be proud.”
+
+“That is very true,” replied Elizabeth, “and I could easily forgive
+_his_ pride, if he had not mortified _mine_.”
+
+“Pride,” observed Mary, who piqued herself upon the solidity of her
+reflections, “is a very common failing, I believe. By all that I have
+ever read, I am convinced that it is very common indeed; that human
+nature is particularly prone to it, and that there are very few of us
+who do not cherish a feeling of self-complacency on the score of some
+quality or other, real or imaginary. Vanity and pride are different
+things, though the words are often used synonymously. A person may
+be proud without being vain. Pride relates more to our opinion of
+ourselves, vanity to what we would have others think of us.”
+
+“If I were as rich as Mr. Darcy,” cried a young Lucas, who came with
+his sisters, “I should not care how proud I was. I would keep a pack of
+foxhounds, and drink a bottle of wine a day.”
+
+“Then you would drink a great deal more than you ought,” said Mrs.
+Bennet; “and if I were to see you at it, I should take away your bottle
+directly.”
+
+The boy protested that she should not; she continued to declare that she
+would, and the argument ended only with the visit.
+
+
+
+Chapter 6
+
+
+The ladies of Longbourn soon waited on those of Netherfield. The visit
+was soon returned in due form. Miss Bennet’s pleasing manners grew on
+the goodwill of Mrs. Hurst and Miss Bingley; and though the mother was
+found to be intolerable, and the younger sisters not worth speaking to,
+a wish of being better acquainted with _them_ was expressed towards
+the two eldest. By Jane, this attention was received with the greatest
+pleasure, but Elizabeth still saw superciliousness in their treatment
+of everybody, hardly excepting even her sister, and could not like them;
+though their kindness to Jane, such as it was, had a value as arising in
+all probability from the influence of their brother’s admiration. It
+was generally evident whenever they met, that he _did_ admire her and
+to _her_ it was equally evident that Jane was yielding to the preference
+which she had begun to entertain for him from the first, and was in a
+way to be very much in love; but she considered with pleasure that it
+was not likely to be discovered by the world in general, since Jane
+united, with great strength of feeling, a composure of temper and a
+uniform cheerfulness of manner which would guard her from the suspicions
+of the impertinent. She mentioned this to her friend Miss Lucas.
+
+“It may perhaps be pleasant,” replied Charlotte, “to be able to impose
+on the public in such a case; but it is sometimes a disadvantage to be
+so very guarded. If a woman conceals her affection with the same skill
+from the object of it, she may lose the opportunity of fixing him; and
+it will then be but poor consolation to believe the world equally in
+the dark. There is so much of gratitude or vanity in almost every
+attachment, that it is not safe to leave any to itself. We can all
+_begin_ freely--a slight preference is natural enough; but there are
+very few of us who have heart enough to be really in love without
+encouragement. In nine cases out of ten a women had better show _more_
+affection than she feels. Bingley likes your sister undoubtedly; but he
+may never do more than like her, if she does not help him on.”
+
+“But she does help him on, as much as her nature will allow. If I can
+perceive her regard for him, he must be a simpleton, indeed, not to
+discover it too.”
+
+“Remember, Eliza, that he does not know Jane’s disposition as you do.”
+
+“But if a woman is partial to a man, and does not endeavour to conceal
+it, he must find it out.”
+
+“Perhaps he must, if he sees enough of her. But, though Bingley and Jane
+meet tolerably often, it is never for many hours together; and, as they
+always see each other in large mixed parties, it is impossible that
+every moment should be employed in conversing together. Jane should
+therefore make the most of every half-hour in which she can command his
+attention. When she is secure of him, there will be more leisure for
+falling in love as much as she chooses.”
+
+“Your plan is a good one,” replied Elizabeth, “where nothing is in
+question but the desire of being well married, and if I were determined
+to get a rich husband, or any husband, I dare say I should adopt it. But
+these are not Jane’s feelings; she is not acting by design. As yet,
+she cannot even be certain of the degree of her own regard nor of its
+reasonableness. She has known him only a fortnight. She danced four
+dances with him at Meryton; she saw him one morning at his own house,
+and has since dined with him in company four times. This is not quite
+enough to make her understand his character.”
+
+“Not as you represent it. Had she merely _dined_ with him, she might
+only have discovered whether he had a good appetite; but you must
+remember that four evenings have also been spent together--and four
+evenings may do a great deal.”
+
+“Yes; these four evenings have enabled them to ascertain that they
+both like Vingt-un better than Commerce; but with respect to any other
+leading characteristic, I do not imagine that much has been unfolded.”
+
+“Well,” said Charlotte, “I wish Jane success with all my heart; and
+if she were married to him to-morrow, I should think she had as good a
+chance of happiness as if she were to be studying his character for a
+twelvemonth. Happiness in marriage is entirely a matter of chance. If
+the dispositions of the parties are ever so well known to each other or
+ever so similar beforehand, it does not advance their felicity in the
+least. They always continue to grow sufficiently unlike afterwards to
+have their share of vexation; and it is better to know as little as
+possible of the defects of the person with whom you are to pass your
+life.”
+
+“You make me laugh, Charlotte; but it is not sound. You know it is not
+sound, and that you would never act in this way yourself.”
+
+Occupied in observing Mr. Bingley’s attentions to her sister, Elizabeth
+was far from suspecting that she was herself becoming an object of some
+interest in the eyes of his friend. Mr. Darcy had at first scarcely
+allowed her to be pretty; he had looked at her without admiration at the
+ball; and when they next met, he looked at her only to criticise. But no
+sooner had he made it clear to himself and his friends that she hardly
+had a good feature in her face, than he began to find it was rendered
+uncommonly intelligent by the beautiful expression of her dark eyes. To
+this discovery succeeded some others equally mortifying. Though he had
+detected with a critical eye more than one failure of perfect symmetry
+in her form, he was forced to acknowledge her figure to be light and
+pleasing; and in spite of his asserting that her manners were not those
+of the fashionable world, he was caught by their easy playfulness. Of
+this she was perfectly unaware; to her he was only the man who made
+himself agreeable nowhere, and who had not thought her handsome enough
+to dance with.
+
+He began to wish to know more of her, and as a step towards conversing
+with her himself, attended to her conversation with others. His doing so
+drew her notice. It was at Sir William Lucas’s, where a large party were
+assembled.
+
+“What does Mr. Darcy mean,” said she to Charlotte, “by listening to my
+conversation with Colonel Forster?”
+
+“That is a question which Mr. Darcy only can answer.”
+
+“But if he does it any more I shall certainly let him know that I see
+what he is about. He has a very satirical eye, and if I do not begin by
+being impertinent myself, I shall soon grow afraid of him.”
+
+On his approaching them soon afterwards, though without seeming to have
+any intention of speaking, Miss Lucas defied her friend to mention such
+a subject to him; which immediately provoking Elizabeth to do it, she
+turned to him and said:
+
+“Did you not think, Mr. Darcy, that I expressed myself uncommonly
+well just now, when I was teasing Colonel Forster to give us a ball at
+Meryton?”
+
+“With great energy; but it is always a subject which makes a lady
+energetic.”
+
+“You are severe on us.”
+
+“It will be _her_ turn soon to be teased,” said Miss Lucas. “I am going
+to open the instrument, Eliza, and you know what follows.”
+
+“You are a very strange creature by way of a friend!--always wanting me
+to play and sing before anybody and everybody! If my vanity had taken
+a musical turn, you would have been invaluable; but as it is, I would
+really rather not sit down before those who must be in the habit of
+hearing the very best performers.” On Miss Lucas’s persevering, however,
+she added, “Very well, if it must be so, it must.” And gravely glancing
+at Mr. Darcy, “There is a fine old saying, which everybody here is of
+course familiar with: ‘Keep your breath to cool your porridge’; and I
+shall keep mine to swell my song.”
+
+Her performance was pleasing, though by no means capital. After a song
+or two, and before she could reply to the entreaties of several that
+she would sing again, she was eagerly succeeded at the instrument by her
+sister Mary, who having, in consequence of being the only plain one in
+the family, worked hard for knowledge and accomplishments, was always
+impatient for display.
+
+Mary had neither genius nor taste; and though vanity had given her
+application, it had given her likewise a pedantic air and conceited
+manner, which would have injured a higher degree of excellence than she
+had reached. Elizabeth, easy and unaffected, had been listened to with
+much more pleasure, though not playing half so well; and Mary, at the
+end of a long concerto, was glad to purchase praise and gratitude by
+Scotch and Irish airs, at the request of her younger sisters, who,
+with some of the Lucases, and two or three officers, joined eagerly in
+dancing at one end of the room.
+
+Mr. Darcy stood near them in silent indignation at such a mode of
+passing the evening, to the exclusion of all conversation, and was too
+much engrossed by his thoughts to perceive that Sir William Lucas was
+his neighbour, till Sir William thus began:
+
+“What a charming amusement for young people this is, Mr. Darcy! There
+is nothing like dancing after all. I consider it as one of the first
+refinements of polished society.”
+
+“Certainly, sir; and it has the advantage also of being in vogue amongst
+the less polished societies of the world. Every savage can dance.”
+
+Sir William only smiled. “Your friend performs delightfully,” he
+continued after a pause, on seeing Bingley join the group; “and I doubt
+not that you are an adept in the science yourself, Mr. Darcy.”
+
+“You saw me dance at Meryton, I believe, sir.”
+
+“Yes, indeed, and received no inconsiderable pleasure from the sight. Do
+you often dance at St. James’s?”
+
+“Never, sir.”
+
+“Do you not think it would be a proper compliment to the place?”
+
+“It is a compliment which I never pay to any place if I can avoid it.”
+
+“You have a house in town, I conclude?”
+
+Mr. Darcy bowed.
+
+“I had once had some thought of fixing in town myself--for I am fond
+of superior society; but I did not feel quite certain that the air of
+London would agree with Lady Lucas.”
+
+He paused in hopes of an answer; but his companion was not disposed
+to make any; and Elizabeth at that instant moving towards them, he was
+struck with the action of doing a very gallant thing, and called out to
+her:
+
+“My dear Miss Eliza, why are you not dancing? Mr. Darcy, you must allow
+me to present this young lady to you as a very desirable partner. You
+cannot refuse to dance, I am sure when so much beauty is before you.”
+ And, taking her hand, he would have given it to Mr. Darcy who, though
+extremely surprised, was not unwilling to receive it, when she instantly
+drew back, and said with some discomposure to Sir William:
+
+“Indeed, sir, I have not the least intention of dancing. I entreat you
+not to suppose that I moved this way in order to beg for a partner.”
+
+Mr. Darcy, with grave propriety, requested to be allowed the honour of
+her hand, but in vain. Elizabeth was determined; nor did Sir William at
+all shake her purpose by his attempt at persuasion.
+
+“You excel so much in the dance, Miss Eliza, that it is cruel to deny
+me the happiness of seeing you; and though this gentleman dislikes the
+amusement in general, he can have no objection, I am sure, to oblige us
+for one half-hour.”
+
+“Mr. Darcy is all politeness,” said Elizabeth, smiling.
+
+“He is, indeed; but, considering the inducement, my dear Miss Eliza,
+we cannot wonder at his complaisance--for who would object to such a
+partner?”
+
+Elizabeth looked archly, and turned away. Her resistance had not
+injured her with the gentleman, and he was thinking of her with some
+complacency, when thus accosted by Miss Bingley:
+
+“I can guess the subject of your reverie.”
+
+“I should imagine not.”
+
+“You are considering how insupportable it would be to pass many evenings
+in this manner--in such society; and indeed I am quite of your opinion.
+I was never more annoyed! The insipidity, and yet the noise--the
+nothingness, and yet the self-importance of all those people! What would
+I give to hear your strictures on them!”
+
+“Your conjecture is totally wrong, I assure you. My mind was more
+agreeably engaged. I have been meditating on the very great pleasure
+which a pair of fine eyes in the face of a pretty woman can bestow.”
+
+Miss Bingley immediately fixed her eyes on his face, and desired he
+would tell her what lady had the credit of inspiring such reflections.
+Mr. Darcy replied with great intrepidity:
+
+“Miss Elizabeth Bennet.”
+
+“Miss Elizabeth Bennet!” repeated Miss Bingley. “I am all astonishment.
+How long has she been such a favourite?--and pray, when am I to wish you
+joy?”
+
+“That is exactly the question which I expected you to ask. A lady’s
+imagination is very rapid; it jumps from admiration to love, from love
+to matrimony, in a moment. I knew you would be wishing me joy.”
+
+“Nay, if you are serious about it, I shall consider the matter is
+absolutely settled. You will be having a charming mother-in-law, indeed;
+and, of course, she will always be at Pemberley with you.”
+
+He listened to her with perfect indifference while she chose to
+entertain herself in this manner; and as his composure convinced her
+that all was safe, her wit flowed long.
+
+
+
+Chapter 7
+
+
+Mr. Bennet’s property consisted almost entirely in an estate of two
+thousand a year, which, unfortunately for his daughters, was entailed,
+in default of heirs male, on a distant relation; and their mother’s
+fortune, though ample for her situation in life, could but ill supply
+the deficiency of his. Her father had been an attorney in Meryton, and
+had left her four thousand pounds.
+
+She had a sister married to a Mr. Phillips, who had been a clerk to
+their father and succeeded him in the business, and a brother settled in
+London in a respectable line of trade.
+
+The village of Longbourn was only one mile from Meryton; a most
+convenient distance for the young ladies, who were usually tempted
+thither three or four times a week, to pay their duty to their aunt and
+to a milliner’s shop just over the way. The two youngest of the family,
+Catherine and Lydia, were particularly frequent in these attentions;
+their minds were more vacant than their sisters’, and when nothing
+better offered, a walk to Meryton was necessary to amuse their morning
+hours and furnish conversation for the evening; and however bare of news
+the country in general might be, they always contrived to learn some
+from their aunt. At present, indeed, they were well supplied both with
+news and happiness by the recent arrival of a militia regiment in the
+neighbourhood; it was to remain the whole winter, and Meryton was the
+headquarters.
+
+Their visits to Mrs. Phillips were now productive of the most
+interesting intelligence. Every day added something to their knowledge
+of the officers’ names and connections. Their lodgings were not long a
+secret, and at length they began to know the officers themselves. Mr.
+Phillips visited them all, and this opened to his nieces a store of
+felicity unknown before. They could talk of nothing but officers; and
+Mr. Bingley’s large fortune, the mention of which gave animation
+to their mother, was worthless in their eyes when opposed to the
+regimentals of an ensign.
+
+After listening one morning to their effusions on this subject, Mr.
+Bennet coolly observed:
+
+“From all that I can collect by your manner of talking, you must be two
+of the silliest girls in the country. I have suspected it some time, but
+I am now convinced.”
+
+Catherine was disconcerted, and made no answer; but Lydia, with perfect
+indifference, continued to express her admiration of Captain Carter,
+and her hope of seeing him in the course of the day, as he was going the
+next morning to London.
+
+“I am astonished, my dear,” said Mrs. Bennet, “that you should be so
+ready to think your own children silly. If I wished to think slightingly
+of anybody’s children, it should not be of my own, however.”
+
+“If my children are silly, I must hope to be always sensible of it.”
+
+“Yes--but as it happens, they are all of them very clever.”
+
+“This is the only point, I flatter myself, on which we do not agree. I
+had hoped that our sentiments coincided in every particular, but I must
+so far differ from you as to think our two youngest daughters uncommonly
+foolish.”
+
+“My dear Mr. Bennet, you must not expect such girls to have the sense of
+their father and mother. When they get to our age, I dare say they will
+not think about officers any more than we do. I remember the time when
+I liked a red coat myself very well--and, indeed, so I do still at my
+heart; and if a smart young colonel, with five or six thousand a year,
+should want one of my girls I shall not say nay to him; and I thought
+Colonel Forster looked very becoming the other night at Sir William’s in
+his regimentals.”
+
+“Mamma,” cried Lydia, “my aunt says that Colonel Forster and Captain
+Carter do not go so often to Miss Watson’s as they did when they first
+came; she sees them now very often standing in Clarke’s library.”
+
+Mrs. Bennet was prevented replying by the entrance of the footman with
+a note for Miss Bennet; it came from Netherfield, and the servant waited
+for an answer. Mrs. Bennet’s eyes sparkled with pleasure, and she was
+eagerly calling out, while her daughter read,
+
+“Well, Jane, who is it from? What is it about? What does he say? Well,
+Jane, make haste and tell us; make haste, my love.”
+
+“It is from Miss Bingley,” said Jane, and then read it aloud.
+
+“MY DEAR FRIEND,--
+
+“If you are not so compassionate as to dine to-day with Louisa and me,
+we shall be in danger of hating each other for the rest of our lives,
+for a whole day’s tete-a-tete between two women can never end without a
+quarrel. Come as soon as you can on receipt of this. My brother and the
+gentlemen are to dine with the officers.--Yours ever,
+
+“CAROLINE BINGLEY”
+
+“With the officers!” cried Lydia. “I wonder my aunt did not tell us of
+_that_.”
+
+“Dining out,” said Mrs. Bennet, “that is very unlucky.”
+
+“Can I have the carriage?” said Jane.
+
+“No, my dear, you had better go on horseback, because it seems likely to
+rain; and then you must stay all night.”
+
+“That would be a good scheme,” said Elizabeth, “if you were sure that
+they would not offer to send her home.”
+
+“Oh! but the gentlemen will have Mr. Bingley’s chaise to go to Meryton,
+and the Hursts have no horses to theirs.”
+
+“I had much rather go in the coach.”
+
+“But, my dear, your father cannot spare the horses, I am sure. They are
+wanted in the farm, Mr. Bennet, are they not?”
+
+“They are wanted in the farm much oftener than I can get them.”
+
+“But if you have got them to-day,” said Elizabeth, “my mother’s purpose
+will be answered.”
+
+She did at last extort from her father an acknowledgment that the horses
+were engaged. Jane was therefore obliged to go on horseback, and her
+mother attended her to the door with many cheerful prognostics of a
+bad day. Her hopes were answered; Jane had not been gone long before
+it rained hard. Her sisters were uneasy for her, but her mother was
+delighted. The rain continued the whole evening without intermission;
+Jane certainly could not come back.
+
+“This was a lucky idea of mine, indeed!” said Mrs. Bennet more than
+once, as if the credit of making it rain were all her own. Till the
+next morning, however, she was not aware of all the felicity of her
+contrivance. Breakfast was scarcely over when a servant from Netherfield
+brought the following note for Elizabeth:
+
+“MY DEAREST LIZZY,--
+
+“I find myself very unwell this morning, which, I suppose, is to be
+imputed to my getting wet through yesterday. My kind friends will not
+hear of my returning till I am better. They insist also on my seeing Mr.
+Jones--therefore do not be alarmed if you should hear of his having been
+to me--and, excepting a sore throat and headache, there is not much the
+matter with me.--Yours, etc.”
+
+“Well, my dear,” said Mr. Bennet, when Elizabeth had read the note
+aloud, “if your daughter should have a dangerous fit of illness--if she
+should die, it would be a comfort to know that it was all in pursuit of
+Mr. Bingley, and under your orders.”
+
+“Oh! I am not afraid of her dying. People do not die of little trifling
+colds. She will be taken good care of. As long as she stays there, it is
+all very well. I would go and see her if I could have the carriage.”
+
+Elizabeth, feeling really anxious, was determined to go to her, though
+the carriage was not to be had; and as she was no horsewoman, walking
+was her only alternative. She declared her resolution.
+
+“How can you be so silly,” cried her mother, “as to think of such a
+thing, in all this dirt! You will not be fit to be seen when you get
+there.”
+
+“I shall be very fit to see Jane--which is all I want.”
+
+“Is this a hint to me, Lizzy,” said her father, “to send for the
+horses?”
+
+“No, indeed, I do not wish to avoid the walk. The distance is nothing
+when one has a motive; only three miles. I shall be back by dinner.”
+
+“I admire the activity of your benevolence,” observed Mary, “but every
+impulse of feeling should be guided by reason; and, in my opinion,
+exertion should always be in proportion to what is required.”
+
+“We will go as far as Meryton with you,” said Catherine and Lydia.
+Elizabeth accepted their company, and the three young ladies set off
+together.
+
+“If we make haste,” said Lydia, as they walked along, “perhaps we may
+see something of Captain Carter before he goes.”
+
+In Meryton they parted; the two youngest repaired to the lodgings of one
+of the officers’ wives, and Elizabeth continued her walk alone, crossing
+field after field at a quick pace, jumping over stiles and springing
+over puddles with impatient activity, and finding herself at last
+within view of the house, with weary ankles, dirty stockings, and a face
+glowing with the warmth of exercise.
+
+She was shown into the breakfast-parlour, where all but Jane were
+assembled, and where her appearance created a great deal of surprise.
+That she should have walked three miles so early in the day, in such
+dirty weather, and by herself, was almost incredible to Mrs. Hurst and
+Miss Bingley; and Elizabeth was convinced that they held her in contempt
+for it. She was received, however, very politely by them; and in their
+brother’s manners there was something better than politeness; there
+was good humour and kindness. Mr. Darcy said very little, and Mr.
+Hurst nothing at all. The former was divided between admiration of the
+brilliancy which exercise had given to her complexion, and doubt as
+to the occasion’s justifying her coming so far alone. The latter was
+thinking only of his breakfast.
+
+Her inquiries after her sister were not very favourably answered. Miss
+Bennet had slept ill, and though up, was very feverish, and not
+well enough to leave her room. Elizabeth was glad to be taken to her
+immediately; and Jane, who had only been withheld by the fear of giving
+alarm or inconvenience from expressing in her note how much she longed
+for such a visit, was delighted at her entrance. She was not equal,
+however, to much conversation, and when Miss Bingley left them
+together, could attempt little besides expressions of gratitude for the
+extraordinary kindness she was treated with. Elizabeth silently attended
+her.
+
+When breakfast was over they were joined by the sisters; and Elizabeth
+began to like them herself, when she saw how much affection and
+solicitude they showed for Jane. The apothecary came, and having
+examined his patient, said, as might be supposed, that she had caught
+a violent cold, and that they must endeavour to get the better of it;
+advised her to return to bed, and promised her some draughts. The advice
+was followed readily, for the feverish symptoms increased, and her head
+ached acutely. Elizabeth did not quit her room for a moment; nor were
+the other ladies often absent; the gentlemen being out, they had, in
+fact, nothing to do elsewhere.
+
+When the clock struck three, Elizabeth felt that she must go, and very
+unwillingly said so. Miss Bingley offered her the carriage, and she only
+wanted a little pressing to accept it, when Jane testified such concern
+in parting with her, that Miss Bingley was obliged to convert the offer
+of the chaise to an invitation to remain at Netherfield for the present.
+Elizabeth most thankfully consented, and a servant was dispatched to
+Longbourn to acquaint the family with her stay and bring back a supply
+of clothes.
+
+
+
+Chapter 8
+
+
+At five o’clock the two ladies retired to dress, and at half-past six
+Elizabeth was summoned to dinner. To the civil inquiries which then
+poured in, and amongst which she had the pleasure of distinguishing the
+much superior solicitude of Mr. Bingley’s, she could not make a very
+favourable answer. Jane was by no means better. The sisters, on hearing
+this, repeated three or four times how much they were grieved, how
+shocking it was to have a bad cold, and how excessively they disliked
+being ill themselves; and then thought no more of the matter: and their
+indifference towards Jane when not immediately before them restored
+Elizabeth to the enjoyment of all her former dislike.
+
+Their brother, indeed, was the only one of the party whom she could
+regard with any complacency. His anxiety for Jane was evident, and his
+attentions to herself most pleasing, and they prevented her feeling
+herself so much an intruder as she believed she was considered by the
+others. She had very little notice from any but him. Miss Bingley was
+engrossed by Mr. Darcy, her sister scarcely less so; and as for Mr.
+Hurst, by whom Elizabeth sat, he was an indolent man, who lived only to
+eat, drink, and play at cards; who, when he found her to prefer a plain
+dish to a ragout, had nothing to say to her.
+
+When dinner was over, she returned directly to Jane, and Miss Bingley
+began abusing her as soon as she was out of the room. Her manners were
+pronounced to be very bad indeed, a mixture of pride and impertinence;
+she had no conversation, no style, no beauty. Mrs. Hurst thought the
+same, and added:
+
+“She has nothing, in short, to recommend her, but being an excellent
+walker. I shall never forget her appearance this morning. She really
+looked almost wild.”
+
+“She did, indeed, Louisa. I could hardly keep my countenance. Very
+nonsensical to come at all! Why must _she_ be scampering about the
+country, because her sister had a cold? Her hair, so untidy, so blowsy!”
+
+“Yes, and her petticoat; I hope you saw her petticoat, six inches deep
+in mud, I am absolutely certain; and the gown which had been let down to
+hide it not doing its office.”
+
+“Your picture may be very exact, Louisa,” said Bingley; “but this was
+all lost upon me. I thought Miss Elizabeth Bennet looked remarkably
+well when she came into the room this morning. Her dirty petticoat quite
+escaped my notice.”
+
+“_You_ observed it, Mr. Darcy, I am sure,” said Miss Bingley; “and I am
+inclined to think that you would not wish to see _your_ sister make such
+an exhibition.”
+
+“Certainly not.”
+
+“To walk three miles, or four miles, or five miles, or whatever it is,
+above her ankles in dirt, and alone, quite alone! What could she mean by
+it? It seems to me to show an abominable sort of conceited independence,
+a most country-town indifference to decorum.”
+
+“It shows an affection for her sister that is very pleasing,” said
+Bingley.
+
+“I am afraid, Mr. Darcy,” observed Miss Bingley in a half whisper, “that
+this adventure has rather affected your admiration of her fine eyes.”
+
+“Not at all,” he replied; “they were brightened by the exercise.” A
+short pause followed this speech, and Mrs. Hurst began again:
+
+“I have an excessive regard for Miss Jane Bennet, she is really a very
+sweet girl, and I wish with all my heart she were well settled. But with
+such a father and mother, and such low connections, I am afraid there is
+no chance of it.”
+
+“I think I have heard you say that their uncle is an attorney in
+Meryton.”
+
+“Yes; and they have another, who lives somewhere near Cheapside.”
+
+“That is capital,” added her sister, and they both laughed heartily.
+
+“If they had uncles enough to fill _all_ Cheapside,” cried Bingley, “it
+would not make them one jot less agreeable.”
+
+“But it must very materially lessen their chance of marrying men of any
+consideration in the world,” replied Darcy.
+
+To this speech Bingley made no answer; but his sisters gave it their
+hearty assent, and indulged their mirth for some time at the expense of
+their dear friend’s vulgar relations.
+
+With a renewal of tenderness, however, they returned to her room on
+leaving the dining-parlour, and sat with her till summoned to coffee.
+She was still very poorly, and Elizabeth would not quit her at all, till
+late in the evening, when she had the comfort of seeing her sleep, and
+when it seemed to her rather right than pleasant that she should go
+downstairs herself. On entering the drawing-room she found the whole
+party at loo, and was immediately invited to join them; but suspecting
+them to be playing high she declined it, and making her sister the
+excuse, said she would amuse herself for the short time she could stay
+below, with a book. Mr. Hurst looked at her with astonishment.
+
+“Do you prefer reading to cards?” said he; “that is rather singular.”
+
+“Miss Eliza Bennet,” said Miss Bingley, “despises cards. She is a great
+reader, and has no pleasure in anything else.”
+
+“I deserve neither such praise nor such censure,” cried Elizabeth; “I am
+_not_ a great reader, and I have pleasure in many things.”
+
+“In nursing your sister I am sure you have pleasure,” said Bingley; “and
+I hope it will be soon increased by seeing her quite well.”
+
+Elizabeth thanked him from her heart, and then walked towards the
+table where a few books were lying. He immediately offered to fetch her
+others--all that his library afforded.
+
+“And I wish my collection were larger for your benefit and my own
+credit; but I am an idle fellow, and though I have not many, I have more
+than I ever looked into.”
+
+Elizabeth assured him that she could suit herself perfectly with those
+in the room.
+
+“I am astonished,” said Miss Bingley, “that my father should have left
+so small a collection of books. What a delightful library you have at
+Pemberley, Mr. Darcy!”
+
+“It ought to be good,” he replied, “it has been the work of many
+generations.”
+
+“And then you have added so much to it yourself, you are always buying
+books.”
+
+“I cannot comprehend the neglect of a family library in such days as
+these.”
+
+“Neglect! I am sure you neglect nothing that can add to the beauties of
+that noble place. Charles, when you build _your_ house, I wish it may be
+half as delightful as Pemberley.”
+
+“I wish it may.”
+
+“But I would really advise you to make your purchase in that
+neighbourhood, and take Pemberley for a kind of model. There is not a
+finer county in England than Derbyshire.”
+
+“With all my heart; I will buy Pemberley itself if Darcy will sell it.”
+
+“I am talking of possibilities, Charles.”
+
+“Upon my word, Caroline, I should think it more possible to get
+Pemberley by purchase than by imitation.”
+
+Elizabeth was so much caught with what passed, as to leave her very
+little attention for her book; and soon laying it wholly aside, she drew
+near the card-table, and stationed herself between Mr. Bingley and his
+eldest sister, to observe the game.
+
+“Is Miss Darcy much grown since the spring?” said Miss Bingley; “will
+she be as tall as I am?”
+
+“I think she will. She is now about Miss Elizabeth Bennet’s height, or
+rather taller.”
+
+“How I long to see her again! I never met with anybody who delighted me
+so much. Such a countenance, such manners! And so extremely accomplished
+for her age! Her performance on the pianoforte is exquisite.”
+
+“It is amazing to me,” said Bingley, “how young ladies can have patience
+to be so very accomplished as they all are.”
+
+“All young ladies accomplished! My dear Charles, what do you mean?”
+
+“Yes, all of them, I think. They all paint tables, cover screens, and
+net purses. I scarcely know anyone who cannot do all this, and I am sure
+I never heard a young lady spoken of for the first time, without being
+informed that she was very accomplished.”
+
+“Your list of the common extent of accomplishments,” said Darcy, “has
+too much truth. The word is applied to many a woman who deserves it no
+otherwise than by netting a purse or covering a screen. But I am very
+far from agreeing with you in your estimation of ladies in general. I
+cannot boast of knowing more than half-a-dozen, in the whole range of my
+acquaintance, that are really accomplished.”
+
+“Nor I, I am sure,” said Miss Bingley.
+
+“Then,” observed Elizabeth, “you must comprehend a great deal in your
+idea of an accomplished woman.”
+
+“Yes, I do comprehend a great deal in it.”
+
+“Oh! certainly,” cried his faithful assistant, “no one can be really
+esteemed accomplished who does not greatly surpass what is usually met
+with. A woman must have a thorough knowledge of music, singing, drawing,
+dancing, and the modern languages, to deserve the word; and besides
+all this, she must possess a certain something in her air and manner of
+walking, the tone of her voice, her address and expressions, or the word
+will be but half-deserved.”
+
+“All this she must possess,” added Darcy, “and to all this she must
+yet add something more substantial, in the improvement of her mind by
+extensive reading.”
+
+“I am no longer surprised at your knowing _only_ six accomplished women.
+I rather wonder now at your knowing _any_.”
+
+“Are you so severe upon your own sex as to doubt the possibility of all
+this?”
+
+“I never saw such a woman. I never saw such capacity, and taste, and
+application, and elegance, as you describe united.”
+
+Mrs. Hurst and Miss Bingley both cried out against the injustice of her
+implied doubt, and were both protesting that they knew many women who
+answered this description, when Mr. Hurst called them to order, with
+bitter complaints of their inattention to what was going forward. As all
+conversation was thereby at an end, Elizabeth soon afterwards left the
+room.
+
+“Elizabeth Bennet,” said Miss Bingley, when the door was closed on her,
+“is one of those young ladies who seek to recommend themselves to the
+other sex by undervaluing their own; and with many men, I dare say, it
+succeeds. But, in my opinion, it is a paltry device, a very mean art.”
+
+“Undoubtedly,” replied Darcy, to whom this remark was chiefly addressed,
+“there is a meanness in _all_ the arts which ladies sometimes condescend
+to employ for captivation. Whatever bears affinity to cunning is
+despicable.”
+
+Miss Bingley was not so entirely satisfied with this reply as to
+continue the subject.
+
+Elizabeth joined them again only to say that her sister was worse, and
+that she could not leave her. Bingley urged Mr. Jones being sent for
+immediately; while his sisters, convinced that no country advice could
+be of any service, recommended an express to town for one of the most
+eminent physicians. This she would not hear of; but she was not so
+unwilling to comply with their brother’s proposal; and it was settled
+that Mr. Jones should be sent for early in the morning, if Miss Bennet
+were not decidedly better. Bingley was quite uncomfortable; his sisters
+declared that they were miserable. They solaced their wretchedness,
+however, by duets after supper, while he could find no better relief
+to his feelings than by giving his housekeeper directions that every
+attention might be paid to the sick lady and her sister.
+
+
+
+Chapter 9
+
+
+Elizabeth passed the chief of the night in her sister’s room, and in the
+morning had the pleasure of being able to send a tolerable answer to the
+inquiries which she very early received from Mr. Bingley by a housemaid,
+and some time afterwards from the two elegant ladies who waited on his
+sisters. In spite of this amendment, however, she requested to have a
+note sent to Longbourn, desiring her mother to visit Jane, and form her
+own judgement of her situation. The note was immediately dispatched, and
+its contents as quickly complied with. Mrs. Bennet, accompanied by her
+two youngest girls, reached Netherfield soon after the family breakfast.
+
+Had she found Jane in any apparent danger, Mrs. Bennet would have been
+very miserable; but being satisfied on seeing her that her illness was
+not alarming, she had no wish of her recovering immediately, as her
+restoration to health would probably remove her from Netherfield. She
+would not listen, therefore, to her daughter’s proposal of being carried
+home; neither did the apothecary, who arrived about the same time, think
+it at all advisable. After sitting a little while with Jane, on Miss
+Bingley’s appearance and invitation, the mother and three daughters all
+attended her into the breakfast parlour. Bingley met them with hopes
+that Mrs. Bennet had not found Miss Bennet worse than she expected.
+
+“Indeed I have, sir,” was her answer. “She is a great deal too ill to be
+moved. Mr. Jones says we must not think of moving her. We must trespass
+a little longer on your kindness.”
+
+“Removed!” cried Bingley. “It must not be thought of. My sister, I am
+sure, will not hear of her removal.”
+
+“You may depend upon it, Madam,” said Miss Bingley, with cold civility,
+“that Miss Bennet will receive every possible attention while she
+remains with us.”
+
+Mrs. Bennet was profuse in her acknowledgments.
+
+“I am sure,” she added, “if it was not for such good friends I do not
+know what would become of her, for she is very ill indeed, and suffers
+a vast deal, though with the greatest patience in the world, which is
+always the way with her, for she has, without exception, the sweetest
+temper I have ever met with. I often tell my other girls they are
+nothing to _her_. You have a sweet room here, Mr. Bingley, and a
+charming prospect over the gravel walk. I do not know a place in the
+country that is equal to Netherfield. You will not think of quitting it
+in a hurry, I hope, though you have but a short lease.”
+
+“Whatever I do is done in a hurry,” replied he; “and therefore if I
+should resolve to quit Netherfield, I should probably be off in five
+minutes. At present, however, I consider myself as quite fixed here.”
+
+“That is exactly what I should have supposed of you,” said Elizabeth.
+
+“You begin to comprehend me, do you?” cried he, turning towards her.
+
+“Oh! yes--I understand you perfectly.”
+
+“I wish I might take this for a compliment; but to be so easily seen
+through I am afraid is pitiful.”
+
+“That is as it happens. It does not follow that a deep, intricate
+character is more or less estimable than such a one as yours.”
+
+“Lizzy,” cried her mother, “remember where you are, and do not run on in
+the wild manner that you are suffered to do at home.”
+
+“I did not know before,” continued Bingley immediately, “that you were a
+studier of character. It must be an amusing study.”
+
+“Yes, but intricate characters are the _most_ amusing. They have at
+least that advantage.”
+
+“The country,” said Darcy, “can in general supply but a few subjects for
+such a study. In a country neighbourhood you move in a very confined and
+unvarying society.”
+
+“But people themselves alter so much, that there is something new to be
+observed in them for ever.”
+
+“Yes, indeed,” cried Mrs. Bennet, offended by his manner of mentioning
+a country neighbourhood. “I assure you there is quite as much of _that_
+going on in the country as in town.”
+
+Everybody was surprised, and Darcy, after looking at her for a moment,
+turned silently away. Mrs. Bennet, who fancied she had gained a complete
+victory over him, continued her triumph.
+
+“I cannot see that London has any great advantage over the country, for
+my part, except the shops and public places. The country is a vast deal
+pleasanter, is it not, Mr. Bingley?”
+
+“When I am in the country,” he replied, “I never wish to leave it;
+and when I am in town it is pretty much the same. They have each their
+advantages, and I can be equally happy in either.”
+
+“Aye--that is because you have the right disposition. But that
+gentleman,” looking at Darcy, “seemed to think the country was nothing
+at all.”
+
+“Indeed, Mamma, you are mistaken,” said Elizabeth, blushing for her
+mother. “You quite mistook Mr. Darcy. He only meant that there was not
+such a variety of people to be met with in the country as in the town,
+which you must acknowledge to be true.”
+
+“Certainly, my dear, nobody said there were; but as to not meeting
+with many people in this neighbourhood, I believe there are few
+neighbourhoods larger. I know we dine with four-and-twenty families.”
+
+Nothing but concern for Elizabeth could enable Bingley to keep his
+countenance. His sister was less delicate, and directed her eyes towards
+Mr. Darcy with a very expressive smile. Elizabeth, for the sake of
+saying something that might turn her mother’s thoughts, now asked her if
+Charlotte Lucas had been at Longbourn since _her_ coming away.
+
+“Yes, she called yesterday with her father. What an agreeable man Sir
+William is, Mr. Bingley, is not he? So much the man of fashion! So
+genteel and easy! He has always something to say to everybody. _That_
+is my idea of good breeding; and those persons who fancy themselves very
+important, and never open their mouths, quite mistake the matter.”
+
+“Did Charlotte dine with you?”
+
+“No, she would go home. I fancy she was wanted about the mince-pies. For
+my part, Mr. Bingley, I always keep servants that can do their own work;
+_my_ daughters are brought up very differently. But everybody is to
+judge for themselves, and the Lucases are a very good sort of girls,
+I assure you. It is a pity they are not handsome! Not that I think
+Charlotte so _very_ plain--but then she is our particular friend.”
+
+“She seems a very pleasant young woman.”
+
+“Oh! dear, yes; but you must own she is very plain. Lady Lucas herself
+has often said so, and envied me Jane’s beauty. I do not like to boast
+of my own child, but to be sure, Jane--one does not often see anybody
+better looking. It is what everybody says. I do not trust my own
+partiality. When she was only fifteen, there was a man at my brother
+Gardiner’s in town so much in love with her that my sister-in-law was
+sure he would make her an offer before we came away. But, however, he
+did not. Perhaps he thought her too young. However, he wrote some verses
+on her, and very pretty they were.”
+
+“And so ended his affection,” said Elizabeth impatiently. “There has
+been many a one, I fancy, overcome in the same way. I wonder who first
+discovered the efficacy of poetry in driving away love!”
+
+“I have been used to consider poetry as the _food_ of love,” said Darcy.
+
+“Of a fine, stout, healthy love it may. Everything nourishes what is
+strong already. But if it be only a slight, thin sort of inclination, I
+am convinced that one good sonnet will starve it entirely away.”
+
+Darcy only smiled; and the general pause which ensued made Elizabeth
+tremble lest her mother should be exposing herself again. She longed to
+speak, but could think of nothing to say; and after a short silence Mrs.
+Bennet began repeating her thanks to Mr. Bingley for his kindness to
+Jane, with an apology for troubling him also with Lizzy. Mr. Bingley was
+unaffectedly civil in his answer, and forced his younger sister to be
+civil also, and say what the occasion required. She performed her part
+indeed without much graciousness, but Mrs. Bennet was satisfied, and
+soon afterwards ordered her carriage. Upon this signal, the youngest of
+her daughters put herself forward. The two girls had been whispering to
+each other during the whole visit, and the result of it was, that the
+youngest should tax Mr. Bingley with having promised on his first coming
+into the country to give a ball at Netherfield.
+
+Lydia was a stout, well-grown girl of fifteen, with a fine complexion
+and good-humoured countenance; a favourite with her mother, whose
+affection had brought her into public at an early age. She had high
+animal spirits, and a sort of natural self-consequence, which the
+attention of the officers, to whom her uncle’s good dinners, and her own
+easy manners recommended her, had increased into assurance. She was very
+equal, therefore, to address Mr. Bingley on the subject of the ball, and
+abruptly reminded him of his promise; adding, that it would be the most
+shameful thing in the world if he did not keep it. His answer to this
+sudden attack was delightful to their mother’s ear:
+
+“I am perfectly ready, I assure you, to keep my engagement; and when
+your sister is recovered, you shall, if you please, name the very day of
+the ball. But you would not wish to be dancing when she is ill.”
+
+Lydia declared herself satisfied. “Oh! yes--it would be much better to
+wait till Jane was well, and by that time most likely Captain Carter
+would be at Meryton again. And when you have given _your_ ball,” she
+added, “I shall insist on their giving one also. I shall tell Colonel
+Forster it will be quite a shame if he does not.”
+
+Mrs. Bennet and her daughters then departed, and Elizabeth returned
+instantly to Jane, leaving her own and her relations’ behaviour to the
+remarks of the two ladies and Mr. Darcy; the latter of whom, however,
+could not be prevailed on to join in their censure of _her_, in spite of
+all Miss Bingley’s witticisms on _fine eyes_.
+
+
+
+Chapter 10
+
+
+The day passed much as the day before had done. Mrs. Hurst and Miss
+Bingley had spent some hours of the morning with the invalid, who
+continued, though slowly, to mend; and in the evening Elizabeth joined
+their party in the drawing-room. The loo-table, however, did not appear.
+Mr. Darcy was writing, and Miss Bingley, seated near him, was watching
+the progress of his letter and repeatedly calling off his attention by
+messages to his sister. Mr. Hurst and Mr. Bingley were at piquet, and
+Mrs. Hurst was observing their game.
+
+Elizabeth took up some needlework, and was sufficiently amused in
+attending to what passed between Darcy and his companion. The perpetual
+commendations of the lady, either on his handwriting, or on the evenness
+of his lines, or on the length of his letter, with the perfect unconcern
+with which her praises were received, formed a curious dialogue, and was
+exactly in union with her opinion of each.
+
+“How delighted Miss Darcy will be to receive such a letter!”
+
+He made no answer.
+
+“You write uncommonly fast.”
+
+“You are mistaken. I write rather slowly.”
+
+“How many letters you must have occasion to write in the course of a
+year! Letters of business, too! How odious I should think them!”
+
+“It is fortunate, then, that they fall to my lot instead of yours.”
+
+“Pray tell your sister that I long to see her.”
+
+“I have already told her so once, by your desire.”
+
+“I am afraid you do not like your pen. Let me mend it for you. I mend
+pens remarkably well.”
+
+“Thank you--but I always mend my own.”
+
+“How can you contrive to write so even?”
+
+He was silent.
+
+“Tell your sister I am delighted to hear of her improvement on the harp;
+and pray let her know that I am quite in raptures with her beautiful
+little design for a table, and I think it infinitely superior to Miss
+Grantley’s.”
+
+“Will you give me leave to defer your raptures till I write again? At
+present I have not room to do them justice.”
+
+“Oh! it is of no consequence. I shall see her in January. But do you
+always write such charming long letters to her, Mr. Darcy?”
+
+“They are generally long; but whether always charming it is not for me
+to determine.”
+
+“It is a rule with me, that a person who can write a long letter with
+ease, cannot write ill.”
+
+“That will not do for a compliment to Darcy, Caroline,” cried her
+brother, “because he does _not_ write with ease. He studies too much for
+words of four syllables. Do not you, Darcy?”
+
+“My style of writing is very different from yours.”
+
+“Oh!” cried Miss Bingley, “Charles writes in the most careless way
+imaginable. He leaves out half his words, and blots the rest.”
+
+“My ideas flow so rapidly that I have not time to express them--by which
+means my letters sometimes convey no ideas at all to my correspondents.”
+
+“Your humility, Mr. Bingley,” said Elizabeth, “must disarm reproof.”
+
+“Nothing is more deceitful,” said Darcy, “than the appearance of
+humility. It is often only carelessness of opinion, and sometimes an
+indirect boast.”
+
+“And which of the two do you call _my_ little recent piece of modesty?”
+
+“The indirect boast; for you are really proud of your defects in
+writing, because you consider them as proceeding from a rapidity of
+thought and carelessness of execution, which, if not estimable, you
+think at least highly interesting. The power of doing anything with
+quickness is always prized much by the possessor, and often without any
+attention to the imperfection of the performance. When you told Mrs.
+Bennet this morning that if you ever resolved upon quitting Netherfield
+you should be gone in five minutes, you meant it to be a sort of
+panegyric, of compliment to yourself--and yet what is there so very
+laudable in a precipitance which must leave very necessary business
+undone, and can be of no real advantage to yourself or anyone else?”
+
+“Nay,” cried Bingley, “this is too much, to remember at night all the
+foolish things that were said in the morning. And yet, upon my honour,
+I believe what I said of myself to be true, and I believe it at this
+moment. At least, therefore, I did not assume the character of needless
+precipitance merely to show off before the ladies.”
+
+“I dare say you believed it; but I am by no means convinced that
+you would be gone with such celerity. Your conduct would be quite as
+dependent on chance as that of any man I know; and if, as you were
+mounting your horse, a friend were to say, ‘Bingley, you had better
+stay till next week,’ you would probably do it, you would probably not
+go--and at another word, might stay a month.”
+
+“You have only proved by this,” cried Elizabeth, “that Mr. Bingley did
+not do justice to his own disposition. You have shown him off now much
+more than he did himself.”
+
+“I am exceedingly gratified,” said Bingley, “by your converting what my
+friend says into a compliment on the sweetness of my temper. But I am
+afraid you are giving it a turn which that gentleman did by no means
+intend; for he would certainly think better of me, if under such a
+circumstance I were to give a flat denial, and ride off as fast as I
+could.”
+
+“Would Mr. Darcy then consider the rashness of your original intentions
+as atoned for by your obstinacy in adhering to it?”
+
+“Upon my word, I cannot exactly explain the matter; Darcy must speak for
+himself.”
+
+“You expect me to account for opinions which you choose to call mine,
+but which I have never acknowledged. Allowing the case, however, to
+stand according to your representation, you must remember, Miss Bennet,
+that the friend who is supposed to desire his return to the house, and
+the delay of his plan, has merely desired it, asked it without offering
+one argument in favour of its propriety.”
+
+“To yield readily--easily--to the _persuasion_ of a friend is no merit
+with you.”
+
+“To yield without conviction is no compliment to the understanding of
+either.”
+
+“You appear to me, Mr. Darcy, to allow nothing for the influence of
+friendship and affection. A regard for the requester would often make
+one readily yield to a request, without waiting for arguments to reason
+one into it. I am not particularly speaking of such a case as you have
+supposed about Mr. Bingley. We may as well wait, perhaps, till the
+circumstance occurs before we discuss the discretion of his behaviour
+thereupon. But in general and ordinary cases between friend and friend,
+where one of them is desired by the other to change a resolution of no
+very great moment, should you think ill of that person for complying
+with the desire, without waiting to be argued into it?”
+
+“Will it not be advisable, before we proceed on this subject, to
+arrange with rather more precision the degree of importance which is to
+appertain to this request, as well as the degree of intimacy subsisting
+between the parties?”
+
+“By all means,” cried Bingley; “let us hear all the particulars, not
+forgetting their comparative height and size; for that will have more
+weight in the argument, Miss Bennet, than you may be aware of. I assure
+you, that if Darcy were not such a great tall fellow, in comparison with
+myself, I should not pay him half so much deference. I declare I do not
+know a more awful object than Darcy, on particular occasions, and in
+particular places; at his own house especially, and of a Sunday evening,
+when he has nothing to do.”
+
+Mr. Darcy smiled; but Elizabeth thought she could perceive that he was
+rather offended, and therefore checked her laugh. Miss Bingley warmly
+resented the indignity he had received, in an expostulation with her
+brother for talking such nonsense.
+
+“I see your design, Bingley,” said his friend. “You dislike an argument,
+and want to silence this.”
+
+“Perhaps I do. Arguments are too much like disputes. If you and Miss
+Bennet will defer yours till I am out of the room, I shall be very
+thankful; and then you may say whatever you like of me.”
+
+“What you ask,” said Elizabeth, “is no sacrifice on my side; and Mr.
+Darcy had much better finish his letter.”
+
+Mr. Darcy took her advice, and did finish his letter.
+
+When that business was over, he applied to Miss Bingley and Elizabeth
+for an indulgence of some music. Miss Bingley moved with some alacrity
+to the pianoforte; and, after a polite request that Elizabeth would lead
+the way which the other as politely and more earnestly negatived, she
+seated herself.
+
+Mrs. Hurst sang with her sister, and while they were thus employed,
+Elizabeth could not help observing, as she turned over some music-books
+that lay on the instrument, how frequently Mr. Darcy’s eyes were fixed
+on her. She hardly knew how to suppose that she could be an object of
+admiration to so great a man; and yet that he should look at her
+because he disliked her, was still more strange. She could only imagine,
+however, at last that she drew his notice because there was something
+more wrong and reprehensible, according to his ideas of right, than in
+any other person present. The supposition did not pain her. She liked
+him too little to care for his approbation.
+
+After playing some Italian songs, Miss Bingley varied the charm by
+a lively Scotch air; and soon afterwards Mr. Darcy, drawing near
+Elizabeth, said to her:
+
+“Do not you feel a great inclination, Miss Bennet, to seize such an
+opportunity of dancing a reel?”
+
+She smiled, but made no answer. He repeated the question, with some
+surprise at her silence.
+
+“Oh!” said she, “I heard you before, but I could not immediately
+determine what to say in reply. You wanted me, I know, to say ‘Yes,’
+that you might have the pleasure of despising my taste; but I always
+delight in overthrowing those kind of schemes, and cheating a person of
+their premeditated contempt. I have, therefore, made up my mind to tell
+you, that I do not want to dance a reel at all--and now despise me if
+you dare.”
+
+“Indeed I do not dare.”
+
+Elizabeth, having rather expected to affront him, was amazed at his
+gallantry; but there was a mixture of sweetness and archness in her
+manner which made it difficult for her to affront anybody; and Darcy
+had never been so bewitched by any woman as he was by her. He really
+believed, that were it not for the inferiority of her connections, he
+should be in some danger.
+
+Miss Bingley saw, or suspected enough to be jealous; and her great
+anxiety for the recovery of her dear friend Jane received some
+assistance from her desire of getting rid of Elizabeth.
+
+She often tried to provoke Darcy into disliking her guest, by talking of
+their supposed marriage, and planning his happiness in such an alliance.
+
+“I hope,” said she, as they were walking together in the shrubbery
+the next day, “you will give your mother-in-law a few hints, when this
+desirable event takes place, as to the advantage of holding her tongue;
+and if you can compass it, do cure the younger girls of running after
+officers. And, if I may mention so delicate a subject, endeavour to
+check that little something, bordering on conceit and impertinence,
+which your lady possesses.”
+
+“Have you anything else to propose for my domestic felicity?”
+
+“Oh! yes. Do let the portraits of your uncle and aunt Phillips be placed
+in the gallery at Pemberley. Put them next to your great-uncle the
+judge. They are in the same profession, you know, only in different
+lines. As for your Elizabeth’s picture, you must not have it taken, for
+what painter could do justice to those beautiful eyes?”
+
+“It would not be easy, indeed, to catch their expression, but their
+colour and shape, and the eyelashes, so remarkably fine, might be
+copied.”
+
+At that moment they were met from another walk by Mrs. Hurst and
+Elizabeth herself.
+
+“I did not know that you intended to walk,” said Miss Bingley, in some
+confusion, lest they had been overheard.
+
+“You used us abominably ill,” answered Mrs. Hurst, “running away without
+telling us that you were coming out.”
+
+Then taking the disengaged arm of Mr. Darcy, she left Elizabeth to walk
+by herself. The path just admitted three. Mr. Darcy felt their rudeness,
+and immediately said:
+
+“This walk is not wide enough for our party. We had better go into the
+avenue.”
+
+But Elizabeth, who had not the least inclination to remain with them,
+laughingly answered:
+
+“No, no; stay where you are. You are charmingly grouped, and appear
+to uncommon advantage. The picturesque would be spoilt by admitting a
+fourth. Good-bye.”
+
+She then ran gaily off, rejoicing as she rambled about, in the hope of
+being at home again in a day or two. Jane was already so much recovered
+as to intend leaving her room for a couple of hours that evening.
+
+
+
+Chapter 11
+
+
+When the ladies removed after dinner, Elizabeth ran up to her
+sister, and seeing her well guarded from cold, attended her into the
+drawing-room, where she was welcomed by her two friends with many
+professions of pleasure; and Elizabeth had never seen them so agreeable
+as they were during the hour which passed before the gentlemen appeared.
+Their powers of conversation were considerable. They could describe an
+entertainment with accuracy, relate an anecdote with humour, and laugh
+at their acquaintance with spirit.
+
+But when the gentlemen entered, Jane was no longer the first object;
+Miss Bingley’s eyes were instantly turned toward Darcy, and she had
+something to say to him before he had advanced many steps. He addressed
+himself to Miss Bennet, with a polite congratulation; Mr. Hurst also
+made her a slight bow, and said he was “very glad;” but diffuseness
+and warmth remained for Bingley’s salutation. He was full of joy and
+attention. The first half-hour was spent in piling up the fire, lest she
+should suffer from the change of room; and she removed at his desire
+to the other side of the fireplace, that she might be further from
+the door. He then sat down by her, and talked scarcely to anyone
+else. Elizabeth, at work in the opposite corner, saw it all with great
+delight.
+
+When tea was over, Mr. Hurst reminded his sister-in-law of the
+card-table--but in vain. She had obtained private intelligence that Mr.
+Darcy did not wish for cards; and Mr. Hurst soon found even his open
+petition rejected. She assured him that no one intended to play, and
+the silence of the whole party on the subject seemed to justify her. Mr.
+Hurst had therefore nothing to do, but to stretch himself on one of the
+sofas and go to sleep. Darcy took up a book; Miss Bingley did the same;
+and Mrs. Hurst, principally occupied in playing with her bracelets
+and rings, joined now and then in her brother’s conversation with Miss
+Bennet.
+
+Miss Bingley’s attention was quite as much engaged in watching Mr.
+Darcy’s progress through _his_ book, as in reading her own; and she
+was perpetually either making some inquiry, or looking at his page. She
+could not win him, however, to any conversation; he merely answered her
+question, and read on. At length, quite exhausted by the attempt to be
+amused with her own book, which she had only chosen because it was the
+second volume of his, she gave a great yawn and said, “How pleasant
+it is to spend an evening in this way! I declare after all there is no
+enjoyment like reading! How much sooner one tires of anything than of a
+book! When I have a house of my own, I shall be miserable if I have not
+an excellent library.”
+
+No one made any reply. She then yawned again, threw aside her book, and
+cast her eyes round the room in quest for some amusement; when hearing
+her brother mentioning a ball to Miss Bennet, she turned suddenly
+towards him and said:
+
+“By the bye, Charles, are you really serious in meditating a dance at
+Netherfield? I would advise you, before you determine on it, to consult
+the wishes of the present party; I am much mistaken if there are
+not some among us to whom a ball would be rather a punishment than a
+pleasure.”
+
+“If you mean Darcy,” cried her brother, “he may go to bed, if he
+chooses, before it begins--but as for the ball, it is quite a settled
+thing; and as soon as Nicholls has made white soup enough, I shall send
+round my cards.”
+
+“I should like balls infinitely better,” she replied, “if they were
+carried on in a different manner; but there is something insufferably
+tedious in the usual process of such a meeting. It would surely be much
+more rational if conversation instead of dancing were made the order of
+the day.”
+
+“Much more rational, my dear Caroline, I dare say, but it would not be
+near so much like a ball.”
+
+Miss Bingley made no answer, and soon afterwards she got up and walked
+about the room. Her figure was elegant, and she walked well; but
+Darcy, at whom it was all aimed, was still inflexibly studious. In
+the desperation of her feelings, she resolved on one effort more, and,
+turning to Elizabeth, said:
+
+“Miss Eliza Bennet, let me persuade you to follow my example, and take a
+turn about the room. I assure you it is very refreshing after sitting so
+long in one attitude.”
+
+Elizabeth was surprised, but agreed to it immediately. Miss Bingley
+succeeded no less in the real object of her civility; Mr. Darcy looked
+up. He was as much awake to the novelty of attention in that quarter as
+Elizabeth herself could be, and unconsciously closed his book. He was
+directly invited to join their party, but he declined it, observing that
+he could imagine but two motives for their choosing to walk up and down
+the room together, with either of which motives his joining them would
+interfere. “What could he mean? She was dying to know what could be his
+meaning?”--and asked Elizabeth whether she could at all understand him?
+
+“Not at all,” was her answer; “but depend upon it, he means to be severe
+on us, and our surest way of disappointing him will be to ask nothing
+about it.”
+
+Miss Bingley, however, was incapable of disappointing Mr. Darcy in
+anything, and persevered therefore in requiring an explanation of his
+two motives.
+
+“I have not the smallest objection to explaining them,” said he, as soon
+as she allowed him to speak. “You either choose this method of passing
+the evening because you are in each other’s confidence, and have secret
+affairs to discuss, or because you are conscious that your figures
+appear to the greatest advantage in walking; if the first, I would be
+completely in your way, and if the second, I can admire you much better
+as I sit by the fire.”
+
+“Oh! shocking!” cried Miss Bingley. “I never heard anything so
+abominable. How shall we punish him for such a speech?”
+
+“Nothing so easy, if you have but the inclination,” said Elizabeth. “We
+can all plague and punish one another. Tease him--laugh at him. Intimate
+as you are, you must know how it is to be done.”
+
+“But upon my honour, I do _not_. I do assure you that my intimacy has
+not yet taught me _that_. Tease calmness of manner and presence of
+mind! No, no; I feel he may defy us there. And as to laughter, we will
+not expose ourselves, if you please, by attempting to laugh without a
+subject. Mr. Darcy may hug himself.”
+
+“Mr. Darcy is not to be laughed at!” cried Elizabeth. “That is an
+uncommon advantage, and uncommon I hope it will continue, for it would
+be a great loss to _me_ to have many such acquaintances. I dearly love a
+laugh.”
+
+“Miss Bingley,” said he, “has given me more credit than can be.
+The wisest and the best of men--nay, the wisest and best of their
+actions--may be rendered ridiculous by a person whose first object in
+life is a joke.”
+
+“Certainly,” replied Elizabeth--“there are such people, but I hope I
+am not one of _them_. I hope I never ridicule what is wise and good.
+Follies and nonsense, whims and inconsistencies, _do_ divert me, I own,
+and I laugh at them whenever I can. But these, I suppose, are precisely
+what you are without.”
+
+“Perhaps that is not possible for anyone. But it has been the study
+of my life to avoid those weaknesses which often expose a strong
+understanding to ridicule.”
+
+“Such as vanity and pride.”
+
+“Yes, vanity is a weakness indeed. But pride--where there is a real
+superiority of mind, pride will be always under good regulation.”
+
+Elizabeth turned away to hide a smile.
+
+“Your examination of Mr. Darcy is over, I presume,” said Miss Bingley;
+“and pray what is the result?”
+
+“I am perfectly convinced by it that Mr. Darcy has no defect. He owns it
+himself without disguise.”
+
+“No,” said Darcy, “I have made no such pretension. I have faults enough,
+but they are not, I hope, of understanding. My temper I dare not vouch
+for. It is, I believe, too little yielding--certainly too little for the
+convenience of the world. I cannot forget the follies and vices of others
+so soon as I ought, nor their offenses against myself. My feelings
+are not puffed about with every attempt to move them. My temper
+would perhaps be called resentful. My good opinion once lost, is lost
+forever.”
+
+“_That_ is a failing indeed!” cried Elizabeth. “Implacable resentment
+_is_ a shade in a character. But you have chosen your fault well. I
+really cannot _laugh_ at it. You are safe from me.”
+
+“There is, I believe, in every disposition a tendency to some particular
+evil--a natural defect, which not even the best education can overcome.”
+
+“And _your_ defect is to hate everybody.”
+
+“And yours,” he replied with a smile, “is willfully to misunderstand
+them.”
+
+“Do let us have a little music,” cried Miss Bingley, tired of a
+conversation in which she had no share. “Louisa, you will not mind my
+waking Mr. Hurst?”
+
+Her sister had not the smallest objection, and the pianoforte was
+opened; and Darcy, after a few moments’ recollection, was not sorry for
+it. He began to feel the danger of paying Elizabeth too much attention.
+
+
+
+Chapter 12
+
+
+In consequence of an agreement between the sisters, Elizabeth wrote the
+next morning to their mother, to beg that the carriage might be sent for
+them in the course of the day. But Mrs. Bennet, who had calculated on
+her daughters remaining at Netherfield till the following Tuesday, which
+would exactly finish Jane’s week, could not bring herself to receive
+them with pleasure before. Her answer, therefore, was not propitious, at
+least not to Elizabeth’s wishes, for she was impatient to get home. Mrs.
+Bennet sent them word that they could not possibly have the carriage
+before Tuesday; and in her postscript it was added, that if Mr. Bingley
+and his sister pressed them to stay longer, she could spare them
+very well. Against staying longer, however, Elizabeth was positively
+resolved--nor did she much expect it would be asked; and fearful, on the
+contrary, as being considered as intruding themselves needlessly long,
+she urged Jane to borrow Mr. Bingley’s carriage immediately, and at
+length it was settled that their original design of leaving Netherfield
+that morning should be mentioned, and the request made.
+
+The communication excited many professions of concern; and enough was
+said of wishing them to stay at least till the following day to work
+on Jane; and till the morrow their going was deferred. Miss Bingley was
+then sorry that she had proposed the delay, for her jealousy and dislike
+of one sister much exceeded her affection for the other.
+
+The master of the house heard with real sorrow that they were to go so
+soon, and repeatedly tried to persuade Miss Bennet that it would not be
+safe for her--that she was not enough recovered; but Jane was firm where
+she felt herself to be right.
+
+To Mr. Darcy it was welcome intelligence--Elizabeth had been at
+Netherfield long enough. She attracted him more than he liked--and Miss
+Bingley was uncivil to _her_, and more teasing than usual to himself.
+He wisely resolved to be particularly careful that no sign of admiration
+should _now_ escape him, nothing that could elevate her with the hope
+of influencing his felicity; sensible that if such an idea had been
+suggested, his behaviour during the last day must have material weight
+in confirming or crushing it. Steady to his purpose, he scarcely spoke
+ten words to her through the whole of Saturday, and though they were
+at one time left by themselves for half-an-hour, he adhered most
+conscientiously to his book, and would not even look at her.
+
+On Sunday, after morning service, the separation, so agreeable to almost
+all, took place. Miss Bingley’s civility to Elizabeth increased at last
+very rapidly, as well as her affection for Jane; and when they parted,
+after assuring the latter of the pleasure it would always give her
+to see her either at Longbourn or Netherfield, and embracing her most
+tenderly, she even shook hands with the former. Elizabeth took leave of
+the whole party in the liveliest of spirits.
+
+They were not welcomed home very cordially by their mother. Mrs. Bennet
+wondered at their coming, and thought them very wrong to give so much
+trouble, and was sure Jane would have caught cold again. But their
+father, though very laconic in his expressions of pleasure, was really
+glad to see them; he had felt their importance in the family circle. The
+evening conversation, when they were all assembled, had lost much of
+its animation, and almost all its sense by the absence of Jane and
+Elizabeth.
+
+They found Mary, as usual, deep in the study of thorough-bass and human
+nature; and had some extracts to admire, and some new observations of
+threadbare morality to listen to. Catherine and Lydia had information
+for them of a different sort. Much had been done and much had been said
+in the regiment since the preceding Wednesday; several of the officers
+had dined lately with their uncle, a private had been flogged, and it
+had actually been hinted that Colonel Forster was going to be married.
+
+
+
+Chapter 13
+
+
+“I hope, my dear,” said Mr. Bennet to his wife, as they were at
+breakfast the next morning, “that you have ordered a good dinner to-day,
+because I have reason to expect an addition to our family party.”
+
+“Who do you mean, my dear? I know of nobody that is coming, I am sure,
+unless Charlotte Lucas should happen to call in--and I hope _my_ dinners
+are good enough for her. I do not believe she often sees such at home.”
+
+“The person of whom I speak is a gentleman, and a stranger.”
+
+Mrs. Bennet’s eyes sparkled. “A gentleman and a stranger! It is Mr.
+Bingley, I am sure! Well, I am sure I shall be extremely glad to see Mr.
+Bingley. But--good Lord! how unlucky! There is not a bit of fish to be
+got to-day. Lydia, my love, ring the bell--I must speak to Hill this
+moment.”
+
+“It is _not_ Mr. Bingley,” said her husband; “it is a person whom I
+never saw in the whole course of my life.”
+
+This roused a general astonishment; and he had the pleasure of being
+eagerly questioned by his wife and his five daughters at once.
+
+After amusing himself some time with their curiosity, he thus explained:
+
+“About a month ago I received this letter; and about a fortnight ago
+I answered it, for I thought it a case of some delicacy, and requiring
+early attention. It is from my cousin, Mr. Collins, who, when I am dead,
+may turn you all out of this house as soon as he pleases.”
+
+“Oh! my dear,” cried his wife, “I cannot bear to hear that mentioned.
+Pray do not talk of that odious man. I do think it is the hardest thing
+in the world, that your estate should be entailed away from your own
+children; and I am sure, if I had been you, I should have tried long ago
+to do something or other about it.”
+
+Jane and Elizabeth tried to explain to her the nature of an entail. They
+had often attempted to do it before, but it was a subject on which
+Mrs. Bennet was beyond the reach of reason, and she continued to rail
+bitterly against the cruelty of settling an estate away from a family of
+five daughters, in favour of a man whom nobody cared anything about.
+
+“It certainly is a most iniquitous affair,” said Mr. Bennet, “and
+nothing can clear Mr. Collins from the guilt of inheriting Longbourn.
+But if you will listen to his letter, you may perhaps be a little
+softened by his manner of expressing himself.”
+
+“No, that I am sure I shall not; and I think it is very impertinent of
+him to write to you at all, and very hypocritical. I hate such false
+friends. Why could he not keep on quarreling with you, as his father did
+before him?”
+
+“Why, indeed; he does seem to have had some filial scruples on that
+head, as you will hear.”
+
+“Hunsford, near Westerham, Kent, 15th October.
+
+“Dear Sir,--
+
+“The disagreement subsisting between yourself and my late honoured
+father always gave me much uneasiness, and since I have had the
+misfortune to lose him, I have frequently wished to heal the breach; but
+for some time I was kept back by my own doubts, fearing lest it might
+seem disrespectful to his memory for me to be on good terms with anyone
+with whom it had always pleased him to be at variance.--‘There, Mrs.
+Bennet.’--My mind, however, is now made up on the subject, for having
+received ordination at Easter, I have been so fortunate as to be
+distinguished by the patronage of the Right Honourable Lady Catherine de
+Bourgh, widow of Sir Lewis de Bourgh, whose bounty and beneficence has
+preferred me to the valuable rectory of this parish, where it shall be
+my earnest endeavour to demean myself with grateful respect towards her
+ladyship, and be ever ready to perform those rites and ceremonies which
+are instituted by the Church of England. As a clergyman, moreover, I
+feel it my duty to promote and establish the blessing of peace in
+all families within the reach of my influence; and on these grounds I
+flatter myself that my present overtures are highly commendable, and
+that the circumstance of my being next in the entail of Longbourn estate
+will be kindly overlooked on your side, and not lead you to reject the
+offered olive-branch. I cannot be otherwise than concerned at being the
+means of injuring your amiable daughters, and beg leave to apologise for
+it, as well as to assure you of my readiness to make them every possible
+amends--but of this hereafter. If you should have no objection to
+receive me into your house, I propose myself the satisfaction of waiting
+on you and your family, Monday, November 18th, by four o’clock, and
+shall probably trespass on your hospitality till the Saturday se’ennight
+following, which I can do without any inconvenience, as Lady Catherine
+is far from objecting to my occasional absence on a Sunday, provided
+that some other clergyman is engaged to do the duty of the day.--I
+remain, dear sir, with respectful compliments to your lady and
+daughters, your well-wisher and friend,
+
+“WILLIAM COLLINS”
+
+“At four o’clock, therefore, we may expect this peace-making gentleman,”
+ said Mr. Bennet, as he folded up the letter. “He seems to be a most
+conscientious and polite young man, upon my word, and I doubt not will
+prove a valuable acquaintance, especially if Lady Catherine should be so
+indulgent as to let him come to us again.”
+
+“There is some sense in what he says about the girls, however, and if
+he is disposed to make them any amends, I shall not be the person to
+discourage him.”
+
+“Though it is difficult,” said Jane, “to guess in what way he can mean
+to make us the atonement he thinks our due, the wish is certainly to his
+credit.”
+
+Elizabeth was chiefly struck by his extraordinary deference for Lady
+Catherine, and his kind intention of christening, marrying, and burying
+his parishioners whenever it were required.
+
+“He must be an oddity, I think,” said she. “I cannot make him
+out.--There is something very pompous in his style.--And what can he
+mean by apologising for being next in the entail?--We cannot suppose he
+would help it if he could.--Could he be a sensible man, sir?”
+
+“No, my dear, I think not. I have great hopes of finding him quite the
+reverse. There is a mixture of servility and self-importance in his
+letter, which promises well. I am impatient to see him.”
+
+“In point of composition,” said Mary, “the letter does not seem
+defective. The idea of the olive-branch perhaps is not wholly new, yet I
+think it is well expressed.”
+
+To Catherine and Lydia, neither the letter nor its writer were in any
+degree interesting. It was next to impossible that their cousin should
+come in a scarlet coat, and it was now some weeks since they had
+received pleasure from the society of a man in any other colour. As for
+their mother, Mr. Collins’s letter had done away much of her ill-will,
+and she was preparing to see him with a degree of composure which
+astonished her husband and daughters.
+
+Mr. Collins was punctual to his time, and was received with great
+politeness by the whole family. Mr. Bennet indeed said little; but the
+ladies were ready enough to talk, and Mr. Collins seemed neither in
+need of encouragement, nor inclined to be silent himself. He was a
+tall, heavy-looking young man of five-and-twenty. His air was grave and
+stately, and his manners were very formal. He had not been long seated
+before he complimented Mrs. Bennet on having so fine a family of
+daughters; said he had heard much of their beauty, but that in this
+instance fame had fallen short of the truth; and added, that he did
+not doubt her seeing them all in due time disposed of in marriage. This
+gallantry was not much to the taste of some of his hearers; but Mrs.
+Bennet, who quarreled with no compliments, answered most readily.
+
+“You are very kind, I am sure; and I wish with all my heart it may
+prove so, for else they will be destitute enough. Things are settled so
+oddly.”
+
+“You allude, perhaps, to the entail of this estate.”
+
+“Ah! sir, I do indeed. It is a grievous affair to my poor girls, you
+must confess. Not that I mean to find fault with _you_, for such things
+I know are all chance in this world. There is no knowing how estates
+will go when once they come to be entailed.”
+
+“I am very sensible, madam, of the hardship to my fair cousins, and
+could say much on the subject, but that I am cautious of appearing
+forward and precipitate. But I can assure the young ladies that I come
+prepared to admire them. At present I will not say more; but, perhaps,
+when we are better acquainted--”
+
+He was interrupted by a summons to dinner; and the girls smiled on each
+other. They were not the only objects of Mr. Collins’s admiration. The
+hall, the dining-room, and all its furniture, were examined and praised;
+and his commendation of everything would have touched Mrs. Bennet’s
+heart, but for the mortifying supposition of his viewing it all as his
+own future property. The dinner too in its turn was highly admired; and
+he begged to know to which of his fair cousins the excellency of its
+cooking was owing. But he was set right there by Mrs. Bennet, who
+assured him with some asperity that they were very well able to keep a
+good cook, and that her daughters had nothing to do in the kitchen. He
+begged pardon for having displeased her. In a softened tone she declared
+herself not at all offended; but he continued to apologise for about a
+quarter of an hour.
+
+
+
+Chapter 14
+
+
+During dinner, Mr. Bennet scarcely spoke at all; but when the servants
+were withdrawn, he thought it time to have some conversation with his
+guest, and therefore started a subject in which he expected him to
+shine, by observing that he seemed very fortunate in his patroness. Lady
+Catherine de Bourgh’s attention to his wishes, and consideration for
+his comfort, appeared very remarkable. Mr. Bennet could not have chosen
+better. Mr. Collins was eloquent in her praise. The subject elevated him
+to more than usual solemnity of manner, and with a most important aspect
+he protested that “he had never in his life witnessed such behaviour in
+a person of rank--such affability and condescension, as he had himself
+experienced from Lady Catherine. She had been graciously pleased to
+approve of both of the discourses which he had already had the honour of
+preaching before her. She had also asked him twice to dine at Rosings,
+and had sent for him only the Saturday before, to make up her pool of
+quadrille in the evening. Lady Catherine was reckoned proud by many
+people he knew, but _he_ had never seen anything but affability in her.
+She had always spoken to him as she would to any other gentleman; she
+made not the smallest objection to his joining in the society of the
+neighbourhood nor to his leaving the parish occasionally for a week or
+two, to visit his relations. She had even condescended to advise him to
+marry as soon as he could, provided he chose with discretion; and had
+once paid him a visit in his humble parsonage, where she had perfectly
+approved all the alterations he had been making, and had even vouchsafed
+to suggest some herself--some shelves in the closet up stairs.”
+
+“That is all very proper and civil, I am sure,” said Mrs. Bennet, “and
+I dare say she is a very agreeable woman. It is a pity that great ladies
+in general are not more like her. Does she live near you, sir?”
+
+“The garden in which stands my humble abode is separated only by a lane
+from Rosings Park, her ladyship’s residence.”
+
+“I think you said she was a widow, sir? Has she any family?”
+
+“She has only one daughter, the heiress of Rosings, and of very
+extensive property.”
+
+“Ah!” said Mrs. Bennet, shaking her head, “then she is better off than
+many girls. And what sort of young lady is she? Is she handsome?”
+
+“She is a most charming young lady indeed. Lady Catherine herself says
+that, in point of true beauty, Miss de Bourgh is far superior to the
+handsomest of her sex, because there is that in her features which marks
+the young lady of distinguished birth. She is unfortunately of a sickly
+constitution, which has prevented her from making that progress in many
+accomplishments which she could not have otherwise failed of, as I am
+informed by the lady who superintended her education, and who still
+resides with them. But she is perfectly amiable, and often condescends
+to drive by my humble abode in her little phaeton and ponies.”
+
+“Has she been presented? I do not remember her name among the ladies at
+court.”
+
+“Her indifferent state of health unhappily prevents her being in town;
+and by that means, as I told Lady Catherine one day, has deprived the
+British court of its brightest ornament. Her ladyship seemed pleased
+with the idea; and you may imagine that I am happy on every occasion to
+offer those little delicate compliments which are always acceptable
+to ladies. I have more than once observed to Lady Catherine, that
+her charming daughter seemed born to be a duchess, and that the most
+elevated rank, instead of giving her consequence, would be adorned by
+her. These are the kind of little things which please her ladyship, and
+it is a sort of attention which I conceive myself peculiarly bound to
+pay.”
+
+“You judge very properly,” said Mr. Bennet, “and it is happy for you
+that you possess the talent of flattering with delicacy. May I ask
+whether these pleasing attentions proceed from the impulse of the
+moment, or are the result of previous study?”
+
+“They arise chiefly from what is passing at the time, and though I
+sometimes amuse myself with suggesting and arranging such little elegant
+compliments as may be adapted to ordinary occasions, I always wish to
+give them as unstudied an air as possible.”
+
+Mr. Bennet’s expectations were fully answered. His cousin was as absurd
+as he had hoped, and he listened to him with the keenest enjoyment,
+maintaining at the same time the most resolute composure of countenance,
+and, except in an occasional glance at Elizabeth, requiring no partner
+in his pleasure.
+
+By tea-time, however, the dose had been enough, and Mr. Bennet was glad
+to take his guest into the drawing-room again, and, when tea was over,
+glad to invite him to read aloud to the ladies. Mr. Collins readily
+assented, and a book was produced; but, on beholding it (for everything
+announced it to be from a circulating library), he started back, and
+begging pardon, protested that he never read novels. Kitty stared at
+him, and Lydia exclaimed. Other books were produced, and after some
+deliberation he chose Fordyce’s Sermons. Lydia gaped as he opened the
+volume, and before he had, with very monotonous solemnity, read three
+pages, she interrupted him with:
+
+“Do you know, mamma, that my uncle Phillips talks of turning away
+Richard; and if he does, Colonel Forster will hire him. My aunt told me
+so herself on Saturday. I shall walk to Meryton to-morrow to hear more
+about it, and to ask when Mr. Denny comes back from town.”
+
+Lydia was bid by her two eldest sisters to hold her tongue; but Mr.
+Collins, much offended, laid aside his book, and said:
+
+“I have often observed how little young ladies are interested by books
+of a serious stamp, though written solely for their benefit. It amazes
+me, I confess; for, certainly, there can be nothing so advantageous to
+them as instruction. But I will no longer importune my young cousin.”
+
+Then turning to Mr. Bennet, he offered himself as his antagonist at
+backgammon. Mr. Bennet accepted the challenge, observing that he acted
+very wisely in leaving the girls to their own trifling amusements.
+Mrs. Bennet and her daughters apologised most civilly for Lydia’s
+interruption, and promised that it should not occur again, if he would
+resume his book; but Mr. Collins, after assuring them that he bore his
+young cousin no ill-will, and should never resent her behaviour as any
+affront, seated himself at another table with Mr. Bennet, and prepared
+for backgammon.
+
+
+
+Chapter 15
+
+
+Mr. Collins was not a sensible man, and the deficiency of nature had
+been but little assisted by education or society; the greatest part
+of his life having been spent under the guidance of an illiterate and
+miserly father; and though he belonged to one of the universities, he
+had merely kept the necessary terms, without forming at it any useful
+acquaintance. The subjection in which his father had brought him up had
+given him originally great humility of manner; but it was now a
+good deal counteracted by the self-conceit of a weak head, living in
+retirement, and the consequential feelings of early and unexpected
+prosperity. A fortunate chance had recommended him to Lady Catherine de
+Bourgh when the living of Hunsford was vacant; and the respect which
+he felt for her high rank, and his veneration for her as his patroness,
+mingling with a very good opinion of himself, of his authority as a
+clergyman, and his right as a rector, made him altogether a mixture of
+pride and obsequiousness, self-importance and humility.
+
+Having now a good house and a very sufficient income, he intended to
+marry; and in seeking a reconciliation with the Longbourn family he had
+a wife in view, as he meant to choose one of the daughters, if he found
+them as handsome and amiable as they were represented by common report.
+This was his plan of amends--of atonement--for inheriting their father’s
+estate; and he thought it an excellent one, full of eligibility and
+suitableness, and excessively generous and disinterested on his own
+part.
+
+His plan did not vary on seeing them. Miss Bennet’s lovely face
+confirmed his views, and established all his strictest notions of what
+was due to seniority; and for the first evening _she_ was his settled
+choice. The next morning, however, made an alteration; for in a
+quarter of an hour’s tete-a-tete with Mrs. Bennet before breakfast, a
+conversation beginning with his parsonage-house, and leading naturally
+to the avowal of his hopes, that a mistress might be found for it at
+Longbourn, produced from her, amid very complaisant smiles and general
+encouragement, a caution against the very Jane he had fixed on. “As to
+her _younger_ daughters, she could not take upon her to say--she could
+not positively answer--but she did not _know_ of any prepossession; her
+_eldest_ daughter, she must just mention--she felt it incumbent on her
+to hint, was likely to be very soon engaged.”
+
+Mr. Collins had only to change from Jane to Elizabeth--and it was soon
+done--done while Mrs. Bennet was stirring the fire. Elizabeth, equally
+next to Jane in birth and beauty, succeeded her of course.
+
+Mrs. Bennet treasured up the hint, and trusted that she might soon have
+two daughters married; and the man whom she could not bear to speak of
+the day before was now high in her good graces.
+
+Lydia’s intention of walking to Meryton was not forgotten; every sister
+except Mary agreed to go with her; and Mr. Collins was to attend them,
+at the request of Mr. Bennet, who was most anxious to get rid of him,
+and have his library to himself; for thither Mr. Collins had followed
+him after breakfast; and there he would continue, nominally engaged with
+one of the largest folios in the collection, but really talking to Mr.
+Bennet, with little cessation, of his house and garden at Hunsford. Such
+doings discomposed Mr. Bennet exceedingly. In his library he had been
+always sure of leisure and tranquillity; and though prepared, as he told
+Elizabeth, to meet with folly and conceit in every other room of the
+house, he was used to be free from them there; his civility, therefore,
+was most prompt in inviting Mr. Collins to join his daughters in their
+walk; and Mr. Collins, being in fact much better fitted for a walker
+than a reader, was extremely pleased to close his large book, and go.
+
+In pompous nothings on his side, and civil assents on that of his
+cousins, their time passed till they entered Meryton. The attention of
+the younger ones was then no longer to be gained by him. Their eyes were
+immediately wandering up in the street in quest of the officers, and
+nothing less than a very smart bonnet indeed, or a really new muslin in
+a shop window, could recall them.
+
+But the attention of every lady was soon caught by a young man, whom
+they had never seen before, of most gentlemanlike appearance, walking
+with another officer on the other side of the way. The officer was
+the very Mr. Denny concerning whose return from London Lydia came
+to inquire, and he bowed as they passed. All were struck with the
+stranger’s air, all wondered who he could be; and Kitty and Lydia,
+determined if possible to find out, led the way across the street, under
+pretense of wanting something in an opposite shop, and fortunately
+had just gained the pavement when the two gentlemen, turning back, had
+reached the same spot. Mr. Denny addressed them directly, and entreated
+permission to introduce his friend, Mr. Wickham, who had returned with
+him the day before from town, and he was happy to say had accepted a
+commission in their corps. This was exactly as it should be; for the
+young man wanted only regimentals to make him completely charming.
+His appearance was greatly in his favour; he had all the best part of
+beauty, a fine countenance, a good figure, and very pleasing address.
+The introduction was followed up on his side by a happy readiness
+of conversation--a readiness at the same time perfectly correct and
+unassuming; and the whole party were still standing and talking together
+very agreeably, when the sound of horses drew their notice, and Darcy
+and Bingley were seen riding down the street. On distinguishing the
+ladies of the group, the two gentlemen came directly towards them, and
+began the usual civilities. Bingley was the principal spokesman, and
+Miss Bennet the principal object. He was then, he said, on his way to
+Longbourn on purpose to inquire after her. Mr. Darcy corroborated
+it with a bow, and was beginning to determine not to fix his eyes
+on Elizabeth, when they were suddenly arrested by the sight of the
+stranger, and Elizabeth happening to see the countenance of both as they
+looked at each other, was all astonishment at the effect of the meeting.
+Both changed colour, one looked white, the other red. Mr. Wickham,
+after a few moments, touched his hat--a salutation which Mr. Darcy just
+deigned to return. What could be the meaning of it? It was impossible to
+imagine; it was impossible not to long to know.
+
+In another minute, Mr. Bingley, but without seeming to have noticed what
+passed, took leave and rode on with his friend.
+
+Mr. Denny and Mr. Wickham walked with the young ladies to the door of
+Mr. Phillip’s house, and then made their bows, in spite of Miss Lydia’s
+pressing entreaties that they should come in, and even in spite of
+Mrs. Phillips’s throwing up the parlour window and loudly seconding the
+invitation.
+
+Mrs. Phillips was always glad to see her nieces; and the two eldest,
+from their recent absence, were particularly welcome, and she was
+eagerly expressing her surprise at their sudden return home, which, as
+their own carriage had not fetched them, she should have known nothing
+about, if she had not happened to see Mr. Jones’s shop-boy in the
+street, who had told her that they were not to send any more draughts to
+Netherfield because the Miss Bennets were come away, when her civility
+was claimed towards Mr. Collins by Jane’s introduction of him. She
+received him with her very best politeness, which he returned with
+as much more, apologising for his intrusion, without any previous
+acquaintance with her, which he could not help flattering himself,
+however, might be justified by his relationship to the young ladies who
+introduced him to her notice. Mrs. Phillips was quite awed by such an
+excess of good breeding; but her contemplation of one stranger was soon
+put to an end by exclamations and inquiries about the other; of whom,
+however, she could only tell her nieces what they already knew, that
+Mr. Denny had brought him from London, and that he was to have a
+lieutenant’s commission in the ----shire. She had been watching him the
+last hour, she said, as he walked up and down the street, and had Mr.
+Wickham appeared, Kitty and Lydia would certainly have continued the
+occupation, but unluckily no one passed windows now except a few of the
+officers, who, in comparison with the stranger, were become “stupid,
+disagreeable fellows.” Some of them were to dine with the Phillipses
+the next day, and their aunt promised to make her husband call on Mr.
+Wickham, and give him an invitation also, if the family from Longbourn
+would come in the evening. This was agreed to, and Mrs. Phillips
+protested that they would have a nice comfortable noisy game of lottery
+tickets, and a little bit of hot supper afterwards. The prospect of such
+delights was very cheering, and they parted in mutual good spirits. Mr.
+Collins repeated his apologies in quitting the room, and was assured
+with unwearying civility that they were perfectly needless.
+
+As they walked home, Elizabeth related to Jane what she had seen pass
+between the two gentlemen; but though Jane would have defended either
+or both, had they appeared to be in the wrong, she could no more explain
+such behaviour than her sister.
+
+Mr. Collins on his return highly gratified Mrs. Bennet by admiring
+Mrs. Phillips’s manners and politeness. He protested that, except Lady
+Catherine and her daughter, he had never seen a more elegant woman;
+for she had not only received him with the utmost civility, but even
+pointedly included him in her invitation for the next evening, although
+utterly unknown to her before. Something, he supposed, might be
+attributed to his connection with them, but yet he had never met with so
+much attention in the whole course of his life.
+
+
+
+Chapter 16
+
+
+As no objection was made to the young people’s engagement with their
+aunt, and all Mr. Collins’s scruples of leaving Mr. and Mrs. Bennet for
+a single evening during his visit were most steadily resisted, the coach
+conveyed him and his five cousins at a suitable hour to Meryton; and
+the girls had the pleasure of hearing, as they entered the drawing-room,
+that Mr. Wickham had accepted their uncle’s invitation, and was then in
+the house.
+
+When this information was given, and they had all taken their seats, Mr.
+Collins was at leisure to look around him and admire, and he was so much
+struck with the size and furniture of the apartment, that he declared he
+might almost have supposed himself in the small summer breakfast
+parlour at Rosings; a comparison that did not at first convey much
+gratification; but when Mrs. Phillips understood from him what
+Rosings was, and who was its proprietor--when she had listened to the
+description of only one of Lady Catherine’s drawing-rooms, and found
+that the chimney-piece alone had cost eight hundred pounds, she felt all
+the force of the compliment, and would hardly have resented a comparison
+with the housekeeper’s room.
+
+In describing to her all the grandeur of Lady Catherine and her mansion,
+with occasional digressions in praise of his own humble abode, and
+the improvements it was receiving, he was happily employed until the
+gentlemen joined them; and he found in Mrs. Phillips a very attentive
+listener, whose opinion of his consequence increased with what she
+heard, and who was resolving to retail it all among her neighbours as
+soon as she could. To the girls, who could not listen to their cousin,
+and who had nothing to do but to wish for an instrument, and examine
+their own indifferent imitations of china on the mantelpiece, the
+interval of waiting appeared very long. It was over at last, however.
+The gentlemen did approach, and when Mr. Wickham walked into the room,
+Elizabeth felt that she had neither been seeing him before, nor thinking
+of him since, with the smallest degree of unreasonable admiration.
+The officers of the ----shire were in general a very creditable,
+gentlemanlike set, and the best of them were of the present party; but
+Mr. Wickham was as far beyond them all in person, countenance, air, and
+walk, as _they_ were superior to the broad-faced, stuffy uncle Phillips,
+breathing port wine, who followed them into the room.
+
+Mr. Wickham was the happy man towards whom almost every female eye was
+turned, and Elizabeth was the happy woman by whom he finally seated
+himself; and the agreeable manner in which he immediately fell into
+conversation, though it was only on its being a wet night, made her feel
+that the commonest, dullest, most threadbare topic might be rendered
+interesting by the skill of the speaker.
+
+With such rivals for the notice of the fair as Mr. Wickham and the
+officers, Mr. Collins seemed to sink into insignificance; to the young
+ladies he certainly was nothing; but he had still at intervals a kind
+listener in Mrs. Phillips, and was by her watchfulness, most abundantly
+supplied with coffee and muffin. When the card-tables were placed, he
+had the opportunity of obliging her in turn, by sitting down to whist.
+
+“I know little of the game at present,” said he, “but I shall be glad
+to improve myself, for in my situation in life--” Mrs. Phillips was very
+glad for his compliance, but could not wait for his reason.
+
+Mr. Wickham did not play at whist, and with ready delight was he
+received at the other table between Elizabeth and Lydia. At first there
+seemed danger of Lydia’s engrossing him entirely, for she was a most
+determined talker; but being likewise extremely fond of lottery tickets,
+she soon grew too much interested in the game, too eager in making bets
+and exclaiming after prizes to have attention for anyone in particular.
+Allowing for the common demands of the game, Mr. Wickham was therefore
+at leisure to talk to Elizabeth, and she was very willing to hear
+him, though what she chiefly wished to hear she could not hope to be
+told--the history of his acquaintance with Mr. Darcy. She dared not
+even mention that gentleman. Her curiosity, however, was unexpectedly
+relieved. Mr. Wickham began the subject himself. He inquired how far
+Netherfield was from Meryton; and, after receiving her answer, asked in
+a hesitating manner how long Mr. Darcy had been staying there.
+
+“About a month,” said Elizabeth; and then, unwilling to let the subject
+drop, added, “He is a man of very large property in Derbyshire, I
+understand.”
+
+“Yes,” replied Mr. Wickham; “his estate there is a noble one. A clear
+ten thousand per annum. You could not have met with a person more
+capable of giving you certain information on that head than myself, for
+I have been connected with his family in a particular manner from my
+infancy.”
+
+Elizabeth could not but look surprised.
+
+“You may well be surprised, Miss Bennet, at such an assertion, after
+seeing, as you probably might, the very cold manner of our meeting
+yesterday. Are you much acquainted with Mr. Darcy?”
+
+“As much as I ever wish to be,” cried Elizabeth very warmly. “I have
+spent four days in the same house with him, and I think him very
+disagreeable.”
+
+“I have no right to give _my_ opinion,” said Wickham, “as to his being
+agreeable or otherwise. I am not qualified to form one. I have known him
+too long and too well to be a fair judge. It is impossible for _me_
+to be impartial. But I believe your opinion of him would in general
+astonish--and perhaps you would not express it quite so strongly
+anywhere else. Here you are in your own family.”
+
+“Upon my word, I say no more _here_ than I might say in any house in
+the neighbourhood, except Netherfield. He is not at all liked in
+Hertfordshire. Everybody is disgusted with his pride. You will not find
+him more favourably spoken of by anyone.”
+
+“I cannot pretend to be sorry,” said Wickham, after a short
+interruption, “that he or that any man should not be estimated beyond
+their deserts; but with _him_ I believe it does not often happen. The
+world is blinded by his fortune and consequence, or frightened by his
+high and imposing manners, and sees him only as he chooses to be seen.”
+
+“I should take him, even on _my_ slight acquaintance, to be an
+ill-tempered man.” Wickham only shook his head.
+
+“I wonder,” said he, at the next opportunity of speaking, “whether he is
+likely to be in this country much longer.”
+
+“I do not at all know; but I _heard_ nothing of his going away when I
+was at Netherfield. I hope your plans in favour of the ----shire will
+not be affected by his being in the neighbourhood.”
+
+“Oh! no--it is not for _me_ to be driven away by Mr. Darcy. If _he_
+wishes to avoid seeing _me_, he must go. We are not on friendly terms,
+and it always gives me pain to meet him, but I have no reason for
+avoiding _him_ but what I might proclaim before all the world, a sense
+of very great ill-usage, and most painful regrets at his being what he
+is. His father, Miss Bennet, the late Mr. Darcy, was one of the best men
+that ever breathed, and the truest friend I ever had; and I can never
+be in company with this Mr. Darcy without being grieved to the soul by
+a thousand tender recollections. His behaviour to myself has been
+scandalous; but I verily believe I could forgive him anything and
+everything, rather than his disappointing the hopes and disgracing the
+memory of his father.”
+
+Elizabeth found the interest of the subject increase, and listened with
+all her heart; but the delicacy of it prevented further inquiry.
+
+Mr. Wickham began to speak on more general topics, Meryton, the
+neighbourhood, the society, appearing highly pleased with all that
+he had yet seen, and speaking of the latter with gentle but very
+intelligible gallantry.
+
+“It was the prospect of constant society, and good society,” he added,
+“which was my chief inducement to enter the ----shire. I knew it to be
+a most respectable, agreeable corps, and my friend Denny tempted me
+further by his account of their present quarters, and the very great
+attentions and excellent acquaintances Meryton had procured them.
+Society, I own, is necessary to me. I have been a disappointed man, and
+my spirits will not bear solitude. I _must_ have employment and society.
+A military life is not what I was intended for, but circumstances have
+now made it eligible. The church _ought_ to have been my profession--I
+was brought up for the church, and I should at this time have been in
+possession of a most valuable living, had it pleased the gentleman we
+were speaking of just now.”
+
+“Indeed!”
+
+“Yes--the late Mr. Darcy bequeathed me the next presentation of the best
+living in his gift. He was my godfather, and excessively attached to me.
+I cannot do justice to his kindness. He meant to provide for me amply,
+and thought he had done it; but when the living fell, it was given
+elsewhere.”
+
+“Good heavens!” cried Elizabeth; “but how could _that_ be? How could his
+will be disregarded? Why did you not seek legal redress?”
+
+“There was just such an informality in the terms of the bequest as to
+give me no hope from law. A man of honour could not have doubted the
+intention, but Mr. Darcy chose to doubt it--or to treat it as a merely
+conditional recommendation, and to assert that I had forfeited all claim
+to it by extravagance, imprudence--in short anything or nothing. Certain
+it is, that the living became vacant two years ago, exactly as I was
+of an age to hold it, and that it was given to another man; and no
+less certain is it, that I cannot accuse myself of having really done
+anything to deserve to lose it. I have a warm, unguarded temper, and
+I may have spoken my opinion _of_ him, and _to_ him, too freely. I can
+recall nothing worse. But the fact is, that we are very different sort
+of men, and that he hates me.”
+
+“This is quite shocking! He deserves to be publicly disgraced.”
+
+“Some time or other he _will_ be--but it shall not be by _me_. Till I
+can forget his father, I can never defy or expose _him_.”
+
+Elizabeth honoured him for such feelings, and thought him handsomer than
+ever as he expressed them.
+
+“But what,” said she, after a pause, “can have been his motive? What can
+have induced him to behave so cruelly?”
+
+“A thorough, determined dislike of me--a dislike which I cannot but
+attribute in some measure to jealousy. Had the late Mr. Darcy liked me
+less, his son might have borne with me better; but his father’s uncommon
+attachment to me irritated him, I believe, very early in life. He had
+not a temper to bear the sort of competition in which we stood--the sort
+of preference which was often given me.”
+
+“I had not thought Mr. Darcy so bad as this--though I have never liked
+him. I had not thought so very ill of him. I had supposed him to be
+despising his fellow-creatures in general, but did not suspect him of
+descending to such malicious revenge, such injustice, such inhumanity as
+this.”
+
+After a few minutes’ reflection, however, she continued, “I _do_
+remember his boasting one day, at Netherfield, of the implacability of
+his resentments, of his having an unforgiving temper. His disposition
+must be dreadful.”
+
+“I will not trust myself on the subject,” replied Wickham; “I can hardly
+be just to him.”
+
+Elizabeth was again deep in thought, and after a time exclaimed, “To
+treat in such a manner the godson, the friend, the favourite of his
+father!” She could have added, “A young man, too, like _you_, whose very
+countenance may vouch for your being amiable”--but she contented herself
+with, “and one, too, who had probably been his companion from childhood,
+connected together, as I think you said, in the closest manner!”
+
+“We were born in the same parish, within the same park; the greatest
+part of our youth was passed together; inmates of the same house,
+sharing the same amusements, objects of the same parental care. _My_
+father began life in the profession which your uncle, Mr. Phillips,
+appears to do so much credit to--but he gave up everything to be of
+use to the late Mr. Darcy and devoted all his time to the care of the
+Pemberley property. He was most highly esteemed by Mr. Darcy, a most
+intimate, confidential friend. Mr. Darcy often acknowledged himself to
+be under the greatest obligations to my father’s active superintendence,
+and when, immediately before my father’s death, Mr. Darcy gave him a
+voluntary promise of providing for me, I am convinced that he felt it to
+be as much a debt of gratitude to _him_, as of his affection to myself.”
+
+“How strange!” cried Elizabeth. “How abominable! I wonder that the very
+pride of this Mr. Darcy has not made him just to you! If from no better
+motive, that he should not have been too proud to be dishonest--for
+dishonesty I must call it.”
+
+“It _is_ wonderful,” replied Wickham, “for almost all his actions may
+be traced to pride; and pride had often been his best friend. It has
+connected him nearer with virtue than with any other feeling. But we are
+none of us consistent, and in his behaviour to me there were stronger
+impulses even than pride.”
+
+“Can such abominable pride as his have ever done him good?”
+
+“Yes. It has often led him to be liberal and generous, to give his money
+freely, to display hospitality, to assist his tenants, and relieve the
+poor. Family pride, and _filial_ pride--for he is very proud of what
+his father was--have done this. Not to appear to disgrace his family,
+to degenerate from the popular qualities, or lose the influence of the
+Pemberley House, is a powerful motive. He has also _brotherly_ pride,
+which, with _some_ brotherly affection, makes him a very kind and
+careful guardian of his sister, and you will hear him generally cried up
+as the most attentive and best of brothers.”
+
+“What sort of girl is Miss Darcy?”
+
+He shook his head. “I wish I could call her amiable. It gives me pain to
+speak ill of a Darcy. But she is too much like her brother--very, very
+proud. As a child, she was affectionate and pleasing, and extremely fond
+of me; and I have devoted hours and hours to her amusement. But she is
+nothing to me now. She is a handsome girl, about fifteen or sixteen,
+and, I understand, highly accomplished. Since her father’s death, her
+home has been London, where a lady lives with her, and superintends her
+education.”
+
+After many pauses and many trials of other subjects, Elizabeth could not
+help reverting once more to the first, and saying:
+
+“I am astonished at his intimacy with Mr. Bingley! How can Mr. Bingley,
+who seems good humour itself, and is, I really believe, truly amiable,
+be in friendship with such a man? How can they suit each other? Do you
+know Mr. Bingley?”
+
+“Not at all.”
+
+“He is a sweet-tempered, amiable, charming man. He cannot know what Mr.
+Darcy is.”
+
+“Probably not; but Mr. Darcy can please where he chooses. He does not
+want abilities. He can be a conversible companion if he thinks it worth
+his while. Among those who are at all his equals in consequence, he is
+a very different man from what he is to the less prosperous. His
+pride never deserts him; but with the rich he is liberal-minded, just,
+sincere, rational, honourable, and perhaps agreeable--allowing something
+for fortune and figure.”
+
+The whist party soon afterwards breaking up, the players gathered round
+the other table and Mr. Collins took his station between his cousin
+Elizabeth and Mrs. Phillips. The usual inquiries as to his success were
+made by the latter. It had not been very great; he had lost every
+point; but when Mrs. Phillips began to express her concern thereupon,
+he assured her with much earnest gravity that it was not of the least
+importance, that he considered the money as a mere trifle, and begged
+that she would not make herself uneasy.
+
+“I know very well, madam,” said he, “that when persons sit down to a
+card-table, they must take their chances of these things, and happily I
+am not in such circumstances as to make five shillings any object. There
+are undoubtedly many who could not say the same, but thanks to Lady
+Catherine de Bourgh, I am removed far beyond the necessity of regarding
+little matters.”
+
+Mr. Wickham’s attention was caught; and after observing Mr. Collins for
+a few moments, he asked Elizabeth in a low voice whether her relation
+was very intimately acquainted with the family of de Bourgh.
+
+“Lady Catherine de Bourgh,” she replied, “has very lately given him
+a living. I hardly know how Mr. Collins was first introduced to her
+notice, but he certainly has not known her long.”
+
+“You know of course that Lady Catherine de Bourgh and Lady Anne Darcy
+were sisters; consequently that she is aunt to the present Mr. Darcy.”
+
+“No, indeed, I did not. I knew nothing at all of Lady Catherine’s
+connections. I never heard of her existence till the day before
+yesterday.”
+
+“Her daughter, Miss de Bourgh, will have a very large fortune, and it is
+believed that she and her cousin will unite the two estates.”
+
+This information made Elizabeth smile, as she thought of poor Miss
+Bingley. Vain indeed must be all her attentions, vain and useless her
+affection for his sister and her praise of himself, if he were already
+self-destined for another.
+
+“Mr. Collins,” said she, “speaks highly both of Lady Catherine and her
+daughter; but from some particulars that he has related of her ladyship,
+I suspect his gratitude misleads him, and that in spite of her being his
+patroness, she is an arrogant, conceited woman.”
+
+“I believe her to be both in a great degree,” replied Wickham; “I have
+not seen her for many years, but I very well remember that I never liked
+her, and that her manners were dictatorial and insolent. She has the
+reputation of being remarkably sensible and clever; but I rather believe
+she derives part of her abilities from her rank and fortune, part from
+her authoritative manner, and the rest from the pride for her
+nephew, who chooses that everyone connected with him should have an
+understanding of the first class.”
+
+Elizabeth allowed that he had given a very rational account of it, and
+they continued talking together, with mutual satisfaction till supper
+put an end to cards, and gave the rest of the ladies their share of Mr.
+Wickham’s attentions. There could be no conversation in the noise
+of Mrs. Phillips’s supper party, but his manners recommended him to
+everybody. Whatever he said, was said well; and whatever he did, done
+gracefully. Elizabeth went away with her head full of him. She could
+think of nothing but of Mr. Wickham, and of what he had told her, all
+the way home; but there was not time for her even to mention his name
+as they went, for neither Lydia nor Mr. Collins were once silent. Lydia
+talked incessantly of lottery tickets, of the fish she had lost and the
+fish she had won; and Mr. Collins in describing the civility of Mr. and
+Mrs. Phillips, protesting that he did not in the least regard his losses
+at whist, enumerating all the dishes at supper, and repeatedly fearing
+that he crowded his cousins, had more to say than he could well manage
+before the carriage stopped at Longbourn House.
+
+
+
+Chapter 17
+
+
+Elizabeth related to Jane the next day what had passed between Mr.
+Wickham and herself. Jane listened with astonishment and concern; she
+knew not how to believe that Mr. Darcy could be so unworthy of Mr.
+Bingley’s regard; and yet, it was not in her nature to question the
+veracity of a young man of such amiable appearance as Wickham. The
+possibility of his having endured such unkindness, was enough to
+interest all her tender feelings; and nothing remained therefore to be
+done, but to think well of them both, to defend the conduct of each,
+and throw into the account of accident or mistake whatever could not be
+otherwise explained.
+
+“They have both,” said she, “been deceived, I dare say, in some way
+or other, of which we can form no idea. Interested people have perhaps
+misrepresented each to the other. It is, in short, impossible for us to
+conjecture the causes or circumstances which may have alienated them,
+without actual blame on either side.”
+
+“Very true, indeed; and now, my dear Jane, what have you got to say on
+behalf of the interested people who have probably been concerned in the
+business? Do clear _them_ too, or we shall be obliged to think ill of
+somebody.”
+
+“Laugh as much as you choose, but you will not laugh me out of my
+opinion. My dearest Lizzy, do but consider in what a disgraceful light
+it places Mr. Darcy, to be treating his father’s favourite in such
+a manner, one whom his father had promised to provide for. It is
+impossible. No man of common humanity, no man who had any value for his
+character, could be capable of it. Can his most intimate friends be so
+excessively deceived in him? Oh! no.”
+
+“I can much more easily believe Mr. Bingley’s being imposed on, than
+that Mr. Wickham should invent such a history of himself as he gave me
+last night; names, facts, everything mentioned without ceremony. If it
+be not so, let Mr. Darcy contradict it. Besides, there was truth in his
+looks.”
+
+“It is difficult indeed--it is distressing. One does not know what to
+think.”
+
+“I beg your pardon; one knows exactly what to think.”
+
+But Jane could think with certainty on only one point--that Mr. Bingley,
+if he _had_ been imposed on, would have much to suffer when the affair
+became public.
+
+The two young ladies were summoned from the shrubbery, where this
+conversation passed, by the arrival of the very persons of whom they had
+been speaking; Mr. Bingley and his sisters came to give their personal
+invitation for the long-expected ball at Netherfield, which was fixed
+for the following Tuesday. The two ladies were delighted to see their
+dear friend again, called it an age since they had met, and repeatedly
+asked what she had been doing with herself since their separation. To
+the rest of the family they paid little attention; avoiding Mrs. Bennet
+as much as possible, saying not much to Elizabeth, and nothing at all to
+the others. They were soon gone again, rising from their seats with an
+activity which took their brother by surprise, and hurrying off as if
+eager to escape from Mrs. Bennet’s civilities.
+
+The prospect of the Netherfield ball was extremely agreeable to every
+female of the family. Mrs. Bennet chose to consider it as given in
+compliment to her eldest daughter, and was particularly flattered
+by receiving the invitation from Mr. Bingley himself, instead of a
+ceremonious card. Jane pictured to herself a happy evening in the
+society of her two friends, and the attentions of their brother; and
+Elizabeth thought with pleasure of dancing a great deal with Mr.
+Wickham, and of seeing a confirmation of everything in Mr. Darcy’s look
+and behaviour. The happiness anticipated by Catherine and Lydia depended
+less on any single event, or any particular person, for though they
+each, like Elizabeth, meant to dance half the evening with Mr. Wickham,
+he was by no means the only partner who could satisfy them, and a ball
+was, at any rate, a ball. And even Mary could assure her family that she
+had no disinclination for it.
+
+“While I can have my mornings to myself,” said she, “it is enough--I
+think it is no sacrifice to join occasionally in evening engagements.
+Society has claims on us all; and I profess myself one of those
+who consider intervals of recreation and amusement as desirable for
+everybody.”
+
+Elizabeth’s spirits were so high on this occasion, that though she did
+not often speak unnecessarily to Mr. Collins, she could not help asking
+him whether he intended to accept Mr. Bingley’s invitation, and if
+he did, whether he would think it proper to join in the evening’s
+amusement; and she was rather surprised to find that he entertained no
+scruple whatever on that head, and was very far from dreading a rebuke
+either from the Archbishop, or Lady Catherine de Bourgh, by venturing to
+dance.
+
+“I am by no means of the opinion, I assure you,” said he, “that a ball
+of this kind, given by a young man of character, to respectable people,
+can have any evil tendency; and I am so far from objecting to dancing
+myself, that I shall hope to be honoured with the hands of all my fair
+cousins in the course of the evening; and I take this opportunity of
+soliciting yours, Miss Elizabeth, for the two first dances especially,
+a preference which I trust my cousin Jane will attribute to the right
+cause, and not to any disrespect for her.”
+
+Elizabeth felt herself completely taken in. She had fully proposed being
+engaged by Mr. Wickham for those very dances; and to have Mr. Collins
+instead! her liveliness had never been worse timed. There was no help
+for it, however. Mr. Wickham’s happiness and her own were perforce
+delayed a little longer, and Mr. Collins’s proposal accepted with as
+good a grace as she could. She was not the better pleased with his
+gallantry from the idea it suggested of something more. It now first
+struck her, that _she_ was selected from among her sisters as worthy
+of being mistress of Hunsford Parsonage, and of assisting to form a
+quadrille table at Rosings, in the absence of more eligible visitors.
+The idea soon reached to conviction, as she observed his increasing
+civilities toward herself, and heard his frequent attempt at a
+compliment on her wit and vivacity; and though more astonished than
+gratified herself by this effect of her charms, it was not long before
+her mother gave her to understand that the probability of their marriage
+was extremely agreeable to _her_. Elizabeth, however, did not choose
+to take the hint, being well aware that a serious dispute must be the
+consequence of any reply. Mr. Collins might never make the offer, and
+till he did, it was useless to quarrel about him.
+
+If there had not been a Netherfield ball to prepare for and talk of, the
+younger Miss Bennets would have been in a very pitiable state at this
+time, for from the day of the invitation, to the day of the ball, there
+was such a succession of rain as prevented their walking to Meryton
+once. No aunt, no officers, no news could be sought after--the very
+shoe-roses for Netherfield were got by proxy. Even Elizabeth might have
+found some trial of her patience in weather which totally suspended the
+improvement of her acquaintance with Mr. Wickham; and nothing less than
+a dance on Tuesday, could have made such a Friday, Saturday, Sunday, and
+Monday endurable to Kitty and Lydia.
+
+
+
+Chapter 18
+
+
+Till Elizabeth entered the drawing-room at Netherfield, and looked in
+vain for Mr. Wickham among the cluster of red coats there assembled, a
+doubt of his being present had never occurred to her. The certainty
+of meeting him had not been checked by any of those recollections that
+might not unreasonably have alarmed her. She had dressed with more than
+usual care, and prepared in the highest spirits for the conquest of all
+that remained unsubdued of his heart, trusting that it was not more than
+might be won in the course of the evening. But in an instant arose
+the dreadful suspicion of his being purposely omitted for Mr. Darcy’s
+pleasure in the Bingleys’ invitation to the officers; and though
+this was not exactly the case, the absolute fact of his absence was
+pronounced by his friend Denny, to whom Lydia eagerly applied, and who
+told them that Wickham had been obliged to go to town on business the
+day before, and was not yet returned; adding, with a significant smile,
+“I do not imagine his business would have called him away just now, if
+he had not wanted to avoid a certain gentleman here.”
+
+This part of his intelligence, though unheard by Lydia, was caught by
+Elizabeth, and, as it assured her that Darcy was not less answerable for
+Wickham’s absence than if her first surmise had been just, every
+feeling of displeasure against the former was so sharpened by immediate
+disappointment, that she could hardly reply with tolerable civility to
+the polite inquiries which he directly afterwards approached to make.
+Attendance, forbearance, patience with Darcy, was injury to Wickham. She
+was resolved against any sort of conversation with him, and turned away
+with a degree of ill-humour which she could not wholly surmount even in
+speaking to Mr. Bingley, whose blind partiality provoked her.
+
+But Elizabeth was not formed for ill-humour; and though every prospect
+of her own was destroyed for the evening, it could not dwell long on her
+spirits; and having told all her griefs to Charlotte Lucas, whom she had
+not seen for a week, she was soon able to make a voluntary transition
+to the oddities of her cousin, and to point him out to her particular
+notice. The first two dances, however, brought a return of distress;
+they were dances of mortification. Mr. Collins, awkward and solemn,
+apologising instead of attending, and often moving wrong without being
+aware of it, gave her all the shame and misery which a disagreeable
+partner for a couple of dances can give. The moment of her release from
+him was ecstasy.
+
+She danced next with an officer, and had the refreshment of talking of
+Wickham, and of hearing that he was universally liked. When those dances
+were over, she returned to Charlotte Lucas, and was in conversation with
+her, when she found herself suddenly addressed by Mr. Darcy who took
+her so much by surprise in his application for her hand, that,
+without knowing what she did, she accepted him. He walked away again
+immediately, and she was left to fret over her own want of presence of
+mind; Charlotte tried to console her:
+
+“I dare say you will find him very agreeable.”
+
+“Heaven forbid! _That_ would be the greatest misfortune of all! To find
+a man agreeable whom one is determined to hate! Do not wish me such an
+evil.”
+
+When the dancing recommenced, however, and Darcy approached to claim her
+hand, Charlotte could not help cautioning her in a whisper, not to be a
+simpleton, and allow her fancy for Wickham to make her appear unpleasant
+in the eyes of a man ten times his consequence. Elizabeth made no
+answer, and took her place in the set, amazed at the dignity to which
+she was arrived in being allowed to stand opposite to Mr. Darcy, and
+reading in her neighbours’ looks, their equal amazement in beholding
+it. They stood for some time without speaking a word; and she began to
+imagine that their silence was to last through the two dances, and at
+first was resolved not to break it; till suddenly fancying that it would
+be the greater punishment to her partner to oblige him to talk, she made
+some slight observation on the dance. He replied, and was again
+silent. After a pause of some minutes, she addressed him a second time
+with:--“It is _your_ turn to say something now, Mr. Darcy. I talked
+about the dance, and _you_ ought to make some sort of remark on the size
+of the room, or the number of couples.”
+
+He smiled, and assured her that whatever she wished him to say should be
+said.
+
+“Very well. That reply will do for the present. Perhaps by and by I may
+observe that private balls are much pleasanter than public ones. But
+_now_ we may be silent.”
+
+“Do you talk by rule, then, while you are dancing?”
+
+“Sometimes. One must speak a little, you know. It would look odd to be
+entirely silent for half an hour together; and yet for the advantage of
+_some_, conversation ought to be so arranged, as that they may have the
+trouble of saying as little as possible.”
+
+“Are you consulting your own feelings in the present case, or do you
+imagine that you are gratifying mine?”
+
+“Both,” replied Elizabeth archly; “for I have always seen a great
+similarity in the turn of our minds. We are each of an unsocial,
+taciturn disposition, unwilling to speak, unless we expect to say
+something that will amaze the whole room, and be handed down to
+posterity with all the eclat of a proverb.”
+
+“This is no very striking resemblance of your own character, I am sure,”
+ said he. “How near it may be to _mine_, I cannot pretend to say. _You_
+think it a faithful portrait undoubtedly.”
+
+“I must not decide on my own performance.”
+
+He made no answer, and they were again silent till they had gone down
+the dance, when he asked her if she and her sisters did not very often
+walk to Meryton. She answered in the affirmative, and, unable to resist
+the temptation, added, “When you met us there the other day, we had just
+been forming a new acquaintance.”
+
+The effect was immediate. A deeper shade of _hauteur_ overspread his
+features, but he said not a word, and Elizabeth, though blaming herself
+for her own weakness, could not go on. At length Darcy spoke, and in a
+constrained manner said, “Mr. Wickham is blessed with such happy manners
+as may ensure his _making_ friends--whether he may be equally capable of
+_retaining_ them, is less certain.”
+
+“He has been so unlucky as to lose _your_ friendship,” replied Elizabeth
+with emphasis, “and in a manner which he is likely to suffer from all
+his life.”
+
+Darcy made no answer, and seemed desirous of changing the subject. At
+that moment, Sir William Lucas appeared close to them, meaning to pass
+through the set to the other side of the room; but on perceiving Mr.
+Darcy, he stopped with a bow of superior courtesy to compliment him on
+his dancing and his partner.
+
+“I have been most highly gratified indeed, my dear sir. Such very
+superior dancing is not often seen. It is evident that you belong to the
+first circles. Allow me to say, however, that your fair partner does not
+disgrace you, and that I must hope to have this pleasure often repeated,
+especially when a certain desirable event, my dear Eliza (glancing at
+her sister and Bingley) shall take place. What congratulations will then
+flow in! I appeal to Mr. Darcy:--but let me not interrupt you, sir. You
+will not thank me for detaining you from the bewitching converse of that
+young lady, whose bright eyes are also upbraiding me.”
+
+The latter part of this address was scarcely heard by Darcy; but Sir
+William’s allusion to his friend seemed to strike him forcibly, and his
+eyes were directed with a very serious expression towards Bingley and
+Jane, who were dancing together. Recovering himself, however, shortly,
+he turned to his partner, and said, “Sir William’s interruption has made
+me forget what we were talking of.”
+
+“I do not think we were speaking at all. Sir William could not have
+interrupted two people in the room who had less to say for themselves.
+We have tried two or three subjects already without success, and what we
+are to talk of next I cannot imagine.”
+
+“What think you of books?” said he, smiling.
+
+“Books--oh! no. I am sure we never read the same, or not with the same
+feelings.”
+
+“I am sorry you think so; but if that be the case, there can at least be
+no want of subject. We may compare our different opinions.”
+
+“No--I cannot talk of books in a ball-room; my head is always full of
+something else.”
+
+“The _present_ always occupies you in such scenes--does it?” said he,
+with a look of doubt.
+
+“Yes, always,” she replied, without knowing what she said, for her
+thoughts had wandered far from the subject, as soon afterwards appeared
+by her suddenly exclaiming, “I remember hearing you once say, Mr. Darcy,
+that you hardly ever forgave, that your resentment once created was
+unappeasable. You are very cautious, I suppose, as to its _being
+created_.”
+
+“I am,” said he, with a firm voice.
+
+“And never allow yourself to be blinded by prejudice?”
+
+“I hope not.”
+
+“It is particularly incumbent on those who never change their opinion,
+to be secure of judging properly at first.”
+
+“May I ask to what these questions tend?”
+
+“Merely to the illustration of _your_ character,” said she, endeavouring
+to shake off her gravity. “I am trying to make it out.”
+
+“And what is your success?”
+
+She shook her head. “I do not get on at all. I hear such different
+accounts of you as puzzle me exceedingly.”
+
+“I can readily believe,” answered he gravely, “that reports may vary
+greatly with respect to me; and I could wish, Miss Bennet, that you were
+not to sketch my character at the present moment, as there is reason to
+fear that the performance would reflect no credit on either.”
+
+“But if I do not take your likeness now, I may never have another
+opportunity.”
+
+“I would by no means suspend any pleasure of yours,” he coldly replied.
+She said no more, and they went down the other dance and parted in
+silence; and on each side dissatisfied, though not to an equal degree,
+for in Darcy’s breast there was a tolerably powerful feeling towards
+her, which soon procured her pardon, and directed all his anger against
+another.
+
+They had not long separated, when Miss Bingley came towards her, and
+with an expression of civil disdain accosted her:
+
+“So, Miss Eliza, I hear you are quite delighted with George Wickham!
+Your sister has been talking to me about him, and asking me a thousand
+questions; and I find that the young man quite forgot to tell you, among
+his other communication, that he was the son of old Wickham, the late
+Mr. Darcy’s steward. Let me recommend you, however, as a friend, not to
+give implicit confidence to all his assertions; for as to Mr. Darcy’s
+using him ill, it is perfectly false; for, on the contrary, he has
+always been remarkably kind to him, though George Wickham has treated
+Mr. Darcy in a most infamous manner. I do not know the particulars, but
+I know very well that Mr. Darcy is not in the least to blame, that he
+cannot bear to hear George Wickham mentioned, and that though my brother
+thought that he could not well avoid including him in his invitation to
+the officers, he was excessively glad to find that he had taken himself
+out of the way. His coming into the country at all is a most insolent
+thing, indeed, and I wonder how he could presume to do it. I pity you,
+Miss Eliza, for this discovery of your favourite’s guilt; but really,
+considering his descent, one could not expect much better.”
+
+“His guilt and his descent appear by your account to be the same,” said
+Elizabeth angrily; “for I have heard you accuse him of nothing worse
+than of being the son of Mr. Darcy’s steward, and of _that_, I can
+assure you, he informed me himself.”
+
+“I beg your pardon,” replied Miss Bingley, turning away with a sneer.
+“Excuse my interference--it was kindly meant.”
+
+“Insolent girl!” said Elizabeth to herself. “You are much mistaken
+if you expect to influence me by such a paltry attack as this. I see
+nothing in it but your own wilful ignorance and the malice of Mr.
+Darcy.” She then sought her eldest sister, who had undertaken to make
+inquiries on the same subject of Bingley. Jane met her with a smile of
+such sweet complacency, a glow of such happy expression, as sufficiently
+marked how well she was satisfied with the occurrences of the evening.
+Elizabeth instantly read her feelings, and at that moment solicitude for
+Wickham, resentment against his enemies, and everything else, gave way
+before the hope of Jane’s being in the fairest way for happiness.
+
+“I want to know,” said she, with a countenance no less smiling than her
+sister’s, “what you have learnt about Mr. Wickham. But perhaps you have
+been too pleasantly engaged to think of any third person; in which case
+you may be sure of my pardon.”
+
+“No,” replied Jane, “I have not forgotten him; but I have nothing
+satisfactory to tell you. Mr. Bingley does not know the whole of
+his history, and is quite ignorant of the circumstances which have
+principally offended Mr. Darcy; but he will vouch for the good conduct,
+the probity, and honour of his friend, and is perfectly convinced that
+Mr. Wickham has deserved much less attention from Mr. Darcy than he has
+received; and I am sorry to say by his account as well as his sister’s,
+Mr. Wickham is by no means a respectable young man. I am afraid he has
+been very imprudent, and has deserved to lose Mr. Darcy’s regard.”
+
+“Mr. Bingley does not know Mr. Wickham himself?”
+
+“No; he never saw him till the other morning at Meryton.”
+
+“This account then is what he has received from Mr. Darcy. I am
+satisfied. But what does he say of the living?”
+
+“He does not exactly recollect the circumstances, though he has heard
+them from Mr. Darcy more than once, but he believes that it was left to
+him _conditionally_ only.”
+
+“I have not a doubt of Mr. Bingley’s sincerity,” said Elizabeth warmly;
+“but you must excuse my not being convinced by assurances only. Mr.
+Bingley’s defense of his friend was a very able one, I dare say; but
+since he is unacquainted with several parts of the story, and has learnt
+the rest from that friend himself, I shall venture to still think of
+both gentlemen as I did before.”
+
+She then changed the discourse to one more gratifying to each, and on
+which there could be no difference of sentiment. Elizabeth listened with
+delight to the happy, though modest hopes which Jane entertained of Mr.
+Bingley’s regard, and said all in her power to heighten her confidence
+in it. On their being joined by Mr. Bingley himself, Elizabeth withdrew
+to Miss Lucas; to whose inquiry after the pleasantness of her last
+partner she had scarcely replied, before Mr. Collins came up to them,
+and told her with great exultation that he had just been so fortunate as
+to make a most important discovery.
+
+“I have found out,” said he, “by a singular accident, that there is now
+in the room a near relation of my patroness. I happened to overhear the
+gentleman himself mentioning to the young lady who does the honours of
+the house the names of his cousin Miss de Bourgh, and of her mother Lady
+Catherine. How wonderfully these sort of things occur! Who would have
+thought of my meeting with, perhaps, a nephew of Lady Catherine de
+Bourgh in this assembly! I am most thankful that the discovery is made
+in time for me to pay my respects to him, which I am now going to
+do, and trust he will excuse my not having done it before. My total
+ignorance of the connection must plead my apology.”
+
+“You are not going to introduce yourself to Mr. Darcy!”
+
+“Indeed I am. I shall entreat his pardon for not having done it earlier.
+I believe him to be Lady Catherine’s _nephew_. It will be in my power to
+assure him that her ladyship was quite well yesterday se’nnight.”
+
+Elizabeth tried hard to dissuade him from such a scheme, assuring him
+that Mr. Darcy would consider his addressing him without introduction
+as an impertinent freedom, rather than a compliment to his aunt; that
+it was not in the least necessary there should be any notice on either
+side; and that if it were, it must belong to Mr. Darcy, the superior in
+consequence, to begin the acquaintance. Mr. Collins listened to her
+with the determined air of following his own inclination, and, when she
+ceased speaking, replied thus:
+
+“My dear Miss Elizabeth, I have the highest opinion in the world in
+your excellent judgement in all matters within the scope of your
+understanding; but permit me to say, that there must be a wide
+difference between the established forms of ceremony amongst the laity,
+and those which regulate the clergy; for, give me leave to observe that
+I consider the clerical office as equal in point of dignity with
+the highest rank in the kingdom--provided that a proper humility of
+behaviour is at the same time maintained. You must therefore allow me to
+follow the dictates of my conscience on this occasion, which leads me to
+perform what I look on as a point of duty. Pardon me for neglecting to
+profit by your advice, which on every other subject shall be my constant
+guide, though in the case before us I consider myself more fitted by
+education and habitual study to decide on what is right than a young
+lady like yourself.” And with a low bow he left her to attack Mr.
+Darcy, whose reception of his advances she eagerly watched, and whose
+astonishment at being so addressed was very evident. Her cousin prefaced
+his speech with a solemn bow and though she could not hear a word of
+it, she felt as if hearing it all, and saw in the motion of his lips the
+words “apology,” “Hunsford,” and “Lady Catherine de Bourgh.” It vexed
+her to see him expose himself to such a man. Mr. Darcy was eyeing him
+with unrestrained wonder, and when at last Mr. Collins allowed him time
+to speak, replied with an air of distant civility. Mr. Collins, however,
+was not discouraged from speaking again, and Mr. Darcy’s contempt seemed
+abundantly increasing with the length of his second speech, and at the
+end of it he only made him a slight bow, and moved another way. Mr.
+Collins then returned to Elizabeth.
+
+“I have no reason, I assure you,” said he, “to be dissatisfied with my
+reception. Mr. Darcy seemed much pleased with the attention. He answered
+me with the utmost civility, and even paid me the compliment of saying
+that he was so well convinced of Lady Catherine’s discernment as to be
+certain she could never bestow a favour unworthily. It was really a very
+handsome thought. Upon the whole, I am much pleased with him.”
+
+As Elizabeth had no longer any interest of her own to pursue, she turned
+her attention almost entirely on her sister and Mr. Bingley; and the
+train of agreeable reflections which her observations gave birth to,
+made her perhaps almost as happy as Jane. She saw her in idea settled in
+that very house, in all the felicity which a marriage of true affection
+could bestow; and she felt capable, under such circumstances, of
+endeavouring even to like Bingley’s two sisters. Her mother’s thoughts
+she plainly saw were bent the same way, and she determined not to
+venture near her, lest she might hear too much. When they sat down to
+supper, therefore, she considered it a most unlucky perverseness which
+placed them within one of each other; and deeply was she vexed to find
+that her mother was talking to that one person (Lady Lucas) freely,
+openly, and of nothing else but her expectation that Jane would soon
+be married to Mr. Bingley. It was an animating subject, and Mrs. Bennet
+seemed incapable of fatigue while enumerating the advantages of the
+match. His being such a charming young man, and so rich, and living but
+three miles from them, were the first points of self-gratulation; and
+then it was such a comfort to think how fond the two sisters were of
+Jane, and to be certain that they must desire the connection as much as
+she could do. It was, moreover, such a promising thing for her younger
+daughters, as Jane’s marrying so greatly must throw them in the way of
+other rich men; and lastly, it was so pleasant at her time of life to be
+able to consign her single daughters to the care of their sister, that
+she might not be obliged to go into company more than she liked. It was
+necessary to make this circumstance a matter of pleasure, because on
+such occasions it is the etiquette; but no one was less likely than Mrs.
+Bennet to find comfort in staying home at any period of her life. She
+concluded with many good wishes that Lady Lucas might soon be equally
+fortunate, though evidently and triumphantly believing there was no
+chance of it.
+
+In vain did Elizabeth endeavour to check the rapidity of her mother’s
+words, or persuade her to describe her felicity in a less audible
+whisper; for, to her inexpressible vexation, she could perceive that the
+chief of it was overheard by Mr. Darcy, who sat opposite to them. Her
+mother only scolded her for being nonsensical.
+
+“What is Mr. Darcy to me, pray, that I should be afraid of him? I am
+sure we owe him no such particular civility as to be obliged to say
+nothing _he_ may not like to hear.”
+
+“For heaven’s sake, madam, speak lower. What advantage can it be for you
+to offend Mr. Darcy? You will never recommend yourself to his friend by
+so doing!”
+
+Nothing that she could say, however, had any influence. Her mother would
+talk of her views in the same intelligible tone. Elizabeth blushed and
+blushed again with shame and vexation. She could not help frequently
+glancing her eye at Mr. Darcy, though every glance convinced her of what
+she dreaded; for though he was not always looking at her mother, she was
+convinced that his attention was invariably fixed by her. The expression
+of his face changed gradually from indignant contempt to a composed and
+steady gravity.
+
+At length, however, Mrs. Bennet had no more to say; and Lady Lucas, who
+had been long yawning at the repetition of delights which she saw no
+likelihood of sharing, was left to the comforts of cold ham and
+chicken. Elizabeth now began to revive. But not long was the interval of
+tranquillity; for, when supper was over, singing was talked of, and
+she had the mortification of seeing Mary, after very little entreaty,
+preparing to oblige the company. By many significant looks and silent
+entreaties, did she endeavour to prevent such a proof of complaisance,
+but in vain; Mary would not understand them; such an opportunity of
+exhibiting was delightful to her, and she began her song. Elizabeth’s
+eyes were fixed on her with most painful sensations, and she watched her
+progress through the several stanzas with an impatience which was very
+ill rewarded at their close; for Mary, on receiving, amongst the thanks
+of the table, the hint of a hope that she might be prevailed on to
+favour them again, after the pause of half a minute began another.
+Mary’s powers were by no means fitted for such a display; her voice was
+weak, and her manner affected. Elizabeth was in agonies. She looked at
+Jane, to see how she bore it; but Jane was very composedly talking to
+Bingley. She looked at his two sisters, and saw them making signs
+of derision at each other, and at Darcy, who continued, however,
+imperturbably grave. She looked at her father to entreat his
+interference, lest Mary should be singing all night. He took the hint,
+and when Mary had finished her second song, said aloud, “That will do
+extremely well, child. You have delighted us long enough. Let the other
+young ladies have time to exhibit.”
+
+Mary, though pretending not to hear, was somewhat disconcerted; and
+Elizabeth, sorry for her, and sorry for her father’s speech, was afraid
+her anxiety had done no good. Others of the party were now applied to.
+
+“If I,” said Mr. Collins, “were so fortunate as to be able to sing, I
+should have great pleasure, I am sure, in obliging the company with an
+air; for I consider music as a very innocent diversion, and perfectly
+compatible with the profession of a clergyman. I do not mean, however,
+to assert that we can be justified in devoting too much of our time
+to music, for there are certainly other things to be attended to. The
+rector of a parish has much to do. In the first place, he must make
+such an agreement for tithes as may be beneficial to himself and not
+offensive to his patron. He must write his own sermons; and the time
+that remains will not be too much for his parish duties, and the care
+and improvement of his dwelling, which he cannot be excused from making
+as comfortable as possible. And I do not think it of light importance
+that he should have attentive and conciliatory manners towards everybody,
+especially towards those to whom he owes his preferment. I cannot acquit
+him of that duty; nor could I think well of the man who should omit an
+occasion of testifying his respect towards anybody connected with the
+family.” And with a bow to Mr. Darcy, he concluded his speech, which had
+been spoken so loud as to be heard by half the room. Many stared--many
+smiled; but no one looked more amused than Mr. Bennet himself, while his
+wife seriously commended Mr. Collins for having spoken so sensibly,
+and observed in a half-whisper to Lady Lucas, that he was a remarkably
+clever, good kind of young man.
+
+To Elizabeth it appeared that, had her family made an agreement to
+expose themselves as much as they could during the evening, it would
+have been impossible for them to play their parts with more spirit or
+finer success; and happy did she think it for Bingley and her sister
+that some of the exhibition had escaped his notice, and that his
+feelings were not of a sort to be much distressed by the folly which he
+must have witnessed. That his two sisters and Mr. Darcy, however, should
+have such an opportunity of ridiculing her relations, was bad enough,
+and she could not determine whether the silent contempt of the
+gentleman, or the insolent smiles of the ladies, were more intolerable.
+
+The rest of the evening brought her little amusement. She was teased by
+Mr. Collins, who continued most perseveringly by her side, and though
+he could not prevail on her to dance with him again, put it out of her
+power to dance with others. In vain did she entreat him to stand up with
+somebody else, and offer to introduce him to any young lady in the room.
+He assured her, that as to dancing, he was perfectly indifferent to it;
+that his chief object was by delicate attentions to recommend himself to
+her and that he should therefore make a point of remaining close to her
+the whole evening. There was no arguing upon such a project. She owed
+her greatest relief to her friend Miss Lucas, who often joined them, and
+good-naturedly engaged Mr. Collins’s conversation to herself.
+
+She was at least free from the offense of Mr. Darcy’s further notice;
+though often standing within a very short distance of her, quite
+disengaged, he never came near enough to speak. She felt it to be the
+probable consequence of her allusions to Mr. Wickham, and rejoiced in
+it.
+
+The Longbourn party were the last of all the company to depart, and, by
+a manoeuvre of Mrs. Bennet, had to wait for their carriage a quarter of
+an hour after everybody else was gone, which gave them time to see how
+heartily they were wished away by some of the family. Mrs. Hurst and her
+sister scarcely opened their mouths, except to complain of fatigue, and
+were evidently impatient to have the house to themselves. They repulsed
+every attempt of Mrs. Bennet at conversation, and by so doing threw a
+languor over the whole party, which was very little relieved by the
+long speeches of Mr. Collins, who was complimenting Mr. Bingley and his
+sisters on the elegance of their entertainment, and the hospitality and
+politeness which had marked their behaviour to their guests. Darcy said
+nothing at all. Mr. Bennet, in equal silence, was enjoying the scene.
+Mr. Bingley and Jane were standing together, a little detached from the
+rest, and talked only to each other. Elizabeth preserved as steady a
+silence as either Mrs. Hurst or Miss Bingley; and even Lydia was too
+much fatigued to utter more than the occasional exclamation of “Lord,
+how tired I am!” accompanied by a violent yawn.
+
+When at length they arose to take leave, Mrs. Bennet was most pressingly
+civil in her hope of seeing the whole family soon at Longbourn, and
+addressed herself especially to Mr. Bingley, to assure him how happy he
+would make them by eating a family dinner with them at any time, without
+the ceremony of a formal invitation. Bingley was all grateful pleasure,
+and he readily engaged for taking the earliest opportunity of waiting on
+her, after his return from London, whither he was obliged to go the next
+day for a short time.
+
+Mrs. Bennet was perfectly satisfied, and quitted the house under the
+delightful persuasion that, allowing for the necessary preparations of
+settlements, new carriages, and wedding clothes, she should undoubtedly
+see her daughter settled at Netherfield in the course of three or four
+months. Of having another daughter married to Mr. Collins, she thought
+with equal certainty, and with considerable, though not equal, pleasure.
+Elizabeth was the least dear to her of all her children; and though the
+man and the match were quite good enough for _her_, the worth of each
+was eclipsed by Mr. Bingley and Netherfield.
+
+
+
+Chapter 19
+
+
+The next day opened a new scene at Longbourn. Mr. Collins made his
+declaration in form. Having resolved to do it without loss of time, as
+his leave of absence extended only to the following Saturday, and having
+no feelings of diffidence to make it distressing to himself even at
+the moment, he set about it in a very orderly manner, with all the
+observances, which he supposed a regular part of the business. On
+finding Mrs. Bennet, Elizabeth, and one of the younger girls together,
+soon after breakfast, he addressed the mother in these words:
+
+“May I hope, madam, for your interest with your fair daughter Elizabeth,
+when I solicit for the honour of a private audience with her in the
+course of this morning?”
+
+Before Elizabeth had time for anything but a blush of surprise, Mrs.
+Bennet answered instantly, “Oh dear!--yes--certainly. I am sure Lizzy
+will be very happy--I am sure she can have no objection. Come, Kitty, I
+want you up stairs.” And, gathering her work together, she was hastening
+away, when Elizabeth called out:
+
+“Dear madam, do not go. I beg you will not go. Mr. Collins must excuse
+me. He can have nothing to say to me that anybody need not hear. I am
+going away myself.”
+
+“No, no, nonsense, Lizzy. I desire you to stay where you are.” And upon
+Elizabeth’s seeming really, with vexed and embarrassed looks, about to
+escape, she added: “Lizzy, I _insist_ upon your staying and hearing Mr.
+Collins.”
+
+Elizabeth would not oppose such an injunction--and a moment’s
+consideration making her also sensible that it would be wisest to get it
+over as soon and as quietly as possible, she sat down again and tried to
+conceal, by incessant employment the feelings which were divided between
+distress and diversion. Mrs. Bennet and Kitty walked off, and as soon as
+they were gone, Mr. Collins began.
+
+“Believe me, my dear Miss Elizabeth, that your modesty, so far from
+doing you any disservice, rather adds to your other perfections. You
+would have been less amiable in my eyes had there _not_ been this little
+unwillingness; but allow me to assure you, that I have your respected
+mother’s permission for this address. You can hardly doubt the
+purport of my discourse, however your natural delicacy may lead you to
+dissemble; my attentions have been too marked to be mistaken. Almost as
+soon as I entered the house, I singled you out as the companion of
+my future life. But before I am run away with by my feelings on this
+subject, perhaps it would be advisable for me to state my reasons for
+marrying--and, moreover, for coming into Hertfordshire with the design
+of selecting a wife, as I certainly did.”
+
+The idea of Mr. Collins, with all his solemn composure, being run away
+with by his feelings, made Elizabeth so near laughing, that she could
+not use the short pause he allowed in any attempt to stop him further,
+and he continued:
+
+“My reasons for marrying are, first, that I think it a right thing for
+every clergyman in easy circumstances (like myself) to set the example
+of matrimony in his parish; secondly, that I am convinced that it will
+add very greatly to my happiness; and thirdly--which perhaps I ought
+to have mentioned earlier, that it is the particular advice and
+recommendation of the very noble lady whom I have the honour of calling
+patroness. Twice has she condescended to give me her opinion (unasked
+too!) on this subject; and it was but the very Saturday night before I
+left Hunsford--between our pools at quadrille, while Mrs. Jenkinson was
+arranging Miss de Bourgh’s footstool, that she said, ‘Mr. Collins, you
+must marry. A clergyman like you must marry. Choose properly, choose
+a gentlewoman for _my_ sake; and for your _own_, let her be an active,
+useful sort of person, not brought up high, but able to make a small
+income go a good way. This is my advice. Find such a woman as soon as
+you can, bring her to Hunsford, and I will visit her.’ Allow me, by the
+way, to observe, my fair cousin, that I do not reckon the notice
+and kindness of Lady Catherine de Bourgh as among the least of the
+advantages in my power to offer. You will find her manners beyond
+anything I can describe; and your wit and vivacity, I think, must be
+acceptable to her, especially when tempered with the silence and
+respect which her rank will inevitably excite. Thus much for my general
+intention in favour of matrimony; it remains to be told why my views
+were directed towards Longbourn instead of my own neighbourhood, where I
+can assure you there are many amiable young women. But the fact is, that
+being, as I am, to inherit this estate after the death of your honoured
+father (who, however, may live many years longer), I could not satisfy
+myself without resolving to choose a wife from among his daughters, that
+the loss to them might be as little as possible, when the melancholy
+event takes place--which, however, as I have already said, may not
+be for several years. This has been my motive, my fair cousin, and
+I flatter myself it will not sink me in your esteem. And now nothing
+remains for me but to assure you in the most animated language of the
+violence of my affection. To fortune I am perfectly indifferent, and
+shall make no demand of that nature on your father, since I am well
+aware that it could not be complied with; and that one thousand pounds
+in the four per cents, which will not be yours till after your mother’s
+decease, is all that you may ever be entitled to. On that head,
+therefore, I shall be uniformly silent; and you may assure yourself that
+no ungenerous reproach shall ever pass my lips when we are married.”
+
+It was absolutely necessary to interrupt him now.
+
+“You are too hasty, sir,” she cried. “You forget that I have made no
+answer. Let me do it without further loss of time. Accept my thanks for
+the compliment you are paying me. I am very sensible of the honour of
+your proposals, but it is impossible for me to do otherwise than to
+decline them.”
+
+“I am not now to learn,” replied Mr. Collins, with a formal wave of the
+hand, “that it is usual with young ladies to reject the addresses of the
+man whom they secretly mean to accept, when he first applies for their
+favour; and that sometimes the refusal is repeated a second, or even a
+third time. I am therefore by no means discouraged by what you have just
+said, and shall hope to lead you to the altar ere long.”
+
+“Upon my word, sir,” cried Elizabeth, “your hope is a rather
+extraordinary one after my declaration. I do assure you that I am not
+one of those young ladies (if such young ladies there are) who are so
+daring as to risk their happiness on the chance of being asked a second
+time. I am perfectly serious in my refusal. You could not make _me_
+happy, and I am convinced that I am the last woman in the world who
+could make you so. Nay, were your friend Lady Catherine to know me, I
+am persuaded she would find me in every respect ill qualified for the
+situation.”
+
+“Were it certain that Lady Catherine would think so,” said Mr. Collins
+very gravely--“but I cannot imagine that her ladyship would at all
+disapprove of you. And you may be certain when I have the honour of
+seeing her again, I shall speak in the very highest terms of your
+modesty, economy, and other amiable qualification.”
+
+“Indeed, Mr. Collins, all praise of me will be unnecessary. You
+must give me leave to judge for myself, and pay me the compliment
+of believing what I say. I wish you very happy and very rich, and by
+refusing your hand, do all in my power to prevent your being otherwise.
+In making me the offer, you must have satisfied the delicacy of your
+feelings with regard to my family, and may take possession of Longbourn
+estate whenever it falls, without any self-reproach. This matter may
+be considered, therefore, as finally settled.” And rising as she
+thus spoke, she would have quitted the room, had Mr. Collins not thus
+addressed her:
+
+“When I do myself the honour of speaking to you next on the subject, I
+shall hope to receive a more favourable answer than you have now given
+me; though I am far from accusing you of cruelty at present, because I
+know it to be the established custom of your sex to reject a man on
+the first application, and perhaps you have even now said as much to
+encourage my suit as would be consistent with the true delicacy of the
+female character.”
+
+“Really, Mr. Collins,” cried Elizabeth with some warmth, “you puzzle me
+exceedingly. If what I have hitherto said can appear to you in the form
+of encouragement, I know not how to express my refusal in such a way as
+to convince you of its being one.”
+
+“You must give me leave to flatter myself, my dear cousin, that your
+refusal of my addresses is merely words of course. My reasons for
+believing it are briefly these: It does not appear to me that my hand is
+unworthy of your acceptance, or that the establishment I can offer would
+be any other than highly desirable. My situation in life, my connections
+with the family of de Bourgh, and my relationship to your own, are
+circumstances highly in my favour; and you should take it into further
+consideration, that in spite of your manifold attractions, it is by no
+means certain that another offer of marriage may ever be made you. Your
+portion is unhappily so small that it will in all likelihood undo
+the effects of your loveliness and amiable qualifications. As I must
+therefore conclude that you are not serious in your rejection of me,
+I shall choose to attribute it to your wish of increasing my love by
+suspense, according to the usual practice of elegant females.”
+
+“I do assure you, sir, that I have no pretensions whatever to that kind
+of elegance which consists in tormenting a respectable man. I would
+rather be paid the compliment of being believed sincere. I thank you
+again and again for the honour you have done me in your proposals, but
+to accept them is absolutely impossible. My feelings in every respect
+forbid it. Can I speak plainer? Do not consider me now as an elegant
+female, intending to plague you, but as a rational creature, speaking
+the truth from her heart.”
+
+“You are uniformly charming!” cried he, with an air of awkward
+gallantry; “and I am persuaded that when sanctioned by the express
+authority of both your excellent parents, my proposals will not fail of
+being acceptable.”
+
+To such perseverance in wilful self-deception Elizabeth would make
+no reply, and immediately and in silence withdrew; determined, if
+he persisted in considering her repeated refusals as flattering
+encouragement, to apply to her father, whose negative might be uttered
+in such a manner as to be decisive, and whose behaviour at least could
+not be mistaken for the affectation and coquetry of an elegant female.
+
+
+
+Chapter 20
+
+
+Mr. Collins was not left long to the silent contemplation of his
+successful love; for Mrs. Bennet, having dawdled about in the vestibule
+to watch for the end of the conference, no sooner saw Elizabeth open
+the door and with quick step pass her towards the staircase, than she
+entered the breakfast-room, and congratulated both him and herself in
+warm terms on the happy prospect of their nearer connection. Mr. Collins
+received and returned these felicitations with equal pleasure, and then
+proceeded to relate the particulars of their interview, with the result
+of which he trusted he had every reason to be satisfied, since the
+refusal which his cousin had steadfastly given him would naturally flow
+from her bashful modesty and the genuine delicacy of her character.
+
+This information, however, startled Mrs. Bennet; she would have been
+glad to be equally satisfied that her daughter had meant to encourage
+him by protesting against his proposals, but she dared not believe it,
+and could not help saying so.
+
+“But, depend upon it, Mr. Collins,” she added, “that Lizzy shall be
+brought to reason. I will speak to her about it directly. She is a very
+headstrong, foolish girl, and does not know her own interest but I will
+_make_ her know it.”
+
+“Pardon me for interrupting you, madam,” cried Mr. Collins; “but if
+she is really headstrong and foolish, I know not whether she would
+altogether be a very desirable wife to a man in my situation, who
+naturally looks for happiness in the marriage state. If therefore she
+actually persists in rejecting my suit, perhaps it were better not
+to force her into accepting me, because if liable to such defects of
+temper, she could not contribute much to my felicity.”
+
+“Sir, you quite misunderstand me,” said Mrs. Bennet, alarmed. “Lizzy is
+only headstrong in such matters as these. In everything else she is as
+good-natured a girl as ever lived. I will go directly to Mr. Bennet, and
+we shall very soon settle it with her, I am sure.”
+
+She would not give him time to reply, but hurrying instantly to her
+husband, called out as she entered the library, “Oh! Mr. Bennet, you
+are wanted immediately; we are all in an uproar. You must come and make
+Lizzy marry Mr. Collins, for she vows she will not have him, and if you
+do not make haste he will change his mind and not have _her_.”
+
+Mr. Bennet raised his eyes from his book as she entered, and fixed them
+on her face with a calm unconcern which was not in the least altered by
+her communication.
+
+“I have not the pleasure of understanding you,” said he, when she had
+finished her speech. “Of what are you talking?”
+
+“Of Mr. Collins and Lizzy. Lizzy declares she will not have Mr. Collins,
+and Mr. Collins begins to say that he will not have Lizzy.”
+
+“And what am I to do on the occasion? It seems an hopeless business.”
+
+“Speak to Lizzy about it yourself. Tell her that you insist upon her
+marrying him.”
+
+“Let her be called down. She shall hear my opinion.”
+
+Mrs. Bennet rang the bell, and Miss Elizabeth was summoned to the
+library.
+
+“Come here, child,” cried her father as she appeared. “I have sent for
+you on an affair of importance. I understand that Mr. Collins has made
+you an offer of marriage. Is it true?” Elizabeth replied that it was.
+“Very well--and this offer of marriage you have refused?”
+
+“I have, sir.”
+
+“Very well. We now come to the point. Your mother insists upon your
+accepting it. Is it not so, Mrs. Bennet?”
+
+“Yes, or I will never see her again.”
+
+“An unhappy alternative is before you, Elizabeth. From this day you must
+be a stranger to one of your parents. Your mother will never see you
+again if you do _not_ marry Mr. Collins, and I will never see you again
+if you _do_.”
+
+Elizabeth could not but smile at such a conclusion of such a beginning,
+but Mrs. Bennet, who had persuaded herself that her husband regarded the
+affair as she wished, was excessively disappointed.
+
+“What do you mean, Mr. Bennet, in talking this way? You promised me to
+_insist_ upon her marrying him.”
+
+“My dear,” replied her husband, “I have two small favours to request.
+First, that you will allow me the free use of my understanding on the
+present occasion; and secondly, of my room. I shall be glad to have the
+library to myself as soon as may be.”
+
+Not yet, however, in spite of her disappointment in her husband, did
+Mrs. Bennet give up the point. She talked to Elizabeth again and again;
+coaxed and threatened her by turns. She endeavoured to secure Jane
+in her interest; but Jane, with all possible mildness, declined
+interfering; and Elizabeth, sometimes with real earnestness, and
+sometimes with playful gaiety, replied to her attacks. Though her manner
+varied, however, her determination never did.
+
+Mr. Collins, meanwhile, was meditating in solitude on what had passed.
+He thought too well of himself to comprehend on what motives his cousin
+could refuse him; and though his pride was hurt, he suffered in no other
+way. His regard for her was quite imaginary; and the possibility of her
+deserving her mother’s reproach prevented his feeling any regret.
+
+While the family were in this confusion, Charlotte Lucas came to spend
+the day with them. She was met in the vestibule by Lydia, who, flying to
+her, cried in a half whisper, “I am glad you are come, for there is such
+fun here! What do you think has happened this morning? Mr. Collins has
+made an offer to Lizzy, and she will not have him.”
+
+Charlotte hardly had time to answer, before they were joined by Kitty,
+who came to tell the same news; and no sooner had they entered the
+breakfast-room, where Mrs. Bennet was alone, than she likewise began on
+the subject, calling on Miss Lucas for her compassion, and entreating
+her to persuade her friend Lizzy to comply with the wishes of all her
+family. “Pray do, my dear Miss Lucas,” she added in a melancholy tone,
+“for nobody is on my side, nobody takes part with me. I am cruelly used,
+nobody feels for my poor nerves.”
+
+Charlotte’s reply was spared by the entrance of Jane and Elizabeth.
+
+“Aye, there she comes,” continued Mrs. Bennet, “looking as unconcerned
+as may be, and caring no more for us than if we were at York, provided
+she can have her own way. But I tell you, Miss Lizzy--if you take it
+into your head to go on refusing every offer of marriage in this way,
+you will never get a husband at all--and I am sure I do not know who is
+to maintain you when your father is dead. I shall not be able to keep
+you--and so I warn you. I have done with you from this very day. I told
+you in the library, you know, that I should never speak to you again,
+and you will find me as good as my word. I have no pleasure in talking
+to undutiful children. Not that I have much pleasure, indeed, in talking
+to anybody. People who suffer as I do from nervous complaints can have
+no great inclination for talking. Nobody can tell what I suffer! But it
+is always so. Those who do not complain are never pitied.”
+
+Her daughters listened in silence to this effusion, sensible that
+any attempt to reason with her or soothe her would only increase the
+irritation. She talked on, therefore, without interruption from any of
+them, till they were joined by Mr. Collins, who entered the room with
+an air more stately than usual, and on perceiving whom, she said to
+the girls, “Now, I do insist upon it, that you, all of you, hold
+your tongues, and let me and Mr. Collins have a little conversation
+together.”
+
+Elizabeth passed quietly out of the room, Jane and Kitty followed, but
+Lydia stood her ground, determined to hear all she could; and Charlotte,
+detained first by the civility of Mr. Collins, whose inquiries after
+herself and all her family were very minute, and then by a little
+curiosity, satisfied herself with walking to the window and pretending
+not to hear. In a doleful voice Mrs. Bennet began the projected
+conversation: “Oh! Mr. Collins!”
+
+“My dear madam,” replied he, “let us be for ever silent on this point.
+Far be it from me,” he presently continued, in a voice that marked his
+displeasure, “to resent the behaviour of your daughter. Resignation
+to inevitable evils is the duty of us all; the peculiar duty of a
+young man who has been so fortunate as I have been in early preferment;
+and I trust I am resigned. Perhaps not the less so from feeling a doubt
+of my positive happiness had my fair cousin honoured me with her hand;
+for I have often observed that resignation is never so perfect as
+when the blessing denied begins to lose somewhat of its value in our
+estimation. You will not, I hope, consider me as showing any disrespect
+to your family, my dear madam, by thus withdrawing my pretensions to
+your daughter’s favour, without having paid yourself and Mr. Bennet the
+compliment of requesting you to interpose your authority in my
+behalf. My conduct may, I fear, be objectionable in having accepted my
+dismission from your daughter’s lips instead of your own. But we are all
+liable to error. I have certainly meant well through the whole affair.
+My object has been to secure an amiable companion for myself, with due
+consideration for the advantage of all your family, and if my _manner_
+has been at all reprehensible, I here beg leave to apologise.”
+
+
+
+Chapter 21
+
+
+The discussion of Mr. Collins’s offer was now nearly at an end, and
+Elizabeth had only to suffer from the uncomfortable feelings necessarily
+attending it, and occasionally from some peevish allusions of her
+mother. As for the gentleman himself, _his_ feelings were chiefly
+expressed, not by embarrassment or dejection, or by trying to avoid her,
+but by stiffness of manner and resentful silence. He scarcely ever spoke
+to her, and the assiduous attentions which he had been so sensible of
+himself were transferred for the rest of the day to Miss Lucas, whose
+civility in listening to him was a seasonable relief to them all, and
+especially to her friend.
+
+The morrow produced no abatement of Mrs. Bennet’s ill-humour or ill
+health. Mr. Collins was also in the same state of angry pride. Elizabeth
+had hoped that his resentment might shorten his visit, but his plan did
+not appear in the least affected by it. He was always to have gone on
+Saturday, and to Saturday he meant to stay.
+
+After breakfast, the girls walked to Meryton to inquire if Mr. Wickham
+were returned, and to lament over his absence from the Netherfield ball.
+He joined them on their entering the town, and attended them to their
+aunt’s where his regret and vexation, and the concern of everybody, was
+well talked over. To Elizabeth, however, he voluntarily acknowledged
+that the necessity of his absence _had_ been self-imposed.
+
+“I found,” said he, “as the time drew near that I had better not meet
+Mr. Darcy; that to be in the same room, the same party with him for so
+many hours together, might be more than I could bear, and that scenes
+might arise unpleasant to more than myself.”
+
+She highly approved his forbearance, and they had leisure for a full
+discussion of it, and for all the commendation which they civilly
+bestowed on each other, as Wickham and another officer walked back with
+them to Longbourn, and during the walk he particularly attended to
+her. His accompanying them was a double advantage; she felt all the
+compliment it offered to herself, and it was most acceptable as an
+occasion of introducing him to her father and mother.
+
+Soon after their return, a letter was delivered to Miss Bennet; it came
+from Netherfield. The envelope contained a sheet of elegant, little,
+hot-pressed paper, well covered with a lady’s fair, flowing hand; and
+Elizabeth saw her sister’s countenance change as she read it, and saw
+her dwelling intently on some particular passages. Jane recollected
+herself soon, and putting the letter away, tried to join with her usual
+cheerfulness in the general conversation; but Elizabeth felt an anxiety
+on the subject which drew off her attention even from Wickham; and no
+sooner had he and his companion taken leave, than a glance from Jane
+invited her to follow her up stairs. When they had gained their own room,
+Jane, taking out the letter, said:
+
+“This is from Caroline Bingley; what it contains has surprised me a good
+deal. The whole party have left Netherfield by this time, and are on
+their way to town--and without any intention of coming back again. You
+shall hear what she says.”
+
+She then read the first sentence aloud, which comprised the information
+of their having just resolved to follow their brother to town directly,
+and of their meaning to dine in Grosvenor Street, where Mr. Hurst had a
+house. The next was in these words: “I do not pretend to regret anything
+I shall leave in Hertfordshire, except your society, my dearest friend;
+but we will hope, at some future period, to enjoy many returns of that
+delightful intercourse we have known, and in the meanwhile may
+lessen the pain of separation by a very frequent and most unreserved
+correspondence. I depend on you for that.” To these highflown
+expressions Elizabeth listened with all the insensibility of distrust;
+and though the suddenness of their removal surprised her, she saw
+nothing in it really to lament; it was not to be supposed that their
+absence from Netherfield would prevent Mr. Bingley’s being there; and as
+to the loss of their society, she was persuaded that Jane must cease to
+regard it, in the enjoyment of his.
+
+“It is unlucky,” said she, after a short pause, “that you should not be
+able to see your friends before they leave the country. But may we not
+hope that the period of future happiness to which Miss Bingley looks
+forward may arrive earlier than she is aware, and that the delightful
+intercourse you have known as friends will be renewed with yet greater
+satisfaction as sisters? Mr. Bingley will not be detained in London by
+them.”
+
+“Caroline decidedly says that none of the party will return into
+Hertfordshire this winter. I will read it to you:”
+
+“When my brother left us yesterday, he imagined that the business which
+took him to London might be concluded in three or four days; but as we
+are certain it cannot be so, and at the same time convinced that when
+Charles gets to town he will be in no hurry to leave it again, we have
+determined on following him thither, that he may not be obliged to spend
+his vacant hours in a comfortless hotel. Many of my acquaintances are
+already there for the winter; I wish that I could hear that you, my
+dearest friend, had any intention of making one of the crowd--but of
+that I despair. I sincerely hope your Christmas in Hertfordshire may
+abound in the gaieties which that season generally brings, and that your
+beaux will be so numerous as to prevent your feeling the loss of the
+three of whom we shall deprive you.”
+
+“It is evident by this,” added Jane, “that he comes back no more this
+winter.”
+
+“It is only evident that Miss Bingley does not mean that he _should_.”
+
+“Why will you think so? It must be his own doing. He is his own
+master. But you do not know _all_. I _will_ read you the passage which
+particularly hurts me. I will have no reserves from _you_.”
+
+“Mr. Darcy is impatient to see his sister; and, to confess the truth,
+_we_ are scarcely less eager to meet her again. I really do not think
+Georgiana Darcy has her equal for beauty, elegance, and accomplishments;
+and the affection she inspires in Louisa and myself is heightened into
+something still more interesting, from the hope we dare entertain of
+her being hereafter our sister. I do not know whether I ever before
+mentioned to you my feelings on this subject; but I will not leave the
+country without confiding them, and I trust you will not esteem them
+unreasonable. My brother admires her greatly already; he will have
+frequent opportunity now of seeing her on the most intimate footing;
+her relations all wish the connection as much as his own; and a sister’s
+partiality is not misleading me, I think, when I call Charles most
+capable of engaging any woman’s heart. With all these circumstances to
+favour an attachment, and nothing to prevent it, am I wrong, my dearest
+Jane, in indulging the hope of an event which will secure the happiness
+of so many?”
+
+“What do you think of _this_ sentence, my dear Lizzy?” said Jane as she
+finished it. “Is it not clear enough? Does it not expressly declare that
+Caroline neither expects nor wishes me to be her sister; that she is
+perfectly convinced of her brother’s indifference; and that if she
+suspects the nature of my feelings for him, she means (most kindly!) to
+put me on my guard? Can there be any other opinion on the subject?”
+
+“Yes, there can; for mine is totally different. Will you hear it?”
+
+“Most willingly.”
+
+“You shall have it in a few words. Miss Bingley sees that her brother is
+in love with you, and wants him to marry Miss Darcy. She follows him
+to town in hope of keeping him there, and tries to persuade you that he
+does not care about you.”
+
+Jane shook her head.
+
+“Indeed, Jane, you ought to believe me. No one who has ever seen you
+together can doubt his affection. Miss Bingley, I am sure, cannot. She
+is not such a simpleton. Could she have seen half as much love in Mr.
+Darcy for herself, she would have ordered her wedding clothes. But the
+case is this: We are not rich enough or grand enough for them; and she
+is the more anxious to get Miss Darcy for her brother, from the notion
+that when there has been _one_ intermarriage, she may have less trouble
+in achieving a second; in which there is certainly some ingenuity, and
+I dare say it would succeed, if Miss de Bourgh were out of the way. But,
+my dearest Jane, you cannot seriously imagine that because Miss Bingley
+tells you her brother greatly admires Miss Darcy, he is in the smallest
+degree less sensible of _your_ merit than when he took leave of you on
+Tuesday, or that it will be in her power to persuade him that, instead
+of being in love with you, he is very much in love with her friend.”
+
+“If we thought alike of Miss Bingley,” replied Jane, “your
+representation of all this might make me quite easy. But I know the
+foundation is unjust. Caroline is incapable of wilfully deceiving
+anyone; and all that I can hope in this case is that she is deceiving
+herself.”
+
+“That is right. You could not have started a more happy idea, since you
+will not take comfort in mine. Believe her to be deceived, by all means.
+You have now done your duty by her, and must fret no longer.”
+
+“But, my dear sister, can I be happy, even supposing the best, in
+accepting a man whose sisters and friends are all wishing him to marry
+elsewhere?”
+
+“You must decide for yourself,” said Elizabeth; “and if, upon mature
+deliberation, you find that the misery of disobliging his two sisters is
+more than equivalent to the happiness of being his wife, I advise you by
+all means to refuse him.”
+
+“How can you talk so?” said Jane, faintly smiling. “You must know that
+though I should be exceedingly grieved at their disapprobation, I could
+not hesitate.”
+
+“I did not think you would; and that being the case, I cannot consider
+your situation with much compassion.”
+
+“But if he returns no more this winter, my choice will never be
+required. A thousand things may arise in six months!”
+
+The idea of his returning no more Elizabeth treated with the utmost
+contempt. It appeared to her merely the suggestion of Caroline’s
+interested wishes, and she could not for a moment suppose that those
+wishes, however openly or artfully spoken, could influence a young man
+so totally independent of everyone.
+
+She represented to her sister as forcibly as possible what she felt
+on the subject, and had soon the pleasure of seeing its happy effect.
+Jane’s temper was not desponding, and she was gradually led to hope,
+though the diffidence of affection sometimes overcame the hope, that
+Bingley would return to Netherfield and answer every wish of her heart.
+
+They agreed that Mrs. Bennet should only hear of the departure of the
+family, without being alarmed on the score of the gentleman’s conduct;
+but even this partial communication gave her a great deal of concern,
+and she bewailed it as exceedingly unlucky that the ladies should happen
+to go away just as they were all getting so intimate together. After
+lamenting it, however, at some length, she had the consolation that Mr.
+Bingley would be soon down again and soon dining at Longbourn, and the
+conclusion of all was the comfortable declaration, that though he had
+been invited only to a family dinner, she would take care to have two
+full courses.
+
+
+
+Chapter 22
+
+
+The Bennets were engaged to dine with the Lucases and again during the
+chief of the day was Miss Lucas so kind as to listen to Mr. Collins.
+Elizabeth took an opportunity of thanking her. “It keeps him in good
+humour,” said she, “and I am more obliged to you than I can express.”
+ Charlotte assured her friend of her satisfaction in being useful, and
+that it amply repaid her for the little sacrifice of her time. This was
+very amiable, but Charlotte’s kindness extended farther than Elizabeth
+had any conception of; its object was nothing else than to secure her
+from any return of Mr. Collins’s addresses, by engaging them towards
+herself. Such was Miss Lucas’s scheme; and appearances were so
+favourable, that when they parted at night, she would have felt almost
+secure of success if he had not been to leave Hertfordshire so very
+soon. But here she did injustice to the fire and independence of his
+character, for it led him to escape out of Longbourn House the next
+morning with admirable slyness, and hasten to Lucas Lodge to throw
+himself at her feet. He was anxious to avoid the notice of his cousins,
+from a conviction that if they saw him depart, they could not fail to
+conjecture his design, and he was not willing to have the attempt known
+till its success might be known likewise; for though feeling almost
+secure, and with reason, for Charlotte had been tolerably encouraging,
+he was comparatively diffident since the adventure of Wednesday.
+His reception, however, was of the most flattering kind. Miss Lucas
+perceived him from an upper window as he walked towards the house, and
+instantly set out to meet him accidentally in the lane. But little had
+she dared to hope that so much love and eloquence awaited her there.
+
+In as short a time as Mr. Collins’s long speeches would allow,
+everything was settled between them to the satisfaction of both; and as
+they entered the house he earnestly entreated her to name the day that
+was to make him the happiest of men; and though such a solicitation must
+be waived for the present, the lady felt no inclination to trifle with
+his happiness. The stupidity with which he was favoured by nature must
+guard his courtship from any charm that could make a woman wish for its
+continuance; and Miss Lucas, who accepted him solely from the pure
+and disinterested desire of an establishment, cared not how soon that
+establishment were gained.
+
+Sir William and Lady Lucas were speedily applied to for their consent;
+and it was bestowed with a most joyful alacrity. Mr. Collins’s present
+circumstances made it a most eligible match for their daughter, to whom
+they could give little fortune; and his prospects of future wealth were
+exceedingly fair. Lady Lucas began directly to calculate, with more
+interest than the matter had ever excited before, how many years longer
+Mr. Bennet was likely to live; and Sir William gave it as his decided
+opinion, that whenever Mr. Collins should be in possession of the
+Longbourn estate, it would be highly expedient that both he and his wife
+should make their appearance at St. James’s. The whole family, in short,
+were properly overjoyed on the occasion. The younger girls formed hopes
+of _coming out_ a year or two sooner than they might otherwise have
+done; and the boys were relieved from their apprehension of Charlotte’s
+dying an old maid. Charlotte herself was tolerably composed. She had
+gained her point, and had time to consider of it. Her reflections were
+in general satisfactory. Mr. Collins, to be sure, was neither sensible
+nor agreeable; his society was irksome, and his attachment to her must
+be imaginary. But still he would be her husband. Without thinking highly
+either of men or matrimony, marriage had always been her object; it was
+the only provision for well-educated young women of small fortune,
+and however uncertain of giving happiness, must be their pleasantest
+preservative from want. This preservative she had now obtained; and at
+the age of twenty-seven, without having ever been handsome, she felt all
+the good luck of it. The least agreeable circumstance in the business
+was the surprise it must occasion to Elizabeth Bennet, whose friendship
+she valued beyond that of any other person. Elizabeth would wonder,
+and probably would blame her; and though her resolution was not to be
+shaken, her feelings must be hurt by such a disapprobation. She resolved
+to give her the information herself, and therefore charged Mr. Collins,
+when he returned to Longbourn to dinner, to drop no hint of what had
+passed before any of the family. A promise of secrecy was of course very
+dutifully given, but it could not be kept without difficulty; for the
+curiosity excited by his long absence burst forth in such very direct
+questions on his return as required some ingenuity to evade, and he was
+at the same time exercising great self-denial, for he was longing to
+publish his prosperous love.
+
+As he was to begin his journey too early on the morrow to see any of the
+family, the ceremony of leave-taking was performed when the ladies moved
+for the night; and Mrs. Bennet, with great politeness and cordiality,
+said how happy they should be to see him at Longbourn again, whenever
+his engagements might allow him to visit them.
+
+“My dear madam,” he replied, “this invitation is particularly
+gratifying, because it is what I have been hoping to receive; and
+you may be very certain that I shall avail myself of it as soon as
+possible.”
+
+They were all astonished; and Mr. Bennet, who could by no means wish for
+so speedy a return, immediately said:
+
+“But is there not danger of Lady Catherine’s disapprobation here, my
+good sir? You had better neglect your relations than run the risk of
+offending your patroness.”
+
+“My dear sir,” replied Mr. Collins, “I am particularly obliged to you
+for this friendly caution, and you may depend upon my not taking so
+material a step without her ladyship’s concurrence.”
+
+“You cannot be too much upon your guard. Risk anything rather than her
+displeasure; and if you find it likely to be raised by your coming to us
+again, which I should think exceedingly probable, stay quietly at home,
+and be satisfied that _we_ shall take no offence.”
+
+“Believe me, my dear sir, my gratitude is warmly excited by such
+affectionate attention; and depend upon it, you will speedily receive
+from me a letter of thanks for this, and for every other mark of your
+regard during my stay in Hertfordshire. As for my fair cousins, though
+my absence may not be long enough to render it necessary, I shall now
+take the liberty of wishing them health and happiness, not excepting my
+cousin Elizabeth.”
+
+With proper civilities the ladies then withdrew; all of them equally
+surprised that he meditated a quick return. Mrs. Bennet wished to
+understand by it that he thought of paying his addresses to one of her
+younger girls, and Mary might have been prevailed on to accept him.
+She rated his abilities much higher than any of the others; there was
+a solidity in his reflections which often struck her, and though by no
+means so clever as herself, she thought that if encouraged to read
+and improve himself by such an example as hers, he might become a very
+agreeable companion. But on the following morning, every hope of this
+kind was done away. Miss Lucas called soon after breakfast, and in a
+private conference with Elizabeth related the event of the day before.
+
+The possibility of Mr. Collins’s fancying himself in love with her
+friend had once occurred to Elizabeth within the last day or two; but
+that Charlotte could encourage him seemed almost as far from
+possibility as she could encourage him herself, and her astonishment was
+consequently so great as to overcome at first the bounds of decorum, and
+she could not help crying out:
+
+“Engaged to Mr. Collins! My dear Charlotte--impossible!”
+
+The steady countenance which Miss Lucas had commanded in telling her
+story, gave way to a momentary confusion here on receiving so direct a
+reproach; though, as it was no more than she expected, she soon regained
+her composure, and calmly replied:
+
+“Why should you be surprised, my dear Eliza? Do you think it incredible
+that Mr. Collins should be able to procure any woman’s good opinion,
+because he was not so happy as to succeed with you?”
+
+But Elizabeth had now recollected herself, and making a strong effort
+for it, was able to assure with tolerable firmness that the prospect of
+their relationship was highly grateful to her, and that she wished her
+all imaginable happiness.
+
+“I see what you are feeling,” replied Charlotte. “You must be surprised,
+very much surprised--so lately as Mr. Collins was wishing to marry
+you. But when you have had time to think it over, I hope you will be
+satisfied with what I have done. I am not romantic, you know; I never
+was. I ask only a comfortable home; and considering Mr. Collins’s
+character, connection, and situation in life, I am convinced that my
+chance of happiness with him is as fair as most people can boast on
+entering the marriage state.”
+
+Elizabeth quietly answered “Undoubtedly;” and after an awkward pause,
+they returned to the rest of the family. Charlotte did not stay much
+longer, and Elizabeth was then left to reflect on what she had heard.
+It was a long time before she became at all reconciled to the idea of so
+unsuitable a match. The strangeness of Mr. Collins’s making two offers
+of marriage within three days was nothing in comparison of his being now
+accepted. She had always felt that Charlotte’s opinion of matrimony was
+not exactly like her own, but she had not supposed it to be possible
+that, when called into action, she would have sacrificed every better
+feeling to worldly advantage. Charlotte the wife of Mr. Collins was a
+most humiliating picture! And to the pang of a friend disgracing herself
+and sunk in her esteem, was added the distressing conviction that it
+was impossible for that friend to be tolerably happy in the lot she had
+chosen.
+
+
+
+Chapter 23
+
+
+Elizabeth was sitting with her mother and sisters, reflecting on what
+she had heard, and doubting whether she was authorised to mention
+it, when Sir William Lucas himself appeared, sent by his daughter, to
+announce her engagement to the family. With many compliments to them,
+and much self-gratulation on the prospect of a connection between the
+houses, he unfolded the matter--to an audience not merely wondering, but
+incredulous; for Mrs. Bennet, with more perseverance than politeness,
+protested he must be entirely mistaken; and Lydia, always unguarded and
+often uncivil, boisterously exclaimed:
+
+“Good Lord! Sir William, how can you tell such a story? Do not you know
+that Mr. Collins wants to marry Lizzy?”
+
+Nothing less than the complaisance of a courtier could have borne
+without anger such treatment; but Sir William’s good breeding carried
+him through it all; and though he begged leave to be positive as to the
+truth of his information, he listened to all their impertinence with the
+most forbearing courtesy.
+
+Elizabeth, feeling it incumbent on her to relieve him from so unpleasant
+a situation, now put herself forward to confirm his account, by
+mentioning her prior knowledge of it from Charlotte herself; and
+endeavoured to put a stop to the exclamations of her mother and sisters
+by the earnestness of her congratulations to Sir William, in which she
+was readily joined by Jane, and by making a variety of remarks on the
+happiness that might be expected from the match, the excellent character
+of Mr. Collins, and the convenient distance of Hunsford from London.
+
+Mrs. Bennet was in fact too much overpowered to say a great deal while
+Sir William remained; but no sooner had he left them than her feelings
+found a rapid vent. In the first place, she persisted in disbelieving
+the whole of the matter; secondly, she was very sure that Mr. Collins
+had been taken in; thirdly, she trusted that they would never be
+happy together; and fourthly, that the match might be broken off. Two
+inferences, however, were plainly deduced from the whole: one, that
+Elizabeth was the real cause of the mischief; and the other that she
+herself had been barbarously misused by them all; and on these two
+points she principally dwelt during the rest of the day. Nothing could
+console and nothing could appease her. Nor did that day wear out her
+resentment. A week elapsed before she could see Elizabeth without
+scolding her, a month passed away before she could speak to Sir William
+or Lady Lucas without being rude, and many months were gone before she
+could at all forgive their daughter.
+
+Mr. Bennet’s emotions were much more tranquil on the occasion, and such
+as he did experience he pronounced to be of a most agreeable sort; for
+it gratified him, he said, to discover that Charlotte Lucas, whom he had
+been used to think tolerably sensible, was as foolish as his wife, and
+more foolish than his daughter!
+
+Jane confessed herself a little surprised at the match; but she said
+less of her astonishment than of her earnest desire for their happiness;
+nor could Elizabeth persuade her to consider it as improbable. Kitty
+and Lydia were far from envying Miss Lucas, for Mr. Collins was only a
+clergyman; and it affected them in no other way than as a piece of news
+to spread at Meryton.
+
+Lady Lucas could not be insensible of triumph on being able to retort
+on Mrs. Bennet the comfort of having a daughter well married; and she
+called at Longbourn rather oftener than usual to say how happy she was,
+though Mrs. Bennet’s sour looks and ill-natured remarks might have been
+enough to drive happiness away.
+
+Between Elizabeth and Charlotte there was a restraint which kept them
+mutually silent on the subject; and Elizabeth felt persuaded that
+no real confidence could ever subsist between them again. Her
+disappointment in Charlotte made her turn with fonder regard to her
+sister, of whose rectitude and delicacy she was sure her opinion could
+never be shaken, and for whose happiness she grew daily more anxious,
+as Bingley had now been gone a week and nothing more was heard of his
+return.
+
+Jane had sent Caroline an early answer to her letter, and was counting
+the days till she might reasonably hope to hear again. The promised
+letter of thanks from Mr. Collins arrived on Tuesday, addressed to
+their father, and written with all the solemnity of gratitude which a
+twelvemonth’s abode in the family might have prompted. After discharging
+his conscience on that head, he proceeded to inform them, with many
+rapturous expressions, of his happiness in having obtained the affection
+of their amiable neighbour, Miss Lucas, and then explained that it was
+merely with the view of enjoying her society that he had been so ready
+to close with their kind wish of seeing him again at Longbourn, whither
+he hoped to be able to return on Monday fortnight; for Lady Catherine,
+he added, so heartily approved his marriage, that she wished it to take
+place as soon as possible, which he trusted would be an unanswerable
+argument with his amiable Charlotte to name an early day for making him
+the happiest of men.
+
+Mr. Collins’s return into Hertfordshire was no longer a matter of
+pleasure to Mrs. Bennet. On the contrary, she was as much disposed to
+complain of it as her husband. It was very strange that he should come
+to Longbourn instead of to Lucas Lodge; it was also very inconvenient
+and exceedingly troublesome. She hated having visitors in the house
+while her health was so indifferent, and lovers were of all people the
+most disagreeable. Such were the gentle murmurs of Mrs. Bennet, and
+they gave way only to the greater distress of Mr. Bingley’s continued
+absence.
+
+Neither Jane nor Elizabeth were comfortable on this subject. Day after
+day passed away without bringing any other tidings of him than the
+report which shortly prevailed in Meryton of his coming no more to
+Netherfield the whole winter; a report which highly incensed Mrs.
+Bennet, and which she never failed to contradict as a most scandalous
+falsehood.
+
+Even Elizabeth began to fear--not that Bingley was indifferent--but that
+his sisters would be successful in keeping him away. Unwilling as
+she was to admit an idea so destructive of Jane’s happiness, and so
+dishonorable to the stability of her lover, she could not prevent its
+frequently occurring. The united efforts of his two unfeeling sisters
+and of his overpowering friend, assisted by the attractions of Miss
+Darcy and the amusements of London might be too much, she feared, for
+the strength of his attachment.
+
+As for Jane, _her_ anxiety under this suspense was, of course, more
+painful than Elizabeth’s, but whatever she felt she was desirous of
+concealing, and between herself and Elizabeth, therefore, the subject
+was never alluded to. But as no such delicacy restrained her mother,
+an hour seldom passed in which she did not talk of Bingley, express her
+impatience for his arrival, or even require Jane to confess that if he
+did not come back she would think herself very ill used. It needed
+all Jane’s steady mildness to bear these attacks with tolerable
+tranquillity.
+
+Mr. Collins returned most punctually on Monday fortnight, but his
+reception at Longbourn was not quite so gracious as it had been on his
+first introduction. He was too happy, however, to need much attention;
+and luckily for the others, the business of love-making relieved them
+from a great deal of his company. The chief of every day was spent by
+him at Lucas Lodge, and he sometimes returned to Longbourn only in time
+to make an apology for his absence before the family went to bed.
+
+Mrs. Bennet was really in a most pitiable state. The very mention of
+anything concerning the match threw her into an agony of ill-humour,
+and wherever she went she was sure of hearing it talked of. The sight
+of Miss Lucas was odious to her. As her successor in that house, she
+regarded her with jealous abhorrence. Whenever Charlotte came to see
+them, she concluded her to be anticipating the hour of possession; and
+whenever she spoke in a low voice to Mr. Collins, was convinced that
+they were talking of the Longbourn estate, and resolving to turn herself
+and her daughters out of the house, as soon as Mr. Bennet were dead. She
+complained bitterly of all this to her husband.
+
+“Indeed, Mr. Bennet,” said she, “it is very hard to think that Charlotte
+Lucas should ever be mistress of this house, that I should be forced to
+make way for _her_, and live to see her take her place in it!”
+
+“My dear, do not give way to such gloomy thoughts. Let us hope for
+better things. Let us flatter ourselves that I may be the survivor.”
+
+This was not very consoling to Mrs. Bennet, and therefore, instead of
+making any answer, she went on as before.
+
+“I cannot bear to think that they should have all this estate. If it was
+not for the entail, I should not mind it.”
+
+“What should not you mind?”
+
+“I should not mind anything at all.”
+
+“Let us be thankful that you are preserved from a state of such
+insensibility.”
+
+“I never can be thankful, Mr. Bennet, for anything about the entail. How
+anyone could have the conscience to entail away an estate from one’s own
+daughters, I cannot understand; and all for the sake of Mr. Collins too!
+Why should _he_ have it more than anybody else?”
+
+“I leave it to yourself to determine,” said Mr. Bennet.
+
+
+
+Chapter 24
+
+
+Miss Bingley’s letter arrived, and put an end to doubt. The very first
+sentence conveyed the assurance of their being all settled in London for
+the winter, and concluded with her brother’s regret at not having had
+time to pay his respects to his friends in Hertfordshire before he left
+the country.
+
+Hope was over, entirely over; and when Jane could attend to the rest
+of the letter, she found little, except the professed affection of the
+writer, that could give her any comfort. Miss Darcy’s praise occupied
+the chief of it. Her many attractions were again dwelt on, and Caroline
+boasted joyfully of their increasing intimacy, and ventured to predict
+the accomplishment of the wishes which had been unfolded in her former
+letter. She wrote also with great pleasure of her brother’s being an
+inmate of Mr. Darcy’s house, and mentioned with raptures some plans of
+the latter with regard to new furniture.
+
+Elizabeth, to whom Jane very soon communicated the chief of all this,
+heard it in silent indignation. Her heart was divided between concern
+for her sister, and resentment against all others. To Caroline’s
+assertion of her brother’s being partial to Miss Darcy she paid no
+credit. That he was really fond of Jane, she doubted no more than she
+had ever done; and much as she had always been disposed to like him, she
+could not think without anger, hardly without contempt, on that easiness
+of temper, that want of proper resolution, which now made him the slave
+of his designing friends, and led him to sacrifice of his own happiness
+to the caprice of their inclination. Had his own happiness, however,
+been the only sacrifice, he might have been allowed to sport with it in
+whatever manner he thought best, but her sister’s was involved in it, as
+she thought he must be sensible himself. It was a subject, in short,
+on which reflection would be long indulged, and must be unavailing. She
+could think of nothing else; and yet whether Bingley’s regard had really
+died away, or were suppressed by his friends’ interference; whether
+he had been aware of Jane’s attachment, or whether it had escaped his
+observation; whatever were the case, though her opinion of him must be
+materially affected by the difference, her sister’s situation remained
+the same, her peace equally wounded.
+
+A day or two passed before Jane had courage to speak of her feelings to
+Elizabeth; but at last, on Mrs. Bennet’s leaving them together, after a
+longer irritation than usual about Netherfield and its master, she could
+not help saying:
+
+“Oh, that my dear mother had more command over herself! She can have no
+idea of the pain she gives me by her continual reflections on him. But
+I will not repine. It cannot last long. He will be forgot, and we shall
+all be as we were before.”
+
+Elizabeth looked at her sister with incredulous solicitude, but said
+nothing.
+
+“You doubt me,” cried Jane, slightly colouring; “indeed, you have
+no reason. He may live in my memory as the most amiable man of my
+acquaintance, but that is all. I have nothing either to hope or fear,
+and nothing to reproach him with. Thank God! I have not _that_ pain. A
+little time, therefore--I shall certainly try to get the better.”
+
+With a stronger voice she soon added, “I have this comfort immediately,
+that it has not been more than an error of fancy on my side, and that it
+has done no harm to anyone but myself.”
+
+“My dear Jane!” exclaimed Elizabeth, “you are too good. Your sweetness
+and disinterestedness are really angelic; I do not know what to say
+to you. I feel as if I had never done you justice, or loved you as you
+deserve.”
+
+Miss Bennet eagerly disclaimed all extraordinary merit, and threw back
+the praise on her sister’s warm affection.
+
+“Nay,” said Elizabeth, “this is not fair. _You_ wish to think all the
+world respectable, and are hurt if I speak ill of anybody. I only want
+to think _you_ perfect, and you set yourself against it. Do not
+be afraid of my running into any excess, of my encroaching on your
+privilege of universal good-will. You need not. There are few people
+whom I really love, and still fewer of whom I think well. The more I see
+of the world, the more am I dissatisfied with it; and every day confirms
+my belief of the inconsistency of all human characters, and of the
+little dependence that can be placed on the appearance of merit or
+sense. I have met with two instances lately, one I will not mention; the
+other is Charlotte’s marriage. It is unaccountable! In every view it is
+unaccountable!”
+
+“My dear Lizzy, do not give way to such feelings as these. They will
+ruin your happiness. You do not make allowance enough for difference
+of situation and temper. Consider Mr. Collins’s respectability, and
+Charlotte’s steady, prudent character. Remember that she is one of a
+large family; that as to fortune, it is a most eligible match; and be
+ready to believe, for everybody’s sake, that she may feel something like
+regard and esteem for our cousin.”
+
+“To oblige you, I would try to believe almost anything, but no one else
+could be benefited by such a belief as this; for were I persuaded that
+Charlotte had any regard for him, I should only think worse of her
+understanding than I now do of her heart. My dear Jane, Mr. Collins is a
+conceited, pompous, narrow-minded, silly man; you know he is, as well as
+I do; and you must feel, as well as I do, that the woman who married him
+cannot have a proper way of thinking. You shall not defend her, though
+it is Charlotte Lucas. You shall not, for the sake of one individual,
+change the meaning of principle and integrity, nor endeavour to persuade
+yourself or me, that selfishness is prudence, and insensibility of
+danger security for happiness.”
+
+“I must think your language too strong in speaking of both,” replied
+Jane; “and I hope you will be convinced of it by seeing them happy
+together. But enough of this. You alluded to something else. You
+mentioned _two_ instances. I cannot misunderstand you, but I entreat
+you, dear Lizzy, not to pain me by thinking _that person_ to blame, and
+saying your opinion of him is sunk. We must not be so ready to fancy
+ourselves intentionally injured. We must not expect a lively young man
+to be always so guarded and circumspect. It is very often nothing but
+our own vanity that deceives us. Women fancy admiration means more than
+it does.”
+
+“And men take care that they should.”
+
+“If it is designedly done, they cannot be justified; but I have no idea
+of there being so much design in the world as some persons imagine.”
+
+“I am far from attributing any part of Mr. Bingley’s conduct to design,”
+ said Elizabeth; “but without scheming to do wrong, or to make others
+unhappy, there may be error, and there may be misery. Thoughtlessness,
+want of attention to other people’s feelings, and want of resolution,
+will do the business.”
+
+“And do you impute it to either of those?”
+
+“Yes; to the last. But if I go on, I shall displease you by saying what
+I think of persons you esteem. Stop me whilst you can.”
+
+“You persist, then, in supposing his sisters influence him?”
+
+“Yes, in conjunction with his friend.”
+
+“I cannot believe it. Why should they try to influence him? They can
+only wish his happiness; and if he is attached to me, no other woman can
+secure it.”
+
+“Your first position is false. They may wish many things besides his
+happiness; they may wish his increase of wealth and consequence; they
+may wish him to marry a girl who has all the importance of money, great
+connections, and pride.”
+
+“Beyond a doubt, they _do_ wish him to choose Miss Darcy,” replied Jane;
+“but this may be from better feelings than you are supposing. They have
+known her much longer than they have known me; no wonder if they love
+her better. But, whatever may be their own wishes, it is very unlikely
+they should have opposed their brother’s. What sister would think
+herself at liberty to do it, unless there were something very
+objectionable? If they believed him attached to me, they would not try
+to part us; if he were so, they could not succeed. By supposing such an
+affection, you make everybody acting unnaturally and wrong, and me most
+unhappy. Do not distress me by the idea. I am not ashamed of having been
+mistaken--or, at least, it is light, it is nothing in comparison of what
+I should feel in thinking ill of him or his sisters. Let me take it in
+the best light, in the light in which it may be understood.”
+
+Elizabeth could not oppose such a wish; and from this time Mr. Bingley’s
+name was scarcely ever mentioned between them.
+
+Mrs. Bennet still continued to wonder and repine at his returning no
+more, and though a day seldom passed in which Elizabeth did not account
+for it clearly, there was little chance of her ever considering it with
+less perplexity. Her daughter endeavoured to convince her of what she
+did not believe herself, that his attentions to Jane had been merely the
+effect of a common and transient liking, which ceased when he saw her
+no more; but though the probability of the statement was admitted at
+the time, she had the same story to repeat every day. Mrs. Bennet’s best
+comfort was that Mr. Bingley must be down again in the summer.
+
+Mr. Bennet treated the matter differently. “So, Lizzy,” said he one day,
+“your sister is crossed in love, I find. I congratulate her. Next to
+being married, a girl likes to be crossed a little in love now and then.
+It is something to think of, and it gives her a sort of distinction
+among her companions. When is your turn to come? You will hardly bear to
+be long outdone by Jane. Now is your time. Here are officers enough in
+Meryton to disappoint all the young ladies in the country. Let Wickham
+be _your_ man. He is a pleasant fellow, and would jilt you creditably.”
+
+“Thank you, sir, but a less agreeable man would satisfy me. We must not
+all expect Jane’s good fortune.”
+
+“True,” said Mr. Bennet, “but it is a comfort to think that whatever of
+that kind may befall you, you have an affectionate mother who will make
+the most of it.”
+
+Mr. Wickham’s society was of material service in dispelling the gloom
+which the late perverse occurrences had thrown on many of the Longbourn
+family. They saw him often, and to his other recommendations was now
+added that of general unreserve. The whole of what Elizabeth had already
+heard, his claims on Mr. Darcy, and all that he had suffered from him,
+was now openly acknowledged and publicly canvassed; and everybody was
+pleased to know how much they had always disliked Mr. Darcy before they
+had known anything of the matter.
+
+Miss Bennet was the only creature who could suppose there might be
+any extenuating circumstances in the case, unknown to the society
+of Hertfordshire; her mild and steady candour always pleaded for
+allowances, and urged the possibility of mistakes--but by everybody else
+Mr. Darcy was condemned as the worst of men.
+
+
+
+Chapter 25
+
+
+After a week spent in professions of love and schemes of felicity,
+Mr. Collins was called from his amiable Charlotte by the arrival of
+Saturday. The pain of separation, however, might be alleviated on his
+side, by preparations for the reception of his bride; as he had reason
+to hope, that shortly after his return into Hertfordshire, the day would
+be fixed that was to make him the happiest of men. He took leave of his
+relations at Longbourn with as much solemnity as before; wished his fair
+cousins health and happiness again, and promised their father another
+letter of thanks.
+
+On the following Monday, Mrs. Bennet had the pleasure of receiving
+her brother and his wife, who came as usual to spend the Christmas
+at Longbourn. Mr. Gardiner was a sensible, gentlemanlike man, greatly
+superior to his sister, as well by nature as education. The Netherfield
+ladies would have had difficulty in believing that a man who lived
+by trade, and within view of his own warehouses, could have been so
+well-bred and agreeable. Mrs. Gardiner, who was several years younger
+than Mrs. Bennet and Mrs. Phillips, was an amiable, intelligent, elegant
+woman, and a great favourite with all her Longbourn nieces. Between the
+two eldest and herself especially, there subsisted a particular regard.
+They had frequently been staying with her in town.
+
+The first part of Mrs. Gardiner’s business on her arrival was to
+distribute her presents and describe the newest fashions. When this was
+done she had a less active part to play. It became her turn to listen.
+Mrs. Bennet had many grievances to relate, and much to complain of. They
+had all been very ill-used since she last saw her sister. Two of her
+girls had been upon the point of marriage, and after all there was
+nothing in it.
+
+“I do not blame Jane,” she continued, “for Jane would have got Mr.
+Bingley if she could. But Lizzy! Oh, sister! It is very hard to think
+that she might have been Mr. Collins’s wife by this time, had it not
+been for her own perverseness. He made her an offer in this very room,
+and she refused him. The consequence of it is, that Lady Lucas will have
+a daughter married before I have, and that the Longbourn estate is just
+as much entailed as ever. The Lucases are very artful people indeed,
+sister. They are all for what they can get. I am sorry to say it of
+them, but so it is. It makes me very nervous and poorly, to be thwarted
+so in my own family, and to have neighbours who think of themselves
+before anybody else. However, your coming just at this time is the
+greatest of comforts, and I am very glad to hear what you tell us, of
+long sleeves.”
+
+Mrs. Gardiner, to whom the chief of this news had been given before,
+in the course of Jane and Elizabeth’s correspondence with her, made her
+sister a slight answer, and, in compassion to her nieces, turned the
+conversation.
+
+When alone with Elizabeth afterwards, she spoke more on the subject. “It
+seems likely to have been a desirable match for Jane,” said she. “I am
+sorry it went off. But these things happen so often! A young man, such
+as you describe Mr. Bingley, so easily falls in love with a pretty girl
+for a few weeks, and when accident separates them, so easily forgets
+her, that these sort of inconsistencies are very frequent.”
+
+“An excellent consolation in its way,” said Elizabeth, “but it will not
+do for _us_. We do not suffer by _accident_. It does not often
+happen that the interference of friends will persuade a young man of
+independent fortune to think no more of a girl whom he was violently in
+love with only a few days before.”
+
+“But that expression of ‘violently in love’ is so hackneyed, so
+doubtful, so indefinite, that it gives me very little idea. It is as
+often applied to feelings which arise from a half-hour’s acquaintance,
+as to a real, strong attachment. Pray, how _violent was_ Mr. Bingley’s
+love?”
+
+“I never saw a more promising inclination; he was growing quite
+inattentive to other people, and wholly engrossed by her. Every time
+they met, it was more decided and remarkable. At his own ball he
+offended two or three young ladies, by not asking them to dance; and I
+spoke to him twice myself, without receiving an answer. Could there be
+finer symptoms? Is not general incivility the very essence of love?”
+
+“Oh, yes!--of that kind of love which I suppose him to have felt. Poor
+Jane! I am sorry for her, because, with her disposition, she may not get
+over it immediately. It had better have happened to _you_, Lizzy; you
+would have laughed yourself out of it sooner. But do you think she
+would be prevailed upon to go back with us? Change of scene might be
+of service--and perhaps a little relief from home may be as useful as
+anything.”
+
+Elizabeth was exceedingly pleased with this proposal, and felt persuaded
+of her sister’s ready acquiescence.
+
+“I hope,” added Mrs. Gardiner, “that no consideration with regard to
+this young man will influence her. We live in so different a part of
+town, all our connections are so different, and, as you well know, we go
+out so little, that it is very improbable that they should meet at all,
+unless he really comes to see her.”
+
+“And _that_ is quite impossible; for he is now in the custody of his
+friend, and Mr. Darcy would no more suffer him to call on Jane in such
+a part of London! My dear aunt, how could you think of it? Mr. Darcy may
+perhaps have _heard_ of such a place as Gracechurch Street, but he
+would hardly think a month’s ablution enough to cleanse him from its
+impurities, were he once to enter it; and depend upon it, Mr. Bingley
+never stirs without him.”
+
+“So much the better. I hope they will not meet at all. But does not Jane
+correspond with his sister? _She_ will not be able to help calling.”
+
+“She will drop the acquaintance entirely.”
+
+But in spite of the certainty in which Elizabeth affected to place this
+point, as well as the still more interesting one of Bingley’s being
+withheld from seeing Jane, she felt a solicitude on the subject which
+convinced her, on examination, that she did not consider it entirely
+hopeless. It was possible, and sometimes she thought it probable, that
+his affection might be reanimated, and the influence of his friends
+successfully combated by the more natural influence of Jane’s
+attractions.
+
+Miss Bennet accepted her aunt’s invitation with pleasure; and the
+Bingleys were no otherwise in her thoughts at the same time, than as she
+hoped by Caroline’s not living in the same house with her brother,
+she might occasionally spend a morning with her, without any danger of
+seeing him.
+
+The Gardiners stayed a week at Longbourn; and what with the Phillipses,
+the Lucases, and the officers, there was not a day without its
+engagement. Mrs. Bennet had so carefully provided for the entertainment
+of her brother and sister, that they did not once sit down to a family
+dinner. When the engagement was for home, some of the officers always
+made part of it--of which officers Mr. Wickham was sure to be one; and
+on these occasions, Mrs. Gardiner, rendered suspicious by Elizabeth’s
+warm commendation, narrowly observed them both. Without supposing them,
+from what she saw, to be very seriously in love, their preference
+of each other was plain enough to make her a little uneasy; and
+she resolved to speak to Elizabeth on the subject before she left
+Hertfordshire, and represent to her the imprudence of encouraging such
+an attachment.
+
+To Mrs. Gardiner, Wickham had one means of affording pleasure,
+unconnected with his general powers. About ten or a dozen years ago,
+before her marriage, she had spent a considerable time in that very
+part of Derbyshire to which he belonged. They had, therefore, many
+acquaintances in common; and though Wickham had been little there since
+the death of Darcy’s father, it was yet in his power to give her fresher
+intelligence of her former friends than she had been in the way of
+procuring.
+
+Mrs. Gardiner had seen Pemberley, and known the late Mr. Darcy by
+character perfectly well. Here consequently was an inexhaustible subject
+of discourse. In comparing her recollection of Pemberley with the minute
+description which Wickham could give, and in bestowing her tribute of
+praise on the character of its late possessor, she was delighting both
+him and herself. On being made acquainted with the present Mr. Darcy’s
+treatment of him, she tried to remember some of that gentleman’s
+reputed disposition when quite a lad which might agree with it, and
+was confident at last that she recollected having heard Mr. Fitzwilliam
+Darcy formerly spoken of as a very proud, ill-natured boy.
+
+
+
+Chapter 26
+
+
+Mrs. Gardiner’s caution to Elizabeth was punctually and kindly given
+on the first favourable opportunity of speaking to her alone; after
+honestly telling her what she thought, she thus went on:
+
+“You are too sensible a girl, Lizzy, to fall in love merely because
+you are warned against it; and, therefore, I am not afraid of speaking
+openly. Seriously, I would have you be on your guard. Do not involve
+yourself or endeavour to involve him in an affection which the want
+of fortune would make so very imprudent. I have nothing to say against
+_him_; he is a most interesting young man; and if he had the fortune he
+ought to have, I should think you could not do better. But as it is, you
+must not let your fancy run away with you. You have sense, and we all
+expect you to use it. Your father would depend on _your_ resolution and
+good conduct, I am sure. You must not disappoint your father.”
+
+“My dear aunt, this is being serious indeed.”
+
+“Yes, and I hope to engage you to be serious likewise.”
+
+“Well, then, you need not be under any alarm. I will take care of
+myself, and of Mr. Wickham too. He shall not be in love with me, if I
+can prevent it.”
+
+“Elizabeth, you are not serious now.”
+
+“I beg your pardon, I will try again. At present I am not in love with
+Mr. Wickham; no, I certainly am not. But he is, beyond all comparison,
+the most agreeable man I ever saw--and if he becomes really attached to
+me--I believe it will be better that he should not. I see the imprudence
+of it. Oh! _that_ abominable Mr. Darcy! My father’s opinion of me does
+me the greatest honour, and I should be miserable to forfeit it. My
+father, however, is partial to Mr. Wickham. In short, my dear aunt, I
+should be very sorry to be the means of making any of you unhappy; but
+since we see every day that where there is affection, young people
+are seldom withheld by immediate want of fortune from entering into
+engagements with each other, how can I promise to be wiser than so many
+of my fellow-creatures if I am tempted, or how am I even to know that it
+would be wisdom to resist? All that I can promise you, therefore, is not
+to be in a hurry. I will not be in a hurry to believe myself his first
+object. When I am in company with him, I will not be wishing. In short,
+I will do my best.”
+
+“Perhaps it will be as well if you discourage his coming here so very
+often. At least, you should not _remind_ your mother of inviting him.”
+
+“As I did the other day,” said Elizabeth with a conscious smile: “very
+true, it will be wise in me to refrain from _that_. But do not imagine
+that he is always here so often. It is on your account that he has been
+so frequently invited this week. You know my mother’s ideas as to the
+necessity of constant company for her friends. But really, and upon my
+honour, I will try to do what I think to be the wisest; and now I hope
+you are satisfied.”
+
+Her aunt assured her that she was, and Elizabeth having thanked her for
+the kindness of her hints, they parted; a wonderful instance of advice
+being given on such a point, without being resented.
+
+Mr. Collins returned into Hertfordshire soon after it had been quitted
+by the Gardiners and Jane; but as he took up his abode with the Lucases,
+his arrival was no great inconvenience to Mrs. Bennet. His marriage was
+now fast approaching, and she was at length so far resigned as to think
+it inevitable, and even repeatedly to say, in an ill-natured tone, that
+she “_wished_ they might be happy.” Thursday was to be the wedding day,
+and on Wednesday Miss Lucas paid her farewell visit; and when she
+rose to take leave, Elizabeth, ashamed of her mother’s ungracious and
+reluctant good wishes, and sincerely affected herself, accompanied her
+out of the room. As they went downstairs together, Charlotte said:
+
+“I shall depend on hearing from you very often, Eliza.”
+
+“_That_ you certainly shall.”
+
+“And I have another favour to ask you. Will you come and see me?”
+
+“We shall often meet, I hope, in Hertfordshire.”
+
+“I am not likely to leave Kent for some time. Promise me, therefore, to
+come to Hunsford.”
+
+Elizabeth could not refuse, though she foresaw little pleasure in the
+visit.
+
+“My father and Maria are coming to me in March,” added Charlotte, “and I
+hope you will consent to be of the party. Indeed, Eliza, you will be as
+welcome as either of them.”
+
+The wedding took place; the bride and bridegroom set off for Kent from
+the church door, and everybody had as much to say, or to hear, on
+the subject as usual. Elizabeth soon heard from her friend; and their
+correspondence was as regular and frequent as it had ever been; that
+it should be equally unreserved was impossible. Elizabeth could never
+address her without feeling that all the comfort of intimacy was over,
+and though determined not to slacken as a correspondent, it was for the
+sake of what had been, rather than what was. Charlotte’s first letters
+were received with a good deal of eagerness; there could not but be
+curiosity to know how she would speak of her new home, how she would
+like Lady Catherine, and how happy she would dare pronounce herself to
+be; though, when the letters were read, Elizabeth felt that Charlotte
+expressed herself on every point exactly as she might have foreseen. She
+wrote cheerfully, seemed surrounded with comforts, and mentioned nothing
+which she could not praise. The house, furniture, neighbourhood, and
+roads, were all to her taste, and Lady Catherine’s behaviour was most
+friendly and obliging. It was Mr. Collins’s picture of Hunsford and
+Rosings rationally softened; and Elizabeth perceived that she must wait
+for her own visit there to know the rest.
+
+Jane had already written a few lines to her sister to announce their
+safe arrival in London; and when she wrote again, Elizabeth hoped it
+would be in her power to say something of the Bingleys.
+
+Her impatience for this second letter was as well rewarded as impatience
+generally is. Jane had been a week in town without either seeing or
+hearing from Caroline. She accounted for it, however, by supposing that
+her last letter to her friend from Longbourn had by some accident been
+lost.
+
+“My aunt,” she continued, “is going to-morrow into that part of the
+town, and I shall take the opportunity of calling in Grosvenor Street.”
+
+She wrote again when the visit was paid, and she had seen Miss Bingley.
+“I did not think Caroline in spirits,” were her words, “but she was very
+glad to see me, and reproached me for giving her no notice of my coming
+to London. I was right, therefore, my last letter had never reached
+her. I inquired after their brother, of course. He was well, but so much
+engaged with Mr. Darcy that they scarcely ever saw him. I found that
+Miss Darcy was expected to dinner. I wish I could see her. My visit was
+not long, as Caroline and Mrs. Hurst were going out. I dare say I shall
+see them soon here.”
+
+Elizabeth shook her head over this letter. It convinced her that
+accident only could discover to Mr. Bingley her sister’s being in town.
+
+Four weeks passed away, and Jane saw nothing of him. She endeavoured to
+persuade herself that she did not regret it; but she could no longer be
+blind to Miss Bingley’s inattention. After waiting at home every morning
+for a fortnight, and inventing every evening a fresh excuse for her, the
+visitor did at last appear; but the shortness of her stay, and yet more,
+the alteration of her manner would allow Jane to deceive herself no
+longer. The letter which she wrote on this occasion to her sister will
+prove what she felt.
+
+“My dearest Lizzy will, I am sure, be incapable of triumphing in her
+better judgement, at my expense, when I confess myself to have been
+entirely deceived in Miss Bingley’s regard for me. But, my dear sister,
+though the event has proved you right, do not think me obstinate if I
+still assert that, considering what her behaviour was, my confidence was
+as natural as your suspicion. I do not at all comprehend her reason for
+wishing to be intimate with me; but if the same circumstances were to
+happen again, I am sure I should be deceived again. Caroline did not
+return my visit till yesterday; and not a note, not a line, did I
+receive in the meantime. When she did come, it was very evident that
+she had no pleasure in it; she made a slight, formal apology, for not
+calling before, said not a word of wishing to see me again, and was
+in every respect so altered a creature, that when she went away I was
+perfectly resolved to continue the acquaintance no longer. I pity,
+though I cannot help blaming her. She was very wrong in singling me out
+as she did; I can safely say that every advance to intimacy began on
+her side. But I pity her, because she must feel that she has been acting
+wrong, and because I am very sure that anxiety for her brother is the
+cause of it. I need not explain myself farther; and though _we_ know
+this anxiety to be quite needless, yet if she feels it, it will easily
+account for her behaviour to me; and so deservedly dear as he is to
+his sister, whatever anxiety she must feel on his behalf is natural and
+amiable. I cannot but wonder, however, at her having any such fears now,
+because, if he had at all cared about me, we must have met, long ago.
+He knows of my being in town, I am certain, from something she said
+herself; and yet it would seem, by her manner of talking, as if she
+wanted to persuade herself that he is really partial to Miss Darcy. I
+cannot understand it. If I were not afraid of judging harshly, I should
+be almost tempted to say that there is a strong appearance of duplicity
+in all this. But I will endeavour to banish every painful thought,
+and think only of what will make me happy--your affection, and the
+invariable kindness of my dear uncle and aunt. Let me hear from you very
+soon. Miss Bingley said something of his never returning to Netherfield
+again, of giving up the house, but not with any certainty. We had better
+not mention it. I am extremely glad that you have such pleasant accounts
+from our friends at Hunsford. Pray go to see them, with Sir William and
+Maria. I am sure you will be very comfortable there.--Yours, etc.”
+
+This letter gave Elizabeth some pain; but her spirits returned as she
+considered that Jane would no longer be duped, by the sister at least.
+All expectation from the brother was now absolutely over. She would not
+even wish for a renewal of his attentions. His character sunk on
+every review of it; and as a punishment for him, as well as a possible
+advantage to Jane, she seriously hoped he might really soon marry Mr.
+Darcy’s sister, as by Wickham’s account, she would make him abundantly
+regret what he had thrown away.
+
+Mrs. Gardiner about this time reminded Elizabeth of her promise
+concerning that gentleman, and required information; and Elizabeth
+had such to send as might rather give contentment to her aunt than to
+herself. His apparent partiality had subsided, his attentions were over,
+he was the admirer of some one else. Elizabeth was watchful enough to
+see it all, but she could see it and write of it without material pain.
+Her heart had been but slightly touched, and her vanity was satisfied
+with believing that _she_ would have been his only choice, had fortune
+permitted it. The sudden acquisition of ten thousand pounds was the most
+remarkable charm of the young lady to whom he was now rendering himself
+agreeable; but Elizabeth, less clear-sighted perhaps in this case than
+in Charlotte’s, did not quarrel with him for his wish of independence.
+Nothing, on the contrary, could be more natural; and while able to
+suppose that it cost him a few struggles to relinquish her, she was
+ready to allow it a wise and desirable measure for both, and could very
+sincerely wish him happy.
+
+All this was acknowledged to Mrs. Gardiner; and after relating the
+circumstances, she thus went on: “I am now convinced, my dear aunt, that
+I have never been much in love; for had I really experienced that pure
+and elevating passion, I should at present detest his very name, and
+wish him all manner of evil. But my feelings are not only cordial
+towards _him_; they are even impartial towards Miss King. I cannot find
+out that I hate her at all, or that I am in the least unwilling to
+think her a very good sort of girl. There can be no love in all this. My
+watchfulness has been effectual; and though I certainly should be a more
+interesting object to all my acquaintances were I distractedly in love
+with him, I cannot say that I regret my comparative insignificance.
+Importance may sometimes be purchased too dearly. Kitty and Lydia take
+his defection much more to heart than I do. They are young in the
+ways of the world, and not yet open to the mortifying conviction that
+handsome young men must have something to live on as well as the plain.”
+
+
+
+Chapter 27
+
+
+With no greater events than these in the Longbourn family, and otherwise
+diversified by little beyond the walks to Meryton, sometimes dirty and
+sometimes cold, did January and February pass away. March was to take
+Elizabeth to Hunsford. She had not at first thought very seriously of
+going thither; but Charlotte, she soon found, was depending on the plan
+and she gradually learned to consider it herself with greater pleasure
+as well as greater certainty. Absence had increased her desire of seeing
+Charlotte again, and weakened her disgust of Mr. Collins. There
+was novelty in the scheme, and as, with such a mother and such
+uncompanionable sisters, home could not be faultless, a little change
+was not unwelcome for its own sake. The journey would moreover give her
+a peep at Jane; and, in short, as the time drew near, she would have
+been very sorry for any delay. Everything, however, went on smoothly,
+and was finally settled according to Charlotte’s first sketch. She was
+to accompany Sir William and his second daughter. The improvement
+of spending a night in London was added in time, and the plan became
+perfect as plan could be.
+
+The only pain was in leaving her father, who would certainly miss her,
+and who, when it came to the point, so little liked her going, that he
+told her to write to him, and almost promised to answer her letter.
+
+The farewell between herself and Mr. Wickham was perfectly friendly; on
+his side even more. His present pursuit could not make him forget that
+Elizabeth had been the first to excite and to deserve his attention, the
+first to listen and to pity, the first to be admired; and in his manner
+of bidding her adieu, wishing her every enjoyment, reminding her of
+what she was to expect in Lady Catherine de Bourgh, and trusting their
+opinion of her--their opinion of everybody--would always coincide, there
+was a solicitude, an interest which she felt must ever attach her to
+him with a most sincere regard; and she parted from him convinced that,
+whether married or single, he must always be her model of the amiable
+and pleasing.
+
+Her fellow-travellers the next day were not of a kind to make her
+think him less agreeable. Sir William Lucas, and his daughter Maria, a
+good-humoured girl, but as empty-headed as himself, had nothing to say
+that could be worth hearing, and were listened to with about as much
+delight as the rattle of the chaise. Elizabeth loved absurdities, but
+she had known Sir William’s too long. He could tell her nothing new of
+the wonders of his presentation and knighthood; and his civilities were
+worn out, like his information.
+
+It was a journey of only twenty-four miles, and they began it so early
+as to be in Gracechurch Street by noon. As they drove to Mr. Gardiner’s
+door, Jane was at a drawing-room window watching their arrival; when
+they entered the passage she was there to welcome them, and Elizabeth,
+looking earnestly in her face, was pleased to see it healthful and
+lovely as ever. On the stairs were a troop of little boys and girls,
+whose eagerness for their cousin’s appearance would not allow them to
+wait in the drawing-room, and whose shyness, as they had not seen
+her for a twelvemonth, prevented their coming lower. All was joy and
+kindness. The day passed most pleasantly away; the morning in bustle and
+shopping, and the evening at one of the theatres.
+
+Elizabeth then contrived to sit by her aunt. Their first object was her
+sister; and she was more grieved than astonished to hear, in reply to
+her minute inquiries, that though Jane always struggled to support her
+spirits, there were periods of dejection. It was reasonable, however,
+to hope that they would not continue long. Mrs. Gardiner gave her the
+particulars also of Miss Bingley’s visit in Gracechurch Street, and
+repeated conversations occurring at different times between Jane and
+herself, which proved that the former had, from her heart, given up the
+acquaintance.
+
+Mrs. Gardiner then rallied her niece on Wickham’s desertion, and
+complimented her on bearing it so well.
+
+“But my dear Elizabeth,” she added, “what sort of girl is Miss King? I
+should be sorry to think our friend mercenary.”
+
+“Pray, my dear aunt, what is the difference in matrimonial affairs,
+between the mercenary and the prudent motive? Where does discretion end,
+and avarice begin? Last Christmas you were afraid of his marrying me,
+because it would be imprudent; and now, because he is trying to get
+a girl with only ten thousand pounds, you want to find out that he is
+mercenary.”
+
+“If you will only tell me what sort of girl Miss King is, I shall know
+what to think.”
+
+“She is a very good kind of girl, I believe. I know no harm of her.”
+
+“But he paid her not the smallest attention till her grandfather’s death
+made her mistress of this fortune.”
+
+“No--why should he? If it were not allowable for him to gain _my_
+affections because I had no money, what occasion could there be for
+making love to a girl whom he did not care about, and who was equally
+poor?”
+
+“But there seems an indelicacy in directing his attentions towards her
+so soon after this event.”
+
+“A man in distressed circumstances has not time for all those elegant
+decorums which other people may observe. If _she_ does not object to it,
+why should _we_?”
+
+“_Her_ not objecting does not justify _him_. It only shows her being
+deficient in something herself--sense or feeling.”
+
+“Well,” cried Elizabeth, “have it as you choose. _He_ shall be
+mercenary, and _she_ shall be foolish.”
+
+“No, Lizzy, that is what I do _not_ choose. I should be sorry, you know,
+to think ill of a young man who has lived so long in Derbyshire.”
+
+“Oh! if that is all, I have a very poor opinion of young men who live in
+Derbyshire; and their intimate friends who live in Hertfordshire are not
+much better. I am sick of them all. Thank Heaven! I am going to-morrow
+where I shall find a man who has not one agreeable quality, who has
+neither manner nor sense to recommend him. Stupid men are the only ones
+worth knowing, after all.”
+
+“Take care, Lizzy; that speech savours strongly of disappointment.”
+
+Before they were separated by the conclusion of the play, she had the
+unexpected happiness of an invitation to accompany her uncle and aunt in
+a tour of pleasure which they proposed taking in the summer.
+
+“We have not determined how far it shall carry us,” said Mrs. Gardiner,
+“but, perhaps, to the Lakes.”
+
+No scheme could have been more agreeable to Elizabeth, and her
+acceptance of the invitation was most ready and grateful. “Oh, my dear,
+dear aunt,” she rapturously cried, “what delight! what felicity! You
+give me fresh life and vigour. Adieu to disappointment and spleen. What
+are young men to rocks and mountains? Oh! what hours of transport
+we shall spend! And when we _do_ return, it shall not be like other
+travellers, without being able to give one accurate idea of anything. We
+_will_ know where we have gone--we _will_ recollect what we have seen.
+Lakes, mountains, and rivers shall not be jumbled together in our
+imaginations; nor when we attempt to describe any particular scene,
+will we begin quarreling about its relative situation. Let _our_
+first effusions be less insupportable than those of the generality of
+travellers.”
+
+
+
+Chapter 28
+
+
+Every object in the next day’s journey was new and interesting to
+Elizabeth; and her spirits were in a state of enjoyment; for she had
+seen her sister looking so well as to banish all fear for her health,
+and the prospect of her northern tour was a constant source of delight.
+
+When they left the high road for the lane to Hunsford, every eye was in
+search of the Parsonage, and every turning expected to bring it in view.
+The palings of Rosings Park was their boundary on one side. Elizabeth
+smiled at the recollection of all that she had heard of its inhabitants.
+
+At length the Parsonage was discernible. The garden sloping to the
+road, the house standing in it, the green pales, and the laurel hedge,
+everything declared they were arriving. Mr. Collins and Charlotte
+appeared at the door, and the carriage stopped at the small gate which
+led by a short gravel walk to the house, amidst the nods and smiles of
+the whole party. In a moment they were all out of the chaise, rejoicing
+at the sight of each other. Mrs. Collins welcomed her friend with the
+liveliest pleasure, and Elizabeth was more and more satisfied with
+coming when she found herself so affectionately received. She saw
+instantly that her cousin’s manners were not altered by his marriage;
+his formal civility was just what it had been, and he detained her some
+minutes at the gate to hear and satisfy his inquiries after all her
+family. They were then, with no other delay than his pointing out the
+neatness of the entrance, taken into the house; and as soon as they
+were in the parlour, he welcomed them a second time, with ostentatious
+formality to his humble abode, and punctually repeated all his wife’s
+offers of refreshment.
+
+Elizabeth was prepared to see him in his glory; and she could not help
+in fancying that in displaying the good proportion of the room, its
+aspect and its furniture, he addressed himself particularly to her,
+as if wishing to make her feel what she had lost in refusing him. But
+though everything seemed neat and comfortable, she was not able to
+gratify him by any sigh of repentance, and rather looked with wonder at
+her friend that she could have so cheerful an air with such a companion.
+When Mr. Collins said anything of which his wife might reasonably be
+ashamed, which certainly was not unseldom, she involuntarily turned her
+eye on Charlotte. Once or twice she could discern a faint blush; but
+in general Charlotte wisely did not hear. After sitting long enough to
+admire every article of furniture in the room, from the sideboard to
+the fender, to give an account of their journey, and of all that had
+happened in London, Mr. Collins invited them to take a stroll in the
+garden, which was large and well laid out, and to the cultivation of
+which he attended himself. To work in this garden was one of his most
+respectable pleasures; and Elizabeth admired the command of countenance
+with which Charlotte talked of the healthfulness of the exercise, and
+owned she encouraged it as much as possible. Here, leading the way
+through every walk and cross walk, and scarcely allowing them an
+interval to utter the praises he asked for, every view was pointed out
+with a minuteness which left beauty entirely behind. He could number the
+fields in every direction, and could tell how many trees there were in
+the most distant clump. But of all the views which his garden, or which
+the country or kingdom could boast, none were to be compared with the
+prospect of Rosings, afforded by an opening in the trees that bordered
+the park nearly opposite the front of his house. It was a handsome
+modern building, well situated on rising ground.
+
+From his garden, Mr. Collins would have led them round his two meadows;
+but the ladies, not having shoes to encounter the remains of a white
+frost, turned back; and while Sir William accompanied him, Charlotte
+took her sister and friend over the house, extremely well pleased,
+probably, to have the opportunity of showing it without her husband’s
+help. It was rather small, but well built and convenient; and everything
+was fitted up and arranged with a neatness and consistency of which
+Elizabeth gave Charlotte all the credit. When Mr. Collins could be
+forgotten, there was really an air of great comfort throughout, and by
+Charlotte’s evident enjoyment of it, Elizabeth supposed he must be often
+forgotten.
+
+She had already learnt that Lady Catherine was still in the country. It
+was spoken of again while they were at dinner, when Mr. Collins joining
+in, observed:
+
+“Yes, Miss Elizabeth, you will have the honour of seeing Lady Catherine
+de Bourgh on the ensuing Sunday at church, and I need not say you will
+be delighted with her. She is all affability and condescension, and I
+doubt not but you will be honoured with some portion of her notice
+when service is over. I have scarcely any hesitation in saying she
+will include you and my sister Maria in every invitation with which she
+honours us during your stay here. Her behaviour to my dear Charlotte is
+charming. We dine at Rosings twice every week, and are never allowed
+to walk home. Her ladyship’s carriage is regularly ordered for us. I
+_should_ say, one of her ladyship’s carriages, for she has several.”
+
+“Lady Catherine is a very respectable, sensible woman indeed,” added
+Charlotte, “and a most attentive neighbour.”
+
+“Very true, my dear, that is exactly what I say. She is the sort of
+woman whom one cannot regard with too much deference.”
+
+The evening was spent chiefly in talking over Hertfordshire news,
+and telling again what had already been written; and when it closed,
+Elizabeth, in the solitude of her chamber, had to meditate upon
+Charlotte’s degree of contentment, to understand her address in guiding,
+and composure in bearing with, her husband, and to acknowledge that it
+was all done very well. She had also to anticipate how her visit
+would pass, the quiet tenor of their usual employments, the vexatious
+interruptions of Mr. Collins, and the gaieties of their intercourse with
+Rosings. A lively imagination soon settled it all.
+
+About the middle of the next day, as she was in her room getting ready
+for a walk, a sudden noise below seemed to speak the whole house in
+confusion; and, after listening a moment, she heard somebody running
+up stairs in a violent hurry, and calling loudly after her. She opened
+the door and met Maria in the landing place, who, breathless with
+agitation, cried out--
+
+“Oh, my dear Eliza! pray make haste and come into the dining-room, for
+there is such a sight to be seen! I will not tell you what it is. Make
+haste, and come down this moment.”
+
+Elizabeth asked questions in vain; Maria would tell her nothing more,
+and down they ran into the dining-room, which fronted the lane, in
+quest of this wonder; It was two ladies stopping in a low phaeton at the
+garden gate.
+
+“And is this all?” cried Elizabeth. “I expected at least that the pigs
+were got into the garden, and here is nothing but Lady Catherine and her
+daughter.”
+
+“La! my dear,” said Maria, quite shocked at the mistake, “it is not
+Lady Catherine. The old lady is Mrs. Jenkinson, who lives with them;
+the other is Miss de Bourgh. Only look at her. She is quite a little
+creature. Who would have thought that she could be so thin and small?”
+
+“She is abominably rude to keep Charlotte out of doors in all this wind.
+Why does she not come in?”
+
+“Oh, Charlotte says she hardly ever does. It is the greatest of favours
+when Miss de Bourgh comes in.”
+
+“I like her appearance,” said Elizabeth, struck with other ideas. “She
+looks sickly and cross. Yes, she will do for him very well. She will
+make him a very proper wife.”
+
+Mr. Collins and Charlotte were both standing at the gate in conversation
+with the ladies; and Sir William, to Elizabeth’s high diversion, was
+stationed in the doorway, in earnest contemplation of the greatness
+before him, and constantly bowing whenever Miss de Bourgh looked that
+way.
+
+At length there was nothing more to be said; the ladies drove on, and
+the others returned into the house. Mr. Collins no sooner saw the two
+girls than he began to congratulate them on their good fortune, which
+Charlotte explained by letting them know that the whole party was asked
+to dine at Rosings the next day.
+
+
+
+Chapter 29
+
+
+Mr. Collins’s triumph, in consequence of this invitation, was complete.
+The power of displaying the grandeur of his patroness to his wondering
+visitors, and of letting them see her civility towards himself and his
+wife, was exactly what he had wished for; and that an opportunity
+of doing it should be given so soon, was such an instance of Lady
+Catherine’s condescension, as he knew not how to admire enough.
+
+“I confess,” said he, “that I should not have been at all surprised by
+her ladyship’s asking us on Sunday to drink tea and spend the evening at
+Rosings. I rather expected, from my knowledge of her affability, that it
+would happen. But who could have foreseen such an attention as this? Who
+could have imagined that we should receive an invitation to dine there
+(an invitation, moreover, including the whole party) so immediately
+after your arrival!”
+
+“I am the less surprised at what has happened,” replied Sir William,
+“from that knowledge of what the manners of the great really are, which
+my situation in life has allowed me to acquire. About the court, such
+instances of elegant breeding are not uncommon.”
+
+Scarcely anything was talked of the whole day or next morning but their
+visit to Rosings. Mr. Collins was carefully instructing them in what
+they were to expect, that the sight of such rooms, so many servants, and
+so splendid a dinner, might not wholly overpower them.
+
+When the ladies were separating for the toilette, he said to Elizabeth--
+
+“Do not make yourself uneasy, my dear cousin, about your apparel. Lady
+Catherine is far from requiring that elegance of dress in us which
+becomes herself and her daughter. I would advise you merely to put on
+whatever of your clothes is superior to the rest--there is no occasion
+for anything more. Lady Catherine will not think the worse of you
+for being simply dressed. She likes to have the distinction of rank
+preserved.”
+
+While they were dressing, he came two or three times to their different
+doors, to recommend their being quick, as Lady Catherine very much
+objected to be kept waiting for her dinner. Such formidable accounts of
+her ladyship, and her manner of living, quite frightened Maria Lucas
+who had been little used to company, and she looked forward to her
+introduction at Rosings with as much apprehension as her father had done
+to his presentation at St. James’s.
+
+As the weather was fine, they had a pleasant walk of about half a
+mile across the park. Every park has its beauty and its prospects; and
+Elizabeth saw much to be pleased with, though she could not be in such
+raptures as Mr. Collins expected the scene to inspire, and was but
+slightly affected by his enumeration of the windows in front of the
+house, and his relation of what the glazing altogether had originally
+cost Sir Lewis de Bourgh.
+
+When they ascended the steps to the hall, Maria’s alarm was every
+moment increasing, and even Sir William did not look perfectly calm.
+Elizabeth’s courage did not fail her. She had heard nothing of Lady
+Catherine that spoke her awful from any extraordinary talents or
+miraculous virtue, and the mere stateliness of money or rank she thought
+she could witness without trepidation.
+
+From the entrance-hall, of which Mr. Collins pointed out, with a
+rapturous air, the fine proportion and the finished ornaments, they
+followed the servants through an ante-chamber, to the room where Lady
+Catherine, her daughter, and Mrs. Jenkinson were sitting. Her ladyship,
+with great condescension, arose to receive them; and as Mrs. Collins had
+settled it with her husband that the office of introduction should
+be hers, it was performed in a proper manner, without any of those
+apologies and thanks which he would have thought necessary.
+
+In spite of having been at St. James’s, Sir William was so completely
+awed by the grandeur surrounding him, that he had but just courage
+enough to make a very low bow, and take his seat without saying a word;
+and his daughter, frightened almost out of her senses, sat on the edge
+of her chair, not knowing which way to look. Elizabeth found herself
+quite equal to the scene, and could observe the three ladies before her
+composedly. Lady Catherine was a tall, large woman, with strongly-marked
+features, which might once have been handsome. Her air was not
+conciliating, nor was her manner of receiving them such as to make her
+visitors forget their inferior rank. She was not rendered formidable by
+silence; but whatever she said was spoken in so authoritative a tone,
+as marked her self-importance, and brought Mr. Wickham immediately to
+Elizabeth’s mind; and from the observation of the day altogether, she
+believed Lady Catherine to be exactly what he represented.
+
+When, after examining the mother, in whose countenance and deportment
+she soon found some resemblance of Mr. Darcy, she turned her eyes on the
+daughter, she could almost have joined in Maria’s astonishment at her
+being so thin and so small. There was neither in figure nor face any
+likeness between the ladies. Miss de Bourgh was pale and sickly; her
+features, though not plain, were insignificant; and she spoke very
+little, except in a low voice, to Mrs. Jenkinson, in whose appearance
+there was nothing remarkable, and who was entirely engaged in listening
+to what she said, and placing a screen in the proper direction before
+her eyes.
+
+After sitting a few minutes, they were all sent to one of the windows to
+admire the view, Mr. Collins attending them to point out its beauties,
+and Lady Catherine kindly informing them that it was much better worth
+looking at in the summer.
+
+The dinner was exceedingly handsome, and there were all the servants and
+all the articles of plate which Mr. Collins had promised; and, as he had
+likewise foretold, he took his seat at the bottom of the table, by her
+ladyship’s desire, and looked as if he felt that life could furnish
+nothing greater. He carved, and ate, and praised with delighted
+alacrity; and every dish was commended, first by him and then by Sir
+William, who was now enough recovered to echo whatever his son-in-law
+said, in a manner which Elizabeth wondered Lady Catherine could bear.
+But Lady Catherine seemed gratified by their excessive admiration, and
+gave most gracious smiles, especially when any dish on the table proved
+a novelty to them. The party did not supply much conversation. Elizabeth
+was ready to speak whenever there was an opening, but she was seated
+between Charlotte and Miss de Bourgh--the former of whom was engaged in
+listening to Lady Catherine, and the latter said not a word to her all
+dinner-time. Mrs. Jenkinson was chiefly employed in watching how little
+Miss de Bourgh ate, pressing her to try some other dish, and fearing
+she was indisposed. Maria thought speaking out of the question, and the
+gentlemen did nothing but eat and admire.
+
+When the ladies returned to the drawing-room, there was little to
+be done but to hear Lady Catherine talk, which she did without any
+intermission till coffee came in, delivering her opinion on every
+subject in so decisive a manner, as proved that she was not used to
+have her judgement controverted. She inquired into Charlotte’s domestic
+concerns familiarly and minutely, gave her a great deal of advice as
+to the management of them all; told her how everything ought to be
+regulated in so small a family as hers, and instructed her as to the
+care of her cows and her poultry. Elizabeth found that nothing was
+beneath this great lady’s attention, which could furnish her with an
+occasion of dictating to others. In the intervals of her discourse
+with Mrs. Collins, she addressed a variety of questions to Maria and
+Elizabeth, but especially to the latter, of whose connections she knew
+the least, and who she observed to Mrs. Collins was a very genteel,
+pretty kind of girl. She asked her, at different times, how many sisters
+she had, whether they were older or younger than herself, whether any of
+them were likely to be married, whether they were handsome, where they
+had been educated, what carriage her father kept, and what had been
+her mother’s maiden name? Elizabeth felt all the impertinence of
+her questions but answered them very composedly. Lady Catherine then
+observed,
+
+“Your father’s estate is entailed on Mr. Collins, I think. For your
+sake,” turning to Charlotte, “I am glad of it; but otherwise I see no
+occasion for entailing estates from the female line. It was not thought
+necessary in Sir Lewis de Bourgh’s family. Do you play and sing, Miss
+Bennet?”
+
+“A little.”
+
+“Oh! then--some time or other we shall be happy to hear you. Our
+instrument is a capital one, probably superior to----You shall try it
+some day. Do your sisters play and sing?”
+
+“One of them does.”
+
+“Why did not you all learn? You ought all to have learned. The Miss
+Webbs all play, and their father has not so good an income as yours. Do
+you draw?”
+
+“No, not at all.”
+
+“What, none of you?”
+
+“Not one.”
+
+“That is very strange. But I suppose you had no opportunity. Your mother
+should have taken you to town every spring for the benefit of masters.”
+
+“My mother would have had no objection, but my father hates London.”
+
+“Has your governess left you?”
+
+“We never had any governess.”
+
+“No governess! How was that possible? Five daughters brought up at home
+without a governess! I never heard of such a thing. Your mother must
+have been quite a slave to your education.”
+
+Elizabeth could hardly help smiling as she assured her that had not been
+the case.
+
+“Then, who taught you? who attended to you? Without a governess, you
+must have been neglected.”
+
+“Compared with some families, I believe we were; but such of us as
+wished to learn never wanted the means. We were always encouraged to
+read, and had all the masters that were necessary. Those who chose to be
+idle, certainly might.”
+
+“Aye, no doubt; but that is what a governess will prevent, and if I had
+known your mother, I should have advised her most strenuously to engage
+one. I always say that nothing is to be done in education without steady
+and regular instruction, and nobody but a governess can give it. It is
+wonderful how many families I have been the means of supplying in that
+way. I am always glad to get a young person well placed out. Four nieces
+of Mrs. Jenkinson are most delightfully situated through my means; and
+it was but the other day that I recommended another young person,
+who was merely accidentally mentioned to me, and the family are quite
+delighted with her. Mrs. Collins, did I tell you of Lady Metcalf’s
+calling yesterday to thank me? She finds Miss Pope a treasure. ‘Lady
+Catherine,’ said she, ‘you have given me a treasure.’ Are any of your
+younger sisters out, Miss Bennet?”
+
+“Yes, ma’am, all.”
+
+“All! What, all five out at once? Very odd! And you only the second. The
+younger ones out before the elder ones are married! Your younger sisters
+must be very young?”
+
+“Yes, my youngest is not sixteen. Perhaps _she_ is full young to be
+much in company. But really, ma’am, I think it would be very hard upon
+younger sisters, that they should not have their share of society and
+amusement, because the elder may not have the means or inclination to
+marry early. The last-born has as good a right to the pleasures of youth
+as the first. And to be kept back on _such_ a motive! I think it would
+not be very likely to promote sisterly affection or delicacy of mind.”
+
+“Upon my word,” said her ladyship, “you give your opinion very decidedly
+for so young a person. Pray, what is your age?”
+
+“With three younger sisters grown up,” replied Elizabeth, smiling, “your
+ladyship can hardly expect me to own it.”
+
+Lady Catherine seemed quite astonished at not receiving a direct answer;
+and Elizabeth suspected herself to be the first creature who had ever
+dared to trifle with so much dignified impertinence.
+
+“You cannot be more than twenty, I am sure, therefore you need not
+conceal your age.”
+
+“I am not one-and-twenty.”
+
+When the gentlemen had joined them, and tea was over, the card-tables
+were placed. Lady Catherine, Sir William, and Mr. and Mrs. Collins sat
+down to quadrille; and as Miss de Bourgh chose to play at cassino, the
+two girls had the honour of assisting Mrs. Jenkinson to make up her
+party. Their table was superlatively stupid. Scarcely a syllable was
+uttered that did not relate to the game, except when Mrs. Jenkinson
+expressed her fears of Miss de Bourgh’s being too hot or too cold, or
+having too much or too little light. A great deal more passed at the
+other table. Lady Catherine was generally speaking--stating the mistakes
+of the three others, or relating some anecdote of herself. Mr. Collins
+was employed in agreeing to everything her ladyship said, thanking her
+for every fish he won, and apologising if he thought he won too many.
+Sir William did not say much. He was storing his memory with anecdotes
+and noble names.
+
+When Lady Catherine and her daughter had played as long as they chose,
+the tables were broken up, the carriage was offered to Mrs. Collins,
+gratefully accepted and immediately ordered. The party then gathered
+round the fire to hear Lady Catherine determine what weather they were
+to have on the morrow. From these instructions they were summoned by
+the arrival of the coach; and with many speeches of thankfulness on Mr.
+Collins’s side and as many bows on Sir William’s they departed. As soon
+as they had driven from the door, Elizabeth was called on by her cousin
+to give her opinion of all that she had seen at Rosings, which, for
+Charlotte’s sake, she made more favourable than it really was. But her
+commendation, though costing her some trouble, could by no means satisfy
+Mr. Collins, and he was very soon obliged to take her ladyship’s praise
+into his own hands.
+
+
+
+Chapter 30
+
+
+Sir William stayed only a week at Hunsford, but his visit was long
+enough to convince him of his daughter’s being most comfortably settled,
+and of her possessing such a husband and such a neighbour as were not
+often met with. While Sir William was with them, Mr. Collins devoted his
+morning to driving him out in his gig, and showing him the country; but
+when he went away, the whole family returned to their usual employments,
+and Elizabeth was thankful to find that they did not see more of her
+cousin by the alteration, for the chief of the time between breakfast
+and dinner was now passed by him either at work in the garden or in
+reading and writing, and looking out of the window in his own book-room,
+which fronted the road. The room in which the ladies sat was backwards.
+Elizabeth had at first rather wondered that Charlotte should not prefer
+the dining-parlour for common use; it was a better sized room, and had a
+more pleasant aspect; but she soon saw that her friend had an excellent
+reason for what she did, for Mr. Collins would undoubtedly have been
+much less in his own apartment, had they sat in one equally lively; and
+she gave Charlotte credit for the arrangement.
+
+From the drawing-room they could distinguish nothing in the lane, and
+were indebted to Mr. Collins for the knowledge of what carriages went
+along, and how often especially Miss de Bourgh drove by in her phaeton,
+which he never failed coming to inform them of, though it happened
+almost every day. She not unfrequently stopped at the Parsonage, and
+had a few minutes’ conversation with Charlotte, but was scarcely ever
+prevailed upon to get out.
+
+Very few days passed in which Mr. Collins did not walk to Rosings, and
+not many in which his wife did not think it necessary to go likewise;
+and till Elizabeth recollected that there might be other family livings
+to be disposed of, she could not understand the sacrifice of so many
+hours. Now and then they were honoured with a call from her ladyship,
+and nothing escaped her observation that was passing in the room during
+these visits. She examined into their employments, looked at their work,
+and advised them to do it differently; found fault with the arrangement
+of the furniture; or detected the housemaid in negligence; and if she
+accepted any refreshment, seemed to do it only for the sake of finding
+out that Mrs. Collins’s joints of meat were too large for her family.
+
+Elizabeth soon perceived, that though this great lady was not in
+commission of the peace of the county, she was a most active magistrate
+in her own parish, the minutest concerns of which were carried to her
+by Mr. Collins; and whenever any of the cottagers were disposed to
+be quarrelsome, discontented, or too poor, she sallied forth into the
+village to settle their differences, silence their complaints, and scold
+them into harmony and plenty.
+
+The entertainment of dining at Rosings was repeated about twice a week;
+and, allowing for the loss of Sir William, and there being only one
+card-table in the evening, every such entertainment was the counterpart
+of the first. Their other engagements were few, as the style of living
+in the neighbourhood in general was beyond Mr. Collins’s reach. This,
+however, was no evil to Elizabeth, and upon the whole she spent her time
+comfortably enough; there were half-hours of pleasant conversation with
+Charlotte, and the weather was so fine for the time of year that she had
+often great enjoyment out of doors. Her favourite walk, and where she
+frequently went while the others were calling on Lady Catherine, was
+along the open grove which edged that side of the park, where there was
+a nice sheltered path, which no one seemed to value but herself, and
+where she felt beyond the reach of Lady Catherine’s curiosity.
+
+In this quiet way, the first fortnight of her visit soon passed away.
+Easter was approaching, and the week preceding it was to bring an
+addition to the family at Rosings, which in so small a circle must be
+important. Elizabeth had heard soon after her arrival that Mr. Darcy was
+expected there in the course of a few weeks, and though there were not
+many of her acquaintances whom she did not prefer, his coming would
+furnish one comparatively new to look at in their Rosings parties, and
+she might be amused in seeing how hopeless Miss Bingley’s designs on him
+were, by his behaviour to his cousin, for whom he was evidently
+destined by Lady Catherine, who talked of his coming with the greatest
+satisfaction, spoke of him in terms of the highest admiration, and
+seemed almost angry to find that he had already been frequently seen by
+Miss Lucas and herself.
+
+His arrival was soon known at the Parsonage; for Mr. Collins was walking
+the whole morning within view of the lodges opening into Hunsford Lane,
+in order to have the earliest assurance of it, and after making his
+bow as the carriage turned into the Park, hurried home with the great
+intelligence. On the following morning he hastened to Rosings to pay his
+respects. There were two nephews of Lady Catherine to require them, for
+Mr. Darcy had brought with him a Colonel Fitzwilliam, the younger son of
+his uncle Lord ----, and, to the great surprise of all the party, when
+Mr. Collins returned, the gentlemen accompanied him. Charlotte had seen
+them from her husband’s room, crossing the road, and immediately running
+into the other, told the girls what an honour they might expect, adding:
+
+“I may thank you, Eliza, for this piece of civility. Mr. Darcy would
+never have come so soon to wait upon me.”
+
+Elizabeth had scarcely time to disclaim all right to the compliment,
+before their approach was announced by the door-bell, and shortly
+afterwards the three gentlemen entered the room. Colonel Fitzwilliam,
+who led the way, was about thirty, not handsome, but in person and
+address most truly the gentleman. Mr. Darcy looked just as he had been
+used to look in Hertfordshire--paid his compliments, with his usual
+reserve, to Mrs. Collins, and whatever might be his feelings toward her
+friend, met her with every appearance of composure. Elizabeth merely
+curtseyed to him without saying a word.
+
+Colonel Fitzwilliam entered into conversation directly with the
+readiness and ease of a well-bred man, and talked very pleasantly; but
+his cousin, after having addressed a slight observation on the house and
+garden to Mrs. Collins, sat for some time without speaking to anybody.
+At length, however, his civility was so far awakened as to inquire of
+Elizabeth after the health of her family. She answered him in the usual
+way, and after a moment’s pause, added:
+
+“My eldest sister has been in town these three months. Have you never
+happened to see her there?”
+
+She was perfectly sensible that he never had; but she wished to see
+whether he would betray any consciousness of what had passed between
+the Bingleys and Jane, and she thought he looked a little confused as he
+answered that he had never been so fortunate as to meet Miss Bennet. The
+subject was pursued no farther, and the gentlemen soon afterwards went
+away.
+
+
+
+Chapter 31
+
+
+Colonel Fitzwilliam’s manners were very much admired at the Parsonage,
+and the ladies all felt that he must add considerably to the pleasures
+of their engagements at Rosings. It was some days, however, before they
+received any invitation thither--for while there were visitors in the
+house, they could not be necessary; and it was not till Easter-day,
+almost a week after the gentlemen’s arrival, that they were honoured by
+such an attention, and then they were merely asked on leaving church to
+come there in the evening. For the last week they had seen very little
+of Lady Catherine or her daughter. Colonel Fitzwilliam had called at the
+Parsonage more than once during the time, but Mr. Darcy they had seen
+only at church.
+
+The invitation was accepted of course, and at a proper hour they joined
+the party in Lady Catherine’s drawing-room. Her ladyship received
+them civilly, but it was plain that their company was by no means so
+acceptable as when she could get nobody else; and she was, in fact,
+almost engrossed by her nephews, speaking to them, especially to Darcy,
+much more than to any other person in the room.
+
+Colonel Fitzwilliam seemed really glad to see them; anything was a
+welcome relief to him at Rosings; and Mrs. Collins’s pretty friend had
+moreover caught his fancy very much. He now seated himself by her, and
+talked so agreeably of Kent and Hertfordshire, of travelling and staying
+at home, of new books and music, that Elizabeth had never been half so
+well entertained in that room before; and they conversed with so much
+spirit and flow, as to draw the attention of Lady Catherine herself,
+as well as of Mr. Darcy. _His_ eyes had been soon and repeatedly turned
+towards them with a look of curiosity; and that her ladyship, after a
+while, shared the feeling, was more openly acknowledged, for she did not
+scruple to call out:
+
+“What is that you are saying, Fitzwilliam? What is it you are talking
+of? What are you telling Miss Bennet? Let me hear what it is.”
+
+“We are speaking of music, madam,” said he, when no longer able to avoid
+a reply.
+
+“Of music! Then pray speak aloud. It is of all subjects my delight. I
+must have my share in the conversation if you are speaking of music.
+There are few people in England, I suppose, who have more true enjoyment
+of music than myself, or a better natural taste. If I had ever learnt,
+I should have been a great proficient. And so would Anne, if her health
+had allowed her to apply. I am confident that she would have performed
+delightfully. How does Georgiana get on, Darcy?”
+
+Mr. Darcy spoke with affectionate praise of his sister’s proficiency.
+
+“I am very glad to hear such a good account of her,” said Lady
+Catherine; “and pray tell her from me, that she cannot expect to excel
+if she does not practice a good deal.”
+
+“I assure you, madam,” he replied, “that she does not need such advice.
+She practises very constantly.”
+
+“So much the better. It cannot be done too much; and when I next write
+to her, I shall charge her not to neglect it on any account. I often
+tell young ladies that no excellence in music is to be acquired without
+constant practice. I have told Miss Bennet several times, that she
+will never play really well unless she practises more; and though Mrs.
+Collins has no instrument, she is very welcome, as I have often told
+her, to come to Rosings every day, and play on the pianoforte in Mrs.
+Jenkinson’s room. She would be in nobody’s way, you know, in that part
+of the house.”
+
+Mr. Darcy looked a little ashamed of his aunt’s ill-breeding, and made
+no answer.
+
+When coffee was over, Colonel Fitzwilliam reminded Elizabeth of having
+promised to play to him; and she sat down directly to the instrument. He
+drew a chair near her. Lady Catherine listened to half a song, and then
+talked, as before, to her other nephew; till the latter walked away
+from her, and making with his usual deliberation towards the pianoforte
+stationed himself so as to command a full view of the fair performer’s
+countenance. Elizabeth saw what he was doing, and at the first
+convenient pause, turned to him with an arch smile, and said:
+
+“You mean to frighten me, Mr. Darcy, by coming in all this state to hear
+me? I will not be alarmed though your sister _does_ play so well. There
+is a stubbornness about me that never can bear to be frightened at the
+will of others. My courage always rises at every attempt to intimidate
+me.”
+
+“I shall not say you are mistaken,” he replied, “because you could not
+really believe me to entertain any design of alarming you; and I have
+had the pleasure of your acquaintance long enough to know that you find
+great enjoyment in occasionally professing opinions which in fact are
+not your own.”
+
+Elizabeth laughed heartily at this picture of herself, and said to
+Colonel Fitzwilliam, “Your cousin will give you a very pretty notion of
+me, and teach you not to believe a word I say. I am particularly unlucky
+in meeting with a person so able to expose my real character, in a part
+of the world where I had hoped to pass myself off with some degree of
+credit. Indeed, Mr. Darcy, it is very ungenerous in you to mention all
+that you knew to my disadvantage in Hertfordshire--and, give me leave to
+say, very impolitic too--for it is provoking me to retaliate, and such
+things may come out as will shock your relations to hear.”
+
+“I am not afraid of you,” said he, smilingly.
+
+“Pray let me hear what you have to accuse him of,” cried Colonel
+Fitzwilliam. “I should like to know how he behaves among strangers.”
+
+“You shall hear then--but prepare yourself for something very dreadful.
+The first time of my ever seeing him in Hertfordshire, you must know,
+was at a ball--and at this ball, what do you think he did? He danced
+only four dances, though gentlemen were scarce; and, to my certain
+knowledge, more than one young lady was sitting down in want of a
+partner. Mr. Darcy, you cannot deny the fact.”
+
+“I had not at that time the honour of knowing any lady in the assembly
+beyond my own party.”
+
+“True; and nobody can ever be introduced in a ball-room. Well, Colonel
+Fitzwilliam, what do I play next? My fingers wait your orders.”
+
+“Perhaps,” said Darcy, “I should have judged better, had I sought an
+introduction; but I am ill-qualified to recommend myself to strangers.”
+
+“Shall we ask your cousin the reason of this?” said Elizabeth, still
+addressing Colonel Fitzwilliam. “Shall we ask him why a man of sense and
+education, and who has lived in the world, is ill qualified to recommend
+himself to strangers?”
+
+“I can answer your question,” said Fitzwilliam, “without applying to
+him. It is because he will not give himself the trouble.”
+
+“I certainly have not the talent which some people possess,” said Darcy,
+“of conversing easily with those I have never seen before. I cannot
+catch their tone of conversation, or appear interested in their
+concerns, as I often see done.”
+
+“My fingers,” said Elizabeth, “do not move over this instrument in the
+masterly manner which I see so many women’s do. They have not the same
+force or rapidity, and do not produce the same expression. But then I
+have always supposed it to be my own fault--because I will not take the
+trouble of practising. It is not that I do not believe _my_ fingers as
+capable as any other woman’s of superior execution.”
+
+Darcy smiled and said, “You are perfectly right. You have employed your
+time much better. No one admitted to the privilege of hearing you can
+think anything wanting. We neither of us perform to strangers.”
+
+Here they were interrupted by Lady Catherine, who called out to know
+what they were talking of. Elizabeth immediately began playing again.
+Lady Catherine approached, and, after listening for a few minutes, said
+to Darcy:
+
+“Miss Bennet would not play at all amiss if she practised more, and
+could have the advantage of a London master. She has a very good notion
+of fingering, though her taste is not equal to Anne’s. Anne would have
+been a delightful performer, had her health allowed her to learn.”
+
+Elizabeth looked at Darcy to see how cordially he assented to his
+cousin’s praise; but neither at that moment nor at any other could she
+discern any symptom of love; and from the whole of his behaviour to Miss
+de Bourgh she derived this comfort for Miss Bingley, that he might have
+been just as likely to marry _her_, had she been his relation.
+
+Lady Catherine continued her remarks on Elizabeth’s performance, mixing
+with them many instructions on execution and taste. Elizabeth received
+them with all the forbearance of civility, and, at the request of the
+gentlemen, remained at the instrument till her ladyship’s carriage was
+ready to take them all home.
+
+
+
+Chapter 32
+
+
+Elizabeth was sitting by herself the next morning, and writing to Jane
+while Mrs. Collins and Maria were gone on business into the village,
+when she was startled by a ring at the door, the certain signal of a
+visitor. As she had heard no carriage, she thought it not unlikely to
+be Lady Catherine, and under that apprehension was putting away her
+half-finished letter that she might escape all impertinent questions,
+when the door opened, and, to her very great surprise, Mr. Darcy, and
+Mr. Darcy only, entered the room.
+
+He seemed astonished too on finding her alone, and apologised for his
+intrusion by letting her know that he had understood all the ladies were
+to be within.
+
+They then sat down, and when her inquiries after Rosings were made,
+seemed in danger of sinking into total silence. It was absolutely
+necessary, therefore, to think of something, and in this emergence
+recollecting _when_ she had seen him last in Hertfordshire, and
+feeling curious to know what he would say on the subject of their hasty
+departure, she observed:
+
+“How very suddenly you all quitted Netherfield last November, Mr. Darcy!
+It must have been a most agreeable surprise to Mr. Bingley to see you
+all after him so soon; for, if I recollect right, he went but the day
+before. He and his sisters were well, I hope, when you left London?”
+
+“Perfectly so, I thank you.”
+
+She found that she was to receive no other answer, and, after a short
+pause added:
+
+“I think I have understood that Mr. Bingley has not much idea of ever
+returning to Netherfield again?”
+
+“I have never heard him say so; but it is probable that he may spend
+very little of his time there in the future. He has many friends, and
+is at a time of life when friends and engagements are continually
+increasing.”
+
+“If he means to be but little at Netherfield, it would be better for
+the neighbourhood that he should give up the place entirely, for then we
+might possibly get a settled family there. But, perhaps, Mr. Bingley did
+not take the house so much for the convenience of the neighbourhood as
+for his own, and we must expect him to keep it or quit it on the same
+principle.”
+
+“I should not be surprised,” said Darcy, “if he were to give it up as
+soon as any eligible purchase offers.”
+
+Elizabeth made no answer. She was afraid of talking longer of his
+friend; and, having nothing else to say, was now determined to leave the
+trouble of finding a subject to him.
+
+He took the hint, and soon began with, “This seems a very comfortable
+house. Lady Catherine, I believe, did a great deal to it when Mr.
+Collins first came to Hunsford.”
+
+“I believe she did--and I am sure she could not have bestowed her
+kindness on a more grateful object.”
+
+“Mr. Collins appears to be very fortunate in his choice of a wife.”
+
+“Yes, indeed, his friends may well rejoice in his having met with one
+of the very few sensible women who would have accepted him, or have made
+him happy if they had. My friend has an excellent understanding--though
+I am not certain that I consider her marrying Mr. Collins as the
+wisest thing she ever did. She seems perfectly happy, however, and in a
+prudential light it is certainly a very good match for her.”
+
+“It must be very agreeable for her to be settled within so easy a
+distance of her own family and friends.”
+
+“An easy distance, do you call it? It is nearly fifty miles.”
+
+“And what is fifty miles of good road? Little more than half a day’s
+journey. Yes, I call it a _very_ easy distance.”
+
+“I should never have considered the distance as one of the _advantages_
+of the match,” cried Elizabeth. “I should never have said Mrs. Collins
+was settled _near_ her family.”
+
+“It is a proof of your own attachment to Hertfordshire. Anything beyond
+the very neighbourhood of Longbourn, I suppose, would appear far.”
+
+As he spoke there was a sort of smile which Elizabeth fancied she
+understood; he must be supposing her to be thinking of Jane and
+Netherfield, and she blushed as she answered:
+
+“I do not mean to say that a woman may not be settled too near her
+family. The far and the near must be relative, and depend on many
+varying circumstances. Where there is fortune to make the expenses of
+travelling unimportant, distance becomes no evil. But that is not the
+case _here_. Mr. and Mrs. Collins have a comfortable income, but not
+such a one as will allow of frequent journeys--and I am persuaded my
+friend would not call herself _near_ her family under less than _half_
+the present distance.”
+
+Mr. Darcy drew his chair a little towards her, and said, “_You_ cannot
+have a right to such very strong local attachment. _You_ cannot have
+been always at Longbourn.”
+
+Elizabeth looked surprised. The gentleman experienced some change of
+feeling; he drew back his chair, took a newspaper from the table, and
+glancing over it, said, in a colder voice:
+
+“Are you pleased with Kent?”
+
+A short dialogue on the subject of the country ensued, on either side
+calm and concise--and soon put an end to by the entrance of Charlotte
+and her sister, just returned from her walk. The tete-a-tete surprised
+them. Mr. Darcy related the mistake which had occasioned his intruding
+on Miss Bennet, and after sitting a few minutes longer without saying
+much to anybody, went away.
+
+“What can be the meaning of this?” said Charlotte, as soon as he was
+gone. “My dear, Eliza, he must be in love with you, or he would never
+have called us in this familiar way.”
+
+But when Elizabeth told of his silence, it did not seem very likely,
+even to Charlotte’s wishes, to be the case; and after various
+conjectures, they could at last only suppose his visit to proceed from
+the difficulty of finding anything to do, which was the more probable
+from the time of year. All field sports were over. Within doors there
+was Lady Catherine, books, and a billiard-table, but gentlemen cannot
+always be within doors; and in the nearness of the Parsonage, or the
+pleasantness of the walk to it, or of the people who lived in it, the
+two cousins found a temptation from this period of walking thither
+almost every day. They called at various times of the morning, sometimes
+separately, sometimes together, and now and then accompanied by their
+aunt. It was plain to them all that Colonel Fitzwilliam came because he
+had pleasure in their society, a persuasion which of course recommended
+him still more; and Elizabeth was reminded by her own satisfaction in
+being with him, as well as by his evident admiration of her, of her
+former favourite George Wickham; and though, in comparing them, she saw
+there was less captivating softness in Colonel Fitzwilliam’s manners,
+she believed he might have the best informed mind.
+
+But why Mr. Darcy came so often to the Parsonage, it was more difficult
+to understand. It could not be for society, as he frequently sat there
+ten minutes together without opening his lips; and when he did speak,
+it seemed the effect of necessity rather than of choice--a sacrifice
+to propriety, not a pleasure to himself. He seldom appeared really
+animated. Mrs. Collins knew not what to make of him. Colonel
+Fitzwilliam’s occasionally laughing at his stupidity, proved that he was
+generally different, which her own knowledge of him could not have told
+her; and as she would liked to have believed this change the effect
+of love, and the object of that love her friend Eliza, she set herself
+seriously to work to find it out. She watched him whenever they were at
+Rosings, and whenever he came to Hunsford; but without much success. He
+certainly looked at her friend a great deal, but the expression of that
+look was disputable. It was an earnest, steadfast gaze, but she often
+doubted whether there were much admiration in it, and sometimes it
+seemed nothing but absence of mind.
+
+She had once or twice suggested to Elizabeth the possibility of his
+being partial to her, but Elizabeth always laughed at the idea; and Mrs.
+Collins did not think it right to press the subject, from the danger of
+raising expectations which might only end in disappointment; for in her
+opinion it admitted not of a doubt, that all her friend’s dislike would
+vanish, if she could suppose him to be in her power.
+
+
+In her kind schemes for Elizabeth, she sometimes planned her marrying
+Colonel Fitzwilliam. He was beyond comparison the most pleasant man; he
+certainly admired her, and his situation in life was most eligible; but,
+to counterbalance these advantages, Mr. Darcy had considerable patronage
+in the church, and his cousin could have none at all.
+
+
+
+Chapter 33
+
+
+More than once did Elizabeth, in her ramble within the park,
+unexpectedly meet Mr. Darcy. She felt all the perverseness of the
+mischance that should bring him where no one else was brought, and, to
+prevent its ever happening again, took care to inform him at first that
+it was a favourite haunt of hers. How it could occur a second time,
+therefore, was very odd! Yet it did, and even a third. It seemed like
+wilful ill-nature, or a voluntary penance, for on these occasions it was
+not merely a few formal inquiries and an awkward pause and then away,
+but he actually thought it necessary to turn back and walk with her. He
+never said a great deal, nor did she give herself the trouble of talking
+or of listening much; but it struck her in the course of their third
+rencontre that he was asking some odd unconnected questions--about
+her pleasure in being at Hunsford, her love of solitary walks, and her
+opinion of Mr. and Mrs. Collins’s happiness; and that in speaking of
+Rosings and her not perfectly understanding the house, he seemed to
+expect that whenever she came into Kent again she would be staying
+_there_ too. His words seemed to imply it. Could he have Colonel
+Fitzwilliam in his thoughts? She supposed, if he meant anything, he must
+mean an allusion to what might arise in that quarter. It distressed
+her a little, and she was quite glad to find herself at the gate in the
+pales opposite the Parsonage.
+
+She was engaged one day as she walked, in perusing Jane’s last letter,
+and dwelling on some passages which proved that Jane had not written in
+spirits, when, instead of being again surprised by Mr. Darcy, she saw
+on looking up that Colonel Fitzwilliam was meeting her. Putting away the
+letter immediately and forcing a smile, she said:
+
+“I did not know before that you ever walked this way.”
+
+“I have been making the tour of the park,” he replied, “as I generally
+do every year, and intend to close it with a call at the Parsonage. Are
+you going much farther?”
+
+“No, I should have turned in a moment.”
+
+And accordingly she did turn, and they walked towards the Parsonage
+together.
+
+“Do you certainly leave Kent on Saturday?” said she.
+
+“Yes--if Darcy does not put it off again. But I am at his disposal. He
+arranges the business just as he pleases.”
+
+“And if not able to please himself in the arrangement, he has at least
+pleasure in the great power of choice. I do not know anybody who seems
+more to enjoy the power of doing what he likes than Mr. Darcy.”
+
+“He likes to have his own way very well,” replied Colonel Fitzwilliam.
+“But so we all do. It is only that he has better means of having it
+than many others, because he is rich, and many others are poor. I speak
+feelingly. A younger son, you know, must be inured to self-denial and
+dependence.”
+
+“In my opinion, the younger son of an earl can know very little of
+either. Now seriously, what have you ever known of self-denial and
+dependence? When have you been prevented by want of money from going
+wherever you chose, or procuring anything you had a fancy for?”
+
+“These are home questions--and perhaps I cannot say that I have
+experienced many hardships of that nature. But in matters of greater
+weight, I may suffer from want of money. Younger sons cannot marry where
+they like.”
+
+“Unless where they like women of fortune, which I think they very often
+do.”
+
+“Our habits of expense make us too dependent, and there are not many
+in my rank of life who can afford to marry without some attention to
+money.”
+
+“Is this,” thought Elizabeth, “meant for me?” and she coloured at the
+idea; but, recovering herself, said in a lively tone, “And pray, what
+is the usual price of an earl’s younger son? Unless the elder brother is
+very sickly, I suppose you would not ask above fifty thousand pounds.”
+
+He answered her in the same style, and the subject dropped. To interrupt
+a silence which might make him fancy her affected with what had passed,
+she soon afterwards said:
+
+“I imagine your cousin brought you down with him chiefly for the sake of
+having someone at his disposal. I wonder he does not marry, to secure a
+lasting convenience of that kind. But, perhaps, his sister does as well
+for the present, and, as she is under his sole care, he may do what he
+likes with her.”
+
+“No,” said Colonel Fitzwilliam, “that is an advantage which he must
+divide with me. I am joined with him in the guardianship of Miss Darcy.”
+
+“Are you indeed? And pray what sort of guardians do you make? Does your
+charge give you much trouble? Young ladies of her age are sometimes a
+little difficult to manage, and if she has the true Darcy spirit, she
+may like to have her own way.”
+
+As she spoke she observed him looking at her earnestly; and the manner
+in which he immediately asked her why she supposed Miss Darcy likely to
+give them any uneasiness, convinced her that she had somehow or other
+got pretty near the truth. She directly replied:
+
+“You need not be frightened. I never heard any harm of her; and I dare
+say she is one of the most tractable creatures in the world. She is a
+very great favourite with some ladies of my acquaintance, Mrs. Hurst and
+Miss Bingley. I think I have heard you say that you know them.”
+
+“I know them a little. Their brother is a pleasant gentlemanlike man--he
+is a great friend of Darcy’s.”
+
+“Oh! yes,” said Elizabeth drily; “Mr. Darcy is uncommonly kind to Mr.
+Bingley, and takes a prodigious deal of care of him.”
+
+“Care of him! Yes, I really believe Darcy _does_ take care of him in
+those points where he most wants care. From something that he told me in
+our journey hither, I have reason to think Bingley very much indebted to
+him. But I ought to beg his pardon, for I have no right to suppose that
+Bingley was the person meant. It was all conjecture.”
+
+“What is it you mean?”
+
+“It is a circumstance which Darcy could not wish to be generally known,
+because if it were to get round to the lady’s family, it would be an
+unpleasant thing.”
+
+“You may depend upon my not mentioning it.”
+
+“And remember that I have not much reason for supposing it to be
+Bingley. What he told me was merely this: that he congratulated himself
+on having lately saved a friend from the inconveniences of a most
+imprudent marriage, but without mentioning names or any other
+particulars, and I only suspected it to be Bingley from believing
+him the kind of young man to get into a scrape of that sort, and from
+knowing them to have been together the whole of last summer.”
+
+“Did Mr. Darcy give you reasons for this interference?”
+
+“I understood that there were some very strong objections against the
+lady.”
+
+“And what arts did he use to separate them?”
+
+“He did not talk to me of his own arts,” said Fitzwilliam, smiling. “He
+only told me what I have now told you.”
+
+Elizabeth made no answer, and walked on, her heart swelling with
+indignation. After watching her a little, Fitzwilliam asked her why she
+was so thoughtful.
+
+“I am thinking of what you have been telling me,” said she. “Your
+cousin’s conduct does not suit my feelings. Why was he to be the judge?”
+
+“You are rather disposed to call his interference officious?”
+
+“I do not see what right Mr. Darcy had to decide on the propriety of his
+friend’s inclination, or why, upon his own judgement alone, he was to
+determine and direct in what manner his friend was to be happy.
+But,” she continued, recollecting herself, “as we know none of the
+particulars, it is not fair to condemn him. It is not to be supposed
+that there was much affection in the case.”
+
+“That is not an unnatural surmise,” said Fitzwilliam, “but it is a
+lessening of the honour of my cousin’s triumph very sadly.”
+
+This was spoken jestingly; but it appeared to her so just a picture
+of Mr. Darcy, that she would not trust herself with an answer, and
+therefore, abruptly changing the conversation talked on indifferent
+matters until they reached the Parsonage. There, shut into her own room,
+as soon as their visitor left them, she could think without interruption
+of all that she had heard. It was not to be supposed that any other
+people could be meant than those with whom she was connected. There
+could not exist in the world _two_ men over whom Mr. Darcy could have
+such boundless influence. That he had been concerned in the measures
+taken to separate Bingley and Jane she had never doubted; but she had
+always attributed to Miss Bingley the principal design and arrangement
+of them. If his own vanity, however, did not mislead him, _he_ was
+the cause, his pride and caprice were the cause, of all that Jane had
+suffered, and still continued to suffer. He had ruined for a while
+every hope of happiness for the most affectionate, generous heart in the
+world; and no one could say how lasting an evil he might have inflicted.
+
+“There were some very strong objections against the lady,” were Colonel
+Fitzwilliam’s words; and those strong objections probably were, her
+having one uncle who was a country attorney, and another who was in
+business in London.
+
+“To Jane herself,” she exclaimed, “there could be no possibility of
+objection; all loveliness and goodness as she is!--her understanding
+excellent, her mind improved, and her manners captivating. Neither
+could anything be urged against my father, who, though with some
+peculiarities, has abilities Mr. Darcy himself need not disdain, and
+respectability which he will probably never reach.” When she thought of
+her mother, her confidence gave way a little; but she would not allow
+that any objections _there_ had material weight with Mr. Darcy, whose
+pride, she was convinced, would receive a deeper wound from the want of
+importance in his friend’s connections, than from their want of sense;
+and she was quite decided, at last, that he had been partly governed
+by this worst kind of pride, and partly by the wish of retaining Mr.
+Bingley for his sister.
+
+The agitation and tears which the subject occasioned, brought on a
+headache; and it grew so much worse towards the evening, that, added to
+her unwillingness to see Mr. Darcy, it determined her not to attend her
+cousins to Rosings, where they were engaged to drink tea. Mrs. Collins,
+seeing that she was really unwell, did not press her to go and as much
+as possible prevented her husband from pressing her; but Mr. Collins
+could not conceal his apprehension of Lady Catherine’s being rather
+displeased by her staying at home.
+
+
+
+Chapter 34
+
+
+When they were gone, Elizabeth, as if intending to exasperate herself
+as much as possible against Mr. Darcy, chose for her employment the
+examination of all the letters which Jane had written to her since her
+being in Kent. They contained no actual complaint, nor was there any
+revival of past occurrences, or any communication of present suffering.
+But in all, and in almost every line of each, there was a want of that
+cheerfulness which had been used to characterise her style, and which,
+proceeding from the serenity of a mind at ease with itself and kindly
+disposed towards everyone, had been scarcely ever clouded. Elizabeth
+noticed every sentence conveying the idea of uneasiness, with an
+attention which it had hardly received on the first perusal. Mr. Darcy’s
+shameful boast of what misery he had been able to inflict, gave her
+a keener sense of her sister’s sufferings. It was some consolation
+to think that his visit to Rosings was to end on the day after the
+next--and, a still greater, that in less than a fortnight she should
+herself be with Jane again, and enabled to contribute to the recovery of
+her spirits, by all that affection could do.
+
+She could not think of Darcy’s leaving Kent without remembering that
+his cousin was to go with him; but Colonel Fitzwilliam had made it clear
+that he had no intentions at all, and agreeable as he was, she did not
+mean to be unhappy about him.
+
+While settling this point, she was suddenly roused by the sound of the
+door-bell, and her spirits were a little fluttered by the idea of its
+being Colonel Fitzwilliam himself, who had once before called late in
+the evening, and might now come to inquire particularly after her.
+But this idea was soon banished, and her spirits were very differently
+affected, when, to her utter amazement, she saw Mr. Darcy walk into the
+room. In an hurried manner he immediately began an inquiry after her
+health, imputing his visit to a wish of hearing that she were better.
+She answered him with cold civility. He sat down for a few moments, and
+then getting up, walked about the room. Elizabeth was surprised, but
+said not a word. After a silence of several minutes, he came towards her
+in an agitated manner, and thus began:
+
+“In vain I have struggled. It will not do. My feelings will not be
+repressed. You must allow me to tell you how ardently I admire and love
+you.”
+
+Elizabeth’s astonishment was beyond expression. She stared, coloured,
+doubted, and was silent. This he considered sufficient encouragement;
+and the avowal of all that he felt, and had long felt for her,
+immediately followed. He spoke well; but there were feelings besides
+those of the heart to be detailed; and he was not more eloquent on the
+subject of tenderness than of pride. His sense of her inferiority--of
+its being a degradation--of the family obstacles which had always
+opposed to inclination, were dwelt on with a warmth which seemed due to
+the consequence he was wounding, but was very unlikely to recommend his
+suit.
+
+In spite of her deeply-rooted dislike, she could not be insensible to
+the compliment of such a man’s affection, and though her intentions did
+not vary for an instant, she was at first sorry for the pain he was to
+receive; till, roused to resentment by his subsequent language, she
+lost all compassion in anger. She tried, however, to compose herself to
+answer him with patience, when he should have done. He concluded with
+representing to her the strength of that attachment which, in spite
+of all his endeavours, he had found impossible to conquer; and with
+expressing his hope that it would now be rewarded by her acceptance of
+his hand. As he said this, she could easily see that he had no doubt
+of a favourable answer. He _spoke_ of apprehension and anxiety, but
+his countenance expressed real security. Such a circumstance could
+only exasperate farther, and, when he ceased, the colour rose into her
+cheeks, and she said:
+
+“In such cases as this, it is, I believe, the established mode to
+express a sense of obligation for the sentiments avowed, however
+unequally they may be returned. It is natural that obligation should
+be felt, and if I could _feel_ gratitude, I would now thank you. But I
+cannot--I have never desired your good opinion, and you have certainly
+bestowed it most unwillingly. I am sorry to have occasioned pain to
+anyone. It has been most unconsciously done, however, and I hope will be
+of short duration. The feelings which, you tell me, have long prevented
+the acknowledgment of your regard, can have little difficulty in
+overcoming it after this explanation.”
+
+Mr. Darcy, who was leaning against the mantelpiece with his eyes fixed
+on her face, seemed to catch her words with no less resentment than
+surprise. His complexion became pale with anger, and the disturbance
+of his mind was visible in every feature. He was struggling for the
+appearance of composure, and would not open his lips till he believed
+himself to have attained it. The pause was to Elizabeth’s feelings
+dreadful. At length, with a voice of forced calmness, he said:
+
+“And this is all the reply which I am to have the honour of expecting!
+I might, perhaps, wish to be informed why, with so little _endeavour_ at
+civility, I am thus rejected. But it is of small importance.”
+
+“I might as well inquire,” replied she, “why with so evident a desire
+of offending and insulting me, you chose to tell me that you liked me
+against your will, against your reason, and even against your character?
+Was not this some excuse for incivility, if I _was_ uncivil? But I have
+other provocations. You know I have. Had not my feelings decided against
+you--had they been indifferent, or had they even been favourable, do you
+think that any consideration would tempt me to accept the man who has
+been the means of ruining, perhaps for ever, the happiness of a most
+beloved sister?”
+
+As she pronounced these words, Mr. Darcy changed colour; but the emotion
+was short, and he listened without attempting to interrupt her while she
+continued:
+
+“I have every reason in the world to think ill of you. No motive can
+excuse the unjust and ungenerous part you acted _there_. You dare not,
+you cannot deny, that you have been the principal, if not the only means
+of dividing them from each other--of exposing one to the censure of the
+world for caprice and instability, and the other to its derision for
+disappointed hopes, and involving them both in misery of the acutest
+kind.”
+
+She paused, and saw with no slight indignation that he was listening
+with an air which proved him wholly unmoved by any feeling of remorse.
+He even looked at her with a smile of affected incredulity.
+
+“Can you deny that you have done it?” she repeated.
+
+With assumed tranquillity he then replied: “I have no wish of denying
+that I did everything in my power to separate my friend from your
+sister, or that I rejoice in my success. Towards _him_ I have been
+kinder than towards myself.”
+
+Elizabeth disdained the appearance of noticing this civil reflection,
+but its meaning did not escape, nor was it likely to conciliate her.
+
+“But it is not merely this affair,” she continued, “on which my dislike
+is founded. Long before it had taken place my opinion of you was
+decided. Your character was unfolded in the recital which I received
+many months ago from Mr. Wickham. On this subject, what can you have to
+say? In what imaginary act of friendship can you here defend yourself?
+or under what misrepresentation can you here impose upon others?”
+
+“You take an eager interest in that gentleman’s concerns,” said Darcy,
+in a less tranquil tone, and with a heightened colour.
+
+“Who that knows what his misfortunes have been, can help feeling an
+interest in him?”
+
+“His misfortunes!” repeated Darcy contemptuously; “yes, his misfortunes
+have been great indeed.”
+
+“And of your infliction,” cried Elizabeth with energy. “You have reduced
+him to his present state of poverty--comparative poverty. You have
+withheld the advantages which you must know to have been designed for
+him. You have deprived the best years of his life of that independence
+which was no less his due than his desert. You have done all this!
+and yet you can treat the mention of his misfortune with contempt and
+ridicule.”
+
+“And this,” cried Darcy, as he walked with quick steps across the room,
+“is your opinion of me! This is the estimation in which you hold me!
+I thank you for explaining it so fully. My faults, according to this
+calculation, are heavy indeed! But perhaps,” added he, stopping in
+his walk, and turning towards her, “these offenses might have been
+overlooked, had not your pride been hurt by my honest confession of the
+scruples that had long prevented my forming any serious design. These
+bitter accusations might have been suppressed, had I, with greater
+policy, concealed my struggles, and flattered you into the belief of
+my being impelled by unqualified, unalloyed inclination; by reason, by
+reflection, by everything. But disguise of every sort is my abhorrence.
+Nor am I ashamed of the feelings I related. They were natural and
+just. Could you expect me to rejoice in the inferiority of your
+connections?--to congratulate myself on the hope of relations, whose
+condition in life is so decidedly beneath my own?”
+
+Elizabeth felt herself growing more angry every moment; yet she tried to
+the utmost to speak with composure when she said:
+
+“You are mistaken, Mr. Darcy, if you suppose that the mode of your
+declaration affected me in any other way, than as it spared me the concern
+which I might have felt in refusing you, had you behaved in a more
+gentlemanlike manner.”
+
+She saw him start at this, but he said nothing, and she continued:
+
+“You could not have made the offer of your hand in any possible way that
+would have tempted me to accept it.”
+
+Again his astonishment was obvious; and he looked at her with an
+expression of mingled incredulity and mortification. She went on:
+
+“From the very beginning--from the first moment, I may almost say--of
+my acquaintance with you, your manners, impressing me with the fullest
+belief of your arrogance, your conceit, and your selfish disdain of
+the feelings of others, were such as to form the groundwork of
+disapprobation on which succeeding events have built so immovable a
+dislike; and I had not known you a month before I felt that you were the
+last man in the world whom I could ever be prevailed on to marry.”
+
+“You have said quite enough, madam. I perfectly comprehend your
+feelings, and have now only to be ashamed of what my own have been.
+Forgive me for having taken up so much of your time, and accept my best
+wishes for your health and happiness.”
+
+And with these words he hastily left the room, and Elizabeth heard him
+the next moment open the front door and quit the house.
+
+The tumult of her mind, was now painfully great. She knew not how
+to support herself, and from actual weakness sat down and cried for
+half-an-hour. Her astonishment, as she reflected on what had passed,
+was increased by every review of it. That she should receive an offer of
+marriage from Mr. Darcy! That he should have been in love with her for
+so many months! So much in love as to wish to marry her in spite of
+all the objections which had made him prevent his friend’s marrying
+her sister, and which must appear at least with equal force in his
+own case--was almost incredible! It was gratifying to have inspired
+unconsciously so strong an affection. But his pride, his abominable
+pride--his shameless avowal of what he had done with respect to
+Jane--his unpardonable assurance in acknowledging, though he could
+not justify it, and the unfeeling manner in which he had mentioned Mr.
+Wickham, his cruelty towards whom he had not attempted to deny, soon
+overcame the pity which the consideration of his attachment had for
+a moment excited. She continued in very agitated reflections till the
+sound of Lady Catherine’s carriage made her feel how unequal she was to
+encounter Charlotte’s observation, and hurried her away to her room.
+
+
+
+Chapter 35
+
+
+Elizabeth awoke the next morning to the same thoughts and meditations
+which had at length closed her eyes. She could not yet recover from the
+surprise of what had happened; it was impossible to think of anything
+else; and, totally indisposed for employment, she resolved, soon after
+breakfast, to indulge herself in air and exercise. She was proceeding
+directly to her favourite walk, when the recollection of Mr. Darcy’s
+sometimes coming there stopped her, and instead of entering the park,
+she turned up the lane, which led farther from the turnpike-road. The
+park paling was still the boundary on one side, and she soon passed one
+of the gates into the ground.
+
+After walking two or three times along that part of the lane, she was
+tempted, by the pleasantness of the morning, to stop at the gates and
+look into the park. The five weeks which she had now passed in Kent had
+made a great difference in the country, and every day was adding to the
+verdure of the early trees. She was on the point of continuing her walk,
+when she caught a glimpse of a gentleman within the sort of grove which
+edged the park; he was moving that way; and, fearful of its being Mr.
+Darcy, she was directly retreating. But the person who advanced was now
+near enough to see her, and stepping forward with eagerness, pronounced
+her name. She had turned away; but on hearing herself called, though
+in a voice which proved it to be Mr. Darcy, she moved again towards the
+gate. He had by that time reached it also, and, holding out a letter,
+which she instinctively took, said, with a look of haughty composure,
+“I have been walking in the grove some time in the hope of meeting you.
+Will you do me the honour of reading that letter?” And then, with a
+slight bow, turned again into the plantation, and was soon out of sight.
+
+With no expectation of pleasure, but with the strongest curiosity,
+Elizabeth opened the letter, and, to her still increasing wonder,
+perceived an envelope containing two sheets of letter-paper, written
+quite through, in a very close hand. The envelope itself was likewise
+full. Pursuing her way along the lane, she then began it. It was dated
+from Rosings, at eight o’clock in the morning, and was as follows:--
+
+“Be not alarmed, madam, on receiving this letter, by the apprehension
+of its containing any repetition of those sentiments or renewal of those
+offers which were last night so disgusting to you. I write without any
+intention of paining you, or humbling myself, by dwelling on wishes
+which, for the happiness of both, cannot be too soon forgotten; and the
+effort which the formation and the perusal of this letter must occasion,
+should have been spared, had not my character required it to be written
+and read. You must, therefore, pardon the freedom with which I demand
+your attention; your feelings, I know, will bestow it unwillingly, but I
+demand it of your justice.
+
+“Two offenses of a very different nature, and by no means of equal
+magnitude, you last night laid to my charge. The first mentioned was,
+that, regardless of the sentiments of either, I had detached Mr. Bingley
+from your sister, and the other, that I had, in defiance of various
+claims, in defiance of honour and humanity, ruined the immediate
+prosperity and blasted the prospects of Mr. Wickham. Wilfully and
+wantonly to have thrown off the companion of my youth, the acknowledged
+favourite of my father, a young man who had scarcely any other
+dependence than on our patronage, and who had been brought up to expect
+its exertion, would be a depravity, to which the separation of two young
+persons, whose affection could be the growth of only a few weeks, could
+bear no comparison. But from the severity of that blame which was last
+night so liberally bestowed, respecting each circumstance, I shall hope
+to be in the future secured, when the following account of my actions
+and their motives has been read. If, in the explanation of them, which
+is due to myself, I am under the necessity of relating feelings which
+may be offensive to yours, I can only say that I am sorry. The necessity
+must be obeyed, and further apology would be absurd.
+
+“I had not been long in Hertfordshire, before I saw, in common with
+others, that Bingley preferred your elder sister to any other young
+woman in the country. But it was not till the evening of the dance
+at Netherfield that I had any apprehension of his feeling a serious
+attachment. I had often seen him in love before. At that ball, while I
+had the honour of dancing with you, I was first made acquainted, by Sir
+William Lucas’s accidental information, that Bingley’s attentions to
+your sister had given rise to a general expectation of their marriage.
+He spoke of it as a certain event, of which the time alone could
+be undecided. From that moment I observed my friend’s behaviour
+attentively; and I could then perceive that his partiality for Miss
+Bennet was beyond what I had ever witnessed in him. Your sister I also
+watched. Her look and manners were open, cheerful, and engaging as ever,
+but without any symptom of peculiar regard, and I remained convinced
+from the evening’s scrutiny, that though she received his attentions
+with pleasure, she did not invite them by any participation of
+sentiment. If _you_ have not been mistaken here, _I_ must have been
+in error. Your superior knowledge of your sister must make the latter
+probable. If it be so, if I have been misled by such error to inflict
+pain on her, your resentment has not been unreasonable. But I shall not
+scruple to assert, that the serenity of your sister’s countenance and
+air was such as might have given the most acute observer a conviction
+that, however amiable her temper, her heart was not likely to be
+easily touched. That I was desirous of believing her indifferent is
+certain--but I will venture to say that my investigation and decisions
+are not usually influenced by my hopes or fears. I did not believe
+her to be indifferent because I wished it; I believed it on impartial
+conviction, as truly as I wished it in reason. My objections to the
+marriage were not merely those which I last night acknowledged to have
+the utmost force of passion to put aside, in my own case; the want of
+connection could not be so great an evil to my friend as to me. But
+there were other causes of repugnance; causes which, though still
+existing, and existing to an equal degree in both instances, I had
+myself endeavoured to forget, because they were not immediately before
+me. These causes must be stated, though briefly. The situation of your
+mother’s family, though objectionable, was nothing in comparison to that
+total want of propriety so frequently, so almost uniformly betrayed by
+herself, by your three younger sisters, and occasionally even by your
+father. Pardon me. It pains me to offend you. But amidst your concern
+for the defects of your nearest relations, and your displeasure at this
+representation of them, let it give you consolation to consider that, to
+have conducted yourselves so as to avoid any share of the like censure,
+is praise no less generally bestowed on you and your elder sister, than
+it is honourable to the sense and disposition of both. I will only say
+farther that from what passed that evening, my opinion of all parties
+was confirmed, and every inducement heightened which could have led
+me before, to preserve my friend from what I esteemed a most unhappy
+connection. He left Netherfield for London, on the day following, as
+you, I am certain, remember, with the design of soon returning.
+
+“The part which I acted is now to be explained. His sisters’ uneasiness
+had been equally excited with my own; our coincidence of feeling was
+soon discovered, and, alike sensible that no time was to be lost in
+detaching their brother, we shortly resolved on joining him directly in
+London. We accordingly went--and there I readily engaged in the office
+of pointing out to my friend the certain evils of such a choice. I
+described, and enforced them earnestly. But, however this remonstrance
+might have staggered or delayed his determination, I do not suppose
+that it would ultimately have prevented the marriage, had it not been
+seconded by the assurance that I hesitated not in giving, of your
+sister’s indifference. He had before believed her to return his
+affection with sincere, if not with equal regard. But Bingley has great
+natural modesty, with a stronger dependence on my judgement than on his
+own. To convince him, therefore, that he had deceived himself, was
+no very difficult point. To persuade him against returning into
+Hertfordshire, when that conviction had been given, was scarcely the
+work of a moment. I cannot blame myself for having done thus much. There
+is but one part of my conduct in the whole affair on which I do not
+reflect with satisfaction; it is that I condescended to adopt the
+measures of art so far as to conceal from him your sister’s being in
+town. I knew it myself, as it was known to Miss Bingley; but her
+brother is even yet ignorant of it. That they might have met without
+ill consequence is perhaps probable; but his regard did not appear to me
+enough extinguished for him to see her without some danger. Perhaps this
+concealment, this disguise was beneath me; it is done, however, and it
+was done for the best. On this subject I have nothing more to say, no
+other apology to offer. If I have wounded your sister’s feelings, it
+was unknowingly done and though the motives which governed me may to
+you very naturally appear insufficient, I have not yet learnt to condemn
+them.
+
+“With respect to that other, more weighty accusation, of having injured
+Mr. Wickham, I can only refute it by laying before you the whole of his
+connection with my family. Of what he has _particularly_ accused me I
+am ignorant; but of the truth of what I shall relate, I can summon more
+than one witness of undoubted veracity.
+
+“Mr. Wickham is the son of a very respectable man, who had for many
+years the management of all the Pemberley estates, and whose good
+conduct in the discharge of his trust naturally inclined my father to
+be of service to him; and on George Wickham, who was his godson, his
+kindness was therefore liberally bestowed. My father supported him at
+school, and afterwards at Cambridge--most important assistance, as his
+own father, always poor from the extravagance of his wife, would have
+been unable to give him a gentleman’s education. My father was not only
+fond of this young man’s society, whose manners were always engaging; he
+had also the highest opinion of him, and hoping the church would be
+his profession, intended to provide for him in it. As for myself, it is
+many, many years since I first began to think of him in a very different
+manner. The vicious propensities--the want of principle, which he was
+careful to guard from the knowledge of his best friend, could not escape
+the observation of a young man of nearly the same age with himself,
+and who had opportunities of seeing him in unguarded moments, which Mr.
+Darcy could not have. Here again I shall give you pain--to what degree
+you only can tell. But whatever may be the sentiments which Mr. Wickham
+has created, a suspicion of their nature shall not prevent me from
+unfolding his real character--it adds even another motive.
+
+“My excellent father died about five years ago; and his attachment to
+Mr. Wickham was to the last so steady, that in his will he particularly
+recommended it to me, to promote his advancement in the best manner
+that his profession might allow--and if he took orders, desired that a
+valuable family living might be his as soon as it became vacant. There
+was also a legacy of one thousand pounds. His own father did not long
+survive mine, and within half a year from these events, Mr. Wickham
+wrote to inform me that, having finally resolved against taking orders,
+he hoped I should not think it unreasonable for him to expect some more
+immediate pecuniary advantage, in lieu of the preferment, by which he
+could not be benefited. He had some intention, he added, of studying
+law, and I must be aware that the interest of one thousand pounds would
+be a very insufficient support therein. I rather wished, than believed
+him to be sincere; but, at any rate, was perfectly ready to accede to
+his proposal. I knew that Mr. Wickham ought not to be a clergyman; the
+business was therefore soon settled--he resigned all claim to assistance
+in the church, were it possible that he could ever be in a situation to
+receive it, and accepted in return three thousand pounds. All connection
+between us seemed now dissolved. I thought too ill of him to invite him
+to Pemberley, or admit his society in town. In town I believe he chiefly
+lived, but his studying the law was a mere pretence, and being now free
+from all restraint, his life was a life of idleness and dissipation.
+For about three years I heard little of him; but on the decease of the
+incumbent of the living which had been designed for him, he applied to
+me again by letter for the presentation. His circumstances, he assured
+me, and I had no difficulty in believing it, were exceedingly bad. He
+had found the law a most unprofitable study, and was now absolutely
+resolved on being ordained, if I would present him to the living in
+question--of which he trusted there could be little doubt, as he was
+well assured that I had no other person to provide for, and I could not
+have forgotten my revered father’s intentions. You will hardly blame
+me for refusing to comply with this entreaty, or for resisting every
+repetition to it. His resentment was in proportion to the distress of
+his circumstances--and he was doubtless as violent in his abuse of me
+to others as in his reproaches to myself. After this period every
+appearance of acquaintance was dropped. How he lived I know not. But
+last summer he was again most painfully obtruded on my notice.
+
+“I must now mention a circumstance which I would wish to forget myself,
+and which no obligation less than the present should induce me to unfold
+to any human being. Having said thus much, I feel no doubt of your
+secrecy. My sister, who is more than ten years my junior, was left to
+the guardianship of my mother’s nephew, Colonel Fitzwilliam, and myself.
+About a year ago, she was taken from school, and an establishment formed
+for her in London; and last summer she went with the lady who presided
+over it, to Ramsgate; and thither also went Mr. Wickham, undoubtedly by
+design; for there proved to have been a prior acquaintance between him
+and Mrs. Younge, in whose character we were most unhappily deceived; and
+by her connivance and aid, he so far recommended himself to Georgiana,
+whose affectionate heart retained a strong impression of his kindness to
+her as a child, that she was persuaded to believe herself in love, and
+to consent to an elopement. She was then but fifteen, which must be her
+excuse; and after stating her imprudence, I am happy to add, that I owed
+the knowledge of it to herself. I joined them unexpectedly a day or two
+before the intended elopement, and then Georgiana, unable to support the
+idea of grieving and offending a brother whom she almost looked up to as
+a father, acknowledged the whole to me. You may imagine what I felt and
+how I acted. Regard for my sister’s credit and feelings prevented
+any public exposure; but I wrote to Mr. Wickham, who left the place
+immediately, and Mrs. Younge was of course removed from her charge. Mr.
+Wickham’s chief object was unquestionably my sister’s fortune, which
+is thirty thousand pounds; but I cannot help supposing that the hope of
+revenging himself on me was a strong inducement. His revenge would have
+been complete indeed.
+
+“This, madam, is a faithful narrative of every event in which we have
+been concerned together; and if you do not absolutely reject it as
+false, you will, I hope, acquit me henceforth of cruelty towards Mr.
+Wickham. I know not in what manner, under what form of falsehood he
+had imposed on you; but his success is not perhaps to be wondered
+at. Ignorant as you previously were of everything concerning either,
+detection could not be in your power, and suspicion certainly not in
+your inclination.
+
+“You may possibly wonder why all this was not told you last night; but
+I was not then master enough of myself to know what could or ought to
+be revealed. For the truth of everything here related, I can appeal more
+particularly to the testimony of Colonel Fitzwilliam, who, from our
+near relationship and constant intimacy, and, still more, as one of
+the executors of my father’s will, has been unavoidably acquainted
+with every particular of these transactions. If your abhorrence of _me_
+should make _my_ assertions valueless, you cannot be prevented by
+the same cause from confiding in my cousin; and that there may be
+the possibility of consulting him, I shall endeavour to find some
+opportunity of putting this letter in your hands in the course of the
+morning. I will only add, God bless you.
+
+“FITZWILLIAM DARCY”
+
+
+
+Chapter 36
+
+
+If Elizabeth, when Mr. Darcy gave her the letter, did not expect it to
+contain a renewal of his offers, she had formed no expectation at all of
+its contents. But such as they were, it may well be supposed how eagerly
+she went through them, and what a contrariety of emotion they excited.
+Her feelings as she read were scarcely to be defined. With amazement did
+she first understand that he believed any apology to be in his power;
+and steadfastly was she persuaded, that he could have no explanation
+to give, which a just sense of shame would not conceal. With a strong
+prejudice against everything he might say, she began his account of what
+had happened at Netherfield. She read with an eagerness which hardly
+left her power of comprehension, and from impatience of knowing what the
+next sentence might bring, was incapable of attending to the sense of
+the one before her eyes. His belief of her sister’s insensibility she
+instantly resolved to be false; and his account of the real, the worst
+objections to the match, made her too angry to have any wish of doing
+him justice. He expressed no regret for what he had done which satisfied
+her; his style was not penitent, but haughty. It was all pride and
+insolence.
+
+But when this subject was succeeded by his account of Mr. Wickham--when
+she read with somewhat clearer attention a relation of events which,
+if true, must overthrow every cherished opinion of his worth, and which
+bore so alarming an affinity to his own history of himself--her
+feelings were yet more acutely painful and more difficult of definition.
+Astonishment, apprehension, and even horror, oppressed her. She wished
+to discredit it entirely, repeatedly exclaiming, “This must be false!
+This cannot be! This must be the grossest falsehood!”--and when she had
+gone through the whole letter, though scarcely knowing anything of the
+last page or two, put it hastily away, protesting that she would not
+regard it, that she would never look in it again.
+
+In this perturbed state of mind, with thoughts that could rest on
+nothing, she walked on; but it would not do; in half a minute the letter
+was unfolded again, and collecting herself as well as she could, she
+again began the mortifying perusal of all that related to Wickham, and
+commanded herself so far as to examine the meaning of every sentence.
+The account of his connection with the Pemberley family was exactly what
+he had related himself; and the kindness of the late Mr. Darcy, though
+she had not before known its extent, agreed equally well with his own
+words. So far each recital confirmed the other; but when she came to the
+will, the difference was great. What Wickham had said of the living
+was fresh in her memory, and as she recalled his very words, it was
+impossible not to feel that there was gross duplicity on one side or the
+other; and, for a few moments, she flattered herself that her wishes did
+not err. But when she read and re-read with the closest attention, the
+particulars immediately following of Wickham’s resigning all pretensions
+to the living, of his receiving in lieu so considerable a sum as three
+thousand pounds, again was she forced to hesitate. She put down
+the letter, weighed every circumstance with what she meant to be
+impartiality--deliberated on the probability of each statement--but with
+little success. On both sides it was only assertion. Again she read
+on; but every line proved more clearly that the affair, which she had
+believed it impossible that any contrivance could so represent as to
+render Mr. Darcy’s conduct in it less than infamous, was capable of a
+turn which must make him entirely blameless throughout the whole.
+
+The extravagance and general profligacy which he scrupled not to lay at
+Mr. Wickham’s charge, exceedingly shocked her; the more so, as she could
+bring no proof of its injustice. She had never heard of him before his
+entrance into the ----shire Militia, in which he had engaged at the
+persuasion of the young man who, on meeting him accidentally in town,
+had there renewed a slight acquaintance. Of his former way of life
+nothing had been known in Hertfordshire but what he told himself. As
+to his real character, had information been in her power, she had
+never felt a wish of inquiring. His countenance, voice, and manner had
+established him at once in the possession of every virtue. She tried
+to recollect some instance of goodness, some distinguished trait of
+integrity or benevolence, that might rescue him from the attacks of
+Mr. Darcy; or at least, by the predominance of virtue, atone for those
+casual errors under which she would endeavour to class what Mr. Darcy
+had described as the idleness and vice of many years’ continuance. But
+no such recollection befriended her. She could see him instantly before
+her, in every charm of air and address; but she could remember no more
+substantial good than the general approbation of the neighbourhood, and
+the regard which his social powers had gained him in the mess. After
+pausing on this point a considerable while, she once more continued to
+read. But, alas! the story which followed, of his designs on Miss
+Darcy, received some confirmation from what had passed between Colonel
+Fitzwilliam and herself only the morning before; and at last she was
+referred for the truth of every particular to Colonel Fitzwilliam
+himself--from whom she had previously received the information of his
+near concern in all his cousin’s affairs, and whose character she had no
+reason to question. At one time she had almost resolved on applying to
+him, but the idea was checked by the awkwardness of the application, and
+at length wholly banished by the conviction that Mr. Darcy would never
+have hazarded such a proposal, if he had not been well assured of his
+cousin’s corroboration.
+
+She perfectly remembered everything that had passed in conversation
+between Wickham and herself, in their first evening at Mr. Phillips’s.
+Many of his expressions were still fresh in her memory. She was _now_
+struck with the impropriety of such communications to a stranger, and
+wondered it had escaped her before. She saw the indelicacy of putting
+himself forward as he had done, and the inconsistency of his professions
+with his conduct. She remembered that he had boasted of having no fear
+of seeing Mr. Darcy--that Mr. Darcy might leave the country, but that
+_he_ should stand his ground; yet he had avoided the Netherfield ball
+the very next week. She remembered also that, till the Netherfield
+family had quitted the country, he had told his story to no one but
+herself; but that after their removal it had been everywhere discussed;
+that he had then no reserves, no scruples in sinking Mr. Darcy’s
+character, though he had assured her that respect for the father would
+always prevent his exposing the son.
+
+How differently did everything now appear in which he was concerned!
+His attentions to Miss King were now the consequence of views solely and
+hatefully mercenary; and the mediocrity of her fortune proved no longer
+the moderation of his wishes, but his eagerness to grasp at anything.
+His behaviour to herself could now have had no tolerable motive; he had
+either been deceived with regard to her fortune, or had been gratifying
+his vanity by encouraging the preference which she believed she had most
+incautiously shown. Every lingering struggle in his favour grew fainter
+and fainter; and in farther justification of Mr. Darcy, she could not
+but allow that Mr. Bingley, when questioned by Jane, had long ago
+asserted his blamelessness in the affair; that proud and repulsive as
+were his manners, she had never, in the whole course of their
+acquaintance--an acquaintance which had latterly brought them much
+together, and given her a sort of intimacy with his ways--seen anything
+that betrayed him to be unprincipled or unjust--anything that spoke him
+of irreligious or immoral habits; that among his own connections he was
+esteemed and valued--that even Wickham had allowed him merit as a
+brother, and that she had often heard him speak so affectionately of his
+sister as to prove him capable of _some_ amiable feeling; that had his
+actions been what Mr. Wickham represented them, so gross a violation of
+everything right could hardly have been concealed from the world; and
+that friendship between a person capable of it, and such an amiable man
+as Mr. Bingley, was incomprehensible.
+
+She grew absolutely ashamed of herself. Of neither Darcy nor Wickham
+could she think without feeling she had been blind, partial, prejudiced,
+absurd.
+
+“How despicably I have acted!” she cried; “I, who have prided myself
+on my discernment! I, who have valued myself on my abilities! who have
+often disdained the generous candour of my sister, and gratified
+my vanity in useless or blameable mistrust! How humiliating is this
+discovery! Yet, how just a humiliation! Had I been in love, I could
+not have been more wretchedly blind! But vanity, not love, has been my
+folly. Pleased with the preference of one, and offended by the neglect
+of the other, on the very beginning of our acquaintance, I have courted
+prepossession and ignorance, and driven reason away, where either were
+concerned. Till this moment I never knew myself.”
+
+From herself to Jane--from Jane to Bingley, her thoughts were in a line
+which soon brought to her recollection that Mr. Darcy’s explanation
+_there_ had appeared very insufficient, and she read it again. Widely
+different was the effect of a second perusal. How could she deny that
+credit to his assertions in one instance, which she had been obliged to
+give in the other? He declared himself to be totally unsuspicious of her
+sister’s attachment; and she could not help remembering what Charlotte’s
+opinion had always been. Neither could she deny the justice of his
+description of Jane. She felt that Jane’s feelings, though fervent, were
+little displayed, and that there was a constant complacency in her air
+and manner not often united with great sensibility.
+
+When she came to that part of the letter in which her family were
+mentioned in terms of such mortifying, yet merited reproach, her sense
+of shame was severe. The justice of the charge struck her too forcibly
+for denial, and the circumstances to which he particularly alluded as
+having passed at the Netherfield ball, and as confirming all his first
+disapprobation, could not have made a stronger impression on his mind
+than on hers.
+
+The compliment to herself and her sister was not unfelt. It soothed,
+but it could not console her for the contempt which had thus been
+self-attracted by the rest of her family; and as she considered
+that Jane’s disappointment had in fact been the work of her nearest
+relations, and reflected how materially the credit of both must be hurt
+by such impropriety of conduct, she felt depressed beyond anything she
+had ever known before.
+
+After wandering along the lane for two hours, giving way to every
+variety of thought--re-considering events, determining probabilities,
+and reconciling herself, as well as she could, to a change so sudden and
+so important, fatigue, and a recollection of her long absence, made
+her at length return home; and she entered the house with the wish
+of appearing cheerful as usual, and the resolution of repressing such
+reflections as must make her unfit for conversation.
+
+She was immediately told that the two gentlemen from Rosings had each
+called during her absence; Mr. Darcy, only for a few minutes, to take
+leave--but that Colonel Fitzwilliam had been sitting with them at least
+an hour, hoping for her return, and almost resolving to walk after her
+till she could be found. Elizabeth could but just _affect_ concern
+in missing him; she really rejoiced at it. Colonel Fitzwilliam was no
+longer an object; she could think only of her letter.
+
+
+
+Chapter 37
+
+
+The two gentlemen left Rosings the next morning, and Mr. Collins having
+been in waiting near the lodges, to make them his parting obeisance, was
+able to bring home the pleasing intelligence, of their appearing in very
+good health, and in as tolerable spirits as could be expected, after the
+melancholy scene so lately gone through at Rosings. To Rosings he then
+hastened, to console Lady Catherine and her daughter; and on his return
+brought back, with great satisfaction, a message from her ladyship,
+importing that she felt herself so dull as to make her very desirous of
+having them all to dine with her.
+
+Elizabeth could not see Lady Catherine without recollecting that, had
+she chosen it, she might by this time have been presented to her as
+her future niece; nor could she think, without a smile, of what her
+ladyship’s indignation would have been. “What would she have said? how
+would she have behaved?” were questions with which she amused herself.
+
+Their first subject was the diminution of the Rosings party. “I assure
+you, I feel it exceedingly,” said Lady Catherine; “I believe no one
+feels the loss of friends so much as I do. But I am particularly
+attached to these young men, and know them to be so much attached to
+me! They were excessively sorry to go! But so they always are. The
+dear Colonel rallied his spirits tolerably till just at last; but Darcy
+seemed to feel it most acutely, more, I think, than last year. His
+attachment to Rosings certainly increases.”
+
+Mr. Collins had a compliment, and an allusion to throw in here, which
+were kindly smiled on by the mother and daughter.
+
+Lady Catherine observed, after dinner, that Miss Bennet seemed out of
+spirits, and immediately accounting for it by herself, by supposing that
+she did not like to go home again so soon, she added:
+
+“But if that is the case, you must write to your mother and beg that
+you may stay a little longer. Mrs. Collins will be very glad of your
+company, I am sure.”
+
+“I am much obliged to your ladyship for your kind invitation,” replied
+Elizabeth, “but it is not in my power to accept it. I must be in town
+next Saturday.”
+
+“Why, at that rate, you will have been here only six weeks. I expected
+you to stay two months. I told Mrs. Collins so before you came. There
+can be no occasion for your going so soon. Mrs. Bennet could certainly
+spare you for another fortnight.”
+
+“But my father cannot. He wrote last week to hurry my return.”
+
+“Oh! your father of course may spare you, if your mother can. Daughters
+are never of so much consequence to a father. And if you will stay
+another _month_ complete, it will be in my power to take one of you as
+far as London, for I am going there early in June, for a week; and as
+Dawson does not object to the barouche-box, there will be very good room
+for one of you--and indeed, if the weather should happen to be cool, I
+should not object to taking you both, as you are neither of you large.”
+
+“You are all kindness, madam; but I believe we must abide by our
+original plan.”
+
+Lady Catherine seemed resigned. “Mrs. Collins, you must send a servant
+with them. You know I always speak my mind, and I cannot bear the idea
+of two young women travelling post by themselves. It is highly improper.
+You must contrive to send somebody. I have the greatest dislike in
+the world to that sort of thing. Young women should always be properly
+guarded and attended, according to their situation in life. When my
+niece Georgiana went to Ramsgate last summer, I made a point of her
+having two men-servants go with her. Miss Darcy, the daughter of
+Mr. Darcy, of Pemberley, and Lady Anne, could not have appeared with
+propriety in a different manner. I am excessively attentive to all those
+things. You must send John with the young ladies, Mrs. Collins. I
+am glad it occurred to me to mention it; for it would really be
+discreditable to _you_ to let them go alone.”
+
+“My uncle is to send a servant for us.”
+
+“Oh! Your uncle! He keeps a man-servant, does he? I am very glad you
+have somebody who thinks of these things. Where shall you change horses?
+Oh! Bromley, of course. If you mention my name at the Bell, you will be
+attended to.”
+
+Lady Catherine had many other questions to ask respecting their journey,
+and as she did not answer them all herself, attention was necessary,
+which Elizabeth believed to be lucky for her; or, with a mind so
+occupied, she might have forgotten where she was. Reflection must be
+reserved for solitary hours; whenever she was alone, she gave way to it
+as the greatest relief; and not a day went by without a solitary
+walk, in which she might indulge in all the delight of unpleasant
+recollections.
+
+Mr. Darcy’s letter she was in a fair way of soon knowing by heart. She
+studied every sentence; and her feelings towards its writer were at
+times widely different. When she remembered the style of his address,
+she was still full of indignation; but when she considered how unjustly
+she had condemned and upbraided him, her anger was turned against
+herself; and his disappointed feelings became the object of compassion.
+His attachment excited gratitude, his general character respect; but she
+could not approve him; nor could she for a moment repent her refusal,
+or feel the slightest inclination ever to see him again. In her own past
+behaviour, there was a constant source of vexation and regret; and in
+the unhappy defects of her family, a subject of yet heavier chagrin.
+They were hopeless of remedy. Her father, contented with laughing at
+them, would never exert himself to restrain the wild giddiness of his
+youngest daughters; and her mother, with manners so far from right
+herself, was entirely insensible of the evil. Elizabeth had frequently
+united with Jane in an endeavour to check the imprudence of Catherine
+and Lydia; but while they were supported by their mother’s indulgence,
+what chance could there be of improvement? Catherine, weak-spirited,
+irritable, and completely under Lydia’s guidance, had been always
+affronted by their advice; and Lydia, self-willed and careless, would
+scarcely give them a hearing. They were ignorant, idle, and vain. While
+there was an officer in Meryton, they would flirt with him; and while
+Meryton was within a walk of Longbourn, they would be going there
+forever.
+
+Anxiety on Jane’s behalf was another prevailing concern; and Mr. Darcy’s
+explanation, by restoring Bingley to all her former good opinion,
+heightened the sense of what Jane had lost. His affection was proved
+to have been sincere, and his conduct cleared of all blame, unless any
+could attach to the implicitness of his confidence in his friend. How
+grievous then was the thought that, of a situation so desirable in every
+respect, so replete with advantage, so promising for happiness, Jane had
+been deprived, by the folly and indecorum of her own family!
+
+When to these recollections was added the development of Wickham’s
+character, it may be easily believed that the happy spirits which had
+seldom been depressed before, were now so much affected as to make it
+almost impossible for her to appear tolerably cheerful.
+
+Their engagements at Rosings were as frequent during the last week of
+her stay as they had been at first. The very last evening was spent
+there; and her ladyship again inquired minutely into the particulars of
+their journey, gave them directions as to the best method of packing,
+and was so urgent on the necessity of placing gowns in the only right
+way, that Maria thought herself obliged, on her return, to undo all the
+work of the morning, and pack her trunk afresh.
+
+When they parted, Lady Catherine, with great condescension, wished them
+a good journey, and invited them to come to Hunsford again next year;
+and Miss de Bourgh exerted herself so far as to curtsey and hold out her
+hand to both.
+
+
+
+Chapter 38
+
+
+On Saturday morning Elizabeth and Mr. Collins met for breakfast a few
+minutes before the others appeared; and he took the opportunity of
+paying the parting civilities which he deemed indispensably necessary.
+
+“I know not, Miss Elizabeth,” said he, “whether Mrs. Collins has yet
+expressed her sense of your kindness in coming to us; but I am very
+certain you will not leave the house without receiving her thanks for
+it. The favour of your company has been much felt, I assure you. We
+know how little there is to tempt anyone to our humble abode. Our plain
+manner of living, our small rooms and few domestics, and the little we
+see of the world, must make Hunsford extremely dull to a young lady like
+yourself; but I hope you will believe us grateful for the condescension,
+and that we have done everything in our power to prevent your spending
+your time unpleasantly.”
+
+Elizabeth was eager with her thanks and assurances of happiness. She
+had spent six weeks with great enjoyment; and the pleasure of being with
+Charlotte, and the kind attentions she had received, must make _her_
+feel the obliged. Mr. Collins was gratified, and with a more smiling
+solemnity replied:
+
+“It gives me great pleasure to hear that you have passed your time not
+disagreeably. We have certainly done our best; and most fortunately
+having it in our power to introduce you to very superior society, and,
+from our connection with Rosings, the frequent means of varying the
+humble home scene, I think we may flatter ourselves that your Hunsford
+visit cannot have been entirely irksome. Our situation with regard to
+Lady Catherine’s family is indeed the sort of extraordinary advantage
+and blessing which few can boast. You see on what a footing we are. You
+see how continually we are engaged there. In truth I must acknowledge
+that, with all the disadvantages of this humble parsonage, I should
+not think anyone abiding in it an object of compassion, while they are
+sharers of our intimacy at Rosings.”
+
+Words were insufficient for the elevation of his feelings; and he was
+obliged to walk about the room, while Elizabeth tried to unite civility
+and truth in a few short sentences.
+
+“You may, in fact, carry a very favourable report of us into
+Hertfordshire, my dear cousin. I flatter myself at least that you will
+be able to do so. Lady Catherine’s great attentions to Mrs. Collins you
+have been a daily witness of; and altogether I trust it does not appear
+that your friend has drawn an unfortunate--but on this point it will be
+as well to be silent. Only let me assure you, my dear Miss Elizabeth,
+that I can from my heart most cordially wish you equal felicity in
+marriage. My dear Charlotte and I have but one mind and one way of
+thinking. There is in everything a most remarkable resemblance of
+character and ideas between us. We seem to have been designed for each
+other.”
+
+Elizabeth could safely say that it was a great happiness where that was
+the case, and with equal sincerity could add, that she firmly believed
+and rejoiced in his domestic comforts. She was not sorry, however, to
+have the recital of them interrupted by the lady from whom they sprang.
+Poor Charlotte! it was melancholy to leave her to such society! But she
+had chosen it with her eyes open; and though evidently regretting that
+her visitors were to go, she did not seem to ask for compassion. Her
+home and her housekeeping, her parish and her poultry, and all their
+dependent concerns, had not yet lost their charms.
+
+At length the chaise arrived, the trunks were fastened on, the parcels
+placed within, and it was pronounced to be ready. After an affectionate
+parting between the friends, Elizabeth was attended to the carriage by
+Mr. Collins, and as they walked down the garden he was commissioning her
+with his best respects to all her family, not forgetting his thanks
+for the kindness he had received at Longbourn in the winter, and his
+compliments to Mr. and Mrs. Gardiner, though unknown. He then handed her
+in, Maria followed, and the door was on the point of being closed,
+when he suddenly reminded them, with some consternation, that they had
+hitherto forgotten to leave any message for the ladies at Rosings.
+
+“But,” he added, “you will of course wish to have your humble respects
+delivered to them, with your grateful thanks for their kindness to you
+while you have been here.”
+
+Elizabeth made no objection; the door was then allowed to be shut, and
+the carriage drove off.
+
+“Good gracious!” cried Maria, after a few minutes’ silence, “it seems
+but a day or two since we first came! and yet how many things have
+happened!”
+
+“A great many indeed,” said her companion with a sigh.
+
+“We have dined nine times at Rosings, besides drinking tea there twice!
+How much I shall have to tell!”
+
+Elizabeth added privately, “And how much I shall have to conceal!”
+
+Their journey was performed without much conversation, or any alarm; and
+within four hours of their leaving Hunsford they reached Mr. Gardiner’s
+house, where they were to remain a few days.
+
+Jane looked well, and Elizabeth had little opportunity of studying her
+spirits, amidst the various engagements which the kindness of her
+aunt had reserved for them. But Jane was to go home with her, and at
+Longbourn there would be leisure enough for observation.
+
+It was not without an effort, meanwhile, that she could wait even for
+Longbourn, before she told her sister of Mr. Darcy’s proposals. To know
+that she had the power of revealing what would so exceedingly astonish
+Jane, and must, at the same time, so highly gratify whatever of her own
+vanity she had not yet been able to reason away, was such a temptation
+to openness as nothing could have conquered but the state of indecision
+in which she remained as to the extent of what she should communicate;
+and her fear, if she once entered on the subject, of being hurried
+into repeating something of Bingley which might only grieve her sister
+further.
+
+
+
+Chapter 39
+
+
+It was the second week in May, in which the three young ladies set out
+together from Gracechurch Street for the town of ----, in Hertfordshire;
+and, as they drew near the appointed inn where Mr. Bennet’s carriage
+was to meet them, they quickly perceived, in token of the coachman’s
+punctuality, both Kitty and Lydia looking out of a dining-room up stairs.
+These two girls had been above an hour in the place, happily employed
+in visiting an opposite milliner, watching the sentinel on guard, and
+dressing a salad and cucumber.
+
+After welcoming their sisters, they triumphantly displayed a table set
+out with such cold meat as an inn larder usually affords, exclaiming,
+“Is not this nice? Is not this an agreeable surprise?”
+
+“And we mean to treat you all,” added Lydia, “but you must lend us the
+money, for we have just spent ours at the shop out there.” Then, showing
+her purchases--“Look here, I have bought this bonnet. I do not think
+it is very pretty; but I thought I might as well buy it as not. I shall
+pull it to pieces as soon as I get home, and see if I can make it up any
+better.”
+
+And when her sisters abused it as ugly, she added, with perfect
+unconcern, “Oh! but there were two or three much uglier in the shop; and
+when I have bought some prettier-coloured satin to trim it with fresh, I
+think it will be very tolerable. Besides, it will not much signify what
+one wears this summer, after the ----shire have left Meryton, and they
+are going in a fortnight.”
+
+“Are they indeed!” cried Elizabeth, with the greatest satisfaction.
+
+“They are going to be encamped near Brighton; and I do so want papa to
+take us all there for the summer! It would be such a delicious scheme;
+and I dare say would hardly cost anything at all. Mamma would like to
+go too of all things! Only think what a miserable summer else we shall
+have!”
+
+“Yes,” thought Elizabeth, “_that_ would be a delightful scheme indeed,
+and completely do for us at once. Good Heaven! Brighton, and a whole
+campful of soldiers, to us, who have been overset already by one poor
+regiment of militia, and the monthly balls of Meryton!”
+
+“Now I have got some news for you,” said Lydia, as they sat down at
+table. “What do you think? It is excellent news--capital news--and about
+a certain person we all like!”
+
+Jane and Elizabeth looked at each other, and the waiter was told he need
+not stay. Lydia laughed, and said:
+
+“Aye, that is just like your formality and discretion. You thought the
+waiter must not hear, as if he cared! I dare say he often hears worse
+things said than I am going to say. But he is an ugly fellow! I am glad
+he is gone. I never saw such a long chin in my life. Well, but now for
+my news; it is about dear Wickham; too good for the waiter, is it not?
+There is no danger of Wickham’s marrying Mary King. There’s for you! She
+is gone down to her uncle at Liverpool: gone to stay. Wickham is safe.”
+
+“And Mary King is safe!” added Elizabeth; “safe from a connection
+imprudent as to fortune.”
+
+“She is a great fool for going away, if she liked him.”
+
+“But I hope there is no strong attachment on either side,” said Jane.
+
+“I am sure there is not on _his_. I will answer for it, he never cared
+three straws about her--who could about such a nasty little freckled
+thing?”
+
+Elizabeth was shocked to think that, however incapable of such
+coarseness of _expression_ herself, the coarseness of the _sentiment_
+was little other than her own breast had harboured and fancied liberal!
+
+As soon as all had ate, and the elder ones paid, the carriage was
+ordered; and after some contrivance, the whole party, with all their
+boxes, work-bags, and parcels, and the unwelcome addition of Kitty’s and
+Lydia’s purchases, were seated in it.
+
+“How nicely we are all crammed in,” cried Lydia. “I am glad I bought my
+bonnet, if it is only for the fun of having another bandbox! Well, now
+let us be quite comfortable and snug, and talk and laugh all the way
+home. And in the first place, let us hear what has happened to you all
+since you went away. Have you seen any pleasant men? Have you had any
+flirting? I was in great hopes that one of you would have got a husband
+before you came back. Jane will be quite an old maid soon, I declare.
+She is almost three-and-twenty! Lord, how ashamed I should be of not
+being married before three-and-twenty! My aunt Phillips wants you so to
+get husbands, you can’t think. She says Lizzy had better have taken Mr.
+Collins; but _I_ do not think there would have been any fun in it. Lord!
+how I should like to be married before any of you; and then I would
+chaperon you about to all the balls. Dear me! we had such a good piece
+of fun the other day at Colonel Forster’s. Kitty and me were to spend
+the day there, and Mrs. Forster promised to have a little dance in the
+evening; (by the bye, Mrs. Forster and me are _such_ friends!) and so
+she asked the two Harringtons to come, but Harriet was ill, and so Pen
+was forced to come by herself; and then, what do you think we did? We
+dressed up Chamberlayne in woman’s clothes on purpose to pass for a
+lady, only think what fun! Not a soul knew of it, but Colonel and Mrs.
+Forster, and Kitty and me, except my aunt, for we were forced to borrow
+one of her gowns; and you cannot imagine how well he looked! When Denny,
+and Wickham, and Pratt, and two or three more of the men came in, they
+did not know him in the least. Lord! how I laughed! and so did Mrs.
+Forster. I thought I should have died. And _that_ made the men suspect
+something, and then they soon found out what was the matter.”
+
+With such kinds of histories of their parties and good jokes, did
+Lydia, assisted by Kitty’s hints and additions, endeavour to amuse her
+companions all the way to Longbourn. Elizabeth listened as little as she
+could, but there was no escaping the frequent mention of Wickham’s name.
+
+Their reception at home was most kind. Mrs. Bennet rejoiced to see Jane
+in undiminished beauty; and more than once during dinner did Mr. Bennet
+say voluntarily to Elizabeth:
+
+“I am glad you are come back, Lizzy.”
+
+Their party in the dining-room was large, for almost all the Lucases
+came to meet Maria and hear the news; and various were the subjects that
+occupied them: Lady Lucas was inquiring of Maria, after the welfare and
+poultry of her eldest daughter; Mrs. Bennet was doubly engaged, on one
+hand collecting an account of the present fashions from Jane, who sat
+some way below her, and, on the other, retailing them all to the younger
+Lucases; and Lydia, in a voice rather louder than any other person’s,
+was enumerating the various pleasures of the morning to anybody who
+would hear her.
+
+“Oh! Mary,” said she, “I wish you had gone with us, for we had such fun!
+As we went along, Kitty and I drew up the blinds, and pretended there
+was nobody in the coach; and I should have gone so all the way, if Kitty
+had not been sick; and when we got to the George, I do think we behaved
+very handsomely, for we treated the other three with the nicest cold
+luncheon in the world, and if you would have gone, we would have treated
+you too. And then when we came away it was such fun! I thought we never
+should have got into the coach. I was ready to die of laughter. And then
+we were so merry all the way home! we talked and laughed so loud, that
+anybody might have heard us ten miles off!”
+
+To this Mary very gravely replied, “Far be it from me, my dear sister,
+to depreciate such pleasures! They would doubtless be congenial with the
+generality of female minds. But I confess they would have no charms for
+_me_--I should infinitely prefer a book.”
+
+But of this answer Lydia heard not a word. She seldom listened to
+anybody for more than half a minute, and never attended to Mary at all.
+
+In the afternoon Lydia was urgent with the rest of the girls to walk
+to Meryton, and to see how everybody went on; but Elizabeth steadily
+opposed the scheme. It should not be said that the Miss Bennets could
+not be at home half a day before they were in pursuit of the officers.
+There was another reason too for her opposition. She dreaded seeing Mr.
+Wickham again, and was resolved to avoid it as long as possible. The
+comfort to _her_ of the regiment’s approaching removal was indeed beyond
+expression. In a fortnight they were to go--and once gone, she hoped
+there could be nothing more to plague her on his account.
+
+She had not been many hours at home before she found that the Brighton
+scheme, of which Lydia had given them a hint at the inn, was under
+frequent discussion between her parents. Elizabeth saw directly that her
+father had not the smallest intention of yielding; but his answers were
+at the same time so vague and equivocal, that her mother, though often
+disheartened, had never yet despaired of succeeding at last.
+
+
+
+Chapter 40
+
+
+Elizabeth’s impatience to acquaint Jane with what had happened could
+no longer be overcome; and at length, resolving to suppress every
+particular in which her sister was concerned, and preparing her to be
+surprised, she related to her the next morning the chief of the scene
+between Mr. Darcy and herself.
+
+Miss Bennet’s astonishment was soon lessened by the strong sisterly
+partiality which made any admiration of Elizabeth appear perfectly
+natural; and all surprise was shortly lost in other feelings. She was
+sorry that Mr. Darcy should have delivered his sentiments in a manner so
+little suited to recommend them; but still more was she grieved for the
+unhappiness which her sister’s refusal must have given him.
+
+“His being so sure of succeeding was wrong,” said she, “and certainly
+ought not to have appeared; but consider how much it must increase his
+disappointment!”
+
+“Indeed,” replied Elizabeth, “I am heartily sorry for him; but he has
+other feelings, which will probably soon drive away his regard for me.
+You do not blame me, however, for refusing him?”
+
+“Blame you! Oh, no.”
+
+“But you blame me for having spoken so warmly of Wickham?”
+
+“No--I do not know that you were wrong in saying what you did.”
+
+“But you _will_ know it, when I tell you what happened the very next
+day.”
+
+She then spoke of the letter, repeating the whole of its contents as far
+as they concerned George Wickham. What a stroke was this for poor Jane!
+who would willingly have gone through the world without believing that
+so much wickedness existed in the whole race of mankind, as was here
+collected in one individual. Nor was Darcy’s vindication, though
+grateful to her feelings, capable of consoling her for such discovery.
+Most earnestly did she labour to prove the probability of error, and
+seek to clear the one without involving the other.
+
+“This will not do,” said Elizabeth; “you never will be able to make both
+of them good for anything. Take your choice, but you must be satisfied
+with only one. There is but such a quantity of merit between them; just
+enough to make one good sort of man; and of late it has been shifting
+about pretty much. For my part, I am inclined to believe it all Darcy’s;
+but you shall do as you choose.”
+
+It was some time, however, before a smile could be extorted from Jane.
+
+“I do not know when I have been more shocked,” said she. “Wickham so
+very bad! It is almost past belief. And poor Mr. Darcy! Dear Lizzy, only
+consider what he must have suffered. Such a disappointment! and with the
+knowledge of your ill opinion, too! and having to relate such a thing
+of his sister! It is really too distressing. I am sure you must feel it
+so.”
+
+“Oh! no, my regret and compassion are all done away by seeing you so
+full of both. I know you will do him such ample justice, that I am
+growing every moment more unconcerned and indifferent. Your profusion
+makes me saving; and if you lament over him much longer, my heart will
+be as light as a feather.”
+
+“Poor Wickham! there is such an expression of goodness in his
+countenance! such an openness and gentleness in his manner!”
+
+“There certainly was some great mismanagement in the education of those
+two young men. One has got all the goodness, and the other all the
+appearance of it.”
+
+“I never thought Mr. Darcy so deficient in the _appearance_ of it as you
+used to do.”
+
+“And yet I meant to be uncommonly clever in taking so decided a dislike
+to him, without any reason. It is such a spur to one’s genius, such an
+opening for wit, to have a dislike of that kind. One may be continually
+abusive without saying anything just; but one cannot always be laughing
+at a man without now and then stumbling on something witty.”
+
+“Lizzy, when you first read that letter, I am sure you could not treat
+the matter as you do now.”
+
+“Indeed, I could not. I was uncomfortable enough, I may say unhappy. And
+with no one to speak to about what I felt, no Jane to comfort me and say
+that I had not been so very weak and vain and nonsensical as I knew I
+had! Oh! how I wanted you!”
+
+“How unfortunate that you should have used such very strong expressions
+in speaking of Wickham to Mr. Darcy, for now they _do_ appear wholly
+undeserved.”
+
+“Certainly. But the misfortune of speaking with bitterness is a most
+natural consequence of the prejudices I had been encouraging. There
+is one point on which I want your advice. I want to be told whether I
+ought, or ought not, to make our acquaintances in general understand
+Wickham’s character.”
+
+Miss Bennet paused a little, and then replied, “Surely there can be no
+occasion for exposing him so dreadfully. What is your opinion?”
+
+“That it ought not to be attempted. Mr. Darcy has not authorised me
+to make his communication public. On the contrary, every particular
+relative to his sister was meant to be kept as much as possible to
+myself; and if I endeavour to undeceive people as to the rest of his
+conduct, who will believe me? The general prejudice against Mr. Darcy
+is so violent, that it would be the death of half the good people in
+Meryton to attempt to place him in an amiable light. I am not equal
+to it. Wickham will soon be gone; and therefore it will not signify to
+anyone here what he really is. Some time hence it will be all found out,
+and then we may laugh at their stupidity in not knowing it before. At
+present I will say nothing about it.”
+
+“You are quite right. To have his errors made public might ruin him for
+ever. He is now, perhaps, sorry for what he has done, and anxious to
+re-establish a character. We must not make him desperate.”
+
+The tumult of Elizabeth’s mind was allayed by this conversation. She had
+got rid of two of the secrets which had weighed on her for a fortnight,
+and was certain of a willing listener in Jane, whenever she might wish
+to talk again of either. But there was still something lurking behind,
+of which prudence forbade the disclosure. She dared not relate the other
+half of Mr. Darcy’s letter, nor explain to her sister how sincerely she
+had been valued by her friend. Here was knowledge in which no one
+could partake; and she was sensible that nothing less than a perfect
+understanding between the parties could justify her in throwing off
+this last encumbrance of mystery. “And then,” said she, “if that very
+improbable event should ever take place, I shall merely be able to
+tell what Bingley may tell in a much more agreeable manner himself. The
+liberty of communication cannot be mine till it has lost all its value!”
+
+She was now, on being settled at home, at leisure to observe the real
+state of her sister’s spirits. Jane was not happy. She still cherished a
+very tender affection for Bingley. Having never even fancied herself
+in love before, her regard had all the warmth of first attachment,
+and, from her age and disposition, greater steadiness than most first
+attachments often boast; and so fervently did she value his remembrance,
+and prefer him to every other man, that all her good sense, and all her
+attention to the feelings of her friends, were requisite to check the
+indulgence of those regrets which must have been injurious to her own
+health and their tranquillity.
+
+“Well, Lizzy,” said Mrs. Bennet one day, “what is your opinion _now_ of
+this sad business of Jane’s? For my part, I am determined never to speak
+of it again to anybody. I told my sister Phillips so the other day. But
+I cannot find out that Jane saw anything of him in London. Well, he is
+a very undeserving young man--and I do not suppose there’s the least
+chance in the world of her ever getting him now. There is no talk of
+his coming to Netherfield again in the summer; and I have inquired of
+everybody, too, who is likely to know.”
+
+“I do not believe he will ever live at Netherfield any more.”
+
+“Oh well! it is just as he chooses. Nobody wants him to come. Though I
+shall always say he used my daughter extremely ill; and if I was her, I
+would not have put up with it. Well, my comfort is, I am sure Jane will
+die of a broken heart; and then he will be sorry for what he has done.”
+
+But as Elizabeth could not receive comfort from any such expectation,
+she made no answer.
+
+“Well, Lizzy,” continued her mother, soon afterwards, “and so the
+Collinses live very comfortable, do they? Well, well, I only hope
+it will last. And what sort of table do they keep? Charlotte is an
+excellent manager, I dare say. If she is half as sharp as her
+mother, she is saving enough. There is nothing extravagant in _their_
+housekeeping, I dare say.”
+
+“No, nothing at all.”
+
+“A great deal of good management, depend upon it. Yes, yes, _they_ will
+take care not to outrun their income. _They_ will never be distressed
+for money. Well, much good may it do them! And so, I suppose, they often
+talk of having Longbourn when your father is dead. They look upon it as
+quite their own, I dare say, whenever that happens.”
+
+“It was a subject which they could not mention before me.”
+
+“No; it would have been strange if they had; but I make no doubt they
+often talk of it between themselves. Well, if they can be easy with an
+estate that is not lawfully their own, so much the better. I should be
+ashamed of having one that was only entailed on me.”
+
+
+
+Chapter 41
+
+
+The first week of their return was soon gone. The second began. It was
+the last of the regiment’s stay in Meryton, and all the young ladies
+in the neighbourhood were drooping apace. The dejection was almost
+universal. The elder Miss Bennets alone were still able to eat, drink,
+and sleep, and pursue the usual course of their employments. Very
+frequently were they reproached for this insensibility by Kitty and
+Lydia, whose own misery was extreme, and who could not comprehend such
+hard-heartedness in any of the family.
+
+“Good Heaven! what is to become of us? What are we to do?” would they
+often exclaim in the bitterness of woe. “How can you be smiling so,
+Lizzy?”
+
+Their affectionate mother shared all their grief; she remembered what
+she had herself endured on a similar occasion, five-and-twenty years
+ago.
+
+“I am sure,” said she, “I cried for two days together when Colonel
+Miller’s regiment went away. I thought I should have broken my heart.”
+
+“I am sure I shall break _mine_,” said Lydia.
+
+“If one could but go to Brighton!” observed Mrs. Bennet.
+
+“Oh, yes!--if one could but go to Brighton! But papa is so
+disagreeable.”
+
+“A little sea-bathing would set me up forever.”
+
+“And my aunt Phillips is sure it would do _me_ a great deal of good,”
+ added Kitty.
+
+Such were the kind of lamentations resounding perpetually through
+Longbourn House. Elizabeth tried to be diverted by them; but all sense
+of pleasure was lost in shame. She felt anew the justice of Mr. Darcy’s
+objections; and never had she been so much disposed to pardon his
+interference in the views of his friend.
+
+But the gloom of Lydia’s prospect was shortly cleared away; for she
+received an invitation from Mrs. Forster, the wife of the colonel of
+the regiment, to accompany her to Brighton. This invaluable friend was a
+very young woman, and very lately married. A resemblance in good humour
+and good spirits had recommended her and Lydia to each other, and out of
+their _three_ months’ acquaintance they had been intimate _two_.
+
+The rapture of Lydia on this occasion, her adoration of Mrs. Forster,
+the delight of Mrs. Bennet, and the mortification of Kitty, are scarcely
+to be described. Wholly inattentive to her sister’s feelings, Lydia
+flew about the house in restless ecstasy, calling for everyone’s
+congratulations, and laughing and talking with more violence than ever;
+whilst the luckless Kitty continued in the parlour repined at her fate
+in terms as unreasonable as her accent was peevish.
+
+“I cannot see why Mrs. Forster should not ask _me_ as well as Lydia,”
+ said she, “Though I am _not_ her particular friend. I have just as much
+right to be asked as she has, and more too, for I am two years older.”
+
+In vain did Elizabeth attempt to make her reasonable, and Jane to make
+her resigned. As for Elizabeth herself, this invitation was so far from
+exciting in her the same feelings as in her mother and Lydia, that she
+considered it as the death warrant of all possibility of common sense
+for the latter; and detestable as such a step must make her were it
+known, she could not help secretly advising her father not to let her
+go. She represented to him all the improprieties of Lydia’s general
+behaviour, the little advantage she could derive from the friendship of
+such a woman as Mrs. Forster, and the probability of her being yet more
+imprudent with such a companion at Brighton, where the temptations must
+be greater than at home. He heard her attentively, and then said:
+
+“Lydia will never be easy until she has exposed herself in some public
+place or other, and we can never expect her to do it with so
+little expense or inconvenience to her family as under the present
+circumstances.”
+
+“If you were aware,” said Elizabeth, “of the very great disadvantage to
+us all which must arise from the public notice of Lydia’s unguarded and
+imprudent manner--nay, which has already arisen from it, I am sure you
+would judge differently in the affair.”
+
+“Already arisen?” repeated Mr. Bennet. “What, has she frightened away
+some of your lovers? Poor little Lizzy! But do not be cast down. Such
+squeamish youths as cannot bear to be connected with a little absurdity
+are not worth a regret. Come, let me see the list of pitiful fellows who
+have been kept aloof by Lydia’s folly.”
+
+“Indeed you are mistaken. I have no such injuries to resent. It is not
+of particular, but of general evils, which I am now complaining. Our
+importance, our respectability in the world must be affected by the
+wild volatility, the assurance and disdain of all restraint which mark
+Lydia’s character. Excuse me, for I must speak plainly. If you, my dear
+father, will not take the trouble of checking her exuberant spirits, and
+of teaching her that her present pursuits are not to be the business of
+her life, she will soon be beyond the reach of amendment. Her character
+will be fixed, and she will, at sixteen, be the most determined flirt
+that ever made herself or her family ridiculous; a flirt, too, in the
+worst and meanest degree of flirtation; without any attraction beyond
+youth and a tolerable person; and, from the ignorance and emptiness
+of her mind, wholly unable to ward off any portion of that universal
+contempt which her rage for admiration will excite. In this danger
+Kitty also is comprehended. She will follow wherever Lydia leads. Vain,
+ignorant, idle, and absolutely uncontrolled! Oh! my dear father, can you
+suppose it possible that they will not be censured and despised wherever
+they are known, and that their sisters will not be often involved in the
+disgrace?”
+
+Mr. Bennet saw that her whole heart was in the subject, and
+affectionately taking her hand said in reply:
+
+“Do not make yourself uneasy, my love. Wherever you and Jane are known
+you must be respected and valued; and you will not appear to less
+advantage for having a couple of--or I may say, three--very silly
+sisters. We shall have no peace at Longbourn if Lydia does not go to
+Brighton. Let her go, then. Colonel Forster is a sensible man, and will
+keep her out of any real mischief; and she is luckily too poor to be an
+object of prey to anybody. At Brighton she will be of less importance
+even as a common flirt than she has been here. The officers will find
+women better worth their notice. Let us hope, therefore, that her being
+there may teach her her own insignificance. At any rate, she cannot grow
+many degrees worse, without authorising us to lock her up for the rest
+of her life.”
+
+With this answer Elizabeth was forced to be content; but her own opinion
+continued the same, and she left him disappointed and sorry. It was not
+in her nature, however, to increase her vexations by dwelling on
+them. She was confident of having performed her duty, and to fret
+over unavoidable evils, or augment them by anxiety, was no part of her
+disposition.
+
+Had Lydia and her mother known the substance of her conference with her
+father, their indignation would hardly have found expression in their
+united volubility. In Lydia’s imagination, a visit to Brighton comprised
+every possibility of earthly happiness. She saw, with the creative eye
+of fancy, the streets of that gay bathing-place covered with officers.
+She saw herself the object of attention, to tens and to scores of them
+at present unknown. She saw all the glories of the camp--its tents
+stretched forth in beauteous uniformity of lines, crowded with the young
+and the gay, and dazzling with scarlet; and, to complete the view, she
+saw herself seated beneath a tent, tenderly flirting with at least six
+officers at once.
+
+Had she known her sister sought to tear her from such prospects and such
+realities as these, what would have been her sensations? They could have
+been understood only by her mother, who might have felt nearly the same.
+Lydia’s going to Brighton was all that consoled her for her melancholy
+conviction of her husband’s never intending to go there himself.
+
+But they were entirely ignorant of what had passed; and their raptures
+continued, with little intermission, to the very day of Lydia’s leaving
+home.
+
+Elizabeth was now to see Mr. Wickham for the last time. Having been
+frequently in company with him since her return, agitation was pretty
+well over; the agitations of former partiality entirely so. She had even
+learnt to detect, in the very gentleness which had first delighted
+her, an affectation and a sameness to disgust and weary. In his present
+behaviour to herself, moreover, she had a fresh source of displeasure,
+for the inclination he soon testified of renewing those intentions which
+had marked the early part of their acquaintance could only serve, after
+what had since passed, to provoke her. She lost all concern for him in
+finding herself thus selected as the object of such idle and frivolous
+gallantry; and while she steadily repressed it, could not but feel the
+reproof contained in his believing, that however long, and for whatever
+cause, his attentions had been withdrawn, her vanity would be gratified,
+and her preference secured at any time by their renewal.
+
+On the very last day of the regiment’s remaining at Meryton, he dined,
+with other of the officers, at Longbourn; and so little was Elizabeth
+disposed to part from him in good humour, that on his making some
+inquiry as to the manner in which her time had passed at Hunsford, she
+mentioned Colonel Fitzwilliam’s and Mr. Darcy’s having both spent three
+weeks at Rosings, and asked him, if he was acquainted with the former.
+
+He looked surprised, displeased, alarmed; but with a moment’s
+recollection and a returning smile, replied, that he had formerly seen
+him often; and, after observing that he was a very gentlemanlike man,
+asked her how she had liked him. Her answer was warmly in his favour.
+With an air of indifference he soon afterwards added:
+
+“How long did you say he was at Rosings?”
+
+“Nearly three weeks.”
+
+“And you saw him frequently?”
+
+“Yes, almost every day.”
+
+“His manners are very different from his cousin’s.”
+
+“Yes, very different. But I think Mr. Darcy improves upon acquaintance.”
+
+“Indeed!” cried Mr. Wickham with a look which did not escape her. “And
+pray, may I ask?--” But checking himself, he added, in a gayer tone, “Is
+it in address that he improves? Has he deigned to add aught of civility
+to his ordinary style?--for I dare not hope,” he continued in a lower
+and more serious tone, “that he is improved in essentials.”
+
+“Oh, no!” said Elizabeth. “In essentials, I believe, he is very much
+what he ever was.”
+
+While she spoke, Wickham looked as if scarcely knowing whether to
+rejoice over her words, or to distrust their meaning. There was a
+something in her countenance which made him listen with an apprehensive
+and anxious attention, while she added:
+
+“When I said that he improved on acquaintance, I did not mean that
+his mind or his manners were in a state of improvement, but that, from
+knowing him better, his disposition was better understood.”
+
+Wickham’s alarm now appeared in a heightened complexion and agitated
+look; for a few minutes he was silent, till, shaking off his
+embarrassment, he turned to her again, and said in the gentlest of
+accents:
+
+“You, who so well know my feeling towards Mr. Darcy, will readily
+comprehend how sincerely I must rejoice that he is wise enough to assume
+even the _appearance_ of what is right. His pride, in that direction,
+may be of service, if not to himself, to many others, for it must only
+deter him from such foul misconduct as I have suffered by. I only
+fear that the sort of cautiousness to which you, I imagine, have been
+alluding, is merely adopted on his visits to his aunt, of whose good
+opinion and judgement he stands much in awe. His fear of her has always
+operated, I know, when they were together; and a good deal is to be
+imputed to his wish of forwarding the match with Miss de Bourgh, which I
+am certain he has very much at heart.”
+
+Elizabeth could not repress a smile at this, but she answered only by a
+slight inclination of the head. She saw that he wanted to engage her on
+the old subject of his grievances, and she was in no humour to indulge
+him. The rest of the evening passed with the _appearance_, on his
+side, of usual cheerfulness, but with no further attempt to distinguish
+Elizabeth; and they parted at last with mutual civility, and possibly a
+mutual desire of never meeting again.
+
+When the party broke up, Lydia returned with Mrs. Forster to Meryton,
+from whence they were to set out early the next morning. The separation
+between her and her family was rather noisy than pathetic. Kitty was the
+only one who shed tears; but she did weep from vexation and envy. Mrs.
+Bennet was diffuse in her good wishes for the felicity of her daughter,
+and impressive in her injunctions that she should not miss the
+opportunity of enjoying herself as much as possible--advice which
+there was every reason to believe would be well attended to; and in
+the clamorous happiness of Lydia herself in bidding farewell, the more
+gentle adieus of her sisters were uttered without being heard.
+
+
+
+Chapter 42
+
+
+Had Elizabeth’s opinion been all drawn from her own family, she could
+not have formed a very pleasing opinion of conjugal felicity or domestic
+comfort. Her father, captivated by youth and beauty, and that appearance
+of good humour which youth and beauty generally give, had married a
+woman whose weak understanding and illiberal mind had very early in
+their marriage put an end to all real affection for her. Respect,
+esteem, and confidence had vanished for ever; and all his views
+of domestic happiness were overthrown. But Mr. Bennet was not of
+a disposition to seek comfort for the disappointment which his own
+imprudence had brought on, in any of those pleasures which too often
+console the unfortunate for their folly or their vice. He was fond of
+the country and of books; and from these tastes had arisen his principal
+enjoyments. To his wife he was very little otherwise indebted, than as
+her ignorance and folly had contributed to his amusement. This is not
+the sort of happiness which a man would in general wish to owe to his
+wife; but where other powers of entertainment are wanting, the true
+philosopher will derive benefit from such as are given.
+
+Elizabeth, however, had never been blind to the impropriety of her
+father’s behaviour as a husband. She had always seen it with pain; but
+respecting his abilities, and grateful for his affectionate treatment of
+herself, she endeavoured to forget what she could not overlook, and to
+banish from her thoughts that continual breach of conjugal obligation
+and decorum which, in exposing his wife to the contempt of her own
+children, was so highly reprehensible. But she had never felt so
+strongly as now the disadvantages which must attend the children of so
+unsuitable a marriage, nor ever been so fully aware of the evils arising
+from so ill-judged a direction of talents; talents, which, rightly used,
+might at least have preserved the respectability of his daughters, even
+if incapable of enlarging the mind of his wife.
+
+When Elizabeth had rejoiced over Wickham’s departure she found little
+other cause for satisfaction in the loss of the regiment. Their parties
+abroad were less varied than before, and at home she had a mother and
+sister whose constant repinings at the dullness of everything around
+them threw a real gloom over their domestic circle; and, though Kitty
+might in time regain her natural degree of sense, since the disturbers
+of her brain were removed, her other sister, from whose disposition
+greater evil might be apprehended, was likely to be hardened in all
+her folly and assurance by a situation of such double danger as a
+watering-place and a camp. Upon the whole, therefore, she found, what
+has been sometimes found before, that an event to which she had been
+looking with impatient desire did not, in taking place, bring all the
+satisfaction she had promised herself. It was consequently necessary to
+name some other period for the commencement of actual felicity--to have
+some other point on which her wishes and hopes might be fixed, and by
+again enjoying the pleasure of anticipation, console herself for the
+present, and prepare for another disappointment. Her tour to the Lakes
+was now the object of her happiest thoughts; it was her best consolation
+for all the uncomfortable hours which the discontentedness of her mother
+and Kitty made inevitable; and could she have included Jane in the
+scheme, every part of it would have been perfect.
+
+“But it is fortunate,” thought she, “that I have something to wish for.
+Were the whole arrangement complete, my disappointment would be certain.
+But here, by carrying with me one ceaseless source of regret in my
+sister’s absence, I may reasonably hope to have all my expectations of
+pleasure realised. A scheme of which every part promises delight can
+never be successful; and general disappointment is only warded off by
+the defence of some little peculiar vexation.”
+
+When Lydia went away she promised to write very often and very minutely
+to her mother and Kitty; but her letters were always long expected, and
+always very short. Those to her mother contained little else than that
+they were just returned from the library, where such and such officers
+had attended them, and where she had seen such beautiful ornaments as
+made her quite wild; that she had a new gown, or a new parasol, which
+she would have described more fully, but was obliged to leave off in a
+violent hurry, as Mrs. Forster called her, and they were going off to
+the camp; and from her correspondence with her sister, there was still
+less to be learnt--for her letters to Kitty, though rather longer, were
+much too full of lines under the words to be made public.
+
+After the first fortnight or three weeks of her absence, health, good
+humour, and cheerfulness began to reappear at Longbourn. Everything wore
+a happier aspect. The families who had been in town for the winter came
+back again, and summer finery and summer engagements arose. Mrs. Bennet
+was restored to her usual querulous serenity; and, by the middle of
+June, Kitty was so much recovered as to be able to enter Meryton without
+tears; an event of such happy promise as to make Elizabeth hope that by
+the following Christmas she might be so tolerably reasonable as not to
+mention an officer above once a day, unless, by some cruel and malicious
+arrangement at the War Office, another regiment should be quartered in
+Meryton.
+
+The time fixed for the beginning of their northern tour was now fast
+approaching, and a fortnight only was wanting of it, when a letter
+arrived from Mrs. Gardiner, which at once delayed its commencement and
+curtailed its extent. Mr. Gardiner would be prevented by business from
+setting out till a fortnight later in July, and must be in London again
+within a month, and as that left too short a period for them to go so
+far, and see so much as they had proposed, or at least to see it with
+the leisure and comfort they had built on, they were obliged to give up
+the Lakes, and substitute a more contracted tour, and, according to the
+present plan, were to go no farther northwards than Derbyshire. In that
+county there was enough to be seen to occupy the chief of their three
+weeks; and to Mrs. Gardiner it had a peculiarly strong attraction. The
+town where she had formerly passed some years of her life, and where
+they were now to spend a few days, was probably as great an object of
+her curiosity as all the celebrated beauties of Matlock, Chatsworth,
+Dovedale, or the Peak.
+
+Elizabeth was excessively disappointed; she had set her heart on seeing
+the Lakes, and still thought there might have been time enough. But it
+was her business to be satisfied--and certainly her temper to be happy;
+and all was soon right again.
+
+With the mention of Derbyshire there were many ideas connected. It was
+impossible for her to see the word without thinking of Pemberley and its
+owner. “But surely,” said she, “I may enter his county with impunity,
+and rob it of a few petrified spars without his perceiving me.”
+
+The period of expectation was now doubled. Four weeks were to pass away
+before her uncle and aunt’s arrival. But they did pass away, and Mr.
+and Mrs. Gardiner, with their four children, did at length appear at
+Longbourn. The children, two girls of six and eight years old, and two
+younger boys, were to be left under the particular care of their
+cousin Jane, who was the general favourite, and whose steady sense and
+sweetness of temper exactly adapted her for attending to them in every
+way--teaching them, playing with them, and loving them.
+
+The Gardiners stayed only one night at Longbourn, and set off the
+next morning with Elizabeth in pursuit of novelty and amusement.
+One enjoyment was certain--that of suitableness of companions;
+a suitableness which comprehended health and temper to bear
+inconveniences--cheerfulness to enhance every pleasure--and affection
+and intelligence, which might supply it among themselves if there were
+disappointments abroad.
+
+It is not the object of this work to give a description of Derbyshire,
+nor of any of the remarkable places through which their route thither
+lay; Oxford, Blenheim, Warwick, Kenilworth, Birmingham, etc. are
+sufficiently known. A small part of Derbyshire is all the present
+concern. To the little town of Lambton, the scene of Mrs. Gardiner’s
+former residence, and where she had lately learned some acquaintance
+still remained, they bent their steps, after having seen all the
+principal wonders of the country; and within five miles of Lambton,
+Elizabeth found from her aunt that Pemberley was situated. It was not
+in their direct road, nor more than a mile or two out of it. In
+talking over their route the evening before, Mrs. Gardiner expressed
+an inclination to see the place again. Mr. Gardiner declared his
+willingness, and Elizabeth was applied to for her approbation.
+
+“My love, should not you like to see a place of which you have heard
+so much?” said her aunt; “a place, too, with which so many of your
+acquaintances are connected. Wickham passed all his youth there, you
+know.”
+
+Elizabeth was distressed. She felt that she had no business at
+Pemberley, and was obliged to assume a disinclination for seeing it. She
+must own that she was tired of seeing great houses; after going over so
+many, she really had no pleasure in fine carpets or satin curtains.
+
+Mrs. Gardiner abused her stupidity. “If it were merely a fine house
+richly furnished,” said she, “I should not care about it myself; but
+the grounds are delightful. They have some of the finest woods in the
+country.”
+
+Elizabeth said no more--but her mind could not acquiesce. The
+possibility of meeting Mr. Darcy, while viewing the place, instantly
+occurred. It would be dreadful! She blushed at the very idea, and
+thought it would be better to speak openly to her aunt than to run such
+a risk. But against this there were objections; and she finally resolved
+that it could be the last resource, if her private inquiries to the
+absence of the family were unfavourably answered.
+
+Accordingly, when she retired at night, she asked the chambermaid
+whether Pemberley were not a very fine place? what was the name of its
+proprietor? and, with no little alarm, whether the family were down for
+the summer? A most welcome negative followed the last question--and her
+alarms now being removed, she was at leisure to feel a great deal of
+curiosity to see the house herself; and when the subject was revived the
+next morning, and she was again applied to, could readily answer, and
+with a proper air of indifference, that she had not really any dislike
+to the scheme. To Pemberley, therefore, they were to go.
+
+
+
+Chapter 43
+
+
+Elizabeth, as they drove along, watched for the first appearance of
+Pemberley Woods with some perturbation; and when at length they turned
+in at the lodge, her spirits were in a high flutter.
+
+The park was very large, and contained great variety of ground. They
+entered it in one of its lowest points, and drove for some time through
+a beautiful wood stretching over a wide extent.
+
+Elizabeth’s mind was too full for conversation, but she saw and admired
+every remarkable spot and point of view. They gradually ascended for
+half-a-mile, and then found themselves at the top of a considerable
+eminence, where the wood ceased, and the eye was instantly caught by
+Pemberley House, situated on the opposite side of a valley, into which
+the road with some abruptness wound. It was a large, handsome stone
+building, standing well on rising ground, and backed by a ridge of
+high woody hills; and in front, a stream of some natural importance was
+swelled into greater, but without any artificial appearance. Its banks
+were neither formal nor falsely adorned. Elizabeth was delighted. She
+had never seen a place for which nature had done more, or where natural
+beauty had been so little counteracted by an awkward taste. They were
+all of them warm in their admiration; and at that moment she felt that
+to be mistress of Pemberley might be something!
+
+They descended the hill, crossed the bridge, and drove to the door; and,
+while examining the nearer aspect of the house, all her apprehension of
+meeting its owner returned. She dreaded lest the chambermaid had been
+mistaken. On applying to see the place, they were admitted into the
+hall; and Elizabeth, as they waited for the housekeeper, had leisure to
+wonder at her being where she was.
+
+The housekeeper came; a respectable-looking elderly woman, much less
+fine, and more civil, than she had any notion of finding her. They
+followed her into the dining-parlour. It was a large, well proportioned
+room, handsomely fitted up. Elizabeth, after slightly surveying it, went
+to a window to enjoy its prospect. The hill, crowned with wood, which
+they had descended, receiving increased abruptness from the distance,
+was a beautiful object. Every disposition of the ground was good; and
+she looked on the whole scene, the river, the trees scattered on its
+banks and the winding of the valley, as far as she could trace it,
+with delight. As they passed into other rooms these objects were taking
+different positions; but from every window there were beauties to be
+seen. The rooms were lofty and handsome, and their furniture suitable to
+the fortune of its proprietor; but Elizabeth saw, with admiration of
+his taste, that it was neither gaudy nor uselessly fine; with less of
+splendour, and more real elegance, than the furniture of Rosings.
+
+“And of this place,” thought she, “I might have been mistress! With
+these rooms I might now have been familiarly acquainted! Instead of
+viewing them as a stranger, I might have rejoiced in them as my own, and
+welcomed to them as visitors my uncle and aunt. But no,”--recollecting
+herself--“that could never be; my uncle and aunt would have been lost to
+me; I should not have been allowed to invite them.”
+
+This was a lucky recollection--it saved her from something very like
+regret.
+
+She longed to inquire of the housekeeper whether her master was really
+absent, but had not the courage for it. At length however, the question
+was asked by her uncle; and she turned away with alarm, while Mrs.
+Reynolds replied that he was, adding, “But we expect him to-morrow, with
+a large party of friends.” How rejoiced was Elizabeth that their own
+journey had not by any circumstance been delayed a day!
+
+Her aunt now called her to look at a picture. She approached and saw the
+likeness of Mr. Wickham, suspended, amongst several other miniatures,
+over the mantelpiece. Her aunt asked her, smilingly, how she liked it.
+The housekeeper came forward, and told them it was a picture of a young
+gentleman, the son of her late master’s steward, who had been brought
+up by him at his own expense. “He is now gone into the army,” she added;
+“but I am afraid he has turned out very wild.”
+
+Mrs. Gardiner looked at her niece with a smile, but Elizabeth could not
+return it.
+
+“And that,” said Mrs. Reynolds, pointing to another of the miniatures,
+“is my master--and very like him. It was drawn at the same time as the
+other--about eight years ago.”
+
+“I have heard much of your master’s fine person,” said Mrs. Gardiner,
+looking at the picture; “it is a handsome face. But, Lizzy, you can tell
+us whether it is like or not.”
+
+Mrs. Reynolds respect for Elizabeth seemed to increase on this
+intimation of her knowing her master.
+
+“Does that young lady know Mr. Darcy?”
+
+Elizabeth coloured, and said: “A little.”
+
+“And do not you think him a very handsome gentleman, ma’am?”
+
+“Yes, very handsome.”
+
+“I am sure I know none so handsome; but in the gallery up stairs you
+will see a finer, larger picture of him than this. This room was my late
+master’s favourite room, and these miniatures are just as they used to
+be then. He was very fond of them.”
+
+This accounted to Elizabeth for Mr. Wickham’s being among them.
+
+Mrs. Reynolds then directed their attention to one of Miss Darcy, drawn
+when she was only eight years old.
+
+“And is Miss Darcy as handsome as her brother?” said Mrs. Gardiner.
+
+“Oh! yes--the handsomest young lady that ever was seen; and so
+accomplished!--She plays and sings all day long. In the next room is
+a new instrument just come down for her--a present from my master; she
+comes here to-morrow with him.”
+
+Mr. Gardiner, whose manners were very easy and pleasant, encouraged her
+communicativeness by his questions and remarks; Mrs. Reynolds, either
+by pride or attachment, had evidently great pleasure in talking of her
+master and his sister.
+
+“Is your master much at Pemberley in the course of the year?”
+
+“Not so much as I could wish, sir; but I dare say he may spend half his
+time here; and Miss Darcy is always down for the summer months.”
+
+“Except,” thought Elizabeth, “when she goes to Ramsgate.”
+
+“If your master would marry, you might see more of him.”
+
+“Yes, sir; but I do not know when _that_ will be. I do not know who is
+good enough for him.”
+
+Mr. and Mrs. Gardiner smiled. Elizabeth could not help saying, “It is
+very much to his credit, I am sure, that you should think so.”
+
+“I say no more than the truth, and everybody will say that knows him,”
+ replied the other. Elizabeth thought this was going pretty far; and she
+listened with increasing astonishment as the housekeeper added, “I have
+never known a cross word from him in my life, and I have known him ever
+since he was four years old.”
+
+This was praise, of all others most extraordinary, most opposite to her
+ideas. That he was not a good-tempered man had been her firmest opinion.
+Her keenest attention was awakened; she longed to hear more, and was
+grateful to her uncle for saying:
+
+“There are very few people of whom so much can be said. You are lucky in
+having such a master.”
+
+“Yes, sir, I know I am. If I were to go through the world, I could
+not meet with a better. But I have always observed, that they who are
+good-natured when children, are good-natured when they grow up; and
+he was always the sweetest-tempered, most generous-hearted boy in the
+world.”
+
+Elizabeth almost stared at her. “Can this be Mr. Darcy?” thought she.
+
+“His father was an excellent man,” said Mrs. Gardiner.
+
+“Yes, ma’am, that he was indeed; and his son will be just like him--just
+as affable to the poor.”
+
+Elizabeth listened, wondered, doubted, and was impatient for more. Mrs.
+Reynolds could interest her on no other point. She related the subjects
+of the pictures, the dimensions of the rooms, and the price of the
+furniture, in vain. Mr. Gardiner, highly amused by the kind of family
+prejudice to which he attributed her excessive commendation of her
+master, soon led again to the subject; and she dwelt with energy on his
+many merits as they proceeded together up the great staircase.
+
+“He is the best landlord, and the best master,” said she, “that ever
+lived; not like the wild young men nowadays, who think of nothing but
+themselves. There is not one of his tenants or servants but will give
+him a good name. Some people call him proud; but I am sure I never saw
+anything of it. To my fancy, it is only because he does not rattle away
+like other young men.”
+
+“In what an amiable light does this place him!” thought Elizabeth.
+
+“This fine account of him,” whispered her aunt as they walked, “is not
+quite consistent with his behaviour to our poor friend.”
+
+“Perhaps we might be deceived.”
+
+“That is not very likely; our authority was too good.”
+
+On reaching the spacious lobby above they were shown into a very pretty
+sitting-room, lately fitted up with greater elegance and lightness than
+the apartments below; and were informed that it was but just done to
+give pleasure to Miss Darcy, who had taken a liking to the room when
+last at Pemberley.
+
+“He is certainly a good brother,” said Elizabeth, as she walked towards
+one of the windows.
+
+Mrs. Reynolds anticipated Miss Darcy’s delight, when she should enter
+the room. “And this is always the way with him,” she added. “Whatever
+can give his sister any pleasure is sure to be done in a moment. There
+is nothing he would not do for her.”
+
+The picture-gallery, and two or three of the principal bedrooms, were
+all that remained to be shown. In the former were many good paintings;
+but Elizabeth knew nothing of the art; and from such as had been already
+visible below, she had willingly turned to look at some drawings of Miss
+Darcy’s, in crayons, whose subjects were usually more interesting, and
+also more intelligible.
+
+In the gallery there were many family portraits, but they could have
+little to fix the attention of a stranger. Elizabeth walked in quest of
+the only face whose features would be known to her. At last it arrested
+her--and she beheld a striking resemblance to Mr. Darcy, with such a
+smile over the face as she remembered to have sometimes seen when he
+looked at her. She stood several minutes before the picture, in earnest
+contemplation, and returned to it again before they quitted the gallery.
+Mrs. Reynolds informed them that it had been taken in his father’s
+lifetime.
+
+There was certainly at this moment, in Elizabeth’s mind, a more gentle
+sensation towards the original than she had ever felt at the height of
+their acquaintance. The commendation bestowed on him by Mrs. Reynolds
+was of no trifling nature. What praise is more valuable than the praise
+of an intelligent servant? As a brother, a landlord, a master, she
+considered how many people’s happiness were in his guardianship!--how
+much of pleasure or pain was it in his power to bestow!--how much of
+good or evil must be done by him! Every idea that had been brought
+forward by the housekeeper was favourable to his character, and as she
+stood before the canvas on which he was represented, and fixed his
+eyes upon herself, she thought of his regard with a deeper sentiment of
+gratitude than it had ever raised before; she remembered its warmth, and
+softened its impropriety of expression.
+
+When all of the house that was open to general inspection had been seen,
+they returned downstairs, and, taking leave of the housekeeper, were
+consigned over to the gardener, who met them at the hall-door.
+
+As they walked across the hall towards the river, Elizabeth turned back
+to look again; her uncle and aunt stopped also, and while the former
+was conjecturing as to the date of the building, the owner of it himself
+suddenly came forward from the road, which led behind it to the stables.
+
+They were within twenty yards of each other, and so abrupt was his
+appearance, that it was impossible to avoid his sight. Their eyes
+instantly met, and the cheeks of both were overspread with the deepest
+blush. He absolutely started, and for a moment seemed immovable from
+surprise; but shortly recovering himself, advanced towards the party,
+and spoke to Elizabeth, if not in terms of perfect composure, at least
+of perfect civility.
+
+She had instinctively turned away; but stopping on his approach,
+received his compliments with an embarrassment impossible to be
+overcome. Had his first appearance, or his resemblance to the picture
+they had just been examining, been insufficient to assure the other two
+that they now saw Mr. Darcy, the gardener’s expression of surprise, on
+beholding his master, must immediately have told it. They stood a little
+aloof while he was talking to their niece, who, astonished and confused,
+scarcely dared lift her eyes to his face, and knew not what answer
+she returned to his civil inquiries after her family. Amazed at the
+alteration of his manner since they last parted, every sentence that
+he uttered was increasing her embarrassment; and every idea of the
+impropriety of her being found there recurring to her mind, the few
+minutes in which they continued were some of the most uncomfortable in
+her life. Nor did he seem much more at ease; when he spoke, his accent
+had none of its usual sedateness; and he repeated his inquiries as
+to the time of her having left Longbourn, and of her having stayed in
+Derbyshire, so often, and in so hurried a way, as plainly spoke the
+distraction of his thoughts.
+
+At length every idea seemed to fail him; and, after standing a few
+moments without saying a word, he suddenly recollected himself, and took
+leave.
+
+The others then joined her, and expressed admiration of his figure; but
+Elizabeth heard not a word, and wholly engrossed by her own feelings,
+followed them in silence. She was overpowered by shame and vexation. Her
+coming there was the most unfortunate, the most ill-judged thing in the
+world! How strange it must appear to him! In what a disgraceful light
+might it not strike so vain a man! It might seem as if she had purposely
+thrown herself in his way again! Oh! why did she come? Or, why did he
+thus come a day before he was expected? Had they been only ten minutes
+sooner, they should have been beyond the reach of his discrimination;
+for it was plain that he was that moment arrived--that moment alighted
+from his horse or his carriage. She blushed again and again over
+the perverseness of the meeting. And his behaviour, so strikingly
+altered--what could it mean? That he should even speak to her was
+amazing!--but to speak with such civility, to inquire after her family!
+Never in her life had she seen his manners so little dignified, never
+had he spoken with such gentleness as on this unexpected meeting. What
+a contrast did it offer to his last address in Rosings Park, when he put
+his letter into her hand! She knew not what to think, or how to account
+for it.
+
+They had now entered a beautiful walk by the side of the water, and
+every step was bringing forward a nobler fall of ground, or a finer
+reach of the woods to which they were approaching; but it was some time
+before Elizabeth was sensible of any of it; and, though she answered
+mechanically to the repeated appeals of her uncle and aunt, and
+seemed to direct her eyes to such objects as they pointed out, she
+distinguished no part of the scene. Her thoughts were all fixed on that
+one spot of Pemberley House, whichever it might be, where Mr. Darcy then
+was. She longed to know what at the moment was passing in his mind--in
+what manner he thought of her, and whether, in defiance of everything,
+she was still dear to him. Perhaps he had been civil only because he
+felt himself at ease; yet there had been _that_ in his voice which was
+not like ease. Whether he had felt more of pain or of pleasure in
+seeing her she could not tell, but he certainly had not seen her with
+composure.
+
+At length, however, the remarks of her companions on her absence of mind
+aroused her, and she felt the necessity of appearing more like herself.
+
+They entered the woods, and bidding adieu to the river for a while,
+ascended some of the higher grounds; when, in spots where the opening of
+the trees gave the eye power to wander, were many charming views of the
+valley, the opposite hills, with the long range of woods overspreading
+many, and occasionally part of the stream. Mr. Gardiner expressed a wish
+of going round the whole park, but feared it might be beyond a walk.
+With a triumphant smile they were told that it was ten miles round.
+It settled the matter; and they pursued the accustomed circuit; which
+brought them again, after some time, in a descent among hanging woods,
+to the edge of the water, and one of its narrowest parts. They crossed
+it by a simple bridge, in character with the general air of the scene;
+it was a spot less adorned than any they had yet visited; and the
+valley, here contracted into a glen, allowed room only for the stream,
+and a narrow walk amidst the rough coppice-wood which bordered it.
+Elizabeth longed to explore its windings; but when they had crossed the
+bridge, and perceived their distance from the house, Mrs. Gardiner,
+who was not a great walker, could go no farther, and thought only
+of returning to the carriage as quickly as possible. Her niece was,
+therefore, obliged to submit, and they took their way towards the house
+on the opposite side of the river, in the nearest direction; but their
+progress was slow, for Mr. Gardiner, though seldom able to indulge the
+taste, was very fond of fishing, and was so much engaged in watching the
+occasional appearance of some trout in the water, and talking to the
+man about them, that he advanced but little. Whilst wandering on in this
+slow manner, they were again surprised, and Elizabeth’s astonishment
+was quite equal to what it had been at first, by the sight of Mr. Darcy
+approaching them, and at no great distance. The walk being here
+less sheltered than on the other side, allowed them to see him before
+they met. Elizabeth, however astonished, was at least more prepared
+for an interview than before, and resolved to appear and to speak with
+calmness, if he really intended to meet them. For a few moments, indeed,
+she felt that he would probably strike into some other path. The idea
+lasted while a turning in the walk concealed him from their view; the
+turning past, he was immediately before them. With a glance, she saw
+that he had lost none of his recent civility; and, to imitate his
+politeness, she began, as they met, to admire the beauty of the place;
+but she had not got beyond the words “delightful,” and “charming,” when
+some unlucky recollections obtruded, and she fancied that praise of
+Pemberley from her might be mischievously construed. Her colour changed,
+and she said no more.
+
+Mrs. Gardiner was standing a little behind; and on her pausing, he asked
+her if she would do him the honour of introducing him to her friends.
+This was a stroke of civility for which she was quite unprepared;
+and she could hardly suppress a smile at his being now seeking the
+acquaintance of some of those very people against whom his pride had
+revolted in his offer to herself. “What will be his surprise,” thought
+she, “when he knows who they are? He takes them now for people of
+fashion.”
+
+The introduction, however, was immediately made; and as she named their
+relationship to herself, she stole a sly look at him, to see how he bore
+it, and was not without the expectation of his decamping as fast as he
+could from such disgraceful companions. That he was _surprised_ by the
+connection was evident; he sustained it, however, with fortitude, and
+so far from going away, turned back with them, and entered into
+conversation with Mr. Gardiner. Elizabeth could not but be pleased,
+could not but triumph. It was consoling that he should know she had
+some relations for whom there was no need to blush. She listened most
+attentively to all that passed between them, and gloried in every
+expression, every sentence of her uncle, which marked his intelligence,
+his taste, or his good manners.
+
+The conversation soon turned upon fishing; and she heard Mr. Darcy
+invite him, with the greatest civility, to fish there as often as he
+chose while he continued in the neighbourhood, offering at the same time
+to supply him with fishing tackle, and pointing out those parts of
+the stream where there was usually most sport. Mrs. Gardiner, who was
+walking arm-in-arm with Elizabeth, gave her a look expressive of wonder.
+Elizabeth said nothing, but it gratified her exceedingly; the compliment
+must be all for herself. Her astonishment, however, was extreme, and
+continually was she repeating, “Why is he so altered? From what can
+it proceed? It cannot be for _me_--it cannot be for _my_ sake that his
+manners are thus softened. My reproofs at Hunsford could not work such a
+change as this. It is impossible that he should still love me.”
+
+After walking some time in this way, the two ladies in front, the two
+gentlemen behind, on resuming their places, after descending to
+the brink of the river for the better inspection of some curious
+water-plant, there chanced to be a little alteration. It originated
+in Mrs. Gardiner, who, fatigued by the exercise of the morning, found
+Elizabeth’s arm inadequate to her support, and consequently preferred
+her husband’s. Mr. Darcy took her place by her niece, and they walked on
+together. After a short silence, the lady first spoke. She wished him
+to know that she had been assured of his absence before she came to the
+place, and accordingly began by observing, that his arrival had been
+very unexpected--“for your housekeeper,” she added, “informed us that
+you would certainly not be here till to-morrow; and indeed, before we
+left Bakewell, we understood that you were not immediately expected
+in the country.” He acknowledged the truth of it all, and said that
+business with his steward had occasioned his coming forward a few hours
+before the rest of the party with whom he had been travelling. “They
+will join me early to-morrow,” he continued, “and among them are some
+who will claim an acquaintance with you--Mr. Bingley and his sisters.”
+
+Elizabeth answered only by a slight bow. Her thoughts were instantly
+driven back to the time when Mr. Bingley’s name had been the last
+mentioned between them; and, if she might judge by his complexion, _his_
+mind was not very differently engaged.
+
+“There is also one other person in the party,” he continued after a
+pause, “who more particularly wishes to be known to you. Will you allow
+me, or do I ask too much, to introduce my sister to your acquaintance
+during your stay at Lambton?”
+
+The surprise of such an application was great indeed; it was too great
+for her to know in what manner she acceded to it. She immediately felt
+that whatever desire Miss Darcy might have of being acquainted with her
+must be the work of her brother, and, without looking farther, it was
+satisfactory; it was gratifying to know that his resentment had not made
+him think really ill of her.
+
+They now walked on in silence, each of them deep in thought. Elizabeth
+was not comfortable; that was impossible; but she was flattered and
+pleased. His wish of introducing his sister to her was a compliment of
+the highest kind. They soon outstripped the others, and when they had
+reached the carriage, Mr. and Mrs. Gardiner were half a quarter of a
+mile behind.
+
+He then asked her to walk into the house--but she declared herself not
+tired, and they stood together on the lawn. At such a time much might
+have been said, and silence was very awkward. She wanted to talk, but
+there seemed to be an embargo on every subject. At last she recollected
+that she had been travelling, and they talked of Matlock and Dove Dale
+with great perseverance. Yet time and her aunt moved slowly--and her
+patience and her ideas were nearly worn out before the tete-a-tete was
+over. On Mr. and Mrs. Gardiner’s coming up they were all pressed to go
+into the house and take some refreshment; but this was declined, and
+they parted on each side with utmost politeness. Mr. Darcy handed the
+ladies into the carriage; and when it drove off, Elizabeth saw him
+walking slowly towards the house.
+
+The observations of her uncle and aunt now began; and each of them
+pronounced him to be infinitely superior to anything they had expected.
+“He is perfectly well behaved, polite, and unassuming,” said her uncle.
+
+“There _is_ something a little stately in him, to be sure,” replied her
+aunt, “but it is confined to his air, and is not unbecoming. I can now
+say with the housekeeper, that though some people may call him proud, I
+have seen nothing of it.”
+
+“I was never more surprised than by his behaviour to us. It was more
+than civil; it was really attentive; and there was no necessity for such
+attention. His acquaintance with Elizabeth was very trifling.”
+
+“To be sure, Lizzy,” said her aunt, “he is not so handsome as Wickham;
+or, rather, he has not Wickham’s countenance, for his features
+are perfectly good. But how came you to tell me that he was so
+disagreeable?”
+
+Elizabeth excused herself as well as she could; said that she had liked
+him better when they had met in Kent than before, and that she had never
+seen him so pleasant as this morning.
+
+“But perhaps he may be a little whimsical in his civilities,” replied
+her uncle. “Your great men often are; and therefore I shall not take him
+at his word, as he might change his mind another day, and warn me off
+his grounds.”
+
+Elizabeth felt that they had entirely misunderstood his character, but
+said nothing.
+
+“From what we have seen of him,” continued Mrs. Gardiner, “I really
+should not have thought that he could have behaved in so cruel a way by
+anybody as he has done by poor Wickham. He has not an ill-natured look.
+On the contrary, there is something pleasing about his mouth when he
+speaks. And there is something of dignity in his countenance that would
+not give one an unfavourable idea of his heart. But, to be sure, the
+good lady who showed us his house did give him a most flaming character!
+I could hardly help laughing aloud sometimes. But he is a liberal
+master, I suppose, and _that_ in the eye of a servant comprehends every
+virtue.”
+
+Elizabeth here felt herself called on to say something in vindication of
+his behaviour to Wickham; and therefore gave them to understand, in
+as guarded a manner as she could, that by what she had heard from
+his relations in Kent, his actions were capable of a very different
+construction; and that his character was by no means so faulty, nor
+Wickham’s so amiable, as they had been considered in Hertfordshire. In
+confirmation of this, she related the particulars of all the pecuniary
+transactions in which they had been connected, without actually naming
+her authority, but stating it to be such as might be relied on.
+
+Mrs. Gardiner was surprised and concerned; but as they were now
+approaching the scene of her former pleasures, every idea gave way to
+the charm of recollection; and she was too much engaged in pointing out
+to her husband all the interesting spots in its environs to think of
+anything else. Fatigued as she had been by the morning’s walk they
+had no sooner dined than she set off again in quest of her former
+acquaintance, and the evening was spent in the satisfactions of a
+intercourse renewed after many years’ discontinuance.
+
+The occurrences of the day were too full of interest to leave Elizabeth
+much attention for any of these new friends; and she could do nothing
+but think, and think with wonder, of Mr. Darcy’s civility, and, above
+all, of his wishing her to be acquainted with his sister.
+
+
+
+Chapter 44
+
+
+Elizabeth had settled it that Mr. Darcy would bring his sister to visit
+her the very day after her reaching Pemberley; and was consequently
+resolved not to be out of sight of the inn the whole of that morning.
+But her conclusion was false; for on the very morning after their
+arrival at Lambton, these visitors came. They had been walking about the
+place with some of their new friends, and were just returning to the inn
+to dress themselves for dining with the same family, when the sound of a
+carriage drew them to a window, and they saw a gentleman and a lady in
+a curricle driving up the street. Elizabeth immediately recognizing
+the livery, guessed what it meant, and imparted no small degree of her
+surprise to her relations by acquainting them with the honour which she
+expected. Her uncle and aunt were all amazement; and the embarrassment
+of her manner as she spoke, joined to the circumstance itself, and many
+of the circumstances of the preceding day, opened to them a new idea on
+the business. Nothing had ever suggested it before, but they felt that
+there was no other way of accounting for such attentions from such a
+quarter than by supposing a partiality for their niece. While these
+newly-born notions were passing in their heads, the perturbation of
+Elizabeth’s feelings was at every moment increasing. She was quite
+amazed at her own discomposure; but amongst other causes of disquiet,
+she dreaded lest the partiality of the brother should have said too much
+in her favour; and, more than commonly anxious to please, she naturally
+suspected that every power of pleasing would fail her.
+
+She retreated from the window, fearful of being seen; and as she walked
+up and down the room, endeavouring to compose herself, saw such looks of
+inquiring surprise in her uncle and aunt as made everything worse.
+
+Miss Darcy and her brother appeared, and this formidable introduction
+took place. With astonishment did Elizabeth see that her new
+acquaintance was at least as much embarrassed as herself. Since her
+being at Lambton, she had heard that Miss Darcy was exceedingly proud;
+but the observation of a very few minutes convinced her that she was
+only exceedingly shy. She found it difficult to obtain even a word from
+her beyond a monosyllable.
+
+Miss Darcy was tall, and on a larger scale than Elizabeth; and, though
+little more than sixteen, her figure was formed, and her appearance
+womanly and graceful. She was less handsome than her brother; but there
+was sense and good humour in her face, and her manners were perfectly
+unassuming and gentle. Elizabeth, who had expected to find in her as
+acute and unembarrassed an observer as ever Mr. Darcy had been, was much
+relieved by discerning such different feelings.
+
+They had not long been together before Mr. Darcy told her that Bingley
+was also coming to wait on her; and she had barely time to express her
+satisfaction, and prepare for such a visitor, when Bingley’s quick
+step was heard on the stairs, and in a moment he entered the room. All
+Elizabeth’s anger against him had been long done away; but had she still
+felt any, it could hardly have stood its ground against the unaffected
+cordiality with which he expressed himself on seeing her again. He
+inquired in a friendly, though general way, after her family, and looked
+and spoke with the same good-humoured ease that he had ever done.
+
+To Mr. and Mrs. Gardiner he was scarcely a less interesting personage
+than to herself. They had long wished to see him. The whole party before
+them, indeed, excited a lively attention. The suspicions which had just
+arisen of Mr. Darcy and their niece directed their observation towards
+each with an earnest though guarded inquiry; and they soon drew from
+those inquiries the full conviction that one of them at least knew
+what it was to love. Of the lady’s sensations they remained a little
+in doubt; but that the gentleman was overflowing with admiration was
+evident enough.
+
+Elizabeth, on her side, had much to do. She wanted to ascertain the
+feelings of each of her visitors; she wanted to compose her own, and
+to make herself agreeable to all; and in the latter object, where she
+feared most to fail, she was most sure of success, for those to whom she
+endeavoured to give pleasure were prepossessed in her favour. Bingley
+was ready, Georgiana was eager, and Darcy determined, to be pleased.
+
+In seeing Bingley, her thoughts naturally flew to her sister; and, oh!
+how ardently did she long to know whether any of his were directed in
+a like manner. Sometimes she could fancy that he talked less than on
+former occasions, and once or twice pleased herself with the notion
+that, as he looked at her, he was trying to trace a resemblance. But,
+though this might be imaginary, she could not be deceived as to his
+behaviour to Miss Darcy, who had been set up as a rival to Jane. No look
+appeared on either side that spoke particular regard. Nothing occurred
+between them that could justify the hopes of his sister. On this point
+she was soon satisfied; and two or three little circumstances occurred
+ere they parted, which, in her anxious interpretation, denoted a
+recollection of Jane not untinctured by tenderness, and a wish of saying
+more that might lead to the mention of her, had he dared. He observed
+to her, at a moment when the others were talking together, and in a tone
+which had something of real regret, that it “was a very long time since
+he had had the pleasure of seeing her;” and, before she could reply,
+he added, “It is above eight months. We have not met since the 26th of
+November, when we were all dancing together at Netherfield.”
+
+Elizabeth was pleased to find his memory so exact; and he afterwards
+took occasion to ask her, when unattended to by any of the rest, whether
+_all_ her sisters were at Longbourn. There was not much in the question,
+nor in the preceding remark; but there was a look and a manner which
+gave them meaning.
+
+It was not often that she could turn her eyes on Mr. Darcy himself;
+but, whenever she did catch a glimpse, she saw an expression of general
+complaisance, and in all that he said she heard an accent so removed
+from _hauteur_ or disdain of his companions, as convinced her that
+the improvement of manners which she had yesterday witnessed however
+temporary its existence might prove, had at least outlived one day. When
+she saw him thus seeking the acquaintance and courting the good opinion
+of people with whom any intercourse a few months ago would have been a
+disgrace--when she saw him thus civil, not only to herself, but to the
+very relations whom he had openly disdained, and recollected their last
+lively scene in Hunsford Parsonage--the difference, the change was
+so great, and struck so forcibly on her mind, that she could hardly
+restrain her astonishment from being visible. Never, even in the company
+of his dear friends at Netherfield, or his dignified relations
+at Rosings, had she seen him so desirous to please, so free from
+self-consequence or unbending reserve, as now, when no importance
+could result from the success of his endeavours, and when even the
+acquaintance of those to whom his attentions were addressed would draw
+down the ridicule and censure of the ladies both of Netherfield and
+Rosings.
+
+Their visitors stayed with them above half-an-hour; and when they arose
+to depart, Mr. Darcy called on his sister to join him in expressing
+their wish of seeing Mr. and Mrs. Gardiner, and Miss Bennet, to dinner
+at Pemberley, before they left the country. Miss Darcy, though with a
+diffidence which marked her little in the habit of giving invitations,
+readily obeyed. Mrs. Gardiner looked at her niece, desirous of knowing
+how _she_, whom the invitation most concerned, felt disposed as to its
+acceptance, but Elizabeth had turned away her head. Presuming however,
+that this studied avoidance spoke rather a momentary embarrassment than
+any dislike of the proposal, and seeing in her husband, who was fond of
+society, a perfect willingness to accept it, she ventured to engage for
+her attendance, and the day after the next was fixed on.
+
+Bingley expressed great pleasure in the certainty of seeing Elizabeth
+again, having still a great deal to say to her, and many inquiries to
+make after all their Hertfordshire friends. Elizabeth, construing all
+this into a wish of hearing her speak of her sister, was pleased, and on
+this account, as well as some others, found herself, when their
+visitors left them, capable of considering the last half-hour with some
+satisfaction, though while it was passing, the enjoyment of it had been
+little. Eager to be alone, and fearful of inquiries or hints from her
+uncle and aunt, she stayed with them only long enough to hear their
+favourable opinion of Bingley, and then hurried away to dress.
+
+But she had no reason to fear Mr. and Mrs. Gardiner’s curiosity; it was
+not their wish to force her communication. It was evident that she was
+much better acquainted with Mr. Darcy than they had before any idea of;
+it was evident that he was very much in love with her. They saw much to
+interest, but nothing to justify inquiry.
+
+Of Mr. Darcy it was now a matter of anxiety to think well; and, as far
+as their acquaintance reached, there was no fault to find. They could
+not be untouched by his politeness; and had they drawn his character
+from their own feelings and his servant’s report, without any reference
+to any other account, the circle in Hertfordshire to which he was known
+would not have recognized it for Mr. Darcy. There was now an interest,
+however, in believing the housekeeper; and they soon became sensible
+that the authority of a servant who had known him since he was four
+years old, and whose own manners indicated respectability, was not to be
+hastily rejected. Neither had anything occurred in the intelligence of
+their Lambton friends that could materially lessen its weight. They had
+nothing to accuse him of but pride; pride he probably had, and if not,
+it would certainly be imputed by the inhabitants of a small market-town
+where the family did not visit. It was acknowledged, however, that he
+was a liberal man, and did much good among the poor.
+
+With respect to Wickham, the travellers soon found that he was not held
+there in much estimation; for though the chief of his concerns with the
+son of his patron were imperfectly understood, it was yet a well-known
+fact that, on his quitting Derbyshire, he had left many debts behind
+him, which Mr. Darcy afterwards discharged.
+
+As for Elizabeth, her thoughts were at Pemberley this evening more than
+the last; and the evening, though as it passed it seemed long, was not
+long enough to determine her feelings towards _one_ in that mansion;
+and she lay awake two whole hours endeavouring to make them out. She
+certainly did not hate him. No; hatred had vanished long ago, and she
+had almost as long been ashamed of ever feeling a dislike against him,
+that could be so called. The respect created by the conviction of his
+valuable qualities, though at first unwillingly admitted, had for some
+time ceased to be repugnant to her feeling; and it was now heightened
+into somewhat of a friendlier nature, by the testimony so highly in
+his favour, and bringing forward his disposition in so amiable a light,
+which yesterday had produced. But above all, above respect and esteem,
+there was a motive within her of goodwill which could not be overlooked.
+It was gratitude; gratitude, not merely for having once loved her,
+but for loving her still well enough to forgive all the petulance and
+acrimony of her manner in rejecting him, and all the unjust accusations
+accompanying her rejection. He who, she had been persuaded, would avoid
+her as his greatest enemy, seemed, on this accidental meeting, most
+eager to preserve the acquaintance, and without any indelicate display
+of regard, or any peculiarity of manner, where their two selves only
+were concerned, was soliciting the good opinion of her friends, and bent
+on making her known to his sister. Such a change in a man of so much
+pride exciting not only astonishment but gratitude--for to love, ardent
+love, it must be attributed; and as such its impression on her was of a
+sort to be encouraged, as by no means unpleasing, though it could not be
+exactly defined. She respected, she esteemed, she was grateful to him,
+she felt a real interest in his welfare; and she only wanted to know how
+far she wished that welfare to depend upon herself, and how far it would
+be for the happiness of both that she should employ the power, which her
+fancy told her she still possessed, of bringing on her the renewal of
+his addresses.
+
+It had been settled in the evening between the aunt and the niece, that
+such a striking civility as Miss Darcy’s in coming to see them on the
+very day of her arrival at Pemberley, for she had reached it only to a
+late breakfast, ought to be imitated, though it could not be equalled,
+by some exertion of politeness on their side; and, consequently, that
+it would be highly expedient to wait on her at Pemberley the following
+morning. They were, therefore, to go. Elizabeth was pleased; though when
+she asked herself the reason, she had very little to say in reply.
+
+Mr. Gardiner left them soon after breakfast. The fishing scheme had been
+renewed the day before, and a positive engagement made of his meeting
+some of the gentlemen at Pemberley before noon.
+
+
+
+Chapter 45
+
+
+Convinced as Elizabeth now was that Miss Bingley’s dislike of her had
+originated in jealousy, she could not help feeling how unwelcome her
+appearance at Pemberley must be to her, and was curious to know with how
+much civility on that lady’s side the acquaintance would now be renewed.
+
+On reaching the house, they were shown through the hall into the saloon,
+whose northern aspect rendered it delightful for summer. Its windows
+opening to the ground, admitted a most refreshing view of the high woody
+hills behind the house, and of the beautiful oaks and Spanish chestnuts
+which were scattered over the intermediate lawn.
+
+In this house they were received by Miss Darcy, who was sitting there
+with Mrs. Hurst and Miss Bingley, and the lady with whom she lived in
+London. Georgiana’s reception of them was very civil, but attended with
+all the embarrassment which, though proceeding from shyness and the fear
+of doing wrong, would easily give to those who felt themselves inferior
+the belief of her being proud and reserved. Mrs. Gardiner and her niece,
+however, did her justice, and pitied her.
+
+By Mrs. Hurst and Miss Bingley they were noticed only by a curtsey; and,
+on their being seated, a pause, awkward as such pauses must always be,
+succeeded for a few moments. It was first broken by Mrs. Annesley, a
+genteel, agreeable-looking woman, whose endeavour to introduce some kind
+of discourse proved her to be more truly well-bred than either of the
+others; and between her and Mrs. Gardiner, with occasional help from
+Elizabeth, the conversation was carried on. Miss Darcy looked as if she
+wished for courage enough to join in it; and sometimes did venture a
+short sentence when there was least danger of its being heard.
+
+Elizabeth soon saw that she was herself closely watched by Miss Bingley,
+and that she could not speak a word, especially to Miss Darcy, without
+calling her attention. This observation would not have prevented her
+from trying to talk to the latter, had they not been seated at an
+inconvenient distance; but she was not sorry to be spared the necessity
+of saying much. Her own thoughts were employing her. She expected every
+moment that some of the gentlemen would enter the room. She wished, she
+feared that the master of the house might be amongst them; and whether
+she wished or feared it most, she could scarcely determine. After
+sitting in this manner a quarter of an hour without hearing Miss
+Bingley’s voice, Elizabeth was roused by receiving from her a cold
+inquiry after the health of her family. She answered with equal
+indifference and brevity, and the other said no more.
+
+The next variation which their visit afforded was produced by the
+entrance of servants with cold meat, cake, and a variety of all the
+finest fruits in season; but this did not take place till after many
+a significant look and smile from Mrs. Annesley to Miss Darcy had been
+given, to remind her of her post. There was now employment for the whole
+party--for though they could not all talk, they could all eat; and the
+beautiful pyramids of grapes, nectarines, and peaches soon collected
+them round the table.
+
+While thus engaged, Elizabeth had a fair opportunity of deciding whether
+she most feared or wished for the appearance of Mr. Darcy, by the
+feelings which prevailed on his entering the room; and then, though but
+a moment before she had believed her wishes to predominate, she began to
+regret that he came.
+
+He had been some time with Mr. Gardiner, who, with two or three other
+gentlemen from the house, was engaged by the river, and had left him
+only on learning that the ladies of the family intended a visit to
+Georgiana that morning. No sooner did he appear than Elizabeth wisely
+resolved to be perfectly easy and unembarrassed; a resolution the more
+necessary to be made, but perhaps not the more easily kept, because she
+saw that the suspicions of the whole party were awakened against them,
+and that there was scarcely an eye which did not watch his behaviour
+when he first came into the room. In no countenance was attentive
+curiosity so strongly marked as in Miss Bingley’s, in spite of the
+smiles which overspread her face whenever she spoke to one of its
+objects; for jealousy had not yet made her desperate, and her attentions
+to Mr. Darcy were by no means over. Miss Darcy, on her brother’s
+entrance, exerted herself much more to talk, and Elizabeth saw that he
+was anxious for his sister and herself to get acquainted, and forwarded
+as much as possible, every attempt at conversation on either side. Miss
+Bingley saw all this likewise; and, in the imprudence of anger, took the
+first opportunity of saying, with sneering civility:
+
+“Pray, Miss Eliza, are not the ----shire Militia removed from Meryton?
+They must be a great loss to _your_ family.”
+
+In Darcy’s presence she dared not mention Wickham’s name; but Elizabeth
+instantly comprehended that he was uppermost in her thoughts; and the
+various recollections connected with him gave her a moment’s distress;
+but exerting herself vigorously to repel the ill-natured attack, she
+presently answered the question in a tolerably detached tone. While
+she spoke, an involuntary glance showed her Darcy, with a heightened
+complexion, earnestly looking at her, and his sister overcome with
+confusion, and unable to lift up her eyes. Had Miss Bingley known what
+pain she was then giving her beloved friend, she undoubtedly would
+have refrained from the hint; but she had merely intended to discompose
+Elizabeth by bringing forward the idea of a man to whom she believed
+her partial, to make her betray a sensibility which might injure her in
+Darcy’s opinion, and, perhaps, to remind the latter of all the follies
+and absurdities by which some part of her family were connected
+with that corps. Not a syllable had ever reached her of Miss Darcy’s
+meditated elopement. To no creature had it been revealed, where secrecy
+was possible, except to Elizabeth; and from all Bingley’s connections
+her brother was particularly anxious to conceal it, from the very
+wish which Elizabeth had long ago attributed to him, of their becoming
+hereafter her own. He had certainly formed such a plan, and without
+meaning that it should affect his endeavour to separate him from Miss
+Bennet, it is probable that it might add something to his lively concern
+for the welfare of his friend.
+
+Elizabeth’s collected behaviour, however, soon quieted his emotion; and
+as Miss Bingley, vexed and disappointed, dared not approach nearer to
+Wickham, Georgiana also recovered in time, though not enough to be able
+to speak any more. Her brother, whose eye she feared to meet, scarcely
+recollected her interest in the affair, and the very circumstance which
+had been designed to turn his thoughts from Elizabeth seemed to have
+fixed them on her more and more cheerfully.
+
+Their visit did not continue long after the question and answer above
+mentioned; and while Mr. Darcy was attending them to their carriage Miss
+Bingley was venting her feelings in criticisms on Elizabeth’s person,
+behaviour, and dress. But Georgiana would not join her. Her brother’s
+recommendation was enough to ensure her favour; his judgement could not
+err. And he had spoken in such terms of Elizabeth as to leave Georgiana
+without the power of finding her otherwise than lovely and amiable. When
+Darcy returned to the saloon, Miss Bingley could not help repeating to
+him some part of what she had been saying to his sister.
+
+“How very ill Miss Eliza Bennet looks this morning, Mr. Darcy,” she
+cried; “I never in my life saw anyone so much altered as she is since
+the winter. She is grown so brown and coarse! Louisa and I were agreeing
+that we should not have known her again.”
+
+However little Mr. Darcy might have liked such an address, he contented
+himself with coolly replying that he perceived no other alteration than
+her being rather tanned, no miraculous consequence of travelling in the
+summer.
+
+“For my own part,” she rejoined, “I must confess that I never could
+see any beauty in her. Her face is too thin; her complexion has no
+brilliancy; and her features are not at all handsome. Her nose
+wants character--there is nothing marked in its lines. Her teeth are
+tolerable, but not out of the common way; and as for her eyes,
+which have sometimes been called so fine, I could never see anything
+extraordinary in them. They have a sharp, shrewish look, which I do
+not like at all; and in her air altogether there is a self-sufficiency
+without fashion, which is intolerable.”
+
+Persuaded as Miss Bingley was that Darcy admired Elizabeth, this was not
+the best method of recommending herself; but angry people are not always
+wise; and in seeing him at last look somewhat nettled, she had all the
+success she expected. He was resolutely silent, however, and, from a
+determination of making him speak, she continued:
+
+“I remember, when we first knew her in Hertfordshire, how amazed we all
+were to find that she was a reputed beauty; and I particularly recollect
+your saying one night, after they had been dining at Netherfield, ‘_She_
+a beauty!--I should as soon call her mother a wit.’ But afterwards she
+seemed to improve on you, and I believe you thought her rather pretty at
+one time.”
+
+“Yes,” replied Darcy, who could contain himself no longer, “but _that_
+was only when I first saw her, for it is many months since I have
+considered her as one of the handsomest women of my acquaintance.”
+
+He then went away, and Miss Bingley was left to all the satisfaction of
+having forced him to say what gave no one any pain but herself.
+
+Mrs. Gardiner and Elizabeth talked of all that had occurred during their
+visit, as they returned, except what had particularly interested them
+both. The look and behaviour of everybody they had seen were discussed,
+except of the person who had mostly engaged their attention. They talked
+of his sister, his friends, his house, his fruit--of everything but
+himself; yet Elizabeth was longing to know what Mrs. Gardiner thought of
+him, and Mrs. Gardiner would have been highly gratified by her niece’s
+beginning the subject.
+
+
+
+Chapter 46
+
+
+Elizabeth had been a good deal disappointed in not finding a letter from
+Jane on their first arrival at Lambton; and this disappointment had been
+renewed on each of the mornings that had now been spent there; but
+on the third her repining was over, and her sister justified, by the
+receipt of two letters from her at once, on one of which was marked that
+it had been missent elsewhere. Elizabeth was not surprised at it, as
+Jane had written the direction remarkably ill.
+
+They had just been preparing to walk as the letters came in; and
+her uncle and aunt, leaving her to enjoy them in quiet, set off by
+themselves. The one missent must first be attended to; it had been
+written five days ago. The beginning contained an account of all their
+little parties and engagements, with such news as the country afforded;
+but the latter half, which was dated a day later, and written in evident
+agitation, gave more important intelligence. It was to this effect:
+
+“Since writing the above, dearest Lizzy, something has occurred of a
+most unexpected and serious nature; but I am afraid of alarming you--be
+assured that we are all well. What I have to say relates to poor Lydia.
+An express came at twelve last night, just as we were all gone to bed,
+from Colonel Forster, to inform us that she was gone off to Scotland
+with one of his officers; to own the truth, with Wickham! Imagine our
+surprise. To Kitty, however, it does not seem so wholly unexpected. I am
+very, very sorry. So imprudent a match on both sides! But I am willing
+to hope the best, and that his character has been misunderstood.
+Thoughtless and indiscreet I can easily believe him, but this step
+(and let us rejoice over it) marks nothing bad at heart. His choice is
+disinterested at least, for he must know my father can give her nothing.
+Our poor mother is sadly grieved. My father bears it better. How
+thankful am I that we never let them know what has been said against
+him; we must forget it ourselves. They were off Saturday night about
+twelve, as is conjectured, but were not missed till yesterday morning at
+eight. The express was sent off directly. My dear Lizzy, they must have
+passed within ten miles of us. Colonel Forster gives us reason to expect
+him here soon. Lydia left a few lines for his wife, informing her of
+their intention. I must conclude, for I cannot be long from my poor
+mother. I am afraid you will not be able to make it out, but I hardly
+know what I have written.”
+
+Without allowing herself time for consideration, and scarcely knowing
+what she felt, Elizabeth on finishing this letter instantly seized the
+other, and opening it with the utmost impatience, read as follows: it
+had been written a day later than the conclusion of the first.
+
+“By this time, my dearest sister, you have received my hurried letter; I
+wish this may be more intelligible, but though not confined for time, my
+head is so bewildered that I cannot answer for being coherent. Dearest
+Lizzy, I hardly know what I would write, but I have bad news for you,
+and it cannot be delayed. Imprudent as the marriage between Mr. Wickham
+and our poor Lydia would be, we are now anxious to be assured it has
+taken place, for there is but too much reason to fear they are not gone
+to Scotland. Colonel Forster came yesterday, having left Brighton the
+day before, not many hours after the express. Though Lydia’s short
+letter to Mrs. F. gave them to understand that they were going to Gretna
+Green, something was dropped by Denny expressing his belief that W.
+never intended to go there, or to marry Lydia at all, which was
+repeated to Colonel F., who, instantly taking the alarm, set off from B.
+intending to trace their route. He did trace them easily to Clapham,
+but no further; for on entering that place, they removed into a hackney
+coach, and dismissed the chaise that brought them from Epsom. All that
+is known after this is, that they were seen to continue the London road.
+I know not what to think. After making every possible inquiry on that
+side London, Colonel F. came on into Hertfordshire, anxiously renewing
+them at all the turnpikes, and at the inns in Barnet and Hatfield, but
+without any success--no such people had been seen to pass through. With
+the kindest concern he came on to Longbourn, and broke his apprehensions
+to us in a manner most creditable to his heart. I am sincerely grieved
+for him and Mrs. F., but no one can throw any blame on them. Our
+distress, my dear Lizzy, is very great. My father and mother believe the
+worst, but I cannot think so ill of him. Many circumstances might make
+it more eligible for them to be married privately in town than to pursue
+their first plan; and even if _he_ could form such a design against a
+young woman of Lydia’s connections, which is not likely, can I suppose
+her so lost to everything? Impossible! I grieve to find, however, that
+Colonel F. is not disposed to depend upon their marriage; he shook his
+head when I expressed my hopes, and said he feared W. was not a man to
+be trusted. My poor mother is really ill, and keeps her room. Could she
+exert herself, it would be better; but this is not to be expected. And
+as to my father, I never in my life saw him so affected. Poor Kitty has
+anger for having concealed their attachment; but as it was a matter of
+confidence, one cannot wonder. I am truly glad, dearest Lizzy, that you
+have been spared something of these distressing scenes; but now, as the
+first shock is over, shall I own that I long for your return? I am not
+so selfish, however, as to press for it, if inconvenient. Adieu! I
+take up my pen again to do what I have just told you I would not; but
+circumstances are such that I cannot help earnestly begging you all to
+come here as soon as possible. I know my dear uncle and aunt so well,
+that I am not afraid of requesting it, though I have still something
+more to ask of the former. My father is going to London with Colonel
+Forster instantly, to try to discover her. What he means to do I am sure
+I know not; but his excessive distress will not allow him to pursue any
+measure in the best and safest way, and Colonel Forster is obliged to
+be at Brighton again to-morrow evening. In such an exigence, my
+uncle’s advice and assistance would be everything in the world; he will
+immediately comprehend what I must feel, and I rely upon his goodness.”
+
+“Oh! where, where is my uncle?” cried Elizabeth, darting from her seat
+as she finished the letter, in eagerness to follow him, without losing
+a moment of the time so precious; but as she reached the door it was
+opened by a servant, and Mr. Darcy appeared. Her pale face and impetuous
+manner made him start, and before he could recover himself to speak,
+she, in whose mind every idea was superseded by Lydia’s situation,
+hastily exclaimed, “I beg your pardon, but I must leave you. I must find
+Mr. Gardiner this moment, on business that cannot be delayed; I have not
+an instant to lose.”
+
+“Good God! what is the matter?” cried he, with more feeling than
+politeness; then recollecting himself, “I will not detain you a minute;
+but let me, or let the servant go after Mr. and Mrs. Gardiner. You are
+not well enough; you cannot go yourself.”
+
+Elizabeth hesitated, but her knees trembled under her and she felt how
+little would be gained by her attempting to pursue them. Calling back
+the servant, therefore, she commissioned him, though in so breathless
+an accent as made her almost unintelligible, to fetch his master and
+mistress home instantly.
+
+On his quitting the room she sat down, unable to support herself, and
+looking so miserably ill, that it was impossible for Darcy to leave her,
+or to refrain from saying, in a tone of gentleness and commiseration,
+“Let me call your maid. Is there nothing you could take to give you
+present relief? A glass of wine; shall I get you one? You are very ill.”
+
+“No, I thank you,” she replied, endeavouring to recover herself. “There
+is nothing the matter with me. I am quite well; I am only distressed by
+some dreadful news which I have just received from Longbourn.”
+
+She burst into tears as she alluded to it, and for a few minutes could
+not speak another word. Darcy, in wretched suspense, could only say
+something indistinctly of his concern, and observe her in compassionate
+silence. At length she spoke again. “I have just had a letter from Jane,
+with such dreadful news. It cannot be concealed from anyone. My younger
+sister has left all her friends--has eloped; has thrown herself into
+the power of--of Mr. Wickham. They are gone off together from Brighton.
+_You_ know him too well to doubt the rest. She has no money, no
+connections, nothing that can tempt him to--she is lost for ever.”
+
+Darcy was fixed in astonishment. “When I consider,” she added in a yet
+more agitated voice, “that I might have prevented it! I, who knew what
+he was. Had I but explained some part of it only--some part of what I
+learnt, to my own family! Had his character been known, this could not
+have happened. But it is all--all too late now.”
+
+“I am grieved indeed,” cried Darcy; “grieved--shocked. But is it
+certain--absolutely certain?”
+
+“Oh, yes! They left Brighton together on Sunday night, and were traced
+almost to London, but not beyond; they are certainly not gone to
+Scotland.”
+
+“And what has been done, what has been attempted, to recover her?”
+
+“My father is gone to London, and Jane has written to beg my uncle’s
+immediate assistance; and we shall be off, I hope, in half-an-hour. But
+nothing can be done--I know very well that nothing can be done. How is
+such a man to be worked on? How are they even to be discovered? I have
+not the smallest hope. It is every way horrible!”
+
+Darcy shook his head in silent acquiescence.
+
+“When _my_ eyes were opened to his real character--Oh! had I known what
+I ought, what I dared to do! But I knew not--I was afraid of doing too
+much. Wretched, wretched mistake!”
+
+Darcy made no answer. He seemed scarcely to hear her, and was walking
+up and down the room in earnest meditation, his brow contracted, his air
+gloomy. Elizabeth soon observed, and instantly understood it. Her
+power was sinking; everything _must_ sink under such a proof of family
+weakness, such an assurance of the deepest disgrace. She could neither
+wonder nor condemn, but the belief of his self-conquest brought nothing
+consolatory to her bosom, afforded no palliation of her distress. It
+was, on the contrary, exactly calculated to make her understand her own
+wishes; and never had she so honestly felt that she could have loved
+him, as now, when all love must be vain.
+
+But self, though it would intrude, could not engross her. Lydia--the
+humiliation, the misery she was bringing on them all, soon swallowed
+up every private care; and covering her face with her handkerchief,
+Elizabeth was soon lost to everything else; and, after a pause of
+several minutes, was only recalled to a sense of her situation by
+the voice of her companion, who, in a manner which, though it spoke
+compassion, spoke likewise restraint, said, “I am afraid you have been
+long desiring my absence, nor have I anything to plead in excuse of my
+stay, but real, though unavailing concern. Would to Heaven that anything
+could be either said or done on my part that might offer consolation to
+such distress! But I will not torment you with vain wishes, which may
+seem purposely to ask for your thanks. This unfortunate affair will, I
+fear, prevent my sister’s having the pleasure of seeing you at Pemberley
+to-day.”
+
+“Oh, yes. Be so kind as to apologise for us to Miss Darcy. Say that
+urgent business calls us home immediately. Conceal the unhappy truth as
+long as it is possible, I know it cannot be long.”
+
+He readily assured her of his secrecy; again expressed his sorrow for
+her distress, wished it a happier conclusion than there was at present
+reason to hope, and leaving his compliments for her relations, with only
+one serious, parting look, went away.
+
+As he quitted the room, Elizabeth felt how improbable it was that they
+should ever see each other again on such terms of cordiality as
+had marked their several meetings in Derbyshire; and as she threw a
+retrospective glance over the whole of their acquaintance, so full
+of contradictions and varieties, sighed at the perverseness of those
+feelings which would now have promoted its continuance, and would
+formerly have rejoiced in its termination.
+
+If gratitude and esteem are good foundations of affection, Elizabeth’s
+change of sentiment will be neither improbable nor faulty. But if
+otherwise--if regard springing from such sources is unreasonable or
+unnatural, in comparison of what is so often described as arising on
+a first interview with its object, and even before two words have been
+exchanged, nothing can be said in her defence, except that she had given
+somewhat of a trial to the latter method in her partiality for Wickham,
+and that its ill success might, perhaps, authorise her to seek the other
+less interesting mode of attachment. Be that as it may, she saw him
+go with regret; and in this early example of what Lydia’s infamy must
+produce, found additional anguish as she reflected on that wretched
+business. Never, since reading Jane’s second letter, had she entertained
+a hope of Wickham’s meaning to marry her. No one but Jane, she thought,
+could flatter herself with such an expectation. Surprise was the least
+of her feelings on this development. While the contents of the first
+letter remained in her mind, she was all surprise--all astonishment that
+Wickham should marry a girl whom it was impossible he could marry
+for money; and how Lydia could ever have attached him had appeared
+incomprehensible. But now it was all too natural. For such an attachment
+as this she might have sufficient charms; and though she did not suppose
+Lydia to be deliberately engaging in an elopement without the intention
+of marriage, she had no difficulty in believing that neither her virtue
+nor her understanding would preserve her from falling an easy prey.
+
+She had never perceived, while the regiment was in Hertfordshire, that
+Lydia had any partiality for him; but she was convinced that Lydia
+wanted only encouragement to attach herself to anybody. Sometimes one
+officer, sometimes another, had been her favourite, as their attentions
+raised them in her opinion. Her affections had continually been
+fluctuating but never without an object. The mischief of neglect and
+mistaken indulgence towards such a girl--oh! how acutely did she now
+feel it!
+
+She was wild to be at home--to hear, to see, to be upon the spot to
+share with Jane in the cares that must now fall wholly upon her, in a
+family so deranged, a father absent, a mother incapable of exertion, and
+requiring constant attendance; and though almost persuaded that nothing
+could be done for Lydia, her uncle’s interference seemed of the utmost
+importance, and till he entered the room her impatience was severe. Mr.
+and Mrs. Gardiner had hurried back in alarm, supposing by the servant’s
+account that their niece was taken suddenly ill; but satisfying them
+instantly on that head, she eagerly communicated the cause of their
+summons, reading the two letters aloud, and dwelling on the postscript
+of the last with trembling energy.--Though Lydia had never been a
+favourite with them, Mr. and Mrs. Gardiner could not but be deeply
+afflicted. Not Lydia only, but all were concerned in it; and after the
+first exclamations of surprise and horror, Mr. Gardiner promised every
+assistance in his power. Elizabeth, though expecting no less, thanked
+him with tears of gratitude; and all three being actuated by one spirit,
+everything relating to their journey was speedily settled. They were to
+be off as soon as possible. “But what is to be done about Pemberley?”
+ cried Mrs. Gardiner. “John told us Mr. Darcy was here when you sent for
+us; was it so?”
+
+“Yes; and I told him we should not be able to keep our engagement.
+_That_ is all settled.”
+
+“What is all settled?” repeated the other, as she ran into her room to
+prepare. “And are they upon such terms as for her to disclose the real
+truth? Oh, that I knew how it was!”
+
+But wishes were vain, or at least could only serve to amuse her in the
+hurry and confusion of the following hour. Had Elizabeth been at leisure
+to be idle, she would have remained certain that all employment was
+impossible to one so wretched as herself; but she had her share of
+business as well as her aunt, and amongst the rest there were notes to
+be written to all their friends at Lambton, with false excuses for their
+sudden departure. An hour, however, saw the whole completed; and Mr.
+Gardiner meanwhile having settled his account at the inn, nothing
+remained to be done but to go; and Elizabeth, after all the misery of
+the morning, found herself, in a shorter space of time than she could
+have supposed, seated in the carriage, and on the road to Longbourn.
+
+
+
+Chapter 47
+
+
+“I have been thinking it over again, Elizabeth,” said her uncle, as they
+drove from the town; “and really, upon serious consideration, I am much
+more inclined than I was to judge as your eldest sister does on the
+matter. It appears to me so very unlikely that any young man should
+form such a design against a girl who is by no means unprotected or
+friendless, and who was actually staying in his colonel’s family, that I
+am strongly inclined to hope the best. Could he expect that her friends
+would not step forward? Could he expect to be noticed again by the
+regiment, after such an affront to Colonel Forster? His temptation is
+not adequate to the risk!”
+
+“Do you really think so?” cried Elizabeth, brightening up for a moment.
+
+“Upon my word,” said Mrs. Gardiner, “I begin to be of your uncle’s
+opinion. It is really too great a violation of decency, honour, and
+interest, for him to be guilty of. I cannot think so very ill of
+Wickham. Can you yourself, Lizzy, so wholly give him up, as to believe
+him capable of it?”
+
+“Not, perhaps, of neglecting his own interest; but of every other
+neglect I can believe him capable. If, indeed, it should be so! But I
+dare not hope it. Why should they not go on to Scotland if that had been
+the case?”
+
+“In the first place,” replied Mr. Gardiner, “there is no absolute proof
+that they are not gone to Scotland.”
+
+“Oh! but their removing from the chaise into a hackney coach is such
+a presumption! And, besides, no traces of them were to be found on the
+Barnet road.”
+
+“Well, then--supposing them to be in London. They may be there, though
+for the purpose of concealment, for no more exceptional purpose. It is
+not likely that money should be very abundant on either side; and it
+might strike them that they could be more economically, though less
+expeditiously, married in London than in Scotland.”
+
+“But why all this secrecy? Why any fear of detection? Why must their
+marriage be private? Oh, no, no--this is not likely. His most particular
+friend, you see by Jane’s account, was persuaded of his never intending
+to marry her. Wickham will never marry a woman without some money. He
+cannot afford it. And what claims has Lydia--what attraction has she
+beyond youth, health, and good humour that could make him, for her sake,
+forego every chance of benefiting himself by marrying well? As to what
+restraint the apprehensions of disgrace in the corps might throw on a
+dishonourable elopement with her, I am not able to judge; for I know
+nothing of the effects that such a step might produce. But as to your
+other objection, I am afraid it will hardly hold good. Lydia has
+no brothers to step forward; and he might imagine, from my father’s
+behaviour, from his indolence and the little attention he has ever
+seemed to give to what was going forward in his family, that _he_ would
+do as little, and think as little about it, as any father could do, in
+such a matter.”
+
+“But can you think that Lydia is so lost to everything but love of him
+as to consent to live with him on any terms other than marriage?”
+
+“It does seem, and it is most shocking indeed,” replied Elizabeth, with
+tears in her eyes, “that a sister’s sense of decency and virtue in such
+a point should admit of doubt. But, really, I know not what to say.
+Perhaps I am not doing her justice. But she is very young; she has never
+been taught to think on serious subjects; and for the last half-year,
+nay, for a twelvemonth--she has been given up to nothing but amusement
+and vanity. She has been allowed to dispose of her time in the most idle
+and frivolous manner, and to adopt any opinions that came in her way.
+Since the ----shire were first quartered in Meryton, nothing but love,
+flirtation, and officers have been in her head. She has been doing
+everything in her power by thinking and talking on the subject, to give
+greater--what shall I call it? susceptibility to her feelings; which are
+naturally lively enough. And we all know that Wickham has every charm of
+person and address that can captivate a woman.”
+
+“But you see that Jane,” said her aunt, “does not think so very ill of
+Wickham as to believe him capable of the attempt.”
+
+“Of whom does Jane ever think ill? And who is there, whatever might be
+their former conduct, that she would think capable of such an attempt,
+till it were proved against them? But Jane knows, as well as I do, what
+Wickham really is. We both know that he has been profligate in every
+sense of the word; that he has neither integrity nor honour; that he is
+as false and deceitful as he is insinuating.”
+
+“And do you really know all this?” cried Mrs. Gardiner, whose curiosity
+as to the mode of her intelligence was all alive.
+
+“I do indeed,” replied Elizabeth, colouring. “I told you, the other day,
+of his infamous behaviour to Mr. Darcy; and you yourself, when last at
+Longbourn, heard in what manner he spoke of the man who had behaved
+with such forbearance and liberality towards him. And there are other
+circumstances which I am not at liberty--which it is not worth while to
+relate; but his lies about the whole Pemberley family are endless. From
+what he said of Miss Darcy I was thoroughly prepared to see a proud,
+reserved, disagreeable girl. Yet he knew to the contrary himself. He
+must know that she was as amiable and unpretending as we have found
+her.”
+
+“But does Lydia know nothing of this? can she be ignorant of what you
+and Jane seem so well to understand?”
+
+“Oh, yes!--that, that is the worst of all. Till I was in Kent, and saw
+so much both of Mr. Darcy and his relation Colonel Fitzwilliam, I was
+ignorant of the truth myself. And when I returned home, the ----shire
+was to leave Meryton in a week or fortnight’s time. As that was the
+case, neither Jane, to whom I related the whole, nor I, thought it
+necessary to make our knowledge public; for of what use could
+it apparently be to any one, that the good opinion which all the
+neighbourhood had of him should then be overthrown? And even when it was
+settled that Lydia should go with Mrs. Forster, the necessity of opening
+her eyes to his character never occurred to me. That _she_ could be
+in any danger from the deception never entered my head. That such a
+consequence as _this_ could ensue, you may easily believe, was far
+enough from my thoughts.”
+
+“When they all removed to Brighton, therefore, you had no reason, I
+suppose, to believe them fond of each other?”
+
+“Not the slightest. I can remember no symptom of affection on either
+side; and had anything of the kind been perceptible, you must be aware
+that ours is not a family on which it could be thrown away. When first
+he entered the corps, she was ready enough to admire him; but so we all
+were. Every girl in or near Meryton was out of her senses about him for
+the first two months; but he never distinguished _her_ by any particular
+attention; and, consequently, after a moderate period of extravagant and
+wild admiration, her fancy for him gave way, and others of the regiment,
+who treated her with more distinction, again became her favourites.”
+
+                          * * * * *
+
+It may be easily believed, that however little of novelty could be added
+to their fears, hopes, and conjectures, on this interesting subject, by
+its repeated discussion, no other could detain them from it long, during
+the whole of the journey. From Elizabeth’s thoughts it was never absent.
+Fixed there by the keenest of all anguish, self-reproach, she could find
+no interval of ease or forgetfulness.
+
+They travelled as expeditiously as possible, and, sleeping one night
+on the road, reached Longbourn by dinner time the next day. It was a
+comfort to Elizabeth to consider that Jane could not have been wearied
+by long expectations.
+
+The little Gardiners, attracted by the sight of a chaise, were standing
+on the steps of the house as they entered the paddock; and, when the
+carriage drove up to the door, the joyful surprise that lighted up their
+faces, and displayed itself over their whole bodies, in a variety of
+capers and frisks, was the first pleasing earnest of their welcome.
+
+Elizabeth jumped out; and, after giving each of them a hasty kiss,
+hurried into the vestibule, where Jane, who came running down from her
+mother’s apartment, immediately met her.
+
+Elizabeth, as she affectionately embraced her, whilst tears filled the
+eyes of both, lost not a moment in asking whether anything had been
+heard of the fugitives.
+
+“Not yet,” replied Jane. “But now that my dear uncle is come, I hope
+everything will be well.”
+
+“Is my father in town?”
+
+“Yes, he went on Tuesday, as I wrote you word.”
+
+“And have you heard from him often?”
+
+“We have heard only twice. He wrote me a few lines on Wednesday to say
+that he had arrived in safety, and to give me his directions, which I
+particularly begged him to do. He merely added that he should not write
+again till he had something of importance to mention.”
+
+“And my mother--how is she? How are you all?”
+
+“My mother is tolerably well, I trust; though her spirits are greatly
+shaken. She is up stairs and will have great satisfaction in seeing you
+all. She does not yet leave her dressing-room. Mary and Kitty, thank
+Heaven, are quite well.”
+
+“But you--how are you?” cried Elizabeth. “You look pale. How much you
+must have gone through!”
+
+Her sister, however, assured her of her being perfectly well; and their
+conversation, which had been passing while Mr. and Mrs. Gardiner were
+engaged with their children, was now put an end to by the approach
+of the whole party. Jane ran to her uncle and aunt, and welcomed and
+thanked them both, with alternate smiles and tears.
+
+When they were all in the drawing-room, the questions which Elizabeth
+had already asked were of course repeated by the others, and they soon
+found that Jane had no intelligence to give. The sanguine hope of
+good, however, which the benevolence of her heart suggested had not yet
+deserted her; she still expected that it would all end well, and that
+every morning would bring some letter, either from Lydia or her father,
+to explain their proceedings, and, perhaps, announce their marriage.
+
+Mrs. Bennet, to whose apartment they all repaired, after a few minutes’
+conversation together, received them exactly as might be expected; with
+tears and lamentations of regret, invectives against the villainous
+conduct of Wickham, and complaints of her own sufferings and ill-usage;
+blaming everybody but the person to whose ill-judging indulgence the
+errors of her daughter must principally be owing.
+
+“If I had been able,” said she, “to carry my point in going to Brighton,
+with all my family, _this_ would not have happened; but poor dear Lydia
+had nobody to take care of her. Why did the Forsters ever let her go out
+of their sight? I am sure there was some great neglect or other on their
+side, for she is not the kind of girl to do such a thing if she had been
+well looked after. I always thought they were very unfit to have the
+charge of her; but I was overruled, as I always am. Poor dear child!
+And now here’s Mr. Bennet gone away, and I know he will fight Wickham,
+wherever he meets him and then he will be killed, and what is to become
+of us all? The Collinses will turn us out before he is cold in his
+grave, and if you are not kind to us, brother, I do not know what we
+shall do.”
+
+They all exclaimed against such terrific ideas; and Mr. Gardiner, after
+general assurances of his affection for her and all her family, told her
+that he meant to be in London the very next day, and would assist Mr.
+Bennet in every endeavour for recovering Lydia.
+
+“Do not give way to useless alarm,” added he; “though it is right to be
+prepared for the worst, there is no occasion to look on it as certain.
+It is not quite a week since they left Brighton. In a few days more we
+may gain some news of them; and till we know that they are not married,
+and have no design of marrying, do not let us give the matter over as
+lost. As soon as I get to town I shall go to my brother, and make
+him come home with me to Gracechurch Street; and then we may consult
+together as to what is to be done.”
+
+“Oh! my dear brother,” replied Mrs. Bennet, “that is exactly what I
+could most wish for. And now do, when you get to town, find them out,
+wherever they may be; and if they are not married already, _make_ them
+marry. And as for wedding clothes, do not let them wait for that, but
+tell Lydia she shall have as much money as she chooses to buy them,
+after they are married. And, above all, keep Mr. Bennet from fighting.
+Tell him what a dreadful state I am in, that I am frighted out of my
+wits--and have such tremblings, such flutterings, all over me--such
+spasms in my side and pains in my head, and such beatings at heart, that
+I can get no rest by night nor by day. And tell my dear Lydia not to
+give any directions about her clothes till she has seen me, for she does
+not know which are the best warehouses. Oh, brother, how kind you are! I
+know you will contrive it all.”
+
+But Mr. Gardiner, though he assured her again of his earnest endeavours
+in the cause, could not avoid recommending moderation to her, as well
+in her hopes as her fear; and after talking with her in this manner till
+dinner was on the table, they all left her to vent all her feelings on
+the housekeeper, who attended in the absence of her daughters.
+
+Though her brother and sister were persuaded that there was no real
+occasion for such a seclusion from the family, they did not attempt to
+oppose it, for they knew that she had not prudence enough to hold her
+tongue before the servants, while they waited at table, and judged it
+better that _one_ only of the household, and the one whom they could
+most trust should comprehend all her fears and solicitude on the
+subject.
+
+In the dining-room they were soon joined by Mary and Kitty, who had been
+too busily engaged in their separate apartments to make their appearance
+before. One came from her books, and the other from her toilette. The
+faces of both, however, were tolerably calm; and no change was visible
+in either, except that the loss of her favourite sister, or the anger
+which she had herself incurred in this business, had given more of
+fretfulness than usual to the accents of Kitty. As for Mary, she was
+mistress enough of herself to whisper to Elizabeth, with a countenance
+of grave reflection, soon after they were seated at table:
+
+“This is a most unfortunate affair, and will probably be much talked of.
+But we must stem the tide of malice, and pour into the wounded bosoms of
+each other the balm of sisterly consolation.”
+
+Then, perceiving in Elizabeth no inclination of replying, she added,
+“Unhappy as the event must be for Lydia, we may draw from it this useful
+lesson: that loss of virtue in a female is irretrievable; that one
+false step involves her in endless ruin; that her reputation is no less
+brittle than it is beautiful; and that she cannot be too much guarded in
+her behaviour towards the undeserving of the other sex.”
+
+Elizabeth lifted up her eyes in amazement, but was too much oppressed
+to make any reply. Mary, however, continued to console herself with such
+kind of moral extractions from the evil before them.
+
+In the afternoon, the two elder Miss Bennets were able to be for
+half-an-hour by themselves; and Elizabeth instantly availed herself of
+the opportunity of making any inquiries, which Jane was equally eager to
+satisfy. After joining in general lamentations over the dreadful sequel
+of this event, which Elizabeth considered as all but certain, and Miss
+Bennet could not assert to be wholly impossible, the former continued
+the subject, by saying, “But tell me all and everything about it which
+I have not already heard. Give me further particulars. What did Colonel
+Forster say? Had they no apprehension of anything before the elopement
+took place? They must have seen them together for ever.”
+
+“Colonel Forster did own that he had often suspected some partiality,
+especially on Lydia’s side, but nothing to give him any alarm. I am so
+grieved for him! His behaviour was attentive and kind to the utmost. He
+_was_ coming to us, in order to assure us of his concern, before he had
+any idea of their not being gone to Scotland: when that apprehension
+first got abroad, it hastened his journey.”
+
+“And was Denny convinced that Wickham would not marry? Did he know of
+their intending to go off? Had Colonel Forster seen Denny himself?”
+
+“Yes; but, when questioned by _him_, Denny denied knowing anything of
+their plans, and would not give his real opinion about it. He did not
+repeat his persuasion of their not marrying--and from _that_, I am
+inclined to hope, he might have been misunderstood before.”
+
+“And till Colonel Forster came himself, not one of you entertained a
+doubt, I suppose, of their being really married?”
+
+“How was it possible that such an idea should enter our brains? I felt
+a little uneasy--a little fearful of my sister’s happiness with him
+in marriage, because I knew that his conduct had not been always quite
+right. My father and mother knew nothing of that; they only felt how
+imprudent a match it must be. Kitty then owned, with a very natural
+triumph on knowing more than the rest of us, that in Lydia’s last letter
+she had prepared her for such a step. She had known, it seems, of their
+being in love with each other, many weeks.”
+
+“But not before they went to Brighton?”
+
+“No, I believe not.”
+
+“And did Colonel Forster appear to think well of Wickham himself? Does
+he know his real character?”
+
+“I must confess that he did not speak so well of Wickham as he formerly
+did. He believed him to be imprudent and extravagant. And since this sad
+affair has taken place, it is said that he left Meryton greatly in debt;
+but I hope this may be false.”
+
+“Oh, Jane, had we been less secret, had we told what we knew of him,
+this could not have happened!”
+
+“Perhaps it would have been better,” replied her sister. “But to expose
+the former faults of any person without knowing what their present
+feelings were, seemed unjustifiable. We acted with the best intentions.”
+
+“Could Colonel Forster repeat the particulars of Lydia’s note to his
+wife?”
+
+“He brought it with him for us to see.”
+
+Jane then took it from her pocket-book, and gave it to Elizabeth. These
+were the contents:
+
+“MY DEAR HARRIET,
+
+“You will laugh when you know where I am gone, and I cannot help
+laughing myself at your surprise to-morrow morning, as soon as I am
+missed. I am going to Gretna Green, and if you cannot guess with who,
+I shall think you a simpleton, for there is but one man in the world I
+love, and he is an angel. I should never be happy without him, so think
+it no harm to be off. You need not send them word at Longbourn of my
+going, if you do not like it, for it will make the surprise the greater,
+when I write to them and sign my name ‘Lydia Wickham.’ What a good joke
+it will be! I can hardly write for laughing. Pray make my excuses to
+Pratt for not keeping my engagement, and dancing with him to-night.
+Tell him I hope he will excuse me when he knows all; and tell him I will
+dance with him at the next ball we meet, with great pleasure. I shall
+send for my clothes when I get to Longbourn; but I wish you would tell
+Sally to mend a great slit in my worked muslin gown before they are
+packed up. Good-bye. Give my love to Colonel Forster. I hope you will
+drink to our good journey.
+
+“Your affectionate friend,
+
+“LYDIA BENNET.”
+
+“Oh! thoughtless, thoughtless Lydia!” cried Elizabeth when she had
+finished it. “What a letter is this, to be written at such a moment!
+But at least it shows that _she_ was serious on the subject of their
+journey. Whatever he might afterwards persuade her to, it was not on her
+side a _scheme_ of infamy. My poor father! how he must have felt it!”
+
+“I never saw anyone so shocked. He could not speak a word for full ten
+minutes. My mother was taken ill immediately, and the whole house in
+such confusion!”
+
+“Oh! Jane,” cried Elizabeth, “was there a servant belonging to it who
+did not know the whole story before the end of the day?”
+
+“I do not know. I hope there was. But to be guarded at such a time is
+very difficult. My mother was in hysterics, and though I endeavoured to
+give her every assistance in my power, I am afraid I did not do so
+much as I might have done! But the horror of what might possibly happen
+almost took from me my faculties.”
+
+“Your attendance upon her has been too much for you. You do not look
+well. Oh that I had been with you! you have had every care and anxiety
+upon yourself alone.”
+
+“Mary and Kitty have been very kind, and would have shared in every
+fatigue, I am sure; but I did not think it right for either of them.
+Kitty is slight and delicate; and Mary studies so much, that her hours
+of repose should not be broken in on. My aunt Phillips came to Longbourn
+on Tuesday, after my father went away; and was so good as to stay till
+Thursday with me. She was of great use and comfort to us all. And
+Lady Lucas has been very kind; she walked here on Wednesday morning to
+condole with us, and offered her services, or any of her daughters’, if
+they should be of use to us.”
+
+“She had better have stayed at home,” cried Elizabeth; “perhaps she
+_meant_ well, but, under such a misfortune as this, one cannot see
+too little of one’s neighbours. Assistance is impossible; condolence
+insufferable. Let them triumph over us at a distance, and be satisfied.”
+
+She then proceeded to inquire into the measures which her father had
+intended to pursue, while in town, for the recovery of his daughter.
+
+“He meant I believe,” replied Jane, “to go to Epsom, the place where
+they last changed horses, see the postilions and try if anything could
+be made out from them. His principal object must be to discover the
+number of the hackney coach which took them from Clapham. It had come
+with a fare from London; and as he thought that the circumstance of a
+gentleman and lady’s removing from one carriage into another might
+be remarked he meant to make inquiries at Clapham. If he could anyhow
+discover at what house the coachman had before set down his fare, he
+determined to make inquiries there, and hoped it might not be impossible
+to find out the stand and number of the coach. I do not know of any
+other designs that he had formed; but he was in such a hurry to be gone,
+and his spirits so greatly discomposed, that I had difficulty in finding
+out even so much as this.”
+
+
+
+Chapter 48
+
+
+The whole party were in hopes of a letter from Mr. Bennet the next
+morning, but the post came in without bringing a single line from him.
+His family knew him to be, on all common occasions, a most negligent and
+dilatory correspondent; but at such a time they had hoped for exertion.
+They were forced to conclude that he had no pleasing intelligence to
+send; but even of _that_ they would have been glad to be certain. Mr.
+Gardiner had waited only for the letters before he set off.
+
+When he was gone, they were certain at least of receiving constant
+information of what was going on, and their uncle promised, at parting,
+to prevail on Mr. Bennet to return to Longbourn, as soon as he could,
+to the great consolation of his sister, who considered it as the only
+security for her husband’s not being killed in a duel.
+
+Mrs. Gardiner and the children were to remain in Hertfordshire a few
+days longer, as the former thought her presence might be serviceable
+to her nieces. She shared in their attendance on Mrs. Bennet, and was a
+great comfort to them in their hours of freedom. Their other aunt also
+visited them frequently, and always, as she said, with the design of
+cheering and heartening them up--though, as she never came without
+reporting some fresh instance of Wickham’s extravagance or irregularity,
+she seldom went away without leaving them more dispirited than she found
+them.
+
+All Meryton seemed striving to blacken the man who, but three months
+before, had been almost an angel of light. He was declared to be in debt
+to every tradesman in the place, and his intrigues, all honoured with
+the title of seduction, had been extended into every tradesman’s family.
+Everybody declared that he was the wickedest young man in the world;
+and everybody began to find out that they had always distrusted the
+appearance of his goodness. Elizabeth, though she did not credit above
+half of what was said, believed enough to make her former assurance of
+her sister’s ruin more certain; and even Jane, who believed still less
+of it, became almost hopeless, more especially as the time was now come
+when, if they had gone to Scotland, which she had never before entirely
+despaired of, they must in all probability have gained some news of
+them.
+
+Mr. Gardiner left Longbourn on Sunday; on Tuesday his wife received a
+letter from him; it told them that, on his arrival, he had immediately
+found out his brother, and persuaded him to come to Gracechurch Street;
+that Mr. Bennet had been to Epsom and Clapham, before his arrival,
+but without gaining any satisfactory information; and that he was now
+determined to inquire at all the principal hotels in town, as Mr. Bennet
+thought it possible they might have gone to one of them, on their first
+coming to London, before they procured lodgings. Mr. Gardiner himself
+did not expect any success from this measure, but as his brother was
+eager in it, he meant to assist him in pursuing it. He added that Mr.
+Bennet seemed wholly disinclined at present to leave London and promised
+to write again very soon. There was also a postscript to this effect:
+
+“I have written to Colonel Forster to desire him to find out, if
+possible, from some of the young man’s intimates in the regiment,
+whether Wickham has any relations or connections who would be likely to
+know in what part of town he has now concealed himself. If there were
+anyone that one could apply to with a probability of gaining such a
+clue as that, it might be of essential consequence. At present we have
+nothing to guide us. Colonel Forster will, I dare say, do everything in
+his power to satisfy us on this head. But, on second thoughts, perhaps,
+Lizzy could tell us what relations he has now living, better than any
+other person.”
+
+Elizabeth was at no loss to understand from whence this deference to her
+authority proceeded; but it was not in her power to give any information
+of so satisfactory a nature as the compliment deserved. She had never
+heard of his having had any relations, except a father and mother, both
+of whom had been dead many years. It was possible, however, that some of
+his companions in the ----shire might be able to give more information;
+and though she was not very sanguine in expecting it, the application
+was a something to look forward to.
+
+Every day at Longbourn was now a day of anxiety; but the most anxious
+part of each was when the post was expected. The arrival of letters
+was the grand object of every morning’s impatience. Through letters,
+whatever of good or bad was to be told would be communicated, and every
+succeeding day was expected to bring some news of importance.
+
+But before they heard again from Mr. Gardiner, a letter arrived for
+their father, from a different quarter, from Mr. Collins; which, as Jane
+had received directions to open all that came for him in his absence,
+she accordingly read; and Elizabeth, who knew what curiosities his
+letters always were, looked over her, and read it likewise. It was as
+follows:
+
+“MY DEAR SIR,
+
+“I feel myself called upon, by our relationship, and my situation
+in life, to condole with you on the grievous affliction you are now
+suffering under, of which we were yesterday informed by a letter from
+Hertfordshire. Be assured, my dear sir, that Mrs. Collins and myself
+sincerely sympathise with you and all your respectable family, in
+your present distress, which must be of the bitterest kind, because
+proceeding from a cause which no time can remove. No arguments shall be
+wanting on my part that can alleviate so severe a misfortune--or that
+may comfort you, under a circumstance that must be of all others the
+most afflicting to a parent’s mind. The death of your daughter would
+have been a blessing in comparison of this. And it is the more to
+be lamented, because there is reason to suppose as my dear Charlotte
+informs me, that this licentiousness of behaviour in your daughter has
+proceeded from a faulty degree of indulgence; though, at the same time,
+for the consolation of yourself and Mrs. Bennet, I am inclined to think
+that her own disposition must be naturally bad, or she could not be
+guilty of such an enormity, at so early an age. Howsoever that may be,
+you are grievously to be pitied; in which opinion I am not only joined
+by Mrs. Collins, but likewise by Lady Catherine and her daughter, to
+whom I have related the affair. They agree with me in apprehending that
+this false step in one daughter will be injurious to the fortunes of
+all the others; for who, as Lady Catherine herself condescendingly says,
+will connect themselves with such a family? And this consideration leads
+me moreover to reflect, with augmented satisfaction, on a certain event
+of last November; for had it been otherwise, I must have been involved
+in all your sorrow and disgrace. Let me then advise you, dear sir, to
+console yourself as much as possible, to throw off your unworthy child
+from your affection for ever, and leave her to reap the fruits of her
+own heinous offense.
+
+“I am, dear sir, etc., etc.”
+
+Mr. Gardiner did not write again till he had received an answer from
+Colonel Forster; and then he had nothing of a pleasant nature to send.
+It was not known that Wickham had a single relationship with whom he
+kept up any connection, and it was certain that he had no near one
+living. His former acquaintances had been numerous; but since he
+had been in the militia, it did not appear that he was on terms of
+particular friendship with any of them. There was no one, therefore,
+who could be pointed out as likely to give any news of him. And in the
+wretched state of his own finances, there was a very powerful motive for
+secrecy, in addition to his fear of discovery by Lydia’s relations, for
+it had just transpired that he had left gaming debts behind him to a
+very considerable amount. Colonel Forster believed that more than a
+thousand pounds would be necessary to clear his expenses at Brighton.
+He owed a good deal in town, but his debts of honour were still more
+formidable. Mr. Gardiner did not attempt to conceal these particulars
+from the Longbourn family. Jane heard them with horror. “A gamester!”
+ she cried. “This is wholly unexpected. I had not an idea of it.”
+
+Mr. Gardiner added in his letter, that they might expect to see their
+father at home on the following day, which was Saturday. Rendered
+spiritless by the ill-success of all their endeavours, he had yielded
+to his brother-in-law’s entreaty that he would return to his family, and
+leave it to him to do whatever occasion might suggest to be advisable
+for continuing their pursuit. When Mrs. Bennet was told of this, she did
+not express so much satisfaction as her children expected, considering
+what her anxiety for his life had been before.
+
+“What, is he coming home, and without poor Lydia?” she cried. “Sure he
+will not leave London before he has found them. Who is to fight Wickham,
+and make him marry her, if he comes away?”
+
+As Mrs. Gardiner began to wish to be at home, it was settled that she
+and the children should go to London, at the same time that Mr. Bennet
+came from it. The coach, therefore, took them the first stage of their
+journey, and brought its master back to Longbourn.
+
+Mrs. Gardiner went away in all the perplexity about Elizabeth and her
+Derbyshire friend that had attended her from that part of the world. His
+name had never been voluntarily mentioned before them by her niece; and
+the kind of half-expectation which Mrs. Gardiner had formed, of their
+being followed by a letter from him, had ended in nothing. Elizabeth had
+received none since her return that could come from Pemberley.
+
+The present unhappy state of the family rendered any other excuse for
+the lowness of her spirits unnecessary; nothing, therefore, could be
+fairly conjectured from _that_, though Elizabeth, who was by this time
+tolerably well acquainted with her own feelings, was perfectly aware
+that, had she known nothing of Darcy, she could have borne the dread of
+Lydia’s infamy somewhat better. It would have spared her, she thought,
+one sleepless night out of two.
+
+When Mr. Bennet arrived, he had all the appearance of his usual
+philosophic composure. He said as little as he had ever been in the
+habit of saying; made no mention of the business that had taken him
+away, and it was some time before his daughters had courage to speak of
+it.
+
+It was not till the afternoon, when he had joined them at tea, that
+Elizabeth ventured to introduce the subject; and then, on her briefly
+expressing her sorrow for what he must have endured, he replied, “Say
+nothing of that. Who should suffer but myself? It has been my own doing,
+and I ought to feel it.”
+
+“You must not be too severe upon yourself,” replied Elizabeth.
+
+“You may well warn me against such an evil. Human nature is so prone
+to fall into it! No, Lizzy, let me once in my life feel how much I have
+been to blame. I am not afraid of being overpowered by the impression.
+It will pass away soon enough.”
+
+“Do you suppose them to be in London?”
+
+“Yes; where else can they be so well concealed?”
+
+“And Lydia used to want to go to London,” added Kitty.
+
+“She is happy then,” said her father drily; “and her residence there
+will probably be of some duration.”
+
+Then after a short silence he continued:
+
+“Lizzy, I bear you no ill-will for being justified in your advice to me
+last May, which, considering the event, shows some greatness of mind.”
+
+They were interrupted by Miss Bennet, who came to fetch her mother’s
+tea.
+
+“This is a parade,” he cried, “which does one good; it gives such an
+elegance to misfortune! Another day I will do the same; I will sit in my
+library, in my nightcap and powdering gown, and give as much trouble as
+I can; or, perhaps, I may defer it till Kitty runs away.”
+
+“I am not going to run away, papa,” said Kitty fretfully. “If I should
+ever go to Brighton, I would behave better than Lydia.”
+
+“_You_ go to Brighton. I would not trust you so near it as Eastbourne
+for fifty pounds! No, Kitty, I have at last learnt to be cautious, and
+you will feel the effects of it. No officer is ever to enter into
+my house again, nor even to pass through the village. Balls will be
+absolutely prohibited, unless you stand up with one of your sisters.
+And you are never to stir out of doors till you can prove that you have
+spent ten minutes of every day in a rational manner.”
+
+Kitty, who took all these threats in a serious light, began to cry.
+
+“Well, well,” said he, “do not make yourself unhappy. If you are a good
+girl for the next ten years, I will take you to a review at the end of
+them.”
+
+
+
+Chapter 49
+
+
+Two days after Mr. Bennet’s return, as Jane and Elizabeth were walking
+together in the shrubbery behind the house, they saw the housekeeper
+coming towards them, and, concluding that she came to call them to their
+mother, went forward to meet her; but, instead of the expected summons,
+when they approached her, she said to Miss Bennet, “I beg your pardon,
+madam, for interrupting you, but I was in hopes you might have got some
+good news from town, so I took the liberty of coming to ask.”
+
+“What do you mean, Hill? We have heard nothing from town.”
+
+“Dear madam,” cried Mrs. Hill, in great astonishment, “don’t you know
+there is an express come for master from Mr. Gardiner? He has been here
+this half-hour, and master has had a letter.”
+
+Away ran the girls, too eager to get in to have time for speech. They
+ran through the vestibule into the breakfast-room; from thence to the
+library; their father was in neither; and they were on the point of
+seeking him up stairs with their mother, when they were met by the
+butler, who said:
+
+“If you are looking for my master, ma’am, he is walking towards the
+little copse.”
+
+Upon this information, they instantly passed through the hall once
+more, and ran across the lawn after their father, who was deliberately
+pursuing his way towards a small wood on one side of the paddock.
+
+Jane, who was not so light nor so much in the habit of running as
+Elizabeth, soon lagged behind, while her sister, panting for breath,
+came up with him, and eagerly cried out:
+
+“Oh, papa, what news--what news? Have you heard from my uncle?”
+
+“Yes I have had a letter from him by express.”
+
+“Well, and what news does it bring--good or bad?”
+
+“What is there of good to be expected?” said he, taking the letter from
+his pocket. “But perhaps you would like to read it.”
+
+Elizabeth impatiently caught it from his hand. Jane now came up.
+
+“Read it aloud,” said their father, “for I hardly know myself what it is
+about.”
+
+“Gracechurch Street, Monday, August 2.
+
+“MY DEAR BROTHER,
+
+“At last I am able to send you some tidings of my niece, and such as,
+upon the whole, I hope it will give you satisfaction. Soon after you
+left me on Saturday, I was fortunate enough to find out in what part of
+London they were. The particulars I reserve till we meet; it is enough
+to know they are discovered. I have seen them both--”
+
+“Then it is as I always hoped,” cried Jane; “they are married!”
+
+Elizabeth read on:
+
+“I have seen them both. They are not married, nor can I find there
+was any intention of being so; but if you are willing to perform the
+engagements which I have ventured to make on your side, I hope it will
+not be long before they are. All that is required of you is, to assure
+to your daughter, by settlement, her equal share of the five thousand
+pounds secured among your children after the decease of yourself and
+my sister; and, moreover, to enter into an engagement of allowing her,
+during your life, one hundred pounds per annum. These are conditions
+which, considering everything, I had no hesitation in complying with,
+as far as I thought myself privileged, for you. I shall send this by
+express, that no time may be lost in bringing me your answer. You
+will easily comprehend, from these particulars, that Mr. Wickham’s
+circumstances are not so hopeless as they are generally believed to be.
+The world has been deceived in that respect; and I am happy to say there
+will be some little money, even when all his debts are discharged, to
+settle on my niece, in addition to her own fortune. If, as I conclude
+will be the case, you send me full powers to act in your name throughout
+the whole of this business, I will immediately give directions to
+Haggerston for preparing a proper settlement. There will not be the
+smallest occasion for your coming to town again; therefore stay quiet at
+Longbourn, and depend on my diligence and care. Send back your answer as
+fast as you can, and be careful to write explicitly. We have judged it
+best that my niece should be married from this house, of which I hope
+you will approve. She comes to us to-day. I shall write again as soon as
+anything more is determined on. Yours, etc.,
+
+“EDW. GARDINER.”
+
+“Is it possible?” cried Elizabeth, when she had finished. “Can it be
+possible that he will marry her?”
+
+“Wickham is not so undeserving, then, as we thought him,” said her
+sister. “My dear father, I congratulate you.”
+
+“And have you answered the letter?” cried Elizabeth.
+
+“No; but it must be done soon.”
+
+Most earnestly did she then entreat him to lose no more time before he
+wrote.
+
+“Oh! my dear father,” she cried, “come back and write immediately.
+Consider how important every moment is in such a case.”
+
+“Let me write for you,” said Jane, “if you dislike the trouble
+yourself.”
+
+“I dislike it very much,” he replied; “but it must be done.”
+
+And so saying, he turned back with them, and walked towards the house.
+
+“And may I ask--” said Elizabeth; “but the terms, I suppose, must be
+complied with.”
+
+“Complied with! I am only ashamed of his asking so little.”
+
+“And they _must_ marry! Yet he is _such_ a man!”
+
+“Yes, yes, they must marry. There is nothing else to be done. But there
+are two things that I want very much to know; one is, how much money
+your uncle has laid down to bring it about; and the other, how am I ever
+to pay him.”
+
+“Money! My uncle!” cried Jane, “what do you mean, sir?”
+
+“I mean, that no man in his senses would marry Lydia on so slight a
+temptation as one hundred a year during my life, and fifty after I am
+gone.”
+
+“That is very true,” said Elizabeth; “though it had not occurred to me
+before. His debts to be discharged, and something still to remain! Oh!
+it must be my uncle’s doings! Generous, good man, I am afraid he has
+distressed himself. A small sum could not do all this.”
+
+“No,” said her father; “Wickham’s a fool if he takes her with a farthing
+less than ten thousand pounds. I should be sorry to think so ill of him,
+in the very beginning of our relationship.”
+
+“Ten thousand pounds! Heaven forbid! How is half such a sum to be
+repaid?”
+
+Mr. Bennet made no answer, and each of them, deep in thought, continued
+silent till they reached the house. Their father then went on to the
+library to write, and the girls walked into the breakfast-room.
+
+“And they are really to be married!” cried Elizabeth, as soon as they
+were by themselves. “How strange this is! And for _this_ we are to be
+thankful. That they should marry, small as is their chance of happiness,
+and wretched as is his character, we are forced to rejoice. Oh, Lydia!”
+
+“I comfort myself with thinking,” replied Jane, “that he certainly would
+not marry Lydia if he had not a real regard for her. Though our kind
+uncle has done something towards clearing him, I cannot believe that ten
+thousand pounds, or anything like it, has been advanced. He has children
+of his own, and may have more. How could he spare half ten thousand
+pounds?”
+
+“If he were ever able to learn what Wickham’s debts have been,” said
+Elizabeth, “and how much is settled on his side on our sister, we shall
+exactly know what Mr. Gardiner has done for them, because Wickham has
+not sixpence of his own. The kindness of my uncle and aunt can never
+be requited. Their taking her home, and affording her their personal
+protection and countenance, is such a sacrifice to her advantage as
+years of gratitude cannot enough acknowledge. By this time she is
+actually with them! If such goodness does not make her miserable now,
+she will never deserve to be happy! What a meeting for her, when she
+first sees my aunt!”
+
+“We must endeavour to forget all that has passed on either side,” said
+Jane: “I hope and trust they will yet be happy. His consenting to
+marry her is a proof, I will believe, that he is come to a right way of
+thinking. Their mutual affection will steady them; and I flatter myself
+they will settle so quietly, and live in so rational a manner, as may in
+time make their past imprudence forgotten.”
+
+“Their conduct has been such,” replied Elizabeth, “as neither you, nor
+I, nor anybody can ever forget. It is useless to talk of it.”
+
+It now occurred to the girls that their mother was in all likelihood
+perfectly ignorant of what had happened. They went to the library,
+therefore, and asked their father whether he would not wish them to make
+it known to her. He was writing and, without raising his head, coolly
+replied:
+
+“Just as you please.”
+
+“May we take my uncle’s letter to read to her?”
+
+“Take whatever you like, and get away.”
+
+Elizabeth took the letter from his writing-table, and they went up stairs
+together. Mary and Kitty were both with Mrs. Bennet: one communication
+would, therefore, do for all. After a slight preparation for good news,
+the letter was read aloud. Mrs. Bennet could hardly contain herself. As
+soon as Jane had read Mr. Gardiner’s hope of Lydia’s being soon
+married, her joy burst forth, and every following sentence added to its
+exuberance. She was now in an irritation as violent from delight, as she
+had ever been fidgety from alarm and vexation. To know that her daughter
+would be married was enough. She was disturbed by no fear for her
+felicity, nor humbled by any remembrance of her misconduct.
+
+“My dear, dear Lydia!” she cried. “This is delightful indeed! She will
+be married! I shall see her again! She will be married at sixteen!
+My good, kind brother! I knew how it would be. I knew he would manage
+everything! How I long to see her! and to see dear Wickham too! But the
+clothes, the wedding clothes! I will write to my sister Gardiner about
+them directly. Lizzy, my dear, run down to your father, and ask him
+how much he will give her. Stay, stay, I will go myself. Ring the bell,
+Kitty, for Hill. I will put on my things in a moment. My dear, dear
+Lydia! How merry we shall be together when we meet!”
+
+Her eldest daughter endeavoured to give some relief to the violence of
+these transports, by leading her thoughts to the obligations which Mr.
+Gardiner’s behaviour laid them all under.
+
+“For we must attribute this happy conclusion,” she added, “in a great
+measure to his kindness. We are persuaded that he has pledged himself to
+assist Mr. Wickham with money.”
+
+“Well,” cried her mother, “it is all very right; who should do it but
+her own uncle? If he had not had a family of his own, I and my children
+must have had all his money, you know; and it is the first time we have
+ever had anything from him, except a few presents. Well! I am so happy!
+In a short time I shall have a daughter married. Mrs. Wickham! How well
+it sounds! And she was only sixteen last June. My dear Jane, I am in
+such a flutter, that I am sure I can’t write; so I will dictate, and
+you write for me. We will settle with your father about the money
+afterwards; but the things should be ordered immediately.”
+
+She was then proceeding to all the particulars of calico, muslin, and
+cambric, and would shortly have dictated some very plentiful orders, had
+not Jane, though with some difficulty, persuaded her to wait till her
+father was at leisure to be consulted. One day’s delay, she observed,
+would be of small importance; and her mother was too happy to be quite
+so obstinate as usual. Other schemes, too, came into her head.
+
+“I will go to Meryton,” said she, “as soon as I am dressed, and tell the
+good, good news to my sister Philips. And as I come back, I can call
+on Lady Lucas and Mrs. Long. Kitty, run down and order the carriage.
+An airing would do me a great deal of good, I am sure. Girls, can I do
+anything for you in Meryton? Oh! Here comes Hill! My dear Hill, have you
+heard the good news? Miss Lydia is going to be married; and you shall
+all have a bowl of punch to make merry at her wedding.”
+
+Mrs. Hill began instantly to express her joy. Elizabeth received her
+congratulations amongst the rest, and then, sick of this folly, took
+refuge in her own room, that she might think with freedom.
+
+Poor Lydia’s situation must, at best, be bad enough; but that it was
+no worse, she had need to be thankful. She felt it so; and though, in
+looking forward, neither rational happiness nor worldly prosperity could
+be justly expected for her sister, in looking back to what they had
+feared, only two hours ago, she felt all the advantages of what they had
+gained.
+
+
+
+Chapter 50
+
+
+Mr. Bennet had very often wished before this period of his life that,
+instead of spending his whole income, he had laid by an annual sum for
+the better provision of his children, and of his wife, if she survived
+him. He now wished it more than ever. Had he done his duty in that
+respect, Lydia need not have been indebted to her uncle for whatever
+of honour or credit could now be purchased for her. The satisfaction of
+prevailing on one of the most worthless young men in Great Britain to be
+her husband might then have rested in its proper place.
+
+He was seriously concerned that a cause of so little advantage to anyone
+should be forwarded at the sole expense of his brother-in-law, and he
+was determined, if possible, to find out the extent of his assistance,
+and to discharge the obligation as soon as he could.
+
+When first Mr. Bennet had married, economy was held to be perfectly
+useless, for, of course, they were to have a son. The son was to join
+in cutting off the entail, as soon as he should be of age, and the widow
+and younger children would by that means be provided for. Five daughters
+successively entered the world, but yet the son was to come; and Mrs.
+Bennet, for many years after Lydia’s birth, had been certain that he
+would. This event had at last been despaired of, but it was then
+too late to be saving. Mrs. Bennet had no turn for economy, and her
+husband’s love of independence had alone prevented their exceeding their
+income.
+
+Five thousand pounds was settled by marriage articles on Mrs. Bennet and
+the children. But in what proportions it should be divided amongst the
+latter depended on the will of the parents. This was one point, with
+regard to Lydia, at least, which was now to be settled, and Mr. Bennet
+could have no hesitation in acceding to the proposal before him. In
+terms of grateful acknowledgment for the kindness of his brother,
+though expressed most concisely, he then delivered on paper his perfect
+approbation of all that was done, and his willingness to fulfil the
+engagements that had been made for him. He had never before supposed
+that, could Wickham be prevailed on to marry his daughter, it would
+be done with so little inconvenience to himself as by the present
+arrangement. He would scarcely be ten pounds a year the loser by the
+hundred that was to be paid them; for, what with her board and pocket
+allowance, and the continual presents in money which passed to her
+through her mother’s hands, Lydia’s expenses had been very little within
+that sum.
+
+That it would be done with such trifling exertion on his side, too, was
+another very welcome surprise; for his wish at present was to have as
+little trouble in the business as possible. When the first transports
+of rage which had produced his activity in seeking her were over, he
+naturally returned to all his former indolence. His letter was soon
+dispatched; for, though dilatory in undertaking business, he was quick
+in its execution. He begged to know further particulars of what he
+was indebted to his brother, but was too angry with Lydia to send any
+message to her.
+
+The good news spread quickly through the house, and with proportionate
+speed through the neighbourhood. It was borne in the latter with decent
+philosophy. To be sure, it would have been more for the advantage
+of conversation had Miss Lydia Bennet come upon the town; or, as the
+happiest alternative, been secluded from the world, in some distant
+farmhouse. But there was much to be talked of in marrying her; and the
+good-natured wishes for her well-doing which had proceeded before from
+all the spiteful old ladies in Meryton lost but a little of their spirit
+in this change of circumstances, because with such an husband her misery
+was considered certain.
+
+It was a fortnight since Mrs. Bennet had been downstairs; but on this
+happy day she again took her seat at the head of her table, and in
+spirits oppressively high. No sentiment of shame gave a damp to her
+triumph. The marriage of a daughter, which had been the first object
+of her wishes since Jane was sixteen, was now on the point of
+accomplishment, and her thoughts and her words ran wholly on those
+attendants of elegant nuptials, fine muslins, new carriages, and
+servants. She was busily searching through the neighbourhood for a
+proper situation for her daughter, and, without knowing or considering
+what their income might be, rejected many as deficient in size and
+importance.
+
+“Haye Park might do,” said she, “if the Gouldings could quit it--or the
+great house at Stoke, if the drawing-room were larger; but Ashworth is
+too far off! I could not bear to have her ten miles from me; and as for
+Pulvis Lodge, the attics are dreadful.”
+
+Her husband allowed her to talk on without interruption while the
+servants remained. But when they had withdrawn, he said to her: “Mrs.
+Bennet, before you take any or all of these houses for your son and
+daughter, let us come to a right understanding. Into _one_ house in this
+neighbourhood they shall never have admittance. I will not encourage the
+impudence of either, by receiving them at Longbourn.”
+
+A long dispute followed this declaration; but Mr. Bennet was firm. It
+soon led to another; and Mrs. Bennet found, with amazement and horror,
+that her husband would not advance a guinea to buy clothes for his
+daughter. He protested that she should receive from him no mark of
+affection whatever on the occasion. Mrs. Bennet could hardly comprehend
+it. That his anger could be carried to such a point of inconceivable
+resentment as to refuse his daughter a privilege without which her
+marriage would scarcely seem valid, exceeded all she could believe
+possible. She was more alive to the disgrace which her want of new
+clothes must reflect on her daughter’s nuptials, than to any sense of
+shame at her eloping and living with Wickham a fortnight before they
+took place.
+
+Elizabeth was now most heartily sorry that she had, from the distress of
+the moment, been led to make Mr. Darcy acquainted with their fears for
+her sister; for since her marriage would so shortly give the
+proper termination to the elopement, they might hope to conceal its
+unfavourable beginning from all those who were not immediately on the
+spot.
+
+She had no fear of its spreading farther through his means. There were
+few people on whose secrecy she would have more confidently depended;
+but, at the same time, there was no one whose knowledge of a sister’s
+frailty would have mortified her so much--not, however, from any fear
+of disadvantage from it individually to herself, for, at any rate,
+there seemed a gulf impassable between them. Had Lydia’s marriage been
+concluded on the most honourable terms, it was not to be supposed that
+Mr. Darcy would connect himself with a family where, to every other
+objection, would now be added an alliance and relationship of the
+nearest kind with a man whom he so justly scorned.
+
+From such a connection she could not wonder that he would shrink. The
+wish of procuring her regard, which she had assured herself of his
+feeling in Derbyshire, could not in rational expectation survive such a
+blow as this. She was humbled, she was grieved; she repented, though she
+hardly knew of what. She became jealous of his esteem, when she could no
+longer hope to be benefited by it. She wanted to hear of him, when there
+seemed the least chance of gaining intelligence. She was convinced that
+she could have been happy with him, when it was no longer likely they
+should meet.
+
+What a triumph for him, as she often thought, could he know that the
+proposals which she had proudly spurned only four months ago, would now
+have been most gladly and gratefully received! He was as generous, she
+doubted not, as the most generous of his sex; but while he was mortal,
+there must be a triumph.
+
+She began now to comprehend that he was exactly the man who, in
+disposition and talents, would most suit her. His understanding and
+temper, though unlike her own, would have answered all her wishes. It
+was an union that must have been to the advantage of both; by her ease
+and liveliness, his mind might have been softened, his manners improved;
+and from his judgement, information, and knowledge of the world, she
+must have received benefit of greater importance.
+
+But no such happy marriage could now teach the admiring multitude what
+connubial felicity really was. An union of a different tendency, and
+precluding the possibility of the other, was soon to be formed in their
+family.
+
+How Wickham and Lydia were to be supported in tolerable independence,
+she could not imagine. But how little of permanent happiness could
+belong to a couple who were only brought together because their passions
+were stronger than their virtue, she could easily conjecture.
+
+                          * * * * *
+
+Mr. Gardiner soon wrote again to his brother. To Mr. Bennet’s
+acknowledgments he briefly replied, with assurance of his eagerness to
+promote the welfare of any of his family; and concluded with entreaties
+that the subject might never be mentioned to him again. The principal
+purport of his letter was to inform them that Mr. Wickham had resolved
+on quitting the militia.
+
+“It was greatly my wish that he should do so,” he added, “as soon as
+his marriage was fixed on. And I think you will agree with me, in
+considering the removal from that corps as highly advisable, both on
+his account and my niece’s. It is Mr. Wickham’s intention to go into
+the regulars; and among his former friends, there are still some who
+are able and willing to assist him in the army. He has the promise of an
+ensigncy in General ----‘s regiment, now quartered in the North. It
+is an advantage to have it so far from this part of the kingdom. He
+promises fairly; and I hope among different people, where they may each
+have a character to preserve, they will both be more prudent. I have
+written to Colonel Forster, to inform him of our present arrangements,
+and to request that he will satisfy the various creditors of Mr. Wickham
+in and near Brighton, with assurances of speedy payment, for which I
+have pledged myself. And will you give yourself the trouble of carrying
+similar assurances to his creditors in Meryton, of whom I shall subjoin
+a list according to his information? He has given in all his debts; I
+hope at least he has not deceived us. Haggerston has our directions,
+and all will be completed in a week. They will then join his regiment,
+unless they are first invited to Longbourn; and I understand from Mrs.
+Gardiner, that my niece is very desirous of seeing you all before she
+leaves the South. She is well, and begs to be dutifully remembered to
+you and her mother.--Yours, etc.,
+
+“E. GARDINER.”
+
+Mr. Bennet and his daughters saw all the advantages of Wickham’s removal
+from the ----shire as clearly as Mr. Gardiner could do. But Mrs. Bennet
+was not so well pleased with it. Lydia’s being settled in the North,
+just when she had expected most pleasure and pride in her company,
+for she had by no means given up her plan of their residing in
+Hertfordshire, was a severe disappointment; and, besides, it was such a
+pity that Lydia should be taken from a regiment where she was acquainted
+with everybody, and had so many favourites.
+
+“She is so fond of Mrs. Forster,” said she, “it will be quite shocking
+to send her away! And there are several of the young men, too, that she
+likes very much. The officers may not be so pleasant in General ----‘s
+regiment.”
+
+His daughter’s request, for such it might be considered, of being
+admitted into her family again before she set off for the North,
+received at first an absolute negative. But Jane and Elizabeth,
+who agreed in wishing, for the sake of their sister’s feelings and
+consequence, that she should be noticed on her marriage by her parents,
+urged him so earnestly yet so rationally and so mildly, to receive her
+and her husband at Longbourn, as soon as they were married, that he was
+prevailed on to think as they thought, and act as they wished. And their
+mother had the satisfaction of knowing that she would be able to show
+her married daughter in the neighbourhood before she was banished to the
+North. When Mr. Bennet wrote again to his brother, therefore, he sent
+his permission for them to come; and it was settled, that as soon as
+the ceremony was over, they should proceed to Longbourn. Elizabeth was
+surprised, however, that Wickham should consent to such a scheme, and
+had she consulted only her own inclination, any meeting with him would
+have been the last object of her wishes.
+
+
+
+Chapter 51
+
+
+Their sister’s wedding day arrived; and Jane and Elizabeth felt for her
+probably more than she felt for herself. The carriage was sent to
+meet them at ----, and they were to return in it by dinner-time. Their
+arrival was dreaded by the elder Miss Bennets, and Jane more especially,
+who gave Lydia the feelings which would have attended herself, had she
+been the culprit, and was wretched in the thought of what her sister
+must endure.
+
+They came. The family were assembled in the breakfast room to receive
+them. Smiles decked the face of Mrs. Bennet as the carriage drove up to
+the door; her husband looked impenetrably grave; her daughters, alarmed,
+anxious, uneasy.
+
+Lydia’s voice was heard in the vestibule; the door was thrown open, and
+she ran into the room. Her mother stepped forwards, embraced her, and
+welcomed her with rapture; gave her hand, with an affectionate smile,
+to Wickham, who followed his lady; and wished them both joy with an
+alacrity which shewed no doubt of their happiness.
+
+Their reception from Mr. Bennet, to whom they then turned, was not quite
+so cordial. His countenance rather gained in austerity; and he scarcely
+opened his lips. The easy assurance of the young couple, indeed, was
+enough to provoke him. Elizabeth was disgusted, and even Miss Bennet
+was shocked. Lydia was Lydia still; untamed, unabashed, wild, noisy,
+and fearless. She turned from sister to sister, demanding their
+congratulations; and when at length they all sat down, looked eagerly
+round the room, took notice of some little alteration in it, and
+observed, with a laugh, that it was a great while since she had been
+there.
+
+Wickham was not at all more distressed than herself, but his manners
+were always so pleasing, that had his character and his marriage been
+exactly what they ought, his smiles and his easy address, while he
+claimed their relationship, would have delighted them all. Elizabeth had
+not before believed him quite equal to such assurance; but she sat down,
+resolving within herself to draw no limits in future to the impudence
+of an impudent man. She blushed, and Jane blushed; but the cheeks of the
+two who caused their confusion suffered no variation of colour.
+
+There was no want of discourse. The bride and her mother could neither
+of them talk fast enough; and Wickham, who happened to sit near
+Elizabeth, began inquiring after his acquaintance in that neighbourhood,
+with a good humoured ease which she felt very unable to equal in her
+replies. They seemed each of them to have the happiest memories in the
+world. Nothing of the past was recollected with pain; and Lydia led
+voluntarily to subjects which her sisters would not have alluded to for
+the world.
+
+“Only think of its being three months,” she cried, “since I went away;
+it seems but a fortnight I declare; and yet there have been things
+enough happened in the time. Good gracious! when I went away, I am sure
+I had no more idea of being married till I came back again! though I
+thought it would be very good fun if I was.”
+
+Her father lifted up his eyes. Jane was distressed. Elizabeth looked
+expressively at Lydia; but she, who never heard nor saw anything of
+which she chose to be insensible, gaily continued, “Oh! mamma, do the
+people hereabouts know I am married to-day? I was afraid they might not;
+and we overtook William Goulding in his curricle, so I was determined he
+should know it, and so I let down the side-glass next to him, and took
+off my glove, and let my hand just rest upon the window frame, so that
+he might see the ring, and then I bowed and smiled like anything.”
+
+Elizabeth could bear it no longer. She got up, and ran out of the room;
+and returned no more, till she heard them passing through the hall to
+the dining parlour. She then joined them soon enough to see Lydia, with
+anxious parade, walk up to her mother’s right hand, and hear her say
+to her eldest sister, “Ah! Jane, I take your place now, and you must go
+lower, because I am a married woman.”
+
+It was not to be supposed that time would give Lydia that embarrassment
+from which she had been so wholly free at first. Her ease and good
+spirits increased. She longed to see Mrs. Phillips, the Lucases, and
+all their other neighbours, and to hear herself called “Mrs. Wickham”
+ by each of them; and in the mean time, she went after dinner to show her
+ring, and boast of being married, to Mrs. Hill and the two housemaids.
+
+“Well, mamma,” said she, when they were all returned to the breakfast
+room, “and what do you think of my husband? Is not he a charming man? I
+am sure my sisters must all envy me. I only hope they may have half
+my good luck. They must all go to Brighton. That is the place to get
+husbands. What a pity it is, mamma, we did not all go.”
+
+“Very true; and if I had my will, we should. But my dear Lydia, I don’t
+at all like your going such a way off. Must it be so?”
+
+“Oh, lord! yes;--there is nothing in that. I shall like it of all
+things. You and papa, and my sisters, must come down and see us. We
+shall be at Newcastle all the winter, and I dare say there will be some
+balls, and I will take care to get good partners for them all.”
+
+“I should like it beyond anything!” said her mother.
+
+“And then when you go away, you may leave one or two of my sisters
+behind you; and I dare say I shall get husbands for them before the
+winter is over.”
+
+“I thank you for my share of the favour,” said Elizabeth; “but I do not
+particularly like your way of getting husbands.”
+
+Their visitors were not to remain above ten days with them. Mr. Wickham
+had received his commission before he left London, and he was to join
+his regiment at the end of a fortnight.
+
+No one but Mrs. Bennet regretted that their stay would be so short; and
+she made the most of the time by visiting about with her daughter, and
+having very frequent parties at home. These parties were acceptable to
+all; to avoid a family circle was even more desirable to such as did
+think, than such as did not.
+
+Wickham’s affection for Lydia was just what Elizabeth had expected
+to find it; not equal to Lydia’s for him. She had scarcely needed her
+present observation to be satisfied, from the reason of things, that
+their elopement had been brought on by the strength of her love, rather
+than by his; and she would have wondered why, without violently caring
+for her, he chose to elope with her at all, had she not felt certain
+that his flight was rendered necessary by distress of circumstances; and
+if that were the case, he was not the young man to resist an opportunity
+of having a companion.
+
+Lydia was exceedingly fond of him. He was her dear Wickham on every
+occasion; no one was to be put in competition with him. He did every
+thing best in the world; and she was sure he would kill more birds on
+the first of September, than any body else in the country.
+
+One morning, soon after their arrival, as she was sitting with her two
+elder sisters, she said to Elizabeth:
+
+“Lizzy, I never gave _you_ an account of my wedding, I believe. You
+were not by, when I told mamma and the others all about it. Are not you
+curious to hear how it was managed?”
+
+“No really,” replied Elizabeth; “I think there cannot be too little said
+on the subject.”
+
+“La! You are so strange! But I must tell you how it went off. We were
+married, you know, at St. Clement’s, because Wickham’s lodgings were in
+that parish. And it was settled that we should all be there by eleven
+o’clock. My uncle and aunt and I were to go together; and the others
+were to meet us at the church. Well, Monday morning came, and I was in
+such a fuss! I was so afraid, you know, that something would happen to
+put it off, and then I should have gone quite distracted. And there was
+my aunt, all the time I was dressing, preaching and talking away just as
+if she was reading a sermon. However, I did not hear above one word in
+ten, for I was thinking, you may suppose, of my dear Wickham. I longed
+to know whether he would be married in his blue coat.”
+
+“Well, and so we breakfasted at ten as usual; I thought it would never
+be over; for, by the bye, you are to understand, that my uncle and aunt
+were horrid unpleasant all the time I was with them. If you’ll believe
+me, I did not once put my foot out of doors, though I was there a
+fortnight. Not one party, or scheme, or anything. To be sure London was
+rather thin, but, however, the Little Theatre was open. Well, and so
+just as the carriage came to the door, my uncle was called away upon
+business to that horrid man Mr. Stone. And then, you know, when once
+they get together, there is no end of it. Well, I was so frightened I
+did not know what to do, for my uncle was to give me away; and if we
+were beyond the hour, we could not be married all day. But, luckily, he
+came back again in ten minutes’ time, and then we all set out. However,
+I recollected afterwards that if he had been prevented going, the
+wedding need not be put off, for Mr. Darcy might have done as well.”
+
+“Mr. Darcy!” repeated Elizabeth, in utter amazement.
+
+“Oh, yes!--he was to come there with Wickham, you know. But gracious
+me! I quite forgot! I ought not to have said a word about it. I promised
+them so faithfully! What will Wickham say? It was to be such a secret!”
+
+“If it was to be secret,” said Jane, “say not another word on the
+subject. You may depend upon my seeking no further.”
+
+“Oh! certainly,” said Elizabeth, though burning with curiosity; “we will
+ask you no questions.”
+
+“Thank you,” said Lydia, “for if you did, I should certainly tell you
+all, and then Wickham would be angry.”
+
+On such encouragement to ask, Elizabeth was forced to put it out of her
+power, by running away.
+
+But to live in ignorance on such a point was impossible; or at least
+it was impossible not to try for information. Mr. Darcy had been at
+her sister’s wedding. It was exactly a scene, and exactly among people,
+where he had apparently least to do, and least temptation to go.
+Conjectures as to the meaning of it, rapid and wild, hurried into her
+brain; but she was satisfied with none. Those that best pleased her, as
+placing his conduct in the noblest light, seemed most improbable. She
+could not bear such suspense; and hastily seizing a sheet of paper,
+wrote a short letter to her aunt, to request an explanation of what
+Lydia had dropt, if it were compatible with the secrecy which had been
+intended.
+
+“You may readily comprehend,” she added, “what my curiosity must be
+to know how a person unconnected with any of us, and (comparatively
+speaking) a stranger to our family, should have been amongst you at such
+a time. Pray write instantly, and let me understand it--unless it is,
+for very cogent reasons, to remain in the secrecy which Lydia seems
+to think necessary; and then I must endeavour to be satisfied with
+ignorance.”
+
+“Not that I _shall_, though,” she added to herself, as she finished
+the letter; “and my dear aunt, if you do not tell me in an honourable
+manner, I shall certainly be reduced to tricks and stratagems to find it
+out.”
+
+Jane’s delicate sense of honour would not allow her to speak to
+Elizabeth privately of what Lydia had let fall; Elizabeth was glad
+of it;--till it appeared whether her inquiries would receive any
+satisfaction, she had rather be without a confidante.
+
+
+
+Chapter 52
+
+
+Elizabeth had the satisfaction of receiving an answer to her letter as
+soon as she possibly could. She was no sooner in possession of it
+than, hurrying into the little copse, where she was least likely to
+be interrupted, she sat down on one of the benches and prepared to
+be happy; for the length of the letter convinced her that it did not
+contain a denial.
+
+“Gracechurch street, Sept. 6.
+
+“MY DEAR NIECE,
+
+“I have just received your letter, and shall devote this whole morning
+to answering it, as I foresee that a _little_ writing will not comprise
+what I have to tell you. I must confess myself surprised by your
+application; I did not expect it from _you_. Don’t think me angry,
+however, for I only mean to let you know that I had not imagined such
+inquiries to be necessary on _your_ side. If you do not choose to
+understand me, forgive my impertinence. Your uncle is as much surprised
+as I am--and nothing but the belief of your being a party concerned
+would have allowed him to act as he has done. But if you are really
+innocent and ignorant, I must be more explicit.
+
+“On the very day of my coming home from Longbourn, your uncle had a most
+unexpected visitor. Mr. Darcy called, and was shut up with him several
+hours. It was all over before I arrived; so my curiosity was not so
+dreadfully racked as _yours_ seems to have been. He came to tell Mr.
+Gardiner that he had found out where your sister and Mr. Wickham were,
+and that he had seen and talked with them both; Wickham repeatedly,
+Lydia once. From what I can collect, he left Derbyshire only one day
+after ourselves, and came to town with the resolution of hunting for
+them. The motive professed was his conviction of its being owing to
+himself that Wickham’s worthlessness had not been so well known as to
+make it impossible for any young woman of character to love or confide
+in him. He generously imputed the whole to his mistaken pride, and
+confessed that he had before thought it beneath him to lay his private
+actions open to the world. His character was to speak for itself. He
+called it, therefore, his duty to step forward, and endeavour to remedy
+an evil which had been brought on by himself. If he _had another_
+motive, I am sure it would never disgrace him. He had been some days
+in town, before he was able to discover them; but he had something to
+direct his search, which was more than _we_ had; and the consciousness
+of this was another reason for his resolving to follow us.
+
+“There is a lady, it seems, a Mrs. Younge, who was some time ago
+governess to Miss Darcy, and was dismissed from her charge on some cause
+of disapprobation, though he did not say what. She then took a large
+house in Edward-street, and has since maintained herself by letting
+lodgings. This Mrs. Younge was, he knew, intimately acquainted with
+Wickham; and he went to her for intelligence of him as soon as he got to
+town. But it was two or three days before he could get from her what he
+wanted. She would not betray her trust, I suppose, without bribery and
+corruption, for she really did know where her friend was to be found.
+Wickham indeed had gone to her on their first arrival in London, and had
+she been able to receive them into her house, they would have taken up
+their abode with her. At length, however, our kind friend procured the
+wished-for direction. They were in ---- street. He saw Wickham, and
+afterwards insisted on seeing Lydia. His first object with her, he
+acknowledged, had been to persuade her to quit her present disgraceful
+situation, and return to her friends as soon as they could be prevailed
+on to receive her, offering his assistance, as far as it would go. But
+he found Lydia absolutely resolved on remaining where she was. She cared
+for none of her friends; she wanted no help of his; she would not hear
+of leaving Wickham. She was sure they should be married some time or
+other, and it did not much signify when. Since such were her feelings,
+it only remained, he thought, to secure and expedite a marriage, which,
+in his very first conversation with Wickham, he easily learnt had never
+been _his_ design. He confessed himself obliged to leave the regiment,
+on account of some debts of honour, which were very pressing; and
+scrupled not to lay all the ill-consequences of Lydia’s flight on her
+own folly alone. He meant to resign his commission immediately; and as
+to his future situation, he could conjecture very little about it. He
+must go somewhere, but he did not know where, and he knew he should have
+nothing to live on.
+
+“Mr. Darcy asked him why he had not married your sister at once. Though
+Mr. Bennet was not imagined to be very rich, he would have been able
+to do something for him, and his situation must have been benefited by
+marriage. But he found, in reply to this question, that Wickham still
+cherished the hope of more effectually making his fortune by marriage in
+some other country. Under such circumstances, however, he was not likely
+to be proof against the temptation of immediate relief.
+
+“They met several times, for there was much to be discussed. Wickham of
+course wanted more than he could get; but at length was reduced to be
+reasonable.
+
+“Every thing being settled between _them_, Mr. Darcy’s next step was to
+make your uncle acquainted with it, and he first called in Gracechurch
+street the evening before I came home. But Mr. Gardiner could not be
+seen, and Mr. Darcy found, on further inquiry, that your father was
+still with him, but would quit town the next morning. He did not judge
+your father to be a person whom he could so properly consult as your
+uncle, and therefore readily postponed seeing him till after the
+departure of the former. He did not leave his name, and till the next
+day it was only known that a gentleman had called on business.
+
+“On Saturday he came again. Your father was gone, your uncle at home,
+and, as I said before, they had a great deal of talk together.
+
+“They met again on Sunday, and then _I_ saw him too. It was not all
+settled before Monday: as soon as it was, the express was sent off to
+Longbourn. But our visitor was very obstinate. I fancy, Lizzy, that
+obstinacy is the real defect of his character, after all. He has been
+accused of many faults at different times, but _this_ is the true one.
+Nothing was to be done that he did not do himself; though I am sure (and
+I do not speak it to be thanked, therefore say nothing about it), your
+uncle would most readily have settled the whole.
+
+“They battled it together for a long time, which was more than either
+the gentleman or lady concerned in it deserved. But at last your uncle
+was forced to yield, and instead of being allowed to be of use to his
+niece, was forced to put up with only having the probable credit of it,
+which went sorely against the grain; and I really believe your letter
+this morning gave him great pleasure, because it required an explanation
+that would rob him of his borrowed feathers, and give the praise where
+it was due. But, Lizzy, this must go no farther than yourself, or Jane
+at most.
+
+“You know pretty well, I suppose, what has been done for the young
+people. His debts are to be paid, amounting, I believe, to considerably
+more than a thousand pounds, another thousand in addition to her own
+settled upon _her_, and his commission purchased. The reason why all
+this was to be done by him alone, was such as I have given above. It
+was owing to him, to his reserve and want of proper consideration, that
+Wickham’s character had been so misunderstood, and consequently that he
+had been received and noticed as he was. Perhaps there was some truth
+in _this_; though I doubt whether _his_ reserve, or _anybody’s_ reserve,
+can be answerable for the event. But in spite of all this fine talking,
+my dear Lizzy, you may rest perfectly assured that your uncle would
+never have yielded, if we had not given him credit for _another
+interest_ in the affair.
+
+“When all this was resolved on, he returned again to his friends, who
+were still staying at Pemberley; but it was agreed that he should be in
+London once more when the wedding took place, and all money matters were
+then to receive the last finish.
+
+“I believe I have now told you every thing. It is a relation which
+you tell me is to give you great surprise; I hope at least it will not
+afford you any displeasure. Lydia came to us; and Wickham had constant
+admission to the house. _He_ was exactly what he had been, when I
+knew him in Hertfordshire; but I would not tell you how little I was
+satisfied with her behaviour while she staid with us, if I had not
+perceived, by Jane’s letter last Wednesday, that her conduct on coming
+home was exactly of a piece with it, and therefore what I now tell
+you can give you no fresh pain. I talked to her repeatedly in the most
+serious manner, representing to her all the wickedness of what she had
+done, and all the unhappiness she had brought on her family. If she
+heard me, it was by good luck, for I am sure she did not listen. I was
+sometimes quite provoked, but then I recollected my dear Elizabeth and
+Jane, and for their sakes had patience with her.
+
+“Mr. Darcy was punctual in his return, and as Lydia informed you,
+attended the wedding. He dined with us the next day, and was to leave
+town again on Wednesday or Thursday. Will you be very angry with me, my
+dear Lizzy, if I take this opportunity of saying (what I was never bold
+enough to say before) how much I like him. His behaviour to us has,
+in every respect, been as pleasing as when we were in Derbyshire. His
+understanding and opinions all please me; he wants nothing but a little
+more liveliness, and _that_, if he marry _prudently_, his wife may teach
+him. I thought him very sly;--he hardly ever mentioned your name. But
+slyness seems the fashion.
+
+“Pray forgive me if I have been very presuming, or at least do not
+punish me so far as to exclude me from P. I shall never be quite happy
+till I have been all round the park. A low phaeton, with a nice little
+pair of ponies, would be the very thing.
+
+“But I must write no more. The children have been wanting me this half
+hour.
+
+“Yours, very sincerely,
+
+“M. GARDINER.”
+
+The contents of this letter threw Elizabeth into a flutter of spirits,
+in which it was difficult to determine whether pleasure or pain bore the
+greatest share. The vague and unsettled suspicions which uncertainty had
+produced of what Mr. Darcy might have been doing to forward her sister’s
+match, which she had feared to encourage as an exertion of goodness too
+great to be probable, and at the same time dreaded to be just, from the
+pain of obligation, were proved beyond their greatest extent to be true!
+He had followed them purposely to town, he had taken on himself all
+the trouble and mortification attendant on such a research; in which
+supplication had been necessary to a woman whom he must abominate and
+despise, and where he was reduced to meet, frequently meet, reason
+with, persuade, and finally bribe, the man whom he always most wished to
+avoid, and whose very name it was punishment to him to pronounce. He had
+done all this for a girl whom he could neither regard nor esteem. Her
+heart did whisper that he had done it for her. But it was a hope shortly
+checked by other considerations, and she soon felt that even her vanity
+was insufficient, when required to depend on his affection for her--for
+a woman who had already refused him--as able to overcome a sentiment so
+natural as abhorrence against relationship with Wickham. Brother-in-law
+of Wickham! Every kind of pride must revolt from the connection. He had,
+to be sure, done much. She was ashamed to think how much. But he had
+given a reason for his interference, which asked no extraordinary
+stretch of belief. It was reasonable that he should feel he had been
+wrong; he had liberality, and he had the means of exercising it; and
+though she would not place herself as his principal inducement, she
+could, perhaps, believe that remaining partiality for her might assist
+his endeavours in a cause where her peace of mind must be materially
+concerned. It was painful, exceedingly painful, to know that they were
+under obligations to a person who could never receive a return. They
+owed the restoration of Lydia, her character, every thing, to him. Oh!
+how heartily did she grieve over every ungracious sensation she had ever
+encouraged, every saucy speech she had ever directed towards him. For
+herself she was humbled; but she was proud of him. Proud that in a cause
+of compassion and honour, he had been able to get the better of himself.
+She read over her aunt’s commendation of him again and again. It
+was hardly enough; but it pleased her. She was even sensible of some
+pleasure, though mixed with regret, on finding how steadfastly both she
+and her uncle had been persuaded that affection and confidence subsisted
+between Mr. Darcy and herself.
+
+She was roused from her seat, and her reflections, by some one’s
+approach; and before she could strike into another path, she was
+overtaken by Wickham.
+
+“I am afraid I interrupt your solitary ramble, my dear sister?” said he,
+as he joined her.
+
+“You certainly do,” she replied with a smile; “but it does not follow
+that the interruption must be unwelcome.”
+
+“I should be sorry indeed, if it were. We were always good friends; and
+now we are better.”
+
+“True. Are the others coming out?”
+
+“I do not know. Mrs. Bennet and Lydia are going in the carriage to
+Meryton. And so, my dear sister, I find, from our uncle and aunt, that
+you have actually seen Pemberley.”
+
+She replied in the affirmative.
+
+“I almost envy you the pleasure, and yet I believe it would be too much
+for me, or else I could take it in my way to Newcastle. And you saw the
+old housekeeper, I suppose? Poor Reynolds, she was always very fond of
+me. But of course she did not mention my name to you.”
+
+“Yes, she did.”
+
+“And what did she say?”
+
+“That you were gone into the army, and she was afraid had--not turned
+out well. At such a distance as _that_, you know, things are strangely
+misrepresented.”
+
+“Certainly,” he replied, biting his lips. Elizabeth hoped she had
+silenced him; but he soon afterwards said:
+
+“I was surprised to see Darcy in town last month. We passed each other
+several times. I wonder what he can be doing there.”
+
+“Perhaps preparing for his marriage with Miss de Bourgh,” said
+Elizabeth. “It must be something particular, to take him there at this
+time of year.”
+
+“Undoubtedly. Did you see him while you were at Lambton? I thought I
+understood from the Gardiners that you had.”
+
+“Yes; he introduced us to his sister.”
+
+“And do you like her?”
+
+“Very much.”
+
+“I have heard, indeed, that she is uncommonly improved within this year
+or two. When I last saw her, she was not very promising. I am very glad
+you liked her. I hope she will turn out well.”
+
+“I dare say she will; she has got over the most trying age.”
+
+“Did you go by the village of Kympton?”
+
+“I do not recollect that we did.”
+
+“I mention it, because it is the living which I ought to have had. A
+most delightful place!--Excellent Parsonage House! It would have suited
+me in every respect.”
+
+“How should you have liked making sermons?”
+
+“Exceedingly well. I should have considered it as part of my duty,
+and the exertion would soon have been nothing. One ought not to
+repine;--but, to be sure, it would have been such a thing for me! The
+quiet, the retirement of such a life would have answered all my ideas
+of happiness! But it was not to be. Did you ever hear Darcy mention the
+circumstance, when you were in Kent?”
+
+“I have heard from authority, which I thought _as good_, that it was
+left you conditionally only, and at the will of the present patron.”
+
+“You have. Yes, there was something in _that_; I told you so from the
+first, you may remember.”
+
+“I _did_ hear, too, that there was a time, when sermon-making was not
+so palatable to you as it seems to be at present; that you actually
+declared your resolution of never taking orders, and that the business
+had been compromised accordingly.”
+
+“You did! and it was not wholly without foundation. You may remember
+what I told you on that point, when first we talked of it.”
+
+They were now almost at the door of the house, for she had walked fast
+to get rid of him; and unwilling, for her sister’s sake, to provoke him,
+she only said in reply, with a good-humoured smile:
+
+“Come, Mr. Wickham, we are brother and sister, you know. Do not let
+us quarrel about the past. In future, I hope we shall be always of one
+mind.”
+
+She held out her hand; he kissed it with affectionate gallantry, though
+he hardly knew how to look, and they entered the house.
+
+
+
+Chapter 53
+
+
+Mr. Wickham was so perfectly satisfied with this conversation that he
+never again distressed himself, or provoked his dear sister Elizabeth,
+by introducing the subject of it; and she was pleased to find that she
+had said enough to keep him quiet.
+
+The day of his and Lydia’s departure soon came, and Mrs. Bennet was
+forced to submit to a separation, which, as her husband by no means
+entered into her scheme of their all going to Newcastle, was likely to
+continue at least a twelvemonth.
+
+“Oh! my dear Lydia,” she cried, “when shall we meet again?”
+
+“Oh, lord! I don’t know. Not these two or three years, perhaps.”
+
+“Write to me very often, my dear.”
+
+“As often as I can. But you know married women have never much time for
+writing. My sisters may write to _me_. They will have nothing else to
+do.”
+
+Mr. Wickham’s adieus were much more affectionate than his wife’s. He
+smiled, looked handsome, and said many pretty things.
+
+“He is as fine a fellow,” said Mr. Bennet, as soon as they were out of
+the house, “as ever I saw. He simpers, and smirks, and makes love to
+us all. I am prodigiously proud of him. I defy even Sir William Lucas
+himself to produce a more valuable son-in-law.”
+
+The loss of her daughter made Mrs. Bennet very dull for several days.
+
+“I often think,” said she, “that there is nothing so bad as parting with
+one’s friends. One seems so forlorn without them.”
+
+“This is the consequence, you see, Madam, of marrying a daughter,” said
+Elizabeth. “It must make you better satisfied that your other four are
+single.”
+
+“It is no such thing. Lydia does not leave me because she is married,
+but only because her husband’s regiment happens to be so far off. If
+that had been nearer, she would not have gone so soon.”
+
+But the spiritless condition which this event threw her into was shortly
+relieved, and her mind opened again to the agitation of hope, by an
+article of news which then began to be in circulation. The housekeeper
+at Netherfield had received orders to prepare for the arrival of her
+master, who was coming down in a day or two, to shoot there for several
+weeks. Mrs. Bennet was quite in the fidgets. She looked at Jane, and
+smiled and shook her head by turns.
+
+“Well, well, and so Mr. Bingley is coming down, sister,” (for Mrs.
+Phillips first brought her the news). “Well, so much the better. Not
+that I care about it, though. He is nothing to us, you know, and I am
+sure _I_ never want to see him again. But, however, he is very welcome
+to come to Netherfield, if he likes it. And who knows what _may_ happen?
+But that is nothing to us. You know, sister, we agreed long ago never to
+mention a word about it. And so, is it quite certain he is coming?”
+
+“You may depend on it,” replied the other, “for Mrs. Nicholls was in
+Meryton last night; I saw her passing by, and went out myself on purpose
+to know the truth of it; and she told me that it was certain true. He
+comes down on Thursday at the latest, very likely on Wednesday. She was
+going to the butcher’s, she told me, on purpose to order in some meat on
+Wednesday, and she has got three couple of ducks just fit to be killed.”
+
+Miss Bennet had not been able to hear of his coming without changing
+colour. It was many months since she had mentioned his name to
+Elizabeth; but now, as soon as they were alone together, she said:
+
+“I saw you look at me to-day, Lizzy, when my aunt told us of the present
+report; and I know I appeared distressed. But don’t imagine it was from
+any silly cause. I was only confused for the moment, because I felt that
+I _should_ be looked at. I do assure you that the news does not affect
+me either with pleasure or pain. I am glad of one thing, that he comes
+alone; because we shall see the less of him. Not that I am afraid of
+_myself_, but I dread other people’s remarks.”
+
+Elizabeth did not know what to make of it. Had she not seen him in
+Derbyshire, she might have supposed him capable of coming there with no
+other view than what was acknowledged; but she still thought him partial
+to Jane, and she wavered as to the greater probability of his coming
+there _with_ his friend’s permission, or being bold enough to come
+without it.
+
+“Yet it is hard,” she sometimes thought, “that this poor man cannot
+come to a house which he has legally hired, without raising all this
+speculation! I _will_ leave him to himself.”
+
+In spite of what her sister declared, and really believed to be her
+feelings in the expectation of his arrival, Elizabeth could easily
+perceive that her spirits were affected by it. They were more disturbed,
+more unequal, than she had often seen them.
+
+The subject which had been so warmly canvassed between their parents,
+about a twelvemonth ago, was now brought forward again.
+
+“As soon as ever Mr. Bingley comes, my dear,” said Mrs. Bennet, “you
+will wait on him of course.”
+
+“No, no. You forced me into visiting him last year, and promised, if I
+went to see him, he should marry one of my daughters. But it ended in
+nothing, and I will not be sent on a fool’s errand again.”
+
+His wife represented to him how absolutely necessary such an attention
+would be from all the neighbouring gentlemen, on his returning to
+Netherfield.
+
+“‘Tis an etiquette I despise,” said he. “If he wants our society,
+let him seek it. He knows where we live. I will not spend my hours
+in running after my neighbours every time they go away and come back
+again.”
+
+“Well, all I know is, that it will be abominably rude if you do not wait
+on him. But, however, that shan’t prevent my asking him to dine here, I
+am determined. We must have Mrs. Long and the Gouldings soon. That will
+make thirteen with ourselves, so there will be just room at table for
+him.”
+
+Consoled by this resolution, she was the better able to bear her
+husband’s incivility; though it was very mortifying to know that her
+neighbours might all see Mr. Bingley, in consequence of it, before
+_they_ did. As the day of his arrival drew near,--
+
+“I begin to be sorry that he comes at all,” said Jane to her sister. “It
+would be nothing; I could see him with perfect indifference, but I can
+hardly bear to hear it thus perpetually talked of. My mother means well;
+but she does not know, no one can know, how much I suffer from what she
+says. Happy shall I be, when his stay at Netherfield is over!”
+
+“I wish I could say anything to comfort you,” replied Elizabeth; “but it
+is wholly out of my power. You must feel it; and the usual satisfaction
+of preaching patience to a sufferer is denied me, because you have
+always so much.”
+
+Mr. Bingley arrived. Mrs. Bennet, through the assistance of servants,
+contrived to have the earliest tidings of it, that the period of anxiety
+and fretfulness on her side might be as long as it could. She counted
+the days that must intervene before their invitation could be sent;
+hopeless of seeing him before. But on the third morning after his
+arrival in Hertfordshire, she saw him, from her dressing-room window,
+enter the paddock and ride towards the house.
+
+Her daughters were eagerly called to partake of her joy. Jane resolutely
+kept her place at the table; but Elizabeth, to satisfy her mother, went
+to the window--she looked,--she saw Mr. Darcy with him, and sat down
+again by her sister.
+
+“There is a gentleman with him, mamma,” said Kitty; “who can it be?”
+
+“Some acquaintance or other, my dear, I suppose; I am sure I do not
+know.”
+
+“La!” replied Kitty, “it looks just like that man that used to be with
+him before. Mr. what’s-his-name. That tall, proud man.”
+
+“Good gracious! Mr. Darcy!--and so it does, I vow. Well, any friend of
+Mr. Bingley’s will always be welcome here, to be sure; but else I must
+say that I hate the very sight of him.”
+
+Jane looked at Elizabeth with surprise and concern. She knew but little
+of their meeting in Derbyshire, and therefore felt for the awkwardness
+which must attend her sister, in seeing him almost for the first time
+after receiving his explanatory letter. Both sisters were uncomfortable
+enough. Each felt for the other, and of course for themselves; and their
+mother talked on, of her dislike of Mr. Darcy, and her resolution to be
+civil to him only as Mr. Bingley’s friend, without being heard by either
+of them. But Elizabeth had sources of uneasiness which could not be
+suspected by Jane, to whom she had never yet had courage to shew Mrs.
+Gardiner’s letter, or to relate her own change of sentiment towards him.
+To Jane, he could be only a man whose proposals she had refused,
+and whose merit she had undervalued; but to her own more extensive
+information, he was the person to whom the whole family were indebted
+for the first of benefits, and whom she regarded herself with an
+interest, if not quite so tender, at least as reasonable and just as
+what Jane felt for Bingley. Her astonishment at his coming--at his
+coming to Netherfield, to Longbourn, and voluntarily seeking her again,
+was almost equal to what she had known on first witnessing his altered
+behaviour in Derbyshire.
+
+The colour which had been driven from her face, returned for half a
+minute with an additional glow, and a smile of delight added lustre to
+her eyes, as she thought for that space of time that his affection and
+wishes must still be unshaken. But she would not be secure.
+
+“Let me first see how he behaves,” said she; “it will then be early
+enough for expectation.”
+
+She sat intently at work, striving to be composed, and without daring to
+lift up her eyes, till anxious curiosity carried them to the face of
+her sister as the servant was approaching the door. Jane looked a little
+paler than usual, but more sedate than Elizabeth had expected. On the
+gentlemen’s appearing, her colour increased; yet she received them with
+tolerable ease, and with a propriety of behaviour equally free from any
+symptom of resentment or any unnecessary complaisance.
+
+Elizabeth said as little to either as civility would allow, and sat down
+again to her work, with an eagerness which it did not often command. She
+had ventured only one glance at Darcy. He looked serious, as usual; and,
+she thought, more as he had been used to look in Hertfordshire, than as
+she had seen him at Pemberley. But, perhaps he could not in her mother’s
+presence be what he was before her uncle and aunt. It was a painful, but
+not an improbable, conjecture.
+
+Bingley, she had likewise seen for an instant, and in that short period
+saw him looking both pleased and embarrassed. He was received by Mrs.
+Bennet with a degree of civility which made her two daughters ashamed,
+especially when contrasted with the cold and ceremonious politeness of
+her curtsey and address to his friend.
+
+Elizabeth, particularly, who knew that her mother owed to the latter
+the preservation of her favourite daughter from irremediable infamy,
+was hurt and distressed to a most painful degree by a distinction so ill
+applied.
+
+Darcy, after inquiring of her how Mr. and Mrs. Gardiner did, a question
+which she could not answer without confusion, said scarcely anything. He
+was not seated by her; perhaps that was the reason of his silence; but
+it had not been so in Derbyshire. There he had talked to her friends,
+when he could not to herself. But now several minutes elapsed without
+bringing the sound of his voice; and when occasionally, unable to resist
+the impulse of curiosity, she raised her eyes to his face, she as often
+found him looking at Jane as at herself, and frequently on no object but
+the ground. More thoughtfulness and less anxiety to please, than when
+they last met, were plainly expressed. She was disappointed, and angry
+with herself for being so.
+
+“Could I expect it to be otherwise!” said she. “Yet why did he come?”
+
+She was in no humour for conversation with anyone but himself; and to
+him she had hardly courage to speak.
+
+She inquired after his sister, but could do no more.
+
+“It is a long time, Mr. Bingley, since you went away,” said Mrs. Bennet.
+
+He readily agreed to it.
+
+“I began to be afraid you would never come back again. People _did_ say
+you meant to quit the place entirely at Michaelmas; but, however, I hope
+it is not true. A great many changes have happened in the neighbourhood,
+since you went away. Miss Lucas is married and settled. And one of my
+own daughters. I suppose you have heard of it; indeed, you must have
+seen it in the papers. It was in The Times and The Courier, I know;
+though it was not put in as it ought to be. It was only said, ‘Lately,
+George Wickham, Esq. to Miss Lydia Bennet,’ without there being a
+syllable said of her father, or the place where she lived, or anything.
+It was my brother Gardiner’s drawing up too, and I wonder how he came to
+make such an awkward business of it. Did you see it?”
+
+Bingley replied that he did, and made his congratulations. Elizabeth
+dared not lift up her eyes. How Mr. Darcy looked, therefore, she could
+not tell.
+
+“It is a delightful thing, to be sure, to have a daughter well married,”
+ continued her mother, “but at the same time, Mr. Bingley, it is very
+hard to have her taken such a way from me. They are gone down to
+Newcastle, a place quite northward, it seems, and there they are to stay
+I do not know how long. His regiment is there; for I suppose you have
+heard of his leaving the ----shire, and of his being gone into the
+regulars. Thank Heaven! he has _some_ friends, though perhaps not so
+many as he deserves.”
+
+Elizabeth, who knew this to be levelled at Mr. Darcy, was in such
+misery of shame, that she could hardly keep her seat. It drew from her,
+however, the exertion of speaking, which nothing else had so effectually
+done before; and she asked Bingley whether he meant to make any stay in
+the country at present. A few weeks, he believed.
+
+“When you have killed all your own birds, Mr. Bingley,” said her mother,
+“I beg you will come here, and shoot as many as you please on Mr.
+Bennet’s manor. I am sure he will be vastly happy to oblige you, and
+will save all the best of the covies for you.”
+
+Elizabeth’s misery increased, at such unnecessary, such officious
+attention! Were the same fair prospect to arise at present as had
+flattered them a year ago, every thing, she was persuaded, would be
+hastening to the same vexatious conclusion. At that instant, she felt
+that years of happiness could not make Jane or herself amends for
+moments of such painful confusion.
+
+“The first wish of my heart,” said she to herself, “is never more to
+be in company with either of them. Their society can afford no pleasure
+that will atone for such wretchedness as this! Let me never see either
+one or the other again!”
+
+Yet the misery, for which years of happiness were to offer no
+compensation, received soon afterwards material relief, from observing
+how much the beauty of her sister re-kindled the admiration of her
+former lover. When first he came in, he had spoken to her but little;
+but every five minutes seemed to be giving her more of his attention. He
+found her as handsome as she had been last year; as good natured, and
+as unaffected, though not quite so chatty. Jane was anxious that no
+difference should be perceived in her at all, and was really persuaded
+that she talked as much as ever. But her mind was so busily engaged,
+that she did not always know when she was silent.
+
+When the gentlemen rose to go away, Mrs. Bennet was mindful of her
+intended civility, and they were invited and engaged to dine at
+Longbourn in a few days time.
+
+“You are quite a visit in my debt, Mr. Bingley,” she added, “for when
+you went to town last winter, you promised to take a family dinner with
+us, as soon as you returned. I have not forgot, you see; and I assure
+you, I was very much disappointed that you did not come back and keep
+your engagement.”
+
+Bingley looked a little silly at this reflection, and said something of
+his concern at having been prevented by business. They then went away.
+
+Mrs. Bennet had been strongly inclined to ask them to stay and dine
+there that day; but, though she always kept a very good table, she did
+not think anything less than two courses could be good enough for a man
+on whom she had such anxious designs, or satisfy the appetite and pride
+of one who had ten thousand a year.
+
+
+
+Chapter 54
+
+
+As soon as they were gone, Elizabeth walked out to recover her spirits;
+or in other words, to dwell without interruption on those subjects that
+must deaden them more. Mr. Darcy’s behaviour astonished and vexed her.
+
+“Why, if he came only to be silent, grave, and indifferent,” said she,
+“did he come at all?”
+
+She could settle it in no way that gave her pleasure.
+
+“He could be still amiable, still pleasing, to my uncle and aunt, when
+he was in town; and why not to me? If he fears me, why come hither? If
+he no longer cares for me, why silent? Teasing, teasing, man! I will
+think no more about him.”
+
+Her resolution was for a short time involuntarily kept by the approach
+of her sister, who joined her with a cheerful look, which showed her
+better satisfied with their visitors, than Elizabeth.
+
+“Now,” said she, “that this first meeting is over, I feel perfectly
+easy. I know my own strength, and I shall never be embarrassed again by
+his coming. I am glad he dines here on Tuesday. It will then be publicly
+seen that, on both sides, we meet only as common and indifferent
+acquaintance.”
+
+“Yes, very indifferent indeed,” said Elizabeth, laughingly. “Oh, Jane,
+take care.”
+
+“My dear Lizzy, you cannot think me so weak, as to be in danger now?”
+
+“I think you are in very great danger of making him as much in love with
+you as ever.”
+
+                          * * * * *
+
+They did not see the gentlemen again till Tuesday; and Mrs. Bennet, in
+the meanwhile, was giving way to all the happy schemes, which the good
+humour and common politeness of Bingley, in half an hour’s visit, had
+revived.
+
+On Tuesday there was a large party assembled at Longbourn; and the two
+who were most anxiously expected, to the credit of their punctuality
+as sportsmen, were in very good time. When they repaired to the
+dining-room, Elizabeth eagerly watched to see whether Bingley would take
+the place, which, in all their former parties, had belonged to him, by
+her sister. Her prudent mother, occupied by the same ideas, forbore
+to invite him to sit by herself. On entering the room, he seemed to
+hesitate; but Jane happened to look round, and happened to smile: it was
+decided. He placed himself by her.
+
+Elizabeth, with a triumphant sensation, looked towards his friend.
+He bore it with noble indifference, and she would have imagined that
+Bingley had received his sanction to be happy, had she not seen his eyes
+likewise turned towards Mr. Darcy, with an expression of half-laughing
+alarm.
+
+His behaviour to her sister was such, during dinner time, as showed an
+admiration of her, which, though more guarded than formerly, persuaded
+Elizabeth, that if left wholly to himself, Jane’s happiness, and his
+own, would be speedily secured. Though she dared not depend upon the
+consequence, she yet received pleasure from observing his behaviour. It
+gave her all the animation that her spirits could boast; for she was in
+no cheerful humour. Mr. Darcy was almost as far from her as the table
+could divide them. He was on one side of her mother. She knew how little
+such a situation would give pleasure to either, or make either appear to
+advantage. She was not near enough to hear any of their discourse, but
+she could see how seldom they spoke to each other, and how formal and
+cold was their manner whenever they did. Her mother’s ungraciousness,
+made the sense of what they owed him more painful to Elizabeth’s mind;
+and she would, at times, have given anything to be privileged to tell
+him that his kindness was neither unknown nor unfelt by the whole of the
+family.
+
+She was in hopes that the evening would afford some opportunity of
+bringing them together; that the whole of the visit would not pass away
+without enabling them to enter into something more of conversation than
+the mere ceremonious salutation attending his entrance. Anxious
+and uneasy, the period which passed in the drawing-room, before the
+gentlemen came, was wearisome and dull to a degree that almost made her
+uncivil. She looked forward to their entrance as the point on which all
+her chance of pleasure for the evening must depend.
+
+“If he does not come to me, _then_,” said she, “I shall give him up for
+ever.”
+
+The gentlemen came; and she thought he looked as if he would have
+answered her hopes; but, alas! the ladies had crowded round the table,
+where Miss Bennet was making tea, and Elizabeth pouring out the coffee,
+in so close a confederacy that there was not a single vacancy near her
+which would admit of a chair. And on the gentlemen’s approaching, one of
+the girls moved closer to her than ever, and said, in a whisper:
+
+“The men shan’t come and part us, I am determined. We want none of them;
+do we?”
+
+Darcy had walked away to another part of the room. She followed him with
+her eyes, envied everyone to whom he spoke, had scarcely patience enough
+to help anybody to coffee; and then was enraged against herself for
+being so silly!
+
+“A man who has once been refused! How could I ever be foolish enough to
+expect a renewal of his love? Is there one among the sex, who would not
+protest against such a weakness as a second proposal to the same woman?
+There is no indignity so abhorrent to their feelings!”
+
+She was a little revived, however, by his bringing back his coffee cup
+himself; and she seized the opportunity of saying:
+
+“Is your sister at Pemberley still?”
+
+“Yes, she will remain there till Christmas.”
+
+“And quite alone? Have all her friends left her?”
+
+“Mrs. Annesley is with her. The others have been gone on to Scarborough,
+these three weeks.”
+
+She could think of nothing more to say; but if he wished to converse
+with her, he might have better success. He stood by her, however, for
+some minutes, in silence; and, at last, on the young lady’s whispering
+to Elizabeth again, he walked away.
+
+When the tea-things were removed, and the card-tables placed, the ladies
+all rose, and Elizabeth was then hoping to be soon joined by him,
+when all her views were overthrown by seeing him fall a victim to her
+mother’s rapacity for whist players, and in a few moments after seated
+with the rest of the party. She now lost every expectation of pleasure.
+They were confined for the evening at different tables, and she had
+nothing to hope, but that his eyes were so often turned towards her side
+of the room, as to make him play as unsuccessfully as herself.
+
+Mrs. Bennet had designed to keep the two Netherfield gentlemen to
+supper; but their carriage was unluckily ordered before any of the
+others, and she had no opportunity of detaining them.
+
+“Well girls,” said she, as soon as they were left to themselves, “What
+say you to the day? I think every thing has passed off uncommonly well,
+I assure you. The dinner was as well dressed as any I ever saw. The
+venison was roasted to a turn--and everybody said they never saw so
+fat a haunch. The soup was fifty times better than what we had at the
+Lucases’ last week; and even Mr. Darcy acknowledged, that the partridges
+were remarkably well done; and I suppose he has two or three French
+cooks at least. And, my dear Jane, I never saw you look in greater
+beauty. Mrs. Long said so too, for I asked her whether you did not. And
+what do you think she said besides? ‘Ah! Mrs. Bennet, we shall have her
+at Netherfield at last.’ She did indeed. I do think Mrs. Long is as good
+a creature as ever lived--and her nieces are very pretty behaved girls,
+and not at all handsome: I like them prodigiously.”
+
+Mrs. Bennet, in short, was in very great spirits; she had seen enough of
+Bingley’s behaviour to Jane, to be convinced that she would get him at
+last; and her expectations of advantage to her family, when in a happy
+humour, were so far beyond reason, that she was quite disappointed at
+not seeing him there again the next day, to make his proposals.
+
+“It has been a very agreeable day,” said Miss Bennet to Elizabeth. “The
+party seemed so well selected, so suitable one with the other. I hope we
+may often meet again.”
+
+Elizabeth smiled.
+
+“Lizzy, you must not do so. You must not suspect me. It mortifies me.
+I assure you that I have now learnt to enjoy his conversation as an
+agreeable and sensible young man, without having a wish beyond it. I am
+perfectly satisfied, from what his manners now are, that he never had
+any design of engaging my affection. It is only that he is blessed
+with greater sweetness of address, and a stronger desire of generally
+pleasing, than any other man.”
+
+“You are very cruel,” said her sister, “you will not let me smile, and
+are provoking me to it every moment.”
+
+“How hard it is in some cases to be believed!”
+
+“And how impossible in others!”
+
+“But why should you wish to persuade me that I feel more than I
+acknowledge?”
+
+“That is a question which I hardly know how to answer. We all love to
+instruct, though we can teach only what is not worth knowing. Forgive
+me; and if you persist in indifference, do not make me your confidante.”
+
+
+
+Chapter 55
+
+
+A few days after this visit, Mr. Bingley called again, and alone. His
+friend had left him that morning for London, but was to return home in
+ten days time. He sat with them above an hour, and was in remarkably
+good spirits. Mrs. Bennet invited him to dine with them; but, with many
+expressions of concern, he confessed himself engaged elsewhere.
+
+“Next time you call,” said she, “I hope we shall be more lucky.”
+
+He should be particularly happy at any time, etc. etc.; and if she would
+give him leave, would take an early opportunity of waiting on them.
+
+“Can you come to-morrow?”
+
+Yes, he had no engagement at all for to-morrow; and her invitation was
+accepted with alacrity.
+
+He came, and in such very good time that the ladies were none of them
+dressed. In ran Mrs. Bennet to her daughter’s room, in her dressing
+gown, and with her hair half finished, crying out:
+
+“My dear Jane, make haste and hurry down. He is come--Mr. Bingley is
+come. He is, indeed. Make haste, make haste. Here, Sarah, come to Miss
+Bennet this moment, and help her on with her gown. Never mind Miss
+Lizzy’s hair.”
+
+“We will be down as soon as we can,” said Jane; “but I dare say Kitty is
+forwarder than either of us, for she went up stairs half an hour ago.”
+
+“Oh! hang Kitty! what has she to do with it? Come be quick, be quick!
+Where is your sash, my dear?”
+
+But when her mother was gone, Jane would not be prevailed on to go down
+without one of her sisters.
+
+The same anxiety to get them by themselves was visible again in the
+evening. After tea, Mr. Bennet retired to the library, as was his
+custom, and Mary went up stairs to her instrument. Two obstacles of
+the five being thus removed, Mrs. Bennet sat looking and winking at
+Elizabeth and Catherine for a considerable time, without making any
+impression on them. Elizabeth would not observe her; and when at last
+Kitty did, she very innocently said, “What is the matter mamma? What do
+you keep winking at me for? What am I to do?”
+
+“Nothing child, nothing. I did not wink at you.” She then sat still
+five minutes longer; but unable to waste such a precious occasion, she
+suddenly got up, and saying to Kitty, “Come here, my love, I want to
+speak to you,” took her out of the room. Jane instantly gave a look
+at Elizabeth which spoke her distress at such premeditation, and her
+entreaty that _she_ would not give in to it. In a few minutes, Mrs.
+Bennet half-opened the door and called out:
+
+“Lizzy, my dear, I want to speak with you.”
+
+Elizabeth was forced to go.
+
+“We may as well leave them by themselves you know;” said her mother, as
+soon as she was in the hall. “Kitty and I are going up stairs to sit in
+my dressing-room.”
+
+Elizabeth made no attempt to reason with her mother, but remained
+quietly in the hall, till she and Kitty were out of sight, then returned
+into the drawing-room.
+
+Mrs. Bennet’s schemes for this day were ineffectual. Bingley was every
+thing that was charming, except the professed lover of her daughter. His
+ease and cheerfulness rendered him a most agreeable addition to their
+evening party; and he bore with the ill-judged officiousness of the
+mother, and heard all her silly remarks with a forbearance and command
+of countenance particularly grateful to the daughter.
+
+He scarcely needed an invitation to stay supper; and before he went
+away, an engagement was formed, chiefly through his own and Mrs.
+Bennet’s means, for his coming next morning to shoot with her husband.
+
+After this day, Jane said no more of her indifference. Not a word passed
+between the sisters concerning Bingley; but Elizabeth went to bed in
+the happy belief that all must speedily be concluded, unless Mr. Darcy
+returned within the stated time. Seriously, however, she felt tolerably
+persuaded that all this must have taken place with that gentleman’s
+concurrence.
+
+Bingley was punctual to his appointment; and he and Mr. Bennet spent
+the morning together, as had been agreed on. The latter was much more
+agreeable than his companion expected. There was nothing of presumption
+or folly in Bingley that could provoke his ridicule, or disgust him into
+silence; and he was more communicative, and less eccentric, than the
+other had ever seen him. Bingley of course returned with him to dinner;
+and in the evening Mrs. Bennet’s invention was again at work to get
+every body away from him and her daughter. Elizabeth, who had a letter
+to write, went into the breakfast room for that purpose soon after tea;
+for as the others were all going to sit down to cards, she could not be
+wanted to counteract her mother’s schemes.
+
+But on returning to the drawing-room, when her letter was finished, she
+saw, to her infinite surprise, there was reason to fear that her mother
+had been too ingenious for her. On opening the door, she perceived her
+sister and Bingley standing together over the hearth, as if engaged in
+earnest conversation; and had this led to no suspicion, the faces of
+both, as they hastily turned round and moved away from each other, would
+have told it all. Their situation was awkward enough; but _hers_ she
+thought was still worse. Not a syllable was uttered by either; and
+Elizabeth was on the point of going away again, when Bingley, who as
+well as the other had sat down, suddenly rose, and whispering a few
+words to her sister, ran out of the room.
+
+Jane could have no reserves from Elizabeth, where confidence would give
+pleasure; and instantly embracing her, acknowledged, with the liveliest
+emotion, that she was the happiest creature in the world.
+
+“‘Tis too much!” she added, “by far too much. I do not deserve it. Oh!
+why is not everybody as happy?”
+
+Elizabeth’s congratulations were given with a sincerity, a warmth,
+a delight, which words could but poorly express. Every sentence of
+kindness was a fresh source of happiness to Jane. But she would not
+allow herself to stay with her sister, or say half that remained to be
+said for the present.
+
+“I must go instantly to my mother;” she cried. “I would not on any
+account trifle with her affectionate solicitude; or allow her to hear it
+from anyone but myself. He is gone to my father already. Oh! Lizzy, to
+know that what I have to relate will give such pleasure to all my dear
+family! how shall I bear so much happiness!”
+
+She then hastened away to her mother, who had purposely broken up the
+card party, and was sitting up stairs with Kitty.
+
+Elizabeth, who was left by herself, now smiled at the rapidity and ease
+with which an affair was finally settled, that had given them so many
+previous months of suspense and vexation.
+
+“And this,” said she, “is the end of all his friend’s anxious
+circumspection! of all his sister’s falsehood and contrivance! the
+happiest, wisest, most reasonable end!”
+
+In a few minutes she was joined by Bingley, whose conference with her
+father had been short and to the purpose.
+
+“Where is your sister?” said he hastily, as he opened the door.
+
+“With my mother up stairs. She will be down in a moment, I dare say.”
+
+He then shut the door, and, coming up to her, claimed the good wishes
+and affection of a sister. Elizabeth honestly and heartily expressed
+her delight in the prospect of their relationship. They shook hands with
+great cordiality; and then, till her sister came down, she had to listen
+to all he had to say of his own happiness, and of Jane’s perfections;
+and in spite of his being a lover, Elizabeth really believed all his
+expectations of felicity to be rationally founded, because they had for
+basis the excellent understanding, and super-excellent disposition of
+Jane, and a general similarity of feeling and taste between her and
+himself.
+
+It was an evening of no common delight to them all; the satisfaction of
+Miss Bennet’s mind gave a glow of such sweet animation to her face, as
+made her look handsomer than ever. Kitty simpered and smiled, and hoped
+her turn was coming soon. Mrs. Bennet could not give her consent or
+speak her approbation in terms warm enough to satisfy her feelings,
+though she talked to Bingley of nothing else for half an hour; and when
+Mr. Bennet joined them at supper, his voice and manner plainly showed
+how really happy he was.
+
+Not a word, however, passed his lips in allusion to it, till their
+visitor took his leave for the night; but as soon as he was gone, he
+turned to his daughter, and said:
+
+“Jane, I congratulate you. You will be a very happy woman.”
+
+Jane went to him instantly, kissed him, and thanked him for his
+goodness.
+
+“You are a good girl;” he replied, “and I have great pleasure in
+thinking you will be so happily settled. I have not a doubt of your
+doing very well together. Your tempers are by no means unlike. You are
+each of you so complying, that nothing will ever be resolved on; so
+easy, that every servant will cheat you; and so generous, that you will
+always exceed your income.”
+
+“I hope not so. Imprudence or thoughtlessness in money matters would be
+unpardonable in me.”
+
+“Exceed their income! My dear Mr. Bennet,” cried his wife, “what are you
+talking of? Why, he has four or five thousand a year, and very likely
+more.” Then addressing her daughter, “Oh! my dear, dear Jane, I am so
+happy! I am sure I shan’t get a wink of sleep all night. I knew how it
+would be. I always said it must be so, at last. I was sure you could not
+be so beautiful for nothing! I remember, as soon as ever I saw him, when
+he first came into Hertfordshire last year, I thought how likely it was
+that you should come together. Oh! he is the handsomest young man that
+ever was seen!”
+
+Wickham, Lydia, were all forgotten. Jane was beyond competition her
+favourite child. At that moment, she cared for no other. Her younger
+sisters soon began to make interest with her for objects of happiness
+which she might in future be able to dispense.
+
+Mary petitioned for the use of the library at Netherfield; and Kitty
+begged very hard for a few balls there every winter.
+
+Bingley, from this time, was of course a daily visitor at Longbourn;
+coming frequently before breakfast, and always remaining till after
+supper; unless when some barbarous neighbour, who could not be enough
+detested, had given him an invitation to dinner which he thought himself
+obliged to accept.
+
+Elizabeth had now but little time for conversation with her sister; for
+while he was present, Jane had no attention to bestow on anyone else;
+but she found herself considerably useful to both of them in those hours
+of separation that must sometimes occur. In the absence of Jane, he
+always attached himself to Elizabeth, for the pleasure of talking of
+her; and when Bingley was gone, Jane constantly sought the same means of
+relief.
+
+“He has made me so happy,” said she, one evening, “by telling me that he
+was totally ignorant of my being in town last spring! I had not believed
+it possible.”
+
+“I suspected as much,” replied Elizabeth. “But how did he account for
+it?”
+
+“It must have been his sister’s doing. They were certainly no friends to
+his acquaintance with me, which I cannot wonder at, since he might have
+chosen so much more advantageously in many respects. But when they see,
+as I trust they will, that their brother is happy with me, they will
+learn to be contented, and we shall be on good terms again; though we
+can never be what we once were to each other.”
+
+“That is the most unforgiving speech,” said Elizabeth, “that I ever
+heard you utter. Good girl! It would vex me, indeed, to see you again
+the dupe of Miss Bingley’s pretended regard.”
+
+“Would you believe it, Lizzy, that when he went to town last November,
+he really loved me, and nothing but a persuasion of _my_ being
+indifferent would have prevented his coming down again!”
+
+“He made a little mistake to be sure; but it is to the credit of his
+modesty.”
+
+This naturally introduced a panegyric from Jane on his diffidence, and
+the little value he put on his own good qualities. Elizabeth was pleased
+to find that he had not betrayed the interference of his friend; for,
+though Jane had the most generous and forgiving heart in the world, she
+knew it was a circumstance which must prejudice her against him.
+
+“I am certainly the most fortunate creature that ever existed!” cried
+Jane. “Oh! Lizzy, why am I thus singled from my family, and blessed
+above them all! If I could but see _you_ as happy! If there _were_ but
+such another man for you!”
+
+“If you were to give me forty such men, I never could be so happy as
+you. Till I have your disposition, your goodness, I never can have your
+happiness. No, no, let me shift for myself; and, perhaps, if I have very
+good luck, I may meet with another Mr. Collins in time.”
+
+The situation of affairs in the Longbourn family could not be long a
+secret. Mrs. Bennet was privileged to whisper it to Mrs. Phillips,
+and she ventured, without any permission, to do the same by all her
+neighbours in Meryton.
+
+The Bennets were speedily pronounced to be the luckiest family in the
+world, though only a few weeks before, when Lydia had first run away,
+they had been generally proved to be marked out for misfortune.
+
+
+
+Chapter 56
+
+
+One morning, about a week after Bingley’s engagement with Jane had been
+formed, as he and the females of the family were sitting together in the
+dining-room, their attention was suddenly drawn to the window, by the
+sound of a carriage; and they perceived a chaise and four driving up
+the lawn. It was too early in the morning for visitors, and besides, the
+equipage did not answer to that of any of their neighbours. The horses
+were post; and neither the carriage, nor the livery of the servant who
+preceded it, were familiar to them. As it was certain, however, that
+somebody was coming, Bingley instantly prevailed on Miss Bennet to avoid
+the confinement of such an intrusion, and walk away with him into the
+shrubbery. They both set off, and the conjectures of the remaining three
+continued, though with little satisfaction, till the door was thrown
+open and their visitor entered. It was Lady Catherine de Bourgh.
+
+They were of course all intending to be surprised; but their
+astonishment was beyond their expectation; and on the part of Mrs.
+Bennet and Kitty, though she was perfectly unknown to them, even
+inferior to what Elizabeth felt.
+
+She entered the room with an air more than usually ungracious, made no
+other reply to Elizabeth’s salutation than a slight inclination of the
+head, and sat down without saying a word. Elizabeth had mentioned her
+name to her mother on her ladyship’s entrance, though no request of
+introduction had been made.
+
+Mrs. Bennet, all amazement, though flattered by having a guest of such
+high importance, received her with the utmost politeness. After sitting
+for a moment in silence, she said very stiffly to Elizabeth,
+
+“I hope you are well, Miss Bennet. That lady, I suppose, is your
+mother.”
+
+Elizabeth replied very concisely that she was.
+
+“And _that_ I suppose is one of your sisters.”
+
+“Yes, madam,” said Mrs. Bennet, delighted to speak to Lady Catherine.
+“She is my youngest girl but one. My youngest of all is lately married,
+and my eldest is somewhere about the grounds, walking with a young man
+who, I believe, will soon become a part of the family.”
+
+“You have a very small park here,” returned Lady Catherine after a short
+silence.
+
+“It is nothing in comparison of Rosings, my lady, I dare say; but I
+assure you it is much larger than Sir William Lucas’s.”
+
+“This must be a most inconvenient sitting room for the evening, in
+summer; the windows are full west.”
+
+Mrs. Bennet assured her that they never sat there after dinner, and then
+added:
+
+“May I take the liberty of asking your ladyship whether you left Mr. and
+Mrs. Collins well.”
+
+“Yes, very well. I saw them the night before last.”
+
+Elizabeth now expected that she would produce a letter for her from
+Charlotte, as it seemed the only probable motive for her calling. But no
+letter appeared, and she was completely puzzled.
+
+Mrs. Bennet, with great civility, begged her ladyship to take some
+refreshment; but Lady Catherine very resolutely, and not very politely,
+declined eating anything; and then, rising up, said to Elizabeth,
+
+“Miss Bennet, there seemed to be a prettyish kind of a little wilderness
+on one side of your lawn. I should be glad to take a turn in it, if you
+will favour me with your company.”
+
+“Go, my dear,” cried her mother, “and show her ladyship about the
+different walks. I think she will be pleased with the hermitage.”
+
+Elizabeth obeyed, and running into her own room for her parasol,
+attended her noble guest downstairs. As they passed through the
+hall, Lady Catherine opened the doors into the dining-parlour and
+drawing-room, and pronouncing them, after a short survey, to be decent
+looking rooms, walked on.
+
+Her carriage remained at the door, and Elizabeth saw that her
+waiting-woman was in it. They proceeded in silence along the gravel walk
+that led to the copse; Elizabeth was determined to make no effort for
+conversation with a woman who was now more than usually insolent and
+disagreeable.
+
+“How could I ever think her like her nephew?” said she, as she looked in
+her face.
+
+As soon as they entered the copse, Lady Catherine began in the following
+manner:--
+
+“You can be at no loss, Miss Bennet, to understand the reason of my
+journey hither. Your own heart, your own conscience, must tell you why I
+come.”
+
+Elizabeth looked with unaffected astonishment.
+
+“Indeed, you are mistaken, Madam. I have not been at all able to account
+for the honour of seeing you here.”
+
+“Miss Bennet,” replied her ladyship, in an angry tone, “you ought to
+know, that I am not to be trifled with. But however insincere _you_ may
+choose to be, you shall not find _me_ so. My character has ever been
+celebrated for its sincerity and frankness, and in a cause of such
+moment as this, I shall certainly not depart from it. A report of a most
+alarming nature reached me two days ago. I was told that not only your
+sister was on the point of being most advantageously married, but that
+you, that Miss Elizabeth Bennet, would, in all likelihood, be soon
+afterwards united to my nephew, my own nephew, Mr. Darcy. Though I
+_know_ it must be a scandalous falsehood, though I would not injure him
+so much as to suppose the truth of it possible, I instantly resolved
+on setting off for this place, that I might make my sentiments known to
+you.”
+
+“If you believed it impossible to be true,” said Elizabeth, colouring
+with astonishment and disdain, “I wonder you took the trouble of coming
+so far. What could your ladyship propose by it?”
+
+“At once to insist upon having such a report universally contradicted.”
+
+“Your coming to Longbourn, to see me and my family,” said Elizabeth
+coolly, “will be rather a confirmation of it; if, indeed, such a report
+is in existence.”
+
+“If! Do you then pretend to be ignorant of it? Has it not been
+industriously circulated by yourselves? Do you not know that such a
+report is spread abroad?”
+
+“I never heard that it was.”
+
+“And can you likewise declare, that there is no foundation for it?”
+
+“I do not pretend to possess equal frankness with your ladyship. You may
+ask questions which I shall not choose to answer.”
+
+“This is not to be borne. Miss Bennet, I insist on being satisfied. Has
+he, has my nephew, made you an offer of marriage?”
+
+“Your ladyship has declared it to be impossible.”
+
+“It ought to be so; it must be so, while he retains the use of his
+reason. But your arts and allurements may, in a moment of infatuation,
+have made him forget what he owes to himself and to all his family. You
+may have drawn him in.”
+
+“If I have, I shall be the last person to confess it.”
+
+“Miss Bennet, do you know who I am? I have not been accustomed to such
+language as this. I am almost the nearest relation he has in the world,
+and am entitled to know all his dearest concerns.”
+
+“But you are not entitled to know mine; nor will such behaviour as this,
+ever induce me to be explicit.”
+
+“Let me be rightly understood. This match, to which you have the
+presumption to aspire, can never take place. No, never. Mr. Darcy is
+engaged to my daughter. Now what have you to say?”
+
+“Only this; that if he is so, you can have no reason to suppose he will
+make an offer to me.”
+
+Lady Catherine hesitated for a moment, and then replied:
+
+“The engagement between them is of a peculiar kind. From their infancy,
+they have been intended for each other. It was the favourite wish of
+_his_ mother, as well as of hers. While in their cradles, we planned
+the union: and now, at the moment when the wishes of both sisters would
+be accomplished in their marriage, to be prevented by a young woman of
+inferior birth, of no importance in the world, and wholly unallied to
+the family! Do you pay no regard to the wishes of his friends? To his
+tacit engagement with Miss de Bourgh? Are you lost to every feeling of
+propriety and delicacy? Have you not heard me say that from his earliest
+hours he was destined for his cousin?”
+
+“Yes, and I had heard it before. But what is that to me? If there is
+no other objection to my marrying your nephew, I shall certainly not
+be kept from it by knowing that his mother and aunt wished him to
+marry Miss de Bourgh. You both did as much as you could in planning the
+marriage. Its completion depended on others. If Mr. Darcy is neither
+by honour nor inclination confined to his cousin, why is not he to make
+another choice? And if I am that choice, why may not I accept him?”
+
+“Because honour, decorum, prudence, nay, interest, forbid it. Yes,
+Miss Bennet, interest; for do not expect to be noticed by his family or
+friends, if you wilfully act against the inclinations of all. You will
+be censured, slighted, and despised, by everyone connected with him.
+Your alliance will be a disgrace; your name will never even be mentioned
+by any of us.”
+
+“These are heavy misfortunes,” replied Elizabeth. “But the wife of Mr.
+Darcy must have such extraordinary sources of happiness necessarily
+attached to her situation, that she could, upon the whole, have no cause
+to repine.”
+
+“Obstinate, headstrong girl! I am ashamed of you! Is this your gratitude
+for my attentions to you last spring? Is nothing due to me on that
+score? Let us sit down. You are to understand, Miss Bennet, that I came
+here with the determined resolution of carrying my purpose; nor will
+I be dissuaded from it. I have not been used to submit to any person’s
+whims. I have not been in the habit of brooking disappointment.”
+
+“_That_ will make your ladyship’s situation at present more pitiable;
+but it will have no effect on me.”
+
+“I will not be interrupted. Hear me in silence. My daughter and my
+nephew are formed for each other. They are descended, on the maternal
+side, from the same noble line; and, on the father’s, from respectable,
+honourable, and ancient--though untitled--families. Their fortune on
+both sides is splendid. They are destined for each other by the voice of
+every member of their respective houses; and what is to divide them?
+The upstart pretensions of a young woman without family, connections,
+or fortune. Is this to be endured! But it must not, shall not be. If you
+were sensible of your own good, you would not wish to quit the sphere in
+which you have been brought up.”
+
+“In marrying your nephew, I should not consider myself as quitting that
+sphere. He is a gentleman; I am a gentleman’s daughter; so far we are
+equal.”
+
+“True. You _are_ a gentleman’s daughter. But who was your mother?
+Who are your uncles and aunts? Do not imagine me ignorant of their
+condition.”
+
+“Whatever my connections may be,” said Elizabeth, “if your nephew does
+not object to them, they can be nothing to _you_.”
+
+“Tell me once for all, are you engaged to him?”
+
+Though Elizabeth would not, for the mere purpose of obliging Lady
+Catherine, have answered this question, she could not but say, after a
+moment’s deliberation:
+
+“I am not.”
+
+Lady Catherine seemed pleased.
+
+“And will you promise me, never to enter into such an engagement?”
+
+“I will make no promise of the kind.”
+
+“Miss Bennet I am shocked and astonished. I expected to find a more
+reasonable young woman. But do not deceive yourself into a belief that
+I will ever recede. I shall not go away till you have given me the
+assurance I require.”
+
+“And I certainly _never_ shall give it. I am not to be intimidated into
+anything so wholly unreasonable. Your ladyship wants Mr. Darcy to marry
+your daughter; but would my giving you the wished-for promise make their
+marriage at all more probable? Supposing him to be attached to me, would
+my refusing to accept his hand make him wish to bestow it on his cousin?
+Allow me to say, Lady Catherine, that the arguments with which you have
+supported this extraordinary application have been as frivolous as the
+application was ill-judged. You have widely mistaken my character, if
+you think I can be worked on by such persuasions as these. How far your
+nephew might approve of your interference in his affairs, I cannot tell;
+but you have certainly no right to concern yourself in mine. I must beg,
+therefore, to be importuned no farther on the subject.”
+
+“Not so hasty, if you please. I have by no means done. To all the
+objections I have already urged, I have still another to add. I am
+no stranger to the particulars of your youngest sister’s infamous
+elopement. I know it all; that the young man’s marrying her was a
+patched-up business, at the expence of your father and uncles. And is
+such a girl to be my nephew’s sister? Is her husband, is the son of his
+late father’s steward, to be his brother? Heaven and earth!--of what are
+you thinking? Are the shades of Pemberley to be thus polluted?”
+
+“You can now have nothing further to say,” she resentfully answered.
+“You have insulted me in every possible method. I must beg to return to
+the house.”
+
+And she rose as she spoke. Lady Catherine rose also, and they turned
+back. Her ladyship was highly incensed.
+
+“You have no regard, then, for the honour and credit of my nephew!
+Unfeeling, selfish girl! Do you not consider that a connection with you
+must disgrace him in the eyes of everybody?”
+
+“Lady Catherine, I have nothing further to say. You know my sentiments.”
+
+“You are then resolved to have him?”
+
+“I have said no such thing. I am only resolved to act in that manner,
+which will, in my own opinion, constitute my happiness, without
+reference to _you_, or to any person so wholly unconnected with me.”
+
+“It is well. You refuse, then, to oblige me. You refuse to obey the
+claims of duty, honour, and gratitude. You are determined to ruin him in
+the opinion of all his friends, and make him the contempt of the world.”
+
+“Neither duty, nor honour, nor gratitude,” replied Elizabeth, “have any
+possible claim on me, in the present instance. No principle of either
+would be violated by my marriage with Mr. Darcy. And with regard to the
+resentment of his family, or the indignation of the world, if the former
+_were_ excited by his marrying me, it would not give me one moment’s
+concern--and the world in general would have too much sense to join in
+the scorn.”
+
+“And this is your real opinion! This is your final resolve! Very well.
+I shall now know how to act. Do not imagine, Miss Bennet, that your
+ambition will ever be gratified. I came to try you. I hoped to find you
+reasonable; but, depend upon it, I will carry my point.”
+
+In this manner Lady Catherine talked on, till they were at the door of
+the carriage, when, turning hastily round, she added, “I take no leave
+of you, Miss Bennet. I send no compliments to your mother. You deserve
+no such attention. I am most seriously displeased.”
+
+Elizabeth made no answer; and without attempting to persuade her
+ladyship to return into the house, walked quietly into it herself. She
+heard the carriage drive away as she proceeded up stairs. Her mother
+impatiently met her at the door of the dressing-room, to ask why Lady
+Catherine would not come in again and rest herself.
+
+“She did not choose it,” said her daughter, “she would go.”
+
+“She is a very fine-looking woman! and her calling here was prodigiously
+civil! for she only came, I suppose, to tell us the Collinses were
+well. She is on her road somewhere, I dare say, and so, passing through
+Meryton, thought she might as well call on you. I suppose she had
+nothing particular to say to you, Lizzy?”
+
+Elizabeth was forced to give into a little falsehood here; for to
+acknowledge the substance of their conversation was impossible.
+
+
+
+Chapter 57
+
+
+The discomposure of spirits which this extraordinary visit threw
+Elizabeth into, could not be easily overcome; nor could she, for many
+hours, learn to think of it less than incessantly. Lady Catherine, it
+appeared, had actually taken the trouble of this journey from Rosings,
+for the sole purpose of breaking off her supposed engagement with Mr.
+Darcy. It was a rational scheme, to be sure! but from what the report
+of their engagement could originate, Elizabeth was at a loss to imagine;
+till she recollected that _his_ being the intimate friend of Bingley,
+and _her_ being the sister of Jane, was enough, at a time when the
+expectation of one wedding made everybody eager for another, to supply
+the idea. She had not herself forgotten to feel that the marriage of her
+sister must bring them more frequently together. And her neighbours
+at Lucas Lodge, therefore (for through their communication with the
+Collinses, the report, she concluded, had reached Lady Catherine), had
+only set that down as almost certain and immediate, which she had looked
+forward to as possible at some future time.
+
+In revolving Lady Catherine’s expressions, however, she could not help
+feeling some uneasiness as to the possible consequence of her persisting
+in this interference. From what she had said of her resolution to
+prevent their marriage, it occurred to Elizabeth that she must meditate
+an application to her nephew; and how _he_ might take a similar
+representation of the evils attached to a connection with her, she dared
+not pronounce. She knew not the exact degree of his affection for his
+aunt, or his dependence on her judgment, but it was natural to suppose
+that he thought much higher of her ladyship than _she_ could do; and it
+was certain that, in enumerating the miseries of a marriage with _one_,
+whose immediate connections were so unequal to his own, his aunt would
+address him on his weakest side. With his notions of dignity, he would
+probably feel that the arguments, which to Elizabeth had appeared weak
+and ridiculous, contained much good sense and solid reasoning.
+
+If he had been wavering before as to what he should do, which had often
+seemed likely, the advice and entreaty of so near a relation might
+settle every doubt, and determine him at once to be as happy as dignity
+unblemished could make him. In that case he would return no more. Lady
+Catherine might see him in her way through town; and his engagement to
+Bingley of coming again to Netherfield must give way.
+
+“If, therefore, an excuse for not keeping his promise should come to his
+friend within a few days,” she added, “I shall know how to understand
+it. I shall then give over every expectation, every wish of his
+constancy. If he is satisfied with only regretting me, when he might
+have obtained my affections and hand, I shall soon cease to regret him
+at all.”
+
+                          * * * * *
+
+The surprise of the rest of the family, on hearing who their visitor had
+been, was very great; but they obligingly satisfied it, with the same
+kind of supposition which had appeased Mrs. Bennet’s curiosity; and
+Elizabeth was spared from much teasing on the subject.
+
+The next morning, as she was going downstairs, she was met by her
+father, who came out of his library with a letter in his hand.
+
+“Lizzy,” said he, “I was going to look for you; come into my room.”
+
+She followed him thither; and her curiosity to know what he had to
+tell her was heightened by the supposition of its being in some manner
+connected with the letter he held. It suddenly struck her that it
+might be from Lady Catherine; and she anticipated with dismay all the
+consequent explanations.
+
+She followed her father to the fire place, and they both sat down. He
+then said,
+
+“I have received a letter this morning that has astonished me
+exceedingly. As it principally concerns yourself, you ought to know its
+contents. I did not know before, that I had two daughters on the brink
+of matrimony. Let me congratulate you on a very important conquest.”
+
+The colour now rushed into Elizabeth’s cheeks in the instantaneous
+conviction of its being a letter from the nephew, instead of the aunt;
+and she was undetermined whether most to be pleased that he explained
+himself at all, or offended that his letter was not rather addressed to
+herself; when her father continued:
+
+“You look conscious. Young ladies have great penetration in such matters
+as these; but I think I may defy even _your_ sagacity, to discover the
+name of your admirer. This letter is from Mr. Collins.”
+
+“From Mr. Collins! and what can _he_ have to say?”
+
+“Something very much to the purpose of course. He begins with
+congratulations on the approaching nuptials of my eldest daughter, of
+which, it seems, he has been told by some of the good-natured, gossiping
+Lucases. I shall not sport with your impatience, by reading what he says
+on that point. What relates to yourself, is as follows: ‘Having thus
+offered you the sincere congratulations of Mrs. Collins and myself on
+this happy event, let me now add a short hint on the subject of another;
+of which we have been advertised by the same authority. Your daughter
+Elizabeth, it is presumed, will not long bear the name of Bennet, after
+her elder sister has resigned it, and the chosen partner of her fate may
+be reasonably looked up to as one of the most illustrious personages in
+this land.’
+
+“Can you possibly guess, Lizzy, who is meant by this? ‘This young
+gentleman is blessed, in a peculiar way, with every thing the heart of
+mortal can most desire,--splendid property, noble kindred, and extensive
+patronage. Yet in spite of all these temptations, let me warn my cousin
+Elizabeth, and yourself, of what evils you may incur by a precipitate
+closure with this gentleman’s proposals, which, of course, you will be
+inclined to take immediate advantage of.’
+
+“Have you any idea, Lizzy, who this gentleman is? But now it comes out:
+
+“‘My motive for cautioning you is as follows. We have reason to imagine
+that his aunt, Lady Catherine de Bourgh, does not look on the match with
+a friendly eye.’
+
+“_Mr. Darcy_, you see, is the man! Now, Lizzy, I think I _have_
+surprised you. Could he, or the Lucases, have pitched on any man within
+the circle of our acquaintance, whose name would have given the lie
+more effectually to what they related? Mr. Darcy, who never looks at any
+woman but to see a blemish, and who probably never looked at you in his
+life! It is admirable!”
+
+Elizabeth tried to join in her father’s pleasantry, but could only force
+one most reluctant smile. Never had his wit been directed in a manner so
+little agreeable to her.
+
+“Are you not diverted?”
+
+“Oh! yes. Pray read on.”
+
+“‘After mentioning the likelihood of this marriage to her ladyship last
+night, she immediately, with her usual condescension, expressed what she
+felt on the occasion; when it became apparent, that on the score of some
+family objections on the part of my cousin, she would never give her
+consent to what she termed so disgraceful a match. I thought it my duty
+to give the speediest intelligence of this to my cousin, that she and
+her noble admirer may be aware of what they are about, and not run
+hastily into a marriage which has not been properly sanctioned.’ Mr.
+Collins moreover adds, ‘I am truly rejoiced that my cousin Lydia’s sad
+business has been so well hushed up, and am only concerned that their
+living together before the marriage took place should be so generally
+known. I must not, however, neglect the duties of my station, or refrain
+from declaring my amazement at hearing that you received the young
+couple into your house as soon as they were married. It was an
+encouragement of vice; and had I been the rector of Longbourn, I should
+very strenuously have opposed it. You ought certainly to forgive them,
+as a Christian, but never to admit them in your sight, or allow their
+names to be mentioned in your hearing.’ That is his notion of Christian
+forgiveness! The rest of his letter is only about his dear Charlotte’s
+situation, and his expectation of a young olive-branch. But, Lizzy, you
+look as if you did not enjoy it. You are not going to be _missish_,
+I hope, and pretend to be affronted at an idle report. For what do we
+live, but to make sport for our neighbours, and laugh at them in our
+turn?”
+
+“Oh!” cried Elizabeth, “I am excessively diverted. But it is so
+strange!”
+
+“Yes--_that_ is what makes it amusing. Had they fixed on any other man
+it would have been nothing; but _his_ perfect indifference, and _your_
+pointed dislike, make it so delightfully absurd! Much as I abominate
+writing, I would not give up Mr. Collins’s correspondence for any
+consideration. Nay, when I read a letter of his, I cannot help giving
+him the preference even over Wickham, much as I value the impudence and
+hypocrisy of my son-in-law. And pray, Lizzy, what said Lady Catherine
+about this report? Did she call to refuse her consent?”
+
+To this question his daughter replied only with a laugh; and as it had
+been asked without the least suspicion, she was not distressed by
+his repeating it. Elizabeth had never been more at a loss to make her
+feelings appear what they were not. It was necessary to laugh, when she
+would rather have cried. Her father had most cruelly mortified her, by
+what he said of Mr. Darcy’s indifference, and she could do nothing but
+wonder at such a want of penetration, or fear that perhaps, instead of
+his seeing too little, she might have fancied too much.
+
+
+
+Chapter 58
+
+
+Instead of receiving any such letter of excuse from his friend, as
+Elizabeth half expected Mr. Bingley to do, he was able to bring Darcy
+with him to Longbourn before many days had passed after Lady Catherine’s
+visit. The gentlemen arrived early; and, before Mrs. Bennet had time
+to tell him of their having seen his aunt, of which her daughter sat
+in momentary dread, Bingley, who wanted to be alone with Jane, proposed
+their all walking out. It was agreed to. Mrs. Bennet was not in the
+habit of walking; Mary could never spare time; but the remaining five
+set off together. Bingley and Jane, however, soon allowed the others
+to outstrip them. They lagged behind, while Elizabeth, Kitty, and Darcy
+were to entertain each other. Very little was said by either; Kitty
+was too much afraid of him to talk; Elizabeth was secretly forming a
+desperate resolution; and perhaps he might be doing the same.
+
+They walked towards the Lucases, because Kitty wished to call upon
+Maria; and as Elizabeth saw no occasion for making it a general concern,
+when Kitty left them she went boldly on with him alone. Now was the
+moment for her resolution to be executed, and, while her courage was
+high, she immediately said:
+
+“Mr. Darcy, I am a very selfish creature; and, for the sake of giving
+relief to my own feelings, care not how much I may be wounding yours. I
+can no longer help thanking you for your unexampled kindness to my
+poor sister. Ever since I have known it, I have been most anxious to
+acknowledge to you how gratefully I feel it. Were it known to the rest
+of my family, I should not have merely my own gratitude to express.”
+
+“I am sorry, exceedingly sorry,” replied Darcy, in a tone of surprise
+and emotion, “that you have ever been informed of what may, in a
+mistaken light, have given you uneasiness. I did not think Mrs. Gardiner
+was so little to be trusted.”
+
+“You must not blame my aunt. Lydia’s thoughtlessness first betrayed to
+me that you had been concerned in the matter; and, of course, I could
+not rest till I knew the particulars. Let me thank you again and again,
+in the name of all my family, for that generous compassion which induced
+you to take so much trouble, and bear so many mortifications, for the
+sake of discovering them.”
+
+“If you _will_ thank me,” he replied, “let it be for yourself alone.
+That the wish of giving happiness to you might add force to the other
+inducements which led me on, I shall not attempt to deny. But your
+_family_ owe me nothing. Much as I respect them, I believe I thought
+only of _you_.”
+
+Elizabeth was too much embarrassed to say a word. After a short pause,
+her companion added, “You are too generous to trifle with me. If your
+feelings are still what they were last April, tell me so at once. _My_
+affections and wishes are unchanged, but one word from you will silence
+me on this subject for ever.”
+
+Elizabeth, feeling all the more than common awkwardness and anxiety of
+his situation, now forced herself to speak; and immediately, though not
+very fluently, gave him to understand that her sentiments had undergone
+so material a change, since the period to which he alluded, as to make
+her receive with gratitude and pleasure his present assurances. The
+happiness which this reply produced, was such as he had probably never
+felt before; and he expressed himself on the occasion as sensibly and as
+warmly as a man violently in love can be supposed to do. Had Elizabeth
+been able to encounter his eye, she might have seen how well the
+expression of heartfelt delight, diffused over his face, became him;
+but, though she could not look, she could listen, and he told her of
+feelings, which, in proving of what importance she was to him, made his
+affection every moment more valuable.
+
+They walked on, without knowing in what direction. There was too much to
+be thought, and felt, and said, for attention to any other objects. She
+soon learnt that they were indebted for their present good understanding
+to the efforts of his aunt, who did call on him in her return through
+London, and there relate her journey to Longbourn, its motive, and the
+substance of her conversation with Elizabeth; dwelling emphatically on
+every expression of the latter which, in her ladyship’s apprehension,
+peculiarly denoted her perverseness and assurance; in the belief that
+such a relation must assist her endeavours to obtain that promise
+from her nephew which she had refused to give. But, unluckily for her
+ladyship, its effect had been exactly contrariwise.
+
+“It taught me to hope,” said he, “as I had scarcely ever allowed myself
+to hope before. I knew enough of your disposition to be certain that,
+had you been absolutely, irrevocably decided against me, you would have
+acknowledged it to Lady Catherine, frankly and openly.”
+
+Elizabeth coloured and laughed as she replied, “Yes, you know enough
+of my frankness to believe me capable of _that_. After abusing you so
+abominably to your face, I could have no scruple in abusing you to all
+your relations.”
+
+“What did you say of me, that I did not deserve? For, though your
+accusations were ill-founded, formed on mistaken premises, my
+behaviour to you at the time had merited the severest reproof. It was
+unpardonable. I cannot think of it without abhorrence.”
+
+“We will not quarrel for the greater share of blame annexed to that
+evening,” said Elizabeth. “The conduct of neither, if strictly examined,
+will be irreproachable; but since then, we have both, I hope, improved
+in civility.”
+
+“I cannot be so easily reconciled to myself. The recollection of what I
+then said, of my conduct, my manners, my expressions during the whole of
+it, is now, and has been many months, inexpressibly painful to me. Your
+reproof, so well applied, I shall never forget: ‘had you behaved in a
+more gentlemanlike manner.’ Those were your words. You know not, you can
+scarcely conceive, how they have tortured me;--though it was some time,
+I confess, before I was reasonable enough to allow their justice.”
+
+“I was certainly very far from expecting them to make so strong an
+impression. I had not the smallest idea of their being ever felt in such
+a way.”
+
+“I can easily believe it. You thought me then devoid of every proper
+feeling, I am sure you did. The turn of your countenance I shall never
+forget, as you said that I could not have addressed you in any possible
+way that would induce you to accept me.”
+
+“Oh! do not repeat what I then said. These recollections will not do at
+all. I assure you that I have long been most heartily ashamed of it.”
+
+Darcy mentioned his letter. “Did it,” said he, “did it soon make you
+think better of me? Did you, on reading it, give any credit to its
+contents?”
+
+She explained what its effect on her had been, and how gradually all her
+former prejudices had been removed.
+
+“I knew,” said he, “that what I wrote must give you pain, but it was
+necessary. I hope you have destroyed the letter. There was one part
+especially, the opening of it, which I should dread your having the
+power of reading again. I can remember some expressions which might
+justly make you hate me.”
+
+“The letter shall certainly be burnt, if you believe it essential to the
+preservation of my regard; but, though we have both reason to think my
+opinions not entirely unalterable, they are not, I hope, quite so easily
+changed as that implies.”
+
+“When I wrote that letter,” replied Darcy, “I believed myself perfectly
+calm and cool, but I am since convinced that it was written in a
+dreadful bitterness of spirit.”
+
+“The letter, perhaps, began in bitterness, but it did not end so. The
+adieu is charity itself. But think no more of the letter. The feelings
+of the person who wrote, and the person who received it, are now
+so widely different from what they were then, that every unpleasant
+circumstance attending it ought to be forgotten. You must learn some
+of my philosophy. Think only of the past as its remembrance gives you
+pleasure.”
+
+“I cannot give you credit for any philosophy of the kind. Your
+retrospections must be so totally void of reproach, that the contentment
+arising from them is not of philosophy, but, what is much better, of
+innocence. But with me, it is not so. Painful recollections will intrude
+which cannot, which ought not, to be repelled. I have been a selfish
+being all my life, in practice, though not in principle. As a child I
+was taught what was right, but I was not taught to correct my temper. I
+was given good principles, but left to follow them in pride and conceit.
+Unfortunately an only son (for many years an only child), I was spoilt
+by my parents, who, though good themselves (my father, particularly, all
+that was benevolent and amiable), allowed, encouraged, almost taught
+me to be selfish and overbearing; to care for none beyond my own family
+circle; to think meanly of all the rest of the world; to wish at least
+to think meanly of their sense and worth compared with my own. Such I
+was, from eight to eight and twenty; and such I might still have been
+but for you, dearest, loveliest Elizabeth! What do I not owe you! You
+taught me a lesson, hard indeed at first, but most advantageous. By you,
+I was properly humbled. I came to you without a doubt of my reception.
+You showed me how insufficient were all my pretensions to please a woman
+worthy of being pleased.”
+
+“Had you then persuaded yourself that I should?”
+
+“Indeed I had. What will you think of my vanity? I believed you to be
+wishing, expecting my addresses.”
+
+“My manners must have been in fault, but not intentionally, I assure
+you. I never meant to deceive you, but my spirits might often lead me
+wrong. How you must have hated me after _that_ evening?”
+
+“Hate you! I was angry perhaps at first, but my anger soon began to take
+a proper direction.”
+
+“I am almost afraid of asking what you thought of me, when we met at
+Pemberley. You blamed me for coming?”
+
+“No indeed; I felt nothing but surprise.”
+
+“Your surprise could not be greater than _mine_ in being noticed by you.
+My conscience told me that I deserved no extraordinary politeness, and I
+confess that I did not expect to receive _more_ than my due.”
+
+“My object then,” replied Darcy, “was to show you, by every civility in
+my power, that I was not so mean as to resent the past; and I hoped to
+obtain your forgiveness, to lessen your ill opinion, by letting you
+see that your reproofs had been attended to. How soon any other wishes
+introduced themselves I can hardly tell, but I believe in about half an
+hour after I had seen you.”
+
+He then told her of Georgiana’s delight in her acquaintance, and of her
+disappointment at its sudden interruption; which naturally leading to
+the cause of that interruption, she soon learnt that his resolution of
+following her from Derbyshire in quest of her sister had been formed
+before he quitted the inn, and that his gravity and thoughtfulness
+there had arisen from no other struggles than what such a purpose must
+comprehend.
+
+She expressed her gratitude again, but it was too painful a subject to
+each, to be dwelt on farther.
+
+After walking several miles in a leisurely manner, and too busy to know
+anything about it, they found at last, on examining their watches, that
+it was time to be at home.
+
+“What could become of Mr. Bingley and Jane!” was a wonder which
+introduced the discussion of their affairs. Darcy was delighted with
+their engagement; his friend had given him the earliest information of
+it.
+
+“I must ask whether you were surprised?” said Elizabeth.
+
+“Not at all. When I went away, I felt that it would soon happen.”
+
+“That is to say, you had given your permission. I guessed as much.” And
+though he exclaimed at the term, she found that it had been pretty much
+the case.
+
+“On the evening before my going to London,” said he, “I made a
+confession to him, which I believe I ought to have made long ago. I
+told him of all that had occurred to make my former interference in his
+affairs absurd and impertinent. His surprise was great. He had never had
+the slightest suspicion. I told him, moreover, that I believed myself
+mistaken in supposing, as I had done, that your sister was indifferent
+to him; and as I could easily perceive that his attachment to her was
+unabated, I felt no doubt of their happiness together.”
+
+Elizabeth could not help smiling at his easy manner of directing his
+friend.
+
+“Did you speak from your own observation,” said she, “when you told him
+that my sister loved him, or merely from my information last spring?”
+
+“From the former. I had narrowly observed her during the two visits
+which I had lately made here; and I was convinced of her affection.”
+
+“And your assurance of it, I suppose, carried immediate conviction to
+him.”
+
+“It did. Bingley is most unaffectedly modest. His diffidence had
+prevented his depending on his own judgment in so anxious a case, but
+his reliance on mine made every thing easy. I was obliged to confess
+one thing, which for a time, and not unjustly, offended him. I could not
+allow myself to conceal that your sister had been in town three months
+last winter, that I had known it, and purposely kept it from him. He was
+angry. But his anger, I am persuaded, lasted no longer than he remained
+in any doubt of your sister’s sentiments. He has heartily forgiven me
+now.”
+
+Elizabeth longed to observe that Mr. Bingley had been a most delightful
+friend; so easily guided that his worth was invaluable; but she checked
+herself. She remembered that he had yet to learn to be laughed at,
+and it was rather too early to begin. In anticipating the happiness
+of Bingley, which of course was to be inferior only to his own, he
+continued the conversation till they reached the house. In the hall they
+parted.
+
+
+
+Chapter 59
+
+
+“My dear Lizzy, where can you have been walking to?” was a question
+which Elizabeth received from Jane as soon as she entered their room,
+and from all the others when they sat down to table. She had only to
+say in reply, that they had wandered about, till she was beyond her own
+knowledge. She coloured as she spoke; but neither that, nor anything
+else, awakened a suspicion of the truth.
+
+The evening passed quietly, unmarked by anything extraordinary. The
+acknowledged lovers talked and laughed, the unacknowledged were silent.
+Darcy was not of a disposition in which happiness overflows in mirth;
+and Elizabeth, agitated and confused, rather _knew_ that she was happy
+than _felt_ herself to be so; for, besides the immediate embarrassment,
+there were other evils before her. She anticipated what would be felt
+in the family when her situation became known; she was aware that no
+one liked him but Jane; and even feared that with the others it was a
+dislike which not all his fortune and consequence might do away.
+
+At night she opened her heart to Jane. Though suspicion was very far
+from Miss Bennet’s general habits, she was absolutely incredulous here.
+
+“You are joking, Lizzy. This cannot be!--engaged to Mr. Darcy! No, no,
+you shall not deceive me. I know it to be impossible.”
+
+“This is a wretched beginning indeed! My sole dependence was on you; and
+I am sure nobody else will believe me, if you do not. Yet, indeed, I am
+in earnest. I speak nothing but the truth. He still loves me, and we are
+engaged.”
+
+Jane looked at her doubtingly. “Oh, Lizzy! it cannot be. I know how much
+you dislike him.”
+
+“You know nothing of the matter. _That_ is all to be forgot. Perhaps I
+did not always love him so well as I do now. But in such cases as
+these, a good memory is unpardonable. This is the last time I shall ever
+remember it myself.”
+
+Miss Bennet still looked all amazement. Elizabeth again, and more
+seriously assured her of its truth.
+
+“Good Heaven! can it be really so! Yet now I must believe you,” cried
+Jane. “My dear, dear Lizzy, I would--I do congratulate you--but are you
+certain? forgive the question--are you quite certain that you can be
+happy with him?”
+
+“There can be no doubt of that. It is settled between us already, that
+we are to be the happiest couple in the world. But are you pleased,
+Jane? Shall you like to have such a brother?”
+
+“Very, very much. Nothing could give either Bingley or myself more
+delight. But we considered it, we talked of it as impossible. And do you
+really love him quite well enough? Oh, Lizzy! do anything rather than
+marry without affection. Are you quite sure that you feel what you ought
+to do?”
+
+“Oh, yes! You will only think I feel _more_ than I ought to do, when I
+tell you all.”
+
+“What do you mean?”
+
+“Why, I must confess that I love him better than I do Bingley. I am
+afraid you will be angry.”
+
+“My dearest sister, now _be_ serious. I want to talk very seriously. Let
+me know every thing that I am to know, without delay. Will you tell me
+how long you have loved him?”
+
+“It has been coming on so gradually, that I hardly know when it began.
+But I believe I must date it from my first seeing his beautiful grounds
+at Pemberley.”
+
+Another entreaty that she would be serious, however, produced the
+desired effect; and she soon satisfied Jane by her solemn assurances
+of attachment. When convinced on that article, Miss Bennet had nothing
+further to wish.
+
+“Now I am quite happy,” said she, “for you will be as happy as myself.
+I always had a value for him. Were it for nothing but his love of you,
+I must always have esteemed him; but now, as Bingley’s friend and your
+husband, there can be only Bingley and yourself more dear to me. But
+Lizzy, you have been very sly, very reserved with me. How little did you
+tell me of what passed at Pemberley and Lambton! I owe all that I know
+of it to another, not to you.”
+
+Elizabeth told her the motives of her secrecy. She had been unwilling
+to mention Bingley; and the unsettled state of her own feelings had made
+her equally avoid the name of his friend. But now she would no longer
+conceal from her his share in Lydia’s marriage. All was acknowledged,
+and half the night spent in conversation.
+
+                          * * * * *
+
+“Good gracious!” cried Mrs. Bennet, as she stood at a window the next
+morning, “if that disagreeable Mr. Darcy is not coming here again with
+our dear Bingley! What can he mean by being so tiresome as to be always
+coming here? I had no notion but he would go a-shooting, or something or
+other, and not disturb us with his company. What shall we do with him?
+Lizzy, you must walk out with him again, that he may not be in Bingley’s
+way.”
+
+Elizabeth could hardly help laughing at so convenient a proposal; yet
+was really vexed that her mother should be always giving him such an
+epithet.
+
+As soon as they entered, Bingley looked at her so expressively, and
+shook hands with such warmth, as left no doubt of his good information;
+and he soon afterwards said aloud, “Mrs. Bennet, have you no more lanes
+hereabouts in which Lizzy may lose her way again to-day?”
+
+“I advise Mr. Darcy, and Lizzy, and Kitty,” said Mrs. Bennet, “to walk
+to Oakham Mount this morning. It is a nice long walk, and Mr. Darcy has
+never seen the view.”
+
+“It may do very well for the others,” replied Mr. Bingley; “but I am
+sure it will be too much for Kitty. Won’t it, Kitty?” Kitty owned that
+she had rather stay at home. Darcy professed a great curiosity to see
+the view from the Mount, and Elizabeth silently consented. As she went
+up stairs to get ready, Mrs. Bennet followed her, saying:
+
+“I am quite sorry, Lizzy, that you should be forced to have that
+disagreeable man all to yourself. But I hope you will not mind it: it is
+all for Jane’s sake, you know; and there is no occasion for talking
+to him, except just now and then. So, do not put yourself to
+inconvenience.”
+
+During their walk, it was resolved that Mr. Bennet’s consent should be
+asked in the course of the evening. Elizabeth reserved to herself the
+application for her mother’s. She could not determine how her mother
+would take it; sometimes doubting whether all his wealth and grandeur
+would be enough to overcome her abhorrence of the man. But whether she
+were violently set against the match, or violently delighted with it, it
+was certain that her manner would be equally ill adapted to do credit
+to her sense; and she could no more bear that Mr. Darcy should hear
+the first raptures of her joy, than the first vehemence of her
+disapprobation.
+
+                          * * * * *
+
+In the evening, soon after Mr. Bennet withdrew to the library, she saw
+Mr. Darcy rise also and follow him, and her agitation on seeing it was
+extreme. She did not fear her father’s opposition, but he was going to
+be made unhappy; and that it should be through her means--that _she_,
+his favourite child, should be distressing him by her choice, should be
+filling him with fears and regrets in disposing of her--was a wretched
+reflection, and she sat in misery till Mr. Darcy appeared again, when,
+looking at him, she was a little relieved by his smile. In a few minutes
+he approached the table where she was sitting with Kitty; and, while
+pretending to admire her work said in a whisper, “Go to your father, he
+wants you in the library.” She was gone directly.
+
+Her father was walking about the room, looking grave and anxious.
+“Lizzy,” said he, “what are you doing? Are you out of your senses, to be
+accepting this man? Have not you always hated him?”
+
+How earnestly did she then wish that her former opinions had been more
+reasonable, her expressions more moderate! It would have spared her from
+explanations and professions which it was exceedingly awkward to give;
+but they were now necessary, and she assured him, with some confusion,
+of her attachment to Mr. Darcy.
+
+“Or, in other words, you are determined to have him. He is rich, to be
+sure, and you may have more fine clothes and fine carriages than Jane.
+But will they make you happy?”
+
+“Have you any other objection,” said Elizabeth, “than your belief of my
+indifference?”
+
+“None at all. We all know him to be a proud, unpleasant sort of man; but
+this would be nothing if you really liked him.”
+
+“I do, I do like him,” she replied, with tears in her eyes, “I love him.
+Indeed he has no improper pride. He is perfectly amiable. You do not
+know what he really is; then pray do not pain me by speaking of him in
+such terms.”
+
+“Lizzy,” said her father, “I have given him my consent. He is the kind
+of man, indeed, to whom I should never dare refuse anything, which he
+condescended to ask. I now give it to _you_, if you are resolved on
+having him. But let me advise you to think better of it. I know
+your disposition, Lizzy. I know that you could be neither happy nor
+respectable, unless you truly esteemed your husband; unless you looked
+up to him as a superior. Your lively talents would place you in the
+greatest danger in an unequal marriage. You could scarcely escape
+discredit and misery. My child, let me not have the grief of seeing
+_you_ unable to respect your partner in life. You know not what you are
+about.”
+
+Elizabeth, still more affected, was earnest and solemn in her reply; and
+at length, by repeated assurances that Mr. Darcy was really the object
+of her choice, by explaining the gradual change which her estimation of
+him had undergone, relating her absolute certainty that his affection
+was not the work of a day, but had stood the test of many months’
+suspense, and enumerating with energy all his good qualities, she did
+conquer her father’s incredulity, and reconcile him to the match.
+
+“Well, my dear,” said he, when she ceased speaking, “I have no more to
+say. If this be the case, he deserves you. I could not have parted with
+you, my Lizzy, to anyone less worthy.”
+
+To complete the favourable impression, she then told him what Mr. Darcy
+had voluntarily done for Lydia. He heard her with astonishment.
+
+“This is an evening of wonders, indeed! And so, Darcy did every thing;
+made up the match, gave the money, paid the fellow’s debts, and got him
+his commission! So much the better. It will save me a world of trouble
+and economy. Had it been your uncle’s doing, I must and _would_ have
+paid him; but these violent young lovers carry every thing their own
+way. I shall offer to pay him to-morrow; he will rant and storm about
+his love for you, and there will be an end of the matter.”
+
+He then recollected her embarrassment a few days before, on his reading
+Mr. Collins’s letter; and after laughing at her some time, allowed her
+at last to go--saying, as she quitted the room, “If any young men come
+for Mary or Kitty, send them in, for I am quite at leisure.”
+
+Elizabeth’s mind was now relieved from a very heavy weight; and, after
+half an hour’s quiet reflection in her own room, she was able to join
+the others with tolerable composure. Every thing was too recent for
+gaiety, but the evening passed tranquilly away; there was no longer
+anything material to be dreaded, and the comfort of ease and familiarity
+would come in time.
+
+When her mother went up to her dressing-room at night, she followed her,
+and made the important communication. Its effect was most extraordinary;
+for on first hearing it, Mrs. Bennet sat quite still, and unable to
+utter a syllable. Nor was it under many, many minutes that she could
+comprehend what she heard; though not in general backward to credit
+what was for the advantage of her family, or that came in the shape of a
+lover to any of them. She began at length to recover, to fidget about in
+her chair, get up, sit down again, wonder, and bless herself.
+
+“Good gracious! Lord bless me! only think! dear me! Mr. Darcy! Who would
+have thought it! And is it really true? Oh! my sweetest Lizzy! how rich
+and how great you will be! What pin-money, what jewels, what carriages
+you will have! Jane’s is nothing to it--nothing at all. I am so
+pleased--so happy. Such a charming man!--so handsome! so tall!--Oh, my
+dear Lizzy! pray apologise for my having disliked him so much before. I
+hope he will overlook it. Dear, dear Lizzy. A house in town! Every thing
+that is charming! Three daughters married! Ten thousand a year! Oh,
+Lord! What will become of me. I shall go distracted.”
+
+This was enough to prove that her approbation need not be doubted: and
+Elizabeth, rejoicing that such an effusion was heard only by herself,
+soon went away. But before she had been three minutes in her own room,
+her mother followed her.
+
+“My dearest child,” she cried, “I can think of nothing else! Ten
+thousand a year, and very likely more! ‘Tis as good as a Lord! And a
+special licence. You must and shall be married by a special licence. But
+my dearest love, tell me what dish Mr. Darcy is particularly fond of,
+that I may have it to-morrow.”
+
+This was a sad omen of what her mother’s behaviour to the gentleman
+himself might be; and Elizabeth found that, though in the certain
+possession of his warmest affection, and secure of her relations’
+consent, there was still something to be wished for. But the morrow
+passed off much better than she expected; for Mrs. Bennet luckily stood
+in such awe of her intended son-in-law that she ventured not to speak to
+him, unless it was in her power to offer him any attention, or mark her
+deference for his opinion.
+
+Elizabeth had the satisfaction of seeing her father taking pains to get
+acquainted with him; and Mr. Bennet soon assured her that he was rising
+every hour in his esteem.
+
+“I admire all my three sons-in-law highly,” said he. “Wickham, perhaps,
+is my favourite; but I think I shall like _your_ husband quite as well
+as Jane’s.”
+
+
+
+Chapter 60
+
+
+Elizabeth’s spirits soon rising to playfulness again, she wanted Mr.
+Darcy to account for his having ever fallen in love with her. “How could
+you begin?” said she. “I can comprehend your going on charmingly, when
+you had once made a beginning; but what could set you off in the first
+place?”
+
+“I cannot fix on the hour, or the spot, or the look, or the words, which
+laid the foundation. It is too long ago. I was in the middle before I
+knew that I _had_ begun.”
+
+“My beauty you had early withstood, and as for my manners--my behaviour
+to _you_ was at least always bordering on the uncivil, and I never spoke
+to you without rather wishing to give you pain than not. Now be sincere;
+did you admire me for my impertinence?”
+
+“For the liveliness of your mind, I did.”
+
+“You may as well call it impertinence at once. It was very little less.
+The fact is, that you were sick of civility, of deference, of officious
+attention. You were disgusted with the women who were always speaking,
+and looking, and thinking for _your_ approbation alone. I roused, and
+interested you, because I was so unlike _them_. Had you not been really
+amiable, you would have hated me for it; but in spite of the pains you
+took to disguise yourself, your feelings were always noble and just; and
+in your heart, you thoroughly despised the persons who so assiduously
+courted you. There--I have saved you the trouble of accounting for
+it; and really, all things considered, I begin to think it perfectly
+reasonable. To be sure, you knew no actual good of me--but nobody thinks
+of _that_ when they fall in love.”
+
+“Was there no good in your affectionate behaviour to Jane while she was
+ill at Netherfield?”
+
+“Dearest Jane! who could have done less for her? But make a virtue of it
+by all means. My good qualities are under your protection, and you are
+to exaggerate them as much as possible; and, in return, it belongs to me
+to find occasions for teasing and quarrelling with you as often as may
+be; and I shall begin directly by asking you what made you so unwilling
+to come to the point at last. What made you so shy of me, when you first
+called, and afterwards dined here? Why, especially, when you called, did
+you look as if you did not care about me?”
+
+“Because you were grave and silent, and gave me no encouragement.”
+
+“But I was embarrassed.”
+
+“And so was I.”
+
+“You might have talked to me more when you came to dinner.”
+
+“A man who had felt less, might.”
+
+“How unlucky that you should have a reasonable answer to give, and that
+I should be so reasonable as to admit it! But I wonder how long you
+_would_ have gone on, if you had been left to yourself. I wonder when
+you _would_ have spoken, if I had not asked you! My resolution of
+thanking you for your kindness to Lydia had certainly great effect.
+_Too much_, I am afraid; for what becomes of the moral, if our comfort
+springs from a breach of promise? for I ought not to have mentioned the
+subject. This will never do.”
+
+“You need not distress yourself. The moral will be perfectly fair. Lady
+Catherine’s unjustifiable endeavours to separate us were the means of
+removing all my doubts. I am not indebted for my present happiness to
+your eager desire of expressing your gratitude. I was not in a humour
+to wait for any opening of yours. My aunt’s intelligence had given me
+hope, and I was determined at once to know every thing.”
+
+“Lady Catherine has been of infinite use, which ought to make her happy,
+for she loves to be of use. But tell me, what did you come down to
+Netherfield for? Was it merely to ride to Longbourn and be embarrassed?
+or had you intended any more serious consequence?”
+
+“My real purpose was to see _you_, and to judge, if I could, whether I
+might ever hope to make you love me. My avowed one, or what I avowed to
+myself, was to see whether your sister were still partial to Bingley,
+and if she were, to make the confession to him which I have since made.”
+
+“Shall you ever have courage to announce to Lady Catherine what is to
+befall her?”
+
+“I am more likely to want more time than courage, Elizabeth. But it
+ought to be done, and if you will give me a sheet of paper, it shall be
+done directly.”
+
+“And if I had not a letter to write myself, I might sit by you and
+admire the evenness of your writing, as another young lady once did. But
+I have an aunt, too, who must not be longer neglected.”
+
+From an unwillingness to confess how much her intimacy with Mr. Darcy
+had been over-rated, Elizabeth had never yet answered Mrs. Gardiner’s
+long letter; but now, having _that_ to communicate which she knew would
+be most welcome, she was almost ashamed to find that her uncle and
+aunt had already lost three days of happiness, and immediately wrote as
+follows:
+
+“I would have thanked you before, my dear aunt, as I ought to have done,
+for your long, kind, satisfactory, detail of particulars; but to say the
+truth, I was too cross to write. You supposed more than really existed.
+But _now_ suppose as much as you choose; give a loose rein to your
+fancy, indulge your imagination in every possible flight which the
+subject will afford, and unless you believe me actually married, you
+cannot greatly err. You must write again very soon, and praise him a
+great deal more than you did in your last. I thank you, again and again,
+for not going to the Lakes. How could I be so silly as to wish it! Your
+idea of the ponies is delightful. We will go round the Park every day. I
+am the happiest creature in the world. Perhaps other people have said so
+before, but not one with such justice. I am happier even than Jane; she
+only smiles, I laugh. Mr. Darcy sends you all the love in the world that
+he can spare from me. You are all to come to Pemberley at Christmas.
+Yours, etc.”
+
+Mr. Darcy’s letter to Lady Catherine was in a different style; and still
+different from either was what Mr. Bennet sent to Mr. Collins, in reply
+to his last.
+
+“DEAR SIR,
+
+“I must trouble you once more for congratulations. Elizabeth will soon
+be the wife of Mr. Darcy. Console Lady Catherine as well as you can.
+But, if I were you, I would stand by the nephew. He has more to give.
+
+“Yours sincerely, etc.”
+
+Miss Bingley’s congratulations to her brother, on his approaching
+marriage, were all that was affectionate and insincere. She wrote even
+to Jane on the occasion, to express her delight, and repeat all her
+former professions of regard. Jane was not deceived, but she was
+affected; and though feeling no reliance on her, could not help writing
+her a much kinder answer than she knew was deserved.
+
+The joy which Miss Darcy expressed on receiving similar information,
+was as sincere as her brother’s in sending it. Four sides of paper were
+insufficient to contain all her delight, and all her earnest desire of
+being loved by her sister.
+
+Before any answer could arrive from Mr. Collins, or any congratulations
+to Elizabeth from his wife, the Longbourn family heard that the
+Collinses were come themselves to Lucas Lodge. The reason of this
+sudden removal was soon evident. Lady Catherine had been rendered
+so exceedingly angry by the contents of her nephew’s letter, that
+Charlotte, really rejoicing in the match, was anxious to get away till
+the storm was blown over. At such a moment, the arrival of her friend
+was a sincere pleasure to Elizabeth, though in the course of their
+meetings she must sometimes think the pleasure dearly bought, when she
+saw Mr. Darcy exposed to all the parading and obsequious civility of
+her husband. He bore it, however, with admirable calmness. He could even
+listen to Sir William Lucas, when he complimented him on carrying away
+the brightest jewel of the country, and expressed his hopes of their all
+meeting frequently at St. James’s, with very decent composure. If he did
+shrug his shoulders, it was not till Sir William was out of sight.
+
+Mrs. Phillips’s vulgarity was another, and perhaps a greater, tax on his
+forbearance; and though Mrs. Phillips, as well as her sister, stood in
+too much awe of him to speak with the familiarity which Bingley’s good
+humour encouraged, yet, whenever she _did_ speak, she must be vulgar.
+Nor was her respect for him, though it made her more quiet, at all
+likely to make her more elegant. Elizabeth did all she could to shield
+him from the frequent notice of either, and was ever anxious to keep
+him to herself, and to those of her family with whom he might converse
+without mortification; and though the uncomfortable feelings arising
+from all this took from the season of courtship much of its pleasure, it
+added to the hope of the future; and she looked forward with delight to
+the time when they should be removed from society so little pleasing
+to either, to all the comfort and elegance of their family party at
+Pemberley.
+
+
+
+Chapter 61
+
+
+Happy for all her maternal feelings was the day on which Mrs. Bennet got
+rid of her two most deserving daughters. With what delighted pride
+she afterwards visited Mrs. Bingley, and talked of Mrs. Darcy, may
+be guessed. I wish I could say, for the sake of her family, that the
+accomplishment of her earnest desire in the establishment of so many
+of her children produced so happy an effect as to make her a sensible,
+amiable, well-informed woman for the rest of her life; though perhaps it
+was lucky for her husband, who might not have relished domestic felicity
+in so unusual a form, that she still was occasionally nervous and
+invariably silly.
+
+Mr. Bennet missed his second daughter exceedingly; his affection for her
+drew him oftener from home than anything else could do. He delighted in
+going to Pemberley, especially when he was least expected.
+
+Mr. Bingley and Jane remained at Netherfield only a twelvemonth. So near
+a vicinity to her mother and Meryton relations was not desirable even to
+_his_ easy temper, or _her_ affectionate heart. The darling wish of his
+sisters was then gratified; he bought an estate in a neighbouring county
+to Derbyshire, and Jane and Elizabeth, in addition to every other source
+of happiness, were within thirty miles of each other.
+
+Kitty, to her very material advantage, spent the chief of her time with
+her two elder sisters. In society so superior to what she had generally
+known, her improvement was great. She was not of so ungovernable a
+temper as Lydia; and, removed from the influence of Lydia’s example,
+she became, by proper attention and management, less irritable, less
+ignorant, and less insipid. From the further disadvantage of Lydia’s
+society she was of course carefully kept, and though Mrs. Wickham
+frequently invited her to come and stay with her, with the promise of
+balls and young men, her father would never consent to her going.
+
+Mary was the only daughter who remained at home; and she was necessarily
+drawn from the pursuit of accomplishments by Mrs. Bennet’s being quite
+unable to sit alone. Mary was obliged to mix more with the world, but
+she could still moralize over every morning visit; and as she was no
+longer mortified by comparisons between her sisters’ beauty and her own,
+it was suspected by her father that she submitted to the change without
+much reluctance.
+
+As for Wickham and Lydia, their characters suffered no revolution from
+the marriage of her sisters. He bore with philosophy the conviction that
+Elizabeth must now become acquainted with whatever of his ingratitude
+and falsehood had before been unknown to her; and in spite of every
+thing, was not wholly without hope that Darcy might yet be prevailed on
+to make his fortune. The congratulatory letter which Elizabeth received
+from Lydia on her marriage, explained to her that, by his wife at least,
+if not by himself, such a hope was cherished. The letter was to this
+effect:
+
+“MY DEAR LIZZY,
+
+“I wish you joy. If you love Mr. Darcy half as well as I do my dear
+Wickham, you must be very happy. It is a great comfort to have you so
+rich, and when you have nothing else to do, I hope you will think of us.
+I am sure Wickham would like a place at court very much, and I do not
+think we shall have quite money enough to live upon without some help.
+Any place would do, of about three or four hundred a year; but however,
+do not speak to Mr. Darcy about it, if you had rather not.
+
+“Yours, etc.”
+
+As it happened that Elizabeth had _much_ rather not, she endeavoured in
+her answer to put an end to every entreaty and expectation of the kind.
+Such relief, however, as it was in her power to afford, by the practice
+of what might be called economy in her own private expences, she
+frequently sent them. It had always been evident to her that such an
+income as theirs, under the direction of two persons so extravagant in
+their wants, and heedless of the future, must be very insufficient to
+their support; and whenever they changed their quarters, either Jane or
+herself were sure of being applied to for some little assistance
+towards discharging their bills. Their manner of living, even when the
+restoration of peace dismissed them to a home, was unsettled in the
+extreme. They were always moving from place to place in quest of a cheap
+situation, and always spending more than they ought. His affection for
+her soon sunk into indifference; hers lasted a little longer; and
+in spite of her youth and her manners, she retained all the claims to
+reputation which her marriage had given her.
+
+Though Darcy could never receive _him_ at Pemberley, yet, for
+Elizabeth’s sake, he assisted him further in his profession. Lydia was
+occasionally a visitor there, when her husband was gone to enjoy himself
+in London or Bath; and with the Bingleys they both of them frequently
+staid so long, that even Bingley’s good humour was overcome, and he
+proceeded so far as to talk of giving them a hint to be gone.
+
+Miss Bingley was very deeply mortified by Darcy’s marriage; but as she
+thought it advisable to retain the right of visiting at Pemberley, she
+dropt all her resentment; was fonder than ever of Georgiana, almost as
+attentive to Darcy as heretofore, and paid off every arrear of civility
+to Elizabeth.
+
+Pemberley was now Georgiana’s home; and the attachment of the sisters
+was exactly what Darcy had hoped to see. They were able to love each
+other even as well as they intended. Georgiana had the highest opinion
+in the world of Elizabeth; though at first she often listened with
+an astonishment bordering on alarm at her lively, sportive, manner of
+talking to her brother. He, who had always inspired in herself a respect
+which almost overcame her affection, she now saw the object of open
+pleasantry. Her mind received knowledge which had never before fallen
+in her way. By Elizabeth’s instructions, she began to comprehend that
+a woman may take liberties with her husband which a brother will not
+always allow in a sister more than ten years younger than himself.
+
+Lady Catherine was extremely indignant on the marriage of her nephew;
+and as she gave way to all the genuine frankness of her character in
+her reply to the letter which announced its arrangement, she sent him
+language so very abusive, especially of Elizabeth, that for some time
+all intercourse was at an end. But at length, by Elizabeth’s persuasion,
+he was prevailed on to overlook the offence, and seek a reconciliation;
+and, after a little further resistance on the part of his aunt, her
+resentment gave way, either to her affection for him, or her curiosity
+to see how his wife conducted herself; and she condescended to wait
+on them at Pemberley, in spite of that pollution which its woods had
+received, not merely from the presence of such a mistress, but the
+visits of her uncle and aunt from the city.
+
+With the Gardiners, they were always on the most intimate terms.
+Darcy, as well as Elizabeth, really loved them; and they were both ever
+sensible of the warmest gratitude towards the persons who, by bringing
+her into Derbyshire, had been the means of uniting them.
+
+
+
+
+
+End of the Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+***** This file should be named 1342-0.txt or 1342-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/3/4/1342/
+
+Produced by Anonymous Volunteers
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/relativity-special-and-general-theory.txt
+++ b/jet/source-sink-builder/src/main/resources/books/relativity-special-and-general-theory.txt
@@ -1,0 +1,4063 @@
+﻿The Project Gutenberg EBook of Relativity: The Special and General Theory
+by Albert Einstein
+(#1 in our series by Albert Einstein)
+
+Note: 58 image files are part of this eBook.  They include tables,
+equations and figures that could not be represented well as plain text.
+
+Copyright laws are changing all over the world. Be sure to check the
+copyright laws for your country before downloading or redistributing
+this or any other Project Gutenberg eBook.
+
+This header should be the first thing seen when viewing this Project
+Gutenberg file.  Please do not remove it.  Do not change or edit the
+header without written permission.
+
+Please read the "legal small print," and other information about the
+eBook and Project Gutenberg at the bottom of this file.  Included is
+important information about your specific rights and restrictions in
+how the file may be used.  You can also find out about how to make a
+donation to Project Gutenberg, and how to get involved.
+
+
+**Welcome To The World of Free Plain Vanilla Electronic Texts**
+
+**eBooks Readable By Both Humans and By Computers, Since 1971**
+
+*****These eBooks Were Prepared By Thousands of Volunteers!*****
+
+
+Title: Relativity: The Special and General Theory
+
+Author: Albert Einstein
+
+Release Date: February, 2004  [EBook #5001]
+[Yes, we are more than one year ahead of schedule]
+[This file was first posted on April 1, 2002]
+
+Edition: 10
+
+Language: English
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+
+
+
+ALBERT EINSTEIN REFERENCE ARCHIVE
+
+RELATIVITY: THE SPECIAL AND GENERAL THEORY
+
+BY ALBERT EINSTEIN
+
+
+Written: 1916 (this revised edition: 1924)
+Source: Relativity: The Special and General Theory (1920)
+Publisher: Methuen & Co Ltd
+First Published: December, 1916
+Translated: Robert W. Lawson (Authorised translation)
+Transcription/Markup: Brian Basgen <brian@marxists.org>
+Transcription to text: Gregory B. Newby <gbnewby@petascale.org>
+Thanks to: Einstein Reference Archive (marxists.org)
+The Einstein Reference Archive is online at:
+http://www.marxists.org/reference/archive/einstein/index.htm
+
+Transcriber note: This file is a plain text rendition of HTML.
+Because many equations cannot be presented effectively in plain text,
+images are supplied for many equations and for all figures and tables.
+
+
+CONTENTS
+
+Preface
+
+Part I: The Special Theory of Relativity
+
+01. Physical Meaning of Geometrical Propositions
+02. The System of Co-ordinates
+03. Space and Time in Classical Mechanics
+04. The Galileian System of Co-ordinates
+05. The Principle of Relativity (in the Restricted Sense)
+06. The Theorem of the Addition of Velocities employed in
+Classical Mechanics
+07. The Apparent Incompatability of the Law of Propagation of
+Light with the Principle of Relativity
+08. On the Idea of Time in Physics
+09. The Relativity of Simultaneity
+10. On the Relativity of the Conception of Distance
+11. The Lorentz Transformation
+12. The Behaviour of Measuring-Rods and Clocks in Motion
+13. Theorem of the Addition of Velocities. The Experiment of Fizeau
+14. The Hueristic Value of the Theory of Relativity
+15. General Results of the Theory
+16. Expereince and the Special Theory of Relativity
+17. Minkowski's Four-dimensial Space
+
+
+Part II: The General Theory of Relativity
+
+18. Special and General Principle of Relativity
+19. The Gravitational Field
+20. The Equality of Inertial and Gravitational Mass as an Argument
+for the General Postulate of Relativity
+21. In What Respects are the Foundations of Classical Mechanics
+and of the Special Theory of Relativity Unsatisfactory?
+22. A Few Inferences from the General Principle of Relativity
+23. Behaviour of Clocks and Measuring-Rods on a Rotating Body of
+Reference
+24. Euclidean and non-Euclidean Continuum
+25. Gaussian Co-ordinates
+26. The Space-Time Continuum of the Speical Theory of Relativity
+Considered as a Euclidean Continuum
+27. The Space-Time Continuum of the General Theory of Relativity
+is Not a Eculidean Continuum
+28. Exact Formulation of the General Principle of Relativity
+29. The Solution of the Problem of Gravitation on the Basis of the
+General Principle of Relativity
+
+
+Part III: Considerations on the Universe as a Whole
+
+30. Cosmological Difficulties of Netwon's Theory
+31. The Possibility of a "Finite" and yet "Unbounded" Universe
+32. The Structure of Space According to the General Theory of
+Relativity
+
+
+Appendices:
+
+01. Simple Derivation of the Lorentz Transformation (sup. ch. 11)
+02. Minkowski's Four-Dimensional Space ("World") (sup. ch 17)
+03. The Experimental Confirmation of the General Theory of Relativity
+04. The Structure of Space According to the General Theory of
+Relativity (sup. ch 32)
+05. Relativity and the Problem of Space
+
+Note: The fifth Appendix was added by Einstein at the time of the
+fifteenth re-printing of this book; and as a result is still under
+copyright restrictions so cannot be added without the permission of
+the publisher.
+
+
+
+PREFACE
+
+ (December, 1916)
+
+The present book is intended, as far as possible, to give an exact
+insight into the theory of Relativity to those readers who, from a
+general scientific and philosophical point of view, are interested in
+the theory, but who are not conversant with the mathematical apparatus
+of theoretical physics. The work presumes a standard of education
+corresponding to that of a university matriculation examination, and,
+despite the shortness of the book, a fair amount of patience and force
+of will on the part of the reader. The author has spared himself no
+pains in his endeavour to present the main ideas in the simplest and
+most intelligible form, and on the whole, in the sequence and
+connection in which they actually originated. In the interest of
+clearness, it appeared to me inevitable that I should repeat myself
+frequently, without paying the slightest attention to the elegance of
+the presentation. I adhered scrupulously to the precept of that
+brilliant theoretical physicist L. Boltzmann, according to whom
+matters of elegance ought to be left to the tailor and to the cobbler.
+I make no pretence of having withheld from the reader difficulties
+which are inherent to the subject. On the other hand, I have purposely
+treated the empirical physical foundations of the theory in a
+"step-motherly" fashion, so that readers unfamiliar with physics may
+not feel like the wanderer who was unable to see the forest for the
+trees. May the book bring some one a few happy hours of suggestive
+thought!
+
+December, 1916
+A. EINSTEIN
+
+
+
+PART I
+
+THE SPECIAL THEORY OF RELATIVITY
+
+PHYSICAL MEANING OF GEOMETRICAL PROPOSITIONS
+
+
+In your schooldays most of you who read this book made acquaintance
+with the noble building of Euclid's geometry, and you remember --
+perhaps with more respect than love -- the magnificent structure, on
+the lofty staircase of which you were chased about for uncounted hours
+by conscientious teachers. By reason of our past experience, you would
+certainly regard everyone with disdain who should pronounce even the
+most out-of-the-way proposition of this science to be untrue. But
+perhaps this feeling of proud certainty would leave you immediately if
+some one were to ask you: "What, then, do you mean by the assertion
+that these propositions are true?" Let us proceed to give this
+question a little consideration.
+
+Geometry sets out form certain conceptions such as "plane," "point,"
+and "straight line," with which we are able to associate more or less
+definite ideas, and from certain simple propositions (axioms) which,
+in virtue of these ideas, we are inclined to accept as "true." Then,
+on the basis of a logical process, the justification of which we feel
+ourselves compelled to admit, all remaining propositions are shown to
+follow from those axioms, i.e. they are proven. A proposition is then
+correct ("true") when it has been derived in the recognised manner
+from the axioms. The question of "truth" of the individual geometrical
+propositions is thus reduced to one of the "truth" of the axioms. Now
+it has long been known that the last question is not only unanswerable
+by the methods of geometry, but that it is in itself entirely without
+meaning. We cannot ask whether it is true that only one straight line
+goes through two points. We can only say that Euclidean geometry deals
+with things called "straight lines," to each of which is ascribed the
+property of being uniquely determined by two points situated on it.
+The concept "true" does not tally with the assertions of pure
+geometry, because by the word "true" we are eventually in the habit of
+designating always the correspondence with a "real" object; geometry,
+however, is not concerned with the relation of the ideas involved in
+it to objects of experience, but only with the logical connection of
+these ideas among themselves.
+
+It is not difficult to understand why, in spite of this, we feel
+constrained to call the propositions of geometry "true." Geometrical
+ideas correspond to more or less exact objects in nature, and these
+last are undoubtedly the exclusive cause of the genesis of those
+ideas. Geometry ought to refrain from such a course, in order to give
+to its structure the largest possible logical unity. The practice, for
+example, of seeing in a "distance" two marked positions on a
+practically rigid body is something which is lodged deeply in our
+habit of thought. We are accustomed further to regard three points as
+being situated on a straight line, if their apparent positions can be
+made to coincide for observation with one eye, under suitable choice
+of our place of observation.
+
+If, in pursuance of our habit of thought, we now supplement the
+propositions of Euclidean geometry by the single proposition that two
+points on a practically rigid body always correspond to the same
+distance (line-interval), independently of any changes in position to
+which we may subject the body, the propositions of Euclidean geometry
+then resolve themselves into propositions on the possible relative
+position of practically rigid bodies.* Geometry which has been
+supplemented in this way is then to be treated as a branch of physics.
+We can now legitimately ask as to the "truth" of geometrical
+propositions interpreted in this way, since we are justified in asking
+whether these propositions are satisfied for those real things we have
+associated with the geometrical ideas. In less exact terms we can
+express this by saying that by the "truth" of a geometrical
+proposition in this sense we understand its validity for a
+construction with rule and compasses.
+
+Of course the conviction of the "truth" of geometrical propositions in
+this sense is founded exclusively on rather incomplete experience. For
+the present we shall assume the "truth" of the geometrical
+propositions, then at a later stage (in the general theory of
+relativity) we shall see that this "truth" is limited, and we shall
+consider the extent of its limitation.
+
+
+  Notes
+
+*) It follows that a natural object is associated also with a
+straight line. Three points A, B and C on a rigid body thus lie in a
+straight line when the points A and C being given, B is chosen such
+that the sum of the distances AB and BC is as short as possible. This
+incomplete suggestion will suffice for the present purpose.
+
+
+
+THE SYSTEM OF CO-ORDINATES
+
+
+On the basis of the physical interpretation of distance which has been
+indicated, we are also in a position to establish the distance between
+two points on a rigid body by means of measurements. For this purpose
+we require a " distance " (rod S) which is to be used once and for
+all, and which we employ as a standard measure. If, now, A and B are
+two points on a rigid body, we can construct the line joining them
+according to the rules of geometry ; then, starting from A, we can
+mark off the distance S time after time until we reach B. The number
+of these operations required is the numerical measure of the distance
+AB. This is the basis of all measurement of length. *
+
+Every description of the scene of an event or of the position of an
+object in space is based on the specification of the point on a rigid
+body (body of reference) with which that event or object coincides.
+This applies not only to scientific description, but also to everyday
+life. If I analyse the place specification " Times Square, New York,"
+**A I arrive at the following result. The earth is the rigid body
+to which the specification of place refers; " Times Square, New York,"
+is a well-defined point, to which a name has been assigned, and with
+which the event coincides in space.**B
+
+This primitive method of place specification deals only with places on
+the surface of rigid bodies, and is dependent on the existence of
+points on this surface which are distinguishable from each other. But
+we can free ourselves from both of these limitations without altering
+the nature of our specification of position. If, for instance, a cloud
+is hovering over Times Square, then we can determine its position
+relative to the surface of the earth by erecting a pole
+perpendicularly on the Square, so that it reaches the cloud. The
+length of the pole measured with the standard measuring-rod, combined
+with the specification of the position of the foot of the pole,
+supplies us with a complete place specification. On the basis of this
+illustration, we are able to see the manner in which a refinement of
+the conception of position has been developed.
+
+(a) We imagine the rigid body, to which the place specification is
+referred, supplemented in such a manner that the object whose position
+we require is reached by. the completed rigid body.
+
+(b) In locating the position of the object, we make use of a number
+(here the length of the pole measured with the measuring-rod) instead
+of designated points of reference.
+
+(c) We speak of the height of the cloud even when the pole which
+reaches the cloud has not been erected. By means of optical
+observations of the cloud from different positions on the ground, and
+taking into account the properties of the propagation of light, we
+determine the length of the pole we should have required in order to
+reach the cloud.
+
+From this consideration we see that it will be advantageous if, in the
+description of position, it should be possible by means of numerical
+measures to make ourselves independent of the existence of marked
+positions (possessing names) on the rigid body of reference. In the
+physics of measurement this is attained by the application of the
+Cartesian system of co-ordinates.
+
+This consists of three plane surfaces perpendicular to each other and
+rigidly attached to a rigid body. Referred to a system of
+co-ordinates, the scene of any event will be determined (for the main
+part) by the specification of the lengths of the three perpendiculars
+or co-ordinates (x, y, z) which can be dropped from the scene of the
+event to those three plane surfaces. The lengths of these three
+perpendiculars can be determined by a series of manipulations with
+rigid measuring-rods performed according to the rules and methods laid
+down by Euclidean geometry.
+
+In practice, the rigid surfaces which constitute the system of
+co-ordinates are generally not available ; furthermore, the magnitudes
+of the co-ordinates are not actually determined by constructions with
+rigid rods, but by indirect means. If the results of physics and
+astronomy are to maintain their clearness, the physical meaning of
+specifications of position must always be sought in accordance with
+the above considerations. ***
+
+We thus obtain the following result: Every description of events in
+space involves the use of a rigid body to which such events have to be
+referred. The resulting relationship takes for granted that the laws
+of Euclidean geometry hold for "distances;" the "distance" being
+represented physically by means of the convention of two marks on a
+rigid body.
+
+
+  Notes
+
+* Here we have assumed that there is nothing left over i.e. that
+the measurement gives a whole number. This difficulty is got over by
+the use of divided measuring-rods, the introduction of which does not
+demand any fundamentally new method.
+
+**A Einstein used "Potsdamer Platz, Berlin" in the original text.
+In the authorised translation this was supplemented with "Tranfalgar
+Square, London". We have changed this to "Times Square, New York", as
+this is the most well known/identifiable location to English speakers
+in the present day. [Note by the janitor.]
+
+**B It is not necessary here to investigate further the significance
+of the expression "coincidence in space." This conception is
+sufficiently obvious to ensure that differences of opinion are
+scarcely likely to arise as to its applicability in practice.
+
+*** A refinement and modification of these views does not become
+necessary until we come to deal with the general theory of relativity,
+treated in the second part of this book.
+
+
+
+SPACE AND TIME IN CLASSICAL MECHANICS
+
+
+The purpose of mechanics is to describe how bodies change their
+position in space with "time." I should load my conscience with grave
+sins against the sacred spirit of lucidity were I to formulate the
+aims of mechanics in this way, without serious reflection and detailed
+explanations. Let us proceed to disclose these sins.
+
+It is not clear what is to be understood here by "position" and
+"space." I stand at the window of a railway carriage which is
+travelling uniformly, and drop a stone on the embankment, without
+throwing it. Then, disregarding the influence of the air resistance, I
+see the stone descend in a straight line. A pedestrian who observes
+the misdeed from the footpath notices that the stone falls to earth in
+a parabolic curve. I now ask: Do the "positions" traversed by the
+stone lie "in reality" on a straight line or on a parabola? Moreover,
+what is meant here by motion "in space" ? From the considerations of
+the previous section the answer is self-evident. In the first place we
+entirely shun the vague word "space," of which, we must honestly
+acknowledge, we cannot form the slightest conception, and we replace
+it by "motion relative to a practically rigid body of reference." The
+positions relative to the body of reference (railway carriage or
+embankment) have already been defined in detail in the preceding
+section. If instead of " body of reference " we insert " system of
+co-ordinates," which is a useful idea for mathematical description, we
+are in a position to say : The stone traverses a straight line
+relative to a system of co-ordinates rigidly attached to the carriage,
+but relative to a system of co-ordinates rigidly attached to the
+ground (embankment) it describes a parabola. With the aid of this
+example it is clearly seen that there is no such thing as an
+independently existing trajectory (lit. "path-curve"*), but only
+a trajectory relative to a particular body of reference.
+
+In order to have a complete description of the motion, we must specify
+how the body alters its position with time ; i.e. for every point on
+the trajectory it must be stated at what time the body is situated
+there. These data must be supplemented by such a definition of time
+that, in virtue of this definition, these time-values can be regarded
+essentially as magnitudes (results of measurements) capable of
+observation. If we take our stand on the ground of classical
+mechanics, we can satisfy this requirement for our illustration in the
+following manner. We imagine two clocks of identical construction ;
+the man at the railway-carriage window is holding one of them, and the
+man on the footpath the other. Each of the observers determines the
+position on his own reference-body occupied by the stone at each tick
+of the clock he is holding in his hand. In this connection we have not
+taken account of the inaccuracy involved by the finiteness of the
+velocity of propagation of light. With this and with a second
+difficulty prevailing here we shall have to deal in detail later.
+
+
+  Notes
+
+*) That is, a curve along which the body moves.
+
+
+
+THE GALILEIAN SYSTEM OF CO-ORDINATES
+
+
+As is well known, the fundamental law of the mechanics of
+Galilei-Newton, which is known as the law of inertia, can be stated
+thus: A body removed sufficiently far from other bodies continues in a
+state of rest or of uniform motion in a straight line. This law not
+only says something about the motion of the bodies, but it also
+indicates the reference-bodies or systems of coordinates, permissible
+in mechanics, which can be used in mechanical description. The visible
+fixed stars are bodies for which the law of inertia certainly holds to
+a high degree of approximation. Now if we use a system of co-ordinates
+which is rigidly attached to the earth, then, relative to this system,
+every fixed star describes a circle of immense radius in the course of
+an astronomical day, a result which is opposed to the statement of the
+law of inertia. So that if we adhere to this law we must refer these
+motions only to systems of coordinates relative to which the fixed
+stars do not move in a circle. A system of co-ordinates of which the
+state of motion is such that the law of inertia holds relative to it
+is called a " Galileian system of co-ordinates." The laws of the
+mechanics of Galflei-Newton can be regarded as valid only for a
+Galileian system of co-ordinates.
+
+
+
+THE PRINCIPLE OF RELATIVITY
+(IN THE RESTRICTED SENSE)
+
+
+In order to attain the greatest possible clearness, let us return to
+our example of the railway carriage supposed to be travelling
+uniformly. We call its motion a uniform translation ("uniform" because
+it is of constant velocity and direction, " translation " because
+although the carriage changes its position relative to the embankment
+yet it does not rotate in so doing). Let us imagine a raven flying
+through the air in such a manner that its motion, as observed from the
+embankment, is uniform and in a straight line. If we were to observe
+the flying raven from the moving railway carriage. we should find that
+the motion of the raven would be one of different velocity and
+direction, but that it would still be uniform and in a straight line.
+Expressed in an abstract manner we may say : If a mass m is moving
+uniformly in a straight line with respect to a co-ordinate system K,
+then it will also be moving uniformly and in a straight line relative
+to a second co-ordinate system K1 provided that the latter is
+executing a uniform translatory motion with respect to K. In
+accordance with the discussion contained in the preceding section, it
+follows that:
+
+If K is a Galileian co-ordinate system. then every other co-ordinate
+system K' is a Galileian one, when, in relation to K, it is in a
+condition of uniform motion of translation. Relative to K1 the
+mechanical laws of Galilei-Newton hold good exactly as they do with
+respect to K.
+
+We advance a step farther in our generalisation when we express the
+tenet thus: If, relative to K, K1 is a uniformly moving co-ordinate
+system devoid of rotation, then natural phenomena run their course
+with respect to K1 according to exactly the same general laws as with
+respect to K. This statement is called the principle of relativity (in
+the restricted sense).
+
+As long as one was convinced that all natural phenomena were capable
+of representation with the help of classical mechanics, there was no
+need to doubt the validity of this principle of relativity. But in
+view of the more recent development of electrodynamics and optics it
+became more and more evident that classical mechanics affords an
+insufficient foundation for the physical description of all natural
+phenomena. At this juncture the question of the validity of the
+principle of relativity became ripe for discussion, and it did not
+appear impossible that the answer to this question might be in the
+negative.
+
+Nevertheless, there are two general facts which at the outset speak
+very much in favour of the validity of the principle of relativity.
+Even though classical mechanics does not supply us with a sufficiently
+broad basis for the theoretical presentation of all physical
+phenomena, still we must grant it a considerable measure of " truth,"
+since it supplies us with the actual motions of the heavenly bodies
+with a delicacy of detail little short of wonderful. The principle of
+relativity must therefore apply with great accuracy in the domain of
+mechanics. But that a principle of such broad generality should hold
+with such exactness in one domain of phenomena, and yet should be
+invalid for another, is a priori not very probable.
+
+We now proceed to the second argument, to which, moreover, we shall
+return later. If the principle of relativity (in the restricted sense)
+does not hold, then the Galileian co-ordinate systems K, K1, K2, etc.,
+which are moving uniformly relative to each other, will not be
+equivalent for the description of natural phenomena. In this case we
+should be constrained to believe that natural laws are capable of
+being formulated in a particularly simple manner, and of course only
+on condition that, from amongst all possible Galileian co-ordinate
+systems, we should have chosen one (K[0]) of a particular state of
+motion as our body of reference. We should then be justified (because
+of its merits for the description of natural phenomena) in calling
+this system " absolutely at rest," and all other Galileian systems K "
+in motion." If, for instance, our embankment were the system K[0] then
+our railway carriage would be a system K, relative to which less
+simple laws would hold than with respect to K[0]. This diminished
+simplicity would be due to the fact that the carriage K would be in
+motion (i.e."really")with respect to K[0]. In the general laws of
+nature which have been formulated with reference to K, the magnitude
+and direction of the velocity of the carriage would necessarily play a
+part. We should expect, for instance, that the note emitted by an
+organpipe placed with its axis parallel to the direction of travel
+would be different from that emitted if the axis of the pipe were
+placed perpendicular to this direction.
+
+Now in virtue of its motion in an orbit round the sun, our earth is
+comparable with a railway carriage travelling with a velocity of about
+30 kilometres per second. If the principle of relativity were not
+valid we should therefore expect that the direction of motion of the
+earth at any moment would enter into the laws of nature, and also that
+physical systems in their behaviour would be dependent on the
+orientation in space with respect to the earth. For owing to the
+alteration in direction of the velocity of revolution of the earth in
+the course of a year, the earth cannot be at rest relative to the
+hypothetical system K[0] throughout the whole year. However, the most
+careful observations have never revealed such anisotropic properties
+in terrestrial physical space, i.e. a physical non-equivalence of
+different directions. This is very powerful argument in favour of the
+principle of relativity.
+
+
+
+THE THEOREM OF THE
+ADDITION OF VELOCITIES
+EMPLOYED IN CLASSICAL MECHANICS
+
+
+Let us suppose our old friend the railway carriage to be travelling
+along the rails with a constant velocity v, and that a man traverses
+the length of the carriage in the direction of travel with a velocity
+w. How quickly or, in other words, with what velocity W does the man
+advance relative to the embankment during the process ? The only
+possible answer seems to result from the following consideration: If
+the man were to stand still for a second, he would advance relative to
+the embankment through a distance v equal numerically to the velocity
+of the carriage. As a consequence of his walking, however, he
+traverses an additional distance w relative to the carriage, and hence
+also relative to the embankment, in this second, the distance w being
+numerically equal to the velocity with which he is walking. Thus in
+total be covers the distance W=v+w relative to the embankment in the
+second considered. We shall see later that this result, which
+expresses the theorem of the addition of velocities employed in
+classical mechanics, cannot be maintained ; in other words, the law
+that we have just written down does not hold in reality. For the time
+being, however, we shall assume its correctness.
+
+
+
+THE APPARENT INCOMPATIBILITY OF THE
+LAW OF PROPAGATION OF LIGHT WITH THE
+PRINCIPLE OF RELATIVITY
+
+
+There is hardly a simpler law in physics than that according to which
+light is propagated in empty space. Every child at school knows, or
+believes he knows, that this propagation takes place in straight lines
+with a velocity c= 300,000 km./sec. At all events we know with great
+exactness that this velocity is the same for all colours, because if
+this were not the case, the minimum of emission would not be observed
+simultaneously for different colours during the eclipse of a fixed
+star by its dark neighbour. By means of similar considerations based
+on observa- tions of double stars, the Dutch astronomer De Sitter was
+also able to show that the velocity of propagation of light cannot
+depend on the velocity of motion of the body emitting the light. The
+assumption that this velocity of propagation is dependent on the
+direction "in space" is in itself improbable.
+
+In short, let us assume that the simple law of the constancy of the
+velocity of light c (in vacuum) is justifiably believed by the child
+at school. Who would imagine that this simple law has plunged the
+conscientiously thoughtful physicist into the greatest intellectual
+difficulties? Let us consider how these difficulties arise.
+
+Of course we must refer the process of the propagation of light (and
+indeed every other process) to a rigid reference-body (co-ordinate
+system). As such a system let us again choose our embankment. We shall
+imagine the air above it to have been removed. If a ray of light be
+sent along the embankment, we see from the above that the tip of the
+ray will be transmitted with the velocity c relative to the
+embankment. Now let us suppose that our railway carriage is again
+travelling along the railway lines with the velocity v, and that its
+direction is the same as that of the ray of light, but its velocity of
+course much less. Let us inquire about the velocity of propagation of
+the ray of light relative to the carriage. It is obvious that we can
+here apply the consideration of the previous section, since the ray of
+light plays the part of the man walking along relatively to the
+carriage. The velocity w of the man relative to the embankment is here
+replaced by the velocity of light relative to the embankment. w is the
+required velocity of light with respect to the carriage, and we have
+
+                               w = c-v.
+
+The velocity of propagation ot a ray of light relative to the carriage
+thus comes cut smaller than c.
+
+But this result comes into conflict with the principle of relativity
+set forth in Section V. For, like every other general law of
+nature, the law of the transmission of light in vacuo [in vacuum]
+must, according to the principle of relativity, be the same for the
+railway carriage as reference-body as when the rails are the body of
+reference. But, from our above consideration, this would appear to be
+impossible. If every ray of light is propagated relative to the
+embankment with the velocity c, then for this reason it would appear
+that another law of propagation of light must necessarily hold with
+respect to the carriage -- a result contradictory to the principle of
+relativity.
+
+In view of this dilemma there appears to be nothing else for it than
+to abandon either the principle of relativity or the simple law of the
+propagation of light in vacuo. Those of you who have carefully
+followed the preceding discussion are almost sure to expect that we
+should retain the principle of relativity, which appeals so
+convincingly to the intellect because it is so natural and simple. The
+law of the propagation of light in vacuo would then have to be
+replaced by a more complicated law conformable to the principle of
+relativity. The development of theoretical physics shows, however,
+that we cannot pursue this course. The epoch-making theoretical
+investigations of H. A. Lorentz on the electrodynamical and optical
+phenomena connected with moving bodies show that experience in this
+domain leads conclusively to a theory of electromagnetic phenomena, of
+which the law of the constancy of the velocity of light in vacuo is a
+necessary consequence. Prominent theoretical physicists were theref
+ore more inclined to reject the principle of relativity, in spite of
+the fact that no empirical data had been found which were
+contradictory to this principle.
+
+At this juncture the theory of relativity entered the arena. As a
+result of an analysis of the physical conceptions of time and space,
+it became evident that in realily there is not the least
+incompatibilitiy between the principle of relativity and the law of
+propagation of light, and that by systematically holding fast to both
+these laws a logically rigid theory could be arrived at. This theory
+has been called the special theory of relativity to distinguish it
+from the extended theory, with which we shall deal later. In the
+following pages we shall present the fundamental ideas of the special
+theory of relativity.
+
+
+
+ON THE IDEA OF TIME IN PHYSICS
+
+
+Lightning has struck the rails on our railway embankment at two places
+A and B far distant from each other. I make the additional assertion
+that these two lightning flashes occurred simultaneously. If I ask you
+whether there is sense in this statement, you will answer my question
+with a decided "Yes." But if I now approach you with the request to
+explain to me the sense of the statement more precisely, you find
+after some consideration that the answer to this question is not so
+easy as it appears at first sight.
+
+After some time perhaps the following answer would occur to you: "The
+significance of the statement is clear in itself and needs no further
+explanation; of course it would require some consideration if I were
+to be commissioned to determine by observations whether in the actual
+case the two events took place simultaneously or not." I cannot be
+satisfied with this answer for the following reason. Supposing that as
+a result of ingenious considerations an able meteorologist were to
+discover that the lightning must always strike the places A and B
+simultaneously, then we should be faced with the task of testing
+whether or not this theoretical result is in accordance with the
+reality. We encounter the same difficulty with all physical statements
+in which the conception " simultaneous " plays a part. The concept
+does not exist for the physicist until he has the possibility of
+discovering whether or not it is fulfilled in an actual case. We thus
+require a definition of simultaneity such that this definition
+supplies us with the method by means of which, in the present case, he
+can decide by experiment whether or not both the lightning strokes
+occurred simultaneously. As long as this requirement is not satisfied,
+I allow myself to be deceived as a physicist (and of course the same
+applies if I am not a physicist), when I imagine that I am able to
+attach a meaning to the statement of simultaneity. (I would ask the
+reader not to proceed farther until he is fully convinced on this
+point.)
+
+After thinking the matter over for some time you then offer the
+following suggestion with which to test simultaneity. By measuring
+along the rails, the connecting line AB should be measured up and an
+observer placed at the mid-point M of the distance AB. This observer
+should be supplied with an arrangement (e.g. two mirrors inclined at
+90^0) which allows him visually to observe both places A and B at the
+same time. If the observer perceives the two flashes of lightning at
+the same time, then they are simultaneous.
+
+I am very pleased with this suggestion, but for all that I cannot
+regard the matter as quite settled, because I feel constrained to
+raise the following objection:
+
+"Your definition would certainly be right, if only I knew that the
+light by means of which the observer at M perceives the lightning
+flashes travels along the length A arrow M with the same velocity as
+along the length B arrow M. But an examination of this supposition
+would only be possible if we already had at our disposal the means of
+measuring time. It would thus appear as though we were moving here in
+a logical circle."
+
+After further consideration you cast a somewhat disdainful glance at
+me -- and rightly so -- and you declare:
+
+"I maintain my previous definition nevertheless, because in reality it
+assumes absolutely nothing about light. There is only one demand to be
+made of the definition of simultaneity, namely, that in every real
+case it must supply us with an empirical decision as to whether or not
+the conception that has to be defined is fulfilled. That my definition
+satisfies this demand is indisputable. That light requires the same
+time to traverse the path A arrow M as for the path B arrow M is in
+reality neither a supposition nor a hypothesis about the physical
+nature of light, but a stipulation which I can make of my own freewill
+in order to arrive at a definition of simultaneity."
+
+It is clear that this definition can be used to give an exact meaning
+not only to two events, but to as many events as we care to choose,
+and independently of the positions of the scenes of the events with
+respect to the body of reference * (here the railway embankment).
+We are thus led also to a definition of " time " in physics. For this
+purpose we suppose that clocks of identical construction are placed at
+the points A, B and C of the railway line (co-ordinate system) and
+that they are set in such a manner that the positions of their
+pointers are simultaneously (in the above sense) the same. Under these
+conditions we understand by the " time " of an event the reading
+(position of the hands) of that one of these clocks which is in the
+immediate vicinity (in space) of the event. In this manner a
+time-value is associated with every event which is essentially capable
+of observation.
+
+This stipulation contains a further physical hypothesis, the validity
+of which will hardly be doubted without empirical evidence to the
+contrary. It has been assumed that all these clocks go at the same
+rate if they are of identical construction. Stated more exactly: When
+two clocks arranged at rest in different places of a reference-body
+are set in such a manner that a particular position of the pointers of
+the one clock is simultaneous (in the above sense) with the same
+position, of the pointers of the other clock, then identical "
+settings " are always simultaneous (in the sense of the above
+definition).
+
+
+  Notes
+
+*) We suppose further, that, when three events A, B and C occur in
+different places in such a manner that A is simultaneous with B and B
+is simultaneous with C (simultaneous in the sense of the above
+definition), then the criterion for the simultaneity of the pair of
+events A, C is also satisfied. This assumption is a physical
+hypothesis about the the of propagation of light: it must certainly be
+fulfilled if we are to maintain the law of the constancy of the
+velocity of light in vacuo.
+
+
+
+THE RELATIVITY OF SIMULATNEITY
+
+
+Up to now our considerations have been referred to a particular body
+of reference, which we have styled a " railway embankment." We suppose
+a very long train travelling along the rails with the constant
+velocity v and in the direction indicated in Fig 1. People travelling
+in this train will with a vantage view the train as a rigid
+reference-body (co-ordinate system); they regard all events in
+
+                       Fig. 01: file fig01.gif
+
+
+reference to the train. Then every event which takes place along the
+line also takes place at a particular point of the train. Also the
+definition of simultaneity can be given relative to the train in
+exactly the same way as with respect to the embankment. As a natural
+consequence, however, the following question arises :
+
+Are two events (e.g. the two strokes of lightning A and B) which are
+simultaneous with reference to the railway embankment also
+simultaneous relatively to the train? We shall show directly that the
+answer must be in the negative.
+
+When we say that the lightning strokes A and B are simultaneous with
+respect to be embankment, we mean: the rays of light emitted at the
+places A and B, where the lightning occurs, meet each other at the
+mid-point M of the length A arrow B of the embankment. But the events
+A and B also correspond to positions A and B on the train. Let M1 be
+the mid-point of the distance A arrow B on the travelling train. Just
+when the flashes (as judged from the embankment) of lightning occur,
+this point M1 naturally coincides with the point M but it moves
+towards the right in the diagram with the velocity v of the train. If
+an observer sitting in the position M1 in the train did not possess
+this velocity, then he would remain permanently at M, and the light
+rays emitted by the flashes of lightning A and B would reach him
+simultaneously, i.e. they would meet just where he is situated. Now in
+reality (considered with reference to the railway embankment) he is
+hastening towards the beam of light coming from B, whilst he is riding
+on ahead of the beam of light coming from A. Hence the observer will
+see the beam of light emitted from B earlier than he will see that
+emitted from A. Observers who take the railway train as their
+reference-body must therefore come to the conclusion that the
+lightning flash B took place earlier than the lightning flash A. We
+thus arrive at the important result:
+
+Events which are simultaneous with reference to the embankment are not
+simultaneous with respect to the train, and vice versa (relativity of
+simultaneity). Every reference-body (co-ordinate system) has its own
+particular time ; unless we are told the reference-body to which the
+statement of time refers, there is no meaning in a statement of the
+time of an event.
+
+Now before the advent of the theory of relativity it had always
+tacitly been assumed in physics that the statement of time had an
+absolute significance, i.e. that it is independent of the state of
+motion of the body of reference. But we have just seen that this
+assumption is incompatible with the most natural definition of
+simultaneity; if we discard this assumption, then the conflict between
+the law of the propagation of light in vacuo and the principle of
+relativity (developed in Section 7) disappears.
+
+We were led to that conflict by the considerations of Section 6,
+which are now no longer tenable. In that section we concluded that the
+man in the carriage, who traverses the distance w per second relative
+to the carriage, traverses the same distance also with respect to the
+embankment in each second of time. But, according to the foregoing
+considerations, the time required by a particular occurrence with
+respect to the carriage must not be considered equal to the duration
+of the same occurrence as judged from the embankment (as
+reference-body). Hence it cannot be contended that the man in walking
+travels the distance w relative to the railway line in a time which is
+equal to one second as judged from the embankment.
+
+Moreover, the considerations of Section 6 are based on yet a second
+assumption, which, in the light of a strict consideration, appears to
+be arbitrary, although it was always tacitly made even before the
+introduction of the theory of relativity.
+
+
+
+ON THE RELATIVITY OF THE CONCEPTION OF DISTANCE
+
+
+Let us consider two particular points on the train * travelling
+along the embankment with the velocity v, and inquire as to their
+distance apart. We already know that it is necessary to have a body of
+reference for the measurement of a distance, with respect to which
+body the distance can be measured up. It is the simplest plan to use
+the train itself as reference-body (co-ordinate system). An observer
+in the train measures the interval by marking off his measuring-rod in
+a straight line (e.g. along the floor of the carriage) as many times
+as is necessary to take him from the one marked point to the other.
+Then the number which tells us how often the rod has to be laid down
+is the required distance.
+
+It is a different matter when the distance has to be judged from the
+railway line. Here the following method suggests itself. If we call
+A^1 and B^1 the two points on the train whose distance apart is
+required, then both of these points are moving with the velocity v
+along the embankment. In the first place we require to determine the
+points A and B of the embankment which are just being passed by the
+two points A^1 and B^1 at a particular time t -- judged from the
+embankment. These points A and B of the embankment can be determined
+by applying the definition of time given in Section 8. The distance
+between these points A and B is then measured by repeated application
+of thee measuring-rod along the embankment.
+
+A priori it is by no means certain that this last measurement will
+supply us with the same result as the first. Thus the length of the
+train as measured from the embankment may be different from that
+obtained by measuring in the train itself. This circumstance leads us
+to a second objection which must be raised against the apparently
+obvious consideration of Section 6. Namely, if the man in the
+carriage covers the distance w in a unit of time -- measured from the
+train, -- then this distance -- as measured from the embankment -- is
+not necessarily also equal to w.
+
+
+  Notes
+
+*) e.g. the middle of the first and of the hundredth carriage.
+
+
+
+THE LORENTZ TRANSFORMATION
+
+
+The results of the last three sections show that the apparent
+incompatibility of the law of propagation of light with the principle
+of relativity (Section 7) has been derived by means of a
+consideration which borrowed two unjustifiable hypotheses from
+classical mechanics; these are as follows:
+
+(1) The time-interval (time) between two events is independent of the
+condition of motion of the body of reference.
+
+(2) The space-interval (distance) between two points of a rigid body
+is independent of the condition of motion of the body of reference.
+
+If we drop these hypotheses, then the dilemma of Section 7
+disappears, because the theorem of the addition of velocities derived
+in Section 6 becomes invalid. The possibility presents itself that
+the law of the propagation of light in vacuo may be compatible with
+the principle of relativity, and the question arises: How have we to
+modify the considerations of Section 6 in order to remove the
+apparent disagreement between these two fundamental results of
+experience? This question leads to a general one. In the discussion of
+Section 6 we have to do with places and times relative both to the
+train and to the embankment. How are we to find the place and time of
+an event in relation to the train, when we know the place and time of
+the event with respect to the railway embankment ? Is there a
+thinkable answer to this question of such a nature that the law of
+transmission of light in vacuo does not contradict the principle of
+relativity ? In other words : Can we conceive of a relation between
+place and time of the individual events relative to both
+reference-bodies, such that every ray of light possesses the velocity
+of transmission c relative to the embankment and relative to the train
+? This question leads to a quite definite positive answer, and to a
+perfectly definite transformation law for the space-time magnitudes of
+an event when changing over from one body of reference to another.
+
+Before we deal with this, we shall introduce the following incidental
+consideration. Up to the present we have only considered events taking
+place along the embankment, which had mathematically to assume the
+function of a straight line. In the manner indicated in Section 2
+we can imagine this reference-body supplemented laterally and in a
+vertical direction by means of a framework of rods, so that an event
+which takes place anywhere can be localised with reference to this
+framework. Fig. 2 Similarly, we can imagine the train travelling with
+the velocity v to be continued across the whole of space, so that
+every event, no matter how far off it may be, could also be localised
+with respect to the second framework. Without committing any
+fundamental error, we can disregard the fact that in reality these
+frameworks would continually interfere with each other, owing to the
+impenetrability of solid bodies. In every such framework we imagine
+three surfaces perpendicular to each other marked out, and designated
+as " co-ordinate planes " (" co-ordinate system "). A co-ordinate
+system K then corresponds to the embankment, and a co-ordinate system
+K' to the train. An event, wherever it may have taken place, would be
+fixed in space with respect to K by the three perpendiculars x, y, z
+on the co-ordinate planes, and with regard to time by a time value t.
+Relative to K1, the same event would be fixed in respect of space and
+time by corresponding values x1, y1, z1, t1, which of course are not
+identical with x, y, z, t. It has already been set forth in detail how
+these magnitudes are to be regarded as results of physical
+measurements.
+
+Obviously our problem can be exactly formulated in the following
+manner. What are the values x1, y1, z1, t1, of an event with respect
+to K1, when the magnitudes x, y, z, t, of the same event with respect
+to K are given ? The relations must be so chosen that the law of the
+transmission of light in vacuo is satisfied for one and the same ray
+of light (and of course for every ray) with respect to K and K1. For
+the relative orientation in space of the co-ordinate systems indicated
+in the diagram ([7]Fig. 2), this problem is solved by means of the
+equations :
+
+                         eq. 1: file eq01.gif
+
+                                y1 = y
+                                z1 = z
+
+                         eq. 2: file eq02.gif
+
+This system of equations is known as the " Lorentz transformation." *
+
+If in place of the law of transmission of light we had taken as our
+basis the tacit assumptions of the older mechanics as to the absolute
+character of times and lengths, then instead of the above we should
+have obtained the following equations:
+
+                             x1 = x - vt
+                                y1 = y
+                                z1 = z
+                                t1 = t
+
+This system of equations is often termed the " Galilei
+transformation." The Galilei transformation can be obtained from the
+Lorentz transformation by substituting an infinitely large value for
+the velocity of light c in the latter transformation.
+
+Aided by the following illustration, we can readily see that, in
+accordance with the Lorentz transformation, the law of the
+transmission of light in vacuo is satisfied both for the
+reference-body K and for the reference-body K1. A light-signal is sent
+along the positive x-axis, and this light-stimulus advances in
+accordance with the equation
+
+                               x = ct,
+
+i.e. with the velocity c. According to the equations of the Lorentz
+transformation, this simple relation between x and t involves a
+relation between x1 and t1. In point of fact, if we substitute for x
+the value ct in the first and fourth equations of the Lorentz
+transformation, we obtain:
+
+                         eq. 3: file eq03.gif
+
+
+                         eq. 4: file eq04.gif
+
+from which, by division, the expression
+
+                               x1 = ct1
+
+immediately follows. If referred to the system K1, the propagation of
+light takes place according to this equation. We thus see that the
+velocity of transmission relative to the reference-body K1 is also
+equal to c. The same result is obtained for rays of light advancing in
+any other direction whatsoever. Of cause this is not surprising, since
+the equations of the Lorentz transformation were derived conformably
+to this point of view.
+
+
+  Notes
+
+*) A simple derivation of the Lorentz transformation is given in
+Appendix I.
+
+
+
+THE BEHAVIOUR OF MEASURING-RODS AND CLOCKS IN MOTION
+
+
+Place a metre-rod in the x1-axis of K1 in such a manner that one end
+(the beginning) coincides with the point x1=0 whilst the other end
+(the end of the rod) coincides with the point x1=I. What is the length
+of the metre-rod relatively to the system K? In order to learn this,
+we need only ask where the beginning of the rod and the end of the rod
+lie with respect to K at a particular time t of the system K. By means
+of the first equation of the Lorentz transformation the values of
+these two points at the time t = 0 can be shown to be
+
+                       eq. 05a: file eq05a.gif
+
+
+                       eq. 05b: file eq05b.gif
+
+
+the distance between the points being eq. 06 .
+
+But the metre-rod is moving with the velocity v relative to K. It
+therefore follows that the length of a rigid metre-rod moving in the
+direction of its length with a velocity v is eq. 06 of a metre.
+
+The rigid rod is thus shorter when in motion than when at rest, and
+the more quickly it is moving, the shorter is the rod. For the
+velocity v=c we should have eq. 06a ,
+
+and for stiII greater velocities the square-root becomes imaginary.
+From this we conclude that in the theory of relativity the velocity c
+plays the part of a limiting velocity, which can neither be reached
+nor exceeded by any real body.
+
+Of course this feature of the velocity c as a limiting velocity also
+clearly follows from the equations of the Lorentz transformation, for
+these became meaningless if we choose values of v greater than c.
+
+If, on the contrary, we had considered a metre-rod at rest in the
+x-axis with respect to K, then we should have found that the length of
+the rod as judged from K1 would have been eq. 06 ;
+
+this is quite in accordance with the principle of relativity which
+forms the basis of our considerations.
+
+A Priori it is quite clear that we must be able to learn something
+about the physical behaviour of measuring-rods and clocks from the
+equations of transformation, for the magnitudes z, y, x, t, are
+nothing more nor less than the results of measurements obtainable by
+means of measuring-rods and clocks. If we had based our considerations
+on the Galileian transformation we should not have obtained a
+contraction of the rod as a consequence of its motion.
+
+Let us now consider a seconds-clock which is permanently situated at
+the origin (x1=0) of K1. t1=0 and t1=I are two successive ticks of
+this clock. The first and fourth equations of the Lorentz
+transformation give for these two ticks :
+
+                                t = 0
+
+and
+
+                        eq. 07: file eq07.gif
+
+As judged from K, the clock is moving with the velocity v; as judged
+from this reference-body, the time which elapses between two strokes
+of the clock is not one second, but
+
+                        eq. 08: file eq08.gif
+
+seconds, i.e. a somewhat larger time. As a consequence of its motion
+the clock goes more slowly than when at rest. Here also the velocity c
+plays the part of an unattainable limiting velocity.
+
+
+
+THEOREM OF THE ADDITION OF VELOCITIES.
+THE EXPERIMENT OF FIZEAU
+
+
+Now in practice we can move clocks and measuring-rods only with
+velocities that are small compared with the velocity of light; hence
+we shall hardly be able to compare the results of the previous section
+directly with the reality. But, on the other hand, these results must
+strike you as being very singular, and for that reason I shall now
+draw another conclusion from the theory, one which can easily be
+derived from the foregoing considerations, and which has been most
+elegantly confirmed by experiment.
+
+In Section 6 we derived the theorem of the addition of velocities
+in one direction in the form which also results from the hypotheses of
+classical mechanics- This theorem can also be deduced readily horn the
+Galilei transformation (Section 11). In place of the man walking
+inside the carriage, we introduce a point moving relatively to the
+co-ordinate system K1 in accordance with the equation
+
+                               x1 = wt1
+
+By means of the first and fourth equations of the Galilei
+transformation we can express x1 and t1 in terms of x and t, and we
+then obtain
+
+                             x = (v + w)t
+
+This equation expresses nothing else than the law of motion of the
+point with reference to the system K (of the man with reference to the
+embankment). We denote this velocity by the symbol W, and we then
+obtain, as in Section 6,
+
+                           W=v+w         A)
+
+But we can carry out this consideration just as well on the basis of
+the theory of relativity. In the equation
+
+                         x1 = wt1         B)
+
+we must then express x1and t1 in terms of x and t, making use of the
+first and fourth equations of the Lorentz transformation. Instead of
+the equation (A) we then obtain the equation
+
+                        eq. 09: file eq09.gif
+
+
+which corresponds to the theorem of addition for velocities in one
+direction according to the theory of relativity. The question now
+arises as to which of these two theorems is the better in accord with
+experience. On this point we axe enlightened by a most important
+experiment which the brilliant physicist Fizeau performed more than
+half a century ago, and which has been repeated since then by some of
+the best experimental physicists, so that there can be no doubt about
+its result. The experiment is concerned with the following question.
+Light travels in a motionless liquid with a particular velocity w. How
+quickly does it travel in the direction of the arrow in the tube T
+(see the accompanying diagram, Fig. 3) when the liquid above
+mentioned is flowing through the tube with a velocity v ?
+
+In accordance with the principle of relativity we shall certainly have
+to take for granted that the propagation of light always takes place
+with the same velocity w with respect to the liquid, whether the
+latter is in motion with reference to other bodies or not. The
+velocity of light relative to the liquid and the velocity of the
+latter relative to the tube are thus known, and we require the
+velocity of light relative to the tube.
+
+It is clear that we have the problem of Section 6 again before us. The
+tube plays the part of the railway embankment or of the co-ordinate
+system K, the liquid plays the part of the carriage or of the
+co-ordinate system K1, and finally, the light plays the part of the
+
+                      Figure 03: file fig03.gif
+
+
+man walking along the carriage, or of the moving point in the present
+section. If we denote the velocity of the light relative to the tube
+by W, then this is given by the equation (A) or (B), according as the
+Galilei transformation or the Lorentz transformation corresponds to
+the facts. Experiment * decides in favour of equation (B) derived
+from the theory of relativity, and the agreement is, indeed, very
+exact. According to recent and most excellent measurements by Zeeman,
+the influence of the velocity of flow v on the propagation of light is
+represented by formula (B) to within one per cent.
+
+Nevertheless we must now draw attention to the fact that a theory of
+this phenomenon was given by H. A. Lorentz long before the statement
+of the theory of relativity. This theory was of a purely
+electrodynamical nature, and was obtained by the use of particular
+hypotheses as to the electromagnetic structure of matter. This
+circumstance, however, does not in the least diminish the
+conclusiveness of the experiment as a crucial test in favour of the
+theory of relativity, for the electrodynamics of Maxwell-Lorentz, on
+which the original theory was based, in no way opposes the theory of
+relativity. Rather has the latter been developed trom electrodynamics
+as an astoundingly simple combination and generalisation of the
+hypotheses, formerly independent of each other, on which
+electrodynamics was built.
+
+
+  Notes
+
+*) Fizeau found eq. 10 , where eq. 11
+
+is the index of refraction of the liquid. On the other hand, owing to
+the smallness of eq. 12 as compared with I,
+
+we can replace (B) in the first place by eq. 13 , or to the same order
+of approximation by
+
+eq. 14 , which agrees with Fizeau's result.
+
+
+
+THE HEURISTIC VALUE OF THE THEORY OF RELATIVITY
+
+
+Our train of thought in the foregoing pages can be epitomised in the
+following manner. Experience has led to the conviction that, on the
+one hand, the principle of relativity holds true and that on the other
+hand the velocity of transmission of light in vacuo has to be
+considered equal to a constant c. By uniting these two postulates we
+obtained the law of transformation for the rectangular co-ordinates x,
+y, z and the time t of the events which constitute the processes of
+nature. In this connection we did not obtain the Galilei
+transformation, but, differing from classical mechanics, the Lorentz
+transformation.
+
+The law of transmission of light, the acceptance of which is justified
+by our actual knowledge, played an important part in this process of
+thought. Once in possession of the Lorentz transformation, however, we
+can combine this with the principle of relativity, and sum up the
+theory thus:
+
+Every general law of nature must be so constituted that it is
+transformed into a law of exactly the same form when, instead of the
+space-time variables x, y, z, t of the original coordinate system K,
+we introduce new space-time variables x1, y1, z1, t1 of a co-ordinate
+system K1. In this connection the relation between the ordinary and
+the accented magnitudes is given by the Lorentz transformation. Or in
+brief : General laws of nature are co-variant with respect to Lorentz
+transformations.
+
+This is a definite mathematical condition that the theory of
+relativity demands of a natural law, and in virtue of this, the theory
+becomes a valuable heuristic aid in the search for general laws of
+nature. If a general law of nature were to be found which did not
+satisfy this condition, then at least one of the two fundamental
+assumptions of the theory would have been disproved. Let us now
+examine what general results the latter theory has hitherto evinced.
+
+
+
+GENERAL RESULTS OF THE THEORY
+
+
+It is clear from our previous considerations that the (special) theory
+of relativity has grown out of electrodynamics and optics. In these
+fields it has not appreciably altered the predictions of theory, but
+it has considerably simplified the theoretical structure, i.e. the
+derivation of laws, and -- what is incomparably more important -- it
+has considerably reduced the number of independent hypothese forming
+the basis of theory. The special theory of relativity has rendered the
+Maxwell-Lorentz theory so plausible, that the latter would have been
+generally accepted by physicists even if experiment had decided less
+unequivocally in its favour.
+
+Classical mechanics required to be modified before it could come into
+line with the demands of the special theory of relativity. For the
+main part, however, this modification affects only the laws for rapid
+motions, in which the velocities of matter v are not very small as
+compared with the velocity of light. We have experience of such rapid
+motions only in the case of electrons and ions; for other motions the
+variations from the laws of classical mechanics are too small to make
+themselves evident in practice. We shall not consider the motion of
+stars until we come to speak of the general theory of relativity. In
+accordance with the theory of relativity the kinetic energy of a
+material point of mass m is no longer given by the well-known
+expression
+
+                        eq. 15: file eq15.gif
+
+but by the expression
+
+                        eq. 16: file eq16.gif
+
+
+This expression approaches infinity as the velocity v approaches the
+velocity of light c. The velocity must therefore always remain less
+than c, however great may be the energies used to produce the
+acceleration. If we develop the expression for the kinetic energy in
+the form of a series, we obtain
+
+                        eq. 17: file eq17.gif
+
+
+When eq. 18 is small compared with unity, the third of these terms is
+always small in comparison with the second,
+
+which last is alone considered in classical mechanics. The first term
+mc^2 does not contain the velocity, and requires no consideration if
+we are only dealing with the question as to how the energy of a
+point-mass; depends on the velocity. We shall speak of its essential
+significance later.
+
+The most important result of a general character to which the special
+theory of relativity has led is concerned with the conception of mass.
+Before the advent of relativity, physics recognised two conservation
+laws of fundamental importance, namely, the law of the canservation of
+energy and the law of the conservation of mass these two fundamental
+laws appeared to be quite independent of each other. By means of the
+theory of relativity they have been united into one law. We shall now
+briefly consider how this unification came about, and what meaning is
+to be attached to it.
+
+The principle of relativity requires that the law of the concervation
+of energy should hold not only with reference to a co-ordinate system
+K, but also with respect to every co-ordinate system K1 which is in a
+state of uniform motion of translation relative to K, or, briefly,
+relative to every " Galileian " system of co-ordinates. In contrast to
+classical mechanics; the Lorentz transformation is the deciding factor
+in the transition from one such system to another.
+
+By means of comparatively simple considerations we are led to draw the
+following conclusion from these premises, in conjunction with the
+fundamental equations of the electrodynamics of Maxwell: A body moving
+with the velocity v, which absorbs * an amount of energy E[0] in
+the form of radiation without suffering an alteration in velocity in
+the process, has, as a consequence, its energy increased by an amount
+
+                        eq. 19: file eq19.gif
+
+In consideration of the expression given above for the kinetic energy
+of the body, the required energy of the body comes out to be
+
+                        eq. 20: file eq20.gif
+
+
+Thus the body has the same energy as a body of mass
+
+                         eq.21: file eq21.gif
+
+moving with the velocity v. Hence we can say: If a body takes up an
+amount of energy E[0], then its inertial mass increases by an amount
+
+                        eq. 22: file eq22.gif
+
+
+the inertial mass of a body is not a constant but varies according to
+the change in the energy of the body. The inertial mass of a system of
+bodies can even be regarded as a measure of its energy. The law of the
+conservation of the mass of a system becomes identical with the law of
+the conservation of energy, and is only valid provided that the system
+neither takes up nor sends out energy. Writing the expression for the
+energy in the form
+
+                        eq. 23: file eq23.gif
+
+we see that the term mc^2, which has hitherto attracted our attention,
+is nothing else than the energy possessed by the body ** before it
+absorbed the energy E[0].
+
+A direct comparison of this relation with experiment is not possible
+at the present time (1920; see *** Note, p. 48), owing to the fact that
+the changes in energy E[0] to which we can Subject a system are not
+large enough to make themselves perceptible as a change in the
+inertial mass of the system.
+
+                                eq. 22: file eq22.gif
+
+
+is too small in comparison with the mass m, which was present before
+the alteration of the energy. It is owing to this circumstance that
+classical mechanics was able to establish successfully the
+conservation of mass as a law of independent validity.
+
+Let me add a final remark of a fundamental nature. The success of the
+Faraday-Maxwell interpretation of electromagnetic action at a distance
+resulted in physicists becoming convinced that there are no such
+things as instantaneous actions at a distance (not involving an
+intermediary medium) of the type of Newton's law of gravitation.
+According to the theory of relativity, action at a distance with the
+velocity of light always takes the place of instantaneous action at a
+distance or of action at a distance with an infinite velocity of
+transmission. This is connected with the fact that the velocity c
+plays a fundamental role in this theory. In Part II we shall see in
+what way this result becomes modified in the general theory of
+relativity.
+
+
+  Notes
+
+*) E[0] is the energy taken up, as judged from a co-ordinate system
+moving with the body.
+
+**) As judged from a co-ordinate system moving with the body.
+
+***[Note] The equation E = mc^2 has been thoroughly proved time and
+again since this time.
+
+
+
+EXPERIENCE AND THE SPECIAL THEORY OF RELATIVITY
+
+
+To what extent is the special theory of relativity supported by
+experience?  This question is not easily answered for the reason
+already mentioned in connection with the fundamental experiment of
+Fizeau. The special theory of relativity has crystallised out from the
+Maxwell-Lorentz theory of electromagnetic phenomena. Thus all facts of
+experience which support the electromagnetic theory also support the
+theory of relativity. As being of particular importance, I mention
+here the fact that the theory of relativity enables us to predict the
+effects produced on the light reaching us from the fixed stars. These
+results are obtained in an exceedingly simple manner, and the effects
+indicated, which are due to the relative motion of the earth with
+reference to those fixed stars are found to be in accord with
+experience. We refer to the yearly movement of the apparent position
+of the fixed stars resulting from the motion of the earth round the
+sun (aberration), and to the influence of the radial components of the
+relative motions of the fixed stars with respect to the earth on the
+colour of the light reaching us from them. The latter effect manifests
+itself in a slight displacement of the spectral lines of the light
+transmitted to us from a fixed star, as compared with the position of
+the same spectral lines when they are produced by a terrestrial source
+of light (Doppler principle). The experimental arguments in favour of
+the Maxwell-Lorentz theory, which are at the same time arguments in
+favour of the theory of relativity, are too numerous to be set forth
+here. In reality they limit the theoretical possibilities to such an
+extent, that no other theory than that of Maxwell and Lorentz has been
+able to hold its own when tested by experience.
+
+But there are two classes of experimental facts hitherto obtained
+which can be represented in the Maxwell-Lorentz theory only by the
+introduction of an auxiliary hypothesis, which in itself -- i.e.
+without making use of the theory of relativity -- appears extraneous.
+
+It is known that cathode rays and the so-called b-rays emitted by
+radioactive substances consist of negatively electrified particles
+(electrons) of very small inertia and large velocity. By examining the
+deflection of these rays under the influence of electric and magnetic
+fields, we can study the law of motion of these particles very
+exactly.
+
+In the theoretical treatment of these electrons, we are faced with the
+difficulty that electrodynamic theory of itself is unable to give an
+account of their nature. For since electrical masses of one sign repel
+each other, the negative electrical masses constituting the electron
+would necessarily be scattered under the influence of their mutual
+repulsions, unless there are forces of another kind operating between
+them, the nature of which has hitherto remained obscure to us.*   If
+we now assume that the relative distances between the electrical
+masses constituting the electron remain unchanged during the motion of
+the electron (rigid connection in the sense of classical mechanics),
+we arrive at a law of motion of the electron which does not agree with
+experience. Guided by purely formal points of view, H. A. Lorentz was
+the first to introduce the hypothesis that the form of the electron
+experiences a contraction in the direction of motion in consequence of
+that motion. the contracted length being proportional to the
+expression
+
+                        eq. 05: file eq05.gif
+
+This, hypothesis, which is not justifiable by any electrodynamical
+facts, supplies us then with that particular law of motion which has
+been confirmed with great precision in recent years.
+
+The theory of relativity leads to the same law of motion, without
+requiring any special hypothesis whatsoever as to the structure and
+the behaviour of the electron. We arrived at a similar conclusion in
+Section 13 in connection with the experiment of Fizeau, the result
+of which is foretold by the theory of relativity without the necessity
+of drawing on hypotheses as to the physical nature of the liquid.
+
+The second class of facts to which we have alluded has reference to
+the question whether or not the motion of the earth in space can be
+made perceptible in terrestrial experiments. We have already remarked
+in Section 5 that all attempts of this nature led to a negative
+result. Before the theory of relativity was put forward, it was
+difficult to become reconciled to this negative result, for reasons
+now to be discussed. The inherited prejudices about time and space did
+not allow any doubt to arise as to the prime importance of the
+Galileian transformation for changing over from one body of reference
+to another. Now assuming that the Maxwell-Lorentz equations hold for a
+reference-body K, we then find that they do not hold for a
+reference-body K1 moving uniformly with respect to K, if we assume
+that the relations of the Galileian transformstion exist between the
+co-ordinates of K and K1. It thus appears that, of all Galileian
+co-ordinate systems, one (K) corresponding to a particular state of
+motion is physically unique. This result was interpreted physically by
+regarding K as at rest with respect to a hypothetical ćther of space.
+On the other hand, all coordinate systems K1 moving relatively to K
+were to be regarded as in motion with respect to the ćther. To this
+motion of K1 against the ćther ("ćther-drift " relative to K1) were
+attributed the more complicated laws which were supposed to hold
+relative to K1. Strictly speaking, such an ćther-drift ought also to
+be assumed relative to the earth, and for a long time the efforts of
+physicists were devoted to attempts to detect the existence of an
+ćther-drift at the earth's surface.
+
+In one of the most notable of these attempts Michelson devised a
+method which appears as though it must be decisive. Imagine two
+mirrors so arranged on a rigid body that the reflecting surfaces face
+each other. A ray of light requires a perfectly definite time T to
+pass from one mirror to the other and back again, if the whole system
+be at rest with respect to the ćther. It is found by calculation,
+however, that a slightly different time T1 is required for this
+process, if the body, together with the mirrors, be moving relatively
+to the ćther. And yet another point: it is shown by calculation that
+for a given velocity v with reference to the ćther, this time T1 is
+different when the body is moving perpendicularly to the planes of the
+mirrors from that resulting when the motion is parallel to these
+planes. Although the estimated difference between these two times is
+exceedingly small, Michelson and Morley performed an experiment
+involving interference in which this difference should have been
+clearly detectable. But the experiment gave a negative result -- a
+fact very perplexing to physicists. Lorentz and FitzGerald rescued the
+theory from this difficulty by assuming that the motion of the body
+relative to the ćther produces a contraction of the body in the
+direction of motion, the amount of contraction being just sufficient
+to compensate for the differeace in time mentioned above. Comparison
+with the discussion in Section 11 shows that also from the
+standpoint of the theory of relativity this solution of the difficulty
+was the right one. But on the basis of the theory of relativity the
+method of interpretation is incomparably more satisfactory. According
+to this theory there is no such thing as a " specially favoured "
+(unique) co-ordinate system to occasion the introduction of the
+ćther-idea, and hence there can be no ćther-drift, nor any experiment
+with which to demonstrate it. Here the contraction of moving bodies
+follows from the two fundamental principles of the theory, without the
+introduction of particular hypotheses ; and as the prime factor
+involved in this contraction we find, not the motion in itself, to
+which we cannot attach any meaning, but the motion with respect to the
+body of reference chosen in the particular case in point. Thus for a
+co-ordinate system moving with the earth the mirror system of
+Michelson and Morley is not shortened, but it is shortened for a
+co-ordinate system which is at rest relatively to the sun.
+
+
+  Notes
+
+*) The general theory of relativity renders it likely that the
+electrical masses of an electron are held together by gravitational
+forces.
+
+
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE
+
+
+The non-mathematician is seized by a mysterious shuddering when he
+hears of "four-dimensional" things, by a feeling not unlike that
+awakened by thoughts of the occult. And yet there is no more
+common-place statement than that the world in which we live is a
+four-dimensional space-time continuum.
+
+Space is a three-dimensional continuum. By this we mean that it is
+possible to describe the position of a point (at rest) by means of
+three numbers (co-ordinales) x, y, z, and that there is an indefinite
+number of points in the neighbourhood of this one, the position of
+which can be described by co-ordinates such as x[1], y[1], z[1], which
+may be as near as we choose to the respective values of the
+co-ordinates x, y, z, of the first point. In virtue of the latter
+property we speak of a " continuum," and owing to the fact that there
+are three co-ordinates we speak of it as being " three-dimensional."
+
+Similarly, the world of physical phenomena which was briefly called "
+world " by Minkowski is naturally four dimensional in the space-time
+sense. For it is composed of individual events, each of which is
+described by four numbers, namely, three space co-ordinates x, y, z,
+and a time co-ordinate, the time value t. The" world" is in this sense
+also a continuum; for to every event there are as many "neighbouring"
+events (realised or at least thinkable) as we care to choose, the
+co-ordinates x[1], y[1], z[1], t[1] of which differ by an indefinitely
+small amount from those of the event x, y, z, t originally considered.
+That we have not been accustomed to regard the world in this sense as
+a four-dimensional continuum is due to the fact that in physics,
+before the advent of the theory of relativity, time played a different
+and more independent role, as compared with the space coordinates. It
+is for this reason that we have been in the habit of treating time as
+an independent continuum. As a matter of fact, according to classical
+mechanics, time is absolute, i.e. it is independent of the position
+and the condition of motion of the system of co-ordinates. We see this
+expressed in the last equation of the Galileian transformation (t1 =
+t)
+
+The four-dimensional mode of consideration of the "world" is natural
+on the theory of relativity, since according to this theory time is
+robbed of its independence. This is shown by the fourth equation of
+the Lorentz transformation:
+
+                        eq. 24: file eq24.gif
+
+
+Moreover, according to this equation the time difference Dt1 of two
+events with respect to K1 does not in general vanish, even when the
+time difference Dt1 of the same events with reference to K vanishes.
+Pure " space-distance " of two events with respect to K results in "
+time-distance " of the same events with respect to K. But the
+discovery of Minkowski, which was of importance for the formal
+development of the theory of relativity, does not lie here. It is to
+be found rather in the fact of his recognition that the
+four-dimensional space-time continuum of the theory of relativity, in
+its most essential formal properties, shows a pronounced relationship
+to the three-dimensional continuum of Euclidean geometrical
+space.*  In order to give due prominence to this relationship,
+however, we must replace the usual time co-ordinate t by an imaginary
+magnitude eq. 25 proportional to it. Under these conditions, the
+natural laws satisfying the demands of the (special) theory of
+relativity assume mathematical forms, in which the time co-ordinate
+plays exactly the same role as the three space co-ordinates. Formally,
+these four co-ordinates correspond exactly to the three space
+co-ordinates in Euclidean geometry. It must be clear even to the
+non-mathematician that, as a consequence of this purely formal
+addition to our knowledge, the theory perforce gained clearness in no
+mean measure.
+
+These inadequate remarks can give the reader only a vague notion of
+the important idea contributed by Minkowski. Without it the general
+theory of relativity, of which the fundamental ideas are developed in
+the following pages, would perhaps have got no farther than its long
+clothes. Minkowski's work is doubtless difficult of access to anyone
+inexperienced in mathematics, but since it is not necessary to have a
+very exact grasp of this work in order to understand the fundamental
+ideas of either the special or the general theory of relativity, I
+shall leave it here at present, and revert to it only towards the end
+of Part 2.
+
+
+  Notes
+
+*) Cf. the somewhat more detailed discussion in Appendix II.
+
+
+
+
+PART II
+
+THE GENERAL THEORY OF RELATIVITY
+
+
+SPECIAL AND GENERAL PRINCIPLE OF RELATIVITY
+
+
+The basal principle, which was the pivot of all our previous
+considerations, was the special principle of relativity, i.e. the
+principle of the physical relativity of all uniform motion. Let as
+once more analyse its meaning carefully.
+
+It was at all times clear that, from the point of view of the idea it
+conveys to us, every motion must be considered only as a relative
+motion. Returning to the illustration we have frequently used of the
+embankment and the railway carriage, we can express the fact of the
+motion here taking place in the following two forms, both of which are
+equally justifiable :
+
+(a) The carriage is in motion relative to the embankment,
+(b) The embankment is in motion relative to the carriage.
+
+In (a) the embankment, in (b) the carriage, serves as the body of
+reference in our statement of the motion taking place. If it is simply
+a question of detecting or of describing the motion involved, it is in
+principle immaterial to what reference-body we refer the motion. As
+already mentioned, this is self-evident, but it must not be confused
+with the much more comprehensive statement called "the principle of
+relativity," which we have taken as the basis of our investigations.
+
+The principle we have made use of not only maintains that we may
+equally well choose the carriage or the embankment as our
+reference-body for the description of any event (for this, too, is
+self-evident). Our principle rather asserts what follows : If we
+formulate the general laws of nature as they are obtained from
+experience, by making use of
+
+(a) the embankment as reference-body,
+(b) the railway carriage as reference-body,
+
+then these general laws of nature (e.g. the laws of mechanics or the
+law of the propagation of light in vacuo) have exactly the same form
+in both cases. This can also be expressed as follows : For the
+physical description of natural processes, neither of the reference
+bodies K, K1 is unique (lit. " specially marked out ") as compared
+with the other. Unlike the first, this latter statement need not of
+necessity hold a priori; it is not contained in the conceptions of "
+motion" and " reference-body " and derivable from them; only
+experience can decide as to its correctness or incorrectness.
+
+Up to the present, however, we have by no means maintained the
+equivalence of all bodies of reference K in connection with the
+formulation of natural laws. Our course was more on the following
+Iines. In the first place, we started out from the assumption that
+there exists a reference-body K, whose condition of motion is such
+that the Galileian law holds with respect to it : A particle left to
+itself and sufficiently far removed from all other particles moves
+uniformly in a straight line. With reference to K (Galileian
+reference-body) the laws of nature were to be as simple as possible.
+But in addition to K, all bodies of reference K1 should be given
+preference in this sense, and they should be exactly equivalent to K
+for the formulation of natural laws, provided that they are in a state
+of uniform rectilinear and non-rotary motion with respect to K ; all
+these bodies of reference are to be regarded as Galileian
+reference-bodies. The validity of the principle of relativity was
+assumed only for these reference-bodies, but not for others (e.g.
+those possessing motion of a different kind). In this sense we speak
+of the special principle of relativity, or special theory of
+relativity.
+
+In contrast to this we wish to understand by the "general principle of
+relativity" the following statement : All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion. But before proceeding farther, it ought to be pointed
+out that this formulation must be replaced later by a more abstract
+one, for reasons which will become evident at a later stage.
+
+Since the introduction of the special principle of relativity has been
+justified, every intellect which strives after generalisation must
+feel the temptation to venture the step towards the general principle
+of relativity. But a simple and apparently quite reliable
+consideration seems to suggest that, for the present at any rate,
+there is little hope of success in such an attempt; Let us imagine
+ourselves transferred to our old friend the railway carriage, which is
+travelling at a uniform rate. As long as it is moving unifromly, the
+occupant of the carriage is not sensible of its motion, and it is for
+this reason that he can without reluctance interpret the facts of the
+case as indicating that the carriage is at rest, but the embankment in
+motion. Moreover, according to the special principle of relativity,
+this interpretation is quite justified also from a physical point of
+view.
+
+If the motion of the carriage is now changed into a non-uniform
+motion, as for instance by a powerful application of the brakes, then
+the occupant of the carriage experiences a correspondingly powerful
+jerk forwards. The retarded motion is manifested in the mechanical
+behaviour of bodies relative to the person in the railway carriage.
+The mechanical behaviour is different from that of the case previously
+considered, and for this reason it would appear to be impossible that
+the same mechanical laws hold relatively to the non-uniformly moving
+carriage, as hold with reference to the carriage when at rest or in
+uniform motion. At all events it is clear that the Galileian law does
+not hold with respect to the non-uniformly moving carriage. Because of
+this, we feel compelled at the present juncture to grant a kind of
+absolute physical reality to non-uniform motion, in opposition to the
+general principle of relatvity. But in what follows we shall soon see
+that this conclusion cannot be maintained.
+
+
+
+THE GRAVITATIONAL FIELD
+
+
+"If we pick up a stone and then let it go, why does it fall to the
+ground ?" The usual answer to this question is: "Because it is
+attracted by the earth." Modern physics formulates the answer rather
+differently for the following reason. As a result of the more careful
+study of electromagnetic phenomena, we have come to regard action at a
+distance as a process impossible without the intervention of some
+intermediary medium. If, for instance, a magnet attracts a piece of
+iron, we cannot be content to regard this as meaning that the magnet
+acts directly on the iron through the intermediate empty space, but we
+are constrained to imagine -- after the manner of Faraday -- that the
+magnet always calls into being something physically real in the space
+around it, that something being what we call a "magnetic field." In
+its turn this magnetic field operates on the piece of iron, so that
+the latter strives to move towards the magnet. We shall not discuss
+here the justification for this incidental conception, which is indeed
+a somewhat arbitrary one. We shall only mention that with its aid
+electromagnetic phenomena can be theoretically represented much more
+satisfactorily than without it, and this applies particularly to the
+transmission of electromagnetic waves. The effects of gravitation also
+are regarded in an analogous manner.
+
+The action of the earth on the stone takes place indirectly. The earth
+produces in its surrounding a gravitational field, which acts on the
+stone and produces its motion of fall. As we know from experience, the
+intensity of the action on a body dimishes according to a quite
+definite law, as we proceed farther and farther away from the earth.
+From our point of view this means : The law governing the properties
+of the gravitational field in space must be a perfectly definite one,
+in order correctly to represent the diminution of gravitational action
+with the distance from operative bodies. It is something like this:
+The body (e.g. the earth) produces a field in its immediate
+neighbourhood directly; the intensity and direction of the field at
+points farther removed from the body are thence determined by the law
+which governs the properties in space of the gravitational fields
+themselves.
+
+In contrast to electric and magnetic fields, the gravitational field
+exhibits a most remarkable property, which is of fundamental
+importance for what follows. Bodies which are moving under the sole
+influence of a gravitational field receive an acceleration, which does
+not in the least depend either on the material or on the physical
+state of the body. For instance, a piece of lead and a piece of wood
+fall in exactly the same manner in a gravitational field (in vacuo),
+when they start off from rest or with the same initial velocity. This
+law, which holds most accurately, can be expressed in a different form
+in the light of the following consideration.
+
+According to Newton's law of motion, we have
+
+(Force) = (inertial mass) x (acceleration),
+
+where the "inertial mass" is a characteristic constant of the
+accelerated body. If now gravitation is the cause of the acceleration,
+we then have
+
+(Force) = (gravitational mass) x (intensity of the gravitational
+field),
+
+where the "gravitational mass" is likewise a characteristic constant
+for the body. From these two relations follows:
+
+                                eq. 26: file eq26.gif
+
+
+If now, as we find from experience, the acceleration is to be
+independent of the nature and the condition of the body and always the
+same for a given gravitational field, then the ratio of the
+gravitational to the inertial mass must likewise be the same for all
+bodies. By a suitable choice of units we can thus make this ratio
+equal to unity. We then have the following law: The gravitational mass
+of a body is equal to its inertial law.
+
+It is true that this important law had hitherto been recorded in
+mechanics, but it had not been interpreted. A satisfactory
+interpretation can be obtained only if we recognise the following fact
+: The same quality of a body manifests itself according to
+circumstances as " inertia " or as " weight " (lit. " heaviness '). In
+the following section we shall show to what extent this is actually
+the case, and how this question is connected with the general
+postulate of relativity.
+
+
+
+
+THE EQUALITY OF INERTIAL AND GRAVITATIONAL MASS
+AS AN ARGUMENT FOR THE GENERAL POSTULE OF RELATIVITY
+
+
+We imagine a large portion of empty space, so far removed from stars
+and other appreciable masses, that we have before us approximately the
+conditions required by the fundamental law of Galilei. It is then
+possible to choose a Galileian reference-body for this part of space
+(world), relative to which points at rest remain at rest and points in
+motion continue permanently in uniform rectilinear motion. As
+reference-body let us imagine a spacious chest resembling a room with
+an observer inside who is equipped with apparatus. Gravitation
+naturally does not exist for this observer. He must fasten himself
+with strings to the floor, otherwise the slightest impact against the
+floor will cause him to rise slowly towards the ceiling of the room.
+
+To the middle of the lid of the chest is fixed externally a hook with
+rope attached, and now a " being " (what kind of a being is immaterial
+to us) begins pulling at this with a constant force. The chest
+together with the observer then begin to move "upwards" with a
+uniformly accelerated motion. In course of time their velocity will
+reach unheard-of values -- provided that we are viewing all this from
+another reference-body which is not being pulled with a rope.
+
+But how does the man in the chest regard the Process ? The
+acceleration of the chest will be transmitted to him by the reaction
+of the floor of the chest. He must therefore take up this pressure by
+means of his legs if he does not wish to be laid out full length on
+the floor. He is then standing in the chest in exactly the same way as
+anyone stands in a room of a home on our earth. If he releases a body
+which he previously had in his land, the accelertion of the chest will
+no longer be transmitted to this body, and for this reason the body
+will approach the floor of the chest with an accelerated relative
+motion. The observer will further convince himself that the
+acceleration of the body towards the floor of the chest is always of
+the same magnitude, whatever kind of body he may happen to use for the
+experiment.
+
+Relying on his knowledge of the gravitational field (as it was
+discussed in the preceding section), the man in the chest will thus
+come to the conclusion that he and the chest are in a gravitational
+field which is constant with regard to time. Of course he will be
+puzzled for a moment as to why the chest does not fall in this
+gravitational field. just then, however, he discovers the hook in the
+middle of the lid of the chest and the rope which is attached to it,
+and he consequently comes to the conclusion that the chest is
+suspended at rest in the gravitational field.
+
+Ought we to smile at the man and say that he errs in his conclusion ?
+I do not believe we ought to if we wish to remain consistent ; we must
+rather admit that his mode of grasping the situation violates neither
+reason nor known mechanical laws. Even though it is being accelerated
+with respect to the "Galileian space" first considered, we can
+nevertheless regard the chest as being at rest. We have thus good
+grounds for extending the principle of relativity to include bodies of
+reference which are accelerated with respect to each other, and as a
+result we have gained a powerful argument for a generalised postulate
+of relativity.
+
+We must note carefully that the possibility of this mode of
+interpretation rests on the fundamental property of the gravitational
+field of giving all bodies the same acceleration, or, what comes to
+the same thing, on the law of the equality of inertial and
+gravitational mass. If this natural law did not exist, the man in the
+accelerated chest would not be able to interpret the behaviour of the
+bodies around him on the supposition of a gravitational field, and he
+would not be justified on the grounds of experience in supposing his
+reference-body to be " at rest."
+
+Suppose that the man in the chest fixes a rope to the inner side of
+the lid, and that he attaches a body to the free end of the rope. The
+result of this will be to strech the rope so that it will hang "
+vertically " downwards. If we ask for an opinion of the cause of
+tension in the rope, the man in the chest will say: "The suspended
+body experiences a downward force in the gravitational field, and this
+is neutralised by the tension of the rope ; what determines the
+magnitude of the tension of the rope is the gravitational mass of the
+suspended body." On the other hand, an observer who is poised freely
+in space will interpret the condition of things thus : " The rope must
+perforce take part in the accelerated motion of the chest, and it
+transmits this motion to the body attached to it. The tension of the
+rope is just large enough to effect the acceleration of the body. That
+which determines the magnitude of the tension of the rope is the
+inertial mass of the body." Guided by this example, we see that our
+extension of the principle of relativity implies the necessity of the
+law of the equality of inertial and gravitational mass. Thus we have
+obtained a physical interpretation of this law.
+
+From our consideration of the accelerated chest we see that a general
+theory of relativity must yield important results on the laws of
+gravitation. In point of fact, the systematic pursuit of the general
+idea of relativity has supplied the laws satisfied by the
+gravitational field. Before proceeding farther, however, I must warn
+the reader against a misconception suggested by these considerations.
+A gravitational field exists for the man in the chest, despite the
+fact that there was no such field for the co-ordinate system first
+chosen. Now we might easily suppose that the existence of a
+gravitational field is always only an apparent one. We might also
+think that, regardless of the kind of gravitational field which may be
+present, we could always choose another reference-body such that no
+gravitational field exists with reference to it. This is by no means
+true for all gravitational fields, but only for those of quite special
+form. It is, for instance, impossible to choose a body of reference
+such that, as judged from it, the gravitational field of the earth (in
+its entirety) vanishes.
+
+We can now appreciate why that argument is not convincing, which we
+brought forward against the general principle of relativity at theend
+of Section 18. It is certainly true that the observer in the
+railway carriage experiences a jerk forwards as a result of the
+application of the brake, and that he recognises, in this the
+non-uniformity of motion (retardation) of the carriage. But he is
+compelled by nobody to refer this jerk to a " real " acceleration
+(retardation) of the carriage. He might also interpret his experience
+thus: " My body of reference (the carriage) remains permanently at
+rest. With reference to it, however, there exists (during the period
+of application of the brakes) a gravitational field which is directed
+forwards and which is variable with respect to time. Under the
+influence of this field, the embankment together with the earth moves
+non-uniformly in such a manner that their original velocity in the
+backwards direction is continuously reduced."
+
+
+
+IN WHAT RESPECTS ARE THE FOUNDATIONS OF CLASSICAL MECHANICS AND OF THE
+SPECIAL THEORY OF RELATIVITY UNSATISFACTORY?
+
+
+We have already stated several times that classical mechanics starts
+out from the following law: Material particles sufficiently far
+removed from other material particles continue to move uniformly in a
+straight line or continue in a state of rest. We have also repeatedly
+emphasised that this fundamental law can only be valid for bodies of
+reference K which possess certain unique states of motion, and which
+are in uniform translational motion relative to each other. Relative
+to other reference-bodies K the law is not valid. Both in classical
+mechanics and in the special theory of relativity we therefore
+differentiate between reference-bodies K relative to which the
+recognised " laws of nature " can be said to hold, and
+reference-bodies K relative to which these laws do not hold.
+
+But no person whose mode of thought is logical can rest satisfied with
+this condition of things. He asks : " How does it come that certain
+reference-bodies (or their states of motion) are given priority over
+other reference-bodies (or their states of motion) ? What is the
+reason for this Preference? In order to show clearly what I mean by
+this question, I shall make use of a comparison.
+
+I am standing in front of a gas range. Standing alongside of each
+other on the range are two pans so much alike that one may be mistaken
+for the other. Both are half full of water. I notice that steam is
+being emitted continuously from the one pan, but not from the other. I
+am surprised at this, even if I have never seen either a gas range or
+a pan before. But if I now notice a luminous something of bluish
+colour under the first pan but not under the other, I cease to be
+astonished, even if I have never before seen a gas flame. For I can
+only say that this bluish something will cause the emission of the
+steam, or at least possibly it may do so. If, however, I notice the
+bluish something in neither case, and if I observe that the one
+continuously emits steam whilst the other does not, then I shall
+remain astonished and dissatisfied until I have discovered some
+circumstance to which I can attribute the different behaviour of the
+two pans.
+
+Analogously, I seek in vain for a real something in classical
+mechanics (or in the special theory of relativity) to which I can
+attribute the different behaviour of bodies considered with respect to
+the reference systems K and K1.*  Newton saw this objection and
+attempted to invalidate it, but without success. But E. Mach recognsed
+it most clearly of all, and because of this objection he claimed that
+mechanics must be placed on a new basis. It can only be got rid of by
+means of a physics which is conformable to the general principle of
+relativity, since the equations of such a theory hold for every body
+of reference, whatever may be its state of motion.
+
+
+  Notes
+
+*) The objection is of importance more especially when the state of
+motion of the reference-body is of such a nature that it does not
+require any external agency for its maintenance, e.g. in the case when
+the reference-body is rotating uniformly.
+
+
+
+A FEW INFERENCES FROM THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+The considerations of Section 20 show that the general principle of
+relativity puts us in a position to derive properties of the
+gravitational field in a purely theoretical manner. Let us suppose,
+for instance, that we know the space-time " course " for any natural
+process whatsoever, as regards the manner in which it takes place in
+the Galileian domain relative to a Galileian body of reference K. By
+means of purely theoretical operations (i.e. simply by calculation) we
+are then able to find how this known natural process appears, as seen
+from a reference-body K1 which is accelerated relatively to K. But
+since a gravitational field exists with respect to this new body of
+reference K1, our consideration also teaches us how the gravitational
+field influences the process studied.
+
+For example, we learn that a body which is in a state of uniform
+rectilinear motion with respect to K (in accordance with the law of
+Galilei) is executing an accelerated and in general curvilinear motion
+with respect to the accelerated reference-body K1 (chest). This
+acceleration or curvature corresponds to the influence on the moving
+body of the gravitational field prevailing relatively to K. It is
+known that a gravitational field influences the movement of bodies in
+this way, so that our consideration supplies us with nothing
+essentially new.
+
+However, we obtain a new result of fundamental importance when we
+carry out the analogous consideration for a ray of light. With respect
+to the Galileian reference-body K, such a ray of light is transmitted
+rectilinearly with the velocity c. It can easily be shown that the
+path of the same ray of light is no longer a straight line when we
+consider it with reference to the accelerated chest (reference-body
+K1). From this we conclude, that, in general, rays of light are
+propagated curvilinearly in gravitational fields. In two respects this
+result is of great importance.
+
+In the first place, it can be compared with the reality. Although a
+detailed examination of the question shows that the curvature of light
+rays required by the general theory of relativity is only exceedingly
+small for the gravitational fields at our disposal in practice, its
+estimated magnitude for light rays passing the sun at grazing
+incidence is nevertheless 1.7 seconds of arc. This ought to manifest
+itself in the following way. As seen from the earth, certain fixed
+stars appear to be in the neighbourhood of the sun, and are thus
+capable of observation during a total eclipse of the sun. At such
+times, these stars ought to appear to be displaced outwards from the
+sun by an amount indicated above, as compared with their apparent
+position in the sky when the sun is situated at another part of the
+heavens. The examination of the correctness or otherwise of this
+deduction is a problem of the greatest importance, the early solution
+of which is to be expected of astronomers.[2]*
+
+In the second place our result shows that, according to the general
+theory of relativity, the law of the constancy of the velocity of
+light in vacuo, which constitutes one of the two fundamental
+assumptions in the special theory of relativity and to which we have
+already frequently referred, cannot claim any unlimited validity. A
+curvature of rays of light can only take place when the velocity of
+propagation of light varies with position. Now we might think that as
+a consequence of this, the special theory of relativity and with it
+the whole theory of relativity would be laid in the dust. But in
+reality this is not the case. We can only conclude that the special
+theory of relativity cannot claim an unlinlited domain of validity ;
+its results hold only so long as we are able to disregard the
+influences of gravitational fields on the phenomena (e.g. of light).
+
+Since it has often been contended by opponents of the theory of
+relativity that the special theory of relativity is overthrown by the
+general theory of relativity, it is perhaps advisable to make the
+facts of the case clearer by means of an appropriate comparison.
+Before the development of electrodynamics the laws of electrostatics
+were looked upon as the laws of electricity. At the present time we
+know that electric fields can be derived correctly from electrostatic
+considerations only for the case, which is never strictly realised, in
+which the electrical masses are quite at rest relatively to each
+other, and to the co-ordinate system. Should we be justified in saying
+that for this reason electrostatics is overthrown by the
+field-equations of Maxwell in electrodynamics ? Not in the least.
+Electrostatics is contained in electrodynamics as a limiting case ;
+the laws of the latter lead directly to those of the former for the
+case in which the fields are invariable with regard to time. No fairer
+destiny could be allotted to any physical theory, than that it should
+of itself point out the way to the introduction of a more
+comprehensive theory, in which it lives on as a limiting case.
+
+In the example of the transmission of light just dealt with, we have
+seen that the general theory of relativity enables us to derive
+theoretically the influence of a gravitational field on the course of
+natural processes, the Iaws of which are already known when a
+gravitational field is absent. But the most attractive problem, to the
+solution of which the general theory of relativity supplies the key,
+concerns the investigation of the laws satisfied by the gravitational
+field itself. Let us consider this for a moment.
+
+We are acquainted with space-time domains which behave (approximately)
+in a " Galileian " fashion under suitable choice of reference-body,
+i.e. domains in which gravitational fields are absent. If we now refer
+such a domain to a reference-body K1 possessing any kind of motion,
+then relative to K1 there exists a gravitational field which is
+variable with respect to space and time.[3]**  The character of this
+field will of course depend on the motion chosen for K1. According to
+the general theory of relativity, the general law of the gravitational
+field must be satisfied for all gravitational fields obtainable in
+this way. Even though by no means all gravitationial fields can be
+produced in this way, yet we may entertain the hope that the general
+law of gravitation will be derivable from such gravitational fields of
+a special kind. This hope has been realised in the most beautiful
+manner. But between the clear vision of this goal and its actual
+realisation it was necessary to surmount a serious difficulty, and as
+this lies deep at the root of things, I dare not withhold it from the
+reader. We require to extend our ideas of the space-time continuum
+still farther.
+
+
+  Notes
+
+*) By means of the star photographs of two expeditions equipped by
+a Joint Committee of the Royal and Royal Astronomical Societies, the
+existence of the deflection of light demanded by theory was first
+confirmed during the solar eclipse of 29th May, 1919. (Cf. Appendix
+III.)
+
+**) This follows from a generalisation of the discussion in
+Section 20
+
+
+
+BEHAVIOUR OF CLOCKS AND MEASURING-RODS ON A ROTATING BODY OF REFERENCE
+
+
+Hitherto I have purposely refrained from speaking about the physical
+interpretation of space- and time-data in the case of the general
+theory of relativity. As a consequence, I am guilty of a certain
+slovenliness of treatment, which, as we know from the special theory
+of relativity, is far from being unimportant and pardonable. It is now
+high time that we remedy this defect; but I would mention at the
+outset, that this matter lays no small claims on the patience and on
+the power of abstraction of the reader.
+
+We start off again from quite special cases, which we have frequently
+used before. Let us consider a space time domain in which no
+gravitational field exists relative to a reference-body K whose state
+of motion has been suitably chosen. K is then a Galileian
+reference-body as regards the domain considered, and the results of
+the special theory of relativity hold relative to K. Let us supposse
+the same domain referred to a second body of reference K1, which is
+rotating uniformly with respect to K. In order to fix our ideas, we
+shall imagine K1 to be in the form of a plane circular disc, which
+rotates uniformly in its own plane about its centre. An observer who
+is sitting eccentrically on the disc K1 is sensible of a force which
+acts outwards in a radial direction, and which would be interpreted as
+an effect of inertia (centrifugal force) by an observer who was at
+rest with respect to the original reference-body K. But the observer
+on the disc may regard his disc as a reference-body which is " at rest
+" ; on the basis of the general principle of relativity he is
+justified in doing this. The force acting on himself, and in fact on
+all other bodies which are at rest relative to the disc, he regards as
+the effect of a gravitational field. Nevertheless, the
+space-distribution of this gravitational field is of a kind that would
+not be possible on Newton's theory of gravitation.* But since the
+observer believes in the general theory of relativity, this does not
+disturb him; he is quite in the right when he believes that a general
+law of gravitation can be formulated- a law which not only explains
+the motion of the stars correctly, but also the field of force
+experienced by himself.
+
+The observer performs experiments on his circular disc with clocks and
+measuring-rods. In doing so, it is his intention to arrive at exact
+definitions for the signification of time- and space-data with
+reference to the circular disc K1, these definitions being based on
+his observations. What will be his experience in this enterprise ?
+
+To start with, he places one of two identically constructed clocks at
+the centre of the circular disc, and the other on the edge of the
+disc, so that they are at rest relative to it. We now ask ourselves
+whether both clocks go at the same rate from the standpoint of the
+non-rotating Galileian reference-body K. As judged from this body, the
+clock at the centre of the disc has no velocity, whereas the clock at
+the edge of the disc is in motion relative to K in consequence of the
+rotation. According to a result obtained in Section 12, it follows
+that the latter clock goes at a rate permanently slower than that of
+the clock at the centre of the circular disc, i.e. as observed from K.
+It is obvious that the same effect would be noted by an observer whom
+we will imagine sitting alongside his clock at the centre of the
+circular disc. Thus on our circular disc, or, to make the case more
+general, in every gravitational field, a clock will go more quickly or
+less quickly, according to the position in which the clock is situated
+(at rest). For this reason it is not possible to obtain a reasonable
+definition of time with the aid of clocks which are arranged at rest
+with respect to the body of reference. A similar difficulty presents
+itself when we attempt to apply our earlier definition of simultaneity
+in such a case, but I do not wish to go any farther into this
+question.
+
+Moreover, at this stage the definition of the space co-ordinates also
+presents insurmountable difficulties. If the observer applies his
+standard measuring-rod (a rod which is short as compared with the
+radius of the disc) tangentially to the edge of the disc, then, as
+judged from the Galileian system, the length of this rod will be less
+than I, since, according to Section 12, moving bodies suffer a
+shortening in the direction of the motion. On the other hand, the
+measaring-rod will not experience a shortening in length, as judged
+from K, if it is applied to the disc in the direction of the radius.
+If, then, the observer first measures the circumference of the disc
+with his measuring-rod and then the diameter of the disc, on dividing
+the one by the other, he will not obtain as quotient the familiar
+number p = 3.14 . . ., but a larger number,[4]** whereas of course,
+for a disc which is at rest with respect to K, this operation would
+yield p exactly. This proves that the propositions of Euclidean
+geometry cannot hold exactly on the rotating disc, nor in general in a
+gravitational field, at least if we attribute the length I to the rod
+in all positions and in every orientation. Hence the idea of a
+straight line also loses its meaning. We are therefore not in a
+position to define exactly the co-ordinates x, y, z relative to the
+disc by means of the method used in discussing the special theory, and
+as long as the co- ordinates and times of events have not been
+defined, we cannot assign an exact meaning to the natural laws in
+which these occur.
+
+Thus all our previous conclusions based on general relativity would
+appear to be called in question. In reality we must make a subtle
+detour in order to be able to apply the postulate of general
+relativity exactly. I shall prepare the reader for this in the
+following paragraphs.
+
+
+  Notes
+
+*) The field disappears at the centre of the disc and increases
+proportionally to the distance from the centre as we proceed outwards.
+
+**) Throughout this consideration we have to use the Galileian
+(non-rotating) system K as reference-body, since we may only assume
+the validity of the results of the special theory of relativity
+relative to K (relative to K1 a gravitational field prevails).
+
+
+
+EUCLIDEAN AND NON-EUCLIDEAN CONTINUUM
+
+
+The surface of a marble table is spread out in front of me. I can get
+from any one point on this table to any other point by passing
+continuously from one point to a " neighbouring " one, and repeating
+this process a (large) number of times, or, in other words, by going
+from point to point without executing "jumps." I am sure the reader
+will appreciate with sufficient clearness what I mean here by "
+neighbouring " and by " jumps " (if he is not too pedantic). We
+express this property of the surface by describing the latter as a
+continuum.
+
+Let us now imagine that a large number of little rods of equal length
+have been made, their lengths being small compared with the dimensions
+of the marble slab. When I say they are of equal length, I mean that
+one can be laid on any other without the ends overlapping. We next lay
+four of these little rods on the marble slab so that they constitute a
+quadrilateral figure (a square), the diagonals of which are equally
+long. To ensure the equality of the diagonals, we make use of a little
+testing-rod. To this square we add similar ones, each of which has one
+rod in common with the first. We proceed in like manner with each of
+these squares until finally the whole marble slab is laid out with
+squares. The arrangement is such, that each side of a square belongs
+to two squares and each corner to four squares.
+
+It is a veritable wonder that we can carry out this business without
+getting into the greatest difficulties. We only need to think of the
+following. If at any moment three squares meet at a corner, then two
+sides of the fourth square are already laid, and, as a consequence,
+the arrangement of the remaining two sides of the square is already
+completely determined. But I am now no longer able to adjust the
+quadrilateral so that its diagonals may be equal. If they are equal of
+their own accord, then this is an especial favour of the marble slab
+and of the little rods, about which I can only be thankfully
+surprised. We must experience many such surprises if the construction
+is to be successful.
+
+If everything has really gone smoothly, then I say that the points of
+the marble slab constitute a Euclidean continuum with respect to the
+little rod, which has been used as a " distance " (line-interval). By
+choosing one corner of a square as " origin" I can characterise every
+other corner of a square with reference to this origin by means of two
+numbers. I only need state how many rods I must pass over when,
+starting from the origin, I proceed towards the " right " and then "
+upwards," in order to arrive at the corner of the square under
+consideration. These two numbers are then the " Cartesian co-ordinates
+" of this corner with reference to the " Cartesian co-ordinate system"
+which is determined by the arrangement of little rods.
+
+By making use of the following modification of this abstract
+experiment, we recognise that there must also be cases in which the
+experiment would be unsuccessful. We shall suppose that the rods "
+expand " by in amount proportional to the increase of temperature. We
+heat the central part of the marble slab, but not the periphery, in
+which case two of our little rods can still be brought into
+coincidence at every position on the table. But our construction of
+squares must necessarily come into disorder during the heating,
+because the little rods on the central region of the table expand,
+whereas those on the outer part do not.
+
+With reference to our little rods -- defined as unit lengths -- the
+marble slab is no longer a Euclidean continuum, and we are also no
+longer in the position of defining Cartesian co-ordinates directly
+with their aid, since the above construction can no longer be carried
+out. But since there are other things which are not influenced in a
+similar manner to the little rods (or perhaps not at all) by the
+temperature of the table, it is possible quite naturally to maintain
+the point of view that the marble slab is a " Euclidean continuum."
+This can be done in a satisfactory manner by making a more subtle
+stipulation about the measurement or the comparison of lengths.
+
+But if rods of every kind (i.e. of every material) were to behave in
+the same way as regards the influence of temperature when they are on
+the variably heated marble slab, and if we had no other means of
+detecting the effect of temperature than the geometrical behaviour of
+our rods in experiments analogous to the one described above, then our
+best plan would be to assign the distance one to two points on the
+slab, provided that the ends of one of our rods could be made to
+coincide with these two points ; for how else should we define the
+distance without our proceeding being in the highest measure grossly
+arbitrary ? The method of Cartesian coordinates must then be
+discarded, and replaced by another which does not assume the validity
+of Euclidean geometry for rigid bodies.*  The reader will notice
+that the situation depicted here corresponds to the one brought about
+by the general postitlate of relativity (Section 23).
+
+
+  Notes
+
+*) Mathematicians have been confronted with our problem in the
+following form. If we are given a surface (e.g. an ellipsoid) in
+Euclidean three-dimensional space, then there exists for this surface
+a two-dimensional geometry, just as much as for a plane surface. Gauss
+undertook the task of treating this two-dimensional geometry from
+first principles, without making use of the fact that the surface
+belongs to a Euclidean continuum of three dimensions. If we imagine
+constructions to be made with rigid rods in the surface (similar to
+that above with the marble slab), we should find that different laws
+hold for these from those resulting on the basis of Euclidean plane
+geometry. The surface is not a Euclidean continuum with respect to the
+rods, and we cannot define Cartesian co-ordinates in the surface.
+Gauss indicated the principles according to which we can treat the
+geometrical relationships in the surface, and thus pointed out the way
+to the method of Riemman of treating multi-dimensional, non-Euclidean
+continuum. Thus it is that mathematicians long ago solved the formal
+problems to which we are led by the general postulate of relativity.
+
+
+
+GAUSSIAN CO-ORDINATES
+
+
+According to Gauss, this combined analytical and geometrical mode of
+handling the problem can be arrived at in the following way. We
+imagine a system of arbitrary curves (see Fig. 4) drawn on the surface
+of the table. These we designate as u-curves, and we indicate each of
+them by means of a number. The Curves u= 1, u= 2 and u= 3 are drawn in
+the diagram. Between the curves u= 1 and u= 2 we must imagine an
+infinitely large number to be drawn, all of which correspond to real
+numbers lying between 1 and 2. fig. 04 We have then a system of
+u-curves, and this "infinitely dense" system covers the whole surface
+of the table. These u-curves must not intersect each other, and
+through each point of the surface one and only one curve must pass.
+Thus a perfectly definite value of u belongs to every point on the
+surface of the marble slab. In like manner we imagine a system of
+v-curves drawn on the surface. These satisfy the same conditions as
+the u-curves, they are provided with numbers in a corresponding
+manner, and they may likewise be of arbitrary shape. It follows that a
+value of u and a value of v belong to every point on the surface of
+the table. We call these two numbers the co-ordinates of the surface
+of the table (Gaussian co-ordinates). For example, the point P in the
+diagram has the Gaussian co-ordinates u= 3, v= 1. Two neighbouring
+points P and P1 on the surface then correspond to the co-ordinates
+
+                       P:       u,v
+
+                       P1:     u + du, v + dv,
+
+where du and dv signify very small numbers. In a similar manner we may
+indicate the distance (line-interval) between P and P1, as measured
+with a little rod, by means of the very small number ds. Then
+according to Gauss we have
+
+                ds2 = g[11]du2 + 2g[12]dudv = g[22]dv2
+
+where g[11], g[12], g[22], are magnitudes which depend in a perfectly
+definite way on u and v. The magnitudes g[11], g[12] and g[22],
+determine the behaviour of the rods relative to the u-curves and
+v-curves, and thus also relative to the surface of the table. For the
+case in which the points of the surface considered form a Euclidean
+continuum with reference to the measuring-rods, but only in this case,
+it is possible to draw the u-curves and v-curves and to attach numbers
+to them, in such a manner, that we simply have :
+
+                           ds2 = du2 + dv2
+
+Under these conditions, the u-curves and v-curves are straight lines
+in the sense of Euclidean geometry, and they are perpendicular to each
+other. Here the Gaussian coordinates are samply Cartesian ones. It is
+clear that Gauss co-ordinates are nothing more than an association of
+two sets of numbers with the points of the surface considered, of such
+a nature that numerical values differing very slightly from each other
+are associated with neighbouring points " in space."
+
+So far, these considerations hold for a continuum of two dimensions.
+But the Gaussian method can be applied also to a continuum of three,
+four or more dimensions. If, for instance, a continuum of four
+dimensions be supposed available, we may represent it in the following
+way. With every point of the continuum, we associate arbitrarily four
+numbers, x[1], x[2], x[3], x[4], which are known as " co-ordinates."
+Adjacent points correspond to adjacent values of the coordinates. If a
+distance ds is associated with the adjacent points P and P1, this
+distance being measurable and well defined from a physical point of
+view, then the following formula holds:
+
+ds2 = g[11]dx[1]^2 + 2g[12]dx[1]dx[2] . . . . g[44]dx[4]^2,
+
+where the magnitudes g[11], etc., have values which vary with the
+position in the continuum. Only when the continuum is a Euclidean one
+is it possible to associate the co-ordinates x[1] . . x[4]. with the
+points of the continuum so that we have simply
+
+ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+In this case relations hold in the four-dimensional continuum which
+are analogous to those holding in our three-dimensional measurements.
+
+However, the Gauss treatment for ds2 which we have given above is not
+always possible. It is only possible when sufficiently small regions
+of the continuum under consideration may be regarded as Euclidean
+continua. For example, this obviously holds in the case of the marble
+slab of the table and local variation of temperature. The temperature
+is practically constant for a small part of the slab, and thus the
+geometrical behaviour of the rods is almost as it ought to be
+according to the rules of Euclidean geometry. Hence the imperfections
+of the construction of squares in the previous section do not show
+themselves clearly until this construction is extended over a
+considerable portion of the surface of the table.
+
+We can sum this up as follows: Gauss invented a method for the
+mathematical treatment of continua in general, in which "
+size-relations " (" distances " between neighbouring points) are
+defined. To every point of a continuum are assigned as many numbers
+(Gaussian coordinates) as the continuum has dimensions. This is done
+in such a way, that only one meaning can be attached to the
+assignment, and that numbers (Gaussian coordinates) which differ by an
+indefinitely small amount are assigned to adjacent points. The
+Gaussian coordinate system is a logical generalisation of the
+Cartesian co-ordinate system. It is also applicable to non-Euclidean
+continua, but only when, with respect to the defined "size" or
+"distance," small parts of the continuum under consideration behave
+more nearly like a Euclidean system, the smaller the part of the
+continuum under our notice.
+
+
+
+THE SPACE-TIME CONTINUUM OF THE SPEICAL THEORY OF RELATIVITY CONSIDERED AS A
+EUCLIDEAN CONTINUUM
+
+
+We are now in a position to formulate more exactly the idea of
+Minkowski, which was only vaguely indicated in Section 17. In
+accordance with the special theory of relativity, certain co-ordinate
+systems are given preference for the description of the
+four-dimensional, space-time continuum. We called these " Galileian
+co-ordinate systems." For these systems, the four co-ordinates x, y,
+z, t, which determine an event or -- in other words, a point of the
+four-dimensional continuum -- are defined physically in a simple
+manner, as set forth in detail in the first part of this book. For the
+transition from one Galileian system to another, which is moving
+uniformly with reference to the first, the equations of the Lorentz
+transformation are valid. These last form the basis for the derivation
+of deductions from the special theory of relativity, and in themselves
+they are nothing more than the expression of the universal validity of
+the law of transmission of light for all Galileian systems of
+reference.
+
+Minkowski found that the Lorentz transformations satisfy the following
+simple conditions. Let us consider two neighbouring events, the
+relative position of which in the four-dimensional continuum is given
+with respect to a Galileian reference-body K by the space co-ordinate
+differences dx, dy, dz and the time-difference dt. With reference to a
+second Galileian system we shall suppose that the corresponding
+differences for these two events are dx1, dy1, dz1, dt1. Then these
+magnitudes always fulfil the condition*
+
+     dx2 + dy2 + dz2 - c^2dt2 = dx1 2 + dy1 2 + dz1 2 - c^2dt1 2.
+
+The validity of the Lorentz transformation follows from this
+condition. We can express this as follows: The magnitude
+
+                   ds2 = dx2 + dy2 + dz2 - c^2dt2,
+
+which belongs to two adjacent points of the four-dimensional
+space-time continuum, has the same value for all selected (Galileian)
+reference-bodies. If we replace x, y, z, sq. rt. -I . ct , by x[1],
+x[2], x[3], x[4], we also obtaill the result that
+
+             ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+is independent of the choice of the body of reference. We call the
+magnitude ds the " distance " apart of the two events or
+four-dimensional points.
+
+Thus, if we choose as time-variable the imaginary variable sq. rt. -I
+. ct instead of the real quantity t, we can regard the space-time
+contintium -- accordance with the special theory of relativity -- as a
+", Euclidean " four-dimensional continuum, a result which follows from
+the considerations of the preceding section.
+
+
+  Notes
+
+*) Cf. Appendixes I and 2. The relations which are derived
+there for the co-ordlnates themselves are valid also for co-ordinate
+differences, and thus also for co-ordinate differentials (indefinitely
+small differences).
+
+
+
+THE SPACE-TIME CONTINUUM OF THE GENERAL THEORY OF REALTIIVTY IS NOT A
+ECULIDEAN CONTINUUM
+
+
+In the first part of this book we were able to make use of space-time
+co-ordinates which allowed of a simple and direct physical
+interpretation, and which, according to Section 26, can be regarded
+as four-dimensional Cartesian co-ordinates. This was possible on the
+basis of the law of the constancy of the velocity of tight. But
+according to Section 21 the general theory of relativity cannot
+retain this law. On the contrary, we arrived at the result that
+according to this latter theory the velocity of light must always
+depend on the co-ordinates when a gravitational field is present. In
+connection with a specific illustration in Section 23, we found
+that the presence of a gravitational field invalidates the definition
+of the coordinates and the ifine, which led us to our objective in the
+special theory of relativity.
+
+In view of the resuIts of these considerations we are led to the
+conviction that, according to the general principle of relativity, the
+space-time continuum cannot be regarded as a Euclidean one, but that
+here we have the general case, corresponding to the marble slab with
+local variations of temperature, and with which we made acquaintance
+as an example of a two-dimensional continuum. Just as it was there
+impossible to construct a Cartesian co-ordinate system from equal
+rods, so here it is impossible to build up a system (reference-body)
+from rigid bodies and clocks, which shall be of such a nature that
+measuring-rods and clocks, arranged rigidly with respect to one
+another, shaIll indicate position and time directly. Such was the
+essence of the difficulty with which we were confronted in Section
+23.
+
+But the considerations of Sections 25 and 26 show us the way to
+surmount this difficulty. We refer the fourdimensional space-time
+continuum in an arbitrary manner to Gauss co-ordinates. We assign to
+every point of the continuum (event) four numbers, x[1], x[2], x[3],
+x[4] (co-ordinates), which have not the least direct physical
+significance, but only serve the purpose of numbering the points of
+the continuum in a definite but arbitrary manner. This arrangement
+does not even need to be of such a kind that we must regard x[1],
+x[2], x[3], as "space" co-ordinates and x[4], as a " time "
+co-ordinate.
+
+The reader may think that such a description of the world would be
+quite inadequate. What does it mean to assign to an event the
+particular co-ordinates x[1], x[2], x[3], x[4], if in themselves these
+co-ordinates have no significance ? More careful consideration shows,
+however, that this anxiety is unfounded. Let us consider, for
+instance, a material point with any kind of motion. If this point had
+only a momentary existence without duration, then it would to
+described in space-time by a single system of values x[1], x[2], x[3],
+x[4]. Thus its permanent existence must be characterised by an
+infinitely large number of such systems of values, the co-ordinate
+values of which are so close together as to give continuity;
+corresponding to the material point, we thus have a (uni-dimensional)
+line in the four-dimensional continuum. In the same way, any such
+lines in our continuum correspond to many points in motion. The only
+statements having regard to these points which can claim a physical
+existence are in reality the statements about their encounters. In our
+mathematical treatment, such an encounter is expressed in the fact
+that the two lines which represent the motions of the points in
+question have a particular system of co-ordinate values, x[1], x[2],
+x[3], x[4], in common. After mature consideration the reader will
+doubtless admit that in reality such encounters constitute the only
+actual evidence of a time-space nature with which we meet in physical
+statements.
+
+When we were describing the motion of a material point relative to a
+body of reference, we stated nothing more than the encounters of this
+point with particular points of the reference-body. We can also
+determine the corresponding values of the time by the observation of
+encounters of the body with clocks, in conjunction with the
+observation of the encounter of the hands of clocks with particular
+points on the dials. It is just the same in the case of
+space-measurements by means of measuring-rods, as a litttle
+consideration will show.
+
+The following statements hold generally : Every physical description
+resolves itself into a number of statements, each of which refers to
+the space-time coincidence of two events A and B. In terms of Gaussian
+co-ordinates, every such statement is expressed by the agreement of
+their four co-ordinates x[1], x[2], x[3], x[4]. Thus in reality, the
+description of the time-space continuum by means of Gauss co-ordinates
+completely replaces the description with the aid of a body of
+reference, without suffering from the defects of the latter mode of
+description; it is not tied down to the Euclidean character of the
+continuum which has to be represented.
+
+
+
+EXACT FORMULATION OF THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+We are now in a position to replace the pro. visional formulation of
+the general principle of relativity given in Section 18 by an exact
+formulation. The form there used, "All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion," cannot be maintained, because the use of rigid
+reference-bodies, in the sense of the method followed in the special
+theory of relativity, is in general not possible in space-time
+description. The Gauss co-ordinate system has to take the place of the
+body of reference. The following statement corresponds to the
+fundamental idea of the general principle of relativity: "All Gaussian
+co-ordinate systems are essentially equivalent for the formulation of
+the general laws of nature."
+
+We can state this general principle of relativity in still another
+form, which renders it yet more clearly intelligible than it is when
+in the form of the natural extension of the special principle of
+relativity. According to the special theory of relativity, the
+equations which express the general laws of nature pass over into
+equations of the same form when, by making use of the Lorentz
+transformation, we replace the space-time variables x, y, z, t, of a
+(Galileian) reference-body K by the space-time variables x1, y1, z1,
+t1, of a new reference-body K1. According to the general theory of
+relativity, on the other hand, by application of arbitrary
+substitutions of the Gauss variables x[1], x[2], x[3], x[4], the
+equations must pass over into equations of the same form; for every
+transformation (not only the Lorentz transformation) corresponds to
+the transition of one Gauss co-ordinate system into another.
+
+If we desire to adhere to our "old-time" three-dimensional view of
+things, then we can characterise the development which is being
+undergone by the fundamental idea of the general theory of relativity
+as follows : The special theory of relativity has reference to
+Galileian domains, i.e. to those in which no gravitational field
+exists. In this connection a Galileian reference-body serves as body
+of reference, i.e. a rigid body the state of motion of which is so
+chosen that the Galileian law of the uniform rectilinear motion of
+"isolated" material points holds relatively to it.
+
+Certain considerations suggest that we should refer the same Galileian
+domains to non-Galileian reference-bodies also. A gravitational field
+of a special kind is then present with respect to these bodies (cf.
+Sections 20 and 23).
+
+In gravitational fields there are no such things as rigid bodies with
+Euclidean properties; thus the fictitious rigid body of reference is
+of no avail in the general theory of relativity. The motion of clocks
+is also influenced by gravitational fields, and in such a way that a
+physical definition of time which is made directly with the aid of
+clocks has by no means the same degree of plausibility as in the
+special theory of relativity.
+
+For this reason non-rigid reference-bodies are used, which are as a
+whole not only moving in any way whatsoever, but which also suffer
+alterations in form ad lib. during their motion. Clocks, for which the
+law of motion is of any kind, however irregular, serve for the
+definition of time. We have to imagine each of these clocks fixed at a
+point on the non-rigid reference-body. These clocks satisfy only the
+one condition, that the "readings" which are observed simultaneously
+on adjacent clocks (in space) differ from each other by an
+indefinitely small amount. This non-rigid reference-body, which might
+appropriately be termed a "reference-mollusc", is in the main
+equivalent to a Gaussian four-dimensional co-ordinate system chosen
+arbitrarily. That which gives the "mollusc" a certain
+comprehensibility as compared with the Gauss co-ordinate system is the
+(really unjustified) formal retention of the separate existence of the
+space co-ordinates as opposed to the time co-ordinate. Every point on
+the mollusc is treated as a space-point, and every material point
+which is at rest relatively to it as at rest, so long as the mollusc
+is considered as reference-body. The general principle of relativity
+requires that all these molluscs can be used as reference-bodies with
+equal right and equal success in the formulation of the general laws
+of nature; the laws themselves must be quite independent of the choice
+of mollusc.
+
+The great power possessed by the general principle of relativity lies
+in the comprehensive limitation which is imposed on the laws of nature
+in consequence of what we have seen above.
+
+
+
+THE SOLUTION OF THE PROBLEM OF GRAVITATION ON THE BASIS OF THE GENERAL
+PRINCIPLE OF RELATIVITY
+
+
+If the reader has followed all our previous considerations, he will
+have no further difficulty in understanding the methods leading to the
+solution of the problem of gravitation.
+
+We start off on a consideration of a Galileian domain, i.e. a domain
+in which there is no gravitational field relative to the Galileian
+reference-body K. The behaviour of measuring-rods and clocks with
+reference to K is known from the special theory of relativity,
+likewise the behaviour of "isolated" material points; the latter move
+uniformly and in straight lines.
+
+Now let us refer this domain to a random Gauss coordinate system or to
+a "mollusc" as reference-body K1. Then with respect to K1 there is a
+gravitational field G (of a particular kind). We learn the behaviour
+of measuring-rods and clocks and also of freely-moving material points
+with reference to K1 simply by mathematical transformation. We
+interpret this behaviour as the behaviour of measuring-rods, docks and
+material points tinder the influence of the gravitational field G.
+Hereupon we introduce a hypothesis: that the influence of the
+gravitational field on measuringrods, clocks and freely-moving
+material points continues to take place according to the same laws,
+even in the case where the prevailing gravitational field is not
+derivable from the Galfleian special care, simply by means of a
+transformation of co-ordinates.
+
+The next step is to investigate the space-time behaviour of the
+gravitational field G, which was derived from the Galileian special
+case simply by transformation of the coordinates. This behaviour is
+formulated in a law, which is always valid, no matter how the
+reference-body (mollusc) used in the description may be chosen.
+
+This law is not yet the general law of the gravitational field, since
+the gravitational field under consideration is of a special kind. In
+order to find out the general law-of-field of gravitation we still
+require to obtain a generalisation of the law as found above. This can
+be obtained without caprice, however, by taking into consideration the
+following demands:
+
+(a) The required generalisation must likewise satisfy the general
+postulate of relativity.
+
+(b) If there is any matter in the domain under consideration, only its
+inertial mass, and thus according to Section 15 only its energy is
+of importance for its etfect in exciting a field.
+
+(c) Gravitational field and matter together must satisfy the law of
+the conservation of energy (and of impulse).
+
+Finally, the general principle of relativity permits us to determine
+the influence of the gravitational field on the course of all those
+processes which take place according to known laws when a
+gravitational field is absent i.e. which have already been fitted into
+the frame of the special theory of relativity. In this connection we
+proceed in principle according to the method which has already been
+explained for measuring-rods, clocks and freely moving material
+points.
+
+The theory of gravitation derived in this way from the general
+postulate of relativity excels not only in its beauty ; nor in
+removing the defect attaching to classical mechanics which was brought
+to light in Section 21; nor in interpreting the empirical law of
+the equality of inertial and gravitational mass ; but it has also
+already explained a result of observation in astronomy, against which
+classical mechanics is powerless.
+
+If we confine the application of the theory to the case where the
+gravitational fields can be regarded as being weak, and in which all
+masses move with respect to the coordinate system with velocities
+which are small compared with the velocity of light, we then obtain as
+a first approximation the Newtonian theory. Thus the latter theory is
+obtained here without any particular assumption, whereas Newton had to
+introduce the hypothesis that the force of attraction between mutually
+attracting material points is inversely proportional to the square of
+the distance between them. If we increase the accuracy of the
+calculation, deviations from the theory of Newton make their
+appearance, practically all of which must nevertheless escape the test
+of observation owing to their smallness.
+
+We must draw attention here to one of these deviations. According to
+Newton's theory, a planet moves round the sun in an ellipse, which
+would permanently maintain its position with respect to the fixed
+stars, if we could disregard the motion of the fixed stars themselves
+and the action of the other planets under consideration. Thus, if we
+correct the observed motion of the planets for these two influences,
+and if Newton's theory be strictly correct, we ought to obtain for the
+orbit of the planet an ellipse, which is fixed with reference to the
+fixed stars. This deduction, which can be tested with great accuracy,
+has been confirmed for all the planets save one, with the precision
+that is capable of being obtained by the delicacy of observation
+attainable at the present time. The sole exception is Mercury, the
+planet which lies nearest the sun. Since the time of Leverrier, it has
+been known that the ellipse corresponding to the orbit of Mercury,
+after it has been corrected for the influences mentioned above, is not
+stationary with respect to the fixed stars, but that it rotates
+exceedingly slowly in the plane of the orbit and in the sense of the
+orbital motion. The value obtained for this rotary movement of the
+orbital ellipse was 43 seconds of arc per century, an amount ensured
+to be correct to within a few seconds of arc. This effect can be
+explained by means of classical mechanics only on the assumption of
+hypotheses which have little probability, and which were devised
+solely for this purponse.
+
+On the basis of the general theory of relativity, it is found that the
+ellipse of every planet round the sun must necessarily rotate in the
+manner indicated above ; that for all the planets, with the exception
+of Mercury, this rotation is too small to be detected with the
+delicacy of observation possible at the present time ; but that in the
+case of Mercury it must amount to 43 seconds of arc per century, a
+result which is strictly in agreement with observation.
+
+Apart from this one, it has hitherto been possible to make only two
+deductions from the theory which admit of being tested by observation,
+to wit, the curvature of light rays by the gravitational field of the
+sun,*x and a displacement of the spectral lines of light reaching
+us from large stars, as compared with the corresponding lines for
+light produced in an analogous manner terrestrially (i.e. by the same
+kind of atom).**  These two deductions from the theory have both
+been confirmed.
+
+
+  Notes
+
+*) First observed by Eddington and others in 1919. (Cf. Appendix
+III, pp. 126-129).
+
+**) Established by Adams in 1924. (Cf. p. 132)
+
+
+
+
+PART III
+
+CONSIDERATIONS ON THE UNIVERSE AS A WHOLE
+
+
+COSMOLOGICAL DIFFICULTIES OF NEWTON'S THEORY
+
+
+Part from the difficulty discussed in Section 21, there is a second
+fundamental difficulty attending classical celestial mechanics, which,
+to the best of my knowledge, was first discussed in detail by the
+astronomer Seeliger. If we ponder over the question as to how the
+universe, considered as a whole, is to be regarded, the first answer
+that suggests itself to us is surely this: As regards space (and time)
+the universe is infinite. There are stars everywhere, so that the
+density of matter, although very variable in detail, is nevertheless
+on the average everywhere the same. In other words: However far we
+might travel through space, we should find everywhere an attenuated
+swarm of fixed stars of approrimately the same kind and density.
+
+This view is not in harmony with the theory of Newton. The latter
+theory rather requires that the universe should have a kind of centre
+in which the density of the stars is a maximum, and that as we proceed
+outwards from this centre the group-density of the stars should
+diminish, until finally, at great distances, it is succeeded by an
+infinite region of emptiness. The stellar universe ought to be a
+finite island in the infinite ocean of space.*
+
+This conception is in itself not very satisfactory. It is still less
+satisfactory because it leads to the result that the light emitted by
+the stars and also individual stars of the stellar system are
+perpetually passing out into infinite space, never to return, and
+without ever again coming into interaction with other objects of
+nature. Such a finite material universe would be destined to become
+gradually but systematically impoverished.
+
+In order to escape this dilemma, Seeliger suggested a modification of
+Newton's law, in which he assumes that for great distances the force
+of attraction between two masses diminishes more rapidly than would
+result from the inverse square law. In this way it is possible for the
+mean density of matter to be constant everywhere, even to infinity,
+without infinitely large gravitational fields being produced. We thus
+free ourselves from the distasteful conception that the material
+universe ought to possess something of the nature of a centre. Of
+course we purchase our emancipation from the fundamental difficulties
+mentioned, at the cost of a modification and complication of Newton's
+law which has neither empirical nor theoretical foundation. We can
+imagine innumerable laws which would serve the same purpose, without
+our being able to state a reason why one of them is to be preferred to
+the others ; for any one of these laws would be founded just as little
+on more general theoretical principles as is the law of Newton.
+
+
+  Notes
+
+*) Proof -- According to the theory of Newton, the number of "lines
+of force" which come from infinity and terminate in a mass m is
+proportional to the mass m. If, on the average, the Mass density p[0]
+is constant throughout tithe universe, then a sphere of volume V will
+enclose the average man p[0]V. Thus the number of lines of force
+passing through the surface F of the sphere into its interior is
+proportional to p[0] V. For unit area of the surface of the sphere the
+number of lines of force which enters the sphere is thus proportional
+to p[0] V/F or to p[0]R. Hence the intensity of the field at the
+surface would ultimately become infinite with increasing radius R of
+the sphere, which is impossible.
+
+
+
+THE POSSIBILITY OF A "FINITE" AND YET "UNBOUNDED" UNIVERSE
+
+
+But speculations on the structure of the universe also move in quite
+another direction. The development of non-Euclidean geometry led to
+the recognition of the fact, that we can cast doubt on the
+infiniteness of our space without coming into conflict with the laws
+of thought or with experience (Riemann, Helmholtz). These questions
+have already been treated in detail and with unsurpassable lucidity by
+Helmholtz and Poincaré, whereas I can only touch on them briefly here.
+
+In the first place, we imagine an existence in two dimensional space.
+Flat beings with flat implements, and in particular flat rigid
+measuring-rods, are free to move in a plane. For them nothing exists
+outside of this plane: that which they observe to happen to themselves
+and to their flat " things " is the all-inclusive reality of their
+plane. In particular, the constructions of plane Euclidean geometry
+can be carried out by means of the rods e.g. the lattice construction,
+considered in Section 24. In contrast to ours, the universe of
+these beings is two-dimensional; but, like ours, it extends to
+infinity. In their universe there is room for an infinite number of
+identical squares made up of rods, i.e. its volume (surface) is
+infinite. If these beings say their universe is " plane," there is
+sense in the statement, because they mean that they can perform the
+constructions of plane Euclidean geometry with their rods. In this
+connection the individual rods always represent the same distance,
+independently of their position.
+
+Let us consider now a second two-dimensional existence, but this time
+on a spherical surface instead of on a plane. The flat beings with
+their measuring-rods and other objects fit exactly on this surface and
+they are unable to leave it. Their whole universe of observation
+extends exclusively over the surface of the sphere. Are these beings
+able to regard the geometry of their universe as being plane geometry
+and their rods withal as the realisation of " distance " ? They cannot
+do this. For if they attempt to realise a straight line, they will
+obtain a curve, which we " three-dimensional beings " designate as a
+great circle, i.e. a self-contained line of definite finite length,
+which can be measured up by means of a measuring-rod. Similarly, this
+universe has a finite area that can be compared with the area, of a
+square constructed with rods. The great charm resulting from this
+consideration lies in the recognition of the fact that the universe of
+these beings is finite and yet has no limits.
+
+But the spherical-surface beings do not need to go on a world-tour in
+order to perceive that they are not living in a Euclidean universe.
+They can convince themselves of this on every part of their " world,"
+provided they do not use too small a piece of it. Starting from a
+point, they draw " straight lines " (arcs of circles as judged in
+three dimensional space) of equal length in all directions. They will
+call the line joining the free ends of these lines a " circle." For a
+plane surface, the ratio of the circumference of a circle to its
+diameter, both lengths being measured with the same rod, is, according
+to Euclidean geometry of the plane, equal to a constant value p, which
+is independent of the diameter of the circle. On their spherical
+surface our flat beings would find for this ratio the value
+
+                        eq. 27: file eq27.gif
+
+i.e. a smaller value than p, the difference being the more
+considerable, the greater is the radius of the circle in comparison
+with the radius R of the " world-sphere." By means of this relation
+the spherical beings can determine the radius of their universe ("
+world "), even when only a relatively small part of their worldsphere
+is available for their measurements. But if this part is very small
+indeed, they will no longer be able to demonstrate that they are on a
+spherical " world " and not on a Euclidean plane, for a small part of
+a spherical surface differs only slightly from a piece of a plane of
+the same size.
+
+Thus if the spherical surface beings are living on a planet of which
+the solar system occupies only a negligibly small part of the
+spherical universe, they have no means of determining whether they are
+living in a finite or in an infinite universe, because the " piece of
+universe " to which they have access is in both cases practically
+plane, or Euclidean. It follows directly from this discussion, that
+for our sphere-beings the circumference of a circle first increases
+with the radius until the " circumference of the universe " is
+reached, and that it thenceforward gradually decreases to zero for
+still further increasing values of the radius. During this process the
+area of the circle continues to increase more and more, until finally
+it becomes equal to the total area of the whole " world-sphere."
+
+Perhaps the reader will wonder why we have placed our " beings " on a
+sphere rather than on another closed surface. But this choice has its
+justification in the fact that, of all closed surfaces, the sphere is
+unique in possessing the property that all points on it are
+equivalent. I admit that the ratio of the circumference c of a circle
+to its radius r depends on r, but for a given value of r it is the
+same for all points of the " worldsphere "; in other words, the "
+world-sphere " is a " surface of constant curvature."
+
+To this two-dimensional sphere-universe there is a three-dimensional
+analogy, namely, the three-dimensional spherical space which was
+discovered by Riemann. its points are likewise all equivalent. It
+possesses a finite volume, which is determined by its "radius"
+(2p2R3). Is it possible to imagine a spherical space? To imagine a
+space means nothing else than that we imagine an epitome of our "
+space " experience, i.e. of experience that we can have in the
+movement of " rigid " bodies. In this sense we can imagine a spherical
+space.
+
+Suppose we draw lines or stretch strings in all directions from a
+point, and mark off from each of these the distance r with a
+measuring-rod. All the free end-points of these lengths lie on a
+spherical surface. We can specially measure up the area (F) of this
+surface by means of a square made up of measuring-rods. If the
+universe is Euclidean, then F = 4pR2 ; if it is spherical, then F is
+always less than 4pR2. With increasing values of r, F increases from
+zero up to a maximum value which is determined by the " world-radius,"
+but for still further increasing values of r, the area gradually
+diminishes to zero. At first, the straight lines which radiate from
+the starting point diverge farther and farther from one another, but
+later they approach each other, and finally they run together again at
+a "counter-point" to the starting point. Under such conditions they
+have traversed the whole spherical space. It is easily seen that the
+three-dimensional spherical space is quite analogous to the
+two-dimensional spherical surface. It is finite (i.e. of finite
+volume), and has no bounds.
+
+It may be mentioned that there is yet another kind of curved space: "
+elliptical space." It can be regarded as a curved space in which the
+two " counter-points " are identical (indistinguishable from each
+other). An elliptical universe can thus be considered to some extent
+as a curved universe possessing central symmetry.
+
+It follows from what has been said, that closed spaces without limits
+are conceivable. From amongst these, the spherical space (and the
+elliptical) excels in its simplicity, since all points on it are
+equivalent. As a result of this discussion, a most interesting
+question arises for astronomers and physicists, and that is whether
+the universe in which we live is infinite, or whether it is finite in
+the manner of the spherical universe. Our experience is far from being
+sufficient to enable us to answer this question. But the general
+theory of relativity permits of our answering it with a moduate degree
+of certainty, and in this connection the difficulty mentioned in
+Section 30 finds its solution.
+
+
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+
+
+According to the general theory of relativity, the geometrical
+properties of space are not independent, but they are determined by
+matter. Thus we can draw conclusions about the geometrical structure
+of the universe only if we base our considerations on the state of the
+matter as being something that is known. We know from experience that,
+for a suitably chosen co-ordinate system, the velocities of the stars
+are small as compared with the velocity of transmission of light. We
+can thus as a rough approximation arrive at a conclusion as to the
+nature of the universe as a whole, if we treat the matter as being at
+rest.
+
+We already know from our previous discussion that the behaviour of
+measuring-rods and clocks is influenced by gravitational fields, i.e.
+by the distribution of matter. This in itself is sufficient to exclude
+the possibility of the exact validity of Euclidean geometry in our
+universe. But it is conceivable that our universe differs only
+slightly from a Euclidean one, and this notion seems all the more
+probable, since calculations show that the metrics of surrounding
+space is influenced only to an exceedingly small extent by masses even
+of the magnitude of our sun. We might imagine that, as regards
+geometry, our universe behaves analogously to a surface which is
+irregularly curved in its individual parts, but which nowhere departs
+appreciably from a plane: something like the rippled surface of a
+lake. Such a universe might fittingly be called a quasi-Euclidean
+universe. As regards its space it would be infinite. But calculation
+shows that in a quasi-Euclidean universe the average density of matter
+would necessarily be nil. Thus such a universe could not be inhabited
+by matter everywhere ; it would present to us that unsatisfactory
+picture which we portrayed in Section 30.
+
+If we are to have in the universe an average density of matter which
+differs from zero, however small may be that difference, then the
+universe cannot be quasi-Euclidean. On the contrary, the results of
+calculation indicate that if matter be distributed uniformly, the
+universe would necessarily be spherical (or elliptical). Since in
+reality the detailed distribution of matter is not uniform, the real
+universe will deviate in individual parts from the spherical, i.e. the
+universe will be quasi-spherical. But it will be necessarily finite.
+In fact, the theory supplies us with a simple connection *  between
+the space-expanse of the universe and the average density of matter in
+it.
+
+
+  Notes
+
+*) For the radius R of the universe we obtain the equation
+
+                        eq. 28: file eq28.gif
+
+The use of the C.G.S. system in this equation gives 2/k = 1^.08.10^27;
+p is the average density of the matter and k is a constant connected
+with the Newtonian constant of gravitation.
+
+
+
+APPENDIX I
+
+SIMPLE DERIVATION OF THE LORENTZ TRANSFORMATION
+(SUPPLEMENTARY TO SECTION 11)
+
+
+For the relative orientation of the co-ordinate systems indicated in
+Fig. 2, the x-axes of both systems pernumently coincide. In the
+present case we can divide the problem into parts by considering first
+only events which are localised on the x-axis. Any such event is
+represented with respect to the co-ordinate system K by the abscissa x
+and the time t, and with respect to the system K1 by the abscissa x'
+and the time t'. We require to find x' and t' when x and t are given.
+
+A light-signal, which is proceeding along the positive axis of x, is
+transmitted according to the equation
+
+                                x = ct
+
+or
+
+                 x - ct = 0     .     .     .    (1).
+
+Since the same light-signal has to be transmitted relative to K1 with
+the velocity c, the propagation relative to the system K1 will be
+represented by the analogous formula
+
+                x' - ct' = O     .     .     .    (2)
+
+Those space-time points (events) which satisfy (x) must also satisfy
+(2). Obviously this will be the case when the relation
+
+          (x' - ct') = l (x - ct)     .     .     .    (3).
+
+is fulfilled in general, where l indicates a constant ; for, according
+to (3), the disappearance of (x - ct) involves the disappearance of
+(x' - ct').
+
+If we apply quite similar considerations to light rays which are being
+transmitted along the negative x-axis, we obtain the condition
+
+           (x' + ct') = ľ(x + ct)    .     .     .    (4).
+
+By adding (or subtracting) equations (3) and (4), and introducing for
+convenience the constants a and b in place of the constants l and ľ,
+where
+
+                        eq. 29: file eq29.gif
+
+and
+
+                        eq. 30: file eq30.gif
+
+we obtain the equations
+
+                        eq. 31: file eq31.gif
+
+We should thus have the solution of our problem, if the constants a
+and b were known. These result from the following discussion.
+
+For the origin of K1 we have permanently x' = 0, and hence according
+to the first of the equations (5)
+
+                        eq. 32: file eq32.gif
+
+If we call v the velocity with which the origin of K1 is moving
+relative to K, we then have
+
+                        eq. 33: file eq33.gif
+
+The same value v can be obtained from equations (5), if we calculate
+the velocity of another point of K1 relative to K, or the velocity
+(directed towards the negative x-axis) of a point of K with respect to
+K'. In short, we can designate v as the relative velocity of the two
+systems.
+
+Furthermore, the principle of relativity teaches us that, as judged
+from K, the length of a unit measuring-rod which is at rest with
+reference to K1 must be exactly the same as the length, as judged from
+K', of a unit measuring-rod which is at rest relative to K. In order
+to see how the points of the x-axis appear as viewed from K, we only
+require to take a " snapshot " of K1 from K; this means that we have
+to insert a particular value of t (time of K), e.g. t = 0. For this
+value of t we then obtain from the first of the equations (5)
+
+                               x' = ax
+
+Two points of the x'-axis which are separated by the distance Dx' = I
+when measured in the K1 system are thus separated in our instantaneous
+photograph by the distance
+
+                        eq. 34: file eq34.gif
+
+But if the snapshot be taken from K'(t' = 0), and if we eliminate t
+from the equations (5), taking into account the expression (6), we
+obtain
+
+                        eq. 35: file eq35.gif
+
+From this we conclude that two points on the x-axis separated by the
+distance I (relative to K) will be represented on our snapshot by the
+distance
+
+                        eq. 36: file eq36.gif
+
+But from what has been said, the two snapshots must be identical;
+hence Dx in (7) must be equal to Dx' in (7a), so that we obtain
+
+                        eq. 37: file eq37.gif
+
+The equations (6) and (7b) determine the constants a and b. By
+inserting the values of these constants in (5), we obtain the first
+and the fourth of the equations given in Section 11.
+
+                        eq. 38: file eq38.gif
+
+Thus we have obtained the Lorentz transformation for events on the
+x-axis. It satisfies the condition
+
+         x'2 - c^2t'2 = x2 - c^2t2    .     .     .    (8a).
+
+The extension of this result, to include events which take place
+outside the x-axis, is obtained by retaining equations (8) and
+supplementing them by the relations
+
+                        eq. 39: file eq39.gif
+
+In this way we satisfy the postulate of the constancy of the velocity
+of light in vacuo for rays of light of arbitrary direction, both for
+the system K and for the system K'. This may be shown in the following
+manner.
+
+We suppose a light-signal sent out from the origin of K at the time t
+= 0. It will be propagated according to the equation
+
+                        eq. 40: file eq40.gif
+
+or, if we square this equation, according to the equation
+
+          x2 + y2 + z2 = c^2t2 = 0    .     .     .    (10).
+
+It is required by the law of propagation of light, in conjunction with
+the postulate of relativity, that the transmission of the signal in
+question should take place -- as judged from K1 -- in accordance with
+the corresponding formula
+
+                               r' = ct'
+
+or,
+
+       x'2 + y'2 + z'2 - c^2t'2 = 0    .     .     .    (10a).
+
+In order that equation (10a) may be a consequence of equation (10), we
+must have
+
+   x'2 + y'2 + z'2 - c^2t'2 = s (x2 + y2 + z2 - c^2t2)       (11).
+
+Since equation (8a) must hold for points on the x-axis, we thus have s
+= I. It is easily seen that the Lorentz transformation really
+satisfies equation (11) for s = I; for (11) is a consequence of (8a)
+and (9), and hence also of (8) and (9). We have thus derived the
+Lorentz transformation.
+
+The Lorentz transformation represented by (8) and (9) still requires
+to be generalised. Obviously it is immaterial whether the axes of K1
+be chosen so that they are spatially parallel to those of K. It is
+also not essential that the velocity of translation of K1 with respect
+to K should be in the direction of the x-axis. A simple consideration
+shows that we are able to construct the Lorentz transformation in this
+general sense from two kinds of transformations, viz. from Lorentz
+transformations in the special sense and from purely spatial
+transformations. which corresponds to the replacement of the
+rectangular co-ordinate system by a new system with its axes pointing
+in other directions.
+
+Mathematically, we can characterise the generalised Lorentz
+transformation thus :
+
+It expresses x', y', x', t', in terms of linear homogeneous functions
+of x, y, x, t, of such a kind that the relation
+
+     x'2 + y'2 + z'2 - c^2t'2 = x2 + y2 + z2 - c^2t2       (11a).
+
+is satisficd identically. That is to say: If we substitute their
+expressions in x, y, x, t, in place of x', y', x', t', on the
+left-hand side, then the left-hand side of (11a) agrees with the
+right-hand side.
+
+
+
+APPENDIX II
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE ("WORLD")
+(SUPPLEMENTARY TO SECTION 17)
+
+
+We can characterise the Lorentz transformation still more simply if we
+introduce the imaginary eq. 25 in place of t, as time-variable. If, in
+accordance with this, we insert
+
+                              x[1] = x
+                              x[2] = y
+                              x[3] = z
+                              x[4] = eq. 25
+
+and similarly for the accented system K1, then the condition which is
+identically satisfied by the transformation can be expressed thus :
+
+x[1]'2 + x[2]'2 + x[3]'2 + x[4]'2 = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    (12).
+
+That is, by the afore-mentioned choice of " coordinates," (11a) [see
+the end of Appendix II] is transformed into this equation.
+
+We see from (12) that the imaginary time co-ordinate x[4], enters into
+the condition of transformation in exactly the same way as the space
+co-ordinates x[1], x[2], x[3]. It is due to this fact that, according
+to the theory of relativity, the " time "x[4], enters into natural
+laws in the same form as the space co ordinates x[1], x[2], x[3].
+
+A four-dimensional continuum described by the "co-ordinates" x[1],
+x[2], x[3], x[4], was called "world" by Minkowski, who also termed a
+point-event a " world-point." From a "happening" in three-dimensional
+space, physics becomes, as it were, an " existence " in the
+four-dimensional " world."
+
+This four-dimensional " world " bears a close similarity to the
+three-dimensional " space " of (Euclidean) analytical geometry. If we
+introduce into the latter a new Cartesian co-ordinate system (x'[1],
+x'[2], x'[3]) with the same origin, then x'[1], x'[2], x'[3], are
+linear homogeneous functions of x[1], x[2], x[3] which identically
+satisfy the equation
+
+        x'[1]^2 + x'[2]^2 + x'[3]^2 = x[1]^2 + x[2]^2 + x[3]^2
+
+The analogy with (12) is a complete one. We can regard Minkowski's "
+world " in a formal manner as a four-dimensional Euclidean space (with
+an imaginary time coordinate) ; the Lorentz transformation corresponds
+to a " rotation " of the co-ordinate system in the fourdimensional "
+world."
+
+
+
+APPENDIX III
+
+THE EXPERIMENTAL CONFIRMATION OF THE GENERAL THEORY OF RELATIVITY
+
+
+From a systematic theoretical point of view, we may imagine the
+process of evolution of an empirical science to be a continuous
+process of induction. Theories are evolved and are expressed in short
+compass as statements of a large number of individual observations in
+the form of empirical laws, from which the general laws can be
+ascertained by comparison. Regarded in this way, the development of a
+science bears some resemblance to the compilation of a classified
+catalogue. It is, as it were, a purely empirical enterprise.
+
+But this point of view by no means embraces the whole of the actual
+process ; for it slurs over the important part played by intuition and
+deductive thought in the development of an exact science. As soon as a
+science has emerged from its initial stages, theoretical advances are
+no longer achieved merely by a process of arrangement. Guided by
+empirical data, the investigator rather develops a system of thought
+which, in general, is built up logically from a small number of
+fundamental assumptions, the so-called axioms. We call such a system
+of thought a theory. The theory finds the justification for its
+existence in the fact that it correlates a large number of single
+observations, and it is just here that the " truth " of the theory
+lies.
+
+Corresponding to the same complex of empirical data, there may be
+several theories, which differ from one another to a considerable
+extent. But as regards the deductions from the theories which are
+capable of being tested, the agreement between the theories may be so
+complete that it becomes difficult to find any deductions in which the
+two theories differ from each other. As an example, a case of general
+interest is available in the province of biology, in the Darwinian
+theory of the development of species by selection in the struggle for
+existence, and in the theory of development which is based on the
+hypothesis of the hereditary transmission of acquired characters.
+
+We have another instance of far-reaching agreement between the
+deductions from two theories in Newtonian mechanics on the one hand,
+and the general theory of relativity on the other. This agreement goes
+so far, that up to the preseat we have been able to find only a few
+deductions from the general theory of relativity which are capable of
+investigation, and to which the physics of pre-relativity days does
+not also lead, and this despite the profound difference in the
+fundamental assumptions of the two theories. In what follows, we shall
+again consider these important deductions, and we shall also discuss
+the empirical evidence appertaining to them which has hitherto been
+obtained.
+
+ (a) Motion of the Perihelion of Mercury
+
+According to Newtonian mechanics and Newton's law of gravitation, a
+planet which is revolving round the sun would describe an ellipse
+round the latter, or, more correctly, round the common centre of
+gravity of the sun and the planet. In such a system, the sun, or the
+common centre of gravity, lies in one of the foci of the orbital
+ellipse in such a manner that, in the course of a planet-year, the
+distance sun-planet grows from a minimum to a maximum, and then
+decreases again to a minimum. If instead of Newton's law we insert a
+somewhat different law of attraction into the calculation, we find
+that, according to this new law, the motion would still take place in
+such a manner that the distance sun-planet exhibits periodic
+variations; but in this case the angle described by the line joining
+sun and planet during such a period (from perihelion--closest
+proximity to the sun--to perihelion) would differ from 360^0. The line
+of the orbit would not then be a closed one but in the course of time
+it would fill up an annular part of the orbital plane, viz. between
+the circle of least and the circle of greatest distance of the planet
+from the sun.
+
+According also to the general theory of relativity, which differs of
+course from the theory of Newton, a small variation from the
+Newton-Kepler motion of a planet in its orbit should take place, and
+in such away, that the angle described by the radius sun-planet
+between one perhelion and the next should exceed that corresponding to
+one complete revolution by an amount given by
+
+                        eq. 41: file eq41.gif
+
+(N.B. -- One complete revolution corresponds to the angle 2p in the
+absolute angular measure customary in physics, and the above
+expression giver the amount by which the radius sun-planet exceeds
+this angle during the interval between one perihelion and the next.)
+In this expression a represents the major semi-axis of the ellipse, e
+its eccentricity, c the velocity of light, and T the period of
+revolution of the planet. Our result may also be stated as follows :
+According to the general theory of relativity, the major axis of the
+ellipse rotates round the sun in the same sense as the orbital motion
+of the planet. Theory requires that this rotation should amount to 43
+seconds of arc per century for the planet Mercury, but for the other
+Planets of our solar system its magnitude should be so small that it
+would necessarily escape detection. *
+
+In point of fact, astronomers have found that the theory of Newton
+does not suffice to calculate the observed motion of Mercury with an
+exactness corresponding to that of the delicacy of observation
+attainable at the present time. After taking account of all the
+disturbing influences exerted on Mercury by the remaining planets, it
+was found (Leverrier: 1859; and Newcomb: 1895) that an unexplained
+perihelial movement of the orbit of Mercury remained over, the amount
+of which does not differ sensibly from the above mentioned +43 seconds
+of arc per century. The uncertainty of the empirical result amounts to
+a few seconds only.
+
+ (b) Deflection of Light by a Gravitational Field
+
+In Section 22 it has been already mentioned that according to the
+general theory of relativity, a ray of light will experience a
+curvature of its path when passing through a gravitational field, this
+curvature being similar to that experienced by the path of a body
+which is projected through a gravitational field. As a result of this
+theory, we should expect that a ray of light which is passing close to
+a heavenly body would be deviated towards the latter. For a ray of
+light which passes the sun at a distance of D sun-radii from its
+centre, the angle of deflection (a) should amount to
+
+                        eq. 42: file eq42.gif
+
+It may be added that, according to the theory, half of Figure 05 this
+deflection is produced by the Newtonian field of attraction of the
+sun, and the other half by the geometrical modification (" curvature
+") of space caused by the sun.
+
+This result admits of an experimental test by means of the
+photographic registration of stars during a total eclipse of the sun.
+The only reason why we must wait for a total eclipse is because at
+every other time the atmosphere is so strongly illuminated by the
+light from the sun that the stars situated near the sun's disc are
+invisible. The predicted effect can be seen clearly from the
+accompanying diagram. If the sun (S) were not present, a star which is
+practically infinitely distant would be seen in the direction D[1], as
+observed front the earth. But as a consequence of the deflection of
+light from the star by the sun, the star will be seen in the direction
+D[2], i.e. at a somewhat greater distance from the centre of the sun
+than corresponds to its real position.
+
+In practice, the question is tested in the following way. The stars in
+the neighbourhood of the sun are photographed during a solar eclipse.
+In addition, a second photograph of the same stars is taken when the
+sun is situated at another position in the sky, i.e. a few months
+earlier or later. As compared whh the standard photograph, the
+positions of the stars on the eclipse-photograph ought to appear
+displaced radially outwards (away from the centre of the sun) by an
+amount corresponding to the angle a.
+
+We are indebted to the [British] Royal Society and to the Royal
+Astronomical Society for the investigation of this important
+deduction. Undaunted by the [first world] war and by difficulties of
+both a material and a psychological nature aroused by the war, these
+societies equipped two expeditions -- to Sobral (Brazil), and to the
+island of Principe (West Africa) -- and sent several of Britain's most
+celebrated astronomers (Eddington, Cottingham, Crommelin, Davidson),
+in order to obtain photographs of the solar eclipse of 29th May, 1919.
+The relative discrepancies to be expected between the stellar
+photographs obtained during the eclipse and the comparison photographs
+amounted to a few hundredths of a millimetre only. Thus great accuracy
+was necessary in making the adjustments required for the taking of the
+photographs, and in their subsequent measurement.
+
+The results of the measurements confirmed the theory in a thoroughly
+satisfactory manner. The rectangular components of the observed and of
+the calculated deviations of the stars (in seconds of arc) are set
+forth in the following table of results :
+
+                      Table 01: file table01.gif
+
+ (c) Displacement of Spectral Lines Towards the Red
+
+In Section 23 it has been shown that in a system K1 which is in
+rotation with regard to a Galileian system K, clocks of identical
+construction, and which are considered at rest with respect to the
+rotating reference-body, go at rates which are dependent on the
+positions of the clocks. We shall now examine this dependence
+quantitatively. A clock, which is situated at a distance r from the
+centre of the disc, has a velocity relative to K which is given by
+
+                                V = wr
+
+where w represents the angular velocity of rotation of the disc K1
+with respect to K. If v[0], represents the number of ticks of the
+clock per unit time (" rate " of the clock) relative to K when the
+clock is at rest, then the " rate " of the clock (v) when it is moving
+relative to K with a velocity V, but at rest with respect to the disc,
+will, in accordance with Section 12, be given by
+
+                        eq. 43: file eq43.gif
+
+or with sufficient accuracy by
+
+                        eq. 44: file eq44.gif
+
+This expression may also be stated in the following form:
+
+                        eq. 45: file eq45.gif
+
+If we represent the difference of potential of the centrifugal force
+between the position of the clock and the centre of the disc by f,
+i.e. the work, considered negatively, which must be performed on the
+unit of mass against the centrifugal force in order to transport it
+from the position of the clock on the rotating disc to the centre of
+the disc, then we have
+
+                        eq. 46: file eq46.gif
+
+From this it follows that
+
+                        eq. 47: file eq47.gif
+
+In the first place, we see from this expression that two clocks of
+identical construction will go at different rates when situated at
+different distances from the centre of the disc. This result is aiso
+valid from the standpoint of an observer who is rotating with the
+disc.
+
+Now, as judged from the disc, the latter is in a gravititional field
+of potential f, hence the result we have obtained will hold quite
+generally for gravitational fields. Furthermore, we can regard an atom
+which is emitting spectral lines as a clock, so that the following
+statement will hold:
+
+An atom absorbs or emits light of a frequency which is dependent on
+the potential of the gravitational field in which it is situated.
+
+The frequency of an atom situated on the surface of a heavenly body
+will be somewhat less than the frequency of an atom of the same
+element which is situated in free space (or on the surface of a
+smaller celestial body).
+
+Now f = - K (M/r), where K is Newton's constant of gravitation, and M
+is the mass of the heavenly body. Thus a displacement towards the red
+ought to take place for spectral lines produced at the surface of
+stars as compared with the spectral lines of the same element produced
+at the surface of the earth, the amount of this displacement being
+
+                        eq. 48: file eq48.gif
+
+For the sun, the displacement towards the red predicted by theory
+amounts to about two millionths of the wave-length. A trustworthy
+calculation is not possible in the case of the stars, because in
+general neither the mass M nor the radius r are known.
+
+It is an open question whether or not this effect exists, and at the
+present time (1920) astronomers are working with great zeal towards
+the solution. Owing to the smallness of the effect in the case of the
+sun, it is difficult to form an opinion as to its existence. Whereas
+Grebe and Bachem (Bonn), as a result of their own measurements and
+those of Evershed and Schwarzschild on the cyanogen bands, have placed
+the existence of the effect almost beyond doubt, while other
+investigators, particularly St. John, have been led to the opposite
+opinion in consequence of their measurements.
+
+Mean displacements of lines towards the less refrangible end of the
+spectrum are certainly revealed by statistical investigations of the
+fixed stars ; but up to the present the examination of the available
+data does not allow of any definite decision being arrived at, as to
+whether or not these displacements are to be referred in reality to
+the effect of gravitation. The results of observation have been
+collected together, and discussed in detail from the standpoint of the
+question which has been engaging our attention here, in a paper by E.
+Freundlich entitled "Zur Prüfung der allgemeinen
+Relativit&umlaut;ts-Theorie" (Die Naturwissenschaften, 1919, No. 35,
+p. 520: Julius Springer, Berlin).
+
+At all events, a definite decision will be reached during the next few
+years. If the displacement of spectral lines towards the red by the
+gravitational potential does not exist, then the general theory of
+relativity will be untenable. On the other hand, if the cause of the
+displacement of spectral lines be definitely traced to the
+gravitational potential, then the study of this displacement will
+furnish us with important information as to the mass of the heavenly
+bodies. [5][A]
+
+
+  Notes
+
+*) Especially since the next planet Venus has an orbit that is
+almost an exact circle, which makes it more difficult to locate the
+perihelion with precision.
+
+The displacentent of spectral lines towards the red end of the
+spectrum was definitely established by Adams in 1924, by observations
+on the dense companion of Sirius, for which the effect is about thirty
+times greater than for the Sun. R.W.L. -- translator
+
+
+
+APPENDIX IV
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+(SUPPLEMENTARY TO SECTION 32)
+
+
+Since the publication of the first edition of this little book, our
+knowledge about the structure of space in the large (" cosmological
+problem ") has had an important development, which ought to be
+mentioned even in a popular presentation of the subject.
+
+My original considerations on the subject were based on two
+hypotheses:
+
+(1) There exists an average density of matter in the whole of space
+which is everywhere the same and different from zero.
+
+(2) The magnitude (" radius ") of space is independent of time.
+
+Both these hypotheses proved to be consistent, according to the
+general theory of relativity, but only after a hypothetical term was
+added to the field equations, a term which was not required by the
+theory as such nor did it seem natural from a theoretical point of
+view (" cosmological term of the field equations ").
+
+Hypothesis (2) appeared unavoidable to me at the time, since I thought
+that one would get into bottomless speculations if one departed from
+it.
+
+However, already in the 'twenties, the Russian mathematician Friedman
+showed that a different hypothesis was natural from a purely
+theoretical point of view. He realized that it was possible to
+preserve hypothesis (1) without introducing the less natural
+cosmological term into the field equations of gravitation, if one was
+ready to drop hypothesis (2). Namely, the original field equations
+admit a solution in which the " world radius " depends on time
+(expanding space). In that sense one can say, according to Friedman,
+that the theory demands an expansion of space.
+
+A few years later Hubble showed, by a special investigation of the
+extra-galactic nebulae (" milky ways "), that the spectral lines
+emitted showed a red shift which increased regularly with the distance
+of the nebulae. This can be interpreted in regard to our present
+knowledge only in the sense of Doppler's principle, as an expansive
+motion of the system of stars in the large -- as required, according
+to Friedman, by the field equations of gravitation. Hubble's discovery
+can, therefore, be considered to some extent as a confirmation of the
+theory.
+
+There does arise, however, a strange difficulty. The interpretation of
+the galactic line-shift discovered by Hubble as an expansion (which
+can hardly be doubted from a theoretical point of view), leads to an
+origin of this expansion which lies " only " about 10^9 years ago,
+while physical astronomy makes it appear likely that the development
+of individual stars and systems of stars takes considerably longer. It
+is in no way known how this incongruity is to be overcome.
+
+I further want to rernark that the theory of expanding space, together
+with the empirical data of astronomy, permit no decision to be reached
+about the finite or infinite character of (three-dimensional) space,
+while the original " static " hypothesis of space yielded the closure
+(finiteness) of space.
+
+
+K = co-ordinate system
+x, y = two-dimensional co-ordinates
+x, y, z = three-dimensional co-ordinates
+x, y, z, t = four-dimensional co-ordinates
+
+t = time
+I = distance
+v = velocity
+
+F = force
+G = gravitational field
+
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+This file should be named 5001.zip and contains numerous
+image files for equations.
+
+Project Gutenberg eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the US
+unless a copyright notice is included.  Thus, we usually do not
+keep eBooks in compliance with any particular paper edition.
+
+We are now trying to release all our eBooks one year in advance
+of the official release dates, leaving time for better editing.
+Please be encouraged to tell us about any error or corrections,
+even years after the official publication date.
+
+Please note neither this listing nor its contents are final til
+midnight of the last day of the month of any such announcement.
+The official release date of all Project Gutenberg eBooks is at
+Midnight, Central Time, of the last day of the stated month.  A
+preliminary version may often be posted for suggestion, comment
+and editing by those who wish to do so.
+
+Most people start at our Web sites at:
+http://gutenberg.net or
+http://promo.net/pg
+
+These Web sites include award-winning information about Project
+Gutenberg, including how to donate, how to help produce our new
+eBooks, and how to subscribe to our email newsletter (free!).
+
+
+Those of you who want to download any eBook before announcement
+can get to them as follows, and just download by date.  This is
+also a good way to get them instantly upon announcement, as the
+indexes our cataloguers produce obviously take a while after an
+announcement goes out in the Project Gutenberg Newsletter.
+
+http://www.ibiblio.org/gutenberg/etext03 or
+ftp://ftp.ibiblio.org/pub/docs/books/gutenberg/etext03
+
+Or /etext02, 01, 00, 99, 98, 97, 96, 95, 94, 93, 92, 92, 91 or 90
+
+Just search by the first five letters of the filename you want,
+as it appears in our Newsletters.
+
+
+Information about Project Gutenberg (one page)
+
+We produce about two million dollars for each hour we work.  The
+time it takes us, a rather conservative estimate, is fifty hours
+to get any eBook selected, entered, proofread, edited, copyright
+searched and analyzed, the copyright letters written, etc.   Our
+projected audience is one hundred million readers.  If the value
+per text is nominally estimated at one dollar then we produce $2
+million dollars per hour in 2002 as we release over 100 new text
+files per month:  1240 more eBooks in 2001 for a total of 4000+
+We are already on our way to trying for 2000 more eBooks in 2002
+If they reach just 1-2% of the world's population then the total
+will reach over half a trillion eBooks given away by year's end.
+
+The Goal of Project Gutenberg is to Give Away 1 Trillion eBooks!
+This is ten thousand titles each to one hundred million readers,
+which is only about 4% of the present number of computer users.
+
+Here is the briefest record of our progress (* means estimated):
+
+eBooks Year Month
+
+    1  1971 July
+   10  1991 January
+  100  1994 January
+ 1000  1997 August
+ 1500  1998 October
+ 2000  1999 December
+ 2500  2000 December
+ 3000  2001 November
+ 4000  2001 October/November
+ 6000  2002 December*
+ 9000  2003 November*
+10000  2004 January*
+
+
+The Project Gutenberg Literary Archive Foundation has been created
+to secure a future for Project Gutenberg into the next millennium.
+
+We need your donations more than ever!
+
+As of February, 2002, contributions are being solicited from people
+and organizations in: Alabama, Alaska, Arkansas, Connecticut,
+Delaware, District of Columbia, Florida, Georgia, Hawaii, Illinois,
+Indiana, Iowa, Kansas, Kentucky, Louisiana, Maine, Massachusetts,
+Michigan, Mississippi, Missouri, Montana, Nebraska, Nevada, New
+Hampshire, New Jersey, New Mexico, New York, North Carolina, Ohio,
+Oklahoma, Oregon, Pennsylvania, Rhode Island, South Carolina, South
+Dakota, Tennessee, Texas, Utah, Vermont, Virginia, Washington, West
+Virginia, Wisconsin, and Wyoming.
+
+We have filed in all 50 states now, but these are the only ones
+that have responded.
+
+As the requirements for other states are met, additions to this list
+will be made and fund raising will begin in the additional states.
+Please feel free to ask to check the status of your state.
+
+In answer to various questions we have received on this:
+
+We are constantly working on finishing the paperwork to legally
+request donations in all 50 states.  If your state is not listed and
+you would like to know if we have added it since the list you have,
+just ask.
+
+While we cannot solicit donations from people in states where we are
+not yet registered, we know of no prohibition against accepting
+donations from donors in these states who approach us with an offer to
+donate.
+
+International donations are accepted, but we don't know ANYTHING about
+how to make them tax-deductible, or even if they CAN be made
+deductible, and don't have the staff to handle it even if there are
+ways.
+
+Donations by check or money order may be sent to:
+
+Project Gutenberg Literary Archive Foundation
+PMB 113
+1739 University Ave.
+Oxford, MS 38655-4109
+
+Contact us if you want to arrange for a wire transfer or payment
+method other than by check or money order.
+
+The Project Gutenberg Literary Archive Foundation has been approved by
+the US Internal Revenue Service as a 501(c)(3) organization with EIN
+[Employee Identification Number] 64-622154.  Donations are
+tax-deductible to the maximum extent permitted by law.  As fund-raising
+requirements for other states are met, additions to this list will be
+made and fund-raising will begin in the additional states.
+
+We need your donations more than ever!
+
+You can get up to date donation information online at:
+
+http://www.gutenberg.net/donation.html
+
+
+***
+
+If you can't reach Project Gutenberg,
+you can always email directly to:
+
+Michael S. Hart <hart@pobox.com>
+
+Prof. Hart will answer or forward your message.
+
+We would prefer to send you information by email.
+
+
+**The Legal Small Print**
+
+
+(Three Pages)
+
+***START**THE SMALL PRINT!**FOR PUBLIC DOMAIN EBOOKS**START***
+Why is this "Small Print!" statement here? You know: lawyers.
+They tell us you might sue us if there is something wrong with
+your copy of this eBook, even if you got it for free from
+someone other than us, and even if what's wrong is not our
+fault. So, among other things, this "Small Print!" statement
+disclaims most of our liability to you. It also tells you how
+you may distribute copies of this eBook if you want to.
+
+*BEFORE!* YOU USE OR READ THIS EBOOK
+By using or reading any part of this PROJECT GUTENBERG-tm
+eBook, you indicate that you understand, agree to and accept
+this "Small Print!" statement. If you do not, you can receive
+a refund of the money (if any) you paid for this eBook by
+sending a request within 30 days of receiving it to the person
+you got it from. If you received this eBook on a physical
+medium (such as a disk), you must return it with your request.
+
+ABOUT PROJECT GUTENBERG-TM EBOOKS
+This PROJECT GUTENBERG-tm eBook, like most PROJECT GUTENBERG-tm eBooks,
+is a "public domain" work distributed by Professor Michael S. Hart
+through the Project Gutenberg Association (the "Project").
+Among other things, this means that no one owns a United States copyright
+on or for this work, so the Project (and you!) can copy and
+distribute it in the United States without permission and
+without paying copyright royalties. Special rules, set forth
+below, apply if you wish to copy and distribute this eBook
+under the "PROJECT GUTENBERG" trademark.
+
+Please do not use the "PROJECT GUTENBERG" trademark to market
+any commercial products without permission.
+
+To create these eBooks, the Project expends considerable
+efforts to identify, transcribe and proofread public domain
+works. Despite these efforts, the Project's eBooks and any
+medium they may be on may contain "Defects". Among other
+things, Defects may take the form of incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged
+disk or other eBook medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+LIMITED WARRANTY; DISCLAIMER OF DAMAGES
+But for the "Right of Replacement or Refund" described below,
+[1] Michael Hart and the Foundation (and any other party you may
+receive this eBook from as a PROJECT GUTENBERG-tm eBook) disclaims
+all liability to you for damages, costs and expenses, including
+legal fees, and [2] YOU HAVE NO REMEDIES FOR NEGLIGENCE OR
+UNDER STRICT LIABILITY, OR FOR BREACH OF WARRANTY OR CONTRACT,
+INCLUDING BUT NOT LIMITED TO INDIRECT, CONSEQUENTIAL, PUNITIVE
+OR INCIDENTAL DAMAGES, EVEN IF YOU GIVE NOTICE OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+If you discover a Defect in this eBook within 90 days of
+receiving it, you can receive a refund of the money (if any)
+you paid for it by sending an explanatory note within that
+time to the person you received it from. If you received it
+on a physical medium, you must return it with your note, and
+such person may choose to alternatively give you a replacement
+copy. If you received it electronically, such person may
+choose to alternatively give you a second opportunity to
+receive it electronically.
+
+THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS". NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, ARE MADE TO YOU AS
+TO THE EBOOK OR ANY MEDIUM IT MAY BE ON, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+Some states do not allow disclaimers of implied warranties or
+the exclusion or limitation of consequential damages, so the
+above disclaimers and exclusions may not apply to you, and you
+may have other legal rights.
+
+INDEMNITY
+You will indemnify and hold Michael Hart, the Foundation,
+and its trustees and agents, and any volunteers associated
+with the production and distribution of Project Gutenberg-tm
+texts harmless, from all liability, cost and expense, including
+legal fees, that arise directly or indirectly from any of the
+following that you do or cause:  [1] distribution of this eBook,
+[2] alteration, modification, or addition to the eBook,
+or [3] any Defect.
+
+DISTRIBUTION UNDER "PROJECT GUTENBERG-tm"
+You may distribute copies of this eBook electronically, or by
+disk, book or any other medium if you either delete this
+"Small Print!" and all other references to Project Gutenberg,
+or:
+
+[1]  Only give exact copies of it.  Among other things, this
+     requires that you do not remove, alter or modify the
+     eBook or this "small print!" statement.  You may however,
+     if you wish, distribute this eBook in machine readable
+     binary, compressed, mark-up, or proprietary form,
+     including any form resulting from conversion by word
+     processing or hypertext software, but only so long as
+     *EITHER*:
+
+     [*]  The eBook, when displayed, is clearly readable, and
+          does *not* contain characters other than those
+          intended by the author of the work, although tilde
+          (~), asterisk (*) and underline (_) characters may
+          be used to convey punctuation intended by the
+          author, and additional characters may be used to
+          indicate hypertext links; OR
+
+     [*]  The eBook may be readily converted by the reader at
+          no expense into plain ASCII, EBCDIC or equivalent
+          form by the program that displays the eBook (as is
+          the case, for instance, with most word processors);
+          OR
+
+     [*]  You provide, or agree to also provide on request at
+          no additional cost, fee or expense, a copy of the
+          eBook in its original plain ASCII form (or in EBCDIC
+          or other equivalent proprietary form).
+
+[2]  Honor the eBook refund and replacement provisions of this
+     "Small Print!" statement.
+
+[3]  Pay a trademark license fee to the Foundation of 20% of the
+     gross profits you derive calculated using the method you
+     already use to calculate your applicable taxes.  If you
+     don't derive profits, no royalty is due.  Royalties are
+     payable to "Project Gutenberg Literary Archive Foundation"
+     the 60 days following each date you prepare (or were
+     legally required to prepare) your annual (or equivalent
+     periodic) tax return.  Please contact us beforehand to
+     let us know your plans and to work out the details.
+
+WHAT IF YOU *WANT* TO SEND MONEY EVEN IF YOU DON'T HAVE TO?
+Project Gutenberg is dedicated to increasing the number of
+public domain and licensed works that can be freely distributed
+in machine readable form.
+
+The Project gratefully accepts contributions of money, time,
+public domain materials, or royalty free copyright licenses.
+Money should be paid to the:
+"Project Gutenberg Literary Archive Foundation."
+
+If you are interested in contributing scanning equipment or
+software or other items, please contact Michael Hart at:
+hart@pobox.com
+
+[Portions of this eBook's header and trailer may be reprinted only
+when distributed free of all fees.  Copyright (C) 2001, 2002 by
+Michael S. Hart.  Project Gutenberg is a TradeMark and may not be
+used in any sales of Project Gutenberg eBooks or other materials be
+they hardware or software or any other related product without
+express permission.]
+
+*END THE SMALL PRINT! FOR PUBLIC DOMAIN EBOOKS*Ver.02/11/02*END*

--- a/jet/source-sink-builder/src/main/resources/books/through-the-looking-glass.txt
+++ b/jet/source-sink-builder/src/main/resources/books/through-the-looking-glass.txt
@@ -1,0 +1,4306 @@
+﻿The Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson                         AKA Lewis Carroll
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Through the Looking-Glass
+
+Author: Charles Dodgson, AKA Lewis Carroll
+
+Posting Date: June 25, 2008 [EBook #12]
+Release Date: February, 1991
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+
+
+
+
+
+
+
+
+
+THROUGH THE LOOKING-GLASS
+
+By Lewis Carroll
+
+
+The Millennium Fulcrum Edition 1.7
+
+
+
+
+CHAPTER I. Looking-Glass house
+
+One thing was certain, that the WHITE kitten had had nothing to do with
+it:--it was the black kitten’s fault entirely. For the white kitten had
+been having its face washed by the old cat for the last quarter of
+an hour (and bearing it pretty well, considering); so you see that it
+COULDN’T have had any hand in the mischief.
+
+The way Dinah washed her children’s faces was this: first she held the
+poor thing down by its ear with one paw, and then with the other paw she
+rubbed its face all over, the wrong way, beginning at the nose: and
+just now, as I said, she was hard at work on the white kitten, which was
+lying quite still and trying to purr--no doubt feeling that it was all
+meant for its good.
+
+But the black kitten had been finished with earlier in the afternoon,
+and so, while Alice was sitting curled up in a corner of the great
+arm-chair, half talking to herself and half asleep, the kitten had been
+having a grand game of romps with the ball of worsted Alice had been
+trying to wind up, and had been rolling it up and down till it had all
+come undone again; and there it was, spread over the hearth-rug, all
+knots and tangles, with the kitten running after its own tail in the
+middle.
+
+‘Oh, you wicked little thing!’ cried Alice, catching up the kitten, and
+giving it a little kiss to make it understand that it was in disgrace.
+‘Really, Dinah ought to have taught you better manners! You OUGHT,
+Dinah, you know you ought!’ she added, looking reproachfully at the old
+cat, and speaking in as cross a voice as she could manage--and then she
+scrambled back into the arm-chair, taking the kitten and the worsted
+with her, and began winding up the ball again. But she didn’t get on
+very fast, as she was talking all the time, sometimes to the kitten, and
+sometimes to herself. Kitty sat very demurely on her knee, pretending to
+watch the progress of the winding, and now and then putting out one
+paw and gently touching the ball, as if it would be glad to help, if it
+might.
+
+‘Do you know what to-morrow is, Kitty?’ Alice began. ‘You’d have guessed
+if you’d been up in the window with me--only Dinah was making you tidy,
+so you couldn’t. I was watching the boys getting in sticks for the
+bonfire--and it wants plenty of sticks, Kitty! Only it got so cold, and
+it snowed so, they had to leave off. Never mind, Kitty, we’ll go and
+see the bonfire to-morrow.’ Here Alice wound two or three turns of the
+worsted round the kitten’s neck, just to see how it would look: this led
+to a scramble, in which the ball rolled down upon the floor, and yards
+and yards of it got unwound again.
+
+‘Do you know, I was so angry, Kitty,’ Alice went on as soon as they were
+comfortably settled again, ‘when I saw all the mischief you had been
+doing, I was very nearly opening the window, and putting you out into
+the snow! And you’d have deserved it, you little mischievous darling!
+What have you got to say for yourself? Now don’t interrupt me!’ she
+went on, holding up one finger. ‘I’m going to tell you all your faults.
+Number one: you squeaked twice while Dinah was washing your face this
+morning. Now you can’t deny it, Kitty: I heard you! What’s that you
+say?’ (pretending that the kitten was speaking.) ‘Her paw went into your
+eye? Well, that’s YOUR fault, for keeping your eyes open--if you’d
+shut them tight up, it wouldn’t have happened. Now don’t make any more
+excuses, but listen! Number two: you pulled Snowdrop away by the tail
+just as I had put down the saucer of milk before her! What, you were
+thirsty, were you? How do you know she wasn’t thirsty too? Now for
+number three: you unwound every bit of the worsted while I wasn’t
+looking!
+
+‘That’s three faults, Kitty, and you’ve not been punished for any of
+them yet. You know I’m saving up all your punishments for Wednesday
+week--Suppose they had saved up all MY punishments!’ she went on,
+talking more to herself than the kitten. ‘What WOULD they do at the end
+of a year? I should be sent to prison, I suppose, when the day came.
+Or--let me see--suppose each punishment was to be going without a
+dinner: then, when the miserable day came, I should have to go without
+fifty dinners at once! Well, I shouldn’t mind THAT much! I’d far rather
+go without them than eat them!
+
+‘Do you hear the snow against the window-panes, Kitty? How nice and soft
+it sounds! Just as if some one was kissing the window all over outside.
+I wonder if the snow LOVES the trees and fields, that it kisses them so
+gently? And then it covers them up snug, you know, with a white quilt;
+and perhaps it says, “Go to sleep, darlings, till the summer comes
+again.” And when they wake up in the summer, Kitty, they dress
+themselves all in green, and dance about--whenever the wind blows--oh,
+that’s very pretty!’ cried Alice, dropping the ball of worsted to clap
+her hands. ‘And I do so WISH it was true! I’m sure the woods look sleepy
+in the autumn, when the leaves are getting brown.
+
+‘Kitty, can you play chess? Now, don’t smile, my dear, I’m asking it
+seriously. Because, when we were playing just now, you watched just as
+if you understood it: and when I said “Check!” you purred! Well, it WAS
+a nice check, Kitty, and really I might have won, if it hadn’t been for
+that nasty Knight, that came wiggling down among my pieces. Kitty, dear,
+let’s pretend--’ And here I wish I could tell you half the things Alice
+used to say, beginning with her favourite phrase ‘Let’s pretend.’ She
+had had quite a long argument with her sister only the day before--all
+because Alice had begun with ‘Let’s pretend we’re kings and queens;’ and
+her sister, who liked being very exact, had argued that they couldn’t,
+because there were only two of them, and Alice had been reduced at last
+to say, ‘Well, YOU can be one of them then, and I’LL be all the rest.’
+And once she had really frightened her old nurse by shouting suddenly in
+her ear, ‘Nurse! Do let’s pretend that I’m a hungry hyaena, and you’re a
+bone.’
+
+But this is taking us away from Alice’s speech to the kitten. ‘Let’s
+pretend that you’re the Red Queen, Kitty! Do you know, I think if you
+sat up and folded your arms, you’d look exactly like her. Now do try,
+there’s a dear!’ And Alice got the Red Queen off the table, and set it
+up before the kitten as a model for it to imitate: however, the thing
+didn’t succeed, principally, Alice said, because the kitten wouldn’t
+fold its arms properly. So, to punish it, she held it up to the
+Looking-glass, that it might see how sulky it was--‘and if you’re not
+good directly,’ she added, ‘I’ll put you through into Looking-glass
+House. How would you like THAT?’
+
+‘Now, if you’ll only attend, Kitty, and not talk so much, I’ll tell you
+all my ideas about Looking-glass House. First, there’s the room you can
+see through the glass--that’s just the same as our drawing room, only
+the things go the other way. I can see all of it when I get upon a
+chair--all but the bit behind the fireplace. Oh! I do so wish I could
+see THAT bit! I want so much to know whether they’ve a fire in the
+winter: you never CAN tell, you know, unless our fire smokes, and then
+smoke comes up in that room too--but that may be only pretence, just to
+make it look as if they had a fire. Well then, the books are something
+like our books, only the words go the wrong way; I know that, because
+I’ve held up one of our books to the glass, and then they hold up one in
+the other room.
+
+‘How would you like to live in Looking-glass House, Kitty? I wonder if
+they’d give you milk in there? Perhaps Looking-glass milk isn’t good
+to drink--But oh, Kitty! now we come to the passage. You can just see a
+little PEEP of the passage in Looking-glass House, if you leave the door
+of our drawing-room wide open: and it’s very like our passage as far
+as you can see, only you know it may be quite different on beyond.
+Oh, Kitty! how nice it would be if we could only get through into
+Looking-glass House! I’m sure it’s got, oh! such beautiful things in it!
+Let’s pretend there’s a way of getting through into it, somehow, Kitty.
+Let’s pretend the glass has got all soft like gauze, so that we can get
+through. Why, it’s turning into a sort of mist now, I declare! It’ll be
+easy enough to get through--’ She was up on the chimney-piece while she
+said this, though she hardly knew how she had got there. And certainly
+the glass WAS beginning to melt away, just like a bright silvery mist.
+
+In another moment Alice was through the glass, and had jumped lightly
+down into the Looking-glass room. The very first thing she did was
+to look whether there was a fire in the fireplace, and she was quite
+pleased to find that there was a real one, blazing away as brightly as
+the one she had left behind. ‘So I shall be as warm here as I was in the
+old room,’ thought Alice: ‘warmer, in fact, because there’ll be no one
+here to scold me away from the fire. Oh, what fun it’ll be, when they
+see me through the glass in here, and can’t get at me!’
+
+Then she began looking about, and noticed that what could be seen from
+the old room was quite common and uninteresting, but that all the rest
+was as different as possible. For instance, the pictures on the
+wall next the fire seemed to be all alive, and the very clock on
+the chimney-piece (you know you can only see the back of it in the
+Looking-glass) had got the face of a little old man, and grinned at her.
+
+‘They don’t keep this room so tidy as the other,’ Alice thought to
+herself, as she noticed several of the chessmen down in the hearth among
+the cinders: but in another moment, with a little ‘Oh!’ of surprise, she
+was down on her hands and knees watching them. The chessmen were walking
+about, two and two!
+
+‘Here are the Red King and the Red Queen,’ Alice said (in a whisper, for
+fear of frightening them), ‘and there are the White King and the White
+Queen sitting on the edge of the shovel--and here are two castles
+walking arm in arm--I don’t think they can hear me,’ she went on, as she
+put her head closer down, ‘and I’m nearly sure they can’t see me. I feel
+somehow as if I were invisible--’
+
+Here something began squeaking on the table behind Alice, and made her
+turn her head just in time to see one of the White Pawns roll over and
+begin kicking: she watched it with great curiosity to see what would
+happen next.
+
+‘It is the voice of my child!’ the White Queen cried out as she rushed
+past the King, so violently that she knocked him over among the cinders.
+‘My precious Lily! My imperial kitten!’ and she began scrambling wildly
+up the side of the fender.
+
+‘Imperial fiddlestick!’ said the King, rubbing his nose, which had been
+hurt by the fall. He had a right to be a LITTLE annoyed with the Queen,
+for he was covered with ashes from head to foot.
+
+Alice was very anxious to be of use, and, as the poor little Lily was
+nearly screaming herself into a fit, she hastily picked up the Queen and
+set her on the table by the side of her noisy little daughter.
+
+The Queen gasped, and sat down: the rapid journey through the air had
+quite taken away her breath and for a minute or two she could do nothing
+but hug the little Lily in silence. As soon as she had recovered her
+breath a little, she called out to the White King, who was sitting
+sulkily among the ashes, ‘Mind the volcano!’
+
+‘What volcano?’ said the King, looking up anxiously into the fire, as if
+he thought that was the most likely place to find one.
+
+‘Blew--me--up,’ panted the Queen, who was still a little out of breath.
+‘Mind you come up--the regular way--don’t get blown up!’
+
+Alice watched the White King as he slowly struggled up from bar to bar,
+till at last she said, ‘Why, you’ll be hours and hours getting to the
+table, at that rate. I’d far better help you, hadn’t I?’ But the King
+took no notice of the question: it was quite clear that he could neither
+hear her nor see her.
+
+So Alice picked him up very gently, and lifted him across more slowly
+than she had lifted the Queen, that she mightn’t take his breath away:
+but, before she put him on the table, she thought she might as well dust
+him a little, he was so covered with ashes.
+
+She said afterwards that she had never seen in all her life such a face
+as the King made, when he found himself held in the air by an invisible
+hand, and being dusted: he was far too much astonished to cry out, but
+his eyes and his mouth went on getting larger and larger, and rounder
+and rounder, till her hand shook so with laughing that she nearly let
+him drop upon the floor.
+
+‘Oh! PLEASE don’t make such faces, my dear!’ she cried out, quite
+forgetting that the King couldn’t hear her. ‘You make me laugh so that
+I can hardly hold you! And don’t keep your mouth so wide open! All the
+ashes will get into it--there, now I think you’re tidy enough!’ she
+added, as she smoothed his hair, and set him upon the table near the
+Queen.
+
+The King immediately fell flat on his back, and lay perfectly still: and
+Alice was a little alarmed at what she had done, and went round the room
+to see if she could find any water to throw over him. However, she could
+find nothing but a bottle of ink, and when she got back with it she
+found he had recovered, and he and the Queen were talking together in a
+frightened whisper--so low, that Alice could hardly hear what they said.
+
+The King was saying, ‘I assure, you my dear, I turned cold to the very
+ends of my whiskers!’
+
+To which the Queen replied, ‘You haven’t got any whiskers.’
+
+‘The horror of that moment,’ the King went on, ‘I shall never, NEVER
+forget!’
+
+‘You will, though,’ the Queen said, ‘if you don’t make a memorandum of
+it.’
+
+Alice looked on with great interest as the King took an enormous
+memorandum-book out of his pocket, and began writing. A sudden thought
+struck her, and she took hold of the end of the pencil, which came some
+way over his shoulder, and began writing for him.
+
+The poor King looked puzzled and unhappy, and struggled with the pencil
+for some time without saying anything; but Alice was too strong for him,
+and at last he panted out, ‘My dear! I really MUST get a thinner pencil.
+I can’t manage this one a bit; it writes all manner of things that I
+don’t intend--’
+
+‘What manner of things?’ said the Queen, looking over the book (in which
+Alice had put ‘THE WHITE KNIGHT IS SLIDING DOWN THE POKER. HE BALANCES
+VERY BADLY’) ‘That’s not a memorandum of YOUR feelings!’
+
+There was a book lying near Alice on the table, and while she sat
+watching the White King (for she was still a little anxious about him,
+and had the ink all ready to throw over him, in case he fainted again),
+she turned over the leaves, to find some part that she could read,
+‘--for it’s all in some language I don’t know,’ she said to herself.
+
+It was like this.
+
+
+             YKCOWREBBAJ
+
+     sevot yhtils eht dna,gillirb sawT’
+      ebaw eht ni elbmig dna eryg diD
+        ,sevogorob eht erew ysmim llA
+       .ebargtuo shtar emom eht dnA
+
+
+She puzzled over this for some time, but at last a bright thought struck
+her. ‘Why, it’s a Looking-glass book, of course! And if I hold it up to
+a glass, the words will all go the right way again.’
+
+This was the poem that Alice read.
+
+
+             JABBERWOCKY
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+     ‘Beware the Jabberwock, my son!
+      The jaws that bite, the claws that catch!
+     Beware the Jubjub bird, and shun
+      The frumious Bandersnatch!’
+
+     He took his vorpal sword in hand:
+      Long time the manxome foe he sought--
+     So rested he by the Tumtum tree,
+      And stood awhile in thought.
+
+     And as in uffish thought he stood,
+      The Jabberwock, with eyes of flame,
+     Came whiffling through the tulgey wood,
+      And burbled as it came!
+
+     One, two! One, two! And through and through
+      The vorpal blade went snicker-snack!
+     He left it dead, and with its head
+      He went galumphing back.
+
+     ‘And hast thou slain the Jabberwock?
+      Come to my arms, my beamish boy!
+     O frabjous day! Callooh! Callay!’
+      He chortled in his joy.
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+
+‘It seems very pretty,’ she said when she had finished it, ‘but it’s
+RATHER hard to understand!’ (You see she didn’t like to confess, even
+to herself, that she couldn’t make it out at all.) ‘Somehow it seems
+to fill my head with ideas--only I don’t exactly know what they are!
+However, SOMEBODY killed SOMETHING: that’s clear, at any rate--’
+
+‘But oh!’ thought Alice, suddenly jumping up, ‘if I don’t make haste I
+shall have to go back through the Looking-glass, before I’ve seen what
+the rest of the house is like! Let’s have a look at the garden first!’
+She was out of the room in a moment, and ran down stairs--or, at least,
+it wasn’t exactly running, but a new invention of hers for getting down
+stairs quickly and easily, as Alice said to herself. She just kept the
+tips of her fingers on the hand-rail, and floated gently down without
+even touching the stairs with her feet; then she floated on through the
+hall, and would have gone straight out at the door in the same way, if
+she hadn’t caught hold of the door-post. She was getting a little giddy
+with so much floating in the air, and was rather glad to find herself
+walking again in the natural way.
+
+
+
+
+CHAPTER II. The Garden of Live Flowers
+
+‘I should see the garden far better,’ said Alice to herself, ‘if I could
+get to the top of that hill: and here’s a path that leads straight to
+it--at least, no, it doesn’t do that--’ (after going a few yards along
+the path, and turning several sharp corners), ‘but I suppose it will
+at last. But how curiously it twists! It’s more like a corkscrew than a
+path! Well, THIS turn goes to the hill, I suppose--no, it doesn’t! This
+goes straight back to the house! Well then, I’ll try it the other way.’
+
+And so she did: wandering up and down, and trying turn after turn, but
+always coming back to the house, do what she would. Indeed, once, when
+she turned a corner rather more quickly than usual, she ran against it
+before she could stop herself.
+
+‘It’s no use talking about it,’ Alice said, looking up at the house and
+pretending it was arguing with her. ‘I’m NOT going in again yet. I know
+I should have to get through the Looking-glass again--back into the old
+room--and there’d be an end of all my adventures!’
+
+So, resolutely turning her back upon the house, she set out once more
+down the path, determined to keep straight on till she got to the hill.
+For a few minutes all went on well, and she was just saying, ‘I really
+SHALL do it this time--’ when the path gave a sudden twist and shook
+itself (as she described it afterwards), and the next moment she found
+herself actually walking in at the door.
+
+‘Oh, it’s too bad!’ she cried. ‘I never saw such a house for getting in
+the way! Never!’
+
+However, there was the hill full in sight, so there was nothing to be
+done but start again. This time she came upon a large flower-bed, with a
+border of daisies, and a willow-tree growing in the middle.
+
+‘O Tiger-lily,’ said Alice, addressing herself to one that was waving
+gracefully about in the wind, ‘I WISH you could talk!’
+
+‘We CAN talk,’ said the Tiger-lily: ‘when there’s anybody worth talking
+to.’
+
+Alice was so astonished that she could not speak for a minute: it quite
+seemed to take her breath away. At length, as the Tiger-lily only went
+on waving about, she spoke again, in a timid voice--almost in a whisper.
+‘And can ALL the flowers talk?’
+
+‘As well as YOU can,’ said the Tiger-lily. ‘And a great deal louder.’
+
+‘It isn’t manners for us to begin, you know,’ said the Rose, ‘and I
+really was wondering when you’d speak! Said I to myself, “Her face has
+got SOME sense in it, though it’s not a clever one!” Still, you’re the
+right colour, and that goes a long way.’
+
+‘I don’t care about the colour,’ the Tiger-lily remarked. ‘If only her
+petals curled up a little more, she’d be all right.’
+
+Alice didn’t like being criticised, so she began asking questions.
+‘Aren’t you sometimes frightened at being planted out here, with nobody
+to take care of you?’
+
+‘There’s the tree in the middle,’ said the Rose: ‘what else is it good
+for?’
+
+‘But what could it do, if any danger came?’ Alice asked.
+
+‘It says “Bough-wough!”’ cried a Daisy: ‘that’s why its branches are
+called boughs!’
+
+‘Didn’t you know THAT?’ cried another Daisy, and here they all began
+shouting together, till the air seemed quite full of little shrill
+voices. ‘Silence, every one of you!’ cried the Tiger-lily, waving itself
+passionately from side to side, and trembling with excitement. ‘They
+know I can’t get at them!’ it panted, bending its quivering head towards
+Alice, ‘or they wouldn’t dare to do it!’
+
+‘Never mind!’ Alice said in a soothing tone, and stooping down to the
+daisies, who were just beginning again, she whispered, ‘If you don’t
+hold your tongues, I’ll pick you!’
+
+There was silence in a moment, and several of the pink daisies turned
+white.
+
+‘That’s right!’ said the Tiger-lily. ‘The daisies are worst of all. When
+one speaks, they all begin together, and it’s enough to make one wither
+to hear the way they go on!’
+
+‘How is it you can all talk so nicely?’ Alice said, hoping to get it
+into a better temper by a compliment. ‘I’ve been in many gardens before,
+but none of the flowers could talk.’
+
+‘Put your hand down, and feel the ground,’ said the Tiger-lily. ‘Then
+you’ll know why.’
+
+Alice did so. ‘It’s very hard,’ she said, ‘but I don’t see what that has
+to do with it.’
+
+‘In most gardens,’ the Tiger-lily said, ‘they make the beds too soft--so
+that the flowers are always asleep.’
+
+This sounded a very good reason, and Alice was quite pleased to know it.
+‘I never thought of that before!’ she said.
+
+‘It’s MY opinion that you never think AT ALL,’ the Rose said in a rather
+severe tone.
+
+‘I never saw anybody that looked stupider,’ a Violet said, so suddenly,
+that Alice quite jumped; for it hadn’t spoken before.
+
+‘Hold YOUR tongue!’ cried the Tiger-lily. ‘As if YOU ever saw anybody!
+You keep your head under the leaves, and snore away there, till you know
+no more what’s going on in the world, than if you were a bud!’
+
+‘Are there any more people in the garden besides me?’ Alice said, not
+choosing to notice the Rose’s last remark.
+
+‘There’s one other flower in the garden that can move about like you,’
+said the Rose. ‘I wonder how you do it--’ (‘You’re always wondering,’
+said the Tiger-lily), ‘but she’s more bushy than you are.’
+
+‘Is she like me?’ Alice asked eagerly, for the thought crossed her mind,
+‘There’s another little girl in the garden, somewhere!’
+
+‘Well, she has the same awkward shape as you,’ the Rose said, ‘but she’s
+redder--and her petals are shorter, I think.’
+
+‘Her petals are done up close, almost like a dahlia,’ the Tiger-lily
+interrupted: ‘not tumbled about anyhow, like yours.’
+
+‘But that’s not YOUR fault,’ the Rose added kindly: ‘you’re beginning
+to fade, you know--and then one can’t help one’s petals getting a little
+untidy.’
+
+Alice didn’t like this idea at all: so, to change the subject, she asked
+‘Does she ever come out here?’
+
+‘I daresay you’ll see her soon,’ said the Rose. ‘She’s one of the thorny
+kind.’
+
+‘Where does she wear the thorns?’ Alice asked with some curiosity.
+
+‘Why all round her head, of course,’ the Rose replied. ‘I was wondering
+YOU hadn’t got some too. I thought it was the regular rule.’
+
+‘She’s coming!’ cried the Larkspur. ‘I hear her footstep, thump, thump,
+thump, along the gravel-walk!’
+
+Alice looked round eagerly, and found that it was the Red Queen. ‘She’s
+grown a good deal!’ was her first remark. She had indeed: when Alice
+first found her in the ashes, she had been only three inches high--and
+here she was, half a head taller than Alice herself!
+
+‘It’s the fresh air that does it,’ said the Rose: ‘wonderfully fine air
+it is, out here.’
+
+‘I think I’ll go and meet her,’ said Alice, for, though the flowers were
+interesting enough, she felt that it would be far grander to have a talk
+with a real Queen.
+
+‘You can’t possibly do that,’ said the Rose: ‘_I_ should advise you to
+walk the other way.’
+
+This sounded nonsense to Alice, so she said nothing, but set off at
+once towards the Red Queen. To her surprise, she lost sight of her in a
+moment, and found herself walking in at the front-door again.
+
+A little provoked, she drew back, and after looking everywhere for the
+queen (whom she spied out at last, a long way off), she thought she
+would try the plan, this time, of walking in the opposite direction.
+
+It succeeded beautifully. She had not been walking a minute before she
+found herself face to face with the Red Queen, and full in sight of the
+hill she had been so long aiming at.
+
+‘Where do you come from?’ said the Red Queen. ‘And where are you going?
+Look up, speak nicely, and don’t twiddle your fingers all the time.’
+
+Alice attended to all these directions, and explained, as well as she
+could, that she had lost her way.
+
+‘I don’t know what you mean by YOUR way,’ said the Queen: ‘all the ways
+about here belong to ME--but why did you come out here at all?’ she
+added in a kinder tone. ‘Curtsey while you’re thinking what to say, it
+saves time.’
+
+Alice wondered a little at this, but she was too much in awe of the
+Queen to disbelieve it. ‘I’ll try it when I go home,’ she thought to
+herself, ‘the next time I’m a little late for dinner.’
+
+‘It’s time for you to answer now,’ the Queen said, looking at her watch:
+‘open your mouth a LITTLE wider when you speak, and always say “your
+Majesty.”’
+
+‘I only wanted to see what the garden was like, your Majesty--’
+
+‘That’s right,’ said the Queen, patting her on the head, which Alice
+didn’t like at all, ‘though, when you say “garden,”--I’VE seen gardens,
+compared with which this would be a wilderness.’
+
+Alice didn’t dare to argue the point, but went on: ‘--and I thought I’d
+try and find my way to the top of that hill--’
+
+‘When you say “hill,”’ the Queen interrupted, ‘_I_ could show you hills,
+in comparison with which you’d call that a valley.’
+
+‘No, I shouldn’t,’ said Alice, surprised into contradicting her at last:
+‘a hill CAN’T be a valley, you know. That would be nonsense--’
+
+The Red Queen shook her head, ‘You may call it “nonsense” if you like,’
+she said, ‘but I’VE heard nonsense, compared with which that would be as
+sensible as a dictionary!’
+
+Alice curtseyed again, as she was afraid from the Queen’s tone that she
+was a LITTLE offended: and they walked on in silence till they got to
+the top of the little hill.
+
+For some minutes Alice stood without speaking, looking out in all
+directions over the country--and a most curious country it was. There
+were a number of tiny little brooks running straight across it from side
+to side, and the ground between was divided up into squares by a number
+of little green hedges, that reached from brook to brook.
+
+‘I declare it’s marked out just like a large chessboard!’ Alice said at
+last. ‘There ought to be some men moving about somewhere--and so there
+are!’ She added in a tone of delight, and her heart began to beat quick
+with excitement as she went on. ‘It’s a great huge game of chess that’s
+being played--all over the world--if this IS the world at all, you know.
+Oh, what fun it is! How I WISH I was one of them! I wouldn’t mind being
+a Pawn, if only I might join--though of course I should LIKE to be a
+Queen, best.’
+
+She glanced rather shyly at the real Queen as she said this, but her
+companion only smiled pleasantly, and said, ‘That’s easily managed. You
+can be the White Queen’s Pawn, if you like, as Lily’s too young to
+play; and you’re in the Second Square to begin with: when you get to
+the Eighth Square you’ll be a Queen--’ Just at this moment, somehow or
+other, they began to run.
+
+Alice never could quite make out, in thinking it over afterwards, how it
+was that they began: all she remembers is, that they were running hand
+in hand, and the Queen went so fast that it was all she could do to keep
+up with her: and still the Queen kept crying ‘Faster! Faster!’ but Alice
+felt she COULD NOT go faster, though she had not breath left to say so.
+
+The most curious part of the thing was, that the trees and the other
+things round them never changed their places at all: however fast they
+went, they never seemed to pass anything. ‘I wonder if all the things
+move along with us?’ thought poor puzzled Alice. And the Queen seemed to
+guess her thoughts, for she cried, ‘Faster! Don’t try to talk!’
+
+Not that Alice had any idea of doing THAT. She felt as if she would
+never be able to talk again, she was getting so much out of breath: and
+still the Queen cried ‘Faster! Faster!’ and dragged her along. ‘Are we
+nearly there?’ Alice managed to pant out at last.
+
+‘Nearly there!’ the Queen repeated. ‘Why, we passed it ten minutes ago!
+Faster!’ And they ran on for a time in silence, with the wind whistling
+in Alice’s ears, and almost blowing her hair off her head, she fancied.
+
+‘Now! Now!’ cried the Queen. ‘Faster! Faster!’ And they went so fast
+that at last they seemed to skim through the air, hardly touching the
+ground with their feet, till suddenly, just as Alice was getting quite
+exhausted, they stopped, and she found herself sitting on the ground,
+breathless and giddy.
+
+The Queen propped her up against a tree, and said kindly, ‘You may rest
+a little now.’
+
+Alice looked round her in great surprise. ‘Why, I do believe we’ve been
+under this tree the whole time! Everything’s just as it was!’
+
+‘Of course it is,’ said the Queen, ‘what would you have it?’
+
+‘Well, in OUR country,’ said Alice, still panting a little, ‘you’d
+generally get to somewhere else--if you ran very fast for a long time,
+as we’ve been doing.’
+
+‘A slow sort of country!’ said the Queen. ‘Now, HERE, you see, it takes
+all the running YOU can do, to keep in the same place. If you want to
+get somewhere else, you must run at least twice as fast as that!’
+
+‘I’d rather not try, please!’ said Alice. ‘I’m quite content to stay
+here--only I AM so hot and thirsty!’
+
+‘I know what YOU’D like!’ the Queen said good-naturedly, taking a little
+box out of her pocket. ‘Have a biscuit?’
+
+Alice thought it would not be civil to say ‘No,’ though it wasn’t at all
+what she wanted. So she took it, and ate it as well as she could: and it
+was VERY dry; and she thought she had never been so nearly choked in all
+her life.
+
+‘While you’re refreshing yourself,’ said the Queen, ‘I’ll just take
+the measurements.’ And she took a ribbon out of her pocket, marked in
+inches, and began measuring the ground, and sticking little pegs in here
+and there.
+
+‘At the end of two yards,’ she said, putting in a peg to mark the
+distance, ‘I shall give you your directions--have another biscuit?’
+
+‘No, thank you,’ said Alice: ‘one’s QUITE enough!’
+
+‘Thirst quenched, I hope?’ said the Queen.
+
+Alice did not know what to say to this, but luckily the Queen did not
+wait for an answer, but went on. ‘At the end of THREE yards I shall
+repeat them--for fear of your forgetting them. At the end of FOUR, I
+shall say good-bye. And at the end of FIVE, I shall go!’
+
+She had got all the pegs put in by this time, and Alice looked on
+with great interest as she returned to the tree, and then began slowly
+walking down the row.
+
+At the two-yard peg she faced round, and said, ‘A pawn goes two squares
+in its first move, you know. So you’ll go VERY quickly through the Third
+Square--by railway, I should think--and you’ll find yourself in the
+Fourth Square in no time. Well, THAT square belongs to Tweedledum and
+Tweedledee--the Fifth is mostly water--the Sixth belongs to Humpty
+Dumpty--But you make no remark?’
+
+‘I--I didn’t know I had to make one--just then,’ Alice faltered out.
+
+‘You SHOULD have said, “It’s extremely kind of you to tell me all
+this”--however, we’ll suppose it said--the Seventh Square is all
+forest--however, one of the Knights will show you the way--and in the
+Eighth Square we shall be Queens together, and it’s all feasting and
+fun!’ Alice got up and curtseyed, and sat down again.
+
+At the next peg the Queen turned again, and this time she said, ‘Speak
+in French when you can’t think of the English for a thing--turn out your
+toes as you walk--and remember who you are!’ She did not wait for Alice
+to curtsey this time, but walked on quickly to the next peg, where she
+turned for a moment to say ‘good-bye,’ and then hurried on to the last.
+
+How it happened, Alice never knew, but exactly as she came to the last
+peg, she was gone. Whether she vanished into the air, or whether she
+ran quickly into the wood (‘and she CAN run very fast!’ thought Alice),
+there was no way of guessing, but she was gone, and Alice began to
+remember that she was a Pawn, and that it would soon be time for her to
+move.
+
+
+
+
+CHAPTER III. Looking-Glass Insects
+
+Of course the first thing to do was to make a grand survey of the
+country she was going to travel through. ‘It’s something very like
+learning geography,’ thought Alice, as she stood on tiptoe in hopes of
+being able to see a little further. ‘Principal rivers--there ARE none.
+Principal mountains--I’m on the only one, but I don’t think it’s got any
+name. Principal towns--why, what ARE those creatures, making honey down
+there? They can’t be bees--nobody ever saw bees a mile off, you know--’
+and for some time she stood silent, watching one of them that was
+bustling about among the flowers, poking its proboscis into them, ‘just
+as if it was a regular bee,’ thought Alice.
+
+However, this was anything but a regular bee: in fact it was an
+elephant--as Alice soon found out, though the idea quite took her breath
+away at first. ‘And what enormous flowers they must be!’ was her next
+idea. ‘Something like cottages with the roofs taken off, and stalks put
+to them--and what quantities of honey they must make! I think I’ll go
+down and--no, I won’t JUST yet,’ she went on, checking herself just as
+she was beginning to run down the hill, and trying to find some excuse
+for turning shy so suddenly. ‘It’ll never do to go down among them
+without a good long branch to brush them away--and what fun it’ll be
+when they ask me how I like my walk. I shall say--“Oh, I like it well
+enough--“’ (here came the favourite little toss of the head), ‘“only it
+was so dusty and hot, and the elephants did tease so!”’
+
+‘I think I’ll go down the other way,’ she said after a pause: ‘and
+perhaps I may visit the elephants later on. Besides, I do so want to get
+into the Third Square!’
+
+So with this excuse she ran down the hill and jumped over the first of
+the six little brooks.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Tickets, please!’ said the Guard, putting his head in at the window.
+In a moment everybody was holding out a ticket: they were about the same
+size as the people, and quite seemed to fill the carriage.
+
+‘Now then! Show your ticket, child!’ the Guard went on, looking angrily
+at Alice. And a great many voices all said together (‘like the chorus of
+a song,’ thought Alice), ‘Don’t keep him waiting, child! Why, his time
+is worth a thousand pounds a minute!’
+
+‘I’m afraid I haven’t got one,’ Alice said in a frightened tone: ‘there
+wasn’t a ticket-office where I came from.’ And again the chorus of
+voices went on. ‘There wasn’t room for one where she came from. The land
+there is worth a thousand pounds an inch!’
+
+‘Don’t make excuses,’ said the Guard: ‘you should have bought one from
+the engine-driver.’ And once more the chorus of voices went on with ‘The
+man that drives the engine. Why, the smoke alone is worth a thousand
+pounds a puff!’
+
+Alice thought to herself, ‘Then there’s no use in speaking.’ The
+voices didn’t join in this time, as she hadn’t spoken, but to her
+great surprise, they all THOUGHT in chorus (I hope you understand what
+THINKING IN CHORUS means--for I must confess that _I_ don’t), ‘Better
+say nothing at all. Language is worth a thousand pounds a word!’
+
+‘I shall dream about a thousand pounds tonight, I know I shall!’ thought
+Alice.
+
+All this time the Guard was looking at her, first through a telescope,
+then through a microscope, and then through an opera-glass. At last he
+said, ‘You’re travelling the wrong way,’ and shut up the window and went
+away.
+
+‘So young a child,’ said the gentleman sitting opposite to her (he was
+dressed in white paper), ‘ought to know which way she’s going, even if
+she doesn’t know her own name!’
+
+A Goat, that was sitting next to the gentleman in white, shut his
+eyes and said in a loud voice, ‘She ought to know her way to the
+ticket-office, even if she doesn’t know her alphabet!’
+
+There was a Beetle sitting next to the Goat (it was a very queer
+carriage-full of passengers altogether), and, as the rule seemed to be
+that they should all speak in turn, HE went on with ‘She’ll have to go
+back from here as luggage!’
+
+Alice couldn’t see who was sitting beyond the Beetle, but a hoarse voice
+spoke next. ‘Change engines--’ it said, and was obliged to leave off.
+
+‘It sounds like a horse,’ Alice thought to herself. And an extremely
+small voice, close to her ear, said, ‘You might make a joke on
+that--something about “horse” and “hoarse,” you know.’
+
+Then a very gentle voice in the distance said, ‘She must be labelled
+“Lass, with care,” you know--’
+
+And after that other voices went on (‘What a number of people there are
+in the carriage!’ thought Alice), saying, ‘She must go by post, as she’s
+got a head on her--’ ‘She must be sent as a message by the telegraph--’
+‘She must draw the train herself the rest of the way--’ and so on.
+
+But the gentleman dressed in white paper leaned forwards and whispered
+in her ear, ‘Never mind what they all say, my dear, but take a
+return-ticket every time the train stops.’
+
+‘Indeed I shan’t!’ Alice said rather impatiently. ‘I don’t belong to
+this railway journey at all--I was in a wood just now--and I wish I
+could get back there.’
+
+‘You might make a joke on THAT,’ said the little voice close to her ear:
+‘something about “you WOULD if you could,” you know.’
+
+‘Don’t tease so,’ said Alice, looking about in vain to see where the
+voice came from; ‘if you’re so anxious to have a joke made, why don’t
+you make one yourself?’
+
+The little voice sighed deeply: it was VERY unhappy, evidently, and
+Alice would have said something pitying to comfort it, ‘If it would only
+sigh like other people!’ she thought. But this was such a wonderfully
+small sigh, that she wouldn’t have heard it at all, if it hadn’t come
+QUITE close to her ear. The consequence of this was that it tickled her
+ear very much, and quite took off her thoughts from the unhappiness of
+the poor little creature.
+
+‘I know you are a friend,’ the little voice went on; ‘a dear friend, and
+an old friend. And you won’t hurt me, though I AM an insect.’
+
+‘What kind of insect?’ Alice inquired a little anxiously. What she
+really wanted to know was, whether it could sting or not, but she
+thought this wouldn’t be quite a civil question to ask.
+
+‘What, then you don’t--’ the little voice began, when it was drowned by
+a shrill scream from the engine, and everybody jumped up in alarm, Alice
+among the rest.
+
+The Horse, who had put his head out of the window, quietly drew it in
+and said, ‘It’s only a brook we have to jump over.’ Everybody seemed
+satisfied with this, though Alice felt a little nervous at the idea of
+trains jumping at all. ‘However, it’ll take us into the Fourth Square,
+that’s some comfort!’ she said to herself. In another moment she felt
+the carriage rise straight up into the air, and in her fright she caught
+at the thing nearest to her hand, which happened to be the Goat’s beard.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+But the beard seemed to melt away as she touched it, and she found
+herself sitting quietly under a tree--while the Gnat (for that was the
+insect she had been talking to) was balancing itself on a twig just over
+her head, and fanning her with its wings.
+
+It certainly was a VERY large Gnat: ‘about the size of a chicken,’ Alice
+thought. Still, she couldn’t feel nervous with it, after they had been
+talking together so long.
+
+‘--then you don’t like all insects?’ the Gnat went on, as quietly as if
+nothing had happened.
+
+‘I like them when they can talk,’ Alice said. ‘None of them ever talk,
+where _I_ come from.’
+
+‘What sort of insects do you rejoice in, where YOU come from?’ the Gnat
+inquired.
+
+‘I don’t REJOICE in insects at all,’ Alice explained, ‘because I’m
+rather afraid of them--at least the large kinds. But I can tell you the
+names of some of them.’
+
+‘Of course they answer to their names?’ the Gnat remarked carelessly.
+
+‘I never knew them to do it.’
+
+‘What’s the use of their having names,’ the Gnat said, ‘if they won’t
+answer to them?’
+
+‘No use to THEM,’ said Alice; ‘but it’s useful to the people who name
+them, I suppose. If not, why do things have names at all?’
+
+‘I can’t say,’ the Gnat replied. ‘Further on, in the wood down there,
+they’ve got no names--however, go on with your list of insects: you’re
+wasting time.’
+
+‘Well, there’s the Horse-fly,’ Alice began, counting off the names on
+her fingers.
+
+‘All right,’ said the Gnat: ‘half way up that bush, you’ll see a
+Rocking-horse-fly, if you look. It’s made entirely of wood, and gets
+about by swinging itself from branch to branch.’
+
+‘What does it live on?’ Alice asked, with great curiosity.
+
+‘Sap and sawdust,’ said the Gnat. ‘Go on with the list.’
+
+Alice looked up at the Rocking-horse-fly with great interest, and made
+up her mind that it must have been just repainted, it looked so bright
+and sticky; and then she went on.
+
+‘And there’s the Dragon-fly.’
+
+‘Look on the branch above your head,’ said the Gnat, ‘and there you’ll
+find a snap-dragon-fly. Its body is made of plum-pudding, its wings of
+holly-leaves, and its head is a raisin burning in brandy.’
+
+‘And what does it live on?’
+
+‘Frumenty and mince pie,’ the Gnat replied; ‘and it makes its nest in a
+Christmas box.’
+
+‘And then there’s the Butterfly,’ Alice went on, after she had taken
+a good look at the insect with its head on fire, and had thought to
+herself, ‘I wonder if that’s the reason insects are so fond of flying
+into candles--because they want to turn into Snap-dragon-flies!’
+
+‘Crawling at your feet,’ said the Gnat (Alice drew her feet back in
+some alarm), ‘you may observe a Bread-and-Butterfly. Its wings are thin
+slices of Bread-and-butter, its body is a crust, and its head is a lump
+of sugar.’
+
+‘And what does IT live on?’
+
+‘Weak tea with cream in it.’
+
+A new difficulty came into Alice’s head. ‘Supposing it couldn’t find
+any?’ she suggested.
+
+‘Then it would die, of course.’
+
+‘But that must happen very often,’ Alice remarked thoughtfully.
+
+‘It always happens,’ said the Gnat.
+
+After this, Alice was silent for a minute or two, pondering. The Gnat
+amused itself meanwhile by humming round and round her head: at last
+it settled again and remarked, ‘I suppose you don’t want to lose your
+name?’
+
+‘No, indeed,’ Alice said, a little anxiously.
+
+‘And yet I don’t know,’ the Gnat went on in a careless tone: ‘only think
+how convenient it would be if you could manage to go home without it!
+For instance, if the governess wanted to call you to your lessons, she
+would call out “come here--,” and there she would have to leave off,
+because there wouldn’t be any name for her to call, and of course you
+wouldn’t have to go, you know.’
+
+‘That would never do, I’m sure,’ said Alice: ‘the governess would never
+think of excusing me lessons for that. If she couldn’t remember my name,
+she’d call me “Miss!” as the servants do.’
+
+‘Well, if she said “Miss,” and didn’t say anything more,’ the Gnat
+remarked, ‘of course you’d miss your lessons. That’s a joke. I wish YOU
+had made it.’
+
+‘Why do you wish _I_ had made it?’ Alice asked. ‘It’s a very bad one.’
+
+But the Gnat only sighed deeply, while two large tears came rolling down
+its cheeks.
+
+‘You shouldn’t make jokes,’ Alice said, ‘if it makes you so unhappy.’
+
+Then came another of those melancholy little sighs, and this time the
+poor Gnat really seemed to have sighed itself away, for, when Alice
+looked up, there was nothing whatever to be seen on the twig, and, as
+she was getting quite chilly with sitting still so long, she got up and
+walked on.
+
+She very soon came to an open field, with a wood on the other side of
+it: it looked much darker than the last wood, and Alice felt a LITTLE
+timid about going into it. However, on second thoughts, she made up her
+mind to go on: ‘for I certainly won’t go BACK,’ she thought to herself,
+and this was the only way to the Eighth Square.
+
+‘This must be the wood,’ she said thoughtfully to herself, ‘where
+things have no names. I wonder what’ll become of MY name when I go in?
+I shouldn’t like to lose it at all--because they’d have to give me
+another, and it would be almost certain to be an ugly one. But then
+the fun would be trying to find the creature that had got my old
+name! That’s just like the advertisements, you know, when people lose
+dogs--“ANSWERS TO THE NAME OF ‘DASH:’ HAD ON A BRASS COLLAR”--just fancy
+calling everything you met “Alice,” till one of them answered! Only they
+wouldn’t answer at all, if they were wise.’
+
+She was rambling on in this way when she reached the wood: it looked
+very cool and shady. ‘Well, at any rate it’s a great comfort,’ she
+said as she stepped under the trees, ‘after being so hot, to get into
+the--into WHAT?’ she went on, rather surprised at not being able to
+think of the word. ‘I mean to get under the--under the--under THIS, you
+know!’ putting her hand on the trunk of the tree. ‘What DOES it call
+itself, I wonder? I do believe it’s got no name--why, to be sure it
+hasn’t!’
+
+She stood silent for a minute, thinking: then she suddenly began again.
+‘Then it really HAS happened, after all! And now, who am I? I WILL
+remember, if I can! I’m determined to do it!’ But being determined
+didn’t help much, and all she could say, after a great deal of puzzling,
+was, ‘L, I KNOW it begins with L!’
+
+Just then a Fawn came wandering by: it looked at Alice with its large
+gentle eyes, but didn’t seem at all frightened. ‘Here then! Here then!’
+Alice said, as she held out her hand and tried to stroke it; but it only
+started back a little, and then stood looking at her again.
+
+‘What do you call yourself?’ the Fawn said at last. Such a soft sweet
+voice it had!
+
+‘I wish I knew!’ thought poor Alice. She answered, rather sadly,
+‘Nothing, just now.’
+
+‘Think again,’ it said: ‘that won’t do.’
+
+Alice thought, but nothing came of it. ‘Please, would you tell me
+what YOU call yourself?’ she said timidly. ‘I think that might help a
+little.’
+
+‘I’ll tell you, if you’ll move a little further on,’ the Fawn said. ‘I
+can’t remember here.’
+
+So they walked on together though the wood, Alice with her arms clasped
+lovingly round the soft neck of the Fawn, till they came out into
+another open field, and here the Fawn gave a sudden bound into the air,
+and shook itself free from Alice’s arms. ‘I’m a Fawn!’ it cried out in a
+voice of delight, ‘and, dear me! you’re a human child!’ A sudden look of
+alarm came into its beautiful brown eyes, and in another moment it had
+darted away at full speed.
+
+Alice stood looking after it, almost ready to cry with vexation at
+having lost her dear little fellow-traveller so suddenly. ‘However, I
+know my name now.’ she said, ‘that’s SOME comfort. Alice--Alice--I won’t
+forget it again. And now, which of these finger-posts ought I to follow,
+I wonder?’
+
+It was not a very difficult question to answer, as there was only one
+road through the wood, and the two finger-posts both pointed along it.
+‘I’ll settle it,’ Alice said to herself, ‘when the road divides and they
+point different ways.’
+
+But this did not seem likely to happen. She went on and on, a long way,
+but wherever the road divided there were sure to be two finger-posts
+pointing the same way, one marked ‘TO TWEEDLEDUM’S HOUSE’ and the other
+‘TO THE HOUSE OF TWEEDLEDEE.’
+
+‘I do believe,’ said Alice at last, ‘that they live in the same house! I
+wonder I never thought of that before--But I can’t stay there long. I’ll
+just call and say “how d’you do?” and ask them the way out of the wood.
+If I could only get to the Eighth Square before it gets dark!’ So she
+wandered on, talking to herself as she went, till, on turning a sharp
+corner, she came upon two fat little men, so suddenly that she could not
+help starting back, but in another moment she recovered herself, feeling
+sure that they must be.
+
+
+
+
+CHAPTER IV. Tweedledum And Tweedledee
+
+They were standing under a tree, each with an arm round the other’s
+neck, and Alice knew which was which in a moment, because one of them
+had ‘DUM’ embroidered on his collar, and the other ‘DEE.’ ‘I suppose
+they’ve each got “TWEEDLE” round at the back of the collar,’ she said to
+herself.
+
+They stood so still that she quite forgot they were alive, and she was
+just looking round to see if the word “TWEEDLE” was written at the back
+of each collar, when she was startled by a voice coming from the one
+marked ‘DUM.’
+
+‘If you think we’re wax-works,’ he said, ‘you ought to pay, you know.
+Wax-works weren’t made to be looked at for nothing, nohow!’
+
+‘Contrariwise,’ added the one marked ‘DEE,’ ‘if you think we’re alive,
+you ought to speak.’
+
+‘I’m sure I’m very sorry,’ was all Alice could say; for the words of the
+old song kept ringing through her head like the ticking of a clock, and
+she could hardly help saying them out loud:--
+
+
+     ‘Tweedledum and Tweedledee
+      Agreed to have a battle;
+     For Tweedledum said Tweedledee
+      Had spoiled his nice new rattle.
+
+     Just then flew down a monstrous crow,
+      As black as a tar-barrel;
+     Which frightened both the heroes so,
+      They quite forgot their quarrel.’
+
+‘I know what you’re thinking about,’ said Tweedledum: ‘but it isn’t so,
+nohow.’
+
+‘Contrariwise,’ continued Tweedledee, ‘if it was so, it might be; and if
+it were so, it would be; but as it isn’t, it ain’t. That’s logic.’
+
+‘I was thinking,’ Alice said very politely, ‘which is the best way out
+of this wood: it’s getting so dark. Would you tell me, please?’
+
+But the little men only looked at each other and grinned.
+
+They looked so exactly like a couple of great schoolboys, that Alice
+couldn’t help pointing her finger at Tweedledum, and saying ‘First Boy!’
+
+‘Nohow!’ Tweedledum cried out briskly, and shut his mouth up again with
+a snap.
+
+‘Next Boy!’ said Alice, passing on to Tweedledee, though she felt quite
+certain he would only shout out ‘Contrariwise!’ and so he did.
+
+‘You’ve been wrong!’ cried Tweedledum. ‘The first thing in a visit is to
+say “How d’ye do?” and shake hands!’ And here the two brothers gave each
+other a hug, and then they held out the two hands that were free, to
+shake hands with her.
+
+Alice did not like shaking hands with either of them first, for fear
+of hurting the other one’s feelings; so, as the best way out of the
+difficulty, she took hold of both hands at once: the next moment they
+were dancing round in a ring. This seemed quite natural (she remembered
+afterwards), and she was not even surprised to hear music playing: it
+seemed to come from the tree under which they were dancing, and it was
+done (as well as she could make it out) by the branches rubbing one
+across the other, like fiddles and fiddle-sticks.
+
+‘But it certainly WAS funny,’ (Alice said afterwards, when she was
+telling her sister the history of all this,) ‘to find myself singing
+“HERE WE GO ROUND THE MULBERRY BUSH.” I don’t know when I began it, but
+somehow I felt as if I’d been singing it a long long time!’
+
+The other two dancers were fat, and very soon out of breath. ‘Four times
+round is enough for one dance,’ Tweedledum panted out, and they left
+off dancing as suddenly as they had begun: the music stopped at the same
+moment.
+
+Then they let go of Alice’s hands, and stood looking at her for a
+minute: there was a rather awkward pause, as Alice didn’t know how to
+begin a conversation with people she had just been dancing with. ‘It
+would never do to say “How d’ye do?” NOW,’ she said to herself: ‘we seem
+to have got beyond that, somehow!’
+
+‘I hope you’re not much tired?’ she said at last.
+
+‘Nohow. And thank you VERY much for asking,’ said Tweedledum.
+
+‘So much obliged!’ added Tweedledee. ‘You like poetry?’
+
+‘Ye-es, pretty well--SOME poetry,’ Alice said doubtfully. ‘Would you
+tell me which road leads out of the wood?’
+
+‘What shall I repeat to her?’ said Tweedledee, looking round at
+Tweedledum with great solemn eyes, and not noticing Alice’s question.
+
+‘“THE WALRUS AND THE CARPENTER” is the longest,’ Tweedledum replied,
+giving his brother an affectionate hug.
+
+Tweedledee began instantly:
+
+       ‘The sun was shining--’
+
+Here Alice ventured to interrupt him. ‘If it’s VERY long,’ she said, as
+politely as she could, ‘would you please tell me first which road--’
+
+Tweedledee smiled gently, and began again:
+
+     ‘The sun was shining on the sea,
+      Shining with all his might:
+     He did his very best to make
+      The billows smooth and bright--
+     And this was odd, because it was
+      The middle of the night.
+
+     The moon was shining sulkily,
+      Because she thought the sun
+     Had got no business to be there
+      After the day was done--
+     “It’s very rude of him,” she said,
+      “To come and spoil the fun!”
+
+     The sea was wet as wet could be,
+      The sands were dry as dry.
+     You could not see a cloud, because
+      No cloud was in the sky:
+     No birds were flying over head--
+      There were no birds to fly.
+
+     The Walrus and the Carpenter
+      Were walking close at hand;
+     They wept like anything to see
+      Such quantities of sand:
+     “If this were only cleared away,”
+       They said, “it WOULD be grand!”
+
+     “If seven maids with seven mops
+      Swept it for half a year,
+     Do you suppose,” the Walrus said,
+      “That they could get it clear?”
+      “I doubt it,” said the Carpenter,
+      And shed a bitter tear.
+
+     “O Oysters, come and walk with us!”
+       The Walrus did beseech.
+     “A pleasant walk, a pleasant talk,
+      Along the briny beach:
+     We cannot do with more than four,
+      To give a hand to each.”
+
+     The eldest Oyster looked at him.
+      But never a word he said:
+     The eldest Oyster winked his eye,
+      And shook his heavy head--
+     Meaning to say he did not choose
+      To leave the oyster-bed.
+
+     But four young oysters hurried up,
+      All eager for the treat:
+     Their coats were brushed, their faces washed,
+      Their shoes were clean and neat--
+     And this was odd, because, you know,
+      They hadn’t any feet.
+
+     Four other Oysters followed them,
+      And yet another four;
+     And thick and fast they came at last,
+      And more, and more, and more--
+     All hopping through the frothy waves,
+      And scrambling to the shore.
+
+     The Walrus and the Carpenter
+      Walked on a mile or so,
+     And then they rested on a rock
+      Conveniently low:
+     And all the little Oysters stood
+      And waited in a row.
+
+     “The time has come,” the Walrus said,
+      “To talk of many things:
+     Of shoes--and ships--and sealing-wax--
+      Of cabbages--and kings--
+     And why the sea is boiling hot--
+      And whether pigs have wings.”
+
+     “But wait a bit,” the Oysters cried,
+      “Before we have our chat;
+     For some of us are out of breath,
+      And all of us are fat!”
+      “No hurry!” said the Carpenter.
+      They thanked him much for that.
+
+     “A loaf of bread,” the Walrus said,
+      “Is what we chiefly need:
+     Pepper and vinegar besides
+      Are very good indeed--
+     Now if you’re ready Oysters dear,
+      We can begin to feed.”
+
+     “But not on us!” the Oysters cried,
+      Turning a little blue,
+     “After such kindness, that would be
+      A dismal thing to do!”
+      “The night is fine,” the Walrus said
+      “Do you admire the view?
+
+     “It was so kind of you to come!
+      And you are very nice!”
+      The Carpenter said nothing but
+      “Cut us another slice:
+     I wish you were not quite so deaf--
+      I’ve had to ask you twice!”
+
+     “It seems a shame,” the Walrus said,
+      “To play them such a trick,
+     After we’ve brought them out so far,
+      And made them trot so quick!”
+      The Carpenter said nothing but
+      “The butter’s spread too thick!”
+
+     “I weep for you,” the Walrus said.
+      “I deeply sympathize.”
+      With sobs and tears he sorted out
+      Those of the largest size.
+     Holding his pocket handkerchief
+      Before his streaming eyes.
+
+     “O Oysters,” said the Carpenter.
+      “You’ve had a pleasant run!
+     Shall we be trotting home again?”
+       But answer came there none--
+     And that was scarcely odd, because
+      They’d eaten every one.’
+
+‘I like the Walrus best,’ said Alice: ‘because you see he was a LITTLE
+sorry for the poor oysters.’
+
+‘He ate more than the Carpenter, though,’ said Tweedledee. ‘You see he
+held his handkerchief in front, so that the Carpenter couldn’t count how
+many he took: contrariwise.’
+
+‘That was mean!’ Alice said indignantly. ‘Then I like the Carpenter
+best--if he didn’t eat so many as the Walrus.’
+
+‘But he ate as many as he could get,’ said Tweedledum.
+
+This was a puzzler. After a pause, Alice began, ‘Well! They were BOTH
+very unpleasant characters--’ Here she checked herself in some alarm,
+at hearing something that sounded to her like the puffing of a large
+steam-engine in the wood near them, though she feared it was more likely
+to be a wild beast. ‘Are there any lions or tigers about here?’ she
+asked timidly.
+
+‘It’s only the Red King snoring,’ said Tweedledee.
+
+‘Come and look at him!’ the brothers cried, and they each took one of
+Alice’s hands, and led her up to where the King was sleeping.
+
+‘Isn’t he a LOVELY sight?’ said Tweedledum.
+
+Alice couldn’t say honestly that he was. He had a tall red night-cap on,
+with a tassel, and he was lying crumpled up into a sort of untidy heap,
+and snoring loud--‘fit to snore his head off!’ as Tweedledum remarked.
+
+‘I’m afraid he’ll catch cold with lying on the damp grass,’ said Alice,
+who was a very thoughtful little girl.
+
+‘He’s dreaming now,’ said Tweedledee: ‘and what do you think he’s
+dreaming about?’
+
+Alice said ‘Nobody can guess that.’
+
+‘Why, about YOU!’ Tweedledee exclaimed, clapping his hands triumphantly.
+‘And if he left off dreaming about you, where do you suppose you’d be?’
+
+‘Where I am now, of course,’ said Alice.
+
+‘Not you!’ Tweedledee retorted contemptuously. ‘You’d be nowhere. Why,
+you’re only a sort of thing in his dream!’
+
+‘If that there King was to wake,’ added Tweedledum, ‘you’d go
+out--bang!--just like a candle!’
+
+‘I shouldn’t!’ Alice exclaimed indignantly. ‘Besides, if I’M only a sort
+of thing in his dream, what are YOU, I should like to know?’
+
+‘Ditto’ said Tweedledum.
+
+‘Ditto, ditto’ cried Tweedledee.
+
+He shouted this so loud that Alice couldn’t help saying, ‘Hush! You’ll
+be waking him, I’m afraid, if you make so much noise.’
+
+‘Well, it no use YOUR talking about waking him,’ said Tweedledum, ‘when
+you’re only one of the things in his dream. You know very well you’re
+not real.’
+
+‘I AM real!’ said Alice and began to cry.
+
+‘You won’t make yourself a bit realler by crying,’ Tweedledee remarked:
+‘there’s nothing to cry about.’
+
+‘If I wasn’t real,’ Alice said--half-laughing through her tears, it all
+seemed so ridiculous--‘I shouldn’t be able to cry.’
+
+‘I hope you don’t suppose those are real tears?’ Tweedledum interrupted
+in a tone of great contempt.
+
+‘I know they’re talking nonsense,’ Alice thought to herself: ‘and it’s
+foolish to cry about it.’ So she brushed away her tears, and went on as
+cheerfully as she could. ‘At any rate I’d better be getting out of the
+wood, for really it’s coming on very dark. Do you think it’s going to
+rain?’
+
+Tweedledum spread a large umbrella over himself and his brother, and
+looked up into it. ‘No, I don’t think it is,’ he said: ‘at least--not
+under HERE. Nohow.’
+
+‘But it may rain OUTSIDE?’
+
+‘It may--if it chooses,’ said Tweedledee: ‘we’ve no objection.
+Contrariwise.’
+
+‘Selfish things!’ thought Alice, and she was just going to say
+‘Good-night’ and leave them, when Tweedledum sprang out from under the
+umbrella and seized her by the wrist.
+
+‘Do you see THAT?’ he said, in a voice choking with passion, and
+his eyes grew large and yellow all in a moment, as he pointed with a
+trembling finger at a small white thing lying under the tree.
+
+‘It’s only a rattle,’ Alice said, after a careful examination of the
+little white thing. ‘Not a rattleSNAKE, you know,’ she added hastily,
+thinking that he was frightened: ‘only an old rattle--quite old and
+broken.’
+
+‘I knew it was!’ cried Tweedledum, beginning to stamp about wildly and
+tear his hair. ‘It’s spoilt, of course!’ Here he looked at Tweedledee,
+who immediately sat down on the ground, and tried to hide himself under
+the umbrella.
+
+Alice laid her hand upon his arm, and said in a soothing tone, ‘You
+needn’t be so angry about an old rattle.’
+
+‘But it isn’t old!’ Tweedledum cried, in a greater fury than ever. ‘It’s
+new, I tell you--I bought it yesterday--my nice new RATTLE!’ and his
+voice rose to a perfect scream.
+
+All this time Tweedledee was trying his best to fold up the umbrella,
+with himself in it: which was such an extraordinary thing to do, that it
+quite took off Alice’s attention from the angry brother. But he couldn’t
+quite succeed, and it ended in his rolling over, bundled up in the
+umbrella, with only his head out: and there he lay, opening and shutting
+his mouth and his large eyes--‘looking more like a fish than anything
+else,’ Alice thought.
+
+‘Of course you agree to have a battle?’ Tweedledum said in a calmer
+tone.
+
+‘I suppose so,’ the other sulkily replied, as he crawled out of the
+umbrella: ‘only SHE must help us to dress up, you know.’
+
+So the two brothers went off hand-in-hand into the wood, and returned
+in a minute with their arms full of things--such as bolsters, blankets,
+hearth-rugs, table-cloths, dish-covers and coal-scuttles. ‘I hope you’re
+a good hand at pinning and tying strings?’ Tweedledum remarked. ‘Every
+one of these things has got to go on, somehow or other.’
+
+Alice said afterwards she had never seen such a fuss made about anything
+in all her life--the way those two bustled about--and the quantity of
+things they put on--and the trouble they gave her in tying strings and
+fastening buttons--‘Really they’ll be more like bundles of old clothes
+than anything else, by the time they’re ready!’ she said to herself, as
+she arranged a bolster round the neck of Tweedledee, ‘to keep his head
+from being cut off,’ as he said.
+
+‘You know,’ he added very gravely, ‘it’s one of the most serious things
+that can possibly happen to one in a battle--to get one’s head cut off.’
+
+Alice laughed aloud: but she managed to turn it into a cough, for fear
+of hurting his feelings.
+
+‘Do I look very pale?’ said Tweedledum, coming up to have his helmet
+tied on. (He CALLED it a helmet, though it certainly looked much more
+like a saucepan.)
+
+‘Well--yes--a LITTLE,’ Alice replied gently.
+
+‘I’m very brave generally,’ he went on in a low voice: ‘only to-day I
+happen to have a headache.’
+
+‘And I’VE got a toothache!’ said Tweedledee, who had overheard the
+remark. ‘I’m far worse off than you!’
+
+‘Then you’d better not fight to-day,’ said Alice, thinking it a good
+opportunity to make peace.
+
+‘We MUST have a bit of a fight, but I don’t care about going on long,’
+said Tweedledum. ‘What’s the time now?’
+
+Tweedledee looked at his watch, and said ‘Half-past four.’
+
+‘Let’s fight till six, and then have dinner,’ said Tweedledum.
+
+‘Very well,’ the other said, rather sadly: ‘and SHE can watch us--only
+you’d better not come VERY close,’ he added: ‘I generally hit everything
+I can see--when I get really excited.’
+
+‘And _I_ hit everything within reach,’ cried Tweedledum, ‘whether I can
+see it or not!’
+
+Alice laughed. ‘You must hit the TREES pretty often, I should think,’
+she said.
+
+Tweedledum looked round him with a satisfied smile. ‘I don’t suppose,’
+he said, ‘there’ll be a tree left standing, for ever so far round, by
+the time we’ve finished!’
+
+‘And all about a rattle!’ said Alice, still hoping to make them a LITTLE
+ashamed of fighting for such a trifle.
+
+‘I shouldn’t have minded it so much,’ said Tweedledum, ‘if it hadn’t
+been a new one.’
+
+‘I wish the monstrous crow would come!’ thought Alice.
+
+‘There’s only one sword, you know,’ Tweedledum said to his brother:
+‘but you can have the umbrella--it’s quite as sharp. Only we must begin
+quick. It’s getting as dark as it can.’
+
+‘And darker,’ said Tweedledee.
+
+It was getting dark so suddenly that Alice thought there must be a
+thunderstorm coming on. ‘What a thick black cloud that is!’ she said.
+‘And how fast it comes! Why, I do believe it’s got wings!’
+
+‘It’s the crow!’ Tweedledum cried out in a shrill voice of alarm: and
+the two brothers took to their heels and were out of sight in a moment.
+
+Alice ran a little way into the wood, and stopped under a large tree.
+‘It can never get at me HERE,’ she thought: ‘it’s far too large to
+squeeze itself in among the trees. But I wish it wouldn’t flap its wings
+so--it makes quite a hurricane in the wood--here’s somebody’s shawl
+being blown away!’
+
+
+
+
+CHAPTER V. Wool and Water
+
+She caught the shawl as she spoke, and looked about for the owner: in
+another moment the White Queen came running wildly through the wood,
+with both arms stretched out wide, as if she were flying, and Alice very
+civilly went to meet her with the shawl.
+
+‘I’m very glad I happened to be in the way,’ Alice said, as she helped
+her to put on her shawl again.
+
+The White Queen only looked at her in a helpless frightened sort of way,
+and kept repeating something in a whisper to herself that sounded like
+‘bread-and-butter, bread-and-butter,’ and Alice felt that if there was
+to be any conversation at all, she must manage it herself. So she began
+rather timidly: ‘Am I addressing the White Queen?’
+
+‘Well, yes, if you call that a-dressing,’ The Queen said. ‘It isn’t MY
+notion of the thing, at all.’
+
+Alice thought it would never do to have an argument at the very
+beginning of their conversation, so she smiled and said, ‘If your
+Majesty will only tell me the right way to begin, I’ll do it as well as
+I can.’
+
+‘But I don’t want it done at all!’ groaned the poor Queen. ‘I’ve been
+a-dressing myself for the last two hours.’
+
+It would have been all the better, as it seemed to Alice, if she had got
+some one else to dress her, she was so dreadfully untidy. ‘Every
+single thing’s crooked,’ Alice thought to herself, ‘and she’s all over
+pins!--may I put your shawl straight for you?’ she added aloud.
+
+‘I don’t know what’s the matter with it!’ the Queen said, in a
+melancholy voice. ‘It’s out of temper, I think. I’ve pinned it here, and
+I’ve pinned it there, but there’s no pleasing it!’
+
+‘It CAN’T go straight, you know, if you pin it all on one side,’ Alice
+said, as she gently put it right for her; ‘and, dear me, what a state
+your hair is in!’
+
+‘The brush has got entangled in it!’ the Queen said with a sigh. ‘And I
+lost the comb yesterday.’
+
+Alice carefully released the brush, and did her best to get the hair
+into order. ‘Come, you look rather better now!’ she said, after altering
+most of the pins. ‘But really you should have a lady’s maid!’
+
+‘I’m sure I’ll take you with pleasure!’ the Queen said. ‘Twopence a
+week, and jam every other day.’
+
+Alice couldn’t help laughing, as she said, ‘I don’t want you to hire
+ME--and I don’t care for jam.’
+
+‘It’s very good jam,’ said the Queen.
+
+‘Well, I don’t want any TO-DAY, at any rate.’
+
+‘You couldn’t have it if you DID want it,’ the Queen said. ‘The rule is,
+jam to-morrow and jam yesterday--but never jam to-day.’
+
+‘It MUST come sometimes to “jam to-day,”’ Alice objected.
+
+‘No, it can’t,’ said the Queen. ‘It’s jam every OTHER day: to-day isn’t
+any OTHER day, you know.’
+
+‘I don’t understand you,’ said Alice. ‘It’s dreadfully confusing!’
+
+‘That’s the effect of living backwards,’ the Queen said kindly: ‘it
+always makes one a little giddy at first--’
+
+‘Living backwards!’ Alice repeated in great astonishment. ‘I never heard
+of such a thing!’
+
+‘--but there’s one great advantage in it, that one’s memory works both
+ways.’
+
+‘I’m sure MINE only works one way,’ Alice remarked. ‘I can’t remember
+things before they happen.’
+
+‘It’s a poor sort of memory that only works backwards,’ the Queen
+remarked.
+
+‘What sort of things do YOU remember best?’ Alice ventured to ask.
+
+‘Oh, things that happened the week after next,’ the Queen replied in a
+careless tone. ‘For instance, now,’ she went on, sticking a large piece
+of plaster on her finger as she spoke, ‘there’s the King’s
+Messenger. He’s in prison now, being punished: and the trial doesn’t
+even begin till next Wednesday: and of course the crime comes last of
+all.’
+
+‘Suppose he never commits the crime?’ said Alice.
+
+‘That would be all the better, wouldn’t it?’ the Queen said, as she
+bound the plaster round her finger with a bit of ribbon.
+
+Alice felt there was no denying THAT. ‘Of course it would be all
+the better,’ she said: ‘but it wouldn’t be all the better his being
+punished.’
+
+‘You’re wrong THERE, at any rate,’ said the Queen: ‘were YOU ever
+punished?’
+
+‘Only for faults,’ said Alice.
+
+‘And you were all the better for it, I know!’ the Queen said
+triumphantly.
+
+‘Yes, but then I HAD done the things I was punished for,’ said Alice:
+‘that makes all the difference.’
+
+‘But if you HADN’T done them,’ the Queen said, ‘that would have been
+better still; better, and better, and better!’ Her voice went higher
+with each ‘better,’ till it got quite to a squeak at last.
+
+Alice was just beginning to say ‘There’s a mistake somewhere--,’ when
+the Queen began screaming so loud that she had to leave the sentence
+unfinished. ‘Oh, oh, oh!’ shouted the Queen, shaking her hand about as
+if she wanted to shake it off. ‘My finger’s bleeding! Oh, oh, oh, oh!’
+
+Her screams were so exactly like the whistle of a steam-engine, that
+Alice had to hold both her hands over her ears.
+
+‘What IS the matter?’ she said, as soon as there was a chance of making
+herself heard. ‘Have you pricked your finger?’
+
+‘I haven’t pricked it YET,’ the Queen said, ‘but I soon shall--oh, oh,
+oh!’
+
+‘When do you expect to do it?’ Alice asked, feeling very much inclined
+to laugh.
+
+‘When I fasten my shawl again,’ the poor Queen groaned out: ‘the brooch
+will come undone directly. Oh, oh!’ As she said the words the brooch
+flew open, and the Queen clutched wildly at it, and tried to clasp it
+again.
+
+‘Take care!’ cried Alice. ‘You’re holding it all crooked!’ And she
+caught at the brooch; but it was too late: the pin had slipped, and the
+Queen had pricked her finger.
+
+‘That accounts for the bleeding, you see,’ she said to Alice with a
+smile. ‘Now you understand the way things happen here.’
+
+‘But why don’t you scream now?’ Alice asked, holding her hands ready to
+put over her ears again.
+
+‘Why, I’ve done all the screaming already,’ said the Queen. ‘What would
+be the good of having it all over again?’
+
+By this time it was getting light. ‘The crow must have flown away, I
+think,’ said Alice: ‘I’m so glad it’s gone. I thought it was the night
+coming on.’
+
+‘I wish _I_ could manage to be glad!’ the Queen said. ‘Only I never
+can remember the rule. You must be very happy, living in this wood, and
+being glad whenever you like!’
+
+‘Only it is so VERY lonely here!’ Alice said in a melancholy voice; and
+at the thought of her loneliness two large tears came rolling down her
+cheeks.
+
+‘Oh, don’t go on like that!’ cried the poor Queen, wringing her hands in
+despair. ‘Consider what a great girl you are. Consider what a long way
+you’ve come to-day. Consider what o’clock it is. Consider anything, only
+don’t cry!’
+
+Alice could not help laughing at this, even in the midst of her tears.
+‘Can YOU keep from crying by considering things?’ she asked.
+
+‘That’s the way it’s done,’ the Queen said with great decision: ‘nobody
+can do two things at once, you know. Let’s consider your age to begin
+with--how old are you?’
+
+‘I’m seven and a half exactly.’
+
+‘You needn’t say “exactually,”’ the Queen remarked: ‘I can believe
+it without that. Now I’ll give YOU something to believe. I’m just one
+hundred and one, five months and a day.’
+
+‘I can’t believe THAT!’ said Alice.
+
+‘Can’t you?’ the Queen said in a pitying tone. ‘Try again: draw a long
+breath, and shut your eyes.’
+
+Alice laughed. ‘There’s no use trying,’ she said: ‘one CAN’T believe
+impossible things.’
+
+‘I daresay you haven’t had much practice,’ said the Queen. ‘When I was
+your age, I always did it for half-an-hour a day. Why, sometimes I’ve
+believed as many as six impossible things before breakfast. There goes
+the shawl again!’
+
+The brooch had come undone as she spoke, and a sudden gust of wind blew
+the Queen’s shawl across a little brook. The Queen spread out her arms
+again, and went flying after it, and this time she succeeded in catching
+it for herself. ‘I’ve got it!’ she cried in a triumphant tone. ‘Now you
+shall see me pin it on again, all by myself!’
+
+‘Then I hope your finger is better now?’ Alice said very politely, as
+she crossed the little brook after the Queen.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Oh, much better!’ cried the Queen, her voice rising to a squeak as she
+went on. ‘Much be-etter! Be-etter! Be-e-e-etter! Be-e-ehh!’ The last
+word ended in a long bleat, so like a sheep that Alice quite started.
+
+She looked at the Queen, who seemed to have suddenly wrapped herself up
+in wool. Alice rubbed her eyes, and looked again. She couldn’t make out
+what had happened at all. Was she in a shop? And was that really--was it
+really a SHEEP that was sitting on the other side of the counter? Rub as
+she could, she could make nothing more of it: she was in a little dark
+shop, leaning with her elbows on the counter, and opposite to her was
+an old Sheep, sitting in an arm-chair knitting, and every now and then
+leaving off to look at her through a great pair of spectacles.
+
+‘What is it you want to buy?’ the Sheep said at last, looking up for a
+moment from her knitting.
+
+‘I don’t QUITE know yet,’ Alice said, very gently. ‘I should like to
+look all round me first, if I might.’
+
+‘You may look in front of you, and on both sides, if you like,’ said the
+Sheep: ‘but you can’t look ALL round you--unless you’ve got eyes at the
+back of your head.’
+
+But these, as it happened, Alice had NOT got: so she contented herself
+with turning round, looking at the shelves as she came to them.
+
+The shop seemed to be full of all manner of curious things--but the
+oddest part of it all was, that whenever she looked hard at any shelf,
+to make out exactly what it had on it, that particular shelf was always
+quite empty: though the others round it were crowded as full as they
+could hold.
+
+‘Things flow about so here!’ she said at last in a plaintive tone, after
+she had spent a minute or so in vainly pursuing a large bright thing,
+that looked sometimes like a doll and sometimes like a work-box, and was
+always in the shelf next above the one she was looking at. ‘And this one
+is the most provoking of all--but I’ll tell you what--’ she added, as a
+sudden thought struck her, ‘I’ll follow it up to the very top shelf of
+all. It’ll puzzle it to go through the ceiling, I expect!’
+
+But even this plan failed: the ‘thing’ went through the ceiling as
+quietly as possible, as if it were quite used to it.
+
+‘Are you a child or a teetotum?’ the Sheep said, as she took up another
+pair of needles. ‘You’ll make me giddy soon, if you go on turning round
+like that.’ She was now working with fourteen pairs at once, and Alice
+couldn’t help looking at her in great astonishment.
+
+‘How CAN she knit with so many?’ the puzzled child thought to herself.
+‘She gets more and more like a porcupine every minute!’
+
+‘Can you row?’ the Sheep asked, handing her a pair of knitting-needles
+as she spoke.
+
+‘Yes, a little--but not on land--and not with needles--’ Alice was
+beginning to say, when suddenly the needles turned into oars in her
+hands, and she found they were in a little boat, gliding along between
+banks: so there was nothing for it but to do her best.
+
+‘Feather!’ cried the Sheep, as she took up another pair of needles.
+
+This didn’t sound like a remark that needed any answer, so Alice said
+nothing, but pulled away. There was something very queer about the
+water, she thought, as every now and then the oars got fast in it, and
+would hardly come out again.
+
+‘Feather! Feather!’ the Sheep cried again, taking more needles. ‘You’ll
+be catching a crab directly.’
+
+‘A dear little crab!’ thought Alice. ‘I should like that.’
+
+‘Didn’t you hear me say “Feather”?’ the Sheep cried angrily, taking up
+quite a bunch of needles.
+
+‘Indeed I did,’ said Alice: ‘you’ve said it very often--and very loud.
+Please, where ARE the crabs?’
+
+‘In the water, of course!’ said the Sheep, sticking some of the needles
+into her hair, as her hands were full. ‘Feather, I say!’
+
+‘WHY do you say “feather” so often?’ Alice asked at last, rather vexed.
+‘I’m not a bird!’
+
+‘You are,’ said the Sheep: ‘you’re a little goose.’
+
+This offended Alice a little, so there was no more conversation for a
+minute or two, while the boat glided gently on, sometimes among beds of
+weeds (which made the oars stick fast in the water, worse then ever),
+and sometimes under trees, but always with the same tall river-banks
+frowning over their heads.
+
+‘Oh, please! There are some scented rushes!’ Alice cried in a sudden
+transport of delight. ‘There really are--and SUCH beauties!’
+
+‘You needn’t say “please” to ME about ‘em,’ the Sheep said, without
+looking up from her knitting: ‘I didn’t put ‘em there, and I’m not going
+to take ‘em away.’
+
+‘No, but I meant--please, may we wait and pick some?’ Alice pleaded. ‘If
+you don’t mind stopping the boat for a minute.’
+
+‘How am _I_ to stop it?’ said the Sheep. ‘If you leave off rowing, it’ll
+stop of itself.’
+
+So the boat was left to drift down the stream as it would, till it
+glided gently in among the waving rushes. And then the little sleeves
+were carefully rolled up, and the little arms were plunged in elbow-deep
+to get the rushes a good long way down before breaking them off--and for
+a while Alice forgot all about the Sheep and the knitting, as she
+bent over the side of the boat, with just the ends of her tangled hair
+dipping into the water--while with bright eager eyes she caught at one
+bunch after another of the darling scented rushes.
+
+‘I only hope the boat won’t tipple over!’ she said to herself. ‘Oh, WHAT
+a lovely one! Only I couldn’t quite reach it.’ ‘And it certainly DID
+seem a little provoking (‘almost as if it happened on purpose,’ she
+thought) that, though she managed to pick plenty of beautiful rushes as
+the boat glided by, there was always a more lovely one that she couldn’t
+reach.
+
+‘The prettiest are always further!’ she said at last, with a sigh at the
+obstinacy of the rushes in growing so far off, as, with flushed cheeks
+and dripping hair and hands, she scrambled back into her place, and
+began to arrange her new-found treasures.
+
+What mattered it to her just then that the rushes had begun to fade, and
+to lose all their scent and beauty, from the very moment that she
+picked them? Even real scented rushes, you know, last only a very little
+while--and these, being dream-rushes, melted away almost like snow, as
+they lay in heaps at her feet--but Alice hardly noticed this, there were
+so many other curious things to think about.
+
+They hadn’t gone much farther before the blade of one of the oars got
+fast in the water and WOULDN’T come out again (so Alice explained it
+afterwards), and the consequence was that the handle of it caught her
+under the chin, and, in spite of a series of little shrieks of ‘Oh, oh,
+oh!’ from poor Alice, it swept her straight off the seat, and down among
+the heap of rushes.
+
+However, she wasn’t hurt, and was soon up again: the Sheep went on with
+her knitting all the while, just as if nothing had happened. ‘That was
+a nice crab you caught!’ she remarked, as Alice got back into her place,
+very much relieved to find herself still in the boat.
+
+‘Was it? I didn’t see it,’ Said Alice, peeping cautiously over the side
+of the boat into the dark water. ‘I wish it hadn’t let go--I should
+so like to see a little crab to take home with me!’ But the Sheep only
+laughed scornfully, and went on with her knitting.
+
+‘Are there many crabs here?’ said Alice.
+
+‘Crabs, and all sorts of things,’ said the Sheep: ‘plenty of choice,
+only make up your mind. Now, what DO you want to buy?’
+
+‘To buy!’ Alice echoed in a tone that was half astonished and half
+frightened--for the oars, and the boat, and the river, had vanished all
+in a moment, and she was back again in the little dark shop.
+
+‘I should like to buy an egg, please,’ she said timidly. ‘How do you
+sell them?’
+
+‘Fivepence farthing for one--Twopence for two,’ the Sheep replied.
+
+‘Then two are cheaper than one?’ Alice said in a surprised tone, taking
+out her purse.
+
+‘Only you MUST eat them both, if you buy two,’ said the Sheep.
+
+‘Then I’ll have ONE, please,’ said Alice, as she put the money down on
+the counter. For she thought to herself, ‘They mightn’t be at all nice,
+you know.’
+
+The Sheep took the money, and put it away in a box: then she said ‘I
+never put things into people’s hands--that would never do--you must get
+it for yourself.’ And so saying, she went off to the other end of the
+shop, and set the egg upright on a shelf.
+
+‘I wonder WHY it wouldn’t do?’ thought Alice, as she groped her way
+among the tables and chairs, for the shop was very dark towards the end.
+‘The egg seems to get further away the more I walk towards it. Let me
+see, is this a chair? Why, it’s got branches, I declare! How very odd to
+find trees growing here! And actually here’s a little brook! Well, this
+is the very queerest shop I ever saw!’
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+
+So she went on, wondering more and more at every step, as everything
+turned into a tree the moment she came up to it, and she quite expected
+the egg to do the same.
+
+
+
+
+CHAPTER VI. Humpty Dumpty
+
+However, the egg only got larger and larger, and more and more human:
+when she had come within a few yards of it, she saw that it had eyes
+and a nose and mouth; and when she had come close to it, she saw clearly
+that it was HUMPTY DUMPTY himself. ‘It can’t be anybody else!’ she said
+to herself. ‘I’m as certain of it, as if his name were written all over
+his face.’
+
+It might have been written a hundred times, easily, on that enormous
+face. Humpty Dumpty was sitting with his legs crossed, like a Turk, on
+the top of a high wall--such a narrow one that Alice quite wondered how
+he could keep his balance--and, as his eyes were steadily fixed in the
+opposite direction, and he didn’t take the least notice of her, she
+thought he must be a stuffed figure after all.
+
+‘And how exactly like an egg he is!’ she said aloud, standing with her
+hands ready to catch him, for she was every moment expecting him to
+fall.
+
+‘It’s VERY provoking,’ Humpty Dumpty said after a long silence, looking
+away from Alice as he spoke, ‘to be called an egg--VERY!’
+
+‘I said you LOOKED like an egg, Sir,’ Alice gently explained. ‘And some
+eggs are very pretty, you know’ she added, hoping to turn her remark
+into a sort of a compliment.
+
+‘Some people,’ said Humpty Dumpty, looking away from her as usual, ‘have
+no more sense than a baby!’
+
+Alice didn’t know what to say to this: it wasn’t at all like
+conversation, she thought, as he never said anything to HER; in fact,
+his last remark was evidently addressed to a tree--so she stood and
+softly repeated to herself:--
+
+
+     ‘Humpty Dumpty sat on a wall:
+     Humpty Dumpty had a great fall.
+     All the King’s horses and all the King’s men
+     Couldn’t put Humpty Dumpty in his place again.’
+
+
+‘That last line is much too long for the poetry,’ she added, almost out
+loud, forgetting that Humpty Dumpty would hear her.
+
+‘Don’t stand there chattering to yourself like that,’ Humpty Dumpty
+said, looking at her for the first time, ‘but tell me your name and your
+business.’
+
+‘My NAME is Alice, but--’
+
+‘It’s a stupid enough name!’ Humpty Dumpty interrupted impatiently.
+‘What does it mean?’
+
+‘MUST a name mean something?’ Alice asked doubtfully.
+
+‘Of course it must,’ Humpty Dumpty said with a short laugh: ‘MY name
+means the shape I am--and a good handsome shape it is, too. With a name
+like yours, you might be any shape, almost.’
+
+‘Why do you sit out here all alone?’ said Alice, not wishing to begin an
+argument.
+
+‘Why, because there’s nobody with me!’ cried Humpty Dumpty. ‘Did you
+think I didn’t know the answer to THAT? Ask another.’
+
+‘Don’t you think you’d be safer down on the ground?’ Alice went on, not
+with any idea of making another riddle, but simply in her good-natured
+anxiety for the queer creature. ‘That wall is so VERY narrow!’
+
+‘What tremendously easy riddles you ask!’ Humpty Dumpty growled out. ‘Of
+course I don’t think so! Why, if ever I DID fall off--which there’s no
+chance of--but IF I did--’ Here he pursed up his lips and looked so solemn
+and grand that Alice could hardly help laughing. ‘IF I did fall,’ he
+went on, ‘THE KING HAS PROMISED ME--ah, you may turn pale, if you like!
+You didn’t think I was going to say that, did you? THE KING HAS PROMISED ME--
+WITH HIS VERY OWN MOUTH--to--to--’
+
+‘To send all his horses and all his men,’ Alice interrupted, rather
+unwisely.
+
+‘Now I declare that’s too bad!’ Humpty Dumpty cried, breaking into a
+sudden passion. ‘You’ve been listening at doors--and behind trees--and
+down chimneys--or you couldn’t have known it!’
+
+‘I haven’t, indeed!’ Alice said very gently. ‘It’s in a book.’
+
+‘Ah, well! They may write such things in a BOOK,’ Humpty Dumpty said in
+a calmer tone. ‘That’s what you call a History of England, that is.
+Now, take a good look at me! I’m one that has spoken to a King, _I_ am:
+mayhap you’ll never see such another: and to show you I’m not proud, you
+may shake hands with me!’ And he grinned almost from ear to ear, as he
+leant forwards (and as nearly as possible fell off the wall in doing so)
+and offered Alice his hand. She watched him a little anxiously as she
+took it. ‘If he smiled much more, the ends of his mouth might meet
+behind,’ she thought: ‘and then I don’t know what would happen to his
+head! I’m afraid it would come off!’
+
+‘Yes, all his horses and all his men,’ Humpty Dumpty went on. ‘They’d
+pick me up again in a minute, THEY would! However, this conversation is
+going on a little too fast: let’s go back to the last remark but one.’
+
+‘I’m afraid I can’t quite remember it,’ Alice said very politely.
+
+‘In that case we start fresh,’ said Humpty Dumpty, ‘and it’s my turn
+to choose a subject--’ (‘He talks about it just as if it was a game!’
+thought Alice.) ‘So here’s a question for you. How old did you say you
+were?’
+
+Alice made a short calculation, and said ‘Seven years and six months.’
+
+‘Wrong!’ Humpty Dumpty exclaimed triumphantly. ‘You never said a word
+like it!’
+
+‘I though you meant “How old ARE you?”’ Alice explained.
+
+‘If I’d meant that, I’d have said it,’ said Humpty Dumpty.
+
+Alice didn’t want to begin another argument, so she said nothing.
+
+‘Seven years and six months!’ Humpty Dumpty repeated thoughtfully. ‘An
+uncomfortable sort of age. Now if you’d asked MY advice, I’d have said
+“Leave off at seven”--but it’s too late now.’
+
+‘I never ask advice about growing,’ Alice said indignantly.
+
+‘Too proud?’ the other inquired.
+
+Alice felt even more indignant at this suggestion. ‘I mean,’ she said,
+‘that one can’t help growing older.’
+
+‘ONE can’t, perhaps,’ said Humpty Dumpty, ‘but TWO can. With proper
+assistance, you might have left off at seven.’
+
+‘What a beautiful belt you’ve got on!’ Alice suddenly remarked.
+
+(They had had quite enough of the subject of age, she thought: and if
+they really were to take turns in choosing subjects, it was her turn
+now.) ‘At least,’ she corrected herself on second thoughts, ‘a beautiful
+cravat, I should have said--no, a belt, I mean--I beg your pardon!’ she
+added in dismay, for Humpty Dumpty looked thoroughly offended, and she
+began to wish she hadn’t chosen that subject. ‘If I only knew,’ she
+thought to herself, ‘which was neck and which was waist!’
+
+Evidently Humpty Dumpty was very angry, though he said nothing for a
+minute or two. When he DID speak again, it was in a deep growl.
+
+‘It is a--MOST--PROVOKING--thing,’ he said at last, ‘when a person
+doesn’t know a cravat from a belt!’
+
+‘I know it’s very ignorant of me,’ Alice said, in so humble a tone that
+Humpty Dumpty relented.
+
+‘It’s a cravat, child, and a beautiful one, as you say. It’s a present
+from the White King and Queen. There now!’
+
+‘Is it really?’ said Alice, quite pleased to find that she HAD chosen a
+good subject, after all.
+
+‘They gave it me,’ Humpty Dumpty continued thoughtfully, as he crossed
+one knee over the other and clasped his hands round it, ‘they gave it
+me--for an un-birthday present.’
+
+‘I beg your pardon?’ Alice said with a puzzled air.
+
+‘I’m not offended,’ said Humpty Dumpty.
+
+‘I mean, what IS an un-birthday present?’
+
+‘A present given when it isn’t your birthday, of course.’
+
+Alice considered a little. ‘I like birthday presents best,’ she said at
+last.
+
+‘You don’t know what you’re talking about!’ cried Humpty Dumpty. ‘How
+many days are there in a year?’
+
+‘Three hundred and sixty-five,’ said Alice.
+
+‘And how many birthdays have you?’
+
+‘One.’
+
+‘And if you take one from three hundred and sixty-five, what remains?’
+
+‘Three hundred and sixty-four, of course.’
+
+Humpty Dumpty looked doubtful. ‘I’d rather see that done on paper,’ he
+said.
+
+Alice couldn’t help smiling as she took out her memorandum-book, and
+worked the sum for him:
+
+
+               365
+                1
+               ____
+
+               364
+               ___
+
+Humpty Dumpty took the book, and looked at it carefully. ‘That seems to
+be done right--’ he began.
+
+‘You’re holding it upside down!’ Alice interrupted.
+
+‘To be sure I was!’ Humpty Dumpty said gaily, as she turned it round for
+him. ‘I thought it looked a little queer. As I was saying, that SEEMS
+to be done right--though I haven’t time to look it over thoroughly just
+now--and that shows that there are three hundred and sixty-four days
+when you might get un-birthday presents--’
+
+‘Certainly,’ said Alice.
+
+‘And only ONE for birthday presents, you know. There’s glory for you!’
+
+‘I don’t know what you mean by “glory,”’ Alice said.
+
+Humpty Dumpty smiled contemptuously. ‘Of course you don’t--till I tell
+you. I meant “there’s a nice knock-down argument for you!”’
+
+‘But “glory” doesn’t mean “a nice knock-down argument,”’ Alice objected.
+
+‘When _I_ use a word,’ Humpty Dumpty said in rather a scornful tone, ‘it
+means just what I choose it to mean--neither more nor less.’
+
+‘The question is,’ said Alice, ‘whether you CAN make words mean so many
+different things.’
+
+‘The question is,’ said Humpty Dumpty, ‘which is to be master--that’s
+all.’
+
+Alice was too much puzzled to say anything, so after a minute Humpty
+Dumpty began again. ‘They’ve a temper, some of them--particularly verbs,
+they’re the proudest--adjectives you can do anything with, but not
+verbs--however, _I_ can manage the whole lot of them! Impenetrability!
+That’s what _I_ say!’
+
+‘Would you tell me, please,’ said Alice ‘what that means?’
+
+‘Now you talk like a reasonable child,’ said Humpty Dumpty, looking very
+much pleased. ‘I meant by “impenetrability” that we’ve had enough of
+that subject, and it would be just as well if you’d mention what you
+mean to do next, as I suppose you don’t mean to stop here all the rest
+of your life.’
+
+‘That’s a great deal to make one word mean,’ Alice said in a thoughtful
+tone.
+
+‘When I make a word do a lot of work like that,’ said Humpty Dumpty, ‘I
+always pay it extra.’
+
+‘Oh!’ said Alice. She was too much puzzled to make any other remark.
+
+‘Ah, you should see ‘em come round me of a Saturday night,’ Humpty
+Dumpty went on, wagging his head gravely from side to side: ‘for to get
+their wages, you know.’
+
+(Alice didn’t venture to ask what he paid them with; and so you see I
+can’t tell YOU.)
+
+‘You seem very clever at explaining words, Sir,’ said Alice. ‘Would you
+kindly tell me the meaning of the poem called “Jabberwocky”?’
+
+‘Let’s hear it,’ said Humpty Dumpty. ‘I can explain all the poems that
+were ever invented--and a good many that haven’t been invented just
+yet.’
+
+This sounded very hopeful, so Alice repeated the first verse:
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+‘That’s enough to begin with,’ Humpty Dumpty interrupted: ‘there
+are plenty of hard words there. “BRILLIG” means four o’clock in the
+afternoon--the time when you begin BROILING things for dinner.’
+
+‘That’ll do very well,’ said Alice: ‘and “SLITHY”?’
+
+‘Well, “SLITHY” means “lithe and slimy.” “Lithe” is the same as
+“active.” You see it’s like a portmanteau--there are two meanings packed
+up into one word.’
+
+‘I see it now,’ Alice remarked thoughtfully: ‘and what are “TOVES”?’
+
+‘Well, “TOVES” are something like badgers--they’re something like
+lizards--and they’re something like corkscrews.’
+
+‘They must be very curious looking creatures.’
+
+‘They are that,’ said Humpty Dumpty: ‘also they make their nests under
+sun-dials--also they live on cheese.’
+
+‘And what’s the “GYRE” and to “GIMBLE”?’
+
+‘To “GYRE” is to go round and round like a gyroscope. To “GIMBLE” is to
+make holes like a gimlet.’
+
+‘And “THE WABE” is the grass-plot round a sun-dial, I suppose?’ said
+Alice, surprised at her own ingenuity.
+
+‘Of course it is. It’s called “WABE,” you know, because it goes a long
+way before it, and a long way behind it--’
+
+‘And a long way beyond it on each side,’ Alice added.
+
+‘Exactly so. Well, then, “MIMSY” is “flimsy and miserable” (there’s
+another portmanteau for you). And a “BOROGOVE” is a thin shabby-looking
+bird with its feathers sticking out all round--something like a live
+mop.’
+
+‘And then “MOME RATHS”?’ said Alice. ‘I’m afraid I’m giving you a great
+deal of trouble.’
+
+‘Well, a “RATH” is a sort of green pig: but “MOME” I’m not certain
+about. I think it’s short for “from home”--meaning that they’d lost
+their way, you know.’
+
+‘And what does “OUTGRABE” mean?’
+
+‘Well, “OUTGRABING” is something between bellowing and whistling, with a
+kind of sneeze in the middle: however, you’ll hear it done, maybe--down
+in the wood yonder--and when you’ve once heard it you’ll be QUITE
+content. Who’s been repeating all that hard stuff to you?’
+
+‘I read it in a book,’ said Alice. ‘But I had some poetry repeated to
+me, much easier than that, by--Tweedledee, I think it was.’
+
+‘As to poetry, you know,’ said Humpty Dumpty, stretching out one of his
+great hands, ‘_I_ can repeat poetry as well as other folk, if it comes
+to that--’
+
+‘Oh, it needn’t come to that!’ Alice hastily said, hoping to keep him
+from beginning.
+
+‘The piece I’m going to repeat,’ he went on without noticing her remark,
+‘was written entirely for your amusement.’
+
+Alice felt that in that case she really OUGHT to listen to it, so she
+sat down, and said ‘Thank you’ rather sadly.
+
+
+     ‘In winter, when the fields are white,
+     I sing this song for your delight--
+
+
+only I don’t sing it,’ he added, as an explanation.
+
+‘I see you don’t,’ said Alice.
+
+‘If you can SEE whether I’m singing or not, you’ve sharper eyes than
+most.’ Humpty Dumpty remarked severely. Alice was silent.
+
+
+     ‘In spring, when woods are getting green,
+     I’ll try and tell you what I mean.’
+
+
+‘Thank you very much,’ said Alice.
+
+
+     ‘In summer, when the days are long,
+     Perhaps you’ll understand the song:
+     In autumn, when the leaves are brown,
+     Take pen and ink, and write it down.’
+
+
+‘I will, if I can remember it so long,’ said Alice.
+
+‘You needn’t go on making remarks like that,’ Humpty Dumpty said:
+‘they’re not sensible, and they put me out.’
+
+     ‘I sent a message to the fish:
+     I told them “This is what I wish.”
+
+     The little fishes of the sea,
+     They sent an answer back to me.
+
+     The little fishes’ answer was
+     “We cannot do it, Sir, because--“’
+
+
+‘I’m afraid I don’t quite understand,’ said Alice.
+
+‘It gets easier further on,’ Humpty Dumpty replied.
+
+
+     ‘I sent to them again to say
+     “It will be better to obey.”
+
+     The fishes answered with a grin,
+     “Why, what a temper you are in!”
+
+     I told them once, I told them twice:
+     They would not listen to advice.
+
+     I took a kettle large and new,
+     Fit for the deed I had to do.
+
+     My heart went hop, my heart went thump;
+     I filled the kettle at the pump.
+
+     Then some one came to me and said,
+     “The little fishes are in bed.”
+
+     I said to him, I said it plain,
+     “Then you must wake them up again.”
+
+     I said it very loud and clear;
+     I went and shouted in his ear.’
+
+
+Humpty Dumpty raised his voice almost to a scream as he repeated this
+verse, and Alice thought with a shudder, ‘I wouldn’t have been the
+messenger for ANYTHING!’
+
+
+     ‘But he was very stiff and proud;
+     He said “You needn’t shout so loud!”
+
+     And he was very proud and stiff;
+     He said “I’d go and wake them, if--”
+
+     I took a corkscrew from the shelf:
+     I went to wake them up myself.
+
+     And when I found the door was locked,
+     I pulled and pushed and kicked and knocked.
+
+     And when I found the door was shut,
+     I tried to turn the handle, but--’
+
+
+There was a long pause.
+
+‘Is that all?’ Alice timidly asked.
+
+‘That’s all,’ said Humpty Dumpty. ‘Good-bye.’
+
+This was rather sudden, Alice thought: but, after such a VERY strong
+hint that she ought to be going, she felt that it would hardly be civil
+to stay. So she got up, and held out her hand. ‘Good-bye, till we meet
+again!’ she said as cheerfully as she could.
+
+‘I shouldn’t know you again if we DID meet,’ Humpty Dumpty replied in
+a discontented tone, giving her one of his fingers to shake; ‘you’re so
+exactly like other people.’
+
+‘The face is what one goes by, generally,’ Alice remarked in a
+thoughtful tone.
+
+‘That’s just what I complain of,’ said Humpty Dumpty. ‘Your face is the
+same as everybody has--the two eyes, so--’ (marking their places in the
+air with this thumb) ‘nose in the middle, mouth under. It’s always the
+same. Now if you had the two eyes on the same side of the nose, for
+instance--or the mouth at the top--that would be SOME help.’
+
+‘It wouldn’t look nice,’ Alice objected. But Humpty Dumpty only shut his
+eyes and said ‘Wait till you’ve tried.’
+
+Alice waited a minute to see if he would speak again, but as he never
+opened his eyes or took any further notice of her, she said ‘Good-bye!’
+once more, and, getting no answer to this, she quietly walked away:
+but she couldn’t help saying to herself as she went, ‘Of all the
+unsatisfactory--’ (she repeated this aloud, as it was a great comfort to
+have such a long word to say) ‘of all the unsatisfactory people I EVER
+met--’ She never finished the sentence, for at this moment a heavy crash
+shook the forest from end to end.
+
+
+
+
+CHAPTER VII. The Lion and the Unicorn
+
+The next moment soldiers came running through the wood, at first in twos
+and threes, then ten or twenty together, and at last in such crowds that
+they seemed to fill the whole forest. Alice got behind a tree, for fear
+of being run over, and watched them go by.
+
+She thought that in all her life she had never seen soldiers so
+uncertain on their feet: they were always tripping over something or
+other, and whenever one went down, several more always fell over him, so
+that the ground was soon covered with little heaps of men.
+
+Then came the horses. Having four feet, these managed rather better than
+the foot-soldiers: but even THEY stumbled now and then; and it seemed
+to be a regular rule that, whenever a horse stumbled the rider fell off
+instantly. The confusion got worse every moment, and Alice was very glad
+to get out of the wood into an open place, where she found the White
+King seated on the ground, busily writing in his memorandum-book.
+
+‘I’ve sent them all!’ the King cried in a tone of delight, on seeing
+Alice. ‘Did you happen to meet any soldiers, my dear, as you came
+through the wood?’
+
+‘Yes, I did,’ said Alice: ‘several thousand, I should think.’
+
+‘Four thousand two hundred and seven, that’s the exact number,’ the King
+said, referring to his book. ‘I couldn’t send all the horses, you know,
+because two of them are wanted in the game. And I haven’t sent the two
+Messengers, either. They’re both gone to the town. Just look along the
+road, and tell me if you can see either of them.’
+
+‘I see nobody on the road,’ said Alice.
+
+‘I only wish _I_ had such eyes,’ the King remarked in a fretful tone.
+‘To be able to see Nobody! And at that distance, too! Why, it’s as much
+as _I_ can do to see real people, by this light!’
+
+All this was lost on Alice, who was still looking intently along
+the road, shading her eyes with one hand. ‘I see somebody now!’ she
+exclaimed at last. ‘But he’s coming very slowly--and what curious
+attitudes he goes into!’ (For the messenger kept skipping up and down,
+and wriggling like an eel, as he came along, with his great hands spread
+out like fans on each side.)
+
+‘Not at all,’ said the King. ‘He’s an Anglo-Saxon Messenger--and those
+are Anglo-Saxon attitudes. He only does them when he’s happy. His name
+is Haigha.’ (He pronounced it so as to rhyme with ‘mayor.’)
+
+‘I love my love with an H,’ Alice couldn’t help beginning, ‘because
+he is Happy. I hate him with an H, because he is Hideous. I fed him
+with--with--with Ham-sandwiches and Hay. His name is Haigha, and he
+lives--’
+
+‘He lives on the Hill,’ the King remarked simply, without the least idea
+that he was joining in the game, while Alice was still hesitating for
+the name of a town beginning with H. ‘The other Messenger’s called
+Hatta. I must have TWO, you know--to come and go. One to come, and one
+to go.’
+
+‘I beg your pardon?’ said Alice.
+
+‘It isn’t respectable to beg,’ said the King.
+
+‘I only meant that I didn’t understand,’ said Alice. ‘Why one to come
+and one to go?’
+
+‘Didn’t I tell you?’ the King repeated impatiently. ‘I must have Two--to
+fetch and carry. One to fetch, and one to carry.’
+
+At this moment the Messenger arrived: he was far too much out of breath
+to say a word, and could only wave his hands about, and make the most
+fearful faces at the poor King.
+
+‘This young lady loves you with an H,’ the King said, introducing Alice
+in the hope of turning off the Messenger’s attention from himself--but
+it was no use--the Anglo-Saxon attitudes only got more extraordinary
+every moment, while the great eyes rolled wildly from side to side.
+
+‘You alarm me!’ said the King. ‘I feel faint--Give me a ham sandwich!’
+
+On which the Messenger, to Alice’s great amusement, opened a bag that
+hung round his neck, and handed a sandwich to the King, who devoured it
+greedily.
+
+‘Another sandwich!’ said the King.
+
+‘There’s nothing but hay left now,’ the Messenger said, peeping into the
+bag.
+
+‘Hay, then,’ the King murmured in a faint whisper.
+
+Alice was glad to see that it revived him a good deal. ‘There’s nothing
+like eating hay when you’re faint,’ he remarked to her, as he munched
+away.
+
+‘I should think throwing cold water over you would be better,’ Alice
+suggested: ‘or some sal-volatile.’
+
+‘I didn’t say there was nothing BETTER,’ the King replied. ‘I said there
+was nothing LIKE it.’ Which Alice did not venture to deny.
+
+‘Who did you pass on the road?’ the King went on, holding out his hand
+to the Messenger for some more hay.
+
+‘Nobody,’ said the Messenger.
+
+‘Quite right,’ said the King: ‘this young lady saw him too. So of course
+Nobody walks slower than you.’
+
+‘I do my best,’ the Messenger said in a sulky tone. ‘I’m sure nobody
+walks much faster than I do!’
+
+‘He can’t do that,’ said the King, ‘or else he’d have been here first.
+However, now you’ve got your breath, you may tell us what’s happened in
+the town.’
+
+‘I’ll whisper it,’ said the Messenger, putting his hands to his mouth
+in the shape of a trumpet, and stooping so as to get close to the King’s
+ear. Alice was sorry for this, as she wanted to hear the news too.
+However, instead of whispering, he simply shouted at the top of his
+voice ‘They’re at it again!’
+
+‘Do you call THAT a whisper?’ cried the poor King, jumping up and
+shaking himself. ‘If you do such a thing again, I’ll have you buttered!
+It went through and through my head like an earthquake!’
+
+‘It would have to be a very tiny earthquake!’ thought Alice. ‘Who are at
+it again?’ she ventured to ask.
+
+‘Why the Lion and the Unicorn, of course,’ said the King.
+
+‘Fighting for the crown?’
+
+‘Yes, to be sure,’ said the King: ‘and the best of the joke is, that
+it’s MY crown all the while! Let’s run and see them.’ And they trotted
+off, Alice repeating to herself, as she ran, the words of the old
+song:--
+
+
+   ‘The Lion and the Unicorn were fighting for the crown:
+   The Lion beat the Unicorn all round the town.
+   Some gave them white bread, some gave them brown;
+   Some gave them plum-cake and drummed them out of town.’
+
+
+‘Does--the one--that wins--get the crown?’ she asked, as well as she
+could, for the run was putting her quite out of breath.
+
+‘Dear me, no!’ said the King. ‘What an idea!’
+
+‘Would you--be good enough,’ Alice panted out, after running a little
+further, ‘to stop a minute--just to get--one’s breath again?’
+
+‘I’m GOOD enough,’ the King said, ‘only I’m not strong enough. You see,
+a minute goes by so fearfully quick. You might as well try to stop a
+Bandersnatch!’
+
+Alice had no more breath for talking, so they trotted on in silence,
+till they came in sight of a great crowd, in the middle of which the
+Lion and Unicorn were fighting. They were in such a cloud of dust, that
+at first Alice could not make out which was which: but she soon managed
+to distinguish the Unicorn by his horn.
+
+They placed themselves close to where Hatta, the other messenger, was
+standing watching the fight, with a cup of tea in one hand and a piece
+of bread-and-butter in the other.
+
+‘He’s only just out of prison, and he hadn’t finished his tea when
+he was sent in,’ Haigha whispered to Alice: ‘and they only give them
+oyster-shells in there--so you see he’s very hungry and thirsty. How
+are you, dear child?’ he went on, putting his arm affectionately round
+Hatta’s neck.
+
+Hatta looked round and nodded, and went on with his bread and butter.
+
+‘Were you happy in prison, dear child?’ said Haigha.
+
+Hatta looked round once more, and this time a tear or two trickled down
+his cheek: but not a word would he say.
+
+‘Speak, can’t you!’ Haigha cried impatiently. But Hatta only munched
+away, and drank some more tea.
+
+‘Speak, won’t you!’ cried the King. ‘How are they getting on with the
+fight?’
+
+Hatta made a desperate effort, and swallowed a large piece of
+bread-and-butter. ‘They’re getting on very well,’ he said in a choking
+voice: ‘each of them has been down about eighty-seven times.’
+
+‘Then I suppose they’ll soon bring the white bread and the brown?’ Alice
+ventured to remark.
+
+‘It’s waiting for ‘em now,’ said Hatta: ‘this is a bit of it as I’m
+eating.’
+
+There was a pause in the fight just then, and the Lion and the Unicorn
+sat down, panting, while the King called out ‘Ten minutes allowed for
+refreshments!’ Haigha and Hatta set to work at once, carrying rough
+trays of white and brown bread. Alice took a piece to taste, but it was
+VERY dry.
+
+‘I don’t think they’ll fight any more to-day,’ the King said to Hatta:
+‘go and order the drums to begin.’ And Hatta went bounding away like a
+grasshopper.
+
+For a minute or two Alice stood silent, watching him. Suddenly she
+brightened up. ‘Look, look!’ she cried, pointing eagerly. ‘There’s the
+White Queen running across the country! She came flying out of the wood
+over yonder--How fast those Queens CAN run!’
+
+‘There’s some enemy after her, no doubt,’ the King said, without even
+looking round. ‘That wood’s full of them.’
+
+‘But aren’t you going to run and help her?’ Alice asked, very much
+surprised at his taking it so quietly.
+
+‘No use, no use!’ said the King. ‘She runs so fearfully quick. You might
+as well try to catch a Bandersnatch! But I’ll make a memorandum about
+her, if you like--She’s a dear good creature,’ he repeated softly to
+himself, as he opened his memorandum-book. ‘Do you spell “creature” with
+a double “e”?’
+
+At this moment the Unicorn sauntered by them, with his hands in his
+pockets. ‘I had the best of it this time?’ he said to the King, just
+glancing at him as he passed.
+
+‘A little--a little,’ the King replied, rather nervously. ‘You shouldn’t
+have run him through with your horn, you know.’
+
+‘It didn’t hurt him,’ the Unicorn said carelessly, and he was going
+on, when his eye happened to fall upon Alice: he turned round rather
+instantly, and stood for some time looking at her with an air of the
+deepest disgust.
+
+‘What--is--this?’ he said at last.
+
+‘This is a child!’ Haigha replied eagerly, coming in front of Alice
+to introduce her, and spreading out both his hands towards her in an
+Anglo-Saxon attitude. ‘We only found it to-day. It’s as large as life,
+and twice as natural!’
+
+‘I always thought they were fabulous monsters!’ said the Unicorn. ‘Is it
+alive?’
+
+‘It can talk,’ said Haigha, solemnly.
+
+The Unicorn looked dreamily at Alice, and said ‘Talk, child.’
+
+Alice could not help her lips curling up into a smile as she began: ‘Do
+you know, I always thought Unicorns were fabulous monsters, too! I never
+saw one alive before!’
+
+‘Well, now that we HAVE seen each other,’ said the Unicorn, ‘if you’ll
+believe in me, I’ll believe in you. Is that a bargain?’
+
+‘Yes, if you like,’ said Alice.
+
+‘Come, fetch out the plum-cake, old man!’ the Unicorn went on, turning
+from her to the King. ‘None of your brown bread for me!’
+
+‘Certainly--certainly!’ the King muttered, and beckoned to Haigha. ‘Open
+the bag!’ he whispered. ‘Quick! Not that one--that’s full of hay!’
+
+Haigha took a large cake out of the bag, and gave it to Alice to hold,
+while he got out a dish and carving-knife. How they all came out of it
+Alice couldn’t guess. It was just like a conjuring-trick, she thought.
+
+The Lion had joined them while this was going on: he looked very
+tired and sleepy, and his eyes were half shut. ‘What’s this!’ he said,
+blinking lazily at Alice, and speaking in a deep hollow tone that
+sounded like the tolling of a great bell.
+
+‘Ah, what IS it, now?’ the Unicorn cried eagerly. ‘You’ll never guess!
+_I_ couldn’t.’
+
+The Lion looked at Alice wearily. ‘Are you animal--vegetable--or
+mineral?’ he said, yawning at every other word.
+
+‘It’s a fabulous monster!’ the Unicorn cried out, before Alice could
+reply.
+
+‘Then hand round the plum-cake, Monster,’ the Lion said, lying down and
+putting his chin on his paws. ‘And sit down, both of you,’ (to the King
+and the Unicorn): ‘fair play with the cake, you know!’
+
+The King was evidently very uncomfortable at having to sit down between
+the two great creatures; but there was no other place for him.
+
+‘What a fight we might have for the crown, NOW!’ the Unicorn said,
+looking slyly up at the crown, which the poor King was nearly shaking
+off his head, he trembled so much.
+
+‘I should win easy,’ said the Lion.
+
+‘I’m not so sure of that,’ said the Unicorn.
+
+‘Why, I beat you all round the town, you chicken!’ the Lion replied
+angrily, half getting up as he spoke.
+
+Here the King interrupted, to prevent the quarrel going on: he was very
+nervous, and his voice quite quivered. ‘All round the town?’ he
+said. ‘That’s a good long way. Did you go by the old bridge, or the
+market-place? You get the best view by the old bridge.’
+
+‘I’m sure I don’t know,’ the Lion growled out as he lay down again.
+‘There was too much dust to see anything. What a time the Monster is,
+cutting up that cake!’
+
+Alice had seated herself on the bank of a little brook, with the great
+dish on her knees, and was sawing away diligently with the knife. ‘It’s
+very provoking!’ she said, in reply to the Lion (she was getting quite
+used to being called ‘the Monster’). ‘I’ve cut several slices already,
+but they always join on again!’
+
+‘You don’t know how to manage Looking-glass cakes,’ the Unicorn
+remarked. ‘Hand it round first, and cut it afterwards.’
+
+This sounded nonsense, but Alice very obediently got up, and carried the
+dish round, and the cake divided itself into three pieces as she did so.
+‘NOW cut it up,’ said the Lion, as she returned to her place with the
+empty dish.
+
+‘I say, this isn’t fair!’ cried the Unicorn, as Alice sat with the knife
+in her hand, very much puzzled how to begin. ‘The Monster has given the
+Lion twice as much as me!’
+
+‘She’s kept none for herself, anyhow,’ said the Lion. ‘Do you like
+plum-cake, Monster?’
+
+But before Alice could answer him, the drums began.
+
+Where the noise came from, she couldn’t make out: the air seemed full
+of it, and it rang through and through her head till she felt quite
+deafened. She started to her feet and sprang across the little brook in
+her terror,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and had just time to see the Lion and the Unicorn rise to their feet,
+with angry looks at being interrupted in their feast, before she dropped
+to her knees, and put her hands over her ears, vainly trying to shut out
+the dreadful uproar.
+
+‘If THAT doesn’t “drum them out of town,”’ she thought to herself,
+‘nothing ever will!’
+
+
+
+
+CHAPTER VIII. ‘It’s my own Invention’
+
+After a while the noise seemed gradually to die away, till all was dead
+silence, and Alice lifted up her head in some alarm. There was no one
+to be seen, and her first thought was that she must have been dreaming
+about the Lion and the Unicorn and those queer Anglo-Saxon Messengers.
+However, there was the great dish still lying at her feet, on which she
+had tried to cut the plum-cake, ‘So I wasn’t dreaming, after all,’ she
+said to herself, ‘unless--unless we’re all part of the same dream. Only
+I do hope it’s MY dream, and not the Red King’s! I don’t like belonging
+to another person’s dream,’ she went on in a rather complaining tone:
+‘I’ve a great mind to go and wake him, and see what happens!’
+
+At this moment her thoughts were interrupted by a loud shouting of
+‘Ahoy! Ahoy! Check!’ and a Knight dressed in crimson armour came
+galloping down upon her, brandishing a great club. Just as he reached
+her, the horse stopped suddenly: ‘You’re my prisoner!’ the Knight cried,
+as he tumbled off his horse.
+
+Startled as she was, Alice was more frightened for him than for herself
+at the moment, and watched him with some anxiety as he mounted again.
+As soon as he was comfortably in the saddle, he began once more ‘You’re
+my--’ but here another voice broke in ‘Ahoy! Ahoy! Check!’ and Alice
+looked round in some surprise for the new enemy.
+
+This time it was a White Knight. He drew up at Alice’s side, and tumbled
+off his horse just as the Red Knight had done: then he got on again,
+and the two Knights sat and looked at each other for some time without
+speaking. Alice looked from one to the other in some bewilderment.
+
+‘She’s MY prisoner, you know!’ the Red Knight said at last.
+
+‘Yes, but then _I_ came and rescued her!’ the White Knight replied.
+
+‘Well, we must fight for her, then,’ said the Red Knight, as he took up
+his helmet (which hung from the saddle, and was something the shape of a
+horse’s head), and put it on.
+
+‘You will observe the Rules of Battle, of course?’ the White Knight
+remarked, putting on his helmet too.
+
+‘I always do,’ said the Red Knight, and they began banging away at each
+other with such fury that Alice got behind a tree to be out of the way
+of the blows.
+
+‘I wonder, now, what the Rules of Battle are,’ she said to herself, as
+she watched the fight, timidly peeping out from her hiding-place: ‘one
+Rule seems to be, that if one Knight hits the other, he knocks him off
+his horse, and if he misses, he tumbles off himself--and another Rule
+seems to be that they hold their clubs with their arms, as if they were
+Punch and Judy--What a noise they make when they tumble! Just like
+a whole set of fire-irons falling into the fender! And how quiet the
+horses are! They let them get on and off them just as if they were
+tables!’
+
+Another Rule of Battle, that Alice had not noticed, seemed to be that
+they always fell on their heads, and the battle ended with their both
+falling off in this way, side by side: when they got up again, they
+shook hands, and then the Red Knight mounted and galloped off.
+
+‘It was a glorious victory, wasn’t it?’ said the White Knight, as he
+came up panting.
+
+‘I don’t know,’ Alice said doubtfully. ‘I don’t want to be anybody’s
+prisoner. I want to be a Queen.’
+
+‘So you will, when you’ve crossed the next brook,’ said the White
+Knight. ‘I’ll see you safe to the end of the wood--and then I must go
+back, you know. That’s the end of my move.’
+
+‘Thank you very much,’ said Alice. ‘May I help you off with your
+helmet?’ It was evidently more than he could manage by himself; however,
+she managed to shake him out of it at last.
+
+‘Now one can breathe more easily,’ said the Knight, putting back his
+shaggy hair with both hands, and turning his gentle face and large mild
+eyes to Alice. She thought she had never seen such a strange-looking
+soldier in all her life.
+
+He was dressed in tin armour, which seemed to fit him very badly, and
+he had a queer-shaped little deal box fastened across his shoulder,
+upside-down, and with the lid hanging open. Alice looked at it with
+great curiosity.
+
+‘I see you’re admiring my little box.’ the Knight said in a friendly
+tone. ‘It’s my own invention--to keep clothes and sandwiches in. You see
+I carry it upside-down, so that the rain can’t get in.’
+
+‘But the things can get OUT,’ Alice gently remarked. ‘Do you know the
+lid’s open?’
+
+‘I didn’t know it,’ the Knight said, a shade of vexation passing over
+his face. ‘Then all the things must have fallen out! And the box is no
+use without them.’ He unfastened it as he spoke, and was just going to
+throw it into the bushes, when a sudden thought seemed to strike him,
+and he hung it carefully on a tree. ‘Can you guess why I did that?’ he
+said to Alice.
+
+Alice shook her head.
+
+‘In hopes some bees may make a nest in it--then I should get the honey.’
+
+‘But you’ve got a bee-hive--or something like one--fastened to the
+saddle,’ said Alice.
+
+‘Yes, it’s a very good bee-hive,’ the Knight said in a discontented
+tone, ‘one of the best kind. But not a single bee has come near it yet.
+And the other thing is a mouse-trap. I suppose the mice keep the bees
+out--or the bees keep the mice out, I don’t know which.’
+
+‘I was wondering what the mouse-trap was for,’ said Alice. ‘It isn’t
+very likely there would be any mice on the horse’s back.’
+
+‘Not very likely, perhaps,’ said the Knight: ‘but if they DO come, I
+don’t choose to have them running all about.’
+
+‘You see,’ he went on after a pause, ‘it’s as well to be provided for
+EVERYTHING. That’s the reason the horse has all those anklets round his
+feet.’
+
+‘But what are they for?’ Alice asked in a tone of great curiosity.
+
+‘To guard against the bites of sharks,’ the Knight replied. ‘It’s an
+invention of my own. And now help me on. I’ll go with you to the end of
+the wood--What’s the dish for?’
+
+‘It’s meant for plum-cake,’ said Alice.
+
+‘We’d better take it with us,’ the Knight said. ‘It’ll come in handy if
+we find any plum-cake. Help me to get it into this bag.’
+
+This took a very long time to manage, though Alice held the bag open
+very carefully, because the Knight was so VERY awkward in putting in
+the dish: the first two or three times that he tried he fell in himself
+instead. ‘It’s rather a tight fit, you see,’ he said, as they got it in
+a last; ‘There are so many candlesticks in the bag.’ And he hung it
+to the saddle, which was already loaded with bunches of carrots, and
+fire-irons, and many other things.
+
+‘I hope you’ve got your hair well fastened on?’ he continued, as they
+set off.
+
+‘Only in the usual way,’ Alice said, smiling.
+
+‘That’s hardly enough,’ he said, anxiously. ‘You see the wind is so VERY
+strong here. It’s as strong as soup.’
+
+‘Have you invented a plan for keeping the hair from being blown off?’
+Alice enquired.
+
+‘Not yet,’ said the Knight. ‘But I’ve got a plan for keeping it from
+FALLING off.’
+
+‘I should like to hear it, very much.’
+
+‘First you take an upright stick,’ said the Knight. ‘Then you make your
+hair creep up it, like a fruit-tree. Now the reason hair falls off is
+because it hangs DOWN--things never fall UPWARDS, you know. It’s a plan
+of my own invention. You may try it if you like.’
+
+It didn’t sound a comfortable plan, Alice thought, and for a few minutes
+she walked on in silence, puzzling over the idea, and every now and then
+stopping to help the poor Knight, who certainly was NOT a good rider.
+
+Whenever the horse stopped (which it did very often), he fell off in
+front; and whenever it went on again (which it generally did rather
+suddenly), he fell off behind. Otherwise he kept on pretty well, except
+that he had a habit of now and then falling off sideways; and as he
+generally did this on the side on which Alice was walking, she soon
+found that it was the best plan not to walk QUITE close to the horse.
+
+‘I’m afraid you’ve not had much practice in riding,’ she ventured to
+say, as she was helping him up from his fifth tumble.
+
+The Knight looked very much surprised, and a little offended at the
+remark. ‘What makes you say that?’ he asked, as he scrambled back into
+the saddle, keeping hold of Alice’s hair with one hand, to save himself
+from falling over on the other side.
+
+‘Because people don’t fall off quite so often, when they’ve had much
+practice.’
+
+‘I’ve had plenty of practice,’ the Knight said very gravely: ‘plenty of
+practice!’
+
+Alice could think of nothing better to say than ‘Indeed?’ but she said
+it as heartily as she could. They went on a little way in silence after
+this, the Knight with his eyes shut, muttering to himself, and Alice
+watching anxiously for the next tumble.
+
+‘The great art of riding,’ the Knight suddenly began in a loud voice,
+waving his right arm as he spoke, ‘is to keep--’ Here the sentence ended
+as suddenly as it had begun, as the Knight fell heavily on the top of
+his head exactly in the path where Alice was walking. She was quite
+frightened this time, and said in an anxious tone, as she picked him up,
+‘I hope no bones are broken?’
+
+‘None to speak of,’ the Knight said, as if he didn’t mind breaking two
+or three of them. ‘The great art of riding, as I was saying, is--to keep
+your balance properly. Like this, you know--’
+
+He let go the bridle, and stretched out both his arms to show Alice
+what he meant, and this time he fell flat on his back, right under the
+horse’s feet.
+
+‘Plenty of practice!’ he went on repeating, all the time that Alice was
+getting him on his feet again. ‘Plenty of practice!’
+
+‘It’s too ridiculous!’ cried Alice, losing all her patience this time.
+‘You ought to have a wooden horse on wheels, that you ought!’
+
+‘Does that kind go smoothly?’ the Knight asked in a tone of great
+interest, clasping his arms round the horse’s neck as he spoke, just in
+time to save himself from tumbling off again.
+
+‘Much more smoothly than a live horse,’ Alice said, with a little scream
+of laughter, in spite of all she could do to prevent it.
+
+‘I’ll get one,’ the Knight said thoughtfully to himself. ‘One or
+two--several.’
+
+There was a short silence after this, and then the Knight went on again.
+‘I’m a great hand at inventing things. Now, I daresay you noticed, that
+last time you picked me up, that I was looking rather thoughtful?’
+
+‘You WERE a little grave,’ said Alice.
+
+‘Well, just then I was inventing a new way of getting over a gate--would
+you like to hear it?’
+
+‘Very much indeed,’ Alice said politely.
+
+‘I’ll tell you how I came to think of it,’ said the Knight. ‘You see, I
+said to myself, “The only difficulty is with the feet: the HEAD is high
+enough already.” Now, first I put my head on the top of the gate--then I
+stand on my head--then the feet are high enough, you see--then I’m over,
+you see.’
+
+‘Yes, I suppose you’d be over when that was done,’ Alice said
+thoughtfully: ‘but don’t you think it would be rather hard?’
+
+‘I haven’t tried it yet,’ the Knight said, gravely: ‘so I can’t tell for
+certain--but I’m afraid it WOULD be a little hard.’
+
+He looked so vexed at the idea, that Alice changed the subject hastily.
+‘What a curious helmet you’ve got!’ she said cheerfully. ‘Is that your
+invention too?’
+
+The Knight looked down proudly at his helmet, which hung from the
+saddle. ‘Yes,’ he said, ‘but I’ve invented a better one than that--like
+a sugar loaf. When I used to wear it, if I fell off the horse, it always
+touched the ground directly. So I had a VERY little way to fall, you
+see--But there WAS the danger of falling INTO it, to be sure. That
+happened to me once--and the worst of it was, before I could get out
+again, the other White Knight came and put it on. He thought it was his
+own helmet.’
+
+The knight looked so solemn about it that Alice did not dare to laugh.
+‘I’m afraid you must have hurt him,’ she said in a trembling voice,
+‘being on the top of his head.’
+
+‘I had to kick him, of course,’ the Knight said, very seriously. ‘And
+then he took the helmet off again--but it took hours and hours to get me
+out. I was as fast as--as lightning, you know.’
+
+‘But that’s a different kind of fastness,’ Alice objected.
+
+The Knight shook his head. ‘It was all kinds of fastness with me, I can
+assure you!’ he said. He raised his hands in some excitement as he said
+this, and instantly rolled out of the saddle, and fell headlong into a
+deep ditch.
+
+Alice ran to the side of the ditch to look for him. She was rather
+startled by the fall, as for some time he had kept on very well, and she
+was afraid that he really WAS hurt this time. However, though she could
+see nothing but the soles of his feet, she was much relieved to hear
+that he was talking on in his usual tone. ‘All kinds of fastness,’
+he repeated: ‘but it was careless of him to put another man’s helmet
+on--with the man in it, too.’
+
+‘How CAN you go on talking so quietly, head downwards?’ Alice asked, as
+she dragged him out by the feet, and laid him in a heap on the bank.
+
+The Knight looked surprised at the question. ‘What does it matter where
+my body happens to be?’ he said. ‘My mind goes on working all the same.
+In fact, the more head downwards I am, the more I keep inventing new
+things.’
+
+‘Now the cleverest thing of the sort that I ever did,’ he went on after
+a pause, ‘was inventing a new pudding during the meat-course.’
+
+‘In time to have it cooked for the next course?’ said Alice. ‘Well,
+not the NEXT course,’ the Knight said in a slow thoughtful tone: ‘no,
+certainly not the next COURSE.’
+
+‘Then it would have to be the next day. I suppose you wouldn’t have two
+pudding-courses in one dinner?’
+
+‘Well, not the NEXT day,’ the Knight repeated as before: ‘not the next
+DAY. In fact,’ he went on, holding his head down, and his voice getting
+lower and lower, ‘I don’t believe that pudding ever WAS cooked! In fact,
+I don’t believe that pudding ever WILL be cooked! And yet it was a very
+clever pudding to invent.’
+
+‘What did you mean it to be made of?’ Alice asked, hoping to cheer him
+up, for the poor Knight seemed quite low-spirited about it.
+
+‘It began with blotting paper,’ the Knight answered with a groan.
+
+‘That wouldn’t be very nice, I’m afraid--’
+
+‘Not very nice ALONE,’ he interrupted, quite eagerly: ‘but you’ve no
+idea what a difference it makes mixing it with other things--such as
+gunpowder and sealing-wax. And here I must leave you.’ They had just
+come to the end of the wood.
+
+Alice could only look puzzled: she was thinking of the pudding.
+
+‘You are sad,’ the Knight said in an anxious tone: ‘let me sing you a
+song to comfort you.’
+
+‘Is it very long?’ Alice asked, for she had heard a good deal of poetry
+that day.
+
+‘It’s long,’ said the Knight, ‘but very, VERY beautiful. Everybody that
+hears me sing it--either it brings the TEARS into their eyes, or else--’
+
+‘Or else what?’ said Alice, for the Knight had made a sudden pause.
+
+‘Or else it doesn’t, you know. The name of the song is called “HADDOCKS’
+EYES.”’
+
+‘Oh, that’s the name of the song, is it?’ Alice said, trying to feel
+interested.
+
+‘No, you don’t understand,’ the Knight said, looking a little vexed.
+‘That’s what the name is CALLED. The name really IS “THE AGED AGED
+MAN.”’
+
+‘Then I ought to have said “That’s what the SONG is called”?’ Alice
+corrected herself.
+
+‘No, you oughtn’t: that’s quite another thing! The SONG is called “WAYS
+AND MEANS”: but that’s only what it’s CALLED, you know!’
+
+‘Well, what IS the song, then?’ said Alice, who was by this time
+completely bewildered.
+
+‘I was coming to that,’ the Knight said. ‘The song really IS “A-SITTING
+ON A GATE”: and the tune’s my own invention.’
+
+So saying, he stopped his horse and let the reins fall on its neck:
+then, slowly beating time with one hand, and with a faint smile lighting
+up his gentle foolish face, as if he enjoyed the music of his song, he
+began.
+
+Of all the strange things that Alice saw in her journey Through The
+Looking-Glass, this was the one that she always remembered most clearly.
+Years afterwards she could bring the whole scene back again, as if it
+had been only yesterday--the mild blue eyes and kindly smile of the
+Knight--the setting sun gleaming through his hair, and shining on his
+armour in a blaze of light that quite dazzled her--the horse quietly
+moving about, with the reins hanging loose on his neck, cropping the
+grass at her feet--and the black shadows of the forest behind--all this
+she took in like a picture, as, with one hand shading her eyes, she
+leant against a tree, watching the strange pair, and listening, in a
+half dream, to the melancholy music of the song.
+
+‘But the tune ISN’T his own invention,’ she said to herself: ‘it’s “I
+GIVE THEE ALL, I CAN NO MORE.”’ She stood and listened very attentively,
+but no tears came into her eyes.
+
+
+     ‘I’ll tell thee everything I can;
+      There’s little to relate.
+     I saw an aged aged man,
+      A-sitting on a gate.
+     “Who are you, aged man?” I said,
+      “and how is it you live?”
+      And his answer trickled through my head
+      Like water through a sieve.
+
+     He said “I look for butterflies
+      That sleep among the wheat:
+     I make them into mutton-pies,
+      And sell them in the street.
+     I sell them unto men,” he said,
+      “Who sail on stormy seas;
+     And that’s the way I get my bread--
+      A trifle, if you please.”
+
+     But I was thinking of a plan
+      To dye one’s whiskers green,
+     And always use so large a fan
+      That they could not be seen.
+     So, having no reply to give
+      To what the old man said,
+     I cried, “Come, tell me how you live!”
+       And thumped him on the head.
+
+     His accents mild took up the tale:
+      He said “I go my ways,
+     And when I find a mountain-rill,
+      I set it in a blaze;
+     And thence they make a stuff they call
+      Rolands’ Macassar Oil--
+     Yet twopence-halfpenny is all
+      They give me for my toil.”
+
+     But I was thinking of a way
+      To feed oneself on batter,
+     And so go on from day to day
+      Getting a little fatter.
+     I shook him well from side to side,
+      Until his face was blue:
+     “Come, tell me how you live,” I cried,
+      “And what it is you do!”
+
+     He said “I hunt for haddocks’ eyes
+      Among the heather bright,
+     And work them into waistcoat-buttons
+      In the silent night.
+     And these I do not sell for gold
+      Or coin of silvery shine
+     But for a copper halfpenny,
+      And that will purchase nine.
+
+     “I sometimes dig for buttered rolls,
+      Or set limed twigs for crabs;
+     I sometimes search the grassy knolls
+      For wheels of Hansom-cabs.
+     And that’s the way” (he gave a wink)
+      “By which I get my wealth--
+     And very gladly will I drink
+      Your Honour’s noble health.”
+
+     I heard him then, for I had just
+      Completed my design
+     To keep the Menai bridge from rust
+      By boiling it in wine.
+     I thanked him much for telling me
+      The way he got his wealth,
+     But chiefly for his wish that he
+      Might drink my noble health.
+
+     And now, if e’er by chance I put
+      My fingers into glue
+     Or madly squeeze a right-hand foot
+      Into a left-hand shoe,
+     Or if I drop upon my toe
+      A very heavy weight,
+     I weep, for it reminds me so,
+      Of that old man I used to know--
+
+     Whose look was mild, whose speech was slow,
+     Whose hair was whiter than the snow,
+     Whose face was very like a crow,
+     With eyes, like cinders, all aglow,
+     Who seemed distracted with his woe,
+     Who rocked his body to and fro,
+     And muttered mumblingly and low,
+     As if his mouth were full of dough,
+     Who snorted like a buffalo--
+     That summer evening, long ago,
+      A-sitting on a gate.’
+
+
+As the Knight sang the last words of the ballad, he gathered up the
+reins, and turned his horse’s head along the road by which they had
+come. ‘You’ve only a few yards to go,’ he said, ‘down the hill and over
+that little brook, and then you’ll be a Queen--But you’ll stay and
+see me off first?’ he added as Alice turned with an eager look in the
+direction to which he pointed. ‘I shan’t be long. You’ll wait and wave
+your handkerchief when I get to that turn in the road? I think it’ll
+encourage me, you see.’
+
+‘Of course I’ll wait,’ said Alice: ‘and thank you very much for coming
+so far--and for the song--I liked it very much.’
+
+‘I hope so,’ the Knight said doubtfully: ‘but you didn’t cry so much as
+I thought you would.’
+
+So they shook hands, and then the Knight rode slowly away into the
+forest. ‘It won’t take long to see him OFF, I expect,’ Alice said to
+herself, as she stood watching him. ‘There he goes! Right on his head as
+usual! However, he gets on again pretty easily--that comes of having so
+many things hung round the horse--’ So she went on talking to herself,
+as she watched the horse walking leisurely along the road, and the
+Knight tumbling off, first on one side and then on the other. After
+the fourth or fifth tumble he reached the turn, and then she waved her
+handkerchief to him, and waited till he was out of sight.
+
+‘I hope it encouraged him,’ she said, as she turned to run down the
+hill: ‘and now for the last brook, and to be a Queen! How grand it
+sounds!’ A very few steps brought her to the edge of the brook. ‘The
+Eighth Square at last!’ she cried as she bounded across,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and threw herself down to rest on a lawn as soft as moss, with little
+flower-beds dotted about it here and there. ‘Oh, how glad I am to get
+here! And what IS this on my head?’ she exclaimed in a tone of dismay,
+as she put her hands up to something very heavy, and fitted tight all
+round her head.
+
+‘But how CAN it have got there without my knowing it?’ she said to
+herself, as she lifted it off, and set it on her lap to make out what it
+could possibly be.
+
+It was a golden crown.
+
+
+
+
+CHAPTER IX. Queen Alice
+
+‘Well, this IS grand!’ said Alice. ‘I never expected I should be a Queen
+so soon--and I’ll tell you what it is, your majesty,’ she went on in
+a severe tone (she was always rather fond of scolding herself), ‘it’ll
+never do for you to be lolling about on the grass like that! Queens have
+to be dignified, you know!’
+
+So she got up and walked about--rather stiffly just at first, as she was
+afraid that the crown might come off: but she comforted herself with the
+thought that there was nobody to see her, ‘and if I really am a Queen,’
+she said as she sat down again, ‘I shall be able to manage it quite well
+in time.’
+
+Everything was happening so oddly that she didn’t feel a bit surprised
+at finding the Red Queen and the White Queen sitting close to her, one
+on each side: she would have liked very much to ask them how they came
+there, but she feared it would not be quite civil. However, there would
+be no harm, she thought, in asking if the game was over. ‘Please, would
+you tell me--’ she began, looking timidly at the Red Queen.
+
+‘Speak when you’re spoken to!’ The Queen sharply interrupted her.
+
+‘But if everybody obeyed that rule,’ said Alice, who was always ready
+for a little argument, ‘and if you only spoke when you were spoken to,
+and the other person always waited for YOU to begin, you see nobody
+would ever say anything, so that--’
+
+‘Ridiculous!’ cried the Queen. ‘Why, don’t you see, child--’ here she
+broke off with a frown, and, after thinking for a minute, suddenly
+changed the subject of the conversation. ‘What do you mean by “If you
+really are a Queen”? What right have you to call yourself so? You can’t
+be a Queen, you know, till you’ve passed the proper examination. And the
+sooner we begin it, the better.’
+
+‘I only said “if”!’ poor Alice pleaded in a piteous tone.
+
+The two Queens looked at each other, and the Red Queen remarked, with a
+little shudder, ‘She SAYS she only said “if”--’
+
+‘But she said a great deal more than that!’ the White Queen moaned,
+wringing her hands. ‘Oh, ever so much more than that!’
+
+‘So you did, you know,’ the Red Queen said to Alice. ‘Always speak the
+truth--think before you speak--and write it down afterwards.’
+
+‘I’m sure I didn’t mean--’ Alice was beginning, but the Red Queen
+interrupted her impatiently.
+
+‘That’s just what I complain of! You SHOULD have meant! What do you
+suppose is the use of child without any meaning? Even a joke should
+have some meaning--and a child’s more important than a joke, I hope. You
+couldn’t deny that, even if you tried with both hands.’
+
+‘I don’t deny things with my HANDS,’ Alice objected.
+
+‘Nobody said you did,’ said the Red Queen. ‘I said you couldn’t if you
+tried.’
+
+‘She’s in that state of mind,’ said the White Queen, ‘that she wants to
+deny SOMETHING--only she doesn’t know what to deny!’
+
+‘A nasty, vicious temper,’ the Red Queen remarked; and then there was an
+uncomfortable silence for a minute or two.
+
+The Red Queen broke the silence by saying to the White Queen, ‘I invite
+you to Alice’s dinner-party this afternoon.’
+
+The White Queen smiled feebly, and said ‘And I invite YOU.’
+
+‘I didn’t know I was to have a party at all,’ said Alice; ‘but if there
+is to be one, I think _I_ ought to invite the guests.’
+
+‘We gave you the opportunity of doing it,’ the Red Queen remarked: ‘but
+I daresay you’ve not had many lessons in manners yet?’
+
+‘Manners are not taught in lessons,’ said Alice. ‘Lessons teach you to
+do sums, and things of that sort.’
+
+‘And you do Addition?’ the White Queen asked. ‘What’s one and one and
+one and one and one and one and one and one and one and one?’
+
+‘I don’t know,’ said Alice. ‘I lost count.’
+
+‘She can’t do Addition,’ the Red Queen interrupted. ‘Can you do
+Subtraction? Take nine from eight.’
+
+‘Nine from eight I can’t, you know,’ Alice replied very readily: ‘but--’
+
+‘She can’t do Subtraction,’ said the White Queen. ‘Can you do Division?
+Divide a loaf by a knife--what’s the answer to that?’
+
+‘I suppose--’ Alice was beginning, but the Red Queen answered for her.
+‘Bread-and-butter, of course. Try another Subtraction sum. Take a bone
+from a dog: what remains?’
+
+Alice considered. ‘The bone wouldn’t remain, of course, if I took
+it--and the dog wouldn’t remain; it would come to bite me--and I’m sure
+I shouldn’t remain!’
+
+‘Then you think nothing would remain?’ said the Red Queen.
+
+‘I think that’s the answer.’
+
+‘Wrong, as usual,’ said the Red Queen: ‘the dog’s temper would remain.’
+
+‘But I don’t see how--’
+
+‘Why, look here!’ the Red Queen cried. ‘The dog would lose its temper,
+wouldn’t it?’
+
+‘Perhaps it would,’ Alice replied cautiously.
+
+‘Then if the dog went away, its temper would remain!’ the Queen
+exclaimed triumphantly.
+
+Alice said, as gravely as she could, ‘They might go different ways.’ But
+she couldn’t help thinking to herself, ‘What dreadful nonsense we ARE
+talking!’
+
+‘She can’t do sums a BIT!’ the Queens said together, with great
+emphasis.
+
+‘Can YOU do sums?’ Alice said, turning suddenly on the White Queen, for
+she didn’t like being found fault with so much.
+
+The Queen gasped and shut her eyes. ‘I can do Addition, if you give me
+time--but I can’t do Subtraction, under ANY circumstances!’
+
+‘Of course you know your A B C?’ said the Red Queen.
+
+‘To be sure I do.’ said Alice.
+
+‘So do I,’ the White Queen whispered: ‘we’ll often say it over together,
+dear. And I’ll tell you a secret--I can read words of one letter! Isn’t
+THAT grand! However, don’t be discouraged. You’ll come to it in time.’
+
+Here the Red Queen began again. ‘Can you answer useful questions?’ she
+said. ‘How is bread made?’
+
+‘I know THAT!’ Alice cried eagerly. ‘You take some flour--’
+
+‘Where do you pick the flower?’ the White Queen asked. ‘In a garden, or
+in the hedges?’
+
+‘Well, it isn’t PICKED at all,’ Alice explained: ‘it’s GROUND--’
+
+‘How many acres of ground?’ said the White Queen. ‘You mustn’t leave out
+so many things.’
+
+‘Fan her head!’ the Red Queen anxiously interrupted. ‘She’ll be feverish
+after so much thinking.’ So they set to work and fanned her with bunches
+of leaves, till she had to beg them to leave off, it blew her hair about
+so.
+
+‘She’s all right again now,’ said the Red Queen. ‘Do you know Languages?
+What’s the French for fiddle-de-dee?’
+
+‘Fiddle-de-dee’s not English,’ Alice replied gravely.
+
+‘Who ever said it was?’ said the Red Queen.
+
+Alice thought she saw a way out of the difficulty this time. ‘If you’ll
+tell me what language “fiddle-de-dee” is, I’ll tell you the French for
+it!’ she exclaimed triumphantly.
+
+But the Red Queen drew herself up rather stiffly, and said ‘Queens never
+make bargains.’
+
+‘I wish Queens never asked questions,’ Alice thought to herself.
+
+‘Don’t let us quarrel,’ the White Queen said in an anxious tone. ‘What
+is the cause of lightning?’
+
+‘The cause of lightning,’ Alice said very decidedly, for she felt quite
+certain about this, ‘is the thunder--no, no!’ she hastily corrected
+herself. ‘I meant the other way.’
+
+‘It’s too late to correct it,’ said the Red Queen: ‘when you’ve once
+said a thing, that fixes it, and you must take the consequences.’
+
+‘Which reminds me--’ the White Queen said, looking down and nervously
+clasping and unclasping her hands, ‘we had SUCH a thunderstorm last
+Tuesday--I mean one of the last set of Tuesdays, you know.’
+
+Alice was puzzled. ‘In OUR country,’ she remarked, ‘there’s only one day
+at a time.’
+
+The Red Queen said, ‘That’s a poor thin way of doing things. Now HERE,
+we mostly have days and nights two or three at a time, and sometimes
+in the winter we take as many as five nights together--for warmth, you
+know.’
+
+‘Are five nights warmer than one night, then?’ Alice ventured to ask.
+
+‘Five times as warm, of course.’
+
+‘But they should be five times as COLD, by the same rule--’
+
+‘Just so!’ cried the Red Queen. ‘Five times as warm, AND five times
+as cold--just as I’m five times as rich as you are, AND five times as
+clever!’
+
+Alice sighed and gave it up. ‘It’s exactly like a riddle with no
+answer!’ she thought.
+
+‘Humpty Dumpty saw it too,’ the White Queen went on in a low voice, more
+as if she were talking to herself. ‘He came to the door with a corkscrew
+in his hand--’
+
+‘What did he want?’ said the Red Queen.
+
+‘He said he WOULD come in,’ the White Queen went on, ‘because he was
+looking for a hippopotamus. Now, as it happened, there wasn’t such a
+thing in the house, that morning.’
+
+‘Is there generally?’ Alice asked in an astonished tone.
+
+‘Well, only on Thursdays,’ said the Queen.
+
+‘I know what he came for,’ said Alice: ‘he wanted to punish the fish,
+because--’
+
+Here the White Queen began again. ‘It was SUCH a thunderstorm, you can’t
+think!’ (‘She NEVER could, you know,’ said the Red Queen.) ‘And part of
+the roof came off, and ever so much thunder got in--and it went
+rolling round the room in great lumps--and knocking over the tables and
+things--till I was so frightened, I couldn’t remember my own name!’
+
+Alice thought to herself, ‘I never should TRY to remember my name in the
+middle of an accident! Where would be the use of it?’ but she did not
+say this aloud, for fear of hurting the poor Queen’s feeling.
+
+‘Your Majesty must excuse her,’ the Red Queen said to Alice, taking
+one of the White Queen’s hands in her own, and gently stroking it:
+‘she means well, but she can’t help saying foolish things, as a general
+rule.’
+
+The White Queen looked timidly at Alice, who felt she OUGHT to say
+something kind, but really couldn’t think of anything at the moment.
+
+‘She never was really well brought up,’ the Red Queen went on: ‘but
+it’s amazing how good-tempered she is! Pat her on the head, and see how
+pleased she’ll be!’ But this was more than Alice had courage to do.
+
+‘A little kindness--and putting her hair in papers--would do wonders
+with her--’
+
+The White Queen gave a deep sigh, and laid her head on Alice’s shoulder.
+‘I AM so sleepy?’ she moaned.
+
+‘She’s tired, poor thing!’ said the Red Queen. ‘Smooth her hair--lend
+her your nightcap--and sing her a soothing lullaby.’
+
+‘I haven’t got a nightcap with me,’ said Alice, as she tried to obey the
+first direction: ‘and I don’t know any soothing lullabies.’
+
+‘I must do it myself, then,’ said the Red Queen, and she began:
+
+
+   ‘Hush-a-by lady, in Alice’s lap!
+   Till the feast’s ready, we’ve time for a nap:
+   When the feast’s over, we’ll go to the ball--
+   Red Queen, and White Queen, and Alice, and all!
+
+
+‘And now you know the words,’ she added, as she put her head down on
+Alice’s other shoulder, ‘just sing it through to ME. I’m getting sleepy,
+too.’ In another moment both Queens were fast asleep, and snoring loud.
+
+‘What AM I to do?’ exclaimed Alice, looking about in great perplexity,
+as first one round head, and then the other, rolled down from her
+shoulder, and lay like a heavy lump in her lap. ‘I don’t think it EVER
+happened before, that any one had to take care of two Queens asleep
+at once! No, not in all the History of England--it couldn’t, you know,
+because there never was more than one Queen at a time. Do wake up, you
+heavy things!’ she went on in an impatient tone; but there was no answer
+but a gentle snoring.
+
+The snoring got more distinct every minute, and sounded more like a
+tune: at last she could even make out the words, and she listened so
+eagerly that, when the two great heads vanished from her lap, she hardly
+missed them.
+
+She was standing before an arched doorway over which were the words
+QUEEN ALICE in large letters, and on each side of the arch there was a
+bell-handle; one was marked ‘Visitors’ Bell,’ and the other ‘Servants’
+Bell.’
+
+‘I’ll wait till the song’s over,’ thought Alice, ‘and then I’ll
+ring--the--WHICH bell must I ring?’ she went on, very much puzzled by
+the names. ‘I’m not a visitor, and I’m not a servant. There OUGHT to be
+one marked “Queen,” you know--’
+
+Just then the door opened a little way, and a creature with a long beak
+put its head out for a moment and said ‘No admittance till the week
+after next!’ and shut the door again with a bang.
+
+Alice knocked and rang in vain for a long time, but at last, a very old
+Frog, who was sitting under a tree, got up and hobbled slowly towards
+her: he was dressed in bright yellow, and had enormous boots on.
+
+‘What is it, now?’ the Frog said in a deep hoarse whisper.
+
+Alice turned round, ready to find fault with anybody. ‘Where’s the
+servant whose business it is to answer the door?’ she began angrily.
+
+‘Which door?’ said the Frog.
+
+Alice almost stamped with irritation at the slow drawl in which he
+spoke. ‘THIS door, of course!’
+
+The Frog looked at the door with his large dull eyes for a minute:
+then he went nearer and rubbed it with his thumb, as if he were trying
+whether the paint would come off; then he looked at Alice.
+
+‘To answer the door?’ he said. ‘What’s it been asking of?’ He was so
+hoarse that Alice could scarcely hear him.
+
+‘I don’t know what you mean,’ she said.
+
+‘I talks English, doesn’t I?’ the Frog went on. ‘Or are you deaf? What
+did it ask you?’
+
+‘Nothing!’ Alice said impatiently. ‘I’ve been knocking at it!’
+
+‘Shouldn’t do that--shouldn’t do that--’ the Frog muttered. ‘Vexes it,
+you know.’ Then he went up and gave the door a kick with one of his
+great feet. ‘You let IT alone,’ he panted out, as he hobbled back to his
+tree, ‘and it’ll let YOU alone, you know.’
+
+At this moment the door was flung open, and a shrill voice was heard
+singing:
+
+
+   ‘To the Looking-Glass world it was Alice that said,
+   “I’ve a sceptre in hand, I’ve a crown on my head;
+   Let the Looking-Glass creatures, whatever they be,
+   Come and dine with the Red Queen, the White Queen, and me.”’
+
+
+And hundreds of voices joined in the chorus:
+
+
+  ‘Then fill up the glasses as quick as you can,
+  And sprinkle the table with buttons and bran:
+  Put cats in the coffee, and mice in the tea--
+  And welcome Queen Alice with thirty-times-three!’
+
+
+Then followed a confused noise of cheering, and Alice thought to
+herself, ‘Thirty times three makes ninety. I wonder if any one’s
+counting?’ In a minute there was silence again, and the same shrill
+voice sang another verse;
+
+
+  ‘“O Looking-Glass creatures,” quoth Alice, “draw near!
+  ‘Tis an honour to see me, a favour to hear:
+  ‘Tis a privilege high to have dinner and tea
+  Along with the Red Queen, the White Queen, and me!”’
+
+
+Then came the chorus again:--
+
+
+  ‘Then fill up the glasses with treacle and ink,
+  Or anything else that is pleasant to drink:
+  Mix sand with the cider, and wool with the wine--
+  And welcome Queen Alice with ninety-times-nine!’
+
+
+‘Ninety times nine!’ Alice repeated in despair, ‘Oh, that’ll never
+be done! I’d better go in at once--’ and there was a dead silence the
+moment she appeared.
+
+Alice glanced nervously along the table, as she walked up the large
+hall, and noticed that there were about fifty guests, of all kinds: some
+were animals, some birds, and there were even a few flowers among them.
+‘I’m glad they’ve come without waiting to be asked,’ she thought: ‘I
+should never have known who were the right people to invite!’
+
+There were three chairs at the head of the table; the Red and White
+Queens had already taken two of them, but the middle one was empty.
+Alice sat down in it, rather uncomfortable in the silence, and longing
+for some one to speak.
+
+At last the Red Queen began. ‘You’ve missed the soup and fish,’ she
+said. ‘Put on the joint!’ And the waiters set a leg of mutton before
+Alice, who looked at it rather anxiously, as she had never had to carve
+a joint before.
+
+‘You look a little shy; let me introduce you to that leg of mutton,’
+said the Red Queen. ‘Alice--Mutton; Mutton--Alice.’ The leg of mutton
+got up in the dish and made a little bow to Alice; and Alice returned
+the bow, not knowing whether to be frightened or amused.
+
+‘May I give you a slice?’ she said, taking up the knife and fork, and
+looking from one Queen to the other.
+
+‘Certainly not,’ the Red Queen said, very decidedly: ‘it isn’t etiquette
+to cut any one you’ve been introduced to. Remove the joint!’ And the
+waiters carried it off, and brought a large plum-pudding in its place.
+
+‘I won’t be introduced to the pudding, please,’ Alice said rather
+hastily, ‘or we shall get no dinner at all. May I give you some?’
+
+But the Red Queen looked sulky, and growled ‘Pudding--Alice;
+Alice--Pudding. Remove the pudding!’ and the waiters took it away so
+quickly that Alice couldn’t return its bow.
+
+However, she didn’t see why the Red Queen should be the only one to give
+orders, so, as an experiment, she called out ‘Waiter! Bring back the
+pudding!’ and there it was again in a moment like a conjuring-trick. It
+was so large that she couldn’t help feeling a LITTLE shy with it, as she
+had been with the mutton; however, she conquered her shyness by a great
+effort and cut a slice and handed it to the Red Queen.
+
+‘What impertinence!’ said the Pudding. ‘I wonder how you’d like it, if I
+were to cut a slice out of YOU, you creature!’
+
+It spoke in a thick, suety sort of voice, and Alice hadn’t a word to say
+in reply: she could only sit and look at it and gasp.
+
+‘Make a remark,’ said the Red Queen: ‘it’s ridiculous to leave all the
+conversation to the pudding!’
+
+‘Do you know, I’ve had such a quantity of poetry repeated to me to-day,’
+Alice began, a little frightened at finding that, the moment she opened
+her lips, there was dead silence, and all eyes were fixed upon her; ‘and
+it’s a very curious thing, I think--every poem was about fishes in some
+way. Do you know why they’re so fond of fishes, all about here?’
+
+She spoke to the Red Queen, whose answer was a little wide of the mark.
+‘As to fishes,’ she said, very slowly and solemnly, putting her mouth
+close to Alice’s ear, ‘her White Majesty knows a lovely riddle--all in
+poetry--all about fishes. Shall she repeat it?’
+
+‘Her Red Majesty’s very kind to mention it,’ the White Queen murmured
+into Alice’s other ear, in a voice like the cooing of a pigeon. ‘It
+would be SUCH a treat! May I?’
+
+‘Please do,’ Alice said very politely.
+
+The White Queen laughed with delight, and stroked Alice’s cheek. Then
+she began:
+
+
+    ‘“First, the fish must be caught.”
+   That is easy: a baby, I think, could have caught it.
+    “Next, the fish must be bought.”
+   That is easy: a penny, I think, would have bought it.
+
+    “Now cook me the fish!”
+   That is easy, and will not take more than a minute.
+    “Let it lie in a dish!”
+   That is easy, because it already is in it.
+
+    “Bring it here! Let me sup!”
+   It is easy to set such a dish on the table.
+    “Take the dish-cover up!”
+   Ah, THAT is so hard that I fear I’m unable!
+
+    For it holds it like glue--
+  Holds the lid to the dish, while it lies in the middle:
+    Which is easiest to do,
+  Un-dish-cover the fish, or dishcover the riddle?’
+
+
+‘Take a minute to think about it, and then guess,’ said the Red Queen.
+‘Meanwhile, we’ll drink your health--Queen Alice’s health!’ she screamed
+at the top of her voice, and all the guests began drinking it directly,
+and very queerly they managed it: some of them put their glasses upon
+their heads like extinguishers, and drank all that trickled down their
+faces--others upset the decanters, and drank the wine as it ran off
+the edges of the table--and three of them (who looked like kangaroos)
+scrambled into the dish of roast mutton, and began eagerly lapping up
+the gravy, ‘just like pigs in a trough!’ thought Alice.
+
+‘You ought to return thanks in a neat speech,’ the Red Queen said,
+frowning at Alice as she spoke.
+
+‘We must support you, you know,’ the White Queen whispered, as Alice got
+up to do it, very obediently, but a little frightened.
+
+‘Thank you very much,’ she whispered in reply, ‘but I can do quite well
+without.’
+
+‘That wouldn’t be at all the thing,’ the Red Queen said very decidedly:
+so Alice tried to submit to it with a good grace.
+
+(‘And they DID push so!’ she said afterwards, when she was telling her
+sister the history of the feast. ‘You would have thought they wanted to
+squeeze me flat!’)
+
+In fact it was rather difficult for her to keep in her place while she
+made her speech: the two Queens pushed her so, one on each side, that
+they nearly lifted her up into the air: ‘I rise to return thanks--’
+Alice began: and she really DID rise as she spoke, several inches; but
+she got hold of the edge of the table, and managed to pull herself down
+again.
+
+‘Take care of yourself!’ screamed the White Queen, seizing Alice’s hair
+with both her hands. ‘Something’s going to happen!’
+
+And then (as Alice afterwards described it) all sorts of things happened
+in a moment. The candles all grew up to the ceiling, looking something
+like a bed of rushes with fireworks at the top. As to the bottles, they
+each took a pair of plates, which they hastily fitted on as wings, and
+so, with forks for legs, went fluttering about in all directions: ‘and
+very like birds they look,’ Alice thought to herself, as well as she
+could in the dreadful confusion that was beginning.
+
+At this moment she heard a hoarse laugh at her side, and turned to see
+what was the matter with the White Queen; but, instead of the Queen,
+there was the leg of mutton sitting in the chair. ‘Here I am!’ cried a
+voice from the soup tureen, and Alice turned again, just in time to see
+the Queen’s broad good-natured face grinning at her for a moment over
+the edge of the tureen, before she disappeared into the soup.
+
+There was not a moment to be lost. Already several of the guests were
+lying down in the dishes, and the soup ladle was walking up the table
+towards Alice’s chair, and beckoning to her impatiently to get out of
+its way.
+
+‘I can’t stand this any longer!’ she cried as she jumped up and seized
+the table-cloth with both hands: one good pull, and plates, dishes,
+guests, and candles came crashing down together in a heap on the floor.
+
+‘And as for YOU,’ she went on, turning fiercely upon the Red Queen, whom
+she considered as the cause of all the mischief--but the Queen was no
+longer at her side--she had suddenly dwindled down to the size of a
+little doll, and was now on the table, merrily running round and round
+after her own shawl, which was trailing behind her.
+
+At any other time, Alice would have felt surprised at this, but she was
+far too much excited to be surprised at anything NOW. ‘As for YOU,’
+she repeated, catching hold of the little creature in the very act of
+jumping over a bottle which had just lighted upon the table, ‘I’ll shake
+you into a kitten, that I will!’
+
+
+
+
+CHAPTER X. Shaking
+
+She took her off the table as she spoke, and shook her backwards and
+forwards with all her might.
+
+The Red Queen made no resistance whatever; only her face grew very
+small, and her eyes got large and green: and still, as Alice went on
+shaking her, she kept on growing shorter--and fatter--and softer--and
+rounder--and--
+
+
+
+
+CHAPTER XI. Waking
+
+--and it really WAS a kitten, after all.
+
+
+
+
+CHAPTER XII. Which Dreamed it?
+
+‘Your majesty shouldn’t purr so loud,’ Alice said, rubbing her eyes, and
+addressing the kitten, respectfully, yet with some severity. ‘You
+woke me out of oh! such a nice dream! And you’ve been along with me,
+Kitty--all through the Looking-Glass world. Did you know it, dear?’
+
+It is a very inconvenient habit of kittens (Alice had once made the
+remark) that, whatever you say to them, they ALWAYS purr. ‘If they would
+only purr for “yes” and mew for “no,” or any rule of that sort,’ she had
+said, ‘so that one could keep up a conversation! But how CAN you talk
+with a person if they always say the same thing?’
+
+On this occasion the kitten only purred: and it was impossible to guess
+whether it meant ‘yes’ or ‘no.’
+
+So Alice hunted among the chessmen on the table till she had found the
+Red Queen: then she went down on her knees on the hearth-rug, and put
+the kitten and the Queen to look at each other. ‘Now, Kitty!’ she cried,
+clapping her hands triumphantly. ‘Confess that was what you turned
+into!’
+
+(‘But it wouldn’t look at it,’ she said, when she was explaining the
+thing afterwards to her sister: ‘it turned away its head, and pretended
+not to see it: but it looked a LITTLE ashamed of itself, so I think it
+MUST have been the Red Queen.’)
+
+‘Sit up a little more stiffly, dear!’ Alice cried with a merry laugh.
+‘And curtsey while you’re thinking what to--what to purr. It saves time,
+remember!’ And she caught it up and gave it one little kiss, ‘just in
+honour of having been a Red Queen.’
+
+‘Snowdrop, my pet!’ she went on, looking over her shoulder at the White
+Kitten, which was still patiently undergoing its toilet, ‘when WILL
+Dinah have finished with your White Majesty, I wonder? That must be the
+reason you were so untidy in my dream--Dinah! do you know that you’re
+scrubbing a White Queen? Really, it’s most disrespectful of you!
+
+‘And what did DINAH turn to, I wonder?’ she prattled on, as she settled
+comfortably down, with one elbow in the rug, and her chin in her hand,
+to watch the kittens. ‘Tell me, Dinah, did you turn to Humpty Dumpty? I
+THINK you did--however, you’d better not mention it to your friends just
+yet, for I’m not sure.
+
+‘By the way, Kitty, if only you’d been really with me in my dream, there
+was one thing you WOULD have enjoyed--I had such a quantity of poetry
+said to me, all about fishes! To-morrow morning you shall have a real
+treat. All the time you’re eating your breakfast, I’ll repeat “The
+Walrus and the Carpenter” to you; and then you can make believe it’s
+oysters, dear!
+
+‘Now, Kitty, let’s consider who it was that dreamed it all. This is a
+serious question, my dear, and you should NOT go on licking your paw
+like that--as if Dinah hadn’t washed you this morning! You see, Kitty,
+it MUST have been either me or the Red King. He was part of my dream,
+of course--but then I was part of his dream, too! WAS it the Red King,
+Kitty? You were his wife, my dear, so you ought to know--Oh, Kitty, DO
+help to settle it! I’m sure your paw can wait!’ But the provoking kitten
+only began on the other paw, and pretended it hadn’t heard the question.
+
+Which do YOU think it was?
+
+
+              ----
+
+
+         A boat beneath a sunny sky,
+         Lingering onward dreamily
+         In an evening of July--
+
+         Children three that nestle near,
+         Eager eye and willing ear,
+         Pleased a simple tale to hear--
+
+         Long has paled that sunny sky:
+         Echoes fade and memories die.
+         Autumn frosts have slain July.
+
+         Still she haunts me, phantomwise,
+         Alice moving under skies
+         Never seen by waking eyes.
+
+         Children yet, the tale to hear,
+         Eager eye and willing ear,
+         Lovingly shall nestle near.
+
+         In a Wonderland they lie,
+         Dreaming as the days go by,
+         Dreaming as the summers die:
+
+         Ever drifting down the stream--
+         Lingering in the golden gleam--
+         Life, what is it but a dream?
+
+
+              THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson, AKA Lewis Carroll
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+***** This file should be named 12-0.txt or 12-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/12/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/time-machine.txt
+++ b/jet/source-sink-builder/src/main/resources/books/time-machine.txt
@@ -1,0 +1,3617 @@
+﻿Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Time Machine
+
+Author: H. G. (Herbert George) Wells
+
+Release Date: October 2, 2004 [EBook #35]
+[Last updated: October 3, 2014]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+
+
+
+
+
+
+
+
+
+
+
+The Time Machine, by H. G. Wells [1898]
+
+
+
+
+I
+
+
+The Time Traveller (for so it will be convenient to speak of him)
+was expounding a recondite matter to us. His grey eyes shone and
+twinkled, and his usually pale face was flushed and animated. The
+fire burned brightly, and the soft radiance of the incandescent
+lights in the lilies of silver caught the bubbles that flashed and
+passed in our glasses. Our chairs, being his patents, embraced and
+caressed us rather than submitted to be sat upon, and there was that
+luxurious after-dinner atmosphere when thought roams gracefully
+free of the trammels of precision. And he put it to us in this
+way--marking the points with a lean forefinger--as we sat and lazily
+admired his earnestness over this new paradox (as we thought it)
+and his fecundity.
+
+'You must follow me carefully. I shall have to controvert one or two
+ideas that are almost universally accepted. The geometry, for
+instance, they taught you at school is founded on a misconception.'
+
+'Is not that rather a large thing to expect us to begin upon?'
+said Filby, an argumentative person with red hair.
+
+'I do not mean to ask you to accept anything without reasonable
+ground for it. You will soon admit as much as I need from you. You
+know of course that a mathematical line, a line of thickness _nil_,
+has no real existence. They taught you that? Neither has a
+mathematical plane. These things are mere abstractions.'
+
+'That is all right,' said the Psychologist.
+
+'Nor, having only length, breadth, and thickness, can a cube have a
+real existence.'
+
+'There I object,' said Filby. 'Of course a solid body may exist. All
+real things--'
+
+'So most people think. But wait a moment. Can an _instantaneous_
+cube exist?'
+
+'Don't follow you,' said Filby.
+
+'Can a cube that does not last for any time at all, have a real
+existence?'
+
+Filby became pensive. 'Clearly,' the Time Traveller proceeded, 'any
+real body must have extension in _four_ directions: it must have
+Length, Breadth, Thickness, and--Duration. But through a natural
+infirmity of the flesh, which I will explain to you in a moment, we
+incline to overlook this fact. There are really four dimensions,
+three which we call the three planes of Space, and a fourth, Time.
+There is, however, a tendency to draw an unreal distinction between
+the former three dimensions and the latter, because it happens that
+our consciousness moves intermittently in one direction along the
+latter from the beginning to the end of our lives.'
+
+'That,' said a very young man, making spasmodic efforts to relight
+his cigar over the lamp; 'that ... very clear indeed.'
+
+'Now, it is very remarkable that this is so extensively overlooked,'
+continued the Time Traveller, with a slight accession of
+cheerfulness. 'Really this is what is meant by the Fourth Dimension,
+though some people who talk about the Fourth Dimension do not know
+they mean it. It is only another way of looking at Time. _There is
+no difference between Time and any of the three dimensions of Space
+except that our consciousness moves along it_. But some foolish
+people have got hold of the wrong side of that idea. You have all
+heard what they have to say about this Fourth Dimension?'
+
+'_I_ have not,' said the Provincial Mayor.
+
+'It is simply this. That Space, as our mathematicians have it, is
+spoken of as having three dimensions, which one may call Length,
+Breadth, and Thickness, and is always definable by reference to
+three planes, each at right angles to the others. But some
+philosophical people have been asking why _three_ dimensions
+particularly--why not another direction at right angles to the other
+three?--and have even tried to construct a Four-Dimension geometry.
+Professor Simon Newcomb was expounding this to the New York
+Mathematical Society only a month or so ago. You know how on a flat
+surface, which has only two dimensions, we can represent a figure of
+a three-dimensional solid, and similarly they think that by models
+of three dimensions they could represent one of four--if they could
+master the perspective of the thing. See?'
+
+'I think so,' murmured the Provincial Mayor; and, knitting his
+brows, he lapsed into an introspective state, his lips moving as one
+who repeats mystic words. 'Yes, I think I see it now,' he said after
+some time, brightening in a quite transitory manner.
+
+'Well, I do not mind telling you I have been at work upon this
+geometry of Four Dimensions for some time. Some of my results
+are curious. For instance, here is a portrait of a man at eight
+years old, another at fifteen, another at seventeen, another at
+twenty-three, and so on. All these are evidently sections, as it
+were, Three-Dimensional representations of his Four-Dimensioned
+being, which is a fixed and unalterable thing.
+
+'Scientific people,' proceeded the Time Traveller, after the pause
+required for the proper assimilation of this, 'know very well that
+Time is only a kind of Space. Here is a popular scientific diagram,
+a weather record. This line I trace with my finger shows the
+movement of the barometer. Yesterday it was so high, yesterday night
+it fell, then this morning it rose again, and so gently upward to
+here. Surely the mercury did not trace this line in any of the
+dimensions of Space generally recognized? But certainly it traced
+such a line, and that line, therefore, we must conclude was along
+the Time-Dimension.'
+
+'But,' said the Medical Man, staring hard at a coal in the fire, 'if
+Time is really only a fourth dimension of Space, why is it, and why
+has it always been, regarded as something different? And why cannot
+we move in Time as we move about in the other dimensions of Space?'
+
+The Time Traveller smiled. 'Are you sure we can move freely in
+Space? Right and left we can go, backward and forward freely enough,
+and men always have done so. I admit we move freely in two
+dimensions. But how about up and down? Gravitation limits us there.'
+
+'Not exactly,' said the Medical Man. 'There are balloons.'
+
+'But before the balloons, save for spasmodic jumping and the
+inequalities of the surface, man had no freedom of vertical
+movement.'
+
+'Still they could move a little up and down,' said the Medical Man.
+
+'Easier, far easier down than up.'
+
+'And you cannot move at all in Time, you cannot get away from the
+present moment.'
+
+'My dear sir, that is just where you are wrong. That is just where
+the whole world has gone wrong. We are always getting away from the
+present moment. Our mental existences, which are immaterial and have
+no dimensions, are passing along the Time-Dimension with a uniform
+velocity from the cradle to the grave. Just as we should travel _down_
+if we began our existence fifty miles above the earth's surface.'
+
+'But the great difficulty is this,' interrupted the Psychologist.
+'You _can_ move about in all directions of Space, but you cannot
+move about in Time.'
+
+'That is the germ of my great discovery. But you are wrong to say
+that we cannot move about in Time. For instance, if I am recalling
+an incident very vividly I go back to the instant of its occurrence:
+I become absent-minded, as you say. I jump back for a moment. Of
+course we have no means of staying back for any length of Time, any
+more than a savage or an animal has of staying six feet above the
+ground. But a civilized man is better off than the savage in this
+respect. He can go up against gravitation in a balloon, and why
+should he not hope that ultimately he may be able to stop or
+accelerate his drift along the Time-Dimension, or even turn about
+and travel the other way?'
+
+'Oh, _this_,' began Filby, 'is all--'
+
+'Why not?' said the Time Traveller.
+
+'It's against reason,' said Filby.
+
+'What reason?' said the Time Traveller.
+
+'You can show black is white by argument,' said Filby, 'but you will
+never convince me.'
+
+'Possibly not,' said the Time Traveller. 'But now you begin to see
+the object of my investigations into the geometry of Four
+Dimensions. Long ago I had a vague inkling of a machine--'
+
+'To travel through Time!' exclaimed the Very Young Man.
+
+'That shall travel indifferently in any direction of Space and Time,
+as the driver determines.'
+
+Filby contented himself with laughter.
+
+'But I have experimental verification,' said the Time Traveller.
+
+'It would be remarkably convenient for the historian,' the
+Psychologist suggested. 'One might travel back and verify the
+accepted account of the Battle of Hastings, for instance!'
+
+'Don't you think you would attract attention?' said the Medical Man.
+'Our ancestors had no great tolerance for anachronisms.'
+
+'One might get one's Greek from the very lips of Homer and Plato,'
+the Very Young Man thought.
+
+'In which case they would certainly plough you for the Little-go.
+The German scholars have improved Greek so much.'
+
+'Then there is the future,' said the Very Young Man. 'Just think!
+One might invest all one's money, leave it to accumulate at
+interest, and hurry on ahead!'
+
+'To discover a society,' said I, 'erected on a strictly communistic
+basis.'
+
+'Of all the wild extravagant theories!' began the Psychologist.
+
+'Yes, so it seemed to me, and so I never talked of it until--'
+
+'Experimental verification!' cried I. 'You are going to verify
+_that_?'
+
+'The experiment!' cried Filby, who was getting brain-weary.
+
+'Let's see your experiment anyhow,' said the Psychologist, 'though
+it's all humbug, you know.'
+
+The Time Traveller smiled round at us. Then, still smiling faintly,
+and with his hands deep in his trousers pockets, he walked slowly
+out of the room, and we heard his slippers shuffling down the long
+passage to his laboratory.
+
+The Psychologist looked at us. 'I wonder what he's got?'
+
+'Some sleight-of-hand trick or other,' said the Medical Man, and
+Filby tried to tell us about a conjurer he had seen at Burslem; but
+before he had finished his preface the Time Traveller came back, and
+Filby's anecdote collapsed.
+
+The thing the Time Traveller held in his hand was a glittering
+metallic framework, scarcely larger than a small clock, and very
+delicately made. There was ivory in it, and some transparent
+crystalline substance. And now I must be explicit, for this that
+follows--unless his explanation is to be accepted--is an absolutely
+unaccountable thing. He took one of the small octagonal tables that
+were scattered about the room, and set it in front of the fire, with
+two legs on the hearthrug. On this table he placed the mechanism.
+Then he drew up a chair, and sat down. The only other object on the
+table was a small shaded lamp, the bright light of which fell upon
+the model. There were also perhaps a dozen candles about, two in
+brass candlesticks upon the mantel and several in sconces, so that
+the room was brilliantly illuminated. I sat in a low arm-chair
+nearest the fire, and I drew this forward so as to be almost between
+the Time Traveller and the fireplace. Filby sat behind him, looking
+over his shoulder. The Medical Man and the Provincial Mayor watched
+him in profile from the right, the Psychologist from the left. The
+Very Young Man stood behind the Psychologist. We were all on the
+alert. It appears incredible to me that any kind of trick, however
+subtly conceived and however adroitly done, could have been played
+upon us under these conditions.
+
+The Time Traveller looked at us, and then at the mechanism. 'Well?'
+said the Psychologist.
+
+'This little affair,' said the Time Traveller, resting his elbows
+upon the table and pressing his hands together above the apparatus,
+'is only a model. It is my plan for a machine to travel through
+time. You will notice that it looks singularly askew, and that there
+is an odd twinkling appearance about this bar, as though it was in
+some way unreal.' He pointed to the part with his finger. 'Also,
+here is one little white lever, and here is another.'
+
+The Medical Man got up out of his chair and peered into the thing.
+'It's beautifully made,' he said.
+
+'It took two years to make,' retorted the Time Traveller. Then, when
+we had all imitated the action of the Medical Man, he said: 'Now I
+want you clearly to understand that this lever, being pressed over,
+sends the machine gliding into the future, and this other reverses
+the motion. This saddle represents the seat of a time traveller.
+Presently I am going to press the lever, and off the machine will
+go. It will vanish, pass into future Time, and disappear. Have a
+good look at the thing. Look at the table too, and satisfy
+yourselves there is no trickery. I don't want to waste this model,
+and then be told I'm a quack.'
+
+There was a minute's pause perhaps. The Psychologist seemed about to
+speak to me, but changed his mind. Then the Time Traveller put forth
+his finger towards the lever. 'No,' he said suddenly. 'Lend me your
+hand.' And turning to the Psychologist, he took that individual's
+hand in his own and told him to put out his forefinger. So that it
+was the Psychologist himself who sent forth the model Time Machine
+on its interminable voyage. We all saw the lever turn. I am
+absolutely certain there was no trickery. There was a breath of
+wind, and the lamp flame jumped. One of the candles on the mantel
+was blown out, and the little machine suddenly swung round, became
+indistinct, was seen as a ghost for a second perhaps, as an eddy of
+faintly glittering brass and ivory; and it was gone--vanished! Save
+for the lamp the table was bare.
+
+Everyone was silent for a minute. Then Filby said he was damned.
+
+The Psychologist recovered from his stupor, and suddenly looked
+under the table. At that the Time Traveller laughed cheerfully.
+'Well?' he said, with a reminiscence of the Psychologist. Then,
+getting up, he went to the tobacco jar on the mantel, and with his
+back to us began to fill his pipe.
+
+We stared at each other. 'Look here,' said the Medical Man, 'are you
+in earnest about this? Do you seriously believe that that machine
+has travelled into time?'
+
+'Certainly,' said the Time Traveller, stooping to light a spill at
+the fire. Then he turned, lighting his pipe, to look at the
+Psychologist's face. (The Psychologist, to show that he was not
+unhinged, helped himself to a cigar and tried to light it uncut.)
+'What is more, I have a big machine nearly finished in there'--he
+indicated the laboratory--'and when that is put together I mean to
+have a journey on my own account.'
+
+'You mean to say that that machine has travelled into the future?'
+said Filby.
+
+'Into the future or the past--I don't, for certain, know which.'
+
+After an interval the Psychologist had an inspiration. 'It must have
+gone into the past if it has gone anywhere,' he said.
+
+'Why?' said the Time Traveller.
+
+'Because I presume that it has not moved in space, and if it
+travelled into the future it would still be here all this time,
+since it must have travelled through this time.'
+
+'But,' I said, 'If it travelled into the past it would have been
+visible when we came first into this room; and last Thursday when we
+were here; and the Thursday before that; and so forth!'
+
+'Serious objections,' remarked the Provincial Mayor, with an air of
+impartiality, turning towards the Time Traveller.
+
+'Not a bit,' said the Time Traveller, and, to the Psychologist: 'You
+think. You can explain that. It's presentation below the threshold,
+you know, diluted presentation.'
+
+'Of course,' said the Psychologist, and reassured us. 'That's a
+simple point of psychology. I should have thought of it. It's plain
+enough, and helps the paradox delightfully. We cannot see it, nor
+can we appreciate this machine, any more than we can the spoke of
+a wheel spinning, or a bullet flying through the air. If it is
+travelling through time fifty times or a hundred times faster than
+we are, if it gets through a minute while we get through a second,
+the impression it creates will of course be only one-fiftieth or
+one-hundredth of what it would make if it were not travelling in
+time. That's plain enough.' He passed his hand through the space in
+which the machine had been. 'You see?' he said, laughing.
+
+We sat and stared at the vacant table for a minute or so. Then the
+Time Traveller asked us what we thought of it all.
+
+'It sounds plausible enough to-night,' said the Medical Man; 'but
+wait until to-morrow. Wait for the common sense of the morning.'
+
+'Would you like to see the Time Machine itself?' asked the Time
+Traveller. And therewith, taking the lamp in his hand, he led the
+way down the long, draughty corridor to his laboratory. I remember
+vividly the flickering light, his queer, broad head in silhouette,
+the dance of the shadows, how we all followed him, puzzled but
+incredulous, and how there in the laboratory we beheld a larger
+edition of the little mechanism which we had seen vanish from before
+our eyes. Parts were of nickel, parts of ivory, parts had certainly
+been filed or sawn out of rock crystal. The thing was generally
+complete, but the twisted crystalline bars lay unfinished upon the
+bench beside some sheets of drawings, and I took one up for a better
+look at it. Quartz it seemed to be.
+
+'Look here,' said the Medical Man, 'are you perfectly serious?
+Or is this a trick--like that ghost you showed us last Christmas?'
+
+'Upon that machine,' said the Time Traveller, holding the lamp
+aloft, 'I intend to explore time. Is that plain? I was never more
+serious in my life.'
+
+None of us quite knew how to take it.
+
+I caught Filby's eye over the shoulder of the Medical Man, and he
+winked at me solemnly.
+
+
+
+
+II
+
+
+I think that at that time none of us quite believed in the Time
+Machine. The fact is, the Time Traveller was one of those men who
+are too clever to be believed: you never felt that you saw all round
+him; you always suspected some subtle reserve, some ingenuity in
+ambush, behind his lucid frankness. Had Filby shown the model and
+explained the matter in the Time Traveller's words, we should have
+shown _him_ far less scepticism. For we should have perceived his
+motives; a pork butcher could understand Filby. But the Time
+Traveller had more than a touch of whim among his elements, and we
+distrusted him. Things that would have made the frame of a less
+clever man seemed tricks in his hands. It is a mistake to do things
+too easily. The serious people who took him seriously never felt
+quite sure of his deportment; they were somehow aware that trusting
+their reputations for judgment with him was like furnishing a
+nursery with egg-shell china. So I don't think any of us said very
+much about time travelling in the interval between that Thursday and
+the next, though its odd potentialities ran, no doubt, in most of
+our minds: its plausibility, that is, its practical incredibleness,
+the curious possibilities of anachronism and of utter confusion it
+suggested. For my own part, I was particularly preoccupied with the
+trick of the model. That I remember discussing with the Medical Man,
+whom I met on Friday at the Linnaean. He said he had seen a similar
+thing at Tubingen, and laid considerable stress on the blowing out
+of the candle. But how the trick was done he could not explain.
+
+The next Thursday I went again to Richmond--I suppose I was one of
+the Time Traveller's most constant guests--and, arriving late, found
+four or five men already assembled in his drawing-room. The Medical
+Man was standing before the fire with a sheet of paper in one hand
+and his watch in the other. I looked round for the Time Traveller,
+and--'It's half-past seven now,' said the Medical Man. 'I suppose
+we'd better have dinner?'
+
+'Where's----?' said I, naming our host.
+
+'You've just come? It's rather odd. He's unavoidably detained. He
+asks me in this note to lead off with dinner at seven if he's not
+back. Says he'll explain when he comes.'
+
+'It seems a pity to let the dinner spoil,' said the Editor of a
+well-known daily paper; and thereupon the Doctor rang the bell.
+
+The Psychologist was the only person besides the Doctor and myself
+who had attended the previous dinner. The other men were Blank, the
+Editor aforementioned, a certain journalist, and another--a quiet,
+shy man with a beard--whom I didn't know, and who, as far as my
+observation went, never opened his mouth all the evening. There was
+some speculation at the dinner-table about the Time Traveller's
+absence, and I suggested time travelling, in a half-jocular spirit.
+The Editor wanted that explained to him, and the Psychologist
+volunteered a wooden account of the 'ingenious paradox and trick' we
+had witnessed that day week. He was in the midst of his exposition
+when the door from the corridor opened slowly and without noise. I
+was facing the door, and saw it first. 'Hallo!' I said. 'At last!'
+And the door opened wider, and the Time Traveller stood before us.
+I gave a cry of surprise. 'Good heavens! man, what's the matter?'
+cried the Medical Man, who saw him next. And the whole tableful
+turned towards the door.
+
+He was in an amazing plight. His coat was dusty and dirty, and
+smeared with green down the sleeves; his hair disordered, and as it
+seemed to me greyer--either with dust and dirt or because its colour
+had actually faded. His face was ghastly pale; his chin had a brown
+cut on it--a cut half healed; his expression was haggard and drawn,
+as by intense suffering. For a moment he hesitated in the doorway,
+as if he had been dazzled by the light. Then he came into the room.
+He walked with just such a limp as I have seen in footsore tramps.
+We stared at him in silence, expecting him to speak.
+
+He said not a word, but came painfully to the table, and made a
+motion towards the wine. The Editor filled a glass of champagne, and
+pushed it towards him. He drained it, and it seemed to do him good:
+for he looked round the table, and the ghost of his old smile
+flickered across his face. 'What on earth have you been up to, man?'
+said the Doctor. The Time Traveller did not seem to hear. 'Don't let
+me disturb you,' he said, with a certain faltering articulation.
+'I'm all right.' He stopped, held out his glass for more, and took
+it off at a draught. 'That's good,' he said. His eyes grew brighter,
+and a faint colour came into his cheeks. His glance flickered over
+our faces with a certain dull approval, and then went round the warm
+and comfortable room. Then he spoke again, still as it were feeling
+his way among his words. 'I'm going to wash and dress, and then I'll
+come down and explain things ... Save me some of that mutton. I'm
+starving for a bit of meat.'
+
+He looked across at the Editor, who was a rare visitor, and hoped he
+was all right. The Editor began a question. 'Tell you presently,'
+said the Time Traveller. 'I'm--funny! Be all right in a minute.'
+
+He put down his glass, and walked towards the staircase door. Again
+I remarked his lameness and the soft padding sound of his footfall,
+and standing up in my place, I saw his feet as he went out. He had
+nothing on them but a pair of tattered, blood-stained socks. Then the
+door closed upon him. I had half a mind to follow, till I remembered
+how he detested any fuss about himself. For a minute, perhaps, my
+mind was wool-gathering. Then, 'Remarkable Behaviour of an Eminent
+Scientist,' I heard the Editor say, thinking (after his wont) in
+headlines. And this brought my attention back to the bright
+dinner-table.
+
+'What's the game?' said the Journalist. 'Has he been doing the
+Amateur Cadger? I don't follow.' I met the eye of the Psychologist,
+and read my own interpretation in his face. I thought of the Time
+Traveller limping painfully upstairs. I don't think any one else had
+noticed his lameness.
+
+The first to recover completely from this surprise was the Medical
+Man, who rang the bell--the Time Traveller hated to have servants
+waiting at dinner--for a hot plate. At that the Editor turned to his
+knife and fork with a grunt, and the Silent Man followed suit. The
+dinner was resumed. Conversation was exclamatory for a little while,
+with gaps of wonderment; and then the Editor got fervent in his
+curiosity. 'Does our friend eke out his modest income with a
+crossing? or has he his Nebuchadnezzar phases?' he inquired. 'I feel
+assured it's this business of the Time Machine,' I said, and took up
+the Psychologist's account of our previous meeting. The new guests
+were frankly incredulous. The Editor raised objections. 'What _was_
+this time travelling? A man couldn't cover himself with dust by
+rolling in a paradox, could he?' And then, as the idea came home to
+him, he resorted to caricature. Hadn't they any clothes-brushes in
+the Future? The Journalist too, would not believe at any price, and
+joined the Editor in the easy work of heaping ridicule on the whole
+thing. They were both the new kind of journalist--very joyous,
+irreverent young men. 'Our Special Correspondent in the Day
+after To-morrow reports,' the Journalist was saying--or rather
+shouting--when the Time Traveller came back. He was dressed in
+ordinary evening clothes, and nothing save his haggard look remained
+of the change that had startled me.
+
+'I say,' said the Editor hilariously, 'these chaps here say you have
+been travelling into the middle of next week! Tell us all about
+little Rosebery, will you? What will you take for the lot?'
+
+The Time Traveller came to the place reserved for him without a
+word. He smiled quietly, in his old way. 'Where's my mutton?' he
+said. 'What a treat it is to stick a fork into meat again!'
+
+'Story!' cried the Editor.
+
+'Story be damned!' said the Time Traveller. 'I want something to
+eat. I won't say a word until I get some peptone into my arteries.
+Thanks. And the salt.'
+
+'One word,' said I. 'Have you been time travelling?'
+
+'Yes,' said the Time Traveller, with his mouth full, nodding his
+head.
+
+'I'd give a shilling a line for a verbatim note,' said the Editor.
+The Time Traveller pushed his glass towards the Silent Man and rang
+it with his fingernail; at which the Silent Man, who had been
+staring at his face, started convulsively, and poured him wine.
+The rest of the dinner was uncomfortable. For my own part, sudden
+questions kept on rising to my lips, and I dare say it was the same
+with the others. The Journalist tried to relieve the tension by
+telling anecdotes of Hettie Potter. The Time Traveller devoted his
+attention to his dinner, and displayed the appetite of a tramp.
+The Medical Man smoked a cigarette, and watched the Time Traveller
+through his eyelashes. The Silent Man seemed even more clumsy than
+usual, and drank champagne with regularity and determination out of
+sheer nervousness. At last the Time Traveller pushed his plate away,
+and looked round us. 'I suppose I must apologize,' he said. 'I was
+simply starving. I've had a most amazing time.' He reached out his
+hand for a cigar, and cut the end. 'But come into the smoking-room.
+It's too long a story to tell over greasy plates.' And ringing the
+bell in passing, he led the way into the adjoining room.
+
+'You have told Blank, and Dash, and Chose about the machine?' he
+said to me, leaning back in his easy-chair and naming the three new
+guests.
+
+'But the thing's a mere paradox,' said the Editor.
+
+'I can't argue to-night. I don't mind telling you the story, but
+I can't argue. I will,' he went on, 'tell you the story of what
+has happened to me, if you like, but you must refrain from
+interruptions. I want to tell it. Badly. Most of it will sound like
+lying. So be it! It's true--every word of it, all the same. I was in
+my laboratory at four o'clock, and since then ... I've lived eight
+days ... such days as no human being ever lived before! I'm nearly
+worn out, but I shan't sleep till I've told this thing over to you.
+Then I shall go to bed. But no interruptions! Is it agreed?'
+
+'Agreed,' said the Editor, and the rest of us echoed 'Agreed.' And
+with that the Time Traveller began his story as I have set it forth.
+He sat back in his chair at first, and spoke like a weary man.
+Afterwards he got more animated. In writing it down I feel with only
+too much keenness the inadequacy of pen and ink--and, above all, my
+own inadequacy--to express its quality. You read, I will suppose,
+attentively enough; but you cannot see the speaker's white,
+sincere face in the bright circle of the little lamp, nor hear the
+intonation of his voice. You cannot know how his expression followed
+the turns of his story! Most of us hearers were in shadow, for the
+candles in the smoking-room had not been lighted, and only the face
+of the Journalist and the legs of the Silent Man from the knees
+downward were illuminated. At first we glanced now and again at each
+other. After a time we ceased to do that, and looked only at the
+Time Traveller's face.
+
+
+
+
+III
+
+
+'I told some of you last Thursday of the principles of the Time
+Machine, and showed you the actual thing itself, incomplete in the
+workshop. There it is now, a little travel-worn, truly; and one of
+the ivory bars is cracked, and a brass rail bent; but the rest of
+it's sound enough. I expected to finish it on Friday, but on Friday,
+when the putting together was nearly done, I found that one of the
+nickel bars was exactly one inch too short, and this I had to get
+remade; so that the thing was not complete until this morning. It
+was at ten o'clock to-day that the first of all Time Machines began
+its career. I gave it a last tap, tried all the screws again, put
+one more drop of oil on the quartz rod, and sat myself in the
+saddle. I suppose a suicide who holds a pistol to his skull feels
+much the same wonder at what will come next as I felt then. I took
+the starting lever in one hand and the stopping one in the other,
+pressed the first, and almost immediately the second. I seemed to
+reel; I felt a nightmare sensation of falling; and, looking round,
+I saw the laboratory exactly as before. Had anything happened? For
+a moment I suspected that my intellect had tricked me. Then I noted
+the clock. A moment before, as it seemed, it had stood at a minute
+or so past ten; now it was nearly half-past three!
+
+'I drew a breath, set my teeth, gripped the starting lever with both
+hands, and went off with a thud. The laboratory got hazy and went
+dark. Mrs. Watchett came in and walked, apparently without seeing
+me, towards the garden door. I suppose it took her a minute or so to
+traverse the place, but to me she seemed to shoot across the room
+like a rocket. I pressed the lever over to its extreme position. The
+night came like the turning out of a lamp, and in another moment
+came to-morrow. The laboratory grew faint and hazy, then fainter
+and ever fainter. To-morrow night came black, then day again, night
+again, day again, faster and faster still. An eddying murmur filled
+my ears, and a strange, dumb confusedness descended on my mind.
+
+'I am afraid I cannot convey the peculiar sensations of time
+travelling. They are excessively unpleasant. There is a feeling
+exactly like that one has upon a switchback--of a helpless headlong
+motion! I felt the same horrible anticipation, too, of an imminent
+smash. As I put on pace, night followed day like the flapping of a
+black wing. The dim suggestion of the laboratory seemed presently to
+fall away from me, and I saw the sun hopping swiftly across the sky,
+leaping it every minute, and every minute marking a day. I supposed
+the laboratory had been destroyed and I had come into the open air.
+I had a dim impression of scaffolding, but I was already going too
+fast to be conscious of any moving things. The slowest snail that
+ever crawled dashed by too fast for me. The twinkling succession of
+darkness and light was excessively painful to the eye. Then, in the
+intermittent darknesses, I saw the moon spinning swiftly through her
+quarters from new to full, and had a faint glimpse of the circling
+stars. Presently, as I went on, still gaining velocity, the
+palpitation of night and day merged into one continuous greyness;
+the sky took on a wonderful deepness of blue, a splendid luminous
+color like that of early twilight; the jerking sun became a streak
+of fire, a brilliant arch, in space; the moon a fainter fluctuating
+band; and I could see nothing of the stars, save now and then a
+brighter circle flickering in the blue.
+
+'The landscape was misty and vague. I was still on the hill-side
+upon which this house now stands, and the shoulder rose above me
+grey and dim. I saw trees growing and changing like puffs of vapour,
+now brown, now green; they grew, spread, shivered, and passed away.
+I saw huge buildings rise up faint and fair, and pass like dreams.
+The whole surface of the earth seemed changed--melting and flowing
+under my eyes. The little hands upon the dials that registered my
+speed raced round faster and faster. Presently I noted that the sun
+belt swayed up and down, from solstice to solstice, in a minute or
+less, and that consequently my pace was over a year a minute; and
+minute by minute the white snow flashed across the world, and
+vanished, and was followed by the bright, brief green of spring.
+
+'The unpleasant sensations of the start were less poignant now. They
+merged at last into a kind of hysterical exhilaration. I remarked
+indeed a clumsy swaying of the machine, for which I was unable to
+account. But my mind was too confused to attend to it, so with a
+kind of madness growing upon me, I flung myself into futurity. At
+first I scarce thought of stopping, scarce thought of anything but
+these new sensations. But presently a fresh series of impressions
+grew up in my mind--a certain curiosity and therewith a certain
+dread--until at last they took complete possession of me. What
+strange developments of humanity, what wonderful advances upon our
+rudimentary civilization, I thought, might not appear when I came to
+look nearly into the dim elusive world that raced and fluctuated
+before my eyes! I saw great and splendid architecture rising about
+me, more massive than any buildings of our own time, and yet, as it
+seemed, built of glimmer and mist. I saw a richer green flow up the
+hill-side, and remain there, without any wintry intermission. Even
+through the veil of my confusion the earth seemed very fair. And so
+my mind came round to the business of stopping.
+
+'The peculiar risk lay in the possibility of my finding some
+substance in the space which I, or the machine, occupied. So long
+as I travelled at a high velocity through time, this scarcely
+mattered; I was, so to speak, attenuated--was slipping like a vapour
+through the interstices of intervening substances! But to come to
+a stop involved the jamming of myself, molecule by molecule, into
+whatever lay in my way; meant bringing my atoms into such intimate
+contact with those of the obstacle that a profound chemical
+reaction--possibly a far-reaching explosion--would result, and blow
+myself and my apparatus out of all possible dimensions--into the
+Unknown. This possibility had occurred to me again and again while I
+was making the machine; but then I had cheerfully accepted it as an
+unavoidable risk--one of the risks a man has got to take! Now the
+risk was inevitable, I no longer saw it in the same cheerful light.
+The fact is that, insensibly, the absolute strangeness of everything,
+the sickly jarring and swaying of the machine, above all, the
+feeling of prolonged falling, had absolutely upset my nerve. I told
+myself that I could never stop, and with a gust of petulance I
+resolved to stop forthwith. Like an impatient fool, I lugged over
+the lever, and incontinently the thing went reeling over, and I was
+flung headlong through the air.
+
+'There was the sound of a clap of thunder in my ears. I may have
+been stunned for a moment. A pitiless hail was hissing round me,
+and I was sitting on soft turf in front of the overset machine.
+Everything still seemed grey, but presently I remarked that the
+confusion in my ears was gone. I looked round me. I was on what
+seemed to be a little lawn in a garden, surrounded by rhododendron
+bushes, and I noticed that their mauve and purple blossoms were
+dropping in a shower under the beating of the hail-stones. The
+rebounding, dancing hail hung in a cloud over the machine, and drove
+along the ground like smoke. In a moment I was wet to the skin.
+"Fine hospitality," said I, "to a man who has travelled innumerable
+years to see you."
+
+'Presently I thought what a fool I was to get wet. I stood up and
+looked round me. A colossal figure, carved apparently in some white
+stone, loomed indistinctly beyond the rhododendrons through the hazy
+downpour. But all else of the world was invisible.
+
+'My sensations would be hard to describe. As the columns of hail
+grew thinner, I saw the white figure more distinctly. It was very
+large, for a silver birch-tree touched its shoulder. It was of white
+marble, in shape something like a winged sphinx, but the wings,
+instead of being carried vertically at the sides, were spread so
+that it seemed to hover. The pedestal, it appeared to me, was of
+bronze, and was thick with verdigris. It chanced that the face was
+towards me; the sightless eyes seemed to watch me; there was the
+faint shadow of a smile on the lips. It was greatly weather-worn,
+and that imparted an unpleasant suggestion of disease. I stood
+looking at it for a little space--half a minute, perhaps, or half an
+hour. It seemed to advance and to recede as the hail drove before it
+denser or thinner. At last I tore my eyes from it for a moment and
+saw that the hail curtain had worn threadbare, and that the sky was
+lightening with the promise of the sun.
+
+'I looked up again at the crouching white shape, and the full
+temerity of my voyage came suddenly upon me. What might appear when
+that hazy curtain was altogether withdrawn? What might not have
+happened to men? What if cruelty had grown into a common passion?
+What if in this interval the race had lost its manliness and had
+developed into something inhuman, unsympathetic, and overwhelmingly
+powerful? I might seem some old-world savage animal, only the more
+dreadful and disgusting for our common likeness--a foul creature to
+be incontinently slain.
+
+'Already I saw other vast shapes--huge buildings with intricate
+parapets and tall columns, with a wooded hill-side dimly creeping
+in upon me through the lessening storm. I was seized with a panic
+fear. I turned frantically to the Time Machine, and strove hard to
+readjust it. As I did so the shafts of the sun smote through the
+thunderstorm. The grey downpour was swept aside and vanished like
+the trailing garments of a ghost. Above me, in the intense blue
+of the summer sky, some faint brown shreds of cloud whirled into
+nothingness. The great buildings about me stood out clear and
+distinct, shining with the wet of the thunderstorm, and picked out
+in white by the unmelted hailstones piled along their courses. I
+felt naked in a strange world. I felt as perhaps a bird may feel in
+the clear air, knowing the hawk wings above and will swoop. My fear
+grew to frenzy. I took a breathing space, set my teeth, and again
+grappled fiercely, wrist and knee, with the machine. It gave under
+my desperate onset and turned over. It struck my chin violently. One
+hand on the saddle, the other on the lever, I stood panting heavily
+in attitude to mount again.
+
+'But with this recovery of a prompt retreat my courage recovered. I
+looked more curiously and less fearfully at this world of the remote
+future. In a circular opening, high up in the wall of the nearer
+house, I saw a group of figures clad in rich soft robes. They had
+seen me, and their faces were directed towards me.
+
+'Then I heard voices approaching me. Coming through the bushes by
+the White Sphinx were the heads and shoulders of men running. One of
+these emerged in a pathway leading straight to the little lawn upon
+which I stood with my machine. He was a slight creature--perhaps
+four feet high--clad in a purple tunic, girdled at the waist with a
+leather belt. Sandals or buskins--I could not clearly distinguish
+which--were on his feet; his legs were bare to the knees, and his
+head was bare. Noticing that, I noticed for the first time how warm
+the air was.
+
+'He struck me as being a very beautiful and graceful creature, but
+indescribably frail. His flushed face reminded me of the more
+beautiful kind of consumptive--that hectic beauty of which we used
+to hear so much. At the sight of him I suddenly regained confidence.
+I took my hands from the machine.
+
+
+
+
+IV
+
+
+'In another moment we were standing face to face, I and this fragile
+thing out of futurity. He came straight up to me and laughed into my
+eyes. The absence from his bearing of any sign of fear struck me at
+once. Then he turned to the two others who were following him and
+spoke to them in a strange and very sweet and liquid tongue.
+
+'There were others coming, and presently a little group of perhaps
+eight or ten of these exquisite creatures were about me. One of them
+addressed me. It came into my head, oddly enough, that my voice was
+too harsh and deep for them. So I shook my head, and, pointing to my
+ears, shook it again. He came a step forward, hesitated, and then
+touched my hand. Then I felt other soft little tentacles upon my
+back and shoulders. They wanted to make sure I was real. There was
+nothing in this at all alarming. Indeed, there was something in
+these pretty little people that inspired confidence--a graceful
+gentleness, a certain childlike ease. And besides, they looked so
+frail that I could fancy myself flinging the whole dozen of them
+about like nine-pins. But I made a sudden motion to warn them when I
+saw their little pink hands feeling at the Time Machine. Happily
+then, when it was not too late, I thought of a danger I had hitherto
+forgotten, and reaching over the bars of the machine I unscrewed the
+little levers that would set it in motion, and put these in my
+pocket. Then I turned again to see what I could do in the way of
+communication.
+
+'And then, looking more nearly into their features, I saw some
+further peculiarities in their Dresden-china type of prettiness.
+Their hair, which was uniformly curly, came to a sharp end at the
+neck and cheek; there was not the faintest suggestion of it on the
+face, and their ears were singularly minute. The mouths were small,
+with bright red, rather thin lips, and the little chins ran to a
+point. The eyes were large and mild; and--this may seem egotism on
+my part--I fancied even that there was a certain lack of the
+interest I might have expected in them.
+
+'As they made no effort to communicate with me, but simply stood
+round me smiling and speaking in soft cooing notes to each other, I
+began the conversation. I pointed to the Time Machine and to myself.
+Then hesitating for a moment how to express time, I pointed to the
+sun. At once a quaintly pretty little figure in chequered purple and
+white followed my gesture, and then astonished me by imitating the
+sound of thunder.
+
+'For a moment I was staggered, though the import of his gesture was
+plain enough. The question had come into my mind abruptly: were
+these creatures fools? You may hardly understand how it took me.
+You see I had always anticipated that the people of the year Eight
+Hundred and Two Thousand odd would be incredibly in front of us in
+knowledge, art, everything. Then one of them suddenly asked me a
+question that showed him to be on the intellectual level of one of
+our five-year-old children--asked me, in fact, if I had come from
+the sun in a thunderstorm! It let loose the judgment I had suspended
+upon their clothes, their frail light limbs, and fragile features.
+A flow of disappointment rushed across my mind. For a moment I felt
+that I had built the Time Machine in vain.
+
+'I nodded, pointed to the sun, and gave them such a vivid rendering
+of a thunderclap as startled them. They all withdrew a pace or so
+and bowed. Then came one laughing towards me, carrying a chain of
+beautiful flowers altogether new to me, and put it about my neck.
+The idea was received with melodious applause; and presently they
+were all running to and fro for flowers, and laughingly flinging
+them upon me until I was almost smothered with blossom. You who
+have never seen the like can scarcely imagine what delicate and
+wonderful flowers countless years of culture had created. Then
+someone suggested that their plaything should be exhibited in the
+nearest building, and so I was led past the sphinx of white marble,
+which had seemed to watch me all the while with a smile at my
+astonishment, towards a vast grey edifice of fretted stone. As I
+went with them the memory of my confident anticipations of a
+profoundly grave and intellectual posterity came, with irresistible
+merriment, to my mind.
+
+'The building had a huge entry, and was altogether of colossal
+dimensions. I was naturally most occupied with the growing crowd of
+little people, and with the big open portals that yawned before me
+shadowy and mysterious. My general impression of the world I saw
+over their heads was a tangled waste of beautiful bushes and
+flowers, a long neglected and yet weedless garden. I saw a number
+of tall spikes of strange white flowers, measuring a foot perhaps
+across the spread of the waxen petals. They grew scattered, as if
+wild, among the variegated shrubs, but, as I say, I did not examine
+them closely at this time. The Time Machine was left deserted on the
+turf among the rhododendrons.
+
+'The arch of the doorway was richly carved, but naturally I did
+not observe the carving very narrowly, though I fancied I saw
+suggestions of old Phoenician decorations as I passed through, and
+it struck me that they were very badly broken and weather-worn.
+Several more brightly clad people met me in the doorway, and so we
+entered, I, dressed in dingy nineteenth-century garments, looking
+grotesque enough, garlanded with flowers, and surrounded by an
+eddying mass of bright, soft-colored robes and shining white limbs,
+in a melodious whirl of laughter and laughing speech.
+
+'The big doorway opened into a proportionately great hall hung with
+brown. The roof was in shadow, and the windows, partially glazed
+with coloured glass and partially unglazed, admitted a tempered
+light. The floor was made up of huge blocks of some very hard white
+metal, not plates nor slabs--blocks, and it was so much worn, as I
+judged by the going to and fro of past generations, as to be deeply
+channelled along the more frequented ways. Transverse to the length
+were innumerable tables made of slabs of polished stone, raised
+perhaps a foot from the floor, and upon these were heaps of fruits.
+Some I recognized as a kind of hypertrophied raspberry and orange,
+but for the most part they were strange.
+
+'Between the tables was scattered a great number of cushions.
+Upon these my conductors seated themselves, signing for me to do
+likewise. With a pretty absence of ceremony they began to eat the
+fruit with their hands, flinging peel and stalks, and so forth, into
+the round openings in the sides of the tables. I was not loath to
+follow their example, for I felt thirsty and hungry. As I did so I
+surveyed the hall at my leisure.
+
+'And perhaps the thing that struck me most was its dilapidated look.
+The stained-glass windows, which displayed only a geometrical
+pattern, were broken in many places, and the curtains that hung
+across the lower end were thick with dust. And it caught my eye that
+the corner of the marble table near me was fractured. Nevertheless,
+the general effect was extremely rich and picturesque. There were,
+perhaps, a couple of hundred people dining in the hall, and most of
+them, seated as near to me as they could come, were watching me with
+interest, their little eyes shining over the fruit they were eating.
+All were clad in the same soft and yet strong, silky material.
+
+'Fruit, by the by, was all their diet. These people of the remote
+future were strict vegetarians, and while I was with them, in spite
+of some carnal cravings, I had to be frugivorous also. Indeed, I
+found afterwards that horses, cattle, sheep, dogs, had followed the
+Ichthyosaurus into extinction. But the fruits were very delightful;
+one, in particular, that seemed to be in season all the time I was
+there--a floury thing in a three-sided husk--was especially good,
+and I made it my staple. At first I was puzzled by all these strange
+fruits, and by the strange flowers I saw, but later I began to
+perceive their import.
+
+'However, I am telling you of my fruit dinner in the distant future
+now. So soon as my appetite was a little checked, I determined to
+make a resolute attempt to learn the speech of these new men of
+mine. Clearly that was the next thing to do. The fruits seemed a
+convenient thing to begin upon, and holding one of these up I began
+a series of interrogative sounds and gestures. I had some
+considerable difficulty in conveying my meaning. At first my efforts
+met with a stare of surprise or inextinguishable laughter, but
+presently a fair-haired little creature seemed to grasp my intention
+and repeated a name. They had to chatter and explain the business
+at great length to each other, and my first attempts to make the
+exquisite little sounds of their language caused an immense amount
+of amusement. However, I felt like a schoolmaster amidst children,
+and persisted, and presently I had a score of noun substantives at
+least at my command; and then I got to demonstrative pronouns, and
+even the verb "to eat." But it was slow work, and the little people
+soon tired and wanted to get away from my interrogations, so I
+determined, rather of necessity, to let them give their lessons in
+little doses when they felt inclined. And very little doses I found
+they were before long, for I never met people more indolent or more
+easily fatigued.
+
+'A queer thing I soon discovered about my little hosts, and that was
+their lack of interest. They would come to me with eager cries of
+astonishment, like children, but like children they would soon stop
+examining me and wander away after some other toy. The dinner and my
+conversational beginnings ended, I noted for the first time that
+almost all those who had surrounded me at first were gone. It is
+odd, too, how speedily I came to disregard these little people. I
+went out through the portal into the sunlit world again as soon as
+my hunger was satisfied. I was continually meeting more of these men
+of the future, who would follow me a little distance, chatter and
+laugh about me, and, having smiled and gesticulated in a friendly
+way, leave me again to my own devices.
+
+'The calm of evening was upon the world as I emerged from the great
+hall, and the scene was lit by the warm glow of the setting sun.
+At first things were very confusing. Everything was so entirely
+different from the world I had known--even the flowers. The big
+building I had left was situated on the slope of a broad river
+valley, but the Thames had shifted perhaps a mile from its present
+position. I resolved to mount to the summit of a crest, perhaps a
+mile and a half away, from which I could get a wider view of this
+our planet in the year Eight Hundred and Two Thousand Seven Hundred
+and One A.D. For that, I should explain, was the date the little
+dials of my machine recorded.
+
+'As I walked I was watching for every impression that could possibly
+help to explain the condition of ruinous splendour in which I
+found the world--for ruinous it was. A little way up the hill, for
+instance, was a great heap of granite, bound together by masses of
+aluminium, a vast labyrinth of precipitous walls and crumpled
+heaps, amidst which were thick heaps of very beautiful pagoda-like
+plants--nettles possibly--but wonderfully tinted with brown about
+the leaves, and incapable of stinging. It was evidently the derelict
+remains of some vast structure, to what end built I could not
+determine. It was here that I was destined, at a later date, to have
+a very strange experience--the first intimation of a still stranger
+discovery--but of that I will speak in its proper place.
+
+'Looking round with a sudden thought, from a terrace on which I
+rested for a while, I realized that there were no small houses to be
+seen. Apparently the single house, and possibly even the household,
+had vanished. Here and there among the greenery were palace-like
+buildings, but the house and the cottage, which form such
+characteristic features of our own English landscape, had
+disappeared.
+
+'"Communism," said I to myself.
+
+'And on the heels of that came another thought. I looked at the
+half-dozen little figures that were following me. Then, in a flash,
+I perceived that all had the same form of costume, the same soft
+hairless visage, and the same girlish rotundity of limb. It may seem
+strange, perhaps, that I had not noticed this before. But everything
+was so strange. Now, I saw the fact plainly enough. In costume, and
+in all the differences of texture and bearing that now mark off the
+sexes from each other, these people of the future were alike. And
+the children seemed to my eyes to be but the miniatures of their
+parents. I judged, then, that the children of that time were
+extremely precocious, physically at least, and I found afterwards
+abundant verification of my opinion.
+
+'Seeing the ease and security in which these people were living, I
+felt that this close resemblance of the sexes was after all what
+one would expect; for the strength of a man and the softness of a
+woman, the institution of the family, and the differentiation of
+occupations are mere militant necessities of an age of physical
+force; where population is balanced and abundant, much childbearing
+becomes an evil rather than a blessing to the State; where
+violence comes but rarely and off-spring are secure, there is less
+necessity--indeed there is no necessity--for an efficient family,
+and the specialization of the sexes with reference to their
+children's needs disappears. We see some beginnings of this even
+in our own time, and in this future age it was complete. This, I
+must remind you, was my speculation at the time. Later, I was to
+appreciate how far it fell short of the reality.
+
+'While I was musing upon these things, my attention was attracted by
+a pretty little structure, like a well under a cupola. I thought in
+a transitory way of the oddness of wells still existing, and then
+resumed the thread of my speculations. There were no large buildings
+towards the top of the hill, and as my walking powers were evidently
+miraculous, I was presently left alone for the first time. With a
+strange sense of freedom and adventure I pushed on up to the crest.
+
+'There I found a seat of some yellow metal that I did not recognize,
+corroded in places with a kind of pinkish rust and half smothered
+in soft moss, the arm-rests cast and filed into the resemblance of
+griffins' heads. I sat down on it, and I surveyed the broad view of
+our old world under the sunset of that long day. It was as sweet and
+fair a view as I have ever seen. The sun had already gone below the
+horizon and the west was flaming gold, touched with some horizontal
+bars of purple and crimson. Below was the valley of the Thames, in
+which the river lay like a band of burnished steel. I have already
+spoken of the great palaces dotted about among the variegated
+greenery, some in ruins and some still occupied. Here and there rose
+a white or silvery figure in the waste garden of the earth, here and
+there came the sharp vertical line of some cupola or obelisk. There
+were no hedges, no signs of proprietary rights, no evidences of
+agriculture; the whole earth had become a garden.
+
+'So watching, I began to put my interpretation upon the things I had
+seen, and as it shaped itself to me that evening, my interpretation
+was something in this way. (Afterwards I found I had got only a
+half-truth--or only a glimpse of one facet of the truth.)
+
+'It seemed to me that I had happened upon humanity upon the wane.
+The ruddy sunset set me thinking of the sunset of mankind. For the
+first time I began to realize an odd consequence of the social
+effort in which we are at present engaged. And yet, come to think,
+it is a logical consequence enough. Strength is the outcome of need;
+security sets a premium on feebleness. The work of ameliorating the
+conditions of life--the true civilizing process that makes life more
+and more secure--had gone steadily on to a climax. One triumph of a
+united humanity over Nature had followed another. Things that are
+now mere dreams had become projects deliberately put in hand and
+carried forward. And the harvest was what I saw!
+
+'After all, the sanitation and the agriculture of to-day are still
+in the rudimentary stage. The science of our time has attacked but
+a little department of the field of human disease, but even so,
+it spreads its operations very steadily and persistently. Our
+agriculture and horticulture destroy a weed just here and there and
+cultivate perhaps a score or so of wholesome plants, leaving the
+greater number to fight out a balance as they can. We improve our
+favourite plants and animals--and how few they are--gradually by
+selective breeding; now a new and better peach, now a seedless
+grape, now a sweeter and larger flower, now a more convenient breed
+of cattle. We improve them gradually, because our ideals are vague
+and tentative, and our knowledge is very limited; because Nature,
+too, is shy and slow in our clumsy hands. Some day all this will
+be better organized, and still better. That is the drift of the
+current in spite of the eddies. The whole world will be intelligent,
+educated, and co-operating; things will move faster and faster
+towards the subjugation of Nature. In the end, wisely and carefully
+we shall readjust the balance of animal and vegetable life to suit
+our human needs.
+
+'This adjustment, I say, must have been done, and done well; done
+indeed for all Time, in the space of Time across which my machine
+had leaped. The air was free from gnats, the earth from weeds or
+fungi; everywhere were fruits and sweet and delightful flowers;
+brilliant butterflies flew hither and thither. The ideal of
+preventive medicine was attained. Diseases had been stamped out. I
+saw no evidence of any contagious diseases during all my stay. And I
+shall have to tell you later that even the processes of putrefaction
+and decay had been profoundly affected by these changes.
+
+'Social triumphs, too, had been effected. I saw mankind housed in
+splendid shelters, gloriously clothed, and as yet I had found them
+engaged in no toil. There were no signs of struggle, neither social
+nor economical struggle. The shop, the advertisement, traffic, all
+that commerce which constitutes the body of our world, was gone. It
+was natural on that golden evening that I should jump at the idea of
+a social paradise. The difficulty of increasing population had been
+met, I guessed, and population had ceased to increase.
+
+'But with this change in condition comes inevitably adaptations to
+the change. What, unless biological science is a mass of errors, is
+the cause of human intelligence and vigour? Hardship and freedom:
+conditions under which the active, strong, and subtle survive and
+the weaker go to the wall; conditions that put a premium upon the
+loyal alliance of capable men, upon self-restraint, patience, and
+decision. And the institution of the family, and the emotions that
+arise therein, the fierce jealousy, the tenderness for offspring,
+parental self-devotion, all found their justification and support in
+the imminent dangers of the young. _Now_, where are these imminent
+dangers? There is a sentiment arising, and it will grow, against
+connubial jealousy, against fierce maternity, against passion
+of all sorts; unnecessary things now, and things that make us
+uncomfortable, savage survivals, discords in a refined and pleasant
+life.
+
+'I thought of the physical slightness of the people, their lack of
+intelligence, and those big abundant ruins, and it strengthened my
+belief in a perfect conquest of Nature. For after the battle comes
+Quiet. Humanity had been strong, energetic, and intelligent, and had
+used all its abundant vitality to alter the conditions under which
+it lived. And now came the reaction of the altered conditions.
+
+'Under the new conditions of perfect comfort and security, that
+restless energy, that with us is strength, would become weakness.
+Even in our own time certain tendencies and desires, once necessary
+to survival, are a constant source of failure. Physical courage and
+the love of battle, for instance, are no great help--may even be
+hindrances--to a civilized man. And in a state of physical balance
+and security, power, intellectual as well as physical, would be out
+of place. For countless years I judged there had been no danger of
+war or solitary violence, no danger from wild beasts, no wasting
+disease to require strength of constitution, no need of toil. For
+such a life, what we should call the weak are as well equipped as
+the strong, are indeed no longer weak. Better equipped indeed they
+are, for the strong would be fretted by an energy for which there
+was no outlet. No doubt the exquisite beauty of the buildings I saw
+was the outcome of the last surgings of the now purposeless energy
+of mankind before it settled down into perfect harmony with the
+conditions under which it lived--the flourish of that triumph which
+began the last great peace. This has ever been the fate of energy in
+security; it takes to art and to eroticism, and then come languor
+and decay.
+
+'Even this artistic impetus would at last die away--had almost died
+in the Time I saw. To adorn themselves with flowers, to dance, to
+sing in the sunlight: so much was left of the artistic spirit, and
+no more. Even that would fade in the end into a contented
+inactivity. We are kept keen on the grindstone of pain and
+necessity, and, it seemed to me, that here was that hateful
+grindstone broken at last!
+
+'As I stood there in the gathering dark I thought that in this
+simple explanation I had mastered the problem of the world--mastered
+the whole secret of these delicious people. Possibly the checks they
+had devised for the increase of population had succeeded too well,
+and their numbers had rather diminished than kept stationary.
+That would account for the abandoned ruins. Very simple was my
+explanation, and plausible enough--as most wrong theories are!
+
+
+
+
+V
+
+
+'As I stood there musing over this too perfect triumph of man, the
+full moon, yellow and gibbous, came up out of an overflow of silver
+light in the north-east. The bright little figures ceased to move
+about below, a noiseless owl flitted by, and I shivered with the
+chill of the night. I determined to descend and find where I could
+sleep.
+
+'I looked for the building I knew. Then my eye travelled along to
+the figure of the White Sphinx upon the pedestal of bronze, growing
+distinct as the light of the rising moon grew brighter. I could see
+the silver birch against it. There was the tangle of rhododendron
+bushes, black in the pale light, and there was the little lawn.
+I looked at the lawn again. A queer doubt chilled my complacency.
+"No," said I stoutly to myself, "that was not the lawn."
+
+'But it _was_ the lawn. For the white leprous face of the sphinx was
+towards it. Can you imagine what I felt as this conviction came
+home to me? But you cannot. The Time Machine was gone!
+
+'At once, like a lash across the face, came the possibility of
+losing my own age, of being left helpless in this strange new world.
+The bare thought of it was an actual physical sensation. I could
+feel it grip me at the throat and stop my breathing. In another
+moment I was in a passion of fear and running with great leaping
+strides down the slope. Once I fell headlong and cut my face; I lost
+no time in stanching the blood, but jumped up and ran on, with a
+warm trickle down my cheek and chin. All the time I ran I was saying
+to myself: "They have moved it a little, pushed it under the bushes
+out of the way." Nevertheless, I ran with all my might. All the
+time, with the certainty that sometimes comes with excessive dread,
+I knew that such assurance was folly, knew instinctively that the
+machine was removed out of my reach. My breath came with pain. I
+suppose I covered the whole distance from the hill crest to the
+little lawn, two miles perhaps, in ten minutes. And I am not a young
+man. I cursed aloud, as I ran, at my confident folly in leaving the
+machine, wasting good breath thereby. I cried aloud, and none
+answered. Not a creature seemed to be stirring in that moonlit
+world.
+
+'When I reached the lawn my worst fears were realized. Not a trace
+of the thing was to be seen. I felt faint and cold when I faced the
+empty space among the black tangle of bushes. I ran round it
+furiously, as if the thing might be hidden in a corner, and then
+stopped abruptly, with my hands clutching my hair. Above me towered
+the sphinx, upon the bronze pedestal, white, shining, leprous, in
+the light of the rising moon. It seemed to smile in mockery of my
+dismay.
+
+'I might have consoled myself by imagining the little people had put
+the mechanism in some shelter for me, had I not felt assured of
+their physical and intellectual inadequacy. That is what dismayed
+me: the sense of some hitherto unsuspected power, through whose
+intervention my invention had vanished. Yet, for one thing I felt
+assured: unless some other age had produced its exact duplicate,
+the machine could not have moved in time. The attachment of the
+levers--I will show you the method later--prevented any one from
+tampering with it in that way when they were removed. It had moved,
+and was hid, only in space. But then, where could it be?
+
+'I think I must have had a kind of frenzy. I remember running
+violently in and out among the moonlit bushes all round the sphinx,
+and startling some white animal that, in the dim light, I took for a
+small deer. I remember, too, late that night, beating the bushes
+with my clenched fist until my knuckles were gashed and bleeding
+from the broken twigs. Then, sobbing and raving in my anguish of
+mind, I went down to the great building of stone. The big hall was
+dark, silent, and deserted. I slipped on the uneven floor, and fell
+over one of the malachite tables, almost breaking my shin. I lit a
+match and went on past the dusty curtains, of which I have told you.
+
+'There I found a second great hall covered with cushions, upon
+which, perhaps, a score or so of the little people were sleeping. I
+have no doubt they found my second appearance strange enough, coming
+suddenly out of the quiet darkness with inarticulate noises and the
+splutter and flare of a match. For they had forgotten about matches.
+"Where is my Time Machine?" I began, bawling like an angry child,
+laying hands upon them and shaking them up together. It must have
+been very queer to them. Some laughed, most of them looked sorely
+frightened. When I saw them standing round me, it came into my head
+that I was doing as foolish a thing as it was possible for me to do
+under the circumstances, in trying to revive the sensation of fear.
+For, reasoning from their daylight behaviour, I thought that fear
+must be forgotten.
+
+'Abruptly, I dashed down the match, and, knocking one of the people
+over in my course, went blundering across the big dining-hall again,
+out under the moonlight. I heard cries of terror and their little
+feet running and stumbling this way and that. I do not remember all
+I did as the moon crept up the sky. I suppose it was the unexpected
+nature of my loss that maddened me. I felt hopelessly cut off from
+my own kind--a strange animal in an unknown world. I must have raved
+to and fro, screaming and crying upon God and Fate. I have a memory
+of horrible fatigue, as the long night of despair wore away; of
+looking in this impossible place and that; of groping among moon-lit
+ruins and touching strange creatures in the black shadows; at last,
+of lying on the ground near the sphinx and weeping with absolute
+wretchedness. I had nothing left but misery. Then I slept, and when
+I woke again it was full day, and a couple of sparrows were hopping
+round me on the turf within reach of my arm.
+
+'I sat up in the freshness of the morning, trying to remember how
+I had got there, and why I had such a profound sense of desertion
+and despair. Then things came clear in my mind. With the plain,
+reasonable daylight, I could look my circumstances fairly in the
+face. I saw the wild folly of my frenzy overnight, and I could
+reason with myself. "Suppose the worst?" I said. "Suppose the
+machine altogether lost--perhaps destroyed? It behoves me to be
+calm and patient, to learn the way of the people, to get a clear
+idea of the method of my loss, and the means of getting materials
+and tools; so that in the end, perhaps, I may make another." That
+would be my only hope, perhaps, but better than despair. And, after
+all, it was a beautiful and curious world.
+
+'But probably, the machine had only been taken away. Still, I must
+be calm and patient, find its hiding-place, and recover it by force
+or cunning. And with that I scrambled to my feet and looked about
+me, wondering where I could bathe. I felt weary, stiff, and
+travel-soiled. The freshness of the morning made me desire an equal
+freshness. I had exhausted my emotion. Indeed, as I went about
+my business, I found myself wondering at my intense excitement
+overnight. I made a careful examination of the ground about the
+little lawn. I wasted some time in futile questionings, conveyed, as
+well as I was able, to such of the little people as came by. They
+all failed to understand my gestures; some were simply stolid, some
+thought it was a jest and laughed at me. I had the hardest task in
+the world to keep my hands off their pretty laughing faces. It was
+a foolish impulse, but the devil begotten of fear and blind anger
+was ill curbed and still eager to take advantage of my perplexity.
+The turf gave better counsel. I found a groove ripped in it, about
+midway between the pedestal of the sphinx and the marks of my feet
+where, on arrival, I had struggled with the overturned machine.
+There were other signs of removal about, with queer narrow
+footprints like those I could imagine made by a sloth. This directed
+my closer attention to the pedestal. It was, as I think I have said,
+of bronze. It was not a mere block, but highly decorated with deep
+framed panels on either side. I went and rapped at these. The
+pedestal was hollow. Examining the panels with care I found them
+discontinuous with the frames. There were no handles or keyholes,
+but possibly the panels, if they were doors, as I supposed, opened
+from within. One thing was clear enough to my mind. It took no very
+great mental effort to infer that my Time Machine was inside that
+pedestal. But how it got there was a different problem.
+
+'I saw the heads of two orange-clad people coming through the bushes
+and under some blossom-covered apple-trees towards me. I turned
+smiling to them and beckoned them to me. They came, and then,
+pointing to the bronze pedestal, I tried to intimate my wish to open
+it. But at my first gesture towards this they behaved very oddly. I
+don't know how to convey their expression to you. Suppose you were
+to use a grossly improper gesture to a delicate-minded woman--it is
+how she would look. They went off as if they had received the last
+possible insult. I tried a sweet-looking little chap in white next,
+with exactly the same result. Somehow, his manner made me feel
+ashamed of myself. But, as you know, I wanted the Time Machine, and
+I tried him once more. As he turned off, like the others, my temper
+got the better of me. In three strides I was after him, had him by
+the loose part of his robe round the neck, and began dragging him
+towards the sphinx. Then I saw the horror and repugnance of his
+face, and all of a sudden I let him go.
+
+'But I was not beaten yet. I banged with my fist at the bronze
+panels. I thought I heard something stir inside--to be explicit,
+I thought I heard a sound like a chuckle--but I must have been
+mistaken. Then I got a big pebble from the river, and came and
+hammered till I had flattened a coil in the decorations, and the
+verdigris came off in powdery flakes. The delicate little people
+must have heard me hammering in gusty outbreaks a mile away on
+either hand, but nothing came of it. I saw a crowd of them upon the
+slopes, looking furtively at me. At last, hot and tired, I sat down
+to watch the place. But I was too restless to watch long; I am too
+Occidental for a long vigil. I could work at a problem for years,
+but to wait inactive for twenty-four hours--that is another matter.
+
+'I got up after a time, and began walking aimlessly through the
+bushes towards the hill again. "Patience," said I to myself. "If you
+want your machine again you must leave that sphinx alone. If they
+mean to take your machine away, it's little good your wrecking their
+bronze panels, and if they don't, you will get it back as soon as
+you can ask for it. To sit among all those unknown things before a
+puzzle like that is hopeless. That way lies monomania. Face this
+world. Learn its ways, watch it, be careful of too hasty guesses
+at its meaning. In the end you will find clues to it all." Then
+suddenly the humour of the situation came into my mind: the thought
+of the years I had spent in study and toil to get into the future
+age, and now my passion of anxiety to get out of it. I had made
+myself the most complicated and the most hopeless trap that ever a
+man devised. Although it was at my own expense, I could not help
+myself. I laughed aloud.
+
+'Going through the big palace, it seemed to me that the little
+people avoided me. It may have been my fancy, or it may have had
+something to do with my hammering at the gates of bronze. Yet I felt
+tolerably sure of the avoidance. I was careful, however, to show no
+concern and to abstain from any pursuit of them, and in the course
+of a day or two things got back to the old footing. I made what
+progress I could in the language, and in addition I pushed my
+explorations here and there. Either I missed some subtle point or
+their language was excessively simple--almost exclusively composed
+of concrete substantives and verbs. There seemed to be few, if any,
+abstract terms, or little use of figurative language. Their
+sentences were usually simple and of two words, and I failed to
+convey or understand any but the simplest propositions. I determined
+to put the thought of my Time Machine and the mystery of the bronze
+doors under the sphinx as much as possible in a corner of memory,
+until my growing knowledge would lead me back to them in a natural
+way. Yet a certain feeling, you may understand, tethered me in a
+circle of a few miles round the point of my arrival.
+
+'So far as I could see, all the world displayed the same exuberant
+richness as the Thames valley. From every hill I climbed I saw the
+same abundance of splendid buildings, endlessly varied in material
+and style, the same clustering thickets of evergreens, the same
+blossom-laden trees and tree-ferns. Here and there water shone like
+silver, and beyond, the land rose into blue undulating hills, and
+so faded into the serenity of the sky. A peculiar feature, which
+presently attracted my attention, was the presence of certain
+circular wells, several, as it seemed to me, of a very great depth.
+One lay by the path up the hill, which I had followed during my
+first walk. Like the others, it was rimmed with bronze, curiously
+wrought, and protected by a little cupola from the rain. Sitting by
+the side of these wells, and peering down into the shafted darkness,
+I could see no gleam of water, nor could I start any reflection
+with a lighted match. But in all of them I heard a certain sound:
+a thud--thud--thud, like the beating of some big engine; and I
+discovered, from the flaring of my matches, that a steady current of
+air set down the shafts. Further, I threw a scrap of paper into the
+throat of one, and, instead of fluttering slowly down, it was at
+once sucked swiftly out of sight.
+
+'After a time, too, I came to connect these wells with tall towers
+standing here and there upon the slopes; for above them there was
+often just such a flicker in the air as one sees on a hot day above
+a sun-scorched beach. Putting things together, I reached a strong
+suggestion of an extensive system of subterranean ventilation, whose
+true import it was difficult to imagine. I was at first inclined to
+associate it with the sanitary apparatus of these people. It was an
+obvious conclusion, but it was absolutely wrong.
+
+'And here I must admit that I learned very little of drains and
+bells and modes of conveyance, and the like conveniences, during my
+time in this real future. In some of these visions of Utopias and
+coming times which I have read, there is a vast amount of detail
+about building, and social arrangements, and so forth. But while
+such details are easy enough to obtain when the whole world is
+contained in one's imagination, they are altogether inaccessible to
+a real traveller amid such realities as I found here. Conceive the
+tale of London which a negro, fresh from Central Africa, would take
+back to his tribe! What would he know of railway companies, of
+social movements, of telephone and telegraph wires, of the Parcels
+Delivery Company, and postal orders and the like? Yet we, at least,
+should be willing enough to explain these things to him! And even of
+what he knew, how much could he make his untravelled friend either
+apprehend or believe? Then, think how narrow the gap between a negro
+and a white man of our own times, and how wide the interval between
+myself and these of the Golden Age! I was sensible of much which was
+unseen, and which contributed to my comfort; but save for a general
+impression of automatic organization, I fear I can convey very
+little of the difference to your mind.
+
+'In the matter of sepulture, for instance, I could see no signs of
+crematoria nor anything suggestive of tombs. But it occurred to me
+that, possibly, there might be cemeteries (or crematoria) somewhere
+beyond the range of my explorings. This, again, was a question I
+deliberately put to myself, and my curiosity was at first entirely
+defeated upon the point. The thing puzzled me, and I was led to make
+a further remark, which puzzled me still more: that aged and infirm
+among this people there were none.
+
+'I must confess that my satisfaction with my first theories of an
+automatic civilization and a decadent humanity did not long endure.
+Yet I could think of no other. Let me put my difficulties. The
+several big palaces I had explored were mere living places, great
+dining-halls and sleeping apartments. I could find no machinery, no
+appliances of any kind. Yet these people were clothed in pleasant
+fabrics that must at times need renewal, and their sandals, though
+undecorated, were fairly complex specimens of metalwork. Somehow
+such things must be made. And the little people displayed no vestige
+of a creative tendency. There were no shops, no workshops, no sign
+of importations among them. They spent all their time in playing
+gently, in bathing in the river, in making love in a half-playful
+fashion, in eating fruit and sleeping. I could not see how things
+were kept going.
+
+'Then, again, about the Time Machine: something, I knew not what,
+had taken it into the hollow pedestal of the White Sphinx. Why? For
+the life of me I could not imagine. Those waterless wells, too,
+those flickering pillars. I felt I lacked a clue. I felt--how shall
+I put it? Suppose you found an inscription, with sentences here and
+there in excellent plain English, and interpolated therewith, others
+made up of words, of letters even, absolutely unknown to you? Well,
+on the third day of my visit, that was how the world of Eight
+Hundred and Two Thousand Seven Hundred and One presented itself to
+me!
+
+'That day, too, I made a friend--of a sort. It happened that, as I
+was watching some of the little people bathing in a shallow, one of
+them was seized with cramp and began drifting downstream. The main
+current ran rather swiftly, but not too strongly for even a moderate
+swimmer. It will give you an idea, therefore, of the strange
+deficiency in these creatures, when I tell you that none made the
+slightest attempt to rescue the weakly crying little thing which
+was drowning before their eyes. When I realized this, I hurriedly
+slipped off my clothes, and, wading in at a point lower down, I
+caught the poor mite and drew her safe to land. A little rubbing of
+the limbs soon brought her round, and I had the satisfaction of
+seeing she was all right before I left her. I had got to such a low
+estimate of her kind that I did not expect any gratitude from her.
+In that, however, I was wrong.
+
+'This happened in the morning. In the afternoon I met my little
+woman, as I believe it was, as I was returning towards my centre
+from an exploration, and she received me with cries of delight and
+presented me with a big garland of flowers--evidently made for me
+and me alone. The thing took my imagination. Very possibly I had
+been feeling desolate. At any rate I did my best to display my
+appreciation of the gift. We were soon seated together in a little
+stone arbour, engaged in conversation, chiefly of smiles. The
+creature's friendliness affected me exactly as a child's might have
+done. We passed each other flowers, and she kissed my hands. I did
+the same to hers. Then I tried talk, and found that her name was
+Weena, which, though I don't know what it meant, somehow seemed
+appropriate enough. That was the beginning of a queer friendship
+which lasted a week, and ended--as I will tell you!
+
+'She was exactly like a child. She wanted to be with me always. She
+tried to follow me everywhere, and on my next journey out and about
+it went to my heart to tire her down, and leave her at last,
+exhausted and calling after me rather plaintively. But the problems
+of the world had to be mastered. I had not, I said to myself, come
+into the future to carry on a miniature flirtation. Yet her distress
+when I left her was very great, her expostulations at the parting
+were sometimes frantic, and I think, altogether, I had as much
+trouble as comfort from her devotion. Nevertheless she was, somehow,
+a very great comfort. I thought it was mere childish affection that
+made her cling to me. Until it was too late, I did not clearly know
+what I had inflicted upon her when I left her. Nor until it was too
+late did I clearly understand what she was to me. For, by merely
+seeming fond of me, and showing in her weak, futile way that she
+cared for me, the little doll of a creature presently gave my return
+to the neighbourhood of the White Sphinx almost the feeling of
+coming home; and I would watch for her tiny figure of white and gold
+so soon as I came over the hill.
+
+'It was from her, too, that I learned that fear had not yet left the
+world. She was fearless enough in the daylight, and she had the
+oddest confidence in me; for once, in a foolish moment, I made
+threatening grimaces at her, and she simply laughed at them. But she
+dreaded the dark, dreaded shadows, dreaded black things. Darkness
+to her was the one thing dreadful. It was a singularly passionate
+emotion, and it set me thinking and observing. I discovered then,
+among other things, that these little people gathered into the great
+houses after dark, and slept in droves. To enter upon them without a
+light was to put them into a tumult of apprehension. I never found
+one out of doors, or one sleeping alone within doors, after dark.
+Yet I was still such a blockhead that I missed the lesson of that
+fear, and in spite of Weena's distress I insisted upon sleeping away
+from these slumbering multitudes.
+
+'It troubled her greatly, but in the end her odd affection for me
+triumphed, and for five of the nights of our acquaintance, including
+the last night of all, she slept with her head pillowed on my arm.
+But my story slips away from me as I speak of her. It must have been
+the night before her rescue that I was awakened about dawn. I had
+been restless, dreaming most disagreeably that I was drowned, and
+that sea anemones were feeling over my face with their soft palps.
+I woke with a start, and with an odd fancy that some greyish animal
+had just rushed out of the chamber. I tried to get to sleep again,
+but I felt restless and uncomfortable. It was that dim grey hour
+when things are just creeping out of darkness, when everything is
+colourless and clear cut, and yet unreal. I got up, and went down
+into the great hall, and so out upon the flagstones in front of the
+palace. I thought I would make a virtue of necessity, and see the
+sunrise.
+
+'The moon was setting, and the dying moonlight and the first pallor
+of dawn were mingled in a ghastly half-light. The bushes were inky
+black, the ground a sombre grey, the sky colourless and cheerless.
+And up the hill I thought I could see ghosts. There several times,
+as I scanned the slope, I saw white figures. Twice I fancied I saw
+a solitary white, ape-like creature running rather quickly up the
+hill, and once near the ruins I saw a leash of them carrying some
+dark body. They moved hastily. I did not see what became of them.
+It seemed that they vanished among the bushes. The dawn was still
+indistinct, you must understand. I was feeling that chill,
+uncertain, early-morning feeling you may have known. I doubted
+my eyes.
+
+'As the eastern sky grew brighter, and the light of the day came on
+and its vivid colouring returned upon the world once more, I scanned
+the view keenly. But I saw no vestige of my white figures. They were
+mere creatures of the half light. "They must have been ghosts," I
+said; "I wonder whence they dated." For a queer notion of Grant
+Allen's came into my head, and amused me. If each generation die and
+leave ghosts, he argued, the world at last will get overcrowded with
+them. On that theory they would have grown innumerable some Eight
+Hundred Thousand Years hence, and it was no great wonder to see four
+at once. But the jest was unsatisfying, and I was thinking of these
+figures all the morning, until Weena's rescue drove them out of my
+head. I associated them in some indefinite way with the white animal
+I had startled in my first passionate search for the Time Machine.
+But Weena was a pleasant substitute. Yet all the same, they were
+soon destined to take far deadlier possession of my mind.
+
+'I think I have said how much hotter than our own was the weather
+of this Golden Age. I cannot account for it. It may be that the sun
+was hotter, or the earth nearer the sun. It is usual to assume that
+the sun will go on cooling steadily in the future. But people,
+unfamiliar with such speculations as those of the younger Darwin,
+forget that the planets must ultimately fall back one by one into
+the parent body. As these catastrophes occur, the sun will blaze
+with renewed energy; and it may be that some inner planet had
+suffered this fate. Whatever the reason, the fact remains that the
+sun was very much hotter than we know it.
+
+'Well, one very hot morning--my fourth, I think--as I was seeking
+shelter from the heat and glare in a colossal ruin near the great
+house where I slept and fed, there happened this strange thing:
+Clambering among these heaps of masonry, I found a narrow gallery,
+whose end and side windows were blocked by fallen masses of stone.
+By contrast with the brilliancy outside, it seemed at first
+impenetrably dark to me. I entered it groping, for the change from
+light to blackness made spots of colour swim before me. Suddenly I
+halted spellbound. A pair of eyes, luminous by reflection against
+the daylight without, was watching me out of the darkness.
+
+'The old instinctive dread of wild beasts came upon me. I clenched
+my hands and steadfastly looked into the glaring eyeballs. I was
+afraid to turn. Then the thought of the absolute security in which
+humanity appeared to be living came to my mind. And then I
+remembered that strange terror of the dark. Overcoming my fear to
+some extent, I advanced a step and spoke. I will admit that my
+voice was harsh and ill-controlled. I put out my hand and touched
+something soft. At once the eyes darted sideways, and something
+white ran past me. I turned with my heart in my mouth, and saw a
+queer little ape-like figure, its head held down in a peculiar
+manner, running across the sunlit space behind me. It blundered
+against a block of granite, staggered aside, and in a moment was
+hidden in a black shadow beneath another pile of ruined masonry.
+
+'My impression of it is, of course, imperfect; but I know it was a
+dull white, and had strange large greyish-red eyes; also that there
+was flaxen hair on its head and down its back. But, as I say, it
+went too fast for me to see distinctly. I cannot even say whether it
+ran on all-fours, or only with its forearms held very low. After an
+instant's pause I followed it into the second heap of ruins. I could
+not find it at first; but, after a time in the profound obscurity, I
+came upon one of those round well-like openings of which I have told
+you, half closed by a fallen pillar. A sudden thought came to me.
+Could this Thing have vanished down the shaft? I lit a match, and,
+looking down, I saw a small, white, moving creature, with large
+bright eyes which regarded me steadfastly as it retreated. It made
+me shudder. It was so like a human spider! It was clambering down
+the wall, and now I saw for the first time a number of metal foot
+and hand rests forming a kind of ladder down the shaft. Then the
+light burned my fingers and fell out of my hand, going out as it
+dropped, and when I had lit another the little monster had
+disappeared.
+
+'I do not know how long I sat peering down that well. It was not for
+some time that I could succeed in persuading myself that the thing I
+had seen was human. But, gradually, the truth dawned on me: that
+Man had not remained one species, but had differentiated into two
+distinct animals: that my graceful children of the Upper-world were
+not the sole descendants of our generation, but that this bleached,
+obscene, nocturnal Thing, which had flashed before me, was also heir
+to all the ages.
+
+'I thought of the flickering pillars and of my theory of an
+underground ventilation. I began to suspect their true import. And
+what, I wondered, was this Lemur doing in my scheme of a perfectly
+balanced organization? How was it related to the indolent serenity
+of the beautiful Upper-worlders? And what was hidden down there,
+at the foot of that shaft? I sat upon the edge of the well telling
+myself that, at any rate, there was nothing to fear, and that there
+I must descend for the solution of my difficulties. And withal I
+was absolutely afraid to go! As I hesitated, two of the beautiful
+Upper-world people came running in their amorous sport across the
+daylight in the shadow. The male pursued the female, flinging
+flowers at her as he ran.
+
+'They seemed distressed to find me, my arm against the overturned
+pillar, peering down the well. Apparently it was considered bad form
+to remark these apertures; for when I pointed to this one, and tried
+to frame a question about it in their tongue, they were still more
+visibly distressed and turned away. But they were interested by my
+matches, and I struck some to amuse them. I tried them again about
+the well, and again I failed. So presently I left them, meaning to
+go back to Weena, and see what I could get from her. But my mind was
+already in revolution; my guesses and impressions were slipping and
+sliding to a new adjustment. I had now a clue to the import of these
+wells, to the ventilating towers, to the mystery of the ghosts; to
+say nothing of a hint at the meaning of the bronze gates and the
+fate of the Time Machine! And very vaguely there came a suggestion
+towards the solution of the economic problem that had puzzled me.
+
+'Here was the new view. Plainly, this second species of Man was
+subterranean. There were three circumstances in particular which
+made me think that its rare emergence above ground was the outcome
+of a long-continued underground habit. In the first place, there was
+the bleached look common in most animals that live largely in the
+dark--the white fish of the Kentucky caves, for instance. Then,
+those large eyes, with that capacity for reflecting light, are
+common features of nocturnal things--witness the owl and the cat.
+And last of all, that evident confusion in the sunshine, that hasty
+yet fumbling awkward flight towards dark shadow, and that peculiar
+carriage of the head while in the light--all reinforced the theory
+of an extreme sensitiveness of the retina.
+
+'Beneath my feet, then, the earth must be tunnelled enormously, and
+these tunnellings were the habitat of the new race. The presence of
+ventilating shafts and wells along the hill slopes--everywhere, in
+fact, except along the river valley--showed how universal were its
+ramifications. What so natural, then, as to assume that it was in
+this artificial Underworld that such work as was necessary to the
+comfort of the daylight race was done? The notion was so plausible
+that I at once accepted it, and went on to assume the _how_ of this
+splitting of the human species. I dare say you will anticipate the
+shape of my theory; though, for myself, I very soon felt that it
+fell far short of the truth.
+
+'At first, proceeding from the problems of our own age, it seemed
+clear as daylight to me that the gradual widening of the present
+merely temporary and social difference between the Capitalist and
+the Labourer, was the key to the whole position. No doubt it will
+seem grotesque enough to you--and wildly incredible!--and yet even
+now there are existing circumstances to point that way. There is
+a tendency to utilize underground space for the less ornamental
+purposes of civilization; there is the Metropolitan Railway in
+London, for instance, there are new electric railways, there are
+subways, there are underground workrooms and restaurants, and they
+increase and multiply. Evidently, I thought, this tendency had
+increased till Industry had gradually lost its birthright in the
+sky. I mean that it had gone deeper and deeper into larger and ever
+larger underground factories, spending a still-increasing amount of
+its time therein, till, in the end--! Even now, does not an East-end
+worker live in such artificial conditions as practically to be cut
+off from the natural surface of the earth?
+
+'Again, the exclusive tendency of richer people--due, no doubt, to
+the increasing refinement of their education, and the widening gulf
+between them and the rude violence of the poor--is already leading
+to the closing, in their interest, of considerable portions of the
+surface of the land. About London, for instance, perhaps half the
+prettier country is shut in against intrusion. And this same
+widening gulf--which is due to the length and expense of the higher
+educational process and the increased facilities for and temptations
+towards refined habits on the part of the rich--will make that
+exchange between class and class, that promotion by intermarriage
+which at present retards the splitting of our species along lines
+of social stratification, less and less frequent. So, in the end,
+above ground you must have the Haves, pursuing pleasure and comfort
+and beauty, and below ground the Have-nots, the Workers getting
+continually adapted to the conditions of their labour. Once they
+were there, they would no doubt have to pay rent, and not a little
+of it, for the ventilation of their caverns; and if they refused,
+they would starve or be suffocated for arrears. Such of them as were
+so constituted as to be miserable and rebellious would die; and, in
+the end, the balance being permanent, the survivors would become as
+well adapted to the conditions of underground life, and as happy in
+their way, as the Upper-world people were to theirs. As it seemed to
+me, the refined beauty and the etiolated pallor followed naturally
+enough.
+
+'The great triumph of Humanity I had dreamed of took a different
+shape in my mind. It had been no such triumph of moral education and
+general co-operation as I had imagined. Instead, I saw a real
+aristocracy, armed with a perfected science and working to a logical
+conclusion the industrial system of to-day. Its triumph had not been
+simply a triumph over Nature, but a triumph over Nature and the
+fellow-man. This, I must warn you, was my theory at the time. I had
+no convenient cicerone in the pattern of the Utopian books. My
+explanation may be absolutely wrong. I still think it is the
+most plausible one. But even on this supposition the balanced
+civilization that was at last attained must have long since passed
+its zenith, and was now far fallen into decay. The too-perfect
+security of the Upper-worlders had led them to a slow movement of
+degeneration, to a general dwindling in size, strength, and
+intelligence. That I could see clearly enough already. What had
+happened to the Under-grounders I did not yet suspect; but from what
+I had seen of the Morlocks--that, by the by, was the name by which
+these creatures were called--I could imagine that the modification
+of the human type was even far more profound than among the "Eloi,"
+the beautiful race that I already knew.
+
+'Then came troublesome doubts. Why had the Morlocks taken my Time
+Machine? For I felt sure it was they who had taken it. Why, too, if
+the Eloi were masters, could they not restore the machine to me? And
+why were they so terribly afraid of the dark? I proceeded, as I have
+said, to question Weena about this Under-world, but here again I was
+disappointed. At first she would not understand my questions, and
+presently she refused to answer them. She shivered as though the
+topic was unendurable. And when I pressed her, perhaps a little
+harshly, she burst into tears. They were the only tears, except my
+own, I ever saw in that Golden Age. When I saw them I ceased
+abruptly to trouble about the Morlocks, and was only concerned in
+banishing these signs of the human inheritance from Weena's eyes.
+And very soon she was smiling and clapping her hands, while I
+solemnly burned a match.
+
+
+
+
+VI
+
+
+'It may seem odd to you, but it was two days before I could follow
+up the new-found clue in what was manifestly the proper way. I felt
+a peculiar shrinking from those pallid bodies. They were just the
+half-bleached colour of the worms and things one sees preserved in
+spirit in a zoological museum. And they were filthily cold to the
+touch. Probably my shrinking was largely due to the sympathetic
+influence of the Eloi, whose disgust of the Morlocks I now began
+to appreciate.
+
+'The next night I did not sleep well. Probably my health was a
+little disordered. I was oppressed with perplexity and doubt. Once
+or twice I had a feeling of intense fear for which I could perceive
+no definite reason. I remember creeping noiselessly into the great
+hall where the little people were sleeping in the moonlight--that
+night Weena was among them--and feeling reassured by their presence.
+It occurred to me even then, that in the course of a few days the
+moon must pass through its last quarter, and the nights grow dark,
+when the appearances of these unpleasant creatures from below, these
+whitened Lemurs, this new vermin that had replaced the old, might be
+more abundant. And on both these days I had the restless feeling of
+one who shirks an inevitable duty. I felt assured that the Time
+Machine was only to be recovered by boldly penetrating these
+underground mysteries. Yet I could not face the mystery. If only I
+had had a companion it would have been different. But I was so
+horribly alone, and even to clamber down into the darkness of the
+well appalled me. I don't know if you will understand my feeling,
+but I never felt quite safe at my back.
+
+'It was this restlessness, this insecurity, perhaps, that drove me
+further and further afield in my exploring expeditions. Going to the
+south-westward towards the rising country that is now called Combe
+Wood, I observed far off, in the direction of nineteenth-century
+Banstead, a vast green structure, different in character from any
+I had hitherto seen. It was larger than the largest of the palaces
+or ruins I knew, and the facade had an Oriental look: the face
+of it having the lustre, as well as the pale-green tint, a kind
+of bluish-green, of a certain type of Chinese porcelain. This
+difference in aspect suggested a difference in use, and I was minded
+to push on and explore. But the day was growing late, and I had come
+upon the sight of the place after a long and tiring circuit; so I
+resolved to hold over the adventure for the following day, and I
+returned to the welcome and the caresses of little Weena. But next
+morning I perceived clearly enough that my curiosity regarding the
+Palace of Green Porcelain was a piece of self-deception, to enable
+me to shirk, by another day, an experience I dreaded. I resolved I
+would make the descent without further waste of time, and started
+out in the early morning towards a well near the ruins of granite
+and aluminium.
+
+'Little Weena ran with me. She danced beside me to the well, but
+when she saw me lean over the mouth and look downward, she seemed
+strangely disconcerted. "Good-bye, little Weena," I said, kissing
+her; and then putting her down, I began to feel over the parapet
+for the climbing hooks. Rather hastily, I may as well confess, for
+I feared my courage might leak away! At first she watched me in
+amazement. Then she gave a most piteous cry, and running to me, she
+began to pull at me with her little hands. I think her opposition
+nerved me rather to proceed. I shook her off, perhaps a little
+roughly, and in another moment I was in the throat of the well. I
+saw her agonized face over the parapet, and smiled to reassure her.
+Then I had to look down at the unstable hooks to which I clung.
+
+'I had to clamber down a shaft of perhaps two hundred yards. The
+descent was effected by means of metallic bars projecting from
+the sides of the well, and these being adapted to the needs of
+a creature much smaller and lighter than myself, I was speedily
+cramped and fatigued by the descent. And not simply fatigued! One of
+the bars bent suddenly under my weight, and almost swung me off into
+the blackness beneath. For a moment I hung by one hand, and after
+that experience I did not dare to rest again. Though my arms and
+back were presently acutely painful, I went on clambering down the
+sheer descent with as quick a motion as possible. Glancing upward,
+I saw the aperture, a small blue disk, in which a star was visible,
+while little Weena's head showed as a round black projection. The
+thudding sound of a machine below grew louder and more oppressive.
+Everything save that little disk above was profoundly dark, and when
+I looked up again Weena had disappeared.
+
+'I was in an agony of discomfort. I had some thought of trying to go
+up the shaft again, and leave the Under-world alone. But even while
+I turned this over in my mind I continued to descend. At last, with
+intense relief, I saw dimly coming up, a foot to the right of me, a
+slender loophole in the wall. Swinging myself in, I found it was the
+aperture of a narrow horizontal tunnel in which I could lie down and
+rest. It was not too soon. My arms ached, my back was cramped, and I
+was trembling with the prolonged terror of a fall. Besides this, the
+unbroken darkness had had a distressing effect upon my eyes. The air
+was full of the throb and hum of machinery pumping air down the
+shaft.
+
+'I do not know how long I lay. I was roused by a soft hand touching
+my face. Starting up in the darkness I snatched at my matches and,
+hastily striking one, I saw three stooping white creatures similar
+to the one I had seen above ground in the ruin, hastily retreating
+before the light. Living, as they did, in what appeared to me
+impenetrable darkness, their eyes were abnormally large and
+sensitive, just as are the pupils of the abysmal fishes, and they
+reflected the light in the same way. I have no doubt they could see
+me in that rayless obscurity, and they did not seem to have any fear
+of me apart from the light. But, so soon as I struck a match in
+order to see them, they fled incontinently, vanishing into dark
+gutters and tunnels, from which their eyes glared at me in the
+strangest fashion.
+
+'I tried to call to them, but the language they had was apparently
+different from that of the Over-world people; so that I was needs
+left to my own unaided efforts, and the thought of flight before
+exploration was even then in my mind. But I said to myself, "You are
+in for it now," and, feeling my way along the tunnel, I found the
+noise of machinery grow louder. Presently the walls fell away from
+me, and I came to a large open space, and striking another match,
+saw that I had entered a vast arched cavern, which stretched into
+utter darkness beyond the range of my light. The view I had of it
+was as much as one could see in the burning of a match.
+
+'Necessarily my memory is vague. Great shapes like big machines rose
+out of the dimness, and cast grotesque black shadows, in which dim
+spectral Morlocks sheltered from the glare. The place, by the by,
+was very stuffy and oppressive, and the faint halitus of freshly
+shed blood was in the air. Some way down the central vista was a
+little table of white metal, laid with what seemed a meal. The
+Morlocks at any rate were carnivorous! Even at the time, I remember
+wondering what large animal could have survived to furnish the red
+joint I saw. It was all very indistinct: the heavy smell, the big
+unmeaning shapes, the obscene figures lurking in the shadows, and
+only waiting for the darkness to come at me again! Then the match
+burned down, and stung my fingers, and fell, a wriggling red spot
+in the blackness.
+
+'I have thought since how particularly ill-equipped I was for such
+an experience. When I had started with the Time Machine, I had
+started with the absurd assumption that the men of the Future would
+certainly be infinitely ahead of ourselves in all their appliances.
+I had come without arms, without medicine, without anything to
+smoke--at times I missed tobacco frightfully--even without enough
+matches. If only I had thought of a Kodak! I could have flashed that
+glimpse of the Underworld in a second, and examined it at leisure.
+But, as it was, I stood there with only the weapons and the powers
+that Nature had endowed me with--hands, feet, and teeth; these, and
+four safety-matches that still remained to me.
+
+'I was afraid to push my way in among all this machinery in the
+dark, and it was only with my last glimpse of light I discovered
+that my store of matches had run low. It had never occurred to me
+until that moment that there was any need to economize them, and I
+had wasted almost half the box in astonishing the Upper-worlders, to
+whom fire was a novelty. Now, as I say, I had four left, and while I
+stood in the dark, a hand touched mine, lank fingers came feeling
+over my face, and I was sensible of a peculiar unpleasant odour. I
+fancied I heard the breathing of a crowd of those dreadful little
+beings about me. I felt the box of matches in my hand being gently
+disengaged, and other hands behind me plucking at my clothing. The
+sense of these unseen creatures examining me was indescribably
+unpleasant. The sudden realization of my ignorance of their ways of
+thinking and doing came home to me very vividly in the darkness. I
+shouted at them as loudly as I could. They started away, and then
+I could feel them approaching me again. They clutched at me more
+boldly, whispering odd sounds to each other. I shivered violently,
+and shouted again--rather discordantly. This time they were not so
+seriously alarmed, and they made a queer laughing noise as they came
+back at me. I will confess I was horribly frightened. I determined
+to strike another match and escape under the protection of its
+glare. I did so, and eking out the flicker with a scrap of paper
+from my pocket, I made good my retreat to the narrow tunnel. But I
+had scarce entered this when my light was blown out and in the
+blackness I could hear the Morlocks rustling like wind among leaves,
+and pattering like the rain, as they hurried after me.
+
+'In a moment I was clutched by several hands, and there was no
+mistaking that they were trying to haul me back. I struck another
+light, and waved it in their dazzled faces. You can scarce imagine
+how nauseatingly inhuman they looked--those pale, chinless faces
+and great, lidless, pinkish-grey eyes!--as they stared in their
+blindness and bewilderment. But I did not stay to look, I promise
+you: I retreated again, and when my second match had ended, I struck
+my third. It had almost burned through when I reached the opening
+into the shaft. I lay down on the edge, for the throb of the great
+pump below made me giddy. Then I felt sideways for the projecting
+hooks, and, as I did so, my feet were grasped from behind, and I
+was violently tugged backward. I lit my last match ... and it
+incontinently went out. But I had my hand on the climbing bars now,
+and, kicking violently, I disengaged myself from the clutches of the
+Morlocks and was speedily clambering up the shaft, while they stayed
+peering and blinking up at me: all but one little wretch who
+followed me for some way, and well-nigh secured my boot as a trophy.
+
+'That climb seemed interminable to me. With the last twenty or
+thirty feet of it a deadly nausea came upon me. I had the greatest
+difficulty in keeping my hold. The last few yards was a frightful
+struggle against this faintness. Several times my head swam, and I
+felt all the sensations of falling. At last, however, I got over the
+well-mouth somehow, and staggered out of the ruin into the blinding
+sunlight. I fell upon my face. Even the soil smelt sweet and clean.
+Then I remember Weena kissing my hands and ears, and the voices of
+others among the Eloi. Then, for a time, I was insensible.
+
+
+
+
+VII
+
+
+'Now, indeed, I seemed in a worse case than before. Hitherto,
+except during my night's anguish at the loss of the Time Machine,
+I had felt a sustaining hope of ultimate escape, but that hope was
+staggered by these new discoveries. Hitherto I had merely thought
+myself impeded by the childish simplicity of the little people, and
+by some unknown forces which I had only to understand to overcome;
+but there was an altogether new element in the sickening quality of
+the Morlocks--a something inhuman and malign. Instinctively I
+loathed them. Before, I had felt as a man might feel who had fallen
+into a pit: my concern was with the pit and how to get out of it.
+Now I felt like a beast in a trap, whose enemy would come upon him
+soon.
+
+'The enemy I dreaded may surprise you. It was the darkness of the
+new moon. Weena had put this into my head by some at first
+incomprehensible remarks about the Dark Nights. It was not now
+such a very difficult problem to guess what the coming Dark Nights
+might mean. The moon was on the wane: each night there was a longer
+interval of darkness. And I now understood to some slight degree at
+least the reason of the fear of the little Upper-world people for
+the dark. I wondered vaguely what foul villainy it might be that
+the Morlocks did under the new moon. I felt pretty sure now that
+my second hypothesis was all wrong. The Upper-world people might
+once have been the favoured aristocracy, and the Morlocks their
+mechanical servants: but that had long since passed away. The two
+species that had resulted from the evolution of man were sliding
+down towards, or had already arrived at, an altogether new
+relationship. The Eloi, like the Carolingian kings, had decayed
+to a mere beautiful futility. They still possessed the earth on
+sufferance: since the Morlocks, subterranean for innumerable
+generations, had come at last to find the daylit surface
+intolerable. And the Morlocks made their garments, I inferred, and
+maintained them in their habitual needs, perhaps through the
+survival of an old habit of service. They did it as a standing horse
+paws with his foot, or as a man enjoys killing animals in sport:
+because ancient and departed necessities had impressed it on the
+organism. But, clearly, the old order was already in part reversed.
+The Nemesis of the delicate ones was creeping on apace. Ages ago,
+thousands of generations ago, man had thrust his brother man out of
+the ease and the sunshine. And now that brother was coming back
+changed! Already the Eloi had begun to learn one old lesson anew.
+They were becoming reacquainted with Fear. And suddenly there came
+into my head the memory of the meat I had seen in the Under-world.
+It seemed odd how it floated into my mind: not stirred up as it
+were by the current of my meditations, but coming in almost like a
+question from outside. I tried to recall the form of it. I had a
+vague sense of something familiar, but I could not tell what it was
+at the time.
+
+'Still, however helpless the little people in the presence of their
+mysterious Fear, I was differently constituted. I came out of this
+age of ours, this ripe prime of the human race, when Fear does not
+paralyse and mystery has lost its terrors. I at least would defend
+myself. Without further delay I determined to make myself arms and a
+fastness where I might sleep. With that refuge as a base, I could
+face this strange world with some of that confidence I had lost in
+realizing to what creatures night by night I lay exposed. I felt
+I could never sleep again until my bed was secure from them. I
+shuddered with horror to think how they must already have examined
+me.
+
+'I wandered during the afternoon along the valley of the Thames, but
+found nothing that commended itself to my mind as inaccessible. All
+the buildings and trees seemed easily practicable to such dexterous
+climbers as the Morlocks, to judge by their wells, must be. Then the
+tall pinnacles of the Palace of Green Porcelain and the polished
+gleam of its walls came back to my memory; and in the evening,
+taking Weena like a child upon my shoulder, I went up the hills
+towards the south-west. The distance, I had reckoned, was seven or
+eight miles, but it must have been nearer eighteen. I had first seen
+the place on a moist afternoon when distances are deceptively
+diminished. In addition, the heel of one of my shoes was loose, and
+a nail was working through the sole--they were comfortable old shoes
+I wore about indoors--so that I was lame. And it was already long
+past sunset when I came in sight of the palace, silhouetted black
+against the pale yellow of the sky.
+
+'Weena had been hugely delighted when I began to carry her, but
+after a while she desired me to let her down, and ran along by the
+side of me, occasionally darting off on either hand to pick flowers
+to stick in my pockets. My pockets had always puzzled Weena, but at
+the last she had concluded that they were an eccentric kind of vase
+for floral decoration. At least she utilized them for that purpose.
+And that reminds me! In changing my jacket I found...'
+
+The Time Traveller paused, put his hand into his pocket, and
+silently placed two withered flowers, not unlike very large white
+mallows, upon the little table. Then he resumed his narrative.
+
+'As the hush of evening crept over the world and we proceeded over
+the hill crest towards Wimbledon, Weena grew tired and wanted to
+return to the house of grey stone. But I pointed out the distant
+pinnacles of the Palace of Green Porcelain to her, and contrived to
+make her understand that we were seeking a refuge there from her
+Fear. You know that great pause that comes upon things before the
+dusk? Even the breeze stops in the trees. To me there is always an
+air of expectation about that evening stillness. The sky was clear,
+remote, and empty save for a few horizontal bars far down in the
+sunset. Well, that night the expectation took the colour of my
+fears. In that darkling calm my senses seemed preternaturally
+sharpened. I fancied I could even feel the hollowness of the ground
+beneath my feet: could, indeed, almost see through it the Morlocks
+on their ant-hill going hither and thither and waiting for the dark.
+In my excitement I fancied that they would receive my invasion of
+their burrows as a declaration of war. And why had they taken my
+Time Machine?
+
+'So we went on in the quiet, and the twilight deepened into night.
+The clear blue of the distance faded, and one star after another
+came out. The ground grew dim and the trees black. Weena's fears and
+her fatigue grew upon her. I took her in my arms and talked to her
+and caressed her. Then, as the darkness grew deeper, she put her
+arms round my neck, and, closing her eyes, tightly pressed her face
+against my shoulder. So we went down a long slope into a valley, and
+there in the dimness I almost walked into a little river. This I
+waded, and went up the opposite side of the valley, past a number
+of sleeping houses, and by a statue--a Faun, or some such figure,
+_minus_ the head. Here too were acacias. So far I had seen nothing of
+the Morlocks, but it was yet early in the night, and the darker hours
+before the old moon rose were still to come.
+
+'From the brow of the next hill I saw a thick wood spreading wide
+and black before me. I hesitated at this. I could see no end to
+it, either to the right or the left. Feeling tired--my feet, in
+particular, were very sore--I carefully lowered Weena from my
+shoulder as I halted, and sat down upon the turf. I could no
+longer see the Palace of Green Porcelain, and I was in doubt of my
+direction. I looked into the thickness of the wood and thought of
+what it might hide. Under that dense tangle of branches one would
+be out of sight of the stars. Even were there no other lurking
+danger--a danger I did not care to let my imagination loose
+upon--there would still be all the roots to stumble over and the
+tree-boles to strike against.
+
+'I was very tired, too, after the excitements of the day; so I
+decided that I would not face it, but would pass the night upon the
+open hill.
+
+'Weena, I was glad to find, was fast asleep. I carefully wrapped her
+in my jacket, and sat down beside her to wait for the moonrise. The
+hill-side was quiet and deserted, but from the black of the wood
+there came now and then a stir of living things. Above me shone the
+stars, for the night was very clear. I felt a certain sense of
+friendly comfort in their twinkling. All the old constellations
+had gone from the sky, however: that slow movement which is
+imperceptible in a hundred human lifetimes, had long since
+rearranged them in unfamiliar groupings. But the Milky Way, it
+seemed to me, was still the same tattered streamer of star-dust as
+of yore. Southward (as I judged it) was a very bright red star that
+was new to me; it was even more splendid than our own green Sirius.
+And amid all these scintillating points of light one bright planet
+shone kindly and steadily like the face of an old friend.
+
+'Looking at these stars suddenly dwarfed my own troubles and all
+the gravities of terrestrial life. I thought of their unfathomable
+distance, and the slow inevitable drift of their movements out of
+the unknown past into the unknown future. I thought of the great
+precessional cycle that the pole of the earth describes. Only forty
+times had that silent revolution occurred during all the years that
+I had traversed. And during these few revolutions all the activity,
+all the traditions, the complex organizations, the nations,
+languages, literatures, aspirations, even the mere memory of Man as
+I knew him, had been swept out of existence. Instead were these
+frail creatures who had forgotten their high ancestry, and the white
+Things of which I went in terror. Then I thought of the Great Fear
+that was between the two species, and for the first time, with a
+sudden shiver, came the clear knowledge of what the meat I had seen
+might be. Yet it was too horrible! I looked at little Weena sleeping
+beside me, her face white and starlike under the stars, and
+forthwith dismissed the thought.
+
+'Through that long night I held my mind off the Morlocks as well as
+I could, and whiled away the time by trying to fancy I could find
+signs of the old constellations in the new confusion. The sky kept
+very clear, except for a hazy cloud or so. No doubt I dozed at
+times. Then, as my vigil wore on, came a faintness in the eastward
+sky, like the reflection of some colourless fire, and the old moon
+rose, thin and peaked and white. And close behind, and overtaking
+it, and overflowing it, the dawn came, pale at first, and then
+growing pink and warm. No Morlocks had approached us. Indeed, I had
+seen none upon the hill that night. And in the confidence of renewed
+day it almost seemed to me that my fear had been unreasonable. I
+stood up and found my foot with the loose heel swollen at the ankle
+and painful under the heel; so I sat down again, took off my shoes,
+and flung them away.
+
+'I awakened Weena, and we went down into the wood, now green and
+pleasant instead of black and forbidding. We found some fruit
+wherewith to break our fast. We soon met others of the dainty ones,
+laughing and dancing in the sunlight as though there was no such
+thing in nature as the night. And then I thought once more of the
+meat that I had seen. I felt assured now of what it was, and from
+the bottom of my heart I pitied this last feeble rill from the great
+flood of humanity. Clearly, at some time in the Long-Ago of human
+decay the Morlocks' food had run short. Possibly they had lived on
+rats and such-like vermin. Even now man is far less discriminating
+and exclusive in his food than he was--far less than any monkey. His
+prejudice against human flesh is no deep-seated instinct. And so
+these inhuman sons of men----! I tried to look at the thing in a
+scientific spirit. After all, they were less human and more remote
+than our cannibal ancestors of three or four thousand years ago.
+And the intelligence that would have made this state of things a
+torment had gone. Why should I trouble myself? These Eloi were mere
+fatted cattle, which the ant-like Morlocks preserved and preyed
+upon--probably saw to the breeding of. And there was Weena dancing
+at my side!
+
+'Then I tried to preserve myself from the horror that was coming
+upon me, by regarding it as a rigorous punishment of human
+selfishness. Man had been content to live in ease and delight upon
+the labours of his fellow-man, had taken Necessity as his watchword
+and excuse, and in the fullness of time Necessity had come home to
+him. I even tried a Carlyle-like scorn of this wretched aristocracy
+in decay. But this attitude of mind was impossible. However great
+their intellectual degradation, the Eloi had kept too much of the
+human form not to claim my sympathy, and to make me perforce a
+sharer in their degradation and their Fear.
+
+'I had at that time very vague ideas as to the course I should
+pursue. My first was to secure some safe place of refuge, and to
+make myself such arms of metal or stone as I could contrive. That
+necessity was immediate. In the next place, I hoped to procure some
+means of fire, so that I should have the weapon of a torch at hand,
+for nothing, I knew, would be more efficient against these Morlocks.
+Then I wanted to arrange some contrivance to break open the doors of
+bronze under the White Sphinx. I had in mind a battering ram. I had
+a persuasion that if I could enter those doors and carry a blaze of
+light before me I should discover the Time Machine and escape. I
+could not imagine the Morlocks were strong enough to move it far
+away. Weena I had resolved to bring with me to our own time. And
+turning such schemes over in my mind I pursued our way towards the
+building which my fancy had chosen as our dwelling.
+
+
+
+
+VIII
+
+
+'I found the Palace of Green Porcelain, when we approached it about
+noon, deserted and falling into ruin. Only ragged vestiges of glass
+remained in its windows, and great sheets of the green facing had
+fallen away from the corroded metallic framework. It lay very high
+upon a turfy down, and looking north-eastward before I entered it, I
+was surprised to see a large estuary, or even creek, where I judged
+Wandsworth and Battersea must once have been. I thought then--though
+I never followed up the thought--of what might have happened, or
+might be happening, to the living things in the sea.
+
+'The material of the Palace proved on examination to be indeed
+porcelain, and along the face of it I saw an inscription in some
+unknown character. I thought, rather foolishly, that Weena might
+help me to interpret this, but I only learned that the bare idea of
+writing had never entered her head. She always seemed to me, I
+fancy, more human than she was, perhaps because her affection was so
+human.
+
+'Within the big valves of the door--which were open and broken--we
+found, instead of the customary hall, a long gallery lit by many
+side windows. At the first glance I was reminded of a museum.
+The tiled floor was thick with dust, and a remarkable array of
+miscellaneous objects was shrouded in the same grey covering. Then
+I perceived, standing strange and gaunt in the centre of the hall,
+what was clearly the lower part of a huge skeleton. I recognized
+by the oblique feet that it was some extinct creature after the
+fashion of the Megatherium. The skull and the upper bones lay
+beside it in the thick dust, and in one place, where rain-water had
+dropped through a leak in the roof, the thing itself had been worn
+away. Further in the gallery was the huge skeleton barrel of a
+Brontosaurus. My museum hypothesis was confirmed. Going towards the
+side I found what appeared to be sloping shelves, and clearing away
+the thick dust, I found the old familiar glass cases of our own
+time. But they must have been air-tight to judge from the fair
+preservation of some of their contents.
+
+'Clearly we stood among the ruins of some latter-day South
+Kensington! Here, apparently, was the Palaeontological Section,
+and a very splendid array of fossils it must have been, though the
+inevitable process of decay that had been staved off for a time, and
+had, through the extinction of bacteria and fungi, lost ninety-nine
+hundredths of its force, was nevertheless, with extreme sureness if
+with extreme slowness at work again upon all its treasures. Here and
+there I found traces of the little people in the shape of rare
+fossils broken to pieces or threaded in strings upon reeds. And the
+cases had in some instances been bodily removed--by the Morlocks as
+I judged. The place was very silent. The thick dust deadened our
+footsteps. Weena, who had been rolling a sea urchin down the sloping
+glass of a case, presently came, as I stared about me, and very
+quietly took my hand and stood beside me.
+
+'And at first I was so much surprised by this ancient monument of an
+intellectual age, that I gave no thought to the possibilities it
+presented. Even my preoccupation about the Time Machine receded a
+little from my mind.
+
+'To judge from the size of the place, this Palace of Green Porcelain
+had a great deal more in it than a Gallery of Palaeontology;
+possibly historical galleries; it might be, even a library! To me,
+at least in my present circumstances, these would be vastly more
+interesting than this spectacle of oldtime geology in decay.
+Exploring, I found another short gallery running transversely to the
+first. This appeared to be devoted to minerals, and the sight of a
+block of sulphur set my mind running on gunpowder. But I could find
+no saltpeter; indeed, no nitrates of any kind. Doubtless they had
+deliquesced ages ago. Yet the sulphur hung in my mind, and set up a
+train of thinking. As for the rest of the contents of that gallery,
+though on the whole they were the best preserved of all I saw, I had
+little interest. I am no specialist in mineralogy, and I went on
+down a very ruinous aisle running parallel to the first hall I had
+entered. Apparently this section had been devoted to natural
+history, but everything had long since passed out of recognition. A
+few shrivelled and blackened vestiges of what had once been stuffed
+animals, desiccated mummies in jars that had once held spirit, a
+brown dust of departed plants: that was all! I was sorry for that,
+because I should have been glad to trace the patent readjustments by
+which the conquest of animated nature had been attained. Then we
+came to a gallery of simply colossal proportions, but singularly
+ill-lit, the floor of it running downward at a slight angle from the
+end at which I entered. At intervals white globes hung from the
+ceiling--many of them cracked and smashed--which suggested that
+originally the place had been artificially lit. Here I was more in
+my element, for rising on either side of me were the huge bulks of
+big machines, all greatly corroded and many broken down, but some
+still fairly complete. You know I have a certain weakness for
+mechanism, and I was inclined to linger among these; the more so as
+for the most part they had the interest of puzzles, and I could make
+only the vaguest guesses at what they were for. I fancied that if
+I could solve their puzzles I should find myself in possession of
+powers that might be of use against the Morlocks.
+
+'Suddenly Weena came very close to my side. So suddenly that she
+startled me. Had it not been for her I do not think I should have
+noticed that the floor of the gallery sloped at all. [Footnote: It
+may be, of course, that the floor did not slope, but that the museum
+was built into the side of a hill.--ED.] The end I had come in at
+was quite above ground, and was lit by rare slit-like windows. As
+you went down the length, the ground came up against these windows,
+until at last there was a pit like the "area" of a London house
+before each, and only a narrow line of daylight at the top. I went
+slowly along, puzzling about the machines, and had been too intent
+upon them to notice the gradual diminution of the light, until
+Weena's increasing apprehensions drew my attention. Then I saw that
+the gallery ran down at last into a thick darkness. I hesitated, and
+then, as I looked round me, I saw that the dust was less abundant
+and its surface less even. Further away towards the dimness, it
+appeared to be broken by a number of small narrow footprints. My
+sense of the immediate presence of the Morlocks revived at that.
+I felt that I was wasting my time in the academic examination of
+machinery. I called to mind that it was already far advanced in the
+afternoon, and that I had still no weapon, no refuge, and no means
+of making a fire. And then down in the remote blackness of the
+gallery I heard a peculiar pattering, and the same odd noises I had
+heard down the well.
+
+'I took Weena's hand. Then, struck with a sudden idea, I left her
+and turned to a machine from which projected a lever not unlike
+those in a signal-box. Clambering upon the stand, and grasping this
+lever in my hands, I put all my weight upon it sideways. Suddenly
+Weena, deserted in the central aisle, began to whimper. I had judged
+the strength of the lever pretty correctly, for it snapped after a
+minute's strain, and I rejoined her with a mace in my hand more than
+sufficient, I judged, for any Morlock skull I might encounter. And I
+longed very much to kill a Morlock or so. Very inhuman, you may
+think, to want to go killing one's own descendants! But it was
+impossible, somehow, to feel any humanity in the things. Only my
+disinclination to leave Weena, and a persuasion that if I began to
+slake my thirst for murder my Time Machine might suffer, restrained
+me from going straight down the gallery and killing the brutes I
+heard.
+
+'Well, mace in one hand and Weena in the other, I went out of that
+gallery and into another and still larger one, which at the first
+glance reminded me of a military chapel hung with tattered flags.
+The brown and charred rags that hung from the sides of it, I
+presently recognized as the decaying vestiges of books. They had
+long since dropped to pieces, and every semblance of print had left
+them. But here and there were warped boards and cracked metallic
+clasps that told the tale well enough. Had I been a literary man I
+might, perhaps, have moralized upon the futility of all ambition.
+But as it was, the thing that struck me with keenest force was the
+enormous waste of labour to which this sombre wilderness of rotting
+paper testified. At the time I will confess that I thought chiefly
+of the _Philosophical Transactions_ and my own seventeen papers upon
+physical optics.
+
+'Then, going up a broad staircase, we came to what may once have
+been a gallery of technical chemistry. And here I had not a little
+hope of useful discoveries. Except at one end where the roof had
+collapsed, this gallery was well preserved. I went eagerly to every
+unbroken case. And at last, in one of the really air-tight cases,
+I found a box of matches. Very eagerly I tried them. They were
+perfectly good. They were not even damp. I turned to Weena. "Dance,"
+I cried to her in her own tongue. For now I had a weapon indeed
+against the horrible creatures we feared. And so, in that derelict
+museum, upon the thick soft carpeting of dust, to Weena's huge
+delight, I solemnly performed a kind of composite dance, whistling
+_The Land of the Leal_ as cheerfully as I could. In part it was a
+modest _cancan_, in part a step dance, in part a skirt-dance (so far
+as my tail-coat permitted), and in part original. For I am naturally
+inventive, as you know.
+
+'Now, I still think that for this box of matches to have escaped
+the wear of time for immemorial years was a most strange, as for
+me it was a most fortunate thing. Yet, oddly enough, I found a far
+unlikelier substance, and that was camphor. I found it in a sealed
+jar, that by chance, I suppose, had been really hermetically sealed.
+I fancied at first that it was paraffin wax, and smashed the glass
+accordingly. But the odour of camphor was unmistakable. In the
+universal decay this volatile substance had chanced to survive,
+perhaps through many thousands of centuries. It reminded me of a
+sepia painting I had once seen done from the ink of a fossil
+Belemnite that must have perished and become fossilized millions
+of years ago. I was about to throw it away, but I remembered that
+it was inflammable and burned with a good bright flame--was, in
+fact, an excellent candle--and I put it in my pocket. I found no
+explosives, however, nor any means of breaking down the bronze
+doors. As yet my iron crowbar was the most helpful thing I had
+chanced upon. Nevertheless I left that gallery greatly elated.
+
+'I cannot tell you all the story of that long afternoon. It would
+require a great effort of memory to recall my explorations in at all
+the proper order. I remember a long gallery of rusting stands of
+arms, and how I hesitated between my crowbar and a hatchet or a
+sword. I could not carry both, however, and my bar of iron promised
+best against the bronze gates. There were numbers of guns, pistols,
+and rifles. The most were masses of rust, but many were of some
+new metal, and still fairly sound. But any cartridges or powder
+there may once have been had rotted into dust. One corner I saw was
+charred and shattered; perhaps, I thought, by an explosion among the
+specimens. In another place was a vast array of idols--Polynesian,
+Mexican, Grecian, Phoenician, every country on earth I should think.
+And here, yielding to an irresistible impulse, I wrote my name upon
+the nose of a steatite monster from South America that particularly
+took my fancy.
+
+'As the evening drew on, my interest waned. I went through gallery
+after gallery, dusty, silent, often ruinous, the exhibits sometimes
+mere heaps of rust and lignite, sometimes fresher. In one place I
+suddenly found myself near the model of a tin-mine, and then by the
+merest accident I discovered, in an air-tight case, two dynamite
+cartridges! I shouted "Eureka!" and smashed the case with joy. Then
+came a doubt. I hesitated. Then, selecting a little side gallery,
+I made my essay. I never felt such a disappointment as I did in
+waiting five, ten, fifteen minutes for an explosion that never came.
+Of course the things were dummies, as I might have guessed from
+their presence. I really believe that had they not been so, I should
+have rushed off incontinently and blown Sphinx, bronze doors, and
+(as it proved) my chances of finding the Time Machine, all together
+into non-existence.
+
+'It was after that, I think, that we came to a little open court
+within the palace. It was turfed, and had three fruit-trees. So we
+rested and refreshed ourselves. Towards sunset I began to consider
+our position. Night was creeping upon us, and my inaccessible
+hiding-place had still to be found. But that troubled me very little
+now. I had in my possession a thing that was, perhaps, the best of
+all defences against the Morlocks--I had matches! I had the camphor
+in my pocket, too, if a blaze were needed. It seemed to me that
+the best thing we could do would be to pass the night in the open,
+protected by a fire. In the morning there was the getting of the
+Time Machine. Towards that, as yet, I had only my iron mace. But
+now, with my growing knowledge, I felt very differently towards
+those bronze doors. Up to this, I had refrained from forcing them,
+largely because of the mystery on the other side. They had never
+impressed me as being very strong, and I hoped to find my bar of
+iron not altogether inadequate for the work.
+
+
+
+
+IX
+
+
+'We emerged from the palace while the sun was still in part above
+the horizon. I was determined to reach the White Sphinx early the
+next morning, and ere the dusk I purposed pushing through the woods
+that had stopped me on the previous journey. My plan was to go as
+far as possible that night, and then, building a fire, to sleep
+in the protection of its glare. Accordingly, as we went along I
+gathered any sticks or dried grass I saw, and presently had my arms
+full of such litter. Thus loaded, our progress was slower than I had
+anticipated, and besides Weena was tired. And I began to suffer from
+sleepiness too; so that it was full night before we reached the
+wood. Upon the shrubby hill of its edge Weena would have stopped,
+fearing the darkness before us; but a singular sense of impending
+calamity, that should indeed have served me as a warning, drove me
+onward. I had been without sleep for a night and two days, and I was
+feverish and irritable. I felt sleep coming upon me, and the
+Morlocks with it.
+
+'While we hesitated, among the black bushes behind us, and dim
+against their blackness, I saw three crouching figures. There was
+scrub and long grass all about us, and I did not feel safe from
+their insidious approach. The forest, I calculated, was rather
+less than a mile across. If we could get through it to the bare
+hill-side, there, as it seemed to me, was an altogether safer
+resting-place; I thought that with my matches and my camphor I could
+contrive to keep my path illuminated through the woods. Yet it was
+evident that if I was to flourish matches with my hands I should
+have to abandon my firewood; so, rather reluctantly, I put it down.
+And then it came into my head that I would amaze our friends behind
+by lighting it. I was to discover the atrocious folly of this
+proceeding, but it came to my mind as an ingenious move for covering
+our retreat.
+
+'I don't know if you have ever thought what a rare thing flame must
+be in the absence of man and in a temperate climate. The sun's
+heat is rarely strong enough to burn, even when it is focused by
+dewdrops, as is sometimes the case in more tropical districts.
+Lightning may blast and blacken, but it rarely gives rise to
+widespread fire. Decaying vegetation may occasionally smoulder with
+the heat of its fermentation, but this rarely results in flame. In
+this decadence, too, the art of fire-making had been forgotten on
+the earth. The red tongues that went licking up my heap of wood were
+an altogether new and strange thing to Weena.
+
+'She wanted to run to it and play with it. I believe she would have
+cast herself into it had I not restrained her. But I caught her up,
+and in spite of her struggles, plunged boldly before me into the
+wood. For a little way the glare of my fire lit the path. Looking
+back presently, I could see, through the crowded stems, that from my
+heap of sticks the blaze had spread to some bushes adjacent, and a
+curved line of fire was creeping up the grass of the hill. I laughed
+at that, and turned again to the dark trees before me. It was very
+black, and Weena clung to me convulsively, but there was still, as
+my eyes grew accustomed to the darkness, sufficient light for me to
+avoid the stems. Overhead it was simply black, except where a gap of
+remote blue sky shone down upon us here and there. I struck none of
+my matches because I had no hand free. Upon my left arm I carried my
+little one, in my right hand I had my iron bar.
+
+'For some way I heard nothing but the crackling twigs under my feet,
+the faint rustle of the breeze above, and my own breathing and the
+throb of the blood-vessels in my ears. Then I seemed to know of a
+pattering about me. I pushed on grimly. The pattering grew more
+distinct, and then I caught the same queer sound and voices I had
+heard in the Under-world. There were evidently several of the
+Morlocks, and they were closing in upon me. Indeed, in another
+minute I felt a tug at my coat, then something at my arm. And Weena
+shivered violently, and became quite still.
+
+'It was time for a match. But to get one I must put her down. I did
+so, and, as I fumbled with my pocket, a struggle began in the
+darkness about my knees, perfectly silent on her part and with the
+same peculiar cooing sounds from the Morlocks. Soft little hands,
+too, were creeping over my coat and back, touching even my neck.
+Then the match scratched and fizzed. I held it flaring, and saw the
+white backs of the Morlocks in flight amid the trees. I hastily took
+a lump of camphor from my pocket, and prepared to light it as soon
+as the match should wane. Then I looked at Weena. She was lying
+clutching my feet and quite motionless, with her face to the ground.
+With a sudden fright I stooped to her. She seemed scarcely to
+breathe. I lit the block of camphor and flung it to the ground,
+and as it split and flared up and drove back the Morlocks and the
+shadows, I knelt down and lifted her. The wood behind seemed full of
+the stir and murmur of a great company!
+
+'She seemed to have fainted. I put her carefully upon my shoulder
+and rose to push on, and then there came a horrible realization. In
+manoeuvring with my matches and Weena, I had turned myself about
+several times, and now I had not the faintest idea in what direction
+lay my path. For all I knew, I might be facing back towards the
+Palace of Green Porcelain. I found myself in a cold sweat. I had to
+think rapidly what to do. I determined to build a fire and encamp
+where we were. I put Weena, still motionless, down upon a turfy
+bole, and very hastily, as my first lump of camphor waned, I began
+collecting sticks and leaves. Here and there out of the darkness
+round me the Morlocks' eyes shone like carbuncles.
+
+'The camphor flickered and went out. I lit a match, and as I did so,
+two white forms that had been approaching Weena dashed hastily away.
+One was so blinded by the light that he came straight for me, and I
+felt his bones grind under the blow of my fist. He gave a whoop of
+dismay, staggered a little way, and fell down. I lit another piece
+of camphor, and went on gathering my bonfire. Presently I noticed
+how dry was some of the foliage above me, for since my arrival
+on the Time Machine, a matter of a week, no rain had fallen. So,
+instead of casting about among the trees for fallen twigs, I began
+leaping up and dragging down branches. Very soon I had a choking
+smoky fire of green wood and dry sticks, and could economize my
+camphor. Then I turned to where Weena lay beside my iron mace. I
+tried what I could to revive her, but she lay like one dead. I could
+not even satisfy myself whether or not she breathed.
+
+'Now, the smoke of the fire beat over towards me, and it must have
+made me heavy of a sudden. Moreover, the vapour of camphor was in
+the air. My fire would not need replenishing for an hour or so. I
+felt very weary after my exertion, and sat down. The wood, too, was
+full of a slumbrous murmur that I did not understand. I seemed just
+to nod and open my eyes. But all was dark, and the Morlocks had
+their hands upon me. Flinging off their clinging fingers I hastily
+felt in my pocket for the match-box, and--it had gone! Then they
+gripped and closed with me again. In a moment I knew what had
+happened. I had slept, and my fire had gone out, and the bitterness
+of death came over my soul. The forest seemed full of the smell of
+burning wood. I was caught by the neck, by the hair, by the arms,
+and pulled down. It was indescribably horrible in the darkness to
+feel all these soft creatures heaped upon me. I felt as if I was in
+a monstrous spider's web. I was overpowered, and went down. I felt
+little teeth nipping at my neck. I rolled over, and as I did so my
+hand came against my iron lever. It gave me strength. I struggled
+up, shaking the human rats from me, and, holding the bar short,
+I thrust where I judged their faces might be. I could feel the
+succulent giving of flesh and bone under my blows, and for a moment
+I was free.
+
+'The strange exultation that so often seems to accompany hard
+fighting came upon me. I knew that both I and Weena were lost, but I
+determined to make the Morlocks pay for their meat. I stood with my
+back to a tree, swinging the iron bar before me. The whole wood was
+full of the stir and cries of them. A minute passed. Their voices
+seemed to rise to a higher pitch of excitement, and their movements
+grew faster. Yet none came within reach. I stood glaring at the
+blackness. Then suddenly came hope. What if the Morlocks were
+afraid? And close on the heels of that came a strange thing. The
+darkness seemed to grow luminous. Very dimly I began to see the
+Morlocks about me--three battered at my feet--and then I recognized,
+with incredulous surprise, that the others were running, in an
+incessant stream, as it seemed, from behind me, and away through the
+wood in front. And their backs seemed no longer white, but reddish.
+As I stood agape, I saw a little red spark go drifting across a gap
+of starlight between the branches, and vanish. And at that I
+understood the smell of burning wood, the slumbrous murmur that was
+growing now into a gusty roar, the red glow, and the Morlocks'
+flight.
+
+'Stepping out from behind my tree and looking back, I saw, through
+the black pillars of the nearer trees, the flames of the burning
+forest. It was my first fire coming after me. With that I looked for
+Weena, but she was gone. The hissing and crackling behind me, the
+explosive thud as each fresh tree burst into flame, left little
+time for reflection. My iron bar still gripped, I followed in the
+Morlocks' path. It was a close race. Once the flames crept forward
+so swiftly on my right as I ran that I was outflanked and had to
+strike off to the left. But at last I emerged upon a small open
+space, and as I did so, a Morlock came blundering towards me, and
+past me, and went on straight into the fire!
+
+'And now I was to see the most weird and horrible thing, I think, of
+all that I beheld in that future age. This whole space was as bright
+as day with the reflection of the fire. In the centre was a hillock
+or tumulus, surmounted by a scorched hawthorn. Beyond this was
+another arm of the burning forest, with yellow tongues already
+writhing from it, completely encircling the space with a fence of
+fire. Upon the hill-side were some thirty or forty Morlocks, dazzled
+by the light and heat, and blundering hither and thither against
+each other in their bewilderment. At first I did not realize their
+blindness, and struck furiously at them with my bar, in a frenzy of
+fear, as they approached me, killing one and crippling several more.
+But when I had watched the gestures of one of them groping under the
+hawthorn against the red sky, and heard their moans, I was assured
+of their absolute helplessness and misery in the glare, and I struck
+no more of them.
+
+'Yet every now and then one would come straight towards me, setting
+loose a quivering horror that made me quick to elude him. At one
+time the flames died down somewhat, and I feared the foul creatures
+would presently be able to see me. I was thinking of beginning the
+fight by killing some of them before this should happen; but the
+fire burst out again brightly, and I stayed my hand. I walked about
+the hill among them and avoided them, looking for some trace of
+Weena. But Weena was gone.
+
+'At last I sat down on the summit of the hillock, and watched this
+strange incredible company of blind things groping to and fro, and
+making uncanny noises to each other, as the glare of the fire beat
+on them. The coiling uprush of smoke streamed across the sky, and
+through the rare tatters of that red canopy, remote as though they
+belonged to another universe, shone the little stars. Two or three
+Morlocks came blundering into me, and I drove them off with blows
+of my fists, trembling as I did so.
+
+'For the most part of that night I was persuaded it was a nightmare.
+I bit myself and screamed in a passionate desire to awake. I beat
+the ground with my hands, and got up and sat down again, and
+wandered here and there, and again sat down. Then I would fall to
+rubbing my eyes and calling upon God to let me awake. Thrice I saw
+Morlocks put their heads down in a kind of agony and rush into the
+flames. But, at last, above the subsiding red of the fire, above the
+streaming masses of black smoke and the whitening and blackening
+tree stumps, and the diminishing numbers of these dim creatures,
+came the white light of the day.
+
+'I searched again for traces of Weena, but there were none. It was
+plain that they had left her poor little body in the forest. I
+cannot describe how it relieved me to think that it had escaped the
+awful fate to which it seemed destined. As I thought of that, I was
+almost moved to begin a massacre of the helpless abominations about
+me, but I contained myself. The hillock, as I have said, was a kind
+of island in the forest. From its summit I could now make out
+through a haze of smoke the Palace of Green Porcelain, and from that
+I could get my bearings for the White Sphinx. And so, leaving the
+remnant of these damned souls still going hither and thither and
+moaning, as the day grew clearer, I tied some grass about my feet
+and limped on across smoking ashes and among black stems, that still
+pulsated internally with fire, towards the hiding-place of the Time
+Machine. I walked slowly, for I was almost exhausted, as well as
+lame, and I felt the intensest wretchedness for the horrible death
+of little Weena. It seemed an overwhelming calamity. Now, in this
+old familiar room, it is more like the sorrow of a dream than an
+actual loss. But that morning it left me absolutely lonely
+again--terribly alone. I began to think of this house of mine, of
+this fireside, of some of you, and with such thoughts came a longing
+that was pain.
+
+'But as I walked over the smoking ashes under the bright morning
+sky, I made a discovery. In my trouser pocket were still some loose
+matches. The box must have leaked before it was lost.
+
+
+
+
+X
+
+
+'About eight or nine in the morning I came to the same seat of
+yellow metal from which I had viewed the world upon the evening of
+my arrival. I thought of my hasty conclusions upon that evening and
+could not refrain from laughing bitterly at my confidence. Here
+was the same beautiful scene, the same abundant foliage, the same
+splendid palaces and magnificent ruins, the same silver river
+running between its fertile banks. The gay robes of the beautiful
+people moved hither and thither among the trees. Some were bathing
+in exactly the place where I had saved Weena, and that suddenly gave
+me a keen stab of pain. And like blots upon the landscape rose the
+cupolas above the ways to the Under-world. I understood now what all
+the beauty of the Over-world people covered. Very pleasant was their
+day, as pleasant as the day of the cattle in the field. Like the
+cattle, they knew of no enemies and provided against no needs. And
+their end was the same.
+
+'I grieved to think how brief the dream of the human intellect had
+been. It had committed suicide. It had set itself steadfastly
+towards comfort and ease, a balanced society with security and
+permanency as its watchword, it had attained its hopes--to come
+to this at last. Once, life and property must have reached almost
+absolute safety. The rich had been assured of his wealth and
+comfort, the toiler assured of his life and work. No doubt in that
+perfect world there had been no unemployed problem, no social
+question left unsolved. And a great quiet had followed.
+
+'It is a law of nature we overlook, that intellectual versatility
+is the compensation for change, danger, and trouble. An animal
+perfectly in harmony with its environment is a perfect mechanism.
+Nature never appeals to intelligence until habit and instinct are
+useless. There is no intelligence where there is no change and no
+need of change. Only those animals partake of intelligence that have
+to meet a huge variety of needs and dangers.
+
+'So, as I see it, the Upper-world man had drifted towards his
+feeble prettiness, and the Under-world to mere mechanical industry.
+But that perfect state had lacked one thing even for mechanical
+perfection--absolute permanency. Apparently as time went on, the
+feeding of the Under-world, however it was effected, had become
+disjointed. Mother Necessity, who had been staved off for a
+few thousand years, came back again, and she began below. The
+Under-world being in contact with machinery, which, however perfect,
+still needs some little thought outside habit, had probably retained
+perforce rather more initiative, if less of every other human
+character, than the Upper. And when other meat failed them, they
+turned to what old habit had hitherto forbidden. So I say I saw it
+in my last view of the world of Eight Hundred and Two Thousand Seven
+Hundred and One. It may be as wrong an explanation as mortal wit
+could invent. It is how the thing shaped itself to me, and as that I
+give it to you.
+
+'After the fatigues, excitements, and terrors of the past days, and
+in spite of my grief, this seat and the tranquil view and the warm
+sunlight were very pleasant. I was very tired and sleepy, and soon
+my theorizing passed into dozing. Catching myself at that, I took my
+own hint, and spreading myself out upon the turf I had a long and
+refreshing sleep.
+
+'I awoke a little before sunsetting. I now felt safe against being
+caught napping by the Morlocks, and, stretching myself, I came on
+down the hill towards the White Sphinx. I had my crowbar in one
+hand, and the other hand played with the matches in my pocket.
+
+'And now came a most unexpected thing. As I approached the pedestal
+of the sphinx I found the bronze valves were open. They had slid
+down into grooves.
+
+'At that I stopped short before them, hesitating to enter.
+
+'Within was a small apartment, and on a raised place in the corner
+of this was the Time Machine. I had the small levers in my pocket.
+So here, after all my elaborate preparations for the siege of the
+White Sphinx, was a meek surrender. I threw my iron bar away, almost
+sorry not to use it.
+
+'A sudden thought came into my head as I stooped towards the portal.
+For once, at least, I grasped the mental operations of the Morlocks.
+Suppressing a strong inclination to laugh, I stepped through the
+bronze frame and up to the Time Machine. I was surprised to find it
+had been carefully oiled and cleaned. I have suspected since that
+the Morlocks had even partially taken it to pieces while trying in
+their dim way to grasp its purpose.
+
+'Now as I stood and examined it, finding a pleasure in the mere
+touch of the contrivance, the thing I had expected happened. The
+bronze panels suddenly slid up and struck the frame with a clang.
+I was in the dark--trapped. So the Morlocks thought. At that I
+chuckled gleefully.
+
+'I could already hear their murmuring laughter as they came towards
+me. Very calmly I tried to strike the match. I had only to fix on
+the levers and depart then like a ghost. But I had overlooked one
+little thing. The matches were of that abominable kind that light
+only on the box.
+
+'You may imagine how all my calm vanished. The little brutes were
+close upon me. One touched me. I made a sweeping blow in the dark at
+them with the levers, and began to scramble into the saddle of the
+machine. Then came one hand upon me and then another. Then I had
+simply to fight against their persistent fingers for my levers, and
+at the same time feel for the studs over which these fitted. One,
+indeed, they almost got away from me. As it slipped from my hand,
+I had to butt in the dark with my head--I could hear the Morlock's
+skull ring--to recover it. It was a nearer thing than the fight in
+the forest, I think, this last scramble.
+
+'But at last the lever was fitted and pulled over. The clinging
+hands slipped from me. The darkness presently fell from my eyes.
+I found myself in the same grey light and tumult I have already
+described.
+
+
+
+
+XI
+
+
+'I have already told you of the sickness and confusion that comes
+with time travelling. And this time I was not seated properly in the
+saddle, but sideways and in an unstable fashion. For an indefinite
+time I clung to the machine as it swayed and vibrated, quite
+unheeding how I went, and when I brought myself to look at the dials
+again I was amazed to find where I had arrived. One dial records
+days, and another thousands of days, another millions of days, and
+another thousands of millions. Now, instead of reversing the levers,
+I had pulled them over so as to go forward with them, and when I
+came to look at these indicators I found that the thousands hand was
+sweeping round as fast as the seconds hand of a watch--into
+futurity.
+
+'As I drove on, a peculiar change crept over the appearance of
+things. The palpitating greyness grew darker; then--though I was
+still travelling with prodigious velocity--the blinking succession
+of day and night, which was usually indicative of a slower pace,
+returned, and grew more and more marked. This puzzled me very much
+at first. The alternations of night and day grew slower and slower,
+and so did the passage of the sun across the sky, until they seemed
+to stretch through centuries. At last a steady twilight brooded over
+the earth, a twilight only broken now and then when a comet glared
+across the darkling sky. The band of light that had indicated the
+sun had long since disappeared; for the sun had ceased to set--it
+simply rose and fell in the west, and grew ever broader and more
+red. All trace of the moon had vanished. The circling of the stars,
+growing slower and slower, had given place to creeping points of
+light. At last, some time before I stopped, the sun, red and very
+large, halted motionless upon the horizon, a vast dome glowing with
+a dull heat, and now and then suffering a momentary extinction. At
+one time it had for a little while glowed more brilliantly again,
+but it speedily reverted to its sullen red heat. I perceived by this
+slowing down of its rising and setting that the work of the tidal
+drag was done. The earth had come to rest with one face to the sun,
+even as in our own time the moon faces the earth. Very cautiously,
+for I remembered my former headlong fall, I began to reverse
+my motion. Slower and slower went the circling hands until the
+thousands one seemed motionless and the daily one was no longer a
+mere mist upon its scale. Still slower, until the dim outlines of a
+desolate beach grew visible.
+
+'I stopped very gently and sat upon the Time Machine, looking round.
+The sky was no longer blue. North-eastward it was inky black,
+and out of the blackness shone brightly and steadily the pale
+white stars. Overhead it was a deep Indian red and starless, and
+south-eastward it grew brighter to a glowing scarlet where, cut by
+the horizon, lay the huge hull of the sun, red and motionless. The
+rocks about me were of a harsh reddish colour, and all the trace of
+life that I could see at first was the intensely green vegetation
+that covered every projecting point on their south-eastern face. It
+was the same rich green that one sees on forest moss or on the
+lichen in caves: plants which like these grow in a perpetual
+twilight.
+
+'The machine was standing on a sloping beach. The sea stretched away
+to the south-west, to rise into a sharp bright horizon against the
+wan sky. There were no breakers and no waves, for not a breath of
+wind was stirring. Only a slight oily swell rose and fell like a
+gentle breathing, and showed that the eternal sea was still moving
+and living. And along the margin where the water sometimes broke was
+a thick incrustation of salt--pink under the lurid sky. There was a
+sense of oppression in my head, and I noticed that I was breathing
+very fast. The sensation reminded me of my only experience of
+mountaineering, and from that I judged the air to be more rarefied
+than it is now.
+
+'Far away up the desolate slope I heard a harsh scream, and saw a
+thing like a huge white butterfly go slanting and fluttering up into
+the sky and, circling, disappear over some low hillocks beyond. The
+sound of its voice was so dismal that I shivered and seated myself
+more firmly upon the machine. Looking round me again, I saw that,
+quite near, what I had taken to be a reddish mass of rock was moving
+slowly towards me. Then I saw the thing was really a monstrous
+crab-like creature. Can you imagine a crab as large as yonder table,
+with its many legs moving slowly and uncertainly, its big claws
+swaying, its long antennae, like carters' whips, waving and feeling,
+and its stalked eyes gleaming at you on either side of its metallic
+front? Its back was corrugated and ornamented with ungainly bosses,
+and a greenish incrustation blotched it here and there. I could see
+the many palps of its complicated mouth flickering and feeling as it
+moved.
+
+'As I stared at this sinister apparition crawling towards me, I felt
+a tickling on my cheek as though a fly had lighted there. I tried to
+brush it away with my hand, but in a moment it returned, and almost
+immediately came another by my ear. I struck at this, and caught
+something threadlike. It was drawn swiftly out of my hand. With a
+frightful qualm, I turned, and I saw that I had grasped the antenna
+of another monster crab that stood just behind me. Its evil eyes
+were wriggling on their stalks, its mouth was all alive with
+appetite, and its vast ungainly claws, smeared with an algal slime,
+were descending upon me. In a moment my hand was on the lever, and
+I had placed a month between myself and these monsters. But I was
+still on the same beach, and I saw them distinctly now as soon as I
+stopped. Dozens of them seemed to be crawling here and there, in the
+sombre light, among the foliated sheets of intense green.
+
+'I cannot convey the sense of abominable desolation that hung over
+the world. The red eastern sky, the northward blackness, the salt
+Dead Sea, the stony beach crawling with these foul, slow-stirring
+monsters, the uniform poisonous-looking green of the lichenous
+plants, the thin air that hurts one's lungs: all contributed to an
+appalling effect. I moved on a hundred years, and there was the same
+red sun--a little larger, a little duller--the same dying sea, the
+same chill air, and the same crowd of earthy crustacea creeping in
+and out among the green weed and the red rocks. And in the westward
+sky, I saw a curved pale line like a vast new moon.
+
+'So I travelled, stopping ever and again, in great strides of a
+thousand years or more, drawn on by the mystery of the earth's fate,
+watching with a strange fascination the sun grow larger and duller
+in the westward sky, and the life of the old earth ebb away. At
+last, more than thirty million years hence, the huge red-hot dome of
+the sun had come to obscure nearly a tenth part of the darkling
+heavens. Then I stopped once more, for the crawling multitude of
+crabs had disappeared, and the red beach, save for its livid green
+liverworts and lichens, seemed lifeless. And now it was flecked with
+white. A bitter cold assailed me. Rare white flakes ever and again
+came eddying down. To the north-eastward, the glare of snow lay
+under the starlight of the sable sky and I could see an undulating
+crest of hillocks pinkish white. There were fringes of ice along the
+sea margin, with drifting masses further out; but the main expanse
+of that salt ocean, all bloody under the eternal sunset, was still
+unfrozen.
+
+'I looked about me to see if any traces of animal life remained. A
+certain indefinable apprehension still kept me in the saddle of the
+machine. But I saw nothing moving, in earth or sky or sea. The green
+slime on the rocks alone testified that life was not extinct. A
+shallow sandbank had appeared in the sea and the water had receded
+from the beach. I fancied I saw some black object flopping about
+upon this bank, but it became motionless as I looked at it, and I
+judged that my eye had been deceived, and that the black object was
+merely a rock. The stars in the sky were intensely bright and seemed
+to me to twinkle very little.
+
+'Suddenly I noticed that the circular westward outline of the sun
+had changed; that a concavity, a bay, had appeared in the curve. I
+saw this grow larger. For a minute perhaps I stared aghast at this
+blackness that was creeping over the day, and then I realized that
+an eclipse was beginning. Either the moon or the planet Mercury was
+passing across the sun's disk. Naturally, at first I took it to be
+the moon, but there is much to incline me to believe that what I
+really saw was the transit of an inner planet passing very near to
+the earth.
+
+'The darkness grew apace; a cold wind began to blow in freshening
+gusts from the east, and the showering white flakes in the air
+increased in number. From the edge of the sea came a ripple and
+whisper. Beyond these lifeless sounds the world was silent. Silent?
+It would be hard to convey the stillness of it. All the sounds of
+man, the bleating of sheep, the cries of birds, the hum of insects,
+the stir that makes the background of our lives--all that was over.
+As the darkness thickened, the eddying flakes grew more abundant,
+dancing before my eyes; and the cold of the air more intense. At
+last, one by one, swiftly, one after the other, the white peaks of
+the distant hills vanished into blackness. The breeze rose to a
+moaning wind. I saw the black central shadow of the eclipse sweeping
+towards me. In another moment the pale stars alone were visible. All
+else was rayless obscurity. The sky was absolutely black.
+
+'A horror of this great darkness came on me. The cold, that smote
+to my marrow, and the pain I felt in breathing, overcame me. I
+shivered, and a deadly nausea seized me. Then like a red-hot bow
+in the sky appeared the edge of the sun. I got off the machine to
+recover myself. I felt giddy and incapable of facing the return
+journey. As I stood sick and confused I saw again the moving thing
+upon the shoal--there was no mistake now that it was a moving
+thing--against the red water of the sea. It was a round thing, the
+size of a football perhaps, or, it may be, bigger, and tentacles
+trailed down from it; it seemed black against the weltering
+blood-red water, and it was hopping fitfully about. Then I felt I
+was fainting. But a terrible dread of lying helpless in that remote
+and awful twilight sustained me while I clambered upon the saddle.
+
+
+
+
+XII
+
+
+'So I came back. For a long time I must have been insensible upon
+the machine. The blinking succession of the days and nights was
+resumed, the sun got golden again, the sky blue. I breathed with
+greater freedom. The fluctuating contours of the land ebbed and
+flowed. The hands spun backward upon the dials. At last I saw again
+the dim shadows of houses, the evidences of decadent humanity.
+These, too, changed and passed, and others came. Presently, when the
+million dial was at zero, I slackened speed. I began to recognize
+our own pretty and familiar architecture, the thousands hand ran back
+to the starting-point, the night and day flapped slower and slower.
+Then the old walls of the laboratory came round me. Very gently,
+now, I slowed the mechanism down.
+
+'I saw one little thing that seemed odd to me. I think I have told
+you that when I set out, before my velocity became very high, Mrs.
+Watchett had walked across the room, travelling, as it seemed to me,
+like a rocket. As I returned, I passed again across that minute when
+she traversed the laboratory. But now her every motion appeared to
+be the exact inversion of her previous ones. The door at the lower
+end opened, and she glided quietly up the laboratory, back foremost,
+and disappeared behind the door by which she had previously entered.
+Just before that I seemed to see Hillyer for a moment; but he passed
+like a flash.
+
+'Then I stopped the machine, and saw about me again the old familiar
+laboratory, my tools, my appliances just as I had left them. I got
+off the thing very shakily, and sat down upon my bench. For several
+minutes I trembled violently. Then I became calmer. Around me was
+my old workshop again, exactly as it had been. I might have slept
+there, and the whole thing have been a dream.
+
+'And yet, not exactly! The thing had started from the south-east
+corner of the laboratory. It had come to rest again in the
+north-west, against the wall where you saw it. That gives you the
+exact distance from my little lawn to the pedestal of the White
+Sphinx, into which the Morlocks had carried my machine.
+
+'For a time my brain went stagnant. Presently I got up and came
+through the passage here, limping, because my heel was still
+painful, and feeling sorely begrimed. I saw the _Pall Mall Gazette_
+on the table by the door. I found the date was indeed to-day, and
+looking at the timepiece, saw the hour was almost eight o'clock. I
+heard your voices and the clatter of plates. I hesitated--I felt so
+sick and weak. Then I sniffed good wholesome meat, and opened the
+door on you. You know the rest. I washed, and dined, and now I am
+telling you the story.
+
+'I know,' he said, after a pause, 'that all this will be absolutely
+incredible to you. To me the one incredible thing is that I am here
+to-night in this old familiar room looking into your friendly faces
+and telling you these strange adventures.'
+
+He looked at the Medical Man. 'No. I cannot expect you to believe
+it. Take it as a lie--or a prophecy. Say I dreamed it in the
+workshop. Consider I have been speculating upon the destinies of our
+race until I have hatched this fiction. Treat my assertion of its
+truth as a mere stroke of art to enhance its interest. And taking
+it as a story, what do you think of it?'
+
+He took up his pipe, and began, in his old accustomed manner, to tap
+with it nervously upon the bars of the grate. There was a momentary
+stillness. Then chairs began to creak and shoes to scrape upon the
+carpet. I took my eyes off the Time Traveller's face, and looked
+round at his audience. They were in the dark, and little spots of
+colour swam before them. The Medical Man seemed absorbed in the
+contemplation of our host. The Editor was looking hard at the end
+of his cigar--the sixth. The Journalist fumbled for his watch. The
+others, as far as I remember, were motionless.
+
+The Editor stood up with a sigh. 'What a pity it is you're not
+a writer of stories!' he said, putting his hand on the Time
+Traveller's shoulder.
+
+'You don't believe it?'
+
+'Well----'
+
+'I thought not.'
+
+The Time Traveller turned to us. 'Where are the matches?' he said.
+He lit one and spoke over his pipe, puffing. 'To tell you the truth
+... I hardly believe it myself.... And yet...'
+
+His eye fell with a mute inquiry upon the withered white flowers
+upon the little table. Then he turned over the hand holding his
+pipe, and I saw he was looking at some half-healed scars on his
+knuckles.
+
+The Medical Man rose, came to the lamp, and examined the flowers.
+'The gynaeceum's odd,' he said. The Psychologist leant forward to
+see, holding out his hand for a specimen.
+
+'I'm hanged if it isn't a quarter to one,' said the Journalist.
+'How shall we get home?'
+
+'Plenty of cabs at the station,' said the Psychologist.
+
+'It's a curious thing,' said the Medical Man; 'but I certainly don't
+know the natural order of these flowers. May I have them?'
+
+The Time Traveller hesitated. Then suddenly: 'Certainly not.'
+
+'Where did you really get them?' said the Medical Man.
+
+The Time Traveller put his hand to his head. He spoke like one who
+was trying to keep hold of an idea that eluded him. 'They were put
+into my pocket by Weena, when I travelled into Time.' He stared
+round the room. 'I'm damned if it isn't all going. This room and you
+and the atmosphere of every day is too much for my memory. Did I
+ever make a Time Machine, or a model of a Time Machine? Or is it all
+only a dream? They say life is a dream, a precious poor dream at
+times--but I can't stand another that won't fit. It's madness. And
+where did the dream come from? ... I must look at that machine. If
+there is one!'
+
+He caught up the lamp swiftly, and carried it, flaring red, through
+the door into the corridor. We followed him. There in the flickering
+light of the lamp was the machine sure enough, squat, ugly, and
+askew; a thing of brass, ebony, ivory, and translucent glimmering
+quartz. Solid to the touch--for I put out my hand and felt the rail
+of it--and with brown spots and smears upon the ivory, and bits of
+grass and moss upon the lower parts, and one rail bent awry.
+
+The Time Traveller put the lamp down on the bench, and ran his hand
+along the damaged rail. 'It's all right now,' he said. 'The story I
+told you was true. I'm sorry to have brought you out here in the
+cold.' He took up the lamp, and, in an absolute silence, we
+returned to the smoking-room.
+
+He came into the hall with us and helped the Editor on with his
+coat. The Medical Man looked into his face and, with a certain
+hesitation, told him he was suffering from overwork, at which he
+laughed hugely. I remember him standing in the open doorway, bawling
+good night.
+
+I shared a cab with the Editor. He thought the tale a 'gaudy lie.'
+For my own part I was unable to come to a conclusion. The story was
+so fantastic and incredible, the telling so credible and sober. I
+lay awake most of the night thinking about it. I determined to go
+next day and see the Time Traveller again. I was told he was in the
+laboratory, and being on easy terms in the house, I went up to him.
+The laboratory, however, was empty. I stared for a minute at the
+Time Machine and put out my hand and touched the lever. At that the
+squat substantial-looking mass swayed like a bough shaken by the
+wind. Its instability startled me extremely, and I had a queer
+reminiscence of the childish days when I used to be forbidden to
+meddle. I came back through the corridor. The Time Traveller met me
+in the smoking-room. He was coming from the house. He had a small
+camera under one arm and a knapsack under the other. He laughed when
+he saw me, and gave me an elbow to shake. 'I'm frightfully busy,'
+said he, 'with that thing in there.'
+
+'But is it not some hoax?' I said. 'Do you really travel through
+time?'
+
+'Really and truly I do.' And he looked frankly into my eyes. He
+hesitated. His eye wandered about the room. 'I only want half an
+hour,' he said. 'I know why you came, and it's awfully good of you.
+There's some magazines here. If you'll stop to lunch I'll prove you
+this time travelling up to the hilt, specimen and all. If you'll
+forgive my leaving you now?'
+
+I consented, hardly comprehending then the full import of his words,
+and he nodded and went on down the corridor. I heard the door of
+the laboratory slam, seated myself in a chair, and took up a daily
+paper. What was he going to do before lunch-time? Then suddenly
+I was reminded by an advertisement that I had promised to meet
+Richardson, the publisher, at two. I looked at my watch, and saw
+that I could barely save that engagement. I got up and went down the
+passage to tell the Time Traveller.
+
+As I took hold of the handle of the door I heard an exclamation,
+oddly truncated at the end, and a click and a thud. A gust of air
+whirled round me as I opened the door, and from within came the
+sound of broken glass falling on the floor. The Time Traveller was
+not there. I seemed to see a ghostly, indistinct figure sitting in
+a whirling mass of black and brass for a moment--a figure so
+transparent that the bench behind with its sheets of drawings was
+absolutely distinct; but this phantasm vanished as I rubbed my eyes.
+The Time Machine had gone. Save for a subsiding stir of dust, the
+further end of the laboratory was empty. A pane of the skylight had,
+apparently, just been blown in.
+
+I felt an unreasonable amazement. I knew that something strange had
+happened, and for the moment could not distinguish what the strange
+thing might be. As I stood staring, the door into the garden opened,
+and the man-servant appeared.
+
+We looked at each other. Then ideas began to come. 'Has Mr. ----
+gone out that way?' said I.
+
+'No, sir. No one has come out this way. I was expecting to find him
+here.'
+
+At that I understood. At the risk of disappointing Richardson I
+stayed on, waiting for the Time Traveller; waiting for the second,
+perhaps still stranger story, and the specimens and photographs he
+would bring with him. But I am beginning now to fear that I must
+wait a lifetime. The Time Traveller vanished three years ago. And,
+as everybody knows now, he has never returned.
+
+
+
+
+EPILOGUE
+
+
+One cannot choose but wonder. Will he ever return? It may be that he
+swept back into the past, and fell among the blood-drinking, hairy
+savages of the Age of Unpolished Stone; into the abysses of the
+Cretaceous Sea; or among the grotesque saurians, the huge reptilian
+brutes of the Jurassic times. He may even now--if I may use the
+phrase--be wandering on some plesiosaurus-haunted Oolitic coral
+reef, or beside the lonely saline lakes of the Triassic Age. Or did
+he go forward, into one of the nearer ages, in which men are still
+men, but with the riddles of our own time answered and its wearisome
+problems solved? Into the manhood of the race: for I, for my own
+part, cannot think that these latter days of weak experiment,
+fragmentary theory, and mutual discord are indeed man's culminating
+time! I say, for my own part. He, I know--for the question had been
+discussed among us long before the Time Machine was made--thought
+but cheerlessly of the Advancement of Mankind, and saw in the
+growing pile of civilization only a foolish heaping that must
+inevitably fall back upon and destroy its makers in the end. If that
+is so, it remains for us to live as though it were not so. But to me
+the future is still black and blank--is a vast ignorance, lit at a
+few casual places by the memory of his story. And I have by me, for
+my comfort, two strange white flowers--shrivelled now, and brown and
+flat and brittle--to witness that even when mind and strength had
+gone, gratitude and a mutual tenderness still lived on in the heart
+of man.
+
+
+
+
+
+
+
+End of Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+***** This file should be named 35.txt or 35.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/35/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/source-sink-builder/src/main/resources/books/tom-sawyer.txt
+++ b/jet/source-sink-builder/src/main/resources/books/tom-sawyer.txt
@@ -1,0 +1,9209 @@
+
+The Project Gutenberg EBook of The Adventures of Tom Sawyer, Complete by
+Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: The Adventures of Tom Sawyer, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #74]
+Last updated: August 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+Produced by David Widger
+
+
+
+
+
+THE ADVENTURES OF TOM SAWYER
+
+By Mark Twain
+
+(Samuel Langhorne Clemens)
+
+
+
+
+CONTENTS
+
+CHAPTER I. Y-o-u-u Tom-Aunt Polly Decides Upon her Duty--Tom Practices
+Music--The Challenge--A Private Entrance
+
+CHAPTER II. Strong Temptations--Strategic Movements--The Innocents
+Beguiled
+
+CHAPTER III. Tom as a General--Triumph and Reward--Dismal
+Felicity--Commission and Omission
+
+CHAPTER IV. Mental Acrobatics--Attending Sunday--School--The
+Superintendent--“Showing off”--Tom Lionized
+
+CHAPTER V. A Useful Minister--In Church--The Climax
+
+CHAPTER VI. Self-Examination--Dentistry--The Midnight Charm--Witches and
+Devils--Cautious Approaches--Happy Hours
+
+CHAPTER VII. A Treaty Entered Into--Early Lessons--A Mistake Made
+
+CHAPTER VIII. Tom Decides on his Course--Old Scenes Re-enacted
+
+CHAPTER IX. A Solemn Situation--Grave Subjects Introduced--Injun Joe
+Explains
+
+CHAPTER X. The Solemn Oath--Terror Brings Repentance--Mental Punishment
+
+CHAPTER XI. Muff Potter Comes Himself--Tom’s Conscience at Work
+
+CHAPTER XII. Tom Shows his Generosity--Aunt Polly Weakens
+
+CHAPTER XIII. The Young Pirates--Going to the Rendezvous--The Camp--Fire
+Talk
+
+CHAPTER XIV. Camp-Life--A Sensation--Tom Steals Away from Camp
+
+CHAPTER XV. Tom Reconnoiters--Learns the Situation--Reports at Camp
+
+CHAPTER XVI. A Day’s Amusements--Tom Reveals a Secret--The Pirates take a
+Lesson--A Night Surprise--An Indian War
+
+CHAPTER XVII. Memories of the Lost Heroes--The Point in Tom’s Secret
+
+CHAPTER XVIII. Tom’s Feelings Investigated--Wonderful Dream--Becky
+Thatcher Overshadowed--Tom Becomes Jealous--Black Revenge
+
+CHAPTER XIX. Tom Tells the Truth
+
+CHAPTER XX. Becky in a Dilemma--Tom’s Nobility Asserts Itself
+
+CHAPTER XXI. Youthful Eloquence--Compositions by the Young Ladies--A
+Lengthy Vision--The Boy’s Vengeance Satisfied
+
+CHAPTER XXII. Tom’s Confidence Betrayed--Expects Signal Punishment
+
+CHAPTER XXIII. Old Muff’s Friends--Muff Potter in Court--Muff Potter
+Saved
+
+CHAPTER XXIV. Tom as the Village Hero--Days of Splendor and Nights of
+Horror--Pursuit of Injun Joe
+
+CHAPTER XXV. About Kings and Diamonds--Search for the Treasure--Dead
+People and Ghosts
+
+CHAPTER XXVI. The Haunted House--Sleepy Ghosts--A Box of Gold--Bitter Luck
+
+CHAPTER XXVII. Doubts to be Settled--The Young Detectives
+
+CHAPTER XXVIII. An Attempt at No. Two--Huck Mounts Guard
+
+CHAPTER XXIX. The Pic-nic--Huck on Injun Joe’s Track--The “Revenge”
+ Job--Aid for the Widow
+
+CHAPTER XXX. The Welchman Reports--Huck Under Fire--The Story Circulated
+--A New Sensation--Hope Giving Way to Despair
+
+CHAPTER XXXI. An Exploring Expedition--Trouble Commences--Lost in the
+Cave--Total Darkness--Found but not Saved
+
+CHAPTER XXXII. Tom tells the Story of their Escape--Tom’s Enemy in Safe
+Quarters
+
+CHAPTER XXXIII. The Fate of Injun Joe--Huck and Tom Compare Notes
+--An Expedition to the Cave--Protection Against Ghosts--“An Awful Snug
+Place”--A Reception at the Widow Douglas’s
+
+CHAPTER XXXIV. Springing a Secret--Mr. Jones’ Surprise a Failure
+
+CHAPTER XXXV. A New Order of Things--Poor Huck--New Adventures Planned
+
+
+
+
+ILLUSTRATIONS
+
+Tom Sawyer
+
+Tom at Home
+
+Aunt Polly Beguiled
+
+A Good Opportunity
+
+Who’s Afraid
+
+Late Home
+
+Jim
+
+‘Tendin’ to Business
+
+Ain’t that Work?
+
+Cat and Toys
+
+Amusement
+
+Becky Thatcher
+
+Paying Off
+
+After the Battle
+
+“Showing Off”
+
+Not Amiss
+
+Mary
+
+Tom Contemplating
+
+Dampened Ardor
+
+Youth
+
+Boyhood
+
+Using the “Barlow”
+
+The Church
+
+Necessities
+
+Tom as a Sunday-School Hero    
+
+The Prize
+
+At Church
+
+The Model Boy
+
+The Church Choir
+
+A Side Show
+
+Result of Playing in Church
+
+The Pinch-Bug
+
+Sid
+
+Dentistry
+
+Huckleberry Finn
+
+Mother Hopkins
+
+Result of Tom’s Truthfulness
+
+Tom as an Artist
+
+Interrupted Courtship
+
+The Master
+
+Vain Pleading
+
+Tail Piece
+
+The Grave in the Woods
+
+Tom Meditates
+
+Robin Hood and his Foe
+
+Death of Robin Hood
+
+Midnight
+
+Tom’s Mode of Egress
+
+Tom’s Effort at Prayer
+
+Muff Potter Outwitted
+
+The Graveyard
+
+Forewarnings
+
+Disturbing Muff’s Sleep
+
+Tom’s Talk with his Aunt
+
+Muff Potter
+
+A Suspicious Incident
+
+Injun Joe’s two Victims
+
+In the Coils
+
+Peter
+
+Aunt Polly seeks Information
+
+A General Good Time
+
+Demoralized
+
+Joe Harper
+
+On Board Their First Prize
+
+The Pirates Ashore
+
+Wild Life
+
+The Pirate’s Bath
+
+The Pleasant Stroll
+
+The Search for the Drowned
+
+The Mysterious Writing
+
+River View
+
+What Tom Saw
+
+Tom Swims the River
+
+Taking Lessons
+
+The Pirates’ Egg Market
+
+Tom Looking for Joe’s Knife    
+
+The Thunder Storm
+
+Terrible Slaughter
+
+The Mourner
+
+Tom’s Proudest Moment
+
+Amy Lawrence
+
+Tom tries to Remember
+
+The Hero
+
+A Flirtation
+
+Becky Retaliates
+
+A Sudden Frost
+
+Counter-irritation
+
+Aunt Polly
+
+Tom justified
+
+The Discovery
+
+Caught in the Act
+
+Tom Astonishes the School
+
+Literature
+
+Tom Declaims
+
+Examination Evening
+
+On Exhibition
+
+Prize Authors
+
+The Master’s Dilemma
+
+The School House
+
+The Cadet
+
+Happy for Two Days
+
+Enjoying the Vacation
+
+The Stolen Melons
+
+The Judge
+
+Visiting the Prisoner
+
+Tom Swears
+
+The Court Room
+
+The Detective
+
+Tom Dreams
+
+The Treasure
+
+The Private Conference
+
+A King; Poor Fellow!
+
+Business
+
+The Ha’nted House
+
+Injun Joe
+
+The Greatest and Best
+
+Hidden Treasures Unearthed
+
+The Boy’s Salvation
+
+Room No. 2
+
+The Next Day’s Conference
+
+Treasures
+
+Uncle Jake
+
+Buck at Home
+
+The Haunted Room
+
+“Run for Your Life”
+
+McDougal’s Cave
+
+Inside the Cave
+
+Huck on Duty
+
+A Rousing Act
+
+Tail Piece
+
+The Welchman
+
+Result of a Sneeze
+
+Cornered
+
+Alarming Discoveries
+
+Tom and Becky stir up the Town
+
+Tom’s Marks
+
+Huck Questions the Widow
+
+Vampires
+
+Wonders of the Cave
+
+Attacked by Natives
+
+Despair
+
+The Wedding Cake
+
+A New Terror
+
+Daylight
+
+“Turn Out” to Receive Tom and Becky
+
+The Escape from the Cave
+
+Fate of the Ragged Man
+
+The Treasures Found
+
+Caught at Last
+
+Drop after Drop
+
+Having a Good Time
+
+A Business Trip
+
+“Got it at Last!”
+
+Tail Piece
+
+Widow Douglas
+
+Tom Backs his Statement
+
+Tail Piece
+
+Huck Transformed
+
+Comfortable Once More
+
+High up in Society
+
+Contentment
+
+
+
+
+PREFACE
+
+Most of the adventures recorded in this book really occurred; one or two
+were experiences of my own, the rest those of boys who were schoolmates
+of mine. Huck Finn is drawn from life; Tom Sawyer also, but not from an
+individual--he is a combination of the characteristics of three boys whom
+I knew, and therefore belongs to the composite order of architecture.
+
+The odd superstitions touched upon were all prevalent among children and
+slaves in the West at the period of this story--that is to say, thirty or
+forty years ago.
+
+Although my book is intended mainly for the entertainment of boys and
+girls, I hope it will not be shunned by men and women on that account,
+for part of my plan has been to try to pleasantly remind adults of what
+they once were themselves, and of how they felt and thought and talked,
+and what queer enterprises they sometimes engaged in.
+
+THE AUTHOR.
+
+HARTFORD, 1876.
+
+
+
+
+CHAPTER I
+
+“TOM!”
+
+No answer.
+
+“TOM!”
+
+No answer.
+
+“What’s gone with that boy,  I wonder? You TOM!”
+
+No answer.
+
+The old lady pulled her spectacles down and looked over them about the
+room; then she put them up and looked out under them. She seldom or
+never looked _through_ them for so small a thing as a boy; they were
+her state pair, the pride of her heart, and were built for “style,” not
+service--she could have seen through a pair of stove-lids just as well.
+She looked perplexed for a moment, and then said, not fiercely, but
+still loud enough for the furniture to hear:
+
+“Well, I lay if I get hold of you I’ll--”
+
+She did not finish, for by this time she was bending down and punching
+under the bed with the broom, and so she needed breath to punctuate the
+punches with. She resurrected nothing but the cat.
+
+“I never did see the beat of that boy!”
+
+She went to the open door and stood in it and looked out among the
+tomato vines and “jimpson” weeds that constituted the garden. No Tom. So
+she lifted up her voice at an angle calculated for distance and shouted:
+
+“Y-o-u-u TOM!”
+
+There was a slight noise behind her and she turned just in time to seize
+a small boy by the slack of his roundabout and arrest his flight.
+
+“There! I might ‘a’ thought of that closet. What you been doing in
+there?”
+
+“Nothing.”
+
+“Nothing! Look at your hands. And look at your mouth. What _is_ that
+truck?”
+
+“I don’t know, aunt.”
+
+“Well, I know. It’s jam--that’s what it is. Forty times I’ve said if you
+didn’t let that jam alone I’d skin you. Hand me that switch.”
+
+The switch hovered in the air--the peril was desperate--
+
+“My! Look behind you, aunt!”
+
+The old lady whirled round, and snatched her skirts out of danger.
+The lad fled on the instant, scrambled up the high board-fence, and
+disappeared over it.
+
+His aunt Polly stood surprised a moment, and then broke into a gentle
+laugh.
+
+“Hang the boy, can’t I never learn anything? Ain’t he played me tricks
+enough like that for me to be looking out for him by this time? But old
+fools is the biggest fools there is. Can’t learn an old dog new tricks,
+as the saying is. But my goodness, he never plays them alike, two days,
+and how is a body to know what’s coming? He ‘pears to know just how long
+he can torment me before I get my dander up, and he knows if he can make
+out to put me off for a minute or make me laugh, it’s all down again and
+I can’t hit him a lick. I ain’t doing my duty by that boy, and that’s
+the Lord’s truth, goodness knows. Spare the rod and spile the child,
+as the Good Book says. I’m a laying up sin and suffering for us both,
+I know. He’s full of the Old Scratch, but laws-a-me! he’s my own
+dead sister’s boy, poor thing, and I ain’t got the heart to lash him,
+somehow. Every time I let him off, my conscience does hurt me so, and
+every time I hit him my old heart most breaks. Well-a-well, man that is
+born of woman is of few days and full of trouble, as the Scripture
+says, and I reckon it’s so. He’ll play hookey this evening, * and [*
+Southwestern for “afternoon”] I’ll just be obleeged to make him work,
+tomorrow, to punish him. It’s mighty hard to make him work Saturdays,
+when all the boys is having holiday, but he hates work more than he
+hates anything else, and I’ve _got_ to do some of my duty by him, or
+I’ll be the ruination of the child.”
+
+Tom did play hookey, and he had a very good time. He got back home
+barely in season to help Jim, the small colored boy, saw next-day’s wood
+and split the kindlings before supper--at least he was there in time
+to tell his adventures to Jim while Jim did three-fourths of the work.
+Tom’s younger brother (or rather half-brother) Sid was already through
+with his part of the work (picking up chips), for he was a quiet boy,
+and had no adventurous, trouble-some ways.
+
+While Tom was eating his supper, and stealing sugar as opportunity
+offered, Aunt Polly asked him questions that were full of guile, and
+very deep--for she wanted to trap him into damaging revealments. Like
+many other simple-hearted souls, it was her pet vanity to believe she
+was endowed with a talent for dark and mysterious diplomacy, and she
+loved to contemplate her most transparent devices as marvels of low
+cunning. Said she:
+
+“Tom, it was middling warm in school, warn’t it?”
+
+“Yes’m.”
+
+“Powerful warm, warn’t it?”
+
+“Yes’m.”
+
+“Didn’t you want to go in a-swimming, Tom?”
+
+A bit of a scare shot through Tom--a touch of uncomfortable suspicion. He
+searched Aunt Polly’s face, but it told him nothing. So he said:
+
+“No’m--well, not very much.”
+
+The old lady reached out her hand and felt Tom’s shirt, and said:
+
+“But you ain’t too warm now, though.” And it flattered her to reflect
+that she had discovered that the shirt was dry without anybody knowing
+that that was what she had in her mind. But in spite of her, Tom knew
+where the wind lay, now. So he forestalled what might be the next move:
+
+“Some of us pumped on our heads--mine’s damp yet. See?”
+
+Aunt Polly was vexed to think she had overlooked that bit of
+circumstantial evidence, and missed a trick. Then she had a new
+inspiration:
+
+“Tom, you didn’t have to undo your shirt collar where I sewed it, to
+pump on your head, did you? Unbutton your jacket!”
+
+The trouble vanished out of Tom’s face. He opened his jacket. His shirt
+collar was securely sewed.
+
+“Bother! Well, go ‘long with you. I’d made sure you’d played hookey
+and been a-swimming. But I forgive ye, Tom. I reckon you’re a kind of a
+singed cat, as the saying is--better’n you look. _This_ time.”
+
+She was half sorry her sagacity had miscarried, and half glad that Tom
+had stumbled into obedient conduct for once.
+
+But Sidney said:
+
+“Well, now, if I didn’t think you sewed his collar with white thread,
+but it’s black.”
+
+“Why, I did sew it with white! Tom!”
+
+But Tom did not wait for the rest. As he went out at the door he said:
+
+“Siddy, I’ll lick you for that.”
+
+In a safe place Tom examined two large needles which were thrust into
+the lapels of his jacket, and had thread bound about them--one needle
+carried white thread and the other black. He said:
+
+“She’d never noticed if it hadn’t been for Sid. Confound it! sometimes
+she sews it with white, and sometimes she sews it with black. I wish to
+gee-miny she’d stick to one or t’other--I can’t keep the run of ‘em. But
+I bet you I’ll lam Sid for that. I’ll learn him!”
+
+He was not the Model Boy of the village. He knew the model boy very well
+though--and loathed him.
+
+Within two minutes, or even less, he had forgotten all his troubles. Not
+because his troubles were one whit less heavy and bitter to him than a
+man’s are to a man, but because a new and powerful interest bore
+them down and drove them out of his mind for the time--just as men’s
+misfortunes are forgotten in the excitement of new enterprises. This new
+interest was a valued novelty in whistling, which he had just acquired
+from a negro, and he was suffering to practise it un-disturbed. It
+consisted in a peculiar bird-like turn, a sort of liquid warble,
+produced by touching the tongue to the roof of the mouth at short
+intervals in the midst of the music--the reader probably remembers how to
+do it, if he has ever been a boy. Diligence and attention soon gave him
+the knack of it, and he strode down the street with his mouth full of
+harmony and his soul full of gratitude. He felt much as an astronomer
+feels who has discovered a new planet--no doubt, as far as strong, deep,
+unalloyed pleasure is concerned, the advantage was with the boy, not the
+astronomer.
+
+The summer evenings were long. It was not dark, yet. Presently Tom
+checked his whistle. A stranger was before him--a boy a shade larger
+than himself. A new-comer of any age or either sex was an im-pressive
+curiosity in the poor little shabby village of St. Petersburg. This boy
+was well dressed, too--well dressed on a week-day. This was simply as
+astounding. His cap was a dainty thing, his close-buttoned blue cloth
+roundabout was new and natty, and so were his pantaloons. He had shoes
+on--and it was only Friday. He even wore a necktie, a bright bit of
+ribbon. He had a citified air about him that ate into Tom’s vitals. The
+more Tom stared at the splendid marvel, the higher he turned up his nose
+at his finery and the shabbier and shabbier his own outfit seemed to
+him to grow. Neither boy spoke. If one moved, the other moved--but only
+sidewise, in a circle; they kept face to face and eye to eye all the
+time. Finally Tom said:
+
+“I can lick you!”
+
+“I’d like to see you try it.”
+
+“Well, I can do it.”
+
+“No you can’t, either.”
+
+“Yes I can.”
+
+“No you can’t.”
+
+“I can.”
+
+“You can’t.”
+
+“Can!”
+
+“Can’t!”
+
+An uncomfortable pause. Then Tom said:
+
+“What’s your name?”
+
+“‘Tisn’t any of your business, maybe.”
+
+“Well I ‘low I’ll _make_ it my business.”
+
+“Well why don’t you?”
+
+“If you say much, I will.”
+
+“Much--much--_much_. There now.”
+
+“Oh, you think you’re mighty smart, _don’t_ you? I could lick you with
+one hand tied behind me, if I wanted to.”
+
+“Well why don’t you _do_ it? You _say_ you can do it.”
+
+“Well I _will_, if you fool with me.”
+
+“Oh yes--I’ve seen whole families in the same fix.”
+
+“Smarty! You think you’re _some_, now, _don’t_ you? Oh, what a hat!”
+
+“You can lump that hat if you don’t like it. I dare you to knock it
+off--and anybody that’ll take a dare will suck eggs.”
+
+“You’re a liar!”
+
+“You’re another.”
+
+“You’re a fighting liar and dasn’t take it up.”
+
+“Aw--take a walk!”
+
+“Say--if you give me much more of your sass I’ll take and bounce a rock
+off’n your head.”
+
+“Oh, of _course_ you will.”
+
+“Well I _will_.”
+
+“Well why don’t you _do_ it then? What do you keep _saying_ you will
+for? Why don’t you _do_ it? It’s because you’re afraid.”
+
+“I _ain’t_ afraid.”
+
+“You are.”
+
+“I ain’t.”
+
+“You are.”
+
+Another pause, and more eying and sidling around each other. Presently
+they were shoulder to shoulder. Tom said:
+
+“Get away from here!”
+
+“Go away yourself!”
+
+“I won’t.”
+
+“I won’t either.”
+
+So they stood, each with a foot placed at an angle as a brace, and both
+shoving with might and main, and glowering at each other with hate. But
+neither could get an advantage. After struggling till both were hot and
+flushed, each relaxed his strain with watchful caution, and Tom said:
+
+“You’re a coward and a pup. I’ll tell my big brother on you, and he can
+thrash you with his little finger, and I’ll make him do it, too.”
+
+“What do I care for your big brother? I’ve got a brother that’s bigger
+than he is--and what’s more, he can throw him over that fence, too.”
+ [Both brothers were imaginary.]
+
+“That’s a lie.”
+
+“_Your_ saying so don’t make it so.”
+
+Tom drew a line in the dust with his big toe, and said:
+
+“I dare you to step over that, and I’ll lick you till you can’t stand
+up. Anybody that’ll take a dare will steal sheep.”
+
+The new boy stepped over promptly, and said:
+
+“Now you said you’d do it, now let’s see you do it.”
+
+“Don’t you crowd me now; you better look out.”
+
+“Well, you _said_ you’d do it--why don’t you do it?”
+
+“By jingo! for two cents I _will_ do it.”
+
+The new boy took two broad coppers out of his pocket and held them out
+with derision. Tom struck them to the ground. In an instant both boys
+were rolling and tumbling in the dirt, gripped together like cats; and
+for the space of a minute they tugged and tore at each other’s hair and
+clothes, punched and scratched each other’s nose, and covered themselves
+with dust and glory. Presently the confusion took form, and through the
+fog of battle Tom appeared, seated astride the new boy, and pounding him
+with his fists. “Holler ‘nuff!” said he.
+
+The boy only struggled to free himself. He was crying--mainly from rage.
+
+“Holler ‘nuff!”--and the pounding went on.
+
+At last the stranger got out a smothered “‘Nuff!” and Tom let him up and
+said:
+
+“Now that’ll learn you. Better look out who you’re fooling with next
+time.”
+
+The new boy went off brushing the dust from his clothes, sobbing,
+snuffling, and occasionally looking back and shaking his head and
+threatening what he would do to Tom the “next time he caught him out.”
+ To which Tom responded with jeers, and started off in high feather, and
+as soon as his back was turned the new boy snatched up a stone, threw it
+and hit him between the shoulders and then turned tail and ran like
+an antelope. Tom chased the traitor home, and thus found out where he
+lived. He then held a position at the gate for some time, daring the
+enemy to come outside, but the enemy only made faces at him through the
+window and declined. At last the enemy’s mother appeared, and called Tom
+a bad, vicious, vulgar child, and ordered him away. So he went away; but
+he said he “‘lowed” to “lay” for that boy.
+
+He got home pretty late that night, and when he climbed cautiously in
+at the window, he uncovered an ambuscade, in the person of his aunt; and
+when she saw the state his clothes were in her resolution to turn his
+Saturday holiday into captivity at hard labor became adamantine in its
+firmness.
+
+
+
+
+CHAPTER II
+
+SATURDAY morning was come, and all the summer world was bright and
+fresh, and brimming with life. There was a song in every heart; and if
+the heart was young the music issued at the lips. There was cheer in
+every face and a spring in every step. The locust-trees were in bloom
+and the fragrance of the blossoms filled the air. Cardiff Hill, beyond
+the village and above it, was green with vegetation and it lay just far
+enough away to seem a Delectable Land, dreamy, reposeful, and inviting.
+
+Tom appeared on the sidewalk with a bucket of whitewash and a
+long-handled brush. He surveyed the fence, and all gladness left him and
+a deep melancholy settled down upon his spirit. Thirty yards of board
+fence nine feet high. Life to him seemed hollow, and existence but a
+burden. Sighing, he dipped his brush and passed it along the topmost
+plank; repeated the operation; did it again; compared the insignificant
+whitewashed streak with the far-reaching continent of unwhitewashed
+fence, and sat down on a tree-box discouraged. Jim came skipping out at
+the gate with a tin pail, and singing Buffalo Gals. Bringing water from
+the town pump had always been hateful work in Tom’s eyes, before, but
+now it did not strike him so. He remembered that there was company at
+the pump. White, mulatto, and negro boys and girls were always there
+waiting their turns, resting, trading playthings, quarrelling, fighting,
+skylarking. And he remembered that although the pump was only a hundred
+and fifty yards off, Jim never got back with a bucket of water under an
+hour--and even then somebody generally had to go after him. Tom said:
+
+“Say, Jim, I’ll fetch the water if you’ll whitewash some.”
+
+Jim shook his head and said:
+
+“Can’t, Mars Tom. Ole missis, she tole me I got to go an’ git dis water
+an’ not stop foolin’ roun’ wid anybody. She say she spec’ Mars Tom gwine
+to ax me to whitewash, an’ so she tole me go ‘long an’ ‘tend to my own
+business--she ‘lowed _she’d_ ‘tend to de whitewashin’.”
+
+“Oh, never you mind what she said, Jim. That’s the way she always talks.
+Gimme the bucket--I won’t be gone only a a minute. _She_ won’t ever
+know.”
+
+“Oh, I dasn’t, Mars Tom. Ole missis she’d take an’ tar de head off’n me.
+‘Deed she would.”
+
+“_She_! She never licks anybody--whacks ‘em over the head with her
+thimble--and who cares for that, I’d like to know. She talks awful, but
+talk don’t hurt--anyways it don’t if she don’t cry. Jim, I’ll give you a
+marvel. I’ll give you a white alley!”
+
+Jim began to waver.
+
+“White alley, Jim! And it’s a bully taw.”
+
+“My! Dat’s a mighty gay marvel, I tell you! But Mars Tom I’s powerful
+‘fraid ole missis--”
+
+“And besides, if you will I’ll show you my sore toe.”
+
+Jim was only human--this attraction was too much for him. He put down
+his pail, took the white alley, and bent over the toe with absorbing
+interest while the bandage was being unwound. In another moment he
+was flying down the street with his pail and a tingling rear, Tom was
+whitewashing with vigor, and Aunt Polly was retiring from the field with
+a slipper in her hand and triumph in her eye.
+
+But Tom’s energy did not last. He began to think of the fun he had
+planned for this day, and his sorrows multiplied. Soon the free boys
+would come tripping along on all sorts of delicious expeditions, and
+they would make a world of fun of him for having to work--the very
+thought of it burnt him like fire. He got out his worldly wealth and
+examined it--bits of toys, marbles, and trash; enough to buy an exchange
+of _work_, maybe, but not half enough to buy so much as half an hour
+of pure freedom. So he returned his straitened means to his pocket, and
+gave up the idea of trying to buy the boys. At this dark and hopeless
+moment an inspiration burst upon him! Nothing less than a great,
+magnificent inspiration.
+
+He took up his brush and went tranquilly to work. Ben Rogers hove in
+sight presently--the very boy, of all boys, whose ridicule he had been
+dreading. Ben’s gait was the hop-skip-and-jump--proof enough that his
+heart was light and his anticipations high. He was eating an apple, and
+giving a long, melodious whoop, at intervals, followed by a deep-toned
+ding-dong-dong, ding-dong-dong, for he was personating a steamboat. As
+he drew near, he slackened speed, took the middle of the street, leaned
+far over to starboard and rounded to ponderously and with laborious pomp
+and circumstance--for he was personating the Big Missouri, and considered
+himself to be drawing nine feet of water. He was boat and captain and
+engine-bells combined, so he had to imagine himself standing on his own
+hurricane-deck giving the orders and executing them:
+
+“Stop her, sir! Ting-a-ling-ling!” The headway ran almost out, and he
+drew up slowly toward the sidewalk.
+
+“Ship up to back! Ting-a-ling-ling!” His arms straightened and stiffened
+down his sides.
+
+“Set her back on the stabboard! Ting-a-ling-ling! Chow! ch-chow-wow!
+Chow!” His right hand, mean-time, describing stately circles--for it was
+representing a forty-foot wheel.
+
+“Let her go back on the labboard! Ting-a-ling-ling! Chow-ch-chow-chow!”
+ The left hand began to describe circles.
+
+“Stop the stabboard! Ting-a-ling-ling! Stop the labboard! Come ahead on
+the stabboard! Stop her! Let your outside turn over slow! Ting-a-ling-ling!
+Chow-ow-ow! Get out that head-line! _lively_ now! Come--out with
+your spring-line--what’re you about there! Take a turn round that stump
+with the bight of it! Stand by that stage, now--let her go! Done with
+the engines, sir! Ting-a-ling-ling! SH’T! S’H’T! SH’T!” (trying the
+gauge-cocks).
+
+Tom went on whitewashing--paid no attention to the steamboat. Ben stared
+a moment and then said: “_Hi-Yi! You’re_ up a stump, ain’t you!”
+
+No answer. Tom surveyed his last touch with the eye of an artist, then
+he gave his brush another gentle sweep and surveyed the result, as
+before. Ben ranged up alongside of him. Tom’s mouth watered for the
+apple, but he stuck to his work. Ben said:
+
+“Hello, old chap, you got to work, hey?”
+
+Tom wheeled suddenly and said:
+
+“Why, it’s you, Ben! I warn’t noticing.”
+
+“Say--I’m going in a-swimming, I am. Don’t you wish you could? But of
+course you’d druther _work_--wouldn’t you? Course you would!”
+
+Tom contemplated the boy a bit, and said:
+
+“What do you call work?”
+
+“Why, ain’t _that_ work?”
+
+Tom resumed his whitewashing, and answered carelessly:
+
+“Well, maybe it is, and maybe it ain’t. All I know, is, it suits Tom
+Sawyer.”
+
+“Oh come, now, you don’t mean to let on that you _like_ it?”
+
+The brush continued to move.
+
+“Like it? Well, I don’t see why I oughtn’t to like it. Does a boy get a
+chance to whitewash a fence every day?”
+
+That put the thing in a new light. Ben stopped nibbling his apple.
+Tom swept his brush daintily back and forth--stepped back to note the
+effect--added a touch here and there--criticised the effect again--Ben
+watching every move and getting more and more interested, more and more
+absorbed. Presently he said:
+
+“Say, Tom, let _me_ whitewash a little.”
+
+Tom considered, was about to consent; but he altered his mind:
+
+“No--no--I reckon it wouldn’t hardly do, Ben. You see, Aunt Polly’s awful
+particular about this fence--right here on the street, you know--but if it
+was the back fence I wouldn’t mind and _she_ wouldn’t. Yes, she’s awful
+particular about this fence; it’s got to be done very careful; I reckon
+there ain’t one boy in a thousand, maybe two thousand, that can do it
+the way it’s got to be done.”
+
+“No--is that so? Oh come, now--lemme just try. Only just a little--I’d let
+_you_, if you was me, Tom.”
+
+“Ben, I’d like to, honest injun; but Aunt Polly--well, Jim wanted to do
+it, but she wouldn’t let him; Sid wanted to do it, and she wouldn’t let
+Sid. Now don’t you see how I’m fixed? If you was to tackle this fence
+and anything was to happen to it--”
+
+“Oh, shucks, I’ll be just as careful. Now lemme try. Say--I’ll give you
+the core of my apple.”
+
+“Well, here--No, Ben, now don’t. I’m afeard--”
+
+“I’ll give you _all_ of it!”
+
+Tom gave up the brush with reluctance in his face, but alacrity in his
+heart. And while the late steamer Big Missouri worked and sweated in the
+sun, the retired artist sat on a barrel in the shade close by,
+dangled his legs, munched his apple, and planned the slaughter of more
+innocents. There was no lack of material; boys happened along every
+little while; they came to jeer, but remained to whitewash. By the time
+Ben was fagged out, Tom had traded the next chance to Billy Fisher for
+a kite, in good repair; and when he played out, Johnny Miller bought in
+for a dead rat and a string to swing it with--and so on, and so on, hour
+after hour. And when the middle of the afternoon came, from being a
+poor poverty-stricken boy in the morning, Tom was literally rolling in
+wealth. He had besides the things before mentioned, twelve marbles, part
+of a jews-harp, a piece of blue bottle-glass to look through, a spool
+cannon, a key that wouldn’t unlock anything, a fragment of chalk, a
+glass stopper of a decanter, a tin soldier, a couple of tadpoles,
+six fire-crackers, a kitten with only one eye, a brass door-knob, a
+dog-collar--but no dog--the handle of a knife, four pieces of orange-peel,
+and a dilapidated old window sash.
+
+He had had a nice, good, idle time all the while--plenty of company--and
+the fence had three coats of whitewash on it! If he hadn’t run out of
+whitewash he would have bankrupted every boy in the village.
+
+Tom said to himself that it was not such a hollow world, after all. He
+had discovered a great law of human action, without knowing it--namely,
+that in order to make a man or a boy covet a thing, it is only necessary
+to make the thing difficult to attain. If he had been a great and
+wise philosopher, like the writer of this book, he would now have
+comprehended that Work consists of whatever a body is _obliged_ to do,
+and that Play consists of whatever a body is not obliged to do. And
+this would help him to understand why constructing artificial flowers or
+performing on a tread-mill is work, while rolling ten-pins or climbing
+Mont Blanc is only amusement. There are wealthy gentlemen in England
+who drive four-horse passenger-coaches twenty or thirty miles on a
+daily line, in the summer, because the privilege costs them considerable
+money; but if they were offered wages for the service, that would turn
+it into work and then they would resign.
+
+The boy mused awhile over the substantial change which had taken place
+in his worldly circumstances, and then wended toward headquarters to
+report.
+
+
+
+
+CHAPTER III
+
+TOM presented himself before Aunt Polly, who was sitting by an
+open window in a pleasant rearward apartment, which was bedroom,
+breakfast-room, dining-room, and library, combined. The balmy summer
+air, the restful quiet, the odor of the flowers, and the drowsing
+murmur of the bees had had their effect, and she was nodding over her
+knitting--for she had no company but the cat, and it was asleep in her
+lap. Her spectacles were propped up on her gray head for safety. She had
+thought that of course Tom had deserted long ago, and she wondered at
+seeing him place himself in her power again in this intrepid way. He
+said: “Mayn’t I go and play now, aunt?”
+
+“What, a’ready? How much have you done?”
+
+“It’s all done, aunt.”
+
+“Tom, don’t lie to me--I can’t bear it.”
+
+“I ain’t, aunt; it _is_ all done.”
+
+Aunt Polly placed small trust in such evidence. She went out to see for
+herself; and she would have been content to find twenty per cent. of
+Tom’s statement true. When she found the entire fence white-washed, and
+not only whitewashed but elaborately coated and recoated, and even a
+streak added to the ground, her astonishment was almost unspeakable. She
+said:
+
+“Well, I never! There’s no getting round it, you can work when you’re a
+mind to, Tom.” And then she diluted the compliment by adding, “But it’s
+powerful seldom you’re a mind to, I’m bound to say. Well, go ‘long and
+play; but mind you get back some time in a week, or I’ll tan you.”
+
+She was so overcome by the splendor of his achievement that she took
+him into the closet and selected a choice apple and delivered it to him,
+along with an improving lecture upon the added value and flavor a treat
+took to itself when it came without sin through virtuous effort.
+And while she closed with a happy Scriptural flourish, he “hooked” a
+doughnut.
+
+Then he skipped out, and saw Sid just starting up the outside stairway
+that led to the back rooms on the second floor. Clods were handy and
+the air was full of them in a twinkling. They raged around Sid like a
+hail-storm; and before Aunt Polly could collect her surprised faculties
+and sally to the rescue, six or seven clods had taken personal effect,
+and Tom was over the fence and gone. There was a gate, but as a general
+thing he was too crowded for time to make use of it. His soul was at
+peace, now that he had settled with Sid for calling attention to his
+black thread and getting him into trouble.
+
+Tom skirted the block, and came round into a muddy alley that led by the
+back of his aunt’s cow-stable. He presently got safely beyond the reach
+of capture and punishment, and hastened toward the public square of the
+village, where two “military” companies of boys had met for conflict,
+according to previous appointment. Tom was General of one of these
+armies, Joe Harper (a bosom friend) General of the other. These two
+great commanders did not condescend to fight in person--that being better
+suited to the still smaller fry--but sat together on an eminence
+and conducted the field operations by orders delivered through
+aides-de-camp. Tom’s army won a great victory, after a long and
+hard-fought battle. Then the dead were counted, prisoners exchanged,
+the terms of the next disagreement agreed upon, and the day for the
+necessary battle appointed; after which the armies fell into line and
+marched away, and Tom turned homeward alone.
+
+As he was passing by the house where Jeff Thatcher lived, he saw a new
+girl in the garden--a lovely little blue-eyed creature with yellow
+hair plaited into two long-tails, white summer frock and embroidered
+pan-talettes. The fresh-crowned hero fell without firing a shot. A
+certain Amy Lawrence vanished out of his heart and left not even a
+memory of herself behind. He had thought he loved her to distraction;
+he had regarded his passion as adoration; and behold it was only a poor
+little evanescent partiality. He had been months winning her; she had
+confessed hardly a week ago; he had been the happiest and the proudest
+boy in the world only seven short days, and here in one instant of time
+she had gone out of his heart like a casual stranger whose visit is
+done.
+
+He worshipped this new angel with furtive eye, till he saw that she had
+discovered him; then he pretended he did not know she was present, and
+began to “show off” in all sorts of absurd boyish ways, in order to win
+her admiration. He kept up this grotesque foolishness for some time;
+but by-and-by, while he was in the midst of some dangerous gymnastic
+performances, he glanced aside and saw that the little girl was wending
+her way toward the house. Tom came up to the fence and leaned on it,
+grieving, and hoping she would tarry yet awhile longer. She halted a
+moment on the steps and then moved toward the door. Tom heaved a great
+sigh as she put her foot on the threshold. But his face lit up,
+right away, for she tossed a pansy over the fence a moment before she
+disappeared.
+
+The boy ran around and stopped within a foot or two of the flower, and
+then shaded his eyes with his hand and began to look down street as
+if he had discovered something of interest going on in that direction.
+Presently he picked up a straw and began trying to balance it on his
+nose, with his head tilted far back; and as he moved from side to side,
+in his efforts, he edged nearer and nearer toward the pansy; finally his
+bare foot rested upon it, his pliant toes closed upon it, and he hopped
+away with the treasure and disappeared round the corner. But only for a
+minute--only while he could button the flower inside his jacket, next
+his heart--or next his stomach, possibly, for he was not much posted in
+anatomy, and not hypercritical, anyway.
+
+He returned, now, and hung about the fence till nightfall, “showing
+off,” as before; but the girl never exhibited herself again, though Tom
+comforted himself a little with the hope that she had been near some
+window, meantime, and been aware of his attentions. Finally he strode
+home reluctantly, with his poor head full of visions.
+
+All through supper his spirits were so high that his aunt wondered “what
+had got into the child.” He took a good scolding about clodding Sid, and
+did not seem to mind it in the least. He tried to steal sugar under his
+aunt’s very nose, and got his knuckles rapped for it. He said:
+
+“Aunt, you don’t whack Sid when he takes it.”
+
+“Well, Sid don’t torment a body the way you do. You’d be always into
+that sugar if I warn’t watching you.”
+
+Presently she stepped into the kitchen, and Sid, happy in his immunity,
+reached for the sugar-bowl--a sort of glorying over Tom which was
+wellnigh unbearable. But Sid’s fingers slipped and the bowl dropped and
+broke. Tom was in ecstasies. In such ecstasies that he even controlled
+his tongue and was silent. He said to himself that he would not speak a
+word, even when his aunt came in, but would sit perfectly still till she
+asked who did the mischief; and then he would tell, and there would be
+nothing so good in the world as to see that pet model “catch it.” He was
+so brimful of exultation that he could hardly hold himself when the old
+lady came back and stood above the wreck discharging lightnings of wrath
+from over her spectacles. He said to himself, “Now it’s coming!” And the
+next instant he was sprawling on the floor! The potent palm was uplifted
+to strike again when Tom cried out:
+
+“Hold on, now, what ‘er you belting _me_ for?--Sid broke it!”
+
+Aunt Polly paused, perplexed, and Tom looked for healing pity. But when
+she got her tongue again, she only said:
+
+“Umf! Well, you didn’t get a lick amiss, I reckon. You been into some
+other audacious mischief when I wasn’t around, like enough.”
+
+Then her conscience reproached her, and she yearned to say something
+kind and loving; but she judged that this would be construed into a
+confession that she had been in the wrong, and discipline forbade that.
+So she kept silence, and went about her affairs with a troubled heart.
+Tom sulked in a corner and exalted his woes. He knew that in her heart
+his aunt was on her knees to him, and he was morosely gratified by the
+consciousness of it. He would hang out no signals, he would take notice
+of none. He knew that a yearning glance fell upon him, now and then,
+through a film of tears, but he refused recognition of it. He pictured
+himself lying sick unto death and his aunt bending over him beseeching
+one little forgiving word, but he would turn his face to the wall, and
+die with that word unsaid. Ah, how would she feel then? And he pictured
+himself brought home from the river, dead, with his curls all wet, and
+his sore heart at rest. How she would throw herself upon him, and how
+her tears would fall like rain, and her lips pray God to give her back
+her boy and she would never, never abuse him any more! But he would
+lie there cold and white and make no sign--a poor little sufferer, whose
+griefs were at an end. He so worked upon his feelings with the pathos of
+these dreams, that he had to keep swallowing, he was so like to choke;
+and his eyes swam in a blur of water, which overflowed when he winked,
+and ran down and trickled from the end of his nose. And such a luxury to
+him was this petting of his sorrows, that he could not bear to have any
+worldly cheeriness or any grating delight intrude upon it; it was too
+sacred for such contact; and so, presently, when his cousin Mary danced
+in, all alive with the joy of seeing home again after an age-long visit
+of one week to the country, he got up and moved in clouds and darkness
+out at one door as she brought song and sunshine in at the other.
+
+He wandered far from the accustomed haunts of boys, and sought desolate
+places that were in harmony with his spirit. A log raft in the river
+invited him, and he seated himself on its outer edge and contemplated
+the dreary vastness of the stream, wishing, the while, that he could
+only be drowned, all at once and unconsciously, without undergoing the
+uncomfortable routine devised by nature. Then he thought of his flower.
+He got it out, rumpled and wilted, and it mightily increased his dismal
+felicity. He wondered if she would pity him if she knew? Would she
+cry, and wish that she had a right to put her arms around his neck and
+comfort him? Or would she turn coldly away like all the hollow world?
+This picture brought such an agony of pleasurable suffering that he
+worked it over and over again in his mind and set it up in new and
+varied lights, till he wore it threadbare. At last he rose up sighing
+and departed in the darkness.
+
+About half-past nine or ten o’clock he came along the deserted street to
+where the Adored Unknown lived; he paused a moment; no sound fell upon
+his listening ear; a candle was casting a dull glow upon the curtain
+of a second-story window. Was the sacred presence there? He climbed the
+fence, threaded his stealthy way through the plants, till he stood under
+that window; he looked up at it long, and with emotion; then he laid him
+down on the ground under it, disposing himself upon his back, with his
+hands clasped upon his breast and holding his poor wilted flower.
+And thus he would die--out in the cold world, with no shelter over his
+homeless head, no friendly hand to wipe the death-damps from his brow,
+no loving face to bend pityingly over him when the great agony came. And
+thus _she_ would see him when she looked out upon the glad morning, and
+oh! would she drop one little tear upon his poor, lifeless form, would
+she heave one little sigh to see a bright young life so rudely blighted,
+so untimely cut down?
+
+The window went up, a maid-servant’s discordant voice profaned the holy
+calm, and a deluge of water drenched the prone martyr’s remains!
+
+The strangling hero sprang up with a relieving snort. There was a whiz
+as of a missile in the air, mingled with the murmur of a curse, a sound
+as of shivering glass followed, and a small, vague form went over the
+fence and shot away in the gloom.
+
+Not long after, as Tom, all undressed for bed, was surveying his
+drenched garments by the light of a tallow dip, Sid woke up; but if he
+had any dim idea of making any “references to allusions,” he thought
+better of it and held his peace, for there was danger in Tom’s eye.
+
+Tom turned in without the added vexation of prayers, and Sid made mental
+note of the omission.
+
+
+
+
+CHAPTER IV
+
+THE sun rose upon a tranquil world, and beamed down upon the peaceful
+village like a benediction. Breakfast over, Aunt Polly had family
+worship: it began with a prayer built from the ground up of solid
+courses of Scriptural quotations, welded together with a thin mortar of
+originality; and from the summit of this she delivered a grim chapter of
+the Mosaic Law, as from Sinai.
+
+Then Tom girded up his loins, so to speak, and went to work to “get
+his verses.” Sid had learned his lesson days before. Tom bent all his
+energies to the memorizing of five verses, and he chose part of the
+Sermon on the Mount, because he could find no verses that were shorter.
+At the end of half an hour Tom had a vague general idea of his lesson,
+but no more, for his mind was traversing the whole field of human
+thought, and his hands were busy with distracting recreations. Mary took
+his book to hear him recite, and he tried to find his way through the
+fog:
+
+“Blessed are the--a--a--”
+
+“Poor”--
+
+“Yes--poor; blessed are the poor--a--a--”
+
+“In spirit--”
+
+“In spirit; blessed are the poor in spirit, for they--they--”
+
+“_Theirs_--”
+
+“For _theirs_. Blessed are the poor in spirit, for theirs is the kingdom
+of heaven. Blessed are they that mourn, for they--they--”
+
+“Sh--”
+
+“For they--a--”
+
+“S, H, A--”
+
+“For they S, H--Oh, I don’t know what it is!”
+
+“_Shall_!”
+
+“Oh, _shall_! for they shall--for they shall--a--a--shall mourn--a--a--blessed
+are they that shall--they that--a--they that shall mourn, for they
+shall--a--shall _what_? Why don’t you tell me, Mary?--what do you want to
+be so mean for?”
+
+“Oh, Tom, you poor thick-headed thing, I’m not teasing you. I wouldn’t
+do that. You must go and learn it again. Don’t you be discouraged, Tom,
+you’ll manage it--and if you do, I’ll give you something ever so nice.
+There, now, that’s a good boy.”
+
+“All right! What is it, Mary, tell me what it is.”
+
+“Never you mind, Tom. You know if I say it’s nice, it is nice.”
+
+“You bet you that’s so, Mary. All right, I’ll tackle it again.”
+
+And he did “tackle it again”--and under the double pressure of curiosity
+and prospective gain he did it with such spirit that he accomplished a
+shining success. Mary gave him a brand-new “Barlow” knife worth twelve
+and a half cents; and the convulsion of delight that swept his system
+shook him to his foundations. True, the knife would not cut anything,
+but it was a “sure-enough” Barlow, and there was inconceivable grandeur
+in that--though where the Western boys ever got the idea that such a
+weapon could possibly be counterfeited to its injury is an imposing
+mystery and will always remain so, perhaps. Tom contrived to scarify the
+cupboard with it, and was arranging to begin on the bureau, when he was
+called off to dress for Sunday-school.
+
+Mary gave him a tin basin of water and a piece of soap, and he went
+outside the door and set the basin on a little bench there; then he
+dipped the soap in the water and laid it down; turned up his sleeves;
+poured out the water on the ground, gently, and then entered the kitchen
+and began to wipe his face diligently on the towel behind the door. But
+Mary removed the towel and said:
+
+“Now ain’t you ashamed, Tom. You mustn’t be so bad. Water won’t hurt
+you.”
+
+Tom was a trifle disconcerted. The basin was refilled, and this time he
+stood over it a little while, gathering resolution; took in a big breath
+and began. When he entered the kitchen presently, with both eyes shut
+and groping for the towel with his hands, an honorable testimony of
+suds and water was dripping from his face. But when he emerged from
+the towel, he was not yet satisfactory, for the clean territory stopped
+short at his chin and his jaws, like a mask; below and beyond this line
+there was a dark expanse of unirrigated soil that spread downward in
+front and backward around his neck. Mary took him in hand, and when she
+was done with him he was a man and a brother, without distinction of
+color, and his saturated hair was neatly brushed, and its short curls
+wrought into a dainty and symmetrical general effect. [He privately
+smoothed out the curls, with labor and difficulty, and plastered his
+hair close down to his head; for he held curls to be effeminate, and his
+own filled his life with bitterness.] Then Mary got out a suit of his
+clothing that had been used only on Sundays during two years--they were
+simply called his “other clothes”--and so by that we know the size of his
+wardrobe. The girl “put him to rights” after he had dressed himself;
+she buttoned his neat roundabout up to his chin, turned his vast shirt
+collar down over his shoulders, brushed him off and crowned him with
+his speckled straw hat. He now looked exceedingly improved and
+uncomfortable. He was fully as uncomfortable as he looked; for there
+was a restraint about whole clothes and cleanliness that galled him. He
+hoped that Mary would forget his shoes, but the hope was blighted; she
+coated them thoroughly with tallow, as was the custom, and brought
+them out. He lost his temper and said he was always being made to do
+everything he didn’t want to do. But Mary said, persuasively:
+
+“Please, Tom--that’s a good boy.”
+
+So he got into the shoes snarling. Mary was soon ready, and the three
+children set out for Sunday-school--a place that Tom hated with his whole
+heart; but Sid and Mary were fond of it.
+
+Sabbath-school hours were from nine to half-past ten; and then church
+service. Two of the children always remained for the sermon voluntarily,
+and the other always remained too--for stronger reasons. The church’s
+high-backed, uncushioned pews would seat about three hundred persons;
+the edifice was but a small, plain affair, with a sort of pine board
+tree-box on top of it for a steeple. At the door Tom dropped back a step
+and accosted a Sunday-dressed comrade:
+
+“Say, Billy, got a yaller ticket?”
+
+“Yes.”
+
+“What’ll you take for her?”
+
+“What’ll you give?”
+
+“Piece of lickrish and a fish-hook.”
+
+“Less see ‘em.”
+
+Tom exhibited. They were satisfactory, and the property changed hands.
+Then Tom traded a couple of white alleys for three red tickets, and some
+small trifle or other for a couple of blue ones. He waylaid other
+boys as they came, and went on buying tickets of various colors ten
+or fifteen minutes longer. He entered the church, now, with a swarm
+of clean and noisy boys and girls, proceeded to his seat and started
+a quarrel with the first boy that came handy. The teacher, a grave,
+elderly man, interfered; then turned his back a moment and Tom pulled a
+boy’s hair in the next bench, and was absorbed in his book when the boy
+turned around; stuck a pin in another boy, presently, in order to hear
+him say “Ouch!” and got a new reprimand from his teacher. Tom’s whole
+class were of a pattern--restless, noisy, and troublesome. When they came
+to recite their lessons, not one of them knew his verses perfectly, but
+had to be prompted all along. However, they worried through, and each
+got his reward--in small blue tickets, each with a passage of Scripture
+on it; each blue ticket was pay for two verses of the recitation. Ten
+blue tickets equalled a red one, and could be exchanged for it; ten red
+tickets equalled a yellow one; for ten yellow tickets the superintendent
+gave a very plainly bound Bible (worth forty cents in those easy
+times) to the pupil. How many of my readers would have the industry and
+application to memorize two thousand verses, even for a Dore Bible? And
+yet Mary had acquired two Bibles in this way--it was the patient work of
+two years--and a boy of German parentage had won four or five. He once
+recited three thousand verses without stopping; but the strain upon his
+mental faculties was too great, and he was little better than an idiot
+from that day forth--a grievous misfortune for the school, for on great
+occasions, before company, the superintendent (as Tom expressed it)
+had always made this boy come out and “spread himself.” Only the older
+pupils managed to keep their tickets and stick to their tedious work
+long enough to get a Bible, and so the delivery of one of these prizes
+was a rare and noteworthy circumstance; the successful pupil was so
+great and conspicuous for that day that on the spot every scholar’s
+heart was fired with a fresh ambition that often lasted a couple
+of weeks. It is possible that Tom’s mental stomach had never really
+hungered for one of those prizes, but unquestionably his entire being
+had for many a day longed for the glory and the eclat that came with it.
+
+In due course the superintendent stood up in front of the pulpit, with
+a closed hymn-book in his hand and his forefinger inserted between its
+leaves, and commanded attention. When a Sunday-school superintendent
+makes his customary little speech, a hymn-book in the hand is as
+necessary as is the inevitable sheet of music in the hand of a singer
+who stands forward on the platform and sings a solo at a concert--though
+why, is a mystery: for neither the hymn-book nor the sheet of music
+is ever referred to by the sufferer. This superintendent was a slim
+creature of thirty-five, with a sandy goatee and short sandy hair; he
+wore a stiff standing-collar whose upper edge almost reached his ears
+and whose sharp points curved forward abreast the corners of his mouth--a
+fence that compelled a straight lookout ahead, and a turning of the
+whole body when a side view was required; his chin was propped on a
+spreading cravat which was as broad and as long as a bank-note, and had
+fringed ends; his boot toes were turned sharply up, in the fashion
+of the day, like sleigh-runners--an effect patiently and laboriously
+produced by the young men by sitting with their toes pressed against a
+wall for hours together. Mr. Walters was very earnest of mien, and very
+sincere and honest at heart; and he held sacred things and places
+in such reverence, and so separated them from worldly matters, that
+unconsciously to himself his Sunday-school voice had acquired a peculiar
+intonation which was wholly absent on week-days. He began after this
+fashion:
+
+“Now, children, I want you all to sit up just as straight and pretty as
+you can and give me all your attention for a minute or two. There--that
+is it. That is the way good little boys and girls should do. I see one
+little girl who is looking out of the window--I am afraid she thinks I
+am out there somewhere--perhaps up in one of the trees making a speech
+to the little birds. [Applausive titter.] I want to tell you how good it
+makes me feel to see so many bright, clean little faces assembled in a
+place like this, learning to do right and be good.” And so forth and so
+on. It is not necessary to set down the rest of the oration. It was of a
+pattern which does not vary, and so it is familiar to us all.
+
+The latter third of the speech was marred by the resumption of fights
+and other recreations among certain of the bad boys, and by fidgetings
+and whisperings that extended far and wide, washing even to the bases of
+isolated and incorruptible rocks like Sid and Mary. But now every sound
+ceased suddenly, with the subsidence of Mr. Walters’ voice, and the
+conclusion of the speech was received with a burst of silent gratitude.
+
+A good part of the whispering had been occasioned by an event which was
+more or less rare--the entrance of visitors: lawyer Thatcher, accompanied
+by a very feeble and aged man; a fine, portly, middle-aged gentleman
+with iron-gray hair; and a dignified lady who was doubtless the latter’s
+wife. The lady was leading a child. Tom had been restless and full of
+chafings and repinings; conscience-smitten, too--he could not meet Amy
+Lawrence’s eye, he could not brook her loving gaze. But when he saw this
+small newcomer his soul was all ablaze with bliss in a moment. The next
+moment he was “showing off” with all his might--cuffing boys, pulling
+hair, making faces--in a word, using every art that seemed likely to
+fascinate a girl and win her applause. His exaltation had but one
+alloy--the memory of his humiliation in this angel’s garden--and that
+record in sand was fast washing out, under the waves of happiness that
+were sweeping over it now.
+
+The visitors were given the highest seat of honor, and as soon as Mr.
+Walters’ speech was finished, he introduced them to the school. The
+middle-aged man turned out to be a prodigious personage--no less a one
+than the county judge--altogether the most august creation these children
+had ever looked upon--and they wondered what kind of material he was made
+of--and they half wanted to hear him roar, and were half afraid he might,
+too. He was from Constantinople, twelve miles away--so he had travelled,
+and seen the world--these very eyes had looked upon the county
+court-house--which was said to have a tin roof. The awe which these
+reflections inspired was attested by the impressive silence and the
+ranks of staring eyes. This was the great Judge Thatcher, brother of
+their own lawyer. Jeff Thatcher immediately went forward, to be familiar
+with the great man and be envied by the school. It would have been music
+to his soul to hear the whisperings:
+
+“Look at him, Jim! He’s a going up there. Say--look! he’s a going to
+shake hands with him--he _is_ shaking hands with him! By jings, don’t you
+wish you was Jeff?”
+
+Mr. Walters fell to “showing off,” with all sorts of official bustlings
+and activities, giving orders, delivering judgments, discharging
+directions here, there, everywhere that he could find a target. The
+librarian “showed off”--running hither and thither with his arms full of
+books and making a deal of the splutter and fuss that insect authority
+delights in. The young lady teachers “showed off”--bending sweetly over
+pupils that were lately being boxed, lifting pretty warning fingers
+at bad little boys and patting good ones lovingly. The young gentlemen
+teachers “showed off” with small scoldings and other little displays of
+authority and fine attention to discipline--and most of the teachers, of
+both sexes, found business up at the library, by the pulpit; and it was
+business that frequently had to be done over again two or three times
+(with much seeming vexation). The little girls “showed off” in various
+ways, and the little boys “showed off” with such diligence that the air
+was thick with paper wads and the murmur of scufflings. And above it
+all the great man sat and beamed a majestic judicial smile upon all
+the house, and warmed himself in the sun of his own grandeur--for he was
+“showing off,” too.
+
+There was only one thing wanting to make Mr. Walters’ ecstasy complete,
+and that was a chance to deliver a Bible-prize and exhibit a prodigy.
+Several pupils had a few yellow tickets, but none had enough--he had been
+around among the star pupils inquiring. He would have given worlds, now,
+to have that German lad back again with a sound mind.
+
+And now at this moment, when hope was dead, Tom Sawyer came forward with
+nine yellow tickets, nine red tickets, and ten blue ones, and demanded
+a Bible. This was a thunderbolt out of a clear sky. Walters was not
+expecting an application from this source for the next ten years. But
+there was no getting around it--here were the certified checks, and they
+were good for their face. Tom was therefore elevated to a place with
+the Judge and the other elect, and the great news was announced from
+headquarters. It was the most stunning surprise of the decade, and
+so profound was the sensation that it lifted the new hero up to the
+judicial one’s altitude, and the school had two marvels to gaze upon
+in place of one. The boys were all eaten up with envy--but those that
+suffered the bitterest pangs were those who perceived too late that they
+themselves had contributed to this hated splendor by trading tickets to
+Tom for the wealth he had amassed in selling whitewashing privileges.
+These despised themselves, as being the dupes of a wily fraud, a
+guileful snake in the grass.
+
+The prize was delivered to Tom with as much effusion as the
+superintendent could pump up under the circumstances; but it lacked
+somewhat of the true gush, for the poor fellow’s instinct taught him
+that there was a mystery here that could not well bear the light,
+perhaps; it was simply preposterous that this boy had warehoused two
+thousand sheaves of Scriptural wisdom on his premises--a dozen would
+strain his capacity, without a doubt.
+
+Amy Lawrence was proud and glad, and she tried to make Tom see it in
+her face--but he wouldn’t look. She wondered; then she was just a grain
+troubled; next a dim suspicion came and went--came again; she watched;
+a furtive glance told her worlds--and then her heart broke, and she was
+jealous, and angry, and the tears came and she hated everybody. Tom most
+of all (she thought).
+
+Tom was introduced to the Judge; but his tongue was tied, his breath
+would hardly come, his heart quaked--partly because of the awful
+greatness of the man, but mainly because he was her parent. He would
+have liked to fall down and worship him, if it were in the dark. The
+Judge put his hand on Tom’s head and called him a fine little man, and
+asked him what his name was. The boy stammered, gasped, and got it out:
+
+“Tom.”
+
+“Oh, no, not Tom--it is--”
+
+“Thomas.”
+
+“Ah, that’s it. I thought there was more to it, maybe. That’s very well.
+But you’ve another one I daresay, and you’ll tell it to me, won’t you?”
+
+“Tell the gentleman your other name, Thomas,” said Walters, “and say
+sir. You mustn’t forget your manners.”
+
+“Thomas Sawyer--sir.”
+
+“That’s it! That’s a good boy. Fine boy. Fine, manly little fellow. Two
+thousand verses is a great many--very, very great many. And you never can
+be sorry for the trouble you took to learn them; for knowledge is worth
+more than anything there is in the world; it’s what makes great men
+and good men; you’ll be a great man and a good man yourself, some
+day, Thomas, and then you’ll look back and say, It’s all owing to the
+precious Sunday-school privileges of my boyhood--it’s all owing to
+my dear teachers that taught me to learn--it’s all owing to the good
+superintendent, who encouraged me, and watched over me, and gave me a
+beautiful Bible--a splendid elegant Bible--to keep and have it all for my
+own, always--it’s all owing to right bringing up! That is what you will
+say, Thomas--and you wouldn’t take any money for those two thousand
+verses--no indeed you wouldn’t. And now you wouldn’t mind telling me and
+this lady some of the things you’ve learned--no, I know you wouldn’t--for
+we are proud of little boys that learn. Now, no doubt you know the names
+of all the twelve disciples. Won’t you tell us the names of the first
+two that were appointed?”
+
+Tom was tugging at a button-hole and looking sheepish. He blushed,
+now, and his eyes fell. Mr. Walters’ heart sank within him. He said
+to himself, it is not possible that the boy can answer the simplest
+question--why _did_ the Judge ask him? Yet he felt obliged to speak up
+and say:
+
+“Answer the gentleman, Thomas--don’t be afraid.”
+
+Tom still hung fire.
+
+“Now I know you’ll tell me,” said the lady. “The names of the first two
+disciples were--”
+
+“_David And Goliah!_”
+
+Let us draw the curtain of charity over the rest of the scene.
+
+
+
+
+CHAPTER V
+
+ABOUT half-past ten the cracked bell of the small church began to ring,
+and presently the people began to gather for the morning sermon. The
+Sunday-school children distributed themselves about the house and
+occupied pews with their parents, so as to be under supervision. Aunt
+Polly came, and Tom and Sid and Mary sat with her--Tom being placed next
+the aisle, in order that he might be as far away from the open window
+and the seductive outside summer scenes as possible. The crowd filed up
+the aisles: the aged and needy postmaster, who had seen better days;
+the mayor and his wife--for they had a mayor there, among other
+unnecessaries; the justice of the peace; the widow Douglass, fair,
+smart, and forty, a generous, good-hearted soul and well-to-do, her hill
+mansion the only palace in the town, and the most hospitable and much
+the most lavish in the matter of festivities that St. Petersburg could
+boast; the bent and venerable Major and Mrs. Ward; lawyer Riverson, the
+new notable from a distance; next the belle of the village, followed by
+a troop of lawn-clad and ribbon-decked young heart-breakers; then all
+the young clerks in town in a body--for they had stood in the vestibule
+sucking their cane-heads, a circling wall of oiled and simpering
+admirers, till the last girl had run their gantlet; and last of all came
+the Model Boy, Willie Mufferson, taking as heedful care of his mother as
+if she were cut glass. He always brought his mother to church, and was
+the pride of all the matrons. The boys all hated him, he was so
+good. And besides, he had been “thrown up to them” so much. His
+white handkerchief was hanging out of his pocket behind, as usual on
+Sundays--accidentally. Tom had no handkerchief, and he looked upon boys
+who had as snobs.
+
+The congregation being fully assembled, now, the bell rang once more,
+to warn laggards and stragglers, and then a solemn hush fell upon the
+church which was only broken by the tittering and whispering of the
+choir in the gallery. The choir always tittered and whispered all
+through service. There was once a church choir that was not ill-bred,
+but I have forgotten where it was, now. It was a great many years ago,
+and I can scarcely remember anything about it, but I think it was in
+some foreign country.
+
+The minister gave out the hymn, and read it through with a relish, in a
+peculiar style which was much admired in that part of the country. His
+voice began on a medium key and climbed steadily up till it reached a
+certain point, where it bore with strong emphasis upon the topmost word
+and then plunged down as if from a spring-board:
+
+Shall I be car-ri-ed toe the skies, on flow’ry _beds_ of ease,
+
+Whilst others fight to win the prize, and sail thro’ _blood_-y seas?
+
+He was regarded as a wonderful reader. At church “sociables” he was
+always called upon to read poetry; and when he was through, the ladies
+would lift up their hands and let them fall helplessly in their laps,
+and “wall” their eyes, and shake their heads, as much as to say, “Words
+cannot express it; it is too beautiful, TOO beautiful for this mortal
+earth.”
+
+After the hymn had been sung, the Rev. Mr. Sprague turned himself into
+a bulletin-board, and read off “notices” of meetings and societies and
+things till it seemed that the list would stretch out to the crack of
+doom--a queer custom which is still kept up in America, even in cities,
+away here in this age of abundant newspapers. Often, the less there is
+to justify a traditional custom, the harder it is to get rid of it.
+
+And now the minister prayed. A good, generous prayer it was, and went
+into details: it pleaded for the church, and the little children of the
+church; for the other churches of the village; for the village itself;
+for the county; for the State; for the State officers; for the United
+States; for the churches of the United States; for Congress; for the
+President; for the officers of the Government; for poor sailors, tossed
+by stormy seas; for the oppressed millions groaning under the heel of
+European monarchies and Oriental despotisms; for such as have the light
+and the good tidings, and yet have not eyes to see nor ears to hear
+withal; for the heathen in the far islands of the sea; and closed with
+a supplication that the words he was about to speak might find grace
+and favor, and be as seed sown in fertile ground, yielding in time a
+grateful harvest of good. Amen.
+
+There was a rustling of dresses, and the standing congregation sat down.
+The boy whose history this book relates did not enjoy the prayer, he
+only endured it--if he even did that much. He was restive all through it;
+he kept tally of the details of the prayer, unconsciously--for he was not
+listening, but he knew the ground of old, and the clergyman’s regular
+route over it--and when a little trifle of new matter was interlarded,
+his ear detected it and his whole nature resented it; he considered
+additions unfair, and scoundrelly. In the midst of the prayer a fly had
+lit on the back of the pew in front of him and tortured his spirit by
+calmly rubbing its hands together, embracing its head with its arms, and
+polishing it so vigorously that it seemed to almost part company with
+the body, and the slender thread of a neck was exposed to view; scraping
+its wings with its hind legs and smoothing them to its body as if they
+had been coat-tails; going through its whole toilet as tranquilly as if
+it knew it was perfectly safe. As indeed it was; for as sorely as Tom’s
+hands itched to grab for it they did not dare--he believed his soul would
+be instantly destroyed if he did such a thing while the prayer was going
+on. But with the closing sentence his hand began to curve and steal
+forward; and the instant the “Amen” was out the fly was a prisoner of
+war. His aunt detected the act and made him let it go.
+
+The minister gave out his text and droned along monotonously through an
+argument that was so prosy that many a head by and by began to nod--and
+yet it was an argument that dealt in limitless fire and brimstone and
+thinned the predestined elect down to a company so small as to be hardly
+worth the saving. Tom counted the pages of the sermon; after church he
+always knew how many pages there had been, but he seldom knew anything
+else about the discourse. However, this time he was really interested
+for a little while. The minister made a grand and moving picture of the
+assembling together of the world’s hosts at the millennium when the lion
+and the lamb should lie down together and a little child should lead
+them. But the pathos, the lesson, the moral of the great spectacle
+were lost upon the boy; he only thought of the conspicuousness of the
+principal character before the on-looking nations; his face lit with the
+thought, and he said to himself that he wished he could be that child,
+if it was a tame lion.
+
+Now he lapsed into suffering again, as the dry argument was resumed.
+Presently he bethought him of a treasure he had and got it out. It was
+a large black beetle with formidable jaws--a “pinchbug,” he called it. It
+was in a percussion-cap box. The first thing the beetle did was to
+take him by the finger. A natural fillip followed, the beetle went
+floundering into the aisle and lit on its back, and the hurt finger went
+into the boy’s mouth. The beetle lay there working its helpless legs,
+unable to turn over. Tom eyed it, and longed for it; but it was safe out
+of his reach. Other people uninterested in the sermon found relief in
+the beetle, and they eyed it too. Presently a vagrant poodle dog came
+idling along, sad at heart, lazy with the summer softness and the
+quiet, weary of captivity, sighing for change. He spied the beetle; the
+drooping tail lifted and wagged. He surveyed the prize; walked around
+it; smelt at it from a safe distance; walked around it again; grew
+bolder, and took a closer smell; then lifted his lip and made a gingerly
+snatch at it, just missing it; made another, and another; began to enjoy
+the diversion; subsided to his stomach with the beetle between his paws,
+and continued his experiments; grew weary at last, and then indifferent
+and absent-minded. His head nodded, and little by little his chin
+descended and touched the enemy, who seized it. There was a sharp yelp,
+a flirt of the poodle’s head, and the beetle fell a couple of yards
+away, and lit on its back once more. The neighboring spectators
+shook with a gentle inward joy, several faces went behind fans and
+hand-kerchiefs, and Tom was entirely happy. The dog looked foolish,
+and probably felt so; but there was resentment in his heart, too, and a
+craving for revenge. So he went to the beetle and began a wary attack on
+it again; jumping at it from every point of a circle, lighting with his
+fore-paws within an inch of the creature, making even closer snatches at
+it with his teeth, and jerking his head till his ears flapped again. But
+he grew tired once more, after a while; tried to amuse himself with a
+fly but found no relief; followed an ant around, with his nose close
+to the floor, and quickly wearied of that; yawned, sighed, forgot the
+beetle entirely, and sat down on it. Then there was a wild yelp of agony
+and the poodle went sailing up the aisle; the yelps continued, and so
+did the dog; he crossed the house in front of the altar; he flew
+down the other aisle; he crossed before the doors; he clamored up the
+home-stretch; his anguish grew with his progress, till presently he was
+but a woolly comet moving in its orbit with the gleam and the speed of
+light. At last the frantic sufferer sheered from its course, and sprang
+into its master’s lap; he flung it out of the window, and the voice of
+distress quickly thinned away and died in the distance.
+
+By this time the whole church was red-faced and suffocating with
+suppressed laughter, and the sermon had come to a dead standstill.
+The discourse was resumed presently, but it went lame and halting, all
+possibility of impressiveness being at an end; for even the gravest
+sentiments were constantly being received with a smothered burst of
+unholy mirth, under cover of some remote pew-back, as if the poor parson
+had said a rarely facetious thing. It was a genuine relief to the whole
+congregation when the ordeal was over and the benediction pronounced.
+
+Tom Sawyer went home quite cheerful, thinking to himself that there was
+some satisfaction about divine service when there was a bit of variety
+in it. He had but one marring thought; he was willing that the dog
+should play with his pinchbug, but he did not think it was upright in
+him to carry it off.
+
+
+
+
+CHAPTER VI
+
+MONDAY morning found Tom Sawyer miserable. Monday morning always found
+him so--because it began another week’s slow suffering in school. He
+generally began that day with wishing he had had no intervening holiday,
+it made the going into captivity and fetters again so much more odious.
+
+Tom lay thinking. Presently it occurred to him that he wished he was
+sick; then he could stay home from school. Here was a vague possibility.
+He canvassed his system. No ailment was found, and he investigated
+again. This time he thought he could detect colicky symptoms, and he
+began to encourage them with considerable hope. But they soon grew
+feeble, and presently died wholly away. He reflected further. Suddenly
+he discovered something. One of his upper front teeth was loose. This
+was lucky; he was about to begin to groan, as a “starter,” as he
+called it, when it occurred to him that if he came into court with that
+argument, his aunt would pull it out, and that would hurt. So he thought
+he would hold the tooth in reserve for the present, and seek further.
+Nothing offered for some little time, and then he remembered hearing
+the doctor tell about a certain thing that laid up a patient for two or
+three weeks and threatened to make him lose a finger. So the boy eagerly
+drew his sore toe from under the sheet and held it up for inspection.
+But now he did not know the necessary symptoms. However, it seemed
+well worth while to chance it, so he fell to groaning with considerable
+spirit.
+
+But Sid slept on unconscious.
+
+Tom groaned louder, and fancied that he began to feel pain in the toe.
+
+No result from Sid.
+
+Tom was panting with his exertions by this time. He took a rest and then
+swelled himself up and fetched a succession of admirable groans.
+
+Sid snored on.
+
+Tom was aggravated. He said, “Sid, Sid!” and shook him. This course
+worked well, and Tom began to groan again. Sid yawned, stretched, then
+brought himself up on his elbow with a snort, and began to stare at Tom.
+Tom went on groaning. Sid said:
+
+“Tom! Say, Tom!” [No response.] “Here, Tom! TOM! What is the matter,
+Tom?” And he shook him and looked in his face anxiously.
+
+Tom moaned out:
+
+“Oh, don’t, Sid. Don’t joggle me.”
+
+“Why, what’s the matter, Tom? I must call auntie.”
+
+“No--never mind. It’ll be over by and by, maybe. Don’t call anybody.”
+
+“But I must! _Don’t_ groan so, Tom, it’s awful. How long you been this
+way?”
+
+“Hours. Ouch! Oh, don’t stir so, Sid, you’ll kill me.”
+
+“Tom, why didn’t you wake me sooner? Oh, Tom, _don’t!_ It makes my flesh
+crawl to hear you. Tom, what is the matter?”
+
+“I forgive you everything, Sid. [Groan.] Everything you’ve ever done to
+me. When I’m gone--”
+
+“Oh, Tom, you ain’t dying, are you? Don’t, Tom--oh, don’t. Maybe--”
+
+“I forgive everybody, Sid. [Groan.] Tell ‘em so, Sid. And Sid, you give
+my window-sash and my cat with one eye to that new girl that’s come to
+town, and tell her--”
+
+But Sid had snatched his clothes and gone. Tom was suffering in reality,
+now, so handsomely was his imagination working, and so his groans had
+gathered quite a genuine tone.
+
+Sid flew downstairs and said:
+
+“Oh, Aunt Polly, come! Tom’s dying!”
+
+“Dying!”
+
+“Yes’m. Don’t wait--come quick!”
+
+“Rubbage! I don’t believe it!”
+
+But she fled upstairs, nevertheless, with Sid and Mary at her heels.
+And her face grew white, too, and her lip trembled. When she reached the
+bedside she gasped out:
+
+“You, Tom! Tom, what’s the matter with you?”
+
+“Oh, auntie, I’m--”
+
+“What’s the matter with you--what is the matter with you, child?”
+
+“Oh, auntie, my sore toe’s mortified!”
+
+The old lady sank down into a chair and laughed a little, then cried a
+little, then did both together. This restored her and she said:
+
+“Tom, what a turn you did give me. Now you shut up that nonsense and
+climb out of this.”
+
+The groans ceased and the pain vanished from the toe. The boy felt a
+little foolish, and he said:
+
+“Aunt Polly, it _seemed_ mortified, and it hurt so I never minded my
+tooth at all.”
+
+“Your tooth, indeed! What’s the matter with your tooth?”
+
+“One of them’s loose, and it aches perfectly awful.”
+
+“There, there, now, don’t begin that groaning again. Open your mouth.
+Well--your tooth _is_ loose, but you’re not going to die about that.
+Mary, get me a silk thread, and a chunk of fire out of the kitchen.”
+
+Tom said:
+
+“Oh, please, auntie, don’t pull it out. It don’t hurt any more. I wish
+I may never stir if it does. Please don’t, auntie. I don’t want to stay
+home from school.”
+
+“Oh, you don’t, don’t you? So all this row was because you thought you’d
+get to stay home from school and go a-fishing? Tom, Tom, I love you so,
+and you seem to try every way you can to break my old heart with your
+outrageousness.” By this time the dental instruments were ready. The old
+lady made one end of the silk thread fast to Tom’s tooth with a loop
+and tied the other to the bedpost. Then she seized the chunk of fire and
+suddenly thrust it almost into the boy’s face. The tooth hung dangling
+by the bedpost, now.
+
+But all trials bring their compensations. As Tom wended to school after
+breakfast, he was the envy of every boy he met because the gap in his
+upper row of teeth enabled him to expectorate in a new and admirable
+way. He gathered quite a following of lads interested in the exhibition;
+and one that had cut his finger and had been a centre of fascination and
+homage up to this time, now found himself suddenly without an adherent,
+and shorn of his glory. His heart was heavy, and he said with a disdain
+which he did not feel that it wasn’t anything to spit like Tom Sawyer;
+but another boy said, “Sour grapes!” and he wandered away a dismantled
+hero.
+
+Shortly Tom came upon the juvenile pariah of the village, Huckleberry
+Finn, son of the town drunkard. Huckleberry was cordially hated and
+dreaded by all the mothers of the town, because he was idle and lawless
+and vulgar and bad--and because all their children admired him so, and
+delighted in his forbidden society, and wished they dared to be like
+him. Tom was like the rest of the respectable boys, in that he envied
+Huckleberry his gaudy outcast condition, and was under strict orders
+not to play with him. So he played with him every time he got a chance.
+Huckleberry was always dressed in the cast-off clothes of full-grown
+men, and they were in perennial bloom and fluttering with rags. His hat
+was a vast ruin with a wide crescent lopped out of its brim; his coat,
+when he wore one, hung nearly to his heels and had the rearward buttons
+far down the back; but one suspender supported his trousers; the seat of
+the trousers bagged low and contained nothing, the fringed legs dragged
+in the dirt when not rolled up.
+
+Huckleberry came and went, at his own free will. He slept on doorsteps
+in fine weather and in empty hogsheads in wet; he did not have to go to
+school or to church, or call any being master or obey anybody; he could
+go fishing or swimming when and where he chose, and stay as long as it
+suited him; nobody forbade him to fight; he could sit up as late as he
+pleased; he was always the first boy that went barefoot in the spring
+and the last to resume leather in the fall; he never had to wash, nor
+put on clean clothes; he could swear wonderfully. In a word, everything
+that goes to make life precious that boy had. So thought every harassed,
+hampered, respectable boy in St. Petersburg.
+
+Tom hailed the romantic outcast:
+
+“Hello, Huckleberry!”
+
+“Hello yourself, and see how you like it.”
+
+“What’s that you got?”
+
+“Dead cat.”
+
+“Lemme see him, Huck. My, he’s pretty stiff. Where’d you get him?”
+
+“Bought him off’n a boy.”
+
+“What did you give?”
+
+“I give a blue ticket and a bladder that I got at the slaughter-house.”
+
+“Where’d you get the blue ticket?”
+
+“Bought it off’n Ben Rogers two weeks ago for a hoop-stick.”
+
+“Say--what is dead cats good for, Huck?”
+
+“Good for? Cure warts with.”
+
+“No! Is that so? I know something that’s better.”
+
+“I bet you don’t. What is it?”
+
+“Why, spunk-water.”
+
+“Spunk-water! I wouldn’t give a dern for spunk-water.”
+
+“You wouldn’t, wouldn’t you? D’you ever try it?”
+
+“No, I hain’t. But Bob Tanner did.”
+
+“Who told you so!”
+
+“Why, he told Jeff Thatcher, and Jeff told Johnny Baker, and Johnny
+told Jim Hollis, and Jim told Ben Rogers, and Ben told a nigger, and the
+nigger told me. There now!”
+
+“Well, what of it? They’ll all lie. Leastways all but the nigger. I
+don’t know _him_. But I never see a nigger that _wouldn’t_ lie. Shucks!
+Now you tell me how Bob Tanner done it, Huck.”
+
+“Why, he took and dipped his hand in a rotten stump where the rain-water
+was.”
+
+“In the daytime?”
+
+“Certainly.”
+
+“With his face to the stump?”
+
+“Yes. Least I reckon so.”
+
+“Did he say anything?”
+
+“I don’t reckon he did. I don’t know.”
+
+“Aha! Talk about trying to cure warts with spunk-water such a blame fool
+way as that! Why, that ain’t a-going to do any good. You got to go all
+by yourself, to the middle of the woods, where you know there’s a
+spunk-water stump, and just as it’s midnight you back up against the stump
+and jam your hand in and say:
+
+‘Barley-corn, barley-corn, injun-meal shorts, Spunk-water, spunk-water,
+swaller these warts,’
+
+and then walk away quick, eleven steps, with your eyes shut, and then
+turn around three times and walk home without speaking to anybody.
+Because if you speak the charm’s busted.”
+
+“Well, that sounds like a good way; but that ain’t the way Bob Tanner
+done.”
+
+“No, sir, you can bet he didn’t, becuz he’s the wartiest boy in this
+town; and he wouldn’t have a wart on him if he’d knowed how to work
+spunk-water. I’ve took off thousands of warts off of my hands that way,
+Huck. I play with frogs so much that I’ve always got considerable many
+warts. Sometimes I take ‘em off with a bean.”
+
+“Yes, bean’s good. I’ve done that.”
+
+“Have you? What’s your way?”
+
+“You take and split the bean, and cut the wart so as to get some blood,
+and then you put the blood on one piece of the bean and take and dig
+a hole and bury it ‘bout midnight at the crossroads in the dark of the
+moon, and then you burn up the rest of the bean. You see that piece
+that’s got the blood on it will keep drawing and drawing, trying to
+fetch the other piece to it, and so that helps the blood to draw the
+wart, and pretty soon off she comes.”
+
+“Yes, that’s it, Huck--that’s it; though when you’re burying it if you
+say ‘Down bean; off wart; come no more to bother me!’ it’s better.
+That’s the way Joe Harper does, and he’s been nearly to Coonville and
+most everywheres. But say--how do you cure ‘em with dead cats?”
+
+“Why, you take your cat and go and get in the grave-yard ‘long about
+midnight when somebody that was wicked has been buried; and when it’s
+midnight a devil will come, or maybe two or three, but you can’t see
+‘em, you can only hear something like the wind, or maybe hear ‘em talk;
+and when they’re taking that feller away, you heave your cat after ‘em
+and say, ‘Devil follow corpse, cat follow devil, warts follow cat, I’m
+done with ye!’ That’ll fetch _any_ wart.”
+
+“Sounds right. D’you ever try it, Huck?”
+
+“No, but old Mother Hopkins told me.”
+
+“Well, I reckon it’s so, then. Becuz they say she’s a witch.”
+
+“Say! Why, Tom, I _know_ she is. She witched pap. Pap says so his own
+self. He come along one day, and he see she was a-witching him, so he
+took up a rock, and if she hadn’t dodged, he’d a got her. Well, that
+very night he rolled off’n a shed wher’ he was a layin drunk, and broke
+his arm.”
+
+“Why, that’s awful. How did he know she was a-witching him?”
+
+“Lord, pap can tell, easy. Pap says when they keep looking at you right
+stiddy, they’re a-witching you. Specially if they mumble. Becuz when
+they mumble they’re saying the Lord’s Prayer backards.”
+
+“Say, Hucky, when you going to try the cat?”
+
+“To-night. I reckon they’ll come after old Hoss Williams to-night.”
+
+“But they buried him Saturday. Didn’t they get him Saturday night?”
+
+“Why, how you talk! How could their charms work till midnight?--and
+_then_ it’s Sunday. Devils don’t slosh around much of a Sunday, I don’t
+reckon.”
+
+“I never thought of that. That’s so. Lemme go with you?”
+
+“Of course--if you ain’t afeard.”
+
+“Afeard! ‘Tain’t likely. Will you meow?”
+
+“Yes--and you meow back, if you get a chance. Last time, you kep’ me
+a-meowing around till old Hays went to throwing rocks at me and says
+‘Dern that cat!’ and so I hove a brick through his window--but don’t you
+tell.”
+
+“I won’t. I couldn’t meow that night, becuz auntie was watching me, but
+I’ll meow this time. Say--what’s that?”
+
+“Nothing but a tick.”
+
+“Where’d you get him?”
+
+“Out in the woods.”
+
+“What’ll you take for him?”
+
+“I don’t know. I don’t want to sell him.”
+
+“All right. It’s a mighty small tick, anyway.”
+
+“Oh, anybody can run a tick down that don’t belong to them. I’m
+satisfied with it. It’s a good enough tick for me.”
+
+“Sho, there’s ticks a plenty. I could have a thousand of ‘em if I wanted
+to.”
+
+“Well, why don’t you? Becuz you know mighty well you can’t. This is a
+pretty early tick, I reckon. It’s the first one I’ve seen this year.”
+
+“Say, Huck--I’ll give you my tooth for him.”
+
+“Less see it.”
+
+Tom got out a bit of paper and carefully unrolled it. Huckleberry viewed
+it wistfully. The temptation was very strong. At last he said:
+
+“Is it genuwyne?”
+
+Tom lifted his lip and showed the vacancy.
+
+“Well, all right,” said Huckleberry, “it’s a trade.”
+
+Tom enclosed the tick in the percussion-cap box that had lately been the
+pinchbug’s prison, and the boys separated, each feeling wealthier than
+before.
+
+When Tom reached the little isolated frame school-house, he strode in
+briskly, with the manner of one who had come with all honest speed. He
+hung his hat on a peg and flung himself into his seat with business-like
+alacrity. The master, throned on high in his great splint-bottom
+arm-chair, was dozing, lulled by the drowsy hum of study. The
+interruption roused him.
+
+“Thomas Sawyer!”
+
+Tom knew that when his name was pronounced in full, it meant trouble.
+
+“Sir!”
+
+“Come up here. Now, sir, why are you late again, as usual?”
+
+Tom was about to take refuge in a lie, when he saw two long tails of
+yellow hair hanging down a back that he recognized by the electric
+sympathy of love; and by that form was _the only vacant place_ on the
+girls’ side of the school-house. He instantly said:
+
+“_I stopped to talk with Huckleberry Finn!_”
+
+The master’s pulse stood still, and he stared helplessly. The buzz of
+study ceased. The pupils wondered if this foolhardy boy had lost his
+mind. The master said:
+
+“You--you did what?”
+
+“Stopped to talk with Huckleberry Finn.”
+
+There was no mistaking the words.
+
+“Thomas Sawyer, this is the most astounding confession I have ever
+listened to. No mere ferule will answer for this offence. Take off your
+jacket.”
+
+The master’s arm performed until it was tired and the stock of switches
+notably diminished. Then the order followed:
+
+“Now, sir, go and sit with the girls! And let this be a warning to you.”
+
+The titter that rippled around the room appeared to abash the boy, but
+in reality that result was caused rather more by his worshipful awe
+of his unknown idol and the dread pleasure that lay in his high good
+fortune. He sat down upon the end of the pine bench and the girl hitched
+herself away from him with a toss of her head. Nudges and winks and
+whispers traversed the room, but Tom sat still, with his arms upon the
+long, low desk before him, and seemed to study his book.
+
+By and by attention ceased from him, and the accustomed school murmur
+rose upon the dull air once more. Presently the boy began to steal
+furtive glances at the girl. She observed it, “made a mouth” at him
+and gave him the back of her head for the space of a minute. When she
+cautiously faced around again, a peach lay before her. She thrust it
+away. Tom gently put it back. She thrust it away again, but with less
+animosity. Tom patiently returned it to its place. Then she let it
+remain. Tom scrawled on his slate, “Please take it--I got more.” The
+girl glanced at the words, but made no sign. Now the boy began to draw
+something on the slate, hiding his work with his left hand. For a time
+the girl refused to notice; but her human curiosity presently began
+to manifest itself by hardly perceptible signs. The boy worked on,
+apparently unconscious. The girl made a sort of non-committal attempt
+to see, but the boy did not betray that he was aware of it. At last she
+gave in and hesitatingly whispered:
+
+“Let me see it.”
+
+Tom partly uncovered a dismal caricature of a house with two gable ends
+to it and a corkscrew of smoke issuing from the chimney. Then the girl’s
+interest began to fasten itself upon the work and she forgot everything
+else. When it was finished, she gazed a moment, then whispered:
+
+“It’s nice--make a man.”
+
+The artist erected a man in the front yard, that resembled a derrick. He
+could have stepped over the house; but the girl was not hypercritical;
+she was satisfied with the monster, and whispered:
+
+“It’s a beautiful man--now make me coming along.”
+
+Tom drew an hour-glass with a full moon and straw limbs to it and armed
+the spreading fingers with a portentous fan. The girl said:
+
+“It’s ever so nice--I wish I could draw.”
+
+“It’s easy,” whispered Tom, “I’ll learn you.”
+
+“Oh, will you? When?”
+
+“At noon. Do you go home to dinner?”
+
+“I’ll stay if you will.”
+
+“Good--that’s a whack. What’s your name?”
+
+“Becky Thatcher. What’s yours? Oh, I know. It’s Thomas Sawyer.”
+
+“That’s the name they lick me by. I’m Tom when I’m good. You call me
+Tom, will you?”
+
+“Yes.”
+
+Now Tom began to scrawl something on the slate, hiding the words from
+the girl. But she was not backward this time. She begged to see. Tom
+said:
+
+“Oh, it ain’t anything.”
+
+“Yes it is.”
+
+“No it ain’t. You don’t want to see.”
+
+“Yes I do, indeed I do. Please let me.”
+
+“You’ll tell.”
+
+“No I won’t--deed and deed and double deed won’t.”
+
+“You won’t tell anybody at all? Ever, as long as you live?”
+
+“No, I won’t ever tell _any_body. Now let me.”
+
+“Oh, _you_ don’t want to see!”
+
+“Now that you treat me so, I _will_ see.” And she put her small hand
+upon his and a little scuffle ensued, Tom pretending to resist in
+earnest but letting his hand slip by degrees till these words were
+revealed: “_I love you_.”
+
+“Oh, you bad thing!” And she hit his hand a smart rap, but reddened and
+looked pleased, nevertheless.
+
+Just at this juncture the boy felt a slow, fateful grip closing on his
+ear, and a steady lifting impulse. In that wise he was borne across the
+house and deposited in his own seat, under a peppering fire of giggles
+from the whole school. Then the master stood over him during a few awful
+moments, and finally moved away to his throne without saying a word. But
+although Tom’s ear tingled, his heart was jubilant.
+
+As the school quieted down Tom made an honest effort to study, but
+the turmoil within him was too great. In turn he took his place in the
+reading class and made a botch of it; then in the geography class and
+turned lakes into mountains, mountains into rivers, and rivers into
+continents, till chaos was come again; then in the spelling class, and
+got “turned down,” by a succession of mere baby words, till he brought
+up at the foot and yielded up the pewter medal which he had worn with
+ostentation for months.
+
+
+
+
+CHAPTER VII
+
+THE harder Tom tried to fasten his mind on his book, the more his ideas
+wandered. So at last, with a sigh and a yawn, he gave it up. It seemed
+to him that the noon recess would never come. The air was utterly dead.
+There was not a breath stirring. It was the sleepiest of sleepy days.
+The drowsing murmur of the five and twenty studying scholars soothed
+the soul like the spell that is in the murmur of bees. Away off in the
+flaming sunshine, Cardiff Hill lifted its soft green sides through a
+shimmering veil of heat, tinted with the purple of distance; a few birds
+floated on lazy wing high in the air; no other living thing was visible
+but some cows, and they were asleep. Tom’s heart ached to be free, or
+else to have something of interest to do to pass the dreary time.
+His hand wandered into his pocket and his face lit up with a glow of
+gratitude that was prayer, though he did not know it. Then furtively
+the percussion-cap box came out. He released the tick and put him on
+the long flat desk. The creature probably glowed with a gratitude that
+amounted to prayer, too, at this moment, but it was premature: for when
+he started thankfully to travel off, Tom turned him aside with a pin and
+made him take a new direction.
+
+Tom’s bosom friend sat next him, suffering just as Tom had been, and
+now he was deeply and gratefully interested in this entertainment in
+an instant. This bosom friend was Joe Harper. The two boys were sworn
+friends all the week, and embattled enemies on Saturdays. Joe took a
+pin out of his lapel and began to assist in exercising the prisoner.
+The sport grew in interest momently. Soon Tom said that they were
+interfering with each other, and neither getting the fullest benefit
+of the tick. So he put Joe’s slate on the desk and drew a line down the
+middle of it from top to bottom.
+
+“Now,” said he, “as long as he is on your side you can stir him up and
+I’ll let him alone; but if you let him get away and get on my side,
+you’re to leave him alone as long as I can keep him from crossing over.”
+
+“All right, go ahead; start him up.”
+
+The tick escaped from Tom, presently, and crossed the equator. Joe
+harassed him awhile, and then he got away and crossed back again. This
+change of base occurred often. While one boy was worrying the tick with
+absorbing interest, the other would look on with interest as strong, the
+two heads bowed together over the slate, and the two souls dead to all
+things else. At last luck seemed to settle and abide with Joe. The
+tick tried this, that, and the other course, and got as excited and as
+anxious as the boys themselves, but time and again just as he would
+have victory in his very grasp, so to speak, and Tom’s fingers would
+be twitching to begin, Joe’s pin would deftly head him off, and keep
+possession. At last Tom could stand it no longer. The temptation was too
+strong. So he reached out and lent a hand with his pin. Joe was angry in
+a moment. Said he:
+
+“Tom, you let him alone.”
+
+“I only just want to stir him up a little, Joe.”
+
+“No, sir, it ain’t fair; you just let him alone.”
+
+“Blame it, I ain’t going to stir him much.”
+
+“Let him alone, I tell you.”
+
+“I won’t!”
+
+“You shall--he’s on my side of the line.”
+
+“Look here, Joe Harper, whose is that tick?”
+
+“I don’t care whose tick he is--he’s on my side of the line, and you
+sha’n’t touch him.”
+
+“Well, I’ll just bet I will, though. He’s my tick and I’ll do what I
+blame please with him, or die!”
+
+A tremendous whack came down on Tom’s shoulders, and its duplicate on
+Joe’s; and for the space of two minutes the dust continued to fly from
+the two jackets and the whole school to enjoy it. The boys had been
+too absorbed to notice the hush that had stolen upon the school awhile
+before when the master came tiptoeing down the room and stood over them.
+He had contemplated a good part of the performance before he contributed
+his bit of variety to it.
+
+When school broke up at noon, Tom flew to Becky Thatcher, and whispered
+in her ear:
+
+“Put on your bonnet and let on you’re going home; and when you get to
+the corner, give the rest of ‘em the slip, and turn down through the
+lane and come back. I’ll go the other way and come it over ‘em the same
+way.”
+
+So the one went off with one group of scholars, and the other with
+another. In a little while the two met at the bottom of the lane, and
+when they reached the school they had it all to themselves. Then they
+sat together, with a slate before them, and Tom gave Becky the pencil
+and held her hand in his, guiding it, and so created another surprising
+house. When the interest in art began to wane, the two fell to talking.
+Tom was swimming in bliss. He said:
+
+“Do you love rats?”
+
+“No! I hate them!”
+
+“Well, I do, too--_live_ ones. But I mean dead ones, to swing round your
+head with a string.”
+
+“No, I don’t care for rats much, anyway. What I like is chewing-gum.”
+
+“Oh, I should say so! I wish I had some now.”
+
+“Do you? I’ve got some. I’ll let you chew it awhile, but you must give
+it back to me.”
+
+That was agreeable, so they chewed it turn about, and dangled their legs
+against the bench in excess of contentment.
+
+“Was you ever at a circus?” said Tom.
+
+“Yes, and my pa’s going to take me again some time, if I’m good.”
+
+“I been to the circus three or four times--lots of times. Church ain’t
+shucks to a circus. There’s things going on at a circus all the time.
+I’m going to be a clown in a circus when I grow up.”
+
+“Oh, are you! That will be nice. They’re so lovely, all spotted up.”
+
+“Yes, that’s so. And they get slathers of money--most a dollar a day, Ben
+Rogers says. Say, Becky, was you ever engaged?”
+
+“What’s that?”
+
+“Why, engaged to be married.”
+
+“No.”
+
+“Would you like to?”
+
+“I reckon so. I don’t know. What is it like?”
+
+“Like? Why it ain’t like anything. You only just tell a boy you won’t
+ever have anybody but him, ever ever ever, and then you kiss and that’s
+all. Anybody can do it.”
+
+“Kiss? What do you kiss for?”
+
+“Why, that, you know, is to--well, they always do that.”
+
+“Everybody?”
+
+“Why, yes, everybody that’s in love with each other. Do you remember
+what I wrote on the slate?”
+
+“Ye--yes.”
+
+“What was it?”
+
+“I sha’n’t tell you.”
+
+“Shall I tell _you_?”
+
+“Ye--yes--but some other time.”
+
+“No, now.”
+
+“No, not now--to-morrow.”
+
+“Oh, no, _now_. Please, Becky--I’ll whisper it, I’ll whisper it ever so
+easy.”
+
+Becky hesitating, Tom took silence for consent, and passed his arm about
+her waist and whispered the tale ever so softly, with his mouth close to
+her ear. And then he added:
+
+“Now you whisper it to me--just the same.”
+
+She resisted, for a while, and then said:
+
+“You turn your face away so you can’t see, and then I will. But you
+mustn’t ever tell anybody--_will_ you, Tom? Now you won’t, _will_ you?”
+
+“No, indeed, indeed I won’t. Now, Becky.”
+
+He turned his face away. She bent timidly around till her breath stirred
+his curls and whispered, “I--love--you!”
+
+Then she sprang away and ran around and around the desks and benches,
+with Tom after her, and took refuge in a corner at last, with her little
+white apron to her face. Tom clasped her about her neck and pleaded:
+
+“Now, Becky, it’s all done--all over but the kiss. Don’t you be afraid
+of that--it ain’t anything at all. Please, Becky.” And he tugged at her
+apron and the hands.
+
+By and by she gave up, and let her hands drop; her face, all glowing
+with the struggle, came up and submitted. Tom kissed the red lips and
+said:
+
+“Now it’s all done, Becky. And always after this, you know, you ain’t
+ever to love anybody but me, and you ain’t ever to marry anybody but me,
+ever never and forever. Will you?”
+
+“No, I’ll never love anybody but you, Tom, and I’ll never marry anybody
+but you--and you ain’t to ever marry anybody but me, either.”
+
+“Certainly. Of course. That’s _part_ of it. And always coming to school
+or when we’re going home, you’re to walk with me, when there ain’t
+anybody looking--and you choose me and I choose you at parties, because
+that’s the way you do when you’re engaged.”
+
+“It’s so nice. I never heard of it before.”
+
+“Oh, it’s ever so gay! Why, me and Amy Lawrence--”
+
+The big eyes told Tom his blunder and he stopped, confused.
+
+“Oh, Tom! Then I ain’t the first you’ve ever been engaged to!”
+
+The child began to cry. Tom said:
+
+“Oh, don’t cry, Becky, I don’t care for her any more.”
+
+“Yes, you do, Tom--you know you do.”
+
+Tom tried to put his arm about her neck, but she pushed him away and
+turned her face to the wall, and went on crying. Tom tried again, with
+soothing words in his mouth, and was repulsed again. Then his pride was
+up, and he strode away and went outside. He stood about, restless and
+uneasy, for a while, glancing at the door, every now and then, hoping
+she would repent and come to find him. But she did not. Then he began
+to feel badly and fear that he was in the wrong. It was a hard struggle
+with him to make new advances, now, but he nerved himself to it and
+entered. She was still standing back there in the corner, sobbing, with
+her face to the wall. Tom’s heart smote him. He went to her and stood a
+moment, not knowing exactly how to proceed. Then he said hesitatingly:
+
+“Becky, I--I don’t care for anybody but you.”
+
+No reply--but sobs.
+
+“Becky”--pleadingly. “Becky, won’t you say something?”
+
+More sobs.
+
+Tom got out his chiefest jewel, a brass knob from the top of an andiron,
+and passed it around her so that she could see it, and said:
+
+“Please, Becky, won’t you take it?”
+
+She struck it to the floor. Then Tom marched out of the house and over
+the hills and far away, to return to school no more that day. Presently
+Becky began to suspect. She ran to the door; he was not in sight; she
+flew around to the play-yard; he was not there. Then she called:
+
+“Tom! Come back, Tom!”
+
+She listened intently, but there was no answer. She had no companions
+but silence and loneliness. So she sat down to cry again and upbraid
+herself; and by this time the scholars began to gather again, and she
+had to hide her griefs and still her broken heart and take up the cross
+of a long, dreary, aching afternoon, with none among the strangers about
+her to exchange sorrows with.
+
+
+
+
+CHAPTER VIII
+
+TOM dodged hither and thither through lanes until he was well out of the
+track of returning scholars, and then fell into a moody jog. He crossed
+a small “branch” two or three times, because of a prevailing juvenile
+superstition that to cross water baffled pursuit. Half an hour later
+he was disappearing behind the Douglas mansion on the summit of Cardiff
+Hill, and the school-house was hardly distinguishable away off in the
+valley behind him. He entered a dense wood, picked his pathless way to
+the centre of it, and sat down on a mossy spot under a spreading oak.
+There was not even a zephyr stirring; the dead noonday heat had even
+stilled the songs of the birds; nature lay in a trance that was broken
+by no sound but the occasional far-off hammering of a wood-pecker, and
+this seemed to render the pervading silence and sense of loneliness the
+more profound. The boy’s soul was steeped in melancholy; his feelings
+were in happy accord with his surroundings. He sat long with his elbows
+on his knees and his chin in his hands, meditating. It seemed to him
+that life was but a trouble, at best, and he more than half envied Jimmy
+Hodges, so lately released; it must be very peaceful, he thought, to lie
+and slumber and dream forever and ever, with the wind whispering through
+the trees and caressing the grass and the flowers over the grave, and
+nothing to bother and grieve about, ever any more. If he only had a
+clean Sunday-school record he could be willing to go, and be done with
+it all. Now as to this girl. What had he done? Nothing. He had meant
+the best in the world, and been treated like a dog--like a very dog. She
+would be sorry some day--maybe when it was too late. Ah, if he could only
+die _temporarily_!
+
+But the elastic heart of youth cannot be compressed into one constrained
+shape long at a time. Tom presently began to drift insensibly back into
+the concerns of this life again. What if he turned his back, now, and
+disappeared mysteriously? What if he went away--ever so far away, into
+unknown countries beyond the seas--and never came back any more! How
+would she feel then! The idea of being a clown recurred to him now, only
+to fill him with disgust. For frivolity and jokes and spotted tights
+were an offense, when they intruded themselves upon a spirit that was
+exalted into the vague august realm of the romantic. No, he would be
+a soldier, and return after long years, all war-worn and illustrious.
+No--better still, he would join the Indians, and hunt buffaloes and go on
+the warpath in the mountain ranges and the trackless great plains of the
+Far West, and away in the future come back a great chief, bristling with
+feathers, hideous with paint, and prance into Sunday-school, some drowsy
+summer morning, with a blood-curdling war-whoop, and sear the eyeballs
+of all his companions with unappeasable envy. But no, there was
+something gaudier even than this. He would be a pirate! That was it!
+_now_ his future lay plain before him, and glowing with unimaginable
+splendor. How his name would fill the world, and make people shudder!
+How gloriously he would go plowing the dancing seas, in his long, low,
+black-hulled racer, the Spirit of the Storm, with his grisly flag flying
+at the fore! And at the zenith of his fame, how he would suddenly appear
+at the old village and stalk into church, brown and weather-beaten, in
+his black velvet doublet and trunks, his great jack-boots, his crimson
+sash, his belt bristling with horse-pistols, his crime-rusted cutlass
+at his side, his slouch hat with waving plumes, his black flag unfurled,
+with the skull and crossbones on it, and hear with swelling ecstasy
+the whisperings, “It’s Tom Sawyer the Pirate!--the Black Avenger of the
+Spanish Main!”
+
+Yes, it was settled; his career was determined. He would run away from
+home and enter upon it. He would start the very next morning. Therefore
+he must now begin to get ready. He would collect his resources together.
+He went to a rotten log near at hand and began to dig under one end of
+it with his Barlow knife. He soon struck wood that sounded hollow. He
+put his hand there and uttered this incantation impressively:
+
+“What hasn’t come here, come! What’s here, stay here!”
+
+Then he scraped away the dirt, and exposed a pine shingle. He took it
+up and disclosed a shapely little treasure-house whose bottom and sides
+were of shingles. In it lay a marble. Tom’s astonishment was bound-less!
+He scratched his head with a perplexed air, and said:
+
+“Well, that beats anything!”
+
+Then he tossed the marble away pettishly, and stood cogitating. The
+truth was, that a superstition of his had failed, here, which he and
+all his comrades had always looked upon as infallible. If you buried
+a marble with certain necessary incantations, and left it alone a
+fortnight, and then opened the place with the incantation he had just
+used, you would find that all the marbles you had ever lost had gathered
+themselves together there, meantime, no matter how widely they had been
+separated. But now, this thing had actually and unquestionably failed.
+Tom’s whole structure of faith was shaken to its foundations. He had
+many a time heard of this thing succeeding but never of its failing
+before. It did not occur to him that he had tried it several times
+before, himself, but could never find the hiding-places afterward. He
+puzzled over the matter some time, and finally decided that some witch
+had interfered and broken the charm. He thought he would satisfy himself
+on that point; so he searched around till he found a small sandy spot
+with a little funnel-shaped depression in it. He laid himself down and
+put his mouth close to this depression and called--
+
+“Doodle-bug, doodle-bug, tell me what I want to know! Doodle-bug,
+doodle-bug, tell me what I want to know!”
+
+The sand began to work, and presently a small black bug appeared for a
+second and then darted under again in a fright.
+
+“He dasn’t tell! So it _was_ a witch that done it. I just knowed it.”
+
+He well knew the futility of trying to contend against witches, so he
+gave up discouraged. But it occurred to him that he might as well have
+the marble he had just thrown away, and therefore he went and made a
+patient search for it. But he could not find it. Now he went back to his
+treasure-house and carefully placed himself just as he had been standing
+when he tossed the marble away; then he took another marble from his
+pocket and tossed it in the same way, saying:
+
+“Brother, go find your brother!”
+
+He watched where it stopped, and went there and looked. But it must
+have fallen short or gone too far; so he tried twice more. The last
+repetition was successful. The two marbles lay within a foot of each
+other.
+
+Just here the blast of a toy tin trumpet came faintly down the green
+aisles of the forest. Tom flung off his jacket and trousers, turned
+a suspender into a belt, raked away some brush behind the rotten log,
+disclosing a rude bow and arrow, a lath sword and a tin trumpet, and
+in a moment had seized these things and bounded away, barelegged,
+with fluttering shirt. He presently halted under a great elm, blew an
+answering blast, and then began to tiptoe and look warily out, this way
+and that. He said cautiously--to an imaginary company:
+
+“Hold, my merry men! Keep hid till I blow.”
+
+Now appeared Joe Harper, as airily clad and elaborately armed as Tom.
+Tom called:
+
+“Hold! Who comes here into Sherwood Forest without my pass?”
+
+“Guy of Guisborne wants no man’s pass. Who art thou that--that--”
+
+“Dares to hold such language,” said Tom, prompting--for they talked “by
+the book,” from memory.
+
+“Who art thou that dares to hold such language?”
+
+“I, indeed! I am Robin Hood, as thy caitiff carcase soon shall know.”
+
+“Then art thou indeed that famous outlaw? Right gladly will I dispute
+with thee the passes of the merry wood. Have at thee!”
+
+They took their lath swords, dumped their other traps on the ground,
+struck a fencing attitude, foot to foot, and began a grave, careful
+combat, “two up and two down.” Presently Tom said:
+
+“Now, if you’ve got the hang, go it lively!”
+
+So they “went it lively,” panting and perspiring with the work. By and
+by Tom shouted:
+
+“Fall! fall! Why don’t you fall?”
+
+“I sha’n’t! Why don’t you fall yourself? You’re getting the worst of
+it.”
+
+“Why, that ain’t anything. I can’t fall; that ain’t the way it is in the
+book. The book says, ‘Then with one back-handed stroke he slew poor Guy
+of Guisborne.’ You’re to turn around and let me hit you in the back.”
+
+There was no getting around the authorities, so Joe turned, received the
+whack and fell.
+
+“Now,” said Joe, getting up, “you got to let me kill _you_. That’s
+fair.”
+
+“Why, I can’t do that, it ain’t in the book.”
+
+“Well, it’s blamed mean--that’s all.”
+
+“Well, say, Joe, you can be Friar Tuck or Much the miller’s son, and lam
+me with a quarter-staff; or I’ll be the Sheriff of Nottingham and you be
+Robin Hood a little while and kill me.”
+
+This was satisfactory, and so these adventures were carried out. Then
+Tom became Robin Hood again, and was allowed by the treacherous nun to
+bleed his strength away through his neglected wound. And at last Joe,
+representing a whole tribe of weeping outlaws, dragged him sadly forth,
+gave his bow into his feeble hands, and Tom said, “Where this arrow
+falls, there bury poor Robin Hood under the greenwood tree.” Then he
+shot the arrow and fell back and would have died, but he lit on a nettle
+and sprang up too gaily for a corpse.
+
+The boys dressed themselves, hid their accoutrements, and went off
+grieving that there were no outlaws any more, and wondering what modern
+civilization could claim to have done to compensate for their loss.
+They said they would rather be outlaws a year in Sherwood Forest than
+President of the United States forever.
+
+
+
+
+CHAPTER IX
+
+AT half-past nine, that night, Tom and Sid were sent to bed, as usual.
+They said their prayers, and Sid was soon asleep. Tom lay awake and
+waited, in restless impatience. When it seemed to him that it must be
+nearly daylight, he heard the clock strike ten! This was despair. He
+would have tossed and fidgeted, as his nerves demanded, but he was
+afraid he might wake Sid. So he lay still, and stared up into the dark.
+Everything was dismally still. By and by, out of the stillness, little,
+scarcely perceptible noises began to emphasize themselves. The ticking
+of the clock began to bring itself into notice. Old beams began to crack
+mysteriously. The stairs creaked faintly. Evidently spirits were abroad.
+A measured, muffled snore issued from Aunt Polly’s chamber. And now the
+tiresome chirping of a cricket that no human ingenuity could locate,
+began. Next the ghastly ticking of a death-watch in the wall at the
+bed’s head made Tom shudder--it meant that somebody’s days were numbered.
+Then the howl of a far-off dog rose on the night air, and was answered
+by a fainter howl from a remoter distance. Tom was in an agony. At last
+he was satisfied that time had ceased and eternity begun; he began to
+doze, in spite of himself; the clock chimed eleven, but he did not hear
+it. And then there came, mingling with his half-formed dreams, a most
+melancholy caterwauling. The raising of a neighboring window disturbed
+him. A cry of “Scat! you devil!” and the crash of an empty bottle
+against the back of his aunt’s woodshed brought him wide awake, and a
+single minute later he was dressed and out of the window and creeping
+along the roof of the “ell” on all fours. He “meow’d” with caution once
+or twice, as he went; then jumped to the roof of the woodshed and thence
+to the ground. Huckleberry Finn was there, with his dead cat. The boys
+moved off and disappeared in the gloom. At the end of half an hour they
+were wading through the tall grass of the graveyard.
+
+It was a graveyard of the old-fashioned Western kind. It was on a hill,
+about a mile and a half from the village. It had a crazy board fence
+around it, which leaned inward in places, and outward the rest of the
+time, but stood upright nowhere. Grass and weeds grew rank over the
+whole cemetery. All the old graves were sunken in, there was not a
+tombstone on the place; round-topped, worm-eaten boards staggered over
+the graves, leaning for support and finding none. “Sacred to the memory
+of” So-and-So had been painted on them once, but it could no longer have
+been read, on the most of them, now, even if there had been light.
+
+A faint wind moaned through the trees, and Tom feared it might be the
+spirits of the dead, complaining at being disturbed. The boys talked
+little, and only under their breath, for the time and the place and the
+pervading solemnity and silence oppressed their spirits. They found the
+sharp new heap they were seeking, and ensconced themselves within the
+protection of three great elms that grew in a bunch within a few feet of
+the grave.
+
+Then they waited in silence for what seemed a long time. The hooting of
+a distant owl was all the sound that troubled the dead stillness. Tom’s
+reflections grew oppressive. He must force some talk. So he said in a
+whisper:
+
+“Hucky, do you believe the dead people like it for us to be here?”
+
+Huckleberry whispered:
+
+“I wisht I knowed. It’s awful solemn like, _ain’t_ it?”
+
+“I bet it is.”
+
+There was a considerable pause, while the boys canvassed this matter
+inwardly. Then Tom whispered:
+
+“Say, Hucky--do you reckon Hoss Williams hears us talking?”
+
+“O’ course he does. Least his sperrit does.”
+
+Tom, after a pause:
+
+“I wish I’d said Mister Williams. But I never meant any harm. Everybody
+calls him Hoss.”
+
+“A body can’t be too partic’lar how they talk ‘bout these-yer dead
+people, Tom.”
+
+This was a damper, and conversation died again.
+
+Presently Tom seized his comrade’s arm and said:
+
+“Sh!”
+
+“What is it, Tom?” And the two clung together with beating hearts.
+
+“Sh! There ‘tis again! Didn’t you hear it?”
+
+“I--”
+
+“There! Now you hear it.”
+
+“Lord, Tom, they’re coming! They’re coming, sure. What’ll we do?”
+
+“I dono. Think they’ll see us?”
+
+“Oh, Tom, they can see in the dark, same as cats. I wisht I hadn’t
+come.”
+
+“Oh, don’t be afeard. I don’t believe they’ll bother us. We ain’t doing
+any harm. If we keep perfectly still, maybe they won’t notice us at
+all.”
+
+“I’ll try to, Tom, but, Lord, I’m all of a shiver.”
+
+“Listen!”
+
+The boys bent their heads together and scarcely breathed. A muffled
+sound of voices floated up from the far end of the graveyard.
+
+“Look! See there!” whispered Tom. “What is it?”
+
+“It’s devil-fire. Oh, Tom, this is awful.”
+
+Some vague figures approached through the gloom, swinging an
+old-fashioned tin lantern that freckled the ground with innumerable
+little spangles of light. Presently Huckleberry whispered with a
+shudder:
+
+“It’s the devils sure enough. Three of ‘em! Lordy, Tom, we’re goners!
+Can you pray?”
+
+“I’ll try, but don’t you be afeard. They ain’t going to hurt us. ‘Now I
+lay me down to sleep, I--’”
+
+“Sh!”
+
+“What is it, Huck?”
+
+“They’re _humans_! One of ‘em is, anyway. One of ‘em’s old Muff Potter’s
+voice.”
+
+“No--‘tain’t so, is it?”
+
+“I bet I know it. Don’t you stir nor budge. He ain’t sharp enough to
+notice us. Drunk, the same as usual, likely--blamed old rip!”
+
+“All right, I’ll keep still. Now they’re stuck. Can’t find it. Here they
+come again. Now they’re hot. Cold again. Hot again. Red hot! They’re
+p’inted right, this time. Say, Huck, I know another o’ them voices; it’s
+Injun Joe.”
+
+“That’s so--that murderin’ half-breed! I’d druther they was devils a dern
+sight. What kin they be up to?”
+
+The whisper died wholly out, now, for the three men had reached the
+grave and stood within a few feet of the boys’ hiding-place.
+
+“Here it is,” said the third voice; and the owner of it held the lantern
+up and revealed the face of young Doctor Robinson.
+
+Potter and Injun Joe were carrying a handbarrow with a rope and a couple
+of shovels on it. They cast down their load and began to open the grave.
+The doctor put the lantern at the head of the grave and came and sat
+down with his back against one of the elm trees. He was so close the
+boys could have touched him.
+
+“Hurry, men!” he said, in a low voice; “the moon might come out at any
+moment.”
+
+They growled a response and went on digging. For some time there was no
+noise but the grating sound of the spades discharging their freight of
+mould and gravel. It was very monotonous. Finally a spade struck upon
+the coffin with a dull woody accent, and within another minute or two
+the men had hoisted it out on the ground. They pried off the lid with
+their shovels, got out the body and dumped it rudely on the ground. The
+moon drifted from behind the clouds and exposed the pallid face.
+The barrow was got ready and the corpse placed on it, covered with a
+blanket, and bound to its place with the rope. Potter took out a large
+spring-knife and cut off the dangling end of the rope and then said:
+
+“Now the cussed thing’s ready, Sawbones, and you’ll just out with
+another five, or here she stays.”
+
+“That’s the talk!” said Injun Joe.
+
+“Look here, what does this mean?” said the doctor. “You required your
+pay in advance, and I’ve paid you.”
+
+“Yes, and you done more than that,” said Injun Joe, approaching the
+doctor, who was now standing. “Five years ago you drove me away from
+your father’s kitchen one night, when I come to ask for something to
+eat, and you said I warn’t there for any good; and when I swore I’d get
+even with you if it took a hundred years, your father had me jailed for
+a vagrant. Did you think I’d forget? The Injun blood ain’t in me for
+nothing. And now I’ve _got_ you, and you got to _settle_, you know!”
+
+He was threatening the doctor, with his fist in his face, by this time.
+The doctor struck out suddenly and stretched the ruffian on the ground.
+Potter dropped his knife, and exclaimed:
+
+“Here, now, don’t you hit my pard!” and the next moment he had grappled
+with the doctor and the two were struggling with might and main,
+trampling the grass and tearing the ground with their heels. Injun Joe
+sprang to his feet, his eyes flaming with passion, snatched up Potter’s
+knife, and went creeping, catlike and stooping, round and round about
+the combatants, seeking an opportunity. All at once the doctor flung
+himself free, seized the heavy headboard of Williams’ grave and felled
+Potter to the earth with it--and in the same instant the half-breed saw
+his chance and drove the knife to the hilt in the young man’s breast. He
+reeled and fell partly upon Potter, flooding him with his blood, and in
+the same moment the clouds blotted out the dreadful spectacle and the
+two frightened boys went speeding away in the dark.
+
+Presently, when the moon emerged again, Injun Joe was standing over the
+two forms, contemplating them. The doctor murmured inarticulately, gave
+a long gasp or two and was still. The half-breed muttered:
+
+“_That_ score is settled--damn you.”
+
+Then he robbed the body. After which he put the fatal knife in Potter’s
+open right hand, and sat down on the dismantled coffin. Three--four--five
+minutes passed, and then Potter began to stir and moan. His hand closed
+upon the knife; he raised it, glanced at it, and let it fall, with a
+shudder. Then he sat up, pushing the body from him, and gazed at it, and
+then around him, confusedly. His eyes met Joe’s.
+
+“Lord, how is this, Joe?” he said.
+
+“It’s a dirty business,” said Joe, without moving.
+
+“What did you do it for?”
+
+“I! I never done it!”
+
+“Look here! That kind of talk won’t wash.”
+
+Potter trembled and grew white.
+
+“I thought I’d got sober. I’d no business to drink to-night. But it’s
+in my head yet--worse’n when we started here. I’m all in a muddle;
+can’t recollect anything of it, hardly. Tell me, Joe--_honest_, now,
+old feller--did I do it? Joe, I never meant to--‘pon my soul and honor, I
+never meant to, Joe. Tell me how it was, Joe. Oh, it’s awful--and him so
+young and promising.”
+
+“Why, you two was scuffling, and he fetched you one with the headboard
+and you fell flat; and then up you come, all reeling and staggering
+like, and snatched the knife and jammed it into him, just as he fetched
+you another awful clip--and here you’ve laid, as dead as a wedge til
+now.”
+
+“Oh, I didn’t know what I was a-doing. I wish I may die this minute if I
+did. It was all on account of the whiskey and the excitement, I reckon.
+I never used a weepon in my life before, Joe. I’ve fought, but never
+with weepons. They’ll all say that. Joe, don’t tell! Say you won’t tell,
+Joe--that’s a good feller. I always liked you, Joe, and stood up for you,
+too. Don’t you remember? You _won’t_ tell, _will_ you, Joe?” And the
+poor creature dropped on his knees before the stolid murderer, and
+clasped his appealing hands.
+
+“No, you’ve always been fair and square with me, Muff Potter, and I
+won’t go back on you. There, now, that’s as fair as a man can say.”
+
+“Oh, Joe, you’re an angel. I’ll bless you for this the longest day I
+live.” And Potter began to cry.
+
+“Come, now, that’s enough of that. This ain’t any time for blubbering.
+You be off yonder way and I’ll go this. Move, now, and don’t leave any
+tracks behind you.”
+
+Potter started on a trot that quickly increased to a run. The half-breed
+stood looking after him. He muttered:
+
+“If he’s as much stunned with the lick and fuddled with the rum as he
+had the look of being, he won’t think of the knife till he’s gone so
+far he’ll be afraid to come back after it to such a place by
+himself--chicken-heart!”
+
+Two or three minutes later the murdered man, the blanketed corpse, the
+lidless coffin, and the open grave were under no inspection but the
+moon’s. The stillness was complete again, too.
+
+
+
+
+CHAPTER X
+
+THE two boys flew on and on, toward the village, speechless with
+horror. They glanced backward over their shoulders from time to time,
+apprehensively, as if they feared they might be followed. Every stump
+that started up in their path seemed a man and an enemy, and made them
+catch their breath; and as they sped by some outlying cottages that lay
+near the village, the barking of the aroused watch-dogs seemed to give
+wings to their feet.
+
+“If we can only get to the old tannery before we break down!” whispered
+Tom, in short catches between breaths. “I can’t stand it much longer.”
+
+Huckleberry’s hard pantings were his only reply, and the boys fixed
+their eyes on the goal of their hopes and bent to their work to win it.
+They gained steadily on it, and at last, breast to breast, they burst
+through the open door and fell grateful and exhausted in the sheltering
+shadows beyond. By and by their pulses slowed down, and Tom whispered:
+
+“Huckleberry, what do you reckon’ll come of this?”
+
+“If Doctor Robinson dies, I reckon hanging’ll come of it.”
+
+“Do you though?”
+
+“Why, I _know_ it, Tom.”
+
+Tom thought a while, then he said:
+
+“Who’ll tell? We?”
+
+“What are you talking about? S’pose something happened and Injun Joe
+_didn’t_ hang? Why, he’d kill us some time or other, just as dead sure
+as we’re a laying here.”
+
+“That’s just what I was thinking to myself, Huck.”
+
+“If anybody tells, let Muff Potter do it, if he’s fool enough. He’s
+generally drunk enough.”
+
+Tom said nothing--went on thinking. Presently he whispered:
+
+“Huck, Muff Potter don’t know it. How can he tell?”
+
+“What’s the reason he don’t know it?”
+
+“Because he’d just got that whack when Injun Joe done it. D’you reckon
+he could see anything? D’you reckon he knowed anything?”
+
+“By hokey, that’s so, Tom!”
+
+“And besides, look-a-here--maybe that whack done for _him_!”
+
+“No, ‘taint likely, Tom. He had liquor in him; I could see that; and
+besides, he always has. Well, when pap’s full, you might take and belt
+him over the head with a church and you couldn’t phase him. He says so,
+his own self. So it’s the same with Muff Potter, of course. But if a man
+was dead sober, I reckon maybe that whack might fetch him; I dono.”
+
+After another reflective silence, Tom said:
+
+“Hucky, you sure you can keep mum?”
+
+“Tom, we _got_ to keep mum. You know that. That Injun devil wouldn’t
+make any more of drownding us than a couple of cats, if we was to squeak
+‘bout this and they didn’t hang him. Now, look-a-here, Tom, less take
+and swear to one another--that’s what we got to do--swear to keep mum.”
+
+“I’m agreed. It’s the best thing. Would you just hold hands and swear
+that we--”
+
+“Oh no, that wouldn’t do for this. That’s good enough for little
+rubbishy common things--specially with gals, cuz _they_ go back on you
+anyway, and blab if they get in a huff--but there orter be writing ‘bout
+a big thing like this. And blood.”
+
+Tom’s whole being applauded this idea. It was deep, and dark, and awful;
+the hour, the circumstances, the surroundings, were in keeping with it.
+He picked up a clean pine shingle that lay in the moon-light, took a
+little fragment of “red keel” out of his pocket, got the moon on
+his work, and painfully scrawled these lines, emphasizing each slow
+down-stroke by clamping his tongue between his teeth, and letting up the
+pressure on the up-strokes. [See next page.]
+
+“Huck Finn and Tom Sawyer swears they will keep mum about This and They
+wish They may Drop down dead in Their Tracks if They ever Tell and Rot.”
+
+Huckleberry was filled with admiration of Tom’s facility in writing, and
+the sublimity of his language. He at once took a pin from his lapel and
+was going to prick his flesh, but Tom said:
+
+“Hold on! Don’t do that. A pin’s brass. It might have verdigrease on
+it.”
+
+“What’s verdigrease?”
+
+“It’s p’ison. That’s what it is. You just swaller some of it once--you’ll
+see.”
+
+So Tom unwound the thread from one of his needles, and each boy pricked
+the ball of his thumb and squeezed out a drop of blood. In time, after
+many squeezes, Tom managed to sign his initials, using the ball of his
+little finger for a pen. Then he showed Huckleberry how to make an H and
+an F, and the oath was complete. They buried the shingle close to the
+wall, with some dismal ceremonies and incantations, and the fetters
+that bound their tongues were considered to be locked and the key thrown
+away.
+
+A figure crept stealthily through a break in the other end of the ruined
+building, now, but they did not notice it.
+
+“Tom,” whispered Huckleberry, “does this keep us from _ever_
+telling--_always_?”
+
+“Of course it does. It don’t make any difference _what_ happens, we got
+to keep mum. We’d drop down dead--don’t _you_ know that?”
+
+“Yes, I reckon that’s so.”
+
+They continued to whisper for some little time. Presently a dog set up
+a long, lugubrious howl just outside--within ten feet of them. The boys
+clasped each other suddenly, in an agony of fright.
+
+“Which of us does he mean?” gasped Huckleberry.
+
+“I dono--peep through the crack. Quick!”
+
+“No, _you_, Tom!”
+
+“I can’t--I can’t _do_ it, Huck!”
+
+“Please, Tom. There ‘tis again!”
+
+“Oh, lordy, I’m thankful!” whispered Tom. “I know his voice. It’s Bull
+Harbison.” *
+
+[* If Mr. Harbison owned a slave named Bull, Tom would have spoken of
+him as “Harbison’s Bull,” but a son or a dog of that name was “Bull
+Harbison.”]
+
+“Oh, that’s good--I tell you, Tom, I was most scared to death; I’d a bet
+anything it was a _stray_ dog.”
+
+The dog howled again. The boys’ hearts sank once more.
+
+“Oh, my! that ain’t no Bull Harbison!” whispered Huckleberry. “_Do_,
+Tom!”
+
+Tom, quaking with fear, yielded, and put his eye to the crack. His
+whisper was hardly audible when he said:
+
+“Oh, Huck, _its a stray dog_!”
+
+“Quick, Tom, quick! Who does he mean?”
+
+“Huck, he must mean us both--we’re right together.”
+
+“Oh, Tom, I reckon we’re goners. I reckon there ain’t no mistake ‘bout
+where _I’ll_ go to. I been so wicked.”
+
+“Dad fetch it! This comes of playing hookey and doing everything a
+feller’s told _not_ to do. I might a been good, like Sid, if I’d a
+tried--but no, I wouldn’t, of course. But if ever I get off this time,
+I lay I’ll just _waller_ in Sunday-schools!” And Tom began to snuffle a
+little.
+
+“_You_ bad!” and Huckleberry began to snuffle too. “Consound it, Tom
+Sawyer, you’re just old pie, ‘long-side o’ what I am. Oh, _lordy_,
+lordy, lordy, I wisht I only had half your chance.”
+
+Tom choked off and whispered:
+
+“Look, Hucky, look! He’s got his _back_ to us!”
+
+Hucky looked, with joy in his heart.
+
+“Well, he has, by jingoes! Did he before?”
+
+“Yes, he did. But I, like a fool, never thought. Oh, this is bully, you
+know. _Now_ who can he mean?”
+
+The howling stopped. Tom pricked up his ears.
+
+“Sh! What’s that?” he whispered.
+
+“Sounds like--like hogs grunting. No--it’s somebody snoring, Tom.”
+
+“That _is_ it! Where ‘bouts is it, Huck?”
+
+“I bleeve it’s down at ‘tother end. Sounds so, anyway. Pap used to sleep
+there, sometimes, ‘long with the hogs, but laws bless you, he just lifts
+things when _he_ snores. Besides, I reckon he ain’t ever coming back to
+this town any more.”
+
+The spirit of adventure rose in the boys’ souls once more.
+
+“Hucky, do you das’t to go if I lead?”
+
+“I don’t like to, much. Tom, s’pose it’s Injun Joe!”
+
+Tom quailed. But presently the temptation rose up strong again and the
+boys agreed to try, with the understanding that they would take to their
+heels if the snoring stopped. So they went tiptoeing stealthily down,
+the one behind the other. When they had got to within five steps of the
+snorer, Tom stepped on a stick, and it broke with a sharp snap. The man
+moaned, writhed a little, and his face came into the moonlight. It was
+Muff Potter. The boys’ hearts had stood still, and their hopes too,
+when the man moved, but their fears passed away now. They tip-toed out,
+through the broken weather-boarding, and stopped at a little distance
+to exchange a parting word. That long, lugubrious howl rose on the night
+air again! They turned and saw the strange dog standing within a few
+feet of where Potter was lying, and _facing_ Potter, with his nose
+pointing heavenward.
+
+“Oh, geeminy, it’s _him_!” exclaimed both boys, in a breath.
+
+“Say, Tom--they say a stray dog come howling around Johnny Miller’s
+house, ‘bout midnight, as much as two weeks ago; and a whippoorwill come
+in and lit on the banisters and sung, the very same evening; and there
+ain’t anybody dead there yet.”
+
+“Well, I know that. And suppose there ain’t. Didn’t Gracie Miller fall
+in the kitchen fire and burn herself terrible the very next Saturday?”
+
+“Yes, but she ain’t _dead_. And what’s more, she’s getting better, too.”
+
+“All right, you wait and see. She’s a goner, just as dead sure as Muff
+Potter’s a goner. That’s what the niggers say, and they know all about
+these kind of things, Huck.”
+
+Then they separated, cogitating. When Tom crept in at his bedroom window
+the night was almost spent. He undressed with excessive caution, and
+fell asleep congratulating himself that nobody knew of his escapade. He
+was not aware that the gently-snoring Sid was awake, and had been so for
+an hour.
+
+When Tom awoke, Sid was dressed and gone. There was a late look in the
+light, a late sense in the atmosphere. He was startled. Why had he not
+been called--persecuted till he was up, as usual? The thought filled
+him with bodings. Within five minutes he was dressed and down-stairs,
+feeling sore and drowsy. The family were still at table, but they had
+finished breakfast. There was no voice of rebuke; but there were averted
+eyes; there was a silence and an air of solemnity that struck a chill
+to the culprit’s heart. He sat down and tried to seem gay, but it
+was up-hill work; it roused no smile, no response, and he lapsed into
+silence and let his heart sink down to the depths.
+
+After breakfast his aunt took him aside, and Tom almost brightened in
+the hope that he was going to be flogged; but it was not so. His aunt
+wept over him and asked him how he could go and break her old heart so;
+and finally told him to go on, and ruin himself and bring her gray hairs
+with sorrow to the grave, for it was no use for her to try any more.
+This was worse than a thousand whippings, and Tom’s heart was sorer now
+than his body. He cried, he pleaded for forgiveness, promised to reform
+over and over again, and then received his dismissal, feeling that
+he had won but an imperfect forgiveness and established but a feeble
+confidence.
+
+He left the presence too miserable to even feel revengeful toward
+Sid; and so the latter’s prompt retreat through the back gate was
+unnecessary. He moped to school gloomy and sad, and took his flogging,
+along with Joe Harper, for playing hookey the day before, with the
+air of one whose heart was busy with heavier woes and wholly dead to
+trifles. Then he betook himself to his seat, rested his elbows on his
+desk and his jaws in his hands, and stared at the wall with the stony
+stare of suffering that has reached the limit and can no further go.
+His elbow was pressing against some hard substance. After a long time
+he slowly and sadly changed his position, and took up this object with
+a sigh. It was in a paper. He unrolled it. A long, lingering, colossal
+sigh followed, and his heart broke. It was his brass andiron knob!
+
+This final feather broke the camel’s back.
+
+
+
+
+CHAPTER XI
+
+CLOSE upon the hour of noon the whole village was suddenly electrified
+with the ghastly news. No need of the as yet un-dreamed-of telegraph;
+the tale flew from man to man, from group to group, from house to house,
+with little less than telegraphic speed. Of course the schoolmaster gave
+holi-day for that afternoon; the town would have thought strangely of
+him if he had not.
+
+A gory knife had been found close to the murdered man, and it had been
+recognized by somebody as belonging to Muff Potter--so the story ran. And
+it was said that a belated citizen had come upon Potter washing himself
+in the “branch” about one or two o’clock in the morning, and that Potter
+had at once sneaked off--suspicious circumstances, especially the washing
+which was not a habit with Potter. It was also said that the town had
+been ransacked for this “murderer” (the public are not slow in the
+matter of sifting evidence and arriving at a verdict), but that he
+could not be found. Horsemen had departed down all the roads in every
+direction, and the Sheriff “was confident” that he would be captured
+before night.
+
+All the town was drifting toward the graveyard. Tom’s heartbreak
+vanished and he joined the procession, not because he would not
+a thousand times rather go anywhere else, but because an awful,
+unaccountable fascination drew him on. Arrived at the dreadful place, he
+wormed his small body through the crowd and saw the dismal spectacle.
+It seemed to him an age since he was there before. Somebody pinched
+his arm. He turned, and his eyes met Huckleberry’s. Then both looked
+elsewhere at once, and wondered if anybody had noticed anything in their
+mutual glance. But everybody was talking, and intent upon the grisly
+spectacle before them.
+
+“Poor fellow!” “Poor young fellow!” “This ought to be a lesson to grave
+robbers!” “Muff Potter’ll hang for this if they catch him!” This was the
+drift of remark; and the minister said, “It was a judgment; His hand is
+here.”
+
+Now Tom shivered from head to heel; for his eye fell upon the stolid
+face of Injun Joe. At this moment the crowd began to sway and struggle,
+and voices shouted, “It’s him! it’s him! he’s coming himself!”
+
+“Who? Who?” from twenty voices.
+
+“Muff Potter!”
+
+“Hallo, he’s stopped!--Look out, he’s turning! Don’t let him get away!”
+
+People in the branches of the trees over Tom’s head said he wasn’t
+trying to get away--he only looked doubtful and perplexed.
+
+“Infernal impudence!” said a bystander; “wanted to come and take a quiet
+look at his work, I reckon--didn’t expect any company.”
+
+The crowd fell apart, now, and the Sheriff came through, ostentatiously
+leading Potter by the arm. The poor fellow’s face was haggard, and
+his eyes showed the fear that was upon him. When he stood before the
+murdered man, he shook as with a palsy, and he put his face in his hands
+and burst into tears.
+
+“I didn’t do it, friends,” he sobbed; “‘pon my word and honor I never
+done it.”
+
+“Who’s accused you?” shouted a voice.
+
+This shot seemed to carry home. Potter lifted his face and looked around
+him with a pathetic hopelessness in his eyes. He saw Injun Joe, and
+exclaimed:
+
+“Oh, Injun Joe, you promised me you’d never--”
+
+“Is that your knife?” and it was thrust before him by the Sheriff.
+
+Potter would have fallen if they had not caught him and eased him to the
+ground. Then he said:
+
+“Something told me ‘t if I didn’t come back and get--” He shuddered; then
+waved his nerveless hand with a vanquished gesture and said, “Tell ‘em,
+Joe, tell ‘em--it ain’t any use any more.”
+
+Then Huckleberry and Tom stood dumb and staring, and heard the
+stony-hearted liar reel off his serene statement, they expecting every
+moment that the clear sky would deliver God’s lightnings upon his head,
+and wondering to see how long the stroke was delayed. And when he had
+finished and still stood alive and whole, their wavering impulse to
+break their oath and save the poor betrayed prisoner’s life faded and
+vanished away, for plainly this miscreant had sold himself to Satan and
+it would be fatal to meddle with the property of such a power as that.
+
+“Why didn’t you leave? What did you want to come here for?” somebody
+said.
+
+“I couldn’t help it--I couldn’t help it,” Potter moaned. “I wanted to
+run away, but I couldn’t seem to come anywhere but here.” And he fell to
+sobbing again.
+
+Injun Joe repeated his statement, just as calmly, a few minutes
+afterward on the inquest, under oath; and the boys, seeing that the
+lightnings were still withheld, were confirmed in their belief that
+Joe had sold himself to the devil. He was now become, to them, the most
+balefully interesting object they had ever looked upon, and they could
+not take their fascinated eyes from his face.
+
+They inwardly resolved to watch him nights, when opportunity should
+offer, in the hope of getting a glimpse of his dread master.
+
+Injun Joe helped to raise the body of the murdered man and put it in
+a wagon for removal; and it was whispered through the shuddering
+crowd that the wound bled a little! The boys thought that this happy
+circumstance would turn suspicion in the right direction; but they were
+disappointed, for more than one villager remarked:
+
+“It was within three feet of Muff Potter when it done it.”
+
+Tom’s fearful secret and gnawing conscience disturbed his sleep for as
+much as a week after this; and at breakfast one morning Sid said:
+
+“Tom, you pitch around and talk in your sleep so much that you keep me
+awake half the time.”
+
+Tom blanched and dropped his eyes.
+
+“It’s a bad sign,” said Aunt Polly, gravely. “What you got on your mind,
+Tom?”
+
+“Nothing. Nothing ‘t I know of.” But the boy’s hand shook so that he
+spilled his coffee.
+
+“And you do talk such stuff,” Sid said. “Last night you said, ‘It’s
+blood, it’s blood, that’s what it is!’ You said that over and over.
+And you said, ‘Don’t torment me so--I’ll tell!’ Tell _what_? What is it
+you’ll tell?”
+
+Everything was swimming before Tom. There is no telling what might have
+happened, now, but luckily the concern passed out of Aunt Polly’s face
+and she came to Tom’s relief without knowing it. She said:
+
+“Sho! It’s that dreadful murder. I dream about it most every night
+myself. Sometimes I dream it’s me that done it.”
+
+Mary said she had been affected much the same way. Sid seemed satisfied.
+Tom got out of the presence as quick as he plausibly could, and after
+that he complained of toothache for a week, and tied up his jaws every
+night. He never knew that Sid lay nightly watching, and frequently
+slipped the bandage free and then leaned on his elbow listening a good
+while at a time, and afterward slipped the bandage back to its place
+again. Tom’s distress of mind wore off gradually and the toothache grew
+irksome and was discarded. If Sid really managed to make anything out of
+Tom’s disjointed mutterings, he kept it to himself.
+
+It seemed to Tom that his schoolmates never would get done holding
+inquests on dead cats, and thus keeping his trouble present to his mind.
+Sid noticed that Tom never was coroner at one of these inquiries,
+though it had been his habit to take the lead in all new enterprises;
+he noticed, too, that Tom never acted as a witness--and that was strange;
+and Sid did not overlook the fact that Tom even showed a marked aversion
+to these inquests, and always avoided them when he could. Sid marvelled,
+but said nothing. However, even inquests went out of vogue at last, and
+ceased to torture Tom’s conscience.
+
+Every day or two, during this time of sorrow, Tom watched his
+opportunity and went to the little grated jail-window and smuggled such
+small comforts through to the “murderer” as he could get hold of. The
+jail was a trifling little brick den that stood in a marsh at the edge
+of the village, and no guards were afforded for it; indeed, it
+was seldom occupied. These offerings greatly helped to ease Tom’s
+conscience.
+
+The villagers had a strong desire to tar-and-feather Injun Joe and ride
+him on a rail, for body-snatching, but so formidable was his character
+that nobody could be found who was willing to take the lead in the
+matter, so it was dropped. He had been careful to begin both of his
+inquest-statements with the fight, without confessing the grave-robbery
+that preceded it; therefore it was deemed wisest not to try the case in
+the courts at present.
+
+
+
+
+CHAPTER XII
+
+ONE of the reasons why Tom’s mind had drifted away from its secret
+troubles was, that it had found a new and weighty matter to interest
+itself about. Becky Thatcher had stopped coming to school. Tom had
+struggled with his pride a few days, and tried to “whistle her down the
+wind,” but failed. He began to find himself hanging around her father’s
+house, nights, and feeling very miserable. She was ill. What if she
+should die! There was distraction in the thought. He no longer took an
+interest in war, nor even in piracy. The charm of life was gone; there
+was nothing but dreariness left. He put his hoop away, and his bat;
+there was no joy in them any more. His aunt was concerned. She began to
+try all manner of remedies on him. She was one of those people who
+are infatuated with patent medicines and all new-fangled methods of
+producing health or mending it. She was an inveterate experimenter in
+these things. When something fresh in this line came out she was in a
+fever, right away, to try it; not on herself, for she was never ailing,
+but on anybody else that came handy. She was a subscriber for all the
+“Health” periodicals and phrenological frauds; and the solemn ignorance
+they were inflated with was breath to her nostrils. All the “rot” they
+contained about ventilation, and how to go to bed, and how to get up,
+and what to eat, and what to drink, and how much exercise to take, and
+what frame of mind to keep one’s self in, and what sort of clothing
+to wear, was all gospel to her, and she never observed that her
+health-journals of the current month customarily upset everything they
+had recommended the month before. She was as simple-hearted and honest
+as the day was long, and so she was an easy victim. She gathered
+together her quack periodicals and her quack medicines, and thus armed
+with death, went about on her pale horse, metaphorically speaking, with
+“hell following after.” But she never suspected that she was not an
+angel of healing and the balm of Gilead in disguise, to the suffering
+neighbors.
+
+The water treatment was new, now, and Tom’s low condition was a windfall
+to her. She had him out at daylight every morning, stood him up in the
+wood-shed and drowned him with a deluge of cold water; then she scrubbed
+him down with a towel like a file, and so brought him to; then she
+rolled him up in a wet sheet and put him away under blankets till she
+sweated his soul clean and “the yellow stains of it came through his
+pores”--as Tom said.
+
+Yet notwithstanding all this, the boy grew more and more melancholy and
+pale and dejected. She added hot baths, sitz baths, shower baths, and
+plunges. The boy remained as dismal as a hearse. She began to assist the
+water with a slim oatmeal diet and blister-plasters. She calculated his
+capacity as she would a jug’s, and filled him up every day with quack
+cure-alls.
+
+Tom had become indifferent to persecution by this time. This phase
+filled the old lady’s heart with consternation. This indifference must
+be broken up at any cost. Now she heard of Pain-killer for the first
+time. She ordered a lot at once. She tasted it and was filled with
+gratitude. It was simply fire in a liquid form. She dropped the water
+treatment and everything else, and pinned her faith to Pain-killer.
+She gave Tom a teaspoonful and watched with the deepest anxiety for the
+result. Her troubles were instantly at rest, her soul at peace again;
+for the “indifference” was broken up. The boy could not have shown a
+wilder, heartier interest, if she had built a fire under him.
+
+Tom felt that it was time to wake up; this sort of life might be
+romantic enough, in his blighted condition, but it was getting to have
+too little sentiment and too much distracting variety about it. So he
+thought over various plans for relief, and finally hit upon that of
+professing to be fond of Pain-killer. He asked for it so often that he
+became a nuisance, and his aunt ended by telling him to help himself and
+quit bothering her. If it had been Sid, she would have had no misgivings
+to alloy her delight; but since it was Tom, she watched the bottle
+clandestinely. She found that the medicine did really diminish, but it
+did not occur to her that the boy was mending the health of a crack in
+the sitting-room floor with it.
+
+One day Tom was in the act of dosing the crack when his aunt’s yellow
+cat came along, purring, eyeing the teaspoon avariciously, and begging
+for a taste. Tom said:
+
+“Don’t ask for it unless you want it, Peter.”
+
+But Peter signified that he did want it.
+
+“You better make sure.”
+
+Peter was sure.
+
+“Now you’ve asked for it, and I’ll give it to you, because there ain’t
+anything mean about me; but if you find you don’t like it, you mustn’t
+blame anybody but your own self.”
+
+Peter was agreeable. So Tom pried his mouth open and poured down
+the Pain-killer. Peter sprang a couple of yards in the air, and then
+delivered a war-whoop and set off round and round the room, banging
+against furniture, upsetting flower-pots, and making general havoc. Next
+he rose on his hind feet and pranced around, in a frenzy of enjoyment,
+with his head over his shoulder and his voice proclaiming his
+unappeasable happiness. Then he went tearing around the house again
+spreading chaos and destruction in his path. Aunt Polly entered in time
+to see him throw a few double summersets, deliver a final mighty hurrah,
+and sail through the open window, carrying the rest of the flower-pots
+with him. The old lady stood petrified with astonishment, peering over
+her glasses; Tom lay on the floor expiring with laughter.
+
+“Tom, what on earth ails that cat?”
+
+“I don’t know, aunt,” gasped the boy.
+
+“Why, I never see anything like it. What did make him act so?”
+
+“Deed I don’t know, Aunt Polly; cats always act so when they’re having a
+good time.”
+
+“They do, do they?” There was something in the tone that made Tom
+apprehensive.
+
+“Yes’m. That is, I believe they do.”
+
+“You _do_?”
+
+“Yes’m.”
+
+The old lady was bending down, Tom watching, with interest emphasized
+by anxiety. Too late he divined her “drift.” The handle of the telltale
+tea-spoon was visible under the bed-valance. Aunt Polly took it, held it
+up. Tom winced, and dropped his eyes. Aunt Polly raised him by the usual
+handle--his ear--and cracked his head soundly with her thimble.
+
+“Now, sir, what did you want to treat that poor dumb beast so, for?”
+
+“I done it out of pity for him--because he hadn’t any aunt.”
+
+“Hadn’t any aunt!--you numskull. What has that got to do with it?”
+
+“Heaps. Because if he’d had one she’d a burnt him out herself! She’d a
+roasted his bowels out of him ‘thout any more feeling than if he was a
+human!”
+
+Aunt Polly felt a sudden pang of remorse. This was putting the thing in
+a new light; what was cruelty to a cat _might_ be cruelty to a boy, too.
+She began to soften; she felt sorry. Her eyes watered a little, and she
+put her hand on Tom’s head and said gently:
+
+“I was meaning for the best, Tom. And, Tom, it _did_ do you good.”
+
+Tom looked up in her face with just a perceptible twinkle peeping
+through his gravity.
+
+“I know you was meaning for the best, aunty, and so was I with Peter. It
+done _him_ good, too. I never see him get around so since--”
+
+“Oh, go ‘long with you, Tom, before you aggravate me again. And you try
+and see if you can’t be a good boy, for once, and you needn’t take any
+more medicine.”
+
+Tom reached school ahead of time. It was noticed that this strange thing
+had been occurring every day latterly. And now, as usual of late,
+he hung about the gate of the schoolyard instead of playing with his
+comrades. He was sick, he said, and he looked it. He tried to seem to
+be looking everywhere but whither he really was looking--down the road.
+Presently Jeff Thatcher hove in sight, and Tom’s face lighted; he gazed
+a moment, and then turned sorrowfully away. When Jeff arrived, Tom
+accosted him; and “led up” warily to opportunities for remark about
+Becky, but the giddy lad never could see the bait. Tom watched and
+watched, hoping whenever a frisking frock came in sight, and hating the
+owner of it as soon as he saw she was not the right one. At last frocks
+ceased to appear, and he dropped hopelessly into the dumps; he entered
+the empty schoolhouse and sat down to suffer. Then one more frock passed
+in at the gate, and Tom’s heart gave a great bound. The next instant he
+was out, and “going on” like an Indian; yelling, laughing, chasing boys,
+jumping over the fence at risk of life and limb, throwing handsprings,
+standing on his head--doing all the heroic things he could conceive of,
+and keeping a furtive eye out, all the while, to see if Becky Thatcher
+was noticing. But she seemed to be unconscious of it all; she never
+looked. Could it be possible that she was not aware that he was there?
+He carried his exploits to her immediate vicinity; came war-whooping
+around, snatched a boy’s cap, hurled it to the roof of the schoolhouse,
+broke through a group of boys, tumbling them in every direction, and
+fell sprawling, himself, under Becky’s nose, almost upsetting her--and
+she turned, with her nose in the air, and he heard her say: “Mf! some
+people think they’re mighty smart--always showing off!”
+
+Tom’s cheeks burned. He gathered himself up and sneaked off, crushed and
+crestfallen.
+
+
+
+
+CHAPTER XIII
+
+TOM’S mind was made up now. He was gloomy and desperate. He was a
+forsaken, friendless boy, he said; nobody loved him; when they found out
+what they had driven him to, perhaps they would be sorry; he had tried
+to do right and get along, but they would not let him; since nothing
+would do them but to be rid of him, let it be so; and let them blame
+_him_ for the consequences--why shouldn’t they? What right had the
+friendless to complain? Yes, they had forced him to it at last: he would
+lead a life of crime. There was no choice.
+
+By this time he was far down Meadow Lane, and the bell for school to
+“take up” tinkled faintly upon his ear. He sobbed, now, to think he
+should never, never hear that old familiar sound any more--it was very
+hard, but it was forced on him; since he was driven out into the cold
+world, he must submit--but he forgave them. Then the sobs came thick and
+fast.
+
+Just at this point he met his soul’s sworn comrade, Joe
+Harper--hard-eyed, and with evidently a great and dismal purpose in his
+heart. Plainly here were “two souls with but a single thought.” Tom,
+wiping his eyes with his sleeve, began to blubber out something about
+a resolution to escape from hard usage and lack of sympathy at home by
+roaming abroad into the great world never to return; and ended by hoping
+that Joe would not forget him.
+
+But it transpired that this was a request which Joe had just been going
+to make of Tom, and had come to hunt him up for that purpose. His mother
+had whipped him for drinking some cream which he had never tasted and
+knew nothing about; it was plain that she was tired of him and wished
+him to go; if she felt that way, there was nothing for him to do but
+succumb; he hoped she would be happy, and never regret having driven her
+poor boy out into the unfeeling world to suffer and die.
+
+As the two boys walked sorrowing along, they made a new compact to stand
+by each other and be brothers and never separate till death relieved
+them of their troubles. Then they began to lay their plans. Joe was for
+being a hermit, and living on crusts in a remote cave, and dying,
+some time, of cold and want and grief; but after listening to Tom, he
+conceded that there were some conspicuous advantages about a life of
+crime, and so he consented to be a pirate.
+
+Three miles below St. Petersburg, at a point where the Mississippi River
+was a trifle over a mile wide, there was a long, narrow, wooded island,
+with a shallow bar at the head of it, and this offered well as a
+rendezvous. It was not inhabited; it lay far over toward the further
+shore, abreast a dense and almost wholly unpeopled forest. So Jackson’s
+Island was chosen. Who were to be the subjects of their piracies was a
+matter that did not occur to them. Then they hunted up Huckleberry Finn,
+and he joined them promptly, for all careers were one to him; he was
+indifferent. They presently separated to meet at a lonely spot on the
+river-bank two miles above the village at the favorite hour--which was
+midnight. There was a small log raft there which they meant to capture.
+Each would bring hooks and lines, and such provision as he could steal
+in the most dark and mysterious way--as became outlaws. And before the
+afternoon was done, they had all managed to enjoy the sweet glory of
+spreading the fact that pretty soon the town would “hear something.” All
+who got this vague hint were cautioned to “be mum and wait.”
+
+About midnight Tom arrived with a boiled ham and a few trifles,
+and stopped in a dense undergrowth on a small bluff overlooking the
+meeting-place. It was starlight, and very still. The mighty river lay
+like an ocean at rest. Tom listened a moment, but no sound disturbed the
+quiet. Then he gave a low, distinct whistle. It was answered from under
+the bluff. Tom whistled twice more; these signals were answered in the
+same way. Then a guarded voice said:
+
+“Who goes there?”
+
+“Tom Sawyer, the Black Avenger of the Spanish Main. Name your names.”
+
+“Huck Finn the Red-Handed, and Joe Harper the Terror of the Seas.” Tom
+had furnished these titles, from his favorite literature.
+
+“‘Tis well. Give the countersign.”
+
+Two hoarse whispers delivered the same awful word simultaneously to the
+brooding night:
+
+“_Blood_!”
+
+Then Tom tumbled his ham over the bluff and let himself down after it,
+tearing both skin and clothes to some extent in the effort. There was
+an easy, comfortable path along the shore under the bluff, but it lacked
+the advantages of difficulty and danger so valued by a pirate.
+
+The Terror of the Seas had brought a side of bacon, and had about worn
+himself out with getting it there. Finn the Red-Handed had stolen a
+skillet and a quantity of half-cured leaf tobacco, and had also brought
+a few corn-cobs to make pipes with. But none of the pirates smoked or
+“chewed” but himself. The Black Avenger of the Spanish Main said it
+would never do to start without some fire. That was a wise thought;
+matches were hardly known there in that day. They saw a fire smouldering
+upon a great raft a hundred yards above, and they went stealthily
+thither and helped themselves to a chunk. They made an imposing
+adventure of it, saying, “Hist!” every now and then, and suddenly
+halting with finger on lip; moving with hands on imaginary dagger-hilts;
+and giving orders in dismal whispers that if “the foe” stirred, to “let
+him have it to the hilt,” because “dead men tell no tales.” They knew
+well enough that the raftsmen were all down at the village laying
+in stores or having a spree, but still that was no excuse for their
+conducting this thing in an unpiratical way.
+
+They shoved off, presently, Tom in command, Huck at the after oar and
+Joe at the forward. Tom stood amidships, gloomy-browed, and with folded
+arms, and gave his orders in a low, stern whisper:
+
+“Luff, and bring her to the wind!”
+
+“Aye-aye, sir!”
+
+“Steady, steady-y-y-y!”
+
+“Steady it is, sir!”
+
+“Let her go off a point!”
+
+“Point it is, sir!”
+
+As the boys steadily and monotonously drove the raft toward mid-stream
+it was no doubt understood that these orders were given only for
+“style,” and were not intended to mean anything in particular.
+
+“What sail’s she carrying?”
+
+“Courses, tops’ls, and flying-jib, sir.”
+
+“Send the r’yals up! Lay out aloft, there, half a dozen of
+ye--foretopmaststuns’l! Lively, now!”
+
+“Aye-aye, sir!”
+
+“Shake out that maintogalans’l! Sheets and braces! _now_ my hearties!”
+
+“Aye-aye, sir!”
+
+“Hellum-a-lee--hard a port! Stand by to meet her when she comes! Port,
+port! _Now_, men! With a will! Stead-y-y-y!”
+
+“Steady it is, sir!”
+
+The raft drew beyond the middle of the river; the boys pointed her head
+right, and then lay on their oars. The river was not high, so there was
+not more than a two or three mile current. Hardly a word was said during
+the next three-quarters of an hour. Now the raft was passing before
+the distant town. Two or three glimmering lights showed where it lay,
+peacefully sleeping, beyond the vague vast sweep of star-gemmed water,
+unconscious of the tremendous event that was happening. The Black
+Avenger stood still with folded arms, “looking his last” upon the scene
+of his former joys and his later sufferings, and wishing “she” could see
+him now, abroad on the wild sea, facing peril and death with dauntless
+heart, going to his doom with a grim smile on his lips. It was but
+a small strain on his imagination to remove Jackson’s Island beyond
+eye-shot of the village, and so he “looked his last” with a broken and
+satisfied heart. The other pirates were looking their last, too; and
+they all looked so long that they came near letting the current drift
+them out of the range of the island. But they discovered the danger in
+time, and made shift to avert it. About two o’clock in the morning the
+raft grounded on the bar two hundred yards above the head of the island,
+and they waded back and forth until they had landed their freight. Part
+of the little raft’s belongings consisted of an old sail, and this they
+spread over a nook in the bushes for a tent to shelter their provisions;
+but they themselves would sleep in the open air in good weather, as
+became outlaws.
+
+They built a fire against the side of a great log twenty or thirty steps
+within the sombre depths of the forest, and then cooked some bacon in
+the frying-pan for supper, and used up half of the corn “pone” stock
+they had brought. It seemed glorious sport to be feasting in that wild,
+free way in the virgin forest of an unexplored and uninhabited island,
+far from the haunts of men, and they said they never would return to
+civilization. The climbing fire lit up their faces and threw its ruddy
+glare upon the pillared tree-trunks of their forest temple, and upon the
+varnished foliage and festooning vines.
+
+When the last crisp slice of bacon was gone, and the last allowance
+of corn pone devoured, the boys stretched themselves out on the grass,
+filled with contentment. They could have found a cooler place, but
+they would not deny themselves such a romantic feature as the roasting
+campfire.
+
+“_Ain’t_ it gay?” said Joe.
+
+“It’s _nuts_!” said Tom. “What would the boys say if they could see us?”
+
+“Say? Well, they’d just die to be here--hey, Hucky!”
+
+“I reckon so,” said Huckleberry; “anyways, I’m suited. I don’t want
+nothing better’n this. I don’t ever get enough to eat, gen’ally--and here
+they can’t come and pick at a feller and bullyrag him so.”
+
+“It’s just the life for me,” said Tom. “You don’t have to get up,
+mornings, and you don’t have to go to school, and wash, and all that
+blame foolishness. You see a pirate don’t have to do _anything_, Joe,
+when he’s ashore, but a hermit _he_ has to be praying considerable, and
+then he don’t have any fun, anyway, all by himself that way.”
+
+“Oh yes, that’s so,” said Joe, “but I hadn’t thought much about it, you
+know. I’d a good deal rather be a pirate, now that I’ve tried it.”
+
+“You see,” said Tom, “people don’t go much on hermits, nowadays, like
+they used to in old times, but a pirate’s always respected. And
+a hermit’s got to sleep on the hardest place he can find, and put
+sackcloth and ashes on his head, and stand out in the rain, and--”
+
+“What does he put sackcloth and ashes on his head for?” inquired Huck.
+
+“I dono. But they’ve _got_ to do it. Hermits always do. You’d have to do
+that if you was a hermit.”
+
+“Dern’d if I would,” said Huck.
+
+“Well, what would you do?”
+
+“I dono. But I wouldn’t do that.”
+
+“Why, Huck, you’d _have_ to. How’d you get around it?”
+
+“Why, I just wouldn’t stand it. I’d run away.”
+
+“Run away! Well, you _would_ be a nice old slouch of a hermit. You’d be
+a disgrace.”
+
+The Red-Handed made no response, being better employed. He had finished
+gouging out a cob, and now he fitted a weed stem to it, loaded it with
+tobacco, and was pressing a coal to the charge and blowing a cloud of
+fragrant smoke--he was in the full bloom of luxurious contentment. The
+other pirates envied him this majestic vice, and secretly resolved to
+acquire it shortly. Presently Huck said:
+
+“What does pirates have to do?”
+
+Tom said:
+
+“Oh, they have just a bully time--take ships and burn them, and get the
+money and bury it in awful places in their island where there’s ghosts
+and things to watch it, and kill everybody in the ships--make ‘em walk a
+plank.”
+
+“And they carry the women to the island,” said Joe; “they don’t kill the
+women.”
+
+“No,” assented Tom, “they don’t kill the women--they’re too noble. And
+the women’s always beautiful, too.
+
+“And don’t they wear the bulliest clothes! Oh no! All gold and silver
+and di’monds,” said Joe, with enthusiasm.
+
+“Who?” said Huck.
+
+“Why, the pirates.”
+
+Huck scanned his own clothing forlornly.
+
+“I reckon I ain’t dressed fitten for a pirate,” said he, with a
+regretful pathos in his voice; “but I ain’t got none but these.”
+
+But the other boys told him the fine clothes would come fast enough,
+after they should have begun their adventures. They made him understand
+that his poor rags would do to begin with, though it was customary for
+wealthy pirates to start with a proper wardrobe.
+
+Gradually their talk died out and drowsiness began to steal upon the
+eyelids of the little waifs. The pipe dropped from the fingers of the
+Red-Handed, and he slept the sleep of the conscience-free and the weary.
+The Terror of the Seas and the Black Avenger of the Spanish Main had
+more difficulty in getting to sleep. They said their prayers inwardly,
+and lying down, since there was nobody there with authority to make them
+kneel and recite aloud; in truth, they had a mind not to say them at
+all, but they were afraid to proceed to such lengths as that, lest they
+might call down a sudden and special thunderbolt from heaven. Then at
+once they reached and hovered upon the imminent verge of sleep--but an
+intruder came, now, that would not “down.” It was conscience. They began
+to feel a vague fear that they had been doing wrong to run away; and
+next they thought of the stolen meat, and then the real torture came.
+They tried to argue it away by reminding conscience that they had
+purloined sweetmeats and apples scores of times; but conscience was not
+to be appeased by such thin plausibilities; it seemed to them, in the
+end, that there was no getting around the stubborn fact that taking
+sweetmeats was only “hooking,” while taking bacon and hams and such
+valuables was plain simple stealing--and there was a command against that
+in the Bible. So they inwardly resolved that so long as they remained in
+the business, their piracies should not again be sullied with the
+crime of stealing. Then conscience granted a truce, and these curiously
+inconsistent pirates fell peacefully to sleep.
+
+
+
+
+CHAPTER XIV
+
+WHEN Tom awoke in the morning, he wondered where he was. He sat up and
+rubbed his eyes and looked around. Then he comprehended. It was the cool
+gray dawn, and there was a delicious sense of repose and peace in the
+deep pervading calm and silence of the woods. Not a leaf stirred; not
+a sound obtruded upon great Nature’s meditation. Beaded dewdrops stood
+upon the leaves and grasses. A white layer of ashes covered the fire,
+and a thin blue breath of smoke rose straight into the air. Joe and Huck
+still slept.
+
+Now, far away in the woods a bird called; another answered; presently
+the hammering of a woodpecker was heard. Gradually the cool dim gray
+of the morning whitened, and as gradually sounds multiplied and life
+manifested itself. The marvel of Nature shaking off sleep and going
+to work unfolded itself to the musing boy. A little green worm came
+crawling over a dewy leaf, lifting two-thirds of his body into the air
+from time to time and “sniffing around,” then proceeding again--for he
+was measuring, Tom said; and when the worm approached him, of its own
+accord, he sat as still as a stone, with his hopes rising and falling,
+by turns, as the creature still came toward him or seemed inclined to
+go elsewhere; and when at last it considered a painful moment with its
+curved body in the air and then came decisively down upon Tom’s leg and
+began a journey over him, his whole heart was glad--for that meant that
+he was going to have a new suit of clothes--without the shadow of a
+doubt a gaudy piratical uniform. Now a procession of ants appeared,
+from nowhere in particular, and went about their labors; one struggled
+manfully by with a dead spider five times as big as itself in its arms,
+and lugged it straight up a tree-trunk. A brown spotted lady-bug climbed
+the dizzy height of a grass blade, and Tom bent down close to it and
+said, “Lady-bug, lady-bug, fly away home, your house is on fire, your
+children’s alone,” and she took wing and went off to see about it--which
+did not surprise the boy, for he knew of old that this insect was
+credulous about conflagrations, and he had practised upon its simplicity
+more than once. A tumblebug came next, heaving sturdily at its ball, and
+Tom touched the creature, to see it shut its legs against its body
+and pretend to be dead. The birds were fairly rioting by this time. A
+catbird, the Northern mocker, lit in a tree over Tom’s head, and trilled
+out her imitations of her neighbors in a rapture of enjoyment; then
+a shrill jay swept down, a flash of blue flame, and stopped on a twig
+almost within the boy’s reach, cocked his head to one side and eyed the
+strangers with a consuming curiosity; a gray squirrel and a big fellow
+of the “fox” kind came skurrying along, sitting up at intervals to
+inspect and chatter at the boys, for the wild things had probably never
+seen a human being before and scarcely knew whether to be afraid or not.
+All Nature was wide awake and stirring, now; long lances of sunlight
+pierced down through the dense foliage far and near, and a few
+butterflies came fluttering upon the scene.
+
+Tom stirred up the other pirates and they all clattered away with
+a shout, and in a minute or two were stripped and chasing after and
+tumbling over each other in the shallow limpid water of the white
+sandbar. They felt no longing for the little village sleeping in the
+distance beyond the majestic waste of water. A vagrant current or a
+slight rise in the river had carried off their raft, but this only
+gratified them, since its going was something like burning the bridge
+between them and civilization.
+
+They came back to camp wonderfully refreshed, glad-hearted, and
+ravenous; and they soon had the camp-fire blazing up again. Huck found a
+spring of clear cold water close by, and the boys made cups of broad oak
+or hickory leaves, and felt that water, sweetened with such a wildwood
+charm as that, would be a good enough substitute for coffee. While Joe
+was slicing bacon for breakfast, Tom and Huck asked him to hold on a
+minute; they stepped to a promising nook in the river-bank and threw in
+their lines; almost immediately they had reward. Joe had not had time
+to get impatient before they were back again with some handsome bass,
+a couple of sun-perch and a small catfish--provisions enough for quite a
+family. They fried the fish with the bacon, and were astonished; for
+no fish had ever seemed so delicious before. They did not know that the
+quicker a fresh-water fish is on the fire after he is caught the better
+he is; and they reflected little upon what a sauce open-air sleeping,
+open-air exercise, bathing, and a large ingredient of hunger make, too.
+
+They lay around in the shade, after breakfast, while Huck had a smoke,
+and then went off through the woods on an exploring expedition. They
+tramped gayly along, over decaying logs, through tangled underbrush,
+among solemn monarchs of the forest, hung from their crowns to the
+ground with a drooping regalia of grape-vines. Now and then they came
+upon snug nooks carpeted with grass and jeweled with flowers.
+
+They found plenty of things to be delighted with, but nothing to be
+astonished at. They discovered that the island was about three miles
+long and a quarter of a mile wide, and that the shore it lay closest to
+was only separated from it by a narrow channel hardly two hundred yards
+wide. They took a swim about every hour, so it was close upon the middle
+of the afternoon when they got back to camp. They were too hungry to
+stop to fish, but they fared sumptuously upon cold ham, and then threw
+themselves down in the shade to talk. But the talk soon began to drag,
+and then died. The stillness, the solemnity that brooded in the woods,
+and the sense of loneliness, began to tell upon the spirits of the boys.
+They fell to thinking. A sort of undefined longing crept upon them. This
+took dim shape, presently--it was budding homesickness. Even Finn the
+Red-Handed was dreaming of his doorsteps and empty hogsheads. But they
+were all ashamed of their weakness, and none was brave enough to speak
+his thought.
+
+For some time, now, the boys had been dully conscious of a peculiar
+sound in the distance, just as one sometimes is of the ticking of a
+clock which he takes no distinct note of. But now this mysterious sound
+became more pronounced, and forced a recognition. The boys started,
+glanced at each other, and then each assumed a listening attitude. There
+was a long silence, profound and unbroken; then a deep, sullen boom came
+floating down out of the distance.
+
+“What is it!” exclaimed Joe, under his breath.
+
+“I wonder,” said Tom in a whisper.
+
+“‘Tain’t thunder,” said Huckleberry, in an awed tone, “becuz thunder--”
+
+“Hark!” said Tom. “Listen--don’t talk.”
+
+They waited a time that seemed an age, and then the same muffled boom
+troubled the solemn hush.
+
+“Let’s go and see.”
+
+They sprang to their feet and hurried to the shore toward the town. They
+parted the bushes on the bank and peered out over the water. The little
+steam ferry-boat was about a mile below the village, drifting with the
+current. Her broad deck seemed crowded with people. There were a great
+many skiffs rowing about or floating with the stream in the neighborhood
+of the ferryboat, but the boys could not determine what the men in
+them were doing. Presently a great jet of white smoke burst from the
+ferryboat’s side, and as it expanded and rose in a lazy cloud, that same
+dull throb of sound was borne to the listeners again.
+
+“I know now!” exclaimed Tom; “somebody’s drownded!”
+
+“That’s it!” said Huck; “they done that last summer, when Bill Turner
+got drownded; they shoot a cannon over the water, and that makes
+him come up to the top. Yes, and they take loaves of bread and put
+quicksilver in ‘em and set ‘em afloat, and wherever there’s anybody
+that’s drownded, they’ll float right there and stop.”
+
+“Yes, I’ve heard about that,” said Joe. “I wonder what makes the bread
+do that.”
+
+“Oh, it ain’t the bread, so much,” said Tom; “I reckon it’s mostly what
+they _say_ over it before they start it out.”
+
+“But they don’t say anything over it,” said Huck. “I’ve seen ‘em and
+they don’t.”
+
+“Well, that’s funny,” said Tom. “But maybe they say it to themselves. Of
+_course_ they do. Anybody might know that.”
+
+The other boys agreed that there was reason in what Tom said, because
+an ignorant lump of bread, uninstructed by an incantation, could not
+be expected to act very intelligently when set upon an errand of such
+gravity.
+
+“By jings, I wish I was over there, now,” said Joe.
+
+“I do too” said Huck “I’d give heaps to know who it is.”
+
+The boys still listened and watched. Presently a revealing thought
+flashed through Tom’s mind, and he exclaimed:
+
+“Boys, I know who’s drownded--it’s us!”
+
+They felt like heroes in an instant. Here was a gorgeous triumph; they
+were missed; they were mourned; hearts were breaking on their account;
+tears were being shed; accusing memories of unkindness to these poor
+lost lads were rising up, and unavailing regrets and remorse were being
+indulged; and best of all, the departed were the talk of the whole town,
+and the envy of all the boys, as far as this dazzling notoriety was
+concerned. This was fine. It was worth while to be a pirate, after all.
+
+As twilight drew on, the ferryboat went back to her accustomed business
+and the skiffs disappeared. The pirates returned to camp. They were
+jubilant with vanity over their new grandeur and the illustrious trouble
+they were making. They caught fish, cooked supper and ate it, and then
+fell to guessing at what the village was thinking and saying about them;
+and the pictures they drew of the public distress on their account were
+gratifying to look upon--from their point of view. But when the shadows
+of night closed them in, they gradually ceased to talk, and sat gazing
+into the fire, with their minds evidently wandering elsewhere. The
+excitement was gone, now, and Tom and Joe could not keep back thoughts
+of certain persons at home who were not enjoying this fine frolic as
+much as they were. Misgivings came; they grew troubled and unhappy; a
+sigh or two escaped, unawares. By and by Joe timidly ventured upon a
+roundabout “feeler” as to how the others might look upon a return to
+civilization--not right now, but--
+
+Tom withered him with derision! Huck, being uncommitted as yet, joined
+in with Tom, and the waverer quickly “explained,” and was glad to get
+out of the scrape with as little taint of chicken-hearted home-sickness
+clinging to his garments as he could. Mutiny was effectually laid to
+rest for the moment.
+
+As the night deepened, Huck began to nod, and presently to snore.
+Joe followed next. Tom lay upon his elbow motionless, for some time,
+watching the two intently. At last he got up cautiously, on his knees,
+and went searching among the grass and the flickering reflections flung
+by the campfire. He picked up and inspected several large semi-cylinders
+of the thin white bark of a sycamore, and finally chose two which seemed
+to suit him. Then he knelt by the fire and painfully wrote something
+upon each of these with his “red keel”; one he rolled up and put in his
+jacket pocket, and the other he put in Joe’s hat and removed it to a
+little distance from the owner. And he also put into the hat certain
+schoolboy treasures of almost inestimable value--among them a lump of
+chalk, an India-rubber ball, three fishhooks, and one of that kind
+of marbles known as a “sure ‘nough crystal.” Then he tiptoed his way
+cautiously among the trees till he felt that he was out of hearing, and
+straightway broke into a keen run in the direction of the sandbar.
+
+
+
+
+CHAPTER XV
+
+A few minutes later Tom was in the shoal water of the bar, wading toward
+the Illinois shore. Before the depth reached his middle he was halfway
+over; the current would permit no more wading, now, so he struck out
+confidently to swim the remaining hundred yards. He swam quartering
+upstream, but still was swept downward rather faster than he had
+expected. However, he reached the shore finally, and drifted along till
+he found a low place and drew himself out. He put his hand on his jacket
+pocket, found his piece of bark safe, and then struck through the woods,
+following the shore, with streaming garments. Shortly before ten
+o’clock he came out into an open place opposite the village, and saw the
+ferryboat lying in the shadow of the trees and the high bank. Everything
+was quiet under the blinking stars. He crept down the bank, watching
+with all his eyes, slipped into the water, swam three or four strokes
+and climbed into the skiff that did “yawl” duty at the boat’s stern. He
+laid himself down under the thwarts and waited, panting.
+
+Presently the cracked bell tapped and a voice gave the order to “cast
+off.” A minute or two later the skiff’s head was standing high up,
+against the boat’s swell, and the voyage was begun. Tom felt happy in
+his success, for he knew it was the boat’s last trip for the night. At
+the end of a long twelve or fifteen minutes the wheels stopped, and
+Tom slipped overboard and swam ashore in the dusk, landing fifty yards
+downstream, out of danger of possible stragglers.
+
+He flew along unfrequented alleys, and shortly found himself at his
+aunt’s back fence. He climbed over, approached the “ell,” and looked
+in at the sitting-room window, for a light was burning there. There
+sat Aunt Polly, Sid, Mary, and Joe Harper’s mother, grouped together,
+talking. They were by the bed, and the bed was between them and the
+door. Tom went to the door and began to softly lift the latch; then
+he pressed gently and the door yielded a crack; he continued pushing
+cautiously, and quaking every time it creaked, till he judged he might
+squeeze through on his knees; so he put his head through and began,
+warily.
+
+“What makes the candle blow so?” said Aunt Polly. Tom hurried up. “Why,
+that door’s open, I believe. Why, of course it is. No end of strange
+things now. Go ‘long and shut it, Sid.”
+
+Tom disappeared under the bed just in time. He lay and “breathed”
+ himself for a time, and then crept to where he could almost touch his
+aunt’s foot.
+
+“But as I was saying,” said Aunt Polly, “he warn’t _bad_, so to say--only
+misch_ee_vous. Only just giddy, and harum-scarum, you know. He warn’t
+any more responsible than a colt. _He_ never meant any harm, and he was
+the best-hearted boy that ever was”--and she began to cry.
+
+“It was just so with my Joe--always full of his devilment, and up to
+every kind of mischief, but he was just as unselfish and kind as he
+could be--and laws bless me, to think I went and whipped him for taking
+that cream, never once recollecting that I throwed it out myself because
+it was sour, and I never to see him again in this world, never, never,
+never, poor abused boy!” And Mrs. Harper sobbed as if her heart would
+break.
+
+“I hope Tom’s better off where he is,” said Sid, “but if he’d been
+better in some ways--”
+
+“_Sid!_” Tom felt the glare of the old lady’s eye, though he could not
+see it. “Not a word against my Tom, now that he’s gone! God’ll take care
+of _him_--never you trouble _your_self, sir! Oh, Mrs. Harper, I don’t
+know how to give him up! I don’t know how to give him up! He was such a
+comfort to me, although he tormented my old heart out of me, ‘most.”
+
+“The Lord giveth and the Lord hath taken away--Blessed be the name of
+the Lord! But it’s so hard--Oh, it’s so hard! Only last Saturday my Joe
+busted a firecracker right under my nose and I knocked him sprawling.
+Little did I know then, how soon--Oh, if it was to do over again I’d hug
+him and bless him for it.”
+
+“Yes, yes, yes, I know just how you feel, Mrs. Harper, I know just
+exactly how you feel. No longer ago than yesterday noon, my Tom took
+and filled the cat full of Pain-killer, and I did think the cretur would
+tear the house down. And God forgive me, I cracked Tom’s head with my
+thimble, poor boy, poor dead boy. But he’s out of all his troubles now.
+And the last words I ever heard him say was to reproach--”
+
+But this memory was too much for the old lady, and she broke entirely
+down. Tom was snuffling, now, himself--and more in pity of himself than
+anybody else. He could hear Mary crying, and putting in a kindly word
+for him from time to time. He began to have a nobler opinion of himself
+than ever before. Still, he was sufficiently touched by his aunt’s grief
+to long to rush out from under the bed and overwhelm her with joy--and
+the theatrical gorgeousness of the thing appealed strongly to his
+nature, too, but he resisted and lay still.
+
+He went on listening, and gathered by odds and ends that it was
+conjectured at first that the boys had got drowned while taking a swim;
+then the small raft had been missed; next, certain boys said the missing
+lads had promised that the village should “hear something” soon; the
+wise-heads had “put this and that together” and decided that the lads
+had gone off on that raft and would turn up at the next town below,
+presently; but toward noon the raft had been found, lodged against the
+Missouri shore some five or six miles below the village--and then hope
+perished; they must be drowned, else hunger would have driven them home
+by nightfall if not sooner. It was believed that the search for the
+bodies had been a fruitless effort merely because the drowning must
+have occurred in mid-channel, since the boys, being good swimmers, would
+otherwise have escaped to shore. This was Wednesday night. If the bodies
+continued missing until Sunday, all hope would be given over, and the
+funerals would be preached on that morning. Tom shuddered.
+
+Mrs. Harper gave a sobbing goodnight and turned to go. Then with a
+mutual impulse the two bereaved women flung themselves into each other’s
+arms and had a good, consoling cry, and then parted. Aunt Polly was
+tender far beyond her wont, in her goodnight to Sid and Mary. Sid
+snuffled a bit and Mary went off crying with all her heart.
+
+Aunt Polly knelt down and prayed for Tom so touchingly, so appealingly,
+and with such measureless love in her words and her old trembling voice,
+that he was weltering in tears again, long before she was through.
+
+He had to keep still long after she went to bed, for she kept making
+broken-hearted ejaculations from time to time, tossing unrestfully, and
+turning over. But at last she was still, only moaning a little in her
+sleep. Now the boy stole out, rose gradually by the bedside, shaded the
+candle-light with his hand, and stood regarding her. His heart was full
+of pity for her. He took out his sycamore scroll and placed it by the
+candle. But something occurred to him, and he lingered considering.
+His face lighted with a happy solution of his thought; he put the bark
+hastily in his pocket. Then he bent over and kissed the faded lips, and
+straightway made his stealthy exit, latching the door behind him.
+
+He threaded his way back to the ferry landing, found nobody at large
+there, and walked boldly on board the boat, for he knew she was
+tenantless except that there was a watchman, who always turned in and
+slept like a graven image. He untied the skiff at the stern, slipped
+into it, and was soon rowing cautiously upstream. When he had pulled a
+mile above the village, he started quartering across and bent himself
+stoutly to his work. He hit the landing on the other side neatly, for
+this was a familiar bit of work to him. He was moved to capture
+the skiff, arguing that it might be considered a ship and therefore
+legitimate prey for a pirate, but he knew a thorough search would be
+made for it and that might end in revelations. So he stepped ashore and
+entered the woods.
+
+He sat down and took a long rest, torturing himself meanwhile to keep
+awake, and then started warily down the home-stretch. The night was far
+spent. It was broad daylight before he found himself fairly abreast the
+island bar. He rested again until the sun was well up and gilding the
+great river with its splendor, and then he plunged into the stream. A
+little later he paused, dripping, upon the threshold of the camp, and
+heard Joe say:
+
+“No, Tom’s true-blue, Huck, and he’ll come back. He won’t desert. He
+knows that would be a disgrace to a pirate, and Tom’s too proud for that
+sort of thing. He’s up to something or other. Now I wonder what?”
+
+“Well, the things is ours, anyway, ain’t they?”
+
+“Pretty near, but not yet, Huck. The writing says they are if he ain’t
+back here to breakfast.”
+
+“Which he is!” exclaimed Tom, with fine dramatic effect, stepping
+grandly into camp.
+
+A sumptuous breakfast of bacon and fish was shortly provided, and as the
+boys set to work upon it, Tom recounted (and adorned) his adventures.
+They were a vain and boastful company of heroes when the tale was done.
+Then Tom hid himself away in a shady nook to sleep till noon, and the
+other pirates got ready to fish and explore.
+
+
+
+
+CHAPTER XVI
+
+AFTER dinner all the gang turned out to hunt for turtle eggs on the bar.
+They went about poking sticks into the sand, and when they found a soft
+place they went down on their knees and dug with their hands. Sometimes
+they would take fifty or sixty eggs out of one hole. They were perfectly
+round white things a trifle smaller than an English walnut. They had a
+famous fried-egg feast that night, and another on Friday morning.
+
+After breakfast they went whooping and prancing out on the bar, and
+chased each other round and round, shedding clothes as they went, until
+they were naked, and then continued the frolic far away up the shoal
+water of the bar, against the stiff current, which latter tripped their
+legs from under them from time to time and greatly increased the fun.
+And now and then they stooped in a group and splashed water in each
+other’s faces with their palms, gradually approaching each other, with
+averted faces to avoid the strangling sprays, and finally gripping and
+struggling till the best man ducked his neighbor, and then they all
+went under in a tangle of white legs and arms and came up blowing,
+sputtering, laughing, and gasping for breath at one and the same time.
+
+When they were well exhausted, they would run out and sprawl on the dry,
+hot sand, and lie there and cover themselves up with it, and by and by
+break for the water again and go through the original performance once
+more. Finally it occurred to them that their naked skin represented
+flesh-colored “tights” very fairly; so they drew a ring in the sand and
+had a circus--with three clowns in it, for none would yield this proudest
+post to his neighbor.
+
+Next they got their marbles and played “knucks” and “ringtaw” and
+“keeps” till that amusement grew stale. Then Joe and Huck had another
+swim, but Tom would not venture, because he found that in kicking off
+his trousers he had kicked his string of rattlesnake rattles off his
+ankle, and he wondered how he had escaped cramp so long without the
+protection of this mysterious charm. He did not venture again until he
+had found it, and by that time the other boys were tired and ready to
+rest. They gradually wandered apart, dropped into the “dumps,” and
+fell to gazing longingly across the wide river to where the village lay
+drowsing in the sun. Tom found himself writing “BECKY” in the sand with
+his big toe; he scratched it out, and was angry with himself for his
+weakness. But he wrote it again, nevertheless; he could not help it. He
+erased it once more and then took himself out of temptation by driving
+the other boys together and joining them.
+
+But Joe’s spirits had gone down almost beyond resurrection. He was so
+homesick that he could hardly endure the misery of it. The tears lay
+very near the surface. Huck was melancholy, too. Tom was downhearted,
+but tried hard not to show it. He had a secret which he was not ready
+to tell, yet, but if this mutinous depression was not broken up soon, he
+would have to bring it out. He said, with a great show of cheerfulness:
+
+“I bet there’s been pirates on this island before, boys. We’ll explore
+it again. They’ve hid treasures here somewhere. How’d you feel to light
+on a rotten chest full of gold and silver--hey?”
+
+But it roused only faint enthusiasm, which faded out, with no reply.
+Tom tried one or two other seductions; but they failed, too. It was
+discouraging work. Joe sat poking up the sand with a stick and looking
+very gloomy. Finally he said:
+
+“Oh, boys, let’s give it up. I want to go home. It’s so lonesome.”
+
+“Oh no, Joe, you’ll feel better by and by,” said Tom. “Just think of the
+fishing that’s here.”
+
+“I don’t care for fishing. I want to go home.”
+
+“But, Joe, there ain’t such another swimming-place anywhere.”
+
+“Swimming’s no good. I don’t seem to care for it, somehow, when there
+ain’t anybody to say I sha’n’t go in. I mean to go home.”
+
+“Oh, shucks! Baby! You want to see your mother, I reckon.”
+
+“Yes, I _do_ want to see my mother--and you would, too, if you had one. I
+ain’t any more baby than you are.” And Joe snuffled a little.
+
+“Well, we’ll let the crybaby go home to his mother, won’t we, Huck? Poor
+thing--does it want to see its mother? And so it shall. You like it here,
+don’t you, Huck? We’ll stay, won’t we?”
+
+Huck said, “Y-e-s”--without any heart in it.
+
+“I’ll never speak to you again as long as I live,” said Joe, rising.
+“There now!” And he moved moodily away and began to dress himself.
+
+“Who cares!” said Tom. “Nobody wants you to. Go ‘long home and get
+laughed at. Oh, you’re a nice pirate. Huck and me ain’t crybabies. We’ll
+stay, won’t we, Huck? Let him go if he wants to. I reckon we can get
+along without him, per’aps.”
+
+But Tom was uneasy, nevertheless, and was alarmed to see Joe go sullenly
+on with his dressing. And then it was discomforting to see Huck eying
+Joe’s preparations so wistfully, and keeping up such an ominous silence.
+Presently, without a parting word, Joe began to wade off toward the
+Illinois shore. Tom’s heart began to sink. He glanced at Huck. Huck
+could not bear the look, and dropped his eyes. Then he said:
+
+“I want to go, too, Tom. It was getting so lonesome anyway, and now
+it’ll be worse. Let’s us go, too, Tom.”
+
+“I won’t! You can all go, if you want to. I mean to stay.”
+
+“Tom, I better go.”
+
+“Well, go ‘long--who’s hendering you.”
+
+Huck began to pick up his scattered clothes. He said:
+
+“Tom, I wisht you’d come, too. Now you think it over. We’ll wait for you
+when we get to shore.”
+
+“Well, you’ll wait a blame long time, that’s all.”
+
+Huck started sorrowfully away, and Tom stood looking after him, with a
+strong desire tugging at his heart to yield his pride and go along
+too. He hoped the boys would stop, but they still waded slowly on. It
+suddenly dawned on Tom that it was become very lonely and still. He made
+one final struggle with his pride, and then darted after his comrades,
+yelling:
+
+“Wait! Wait! I want to tell you something!”
+
+They presently stopped and turned around. When he got to where they
+were, he began unfolding his secret, and they listened moodily till
+at last they saw the “point” he was driving at, and then they set up a
+warwhoop of applause and said it was “splendid!” and said if he had
+told them at first, they wouldn’t have started away. He made a plausible
+excuse; but his real reason had been the fear that not even the secret
+would keep them with him any very great length of time, and so he had
+meant to hold it in reserve as a last seduction.
+
+The lads came gayly back and went at their sports again with a will,
+chattering all the time about Tom’s stupendous plan and admiring the
+genius of it. After a dainty egg and fish dinner, Tom said he wanted to
+learn to smoke, now. Joe caught at the idea and said he would like to
+try, too. So Huck made pipes and filled them. These novices had never
+smoked anything before but cigars made of grapevine, and they “bit” the
+tongue, and were not considered manly anyway.
+
+Now they stretched themselves out on their elbows and began to puff,
+charily, and with slender confidence. The smoke had an unpleasant taste,
+and they gagged a little, but Tom said:
+
+“Why, it’s just as easy! If I’d a knowed this was all, I’d a learnt long
+ago.”
+
+“So would I,” said Joe. “It’s just nothing.”
+
+“Why, many a time I’ve looked at people smoking, and thought well I wish
+I could do that; but I never thought I could,” said Tom.
+
+“That’s just the way with me, hain’t it, Huck? You’ve heard me talk just
+that way--haven’t you, Huck? I’ll leave it to Huck if I haven’t.”
+
+“Yes--heaps of times,” said Huck.
+
+“Well, I have too,” said Tom; “oh, hundreds of times. Once down by the
+slaughter-house. Don’t you remember, Huck? Bob Tanner was there, and
+Johnny Miller, and Jeff Thatcher, when I said it. Don’t you remember,
+Huck, ‘bout me saying that?”
+
+“Yes, that’s so,” said Huck. “That was the day after I lost a white
+alley. No, ‘twas the day before.”
+
+“There--I told you so,” said Tom. “Huck recollects it.”
+
+“I bleeve I could smoke this pipe all day,” said Joe. “I don’t feel
+sick.”
+
+“Neither do I,” said Tom. “I could smoke it all day. But I bet you Jeff
+Thatcher couldn’t.”
+
+“Jeff Thatcher! Why, he’d keel over just with two draws. Just let him
+try it once. _He’d_ see!”
+
+“I bet he would. And Johnny Miller--I wish could see Johnny Miller tackle
+it once.”
+
+“Oh, don’t I!” said Joe. “Why, I bet you Johnny Miller couldn’t any more
+do this than nothing. Just one little snifter would fetch _him_.”
+
+“‘Deed it would, Joe. Say--I wish the boys could see us now.”
+
+“So do I.”
+
+“Say--boys, don’t say anything about it, and some time when they’re
+around, I’ll come up to you and say, ‘Joe, got a pipe? I want a smoke.’
+And you’ll say, kind of careless like, as if it warn’t anything, you’ll
+say, ‘Yes, I got my _old_ pipe, and another one, but my tobacker ain’t
+very good.’ And I’ll say, ‘Oh, that’s all right, if it’s _strong_
+enough.’ And then you’ll out with the pipes, and we’ll light up just as
+ca’m, and then just see ‘em look!”
+
+“By jings, that’ll be gay, Tom! I wish it was _now_!”
+
+“So do I! And when we tell ‘em we learned when we was off pirating,
+won’t they wish they’d been along?”
+
+“Oh, I reckon not! I’ll just _bet_ they will!”
+
+So the talk ran on. But presently it began to flag a trifle, and
+grow disjointed. The silences widened; the expectoration marvellously
+increased. Every pore inside the boys’ cheeks became a spouting
+fountain; they could scarcely bail out the cellars under their tongues
+fast enough to prevent an inundation; little overflowings down their
+throats occurred in spite of all they could do, and sudden retchings
+followed every time. Both boys were looking very pale and miserable,
+now. Joe’s pipe dropped from his nerveless fingers. Tom’s followed. Both
+fountains were going furiously and both pumps bailing with might and
+main. Joe said feebly:
+
+“I’ve lost my knife. I reckon I better go and find it.”
+
+Tom said, with quivering lips and halting utterance:
+
+“I’ll help you. You go over that way and I’ll hunt around by the spring.
+No, you needn’t come, Huck--we can find it.”
+
+So Huck sat down again, and waited an hour. Then he found it lonesome,
+and went to find his comrades. They were wide apart in the woods, both
+very pale, both fast asleep. But something informed him that if they had
+had any trouble they had got rid of it.
+
+They were not talkative at supper that night. They had a humble look,
+and when Huck prepared his pipe after the meal and was going to prepare
+theirs, they said no, they were not feeling very well--something they ate
+at dinner had disagreed with them.
+
+About midnight Joe awoke, and called the boys. There was a brooding
+oppressiveness in the air that seemed to bode something. The boys
+huddled themselves together and sought the friendly companionship of
+the fire, though the dull dead heat of the breathless atmosphere was
+stifling. They sat still, intent and waiting. The solemn hush continued.
+Beyond the light of the fire everything was swallowed up in the
+blackness of darkness. Presently there came a quivering glow that
+vaguely revealed the foliage for a moment and then vanished. By and by
+another came, a little stronger. Then another. Then a faint moan came
+sighing through the branches of the forest and the boys felt a fleeting
+breath upon their cheeks, and shuddered with the fancy that the Spirit
+of the Night had gone by. There was a pause. Now a weird flash turned
+night into day and showed every little grassblade, separate and
+distinct, that grew about their feet. And it showed three white,
+startled faces, too. A deep peal of thunder went rolling and tumbling
+down the heavens and lost itself in sullen rumblings in the distance. A
+sweep of chilly air passed by, rustling all the leaves and snowing the
+flaky ashes broadcast about the fire. Another fierce glare lit up the
+forest and an instant crash followed that seemed to rend the treetops
+right over the boys’ heads. They clung together in terror, in the thick
+gloom that followed. A few big raindrops fell pattering upon the leaves.
+
+“Quick! boys, go for the tent!” exclaimed Tom.
+
+They sprang away, stumbling over roots and among vines in the dark, no
+two plunging in the same direction. A furious blast roared through
+the trees, making everything sing as it went. One blinding flash after
+another came, and peal on peal of deafening thunder. And now a drenching
+rain poured down and the rising hurricane drove it in sheets along the
+ground. The boys cried out to each other, but the roaring wind and the
+booming thunderblasts drowned their voices utterly. However, one by one
+they straggled in at last and took shelter under the tent, cold, scared,
+and streaming with water; but to have company in misery seemed something
+to be grateful for. They could not talk, the old sail flapped so
+furiously, even if the other noises would have allowed them. The tempest
+rose higher and higher, and presently the sail tore loose from its
+fastenings and went winging away on the blast. The boys seized each
+others’ hands and fled, with many tumblings and bruises, to the shelter
+of a great oak that stood upon the riverbank. Now the battle was at its
+highest. Under the ceaseless conflagration of lightning that flamed
+in the skies, everything below stood out in cleancut and shadowless
+distinctness: the bending trees, the billowy river, white with foam, the
+driving spray of spumeflakes, the dim outlines of the high bluffs on
+the other side, glimpsed through the drifting cloudrack and the slanting
+veil of rain. Every little while some giant tree yielded the fight
+and fell crashing through the younger growth; and the unflagging
+thunderpeals came now in ear-splitting explosive bursts, keen and sharp,
+and unspeakably appalling. The storm culminated in one matchless effort
+that seemed likely to tear the island to pieces, burn it up, drown it to
+the treetops, blow it away, and deafen every creature in it, all at one
+and the same moment. It was a wild night for homeless young heads to be
+out in.
+
+But at last the battle was done, and the forces retired with weaker and
+weaker threatenings and grumblings, and peace resumed her sway. The
+boys went back to camp, a good deal awed; but they found there was still
+something to be thankful for, because the great sycamore, the shelter
+of their beds, was a ruin, now, blasted by the lightnings, and they were
+not under it when the catastrophe happened.
+
+Everything in camp was drenched, the campfire as well; for they were but
+heedless lads, like their generation, and had made no provision against
+rain. Here was matter for dismay, for they were soaked through and
+chilled. They were eloquent in their distress; but they presently
+discovered that the fire had eaten so far up under the great log it had
+been built against (where it curved upward and separated itself from
+the ground), that a handbreadth or so of it had escaped wetting; so they
+patiently wrought until, with shreds and bark gathered from the under
+sides of sheltered logs, they coaxed the fire to burn again. Then they
+piled on great dead boughs till they had a roaring furnace, and were
+gladhearted once more. They dried their boiled ham and had a feast,
+and after that they sat by the fire and expanded and glorified their
+midnight adventure until morning, for there was not a dry spot to sleep
+on, anywhere around.
+
+As the sun began to steal in upon the boys, drowsiness came over
+them, and they went out on the sandbar and lay down to sleep. They got
+scorched out by and by, and drearily set about getting breakfast. After
+the meal they felt rusty, and stiff-jointed, and a little homesick once
+more. Tom saw the signs, and fell to cheering up the pirates as well as
+he could. But they cared nothing for marbles, or circus, or swimming, or
+anything. He reminded them of the imposing secret, and raised a ray of
+cheer. While it lasted, he got them interested in a new device. This was
+to knock off being pirates, for a while, and be Indians for a change.
+They were attracted by this idea; so it was not long before they were
+stripped, and striped from head to heel with black mud, like so many
+zebras--all of them chiefs, of course--and then they went tearing through
+the woods to attack an English settlement.
+
+By and by they separated into three hostile tribes, and darted upon each
+other from ambush with dreadful warwhoops, and killed and scalped each
+other by thousands. It was a gory day. Consequently it was an extremely
+satisfactory one.
+
+They assembled in camp toward suppertime, hungry and happy; but now
+a difficulty arose--hostile Indians could not break the bread of
+hospitality together without first making peace, and this was a simple
+impossibility without smoking a pipe of peace. There was no other
+process that ever they had heard of. Two of the savages almost wished
+they had remained pirates. However, there was no other way; so with such
+show of cheerfulness as they could muster they called for the pipe and
+took their whiff as it passed, in due form.
+
+And behold, they were glad they had gone into savagery, for they had
+gained something; they found that they could now smoke a little without
+having to go and hunt for a lost knife; they did not get sick enough to
+be seriously uncomfortable. They were not likely to fool away this high
+promise for lack of effort. No, they practised cautiously, after supper,
+with right fair success, and so they spent a jubilant evening. They were
+prouder and happier in their new acquirement than they would have been
+in the scalping and skinning of the Six Nations. We will leave them to
+smoke and chatter and brag, since we have no further use for them at
+present.
+
+
+
+
+CHAPTER XVII
+
+BUT there was no hilarity in the little town that same tranquil Saturday
+afternoon. The Harpers, and Aunt Polly’s family, were being put into
+mourning, with great grief and many tears. An unusual quiet possessed
+the village, although it was ordinarily quiet enough, in all conscience.
+The villagers conducted their concerns with an absent air, and talked
+little; but they sighed often. The Saturday holiday seemed a burden to
+the children. They had no heart in their sports, and gradually gave them
+up.
+
+In the afternoon Becky Thatcher found herself moping about the deserted
+schoolhouse yard, and feeling very melancholy. But she found nothing
+there to comfort her. She soliloquized:
+
+“Oh, if I only had a brass andiron-knob again! But I haven’t got
+anything now to remember him by.” And she choked back a little sob.
+
+Presently she stopped, and said to herself:
+
+“It was right here. Oh, if it was to do over again, I wouldn’t say
+that--I wouldn’t say it for the whole world. But he’s gone now; I’ll
+never, never, never see him any more.”
+
+This thought broke her down, and she wandered away, with tears rolling
+down her cheeks. Then quite a group of boys and girls--playmates of Tom’s
+and Joe’s--came by, and stood looking over the paling fence and talking
+in reverent tones of how Tom did so-and-so the last time they saw
+him, and how Joe said this and that small trifle (pregnant with awful
+prophecy, as they could easily see now!)--and each speaker pointed out
+the exact spot where the lost lads stood at the time, and then added
+something like “and I was a-standing just so--just as I am now, and as if
+you was him--I was as close as that--and he smiled, just this way--and then
+something seemed to go all over me, like--awful, you know--and I never
+thought what it meant, of course, but I can see now!”
+
+Then there was a dispute about who saw the dead boys last in life, and
+many claimed that dismal distinction, and offered evidences, more or
+less tampered with by the witness; and when it was ultimately decided
+who _did_ see the departed last, and exchanged the last words with them,
+the lucky parties took upon themselves a sort of sacred importance,
+and were gaped at and envied by all the rest. One poor chap, who had
+no other grandeur to offer, said with tolerably manifest pride in the
+remembrance:
+
+“Well, Tom Sawyer he licked me once.”
+
+But that bid for glory was a failure. Most of the boys could say that,
+and so that cheapened the distinction too much. The group loitered away,
+still recalling memories of the lost heroes, in awed voices.
+
+When the Sunday-school hour was finished, the next morning, the bell
+began to toll, instead of ringing in the usual way. It was a very still
+Sabbath, and the mournful sound seemed in keeping with the musing hush
+that lay upon nature. The villagers began to gather, loitering a moment
+in the vestibule to converse in whispers about the sad event. But there
+was no whispering in the house; only the funereal rustling of dresses
+as the women gathered to their seats disturbed the silence there. None
+could remember when the little church had been so full before. There
+was finally a waiting pause, an expectant dumbness, and then Aunt Polly
+entered, followed by Sid and Mary, and they by the Harper family, all in
+deep black, and the whole congregation, the old minister as well, rose
+reverently and stood until the mourners were seated in the front pew.
+There was another communing silence, broken at intervals by muffled
+sobs, and then the minister spread his hands abroad and prayed. A moving
+hymn was sung, and the text followed: “I am the Resurrection and the
+Life.”
+
+As the service proceeded, the clergyman drew such pictures of the
+graces, the winning ways, and the rare promise of the lost lads that
+every soul there, thinking he recognized these pictures, felt a pang
+in remembering that he had persistently blinded himself to them always
+before, and had as persistently seen only faults and flaws in the poor
+boys. The minister related many a touching incident in the lives of the
+departed, too, which illustrated their sweet, generous natures, and the
+people could easily see, now, how noble and beautiful those episodes
+were, and remembered with grief that at the time they occurred they had
+seemed rank rascalities, well deserving of the cowhide. The congregation
+became more and more moved, as the pathetic tale went on, till at last
+the whole company broke down and joined the weeping mourners in a chorus
+of anguished sobs, the preacher himself giving way to his feelings, and
+crying in the pulpit.
+
+There was a rustle in the gallery, which nobody noticed; a moment later
+the church door creaked; the minister raised his streaming eyes above
+his handkerchief, and stood transfixed! First one and then another pair
+of eyes followed the minister’s, and then almost with one impulse the
+congregation rose and stared while the three dead boys came marching up
+the aisle, Tom in the lead, Joe next, and Huck, a ruin of drooping rags,
+sneaking sheepishly in the rear! They had been hid in the unused gallery
+listening to their own funeral sermon!
+
+Aunt Polly, Mary, and the Harpers threw themselves upon their restored
+ones, smothered them with kisses and poured out thanksgivings, while
+poor Huck stood abashed and uncomfortable, not knowing exactly what
+to do or where to hide from so many unwelcoming eyes. He wavered, and
+started to slink away, but Tom seized him and said:
+
+“Aunt Polly, it ain’t fair. Somebody’s got to be glad to see Huck.”
+
+“And so they shall. I’m glad to see him, poor motherless thing!” And
+the loving attentions Aunt Polly lavished upon him were the one thing
+capable of making him more uncomfortable than he was before.
+
+Suddenly the minister shouted at the top of his voice: “Praise God from
+whom all blessings flow--_sing_!--and put your hearts in it!”
+
+And they did. Old Hundred swelled up with a triumphant burst, and
+while it shook the rafters Tom Sawyer the Pirate looked around upon the
+envying juveniles about him and confessed in his heart that this was the
+proudest moment of his life.
+
+As the “sold” congregation trooped out they said they would almost be
+willing to be made ridiculous again to hear Old Hundred sung like that
+once more.
+
+Tom got more cuffs and kisses that day--according to Aunt Polly’s varying
+moods--than he had earned before in a year; and he hardly knew which
+expressed the most gratefulness to God and affection for himself.
+
+
+
+
+CHAPTER XVIII
+
+THAT was Tom’s great secret--the scheme to return home with his brother
+pirates and attend their own funerals. They had paddled over to the
+Missouri shore on a log, at dusk on Saturday, landing five or six miles
+below the village; they had slept in the woods at the edge of the town
+till nearly daylight, and had then crept through back lanes and alleys
+and finished their sleep in the gallery of the church among a chaos of
+invalided benches.
+
+At breakfast, Monday morning, Aunt Polly and Mary were very loving to
+Tom, and very attentive to his wants. There was an unusual amount of
+talk. In the course of it Aunt Polly said:
+
+“Well, I don’t say it wasn’t a fine joke, Tom, to keep everybody
+suffering ‘most a week so you boys had a good time, but it is a pity you
+could be so hard-hearted as to let me suffer so. If you could come over
+on a log to go to your funeral, you could have come over and give me a
+hint some way that you warn’t dead, but only run off.”
+
+“Yes, you could have done that, Tom,” said Mary; “and I believe you
+would if you had thought of it.”
+
+“Would you, Tom?” said Aunt Polly, her face lighting wistfully. “Say,
+now, would you, if you’d thought of it?”
+
+“I--well, I don’t know. ‘Twould ‘a’ spoiled everything.”
+
+“Tom, I hoped you loved me that much,” said Aunt Polly, with a grieved
+tone that discomforted the boy. “It would have been something if you’d
+cared enough to _think_ of it, even if you didn’t _do_ it.”
+
+“Now, auntie, that ain’t any harm,” pleaded Mary; “it’s only Tom’s giddy
+way--he is always in such a rush that he never thinks of anything.”
+
+“More’s the pity. Sid would have thought. And Sid would have come and
+_done_ it, too. Tom, you’ll look back, some day, when it’s too late,
+and wish you’d cared a little more for me when it would have cost you so
+little.”
+
+“Now, auntie, you know I do care for you,” said Tom.
+
+“I’d know it better if you acted more like it.”
+
+“I wish now I’d thought,” said Tom, with a repentant tone; “but I dreamt
+about you, anyway. That’s something, ain’t it?”
+
+“It ain’t much--a cat does that much--but it’s better than nothing. What
+did you dream?”
+
+“Why, Wednesday night I dreamt that you was sitting over there by the
+bed, and Sid was sitting by the woodbox, and Mary next to him.”
+
+“Well, so we did. So we always do. I’m glad your dreams could take even
+that much trouble about us.”
+
+“And I dreamt that Joe Harper’s mother was here.”
+
+“Why, she was here! Did you dream any more?”
+
+“Oh, lots. But it’s so dim, now.”
+
+“Well, try to recollect--can’t you?”
+
+“Somehow it seems to me that the wind--the wind blowed the--the--”
+
+“Try harder, Tom! The wind did blow something. Come!”
+
+Tom pressed his fingers on his forehead an anxious minute, and then
+said:
+
+“I’ve got it now! I’ve got it now! It blowed the candle!”
+
+“Mercy on us! Go on, Tom--go on!”
+
+“And it seems to me that you said, ‘Why, I believe that that door--’”
+
+“Go _on_, Tom!”
+
+“Just let me study a moment--just a moment. Oh, yes--you said you believed
+the door was open.”
+
+“As I’m sitting here, I did! Didn’t I, Mary! Go on!”
+
+“And then--and then--well I won’t be certain, but it seems like as if you
+made Sid go and--and--”
+
+“Well? Well? What did I make him do, Tom? What did I make him do?”
+
+“You made him--you--Oh, you made him shut it.”
+
+“Well, for the land’s sake! I never heard the beat of that in all my
+days! Don’t tell _me_ there ain’t anything in dreams, any more. Sereny
+Harper shall know of this before I’m an hour older. I’d like to see her
+get around _this_ with her rubbage ‘bout superstition. Go on, Tom!”
+
+“Oh, it’s all getting just as bright as day, now. Next you said I warn’t
+_bad_, only mischeevous and harum-scarum, and not any more responsible
+than--than--I think it was a colt, or something.”
+
+“And so it was! Well, goodness gracious! Go on, Tom!”
+
+“And then you began to cry.”
+
+“So I did. So I did. Not the first time, neither. And then--”
+
+“Then Mrs. Harper she began to cry, and said Joe was just the same, and
+she wished she hadn’t whipped him for taking cream when she’d throwed it
+out her own self--”
+
+“Tom! The sperrit was upon you! You was a prophesying--that’s what you
+was doing! Land alive, go on, Tom!”
+
+“Then Sid he said--he said--”
+
+“I don’t think I said anything,” said Sid.
+
+“Yes you did, Sid,” said Mary.
+
+“Shut your heads and let Tom go on! What did he say, Tom?”
+
+“He said--I _think_ he said he hoped I was better off where I was gone
+to, but if I’d been better sometimes--”
+
+“_There_, d’you hear that! It was his very words!”
+
+“And you shut him up sharp.”
+
+“I lay I did! There must ‘a’ been an angel there. There _was_ an angel
+there, somewheres!”
+
+“And Mrs. Harper told about Joe scaring her with a firecracker, and you
+told about Peter and the Pain-killer--”
+
+“Just as true as I live!”
+
+“And then there was a whole lot of talk ‘bout dragging the river for us,
+and ‘bout having the funeral Sunday, and then you and old Miss Harper
+hugged and cried, and she went.”
+
+“It happened just so! It happened just so, as sure as I’m a-sitting in
+these very tracks. Tom, you couldn’t told it more like if you’d ‘a’ seen
+it! And then what? Go on, Tom!”
+
+“Then I thought you prayed for me--and I could see you and hear every
+word you said. And you went to bed, and I was so sorry that I took and
+wrote on a piece of sycamore bark, ‘We ain’t dead--we are only off being
+pirates,’ and put it on the table by the candle; and then you looked
+so good, laying there asleep, that I thought I went and leaned over and
+kissed you on the lips.”
+
+“Did you, Tom, _did_ you! I just forgive you everything for that!” And
+she seized the boy in a crushing embrace that made him feel like the
+guiltiest of villains.
+
+“It was very kind, even though it was only a--dream,” Sid soliloquized
+just audibly.
+
+“Shut up, Sid! A body does just the same in a dream as he’d do if he was
+awake. Here’s a big Milum apple I’ve been saving for you, Tom, if you
+was ever found again--now go ‘long to school. I’m thankful to the good
+God and Father of us all I’ve got you back, that’s long-suffering and
+merciful to them that believe on Him and keep His word, though goodness
+knows I’m unworthy of it, but if only the worthy ones got His blessings
+and had His hand to help them over the rough places, there’s few enough
+would smile here or ever enter into His rest when the long night comes.
+Go ‘long Sid, Mary, Tom--take yourselves off--you’ve hendered me long
+enough.”
+
+The children left for school, and the old lady to call on Mrs. Harper
+and vanquish her realism with Tom’s marvellous dream. Sid had better
+judgment than to utter the thought that was in his mind as he left the
+house. It was this: “Pretty thin--as long a dream as that, without any
+mistakes in it!”
+
+What a hero Tom was become, now! He did not go skipping and prancing,
+but moved with a dignified swagger as became a pirate who felt that the
+public eye was on him. And indeed it was; he tried not to seem to see
+the looks or hear the remarks as he passed along, but they were food and
+drink to him. Smaller boys than himself flocked at his heels, as proud
+to be seen with him, and tolerated by him, as if he had been the drummer
+at the head of a procession or the elephant leading a menagerie into
+town. Boys of his own size pretended not to know he had been away at
+all; but they were consuming with envy, nevertheless. They would have
+given anything to have that swarthy sun-tanned skin of his, and his
+glittering notoriety; and Tom would not have parted with either for a
+circus.
+
+At school the children made so much of him and of Joe, and delivered
+such eloquent admiration from their eyes, that the two heroes were
+not long in becoming insufferably “stuck-up.” They began to tell their
+adventures to hungry listeners--but they only began; it was not a
+thing likely to have an end, with imaginations like theirs to furnish
+material. And finally, when they got out their pipes and went serenely
+puffing around, the very summit of glory was reached.
+
+Tom decided that he could be independent of Becky Thatcher now. Glory
+was sufficient. He would live for glory. Now that he was distinguished,
+maybe she would be wanting to “make up.” Well, let her--she should see
+that he could be as indifferent as some other people. Presently she
+arrived. Tom pretended not to see her. He moved away and joined a group
+of boys and girls and began to talk. Soon he observed that she was
+tripping gayly back and forth with flushed face and dancing eyes,
+pretending to be busy chasing schoolmates, and screaming with laughter
+when she made a capture; but he noticed that she always made her
+captures in his vicinity, and that she seemed to cast a conscious eye
+in his direction at such times, too. It gratified all the vicious vanity
+that was in him; and so, instead of winning him, it only “set him up”
+ the more and made him the more diligent to avoid betraying that he
+knew she was about. Presently she gave over skylarking, and moved
+irresolutely about, sighing once or twice and glancing furtively and
+wistfully toward Tom. Then she observed that now Tom was talking more
+particularly to Amy Lawrence than to any one else. She felt a sharp pang
+and grew disturbed and uneasy at once. She tried to go away, but her
+feet were treacherous, and carried her to the group instead. She said to
+a girl almost at Tom’s elbow--with sham vivacity:
+
+“Why, Mary Austin! you bad girl, why didn’t you come to Sunday-school?”
+
+“I did come--didn’t you see me?”
+
+“Why, no! Did you? Where did you sit?”
+
+“I was in Miss Peters’ class, where I always go. I saw _you_.”
+
+“Did you? Why, it’s funny I didn’t see you. I wanted to tell you about
+the picnic.”
+
+“Oh, that’s jolly. Who’s going to give it?”
+
+“My ma’s going to let me have one.”
+
+“Oh, goody; I hope she’ll let _me_ come.”
+
+“Well, she will. The picnic’s for me. She’ll let anybody come that I
+want, and I want you.”
+
+“That’s ever so nice. When is it going to be?”
+
+“By and by. Maybe about vacation.”
+
+“Oh, won’t it be fun! You going to have all the girls and boys?”
+
+“Yes, every one that’s friends to me--or wants to be”; and she glanced
+ever so furtively at Tom, but he talked right along to Amy Lawrence
+about the terrible storm on the island, and how the lightning tore the
+great sycamore tree “all to flinders” while he was “standing within
+three feet of it.”
+
+“Oh, may I come?” said Grace Miller.
+
+“Yes.”
+
+“And me?” said Sally Rogers.
+
+“Yes.”
+
+“And me, too?” said Susy Harper. “And Joe?”
+
+“Yes.”
+
+And so on, with clapping of joyful hands till all the group had begged
+for invitations but Tom and Amy. Then Tom turned coolly away, still
+talking, and took Amy with him. Becky’s lips trembled and the tears
+came to her eyes; she hid these signs with a forced gayety and went on
+chattering, but the life had gone out of the picnic, now, and out of
+everything else; she got away as soon as she could and hid herself and
+had what her sex call “a good cry.” Then she sat moody, with wounded
+pride, till the bell rang. She roused up, now, with a vindictive cast
+in her eye, and gave her plaited tails a shake and said she knew what
+_she’d_ do.
+
+At recess Tom continued his flirtation with Amy with jubilant
+self-satisfaction. And he kept drifting about to find Becky and lacerate
+her with the performance. At last he spied her, but there was a sudden
+falling of his mercury. She was sitting cosily on a little bench behind
+the schoolhouse looking at a picture-book with Alfred Temple--and so
+absorbed were they, and their heads so close together over the book,
+that they did not seem to be conscious of anything in the world besides.
+Jealousy ran red-hot through Tom’s veins. He began to hate himself for
+throwing away the chance Becky had offered for a reconciliation. He
+called himself a fool, and all the hard names he could think of. He
+wanted to cry with vexation. Amy chatted happily along, as they walked,
+for her heart was singing, but Tom’s tongue had lost its function. He
+did not hear what Amy was saying, and whenever she paused expectantly
+he could only stammer an awkward assent, which was as often misplaced
+as otherwise. He kept drifting to the rear of the schoolhouse, again and
+again, to sear his eyeballs with the hateful spectacle there. He could
+not help it. And it maddened him to see, as he thought he saw, that
+Becky Thatcher never once suspected that he was even in the land of the
+living. But she did see, nevertheless; and she knew she was winning her
+fight, too, and was glad to see him suffer as she had suffered.
+
+Amy’s happy prattle became intolerable. Tom hinted at things he had
+to attend to; things that must be done; and time was fleeting. But in
+vain--the girl chirped on. Tom thought, “Oh, hang her, ain’t I ever going
+to get rid of her?” At last he must be attending to those things--and she
+said artlessly that she would be “around” when school let out. And he
+hastened away, hating her for it.
+
+“Any other boy!” Tom thought, grating his teeth. “Any boy in the whole
+town but that Saint Louis smarty that thinks he dresses so fine and is
+aristocracy! Oh, all right, I licked you the first day you ever saw this
+town, mister, and I’ll lick you again! You just wait till I catch you
+out! I’ll just take and--”
+
+And he went through the motions of thrashing an imaginary boy--pummelling
+the air, and kicking and gouging. “Oh, you do, do you? You holler
+‘nough, do you? Now, then, let that learn you!” And so the imaginary
+flogging was finished to his satisfaction.
+
+Tom fled home at noon. His conscience could not endure any more of Amy’s
+grateful happiness, and his jealousy could bear no more of the other
+distress. Becky resumed her picture inspections with Alfred, but as the
+minutes dragged along and no Tom came to suffer, her triumph began to
+cloud and she lost interest; gravity and absentmindedness followed,
+and then melancholy; two or three times she pricked up her ear at
+a footstep, but it was a false hope; no Tom came. At last she grew
+entirely miserable and wished she hadn’t carried it so far. When
+poor Alfred, seeing that he was losing her, he did not know how, kept
+exclaiming: “Oh, here’s a jolly one! look at this!” she lost patience at
+last, and said, “Oh, don’t bother me! I don’t care for them!” and burst
+into tears, and got up and walked away.
+
+Alfred dropped alongside and was going to try to comfort her, but she
+said:
+
+“Go away and leave me alone, can’t you! I hate you!”
+
+So the boy halted, wondering what he could have done--for she had said
+she would look at pictures all through the nooning--and she walked on,
+crying. Then Alfred went musing into the deserted schoolhouse. He was
+humiliated and angry. He easily guessed his way to the truth--the girl
+had simply made a convenience of him to vent her spite upon Tom Sawyer.
+He was far from hating Tom the less when this thought occurred to him.
+He wished there was some way to get that boy into trouble without much
+risk to himself. Tom’s spelling-book fell under his eye. Here was his
+opportunity. He gratefully opened to the lesson for the afternoon and
+poured ink upon the page.
+
+Becky, glancing in at a window behind him at the moment, saw the act,
+and moved on, without discovering herself. She started homeward, now,
+intending to find Tom and tell him; Tom would be thankful and their
+troubles would be healed. Before she was half way home, however, she
+had changed her mind. The thought of Tom’s treatment of her when she was
+talking about her picnic came scorching back and filled her with shame.
+She resolved to let him get whipped on the damaged spelling-book’s
+account, and to hate him forever, into the bargain.
+
+
+
+
+CHAPTER XIX
+
+TOM arrived at home in a dreary mood, and the first thing his aunt said
+to him showed him that he had brought his sorrows to an unpromising
+market:
+
+“Tom, I’ve a notion to skin you alive!”
+
+“Auntie, what have I done?”
+
+“Well, you’ve done enough. Here I go over to Sereny Harper, like an old
+softy, expecting I’m going to make her believe all that rubbage about
+that dream, when lo and behold you she’d found out from Joe that you was
+over here and heard all the talk we had that night. Tom, I don’t know
+what is to become of a boy that will act like that. It makes me feel so
+bad to think you could let me go to Sereny Harper and make such a fool
+of myself and never say a word.”
+
+This was a new aspect of the thing. His smartness of the morning had
+seemed to Tom a good joke before, and very ingenious. It merely looked
+mean and shabby now. He hung his head and could not think of anything to
+say for a moment. Then he said:
+
+“Auntie, I wish I hadn’t done it--but I didn’t think.”
+
+“Oh, child, you never think. You never think of anything but your
+own selfishness. You could think to come all the way over here from
+Jackson’s Island in the night to laugh at our troubles, and you could
+think to fool me with a lie about a dream; but you couldn’t ever think
+to pity us and save us from sorrow.”
+
+“Auntie, I know now it was mean, but I didn’t mean to be mean. I didn’t,
+honest. And besides, I didn’t come over here to laugh at you that
+night.”
+
+“What did you come for, then?”
+
+“It was to tell you not to be uneasy about us, because we hadn’t got
+drownded.”
+
+“Tom, Tom, I would be the thankfullest soul in this world if I could
+believe you ever had as good a thought as that, but you know you never
+did--and I know it, Tom.”
+
+“Indeed and ‘deed I did, auntie--I wish I may never stir if I didn’t.”
+
+“Oh, Tom, don’t lie--don’t do it. It only makes things a hundred times
+worse.”
+
+“It ain’t a lie, auntie; it’s the truth. I wanted to keep you from
+grieving--that was all that made me come.”
+
+“I’d give the whole world to believe that--it would cover up a power
+of sins, Tom. I’d ‘most be glad you’d run off and acted so bad. But it
+ain’t reasonable; because, why didn’t you tell me, child?”
+
+“Why, you see, when you got to talking about the funeral, I just got all
+full of the idea of our coming and hiding in the church, and I couldn’t
+somehow bear to spoil it. So I just put the bark back in my pocket and
+kept mum.”
+
+“What bark?”
+
+“The bark I had wrote on to tell you we’d gone pirating. I wish, now,
+you’d waked up when I kissed you--I do, honest.”
+
+The hard lines in his aunt’s face relaxed and a sudden tenderness dawned
+in her eyes.
+
+“_Did_ you kiss me, Tom?”
+
+“Why, yes, I did.”
+
+“Are you sure you did, Tom?”
+
+“Why, yes, I did, auntie--certain sure.”
+
+“What did you kiss me for, Tom?”
+
+“Because I loved you so, and you laid there moaning and I was so sorry.”
+
+The words sounded like truth. The old lady could not hide a tremor in
+her voice when she said:
+
+“Kiss me again, Tom!--and be off with you to school, now, and don’t
+bother me any more.”
+
+The moment he was gone, she ran to a closet and got out the ruin of a
+jacket which Tom had gone pirating in. Then she stopped, with it in her
+hand, and said to herself:
+
+“No, I don’t dare. Poor boy, I reckon he’s lied about it--but it’s a
+blessed, blessed lie, there’s such a comfort come from it. I hope
+the Lord--I _know_ the Lord will forgive him, because it was such
+good-heartedness in him to tell it. But I don’t want to find out it’s a
+lie. I won’t look.”
+
+She put the jacket away, and stood by musing a minute. Twice she put out
+her hand to take the garment again, and twice she refrained. Once more
+she ventured, and this time she fortified herself with the thought:
+“It’s a good lie--it’s a good lie--I won’t let it grieve me.” So she
+sought the jacket pocket. A moment later she was reading Tom’s piece of
+bark through flowing tears and saying: “I could forgive the boy, now, if
+he’d committed a million sins!”
+
+
+
+
+CHAPTER XX
+
+THERE was something about Aunt Polly’s manner, when she kissed Tom, that
+swept away his low spirits and made him lighthearted and happy again. He
+started to school and had the luck of coming upon Becky Thatcher at the
+head of Meadow Lane. His mood always determined his manner. Without a
+moment’s hesitation he ran to her and said:
+
+“I acted mighty mean today, Becky, and I’m so sorry. I won’t ever, ever
+do that way again, as long as ever I live--please make up, won’t you?”
+
+The girl stopped and looked him scornfully in the face:
+
+“I’ll thank you to keep yourself _to_ yourself, Mr. Thomas Sawyer. I’ll
+never speak to you again.”
+
+She tossed her head and passed on. Tom was so stunned that he had not
+even presence of mind enough to say “Who cares, Miss Smarty?” until the
+right time to say it had gone by. So he said nothing. But he was in a
+fine rage, nevertheless. He moped into the schoolyard wishing she were
+a boy, and imagining how he would trounce her if she were. He presently
+encountered her and delivered a stinging remark as he passed. She hurled
+one in return, and the angry breach was complete. It seemed to Becky, in
+her hot resentment, that she could hardly wait for school to “take in,”
+ she was so impatient to see Tom flogged for the injured spelling-book.
+If she had had any lingering notion of exposing Alfred Temple, Tom’s
+offensive fling had driven it entirely away.
+
+Poor girl, she did not know how fast she was nearing trouble herself.
+The master, Mr. Dobbins, had reached middle age with an unsatisfied
+ambition. The darling of his desires was, to be a doctor, but
+poverty had decreed that he should be nothing higher than a village
+schoolmaster. Every day he took a mysterious book out of his desk and
+absorbed himself in it at times when no classes were reciting. He kept
+that book under lock and key. There was not an urchin in school but was
+perishing to have a glimpse of it, but the chance never came. Every boy
+and girl had a theory about the nature of that book; but no two theories
+were alike, and there was no way of getting at the facts in the case.
+Now, as Becky was passing by the desk, which stood near the door, she
+noticed that the key was in the lock! It was a precious moment. She
+glanced around; found herself alone, and the next instant she had the
+book in her hands. The titlepage--Professor Somebody’s _Anatomy_--carried
+no information to her mind; so she began to turn the leaves. She came at
+once upon a handsomely engraved and colored frontispiece--a human figure,
+stark naked. At that moment a shadow fell on the page and Tom Sawyer
+stepped in at the door and caught a glimpse of the picture. Becky
+snatched at the book to close it, and had the hard luck to tear the
+pictured page half down the middle. She thrust the volume into the desk,
+turned the key, and burst out crying with shame and vexation.
+
+“Tom Sawyer, you are just as mean as you can be, to sneak up on a person
+and look at what they’re looking at.”
+
+“How could I know you was looking at anything?”
+
+“You ought to be ashamed of yourself, Tom Sawyer; you know you’re
+going to tell on me, and oh, what shall I do, what shall I do! I’ll be
+whipped, and I never was whipped in school.”
+
+Then she stamped her little foot and said:
+
+“_Be_ so mean if you want to! I know something that’s going to happen.
+You just wait and you’ll see! Hateful, hateful, hateful!”--and she flung
+out of the house with a new explosion of crying.
+
+Tom stood still, rather flustered by this onslaught. Presently he said
+to himself:
+
+“What a curious kind of a fool a girl is! Never been licked in
+school! Shucks! What’s a licking! That’s just like a girl--they’re so
+thin-skinned and chicken-hearted. Well, of course I ain’t going to tell
+old Dobbins on this little fool, because there’s other ways of getting
+even on her, that ain’t so mean; but what of it? Old Dobbins will ask
+who it was tore his book. Nobody’ll answer. Then he’ll do just the way
+he always does--ask first one and then t’other, and when he comes to the
+right girl he’ll know it, without any telling. Girls’ faces always tell
+on them. They ain’t got any backbone. She’ll get licked. Well, it’s a
+kind of a tight place for Becky Thatcher, because there ain’t any way
+out of it.” Tom conned the thing a moment longer, and then added: “All
+right, though; she’d like to see me in just such a fix--let her sweat it
+out!”
+
+Tom joined the mob of skylarking scholars outside. In a few moments the
+master arrived and school “took in.” Tom did not feel a strong interest
+in his studies. Every time he stole a glance at the girls’ side of the
+room Becky’s face troubled him. Considering all things, he did not want
+to pity her, and yet it was all he could do to help it. He could get
+up no exultation that was really worthy the name. Presently the
+spelling-book discovery was made, and Tom’s mind was entirely full
+of his own matters for a while after that. Becky roused up from her
+lethargy of distress and showed good interest in the proceedings. She
+did not expect that Tom could get out of his trouble by denying that he
+spilt the ink on the book himself; and she was right. The denial only
+seemed to make the thing worse for Tom. Becky supposed she would be glad
+of that, and she tried to believe she was glad of it, but she found she
+was not certain. When the worst came to the worst, she had an impulse
+to get up and tell on Alfred Temple, but she made an effort and forced
+herself to keep still--because, said she to herself, “he’ll tell about me
+tearing the picture sure. I wouldn’t say a word, not to save his life!”
+
+Tom took his whipping and went back to his seat not at all
+broken-hearted, for he thought it was possible that he had unknowingly
+upset the ink on the spelling-book himself, in some skylarking bout--he
+had denied it for form’s sake and because it was custom, and had stuck
+to the denial from principle.
+
+A whole hour drifted by, the master sat nodding in his throne, the air
+was drowsy with the hum of study. By and by, Mr. Dobbins straightened
+himself up, yawned, then unlocked his desk, and reached for his book,
+but seemed undecided whether to take it out or leave it. Most of the
+pupils glanced up languidly, but there were two among them that watched
+his movements with intent eyes. Mr. Dobbins fingered his book absently
+for a while, then took it out and settled himself in his chair to read!
+Tom shot a glance at Becky. He had seen a hunted and helpless rabbit
+look as she did, with a gun levelled at its head. Instantly he forgot
+his quarrel with her. Quick--something must be done! done in a flash,
+too! But the very imminence of the emergency paralyzed his invention.
+Good!--he had an inspiration! He would run and snatch the book, spring
+through the door and fly. But his resolution shook for one little
+instant, and the chance was lost--the master opened the volume. If Tom
+only had the wasted opportunity back again! Too late. There was no help
+for Becky now, he said. The next moment the master faced the school.
+Every eye sank under his gaze. There was that in it which smote even
+the innocent with fear. There was silence while one might count ten--the
+master was gathering his wrath. Then he spoke: “Who tore this book?”
+
+There was not a sound. One could have heard a pin drop. The stillness
+continued; the master searched face after face for signs of guilt.
+
+“Benjamin Rogers, did you tear this book?”
+
+A denial. Another pause.
+
+“Joseph Harper, did you?”
+
+Another denial. Tom’s uneasiness grew more and more intense under the
+slow torture of these proceedings. The master scanned the ranks of
+boys--considered a while, then turned to the girls:
+
+“Amy Lawrence?”
+
+A shake of the head.
+
+“Gracie Miller?”
+
+The same sign.
+
+“Susan Harper, did you do this?”
+
+Another negative. The next girl was Becky Thatcher. Tom was trembling
+from head to foot with excitement and a sense of the hopelessness of the
+situation.
+
+“Rebecca Thatcher” [Tom glanced at her face--it was white with
+terror]--“did you tear--no, look me in the face” [her hands rose in
+appeal]--“did you tear this book?”
+
+A thought shot like lightning through Tom’s brain. He sprang to his feet
+and shouted--“I done it!”
+
+The school stared in perplexity at this incredible folly. Tom stood a
+moment, to gather his dismembered faculties; and when he stepped forward
+to go to his punishment the surprise, the gratitude, the adoration that
+shone upon him out of poor Becky’s eyes seemed pay enough for a hundred
+floggings. Inspired by the splendor of his own act, he took without
+an outcry the most merciless flaying that even Mr. Dobbins had ever
+administered; and also received with indifference the added cruelty of a
+command to remain two hours after school should be dismissed--for he
+knew who would wait for him outside till his captivity was done, and not
+count the tedious time as loss, either.
+
+Tom went to bed that night planning vengeance against Alfred Temple; for
+with shame and repentance Becky had told him all, not forgetting her own
+treachery; but even the longing for vengeance had to give way, soon, to
+pleasanter musings, and he fell asleep at last with Becky’s latest words
+lingering dreamily in his ear--
+
+“Tom, how _could_ you be so noble!”
+
+
+
+
+CHAPTER XXI
+
+VACATION was approaching. The schoolmaster, always severe, grew severer
+and more exacting than ever, for he wanted the school to make a good
+showing on “Examination” day. His rod and his ferule were seldom idle
+now--at least among the smaller pupils. Only the biggest boys, and young
+ladies of eighteen and twenty, escaped lashing. Mr. Dobbins’ lashings
+were very vigorous ones, too; for although he carried, under his wig, a
+perfectly bald and shiny head, he had only reached middle age, and there
+was no sign of feebleness in his muscle. As the great day approached,
+all the tyranny that was in him came to the surface; he seemed to take a
+vindictive pleasure in punishing the least shortcomings. The consequence
+was, that the smaller boys spent their days in terror and suffering and
+their nights in plotting revenge. They threw away no opportunity to do
+the master a mischief. But he kept ahead all the time. The retribution
+that followed every vengeful success was so sweeping and majestic that
+the boys always retired from the field badly worsted. At last they
+conspired together and hit upon a plan that promised a dazzling victory.
+They swore in the signpainter’s boy, told him the scheme, and asked his
+help. He had his own reasons for being delighted, for the master boarded
+in his father’s family and had given the boy ample cause to hate him.
+The master’s wife would go on a visit to the country in a few days, and
+there would be nothing to interfere with the plan; the master always
+prepared himself for great occasions by getting pretty well fuddled, and
+the signpainter’s boy said that when the dominie had reached the proper
+condition on Examination Evening he would “manage the thing” while he
+napped in his chair; then he would have him awakened at the right time
+and hurried away to school.
+
+In the fulness of time the interesting occasion arrived. At eight in
+the evening the schoolhouse was brilliantly lighted, and adorned with
+wreaths and festoons of foliage and flowers. The master sat throned in
+his great chair upon a raised platform, with his blackboard behind him.
+He was looking tolerably mellow. Three rows of benches on each side and
+six rows in front of him were occupied by the dignitaries of the town
+and by the parents of the pupils. To his left, back of the rows of
+citizens, was a spacious temporary platform upon which were seated the
+scholars who were to take part in the exercises of the evening; rows of
+small boys, washed and dressed to an intolerable state of discomfort;
+rows of gawky big boys; snowbanks of girls and young ladies clad in
+lawn and muslin and conspicuously conscious of their bare arms, their
+grandmothers’ ancient trinkets, their bits of pink and blue ribbon and
+the flowers in their hair. All the rest of the house was filled with
+non-participating scholars.
+
+The exercises began. A very little boy stood up and sheepishly recited,
+“You’d scarce expect one of my age to speak in public on the stage,”
+ etc.--accompanying himself with the painfully exact and spasmodic
+gestures which a machine might have used--supposing the machine to be a
+trifle out of order. But he got through safely, though cruelly scared,
+and got a fine round of applause when he made his manufactured bow and
+retired.
+
+A little shamefaced girl lisped, “Mary had a little lamb,” etc.,
+performed a compassion-inspiring curtsy, got her meed of applause, and
+sat down flushed and happy.
+
+Tom Sawyer stepped forward with conceited confidence and soared into
+the unquenchable and indestructible “Give me liberty or give me death”
+ speech, with fine fury and frantic gesticulation, and broke down in the
+middle of it. A ghastly stage-fright seized him, his legs quaked under
+him and he was like to choke. True, he had the manifest sympathy of the
+house but he had the house’s silence, too, which was even worse than
+its sympathy. The master frowned, and this completed the disaster. Tom
+struggled awhile and then retired, utterly defeated. There was a weak
+attempt at applause, but it died early.
+
+“The Boy Stood on the Burning Deck” followed; also “The Assyrian Came
+Down,” and other declamatory gems. Then there were reading exercises,
+and a spelling fight. The meagre Latin class recited with honor. The
+prime feature of the evening was in order, now--original “compositions”
+ by the young ladies. Each in her turn stepped forward to the edge of the
+platform, cleared her throat, held up her manuscript (tied with dainty
+ribbon), and proceeded to read, with labored attention to “expression”
+ and punctuation. The themes were the same that had been illuminated upon
+similar occasions by their mothers before them, their grandmothers,
+and doubtless all their ancestors in the female line clear back to the
+Crusades. “Friendship” was one; “Memories of Other Days”; “Religion in
+History”; “Dream Land”; “The Advantages of Culture”; “Forms of Political
+Government Compared and Contrasted”; “Melancholy”; “Filial Love”; “Heart
+Longings,” etc., etc.
+
+A prevalent feature in these compositions was a nursed and petted
+melancholy; another was a wasteful and opulent gush of “fine language”;
+another was a tendency to lug in by the ears particularly prized words
+and phrases until they were worn entirely out; and a peculiarity that
+conspicuously marked and marred them was the inveterate and intolerable
+sermon that wagged its crippled tail at the end of each and every one
+of them. No matter what the subject might be, a brainracking effort was
+made to squirm it into some aspect or other that the moral and religious
+mind could contemplate with edification. The glaring insincerity of
+these sermons was not sufficient to compass the banishment of the
+fashion from the schools, and it is not sufficient today; it never will
+be sufficient while the world stands, perhaps. There is no school in
+all our land where the young ladies do not feel obliged to close their
+compositions with a sermon; and you will find that the sermon of the
+most frivolous and the least religious girl in the school is always
+the longest and the most relentlessly pious. But enough of this. Homely
+truth is unpalatable.
+
+Let us return to the “Examination.” The first composition that was read
+was one entitled “Is this, then, Life?” Perhaps the reader can endure an
+extract from it:
+
+“In the common walks of life, with what delightful emotions does the
+youthful mind look forward to some anticipated scene of festivity!
+Imagination is busy sketching rose-tinted pictures of joy. In fancy, the
+voluptuous votary of fashion sees herself amid the festive throng, ‘the
+observed of all observers.’ Her graceful form, arrayed in snowy robes,
+is whirling through the mazes of the joyous dance; her eye is brightest,
+her step is lightest in the gay assembly.
+
+“In such delicious fancies time quickly glides by, and the welcome hour
+arrives for her entrance into the Elysian world, of which she has
+had such bright dreams. How fairy-like does everything appear to her
+enchanted vision! Each new scene is more charming than the last. But
+after a while she finds that beneath this goodly exterior, all is
+vanity, the flattery which once charmed her soul, now grates harshly
+upon her ear; the ballroom has lost its charms; and with wasted health
+and imbittered heart, she turns away with the conviction that earthly
+pleasures cannot satisfy the longings of the soul!”
+
+And so forth and so on. There was a buzz of gratification from time to
+time during the reading, accompanied by whispered ejaculations of “How
+sweet!” “How eloquent!” “So true!” etc., and after the thing had closed
+with a peculiarly afflicting sermon the applause was enthusiastic.
+
+Then arose a slim, melancholy girl, whose face had the “interesting”
+ paleness that comes of pills and indigestion, and read a “poem.” Two
+stanzas of it will do:
+
+“A MISSOURI MAIDEN’S FAREWELL TO ALABAMA
+
+“Alabama, goodbye! I love thee well! But yet for a while do I leave thee
+now! Sad, yes, sad thoughts of thee my heart doth swell, And burning
+recollections throng my brow! For I have wandered through thy flowery
+woods; Have roamed and read near Tallapoosa’s stream; Have listened to
+Tallassee’s warring floods, And wooed on Coosa’s side Aurora’s beam.
+
+“Yet shame I not to bear an o’erfull heart, Nor blush to turn behind
+my tearful eyes; ‘Tis from no stranger land I now must part, ‘Tis to no
+strangers left I yield these sighs. Welcome and home were mine within
+this State, Whose vales I leave--whose spires fade fast from me And cold
+must be mine eyes, and heart, and tete, When, dear Alabama! they turn
+cold on thee!” There were very few there who knew what “tete” meant, but
+the poem was very satisfactory, nevertheless.
+
+Next appeared a dark-complexioned, black-eyed, black-haired young lady,
+who paused an impressive moment, assumed a tragic expression, and began
+to read in a measured, solemn tone:
+
+“A VISION
+
+“Dark and tempestuous was night. Around the throne on high not a single
+star quivered; but the deep intonations of the heavy thunder constantly
+vibrated upon the ear; whilst the terrific lightning revelled in angry
+mood through the cloudy chambers of heaven, seeming to scorn the power
+exerted over its terror by the illustrious Franklin! Even the boisterous
+winds unanimously came forth from their mystic homes, and blustered
+about as if to enhance by their aid the wildness of the scene.
+
+“At such a time, so dark, so dreary, for human sympathy my very spirit
+sighed; but instead thereof,
+
+“‘My dearest friend, my counsellor, my comforter and guide--My joy in
+grief, my second bliss in joy,’ came to my side. She moved like one of
+those bright beings pictured in the sunny walks of fancy’s Eden by
+the romantic and young, a queen of beauty unadorned save by her own
+transcendent loveliness. So soft was her step, it failed to make even a
+sound, and but for the magical thrill imparted by her genial touch,
+as other unobtrusive beauties, she would have glided away
+unperceived--unsought. A strange sadness rested upon her features, like
+icy tears upon the robe of December, as she pointed to the contending
+elements without, and bade me contemplate the two beings presented.”
+
+This nightmare occupied some ten pages of manuscript and wound up with a
+sermon so destructive of all hope to non-Presbyterians that it took
+the first prize. This composition was considered to be the very finest
+effort of the evening. The mayor of the village, in delivering the prize
+to the author of it, made a warm speech in which he said that it was by
+far the most “eloquent” thing he had ever listened to, and that Daniel
+Webster himself might well be proud of it.
+
+It may be remarked, in passing, that the number of compositions in which
+the word “beauteous” was over-fondled, and human experience referred to
+as “life’s page,” was up to the usual average.
+
+Now the master, mellow almost to the verge of geniality, put his chair
+aside, turned his back to the audience, and began to draw a map of
+America on the blackboard, to exercise the geography class upon. But he
+made a sad business of it with his unsteady hand, and a smothered titter
+rippled over the house. He knew what the matter was, and set himself to
+right it. He sponged out lines and remade them; but he only distorted
+them more than ever, and the tittering was more pronounced. He threw his
+entire attention upon his work, now, as if determined not to be put down
+by the mirth. He felt that all eyes were fastened upon him; he imagined
+he was succeeding, and yet the tittering continued; it even manifestly
+increased. And well it might. There was a garret above, pierced with
+a scuttle over his head; and down through this scuttle came a cat,
+suspended around the haunches by a string; she had a rag tied about
+her head and jaws to keep her from mewing; as she slowly descended she
+curved upward and clawed at the string, she swung downward and clawed
+at the intangible air. The tittering rose higher and higher--the cat was
+within six inches of the absorbed teacher’s head--down, down, a little
+lower, and she grabbed his wig with her desperate claws, clung to it,
+and was snatched up into the garret in an instant with her trophy still
+in her possession! And how the light did blaze abroad from the master’s
+bald pate--for the signpainter’s boy had _gilded_ it!
+
+That broke up the meeting. The boys were avenged. Vacation had come.
+
+NOTE:--The pretended “compositions” quoted in this chapter are taken
+without alteration from a volume entitled “Prose and Poetry, by a
+Western Lady”--but they are exactly and precisely after the schoolgirl
+pattern, and hence are much happier than any mere imitations could be.
+
+
+
+
+CHAPTER XXII
+
+TOM joined the new order of Cadets of Temperance, being attracted by the
+showy character of their “regalia.” He promised to abstain from smoking,
+chewing, and profanity as long as he remained a member. Now he found out
+a new thing--namely, that to promise not to do a thing is the surest way
+in the world to make a body want to go and do that very thing. Tom soon
+found himself tormented with a desire to drink and swear; the desire
+grew to be so intense that nothing but the hope of a chance to display
+himself in his red sash kept him from withdrawing from the order. Fourth
+of July was coming; but he soon gave that up--gave it up before he had
+worn his shackles over forty-eight hours--and fixed his hopes upon old
+Judge Frazer, justice of the peace, who was apparently on his deathbed
+and would have a big public funeral, since he was so high an official.
+During three days Tom was deeply concerned about the Judge’s condition
+and hungry for news of it. Sometimes his hopes ran high--so high that
+he would venture to get out his regalia and practise before the
+looking-glass. But the Judge had a most discouraging way of fluctuating.
+At last he was pronounced upon the mend--and then convalescent. Tom was
+disgusted; and felt a sense of injury, too. He handed in his resignation
+at once--and that night the Judge suffered a relapse and died. Tom
+resolved that he would never trust a man like that again.
+
+The funeral was a fine thing. The Cadets paraded in a style calculated
+to kill the late member with envy. Tom was a free boy again,
+however--there was something in that. He could drink and swear, now--but
+found to his surprise that he did not want to. The simple fact that he
+could, took the desire away, and the charm of it.
+
+Tom presently wondered to find that his coveted vacation was beginning
+to hang a little heavily on his hands.
+
+He attempted a diary--but nothing happened during three days, and so he
+abandoned it.
+
+The first of all the negro minstrel shows came to town, and made a
+sensation. Tom and Joe Harper got up a band of performers and were happy
+for two days.
+
+Even the Glorious Fourth was in some sense a failure, for it rained
+hard, there was no procession in consequence, and the greatest man
+in the world (as Tom supposed), Mr. Benton, an actual United States
+Senator, proved an overwhelming disappointment--for he was not
+twenty-five feet high, nor even anywhere in the neighborhood of it.
+
+A circus came. The boys played circus for three days afterward in tents
+made of rag carpeting--admission, three pins for boys, two for girls--and
+then circusing was abandoned.
+
+A phrenologist and a mesmerizer came--and went again and left the village
+duller and drearier than ever.
+
+There were some boys-and-girls’ parties, but they were so few and so
+delightful that they only made the aching voids between ache the harder.
+
+Becky Thatcher was gone to her Constantinople home to stay with her
+parents during vacation--so there was no bright side to life anywhere.
+
+The dreadful secret of the murder was a chronic misery. It was a very
+cancer for permanency and pain.
+
+Then came the measles.
+
+During two long weeks Tom lay a prisoner, dead to the world and its
+happenings. He was very ill, he was interested in nothing. When he got
+upon his feet at last and moved feebly downtown, a melancholy change had
+come over everything and every creature. There had been a “revival,” and
+everybody had “got religion,” not only the adults, but even the boys and
+girls. Tom went about, hoping against hope for the sight of one blessed
+sinful face, but disappointment crossed him everywhere. He found Joe
+Harper studying a Testament, and turned sadly away from the depressing
+spectacle. He sought Ben Rogers, and found him visiting the poor with a
+basket of tracts. He hunted up Jim Hollis, who called his attention to
+the precious blessing of his late measles as a warning. Every boy
+he encountered added another ton to his depression; and when, in
+desperation, he flew for refuge at last to the bosom of Huckleberry Finn
+and was received with a Scriptural quotation, his heart broke and he
+crept home and to bed realizing that he alone of all the town was lost,
+forever and forever.
+
+And that night there came on a terrific storm, with driving rain, awful
+claps of thunder and blinding sheets of lightning. He covered his head
+with the bedclothes and waited in a horror of suspense for his doom; for
+he had not the shadow of a doubt that all this hubbub was about him.
+He believed he had taxed the forbearance of the powers above to the
+extremity of endurance and that this was the result. It might have
+seemed to him a waste of pomp and ammunition to kill a bug with a
+battery of artillery, but there seemed nothing incongruous about the
+getting up such an expensive thunderstorm as this to knock the turf from
+under an insect like himself.
+
+By and by the tempest spent itself and died without accomplishing its
+object. The boy’s first impulse was to be grateful, and reform. His
+second was to wait--for there might not be any more storms.
+
+The next day the doctors were back; Tom had relapsed. The three weeks he
+spent on his back this time seemed an entire age. When he got abroad
+at last he was hardly grateful that he had been spared, remembering how
+lonely was his estate, how companionless and forlorn he was. He drifted
+listlessly down the street and found Jim Hollis acting as judge in a
+juvenile court that was trying a cat for murder, in the presence of her
+victim, a bird. He found Joe Harper and Huck Finn up an alley eating a
+stolen melon. Poor lads! they--like Tom--had suffered a relapse.
+
+
+
+
+CHAPTER XXIII
+
+AT last the sleepy atmosphere was stirred--and vigorously: the murder
+trial came on in the court. It became the absorbing topic of village
+talk immediately. Tom could not get away from it. Every reference to
+the murder sent a shudder to his heart, for his troubled conscience
+and fears almost persuaded him that these remarks were put forth in
+his hearing as “feelers”; he did not see how he could be suspected of
+knowing anything about the murder, but still he could not be comfortable
+in the midst of this gossip. It kept him in a cold shiver all the time.
+He took Huck to a lonely place to have a talk with him. It would be some
+relief to unseal his tongue for a little while; to divide his burden of
+distress with another sufferer. Moreover, he wanted to assure himself
+that Huck had remained discreet.
+
+“Huck, have you ever told anybody about--that?”
+
+“‘Bout what?”
+
+“You know what.”
+
+“Oh--‘course I haven’t.”
+
+“Never a word?”
+
+“Never a solitary word, so help me. What makes you ask?”
+
+“Well, I was afeard.”
+
+“Why, Tom Sawyer, we wouldn’t be alive two days if that got found out.
+_You_ know that.”
+
+Tom felt more comfortable. After a pause:
+
+“Huck, they couldn’t anybody get you to tell, could they?”
+
+“Get me to tell? Why, if I wanted that halfbreed devil to drownd me they
+could get me to tell. They ain’t no different way.”
+
+“Well, that’s all right, then. I reckon we’re safe as long as we keep
+mum. But let’s swear again, anyway. It’s more surer.”
+
+“I’m agreed.”
+
+So they swore again with dread solemnities.
+
+“What is the talk around, Huck? I’ve heard a power of it.”
+
+“Talk? Well, it’s just Muff Potter, Muff Potter, Muff Potter all the
+time. It keeps me in a sweat, constant, so’s I want to hide som’ers.”
+
+“That’s just the same way they go on round me. I reckon he’s a goner.
+Don’t you feel sorry for him, sometimes?”
+
+“Most always--most always. He ain’t no account; but then he hain’t ever
+done anything to hurt anybody. Just fishes a little, to get money to
+get drunk on--and loafs around considerable; but lord, we all do
+that--leastways most of us--preachers and such like. But he’s kind of
+good--he give me half a fish, once, when there warn’t enough for two; and
+lots of times he’s kind of stood by me when I was out of luck.”
+
+“Well, he’s mended kites for me, Huck, and knitted hooks on to my line.
+I wish we could get him out of there.”
+
+“My! we couldn’t get him out, Tom. And besides, ‘twouldn’t do any good;
+they’d ketch him again.”
+
+“Yes--so they would. But I hate to hear ‘em abuse him so like the dickens
+when he never done--that.”
+
+“I do too, Tom. Lord, I hear ‘em say he’s the bloodiest looking villain
+in this country, and they wonder he wasn’t ever hung before.”
+
+“Yes, they talk like that, all the time. I’ve heard ‘em say that if he
+was to get free they’d lynch him.”
+
+“And they’d do it, too.”
+
+The boys had a long talk, but it brought them little comfort. As the
+twilight drew on, they found themselves hanging about the neighborhood
+of the little isolated jail, perhaps with an undefined hope that
+something would happen that might clear away their difficulties. But
+nothing happened; there seemed to be no angels or fairies interested in
+this luckless captive.
+
+The boys did as they had often done before--went to the cell grating and
+gave Potter some tobacco and matches. He was on the ground floor and
+there were no guards.
+
+His gratitude for their gifts had always smote their consciences
+before--it cut deeper than ever, this time. They felt cowardly and
+treacherous to the last degree when Potter said:
+
+“You’ve been mighty good to me, boys--better’n anybody else in this town.
+And I don’t forget it, I don’t. Often I says to myself, says I, ‘I used
+to mend all the boys’ kites and things, and show ‘em where the good
+fishin’ places was, and befriend ‘em what I could, and now they’ve
+all forgot old Muff when he’s in trouble; but Tom don’t, and Huck
+don’t--_they_ don’t forget him, says I, ‘and I don’t forget them.’ Well,
+boys, I done an awful thing--drunk and crazy at the time--that’s the only
+way I account for it--and now I got to swing for it, and it’s right.
+Right, and _best_, too, I reckon--hope so, anyway. Well, we won’t talk
+about that. I don’t want to make _you_ feel bad; you’ve befriended me.
+But what I want to say, is, don’t _you_ ever get drunk--then you won’t
+ever get here. Stand a litter furder west--so--that’s it; it’s a prime
+comfort to see faces that’s friendly when a body’s in such a muck
+of trouble, and there don’t none come here but yourn. Good friendly
+faces--good friendly faces. Git up on one another’s backs and let me
+touch ‘em. That’s it. Shake hands--yourn’ll come through the bars, but
+mine’s too big. Little hands, and weak--but they’ve helped Muff Potter a
+power, and they’d help him more if they could.”
+
+Tom went home miserable, and his dreams that night were full of horrors.
+The next day and the day after, he hung about the courtroom, drawn by an
+almost irresistible impulse to go in, but forcing himself to stay out.
+Huck was having the same experience. They studiously avoided each other.
+Each wandered away, from time to time, but the same dismal fascination
+always brought them back presently. Tom kept his ears open when idlers
+sauntered out of the courtroom, but invariably heard distressing
+news--the toils were closing more and more relentlessly around poor
+Potter. At the end of the second day the village talk was to the effect
+that Injun Joe’s evidence stood firm and unshaken, and that there was
+not the slightest question as to what the jury’s verdict would be.
+
+Tom was out late, that night, and came to bed through the window. He
+was in a tremendous state of excitement. It was hours before he got to
+sleep. All the village flocked to the courthouse the next morning, for
+this was to be the great day. Both sexes were about equally represented
+in the packed audience. After a long wait the jury filed in and took
+their places; shortly afterward, Potter, pale and haggard, timid and
+hopeless, was brought in, with chains upon him, and seated where all
+the curious eyes could stare at him; no less conspicuous was Injun Joe,
+stolid as ever. There was another pause, and then the judge arrived and
+the sheriff proclaimed the opening of the court. The usual whisperings
+among the lawyers and gathering together of papers followed. These
+details and accompanying delays worked up an atmosphere of preparation
+that was as impressive as it was fascinating.
+
+Now a witness was called who testified that he found Muff Potter washing
+in the brook, at an early hour of the morning that the murder was
+discovered, and that he immediately sneaked away. After some further
+questioning, counsel for the prosecution said:
+
+“Take the witness.”
+
+The prisoner raised his eyes for a moment, but dropped them again when
+his own counsel said:
+
+“I have no questions to ask him.”
+
+The next witness proved the finding of the knife near the corpse.
+Counsel for the prosecution said:
+
+“Take the witness.”
+
+“I have no questions to ask him,” Potter’s lawyer replied.
+
+A third witness swore he had often seen the knife in Potter’s
+possession.
+
+“Take the witness.”
+
+Counsel for Potter declined to question him. The faces of the audience
+began to betray annoyance. Did this attorney mean to throw away his
+client’s life without an effort?
+
+Several witnesses deposed concerning Potter’s guilty behavior when
+brought to the scene of the murder. They were allowed to leave the stand
+without being cross-questioned.
+
+Every detail of the damaging circumstances that occurred in the
+graveyard upon that morning which all present remembered so well was
+brought out by credible witnesses, but none of them were cross-examined
+by Potter’s lawyer. The perplexity and dissatisfaction of the house
+expressed itself in murmurs and provoked a reproof from the bench.
+Counsel for the prosecution now said:
+
+“By the oaths of citizens whose simple word is above suspicion, we have
+fastened this awful crime, beyond all possibility of question, upon the
+unhappy prisoner at the bar. We rest our case here.”
+
+A groan escaped from poor Potter, and he put his face in his hands and
+rocked his body softly to and fro, while a painful silence reigned
+in the courtroom. Many men were moved, and many women’s compassion
+testified itself in tears. Counsel for the defence rose and said:
+
+“Your honor, in our remarks at the opening of this trial, we
+foreshadowed our purpose to prove that our client did this fearful deed
+while under the influence of a blind and irresponsible delirium produced
+by drink. We have changed our mind. We shall not offer that plea.” [Then
+to the clerk:] “Call Thomas Sawyer!”
+
+A puzzled amazement awoke in every face in the house, not even excepting
+Potter’s. Every eye fastened itself with wondering interest upon Tom as
+he rose and took his place upon the stand. The boy looked wild enough,
+for he was badly scared. The oath was administered.
+
+“Thomas Sawyer, where were you on the seventeenth of June, about the
+hour of midnight?”
+
+Tom glanced at Injun Joe’s iron face and his tongue failed him. The
+audience listened breathless, but the words refused to come. After a few
+moments, however, the boy got a little of his strength back, and managed
+to put enough of it into his voice to make part of the house hear:
+
+“In the graveyard!”
+
+“A little bit louder, please. Don’t be afraid. You were--”
+
+“In the graveyard.”
+
+A contemptuous smile flitted across Injun Joe’s face.
+
+“Were you anywhere near Horse Williams’ grave?”
+
+“Yes, sir.”
+
+“Speak up--just a trifle louder. How near were you?”
+
+“Near as I am to you.”
+
+“Were you hidden, or not?”
+
+“I was hid.”
+
+“Where?”
+
+“Behind the elms that’s on the edge of the grave.”
+
+Injun Joe gave a barely perceptible start.
+
+“Any one with you?”
+
+“Yes, sir. I went there with--”
+
+“Wait--wait a moment. Never mind mentioning your companion’s name. We
+will produce him at the proper time. Did you carry anything there with
+you.”
+
+Tom hesitated and looked confused.
+
+“Speak out, my boy--don’t be diffident. The truth is always respectable.
+What did you take there?”
+
+“Only a--a--dead cat.”
+
+There was a ripple of mirth, which the court checked.
+
+“We will produce the skeleton of that cat. Now, my boy, tell us
+everything that occurred--tell it in your own way--don’t skip anything,
+and don’t be afraid.”
+
+Tom began--hesitatingly at first, but as he warmed to his subject his
+words flowed more and more easily; in a little while every sound ceased
+but his own voice; every eye fixed itself upon him; with parted lips and
+bated breath the audience hung upon his words, taking no note of time,
+rapt in the ghastly fascinations of the tale. The strain upon pent
+emotion reached its climax when the boy said:
+
+“--and as the doctor fetched the board around and Muff Potter fell, Injun
+Joe jumped with the knife and--”
+
+Crash! Quick as lightning the halfbreed sprang for a window, tore his
+way through all opposers, and was gone!
+
+
+
+
+CHAPTER XXIV
+
+TOM was a glittering hero once more--the pet of the old, the envy of the
+young. His name even went into immortal print, for the village paper
+magnified him. There were some that believed he would be President, yet,
+if he escaped hanging.
+
+As usual, the fickle, unreasoning world took Muff Potter to its bosom
+and fondled him as lavishly as it had abused him before. But that sort
+of conduct is to the world’s credit; therefore it is not well to find
+fault with it.
+
+Tom’s days were days of splendor and exultation to him, but his nights
+were seasons of horror. Injun Joe infested all his dreams, and always
+with doom in his eye. Hardly any temptation could persuade the boy
+to stir abroad after nightfall. Poor Huck was in the same state of
+wretchedness and terror, for Tom had told the whole story to the lawyer
+the night before the great day of the trial, and Huck was sore afraid
+that his share in the business might leak out, yet, notwithstanding
+Injun Joe’s flight had saved him the suffering of testifying in court.
+The poor fellow had got the attorney to promise secrecy, but what of
+that? Since Tom’s harassed conscience had managed to drive him to the
+lawyer’s house by night and wring a dread tale from lips that had
+been sealed with the dismalest and most formidable of oaths, Huck’s
+confidence in the human race was wellnigh obliterated.
+
+Daily Muff Potter’s gratitude made Tom glad he had spoken; but nightly
+he wished he had sealed up his tongue.
+
+Half the time Tom was afraid Injun Joe would never be captured; the
+other half he was afraid he would be. He felt sure he never could draw a
+safe breath again until that man was dead and he had seen the corpse.
+
+Rewards had been offered, the country had been scoured, but no Injun
+Joe was found. One of those omniscient and aweinspiring marvels, a
+detective, came up from St. Louis, moused around, shook his head, looked
+wise, and made that sort of astounding success which members of that
+craft usually achieve. That is to say, he “found a clew.” But you can’t
+hang a “clew” for murder, and so after that detective had got through
+and gone home, Tom felt just as insecure as he was before.
+
+The slow days drifted on, and each left behind it a slightly lightened
+weight of apprehension.
+
+
+
+
+CHAPTER XXV
+
+THERE comes a time in every rightly-constructed boy’s life when he has
+a raging desire to go somewhere and dig for hidden treasure. This desire
+suddenly came upon Tom one day. He sallied out to find Joe Harper,
+but failed of success. Next he sought Ben Rogers; he had gone fishing.
+Presently he stumbled upon Huck Finn the Red-Handed. Huck would
+answer. Tom took him to a private place and opened the matter to him
+confidentially. Huck was willing. Huck was always willing to take a hand
+in any enterprise that offered entertainment and required no capital,
+for he had a troublesome superabundance of that sort of time which is
+not money. “Where’ll we dig?” said Huck.
+
+“Oh, most anywhere.”
+
+“Why, is it hid all around?”
+
+“No, indeed it ain’t. It’s hid in mighty particular places,
+Huck--sometimes on islands, sometimes in rotten chests under the end of
+a limb of an old dead tree, just where the shadow falls at midnight; but
+mostly under the floor in ha’nted houses.”
+
+“Who hides it?”
+
+“Why, robbers, of course--who’d you reckon? Sunday-school
+sup’rintendents?”
+
+“I don’t know. If ‘twas mine I wouldn’t hide it; I’d spend it and have a
+good time.”
+
+“So would I. But robbers don’t do that way. They always hide it and
+leave it there.”
+
+“Don’t they come after it any more?”
+
+“No, they think they will, but they generally forget the marks, or else
+they die. Anyway, it lays there a long time and gets rusty; and by and
+by somebody finds an old yellow paper that tells how to find the marks--a
+paper that’s got to be ciphered over about a week because it’s mostly
+signs and hy’roglyphics.”
+
+“Hyro--which?”
+
+“Hy’roglyphics--pictures and things, you know, that don’t seem to mean
+anything.”
+
+“Have you got one of them papers, Tom?”
+
+“No.”
+
+“Well then, how you going to find the marks?”
+
+“I don’t want any marks. They always bury it under a ha’nted house or on
+an island, or under a dead tree that’s got one limb sticking out. Well,
+we’ve tried Jackson’s Island a little, and we can try it again some
+time; and there’s the old ha’nted house up the Still-House branch, and
+there’s lots of dead-limb trees--dead loads of ‘em.”
+
+“Is it under all of them?”
+
+“How you talk! No!”
+
+“Then how you going to know which one to go for?”
+
+“Go for all of ‘em!”
+
+“Why, Tom, it’ll take all summer.”
+
+“Well, what of that? Suppose you find a brass pot with a hundred dollars
+in it, all rusty and gray, or rotten chest full of di’monds. How’s
+that?”
+
+Huck’s eyes glowed.
+
+“That’s bully. Plenty bully enough for me. Just you gimme the hundred
+dollars and I don’t want no di’monds.”
+
+“All right. But I bet you I ain’t going to throw off on di’monds. Some
+of ‘em’s worth twenty dollars apiece--there ain’t any, hardly, but’s
+worth six bits or a dollar.”
+
+“No! Is that so?”
+
+“Cert’nly--anybody’ll tell you so. Hain’t you ever seen one, Huck?”
+
+“Not as I remember.”
+
+“Oh, kings have slathers of them.”
+
+“Well, I don’ know no kings, Tom.”
+
+“I reckon you don’t. But if you was to go to Europe you’d see a raft of
+‘em hopping around.”
+
+“Do they hop?”
+
+“Hop?--your granny! No!”
+
+“Well, what did you say they did, for?”
+
+“Shucks, I only meant you’d _see_ ‘em--not hopping, of course--what do
+they want to hop for?--but I mean you’d just see ‘em--scattered around,
+you know, in a kind of a general way. Like that old humpbacked Richard.”
+
+“Richard? What’s his other name?”
+
+“He didn’t have any other name. Kings don’t have any but a given name.”
+
+“No?”
+
+“But they don’t.”
+
+“Well, if they like it, Tom, all right; but I don’t want to be a king
+and have only just a given name, like a nigger. But say--where you going
+to dig first?”
+
+“Well, I don’t know. S’pose we tackle that old dead-limb tree on the
+hill t’other side of Still-House branch?”
+
+“I’m agreed.”
+
+So they got a crippled pick and a shovel, and set out on their
+three-mile tramp. They arrived hot and panting, and threw themselves
+down in the shade of a neighboring elm to rest and have a smoke.
+
+“I like this,” said Tom.
+
+“So do I.”
+
+“Say, Huck, if we find a treasure here, what you going to do with your
+share?”
+
+“Well, I’ll have pie and a glass of soda every day, and I’ll go to every
+circus that comes along. I bet I’ll have a gay time.”
+
+“Well, ain’t you going to save any of it?”
+
+“Save it? What for?”
+
+“Why, so as to have something to live on, by and by.”
+
+“Oh, that ain’t any use. Pap would come back to thish-yer town some day
+and get his claws on it if I didn’t hurry up, and I tell you he’d clean
+it out pretty quick. What you going to do with yourn, Tom?”
+
+“I’m going to buy a new drum, and a sure’nough sword, and a red necktie
+and a bull pup, and get married.”
+
+“Married!”
+
+“That’s it.”
+
+“Tom, you--why, you ain’t in your right mind.”
+
+“Wait--you’ll see.”
+
+“Well, that’s the foolishest thing you could do. Look at pap and my
+mother. Fight! Why, they used to fight all the time. I remember, mighty
+well.”
+
+“That ain’t anything. The girl I’m going to marry won’t fight.”
+
+“Tom, I reckon they’re all alike. They’ll all comb a body. Now you
+better think ‘bout this awhile. I tell you you better. What’s the name
+of the gal?”
+
+“It ain’t a gal at all--it’s a girl.”
+
+“It’s all the same, I reckon; some says gal, some says girl--both’s
+right, like enough. Anyway, what’s her name, Tom?”
+
+“I’ll tell you some time--not now.”
+
+“All right--that’ll do. Only if you get married I’ll be more lonesomer
+than ever.”
+
+“No you won’t. You’ll come and live with me. Now stir out of this and
+we’ll go to digging.”
+
+They worked and sweated for half an hour. No result. They toiled another
+halfhour. Still no result. Huck said:
+
+“Do they always bury it as deep as this?”
+
+“Sometimes--not always. Not generally. I reckon we haven’t got the right
+place.”
+
+So they chose a new spot and began again. The labor dragged a little,
+but still they made progress. They pegged away in silence for some time.
+Finally Huck leaned on his shovel, swabbed the beaded drops from his
+brow with his sleeve, and said:
+
+“Where you going to dig next, after we get this one?”
+
+“I reckon maybe we’ll tackle the old tree that’s over yonder on Cardiff
+Hill back of the widow’s.”
+
+“I reckon that’ll be a good one. But won’t the widow take it away from
+us, Tom? It’s on her land.”
+
+“_She_ take it away! Maybe she’d like to try it once. Whoever finds one
+of these hid treasures, it belongs to him. It don’t make any difference
+whose land it’s on.”
+
+That was satisfactory. The work went on. By and by Huck said:
+
+“Blame it, we must be in the wrong place again. What do you think?”
+
+“It is mighty curious, Huck. I don’t understand it. Sometimes witches
+interfere. I reckon maybe that’s what’s the trouble now.”
+
+“Shucks! Witches ain’t got no power in the daytime.”
+
+“Well, that’s so. I didn’t think of that. Oh, I know what the matter is!
+What a blamed lot of fools we are! You got to find out where the shadow
+of the limb falls at midnight, and that’s where you dig!”
+
+“Then consound it, we’ve fooled away all this work for nothing. Now hang
+it all, we got to come back in the night. It’s an awful long way. Can
+you get out?”
+
+“I bet I will. We’ve got to do it tonight, too, because if somebody sees
+these holes they’ll know in a minute what’s here and they’ll go for it.”
+
+“Well, I’ll come around and maow tonight.”
+
+“All right. Let’s hide the tools in the bushes.”
+
+The boys were there that night, about the appointed time. They sat in
+the shadow waiting. It was a lonely place, and an hour made solemn by
+old traditions. Spirits whispered in the rustling leaves, ghosts lurked
+in the murky nooks, the deep baying of a hound floated up out of the
+distance, an owl answered with his sepulchral note. The boys were
+subdued by these solemnities, and talked little. By and by they judged
+that twelve had come; they marked where the shadow fell, and began to
+dig. Their hopes commenced to rise. Their interest grew stronger, and
+their industry kept pace with it. The hole deepened and still deepened,
+but every time their hearts jumped to hear the pick strike upon
+something, they only suffered a new disappointment. It was only a stone
+or a chunk. At last Tom said:
+
+“It ain’t any use, Huck, we’re wrong again.”
+
+“Well, but we _can’t_ be wrong. We spotted the shadder to a dot.”
+
+“I know it, but then there’s another thing.”
+
+“What’s that?”.
+
+“Why, we only guessed at the time. Like enough it was too late or too
+early.”
+
+Huck dropped his shovel.
+
+“That’s it,” said he. “That’s the very trouble. We got to give this one
+up. We can’t ever tell the right time, and besides this kind of thing’s
+too awful, here this time of night with witches and ghosts a-fluttering
+around so. I feel as if something’s behind me all the time;  and I’m
+afeard to turn around, becuz maybe there’s others in front a-waiting for
+a chance. I been creeping all over, ever since I got here.”
+
+“Well, I’ve been pretty much so, too, Huck. They most always put in a
+dead man when they bury a treasure under a tree, to look out for it.”
+
+“Lordy!”
+
+“Yes, they do. I’ve always heard that.”
+
+“Tom, I don’t like to fool around much where there’s dead people. A
+body’s bound to get into trouble with ‘em, sure.”
+
+“I don’t like to stir ‘em up, either. S’pose this one here was to stick
+his skull out and say something!”
+
+“Don’t Tom! It’s awful.”
+
+“Well, it just is. Huck, I don’t feel comfortable a bit.”
+
+“Say, Tom, let’s give this place up, and try somewheres else.”
+
+“All right, I reckon we better.”
+
+“What’ll it be?”
+
+Tom considered awhile; and then said:
+
+“The ha’nted house. That’s it!”
+
+“Blame it, I don’t like ha’nted houses, Tom. Why, they’re a dern sight
+worse’n dead people. Dead people might talk, maybe, but they don’t come
+sliding around in a shroud, when you ain’t noticing, and peep over your
+shoulder all of a sudden and grit their teeth, the way a ghost does. I
+couldn’t stand such a thing as that, Tom--nobody could.”
+
+“Yes, but, Huck, ghosts don’t travel around only at night. They won’t
+hender us from digging there in the daytime.”
+
+“Well, that’s so. But you know mighty well people don’t go about that
+ha’nted house in the day nor the night.”
+
+“Well, that’s mostly because they don’t like to go where a man’s been
+murdered, anyway--but nothing’s ever been seen around that house except
+in the night--just some blue lights slipping by the windows--no regular
+ghosts.”
+
+“Well, where you see one of them blue lights flickering around, Tom,
+you can bet there’s a ghost mighty close behind it. It stands to reason.
+Becuz you know that they don’t anybody but ghosts use ‘em.”
+
+“Yes, that’s so. But anyway they don’t come around in the daytime, so
+what’s the use of our being afeard?”
+
+“Well, all right. We’ll tackle the ha’nted house if you say so--but I
+reckon it’s taking chances.”
+
+They had started down the hill by this time. There in the middle of the
+moonlit valley below them stood the “ha’nted” house, utterly isolated,
+its fences gone long ago, rank weeds smothering the very doorsteps, the
+chimney crumbled to ruin, the window-sashes vacant, a corner of the roof
+caved in. The boys gazed awhile, half expecting to see a blue light flit
+past a window; then talking in a low tone, as befitted the time and the
+circumstances, they struck far off to the right, to give the haunted
+house a wide berth, and took their way homeward through the woods that
+adorned the rearward side of Cardiff Hill.
+
+
+
+
+CHAPTER XVI
+
+ABOUT noon the next day the boys arrived at the dead tree; they had come
+for their tools. Tom was impatient to go to the haunted house; Huck was
+measurably so, also--but suddenly said:
+
+“Lookyhere, Tom, do you know what day it is?”
+
+Tom mentally ran over the days of the week, and then quickly lifted his
+eyes with a startled look in them--
+
+“My! I never once thought of it, Huck!”
+
+“Well, I didn’t neither, but all at once it popped onto me that it was
+Friday.”
+
+“Blame it, a body can’t be too careful, Huck. We might ‘a’ got into an
+awful scrape, tackling such a thing on a Friday.”
+
+“_Might_! Better say we _would_! There’s some lucky days, maybe, but
+Friday ain’t.”
+
+“Any fool knows that. I don’t reckon _you_ was the first that found it
+out, Huck.”
+
+“Well, I never said I was, did I? And Friday ain’t all, neither. I had a
+rotten bad dream last night--dreampt about rats.”
+
+“No! Sure sign of trouble. Did they fight?”
+
+“No.”
+
+“Well, that’s good, Huck. When they don’t fight it’s only a sign that
+there’s trouble around, you know. All we got to do is to look mighty
+sharp and keep out of it. We’ll drop this thing for today, and play. Do
+you know Robin Hood, Huck?”
+
+“No. Who’s Robin Hood?”
+
+“Why, he was one of the greatest men that was ever in England--and the
+best. He was a robber.”
+
+“Cracky, I wisht I was. Who did he rob?”
+
+“Only sheriffs and bishops and rich people and kings, and such like. But
+he never bothered the poor. He loved ‘em. He always divided up with ‘em
+perfectly square.”
+
+“Well, he must ‘a’ been a brick.”
+
+“I bet you he was, Huck. Oh, he was the noblest man that ever was.
+They ain’t any such men now, I can tell you. He could lick any man in
+England, with one hand tied behind him; and he could take his yew bow
+and plug a ten-cent piece every time, a mile and a half.”
+
+“What’s a _yew_ bow?”
+
+“I don’t know. It’s some kind of a bow, of course. And if he hit that
+dime only on the edge he would set down and cry--and curse. But we’ll
+play Robin Hood--it’s nobby fun. I’ll learn you.”
+
+“I’m agreed.”
+
+So they played Robin Hood all the afternoon, now and then casting a
+yearning eye down upon the haunted house and passing a remark about the
+morrow’s prospects and possibilities there. As the sun began to sink
+into the west they took their way homeward athwart the long shadows
+of the trees and soon were buried from sight in the forests of Cardiff
+Hill.
+
+On Saturday, shortly after noon, the boys were at the dead tree again.
+They had a smoke and a chat in the shade, and then dug a little in their
+last hole, not with great hope, but merely because Tom said there were
+so many cases where people had given up a treasure after getting down
+within six inches of it, and then somebody else had come along and
+turned it up with a single thrust of a shovel. The thing failed this
+time, however, so the boys shouldered their tools and went away feeling
+that they had not trifled with fortune, but had fulfilled all the
+requirements that belong to the business of treasure-hunting.
+
+When they reached the haunted house there was something so weird and
+grisly about the dead silence that reigned there under the baking sun,
+and something so depressing about the loneliness and desolation of the
+place, that they were afraid, for a moment, to venture in. Then they
+crept to the door and took a trembling peep. They saw a weedgrown,
+floorless room, unplastered, an ancient fireplace, vacant windows,
+a ruinous staircase; and here, there, and everywhere hung ragged and
+abandoned cobwebs. They presently entered, softly, with quickened
+pulses, talking in whispers, ears alert to catch the slightest sound,
+and muscles tense and ready for instant retreat.
+
+In a little while familiarity modified their fears and they gave the
+place a critical and interested examination, rather admiring their own
+boldness, and wondering at it, too. Next they wanted to look upstairs.
+This was something like cutting off retreat, but they got to daring
+each other, and of course there could be but one result--they threw their
+tools into a corner and made the ascent. Up there were the same signs of
+decay. In one corner they found a closet that promised mystery, but the
+promise was a fraud--there was nothing in it. Their courage was up now
+and well in hand. They were about to go down and begin work when--
+
+“Sh!” said Tom.
+
+“What is it?” whispered Huck, blanching with fright.
+
+“Sh!... There!... Hear it?”
+
+“Yes!... Oh, my! Let’s run!”
+
+“Keep still! Don’t you budge! They’re coming right toward the door.”
+
+The boys stretched themselves upon the floor with their eyes to
+knotholes in the planking, and lay waiting, in a misery of fear.
+
+“They’ve stopped.... No--coming.... Here they are. Don’t whisper another
+word, Huck. My goodness, I wish I was out of this!”
+
+Two men entered. Each boy said to himself: “There’s the old deaf and
+dumb Spaniard that’s been about town once or twice lately--never saw
+t’other man before.”
+
+“T’other” was a ragged, unkempt creature, with nothing very pleasant
+in his face. The Spaniard was wrapped in a serape; he had bushy white
+whiskers; long white hair flowed from under his sombrero, and he wore
+green goggles. When they came in, “t’other” was talking in a low voice;
+they sat down on the ground, facing the door, with their backs to the
+wall, and the speaker continued his remarks. His manner became less
+guarded and his words more distinct as he proceeded:
+
+“No,” said he, “I’ve thought it all over, and I don’t like it. It’s
+dangerous.”
+
+“Dangerous!” grunted the “deaf and dumb” Spaniard--to the vast surprise
+of the boys. “Milksop!”
+
+This voice made the boys gasp and quake. It was Injun Joe’s! There was
+silence for some time. Then Joe said:
+
+“What’s any more dangerous than that job up yonder--but nothing’s come of
+it.”
+
+“That’s different. Away up the river so, and not another house about.
+‘Twon’t ever be known that we tried, anyway, long as we didn’t succeed.”
+
+“Well, what’s more dangerous than coming here in the daytime!--anybody
+would suspicion us that saw us.”
+
+“I know that. But there warn’t any other place as handy after that fool
+of a job. I want to quit this shanty. I wanted to yesterday, only it
+warn’t any use trying to stir out of here, with those infernal boys
+playing over there on the hill right in full view.”
+
+“Those infernal boys” quaked again under the inspiration of this remark,
+and thought how lucky it was that they had remembered it was Friday and
+concluded to wait a day. They wished in their hearts they had waited a
+year.
+
+The two men got out some food and made a luncheon. After a long and
+thoughtful silence, Injun Joe said:
+
+“Look here, lad--you go back up the river where you belong. Wait there
+till you hear from me. I’ll take the chances on dropping into this town
+just once more, for a look. We’ll do that ‘dangerous’ job after I’ve
+spied around a little and think things look well for it. Then for Texas!
+We’ll leg it together!”
+
+This was satisfactory. Both men presently fell to yawning, and Injun Joe
+said:
+
+“I’m dead for sleep! It’s your turn to watch.”
+
+He curled down in the weeds and soon began to snore. His comrade stirred
+him once or twice and he became quiet. Presently the watcher began to
+nod; his head drooped lower and lower, both men began to snore now.
+
+The boys drew a long, grateful breath. Tom whispered:
+
+“Now’s our chance--come!”
+
+Huck said:
+
+“I can’t--I’d die if they was to wake.”
+
+Tom urged--Huck held back. At last Tom rose slowly and softly, and
+started alone. But the first step he made wrung such a hideous creak
+from the crazy floor that he sank down almost dead with fright. He never
+made a second attempt. The boys lay there counting the dragging moments
+till it seemed to them that time must be done and eternity growing gray;
+and then they were grateful to note that at last the sun was setting.
+
+Now one snore ceased. Injun Joe sat up, stared around--smiled grimly upon
+his comrade, whose head was drooping upon his knees--stirred him up with
+his foot and said:
+
+“Here! _You’re_ a watchman, ain’t you! All right, though--nothing’s
+happened.”
+
+“My! have I been asleep?”
+
+“Oh, partly, partly. Nearly time for us to be moving, pard. What’ll we
+do with what little swag we’ve got left?”
+
+“I don’t know--leave it here as we’ve always done, I reckon. No use to
+take it away till we start south. Six hundred and fifty in silver’s
+something to carry.”
+
+“Well--all right--it won’t matter to come here once more.”
+
+“No--but I’d say come in the night as we used to do--it’s better.”
+
+“Yes: but look here; it may be a good while before I get the right
+chance at that job; accidents might happen; ‘tain’t in such a very good
+place; we’ll just regularly bury it--and bury it deep.”
+
+“Good idea,” said the comrade, who walked across the room, knelt down,
+raised one of the rearward hearth-stones and took out a bag that jingled
+pleasantly. He subtracted from it twenty or thirty dollars for himself
+and as much for Injun Joe, and passed the bag to the latter, who was on
+his knees in the corner, now, digging with his bowie-knife.
+
+The boys forgot all their fears, all their miseries in an instant. With
+gloating eyes they watched every movement. Luck!--the splendor of it was
+beyond all imagination! Six hundred dollars was money enough to make
+half a dozen boys rich! Here was treasure-hunting under the happiest
+auspices--there would not be any bothersome uncertainty as to where to
+dig. They nudged each other every moment--eloquent nudges and easily
+understood, for they simply meant--“Oh, but ain’t you glad _now_ we’re
+here!”
+
+Joe’s knife struck upon something.
+
+“Hello!” said he.
+
+“What is it?” said his comrade.
+
+“Half-rotten plank--no, it’s a box, I believe. Here--bear a hand and we’ll
+see what it’s here for. Never mind, I’ve broke a hole.”
+
+He reached his hand in and drew it out--
+
+“Man, it’s money!”
+
+The two men examined the handful of coins. They were gold. The boys
+above were as excited as themselves, and as delighted.
+
+Joe’s comrade said:
+
+“We’ll make quick work of this. There’s an old rusty pick over amongst
+the weeds in the corner the other side of the fireplace--I saw it a
+minute ago.”
+
+He ran and brought the boys’ pick and shovel. Injun Joe took the
+pick, looked it over critically, shook his head, muttered something to
+himself, and then began to use it. The box was soon unearthed. It was
+not very large; it was iron bound and had been very strong before the
+slow years had injured it. The men contemplated the treasure awhile in
+blissful silence.
+
+“Pard, there’s thousands of dollars here,” said Injun Joe.
+
+“‘Twas always said that Murrel’s gang used to be around here one
+summer,” the stranger observed.
+
+“I know it,” said Injun Joe; “and this looks like it, I should say.”
+
+“Now you won’t need to do that job.”
+
+The halfbreed frowned. Said he:
+
+“You don’t know me. Least you don’t know all about that thing. ‘Tain’t
+robbery altogether--it’s _revenge_!” and a wicked light flamed in his
+eyes. “I’ll need your help in it. When it’s finished--then Texas. Go home
+to your Nance and your kids, and stand by till you hear from me.”
+
+“Well--if you say so; what’ll we do with this--bury it again?”
+
+“Yes. [Ravishing delight overhead.] _No_! by the great Sachem, no!
+[Profound distress overhead.] I’d nearly forgot. That pick had fresh
+earth on it! [The boys were sick with terror in a moment.] What business
+has a pick and a shovel here? What business with fresh earth on
+them? Who brought them here--and where are they gone? Have you heard
+anybody?--seen anybody? What! bury it again and leave them to come and
+see the ground disturbed? Not exactly--not exactly. We’ll take it to my
+den.”
+
+“Why, of course! Might have thought of that before. You mean Number
+One?”
+
+“No--Number Two--under the cross. The other place is bad--too common.”
+
+“All right. It’s nearly dark enough to start.”
+
+Injun Joe got up and went about from window to window cautiously peeping
+out. Presently he said:
+
+“Who could have brought those tools here? Do you reckon they can be
+upstairs?”
+
+The boys’ breath forsook them. Injun Joe put his hand on his knife,
+halted a moment, undecided, and then turned toward the stairway. The
+boys thought of the closet, but their strength was gone. The steps came
+creaking up the stairs--the intolerable distress of the situation woke
+the stricken resolution of the lads--they were about to spring for the
+closet, when there was a crash of rotten timbers and Injun Joe landed on
+the ground amid the debris of the ruined stairway. He gathered himself
+up cursing, and his comrade said:
+
+“Now what’s the use of all that? If it’s anybody, and they’re up there,
+let them _stay_ there--who cares? If they want to jump down, now, and get
+into trouble, who objects? It will be dark in fifteen minutes--and then
+let them follow us if they want to. I’m willing. In my opinion, whoever
+hove those things in here caught a sight of us and took us for ghosts or
+devils or something. I’ll bet they’re running yet.”
+
+Joe grumbled awhile; then he agreed with his friend that what daylight
+was left ought to be economized in getting things ready for leaving.
+Shortly afterward they slipped out of the house in the deepening
+twilight, and moved toward the river with their precious box.
+
+Tom and Huck rose up, weak but vastly relieved, and stared after them
+through the chinks between the logs of the house. Follow? Not they. They
+were content to reach ground again without broken necks, and take the
+townward track over the hill. They did not talk much. They were too much
+absorbed in hating themselves--hating the ill luck that made them take
+the spade and the pick there. But for that, Injun Joe never would have
+suspected. He would have hidden the silver with the gold to wait
+there till his “revenge” was satisfied, and then he would have had the
+misfortune to find that money turn up missing. Bitter, bitter luck that
+the tools were ever brought there!
+
+They resolved to keep a lookout for that Spaniard when he should come to
+town spying out for chances to do his revengeful job, and follow him to
+“Number Two,” wherever that might be. Then a ghastly thought occurred to
+Tom.
+
+“Revenge? What if he means _us_, Huck!”
+
+“Oh, don’t!” said Huck, nearly fainting.
+
+They talked it all over, and as they entered town they agreed to believe
+that he might possibly mean somebody else--at least that he might at
+least mean nobody but Tom, since only Tom had testified.
+
+Very, very small comfort it was to Tom to be alone in danger! Company
+would be a palpable improvement, he thought.
+
+
+
+
+CHAPTER XXVII
+
+THE adventure of the day mightily tormented Tom’s dreams that night.
+Four times he had his hands on that rich treasure and four times
+it wasted to nothingness in his fingers as sleep forsook him and
+wakefulness brought back the hard reality of his misfortune. As he lay
+in the early morning recalling the incidents of his great adventure, he
+noticed that they seemed curiously subdued and far away--somewhat as if
+they had happened in another world, or in a time long gone by. Then it
+occurred to him that the great adventure itself must be a dream! There
+was one very strong argument in favor of this idea--namely, that the
+quantity of coin he had seen was too vast to be real. He had never seen
+as much as fifty dollars in one mass before, and he was like all boys of
+his age and station in life, in that he imagined that all references to
+“hundreds” and “thousands” were mere fanciful forms of speech, and that
+no such sums really existed in the world. He never had supposed for
+a moment that so large a sum as a hundred dollars was to be found in
+actual money in any one’s possession. If his notions of hidden treasure
+had been analyzed, they would have been found to consist of a handful of
+real dimes and a bushel of vague, splendid, ungraspable dollars.
+
+But the incidents of his adventure grew sensibly sharper and clearer
+under the attrition of thinking them over, and so he presently found
+himself leaning to the impression that the thing might not have been a
+dream, after all. This uncertainty must be swept away. He would snatch a
+hurried breakfast and go and find Huck. Huck was sitting on the gunwale
+of a flatboat, listlessly dangling his feet in the water and looking
+very melancholy. Tom concluded to let Huck lead up to the subject. If
+he did not do it, then the adventure would be proved to have been only a
+dream.
+
+“Hello, Huck!”
+
+“Hello, yourself.”
+
+Silence, for a minute.
+
+“Tom, if we’d ‘a’ left the blame tools at the dead tree, we’d ‘a’ got
+the money. Oh, ain’t it awful!”
+
+“‘Tain’t a dream, then, ‘tain’t a dream! Somehow I most wish it was.
+Dog’d if I don’t, Huck.”
+
+“What ain’t a dream?”
+
+“Oh, that thing yesterday. I been half thinking it was.”
+
+“Dream! If them stairs hadn’t broke down you’d ‘a’ seen how much dream
+it was! I’ve had dreams enough all night--with that patch-eyed Spanish
+devil going for me all through ‘em--rot him!”
+
+“No, not rot him. _Find_ him! Track the money!”
+
+“Tom, we’ll never find him. A feller don’t have only one chance for such
+a pile--and that one’s lost. I’d feel mighty shaky if I was to see him,
+anyway.”
+
+“Well, so’d I; but I’d like to see him, anyway--and track him out--to his
+Number Two.”
+
+“Number Two--yes, that’s it. I been thinking ‘bout that. But I can’t make
+nothing out of it. What do you reckon it is?”
+
+“I dono. It’s too deep. Say, Huck--maybe it’s the number of a house!”
+
+“Goody!... No, Tom, that ain’t it. If it is, it ain’t in this one-horse
+town. They ain’t no numbers here.”
+
+“Well, that’s so. Lemme think a minute. Here--it’s the number of a
+room--in a tavern, you know!”
+
+“Oh, that’s the trick! They ain’t only two taverns. We can find out
+quick.”
+
+“You stay here, Huck, till I come.”
+
+Tom was off at once. He did not care to have Huck’s company in public
+places. He was gone half an hour. He found that in the best tavern, No.
+2 had long been occupied by a young lawyer, and was still so occupied.
+In the less ostentatious house, No. 2 was a mystery. The tavern-keeper’s
+young son said it was kept locked all the time, and he never saw anybody
+go into it or come out of it except at night; he did not know any
+particular reason for this state of things; had had some little
+curiosity, but it was rather feeble; had made the most of the mystery
+by entertaining himself with the idea that that room was “ha’nted”; had
+noticed that there was a light in there the night before.
+
+“That’s what I’ve found out, Huck. I reckon that’s the very No. 2 we’re
+after.”
+
+“I reckon it is, Tom. Now what you going to do?”
+
+“Lemme think.”
+
+Tom thought a long time. Then he said:
+
+“I’ll tell you. The back door of that No. 2 is the door that comes out
+into that little close alley between the tavern and the old rattle trap
+of a brick store. Now you get hold of all the doorkeys you can find, and
+I’ll nip all of auntie’s, and the first dark night we’ll go there and
+try ‘em. And mind you, keep a lookout for Injun Joe, because he said he
+was going to drop into town and spy around once more for a chance to get
+his revenge. If you see him, you just follow him; and if he don’t go to
+that No. 2, that ain’t the place.”
+
+“Lordy, I don’t want to foller him by myself!”
+
+“Why, it’ll be night, sure. He mightn’t ever see you--and if he did,
+maybe he’d never think anything.”
+
+“Well, if it’s pretty dark I reckon I’ll track him. I dono--I dono. I’ll
+try.”
+
+“You bet I’ll follow him, if it’s dark, Huck. Why, he might ‘a’ found
+out he couldn’t get his revenge, and be going right after that money.”
+
+“It’s so, Tom, it’s so. I’ll foller him; I will, by jingoes!”
+
+“Now you’re _talking_! Don’t you ever weaken, Huck, and I won’t.”
+
+
+
+
+CHAPTER XXVIII
+
+THAT night Tom and Huck were ready for their adventure. They hung about
+the neighborhood of the tavern until after nine, one watching the alley
+at a distance and the other the tavern door. Nobody entered the alley or
+left it; nobody resembling the Spaniard entered or left the tavern
+door. The night promised to be a fair one; so Tom went home with the
+understanding that if a considerable degree of darkness came on, Huck
+was to come and “maow,” whereupon he would slip out and try the keys.
+But the night remained clear, and Huck closed his watch and retired to
+bed in an empty sugar hogshead about twelve.
+
+Tuesday the boys had the same ill luck. Also Wednesday. But Thursday
+night promised better. Tom slipped out in good season with his aunt’s
+old tin lantern, and a large towel to blindfold it with. He hid the
+lantern in Huck’s sugar hogshead and the watch began. An hour before
+midnight the tavern closed up and its lights (the only ones thereabouts)
+were put out. No Spaniard had been seen. Nobody had entered or left the
+alley. Everything was auspicious. The blackness of darkness reigned,
+the perfect stillness was interrupted only by occasional mutterings of
+distant thunder.
+
+Tom got his lantern, lit it in the hogshead, wrapped it closely in the
+towel, and the two adventurers crept in the gloom toward the tavern.
+Huck stood sentry and Tom felt his way into the alley. Then there was
+a season of waiting anxiety that weighed upon Huck’s spirits like a
+mountain. He began to wish he could see a flash from the lantern--it
+would frighten him, but it would at least tell him that Tom was alive
+yet. It seemed hours since Tom had disappeared. Surely he must have
+fainted; maybe he was dead; maybe his heart had burst under terror and
+excitement. In his uneasiness Huck found himself drawing closer
+and closer to the alley; fearing all sorts of dreadful things, and
+momentarily expecting some catastrophe to happen that would take away
+his breath. There was not much to take away, for he seemed only able to
+inhale it by thimblefuls, and his heart would soon wear itself out, the
+way it was beating. Suddenly there was a flash of light and Tom came
+tearing by him: “Run!” said he; “run, for your life!”
+
+He needn’t have repeated it; once was enough; Huck was making thirty or
+forty miles an hour before the repetition was uttered. The boys never
+stopped till they reached the shed of a deserted slaughter-house at the
+lower end of the village. Just as they got within its shelter the storm
+burst and the rain poured down. As soon as Tom got his breath he said:
+
+“Huck, it was awful! I tried two of the keys, just as soft as I could;
+but they seemed to make such a power of racket that I couldn’t hardly
+get my breath I was so scared. They wouldn’t turn in the lock, either.
+Well, without noticing what I was doing, I took hold of the knob, and
+open comes the door! It warn’t locked! I hopped in, and shook off the
+towel, and, _Great Caesar’s Ghost!_”
+
+“What!--what’d you see, Tom?”
+
+“Huck, I most stepped onto Injun Joe’s hand!”
+
+“No!”
+
+“Yes! He was lying there, sound asleep on the floor, with his old patch
+on his eye and his arms spread out.”
+
+“Lordy, what did you do? Did he wake up?”
+
+“No, never budged. Drunk, I reckon. I just grabbed that towel and
+started!”
+
+“I’d never ‘a’ thought of the towel, I bet!”
+
+“Well, I would. My aunt would make me mighty sick if I lost it.”
+
+“Say, Tom, did you see that box?”
+
+“Huck, I didn’t wait to look around. I didn’t see the box, I didn’t see
+the cross. I didn’t see anything but a bottle and a tin cup on the floor
+by Injun Joe; yes, I saw two barrels and lots more bottles in the room.
+Don’t you see, now, what’s the matter with that ha’nted room?”
+
+“How?”
+
+“Why, it’s ha’nted with whiskey! Maybe _all_ the Temperance Taverns have
+got a ha’nted room, hey, Huck?”
+
+“Well, I reckon maybe that’s so. Who’d ‘a’ thought such a thing? But
+say, Tom, now’s a mighty good time to get that box, if Injun Joe’s
+drunk.”
+
+“It is, that! You try it!”
+
+Huck shuddered.
+
+“Well, no--I reckon not.”
+
+“And I reckon not, Huck. Only one bottle alongside of Injun Joe ain’t
+enough. If there’d been three, he’d be drunk enough and I’d do it.”
+
+There was a long pause for reflection, and then Tom said:
+
+“Lookyhere, Huck, less not try that thing any more till we know Injun
+Joe’s not in there. It’s too scary. Now, if we watch every night, we’ll
+be dead sure to see him go out, some time or other, and then we’ll
+snatch that box quicker’n lightning.”
+
+“Well, I’m agreed. I’ll watch the whole night long, and I’ll do it every
+night, too, if you’ll do the other part of the job.”
+
+“All right, I will. All you got to do is to trot up Hooper Street a
+block and maow--and if I’m asleep, you throw some gravel at the window
+and that’ll fetch me.”
+
+“Agreed, and good as wheat!”
+
+“Now, Huck, the storm’s over, and I’ll go home. It’ll begin to be
+daylight in a couple of hours. You go back and watch that long, will
+you?”
+
+“I said I would, Tom, and I will. I’ll ha’nt that tavern every night for
+a year! I’ll sleep all day and I’ll stand watch all night.”
+
+“That’s all right. Now, where you going to sleep?”
+
+“In Ben Rogers’ hayloft. He lets me, and so does his pap’s nigger man,
+Uncle Jake. I tote water for Uncle Jake whenever he wants me to, and any
+time I ask him he gives me a little something to eat if he can spare it.
+That’s a mighty good nigger, Tom. He likes me, becuz I don’t ever act as
+if I was above him. Sometime I’ve set right down and eat _with_ him. But
+you needn’t tell that. A body’s got to do things when he’s awful hungry
+he wouldn’t want to do as a steady thing.”
+
+“Well, if I don’t want you in the daytime, I’ll let you sleep. I won’t
+come bothering around. Any time you see something’s up, in the night,
+just skip right around and maow.”
+
+
+
+
+CHAPTER XXIX
+
+THE first thing Tom heard on Friday morning was a glad piece of
+news--Judge Thatcher’s family had come back to town the night before.
+Both Injun Joe and the treasure sunk into secondary importance for a
+moment, and Becky took the chief place in the boy’s interest. He saw her
+and they had an exhausting good time playing “hispy” and “gully-keeper”
+ with a crowd of their schoolmates. The day was completed and crowned in
+a peculiarly satisfactory way: Becky teased her mother to appoint
+the next day for the long-promised and long-delayed picnic, and she
+consented. The child’s delight was boundless; and Tom’s not more
+moderate. The invitations were sent out before sunset, and straightway
+the young folks of the village were thrown into a fever of preparation
+and pleasurable anticipation. Tom’s excitement enabled him to keep
+awake until a pretty late hour, and he had good hopes of hearing Huck’s
+“maow,” and of having his treasure to astonish Becky and the picnickers
+with, next day; but he was disappointed. No signal came that night.
+
+Morning came, eventually, and by ten or eleven o’clock a giddy and
+rollicking company were gathered at Judge Thatcher’s, and everything was
+ready for a start. It was not the custom for elderly people to mar the
+picnics with their presence. The children were considered safe enough
+under the wings of a few young ladies of eighteen and a few young
+gentlemen of twenty-three or thereabouts. The old steam ferry-boat was
+chartered for the occasion; presently the gay throng filed up the main
+street laden with provision-baskets. Sid was sick and had to miss
+the fun; Mary remained at home to entertain him. The last thing Mrs.
+Thatcher said to Becky, was:
+
+“You’ll not get back till late. Perhaps you’d better stay all night with
+some of the girls that live near the ferry-landing, child.”
+
+“Then I’ll stay with Susy Harper, mamma.”
+
+“Very well. And mind and behave yourself and don’t be any trouble.”
+
+Presently, as they tripped along, Tom said to Becky:
+
+“Say--I’ll tell you what we’ll do. ‘Stead of going to Joe Harper’s we’ll
+climb right up the hill and stop at the Widow Douglas’. She’ll have
+ice-cream! She has it most every day--dead loads of it. And she’ll be
+awful glad to have us.”
+
+“Oh, that will be fun!”
+
+Then Becky reflected a moment and said:
+
+“But what will mamma say?”
+
+“How’ll she ever know?”
+
+The girl turned the idea over in her mind, and said reluctantly:
+
+“I reckon it’s wrong--but--”
+
+“But shucks! Your mother won’t know, and so what’s the harm? All she
+wants is that you’ll be safe; and I bet you she’d ‘a’ said go there if
+she’d ‘a’ thought of it. I know she would!”
+
+The Widow Douglas’ splendid hospitality was a tempting bait. It and
+Tom’s persuasions presently carried the day. So it was decided to say
+nothing to anybody about the night’s programme. Presently it occurred to
+Tom that maybe Huck might come this very night and give the signal. The
+thought took a deal of the spirit out of his anticipations. Still he
+could not bear to give up the fun at Widow Douglas’. And why should he
+give it up, he reasoned--the signal did not come the night before, so
+why should it be any more likely to come tonight? The sure fun of the
+evening outweighed the uncertain treasure; and, boy-like, he determined
+to yield to the stronger inclination and not allow himself to think of
+the box of money another time that day.
+
+Three miles below town the ferryboat stopped at the mouth of a woody
+hollow and tied up. The crowd swarmed ashore and soon the forest
+distances and craggy heights echoed far and near with shoutings and
+laughter. All the different ways of getting hot and tired were gone
+through with, and by-and-by the rovers straggled back to camp fortified
+with responsible appetites, and then the destruction of the good things
+began. After the feast there was a refreshing season of rest and chat in
+the shade of spreading oaks. By-and-by somebody shouted:
+
+“Who’s ready for the cave?”
+
+Everybody was. Bundles of candles were procured, and straightway there
+was a general scamper up the hill. The mouth of the cave was up the
+hillside--an opening shaped like a letter A. Its massive oaken door stood
+unbarred. Within was a small chamber, chilly as an icehouse, and walled
+by Nature with solid limestone that was dewy with a cold sweat. It was
+romantic and mysterious to stand here in the deep gloom and look out
+upon the green valley shining in the sun. But the impressiveness of the
+situation quickly wore off, and the romping began again. The moment
+a candle was lighted there was a general rush upon the owner of it; a
+struggle and a gallant defence followed, but the candle was soon knocked
+down or blown out, and then there was a glad clamor of laughter and a
+new chase. But all things have an end. By-and-by the procession went
+filing down the steep descent of the main avenue, the flickering rank of
+lights dimly revealing the lofty walls of rock almost to their point of
+junction sixty feet overhead. This main avenue was not more than
+eight or ten feet wide. Every few steps other lofty and still narrower
+crevices branched from it on either hand--for McDougal’s cave was but a
+vast labyrinth of crooked aisles that ran into each other and out again
+and led nowhere. It was said that one might wander days and nights
+together through its intricate tangle of rifts and chasms, and never
+find the end of the cave; and that he might go down, and down, and
+still down, into the earth, and it was just the same--labyrinth under
+labyrinth, and no end to any of them. No man “knew” the cave. That was
+an impossible thing. Most of the young men knew a portion of it, and it
+was not customary to venture much beyond this known portion. Tom Sawyer
+knew as much of the cave as any one.
+
+The procession moved along the main avenue some three-quarters of
+a mile, and then groups and couples began to slip aside into branch
+avenues, fly along the dismal corridors, and take each other by surprise
+at points where the corridors joined again. Parties were able to elude
+each other for the space of half an hour without going beyond the
+“known” ground.
+
+By-and-by, one group after another came straggling back to the mouth
+of the cave, panting, hilarious, smeared from head to foot with tallow
+drippings, daubed with clay, and entirely delighted with the success of
+the day. Then they were astonished to find that they had been taking
+no note of time and that night was about at hand. The clanging bell had
+been calling for half an hour. However, this sort of close to the day’s
+adventures was romantic and therefore satisfactory. When the ferryboat
+with her wild freight pushed into the stream, nobody cared sixpence for
+the wasted time but the captain of the craft.
+
+Huck was already upon his watch when the ferryboat’s lights went
+glinting past the wharf. He heard no noise on board, for the young
+people were as subdued and still as people usually are who are nearly
+tired to death. He wondered what boat it was, and why she did not
+stop at the wharf--and then he dropped her out of his mind and put his
+attention upon his business. The night was growing cloudy and dark. Ten
+o’clock came, and the noise of vehicles ceased, scattered lights began
+to wink out, all straggling foot-passengers disappeared, the village
+betook itself to its slumbers and left the small watcher alone with the
+silence and the ghosts. Eleven o’clock came, and the tavern lights were
+put out; darkness everywhere, now. Huck waited what seemed a weary long
+time, but nothing happened. His faith was weakening. Was there any use?
+Was there really any use? Why not give it up and turn in?
+
+A noise fell upon his ear. He was all attention in an instant. The alley
+door closed softly. He sprang to the corner of the brick store. The next
+moment two men brushed by him, and one seemed to have something under
+his arm. It must be that box! So they were going to remove the treasure.
+Why call Tom now? It would be absurd--the men would get away with the box
+and never be found again. No, he would stick to their wake and follow
+them; he would trust to the darkness for security from discovery. So
+communing with himself, Huck stepped out and glided along behind the
+men, cat-like, with bare feet, allowing them to keep just far enough
+ahead not to be invisible.
+
+They moved up the river street three blocks, then turned to the left up
+a crossstreet. They went straight ahead, then, until they came to the
+path that led up Cardiff Hill; this they took. They passed by the old
+Welshman’s house, halfway up the hill, without hesitating, and still
+climbed upward. Good, thought Huck, they will bury it in the old quarry.
+But they never stopped at the quarry. They passed on, up the summit.
+They plunged into the narrow path between the tall sumach bushes, and
+were at once hidden in the gloom. Huck closed up and shortened his
+distance, now, for they would never be able to see him. He trotted along
+awhile; then slackened his pace, fearing he was gaining too fast; moved
+on a piece, then stopped altogether; listened; no sound; none, save that
+he seemed to hear the beating of his own heart. The hooting of an
+owl came over the hill--ominous sound! But no footsteps. Heavens, was
+everything lost! He was about to spring with winged feet, when a man
+cleared his throat not four feet from him! Huck’s heart shot into his
+throat, but he swallowed it again; and then he stood there shaking as
+if a dozen agues had taken charge of him at once, and so weak that he
+thought he must surely fall to the ground. He knew where he was. He
+knew he was within five steps of the stile leading into Widow Douglas’
+grounds. Very well, he thought, let them bury it there; it won’t be hard
+to find.
+
+Now there was a voice--a very low voice--Injun Joe’s:
+
+“Damn her, maybe she’s got company--there’s lights, late as it is.”
+
+“I can’t see any.”
+
+This was that stranger’s voice--the stranger of the haunted house. A
+deadly chill went to Huck’s heart--this, then, was the “revenge” job! His
+thought was, to fly. Then he remembered that the Widow Douglas had been
+kind to him more than once, and maybe these men were going to murder
+her. He wished he dared venture to warn her; but he knew he didn’t
+dare--they might come and catch him. He thought all this and more in
+the moment that elapsed between the stranger’s remark and Injun Joe’s
+next--which was--
+
+“Because the bush is in your way. Now--this way--now you see, don’t you?”
+
+“Yes. Well, there _is_ company there, I reckon. Better give it up.”
+
+“Give it up, and I just leaving this country forever! Give it up and
+maybe never have another chance. I tell you again, as I’ve told you
+before, I don’t care for her swag--you may have it. But her husband was
+rough on me--many times he was rough on me--and mainly he was the justice
+of the peace that jugged me for a vagrant. And that ain’t all. It ain’t
+a millionth part of it! He had me _horsewhipped_!--horsewhipped in
+front of the jail, like a nigger!--with all the town looking on!
+_Horsewhipped_!--do you understand? He took advantage of me and died. But
+I’ll take it out of _her_.”
+
+“Oh, don’t kill her! Don’t do that!”
+
+“Kill? Who said anything about killing? I would kill _him_ if he was
+here; but not her. When you want to get revenge on a woman you don’t
+kill her--bosh! you go for her looks. You slit her nostrils--you notch her
+ears like a sow!”
+
+“By God, that’s--”
+
+“Keep your opinion to yourself! It will be safest for you. I’ll tie her
+to the bed. If she bleeds to death, is that my fault? I’ll not cry, if
+she does. My friend, you’ll help me in this thing--for _my_ sake--that’s
+why you’re here--I mightn’t be able alone. If you flinch, I’ll kill you.
+Do you understand that? And if I have to kill you, I’ll kill her--and
+then I reckon nobody’ll ever know much about who done this business.”
+
+“Well, if it’s got to be done, let’s get at it. The quicker the
+better--I’m all in a shiver.”
+
+“Do it _now_? And company there? Look here--I’ll get suspicious of you,
+first thing you know. No--we’ll wait till the lights are out--there’s no
+hurry.”
+
+Huck felt that a silence was going to ensue--a thing still more awful
+than any amount of murderous talk; so he held his breath and stepped
+gingerly back; planted his foot carefully and firmly, after balancing,
+one-legged, in a precarious way and almost toppling over, first on one
+side and then on the other. He took another step back, with the same
+elaboration and the same risks; then another and another, and--a twig
+snapped under his foot! His breath stopped and he listened. There was no
+sound--the stillness was perfect. His gratitude was measureless. Now he
+turned in his tracks, between the walls of sumach bushes--turned
+himself as carefully as if he were a ship--and then stepped quickly but
+cautiously along. When he emerged at the quarry he felt secure, and
+so he picked up his nimble heels and flew. Down, down he sped, till he
+reached the Welshman’s. He banged at the door, and presently the heads
+of the old man and his two stalwart sons were thrust from windows.
+
+“What’s the row there? Who’s banging? What do you want?”
+
+“Let me in--quick! I’ll tell everything.”
+
+“Why, who are you?”
+
+“Huckleberry Finn--quick, let me in!”
+
+“Huckleberry Finn, indeed! It ain’t a name to open many doors, I judge!
+But let him in, lads, and let’s see what’s the trouble.”
+
+“Please don’t ever tell I told you,” were Huck’s first words when he got
+in. “Please don’t--I’d be killed, sure--but the widow’s been good friends
+to me sometimes, and I want to tell--I _will_ tell if you’ll promise you
+won’t ever say it was me.”
+
+“By George, he _has_ got something to tell, or he wouldn’t act so!”
+ exclaimed the old man; “out with it and nobody here’ll ever tell, lad.”
+
+Three minutes later the old man and his sons, well armed, were up the
+hill, and just entering the sumach path on tiptoe, their weapons in
+their hands. Huck accompanied them no further. He hid behind a great
+bowlder and fell to listening. There was a lagging, anxious silence, and
+then all of a sudden there was an explosion of firearms and a cry.
+
+Huck waited for no particulars. He sprang away and sped down the hill as
+fast as his legs could carry him.
+
+
+
+
+CHAPTER XXX
+
+AS the earliest suspicion of dawn appeared on Sunday morning, Huck came
+groping up the hill and rapped gently at the old Welshman’s door. The
+inmates were asleep, but it was a sleep that was set on a hair-trigger,
+on account of the exciting episode of the night. A call came from a
+window:
+
+“Who’s there!”
+
+Huck’s scared voice answered in a low tone:
+
+“Please let me in! It’s only Huck Finn!”
+
+“It’s a name that can open this door night or day, lad!--and welcome!”
+
+These were strange words to the vagabond boy’s ears, and the pleasantest
+he had ever heard. He could not recollect that the closing word had ever
+been applied in his case before. The door was quickly unlocked, and he
+entered. Huck was given a seat and the old man and his brace of tall
+sons speedily dressed themselves.
+
+“Now, my boy, I hope you’re good and hungry, because breakfast will be
+ready as soon as the sun’s up, and we’ll have a piping hot one, too--make
+yourself easy about that! I and the boys hoped you’d turn up and stop
+here last night.”
+
+“I was awful scared,” said Huck, “and I run. I took out when the pistols
+went off, and I didn’t stop for three mile. I’ve come now becuz I wanted
+to know about it, you know; and I come before daylight becuz I didn’t
+want to run across them devils, even if they was dead.”
+
+“Well, poor chap, you do look as if you’d had a hard night of it--but
+there’s a bed here for you when you’ve had your breakfast. No, they
+ain’t dead, lad--we are sorry enough for that. You see we knew right
+where to put our hands on them, by your description; so we crept along
+on tiptoe till we got within fifteen feet of them--dark as a cellar that
+sumach path was--and just then I found I was going to sneeze. It was the
+meanest kind of luck! I tried to keep it back, but no use--‘twas bound to
+come, and it did come! I was in the lead with my pistol raised, and when
+the sneeze started those scoundrels a-rustling to get out of the path,
+I sung out, ‘Fire boys!’ and blazed away at the place where the rustling
+was. So did the boys. But they were off in a jiffy, those villains, and
+we after them, down through the woods. I judge we never touched them.
+They fired a shot apiece as they started, but their bullets whizzed by
+and didn’t do us any harm. As soon as we lost the sound of their feet
+we quit chasing, and went down and stirred up the constables. They got a
+posse together, and went off to guard the river bank, and as soon as it
+is light the sheriff and a gang are going to beat up the woods. My boys
+will be with them presently. I wish we had some sort of description of
+those rascals--‘twould help a good deal. But you couldn’t see what they
+were like, in the dark, lad, I suppose?”
+
+“Oh yes; I saw them downtown and follered them.”
+
+“Splendid! Describe them--describe them, my boy!”
+
+“One’s the old deaf and dumb Spaniard that’s ben around here once or
+twice, and t’other’s a mean-looking, ragged--”
+
+“That’s enough, lad, we know the men! Happened on them in the woods back
+of the widow’s one day, and they slunk away. Off with you, boys, and
+tell the sheriff--get your breakfast tomorrow morning!”
+
+The Welshman’s sons departed at once. As they were leaving the room Huck
+sprang up and exclaimed:
+
+“Oh, please don’t tell _any_body it was me that blowed on them! Oh,
+please!”
+
+“All right if you say it, Huck, but you ought to have the credit of what
+you did.”
+
+“Oh no, no! Please don’t tell!”
+
+When the young men were gone, the old Welshman said:
+
+“They won’t tell--and I won’t. But why don’t you want it known?”
+
+Huck would not explain, further than to say that he already knew too
+much about one of those men and would not have the man know that he knew
+anything against him for the whole world--he would be killed for knowing
+it, sure.
+
+The old man promised secrecy once more, and said:
+
+“How did you come to follow these fellows, lad? Were they looking
+suspicious?”
+
+Huck was silent while he framed a duly cautious reply. Then he said:
+
+“Well, you see, I’m a kind of a hard lot,--least everybody says so, and
+I don’t see nothing agin it--and sometimes I can’t sleep much, on account
+of thinking about it and sort of trying to strike out a new way of
+doing. That was the way of it last night. I couldn’t sleep, and so I
+come along upstreet ‘bout midnight, a-turning it all over, and when I
+got to that old shackly brick store by the Temperance Tavern, I backed
+up agin the wall to have another think. Well, just then along comes
+these two chaps slipping along close by me, with something under their
+arm, and I reckoned they’d stole it. One was a-smoking, and t’other one
+wanted a light; so they stopped right before me and the cigars lit up
+their faces and I see that the big one was the deaf and dumb Spaniard,
+by his white whiskers and the patch on his eye, and t’other one was a
+rusty, ragged-looking devil.”
+
+“Could you see the rags by the light of the cigars?”
+
+This staggered Huck for a moment. Then he said:
+
+“Well, I don’t know--but somehow it seems as if I did.”
+
+“Then they went on, and you--”
+
+“Follered ‘em--yes. That was it. I wanted to see what was up--they sneaked
+along so. I dogged ‘em to the widder’s stile, and stood in the dark and
+heard the ragged one beg for the widder, and the Spaniard swear he’d
+spile her looks just as I told you and your two--”
+
+“What! The _deaf and dumb_ man said all that!”
+
+Huck had made another terrible mistake! He was trying his best to keep
+the old man from getting the faintest hint of who the Spaniard might be,
+and yet his tongue seemed determined to get him into trouble in spite of
+all he could do. He made several efforts to creep out of his scrape,
+but the old man’s eye was upon him and he made blunder after blunder.
+Presently the Welshman said:
+
+“My boy, don’t be afraid of me. I wouldn’t hurt a hair of your head for
+all the world. No--I’d protect you--I’d protect you. This Spaniard is
+not deaf and dumb; you’ve let that slip without intending it; you can’t
+cover that up now. You know something about that Spaniard that you want
+to keep dark. Now trust me--tell me what it is, and trust me--I won’t
+betray you.”
+
+Huck looked into the old man’s honest eyes a moment, then bent over and
+whispered in his ear:
+
+“‘Tain’t a Spaniard--it’s Injun Joe!”
+
+The Welshman almost jumped out of his chair. In a moment he said:
+
+“It’s all plain enough, now. When you talked about notching ears and
+slitting noses I judged that that was your own embellishment, because
+white men don’t take that sort of revenge. But an Injun! That’s a
+different matter altogether.”
+
+During breakfast the talk went on, and in the course of it the old man
+said that the last thing which he and his sons had done, before going
+to bed, was to get a lantern and examine the stile and its vicinity for
+marks of blood. They found none, but captured a bulky bundle of--
+
+“Of _what_?”
+
+If the words had been lightning they could not have leaped with a more
+stunning suddenness from Huck’s blanched lips. His eyes were staring
+wide, now, and his breath suspended--waiting for the answer. The Welshman
+started--stared in return--three seconds--five seconds--ten--then replied:
+
+“Of burglar’s tools. Why, what’s the _matter_ with you?”
+
+Huck sank back, panting gently, but deeply, unutterably grateful. The
+Welshman eyed him gravely, curiously--and presently said:
+
+“Yes, burglar’s tools. That appears to relieve you a good deal. But what
+did give you that turn? What were _you_ expecting we’d found?”
+
+Huck was in a close place--the inquiring eye was upon him--he would have
+given anything for material for a plausible answer--nothing suggested
+itself--the inquiring eye was boring deeper and deeper--a senseless
+reply offered--there was no time to weigh it, so at a venture he uttered
+it--feebly:
+
+“Sunday-school books, maybe.”
+
+Poor Huck was too distressed to smile, but the old man laughed loud and
+joyously, shook up the details of his anatomy from head to foot, and
+ended by saying that such a laugh was money in a-man’s pocket, because
+it cut down the doctor’s bill like everything. Then he added:
+
+“Poor old chap, you’re white and jaded--you ain’t well a bit--no wonder
+you’re a little flighty and off your balance. But you’ll come out of it.
+Rest and sleep will fetch you out all right, I hope.”
+
+Huck was irritated to think he had been such a goose and betrayed such
+a suspicious excitement, for he had dropped the idea that the parcel
+brought from the tavern was the treasure, as soon as he had heard the
+talk at the widow’s stile. He had only thought it was not the treasure,
+however--he had not known that it wasn’t--and so the suggestion of a
+captured bundle was too much for his self-possession. But on the whole
+he felt glad the little episode had happened, for now he knew beyond all
+question that that bundle was not _the_ bundle, and so his mind was
+at rest and exceedingly comfortable. In fact, everything seemed to be
+drifting just in the right direction, now; the treasure must be still
+in No. 2, the men would be captured and jailed that day, and he and
+Tom could seize the gold that night without any trouble or any fear of
+interruption.
+
+Just as breakfast was completed there was a knock at the door. Huck
+jumped for a hiding-place, for he had no mind to be connected even
+remotely with the late event. The Welshman admitted several ladies and
+gentlemen, among them the Widow Douglas, and noticed that groups of
+citizens were climbing up the hill--to stare at the stile. So the news
+had spread. The Welshman had to tell the story of the night to the
+visitors. The widow’s gratitude for her preservation was outspoken.
+
+“Don’t say a word about it, madam. There’s another that you’re more
+beholden to than you are to me and my boys, maybe, but he don’t allow me
+to tell his name. We wouldn’t have been there but for him.”
+
+Of course this excited a curiosity so vast that it almost belittled the
+main matter--but the Welshman allowed it to eat into the vitals of his
+visitors, and through them be transmitted to the whole town, for he
+refused to part with his secret. When all else had been learned, the
+widow said:
+
+“I went to sleep reading in bed and slept straight through all that
+noise. Why didn’t you come and wake me?”
+
+“We judged it warn’t worth while. Those fellows warn’t likely to come
+again--they hadn’t any tools left to work with, and what was the use of
+waking you up and scaring you to death? My three negro men stood guard
+at your house all the rest of the night. They’ve just come back.”
+
+More visitors came, and the story had to be told and retold for a couple
+of hours more.
+
+There was no Sabbath-school during day-school vacation, but everybody
+was early at church. The stirring event was well canvassed. News came
+that not a sign of the two villains had been yet discovered. When the
+sermon was finished, Judge Thatcher’s wife dropped alongside of Mrs.
+Harper as she moved down the aisle with the crowd and said:
+
+“Is my Becky going to sleep all day? I just expected she would be tired
+to death.”
+
+“Your Becky?”
+
+“Yes,” with a startled look--“didn’t she stay with you last night?”
+
+“Why, no.”
+
+Mrs. Thatcher turned pale, and sank into a pew, just as Aunt Polly,
+talking briskly with a friend, passed by. Aunt Polly said:
+
+“Goodmorning, Mrs. Thatcher. Goodmorning, Mrs. Harper. I’ve got a boy
+that’s turned up missing. I reckon my Tom stayed at your house last
+night--one of you. And now he’s afraid to come to church. I’ve got to
+settle with him.”
+
+Mrs. Thatcher shook her head feebly and turned paler than ever.
+
+“He didn’t stay with us,” said Mrs. Harper, beginning to look uneasy. A
+marked anxiety came into Aunt Polly’s face.
+
+“Joe Harper, have you seen my Tom this morning?”
+
+“No’m.”
+
+“When did you see him last?”
+
+Joe tried to remember, but was not sure he could say. The people had
+stopped moving out of church. Whispers passed along, and a boding
+uneasiness took possession of every countenance. Children were anxiously
+questioned, and young teachers. They all said they had not noticed
+whether Tom and Becky were on board the ferryboat on the homeward trip;
+it was dark; no one thought of inquiring if any one was missing. One
+young man finally blurted out his fear that they were still in the cave!
+Mrs. Thatcher swooned away. Aunt Polly fell to crying and wringing her
+hands.
+
+The alarm swept from lip to lip, from group to group, from street to
+street, and within five minutes the bells were wildly clanging and
+the whole town was up! The Cardiff Hill episode sank into instant
+insignificance, the burglars were forgotten, horses were saddled, skiffs
+were manned, the ferryboat ordered out, and before the horror was half
+an hour old, two hundred men were pouring down highroad and river toward
+the cave.
+
+All the long afternoon the village seemed empty and dead. Many women
+visited Aunt Polly and Mrs. Thatcher and tried to comfort them. They
+cried with them, too, and that was still better than words. All the
+tedious night the town waited for news; but when the morning dawned at
+last, all the word that came was, “Send more candles--and send food.”
+ Mrs. Thatcher was almost crazed; and Aunt Polly, also. Judge Thatcher
+sent messages of hope and encouragement from the cave, but they conveyed
+no real cheer.
+
+The old Welshman came home toward daylight, spattered with
+candle-grease, smeared with clay, and almost worn out. He found Huck
+still in the bed that had been provided for him, and delirious with
+fever. The physicians were all at the cave, so the Widow Douglas came
+and took charge of the patient. She said she would do her best by him,
+because, whether he was good, bad, or indifferent, he was the Lord’s,
+and nothing that was the Lord’s was a thing to be neglected. The
+Welshman said Huck had good spots in him, and the widow said:
+
+“You can depend on it. That’s the Lord’s mark. He don’t leave it off.
+He never does. Puts it somewhere on every creature that comes from his
+hands.”
+
+Early in the forenoon parties of jaded men began to straggle into the
+village, but the strongest of the citizens continued searching. All the
+news that could be gained was that remotenesses of the cavern were being
+ransacked that had never been visited before; that every corner and
+crevice was going to be thoroughly searched; that wherever one wandered
+through the maze of passages, lights were to be seen flitting hither
+and thither in the distance, and shoutings and pistol-shots sent their
+hollow reverberations to the ear down the sombre aisles. In one place,
+far from the section usually traversed by tourists, the names “BECKY &
+TOM” had been found traced upon the rocky wall with candle-smoke, and
+near at hand a grease-soiled bit of ribbon. Mrs. Thatcher recognized the
+ribbon and cried over it. She said it was the last relic she should ever
+have of her child; and that no other memorial of her could ever be so
+precious, because this one parted latest from the living body before the
+awful death came. Some said that now and then, in the cave, a far-away
+speck of light would glimmer, and then a glorious shout would burst
+forth and a score of men go trooping down the echoing aisle--and then a
+sickening disappointment always followed; the children were not there;
+it was only a searcher’s light.
+
+Three dreadful days and nights dragged their tedious hours along, and
+the village sank into a hopeless stupor. No one had heart for anything.
+The accidental discovery, just made, that the proprietor of the
+Temperance Tavern kept liquor on his premises, scarcely fluttered the
+public pulse, tremendous as the fact was. In a lucid interval, Huck
+feebly led up to the subject of taverns, and finally asked--dimly
+dreading the worst--if anything had been discovered at the Temperance
+Tavern since he had been ill.
+
+“Yes,” said the widow.
+
+Huck started up in bed, wildeyed:
+
+“What? What was it?”
+
+“Liquor!--and the place has been shut up. Lie down, child--what a turn you
+did give me!”
+
+“Only tell me just one thing--only just one--please! Was it Tom Sawyer
+that found it?”
+
+The widow burst into tears. “Hush, hush, child, hush! I’ve told you
+before, you must _not_ talk. You are very, very sick!”
+
+Then nothing but liquor had been found; there would have been a great
+powwow if it had been the gold. So the treasure was gone forever--gone
+forever! But what could she be crying about? Curious that she should
+cry.
+
+These thoughts worked their dim way through Huck’s mind, and under the
+weariness they gave him he fell asleep. The widow said to herself:
+
+“There--he’s asleep, poor wreck. Tom Sawyer find it! Pity but somebody
+could find Tom Sawyer! Ah, there ain’t many left, now, that’s got hope
+enough, or strength enough, either, to go on searching.”
+
+
+
+
+CHAPTER XXXI
+
+NOW to return to Tom and Becky’s share in the picnic. They tripped along
+the murky aisles with the rest of the company, visiting the familiar
+wonders of the cave--wonders dubbed with rather over-descriptive names,
+such as “The Drawing-Room,” “The Cathedral,” “Aladdin’s Palace,” and
+so on. Presently the hide-and-seek frolicking began, and Tom and Becky
+engaged in it with zeal until the exertion began to grow a trifle
+wearisome; then they wandered down a sinuous avenue holding their
+candles aloft and reading the tangled webwork of names, dates,
+postoffice addresses, and mottoes with which the rocky walls had been
+frescoed (in candle-smoke). Still drifting along and talking, they
+scarcely noticed that they were now in a part of the cave whose walls
+were not frescoed. They smoked their own names under an overhanging
+shelf and moved on. Presently they came to a place where a little stream
+of water, trickling over a ledge and carrying a limestone sediment with
+it, had, in the slow-dragging ages, formed a laced and ruffled Niagara
+in gleaming and imperishable stone. Tom squeezed his small body behind
+it in order to illuminate it for Becky’s gratification. He found that
+it curtained a sort of steep natural stairway which was enclosed between
+narrow walls, and at once the ambition to be a discoverer seized him.
+
+Becky responded to his call, and they made a smoke-mark for future
+guidance, and started upon their quest. They wound this way and that,
+far down into the secret depths of the cave, made another mark, and
+branched off in search of novelties to tell the upper world about. In
+one place they found a spacious cavern, from whose ceiling depended a
+multitude of shining stalactites of the length and circumference of
+a man’s leg; they walked all about it, wondering and admiring, and
+presently left it by one of the numerous passages that opened into
+it. This shortly brought them to a bewitching spring, whose basin was
+incrusted with a frostwork of glittering crystals; it was in the midst
+of a cavern whose walls were supported by many fantastic pillars which
+had been formed by the joining of great stalactites and stalagmites
+together, the result of the ceaseless water-drip of centuries. Under the
+roof vast knots of bats had packed themselves together, thousands in a
+bunch; the lights disturbed the creatures and they came flocking down by
+hundreds, squeaking and darting furiously at the candles. Tom knew their
+ways and the danger of this sort of conduct. He seized Becky’s hand and
+hurried her into the first corridor that offered; and none too soon, for
+a bat struck Becky’s light out with its wing while she was passing out
+of the cavern. The bats chased the children a good distance; but the
+fugitives plunged into every new passage that offered, and at last got
+rid of the perilous things. Tom found a subterranean lake, shortly,
+which stretched its dim length away until its shape was lost in the
+shadows. He wanted to explore its borders, but concluded that it would
+be best to sit down and rest awhile, first. Now, for the first time, the
+deep stillness of the place laid a clammy hand upon the spirits of the
+children. Becky said:
+
+“Why, I didn’t notice, but it seems ever so long since I heard any of
+the others.”
+
+“Come to think, Becky, we are away down below them--and I don’t know how
+far away north, or south, or east, or whichever it is. We couldn’t hear
+them here.”
+
+Becky grew apprehensive.
+
+“I wonder how long we’ve been down here, Tom? We better start back.”
+
+“Yes, I reckon we better. P’raps we better.”
+
+“Can you find the way, Tom? It’s all a mixed-up crookedness to me.”
+
+“I reckon I could find it--but then the bats. If they put our candles
+out it will be an awful fix. Let’s try some other way, so as not to go
+through there.”
+
+“Well. But I hope we won’t get lost. It would be so awful!” and the girl
+shuddered at the thought of the dreadful possibilities.
+
+They started through a corridor, and traversed it in silence a long
+way, glancing at each new opening, to see if there was anything familiar
+about the look of it; but they were all strange. Every time Tom made an
+examination, Becky would watch his face for an encouraging sign, and he
+would say cheerily:
+
+“Oh, it’s all right. This ain’t the one, but we’ll come to it right
+away!”
+
+But he felt less and less hopeful with each failure, and presently began
+to turn off into diverging avenues at sheer random, in desperate hope of
+finding the one that was wanted. He still said it was “all right,” but
+there was such a leaden dread at his heart that the words had lost their
+ring and sounded just as if he had said, “All is lost!” Becky clung to
+his side in an anguish of fear, and tried hard to keep back the tears,
+but they would come. At last she said:
+
+“Oh, Tom, never mind the bats, let’s go back that way! We seem to get
+worse and worse off all the time.”
+
+“Listen!” said he.
+
+Profound silence; silence so deep that even their breathings were
+conspicuous in the hush. Tom shouted. The call went echoing down
+the empty aisles and died out in the distance in a faint sound that
+resembled a ripple of mocking laughter.
+
+“Oh, don’t do it again, Tom, it is too horrid,” said Becky.
+
+“It is horrid, but I better, Becky; they might hear us, you know,” and
+he shouted again.
+
+The “might” was even a chillier horror than the ghostly laughter, it so
+confessed a perishing hope. The children stood still and listened; but
+there was no result. Tom turned upon the back track at once, and hurried
+his steps. It was but a little while before a certain indecision in his
+manner revealed another fearful fact to Becky--he could not find his way
+back!
+
+“Oh, Tom, you didn’t make any marks!”
+
+“Becky, I was such a fool! Such a fool! I never thought we might want to
+come back! No--I can’t find the way. It’s all mixed up.”
+
+“Tom, Tom, we’re lost! we’re lost! We never can get out of this awful
+place! Oh, why _did_ we ever leave the others!”
+
+She sank to the ground and burst into such a frenzy of crying that Tom
+was appalled with the idea that she might die, or lose her reason. He
+sat down by her and put his arms around her; she buried her face in
+his bosom, she clung to him, she poured out her terrors, her unavailing
+regrets, and the far echoes turned them all to jeering laughter. Tom
+begged her to pluck up hope again, and she said she could not. He fell
+to blaming and abusing himself for getting her into this miserable
+situation; this had a better effect. She said she would try to hope
+again, she would get up and follow wherever he might lead if only he
+would not talk like that any more. For he was no more to blame than she,
+she said.
+
+So they moved on again--aimlessly--simply at random--all they could do
+was to move, keep moving. For a little while, hope made a show of
+reviving--not with any reason to back it, but only because it is its
+nature to revive when the spring has not been taken out of it by age and
+familiarity with failure.
+
+By-and-by Tom took Becky’s candle and blew it out. This economy meant so
+much! Words were not needed. Becky understood, and her hope died again.
+She knew that Tom had a whole candle and three or four pieces in his
+pockets--yet he must economize.
+
+By-and-by, fatigue began to assert its claims; the children tried to pay
+attention, for it was dreadful to think of sitting down when time was
+grown to be so precious, moving, in some direction, in any direction,
+was at least progress and might bear fruit; but to sit down was to
+invite death and shorten its pursuit.
+
+At last Becky’s frail limbs refused to carry her farther. She sat down.
+Tom rested with her, and they talked of home, and the friends there,
+and the comfortable beds and, above all, the light! Becky cried, and Tom
+tried to think of some way of comforting her, but all his encouragements
+were grown thread-bare with use, and sounded like sarcasms. Fatigue bore
+so heavily upon Becky that she drowsed off to sleep. Tom was grateful.
+He sat looking into her drawn face and saw it grow smooth and natural
+under the influence of pleasant dreams; and by-and-by a smile dawned and
+rested there. The peaceful face reflected somewhat of peace and healing
+into his own spirit, and his thoughts wandered away to bygone times and
+dreamy memories. While he was deep in his musings, Becky woke up with a
+breezy little laugh--but it was stricken dead upon her lips, and a groan
+followed it.
+
+“Oh, how _could_ I sleep! I wish I never, never had waked! No! No, I
+don’t, Tom! Don’t look so! I won’t say it again.”
+
+“I’m glad you’ve slept, Becky; you’ll feel rested, now, and we’ll find
+the way out.”
+
+“We can try, Tom; but I’ve seen such a beautiful country in my dream. I
+reckon we are going there.”
+
+“Maybe not, maybe not. Cheer up, Becky, and let’s go on trying.”
+
+They rose up and wandered along, hand in hand and hopeless. They tried
+to estimate how long they had been in the cave, but all they knew was
+that it seemed days and weeks, and yet it was plain that this could not
+be, for their candles were not gone yet. A long time after this--they
+could not tell how long--Tom said they must go softly and listen for
+dripping water--they must find a spring. They found one presently, and
+Tom said it was time to rest again. Both were cruelly tired, yet Becky
+said she thought she could go a little farther. She was surprised to
+hear Tom dissent. She could not understand it. They sat down, and Tom
+fastened his candle to the wall in front of them with some clay. Thought
+was soon busy; nothing was said for some time. Then Becky broke the
+silence:
+
+“Tom, I am so hungry!”
+
+Tom took something out of his pocket.
+
+“Do you remember this?” said he.
+
+Becky almost smiled.
+
+“It’s our wedding-cake, Tom.”
+
+“Yes--I wish it was as big as a barrel, for it’s all we’ve got.”
+
+“I saved it from the picnic for us to dream on, Tom, the way grownup
+people do with wedding-cake--but it’ll be our--”
+
+She dropped the sentence where it was. Tom divided the cake and Becky
+ate with good appetite, while Tom nibbled at his moiety. There was
+abundance of cold water to finish the feast with. By-and-by Becky
+suggested that they move on again. Tom was silent a moment. Then he
+said:
+
+“Becky, can you bear it if I tell you something?”
+
+Becky’s face paled, but she thought she could.
+
+“Well, then, Becky, we must stay here, where there’s water to drink.
+That little piece is our last candle!”
+
+Becky gave loose to tears and wailings. Tom did what he could to comfort
+her, but with little effect. At length Becky said:
+
+“Tom!”
+
+“Well, Becky?”
+
+“They’ll miss us and hunt for us!”
+
+“Yes, they will! Certainly they will!”
+
+“Maybe they’re hunting for us now, Tom.”
+
+“Why, I reckon maybe they are. I hope they are.”
+
+“When would they miss us, Tom?”
+
+“When they get back to the boat, I reckon.”
+
+“Tom, it might be dark then--would they notice we hadn’t come?”
+
+“I don’t know. But anyway, your mother would miss you as soon as they
+got home.”
+
+A frightened look in Becky’s face brought Tom to his senses and he saw
+that he had made a blunder. Becky was not to have gone home that night!
+The children became silent and thoughtful. In a moment a new burst of
+grief from Becky showed Tom that the thing in his mind had struck hers
+also--that the Sabbath morning might be half spent before Mrs. Thatcher
+discovered that Becky was not at Mrs. Harper’s.
+
+The children fastened their eyes upon their bit of candle and watched it
+melt slowly and pitilessly away; saw the half inch of wick stand alone
+at last; saw the feeble flame rise and fall, climb the thin column of
+smoke, linger at its top a moment, and then--the horror of utter darkness
+reigned!
+
+How long afterward it was that Becky came to a slow consciousness that
+she was crying in Tom’s arms, neither could tell. All that they knew
+was, that after what seemed a mighty stretch of time, both awoke out of
+a dead stupor of sleep and resumed their miseries once more. Tom said
+it might be Sunday, now--maybe Monday. He tried to get Becky to talk, but
+her sorrows were too oppressive, all her hopes were gone. Tom said that
+they must have been missed long ago, and no doubt the search was going
+on. He would shout and maybe some one would come. He tried it; but in
+the darkness the distant echoes sounded so hideously that he tried it no
+more.
+
+The hours wasted away, and hunger came to torment the captives again. A
+portion of Tom’s half of the cake was left; they divided and ate it. But
+they seemed hungrier than before. The poor morsel of food only whetted
+desire.
+
+By-and-by Tom said:
+
+“SH! Did you hear that?”
+
+Both held their breath and listened. There was a sound like the
+faintest, far-off shout. Instantly Tom answered it, and leading Becky by
+the hand, started groping down the corridor in its direction. Presently
+he listened again; again the sound was heard, and apparently a little
+nearer.
+
+“It’s them!” said Tom; “they’re coming! Come along, Becky--we’re all
+right now!”
+
+The joy of the prisoners was almost overwhelming. Their speed was slow,
+however, because pitfalls were somewhat common, and had to be guarded
+against. They shortly came to one and had to stop. It might be three
+feet deep, it might be a hundred--there was no passing it at any rate.
+Tom got down on his breast and reached as far down as he could. No
+bottom. They must stay there and wait until the searchers came. They
+listened; evidently the distant shoutings were growing more distant!
+a moment or two more and they had gone altogether. The heart-sinking
+misery of it! Tom whooped until he was hoarse, but it was of no use. He
+talked hopefully to Becky; but an age of anxious waiting passed and no
+sounds came again.
+
+The children groped their way back to the spring. The weary time dragged
+on; they slept again, and awoke famished and woe-stricken. Tom believed
+it must be Tuesday by this time.
+
+Now an idea struck him. There were some side passages near at hand. It
+would be better to explore some of these than bear the weight of the
+heavy time in idleness. He took a kite-line from his pocket, tied it to
+a projection, and he and Becky started, Tom in the lead, unwinding the
+line as he groped along. At the end of twenty steps the corridor ended
+in a “jumping-off place.” Tom got down on his knees and felt below,
+and then as far around the corner as he could reach with his hands
+conveniently; he made an effort to stretch yet a little farther to the
+right, and at that moment, not twenty yards away, a human hand, holding
+a candle, appeared from behind a rock! Tom lifted up a glorious shout,
+and instantly that hand was followed by the body it belonged to--Injun
+Joe’s! Tom was paralyzed; he could not move. He was vastly gratified the
+next moment, to see the “Spaniard” take to his heels and get himself out
+of sight. Tom wondered that Joe had not recognized his voice and come
+over and killed him for testifying in court. But the echoes must have
+disguised the voice. Without doubt, that was it, he reasoned. Tom’s
+fright weakened every muscle in his body. He said to himself that if he
+had strength enough to get back to the spring he would stay there, and
+nothing should tempt him to run the risk of meeting Injun Joe again. He
+was careful to keep from Becky what it was he had seen. He told her he
+had only shouted “for luck.”
+
+But hunger and wretchedness rise superior to fears in the long run.
+Another tedious wait at the spring and another long sleep brought
+changes. The children awoke tortured with a raging hunger. Tom believed
+that it must be Wednesday or Thursday or even Friday or Saturday, now,
+and that the search had been given over. He proposed to explore another
+passage. He felt willing to risk Injun Joe and all other terrors. But
+Becky was very weak. She had sunk into a dreary apathy and would not be
+roused. She said she would wait, now, where she was, and die--it would
+not be long. She told Tom to go with the kite-line and explore if he
+chose; but she implored him to come back every little while and speak
+to her; and she made him promise that when the awful time came, he would
+stay by her and hold her hand until all was over.
+
+Tom kissed her, with a choking sensation in his throat, and made a show
+of being confident of finding the searchers or an escape from the cave;
+then he took the kite-line in his hand and went groping down one of the
+passages on his hands and knees, distressed with hunger and sick with
+bodings of coming doom.
+
+
+
+
+CHAPTER XXXII
+
+TUESDAY afternoon came, and waned to the twilight. The village of St.
+Petersburg still mourned. The lost children had not been found. Public
+prayers had been offered up for them, and many and many a private prayer
+that had the petitioner’s whole heart in it; but still no good news came
+from the cave. The majority of the searchers had given up the quest
+and gone back to their daily avocations, saying that it was plain the
+children could never be found. Mrs. Thatcher was very ill, and a great
+part of the time delirious. People said it was heartbreaking to hear her
+call her child, and raise her head and listen a whole minute at a time,
+then lay it wearily down again with a moan. Aunt Polly had drooped into
+a settled melancholy, and her gray hair had grown almost white. The
+village went to its rest on Tuesday night, sad and forlorn.
+
+Away in the middle of the night a wild peal burst from the village
+bells, and in a moment the streets were swarming with frantic half-clad
+people, who shouted, “Turn out! turn out! they’re found! they’re found!”
+ Tin pans and horns were added to the din, the population massed itself
+and moved toward the river, met the children coming in an open carriage
+drawn by shouting citizens, thronged around it, joined its homeward
+march, and swept magnificently up the main street roaring huzzah after
+huzzah!
+
+The village was illuminated; nobody went to bed again; it was the
+greatest night the little town had ever seen. During the first half-hour
+a procession of villagers filed through Judge Thatcher’s house, seized
+the saved ones and kissed them, squeezed Mrs. Thatcher’s hand, tried to
+speak but couldn’t--and drifted out raining tears all over the place.
+
+Aunt Polly’s happiness was complete, and Mrs. Thatcher’s nearly so. It
+would be complete, however, as soon as the messenger dispatched with the
+great news to the cave should get the word to her husband. Tom lay upon
+a sofa with an eager auditory about him and told the history of the
+wonderful adventure, putting in many striking additions to adorn it
+withal; and closed with a description of how he left Becky and went
+on an exploring expedition; how he followed two avenues as far as his
+kite-line would reach; how he followed a third to the fullest stretch
+of the kite-line, and was about to turn back when he glimpsed a far-off
+speck that looked like daylight; dropped the line and groped toward it,
+pushed his head and shoulders through a small hole, and saw the broad
+Mississippi rolling by!
+
+And if it had only happened to be night he would not have seen that
+speck of daylight and would not have explored that passage any more! He
+told how he went back for Becky and broke the good news and she told
+him not to fret her with such stuff, for she was tired, and knew she was
+going to die, and wanted to. He described how he labored with her and
+convinced her; and how she almost died for joy when she had groped to
+where she actually saw the blue speck of daylight; how he pushed his way
+out at the hole and then helped her out; how they sat there and cried
+for gladness; how some men came along in a skiff and Tom hailed them
+and told them their situation and their famished condition; how the men
+didn’t believe the wild tale at first, “because,” said they, “you are
+five miles down the river below the valley the cave is in”--then took
+them aboard, rowed to a house, gave them supper, made them rest till two
+or three hours after dark and then brought them home.
+
+Before day-dawn, Judge Thatcher and the handful of searchers with him
+were tracked out, in the cave, by the twine clews they had strung behind
+them, and informed of the great news.
+
+Three days and nights of toil and hunger in the cave were not to
+be shaken off at once, as Tom and Becky soon discovered. They were
+bedridden all of Wednesday and Thursday, and seemed to grow more and
+more tired and worn, all the time. Tom got about, a little, on Thursday,
+was downtown Friday, and nearly as whole as ever Saturday; but Becky
+did not leave her room until Sunday, and then she looked as if she had
+passed through a wasting illness.
+
+Tom learned of Huck’s sickness and went to see him on Friday, but could
+not be admitted to the bedroom; neither could he on Saturday or Sunday.
+He was admitted daily after that, but was warned to keep still about his
+adventure and introduce no exciting topic. The Widow Douglas stayed by
+to see that he obeyed. At home Tom learned of the Cardiff Hill event;
+also that the “ragged man’s” body had eventually been found in the river
+near the ferry-landing; he had been drowned while trying to escape,
+perhaps.
+
+About a fortnight after Tom’s rescue from the cave, he started off to
+visit Huck, who had grown plenty strong enough, now, to hear exciting
+talk, and Tom had some that would interest him, he thought. Judge
+Thatcher’s house was on Tom’s way, and he stopped to see Becky. The
+Judge and some friends set Tom to talking, and some one asked him
+ironically if he wouldn’t like to go to the cave again. Tom said he
+thought he wouldn’t mind it. The Judge said:
+
+“Well, there are others just like you, Tom, I’ve not the least doubt.
+But we have taken care of that. Nobody will get lost in that cave any
+more.”
+
+“Why?”
+
+“Because I had its big door sheathed with boiler iron two weeks ago, and
+triple-locked--and I’ve got the keys.”
+
+Tom turned as white as a sheet.
+
+“What’s the matter, boy! Here, run, somebody! Fetch a glass of water!”
+
+The water was brought and thrown into Tom’s face.
+
+“Ah, now you’re all right. What was the matter with you, Tom?”
+
+“Oh, Judge, Injun Joe’s in the cave!”
+
+
+
+
+CHAPTER XXXIII
+
+WITHIN a few minutes the news had spread, and a dozen skiff-loads of
+men were on their way to McDougal’s cave, and the ferryboat, well filled
+with passengers, soon followed. Tom Sawyer was in the skiff that bore
+Judge Thatcher.
+
+When the cave door was unlocked, a sorrowful sight presented itself in
+the dim twilight of the place. Injun Joe lay stretched upon the ground,
+dead, with his face close to the crack of the door, as if his longing
+eyes had been fixed, to the latest moment, upon the light and the cheer
+of the free world outside. Tom was touched, for he knew by his own
+experience how this wretch had suffered. His pity was moved, but
+nevertheless he felt an abounding sense of relief and security, now,
+which revealed to him in a degree which he had not fully appreciated
+before how vast a weight of dread had been lying upon him since the day
+he lifted his voice against this bloody-minded outcast.
+
+Injun Joe’s bowie-knife lay close by, its blade broken in two. The great
+foundation-beam of the door had been chipped and hacked through, with
+tedious labor; useless labor, too, it was, for the native rock formed a
+sill outside it, and upon that stubborn material the knife had wrought
+no effect; the only damage done was to the knife itself. But if there
+had been no stony obstruction there the labor would have been useless
+still, for if the beam had been wholly cut away Injun Joe could not have
+squeezed his body under the door, and he knew it. So he had only hacked
+that place in order to be doing something--in order to pass the weary
+time--in order to employ his tortured faculties. Ordinarily one could
+find half a dozen bits of candle stuck around in the crevices of this
+vestibule, left there by tourists; but there were none now. The prisoner
+had searched them out and eaten them. He had also contrived to catch a
+few bats, and these, also, he had eaten, leaving only their claws. The
+poor unfortunate had starved to death. In one place, near at hand, a
+stalagmite had been slowly growing up from the ground for ages, builded
+by the water-drip from a stalactite overhead. The captive had broken off
+the stalagmite, and upon the stump had placed a stone, wherein he had
+scooped a shallow hollow to catch the precious drop that fell once
+in every three minutes with the dreary regularity of a clock-tick--a
+dessertspoonful once in four and twenty hours. That drop was falling
+when the Pyramids were new; when Troy fell; when the foundations of Rome
+were laid; when Christ was crucified; when the Conqueror created the
+British empire; when Columbus sailed; when the massacre at Lexington was
+“news.”
+
+It is falling now; it will still be falling when all these things shall
+have sunk down the afternoon of history, and the twilight of tradition,
+and been swallowed up in the thick night of oblivion. Has everything a
+purpose and a mission? Did this drop fall patiently during five thousand
+years to be ready for this flitting human insect’s need? and has it
+another important object to accomplish ten thousand years to come? No
+matter. It is many and many a year since the hapless half-breed scooped
+out the stone to catch the priceless drops, but to this day the tourist
+stares longest at that pathetic stone and that slow-dropping water when
+he comes to see the wonders of McDougal’s cave. Injun Joe’s cup stands
+first in the list of the cavern’s marvels; even “Aladdin’s Palace”
+ cannot rival it.
+
+Injun Joe was buried near the mouth of the cave; and people flocked
+there in boats and wagons from the towns and from all the farms and
+hamlets for seven miles around; they brought their children, and
+all sorts of provisions, and confessed that they had had almost as
+satisfactory a time at the funeral as they could have had at the
+hanging.
+
+This funeral stopped the further growth of one thing--the petition to the
+governor for Injun Joe’s pardon. The petition had been largely signed;
+many tearful and eloquent meetings had been held, and a committee of
+sappy women been appointed to go in deep mourning and wail around the
+governor, and implore him to be a merciful ass and trample his duty
+under foot. Injun Joe was believed to have killed five citizens of the
+village, but what of that? If he had been Satan himself there would
+have been plenty of weaklings ready to scribble their names to a
+pardon-petition, and drip a tear on it from their permanently impaired
+and leaky water-works.
+
+The morning after the funeral Tom took Huck to a private place to have
+an important talk. Huck had learned all about Tom’s adventure from the
+Welshman and the Widow Douglas, by this time, but Tom said he reckoned
+there was one thing they had not told him; that thing was what he wanted
+to talk about now. Huck’s face saddened. He said:
+
+“I know what it is. You got into No. 2 and never found anything but
+whiskey. Nobody told me it was you; but I just knowed it must ‘a’ ben
+you, soon as I heard ‘bout that whiskey business; and I knowed you
+hadn’t got the money becuz you’d ‘a’ got at me some way or other and
+told me even if you was mum to everybody else. Tom, something’s always
+told me we’d never get holt of that swag.”
+
+“Why, Huck, I never told on that tavern-keeper. _You_ know his tavern
+was all right the Saturday I went to the picnic. Don’t you remember you
+was to watch there that night?”
+
+“Oh yes! Why, it seems ‘bout a year ago. It was that very night that I
+follered Injun Joe to the widder’s.”
+
+“_You_ followed him?”
+
+“Yes--but you keep mum. I reckon Injun Joe’s left friends behind him, and
+I don’t want ‘em souring on me and doing me mean tricks. If it hadn’t
+ben for me he’d be down in Texas now, all right.”
+
+Then Huck told his entire adventure in confidence to Tom, who had only
+heard of the Welshman’s part of it before.
+
+“Well,” said Huck, presently, coming back to the main question, “whoever
+nipped the whiskey in No. 2, nipped the money, too, I reckon--anyways
+it’s a goner for us, Tom.”
+
+“Huck, that money wasn’t ever in No. 2!”
+
+“What!” Huck searched his comrade’s face keenly. “Tom, have you got on
+the track of that money again?”
+
+“Huck, it’s in the cave!”
+
+Huck’s eyes blazed.
+
+“Say it again, Tom.”
+
+“The money’s in the cave!”
+
+“Tom--honest injun, now--is it fun, or earnest?”
+
+“Earnest, Huck--just as earnest as ever I was in my life. Will you go in
+there with me and help get it out?”
+
+“I bet I will! I will if it’s where we can blaze our way to it and not
+get lost.”
+
+“Huck, we can do that without the least little bit of trouble in the
+world.”
+
+“Good as wheat! What makes you think the money’s--”
+
+“Huck, you just wait till we get in there. If we don’t find it I’ll
+agree to give you my drum and every thing I’ve got in the world. I will,
+by jings.”
+
+“All right--it’s a whiz. When do you say?”
+
+“Right now, if you say it. Are you strong enough?”
+
+“Is it far in the cave? I ben on my pins a little, three or four days,
+now, but I can’t walk more’n a mile, Tom--least I don’t think I could.”
+
+“It’s about five mile into there the way anybody but me would go, Huck,
+but there’s a mighty short cut that they don’t anybody but me know
+about. Huck, I’ll take you right to it in a skiff. I’ll float the skiff
+down there, and I’ll pull it back again all by myself. You needn’t ever
+turn your hand over.”
+
+“Less start right off, Tom.”
+
+“All right. We want some bread and meat, and our pipes, and a little
+bag or two, and two or three kite-strings, and some of these new-fangled
+things they call lucifer matches. I tell you, many’s the time I wished I
+had some when I was in there before.”
+
+A trifle after noon the boys borrowed a small skiff from a citizen who
+was absent, and got under way at once. When they were several miles
+below “Cave Hollow,” Tom said:
+
+“Now you see this bluff here looks all alike all the way down from the
+cave hollow--no houses, no wood-yards, bushes all alike. But do you see
+that white place up yonder where there’s been a landslide? Well, that’s
+one of my marks. We’ll get ashore, now.”
+
+They landed.
+
+“Now, Huck, where we’re a-standing you could touch that hole I got out
+of with a fishing-pole. See if you can find it.”
+
+Huck searched all the place about, and found nothing. Tom proudly
+marched into a thick clump of sumach bushes and said:
+
+“Here you are! Look at it, Huck; it’s the snuggest hole in this country.
+You just keep mum about it. All along I’ve been wanting to be a robber,
+but I knew I’d got to have a thing like this, and where to run across
+it was the bother. We’ve got it now, and we’ll keep it quiet, only we’ll
+let Joe Harper and Ben Rogers in--because of course there’s got to be a
+Gang, or else there wouldn’t be any style about it. Tom Sawyer’s Gang--it
+sounds splendid, don’t it, Huck?”
+
+“Well, it just does, Tom. And who’ll we rob?”
+
+“Oh, most anybody. Waylay people--that’s mostly the way.”
+
+“And kill them?”
+
+“No, not always. Hive them in the cave till they raise a ransom.”
+
+“What’s a ransom?”
+
+“Money. You make them raise all they can, off’n their friends; and after
+you’ve kept them a year, if it ain’t raised then you kill them. That’s
+the general way. Only you don’t kill the women. You shut up the women,
+but you don’t kill them. They’re always beautiful and rich, and awfully
+scared. You take their watches and things, but you always take your hat
+off and talk polite. They ain’t anybody as polite as robbers--you’ll see
+that in any book. Well, the women get to loving you, and after they’ve
+been in the cave a week or two weeks they stop crying and after that
+you couldn’t get them to leave. If you drove them out they’d turn right
+around and come back. It’s so in all the books.”
+
+“Why, it’s real bully, Tom. I believe it’s better’n to be a pirate.”
+
+“Yes, it’s better in some ways, because it’s close to home and circuses
+and all that.”
+
+By this time everything was ready and the boys entered the hole, Tom in
+the lead. They toiled their way to the farther end of the tunnel, then
+made their spliced kite-strings fast and moved on. A few steps brought
+them to the spring, and Tom felt a shudder quiver all through him.
+He showed Huck the fragment of candle-wick perched on a lump of clay
+against the wall, and described how he and Becky had watched the flame
+struggle and expire.
+
+The boys began to quiet down to whispers, now, for the stillness and
+gloom of the place oppressed their spirits. They went on, and presently
+entered and followed Tom’s other corridor until they reached the
+“jumping-off place.” The candles revealed the fact that it was not
+really a precipice, but only a steep clay hill twenty or thirty feet
+high. Tom whispered:
+
+“Now I’ll show you something, Huck.”
+
+He held his candle aloft and said:
+
+“Look as far around the corner as you can. Do you see that? There--on the
+big rock over yonder--done with candle-smoke.”
+
+“Tom, it’s a _cross_!”
+
+“_Now_ where’s your Number Two? ‘_under the cross_,’ hey? Right yonder’s
+where I saw Injun Joe poke up his candle, Huck!”
+
+Huck stared at the mystic sign awhile, and then said with a shaky voice:
+
+“Tom, less git out of here!”
+
+“What! and leave the treasure?”
+
+“Yes--leave it. Injun Joe’s ghost is round about there, certain.”
+
+“No it ain’t, Huck, no it ain’t. It would ha’nt the place where he
+died--away out at the mouth of the cave--five mile from here.”
+
+“No, Tom, it wouldn’t. It would hang round the money. I know the ways of
+ghosts, and so do you.”
+
+Tom began to fear that Huck was right. Mis-givings gathered in his mind.
+But presently an idea occurred to him--
+
+“Lookyhere, Huck, what fools we’re making of ourselves! Injun Joe’s
+ghost ain’t a going to come around where there’s a cross!”
+
+The point was well taken. It had its effect.
+
+“Tom, I didn’t think of that. But that’s so. It’s luck for us, that
+cross is. I reckon we’ll climb down there and have a hunt for that box.”
+
+Tom went first, cutting rude steps in the clay hill as he descended.
+Huck followed. Four avenues opened out of the small cavern which the
+great rock stood in. The boys examined three of them with no result.
+They found a small recess in the one nearest the base of the rock, with
+a pallet of blankets spread down in it; also an old suspender, some
+bacon rind, and the well-gnawed bones of two or three fowls. But there
+was no moneybox. The lads searched and researched this place, but in
+vain. Tom said:
+
+“He said _under_ the cross. Well, this comes nearest to being under the
+cross. It can’t be under the rock itself, because that sets solid on the
+ground.”
+
+They searched everywhere once more, and then sat down discouraged. Huck
+could suggest nothing. By-and-by Tom said:
+
+“Lookyhere, Huck, there’s footprints and some candle-grease on the clay
+about one side of this rock, but not on the other sides. Now, what’s
+that for? I bet you the money _is_ under the rock. I’m going to dig in
+the clay.”
+
+“That ain’t no bad notion, Tom!” said Huck with animation.
+
+Tom’s “real Barlow” was out at once, and he had not dug four inches
+before he struck wood.
+
+“Hey, Huck!--you hear that?”
+
+Huck began to dig and scratch now. Some boards were soon uncovered and
+removed. They had concealed a natural chasm which led under the rock.
+Tom got into this and held his candle as far under the rock as he
+could, but said he could not see to the end of the rift. He proposed
+to explore. He stooped and passed under; the narrow way descended
+gradually. He followed its winding course, first to the right, then to
+the left, Huck at his heels. Tom turned a short curve, by-and-by, and
+exclaimed:
+
+“My goodness, Huck, lookyhere!”
+
+It was the treasure-box, sure enough, occupying a snug little cavern,
+along with an empty powder-keg, a couple of guns in leather cases, two
+or three pairs of old moccasins, a leather belt, and some other rubbish
+well soaked with the water-drip.
+
+“Got it at last!” said Huck, ploughing among the tarnished coins with
+his hand. “My, but we’re rich, Tom!”
+
+“Huck, I always reckoned we’d get it. It’s just too good to believe, but
+we _have_ got it, sure! Say--let’s not fool around here. Let’s snake it
+out. Lemme see if I can lift the box.”
+
+It weighed about fifty pounds. Tom could lift it, after an awkward
+fashion, but could not carry it conveniently.
+
+“I thought so,” he said; “_They_ carried it like it was heavy, that day
+at the ha’nted house. I noticed that. I reckon I was right to think of
+fetching the little bags along.”
+
+The money was soon in the bags and the boys took it up to the cross
+rock.
+
+“Now less fetch the guns and things,” said Huck.
+
+“No, Huck--leave them there. They’re just the tricks to have when we
+go to robbing. We’ll keep them there all the time, and we’ll hold our
+orgies there, too. It’s an awful snug place for orgies.”
+
+“What orgies?”
+
+“I dono. But robbers always have orgies, and of course we’ve got to
+have them, too. Come along, Huck, we’ve been in here a long time. It’s
+getting late, I reckon. I’m hungry, too. We’ll eat and smoke when we get
+to the skiff.”
+
+They presently emerged into the clump of sumach bushes, looked warily
+out, found the coast clear, and were soon lunching and smoking in the
+skiff. As the sun dipped toward the horizon they pushed out and got
+under way. Tom skimmed up the shore through the long twilight, chatting
+cheerily with Huck, and landed shortly after dark.
+
+“Now, Huck,” said Tom, “we’ll hide the money in the loft of the widow’s
+woodshed, and I’ll come up in the morning and we’ll count it and divide,
+and then we’ll hunt up a place out in the woods for it where it will be
+safe. Just you lay quiet here and watch the stuff till I run and hook
+Benny Taylor’s little wagon; I won’t be gone a minute.”
+
+He disappeared, and presently returned with the wagon, put the two small
+sacks into it, threw some old rags on top of them, and started off,
+dragging his cargo behind him. When the boys reached the Welshman’s
+house, they stopped to rest. Just as they were about to move on, the
+Welshman stepped out and said:
+
+“Hallo, who’s that?”
+
+“Huck and Tom Sawyer.”
+
+“Good! Come along with me, boys, you are keeping everybody waiting.
+Here--hurry up, trot ahead--I’ll haul the wagon for you. Why, it’s not as
+light as it might be. Got bricks in it?--or old metal?”
+
+“Old metal,” said Tom.
+
+“I judged so; the boys in this town will take more trouble and fool away
+more time hunting up six bits’ worth of old iron to sell to the foundry
+than they would to make twice the money at regular work. But that’s
+human nature--hurry along, hurry along!”
+
+The boys wanted to know what the hurry was about.
+
+“Never mind; you’ll see, when we get to the Widow Douglas’.”
+
+Huck said with some apprehension--for he was long used to being falsely
+accused:
+
+“Mr. Jones, we haven’t been doing nothing.”
+
+The Welshman laughed.
+
+“Well, I don’t know, Huck, my boy. I don’t know about that. Ain’t you
+and the widow good friends?”
+
+“Yes. Well, she’s ben good friends to me, anyway.”
+
+“All right, then. What do you want to be afraid for?”
+
+This question was not entirely answered in Huck’s slow mind before he
+found himself pushed, along with Tom, into Mrs. Douglas’ drawing-room.
+Mr. Jones left the wagon near the door and followed.
+
+The place was grandly lighted, and everybody that was of any consequence
+in the village was there. The Thatchers were there, the Harpers, the
+Rogerses, Aunt Polly, Sid, Mary, the minister, the editor, and a great
+many more, and all dressed in their best. The widow received the boys
+as heartily as any one could well receive two such looking beings. They
+were covered with clay and candle-grease. Aunt Polly blushed crimson
+with humiliation, and frowned and shook her head at Tom. Nobody suffered
+half as much as the two boys did, however. Mr. Jones said:
+
+“Tom wasn’t at home, yet, so I gave him up; but I stumbled on him and
+Huck right at my door, and so I just brought them along in a hurry.”
+
+“And you did just right,” said the widow. “Come with me, boys.”
+
+She took them to a bedchamber and said:
+
+“Now wash and dress yourselves. Here are two new suits of
+clothes--shirts, socks, everything complete. They’re Huck’s--no, no
+thanks, Huck--Mr. Jones bought one and I the other. But they’ll fit both
+of you. Get into them. We’ll wait--come down when you are slicked up
+enough.”
+
+Then she left.
+
+
+
+
+CHAPTER XXXIV
+
+HUCK said: “Tom, we can slope, if we can find a rope. The window ain’t
+high from the ground.”
+
+“Shucks! what do you want to slope for?”
+
+“Well, I ain’t used to that kind of a crowd. I can’t stand it. I ain’t
+going down there, Tom.”
+
+“Oh, bother! It ain’t anything. I don’t mind it a bit. I’ll take care of
+you.”
+
+Sid appeared.
+
+“Tom,” said he, “auntie has been waiting for you all the afternoon. Mary
+got your Sunday clothes ready, and everybody’s been fretting about you.
+Say--ain’t this grease and clay, on your clothes?”
+
+“Now, Mr. Siddy, you jist ‘tend to your own business. What’s all this
+blowout about, anyway?”
+
+“It’s one of the widow’s parties that she’s always having. This time
+it’s for the Welshman and his sons, on account of that scrape they
+helped her out of the other night. And say--I can tell you something, if
+you want to know.”
+
+“Well, what?”
+
+“Why, old Mr. Jones is going to try to spring something on the people
+here tonight, but I overheard him tell auntie today about it, as a
+secret, but I reckon it’s not much of a secret now. Everybody knows--the
+widow, too, for all she tries to let on she don’t. Mr. Jones was bound
+Huck should be here--couldn’t get along with his grand secret without
+Huck, you know!”
+
+“Secret about what, Sid?”
+
+“About Huck tracking the robbers to the widow’s. I reckon Mr. Jones was
+going to make a grand time over his surprise, but I bet you it will drop
+pretty flat.”
+
+Sid chuckled in a very contented and satisfied way.
+
+“Sid, was it you that told?”
+
+“Oh, never mind who it was. _Somebody_ told--that’s enough.”
+
+“Sid, there’s only one person in this town mean enough to do that, and
+that’s you. If you had been in Huck’s place you’d ‘a’ sneaked down the
+hill and never told anybody on the robbers. You can’t do any but mean
+things, and you can’t bear to see anybody praised for doing good ones.
+There--no thanks, as the widow says”--and Tom cuffed Sid’s ears and helped
+him to the door with several kicks. “Now go and tell auntie if you
+dare--and tomorrow you’ll catch it!”
+
+Some minutes later the widow’s guests were at the supper-table, and a
+dozen children were propped up at little side-tables in the same room,
+after the fashion of that country and that day. At the proper time Mr.
+Jones made his little speech, in which he thanked the widow for the
+honor she was doing himself and his sons, but said that there was
+another person whose modesty--
+
+And so forth and so on. He sprung his secret about Huck’s share in
+the adventure in the finest dramatic manner he was master of, but the
+surprise it occasioned was largely counterfeit and not as clamorous and
+effusive as it might have been under happier circumstances. However,
+the widow made a pretty fair show of astonishment, and heaped so many
+compliments and so much gratitude upon Huck that he almost forgot
+the nearly intolerable discomfort of his new clothes in the entirely
+intolerable discomfort of being set up as a target for everybody’s gaze
+and everybody’s laudations.
+
+The widow said she meant to give Huck a home under her roof and have him
+educated; and that when she could spare the money she would start him in
+business in a modest way. Tom’s chance was come. He said:
+
+“Huck don’t need it. Huck’s rich.”
+
+Nothing but a heavy strain upon the good manners of the company kept
+back the due and proper complimentary laugh at this pleasant joke. But
+the silence was a little awkward. Tom broke it:
+
+“Huck’s got money. Maybe you don’t believe it, but he’s got lots of it.
+Oh, you needn’t smile--I reckon I can show you. You just wait a minute.”
+
+Tom ran out of doors. The company looked at each other with a perplexed
+interest--and inquiringly at Huck, who was tongue-tied.
+
+“Sid, what ails Tom?” said Aunt Polly. “He--well, there ain’t ever any
+making of that boy out. I never--”
+
+Tom entered, struggling with the weight of his sacks, and Aunt Polly
+did not finish her sentence. Tom poured the mass of yellow coin upon the
+table and said:
+
+“There--what did I tell you? Half of it’s Huck’s and half of it’s mine!”
+
+The spectacle took the general breath away. All gazed, nobody spoke for
+a moment. Then there was a unanimous call for an explanation. Tom said
+he could furnish it, and he did. The tale was long, but brimful of
+interest. There was scarcely an interruption from any one to break the
+charm of its flow. When he had finished, Mr. Jones said:
+
+“I thought I had fixed up a little surprise for this occasion, but it
+don’t amount to anything now. This one makes it sing mighty small, I’m
+willing to allow.”
+
+The money was counted. The sum amounted to a little over twelve thousand
+dollars. It was more than any one present had ever seen at one time
+before, though several persons were there who were worth considerably
+more than that in property.
+
+
+
+
+CHAPTER XXXV
+
+THE reader may rest satisfied that Tom’s and Huck’s windfall made a
+mighty stir in the poor little village of St. Petersburg. So vast a
+sum, all in actual cash, seemed next to incredible. It was talked
+about, gloated over, glorified, until the reason of many of the citizens
+tottered under the strain of the unhealthy excitement. Every “haunted”
+ house in St. Petersburg and the neighboring villages was dissected,
+plank by plank, and its foundations dug up and ransacked for hidden
+treasure--and not by boys, but men--pretty grave, unromantic men, too,
+some of them. Wherever Tom and Huck appeared they were courted, admired,
+stared at. The boys were not able to remember that their remarks had
+possessed weight before; but now their sayings were treasured and
+repeated; everything they did seemed somehow to be regarded as
+remarkable; they had evidently lost the power of doing and saying
+commonplace things; moreover, their past history was raked up and
+discovered to bear marks of conspicuous originality. The village paper
+published biographical sketches of the boys.
+
+The Widow Douglas put Huck’s money out at six per cent., and Judge
+Thatcher did the same with Tom’s at Aunt Polly’s request. Each lad had
+an income, now, that was simply prodigious--a dollar for every weekday in
+the year and half of the Sundays. It was just what the minister got--no,
+it was what he was promised--he generally couldn’t collect it. A dollar
+and a quarter a week would board, lodge, and school a boy in those old
+simple days--and clothe him and wash him, too, for that matter.
+
+Judge Thatcher had conceived a great opinion of Tom. He said that no
+commonplace boy would ever have got his daughter out of the cave. When
+Becky told her father, in strict confidence, how Tom had taken her
+whipping at school, the Judge was visibly moved; and when she pleaded
+grace for the mighty lie which Tom had told in order to shift that
+whipping from her shoulders to his own, the Judge said with a fine
+outburst that it was a noble, a generous, a magnanimous lie--a lie that
+was worthy to hold up its head and march down through history breast to
+breast with George Washington’s lauded Truth about the hatchet! Becky
+thought her father had never looked so tall and so superb as when he
+walked the floor and stamped his foot and said that. She went straight
+off and told Tom about it.
+
+Judge Thatcher hoped to see Tom a great lawyer or a great soldier some
+day. He said he meant to look to it that Tom should be admitted to the
+National Military Academy and afterward trained in the best law school
+in the country, in order that he might be ready for either career or
+both.
+
+Huck Finn’s wealth and the fact that he was now under the Widow Douglas’
+protection introduced him into society--no, dragged him into it, hurled
+him into it--and his sufferings were almost more than he could bear. The
+widow’s servants kept him clean and neat, combed and brushed, and they
+bedded him nightly in unsympathetic sheets that had not one little spot
+or stain which he could press to his heart and know for a friend. He had
+to eat with a knife and fork; he had to use napkin, cup, and plate;
+he had to learn his book, he had to go to church; he had to talk so
+properly that speech was become insipid in his mouth; whithersoever he
+turned, the bars and shackles of civilization shut him in and bound him
+hand and foot.
+
+He bravely bore his miseries three weeks, and then one day turned up
+missing. For forty-eight hours the widow hunted for him everywhere in
+great distress. The public were profoundly concerned; they searched high
+and low, they dragged the river for his body. Early the third morning
+Tom Sawyer wisely went poking among some old empty hogsheads down behind
+the abandoned slaughter-house, and in one of them he found the refugee.
+Huck had slept there; he had just breakfasted upon some stolen odds and
+ends of food, and was lying off, now, in comfort, with his pipe. He was
+unkempt, uncombed, and clad in the same old ruin of rags that had made
+him picturesque in the days when he was free and happy. Tom routed him
+out, told him the trouble he had been causing, and urged him to go home.
+Huck’s face lost its tranquil content, and took a melancholy cast. He
+said:
+
+“Don’t talk about it, Tom. I’ve tried it, and it don’t work; it don’t
+work, Tom. It ain’t for me; I ain’t used to it. The widder’s good to me,
+and friendly; but I can’t stand them ways. She makes me get up just
+at the same time every morning; she makes me wash, they comb me all
+to thunder; she won’t let me sleep in the woodshed; I got to wear them
+blamed clothes that just smothers me, Tom; they don’t seem to any air
+git through ‘em, somehow; and they’re so rotten nice that I can’t
+set down, nor lay down, nor roll around anywher’s; I hain’t slid on a
+cellar-door for--well, it ‘pears to be years; I got to go to church
+and sweat and sweat--I hate them ornery sermons! I can’t ketch a fly in
+there, I can’t chaw. I got to wear shoes all Sunday. The widder eats by
+a bell; she goes to bed by a bell; she gits up by a bell--everything’s so
+awful reg’lar a body can’t stand it.”
+
+“Well, everybody does that way, Huck.”
+
+“Tom, it don’t make no difference. I ain’t everybody, and I can’t
+_stand_ it. It’s awful to be tied up so. And grub comes too easy--I don’t
+take no interest in vittles, that way. I got to ask to go a-fishing;
+I got to ask to go in a-swimming--dern’d if I hain’t got to ask to do
+everything. Well, I’d got to talk so nice it wasn’t no comfort--I’d got
+to go up in the attic and rip out awhile, every day, to git a taste
+in my mouth, or I’d a died, Tom. The widder wouldn’t let me smoke;
+she wouldn’t let me yell, she wouldn’t let me gape, nor stretch, nor
+scratch, before folks--” [Then with a spasm of special irritation and
+injury]--“And dad fetch it, she prayed all the time! I never see such a
+woman! I _had_ to shove, Tom--I just had to. And besides, that school’s
+going to open, and I’d a had to go to it--well, I wouldn’t stand _that_,
+Tom. Looky-here, Tom, being rich ain’t what it’s cracked up to be. It’s
+just worry and worry, and sweat and sweat, and a-wishing you was dead
+all the time. Now these clothes suits me, and this bar’l suits me, and
+I ain’t ever going to shake ‘em any more. Tom, I wouldn’t ever got into
+all this trouble if it hadn’t ‘a’ ben for that money; now you just take
+my sheer of it along with your’n, and gimme a ten-center sometimes--not
+many times, becuz I don’t give a dern for a thing ‘thout it’s tollable
+hard to git--and you go and beg off for me with the widder.”
+
+“Oh, Huck, you know I can’t do that. ‘Tain’t fair; and besides if you’ll
+try this thing just a while longer you’ll come to like it.”
+
+“Like it! Yes--the way I’d like a hot stove if I was to set on it long
+enough. No, Tom, I won’t be rich, and I won’t live in them cussed
+smothery houses. I like the woods, and the river, and hogsheads, and
+I’ll stick to ‘em, too. Blame it all! just as we’d got guns, and a cave,
+and all just fixed to rob, here this dern foolishness has got to come up
+and spile it all!”
+
+Tom saw his opportunity--
+
+“Lookyhere, Huck, being rich ain’t going to keep me back from turning
+robber.”
+
+“No! Oh, good-licks; are you in real dead-wood earnest, Tom?”
+
+“Just as dead earnest as I’m sitting here. But Huck, we can’t let you
+into the gang if you ain’t respectable, you know.”
+
+Huck’s joy was quenched.
+
+“Can’t let me in, Tom? Didn’t you let me go for a pirate?”
+
+“Yes, but that’s different. A robber is more high-toned than what a
+pirate is--as a general thing. In most countries they’re awful high up in
+the nobility--dukes and such.”
+
+“Now, Tom, hain’t you always ben friendly to me? You wouldn’t shet me
+out, would you, Tom? You wouldn’t do that, now, _would_ you, Tom?”
+
+“Huck, I wouldn’t want to, and I _don’t_ want to--but what would people
+say? Why, they’d say, ‘Mph! Tom Sawyer’s Gang! pretty low characters in
+it!’ They’d mean you, Huck. You wouldn’t like that, and I wouldn’t.”
+
+Huck was silent for some time, engaged in a mental struggle. Finally he
+said:
+
+“Well, I’ll go back to the widder for a month and tackle it and see if I
+can come to stand it, if you’ll let me b’long to the gang, Tom.”
+
+“All right, Huck, it’s a whiz! Come along, old chap, and I’ll ask the
+widow to let up on you a little, Huck.”
+
+“Will you, Tom--now will you? That’s good. If she’ll let up on some of
+the roughest things, I’ll smoke private and cuss private, and crowd
+through or bust. When you going to start the gang and turn robbers?”
+
+“Oh, right off. We’ll get the boys together and have the initiation
+tonight, maybe.”
+
+“Have the which?”
+
+“Have the initiation.”
+
+“What’s that?”
+
+“It’s to swear to stand by one another, and never tell the gang’s
+secrets, even if you’re chopped all to flinders, and kill anybody and
+all his family that hurts one of the gang.”
+
+“That’s gay--that’s mighty gay, Tom, I tell you.”
+
+“Well, I bet it is. And all that swearing’s got to be done at midnight,
+in the lonesomest, awfulest place you can find--a ha’nted house is the
+best, but they’re all ripped up now.”
+
+“Well, midnight’s good, anyway, Tom.”
+
+“Yes, so it is. And you’ve got to swear on a coffin, and sign it with
+blood.”
+
+“Now, that’s something _like_! Why, it’s a million times bullier than
+pirating. I’ll stick to the widder till I rot, Tom; and if I git to be
+a reg’lar ripper of a robber, and everybody talking ‘bout it, I reckon
+she’ll be proud she snaked me in out of the wet.”
+
+CONCLUSION
+
+SO endeth this chronicle. It being strictly a history of a _boy_, it
+must stop here; the story could not go much further without becoming the
+history of a _man_. When one writes a novel about grown people, he knows
+exactly where to stop--that is, with a marriage; but when he writes of
+juveniles, he must stop where he best can.
+
+Most of the characters that perform in this book still live, and are
+prosperous and happy. Some day it may seem worth while to take up the
+story of the younger ones again and see what sort of men and women they
+turned out to be; therefore it will be wisest not to reveal any of that
+part of their lives at present.
+
+End of the Project Gutenberg Ebook of Adventures of Tom Sawyer,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+***** This file should be named 74-0.txt or 74-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/74/
+
+Produced by David Widger. The previous edition was updated by Jose
+Menendez.
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES- Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND- If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY- You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/source-sink-builder/src/main/resources/books/war-of-the-worlds.txt
+++ b/jet/source-sink-builder/src/main/resources/books/war-of-the-worlds.txt
@@ -1,0 +1,6869 @@
+﻿The Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The War of the Worlds
+
+Author: H. G. Wells
+
+Release Date: July, 1992 [EBook #36]
+[Most recently updated October 1, 2004]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+
+
+
+
+
+
+
+
+
+
+The War of the Worlds
+
+by H. G. Wells [1898]
+
+
+     But who shall dwell in these worlds if they be
+     inhabited? .  .  .  Are we or they Lords of the
+     World? .  .  .  And how are all things made for man?--
+          KEPLER (quoted in The Anatomy of Melancholy)
+
+
+
+BOOK ONE
+
+THE COMING OF THE MARTIANS
+
+
+
+CHAPTER ONE
+
+THE EVE OF THE WAR
+
+
+No one would have believed in the last years of the nineteenth
+century that this world was being watched keenly and closely by
+intelligences greater than man's and yet as mortal as his own; that as
+men busied themselves about their various concerns they were
+scrutinised and studied, perhaps almost as narrowly as a man with a
+microscope might scrutinise the transient creatures that swarm and
+multiply in a drop of water.  With infinite complacency men went to
+and fro over this globe about their little affairs, serene in their
+assurance of their empire over matter.  It is possible that the
+infusoria under the microscope do the same.  No one gave a thought to
+the older worlds of space as sources of human danger, or thought of
+them only to dismiss the idea of life upon them as impossible or
+improbable.  It is curious to recall some of the mental habits of
+those departed days.  At most terrestrial men fancied there might be
+other men upon Mars, perhaps inferior to themselves and ready to
+welcome a missionary enterprise.  Yet across the gulf of space, minds
+that are to our minds as ours are to those of the beasts that perish,
+intellects vast and cool and unsympathetic, regarded this earth with
+envious eyes, and slowly and surely drew their plans against us.  And
+early in the twentieth century came the great disillusionment.
+
+The planet Mars, I scarcely need remind the reader, revolves about the
+sun at a mean distance of 140,000,000 miles, and the light and heat it
+receives from the sun is barely half of that received by this world.
+It must be, if the nebular hypothesis has any truth, older than our
+world; and long before this earth ceased to be molten, life upon its
+surface must have begun its course.  The fact that it is scarcely one
+seventh of the volume of the earth must have accelerated its cooling
+to the temperature at which life could begin.  It has air and water
+and all that is necessary for the support of animated existence.
+
+Yet so vain is man, and so blinded by his vanity, that no writer,
+up to the very end of the nineteenth century, expressed any idea that
+intelligent life might have developed there far, or indeed at all,
+beyond its earthly level.  Nor was it generally understood that since
+Mars is older than our earth, with scarcely a quarter of the
+superficial area and remoter from the sun, it necessarily follows that
+it is not only more distant from time's beginning but nearer its end.
+
+The secular cooling that must someday overtake our planet has
+already gone far indeed with our neighbour.  Its physical condition is
+still largely a mystery, but we know now that even in its equatorial
+region the midday temperature barely approaches that of our coldest
+winter.  Its air is much more attenuated than ours, its oceans have
+shrunk until they cover but a third of its surface, and as its slow
+seasons change huge snowcaps gather and melt about either pole and
+periodically inundate its temperate zones.  That last stage of
+exhaustion, which to us is still incredibly remote, has become a
+present-day problem for the inhabitants of Mars.  The immediate
+pressure of necessity has brightened their intellects, enlarged their
+powers, and hardened their hearts.  And looking across space with
+instruments, and intelligences such as we have scarcely dreamed of,
+they see, at its nearest distance only 35,000,000 of miles sunward of
+them, a morning star of hope, our own warmer planet, green with
+vegetation and grey with water, with a cloudy atmosphere eloquent of
+fertility, with glimpses through its drifting cloud wisps of broad
+stretches of populous country and narrow, navy-crowded seas.
+
+And we men, the creatures who inhabit this earth, must be to them
+at least as alien and lowly as are the monkeys and lemurs to us.  The
+intellectual side of man already admits that life is an incessant
+struggle for existence, and it would seem that this too is the belief
+of the minds upon Mars.  Their world is far gone in its cooling and
+this world is still crowded with life, but crowded only with what they
+regard as inferior animals.  To carry warfare sunward is, indeed,
+their only escape from the destruction that, generation after
+generation, creeps upon them.
+
+And before we judge of them too harshly we must remember what
+ruthless and utter destruction our own species has wrought, not only
+upon animals, such as the vanished bison and the dodo, but upon its
+inferior races.  The Tasmanians, in spite of their human likeness,
+were entirely swept out of existence in a war of extermination waged
+by European immigrants, in the space of fifty years.  Are we such
+apostles of mercy as to complain if the Martians warred in the same
+spirit?
+
+The Martians seem to have calculated their descent with amazing
+subtlety--their mathematical learning is evidently far in excess of
+ours--and to have carried out their preparations with a well-nigh
+perfect unanimity.  Had our instruments permitted it, we might have
+seen the gathering trouble far back in the nineteenth century.  Men
+like Schiaparelli watched the red planet--it is odd, by-the-bye, that
+for countless centuries Mars has been the star of war--but failed to
+interpret the fluctuating appearances of the markings they mapped so
+well.  All that time the Martians must have been getting ready.
+
+During the opposition of 1894 a great light was seen on the
+illuminated part of the disk, first at the Lick Observatory, then by
+Perrotin of Nice, and then by other observers.  English readers heard
+of it first in the issue of _Nature_ dated August 2.  I am inclined to
+think that this blaze may have been the casting of the huge gun, in
+the vast pit sunk into their planet, from which their shots were fired
+at us.  Peculiar markings, as yet unexplained, were seen near the site
+of that outbreak during the next two oppositions.
+
+The storm burst upon us six years ago now.  As Mars approached
+opposition, Lavelle of Java set the wires of the astronomical exchange
+palpitating with the amazing intelligence of a huge outbreak of
+incandescent gas upon the planet.  It had occurred towards midnight of
+the twelfth; and the spectroscope, to which he had at once resorted,
+indicated a mass of flaming gas, chiefly hydrogen, moving with an
+enormous velocity towards this earth.  This jet of fire had become
+invisible about a quarter past twelve.  He compared it to a colossal
+puff of flame suddenly and violently squirted out of the planet, "as
+flaming gases rushed out of a gun."
+
+A singularly appropriate phrase it proved.  Yet the next day there
+was nothing of this in the papers except a little note in the _Daily
+Telegraph_, and the world went in ignorance of one of the gravest
+dangers that ever threatened the human race. I might not have heard of
+the eruption at all had I not met Ogilvy, the well-known astronomer,
+at Ottershaw.  He was immensely excited at the news, and in the excess
+of his feelings invited me up to take a turn with him that night in a
+scrutiny of the red planet.
+
+In spite of all that has happened since, I still remember that
+vigil very distinctly: the black and silent observatory, the shadowed
+lantern throwing a feeble glow upon the floor in the corner, the
+steady ticking of the clockwork of the telescope, the little slit in
+the roof--an oblong profundity with the stardust streaked across it.
+Ogilvy moved about, invisible but audible.  Looking through the
+telescope, one saw a circle of deep blue and the little round planet
+swimming in the field.  It seemed such a little thing, so bright and
+small and still, faintly marked with transverse stripes, and slightly
+flattened from the perfect round.  But so little it was, so silvery
+warm--a pin's-head of light! It was as if it quivered, but really this
+was the telescope vibrating with the activity of the clockwork that
+kept the planet in view.
+
+As I watched, the planet seemed to grow larger and smaller and to
+advance and recede, but that was simply that my eye was tired.  Forty
+millions of miles it was from us--more than forty millions of miles of
+void.  Few people realise the immensity of vacancy in which the dust
+of the material universe swims.
+
+Near it in the field, I remember, were three faint points of light,
+three telescopic stars infinitely remote, and all around it was the
+unfathomable darkness of empty space.  You know how that blackness
+looks on a frosty starlight night.  In a telescope it seems far
+profounder.  And invisible to me because it was so remote and small,
+flying swiftly and steadily towards me across that incredible
+distance, drawing nearer every minute by so many thousands of miles,
+came the Thing they were sending us, the Thing that was to bring so
+much struggle and calamity and death to the earth.  I never dreamed of
+it then as I watched; no one on earth dreamed of that unerring
+missile.
+
+That night, too, there was another jetting out of gas from the
+distant planet.  I saw it.  A reddish flash at the edge, the slightest
+projection of the outline just as the chronometer struck midnight; and
+at that I told Ogilvy and he took my place.  The night was warm and I
+was thirsty, and I went stretching my legs clumsily and feeling my way
+in the darkness, to the little table where the siphon stood, while
+Ogilvy exclaimed at the streamer of gas that came out towards us.
+
+That night another invisible missile started on its way to the
+earth from Mars, just a second or so under twenty-four hours after the
+first one.  I remember how I sat on the table there in the blackness,
+with patches of green and crimson swimming before my eyes.  I wished I
+had a light to smoke by, little suspecting the meaning of the minute
+gleam I had seen and all that it would presently bring me.  Ogilvy
+watched till one, and then gave it up; and we lit the lantern and
+walked over to his house.  Down below in the darkness were Ottershaw
+and Chertsey and all their hundreds of people, sleeping in peace.
+
+He was full of speculation that night about the condition of Mars,
+and scoffed at the vulgar idea of its having inhabitants who were
+signalling us.  His idea was that meteorites might be falling in a
+heavy shower upon the planet, or that a huge volcanic explosion was in
+progress.  He pointed out to me how unlikely it was that organic
+evolution had taken the same direction in the two adjacent planets.
+
+"The chances against anything manlike on Mars are a million to
+one," he said.
+
+Hundreds of observers saw the flame that night and the night after
+about midnight, and again the night after; and so for ten nights, a
+flame each night.  Why the shots ceased after the tenth no one on
+earth has attempted to explain.  It may be the gases of the firing
+caused the Martians inconvenience.  Dense clouds of smoke or dust,
+visible through a powerful telescope on earth as little grey,
+fluctuating patches, spread through the clearness of the planet's
+atmosphere and obscured its more familiar features.
+
+Even the daily papers woke up to the disturbances at last, and
+popular notes appeared here, there, and everywhere concerning the
+volcanoes upon Mars.  The seriocomic periodical _Punch_, I remember,
+made a happy use of it in the political cartoon.  And, all
+unsuspected, those missiles the Martians had fired at us drew
+earthward, rushing now at a pace of many miles a second through the
+empty gulf of space, hour by hour and day by day, nearer and nearer.
+It seems to me now almost incredibly wonderful that, with that swift
+fate hanging over us, men could go about their petty concerns as they
+did.  I remember how jubilant Markham was at securing a new photograph
+of the planet for the illustrated paper he edited in those days.
+People in these latter times scarcely realise the abundance and
+enterprise of our nineteenth-century papers.  For my own part, I was
+much occupied in learning to ride the bicycle, and busy upon a series
+of papers discussing the probable developments of moral ideas as
+civilisation progressed.
+
+One night (the first missile then could scarcely have been
+10,000,000 miles away) I went for a walk with my wife.  It was
+starlight and I explained the Signs of the Zodiac to her, and pointed
+out Mars, a bright dot of light creeping zenithward, towards which so
+many telescopes were pointed.  It was a warm night.  Coming home, a
+party of excursionists from Chertsey or Isleworth passed us singing
+and playing music.  There were lights in the upper windows of the
+houses as the people went to bed.  From the railway station in the
+distance came the sound of shunting trains, ringing and rumbling,
+softened almost into melody by the distance.  My wife pointed out to
+me the brightness of the red, green, and yellow signal lights hanging
+in a framework against the sky.  It seemed so safe and tranquil.
+
+
+
+CHAPTER TWO
+
+THE FALLING STAR
+
+
+Then came the night of the first falling star.  It was seen early
+in the morning, rushing over Winchester eastward, a line of flame high
+in the atmosphere.  Hundreds must have seen it, and taken it for an
+ordinary falling star.  Albin described it as leaving a greenish
+streak behind it that glowed for some seconds.  Denning, our greatest
+authority on meteorites, stated that the height of its first
+appearance was about ninety or one hundred miles.  It seemed to him
+that it fell to earth about one hundred miles east of him.
+
+I was at home at that hour and writing in my study; and although my
+French windows face towards Ottershaw and the blind was up (for I
+loved in those days to look up at the night sky), I saw nothing of it.
+Yet this strangest of all things that ever came to earth from outer
+space must have fallen while I was sitting there, visible to me had I
+only looked up as it passed.  Some of those who saw its flight say it
+travelled with a hissing sound.  I myself heard nothing of that.  Many
+people in Berkshire, Surrey, and Middlesex must have seen the fall of
+it, and, at most, have thought that another meteorite had descended.
+No one seems to have troubled to look for the fallen mass that night.
+
+But very early in the morning poor Ogilvy, who had seen the
+shooting star and who was persuaded that a meteorite lay somewhere on
+the common between Horsell, Ottershaw, and Woking, rose early with the
+idea of finding it.  Find it he did, soon after dawn, and not far from
+the sand pits.  An enormous hole had been made by the impact of the
+projectile, and the sand and gravel had been flung violently in every
+direction over the heath, forming heaps visible a mile and a half
+away.  The heather was on fire eastward, and a thin blue smoke rose
+against the dawn.
+
+The Thing itself lay almost entirely buried in sand, amidst the
+scattered splinters of a fir tree it had shivered to fragments in its
+descent.  The uncovered part had the appearance of a huge cylinder,
+caked over and its outline softened by a thick scaly dun-coloured
+incrustation.  It had a diameter of about thirty yards.  He approached
+the mass, surprised at the size and more so at the shape, since most
+meteorites are rounded more or less completely.  It was, however,
+still so hot from its flight through the air as to forbid his near
+approach.  A stirring noise within its cylinder he ascribed to the
+unequal cooling of its surface; for at that time it had not occurred
+to him that it might be hollow.
+
+He remained standing at the edge of the pit that the Thing had made
+for itself, staring at its strange appearance, astonished chiefly at
+its unusual shape and colour, and dimly perceiving even then some
+evidence of design in its arrival.  The early morning was wonderfully
+still, and the sun, just clearing the pine trees towards Weybridge,
+was already warm.  He did not remember hearing any birds that morning,
+there was certainly no breeze stirring, and the only sounds were the
+faint movements from within the cindery cylinder.  He was all alone on
+the common.
+
+Then suddenly he noticed with a start that some of the grey
+clinker, the ashy incrustation that covered the meteorite, was falling
+off the circular edge of the end.  It was dropping off in flakes and
+raining down upon the sand.  A large piece suddenly came off and fell
+with a sharp noise that brought his heart into his mouth.
+
+For a minute he scarcely realised what this meant, and, although
+the heat was excessive, he clambered down into the pit close to the
+bulk to see the Thing more clearly.  He fancied even then that the
+cooling of the body might account for this, but what disturbed that
+idea was the fact that the ash was falling only from the end of the
+cylinder.
+
+And then he perceived that, very slowly, the circular top of the
+cylinder was rotating on its body.  It was such a gradual movement
+that he discovered it only through noticing that a black mark that had
+been near him five minutes ago was now at the other side of the
+circumference.  Even then he scarcely understood what this indicated,
+until he heard a muffled grating sound and saw the black mark jerk
+forward an inch or so.  Then the thing came upon him in a flash.  The
+cylinder was artificial--hollow--with an end that screwed out!
+Something within the cylinder was unscrewing the top!
+
+"Good heavens!" said Ogilvy.  "There's a man in it--men in it! Half
+roasted to death!  Trying to escape!"
+
+At once, with a quick mental leap, he linked the Thing with the
+flash upon Mars.
+
+The thought of the confined creature was so dreadful to him that he
+forgot the heat and went forward to the cylinder to help turn.  But
+luckily the dull radiation arrested him before he could burn his hands
+on the still-glowing metal.  At that he stood irresolute for a moment,
+then turned, scrambled out of the pit, and set off running wildly into
+Woking.  The time then must have been somewhere about six o'clock.
+He met a waggoner and tried to make him understand, but the tale he
+told and his appearance were so wild--his hat had fallen off in the
+pit--that the man simply drove on.  He was equally unsuccessful with the
+potman who was just unlocking the doors of the public-house by Horsell
+Bridge.  The fellow thought he was a lunatic at large and made an
+unsuccessful attempt to shut him into the taproom.  That sobered him a
+little; and when he saw Henderson, the London journalist, in his
+garden, he called over the palings and made himself understood.
+
+"Henderson," he called, "you saw that shooting star last night?"
+
+"Well?" said Henderson.
+
+"It's out on Horsell Common now."
+
+"Good Lord!" said Henderson.  "Fallen meteorite!  That's good."
+
+"But it's something more than a meteorite.  It's a cylinder--an
+artificial cylinder, man!  And there's something inside."
+
+Henderson stood up with his spade in his hand.
+
+"What's that?" he said.  He was deaf in one ear.
+
+Ogilvy told him all that he had seen.  Henderson was a minute or so
+taking it in.  Then he dropped his spade, snatched up his jacket, and
+came out into the road.  The two men hurried back at once to the
+common, and found the cylinder still lying in the same position.  But
+now the sounds inside had ceased, and a thin circle of bright metal
+showed between the top and the body of the cylinder.  Air was either
+entering or escaping at the rim with a thin, sizzling sound.
+
+They listened, rapped on the scaly burnt metal with a stick, and,
+meeting with no response, they both concluded the man or men inside
+must be insensible or dead.
+
+Of course the two were quite unable to do anything.  They shouted
+consolation and promises, and went off back to the town again to get
+help.  One can imagine them, covered with sand, excited and
+disordered, running up the little street in the bright sunlight just
+as the shop folks were taking down their shutters and people were
+opening their bedroom windows.  Henderson went into the railway
+station at once, in order to telegraph the news to London.  The
+newspaper articles had prepared men's minds for the reception of the
+idea.
+
+By eight o'clock a number of boys and unemployed men had already
+started for the common to see the "dead men from Mars."  That was the
+form the story took.  I heard of it first from my newspaper boy about
+a quarter to nine when I went out to get my _Daily Chronicle_.  I was
+naturally startled, and lost no time in going out and across the
+Ottershaw bridge to the sand pits.
+
+
+
+CHAPTER THREE
+
+ON HORSELL COMMON
+
+
+I found a little crowd of perhaps twenty people surrounding the
+huge hole in which the cylinder lay.  I have already described the
+appearance of that colossal bulk, embedded in the ground.  The turf
+and gravel about it seemed charred as if by a sudden explosion.  No
+doubt its impact had caused a flash of fire.  Henderson and Ogilvy
+were not there.  I think they perceived that nothing was to be done
+for the present, and had gone away to breakfast at Henderson's house.
+
+There were four or five boys sitting on the edge of the Pit, with
+their feet dangling, and amusing themselves--until I stopped them--by
+throwing stones at the giant mass.  After I had spoken to them about
+it, they began playing at "touch" in and out of the group of
+bystanders.
+
+Among these were a couple of cyclists, a jobbing gardener I
+employed sometimes, a girl carrying a baby, Gregg the butcher and his
+little boy, and two or three loafers and golf caddies who were
+accustomed to hang about the railway station.  There was very little
+talking.  Few of the common people in England had anything but the
+vaguest astronomical ideas in those days.  Most of them were staring
+quietly at the big table like end of the cylinder, which was still as
+Ogilvy and Henderson had left it.  I fancy the popular expectation of
+a heap of charred corpses was disappointed at this inanimate bulk.
+Some went away while I was there, and other people came.  I clambered
+into the pit and fancied I heard a faint movement under my feet.  The
+top had certainly ceased to rotate.
+
+It was only when I got thus close to it that the strangeness of
+this object was at all evident to me.  At the first glance it was
+really no more exciting than an overturned carriage or a tree blown
+across the road.  Not so much so, indeed.  It looked like a rusty gas
+float.  It required a certain amount of scientific education to
+perceive that the grey scale of the Thing was no common oxide, that
+the yellowish-white metal that gleamed in the crack between the lid
+and the cylinder had an unfamiliar hue.  "Extra-terrestrial" had no
+meaning for most of the onlookers.
+
+At that time it was quite clear in my own mind that the Thing had
+come from the planet Mars, but I judged it improbable that it
+contained any living creature.  I thought the unscrewing might be
+automatic.  In spite of Ogilvy, I still believed that there were men
+in Mars.  My mind ran fancifully on the possibilities of its
+containing manuscript, on the difficulties in translation that might
+arise, whether we should find coins and models in it, and so forth.
+Yet it was a little too large for assurance on this idea.  I felt an
+impatience to see it opened.  About eleven, as nothing seemed
+happening, I walked back, full of such thought, to my home in Maybury.
+But I found it difficult to get to work upon my abstract
+investigations.
+
+In the afternoon the appearance of the common had altered very
+much.  The early editions of the evening papers had startled London
+with enormous headlines:
+
+  "A MESSAGE RECEIVED FROM MARS."
+
+  "REMARKABLE STORY FROM WOKING,"
+
+and so forth.  In addition, Ogilvy's wire to the Astronomical Exchange
+had roused every observatory in the three kingdoms.
+
+There were half a dozen flies or more from the Woking station
+standing in the road by the sand pits, a basket-chaise from Chobham,
+and a rather lordly carriage.  Besides that, there was quite a heap of
+bicycles.  In addition, a large number of people must have walked, in
+spite of the heat of the day, from Woking and Chertsey, so that there
+was altogether quite a considerable crowd--one or two gaily dressed
+ladies among the others.
+
+It was glaringly hot, not a cloud in the sky nor a breath of wind,
+and the only shadow was that of the few scattered pine trees.  The
+burning heather had been extinguished, but the level ground towards
+Ottershaw was blackened as far as one could see, and still giving off
+vertical streamers of smoke.  An enterprising sweet-stuff dealer in
+the Chobham Road had sent up his son with a barrow-load of green
+apples and ginger beer.
+
+Going to the edge of the pit, I found it occupied by a group of
+about half a dozen men--Henderson, Ogilvy, and a tall, fair-haired man
+that I afterwards learned was Stent, the Astronomer Royal, with
+several workmen wielding spades and pickaxes.  Stent was giving
+directions in a clear, high-pitched voice.  He was standing on the
+cylinder, which was now evidently much cooler; his face was crimson
+and streaming with perspiration, and something seemed to have
+irritated him.
+
+A large portion of the cylinder had been uncovered, though its
+lower end was still embedded.  As soon as Ogilvy saw me among the
+staring crowd on the edge of the pit he called to me to come down, and
+asked me if I would mind going over to see Lord Hilton, the lord of
+the manor.
+
+The growing crowd, he said, was becoming a serious impediment to
+their excavations, especially the boys.  They wanted a light railing
+put up, and help to keep the people back.  He told me that a faint
+stirring was occasionally still audible within the case, but that the
+workmen had failed to unscrew the top, as it afforded no grip to them.
+The case appeared to be enormously thick, and it was possible that the
+faint sounds we heard represented a noisy tumult in the interior.
+
+I was very glad to do as he asked, and so become one of the
+privileged spectators within the contemplated enclosure.  I failed to
+find Lord Hilton at his house, but I was told he was expected from
+London by the six o'clock train from Waterloo; and as it was then
+about a quarter past five, I went home, had some tea, and walked up to
+the station to waylay him.
+
+
+
+CHAPTER FOUR
+
+THE CYLINDER OPENS
+
+
+When I returned to the common the sun was setting.  Scattered groups
+were hurrying from the direction of Woking, and one or two persons
+were returning.  The crowd about the pit had increased, and stood out
+black against the lemon yellow of the sky--a couple of hundred people,
+perhaps.  There were raised voices, and some sort of struggle appeared
+to be going on about the pit.  Strange imaginings passed through my
+mind.  As I drew nearer I heard Stent's voice:
+
+"Keep back!  Keep back!"
+
+A boy came running towards me.
+
+"It's a-movin'," he said to me as he passed; "a-screwin' and
+a-screwin' out.  I don't like it.  I'm a-goin' 'ome, I am."
+
+I went on to the crowd.  There were really, I should think, two or
+three hundred people elbowing and jostling one another, the one or two
+ladies there being by no means the least active.
+
+"He's fallen in the pit!" cried some one.
+
+"Keep back!" said several.
+
+The crowd swayed a little, and I elbowed my way through.  Every one
+seemed greatly excited.  I heard a peculiar humming sound from the
+pit.
+
+"I say!" said Ogilvy; "help keep these idiots back.  We don't know
+what's in the confounded thing, you know!"
+
+I saw a young man, a shop assistant in Woking I believe he was,
+standing on the cylinder and trying to scramble out of the hole again.
+The crowd had pushed him in.
+
+The end of the cylinder was being screwed out from within.  Nearly
+two feet of shining screw projected.  Somebody blundered against me,
+and I narrowly missed being pitched onto the top of the screw.  I
+turned, and as I did so the screw must have come out, for the lid of
+the cylinder fell upon the gravel with a ringing concussion.  I stuck
+my elbow into the person behind me, and turned my head towards the
+Thing again.  For a moment that circular cavity seemed perfectly black.
+I had the sunset in my eyes.
+
+I think everyone expected to see a man emerge--possibly something a
+little unlike us terrestrial men, but in all essentials a man.  I know
+I did.  But, looking, I presently saw something stirring within the
+shadow: greyish billowy movements, one above another, and then two
+luminous disks--like eyes.  Then something resembling a little grey
+snake, about the thickness of a walking stick, coiled up out of the
+writhing middle, and wriggled in the air towards me--and then another.
+
+A sudden chill came over me.  There was a loud shriek from a woman
+behind.  I half turned, keeping my eyes fixed upon the cylinder still,
+from which other tentacles were now projecting, and began pushing my
+way back from the edge of the pit.  I saw astonishment giving place to
+horror on the faces of the people about me.  I heard inarticulate
+exclamations on all sides.  There was a general movement backwards.
+I saw the shopman struggling still on the edge of the pit.  I found
+myself alone, and saw the people on the other side of the pit running
+off, Stent among them.  I looked again at the cylinder, and
+ungovernable terror gripped me.  I stood petrified and staring.
+
+A big greyish rounded bulk, the size, perhaps, of a bear, was
+rising slowly and painfully out of the cylinder.  As it bulged up and
+caught the light, it glistened like wet leather.
+
+Two large dark-coloured eyes were regarding me steadfastly.  The
+mass that framed them, the head of the thing, was rounded, and had,
+one might say, a face.  There was a mouth under the eyes, the lipless
+brim of which quivered and panted, and dropped saliva.  The whole
+creature heaved and pulsated convulsively.  A lank tentacular
+appendage gripped the edge of the cylinder, another swayed in the air.
+
+Those who have never seen a living Martian can scarcely imagine the
+strange horror of its appearance.  The peculiar V-shaped mouth with
+its pointed upper lip, the absence of brow ridges, the absence of a
+chin beneath the wedgelike lower lip, the incessant quivering of this
+mouth, the Gorgon groups of tentacles, the tumultuous breathing of the
+lungs in a strange atmosphere, the evident heaviness and painfulness
+of movement due to the greater gravitational energy of the earth--above
+all, the extraordinary intensity of the immense eyes--were at
+once vital, intense, inhuman, crippled and monstrous.  There was
+something fungoid in the oily brown skin, something in the clumsy
+deliberation of the tedious movements unspeakably nasty.  Even at this
+first encounter, this first glimpse, I was overcome with disgust and
+dread.
+
+Suddenly the monster vanished.  It had toppled over the brim of the
+cylinder and fallen into the pit, with a thud like the fall of a great
+mass of leather.  I heard it give a peculiar thick cry, and forthwith
+another of these creatures appeared darkly in the deep shadow of the
+aperture.
+
+I turned and, running madly, made for the first group of trees,
+perhaps a hundred yards away; but I ran slantingly and stumbling, for
+I could not avert my face from these things.
+
+There, among some young pine trees and furze bushes, I stopped,
+panting, and waited further developments.  The common round the sand
+pits was dotted with people, standing like myself in a half-fascinated
+terror, staring at these creatures, or rather at the heaped gravel at
+the edge of the pit in which they lay.  And then, with a renewed
+horror, I saw a round, black object bobbing up and down on the edge of
+the pit.  It was the head of the shopman who had fallen in, but
+showing as a little black object against the hot western sun.  Now he
+got his shoulder and knee up, and again he seemed to slip back until
+only his head was visible.  Suddenly he vanished, and I could have
+fancied a faint shriek had reached me.  I had a momentary impulse to
+go back and help him that my fears overruled.
+
+Everything was then quite invisible, hidden by the deep pit and the
+heap of sand that the fall of the cylinder had made.  Anyone coming
+along the road from Chobham or Woking would have been amazed at the
+sight--a dwindling multitude of perhaps a hundred people or more
+standing in a great irregular circle, in ditches, behind bushes,
+behind gates and hedges, saying little to one another and that in
+short, excited shouts, and staring, staring hard at a few heaps of
+sand.  The barrow of ginger beer stood, a queer derelict, black
+against the burning sky, and in the sand pits was a row of deserted
+vehicles with their horses feeding out of nosebags or pawing the
+ground.
+
+
+
+CHAPTER FIVE
+
+THE HEAT-RAY
+
+
+After the glimpse I had had of the Martians emerging from the
+cylinder in which they had come to the earth from their planet, a kind
+of fascination paralysed my actions.  I remained standing knee-deep in
+the heather, staring at the mound that hid them.  I was a battleground
+of fear and curiosity.
+
+I did not dare to go back towards the pit, but I felt a passionate
+longing to peer into it.  I began walking, therefore, in a big curve,
+seeking some point of vantage and continually looking at the sand
+heaps that hid these new-comers to our earth.  Once a leash of thin
+black whips, like the arms of an octopus, flashed across the sunset
+and was immediately withdrawn, and afterwards a thin rod rose up,
+joint by joint, bearing at its apex a circular disk that spun with a
+wobbling motion.  What could be going on there?
+
+Most of the spectators had gathered in one or two groups--one a
+little crowd towards Woking, the other a knot of people in the
+direction of Chobham.  Evidently they shared my mental conflict.
+There were few near me.  One man I approached--he was, I perceived,
+a neighbour of mine, though I did not know his name--and accosted.
+But it was scarcely a time for articulate conversation.
+
+"What ugly _brutes_!" he said.  "Good God!  What ugly brutes!"  He
+repeated this over and over again.
+
+"Did you see a man in the pit?" I said; but he made no answer to
+that.  We became silent, and stood watching for a time side by side,
+deriving, I fancy, a certain comfort in one another's company.  Then I
+shifted my position to a little knoll that gave me the advantage of a
+yard or more of elevation and when I looked for him presently he was
+walking towards Woking.
+
+The sunset faded to twilight before anything further happened.  The
+crowd far away on the left, towards Woking, seemed to grow, and I
+heard now a faint murmur from it.  The little knot of people towards
+Chobham dispersed.  There was scarcely an intimation of movement from
+the pit.
+
+It was this, as much as anything, that gave people courage, and I
+suppose the new arrivals from Woking also helped to restore
+confidence.  At any rate, as the dusk came on a slow, intermittent
+movement upon the sand pits began, a movement that seemed to gather
+force as the stillness of the evening about the cylinder remained
+unbroken.  Vertical black figures in twos and threes would advance,
+stop, watch, and advance again, spreading out as they did so in a thin
+irregular crescent that promised to enclose the pit in its attenuated
+horns.  I, too, on my side began to move towards the pit.
+
+Then I saw some cabmen and others had walked boldly into the sand
+pits, and heard the clatter of hoofs and the gride of wheels.  I saw a
+lad trundling off the barrow of apples.  And then, within thirty yards
+of the pit, advancing from the direction of Horsell, I noted a little
+black knot of men, the foremost of whom was waving a white flag.
+
+This was the Deputation.  There had been a hasty consultation, and
+since the Martians were evidently, in spite of their repulsive forms,
+intelligent creatures, it had been resolved to show them, by
+approaching them with signals, that we too were intelligent.
+
+Flutter, flutter, went the flag, first to the right, then to the
+left.  It was too far for me to recognise anyone there, but afterwards
+I learned that Ogilvy, Stent, and Henderson were with others in this
+attempt at communication.  This little group had in its advance
+dragged inward, so to speak, the circumference of the now almost
+complete circle of people, and a number of dim black figures followed
+it at discreet distances.
+
+Suddenly there was a flash of light, and a quantity of luminous
+greenish smoke came out of the pit in three distinct puffs, which
+drove up, one after the other, straight into the still air.
+
+This smoke (or flame, perhaps, would be the better word for it) was
+so bright that the deep blue sky overhead and the hazy stretches of
+brown common towards Chertsey, set with black pine trees, seemed to
+darken abruptly as these puffs arose, and to remain the darker after
+their dispersal.  At the same time a faint hissing sound became
+audible.
+
+Beyond the pit stood the little wedge of people with the white flag
+at its apex, arrested by these phenomena, a little knot of small
+vertical black shapes upon the black ground.  As the green smoke arose,
+their faces flashed out pallid green, and faded again as it vanished.
+Then slowly the hissing passed into a humming, into a long, loud,
+droning noise.  Slowly a humped shape rose out of the pit, and the
+ghost of a beam of light seemed to flicker out from it.
+
+Forthwith flashes of actual flame, a bright glare leaping from one
+to another, sprang from the scattered group of men.  It was as if some
+invisible jet impinged upon them and flashed into white flame.  It was
+as if each man were suddenly and momentarily turned to fire.
+
+Then, by the light of their own destruction, I saw them staggering
+and falling, and their supporters turning to run.
+
+I stood staring, not as yet realising that this was death leaping
+from man to man in that little distant crowd.  All I felt was that it
+was something very strange.  An almost noiseless and blinding flash of
+light, and a man fell headlong and lay still; and as the unseen shaft
+of heat passed over them, pine trees burst into fire, and every dry
+furze bush became with one dull thud a mass of flames.  And far away
+towards Knaphill I saw the flashes of trees and hedges and wooden
+buildings suddenly set alight.
+
+It was sweeping round swiftly and steadily, this flaming death,
+this invisible, inevitable sword of heat.  I perceived it coming
+towards me by the flashing bushes it touched, and was too astounded
+and stupefied to stir.  I heard the crackle of fire in the sand pits
+and the sudden squeal of a horse that was as suddenly stilled.  Then
+it was as if an invisible yet intensely heated finger were drawn
+through the heather between me and the Martians, and all along a
+curving line beyond the sand pits the dark ground smoked and crackled.
+Something fell with a crash far away to the left where the road from
+Woking station opens out on the common.  Forth-with the hissing and
+humming ceased, and the black, dome-like object sank slowly out of
+sight into the pit.
+
+All this had happened with such swiftness that I had stood
+motionless, dumbfounded and dazzled by the flashes of light.  Had that
+death swept through a full circle, it must inevitably have slain me in
+my surprise.  But it passed and spared me, and left the night about me
+suddenly dark and unfamiliar.
+
+The undulating common seemed now dark almost to blackness, except
+where its roadways lay grey and pale under the deep blue sky of the
+early night.  It was dark, and suddenly void of men.  Overhead the
+stars were mustering, and in the west the sky was still a pale,
+bright, almost greenish blue.  The tops of the pine trees and the
+roofs of Horsell came out sharp and black against the western
+afterglow.  The Martians and their appliances were altogether
+invisible, save for that thin mast upon which their restless mirror
+wobbled.  Patches of bush and isolated trees here and there smoked and
+glowed still, and the houses towards Woking station were sending up
+spires of flame into the stillness of the evening air.
+
+Nothing was changed save for that and a terrible astonishment.  The
+little group of black specks with the flag of white had been swept out
+of existence, and the stillness of the evening, so it seemed to me,
+had scarcely been broken.
+
+It came to me that I was upon this dark common, helpless,
+unprotected, and alone.  Suddenly, like a thing falling upon me from
+without, came--fear.
+
+With an effort I turned and began a stumbling run through the
+heather.
+
+The fear I felt was no rational fear, but a panic terror not only
+of the Martians, but of the dusk and stillness all about me.  Such an
+extraordinary effect in unmanning me it had that I ran weeping
+silently as a child might do.  Once I had turned, I did not dare to
+look back.
+
+I remember I felt an extraordinary persuasion that I was being
+played with, that presently, when I was upon the very verge of safety,
+this mysterious death--as swift as the passage of light--would leap
+after me from the pit about the cylinder and strike me down.
+
+
+
+CHAPTER SIX
+
+THE HEAT-RAY IN THE CHOBHAM ROAD
+
+
+It is still a matter of wonder how the Martians are able to slay
+men so swiftly and so silently.  Many think that in some way they are
+able to generate an intense heat in a chamber of practically absolute
+non-conductivity.  This intense heat they project in a parallel beam
+against any object they choose, by means of a polished parabolic
+mirror of unknown composition, much as the parabolic mirror of a
+lighthouse projects a beam of light.  But no one has absolutely proved
+these details.  However it is done, it is certain that a beam of heat
+is the essence of the matter.  Heat, and invisible, instead of
+visible, light.  Whatever is combustible flashes into flame at its
+touch, lead runs like water, it softens iron, cracks and melts glass,
+and when it falls upon water, incontinently that explodes into steam.
+
+That night nearly forty people lay under the starlight about the
+pit, charred and distorted beyond recognition, and all night long the
+common from Horsell to Maybury was deserted and brightly ablaze.
+
+The news of the massacre probably reached Chobham, Woking, and
+Ottershaw about the same time.  In Woking the shops had closed when
+the tragedy happened, and a number of people, shop people and so
+forth, attracted by the stories they had heard, were walking over the
+Horsell Bridge and along the road between the hedges that runs out at
+last upon the common.  You may imagine the young people brushed up
+after the labours of the day, and making this novelty, as they would
+make any novelty, the excuse for walking together and enjoying a
+trivial flirtation.  You may figure to yourself the hum of voices
+along the road in the gloaming. . . .
+
+As yet, of course, few people in Woking even knew that the cylinder
+had opened, though poor Henderson had sent a messenger on a bicycle to
+the post office with a special wire to an evening paper.
+
+As these folks came out by twos and threes upon the open, they
+found little knots of people talking excitedly and peering at the
+spinning mirror over the sand pits, and the newcomers were, no doubt,
+soon infected by the excitement of the occasion.
+
+By half past eight, when the Deputation was destroyed, there may
+have been a crowd of three hundred people or more at this place,
+besides those who had left the road to approach the Martians nearer.
+There were three policemen too, one of whom was mounted, doing their
+best, under instructions from Stent, to keep the people back and deter
+them from approaching the cylinder.  There was some booing from those
+more thoughtless and excitable souls to whom a crowd is always an
+occasion for noise and horse-play.
+
+Stent and Ogilvy, anticipating some possibilities of a collision,
+had telegraphed from Horsell to the barracks as soon as the Martians
+emerged, for the help of a company of soldiers to protect these
+strange creatures from violence.  After that they returned to lead that
+ill-fated advance.  The description of their death, as it was seen by
+the crowd, tallies very closely with my own impressions: the three
+puffs of green smoke, the deep humming note, and the flashes of flame.
+
+But that crowd of people had a far narrower escape than mine.  Only
+the fact that a hummock of heathery sand intercepted the lower part of
+the Heat-Ray saved them.  Had the elevation of the parabolic mirror
+been a few yards higher, none could have lived to tell the tale.  They
+saw the flashes and the men falling and an invisible hand, as it were,
+lit the bushes as it hurried towards them through the twilight.  Then,
+with a whistling note that rose above the droning of the pit, the beam
+swung close over their heads, lighting the tops of the beech trees
+that line the road, and splitting the bricks, smashing the windows,
+firing the window frames, and bringing down in crumbling ruin a
+portion of the gable of the house nearest the corner.
+
+In the sudden thud, hiss, and glare of the igniting trees, the
+panic-stricken crowd seems to have swayed hesitatingly for some
+moments.  Sparks and burning twigs began to fall into the road, and
+single leaves like puffs of flame.  Hats and dresses caught fire.  Then
+came a crying from the common.  There were shrieks and shouts, and
+suddenly a mounted policeman came galloping through the confusion with
+his hands clasped over his head, screaming.
+
+"They're coming!" a woman shrieked, and incontinently everyone was
+turning and pushing at those behind, in order to clear their way to
+Woking again.  They must have bolted as blindly as a flock of sheep.
+Where the road grows narrow and black between the high banks the crowd
+jammed, and a desperate struggle occurred.  All that crowd did not
+escape; three persons at least, two women and a little boy, were
+crushed and trampled there, and left to die amid the terror and the
+darkness.
+
+
+
+CHAPTER SEVEN
+
+HOW I REACHED HOME
+
+
+For my own part, I remember nothing of my flight except the stress
+of blundering against trees and stumbling through the heather.  All
+about me gathered the invisible terrors of the Martians; that pitiless
+sword of heat seemed whirling to and fro, flourishing overhead before
+it descended and smote me out of life.  I came into the road between
+the crossroads and Horsell, and ran along this to the crossroads.
+
+At last I could go no further; I was exhausted with the violence of
+my emotion and of my flight, and I staggered and fell by the wayside.
+That was near the bridge that crosses the canal by the gasworks.  I
+fell and lay still.
+
+I must have remained there some time.
+
+I sat up, strangely perplexed.  For a moment, perhaps, I could not
+clearly understand how I came there.  My terror had fallen from me
+like a garment.  My hat had gone, and my collar had burst away from
+its fastener.  A few minutes before, there had only been three real
+things before me--the immensity of the night and space and nature, my
+own feebleness and anguish, and the near approach of death.  Now it
+was as if something turned over, and the point of view altered
+abruptly.  There was no sensible transition from one state of mind to
+the other.  I was immediately the self of every day again--a decent,
+ordinary citizen.  The silent common, the impulse of my flight, the
+starting flames, were as if they had been in a dream.  I asked myself
+had these latter things indeed happened?  I could not credit it.
+
+I rose and walked unsteadily up the steep incline of the bridge.  My
+mind was blank wonder.  My muscles and nerves seemed drained of their
+strength.  I dare say I staggered drunkenly.  A head rose over the
+arch, and the figure of a workman carrying a basket appeared.  Beside
+him ran a little boy.  He passed me, wishing me good night.  I was
+minded to speak to him, but did not.  I answered his greeting with a
+meaningless mumble and went on over the bridge.
+
+Over the Maybury arch a train, a billowing tumult of white, firelit
+smoke, and a long caterpillar of lighted windows, went flying
+south--clatter, clatter, clap, rap, and it had gone.  A dim group of
+people talked in the gate of one of the houses in the pretty little
+row of gables that was called Oriental Terrace.  It was all so real
+and so familiar.  And that behind me!  It was frantic, fantastic!
+Such things, I told myself, could not be.
+
+Perhaps I am a man of exceptional moods.  I do not know how far my
+experience is common.  At times I suffer from the strangest sense of
+detachment from myself and the world about me; I seem to watch it all
+from the outside, from somewhere inconceivably remote, out of time,
+out of space, out of the stress and tragedy of it all.  This feeling
+was very strong upon me that night.  Here was another side to my
+dream.
+
+But the trouble was the blank incongruity of this serenity and the
+swift death flying yonder, not two miles away.  There was a noise of
+business from the gasworks, and the electric lamps were all alight.  I
+stopped at the group of people.
+
+"What news from the common?" said I.
+
+There were two men and a woman at the gate.
+
+"Eh?" said one of the men, turning.
+
+"What news from the common?" I said.
+
+"'Ain't yer just _been_ there?" asked the men.
+
+"People seem fair silly about the common," said the woman over the
+gate.  "What's it all abart?"
+
+"Haven't you heard of the men from Mars?" said I; "the creatures
+from Mars?"
+
+"Quite enough," said the woman over the gate.  "Thenks"; and all
+three of them laughed.
+
+I felt foolish and angry.  I tried and found I could not tell them
+what I had seen.  They laughed again at my broken sentences.
+
+"You'll hear more yet," I said, and went on to my home.
+
+I startled my wife at the doorway, so haggard was I.  I went into
+the dining room, sat down, drank some wine, and so soon as I could
+collect myself sufficiently I told her the things I had seen.  The
+dinner, which was a cold one, had already been served, and remained
+neglected on the table while I told my story.
+
+"There is one thing," I said, to allay the fears I had aroused;
+"they are the most sluggish things I ever saw crawl.  They may keep
+the pit and kill people who come near them, but they cannot get out
+of it. . . .  But the horror of them!"
+
+"Don't, dear!" said my wife, knitting her brows and putting her
+hand on mine.
+
+"Poor Ogilvy!" I said.  "To think he may be lying dead there!"
+
+My wife at least did not find my experience incredible.  When I saw
+how deadly white her face was, I ceased abruptly.
+
+"They may come here," she said again and again.
+
+I pressed her to take wine, and tried to reassure her.
+
+"They can scarcely move," I said.
+
+I began to comfort her and myself by repeating all that Ogilvy had
+told me of the impossibility of the Martians establishing themselves
+on the earth.  In particular I laid stress on the gravitational
+difficulty.  On the surface of the earth the force of gravity is three
+times what it is on the surface of Mars.  A Martian, therefore, would
+weigh three times more than on Mars, albeit his muscular strength
+would be the same.  His own body would be a cope of lead to him.  That,
+indeed, was the general opinion.  Both _The Times_ and the _Daily
+Telegraph_, for instance, insisted on it the next morning, and both
+overlooked, just as I did, two obvious modifying influences.
+
+The atmosphere of the earth, we now know, contains far more oxygen
+or far less argon (whichever way one likes to put it) than does Mars.
+The invigorating influences of this excess of oxygen upon the Martians
+indisputably did much to counterbalance the increased weight of their
+bodies.  And, in the second place, we all overlooked the fact that
+such mechanical intelligence as the Martian possessed was quite able
+to dispense with muscular exertion at a pinch.
+
+But I did not consider these points at the time, and so my
+reasoning was dead against the chances of the invaders.  With wine and
+food, the confidence of my own table, and the necessity of reassuring
+my wife, I grew by insensible degrees courageous and secure.
+
+"They have done a foolish thing," said I, fingering my wineglass.
+"They are dangerous because, no doubt, they are mad with terror.
+Perhaps they expected to find no living things--certainly no
+intelligent living things."
+
+"A shell in the pit" said I, "if the worst comes to the worst will
+kill them all."
+
+The intense excitement of the events had no doubt left my
+perceptive powers in a state of erethism.  I remember that dinner
+table with extraordinary vividness even now.  My dear wife's sweet
+anxious face peering at me from under the pink lamp shade, the white
+cloth with its silver and glass table furniture--for in those days
+even philosophical writers had many little luxuries--the crimson-purple
+wine in my glass, are photographically distinct.  At the end of
+it I sat, tempering nuts with a cigarette, regretting Ogilvy's
+rashness, and denouncing the shortsighted timidity of the Martians.
+
+So some respectable dodo in the Mauritius might have lorded it in
+his nest, and discussed the arrival of that shipful of pitiless
+sailors in want of animal food.  "We will peck them to death tomorrow,
+my dear."
+
+I did not know it, but that was the last civilised dinner I was to
+eat for very many strange and terrible days.
+
+
+
+CHAPTER EIGHT
+
+FRIDAY NIGHT
+
+
+The most extraordinary thing to my mind, of all the strange and
+wonderful things that happened upon that Friday, was the dovetailing
+of the commonplace habits of our social order with the first
+beginnings of the series of events that was to topple that social
+order headlong.  If on Friday night you had taken a pair of compasses
+and drawn a circle with a radius of five miles round the Woking sand
+pits, I doubt if you would have had one human being outside it, unless
+it were some relation of Stent or of the three or four cyclists or
+London people lying dead on the common, whose emotions or habits were
+at all affected by the new-comers.  Many people had heard of the
+cylinder, of course, and talked about it in their leisure, but it
+certainly did not make the sensation that an ultimatum to Germany
+would have done.
+
+In London that night poor Henderson's telegram describing the
+gradual unscrewing of the shot was judged to be a canard, and his
+evening paper, after wiring for authentication from him and receiving
+no reply--the man was killed--decided not to print a special edition.
+
+Even within the five-mile circle the great majority of people were
+inert.  I have already described the behaviour of the men and women to
+whom I spoke.  All over the district people were dining and supping;
+working men were gardening after the labours of the day, children
+were being put to bed, young people were wandering through the lanes
+love-making, students sat over their books.
+
+Maybe there was a murmur in the village streets, a novel and
+dominant topic in the public-houses, and here and there a messenger,
+or even an eye-witness of the later occurrences, caused a whirl of
+excitement, a shouting, and a running to and fro; but for the most
+part the daily routine of working, eating, drinking, sleeping, went on
+as it had done for countless years--as though no planet Mars existed
+in the sky.  Even at Woking station and Horsell and Chobham that was
+the case.
+
+In Woking junction, until a late hour, trains were stopping and
+going on, others were shunting on the sidings, passengers were
+alighting and waiting, and everything was proceeding in the most
+ordinary way.  A boy from the town, trenching on Smith's monopoly, was
+selling papers with the afternoon's news.  The ringing impact of
+trucks, the sharp whistle of the engines from the junction, mingled
+with their shouts of "Men from Mars!"  Excited men came into the
+station about nine o'clock with incredible tidings, and caused no more
+disturbance than drunkards might have done.  People rattling
+Londonwards peered into the darkness outside the carriage windows, and
+saw only a rare, flickering, vanishing spark dance up from the
+direction of Horsell, a red glow and a thin veil of smoke driving
+across the stars, and thought that nothing more serious than a heath
+fire was happening.  It was only round the edge of the common that any
+disturbance was perceptible.  There were half a dozen villas burning
+on the Woking border.  There were lights in all the houses on the
+common side of the three villages, and the people there kept awake
+till dawn.
+
+A curious crowd lingered restlessly, people coming and going but
+the crowd remaining, both on the Chobham and Horsell bridges.  One or
+two adventurous souls, it was afterwards found, went into the darkness
+and crawled quite near the Martians; but they never returned, for now
+and again a light-ray, like the beam of a warship's searchlight swept
+the common, and the Heat-Ray was ready to follow.  Save for such, that
+big area of common was silent and desolate, and the charred bodies lay
+about on it all night under the stars, and all the next day.  A noise
+of hammering from the pit was heard by many people.
+
+So you have the state of things on Friday night.  In the centre,
+sticking into the skin of our old planet Earth like a poisoned dart,
+was this cylinder.  But the poison was scarcely working yet.  Around
+it was a patch of silent common, smouldering in places, and with a few
+dark, dimly seen objects lying in contorted attitudes here and there.
+Here and there was a burning bush or tree.  Beyond was a fringe of
+excitement, and farther than that fringe the inflammation had not
+crept as yet.  In the rest of the world the stream of life still
+flowed as it had flowed for immemorial years.  The fever of war that
+would presently clog vein and artery, deaden nerve and destroy brain,
+had still to develop.
+
+All night long the Martians were hammering and stirring, sleepless,
+indefatigable, at work upon the machines they were making ready, and
+ever and again a puff of greenish-white smoke whirled up to the
+starlit sky.
+
+About eleven a company of soldiers came through Horsell, and
+deployed along the edge of the common to form a cordon.  Later a
+second company marched through Chobham to deploy on the north side of
+the common.  Several officers from the Inkerman barracks had been on
+the common earlier in the day, and one, Major Eden, was reported to be
+missing.  The colonel of the regiment came to the Chobham bridge and
+was busy questioning the crowd at midnight.  The military authorities
+were certainly alive to the seriousness of the business.  About
+eleven, the next morning's papers were able to say, a squadron of
+hussars, two Maxims, and about four hundred men of the Cardigan
+regiment started from Aldershot.
+
+A few seconds after midnight the crowd in the Chertsey road,
+Woking, saw a star fall from heaven into the pine woods to the
+northwest.  It had a greenish colour, and caused a silent brightness
+like summer lightning.  This was the second cylinder.
+
+
+
+CHAPTER NINE
+
+THE FIGHTING BEGINS
+
+
+Saturday lives in my memory as a day of suspense.  It was a day of
+lassitude too, hot and close, with, I am told, a rapidly fluctuating
+barometer.  I had slept but little, though my wife had succeeded in
+sleeping, and I rose early.  I went into my garden before breakfast
+and stood listening, but towards the common there was nothing stirring
+but a lark.
+
+The milkman came as usual.  I heard the rattle of his chariot and I
+went round to the side gate to ask the latest news.  He told me that
+during the night the Martians had been surrounded by troops, and that
+guns were expected.  Then--a familiar, reassuring note--I heard a train
+running towards Woking.
+
+"They aren't to be killed," said the milkman, "if that can possibly
+be avoided."
+
+I saw my neighbour gardening, chatted with him for a time, and then
+strolled in to breakfast.  It was a most unexceptional morning.  My
+neighbour was of opinion that the troops would be able to capture or
+to destroy the Martians during the day.
+
+"It's a pity they make themselves so unapproachable," he said.  "It
+would be curious to know how they live on another planet; we might
+learn a thing or two."
+
+He came up to the fence and extended a handful of strawberries, for
+his gardening was as generous as it was enthusiastic.  At the same
+time he told me of the burning of the pine woods about the Byfleet
+Golf Links.
+
+"They say," said he, "that there's another of those blessed things
+fallen there--number two.  But one's enough, surely.  This lot'll cost
+the insurance people a pretty penny before everything's settled."  He
+laughed with an air of the greatest good humour as he said this.  The
+woods, he said, were still burning, and pointed out a haze of smoke to
+me.  "They will be hot under foot for days, on account of the thick
+soil of pine needles and turf," he said, and then grew serious over
+"poor Ogilvy."
+
+After breakfast, instead of working, I decided to walk down
+towards the common.  Under the railway bridge I found a group of
+soldiers--sappers, I think, men in small round caps, dirty red jackets
+unbuttoned, and showing their blue shirts, dark trousers, and boots
+coming to the calf.  They told me no one was allowed over the canal,
+and, looking along the road towards the bridge, I saw one of the
+Cardigan men standing sentinel there.  I talked with these soldiers
+for a time; I told them of my sight of the Martians on the previous
+evening.  None of them had seen the Martians, and they had but the
+vaguest ideas of them, so that they plied me with questions.  They
+said that they did not know who had authorised the movements of the
+troops; their idea was that a dispute had arisen at the Horse Guards.
+The ordinary sapper is a great deal better educated than the common
+soldier, and they discussed the peculiar conditions of the possible
+fight with some acuteness.  I described the Heat-Ray to them, and they
+began to argue among themselves.
+
+"Crawl up under cover and rush 'em, say I," said one.
+
+"Get aht!" said another.  "What's cover against this 'ere 'eat?
+Sticks to cook yer!  What we got to do is to go as near as the
+ground'll let us, and then drive a trench."
+
+"Blow yer trenches!  You always want trenches; you ought to ha'
+been born a rabbit Snippy."
+
+"Ain't they got any necks, then?" said a third, abruptly--a little,
+contemplative, dark man, smoking a pipe.
+
+I repeated my description.
+
+"Octopuses," said he, "that's what I calls 'em.  Talk about fishers
+of men--fighters of fish it is this time!"
+
+"It ain't no murder killing beasts like that," said the first
+speaker.
+
+"Why not shell the darned things strite off and finish 'em?" said
+the little dark man.  "You carn tell what they might do."
+
+"Where's your shells?" said the first speaker.  "There ain't no
+time.  Do it in a rush, that's my tip, and do it at once."
+
+So they discussed it.  After a while I left them, and went on to
+the railway station to get as many morning papers as I could.
+
+But I will not weary the reader with a description of that long
+morning and of the longer afternoon.  I did not succeed in getting a
+glimpse of the common, for even Horsell and Chobham church towers were
+in the hands of the military authorities.  The soldiers I addressed
+didn't know anything; the officers were mysterious as well as busy.  I
+found people in the town quite secure again in the presence of the
+military, and I heard for the first time from Marshall, the
+tobacconist, that his son was among the dead on the common.  The
+soldiers had made the people on the outskirts of Horsell lock up and
+leave their houses.
+
+I got back to lunch about two, very tired for, as I have said, the
+day was extremely hot and dull; and in order to refresh myself I took
+a cold bath in the afternoon.  About half past four I went up to the
+railway station to get an evening paper, for the morning papers had
+contained only a very inaccurate description of the killing of Stent,
+Henderson, Ogilvy, and the others.  But there was little I didn't
+know.  The Martians did not show an inch of themselves.  They seemed
+busy in their pit, and there was a sound of hammering and an almost
+continuous streamer of smoke.  Apparently they were busy getting ready
+for a struggle.  "Fresh attempts have been made to signal, but without
+success," was the stereotyped formula of the papers.  A sapper told me
+it was done by a man in a ditch with a flag on a long pole.  The
+Martians took as much notice of such advances as we should of the
+lowing of a cow.
+
+I must confess the sight of all this armament, all this
+preparation, greatly excited me.  My imagination became belligerent,
+and defeated the invaders in a dozen striking ways; something of my
+schoolboy dreams of battle and heroism came back.  It hardly seemed a
+fair fight to me at that time.  They seemed very helpless in that pit
+of theirs.
+
+About three o'clock there began the thud of a gun at measured
+intervals from Chertsey or Addlestone.  I learned that the smouldering
+pine wood into which the second cylinder had fallen was being shelled,
+in the hope of destroying that object before it opened.  It was only
+about five, however, that a field gun reached Chobham for use against
+the first body of Martians.
+
+About six in the evening, as I sat at tea with my wife in the
+summerhouse talking vigorously about the battle that was lowering upon
+us, I heard a muffled detonation from the common, and immediately
+after a gust of firing.  Close on the heels of that came a violent
+rattling crash, quite close to us, that shook the ground; and,
+starting out upon the lawn, I saw the tops of the trees about the
+Oriental College burst into smoky red flame, and the tower of the
+little church beside it slide down into ruin.  The pinnacle of the
+mosque had vanished, and the roof line of the college itself looked as
+if a hundred-ton gun had been at work upon it.  One of our chimneys
+cracked as if a shot had hit it, flew, and a piece of it came
+clattering down the tiles and made a heap of broken red fragments upon
+the flower bed by my study window.
+
+I and my wife stood amazed.  Then I realised that the crest of
+Maybury Hill must be within range of the Martians' Heat-Ray now that
+the college was cleared out of the way.
+
+At that I gripped my wife's arm, and without ceremony ran her out
+into the road.  Then I fetched out the servant, telling her I would go
+upstairs myself for the box she was clamouring for.
+
+"We can't possibly stay here," I said; and as I spoke the firing
+reopened for a moment upon the common.
+
+"But where are we to go?" said my wife in terror.
+
+I thought perplexed.  Then I remembered her cousins at Leatherhead.
+
+"Leatherhead!" I shouted above the sudden noise.
+
+She looked away from me downhill.  The people were coming out of
+their houses, astonished.
+
+"How are we to get to Leatherhead?" she said.
+
+Down the hill I saw a bevy of hussars ride under the railway
+bridge; three galloped through the open gates of the Oriental College;
+two others dismounted, and began running from house to house.  The
+sun, shining through the smoke that drove up from the tops of the
+trees, seemed blood red, and threw an unfamiliar lurid light upon
+everything.
+
+"Stop here," said I; "you are safe here"; and I started off at once
+for the Spotted Dog, for I knew the landlord had a horse and dog cart.
+I ran, for I perceived that in a moment everyone upon this side of the
+hill would be moving.  I found him in his bar, quite unaware of what
+was going on behind his house.  A man stood with his back to me,
+talking to him.
+
+"I must have a pound," said the landlord, "and I've no one to drive
+it."
+
+"I'll give you two," said I, over the stranger's shoulder.
+
+"What for?"
+
+"And I'll bring it back by midnight," I said.
+
+"Lord!" said the landlord; "what's the hurry?  I'm selling my bit
+of a pig.  Two pounds, and you bring it back?  What's going on now?"
+
+I explained hastily that I had to leave my home, and so secured the
+dog cart.  At the time it did not seem to me nearly so urgent that the
+landlord should leave his.  I took care to have the cart there and
+then, drove it off down the road, and, leaving it in charge of my wife
+and servant, rushed into my house and packed a few valuables, such
+plate as we had, and so forth.  The beech trees below the house were
+burning while I did this, and the palings up the road glowed red.
+While I was occupied in this way, one of the dismounted hussars came
+running up.  He was going from house to house, warning people to
+leave.  He was going on as I came out of my front door, lugging my
+treasures, done up in a tablecloth.  I shouted after him:
+
+"What news?"
+
+He turned, stared, bawled something about "crawling out in a thing
+like a dish cover," and ran on to the gate of the house at the crest.
+A sudden whirl of black smoke driving across the road hid him for a
+moment.  I ran to my neighbour's door and rapped to satisfy myself of
+what I already knew, that his wife had gone to London with him and had
+locked up their house.  I went in again, according to my promise, to
+get my servant's box, lugged it out, clapped it beside her on the tail
+of the dog cart, and then caught the reins and jumped up into the
+driver's seat beside my wife.  In another moment we were clear of the
+smoke and noise, and spanking down the opposite slope of Maybury Hill
+towards Old Woking.
+
+In front was a quiet sunny landscape, a wheat field ahead on either
+side of the road, and the Maybury Inn with its swinging sign.  I saw
+the doctor's cart ahead of me.  At the bottom of the hill I turned my
+head to look at the hillside I was leaving.  Thick streamers of black
+smoke shot with threads of red fire were driving up into the still
+air, and throwing dark shadows upon the green treetops eastward.  The
+smoke already extended far away to the east and west--to the Byfleet
+pine woods eastward, and to Woking on the west.  The road was dotted
+with people running towards us.  And very faint now, but very distinct
+through the hot, quiet air, one heard the whirr of a machine-gun that
+was presently stilled, and an intermittent cracking of rifles.
+Apparently the Martians were setting fire to everything within range
+of their Heat-Ray.
+
+I am not an expert driver, and I had immediately to turn my
+attention to the horse.  When I looked back again the second hill had
+hidden the black smoke.  I slashed the horse with the whip, and gave
+him a loose rein until Woking and Send lay between us and that
+quivering tumult.  I overtook and passed the doctor between Woking and
+Send.
+
+
+
+CHAPTER TEN
+
+IN THE STORM
+
+
+Leatherhead is about twelve miles from Maybury Hill.  The scent of
+hay was in the air through the lush meadows beyond Pyrford, and the
+hedges on either side were sweet and gay with multitudes of dog-roses.
+The heavy firing that had broken out while we were driving down
+Maybury Hill ceased as abruptly as it began, leaving the evening very
+peaceful and still.  We got to Leatherhead without misadventure about
+nine o'clock, and the horse had an hour's rest while I took supper
+with my cousins and commended my wife to their care.
+
+My wife was curiously silent throughout the drive, and seemed
+oppressed with forebodings of evil.  I talked to her reassuringly,
+pointing out that the Martians were tied to the Pit by sheer
+heaviness, and at the utmost could but crawl a little out of it; but
+she answered only in monosyllables.  Had it not been for my promise to
+the innkeeper, she would, I think, have urged me to stay in
+Leatherhead that night.  Would that I had!  Her face, I remember, was
+very white as we parted.
+
+For my own part, I had been feverishly excited all day.  Something
+very like the war fever that occasionally runs through a civilised
+community had got into my blood, and in my heart I was not so very
+sorry that I had to return to Maybury that night.  I was even afraid
+that that last fusillade I had heard might mean the extermination of
+our invaders from Mars.  I can best express my state of mind by saying
+that I wanted to be in at the death.
+
+It was nearly eleven when I started to return.  The night was
+unexpectedly dark; to me, walking out of the lighted passage of my
+cousins' house, it seemed indeed black, and it was as hot and close as
+the day.  Overhead the clouds were driving fast, albeit not a breath
+stirred the shrubs about us.  My cousins' man lit both lamps.  Happily,
+I knew the road intimately.  My wife stood in the light of the
+doorway, and watched me until I jumped up into the dog cart.  Then
+abruptly she turned and went in, leaving my cousins side by side
+wishing me good hap.
+
+I was a little depressed at first with the contagion of my wife's
+fears, but very soon my thoughts reverted to the Martians.  At that
+time I was absolutely in the dark as to the course of the evening's
+fighting.  I did not know even the circumstances that had precipitated
+the conflict.  As I came through Ockham (for that was the way I
+returned, and not through Send and Old Woking) I saw along the western
+horizon a blood-red glow, which as I drew nearer, crept slowly up the
+sky.  The driving clouds of the gathering thunderstorm mingled there
+with masses of black and red smoke.
+
+Ripley Street was deserted, and except for a lighted window or so
+the village showed not a sign of life; but I narrowly escaped an
+accident at the corner of the road to Pyrford, where a knot of people
+stood with their backs to me.  They said nothing to me as I passed.  I
+do not know what they knew of the things happening beyond the hill,
+nor do I know if the silent houses I passed on my way were sleeping
+securely, or deserted and empty, or harassed and watching against the
+terror of the night.
+
+From Ripley until I came through Pyrford I was in the valley of the
+Wey, and the red glare was hidden from me.  As I ascended the little
+hill beyond Pyrford Church the glare came into view again, and the
+trees about me shivered with the first intimation of the storm that
+was upon me.  Then I heard midnight pealing out from Pyrford Church
+behind me, and then came the silhouette of Maybury Hill, with its
+tree-tops and roofs black and sharp against the red.
+
+Even as I beheld this a lurid green glare lit the road about me and
+showed the distant woods towards Addlestone.  I felt a tug at the
+reins.  I saw that the driving clouds had been pierced as it were by a
+thread of green fire, suddenly lighting their confusion and falling
+into the field to my left.  It was the third falling star!
+
+Close on its apparition, and blindingly violet by contrast, danced
+out the first lightning of the gathering storm, and the thunder burst
+like a rocket overhead.  The horse took the bit between his teeth and
+bolted.
+
+A moderate incline runs towards the foot of Maybury Hill, and down
+this we clattered.  Once the lightning had begun, it went on in as
+rapid a succession of flashes as I have ever seen.  The thunderclaps,
+treading one on the heels of another and with a strange crackling
+accompaniment, sounded more like the working of a gigantic electric
+machine than the usual detonating reverberations.  The flickering
+light was blinding and confusing, and a thin hail smote gustily at my
+face as I drove down the slope.
+
+At first I regarded little but the road before me, and then
+abruptly my attention was arrested by something that was moving
+rapidly down the opposite slope of Maybury Hill.  At first I took it
+for the wet roof of a house, but one flash following another showed it
+to be in swift rolling movement.  It was an elusive vision--a moment
+of bewildering darkness, and then, in a flash like daylight, the red
+masses of the Orphanage near the crest of the hill, the green tops of
+the pine trees, and this problematical object came out clear and sharp
+and bright.
+
+And this Thing I saw!  How can I describe it?  A monstrous tripod,
+higher than many houses, striding over the young pine trees, and
+smashing them aside in its career; a walking engine of glittering
+metal, striding now across the heather; articulate ropes of steel
+dangling from it, and the clattering tumult of its passage mingling
+with the riot of the thunder.  A flash, and it came out vividly,
+heeling over one way with two feet in the air, to vanish and reappear
+almost instantly as it seemed, with the next flash, a hundred yards
+nearer.  Can you imagine a milking stool tilted and bowled violently
+along the ground?  That was the impression those instant flashes gave.
+But instead of a milking stool imagine it a great body of machinery on
+a tripod stand.
+
+Then suddenly the trees in the pine wood ahead of me were parted,
+as brittle reeds are parted by a man thrusting through them; they were
+snapped off and driven headlong, and a second huge tripod appeared,
+rushing, as it seemed, headlong towards me.  And I was galloping hard
+to meet it! At the sight of the second monster my nerve went
+altogether.  Not stopping to look again, I wrenched the horse's head
+hard round to the right and in another moment the dog cart had heeled
+over upon the horse; the shafts smashed noisily, and I was flung
+sideways and fell heavily into a shallow pool of water.
+
+I crawled out almost immediately, and crouched, my feet still in
+the water, under a clump of furze.  The horse lay motionless (his neck
+was broken, poor brute!) and by the lightning flashes I saw the black
+bulk of the overturned dog cart and the silhouette of the wheel still
+spinning slowly.  In another moment the colossal mechanism went
+striding by me, and passed uphill towards Pyrford.
+
+Seen nearer, the Thing was incredibly strange, for it was no mere
+insensate machine driving on its way.  Machine it was, with a ringing
+metallic pace, and long, flexible, glittering tentacles (one of which
+gripped a young pine tree) swinging and rattling about its strange
+body.  It picked its road as it went striding along, and the brazen
+hood that surmounted it moved to and fro with the inevitable
+suggestion of a head looking about.  Behind the main body was a huge
+mass of white metal like a gigantic fisherman's basket, and puffs of
+green smoke squirted out from the joints of the limbs as the monster
+swept by me.  And in an instant it was gone.
+
+So much I saw then, all vaguely for the flickering of the
+lightning, in blinding highlights and dense black shadows.
+
+As it passed it set up an exultant deafening howl that drowned the
+thunder--"Aloo!  Aloo!"--and in another minute it was with its
+companion, half a mile away, stooping over something in the field.  I
+have no doubt this Thing in the field was the third of the ten
+cylinders they had fired at us from Mars.
+
+For some minutes I lay there in the rain and darkness watching, by
+the intermittent light, these monstrous beings of metal moving about
+in the distance over the hedge tops.  A thin hail was now beginning,
+and as it came and went their figures grew misty and then flashed into
+clearness again.  Now and then came a gap in the lightning, and the
+night swallowed them up.
+
+I was soaked with hail above and puddle water below.  It was some
+time before my blank astonishment would let me struggle up the bank to
+a drier position, or think at all of my imminent peril.
+
+Not far from me was a little one-roomed squatter's hut of wood,
+surrounded by a patch of potato garden.  I struggled to my feet at
+last, and, crouching and making use of every chance of cover, I made a
+run for this.  I hammered at the door, but I could not make the people
+hear (if there were any people inside), and after a time I desisted,
+and, availing myself of a ditch for the greater part of the way,
+succeeded in crawling, unobserved by these monstrous machines, into
+the pine woods towards Maybury.
+
+Under cover of this I pushed on, wet and shivering now, towards my
+own house.  I walked among the trees trying to find the footpath.  It
+was very dark indeed in the wood, for the lightning was now becoming
+infrequent, and the hail, which was pouring down in a torrent, fell in
+columns through the gaps in the heavy foliage.
+
+If I had fully realised the meaning of all the things I had seen I
+should have immediately worked my way round through Byfleet to Street
+Cobham, and so gone back to rejoin my wife at Leatherhead.  But that
+night the strangeness of things about me, and my physical
+wretchedness, prevented me, for I was bruised, weary, wet to the skin,
+deafened and blinded by the storm.
+
+I had a vague idea of going on to my own house, and that was as
+much motive as I had.  I staggered through the trees, fell into a
+ditch and bruised my knees against a plank, and finally splashed out
+into the lane that ran down from the College Arms.  I say splashed,
+for the storm water was sweeping the sand down the hill in a muddy
+torrent.  There in the darkness a man blundered into me and sent me
+reeling back.
+
+He gave a cry of terror, sprang sideways, and rushed on before I
+could gather my wits sufficiently to speak to him.  So heavy was the
+stress of the storm just at this place that I had the hardest task to
+win my way up the hill.  I went close up to the fence on the left and
+worked my way along its palings.
+
+Near the top I stumbled upon something soft, and, by a flash of
+lightning, saw between my feet a heap of black broadcloth and a pair
+of boots.  Before I could distinguish clearly how the man lay, the
+flicker of light had passed.  I stood over him waiting for the next
+flash.  When it came, I saw that he was a sturdy man, cheaply but not
+shabbily dressed; his head was bent under his body, and he lay
+crumpled up close to the fence, as though he had been flung violently
+against it.
+
+Overcoming the repugnance natural to one who had never before
+touched a dead body, I stooped and turned him over to feel for his
+heart.  He was quite dead.  Apparently his neck had been broken.  The
+lightning flashed for a third time, and his face leaped upon me.  I
+sprang to my feet.  It was the landlord of the Spotted Dog, whose
+conveyance I had taken.
+
+I stepped over him gingerly and pushed on up the hill.  I made my
+way by the police station and the College Arms towards my own house.
+Nothing was burning on the hillside, though from the common there
+still came a red glare and a rolling tumult of ruddy smoke beating up
+against the drenching hail.  So far as I could see by the flashes, the
+houses about me were mostly uninjured.  By the College Arms a dark
+heap lay in the road.
+
+Down the road towards Maybury Bridge there were voices and the
+sound of feet, but I had not the courage to shout or to go to them.  I
+let myself in with my latchkey, closed, locked and bolted the door,
+staggered to the foot of the staircase, and sat down.  My imagination
+was full of those striding metallic monsters, and of the dead body
+smashed against the fence.
+
+I crouched at the foot of the staircase with my back to the wall,
+shivering violently.
+
+
+
+CHAPTER ELEVEN
+
+AT THE WINDOW
+
+
+I have already said that my storms of emotion have a trick of
+exhausting themselves.  After a time I discovered that I was cold and
+wet, and with little pools of water about me on the stair carpet.  I
+got up almost mechanically, went into the dining room and drank some
+whiskey, and then I was moved to change my clothes.
+
+After I had done that I went upstairs to my study, but why I did so
+I do not know.  The window of my study looks over the trees and the
+railway towards Horsell Common.  In the hurry of our departure this
+window had been left open.  The passage was dark, and, by contrast with
+the picture the window frame enclosed, the side of the room seemed
+impenetrably dark.  I stopped short in the doorway.
+
+The thunderstorm had passed.  The towers of the Oriental College
+and the pine trees about it had gone, and very far away, lit by a
+vivid red glare, the common about the sand pits was visible.  Across
+the light huge black shapes, grotesque and strange, moved busily to
+and fro.
+
+It seemed indeed as if the whole country in that direction was on
+fire--a broad hillside set with minute tongues of flame, swaying and
+writhing with the gusts of the dying storm, and throwing a red
+reflection upon the cloud-scud above.  Every now and then a haze of
+smoke from some nearer conflagration drove across the window and hid
+the Martian shapes.  I could not see what they were doing, nor the
+clear form of them, nor recognise the black objects they were busied
+upon.  Neither could I see the nearer fire, though the reflections of
+it danced on the wall and ceiling of the study.  A sharp, resinous
+tang of burning was in the air.
+
+I closed the door noiselessly and crept towards the window.  As I
+did so, the view opened out until, on the one hand, it reached to the
+houses about Woking station, and on the other to the charred and
+blackened pine woods of Byfleet.  There was a light down below the
+hill, on the railway, near the arch, and several of the houses along
+the Maybury road and the streets near the station were glowing ruins.
+The light upon the railway puzzled me at first; there were a black
+heap and a vivid glare, and to the right of that a row of yellow
+oblongs.  Then I perceived this was a wrecked train, the fore part
+smashed and on fire, the hinder carriages still upon the rails.
+
+Between these three main centres of light--the houses, the train,
+and the burning county towards Chobham--stretched irregular patches of
+dark country, broken here and there by intervals of dimly glowing and
+smoking ground.  It was the strangest spectacle, that black expanse set
+with fire.  It reminded me, more than anything else, of the Potteries
+at night.  At first I could distinguish no people at all, though I
+peered intently for them.  Later I saw against the light of Woking
+station a number of black figures hurrying one after the other across
+the line.
+
+And this was the little world in which I had been living securely
+for years, this fiery chaos!  What had happened in the last seven
+hours I still did not know; nor did I know, though I was beginning to
+guess, the relation between these mechanical colossi and the sluggish
+lumps I had seen disgorged from the cylinder.  With a queer feeling of
+impersonal interest I turned my desk chair to the window, sat down,
+and stared at the blackened country, and particularly at the three
+gigantic black things that were going to and fro in the glare about
+the sand pits.
+
+They seemed amazingly busy.  I began to ask myself what they could
+be.  Were they intelligent mechanisms?  Such a thing I felt was
+impossible.  Or did a Martian sit within each, ruling, directing,
+using, much as a man's brain sits and rules in his body?  I began to
+compare the things to human machines, to ask myself for the first time
+in my life how an ironclad or a steam engine would seem to an
+intelligent lower animal.
+
+The storm had left the sky clear, and over the smoke of the burning
+land the little fading pinpoint of Mars was dropping into the west,
+when a soldier came into my garden.  I heard a slight scraping at the
+fence, and rousing myself from the lethargy that had fallen upon me, I
+looked down and saw him dimly, clambering over the palings.  At the
+sight of another human being my torpor passed, and I leaned out of the
+window eagerly.
+
+"Hist!" said I, in a whisper.
+
+He stopped astride of the fence in doubt.  Then he came over and
+across the lawn to the corner of the house.  He bent down and stepped
+softly.
+
+"Who's there?" he said, also whispering, standing under the window
+and peering up.
+
+"Where are you going?" I asked.
+
+"God knows."
+
+"Are you trying to hide?"
+
+"That's it."
+
+"Come into the house," I said.
+
+I went down, unfastened the door, and let him in, and locked the
+door again.  I could not see his face.  He was hatless, and his coat
+was unbuttoned.
+
+"My God!" he said, as I drew him in.
+
+"What has happened?" I asked.
+
+"What hasn't?"  In the obscurity I could see he made a gesture of
+despair.  "They wiped us out--simply wiped us out," he repeated again
+and again.
+
+He followed me, almost mechanically, into the dining room.
+
+"Take some whiskey," I said, pouring out a stiff dose.
+
+He drank it.  Then abruptly he sat down before the table, put his
+head on his arms, and began to sob and weep like a little boy, in a
+perfect passion of emotion, while I, with a curious forgetfulness of
+my own recent despair, stood beside him, wondering.
+
+It was a long time before he could steady his nerves to answer my
+questions, and then he answered perplexingly and brokenly.  He was a
+driver in the artillery, and had only come into action about seven.  At
+that time firing was going on across the common, and it was said the
+first party of Martians were crawling slowly towards their second
+cylinder under cover of a metal shield.
+
+Later this shield staggered up on tripod legs and became the first
+of the fighting-machines I had seen.  The gun he drove had been
+unlimbered near Horsell, in order to command the sand pits, and its
+arrival it was that had precipitated the action.  As the limber
+gunners went to the rear, his horse trod in a rabbit hole and came
+down, throwing him into a depression of the ground.  At the same
+moment the gun exploded behind him, the ammunition blew up, there was
+fire all about him, and he found himself lying under a heap of charred
+dead men and dead horses.
+
+"I lay still," he said, "scared out of my wits, with the fore quarter
+of a horse atop of me.  We'd been wiped out.  And the smell--good
+God!  Like burnt meat!  I was hurt across the back by the fall of
+the horse, and there I had to lie until I felt better.  Just like
+parade it had been a minute before--then stumble, bang, swish!"
+
+"Wiped out!" he said.
+
+He had hid under the dead horse for a long time, peeping out
+furtively across the common.  The Cardigan men had tried a rush, in
+skirmishing order, at the pit, simply to be swept out of existence.
+Then the monster had risen to its feet and had begun to walk leisurely
+to and fro across the common among the few fugitives, with its
+headlike hood turning about exactly like the head of a cowled human
+being.  A kind of arm carried a complicated metallic case, about which
+green flashes scintillated, and out of the funnel of this there smoked
+the Heat-Ray.
+
+In a few minutes there was, so far as the soldier could see, not a
+living thing left upon the common, and every bush and tree upon it
+that was not already a blackened skeleton was burning.  The hussars
+had been on the road beyond the curvature of the ground, and he saw
+nothing of them.  He heard the Martians rattle for a time and then
+become still.  The giant saved Woking station and its cluster of houses
+until the last; then in a moment the Heat-Ray was brought to bear, and
+the town became a heap of fiery ruins.  Then the Thing shut off the
+Heat-Ray, and turning its back upon the artilleryman, began to waddle
+away towards the smouldering pine woods that sheltered the second
+cylinder.  As it did so a second glittering Titan built itself up out
+of the pit.
+
+The second monster followed the first, and at that the artilleryman
+began to crawl very cautiously across the hot heather ash towards
+Horsell.  He managed to get alive into the ditch by the side of the
+road, and so escaped to Woking.  There his story became ejaculatory.
+The place was impassable.  It seems there were a few people alive
+there, frantic for the most part and many burned and scalded.  He was
+turned aside by the fire, and hid among some almost scorching heaps of
+broken wall as one of the Martian giants returned.  He saw this one
+pursue a man, catch him up in one of its steely tentacles, and knock
+his head against the trunk of a pine tree.  At last, after nightfall,
+the artilleryman made a rush for it and got over the railway
+embankment.
+
+Since then he had been skulking along towards Maybury, in the hope
+of getting out of danger Londonward.  People were hiding in trenches
+and cellars, and many of the survivors had made off towards Woking
+village and Send.  He had been consumed with thirst until he found one
+of the water mains near the railway arch smashed, and the water
+bubbling out like a spring upon the road.
+
+That was the story I got from him, bit by bit.  He grew calmer
+telling me and trying to make me see the things he had seen.  He had
+eaten no food since midday, he told me early in his narrative, and I
+found some mutton and bread in the pantry and brought it into the
+room.  We lit no lamp for fear of attracting the Martians, and ever
+and again our hands would touch upon bread or meat.  As he talked,
+things about us came darkly out of the darkness, and the trampled
+bushes and broken rose trees outside the window grew distinct.  It
+would seem that a number of men or animals had rushed across the lawn.
+I began to see his face, blackened and haggard, as no doubt mine was
+also.
+
+When we had finished eating we went softly upstairs to my study,
+and I looked again out of the open window.  In one night the valley
+had become a valley of ashes.  The fires had dwindled now.  Where
+flames had been there were now streamers of smoke; but the countless
+ruins of shattered and gutted houses and blasted and blackened trees
+that the night had hidden stood out now gaunt and terrible in the
+pitiless light of dawn.  Yet here and there some object had had the
+luck to escape--a white railway signal here, the end of a greenhouse
+there, white and fresh amid the wreckage.  Never before in the history
+of warfare had destruction been so indiscriminate and so universal.
+And shining with the growing light of the east, three of the metallic
+giants stood about the pit, their cowls rotating as though they were
+surveying the desolation they had made.
+
+It seemed to me that the pit had been enlarged, and ever and again
+puffs of vivid green vapour streamed up and out of it towards the
+brightening dawn--streamed up, whirled, broke, and vanished.
+
+Beyond were the pillars of fire about Chobham.  They became pillars
+of bloodshot smoke at the first touch of day.
+
+
+
+CHAPTER TWELVE
+
+WHAT I SAW OF THE DESTRUCTION OF WEYBRIDGE AND SHEPPERTON
+
+
+As the dawn grew brighter we withdrew from the window from which we
+had watched the Martians, and went very quietly downstairs.
+
+The artilleryman agreed with me that the house was no place to stay
+in.  He proposed, he said, to make his way Londonward, and thence
+rejoin his battery--No. 12, of the Horse Artillery.  My plan was to
+return at once to Leatherhead; and so greatly had the strength of the
+Martians impressed me that I had determined to take my wife to
+Newhaven, and go with her out of the country forthwith.  For I already
+perceived clearly that the country about London must inevitably be the
+scene of a disastrous struggle before such creatures as these could be
+destroyed.
+
+Between us and Leatherhead, however, lay the third cylinder, with
+its guarding giants.  Had I been alone, I think I should have taken my
+chance and struck across country.  But the artilleryman dissuaded me:
+"It's no kindness to the right sort of wife," he said, "to make her a
+widow"; and in the end I agreed to go with him, under cover of the
+woods, northward as far as Street Cobham before I parted with him.
+Thence I would make a big detour by Epsom to reach Leatherhead.
+
+I should have started at once, but my companion had been in active
+service and he knew better than that.  He made me ransack the house
+for a flask, which he filled with whiskey; and we lined every
+available pocket with packets of biscuits and slices of meat.  Then
+we crept out of the house, and ran as quickly as we could down the
+ill-made road by which I had come overnight.  The houses seemed
+deserted. In the road lay a group of three charred bodies close
+together, struck dead by the Heat-Ray; and here and there were things
+that people had dropped--a clock, a slipper, a silver spoon, and the
+like poor valuables.  At the corner turning up towards the post
+office a little cart, filled with boxes and furniture, and horseless,
+heeled over on a broken wheel.  A cash box had been hastily smashed
+open and thrown under the debris.
+
+Except the lodge at the Orphanage, which was still on fire, none of
+the houses had suffered very greatly here.  The Heat-Ray had shaved
+the chimney tops and passed.  Yet, save ourselves, there did not seem
+to be a living soul on Maybury Hill.  The majority of the inhabitants
+had escaped, I suppose, by way of the Old Woking road--the road I had
+taken when I drove to Leatherhead--or they had hidden.
+
+We went down the lane, by the body of the man in black, sodden now
+from the overnight hail, and broke into the woods at the foot of the
+hill.  We pushed through these towards the railway without meeting a
+soul.  The woods across the line were but the scarred and blackened
+ruins of woods; for the most part the trees had fallen, but a certain
+proportion still stood, dismal grey stems, with dark brown foliage
+instead of green.
+
+On our side the fire had done no more than scorch the nearer trees;
+it had failed to secure its footing.  In one place the woodmen had
+been at work on Saturday; trees, felled and freshly trimmed, lay in a
+clearing, with heaps of sawdust by the sawing-machine and its engine.
+Hard by was a temporary hut, deserted.  There was not a breath of wind
+this morning, and everything was strangely still.  Even the birds were
+hushed, and as we hurried along I and the artilleryman talked in
+whispers and looked now and again over our shoulders.  Once or twice
+we stopped to listen.
+
+After a time we drew near the road, and as we did so we heard the
+clatter of hoofs and saw through the tree stems three cavalry soldiers
+riding slowly towards Woking.  We hailed them, and they halted while
+we hurried towards them.  It was a lieutenant and a couple of privates
+of the 8th Hussars, with a stand like a theodolite, which the
+artilleryman told me was a heliograph.
+
+"You are the first men I've seen coming this way this morning,"
+said the lieutenant.  "What's brewing?"
+
+His voice and face were eager.  The men behind him stared
+curiously.  The artilleryman jumped down the bank into the road and
+saluted.
+
+"Gun destroyed last night, sir.  Have been hiding.  Trying to
+rejoin battery, sir.  You'll come in sight of the Martians, I expect,
+about half a mile along this road."
+
+"What the dickens are they like?" asked the lieutenant.
+
+"Giants in armour, sir.  Hundred feet high.  Three legs and a body
+like 'luminium, with a mighty great head in a hood, sir."
+
+"Get out!" said the lieutenant.  "What confounded nonsense!"
+
+"You'll see, sir.  They carry a kind of box, sir, that shoots fire
+and strikes you dead."
+
+"What d'ye mean--a gun?"
+
+"No, sir," and the artilleryman began a vivid account of the Heat-Ray.
+Halfway through, the lieutenant interrupted him and looked up at
+me.  I was still standing on the bank by the side of the road.
+
+"It's perfectly true," I said.
+
+"Well," said the lieutenant, "I suppose it's my business to see it
+too.  Look here"--to the artilleryman--"we're detailed here clearing
+people out of their houses.  You'd better go along and report yourself
+to Brigadier-General Marvin, and tell him all you know.  He's at
+Weybridge.  Know the way?"
+
+"I do," I said; and he turned his horse southward again.
+
+"Half a mile, you say?" said he.
+
+"At most," I answered, and pointed over the treetops southward.  He
+thanked me and rode on, and we saw them no more.
+
+Farther along we came upon a group of three women and two children
+in the road, busy clearing out a labourer's cottage.  They had
+got hold of a little hand truck, and were piling it up with
+unclean-looking bundles and shabby furniture.  They were all too
+assiduously engaged to talk to us as we passed.
+
+By Byfleet station we emerged from the pine trees, and found the
+country calm and peaceful under the morning sunlight.  We were far
+beyond the range of the Heat-Ray there, and had it not been for the
+silent desertion of some of the houses, the stirring movement of
+packing in others, and the knot of soldiers standing on the bridge
+over the railway and staring down the line towards Woking, the day
+would have seemed very like any other Sunday.
+
+Several farm waggons and carts were moving creakily along the road
+to Addlestone, and suddenly through the gate of a field we saw, across
+a stretch of flat meadow, six twelve-pounders standing neatly at equal
+distances pointing towards Woking.  The gunners stood by the guns
+waiting, and the ammunition waggons were at a business-like distance.
+The men stood almost as if under inspection.
+
+"That's good!" said I.  "They will get one fair shot, at any rate."
+
+The artilleryman hesitated at the gate.
+
+"I shall go on," he said.
+
+Farther on towards Weybridge, just over the bridge, there were a
+number of men in white fatigue jackets throwing up a long rampart, and
+more guns behind.
+
+"It's bows and arrows against the lightning, anyhow," said the
+artilleryman.  "They 'aven't seen that fire-beam yet."
+
+The officers who were not actively engaged stood and stared over
+the treetops southwestward, and the men digging would stop every now
+and again to stare in the same direction.
+
+Byfleet was in a tumult; people packing, and a score of hussars,
+some of them dismounted, some on horseback, were hunting them about.
+Three or four black government waggons, with crosses in white circles,
+and an old omnibus, among other vehicles, were being loaded in the
+village street.  There were scores of people, most of them
+sufficiently sabbatical to have assumed their best clothes.  The
+soldiers were having the greatest difficulty in making them realise
+the gravity of their position.  We saw one shrivelled old fellow with
+a huge box and a score or more of flower pots containing orchids,
+angrily expostulating with the corporal who would leave them behind.
+I stopped and gripped his arm.
+
+"Do you know what's over there?" I said, pointing at the pine tops
+that hid the Martians.
+
+"Eh?" said he, turning.  "I was explainin' these is vallyble."
+
+"Death!" I shouted.  "Death is coming!  Death!" and leaving him to
+digest that if he could, I hurried on after the artillery-man.  At the
+corner I looked back.  The soldier had left him, and he was still
+standing by his box, with the pots of orchids on the lid of it, and
+staring vaguely over the trees.
+
+No one in Weybridge could tell us where the headquarters were
+established; the whole place was in such confusion as I had never seen
+in any town before.  Carts, carriages everywhere, the most astonishing
+miscellany of conveyances and horseflesh.  The respectable inhabitants
+of the place, men in golf and boating costumes, wives prettily
+dressed, were packing, river-side loafers energetically helping,
+children excited, and, for the most part, highly delighted at this
+astonishing variation of their Sunday experiences.  In the midst of it
+all the worthy vicar was very pluckily holding an early celebration,
+and his bell was jangling out above the excitement.
+
+I and the artilleryman, seated on the step of the drinking
+fountain, made a very passable meal upon what we had brought with
+us. Patrols of soldiers--here no longer hussars, but grenadiers in
+white--were warning people to move now or to take refuge in their
+cellars as soon as the firing began.  We saw as we crossed the
+railway bridge that a growing crowd of people had assembled in and
+about the railway station, and the swarming platform was piled with
+boxes and packages. The ordinary traffic had been stopped, I believe,
+in order to allow of the passage of troops and guns to Chertsey, and
+I have heard since that a savage struggle occurred for places in the
+special trains that were put on at a later hour.
+
+We remained at Weybridge until midday, and at that hour we found
+ourselves at the place near Shepperton Lock where the Wey and Thames
+join.  Part of the time we spent helping two old women to pack a
+little cart.  The Wey has a treble mouth, and at this point boats are
+to be hired, and there was a ferry across the river.  On the
+Shepperton side was an inn with a lawn, and beyond that the tower of
+Shepperton Church--it has been replaced by a spire--rose above the
+trees.
+
+Here we found an excited and noisy crowd of fugitives.  As yet the
+flight had not grown to a panic, but there were already far more
+people than all the boats going to and fro could enable to cross.
+People came panting along under heavy burdens; one husband and wife
+were even carrying a small outhouse door between them, with some of
+their household goods piled thereon.  One man told us he meant to try
+to get away from Shepperton station.
+
+There was a lot of shouting, and one man was even jesting.  The idea
+people seemed to have here was that the Martians were simply
+formidable human beings, who might attack and sack the town, to be
+certainly destroyed in the end.  Every now and then people would
+glance nervously across the Wey, at the meadows towards Chertsey, but
+everything over there was still.
+
+Across the Thames, except just where the boats landed, everything
+was quiet, in vivid contrast with the Surrey side.  The people who
+landed there from the boats went tramping off down the lane.  The big
+ferryboat had just made a journey.  Three or four soldiers stood on
+the lawn of the inn, staring and jesting at the fugitives, without
+offering to help.  The inn was closed, as it was now within prohibited
+hours.
+
+"What's that?" cried a boatman, and "Shut up, you fool!" said a man
+near me to a yelping dog.  Then the sound came again, this time from
+the direction of Chertsey, a muffled thud--the sound of a gun.
+
+The fighting was beginning.  Almost immediately unseen batteries
+across the river to our right, unseen because of the trees, took up
+the chorus, firing heavily one after the other.  A woman screamed.
+Everyone stood arrested by the sudden stir of battle, near us and yet
+invisible to us.  Nothing was to be seen save flat meadows, cows
+feeding unconcernedly for the most part, and silvery pollard willows
+motionless in the warm sunlight.
+
+"The sojers'll stop 'em," said a woman beside me, doubtfully.  A
+haziness rose over the treetops.
+
+Then suddenly we saw a rush of smoke far away up the river, a puff
+of smoke that jerked up into the air and hung; and forthwith the
+ground heaved under foot and a heavy explosion shook the air, smashing
+two or three windows in the houses near, and leaving us astonished.
+
+"Here they are!" shouted a man in a blue jersey.  "Yonder! D'yer
+see them?  Yonder!"
+
+Quickly, one after the other, one, two, three, four of the armoured
+Martians appeared, far away over the little trees, across the flat
+meadows that stretched towards Chertsey, and striding hurriedly
+towards the river.  Little cowled figures they seemed at first, going
+with a rolling motion and as fast as flying birds.
+
+Then, advancing obliquely towards us, came a fifth.  Their armoured
+bodies glittered in the sun as they swept swiftly forward upon the
+guns, growing rapidly larger as they drew nearer.  One on the extreme
+left, the remotest that is, flourished a huge case high in the air,
+and the ghostly, terrible Heat-Ray I had already seen on Friday night
+smote towards Chertsey, and struck the town.
+
+At sight of these strange, swift, and terrible creatures the crowd
+near the water's edge seemed to me to be for a moment horror-struck.
+There was no screaming or shouting, but a silence.  Then a hoarse
+murmur and a movement of feet--a splashing from the water.  A man, too
+frightened to drop the portmanteau he carried on his shoulder, swung
+round and sent me staggering with a blow from the corner of his
+burden.  A woman thrust at me with her hand and rushed past me.  I
+turned with the rush of the people, but I was not too terrified for
+thought.  The terrible Heat-Ray was in my mind.  To get under water!
+That was it!
+
+"Get under water!" I shouted, unheeded.
+
+I faced about again, and rushed towards the approaching Martian,
+rushed right down the gravelly beach and headlong into the water.
+Others did the same.  A boatload of people putting back came leaping
+out as I rushed past.  The stones under my feet were muddy and
+slippery, and the river was so low that I ran perhaps twenty feet
+scarcely waist-deep.  Then, as the Martian towered overhead scarcely
+a couple of hundred yards away, I flung myself forward under the
+surface.  The splashes of the people in the boats leaping into the
+river sounded like thunderclaps in my ears.  People were landing
+hastily on both sides of the river.  But the Martian machine took no
+more notice for the moment of the people running this way and that
+than a man would of the confusion of ants in a nest against which his
+foot has kicked.  When, half suffocated, I raised my head above water,
+the Martian's hood pointed at the batteries that were still firing
+across the river, and as it advanced it swung loose what must have
+been the generator of the Heat-Ray.
+
+In another moment it was on the bank, and in a stride wading
+halfway across.  The knees of its foremost legs bent at the farther
+bank, and in another moment it had raised itself to its full height
+again, close to the village of Shepperton.  Forthwith the six guns
+which, unknown to anyone on the right bank, had been hidden behind the
+outskirts of that village, fired simultaneously.  The sudden near
+concussion, the last close upon the first, made my heart jump.  The
+monster was already raising the case generating the Heat-Ray as the
+first shell burst six yards above the hood.
+
+I gave a cry of astonishment.  I saw and thought nothing of the
+other four Martian monsters; my attention was riveted upon the nearer
+incident.  Simultaneously two other shells burst in the air near the
+body as the hood twisted round in time to receive, but not in time to
+dodge, the fourth shell.
+
+The shell burst clean in the face of the Thing.  The hood bulged,
+flashed, was whirled off in a dozen tattered fragments of red flesh
+and glittering metal.
+
+"Hit!" shouted I, with something between a scream and a cheer.
+
+I heard answering shouts from the people in the water about me.  I
+could have leaped out of the water with that momentary exultation.
+
+The decapitated colossus reeled like a drunken giant; but it did
+not fall over.  It recovered its balance by a miracle, and, no longer
+heeding its steps and with the camera that fired the Heat-Ray now
+rigidly upheld, it reeled swiftly upon Shepperton.  The living
+intelligence, the Martian within the hood, was slain and splashed to
+the four winds of heaven, and the Thing was now but a mere intricate
+device of metal whirling to destruction.  It drove along in a straight
+line, incapable of guidance.  It struck the tower of Shepperton
+Church, smashing it down as the impact of a battering ram might have
+done, swerved aside, blundered on and collapsed with tremendous force
+into the river out of my sight.
+
+A violent explosion shook the air, and a spout of water, steam,
+mud, and shattered metal shot far up into the sky.  As the camera of
+the Heat-Ray hit the water, the latter had immediately flashed into
+steam.  In another moment a huge wave, like a muddy tidal bore but
+almost scaldingly hot, came sweeping round the bend upstream.  I saw
+people struggling shorewards, and heard their screaming and shouting
+faintly above the seething and roar of the Martian's collapse.
+
+For a moment I heeded nothing of the heat, forgot the patent need
+of self-preservation.  I splashed through the tumultuous water,
+pushing aside a man in black to do so, until I could see round the
+bend.  Half a dozen deserted boats pitched aimlessly upon the
+confusion of the waves.  The fallen Martian came into sight
+downstream, lying across the river, and for the most part submerged.
+
+Thick clouds of steam were pouring off the wreckage, and through
+the tumultuously whirling wisps I could see, intermittently and
+vaguely, the gigantic limbs churning the water and flinging a splash
+and spray of mud and froth into the air.  The tentacles swayed and
+struck like living arms, and, save for the helpless purposelessness of
+these movements, it was as if some wounded thing were struggling for
+its life amid the waves.  Enormous quantities of a ruddy-brown fluid
+were spurting up in noisy jets out of the machine.
+
+My attention was diverted from this death flurry by a furious
+yelling, like that of the thing called a siren in our manufacturing
+towns.  A man, knee-deep near the towing path, shouted inaudibly to me
+and pointed.  Looking back, I saw the other Martians advancing with
+gigantic strides down the riverbank from the direction of Chertsey.
+The Shepperton guns spoke this time unavailingly.
+
+At that I ducked at once under water, and, holding my breath until
+movement was an agony, blundered painfully ahead under the surface as
+long as I could.  The water was in a tumult about me, and rapidly
+growing hotter.
+
+When for a moment I raised my head to take breath and throw the
+hair and water from my eyes, the steam was rising in a whirling white
+fog that at first hid the Martians altogether.  The noise was
+deafening.  Then I saw them dimly, colossal figures of grey, magnified
+by the mist.  They had passed by me, and two were stooping over the
+frothing, tumultuous ruins of their comrade.
+
+The third and fourth stood beside him in the water, one perhaps two
+hundred yards from me, the other towards Laleham.  The generators of
+the Heat-Rays waved high, and the hissing beams smote down this way
+and that.
+
+The air was full of sound, a deafening and confusing conflict of
+noises--the clangorous din of the Martians, the crash of falling
+houses, the thud of trees, fences, sheds flashing into flame, and the
+crackling and roaring of fire.  Dense black smoke was leaping up to
+mingle with the steam from the river, and as the Heat-Ray went to and
+fro over Weybridge its impact was marked by flashes of incandescent
+white, that gave place at once to a smoky dance of lurid flames.  The
+nearer houses still stood intact, awaiting their fate, shadowy, faint
+and pallid in the steam, with the fire behind them going to and fro.
+
+For a moment perhaps I stood there, breast-high in the almost
+boiling water, dumbfounded at my position, hopeless of escape.  Through
+the reek I could see the people who had been with me in the river
+scrambling out of the water through the reeds, like little frogs
+hurrying through grass from the advance of a man, or running to and
+fro in utter dismay on the towing path.
+
+Then suddenly the white flashes of the Heat-Ray came leaping
+towards me.  The houses caved in as they dissolved at its touch, and
+darted out flames; the trees changed to fire with a roar.  The Ray
+flickered up and down the towing path, licking off the people who ran
+this way and that, and came down to the water's edge not fifty yards
+from where I stood.  It swept across the river to Shepperton, and the
+water in its track rose in a boiling weal crested with steam.  I
+turned shoreward.
+
+In another moment the huge wave, well-nigh at the boiling-point had
+rushed upon me.  I screamed aloud, and scalded, half blinded,
+agonised, I staggered through the leaping, hissing water towards the
+shore.  Had my foot stumbled, it would have been the end.  I fell
+helplessly, in full sight of the Martians, upon the broad, bare
+gravelly spit that runs down to mark the angle of the Wey and Thames.
+I expected nothing but death.
+
+I have a dim memory of the foot of a Martian coming down within a
+score of yards of my head, driving straight into the loose gravel,
+whirling it this way and that and lifting again; of a long suspense,
+and then of the four carrying the debris of their comrade between
+them, now clear and then presently faint through a veil of smoke,
+receding interminably, as it seemed to me, across a vast space of
+river and meadow.  And then, very slowly, I realised that by a miracle
+I had escaped.
+
+
+
+CHAPTER THIRTEEN
+
+HOW I FELL IN WITH THE CURATE
+
+
+After getting this sudden lesson in the power of terrestrial
+weapons, the Martians retreated to their original position upon
+Horsell Common; and in their haste, and encumbered with the debris of
+their smashed companion, they no doubt overlooked many such a stray
+and negligible victim as myself.  Had they left their comrade and
+pushed on forthwith, there was nothing at that time between them and
+London but batteries of twelve-pounder guns, and they would certainly
+have reached the capital in advance of the tidings of their approach;
+as sudden, dreadful, and destructive their advent would have been as
+the earthquake that destroyed Lisbon a century ago.
+
+But they were in no hurry.  Cylinder followed cylinder on its
+interplanetary flight; every twenty-four hours brought them
+reinforcement.  And meanwhile the military and naval authorities, now
+fully alive to the tremendous power of their antagonists, worked with
+furious energy.  Every minute a fresh gun came into position until,
+before twilight, every copse, every row of suburban villas on the
+hilly slopes about Kingston and Richmond, masked an expectant black
+muzzle.  And through the charred and desolated area--perhaps twenty
+square miles altogether--that encircled the Martian encampment on
+Horsell Common, through charred and ruined villages among the green
+trees, through the blackened and smoking arcades that had been but a
+day ago pine spinneys, crawled the devoted scouts with the heliographs
+that were presently to warn the gunners of the Martian approach.  But
+the Martians now understood our command of artillery and the danger of
+human proximity, and not a man ventured within a mile of either
+cylinder, save at the price of his life.
+
+It would seem that these giants spent the earlier part of the
+afternoon in going to and fro, transferring everything from the second
+and third cylinders--the second in Addlestone Golf Links and the third
+at Pyrford--to their original pit on Horsell Common.  Over that, above
+the blackened heather and ruined buildings that stretched far and
+wide, stood one as sentinel, while the rest abandoned their vast
+fighting-machines and descended into the pit.  They were hard at work
+there far into the night, and the towering pillar of dense green smoke
+that rose therefrom could be seen from the hills about Merrow, and
+even, it is said, from Banstead and Epsom Downs.
+
+And while the Martians behind me were thus preparing for their next
+sally, and in front of me Humanity gathered for the battle, I made my
+way with infinite pains and labour from the fire and smoke of burning
+Weybridge towards London.
+
+I saw an abandoned boat, very small and remote, drifting down-stream;
+and throwing off the most of my sodden clothes, I went after it,
+gained it, and so escaped out of that destruction.  There were no
+oars in the boat, but I contrived to paddle, as well as my parboiled
+hands would allow, down the river towards Halliford and Walton, going
+very tediously and continually looking behind me, as you may well
+understand.  I followed the river, because I considered that the water
+gave me my best chance of escape should these giants return.
+
+The hot water from the Martian's overthrow drifted downstream with
+me, so that for the best part of a mile I could see little of either
+bank.  Once, however, I made out a string of black figures hurrying
+across the meadows from the direction of Weybridge.  Halliford, it
+seemed, was deserted, and several of the houses facing the river were
+on fire.  It was strange to see the place quite tranquil, quite
+desolate under the hot blue sky, with the smoke and little threads of
+flame going straight up into the heat of the afternoon.  Never before
+had I seen houses burning without the accompaniment of an obstructive
+crowd.  A little farther on the dry reeds up the bank were smoking and
+glowing, and a line of fire inland was marching steadily across a late
+field of hay.
+
+For a long time I drifted, so painful and weary was I after the
+violence I had been through, and so intense the heat upon the water.
+Then my fears got the better of me again, and I resumed my paddling.
+The sun scorched my bare back.  At last, as the bridge at Walton was
+coming into sight round the bend, my fever and faintness overcame my
+fears, and I landed on the Middlesex bank and lay down, deadly sick,
+amid the long grass.  I suppose the time was then about four or five
+o'clock.  I got up presently, walked perhaps half a mile without
+meeting a soul, and then lay down again in the shadow of a hedge.  I
+seem to remember talking, wanderingly, to myself during that last
+spurt.  I was also very thirsty, and bitterly regretful I had drunk no
+more water.  It is a curious thing that I felt angry with my wife; I
+cannot account for it, but my impotent desire to reach Leatherhead
+worried me excessively.
+
+I do not clearly remember the arrival of the curate, so that probably
+I dozed.  I became aware of him as a seated figure in soot-smudged
+shirt sleeves, and with his upturned, clean-shaven face staring at
+a faint flickering that danced over the sky.  The sky was what is
+called a mackerel sky--rows and rows of faint down-plumes of
+cloud, just tinted with the midsummer sunset.
+
+I sat up, and at the rustle of my motion he looked at me quickly.
+
+"Have you any water?" I asked abruptly.
+
+He shook his head.
+
+"You have been asking for water for the last hour," he said.
+
+For a moment we were silent, taking stock of each other.  I
+dare say he found me a strange enough figure, naked, save for my
+water-soaked trousers and socks, scalded, and my face and shoulders
+blackened by the smoke.  His face was a fair weakness, his chin
+retreated, and his hair lay in crisp, almost flaxen curls on his low
+forehead; his eyes were rather large, pale blue, and blankly staring.
+He spoke abruptly, looking vacantly away from me.
+
+"What does it mean?" he said.  "What do these things mean?"
+
+I stared at him and made no answer.
+
+He extended a thin white hand and spoke in almost a complaining
+tone.
+
+"Why are these things permitted?  What sins have we done?  The
+morning service was over, I was walking through the roads to clear my
+brain for the afternoon, and then--fire, earthquake, death!  As if it
+were Sodom and Gomorrah!  All our work undone, all the work---- What
+are these Martians?"
+
+"What are we?" I answered, clearing my throat.
+
+He gripped his knees and turned to look at me again.  For half a
+minute, perhaps, he stared silently.
+
+"I was walking through the roads to clear my brain," he said.  "And
+suddenly--fire, earthquake, death!"
+
+He relapsed into silence, with his chin now sunken almost to his
+knees.
+
+Presently he began waving his hand.
+
+"All the work--all the Sunday schools--What have we done--what has
+Weybridge done?  Everything gone--everything destroyed.  The church!
+We rebuilt it only three years ago.  Gone!  Swept out of existence!
+Why?"
+
+Another pause, and he broke out again like one demented.
+
+"The smoke of her burning goeth up for ever and ever!" he shouted.
+
+His eyes flamed, and he pointed a lean finger in the direction of
+Weybridge.
+
+By this time I was beginning to take his measure.  The tremendous
+tragedy in which he had been involved--it was evident he was a
+fugitive from Weybridge--had driven him to the very verge of his
+reason.
+
+"Are we far from Sunbury?" I said, in a matter-of-fact tone.
+
+"What are we to do?" he asked.  "Are these creatures everywhere?
+Has the earth been given over to them?"
+
+"Are we far from Sunbury?"
+
+"Only this morning I officiated at early celebration----"
+
+"Things have changed," I said, quietly.  "You must keep your head.
+There is still hope."
+
+"Hope!"
+
+"Yes.  Plentiful hope--for all this destruction!"
+
+I began to explain my view of our position.  He listened at first,
+but as I went on the interest dawning in his eyes gave place to their
+former stare, and his regard wandered from me.
+
+"This must be the beginning of the end," he said, interrupting me.
+"The end!  The great and terrible day of the Lord!  When men shall
+call upon the mountains and the rocks to fall upon them and hide
+them--hide them from the face of Him that sitteth upon the throne!"
+
+I began to understand the position.  I ceased my laboured
+reasoning, struggled to my feet, and, standing over him, laid my hand
+on his shoulder.
+
+"Be a man!" said I.  "You are scared out of your wits!  What good
+is religion if it collapses under calamity?  Think of what earthquakes
+and floods, wars and volcanoes, have done before to men!  Did you
+think God had exempted Weybridge?  He is not an insurance agent."
+
+For a time he sat in blank silence.
+
+"But how can we escape?" he asked, suddenly.  "They are
+invulnerable, they are pitiless."
+
+"Neither the one nor, perhaps, the other," I answered. "And the
+mightier they are the more sane and wary should we be.  One of them
+was killed yonder not three hours ago."
+
+"Killed!" he said, staring about him.  "How can God's ministers be
+killed?"
+
+"I saw it happen." I proceeded to tell him.  "We have chanced to
+come in for the thick of it," said I, "and that is all."
+
+"What is that flicker in the sky?" he asked abruptly.
+
+I told him it was the heliograph signalling--that it was the sign
+of human help and effort in the sky.
+
+"We are in the midst of it," I said, "quiet as it is.  That flicker
+in the sky tells of the gathering storm.  Yonder, I take it are the
+Martians, and Londonward, where those hills rise about Richmond and
+Kingston and the trees give cover, earthworks are being thrown up and
+guns are being placed.  Presently the Martians will be coming this way
+again."
+
+And even as I spoke he sprang to his feet and stopped me by a
+gesture.
+
+"Listen!" he said.
+
+From beyond the low hills across the water came the dull resonance
+of distant guns and a remote weird crying.  Then everything was still.
+A cockchafer came droning over the hedge and past us.  High in the
+west the crescent moon hung faint and pale above the smoke of
+Weybridge and Shepperton and the hot, still splendour of the sunset.
+
+"We had better follow this path," I said, "northward."
+
+
+
+CHAPTER FOURTEEN
+
+IN LONDON
+
+
+My younger brother was in London when the Martians fell at Woking.
+He was a medical student working for an imminent examination, and he
+heard nothing of the arrival until Saturday morning.  The morning
+papers on Saturday contained, in addition to lengthy special articles
+on the planet Mars, on life in the planets, and so forth, a brief and
+vaguely worded telegram, all the more striking for its brevity.
+
+The Martians, alarmed by the approach of a crowd, had killed a
+number of people with a quick-firing gun, so the story ran.  The
+telegram concluded with the words: "Formidable as they seem to be, the
+Martians have not moved from the pit into which they have fallen, and,
+indeed, seem incapable of doing so.  Probably this is due to the
+relative strength of the earth's gravitational energy."  On that last
+text their leader-writer expanded very comfortingly.
+
+Of course all the students in the crammer's biology class, to which
+my brother went that day, were intensely interested, but there were no
+signs of any unusual excitement in the streets.  The afternoon papers
+puffed scraps of news under big headlines.  They had nothing to tell
+beyond the movements of troops about the common, and the burning of
+the pine woods between Woking and Weybridge, until eight.  Then the
+_St. James's Gazette_, in an extra-special edition, announced the bare
+fact of the interruption of telegraphic communication.  This was
+thought to be due to the falling of burning pine trees across the
+line.  Nothing more of the fighting was known that night, the night of
+my drive to Leatherhead and back.
+
+My brother felt no anxiety about us, as he knew from the
+description in the papers that the cylinder was a good two miles from
+my house.  He made up his mind to run down that night to me, in order,
+as he says, to see the Things before they were killed.  He dispatched
+a telegram, which never reached me, about four o'clock, and spent the
+evening at a music hall.
+
+In London, also, on Saturday night there was a thunderstorm, and my
+brother reached Waterloo in a cab.  On the platform from which the
+midnight train usually starts he learned, after some waiting, that an
+accident prevented trains from reaching Woking that night.  The nature
+of the accident he could not ascertain; indeed, the railway
+authorities did not clearly know at that time.  There was very little
+excitement in the station, as the officials, failing to realise that
+anything further than a breakdown between Byfleet and Woking junction
+had occurred, were running the theatre trains which usually passed
+through Woking round by Virginia Water or Guildford.  They were busy
+making the necessary arrangements to alter the route of the
+Southampton and Portsmouth Sunday League excursions.  A nocturnal
+newspaper reporter, mistaking my brother for the traffic manager, to
+whom he bears a slight resemblance, waylaid and tried to interview
+him.  Few people, excepting the railway officials, connected the
+breakdown with the Martians.
+
+I have read, in another account of these events, that on Sunday
+morning "all London was electrified by the news from Woking."  As a
+matter of fact, there was nothing to justify that very extravagant
+phrase.  Plenty of Londoners did not hear of the Martians until the
+panic of Monday morning.  Those who did took some time to realise all
+that the hastily worded telegrams in the Sunday papers conveyed.  The
+majority of people in London do not read Sunday papers.
+
+The habit of personal security, moreover, is so deeply fixed in the
+Londoner's mind, and startling intelligence so much a matter of course
+in the papers, that they could read without any personal tremors:
+"About seven o'clock last night the Martians came out of the cylinder,
+and, moving about under an armour of metallic shields, have completely
+wrecked Woking station with the adjacent houses, and massacred an
+entire battalion of the Cardigan Regiment.  No details are known.
+Maxims have been absolutely useless against their armour; the field
+guns have been disabled by them.  Flying hussars have been galloping
+into Chertsey.  The Martians appear to be moving slowly towards
+Chertsey or Windsor.  Great anxiety prevails in West Surrey, and
+earthworks are being thrown up to check the advance Londonward."  That
+was how the Sunday _Sun_ put it, and a clever and remarkably prompt
+"handbook" article in the _Referee_ compared the affair to a menagerie
+suddenly let loose in a village.
+
+No one in London knew positively of the nature of the armoured
+Martians, and there was still a fixed idea that these monsters must be
+sluggish: "crawling," "creeping painfully"--such expressions occurred
+in almost all the earlier reports.  None of the telegrams could have
+been written by an eyewitness of their advance.  The Sunday papers
+printed separate editions as further news came to hand, some even in
+default of it.  But there was practically nothing more to tell people
+until late in the afternoon, when the authorities gave the press
+agencies the news in their possession.  It was stated that the people
+of Walton and Weybridge, and all the district were pouring along the
+roads Londonward, and that was all.
+
+My brother went to church at the Foundling Hospital in the morning,
+still in ignorance of what had happened on the previous night.  There
+he heard allusions made to the invasion, and a special prayer for
+peace.  Coming out, he bought a _Referee_.  He became alarmed at the
+news in this, and went again to Waterloo station to find out if
+communication were restored.  The omnibuses, carriages, cyclists, and
+innumerable people walking in their best clothes seemed scarcely
+affected by the strange intelligence that the news venders were
+disseminating.  People were interested, or, if alarmed, alarmed only
+on account of the local residents.  At the station he heard for the
+first time that the Windsor and Chertsey lines were now interrupted.
+The porters told him that several remarkable telegrams had been
+received in the morning from Byfleet and Chertsey stations, but that
+these had abruptly ceased.  My brother could get very little precise
+detail out of them.
+
+"There's fighting going on about Weybridge" was the extent of their
+information.
+
+The train service was now very much disorganised.  Quite a number
+of people who had been expecting friends from places on the
+South-Western network were standing about the station.  One
+grey-headed old gentleman came and abused the South-Western Company
+bitterly to my brother.  "It wants showing up," he said.
+
+One or two trains came in from Richmond, Putney, and Kingston,
+containing people who had gone out for a day's boating and found the
+locks closed and a feeling of panic in the air.  A man in a blue and
+white blazer addressed my brother, full of strange tidings.
+
+"There's hosts of people driving into Kingston in traps and carts
+and things, with boxes of valuables and all that," he said.  "They
+come from Molesey and Weybridge and Walton, and they say there's been
+guns heard at Chertsey, heavy firing, and that mounted soldiers have
+told them to get off at once because the Martians are coming.  We
+heard guns firing at Hampton Court station, but we thought it was
+thunder.  What the dickens does it all mean?  The Martians can't get
+out of their pit, can they?"
+
+My brother could not tell him.
+
+Afterwards he found that the vague feeling of alarm had spread to
+the clients of the underground railway, and that the Sunday
+excursionists began to return from all over the South-Western
+"lung"--Barnes, Wimbledon, Richmond Park, Kew, and so forth--at
+unnaturally early hours; but not a soul had anything more than vague
+hearsay to tell of.  Everyone connected with the terminus seemed
+ill-tempered.
+
+About five o'clock the gathering crowd in the station was immensely
+excited by the opening of the line of communication, which is almost
+invariably closed, between the South-Eastern and the South-Western
+stations, and the passage of carriage trucks bearing huge guns and
+carriages crammed with soldiers.  These were the guns that were
+brought up from Woolwich and Chatham to cover Kingston.  There was
+an exchange of pleasantries: "You'll get eaten!"  "We're the
+beast-tamers!" and so forth.  A little while after that a squad of
+police came into the station and began to clear the public off the
+platforms, and my brother went out into the street again.
+
+The church bells were ringing for evensong, and a squad of
+Salvation Army lassies came singing down Waterloo Road.  On the bridge
+a number of loafers were watching a curious brown scum that came
+drifting down the stream in patches.  The sun was just setting, and the
+Clock Tower and the Houses of Parliament rose against one of the most
+peaceful skies it is possible to imagine, a sky of gold, barred with
+long transverse stripes of reddish-purple cloud.  There was talk of a
+floating body.  One of the men there, a reservist he said he was, told
+my brother he had seen the heliograph flickering in the west.
+
+In Wellington Street my brother met a couple of sturdy roughs who
+had just been rushed out of Fleet Street with still-wet newspapers and
+staring placards.  "Dreadful catastrophe!" they bawled one to the
+other down Wellington Street.  "Fighting at Weybridge!  Full
+description!  Repulse of the Martians! London in Danger!"  He had to
+give threepence for a copy of that paper.
+
+Then it was, and then only, that he realised something of the full
+power and terror of these monsters.  He learned that they were not
+merely a handful of small sluggish creatures, but that they were minds
+swaying vast mechanical bodies; and that they could move swiftly and
+smite with such power that even the mightiest guns could not stand
+against them.
+
+They were described as "vast spiderlike machines, nearly a hundred
+feet high, capable of the speed of an express train, and able to shoot
+out a beam of intense heat."  Masked batteries, chiefly of field guns,
+had been planted in the country about Horsell Common, and especially
+between the Woking district and London.  Five of the machines had been
+seen moving towards the Thames, and one, by a happy chance, had been
+destroyed.  In the other cases the shells had missed, and the
+batteries had been at once annihilated by the Heat-Rays.  Heavy
+losses of soldiers were mentioned, but the tone of the dispatch was
+optimistic.
+
+The Martians had been repulsed; they were not invulnerable.  They
+had retreated to their triangle of cylinders again, in the circle
+about Woking.  Signallers with heliographs were pushing forward upon
+them from all sides.  Guns were in rapid transit from Windsor,
+Portsmouth, Aldershot, Woolwich--even from the north; among others,
+long wire-guns of ninety-five tons from Woolwich.  Altogether one
+hundred and sixteen were in position or being hastily placed, chiefly
+covering London.  Never before in England had there been such a vast
+or rapid concentration of military material.
+
+Any further cylinders that fell, it was hoped, could be destroyed
+at once by high explosives, which were being rapidly manufactured and
+distributed.  No doubt, ran the report, the situation was of the
+strangest and gravest description, but the public was exhorted to
+avoid and discourage panic.  No doubt the Martians were strange and
+terrible in the extreme, but at the outside there could not be more
+than twenty of them against our millions.
+
+The authorities had reason to suppose, from the size of the
+cylinders, that at the outside there could not be more than five in
+each cylinder--fifteen altogether.  And one at least was disposed
+of--perhaps more.  The public would be fairly warned of the approach
+of danger, and elaborate measures were being taken for the protection
+of the people in the threatened southwestern suburbs.  And so, with
+reiterated assurances of the safety of London and the ability of the
+authorities to cope with the difficulty, this quasi-proclamation
+closed.
+
+This was printed in enormous type on paper so fresh that it was
+still wet, and there had been no time to add a word of comment.  It
+was curious, my brother said, to see how ruthlessly the usual contents
+of the paper had been hacked and taken out to give this place.
+
+All down Wellington Street people could be seen fluttering out the
+pink sheets and reading, and the Strand was suddenly noisy with the
+voices of an army of hawkers following these pioneers.  Men came
+scrambling off buses to secure copies.  Certainly this news excited
+people intensely, whatever their previous apathy.  The shutters of a
+map shop in the Strand were being taken down, my brother said, and a
+man in his Sunday raiment, lemon-yellow gloves even, was visible
+inside the window hastily fastening maps of Surrey to the glass.
+
+Going on along the Strand to Trafalgar Square, the paper in his
+hand, my brother saw some of the fugitives from West Surrey.  There
+was a man with his wife and two boys and some articles of furniture in
+a cart such as greengrocers use.  He was driving from the direction of
+Westminster Bridge; and close behind him came a hay waggon with five
+or six respectable-looking people in it, and some boxes and bundles.
+The faces of these people were haggard, and their entire appearance
+contrasted conspicuously with the Sabbath-best appearance of the
+people on the omnibuses.  People in fashionable clothing peeped at
+them out of cabs.  They stopped at the Square as if undecided which
+way to take, and finally turned eastward along the Strand.  Some way
+behind these came a man in workday clothes, riding one of those
+old-fashioned tricycles with a small front wheel.  He was dirty and
+white in the face.
+
+My brother turned down towards Victoria, and met a number of such
+people.  He had a vague idea that he might see something of me.  He
+noticed an unusual number of police regulating the traffic.  Some of
+the refugees were exchanging news with the people on the omnibuses.
+One was professing to have seen the Martians.  "Boilers on stilts, I
+tell you, striding along like men."  Most of them were excited and
+animated by their strange experience.
+
+Beyond Victoria the public-houses were doing a lively trade with
+these arrivals.  At all the street corners groups of people were
+reading papers, talking excitedly, or staring at these unusual Sunday
+visitors.  They seemed to increase as night drew on, until at last the
+roads, my brother said, were like Epsom High Street on a Derby Day.  My
+brother addressed several of these fugitives and got unsatisfactory
+answers from most.
+
+None of them could tell him any news of Woking except one man, who
+assured him that Woking had been entirely destroyed on the previous
+night.
+
+"I come from Byfleet," he said; "man on a bicycle came through the
+place in the early morning, and ran from door to door warning us to
+come away.  Then came soldiers.  We went out to look, and there were
+clouds of smoke to the south--nothing but smoke, and not a soul coming
+that way.  Then we heard the guns at Chertsey, and folks coming from
+Weybridge.  So I've locked up my house and come on."
+
+At the time there was a strong feeling in the streets that the
+authorities were to blame for their incapacity to dispose of the
+invaders without all this inconvenience.
+
+About eight o'clock a noise of heavy firing was distinctly audible
+all over the south of London.  My brother could not hear it for the
+traffic in the main thoroughfares, but by striking through the quiet
+back streets to the river he was able to distinguish it quite plainly.
+
+He walked from Westminster to his apartments near Regent's Park,
+about two.  He was now very anxious on my account, and disturbed at
+the evident magnitude of the trouble.  His mind was inclined to run,
+even as mine had run on Saturday, on military details.  He thought of
+all those silent, expectant guns, of the suddenly nomadic countryside;
+he tried to imagine "boilers on stilts" a hundred feet high.
+
+There were one or two cartloads of refugees passing along Oxford
+Street, and several in the Marylebone Road, but so slowly was the news
+spreading that Regent Street and Portland Place were full of their
+usual Sunday-night promenaders, albeit they talked in groups, and
+along the edge of Regent's Park there were as many silent couples
+"walking out" together under the scattered gas lamps as ever there had
+been.  The night was warm and still, and a little oppressive; the
+sound of guns continued intermittently, and after midnight there
+seemed to be sheet lightning in the south.
+
+He read and re-read the paper, fearing the worst had happened to me.
+He was restless, and after supper prowled out again aimlessly.  He
+returned and tried in vain to divert his attention to his examination
+notes.  He went to bed a little after midnight, and was awakened from
+lurid dreams in the small hours of Monday by the sound of door
+knockers, feet running in the street, distant drumming, and a clamour
+of bells.  Red reflections danced on the ceiling.  For a moment he lay
+astonished, wondering whether day had come or the world gone mad.
+Then he jumped out of bed and ran to the window.
+
+His room was an attic and as he thrust his head out, up and down
+the street there were a dozen echoes to the noise of his window sash,
+and heads in every kind of night disarray appeared.  Enquiries were
+being shouted.  "They are coming!" bawled a policeman, hammering at
+the door; "the Martians are coming!" and hurried to the next door.
+
+The sound of drumming and trumpeting came from the Albany Street
+Barracks, and every church within earshot was hard at work killing
+sleep with a vehement disorderly tocsin.  There was a noise of doors
+opening, and window after window in the houses opposite flashed from
+darkness into yellow illumination.
+
+Up the street came galloping a closed carriage, bursting abruptly
+into noise at the corner, rising to a clattering climax under the
+window, and dying away slowly in the distance.  Close on the rear of
+this came a couple of cabs, the forerunners of a long procession of
+flying vehicles, going for the most part to Chalk Farm station, where
+the North-Western special trains were loading up, instead of coming
+down the gradient into Euston.
+
+For a long time my brother stared out of the window in blank
+astonishment, watching the policemen hammering at door after door, and
+delivering their incomprehensible message.  Then the door behind him
+opened, and the man who lodged across the landing came in, dressed
+only in shirt, trousers, and slippers, his braces loose about his
+waist, his hair disordered from his pillow.
+
+"What the devil is it?" he asked.  "A fire?  What a devil of a
+row!"
+
+They both craned their heads out of the window, straining to hear
+what the policemen were shouting.  People were coming out of the side
+streets, and standing in groups at the corners talking.
+
+"What the devil is it all about?" said my brother's fellow lodger.
+
+My brother answered him vaguely and began to dress, running with
+each garment to the window in order to miss nothing of the growing
+excitement.  And presently men selling unnaturally early newspapers
+came bawling into the street:
+
+"London in danger of suffocation!  The Kingston and Richmond
+defences forced!  Fearful massacres in the Thames Valley!"
+
+And all about him--in the rooms below, in the houses on each side
+and across the road, and behind in the Park Terraces and in the
+hundred other streets of that part of Marylebone, and the Westbourne
+Park district and St. Pancras, and westward and northward in Kilburn
+and St. John's Wood and Hampstead, and eastward in Shoreditch and
+Highbury and Haggerston and Hoxton, and, indeed, through all the
+vastness of London from Ealing to East Ham--people were rubbing their
+eyes, and opening windows to stare out and ask aimless questions,
+dressing hastily as the first breath of the coming storm of Fear blew
+through the streets.  It was the dawn of the great panic.  London,
+which had gone to bed on Sunday night oblivious and inert, was
+awakened, in the small hours of Monday morning, to a vivid sense of
+danger.
+
+Unable from his window to learn what was happening, my brother went
+down and out into the street, just as the sky between the parapets of
+the houses grew pink with the early dawn.  The flying people on foot
+and in vehicles grew more numerous every moment.  "Black Smoke!" he
+heard people crying, and again "Black Smoke!"  The contagion of such
+a unanimous fear was inevitable.  As my brother hesitated on the
+door-step, he saw another news vender approaching, and got a paper
+forthwith.  The man was running away with the rest, and selling his
+papers for a shilling each as he ran--a grotesque mingling of profit
+and panic.
+
+And from this paper my brother read that catastrophic dispatch of
+the Commander-in-Chief:
+
+"The Martians are able to discharge enormous clouds of a black and
+poisonous vapour by means of rockets.  They have smothered our
+batteries, destroyed Richmond, Kingston, and Wimbledon, and are
+advancing slowly towards London, destroying everything on the way.  It
+is impossible to stop them.  There is no safety from the Black Smoke
+but in instant flight."
+
+That was all, but it was enough.  The whole population of the great
+six-million city was stirring, slipping, running; presently it would
+be pouring _en masse_ northward.
+
+"Black Smoke!" the voices cried.  "Fire!"
+
+The bells of the neighbouring church made a jangling tumult, a cart
+carelessly driven smashed, amid shrieks and curses, against the water
+trough up the street.  Sickly yellow lights went to and fro in the
+houses, and some of the passing cabs flaunted unextinguished lamps.
+And overhead the dawn was growing brighter, clear and steady and calm.
+
+He heard footsteps running to and fro in the rooms, and up and down
+stairs behind him.  His landlady came to the door, loosely wrapped in
+dressing gown and shawl; her husband followed ejaculating.
+
+As my brother began to realise the import of all these things, he
+turned hastily to his own room, put all his available money--some ten
+pounds altogether--into his pockets, and went out again into the
+streets.
+
+
+
+CHAPTER FIFTEEN
+
+WHAT HAD HAPPENED IN SURREY
+
+
+It was while the curate had sat and talked so wildly to me under
+the hedge in the flat meadows near Halliford, and while my brother was
+watching the fugitives stream over Westminster Bridge, that the
+Martians had resumed the offensive.  So far as one can ascertain from
+the conflicting accounts that have been put forth, the majority of
+them remained busied with preparations in the Horsell pit until nine
+that night, hurrying on some operation that disengaged huge volumes of
+green smoke.
+
+But three certainly came out about eight o'clock and, advancing
+slowly and cautiously, made their way through Byfleet and Pyrford
+towards Ripley and Weybridge, and so came in sight of the expectant
+batteries against the setting sun.  These Martians did not advance in
+a body, but in a line, each perhaps a mile and a half from his nearest
+fellow.  They communicated with one another by means of sirenlike
+howls, running up and down the scale from one note to another.
+
+It was this howling and firing of the guns at Ripley and St.
+George's Hill that we had heard at Upper Halliford.  The Ripley
+gunners, unseasoned artillery volunteers who ought never to have been
+placed in such a position, fired one wild, premature, ineffectual
+volley, and bolted on horse and foot through the deserted village,
+while the Martian, without using his Heat-Ray, walked serenely over
+their guns, stepped gingerly among them, passed in front of them, and
+so came unexpectedly upon the guns in Painshill Park, which he
+destroyed.
+
+The St. George's Hill men, however, were better led or of a better
+mettle.  Hidden by a pine wood as they were, they seem to have been
+quite unsuspected by the Martian nearest to them.  They laid their
+guns as deliberately as if they had been on parade, and fired at about
+a thousand yards' range.
+
+The shells flashed all round him, and he was seen to advance a few
+paces, stagger, and go down.  Everybody yelled together, and the guns
+were reloaded in frantic haste.  The overthrown Martian set up a
+prolonged ululation, and immediately a second glittering giant,
+answering him, appeared over the trees to the south.  It would seem
+that a leg of the tripod had been smashed by one of the shells.  The
+whole of the second volley flew wide of the Martian on the ground,
+and, simultaneously, both his companions brought their Heat-Rays to
+bear on the battery.  The ammunition blew up, the pine trees all about
+the guns flashed into fire, and only one or two of the men who were
+already running over the crest of the hill escaped.
+
+After this it would seem that the three took counsel together and
+halted, and the scouts who were watching them report that they
+remained absolutely stationary for the next half hour.  The Martian
+who had been overthrown crawled tediously out of his hood, a small
+brown figure, oddly suggestive from that distance of a speck of
+blight, and apparently engaged in the repair of his support.  About
+nine he had finished, for his cowl was then seen above the trees
+again.
+
+It was a few minutes past nine that night when these three
+sentinels were joined by four other Martians, each carrying a thick
+black tube.  A similar tube was handed to each of the three, and the
+seven proceeded to distribute themselves at equal distances along a
+curved line between St. George's Hill, Weybridge, and the village of
+Send, southwest of Ripley.
+
+A dozen rockets sprang out of the hills before them so soon as they
+began to move, and warned the waiting batteries about Ditton and
+Esher.  At the same time four of their fighting machines, similarly
+armed with tubes, crossed the river, and two of them, black against
+the western sky, came into sight of myself and the curate as we
+hurried wearily and painfully along the road that runs northward out
+of Halliford.  They moved, as it seemed to us, upon a cloud, for a
+milky mist covered the fields and rose to a third of their height.
+
+At this sight the curate cried faintly in his throat, and began
+running; but I knew it was no good running from a Martian, and I
+turned aside and crawled through dewy nettles and brambles into the
+broad ditch by the side of the road.  He looked back, saw what I was
+doing, and turned to join me.
+
+The two halted, the nearer to us standing and facing Sunbury, the
+remoter being a grey indistinctness towards the evening star, away
+towards Staines.
+
+The occasional howling of the Martians had ceased; they took up
+their positions in the huge crescent about their cylinders in absolute
+silence.  It was a crescent with twelve miles between its horns.  Never
+since the devising of gunpowder was the beginning of a battle so
+still.  To us and to an observer about Ripley it would have had
+precisely the same effect--the Martians seemed in solitary possession
+of the darkling night, lit only as it was by the slender moon, the
+stars, the afterglow of the daylight, and the ruddy glare from St.
+George's Hill and the woods of Painshill.
+
+But facing that crescent everywhere--at Staines, Hounslow, Ditton,
+Esher, Ockham, behind hills and woods south of the river, and across
+the flat grass meadows to the north of it, wherever a cluster of trees
+or village houses gave sufficient cover--the guns were waiting.  The
+signal rockets burst and rained their sparks through the night and
+vanished, and the spirit of all those watching batteries rose to a
+tense expectation.  The Martians had but to advance into the line of
+fire, and instantly those motionless black forms of men, those guns
+glittering so darkly in the early night, would explode into a
+thunderous fury of battle.
+
+No doubt the thought that was uppermost in a thousand of those
+vigilant minds, even as it was uppermost in mine, was the riddle--how
+much they understood of us.  Did they grasp that we in our millions
+were organized, disciplined, working together?  Or did they interpret
+our spurts of fire, the sudden stinging of our shells, our steady
+investment of their encampment, as we should the furious unanimity of
+onslaught in a disturbed hive of bees?  Did they dream they might
+exterminate us?  (At that time no one knew what food they needed.)  A
+hundred such questions struggled together in my mind as I watched that
+vast sentinel shape.  And in the back of my mind was the sense of all
+the huge unknown and hidden forces Londonward.  Had they prepared
+pitfalls? Were the powder mills at Hounslow ready as a snare?  Would
+the Londoners have the heart and courage to make a greater Moscow of
+their mighty province of houses?
+
+Then, after an interminable time, as it seemed to us, crouching and
+peering through the hedge, came a sound like the distant concussion of
+a gun.  Another nearer, and then another.  And then the Martian beside
+us raised his tube on high and discharged it, gunwise, with a heavy
+report that made the ground heave.  The one towards Staines answered
+him.  There was no flash, no smoke, simply that loaded detonation.
+
+I was so excited by these heavy minute-guns following one another
+that I so far forgot my personal safety and my scalded hands as to
+clamber up into the hedge and stare towards Sunbury.  As I did so a
+second report followed, and a big projectile hurtled overhead towards
+Hounslow.  I expected at least to see smoke or fire, or some such
+evidence of its work.  But all I saw was the deep blue sky above, with
+one solitary star, and the white mist spreading wide and low beneath.
+And there had been no crash, no answering explosion.  The silence was
+restored; the minute lengthened to three.
+
+"What has happened?" said the curate, standing up beside me.
+
+"Heaven knows!" said I.
+
+A bat flickered by and vanished.  A distant tumult of shouting
+began and ceased.  I looked again at the Martian, and saw he was now
+moving eastward along the riverbank, with a swift, rolling motion.
+
+Every moment I expected the fire of some hidden battery to spring
+upon him; but the evening calm was unbroken.  The figure of the Martian
+grew smaller as he receded, and presently the mist and the gathering
+night had swallowed him up.  By a common impulse we clambered higher.
+Towards Sunbury was a dark appearance, as though a conical hill had
+suddenly come into being there, hiding our view of the farther
+country; and then, remoter across the river, over Walton, we saw
+another such summit.  These hill-like forms grew lower and broader
+even as we stared.
+
+Moved by a sudden thought, I looked northward, and there I
+perceived a third of these cloudy black kopjes had risen.
+
+Everything had suddenly become very still.  Far away to the
+southeast, marking the quiet, we heard the Martians hooting to one
+another, and then the air quivered again with the distant thud of
+their guns.  But the earthly artillery made no reply.
+
+Now at the time we could not understand these things, but later I
+was to learn the meaning of these ominous kopjes that gathered in the
+twilight.  Each of the Martians, standing in the great crescent I have
+described, had discharged, by means of the gunlike tube he carried, a
+huge canister over whatever hill, copse, cluster of houses, or other
+possible cover for guns, chanced to be in front of him.  Some fired
+only one of these, some two--as in the case of the one we had seen;
+the one at Ripley is said to have discharged no fewer than five at
+that time.  These canisters smashed on striking the ground--they did
+not explode--and incontinently disengaged an enormous volume of heavy,
+inky vapour, coiling and pouring upward in a huge and ebony cumulus
+cloud, a gaseous hill that sank and spread itself slowly over the
+surrounding country.  And the touch of that vapour, the inhaling of
+its pungent wisps, was death to all that breathes.
+
+It was heavy, this vapour, heavier than the densest smoke, so that,
+after the first tumultuous uprush and outflow of its impact, it sank
+down through the air and poured over the ground in a manner rather
+liquid than gaseous, abandoning the hills, and streaming into the
+valleys and ditches and watercourses even as I have heard the
+carbonic-acid gas that pours from volcanic clefts is wont to do.  And
+where it came upon water some chemical action occurred, and the
+surface would be instantly covered with a powdery scum that sank
+slowly and made way for more.  The scum was absolutely insoluble, and
+it is a strange thing, seeing the instant effect of the gas, that one
+could drink without hurt the water from which it had been strained.
+The vapour did not diffuse as a true gas would do.  It hung together
+in banks, flowing sluggishly down the slope of the land and driving
+reluctantly before the wind, and very slowly it combined with the mist
+and moisture of the air, and sank to the earth in the form of dust.
+Save that an unknown element giving a group of four lines in the blue
+of the spectrum is concerned, we are still entirely ignorant of the
+nature of this substance.
+
+Once the tumultuous upheaval of its dispersion was over, the black
+smoke clung so closely to the ground, even before its precipitation,
+that fifty feet up in the air, on the roofs and upper stories of high
+houses and on great trees, there was a chance of escaping its poison
+altogether, as was proved even that night at Street Cobham and Ditton.
+
+The man who escaped at the former place tells a wonderful story of
+the strangeness of its coiling flow, and how he looked down from the
+church spire and saw the houses of the village rising like ghosts out
+of its inky nothingness.  For a day and a half he remained there,
+weary, starving and sun-scorched, the earth under the blue sky and
+against the prospect of the distant hills a velvet-black expanse, with
+red roofs, green trees, and, later, black-veiled shrubs and gates,
+barns, outhouses, and walls, rising here and there into the sunlight.
+
+But that was at Street Cobham, where the black vapour was allowed
+to remain until it sank of its own accord into the ground.  As a rule
+the Martians, when it had served its purpose, cleared the air of it
+again by wading into it and directing a jet of steam upon it.
+
+This they did with the vapour banks near us, as we saw in the
+starlight from the window of a deserted house at Upper Halliford,
+whither we had returned.  From there we could see the searchlights on
+Richmond Hill and Kingston Hill going to and fro, and about eleven the
+windows rattled, and we heard the sound of the huge siege guns that
+had been put in position there.  These continued intermittently for
+the space of a quarter of an hour, sending chance shots at the
+invisible Martians at Hampton and Ditton, and then the pale beams of
+the electric light vanished, and were replaced by a bright red glow.
+
+Then the fourth cylinder fell--a brilliant green meteor--as I
+learned afterwards, in Bushey Park.  Before the guns on the Richmond
+and Kingston line of hills began, there was a fitful cannonade far
+away in the southwest, due, I believe, to guns being fired haphazard
+before the black vapour could overwhelm the gunners.
+
+So, setting about it as methodically as men might smoke out a
+wasps' nest, the Martians spread this strange stifling vapour over the
+Londonward country.  The horns of the crescent slowly moved apart,
+until at last they formed a line from Hanwell to Coombe and Malden.
+All night through their destructive tubes advanced.  Never once, after
+the Martian at St. George's Hill was brought down, did they give the
+artillery the ghost of a chance against them.  Wherever there was a
+possibility of guns being laid for them unseen, a fresh canister of
+the black vapour was discharged, and where the guns were openly
+displayed the Heat-Ray was brought to bear.
+
+By midnight the blazing trees along the slopes of Richmond Park and
+the glare of Kingston Hill threw their light upon a network of black
+smoke, blotting out the whole valley of the Thames and extending as
+far as the eye could reach.  And through this two Martians slowly
+waded, and turned their hissing steam jets this way and that.
+
+They were sparing of the Heat-Ray that night, either because they
+had but a limited supply of material for its production or because
+they did not wish to destroy the country but only to crush and overawe
+the opposition they had aroused.  In the latter aim they certainly
+succeeded.  Sunday night was the end of the organised opposition to
+their movements.  After that no body of men would stand against them,
+so hopeless was the enterprise.  Even the crews of the torpedo-boats
+and destroyers that had brought their quick-firers up the Thames
+refused to stop, mutinied, and went down again.  The only offensive
+operation men ventured upon after that night was the preparation of
+mines and pitfalls, and even in that their energies were frantic and
+spasmodic.
+
+One has to imagine, as well as one may, the fate of those batteries
+towards Esher, waiting so tensely in the twilight.  Survivors there
+were none.  One may picture the orderly expectation, the officers
+alert and watchful, the gunners ready, the ammunition piled to hand,
+the limber gunners with their horses and waggons, the groups of
+civilian spectators standing as near as they were permitted, the
+evening stillness, the ambulances and hospital tents with the burned
+and wounded from Weybridge; then the dull resonance of the shots the
+Martians fired, and the clumsy projectile whirling over the trees and
+houses and smashing amid the neighbouring fields.
+
+One may picture, too, the sudden shifting of the attention, the
+swiftly spreading coils and bellyings of that blackness advancing
+headlong, towering heavenward, turning the twilight to a palpable
+darkness, a strange and horrible antagonist of vapour striding upon
+its victims, men and horses near it seen dimly, running, shrieking,
+falling headlong, shouts of dismay, the guns suddenly abandoned, men
+choking and writhing on the ground, and the swift broadening-out of
+the opaque cone of smoke.  And then night and extinction--nothing but
+a silent mass of impenetrable vapour hiding its dead.
+
+Before dawn the black vapour was pouring through the streets of
+Richmond, and the disintegrating organism of government was, with a
+last expiring effort, rousing the population of London to the
+necessity of flight.
+
+
+
+CHAPTER SIXTEEN
+
+THE EXODUS FROM LONDON
+
+
+So you understand the roaring wave of fear that swept through the
+greatest city in the world just as Monday was dawning--the stream of
+flight rising swiftly to a torrent, lashing in a foaming tumult round
+the railway stations, banked up into a horrible struggle about the
+shipping in the Thames, and hurrying by every available channel
+northward and eastward.  By ten o'clock the police organisation, and
+by midday even the railway organisations, were losing coherency,
+losing shape and efficiency, guttering, softening, running at last in
+that swift liquefaction of the social body.
+
+All the railway lines north of the Thames and the South-Eastern
+people at Cannon Street had been warned by midnight on Sunday, and
+trains were being filled.  People were fighting savagely for
+standing-room in the carriages even at two o'clock.  By three, people
+were being trampled and crushed even in Bishopsgate Street, a couple
+of hundred yards or more from Liverpool Street station; revolvers were
+fired, people stabbed, and the policemen who had been sent to direct
+the traffic, exhausted and infuriated, were breaking the heads of the
+people they were called out to protect.
+
+And as the day advanced and the engine drivers and stokers refused
+to return to London, the pressure of the flight drove the people in an
+ever-thickening multitude away from the stations and along the
+northward-running roads.  By midday a Martian had been seen at Barnes,
+and a cloud of slowly sinking black vapour drove along the Thames and
+across the flats of Lambeth, cutting off all escape over the bridges
+in its sluggish advance.  Another bank drove over Ealing, and
+surrounded a little island of survivors on Castle Hill, alive, but
+unable to escape.
+
+After a fruitless struggle to get aboard a North-Western train at
+Chalk Farm--the engines of the trains that had loaded in the goods
+yard there _ploughed_ through shrieking people, and a dozen stalwart men
+fought to keep the crowd from crushing the driver against his
+furnace--my brother emerged upon the Chalk Farm road, dodged across
+through a hurrying swarm of vehicles, and had the luck to be foremost
+in the sack of a cycle shop.  The front tire of the machine he got was
+punctured in dragging it through the window, but he got up and off,
+notwithstanding, with no further injury than a cut wrist.  The steep
+foot of Haverstock Hill was impassable owing to several overturned
+horses, and my brother struck into Belsize Road.
+
+So he got out of the fury of the panic, and, skirting the Edgware
+Road, reached Edgware about seven, fasting and wearied, but well ahead
+of the crowd.  Along the road people were standing in the roadway,
+curious, wondering.  He was passed by a number of cyclists, some
+horsemen, and two motor cars.  A mile from Edgware the rim of the
+wheel broke, and the machine became unridable.  He left it by the
+roadside and trudged through the village.  There were shops half
+opened in the main street of the place, and people crowded on the
+pavement and in the doorways and windows, staring astonished at this
+extraordinary procession of fugitives that was beginning.  He
+succeeded in getting some food at an inn.
+
+For a time he remained in Edgware not knowing what next to do.  The
+flying people increased in number.  Many of them, like my brother,
+seemed inclined to loiter in the place.  There was no fresh news of
+the invaders from Mars.
+
+At that time the road was crowded, but as yet far from congested.
+Most of the fugitives at that hour were mounted on cycles, but there
+were soon motor cars, hansom cabs, and carriages hurrying along, and
+the dust hung in heavy clouds along the road to St. Albans.
+
+It was perhaps a vague idea of making his way to Chelmsford, where
+some friends of his lived, that at last induced my brother to strike
+into a quiet lane running eastward.  Presently he came upon a stile,
+and, crossing it, followed a footpath northeastward.  He passed near
+several farmhouses and some little places whose names he did not
+learn.  He saw few fugitives until, in a grass lane towards High
+Barnet, he happened upon two ladies who became his fellow travellers.
+He came upon them just in time to save them.
+
+He heard their screams, and, hurrying round the corner, saw a
+couple of men struggling to drag them out of the little pony-chaise in
+which they had been driving, while a third with difficulty held the
+frightened pony's head.  One of the ladies, a short woman dressed in
+white, was simply screaming; the other, a dark, slender figure,
+slashed at the man who gripped her arm with a whip she held in her
+disengaged hand.
+
+My brother immediately grasped the situation, shouted, and hurried
+towards the struggle.  One of the men desisted and turned towards him,
+and my brother, realising from his antagonist's face that a fight was
+unavoidable, and being an expert boxer, went into him forthwith and
+sent him down against the wheel of the chaise.
+
+It was no time for pugilistic chivalry and my brother laid him
+quiet with a kick, and gripped the collar of the man who pulled at the
+slender lady's arm.  He heard the clatter of hoofs, the whip stung
+across his face, a third antagonist struck him between the eyes, and
+the man he held wrenched himself free and made off down the lane in
+the direction from which he had come.
+
+Partly stunned, he found himself facing the man who had held the
+horse's head, and became aware of the chaise receding from him down
+the lane, swaying from side to side, and with the women in it looking
+back.  The man before him, a burly rough, tried to close, and he
+stopped him with a blow in the face.  Then, realising that he was
+deserted, he dodged round and made off down the lane after the chaise,
+with the sturdy man close behind him, and the fugitive, who had turned
+now, following remotely.
+
+Suddenly he stumbled and fell; his immediate pursuer went headlong,
+and he rose to his feet to find himself with a couple of antagonists
+again.  He would have had little chance against them had not the
+slender lady very pluckily pulled up and returned to his help.  It
+seems she had had a revolver all this time, but it had been under the
+seat when she and her companion were attacked.  She fired at six
+yards' distance, narrowly missing my brother.  The less courageous of
+the robbers made off, and his companion followed him, cursing his
+cowardice.  They both stopped in sight down the lane, where the third
+man lay insensible.
+
+"Take this!" said the slender lady, and she gave my brother her
+revolver.
+
+"Go back to the chaise," said my brother, wiping the blood from his
+split lip.
+
+She turned without a word--they were both panting--and they went
+back to where the lady in white struggled to hold back the frightened
+pony.
+
+The robbers had evidently had enough of it.  When my brother looked
+again they were retreating.
+
+"I'll sit here," said my brother, "if I may"; and he got upon the
+empty front seat.  The lady looked over her shoulder.
+
+"Give me the reins," she said, and laid the whip along the pony's
+side.  In another moment a bend in the road hid the three men from my
+brother's eyes.
+
+So, quite unexpectedly, my brother found himself, panting, with a
+cut mouth, a bruised jaw, and bloodstained knuckles, driving along an
+unknown lane with these two women.
+
+He learned they were the wife and the younger sister of a surgeon
+living at Stanmore, who had come in the small hours from a dangerous
+case at Pinner, and heard at some railway station on his way of the
+Martian advance.  He had hurried home, roused the women--their servant
+had left them two days before--packed some provisions, put his
+revolver under the seat--luckily for my brother--and told them to
+drive on to Edgware, with the idea of getting a train there.  He
+stopped behind to tell the neighbours.  He would overtake them, he
+said, at about half past four in the morning, and now it was nearly
+nine and they had seen nothing of him.  They could not stop in Edgware
+because of the growing traffic through the place, and so they had come
+into this side lane.
+
+That was the story they told my brother in fragments when presently
+they stopped again, nearer to New Barnet.  He promised to stay with
+them, at least until they could determine what to do, or until the
+missing man arrived, and professed to be an expert shot with the
+revolver--a weapon strange to him--in order to give them confidence.
+
+They made a sort of encampment by the wayside, and the pony became
+happy in the hedge.  He told them of his own escape out of London, and
+all that he knew of these Martians and their ways.  The sun crept
+higher in the sky, and after a time their talk died out and gave place
+to an uneasy state of anticipation.  Several wayfarers came along the
+lane, and of these my brother gathered such news as he could.  Every
+broken answer he had deepened his impression of the great disaster
+that had come on humanity, deepened his persuasion of the immediate
+necessity for prosecuting this flight.  He urged the matter upon them.
+
+"We have money," said the slender woman, and hesitated.
+
+Her eyes met my brother's, and her hesitation ended.
+
+"So have I," said my brother.
+
+She explained that they had as much as thirty pounds in gold,
+besides a five-pound note, and suggested that with that they might get
+upon a train at St. Albans or New Barnet.  My brother thought that was
+hopeless, seeing the fury of the Londoners to crowd upon the trains,
+and broached his own idea of striking across Essex towards Harwich and
+thence escaping from the country altogether.
+
+Mrs. Elphinstone--that was the name of the woman in white--would
+listen to no reasoning, and kept calling upon "George"; but her
+sister-in-law was astonishingly quiet and deliberate, and at last
+agreed to my brother's suggestion.  So, designing to cross the Great
+North Road, they went on towards Barnet, my brother leading the pony
+to save it as much as possible.  As the sun crept up the sky the day
+became excessively hot, and under foot a thick, whitish sand grew
+burning and blinding, so that they travelled only very slowly.  The
+hedges were grey with dust.  And as they advanced towards Barnet a
+tumultuous murmuring grew stronger.
+
+They began to meet more people.  For the most part these were
+staring before them, murmuring indistinct questions, jaded, haggard,
+unclean.  One man in evening dress passed them on foot, his eyes on
+the ground.  They heard his voice, and, looking back at him, saw one
+hand clutched in his hair and the other beating invisible things.  His
+paroxysm of rage over, he went on his way without once looking back.
+
+As my brother's party went on towards the crossroads to the south
+of Barnet they saw a woman approaching the road across some fields on
+their left, carrying a child and with two other children; and then
+passed a man in dirty black, with a thick stick in one hand and a
+small portmanteau in the other.  Then round the corner of the lane,
+from between the villas that guarded it at its confluence with the
+high road, came a little cart drawn by a sweating black pony and
+driven by a sallow youth in a bowler hat, grey with dust.  There were
+three girls, East End factory girls, and a couple of little children
+crowded in the cart.
+
+"This'll tike us rahnd Edgware?" asked the driver, wild-eyed,
+white-faced; and when my brother told him it would if he turned to the
+left, he whipped up at once without the formality of thanks.
+
+My brother noticed a pale grey smoke or haze rising among the
+houses in front of them, and veiling the white facade of a terrace
+beyond the road that appeared between the backs of the villas.  Mrs.
+Elphinstone suddenly cried out at a number of tongues of smoky red
+flame leaping up above the houses in front of them against the hot,
+blue sky.  The tumultuous noise resolved itself now into the
+disorderly mingling of many voices, the gride of many wheels, the
+creaking of waggons, and the staccato of hoofs.  The lane came round
+sharply not fifty yards from the crossroads.
+
+"Good heavens!" cried Mrs. Elphinstone.  "What is this you are
+driving us into?"
+
+My brother stopped.
+
+For the main road was a boiling stream of people, a torrent of
+human beings rushing northward, one pressing on another.  A great bank
+of dust, white and luminous in the blaze of the sun, made everything
+within twenty feet of the ground grey and indistinct and was
+perpetually renewed by the hurrying feet of a dense crowd of horses
+and of men and women on foot, and by the wheels of vehicles of every
+description.
+
+"Way!" my brother heard voices crying.  "Make way!"
+
+It was like riding into the smoke of a fire to approach the meeting
+point of the lane and road; the crowd roared like a fire, and the dust
+was hot and pungent.  And, indeed, a little way up the road a villa
+was burning and sending rolling masses of black smoke across the road
+to add to the confusion.
+
+Two men came past them.  Then a dirty woman, carrying a heavy
+bundle and weeping.  A lost retriever dog, with hanging tongue,
+circled dubiously round them, scared and wretched, and fled at my
+brother's threat.
+
+So much as they could see of the road Londonward between the houses
+to the right was a tumultuous stream of dirty, hurrying people, pent
+in between the villas on either side; the black heads, the crowded
+forms, grew into distinctness as they rushed towards the corner,
+hurried past, and merged their individuality again in a receding
+multitude that was swallowed up at last in a cloud of dust.
+
+"Go on!  Go on!" cried the voices.  "Way!  Way!"
+
+One man's hands pressed on the back of another.  My brother stood
+at the pony's head.  Irresistibly attracted, he advanced slowly, pace
+by pace, down the lane.
+
+Edgware had been a scene of confusion, Chalk Farm a riotous tumult,
+but this was a whole population in movement.  It is hard to imagine
+that host.  It had no character of its own.  The figures poured out
+past the corner, and receded with their backs to the group in the
+lane.  Along the margin came those who were on foot threatened by the
+wheels, stumbling in the ditches, blundering into one another.
+
+The carts and carriages crowded close upon one another, making
+little way for those swifter and more impatient vehicles that darted
+forward every now and then when an opportunity showed itself of doing
+so, sending the people scattering against the fences and gates of the
+villas.
+
+"Push on!" was the cry.  "Push on!  They are coming!"
+
+In one cart stood a blind man in the uniform of the Salvation Army,
+gesticulating with his crooked fingers and bawling, "Eternity!
+Eternity!"  His voice was hoarse and very loud so that my brother
+could hear him long after he was lost to sight in the dust.  Some of
+the people who crowded in the carts whipped stupidly at their horses
+and quarrelled with other drivers; some sat motionless, staring at
+nothing with miserable eyes; some gnawed their hands with thirst, or
+lay prostrate in the bottoms of their conveyances.  The horses' bits
+were covered with foam, their eyes bloodshot.
+
+There were cabs, carriages, shop cars, waggons, beyond counting; a
+mail cart, a road-cleaner's cart marked "Vestry of St. Pancras," a
+huge timber waggon crowded with roughs.  A brewer's dray rumbled by
+with its two near wheels splashed with fresh blood.
+
+"Clear the way!" cried the voices.  "Clear the way!"
+
+"Eter-nity!  Eter-nity!" came echoing down the road.
+
+There were sad, haggard women tramping by, well dressed, with
+children that cried and stumbled, their dainty clothes smothered in
+dust, their weary faces smeared with tears.  With many of these came
+men, sometimes helpful, sometimes lowering and savage.  Fighting side
+by side with them pushed some weary street outcast in faded black
+rags, wide-eyed, loud-voiced, and foul-mouthed.  There were sturdy
+workmen thrusting their way along, wretched, unkempt men, clothed like
+clerks or shopmen, struggling spasmodically; a wounded soldier my
+brother noticed, men dressed in the clothes of railway porters, one
+wretched creature in a nightshirt with a coat thrown over it.
+
+But varied as its composition was, certain things all that host had
+in common.  There were fear and pain on their faces, and fear behind
+them.  A tumult up the road, a quarrel for a place in a waggon, sent
+the whole host of them quickening their pace; even a man so scared and
+broken that his knees bent under him was galvanised for a moment into
+renewed activity.  The heat and dust had already been at work upon
+this multitude.  Their skins were dry, their lips black and cracked.
+They were all thirsty, weary, and footsore.  And amid the various
+cries one heard disputes, reproaches, groans of weariness and fatigue;
+the voices of most of them were hoarse and weak.  Through it all ran a
+refrain:
+
+"Way!  Way!  The Martians are coming!"
+
+Few stopped and came aside from that flood.  The lane opened
+slantingly into the main road with a narrow opening, and had a
+delusive appearance of coming from the direction of London.  Yet a
+kind of eddy of people drove into its mouth; weaklings elbowed out of
+the stream, who for the most part rested but a moment before plunging
+into it again.  A little way down the lane, with two friends bending
+over him, lay a man with a bare leg, wrapped about with bloody rags.
+He was a lucky man to have friends.
+
+A little old man, with a grey military moustache and a filthy black
+frock coat, limped out and sat down beside the trap, removed his
+boot--his sock was blood-stained--shook out a pebble, and hobbled on
+again; and then a little girl of eight or nine, all alone, threw
+herself under the hedge close by my brother, weeping.
+
+"I can't go on!  I can't go on!"
+
+My brother woke from his torpor of astonishment and lifted her up,
+speaking gently to her, and carried her to Miss Elphinstone.  So soon
+as my brother touched her she became quite still, as if frightened.
+
+"Ellen!" shrieked a woman in the crowd, with tears in her
+voice--"Ellen!"  And the child suddenly darted away from my brother,
+crying "Mother!"
+
+"They are coming," said a man on horseback, riding past along the
+lane.
+
+"Out of the way, there!" bawled a coachman, towering high; and my
+brother saw a closed carriage turning into the lane.
+
+The people crushed back on one another to avoid the horse.  My
+brother pushed the pony and chaise back into the hedge, and the man
+drove by and stopped at the turn of the way.  It was a carriage, with
+a pole for a pair of horses, but only one was in the traces.  My
+brother saw dimly through the dust that two men lifted out something
+on a white stretcher and put it gently on the grass beneath the privet
+hedge.
+
+One of the men came running to my brother.
+
+"Where is there any water?" he said.  "He is dying fast, and very
+thirsty.  It is Lord Garrick."
+
+"Lord Garrick!" said my brother; "the Chief Justice?"
+
+"The water?" he said.
+
+"There may be a tap," said my brother, "in some of the houses.  We
+have no water.  I dare not leave my people."
+
+The man pushed against the crowd towards the gate of the corner
+house.
+
+"Go on!" said the people, thrusting at him.  "They are coming!  Go
+on!"
+
+Then my brother's attention was distracted by a bearded, eagle-faced
+man lugging a small handbag, which split even as my brother's
+eyes rested on it and disgorged a mass of sovereigns that seemed to
+break up into separate coins as it struck the ground.  They rolled
+hither and thither among the struggling feet of men and horses.  The
+man stopped and looked stupidly at the heap, and the shaft of a cab
+struck his shoulder and sent him reeling.  He gave a shriek and dodged
+back, and a cartwheel shaved him narrowly.
+
+"Way!" cried the men all about him.  "Make way!"
+
+So soon as the cab had passed, he flung himself, with both hands
+open, upon the heap of coins, and began thrusting handfuls in his
+pocket.  A horse rose close upon him, and in another moment, half
+rising, he had been borne down under the horse's hoofs.
+
+"Stop!" screamed my brother, and pushing a woman out of his way,
+tried to clutch the bit of the horse.
+
+Before he could get to it, he heard a scream under the wheels, and
+saw through the dust the rim passing over the poor wretch's back.  The
+driver of the cart slashed his whip at my brother, who ran round
+behind the cart.  The multitudinous shouting confused his ears.  The
+man was writhing in the dust among his scattered money, unable to
+rise, for the wheel had broken his back, and his lower limbs lay limp
+and dead.  My brother stood up and yelled at the next driver, and a
+man on a black horse came to his assistance.
+
+"Get him out of the road," said he; and, clutching the man's collar
+with his free hand, my brother lugged him sideways.  But he still
+clutched after his money, and regarded my brother fiercely, hammering
+at his arm with a handful of gold.  "Go on!  Go on!" shouted angry
+voices behind.
+
+"Way!  Way!"
+
+There was a smash as the pole of a carriage crashed into the cart
+that the man on horseback stopped.  My brother looked up, and the man
+with the gold twisted his head round and bit the wrist that held his
+collar.  There was a concussion, and the black horse came staggering
+sideways, and the carthorse pushed beside it.  A hoof missed my
+brother's foot by a hair's breadth.  He released his grip on the
+fallen man and jumped back.  He saw anger change to terror on the face
+of the poor wretch on the ground, and in a moment he was hidden and my
+brother was borne backward and carried past the entrance of the lane,
+and had to fight hard in the torrent to recover it.
+
+He saw Miss Elphinstone covering her eyes, and a little child, with
+all a child's want of sympathetic imagination, staring with dilated
+eyes at a dusty something that lay black and still, ground and crushed
+under the rolling wheels.  "Let us go back!" he shouted, and began
+turning the pony round. "We cannot cross this--hell," he said and they
+went back a hundred yards the way they had come, until the fighting
+crowd was hidden.  As they passed the bend in the lane my brother saw
+the face of the dying man in the ditch under the privet, deadly white
+and drawn, and shining with perspiration.  The two women sat silent,
+crouching in their seat and shivering.
+
+Then beyond the bend my brother stopped again.  Miss Elphinstone
+was white and pale, and her sister-in-law sat weeping, too wretched
+even to call upon "George."  My brother was horrified and perplexed.
+So soon as they had retreated he realised how urgent and unavoidable
+it was to attempt this crossing.  He turned to Miss Elphinstone,
+suddenly resolute.
+
+"We must go that way," he said, and led the pony round again.
+
+For the second time that day this girl proved her quality.  To force
+their way into the torrent of people, my brother plunged into the
+traffic and held back a cab horse, while she drove the pony across its
+head.  A waggon locked wheels for a moment and ripped a long splinter
+from the chaise.  In another moment they were caught and swept forward
+by the stream.  My brother, with the cabman's whip marks red across
+his face and hands, scrambled into the chaise and took the reins from
+her.
+
+"Point the revolver at the man behind," he said, giving it to her,
+"if he presses us too hard.  No!--point it at his horse."
+
+Then he began to look out for a chance of edging to the right
+across the road.  But once in the stream he seemed to lose volition,
+to become a part of that dusty rout.  They swept through Chipping
+Barnet with the torrent; they were nearly a mile beyond the centre of
+the town before they had fought across to the opposite side of the
+way.  It was din and confusion indescribable; but in and beyond the
+town the road forks repeatedly, and this to some extent relieved the
+stress.
+
+They struck eastward through Hadley, and there on either side of
+the road, and at another place farther on they came upon a great
+multitude of people drinking at the stream, some fighting to come at
+the water.  And farther on, from a lull near East Barnet, they saw
+two trains running slowly one after the other without signal or
+order--trains swarming with people, with men even among the coals
+behind the engines--going northward along the Great Northern Railway.
+My brother supposes they must have filled outside London, for at that
+time the furious terror of the people had rendered the central
+termini impossible.
+
+Near this place they halted for the rest of the afternoon, for the
+violence of the day had already utterly exhausted all three of them.
+They began to suffer the beginnings of hunger; the night was cold, and
+none of them dared to sleep.  And in the evening many people came
+hurrying along the road nearby their stopping place, fleeing from
+unknown dangers before them, and going in the direction from which my
+brother had come.
+
+
+
+CHAPTER SEVENTEEN
+
+THE "THUNDER CHILD"
+
+
+Had the Martians aimed only at destruction, they might on Monday
+have annihilated the entire population of London, as it spread itself
+slowly through the home counties.  Not only along the road through
+Barnet, but also through Edgware and Waltham Abbey, and along the
+roads eastward to Southend and Shoeburyness, and south of the Thames
+to Deal and Broadstairs, poured the same frantic rout.  If one could
+have hung that June morning in a balloon in the blazing blue above
+London every northward and eastward road running out of the tangled
+maze of streets would have seemed stippled black with the streaming
+fugitives, each dot a human agony of terror and physical distress.  I
+have set forth at length in the last chapter my brother's account of
+the road through Chipping Barnet, in order that my readers may realise
+how that swarming of black dots appeared to one of those concerned.
+Never before in the history of the world had such a mass of human
+beings moved and suffered together.  The legendary hosts of Goths and
+Huns, the hugest armies Asia has ever seen, would have been but a drop
+in that current.  And this was no disciplined march; it was a
+stampede--a stampede gigantic and terrible--without order and without
+a goal, six million people unarmed and unprovisioned, driving
+headlong.  It was the beginning of the rout of civilisation, of the
+massacre of mankind.
+
+Directly below him the balloonist would have seen the network of
+streets far and wide, houses, churches, squares, crescents,
+gardens--already derelict--spread out like a huge map, and in the
+southward _blotted_.  Over Ealing, Richmond, Wimbledon, it would
+have seemed as if some monstrous pen had flung ink upon the chart.
+Steadily, incessantly, each black splash grew and spread, shooting out
+ramifications this way and that, now banking itself against rising
+ground, now pouring swiftly over a crest into a new-found valley,
+exactly as a gout of ink would spread itself upon blotting paper.
+
+And beyond, over the blue hills that rise southward of the river,
+the glittering Martians went to and fro, calmly and methodically
+spreading their poison cloud over this patch of country and then over
+that, laying it again with their steam jets when it had served its
+purpose, and taking possession of the conquered country.  They do not
+seem to have aimed at extermination so much as at complete
+demoralisation and the destruction of any opposition.  They exploded
+any stores of powder they came upon, cut every telegraph, and wrecked
+the railways here and there.  They were hamstringing mankind.  They
+seemed in no hurry to extend the field of their operations, and did
+not come beyond the central part of London all that day.  It is
+possible that a very considerable number of people in London stuck to
+their houses through Monday morning.  Certain it is that many died at
+home suffocated by the Black Smoke.
+
+Until about midday the Pool of London was an astonishing scene.
+Steamboats and shipping of all sorts lay there, tempted by the
+enormous sums of money offered by fugitives, and it is said that many
+who swam out to these vessels were thrust off with boathooks and
+drowned.  About one o'clock in the afternoon the thinning remnant of a
+cloud of the black vapour appeared between the arches of Blackfriars
+Bridge.  At that the Pool became a scene of mad confusion, fighting,
+and collision, and for some time a multitude of boats and barges
+jammed in the northern arch of the Tower Bridge, and the sailors and
+lightermen had to fight savagely against the people who swarmed upon
+them from the riverfront.  People were actually clambering down the
+piers of the bridge from above.
+
+When, an hour later, a Martian appeared beyond the Clock Tower and
+waded down the river, nothing but wreckage floated above Limehouse.
+
+Of the falling of the fifth cylinder I have presently to tell.  The
+sixth star fell at Wimbledon.  My brother, keeping watch beside the
+women in the chaise in a meadow, saw the green flash of it far beyond
+the hills.  On Tuesday the little party, still set upon getting across
+the sea, made its way through the swarming country towards Colchester.
+The news that the Martians were now in possession of the whole of
+London was confirmed.  They had been seen at Highgate, and even, it
+was said, at Neasden.  But they did not come into my brother's view
+until the morrow.
+
+That day the scattered multitudes began to realise the urgent need
+of provisions.  As they grew hungry the rights of property ceased to
+be regarded.  Farmers were out to defend their cattle-sheds,
+granaries, and ripening root crops with arms in their hands.  A number
+of people now, like my brother, had their faces eastward, and there
+were some desperate souls even going back towards London to get food.
+These were chiefly people from the northern suburbs, whose knowledge
+of the Black Smoke came by hearsay.  He heard that about half the
+members of the government had gathered at Birmingham, and that
+enormous quantities of high explosives were being prepared to be used
+in automatic mines across the Midland counties.
+
+He was also told that the Midland Railway Company had replaced the
+desertions of the first day's panic, had resumed traffic, and was
+running northward trains from St. Albans to relieve the congestion of
+the home counties.  There was also a placard in Chipping Ongar
+announcing that large stores of flour were available in the northern
+towns and that within twenty-four hours bread would be distributed
+among the starving people in the neighbourhood.  But this intelligence
+did not deter him from the plan of escape he had formed, and the three
+pressed eastward all day, and heard no more of the bread distribution
+than this promise.  Nor, as a matter of fact, did anyone else hear
+more of it.  That night fell the seventh star, falling upon Primrose
+Hill.  It fell while Miss Elphinstone was watching, for she took that
+duty alternately with my brother.  She saw it.
+
+On Wednesday the three fugitives--they had passed the night in a
+field of unripe wheat--reached Chelmsford, and there a body of the
+inhabitants, calling itself the Committee of Public Supply, seized the
+pony as provisions, and would give nothing in exchange for it but the
+promise of a share in it the next day.  Here there were rumours of
+Martians at Epping, and news of the destruction of Waltham Abbey
+Powder Mills in a vain attempt to blow up one of the invaders.
+
+People were watching for Martians here from the church towers.  My
+brother, very luckily for him as it chanced, preferred to push on at
+once to the coast rather than wait for food, although all three of
+them were very hungry.  By midday they passed through Tillingham,
+which, strangely enough, seemed to be quite silent and deserted, save
+for a few furtive plunderers hunting for food.  Near Tillingham they
+suddenly came in sight of the sea, and the most amazing crowd of
+shipping of all sorts that it is possible to imagine.
+
+For after the sailors could no longer come up the Thames, they came
+on to the Essex coast, to Harwich and Walton and Clacton, and
+afterwards to Foulness and Shoebury, to bring off the people.  They
+lay in a huge sickle-shaped curve that vanished into mist at last
+towards the Naze.  Close inshore was a multitude of fishing
+smacks--English, Scotch, French, Dutch, and Swedish; steam launches
+from the Thames, yachts, electric boats; and beyond were ships of large
+burden, a multitude of filthy colliers, trim merchantmen, cattle ships,
+passenger boats, petroleum tanks, ocean tramps, an old white transport
+even, neat white and grey liners from Southampton and Hamburg; and
+along the blue coast across the Blackwater my brother could make out
+dimly a dense swarm of boats chaffering with the people on the beach,
+a swarm which also extended up the Blackwater almost to Maldon.
+
+About a couple of miles out lay an ironclad, very low in the water,
+almost, to my brother's perception, like a water-logged ship.  This
+was the ram _Thunder Child_.  It was the only warship in sight, but far
+away to the right over the smooth surface of the sea--for that day
+there was a dead calm--lay a serpent of black smoke to mark the next
+ironclads of the Channel Fleet, which hovered in an extended line,
+steam up and ready for action, across the Thames estuary during the
+course of the Martian conquest, vigilant and yet powerless to prevent
+it.
+
+At the sight of the sea, Mrs. Elphinstone, in spite of the
+assurances of her sister-in-law, gave way to panic.  She had never
+been out of England before, she would rather die than trust herself
+friendless in a foreign country, and so forth.  She seemed, poor woman,
+to imagine that the French and the Martians might prove very similar.
+She had been growing increasingly hysterical, fearful, and depressed
+during the two days' journeyings.  Her great idea was to return to
+Stanmore.  Things had been always well and safe at Stanmore.  They
+would find George at Stanmore.
+
+It was with the greatest difficulty they could get her down to the
+beach, where presently my brother succeeded in attracting the
+attention of some men on a paddle steamer from the Thames.  They sent
+a boat and drove a bargain for thirty-six pounds for the three.  The
+steamer was going, these men said, to Ostend.
+
+It was about two o'clock when my brother, having paid their fares
+at the gangway, found himself safely aboard the steamboat with his
+charges.  There was food aboard, albeit at exorbitant prices, and the
+three of them contrived to eat a meal on one of the seats forward.
+
+There were already a couple of score of passengers aboard, some of
+whom had expended their last money in securing a passage, but the
+captain lay off the Blackwater until five in the afternoon, picking up
+passengers until the seated decks were even dangerously crowded.  He
+would probably have remained longer had it not been for the sound of
+guns that began about that hour in the south.  As if in answer, the
+ironclad seaward fired a small gun and hoisted a string of flags.  A
+jet of smoke sprang out of her funnels.
+
+Some of the passengers were of opinion that this firing came from
+Shoeburyness, until it was noticed that it was growing louder.  At the
+same time, far away in the southeast the masts and upperworks of three
+ironclads rose one after the other out of the sea, beneath clouds of
+black smoke.  But my brother's attention speedily reverted to the
+distant firing in the south.  He fancied he saw a column of smoke
+rising out of the distant grey haze.
+
+The little steamer was already flapping her way eastward of the big
+crescent of shipping, and the low Essex coast was growing blue and
+hazy, when a Martian appeared, small and faint in the remote distance,
+advancing along the muddy coast from the direction of Foulness.  At
+that the captain on the bridge swore at the top of his voice with fear
+and anger at his own delay, and the paddles seemed infected with his
+terror.  Every soul aboard stood at the bulwarks or on the seats of
+the steamer and stared at that distant shape, higher than the trees or
+church towers inland, and advancing with a leisurely parody of a human
+stride.
+
+It was the first Martian my brother had seen, and he stood, more
+amazed than terrified, watching this Titan advancing deliberately
+towards the shipping, wading farther and farther into the water as the
+coast fell away.  Then, far away beyond the Crouch, came another,
+striding over some stunted trees, and then yet another, still farther
+off, wading deeply through a shiny mudflat that seemed to hang halfway
+up between sea and sky.  They were all stalking seaward, as if to
+intercept the escape of the multitudinous vessels that were crowded
+between Foulness and the Naze.  In spite of the throbbing exertions of
+the engines of the little paddle-boat, and the pouring foam that her
+wheels flung behind her, she receded with terrifying slowness from
+this ominous advance.
+
+Glancing northwestward, my brother saw the large crescent of
+shipping already writhing with the approaching terror; one ship
+passing behind another, another coming round from broadside to end on,
+steamships whistling and giving off volumes of steam, sails being let
+out, launches rushing hither and thither.  He was so fascinated by
+this and by the creeping danger away to the left that he had no eyes
+for anything seaward.  And then a swift movement of the steamboat (she
+had suddenly come round to avoid being run down) flung him headlong
+from the seat upon which he was standing.  There was a shouting all
+about him, a trampling of feet, and a cheer that seemed to be answered
+faintly.  The steamboat lurched and rolled him over upon his hands.
+
+He sprang to his feet and saw to starboard, and not a hundred yards
+from their heeling, pitching boat, a vast iron bulk like the blade of
+a plough tearing through the water, tossing it on either side in huge
+waves of foam that leaped towards the steamer, flinging her paddles
+helplessly in the air, and then sucking her deck down almost to the
+waterline.
+
+A douche of spray blinded my brother for a moment.  When his eyes
+were clear again he saw the monster had passed and was rushing
+landward.  Big iron upperworks rose out of this headlong structure,
+and from that twin funnels projected and spat a smoking blast shot
+with fire.  It was the torpedo ram, _Thunder Child_, steaming headlong,
+coming to the rescue of the threatened shipping.
+
+Keeping his footing on the heaving deck by clutching the bulwarks,
+my brother looked past this charging leviathan at the Martians again,
+and he saw the three of them now close together, and standing so far
+out to sea that their tripod supports were almost entirely submerged.
+Thus sunken, and seen in remote perspective, they appeared far less
+formidable than the huge iron bulk in whose wake the steamer was
+pitching so helplessly.  It would seem they were regarding this new
+antagonist with astonishment.  To their intelligence, it may be, the
+giant was even such another as themselves.  The _Thunder Child_ fired no
+gun, but simply drove full speed towards them.  It was probably her
+not firing that enabled her to get so near the enemy as she did.  They
+did not know what to make of her.  One shell, and they would have sent
+her to the bottom forthwith with the Heat-Ray.
+
+She was steaming at such a pace that in a minute she seemed halfway
+between the steamboat and the Martians--a diminishing black bulk
+against the receding horizontal expanse of the Essex coast.
+
+Suddenly the foremost Martian lowered his tube and discharged a
+canister of the black gas at the ironclad.  It hit her larboard side
+and glanced off in an inky jet that rolled away to seaward, an
+unfolding torrent of Black Smoke, from which the ironclad drove clear.
+To the watchers from the steamer, low in the water and with the sun in
+their eyes, it seemed as though she were already among the Martians.
+
+They saw the gaunt figures separating and rising out of the water
+as they retreated shoreward, and one of them raised the camera-like
+generator of the Heat-Ray.  He held it pointing obliquely downward,
+and a bank of steam sprang from the water at its touch.  It must have
+driven through the iron of the ship's side like a white-hot iron rod
+through paper.
+
+A flicker of flame went up through the rising steam, and then the
+Martian reeled and staggered.  In another moment he was cut down, and
+a great body of water and steam shot high in the air.  The guns of the
+_Thunder Child_ sounded through the reek, going off one after the other,
+and one shot splashed the water high close by the steamer, ricocheted
+towards the other flying ships to the north, and smashed a smack to
+matchwood.
+
+But no one heeded that very much.  At the sight of the Martian's
+collapse the captain on the bridge yelled inarticulately, and all the
+crowding passengers on the steamer's stern shouted together.  And then
+they yelled again.  For, surging out beyond the white tumult, drove
+something long and black, the flames streaming from its middle parts,
+its ventilators and funnels spouting fire.
+
+She was alive still; the steering gear, it seems, was intact and
+her engines working.  She headed straight for a second Martian, and
+was within a hundred yards of him when the Heat-Ray came to bear.  Then
+with a violent thud, a blinding flash, her decks, her funnels, leaped
+upward.  The Martian staggered with the violence of her explosion, and
+in another moment the flaming wreckage, still driving forward with the
+impetus of its pace, had struck him and crumpled him up like a thing
+of cardboard.  My brother shouted involuntarily.  A boiling tumult of
+steam hid everything again.
+
+"Two!" yelled the captain.
+
+Everyone was shouting.  The whole steamer from end to end rang with
+frantic cheering that was taken up first by one and then by all in the
+crowding multitude of ships and boats that was driving out to sea.
+
+The steam hung upon the water for many minutes, hiding the third
+Martian and the coast altogether.  And all this time the boat was
+paddling steadily out to sea and away from the fight; and when at last
+the confusion cleared, the drifting bank of black vapour intervened,
+and nothing of the _Thunder Child_ could be made out, nor could the
+third Martian be seen.  But the ironclads to seaward were now quite
+close and standing in towards shore past the steamboat.
+
+The little vessel continued to beat its way seaward, and the
+ironclads receded slowly towards the coast, which was hidden still by
+a marbled bank of vapour, part steam, part black gas, eddying and
+combining in the strangest way.  The fleet of refugees was scattering
+to the northeast; several smacks were sailing between the ironclads
+and the steamboat.  After a time, and before they reached the sinking
+cloud bank, the warships turned northward, and then abruptly went
+about and passed into the thickening haze of evening southward.  The
+coast grew faint, and at last indistinguishable amid the low banks of
+clouds that were gathering about the sinking sun.
+
+Then suddenly out of the golden haze of the sunset came the
+vibration of guns, and a form of black shadows moving.  Everyone
+struggled to the rail of the steamer and peered into the blinding
+furnace of the west, but nothing was to be distinguished clearly.  A
+mass of smoke rose slanting and barred the face of the sun.  The
+steamboat throbbed on its way through an interminable suspense.
+
+The sun sank into grey clouds, the sky flushed and darkened, the
+evening star trembled into sight.  It was deep twilight when the
+captain cried out and pointed.  My brother strained his eyes.
+Something rushed up into the sky out of the greyness--rushed
+slantingly upward and very swiftly into the luminous clearness above
+the clouds in the western sky; something flat and broad, and very
+large, that swept round in a vast curve, grew smaller, sank slowly,
+and vanished again into the grey mystery of the night.  And as it flew
+it rained down darkness upon the land.
+
+
+
+BOOK TWO
+
+THE EARTH UNDER THE MARTIANS
+
+
+
+CHAPTER ONE
+
+UNDER FOOT
+
+
+In the first book I have wandered so much from my own adventures to
+tell of the experiences of my brother that all through the last two
+chapters I and the curate have been lurking in the empty house at
+Halliford whither we fled to escape the Black Smoke.  There I will
+resume.  We stopped there all Sunday night and all the next day--the
+day of the panic--in a little island of daylight, cut off by the Black
+Smoke from the rest of the world.  We could do nothing but wait in
+aching inactivity during those two weary days.
+
+My mind was occupied by anxiety for my wife.  I figured her at
+Leatherhead, terrified, in danger, mourning me already as a dead man.
+I paced the rooms and cried aloud when I thought of how I was cut off
+from her, of all that might happen to her in my absence.  My cousin I
+knew was brave enough for any emergency, but he was not the sort of
+man to realise danger quickly, to rise promptly.  What was needed now
+was not bravery, but circumspection.  My only consolation was to
+believe that the Martians were moving London-ward and away from her.
+Such vague anxieties keep the mind sensitive and painful.  I grew very
+weary and irritable with the curate's perpetual ejaculations; I tired
+of the sight of his selfish despair.  After some ineffectual
+remonstrance I kept away from him, staying in a room--evidently a
+children's schoolroom--containing globes, forms, and copybooks.  When
+he followed me thither, I went to a box room at the top of the house
+and, in order to be alone with my aching miseries, locked myself in.
+
+We were hopelessly hemmed in by the Black Smoke all that day and
+the morning of the next.  There were signs of people in the next house
+on Sunday evening--a face at a window and moving lights, and later the
+slamming of a door.  But I do not know who these people were, nor what
+became of them.  We saw nothing of them next day.  The Black Smoke
+drifted slowly riverward all through Monday morning, creeping nearer
+and nearer to us, driving at last along the roadway outside the house
+that hid us.
+
+A Martian came across the fields about midday, laying the stuff
+with a jet of superheated steam that hissed against the walls, smashed
+all the windows it touched, and scalded the curate's hand as he fled
+out of the front room.  When at last we crept across the sodden rooms
+and looked out again, the country northward was as though a black
+snowstorm had passed over it.  Looking towards the river, we were
+astonished to see an unaccountable redness mingling with the black of
+the scorched meadows.
+
+For a time we did not see how this change affected our position,
+save that we were relieved of our fear of the Black Smoke.  But later
+I perceived that we were no longer hemmed in, that now we might get
+away.  So soon as I realised that the way of escape was open, my dream
+of action returned.  But the curate was lethargic, unreasonable.
+
+"We are safe here," he repeated; "safe here."
+
+I resolved to leave him--would that I had!  Wiser now for the
+artilleryman's teaching, I sought out food and drink.  I had found oil
+and rags for my burns, and I also took a hat and a flannel shirt that
+I found in one of the bedrooms.  When it was clear to him that I meant
+to go alone--had reconciled myself to going alone--he suddenly roused
+himself to come.  And all being quiet throughout the afternoon, we
+started about five o'clock, as I should judge, along the blackened
+road to Sunbury.
+
+In Sunbury, and at intervals along the road, were dead bodies lying
+in contorted attitudes, horses as well as men, overturned carts and
+luggage, all covered thickly with black dust.  That pall of cindery
+powder made me think of what I had read of the destruction of Pompeii.
+We got to Hampton Court without misadventure, our minds full of
+strange and unfamiliar appearances, and at Hampton Court our eyes were
+relieved to find a patch of green that had escaped the suffocating
+drift.  We went through Bushey Park, with its deer going to and fro
+under the chestnuts, and some men and women hurrying in the distance
+towards Hampton, and so we came to Twickenham.  These were the first
+people we saw.
+
+Away across the road the woods beyond Ham and Petersham were still
+afire.  Twickenham was uninjured by either Heat-Ray or Black Smoke,
+and there were more people about here, though none could give us news.
+For the most part they were like ourselves, taking advantage of a lull
+to shift their quarters.  I have an impression that many of the houses
+here were still occupied by scared inhabitants, too frightened even
+for flight.  Here too the evidence of a hasty rout was abundant along
+the road.  I remember most vividly three smashed bicycles in a heap,
+pounded into the road by the wheels of subsequent carts.  We crossed
+Richmond Bridge about half past eight.  We hurried across the exposed
+bridge, of course, but I noticed floating down the stream a number
+of red masses, some many feet across.  I did not know what these
+were--there was no time for scrutiny--and I put a more horrible
+interpretation on them than they deserved.  Here again on the Surrey
+side were black dust that had once been smoke, and dead bodies--a heap
+near the approach to the station; but we had no glimpse of the
+Martians until we were some way towards Barnes.
+
+We saw in the blackened distance a group of three people running
+down a side street towards the river, but otherwise it seemed
+deserted.  Up the hill Richmond town was burning briskly; outside the
+town of Richmond there was no trace of the Black Smoke.
+
+Then suddenly, as we approached Kew, came a number of people
+running, and the upperworks of a Martian fighting-machine loomed in
+sight over the housetops, not a hundred yards away from us.  We stood
+aghast at our danger, and had the Martian looked down we must
+immediately have perished.  We were so terrified that we dared not go
+on, but turned aside and hid in a shed in a garden.  There the curate
+crouched, weeping silently, and refusing to stir again.
+
+But my fixed idea of reaching Leatherhead would not let me rest,
+and in the twilight I ventured out again.  I went through a shrubbery,
+and along a passage beside a big house standing in its own grounds,
+and so emerged upon the road towards Kew.  The curate I left in the
+shed, but he came hurrying after me.
+
+That second start was the most foolhardy thing I ever did.  For it
+was manifest the Martians were about us.  No sooner had the curate
+overtaken me than we saw either the fighting-machine we had seen
+before or another, far away across the meadows in the direction of Kew
+Lodge.  Four or five little black figures hurried before it across the
+green-grey of the field, and in a moment it was evident this Martian
+pursued them.  In three strides he was among them, and they ran
+radiating from his feet in all directions.  He used no Heat-Ray to
+destroy them, but picked them up one by one.  Apparently he tossed
+them into the great metallic carrier which projected behind him, much
+as a workman's basket hangs over his shoulder.
+
+It was the first time I realised that the Martians might have any
+other purpose than destruction with defeated humanity.  We stood for a
+moment petrified, then turned and fled through a gate behind us into a
+walled garden, fell into, rather than found, a fortunate ditch, and
+lay there, scarce daring to whisper to each other until the stars were
+out.
+
+I suppose it was nearly eleven o'clock before we gathered courage
+to start again, no longer venturing into the road, but sneaking along
+hedgerows and through plantations, and watching keenly through the
+darkness, he on the right and I on the left, for the Martians, who
+seemed to be all about us.  In one place we blundered upon a scorched
+and blackened area, now cooling and ashen, and a number of scattered
+dead bodies of men, burned horribly about the heads and trunks but
+with their legs and boots mostly intact; and of dead horses, fifty
+feet, perhaps, behind a line of four ripped guns and smashed gun
+carriages.
+
+Sheen, it seemed, had escaped destruction, but the place was silent
+and deserted.  Here we happened on no dead, though the night was too
+dark for us to see into the side roads of the place.  In Sheen my
+companion suddenly complained of faintness and thirst, and we decided
+to try one of the houses.
+
+The first house we entered, after a little difficulty with the
+window, was a small semi-detached villa, and I found nothing eatable
+left in the place but some mouldy cheese.  There was, however, water
+to drink; and I took a hatchet, which promised to be useful in our
+next house-breaking.
+
+We then crossed to a place where the road turns towards Mortlake.
+Here there stood a white house within a walled garden, and in the
+pantry of this domicile we found a store of food--two loaves of bread
+in a pan, an uncooked steak, and the half of a ham.  I give this
+catalogue so precisely because, as it happened, we were destined to
+subsist upon this store for the next fortnight.  Bottled beer stood
+under a shelf, and there were two bags of haricot beans and some limp
+lettuces.  This pantry opened into a kind of wash-up kitchen, and in
+this was firewood; there was also a cupboard, in which we found nearly
+a dozen of burgundy, tinned soups and salmon, and two tins of
+biscuits.
+
+We sat in the adjacent kitchen in the dark--for we dared not strike
+a light--and ate bread and ham, and drank beer out of the same bottle.
+The curate, who was still timorous and restless, was now, oddly
+enough, for pushing on, and I was urging him to keep up his strength
+by eating when the thing happened that was to imprison us.
+
+"It can't be midnight yet," I said, and then came a blinding glare
+of vivid green light.  Everything in the kitchen leaped out, clearly
+visible in green and black, and vanished again.  And then followed such
+a concussion as I have never heard before or since.  So close on the
+heels of this as to seem instantaneous came a thud behind me, a clash
+of glass, a crash and rattle of falling masonry all about us, and the
+plaster of the ceiling came down upon us, smashing into a multitude of
+fragments upon our heads.  I was knocked headlong across the floor
+against the oven handle and stunned.  I was insensible for a long
+time, the curate told me, and when I came to we were in darkness
+again, and he, with a face wet, as I found afterwards, with blood from
+a cut forehead, was dabbing water over me.
+
+For some time I could not recollect what had happened.  Then things
+came to me slowly.  A bruise on my temple asserted itself.
+
+"Are you better?" asked the curate in a whisper.
+
+At last I answered him.  I sat up.
+
+"Don't move," he said.  "The floor is covered with smashed crockery
+from the dresser.  You can't possibly move without making a noise, and
+I fancy _they_ are outside."
+
+We both sat quite silent, so that we could scarcely hear each other
+breathing.  Everything seemed deadly still, but once something near
+us, some plaster or broken brickwork, slid down with a rumbling sound.
+Outside and very near was an intermittent, metallic rattle.
+
+"That!" said the curate, when presently it happened again.
+
+"Yes," I said.  "But what is it?"
+
+"A Martian!" said the curate.
+
+I listened again.
+
+"It was not like the Heat-Ray," I said, and for a time I was
+inclined to think one of the great fighting-machines had stumbled
+against the house, as I had seen one stumble against the tower of
+Shepperton Church.
+
+Our situation was so strange and incomprehensible that for three or
+four hours, until the dawn came, we scarcely moved.  And then the light
+filtered in, not through the window, which remained black, but through
+a triangular aperture between a beam and a heap of broken bricks in
+the wall behind us.  The interior of the kitchen we now saw greyly for
+the first time.
+
+The window had been burst in by a mass of garden mould, which
+flowed over the table upon which we had been sitting and lay about our
+feet.  Outside, the soil was banked high against the house.  At the
+top of the window frame we could see an uprooted drainpipe.  The floor
+was littered with smashed hardware; the end of the kitchen towards the
+house was broken into, and since the daylight shone in there, it was
+evident the greater part of the house had collapsed.  Contrasting
+vividly with this ruin was the neat dresser, stained in the fashion,
+pale green, and with a number of copper and tin vessels below it, the
+wallpaper imitating blue and white tiles, and a couple of coloured
+supplements fluttering from the walls above the kitchen range.
+
+As the dawn grew clearer, we saw through the gap in the wall the
+body of a Martian, standing sentinel, I suppose, over the still
+glowing cylinder.  At the sight of that we crawled as circumspectly as
+possible out of the twilight of the kitchen into the darkness of the
+scullery.
+
+Abruptly the right interpretation dawned upon my mind.
+
+"The fifth cylinder," I whispered, "the fifth shot from Mars, has
+struck this house and buried us under the ruins!"
+
+For a time the curate was silent, and then he whispered:
+
+"God have mercy upon us!"
+
+I heard him presently whimpering to himself.
+
+Save for that sound we lay quite still in the scullery; I for my
+part scarce dared breathe, and sat with my eyes fixed on the faint
+light of the kitchen door.  I could just see the curate's face, a dim,
+oval shape, and his collar and cuffs.  Outside there began a metallic
+hammering, then a violent hooting, and then again, after a quiet
+interval, a hissing like the hissing of an engine.  These noises, for
+the most part problematical, continued intermittently, and seemed if
+anything to increase in number as time wore on.  Presently a measured
+thudding and a vibration that made everything about us quiver and the
+vessels in the pantry ring and shift, began and continued.  Once the
+light was eclipsed, and the ghostly kitchen doorway became absolutely
+dark.  For many hours we must have crouched there, silent and
+shivering, until our tired attention failed. . . .
+
+At last I found myself awake and very hungry.  I am inclined to
+believe we must have spent the greater portion of a day before that
+awakening.  My hunger was at a stride so insistent that it moved me to
+action.  I told the curate I was going to seek food, and felt my way
+towards the pantry.  He made me no answer, but so soon as I began
+eating the faint noise I made stirred him up and I heard him crawling
+after me.
+
+
+
+CHAPTER TWO
+
+WHAT WE SAW FROM THE RUINED HOUSE
+
+
+After eating we crept back to the scullery, and there I must have
+dozed again, for when presently I looked round I was alone.  The
+thudding vibration continued with wearisome persistence.  I whispered
+for the curate several times, and at last felt my way to the door of
+the kitchen.  It was still daylight, and I perceived him across the
+room, lying against the triangular hole that looked out upon the
+Martians.  His shoulders were hunched, so that his head was hidden
+from me.
+
+I could hear a number of noises almost like those in an engine
+shed; and the place rocked with that beating thud.  Through the
+aperture in the wall I could see the top of a tree touched with gold
+and the warm blue of a tranquil evening sky.  For a minute or so I
+remained watching the curate, and then I advanced, crouching and
+stepping with extreme care amid the broken crockery that littered the
+floor.
+
+I touched the curate's leg, and he started so violently that a mass
+of plaster went sliding down outside and fell with a loud impact.  I
+gripped his arm, fearing he might cry out, and for a long time we
+crouched motionless.  Then I turned to see how much of our rampart
+remained.  The detachment of the plaster had left a vertical slit open
+in the debris, and by raising myself cautiously across a beam I was
+able to see out of this gap into what had been overnight a quiet
+suburban roadway.  Vast, indeed, was the change that we beheld.
+
+The fifth cylinder must have fallen right into the midst of the
+house we had first visited.  The building had vanished, completely
+smashed, pulverised, and dispersed by the blow.  The cylinder lay now
+far beneath the original foundations--deep in a hole, already vastly
+larger than the pit I had looked into at Woking.  The earth all round
+it had splashed under that tremendous impact--"splashed" is the only
+word--and lay in heaped piles that hid the masses of the adjacent
+houses.  It had behaved exactly like mud under the violent blow of a
+hammer.  Our house had collapsed backward; the front portion, even on
+the ground floor, had been destroyed completely; by a chance the
+kitchen and scullery had escaped, and stood buried now under soil and
+ruins, closed in by tons of earth on every side save towards the
+cylinder.  Over that aspect we hung now on the very edge of the great
+circular pit the Martians were engaged in making.  The heavy beating
+sound was evidently just behind us, and ever and again a bright green
+vapour drove up like a veil across our peephole.
+
+The cylinder was already opened in the centre of the pit, and on
+the farther edge of the pit, amid the smashed and gravel-heaped
+shrubbery, one of the great fighting-machines, deserted by its
+occupant, stood stiff and tall against the evening sky.  At first I
+scarcely noticed the pit and the cylinder, although it has been
+convenient to describe them first, on account of the extraordinary
+glittering mechanism I saw busy in the excavation, and on account of
+the strange creatures that were crawling slowly and painfully across
+the heaped mould near it.
+
+The mechanism it certainly was that held my attention first.  It
+was one of those complicated fabrics that have since been called
+handling-machines, and the study of which has already given such an
+enormous impetus to terrestrial invention.  As it dawned upon me
+first, it presented a sort of metallic spider with five jointed,
+agile legs, and with an extraordinary number of jointed levers, bars,
+and reaching and clutching tentacles about its body.  Most of its
+arms were retracted, but with three long tentacles it was fishing
+out a number of rods, plates, and bars which lined the covering and
+apparently strengthened the walls of the cylinder.  These, as it
+extracted them, were lifted out and deposited upon a level surface
+of earth behind it.
+
+Its motion was so swift, complex, and perfect that at first I did
+not see it as a machine, in spite of its metallic glitter.  The
+fighting-machines were coordinated and animated to an extraordinary
+pitch, but nothing to compare with this.  People who have never seen
+these structures, and have only the ill-imagined efforts of artists or
+the imperfect descriptions of such eye-witnesses as myself to go upon,
+scarcely realise that living quality.
+
+I recall particularly the illustration of one of the first
+pamphlets to give a consecutive account of the war.  The artist had
+evidently made a hasty study of one of the fighting-machines, and
+there his knowledge ended.  He presented them as tilted, stiff
+tripods, without either flexibility or subtlety, and with an
+altogether misleading monotony of effect.  The pamphlet containing
+these renderings had a considerable vogue, and I mention them here
+simply to warn the reader against the impression they may have
+created.  They were no more like the Martians I saw in action than a
+Dutch doll is like a human being.  To my mind, the pamphlet would have
+been much better without them.
+
+At first, I say, the handling-machine did not impress me as a
+machine, but as a crablike creature with a glittering integument, the
+controlling Martian whose delicate tentacles actuated its movements
+seeming to be simply the equivalent of the crab's cerebral portion.
+But then I perceived the resemblance of its grey-brown, shiny,
+leathery integument to that of the other sprawling bodies beyond, and
+the true nature of this dexterous workman dawned upon me.  With that
+realisation my interest shifted to those other creatures, the real
+Martians.  Already I had had a transient impression of these, and the
+first nausea no longer obscured my observation.  Moreover, I was
+concealed and motionless, and under no urgency of action.
+
+They were, I now saw, the most unearthly creatures it is possible
+to conceive.  They were huge round bodies--or, rather, heads--about
+four feet in diameter, each body having in front of it a face.  This
+face had no nostrils--indeed, the Martians do not seem to have had any
+sense of smell, but it had a pair of very large dark-coloured eyes,
+and just beneath this a kind of fleshy beak.  In the back of this head
+or body--I scarcely know how to speak of it--was the single tight
+tympanic surface, since known to be anatomically an ear, though it
+must have been almost useless in our dense air.  In a group round the
+mouth were sixteen slender, almost whiplike tentacles, arranged in two
+bunches of eight each.  These bunches have since been named rather
+aptly, by that distinguished anatomist, Professor Howes, the _hands_.
+Even as I saw these Martians for the first time they seemed to be
+endeavouring to raise themselves on these hands, but of course, with
+the increased weight of terrestrial conditions, this was impossible.
+There is reason to suppose that on Mars they may have progressed upon
+them with some facility.
+
+The internal anatomy, I may remark here, as dissection has since
+shown, was almost equally simple.  The greater part of the structure
+was the brain, sending enormous nerves to the eyes, ear, and tactile
+tentacles.  Besides this were the bulky lungs, into which the mouth
+opened, and the heart and its vessels.  The pulmonary distress caused
+by the denser atmosphere and greater gravitational attraction was only
+too evident in the convulsive movements of the outer skin.
+
+And this was the sum of the Martian organs.  Strange as it may seem
+to a human being, all the complex apparatus of digestion, which makes
+up the bulk of our bodies, did not exist in the Martians.  They were
+heads--merely heads.  Entrails they had none.  They did not eat, much
+less digest.  Instead, they took the fresh, living blood of other
+creatures, and _injected_ it into their own veins.  I have myself seen
+this being done, as I shall mention in its place.  But, squeamish as I
+may seem, I cannot bring myself to describe what I could not endure
+even to continue watching.  Let it suffice to say, blood obtained from
+a still living animal, in most cases from a human being, was run
+directly by means of a little pipette into the recipient canal. . . .
+
+The bare idea of this is no doubt horribly repulsive to us, but at
+the same time I think that we should remember how repulsive our
+carnivorous habits would seem to an intelligent rabbit.
+
+The physiological advantages of the practice of injection are
+undeniable, if one thinks of the tremendous waste of human time and
+energy occasioned by eating and the digestive process.  Our bodies are
+half made up of glands and tubes and organs, occupied in turning
+heterogeneous food into blood.  The digestive processes and their
+reaction upon the nervous system sap our strength and colour our
+minds.  Men go happy or miserable as they have healthy or unhealthy
+livers, or sound gastric glands.  But the Martians were lifted above
+all these organic fluctuations of mood and emotion.
+
+Their undeniable preference for men as their source of nourishment
+is partly explained by the nature of the remains of the victims they
+had brought with them as provisions from Mars.  These creatures, to
+judge from the shrivelled remains that have fallen into human hands,
+were bipeds with flimsy, silicious skeletons (almost like those of the
+silicious sponges) and feeble musculature, standing about six feet
+high and having round, erect heads, and large eyes in flinty sockets.
+Two or three of these seem to have been brought in each cylinder, and
+all were killed before earth was reached.  It was just as well for
+them, for the mere attempt to stand upright upon our planet would have
+broken every bone in their bodies.
+
+And while I am engaged in this description, I may add in this place
+certain further details which, although they were not all evident to
+us at the time, will enable the reader who is unacquainted with them
+to form a clearer picture of these offensive creatures.
+
+In three other points their physiology differed strangely from
+ours.  Their organisms did not sleep, any more than the heart of man
+sleeps.  Since they had no extensive muscular mechanism to recuperate,
+that periodical extinction was unknown to them.  They had little or
+no sense of fatigue, it would seem.  On earth they could never have
+moved without effort, yet even to the last they kept in action.  In
+twenty-four hours they did twenty-four hours of work, as even on earth
+is perhaps the case with the ants.
+
+In the next place, wonderful as it seems in a sexual world, the
+Martians were absolutely without sex, and therefore without any of the
+tumultuous emotions that arise from that difference among men.  A
+young Martian, there can now be no dispute, was really born upon earth
+during the war, and it was found attached to its parent, partially
+_budded_ off, just as young lilybulbs bud off, or like the young animals
+in the fresh-water polyp.
+
+In man, in all the higher terrestrial animals, such a method of
+increase has disappeared; but even on this earth it was certainly the
+primitive method.  Among the lower animals, up even to those first
+cousins of the vertebrated animals, the Tunicates, the two processes
+occur side by side, but finally the sexual method superseded its
+competitor altogether.  On Mars, however, just the reverse has
+apparently been the case.
+
+It is worthy of remark that a certain speculative writer of
+quasi-scientific repute, writing long before the Martian invasion, did
+forecast for man a final structure not unlike the actual Martian
+condition.  His prophecy, I remember, appeared in November or
+December, 1893, in a long-defunct publication, the _Pall Mall Budget_,
+and I recall a caricature of it in a pre-Martian periodical called
+_Punch_.  He pointed out--writing in a foolish, facetious tone--that the
+perfection of mechanical appliances must ultimately supersede limbs;
+the perfection of chemical devices, digestion; that such organs as
+hair, external nose, teeth, ears, and chin were no longer essential
+parts of the human being, and that the tendency of natural selection
+would lie in the direction of their steady diminution through the
+coming ages.  The brain alone remained a cardinal necessity.  Only one
+other part of the body had a strong case for survival, and that was
+the hand, "teacher and agent of the brain."  While the rest of the
+body dwindled, the hands would grow larger.
+
+There is many a true word written in jest, and here in the Martians
+we have beyond dispute the actual accomplishment of such a suppression
+of the animal side of the organism by the intelligence.  To me it is
+quite credible that the Martians may be descended from beings not
+unlike ourselves, by a gradual development of brain and hands (the
+latter giving rise to the two bunches of delicate tentacles at last)
+at the expense of the rest of the body.  Without the body the brain
+would, of course, become a mere selfish intelligence, without any of
+the emotional substratum of the human being.
+
+The last salient point in which the systems of these creatures
+differed from ours was in what one might have thought a very trivial
+particular.  Micro-organisms, which cause so much disease and pain on
+earth, have either never appeared upon Mars or Martian sanitary
+science eliminated them ages ago.  A hundred diseases, all the fevers
+and contagions of human life, consumption, cancers, tumours and such
+morbidities, never enter the scheme of their life.  And speaking of
+the differences between the life on Mars and terrestrial life, I may
+allude here to the curious suggestions of the red weed.
+
+Apparently the vegetable kingdom in Mars, instead of having green
+for a dominant colour, is of a vivid blood-red tint.  At any rate, the
+seeds which the Martians (intentionally or accidentally) brought with
+them gave rise in all cases to red-coloured growths.  Only that known
+popularly as the red weed, however, gained any footing in competition
+with terrestrial forms.  The red creeper was quite a transitory
+growth, and few people have seen it growing.  For a time, however, the
+red weed grew with astonishing vigour and luxuriance.  It spread up
+the sides of the pit by the third or fourth day of our imprisonment,
+and its cactus-like branches formed a carmine fringe to the edges of
+our triangular window.  And afterwards I found it broadcast throughout
+the country, and especially wherever there was a stream of water.
+
+The Martians had what appears to have been an auditory organ, a
+single round drum at the back of the head-body, and eyes with a visual
+range not very different from ours except that, according to Philips,
+blue and violet were as black to them.  It is commonly supposed that
+they communicated by sounds and tentacular gesticulations; this is
+asserted, for instance, in the able but hastily compiled pamphlet
+(written evidently by someone not an eye-witness of Martian actions)
+to which I have already alluded, and which, so far, has been the chief
+source of information concerning them.  Now no surviving human being
+saw so much of the Martians in action as I did.  I take no credit to
+myself for an accident, but the fact is so.  And I assert that I
+watched them closely time after time, and that I have seen four, five,
+and (once) six of them sluggishly performing the most elaborately
+complicated operations together without either sound or gesture.  Their
+peculiar hooting invariably preceded feeding; it had no modulation,
+and was, I believe, in no sense a signal, but merely the expiration of
+air preparatory to the suctional operation.  I have a certain claim to
+at least an elementary knowledge of psychology, and in this matter I
+am convinced--as firmly as I am convinced of anything--that the
+Martians interchanged thoughts without any physical intermediation.
+And I have been convinced of this in spite of strong preconceptions.
+Before the Martian invasion, as an occasional reader here or there may
+remember, I had written with some little vehemence against the
+telepathic theory.
+
+The Martians wore no clothing.  Their conceptions of ornament and
+decorum were necessarily different from ours; and not only were they
+evidently much less sensible of changes of temperature than we are,
+but changes of pressure do not seem to have affected their health at
+all seriously.  Yet though they wore no clothing, it was in the other
+artificial additions to their bodily resources that their great
+superiority over man lay.  We men, with our bicycles and road-skates,
+our Lilienthal soaring-machines, our guns and sticks and so forth, are
+just in the beginning of the evolution that the Martians have worked
+out.  They have become practically mere brains, wearing different
+bodies according to their needs just as men wear suits of clothes and
+take a bicycle in a hurry or an umbrella in the wet.  And of their
+appliances, perhaps nothing is more wonderful to a man than the
+curious fact that what is the dominant feature of almost all human
+devices in mechanism is absent--the _wheel_ is absent; among all the
+things they brought to earth there is no trace or suggestion of their
+use of wheels.  One would have at least expected it in locomotion.  And
+in this connection it is curious to remark that even on this earth
+Nature has never hit upon the wheel, or has preferred other expedients
+to its development.  And not only did the Martians either not know of
+(which is incredible), or abstain from, the wheel, but in their
+apparatus singularly little use is made of the fixed pivot or
+relatively fixed pivot, with circular motions thereabout confined
+to one plane.  Almost all the joints of the machinery present a
+complicated system of sliding parts moving over small but beautifully
+curved friction bearings.  And while upon this matter of detail, it is
+remarkable that the long leverages of their machines are in most cases
+actuated by a sort of sham musculature of the disks in an elastic
+sheath; these disks become polarised and drawn closely and powerfully
+together when traversed by a current of electricity.  In this way the
+curious parallelism to animal motions, which was so striking and
+disturbing to the human beholder, was attained.  Such quasi-muscles
+abounded in the crablike handling-machine which, on my first peeping
+out of the slit, I watched unpacking the cylinder.  It seemed
+infinitely more alive than the actual Martians lying beyond it in the
+sunset light, panting, stirring ineffectual tentacles, and moving
+feebly after their vast journey across space.
+
+While I was still watching their sluggish motions in the sunlight,
+and noting each strange detail of their form, the curate reminded me
+of his presence by pulling violently at my arm.  I turned to a
+scowling face, and silent, eloquent lips.  He wanted the slit, which
+permitted only one of us to peep through; and so I had to forego
+watching them for a time while he enjoyed that privilege.
+
+When I looked again, the busy handling-machine had already put
+together several of the pieces of apparatus it had taken out of the
+cylinder into a shape having an unmistakable likeness to its own; and
+down on the left a busy little digging mechanism had come into view,
+emitting jets of green vapour and working its way round the pit,
+excavating and embanking in a methodical and discriminating manner.
+This it was which had caused the regular beating noise, and the
+rhythmic shocks that had kept our ruinous refuge quivering.  It piped
+and whistled as it worked.  So far as I could see, the thing was
+without a directing Martian at all.
+
+
+
+CHAPTER THREE
+
+THE DAYS OF IMPRISONMENT
+
+
+The arrival of a second fighting-machine drove us from our peephole
+into the scullery, for we feared that from his elevation the Martian
+might see down upon us behind our barrier.  At a later date we began
+to feel less in danger of their eyes, for to an eye in the dazzle of
+the sunlight outside our refuge must have been blank blackness, but at
+first the slightest suggestion of approach drove us into the scullery
+in heart-throbbing retreat.  Yet terrible as was the danger we
+incurred, the attraction of peeping was for both of us irresistible.
+And I recall now with a sort of wonder that, in spite of the infinite
+danger in which we were between starvation and a still more terrible
+death, we could yet struggle bitterly for that horrible privilege of
+sight.  We would race across the kitchen in a grotesque way between
+eagerness and the dread of making a noise, and strike each other, and
+thrust and kick, within a few inches of exposure.
+
+The fact is that we had absolutely incompatible dispositions and
+habits of thought and action, and our danger and isolation only
+accentuated the incompatibility.  At Halliford I had already come to
+hate the curate's trick of helpless exclamation, his stupid rigidity
+of mind.  His endless muttering monologue vitiated every effort I made
+to think out a line of action, and drove me at times, thus pent up and
+intensified, almost to the verge of craziness.  He was as lacking in
+restraint as a silly woman.  He would weep for hours together, and I
+verily believe that to the very end this spoiled child of life thought
+his weak tears in some way efficacious.  And I would sit in the
+darkness unable to keep my mind off him by reason of his
+importunities.  He ate more than I did, and it was in vain I pointed
+out that our only chance of life was to stop in the house until the
+Martians had done with their pit, that in that long patience a time
+might presently come when we should need food.  He ate and drank
+impulsively in heavy meals at long intervals.  He slept little.
+
+As the days wore on, his utter carelessness of any consideration so
+intensified our distress and danger that I had, much as I loathed
+doing it, to resort to threats, and at last to blows.  That brought him
+to reason for a time.  But he was one of those weak creatures, void of
+pride, timorous, anaemic, hateful souls, full of shifty cunning, who
+face neither God nor man, who face not even themselves.
+
+It is disagreeable for me to recall and write these things, but I
+set them down that my story may lack nothing.  Those who have escaped
+the dark and terrible aspects of life will find my brutality, my flash
+of rage in our final tragedy, easy enough to blame; for they know what
+is wrong as well as any, but not what is possible to tortured men.  But
+those who have been under the shadow, who have gone down at last to
+elemental things, will have a wider charity.
+
+And while within we fought out our dark, dim contest of whispers,
+snatched food and drink, and gripping hands and blows, without, in the
+pitiless sunlight of that terrible June, was the strange wonder, the
+unfamiliar routine of the Martians in the pit.  Let me return to those
+first new experiences of mine.  After a long time I ventured back to
+the peephole, to find that the new-comers had been reinforced by the
+occupants of no fewer than three of the fighting-machines.  These last
+had brought with them certain fresh appliances that stood in an
+orderly manner about the cylinder.  The second handling-machine was now
+completed, and was busied in serving one of the novel contrivances the
+big machine had brought.  This was a body resembling a milk can in its
+general form, above which oscillated a pear-shaped receptacle, and
+from which a stream of white powder flowed into a circular basin
+below.
+
+The oscillatory motion was imparted to this by one tentacle of the
+handling-machine.  With two spatulate hands the handling-machine was
+digging out and flinging masses of clay into the pear-shaped
+receptacle above, while with another arm it periodically opened a door
+and removed rusty and blackened clinkers from the middle part of the
+machine.  Another steely tentacle directed the powder from the basin
+along a ribbed channel towards some receiver that was hidden from me
+by the mound of bluish dust.  From this unseen receiver a little
+thread of green smoke rose vertically into the quiet air.  As I looked,
+the handling-machine, with a faint and musical clinking, extended,
+telescopic fashion, a tentacle that had been a moment before a mere
+blunt projection, until its end was hidden behind the mound of clay.
+In another second it had lifted a bar of white aluminium into sight,
+untarnished as yet, and shining dazzlingly, and deposited it in a
+growing stack of bars that stood at the side of the pit.  Between
+sunset and starlight this dexterous machine must have made more than a
+hundred such bars out of the crude clay, and the mound of bluish dust
+rose steadily until it topped the side of the pit.
+
+The contrast between the swift and complex movements of these
+contrivances and the inert panting clumsiness of their masters was
+acute, and for days I had to tell myself repeatedly that these latter
+were indeed the living of the two things.
+
+The curate had possession of the slit when the first men were
+brought to the pit.  I was sitting below, huddled up, listening with
+all my ears.  He made a sudden movement backward, and I, fearful that
+we were observed, crouched in a spasm of terror.  He came sliding down
+the rubbish and crept beside me in the darkness, inarticulate,
+gesticulating, and for a moment I shared his panic.  His gesture
+suggested a resignation of the slit, and after a little while my
+curiosity gave me courage, and I rose up, stepped across him, and
+clambered up to it.  At first I could see no reason for his frantic
+behaviour.  The twilight had now come, the stars were little and
+faint, but the pit was illuminated by the flickering green fire that
+came from the aluminium-making.  The whole picture was a flickering
+scheme of green gleams and shifting rusty black shadows, strangely
+trying to the eyes.  Over and through it all went the bats, heeding it
+not at all.  The sprawling Martians were no longer to be seen, the
+mound of blue-green powder had risen to cover them from sight, and a
+fighting-machine, with its legs contracted, crumpled, and abbreviated,
+stood across the corner of the pit.  And then, amid the clangour of
+the machinery, came a drifting suspicion of human voices, that I
+entertained at first only to dismiss.
+
+I crouched, watching this fighting-machine closely, satisfying
+myself now for the first time that the hood did indeed contain a
+Martian.  As the green flames lifted I could see the oily gleam of
+his integument and the brightness of his eyes.  And suddenly I heard
+a yell, and saw a long tentacle reaching over the shoulder of the
+machine to the little cage that hunched upon its back.  Then
+something--something struggling violently--was lifted high against the
+sky, a black, vague enigma against the starlight; and as this black
+object came down again, I saw by the green brightness that it was a
+man.  For an instant he was clearly visible.  He was a stout, ruddy,
+middle-aged man, well dressed; three days before, he must have been
+walking the world, a man of considerable consequence.  I could see his
+staring eyes and gleams of light on his studs and watch chain.  He
+vanished behind the mound, and for a moment there was silence.  And
+then began a shrieking and a sustained and cheerful hooting from the
+Martians.
+
+I slid down the rubbish, struggled to my feet, clapped my hands
+over my ears, and bolted into the scullery.  The curate, who had been
+crouching silently with his arms over his head, looked up as I passed,
+cried out quite loudly at my desertion of him, and came running after
+me.
+
+That night, as we lurked in the scullery, balanced between our
+horror and the terrible fascination this peeping had, although I felt
+an urgent need of action I tried in vain to conceive some plan of
+escape; but afterwards, during the second day, I was able to consider
+our position with great clearness.  The curate, I found, was quite
+incapable of discussion; this new and culminating atrocity had robbed
+him of all vestiges of reason or forethought.  Practically he had
+already sunk to the level of an animal.  But as the saying goes, I
+gripped myself with both hands.  It grew upon my mind, once I could
+face the facts, that terrible as our position was, there was as yet
+no justification for absolute despair.  Our chief chance lay in the
+possibility of the Martians making the pit nothing more than a
+temporary encampment.  Or even if they kept it permanently, they might
+not consider it necessary to guard it, and a chance of escape might be
+afforded us.  I also weighed very carefully the possibility of our
+digging a way out in a direction away from the pit, but the chances of
+our emerging within sight of some sentinel fighting-machine seemed at
+first too great.  And I should have had to do all the digging myself.
+The curate would certainly have failed me.
+
+It was on the third day, if my memory serves me right, that I saw
+the lad killed.  It was the only occasion on which I actually saw the
+Martians feed.  After that experience I avoided the hole in the wall
+for the better part of a day.  I went into the scullery, removed the
+door, and spent some hours digging with my hatchet as silently as
+possible; but when I had made a hole about a couple of feet deep the
+loose earth collapsed noisily, and I did not dare continue.  I lost
+heart, and lay down on the scullery floor for a long time, having no
+spirit even to move.  And after that I abandoned altogether the idea
+of escaping by excavation.
+
+It says much for the impression the Martians had made upon me that
+at first I entertained little or no hope of our escape being brought
+about by their overthrow through any human effort.  But on the fourth
+or fifth night I heard a sound like heavy guns.
+
+It was very late in the night, and the moon was shining brightly.
+The Martians had taken away the excavating-machine, and, save for a
+fighting-machine that stood in the remoter bank of the pit and a
+handling-machine that was buried out of my sight in a corner of the
+pit immediately beneath my peephole, the place was deserted by them.
+Except for the pale glow from the handling-machine and the bars and
+patches of white moonlight the pit was in darkness, and, except for
+the clinking of the handling-machine, quite still.  That night was a
+beautiful serenity; save for one planet, the moon seemed to have the
+sky to herself.  I heard a dog howling, and that familiar sound it was
+that made me listen.  Then I heard quite distinctly a booming exactly
+like the sound of great guns.  Six distinct reports I counted, and
+after a long interval six again.  And that was all.
+
+
+
+CHAPTER FOUR
+
+THE DEATH OF THE CURATE
+
+
+It was on the sixth day of our imprisonment that I peeped for the
+last time, and presently found myself alone.  Instead of keeping close
+to me and trying to oust me from the slit, the curate had gone back
+into the scullery.  I was struck by a sudden thought.  I went back
+quickly and quietly into the scullery.  In the darkness I heard the
+curate drinking.  I snatched in the darkness, and my fingers caught a
+bottle of burgundy.
+
+For a few minutes there was a tussle.  The bottle struck the floor
+and broke, and I desisted and rose.  We stood panting and threatening
+each other.  In the end I planted myself between him and the food, and
+told him of my determination to begin a discipline.  I divided the
+food in the pantry, into rations to last us ten days.  I would not let
+him eat any more that day.  In the afternoon he made a feeble effort
+to get at the food.  I had been dozing, but in an instant I was awake.
+All day and all night we sat face to face, I weary but resolute, and
+he weeping and complaining of his immediate hunger.  It was, I know, a
+night and a day, but to me it seemed--it seems now--an interminable
+length of time.
+
+And so our widened incompatibility ended at last in open conflict.
+For two vast days we struggled in undertones and wrestling contests.
+There were times when I beat and kicked him madly, times when I
+cajoled and persuaded him, and once I tried to bribe him with the last
+bottle of burgundy, for there was a rain-water pump from which I could
+get water.  But neither force nor kindness availed; he was indeed
+beyond reason.  He would neither desist from his attacks on the food
+nor from his noisy babbling to himself.  The rudimentary precautions
+to keep our imprisonment endurable he would not observe.  Slowly I
+began to realise the complete overthrow of his intelligence, to
+perceive that my sole companion in this close and sickly darkness was
+a man insane.
+
+From certain vague memories I am inclined to think my own mind
+wandered at times.  I had strange and hideous dreams whenever I slept.
+It sounds paradoxical, but I am inclined to think that the weakness
+and insanity of the curate warned me, braced me, and kept me a sane
+man.
+
+On the eighth day he began to talk aloud instead of whispering, and
+nothing I could do would moderate his speech.
+
+"It is just, O God!" he would say, over and over again. "It is
+just.  On me and mine be the punishment laid.  We have sinned, we have
+fallen short.  There was poverty, sorrow; the poor were trodden in
+the dust, and I held my peace.  I preached acceptable folly--my God,
+what folly!--when I should have stood up, though I died for it, and
+called upon them to repent--repent! . . .  Oppressors of the poor and
+needy . . . !  The wine press of God!"
+
+Then he would suddenly revert to the matter of the food I withheld
+from him, praying, begging, weeping, at last threatening.  He began to
+raise his voice--I prayed him not to.  He perceived a hold on me--he
+threatened he would shout and bring the Martians upon us.  For a time
+that scared me; but any concession would have shortened our chance of
+escape beyond estimating.  I defied him, although I felt no assurance
+that he might not do this thing.  But that day, at any rate, he did
+not.  He talked with his voice rising slowly, through the greater part
+of the eighth and ninth days--threats, entreaties, mingled with a
+torrent of half-sane and always frothy repentance for his vacant sham
+of God's service, such as made me pity him.  Then he slept awhile, and
+began again with renewed strength, so loudly that I must needs make
+him desist.
+
+"Be still!" I implored.
+
+He rose to his knees, for he had been sitting in the darkness near
+the copper.
+
+"I have been still too long," he said, in a tone that must have
+reached the pit, "and now I must bear my witness.  Woe unto this
+unfaithful city!  Woe!  Woe!  Woe!  Woe!  Woe! To the inhabitants of
+the earth by reason of the other voices of the trumpet----"
+
+"Shut up!" I said, rising to my feet, and in a terror lest the
+Martians should hear us.  "For God's sake----"
+
+"Nay," shouted the curate, at the top of his voice, standing
+likewise and extending his arms.  "Speak!  The word of the Lord is
+upon me!"
+
+In three strides he was at the door leading into the kitchen.
+
+"I must bear my witness!  I go!  It has already been too long
+delayed."
+
+I put out my hand and felt the meat chopper hanging to the wall.
+In a flash I was after him.  I was fierce with fear.  Before he was
+halfway across the kitchen I had overtaken him.  With one last touch
+of humanity I turned the blade back and struck him with the butt.  He
+went headlong forward and lay stretched on the ground.  I stumbled
+over him and stood panting.  He lay still.
+
+Suddenly I heard a noise without, the run and smash of slipping
+plaster, and the triangular aperture in the wall was darkened.  I
+looked up and saw the lower surface of a handling-machine coming
+slowly across the hole.  One of its gripping limbs curled amid the
+debris; another limb appeared, feeling its way over the fallen beams.
+I stood petrified, staring.  Then I saw through a sort of glass plate
+near the edge of the body the face, as we may call it, and the large
+dark eyes of a Martian, peering, and then a long metallic snake of
+tentacle came feeling slowly through the hole.
+
+I turned by an effort, stumbled over the curate, and stopped at the
+scullery door.  The tentacle was now some way, two yards or more, in
+the room, and twisting and turning, with queer sudden movements, this
+way and that.  For a while I stood fascinated by that slow, fitful
+advance.  Then, with a faint, hoarse cry, I forced myself across the
+scullery.  I trembled violently; I could scarcely stand upright.  I
+opened the door of the coal cellar, and stood there in the darkness
+staring at the faintly lit doorway into the kitchen, and listening.
+Had the Martian seen me?  What was it doing now?
+
+Something was moving to and fro there, very quietly; every now and
+then it tapped against the wall, or started on its movements with a
+faint metallic ringing, like the movements of keys on a split-ring.
+Then a heavy body--I knew too well what--was dragged across the floor
+of the kitchen towards the opening.  Irresistibly attracted, I crept
+to the door and peeped into the kitchen.  In the triangle of bright
+outer sunlight I saw the Martian, in its Briareus of a handling-machine,
+scrutinizing the curate's head.  I thought at once that it would infer
+my presence from the mark of the blow I had given him.
+
+I crept back to the coal cellar, shut the door, and began to cover
+myself up as much as I could, and as noiselessly as possible in the
+darkness, among the firewood and coal therein.  Every now and then I
+paused, rigid, to hear if the Martian had thrust its tentacles through
+the opening again.
+
+Then the faint metallic jingle returned.  I traced it slowly
+feeling over the kitchen.  Presently I heard it nearer--in the
+scullery, as I judged.  I thought that its length might be
+insufficient to reach me.  I prayed copiously.  It passed, scraping
+faintly across the cellar door.  An age of almost intolerable suspense
+intervened; then I heard it fumbling at the latch! It had found the
+door!  The Martians understood doors!
+
+It worried at the catch for a minute, perhaps, and then the door
+opened.
+
+In the darkness I could just see the thing--like an elephant's
+trunk more than anything else--waving towards me and touching and
+examining the wall, coals, wood and ceiling.  It was like a black worm
+swaying its blind head to and fro.
+
+Once, even, it touched the heel of my boot.  I was on the verge of
+screaming; I bit my hand.  For a time the tentacle was silent.  I
+could have fancied it had been withdrawn.  Presently, with an abrupt
+click, it gripped something--I thought it had me!--and seemed to go
+out of the cellar again.  For a minute I was not sure.  Apparently it
+had taken a lump of coal to examine.
+
+I seized the opportunity of slightly shifting my position, which
+had become cramped, and then listened.  I whispered passionate prayers
+for safety.
+
+Then I heard the slow, deliberate sound creeping towards me again.
+Slowly, slowly it drew near, scratching against the walls and tapping
+the furniture.
+
+While I was still doubtful, it rapped smartly against the cellar
+door and closed it.  I heard it go into the pantry, and the biscuit-tins
+rattled and a bottle smashed, and then came a heavy bump against
+the cellar door.  Then silence that passed into an infinity of
+suspense.
+
+Had it gone?
+
+At last I decided that it had.
+
+It came into the scullery no more; but I lay all the tenth day in
+the close darkness, buried among coals and firewood, not daring even
+to crawl out for the drink for which I craved.  It was the eleventh day
+before I ventured so far from my security.
+
+
+
+CHAPTER FIVE
+
+THE STILLNESS
+
+
+My first act before I went into the pantry was to fasten the door
+between the kitchen and the scullery.  But the pantry was empty; every
+scrap of food had gone.  Apparently, the Martian had taken it all on
+the previous day.  At that discovery I despaired for the first time.  I
+took no food, or no drink either, on the eleventh or the twelfth day.
+
+At first my mouth and throat were parched, and my strength ebbed
+sensibly.  I sat about in the darkness of the scullery, in a state of
+despondent wretchedness.  My mind ran on eating.  I thought I had
+become deaf, for the noises of movement I had been accustomed to hear
+from the pit had ceased absolutely.  I did not feel strong enough to
+crawl noiselessly to the peephole, or I would have gone there.
+
+On the twelfth day my throat was so painful that, taking the chance
+of alarming the Martians, I attacked the creaking rain-water pump that
+stood by the sink, and got a couple of glassfuls of blackened and
+tainted rain water.  I was greatly refreshed by this, and emboldened
+by the fact that no enquiring tentacle followed the noise of my
+pumping.
+
+During these days, in a rambling, inconclusive way, I thought much
+of the curate and of the manner of his death.
+
+On the thirteenth day I drank some more water, and dozed and
+thought disjointedly of eating and of vague impossible plans of
+escape.  Whenever I dozed I dreamt of horrible phantasms, of the death
+of the curate, or of sumptuous dinners; but, asleep or awake, I felt a
+keen pain that urged me to drink again and again.  The light that came
+into the scullery was no longer grey, but red.  To my disordered
+imagination it seemed the colour of blood.
+
+On the fourteenth day I went into the kitchen, and I was surprised
+to find that the fronds of the red weed had grown right across
+the hole in the wall, turning the half-light of the place into a
+crimson-coloured obscurity.
+
+It was early on the fifteenth day that I heard a curious, familiar
+sequence of sounds in the kitchen, and, listening, identified it as
+the snuffing and scratching of a dog.  Going into the kitchen, I saw a
+dog's nose peering in through a break among the ruddy fronds.  This
+greatly surprised me.  At the scent of me he barked shortly.
+
+I thought if I could induce him to come into the place quietly I
+should be able, perhaps, to kill and eat him; and in any case, it
+would be advisable to kill him, lest his actions attracted the
+attention of the Martians.
+
+I crept forward, saying "Good dog!" very softly; but he suddenly
+withdrew his head and disappeared.
+
+I listened--I was not deaf--but certainly the pit was still.  I
+heard a sound like the flutter of a bird's wings, and a hoarse
+croaking, but that was all.
+
+For a long while I lay close to the peephole, but not daring to
+move aside the red plants that obscured it.  Once or twice I heard a
+faint pitter-patter like the feet of the dog going hither and thither
+on the sand far below me, and there were more birdlike sounds, but
+that was all.  At length, encouraged by the silence, I looked out.
+
+Except in the corner, where a multitude of crows hopped and fought
+over the skeletons of the dead the Martians had consumed, there was
+not a living thing in the pit.
+
+I stared about me, scarcely believing my eyes.  All the machinery
+had gone.  Save for the big mound of greyish-blue powder in one
+corner, certain bars of aluminium in another, the black birds, and the
+skeletons of the killed, the place was merely an empty circular pit in
+the sand.
+
+Slowly I thrust myself out through the red weed, and stood upon the
+mound of rubble.  I could see in any direction save behind me, to the
+north, and neither Martians nor sign of Martians were to be seen.  The
+pit dropped sheerly from my feet, but a little way along the rubbish
+afforded a practicable slope to the summit of the ruins.  My chance of
+escape had come.  I began to tremble.
+
+I hesitated for some time, and then, in a gust of desperate
+resolution, and with a heart that throbbed violently, I scrambled to
+the top of the mound in which I had been buried so long.
+
+I looked about again.  To the northward, too, no Martian was
+visible.
+
+When I had last seen this part of Sheen in the daylight it had been
+a straggling street of comfortable white and red houses, interspersed
+with abundant shady trees.  Now I stood on a mound of smashed
+brickwork, clay, and gravel, over which spread a multitude of red
+cactus-shaped plants, knee-high, without a solitary terrestrial growth
+to dispute their footing.  The trees near me were dead and brown, but
+further a network of red thread scaled the still living stems.
+
+The neighbouring houses had all been wrecked, but none had been
+burned; their walls stood, sometimes to the second story, with smashed
+windows and shattered doors.  The red weed grew tumultuously in their
+roofless rooms.  Below me was the great pit, with the crows struggling
+for its refuse.  A number of other birds hopped about among the ruins.
+Far away I saw a gaunt cat slink crouchingly along a wall, but traces
+of men there were none.
+
+The day seemed, by contrast with my recent confinement, dazzlingly
+bright, the sky a glowing blue.  A gentle breeze kept the red weed
+that covered every scrap of unoccupied ground gently swaying.  And oh!
+the sweetness of the air!
+
+
+
+CHAPTER SIX
+
+THE WORK OF FIFTEEN DAYS
+
+
+For some time I stood tottering on the mound regardless of my
+safety.  Within that noisome den from which I had emerged I had
+thought with a narrow intensity only of our immediate security.  I had
+not realised what had been happening to the world, had not anticipated
+this startling vision of unfamiliar things.  I had expected to see
+Sheen in ruins--I found about me the landscape, weird and lurid, of
+another planet.
+
+For that moment I touched an emotion beyond the common range of
+men, yet one that the poor brutes we dominate know only too well.  I
+felt as a rabbit might feel returning to his burrow and suddenly
+confronted by the work of a dozen busy navvies digging the foundations
+of a house.  I felt the first inkling of a thing that presently grew
+quite clear in my mind, that oppressed me for many days, a sense of
+dethronement, a persuasion that I was no longer a master, but an
+animal among the animals, under the Martian heel.  With us it would be
+as with them, to lurk and watch, to run and hide; the fear and empire
+of man had passed away.
+
+But so soon as this strangeness had been realised it passed, and my
+dominant motive became the hunger of my long and dismal fast.  In the
+direction away from the pit I saw, beyond a red-covered wall, a patch
+of garden ground unburied.  This gave me a hint, and I went knee-deep,
+and sometimes neck-deep, in the red weed.  The density of the
+weed gave me a reassuring sense of hiding.  The wall was some six feet
+high, and when I attempted to clamber it I found I could not lift my
+feet to the crest.  So I went along by the side of it, and came to a
+corner and a rockwork that enabled me to get to the top, and tumble
+into the garden I coveted.  Here I found some young onions, a couple
+of gladiolus bulbs, and a quantity of immature carrots, all of which I
+secured, and, scrambling over a ruined wall, went on my way through
+scarlet and crimson trees towards Kew--it was like walking through an
+avenue of gigantic blood drops--possessed with two ideas: to get more
+food, and to limp, as soon and as far as my strength permitted, out of
+this accursed unearthly region of the pit.
+
+Some way farther, in a grassy place, was a group of mushrooms which
+also I devoured, and then I came upon a brown sheet of flowing shallow
+water, where meadows used to be.  These fragments of nourishment served
+only to whet my hunger.  At first I was surprised at this flood in a
+hot, dry summer, but afterwards I discovered that it was caused by the
+tropical exuberance of the red weed.  Directly this extraordinary
+growth encountered water it straightway became gigantic and of
+unparalleled fecundity.  Its seeds were simply poured down into the
+water of the Wey and Thames, and its swiftly growing and Titanic water
+fronds speedily choked both those rivers.
+
+At Putney, as I afterwards saw, the bridge was almost lost in a
+tangle of this weed, and at Richmond, too, the Thames water poured in
+a broad and shallow stream across the meadows of Hampton and
+Twickenham.  As the water spread the weed followed them, until the
+ruined villas of the Thames valley were for a time lost in this red
+swamp, whose margin I explored, and much of the desolation the
+Martians had caused was concealed.
+
+In the end the red weed succumbed almost as quickly as it had
+spread.  A cankering disease, due, it is believed, to the action of
+certain bacteria, presently seized upon it.  Now by the action of
+natural selection, all terrestrial plants have acquired a resisting
+power against bacterial diseases--they never succumb without a severe
+struggle, but the red weed rotted like a thing already dead.  The
+fronds became bleached, and then shrivelled and brittle.  They broke
+off at the least touch, and the waters that had stimulated their early
+growth carried their last vestiges out to sea.
+
+My first act on coming to this water was, of course, to slake my
+thirst.  I drank a great deal of it and, moved by an impulse, gnawed
+some fronds of red weed; but they were watery, and had a sickly,
+metallic taste.  I found the water was sufficiently shallow for me to
+wade securely, although the red weed impeded my feet a little; but the
+flood evidently got deeper towards the river, and I turned back to
+Mortlake.  I managed to make out the road by means of occasional ruins
+of its villas and fences and lamps, and so presently I got out of this
+spate and made my way to the hill going up towards Roehampton and came
+out on Putney Common.
+
+Here the scenery changed from the strange and unfamiliar to the
+wreckage of the familiar: patches of ground exhibited the devastation
+of a cyclone, and in a few score yards I would come upon perfectly
+undisturbed spaces, houses with their blinds trimly drawn and doors
+closed, as if they had been left for a day by the owners, or as if
+their inhabitants slept within.  The red weed was less abundant; the
+tall trees along the lane were free from the red creeper.  I hunted
+for food among the trees, finding nothing, and I also raided a couple
+of silent houses, but they had already been broken into and ransacked.
+I rested for the remainder of the daylight in a shrubbery, being, in
+my enfeebled condition, too fatigued to push on.
+
+All this time I saw no human beings, and no signs of the Martians.
+I encountered a couple of hungry-looking dogs, but both hurried
+circuitously away from the advances I made them.  Near Roehampton I
+had seen two human skeletons--not bodies, but skeletons, picked
+clean--and in the wood by me I found the crushed and scattered bones
+of several cats and rabbits and the skull of a sheep.  But though I
+gnawed parts of these in my mouth, there was nothing to be got from
+them.
+
+After sunset I struggled on along the road towards Putney, where I
+think the Heat-Ray must have been used for some reason.  And in the
+garden beyond Roehampton I got a quantity of immature potatoes,
+sufficient to stay my hunger.  From this garden one looked down upon
+Putney and the river.  The aspect of the place in the dusk was
+singularly desolate: blackened trees, blackened, desolate ruins, and
+down the hill the sheets of the flooded river, red-tinged with the
+weed.  And over all--silence.  It filled me with indescribable terror
+to think how swiftly that desolating change had come.
+
+For a time I believed that mankind had been swept out of existence,
+and that I stood there alone, the last man left alive.  Hard by the
+top of Putney Hill I came upon another skeleton, with the arms
+dislocated and removed several yards from the rest of the body.  As I
+proceeded I became more and more convinced that the extermination of
+mankind was, save for such stragglers as myself, already accomplished
+in this part of the world.  The Martians, I thought, had gone on and
+left the country desolated, seeking food elsewhere.  Perhaps even now
+they were destroying Berlin or Paris, or it might be they had gone
+northward.
+
+
+
+CHAPTER SEVEN
+
+THE MAN ON PUTNEY HILL
+
+
+I spent that night in the inn that stands at the top of Putney
+Hill, sleeping in a made bed for the first time since my flight to
+Leatherhead.  I will not tell the needless trouble I had breaking into
+that house--afterwards I found the front door was on the latch--nor
+how I ransacked every room for food, until just on the verge of
+despair, in what seemed to me to be a servant's bedroom, I found a
+rat-gnawed crust and two tins of pineapple.  The place had been
+already searched and emptied.  In the bar I afterwards found some
+biscuits and sandwiches that had been overlooked.  The latter I could
+not eat, they were too rotten, but the former not only stayed my
+hunger, but filled my pockets.  I lit no lamps, fearing some Martian
+might come beating that part of London for food in the night.  Before
+I went to bed I had an interval of restlessness, and prowled from
+window to window, peering out for some sign of these monsters.  I
+slept little.  As I lay in bed I found myself thinking consecutively--a
+thing I do not remember to have done since my last argument with the
+curate.  During all the intervening time my mental condition had been
+a hurrying succession of vague emotional states or a sort of stupid
+receptivity.  But in the night my brain, reinforced, I suppose, by the
+food I had eaten, grew clear again, and I thought.
+
+Three things struggled for possession of my mind: the killing of
+the curate, the whereabouts of the Martians, and the possible fate of
+my wife.  The former gave me no sensation of horror or remorse to
+recall; I saw it simply as a thing done, a memory infinitely
+disagreeable but quite without the quality of remorse.  I saw myself
+then as I see myself now, driven step by step towards that hasty blow,
+the creature of a sequence of accidents leading inevitably to that.  I
+felt no condemnation; yet the memory, static, unprogressive, haunted
+me.  In the silence of the night, with that sense of the nearness of
+God that sometimes comes into the stillness and the darkness, I stood
+my trial, my only trial, for that moment of wrath and fear.  I
+retraced every step of our conversation from the moment when I had
+found him crouching beside me, heedless of my thirst, and pointing to
+the fire and smoke that streamed up from the ruins of Weybridge.  We
+had been incapable of co-operation--grim chance had taken no heed of
+that.  Had I foreseen, I should have left him at Halliford.  But I did
+not foresee; and crime is to foresee and do.  And I set this down as I
+have set all this story down, as it was.  There were no witnesses--all
+these things I might have concealed.  But I set it down, and the
+reader must form his judgment as he will.
+
+And when, by an effort, I had set aside that picture of a prostrate
+body, I faced the problem of the Martians and the fate of my wife.  For
+the former I had no data; I could imagine a hundred things, and so,
+unhappily, I could for the latter.  And suddenly that night became
+terrible.  I found myself sitting up in bed, staring at the dark.  I
+found myself praying that the Heat-Ray might have suddenly and
+painlessly struck her out of being.  Since the night of my return from
+Leatherhead I had not prayed.  I had uttered prayers, fetish prayers,
+had prayed as heathens mutter charms when I was in extremity; but now
+I prayed indeed, pleading steadfastly and sanely, face to face with
+the darkness of God.  Strange night!  Strangest in this, that so soon
+as dawn had come, I, who had talked with God, crept out of the house
+like a rat leaving its hiding place--a creature scarcely larger, an
+inferior animal, a thing that for any passing whim of our masters
+might be hunted and killed.  Perhaps they also prayed confidently to
+God.  Surely, if we have learned nothing else, this war has taught us
+pity--pity for those witless souls that suffer our dominion.
+
+The morning was bright and fine, and the eastern sky glowed pink,
+and was fretted with little golden clouds.  In the road that runs from
+the top of Putney Hill to Wimbledon was a number of poor vestiges of
+the panic torrent that must have poured Londonward on the Sunday night
+after the fighting began.  There was a little two-wheeled cart
+inscribed with the name of Thomas Lobb, Greengrocer, New Malden, with
+a smashed wheel and an abandoned tin trunk; there was a straw hat
+trampled into the now hardened mud, and at the top of West Hill a lot
+of blood-stained glass about the overturned water trough.  My
+movements were languid, my plans of the vaguest.  I had an idea of
+going to Leatherhead, though I knew that there I had the poorest
+chance of finding my wife.  Certainly, unless death had overtaken them
+suddenly, my cousins and she would have fled thence; but it seemed to
+me I might find or learn there whither the Surrey people had fled.  I
+knew I wanted to find my wife, that my heart ached for her and the
+world of men, but I had no clear idea how the finding might be done.  I
+was also sharply aware now of my intense loneliness.  From the corner
+I went, under cover of a thicket of trees and bushes, to the edge of
+Wimbledon Common, stretching wide and far.
+
+That dark expanse was lit in patches by yellow gorse and broom;
+there was no red weed to be seen, and as I prowled, hesitating, on the
+verge of the open, the sun rose, flooding it all with light and
+vitality.  I came upon a busy swarm of little frogs in a swampy place
+among the trees.  I stopped to look at them, drawing a lesson from
+their stout resolve to live.  And presently, turning suddenly, with an
+odd feeling of being watched, I beheld something crouching amid a
+clump of bushes.  I stood regarding this.  I made a step towards it,
+and it rose up and became a man armed with a cutlass.  I approached
+him slowly.  He stood silent and motionless, regarding me.
+
+As I drew nearer I perceived he was dressed in clothes as dusty and
+filthy as my own; he looked, indeed, as though he had been dragged
+through a culvert.  Nearer, I distinguished the green slime of ditches
+mixing with the pale drab of dried clay and shiny, coaly patches.  His
+black hair fell over his eyes, and his face was dark and dirty and
+sunken, so that at first I did not recognise him.  There was a red cut
+across the lower part of his face.
+
+"Stop!" he cried, when I was within ten yards of him, and I
+stopped.  His voice was hoarse.  "Where do you come from?" he said.
+
+I thought, surveying him.
+
+"I come from Mortlake," I said.  "I was buried near the pit the
+Martians made about their cylinder.  I have worked my way out and
+escaped."
+
+"There is no food about here," he said.  "This is my country.  All
+this hill down to the river, and back to Clapham, and up to the edge
+of the common.  There is only food for one.  Which way are you going?"
+
+I answered slowly.
+
+"I don't know," I said.  "I have been buried in the ruins of a
+house thirteen or fourteen days.  I don't know what has happened."
+
+He looked at me doubtfully, then started, and looked with a changed
+expression.
+
+"I've no wish to stop about here," said I.  "I think I shall go to
+Leatherhead, for my wife was there."
+
+He shot out a pointing finger.
+
+"It is you," said he; "the man from Woking.  And you weren't killed
+at Weybridge?"
+
+I recognised him at the same moment.
+
+"You are the artilleryman who came into my garden."
+
+"Good luck!" he said.  "We are lucky ones!  Fancy _you_!"  He put out
+a hand, and I took it.  "I crawled up a drain," he said. "But they
+didn't kill everyone.  And after they went away I got off towards
+Walton across the fields.  But---- It's not sixteen days altogether--and
+your hair is grey."  He looked over his shoulder suddenly.  "Only
+a rook," he said.  "One gets to know that birds have shadows these
+days.  This is a bit open.  Let us crawl under those bushes and talk."
+
+"Have you seen any Martians?" I said.  "Since I crawled out----"
+
+"They've gone away across London," he said.  "I guess they've got a
+bigger camp there.  Of a night, all over there, Hampstead way, the sky
+is alive with their lights.  It's like a great city, and in the glare
+you can just see them moving.  By daylight you can't.  But nearer--I
+haven't seen them--" (he counted on his fingers) "five days.  Then I
+saw a couple across Hammersmith way carrying something big.  And the
+night before last"--he stopped and spoke impressively--"it was just a
+matter of lights, but it was something up in the air.  I believe
+they've built a flying-machine, and are learning to fly."
+
+I stopped, on hands and knees, for we had come to the bushes.
+
+"Fly!"
+
+"Yes," he said, "fly."
+
+I went on into a little bower, and sat down.
+
+"It is all over with humanity," I said.  "If they can do that they
+will simply go round the world."
+
+He nodded.
+
+"They will.  But---- It will relieve things over here a bit.  And
+besides----"  He looked at me.  "Aren't you satisfied it _is_ up with
+humanity?  I am.  We're down; we're beat."
+
+I stared.  Strange as it may seem, I had not arrived at this fact--a
+fact perfectly obvious so soon as he spoke.  I had still held a
+vague hope; rather, I had kept a lifelong habit of mind.  He repeated
+his words, "We're beat."  They carried absolute conviction.
+
+"It's all over," he said.  "They've lost _one_--just _one_.  And they've
+made their footing good and crippled the greatest power in the world.
+They've walked over us.  The death of that one at Weybridge was an
+accident.  And these are only pioneers.  They kept on coming.  These
+green stars--I've seen none these five or six days, but I've no doubt
+they're falling somewhere every night.  Nothing's to be done.  We're
+under! We're beat!"
+
+I made him no answer.  I sat staring before me, trying in vain to
+devise some countervailing thought.
+
+"This isn't a war," said the artilleryman.  "It never was a war,
+any more than there's war between man and ants."
+
+Suddenly I recalled the night in the observatory.
+
+"After the tenth shot they fired no more--at least, until the first
+cylinder came."
+
+"How do you know?" said the artilleryman.  I explained.  He thought.
+"Something wrong with the gun," he said.  "But what if there is?
+They'll get it right again.  And even if there's a delay, how can it
+alter the end?  It's just men and ants.  There's the ants builds their
+cities, live their lives, have wars, revolutions, until the men want
+them out of the way, and then they go out of the way.  That's what we
+are now--just ants.  Only----"
+
+"Yes," I said.
+
+"We're eatable ants."
+
+We sat looking at each other.
+
+"And what will they do with us?" I said.
+
+"That's what I've been thinking," he said; "that's what I've been
+thinking.  After Weybridge I went south--thinking.  I saw what was up.
+Most of the people were hard at it squealing and exciting themselves.
+But I'm not so fond of squealing.  I've been in sight of death once or
+twice; I'm not an ornamental soldier, and at the best and worst,
+death--it's just death.  And it's the man that keeps on thinking comes
+through.  I saw everyone tracking away south.  Says I, 'Food won't
+last this way,' and I turned right back.  I went for the Martians like
+a sparrow goes for man.  All round"--he waved a hand to the
+horizon--"they're starving in heaps, bolting, treading on each other.
+. . ."
+
+He saw my face, and halted awkwardly.
+
+"No doubt lots who had money have gone away to France," he said.  He
+seemed to hesitate whether to apologise, met my eyes, and went on:
+"There's food all about here.  Canned things in shops; wines, spirits,
+mineral waters; and the water mains and drains are empty.  Well, I was
+telling you what I was thinking.  'Here's intelligent things,' I said,
+'and it seems they want us for food.  First, they'll smash us up--ships,
+machines, guns, cities, all the order and organisation.  All
+that will go.  If we were the size of ants we might pull through.  But
+we're not.  It's all too bulky to stop.  That's the first certainty.'
+Eh?"
+
+I assented.
+
+"It is; I've thought it out.  Very well, then--next; at present
+we're caught as we're wanted.  A Martian has only to go a few miles to
+get a crowd on the run.  And I saw one, one day, out by Wandsworth,
+picking houses to pieces and routing among the wreckage.  But they
+won't keep on doing that.  So soon as they've settled all our guns and
+ships, and smashed our railways, and done all the things they are
+doing over there, they will begin catching us systematic, picking the
+best and storing us in cages and things.  That's what they will start
+doing in a bit.  Lord!  They haven't begun on us yet.  Don't you see
+that?"
+
+"Not begun!" I exclaimed.
+
+"Not begun.  All that's happened so far is through our not having
+the sense to keep quiet--worrying them with guns and such foolery.  And
+losing our heads, and rushing off in crowds to where there wasn't any
+more safety than where we were.  They don't want to bother us yet.
+They're making their things--making all the things they couldn't bring
+with them, getting things ready for the rest of their people.  Very
+likely that's why the cylinders have stopped for a bit, for fear of
+hitting those who are here.  And instead of our rushing about blind,
+on the howl, or getting dynamite on the chance of busting them up,
+we've got to fix ourselves up according to the new state of affairs.
+That's how I figure it out.  It isn't quite according to what a man
+wants for his species, but it's about what the facts point to.  And
+that's the principle I acted upon.  Cities, nations, civilisation,
+progress--it's all over.  That game's up.  We're beat."
+
+"But if that is so, what is there to live for?"
+
+The artilleryman looked at me for a moment.
+
+"There won't be any more blessed concerts for a million years or
+so; there won't be any Royal Academy of Arts, and no nice little feeds
+at restaurants.  If it's amusement you're after, I reckon the game is
+up.  If you've got any drawing-room manners or a dislike to eating
+peas with a knife or dropping aitches, you'd better chuck 'em away.
+They ain't no further use."
+
+"You mean----"
+
+"I mean that men like me are going on living--for the sake of the
+breed.  I tell you, I'm grim set on living.  And if I'm not mistaken,
+you'll show what insides _you've_ got, too, before long.  We aren't
+going to be exterminated.  And I don't mean to be caught either, and
+tamed and fattened and bred like a thundering ox.  Ugh! Fancy those
+brown creepers!"
+
+"You don't mean to say----"
+
+"I do.  I'm going on, under their feet.  I've got it planned; I've
+thought it out.  We men are beat.  We don't know enough.  We've got to
+learn before we've got a chance.  And we've got to live and keep
+independent while we learn.  See! That's what has to be done."
+
+I stared, astonished, and stirred profoundly by the man's
+resolution.
+
+"Great God!" cried I.  "But you are a man indeed!"  And suddenly I
+gripped his hand.
+
+"Eh!" he said, with his eyes shining.  "I've thought it out, eh?"
+
+"Go on," I said.
+
+"Well, those who mean to escape their catching must get ready.  I'm
+getting ready.  Mind you, it isn't all of us that are made for wild
+beasts; and that's what it's got to be.  That's why I watched you.  I
+had my doubts.  You're slender.  I didn't know that it was you, you
+see, or just how you'd been buried.  All these--the sort of people
+that lived in these houses, and all those damn little clerks that used
+to live down that way--they'd be no good.  They haven't any spirit in
+them--no proud dreams and no proud lusts; and a man who hasn't one or
+the other--Lord!  What is he but funk and precautions?  They just used
+to skedaddle off to work--I've seen hundreds of 'em, bit of breakfast
+in hand, running wild and shining to catch their little season-ticket
+train, for fear they'd get dismissed if they didn't; working at
+businesses they were afraid to take the trouble to understand;
+skedaddling back for fear they wouldn't be in time for dinner; keeping
+indoors after dinner for fear of the back streets, and sleeping with
+the wives they married, not because they wanted them, but because they
+had a bit of money that would make for safety in their one little
+miserable skedaddle through the world.  Lives insured and a bit
+invested for fear of accidents.  And on Sundays--fear of the
+hereafter.  As if hell was built for rabbits!  Well, the Martians will
+just be a godsend to these.  Nice roomy cages, fattening food, careful
+breeding, no worry.  After a week or so chasing about the fields and
+lands on empty stomachs, they'll come and be caught cheerful.  They'll
+be quite glad after a bit.  They'll wonder what people did before
+there were Martians to take care of them.  And the bar loafers, and
+mashers, and singers--I can imagine them.  I can imagine them," he
+said, with a sort of sombre gratification.  "There'll be any amount of
+sentiment and religion loose among them.  There's hundreds of things I
+saw with my eyes that I've only begun to see clearly these last few
+days.  There's lots will take things as they are--fat and stupid; and
+lots will be worried by a sort of feeling that it's all wrong, and
+that they ought to be doing something.  Now whenever things are so
+that a lot of people feel they ought to be doing something, the weak,
+and those who go weak with a lot of complicated thinking, always make
+for a sort of do-nothing religion, very pious and superior, and
+submit to persecution and the will of the Lord.  Very likely you've
+seen the same thing.  It's energy in a gale of funk, and turned clean
+inside out.  These cages will be full of psalms and hymns and piety.
+And those of a less simple sort will work in a bit of--what is
+it?--eroticism."
+
+He paused.
+
+"Very likely these Martians will make pets of some of them; train
+them to do tricks--who knows?--get sentimental over the pet boy who
+grew up and had to be killed.  And some, maybe, they will train to
+hunt us."
+
+"No," I cried, "that's impossible!  No human being----"
+
+"What's the good of going on with such lies?" said the
+artilleryman.  "There's men who'd do it cheerful.  What nonsense to
+pretend there isn't!"
+
+And I succumbed to his conviction.
+
+"If they come after me," he said; "Lord, if they come after me!"
+and subsided into a grim meditation.
+
+I sat contemplating these things.  I could find nothing to bring
+against this man's reasoning.  In the days before the invasion no one
+would have questioned my intellectual superiority to his--I, a
+professed and recognised writer on philosophical themes, and he, a
+common soldier; and yet he had already formulated a situation that I
+had scarcely realised.
+
+"What are you doing?" I said presently.  "What plans have you
+made?"
+
+He hesitated.
+
+"Well, it's like this," he said.  "What have we to do?  We have to
+invent a sort of life where men can live and breed, and be
+sufficiently secure to bring the children up.  Yes--wait a bit, and
+I'll make it clearer what I think ought to be done.  The tame ones
+will go like all tame beasts; in a few generations they'll be big,
+beautiful, rich-blooded, stupid--rubbish! The risk is that we who keep
+wild will go savage--degenerate into a sort of big, savage rat. . . .
+You see, how I mean to live is underground.  I've been thinking about
+the drains.  Of course those who don't know drains think horrible
+things; but under this London are miles and miles--hundreds of
+miles--and a few days rain and London empty will leave them sweet and
+clean. The main drains are big enough and airy enough for anyone.
+Then there's cellars, vaults, stores, from which bolting passages may
+be made to the drains. And the railway tunnels and subways.  Eh?  You
+begin to see?  And we form a band--able-bodied, clean-minded men.
+We're not going to pick up any rubbish that drifts in.  Weaklings
+go out again."
+
+"As you meant me to go?"
+
+"Well--I parleyed, didn't I?"
+
+"We won't quarrel about that.  Go on."
+
+"Those who stop obey orders.  Able-bodied, clean-minded women we
+want also--mothers and teachers.  No lackadaisical ladies--no blasted
+rolling eyes.  We can't have any weak or silly.  Life is real again,
+and the useless and cumbersome and mischievous have to die.  They
+ought to die.  They ought to be willing to die.  It's a sort of
+disloyalty, after all, to live and taint the race.  And they can't be
+happy.  Moreover, dying's none so dreadful; it's the funking makes it
+bad.  And in all those places we shall gather.  Our district will be
+London.  And we may even be able to keep a watch, and run about in the
+open when the Martians keep away.  Play cricket, perhaps.  That's how
+we shall save the race.  Eh?  It's a possible thing?  But saving the
+race is nothing in itself.  As I say, that's only being rats.  It's
+saving our knowledge and adding to it is the thing.  There men like
+you come in.  There's books, there's models.  We must make great safe
+places down deep, and get all the books we can; not novels and poetry
+swipes, but ideas, science books.  That's where men like you come in.
+We must go to the British Museum and pick all those books through.
+Especially we must keep up our science--learn more.  We must watch
+these Martians.  Some of us must go as spies.  When it's all working,
+perhaps I will.  Get caught, I mean.  And the great thing is, we must
+leave the Martians alone.  We mustn't even steal.  If we get in their
+way, we clear out.  We must show them we mean no harm.  Yes, I know.
+But they're intelligent things, and they won't hunt us down if they
+have all they want, and think we're just harmless vermin."
+
+The artilleryman paused and laid a brown hand upon my arm.
+
+"After all, it may not be so much we may have to learn before--Just
+imagine this: four or five of their fighting machines suddenly
+starting off--Heat-Rays right and left, and not a Martian in 'em.  Not
+a Martian in 'em, but men--men who have learned the way how.  It may
+be in my time, even--those men.  Fancy having one of them lovely
+things, with its Heat-Ray wide and free!  Fancy having it in control!
+What would it matter if you smashed to smithereens at the end of the
+run, after a bust like that?  I reckon the Martians'll open their
+beautiful eyes!  Can't you see them, man?  Can't you see them
+hurrying, hurrying--puffing and blowing and hooting to their other
+mechanical affairs?  Something out of gear in every case.  And swish,
+bang, rattle, swish!  Just as they are fumbling over it, _swish_ comes
+the Heat-Ray, and, behold! man has come back to his own."
+
+For a while the imaginative daring of the artilleryman, and the
+tone of assurance and courage he assumed, completely dominated my
+mind.  I believed unhesitatingly both in his forecast of human destiny
+and in the practicability of his astonishing scheme, and the reader
+who thinks me susceptible and foolish must contrast his position,
+reading steadily with all his thoughts about his subject, and mine,
+crouching fearfully in the bushes and listening, distracted by
+apprehension.  We talked in this manner through the early morning
+time, and later crept out of the bushes, and, after scanning the sky
+for Martians, hurried precipitately to the house on Putney Hill where
+he had made his lair.  It was the coal cellar of the place, and when I
+saw the work he had spent a week upon--it was a burrow scarcely ten
+yards long, which he designed to reach to the main drain on Putney
+Hill--I had my first inkling of the gulf between his dreams and his
+powers.  Such a hole I could have dug in a day.  But I believed in him
+sufficiently to work with him all that morning until past midday at
+his digging.  We had a garden barrow and shot the earth we removed
+against the kitchen range.  We refreshed ourselves with a tin of
+mock-turtle soup and wine from the neighbouring pantry.  I found a
+curious relief from the aching strangeness of the world in this steady
+labour. As we worked, I turned his project over in my mind, and
+presently objections and doubts began to arise; but I worked there all
+the morning, so glad was I to find myself with a purpose again.  After
+working an hour I began to speculate on the distance one had to go
+before the cloaca was reached, the chances we had of missing it
+altogether.  My immediate trouble was why we should dig this long
+tunnel, when it was possible to get into the drain at once down one of
+the manholes, and work back to the house.  It seemed to me, too, that
+the house was inconveniently chosen, and required a needless length of
+tunnel.  And just as I was beginning to face these things, the
+artilleryman stopped digging, and looked at me.
+
+"We're working well," he said.  He put down his spade. "Let us
+knock off a bit" he said.  "I think it's time we reconnoitred from the
+roof of the house."
+
+I was for going on, and after a little hesitation he resumed his
+spade; and then suddenly I was struck by a thought.  I stopped, and so
+did he at once.
+
+"Why were you walking about the common," I said, "instead of being
+here?"
+
+"Taking the air," he said.  "I was coming back.  It's safer by
+night."
+
+"But the work?"
+
+"Oh, one can't always work," he said, and in a flash I saw the man
+plain.  He hesitated, holding his spade.  "We ought to reconnoitre
+now," he said, "because if any come near they may hear the spades and
+drop upon us unawares."
+
+I was no longer disposed to object.  We went together to the roof
+and stood on a ladder peeping out of the roof door.  No Martians were
+to be seen, and we ventured out on the tiles, and slipped down under
+shelter of the parapet.
+
+From this position a shrubbery hid the greater portion of Putney,
+but we could see the river below, a bubbly mass of red weed, and the
+low parts of Lambeth flooded and red.  The red creeper swarmed up the
+trees about the old palace, and their branches stretched gaunt and
+dead, and set with shrivelled leaves, from amid its clusters.  It was
+strange how entirely dependent both these things were upon flowing
+water for their propagation.  About us neither had gained a footing;
+laburnums, pink mays, snowballs, and trees of arbor-vitae, rose out of
+laurels and hydrangeas, green and brilliant into the sunlight.  Beyond
+Kensington dense smoke was rising, and that and a blue haze hid the
+northward hills.
+
+The artilleryman began to tell me of the sort of people who still
+remained in London.
+
+"One night last week," he said, "some fools got the electric light
+in order, and there was all Regent Street and the Circus ablaze,
+crowded with painted and ragged drunkards, men and women, dancing and
+shouting till dawn.  A man who was there told me.  And as the day came
+they became aware of a fighting-machine standing near by the Langham
+and looking down at them.  Heaven knows how long he had been there.
+It must have given some of them a nasty turn.  He came down the road
+towards them, and picked up nearly a hundred too drunk or frightened
+to run away."
+
+Grotesque gleam of a time no history will ever fully describe!
+
+From that, in answer to my questions, he came round to his
+grandiose plans again.  He grew enthusiastic.  He talked so eloquently
+of the possibility of capturing a fighting-machine that I more than
+half believed in him again.  But now that I was beginning to
+understand something of his quality, I could divine the stress he laid
+on doing nothing precipitately.  And I noted that now there was no
+question that he personally was to capture and fight the great
+machine.
+
+After a time we went down to the cellar.  Neither of us seemed
+disposed to resume digging, and when he suggested a meal, I was
+nothing loath.  He became suddenly very generous, and when we had
+eaten he went away and returned with some excellent cigars.  We lit
+these, and his optimism glowed.  He was inclined to regard my coming
+as a great occasion.
+
+"There's some champagne in the cellar," he said.
+
+"We can dig better on this Thames-side burgundy," said I.
+
+"No," said he; "I am host today.  Champagne!  Great God! We've a
+heavy enough task before us!  Let us take a rest and gather strength
+while we may.  Look at these blistered hands!"
+
+And pursuant to this idea of a holiday, he insisted upon playing
+cards after we had eaten.  He taught me euchre, and after dividing
+London between us, I taking the northern side and he the southern, we
+played for parish points.  Grotesque and foolish as this will seem to
+the sober reader, it is absolutely true, and what is more remarkable,
+I found the card game and several others we played extremely
+interesting.
+
+Strange mind of man! that, with our species upon the edge of
+extermination or appalling degradation, with no clear prospect before
+us but the chance of a horrible death, we could sit following the
+chance of this painted pasteboard, and playing the "joker" with vivid
+delight.  Afterwards he taught me poker, and I beat him at three tough
+chess games.  When dark came we decided to take the risk, and lit a
+lamp.
+
+After an interminable string of games, we supped, and the
+artilleryman finished the champagne.  We went on smoking the cigars.
+He was no longer the energetic regenerator of his species I had
+encountered in the morning.  He was still optimistic, but it was a
+less kinetic, a more thoughtful optimism.  I remember he wound up with
+my health, proposed in a speech of small variety and considerable
+intermittence.  I took a cigar, and went upstairs to look at the
+lights of which he had spoken that blazed so greenly along the
+Highgate hills.
+
+At first I stared unintelligently across the London valley.  The
+northern hills were shrouded in darkness; the fires near Kensington
+glowed redly, and now and then an orange-red tongue of flame flashed
+up and vanished in the deep blue night.  All the rest of London
+was black.  Then, nearer, I perceived a strange light, a pale,
+violet-purple fluorescent glow, quivering under the night breeze.  For
+a space I could not understand it, and then I knew that it must be
+the red weed from which this faint irradiation proceeded.  With that
+realisation my dormant sense of wonder, my sense of the proportion of
+things, awoke again.  I glanced from that to Mars, red and clear,
+glowing high in the west, and then gazed long and earnestly at the
+darkness of Hampstead and Highgate.
+
+I remained a very long time upon the roof, wondering at the
+grotesque changes of the day.  I recalled my mental states from the
+midnight prayer to the foolish card-playing.  I had a violent
+revulsion of feeling.  I remember I flung away the cigar with a
+certain wasteful symbolism.  My folly came to me with glaring
+exaggeration.  I seemed a traitor to my wife and to my kind; I was
+filled with remorse.  I resolved to leave this strange undisciplined
+dreamer of great things to his drink and gluttony, and to go on into
+London.  There, it seemed to me, I had the best chance of learning
+what the Martians and my fellowmen were doing.  I was still upon the
+roof when the late moon rose.
+
+
+
+CHAPTER EIGHT
+
+DEAD LONDON
+
+
+After I had parted from the artilleryman, I went down the hill, and
+by the High Street across the bridge to Fulham.  The red weed was
+tumultuous at that time, and nearly choked the bridge roadway; but its
+fronds were already whitened in patches by the spreading disease that
+presently removed it so swiftly.
+
+At the corner of the lane that runs to Putney Bridge station I
+found a man lying.  He was as black as a sweep with the black dust,
+alive, but helplessly and speechlessly drunk.  I could get nothing
+from him but curses and furious lunges at my head.  I think I should
+have stayed by him but for the brutal expression of his face.
+
+There was black dust along the roadway from the bridge onwards, and
+it grew thicker in Fulham.  The streets were horribly quiet.  I got
+food--sour, hard, and mouldy, but quite eatable--in a baker's shop
+here.  Some way towards Walham Green the streets became clear of
+powder, and I passed a white terrace of houses on fire; the noise of
+the burning was an absolute relief.  Going on towards Brompton, the
+streets were quiet again.
+
+Here I came once more upon the black powder in the streets and upon
+dead bodies.  I saw altogether about a dozen in the length of the
+Fulham Road.  They had been dead many days, so that I hurried quickly
+past them.  The black powder covered them over, and softened their
+outlines.  One or two had been disturbed by dogs.
+
+Where there was no black powder, it was curiously like a Sunday in
+the City, with the closed shops, the houses locked up and the blinds
+drawn, the desertion, and the stillness.  In some places plunderers
+had been at work, but rarely at other than the provision and wine
+shops.  A jeweller's window had been broken open in one place, but
+apparently the thief had been disturbed, and a number of gold chains
+and a watch lay scattered on the pavement.  I did not trouble to touch
+them.  Farther on was a tattered woman in a heap on a doorstep; the
+hand that hung over her knee was gashed and bled down her rusty brown
+dress, and a smashed magnum of champagne formed a pool across the
+pavement.  She seemed asleep, but she was dead.
+
+The farther I penetrated into London, the profounder grew the
+stillness.  But it was not so much the stillness of death--it was the
+stillness of suspense, of expectation.  At any time the destruction
+that had already singed the northwestern borders of the metropolis,
+and had annihilated Ealing and Kilburn, might strike among these
+houses and leave them smoking ruins.  It was a city condemned and
+derelict. . . .
+
+In South Kensington the streets were clear of dead and of black
+powder.  It was near South Kensington that I first heard the howling.
+It crept almost imperceptibly upon my senses.  It was a sobbing
+alternation of two notes, "Ulla, ulla, ulla, ulla," keeping on
+perpetually.  When I passed streets that ran northward it grew in
+volume, and houses and buildings seemed to deaden and cut it off
+again.  It came in a full tide down Exhibition Road.  I stopped,
+staring towards Kensington Gardens, wondering at this strange, remote
+wailing.  It was as if that mighty desert of houses had found a voice
+for its fear and solitude.
+
+"Ulla, ulla, ulla, ulla," wailed that superhuman note--great waves
+of sound sweeping down the broad, sunlit roadway, between the tall
+buildings on each side.  I turned northwards, marvelling, towards the
+iron gates of Hyde Park.  I had half a mind to break into the Natural
+History Museum and find my way up to the summits of the towers, in
+order to see across the park.  But I decided to keep to the ground,
+where quick hiding was possible, and so went on up the Exhibition
+Road.  All the large mansions on each side of the road were empty and
+still, and my footsteps echoed against the sides of the houses.  At
+the top, near the park gate, I came upon a strange sight--a bus
+overturned, and the skeleton of a horse picked clean.  I puzzled over
+this for a time, and then went on to the bridge over the Serpentine.
+The voice grew stronger and stronger, though I could see nothing above
+the housetops on the north side of the park, save a haze of smoke to
+the northwest.
+
+"Ulla, ulla, ulla, ulla," cried the voice, coming, as it seemed to
+me, from the district about Regent's Park.  The desolating cry worked
+upon my mind.  The mood that had sustained me passed.  The wailing
+took possession of me.  I found I was intensely weary, footsore, and
+now again hungry and thirsty.
+
+It was already past noon.  Why was I wandering alone in this city
+of the dead?  Why was I alone when all London was lying in state, and
+in its black shroud?  I felt intolerably lonely.  My mind ran on old
+friends that I had forgotten for years.  I thought of the poisons in
+the chemists' shops, of the liquors the wine merchants stored; I
+recalled the two sodden creatures of despair, who so far as I knew,
+shared the city with myself. . . .
+
+I came into Oxford Street by the Marble Arch, and here again were
+black powder and several bodies, and an evil, ominous smell from the
+gratings of the cellars of some of the houses.  I grew very thirsty
+after the heat of my long walk.  With infinite trouble I managed to
+break into a public-house and get food and drink.  I was weary after
+eating, and went into the parlour behind the bar, and slept on a black
+horsehair sofa I found there.
+
+I awoke to find that dismal howling still in my ears, "Ulla, ulla,
+ulla, ulla."  It was now dusk, and after I had routed out some
+biscuits and a cheese in the bar--there was a meat safe, but it
+contained nothing but maggots--I wandered on through the silent
+residential squares to Baker Street--Portman Square is the only one I
+can name--and so came out at last upon Regent's Park.  And as I
+emerged from the top of Baker Street, I saw far away over the trees in
+the clearness of the sunset the hood of the Martian giant from which
+this howling proceeded.  I was not terrified.  I came upon him as if
+it were a matter of course.  I watched him for some time, but he did
+not move.  He appeared to be standing and yelling, for no reason that
+I could discover.
+
+I tried to formulate a plan of action.  That perpetual sound of
+"Ulla, ulla, ulla, ulla," confused my mind.  Perhaps I was too tired
+to be very fearful.  Certainly I was more curious to know the reason
+of this monotonous crying than afraid.  I turned back away from the
+park and struck into Park Road, intending to skirt the park, went
+along under the shelter of the terraces, and got a view of this
+stationary, howling Martian from the direction of St. John's Wood.  A
+couple of hundred yards out of Baker Street I heard a yelping chorus,
+and saw, first a dog with a piece of putrescent red meat in his jaws
+coming headlong towards me, and then a pack of starving mongrels in
+pursuit of him.  He made a wide curve to avoid me, as though he feared
+I might prove a fresh competitor.  As the yelping died away down the
+silent road, the wailing sound of "Ulla, ulla, ulla, ulla," reasserted
+itself.
+
+I came upon the wrecked handling-machine halfway to St. John's Wood
+station.  At first I thought a house had fallen across the road.  It
+was only as I clambered among the ruins that I saw, with a start, this
+mechanical Samson lying, with its tentacles bent and smashed and
+twisted, among the ruins it had made.  The forepart was shattered.  It
+seemed as if it had driven blindly straight at the house, and had been
+overwhelmed in its overthrow.  It seemed to me then that this might
+have happened by a handling-machine escaping from the guidance of its
+Martian.  I could not clamber among the ruins to see it, and the
+twilight was now so far advanced that the blood with which its seat
+was smeared, and the gnawed gristle of the Martian that the dogs had
+left, were invisible to me.
+
+Wondering still more at all that I had seen, I pushed on towards
+Primrose Hill.  Far away, through a gap in the trees, I saw a second
+Martian, as motionless as the first, standing in the park towards the
+Zoological Gardens, and silent.  A little beyond the ruins about the
+smashed handling-machine I came upon the red weed again, and found the
+Regent's Canal, a spongy mass of dark-red vegetation.
+
+As I crossed the bridge, the sound of "Ulla, ulla, ulla, ulla,"
+ceased.  It was, as it were, cut off.  The silence came like a
+thunderclap.
+
+The dusky houses about me stood faint and tall and dim; the trees
+towards the park were growing black.  All about me the red weed
+clambered among the ruins, writhing to get above me in the dimness.
+Night, the mother of fear and mystery, was coming upon me.  But while
+that voice sounded the solitude, the desolation, had been endurable;
+by virtue of it London had still seemed alive, and the sense of life
+about me had upheld me.  Then suddenly a change, the passing of
+something--I knew not what--and then a stillness that could be felt.
+Nothing but this gaunt quiet.
+
+London about me gazed at me spectrally.  The windows in the white
+houses were like the eye sockets of skulls.  About me my imagination
+found a thousand noiseless enemies moving.  Terror seized me, a horror
+of my temerity.  In front of me the road became pitchy black as though
+it was tarred, and I saw a contorted shape lying across the pathway.  I
+could not bring myself to go on.  I turned down St. John's Wood Road,
+and ran headlong from this unendurable stillness towards Kilburn.  I
+hid from the night and the silence, until long after midnight, in a
+cabmen's shelter in Harrow Road.  But before the dawn my courage
+returned, and while the stars were still in the sky I turned once more
+towards Regent's Park.  I missed my way among the streets, and
+presently saw down a long avenue, in the half-light of the early dawn,
+the curve of Primrose Hill.  On the summit, towering up to the fading
+stars, was a third Martian, erect and motionless like the others.
+
+An insane resolve possessed me.  I would die and end it.  And I
+would save myself even the trouble of killing myself.  I marched on
+recklessly towards this Titan, and then, as I drew nearer and the
+light grew, I saw that a multitude of black birds was circling and
+clustering about the hood.  At that my heart gave a bound, and I began
+running along the road.
+
+I hurried through the red weed that choked St. Edmund's Terrace (I
+waded breast-high across a torrent of water that was rushing down from
+the waterworks towards the Albert Road), and emerged upon the grass
+before the rising of the sun.  Great mounds had been heaped about the
+crest of the hill, making a huge redoubt of it--it was the final and
+largest place the Martians had made--and from behind these heaps there
+rose a thin smoke against the sky.  Against the sky line an eager dog
+ran and disappeared.  The thought that had flashed into my mind grew
+real, grew credible.  I felt no fear, only a wild, trembling
+exultation, as I ran up the hill towards the motionless monster.  Out
+of the hood hung lank shreds of brown, at which the hungry birds
+pecked and tore.
+
+In another moment I had scrambled up the earthen rampart and stood
+upon its crest, and the interior of the redoubt was below me.  A
+mighty space it was, with gigantic machines here and there within it,
+huge mounds of material and strange shelter places.  And scattered
+about it, some in their overturned war-machines, some in the now rigid
+handling-machines, and a dozen of them stark and silent and laid in a
+row, were the Martians--_dead_!--slain by the putrefactive and disease
+bacteria against which their systems were unprepared; slain as the red
+weed was being slain; slain, after all man's devices had failed, by
+the humblest things that God, in his wisdom, has put upon this earth.
+
+For so it had come about, as indeed I and many men might have
+foreseen had not terror and disaster blinded our minds.  These
+germs of disease have taken toll of humanity since the beginning of
+things--taken toll of our prehuman ancestors since life began here.
+But by virtue of this natural selection of our kind we have developed
+resisting power; to no germs do we succumb without a struggle, and to
+many--those that cause putrefaction in dead matter, for instance--our
+living frames are altogether immune.  But there are no bacteria in
+Mars, and directly these invaders arrived, directly they drank and
+fed, our microscopic allies began to work their overthrow.  Already
+when I watched them they were irrevocably doomed, dying and rotting
+even as they went to and fro.  It was inevitable.  By the toll of a
+billion deaths man has bought his birthright of the earth, and it is
+his against all comers; it would still be his were the Martians ten
+times as mighty as they are.  For neither do men live nor die in vain.
+
+Here and there they were scattered, nearly fifty altogether, in
+that great gulf they had made, overtaken by a death that must have
+seemed to them as incomprehensible as any death could be.  To me also
+at that time this death was incomprehensible.  All I knew was that
+these things that had been alive and so terrible to men were dead.
+For a moment I believed that the destruction of Sennacherib had been
+repeated, that God had repented, that the Angel of Death had slain
+them in the night.
+
+I stood staring into the pit, and my heart lightened gloriously,
+even as the rising sun struck the world to fire about me with his
+rays.  The pit was still in darkness; the mighty engines, so great and
+wonderful in their power and complexity, so unearthly in their
+tortuous forms, rose weird and vague and strange out of the shadows
+towards the light.  A multitude of dogs, I could hear, fought over the
+bodies that lay darkly in the depth of the pit, far below me.  Across
+the pit on its farther lip, flat and vast and strange, lay the great
+flying-machine with which they had been experimenting upon our denser
+atmosphere when decay and death arrested them.  Death had come not a
+day too soon.  At the sound of a cawing overhead I looked up at the
+huge fighting-machine that would fight no more for ever, at the
+tattered red shreds of flesh that dripped down upon the overturned
+seats on the summit of Primrose Hill.
+
+I turned and looked down the slope of the hill to where, enhaloed
+now in birds, stood those other two Martians that I had seen
+overnight, just as death had overtaken them.  The one had died, even
+as it had been crying to its companions; perhaps it was the last to
+die, and its voice had gone on perpetually until the force of its
+machinery was exhausted.  They glittered now, harmless tripod towers
+of shining metal, in the brightness of the rising sun.
+
+All about the pit, and saved as by a miracle from everlasting
+destruction, stretched the great Mother of Cities.  Those who have only
+seen London veiled in her sombre robes of smoke can scarcely imagine
+the naked clearness and beauty of the silent wilderness of houses.
+
+Eastward, over the blackened ruins of the Albert Terrace and the
+splintered spire of the church, the sun blazed dazzling in a clear
+sky, and here and there some facet in the great wilderness of roofs
+caught the light and glared with a white intensity.
+
+Northward were Kilburn and Hampsted, blue and crowded with houses;
+westward the great city was dimmed; and southward, beyond the
+Martians, the green waves of Regent's Park, the Langham Hotel, the
+dome of the Albert Hall, the Imperial Institute, and the giant
+mansions of the Brompton Road came out clear and little in the
+sunrise, the jagged ruins of Westminster rising hazily beyond.  Far
+away and blue were the Surrey hills, and the towers of the Crystal
+Palace glittered like two silver rods.  The dome of St. Paul's was
+dark against the sunrise, and injured, I saw for the first time, by a
+huge gaping cavity on its western side.
+
+And as I looked at this wide expanse of houses and factories and
+churches, silent and abandoned; as I thought of the multitudinous
+hopes and efforts, the innumerable hosts of lives that had gone to
+build this human reef, and of the swift and ruthless destruction that
+had hung over it all; when I realised that the shadow had been rolled
+back, and that men might still live in the streets, and this dear vast
+dead city of mine be once more alive and powerful, I felt a wave of
+emotion that was near akin to tears.
+
+The torment was over.  Even that day the healing would begin.  The
+survivors of the people scattered over the country--leaderless,
+lawless, foodless, like sheep without a shepherd--the thousands who
+had fled by sea, would begin to return; the pulse of life, growing
+stronger and stronger, would beat again in the empty streets and pour
+across the vacant squares.  Whatever destruction was done, the hand of
+the destroyer was stayed.  All the gaunt wrecks, the blackened
+skeletons of houses that stared so dismally at the sunlit grass of the
+hill, would presently be echoing with the hammers of the restorers and
+ringing with the tapping of their trowels.  At the thought I extended
+my hands towards the sky and began thanking God.  In a year, thought
+I--in a year. . .
+
+With overwhelming force came the thought of myself, of my wife, and
+the old life of hope and tender helpfulness that had ceased for ever.
+
+
+
+CHAPTER NINE
+
+WRECKAGE
+
+
+And now comes the strangest thing in my story.  Yet, perhaps, it is
+not altogether strange.  I remember, clearly and coldly and vividly,
+all that I did that day until the time that I stood weeping and
+praising God upon the summit of Primrose Hill.  And then I forget.
+
+Of the next three days I know nothing.  I have learned since that,
+so far from my being the first discoverer of the Martian overthrow,
+several such wanderers as myself had already discovered this on the
+previous night.  One man--the first--had gone to St. Martin's-le-Grand,
+and, while I sheltered in the cabmen's hut, had contrived to
+telegraph to Paris.  Thence the joyful news had flashed all over the
+world; a thousand cities, chilled by ghastly apprehensions, suddenly
+flashed into frantic illuminations; they knew of it in Dublin,
+Edinburgh, Manchester, Birmingham, at the time when I stood upon the
+verge of the pit.  Already men, weeping with joy, as I have heard,
+shouting and staying their work to shake hands and shout, were making
+up trains, even as near as Crewe, to descend upon London.  The church
+bells that had ceased a fortnight since suddenly caught the news,
+until all England was bell-ringing.  Men on cycles, lean-faced,
+unkempt, scorched along every country lane shouting of unhoped
+deliverance, shouting to gaunt, staring figures of despair.  And for
+the food!  Across the Channel, across the Irish Sea, across the
+Atlantic, corn, bread, and meat were tearing to our relief.  All the
+shipping in the world seemed going Londonward in those days.  But of
+all this I have no memory.  I drifted--a demented man.  I found myself
+in a house of kindly people, who had found me on the third day
+wandering, weeping, and raving through the streets of St. John's Wood.
+They have told me since that I was singing some insane doggerel about
+"The Last Man Left Alive! Hurrah!  The Last Man Left Alive!"  Troubled
+as they were with their own affairs, these people, whose name, much as
+I would like to express my gratitude to them, I may not even give
+here, nevertheless cumbered themselves with me, sheltered me, and
+protected me from myself.  Apparently they had learned something of my
+story from me during the days of my lapse.
+
+Very gently, when my mind was assured again, did they break to me
+what they had learned of the fate of Leatherhead.  Two days after I
+was imprisoned it had been destroyed, with every soul in it, by a
+Martian.  He had swept it out of existence, as it seemed, without any
+provocation, as a boy might crush an ant hill, in the mere wantonness
+of power.
+
+I was a lonely man, and they were very kind to me.  I was a lonely
+man and a sad one, and they bore with me.  I remained with them four
+days after my recovery.  All that time I felt a vague, a growing
+craving to look once more on whatever remained of the little life that
+seemed so happy and bright in my past.  It was a mere hopeless desire
+to feast upon my misery.  They dissuaded me.  They did all they could
+to divert me from this morbidity.  But at last I could resist the
+impulse no longer, and, promising faithfully to return to them, and
+parting, as I will confess, from these four-day friends with tears, I
+went out again into the streets that had lately been so dark and
+strange and empty.
+
+Already they were busy with returning people; in places even there
+were shops open, and I saw a drinking fountain running water.
+
+I remember how mockingly bright the day seemed as I went back on my
+melancholy pilgrimage to the little house at Woking, how busy the
+streets and vivid the moving life about me.  So many people were
+abroad everywhere, busied in a thousand activities, that it seemed
+incredible that any great proportion of the population could have been
+slain.  But then I noticed how yellow were the skins of the people I
+met, how shaggy the hair of the men, how large and bright their eyes,
+and that every other man still wore his dirty rags.  Their faces
+seemed all with one of two expressions--a leaping exultation and
+energy or a grim resolution.  Save for the expression of the faces,
+London seemed a city of tramps.  The vestries were indiscriminately
+distributing bread sent us by the French government.  The ribs of the
+few horses showed dismally.  Haggard special constables with white
+badges stood at the corners of every street.  I saw little of the
+mischief wrought by the Martians until I reached Wellington Street,
+and there I saw the red weed clambering over the buttresses of
+Waterloo Bridge.
+
+At the corner of the bridge, too, I saw one of the common contrasts
+of that grotesque time--a sheet of paper flaunting against a thicket
+of the red weed, transfixed by a stick that kept it in place.  It was
+the placard of the first newspaper to resume publication--the _Daily
+Mail_.  I bought a copy for a blackened shilling I found in my pocket.
+Most of it was in blank, but the solitary compositor who did the thing
+had amused himself by making a grotesque scheme of advertisement
+stereo on the back page.  The matter he printed was emotional; the
+news organisation had not as yet found its way back.  I learned
+nothing fresh except that already in one week the examination of the
+Martian mechanisms had yielded astonishing results.  Among other
+things, the article assured me what I did not believe at the time,
+that the "Secret of Flying," was discovered.  At Waterloo I found the
+free trains that were taking people to their homes.  The first rush
+was already over.  There were few people in the train, and I was in no
+mood for casual conversation.  I got a compartment to myself, and sat
+with folded arms, looking greyly at the sunlit devastation that flowed
+past the windows.  And just outside the terminus the train jolted over
+temporary rails, and on either side of the railway the houses were
+blackened ruins.  To Clapham Junction the face of London was grimy
+with powder of the Black Smoke, in spite of two days of thunderstorms
+and rain, and at Clapham Junction the line had been wrecked again;
+there were hundreds of out-of-work clerks and shopmen working side by
+side with the customary navvies, and we were jolted over a hasty
+relaying.
+
+All down the line from there the aspect of the country was gaunt
+and unfamiliar; Wimbledon particularly had suffered.  Walton, by virtue
+of its unburned pine woods, seemed the least hurt of any place along
+the line.  The Wandle, the Mole, every little stream, was a heaped
+mass of red weed, in appearance between butcher's meat and pickled
+cabbage.  The Surrey pine woods were too dry, however, for the festoons
+of the red climber.  Beyond Wimbledon, within sight of the line, in
+certain nursery grounds, were the heaped masses of earth about the
+sixth cylinder.  A number of people were standing about it, and some
+sappers were busy in the midst of it.  Over it flaunted a Union Jack,
+flapping cheerfully in the morning breeze.  The nursery grounds were
+everywhere crimson with the weed, a wide expanse of livid colour cut
+with purple shadows, and very painful to the eye.  One's gaze went
+with infinite relief from the scorched greys and sullen reds of the
+foreground to the blue-green softness of the eastward hills.
+
+The line on the London side of Woking station was still undergoing
+repair, so I descended at Byfleet station and took the road to
+Maybury, past the place where I and the artilleryman had talked to the
+hussars, and on by the spot where the Martian had appeared to me in
+the thunderstorm.  Here, moved by curiosity, I turned aside to find,
+among a tangle of red fronds, the warped and broken dog cart with the
+whitened bones of the horse scattered and gnawed.  For a time I stood
+regarding these vestiges. . . .
+
+Then I returned through the pine wood, neck-high with red weed here
+and there, to find the landlord of the Spotted Dog had already found
+burial, and so came home past the College Arms.  A man standing at an
+open cottage door greeted me by name as I passed.
+
+I looked at my house with a quick flash of hope that faded
+immediately.  The door had been forced; it was unfast and was opening
+slowly as I approached.
+
+It slammed again.  The curtains of my study fluttered out of the
+open window from which I and the artilleryman had watched the dawn.  No
+one had closed it since.  The smashed bushes were just as I had left
+them nearly four weeks ago.  I stumbled into the hall, and the house
+felt empty.  The stair carpet was ruffled and discoloured where I had
+crouched, soaked to the skin from the thunderstorm the night of the
+catastrophe.  Our muddy footsteps I saw still went up the stairs.
+
+I followed them to my study, and found lying on my writing-table
+still, with the selenite paper weight upon it, the sheet of work I had
+left on the afternoon of the opening of the cylinder.  For a space I
+stood reading over my abandoned arguments.  It was a paper on the
+probable development of Moral Ideas with the development of the
+civilising process; and the last sentence was the opening of a
+prophecy: "In about two hundred years," I had written, "we may
+expect----"  The sentence ended abruptly.  I remembered my inability
+to fix my mind that morning, scarcely a month gone by, and how I had
+broken off to get my _Daily Chronicle_ from the newsboy.  I remembered
+how I went down to the garden gate as he came along, and how I had
+listened to his odd story of "Men from Mars."
+
+I came down and went into the dining room.  There were the mutton
+and the bread, both far gone now in decay, and a beer bottle
+overturned, just as I and the artilleryman had left them.  My home was
+desolate.  I perceived the folly of the faint hope I had cherished so
+long.  And then a strange thing occurred.  "It is no use," said a
+voice.  "The house is deserted.  No one has been here these ten days.
+Do not stay here to torment yourself.  No one escaped but you."
+
+I was startled.  Had I spoken my thought aloud?  I turned, and the
+French window was open behind me.  I made a step to it, and stood
+looking out.
+
+And there, amazed and afraid, even as I stood amazed and afraid,
+were my cousin and my wife--my wife white and tearless.  She gave a
+faint cry.
+
+"I came," she said.  "I knew--knew----"
+
+She put her hand to her throat--swayed.  I made a step forward, and
+caught her in my arms.
+
+
+
+CHAPTER TEN
+
+THE EPILOGUE
+
+
+I cannot but regret, now that I am concluding my story, how little
+I am able to contribute to the discussion of the many debatable
+questions which are still unsettled.  In one respect I shall certainly
+provoke criticism.  My particular province is speculative philosophy.
+My knowledge of comparative physiology is confined to a book or two,
+but it seems to me that Carver's suggestions as to the reason of the
+rapid death of the Martians is so probable as to be regarded almost as
+a proven conclusion.  I have assumed that in the body of my narrative.
+
+At any rate, in all the bodies of the Martians that were examined
+after the war, no bacteria except those already known as terrestrial
+species were found.  That they did not bury any of their dead, and the
+reckless slaughter they perpetrated, point also to an entire ignorance
+of the putrefactive process.  But probable as this seems, it is by no
+means a proven conclusion.
+
+Neither is the composition of the Black Smoke known, which the
+Martians used with such deadly effect, and the generator of the
+Heat-Rays remains a puzzle.  The terrible disasters at the Ealing
+and South Kensington laboratories have disinclined analysts for further
+investigations upon the latter.  Spectrum analysis of the black powder
+points unmistakably to the presence of an unknown element with a
+brilliant group of three lines in the green, and it is possible that
+it combines with argon to form a compound which acts at once with
+deadly effect upon some constituent in the blood.  But such unproven
+speculations will scarcely be of interest to the general reader, to
+whom this story is addressed.  None of the brown scum that drifted
+down the Thames after the destruction of Shepperton was examined at
+the time, and now none is forthcoming.
+
+The results of an anatomical examination of the Martians, so far
+as the prowling dogs had left such an examination possible, I have
+already given.  But everyone is familiar with the magnificent and
+almost complete specimen in spirits at the Natural History Museum, and
+the countless drawings that have been made from it; and beyond that
+the interest of their physiology and structure is purely scientific.
+
+A question of graver and universal interest is the possibility of
+another attack from the Martians.  I do not think that nearly enough
+attention is being given to this aspect of the matter.  At present the
+planet Mars is in conjunction, but with every return to opposition I,
+for one, anticipate a renewal of their adventure.  In any case, we
+should be prepared.  It seems to me that it should be possible to
+define the position of the gun from which the shots are discharged, to
+keep a sustained watch upon this part of the planet, and to anticipate
+the arrival of the next attack.
+
+In that case the cylinder might be destroyed with dynamite or
+artillery before it was sufficiently cool for the Martians to emerge,
+or they might be butchered by means of guns so soon as the screw
+opened.  It seems to me that they have lost a vast advantage in the
+failure of their first surprise.  Possibly they see it in the same
+light.
+
+Lessing has advanced excellent reasons for supposing that the
+Martians have actually succeeded in effecting a landing on the planet
+Venus.  Seven months ago now, Venus and Mars were in alignment with
+the sun; that is to say, Mars was in opposition from the point of view
+of an observer on Venus.  Subsequently a peculiar luminous and sinuous
+marking appeared on the unillumined half of the inner planet, and
+almost simultaneously a faint dark mark of a similar sinuous character
+was detected upon a photograph of the Martian disk.  One needs to see
+the drawings of these appearances in order to appreciate fully their
+remarkable resemblance in character.
+
+At any rate, whether we expect another invasion or not, our views
+of the human future must be greatly modified by these events.  We have
+learned now that we cannot regard this planet as being fenced in and a
+secure abiding place for Man; we can never anticipate the unseen good
+or evil that may come upon us suddenly out of space.  It may be that
+in the larger design of the universe this invasion from Mars is not
+without its ultimate benefit for men; it has robbed us of that serene
+confidence in the future which is the most fruitful source of
+decadence, the gifts to human science it has brought are enormous, and
+it has done much to promote the conception of the commonweal of
+mankind.  It may be that across the immensity of space the Martians
+have watched the fate of these pioneers of theirs and learned their
+lesson, and that on the planet Venus they have found a securer
+settlement.  Be that as it may, for many years yet there will
+certainly be no relaxation of the eager scrutiny of the Martian disk,
+and those fiery darts of the sky, the shooting stars, will bring with
+them as they fall an unavoidable apprehension to all the sons of men.
+
+The broadening of men's views that has resulted can scarcely be
+exaggerated.  Before the cylinder fell there was a general persuasion
+that through all the deep of space no life existed beyond the petty
+surface of our minute sphere.  Now we see further.  If the Martians
+can reach Venus, there is no reason to suppose that the thing is
+impossible for men, and when the slow cooling of the sun makes this
+earth uninhabitable, as at last it must do, it may be that the thread
+of life that has begun here will have streamed out and caught our
+sister planet within its toils.
+
+Dim and wonderful is the vision I have conjured up in my mind of
+life spreading slowly from this little seed bed of the solar system
+throughout the inanimate vastness of sidereal space.  But that is a
+remote dream.  It may be, on the other hand, that the destruction of
+the Martians is only a reprieve.  To them, and not to us, perhaps, is
+the future ordained.
+
+I must confess the stress and danger of the time have left an
+abiding sense of doubt and insecurity in my mind.  I sit in my study
+writing by lamplight, and suddenly I see again the healing valley
+below set with writhing flames, and feel the house behind and about me
+empty and desolate.  I go out into the Byfleet Road, and vehicles pass
+me, a butcher boy in a cart, a cabful of visitors, a workman on a
+bicycle, children going to school, and suddenly they become vague and
+unreal, and I hurry again with the artilleryman through the hot,
+brooding silence.  Of a night I see the black powder darkening the
+silent streets, and the contorted bodies shrouded in that layer; they
+rise upon me tattered and dog-bitten.  They gibber and grow fiercer,
+paler, uglier, mad distortions of humanity at last, and I wake, cold
+and wretched, in the darkness of the night.
+
+I go to London and see the busy multitudes in Fleet Street and the
+Strand, and it comes across my mind that they are but the ghosts of
+the past, haunting the streets that I have seen silent and wretched,
+going to and fro, phantasms in a dead city, the mockery of life in a
+galvanised body.  And strange, too, it is to stand on Primrose Hill,
+as I did but a day before writing this last chapter, to see the great
+province of houses, dim and blue through the haze of the smoke and
+mist, vanishing at last into the vague lower sky, to see the people
+walking to and fro among the flower beds on the hill, to see the
+sight-seers about the Martian machine that stands there still, to hear
+the tumult of playing children, and to recall the time when I saw it
+all bright and clear-cut, hard and silent, under the dawn of that last
+great day. . . .
+
+And strangest of all is it to hold my wife's hand again, and to think
+that I have counted her, and that she has counted me, among the dead.
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+***** This file should be named 36.txt or 36.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/36/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/pom.xml
+++ b/jet/tf-idf/pom.xml
@@ -27,17 +27,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <directory>../wordcount/src/main/resources</directory>
-            </resource>
-        </resources>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>

--- a/jet/tf-idf/src/main/resources/books/a-tale-of-two-cities.txt
+++ b/jet/tf-idf/src/main/resources/books/a-tale-of-two-cities.txt
@@ -1,0 +1,16272 @@
+﻿The Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: A Tale of Two Cities
+       A Story of the French Revolution
+
+Author: Charles Dickens
+
+Release Date: January, 1994 [EBook #98]
+Posting Date: November 28, 2009
+Last Updated: September 25, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+
+
+
+Produced by Judith Boss
+
+
+
+
+
+
+
+
+A TALE OF TWO CITIES
+
+A STORY OF THE FRENCH REVOLUTION
+
+By Charles Dickens
+
+
+CONTENTS
+
+
+     Book the First--Recalled to Life
+
+     Chapter I      The Period
+     Chapter II     The Mail
+     Chapter III    The Night Shadows
+     Chapter IV     The Preparation
+     Chapter V      The Wine-shop
+     Chapter VI     The Shoemaker
+
+
+     Book the Second--the Golden Thread
+
+     Chapter I      Five Years Later
+     Chapter II     A Sight
+     Chapter III    A Disappointment
+     Chapter IV     Congratulatory
+     Chapter V      The Jackal
+     Chapter VI     Hundreds of People
+     Chapter VII    Monseigneur in Town
+     Chapter VIII   Monseigneur in the Country
+     Chapter IX     The Gorgon’s Head
+     Chapter X      Two Promises
+     Chapter XI     A Companion Picture
+     Chapter XII    The Fellow of Delicacy
+     Chapter XIII   The Fellow of no Delicacy
+     Chapter XIV    The Honest Tradesman
+     Chapter XV     Knitting
+     Chapter XVI    Still Knitting
+     Chapter XVII   One Night
+     Chapter XVIII  Nine Days
+     Chapter XIX    An Opinion
+     Chapter XX     A Plea
+     Chapter XXI    Echoing Footsteps
+     Chapter XXII   The Sea Still Rises
+     Chapter XXIII  Fire Rises
+     Chapter XXIV   Drawn to the Loadstone Rock
+
+
+     Book the Third--the Track of a Storm
+
+     Chapter I      In Secret
+     Chapter II     The Grindstone
+     Chapter III    The Shadow
+     Chapter IV     Calm in Storm
+     Chapter V      The Wood-sawyer
+     Chapter VI     Triumph
+     Chapter VII    A Knock at the Door
+     Chapter VIII   A Hand at Cards
+     Chapter IX     The Game Made
+     Chapter X      The Substance of the Shadow
+     Chapter XI     Dusk
+     Chapter XII    Darkness
+     Chapter XIII   Fifty-two
+     Chapter XIV    The Knitting Done
+     Chapter XV     The Footsteps Die Out For Ever
+
+
+
+
+
+Book the First--Recalled to Life
+
+
+
+
+I. The Period
+
+
+It was the best of times,
+it was the worst of times,
+it was the age of wisdom,
+it was the age of foolishness,
+it was the epoch of belief,
+it was the epoch of incredulity,
+it was the season of Light,
+it was the season of Darkness,
+it was the spring of hope,
+it was the winter of despair,
+we had everything before us,
+we had nothing before us,
+we were all going direct to Heaven,
+we were all going direct the other way--
+in short, the period was so far like the present period, that some of
+its noisiest authorities insisted on its being received, for good or for
+evil, in the superlative degree of comparison only.
+
+There were a king with a large jaw and a queen with a plain face, on the
+throne of England; there were a king with a large jaw and a queen with
+a fair face, on the throne of France. In both countries it was clearer
+than crystal to the lords of the State preserves of loaves and fishes,
+that things in general were settled for ever.
+
+It was the year of Our Lord one thousand seven hundred and seventy-five.
+Spiritual revelations were conceded to England at that favoured period,
+as at this. Mrs. Southcott had recently attained her five-and-twentieth
+blessed birthday, of whom a prophetic private in the Life Guards had
+heralded the sublime appearance by announcing that arrangements were
+made for the swallowing up of London and Westminster. Even the Cock-lane
+ghost had been laid only a round dozen of years, after rapping out its
+messages, as the spirits of this very year last past (supernaturally
+deficient in originality) rapped out theirs. Mere messages in the
+earthly order of events had lately come to the English Crown and People,
+from a congress of British subjects in America: which, strange
+to relate, have proved more important to the human race than any
+communications yet received through any of the chickens of the Cock-lane
+brood.
+
+France, less favoured on the whole as to matters spiritual than her
+sister of the shield and trident, rolled with exceeding smoothness down
+hill, making paper money and spending it. Under the guidance of her
+Christian pastors, she entertained herself, besides, with such humane
+achievements as sentencing a youth to have his hands cut off, his tongue
+torn out with pincers, and his body burned alive, because he had not
+kneeled down in the rain to do honour to a dirty procession of monks
+which passed within his view, at a distance of some fifty or sixty
+yards. It is likely enough that, rooted in the woods of France and
+Norway, there were growing trees, when that sufferer was put to death,
+already marked by the Woodman, Fate, to come down and be sawn into
+boards, to make a certain movable framework with a sack and a knife in
+it, terrible in history. It is likely enough that in the rough outhouses
+of some tillers of the heavy lands adjacent to Paris, there were
+sheltered from the weather that very day, rude carts, bespattered with
+rustic mire, snuffed about by pigs, and roosted in by poultry, which
+the Farmer, Death, had already set apart to be his tumbrils of
+the Revolution. But that Woodman and that Farmer, though they work
+unceasingly, work silently, and no one heard them as they went about
+with muffled tread: the rather, forasmuch as to entertain any suspicion
+that they were awake, was to be atheistical and traitorous.
+
+In England, there was scarcely an amount of order and protection to
+justify much national boasting. Daring burglaries by armed men, and
+highway robberies, took place in the capital itself every night;
+families were publicly cautioned not to go out of town without removing
+their furniture to upholsterers’ warehouses for security; the highwayman
+in the dark was a City tradesman in the light, and, being recognised and
+challenged by his fellow-tradesman whom he stopped in his character of
+“the Captain,” gallantly shot him through the head and rode away; the
+mail was waylaid by seven robbers, and the guard shot three dead, and
+then got shot dead himself by the other four, “in consequence of the
+failure of his ammunition:” after which the mail was robbed in peace;
+that magnificent potentate, the Lord Mayor of London, was made to stand
+and deliver on Turnham Green, by one highwayman, who despoiled the
+illustrious creature in sight of all his retinue; prisoners in London
+gaols fought battles with their turnkeys, and the majesty of the law
+fired blunderbusses in among them, loaded with rounds of shot and ball;
+thieves snipped off diamond crosses from the necks of noble lords at
+Court drawing-rooms; musketeers went into St. Giles’s, to search
+for contraband goods, and the mob fired on the musketeers, and the
+musketeers fired on the mob, and nobody thought any of these occurrences
+much out of the common way. In the midst of them, the hangman, ever busy
+and ever worse than useless, was in constant requisition; now, stringing
+up long rows of miscellaneous criminals; now, hanging a housebreaker on
+Saturday who had been taken on Tuesday; now, burning people in the
+hand at Newgate by the dozen, and now burning pamphlets at the door of
+Westminster Hall; to-day, taking the life of an atrocious murderer,
+and to-morrow of a wretched pilferer who had robbed a farmer’s boy of
+sixpence.
+
+All these things, and a thousand like them, came to pass in and close
+upon the dear old year one thousand seven hundred and seventy-five.
+Environed by them, while the Woodman and the Farmer worked unheeded,
+those two of the large jaws, and those other two of the plain and the
+fair faces, trod with stir enough, and carried their divine rights
+with a high hand. Thus did the year one thousand seven hundred
+and seventy-five conduct their Greatnesses, and myriads of small
+creatures--the creatures of this chronicle among the rest--along the
+roads that lay before them.
+
+
+
+
+II. The Mail
+
+
+It was the Dover road that lay, on a Friday night late in November,
+before the first of the persons with whom this history has business.
+The Dover road lay, as to him, beyond the Dover mail, as it lumbered up
+Shooter’s Hill. He walked up hill in the mire by the side of the mail,
+as the rest of the passengers did; not because they had the least relish
+for walking exercise, under the circumstances, but because the hill,
+and the harness, and the mud, and the mail, were all so heavy, that the
+horses had three times already come to a stop, besides once drawing the
+coach across the road, with the mutinous intent of taking it back
+to Blackheath. Reins and whip and coachman and guard, however, in
+combination, had read that article of war which forbade a purpose
+otherwise strongly in favour of the argument, that some brute animals
+are endued with Reason; and the team had capitulated and returned to
+their duty.
+
+With drooping heads and tremulous tails, they mashed their way through
+the thick mud, floundering and stumbling between whiles, as if they were
+falling to pieces at the larger joints. As often as the driver rested
+them and brought them to a stand, with a wary “Wo-ho! so-ho-then!” the
+near leader violently shook his head and everything upon it--like an
+unusually emphatic horse, denying that the coach could be got up the
+hill. Whenever the leader made this rattle, the passenger started, as a
+nervous passenger might, and was disturbed in mind.
+
+There was a steaming mist in all the hollows, and it had roamed in its
+forlornness up the hill, like an evil spirit, seeking rest and finding
+none. A clammy and intensely cold mist, it made its slow way through the
+air in ripples that visibly followed and overspread one another, as the
+waves of an unwholesome sea might do. It was dense enough to shut out
+everything from the light of the coach-lamps but these its own workings,
+and a few yards of road; and the reek of the labouring horses steamed
+into it, as if they had made it all.
+
+Two other passengers, besides the one, were plodding up the hill by the
+side of the mail. All three were wrapped to the cheekbones and over the
+ears, and wore jack-boots. Not one of the three could have said, from
+anything he saw, what either of the other two was like; and each was
+hidden under almost as many wrappers from the eyes of the mind, as from
+the eyes of the body, of his two companions. In those days, travellers
+were very shy of being confidential on a short notice, for anybody on
+the road might be a robber or in league with robbers. As to the latter,
+when every posting-house and ale-house could produce somebody in
+“the Captain’s” pay, ranging from the landlord to the lowest stable
+non-descript, it was the likeliest thing upon the cards. So the guard
+of the Dover mail thought to himself, that Friday night in November, one
+thousand seven hundred and seventy-five, lumbering up Shooter’s Hill, as
+he stood on his own particular perch behind the mail, beating his feet,
+and keeping an eye and a hand on the arm-chest before him, where a
+loaded blunderbuss lay at the top of six or eight loaded horse-pistols,
+deposited on a substratum of cutlass.
+
+The Dover mail was in its usual genial position that the guard suspected
+the passengers, the passengers suspected one another and the guard, they
+all suspected everybody else, and the coachman was sure of nothing but
+the horses; as to which cattle he could with a clear conscience have
+taken his oath on the two Testaments that they were not fit for the
+journey.
+
+“Wo-ho!” said the coachman. “So, then! One more pull and you’re at the
+top and be damned to you, for I have had trouble enough to get you to
+it!--Joe!”
+
+“Halloa!” the guard replied.
+
+“What o’clock do you make it, Joe?”
+
+“Ten minutes, good, past eleven.”
+
+“My blood!” ejaculated the vexed coachman, “and not atop of Shooter’s
+yet! Tst! Yah! Get on with you!”
+
+The emphatic horse, cut short by the whip in a most decided negative,
+made a decided scramble for it, and the three other horses followed
+suit. Once more, the Dover mail struggled on, with the jack-boots of its
+passengers squashing along by its side. They had stopped when the coach
+stopped, and they kept close company with it. If any one of the three
+had had the hardihood to propose to another to walk on a little ahead
+into the mist and darkness, he would have put himself in a fair way of
+getting shot instantly as a highwayman.
+
+The last burst carried the mail to the summit of the hill. The horses
+stopped to breathe again, and the guard got down to skid the wheel for
+the descent, and open the coach-door to let the passengers in.
+
+“Tst! Joe!” cried the coachman in a warning voice, looking down from his
+box.
+
+“What do you say, Tom?”
+
+They both listened.
+
+“I say a horse at a canter coming up, Joe.”
+
+“_I_ say a horse at a gallop, Tom,” returned the guard, leaving his hold
+of the door, and mounting nimbly to his place. “Gentlemen! In the king’s
+name, all of you!”
+
+With this hurried adjuration, he cocked his blunderbuss, and stood on
+the offensive.
+
+The passenger booked by this history, was on the coach-step, getting in;
+the two other passengers were close behind him, and about to follow. He
+remained on the step, half in the coach and half out of; they remained
+in the road below him. They all looked from the coachman to the guard,
+and from the guard to the coachman, and listened. The coachman looked
+back and the guard looked back, and even the emphatic leader pricked up
+his ears and looked back, without contradicting.
+
+The stillness consequent on the cessation of the rumbling and labouring
+of the coach, added to the stillness of the night, made it very quiet
+indeed. The panting of the horses communicated a tremulous motion to
+the coach, as if it were in a state of agitation. The hearts of the
+passengers beat loud enough perhaps to be heard; but at any rate, the
+quiet pause was audibly expressive of people out of breath, and holding
+the breath, and having the pulses quickened by expectation.
+
+The sound of a horse at a gallop came fast and furiously up the hill.
+
+“So-ho!” the guard sang out, as loud as he could roar. “Yo there! Stand!
+I shall fire!”
+
+The pace was suddenly checked, and, with much splashing and floundering,
+a man’s voice called from the mist, “Is that the Dover mail?”
+
+“Never you mind what it is!” the guard retorted. “What are you?”
+
+“_Is_ that the Dover mail?”
+
+“Why do you want to know?”
+
+“I want a passenger, if it is.”
+
+“What passenger?”
+
+“Mr. Jarvis Lorry.”
+
+Our booked passenger showed in a moment that it was his name. The guard,
+the coachman, and the two other passengers eyed him distrustfully.
+
+“Keep where you are,” the guard called to the voice in the mist,
+“because, if I should make a mistake, it could never be set right in
+your lifetime. Gentleman of the name of Lorry answer straight.”
+
+“What is the matter?” asked the passenger, then, with mildly quavering
+speech. “Who wants me? Is it Jerry?”
+
+(“I don’t like Jerry’s voice, if it is Jerry,” growled the guard to
+himself. “He’s hoarser than suits me, is Jerry.”)
+
+“Yes, Mr. Lorry.”
+
+“What is the matter?”
+
+“A despatch sent after you from over yonder. T. and Co.”
+
+“I know this messenger, guard,” said Mr. Lorry, getting down into the
+road--assisted from behind more swiftly than politely by the other two
+passengers, who immediately scrambled into the coach, shut the door, and
+pulled up the window. “He may come close; there’s nothing wrong.”
+
+“I hope there ain’t, but I can’t make so ‘Nation sure of that,” said the
+guard, in gruff soliloquy. “Hallo you!”
+
+“Well! And hallo you!” said Jerry, more hoarsely than before.
+
+“Come on at a footpace! d’ye mind me? And if you’ve got holsters to that
+saddle o’ yourn, don’t let me see your hand go nigh ‘em. For I’m a devil
+at a quick mistake, and when I make one it takes the form of Lead. So
+now let’s look at you.”
+
+The figures of a horse and rider came slowly through the eddying mist,
+and came to the side of the mail, where the passenger stood. The rider
+stooped, and, casting up his eyes at the guard, handed the passenger
+a small folded paper. The rider’s horse was blown, and both horse and
+rider were covered with mud, from the hoofs of the horse to the hat of
+the man.
+
+“Guard!” said the passenger, in a tone of quiet business confidence.
+
+The watchful guard, with his right hand at the stock of his raised
+blunderbuss, his left at the barrel, and his eye on the horseman,
+answered curtly, “Sir.”
+
+“There is nothing to apprehend. I belong to Tellson’s Bank. You must
+know Tellson’s Bank in London. I am going to Paris on business. A crown
+to drink. I may read this?”
+
+“If so be as you’re quick, sir.”
+
+He opened it in the light of the coach-lamp on that side, and
+read--first to himself and then aloud: “‘Wait at Dover for Mam’selle.’
+It’s not long, you see, guard. Jerry, say that my answer was, RECALLED
+TO LIFE.”
+
+Jerry started in his saddle. “That’s a Blazing strange answer, too,”
+ said he, at his hoarsest.
+
+“Take that message back, and they will know that I received this, as
+well as if I wrote. Make the best of your way. Good night.”
+
+With those words the passenger opened the coach-door and got in; not at
+all assisted by his fellow-passengers, who had expeditiously secreted
+their watches and purses in their boots, and were now making a general
+pretence of being asleep. With no more definite purpose than to escape
+the hazard of originating any other kind of action.
+
+The coach lumbered on again, with heavier wreaths of mist closing round
+it as it began the descent. The guard soon replaced his blunderbuss
+in his arm-chest, and, having looked to the rest of its contents, and
+having looked to the supplementary pistols that he wore in his belt,
+looked to a smaller chest beneath his seat, in which there were a
+few smith’s tools, a couple of torches, and a tinder-box. For he was
+furnished with that completeness that if the coach-lamps had been blown
+and stormed out, which did occasionally happen, he had only to shut
+himself up inside, keep the flint and steel sparks well off the straw,
+and get a light with tolerable safety and ease (if he were lucky) in
+five minutes.
+
+“Tom!” softly over the coach roof.
+
+“Hallo, Joe.”
+
+“Did you hear the message?”
+
+“I did, Joe.”
+
+“What did you make of it, Tom?”
+
+“Nothing at all, Joe.”
+
+“That’s a coincidence, too,” the guard mused, “for I made the same of it
+myself.”
+
+Jerry, left alone in the mist and darkness, dismounted meanwhile, not
+only to ease his spent horse, but to wipe the mud from his face, and
+shake the wet out of his hat-brim, which might be capable of
+holding about half a gallon. After standing with the bridle over his
+heavily-splashed arm, until the wheels of the mail were no longer within
+hearing and the night was quite still again, he turned to walk down the
+hill.
+
+“After that there gallop from Temple Bar, old lady, I won’t trust your
+fore-legs till I get you on the level,” said this hoarse messenger,
+glancing at his mare. “‘Recalled to life.’ That’s a Blazing strange
+message. Much of that wouldn’t do for you, Jerry! I say, Jerry! You’d
+be in a Blazing bad way, if recalling to life was to come into fashion,
+Jerry!”
+
+
+
+
+III. The Night Shadows
+
+
+A wonderful fact to reflect upon, that every human creature is
+constituted to be that profound secret and mystery to every other. A
+solemn consideration, when I enter a great city by night, that every
+one of those darkly clustered houses encloses its own secret; that every
+room in every one of them encloses its own secret; that every beating
+heart in the hundreds of thousands of breasts there, is, in some of
+its imaginings, a secret to the heart nearest it! Something of the
+awfulness, even of Death itself, is referable to this. No more can I
+turn the leaves of this dear book that I loved, and vainly hope in time
+to read it all. No more can I look into the depths of this unfathomable
+water, wherein, as momentary lights glanced into it, I have had glimpses
+of buried treasure and other things submerged. It was appointed that the
+book should shut with a spring, for ever and for ever, when I had read
+but a page. It was appointed that the water should be locked in an
+eternal frost, when the light was playing on its surface, and I stood
+in ignorance on the shore. My friend is dead, my neighbour is dead,
+my love, the darling of my soul, is dead; it is the inexorable
+consolidation and perpetuation of the secret that was always in that
+individuality, and which I shall carry in mine to my life’s end. In
+any of the burial-places of this city through which I pass, is there
+a sleeper more inscrutable than its busy inhabitants are, in their
+innermost personality, to me, or than I am to them?
+
+As to this, his natural and not to be alienated inheritance, the
+messenger on horseback had exactly the same possessions as the King, the
+first Minister of State, or the richest merchant in London. So with the
+three passengers shut up in the narrow compass of one lumbering old mail
+coach; they were mysteries to one another, as complete as if each had
+been in his own coach and six, or his own coach and sixty, with the
+breadth of a county between him and the next.
+
+The messenger rode back at an easy trot, stopping pretty often at
+ale-houses by the way to drink, but evincing a tendency to keep his
+own counsel, and to keep his hat cocked over his eyes. He had eyes that
+assorted very well with that decoration, being of a surface black, with
+no depth in the colour or form, and much too near together--as if they
+were afraid of being found out in something, singly, if they kept too
+far apart. They had a sinister expression, under an old cocked-hat like
+a three-cornered spittoon, and over a great muffler for the chin and
+throat, which descended nearly to the wearer’s knees. When he stopped
+for drink, he moved this muffler with his left hand, only while he
+poured his liquor in with his right; as soon as that was done, he
+muffled again.
+
+“No, Jerry, no!” said the messenger, harping on one theme as he rode.
+“It wouldn’t do for you, Jerry. Jerry, you honest tradesman, it wouldn’t
+suit _your_ line of business! Recalled--! Bust me if I don’t think he’d
+been a drinking!”
+
+His message perplexed his mind to that degree that he was fain, several
+times, to take off his hat to scratch his head. Except on the crown,
+which was raggedly bald, he had stiff, black hair, standing jaggedly all
+over it, and growing down hill almost to his broad, blunt nose. It was
+so like Smith’s work, so much more like the top of a strongly spiked
+wall than a head of hair, that the best of players at leap-frog might
+have declined him, as the most dangerous man in the world to go over.
+
+While he trotted back with the message he was to deliver to the night
+watchman in his box at the door of Tellson’s Bank, by Temple Bar, who
+was to deliver it to greater authorities within, the shadows of the
+night took such shapes to him as arose out of the message, and took such
+shapes to the mare as arose out of _her_ private topics of uneasiness.
+They seemed to be numerous, for she shied at every shadow on the road.
+
+What time, the mail-coach lumbered, jolted, rattled, and bumped upon
+its tedious way, with its three fellow-inscrutables inside. To whom,
+likewise, the shadows of the night revealed themselves, in the forms
+their dozing eyes and wandering thoughts suggested.
+
+Tellson’s Bank had a run upon it in the mail. As the bank
+passenger--with an arm drawn through the leathern strap, which did what
+lay in it to keep him from pounding against the next passenger,
+and driving him into his corner, whenever the coach got a special
+jolt--nodded in his place, with half-shut eyes, the little
+coach-windows, and the coach-lamp dimly gleaming through them, and the
+bulky bundle of opposite passenger, became the bank, and did a great
+stroke of business. The rattle of the harness was the chink of money,
+and more drafts were honoured in five minutes than even Tellson’s, with
+all its foreign and home connection, ever paid in thrice the time. Then
+the strong-rooms underground, at Tellson’s, with such of their valuable
+stores and secrets as were known to the passenger (and it was not a
+little that he knew about them), opened before him, and he went in among
+them with the great keys and the feebly-burning candle, and found them
+safe, and strong, and sound, and still, just as he had last seen them.
+
+But, though the bank was almost always with him, and though the coach
+(in a confused way, like the presence of pain under an opiate) was
+always with him, there was another current of impression that never
+ceased to run, all through the night. He was on his way to dig some one
+out of a grave.
+
+Now, which of the multitude of faces that showed themselves before him
+was the true face of the buried person, the shadows of the night did
+not indicate; but they were all the faces of a man of five-and-forty by
+years, and they differed principally in the passions they expressed,
+and in the ghastliness of their worn and wasted state. Pride, contempt,
+defiance, stubbornness, submission, lamentation, succeeded one another;
+so did varieties of sunken cheek, cadaverous colour, emaciated hands
+and figures. But the face was in the main one face, and every head was
+prematurely white. A hundred times the dozing passenger inquired of this
+spectre:
+
+“Buried how long?”
+
+The answer was always the same: “Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+“You know that you are recalled to life?”
+
+“They tell me so.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+“Shall I show her to you? Will you come and see her?”
+
+The answers to this question were various and contradictory. Sometimes
+the broken reply was, “Wait! It would kill me if I saw her too soon.”
+ Sometimes, it was given in a tender rain of tears, and then it was,
+“Take me to her.” Sometimes it was staring and bewildered, and then it
+was, “I don’t know her. I don’t understand.”
+
+After such imaginary discourse, the passenger in his fancy would dig,
+and dig, dig--now with a spade, now with a great key, now with his
+hands--to dig this wretched creature out. Got out at last, with earth
+hanging about his face and hair, he would suddenly fan away to dust. The
+passenger would then start to himself, and lower the window, to get the
+reality of mist and rain on his cheek.
+
+Yet even when his eyes were opened on the mist and rain, on the moving
+patch of light from the lamps, and the hedge at the roadside retreating
+by jerks, the night shadows outside the coach would fall into the train
+of the night shadows within. The real Banking-house by Temple Bar, the
+real business of the past day, the real strong rooms, the real express
+sent after him, and the real message returned, would all be there. Out
+of the midst of them, the ghostly face would rise, and he would accost
+it again.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“I hope you care to live?”
+
+“I can’t say.”
+
+Dig--dig--dig--until an impatient movement from one of the two
+passengers would admonish him to pull up the window, draw his arm
+securely through the leathern strap, and speculate upon the two
+slumbering forms, until his mind lost its hold of them, and they again
+slid away into the bank and the grave.
+
+“Buried how long?”
+
+“Almost eighteen years.”
+
+“You had abandoned all hope of being dug out?”
+
+“Long ago.”
+
+The words were still in his hearing as just spoken--distinctly in
+his hearing as ever spoken words had been in his life--when the weary
+passenger started to the consciousness of daylight, and found that the
+shadows of the night were gone.
+
+He lowered the window, and looked out at the rising sun. There was a
+ridge of ploughed land, with a plough upon it where it had been left
+last night when the horses were unyoked; beyond, a quiet coppice-wood,
+in which many leaves of burning red and golden yellow still remained
+upon the trees. Though the earth was cold and wet, the sky was clear,
+and the sun rose bright, placid, and beautiful.
+
+“Eighteen years!” said the passenger, looking at the sun. “Gracious
+Creator of day! To be buried alive for eighteen years!”
+
+
+
+
+IV. The Preparation
+
+
+When the mail got successfully to Dover, in the course of the forenoon,
+the head drawer at the Royal George Hotel opened the coach-door as his
+custom was. He did it with some flourish of ceremony, for a mail journey
+from London in winter was an achievement to congratulate an adventurous
+traveller upon.
+
+By that time, there was only one adventurous traveller left be
+congratulated: for the two others had been set down at their respective
+roadside destinations. The mildewy inside of the coach, with its damp
+and dirty straw, its disagreeable smell, and its obscurity, was rather
+like a larger dog-kennel. Mr. Lorry, the passenger, shaking himself out
+of it in chains of straw, a tangle of shaggy wrapper, flapping hat, and
+muddy legs, was rather like a larger sort of dog.
+
+“There will be a packet to Calais, tomorrow, drawer?”
+
+“Yes, sir, if the weather holds and the wind sets tolerable fair. The
+tide will serve pretty nicely at about two in the afternoon, sir. Bed,
+sir?”
+
+“I shall not go to bed till night; but I want a bedroom, and a barber.”
+
+“And then breakfast, sir? Yes, sir. That way, sir, if you please.
+Show Concord! Gentleman’s valise and hot water to Concord. Pull off
+gentleman’s boots in Concord. (You will find a fine sea-coal fire, sir.)
+Fetch barber to Concord. Stir about there, now, for Concord!”
+
+The Concord bed-chamber being always assigned to a passenger by the
+mail, and passengers by the mail being always heavily wrapped up from
+head to foot, the room had the odd interest for the establishment of the
+Royal George, that although but one kind of man was seen to go into it,
+all kinds and varieties of men came out of it. Consequently, another
+drawer, and two porters, and several maids and the landlady, were all
+loitering by accident at various points of the road between the Concord
+and the coffee-room, when a gentleman of sixty, formally dressed in a
+brown suit of clothes, pretty well worn, but very well kept, with large
+square cuffs and large flaps to the pockets, passed along on his way to
+his breakfast.
+
+The coffee-room had no other occupant, that forenoon, than the gentleman
+in brown. His breakfast-table was drawn before the fire, and as he sat,
+with its light shining on him, waiting for the meal, he sat so still,
+that he might have been sitting for his portrait.
+
+Very orderly and methodical he looked, with a hand on each knee, and a
+loud watch ticking a sonorous sermon under his flapped waist-coat,
+as though it pitted its gravity and longevity against the levity and
+evanescence of the brisk fire. He had a good leg, and was a little vain
+of it, for his brown stockings fitted sleek and close, and were of a
+fine texture; his shoes and buckles, too, though plain, were trim. He
+wore an odd little sleek crisp flaxen wig, setting very close to his
+head: which wig, it is to be presumed, was made of hair, but which
+looked far more as though it were spun from filaments of silk or glass.
+His linen, though not of a fineness in accordance with his stockings,
+was as white as the tops of the waves that broke upon the neighbouring
+beach, or the specks of sail that glinted in the sunlight far at sea. A
+face habitually suppressed and quieted, was still lighted up under the
+quaint wig by a pair of moist bright eyes that it must have cost
+their owner, in years gone by, some pains to drill to the composed and
+reserved expression of Tellson’s Bank. He had a healthy colour in his
+cheeks, and his face, though lined, bore few traces of anxiety.
+But, perhaps the confidential bachelor clerks in Tellson’s Bank were
+principally occupied with the cares of other people; and perhaps
+second-hand cares, like second-hand clothes, come easily off and on.
+
+Completing his resemblance to a man who was sitting for his portrait,
+Mr. Lorry dropped off to sleep. The arrival of his breakfast roused him,
+and he said to the drawer, as he moved his chair to it:
+
+“I wish accommodation prepared for a young lady who may come here at any
+time to-day. She may ask for Mr. Jarvis Lorry, or she may only ask for a
+gentleman from Tellson’s Bank. Please to let me know.”
+
+“Yes, sir. Tellson’s Bank in London, sir?”
+
+“Yes.”
+
+“Yes, sir. We have oftentimes the honour to entertain your gentlemen in
+their travelling backwards and forwards betwixt London and Paris, sir. A
+vast deal of travelling, sir, in Tellson and Company’s House.”
+
+“Yes. We are quite a French House, as well as an English one.”
+
+“Yes, sir. Not much in the habit of such travelling yourself, I think,
+sir?”
+
+“Not of late years. It is fifteen years since we--since I--came last
+from France.”
+
+“Indeed, sir? That was before my time here, sir. Before our people’s
+time here, sir. The George was in other hands at that time, sir.”
+
+“I believe so.”
+
+“But I would hold a pretty wager, sir, that a House like Tellson and
+Company was flourishing, a matter of fifty, not to speak of fifteen
+years ago?”
+
+“You might treble that, and say a hundred and fifty, yet not be far from
+the truth.”
+
+“Indeed, sir!”
+
+Rounding his mouth and both his eyes, as he stepped backward from the
+table, the waiter shifted his napkin from his right arm to his left,
+dropped into a comfortable attitude, and stood surveying the guest while
+he ate and drank, as from an observatory or watchtower. According to the
+immemorial usage of waiters in all ages.
+
+When Mr. Lorry had finished his breakfast, he went out for a stroll on
+the beach. The little narrow, crooked town of Dover hid itself away
+from the beach, and ran its head into the chalk cliffs, like a marine
+ostrich. The beach was a desert of heaps of sea and stones tumbling
+wildly about, and the sea did what it liked, and what it liked was
+destruction. It thundered at the town, and thundered at the cliffs, and
+brought the coast down, madly. The air among the houses was of so strong
+a piscatory flavour that one might have supposed sick fish went up to be
+dipped in it, as sick people went down to be dipped in the sea. A little
+fishing was done in the port, and a quantity of strolling about by
+night, and looking seaward: particularly at those times when the tide
+made, and was near flood. Small tradesmen, who did no business whatever,
+sometimes unaccountably realised large fortunes, and it was remarkable
+that nobody in the neighbourhood could endure a lamplighter.
+
+As the day declined into the afternoon, and the air, which had been
+at intervals clear enough to allow the French coast to be seen, became
+again charged with mist and vapour, Mr. Lorry’s thoughts seemed to cloud
+too. When it was dark, and he sat before the coffee-room fire, awaiting
+his dinner as he had awaited his breakfast, his mind was busily digging,
+digging, digging, in the live red coals.
+
+A bottle of good claret after dinner does a digger in the red coals no
+harm, otherwise than as it has a tendency to throw him out of work.
+Mr. Lorry had been idle a long time, and had just poured out his last
+glassful of wine with as complete an appearance of satisfaction as is
+ever to be found in an elderly gentleman of a fresh complexion who has
+got to the end of a bottle, when a rattling of wheels came up the narrow
+street, and rumbled into the inn-yard.
+
+He set down his glass untouched. “This is Mam’selle!” said he.
+
+In a very few minutes the waiter came in to announce that Miss Manette
+had arrived from London, and would be happy to see the gentleman from
+Tellson’s.
+
+“So soon?”
+
+Miss Manette had taken some refreshment on the road, and required none
+then, and was extremely anxious to see the gentleman from Tellson’s
+immediately, if it suited his pleasure and convenience.
+
+The gentleman from Tellson’s had nothing left for it but to empty his
+glass with an air of stolid desperation, settle his odd little flaxen
+wig at the ears, and follow the waiter to Miss Manette’s apartment.
+It was a large, dark room, furnished in a funereal manner with black
+horsehair, and loaded with heavy dark tables. These had been oiled and
+oiled, until the two tall candles on the table in the middle of the room
+were gloomily reflected on every leaf; as if _they_ were buried, in deep
+graves of black mahogany, and no light to speak of could be expected
+from them until they were dug out.
+
+The obscurity was so difficult to penetrate that Mr. Lorry, picking his
+way over the well-worn Turkey carpet, supposed Miss Manette to be, for
+the moment, in some adjacent room, until, having got past the two tall
+candles, he saw standing to receive him by the table between them and
+the fire, a young lady of not more than seventeen, in a riding-cloak,
+and still holding her straw travelling-hat by its ribbon in her hand. As
+his eyes rested on a short, slight, pretty figure, a quantity of golden
+hair, a pair of blue eyes that met his own with an inquiring look, and
+a forehead with a singular capacity (remembering how young and smooth
+it was), of rifting and knitting itself into an expression that was
+not quite one of perplexity, or wonder, or alarm, or merely of a bright
+fixed attention, though it included all the four expressions--as his
+eyes rested on these things, a sudden vivid likeness passed before him,
+of a child whom he had held in his arms on the passage across that very
+Channel, one cold time, when the hail drifted heavily and the sea ran
+high. The likeness passed away, like a breath along the surface of
+the gaunt pier-glass behind her, on the frame of which, a hospital
+procession of negro cupids, several headless and all cripples, were
+offering black baskets of Dead Sea fruit to black divinities of the
+feminine gender--and he made his formal bow to Miss Manette.
+
+“Pray take a seat, sir.” In a very clear and pleasant young voice; a
+little foreign in its accent, but a very little indeed.
+
+“I kiss your hand, miss,” said Mr. Lorry, with the manners of an earlier
+date, as he made his formal bow again, and took his seat.
+
+“I received a letter from the Bank, sir, yesterday, informing me that
+some intelligence--or discovery--”
+
+“The word is not material, miss; either word will do.”
+
+“--respecting the small property of my poor father, whom I never saw--so
+long dead--”
+
+Mr. Lorry moved in his chair, and cast a troubled look towards the
+hospital procession of negro cupids. As if _they_ had any help for
+anybody in their absurd baskets!
+
+“--rendered it necessary that I should go to Paris, there to communicate
+with a gentleman of the Bank, so good as to be despatched to Paris for
+the purpose.”
+
+“Myself.”
+
+“As I was prepared to hear, sir.”
+
+She curtseyed to him (young ladies made curtseys in those days), with a
+pretty desire to convey to him that she felt how much older and wiser he
+was than she. He made her another bow.
+
+“I replied to the Bank, sir, that as it was considered necessary, by
+those who know, and who are so kind as to advise me, that I should go to
+France, and that as I am an orphan and have no friend who could go with
+me, I should esteem it highly if I might be permitted to place myself,
+during the journey, under that worthy gentleman’s protection. The
+gentleman had left London, but I think a messenger was sent after him to
+beg the favour of his waiting for me here.”
+
+“I was happy,” said Mr. Lorry, “to be entrusted with the charge. I shall
+be more happy to execute it.”
+
+“Sir, I thank you indeed. I thank you very gratefully. It was told me
+by the Bank that the gentleman would explain to me the details of the
+business, and that I must prepare myself to find them of a surprising
+nature. I have done my best to prepare myself, and I naturally have a
+strong and eager interest to know what they are.”
+
+“Naturally,” said Mr. Lorry. “Yes--I--”
+
+After a pause, he added, again settling the crisp flaxen wig at the
+ears, “It is very difficult to begin.”
+
+He did not begin, but, in his indecision, met her glance. The young
+forehead lifted itself into that singular expression--but it was pretty
+and characteristic, besides being singular--and she raised her hand,
+as if with an involuntary action she caught at, or stayed some passing
+shadow.
+
+“Are you quite a stranger to me, sir?”
+
+“Am I not?” Mr. Lorry opened his hands, and extended them outwards with
+an argumentative smile.
+
+Between the eyebrows and just over the little feminine nose, the line of
+which was as delicate and fine as it was possible to be, the expression
+deepened itself as she took her seat thoughtfully in the chair by which
+she had hitherto remained standing. He watched her as she mused, and the
+moment she raised her eyes again, went on:
+
+“In your adopted country, I presume, I cannot do better than address you
+as a young English lady, Miss Manette?”
+
+“If you please, sir.”
+
+“Miss Manette, I am a man of business. I have a business charge to
+acquit myself of. In your reception of it, don’t heed me any more than
+if I was a speaking machine--truly, I am not much else. I will, with
+your leave, relate to you, miss, the story of one of our customers.”
+
+“Story!”
+
+He seemed wilfully to mistake the word she had repeated, when he added,
+in a hurry, “Yes, customers; in the banking business we usually call
+our connection our customers. He was a French gentleman; a scientific
+gentleman; a man of great acquirements--a Doctor.”
+
+“Not of Beauvais?”
+
+“Why, yes, of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of Beauvais. Like Monsieur Manette, your father, the
+gentleman was of repute in Paris. I had the honour of knowing him there.
+Our relations were business relations, but confidential. I was at that
+time in our French House, and had been--oh! twenty years.”
+
+“At that time--I may ask, at what time, sir?”
+
+“I speak, miss, of twenty years ago. He married--an English lady--and
+I was one of the trustees. His affairs, like the affairs of many other
+French gentlemen and French families, were entirely in Tellson’s hands.
+In a similar way I am, or I have been, trustee of one kind or other for
+scores of our customers. These are mere business relations, miss;
+there is no friendship in them, no particular interest, nothing like
+sentiment. I have passed from one to another, in the course of my
+business life, just as I pass from one of our customers to another in
+the course of my business day; in short, I have no feelings; I am a mere
+machine. To go on--”
+
+“But this is my father’s story, sir; and I begin to think”--the
+curiously roughened forehead was very intent upon him--“that when I was
+left an orphan through my mother’s surviving my father only two years,
+it was you who brought me to England. I am almost sure it was you.”
+
+Mr. Lorry took the hesitating little hand that confidingly advanced
+to take his, and he put it with some ceremony to his lips. He then
+conducted the young lady straightway to her chair again, and, holding
+the chair-back with his left hand, and using his right by turns to rub
+his chin, pull his wig at the ears, or point what he said, stood looking
+down into her face while she sat looking up into his.
+
+“Miss Manette, it _was_ I. And you will see how truly I spoke of myself
+just now, in saying I had no feelings, and that all the relations I hold
+with my fellow-creatures are mere business relations, when you reflect
+that I have never seen you since. No; you have been the ward of
+Tellson’s House since, and I have been busy with the other business of
+Tellson’s House since. Feelings! I have no time for them, no chance
+of them. I pass my whole life, miss, in turning an immense pecuniary
+Mangle.”
+
+After this odd description of his daily routine of employment, Mr. Lorry
+flattened his flaxen wig upon his head with both hands (which was most
+unnecessary, for nothing could be flatter than its shining surface was
+before), and resumed his former attitude.
+
+“So far, miss (as you have remarked), this is the story of your
+regretted father. Now comes the difference. If your father had not died
+when he did--Don’t be frightened! How you start!”
+
+She did, indeed, start. And she caught his wrist with both her hands.
+
+“Pray,” said Mr. Lorry, in a soothing tone, bringing his left hand from
+the back of the chair to lay it on the supplicatory fingers that clasped
+him in so violent a tremble: “pray control your agitation--a matter of
+business. As I was saying--”
+
+Her look so discomposed him that he stopped, wandered, and began anew:
+
+“As I was saying; if Monsieur Manette had not died; if he had suddenly
+and silently disappeared; if he had been spirited away; if it had not
+been difficult to guess to what dreadful place, though no art could
+trace him; if he had an enemy in some compatriot who could exercise a
+privilege that I in my own time have known the boldest people afraid
+to speak of in a whisper, across the water there; for instance, the
+privilege of filling up blank forms for the consignment of any one
+to the oblivion of a prison for any length of time; if his wife had
+implored the king, the queen, the court, the clergy, for any tidings of
+him, and all quite in vain;--then the history of your father would have
+been the history of this unfortunate gentleman, the Doctor of Beauvais.”
+
+“I entreat you to tell me more, sir.”
+
+“I will. I am going to. You can bear it?”
+
+“I can bear anything but the uncertainty you leave me in at this
+moment.”
+
+“You speak collectedly, and you--_are_ collected. That’s good!” (Though
+his manner was less satisfied than his words.) “A matter of business.
+Regard it as a matter of business--business that must be done. Now
+if this doctor’s wife, though a lady of great courage and spirit,
+had suffered so intensely from this cause before her little child was
+born--”
+
+“The little child was a daughter, sir.”
+
+“A daughter. A-a-matter of business--don’t be distressed. Miss, if the
+poor lady had suffered so intensely before her little child was born,
+that she came to the determination of sparing the poor child the
+inheritance of any part of the agony she had known the pains of, by
+rearing her in the belief that her father was dead--No, don’t kneel! In
+Heaven’s name why should you kneel to me!”
+
+“For the truth. O dear, good, compassionate sir, for the truth!”
+
+“A--a matter of business. You confuse me, and how can I transact
+business if I am confused? Let us be clear-headed. If you could kindly
+mention now, for instance, what nine times ninepence are, or how many
+shillings in twenty guineas, it would be so encouraging. I should be so
+much more at my ease about your state of mind.”
+
+Without directly answering to this appeal, she sat so still when he had
+very gently raised her, and the hands that had not ceased to clasp
+his wrists were so much more steady than they had been, that she
+communicated some reassurance to Mr. Jarvis Lorry.
+
+“That’s right, that’s right. Courage! Business! You have business before
+you; useful business. Miss Manette, your mother took this course with
+you. And when she died--I believe broken-hearted--having never slackened
+her unavailing search for your father, she left you, at two years old,
+to grow to be blooming, beautiful, and happy, without the dark cloud
+upon you of living in uncertainty whether your father soon wore his
+heart out in prison, or wasted there through many lingering years.”
+
+As he said the words he looked down, with an admiring pity, on the
+flowing golden hair; as if he pictured to himself that it might have
+been already tinged with grey.
+
+“You know that your parents had no great possession, and that what
+they had was secured to your mother and to you. There has been no new
+discovery, of money, or of any other property; but--”
+
+He felt his wrist held closer, and he stopped. The expression in the
+forehead, which had so particularly attracted his notice, and which was
+now immovable, had deepened into one of pain and horror.
+
+“But he has been--been found. He is alive. Greatly changed, it is too
+probable; almost a wreck, it is possible; though we will hope the best.
+Still, alive. Your father has been taken to the house of an old servant
+in Paris, and we are going there: I, to identify him if I can: you, to
+restore him to life, love, duty, rest, comfort.”
+
+A shiver ran through her frame, and from it through his. She said, in a
+low, distinct, awe-stricken voice, as if she were saying it in a dream,
+
+“I am going to see his Ghost! It will be his Ghost--not him!”
+
+Mr. Lorry quietly chafed the hands that held his arm. “There, there,
+there! See now, see now! The best and the worst are known to you, now.
+You are well on your way to the poor wronged gentleman, and, with a fair
+sea voyage, and a fair land journey, you will be soon at his dear side.”
+
+She repeated in the same tone, sunk to a whisper, “I have been free, I
+have been happy, yet his Ghost has never haunted me!”
+
+“Only one thing more,” said Mr. Lorry, laying stress upon it as a
+wholesome means of enforcing her attention: “he has been found under
+another name; his own, long forgotten or long concealed. It would be
+worse than useless now to inquire which; worse than useless to seek to
+know whether he has been for years overlooked, or always designedly
+held prisoner. It would be worse than useless now to make any inquiries,
+because it would be dangerous. Better not to mention the subject,
+anywhere or in any way, and to remove him--for a while at all
+events--out of France. Even I, safe as an Englishman, and even
+Tellson’s, important as they are to French credit, avoid all naming of
+the matter. I carry about me, not a scrap of writing openly referring
+to it. This is a secret service altogether. My credentials, entries,
+and memoranda, are all comprehended in the one line, ‘Recalled to Life;’
+which may mean anything. But what is the matter! She doesn’t notice a
+word! Miss Manette!”
+
+Perfectly still and silent, and not even fallen back in her chair, she
+sat under his hand, utterly insensible; with her eyes open and fixed
+upon him, and with that last expression looking as if it were carved or
+branded into her forehead. So close was her hold upon his arm, that he
+feared to detach himself lest he should hurt her; therefore he called
+out loudly for assistance without moving.
+
+A wild-looking woman, whom even in his agitation, Mr. Lorry observed to
+be all of a red colour, and to have red hair, and to be dressed in some
+extraordinary tight-fitting fashion, and to have on her head a most
+wonderful bonnet like a Grenadier wooden measure, and good measure too,
+or a great Stilton cheese, came running into the room in advance of the
+inn servants, and soon settled the question of his detachment from the
+poor young lady, by laying a brawny hand upon his chest, and sending him
+flying back against the nearest wall.
+
+(“I really think this must be a man!” was Mr. Lorry’s breathless
+reflection, simultaneously with his coming against the wall.)
+
+“Why, look at you all!” bawled this figure, addressing the inn servants.
+“Why don’t you go and fetch things, instead of standing there staring
+at me? I am not so much to look at, am I? Why don’t you go and fetch
+things? I’ll let you know, if you don’t bring smelling-salts, cold
+water, and vinegar, quick, I will.”
+
+There was an immediate dispersal for these restoratives, and she
+softly laid the patient on a sofa, and tended her with great skill and
+gentleness: calling her “my precious!” and “my bird!” and spreading her
+golden hair aside over her shoulders with great pride and care.
+
+“And you in brown!” she said, indignantly turning to Mr. Lorry;
+“couldn’t you tell her what you had to tell her, without frightening her
+to death? Look at her, with her pretty pale face and her cold hands. Do
+you call _that_ being a Banker?”
+
+Mr. Lorry was so exceedingly disconcerted by a question so hard to
+answer, that he could only look on, at a distance, with much feebler
+sympathy and humility, while the strong woman, having banished the inn
+servants under the mysterious penalty of “letting them know” something
+not mentioned if they stayed there, staring, recovered her charge by a
+regular series of gradations, and coaxed her to lay her drooping head
+upon her shoulder.
+
+“I hope she will do well now,” said Mr. Lorry.
+
+“No thanks to you in brown, if she does. My darling pretty!”
+
+“I hope,” said Mr. Lorry, after another pause of feeble sympathy and
+humility, “that you accompany Miss Manette to France?”
+
+“A likely thing, too!” replied the strong woman. “If it was ever
+intended that I should go across salt water, do you suppose Providence
+would have cast my lot in an island?”
+
+This being another question hard to answer, Mr. Jarvis Lorry withdrew to
+consider it.
+
+
+
+
+V. The Wine-shop
+
+
+A large cask of wine had been dropped and broken, in the street. The
+accident had happened in getting it out of a cart; the cask had tumbled
+out with a run, the hoops had burst, and it lay on the stones just
+outside the door of the wine-shop, shattered like a walnut-shell.
+
+All the people within reach had suspended their business, or their
+idleness, to run to the spot and drink the wine. The rough, irregular
+stones of the street, pointing every way, and designed, one might have
+thought, expressly to lame all living creatures that approached them,
+had dammed it into little pools; these were surrounded, each by its own
+jostling group or crowd, according to its size. Some men kneeled down,
+made scoops of their two hands joined, and sipped, or tried to help
+women, who bent over their shoulders, to sip, before the wine had all
+run out between their fingers. Others, men and women, dipped in
+the puddles with little mugs of mutilated earthenware, or even with
+handkerchiefs from women’s heads, which were squeezed dry into infants’
+mouths; others made small mud-embankments, to stem the wine as it ran;
+others, directed by lookers-on up at high windows, darted here and
+there, to cut off little streams of wine that started away in new
+directions; others devoted themselves to the sodden and lee-dyed
+pieces of the cask, licking, and even champing the moister wine-rotted
+fragments with eager relish. There was no drainage to carry off the
+wine, and not only did it all get taken up, but so much mud got taken up
+along with it, that there might have been a scavenger in the street,
+if anybody acquainted with it could have believed in such a miraculous
+presence.
+
+A shrill sound of laughter and of amused voices--voices of men, women,
+and children--resounded in the street while this wine game lasted. There
+was little roughness in the sport, and much playfulness. There was a
+special companionship in it, an observable inclination on the part
+of every one to join some other one, which led, especially among the
+luckier or lighter-hearted, to frolicsome embraces, drinking of healths,
+shaking of hands, and even joining of hands and dancing, a dozen
+together. When the wine was gone, and the places where it had been
+most abundant were raked into a gridiron-pattern by fingers, these
+demonstrations ceased, as suddenly as they had broken out. The man who
+had left his saw sticking in the firewood he was cutting, set it in
+motion again; the women who had left on a door-step the little pot of
+hot ashes, at which she had been trying to soften the pain in her own
+starved fingers and toes, or in those of her child, returned to it; men
+with bare arms, matted locks, and cadaverous faces, who had emerged into
+the winter light from cellars, moved away, to descend again; and a gloom
+gathered on the scene that appeared more natural to it than sunshine.
+
+The wine was red wine, and had stained the ground of the narrow street
+in the suburb of Saint Antoine, in Paris, where it was spilled. It had
+stained many hands, too, and many faces, and many naked feet, and many
+wooden shoes. The hands of the man who sawed the wood, left red marks
+on the billets; and the forehead of the woman who nursed her baby, was
+stained with the stain of the old rag she wound about her head again.
+Those who had been greedy with the staves of the cask, had acquired a
+tigerish smear about the mouth; and one tall joker so besmirched, his
+head more out of a long squalid bag of a nightcap than in it, scrawled
+upon a wall with his finger dipped in muddy wine-lees--BLOOD.
+
+The time was to come, when that wine too would be spilled on the
+street-stones, and when the stain of it would be red upon many there.
+
+And now that the cloud settled on Saint Antoine, which a momentary
+gleam had driven from his sacred countenance, the darkness of it was
+heavy--cold, dirt, sickness, ignorance, and want, were the lords in
+waiting on the saintly presence--nobles of great power all of them;
+but, most especially the last. Samples of a people that had undergone a
+terrible grinding and regrinding in the mill, and certainly not in the
+fabulous mill which ground old people young, shivered at every corner,
+passed in and out at every doorway, looked from every window, fluttered
+in every vestige of a garment that the wind shook. The mill which
+had worked them down, was the mill that grinds young people old; the
+children had ancient faces and grave voices; and upon them, and upon the
+grown faces, and ploughed into every furrow of age and coming up afresh,
+was the sigh, Hunger. It was prevalent everywhere. Hunger was pushed out
+of the tall houses, in the wretched clothing that hung upon poles and
+lines; Hunger was patched into them with straw and rag and wood and
+paper; Hunger was repeated in every fragment of the small modicum of
+firewood that the man sawed off; Hunger stared down from the smokeless
+chimneys, and started up from the filthy street that had no offal,
+among its refuse, of anything to eat. Hunger was the inscription on the
+baker’s shelves, written in every small loaf of his scanty stock of
+bad bread; at the sausage-shop, in every dead-dog preparation that
+was offered for sale. Hunger rattled its dry bones among the roasting
+chestnuts in the turned cylinder; Hunger was shred into atomics in every
+farthing porringer of husky chips of potato, fried with some reluctant
+drops of oil.
+
+Its abiding place was in all things fitted to it. A narrow winding
+street, full of offence and stench, with other narrow winding streets
+diverging, all peopled by rags and nightcaps, and all smelling of rags
+and nightcaps, and all visible things with a brooding look upon them
+that looked ill. In the hunted air of the people there was yet some
+wild-beast thought of the possibility of turning at bay. Depressed and
+slinking though they were, eyes of fire were not wanting among them; nor
+compressed lips, white with what they suppressed; nor foreheads knitted
+into the likeness of the gallows-rope they mused about enduring, or
+inflicting. The trade signs (and they were almost as many as the shops)
+were, all, grim illustrations of Want. The butcher and the porkman
+painted up, only the leanest scrags of meat; the baker, the coarsest of
+meagre loaves. The people rudely pictured as drinking in the wine-shops,
+croaked over their scanty measures of thin wine and beer, and were
+gloweringly confidential together. Nothing was represented in a
+flourishing condition, save tools and weapons; but, the cutler’s knives
+and axes were sharp and bright, the smith’s hammers were heavy, and the
+gunmaker’s stock was murderous. The crippling stones of the pavement,
+with their many little reservoirs of mud and water, had no footways, but
+broke off abruptly at the doors. The kennel, to make amends, ran down
+the middle of the street--when it ran at all: which was only after heavy
+rains, and then it ran, by many eccentric fits, into the houses. Across
+the streets, at wide intervals, one clumsy lamp was slung by a rope and
+pulley; at night, when the lamplighter had let these down, and lighted,
+and hoisted them again, a feeble grove of dim wicks swung in a sickly
+manner overhead, as if they were at sea. Indeed they were at sea, and
+the ship and crew were in peril of tempest.
+
+For, the time was to come, when the gaunt scarecrows of that region
+should have watched the lamplighter, in their idleness and hunger, so
+long, as to conceive the idea of improving on his method, and hauling
+up men by those ropes and pulleys, to flare upon the darkness of their
+condition. But, the time was not come yet; and every wind that blew over
+France shook the rags of the scarecrows in vain, for the birds, fine of
+song and feather, took no warning.
+
+The wine-shop was a corner shop, better than most others in its
+appearance and degree, and the master of the wine-shop had stood outside
+it, in a yellow waistcoat and green breeches, looking on at the struggle
+for the lost wine. “It’s not my affair,” said he, with a final shrug
+of the shoulders. “The people from the market did it. Let them bring
+another.”
+
+There, his eyes happening to catch the tall joker writing up his joke,
+he called to him across the way:
+
+“Say, then, my Gaspard, what do you do there?”
+
+The fellow pointed to his joke with immense significance, as is often
+the way with his tribe. It missed its mark, and completely failed, as is
+often the way with his tribe too.
+
+“What now? Are you a subject for the mad hospital?” said the wine-shop
+keeper, crossing the road, and obliterating the jest with a handful of
+mud, picked up for the purpose, and smeared over it. “Why do you write
+in the public streets? Is there--tell me thou--is there no other place
+to write such words in?”
+
+In his expostulation he dropped his cleaner hand (perhaps accidentally,
+perhaps not) upon the joker’s heart. The joker rapped it with his
+own, took a nimble spring upward, and came down in a fantastic dancing
+attitude, with one of his stained shoes jerked off his foot into his
+hand, and held out. A joker of an extremely, not to say wolfishly
+practical character, he looked, under those circumstances.
+
+“Put it on, put it on,” said the other. “Call wine, wine; and finish
+there.” With that advice, he wiped his soiled hand upon the joker’s
+dress, such as it was--quite deliberately, as having dirtied the hand on
+his account; and then recrossed the road and entered the wine-shop.
+
+This wine-shop keeper was a bull-necked, martial-looking man of thirty,
+and he should have been of a hot temperament, for, although it was a
+bitter day, he wore no coat, but carried one slung over his shoulder.
+His shirt-sleeves were rolled up, too, and his brown arms were bare to
+the elbows. Neither did he wear anything more on his head than his own
+crisply-curling short dark hair. He was a dark man altogether, with good
+eyes and a good bold breadth between them. Good-humoured looking on
+the whole, but implacable-looking, too; evidently a man of a strong
+resolution and a set purpose; a man not desirable to be met, rushing
+down a narrow pass with a gulf on either side, for nothing would turn
+the man.
+
+Madame Defarge, his wife, sat in the shop behind the counter as he
+came in. Madame Defarge was a stout woman of about his own age, with
+a watchful eye that seldom seemed to look at anything, a large hand
+heavily ringed, a steady face, strong features, and great composure of
+manner. There was a character about Madame Defarge, from which one might
+have predicated that she did not often make mistakes against herself
+in any of the reckonings over which she presided. Madame Defarge being
+sensitive to cold, was wrapped in fur, and had a quantity of bright
+shawl twined about her head, though not to the concealment of her large
+earrings. Her knitting was before her, but she had laid it down to pick
+her teeth with a toothpick. Thus engaged, with her right elbow supported
+by her left hand, Madame Defarge said nothing when her lord came in, but
+coughed just one grain of cough. This, in combination with the lifting
+of her darkly defined eyebrows over her toothpick by the breadth of a
+line, suggested to her husband that he would do well to look round the
+shop among the customers, for any new customer who had dropped in while
+he stepped over the way.
+
+The wine-shop keeper accordingly rolled his eyes about, until they
+rested upon an elderly gentleman and a young lady, who were seated in
+a corner. Other company were there: two playing cards, two playing
+dominoes, three standing by the counter lengthening out a short supply
+of wine. As he passed behind the counter, he took notice that the
+elderly gentleman said in a look to the young lady, “This is our man.”
+
+“What the devil do _you_ do in that galley there?” said Monsieur Defarge
+to himself; “I don’t know you.”
+
+But, he feigned not to notice the two strangers, and fell into discourse
+with the triumvirate of customers who were drinking at the counter.
+
+“How goes it, Jacques?” said one of these three to Monsieur Defarge. “Is
+all the spilt wine swallowed?”
+
+“Every drop, Jacques,” answered Monsieur Defarge.
+
+When this interchange of Christian name was effected, Madame Defarge,
+picking her teeth with her toothpick, coughed another grain of cough,
+and raised her eyebrows by the breadth of another line.
+
+“It is not often,” said the second of the three, addressing Monsieur
+Defarge, “that many of these miserable beasts know the taste of wine, or
+of anything but black bread and death. Is it not so, Jacques?”
+
+“It is so, Jacques,” Monsieur Defarge returned.
+
+At this second interchange of the Christian name, Madame Defarge, still
+using her toothpick with profound composure, coughed another grain of
+cough, and raised her eyebrows by the breadth of another line.
+
+The last of the three now said his say, as he put down his empty
+drinking vessel and smacked his lips.
+
+“Ah! So much the worse! A bitter taste it is that such poor cattle
+always have in their mouths, and hard lives they live, Jacques. Am I
+right, Jacques?”
+
+“You are right, Jacques,” was the response of Monsieur Defarge.
+
+This third interchange of the Christian name was completed at the moment
+when Madame Defarge put her toothpick by, kept her eyebrows up, and
+slightly rustled in her seat.
+
+“Hold then! True!” muttered her husband. “Gentlemen--my wife!”
+
+The three customers pulled off their hats to Madame Defarge, with three
+flourishes. She acknowledged their homage by bending her head, and
+giving them a quick look. Then she glanced in a casual manner round the
+wine-shop, took up her knitting with great apparent calmness and repose
+of spirit, and became absorbed in it.
+
+“Gentlemen,” said her husband, who had kept his bright eye observantly
+upon her, “good day. The chamber, furnished bachelor-fashion, that you
+wished to see, and were inquiring for when I stepped out, is on the
+fifth floor. The doorway of the staircase gives on the little courtyard
+close to the left here,” pointing with his hand, “near to the window of
+my establishment. But, now that I remember, one of you has already been
+there, and can show the way. Gentlemen, adieu!”
+
+They paid for their wine, and left the place. The eyes of Monsieur
+Defarge were studying his wife at her knitting when the elderly
+gentleman advanced from his corner, and begged the favour of a word.
+
+“Willingly, sir,” said Monsieur Defarge, and quietly stepped with him to
+the door.
+
+Their conference was very short, but very decided. Almost at the first
+word, Monsieur Defarge started and became deeply attentive. It had
+not lasted a minute, when he nodded and went out. The gentleman then
+beckoned to the young lady, and they, too, went out. Madame Defarge
+knitted with nimble fingers and steady eyebrows, and saw nothing.
+
+Mr. Jarvis Lorry and Miss Manette, emerging from the wine-shop thus,
+joined Monsieur Defarge in the doorway to which he had directed his own
+company just before. It opened from a stinking little black courtyard,
+and was the general public entrance to a great pile of houses, inhabited
+by a great number of people. In the gloomy tile-paved entry to the
+gloomy tile-paved staircase, Monsieur Defarge bent down on one knee
+to the child of his old master, and put her hand to his lips. It was
+a gentle action, but not at all gently done; a very remarkable
+transformation had come over him in a few seconds. He had no good-humour
+in his face, nor any openness of aspect left, but had become a secret,
+angry, dangerous man.
+
+“It is very high; it is a little difficult. Better to begin slowly.”
+ Thus, Monsieur Defarge, in a stern voice, to Mr. Lorry, as they began
+ascending the stairs.
+
+“Is he alone?” the latter whispered.
+
+“Alone! God help him, who should be with him!” said the other, in the
+same low voice.
+
+“Is he always alone, then?”
+
+“Yes.”
+
+“Of his own desire?”
+
+“Of his own necessity. As he was, when I first saw him after they
+found me and demanded to know if I would take him, and, at my peril be
+discreet--as he was then, so he is now.”
+
+“He is greatly changed?”
+
+“Changed!”
+
+The keeper of the wine-shop stopped to strike the wall with his hand,
+and mutter a tremendous curse. No direct answer could have been half so
+forcible. Mr. Lorry’s spirits grew heavier and heavier, as he and his
+two companions ascended higher and higher.
+
+Such a staircase, with its accessories, in the older and more crowded
+parts of Paris, would be bad enough now; but, at that time, it was vile
+indeed to unaccustomed and unhardened senses. Every little habitation
+within the great foul nest of one high building--that is to say,
+the room or rooms within every door that opened on the general
+staircase--left its own heap of refuse on its own landing, besides
+flinging other refuse from its own windows. The uncontrollable and
+hopeless mass of decomposition so engendered, would have polluted
+the air, even if poverty and deprivation had not loaded it with their
+intangible impurities; the two bad sources combined made it almost
+insupportable. Through such an atmosphere, by a steep dark shaft of dirt
+and poison, the way lay. Yielding to his own disturbance of mind, and to
+his young companion’s agitation, which became greater every instant, Mr.
+Jarvis Lorry twice stopped to rest. Each of these stoppages was made
+at a doleful grating, by which any languishing good airs that were left
+uncorrupted, seemed to escape, and all spoilt and sickly vapours seemed
+to crawl in. Through the rusted bars, tastes, rather than glimpses, were
+caught of the jumbled neighbourhood; and nothing within range, nearer
+or lower than the summits of the two great towers of Notre-Dame, had any
+promise on it of healthy life or wholesome aspirations.
+
+At last, the top of the staircase was gained, and they stopped for the
+third time. There was yet an upper staircase, of a steeper inclination
+and of contracted dimensions, to be ascended, before the garret story
+was reached. The keeper of the wine-shop, always going a little in
+advance, and always going on the side which Mr. Lorry took, as though he
+dreaded to be asked any question by the young lady, turned himself about
+here, and, carefully feeling in the pockets of the coat he carried over
+his shoulder, took out a key.
+
+“The door is locked then, my friend?” said Mr. Lorry, surprised.
+
+“Ay. Yes,” was the grim reply of Monsieur Defarge.
+
+“You think it necessary to keep the unfortunate gentleman so retired?”
+
+“I think it necessary to turn the key.” Monsieur Defarge whispered it
+closer in his ear, and frowned heavily.
+
+“Why?”
+
+“Why! Because he has lived so long, locked up, that he would be
+frightened--rave--tear himself to pieces--die--come to I know not what
+harm--if his door was left open.”
+
+“Is it possible!” exclaimed Mr. Lorry.
+
+“Is it possible!” repeated Defarge, bitterly. “Yes. And a beautiful
+world we live in, when it _is_ possible, and when many other such things
+are possible, and not only possible, but done--done, see you!--under
+that sky there, every day. Long live the Devil. Let us go on.”
+
+This dialogue had been held in so very low a whisper, that not a word
+of it had reached the young lady’s ears. But, by this time she trembled
+under such strong emotion, and her face expressed such deep anxiety,
+and, above all, such dread and terror, that Mr. Lorry felt it incumbent
+on him to speak a word or two of reassurance.
+
+“Courage, dear miss! Courage! Business! The worst will be over in a
+moment; it is but passing the room-door, and the worst is over. Then,
+all the good you bring to him, all the relief, all the happiness you
+bring to him, begin. Let our good friend here, assist you on that side.
+That’s well, friend Defarge. Come, now. Business, business!”
+
+They went up slowly and softly. The staircase was short, and they were
+soon at the top. There, as it had an abrupt turn in it, they came all at
+once in sight of three men, whose heads were bent down close together at
+the side of a door, and who were intently looking into the room to which
+the door belonged, through some chinks or holes in the wall. On hearing
+footsteps close at hand, these three turned, and rose, and showed
+themselves to be the three of one name who had been drinking in the
+wine-shop.
+
+“I forgot them in the surprise of your visit,” explained Monsieur
+Defarge. “Leave us, good boys; we have business here.”
+
+The three glided by, and went silently down.
+
+There appearing to be no other door on that floor, and the keeper of
+the wine-shop going straight to this one when they were left alone, Mr.
+Lorry asked him in a whisper, with a little anger:
+
+“Do you make a show of Monsieur Manette?”
+
+“I show him, in the way you have seen, to a chosen few.”
+
+“Is that well?”
+
+“_I_ think it is well.”
+
+“Who are the few? How do you choose them?”
+
+“I choose them as real men, of my name--Jacques is my name--to whom the
+sight is likely to do good. Enough; you are English; that is another
+thing. Stay there, if you please, a little moment.”
+
+With an admonitory gesture to keep them back, he stooped, and looked in
+through the crevice in the wall. Soon raising his head again, he struck
+twice or thrice upon the door--evidently with no other object than to
+make a noise there. With the same intention, he drew the key across it,
+three or four times, before he put it clumsily into the lock, and turned
+it as heavily as he could.
+
+The door slowly opened inward under his hand, and he looked into the
+room and said something. A faint voice answered something. Little more
+than a single syllable could have been spoken on either side.
+
+He looked back over his shoulder, and beckoned them to enter. Mr. Lorry
+got his arm securely round the daughter’s waist, and held her; for he
+felt that she was sinking.
+
+“A-a-a-business, business!” he urged, with a moisture that was not of
+business shining on his cheek. “Come in, come in!”
+
+“I am afraid of it,” she answered, shuddering.
+
+“Of it? What?”
+
+“I mean of him. Of my father.”
+
+Rendered in a manner desperate, by her state and by the beckoning of
+their conductor, he drew over his neck the arm that shook upon his
+shoulder, lifted her a little, and hurried her into the room. He sat her
+down just within the door, and held her, clinging to him.
+
+Defarge drew out the key, closed the door, locked it on the inside,
+took out the key again, and held it in his hand. All this he did,
+methodically, and with as loud and harsh an accompaniment of noise as he
+could make. Finally, he walked across the room with a measured tread to
+where the window was. He stopped there, and faced round.
+
+The garret, built to be a depository for firewood and the like, was dim
+and dark: for, the window of dormer shape, was in truth a door in the
+roof, with a little crane over it for the hoisting up of stores from
+the street: unglazed, and closing up the middle in two pieces, like any
+other door of French construction. To exclude the cold, one half of this
+door was fast closed, and the other was opened but a very little way.
+Such a scanty portion of light was admitted through these means, that it
+was difficult, on first coming in, to see anything; and long habit
+alone could have slowly formed in any one, the ability to do any work
+requiring nicety in such obscurity. Yet, work of that kind was being
+done in the garret; for, with his back towards the door, and his face
+towards the window where the keeper of the wine-shop stood looking at
+him, a white-haired man sat on a low bench, stooping forward and very
+busy, making shoes.
+
+
+
+
+VI. The Shoemaker
+
+
+“Good day!” said Monsieur Defarge, looking down at the white head that
+bent low over the shoemaking.
+
+It was raised for a moment, and a very faint voice responded to the
+salutation, as if it were at a distance:
+
+“Good day!”
+
+“You are still hard at work, I see?”
+
+After a long silence, the head was lifted for another moment, and the
+voice replied, “Yes--I am working.” This time, a pair of haggard eyes
+had looked at the questioner, before the face had dropped again.
+
+The faintness of the voice was pitiable and dreadful. It was not the
+faintness of physical weakness, though confinement and hard fare no
+doubt had their part in it. Its deplorable peculiarity was, that it was
+the faintness of solitude and disuse. It was like the last feeble echo
+of a sound made long and long ago. So entirely had it lost the life and
+resonance of the human voice, that it affected the senses like a once
+beautiful colour faded away into a poor weak stain. So sunken and
+suppressed it was, that it was like a voice underground. So expressive
+it was, of a hopeless and lost creature, that a famished traveller,
+wearied out by lonely wandering in a wilderness, would have remembered
+home and friends in such a tone before lying down to die.
+
+Some minutes of silent work had passed: and the haggard eyes had looked
+up again: not with any interest or curiosity, but with a dull mechanical
+perception, beforehand, that the spot where the only visitor they were
+aware of had stood, was not yet empty.
+
+“I want,” said Defarge, who had not removed his gaze from the shoemaker,
+“to let in a little more light here. You can bear a little more?”
+
+The shoemaker stopped his work; looked with a vacant air of listening,
+at the floor on one side of him; then similarly, at the floor on the
+other side of him; then, upward at the speaker.
+
+“What did you say?”
+
+“You can bear a little more light?”
+
+“I must bear it, if you let it in.” (Laying the palest shadow of a
+stress upon the second word.)
+
+The opened half-door was opened a little further, and secured at that
+angle for the time. A broad ray of light fell into the garret, and
+showed the workman with an unfinished shoe upon his lap, pausing in his
+labour. His few common tools and various scraps of leather were at his
+feet and on his bench. He had a white beard, raggedly cut, but not very
+long, a hollow face, and exceedingly bright eyes. The hollowness and
+thinness of his face would have caused them to look large, under his yet
+dark eyebrows and his confused white hair, though they had been really
+otherwise; but, they were naturally large, and looked unnaturally so.
+His yellow rags of shirt lay open at the throat, and showed his body
+to be withered and worn. He, and his old canvas frock, and his loose
+stockings, and all his poor tatters of clothes, had, in a long seclusion
+from direct light and air, faded down to such a dull uniformity of
+parchment-yellow, that it would have been hard to say which was which.
+
+He had put up a hand between his eyes and the light, and the very bones
+of it seemed transparent. So he sat, with a steadfastly vacant gaze,
+pausing in his work. He never looked at the figure before him, without
+first looking down on this side of himself, then on that, as if he had
+lost the habit of associating place with sound; he never spoke, without
+first wandering in this manner, and forgetting to speak.
+
+“Are you going to finish that pair of shoes to-day?” asked Defarge,
+motioning to Mr. Lorry to come forward.
+
+“What did you say?”
+
+“Do you mean to finish that pair of shoes to-day?”
+
+“I can’t say that I mean to. I suppose so. I don’t know.”
+
+But, the question reminded him of his work, and he bent over it again.
+
+Mr. Lorry came silently forward, leaving the daughter by the door. When
+he had stood, for a minute or two, by the side of Defarge, the shoemaker
+looked up. He showed no surprise at seeing another figure, but the
+unsteady fingers of one of his hands strayed to his lips as he looked at
+it (his lips and his nails were of the same pale lead-colour), and then
+the hand dropped to his work, and he once more bent over the shoe. The
+look and the action had occupied but an instant.
+
+“You have a visitor, you see,” said Monsieur Defarge.
+
+“What did you say?”
+
+“Here is a visitor.”
+
+The shoemaker looked up as before, but without removing a hand from his
+work.
+
+“Come!” said Defarge. “Here is monsieur, who knows a well-made shoe when
+he sees one. Show him that shoe you are working at. Take it, monsieur.”
+
+Mr. Lorry took it in his hand.
+
+“Tell monsieur what kind of shoe it is, and the maker’s name.”
+
+There was a longer pause than usual, before the shoemaker replied:
+
+“I forget what it was you asked me. What did you say?”
+
+“I said, couldn’t you describe the kind of shoe, for monsieur’s
+information?”
+
+“It is a lady’s shoe. It is a young lady’s walking-shoe. It is in the
+present mode. I never saw the mode. I have had a pattern in my hand.” He
+glanced at the shoe with some little passing touch of pride.
+
+“And the maker’s name?” said Defarge.
+
+Now that he had no work to hold, he laid the knuckles of the right hand
+in the hollow of the left, and then the knuckles of the left hand in the
+hollow of the right, and then passed a hand across his bearded chin, and
+so on in regular changes, without a moment’s intermission. The task of
+recalling him from the vagrancy into which he always sank when he
+had spoken, was like recalling some very weak person from a swoon, or
+endeavouring, in the hope of some disclosure, to stay the spirit of a
+fast-dying man.
+
+“Did you ask me for my name?”
+
+“Assuredly I did.”
+
+“One Hundred and Five, North Tower.”
+
+“Is that all?”
+
+“One Hundred and Five, North Tower.”
+
+With a weary sound that was not a sigh, nor a groan, he bent to work
+again, until the silence was again broken.
+
+“You are not a shoemaker by trade?” said Mr. Lorry, looking steadfastly
+at him.
+
+His haggard eyes turned to Defarge as if he would have transferred the
+question to him: but as no help came from that quarter, they turned back
+on the questioner when they had sought the ground.
+
+“I am not a shoemaker by trade? No, I was not a shoemaker by trade. I-I
+learnt it here. I taught myself. I asked leave to--”
+
+He lapsed away, even for minutes, ringing those measured changes on his
+hands the whole time. His eyes came slowly back, at last, to the face
+from which they had wandered; when they rested on it, he started, and
+resumed, in the manner of a sleeper that moment awake, reverting to a
+subject of last night.
+
+“I asked leave to teach myself, and I got it with much difficulty after
+a long while, and I have made shoes ever since.”
+
+As he held out his hand for the shoe that had been taken from him, Mr.
+Lorry said, still looking steadfastly in his face:
+
+“Monsieur Manette, do you remember nothing of me?”
+
+The shoe dropped to the ground, and he sat looking fixedly at the
+questioner.
+
+“Monsieur Manette”; Mr. Lorry laid his hand upon Defarge’s arm; “do you
+remember nothing of this man? Look at him. Look at me. Is there no old
+banker, no old business, no old servant, no old time, rising in your
+mind, Monsieur Manette?”
+
+As the captive of many years sat looking fixedly, by turns, at Mr.
+Lorry and at Defarge, some long obliterated marks of an actively intent
+intelligence in the middle of the forehead, gradually forced themselves
+through the black mist that had fallen on him. They were overclouded
+again, they were fainter, they were gone; but they had been there. And
+so exactly was the expression repeated on the fair young face of her who
+had crept along the wall to a point where she could see him, and where
+she now stood looking at him, with hands which at first had been only
+raised in frightened compassion, if not even to keep him off and
+shut out the sight of him, but which were now extending towards him,
+trembling with eagerness to lay the spectral face upon her warm young
+breast, and love it back to life and hope--so exactly was the expression
+repeated (though in stronger characters) on her fair young face, that it
+looked as though it had passed like a moving light, from him to her.
+
+Darkness had fallen on him in its place. He looked at the two, less and
+less attentively, and his eyes in gloomy abstraction sought the ground
+and looked about him in the old way. Finally, with a deep long sigh, he
+took the shoe up, and resumed his work.
+
+“Have you recognised him, monsieur?” asked Defarge in a whisper.
+
+“Yes; for a moment. At first I thought it quite hopeless, but I have
+unquestionably seen, for a single moment, the face that I once knew so
+well. Hush! Let us draw further back. Hush!”
+
+She had moved from the wall of the garret, very near to the bench on
+which he sat. There was something awful in his unconsciousness of the
+figure that could have put out its hand and touched him as he stooped
+over his labour.
+
+Not a word was spoken, not a sound was made. She stood, like a spirit,
+beside him, and he bent over his work.
+
+It happened, at length, that he had occasion to change the instrument
+in his hand, for his shoemaker’s knife. It lay on that side of him
+which was not the side on which she stood. He had taken it up, and was
+stooping to work again, when his eyes caught the skirt of her dress. He
+raised them, and saw her face. The two spectators started forward,
+but she stayed them with a motion of her hand. She had no fear of his
+striking at her with the knife, though they had.
+
+He stared at her with a fearful look, and after a while his lips began
+to form some words, though no sound proceeded from them. By degrees, in
+the pauses of his quick and laboured breathing, he was heard to say:
+
+“What is this?”
+
+With the tears streaming down her face, she put her two hands to her
+lips, and kissed them to him; then clasped them on her breast, as if she
+laid his ruined head there.
+
+“You are not the gaoler’s daughter?”
+
+She sighed “No.”
+
+“Who are you?”
+
+Not yet trusting the tones of her voice, she sat down on the bench
+beside him. He recoiled, but she laid her hand upon his arm. A strange
+thrill struck him when she did so, and visibly passed over his frame; he
+laid the knife down softly, as he sat staring at her.
+
+Her golden hair, which she wore in long curls, had been hurriedly pushed
+aside, and fell down over her neck. Advancing his hand by little and
+little, he took it up and looked at it. In the midst of the action
+he went astray, and, with another deep sigh, fell to work at his
+shoemaking.
+
+But not for long. Releasing his arm, she laid her hand upon his
+shoulder. After looking doubtfully at it, two or three times, as if to
+be sure that it was really there, he laid down his work, put his hand
+to his neck, and took off a blackened string with a scrap of folded rag
+attached to it. He opened this, carefully, on his knee, and it contained
+a very little quantity of hair: not more than one or two long golden
+hairs, which he had, in some old day, wound off upon his finger.
+
+He took her hair into his hand again, and looked closely at it. “It is
+the same. How can it be! When was it! How was it!”
+
+As the concentrated expression returned to his forehead, he seemed to
+become conscious that it was in hers too. He turned her full to the
+light, and looked at her.
+
+“She had laid her head upon my shoulder, that night when I was summoned
+out--she had a fear of my going, though I had none--and when I was
+brought to the North Tower they found these upon my sleeve. ‘You will
+leave me them? They can never help me to escape in the body, though they
+may in the spirit.’ Those were the words I said. I remember them very
+well.”
+
+He formed this speech with his lips many times before he could utter it.
+But when he did find spoken words for it, they came to him coherently,
+though slowly.
+
+“How was this?--_Was it you_?”
+
+Once more, the two spectators started, as he turned upon her with a
+frightful suddenness. But she sat perfectly still in his grasp, and only
+said, in a low voice, “I entreat you, good gentlemen, do not come near
+us, do not speak, do not move!”
+
+“Hark!” he exclaimed. “Whose voice was that?”
+
+His hands released her as he uttered this cry, and went up to his white
+hair, which they tore in a frenzy. It died out, as everything but his
+shoemaking did die out of him, and he refolded his little packet and
+tried to secure it in his breast; but he still looked at her, and
+gloomily shook his head.
+
+“No, no, no; you are too young, too blooming. It can’t be. See what the
+prisoner is. These are not the hands she knew, this is not the face
+she knew, this is not a voice she ever heard. No, no. She was--and He
+was--before the slow years of the North Tower--ages ago. What is your
+name, my gentle angel?”
+
+Hailing his softened tone and manner, his daughter fell upon her knees
+before him, with her appealing hands upon his breast.
+
+“O, sir, at another time you shall know my name, and who my mother was,
+and who my father, and how I never knew their hard, hard history. But I
+cannot tell you at this time, and I cannot tell you here. All that I may
+tell you, here and now, is, that I pray to you to touch me and to bless
+me. Kiss me, kiss me! O my dear, my dear!”
+
+His cold white head mingled with her radiant hair, which warmed and
+lighted it as though it were the light of Freedom shining on him.
+
+“If you hear in my voice--I don’t know that it is so, but I hope it
+is--if you hear in my voice any resemblance to a voice that once was
+sweet music in your ears, weep for it, weep for it! If you touch, in
+touching my hair, anything that recalls a beloved head that lay on your
+breast when you were young and free, weep for it, weep for it! If, when
+I hint to you of a Home that is before us, where I will be true to you
+with all my duty and with all my faithful service, I bring back the
+remembrance of a Home long desolate, while your poor heart pined away,
+weep for it, weep for it!”
+
+She held him closer round the neck, and rocked him on her breast like a
+child.
+
+“If, when I tell you, dearest dear, that your agony is over, and that I
+have come here to take you from it, and that we go to England to be at
+peace and at rest, I cause you to think of your useful life laid waste,
+and of our native France so wicked to you, weep for it, weep for it! And
+if, when I shall tell you of my name, and of my father who is living,
+and of my mother who is dead, you learn that I have to kneel to my
+honoured father, and implore his pardon for having never for his sake
+striven all day and lain awake and wept all night, because the love of
+my poor mother hid his torture from me, weep for it, weep for it! Weep
+for her, then, and for me! Good gentlemen, thank God! I feel his sacred
+tears upon my face, and his sobs strike against my heart. O, see! Thank
+God for us, thank God!”
+
+He had sunk in her arms, and his face dropped on her breast: a sight so
+touching, yet so terrible in the tremendous wrong and suffering which
+had gone before it, that the two beholders covered their faces.
+
+When the quiet of the garret had been long undisturbed, and his heaving
+breast and shaken form had long yielded to the calm that must follow all
+storms--emblem to humanity, of the rest and silence into which the storm
+called Life must hush at last--they came forward to raise the father and
+daughter from the ground. He had gradually dropped to the floor, and lay
+there in a lethargy, worn out. She had nestled down with him, that his
+head might lie upon her arm; and her hair drooping over him curtained
+him from the light.
+
+“If, without disturbing him,” she said, raising her hand to Mr. Lorry as
+he stooped over them, after repeated blowings of his nose, “all could be
+arranged for our leaving Paris at once, so that, from the very door, he
+could be taken away--”
+
+“But, consider. Is he fit for the journey?” asked Mr. Lorry.
+
+“More fit for that, I think, than to remain in this city, so dreadful to
+him.”
+
+“It is true,” said Defarge, who was kneeling to look on and hear. “More
+than that; Monsieur Manette is, for all reasons, best out of France.
+Say, shall I hire a carriage and post-horses?”
+
+“That’s business,” said Mr. Lorry, resuming on the shortest notice his
+methodical manners; “and if business is to be done, I had better do it.”
+
+“Then be so kind,” urged Miss Manette, “as to leave us here. You see how
+composed he has become, and you cannot be afraid to leave him with me
+now. Why should you be? If you will lock the door to secure us from
+interruption, I do not doubt that you will find him, when you come back,
+as quiet as you leave him. In any case, I will take care of him until
+you return, and then we will remove him straight.”
+
+Both Mr. Lorry and Defarge were rather disinclined to this course, and
+in favour of one of them remaining. But, as there were not only carriage
+and horses to be seen to, but travelling papers; and as time pressed,
+for the day was drawing to an end, it came at last to their hastily
+dividing the business that was necessary to be done, and hurrying away
+to do it.
+
+Then, as the darkness closed in, the daughter laid her head down on the
+hard ground close at the father’s side, and watched him. The darkness
+deepened and deepened, and they both lay quiet, until a light gleamed
+through the chinks in the wall.
+
+Mr. Lorry and Monsieur Defarge had made all ready for the journey, and
+had brought with them, besides travelling cloaks and wrappers, bread and
+meat, wine, and hot coffee. Monsieur Defarge put this provender, and the
+lamp he carried, on the shoemaker’s bench (there was nothing else in the
+garret but a pallet bed), and he and Mr. Lorry roused the captive, and
+assisted him to his feet.
+
+No human intelligence could have read the mysteries of his mind, in
+the scared blank wonder of his face. Whether he knew what had happened,
+whether he recollected what they had said to him, whether he knew that
+he was free, were questions which no sagacity could have solved. They
+tried speaking to him; but, he was so confused, and so very slow to
+answer, that they took fright at his bewilderment, and agreed for
+the time to tamper with him no more. He had a wild, lost manner of
+occasionally clasping his head in his hands, that had not been seen
+in him before; yet, he had some pleasure in the mere sound of his
+daughter’s voice, and invariably turned to it when she spoke.
+
+In the submissive way of one long accustomed to obey under coercion, he
+ate and drank what they gave him to eat and drink, and put on the cloak
+and other wrappings, that they gave him to wear. He readily responded to
+his daughter’s drawing her arm through his, and took--and kept--her hand
+in both his own.
+
+They began to descend; Monsieur Defarge going first with the lamp, Mr.
+Lorry closing the little procession. They had not traversed many steps
+of the long main staircase when he stopped, and stared at the roof and
+round at the walls.
+
+“You remember the place, my father? You remember coming up here?”
+
+“What did you say?”
+
+But, before she could repeat the question, he murmured an answer as if
+she had repeated it.
+
+“Remember? No, I don’t remember. It was so very long ago.”
+
+That he had no recollection whatever of his having been brought from his
+prison to that house, was apparent to them. They heard him mutter,
+“One Hundred and Five, North Tower;” and when he looked about him, it
+evidently was for the strong fortress-walls which had long encompassed
+him. On their reaching the courtyard he instinctively altered his
+tread, as being in expectation of a drawbridge; and when there was
+no drawbridge, and he saw the carriage waiting in the open street, he
+dropped his daughter’s hand and clasped his head again.
+
+No crowd was about the door; no people were discernible at any of the
+many windows; not even a chance passerby was in the street. An unnatural
+silence and desertion reigned there. Only one soul was to be seen, and
+that was Madame Defarge--who leaned against the door-post, knitting, and
+saw nothing.
+
+The prisoner had got into a coach, and his daughter had followed
+him, when Mr. Lorry’s feet were arrested on the step by his asking,
+miserably, for his shoemaking tools and the unfinished shoes. Madame
+Defarge immediately called to her husband that she would get them, and
+went, knitting, out of the lamplight, through the courtyard. She quickly
+brought them down and handed them in;--and immediately afterwards leaned
+against the door-post, knitting, and saw nothing.
+
+Defarge got upon the box, and gave the word “To the Barrier!” The
+postilion cracked his whip, and they clattered away under the feeble
+over-swinging lamps.
+
+Under the over-swinging lamps--swinging ever brighter in the better
+streets, and ever dimmer in the worse--and by lighted shops, gay crowds,
+illuminated coffee-houses, and theatre-doors, to one of the city
+gates. Soldiers with lanterns, at the guard-house there. “Your papers,
+travellers!” “See here then, Monsieur the Officer,” said Defarge,
+getting down, and taking him gravely apart, “these are the papers of
+monsieur inside, with the white head. They were consigned to me, with
+him, at the--” He dropped his voice, there was a flutter among the
+military lanterns, and one of them being handed into the coach by an arm
+in uniform, the eyes connected with the arm looked, not an every day
+or an every night look, at monsieur with the white head. “It is well.
+Forward!” from the uniform. “Adieu!” from Defarge. And so, under a short
+grove of feebler and feebler over-swinging lamps, out under the great
+grove of stars.
+
+Beneath that arch of unmoved and eternal lights; some, so remote from
+this little earth that the learned tell us it is doubtful whether their
+rays have even yet discovered it, as a point in space where anything
+is suffered or done: the shadows of the night were broad and black.
+All through the cold and restless interval, until dawn, they once more
+whispered in the ears of Mr. Jarvis Lorry--sitting opposite the buried
+man who had been dug out, and wondering what subtle powers were for ever
+lost to him, and what were capable of restoration--the old inquiry:
+
+“I hope you care to be recalled to life?”
+
+And the old answer:
+
+“I can’t say.”
+
+
+The end of the first book.
+
+
+
+
+
+Book the Second--the Golden Thread
+
+
+
+
+I. Five Years Later
+
+
+Tellson’s Bank by Temple Bar was an old-fashioned place, even in the
+year one thousand seven hundred and eighty. It was very small, very
+dark, very ugly, very incommodious. It was an old-fashioned place,
+moreover, in the moral attribute that the partners in the House were
+proud of its smallness, proud of its darkness, proud of its ugliness,
+proud of its incommodiousness. They were even boastful of its eminence
+in those particulars, and were fired by an express conviction that, if
+it were less objectionable, it would be less respectable. This was
+no passive belief, but an active weapon which they flashed at more
+convenient places of business. Tellson’s (they said) wanted
+no elbow-room, Tellson’s wanted no light, Tellson’s wanted no
+embellishment. Noakes and Co.’s might, or Snooks Brothers’ might; but
+Tellson’s, thank Heaven--!
+
+Any one of these partners would have disinherited his son on the
+question of rebuilding Tellson’s. In this respect the House was much
+on a par with the Country; which did very often disinherit its sons for
+suggesting improvements in laws and customs that had long been highly
+objectionable, but were only the more respectable.
+
+Thus it had come to pass, that Tellson’s was the triumphant perfection
+of inconvenience. After bursting open a door of idiotic obstinacy with
+a weak rattle in its throat, you fell into Tellson’s down two steps,
+and came to your senses in a miserable little shop, with two little
+counters, where the oldest of men made your cheque shake as if the
+wind rustled it, while they examined the signature by the dingiest of
+windows, which were always under a shower-bath of mud from Fleet-street,
+and which were made the dingier by their own iron bars proper, and the
+heavy shadow of Temple Bar. If your business necessitated your seeing
+“the House,” you were put into a species of Condemned Hold at the back,
+where you meditated on a misspent life, until the House came with its
+hands in its pockets, and you could hardly blink at it in the dismal
+twilight. Your money came out of, or went into, wormy old wooden
+drawers, particles of which flew up your nose and down your throat when
+they were opened and shut. Your bank-notes had a musty odour, as if they
+were fast decomposing into rags again. Your plate was stowed away among
+the neighbouring cesspools, and evil communications corrupted its good
+polish in a day or two. Your deeds got into extemporised strong-rooms
+made of kitchens and sculleries, and fretted all the fat out of their
+parchments into the banking-house air. Your lighter boxes of family
+papers went up-stairs into a Barmecide room, that always had a great
+dining-table in it and never had a dinner, and where, even in the year
+one thousand seven hundred and eighty, the first letters written to you
+by your old love, or by your little children, were but newly released
+from the horror of being ogled through the windows, by the heads
+exposed on Temple Bar with an insensate brutality and ferocity worthy of
+Abyssinia or Ashantee.
+
+But indeed, at that time, putting to death was a recipe much in vogue
+with all trades and professions, and not least of all with Tellson’s.
+Death is Nature’s remedy for all things, and why not Legislation’s?
+Accordingly, the forger was put to Death; the utterer of a bad note
+was put to Death; the unlawful opener of a letter was put to Death; the
+purloiner of forty shillings and sixpence was put to Death; the holder
+of a horse at Tellson’s door, who made off with it, was put to
+Death; the coiner of a bad shilling was put to Death; the sounders of
+three-fourths of the notes in the whole gamut of Crime, were put to
+Death. Not that it did the least good in the way of prevention--it
+might almost have been worth remarking that the fact was exactly the
+reverse--but, it cleared off (as to this world) the trouble of each
+particular case, and left nothing else connected with it to be looked
+after. Thus, Tellson’s, in its day, like greater places of business,
+its contemporaries, had taken so many lives, that, if the heads laid
+low before it had been ranged on Temple Bar instead of being privately
+disposed of, they would probably have excluded what little light the
+ground floor had, in a rather significant manner.
+
+Cramped in all kinds of dim cupboards and hutches at Tellson’s, the
+oldest of men carried on the business gravely. When they took a young
+man into Tellson’s London house, they hid him somewhere till he was
+old. They kept him in a dark place, like a cheese, until he had the full
+Tellson flavour and blue-mould upon him. Then only was he permitted to
+be seen, spectacularly poring over large books, and casting his breeches
+and gaiters into the general weight of the establishment.
+
+Outside Tellson’s--never by any means in it, unless called in--was an
+odd-job-man, an occasional porter and messenger, who served as the live
+sign of the house. He was never absent during business hours, unless
+upon an errand, and then he was represented by his son: a grisly urchin
+of twelve, who was his express image. People understood that Tellson’s,
+in a stately way, tolerated the odd-job-man. The house had always
+tolerated some person in that capacity, and time and tide had drifted
+this person to the post. His surname was Cruncher, and on the youthful
+occasion of his renouncing by proxy the works of darkness, in the
+easterly parish church of Hounsditch, he had received the added
+appellation of Jerry.
+
+The scene was Mr. Cruncher’s private lodging in Hanging-sword-alley,
+Whitefriars: the time, half-past seven of the clock on a windy March
+morning, Anno Domini seventeen hundred and eighty. (Mr. Cruncher himself
+always spoke of the year of our Lord as Anna Dominoes: apparently under
+the impression that the Christian era dated from the invention of a
+popular game, by a lady who had bestowed her name upon it.)
+
+Mr. Cruncher’s apartments were not in a savoury neighbourhood, and were
+but two in number, even if a closet with a single pane of glass in it
+might be counted as one. But they were very decently kept. Early as
+it was, on the windy March morning, the room in which he lay abed was
+already scrubbed throughout; and between the cups and saucers arranged
+for breakfast, and the lumbering deal table, a very clean white cloth
+was spread.
+
+Mr. Cruncher reposed under a patchwork counterpane, like a Harlequin
+at home. At first, he slept heavily, but, by degrees, began to roll
+and surge in bed, until he rose above the surface, with his spiky hair
+looking as if it must tear the sheets to ribbons. At which juncture, he
+exclaimed, in a voice of dire exasperation:
+
+“Bust me, if she ain’t at it agin!”
+
+A woman of orderly and industrious appearance rose from her knees in a
+corner, with sufficient haste and trepidation to show that she was the
+person referred to.
+
+“What!” said Mr. Cruncher, looking out of bed for a boot. “You’re at it
+agin, are you?”
+
+After hailing the morn with this second salutation, he threw a boot at
+the woman as a third. It was a very muddy boot, and may introduce the
+odd circumstance connected with Mr. Cruncher’s domestic economy, that,
+whereas he often came home after banking hours with clean boots, he
+often got up next morning to find the same boots covered with clay.
+
+“What,” said Mr. Cruncher, varying his apostrophe after missing his
+mark--“what are you up to, Aggerawayter?”
+
+“I was only saying my prayers.”
+
+“Saying your prayers! You’re a nice woman! What do you mean by flopping
+yourself down and praying agin me?”
+
+“I was not praying against you; I was praying for you.”
+
+“You weren’t. And if you were, I won’t be took the liberty with. Here!
+your mother’s a nice woman, young Jerry, going a praying agin your
+father’s prosperity. You’ve got a dutiful mother, you have, my son.
+You’ve got a religious mother, you have, my boy: going and flopping
+herself down, and praying that the bread-and-butter may be snatched out
+of the mouth of her only child.”
+
+Master Cruncher (who was in his shirt) took this very ill, and, turning
+to his mother, strongly deprecated any praying away of his personal
+board.
+
+“And what do you suppose, you conceited female,” said Mr. Cruncher, with
+unconscious inconsistency, “that the worth of _your_ prayers may be?
+Name the price that you put _your_ prayers at!”
+
+“They only come from the heart, Jerry. They are worth no more than
+that.”
+
+“Worth no more than that,” repeated Mr. Cruncher. “They ain’t worth
+much, then. Whether or no, I won’t be prayed agin, I tell you. I can’t
+afford it. I’m not a going to be made unlucky by _your_ sneaking. If
+you must go flopping yourself down, flop in favour of your husband and
+child, and not in opposition to ‘em. If I had had any but a unnat’ral
+wife, and this poor boy had had any but a unnat’ral mother, I might
+have made some money last week instead of being counter-prayed and
+countermined and religiously circumwented into the worst of luck.
+B-u-u-ust me!” said Mr. Cruncher, who all this time had been putting
+on his clothes, “if I ain’t, what with piety and one blowed thing and
+another, been choused this last week into as bad luck as ever a poor
+devil of a honest tradesman met with! Young Jerry, dress yourself, my
+boy, and while I clean my boots keep a eye upon your mother now and
+then, and if you see any signs of more flopping, give me a call. For, I
+tell you,” here he addressed his wife once more, “I won’t be gone agin,
+in this manner. I am as rickety as a hackney-coach, I’m as sleepy as
+laudanum, my lines is strained to that degree that I shouldn’t know, if
+it wasn’t for the pain in ‘em, which was me and which somebody else, yet
+I’m none the better for it in pocket; and it’s my suspicion that you’ve
+been at it from morning to night to prevent me from being the better for
+it in pocket, and I won’t put up with it, Aggerawayter, and what do you
+say now!”
+
+Growling, in addition, such phrases as “Ah! yes! You’re religious, too.
+You wouldn’t put yourself in opposition to the interests of your husband
+and child, would you? Not you!” and throwing off other sarcastic sparks
+from the whirling grindstone of his indignation, Mr. Cruncher betook
+himself to his boot-cleaning and his general preparation for business.
+In the meantime, his son, whose head was garnished with tenderer spikes,
+and whose young eyes stood close by one another, as his father’s did,
+kept the required watch upon his mother. He greatly disturbed that poor
+woman at intervals, by darting out of his sleeping closet, where he made
+his toilet, with a suppressed cry of “You are going to flop, mother.
+--Halloa, father!” and, after raising this fictitious alarm, darting in
+again with an undutiful grin.
+
+Mr. Cruncher’s temper was not at all improved when he came to his
+breakfast. He resented Mrs. Cruncher’s saying grace with particular
+animosity.
+
+“Now, Aggerawayter! What are you up to? At it again?”
+
+His wife explained that she had merely “asked a blessing.”
+
+“Don’t do it!” said Mr. Crunches looking about, as if he rather expected
+to see the loaf disappear under the efficacy of his wife’s petitions. “I
+ain’t a going to be blest out of house and home. I won’t have my wittles
+blest off my table. Keep still!”
+
+Exceedingly red-eyed and grim, as if he had been up all night at a party
+which had taken anything but a convivial turn, Jerry Cruncher worried
+his breakfast rather than ate it, growling over it like any four-footed
+inmate of a menagerie. Towards nine o’clock he smoothed his ruffled
+aspect, and, presenting as respectable and business-like an exterior as
+he could overlay his natural self with, issued forth to the occupation
+of the day.
+
+It could scarcely be called a trade, in spite of his favourite
+description of himself as “a honest tradesman.” His stock consisted of
+a wooden stool, made out of a broken-backed chair cut down, which stool,
+young Jerry, walking at his father’s side, carried every morning to
+beneath the banking-house window that was nearest Temple Bar: where,
+with the addition of the first handful of straw that could be gleaned
+from any passing vehicle to keep the cold and wet from the odd-job-man’s
+feet, it formed the encampment for the day. On this post of his, Mr.
+Cruncher was as well known to Fleet-street and the Temple, as the Bar
+itself,--and was almost as in-looking.
+
+Encamped at a quarter before nine, in good time to touch his
+three-cornered hat to the oldest of men as they passed in to Tellson’s,
+Jerry took up his station on this windy March morning, with young Jerry
+standing by him, when not engaged in making forays through the Bar, to
+inflict bodily and mental injuries of an acute description on passing
+boys who were small enough for his amiable purpose. Father and son,
+extremely like each other, looking silently on at the morning traffic
+in Fleet-street, with their two heads as near to one another as the two
+eyes of each were, bore a considerable resemblance to a pair of monkeys.
+The resemblance was not lessened by the accidental circumstance, that
+the mature Jerry bit and spat out straw, while the twinkling eyes of the
+youthful Jerry were as restlessly watchful of him as of everything else
+in Fleet-street.
+
+The head of one of the regular indoor messengers attached to Tellson’s
+establishment was put through the door, and the word was given:
+
+“Porter wanted!”
+
+“Hooray, father! Here’s an early job to begin with!”
+
+Having thus given his parent God speed, young Jerry seated himself on
+the stool, entered on his reversionary interest in the straw his father
+had been chewing, and cogitated.
+
+“Al-ways rusty! His fingers is al-ways rusty!” muttered young Jerry.
+“Where does my father get all that iron rust from? He don’t get no iron
+rust here!”
+
+
+
+
+II. A Sight
+
+
+“You know the Old Bailey well, no doubt?” said one of the oldest of
+clerks to Jerry the messenger.
+
+“Ye-es, sir,” returned Jerry, in something of a dogged manner. “I _do_
+know the Bailey.”
+
+“Just so. And you know Mr. Lorry.”
+
+“I know Mr. Lorry, sir, much better than I know the Bailey. Much
+better,” said Jerry, not unlike a reluctant witness at the establishment
+in question, “than I, as a honest tradesman, wish to know the Bailey.”
+
+“Very well. Find the door where the witnesses go in, and show the
+door-keeper this note for Mr. Lorry. He will then let you in.”
+
+“Into the court, sir?”
+
+“Into the court.”
+
+Mr. Cruncher’s eyes seemed to get a little closer to one another, and to
+interchange the inquiry, “What do you think of this?”
+
+“Am I to wait in the court, sir?” he asked, as the result of that
+conference.
+
+“I am going to tell you. The door-keeper will pass the note to Mr.
+Lorry, and do you make any gesture that will attract Mr. Lorry’s
+attention, and show him where you stand. Then what you have to do, is,
+to remain there until he wants you.”
+
+“Is that all, sir?”
+
+“That’s all. He wishes to have a messenger at hand. This is to tell him
+you are there.”
+
+As the ancient clerk deliberately folded and superscribed the note,
+Mr. Cruncher, after surveying him in silence until he came to the
+blotting-paper stage, remarked:
+
+“I suppose they’ll be trying Forgeries this morning?”
+
+“Treason!”
+
+“That’s quartering,” said Jerry. “Barbarous!”
+
+“It is the law,” remarked the ancient clerk, turning his surprised
+spectacles upon him. “It is the law.”
+
+“It’s hard in the law to spile a man, I think. It’s hard enough to kill
+him, but it’s wery hard to spile him, sir.”
+
+“Not at all,” retained the ancient clerk. “Speak well of the law. Take
+care of your chest and voice, my good friend, and leave the law to take
+care of itself. I give you that advice.”
+
+“It’s the damp, sir, what settles on my chest and voice,” said Jerry. “I
+leave you to judge what a damp way of earning a living mine is.”
+
+“Well, well,” said the old clerk; “we all have our various ways of
+gaining a livelihood. Some of us have damp ways, and some of us have dry
+ways. Here is the letter. Go along.”
+
+Jerry took the letter, and, remarking to himself with less internal
+deference than he made an outward show of, “You are a lean old one,
+too,” made his bow, informed his son, in passing, of his destination,
+and went his way.
+
+They hanged at Tyburn, in those days, so the street outside Newgate had
+not obtained one infamous notoriety that has since attached to it.
+But, the gaol was a vile place, in which most kinds of debauchery and
+villainy were practised, and where dire diseases were bred, that came
+into court with the prisoners, and sometimes rushed straight from the
+dock at my Lord Chief Justice himself, and pulled him off the bench. It
+had more than once happened, that the Judge in the black cap pronounced
+his own doom as certainly as the prisoner’s, and even died before him.
+For the rest, the Old Bailey was famous as a kind of deadly inn-yard,
+from which pale travellers set out continually, in carts and coaches, on
+a violent passage into the other world: traversing some two miles and a
+half of public street and road, and shaming few good citizens, if any.
+So powerful is use, and so desirable to be good use in the beginning. It
+was famous, too, for the pillory, a wise old institution, that inflicted
+a punishment of which no one could foresee the extent; also, for
+the whipping-post, another dear old institution, very humanising and
+softening to behold in action; also, for extensive transactions in
+blood-money, another fragment of ancestral wisdom, systematically
+leading to the most frightful mercenary crimes that could be committed
+under Heaven. Altogether, the Old Bailey, at that date, was a choice
+illustration of the precept, that “Whatever is is right;” an aphorism
+that would be as final as it is lazy, did it not include the troublesome
+consequence, that nothing that ever was, was wrong.
+
+Making his way through the tainted crowd, dispersed up and down this
+hideous scene of action, with the skill of a man accustomed to make his
+way quietly, the messenger found out the door he sought, and handed in
+his letter through a trap in it. For, people then paid to see the play
+at the Old Bailey, just as they paid to see the play in Bedlam--only the
+former entertainment was much the dearer. Therefore, all the Old Bailey
+doors were well guarded--except, indeed, the social doors by which the
+criminals got there, and those were always left wide open.
+
+After some delay and demur, the door grudgingly turned on its hinges a
+very little way, and allowed Mr. Jerry Cruncher to squeeze himself into
+court.
+
+“What’s on?” he asked, in a whisper, of the man he found himself next
+to.
+
+“Nothing yet.”
+
+“What’s coming on?”
+
+“The Treason case.”
+
+“The quartering one, eh?”
+
+“Ah!” returned the man, with a relish; “he’ll be drawn on a hurdle to
+be half hanged, and then he’ll be taken down and sliced before his own
+face, and then his inside will be taken out and burnt while he looks on,
+and then his head will be chopped off, and he’ll be cut into quarters.
+That’s the sentence.”
+
+“If he’s found Guilty, you mean to say?” Jerry added, by way of proviso.
+
+“Oh! they’ll find him guilty,” said the other. “Don’t you be afraid of
+that.”
+
+Mr. Cruncher’s attention was here diverted to the door-keeper, whom he
+saw making his way to Mr. Lorry, with the note in his hand. Mr. Lorry
+sat at a table, among the gentlemen in wigs: not far from a wigged
+gentleman, the prisoner’s counsel, who had a great bundle of papers
+before him: and nearly opposite another wigged gentleman with his hands
+in his pockets, whose whole attention, when Mr. Cruncher looked at him
+then or afterwards, seemed to be concentrated on the ceiling of the
+court. After some gruff coughing and rubbing of his chin and signing
+with his hand, Jerry attracted the notice of Mr. Lorry, who had stood up
+to look for him, and who quietly nodded and sat down again.
+
+“What’s _he_ got to do with the case?” asked the man he had spoken with.
+
+“Blest if I know,” said Jerry.
+
+“What have _you_ got to do with it, then, if a person may inquire?”
+
+“Blest if I know that either,” said Jerry.
+
+The entrance of the Judge, and a consequent great stir and settling
+down in the court, stopped the dialogue. Presently, the dock became the
+central point of interest. Two gaolers, who had been standing there,
+went out, and the prisoner was brought in, and put to the bar.
+
+Everybody present, except the one wigged gentleman who looked at the
+ceiling, stared at him. All the human breath in the place, rolled
+at him, like a sea, or a wind, or a fire. Eager faces strained round
+pillars and corners, to get a sight of him; spectators in back rows
+stood up, not to miss a hair of him; people on the floor of the court,
+laid their hands on the shoulders of the people before them, to help
+themselves, at anybody’s cost, to a view of him--stood a-tiptoe, got
+upon ledges, stood upon next to nothing, to see every inch of him.
+Conspicuous among these latter, like an animated bit of the spiked wall
+of Newgate, Jerry stood: aiming at the prisoner the beery breath of a
+whet he had taken as he came along, and discharging it to mingle with
+the waves of other beer, and gin, and tea, and coffee, and what not,
+that flowed at him, and already broke upon the great windows behind him
+in an impure mist and rain.
+
+The object of all this staring and blaring, was a young man of about
+five-and-twenty, well-grown and well-looking, with a sunburnt cheek and
+a dark eye. His condition was that of a young gentleman. He was plainly
+dressed in black, or very dark grey, and his hair, which was long and
+dark, was gathered in a ribbon at the back of his neck; more to be out
+of his way than for ornament. As an emotion of the mind will express
+itself through any covering of the body, so the paleness which his
+situation engendered came through the brown upon his cheek, showing the
+soul to be stronger than the sun. He was otherwise quite self-possessed,
+bowed to the Judge, and stood quiet.
+
+The sort of interest with which this man was stared and breathed at,
+was not a sort that elevated humanity. Had he stood in peril of a less
+horrible sentence--had there been a chance of any one of its savage
+details being spared--by just so much would he have lost in his
+fascination. The form that was to be doomed to be so shamefully mangled,
+was the sight; the immortal creature that was to be so butchered
+and torn asunder, yielded the sensation. Whatever gloss the various
+spectators put upon the interest, according to their several arts and
+powers of self-deceit, the interest was, at the root of it, Ogreish.
+
+Silence in the court! Charles Darnay had yesterday pleaded Not Guilty to
+an indictment denouncing him (with infinite jingle and jangle) for that
+he was a false traitor to our serene, illustrious, excellent, and so
+forth, prince, our Lord the King, by reason of his having, on divers
+occasions, and by divers means and ways, assisted Lewis, the French
+King, in his wars against our said serene, illustrious, excellent, and
+so forth; that was to say, by coming and going, between the dominions of
+our said serene, illustrious, excellent, and so forth, and those of the
+said French Lewis, and wickedly, falsely, traitorously, and otherwise
+evil-adverbiously, revealing to the said French Lewis what forces our
+said serene, illustrious, excellent, and so forth, had in preparation
+to send to Canada and North America. This much, Jerry, with his head
+becoming more and more spiky as the law terms bristled it, made out with
+huge satisfaction, and so arrived circuitously at the understanding that
+the aforesaid, and over and over again aforesaid, Charles Darnay, stood
+there before him upon his trial; that the jury were swearing in; and
+that Mr. Attorney-General was making ready to speak.
+
+The accused, who was (and who knew he was) being mentally hanged,
+beheaded, and quartered, by everybody there, neither flinched from
+the situation, nor assumed any theatrical air in it. He was quiet and
+attentive; watched the opening proceedings with a grave interest;
+and stood with his hands resting on the slab of wood before him, so
+composedly, that they had not displaced a leaf of the herbs with which
+it was strewn. The court was all bestrewn with herbs and sprinkled with
+vinegar, as a precaution against gaol air and gaol fever.
+
+Over the prisoner’s head there was a mirror, to throw the light down
+upon him. Crowds of the wicked and the wretched had been reflected in
+it, and had passed from its surface and this earth’s together. Haunted
+in a most ghastly manner that abominable place would have been, if the
+glass could ever have rendered back its reflections, as the ocean is one
+day to give up its dead. Some passing thought of the infamy and disgrace
+for which it had been reserved, may have struck the prisoner’s mind. Be
+that as it may, a change in his position making him conscious of a bar
+of light across his face, he looked up; and when he saw the glass his
+face flushed, and his right hand pushed the herbs away.
+
+It happened, that the action turned his face to that side of the court
+which was on his left. About on a level with his eyes, there sat,
+in that corner of the Judge’s bench, two persons upon whom his look
+immediately rested; so immediately, and so much to the changing of his
+aspect, that all the eyes that were turned upon him, turned to them.
+
+The spectators saw in the two figures, a young lady of little more than
+twenty, and a gentleman who was evidently her father; a man of a very
+remarkable appearance in respect of the absolute whiteness of his hair,
+and a certain indescribable intensity of face: not of an active kind,
+but pondering and self-communing. When this expression was upon him, he
+looked as if he were old; but when it was stirred and broken up--as
+it was now, in a moment, on his speaking to his daughter--he became a
+handsome man, not past the prime of life.
+
+His daughter had one of her hands drawn through his arm, as she sat by
+him, and the other pressed upon it. She had drawn close to him, in her
+dread of the scene, and in her pity for the prisoner. Her forehead had
+been strikingly expressive of an engrossing terror and compassion
+that saw nothing but the peril of the accused. This had been so very
+noticeable, so very powerfully and naturally shown, that starers who
+had had no pity for him were touched by her; and the whisper went about,
+“Who are they?”
+
+Jerry, the messenger, who had made his own observations, in his own
+manner, and who had been sucking the rust off his fingers in his
+absorption, stretched his neck to hear who they were. The crowd about
+him had pressed and passed the inquiry on to the nearest attendant, and
+from him it had been more slowly pressed and passed back; at last it got
+to Jerry:
+
+“Witnesses.”
+
+“For which side?”
+
+“Against.”
+
+“Against what side?”
+
+“The prisoner’s.”
+
+The Judge, whose eyes had gone in the general direction, recalled them,
+leaned back in his seat, and looked steadily at the man whose life was
+in his hand, as Mr. Attorney-General rose to spin the rope, grind the
+axe, and hammer the nails into the scaffold.
+
+
+
+
+III. A Disappointment
+
+
+Mr. Attorney-General had to inform the jury, that the prisoner before
+them, though young in years, was old in the treasonable practices which
+claimed the forfeit of his life. That this correspondence with the
+public enemy was not a correspondence of to-day, or of yesterday, or
+even of last year, or of the year before. That, it was certain the
+prisoner had, for longer than that, been in the habit of passing and
+repassing between France and England, on secret business of which
+he could give no honest account. That, if it were in the nature of
+traitorous ways to thrive (which happily it never was), the real
+wickedness and guilt of his business might have remained undiscovered.
+That Providence, however, had put it into the heart of a person who
+was beyond fear and beyond reproach, to ferret out the nature of the
+prisoner’s schemes, and, struck with horror, to disclose them to his
+Majesty’s Chief Secretary of State and most honourable Privy Council.
+That, this patriot would be produced before them. That, his position and
+attitude were, on the whole, sublime. That, he had been the prisoner’s
+friend, but, at once in an auspicious and an evil hour detecting his
+infamy, had resolved to immolate the traitor he could no longer cherish
+in his bosom, on the sacred altar of his country. That, if statues
+were decreed in Britain, as in ancient Greece and Rome, to public
+benefactors, this shining citizen would assuredly have had one. That, as
+they were not so decreed, he probably would not have one. That, Virtue,
+as had been observed by the poets (in many passages which he well
+knew the jury would have, word for word, at the tips of their tongues;
+whereat the jury’s countenances displayed a guilty consciousness that
+they knew nothing about the passages), was in a manner contagious; more
+especially the bright virtue known as patriotism, or love of country.
+That, the lofty example of this immaculate and unimpeachable witness
+for the Crown, to refer to whom however unworthily was an honour, had
+communicated itself to the prisoner’s servant, and had engendered in him
+a holy determination to examine his master’s table-drawers and pockets,
+and secrete his papers. That, he (Mr. Attorney-General) was prepared to
+hear some disparagement attempted of this admirable servant; but that,
+in a general way, he preferred him to his (Mr. Attorney-General’s)
+brothers and sisters, and honoured him more than his (Mr.
+Attorney-General’s) father and mother. That, he called with confidence
+on the jury to come and do likewise. That, the evidence of these two
+witnesses, coupled with the documents of their discovering that would be
+produced, would show the prisoner to have been furnished with lists of
+his Majesty’s forces, and of their disposition and preparation, both by
+sea and land, and would leave no doubt that he had habitually conveyed
+such information to a hostile power. That, these lists could not be
+proved to be in the prisoner’s handwriting; but that it was all the
+same; that, indeed, it was rather the better for the prosecution, as
+showing the prisoner to be artful in his precautions. That, the proof
+would go back five years, and would show the prisoner already engaged
+in these pernicious missions, within a few weeks before the date of the
+very first action fought between the British troops and the Americans.
+That, for these reasons, the jury, being a loyal jury (as he knew they
+were), and being a responsible jury (as _they_ knew they were), must
+positively find the prisoner Guilty, and make an end of him, whether
+they liked it or not. That, they never could lay their heads upon their
+pillows; that, they never could tolerate the idea of their wives laying
+their heads upon their pillows; that, they never could endure the notion
+of their children laying their heads upon their pillows; in short, that
+there never more could be, for them or theirs, any laying of heads upon
+pillows at all, unless the prisoner’s head was taken off. That head
+Mr. Attorney-General concluded by demanding of them, in the name of
+everything he could think of with a round turn in it, and on the faith
+of his solemn asseveration that he already considered the prisoner as
+good as dead and gone.
+
+When the Attorney-General ceased, a buzz arose in the court as if
+a cloud of great blue-flies were swarming about the prisoner, in
+anticipation of what he was soon to become. When toned down again, the
+unimpeachable patriot appeared in the witness-box.
+
+Mr. Solicitor-General then, following his leader’s lead, examined the
+patriot: John Barsad, gentleman, by name. The story of his pure soul was
+exactly what Mr. Attorney-General had described it to be--perhaps, if
+it had a fault, a little too exactly. Having released his noble bosom
+of its burden, he would have modestly withdrawn himself, but that the
+wigged gentleman with the papers before him, sitting not far from Mr.
+Lorry, begged to ask him a few questions. The wigged gentleman sitting
+opposite, still looking at the ceiling of the court.
+
+Had he ever been a spy himself? No, he scorned the base insinuation.
+What did he live upon? His property. Where was his property? He didn’t
+precisely remember where it was. What was it? No business of anybody’s.
+Had he inherited it? Yes, he had. From whom? Distant relation. Very
+distant? Rather. Ever been in prison? Certainly not. Never in a debtors’
+prison? Didn’t see what that had to do with it. Never in a debtors’
+prison?--Come, once again. Never? Yes. How many times? Two or three
+times. Not five or six? Perhaps. Of what profession? Gentleman. Ever
+been kicked? Might have been. Frequently? No. Ever kicked downstairs?
+Decidedly not; once received a kick on the top of a staircase, and fell
+downstairs of his own accord. Kicked on that occasion for cheating at
+dice? Something to that effect was said by the intoxicated liar who
+committed the assault, but it was not true. Swear it was not true?
+Positively. Ever live by cheating at play? Never. Ever live by play? Not
+more than other gentlemen do. Ever borrow money of the prisoner? Yes.
+Ever pay him? No. Was not this intimacy with the prisoner, in reality a
+very slight one, forced upon the prisoner in coaches, inns, and packets?
+No. Sure he saw the prisoner with these lists? Certain. Knew no more
+about the lists? No. Had not procured them himself, for instance? No.
+Expect to get anything by this evidence? No. Not in regular government
+pay and employment, to lay traps? Oh dear no. Or to do anything? Oh dear
+no. Swear that? Over and over again. No motives but motives of sheer
+patriotism? None whatever.
+
+The virtuous servant, Roger Cly, swore his way through the case at a
+great rate. He had taken service with the prisoner, in good faith and
+simplicity, four years ago. He had asked the prisoner, aboard the Calais
+packet, if he wanted a handy fellow, and the prisoner had engaged him.
+He had not asked the prisoner to take the handy fellow as an act of
+charity--never thought of such a thing. He began to have suspicions of
+the prisoner, and to keep an eye upon him, soon afterwards. In arranging
+his clothes, while travelling, he had seen similar lists to these in the
+prisoner’s pockets, over and over again. He had taken these lists from
+the drawer of the prisoner’s desk. He had not put them there first. He
+had seen the prisoner show these identical lists to French gentlemen
+at Calais, and similar lists to French gentlemen, both at Calais and
+Boulogne. He loved his country, and couldn’t bear it, and had given
+information. He had never been suspected of stealing a silver tea-pot;
+he had been maligned respecting a mustard-pot, but it turned out to be
+only a plated one. He had known the last witness seven or eight years;
+that was merely a coincidence. He didn’t call it a particularly curious
+coincidence; most coincidences were curious. Neither did he call it a
+curious coincidence that true patriotism was _his_ only motive too. He
+was a true Briton, and hoped there were many like him.
+
+The blue-flies buzzed again, and Mr. Attorney-General called Mr. Jarvis
+Lorry.
+
+“Mr. Jarvis Lorry, are you a clerk in Tellson’s bank?”
+
+“I am.”
+
+“On a certain Friday night in November one thousand seven hundred and
+seventy-five, did business occasion you to travel between London and
+Dover by the mail?”
+
+“It did.”
+
+“Were there any other passengers in the mail?”
+
+“Two.”
+
+“Did they alight on the road in the course of the night?”
+
+“They did.”
+
+“Mr. Lorry, look upon the prisoner. Was he one of those two passengers?”
+
+“I cannot undertake to say that he was.”
+
+“Does he resemble either of these two passengers?”
+
+“Both were so wrapped up, and the night was so dark, and we were all so
+reserved, that I cannot undertake to say even that.”
+
+“Mr. Lorry, look again upon the prisoner. Supposing him wrapped up as
+those two passengers were, is there anything in his bulk and stature to
+render it unlikely that he was one of them?”
+
+“No.”
+
+“You will not swear, Mr. Lorry, that he was not one of them?”
+
+“No.”
+
+“So at least you say he may have been one of them?”
+
+“Yes. Except that I remember them both to have been--like
+myself--timorous of highwaymen, and the prisoner has not a timorous
+air.”
+
+“Did you ever see a counterfeit of timidity, Mr. Lorry?”
+
+“I certainly have seen that.”
+
+“Mr. Lorry, look once more upon the prisoner. Have you seen him, to your
+certain knowledge, before?”
+
+“I have.”
+
+“When?”
+
+“I was returning from France a few days afterwards, and, at Calais, the
+prisoner came on board the packet-ship in which I returned, and made the
+voyage with me.”
+
+“At what hour did he come on board?”
+
+“At a little after midnight.”
+
+“In the dead of the night. Was he the only passenger who came on board
+at that untimely hour?”
+
+“He happened to be the only one.”
+
+“Never mind about ‘happening,’ Mr. Lorry. He was the only passenger who
+came on board in the dead of the night?”
+
+“He was.”
+
+“Were you travelling alone, Mr. Lorry, or with any companion?”
+
+“With two companions. A gentleman and lady. They are here.”
+
+“They are here. Had you any conversation with the prisoner?”
+
+“Hardly any. The weather was stormy, and the passage long and rough, and
+I lay on a sofa, almost from shore to shore.”
+
+“Miss Manette!”
+
+The young lady, to whom all eyes had been turned before, and were now
+turned again, stood up where she had sat. Her father rose with her, and
+kept her hand drawn through his arm.
+
+“Miss Manette, look upon the prisoner.”
+
+To be confronted with such pity, and such earnest youth and beauty, was
+far more trying to the accused than to be confronted with all the crowd.
+Standing, as it were, apart with her on the edge of his grave, not all
+the staring curiosity that looked on, could, for the moment, nerve him
+to remain quite still. His hurried right hand parcelled out the herbs
+before him into imaginary beds of flowers in a garden; and his efforts
+to control and steady his breathing shook the lips from which the colour
+rushed to his heart. The buzz of the great flies was loud again.
+
+“Miss Manette, have you seen the prisoner before?”
+
+“Yes, sir.”
+
+“Where?”
+
+“On board of the packet-ship just now referred to, sir, and on the same
+occasion.”
+
+“You are the young lady just now referred to?”
+
+“O! most unhappily, I am!”
+
+The plaintive tone of her compassion merged into the less musical voice
+of the Judge, as he said something fiercely: “Answer the questions put
+to you, and make no remark upon them.”
+
+“Miss Manette, had you any conversation with the prisoner on that
+passage across the Channel?”
+
+“Yes, sir.”
+
+“Recall it.”
+
+In the midst of a profound stillness, she faintly began: “When the
+gentleman came on board--”
+
+“Do you mean the prisoner?” inquired the Judge, knitting his brows.
+
+“Yes, my Lord.”
+
+“Then say the prisoner.”
+
+“When the prisoner came on board, he noticed that my father,” turning
+her eyes lovingly to him as he stood beside her, “was much fatigued
+and in a very weak state of health. My father was so reduced that I was
+afraid to take him out of the air, and I had made a bed for him on the
+deck near the cabin steps, and I sat on the deck at his side to take
+care of him. There were no other passengers that night, but we four.
+The prisoner was so good as to beg permission to advise me how I could
+shelter my father from the wind and weather, better than I had done. I
+had not known how to do it well, not understanding how the wind would
+set when we were out of the harbour. He did it for me. He expressed
+great gentleness and kindness for my father’s state, and I am sure he
+felt it. That was the manner of our beginning to speak together.”
+
+“Let me interrupt you for a moment. Had he come on board alone?”
+
+“No.”
+
+“How many were with him?”
+
+“Two French gentlemen.”
+
+“Had they conferred together?”
+
+“They had conferred together until the last moment, when it was
+necessary for the French gentlemen to be landed in their boat.”
+
+“Had any papers been handed about among them, similar to these lists?”
+
+“Some papers had been handed about among them, but I don’t know what
+papers.”
+
+“Like these in shape and size?”
+
+“Possibly, but indeed I don’t know, although they stood whispering very
+near to me: because they stood at the top of the cabin steps to have the
+light of the lamp that was hanging there; it was a dull lamp, and they
+spoke very low, and I did not hear what they said, and saw only that
+they looked at papers.”
+
+“Now, to the prisoner’s conversation, Miss Manette.”
+
+“The prisoner was as open in his confidence with me--which arose out
+of my helpless situation--as he was kind, and good, and useful to my
+father. I hope,” bursting into tears, “I may not repay him by doing him
+harm to-day.”
+
+Buzzing from the blue-flies.
+
+“Miss Manette, if the prisoner does not perfectly understand that
+you give the evidence which it is your duty to give--which you must
+give--and which you cannot escape from giving--with great unwillingness,
+he is the only person present in that condition. Please to go on.”
+
+“He told me that he was travelling on business of a delicate and
+difficult nature, which might get people into trouble, and that he was
+therefore travelling under an assumed name. He said that this business
+had, within a few days, taken him to France, and might, at intervals,
+take him backwards and forwards between France and England for a long
+time to come.”
+
+“Did he say anything about America, Miss Manette? Be particular.”
+
+“He tried to explain to me how that quarrel had arisen, and he said
+that, so far as he could judge, it was a wrong and foolish one on
+England’s part. He added, in a jesting way, that perhaps George
+Washington might gain almost as great a name in history as George the
+Third. But there was no harm in his way of saying this: it was said
+laughingly, and to beguile the time.”
+
+Any strongly marked expression of face on the part of a chief actor in
+a scene of great interest to whom many eyes are directed, will be
+unconsciously imitated by the spectators. Her forehead was painfully
+anxious and intent as she gave this evidence, and, in the pauses when
+she stopped for the Judge to write it down, watched its effect upon
+the counsel for and against. Among the lookers-on there was the same
+expression in all quarters of the court; insomuch, that a great majority
+of the foreheads there, might have been mirrors reflecting the witness,
+when the Judge looked up from his notes to glare at that tremendous
+heresy about George Washington.
+
+Mr. Attorney-General now signified to my Lord, that he deemed it
+necessary, as a matter of precaution and form, to call the young lady’s
+father, Doctor Manette. Who was called accordingly.
+
+“Doctor Manette, look upon the prisoner. Have you ever seen him before?”
+
+“Once. When he called at my lodgings in London. Some three years, or
+three years and a half ago.”
+
+“Can you identify him as your fellow-passenger on board the packet, or
+speak to his conversation with your daughter?”
+
+“Sir, I can do neither.”
+
+“Is there any particular and special reason for your being unable to do
+either?”
+
+He answered, in a low voice, “There is.”
+
+“Has it been your misfortune to undergo a long imprisonment, without
+trial, or even accusation, in your native country, Doctor Manette?”
+
+He answered, in a tone that went to every heart, “A long imprisonment.”
+
+“Were you newly released on the occasion in question?”
+
+“They tell me so.”
+
+“Have you no remembrance of the occasion?”
+
+“None. My mind is a blank, from some time--I cannot even say what
+time--when I employed myself, in my captivity, in making shoes, to the
+time when I found myself living in London with my dear daughter
+here. She had become familiar to me, when a gracious God restored
+my faculties; but, I am quite unable even to say how she had become
+familiar. I have no remembrance of the process.”
+
+Mr. Attorney-General sat down, and the father and daughter sat down
+together.
+
+A singular circumstance then arose in the case. The object in hand being
+to show that the prisoner went down, with some fellow-plotter untracked,
+in the Dover mail on that Friday night in November five years ago, and
+got out of the mail in the night, as a blind, at a place where he did
+not remain, but from which he travelled back some dozen miles or more,
+to a garrison and dockyard, and there collected information; a witness
+was called to identify him as having been at the precise time required,
+in the coffee-room of an hotel in that garrison-and-dockyard town,
+waiting for another person. The prisoner’s counsel was cross-examining
+this witness with no result, except that he had never seen the prisoner
+on any other occasion, when the wigged gentleman who had all this time
+been looking at the ceiling of the court, wrote a word or two on a
+little piece of paper, screwed it up, and tossed it to him. Opening
+this piece of paper in the next pause, the counsel looked with great
+attention and curiosity at the prisoner.
+
+“You say again you are quite sure that it was the prisoner?”
+
+The witness was quite sure.
+
+“Did you ever see anybody very like the prisoner?”
+
+Not so like (the witness said) as that he could be mistaken.
+
+“Look well upon that gentleman, my learned friend there,” pointing
+to him who had tossed the paper over, “and then look well upon the
+prisoner. How say you? Are they very like each other?”
+
+Allowing for my learned friend’s appearance being careless and slovenly
+if not debauched, they were sufficiently like each other to surprise,
+not only the witness, but everybody present, when they were thus brought
+into comparison. My Lord being prayed to bid my learned friend lay aside
+his wig, and giving no very gracious consent, the likeness became
+much more remarkable. My Lord inquired of Mr. Stryver (the prisoner’s
+counsel), whether they were next to try Mr. Carton (name of my learned
+friend) for treason? But, Mr. Stryver replied to my Lord, no; but he
+would ask the witness to tell him whether what happened once, might
+happen twice; whether he would have been so confident if he had seen
+this illustration of his rashness sooner, whether he would be so
+confident, having seen it; and more. The upshot of which, was, to smash
+this witness like a crockery vessel, and shiver his part of the case to
+useless lumber.
+
+Mr. Cruncher had by this time taken quite a lunch of rust off his
+fingers in his following of the evidence. He had now to attend while Mr.
+Stryver fitted the prisoner’s case on the jury, like a compact suit
+of clothes; showing them how the patriot, Barsad, was a hired spy and
+traitor, an unblushing trafficker in blood, and one of the greatest
+scoundrels upon earth since accursed Judas--which he certainly did look
+rather like. How the virtuous servant, Cly, was his friend and partner,
+and was worthy to be; how the watchful eyes of those forgers and false
+swearers had rested on the prisoner as a victim, because some family
+affairs in France, he being of French extraction, did require his making
+those passages across the Channel--though what those affairs were, a
+consideration for others who were near and dear to him, forbade him,
+even for his life, to disclose. How the evidence that had been warped
+and wrested from the young lady, whose anguish in giving it they
+had witnessed, came to nothing, involving the mere little innocent
+gallantries and politenesses likely to pass between any young gentleman
+and young lady so thrown together;--with the exception of that
+reference to George Washington, which was altogether too extravagant and
+impossible to be regarded in any other light than as a monstrous joke.
+How it would be a weakness in the government to break down in this
+attempt to practise for popularity on the lowest national antipathies
+and fears, and therefore Mr. Attorney-General had made the most of it;
+how, nevertheless, it rested upon nothing, save that vile and infamous
+character of evidence too often disfiguring such cases, and of which the
+State Trials of this country were full. But, there my Lord interposed
+(with as grave a face as if it had not been true), saying that he could
+not sit upon that Bench and suffer those allusions.
+
+Mr. Stryver then called his few witnesses, and Mr. Cruncher had next to
+attend while Mr. Attorney-General turned the whole suit of clothes Mr.
+Stryver had fitted on the jury, inside out; showing how Barsad and
+Cly were even a hundred times better than he had thought them, and the
+prisoner a hundred times worse. Lastly, came my Lord himself, turning
+the suit of clothes, now inside out, now outside in, but on the whole
+decidedly trimming and shaping them into grave-clothes for the prisoner.
+
+And now, the jury turned to consider, and the great flies swarmed again.
+
+Mr. Carton, who had so long sat looking at the ceiling of the court,
+changed neither his place nor his attitude, even in this excitement.
+While his learned friend, Mr. Stryver, massing his papers before him,
+whispered with those who sat near, and from time to time glanced
+anxiously at the jury; while all the spectators moved more or less, and
+grouped themselves anew; while even my Lord himself arose from his seat,
+and slowly paced up and down his platform, not unattended by a suspicion
+in the minds of the audience that his state was feverish; this one man
+sat leaning back, with his torn gown half off him, his untidy wig put
+on just as it had happened to light on his head after its removal, his
+hands in his pockets, and his eyes on the ceiling as they had been all
+day. Something especially reckless in his demeanour, not only gave him
+a disreputable look, but so diminished the strong resemblance he
+undoubtedly bore to the prisoner (which his momentary earnestness,
+when they were compared together, had strengthened), that many of the
+lookers-on, taking note of him now, said to one another they would
+hardly have thought the two were so alike. Mr. Cruncher made the
+observation to his next neighbour, and added, “I’d hold half a guinea
+that _he_ don’t get no law-work to do. Don’t look like the sort of one
+to get any, do he?”
+
+Yet, this Mr. Carton took in more of the details of the scene than he
+appeared to take in; for now, when Miss Manette’s head dropped upon
+her father’s breast, he was the first to see it, and to say audibly:
+“Officer! look to that young lady. Help the gentleman to take her out.
+Don’t you see she will fall!”
+
+There was much commiseration for her as she was removed, and much
+sympathy with her father. It had evidently been a great distress to
+him, to have the days of his imprisonment recalled. He had shown
+strong internal agitation when he was questioned, and that pondering or
+brooding look which made him old, had been upon him, like a heavy cloud,
+ever since. As he passed out, the jury, who had turned back and paused a
+moment, spoke, through their foreman.
+
+They were not agreed, and wished to retire. My Lord (perhaps with George
+Washington on his mind) showed some surprise that they were not agreed,
+but signified his pleasure that they should retire under watch and ward,
+and retired himself. The trial had lasted all day, and the lamps in
+the court were now being lighted. It began to be rumoured that the
+jury would be out a long while. The spectators dropped off to get
+refreshment, and the prisoner withdrew to the back of the dock, and sat
+down.
+
+Mr. Lorry, who had gone out when the young lady and her father went out,
+now reappeared, and beckoned to Jerry: who, in the slackened interest,
+could easily get near him.
+
+“Jerry, if you wish to take something to eat, you can. But, keep in the
+way. You will be sure to hear when the jury come in. Don’t be a moment
+behind them, for I want you to take the verdict back to the bank. You
+are the quickest messenger I know, and will get to Temple Bar long
+before I can.”
+
+Jerry had just enough forehead to knuckle, and he knuckled it in
+acknowledgment of this communication and a shilling. Mr. Carton came up
+at the moment, and touched Mr. Lorry on the arm.
+
+“How is the young lady?”
+
+“She is greatly distressed; but her father is comforting her, and she
+feels the better for being out of court.”
+
+“I’ll tell the prisoner so. It won’t do for a respectable bank gentleman
+like you, to be seen speaking to him publicly, you know.”
+
+Mr. Lorry reddened as if he were conscious of having debated the point
+in his mind, and Mr. Carton made his way to the outside of the bar.
+The way out of court lay in that direction, and Jerry followed him, all
+eyes, ears, and spikes.
+
+“Mr. Darnay!”
+
+The prisoner came forward directly.
+
+“You will naturally be anxious to hear of the witness, Miss Manette. She
+will do very well. You have seen the worst of her agitation.”
+
+“I am deeply sorry to have been the cause of it. Could you tell her so
+for me, with my fervent acknowledgments?”
+
+“Yes, I could. I will, if you ask it.”
+
+Mr. Carton’s manner was so careless as to be almost insolent. He stood,
+half turned from the prisoner, lounging with his elbow against the bar.
+
+“I do ask it. Accept my cordial thanks.”
+
+“What,” said Carton, still only half turned towards him, “do you expect,
+Mr. Darnay?”
+
+“The worst.”
+
+“It’s the wisest thing to expect, and the likeliest. But I think their
+withdrawing is in your favour.”
+
+Loitering on the way out of court not being allowed, Jerry heard no
+more: but left them--so like each other in feature, so unlike each other
+in manner--standing side by side, both reflected in the glass above
+them.
+
+An hour and a half limped heavily away in the thief-and-rascal crowded
+passages below, even though assisted off with mutton pies and ale.
+The hoarse messenger, uncomfortably seated on a form after taking that
+refection, had dropped into a doze, when a loud murmur and a rapid tide
+of people setting up the stairs that led to the court, carried him along
+with them.
+
+“Jerry! Jerry!” Mr. Lorry was already calling at the door when he got
+there.
+
+“Here, sir! It’s a fight to get back again. Here I am, sir!”
+
+Mr. Lorry handed him a paper through the throng. “Quick! Have you got
+it?”
+
+“Yes, sir.”
+
+Hastily written on the paper was the word “ACQUITTED.”
+
+“If you had sent the message, ‘Recalled to Life,’ again,” muttered
+Jerry, as he turned, “I should have known what you meant, this time.”
+
+He had no opportunity of saying, or so much as thinking, anything else,
+until he was clear of the Old Bailey; for, the crowd came pouring out
+with a vehemence that nearly took him off his legs, and a loud buzz
+swept into the street as if the baffled blue-flies were dispersing in
+search of other carrion.
+
+
+
+
+IV. Congratulatory
+
+
+From the dimly-lighted passages of the court, the last sediment of the
+human stew that had been boiling there all day, was straining off, when
+Doctor Manette, Lucie Manette, his daughter, Mr. Lorry, the solicitor
+for the defence, and its counsel, Mr. Stryver, stood gathered round Mr.
+Charles Darnay--just released--congratulating him on his escape from
+death.
+
+It would have been difficult by a far brighter light, to recognise
+in Doctor Manette, intellectual of face and upright of bearing, the
+shoemaker of the garret in Paris. Yet, no one could have looked at him
+twice, without looking again: even though the opportunity of observation
+had not extended to the mournful cadence of his low grave voice, and
+to the abstraction that overclouded him fitfully, without any apparent
+reason. While one external cause, and that a reference to his long
+lingering agony, would always--as on the trial--evoke this condition
+from the depths of his soul, it was also in its nature to arise of
+itself, and to draw a gloom over him, as incomprehensible to those
+unacquainted with his story as if they had seen the shadow of the actual
+Bastille thrown upon him by a summer sun, when the substance was three
+hundred miles away.
+
+Only his daughter had the power of charming this black brooding from
+his mind. She was the golden thread that united him to a Past beyond his
+misery, and to a Present beyond his misery: and the sound of her voice,
+the light of her face, the touch of her hand, had a strong beneficial
+influence with him almost always. Not absolutely always, for she could
+recall some occasions on which her power had failed; but they were few
+and slight, and she believed them over.
+
+Mr. Darnay had kissed her hand fervently and gratefully, and had turned
+to Mr. Stryver, whom he warmly thanked. Mr. Stryver, a man of little
+more than thirty, but looking twenty years older than he was, stout,
+loud, red, bluff, and free from any drawback of delicacy, had a pushing
+way of shouldering himself (morally and physically) into companies and
+conversations, that argued well for his shouldering his way up in life.
+
+He still had his wig and gown on, and he said, squaring himself at his
+late client to that degree that he squeezed the innocent Mr. Lorry clean
+out of the group: “I am glad to have brought you off with honour, Mr.
+Darnay. It was an infamous prosecution, grossly infamous; but not the
+less likely to succeed on that account.”
+
+“You have laid me under an obligation to you for life--in two senses,”
+ said his late client, taking his hand.
+
+“I have done my best for you, Mr. Darnay; and my best is as good as
+another man’s, I believe.”
+
+It clearly being incumbent on some one to say, “Much better,” Mr. Lorry
+said it; perhaps not quite disinterestedly, but with the interested
+object of squeezing himself back again.
+
+“You think so?” said Mr. Stryver. “Well! you have been present all day,
+and you ought to know. You are a man of business, too.”
+
+“And as such,” quoth Mr. Lorry, whom the counsel learned in the law had
+now shouldered back into the group, just as he had previously shouldered
+him out of it--“as such I will appeal to Doctor Manette, to break up
+this conference and order us all to our homes. Miss Lucie looks ill, Mr.
+Darnay has had a terrible day, we are worn out.”
+
+“Speak for yourself, Mr. Lorry,” said Stryver; “I have a night’s work to
+do yet. Speak for yourself.”
+
+“I speak for myself,” answered Mr. Lorry, “and for Mr. Darnay, and for
+Miss Lucie, and--Miss Lucie, do you not think I may speak for us all?”
+ He asked her the question pointedly, and with a glance at her father.
+
+His face had become frozen, as it were, in a very curious look at
+Darnay: an intent look, deepening into a frown of dislike and distrust,
+not even unmixed with fear. With this strange expression on him his
+thoughts had wandered away.
+
+“My father,” said Lucie, softly laying her hand on his.
+
+He slowly shook the shadow off, and turned to her.
+
+“Shall we go home, my father?”
+
+With a long breath, he answered “Yes.”
+
+The friends of the acquitted prisoner had dispersed, under the
+impression--which he himself had originated--that he would not be
+released that night. The lights were nearly all extinguished in the
+passages, the iron gates were being closed with a jar and a rattle,
+and the dismal place was deserted until to-morrow morning’s interest of
+gallows, pillory, whipping-post, and branding-iron, should repeople it.
+Walking between her father and Mr. Darnay, Lucie Manette passed into
+the open air. A hackney-coach was called, and the father and daughter
+departed in it.
+
+Mr. Stryver had left them in the passages, to shoulder his way back
+to the robing-room. Another person, who had not joined the group, or
+interchanged a word with any one of them, but who had been leaning
+against the wall where its shadow was darkest, had silently strolled
+out after the rest, and had looked on until the coach drove away. He now
+stepped up to where Mr. Lorry and Mr. Darnay stood upon the pavement.
+
+“So, Mr. Lorry! Men of business may speak to Mr. Darnay now?”
+
+Nobody had made any acknowledgment of Mr. Carton’s part in the day’s
+proceedings; nobody had known of it. He was unrobed, and was none the
+better for it in appearance.
+
+“If you knew what a conflict goes on in the business mind, when the
+business mind is divided between good-natured impulse and business
+appearances, you would be amused, Mr. Darnay.”
+
+Mr. Lorry reddened, and said, warmly, “You have mentioned that before,
+sir. We men of business, who serve a House, are not our own masters. We
+have to think of the House more than ourselves.”
+
+“_I_ know, _I_ know,” rejoined Mr. Carton, carelessly. “Don’t be
+nettled, Mr. Lorry. You are as good as another, I have no doubt: better,
+I dare say.”
+
+“And indeed, sir,” pursued Mr. Lorry, not minding him, “I really don’t
+know what you have to do with the matter. If you’ll excuse me, as very
+much your elder, for saying so, I really don’t know that it is your
+business.”
+
+“Business! Bless you, _I_ have no business,” said Mr. Carton.
+
+“It is a pity you have not, sir.”
+
+“I think so, too.”
+
+“If you had,” pursued Mr. Lorry, “perhaps you would attend to it.”
+
+“Lord love you, no!--I shouldn’t,” said Mr. Carton.
+
+“Well, sir!” cried Mr. Lorry, thoroughly heated by his indifference,
+“business is a very good thing, and a very respectable thing. And, sir,
+if business imposes its restraints and its silences and impediments, Mr.
+Darnay as a young gentleman of generosity knows how to make allowance
+for that circumstance. Mr. Darnay, good night, God bless you, sir!
+I hope you have been this day preserved for a prosperous and happy
+life.--Chair there!”
+
+Perhaps a little angry with himself, as well as with the barrister, Mr.
+Lorry bustled into the chair, and was carried off to Tellson’s. Carton,
+who smelt of port wine, and did not appear to be quite sober, laughed
+then, and turned to Darnay:
+
+“This is a strange chance that throws you and me together. This must
+be a strange night to you, standing alone here with your counterpart on
+these street stones?”
+
+“I hardly seem yet,” returned Charles Darnay, “to belong to this world
+again.”
+
+“I don’t wonder at it; it’s not so long since you were pretty far
+advanced on your way to another. You speak faintly.”
+
+“I begin to think I _am_ faint.”
+
+“Then why the devil don’t you dine? I dined, myself, while those
+numskulls were deliberating which world you should belong to--this, or
+some other. Let me show you the nearest tavern to dine well at.”
+
+Drawing his arm through his own, he took him down Ludgate-hill to
+Fleet-street, and so, up a covered way, into a tavern. Here, they were
+shown into a little room, where Charles Darnay was soon recruiting
+his strength with a good plain dinner and good wine: while Carton sat
+opposite to him at the same table, with his separate bottle of port
+before him, and his fully half-insolent manner upon him.
+
+“Do you feel, yet, that you belong to this terrestrial scheme again, Mr.
+Darnay?”
+
+“I am frightfully confused regarding time and place; but I am so far
+mended as to feel that.”
+
+“It must be an immense satisfaction!”
+
+He said it bitterly, and filled up his glass again: which was a large
+one.
+
+“As to me, the greatest desire I have, is to forget that I belong to it.
+It has no good in it for me--except wine like this--nor I for it. So we
+are not much alike in that particular. Indeed, I begin to think we are
+not much alike in any particular, you and I.”
+
+Confused by the emotion of the day, and feeling his being there with
+this Double of coarse deportment, to be like a dream, Charles Darnay was
+at a loss how to answer; finally, answered not at all.
+
+“Now your dinner is done,” Carton presently said, “why don’t you call a
+health, Mr. Darnay; why don’t you give your toast?”
+
+“What health? What toast?”
+
+“Why, it’s on the tip of your tongue. It ought to be, it must be, I’ll
+swear it’s there.”
+
+“Miss Manette, then!”
+
+“Miss Manette, then!”
+
+Looking his companion full in the face while he drank the toast, Carton
+flung his glass over his shoulder against the wall, where it shivered to
+pieces; then, rang the bell, and ordered in another.
+
+“That’s a fair young lady to hand to a coach in the dark, Mr. Darnay!”
+ he said, filling his new goblet.
+
+A slight frown and a laconic “Yes,” were the answer.
+
+“That’s a fair young lady to be pitied by and wept for by! How does it
+feel? Is it worth being tried for one’s life, to be the object of such
+sympathy and compassion, Mr. Darnay?”
+
+Again Darnay answered not a word.
+
+“She was mightily pleased to have your message, when I gave it her. Not
+that she showed she was pleased, but I suppose she was.”
+
+The allusion served as a timely reminder to Darnay that this
+disagreeable companion had, of his own free will, assisted him in the
+strait of the day. He turned the dialogue to that point, and thanked him
+for it.
+
+“I neither want any thanks, nor merit any,” was the careless rejoinder.
+“It was nothing to do, in the first place; and I don’t know why I did
+it, in the second. Mr. Darnay, let me ask you a question.”
+
+“Willingly, and a small return for your good offices.”
+
+“Do you think I particularly like you?”
+
+“Really, Mr. Carton,” returned the other, oddly disconcerted, “I have
+not asked myself the question.”
+
+“But ask yourself the question now.”
+
+“You have acted as if you do; but I don’t think you do.”
+
+“_I_ don’t think I do,” said Carton. “I begin to have a very good
+opinion of your understanding.”
+
+“Nevertheless,” pursued Darnay, rising to ring the bell, “there is
+nothing in that, I hope, to prevent my calling the reckoning, and our
+parting without ill-blood on either side.”
+
+Carton rejoining, “Nothing in life!” Darnay rang. “Do you call the whole
+reckoning?” said Carton. On his answering in the affirmative, “Then
+bring me another pint of this same wine, drawer, and come and wake me at
+ten.”
+
+The bill being paid, Charles Darnay rose and wished him good night.
+Without returning the wish, Carton rose too, with something of a threat
+of defiance in his manner, and said, “A last word, Mr. Darnay: you think
+I am drunk?”
+
+“I think you have been drinking, Mr. Carton.”
+
+“Think? You know I have been drinking.”
+
+“Since I must say so, I know it.”
+
+“Then you shall likewise know why. I am a disappointed drudge, sir. I
+care for no man on earth, and no man on earth cares for me.”
+
+“Much to be regretted. You might have used your talents better.”
+
+“May be so, Mr. Darnay; may be not. Don’t let your sober face elate you,
+however; you don’t know what it may come to. Good night!”
+
+When he was left alone, this strange being took up a candle, went to a
+glass that hung against the wall, and surveyed himself minutely in it.
+
+“Do you particularly like the man?” he muttered, at his own image; “why
+should you particularly like a man who resembles you? There is nothing
+in you to like; you know that. Ah, confound you! What a change you have
+made in yourself! A good reason for taking to a man, that he shows you
+what you have fallen away from, and what you might have been! Change
+places with him, and would you have been looked at by those blue eyes as
+he was, and commiserated by that agitated face as he was? Come on, and
+have it out in plain words! You hate the fellow.”
+
+He resorted to his pint of wine for consolation, drank it all in a few
+minutes, and fell asleep on his arms, with his hair straggling over the
+table, and a long winding-sheet in the candle dripping down upon him.
+
+
+
+
+V. The Jackal
+
+
+Those were drinking days, and most men drank hard. So very great is
+the improvement Time has brought about in such habits, that a moderate
+statement of the quantity of wine and punch which one man would swallow
+in the course of a night, without any detriment to his reputation as a
+perfect gentleman, would seem, in these days, a ridiculous exaggeration.
+The learned profession of the law was certainly not behind any other
+learned profession in its Bacchanalian propensities; neither was Mr.
+Stryver, already fast shouldering his way to a large and lucrative
+practice, behind his compeers in this particular, any more than in the
+drier parts of the legal race.
+
+A favourite at the Old Bailey, and eke at the Sessions, Mr. Stryver had
+begun cautiously to hew away the lower staves of the ladder on which
+he mounted. Sessions and Old Bailey had now to summon their favourite,
+specially, to their longing arms; and shouldering itself towards the
+visage of the Lord Chief Justice in the Court of King’s Bench, the
+florid countenance of Mr. Stryver might be daily seen, bursting out of
+the bed of wigs, like a great sunflower pushing its way at the sun from
+among a rank garden-full of flaring companions.
+
+It had once been noted at the Bar, that while Mr. Stryver was a glib
+man, and an unscrupulous, and a ready, and a bold, he had not that
+faculty of extracting the essence from a heap of statements, which is
+among the most striking and necessary of the advocate’s accomplishments.
+But, a remarkable improvement came upon him as to this. The more
+business he got, the greater his power seemed to grow of getting at its
+pith and marrow; and however late at night he sat carousing with Sydney
+Carton, he always had his points at his fingers’ ends in the morning.
+
+Sydney Carton, idlest and most unpromising of men, was Stryver’s great
+ally. What the two drank together, between Hilary Term and Michaelmas,
+might have floated a king’s ship. Stryver never had a case in hand,
+anywhere, but Carton was there, with his hands in his pockets, staring
+at the ceiling of the court; they went the same Circuit, and even there
+they prolonged their usual orgies late into the night, and Carton was
+rumoured to be seen at broad day, going home stealthily and unsteadily
+to his lodgings, like a dissipated cat. At last, it began to get about,
+among such as were interested in the matter, that although Sydney Carton
+would never be a lion, he was an amazingly good jackal, and that he
+rendered suit and service to Stryver in that humble capacity.
+
+“Ten o’clock, sir,” said the man at the tavern, whom he had charged to
+wake him--“ten o’clock, sir.”
+
+“_What’s_ the matter?”
+
+“Ten o’clock, sir.”
+
+“What do you mean? Ten o’clock at night?”
+
+“Yes, sir. Your honour told me to call you.”
+
+“Oh! I remember. Very well, very well.”
+
+After a few dull efforts to get to sleep again, which the man
+dexterously combated by stirring the fire continuously for five minutes,
+he got up, tossed his hat on, and walked out. He turned into the Temple,
+and, having revived himself by twice pacing the pavements of King’s
+Bench-walk and Paper-buildings, turned into the Stryver chambers.
+
+The Stryver clerk, who never assisted at these conferences, had gone
+home, and the Stryver principal opened the door. He had his slippers on,
+and a loose bed-gown, and his throat was bare for his greater ease. He
+had that rather wild, strained, seared marking about the eyes, which
+may be observed in all free livers of his class, from the portrait of
+Jeffries downward, and which can be traced, under various disguises of
+Art, through the portraits of every Drinking Age.
+
+“You are a little late, Memory,” said Stryver.
+
+“About the usual time; it may be a quarter of an hour later.”
+
+They went into a dingy room lined with books and littered with papers,
+where there was a blazing fire. A kettle steamed upon the hob, and in
+the midst of the wreck of papers a table shone, with plenty of wine upon
+it, and brandy, and rum, and sugar, and lemons.
+
+“You have had your bottle, I perceive, Sydney.”
+
+“Two to-night, I think. I have been dining with the day’s client; or
+seeing him dine--it’s all one!”
+
+“That was a rare point, Sydney, that you brought to bear upon the
+identification. How did you come by it? When did it strike you?”
+
+“I thought he was rather a handsome fellow, and I thought I should have
+been much the same sort of fellow, if I had had any luck.”
+
+Mr. Stryver laughed till he shook his precocious paunch.
+
+“You and your luck, Sydney! Get to work, get to work.”
+
+Sullenly enough, the jackal loosened his dress, went into an adjoining
+room, and came back with a large jug of cold water, a basin, and a towel
+or two. Steeping the towels in the water, and partially wringing them
+out, he folded them on his head in a manner hideous to behold, sat down
+at the table, and said, “Now I am ready!”
+
+“Not much boiling down to be done to-night, Memory,” said Mr. Stryver,
+gaily, as he looked among his papers.
+
+“How much?”
+
+“Only two sets of them.”
+
+“Give me the worst first.”
+
+“There they are, Sydney. Fire away!”
+
+The lion then composed himself on his back on a sofa on one side of the
+drinking-table, while the jackal sat at his own paper-bestrewn table
+proper, on the other side of it, with the bottles and glasses ready to
+his hand. Both resorted to the drinking-table without stint, but each in
+a different way; the lion for the most part reclining with his hands in
+his waistband, looking at the fire, or occasionally flirting with some
+lighter document; the jackal, with knitted brows and intent face,
+so deep in his task, that his eyes did not even follow the hand he
+stretched out for his glass--which often groped about, for a minute or
+more, before it found the glass for his lips. Two or three times, the
+matter in hand became so knotty, that the jackal found it imperative on
+him to get up, and steep his towels anew. From these pilgrimages to the
+jug and basin, he returned with such eccentricities of damp headgear as
+no words can describe; which were made the more ludicrous by his anxious
+gravity.
+
+At length the jackal had got together a compact repast for the lion, and
+proceeded to offer it to him. The lion took it with care and caution,
+made his selections from it, and his remarks upon it, and the jackal
+assisted both. When the repast was fully discussed, the lion put his
+hands in his waistband again, and lay down to meditate. The jackal then
+invigorated himself with a bumper for his throttle, and a fresh application
+to his head, and applied himself to the collection of a second meal;
+this was administered to the lion in the same manner, and was not
+disposed of until the clocks struck three in the morning.
+
+“And now we have done, Sydney, fill a bumper of punch,” said Mr.
+Stryver.
+
+The jackal removed the towels from his head, which had been steaming
+again, shook himself, yawned, shivered, and complied.
+
+“You were very sound, Sydney, in the matter of those crown witnesses
+to-day. Every question told.”
+
+“I always am sound; am I not?”
+
+“I don’t gainsay it. What has roughened your temper? Put some punch to
+it and smooth it again.”
+
+With a deprecatory grunt, the jackal again complied.
+
+“The old Sydney Carton of old Shrewsbury School,” said Stryver, nodding
+his head over him as he reviewed him in the present and the past, “the
+old seesaw Sydney. Up one minute and down the next; now in spirits and
+now in despondency!”
+
+“Ah!” returned the other, sighing: “yes! The same Sydney, with the same
+luck. Even then, I did exercises for other boys, and seldom did my own.”
+
+“And why not?”
+
+“God knows. It was my way, I suppose.”
+
+He sat, with his hands in his pockets and his legs stretched out before
+him, looking at the fire.
+
+“Carton,” said his friend, squaring himself at him with a bullying air,
+as if the fire-grate had been the furnace in which sustained endeavour
+was forged, and the one delicate thing to be done for the old Sydney
+Carton of old Shrewsbury School was to shoulder him into it, “your way
+is, and always was, a lame way. You summon no energy and purpose. Look
+at me.”
+
+“Oh, botheration!” returned Sydney, with a lighter and more
+good-humoured laugh, “don’t _you_ be moral!”
+
+“How have I done what I have done?” said Stryver; “how do I do what I
+do?”
+
+“Partly through paying me to help you, I suppose. But it’s not worth
+your while to apostrophise me, or the air, about it; what you want to
+do, you do. You were always in the front rank, and I was always behind.”
+
+“I had to get into the front rank; I was not born there, was I?”
+
+“I was not present at the ceremony; but my opinion is you were,” said
+Carton. At this, he laughed again, and they both laughed.
+
+“Before Shrewsbury, and at Shrewsbury, and ever since Shrewsbury,”
+ pursued Carton, “you have fallen into your rank, and I have fallen into
+mine. Even when we were fellow-students in the Student-Quarter of Paris,
+picking up French, and French law, and other French crumbs that we
+didn’t get much good of, you were always somewhere, and I was always
+nowhere.”
+
+“And whose fault was that?”
+
+“Upon my soul, I am not sure that it was not yours. You were always
+driving and riving and shouldering and passing, to that restless degree
+that I had no chance for my life but in rust and repose. It’s a gloomy
+thing, however, to talk about one’s own past, with the day breaking.
+Turn me in some other direction before I go.”
+
+“Well then! Pledge me to the pretty witness,” said Stryver, holding up
+his glass. “Are you turned in a pleasant direction?”
+
+Apparently not, for he became gloomy again.
+
+“Pretty witness,” he muttered, looking down into his glass. “I have had
+enough of witnesses to-day and to-night; who’s your pretty witness?”
+
+“The picturesque doctor’s daughter, Miss Manette.”
+
+“_She_ pretty?”
+
+“Is she not?”
+
+“No.”
+
+“Why, man alive, she was the admiration of the whole Court!”
+
+“Rot the admiration of the whole Court! Who made the Old Bailey a judge
+of beauty? She was a golden-haired doll!”
+
+“Do you know, Sydney,” said Mr. Stryver, looking at him with sharp eyes,
+and slowly drawing a hand across his florid face: “do you know, I rather
+thought, at the time, that you sympathised with the golden-haired doll,
+and were quick to see what happened to the golden-haired doll?”
+
+“Quick to see what happened! If a girl, doll or no doll, swoons within a
+yard or two of a man’s nose, he can see it without a perspective-glass.
+I pledge you, but I deny the beauty. And now I’ll have no more drink;
+I’ll get to bed.”
+
+When his host followed him out on the staircase with a candle, to light
+him down the stairs, the day was coldly looking in through its grimy
+windows. When he got out of the house, the air was cold and sad, the
+dull sky overcast, the river dark and dim, the whole scene like a
+lifeless desert. And wreaths of dust were spinning round and round
+before the morning blast, as if the desert-sand had risen far away, and
+the first spray of it in its advance had begun to overwhelm the city.
+
+Waste forces within him, and a desert all around, this man stood still
+on his way across a silent terrace, and saw for a moment, lying in the
+wilderness before him, a mirage of honourable ambition, self-denial, and
+perseverance. In the fair city of this vision, there were airy galleries
+from which the loves and graces looked upon him, gardens in which the
+fruits of life hung ripening, waters of Hope that sparkled in his sight.
+A moment, and it was gone. Climbing to a high chamber in a well of
+houses, he threw himself down in his clothes on a neglected bed, and its
+pillow was wet with wasted tears.
+
+Sadly, sadly, the sun rose; it rose upon no sadder sight than the man of
+good abilities and good emotions, incapable of their directed exercise,
+incapable of his own help and his own happiness, sensible of the blight
+on him, and resigning himself to let it eat him away.
+
+
+
+
+VI. Hundreds of People
+
+
+The quiet lodgings of Doctor Manette were in a quiet street-corner not
+far from Soho-square. On the afternoon of a certain fine Sunday when the
+waves of four months had rolled over the trial for treason, and carried
+it, as to the public interest and memory, far out to sea, Mr. Jarvis
+Lorry walked along the sunny streets from Clerkenwell where he lived,
+on his way to dine with the Doctor. After several relapses into
+business-absorption, Mr. Lorry had become the Doctor’s friend, and the
+quiet street-corner was the sunny part of his life.
+
+On this certain fine Sunday, Mr. Lorry walked towards Soho, early in
+the afternoon, for three reasons of habit. Firstly, because, on fine
+Sundays, he often walked out, before dinner, with the Doctor and Lucie;
+secondly, because, on unfavourable Sundays, he was accustomed to be with
+them as the family friend, talking, reading, looking out of window, and
+generally getting through the day; thirdly, because he happened to have
+his own little shrewd doubts to solve, and knew how the ways of the
+Doctor’s household pointed to that time as a likely time for solving
+them.
+
+A quainter corner than the corner where the Doctor lived, was not to be
+found in London. There was no way through it, and the front windows of
+the Doctor’s lodgings commanded a pleasant little vista of street that
+had a congenial air of retirement on it. There were few buildings then,
+north of the Oxford-road, and forest-trees flourished, and wild flowers
+grew, and the hawthorn blossomed, in the now vanished fields. As a
+consequence, country airs circulated in Soho with vigorous freedom,
+instead of languishing into the parish like stray paupers without a
+settlement; and there was many a good south wall, not far off, on which
+the peaches ripened in their season.
+
+The summer light struck into the corner brilliantly in the earlier part
+of the day; but, when the streets grew hot, the corner was in shadow,
+though not in shadow so remote but that you could see beyond it into a
+glare of brightness. It was a cool spot, staid but cheerful, a wonderful
+place for echoes, and a very harbour from the raging streets.
+
+There ought to have been a tranquil bark in such an anchorage, and
+there was. The Doctor occupied two floors of a large stiff house, where
+several callings purported to be pursued by day, but whereof little was
+audible any day, and which was shunned by all of them at night. In
+a building at the back, attainable by a courtyard where a plane-tree
+rustled its green leaves, church-organs claimed to be made, and silver
+to be chased, and likewise gold to be beaten by some mysterious giant
+who had a golden arm starting out of the wall of the front hall--as if
+he had beaten himself precious, and menaced a similar conversion of all
+visitors. Very little of these trades, or of a lonely lodger rumoured
+to live up-stairs, or of a dim coach-trimming maker asserted to have
+a counting-house below, was ever heard or seen. Occasionally, a stray
+workman putting his coat on, traversed the hall, or a stranger peered
+about there, or a distant clink was heard across the courtyard, or a
+thump from the golden giant. These, however, were only the exceptions
+required to prove the rule that the sparrows in the plane-tree behind
+the house, and the echoes in the corner before it, had their own way
+from Sunday morning unto Saturday night.
+
+Doctor Manette received such patients here as his old reputation, and
+its revival in the floating whispers of his story, brought him.
+His scientific knowledge, and his vigilance and skill in conducting
+ingenious experiments, brought him otherwise into moderate request, and
+he earned as much as he wanted.
+
+These things were within Mr. Jarvis Lorry’s knowledge, thoughts, and
+notice, when he rang the door-bell of the tranquil house in the corner,
+on the fine Sunday afternoon.
+
+“Doctor Manette at home?”
+
+Expected home.
+
+“Miss Lucie at home?”
+
+Expected home.
+
+“Miss Pross at home?”
+
+Possibly at home, but of a certainty impossible for handmaid to
+anticipate intentions of Miss Pross, as to admission or denial of the
+fact.
+
+“As I am at home myself,” said Mr. Lorry, “I’ll go upstairs.”
+
+Although the Doctor’s daughter had known nothing of the country of her
+birth, she appeared to have innately derived from it that ability to
+make much of little means, which is one of its most useful and most
+agreeable characteristics. Simple as the furniture was, it was set off
+by so many little adornments, of no value but for their taste and fancy,
+that its effect was delightful. The disposition of everything in the
+rooms, from the largest object to the least; the arrangement of colours,
+the elegant variety and contrast obtained by thrift in trifles, by
+delicate hands, clear eyes, and good sense; were at once so pleasant in
+themselves, and so expressive of their originator, that, as Mr. Lorry
+stood looking about him, the very chairs and tables seemed to ask him,
+with something of that peculiar expression which he knew so well by this
+time, whether he approved?
+
+There were three rooms on a floor, and, the doors by which they
+communicated being put open that the air might pass freely through them
+all, Mr. Lorry, smilingly observant of that fanciful resemblance which
+he detected all around him, walked from one to another. The first was
+the best room, and in it were Lucie’s birds, and flowers, and books,
+and desk, and work-table, and box of water-colours; the second was
+the Doctor’s consulting-room, used also as the dining-room; the third,
+changingly speckled by the rustle of the plane-tree in the yard, was the
+Doctor’s bedroom, and there, in a corner, stood the disused shoemaker’s
+bench and tray of tools, much as it had stood on the fifth floor of the
+dismal house by the wine-shop, in the suburb of Saint Antoine in Paris.
+
+“I wonder,” said Mr. Lorry, pausing in his looking about, “that he keeps
+that reminder of his sufferings about him!”
+
+“And why wonder at that?” was the abrupt inquiry that made him start.
+
+It proceeded from Miss Pross, the wild red woman, strong of hand, whose
+acquaintance he had first made at the Royal George Hotel at Dover, and
+had since improved.
+
+“I should have thought--” Mr. Lorry began.
+
+“Pooh! You’d have thought!” said Miss Pross; and Mr. Lorry left off.
+
+“How do you do?” inquired that lady then--sharply, and yet as if to
+express that she bore him no malice.
+
+“I am pretty well, I thank you,” answered Mr. Lorry, with meekness; “how
+are you?”
+
+“Nothing to boast of,” said Miss Pross.
+
+“Indeed?”
+
+“Ah! indeed!” said Miss Pross. “I am very much put out about my
+Ladybird.”
+
+“Indeed?”
+
+“For gracious sake say something else besides ‘indeed,’ or you’ll
+fidget me to death,” said Miss Pross: whose character (dissociated from
+stature) was shortness.
+
+“Really, then?” said Mr. Lorry, as an amendment.
+
+“Really, is bad enough,” returned Miss Pross, “but better. Yes, I am
+very much put out.”
+
+“May I ask the cause?”
+
+“I don’t want dozens of people who are not at all worthy of Ladybird, to
+come here looking after her,” said Miss Pross.
+
+“_Do_ dozens come for that purpose?”
+
+“Hundreds,” said Miss Pross.
+
+It was characteristic of this lady (as of some other people before her
+time and since) that whenever her original proposition was questioned,
+she exaggerated it.
+
+“Dear me!” said Mr. Lorry, as the safest remark he could think of.
+
+“I have lived with the darling--or the darling has lived with me, and
+paid me for it; which she certainly should never have done, you may take
+your affidavit, if I could have afforded to keep either myself or her
+for nothing--since she was ten years old. And it’s really very hard,”
+ said Miss Pross.
+
+Not seeing with precision what was very hard, Mr. Lorry shook his head;
+using that important part of himself as a sort of fairy cloak that would
+fit anything.
+
+“All sorts of people who are not in the least degree worthy of the pet,
+are always turning up,” said Miss Pross. “When you began it--”
+
+“_I_ began it, Miss Pross?”
+
+“Didn’t you? Who brought her father to life?”
+
+“Oh! If _that_ was beginning it--” said Mr. Lorry.
+
+“It wasn’t ending it, I suppose? I say, when you began it, it was hard
+enough; not that I have any fault to find with Doctor Manette, except
+that he is not worthy of such a daughter, which is no imputation on
+him, for it was not to be expected that anybody should be, under any
+circumstances. But it really is doubly and trebly hard to have crowds
+and multitudes of people turning up after him (I could have forgiven
+him), to take Ladybird’s affections away from me.”
+
+Mr. Lorry knew Miss Pross to be very jealous, but he also knew her by
+this time to be, beneath the service of her eccentricity, one of those
+unselfish creatures--found only among women--who will, for pure love and
+admiration, bind themselves willing slaves, to youth when they have lost
+it, to beauty that they never had, to accomplishments that they were
+never fortunate enough to gain, to bright hopes that never shone upon
+their own sombre lives. He knew enough of the world to know that there
+is nothing in it better than the faithful service of the heart; so
+rendered and so free from any mercenary taint, he had such an exalted
+respect for it, that in the retributive arrangements made by his own
+mind--we all make such arrangements, more or less--he stationed Miss
+Pross much nearer to the lower Angels than many ladies immeasurably
+better got up both by Nature and Art, who had balances at Tellson’s.
+
+“There never was, nor will be, but one man worthy of Ladybird,” said
+Miss Pross; “and that was my brother Solomon, if he hadn’t made a
+mistake in life.”
+
+Here again: Mr. Lorry’s inquiries into Miss Pross’s personal history had
+established the fact that her brother Solomon was a heartless scoundrel
+who had stripped her of everything she possessed, as a stake to
+speculate with, and had abandoned her in her poverty for evermore, with
+no touch of compunction. Miss Pross’s fidelity of belief in Solomon
+(deducting a mere trifle for this slight mistake) was quite a serious
+matter with Mr. Lorry, and had its weight in his good opinion of her.
+
+“As we happen to be alone for the moment, and are both people of
+business,” he said, when they had got back to the drawing-room and had
+sat down there in friendly relations, “let me ask you--does the Doctor,
+in talking with Lucie, never refer to the shoemaking time, yet?”
+
+“Never.”
+
+“And yet keeps that bench and those tools beside him?”
+
+“Ah!” returned Miss Pross, shaking her head. “But I don’t say he don’t
+refer to it within himself.”
+
+“Do you believe that he thinks of it much?”
+
+“I do,” said Miss Pross.
+
+“Do you imagine--” Mr. Lorry had begun, when Miss Pross took him up
+short with:
+
+“Never imagine anything. Have no imagination at all.”
+
+“I stand corrected; do you suppose--you go so far as to suppose,
+sometimes?”
+
+“Now and then,” said Miss Pross.
+
+“Do you suppose,” Mr. Lorry went on, with a laughing twinkle in his
+bright eye, as it looked kindly at her, “that Doctor Manette has any
+theory of his own, preserved through all those years, relative to
+the cause of his being so oppressed; perhaps, even to the name of his
+oppressor?”
+
+“I don’t suppose anything about it but what Ladybird tells me.”
+
+“And that is--?”
+
+“That she thinks he has.”
+
+“Now don’t be angry at my asking all these questions; because I am a
+mere dull man of business, and you are a woman of business.”
+
+“Dull?” Miss Pross inquired, with placidity.
+
+Rather wishing his modest adjective away, Mr. Lorry replied, “No, no,
+no. Surely not. To return to business:--Is it not remarkable that Doctor
+Manette, unquestionably innocent of any crime as we are all well assured
+he is, should never touch upon that question? I will not say with me,
+though he had business relations with me many years ago, and we are now
+intimate; I will say with the fair daughter to whom he is so devotedly
+attached, and who is so devotedly attached to him? Believe me, Miss
+Pross, I don’t approach the topic with you, out of curiosity, but out of
+zealous interest.”
+
+“Well! To the best of my understanding, and bad’s the best, you’ll tell
+me,” said Miss Pross, softened by the tone of the apology, “he is afraid
+of the whole subject.”
+
+“Afraid?”
+
+“It’s plain enough, I should think, why he may be. It’s a dreadful
+remembrance. Besides that, his loss of himself grew out of it. Not
+knowing how he lost himself, or how he recovered himself, he may never
+feel certain of not losing himself again. That alone wouldn’t make the
+subject pleasant, I should think.”
+
+It was a profounder remark than Mr. Lorry had looked for. “True,” said
+he, “and fearful to reflect upon. Yet, a doubt lurks in my mind, Miss
+Pross, whether it is good for Doctor Manette to have that suppression
+always shut up within him. Indeed, it is this doubt and the uneasiness
+it sometimes causes me that has led me to our present confidence.”
+
+“Can’t be helped,” said Miss Pross, shaking her head. “Touch that
+string, and he instantly changes for the worse. Better leave it alone.
+In short, must leave it alone, like or no like. Sometimes, he gets up in
+the dead of the night, and will be heard, by us overhead there, walking
+up and down, walking up and down, in his room. Ladybird has learnt to
+know then that his mind is walking up and down, walking up and down, in
+his old prison. She hurries to him, and they go on together, walking up
+and down, walking up and down, until he is composed. But he never says
+a word of the true reason of his restlessness, to her, and she finds it
+best not to hint at it to him. In silence they go walking up and down
+together, walking up and down together, till her love and company have
+brought him to himself.”
+
+Notwithstanding Miss Pross’s denial of her own imagination, there was a
+perception of the pain of being monotonously haunted by one sad idea,
+in her repetition of the phrase, walking up and down, which testified to
+her possessing such a thing.
+
+The corner has been mentioned as a wonderful corner for echoes; it
+had begun to echo so resoundingly to the tread of coming feet, that it
+seemed as though the very mention of that weary pacing to and fro had
+set it going.
+
+“Here they are!” said Miss Pross, rising to break up the conference;
+“and now we shall have hundreds of people pretty soon!”
+
+It was such a curious corner in its acoustical properties, such a
+peculiar Ear of a place, that as Mr. Lorry stood at the open window,
+looking for the father and daughter whose steps he heard, he fancied
+they would never approach. Not only would the echoes die away, as though
+the steps had gone; but, echoes of other steps that never came would be
+heard in their stead, and would die away for good when they seemed close
+at hand. However, father and daughter did at last appear, and Miss Pross
+was ready at the street door to receive them.
+
+Miss Pross was a pleasant sight, albeit wild, and red, and grim, taking
+off her darling’s bonnet when she came up-stairs, and touching it up
+with the ends of her handkerchief, and blowing the dust off it, and
+folding her mantle ready for laying by, and smoothing her rich hair with
+as much pride as she could possibly have taken in her own hair if she
+had been the vainest and handsomest of women. Her darling was a pleasant
+sight too, embracing her and thanking her, and protesting against
+her taking so much trouble for her--which last she only dared to do
+playfully, or Miss Pross, sorely hurt, would have retired to her own
+chamber and cried. The Doctor was a pleasant sight too, looking on at
+them, and telling Miss Pross how she spoilt Lucie, in accents and with
+eyes that had as much spoiling in them as Miss Pross had, and would
+have had more if it were possible. Mr. Lorry was a pleasant sight too,
+beaming at all this in his little wig, and thanking his bachelor
+stars for having lighted him in his declining years to a Home. But, no
+Hundreds of people came to see the sights, and Mr. Lorry looked in vain
+for the fulfilment of Miss Pross’s prediction.
+
+Dinner-time, and still no Hundreds of people. In the arrangements of
+the little household, Miss Pross took charge of the lower regions, and
+always acquitted herself marvellously. Her dinners, of a very modest
+quality, were so well cooked and so well served, and so neat in their
+contrivances, half English and half French, that nothing could be
+better. Miss Pross’s friendship being of the thoroughly practical
+kind, she had ravaged Soho and the adjacent provinces, in search of
+impoverished French, who, tempted by shillings and half-crowns, would
+impart culinary mysteries to her. From these decayed sons and daughters
+of Gaul, she had acquired such wonderful arts, that the woman and girl
+who formed the staff of domestics regarded her as quite a Sorceress,
+or Cinderella’s Godmother: who would send out for a fowl, a rabbit,
+a vegetable or two from the garden, and change them into anything she
+pleased.
+
+On Sundays, Miss Pross dined at the Doctor’s table, but on other days
+persisted in taking her meals at unknown periods, either in the lower
+regions, or in her own room on the second floor--a blue chamber, to
+which no one but her Ladybird ever gained admittance. On this occasion,
+Miss Pross, responding to Ladybird’s pleasant face and pleasant efforts
+to please her, unbent exceedingly; so the dinner was very pleasant, too.
+
+It was an oppressive day, and, after dinner, Lucie proposed that the
+wine should be carried out under the plane-tree, and they should sit
+there in the air. As everything turned upon her, and revolved about her,
+they went out under the plane-tree, and she carried the wine down for
+the special benefit of Mr. Lorry. She had installed herself, some
+time before, as Mr. Lorry’s cup-bearer; and while they sat under the
+plane-tree, talking, she kept his glass replenished. Mysterious backs
+and ends of houses peeped at them as they talked, and the plane-tree
+whispered to them in its own way above their heads.
+
+Still, the Hundreds of people did not present themselves. Mr. Darnay
+presented himself while they were sitting under the plane-tree, but he
+was only One.
+
+Doctor Manette received him kindly, and so did Lucie. But, Miss Pross
+suddenly became afflicted with a twitching in the head and body, and
+retired into the house. She was not unfrequently the victim of this
+disorder, and she called it, in familiar conversation, “a fit of the
+jerks.”
+
+The Doctor was in his best condition, and looked specially young. The
+resemblance between him and Lucie was very strong at such times, and as
+they sat side by side, she leaning on his shoulder, and he resting
+his arm on the back of her chair, it was very agreeable to trace the
+likeness.
+
+He had been talking all day, on many subjects, and with unusual
+vivacity. “Pray, Doctor Manette,” said Mr. Darnay, as they sat under the
+plane-tree--and he said it in the natural pursuit of the topic in hand,
+which happened to be the old buildings of London--“have you seen much of
+the Tower?”
+
+“Lucie and I have been there; but only casually. We have seen enough of
+it, to know that it teems with interest; little more.”
+
+“_I_ have been there, as you remember,” said Darnay, with a smile,
+though reddening a little angrily, “in another character, and not in a
+character that gives facilities for seeing much of it. They told me a
+curious thing when I was there.”
+
+“What was that?” Lucie asked.
+
+“In making some alterations, the workmen came upon an old dungeon, which
+had been, for many years, built up and forgotten. Every stone of
+its inner wall was covered by inscriptions which had been carved by
+prisoners--dates, names, complaints, and prayers. Upon a corner stone
+in an angle of the wall, one prisoner, who seemed to have gone to
+execution, had cut as his last work, three letters. They were done with
+some very poor instrument, and hurriedly, with an unsteady hand.
+At first, they were read as D. I. C.; but, on being more carefully
+examined, the last letter was found to be G. There was no record or
+legend of any prisoner with those initials, and many fruitless guesses
+were made what the name could have been. At length, it was suggested
+that the letters were not initials, but the complete word, DIG. The
+floor was examined very carefully under the inscription, and, in the
+earth beneath a stone, or tile, or some fragment of paving, were found
+the ashes of a paper, mingled with the ashes of a small leathern case
+or bag. What the unknown prisoner had written will never be read, but he
+had written something, and hidden it away to keep it from the gaoler.”
+
+“My father,” exclaimed Lucie, “you are ill!”
+
+He had suddenly started up, with his hand to his head. His manner and
+his look quite terrified them all.
+
+“No, my dear, not ill. There are large drops of rain falling, and they
+made me start. We had better go in.”
+
+He recovered himself almost instantly. Rain was really falling in large
+drops, and he showed the back of his hand with rain-drops on it. But, he
+said not a single word in reference to the discovery that had been told
+of, and, as they went into the house, the business eye of Mr. Lorry
+either detected, or fancied it detected, on his face, as it turned
+towards Charles Darnay, the same singular look that had been upon it
+when it turned towards him in the passages of the Court House.
+
+He recovered himself so quickly, however, that Mr. Lorry had doubts of
+his business eye. The arm of the golden giant in the hall was not more
+steady than he was, when he stopped under it to remark to them that he
+was not yet proof against slight surprises (if he ever would be), and
+that the rain had startled him.
+
+Tea-time, and Miss Pross making tea, with another fit of the jerks upon
+her, and yet no Hundreds of people. Mr. Carton had lounged in, but he
+made only Two.
+
+The night was so very sultry, that although they sat with doors and
+windows open, they were overpowered by heat. When the tea-table was
+done with, they all moved to one of the windows, and looked out into the
+heavy twilight. Lucie sat by her father; Darnay sat beside her; Carton
+leaned against a window. The curtains were long and white, and some of
+the thunder-gusts that whirled into the corner, caught them up to the
+ceiling, and waved them like spectral wings.
+
+“The rain-drops are still falling, large, heavy, and few,” said Doctor
+Manette. “It comes slowly.”
+
+“It comes surely,” said Carton.
+
+They spoke low, as people watching and waiting mostly do; as people in a
+dark room, watching and waiting for Lightning, always do.
+
+There was a great hurry in the streets of people speeding away to
+get shelter before the storm broke; the wonderful corner for echoes
+resounded with the echoes of footsteps coming and going, yet not a
+footstep was there.
+
+“A multitude of people, and yet a solitude!” said Darnay, when they had
+listened for a while.
+
+“Is it not impressive, Mr. Darnay?” asked Lucie. “Sometimes, I have
+sat here of an evening, until I have fancied--but even the shade of
+a foolish fancy makes me shudder to-night, when all is so black and
+solemn--”
+
+“Let us shudder too. We may know what it is.”
+
+“It will seem nothing to you. Such whims are only impressive as we
+originate them, I think; they are not to be communicated. I have
+sometimes sat alone here of an evening, listening, until I have made
+the echoes out to be the echoes of all the footsteps that are coming
+by-and-bye into our lives.”
+
+“There is a great crowd coming one day into our lives, if that be so,”
+ Sydney Carton struck in, in his moody way.
+
+The footsteps were incessant, and the hurry of them became more and more
+rapid. The corner echoed and re-echoed with the tread of feet; some,
+as it seemed, under the windows; some, as it seemed, in the room; some
+coming, some going, some breaking off, some stopping altogether; all in
+the distant streets, and not one within sight.
+
+“Are all these footsteps destined to come to all of us, Miss Manette, or
+are we to divide them among us?”
+
+“I don’t know, Mr. Darnay; I told you it was a foolish fancy, but you
+asked for it. When I have yielded myself to it, I have been alone, and
+then I have imagined them the footsteps of the people who are to come
+into my life, and my father’s.”
+
+“I take them into mine!” said Carton. “_I_ ask no questions and make no
+stipulations. There is a great crowd bearing down upon us, Miss Manette,
+and I see them--by the Lightning.” He added the last words, after there
+had been a vivid flash which had shown him lounging in the window.
+
+“And I hear them!” he added again, after a peal of thunder. “Here they
+come, fast, fierce, and furious!”
+
+It was the rush and roar of rain that he typified, and it stopped him,
+for no voice could be heard in it. A memorable storm of thunder and
+lightning broke with that sweep of water, and there was not a moment’s
+interval in crash, and fire, and rain, until after the moon rose at
+midnight.
+
+The great bell of Saint Paul’s was striking one in the cleared air, when
+Mr. Lorry, escorted by Jerry, high-booted and bearing a lantern, set
+forth on his return-passage to Clerkenwell. There were solitary patches
+of road on the way between Soho and Clerkenwell, and Mr. Lorry, mindful
+of foot-pads, always retained Jerry for this service: though it was
+usually performed a good two hours earlier.
+
+“What a night it has been! Almost a night, Jerry,” said Mr. Lorry, “to
+bring the dead out of their graves.”
+
+“I never see the night myself, master--nor yet I don’t expect to--what
+would do that,” answered Jerry.
+
+“Good night, Mr. Carton,” said the man of business. “Good night, Mr.
+Darnay. Shall we ever see such a night again, together!”
+
+Perhaps. Perhaps, see the great crowd of people with its rush and roar,
+bearing down upon them, too.
+
+
+
+
+VII. Monseigneur in Town
+
+
+Monseigneur, one of the great lords in power at the Court, held his
+fortnightly reception in his grand hotel in Paris. Monseigneur was in
+his inner room, his sanctuary of sanctuaries, the Holiest of Holiests to
+the crowd of worshippers in the suite of rooms without. Monseigneur
+was about to take his chocolate. Monseigneur could swallow a great many
+things with ease, and was by some few sullen minds supposed to be rather
+rapidly swallowing France; but, his morning’s chocolate could not so
+much as get into the throat of Monseigneur, without the aid of four
+strong men besides the Cook.
+
+Yes. It took four men, all four ablaze with gorgeous decoration, and the
+Chief of them unable to exist with fewer than two gold watches in his
+pocket, emulative of the noble and chaste fashion set by Monseigneur, to
+conduct the happy chocolate to Monseigneur’s lips. One lacquey carried
+the chocolate-pot into the sacred presence; a second, milled and frothed
+the chocolate with the little instrument he bore for that function;
+a third, presented the favoured napkin; a fourth (he of the two gold
+watches), poured the chocolate out. It was impossible for Monseigneur to
+dispense with one of these attendants on the chocolate and hold his high
+place under the admiring Heavens. Deep would have been the blot upon
+his escutcheon if his chocolate had been ignobly waited on by only three
+men; he must have died of two.
+
+Monseigneur had been out at a little supper last night, where the Comedy
+and the Grand Opera were charmingly represented. Monseigneur was out at
+a little supper most nights, with fascinating company. So polite and so
+impressible was Monseigneur, that the Comedy and the Grand Opera had far
+more influence with him in the tiresome articles of state affairs and
+state secrets, than the needs of all France. A happy circumstance
+for France, as the like always is for all countries similarly
+favoured!--always was for England (by way of example), in the regretted
+days of the merry Stuart who sold it.
+
+Monseigneur had one truly noble idea of general public business, which
+was, to let everything go on in its own way; of particular public
+business, Monseigneur had the other truly noble idea that it must all go
+his way--tend to his own power and pocket. Of his pleasures, general and
+particular, Monseigneur had the other truly noble idea, that the world
+was made for them. The text of his order (altered from the original
+by only a pronoun, which is not much) ran: “The earth and the fulness
+thereof are mine, saith Monseigneur.”
+
+Yet, Monseigneur had slowly found that vulgar embarrassments crept into
+his affairs, both private and public; and he had, as to both classes of
+affairs, allied himself perforce with a Farmer-General. As to finances
+public, because Monseigneur could not make anything at all of them, and
+must consequently let them out to somebody who could; as to finances
+private, because Farmer-Generals were rich, and Monseigneur, after
+generations of great luxury and expense, was growing poor. Hence
+Monseigneur had taken his sister from a convent, while there was yet
+time to ward off the impending veil, the cheapest garment she could
+wear, and had bestowed her as a prize upon a very rich Farmer-General,
+poor in family. Which Farmer-General, carrying an appropriate cane with
+a golden apple on the top of it, was now among the company in the outer
+rooms, much prostrated before by mankind--always excepting superior
+mankind of the blood of Monseigneur, who, his own wife included, looked
+down upon him with the loftiest contempt.
+
+A sumptuous man was the Farmer-General. Thirty horses stood in his
+stables, twenty-four male domestics sat in his halls, six body-women
+waited on his wife. As one who pretended to do nothing but plunder and
+forage where he could, the Farmer-General--howsoever his matrimonial
+relations conduced to social morality--was at least the greatest reality
+among the personages who attended at the hotel of Monseigneur that day.
+
+For, the rooms, though a beautiful scene to look at, and adorned with
+every device of decoration that the taste and skill of the time could
+achieve, were, in truth, not a sound business; considered with any
+reference to the scarecrows in the rags and nightcaps elsewhere (and not
+so far off, either, but that the watching towers of Notre Dame, almost
+equidistant from the two extremes, could see them both), they would
+have been an exceedingly uncomfortable business--if that could have
+been anybody’s business, at the house of Monseigneur. Military officers
+destitute of military knowledge; naval officers with no idea of a ship;
+civil officers without a notion of affairs; brazen ecclesiastics, of the
+worst world worldly, with sensual eyes, loose tongues, and looser lives;
+all totally unfit for their several callings, all lying horribly in
+pretending to belong to them, but all nearly or remotely of the order of
+Monseigneur, and therefore foisted on all public employments from which
+anything was to be got; these were to be told off by the score and the
+score. People not immediately connected with Monseigneur or the State,
+yet equally unconnected with anything that was real, or with lives
+passed in travelling by any straight road to any true earthly end, were
+no less abundant. Doctors who made great fortunes out of dainty remedies
+for imaginary disorders that never existed, smiled upon their courtly
+patients in the ante-chambers of Monseigneur. Projectors who had
+discovered every kind of remedy for the little evils with which the
+State was touched, except the remedy of setting to work in earnest to
+root out a single sin, poured their distracting babble into any ears
+they could lay hold of, at the reception of Monseigneur. Unbelieving
+Philosophers who were remodelling the world with words, and making
+card-towers of Babel to scale the skies with, talked with Unbelieving
+Chemists who had an eye on the transmutation of metals, at this
+wonderful gathering accumulated by Monseigneur. Exquisite gentlemen of
+the finest breeding, which was at that remarkable time--and has been
+since--to be known by its fruits of indifference to every natural
+subject of human interest, were in the most exemplary state of
+exhaustion, at the hotel of Monseigneur. Such homes had these various
+notabilities left behind them in the fine world of Paris, that the spies
+among the assembled devotees of Monseigneur--forming a goodly half
+of the polite company--would have found it hard to discover among
+the angels of that sphere one solitary wife, who, in her manners and
+appearance, owned to being a Mother. Indeed, except for the mere act of
+bringing a troublesome creature into this world--which does not go far
+towards the realisation of the name of mother--there was no such thing
+known to the fashion. Peasant women kept the unfashionable babies close,
+and brought them up, and charming grandmammas of sixty dressed and
+supped as at twenty.
+
+The leprosy of unreality disfigured every human creature in attendance
+upon Monseigneur. In the outermost room were half a dozen exceptional
+people who had had, for a few years, some vague misgiving in them that
+things in general were going rather wrong. As a promising way of setting
+them right, half of the half-dozen had become members of a fantastic
+sect of Convulsionists, and were even then considering within themselves
+whether they should foam, rage, roar, and turn cataleptic on the
+spot--thereby setting up a highly intelligible finger-post to the
+Future, for Monseigneur’s guidance. Besides these Dervishes, were other
+three who had rushed into another sect, which mended matters with a
+jargon about “the Centre of Truth:” holding that Man had got out of the
+Centre of Truth--which did not need much demonstration--but had not got
+out of the Circumference, and that he was to be kept from flying out of
+the Circumference, and was even to be shoved back into the Centre,
+by fasting and seeing of spirits. Among these, accordingly, much
+discoursing with spirits went on--and it did a world of good which never
+became manifest.
+
+But, the comfort was, that all the company at the grand hotel of
+Monseigneur were perfectly dressed. If the Day of Judgment had only been
+ascertained to be a dress day, everybody there would have been eternally
+correct. Such frizzling and powdering and sticking up of hair, such
+delicate complexions artificially preserved and mended, such gallant
+swords to look at, and such delicate honour to the sense of smell, would
+surely keep anything going, for ever and ever. The exquisite gentlemen
+of the finest breeding wore little pendent trinkets that chinked as they
+languidly moved; these golden fetters rang like precious little bells;
+and what with that ringing, and with the rustle of silk and brocade and
+fine linen, there was a flutter in the air that fanned Saint Antoine and
+his devouring hunger far away.
+
+Dress was the one unfailing talisman and charm used for keeping all
+things in their places. Everybody was dressed for a Fancy Ball that
+was never to leave off. From the Palace of the Tuileries, through
+Monseigneur and the whole Court, through the Chambers, the Tribunals
+of Justice, and all society (except the scarecrows), the Fancy Ball
+descended to the Common Executioner: who, in pursuance of the charm, was
+required to officiate “frizzled, powdered, in a gold-laced coat, pumps,
+and white silk stockings.” At the gallows and the wheel--the axe was a
+rarity--Monsieur Paris, as it was the episcopal mode among his brother
+Professors of the provinces, Monsieur Orleans, and the rest, to call
+him, presided in this dainty dress. And who among the company at
+Monseigneur’s reception in that seventeen hundred and eightieth year
+of our Lord, could possibly doubt, that a system rooted in a frizzled
+hangman, powdered, gold-laced, pumped, and white-silk stockinged, would
+see the very stars out!
+
+Monseigneur having eased his four men of their burdens and taken his
+chocolate, caused the doors of the Holiest of Holiests to be thrown
+open, and issued forth. Then, what submission, what cringing and
+fawning, what servility, what abject humiliation! As to bowing down in
+body and spirit, nothing in that way was left for Heaven--which may have
+been one among other reasons why the worshippers of Monseigneur never
+troubled it.
+
+Bestowing a word of promise here and a smile there, a whisper on one
+happy slave and a wave of the hand on another, Monseigneur affably
+passed through his rooms to the remote region of the Circumference of
+Truth. There, Monseigneur turned, and came back again, and so in due
+course of time got himself shut up in his sanctuary by the chocolate
+sprites, and was seen no more.
+
+The show being over, the flutter in the air became quite a little storm,
+and the precious little bells went ringing downstairs. There was soon
+but one person left of all the crowd, and he, with his hat under his arm
+and his snuff-box in his hand, slowly passed among the mirrors on his
+way out.
+
+“I devote you,” said this person, stopping at the last door on his way,
+and turning in the direction of the sanctuary, “to the Devil!”
+
+With that, he shook the snuff from his fingers as if he had shaken the
+dust from his feet, and quietly walked downstairs.
+
+He was a man of about sixty, handsomely dressed, haughty in manner, and
+with a face like a fine mask. A face of a transparent paleness; every
+feature in it clearly defined; one set expression on it. The nose,
+beautifully formed otherwise, was very slightly pinched at the top
+of each nostril. In those two compressions, or dints, the only little
+change that the face ever showed, resided. They persisted in changing
+colour sometimes, and they would be occasionally dilated and contracted
+by something like a faint pulsation; then, they gave a look of
+treachery, and cruelty, to the whole countenance. Examined with
+attention, its capacity of helping such a look was to be found in the
+line of the mouth, and the lines of the orbits of the eyes, being much
+too horizontal and thin; still, in the effect of the face made, it was a
+handsome face, and a remarkable one.
+
+Its owner went downstairs into the courtyard, got into his carriage, and
+drove away. Not many people had talked with him at the reception; he had
+stood in a little space apart, and Monseigneur might have been warmer
+in his manner. It appeared, under the circumstances, rather agreeable
+to him to see the common people dispersed before his horses, and
+often barely escaping from being run down. His man drove as if he were
+charging an enemy, and the furious recklessness of the man brought no
+check into the face, or to the lips, of the master. The complaint had
+sometimes made itself audible, even in that deaf city and dumb age,
+that, in the narrow streets without footways, the fierce patrician
+custom of hard driving endangered and maimed the mere vulgar in a
+barbarous manner. But, few cared enough for that to think of it a second
+time, and, in this matter, as in all others, the common wretches were
+left to get out of their difficulties as they could.
+
+With a wild rattle and clatter, and an inhuman abandonment of
+consideration not easy to be understood in these days, the carriage
+dashed through streets and swept round corners, with women screaming
+before it, and men clutching each other and clutching children out of
+its way. At last, swooping at a street corner by a fountain, one of its
+wheels came to a sickening little jolt, and there was a loud cry from a
+number of voices, and the horses reared and plunged.
+
+But for the latter inconvenience, the carriage probably would not have
+stopped; carriages were often known to drive on, and leave their wounded
+behind, and why not? But the frightened valet had got down in a hurry,
+and there were twenty hands at the horses’ bridles.
+
+“What has gone wrong?” said Monsieur, calmly looking out.
+
+A tall man in a nightcap had caught up a bundle from among the feet of
+the horses, and had laid it on the basement of the fountain, and was
+down in the mud and wet, howling over it like a wild animal.
+
+“Pardon, Monsieur the Marquis!” said a ragged and submissive man, “it is
+a child.”
+
+“Why does he make that abominable noise? Is it his child?”
+
+“Excuse me, Monsieur the Marquis--it is a pity--yes.”
+
+The fountain was a little removed; for the street opened, where it was,
+into a space some ten or twelve yards square. As the tall man suddenly
+got up from the ground, and came running at the carriage, Monsieur the
+Marquis clapped his hand for an instant on his sword-hilt.
+
+“Killed!” shrieked the man, in wild desperation, extending both arms at
+their length above his head, and staring at him. “Dead!”
+
+The people closed round, and looked at Monsieur the Marquis. There was
+nothing revealed by the many eyes that looked at him but watchfulness
+and eagerness; there was no visible menacing or anger. Neither did the
+people say anything; after the first cry, they had been silent, and they
+remained so. The voice of the submissive man who had spoken, was flat
+and tame in its extreme submission. Monsieur the Marquis ran his eyes
+over them all, as if they had been mere rats come out of their holes.
+
+He took out his purse.
+
+“It is extraordinary to me,” said he, “that you people cannot take care
+of yourselves and your children. One or the other of you is for ever in
+the way. How do I know what injury you have done my horses. See! Give
+him that.”
+
+He threw out a gold coin for the valet to pick up, and all the heads
+craned forward that all the eyes might look down at it as it fell. The
+tall man called out again with a most unearthly cry, “Dead!”
+
+He was arrested by the quick arrival of another man, for whom the rest
+made way. On seeing him, the miserable creature fell upon his shoulder,
+sobbing and crying, and pointing to the fountain, where some women were
+stooping over the motionless bundle, and moving gently about it. They
+were as silent, however, as the men.
+
+“I know all, I know all,” said the last comer. “Be a brave man, my
+Gaspard! It is better for the poor little plaything to die so, than to
+live. It has died in a moment without pain. Could it have lived an hour
+as happily?”
+
+“You are a philosopher, you there,” said the Marquis, smiling. “How do
+they call you?”
+
+“They call me Defarge.”
+
+“Of what trade?”
+
+“Monsieur the Marquis, vendor of wine.”
+
+“Pick up that, philosopher and vendor of wine,” said the Marquis,
+throwing him another gold coin, “and spend it as you will. The horses
+there; are they right?”
+
+Without deigning to look at the assemblage a second time, Monsieur the
+Marquis leaned back in his seat, and was just being driven away with the
+air of a gentleman who had accidentally broke some common thing, and had
+paid for it, and could afford to pay for it; when his ease was suddenly
+disturbed by a coin flying into his carriage, and ringing on its floor.
+
+“Hold!” said Monsieur the Marquis. “Hold the horses! Who threw that?”
+
+He looked to the spot where Defarge the vendor of wine had stood, a
+moment before; but the wretched father was grovelling on his face on
+the pavement in that spot, and the figure that stood beside him was the
+figure of a dark stout woman, knitting.
+
+“You dogs!” said the Marquis, but smoothly, and with an unchanged front,
+except as to the spots on his nose: “I would ride over any of you very
+willingly, and exterminate you from the earth. If I knew which rascal
+threw at the carriage, and if that brigand were sufficiently near it, he
+should be crushed under the wheels.”
+
+So cowed was their condition, and so long and hard their experience of
+what such a man could do to them, within the law and beyond it, that not
+a voice, or a hand, or even an eye was raised. Among the men, not one.
+But the woman who stood knitting looked up steadily, and looked the
+Marquis in the face. It was not for his dignity to notice it; his
+contemptuous eyes passed over her, and over all the other rats; and he
+leaned back in his seat again, and gave the word “Go on!”
+
+He was driven on, and other carriages came whirling by in quick
+succession; the Minister, the State-Projector, the Farmer-General, the
+Doctor, the Lawyer, the Ecclesiastic, the Grand Opera, the Comedy, the
+whole Fancy Ball in a bright continuous flow, came whirling by. The rats
+had crept out of their holes to look on, and they remained looking
+on for hours; soldiers and police often passing between them and the
+spectacle, and making a barrier behind which they slunk, and through
+which they peeped. The father had long ago taken up his bundle and
+bidden himself away with it, when the women who had tended the bundle
+while it lay on the base of the fountain, sat there watching the running
+of the water and the rolling of the Fancy Ball--when the one woman who
+had stood conspicuous, knitting, still knitted on with the steadfastness
+of Fate. The water of the fountain ran, the swift river ran, the day ran
+into evening, so much life in the city ran into death according to rule,
+time and tide waited for no man, the rats were sleeping close together
+in their dark holes again, the Fancy Ball was lighted up at supper, all
+things ran their course.
+
+
+
+
+VIII. Monseigneur in the Country
+
+
+A beautiful landscape, with the corn bright in it, but not abundant.
+Patches of poor rye where corn should have been, patches of poor peas
+and beans, patches of most coarse vegetable substitutes for wheat. On
+inanimate nature, as on the men and women who cultivated it, a prevalent
+tendency towards an appearance of vegetating unwillingly--a dejected
+disposition to give up, and wither away.
+
+Monsieur the Marquis in his travelling carriage (which might have been
+lighter), conducted by four post-horses and two postilions, fagged up
+a steep hill. A blush on the countenance of Monsieur the Marquis was
+no impeachment of his high breeding; it was not from within; it was
+occasioned by an external circumstance beyond his control--the setting
+sun.
+
+The sunset struck so brilliantly into the travelling carriage when it
+gained the hill-top, that its occupant was steeped in crimson. “It will
+die out,” said Monsieur the Marquis, glancing at his hands, “directly.”
+
+In effect, the sun was so low that it dipped at the moment. When the
+heavy drag had been adjusted to the wheel, and the carriage slid down
+hill, with a cinderous smell, in a cloud of dust, the red glow departed
+quickly; the sun and the Marquis going down together, there was no glow
+left when the drag was taken off.
+
+But, there remained a broken country, bold and open, a little village
+at the bottom of the hill, a broad sweep and rise beyond it, a
+church-tower, a windmill, a forest for the chase, and a crag with a
+fortress on it used as a prison. Round upon all these darkening objects
+as the night drew on, the Marquis looked, with the air of one who was
+coming near home.
+
+The village had its one poor street, with its poor brewery, poor
+tannery, poor tavern, poor stable-yard for relays of post-horses, poor
+fountain, all usual poor appointments. It had its poor people too. All
+its people were poor, and many of them were sitting at their doors,
+shredding spare onions and the like for supper, while many were at the
+fountain, washing leaves, and grasses, and any such small yieldings of
+the earth that could be eaten. Expressive signs of what made them poor,
+were not wanting; the tax for the state, the tax for the church, the tax
+for the lord, tax local and tax general, were to be paid here and to be
+paid there, according to solemn inscription in the little village, until
+the wonder was, that there was any village left unswallowed.
+
+Few children were to be seen, and no dogs. As to the men and women,
+their choice on earth was stated in the prospect--Life on the lowest
+terms that could sustain it, down in the little village under the mill;
+or captivity and Death in the dominant prison on the crag.
+
+Heralded by a courier in advance, and by the cracking of his postilions’
+whips, which twined snake-like about their heads in the evening air, as
+if he came attended by the Furies, Monsieur the Marquis drew up in
+his travelling carriage at the posting-house gate. It was hard by the
+fountain, and the peasants suspended their operations to look at him.
+He looked at them, and saw in them, without knowing it, the slow
+sure filing down of misery-worn face and figure, that was to make the
+meagreness of Frenchmen an English superstition which should survive the
+truth through the best part of a hundred years.
+
+Monsieur the Marquis cast his eyes over the submissive faces that
+drooped before him, as the like of himself had drooped before
+Monseigneur of the Court--only the difference was, that these faces
+drooped merely to suffer and not to propitiate--when a grizzled mender
+of the roads joined the group.
+
+“Bring me hither that fellow!” said the Marquis to the courier.
+
+The fellow was brought, cap in hand, and the other fellows closed round
+to look and listen, in the manner of the people at the Paris fountain.
+
+“I passed you on the road?”
+
+“Monseigneur, it is true. I had the honour of being passed on the road.”
+
+“Coming up the hill, and at the top of the hill, both?”
+
+“Monseigneur, it is true.”
+
+“What did you look at, so fixedly?”
+
+“Monseigneur, I looked at the man.”
+
+He stooped a little, and with his tattered blue cap pointed under the
+carriage. All his fellows stooped to look under the carriage.
+
+“What man, pig? And why look there?”
+
+“Pardon, Monseigneur; he swung by the chain of the shoe--the drag.”
+
+“Who?” demanded the traveller.
+
+“Monseigneur, the man.”
+
+“May the Devil carry away these idiots! How do you call the man? You
+know all the men of this part of the country. Who was he?”
+
+“Your clemency, Monseigneur! He was not of this part of the country. Of
+all the days of my life, I never saw him.”
+
+“Swinging by the chain? To be suffocated?”
+
+“With your gracious permission, that was the wonder of it, Monseigneur.
+His head hanging over--like this!”
+
+He turned himself sideways to the carriage, and leaned back, with his
+face thrown up to the sky, and his head hanging down; then recovered
+himself, fumbled with his cap, and made a bow.
+
+“What was he like?”
+
+“Monseigneur, he was whiter than the miller. All covered with dust,
+white as a spectre, tall as a spectre!”
+
+The picture produced an immense sensation in the little crowd; but all
+eyes, without comparing notes with other eyes, looked at Monsieur
+the Marquis. Perhaps, to observe whether he had any spectre on his
+conscience.
+
+“Truly, you did well,” said the Marquis, felicitously sensible that such
+vermin were not to ruffle him, “to see a thief accompanying my carriage,
+and not open that great mouth of yours. Bah! Put him aside, Monsieur
+Gabelle!”
+
+Monsieur Gabelle was the Postmaster, and some other taxing functionary
+united; he had come out with great obsequiousness to assist at this
+examination, and had held the examined by the drapery of his arm in an
+official manner.
+
+“Bah! Go aside!” said Monsieur Gabelle.
+
+“Lay hands on this stranger if he seeks to lodge in your village
+to-night, and be sure that his business is honest, Gabelle.”
+
+“Monseigneur, I am flattered to devote myself to your orders.”
+
+“Did he run away, fellow?--where is that Accursed?”
+
+The accursed was already under the carriage with some half-dozen
+particular friends, pointing out the chain with his blue cap. Some
+half-dozen other particular friends promptly hauled him out, and
+presented him breathless to Monsieur the Marquis.
+
+“Did the man run away, Dolt, when we stopped for the drag?”
+
+“Monseigneur, he precipitated himself over the hill-side, head first, as
+a person plunges into the river.”
+
+“See to it, Gabelle. Go on!”
+
+The half-dozen who were peering at the chain were still among the
+wheels, like sheep; the wheels turned so suddenly that they were lucky
+to save their skins and bones; they had very little else to save, or
+they might not have been so fortunate.
+
+The burst with which the carriage started out of the village and up the
+rise beyond, was soon checked by the steepness of the hill. Gradually,
+it subsided to a foot pace, swinging and lumbering upward among the many
+sweet scents of a summer night. The postilions, with a thousand gossamer
+gnats circling about them in lieu of the Furies, quietly mended the
+points to the lashes of their whips; the valet walked by the horses; the
+courier was audible, trotting on ahead into the dull distance.
+
+At the steepest point of the hill there was a little burial-ground,
+with a Cross and a new large figure of Our Saviour on it; it was a poor
+figure in wood, done by some inexperienced rustic carver, but he had
+studied the figure from the life--his own life, maybe--for it was
+dreadfully spare and thin.
+
+To this distressful emblem of a great distress that had long been
+growing worse, and was not at its worst, a woman was kneeling. She
+turned her head as the carriage came up to her, rose quickly, and
+presented herself at the carriage-door.
+
+“It is you, Monseigneur! Monseigneur, a petition.”
+
+With an exclamation of impatience, but with his unchangeable face,
+Monseigneur looked out.
+
+“How, then! What is it? Always petitions!”
+
+“Monseigneur. For the love of the great God! My husband, the forester.”
+
+“What of your husband, the forester? Always the same with you people. He
+cannot pay something?”
+
+“He has paid all, Monseigneur. He is dead.”
+
+“Well! He is quiet. Can I restore him to you?”
+
+“Alas, no, Monseigneur! But he lies yonder, under a little heap of poor
+grass.”
+
+“Well?”
+
+“Monseigneur, there are so many little heaps of poor grass?”
+
+“Again, well?”
+
+She looked an old woman, but was young. Her manner was one of passionate
+grief; by turns she clasped her veinous and knotted hands together
+with wild energy, and laid one of them on the carriage-door--tenderly,
+caressingly, as if it had been a human breast, and could be expected to
+feel the appealing touch.
+
+“Monseigneur, hear me! Monseigneur, hear my petition! My husband died of
+want; so many die of want; so many more will die of want.”
+
+“Again, well? Can I feed them?”
+
+“Monseigneur, the good God knows; but I don’t ask it. My petition is,
+that a morsel of stone or wood, with my husband’s name, may be placed
+over him to show where he lies. Otherwise, the place will be quickly
+forgotten, it will never be found when I am dead of the same malady, I
+shall be laid under some other heap of poor grass. Monseigneur, they
+are so many, they increase so fast, there is so much want. Monseigneur!
+Monseigneur!”
+
+The valet had put her away from the door, the carriage had broken into
+a brisk trot, the postilions had quickened the pace, she was left far
+behind, and Monseigneur, again escorted by the Furies, was rapidly
+diminishing the league or two of distance that remained between him and
+his chateau.
+
+The sweet scents of the summer night rose all around him, and rose, as
+the rain falls, impartially, on the dusty, ragged, and toil-worn group
+at the fountain not far away; to whom the mender of roads, with the aid
+of the blue cap without which he was nothing, still enlarged upon his
+man like a spectre, as long as they could bear it. By degrees, as they
+could bear no more, they dropped off one by one, and lights twinkled
+in little casements; which lights, as the casements darkened, and more
+stars came out, seemed to have shot up into the sky instead of having
+been extinguished.
+
+The shadow of a large high-roofed house, and of many over-hanging trees,
+was upon Monsieur the Marquis by that time; and the shadow was exchanged
+for the light of a flambeau, as his carriage stopped, and the great door
+of his chateau was opened to him.
+
+“Monsieur Charles, whom I expect; is he arrived from England?”
+
+“Monseigneur, not yet.”
+
+
+
+
+IX. The Gorgon’s Head
+
+
+It was a heavy mass of building, that chateau of Monsieur the Marquis,
+with a large stone courtyard before it, and two stone sweeps of
+staircase meeting in a stone terrace before the principal door. A stony
+business altogether, with heavy stone balustrades, and stone urns, and
+stone flowers, and stone faces of men, and stone heads of lions, in
+all directions. As if the Gorgon’s head had surveyed it, when it was
+finished, two centuries ago.
+
+Up the broad flight of shallow steps, Monsieur the Marquis, flambeau
+preceded, went from his carriage, sufficiently disturbing the darkness
+to elicit loud remonstrance from an owl in the roof of the great pile
+of stable building away among the trees. All else was so quiet, that the
+flambeau carried up the steps, and the other flambeau held at the great
+door, burnt as if they were in a close room of state, instead of being
+in the open night-air. Other sound than the owl’s voice there was none,
+save the falling of a fountain into its stone basin; for, it was one of
+those dark nights that hold their breath by the hour together, and then
+heave a long low sigh, and hold their breath again.
+
+The great door clanged behind him, and Monsieur the Marquis crossed a
+hall grim with certain old boar-spears, swords, and knives of the chase;
+grimmer with certain heavy riding-rods and riding-whips, of which many a
+peasant, gone to his benefactor Death, had felt the weight when his lord
+was angry.
+
+Avoiding the larger rooms, which were dark and made fast for the night,
+Monsieur the Marquis, with his flambeau-bearer going on before, went up
+the staircase to a door in a corridor. This thrown open, admitted him
+to his own private apartment of three rooms: his bed-chamber and two
+others. High vaulted rooms with cool uncarpeted floors, great dogs upon
+the hearths for the burning of wood in winter time, and all luxuries
+befitting the state of a marquis in a luxurious age and country.
+The fashion of the last Louis but one, of the line that was never to
+break--the fourteenth Louis--was conspicuous in their rich furniture;
+but, it was diversified by many objects that were illustrations of old
+pages in the history of France.
+
+A supper-table was laid for two, in the third of the rooms; a round
+room, in one of the chateau’s four extinguisher-topped towers. A small
+lofty room, with its window wide open, and the wooden jalousie-blinds
+closed, so that the dark night only showed in slight horizontal lines of
+black, alternating with their broad lines of stone colour.
+
+“My nephew,” said the Marquis, glancing at the supper preparation; “they
+said he was not arrived.”
+
+Nor was he; but, he had been expected with Monseigneur.
+
+“Ah! It is not probable he will arrive to-night; nevertheless, leave the
+table as it is. I shall be ready in a quarter of an hour.”
+
+In a quarter of an hour Monseigneur was ready, and sat down alone to his
+sumptuous and choice supper. His chair was opposite to the window, and
+he had taken his soup, and was raising his glass of Bordeaux to his
+lips, when he put it down.
+
+“What is that?” he calmly asked, looking with attention at the
+horizontal lines of black and stone colour.
+
+“Monseigneur? That?”
+
+“Outside the blinds. Open the blinds.”
+
+It was done.
+
+“Well?”
+
+“Monseigneur, it is nothing. The trees and the night are all that are
+here.”
+
+The servant who spoke, had thrown the blinds wide, had looked out into
+the vacant darkness, and stood with that blank behind him, looking round
+for instructions.
+
+“Good,” said the imperturbable master. “Close them again.”
+
+That was done too, and the Marquis went on with his supper. He was
+half way through it, when he again stopped with his glass in his hand,
+hearing the sound of wheels. It came on briskly, and came up to the
+front of the chateau.
+
+“Ask who is arrived.”
+
+It was the nephew of Monseigneur. He had been some few leagues behind
+Monseigneur, early in the afternoon. He had diminished the distance
+rapidly, but not so rapidly as to come up with Monseigneur on the road.
+He had heard of Monseigneur, at the posting-houses, as being before him.
+
+He was to be told (said Monseigneur) that supper awaited him then and
+there, and that he was prayed to come to it. In a little while he came.
+He had been known in England as Charles Darnay.
+
+Monseigneur received him in a courtly manner, but they did not shake
+hands.
+
+“You left Paris yesterday, sir?” he said to Monseigneur, as he took his
+seat at table.
+
+“Yesterday. And you?”
+
+“I come direct.”
+
+“From London?”
+
+“Yes.”
+
+“You have been a long time coming,” said the Marquis, with a smile.
+
+“On the contrary; I come direct.”
+
+“Pardon me! I mean, not a long time on the journey; a long time
+intending the journey.”
+
+“I have been detained by”--the nephew stopped a moment in his
+answer--“various business.”
+
+“Without doubt,” said the polished uncle.
+
+So long as a servant was present, no other words passed between them.
+When coffee had been served and they were alone together, the nephew,
+looking at the uncle and meeting the eyes of the face that was like a
+fine mask, opened a conversation.
+
+“I have come back, sir, as you anticipate, pursuing the object that
+took me away. It carried me into great and unexpected peril; but it is
+a sacred object, and if it had carried me to death I hope it would have
+sustained me.”
+
+“Not to death,” said the uncle; “it is not necessary to say, to death.”
+
+“I doubt, sir,” returned the nephew, “whether, if it had carried me to
+the utmost brink of death, you would have cared to stop me there.”
+
+The deepened marks in the nose, and the lengthening of the fine straight
+lines in the cruel face, looked ominous as to that; the uncle made a
+graceful gesture of protest, which was so clearly a slight form of good
+breeding that it was not reassuring.
+
+“Indeed, sir,” pursued the nephew, “for anything I know, you may have
+expressly worked to give a more suspicious appearance to the suspicious
+circumstances that surrounded me.”
+
+“No, no, no,” said the uncle, pleasantly.
+
+“But, however that may be,” resumed the nephew, glancing at him with
+deep distrust, “I know that your diplomacy would stop me by any means,
+and would know no scruple as to means.”
+
+“My friend, I told you so,” said the uncle, with a fine pulsation in the
+two marks. “Do me the favour to recall that I told you so, long ago.”
+
+“I recall it.”
+
+“Thank you,” said the Marquis--very sweetly indeed.
+
+His tone lingered in the air, almost like the tone of a musical
+instrument.
+
+“In effect, sir,” pursued the nephew, “I believe it to be at once your
+bad fortune, and my good fortune, that has kept me out of a prison in
+France here.”
+
+“I do not quite understand,” returned the uncle, sipping his coffee.
+“Dare I ask you to explain?”
+
+“I believe that if you were not in disgrace with the Court, and had not
+been overshadowed by that cloud for years past, a letter de cachet would
+have sent me to some fortress indefinitely.”
+
+“It is possible,” said the uncle, with great calmness. “For the honour
+of the family, I could even resolve to incommode you to that extent.
+Pray excuse me!”
+
+“I perceive that, happily for me, the Reception of the day before
+yesterday was, as usual, a cold one,” observed the nephew.
+
+“I would not say happily, my friend,” returned the uncle, with refined
+politeness; “I would not be sure of that. A good opportunity for
+consideration, surrounded by the advantages of solitude, might influence
+your destiny to far greater advantage than you influence it for
+yourself. But it is useless to discuss the question. I am, as you say,
+at a disadvantage. These little instruments of correction, these gentle
+aids to the power and honour of families, these slight favours that
+might so incommode you, are only to be obtained now by interest
+and importunity. They are sought by so many, and they are granted
+(comparatively) to so few! It used not to be so, but France in all such
+things is changed for the worse. Our not remote ancestors held the right
+of life and death over the surrounding vulgar. From this room, many such
+dogs have been taken out to be hanged; in the next room (my bedroom),
+one fellow, to our knowledge, was poniarded on the spot for professing
+some insolent delicacy respecting his daughter--_his_ daughter? We have
+lost many privileges; a new philosophy has become the mode; and the
+assertion of our station, in these days, might (I do not go so far as
+to say would, but might) cause us real inconvenience. All very bad, very
+bad!”
+
+The Marquis took a gentle little pinch of snuff, and shook his head;
+as elegantly despondent as he could becomingly be of a country still
+containing himself, that great means of regeneration.
+
+“We have so asserted our station, both in the old time and in the modern
+time also,” said the nephew, gloomily, “that I believe our name to be
+more detested than any name in France.”
+
+“Let us hope so,” said the uncle. “Detestation of the high is the
+involuntary homage of the low.”
+
+“There is not,” pursued the nephew, in his former tone, “a face I can
+look at, in all this country round about us, which looks at me with any
+deference on it but the dark deference of fear and slavery.”
+
+“A compliment,” said the Marquis, “to the grandeur of the family,
+merited by the manner in which the family has sustained its grandeur.
+Hah!” And he took another gentle little pinch of snuff, and lightly
+crossed his legs.
+
+But, when his nephew, leaning an elbow on the table, covered his eyes
+thoughtfully and dejectedly with his hand, the fine mask looked at
+him sideways with a stronger concentration of keenness, closeness,
+and dislike, than was comportable with its wearer’s assumption of
+indifference.
+
+“Repression is the only lasting philosophy. The dark deference of fear
+and slavery, my friend,” observed the Marquis, “will keep the dogs
+obedient to the whip, as long as this roof,” looking up to it, “shuts
+out the sky.”
+
+That might not be so long as the Marquis supposed. If a picture of the
+chateau as it was to be a very few years hence, and of fifty like it as
+they too were to be a very few years hence, could have been shown to
+him that night, he might have been at a loss to claim his own from
+the ghastly, fire-charred, plunder-wrecked rains. As for the roof
+he vaunted, he might have found _that_ shutting out the sky in a new
+way--to wit, for ever, from the eyes of the bodies into which its lead
+was fired, out of the barrels of a hundred thousand muskets.
+
+“Meanwhile,” said the Marquis, “I will preserve the honour and repose
+of the family, if you will not. But you must be fatigued. Shall we
+terminate our conference for the night?”
+
+“A moment more.”
+
+“An hour, if you please.”
+
+“Sir,” said the nephew, “we have done wrong, and are reaping the fruits
+of wrong.”
+
+“_We_ have done wrong?” repeated the Marquis, with an inquiring smile,
+and delicately pointing, first to his nephew, then to himself.
+
+“Our family; our honourable family, whose honour is of so much account
+to both of us, in such different ways. Even in my father’s time, we did
+a world of wrong, injuring every human creature who came between us and
+our pleasure, whatever it was. Why need I speak of my father’s time,
+when it is equally yours? Can I separate my father’s twin-brother, joint
+inheritor, and next successor, from himself?”
+
+“Death has done that!” said the Marquis.
+
+“And has left me,” answered the nephew, “bound to a system that is
+frightful to me, responsible for it, but powerless in it; seeking to
+execute the last request of my dear mother’s lips, and obey the last
+look of my dear mother’s eyes, which implored me to have mercy and to
+redress; and tortured by seeking assistance and power in vain.”
+
+“Seeking them from me, my nephew,” said the Marquis, touching him on the
+breast with his forefinger--they were now standing by the hearth--“you
+will for ever seek them in vain, be assured.”
+
+Every fine straight line in the clear whiteness of his face, was
+cruelly, craftily, and closely compressed, while he stood looking
+quietly at his nephew, with his snuff-box in his hand. Once again he
+touched him on the breast, as though his finger were the fine point of
+a small sword, with which, in delicate finesse, he ran him through the
+body, and said,
+
+“My friend, I will die, perpetuating the system under which I have
+lived.”
+
+When he had said it, he took a culminating pinch of snuff, and put his
+box in his pocket.
+
+“Better to be a rational creature,” he added then, after ringing a small
+bell on the table, “and accept your natural destiny. But you are lost,
+Monsieur Charles, I see.”
+
+“This property and France are lost to me,” said the nephew, sadly; “I
+renounce them.”
+
+“Are they both yours to renounce? France may be, but is the property? It
+is scarcely worth mentioning; but, is it yet?”
+
+“I had no intention, in the words I used, to claim it yet. If it passed
+to me from you, to-morrow--”
+
+“Which I have the vanity to hope is not probable.”
+
+“--or twenty years hence--”
+
+“You do me too much honour,” said the Marquis; “still, I prefer that
+supposition.”
+
+“--I would abandon it, and live otherwise and elsewhere. It is little to
+relinquish. What is it but a wilderness of misery and ruin!”
+
+“Hah!” said the Marquis, glancing round the luxurious room.
+
+“To the eye it is fair enough, here; but seen in its integrity,
+under the sky, and by the daylight, it is a crumbling tower of waste,
+mismanagement, extortion, debt, mortgage, oppression, hunger, nakedness,
+and suffering.”
+
+“Hah!” said the Marquis again, in a well-satisfied manner.
+
+“If it ever becomes mine, it shall be put into some hands better
+qualified to free it slowly (if such a thing is possible) from the
+weight that drags it down, so that the miserable people who cannot leave
+it and who have been long wrung to the last point of endurance, may, in
+another generation, suffer less; but it is not for me. There is a curse
+on it, and on all this land.”
+
+“And you?” said the uncle. “Forgive my curiosity; do you, under your new
+philosophy, graciously intend to live?”
+
+“I must do, to live, what others of my countrymen, even with nobility at
+their backs, may have to do some day--work.”
+
+“In England, for example?”
+
+“Yes. The family honour, sir, is safe from me in this country. The
+family name can suffer from me in no other, for I bear it in no other.”
+
+The ringing of the bell had caused the adjoining bed-chamber to be
+lighted. It now shone brightly, through the door of communication. The
+Marquis looked that way, and listened for the retreating step of his
+valet.
+
+“England is very attractive to you, seeing how indifferently you have
+prospered there,” he observed then, turning his calm face to his nephew
+with a smile.
+
+“I have already said, that for my prospering there, I am sensible I may
+be indebted to you, sir. For the rest, it is my Refuge.”
+
+“They say, those boastful English, that it is the Refuge of many. You
+know a compatriot who has found a Refuge there? A Doctor?”
+
+“Yes.”
+
+“With a daughter?”
+
+“Yes.”
+
+“Yes,” said the Marquis. “You are fatigued. Good night!”
+
+As he bent his head in his most courtly manner, there was a secrecy
+in his smiling face, and he conveyed an air of mystery to those words,
+which struck the eyes and ears of his nephew forcibly. At the same
+time, the thin straight lines of the setting of the eyes, and the thin
+straight lips, and the markings in the nose, curved with a sarcasm that
+looked handsomely diabolic.
+
+“Yes,” repeated the Marquis. “A Doctor with a daughter. Yes. So
+commences the new philosophy! You are fatigued. Good night!”
+
+It would have been of as much avail to interrogate any stone face
+outside the chateau as to interrogate that face of his. The nephew
+looked at him, in vain, in passing on to the door.
+
+“Good night!” said the uncle. “I look to the pleasure of seeing you
+again in the morning. Good repose! Light Monsieur my nephew to his
+chamber there!--And burn Monsieur my nephew in his bed, if you will,” he
+added to himself, before he rang his little bell again, and summoned his
+valet to his own bedroom.
+
+The valet come and gone, Monsieur the Marquis walked to and fro in his
+loose chamber-robe, to prepare himself gently for sleep, that hot still
+night. Rustling about the room, his softly-slippered feet making no
+noise on the floor, he moved like a refined tiger:--looked like some
+enchanted marquis of the impenitently wicked sort, in story, whose
+periodical change into tiger form was either just going off, or just
+coming on.
+
+He moved from end to end of his voluptuous bedroom, looking again at the
+scraps of the day’s journey that came unbidden into his mind; the slow
+toil up the hill at sunset, the setting sun, the descent, the mill, the
+prison on the crag, the little village in the hollow, the peasants at
+the fountain, and the mender of roads with his blue cap pointing out the
+chain under the carriage. That fountain suggested the Paris fountain,
+the little bundle lying on the step, the women bending over it, and the
+tall man with his arms up, crying, “Dead!”
+
+“I am cool now,” said Monsieur the Marquis, “and may go to bed.”
+
+So, leaving only one light burning on the large hearth, he let his thin
+gauze curtains fall around him, and heard the night break its silence
+with a long sigh as he composed himself to sleep.
+
+The stone faces on the outer walls stared blindly at the black night
+for three heavy hours; for three heavy hours, the horses in the stables
+rattled at their racks, the dogs barked, and the owl made a noise with
+very little resemblance in it to the noise conventionally assigned to
+the owl by men-poets. But it is the obstinate custom of such creatures
+hardly ever to say what is set down for them.
+
+For three heavy hours, the stone faces of the chateau, lion and human,
+stared blindly at the night. Dead darkness lay on all the landscape,
+dead darkness added its own hush to the hushing dust on all the roads.
+The burial-place had got to the pass that its little heaps of poor grass
+were undistinguishable from one another; the figure on the Cross might
+have come down, for anything that could be seen of it. In the village,
+taxers and taxed were fast asleep. Dreaming, perhaps, of banquets, as
+the starved usually do, and of ease and rest, as the driven slave and
+the yoked ox may, its lean inhabitants slept soundly, and were fed and
+freed.
+
+The fountain in the village flowed unseen and unheard, and the fountain
+at the chateau dropped unseen and unheard--both melting away, like the
+minutes that were falling from the spring of Time--through three dark
+hours. Then, the grey water of both began to be ghostly in the light,
+and the eyes of the stone faces of the chateau were opened.
+
+Lighter and lighter, until at last the sun touched the tops of the still
+trees, and poured its radiance over the hill. In the glow, the water
+of the chateau fountain seemed to turn to blood, and the stone faces
+crimsoned. The carol of the birds was loud and high, and, on the
+weather-beaten sill of the great window of the bed-chamber of Monsieur
+the Marquis, one little bird sang its sweetest song with all its might.
+At this, the nearest stone face seemed to stare amazed, and, with open
+mouth and dropped under-jaw, looked awe-stricken.
+
+Now, the sun was full up, and movement began in the village. Casement
+windows opened, crazy doors were unbarred, and people came forth
+shivering--chilled, as yet, by the new sweet air. Then began the rarely
+lightened toil of the day among the village population. Some, to the
+fountain; some, to the fields; men and women here, to dig and delve; men
+and women there, to see to the poor live stock, and lead the bony cows
+out, to such pasture as could be found by the roadside. In the church
+and at the Cross, a kneeling figure or two; attendant on the latter
+prayers, the led cow, trying for a breakfast among the weeds at its
+foot.
+
+The chateau awoke later, as became its quality, but awoke gradually and
+surely. First, the lonely boar-spears and knives of the chase had been
+reddened as of old; then, had gleamed trenchant in the morning sunshine;
+now, doors and windows were thrown open, horses in their stables looked
+round over their shoulders at the light and freshness pouring in at
+doorways, leaves sparkled and rustled at iron-grated windows, dogs
+pulled hard at their chains, and reared impatient to be loosed.
+
+All these trivial incidents belonged to the routine of life, and the
+return of morning. Surely, not so the ringing of the great bell of the
+chateau, nor the running up and down the stairs; nor the hurried
+figures on the terrace; nor the booting and tramping here and there and
+everywhere, nor the quick saddling of horses and riding away?
+
+What winds conveyed this hurry to the grizzled mender of roads, already
+at work on the hill-top beyond the village, with his day’s dinner (not
+much to carry) lying in a bundle that it was worth no crow’s while to
+peck at, on a heap of stones? Had the birds, carrying some grains of it
+to a distance, dropped one over him as they sow chance seeds? Whether or
+no, the mender of roads ran, on the sultry morning, as if for his life,
+down the hill, knee-high in dust, and never stopped till he got to the
+fountain.
+
+All the people of the village were at the fountain, standing about
+in their depressed manner, and whispering low, but showing no other
+emotions than grim curiosity and surprise. The led cows, hastily brought
+in and tethered to anything that would hold them, were looking stupidly
+on, or lying down chewing the cud of nothing particularly repaying their
+trouble, which they had picked up in their interrupted saunter. Some of
+the people of the chateau, and some of those of the posting-house, and
+all the taxing authorities, were armed more or less, and were crowded
+on the other side of the little street in a purposeless way, that was
+highly fraught with nothing. Already, the mender of roads had penetrated
+into the midst of a group of fifty particular friends, and was smiting
+himself in the breast with his blue cap. What did all this portend,
+and what portended the swift hoisting-up of Monsieur Gabelle behind
+a servant on horseback, and the conveying away of the said Gabelle
+(double-laden though the horse was), at a gallop, like a new version of
+the German ballad of Leonora?
+
+It portended that there was one stone face too many, up at the chateau.
+
+The Gorgon had surveyed the building again in the night, and had added
+the one stone face wanting; the stone face for which it had waited
+through about two hundred years.
+
+It lay back on the pillow of Monsieur the Marquis. It was like a fine
+mask, suddenly startled, made angry, and petrified. Driven home into the
+heart of the stone figure attached to it, was a knife. Round its hilt
+was a frill of paper, on which was scrawled:
+
+“Drive him fast to his tomb. This, from Jacques.”
+
+
+
+
+X. Two Promises
+
+
+More months, to the number of twelve, had come and gone, and Mr. Charles
+Darnay was established in England as a higher teacher of the French
+language who was conversant with French literature. In this age, he
+would have been a Professor; in that age, he was a Tutor. He read with
+young men who could find any leisure and interest for the study of a
+living tongue spoken all over the world, and he cultivated a taste for
+its stores of knowledge and fancy. He could write of them, besides, in
+sound English, and render them into sound English. Such masters were not
+at that time easily found; Princes that had been, and Kings that were
+to be, were not yet of the Teacher class, and no ruined nobility had
+dropped out of Tellson’s ledgers, to turn cooks and carpenters. As a
+tutor, whose attainments made the student’s way unusually pleasant and
+profitable, and as an elegant translator who brought something to his
+work besides mere dictionary knowledge, young Mr. Darnay soon became
+known and encouraged. He was well acquainted, more-over, with the
+circumstances of his country, and those were of ever-growing interest.
+So, with great perseverance and untiring industry, he prospered.
+
+In London, he had expected neither to walk on pavements of gold, nor
+to lie on beds of roses; if he had had any such exalted expectation, he
+would not have prospered. He had expected labour, and he found it, and
+did it and made the best of it. In this, his prosperity consisted.
+
+A certain portion of his time was passed at Cambridge, where he
+read with undergraduates as a sort of tolerated smuggler who drove a
+contraband trade in European languages, instead of conveying Greek
+and Latin through the Custom-house. The rest of his time he passed in
+London.
+
+Now, from the days when it was always summer in Eden, to these days
+when it is mostly winter in fallen latitudes, the world of a man has
+invariably gone one way--Charles Darnay’s way--the way of the love of a
+woman.
+
+He had loved Lucie Manette from the hour of his danger. He had never
+heard a sound so sweet and dear as the sound of her compassionate voice;
+he had never seen a face so tenderly beautiful, as hers when it was
+confronted with his own on the edge of the grave that had been dug for
+him. But, he had not yet spoken to her on the subject; the assassination
+at the deserted chateau far away beyond the heaving water and the long,
+long, dusty roads--the solid stone chateau which had itself become the
+mere mist of a dream--had been done a year, and he had never yet, by so
+much as a single spoken word, disclosed to her the state of his heart.
+
+That he had his reasons for this, he knew full well. It was again a
+summer day when, lately arrived in London from his college occupation,
+he turned into the quiet corner in Soho, bent on seeking an opportunity
+of opening his mind to Doctor Manette. It was the close of the summer
+day, and he knew Lucie to be out with Miss Pross.
+
+He found the Doctor reading in his arm-chair at a window. The energy
+which had at once supported him under his old sufferings and aggravated
+their sharpness, had been gradually restored to him. He was now a
+very energetic man indeed, with great firmness of purpose, strength
+of resolution, and vigour of action. In his recovered energy he was
+sometimes a little fitful and sudden, as he had at first been in the
+exercise of his other recovered faculties; but, this had never been
+frequently observable, and had grown more and more rare.
+
+He studied much, slept little, sustained a great deal of fatigue with
+ease, and was equably cheerful. To him, now entered Charles Darnay, at
+sight of whom he laid aside his book and held out his hand.
+
+“Charles Darnay! I rejoice to see you. We have been counting on your
+return these three or four days past. Mr. Stryver and Sydney Carton were
+both here yesterday, and both made you out to be more than due.”
+
+“I am obliged to them for their interest in the matter,” he answered,
+a little coldly as to them, though very warmly as to the Doctor. “Miss
+Manette--”
+
+“Is well,” said the Doctor, as he stopped short, “and your return will
+delight us all. She has gone out on some household matters, but will
+soon be home.”
+
+“Doctor Manette, I knew she was from home. I took the opportunity of her
+being from home, to beg to speak to you.”
+
+There was a blank silence.
+
+“Yes?” said the Doctor, with evident constraint. “Bring your chair here,
+and speak on.”
+
+He complied as to the chair, but appeared to find the speaking on less
+easy.
+
+“I have had the happiness, Doctor Manette, of being so intimate here,”
+ so he at length began, “for some year and a half, that I hope the topic
+on which I am about to touch may not--”
+
+He was stayed by the Doctor’s putting out his hand to stop him. When he
+had kept it so a little while, he said, drawing it back:
+
+“Is Lucie the topic?”
+
+“She is.”
+
+“It is hard for me to speak of her at any time. It is very hard for me
+to hear her spoken of in that tone of yours, Charles Darnay.”
+
+“It is a tone of fervent admiration, true homage, and deep love, Doctor
+Manette!” he said deferentially.
+
+There was another blank silence before her father rejoined:
+
+“I believe it. I do you justice; I believe it.”
+
+His constraint was so manifest, and it was so manifest, too, that it
+originated in an unwillingness to approach the subject, that Charles
+Darnay hesitated.
+
+“Shall I go on, sir?”
+
+Another blank.
+
+“Yes, go on.”
+
+“You anticipate what I would say, though you cannot know how earnestly
+I say it, how earnestly I feel it, without knowing my secret heart, and
+the hopes and fears and anxieties with which it has long been
+laden. Dear Doctor Manette, I love your daughter fondly, dearly,
+disinterestedly, devotedly. If ever there were love in the world, I love
+her. You have loved yourself; let your old love speak for me!”
+
+The Doctor sat with his face turned away, and his eyes bent on the
+ground. At the last words, he stretched out his hand again, hurriedly,
+and cried:
+
+“Not that, sir! Let that be! I adjure you, do not recall that!”
+
+His cry was so like a cry of actual pain, that it rang in Charles
+Darnay’s ears long after he had ceased. He motioned with the hand he had
+extended, and it seemed to be an appeal to Darnay to pause. The latter
+so received it, and remained silent.
+
+“I ask your pardon,” said the Doctor, in a subdued tone, after some
+moments. “I do not doubt your loving Lucie; you may be satisfied of it.”
+
+He turned towards him in his chair, but did not look at him, or
+raise his eyes. His chin dropped upon his hand, and his white hair
+overshadowed his face:
+
+“Have you spoken to Lucie?”
+
+“No.”
+
+“Nor written?”
+
+“Never.”
+
+“It would be ungenerous to affect not to know that your self-denial is
+to be referred to your consideration for her father. Her father thanks
+you.”
+
+He offered his hand; but his eyes did not go with it.
+
+“I know,” said Darnay, respectfully, “how can I fail to know, Doctor
+Manette, I who have seen you together from day to day, that between
+you and Miss Manette there is an affection so unusual, so touching, so
+belonging to the circumstances in which it has been nurtured, that it
+can have few parallels, even in the tenderness between a father and
+child. I know, Doctor Manette--how can I fail to know--that, mingled
+with the affection and duty of a daughter who has become a woman, there
+is, in her heart, towards you, all the love and reliance of infancy
+itself. I know that, as in her childhood she had no parent, so she is
+now devoted to you with all the constancy and fervour of her present
+years and character, united to the trustfulness and attachment of the
+early days in which you were lost to her. I know perfectly well that if
+you had been restored to her from the world beyond this life, you could
+hardly be invested, in her sight, with a more sacred character than that
+in which you are always with her. I know that when she is clinging to
+you, the hands of baby, girl, and woman, all in one, are round your
+neck. I know that in loving you she sees and loves her mother at her
+own age, sees and loves you at my age, loves her mother broken-hearted,
+loves you through your dreadful trial and in your blessed restoration. I
+have known this, night and day, since I have known you in your home.”
+
+Her father sat silent, with his face bent down. His breathing was a
+little quickened; but he repressed all other signs of agitation.
+
+“Dear Doctor Manette, always knowing this, always seeing her and you
+with this hallowed light about you, I have forborne, and forborne, as
+long as it was in the nature of man to do it. I have felt, and do even
+now feel, that to bring my love--even mine--between you, is to touch
+your history with something not quite so good as itself. But I love her.
+Heaven is my witness that I love her!”
+
+“I believe it,” answered her father, mournfully. “I have thought so
+before now. I believe it.”
+
+“But, do not believe,” said Darnay, upon whose ear the mournful voice
+struck with a reproachful sound, “that if my fortune were so cast as
+that, being one day so happy as to make her my wife, I must at any time
+put any separation between her and you, I could or would breathe a
+word of what I now say. Besides that I should know it to be hopeless, I
+should know it to be a baseness. If I had any such possibility, even at
+a remote distance of years, harboured in my thoughts, and hidden in my
+heart--if it ever had been there--if it ever could be there--I could not
+now touch this honoured hand.”
+
+He laid his own upon it as he spoke.
+
+“No, dear Doctor Manette. Like you, a voluntary exile from France; like
+you, driven from it by its distractions, oppressions, and miseries; like
+you, striving to live away from it by my own exertions, and trusting
+in a happier future; I look only to sharing your fortunes, sharing your
+life and home, and being faithful to you to the death. Not to divide
+with Lucie her privilege as your child, companion, and friend; but to
+come in aid of it, and bind her closer to you, if such a thing can be.”
+
+His touch still lingered on her father’s hand. Answering the touch for a
+moment, but not coldly, her father rested his hands upon the arms of
+his chair, and looked up for the first time since the beginning of the
+conference. A struggle was evidently in his face; a struggle with that
+occasional look which had a tendency in it to dark doubt and dread.
+
+“You speak so feelingly and so manfully, Charles Darnay, that I thank
+you with all my heart, and will open all my heart--or nearly so. Have
+you any reason to believe that Lucie loves you?”
+
+“None. As yet, none.”
+
+“Is it the immediate object of this confidence, that you may at once
+ascertain that, with my knowledge?”
+
+“Not even so. I might not have the hopefulness to do it for weeks; I
+might (mistaken or not mistaken) have that hopefulness to-morrow.”
+
+“Do you seek any guidance from me?”
+
+“I ask none, sir. But I have thought it possible that you might have it
+in your power, if you should deem it right, to give me some.”
+
+“Do you seek any promise from me?”
+
+“I do seek that.”
+
+“What is it?”
+
+“I well understand that, without you, I could have no hope. I well
+understand that, even if Miss Manette held me at this moment in her
+innocent heart--do not think I have the presumption to assume so much--I
+could retain no place in it against her love for her father.”
+
+“If that be so, do you see what, on the other hand, is involved in it?”
+
+“I understand equally well, that a word from her father in any suitor’s
+favour, would outweigh herself and all the world. For which reason,
+Doctor Manette,” said Darnay, modestly but firmly, “I would not ask that
+word, to save my life.”
+
+“I am sure of it. Charles Darnay, mysteries arise out of close love, as
+well as out of wide division; in the former case, they are subtle and
+delicate, and difficult to penetrate. My daughter Lucie is, in this one
+respect, such a mystery to me; I can make no guess at the state of her
+heart.”
+
+“May I ask, sir, if you think she is--” As he hesitated, her father
+supplied the rest.
+
+“Is sought by any other suitor?”
+
+“It is what I meant to say.”
+
+Her father considered a little before he answered:
+
+“You have seen Mr. Carton here, yourself. Mr. Stryver is here too,
+occasionally. If it be at all, it can only be by one of these.”
+
+“Or both,” said Darnay.
+
+“I had not thought of both; I should not think either, likely. You want
+a promise from me. Tell me what it is.”
+
+“It is, that if Miss Manette should bring to you at any time, on her own
+part, such a confidence as I have ventured to lay before you, you will
+bear testimony to what I have said, and to your belief in it. I hope you
+may be able to think so well of me, as to urge no influence against
+me. I say nothing more of my stake in this; this is what I ask. The
+condition on which I ask it, and which you have an undoubted right to
+require, I will observe immediately.”
+
+“I give the promise,” said the Doctor, “without any condition. I believe
+your object to be, purely and truthfully, as you have stated it. I
+believe your intention is to perpetuate, and not to weaken, the ties
+between me and my other and far dearer self. If she should ever tell me
+that you are essential to her perfect happiness, I will give her to you.
+If there were--Charles Darnay, if there were--”
+
+The young man had taken his hand gratefully; their hands were joined as
+the Doctor spoke:
+
+“--any fancies, any reasons, any apprehensions, anything whatsoever,
+new or old, against the man she really loved--the direct responsibility
+thereof not lying on his head--they should all be obliterated for her
+sake. She is everything to me; more to me than suffering, more to me
+than wrong, more to me--Well! This is idle talk.”
+
+So strange was the way in which he faded into silence, and so strange
+his fixed look when he had ceased to speak, that Darnay felt his own
+hand turn cold in the hand that slowly released and dropped it.
+
+“You said something to me,” said Doctor Manette, breaking into a smile.
+“What was it you said to me?”
+
+He was at a loss how to answer, until he remembered having spoken of a
+condition. Relieved as his mind reverted to that, he answered:
+
+“Your confidence in me ought to be returned with full confidence on my
+part. My present name, though but slightly changed from my mother’s, is
+not, as you will remember, my own. I wish to tell you what that is, and
+why I am in England.”
+
+“Stop!” said the Doctor of Beauvais.
+
+“I wish it, that I may the better deserve your confidence, and have no
+secret from you.”
+
+“Stop!”
+
+For an instant, the Doctor even had his two hands at his ears; for
+another instant, even had his two hands laid on Darnay’s lips.
+
+“Tell me when I ask you, not now. If your suit should prosper, if Lucie
+should love you, you shall tell me on your marriage morning. Do you
+promise?”
+
+“Willingly.
+
+“Give me your hand. She will be home directly, and it is better she
+should not see us together to-night. Go! God bless you!”
+
+It was dark when Charles Darnay left him, and it was an hour later and
+darker when Lucie came home; she hurried into the room alone--for
+Miss Pross had gone straight up-stairs--and was surprised to find his
+reading-chair empty.
+
+“My father!” she called to him. “Father dear!”
+
+Nothing was said in answer, but she heard a low hammering sound in his
+bedroom. Passing lightly across the intermediate room, she looked in at
+his door and came running back frightened, crying to herself, with her
+blood all chilled, “What shall I do! What shall I do!”
+
+Her uncertainty lasted but a moment; she hurried back, and tapped at
+his door, and softly called to him. The noise ceased at the sound of
+her voice, and he presently came out to her, and they walked up and down
+together for a long time.
+
+She came down from her bed, to look at him in his sleep that night. He
+slept heavily, and his tray of shoemaking tools, and his old unfinished
+work, were all as usual.
+
+
+
+
+XI. A Companion Picture
+
+
+“Sydney,” said Mr. Stryver, on that self-same night, or morning, to his
+jackal; “mix another bowl of punch; I have something to say to you.”
+
+Sydney had been working double tides that night, and the night before,
+and the night before that, and a good many nights in succession, making
+a grand clearance among Mr. Stryver’s papers before the setting in
+of the long vacation. The clearance was effected at last; the Stryver
+arrears were handsomely fetched up; everything was got rid of until
+November should come with its fogs atmospheric, and fogs legal, and
+bring grist to the mill again.
+
+Sydney was none the livelier and none the soberer for so much
+application. It had taken a deal of extra wet-towelling to pull him
+through the night; a correspondingly extra quantity of wine had preceded
+the towelling; and he was in a very damaged condition, as he now pulled
+his turban off and threw it into the basin in which he had steeped it at
+intervals for the last six hours.
+
+“Are you mixing that other bowl of punch?” said Stryver the portly, with
+his hands in his waistband, glancing round from the sofa where he lay on
+his back.
+
+“I am.”
+
+“Now, look here! I am going to tell you something that will rather
+surprise you, and that perhaps will make you think me not quite as
+shrewd as you usually do think me. I intend to marry.”
+
+“_Do_ you?”
+
+“Yes. And not for money. What do you say now?”
+
+“I don’t feel disposed to say much. Who is she?”
+
+“Guess.”
+
+“Do I know her?”
+
+“Guess.”
+
+“I am not going to guess, at five o’clock in the morning, with my brains
+frying and sputtering in my head. If you want me to guess, you must ask
+me to dinner.”
+
+“Well then, I’ll tell you,” said Stryver, coming slowly into a sitting
+posture. “Sydney, I rather despair of making myself intelligible to you,
+because you are such an insensible dog.”
+
+“And you,” returned Sydney, busy concocting the punch, “are such a
+sensitive and poetical spirit--”
+
+“Come!” rejoined Stryver, laughing boastfully, “though I don’t prefer
+any claim to being the soul of Romance (for I hope I know better), still
+I am a tenderer sort of fellow than _you_.”
+
+“You are a luckier, if you mean that.”
+
+“I don’t mean that. I mean I am a man of more--more--”
+
+“Say gallantry, while you are about it,” suggested Carton.
+
+“Well! I’ll say gallantry. My meaning is that I am a man,” said Stryver,
+inflating himself at his friend as he made the punch, “who cares more to
+be agreeable, who takes more pains to be agreeable, who knows better how
+to be agreeable, in a woman’s society, than you do.”
+
+“Go on,” said Sydney Carton.
+
+“No; but before I go on,” said Stryver, shaking his head in his bullying
+way, “I’ll have this out with you. You’ve been at Doctor Manette’s house
+as much as I have, or more than I have. Why, I have been ashamed of your
+moroseness there! Your manners have been of that silent and sullen and
+hangdog kind, that, upon my life and soul, I have been ashamed of you,
+Sydney!”
+
+“It should be very beneficial to a man in your practice at the bar, to
+be ashamed of anything,” returned Sydney; “you ought to be much obliged
+to me.”
+
+“You shall not get off in that way,” rejoined Stryver, shouldering the
+rejoinder at him; “no, Sydney, it’s my duty to tell you--and I tell you
+to your face to do you good--that you are a devilish ill-conditioned
+fellow in that sort of society. You are a disagreeable fellow.”
+
+Sydney drank a bumper of the punch he had made, and laughed.
+
+“Look at me!” said Stryver, squaring himself; “I have less need to make
+myself agreeable than you have, being more independent in circumstances.
+Why do I do it?”
+
+“I never saw you do it yet,” muttered Carton.
+
+“I do it because it’s politic; I do it on principle. And look at me! I
+get on.”
+
+“You don’t get on with your account of your matrimonial intentions,”
+ answered Carton, with a careless air; “I wish you would keep to that. As
+to me--will you never understand that I am incorrigible?”
+
+He asked the question with some appearance of scorn.
+
+“You have no business to be incorrigible,” was his friend’s answer,
+delivered in no very soothing tone.
+
+“I have no business to be, at all, that I know of,” said Sydney Carton.
+“Who is the lady?”
+
+“Now, don’t let my announcement of the name make you uncomfortable,
+Sydney,” said Mr. Stryver, preparing him with ostentatious friendliness
+for the disclosure he was about to make, “because I know you don’t mean
+half you say; and if you meant it all, it would be of no importance. I
+make this little preface, because you once mentioned the young lady to
+me in slighting terms.”
+
+“I did?”
+
+“Certainly; and in these chambers.”
+
+Sydney Carton looked at his punch and looked at his complacent friend;
+drank his punch and looked at his complacent friend.
+
+“You made mention of the young lady as a golden-haired doll. The young
+lady is Miss Manette. If you had been a fellow of any sensitiveness or
+delicacy of feeling in that kind of way, Sydney, I might have been a
+little resentful of your employing such a designation; but you are not.
+You want that sense altogether; therefore I am no more annoyed when I
+think of the expression, than I should be annoyed by a man’s opinion of
+a picture of mine, who had no eye for pictures: or of a piece of music
+of mine, who had no ear for music.”
+
+Sydney Carton drank the punch at a great rate; drank it by bumpers,
+looking at his friend.
+
+“Now you know all about it, Syd,” said Mr. Stryver. “I don’t care about
+fortune: she is a charming creature, and I have made up my mind to
+please myself: on the whole, I think I can afford to please myself. She
+will have in me a man already pretty well off, and a rapidly rising man,
+and a man of some distinction: it is a piece of good fortune for her,
+but she is worthy of good fortune. Are you astonished?”
+
+Carton, still drinking the punch, rejoined, “Why should I be
+astonished?”
+
+“You approve?”
+
+Carton, still drinking the punch, rejoined, “Why should I not approve?”
+
+“Well!” said his friend Stryver, “you take it more easily than I fancied
+you would, and are less mercenary on my behalf than I thought you would
+be; though, to be sure, you know well enough by this time that your
+ancient chum is a man of a pretty strong will. Yes, Sydney, I have had
+enough of this style of life, with no other as a change from it; I
+feel that it is a pleasant thing for a man to have a home when he feels
+inclined to go to it (when he doesn’t, he can stay away), and I feel
+that Miss Manette will tell well in any station, and will always do me
+credit. So I have made up my mind. And now, Sydney, old boy, I want to
+say a word to _you_ about _your_ prospects. You are in a bad way, you
+know; you really are in a bad way. You don’t know the value of money,
+you live hard, you’ll knock up one of these days, and be ill and poor;
+you really ought to think about a nurse.”
+
+The prosperous patronage with which he said it, made him look twice as
+big as he was, and four times as offensive.
+
+“Now, let me recommend you,” pursued Stryver, “to look it in the face.
+I have looked it in the face, in my different way; look it in the face,
+you, in your different way. Marry. Provide somebody to take care of
+you. Never mind your having no enjoyment of women’s society, nor
+understanding of it, nor tact for it. Find out somebody. Find out some
+respectable woman with a little property--somebody in the landlady way,
+or lodging-letting way--and marry her, against a rainy day. That’s the
+kind of thing for _you_. Now think of it, Sydney.”
+
+“I’ll think of it,” said Sydney.
+
+
+
+
+XII. The Fellow of Delicacy
+
+
+Mr. Stryver having made up his mind to that magnanimous bestowal of good
+fortune on the Doctor’s daughter, resolved to make her happiness known
+to her before he left town for the Long Vacation. After some mental
+debating of the point, he came to the conclusion that it would be as
+well to get all the preliminaries done with, and they could then arrange
+at their leisure whether he should give her his hand a week or two
+before Michaelmas Term, or in the little Christmas vacation between it
+and Hilary.
+
+As to the strength of his case, he had not a doubt about it, but clearly
+saw his way to the verdict. Argued with the jury on substantial worldly
+grounds--the only grounds ever worth taking into account--it was a
+plain case, and had not a weak spot in it. He called himself for the
+plaintiff, there was no getting over his evidence, the counsel for
+the defendant threw up his brief, and the jury did not even turn to
+consider. After trying it, Stryver, C. J., was satisfied that no plainer
+case could be.
+
+Accordingly, Mr. Stryver inaugurated the Long Vacation with a formal
+proposal to take Miss Manette to Vauxhall Gardens; that failing, to
+Ranelagh; that unaccountably failing too, it behoved him to present
+himself in Soho, and there declare his noble mind.
+
+Towards Soho, therefore, Mr. Stryver shouldered his way from the Temple,
+while the bloom of the Long Vacation’s infancy was still upon it.
+Anybody who had seen him projecting himself into Soho while he was yet
+on Saint Dunstan’s side of Temple Bar, bursting in his full-blown way
+along the pavement, to the jostlement of all weaker people, might have
+seen how safe and strong he was.
+
+His way taking him past Tellson’s, and he both banking at Tellson’s and
+knowing Mr. Lorry as the intimate friend of the Manettes, it entered Mr.
+Stryver’s mind to enter the bank, and reveal to Mr. Lorry the brightness
+of the Soho horizon. So, he pushed open the door with the weak rattle
+in its throat, stumbled down the two steps, got past the two ancient
+cashiers, and shouldered himself into the musty back closet where Mr.
+Lorry sat at great books ruled for figures, with perpendicular iron
+bars to his window as if that were ruled for figures too, and everything
+under the clouds were a sum.
+
+“Halloa!” said Mr. Stryver. “How do you do? I hope you are well!”
+
+It was Stryver’s grand peculiarity that he always seemed too big for any
+place, or space. He was so much too big for Tellson’s, that old clerks
+in distant corners looked up with looks of remonstrance, as though he
+squeezed them against the wall. The House itself, magnificently reading
+the paper quite in the far-off perspective, lowered displeased, as if
+the Stryver head had been butted into its responsible waistcoat.
+
+The discreet Mr. Lorry said, in a sample tone of the voice he would
+recommend under the circumstances, “How do you do, Mr. Stryver? How do
+you do, sir?” and shook hands. There was a peculiarity in his manner
+of shaking hands, always to be seen in any clerk at Tellson’s who shook
+hands with a customer when the House pervaded the air. He shook in a
+self-abnegating way, as one who shook for Tellson and Co.
+
+“Can I do anything for you, Mr. Stryver?” asked Mr. Lorry, in his
+business character.
+
+“Why, no, thank you; this is a private visit to yourself, Mr. Lorry; I
+have come for a private word.”
+
+“Oh indeed!” said Mr. Lorry, bending down his ear, while his eye strayed
+to the House afar off.
+
+“I am going,” said Mr. Stryver, leaning his arms confidentially on the
+desk: whereupon, although it was a large double one, there appeared to
+be not half desk enough for him: “I am going to make an offer of myself
+in marriage to your agreeable little friend, Miss Manette, Mr. Lorry.”
+
+“Oh dear me!” cried Mr. Lorry, rubbing his chin, and looking at his
+visitor dubiously.
+
+“Oh dear me, sir?” repeated Stryver, drawing back. “Oh dear you, sir?
+What may your meaning be, Mr. Lorry?”
+
+“My meaning,” answered the man of business, “is, of course, friendly and
+appreciative, and that it does you the greatest credit, and--in short,
+my meaning is everything you could desire. But--really, you know, Mr.
+Stryver--” Mr. Lorry paused, and shook his head at him in the oddest
+manner, as if he were compelled against his will to add, internally,
+“you know there really is so much too much of you!”
+
+“Well!” said Stryver, slapping the desk with his contentious hand,
+opening his eyes wider, and taking a long breath, “if I understand you,
+Mr. Lorry, I’ll be hanged!”
+
+Mr. Lorry adjusted his little wig at both ears as a means towards that
+end, and bit the feather of a pen.
+
+“D--n it all, sir!” said Stryver, staring at him, “am I not eligible?”
+
+“Oh dear yes! Yes. Oh yes, you’re eligible!” said Mr. Lorry. “If you say
+eligible, you are eligible.”
+
+“Am I not prosperous?” asked Stryver.
+
+“Oh! if you come to prosperous, you are prosperous,” said Mr. Lorry.
+
+“And advancing?”
+
+“If you come to advancing you know,” said Mr. Lorry, delighted to be
+able to make another admission, “nobody can doubt that.”
+
+“Then what on earth is your meaning, Mr. Lorry?” demanded Stryver,
+perceptibly crestfallen.
+
+“Well! I--Were you going there now?” asked Mr. Lorry.
+
+“Straight!” said Stryver, with a plump of his fist on the desk.
+
+“Then I think I wouldn’t, if I was you.”
+
+“Why?” said Stryver. “Now, I’ll put you in a corner,” forensically
+shaking a forefinger at him. “You are a man of business and bound to
+have a reason. State your reason. Why wouldn’t you go?”
+
+“Because,” said Mr. Lorry, “I wouldn’t go on such an object without
+having some cause to believe that I should succeed.”
+
+“D--n _me_!” cried Stryver, “but this beats everything.”
+
+Mr. Lorry glanced at the distant House, and glanced at the angry
+Stryver.
+
+“Here’s a man of business--a man of years--a man of experience--_in_
+a Bank,” said Stryver; “and having summed up three leading reasons for
+complete success, he says there’s no reason at all! Says it with his
+head on!” Mr. Stryver remarked upon the peculiarity as if it would have
+been infinitely less remarkable if he had said it with his head off.
+
+“When I speak of success, I speak of success with the young lady; and
+when I speak of causes and reasons to make success probable, I speak of
+causes and reasons that will tell as such with the young lady. The young
+lady, my good sir,” said Mr. Lorry, mildly tapping the Stryver arm, “the
+young lady. The young lady goes before all.”
+
+“Then you mean to tell me, Mr. Lorry,” said Stryver, squaring his
+elbows, “that it is your deliberate opinion that the young lady at
+present in question is a mincing Fool?”
+
+“Not exactly so. I mean to tell you, Mr. Stryver,” said Mr. Lorry,
+reddening, “that I will hear no disrespectful word of that young lady
+from any lips; and that if I knew any man--which I hope I do not--whose
+taste was so coarse, and whose temper was so overbearing, that he could
+not restrain himself from speaking disrespectfully of that young lady at
+this desk, not even Tellson’s should prevent my giving him a piece of my
+mind.”
+
+The necessity of being angry in a suppressed tone had put Mr. Stryver’s
+blood-vessels into a dangerous state when it was his turn to be angry;
+Mr. Lorry’s veins, methodical as their courses could usually be, were in
+no better state now it was his turn.
+
+“That is what I mean to tell you, sir,” said Mr. Lorry. “Pray let there
+be no mistake about it.”
+
+Mr. Stryver sucked the end of a ruler for a little while, and then stood
+hitting a tune out of his teeth with it, which probably gave him the
+toothache. He broke the awkward silence by saying:
+
+“This is something new to me, Mr. Lorry. You deliberately advise me not
+to go up to Soho and offer myself--_my_self, Stryver of the King’s Bench
+bar?”
+
+“Do you ask me for my advice, Mr. Stryver?”
+
+“Yes, I do.”
+
+“Very good. Then I give it, and you have repeated it correctly.”
+
+“And all I can say of it is,” laughed Stryver with a vexed laugh, “that
+this--ha, ha!--beats everything past, present, and to come.”
+
+“Now understand me,” pursued Mr. Lorry. “As a man of business, I am
+not justified in saying anything about this matter, for, as a man of
+business, I know nothing of it. But, as an old fellow, who has carried
+Miss Manette in his arms, who is the trusted friend of Miss Manette and
+of her father too, and who has a great affection for them both, I have
+spoken. The confidence is not of my seeking, recollect. Now, you think I
+may not be right?”
+
+“Not I!” said Stryver, whistling. “I can’t undertake to find third
+parties in common sense; I can only find it for myself. I suppose sense
+in certain quarters; you suppose mincing bread-and-butter nonsense. It’s
+new to me, but you are right, I dare say.”
+
+“What I suppose, Mr. Stryver, I claim to characterise for myself--And
+understand me, sir,” said Mr. Lorry, quickly flushing again, “I
+will not--not even at Tellson’s--have it characterised for me by any
+gentleman breathing.”
+
+“There! I beg your pardon!” said Stryver.
+
+“Granted. Thank you. Well, Mr. Stryver, I was about to say:--it might be
+painful to you to find yourself mistaken, it might be painful to Doctor
+Manette to have the task of being explicit with you, it might be very
+painful to Miss Manette to have the task of being explicit with you. You
+know the terms upon which I have the honour and happiness to stand with
+the family. If you please, committing you in no way, representing you
+in no way, I will undertake to correct my advice by the exercise of a
+little new observation and judgment expressly brought to bear upon
+it. If you should then be dissatisfied with it, you can but test its
+soundness for yourself; if, on the other hand, you should be satisfied
+with it, and it should be what it now is, it may spare all sides what is
+best spared. What do you say?”
+
+“How long would you keep me in town?”
+
+“Oh! It is only a question of a few hours. I could go to Soho in the
+evening, and come to your chambers afterwards.”
+
+“Then I say yes,” said Stryver: “I won’t go up there now, I am not so
+hot upon it as that comes to; I say yes, and I shall expect you to look
+in to-night. Good morning.”
+
+Then Mr. Stryver turned and burst out of the Bank, causing such a
+concussion of air on his passage through, that to stand up against it
+bowing behind the two counters, required the utmost remaining strength
+of the two ancient clerks. Those venerable and feeble persons were
+always seen by the public in the act of bowing, and were popularly
+believed, when they had bowed a customer out, still to keep on bowing in
+the empty office until they bowed another customer in.
+
+The barrister was keen enough to divine that the banker would not have
+gone so far in his expression of opinion on any less solid ground than
+moral certainty. Unprepared as he was for the large pill he had to
+swallow, he got it down. “And now,” said Mr. Stryver, shaking his
+forensic forefinger at the Temple in general, when it was down, “my way
+out of this, is, to put you all in the wrong.”
+
+It was a bit of the art of an Old Bailey tactician, in which he found
+great relief. “You shall not put me in the wrong, young lady,” said Mr.
+Stryver; “I’ll do that for you.”
+
+Accordingly, when Mr. Lorry called that night as late as ten o’clock,
+Mr. Stryver, among a quantity of books and papers littered out for the
+purpose, seemed to have nothing less on his mind than the subject of
+the morning. He even showed surprise when he saw Mr. Lorry, and was
+altogether in an absent and preoccupied state.
+
+“Well!” said that good-natured emissary, after a full half-hour of
+bootless attempts to bring him round to the question. “I have been to
+Soho.”
+
+“To Soho?” repeated Mr. Stryver, coldly. “Oh, to be sure! What am I
+thinking of!”
+
+“And I have no doubt,” said Mr. Lorry, “that I was right in the
+conversation we had. My opinion is confirmed, and I reiterate my
+advice.”
+
+“I assure you,” returned Mr. Stryver, in the friendliest way, “that I
+am sorry for it on your account, and sorry for it on the poor father’s
+account. I know this must always be a sore subject with the family; let
+us say no more about it.”
+
+“I don’t understand you,” said Mr. Lorry.
+
+“I dare say not,” rejoined Stryver, nodding his head in a smoothing and
+final way; “no matter, no matter.”
+
+“But it does matter,” Mr. Lorry urged.
+
+“No it doesn’t; I assure you it doesn’t. Having supposed that there was
+sense where there is no sense, and a laudable ambition where there is
+not a laudable ambition, I am well out of my mistake, and no harm is
+done. Young women have committed similar follies often before, and have
+repented them in poverty and obscurity often before. In an unselfish
+aspect, I am sorry that the thing is dropped, because it would have been
+a bad thing for me in a worldly point of view; in a selfish aspect, I am
+glad that the thing has dropped, because it would have been a bad thing
+for me in a worldly point of view--it is hardly necessary to say I could
+have gained nothing by it. There is no harm at all done. I have not
+proposed to the young lady, and, between ourselves, I am by no means
+certain, on reflection, that I ever should have committed myself to
+that extent. Mr. Lorry, you cannot control the mincing vanities and
+giddinesses of empty-headed girls; you must not expect to do it, or you
+will always be disappointed. Now, pray say no more about it. I tell you,
+I regret it on account of others, but I am satisfied on my own account.
+And I am really very much obliged to you for allowing me to sound you,
+and for giving me your advice; you know the young lady better than I do;
+you were right, it never would have done.”
+
+Mr. Lorry was so taken aback, that he looked quite stupidly at Mr.
+Stryver shouldering him towards the door, with an appearance of
+showering generosity, forbearance, and goodwill, on his erring head.
+“Make the best of it, my dear sir,” said Stryver; “say no more about it;
+thank you again for allowing me to sound you; good night!”
+
+Mr. Lorry was out in the night, before he knew where he was. Mr. Stryver
+was lying back on his sofa, winking at his ceiling.
+
+
+
+
+XIII. The Fellow of No Delicacy
+
+
+If Sydney Carton ever shone anywhere, he certainly never shone in the
+house of Doctor Manette. He had been there often, during a whole year,
+and had always been the same moody and morose lounger there. When he
+cared to talk, he talked well; but, the cloud of caring for nothing,
+which overshadowed him with such a fatal darkness, was very rarely
+pierced by the light within him.
+
+And yet he did care something for the streets that environed that house,
+and for the senseless stones that made their pavements. Many a night
+he vaguely and unhappily wandered there, when wine had brought no
+transitory gladness to him; many a dreary daybreak revealed his solitary
+figure lingering there, and still lingering there when the first beams
+of the sun brought into strong relief, removed beauties of architecture
+in spires of churches and lofty buildings, as perhaps the quiet time
+brought some sense of better things, else forgotten and unattainable,
+into his mind. Of late, the neglected bed in the Temple Court had known
+him more scantily than ever; and often when he had thrown himself upon
+it no longer than a few minutes, he had got up again, and haunted that
+neighbourhood.
+
+On a day in August, when Mr. Stryver (after notifying to his jackal
+that “he had thought better of that marrying matter”) had carried his
+delicacy into Devonshire, and when the sight and scent of flowers in the
+City streets had some waifs of goodness in them for the worst, of health
+for the sickliest, and of youth for the oldest, Sydney’s feet still trod
+those stones. From being irresolute and purposeless, his feet became
+animated by an intention, and, in the working out of that intention,
+they took him to the Doctor’s door.
+
+He was shown up-stairs, and found Lucie at her work, alone. She had
+never been quite at her ease with him, and received him with some little
+embarrassment as he seated himself near her table. But, looking up at
+his face in the interchange of the first few common-places, she observed
+a change in it.
+
+“I fear you are not well, Mr. Carton!”
+
+“No. But the life I lead, Miss Manette, is not conducive to health. What
+is to be expected of, or by, such profligates?”
+
+“Is it not--forgive me; I have begun the question on my lips--a pity to
+live no better life?”
+
+“God knows it is a shame!”
+
+“Then why not change it?”
+
+Looking gently at him again, she was surprised and saddened to see that
+there were tears in his eyes. There were tears in his voice too, as he
+answered:
+
+“It is too late for that. I shall never be better than I am. I shall
+sink lower, and be worse.”
+
+He leaned an elbow on her table, and covered his eyes with his hand. The
+table trembled in the silence that followed.
+
+She had never seen him softened, and was much distressed. He knew her to
+be so, without looking at her, and said:
+
+“Pray forgive me, Miss Manette. I break down before the knowledge of
+what I want to say to you. Will you hear me?”
+
+“If it will do you any good, Mr. Carton, if it would make you happier,
+it would make me very glad!”
+
+“God bless you for your sweet compassion!”
+
+He unshaded his face after a little while, and spoke steadily.
+
+“Don’t be afraid to hear me. Don’t shrink from anything I say. I am like
+one who died young. All my life might have been.”
+
+“No, Mr. Carton. I am sure that the best part of it might still be; I am
+sure that you might be much, much worthier of yourself.”
+
+“Say of you, Miss Manette, and although I know better--although in the
+mystery of my own wretched heart I know better--I shall never forget
+it!”
+
+She was pale and trembling. He came to her relief with a fixed despair
+of himself which made the interview unlike any other that could have
+been holden.
+
+“If it had been possible, Miss Manette, that you could have returned the
+love of the man you see before yourself--flung away, wasted, drunken,
+poor creature of misuse as you know him to be--he would have been
+conscious this day and hour, in spite of his happiness, that he would
+bring you to misery, bring you to sorrow and repentance, blight you,
+disgrace you, pull you down with him. I know very well that you can have
+no tenderness for me; I ask for none; I am even thankful that it cannot
+be.”
+
+“Without it, can I not save you, Mr. Carton? Can I not recall
+you--forgive me again!--to a better course? Can I in no way repay your
+confidence? I know this is a confidence,” she modestly said, after a
+little hesitation, and in earnest tears, “I know you would say this to
+no one else. Can I turn it to no good account for yourself, Mr. Carton?”
+
+He shook his head.
+
+“To none. No, Miss Manette, to none. If you will hear me through a very
+little more, all you can ever do for me is done. I wish you to know that
+you have been the last dream of my soul. In my degradation I have not
+been so degraded but that the sight of you with your father, and of this
+home made such a home by you, has stirred old shadows that I thought had
+died out of me. Since I knew you, I have been troubled by a remorse that
+I thought would never reproach me again, and have heard whispers from
+old voices impelling me upward, that I thought were silent for ever. I
+have had unformed ideas of striving afresh, beginning anew, shaking off
+sloth and sensuality, and fighting out the abandoned fight. A dream, all
+a dream, that ends in nothing, and leaves the sleeper where he lay down,
+but I wish you to know that you inspired it.”
+
+“Will nothing of it remain? O Mr. Carton, think again! Try again!”
+
+“No, Miss Manette; all through it, I have known myself to be quite
+undeserving. And yet I have had the weakness, and have still the
+weakness, to wish you to know with what a sudden mastery you kindled me,
+heap of ashes that I am, into fire--a fire, however, inseparable in
+its nature from myself, quickening nothing, lighting nothing, doing no
+service, idly burning away.”
+
+“Since it is my misfortune, Mr. Carton, to have made you more unhappy
+than you were before you knew me--”
+
+“Don’t say that, Miss Manette, for you would have reclaimed me, if
+anything could. You will not be the cause of my becoming worse.”
+
+“Since the state of your mind that you describe, is, at all events,
+attributable to some influence of mine--this is what I mean, if I can
+make it plain--can I use no influence to serve you? Have I no power for
+good, with you, at all?”
+
+“The utmost good that I am capable of now, Miss Manette, I have come
+here to realise. Let me carry through the rest of my misdirected life,
+the remembrance that I opened my heart to you, last of all the world;
+and that there was something left in me at this time which you could
+deplore and pity.”
+
+“Which I entreated you to believe, again and again, most fervently, with
+all my heart, was capable of better things, Mr. Carton!”
+
+“Entreat me to believe it no more, Miss Manette. I have proved myself,
+and I know better. I distress you; I draw fast to an end. Will you let
+me believe, when I recall this day, that the last confidence of my life
+was reposed in your pure and innocent breast, and that it lies there
+alone, and will be shared by no one?”
+
+“If that will be a consolation to you, yes.”
+
+“Not even by the dearest one ever to be known to you?”
+
+“Mr. Carton,” she answered, after an agitated pause, “the secret is
+yours, not mine; and I promise to respect it.”
+
+“Thank you. And again, God bless you.”
+
+He put her hand to his lips, and moved towards the door.
+
+“Be under no apprehension, Miss Manette, of my ever resuming this
+conversation by so much as a passing word. I will never refer to it
+again. If I were dead, that could not be surer than it is henceforth. In
+the hour of my death, I shall hold sacred the one good remembrance--and
+shall thank and bless you for it--that my last avowal of myself was made
+to you, and that my name, and faults, and miseries were gently carried
+in your heart. May it otherwise be light and happy!”
+
+He was so unlike what he had ever shown himself to be, and it was so
+sad to think how much he had thrown away, and how much he every day kept
+down and perverted, that Lucie Manette wept mournfully for him as he
+stood looking back at her.
+
+“Be comforted!” he said, “I am not worth such feeling, Miss Manette. An
+hour or two hence, and the low companions and low habits that I scorn
+but yield to, will render me less worth such tears as those, than any
+wretch who creeps along the streets. Be comforted! But, within myself, I
+shall always be, towards you, what I am now, though outwardly I shall be
+what you have heretofore seen me. The last supplication but one I make
+to you, is, that you will believe this of me.”
+
+“I will, Mr. Carton.”
+
+“My last supplication of all, is this; and with it, I will relieve
+you of a visitor with whom I well know you have nothing in unison, and
+between whom and you there is an impassable space. It is useless to say
+it, I know, but it rises out of my soul. For you, and for any dear to
+you, I would do anything. If my career were of that better kind that
+there was any opportunity or capacity of sacrifice in it, I would
+embrace any sacrifice for you and for those dear to you. Try to hold
+me in your mind, at some quiet times, as ardent and sincere in this one
+thing. The time will come, the time will not be long in coming, when new
+ties will be formed about you--ties that will bind you yet more tenderly
+and strongly to the home you so adorn--the dearest ties that will ever
+grace and gladden you. O Miss Manette, when the little picture of a
+happy father’s face looks up in yours, when you see your own bright
+beauty springing up anew at your feet, think now and then that there is
+a man who would give his life, to keep a life you love beside you!”
+
+He said, “Farewell!” said a last “God bless you!” and left her.
+
+
+
+
+XIV. The Honest Tradesman
+
+
+To the eyes of Mr. Jeremiah Cruncher, sitting on his stool in
+Fleet-street with his grisly urchin beside him, a vast number and
+variety of objects in movement were every day presented. Who could sit
+upon anything in Fleet-street during the busy hours of the day, and
+not be dazed and deafened by two immense processions, one ever tending
+westward with the sun, the other ever tending eastward from the sun,
+both ever tending to the plains beyond the range of red and purple where
+the sun goes down!
+
+With his straw in his mouth, Mr. Cruncher sat watching the two streams,
+like the heathen rustic who has for several centuries been on duty
+watching one stream--saving that Jerry had no expectation of their ever
+running dry. Nor would it have been an expectation of a hopeful kind,
+since a small part of his income was derived from the pilotage of timid
+women (mostly of a full habit and past the middle term of life) from
+Tellson’s side of the tides to the opposite shore. Brief as such
+companionship was in every separate instance, Mr. Cruncher never failed
+to become so interested in the lady as to express a strong desire to
+have the honour of drinking her very good health. And it was from
+the gifts bestowed upon him towards the execution of this benevolent
+purpose, that he recruited his finances, as just now observed.
+
+Time was, when a poet sat upon a stool in a public place, and mused in
+the sight of men. Mr. Cruncher, sitting on a stool in a public place,
+but not being a poet, mused as little as possible, and looked about him.
+
+It fell out that he was thus engaged in a season when crowds were
+few, and belated women few, and when his affairs in general were so
+unprosperous as to awaken a strong suspicion in his breast that Mrs.
+Cruncher must have been “flopping” in some pointed manner, when an
+unusual concourse pouring down Fleet-street westward, attracted his
+attention. Looking that way, Mr. Cruncher made out that some kind of
+funeral was coming along, and that there was popular objection to this
+funeral, which engendered uproar.
+
+“Young Jerry,” said Mr. Cruncher, turning to his offspring, “it’s a
+buryin’.”
+
+“Hooroar, father!” cried Young Jerry.
+
+The young gentleman uttered this exultant sound with mysterious
+significance. The elder gentleman took the cry so ill, that he watched
+his opportunity, and smote the young gentleman on the ear.
+
+“What d’ye mean? What are you hooroaring at? What do you want to conwey
+to your own father, you young Rip? This boy is a getting too many for
+_me_!” said Mr. Cruncher, surveying him. “Him and his hooroars! Don’t
+let me hear no more of you, or you shall feel some more of me. D’ye
+hear?”
+
+“I warn’t doing no harm,” Young Jerry protested, rubbing his cheek.
+
+“Drop it then,” said Mr. Cruncher; “I won’t have none of _your_ no
+harms. Get a top of that there seat, and look at the crowd.”
+
+His son obeyed, and the crowd approached; they were bawling and hissing
+round a dingy hearse and dingy mourning coach, in which mourning coach
+there was only one mourner, dressed in the dingy trappings that were
+considered essential to the dignity of the position. The position
+appeared by no means to please him, however, with an increasing rabble
+surrounding the coach, deriding him, making grimaces at him, and
+incessantly groaning and calling out: “Yah! Spies! Tst! Yaha! Spies!”
+ with many compliments too numerous and forcible to repeat.
+
+Funerals had at all times a remarkable attraction for Mr. Cruncher; he
+always pricked up his senses, and became excited, when a funeral passed
+Tellson’s. Naturally, therefore, a funeral with this uncommon attendance
+excited him greatly, and he asked of the first man who ran against him:
+
+“What is it, brother? What’s it about?”
+
+“_I_ don’t know,” said the man. “Spies! Yaha! Tst! Spies!”
+
+He asked another man. “Who is it?”
+
+“_I_ don’t know,” returned the man, clapping his hands to his mouth
+nevertheless, and vociferating in a surprising heat and with the
+greatest ardour, “Spies! Yaha! Tst, tst! Spi--ies!”
+
+At length, a person better informed on the merits of the case, tumbled
+against him, and from this person he learned that the funeral was the
+funeral of one Roger Cly.
+
+“Was He a spy?” asked Mr. Cruncher.
+
+“Old Bailey spy,” returned his informant. “Yaha! Tst! Yah! Old Bailey
+Spi--i--ies!”
+
+“Why, to be sure!” exclaimed Jerry, recalling the Trial at which he had
+assisted. “I’ve seen him. Dead, is he?”
+
+“Dead as mutton,” returned the other, “and can’t be too dead. Have ‘em
+out, there! Spies! Pull ‘em out, there! Spies!”
+
+The idea was so acceptable in the prevalent absence of any idea,
+that the crowd caught it up with eagerness, and loudly repeating the
+suggestion to have ‘em out, and to pull ‘em out, mobbed the two vehicles
+so closely that they came to a stop. On the crowd’s opening the coach
+doors, the one mourner scuffled out of himself and was in their hands
+for a moment; but he was so alert, and made such good use of his time,
+that in another moment he was scouring away up a bye-street, after
+shedding his cloak, hat, long hatband, white pocket-handkerchief, and
+other symbolical tears.
+
+These, the people tore to pieces and scattered far and wide with great
+enjoyment, while the tradesmen hurriedly shut up their shops; for a
+crowd in those times stopped at nothing, and was a monster much dreaded.
+They had already got the length of opening the hearse to take the coffin
+out, when some brighter genius proposed instead, its being escorted to
+its destination amidst general rejoicing. Practical suggestions being
+much needed, this suggestion, too, was received with acclamation, and
+the coach was immediately filled with eight inside and a dozen out,
+while as many people got on the roof of the hearse as could by any
+exercise of ingenuity stick upon it. Among the first of these volunteers
+was Jerry Cruncher himself, who modestly concealed his spiky head from
+the observation of Tellson’s, in the further corner of the mourning
+coach.
+
+The officiating undertakers made some protest against these changes in
+the ceremonies; but, the river being alarmingly near, and several voices
+remarking on the efficacy of cold immersion in bringing refractory
+members of the profession to reason, the protest was faint and brief.
+The remodelled procession started, with a chimney-sweep driving the
+hearse--advised by the regular driver, who was perched beside him, under
+close inspection, for the purpose--and with a pieman, also attended
+by his cabinet minister, driving the mourning coach. A bear-leader, a
+popular street character of the time, was impressed as an additional
+ornament, before the cavalcade had gone far down the Strand; and his
+bear, who was black and very mangy, gave quite an Undertaking air to
+that part of the procession in which he walked.
+
+Thus, with beer-drinking, pipe-smoking, song-roaring, and infinite
+caricaturing of woe, the disorderly procession went its way, recruiting
+at every step, and all the shops shutting up before it. Its destination
+was the old church of Saint Pancras, far off in the fields. It got there
+in course of time; insisted on pouring into the burial-ground; finally,
+accomplished the interment of the deceased Roger Cly in its own way, and
+highly to its own satisfaction.
+
+The dead man disposed of, and the crowd being under the necessity of
+providing some other entertainment for itself, another brighter
+genius (or perhaps the same) conceived the humour of impeaching casual
+passers-by, as Old Bailey spies, and wreaking vengeance on them. Chase
+was given to some scores of inoffensive persons who had never been near
+the Old Bailey in their lives, in the realisation of this fancy, and
+they were roughly hustled and maltreated. The transition to the sport of
+window-breaking, and thence to the plundering of public-houses, was easy
+and natural. At last, after several hours, when sundry summer-houses had
+been pulled down, and some area-railings had been torn up, to arm
+the more belligerent spirits, a rumour got about that the Guards were
+coming. Before this rumour, the crowd gradually melted away, and perhaps
+the Guards came, and perhaps they never came, and this was the usual
+progress of a mob.
+
+Mr. Cruncher did not assist at the closing sports, but had remained
+behind in the churchyard, to confer and condole with the undertakers.
+The place had a soothing influence on him. He procured a pipe from a
+neighbouring public-house, and smoked it, looking in at the railings and
+maturely considering the spot.
+
+“Jerry,” said Mr. Cruncher, apostrophising himself in his usual way,
+“you see that there Cly that day, and you see with your own eyes that he
+was a young ‘un and a straight made ‘un.”
+
+Having smoked his pipe out, and ruminated a little longer, he turned
+himself about, that he might appear, before the hour of closing, on his
+station at Tellson’s. Whether his meditations on mortality had touched
+his liver, or whether his general health had been previously at all
+amiss, or whether he desired to show a little attention to an eminent
+man, is not so much to the purpose, as that he made a short call upon
+his medical adviser--a distinguished surgeon--on his way back.
+
+Young Jerry relieved his father with dutiful interest, and reported No
+job in his absence. The bank closed, the ancient clerks came out, the
+usual watch was set, and Mr. Cruncher and his son went home to tea.
+
+“Now, I tell you where it is!” said Mr. Cruncher to his wife, on
+entering. “If, as a honest tradesman, my wenturs goes wrong to-night, I
+shall make sure that you’ve been praying again me, and I shall work you
+for it just the same as if I seen you do it.”
+
+The dejected Mrs. Cruncher shook her head.
+
+“Why, you’re at it afore my face!” said Mr. Cruncher, with signs of
+angry apprehension.
+
+“I am saying nothing.”
+
+“Well, then; don’t meditate nothing. You might as well flop as meditate.
+You may as well go again me one way as another. Drop it altogether.”
+
+“Yes, Jerry.”
+
+“Yes, Jerry,” repeated Mr. Cruncher sitting down to tea. “Ah! It _is_
+yes, Jerry. That’s about it. You may say yes, Jerry.”
+
+Mr. Cruncher had no particular meaning in these sulky corroborations,
+but made use of them, as people not unfrequently do, to express general
+ironical dissatisfaction.
+
+“You and your yes, Jerry,” said Mr. Cruncher, taking a bite out of his
+bread-and-butter, and seeming to help it down with a large invisible
+oyster out of his saucer. “Ah! I think so. I believe you.”
+
+“You are going out to-night?” asked his decent wife, when he took
+another bite.
+
+“Yes, I am.”
+
+“May I go with you, father?” asked his son, briskly.
+
+“No, you mayn’t. I’m a going--as your mother knows--a fishing. That’s
+where I’m going to. Going a fishing.”
+
+“Your fishing-rod gets rayther rusty; don’t it, father?”
+
+“Never you mind.”
+
+“Shall you bring any fish home, father?”
+
+“If I don’t, you’ll have short commons, to-morrow,” returned that
+gentleman, shaking his head; “that’s questions enough for you; I ain’t a
+going out, till you’ve been long abed.”
+
+He devoted himself during the remainder of the evening to keeping a
+most vigilant watch on Mrs. Cruncher, and sullenly holding her in
+conversation that she might be prevented from meditating any petitions
+to his disadvantage. With this view, he urged his son to hold her in
+conversation also, and led the unfortunate woman a hard life by dwelling
+on any causes of complaint he could bring against her, rather than
+he would leave her for a moment to her own reflections. The devoutest
+person could have rendered no greater homage to the efficacy of an
+honest prayer than he did in this distrust of his wife. It was as if a
+professed unbeliever in ghosts should be frightened by a ghost story.
+
+“And mind you!” said Mr. Cruncher. “No games to-morrow! If I, as a
+honest tradesman, succeed in providing a jinte of meat or two, none
+of your not touching of it, and sticking to bread. If I, as a honest
+tradesman, am able to provide a little beer, none of your declaring
+on water. When you go to Rome, do as Rome does. Rome will be a ugly
+customer to you, if you don’t. _I_‘m your Rome, you know.”
+
+Then he began grumbling again:
+
+“With your flying into the face of your own wittles and drink! I don’t
+know how scarce you mayn’t make the wittles and drink here, by your
+flopping tricks and your unfeeling conduct. Look at your boy: he _is_
+your’n, ain’t he? He’s as thin as a lath. Do you call yourself a mother,
+and not know that a mother’s first duty is to blow her boy out?”
+
+This touched Young Jerry on a tender place; who adjured his mother to
+perform her first duty, and, whatever else she did or neglected, above
+all things to lay especial stress on the discharge of that maternal
+function so affectingly and delicately indicated by his other parent.
+
+Thus the evening wore away with the Cruncher family, until Young Jerry
+was ordered to bed, and his mother, laid under similar injunctions,
+obeyed them. Mr. Cruncher beguiled the earlier watches of the night with
+solitary pipes, and did not start upon his excursion until nearly one
+o’clock. Towards that small and ghostly hour, he rose up from his chair,
+took a key out of his pocket, opened a locked cupboard, and brought
+forth a sack, a crowbar of convenient size, a rope and chain, and other
+fishing tackle of that nature. Disposing these articles about him
+in skilful manner, he bestowed a parting defiance on Mrs. Cruncher,
+extinguished the light, and went out.
+
+Young Jerry, who had only made a feint of undressing when he went to
+bed, was not long after his father. Under cover of the darkness he
+followed out of the room, followed down the stairs, followed down the
+court, followed out into the streets. He was in no uneasiness concerning
+his getting into the house again, for it was full of lodgers, and the
+door stood ajar all night.
+
+Impelled by a laudable ambition to study the art and mystery of his
+father’s honest calling, Young Jerry, keeping as close to house fronts,
+walls, and doorways, as his eyes were close to one another, held his
+honoured parent in view. The honoured parent steering Northward, had not
+gone far, when he was joined by another disciple of Izaak Walton, and
+the two trudged on together.
+
+Within half an hour from the first starting, they were beyond the
+winking lamps, and the more than winking watchmen, and were out upon a
+lonely road. Another fisherman was picked up here--and that so silently,
+that if Young Jerry had been superstitious, he might have supposed the
+second follower of the gentle craft to have, all of a sudden, split
+himself into two.
+
+The three went on, and Young Jerry went on, until the three stopped
+under a bank overhanging the road. Upon the top of the bank was a low
+brick wall, surmounted by an iron railing. In the shadow of bank and
+wall the three turned out of the road, and up a blind lane, of which
+the wall--there, risen to some eight or ten feet high--formed one side.
+Crouching down in a corner, peeping up the lane, the next object that
+Young Jerry saw, was the form of his honoured parent, pretty well
+defined against a watery and clouded moon, nimbly scaling an iron gate.
+He was soon over, and then the second fisherman got over, and then the
+third. They all dropped softly on the ground within the gate, and lay
+there a little--listening perhaps. Then, they moved away on their hands
+and knees.
+
+It was now Young Jerry’s turn to approach the gate: which he did,
+holding his breath. Crouching down again in a corner there, and looking
+in, he made out the three fishermen creeping through some rank grass!
+and all the gravestones in the churchyard--it was a large churchyard
+that they were in--looking on like ghosts in white, while the church
+tower itself looked on like the ghost of a monstrous giant. They did not
+creep far, before they stopped and stood upright. And then they began to
+fish.
+
+They fished with a spade, at first. Presently the honoured parent
+appeared to be adjusting some instrument like a great corkscrew.
+Whatever tools they worked with, they worked hard, until the awful
+striking of the church clock so terrified Young Jerry, that he made off,
+with his hair as stiff as his father’s.
+
+But, his long-cherished desire to know more about these matters, not
+only stopped him in his running away, but lured him back again. They
+were still fishing perseveringly, when he peeped in at the gate for
+the second time; but, now they seemed to have got a bite. There was a
+screwing and complaining sound down below, and their bent figures were
+strained, as if by a weight. By slow degrees the weight broke away the
+earth upon it, and came to the surface. Young Jerry very well knew what
+it would be; but, when he saw it, and saw his honoured parent about to
+wrench it open, he was so frightened, being new to the sight, that he
+made off again, and never stopped until he had run a mile or more.
+
+He would not have stopped then, for anything less necessary than breath,
+it being a spectral sort of race that he ran, and one highly desirable
+to get to the end of. He had a strong idea that the coffin he had seen
+was running after him; and, pictured as hopping on behind him, bolt
+upright, upon its narrow end, always on the point of overtaking him
+and hopping on at his side--perhaps taking his arm--it was a pursuer to
+shun. It was an inconsistent and ubiquitous fiend too, for, while it
+was making the whole night behind him dreadful, he darted out into the
+roadway to avoid dark alleys, fearful of its coming hopping out of them
+like a dropsical boy’s Kite without tail and wings. It hid in doorways
+too, rubbing its horrible shoulders against doors, and drawing them up
+to its ears, as if it were laughing. It got into shadows on the road,
+and lay cunningly on its back to trip him up. All this time it was
+incessantly hopping on behind and gaining on him, so that when the boy
+got to his own door he had reason for being half dead. And even then
+it would not leave him, but followed him upstairs with a bump on every
+stair, scrambled into bed with him, and bumped down, dead and heavy, on
+his breast when he fell asleep.
+
+From his oppressed slumber, Young Jerry in his closet was awakened after
+daybreak and before sunrise, by the presence of his father in the
+family room. Something had gone wrong with him; at least, so Young Jerry
+inferred, from the circumstance of his holding Mrs. Cruncher by the
+ears, and knocking the back of her head against the head-board of the
+bed.
+
+“I told you I would,” said Mr. Cruncher, “and I did.”
+
+“Jerry, Jerry, Jerry!” his wife implored.
+
+“You oppose yourself to the profit of the business,” said Jerry, “and me
+and my partners suffer. You was to honour and obey; why the devil don’t
+you?”
+
+“I try to be a good wife, Jerry,” the poor woman protested, with tears.
+
+“Is it being a good wife to oppose your husband’s business? Is it
+honouring your husband to dishonour his business? Is it obeying your
+husband to disobey him on the wital subject of his business?”
+
+“You hadn’t taken to the dreadful business then, Jerry.”
+
+“It’s enough for you,” retorted Mr. Cruncher, “to be the wife of a
+honest tradesman, and not to occupy your female mind with calculations
+when he took to his trade or when he didn’t. A honouring and obeying
+wife would let his trade alone altogether. Call yourself a religious
+woman? If you’re a religious woman, give me a irreligious one! You have
+no more nat’ral sense of duty than the bed of this here Thames river has
+of a pile, and similarly it must be knocked into you.”
+
+The altercation was conducted in a low tone of voice, and terminated in
+the honest tradesman’s kicking off his clay-soiled boots, and lying down
+at his length on the floor. After taking a timid peep at him lying on
+his back, with his rusty hands under his head for a pillow, his son lay
+down too, and fell asleep again.
+
+There was no fish for breakfast, and not much of anything else. Mr.
+Cruncher was out of spirits, and out of temper, and kept an iron pot-lid
+by him as a projectile for the correction of Mrs. Cruncher, in case
+he should observe any symptoms of her saying Grace. He was brushed
+and washed at the usual hour, and set off with his son to pursue his
+ostensible calling.
+
+Young Jerry, walking with the stool under his arm at his father’s side
+along sunny and crowded Fleet-street, was a very different Young Jerry
+from him of the previous night, running home through darkness and
+solitude from his grim pursuer. His cunning was fresh with the day,
+and his qualms were gone with the night--in which particulars it is not
+improbable that he had compeers in Fleet-street and the City of London,
+that fine morning.
+
+“Father,” said Young Jerry, as they walked along: taking care to keep
+at arm’s length and to have the stool well between them: “what’s a
+Resurrection-Man?”
+
+Mr. Cruncher came to a stop on the pavement before he answered, “How
+should I know?”
+
+“I thought you knowed everything, father,” said the artless boy.
+
+“Hem! Well,” returned Mr. Cruncher, going on again, and lifting off his
+hat to give his spikes free play, “he’s a tradesman.”
+
+“What’s his goods, father?” asked the brisk Young Jerry.
+
+“His goods,” said Mr. Cruncher, after turning it over in his mind, “is a
+branch of Scientific goods.”
+
+“Persons’ bodies, ain’t it, father?” asked the lively boy.
+
+“I believe it is something of that sort,” said Mr. Cruncher.
+
+“Oh, father, I should so like to be a Resurrection-Man when I’m quite
+growed up!”
+
+Mr. Cruncher was soothed, but shook his head in a dubious and moral way.
+“It depends upon how you dewelop your talents. Be careful to dewelop
+your talents, and never to say no more than you can help to nobody, and
+there’s no telling at the present time what you may not come to be fit
+for.” As Young Jerry, thus encouraged, went on a few yards in advance,
+to plant the stool in the shadow of the Bar, Mr. Cruncher added to
+himself: “Jerry, you honest tradesman, there’s hopes wot that boy will
+yet be a blessing to you, and a recompense to you for his mother!”
+
+
+
+
+XV. Knitting
+
+
+There had been earlier drinking than usual in the wine-shop of Monsieur
+Defarge. As early as six o’clock in the morning, sallow faces peeping
+through its barred windows had descried other faces within, bending over
+measures of wine. Monsieur Defarge sold a very thin wine at the best
+of times, but it would seem to have been an unusually thin wine that
+he sold at this time. A sour wine, moreover, or a souring, for its
+influence on the mood of those who drank it was to make them gloomy. No
+vivacious Bacchanalian flame leaped out of the pressed grape of Monsieur
+Defarge: but, a smouldering fire that burnt in the dark, lay hidden in
+the dregs of it.
+
+This had been the third morning in succession, on which there had been
+early drinking at the wine-shop of Monsieur Defarge. It had begun
+on Monday, and here was Wednesday come. There had been more of early
+brooding than drinking; for, many men had listened and whispered and
+slunk about there from the time of the opening of the door, who could
+not have laid a piece of money on the counter to save their souls. These
+were to the full as interested in the place, however, as if they could
+have commanded whole barrels of wine; and they glided from seat to seat,
+and from corner to corner, swallowing talk in lieu of drink, with greedy
+looks.
+
+Notwithstanding an unusual flow of company, the master of the wine-shop
+was not visible. He was not missed; for, nobody who crossed the
+threshold looked for him, nobody asked for him, nobody wondered to see
+only Madame Defarge in her seat, presiding over the distribution of
+wine, with a bowl of battered small coins before her, as much defaced
+and beaten out of their original impress as the small coinage of
+humanity from whose ragged pockets they had come.
+
+A suspended interest and a prevalent absence of mind, were perhaps
+observed by the spies who looked in at the wine-shop, as they looked in
+at every place, high and low, from the king’s palace to the criminal’s
+gaol. Games at cards languished, players at dominoes musingly built
+towers with them, drinkers drew figures on the tables with spilt drops
+of wine, Madame Defarge herself picked out the pattern on her sleeve
+with her toothpick, and saw and heard something inaudible and invisible
+a long way off.
+
+Thus, Saint Antoine in this vinous feature of his, until midday. It was
+high noontide, when two dusty men passed through his streets and under
+his swinging lamps: of whom, one was Monsieur Defarge: the other a
+mender of roads in a blue cap. All adust and athirst, the two entered
+the wine-shop. Their arrival had lighted a kind of fire in the breast
+of Saint Antoine, fast spreading as they came along, which stirred and
+flickered in flames of faces at most doors and windows. Yet, no one had
+followed them, and no man spoke when they entered the wine-shop, though
+the eyes of every man there were turned upon them.
+
+“Good day, gentlemen!” said Monsieur Defarge.
+
+It may have been a signal for loosening the general tongue. It elicited
+an answering chorus of “Good day!”
+
+“It is bad weather, gentlemen,” said Defarge, shaking his head.
+
+Upon which, every man looked at his neighbour, and then all cast down
+their eyes and sat silent. Except one man, who got up and went out.
+
+“My wife,” said Defarge aloud, addressing Madame Defarge: “I have
+travelled certain leagues with this good mender of roads, called
+Jacques. I met him--by accident--a day and half’s journey out of Paris.
+He is a good child, this mender of roads, called Jacques. Give him to
+drink, my wife!”
+
+A second man got up and went out. Madame Defarge set wine before the
+mender of roads called Jacques, who doffed his blue cap to the company,
+and drank. In the breast of his blouse he carried some coarse dark
+bread; he ate of this between whiles, and sat munching and drinking near
+Madame Defarge’s counter. A third man got up and went out.
+
+Defarge refreshed himself with a draught of wine--but, he took less
+than was given to the stranger, as being himself a man to whom it was no
+rarity--and stood waiting until the countryman had made his breakfast.
+He looked at no one present, and no one now looked at him; not even
+Madame Defarge, who had taken up her knitting, and was at work.
+
+“Have you finished your repast, friend?” he asked, in due season.
+
+“Yes, thank you.”
+
+“Come, then! You shall see the apartment that I told you you could
+occupy. It will suit you to a marvel.”
+
+Out of the wine-shop into the street, out of the street into a
+courtyard, out of the courtyard up a steep staircase, out of the
+staircase into a garret--formerly the garret where a white-haired man
+sat on a low bench, stooping forward and very busy, making shoes.
+
+No white-haired man was there now; but, the three men were there who had
+gone out of the wine-shop singly. And between them and the white-haired
+man afar off, was the one small link, that they had once looked in at
+him through the chinks in the wall.
+
+Defarge closed the door carefully, and spoke in a subdued voice:
+
+“Jacques One, Jacques Two, Jacques Three! This is the witness
+encountered by appointment, by me, Jacques Four. He will tell you all.
+Speak, Jacques Five!”
+
+The mender of roads, blue cap in hand, wiped his swarthy forehead with
+it, and said, “Where shall I commence, monsieur?”
+
+“Commence,” was Monsieur Defarge’s not unreasonable reply, “at the
+commencement.”
+
+“I saw him then, messieurs,” began the mender of roads, “a year ago this
+running summer, underneath the carriage of the Marquis, hanging by the
+chain. Behold the manner of it. I leaving my work on the road, the sun
+going to bed, the carriage of the Marquis slowly ascending the hill, he
+hanging by the chain--like this.”
+
+Again the mender of roads went through the whole performance; in which
+he ought to have been perfect by that time, seeing that it had been
+the infallible resource and indispensable entertainment of his village
+during a whole year.
+
+Jacques One struck in, and asked if he had ever seen the man before?
+
+“Never,” answered the mender of roads, recovering his perpendicular.
+
+Jacques Three demanded how he afterwards recognised him then?
+
+“By his tall figure,” said the mender of roads, softly, and with his
+finger at his nose. “When Monsieur the Marquis demands that evening,
+‘Say, what is he like?’ I make response, ‘Tall as a spectre.’”
+
+“You should have said, short as a dwarf,” returned Jacques Two.
+
+“But what did I know? The deed was not then accomplished, neither did he
+confide in me. Observe! Under those circumstances even, I do not
+offer my testimony. Monsieur the Marquis indicates me with his finger,
+standing near our little fountain, and says, ‘To me! Bring that rascal!’
+My faith, messieurs, I offer nothing.”
+
+“He is right there, Jacques,” murmured Defarge, to him who had
+interrupted. “Go on!”
+
+“Good!” said the mender of roads, with an air of mystery. “The tall man
+is lost, and he is sought--how many months? Nine, ten, eleven?”
+
+“No matter, the number,” said Defarge. “He is well hidden, but at last
+he is unluckily found. Go on!”
+
+“I am again at work upon the hill-side, and the sun is again about to
+go to bed. I am collecting my tools to descend to my cottage down in the
+village below, where it is already dark, when I raise my eyes, and see
+coming over the hill six soldiers. In the midst of them is a tall man
+with his arms bound--tied to his sides--like this!”
+
+With the aid of his indispensable cap, he represented a man with his
+elbows bound fast at his hips, with cords that were knotted behind him.
+
+“I stand aside, messieurs, by my heap of stones, to see the soldiers
+and their prisoner pass (for it is a solitary road, that, where any
+spectacle is well worth looking at), and at first, as they approach, I
+see no more than that they are six soldiers with a tall man bound, and
+that they are almost black to my sight--except on the side of the sun
+going to bed, where they have a red edge, messieurs. Also, I see that
+their long shadows are on the hollow ridge on the opposite side of the
+road, and are on the hill above it, and are like the shadows of giants.
+Also, I see that they are covered with dust, and that the dust moves
+with them as they come, tramp, tramp! But when they advance quite near
+to me, I recognise the tall man, and he recognises me. Ah, but he would
+be well content to precipitate himself over the hill-side once again, as
+on the evening when he and I first encountered, close to the same spot!”
+
+He described it as if he were there, and it was evident that he saw it
+vividly; perhaps he had not seen much in his life.
+
+“I do not show the soldiers that I recognise the tall man; he does not
+show the soldiers that he recognises me; we do it, and we know it, with
+our eyes. ‘Come on!’ says the chief of that company, pointing to the
+village, ‘bring him fast to his tomb!’ and they bring him faster. I
+follow. His arms are swelled because of being bound so tight, his wooden
+shoes are large and clumsy, and he is lame. Because he is lame, and
+consequently slow, they drive him with their guns--like this!”
+
+He imitated the action of a man’s being impelled forward by the
+butt-ends of muskets.
+
+“As they descend the hill like madmen running a race, he falls. They
+laugh and pick him up again. His face is bleeding and covered with dust,
+but he cannot touch it; thereupon they laugh again. They bring him into
+the village; all the village runs to look; they take him past the mill,
+and up to the prison; all the village sees the prison gate open in the
+darkness of the night, and swallow him--like this!”
+
+He opened his mouth as wide as he could, and shut it with a sounding
+snap of his teeth. Observant of his unwillingness to mar the effect by
+opening it again, Defarge said, “Go on, Jacques.”
+
+“All the village,” pursued the mender of roads, on tiptoe and in a low
+voice, “withdraws; all the village whispers by the fountain; all the
+village sleeps; all the village dreams of that unhappy one, within the
+locks and bars of the prison on the crag, and never to come out of it,
+except to perish. In the morning, with my tools upon my shoulder, eating
+my morsel of black bread as I go, I make a circuit by the prison, on
+my way to my work. There I see him, high up, behind the bars of a lofty
+iron cage, bloody and dusty as last night, looking through. He has no
+hand free, to wave to me; I dare not call to him; he regards me like a
+dead man.”
+
+Defarge and the three glanced darkly at one another. The looks of all
+of them were dark, repressed, and revengeful, as they listened to the
+countryman’s story; the manner of all of them, while it was secret, was
+authoritative too. They had the air of a rough tribunal; Jacques One
+and Two sitting on the old pallet-bed, each with his chin resting on
+his hand, and his eyes intent on the road-mender; Jacques Three, equally
+intent, on one knee behind them, with his agitated hand always gliding
+over the network of fine nerves about his mouth and nose; Defarge
+standing between them and the narrator, whom he had stationed in the
+light of the window, by turns looking from him to them, and from them to
+him.
+
+“Go on, Jacques,” said Defarge.
+
+“He remains up there in his iron cage some days. The village looks
+at him by stealth, for it is afraid. But it always looks up, from a
+distance, at the prison on the crag; and in the evening, when the work
+of the day is achieved and it assembles to gossip at the fountain, all
+faces are turned towards the prison. Formerly, they were turned towards
+the posting-house; now, they are turned towards the prison. They
+whisper at the fountain, that although condemned to death he will not be
+executed; they say that petitions have been presented in Paris, showing
+that he was enraged and made mad by the death of his child; they say
+that a petition has been presented to the King himself. What do I know?
+It is possible. Perhaps yes, perhaps no.”
+
+“Listen then, Jacques,” Number One of that name sternly interposed.
+“Know that a petition was presented to the King and Queen. All here,
+yourself excepted, saw the King take it, in his carriage in the street,
+sitting beside the Queen. It is Defarge whom you see here, who, at the
+hazard of his life, darted out before the horses, with the petition in
+his hand.”
+
+“And once again listen, Jacques!” said the kneeling Number Three:
+his fingers ever wandering over and over those fine nerves, with a
+strikingly greedy air, as if he hungered for something--that was neither
+food nor drink; “the guard, horse and foot, surrounded the petitioner,
+and struck him blows. You hear?”
+
+“I hear, messieurs.”
+
+“Go on then,” said Defarge.
+
+“Again; on the other hand, they whisper at the fountain,” resumed the
+countryman, “that he is brought down into our country to be executed on
+the spot, and that he will very certainly be executed. They even whisper
+that because he has slain Monseigneur, and because Monseigneur was the
+father of his tenants--serfs--what you will--he will be executed as a
+parricide. One old man says at the fountain, that his right hand, armed
+with the knife, will be burnt off before his face; that, into wounds
+which will be made in his arms, his breast, and his legs, there will be
+poured boiling oil, melted lead, hot resin, wax, and sulphur; finally,
+that he will be torn limb from limb by four strong horses. That old man
+says, all this was actually done to a prisoner who made an attempt on
+the life of the late King, Louis Fifteen. But how do I know if he lies?
+I am not a scholar.”
+
+“Listen once again then, Jacques!” said the man with the restless hand
+and the craving air. “The name of that prisoner was Damiens, and it was
+all done in open day, in the open streets of this city of Paris; and
+nothing was more noticed in the vast concourse that saw it done, than
+the crowd of ladies of quality and fashion, who were full of eager
+attention to the last--to the last, Jacques, prolonged until nightfall,
+when he had lost two legs and an arm, and still breathed! And it was
+done--why, how old are you?”
+
+“Thirty-five,” said the mender of roads, who looked sixty.
+
+“It was done when you were more than ten years old; you might have seen
+it.”
+
+“Enough!” said Defarge, with grim impatience. “Long live the Devil! Go
+on.”
+
+“Well! Some whisper this, some whisper that; they speak of nothing else;
+even the fountain appears to fall to that tune. At length, on Sunday
+night when all the village is asleep, come soldiers, winding down from
+the prison, and their guns ring on the stones of the little street.
+Workmen dig, workmen hammer, soldiers laugh and sing; in the morning, by
+the fountain, there is raised a gallows forty feet high, poisoning the
+water.”
+
+The mender of roads looked _through_ rather than _at_ the low ceiling,
+and pointed as if he saw the gallows somewhere in the sky.
+
+“All work is stopped, all assemble there, nobody leads the cows out,
+the cows are there with the rest. At midday, the roll of drums. Soldiers
+have marched into the prison in the night, and he is in the midst
+of many soldiers. He is bound as before, and in his mouth there is
+a gag--tied so, with a tight string, making him look almost as if he
+laughed.” He suggested it, by creasing his face with his two thumbs,
+from the corners of his mouth to his ears. “On the top of the gallows is
+fixed the knife, blade upwards, with its point in the air. He is hanged
+there forty feet high--and is left hanging, poisoning the water.”
+
+They looked at one another, as he used his blue cap to wipe his face,
+on which the perspiration had started afresh while he recalled the
+spectacle.
+
+“It is frightful, messieurs. How can the women and the children draw
+water! Who can gossip of an evening, under that shadow! Under it, have
+I said? When I left the village, Monday evening as the sun was going to
+bed, and looked back from the hill, the shadow struck across the church,
+across the mill, across the prison--seemed to strike across the earth,
+messieurs, to where the sky rests upon it!”
+
+The hungry man gnawed one of his fingers as he looked at the other
+three, and his finger quivered with the craving that was on him.
+
+“That’s all, messieurs. I left at sunset (as I had been warned to do),
+and I walked on, that night and half next day, until I met (as I was
+warned I should) this comrade. With him, I came on, now riding and now
+walking, through the rest of yesterday and through last night. And here
+you see me!”
+
+After a gloomy silence, the first Jacques said, “Good! You have acted
+and recounted faithfully. Will you wait for us a little, outside the
+door?”
+
+“Very willingly,” said the mender of roads. Whom Defarge escorted to the
+top of the stairs, and, leaving seated there, returned.
+
+The three had risen, and their heads were together when he came back to
+the garret.
+
+“How say you, Jacques?” demanded Number One. “To be registered?”
+
+“To be registered, as doomed to destruction,” returned Defarge.
+
+“Magnificent!” croaked the man with the craving.
+
+“The chateau, and all the race?” inquired the first.
+
+“The chateau and all the race,” returned Defarge. “Extermination.”
+
+The hungry man repeated, in a rapturous croak, “Magnificent!” and began
+gnawing another finger.
+
+“Are you sure,” asked Jacques Two, of Defarge, “that no embarrassment
+can arise from our manner of keeping the register? Without doubt it is
+safe, for no one beyond ourselves can decipher it; but shall we always
+be able to decipher it--or, I ought to say, will she?”
+
+“Jacques,” returned Defarge, drawing himself up, “if madame my wife
+undertook to keep the register in her memory alone, she would not lose
+a word of it--not a syllable of it. Knitted, in her own stitches and her
+own symbols, it will always be as plain to her as the sun. Confide in
+Madame Defarge. It would be easier for the weakest poltroon that lives,
+to erase himself from existence, than to erase one letter of his name or
+crimes from the knitted register of Madame Defarge.”
+
+There was a murmur of confidence and approval, and then the man who
+hungered, asked: “Is this rustic to be sent back soon? I hope so. He is
+very simple; is he not a little dangerous?”
+
+“He knows nothing,” said Defarge; “at least nothing more than would
+easily elevate himself to a gallows of the same height. I charge myself
+with him; let him remain with me; I will take care of him, and set him
+on his road. He wishes to see the fine world--the King, the Queen, and
+Court; let him see them on Sunday.”
+
+“What?” exclaimed the hungry man, staring. “Is it a good sign, that he
+wishes to see Royalty and Nobility?”
+
+“Jacques,” said Defarge; “judiciously show a cat milk, if you wish her
+to thirst for it. Judiciously show a dog his natural prey, if you wish
+him to bring it down one day.”
+
+Nothing more was said, and the mender of roads, being found already
+dozing on the topmost stair, was advised to lay himself down on the
+pallet-bed and take some rest. He needed no persuasion, and was soon
+asleep.
+
+Worse quarters than Defarge’s wine-shop, could easily have been found
+in Paris for a provincial slave of that degree. Saving for a mysterious
+dread of madame by which he was constantly haunted, his life was very
+new and agreeable. But, madame sat all day at her counter, so expressly
+unconscious of him, and so particularly determined not to perceive that
+his being there had any connection with anything below the surface, that
+he shook in his wooden shoes whenever his eye lighted on her. For, he
+contended with himself that it was impossible to foresee what that lady
+might pretend next; and he felt assured that if she should take it
+into her brightly ornamented head to pretend that she had seen him do a
+murder and afterwards flay the victim, she would infallibly go through
+with it until the play was played out.
+
+Therefore, when Sunday came, the mender of roads was not enchanted
+(though he said he was) to find that madame was to accompany monsieur
+and himself to Versailles. It was additionally disconcerting to have
+madame knitting all the way there, in a public conveyance; it was
+additionally disconcerting yet, to have madame in the crowd in the
+afternoon, still with her knitting in her hands as the crowd waited to
+see the carriage of the King and Queen.
+
+“You work hard, madame,” said a man near her.
+
+“Yes,” answered Madame Defarge; “I have a good deal to do.”
+
+“What do you make, madame?”
+
+“Many things.”
+
+“For instance--”
+
+“For instance,” returned Madame Defarge, composedly, “shrouds.”
+
+The man moved a little further away, as soon as he could, and the mender
+of roads fanned himself with his blue cap: feeling it mightily close
+and oppressive. If he needed a King and Queen to restore him, he was
+fortunate in having his remedy at hand; for, soon the large-faced King
+and the fair-faced Queen came in their golden coach, attended by the
+shining Bull’s Eye of their Court, a glittering multitude of laughing
+ladies and fine lords; and in jewels and silks and powder and splendour
+and elegantly spurning figures and handsomely disdainful faces of both
+sexes, the mender of roads bathed himself, so much to his temporary
+intoxication, that he cried Long live the King, Long live the Queen,
+Long live everybody and everything! as if he had never heard of
+ubiquitous Jacques in his time. Then, there were gardens, courtyards,
+terraces, fountains, green banks, more King and Queen, more Bull’s Eye,
+more lords and ladies, more Long live they all! until he absolutely wept
+with sentiment. During the whole of this scene, which lasted some three
+hours, he had plenty of shouting and weeping and sentimental company,
+and throughout Defarge held him by the collar, as if to restrain him
+from flying at the objects of his brief devotion and tearing them to
+pieces.
+
+“Bravo!” said Defarge, clapping him on the back when it was over, like a
+patron; “you are a good boy!”
+
+The mender of roads was now coming to himself, and was mistrustful of
+having made a mistake in his late demonstrations; but no.
+
+“You are the fellow we want,” said Defarge, in his ear; “you make
+these fools believe that it will last for ever. Then, they are the more
+insolent, and it is the nearer ended.”
+
+“Hey!” cried the mender of roads, reflectively; “that’s true.”
+
+“These fools know nothing. While they despise your breath, and would
+stop it for ever and ever, in you or in a hundred like you rather than
+in one of their own horses or dogs, they only know what your breath
+tells them. Let it deceive them, then, a little longer; it cannot
+deceive them too much.”
+
+Madame Defarge looked superciliously at the client, and nodded in
+confirmation.
+
+“As to you,” said she, “you would shout and shed tears for anything, if
+it made a show and a noise. Say! Would you not?”
+
+“Truly, madame, I think so. For the moment.”
+
+“If you were shown a great heap of dolls, and were set upon them to
+pluck them to pieces and despoil them for your own advantage, you would
+pick out the richest and gayest. Say! Would you not?”
+
+“Truly yes, madame.”
+
+“Yes. And if you were shown a flock of birds, unable to fly, and were
+set upon them to strip them of their feathers for your own advantage,
+you would set upon the birds of the finest feathers; would you not?”
+
+“It is true, madame.”
+
+“You have seen both dolls and birds to-day,” said Madame Defarge, with
+a wave of her hand towards the place where they had last been apparent;
+“now, go home!”
+
+
+
+
+XVI. Still Knitting
+
+
+Madame Defarge and monsieur her husband returned amicably to the
+bosom of Saint Antoine, while a speck in a blue cap toiled through the
+darkness, and through the dust, and down the weary miles of avenue by
+the wayside, slowly tending towards that point of the compass where
+the chateau of Monsieur the Marquis, now in his grave, listened to
+the whispering trees. Such ample leisure had the stone faces, now,
+for listening to the trees and to the fountain, that the few village
+scarecrows who, in their quest for herbs to eat and fragments of dead
+stick to burn, strayed within sight of the great stone courtyard and
+terrace staircase, had it borne in upon their starved fancy that
+the expression of the faces was altered. A rumour just lived in the
+village--had a faint and bare existence there, as its people had--that
+when the knife struck home, the faces changed, from faces of pride to
+faces of anger and pain; also, that when that dangling figure was hauled
+up forty feet above the fountain, they changed again, and bore a cruel
+look of being avenged, which they would henceforth bear for ever. In the
+stone face over the great window of the bed-chamber where the murder
+was done, two fine dints were pointed out in the sculptured nose, which
+everybody recognised, and which nobody had seen of old; and on the
+scarce occasions when two or three ragged peasants emerged from the
+crowd to take a hurried peep at Monsieur the Marquis petrified, a
+skinny finger would not have pointed to it for a minute, before they all
+started away among the moss and leaves, like the more fortunate hares
+who could find a living there.
+
+Chateau and hut, stone face and dangling figure, the red stain on the
+stone floor, and the pure water in the village well--thousands of acres
+of land--a whole province of France--all France itself--lay under the
+night sky, concentrated into a faint hair-breadth line. So does a whole
+world, with all its greatnesses and littlenesses, lie in a twinkling
+star. And as mere human knowledge can split a ray of light and analyse
+the manner of its composition, so, sublimer intelligences may read in
+the feeble shining of this earth of ours, every thought and act, every
+vice and virtue, of every responsible creature on it.
+
+The Defarges, husband and wife, came lumbering under the starlight,
+in their public vehicle, to that gate of Paris whereunto their
+journey naturally tended. There was the usual stoppage at the barrier
+guardhouse, and the usual lanterns came glancing forth for the usual
+examination and inquiry. Monsieur Defarge alighted; knowing one or two
+of the soldiery there, and one of the police. The latter he was intimate
+with, and affectionately embraced.
+
+When Saint Antoine had again enfolded the Defarges in his dusky wings,
+and they, having finally alighted near the Saint’s boundaries, were
+picking their way on foot through the black mud and offal of his
+streets, Madame Defarge spoke to her husband:
+
+“Say then, my friend; what did Jacques of the police tell thee?”
+
+“Very little to-night, but all he knows. There is another spy
+commissioned for our quarter. There may be many more, for all that he
+can say, but he knows of one.”
+
+“Eh well!” said Madame Defarge, raising her eyebrows with a cool
+business air. “It is necessary to register him. How do they call that
+man?”
+
+“He is English.”
+
+“So much the better. His name?”
+
+“Barsad,” said Defarge, making it French by pronunciation. But, he had
+been so careful to get it accurately, that he then spelt it with perfect
+correctness.
+
+“Barsad,” repeated madame. “Good. Christian name?”
+
+“John.”
+
+“John Barsad,” repeated madame, after murmuring it once to herself.
+“Good. His appearance; is it known?”
+
+“Age, about forty years; height, about five feet nine; black hair;
+complexion dark; generally, rather handsome visage; eyes dark, face
+thin, long, and sallow; nose aquiline, but not straight, having a
+peculiar inclination towards the left cheek; expression, therefore,
+sinister.”
+
+“Eh my faith. It is a portrait!” said madame, laughing. “He shall be
+registered to-morrow.”
+
+They turned into the wine-shop, which was closed (for it was midnight),
+and where Madame Defarge immediately took her post at her desk, counted
+the small moneys that had been taken during her absence, examined the
+stock, went through the entries in the book, made other entries of
+her own, checked the serving man in every possible way, and finally
+dismissed him to bed. Then she turned out the contents of the bowl
+of money for the second time, and began knotting them up in her
+handkerchief, in a chain of separate knots, for safe keeping through the
+night. All this while, Defarge, with his pipe in his mouth, walked
+up and down, complacently admiring, but never interfering; in which
+condition, indeed, as to the business and his domestic affairs, he
+walked up and down through life.
+
+The night was hot, and the shop, close shut and surrounded by so foul a
+neighbourhood, was ill-smelling. Monsieur Defarge’s olfactory sense was
+by no means delicate, but the stock of wine smelt much stronger than
+it ever tasted, and so did the stock of rum and brandy and aniseed. He
+whiffed the compound of scents away, as he put down his smoked-out pipe.
+
+“You are fatigued,” said madame, raising her glance as she knotted the
+money. “There are only the usual odours.”
+
+“I am a little tired,” her husband acknowledged.
+
+“You are a little depressed, too,” said madame, whose quick eyes had
+never been so intent on the accounts, but they had had a ray or two for
+him. “Oh, the men, the men!”
+
+“But my dear!” began Defarge.
+
+“But my dear!” repeated madame, nodding firmly; “but my dear! You are
+faint of heart to-night, my dear!”
+
+“Well, then,” said Defarge, as if a thought were wrung out of his
+breast, “it _is_ a long time.”
+
+“It is a long time,” repeated his wife; “and when is it not a long time?
+Vengeance and retribution require a long time; it is the rule.”
+
+“It does not take a long time to strike a man with Lightning,” said
+Defarge.
+
+“How long,” demanded madame, composedly, “does it take to make and store
+the lightning? Tell me.”
+
+Defarge raised his head thoughtfully, as if there were something in that
+too.
+
+“It does not take a long time,” said madame, “for an earthquake to
+swallow a town. Eh well! Tell me how long it takes to prepare the
+earthquake?”
+
+“A long time, I suppose,” said Defarge.
+
+“But when it is ready, it takes place, and grinds to pieces everything
+before it. In the meantime, it is always preparing, though it is not
+seen or heard. That is your consolation. Keep it.”
+
+She tied a knot with flashing eyes, as if it throttled a foe.
+
+“I tell thee,” said madame, extending her right hand, for emphasis,
+“that although it is a long time on the road, it is on the road and
+coming. I tell thee it never retreats, and never stops. I tell thee it
+is always advancing. Look around and consider the lives of all the world
+that we know, consider the faces of all the world that we know, consider
+the rage and discontent to which the Jacquerie addresses itself with
+more and more of certainty every hour. Can such things last? Bah! I mock
+you.”
+
+“My brave wife,” returned Defarge, standing before her with his head
+a little bent, and his hands clasped at his back, like a docile and
+attentive pupil before his catechist, “I do not question all this. But
+it has lasted a long time, and it is possible--you know well, my wife,
+it is possible--that it may not come, during our lives.”
+
+“Eh well! How then?” demanded madame, tying another knot, as if there
+were another enemy strangled.
+
+“Well!” said Defarge, with a half complaining and half apologetic shrug.
+“We shall not see the triumph.”
+
+“We shall have helped it,” returned madame, with her extended hand in
+strong action. “Nothing that we do, is done in vain. I believe, with all
+my soul, that we shall see the triumph. But even if not, even if I knew
+certainly not, show me the neck of an aristocrat and tyrant, and still I
+would--”
+
+Then madame, with her teeth set, tied a very terrible knot indeed.
+
+“Hold!” cried Defarge, reddening a little as if he felt charged with
+cowardice; “I too, my dear, will stop at nothing.”
+
+“Yes! But it is your weakness that you sometimes need to see your victim
+and your opportunity, to sustain you. Sustain yourself without that.
+When the time comes, let loose a tiger and a devil; but wait for the
+time with the tiger and the devil chained--not shown--yet always ready.”
+
+Madame enforced the conclusion of this piece of advice by striking her
+little counter with her chain of money as if she knocked its brains
+out, and then gathering the heavy handkerchief under her arm in a serene
+manner, and observing that it was time to go to bed.
+
+Next noontide saw the admirable woman in her usual place in the
+wine-shop, knitting away assiduously. A rose lay beside her, and if she
+now and then glanced at the flower, it was with no infraction of her
+usual preoccupied air. There were a few customers, drinking or not
+drinking, standing or seated, sprinkled about. The day was very hot,
+and heaps of flies, who were extending their inquisitive and adventurous
+perquisitions into all the glutinous little glasses near madame, fell
+dead at the bottom. Their decease made no impression on the other flies
+out promenading, who looked at them in the coolest manner (as if they
+themselves were elephants, or something as far removed), until they met
+the same fate. Curious to consider how heedless flies are!--perhaps they
+thought as much at Court that sunny summer day.
+
+A figure entering at the door threw a shadow on Madame Defarge which she
+felt to be a new one. She laid down her knitting, and began to pin her
+rose in her head-dress, before she looked at the figure.
+
+It was curious. The moment Madame Defarge took up the rose, the
+customers ceased talking, and began gradually to drop out of the
+wine-shop.
+
+“Good day, madame,” said the new-comer.
+
+“Good day, monsieur.”
+
+She said it aloud, but added to herself, as she resumed her knitting:
+“Hah! Good day, age about forty, height about five feet nine, black
+hair, generally rather handsome visage, complexion dark, eyes dark,
+thin, long and sallow face, aquiline nose but not straight, having a
+peculiar inclination towards the left cheek which imparts a sinister
+expression! Good day, one and all!”
+
+“Have the goodness to give me a little glass of old cognac, and a
+mouthful of cool fresh water, madame.”
+
+Madame complied with a polite air.
+
+“Marvellous cognac this, madame!”
+
+It was the first time it had ever been so complimented, and Madame
+Defarge knew enough of its antecedents to know better. She said,
+however, that the cognac was flattered, and took up her knitting. The
+visitor watched her fingers for a few moments, and took the opportunity
+of observing the place in general.
+
+“You knit with great skill, madame.”
+
+“I am accustomed to it.”
+
+“A pretty pattern too!”
+
+“_You_ think so?” said madame, looking at him with a smile.
+
+“Decidedly. May one ask what it is for?”
+
+“Pastime,” said madame, still looking at him with a smile while her
+fingers moved nimbly.
+
+“Not for use?”
+
+“That depends. I may find a use for it one day. If I do--Well,” said
+madame, drawing a breath and nodding her head with a stern kind of
+coquetry, “I’ll use it!”
+
+It was remarkable; but, the taste of Saint Antoine seemed to be
+decidedly opposed to a rose on the head-dress of Madame Defarge. Two
+men had entered separately, and had been about to order drink, when,
+catching sight of that novelty, they faltered, made a pretence of
+looking about as if for some friend who was not there, and went away.
+Nor, of those who had been there when this visitor entered, was there
+one left. They had all dropped off. The spy had kept his eyes open,
+but had been able to detect no sign. They had lounged away in a
+poverty-stricken, purposeless, accidental manner, quite natural and
+unimpeachable.
+
+“_John_,” thought madame, checking off her work as her fingers knitted,
+and her eyes looked at the stranger. “Stay long enough, and I shall knit
+‘BARSAD’ before you go.”
+
+“You have a husband, madame?”
+
+“I have.”
+
+“Children?”
+
+“No children.”
+
+“Business seems bad?”
+
+“Business is very bad; the people are so poor.”
+
+“Ah, the unfortunate, miserable people! So oppressed, too--as you say.”
+
+“As _you_ say,” madame retorted, correcting him, and deftly knitting an
+extra something into his name that boded him no good.
+
+“Pardon me; certainly it was I who said so, but you naturally think so.
+Of course.”
+
+“_I_ think?” returned madame, in a high voice. “I and my husband have
+enough to do to keep this wine-shop open, without thinking. All we
+think, here, is how to live. That is the subject _we_ think of, and
+it gives us, from morning to night, enough to think about, without
+embarrassing our heads concerning others. _I_ think for others? No, no.”
+
+The spy, who was there to pick up any crumbs he could find or make, did
+not allow his baffled state to express itself in his sinister face; but,
+stood with an air of gossiping gallantry, leaning his elbow on Madame
+Defarge’s little counter, and occasionally sipping his cognac.
+
+“A bad business this, madame, of Gaspard’s execution. Ah! the poor
+Gaspard!” With a sigh of great compassion.
+
+“My faith!” returned madame, coolly and lightly, “if people use knives
+for such purposes, they have to pay for it. He knew beforehand what the
+price of his luxury was; he has paid the price.”
+
+“I believe,” said the spy, dropping his soft voice to a tone
+that invited confidence, and expressing an injured revolutionary
+susceptibility in every muscle of his wicked face: “I believe there
+is much compassion and anger in this neighbourhood, touching the poor
+fellow? Between ourselves.”
+
+“Is there?” asked madame, vacantly.
+
+“Is there not?”
+
+“--Here is my husband!” said Madame Defarge.
+
+As the keeper of the wine-shop entered at the door, the spy saluted
+him by touching his hat, and saying, with an engaging smile, “Good day,
+Jacques!” Defarge stopped short, and stared at him.
+
+“Good day, Jacques!” the spy repeated; with not quite so much
+confidence, or quite so easy a smile under the stare.
+
+“You deceive yourself, monsieur,” returned the keeper of the wine-shop.
+“You mistake me for another. That is not my name. I am Ernest Defarge.”
+
+“It is all the same,” said the spy, airily, but discomfited too: “good
+day!”
+
+“Good day!” answered Defarge, drily.
+
+“I was saying to madame, with whom I had the pleasure of chatting when
+you entered, that they tell me there is--and no wonder!--much sympathy
+and anger in Saint Antoine, touching the unhappy fate of poor Gaspard.”
+
+“No one has told me so,” said Defarge, shaking his head. “I know nothing
+of it.”
+
+Having said it, he passed behind the little counter, and stood with his
+hand on the back of his wife’s chair, looking over that barrier at the
+person to whom they were both opposed, and whom either of them would
+have shot with the greatest satisfaction.
+
+The spy, well used to his business, did not change his unconscious
+attitude, but drained his little glass of cognac, took a sip of fresh
+water, and asked for another glass of cognac. Madame Defarge poured it
+out for him, took to her knitting again, and hummed a little song over
+it.
+
+“You seem to know this quarter well; that is to say, better than I do?”
+ observed Defarge.
+
+“Not at all, but I hope to know it better. I am so profoundly interested
+in its miserable inhabitants.”
+
+“Hah!” muttered Defarge.
+
+“The pleasure of conversing with you, Monsieur Defarge, recalls to me,”
+ pursued the spy, “that I have the honour of cherishing some interesting
+associations with your name.”
+
+“Indeed!” said Defarge, with much indifference.
+
+“Yes, indeed. When Doctor Manette was released, you, his old domestic,
+had the charge of him, I know. He was delivered to you. You see I am
+informed of the circumstances?”
+
+“Such is the fact, certainly,” said Defarge. He had had it conveyed
+to him, in an accidental touch of his wife’s elbow as she knitted and
+warbled, that he would do best to answer, but always with brevity.
+
+“It was to you,” said the spy, “that his daughter came; and it was
+from your care that his daughter took him, accompanied by a neat brown
+monsieur; how is he called?--in a little wig--Lorry--of the bank of
+Tellson and Company--over to England.”
+
+“Such is the fact,” repeated Defarge.
+
+“Very interesting remembrances!” said the spy. “I have known Doctor
+Manette and his daughter, in England.”
+
+“Yes?” said Defarge.
+
+“You don’t hear much about them now?” said the spy.
+
+“No,” said Defarge.
+
+“In effect,” madame struck in, looking up from her work and her little
+song, “we never hear about them. We received the news of their safe
+arrival, and perhaps another letter, or perhaps two; but, since then,
+they have gradually taken their road in life--we, ours--and we have held
+no correspondence.”
+
+“Perfectly so, madame,” replied the spy. “She is going to be married.”
+
+“Going?” echoed madame. “She was pretty enough to have been married long
+ago. You English are cold, it seems to me.”
+
+“Oh! You know I am English.”
+
+“I perceive your tongue is,” returned madame; “and what the tongue is, I
+suppose the man is.”
+
+He did not take the identification as a compliment; but he made the best
+of it, and turned it off with a laugh. After sipping his cognac to the
+end, he added:
+
+“Yes, Miss Manette is going to be married. But not to an Englishman; to
+one who, like herself, is French by birth. And speaking of Gaspard (ah,
+poor Gaspard! It was cruel, cruel!), it is a curious thing that she is
+going to marry the nephew of Monsieur the Marquis, for whom Gaspard
+was exalted to that height of so many feet; in other words, the present
+Marquis. But he lives unknown in England, he is no Marquis there; he is
+Mr. Charles Darnay. D’Aulnais is the name of his mother’s family.”
+
+Madame Defarge knitted steadily, but the intelligence had a palpable
+effect upon her husband. Do what he would, behind the little counter,
+as to the striking of a light and the lighting of his pipe, he was
+troubled, and his hand was not trustworthy. The spy would have been no
+spy if he had failed to see it, or to record it in his mind.
+
+Having made, at least, this one hit, whatever it might prove to be
+worth, and no customers coming in to help him to any other, Mr. Barsad
+paid for what he had drunk, and took his leave: taking occasion to say,
+in a genteel manner, before he departed, that he looked forward to the
+pleasure of seeing Monsieur and Madame Defarge again. For some minutes
+after he had emerged into the outer presence of Saint Antoine, the
+husband and wife remained exactly as he had left them, lest he should
+come back.
+
+“Can it be true,” said Defarge, in a low voice, looking down at his wife
+as he stood smoking with his hand on the back of her chair: “what he has
+said of Ma’amselle Manette?”
+
+“As he has said it,” returned madame, lifting her eyebrows a little, “it
+is probably false. But it may be true.”
+
+“If it is--” Defarge began, and stopped.
+
+“If it is?” repeated his wife.
+
+“--And if it does come, while we live to see it triumph--I hope, for her
+sake, Destiny will keep her husband out of France.”
+
+“Her husband’s destiny,” said Madame Defarge, with her usual composure,
+“will take him where he is to go, and will lead him to the end that is
+to end him. That is all I know.”
+
+“But it is very strange--now, at least, is it not very strange”--said
+Defarge, rather pleading with his wife to induce her to admit it,
+“that, after all our sympathy for Monsieur her father, and herself, her
+husband’s name should be proscribed under your hand at this moment, by
+the side of that infernal dog’s who has just left us?”
+
+“Stranger things than that will happen when it does come,” answered
+madame. “I have them both here, of a certainty; and they are both here
+for their merits; that is enough.”
+
+She rolled up her knitting when she had said those words, and presently
+took the rose out of the handkerchief that was wound about her head.
+Either Saint Antoine had an instinctive sense that the objectionable
+decoration was gone, or Saint Antoine was on the watch for its
+disappearance; howbeit, the Saint took courage to lounge in, very
+shortly afterwards, and the wine-shop recovered its habitual aspect.
+
+In the evening, at which season of all others Saint Antoine turned
+himself inside out, and sat on door-steps and window-ledges, and came
+to the corners of vile streets and courts, for a breath of air, Madame
+Defarge with her work in her hand was accustomed to pass from place
+to place and from group to group: a Missionary--there were many like
+her--such as the world will do well never to breed again. All the women
+knitted. They knitted worthless things; but, the mechanical work was a
+mechanical substitute for eating and drinking; the hands moved for the
+jaws and the digestive apparatus: if the bony fingers had been still,
+the stomachs would have been more famine-pinched.
+
+But, as the fingers went, the eyes went, and the thoughts. And as Madame
+Defarge moved on from group to group, all three went quicker and fiercer
+among every little knot of women that she had spoken with, and left
+behind.
+
+Her husband smoked at his door, looking after her with admiration. “A
+great woman,” said he, “a strong woman, a grand woman, a frightfully
+grand woman!”
+
+Darkness closed around, and then came the ringing of church bells and
+the distant beating of the military drums in the Palace Courtyard, as
+the women sat knitting, knitting. Darkness encompassed them. Another
+darkness was closing in as surely, when the church bells, then ringing
+pleasantly in many an airy steeple over France, should be melted into
+thundering cannon; when the military drums should be beating to drown a
+wretched voice, that night all potent as the voice of Power and Plenty,
+Freedom and Life. So much was closing in about the women who sat
+knitting, knitting, that they their very selves were closing in around
+a structure yet unbuilt, where they were to sit knitting, knitting,
+counting dropping heads.
+
+
+
+
+XVII. One Night
+
+
+Never did the sun go down with a brighter glory on the quiet corner in
+Soho, than one memorable evening when the Doctor and his daughter sat
+under the plane-tree together. Never did the moon rise with a milder
+radiance over great London, than on that night when it found them still
+seated under the tree, and shone upon their faces through its leaves.
+
+Lucie was to be married to-morrow. She had reserved this last evening
+for her father, and they sat alone under the plane-tree.
+
+“You are happy, my dear father?”
+
+“Quite, my child.”
+
+They had said little, though they had been there a long time. When it
+was yet light enough to work and read, she had neither engaged herself
+in her usual work, nor had she read to him. She had employed herself in
+both ways, at his side under the tree, many and many a time; but, this
+time was not quite like any other, and nothing could make it so.
+
+“And I am very happy to-night, dear father. I am deeply happy in the
+love that Heaven has so blessed--my love for Charles, and Charles’s love
+for me. But, if my life were not to be still consecrated to you, or
+if my marriage were so arranged as that it would part us, even by
+the length of a few of these streets, I should be more unhappy and
+self-reproachful now than I can tell you. Even as it is--”
+
+Even as it was, she could not command her voice.
+
+In the sad moonlight, she clasped him by the neck, and laid her face
+upon his breast. In the moonlight which is always sad, as the light of
+the sun itself is--as the light called human life is--at its coming and
+its going.
+
+“Dearest dear! Can you tell me, this last time, that you feel quite,
+quite sure, no new affections of mine, and no new duties of mine, will
+ever interpose between us? _I_ know it well, but do you know it? In your
+own heart, do you feel quite certain?”
+
+Her father answered, with a cheerful firmness of conviction he could
+scarcely have assumed, “Quite sure, my darling! More than that,” he
+added, as he tenderly kissed her: “my future is far brighter, Lucie,
+seen through your marriage, than it could have been--nay, than it ever
+was--without it.”
+
+“If I could hope _that_, my father!--”
+
+“Believe it, love! Indeed it is so. Consider how natural and how plain
+it is, my dear, that it should be so. You, devoted and young, cannot
+fully appreciate the anxiety I have felt that your life should not be
+wasted--”
+
+She moved her hand towards his lips, but he took it in his, and repeated
+the word.
+
+“--wasted, my child--should not be wasted, struck aside from the
+natural order of things--for my sake. Your unselfishness cannot entirely
+comprehend how much my mind has gone on this; but, only ask yourself,
+how could my happiness be perfect, while yours was incomplete?”
+
+“If I had never seen Charles, my father, I should have been quite happy
+with you.”
+
+He smiled at her unconscious admission that she would have been unhappy
+without Charles, having seen him; and replied:
+
+“My child, you did see him, and it is Charles. If it had not been
+Charles, it would have been another. Or, if it had been no other, I
+should have been the cause, and then the dark part of my life would have
+cast its shadow beyond myself, and would have fallen on you.”
+
+It was the first time, except at the trial, of her ever hearing him
+refer to the period of his suffering. It gave her a strange and new
+sensation while his words were in her ears; and she remembered it long
+afterwards.
+
+“See!” said the Doctor of Beauvais, raising his hand towards the moon.
+“I have looked at her from my prison-window, when I could not bear her
+light. I have looked at her when it has been such torture to me to think
+of her shining upon what I had lost, that I have beaten my head against
+my prison-walls. I have looked at her, in a state so dull and lethargic,
+that I have thought of nothing but the number of horizontal lines I
+could draw across her at the full, and the number of perpendicular lines
+with which I could intersect them.” He added in his inward and pondering
+manner, as he looked at the moon, “It was twenty either way, I remember,
+and the twentieth was difficult to squeeze in.”
+
+The strange thrill with which she heard him go back to that time,
+deepened as he dwelt upon it; but, there was nothing to shock her in
+the manner of his reference. He only seemed to contrast his present
+cheerfulness and felicity with the dire endurance that was over.
+
+“I have looked at her, speculating thousands of times upon the unborn
+child from whom I had been rent. Whether it was alive. Whether it had
+been born alive, or the poor mother’s shock had killed it. Whether it
+was a son who would some day avenge his father. (There was a time in my
+imprisonment, when my desire for vengeance was unbearable.) Whether it
+was a son who would never know his father’s story; who might even live
+to weigh the possibility of his father’s having disappeared of his own
+will and act. Whether it was a daughter who would grow to be a woman.”
+
+She drew closer to him, and kissed his cheek and his hand.
+
+“I have pictured my daughter, to myself, as perfectly forgetful of
+me--rather, altogether ignorant of me, and unconscious of me. I have
+cast up the years of her age, year after year. I have seen her married
+to a man who knew nothing of my fate. I have altogether perished from
+the remembrance of the living, and in the next generation my place was a
+blank.”
+
+“My father! Even to hear that you had such thoughts of a daughter who
+never existed, strikes to my heart as if I had been that child.”
+
+“You, Lucie? It is out of the Consolation and restoration you have
+brought to me, that these remembrances arise, and pass between us and
+the moon on this last night.--What did I say just now?”
+
+“She knew nothing of you. She cared nothing for you.”
+
+“So! But on other moonlight nights, when the sadness and the silence
+have touched me in a different way--have affected me with something as
+like a sorrowful sense of peace, as any emotion that had pain for its
+foundations could--I have imagined her as coming to me in my cell, and
+leading me out into the freedom beyond the fortress. I have seen her
+image in the moonlight often, as I now see you; except that I never held
+her in my arms; it stood between the little grated window and the door.
+But, you understand that that was not the child I am speaking of?”
+
+“The figure was not; the--the--image; the fancy?”
+
+“No. That was another thing. It stood before my disturbed sense of
+sight, but it never moved. The phantom that my mind pursued, was another
+and more real child. Of her outward appearance I know no more than
+that she was like her mother. The other had that likeness too--as you
+have--but was not the same. Can you follow me, Lucie? Hardly, I think?
+I doubt you must have been a solitary prisoner to understand these
+perplexed distinctions.”
+
+His collected and calm manner could not prevent her blood from running
+cold, as he thus tried to anatomise his old condition.
+
+“In that more peaceful state, I have imagined her, in the moonlight,
+coming to me and taking me out to show me that the home of her married
+life was full of her loving remembrance of her lost father. My picture
+was in her room, and I was in her prayers. Her life was active,
+cheerful, useful; but my poor history pervaded it all.”
+
+“I was that child, my father, I was not half so good, but in my love
+that was I.”
+
+“And she showed me her children,” said the Doctor of Beauvais, “and
+they had heard of me, and had been taught to pity me. When they passed
+a prison of the State, they kept far from its frowning walls, and looked
+up at its bars, and spoke in whispers. She could never deliver me; I
+imagined that she always brought me back after showing me such things.
+But then, blessed with the relief of tears, I fell upon my knees, and
+blessed her.”
+
+“I am that child, I hope, my father. O my dear, my dear, will you bless
+me as fervently to-morrow?”
+
+“Lucie, I recall these old troubles in the reason that I have to-night
+for loving you better than words can tell, and thanking God for my great
+happiness. My thoughts, when they were wildest, never rose near the
+happiness that I have known with you, and that we have before us.”
+
+He embraced her, solemnly commended her to Heaven, and humbly thanked
+Heaven for having bestowed her on him. By-and-bye, they went into the
+house.
+
+There was no one bidden to the marriage but Mr. Lorry; there was even to
+be no bridesmaid but the gaunt Miss Pross. The marriage was to make no
+change in their place of residence; they had been able to extend it,
+by taking to themselves the upper rooms formerly belonging to the
+apocryphal invisible lodger, and they desired nothing more.
+
+Doctor Manette was very cheerful at the little supper. They were only
+three at table, and Miss Pross made the third. He regretted that Charles
+was not there; was more than half disposed to object to the loving
+little plot that kept him away; and drank to him affectionately.
+
+So, the time came for him to bid Lucie good night, and they separated.
+But, in the stillness of the third hour of the morning, Lucie came
+downstairs again, and stole into his room; not free from unshaped fears,
+beforehand.
+
+All things, however, were in their places; all was quiet; and he lay
+asleep, his white hair picturesque on the untroubled pillow, and his
+hands lying quiet on the coverlet. She put her needless candle in the
+shadow at a distance, crept up to his bed, and put her lips to his;
+then, leaned over him, and looked at him.
+
+Into his handsome face, the bitter waters of captivity had worn; but, he
+covered up their tracks with a determination so strong, that he held the
+mastery of them even in his sleep. A more remarkable face in its quiet,
+resolute, and guarded struggle with an unseen assailant, was not to be
+beheld in all the wide dominions of sleep, that night.
+
+She timidly laid her hand on his dear breast, and put up a prayer that
+she might ever be as true to him as her love aspired to be, and as his
+sorrows deserved. Then, she withdrew her hand, and kissed his lips once
+more, and went away. So, the sunrise came, and the shadows of the leaves
+of the plane-tree moved upon his face, as softly as her lips had moved
+in praying for him.
+
+
+
+
+XVIII. Nine Days
+
+
+The marriage-day was shining brightly, and they were ready outside the
+closed door of the Doctor’s room, where he was speaking with Charles
+Darnay. They were ready to go to church; the beautiful bride, Mr.
+Lorry, and Miss Pross--to whom the event, through a gradual process of
+reconcilement to the inevitable, would have been one of absolute bliss,
+but for the yet lingering consideration that her brother Solomon should
+have been the bridegroom.
+
+“And so,” said Mr. Lorry, who could not sufficiently admire the bride,
+and who had been moving round her to take in every point of her quiet,
+pretty dress; “and so it was for this, my sweet Lucie, that I brought
+you across the Channel, such a baby! Lord bless me! How little I thought
+what I was doing! How lightly I valued the obligation I was conferring
+on my friend Mr. Charles!”
+
+“You didn’t mean it,” remarked the matter-of-fact Miss Pross, “and
+therefore how could you know it? Nonsense!”
+
+“Really? Well; but don’t cry,” said the gentle Mr. Lorry.
+
+“I am not crying,” said Miss Pross; “_you_ are.”
+
+“I, my Pross?” (By this time, Mr. Lorry dared to be pleasant with her,
+on occasion.)
+
+“You were, just now; I saw you do it, and I don’t wonder at it. Such
+a present of plate as you have made ‘em, is enough to bring tears into
+anybody’s eyes. There’s not a fork or a spoon in the collection,” said
+Miss Pross, “that I didn’t cry over, last night after the box came, till
+I couldn’t see it.”
+
+“I am highly gratified,” said Mr. Lorry, “though, upon my honour, I
+had no intention of rendering those trifling articles of remembrance
+invisible to any one. Dear me! This is an occasion that makes a man
+speculate on all he has lost. Dear, dear, dear! To think that there
+might have been a Mrs. Lorry, any time these fifty years almost!”
+
+“Not at all!” From Miss Pross.
+
+“You think there never might have been a Mrs. Lorry?” asked the
+gentleman of that name.
+
+“Pooh!” rejoined Miss Pross; “you were a bachelor in your cradle.”
+
+“Well!” observed Mr. Lorry, beamingly adjusting his little wig, “that
+seems probable, too.”
+
+“And you were cut out for a bachelor,” pursued Miss Pross, “before you
+were put in your cradle.”
+
+“Then, I think,” said Mr. Lorry, “that I was very unhandsomely dealt
+with, and that I ought to have had a voice in the selection of my
+pattern. Enough! Now, my dear Lucie,” drawing his arm soothingly round
+her waist, “I hear them moving in the next room, and Miss Pross and
+I, as two formal folks of business, are anxious not to lose the final
+opportunity of saying something to you that you wish to hear. You leave
+your good father, my dear, in hands as earnest and as loving as your
+own; he shall be taken every conceivable care of; during the next
+fortnight, while you are in Warwickshire and thereabouts, even Tellson’s
+shall go to the wall (comparatively speaking) before him. And when, at
+the fortnight’s end, he comes to join you and your beloved husband, on
+your other fortnight’s trip in Wales, you shall say that we have sent
+him to you in the best health and in the happiest frame. Now, I hear
+Somebody’s step coming to the door. Let me kiss my dear girl with an
+old-fashioned bachelor blessing, before Somebody comes to claim his
+own.”
+
+For a moment, he held the fair face from him to look at the
+well-remembered expression on the forehead, and then laid the bright
+golden hair against his little brown wig, with a genuine tenderness and
+delicacy which, if such things be old-fashioned, were as old as Adam.
+
+The door of the Doctor’s room opened, and he came out with Charles
+Darnay. He was so deadly pale--which had not been the case when they
+went in together--that no vestige of colour was to be seen in his face.
+But, in the composure of his manner he was unaltered, except that to the
+shrewd glance of Mr. Lorry it disclosed some shadowy indication that the
+old air of avoidance and dread had lately passed over him, like a cold
+wind.
+
+He gave his arm to his daughter, and took her down-stairs to the chariot
+which Mr. Lorry had hired in honour of the day. The rest followed in
+another carriage, and soon, in a neighbouring church, where no strange
+eyes looked on, Charles Darnay and Lucie Manette were happily married.
+
+Besides the glancing tears that shone among the smiles of the little
+group when it was done, some diamonds, very bright and sparkling,
+glanced on the bride’s hand, which were newly released from the
+dark obscurity of one of Mr. Lorry’s pockets. They returned home to
+breakfast, and all went well, and in due course the golden hair that had
+mingled with the poor shoemaker’s white locks in the Paris garret, were
+mingled with them again in the morning sunlight, on the threshold of the
+door at parting.
+
+It was a hard parting, though it was not for long. But her father
+cheered her, and said at last, gently disengaging himself from her
+enfolding arms, “Take her, Charles! She is yours!”
+
+And her agitated hand waved to them from a chaise window, and she was
+gone.
+
+The corner being out of the way of the idle and curious, and the
+preparations having been very simple and few, the Doctor, Mr. Lorry,
+and Miss Pross, were left quite alone. It was when they turned into
+the welcome shade of the cool old hall, that Mr. Lorry observed a great
+change to have come over the Doctor; as if the golden arm uplifted
+there, had struck him a poisoned blow.
+
+He had naturally repressed much, and some revulsion might have been
+expected in him when the occasion for repression was gone. But, it was
+the old scared lost look that troubled Mr. Lorry; and through his absent
+manner of clasping his head and drearily wandering away into his own
+room when they got up-stairs, Mr. Lorry was reminded of Defarge the
+wine-shop keeper, and the starlight ride.
+
+“I think,” he whispered to Miss Pross, after anxious consideration, “I
+think we had best not speak to him just now, or at all disturb him.
+I must look in at Tellson’s; so I will go there at once and come back
+presently. Then, we will take him a ride into the country, and dine
+there, and all will be well.”
+
+It was easier for Mr. Lorry to look in at Tellson’s, than to look out of
+Tellson’s. He was detained two hours. When he came back, he ascended the
+old staircase alone, having asked no question of the servant; going thus
+into the Doctor’s rooms, he was stopped by a low sound of knocking.
+
+“Good God!” he said, with a start. “What’s that?”
+
+Miss Pross, with a terrified face, was at his ear. “O me, O me! All is
+lost!” cried she, wringing her hands. “What is to be told to Ladybird?
+He doesn’t know me, and is making shoes!”
+
+Mr. Lorry said what he could to calm her, and went himself into the
+Doctor’s room. The bench was turned towards the light, as it had been
+when he had seen the shoemaker at his work before, and his head was bent
+down, and he was very busy.
+
+“Doctor Manette. My dear friend, Doctor Manette!”
+
+The Doctor looked at him for a moment--half inquiringly, half as if he
+were angry at being spoken to--and bent over his work again.
+
+He had laid aside his coat and waistcoat; his shirt was open at the
+throat, as it used to be when he did that work; and even the old
+haggard, faded surface of face had come back to him. He worked
+hard--impatiently--as if in some sense of having been interrupted.
+
+Mr. Lorry glanced at the work in his hand, and observed that it was a
+shoe of the old size and shape. He took up another that was lying by
+him, and asked what it was.
+
+“A young lady’s walking shoe,” he muttered, without looking up. “It
+ought to have been finished long ago. Let it be.”
+
+“But, Doctor Manette. Look at me!”
+
+He obeyed, in the old mechanically submissive manner, without pausing in
+his work.
+
+“You know me, my dear friend? Think again. This is not your proper
+occupation. Think, dear friend!”
+
+Nothing would induce him to speak more. He looked up, for an instant at
+a time, when he was requested to do so; but, no persuasion would extract
+a word from him. He worked, and worked, and worked, in silence, and
+words fell on him as they would have fallen on an echoless wall, or on
+the air. The only ray of hope that Mr. Lorry could discover, was, that
+he sometimes furtively looked up without being asked. In that, there
+seemed a faint expression of curiosity or perplexity--as though he were
+trying to reconcile some doubts in his mind.
+
+Two things at once impressed themselves on Mr. Lorry, as important above
+all others; the first, that this must be kept secret from Lucie;
+the second, that it must be kept secret from all who knew him. In
+conjunction with Miss Pross, he took immediate steps towards the latter
+precaution, by giving out that the Doctor was not well, and required a
+few days of complete rest. In aid of the kind deception to be practised
+on his daughter, Miss Pross was to write, describing his having been
+called away professionally, and referring to an imaginary letter of
+two or three hurried lines in his own hand, represented to have been
+addressed to her by the same post.
+
+These measures, advisable to be taken in any case, Mr. Lorry took in
+the hope of his coming to himself. If that should happen soon, he kept
+another course in reserve; which was, to have a certain opinion that he
+thought the best, on the Doctor’s case.
+
+In the hope of his recovery, and of resort to this third course
+being thereby rendered practicable, Mr. Lorry resolved to watch him
+attentively, with as little appearance as possible of doing so. He
+therefore made arrangements to absent himself from Tellson’s for the
+first time in his life, and took his post by the window in the same
+room.
+
+He was not long in discovering that it was worse than useless to speak
+to him, since, on being pressed, he became worried. He abandoned that
+attempt on the first day, and resolved merely to keep himself always
+before him, as a silent protest against the delusion into which he had
+fallen, or was falling. He remained, therefore, in his seat near the
+window, reading and writing, and expressing in as many pleasant and
+natural ways as he could think of, that it was a free place.
+
+Doctor Manette took what was given him to eat and drink, and worked on,
+that first day, until it was too dark to see--worked on, half an hour
+after Mr. Lorry could not have seen, for his life, to read or write.
+When he put his tools aside as useless, until morning, Mr. Lorry rose
+and said to him:
+
+“Will you go out?”
+
+He looked down at the floor on either side of him in the old manner,
+looked up in the old manner, and repeated in the old low voice:
+
+“Out?”
+
+“Yes; for a walk with me. Why not?”
+
+He made no effort to say why not, and said not a word more. But, Mr.
+Lorry thought he saw, as he leaned forward on his bench in the dusk,
+with his elbows on his knees and his head in his hands, that he was in
+some misty way asking himself, “Why not?” The sagacity of the man of
+business perceived an advantage here, and determined to hold it.
+
+Miss Pross and he divided the night into two watches, and observed him
+at intervals from the adjoining room. He paced up and down for a long
+time before he lay down; but, when he did finally lay himself down, he
+fell asleep. In the morning, he was up betimes, and went straight to his
+bench and to work.
+
+On this second day, Mr. Lorry saluted him cheerfully by his name,
+and spoke to him on topics that had been of late familiar to them. He
+returned no reply, but it was evident that he heard what was said, and
+that he thought about it, however confusedly. This encouraged Mr. Lorry
+to have Miss Pross in with her work, several times during the day;
+at those times, they quietly spoke of Lucie, and of her father then
+present, precisely in the usual manner, and as if there were nothing
+amiss. This was done without any demonstrative accompaniment, not long
+enough, or often enough to harass him; and it lightened Mr. Lorry’s
+friendly heart to believe that he looked up oftener, and that he
+appeared to be stirred by some perception of inconsistencies surrounding
+him.
+
+When it fell dark again, Mr. Lorry asked him as before:
+
+“Dear Doctor, will you go out?”
+
+As before, he repeated, “Out?”
+
+“Yes; for a walk with me. Why not?”
+
+This time, Mr. Lorry feigned to go out when he could extract no answer
+from him, and, after remaining absent for an hour, returned. In the
+meanwhile, the Doctor had removed to the seat in the window, and had
+sat there looking down at the plane-tree; but, on Mr. Lorry’s return, he
+slipped away to his bench.
+
+The time went very slowly on, and Mr. Lorry’s hope darkened, and his
+heart grew heavier again, and grew yet heavier and heavier every day.
+The third day came and went, the fourth, the fifth. Five days, six days,
+seven days, eight days, nine days.
+
+With a hope ever darkening, and with a heart always growing heavier and
+heavier, Mr. Lorry passed through this anxious time. The secret was
+well kept, and Lucie was unconscious and happy; but he could not fail to
+observe that the shoemaker, whose hand had been a little out at first,
+was growing dreadfully skilful, and that he had never been so intent on
+his work, and that his hands had never been so nimble and expert, as in
+the dusk of the ninth evening.
+
+
+
+
+XIX. An Opinion
+
+
+Worn out by anxious watching, Mr. Lorry fell asleep at his post. On the
+tenth morning of his suspense, he was startled by the shining of the sun
+into the room where a heavy slumber had overtaken him when it was dark
+night.
+
+He rubbed his eyes and roused himself; but he doubted, when he had
+done so, whether he was not still asleep. For, going to the door of the
+Doctor’s room and looking in, he perceived that the shoemaker’s bench
+and tools were put aside again, and that the Doctor himself sat reading
+at the window. He was in his usual morning dress, and his face (which
+Mr. Lorry could distinctly see), though still very pale, was calmly
+studious and attentive.
+
+Even when he had satisfied himself that he was awake, Mr. Lorry felt
+giddily uncertain for some few moments whether the late shoemaking might
+not be a disturbed dream of his own; for, did not his eyes show him his
+friend before him in his accustomed clothing and aspect, and employed
+as usual; and was there any sign within their range, that the change of
+which he had so strong an impression had actually happened?
+
+It was but the inquiry of his first confusion and astonishment, the
+answer being obvious. If the impression were not produced by a real
+corresponding and sufficient cause, how came he, Jarvis Lorry, there?
+How came he to have fallen asleep, in his clothes, on the sofa in Doctor
+Manette’s consulting-room, and to be debating these points outside the
+Doctor’s bedroom door in the early morning?
+
+Within a few minutes, Miss Pross stood whispering at his side. If he
+had had any particle of doubt left, her talk would of necessity have
+resolved it; but he was by that time clear-headed, and had none.
+He advised that they should let the time go by until the regular
+breakfast-hour, and should then meet the Doctor as if nothing unusual
+had occurred. If he appeared to be in his customary state of mind, Mr.
+Lorry would then cautiously proceed to seek direction and guidance from
+the opinion he had been, in his anxiety, so anxious to obtain.
+
+Miss Pross, submitting herself to his judgment, the scheme was worked
+out with care. Having abundance of time for his usual methodical
+toilette, Mr. Lorry presented himself at the breakfast-hour in his usual
+white linen, and with his usual neat leg. The Doctor was summoned in the
+usual way, and came to breakfast.
+
+So far as it was possible to comprehend him without overstepping those
+delicate and gradual approaches which Mr. Lorry felt to be the only safe
+advance, he at first supposed that his daughter’s marriage had taken
+place yesterday. An incidental allusion, purposely thrown out, to
+the day of the week, and the day of the month, set him thinking and
+counting, and evidently made him uneasy. In all other respects, however,
+he was so composedly himself, that Mr. Lorry determined to have the aid
+he sought. And that aid was his own.
+
+Therefore, when the breakfast was done and cleared away, and he and the
+Doctor were left together, Mr. Lorry said, feelingly:
+
+“My dear Manette, I am anxious to have your opinion, in confidence, on a
+very curious case in which I am deeply interested; that is to say, it is
+very curious to me; perhaps, to your better information it may be less
+so.”
+
+Glancing at his hands, which were discoloured by his late work, the
+Doctor looked troubled, and listened attentively. He had already glanced
+at his hands more than once.
+
+“Doctor Manette,” said Mr. Lorry, touching him affectionately on the
+arm, “the case is the case of a particularly dear friend of mine. Pray
+give your mind to it, and advise me well for his sake--and above all,
+for his daughter’s--his daughter’s, my dear Manette.”
+
+“If I understand,” said the Doctor, in a subdued tone, “some mental
+shock--?”
+
+“Yes!”
+
+“Be explicit,” said the Doctor. “Spare no detail.”
+
+Mr. Lorry saw that they understood one another, and proceeded.
+
+“My dear Manette, it is the case of an old and a prolonged shock,
+of great acuteness and severity to the affections, the feelings,
+the--the--as you express it--the mind. The mind. It is the case of a
+shock under which the sufferer was borne down, one cannot say for how
+long, because I believe he cannot calculate the time himself, and there
+are no other means of getting at it. It is the case of a shock from
+which the sufferer recovered, by a process that he cannot trace
+himself--as I once heard him publicly relate in a striking manner. It is
+the case of a shock from which he has recovered, so completely, as to
+be a highly intelligent man, capable of close application of mind, and
+great exertion of body, and of constantly making fresh additions to his
+stock of knowledge, which was already very large. But, unfortunately,
+there has been,” he paused and took a deep breath--“a slight relapse.”
+
+The Doctor, in a low voice, asked, “Of how long duration?”
+
+“Nine days and nights.”
+
+“How did it show itself? I infer,” glancing at his hands again, “in the
+resumption of some old pursuit connected with the shock?”
+
+“That is the fact.”
+
+“Now, did you ever see him,” asked the Doctor, distinctly and
+collectedly, though in the same low voice, “engaged in that pursuit
+originally?”
+
+“Once.”
+
+“And when the relapse fell on him, was he in most respects--or in all
+respects--as he was then?”
+
+“I think in all respects.”
+
+“You spoke of his daughter. Does his daughter know of the relapse?”
+
+“No. It has been kept from her, and I hope will always be kept from her.
+It is known only to myself, and to one other who may be trusted.”
+
+The Doctor grasped his hand, and murmured, “That was very kind. That was
+very thoughtful!” Mr. Lorry grasped his hand in return, and neither of
+the two spoke for a little while.
+
+“Now, my dear Manette,” said Mr. Lorry, at length, in his most
+considerate and most affectionate way, “I am a mere man of business,
+and unfit to cope with such intricate and difficult matters. I do not
+possess the kind of information necessary; I do not possess the kind of
+intelligence; I want guiding. There is no man in this world on whom
+I could so rely for right guidance, as on you. Tell me, how does this
+relapse come about? Is there danger of another? Could a repetition of it
+be prevented? How should a repetition of it be treated? How does it come
+about at all? What can I do for my friend? No man ever can have been
+more desirous in his heart to serve a friend, than I am to serve mine,
+if I knew how.
+
+“But I don’t know how to originate, in such a case. If your sagacity,
+knowledge, and experience, could put me on the right track, I might be
+able to do so much; unenlightened and undirected, I can do so little.
+Pray discuss it with me; pray enable me to see it a little more clearly,
+and teach me how to be a little more useful.”
+
+Doctor Manette sat meditating after these earnest words were spoken, and
+Mr. Lorry did not press him.
+
+“I think it probable,” said the Doctor, breaking silence with an effort,
+“that the relapse you have described, my dear friend, was not quite
+unforeseen by its subject.”
+
+“Was it dreaded by him?” Mr. Lorry ventured to ask.
+
+“Very much.” He said it with an involuntary shudder.
+
+“You have no idea how such an apprehension weighs on the sufferer’s
+mind, and how difficult--how almost impossible--it is, for him to force
+himself to utter a word upon the topic that oppresses him.”
+
+“Would he,” asked Mr. Lorry, “be sensibly relieved if he could prevail
+upon himself to impart that secret brooding to any one, when it is on
+him?”
+
+“I think so. But it is, as I have told you, next to impossible. I even
+believe it--in some cases--to be quite impossible.”
+
+“Now,” said Mr. Lorry, gently laying his hand on the Doctor’s arm again,
+after a short silence on both sides, “to what would you refer this
+attack?”
+
+“I believe,” returned Doctor Manette, “that there had been a strong and
+extraordinary revival of the train of thought and remembrance that
+was the first cause of the malady. Some intense associations of a most
+distressing nature were vividly recalled, I think. It is probable that
+there had long been a dread lurking in his mind, that those associations
+would be recalled--say, under certain circumstances--say, on a
+particular occasion. He tried to prepare himself in vain; perhaps the
+effort to prepare himself made him less able to bear it.”
+
+“Would he remember what took place in the relapse?” asked Mr. Lorry,
+with natural hesitation.
+
+The Doctor looked desolately round the room, shook his head, and
+answered, in a low voice, “Not at all.”
+
+“Now, as to the future,” hinted Mr. Lorry.
+
+“As to the future,” said the Doctor, recovering firmness, “I should have
+great hope. As it pleased Heaven in its mercy to restore him so soon, I
+should have great hope. He, yielding under the pressure of a complicated
+something, long dreaded and long vaguely foreseen and contended against,
+and recovering after the cloud had burst and passed, I should hope that
+the worst was over.”
+
+“Well, well! That’s good comfort. I am thankful!” said Mr. Lorry.
+
+“I am thankful!” repeated the Doctor, bending his head with reverence.
+
+“There are two other points,” said Mr. Lorry, “on which I am anxious to
+be instructed. I may go on?”
+
+“You cannot do your friend a better service.” The Doctor gave him his
+hand.
+
+“To the first, then. He is of a studious habit, and unusually energetic;
+he applies himself with great ardour to the acquisition of professional
+knowledge, to the conducting of experiments, to many things. Now, does
+he do too much?”
+
+“I think not. It may be the character of his mind, to be always in
+singular need of occupation. That may be, in part, natural to it; in
+part, the result of affliction. The less it was occupied with healthy
+things, the more it would be in danger of turning in the unhealthy
+direction. He may have observed himself, and made the discovery.”
+
+“You are sure that he is not under too great a strain?”
+
+“I think I am quite sure of it.”
+
+“My dear Manette, if he were overworked now--”
+
+“My dear Lorry, I doubt if that could easily be. There has been a
+violent stress in one direction, and it needs a counterweight.”
+
+“Excuse me, as a persistent man of business. Assuming for a moment,
+that he _was_ overworked; it would show itself in some renewal of this
+disorder?”
+
+“I do not think so. I do not think,” said Doctor Manette with the
+firmness of self-conviction, “that anything but the one train of
+association would renew it. I think that, henceforth, nothing but some
+extraordinary jarring of that chord could renew it. After what has
+happened, and after his recovery, I find it difficult to imagine any
+such violent sounding of that string again. I trust, and I almost
+believe, that the circumstances likely to renew it are exhausted.”
+
+He spoke with the diffidence of a man who knew how slight a thing
+would overset the delicate organisation of the mind, and yet with the
+confidence of a man who had slowly won his assurance out of personal
+endurance and distress. It was not for his friend to abate that
+confidence. He professed himself more relieved and encouraged than he
+really was, and approached his second and last point. He felt it to
+be the most difficult of all; but, remembering his old Sunday morning
+conversation with Miss Pross, and remembering what he had seen in the
+last nine days, he knew that he must face it.
+
+“The occupation resumed under the influence of this passing affliction
+so happily recovered from,” said Mr. Lorry, clearing his throat, “we
+will call--Blacksmith’s work, Blacksmith’s work. We will say, to put a
+case and for the sake of illustration, that he had been used, in his bad
+time, to work at a little forge. We will say that he was unexpectedly
+found at his forge again. Is it not a pity that he should keep it by
+him?”
+
+The Doctor shaded his forehead with his hand, and beat his foot
+nervously on the ground.
+
+“He has always kept it by him,” said Mr. Lorry, with an anxious look at
+his friend. “Now, would it not be better that he should let it go?”
+
+Still, the Doctor, with shaded forehead, beat his foot nervously on the
+ground.
+
+“You do not find it easy to advise me?” said Mr. Lorry. “I quite
+understand it to be a nice question. And yet I think--” And there he
+shook his head, and stopped.
+
+“You see,” said Doctor Manette, turning to him after an uneasy pause,
+“it is very hard to explain, consistently, the innermost workings
+of this poor man’s mind. He once yearned so frightfully for that
+occupation, and it was so welcome when it came; no doubt it relieved
+his pain so much, by substituting the perplexity of the fingers for
+the perplexity of the brain, and by substituting, as he became more
+practised, the ingenuity of the hands, for the ingenuity of the mental
+torture; that he has never been able to bear the thought of putting it
+quite out of his reach. Even now, when I believe he is more hopeful of
+himself than he has ever been, and even speaks of himself with a kind
+of confidence, the idea that he might need that old employment, and not
+find it, gives him a sudden sense of terror, like that which one may
+fancy strikes to the heart of a lost child.”
+
+He looked like his illustration, as he raised his eyes to Mr. Lorry’s
+face.
+
+“But may not--mind! I ask for information, as a plodding man of business
+who only deals with such material objects as guineas, shillings, and
+bank-notes--may not the retention of the thing involve the retention of
+the idea? If the thing were gone, my dear Manette, might not the fear go
+with it? In short, is it not a concession to the misgiving, to keep the
+forge?”
+
+There was another silence.
+
+“You see, too,” said the Doctor, tremulously, “it is such an old
+companion.”
+
+“I would not keep it,” said Mr. Lorry, shaking his head; for he gained
+in firmness as he saw the Doctor disquieted. “I would recommend him to
+sacrifice it. I only want your authority. I am sure it does no good.
+Come! Give me your authority, like a dear good man. For his daughter’s
+sake, my dear Manette!”
+
+Very strange to see what a struggle there was within him!
+
+“In her name, then, let it be done; I sanction it. But, I would not take
+it away while he was present. Let it be removed when he is not there;
+let him miss his old companion after an absence.”
+
+Mr. Lorry readily engaged for that, and the conference was ended. They
+passed the day in the country, and the Doctor was quite restored. On the
+three following days he remained perfectly well, and on the fourteenth
+day he went away to join Lucie and her husband. The precaution that
+had been taken to account for his silence, Mr. Lorry had previously
+explained to him, and he had written to Lucie in accordance with it, and
+she had no suspicions.
+
+On the night of the day on which he left the house, Mr. Lorry went into
+his room with a chopper, saw, chisel, and hammer, attended by Miss Pross
+carrying a light. There, with closed doors, and in a mysterious and
+guilty manner, Mr. Lorry hacked the shoemaker’s bench to pieces, while
+Miss Pross held the candle as if she were assisting at a murder--for
+which, indeed, in her grimness, she was no unsuitable figure. The
+burning of the body (previously reduced to pieces convenient for the
+purpose) was commenced without delay in the kitchen fire; and the tools,
+shoes, and leather, were buried in the garden. So wicked do destruction
+and secrecy appear to honest minds, that Mr. Lorry and Miss Pross,
+while engaged in the commission of their deed and in the removal of its
+traces, almost felt, and almost looked, like accomplices in a horrible
+crime.
+
+
+
+
+XX. A Plea
+
+
+When the newly-married pair came home, the first person who appeared, to
+offer his congratulations, was Sydney Carton. They had not been at home
+many hours, when he presented himself. He was not improved in habits, or
+in looks, or in manner; but there was a certain rugged air of fidelity
+about him, which was new to the observation of Charles Darnay.
+
+He watched his opportunity of taking Darnay aside into a window, and of
+speaking to him when no one overheard.
+
+“Mr. Darnay,” said Carton, “I wish we might be friends.”
+
+“We are already friends, I hope.”
+
+“You are good enough to say so, as a fashion of speech; but, I don’t
+mean any fashion of speech. Indeed, when I say I wish we might be
+friends, I scarcely mean quite that, either.”
+
+Charles Darnay--as was natural--asked him, in all good-humour and
+good-fellowship, what he did mean?
+
+“Upon my life,” said Carton, smiling, “I find that easier to comprehend
+in my own mind, than to convey to yours. However, let me try. You
+remember a certain famous occasion when I was more drunk than--than
+usual?”
+
+“I remember a certain famous occasion when you forced me to confess that
+you had been drinking.”
+
+“I remember it too. The curse of those occasions is heavy upon me, for I
+always remember them. I hope it may be taken into account one day,
+when all days are at an end for me! Don’t be alarmed; I am not going to
+preach.”
+
+“I am not at all alarmed. Earnestness in you, is anything but alarming
+to me.”
+
+“Ah!” said Carton, with a careless wave of his hand, as if he waved that
+away. “On the drunken occasion in question (one of a large number, as
+you know), I was insufferable about liking you, and not liking you. I
+wish you would forget it.”
+
+“I forgot it long ago.”
+
+“Fashion of speech again! But, Mr. Darnay, oblivion is not so easy to
+me, as you represent it to be to you. I have by no means forgotten it,
+and a light answer does not help me to forget it.”
+
+“If it was a light answer,” returned Darnay, “I beg your forgiveness
+for it. I had no other object than to turn a slight thing, which, to my
+surprise, seems to trouble you too much, aside. I declare to you, on the
+faith of a gentleman, that I have long dismissed it from my mind. Good
+Heaven, what was there to dismiss! Have I had nothing more important to
+remember, in the great service you rendered me that day?”
+
+“As to the great service,” said Carton, “I am bound to avow to you, when
+you speak of it in that way, that it was mere professional claptrap, I
+don’t know that I cared what became of you, when I rendered it.--Mind! I
+say when I rendered it; I am speaking of the past.”
+
+“You make light of the obligation,” returned Darnay, “but I will not
+quarrel with _your_ light answer.”
+
+“Genuine truth, Mr. Darnay, trust me! I have gone aside from my purpose;
+I was speaking about our being friends. Now, you know me; you know I am
+incapable of all the higher and better flights of men. If you doubt it,
+ask Stryver, and he’ll tell you so.”
+
+“I prefer to form my own opinion, without the aid of his.”
+
+“Well! At any rate you know me as a dissolute dog, who has never done
+any good, and never will.”
+
+“I don’t know that you ‘never will.’”
+
+“But I do, and you must take my word for it. Well! If you could endure
+to have such a worthless fellow, and a fellow of such indifferent
+reputation, coming and going at odd times, I should ask that I might be
+permitted to come and go as a privileged person here; that I might
+be regarded as an useless (and I would add, if it were not for the
+resemblance I detected between you and me, an unornamental) piece of
+furniture, tolerated for its old service, and taken no notice of. I
+doubt if I should abuse the permission. It is a hundred to one if I
+should avail myself of it four times in a year. It would satisfy me, I
+dare say, to know that I had it.”
+
+“Will you try?”
+
+“That is another way of saying that I am placed on the footing I have
+indicated. I thank you, Darnay. I may use that freedom with your name?”
+
+“I think so, Carton, by this time.”
+
+They shook hands upon it, and Sydney turned away. Within a minute
+afterwards, he was, to all outward appearance, as unsubstantial as ever.
+
+When he was gone, and in the course of an evening passed with Miss
+Pross, the Doctor, and Mr. Lorry, Charles Darnay made some mention of
+this conversation in general terms, and spoke of Sydney Carton as a
+problem of carelessness and recklessness. He spoke of him, in short, not
+bitterly or meaning to bear hard upon him, but as anybody might who saw
+him as he showed himself.
+
+He had no idea that this could dwell in the thoughts of his fair young
+wife; but, when he afterwards joined her in their own rooms, he found
+her waiting for him with the old pretty lifting of the forehead strongly
+marked.
+
+“We are thoughtful to-night!” said Darnay, drawing his arm about her.
+
+“Yes, dearest Charles,” with her hands on his breast, and the inquiring
+and attentive expression fixed upon him; “we are rather thoughtful
+to-night, for we have something on our mind to-night.”
+
+“What is it, my Lucie?”
+
+“Will you promise not to press one question on me, if I beg you not to
+ask it?”
+
+“Will I promise? What will I not promise to my Love?”
+
+What, indeed, with his hand putting aside the golden hair from the
+cheek, and his other hand against the heart that beat for him!
+
+“I think, Charles, poor Mr. Carton deserves more consideration and
+respect than you expressed for him to-night.”
+
+“Indeed, my own? Why so?”
+
+“That is what you are not to ask me. But I think--I know--he does.”
+
+“If you know it, it is enough. What would you have me do, my Life?”
+
+“I would ask you, dearest, to be very generous with him always, and very
+lenient on his faults when he is not by. I would ask you to believe that
+he has a heart he very, very seldom reveals, and that there are deep
+wounds in it. My dear, I have seen it bleeding.”
+
+“It is a painful reflection to me,” said Charles Darnay, quite
+astounded, “that I should have done him any wrong. I never thought this
+of him.”
+
+“My husband, it is so. I fear he is not to be reclaimed; there is
+scarcely a hope that anything in his character or fortunes is reparable
+now. But, I am sure that he is capable of good things, gentle things,
+even magnanimous things.”
+
+She looked so beautiful in the purity of her faith in this lost man,
+that her husband could have looked at her as she was for hours.
+
+“And, O my dearest Love!” she urged, clinging nearer to him, laying her
+head upon his breast, and raising her eyes to his, “remember how strong
+we are in our happiness, and how weak he is in his misery!”
+
+The supplication touched him home. “I will always remember it, dear
+Heart! I will remember it as long as I live.”
+
+He bent over the golden head, and put the rosy lips to his, and folded
+her in his arms. If one forlorn wanderer then pacing the dark streets,
+could have heard her innocent disclosure, and could have seen the drops
+of pity kissed away by her husband from the soft blue eyes so loving of
+that husband, he might have cried to the night--and the words would not
+have parted from his lips for the first time--
+
+“God bless her for her sweet compassion!”
+
+
+
+
+XXI. Echoing Footsteps
+
+
+A wonderful corner for echoes, it has been remarked, that corner where
+the Doctor lived. Ever busily winding the golden thread which bound
+her husband, and her father, and herself, and her old directress and
+companion, in a life of quiet bliss, Lucie sat in the still house in
+the tranquilly resounding corner, listening to the echoing footsteps of
+years.
+
+At first, there were times, though she was a perfectly happy young wife,
+when her work would slowly fall from her hands, and her eyes would be
+dimmed. For, there was something coming in the echoes, something light,
+afar off, and scarcely audible yet, that stirred her heart too much.
+Fluttering hopes and doubts--hopes, of a love as yet unknown to her:
+doubts, of her remaining upon earth, to enjoy that new delight--divided
+her breast. Among the echoes then, there would arise the sound of
+footsteps at her own early grave; and thoughts of the husband who would
+be left so desolate, and who would mourn for her so much, swelled to her
+eyes, and broke like waves.
+
+That time passed, and her little Lucie lay on her bosom. Then, among the
+advancing echoes, there was the tread of her tiny feet and the sound of
+her prattling words. Let greater echoes resound as they would, the young
+mother at the cradle side could always hear those coming. They came, and
+the shady house was sunny with a child’s laugh, and the Divine friend of
+children, to whom in her trouble she had confided hers, seemed to take
+her child in his arms, as He took the child of old, and made it a sacred
+joy to her.
+
+Ever busily winding the golden thread that bound them all together,
+weaving the service of her happy influence through the tissue of all
+their lives, and making it predominate nowhere, Lucie heard in the
+echoes of years none but friendly and soothing sounds. Her husband’s
+step was strong and prosperous among them; her father’s firm and equal.
+Lo, Miss Pross, in harness of string, awakening the echoes, as an
+unruly charger, whip-corrected, snorting and pawing the earth under the
+plane-tree in the garden!
+
+Even when there were sounds of sorrow among the rest, they were not
+harsh nor cruel. Even when golden hair, like her own, lay in a halo on a
+pillow round the worn face of a little boy, and he said, with a radiant
+smile, “Dear papa and mamma, I am very sorry to leave you both, and to
+leave my pretty sister; but I am called, and I must go!” those were not
+tears all of agony that wetted his young mother’s cheek, as the spirit
+departed from her embrace that had been entrusted to it. Suffer them and
+forbid them not. They see my Father’s face. O Father, blessed words!
+
+Thus, the rustling of an Angel’s wings got blended with the other
+echoes, and they were not wholly of earth, but had in them that breath
+of Heaven. Sighs of the winds that blew over a little garden-tomb were
+mingled with them also, and both were audible to Lucie, in a hushed
+murmur--like the breathing of a summer sea asleep upon a sandy shore--as
+the little Lucie, comically studious at the task of the morning, or
+dressing a doll at her mother’s footstool, chattered in the tongues of
+the Two Cities that were blended in her life.
+
+The Echoes rarely answered to the actual tread of Sydney Carton. Some
+half-dozen times a year, at most, he claimed his privilege of coming in
+uninvited, and would sit among them through the evening, as he had once
+done often. He never came there heated with wine. And one other thing
+regarding him was whispered in the echoes, which has been whispered by
+all true echoes for ages and ages.
+
+No man ever really loved a woman, lost her, and knew her with a
+blameless though an unchanged mind, when she was a wife and a mother,
+but her children had a strange sympathy with him--an instinctive
+delicacy of pity for him. What fine hidden sensibilities are touched in
+such a case, no echoes tell; but it is so, and it was so here. Carton
+was the first stranger to whom little Lucie held out her chubby arms,
+and he kept his place with her as she grew. The little boy had spoken of
+him, almost at the last. “Poor Carton! Kiss him for me!”
+
+Mr. Stryver shouldered his way through the law, like some great engine
+forcing itself through turbid water, and dragged his useful friend in
+his wake, like a boat towed astern. As the boat so favoured is usually
+in a rough plight, and mostly under water, so, Sydney had a swamped
+life of it. But, easy and strong custom, unhappily so much easier and
+stronger in him than any stimulating sense of desert or disgrace, made
+it the life he was to lead; and he no more thought of emerging from his
+state of lion’s jackal, than any real jackal may be supposed to think of
+rising to be a lion. Stryver was rich; had married a florid widow with
+property and three boys, who had nothing particularly shining about them
+but the straight hair of their dumpling heads.
+
+These three young gentlemen, Mr. Stryver, exuding patronage of the most
+offensive quality from every pore, had walked before him like three
+sheep to the quiet corner in Soho, and had offered as pupils to
+Lucie’s husband: delicately saying “Halloa! here are three lumps of
+bread-and-cheese towards your matrimonial picnic, Darnay!” The polite
+rejection of the three lumps of bread-and-cheese had quite bloated Mr.
+Stryver with indignation, which he afterwards turned to account in the
+training of the young gentlemen, by directing them to beware of the
+pride of Beggars, like that tutor-fellow. He was also in the habit of
+declaiming to Mrs. Stryver, over his full-bodied wine, on the arts
+Mrs. Darnay had once put in practice to “catch” him, and on the
+diamond-cut-diamond arts in himself, madam, which had rendered him “not
+to be caught.” Some of his King’s Bench familiars, who were occasionally
+parties to the full-bodied wine and the lie, excused him for the
+latter by saying that he had told it so often, that he believed
+it himself--which is surely such an incorrigible aggravation of an
+originally bad offence, as to justify any such offender’s being carried
+off to some suitably retired spot, and there hanged out of the way.
+
+These were among the echoes to which Lucie, sometimes pensive, sometimes
+amused and laughing, listened in the echoing corner, until her little
+daughter was six years old. How near to her heart the echoes of her
+child’s tread came, and those of her own dear father’s, always active
+and self-possessed, and those of her dear husband’s, need not be told.
+Nor, how the lightest echo of their united home, directed by herself
+with such a wise and elegant thrift that it was more abundant than any
+waste, was music to her. Nor, how there were echoes all about her, sweet
+in her ears, of the many times her father had told her that he found her
+more devoted to him married (if that could be) than single, and of the
+many times her husband had said to her that no cares and duties seemed
+to divide her love for him or her help to him, and asked her “What is
+the magic secret, my darling, of your being everything to all of us,
+as if there were only one of us, yet never seeming to be hurried, or to
+have too much to do?”
+
+But, there were other echoes, from a distance, that rumbled menacingly
+in the corner all through this space of time. And it was now, about
+little Lucie’s sixth birthday, that they began to have an awful sound,
+as of a great storm in France with a dreadful sea rising.
+
+On a night in mid-July, one thousand seven hundred and eighty-nine, Mr.
+Lorry came in late, from Tellson’s, and sat himself down by Lucie and
+her husband in the dark window. It was a hot, wild night, and they were
+all three reminded of the old Sunday night when they had looked at the
+lightning from the same place.
+
+“I began to think,” said Mr. Lorry, pushing his brown wig back, “that
+I should have to pass the night at Tellson’s. We have been so full of
+business all day, that we have not known what to do first, or which way
+to turn. There is such an uneasiness in Paris, that we have actually a
+run of confidence upon us! Our customers over there, seem not to be able
+to confide their property to us fast enough. There is positively a mania
+among some of them for sending it to England.”
+
+“That has a bad look,” said Darnay--
+
+“A bad look, you say, my dear Darnay? Yes, but we don’t know what reason
+there is in it. People are so unreasonable! Some of us at Tellson’s are
+getting old, and we really can’t be troubled out of the ordinary course
+without due occasion.”
+
+“Still,” said Darnay, “you know how gloomy and threatening the sky is.”
+
+“I know that, to be sure,” assented Mr. Lorry, trying to persuade
+himself that his sweet temper was soured, and that he grumbled, “but I
+am determined to be peevish after my long day’s botheration. Where is
+Manette?”
+
+“Here he is,” said the Doctor, entering the dark room at the moment.
+
+“I am quite glad you are at home; for these hurries and forebodings by
+which I have been surrounded all day long, have made me nervous without
+reason. You are not going out, I hope?”
+
+“No; I am going to play backgammon with you, if you like,” said the
+Doctor.
+
+“I don’t think I do like, if I may speak my mind. I am not fit to be
+pitted against you to-night. Is the teaboard still there, Lucie? I can’t
+see.”
+
+“Of course, it has been kept for you.”
+
+“Thank ye, my dear. The precious child is safe in bed?”
+
+“And sleeping soundly.”
+
+“That’s right; all safe and well! I don’t know why anything should be
+otherwise than safe and well here, thank God; but I have been so put out
+all day, and I am not as young as I was! My tea, my dear! Thank ye. Now,
+come and take your place in the circle, and let us sit quiet, and hear
+the echoes about which you have your theory.”
+
+“Not a theory; it was a fancy.”
+
+“A fancy, then, my wise pet,” said Mr. Lorry, patting her hand. “They
+are very numerous and very loud, though, are they not? Only hear them!”
+
+Headlong, mad, and dangerous footsteps to force their way into anybody’s
+life, footsteps not easily made clean again if once stained red, the
+footsteps raging in Saint Antoine afar off, as the little circle sat in
+the dark London window.
+
+Saint Antoine had been, that morning, a vast dusky mass of scarecrows
+heaving to and fro, with frequent gleams of light above the billowy
+heads, where steel blades and bayonets shone in the sun. A tremendous
+roar arose from the throat of Saint Antoine, and a forest of naked arms
+struggled in the air like shrivelled branches of trees in a winter wind:
+all the fingers convulsively clutching at every weapon or semblance of a
+weapon that was thrown up from the depths below, no matter how far off.
+
+Who gave them out, whence they last came, where they began, through what
+agency they crookedly quivered and jerked, scores at a time, over the
+heads of the crowd, like a kind of lightning, no eye in the throng could
+have told; but, muskets were being distributed--so were cartridges,
+powder, and ball, bars of iron and wood, knives, axes, pikes, every
+weapon that distracted ingenuity could discover or devise. People who
+could lay hold of nothing else, set themselves with bleeding hands to
+force stones and bricks out of their places in walls. Every pulse and
+heart in Saint Antoine was on high-fever strain and at high-fever heat.
+Every living creature there held life as of no account, and was demented
+with a passionate readiness to sacrifice it.
+
+As a whirlpool of boiling waters has a centre point, so, all this raging
+circled round Defarge’s wine-shop, and every human drop in the caldron
+had a tendency to be sucked towards the vortex where Defarge himself,
+already begrimed with gunpowder and sweat, issued orders, issued arms,
+thrust this man back, dragged this man forward, disarmed one to arm
+another, laboured and strove in the thickest of the uproar.
+
+“Keep near to me, Jacques Three,” cried Defarge; “and do you, Jacques
+One and Two, separate and put yourselves at the head of as many of these
+patriots as you can. Where is my wife?”
+
+“Eh, well! Here you see me!” said madame, composed as ever, but not
+knitting to-day. Madame’s resolute right hand was occupied with an axe,
+in place of the usual softer implements, and in her girdle were a pistol
+and a cruel knife.
+
+“Where do you go, my wife?”
+
+“I go,” said madame, “with you at present. You shall see me at the head
+of women, by-and-bye.”
+
+“Come, then!” cried Defarge, in a resounding voice. “Patriots and
+friends, we are ready! The Bastille!”
+
+With a roar that sounded as if all the breath in France had been shaped
+into the detested word, the living sea rose, wave on wave, depth on
+depth, and overflowed the city to that point. Alarm-bells ringing, drums
+beating, the sea raging and thundering on its new beach, the attack
+began.
+
+Deep ditches, double drawbridge, massive stone walls, eight great
+towers, cannon, muskets, fire and smoke. Through the fire and through
+the smoke--in the fire and in the smoke, for the sea cast him up against
+a cannon, and on the instant he became a cannonier--Defarge of the
+wine-shop worked like a manful soldier, Two fierce hours.
+
+Deep ditch, single drawbridge, massive stone walls, eight great towers,
+cannon, muskets, fire and smoke. One drawbridge down! “Work, comrades
+all, work! Work, Jacques One, Jacques Two, Jacques One Thousand, Jacques
+Two Thousand, Jacques Five-and-Twenty Thousand; in the name of all
+the Angels or the Devils--which you prefer--work!” Thus Defarge of the
+wine-shop, still at his gun, which had long grown hot.
+
+“To me, women!” cried madame his wife. “What! We can kill as well as
+the men when the place is taken!” And to her, with a shrill thirsty
+cry, trooping women variously armed, but all armed alike in hunger and
+revenge.
+
+Cannon, muskets, fire and smoke; but, still the deep ditch, the single
+drawbridge, the massive stone walls, and the eight great towers. Slight
+displacements of the raging sea, made by the falling wounded. Flashing
+weapons, blazing torches, smoking waggonloads of wet straw, hard work
+at neighbouring barricades in all directions, shrieks, volleys,
+execrations, bravery without stint, boom smash and rattle, and the
+furious sounding of the living sea; but, still the deep ditch, and the
+single drawbridge, and the massive stone walls, and the eight great
+towers, and still Defarge of the wine-shop at his gun, grown doubly hot
+by the service of Four fierce hours.
+
+A white flag from within the fortress, and a parley--this dimly
+perceptible through the raging storm, nothing audible in it--suddenly
+the sea rose immeasurably wider and higher, and swept Defarge of the
+wine-shop over the lowered drawbridge, past the massive stone outer
+walls, in among the eight great towers surrendered!
+
+So resistless was the force of the ocean bearing him on, that even to
+draw his breath or turn his head was as impracticable as if he had been
+struggling in the surf at the South Sea, until he was landed in the
+outer courtyard of the Bastille. There, against an angle of a wall, he
+made a struggle to look about him. Jacques Three was nearly at his side;
+Madame Defarge, still heading some of her women, was visible in the
+inner distance, and her knife was in her hand. Everywhere was tumult,
+exultation, deafening and maniacal bewilderment, astounding noise, yet
+furious dumb-show.
+
+“The Prisoners!”
+
+“The Records!”
+
+“The secret cells!”
+
+“The instruments of torture!”
+
+“The Prisoners!”
+
+Of all these cries, and ten thousand incoherences, “The Prisoners!” was
+the cry most taken up by the sea that rushed in, as if there were an
+eternity of people, as well as of time and space. When the foremost
+billows rolled past, bearing the prison officers with them, and
+threatening them all with instant death if any secret nook remained
+undisclosed, Defarge laid his strong hand on the breast of one of
+these men--a man with a grey head, who had a lighted torch in his
+hand--separated him from the rest, and got him between himself and the
+wall.
+
+“Show me the North Tower!” said Defarge. “Quick!”
+
+“I will faithfully,” replied the man, “if you will come with me. But
+there is no one there.”
+
+“What is the meaning of One Hundred and Five, North Tower?” asked
+Defarge. “Quick!”
+
+“The meaning, monsieur?”
+
+“Does it mean a captive, or a place of captivity? Or do you mean that I
+shall strike you dead?”
+
+“Kill him!” croaked Jacques Three, who had come close up.
+
+“Monsieur, it is a cell.”
+
+“Show it me!”
+
+“Pass this way, then.”
+
+Jacques Three, with his usual craving on him, and evidently disappointed
+by the dialogue taking a turn that did not seem to promise bloodshed,
+held by Defarge’s arm as he held by the turnkey’s. Their three heads had
+been close together during this brief discourse, and it had been as much
+as they could do to hear one another, even then: so tremendous was the
+noise of the living ocean, in its irruption into the Fortress, and
+its inundation of the courts and passages and staircases. All around
+outside, too, it beat the walls with a deep, hoarse roar, from which,
+occasionally, some partial shouts of tumult broke and leaped into the
+air like spray.
+
+Through gloomy vaults where the light of day had never shone, past
+hideous doors of dark dens and cages, down cavernous flights of steps,
+and again up steep rugged ascents of stone and brick, more like dry
+waterfalls than staircases, Defarge, the turnkey, and Jacques Three,
+linked hand and arm, went with all the speed they could make. Here and
+there, especially at first, the inundation started on them and swept by;
+but when they had done descending, and were winding and climbing up a
+tower, they were alone. Hemmed in here by the massive thickness of walls
+and arches, the storm within the fortress and without was only audible
+to them in a dull, subdued way, as if the noise out of which they had
+come had almost destroyed their sense of hearing.
+
+The turnkey stopped at a low door, put a key in a clashing lock, swung
+the door slowly open, and said, as they all bent their heads and passed
+in:
+
+“One hundred and five, North Tower!”
+
+There was a small, heavily-grated, unglazed window high in the wall,
+with a stone screen before it, so that the sky could be only seen by
+stooping low and looking up. There was a small chimney, heavily barred
+across, a few feet within. There was a heap of old feathery wood-ashes
+on the hearth. There was a stool, and table, and a straw bed. There were
+the four blackened walls, and a rusted iron ring in one of them.
+
+“Pass that torch slowly along these walls, that I may see them,” said
+Defarge to the turnkey.
+
+The man obeyed, and Defarge followed the light closely with his eyes.
+
+“Stop!--Look here, Jacques!”
+
+“A. M.!” croaked Jacques Three, as he read greedily.
+
+“Alexandre Manette,” said Defarge in his ear, following the letters
+with his swart forefinger, deeply engrained with gunpowder. “And here he
+wrote ‘a poor physician.’ And it was he, without doubt, who scratched
+a calendar on this stone. What is that in your hand? A crowbar? Give it
+me!”
+
+He had still the linstock of his gun in his own hand. He made a sudden
+exchange of the two instruments, and turning on the worm-eaten stool and
+table, beat them to pieces in a few blows.
+
+“Hold the light higher!” he said, wrathfully, to the turnkey. “Look
+among those fragments with care, Jacques. And see! Here is my knife,”
+ throwing it to him; “rip open that bed, and search the straw. Hold the
+light higher, you!”
+
+With a menacing look at the turnkey he crawled upon the hearth, and,
+peering up the chimney, struck and prised at its sides with the crowbar,
+and worked at the iron grating across it. In a few minutes, some mortar
+and dust came dropping down, which he averted his face to avoid; and
+in it, and in the old wood-ashes, and in a crevice in the chimney
+into which his weapon had slipped or wrought itself, he groped with a
+cautious touch.
+
+“Nothing in the wood, and nothing in the straw, Jacques?”
+
+“Nothing.”
+
+“Let us collect them together, in the middle of the cell. So! Light
+them, you!”
+
+The turnkey fired the little pile, which blazed high and hot. Stooping
+again to come out at the low-arched door, they left it burning, and
+retraced their way to the courtyard; seeming to recover their sense
+of hearing as they came down, until they were in the raging flood once
+more.
+
+They found it surging and tossing, in quest of Defarge himself. Saint
+Antoine was clamorous to have its wine-shop keeper foremost in the guard
+upon the governor who had defended the Bastille and shot the people.
+Otherwise, the governor would not be marched to the Hotel de Ville for
+judgment. Otherwise, the governor would escape, and the people’s
+blood (suddenly of some value, after many years of worthlessness) be
+unavenged.
+
+In the howling universe of passion and contention that seemed to
+encompass this grim old officer conspicuous in his grey coat and red
+decoration, there was but one quite steady figure, and that was a
+woman’s. “See, there is my husband!” she cried, pointing him out.
+“See Defarge!” She stood immovable close to the grim old officer, and
+remained immovable close to him; remained immovable close to him through
+the streets, as Defarge and the rest bore him along; remained immovable
+close to him when he was got near his destination, and began to
+be struck at from behind; remained immovable close to him when the
+long-gathering rain of stabs and blows fell heavy; was so close to him
+when he dropped dead under it, that, suddenly animated, she put her foot
+upon his neck, and with her cruel knife--long ready--hewed off his head.
+
+The hour was come, when Saint Antoine was to execute his horrible idea
+of hoisting up men for lamps to show what he could be and do. Saint
+Antoine’s blood was up, and the blood of tyranny and domination by the
+iron hand was down--down on the steps of the Hotel de Ville where the
+governor’s body lay--down on the sole of the shoe of Madame Defarge
+where she had trodden on the body to steady it for mutilation. “Lower
+the lamp yonder!” cried Saint Antoine, after glaring round for a new
+means of death; “here is one of his soldiers to be left on guard!” The
+swinging sentinel was posted, and the sea rushed on.
+
+The sea of black and threatening waters, and of destructive upheaving
+of wave against wave, whose depths were yet unfathomed and whose forces
+were yet unknown. The remorseless sea of turbulently swaying shapes,
+voices of vengeance, and faces hardened in the furnaces of suffering
+until the touch of pity could make no mark on them.
+
+But, in the ocean of faces where every fierce and furious expression was
+in vivid life, there were two groups of faces--each seven in number--so
+fixedly contrasting with the rest, that never did sea roll which bore
+more memorable wrecks with it. Seven faces of prisoners, suddenly
+released by the storm that had burst their tomb, were carried high
+overhead: all scared, all lost, all wondering and amazed, as if the Last
+Day were come, and those who rejoiced around them were lost spirits.
+Other seven faces there were, carried higher, seven dead faces, whose
+drooping eyelids and half-seen eyes awaited the Last Day. Impassive
+faces, yet with a suspended--not an abolished--expression on them;
+faces, rather, in a fearful pause, as having yet to raise the dropped
+lids of the eyes, and bear witness with the bloodless lips, “THOU DIDST
+IT!”
+
+Seven prisoners released, seven gory heads on pikes, the keys of the
+accursed fortress of the eight strong towers, some discovered letters
+and other memorials of prisoners of old time, long dead of broken
+hearts,--such, and such--like, the loudly echoing footsteps of Saint
+Antoine escort through the Paris streets in mid-July, one thousand seven
+hundred and eighty-nine. Now, Heaven defeat the fancy of Lucie Darnay,
+and keep these feet far out of her life! For, they are headlong, mad,
+and dangerous; and in the years so long after the breaking of the cask
+at Defarge’s wine-shop door, they are not easily purified when once
+stained red.
+
+
+
+
+XXII. The Sea Still Rises
+
+
+Haggard Saint Antoine had had only one exultant week, in which to soften
+his modicum of hard and bitter bread to such extent as he could, with
+the relish of fraternal embraces and congratulations, when Madame
+Defarge sat at her counter, as usual, presiding over the customers.
+Madame Defarge wore no rose in her head, for the great brotherhood of
+Spies had become, even in one short week, extremely chary of trusting
+themselves to the saint’s mercies. The lamps across his streets had a
+portentously elastic swing with them.
+
+Madame Defarge, with her arms folded, sat in the morning light and heat,
+contemplating the wine-shop and the street. In both, there were several
+knots of loungers, squalid and miserable, but now with a manifest sense
+of power enthroned on their distress. The raggedest nightcap, awry on
+the wretchedest head, had this crooked significance in it: “I know how
+hard it has grown for me, the wearer of this, to support life in myself;
+but do you know how easy it has grown for me, the wearer of this, to
+destroy life in you?” Every lean bare arm, that had been without work
+before, had this work always ready for it now, that it could strike.
+The fingers of the knitting women were vicious, with the experience that
+they could tear. There was a change in the appearance of Saint Antoine;
+the image had been hammering into this for hundreds of years, and the
+last finishing blows had told mightily on the expression.
+
+Madame Defarge sat observing it, with such suppressed approval as was
+to be desired in the leader of the Saint Antoine women. One of her
+sisterhood knitted beside her. The short, rather plump wife of a starved
+grocer, and the mother of two children withal, this lieutenant had
+already earned the complimentary name of The Vengeance.
+
+“Hark!” said The Vengeance. “Listen, then! Who comes?”
+
+As if a train of powder laid from the outermost bound of Saint Antoine
+Quarter to the wine-shop door, had been suddenly fired, a fast-spreading
+murmur came rushing along.
+
+“It is Defarge,” said madame. “Silence, patriots!”
+
+Defarge came in breathless, pulled off a red cap he wore, and looked
+around him! “Listen, everywhere!” said madame again. “Listen to him!”
+ Defarge stood, panting, against a background of eager eyes and open
+mouths, formed outside the door; all those within the wine-shop had
+sprung to their feet.
+
+“Say then, my husband. What is it?”
+
+“News from the other world!”
+
+“How, then?” cried madame, contemptuously. “The other world?”
+
+“Does everybody here recall old Foulon, who told the famished people
+that they might eat grass, and who died, and went to Hell?”
+
+“Everybody!” from all throats.
+
+“The news is of him. He is among us!”
+
+“Among us!” from the universal throat again. “And dead?”
+
+“Not dead! He feared us so much--and with reason--that he caused himself
+to be represented as dead, and had a grand mock-funeral. But they have
+found him alive, hiding in the country, and have brought him in. I have
+seen him but now, on his way to the Hotel de Ville, a prisoner. I have
+said that he had reason to fear us. Say all! _Had_ he reason?”
+
+Wretched old sinner of more than threescore years and ten, if he had
+never known it yet, he would have known it in his heart of hearts if he
+could have heard the answering cry.
+
+A moment of profound silence followed. Defarge and his wife looked
+steadfastly at one another. The Vengeance stooped, and the jar of a drum
+was heard as she moved it at her feet behind the counter.
+
+“Patriots!” said Defarge, in a determined voice, “are we ready?”
+
+Instantly Madame Defarge’s knife was in her girdle; the drum was beating
+in the streets, as if it and a drummer had flown together by magic; and
+The Vengeance, uttering terrific shrieks, and flinging her arms about
+her head like all the forty Furies at once, was tearing from house to
+house, rousing the women.
+
+The men were terrible, in the bloody-minded anger with which they looked
+from windows, caught up what arms they had, and came pouring down into
+the streets; but, the women were a sight to chill the boldest. From
+such household occupations as their bare poverty yielded, from their
+children, from their aged and their sick crouching on the bare ground
+famished and naked, they ran out with streaming hair, urging one
+another, and themselves, to madness with the wildest cries and actions.
+Villain Foulon taken, my sister! Old Foulon taken, my mother! Miscreant
+Foulon taken, my daughter! Then, a score of others ran into the midst of
+these, beating their breasts, tearing their hair, and screaming, Foulon
+alive! Foulon who told the starving people they might eat grass! Foulon
+who told my old father that he might eat grass, when I had no bread
+to give him! Foulon who told my baby it might suck grass, when these
+breasts were dry with want! O mother of God, this Foulon! O Heaven our
+suffering! Hear me, my dead baby and my withered father: I swear on my
+knees, on these stones, to avenge you on Foulon! Husbands, and brothers,
+and young men, Give us the blood of Foulon, Give us the head of Foulon,
+Give us the heart of Foulon, Give us the body and soul of Foulon, Rend
+Foulon to pieces, and dig him into the ground, that grass may grow from
+him! With these cries, numbers of the women, lashed into blind frenzy,
+whirled about, striking and tearing at their own friends until they
+dropped into a passionate swoon, and were only saved by the men
+belonging to them from being trampled under foot.
+
+Nevertheless, not a moment was lost; not a moment! This Foulon was at
+the Hotel de Ville, and might be loosed. Never, if Saint Antoine knew
+his own sufferings, insults, and wrongs! Armed men and women flocked out
+of the Quarter so fast, and drew even these last dregs after them with
+such a force of suction, that within a quarter of an hour there was not
+a human creature in Saint Antoine’s bosom but a few old crones and the
+wailing children.
+
+No. They were all by that time choking the Hall of Examination where
+this old man, ugly and wicked, was, and overflowing into the adjacent
+open space and streets. The Defarges, husband and wife, The Vengeance,
+and Jacques Three, were in the first press, and at no great distance
+from him in the Hall.
+
+“See!” cried madame, pointing with her knife. “See the old villain bound
+with ropes. That was well done to tie a bunch of grass upon his back.
+Ha, ha! That was well done. Let him eat it now!” Madame put her knife
+under her arm, and clapped her hands as at a play.
+
+The people immediately behind Madame Defarge, explaining the cause of
+her satisfaction to those behind them, and those again explaining to
+others, and those to others, the neighbouring streets resounded with the
+clapping of hands. Similarly, during two or three hours of drawl,
+and the winnowing of many bushels of words, Madame Defarge’s frequent
+expressions of impatience were taken up, with marvellous quickness, at
+a distance: the more readily, because certain men who had by some
+wonderful exercise of agility climbed up the external architecture
+to look in from the windows, knew Madame Defarge well, and acted as a
+telegraph between her and the crowd outside the building.
+
+At length the sun rose so high that it struck a kindly ray as of hope or
+protection, directly down upon the old prisoner’s head. The favour was
+too much to bear; in an instant the barrier of dust and chaff that had
+stood surprisingly long, went to the winds, and Saint Antoine had got
+him!
+
+It was known directly, to the furthest confines of the crowd. Defarge
+had but sprung over a railing and a table, and folded the miserable
+wretch in a deadly embrace--Madame Defarge had but followed and turned
+her hand in one of the ropes with which he was tied--The Vengeance and
+Jacques Three were not yet up with them, and the men at the windows
+had not yet swooped into the Hall, like birds of prey from their high
+perches--when the cry seemed to go up, all over the city, “Bring him
+out! Bring him to the lamp!”
+
+Down, and up, and head foremost on the steps of the building; now, on
+his knees; now, on his feet; now, on his back; dragged, and struck at,
+and stifled by the bunches of grass and straw that were thrust into his
+face by hundreds of hands; torn, bruised, panting, bleeding, yet always
+entreating and beseeching for mercy; now full of vehement agony of
+action, with a small clear space about him as the people drew one
+another back that they might see; now, a log of dead wood drawn through
+a forest of legs; he was hauled to the nearest street corner where one
+of the fatal lamps swung, and there Madame Defarge let him go--as a cat
+might have done to a mouse--and silently and composedly looked at him
+while they made ready, and while he besought her: the women passionately
+screeching at him all the time, and the men sternly calling out to have
+him killed with grass in his mouth. Once, he went aloft, and the rope
+broke, and they caught him shrieking; twice, he went aloft, and the rope
+broke, and they caught him shrieking; then, the rope was merciful, and
+held him, and his head was soon upon a pike, with grass enough in the
+mouth for all Saint Antoine to dance at the sight of.
+
+Nor was this the end of the day’s bad work, for Saint Antoine so shouted
+and danced his angry blood up, that it boiled again, on hearing when
+the day closed in that the son-in-law of the despatched, another of the
+people’s enemies and insulters, was coming into Paris under a guard
+five hundred strong, in cavalry alone. Saint Antoine wrote his crimes
+on flaring sheets of paper, seized him--would have torn him out of the
+breast of an army to bear Foulon company--set his head and heart on
+pikes, and carried the three spoils of the day, in Wolf-procession
+through the streets.
+
+Not before dark night did the men and women come back to the children,
+wailing and breadless. Then, the miserable bakers’ shops were beset by
+long files of them, patiently waiting to buy bad bread; and while
+they waited with stomachs faint and empty, they beguiled the time by
+embracing one another on the triumphs of the day, and achieving them
+again in gossip. Gradually, these strings of ragged people shortened and
+frayed away; and then poor lights began to shine in high windows, and
+slender fires were made in the streets, at which neighbours cooked in
+common, afterwards supping at their doors.
+
+Scanty and insufficient suppers those, and innocent of meat, as of
+most other sauce to wretched bread. Yet, human fellowship infused
+some nourishment into the flinty viands, and struck some sparks of
+cheerfulness out of them. Fathers and mothers who had had their full
+share in the worst of the day, played gently with their meagre children;
+and lovers, with such a world around them and before them, loved and
+hoped.
+
+It was almost morning, when Defarge’s wine-shop parted with its last
+knot of customers, and Monsieur Defarge said to madame his wife, in
+husky tones, while fastening the door:
+
+“At last it is come, my dear!”
+
+“Eh well!” returned madame. “Almost.”
+
+Saint Antoine slept, the Defarges slept: even The Vengeance slept with
+her starved grocer, and the drum was at rest. The drum’s was the
+only voice in Saint Antoine that blood and hurry had not changed. The
+Vengeance, as custodian of the drum, could have wakened him up and had
+the same speech out of him as before the Bastille fell, or old Foulon
+was seized; not so with the hoarse tones of the men and women in Saint
+Antoine’s bosom.
+
+
+
+
+XXIII. Fire Rises
+
+
+There was a change on the village where the fountain fell, and where
+the mender of roads went forth daily to hammer out of the stones on the
+highway such morsels of bread as might serve for patches to hold his
+poor ignorant soul and his poor reduced body together. The prison on the
+crag was not so dominant as of yore; there were soldiers to guard it,
+but not many; there were officers to guard the soldiers, but not one of
+them knew what his men would do--beyond this: that it would probably not
+be what he was ordered.
+
+Far and wide lay a ruined country, yielding nothing but desolation.
+Every green leaf, every blade of grass and blade of grain, was as
+shrivelled and poor as the miserable people. Everything was bowed down,
+dejected, oppressed, and broken. Habitations, fences, domesticated
+animals, men, women, children, and the soil that bore them--all worn
+out.
+
+Monseigneur (often a most worthy individual gentleman) was a national
+blessing, gave a chivalrous tone to things, was a polite example of
+luxurious and shining life, and a great deal more to equal purpose;
+nevertheless, Monseigneur as a class had, somehow or other, brought
+things to this. Strange that Creation, designed expressly for
+Monseigneur, should be so soon wrung dry and squeezed out! There must
+be something short-sighted in the eternal arrangements, surely! Thus it
+was, however; and the last drop of blood having been extracted from the
+flints, and the last screw of the rack having been turned so often that
+its purchase crumbled, and it now turned and turned with nothing
+to bite, Monseigneur began to run away from a phenomenon so low and
+unaccountable.
+
+But, this was not the change on the village, and on many a village like
+it. For scores of years gone by, Monseigneur had squeezed it and wrung
+it, and had seldom graced it with his presence except for the pleasures
+of the chase--now, found in hunting the people; now, found in hunting
+the beasts, for whose preservation Monseigneur made edifying spaces
+of barbarous and barren wilderness. No. The change consisted in
+the appearance of strange faces of low caste, rather than in the
+disappearance of the high caste, chiselled, and otherwise beautified and
+beautifying features of Monseigneur.
+
+For, in these times, as the mender of roads worked, solitary, in the
+dust, not often troubling himself to reflect that dust he was and
+to dust he must return, being for the most part too much occupied in
+thinking how little he had for supper and how much more he would eat if
+he had it--in these times, as he raised his eyes from his lonely labour,
+and viewed the prospect, he would see some rough figure approaching on
+foot, the like of which was once a rarity in those parts, but was now
+a frequent presence. As it advanced, the mender of roads would discern
+without surprise, that it was a shaggy-haired man, of almost barbarian
+aspect, tall, in wooden shoes that were clumsy even to the eyes of a
+mender of roads, grim, rough, swart, steeped in the mud and dust of many
+highways, dank with the marshy moisture of many low grounds, sprinkled
+with the thorns and leaves and moss of many byways through woods.
+
+Such a man came upon him, like a ghost, at noon in the July weather,
+as he sat on his heap of stones under a bank, taking such shelter as he
+could get from a shower of hail.
+
+The man looked at him, looked at the village in the hollow, at the mill,
+and at the prison on the crag. When he had identified these objects
+in what benighted mind he had, he said, in a dialect that was just
+intelligible:
+
+“How goes it, Jacques?”
+
+“All well, Jacques.”
+
+“Touch then!”
+
+They joined hands, and the man sat down on the heap of stones.
+
+“No dinner?”
+
+“Nothing but supper now,” said the mender of roads, with a hungry face.
+
+“It is the fashion,” growled the man. “I meet no dinner anywhere.”
+
+He took out a blackened pipe, filled it, lighted it with flint and
+steel, pulled at it until it was in a bright glow: then, suddenly held
+it from him and dropped something into it from between his finger and
+thumb, that blazed and went out in a puff of smoke.
+
+“Touch then.” It was the turn of the mender of roads to say it this
+time, after observing these operations. They again joined hands.
+
+“To-night?” said the mender of roads.
+
+“To-night,” said the man, putting the pipe in his mouth.
+
+“Where?”
+
+“Here.”
+
+He and the mender of roads sat on the heap of stones looking silently at
+one another, with the hail driving in between them like a pigmy charge
+of bayonets, until the sky began to clear over the village.
+
+“Show me!” said the traveller then, moving to the brow of the hill.
+
+“See!” returned the mender of roads, with extended finger. “You go down
+here, and straight through the street, and past the fountain--”
+
+“To the Devil with all that!” interrupted the other, rolling his eye
+over the landscape. “_I_ go through no streets and past no fountains.
+Well?”
+
+“Well! About two leagues beyond the summit of that hill above the
+village.”
+
+“Good. When do you cease to work?”
+
+“At sunset.”
+
+“Will you wake me, before departing? I have walked two nights without
+resting. Let me finish my pipe, and I shall sleep like a child. Will you
+wake me?”
+
+“Surely.”
+
+The wayfarer smoked his pipe out, put it in his breast, slipped off his
+great wooden shoes, and lay down on his back on the heap of stones. He
+was fast asleep directly.
+
+As the road-mender plied his dusty labour, and the hail-clouds, rolling
+away, revealed bright bars and streaks of sky which were responded to
+by silver gleams upon the landscape, the little man (who wore a red cap
+now, in place of his blue one) seemed fascinated by the figure on the
+heap of stones. His eyes were so often turned towards it, that he used
+his tools mechanically, and, one would have said, to very poor account.
+The bronze face, the shaggy black hair and beard, the coarse woollen
+red cap, the rough medley dress of home-spun stuff and hairy skins of
+beasts, the powerful frame attenuated by spare living, and the sullen
+and desperate compression of the lips in sleep, inspired the mender
+of roads with awe. The traveller had travelled far, and his feet were
+footsore, and his ankles chafed and bleeding; his great shoes, stuffed
+with leaves and grass, had been heavy to drag over the many long
+leagues, and his clothes were chafed into holes, as he himself was into
+sores. Stooping down beside him, the road-mender tried to get a peep at
+secret weapons in his breast or where not; but, in vain, for he slept
+with his arms crossed upon him, and set as resolutely as his lips.
+Fortified towns with their stockades, guard-houses, gates, trenches, and
+drawbridges, seemed to the mender of roads, to be so much air as against
+this figure. And when he lifted his eyes from it to the horizon and
+looked around, he saw in his small fancy similar figures, stopped by no
+obstacle, tending to centres all over France.
+
+The man slept on, indifferent to showers of hail and intervals of
+brightness, to sunshine on his face and shadow, to the paltering lumps
+of dull ice on his body and the diamonds into which the sun changed
+them, until the sun was low in the west, and the sky was glowing. Then,
+the mender of roads having got his tools together and all things ready
+to go down into the village, roused him.
+
+“Good!” said the sleeper, rising on his elbow. “Two leagues beyond the
+summit of the hill?”
+
+“About.”
+
+“About. Good!”
+
+The mender of roads went home, with the dust going on before him
+according to the set of the wind, and was soon at the fountain,
+squeezing himself in among the lean kine brought there to drink, and
+appearing even to whisper to them in his whispering to all the village.
+When the village had taken its poor supper, it did not creep to bed,
+as it usually did, but came out of doors again, and remained there. A
+curious contagion of whispering was upon it, and also, when it gathered
+together at the fountain in the dark, another curious contagion of
+looking expectantly at the sky in one direction only. Monsieur Gabelle,
+chief functionary of the place, became uneasy; went out on his house-top
+alone, and looked in that direction too; glanced down from behind his
+chimneys at the darkening faces by the fountain below, and sent word to
+the sacristan who kept the keys of the church, that there might be need
+to ring the tocsin by-and-bye.
+
+The night deepened. The trees environing the old chateau, keeping its
+solitary state apart, moved in a rising wind, as though they threatened
+the pile of building massive and dark in the gloom. Up the two terrace
+flights of steps the rain ran wildly, and beat at the great door, like a
+swift messenger rousing those within; uneasy rushes of wind went through
+the hall, among the old spears and knives, and passed lamenting up the
+stairs, and shook the curtains of the bed where the last Marquis
+had slept. East, West, North, and South, through the woods, four
+heavy-treading, unkempt figures crushed the high grass and cracked the
+branches, striding on cautiously to come together in the courtyard. Four
+lights broke out there, and moved away in different directions, and all
+was black again.
+
+But, not for long. Presently, the chateau began to make itself strangely
+visible by some light of its own, as though it were growing luminous.
+Then, a flickering streak played behind the architecture of the front,
+picking out transparent places, and showing where balustrades, arches,
+and windows were. Then it soared higher, and grew broader and brighter.
+Soon, from a score of the great windows, flames burst forth, and the
+stone faces awakened, stared out of fire.
+
+A faint murmur arose about the house from the few people who were left
+there, and there was a saddling of a horse and riding away. There was
+spurring and splashing through the darkness, and bridle was drawn in the
+space by the village fountain, and the horse in a foam stood at Monsieur
+Gabelle’s door. “Help, Gabelle! Help, every one!” The tocsin rang
+impatiently, but other help (if that were any) there was none. The
+mender of roads, and two hundred and fifty particular friends, stood
+with folded arms at the fountain, looking at the pillar of fire in the
+sky. “It must be forty feet high,” said they, grimly; and never moved.
+
+The rider from the chateau, and the horse in a foam, clattered away
+through the village, and galloped up the stony steep, to the prison on
+the crag. At the gate, a group of officers were looking at the fire;
+removed from them, a group of soldiers. “Help, gentlemen--officers! The
+chateau is on fire; valuable objects may be saved from the flames by
+timely aid! Help, help!” The officers looked towards the soldiers who
+looked at the fire; gave no orders; and answered, with shrugs and biting
+of lips, “It must burn.”
+
+As the rider rattled down the hill again and through the street, the
+village was illuminating. The mender of roads, and the two hundred and
+fifty particular friends, inspired as one man and woman by the idea of
+lighting up, had darted into their houses, and were putting candles in
+every dull little pane of glass. The general scarcity of everything,
+occasioned candles to be borrowed in a rather peremptory manner of
+Monsieur Gabelle; and in a moment of reluctance and hesitation on
+that functionary’s part, the mender of roads, once so submissive to
+authority, had remarked that carriages were good to make bonfires with,
+and that post-horses would roast.
+
+The chateau was left to itself to flame and burn. In the roaring and
+raging of the conflagration, a red-hot wind, driving straight from the
+infernal regions, seemed to be blowing the edifice away. With the rising
+and falling of the blaze, the stone faces showed as if they were in
+torment. When great masses of stone and timber fell, the face with the
+two dints in the nose became obscured: anon struggled out of the smoke
+again, as if it were the face of the cruel Marquis, burning at the stake
+and contending with the fire.
+
+The chateau burned; the nearest trees, laid hold of by the fire,
+scorched and shrivelled; trees at a distance, fired by the four fierce
+figures, begirt the blazing edifice with a new forest of smoke. Molten
+lead and iron boiled in the marble basin of the fountain; the water ran
+dry; the extinguisher tops of the towers vanished like ice before the
+heat, and trickled down into four rugged wells of flame. Great rents and
+splits branched out in the solid walls, like crystallisation; stupefied
+birds wheeled about and dropped into the furnace; four fierce figures
+trudged away, East, West, North, and South, along the night-enshrouded
+roads, guided by the beacon they had lighted, towards their next
+destination. The illuminated village had seized hold of the tocsin, and,
+abolishing the lawful ringer, rang for joy.
+
+Not only that; but the village, light-headed with famine, fire, and
+bell-ringing, and bethinking itself that Monsieur Gabelle had to do with
+the collection of rent and taxes--though it was but a small instalment
+of taxes, and no rent at all, that Gabelle had got in those latter
+days--became impatient for an interview with him, and, surrounding his
+house, summoned him to come forth for personal conference. Whereupon,
+Monsieur Gabelle did heavily bar his door, and retire to hold counsel
+with himself. The result of that conference was, that Gabelle again
+withdrew himself to his housetop behind his stack of chimneys; this time
+resolved, if his door were broken in (he was a small Southern man
+of retaliative temperament), to pitch himself head foremost over the
+parapet, and crush a man or two below.
+
+Probably, Monsieur Gabelle passed a long night up there, with the
+distant chateau for fire and candle, and the beating at his door,
+combined with the joy-ringing, for music; not to mention his having an
+ill-omened lamp slung across the road before his posting-house gate,
+which the village showed a lively inclination to displace in his favour.
+A trying suspense, to be passing a whole summer night on the brink of
+the black ocean, ready to take that plunge into it upon which Monsieur
+Gabelle had resolved! But, the friendly dawn appearing at last, and the
+rush-candles of the village guttering out, the people happily dispersed,
+and Monsieur Gabelle came down bringing his life with him for that
+while.
+
+Within a hundred miles, and in the light of other fires, there were
+other functionaries less fortunate, that night and other nights, whom
+the rising sun found hanging across once-peaceful streets, where they
+had been born and bred; also, there were other villagers and townspeople
+less fortunate than the mender of roads and his fellows, upon whom the
+functionaries and soldiery turned with success, and whom they strung up
+in their turn. But, the fierce figures were steadily wending East, West,
+North, and South, be that as it would; and whosoever hung, fire burned.
+The altitude of the gallows that would turn to water and quench it,
+no functionary, by any stretch of mathematics, was able to calculate
+successfully.
+
+
+
+
+XXIV. Drawn to the Loadstone Rock
+
+
+In such risings of fire and risings of sea--the firm earth shaken by
+the rushes of an angry ocean which had now no ebb, but was always on the
+flow, higher and higher, to the terror and wonder of the beholders on
+the shore--three years of tempest were consumed. Three more birthdays
+of little Lucie had been woven by the golden thread into the peaceful
+tissue of the life of her home.
+
+Many a night and many a day had its inmates listened to the echoes in
+the corner, with hearts that failed them when they heard the thronging
+feet. For, the footsteps had become to their minds as the footsteps of
+a people, tumultuous under a red flag and with their country declared in
+danger, changed into wild beasts, by terrible enchantment long persisted
+in.
+
+Monseigneur, as a class, had dissociated himself from the phenomenon of
+his not being appreciated: of his being so little wanted in France, as
+to incur considerable danger of receiving his dismissal from it, and
+this life together. Like the fabled rustic who raised the Devil with
+infinite pains, and was so terrified at the sight of him that he could
+ask the Enemy no question, but immediately fled; so, Monseigneur, after
+boldly reading the Lord’s Prayer backwards for a great number of years,
+and performing many other potent spells for compelling the Evil One, no
+sooner beheld him in his terrors than he took to his noble heels.
+
+The shining Bull’s Eye of the Court was gone, or it would have been the
+mark for a hurricane of national bullets. It had never been a good
+eye to see with--had long had the mote in it of Lucifer’s pride,
+Sardanapalus’s luxury, and a mole’s blindness--but it had dropped
+out and was gone. The Court, from that exclusive inner circle to its
+outermost rotten ring of intrigue, corruption, and dissimulation, was
+all gone together. Royalty was gone; had been besieged in its Palace and
+“suspended,” when the last tidings came over.
+
+The August of the year one thousand seven hundred and ninety-two was
+come, and Monseigneur was by this time scattered far and wide.
+
+As was natural, the head-quarters and great gathering-place of
+Monseigneur, in London, was Tellson’s Bank. Spirits are supposed to
+haunt the places where their bodies most resorted, and Monseigneur
+without a guinea haunted the spot where his guineas used to be.
+Moreover, it was the spot to which such French intelligence as was most
+to be relied upon, came quickest. Again: Tellson’s was a munificent
+house, and extended great liberality to old customers who had fallen
+from their high estate. Again: those nobles who had seen the coming
+storm in time, and anticipating plunder or confiscation, had made
+provident remittances to Tellson’s, were always to be heard of there
+by their needy brethren. To which it must be added that every new-comer
+from France reported himself and his tidings at Tellson’s, almost as
+a matter of course. For such variety of reasons, Tellson’s was at that
+time, as to French intelligence, a kind of High Exchange; and this
+was so well known to the public, and the inquiries made there were in
+consequence so numerous, that Tellson’s sometimes wrote the latest news
+out in a line or so and posted it in the Bank windows, for all who ran
+through Temple Bar to read.
+
+On a steaming, misty afternoon, Mr. Lorry sat at his desk, and Charles
+Darnay stood leaning on it, talking with him in a low voice. The
+penitential den once set apart for interviews with the House, was now
+the news-Exchange, and was filled to overflowing. It was within half an
+hour or so of the time of closing.
+
+“But, although you are the youngest man that ever lived,” said Charles
+Darnay, rather hesitating, “I must still suggest to you--”
+
+“I understand. That I am too old?” said Mr. Lorry.
+
+“Unsettled weather, a long journey, uncertain means of travelling, a
+disorganised country, a city that may not be even safe for you.”
+
+“My dear Charles,” said Mr. Lorry, with cheerful confidence, “you touch
+some of the reasons for my going: not for my staying away. It is safe
+enough for me; nobody will care to interfere with an old fellow of hard
+upon fourscore when there are so many people there much better worth
+interfering with. As to its being a disorganised city, if it were not a
+disorganised city there would be no occasion to send somebody from our
+House here to our House there, who knows the city and the business, of
+old, and is in Tellson’s confidence. As to the uncertain travelling, the
+long journey, and the winter weather, if I were not prepared to submit
+myself to a few inconveniences for the sake of Tellson’s, after all
+these years, who ought to be?”
+
+“I wish I were going myself,” said Charles Darnay, somewhat restlessly,
+and like one thinking aloud.
+
+“Indeed! You are a pretty fellow to object and advise!” exclaimed Mr.
+Lorry. “You wish you were going yourself? And you a Frenchman born? You
+are a wise counsellor.”
+
+“My dear Mr. Lorry, it is because I am a Frenchman born, that the
+thought (which I did not mean to utter here, however) has passed through
+my mind often. One cannot help thinking, having had some sympathy for
+the miserable people, and having abandoned something to them,” he spoke
+here in his former thoughtful manner, “that one might be listened to,
+and might have the power to persuade to some restraint. Only last night,
+after you had left us, when I was talking to Lucie--”
+
+“When you were talking to Lucie,” Mr. Lorry repeated. “Yes. I wonder you
+are not ashamed to mention the name of Lucie! Wishing you were going to
+France at this time of day!”
+
+“However, I am not going,” said Charles Darnay, with a smile. “It is
+more to the purpose that you say you are.”
+
+“And I am, in plain reality. The truth is, my dear Charles,” Mr. Lorry
+glanced at the distant House, and lowered his voice, “you can have no
+conception of the difficulty with which our business is transacted, and
+of the peril in which our books and papers over yonder are involved. The
+Lord above knows what the compromising consequences would be to numbers
+of people, if some of our documents were seized or destroyed; and they
+might be, at any time, you know, for who can say that Paris is not set
+afire to-day, or sacked to-morrow! Now, a judicious selection from these
+with the least possible delay, and the burying of them, or otherwise
+getting of them out of harm’s way, is within the power (without loss of
+precious time) of scarcely any one but myself, if any one. And shall
+I hang back, when Tellson’s knows this and says this--Tellson’s, whose
+bread I have eaten these sixty years--because I am a little stiff about
+the joints? Why, I am a boy, sir, to half a dozen old codgers here!”
+
+“How I admire the gallantry of your youthful spirit, Mr. Lorry.”
+
+“Tut! Nonsense, sir!--And, my dear Charles,” said Mr. Lorry, glancing at
+the House again, “you are to remember, that getting things out of
+Paris at this present time, no matter what things, is next to an
+impossibility. Papers and precious matters were this very day brought
+to us here (I speak in strict confidence; it is not business-like to
+whisper it, even to you), by the strangest bearers you can imagine,
+every one of whom had his head hanging on by a single hair as he passed
+the Barriers. At another time, our parcels would come and go, as easily
+as in business-like Old England; but now, everything is stopped.”
+
+“And do you really go to-night?”
+
+“I really go to-night, for the case has become too pressing to admit of
+delay.”
+
+“And do you take no one with you?”
+
+“All sorts of people have been proposed to me, but I will have nothing
+to say to any of them. I intend to take Jerry. Jerry has been my
+bodyguard on Sunday nights for a long time past and I am used to him.
+Nobody will suspect Jerry of being anything but an English bull-dog, or
+of having any design in his head but to fly at anybody who touches his
+master.”
+
+“I must say again that I heartily admire your gallantry and
+youthfulness.”
+
+“I must say again, nonsense, nonsense! When I have executed this little
+commission, I shall, perhaps, accept Tellson’s proposal to retire and
+live at my ease. Time enough, then, to think about growing old.”
+
+This dialogue had taken place at Mr. Lorry’s usual desk, with
+Monseigneur swarming within a yard or two of it, boastful of what he
+would do to avenge himself on the rascal-people before long. It was too
+much the way of Monseigneur under his reverses as a refugee, and it
+was much too much the way of native British orthodoxy, to talk of this
+terrible Revolution as if it were the only harvest ever known under
+the skies that had not been sown--as if nothing had ever been done, or
+omitted to be done, that had led to it--as if observers of the wretched
+millions in France, and of the misused and perverted resources that
+should have made them prosperous, had not seen it inevitably coming,
+years before, and had not in plain words recorded what they saw. Such
+vapouring, combined with the extravagant plots of Monseigneur for the
+restoration of a state of things that had utterly exhausted itself,
+and worn out Heaven and earth as well as itself, was hard to be endured
+without some remonstrance by any sane man who knew the truth. And it was
+such vapouring all about his ears, like a troublesome confusion of blood
+in his own head, added to a latent uneasiness in his mind, which had
+already made Charles Darnay restless, and which still kept him so.
+
+Among the talkers, was Stryver, of the King’s Bench Bar, far on his
+way to state promotion, and, therefore, loud on the theme: broaching
+to Monseigneur, his devices for blowing the people up and exterminating
+them from the face of the earth, and doing without them: and for
+accomplishing many similar objects akin in their nature to the abolition
+of eagles by sprinkling salt on the tails of the race. Him, Darnay heard
+with a particular feeling of objection; and Darnay stood divided between
+going away that he might hear no more, and remaining to interpose his
+word, when the thing that was to be, went on to shape itself out.
+
+The House approached Mr. Lorry, and laying a soiled and unopened letter
+before him, asked if he had yet discovered any traces of the person to
+whom it was addressed? The House laid the letter down so close to Darnay
+that he saw the direction--the more quickly because it was his own right
+name. The address, turned into English, ran:
+
+“Very pressing. To Monsieur heretofore the Marquis St. Evremonde, of
+France. Confided to the cares of Messrs. Tellson and Co., Bankers,
+London, England.”
+
+On the marriage morning, Doctor Manette had made it his one urgent and
+express request to Charles Darnay, that the secret of this name should
+be--unless he, the Doctor, dissolved the obligation--kept inviolate
+between them. Nobody else knew it to be his name; his own wife had no
+suspicion of the fact; Mr. Lorry could have none.
+
+“No,” said Mr. Lorry, in reply to the House; “I have referred it,
+I think, to everybody now here, and no one can tell me where this
+gentleman is to be found.”
+
+The hands of the clock verging upon the hour of closing the Bank, there
+was a general set of the current of talkers past Mr. Lorry’s desk. He
+held the letter out inquiringly; and Monseigneur looked at it, in the
+person of this plotting and indignant refugee; and Monseigneur looked at
+it in the person of that plotting and indignant refugee; and This, That,
+and The Other, all had something disparaging to say, in French or in
+English, concerning the Marquis who was not to be found.
+
+“Nephew, I believe--but in any case degenerate successor--of the
+polished Marquis who was murdered,” said one. “Happy to say, I never
+knew him.”
+
+“A craven who abandoned his post,” said another--this Monseigneur had
+been got out of Paris, legs uppermost and half suffocated, in a load of
+hay--“some years ago.”
+
+“Infected with the new doctrines,” said a third, eyeing the direction
+through his glass in passing; “set himself in opposition to the last
+Marquis, abandoned the estates when he inherited them, and left them to
+the ruffian herd. They will recompense him now, I hope, as he deserves.”
+
+“Hey?” cried the blatant Stryver. “Did he though? Is that the sort of
+fellow? Let us look at his infamous name. D--n the fellow!”
+
+Darnay, unable to restrain himself any longer, touched Mr. Stryver on
+the shoulder, and said:
+
+“I know the fellow.”
+
+“Do you, by Jupiter?” said Stryver. “I am sorry for it.”
+
+“Why?”
+
+“Why, Mr. Darnay? D’ye hear what he did? Don’t ask, why, in these
+times.”
+
+“But I do ask why?”
+
+“Then I tell you again, Mr. Darnay, I am sorry for it. I am sorry to
+hear you putting any such extraordinary questions. Here is a fellow,
+who, infected by the most pestilent and blasphemous code of devilry that
+ever was known, abandoned his property to the vilest scum of the earth
+that ever did murder by wholesale, and you ask me why I am sorry that a
+man who instructs youth knows him? Well, but I’ll answer you. I am sorry
+because I believe there is contamination in such a scoundrel. That’s
+why.”
+
+Mindful of the secret, Darnay with great difficulty checked himself, and
+said: “You may not understand the gentleman.”
+
+“I understand how to put _you_ in a corner, Mr. Darnay,” said Bully
+Stryver, “and I’ll do it. If this fellow is a gentleman, I _don’t_
+understand him. You may tell him so, with my compliments. You may also
+tell him, from me, that after abandoning his worldly goods and position
+to this butcherly mob, I wonder he is not at the head of them. But, no,
+gentlemen,” said Stryver, looking all round, and snapping his fingers,
+“I know something of human nature, and I tell you that you’ll never
+find a fellow like this fellow, trusting himself to the mercies of such
+precious _protégés_. No, gentlemen; he’ll always show ‘em a clean pair
+of heels very early in the scuffle, and sneak away.”
+
+With those words, and a final snap of his fingers, Mr. Stryver
+shouldered himself into Fleet-street, amidst the general approbation of
+his hearers. Mr. Lorry and Charles Darnay were left alone at the desk,
+in the general departure from the Bank.
+
+“Will you take charge of the letter?” said Mr. Lorry. “You know where to
+deliver it?”
+
+“I do.”
+
+“Will you undertake to explain, that we suppose it to have been
+addressed here, on the chance of our knowing where to forward it, and
+that it has been here some time?”
+
+“I will do so. Do you start for Paris from here?”
+
+“From here, at eight.”
+
+“I will come back, to see you off.”
+
+Very ill at ease with himself, and with Stryver and most other men,
+Darnay made the best of his way into the quiet of the Temple, opened the
+letter, and read it. These were its contents:
+
+
+“Prison of the Abbaye, Paris.
+
+“June 21, 1792. “MONSIEUR HERETOFORE THE MARQUIS.
+
+“After having long been in danger of my life at the hands of the
+village, I have been seized, with great violence and indignity, and
+brought a long journey on foot to Paris. On the road I have suffered a
+great deal. Nor is that all; my house has been destroyed--razed to the
+ground.
+
+“The crime for which I am imprisoned, Monsieur heretofore the Marquis,
+and for which I shall be summoned before the tribunal, and shall lose my
+life (without your so generous help), is, they tell me, treason against
+the majesty of the people, in that I have acted against them for an
+emigrant. It is in vain I represent that I have acted for them, and not
+against, according to your commands. It is in vain I represent that,
+before the sequestration of emigrant property, I had remitted the
+imposts they had ceased to pay; that I had collected no rent; that I had
+had recourse to no process. The only response is, that I have acted for
+an emigrant, and where is that emigrant?
+
+“Ah! most gracious Monsieur heretofore the Marquis, where is that
+emigrant? I cry in my sleep where is he? I demand of Heaven, will he
+not come to deliver me? No answer. Ah Monsieur heretofore the Marquis,
+I send my desolate cry across the sea, hoping it may perhaps reach your
+ears through the great bank of Tilson known at Paris!
+
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name, I supplicate you, Monsieur heretofore the Marquis, to
+succour and release me. My fault is, that I have been true to you. Oh
+Monsieur heretofore the Marquis, I pray you be you true to me!
+
+“From this prison here of horror, whence I every hour tend nearer and
+nearer to destruction, I send you, Monsieur heretofore the Marquis, the
+assurance of my dolorous and unhappy service.
+
+“Your afflicted,
+
+“Gabelle.”
+
+
+The latent uneasiness in Darnay’s mind was roused to vigourous life
+by this letter. The peril of an old servant and a good one, whose
+only crime was fidelity to himself and his family, stared him so
+reproachfully in the face, that, as he walked to and fro in the Temple
+considering what to do, he almost hid his face from the passersby.
+
+He knew very well, that in his horror of the deed which had culminated
+the bad deeds and bad reputation of the old family house, in his
+resentful suspicions of his uncle, and in the aversion with which his
+conscience regarded the crumbling fabric that he was supposed to uphold,
+he had acted imperfectly. He knew very well, that in his love for Lucie,
+his renunciation of his social place, though by no means new to his own
+mind, had been hurried and incomplete. He knew that he ought to have
+systematically worked it out and supervised it, and that he had meant to
+do it, and that it had never been done.
+
+The happiness of his own chosen English home, the necessity of being
+always actively employed, the swift changes and troubles of the time
+which had followed on one another so fast, that the events of this week
+annihilated the immature plans of last week, and the events of the week
+following made all new again; he knew very well, that to the force of
+these circumstances he had yielded:--not without disquiet, but still
+without continuous and accumulating resistance. That he had watched
+the times for a time of action, and that they had shifted and struggled
+until the time had gone by, and the nobility were trooping from
+France by every highway and byway, and their property was in course of
+confiscation and destruction, and their very names were blotting out,
+was as well known to himself as it could be to any new authority in
+France that might impeach him for it.
+
+But, he had oppressed no man, he had imprisoned no man; he was so
+far from having harshly exacted payment of his dues, that he had
+relinquished them of his own will, thrown himself on a world with no
+favour in it, won his own private place there, and earned his own
+bread. Monsieur Gabelle had held the impoverished and involved estate
+on written instructions, to spare the people, to give them what little
+there was to give--such fuel as the heavy creditors would let them have
+in the winter, and such produce as could be saved from the same grip in
+the summer--and no doubt he had put the fact in plea and proof, for his
+own safety, so that it could not but appear now.
+
+This favoured the desperate resolution Charles Darnay had begun to make,
+that he would go to Paris.
+
+Yes. Like the mariner in the old story, the winds and streams had driven
+him within the influence of the Loadstone Rock, and it was drawing him
+to itself, and he must go. Everything that arose before his mind drifted
+him on, faster and faster, more and more steadily, to the terrible
+attraction. His latent uneasiness had been, that bad aims were being
+worked out in his own unhappy land by bad instruments, and that he who
+could not fail to know that he was better than they, was not there,
+trying to do something to stay bloodshed, and assert the claims of mercy
+and humanity. With this uneasiness half stifled, and half reproaching
+him, he had been brought to the pointed comparison of himself with the
+brave old gentleman in whom duty was so strong; upon that comparison
+(injurious to himself) had instantly followed the sneers of Monseigneur,
+which had stung him bitterly, and those of Stryver, which above all were
+coarse and galling, for old reasons. Upon those, had followed Gabelle’s
+letter: the appeal of an innocent prisoner, in danger of death, to his
+justice, honour, and good name.
+
+His resolution was made. He must go to Paris.
+
+Yes. The Loadstone Rock was drawing him, and he must sail on, until he
+struck. He knew of no rock; he saw hardly any danger. The intention
+with which he had done what he had done, even although he had left
+it incomplete, presented it before him in an aspect that would be
+gratefully acknowledged in France on his presenting himself to assert
+it. Then, that glorious vision of doing good, which is so often the
+sanguine mirage of so many good minds, arose before him, and he even
+saw himself in the illusion with some influence to guide this raging
+Revolution that was running so fearfully wild.
+
+As he walked to and fro with his resolution made, he considered that
+neither Lucie nor her father must know of it until he was gone.
+Lucie should be spared the pain of separation; and her father, always
+reluctant to turn his thoughts towards the dangerous ground of old,
+should come to the knowledge of the step, as a step taken, and not in
+the balance of suspense and doubt. How much of the incompleteness of his
+situation was referable to her father, through the painful anxiety
+to avoid reviving old associations of France in his mind, he did not
+discuss with himself. But, that circumstance too, had had its influence
+in his course.
+
+He walked to and fro, with thoughts very busy, until it was time to
+return to Tellson’s and take leave of Mr. Lorry. As soon as he arrived
+in Paris he would present himself to this old friend, but he must say
+nothing of his intention now.
+
+A carriage with post-horses was ready at the Bank door, and Jerry was
+booted and equipped.
+
+“I have delivered that letter,” said Charles Darnay to Mr. Lorry. “I
+would not consent to your being charged with any written answer, but
+perhaps you will take a verbal one?”
+
+“That I will, and readily,” said Mr. Lorry, “if it is not dangerous.”
+
+“Not at all. Though it is to a prisoner in the Abbaye.”
+
+“What is his name?” said Mr. Lorry, with his open pocket-book in his
+hand.
+
+“Gabelle.”
+
+“Gabelle. And what is the message to the unfortunate Gabelle in prison?”
+
+“Simply, ‘that he has received the letter, and will come.’”
+
+“Any time mentioned?”
+
+“He will start upon his journey to-morrow night.”
+
+“Any person mentioned?”
+
+“No.”
+
+He helped Mr. Lorry to wrap himself in a number of coats and cloaks,
+and went out with him from the warm atmosphere of the old Bank, into the
+misty air of Fleet-street. “My love to Lucie, and to little Lucie,” said
+Mr. Lorry at parting, “and take precious care of them till I come back.”
+ Charles Darnay shook his head and doubtfully smiled, as the carriage
+rolled away.
+
+That night--it was the fourteenth of August--he sat up late, and wrote
+two fervent letters; one was to Lucie, explaining the strong obligation
+he was under to go to Paris, and showing her, at length, the reasons
+that he had, for feeling confident that he could become involved in no
+personal danger there; the other was to the Doctor, confiding Lucie and
+their dear child to his care, and dwelling on the same topics with the
+strongest assurances. To both, he wrote that he would despatch letters
+in proof of his safety, immediately after his arrival.
+
+It was a hard day, that day of being among them, with the first
+reservation of their joint lives on his mind. It was a hard matter to
+preserve the innocent deceit of which they were profoundly unsuspicious.
+But, an affectionate glance at his wife, so happy and busy, made him
+resolute not to tell her what impended (he had been half moved to do it,
+so strange it was to him to act in anything without her quiet aid), and
+the day passed quickly. Early in the evening he embraced her, and her
+scarcely less dear namesake, pretending that he would return by-and-bye
+(an imaginary engagement took him out, and he had secreted a valise
+of clothes ready), and so he emerged into the heavy mist of the heavy
+streets, with a heavier heart.
+
+The unseen force was drawing him fast to itself, now, and all the tides
+and winds were setting straight and strong towards it. He left his
+two letters with a trusty porter, to be delivered half an hour before
+midnight, and no sooner; took horse for Dover; and began his journey.
+“For the love of Heaven, of justice, of generosity, of the honour of
+your noble name!” was the poor prisoner’s cry with which he strengthened
+his sinking heart, as he left all that was dear on earth behind him, and
+floated away for the Loadstone Rock.
+
+
+The end of the second book.
+
+
+
+
+
+Book the Third--the Track of a Storm
+
+
+
+
+I. In Secret
+
+
+The traveller fared slowly on his way, who fared towards Paris from
+England in the autumn of the year one thousand seven hundred and
+ninety-two. More than enough of bad roads, bad equipages, and bad
+horses, he would have encountered to delay him, though the fallen and
+unfortunate King of France had been upon his throne in all his glory;
+but, the changed times were fraught with other obstacles than
+these. Every town-gate and village taxing-house had its band of
+citizen-patriots, with their national muskets in a most explosive state
+of readiness, who stopped all comers and goers, cross-questioned them,
+inspected their papers, looked for their names in lists of their own,
+turned them back, or sent them on, or stopped them and laid them in
+hold, as their capricious judgment or fancy deemed best for the dawning
+Republic One and Indivisible, of Liberty, Equality, Fraternity, or
+Death.
+
+A very few French leagues of his journey were accomplished, when Charles
+Darnay began to perceive that for him along these country roads there
+was no hope of return until he should have been declared a good citizen
+at Paris. Whatever might befall now, he must on to his journey’s end.
+Not a mean village closed upon him, not a common barrier dropped across
+the road behind him, but he knew it to be another iron door in
+the series that was barred between him and England. The universal
+watchfulness so encompassed him, that if he had been taken in a net,
+or were being forwarded to his destination in a cage, he could not have
+felt his freedom more completely gone.
+
+This universal watchfulness not only stopped him on the highway twenty
+times in a stage, but retarded his progress twenty times in a day, by
+riding after him and taking him back, riding before him and stopping him
+by anticipation, riding with him and keeping him in charge. He had been
+days upon his journey in France alone, when he went to bed tired out, in
+a little town on the high road, still a long way from Paris.
+
+Nothing but the production of the afflicted Gabelle’s letter from his
+prison of the Abbaye would have got him on so far. His difficulty at the
+guard-house in this small place had been such, that he felt his journey
+to have come to a crisis. And he was, therefore, as little surprised as
+a man could be, to find himself awakened at the small inn to which he
+had been remitted until morning, in the middle of the night.
+
+Awakened by a timid local functionary and three armed patriots in rough
+red caps and with pipes in their mouths, who sat down on the bed.
+
+“Emigrant,” said the functionary, “I am going to send you on to Paris,
+under an escort.”
+
+“Citizen, I desire nothing more than to get to Paris, though I could
+dispense with the escort.”
+
+“Silence!” growled a red-cap, striking at the coverlet with the butt-end
+of his musket. “Peace, aristocrat!”
+
+“It is as the good patriot says,” observed the timid functionary. “You
+are an aristocrat, and must have an escort--and must pay for it.”
+
+“I have no choice,” said Charles Darnay.
+
+“Choice! Listen to him!” cried the same scowling red-cap. “As if it was
+not a favour to be protected from the lamp-iron!”
+
+“It is always as the good patriot says,” observed the functionary. “Rise
+and dress yourself, emigrant.”
+
+Darnay complied, and was taken back to the guard-house, where other
+patriots in rough red caps were smoking, drinking, and sleeping, by
+a watch-fire. Here he paid a heavy price for his escort, and hence he
+started with it on the wet, wet roads at three o’clock in the morning.
+
+The escort were two mounted patriots in red caps and tri-coloured
+cockades, armed with national muskets and sabres, who rode one on either
+side of him.
+
+The escorted governed his own horse, but a loose line was attached to
+his bridle, the end of which one of the patriots kept girded round his
+wrist. In this state they set forth with the sharp rain driving in their
+faces: clattering at a heavy dragoon trot over the uneven town pavement,
+and out upon the mire-deep roads. In this state they traversed without
+change, except of horses and pace, all the mire-deep leagues that lay
+between them and the capital.
+
+They travelled in the night, halting an hour or two after daybreak, and
+lying by until the twilight fell. The escort were so wretchedly clothed,
+that they twisted straw round their bare legs, and thatched their ragged
+shoulders to keep the wet off. Apart from the personal discomfort of
+being so attended, and apart from such considerations of present danger
+as arose from one of the patriots being chronically drunk, and carrying
+his musket very recklessly, Charles Darnay did not allow the restraint
+that was laid upon him to awaken any serious fears in his breast; for,
+he reasoned with himself that it could have no reference to the merits
+of an individual case that was not yet stated, and of representations,
+confirmable by the prisoner in the Abbaye, that were not yet made.
+
+But when they came to the town of Beauvais--which they did at eventide,
+when the streets were filled with people--he could not conceal from
+himself that the aspect of affairs was very alarming. An ominous crowd
+gathered to see him dismount of the posting-yard, and many voices called
+out loudly, “Down with the emigrant!”
+
+He stopped in the act of swinging himself out of his saddle, and,
+resuming it as his safest place, said:
+
+“Emigrant, my friends! Do you not see me here, in France, of my own
+will?”
+
+“You are a cursed emigrant,” cried a farrier, making at him in a
+furious manner through the press, hammer in hand; “and you are a cursed
+aristocrat!”
+
+The postmaster interposed himself between this man and the rider’s
+bridle (at which he was evidently making), and soothingly said, “Let him
+be; let him be! He will be judged at Paris.”
+
+“Judged!” repeated the farrier, swinging his hammer. “Ay! and condemned
+as a traitor.” At this the crowd roared approval.
+
+Checking the postmaster, who was for turning his horse’s head to the
+yard (the drunken patriot sat composedly in his saddle looking on, with
+the line round his wrist), Darnay said, as soon as he could make his
+voice heard:
+
+“Friends, you deceive yourselves, or you are deceived. I am not a
+traitor.”
+
+“He lies!” cried the smith. “He is a traitor since the decree. His life
+is forfeit to the people. His cursed life is not his own!”
+
+At the instant when Darnay saw a rush in the eyes of the crowd, which
+another instant would have brought upon him, the postmaster turned his
+horse into the yard, the escort rode in close upon his horse’s flanks,
+and the postmaster shut and barred the crazy double gates. The farrier
+struck a blow upon them with his hammer, and the crowd groaned; but, no
+more was done.
+
+“What is this decree that the smith spoke of?” Darnay asked the
+postmaster, when he had thanked him, and stood beside him in the yard.
+
+“Truly, a decree for selling the property of emigrants.”
+
+“When passed?”
+
+“On the fourteenth.”
+
+“The day I left England!”
+
+“Everybody says it is but one of several, and that there will be
+others--if there are not already--banishing all emigrants, and
+condemning all to death who return. That is what he meant when he said
+your life was not your own.”
+
+“But there are no such decrees yet?”
+
+“What do I know!” said the postmaster, shrugging his shoulders; “there
+may be, or there will be. It is all the same. What would you have?”
+
+They rested on some straw in a loft until the middle of the night, and
+then rode forward again when all the town was asleep. Among the many
+wild changes observable on familiar things which made this wild ride
+unreal, not the least was the seeming rarity of sleep. After long and
+lonely spurring over dreary roads, they would come to a cluster of poor
+cottages, not steeped in darkness, but all glittering with lights, and
+would find the people, in a ghostly manner in the dead of the night,
+circling hand in hand round a shrivelled tree of Liberty, or all drawn
+up together singing a Liberty song. Happily, however, there was sleep in
+Beauvais that night to help them out of it and they passed on once more
+into solitude and loneliness: jingling through the untimely cold and
+wet, among impoverished fields that had yielded no fruits of the earth
+that year, diversified by the blackened remains of burnt houses, and by
+the sudden emergence from ambuscade, and sharp reining up across their
+way, of patriot patrols on the watch on all the roads.
+
+Daylight at last found them before the wall of Paris. The barrier was
+closed and strongly guarded when they rode up to it.
+
+“Where are the papers of this prisoner?” demanded a resolute-looking man
+in authority, who was summoned out by the guard.
+
+Naturally struck by the disagreeable word, Charles Darnay requested the
+speaker to take notice that he was a free traveller and French citizen,
+in charge of an escort which the disturbed state of the country had
+imposed upon him, and which he had paid for.
+
+“Where,” repeated the same personage, without taking any heed of him
+whatever, “are the papers of this prisoner?”
+
+The drunken patriot had them in his cap, and produced them. Casting his
+eyes over Gabelle’s letter, the same personage in authority showed some
+disorder and surprise, and looked at Darnay with a close attention.
+
+He left escort and escorted without saying a word, however, and went
+into the guard-room; meanwhile, they sat upon their horses outside the
+gate. Looking about him while in this state of suspense, Charles
+Darnay observed that the gate was held by a mixed guard of soldiers and
+patriots, the latter far outnumbering the former; and that while ingress
+into the city for peasants’ carts bringing in supplies, and for similar
+traffic and traffickers, was easy enough, egress, even for the homeliest
+people, was very difficult. A numerous medley of men and women, not
+to mention beasts and vehicles of various sorts, was waiting to issue
+forth; but, the previous identification was so strict, that they
+filtered through the barrier very slowly. Some of these people knew
+their turn for examination to be so far off, that they lay down on the
+ground to sleep or smoke, while others talked together, or loitered
+about. The red cap and tri-colour cockade were universal, both among men
+and women.
+
+When he had sat in his saddle some half-hour, taking note of these
+things, Darnay found himself confronted by the same man in authority,
+who directed the guard to open the barrier. Then he delivered to the
+escort, drunk and sober, a receipt for the escorted, and requested him
+to dismount. He did so, and the two patriots, leading his tired horse,
+turned and rode away without entering the city.
+
+He accompanied his conductor into a guard-room, smelling of common wine
+and tobacco, where certain soldiers and patriots, asleep and awake,
+drunk and sober, and in various neutral states between sleeping and
+waking, drunkenness and sobriety, were standing and lying about. The
+light in the guard-house, half derived from the waning oil-lamps of
+the night, and half from the overcast day, was in a correspondingly
+uncertain condition. Some registers were lying open on a desk, and an
+officer of a coarse, dark aspect, presided over these.
+
+“Citizen Defarge,” said he to Darnay’s conductor, as he took a slip of
+paper to write on. “Is this the emigrant Evremonde?”
+
+“This is the man.”
+
+“Your age, Evremonde?”
+
+“Thirty-seven.”
+
+“Married, Evremonde?”
+
+“Yes.”
+
+“Where married?”
+
+“In England.”
+
+“Without doubt. Where is your wife, Evremonde?”
+
+“In England.”
+
+“Without doubt. You are consigned, Evremonde, to the prison of La
+Force.”
+
+“Just Heaven!” exclaimed Darnay. “Under what law, and for what offence?”
+
+The officer looked up from his slip of paper for a moment.
+
+“We have new laws, Evremonde, and new offences, since you were here.” He
+said it with a hard smile, and went on writing.
+
+“I entreat you to observe that I have come here voluntarily, in response
+to that written appeal of a fellow-countryman which lies before you. I
+demand no more than the opportunity to do so without delay. Is not that
+my right?”
+
+“Emigrants have no rights, Evremonde,” was the stolid reply. The officer
+wrote until he had finished, read over to himself what he had written,
+sanded it, and handed it to Defarge, with the words “In secret.”
+
+Defarge motioned with the paper to the prisoner that he must accompany
+him. The prisoner obeyed, and a guard of two armed patriots attended
+them.
+
+“Is it you,” said Defarge, in a low voice, as they went down the
+guardhouse steps and turned into Paris, “who married the daughter of
+Doctor Manette, once a prisoner in the Bastille that is no more?”
+
+“Yes,” replied Darnay, looking at him with surprise.
+
+“My name is Defarge, and I keep a wine-shop in the Quarter Saint
+Antoine. Possibly you have heard of me.”
+
+“My wife came to your house to reclaim her father? Yes!”
+
+The word “wife” seemed to serve as a gloomy reminder to Defarge, to say
+with sudden impatience, “In the name of that sharp female newly-born,
+and called La Guillotine, why did you come to France?”
+
+“You heard me say why, a minute ago. Do you not believe it is the
+truth?”
+
+“A bad truth for you,” said Defarge, speaking with knitted brows, and
+looking straight before him.
+
+“Indeed I am lost here. All here is so unprecedented, so changed, so
+sudden and unfair, that I am absolutely lost. Will you render me a
+little help?”
+
+“None.” Defarge spoke, always looking straight before him.
+
+“Will you answer me a single question?”
+
+“Perhaps. According to its nature. You can say what it is.”
+
+“In this prison that I am going to so unjustly, shall I have some free
+communication with the world outside?”
+
+“You will see.”
+
+“I am not to be buried there, prejudged, and without any means of
+presenting my case?”
+
+“You will see. But, what then? Other people have been similarly buried
+in worse prisons, before now.”
+
+“But never by me, Citizen Defarge.”
+
+Defarge glanced darkly at him for answer, and walked on in a steady
+and set silence. The deeper he sank into this silence, the fainter hope
+there was--or so Darnay thought--of his softening in any slight degree.
+He, therefore, made haste to say:
+
+“It is of the utmost importance to me (you know, Citizen, even better
+than I, of how much importance), that I should be able to communicate to
+Mr. Lorry of Tellson’s Bank, an English gentleman who is now in Paris,
+the simple fact, without comment, that I have been thrown into the
+prison of La Force. Will you cause that to be done for me?”
+
+“I will do,” Defarge doggedly rejoined, “nothing for you. My duty is to
+my country and the People. I am the sworn servant of both, against you.
+I will do nothing for you.”
+
+Charles Darnay felt it hopeless to entreat him further, and his pride
+was touched besides. As they walked on in silence, he could not but see
+how used the people were to the spectacle of prisoners passing along the
+streets. The very children scarcely noticed him. A few passers turned
+their heads, and a few shook their fingers at him as an aristocrat;
+otherwise, that a man in good clothes should be going to prison, was no
+more remarkable than that a labourer in working clothes should be
+going to work. In one narrow, dark, and dirty street through which they
+passed, an excited orator, mounted on a stool, was addressing an excited
+audience on the crimes against the people, of the king and the royal
+family. The few words that he caught from this man’s lips, first made
+it known to Charles Darnay that the king was in prison, and that the
+foreign ambassadors had one and all left Paris. On the road (except at
+Beauvais) he had heard absolutely nothing. The escort and the universal
+watchfulness had completely isolated him.
+
+That he had fallen among far greater dangers than those which had
+developed themselves when he left England, he of course knew now. That
+perils had thickened about him fast, and might thicken faster and faster
+yet, he of course knew now. He could not but admit to himself that he
+might not have made this journey, if he could have foreseen the events
+of a few days. And yet his misgivings were not so dark as, imagined by
+the light of this later time, they would appear. Troubled as the future
+was, it was the unknown future, and in its obscurity there was ignorant
+hope. The horrible massacre, days and nights long, which, within a few
+rounds of the clock, was to set a great mark of blood upon the blessed
+garnering time of harvest, was as far out of his knowledge as if it had
+been a hundred thousand years away. The “sharp female newly-born, and
+called La Guillotine,” was hardly known to him, or to the generality
+of people, by name. The frightful deeds that were to be soon done, were
+probably unimagined at that time in the brains of the doers. How could
+they have a place in the shadowy conceptions of a gentle mind?
+
+Of unjust treatment in detention and hardship, and in cruel separation
+from his wife and child, he foreshadowed the likelihood, or the
+certainty; but, beyond this, he dreaded nothing distinctly. With this on
+his mind, which was enough to carry into a dreary prison courtyard, he
+arrived at the prison of La Force.
+
+A man with a bloated face opened the strong wicket, to whom Defarge
+presented “The Emigrant Evremonde.”
+
+“What the Devil! How many more of them!” exclaimed the man with the
+bloated face.
+
+Defarge took his receipt without noticing the exclamation, and withdrew,
+with his two fellow-patriots.
+
+“What the Devil, I say again!” exclaimed the gaoler, left with his wife.
+“How many more!”
+
+The gaoler’s wife, being provided with no answer to the question, merely
+replied, “One must have patience, my dear!” Three turnkeys who entered
+responsive to a bell she rang, echoed the sentiment, and one added, “For
+the love of Liberty;” which sounded in that place like an inappropriate
+conclusion.
+
+The prison of La Force was a gloomy prison, dark and filthy, and with a
+horrible smell of foul sleep in it. Extraordinary how soon the noisome
+flavour of imprisoned sleep, becomes manifest in all such places that
+are ill cared for!
+
+“In secret, too,” grumbled the gaoler, looking at the written paper. “As
+if I was not already full to bursting!”
+
+He stuck the paper on a file, in an ill-humour, and Charles Darnay
+awaited his further pleasure for half an hour: sometimes, pacing to and
+fro in the strong arched room: sometimes, resting on a stone seat: in
+either case detained to be imprinted on the memory of the chief and his
+subordinates.
+
+“Come!” said the chief, at length taking up his keys, “come with me,
+emigrant.”
+
+Through the dismal prison twilight, his new charge accompanied him by
+corridor and staircase, many doors clanging and locking behind them,
+until they came into a large, low, vaulted chamber, crowded with
+prisoners of both sexes. The women were seated at a long table, reading
+and writing, knitting, sewing, and embroidering; the men were for the
+most part standing behind their chairs, or lingering up and down the
+room.
+
+In the instinctive association of prisoners with shameful crime and
+disgrace, the new-comer recoiled from this company. But the crowning
+unreality of his long unreal ride, was, their all at once rising to
+receive him, with every refinement of manner known to the time, and with
+all the engaging graces and courtesies of life.
+
+So strangely clouded were these refinements by the prison manners and
+gloom, so spectral did they become in the inappropriate squalor and
+misery through which they were seen, that Charles Darnay seemed to stand
+in a company of the dead. Ghosts all! The ghost of beauty, the ghost
+of stateliness, the ghost of elegance, the ghost of pride, the ghost of
+frivolity, the ghost of wit, the ghost of youth, the ghost of age, all
+waiting their dismissal from the desolate shore, all turning on him eyes
+that were changed by the death they had died in coming there.
+
+It struck him motionless. The gaoler standing at his side, and the other
+gaolers moving about, who would have been well enough as to appearance
+in the ordinary exercise of their functions, looked so extravagantly
+coarse contrasted with sorrowing mothers and blooming daughters who were
+there--with the apparitions of the coquette, the young beauty, and the
+mature woman delicately bred--that the inversion of all experience and
+likelihood which the scene of shadows presented, was heightened to its
+utmost. Surely, ghosts all. Surely, the long unreal ride some progress
+of disease that had brought him to these gloomy shades!
+
+“In the name of the assembled companions in misfortune,” said a
+gentleman of courtly appearance and address, coming forward, “I have the
+honour of giving you welcome to La Force, and of condoling with you
+on the calamity that has brought you among us. May it soon terminate
+happily! It would be an impertinence elsewhere, but it is not so here,
+to ask your name and condition?”
+
+Charles Darnay roused himself, and gave the required information, in
+words as suitable as he could find.
+
+“But I hope,” said the gentleman, following the chief gaoler with his
+eyes, who moved across the room, “that you are not in secret?”
+
+“I do not understand the meaning of the term, but I have heard them say
+so.”
+
+“Ah, what a pity! We so much regret it! But take courage; several
+members of our society have been in secret, at first, and it has lasted
+but a short time.” Then he added, raising his voice, “I grieve to inform
+the society--in secret.”
+
+There was a murmur of commiseration as Charles Darnay crossed the room
+to a grated door where the gaoler awaited him, and many voices--among
+which, the soft and compassionate voices of women were conspicuous--gave
+him good wishes and encouragement. He turned at the grated door, to
+render the thanks of his heart; it closed under the gaoler’s hand; and
+the apparitions vanished from his sight forever.
+
+The wicket opened on a stone staircase, leading upward. When they had
+ascended forty steps (the prisoner of half an hour already counted
+them), the gaoler opened a low black door, and they passed into a
+solitary cell. It struck cold and damp, but was not dark.
+
+“Yours,” said the gaoler.
+
+“Why am I confined alone?”
+
+“How do I know!”
+
+“I can buy pen, ink, and paper?”
+
+“Such are not my orders. You will be visited, and can ask then. At
+present, you may buy your food, and nothing more.”
+
+There were in the cell, a chair, a table, and a straw mattress. As
+the gaoler made a general inspection of these objects, and of the four
+walls, before going out, a wandering fancy wandered through the mind of
+the prisoner leaning against the wall opposite to him, that this gaoler
+was so unwholesomely bloated, both in face and person, as to look like
+a man who had been drowned and filled with water. When the gaoler was
+gone, he thought in the same wandering way, “Now am I left, as if I were
+dead.” Stopping then, to look down at the mattress, he turned from it
+with a sick feeling, and thought, “And here in these crawling creatures
+is the first condition of the body after death.”
+
+“Five paces by four and a half, five paces by four and a half, five
+paces by four and a half.” The prisoner walked to and fro in his cell,
+counting its measurement, and the roar of the city arose like muffled
+drums with a wild swell of voices added to them. “He made shoes, he made
+shoes, he made shoes.” The prisoner counted the measurement again, and
+paced faster, to draw his mind with him from that latter repetition.
+“The ghosts that vanished when the wicket closed. There was one among
+them, the appearance of a lady dressed in black, who was leaning in the
+embrasure of a window, and she had a light shining upon her golden
+hair, and she looked like * * * * Let us ride on again, for God’s sake,
+through the illuminated villages with the people all awake! * * * * He
+made shoes, he made shoes, he made shoes. * * * * Five paces by four and
+a half.” With such scraps tossing and rolling upward from the depths of
+his mind, the prisoner walked faster and faster, obstinately counting
+and counting; and the roar of the city changed to this extent--that it
+still rolled in like muffled drums, but with the wail of voices that he
+knew, in the swell that rose above them.
+
+
+
+
+II. The Grindstone
+
+
+Tellson’s Bank, established in the Saint Germain Quarter of Paris, was
+in a wing of a large house, approached by a courtyard and shut off from
+the street by a high wall and a strong gate. The house belonged to
+a great nobleman who had lived in it until he made a flight from the
+troubles, in his own cook’s dress, and got across the borders. A
+mere beast of the chase flying from hunters, he was still in his
+metempsychosis no other than the same Monseigneur, the preparation
+of whose chocolate for whose lips had once occupied three strong men
+besides the cook in question.
+
+Monseigneur gone, and the three strong men absolving themselves from the
+sin of having drawn his high wages, by being more than ready and
+willing to cut his throat on the altar of the dawning Republic one and
+indivisible of Liberty, Equality, Fraternity, or Death, Monseigneur’s
+house had been first sequestrated, and then confiscated. For, all
+things moved so fast, and decree followed decree with that fierce
+precipitation, that now upon the third night of the autumn month
+of September, patriot emissaries of the law were in possession of
+Monseigneur’s house, and had marked it with the tri-colour, and were
+drinking brandy in its state apartments.
+
+A place of business in London like Tellson’s place of business in Paris,
+would soon have driven the House out of its mind and into the Gazette.
+For, what would staid British responsibility and respectability have
+said to orange-trees in boxes in a Bank courtyard, and even to a Cupid
+over the counter? Yet such things were. Tellson’s had whitewashed the
+Cupid, but he was still to be seen on the ceiling, in the coolest
+linen, aiming (as he very often does) at money from morning to
+night. Bankruptcy must inevitably have come of this young Pagan, in
+Lombard-street, London, and also of a curtained alcove in the rear of
+the immortal boy, and also of a looking-glass let into the wall, and
+also of clerks not at all old, who danced in public on the slightest
+provocation. Yet, a French Tellson’s could get on with these things
+exceedingly well, and, as long as the times held together, no man had
+taken fright at them, and drawn out his money.
+
+What money would be drawn out of Tellson’s henceforth, and what would
+lie there, lost and forgotten; what plate and jewels would tarnish in
+Tellson’s hiding-places, while the depositors rusted in prisons,
+and when they should have violently perished; how many accounts with
+Tellson’s never to be balanced in this world, must be carried over into
+the next; no man could have said, that night, any more than Mr. Jarvis
+Lorry could, though he thought heavily of these questions. He sat by
+a newly-lighted wood fire (the blighted and unfruitful year was
+prematurely cold), and on his honest and courageous face there was a
+deeper shade than the pendent lamp could throw, or any object in the
+room distortedly reflect--a shade of horror.
+
+He occupied rooms in the Bank, in his fidelity to the House of which
+he had grown to be a part, like strong root-ivy. It chanced that they
+derived a kind of security from the patriotic occupation of the main
+building, but the true-hearted old gentleman never calculated about
+that. All such circumstances were indifferent to him, so that he did
+his duty. On the opposite side of the courtyard, under a colonnade,
+was extensive standing--for carriages--where, indeed, some carriages
+of Monseigneur yet stood. Against two of the pillars were fastened two
+great flaring flambeaux, and in the light of these, standing out in the
+open air, was a large grindstone: a roughly mounted thing which appeared
+to have hurriedly been brought there from some neighbouring smithy,
+or other workshop. Rising and looking out of window at these harmless
+objects, Mr. Lorry shivered, and retired to his seat by the fire. He had
+opened, not only the glass window, but the lattice blind outside it, and
+he had closed both again, and he shivered through his frame.
+
+From the streets beyond the high wall and the strong gate, there came
+the usual night hum of the city, with now and then an indescribable ring
+in it, weird and unearthly, as if some unwonted sounds of a terrible
+nature were going up to Heaven.
+
+“Thank God,” said Mr. Lorry, clasping his hands, “that no one near and
+dear to me is in this dreadful town to-night. May He have mercy on all
+who are in danger!”
+
+Soon afterwards, the bell at the great gate sounded, and he thought,
+“They have come back!” and sat listening. But, there was no loud
+irruption into the courtyard, as he had expected, and he heard the gate
+clash again, and all was quiet.
+
+The nervousness and dread that were upon him inspired that vague
+uneasiness respecting the Bank, which a great change would naturally
+awaken, with such feelings roused. It was well guarded, and he got up to
+go among the trusty people who were watching it, when his door suddenly
+opened, and two figures rushed in, at sight of which he fell back in
+amazement.
+
+Lucie and her father! Lucie with her arms stretched out to him, and with
+that old look of earnestness so concentrated and intensified, that it
+seemed as though it had been stamped upon her face expressly to give
+force and power to it in this one passage of her life.
+
+“What is this?” cried Mr. Lorry, breathless and confused. “What is the
+matter? Lucie! Manette! What has happened? What has brought you here?
+What is it?”
+
+With the look fixed upon him, in her paleness and wildness, she panted
+out in his arms, imploringly, “O my dear friend! My husband!”
+
+“Your husband, Lucie?”
+
+“Charles.”
+
+“What of Charles?”
+
+“Here.
+
+“Here, in Paris?”
+
+“Has been here some days--three or four--I don’t know how many--I can’t
+collect my thoughts. An errand of generosity brought him here unknown to
+us; he was stopped at the barrier, and sent to prison.”
+
+The old man uttered an irrepressible cry. Almost at the same moment, the
+bell of the great gate rang again, and a loud noise of feet and voices
+came pouring into the courtyard.
+
+“What is that noise?” said the Doctor, turning towards the window.
+
+“Don’t look!” cried Mr. Lorry. “Don’t look out! Manette, for your life,
+don’t touch the blind!”
+
+The Doctor turned, with his hand upon the fastening of the window, and
+said, with a cool, bold smile:
+
+“My dear friend, I have a charmed life in this city. I have been
+a Bastille prisoner. There is no patriot in Paris--in Paris? In
+France--who, knowing me to have been a prisoner in the Bastille, would
+touch me, except to overwhelm me with embraces, or carry me in triumph.
+My old pain has given me a power that has brought us through the
+barrier, and gained us news of Charles there, and brought us here. I
+knew it would be so; I knew I could help Charles out of all danger; I
+told Lucie so.--What is that noise?” His hand was again upon the window.
+
+“Don’t look!” cried Mr. Lorry, absolutely desperate. “No, Lucie, my
+dear, nor you!” He got his arm round her, and held her. “Don’t be so
+terrified, my love. I solemnly swear to you that I know of no harm
+having happened to Charles; that I had no suspicion even of his being in
+this fatal place. What prison is he in?”
+
+“La Force!”
+
+“La Force! Lucie, my child, if ever you were brave and serviceable in
+your life--and you were always both--you will compose yourself now, to
+do exactly as I bid you; for more depends upon it than you can think, or
+I can say. There is no help for you in any action on your part to-night;
+you cannot possibly stir out. I say this, because what I must bid you
+to do for Charles’s sake, is the hardest thing to do of all. You must
+instantly be obedient, still, and quiet. You must let me put you in a
+room at the back here. You must leave your father and me alone for
+two minutes, and as there are Life and Death in the world you must not
+delay.”
+
+“I will be submissive to you. I see in your face that you know I can do
+nothing else than this. I know you are true.”
+
+The old man kissed her, and hurried her into his room, and turned the
+key; then, came hurrying back to the Doctor, and opened the window and
+partly opened the blind, and put his hand upon the Doctor’s arm, and
+looked out with him into the courtyard.
+
+Looked out upon a throng of men and women: not enough in number, or near
+enough, to fill the courtyard: not more than forty or fifty in all. The
+people in possession of the house had let them in at the gate, and they
+had rushed in to work at the grindstone; it had evidently been set up
+there for their purpose, as in a convenient and retired spot.
+
+But, such awful workers, and such awful work!
+
+The grindstone had a double handle, and, turning at it madly were two
+men, whose faces, as their long hair flapped back when the whirlings of
+the grindstone brought their faces up, were more horrible and cruel than
+the visages of the wildest savages in their most barbarous disguise.
+False eyebrows and false moustaches were stuck upon them, and their
+hideous countenances were all bloody and sweaty, and all awry with
+howling, and all staring and glaring with beastly excitement and want of
+sleep. As these ruffians turned and turned, their matted locks now flung
+forward over their eyes, now flung backward over their necks, some women
+held wine to their mouths that they might drink; and what with dropping
+blood, and what with dropping wine, and what with the stream of sparks
+struck out of the stone, all their wicked atmosphere seemed gore and
+fire. The eye could not detect one creature in the group free from
+the smear of blood. Shouldering one another to get next at the
+sharpening-stone, were men stripped to the waist, with the stain all
+over their limbs and bodies; men in all sorts of rags, with the stain
+upon those rags; men devilishly set off with spoils of women’s lace
+and silk and ribbon, with the stain dyeing those trifles through
+and through. Hatchets, knives, bayonets, swords, all brought to be
+sharpened, were all red with it. Some of the hacked swords were tied to
+the wrists of those who carried them, with strips of linen and fragments
+of dress: ligatures various in kind, but all deep of the one colour. And
+as the frantic wielders of these weapons snatched them from the stream
+of sparks and tore away into the streets, the same red hue was red in
+their frenzied eyes;--eyes which any unbrutalised beholder would have
+given twenty years of life, to petrify with a well-directed gun.
+
+All this was seen in a moment, as the vision of a drowning man, or of
+any human creature at any very great pass, could see a world if it
+were there. They drew back from the window, and the Doctor looked for
+explanation in his friend’s ashy face.
+
+“They are,” Mr. Lorry whispered the words, glancing fearfully round at
+the locked room, “murdering the prisoners. If you are sure of what you
+say; if you really have the power you think you have--as I believe you
+have--make yourself known to these devils, and get taken to La Force. It
+may be too late, I don’t know, but let it not be a minute later!”
+
+Doctor Manette pressed his hand, hastened bareheaded out of the room,
+and was in the courtyard when Mr. Lorry regained the blind.
+
+His streaming white hair, his remarkable face, and the impetuous
+confidence of his manner, as he put the weapons aside like water,
+carried him in an instant to the heart of the concourse at the stone.
+For a few moments there was a pause, and a hurry, and a murmur, and
+the unintelligible sound of his voice; and then Mr. Lorry saw him,
+surrounded by all, and in the midst of a line of twenty men long, all
+linked shoulder to shoulder, and hand to shoulder, hurried out with
+cries of--“Live the Bastille prisoner! Help for the Bastille prisoner’s
+kindred in La Force! Room for the Bastille prisoner in front there! Save
+the prisoner Evremonde at La Force!” and a thousand answering shouts.
+
+He closed the lattice again with a fluttering heart, closed the window
+and the curtain, hastened to Lucie, and told her that her father was
+assisted by the people, and gone in search of her husband. He found
+her child and Miss Pross with her; but, it never occurred to him to be
+surprised by their appearance until a long time afterwards, when he sat
+watching them in such quiet as the night knew.
+
+Lucie had, by that time, fallen into a stupor on the floor at his feet,
+clinging to his hand. Miss Pross had laid the child down on his own
+bed, and her head had gradually fallen on the pillow beside her pretty
+charge. O the long, long night, with the moans of the poor wife! And O
+the long, long night, with no return of her father and no tidings!
+
+Twice more in the darkness the bell at the great gate sounded, and the
+irruption was repeated, and the grindstone whirled and spluttered.
+“What is it?” cried Lucie, affrighted. “Hush! The soldiers’ swords are
+sharpened there,” said Mr. Lorry. “The place is national property now,
+and used as a kind of armoury, my love.”
+
+Twice more in all; but, the last spell of work was feeble and fitful.
+Soon afterwards the day began to dawn, and he softly detached himself
+from the clasping hand, and cautiously looked out again. A man, so
+besmeared that he might have been a sorely wounded soldier creeping back
+to consciousness on a field of slain, was rising from the pavement by
+the side of the grindstone, and looking about him with a vacant air.
+Shortly, this worn-out murderer descried in the imperfect light one of
+the carriages of Monseigneur, and, staggering to that gorgeous vehicle,
+climbed in at the door, and shut himself up to take his rest on its
+dainty cushions.
+
+The great grindstone, Earth, had turned when Mr. Lorry looked out again,
+and the sun was red on the courtyard. But, the lesser grindstone stood
+alone there in the calm morning air, with a red upon it that the sun had
+never given, and would never take away.
+
+
+
+
+III. The Shadow
+
+
+One of the first considerations which arose in the business mind of Mr.
+Lorry when business hours came round, was this:--that he had no right to
+imperil Tellson’s by sheltering the wife of an emigrant prisoner under
+the Bank roof. His own possessions, safety, life, he would have hazarded
+for Lucie and her child, without a moment’s demur; but the great trust
+he held was not his own, and as to that business charge he was a strict
+man of business.
+
+At first, his mind reverted to Defarge, and he thought of finding out
+the wine-shop again and taking counsel with its master in reference to
+the safest dwelling-place in the distracted state of the city. But, the
+same consideration that suggested him, repudiated him; he lived in the
+most violent Quarter, and doubtless was influential there, and deep in
+its dangerous workings.
+
+Noon coming, and the Doctor not returning, and every minute’s delay
+tending to compromise Tellson’s, Mr. Lorry advised with Lucie. She said
+that her father had spoken of hiring a lodging for a short term, in that
+Quarter, near the Banking-house. As there was no business objection to
+this, and as he foresaw that even if it were all well with Charles, and
+he were to be released, he could not hope to leave the city, Mr. Lorry
+went out in quest of such a lodging, and found a suitable one, high up
+in a removed by-street where the closed blinds in all the other windows
+of a high melancholy square of buildings marked deserted homes.
+
+To this lodging he at once removed Lucie and her child, and Miss Pross:
+giving them what comfort he could, and much more than he had himself.
+He left Jerry with them, as a figure to fill a doorway that would bear
+considerable knocking on the head, and returned to his own occupations.
+A disturbed and doleful mind he brought to bear upon them, and slowly
+and heavily the day lagged on with him.
+
+It wore itself out, and wore him out with it, until the Bank closed. He
+was again alone in his room of the previous night, considering what to
+do next, when he heard a foot upon the stair. In a few moments, a
+man stood in his presence, who, with a keenly observant look at him,
+addressed him by his name.
+
+“Your servant,” said Mr. Lorry. “Do you know me?”
+
+He was a strongly made man with dark curling hair, from forty-five
+to fifty years of age. For answer he repeated, without any change of
+emphasis, the words:
+
+“Do you know me?”
+
+“I have seen you somewhere.”
+
+“Perhaps at my wine-shop?”
+
+Much interested and agitated, Mr. Lorry said: “You come from Doctor
+Manette?”
+
+“Yes. I come from Doctor Manette.”
+
+“And what says he? What does he send me?”
+
+Defarge gave into his anxious hand, an open scrap of paper. It bore the
+words in the Doctor’s writing:
+
+    “Charles is safe, but I cannot safely leave this place yet.
+     I have obtained the favour that the bearer has a short note
+     from Charles to his wife.  Let the bearer see his wife.”
+
+It was dated from La Force, within an hour.
+
+“Will you accompany me,” said Mr. Lorry, joyfully relieved after reading
+this note aloud, “to where his wife resides?”
+
+“Yes,” returned Defarge.
+
+Scarcely noticing as yet, in what a curiously reserved and mechanical
+way Defarge spoke, Mr. Lorry put on his hat and they went down into the
+courtyard. There, they found two women; one, knitting.
+
+“Madame Defarge, surely!” said Mr. Lorry, who had left her in exactly
+the same attitude some seventeen years ago.
+
+“It is she,” observed her husband.
+
+“Does Madame go with us?” inquired Mr. Lorry, seeing that she moved as
+they moved.
+
+“Yes. That she may be able to recognise the faces and know the persons.
+It is for their safety.”
+
+Beginning to be struck by Defarge’s manner, Mr. Lorry looked dubiously
+at him, and led the way. Both the women followed; the second woman being
+The Vengeance.
+
+They passed through the intervening streets as quickly as they might,
+ascended the staircase of the new domicile, were admitted by Jerry,
+and found Lucie weeping, alone. She was thrown into a transport by the
+tidings Mr. Lorry gave her of her husband, and clasped the hand that
+delivered his note--little thinking what it had been doing near him in
+the night, and might, but for a chance, have done to him.
+
+     “DEAREST,--Take courage.  I am well, and your father has
+      influence around me.  You cannot answer this.
+      Kiss our child for me.”
+
+That was all the writing. It was so much, however, to her who received
+it, that she turned from Defarge to his wife, and kissed one of the
+hands that knitted. It was a passionate, loving, thankful, womanly
+action, but the hand made no response--dropped cold and heavy, and took
+to its knitting again.
+
+There was something in its touch that gave Lucie a check. She stopped in
+the act of putting the note in her bosom, and, with her hands yet at her
+neck, looked terrified at Madame Defarge. Madame Defarge met the lifted
+eyebrows and forehead with a cold, impassive stare.
+
+“My dear,” said Mr. Lorry, striking in to explain; “there are frequent
+risings in the streets; and, although it is not likely they will ever
+trouble you, Madame Defarge wishes to see those whom she has the power
+to protect at such times, to the end that she may know them--that she
+may identify them. I believe,” said Mr. Lorry, rather halting in his
+reassuring words, as the stony manner of all the three impressed itself
+upon him more and more, “I state the case, Citizen Defarge?”
+
+Defarge looked gloomily at his wife, and gave no other answer than a
+gruff sound of acquiescence.
+
+“You had better, Lucie,” said Mr. Lorry, doing all he could to
+propitiate, by tone and manner, “have the dear child here, and our
+good Pross. Our good Pross, Defarge, is an English lady, and knows no
+French.”
+
+The lady in question, whose rooted conviction that she was more than a
+match for any foreigner, was not to be shaken by distress and, danger,
+appeared with folded arms, and observed in English to The Vengeance,
+whom her eyes first encountered, “Well, I am sure, Boldface! I hope
+_you_ are pretty well!” She also bestowed a British cough on Madame
+Defarge; but, neither of the two took much heed of her.
+
+“Is that his child?” said Madame Defarge, stopping in her work for the
+first time, and pointing her knitting-needle at little Lucie as if it
+were the finger of Fate.
+
+“Yes, madame,” answered Mr. Lorry; “this is our poor prisoner’s darling
+daughter, and only child.”
+
+The shadow attendant on Madame Defarge and her party seemed to fall so
+threatening and dark on the child, that her mother instinctively
+kneeled on the ground beside her, and held her to her breast. The
+shadow attendant on Madame Defarge and her party seemed then to fall,
+threatening and dark, on both the mother and the child.
+
+“It is enough, my husband,” said Madame Defarge. “I have seen them. We
+may go.”
+
+But, the suppressed manner had enough of menace in it--not visible and
+presented, but indistinct and withheld--to alarm Lucie into saying, as
+she laid her appealing hand on Madame Defarge’s dress:
+
+“You will be good to my poor husband. You will do him no harm. You will
+help me to see him if you can?”
+
+“Your husband is not my business here,” returned Madame Defarge, looking
+down at her with perfect composure. “It is the daughter of your father
+who is my business here.”
+
+“For my sake, then, be merciful to my husband. For my child’s sake! She
+will put her hands together and pray you to be merciful. We are more
+afraid of you than of these others.”
+
+Madame Defarge received it as a compliment, and looked at her husband.
+Defarge, who had been uneasily biting his thumb-nail and looking at her,
+collected his face into a sterner expression.
+
+“What is it that your husband says in that little letter?” asked Madame
+Defarge, with a lowering smile. “Influence; he says something touching
+influence?”
+
+“That my father,” said Lucie, hurriedly taking the paper from her
+breast, but with her alarmed eyes on her questioner and not on it, “has
+much influence around him.”
+
+“Surely it will release him!” said Madame Defarge. “Let it do so.”
+
+“As a wife and mother,” cried Lucie, most earnestly, “I implore you to
+have pity on me and not to exercise any power that you possess, against
+my innocent husband, but to use it in his behalf. O sister-woman, think
+of me. As a wife and mother!”
+
+Madame Defarge looked, coldly as ever, at the suppliant, and said,
+turning to her friend The Vengeance:
+
+“The wives and mothers we have been used to see, since we were as little
+as this child, and much less, have not been greatly considered? We have
+known _their_ husbands and fathers laid in prison and kept from them,
+often enough? All our lives, we have seen our sister-women suffer, in
+themselves and in their children, poverty, nakedness, hunger, thirst,
+sickness, misery, oppression and neglect of all kinds?”
+
+“We have seen nothing else,” returned The Vengeance.
+
+“We have borne this a long time,” said Madame Defarge, turning her eyes
+again upon Lucie. “Judge you! Is it likely that the trouble of one wife
+and mother would be much to us now?”
+
+She resumed her knitting and went out. The Vengeance followed. Defarge
+went last, and closed the door.
+
+“Courage, my dear Lucie,” said Mr. Lorry, as he raised her. “Courage,
+courage! So far all goes well with us--much, much better than it has of
+late gone with many poor souls. Cheer up, and have a thankful heart.”
+
+“I am not thankless, I hope, but that dreadful woman seems to throw a
+shadow on me and on all my hopes.”
+
+“Tut, tut!” said Mr. Lorry; “what is this despondency in the brave
+little breast? A shadow indeed! No substance in it, Lucie.”
+
+But the shadow of the manner of these Defarges was dark upon himself,
+for all that, and in his secret mind it troubled him greatly.
+
+
+
+
+IV. Calm in Storm
+
+
+Doctor Manette did not return until the morning of the fourth day of his
+absence. So much of what had happened in that dreadful time as could be
+kept from the knowledge of Lucie was so well concealed from her, that
+not until long afterwards, when France and she were far apart, did she
+know that eleven hundred defenceless prisoners of both sexes and all
+ages had been killed by the populace; that four days and nights had been
+darkened by this deed of horror; and that the air around her had been
+tainted by the slain. She only knew that there had been an attack upon
+the prisons, that all political prisoners had been in danger, and that
+some had been dragged out by the crowd and murdered.
+
+To Mr. Lorry, the Doctor communicated under an injunction of secrecy on
+which he had no need to dwell, that the crowd had taken him through a
+scene of carnage to the prison of La Force. That, in the prison he had
+found a self-appointed Tribunal sitting, before which the prisoners were
+brought singly, and by which they were rapidly ordered to be put forth
+to be massacred, or to be released, or (in a few cases) to be sent back
+to their cells. That, presented by his conductors to this Tribunal, he
+had announced himself by name and profession as having been for eighteen
+years a secret and unaccused prisoner in the Bastille; that, one of the
+body so sitting in judgment had risen and identified him, and that this
+man was Defarge.
+
+That, hereupon he had ascertained, through the registers on the table,
+that his son-in-law was among the living prisoners, and had pleaded hard
+to the Tribunal--of whom some members were asleep and some awake, some
+dirty with murder and some clean, some sober and some not--for his life
+and liberty. That, in the first frantic greetings lavished on himself as
+a notable sufferer under the overthrown system, it had been accorded
+to him to have Charles Darnay brought before the lawless Court, and
+examined. That, he seemed on the point of being at once released, when
+the tide in his favour met with some unexplained check (not intelligible
+to the Doctor), which led to a few words of secret conference. That,
+the man sitting as President had then informed Doctor Manette that
+the prisoner must remain in custody, but should, for his sake, be held
+inviolate in safe custody. That, immediately, on a signal, the prisoner
+was removed to the interior of the prison again; but, that he, the
+Doctor, had then so strongly pleaded for permission to remain and
+assure himself that his son-in-law was, through no malice or mischance,
+delivered to the concourse whose murderous yells outside the gate had
+often drowned the proceedings, that he had obtained the permission, and
+had remained in that Hall of Blood until the danger was over.
+
+The sights he had seen there, with brief snatches of food and sleep by
+intervals, shall remain untold. The mad joy over the prisoners who were
+saved, had astounded him scarcely less than the mad ferocity against
+those who were cut to pieces. One prisoner there was, he said, who had
+been discharged into the street free, but at whom a mistaken savage had
+thrust a pike as he passed out. Being besought to go to him and dress
+the wound, the Doctor had passed out at the same gate, and had found him
+in the arms of a company of Samaritans, who were seated on the bodies
+of their victims. With an inconsistency as monstrous as anything in this
+awful nightmare, they had helped the healer, and tended the wounded man
+with the gentlest solicitude--had made a litter for him and escorted him
+carefully from the spot--had then caught up their weapons and plunged
+anew into a butchery so dreadful, that the Doctor had covered his eyes
+with his hands, and swooned away in the midst of it.
+
+As Mr. Lorry received these confidences, and as he watched the face of
+his friend now sixty-two years of age, a misgiving arose within him that
+such dread experiences would revive the old danger.
+
+But, he had never seen his friend in his present aspect: he had never
+at all known him in his present character. For the first time the Doctor
+felt, now, that his suffering was strength and power. For the first time
+he felt that in that sharp fire, he had slowly forged the iron which
+could break the prison door of his daughter’s husband, and deliver him.
+“It all tended to a good end, my friend; it was not mere waste and ruin.
+As my beloved child was helpful in restoring me to myself, I will be
+helpful now in restoring the dearest part of herself to her; by the aid
+of Heaven I will do it!” Thus, Doctor Manette. And when Jarvis Lorry saw
+the kindled eyes, the resolute face, the calm strong look and bearing
+of the man whose life always seemed to him to have been stopped, like a
+clock, for so many years, and then set going again with an energy which
+had lain dormant during the cessation of its usefulness, he believed.
+
+Greater things than the Doctor had at that time to contend with, would
+have yielded before his persevering purpose. While he kept himself
+in his place, as a physician, whose business was with all degrees
+of mankind, bond and free, rich and poor, bad and good, he used his
+personal influence so wisely, that he was soon the inspecting physician
+of three prisons, and among them of La Force. He could now assure Lucie
+that her husband was no longer confined alone, but was mixed with the
+general body of prisoners; he saw her husband weekly, and brought sweet
+messages to her, straight from his lips; sometimes her husband himself
+sent a letter to her (though never by the Doctor’s hand), but she was
+not permitted to write to him: for, among the many wild suspicions of
+plots in the prisons, the wildest of all pointed at emigrants who were
+known to have made friends or permanent connections abroad.
+
+This new life of the Doctor’s was an anxious life, no doubt; still, the
+sagacious Mr. Lorry saw that there was a new sustaining pride in it.
+Nothing unbecoming tinged the pride; it was a natural and worthy one;
+but he observed it as a curiosity. The Doctor knew, that up to that
+time, his imprisonment had been associated in the minds of his daughter
+and his friend, with his personal affliction, deprivation, and weakness.
+Now that this was changed, and he knew himself to be invested through
+that old trial with forces to which they both looked for Charles’s
+ultimate safety and deliverance, he became so far exalted by the change,
+that he took the lead and direction, and required them as the weak, to
+trust to him as the strong. The preceding relative positions of himself
+and Lucie were reversed, yet only as the liveliest gratitude and
+affection could reverse them, for he could have had no pride but in
+rendering some service to her who had rendered so much to him. “All
+curious to see,” thought Mr. Lorry, in his amiably shrewd way, “but all
+natural and right; so, take the lead, my dear friend, and keep it; it
+couldn’t be in better hands.”
+
+But, though the Doctor tried hard, and never ceased trying, to get
+Charles Darnay set at liberty, or at least to get him brought to trial,
+the public current of the time set too strong and fast for him. The new
+era began; the king was tried, doomed, and beheaded; the Republic of
+Liberty, Equality, Fraternity, or Death, declared for victory or death
+against the world in arms; the black flag waved night and day from the
+great towers of Notre Dame; three hundred thousand men, summoned to rise
+against the tyrants of the earth, rose from all the varying soils
+of France, as if the dragon’s teeth had been sown broadcast, and
+had yielded fruit equally on hill and plain, on rock, in gravel, and
+alluvial mud, under the bright sky of the South and under the clouds of
+the North, in fell and forest, in the vineyards and the olive-grounds
+and among the cropped grass and the stubble of the corn, along the
+fruitful banks of the broad rivers, and in the sand of the sea-shore.
+What private solicitude could rear itself against the deluge of the Year
+One of Liberty--the deluge rising from below, not falling from above,
+and with the windows of Heaven shut, not opened!
+
+There was no pause, no pity, no peace, no interval of relenting rest, no
+measurement of time. Though days and nights circled as regularly as when
+time was young, and the evening and morning were the first day, other
+count of time there was none. Hold of it was lost in the raging fever
+of a nation, as it is in the fever of one patient. Now, breaking the
+unnatural silence of a whole city, the executioner showed the people the
+head of the king--and now, it seemed almost in the same breath, the
+head of his fair wife which had had eight weary months of imprisoned
+widowhood and misery, to turn it grey.
+
+And yet, observing the strange law of contradiction which obtains in
+all such cases, the time was long, while it flamed by so fast. A
+revolutionary tribunal in the capital, and forty or fifty thousand
+revolutionary committees all over the land; a law of the Suspected,
+which struck away all security for liberty or life, and delivered over
+any good and innocent person to any bad and guilty one; prisons gorged
+with people who had committed no offence, and could obtain no hearing;
+these things became the established order and nature of appointed
+things, and seemed to be ancient usage before they were many weeks old.
+Above all, one hideous figure grew as familiar as if it had been before
+the general gaze from the foundations of the world--the figure of the
+sharp female called La Guillotine.
+
+It was the popular theme for jests; it was the best cure for headache,
+it infallibly prevented the hair from turning grey, it imparted a
+peculiar delicacy to the complexion, it was the National Razor which
+shaved close: who kissed La Guillotine, looked through the little window
+and sneezed into the sack. It was the sign of the regeneration of the
+human race. It superseded the Cross. Models of it were worn on breasts
+from which the Cross was discarded, and it was bowed down to and
+believed in where the Cross was denied.
+
+It sheared off heads so many, that it, and the ground it most polluted,
+were a rotten red. It was taken to pieces, like a toy-puzzle for a young
+Devil, and was put together again when the occasion wanted it. It hushed
+the eloquent, struck down the powerful, abolished the beautiful and
+good. Twenty-two friends of high public mark, twenty-one living and one
+dead, it had lopped the heads off, in one morning, in as many minutes.
+The name of the strong man of Old Scripture had descended to the chief
+functionary who worked it; but, so armed, he was stronger than his
+namesake, and blinder, and tore away the gates of God’s own Temple every
+day.
+
+Among these terrors, and the brood belonging to them, the Doctor walked
+with a steady head: confident in his power, cautiously persistent in his
+end, never doubting that he would save Lucie’s husband at last. Yet the
+current of the time swept by, so strong and deep, and carried the time
+away so fiercely, that Charles had lain in prison one year and three
+months when the Doctor was thus steady and confident. So much more
+wicked and distracted had the Revolution grown in that December month,
+that the rivers of the South were encumbered with the bodies of the
+violently drowned by night, and prisoners were shot in lines and squares
+under the southern wintry sun. Still, the Doctor walked among the
+terrors with a steady head. No man better known than he, in Paris at
+that day; no man in a stranger situation. Silent, humane, indispensable
+in hospital and prison, using his art equally among assassins and
+victims, he was a man apart. In the exercise of his skill, the
+appearance and the story of the Bastille Captive removed him from all
+other men. He was not suspected or brought in question, any more than if
+he had indeed been recalled to life some eighteen years before, or were
+a Spirit moving among mortals.
+
+
+
+
+V. The Wood-Sawyer
+
+
+One year and three months. During all that time Lucie was never
+sure, from hour to hour, but that the Guillotine would strike off her
+husband’s head next day. Every day, through the stony streets, the
+tumbrils now jolted heavily, filled with Condemned. Lovely girls; bright
+women, brown-haired, black-haired, and grey; youths; stalwart men and
+old; gentle born and peasant born; all red wine for La Guillotine, all
+daily brought into light from the dark cellars of the loathsome prisons,
+and carried to her through the streets to slake her devouring thirst.
+Liberty, equality, fraternity, or death;--the last, much the easiest to
+bestow, O Guillotine!
+
+If the suddenness of her calamity, and the whirling wheels of the time,
+had stunned the Doctor’s daughter into awaiting the result in idle
+despair, it would but have been with her as it was with many. But, from
+the hour when she had taken the white head to her fresh young bosom in
+the garret of Saint Antoine, she had been true to her duties. She was
+truest to them in the season of trial, as all the quietly loyal and good
+will always be.
+
+As soon as they were established in their new residence, and her father
+had entered on the routine of his avocations, she arranged the little
+household as exactly as if her husband had been there. Everything had
+its appointed place and its appointed time. Little Lucie she taught,
+as regularly, as if they had all been united in their English home. The
+slight devices with which she cheated herself into the show of a belief
+that they would soon be reunited--the little preparations for his speedy
+return, the setting aside of his chair and his books--these, and the
+solemn prayer at night for one dear prisoner especially, among the many
+unhappy souls in prison and the shadow of death--were almost the only
+outspoken reliefs of her heavy mind.
+
+She did not greatly alter in appearance. The plain dark dresses, akin to
+mourning dresses, which she and her child wore, were as neat and as well
+attended to as the brighter clothes of happy days. She lost her colour,
+and the old and intent expression was a constant, not an occasional,
+thing; otherwise, she remained very pretty and comely. Sometimes, at
+night on kissing her father, she would burst into the grief she had
+repressed all day, and would say that her sole reliance, under Heaven,
+was on him. He always resolutely answered: “Nothing can happen to him
+without my knowledge, and I know that I can save him, Lucie.”
+
+They had not made the round of their changed life many weeks, when her
+father said to her, on coming home one evening:
+
+“My dear, there is an upper window in the prison, to which Charles can
+sometimes gain access at three in the afternoon. When he can get to
+it--which depends on many uncertainties and incidents--he might see you
+in the street, he thinks, if you stood in a certain place that I can
+show you. But you will not be able to see him, my poor child, and even
+if you could, it would be unsafe for you to make a sign of recognition.”
+
+“O show me the place, my father, and I will go there every day.”
+
+From that time, in all weathers, she waited there two hours. As the
+clock struck two, she was there, and at four she turned resignedly away.
+When it was not too wet or inclement for her child to be with her, they
+went together; at other times she was alone; but, she never missed a
+single day.
+
+It was the dark and dirty corner of a small winding street. The hovel
+of a cutter of wood into lengths for burning, was the only house at that
+end; all else was wall. On the third day of her being there, he noticed
+her.
+
+“Good day, citizeness.”
+
+“Good day, citizen.”
+
+This mode of address was now prescribed by decree. It had been
+established voluntarily some time ago, among the more thorough patriots;
+but, was now law for everybody.
+
+“Walking here again, citizeness?”
+
+“You see me, citizen!”
+
+The wood-sawyer, who was a little man with a redundancy of gesture (he
+had once been a mender of roads), cast a glance at the prison, pointed
+at the prison, and putting his ten fingers before his face to represent
+bars, peeped through them jocosely.
+
+“But it’s not my business,” said he. And went on sawing his wood.
+
+Next day he was looking out for her, and accosted her the moment she
+appeared.
+
+“What? Walking here again, citizeness?”
+
+“Yes, citizen.”
+
+“Ah! A child too! Your mother, is it not, my little citizeness?”
+
+“Do I say yes, mamma?” whispered little Lucie, drawing close to her.
+
+“Yes, dearest.”
+
+“Yes, citizen.”
+
+“Ah! But it’s not my business. My work is my business. See my saw! I
+call it my Little Guillotine. La, la, la; La, la, la! And off his head
+comes!”
+
+The billet fell as he spoke, and he threw it into a basket.
+
+“I call myself the Samson of the firewood guillotine. See here again!
+Loo, loo, loo; Loo, loo, loo! And off _her_ head comes! Now, a child.
+Tickle, tickle; Pickle, pickle! And off _its_ head comes. All the
+family!”
+
+Lucie shuddered as he threw two more billets into his basket, but it was
+impossible to be there while the wood-sawyer was at work, and not be in
+his sight. Thenceforth, to secure his good will, she always spoke to him
+first, and often gave him drink-money, which he readily received.
+
+He was an inquisitive fellow, and sometimes when she had quite forgotten
+him in gazing at the prison roof and grates, and in lifting her heart
+up to her husband, she would come to herself to find him looking at her,
+with his knee on his bench and his saw stopped in its work. “But it’s
+not my business!” he would generally say at those times, and would
+briskly fall to his sawing again.
+
+In all weathers, in the snow and frost of winter, in the bitter winds of
+spring, in the hot sunshine of summer, in the rains of autumn, and again
+in the snow and frost of winter, Lucie passed two hours of every day at
+this place; and every day on leaving it, she kissed the prison wall.
+Her husband saw her (so she learned from her father) it might be once in
+five or six times: it might be twice or thrice running: it might be, not
+for a week or a fortnight together. It was enough that he could and did
+see her when the chances served, and on that possibility she would have
+waited out the day, seven days a week.
+
+These occupations brought her round to the December month, wherein her
+father walked among the terrors with a steady head. On a lightly-snowing
+afternoon she arrived at the usual corner. It was a day of some wild
+rejoicing, and a festival. She had seen the houses, as she came along,
+decorated with little pikes, and with little red caps stuck upon them;
+also, with tricoloured ribbons; also, with the standard inscription
+(tricoloured letters were the favourite), Republic One and Indivisible.
+Liberty, Equality, Fraternity, or Death!
+
+The miserable shop of the wood-sawyer was so small, that its whole
+surface furnished very indifferent space for this legend. He had got
+somebody to scrawl it up for him, however, who had squeezed Death in
+with most inappropriate difficulty. On his house-top, he displayed pike
+and cap, as a good citizen must, and in a window he had stationed his
+saw inscribed as his “Little Sainte Guillotine”--for the great sharp
+female was by that time popularly canonised. His shop was shut and he
+was not there, which was a relief to Lucie, and left her quite alone.
+
+But, he was not far off, for presently she heard a troubled movement
+and a shouting coming along, which filled her with fear. A moment
+afterwards, and a throng of people came pouring round the corner by the
+prison wall, in the midst of whom was the wood-sawyer hand in hand with
+The Vengeance. There could not be fewer than five hundred people, and
+they were dancing like five thousand demons. There was no other music
+than their own singing. They danced to the popular Revolution song,
+keeping a ferocious time that was like a gnashing of teeth in unison.
+Men and women danced together, women danced together, men danced
+together, as hazard had brought them together. At first, they were a
+mere storm of coarse red caps and coarse woollen rags; but, as they
+filled the place, and stopped to dance about Lucie, some ghastly
+apparition of a dance-figure gone raving mad arose among them. They
+advanced, retreated, struck at one another’s hands, clutched at one
+another’s heads, spun round alone, caught one another and spun round
+in pairs, until many of them dropped. While those were down, the rest
+linked hand in hand, and all spun round together: then the ring broke,
+and in separate rings of two and four they turned and turned until they
+all stopped at once, began again, struck, clutched, and tore, and then
+reversed the spin, and all spun round another way. Suddenly they stopped
+again, paused, struck out the time afresh, formed into lines the width
+of the public way, and, with their heads low down and their hands high
+up, swooped screaming off. No fight could have been half so terrible
+as this dance. It was so emphatically a fallen sport--a something, once
+innocent, delivered over to all devilry--a healthy pastime changed into
+a means of angering the blood, bewildering the senses, and steeling the
+heart. Such grace as was visible in it, made it the uglier, showing how
+warped and perverted all things good by nature were become. The maidenly
+bosom bared to this, the pretty almost-child’s head thus distracted, the
+delicate foot mincing in this slough of blood and dirt, were types of
+the disjointed time.
+
+This was the Carmagnole. As it passed, leaving Lucie frightened and
+bewildered in the doorway of the wood-sawyer’s house, the feathery snow
+fell as quietly and lay as white and soft, as if it had never been.
+
+“O my father!” for he stood before her when she lifted up the eyes she
+had momentarily darkened with her hand; “such a cruel, bad sight.”
+
+“I know, my dear, I know. I have seen it many times. Don’t be
+frightened! Not one of them would harm you.”
+
+“I am not frightened for myself, my father. But when I think of my
+husband, and the mercies of these people--”
+
+“We will set him above their mercies very soon. I left him climbing to
+the window, and I came to tell you. There is no one here to see. You may
+kiss your hand towards that highest shelving roof.”
+
+“I do so, father, and I send him my Soul with it!”
+
+“You cannot see him, my poor dear?”
+
+“No, father,” said Lucie, yearning and weeping as she kissed her hand,
+“no.”
+
+A footstep in the snow. Madame Defarge. “I salute you, citizeness,”
+ from the Doctor. “I salute you, citizen.” This in passing. Nothing more.
+Madame Defarge gone, like a shadow over the white road.
+
+“Give me your arm, my love. Pass from here with an air of cheerfulness
+and courage, for his sake. That was well done;” they had left the spot;
+“it shall not be in vain. Charles is summoned for to-morrow.”
+
+“For to-morrow!”
+
+“There is no time to lose. I am well prepared, but there are precautions
+to be taken, that could not be taken until he was actually summoned
+before the Tribunal. He has not received the notice yet, but I know
+that he will presently be summoned for to-morrow, and removed to the
+Conciergerie; I have timely information. You are not afraid?”
+
+She could scarcely answer, “I trust in you.”
+
+“Do so, implicitly. Your suspense is nearly ended, my darling; he shall
+be restored to you within a few hours; I have encompassed him with every
+protection. I must see Lorry.”
+
+He stopped. There was a heavy lumbering of wheels within hearing. They
+both knew too well what it meant. One. Two. Three. Three tumbrils faring
+away with their dread loads over the hushing snow.
+
+“I must see Lorry,” the Doctor repeated, turning her another way.
+
+The staunch old gentleman was still in his trust; had never left it. He
+and his books were in frequent requisition as to property confiscated
+and made national. What he could save for the owners, he saved. No
+better man living to hold fast by what Tellson’s had in keeping, and to
+hold his peace.
+
+A murky red and yellow sky, and a rising mist from the Seine, denoted
+the approach of darkness. It was almost dark when they arrived at the
+Bank. The stately residence of Monseigneur was altogether blighted and
+deserted. Above a heap of dust and ashes in the court, ran the letters:
+National Property. Republic One and Indivisible. Liberty, Equality,
+Fraternity, or Death!
+
+Who could that be with Mr. Lorry--the owner of the riding-coat upon the
+chair--who must not be seen? From whom newly arrived, did he come out,
+agitated and surprised, to take his favourite in his arms? To whom did
+he appear to repeat her faltering words, when, raising his voice and
+turning his head towards the door of the room from which he had issued,
+he said: “Removed to the Conciergerie, and summoned for to-morrow?”
+
+
+
+
+VI. Triumph
+
+
+The dread tribunal of five Judges, Public Prosecutor, and determined
+Jury, sat every day. Their lists went forth every evening, and were
+read out by the gaolers of the various prisons to their prisoners. The
+standard gaoler-joke was, “Come out and listen to the Evening Paper, you
+inside there!”
+
+“Charles Evremonde, called Darnay!”
+
+So at last began the Evening Paper at La Force.
+
+When a name was called, its owner stepped apart into a spot reserved
+for those who were announced as being thus fatally recorded. Charles
+Evremonde, called Darnay, had reason to know the usage; he had seen
+hundreds pass away so.
+
+His bloated gaoler, who wore spectacles to read with, glanced over them
+to assure himself that he had taken his place, and went through the
+list, making a similar short pause at each name. There were twenty-three
+names, but only twenty were responded to; for one of the prisoners so
+summoned had died in gaol and been forgotten, and two had already been
+guillotined and forgotten. The list was read, in the vaulted chamber
+where Darnay had seen the associated prisoners on the night of his
+arrival. Every one of those had perished in the massacre; every human
+creature he had since cared for and parted with, had died on the
+scaffold.
+
+There were hurried words of farewell and kindness, but the parting was
+soon over. It was the incident of every day, and the society of La Force
+were engaged in the preparation of some games of forfeits and a little
+concert, for that evening. They crowded to the grates and shed tears
+there; but, twenty places in the projected entertainments had to be
+refilled, and the time was, at best, short to the lock-up hour, when the
+common rooms and corridors would be delivered over to the great dogs
+who kept watch there through the night. The prisoners were far from
+insensible or unfeeling; their ways arose out of the condition of the
+time. Similarly, though with a subtle difference, a species of fervour
+or intoxication, known, without doubt, to have led some persons to
+brave the guillotine unnecessarily, and to die by it, was not mere
+boastfulness, but a wild infection of the wildly shaken public mind. In
+seasons of pestilence, some of us will have a secret attraction to the
+disease--a terrible passing inclination to die of it. And all of us have
+like wonders hidden in our breasts, only needing circumstances to evoke
+them.
+
+The passage to the Conciergerie was short and dark; the night in its
+vermin-haunted cells was long and cold. Next day, fifteen prisoners were
+put to the bar before Charles Darnay’s name was called. All the fifteen
+were condemned, and the trials of the whole occupied an hour and a half.
+
+“Charles Evremonde, called Darnay,” was at length arraigned.
+
+His judges sat upon the Bench in feathered hats; but the rough red cap
+and tricoloured cockade was the head-dress otherwise prevailing. Looking
+at the Jury and the turbulent audience, he might have thought that the
+usual order of things was reversed, and that the felons were trying the
+honest men. The lowest, cruelest, and worst populace of a city, never
+without its quantity of low, cruel, and bad, were the directing
+spirits of the scene: noisily commenting, applauding, disapproving,
+anticipating, and precipitating the result, without a check. Of the men,
+the greater part were armed in various ways; of the women, some wore
+knives, some daggers, some ate and drank as they looked on, many
+knitted. Among these last, was one, with a spare piece of knitting under
+her arm as she worked. She was in a front row, by the side of a man whom
+he had never seen since his arrival at the Barrier, but whom he directly
+remembered as Defarge. He noticed that she once or twice whispered in
+his ear, and that she seemed to be his wife; but, what he most noticed
+in the two figures was, that although they were posted as close to
+himself as they could be, they never looked towards him. They seemed to
+be waiting for something with a dogged determination, and they looked at
+the Jury, but at nothing else. Under the President sat Doctor Manette,
+in his usual quiet dress. As well as the prisoner could see, he and Mr.
+Lorry were the only men there, unconnected with the Tribunal, who
+wore their usual clothes, and had not assumed the coarse garb of the
+Carmagnole.
+
+Charles Evremonde, called Darnay, was accused by the public prosecutor
+as an emigrant, whose life was forfeit to the Republic, under the decree
+which banished all emigrants on pain of Death. It was nothing that the
+decree bore date since his return to France. There he was, and there was
+the decree; he had been taken in France, and his head was demanded.
+
+“Take off his head!” cried the audience. “An enemy to the Republic!”
+
+The President rang his bell to silence those cries, and asked the
+prisoner whether it was not true that he had lived many years in
+England?
+
+Undoubtedly it was.
+
+Was he not an emigrant then? What did he call himself?
+
+Not an emigrant, he hoped, within the sense and spirit of the law.
+
+Why not? the President desired to know.
+
+Because he had voluntarily relinquished a title that was distasteful
+to him, and a station that was distasteful to him, and had left
+his country--he submitted before the word emigrant in the present
+acceptation by the Tribunal was in use--to live by his own industry in
+England, rather than on the industry of the overladen people of France.
+
+What proof had he of this?
+
+He handed in the names of two witnesses; Theophile Gabelle, and
+Alexandre Manette.
+
+But he had married in England? the President reminded him.
+
+True, but not an English woman.
+
+A citizeness of France?
+
+Yes. By birth.
+
+Her name and family?
+
+“Lucie Manette, only daughter of Doctor Manette, the good physician who
+sits there.”
+
+This answer had a happy effect upon the audience. Cries in exaltation
+of the well-known good physician rent the hall. So capriciously were
+the people moved, that tears immediately rolled down several ferocious
+countenances which had been glaring at the prisoner a moment before, as
+if with impatience to pluck him out into the streets and kill him.
+
+On these few steps of his dangerous way, Charles Darnay had set his foot
+according to Doctor Manette’s reiterated instructions. The same cautious
+counsel directed every step that lay before him, and had prepared every
+inch of his road.
+
+The President asked, why had he returned to France when he did, and not
+sooner?
+
+He had not returned sooner, he replied, simply because he had no means
+of living in France, save those he had resigned; whereas, in England,
+he lived by giving instruction in the French language and literature.
+He had returned when he did, on the pressing and written entreaty of
+a French citizen, who represented that his life was endangered by his
+absence. He had come back, to save a citizen’s life, and to bear his
+testimony, at whatever personal hazard, to the truth. Was that criminal
+in the eyes of the Republic?
+
+The populace cried enthusiastically, “No!” and the President rang his
+bell to quiet them. Which it did not, for they continued to cry “No!”
+ until they left off, of their own will.
+
+The President required the name of that citizen. The accused explained
+that the citizen was his first witness. He also referred with confidence
+to the citizen’s letter, which had been taken from him at the Barrier,
+but which he did not doubt would be found among the papers then before
+the President.
+
+The Doctor had taken care that it should be there--had assured him that
+it would be there--and at this stage of the proceedings it was produced
+and read. Citizen Gabelle was called to confirm it, and did so. Citizen
+Gabelle hinted, with infinite delicacy and politeness, that in the
+pressure of business imposed on the Tribunal by the multitude of
+enemies of the Republic with which it had to deal, he had been slightly
+overlooked in his prison of the Abbaye--in fact, had rather passed out
+of the Tribunal’s patriotic remembrance--until three days ago; when he
+had been summoned before it, and had been set at liberty on the Jury’s
+declaring themselves satisfied that the accusation against him was
+answered, as to himself, by the surrender of the citizen Evremonde,
+called Darnay.
+
+Doctor Manette was next questioned. His high personal popularity,
+and the clearness of his answers, made a great impression; but, as he
+proceeded, as he showed that the Accused was his first friend on his
+release from his long imprisonment; that, the accused had remained in
+England, always faithful and devoted to his daughter and himself in
+their exile; that, so far from being in favour with the Aristocrat
+government there, he had actually been tried for his life by it, as
+the foe of England and friend of the United States--as he brought these
+circumstances into view, with the greatest discretion and with the
+straightforward force of truth and earnestness, the Jury and the
+populace became one. At last, when he appealed by name to Monsieur
+Lorry, an English gentleman then and there present, who, like himself,
+had been a witness on that English trial and could corroborate his
+account of it, the Jury declared that they had heard enough, and that
+they were ready with their votes if the President were content to
+receive them.
+
+At every vote (the Jurymen voted aloud and individually), the populace
+set up a shout of applause. All the voices were in the prisoner’s
+favour, and the President declared him free.
+
+Then, began one of those extraordinary scenes with which the populace
+sometimes gratified their fickleness, or their better impulses towards
+generosity and mercy, or which they regarded as some set-off against
+their swollen account of cruel rage. No man can decide now to which of
+these motives such extraordinary scenes were referable; it is probable,
+to a blending of all the three, with the second predominating. No sooner
+was the acquittal pronounced, than tears were shed as freely as blood
+at another time, and such fraternal embraces were bestowed upon the
+prisoner by as many of both sexes as could rush at him, that after
+his long and unwholesome confinement he was in danger of fainting from
+exhaustion; none the less because he knew very well, that the very same
+people, carried by another current, would have rushed at him with
+the very same intensity, to rend him to pieces and strew him over the
+streets.
+
+His removal, to make way for other accused persons who were to be tried,
+rescued him from these caresses for the moment. Five were to be tried
+together, next, as enemies of the Republic, forasmuch as they had not
+assisted it by word or deed. So quick was the Tribunal to compensate
+itself and the nation for a chance lost, that these five came down to
+him before he left the place, condemned to die within twenty-four
+hours. The first of them told him so, with the customary prison sign
+of Death--a raised finger--and they all added in words, “Long live the
+Republic!”
+
+The five had had, it is true, no audience to lengthen their proceedings,
+for when he and Doctor Manette emerged from the gate, there was a great
+crowd about it, in which there seemed to be every face he had seen in
+Court--except two, for which he looked in vain. On his coming out, the
+concourse made at him anew, weeping, embracing, and shouting, all by
+turns and all together, until the very tide of the river on the bank of
+which the mad scene was acted, seemed to run mad, like the people on the
+shore.
+
+They put him into a great chair they had among them, and which they had
+taken either out of the Court itself, or one of its rooms or passages.
+Over the chair they had thrown a red flag, and to the back of it they
+had bound a pike with a red cap on its top. In this car of triumph, not
+even the Doctor’s entreaties could prevent his being carried to his home
+on men’s shoulders, with a confused sea of red caps heaving about him,
+and casting up to sight from the stormy deep such wrecks of faces, that
+he more than once misdoubted his mind being in confusion, and that he
+was in the tumbril on his way to the Guillotine.
+
+In wild dreamlike procession, embracing whom they met and pointing
+him out, they carried him on. Reddening the snowy streets with the
+prevailing Republican colour, in winding and tramping through them, as
+they had reddened them below the snow with a deeper dye, they carried
+him thus into the courtyard of the building where he lived. Her father
+had gone on before, to prepare her, and when her husband stood upon his
+feet, she dropped insensible in his arms.
+
+As he held her to his heart and turned her beautiful head between his
+face and the brawling crowd, so that his tears and her lips might come
+together unseen, a few of the people fell to dancing. Instantly, all the
+rest fell to dancing, and the courtyard overflowed with the Carmagnole.
+Then, they elevated into the vacant chair a young woman from the
+crowd to be carried as the Goddess of Liberty, and then swelling and
+overflowing out into the adjacent streets, and along the river’s bank,
+and over the bridge, the Carmagnole absorbed them every one and whirled
+them away.
+
+After grasping the Doctor’s hand, as he stood victorious and proud
+before him; after grasping the hand of Mr. Lorry, who came panting in
+breathless from his struggle against the waterspout of the Carmagnole;
+after kissing little Lucie, who was lifted up to clasp her arms round
+his neck; and after embracing the ever zealous and faithful Pross who
+lifted her; he took his wife in his arms, and carried her up to their
+rooms.
+
+“Lucie! My own! I am safe.”
+
+“O dearest Charles, let me thank God for this on my knees as I have
+prayed to Him.”
+
+They all reverently bowed their heads and hearts. When she was again in
+his arms, he said to her:
+
+“And now speak to your father, dearest. No other man in all this France
+could have done what he has done for me.”
+
+She laid her head upon her father’s breast, as she had laid his poor
+head on her own breast, long, long ago. He was happy in the return he
+had made her, he was recompensed for his suffering, he was proud of his
+strength. “You must not be weak, my darling,” he remonstrated; “don’t
+tremble so. I have saved him.”
+
+
+
+
+VII. A Knock at the Door
+
+
+“I have saved him.” It was not another of the dreams in which he had
+often come back; he was really here. And yet his wife trembled, and a
+vague but heavy fear was upon her.
+
+All the air round was so thick and dark, the people were so passionately
+revengeful and fitful, the innocent were so constantly put to death on
+vague suspicion and black malice, it was so impossible to forget that
+many as blameless as her husband and as dear to others as he was to
+her, every day shared the fate from which he had been clutched, that her
+heart could not be as lightened of its load as she felt it ought to be.
+The shadows of the wintry afternoon were beginning to fall, and even now
+the dreadful carts were rolling through the streets. Her mind pursued
+them, looking for him among the Condemned; and then she clung closer to
+his real presence and trembled more.
+
+Her father, cheering her, showed a compassionate superiority to this
+woman’s weakness, which was wonderful to see. No garret, no shoemaking,
+no One Hundred and Five, North Tower, now! He had accomplished the task
+he had set himself, his promise was redeemed, he had saved Charles. Let
+them all lean upon him.
+
+Their housekeeping was of a very frugal kind: not only because that was
+the safest way of life, involving the least offence to the people, but
+because they were not rich, and Charles, throughout his imprisonment,
+had had to pay heavily for his bad food, and for his guard, and towards
+the living of the poorer prisoners. Partly on this account, and
+partly to avoid a domestic spy, they kept no servant; the citizen and
+citizeness who acted as porters at the courtyard gate, rendered them
+occasional service; and Jerry (almost wholly transferred to them by
+Mr. Lorry) had become their daily retainer, and had his bed there every
+night.
+
+It was an ordinance of the Republic One and Indivisible of Liberty,
+Equality, Fraternity, or Death, that on the door or doorpost of every
+house, the name of every inmate must be legibly inscribed in letters
+of a certain size, at a certain convenient height from the ground. Mr.
+Jerry Cruncher’s name, therefore, duly embellished the doorpost down
+below; and, as the afternoon shadows deepened, the owner of that name
+himself appeared, from overlooking a painter whom Doctor Manette had
+employed to add to the list the name of Charles Evremonde, called
+Darnay.
+
+In the universal fear and distrust that darkened the time, all the usual
+harmless ways of life were changed. In the Doctor’s little household, as
+in very many others, the articles of daily consumption that were wanted
+were purchased every evening, in small quantities and at various small
+shops. To avoid attracting notice, and to give as little occasion as
+possible for talk and envy, was the general desire.
+
+For some months past, Miss Pross and Mr. Cruncher had discharged the
+office of purveyors; the former carrying the money; the latter, the
+basket. Every afternoon at about the time when the public lamps were
+lighted, they fared forth on this duty, and made and brought home
+such purchases as were needful. Although Miss Pross, through her long
+association with a French family, might have known as much of their
+language as of her own, if she had had a mind, she had no mind in that
+direction; consequently she knew no more of that “nonsense” (as she was
+pleased to call it) than Mr. Cruncher did. So her manner of marketing
+was to plump a noun-substantive at the head of a shopkeeper without any
+introduction in the nature of an article, and, if it happened not to be
+the name of the thing she wanted, to look round for that thing, lay hold
+of it, and hold on by it until the bargain was concluded. She always
+made a bargain for it, by holding up, as a statement of its just price,
+one finger less than the merchant held up, whatever his number might be.
+
+“Now, Mr. Cruncher,” said Miss Pross, whose eyes were red with felicity;
+“if you are ready, I am.”
+
+Jerry hoarsely professed himself at Miss Pross’s service. He had worn
+all his rust off long ago, but nothing would file his spiky head down.
+
+“There’s all manner of things wanted,” said Miss Pross, “and we shall
+have a precious time of it. We want wine, among the rest. Nice toasts
+these Redheads will be drinking, wherever we buy it.”
+
+“It will be much the same to your knowledge, miss, I should think,”
+ retorted Jerry, “whether they drink your health or the Old Un’s.”
+
+“Who’s he?” said Miss Pross.
+
+Mr. Cruncher, with some diffidence, explained himself as meaning “Old
+Nick’s.”
+
+“Ha!” said Miss Pross, “it doesn’t need an interpreter to explain the
+meaning of these creatures. They have but one, and it’s Midnight Murder,
+and Mischief.”
+
+“Hush, dear! Pray, pray, be cautious!” cried Lucie.
+
+“Yes, yes, yes, I’ll be cautious,” said Miss Pross; “but I may say
+among ourselves, that I do hope there will be no oniony and tobaccoey
+smotherings in the form of embracings all round, going on in the
+streets. Now, Ladybird, never you stir from that fire till I come back!
+Take care of the dear husband you have recovered, and don’t move your
+pretty head from his shoulder as you have it now, till you see me again!
+May I ask a question, Doctor Manette, before I go?”
+
+“I think you may take that liberty,” the Doctor answered, smiling.
+
+“For gracious sake, don’t talk about Liberty; we have quite enough of
+that,” said Miss Pross.
+
+“Hush, dear! Again?” Lucie remonstrated.
+
+“Well, my sweet,” said Miss Pross, nodding her head emphatically, “the
+short and the long of it is, that I am a subject of His Most Gracious
+Majesty King George the Third;” Miss Pross curtseyed at the name; “and
+as such, my maxim is, Confound their politics, Frustrate their knavish
+tricks, On him our hopes we fix, God save the King!”
+
+Mr. Cruncher, in an access of loyalty, growlingly repeated the words
+after Miss Pross, like somebody at church.
+
+“I am glad you have so much of the Englishman in you, though I wish you
+had never taken that cold in your voice,” said Miss Pross, approvingly.
+“But the question, Doctor Manette. Is there”--it was the good creature’s
+way to affect to make light of anything that was a great anxiety
+with them all, and to come at it in this chance manner--“is there any
+prospect yet, of our getting out of this place?”
+
+“I fear not yet. It would be dangerous for Charles yet.”
+
+“Heigh-ho-hum!” said Miss Pross, cheerfully repressing a sigh as she
+glanced at her darling’s golden hair in the light of the fire, “then we
+must have patience and wait: that’s all. We must hold up our heads and
+fight low, as my brother Solomon used to say. Now, Mr. Cruncher!--Don’t
+you move, Ladybird!”
+
+They went out, leaving Lucie, and her husband, her father, and the
+child, by a bright fire. Mr. Lorry was expected back presently from the
+Banking House. Miss Pross had lighted the lamp, but had put it aside in
+a corner, that they might enjoy the fire-light undisturbed. Little Lucie
+sat by her grandfather with her hands clasped through his arm: and he,
+in a tone not rising much above a whisper, began to tell her a story of
+a great and powerful Fairy who had opened a prison-wall and let out
+a captive who had once done the Fairy a service. All was subdued and
+quiet, and Lucie was more at ease than she had been.
+
+“What is that?” she cried, all at once.
+
+“My dear!” said her father, stopping in his story, and laying his hand
+on hers, “command yourself. What a disordered state you are in! The
+least thing--nothing--startles you! _You_, your father’s daughter!”
+
+“I thought, my father,” said Lucie, excusing herself, with a pale face
+and in a faltering voice, “that I heard strange feet upon the stairs.”
+
+“My love, the staircase is as still as Death.”
+
+As he said the word, a blow was struck upon the door.
+
+“Oh father, father. What can this be! Hide Charles. Save him!”
+
+“My child,” said the Doctor, rising, and laying his hand upon her
+shoulder, “I _have_ saved him. What weakness is this, my dear! Let me go
+to the door.”
+
+He took the lamp in his hand, crossed the two intervening outer rooms,
+and opened it. A rude clattering of feet over the floor, and four rough
+men in red caps, armed with sabres and pistols, entered the room.
+
+“The Citizen Evremonde, called Darnay,” said the first.
+
+“Who seeks him?” answered Darnay.
+
+“I seek him. We seek him. I know you, Evremonde; I saw you before the
+Tribunal to-day. You are again the prisoner of the Republic.”
+
+The four surrounded him, where he stood with his wife and child clinging
+to him.
+
+“Tell me how and why am I again a prisoner?”
+
+“It is enough that you return straight to the Conciergerie, and will
+know to-morrow. You are summoned for to-morrow.”
+
+Doctor Manette, whom this visitation had so turned into stone, that he
+stood with the lamp in his hand, as if he were a statue made to hold it,
+moved after these words were spoken, put the lamp down, and confronting
+the speaker, and taking him, not ungently, by the loose front of his red
+woollen shirt, said:
+
+“You know him, you have said. Do you know me?”
+
+“Yes, I know you, Citizen Doctor.”
+
+“We all know you, Citizen Doctor,” said the other three.
+
+He looked abstractedly from one to another, and said, in a lower voice,
+after a pause:
+
+“Will you answer his question to me then? How does this happen?”
+
+“Citizen Doctor,” said the first, reluctantly, “he has been denounced to
+the Section of Saint Antoine. This citizen,” pointing out the second who
+had entered, “is from Saint Antoine.”
+
+The citizen here indicated nodded his head, and added:
+
+“He is accused by Saint Antoine.”
+
+“Of what?” asked the Doctor.
+
+“Citizen Doctor,” said the first, with his former reluctance, “ask no
+more. If the Republic demands sacrifices from you, without doubt you as
+a good patriot will be happy to make them. The Republic goes before all.
+The People is supreme. Evremonde, we are pressed.”
+
+“One word,” the Doctor entreated. “Will you tell me who denounced him?”
+
+“It is against rule,” answered the first; “but you can ask Him of Saint
+Antoine here.”
+
+The Doctor turned his eyes upon that man. Who moved uneasily on his
+feet, rubbed his beard a little, and at length said:
+
+“Well! Truly it is against rule. But he is denounced--and gravely--by
+the Citizen and Citizeness Defarge. And by one other.”
+
+“What other?”
+
+“Do _you_ ask, Citizen Doctor?”
+
+“Yes.”
+
+“Then,” said he of Saint Antoine, with a strange look, “you will be
+answered to-morrow. Now, I am dumb!”
+
+
+
+
+VIII. A Hand at Cards
+
+
+Happily unconscious of the new calamity at home, Miss Pross threaded her
+way along the narrow streets and crossed the river by the bridge of the
+Pont-Neuf, reckoning in her mind the number of indispensable purchases
+she had to make. Mr. Cruncher, with the basket, walked at her side. They
+both looked to the right and to the left into most of the shops they
+passed, had a wary eye for all gregarious assemblages of people, and
+turned out of their road to avoid any very excited group of talkers. It
+was a raw evening, and the misty river, blurred to the eye with blazing
+lights and to the ear with harsh noises, showed where the barges were
+stationed in which the smiths worked, making guns for the Army of the
+Republic. Woe to the man who played tricks with _that_ Army, or got
+undeserved promotion in it! Better for him that his beard had never
+grown, for the National Razor shaved him close.
+
+Having purchased a few small articles of grocery, and a measure of oil
+for the lamp, Miss Pross bethought herself of the wine they wanted.
+After peeping into several wine-shops, she stopped at the sign of the
+Good Republican Brutus of Antiquity, not far from the National Palace,
+once (and twice) the Tuileries, where the aspect of things rather
+took her fancy. It had a quieter look than any other place of the same
+description they had passed, and, though red with patriotic caps, was
+not so red as the rest. Sounding Mr. Cruncher, and finding him of her
+opinion, Miss Pross resorted to the Good Republican Brutus of Antiquity,
+attended by her cavalier.
+
+Slightly observant of the smoky lights; of the people, pipe in mouth,
+playing with limp cards and yellow dominoes; of the one bare-breasted,
+bare-armed, soot-begrimed workman reading a journal aloud, and of
+the others listening to him; of the weapons worn, or laid aside to be
+resumed; of the two or three customers fallen forward asleep, who in the
+popular high-shouldered shaggy black spencer looked, in that attitude,
+like slumbering bears or dogs; the two outlandish customers approached
+the counter, and showed what they wanted.
+
+As their wine was measuring out, a man parted from another man in a
+corner, and rose to depart. In going, he had to face Miss Pross. No
+sooner did he face her, than Miss Pross uttered a scream, and clapped
+her hands.
+
+In a moment, the whole company were on their feet. That somebody was
+assassinated by somebody vindicating a difference of opinion was the
+likeliest occurrence. Everybody looked to see somebody fall, but only
+saw a man and a woman standing staring at each other; the man with all
+the outward aspect of a Frenchman and a thorough Republican; the woman,
+evidently English.
+
+What was said in this disappointing anti-climax, by the disciples of the
+Good Republican Brutus of Antiquity, except that it was something very
+voluble and loud, would have been as so much Hebrew or Chaldean to Miss
+Pross and her protector, though they had been all ears. But, they had no
+ears for anything in their surprise. For, it must be recorded, that
+not only was Miss Pross lost in amazement and agitation, but,
+Mr. Cruncher--though it seemed on his own separate and individual
+account--was in a state of the greatest wonder.
+
+“What is the matter?” said the man who had caused Miss Pross to scream;
+speaking in a vexed, abrupt voice (though in a low tone), and in
+English.
+
+“Oh, Solomon, dear Solomon!” cried Miss Pross, clapping her hands again.
+“After not setting eyes upon you or hearing of you for so long a time,
+do I find you here!”
+
+“Don’t call me Solomon. Do you want to be the death of me?” asked the
+man, in a furtive, frightened way.
+
+“Brother, brother!” cried Miss Pross, bursting into tears. “Have I ever
+been so hard with you that you ask me such a cruel question?”
+
+“Then hold your meddlesome tongue,” said Solomon, “and come out, if you
+want to speak to me. Pay for your wine, and come out. Who’s this man?”
+
+Miss Pross, shaking her loving and dejected head at her by no means
+affectionate brother, said through her tears, “Mr. Cruncher.”
+
+“Let him come out too,” said Solomon. “Does he think me a ghost?”
+
+Apparently, Mr. Cruncher did, to judge from his looks. He said not a
+word, however, and Miss Pross, exploring the depths of her reticule
+through her tears with great difficulty paid for her wine. As she did
+so, Solomon turned to the followers of the Good Republican Brutus
+of Antiquity, and offered a few words of explanation in the French
+language, which caused them all to relapse into their former places and
+pursuits.
+
+“Now,” said Solomon, stopping at the dark street corner, “what do you
+want?”
+
+“How dreadfully unkind in a brother nothing has ever turned my love away
+from!” cried Miss Pross, “to give me such a greeting, and show me no
+affection.”
+
+“There. Confound it! There,” said Solomon, making a dab at Miss Pross’s
+lips with his own. “Now are you content?”
+
+Miss Pross only shook her head and wept in silence.
+
+“If you expect me to be surprised,” said her brother Solomon, “I am not
+surprised; I knew you were here; I know of most people who are here. If
+you really don’t want to endanger my existence--which I half believe you
+do--go your ways as soon as possible, and let me go mine. I am busy. I
+am an official.”
+
+“My English brother Solomon,” mourned Miss Pross, casting up her
+tear-fraught eyes, “that had the makings in him of one of the best and
+greatest of men in his native country, an official among foreigners, and
+such foreigners! I would almost sooner have seen the dear boy lying in
+his--”
+
+“I said so!” cried her brother, interrupting. “I knew it. You want to be
+the death of me. I shall be rendered Suspected, by my own sister. Just
+as I am getting on!”
+
+“The gracious and merciful Heavens forbid!” cried Miss Pross. “Far
+rather would I never see you again, dear Solomon, though I have ever
+loved you truly, and ever shall. Say but one affectionate word to me,
+and tell me there is nothing angry or estranged between us, and I will
+detain you no longer.”
+
+Good Miss Pross! As if the estrangement between them had come of any
+culpability of hers. As if Mr. Lorry had not known it for a fact, years
+ago, in the quiet corner in Soho, that this precious brother had spent
+her money and left her!
+
+He was saying the affectionate word, however, with a far more grudging
+condescension and patronage than he could have shown if their relative
+merits and positions had been reversed (which is invariably the case,
+all the world over), when Mr. Cruncher, touching him on the shoulder,
+hoarsely and unexpectedly interposed with the following singular
+question:
+
+“I say! Might I ask the favour? As to whether your name is John Solomon,
+or Solomon John?”
+
+The official turned towards him with sudden distrust. He had not
+previously uttered a word.
+
+“Come!” said Mr. Cruncher. “Speak out, you know.” (Which, by the way,
+was more than he could do himself.) “John Solomon, or Solomon John? She
+calls you Solomon, and she must know, being your sister. And _I_ know
+you’re John, you know. Which of the two goes first? And regarding that
+name of Pross, likewise. That warn’t your name over the water.”
+
+“What do you mean?”
+
+“Well, I don’t know all I mean, for I can’t call to mind what your name
+was, over the water.”
+
+“No?”
+
+“No. But I’ll swear it was a name of two syllables.”
+
+“Indeed?”
+
+“Yes. T’other one’s was one syllable. I know you. You was a spy--witness
+at the Bailey. What, in the name of the Father of Lies, own father to
+yourself, was you called at that time?”
+
+“Barsad,” said another voice, striking in.
+
+“That’s the name for a thousand pound!” cried Jerry.
+
+The speaker who struck in, was Sydney Carton. He had his hands behind
+him under the skirts of his riding-coat, and he stood at Mr. Cruncher’s
+elbow as negligently as he might have stood at the Old Bailey itself.
+
+“Don’t be alarmed, my dear Miss Pross. I arrived at Mr. Lorry’s, to his
+surprise, yesterday evening; we agreed that I would not present myself
+elsewhere until all was well, or unless I could be useful; I present
+myself here, to beg a little talk with your brother. I wish you had a
+better employed brother than Mr. Barsad. I wish for your sake Mr. Barsad
+was not a Sheep of the Prisons.”
+
+Sheep was a cant word of the time for a spy, under the gaolers. The spy,
+who was pale, turned paler, and asked him how he dared--
+
+“I’ll tell you,” said Sydney. “I lighted on you, Mr. Barsad, coming out
+of the prison of the Conciergerie while I was contemplating the walls,
+an hour or more ago. You have a face to be remembered, and I remember
+faces well. Made curious by seeing you in that connection, and having
+a reason, to which you are no stranger, for associating you with
+the misfortunes of a friend now very unfortunate, I walked in your
+direction. I walked into the wine-shop here, close after you, and
+sat near you. I had no difficulty in deducing from your unreserved
+conversation, and the rumour openly going about among your admirers, the
+nature of your calling. And gradually, what I had done at random, seemed
+to shape itself into a purpose, Mr. Barsad.”
+
+“What purpose?” the spy asked.
+
+“It would be troublesome, and might be dangerous, to explain in the
+street. Could you favour me, in confidence, with some minutes of your
+company--at the office of Tellson’s Bank, for instance?”
+
+“Under a threat?”
+
+“Oh! Did I say that?”
+
+“Then, why should I go there?”
+
+“Really, Mr. Barsad, I can’t say, if you can’t.”
+
+“Do you mean that you won’t say, sir?” the spy irresolutely asked.
+
+“You apprehend me very clearly, Mr. Barsad. I won’t.”
+
+Carton’s negligent recklessness of manner came powerfully in aid of his
+quickness and skill, in such a business as he had in his secret mind,
+and with such a man as he had to do with. His practised eye saw it, and
+made the most of it.
+
+“Now, I told you so,” said the spy, casting a reproachful look at his
+sister; “if any trouble comes of this, it’s your doing.”
+
+“Come, come, Mr. Barsad!” exclaimed Sydney. “Don’t be ungrateful.
+But for my great respect for your sister, I might not have led up so
+pleasantly to a little proposal that I wish to make for our mutual
+satisfaction. Do you go with me to the Bank?”
+
+“I’ll hear what you have got to say. Yes, I’ll go with you.”
+
+“I propose that we first conduct your sister safely to the corner of her
+own street. Let me take your arm, Miss Pross. This is not a good city,
+at this time, for you to be out in, unprotected; and as your escort
+knows Mr. Barsad, I will invite him to Mr. Lorry’s with us. Are we
+ready? Come then!”
+
+Miss Pross recalled soon afterwards, and to the end of her life
+remembered, that as she pressed her hands on Sydney’s arm and looked up
+in his face, imploring him to do no hurt to Solomon, there was a braced
+purpose in the arm and a kind of inspiration in the eyes, which not only
+contradicted his light manner, but changed and raised the man. She was
+too much occupied then with fears for the brother who so little deserved
+her affection, and with Sydney’s friendly reassurances, adequately to
+heed what she observed.
+
+They left her at the corner of the street, and Carton led the way to Mr.
+Lorry’s, which was within a few minutes’ walk. John Barsad, or Solomon
+Pross, walked at his side.
+
+Mr. Lorry had just finished his dinner, and was sitting before a cheery
+little log or two of fire--perhaps looking into their blaze for the
+picture of that younger elderly gentleman from Tellson’s, who had looked
+into the red coals at the Royal George at Dover, now a good many years
+ago. He turned his head as they entered, and showed the surprise with
+which he saw a stranger.
+
+“Miss Pross’s brother, sir,” said Sydney. “Mr. Barsad.”
+
+“Barsad?” repeated the old gentleman, “Barsad? I have an association
+with the name--and with the face.”
+
+“I told you you had a remarkable face, Mr. Barsad,” observed Carton,
+coolly. “Pray sit down.”
+
+As he took a chair himself, he supplied the link that Mr. Lorry wanted,
+by saying to him with a frown, “Witness at that trial.” Mr. Lorry
+immediately remembered, and regarded his new visitor with an undisguised
+look of abhorrence.
+
+“Mr. Barsad has been recognised by Miss Pross as the affectionate
+brother you have heard of,” said Sydney, “and has acknowledged the
+relationship. I pass to worse news. Darnay has been arrested again.”
+
+Struck with consternation, the old gentleman exclaimed, “What do you
+tell me! I left him safe and free within these two hours, and am about
+to return to him!”
+
+“Arrested for all that. When was it done, Mr. Barsad?”
+
+“Just now, if at all.”
+
+“Mr. Barsad is the best authority possible, sir,” said Sydney, “and I
+have it from Mr. Barsad’s communication to a friend and brother Sheep
+over a bottle of wine, that the arrest has taken place. He left the
+messengers at the gate, and saw them admitted by the porter. There is no
+earthly doubt that he is retaken.”
+
+Mr. Lorry’s business eye read in the speaker’s face that it was loss
+of time to dwell upon the point. Confused, but sensible that something
+might depend on his presence of mind, he commanded himself, and was
+silently attentive.
+
+“Now, I trust,” said Sydney to him, “that the name and influence of
+Doctor Manette may stand him in as good stead to-morrow--you said he
+would be before the Tribunal again to-morrow, Mr. Barsad?--”
+
+“Yes; I believe so.”
+
+“--In as good stead to-morrow as to-day. But it may not be so. I own
+to you, I am shaken, Mr. Lorry, by Doctor Manette’s not having had the
+power to prevent this arrest.”
+
+“He may not have known of it beforehand,” said Mr. Lorry.
+
+“But that very circumstance would be alarming, when we remember how
+identified he is with his son-in-law.”
+
+“That’s true,” Mr. Lorry acknowledged, with his troubled hand at his
+chin, and his troubled eyes on Carton.
+
+“In short,” said Sydney, “this is a desperate time, when desperate games
+are played for desperate stakes. Let the Doctor play the winning game; I
+will play the losing one. No man’s life here is worth purchase. Any one
+carried home by the people to-day, may be condemned tomorrow. Now, the
+stake I have resolved to play for, in case of the worst, is a friend
+in the Conciergerie. And the friend I purpose to myself to win, is Mr.
+Barsad.”
+
+“You need have good cards, sir,” said the spy.
+
+“I’ll run them over. I’ll see what I hold,--Mr. Lorry, you know what a
+brute I am; I wish you’d give me a little brandy.”
+
+It was put before him, and he drank off a glassful--drank off another
+glassful--pushed the bottle thoughtfully away.
+
+“Mr. Barsad,” he went on, in the tone of one who really was looking
+over a hand at cards: “Sheep of the prisons, emissary of Republican
+committees, now turnkey, now prisoner, always spy and secret informer,
+so much the more valuable here for being English that an Englishman
+is less open to suspicion of subornation in those characters than a
+Frenchman, represents himself to his employers under a false name.
+That’s a very good card. Mr. Barsad, now in the employ of the republican
+French government, was formerly in the employ of the aristocratic
+English government, the enemy of France and freedom. That’s an excellent
+card. Inference clear as day in this region of suspicion, that Mr.
+Barsad, still in the pay of the aristocratic English government, is the
+spy of Pitt, the treacherous foe of the Republic crouching in its bosom,
+the English traitor and agent of all mischief so much spoken of and so
+difficult to find. That’s a card not to be beaten. Have you followed my
+hand, Mr. Barsad?”
+
+“Not to understand your play,” returned the spy, somewhat uneasily.
+
+“I play my Ace, Denunciation of Mr. Barsad to the nearest Section
+Committee. Look over your hand, Mr. Barsad, and see what you have. Don’t
+hurry.”
+
+He drew the bottle near, poured out another glassful of brandy, and
+drank it off. He saw that the spy was fearful of his drinking himself
+into a fit state for the immediate denunciation of him. Seeing it, he
+poured out and drank another glassful.
+
+“Look over your hand carefully, Mr. Barsad. Take time.”
+
+It was a poorer hand than he suspected. Mr. Barsad saw losing cards
+in it that Sydney Carton knew nothing of. Thrown out of his honourable
+employment in England, through too much unsuccessful hard swearing
+there--not because he was not wanted there; our English reasons for
+vaunting our superiority to secrecy and spies are of very modern
+date--he knew that he had crossed the Channel, and accepted service in
+France: first, as a tempter and an eavesdropper among his own countrymen
+there: gradually, as a tempter and an eavesdropper among the natives. He
+knew that under the overthrown government he had been a spy upon Saint
+Antoine and Defarge’s wine-shop; had received from the watchful police
+such heads of information concerning Doctor Manette’s imprisonment,
+release, and history, as should serve him for an introduction to
+familiar conversation with the Defarges; and tried them on Madame
+Defarge, and had broken down with them signally. He always remembered
+with fear and trembling, that that terrible woman had knitted when he
+talked with her, and had looked ominously at him as her fingers moved.
+He had since seen her, in the Section of Saint Antoine, over and over
+again produce her knitted registers, and denounce people whose lives the
+guillotine then surely swallowed up. He knew, as every one employed as
+he was did, that he was never safe; that flight was impossible; that
+he was tied fast under the shadow of the axe; and that in spite of
+his utmost tergiversation and treachery in furtherance of the reigning
+terror, a word might bring it down upon him. Once denounced, and on such
+grave grounds as had just now been suggested to his mind, he foresaw
+that the dreadful woman of whose unrelenting character he had seen many
+proofs, would produce against him that fatal register, and would quash
+his last chance of life. Besides that all secret men are men soon
+terrified, here were surely cards enough of one black suit, to justify
+the holder in growing rather livid as he turned them over.
+
+“You scarcely seem to like your hand,” said Sydney, with the greatest
+composure. “Do you play?”
+
+“I think, sir,” said the spy, in the meanest manner, as he turned to Mr.
+Lorry, “I may appeal to a gentleman of your years and benevolence, to
+put it to this other gentleman, so much your junior, whether he can
+under any circumstances reconcile it to his station to play that Ace
+of which he has spoken. I admit that _I_ am a spy, and that it is
+considered a discreditable station--though it must be filled by
+somebody; but this gentleman is no spy, and why should he so demean
+himself as to make himself one?”
+
+“I play my Ace, Mr. Barsad,” said Carton, taking the answer on himself,
+and looking at his watch, “without any scruple, in a very few minutes.”
+
+“I should have hoped, gentlemen both,” said the spy, always striving to
+hook Mr. Lorry into the discussion, “that your respect for my sister--”
+
+“I could not better testify my respect for your sister than by finally
+relieving her of her brother,” said Sydney Carton.
+
+“You think not, sir?”
+
+“I have thoroughly made up my mind about it.”
+
+The smooth manner of the spy, curiously in dissonance with his
+ostentatiously rough dress, and probably with his usual demeanour,
+received such a check from the inscrutability of Carton,--who was a
+mystery to wiser and honester men than he,--that it faltered here and
+failed him. While he was at a loss, Carton said, resuming his former air
+of contemplating cards:
+
+“And indeed, now I think again, I have a strong impression that I
+have another good card here, not yet enumerated. That friend and
+fellow-Sheep, who spoke of himself as pasturing in the country prisons;
+who was he?”
+
+“French. You don’t know him,” said the spy, quickly.
+
+“French, eh?” repeated Carton, musing, and not appearing to notice him
+at all, though he echoed his word. “Well; he may be.”
+
+“Is, I assure you,” said the spy; “though it’s not important.”
+
+“Though it’s not important,” repeated Carton, in the same mechanical
+way--“though it’s not important--No, it’s not important. No. Yet I know
+the face.”
+
+“I think not. I am sure not. It can’t be,” said the spy.
+
+“It-can’t-be,” muttered Sydney Carton, retrospectively, and idling his
+glass (which fortunately was a small one) again. “Can’t-be. Spoke good
+French. Yet like a foreigner, I thought?”
+
+“Provincial,” said the spy.
+
+“No. Foreign!” cried Carton, striking his open hand on the table, as a
+light broke clearly on his mind. “Cly! Disguised, but the same man. We
+had that man before us at the Old Bailey.”
+
+“Now, there you are hasty, sir,” said Barsad, with a smile that gave his
+aquiline nose an extra inclination to one side; “there you really give
+me an advantage over you. Cly (who I will unreservedly admit, at this
+distance of time, was a partner of mine) has been dead several years. I
+attended him in his last illness. He was buried in London, at the church
+of Saint Pancras-in-the-Fields. His unpopularity with the blackguard
+multitude at the moment prevented my following his remains, but I helped
+to lay him in his coffin.”
+
+Here, Mr. Lorry became aware, from where he sat, of a most remarkable
+goblin shadow on the wall. Tracing it to its source, he discovered it
+to be caused by a sudden extraordinary rising and stiffening of all the
+risen and stiff hair on Mr. Cruncher’s head.
+
+“Let us be reasonable,” said the spy, “and let us be fair. To show you
+how mistaken you are, and what an unfounded assumption yours is, I will
+lay before you a certificate of Cly’s burial, which I happened to have
+carried in my pocket-book,” with a hurried hand he produced and opened
+it, “ever since. There it is. Oh, look at it, look at it! You may take
+it in your hand; it’s no forgery.”
+
+Here, Mr. Lorry perceived the reflection on the wall to elongate, and
+Mr. Cruncher rose and stepped forward. His hair could not have been more
+violently on end, if it had been that moment dressed by the Cow with the
+crumpled horn in the house that Jack built.
+
+Unseen by the spy, Mr. Cruncher stood at his side, and touched him on
+the shoulder like a ghostly bailiff.
+
+“That there Roger Cly, master,” said Mr. Cruncher, with a taciturn and
+iron-bound visage. “So _you_ put him in his coffin?”
+
+“I did.”
+
+“Who took him out of it?”
+
+Barsad leaned back in his chair, and stammered, “What do you mean?”
+
+“I mean,” said Mr. Cruncher, “that he warn’t never in it. No! Not he!
+I’ll have my head took off, if he was ever in it.”
+
+The spy looked round at the two gentlemen; they both looked in
+unspeakable astonishment at Jerry.
+
+“I tell you,” said Jerry, “that you buried paving-stones and earth in
+that there coffin. Don’t go and tell me that you buried Cly. It was a
+take in. Me and two more knows it.”
+
+“How do you know it?”
+
+“What’s that to you? Ecod!” growled Mr. Cruncher, “it’s you I have got a
+old grudge again, is it, with your shameful impositions upon tradesmen!
+I’d catch hold of your throat and choke you for half a guinea.”
+
+Sydney Carton, who, with Mr. Lorry, had been lost in amazement at
+this turn of the business, here requested Mr. Cruncher to moderate and
+explain himself.
+
+“At another time, sir,” he returned, evasively, “the present time is
+ill-conwenient for explainin’. What I stand to, is, that he knows well
+wot that there Cly was never in that there coffin. Let him say he was,
+in so much as a word of one syllable, and I’ll either catch hold of his
+throat and choke him for half a guinea;” Mr. Cruncher dwelt upon this as
+quite a liberal offer; “or I’ll out and announce him.”
+
+“Humph! I see one thing,” said Carton. “I hold another card, Mr. Barsad.
+Impossible, here in raging Paris, with Suspicion filling the air, for
+you to outlive denunciation, when you are in communication with another
+aristocratic spy of the same antecedents as yourself, who, moreover, has
+the mystery about him of having feigned death and come to life again!
+A plot in the prisons, of the foreigner against the Republic. A strong
+card--a certain Guillotine card! Do you play?”
+
+“No!” returned the spy. “I throw up. I confess that we were so unpopular
+with the outrageous mob, that I only got away from England at the risk
+of being ducked to death, and that Cly was so ferreted up and down, that
+he never would have got away at all but for that sham. Though how this
+man knows it was a sham, is a wonder of wonders to me.”
+
+“Never you trouble your head about this man,” retorted the contentious
+Mr. Cruncher; “you’ll have trouble enough with giving your attention to
+that gentleman. And look here! Once more!”--Mr. Cruncher could not
+be restrained from making rather an ostentatious parade of his
+liberality--“I’d catch hold of your throat and choke you for half a
+guinea.”
+
+The Sheep of the prisons turned from him to Sydney Carton, and said,
+with more decision, “It has come to a point. I go on duty soon, and
+can’t overstay my time. You told me you had a proposal; what is it?
+Now, it is of no use asking too much of me. Ask me to do anything in my
+office, putting my head in great extra danger, and I had better trust my
+life to the chances of a refusal than the chances of consent. In short,
+I should make that choice. You talk of desperation. We are all desperate
+here. Remember! I may denounce you if I think proper, and I can swear my
+way through stone walls, and so can others. Now, what do you want with
+me?”
+
+“Not very much. You are a turnkey at the Conciergerie?”
+
+“I tell you once for all, there is no such thing as an escape possible,”
+ said the spy, firmly.
+
+“Why need you tell me what I have not asked? You are a turnkey at the
+Conciergerie?”
+
+“I am sometimes.”
+
+“You can be when you choose?”
+
+“I can pass in and out when I choose.”
+
+Sydney Carton filled another glass with brandy, poured it slowly out
+upon the hearth, and watched it as it dropped. It being all spent, he
+said, rising:
+
+“So far, we have spoken before these two, because it was as well that
+the merits of the cards should not rest solely between you and me. Come
+into the dark room here, and let us have one final word alone.”
+
+
+
+
+IX. The Game Made
+
+
+While Sydney Carton and the Sheep of the prisons were in the adjoining
+dark room, speaking so low that not a sound was heard, Mr. Lorry looked
+at Jerry in considerable doubt and mistrust. That honest tradesman’s
+manner of receiving the look, did not inspire confidence; he changed the
+leg on which he rested, as often as if he had fifty of those limbs,
+and were trying them all; he examined his finger-nails with a very
+questionable closeness of attention; and whenever Mr. Lorry’s eye caught
+his, he was taken with that peculiar kind of short cough requiring the
+hollow of a hand before it, which is seldom, if ever, known to be an
+infirmity attendant on perfect openness of character.
+
+“Jerry,” said Mr. Lorry. “Come here.”
+
+Mr. Cruncher came forward sideways, with one of his shoulders in advance
+of him.
+
+“What have you been, besides a messenger?”
+
+After some cogitation, accompanied with an intent look at his patron,
+Mr. Cruncher conceived the luminous idea of replying, “Agicultooral
+character.”
+
+“My mind misgives me much,” said Mr. Lorry, angrily shaking a forefinger
+at him, “that you have used the respectable and great house of Tellson’s
+as a blind, and that you have had an unlawful occupation of an infamous
+description. If you have, don’t expect me to befriend you when you
+get back to England. If you have, don’t expect me to keep your secret.
+Tellson’s shall not be imposed upon.”
+
+“I hope, sir,” pleaded the abashed Mr. Cruncher, “that a gentleman like
+yourself wot I’ve had the honour of odd jobbing till I’m grey at it,
+would think twice about harming of me, even if it wos so--I don’t say it
+is, but even if it wos. And which it is to be took into account that if
+it wos, it wouldn’t, even then, be all o’ one side. There’d be two sides
+to it. There might be medical doctors at the present hour, a picking
+up their guineas where a honest tradesman don’t pick up his
+fardens--fardens! no, nor yet his half fardens--half fardens! no, nor
+yet his quarter--a banking away like smoke at Tellson’s, and a cocking
+their medical eyes at that tradesman on the sly, a going in and going
+out to their own carriages--ah! equally like smoke, if not more so.
+Well, that ‘ud be imposing, too, on Tellson’s. For you cannot sarse the
+goose and not the gander. And here’s Mrs. Cruncher, or leastways wos
+in the Old England times, and would be to-morrow, if cause given,
+a floppin’ again the business to that degree as is ruinating--stark
+ruinating! Whereas them medical doctors’ wives don’t flop--catch ‘em at
+it! Or, if they flop, their floppings goes in favour of more patients,
+and how can you rightly have one without t’other? Then, wot with
+undertakers, and wot with parish clerks, and wot with sextons, and wot
+with private watchmen (all awaricious and all in it), a man wouldn’t get
+much by it, even if it wos so. And wot little a man did get, would never
+prosper with him, Mr. Lorry. He’d never have no good of it; he’d want
+all along to be out of the line, if he, could see his way out, being
+once in--even if it wos so.”
+
+“Ugh!” cried Mr. Lorry, rather relenting, nevertheless, “I am shocked at
+the sight of you.”
+
+“Now, what I would humbly offer to you, sir,” pursued Mr. Cruncher,
+“even if it wos so, which I don’t say it is--”
+
+“Don’t prevaricate,” said Mr. Lorry.
+
+“No, I will _not_, sir,” returned Mr. Crunches as if nothing were
+further from his thoughts or practice--“which I don’t say it is--wot I
+would humbly offer to you, sir, would be this. Upon that there stool, at
+that there Bar, sets that there boy of mine, brought up and growed up to
+be a man, wot will errand you, message you, general-light-job you, till
+your heels is where your head is, if such should be your wishes. If it
+wos so, which I still don’t say it is (for I will not prewaricate to
+you, sir), let that there boy keep his father’s place, and take care of
+his mother; don’t blow upon that boy’s father--do not do it, sir--and
+let that father go into the line of the reg’lar diggin’, and make amends
+for what he would have undug--if it wos so--by diggin’ of ‘em in with
+a will, and with conwictions respectin’ the futur’ keepin’ of ‘em safe.
+That, Mr. Lorry,” said Mr. Cruncher, wiping his forehead with his
+arm, as an announcement that he had arrived at the peroration of his
+discourse, “is wot I would respectfully offer to you, sir. A man don’t
+see all this here a goin’ on dreadful round him, in the way of Subjects
+without heads, dear me, plentiful enough fur to bring the price down
+to porterage and hardly that, without havin’ his serious thoughts of
+things. And these here would be mine, if it wos so, entreatin’ of you
+fur to bear in mind that wot I said just now, I up and said in the good
+cause when I might have kep’ it back.”
+
+“That at least is true,” said Mr. Lorry. “Say no more now. It may be
+that I shall yet stand your friend, if you deserve it, and repent in
+action--not in words. I want no more words.”
+
+Mr. Cruncher knuckled his forehead, as Sydney Carton and the spy
+returned from the dark room. “Adieu, Mr. Barsad,” said the former; “our
+arrangement thus made, you have nothing to fear from me.”
+
+He sat down in a chair on the hearth, over against Mr. Lorry. When they
+were alone, Mr. Lorry asked him what he had done?
+
+“Not much. If it should go ill with the prisoner, I have ensured access
+to him, once.”
+
+Mr. Lorry’s countenance fell.
+
+“It is all I could do,” said Carton. “To propose too much, would be
+to put this man’s head under the axe, and, as he himself said, nothing
+worse could happen to him if he were denounced. It was obviously the
+weakness of the position. There is no help for it.”
+
+“But access to him,” said Mr. Lorry, “if it should go ill before the
+Tribunal, will not save him.”
+
+“I never said it would.”
+
+Mr. Lorry’s eyes gradually sought the fire; his sympathy with his
+darling, and the heavy disappointment of his second arrest, gradually
+weakened them; he was an old man now, overborne with anxiety of late,
+and his tears fell.
+
+“You are a good man and a true friend,” said Carton, in an altered
+voice. “Forgive me if I notice that you are affected. I could not see my
+father weep, and sit by, careless. And I could not respect your
+sorrow more, if you were my father. You are free from that misfortune,
+however.”
+
+Though he said the last words, with a slip into his usual manner, there
+was a true feeling and respect both in his tone and in his touch,
+that Mr. Lorry, who had never seen the better side of him, was wholly
+unprepared for. He gave him his hand, and Carton gently pressed it.
+
+“To return to poor Darnay,” said Carton. “Don’t tell Her of this
+interview, or this arrangement. It would not enable Her to go to see
+him. She might think it was contrived, in case of the worse, to convey
+to him the means of anticipating the sentence.”
+
+Mr. Lorry had not thought of that, and he looked quickly at Carton to
+see if it were in his mind. It seemed to be; he returned the look, and
+evidently understood it.
+
+“She might think a thousand things,” Carton said, “and any of them would
+only add to her trouble. Don’t speak of me to her. As I said to you when
+I first came, I had better not see her. I can put my hand out, to do any
+little helpful work for her that my hand can find to do, without that.
+You are going to her, I hope? She must be very desolate to-night.”
+
+“I am going now, directly.”
+
+“I am glad of that. She has such a strong attachment to you and reliance
+on you. How does she look?”
+
+“Anxious and unhappy, but very beautiful.”
+
+“Ah!”
+
+It was a long, grieving sound, like a sigh--almost like a sob. It
+attracted Mr. Lorry’s eyes to Carton’s face, which was turned to the
+fire. A light, or a shade (the old gentleman could not have said which),
+passed from it as swiftly as a change will sweep over a hill-side on a
+wild bright day, and he lifted his foot to put back one of the little
+flaming logs, which was tumbling forward. He wore the white riding-coat
+and top-boots, then in vogue, and the light of the fire touching their
+light surfaces made him look very pale, with his long brown hair,
+all untrimmed, hanging loose about him. His indifference to fire was
+sufficiently remarkable to elicit a word of remonstrance from Mr. Lorry;
+his boot was still upon the hot embers of the flaming log, when it had
+broken under the weight of his foot.
+
+“I forgot it,” he said.
+
+Mr. Lorry’s eyes were again attracted to his face. Taking note of the
+wasted air which clouded the naturally handsome features, and having
+the expression of prisoners’ faces fresh in his mind, he was strongly
+reminded of that expression.
+
+“And your duties here have drawn to an end, sir?” said Carton, turning
+to him.
+
+“Yes. As I was telling you last night when Lucie came in so
+unexpectedly, I have at length done all that I can do here. I hoped to
+have left them in perfect safety, and then to have quitted Paris. I have
+my Leave to Pass. I was ready to go.”
+
+They were both silent.
+
+“Yours is a long life to look back upon, sir?” said Carton, wistfully.
+
+“I am in my seventy-eighth year.”
+
+“You have been useful all your life; steadily and constantly occupied;
+trusted, respected, and looked up to?”
+
+“I have been a man of business, ever since I have been a man. Indeed, I
+may say that I was a man of business when a boy.”
+
+“See what a place you fill at seventy-eight. How many people will miss
+you when you leave it empty!”
+
+“A solitary old bachelor,” answered Mr. Lorry, shaking his head. “There
+is nobody to weep for me.”
+
+“How can you say that? Wouldn’t She weep for you? Wouldn’t her child?”
+
+“Yes, yes, thank God. I didn’t quite mean what I said.”
+
+“It _is_ a thing to thank God for; is it not?”
+
+“Surely, surely.”
+
+“If you could say, with truth, to your own solitary heart, to-night,
+‘I have secured to myself the love and attachment, the gratitude or
+respect, of no human creature; I have won myself a tender place in no
+regard; I have done nothing good or serviceable to be remembered by!’
+your seventy-eight years would be seventy-eight heavy curses; would they
+not?”
+
+“You say truly, Mr. Carton; I think they would be.”
+
+Sydney turned his eyes again upon the fire, and, after a silence of a
+few moments, said:
+
+“I should like to ask you:--Does your childhood seem far off? Do the
+days when you sat at your mother’s knee, seem days of very long ago?”
+
+Responding to his softened manner, Mr. Lorry answered:
+
+“Twenty years back, yes; at this time of my life, no. For, as I draw
+closer and closer to the end, I travel in the circle, nearer and
+nearer to the beginning. It seems to be one of the kind smoothings and
+preparings of the way. My heart is touched now, by many remembrances
+that had long fallen asleep, of my pretty young mother (and I so old!),
+and by many associations of the days when what we call the World was not
+so real with me, and my faults were not confirmed in me.”
+
+“I understand the feeling!” exclaimed Carton, with a bright flush. “And
+you are the better for it?”
+
+“I hope so.”
+
+Carton terminated the conversation here, by rising to help him on with
+his outer coat; “But you,” said Mr. Lorry, reverting to the theme, “you
+are young.”
+
+“Yes,” said Carton. “I am not old, but my young way was never the way to
+age. Enough of me.”
+
+“And of me, I am sure,” said Mr. Lorry. “Are you going out?”
+
+“I’ll walk with you to her gate. You know my vagabond and restless
+habits. If I should prowl about the streets a long time, don’t be
+uneasy; I shall reappear in the morning. You go to the Court to-morrow?”
+
+“Yes, unhappily.”
+
+“I shall be there, but only as one of the crowd. My Spy will find a
+place for me. Take my arm, sir.”
+
+Mr. Lorry did so, and they went down-stairs and out in the streets. A
+few minutes brought them to Mr. Lorry’s destination. Carton left him
+there; but lingered at a little distance, and turned back to the gate
+again when it was shut, and touched it. He had heard of her going to
+the prison every day. “She came out here,” he said, looking about him,
+“turned this way, must have trod on these stones often. Let me follow in
+her steps.”
+
+It was ten o’clock at night when he stood before the prison of La Force,
+where she had stood hundreds of times. A little wood-sawyer, having
+closed his shop, was smoking his pipe at his shop-door.
+
+“Good night, citizen,” said Sydney Carton, pausing in going by; for, the
+man eyed him inquisitively.
+
+“Good night, citizen.”
+
+“How goes the Republic?”
+
+“You mean the Guillotine. Not ill. Sixty-three to-day. We shall mount
+to a hundred soon. Samson and his men complain sometimes, of being
+exhausted. Ha, ha, ha! He is so droll, that Samson. Such a Barber!”
+
+“Do you often go to see him--”
+
+“Shave? Always. Every day. What a barber! You have seen him at work?”
+
+“Never.”
+
+“Go and see him when he has a good batch. Figure this to yourself,
+citizen; he shaved the sixty-three to-day, in less than two pipes! Less
+than two pipes. Word of honour!”
+
+As the grinning little man held out the pipe he was smoking, to explain
+how he timed the executioner, Carton was so sensible of a rising desire
+to strike the life out of him, that he turned away.
+
+“But you are not English,” said the wood-sawyer, “though you wear
+English dress?”
+
+“Yes,” said Carton, pausing again, and answering over his shoulder.
+
+“You speak like a Frenchman.”
+
+“I am an old student here.”
+
+“Aha, a perfect Frenchman! Good night, Englishman.”
+
+“Good night, citizen.”
+
+“But go and see that droll dog,” the little man persisted, calling after
+him. “And take a pipe with you!”
+
+Sydney had not gone far out of sight, when he stopped in the middle of
+the street under a glimmering lamp, and wrote with his pencil on a scrap
+of paper. Then, traversing with the decided step of one who remembered
+the way well, several dark and dirty streets--much dirtier than usual,
+for the best public thoroughfares remained uncleansed in those times of
+terror--he stopped at a chemist’s shop, which the owner was closing with
+his own hands. A small, dim, crooked shop, kept in a tortuous, up-hill
+thoroughfare, by a small, dim, crooked man.
+
+Giving this citizen, too, good night, as he confronted him at his
+counter, he laid the scrap of paper before him. “Whew!” the chemist
+whistled softly, as he read it. “Hi! hi! hi!”
+
+Sydney Carton took no heed, and the chemist said:
+
+“For you, citizen?”
+
+“For me.”
+
+“You will be careful to keep them separate, citizen? You know the
+consequences of mixing them?”
+
+“Perfectly.”
+
+Certain small packets were made and given to him. He put them, one by
+one, in the breast of his inner coat, counted out the money for them,
+and deliberately left the shop. “There is nothing more to do,” said he,
+glancing upward at the moon, “until to-morrow. I can’t sleep.”
+
+It was not a reckless manner, the manner in which he said these words
+aloud under the fast-sailing clouds, nor was it more expressive of
+negligence than defiance. It was the settled manner of a tired man, who
+had wandered and struggled and got lost, but who at length struck into
+his road and saw its end.
+
+Long ago, when he had been famous among his earliest competitors as a
+youth of great promise, he had followed his father to the grave. His
+mother had died, years before. These solemn words, which had been
+read at his father’s grave, arose in his mind as he went down the dark
+streets, among the heavy shadows, with the moon and the clouds sailing
+on high above him. “I am the resurrection and the life, saith the Lord:
+he that believeth in me, though he were dead, yet shall he live: and
+whosoever liveth and believeth in me, shall never die.”
+
+In a city dominated by the axe, alone at night, with natural sorrow
+rising in him for the sixty-three who had been that day put to death,
+and for to-morrow’s victims then awaiting their doom in the prisons,
+and still of to-morrow’s and to-morrow’s, the chain of association that
+brought the words home, like a rusty old ship’s anchor from the deep,
+might have been easily found. He did not seek it, but repeated them and
+went on.
+
+With a solemn interest in the lighted windows where the people were
+going to rest, forgetful through a few calm hours of the horrors
+surrounding them; in the towers of the churches, where no prayers
+were said, for the popular revulsion had even travelled that length
+of self-destruction from years of priestly impostors, plunderers, and
+profligates; in the distant burial-places, reserved, as they wrote upon
+the gates, for Eternal Sleep; in the abounding gaols; and in the streets
+along which the sixties rolled to a death which had become so common and
+material, that no sorrowful story of a haunting Spirit ever arose among
+the people out of all the working of the Guillotine; with a solemn
+interest in the whole life and death of the city settling down to its
+short nightly pause in fury; Sydney Carton crossed the Seine again for
+the lighter streets.
+
+Few coaches were abroad, for riders in coaches were liable to be
+suspected, and gentility hid its head in red nightcaps, and put on heavy
+shoes, and trudged. But, the theatres were all well filled, and the
+people poured cheerfully out as he passed, and went chatting home. At
+one of the theatre doors, there was a little girl with a mother, looking
+for a way across the street through the mud. He carried the child over,
+and before the timid arm was loosed from his neck asked her for a kiss.
+
+“I am the resurrection and the life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me, shall never die.”
+
+Now, that the streets were quiet, and the night wore on, the words
+were in the echoes of his feet, and were in the air. Perfectly calm
+and steady, he sometimes repeated them to himself as he walked; but, he
+heard them always.
+
+The night wore out, and, as he stood upon the bridge listening to the
+water as it splashed the river-walls of the Island of Paris, where the
+picturesque confusion of houses and cathedral shone bright in the light
+of the moon, the day came coldly, looking like a dead face out of the
+sky. Then, the night, with the moon and the stars, turned pale and died,
+and for a little while it seemed as if Creation were delivered over to
+Death’s dominion.
+
+But, the glorious sun, rising, seemed to strike those words, that burden
+of the night, straight and warm to his heart in its long bright rays.
+And looking along them, with reverently shaded eyes, a bridge of light
+appeared to span the air between him and the sun, while the river
+sparkled under it.
+
+The strong tide, so swift, so deep, and certain, was like a congenial
+friend, in the morning stillness. He walked by the stream, far from the
+houses, and in the light and warmth of the sun fell asleep on the
+bank. When he awoke and was afoot again, he lingered there yet a little
+longer, watching an eddy that turned and turned purposeless, until the
+stream absorbed it, and carried it on to the sea.--“Like me.”
+
+A trading-boat, with a sail of the softened colour of a dead leaf, then
+glided into his view, floated by him, and died away. As its silent track
+in the water disappeared, the prayer that had broken up out of his heart
+for a merciful consideration of all his poor blindnesses and errors,
+ended in the words, “I am the resurrection and the life.”
+
+Mr. Lorry was already out when he got back, and it was easy to surmise
+where the good old man was gone. Sydney Carton drank nothing but a
+little coffee, ate some bread, and, having washed and changed to refresh
+himself, went out to the place of trial.
+
+The court was all astir and a-buzz, when the black sheep--whom many fell
+away from in dread--pressed him into an obscure corner among the crowd.
+Mr. Lorry was there, and Doctor Manette was there. She was there,
+sitting beside her father.
+
+When her husband was brought in, she turned a look upon him, so
+sustaining, so encouraging, so full of admiring love and pitying
+tenderness, yet so courageous for his sake, that it called the healthy
+blood into his face, brightened his glance, and animated his heart. If
+there had been any eyes to notice the influence of her look, on Sydney
+Carton, it would have been seen to be the same influence exactly.
+
+Before that unjust Tribunal, there was little or no order of procedure,
+ensuring to any accused person any reasonable hearing. There could have
+been no such Revolution, if all laws, forms, and ceremonies, had not
+first been so monstrously abused, that the suicidal vengeance of the
+Revolution was to scatter them all to the winds.
+
+Every eye was turned to the jury. The same determined patriots and good
+republicans as yesterday and the day before, and to-morrow and the day
+after. Eager and prominent among them, one man with a craving face, and
+his fingers perpetually hovering about his lips, whose appearance
+gave great satisfaction to the spectators. A life-thirsting,
+cannibal-looking, bloody-minded juryman, the Jacques Three of St.
+Antoine. The whole jury, as a jury of dogs empannelled to try the deer.
+
+Every eye then turned to the five judges and the public prosecutor.
+No favourable leaning in that quarter to-day. A fell, uncompromising,
+murderous business-meaning there. Every eye then sought some other eye
+in the crowd, and gleamed at it approvingly; and heads nodded at one
+another, before bending forward with a strained attention.
+
+Charles Evremonde, called Darnay. Released yesterday. Reaccused and
+retaken yesterday. Indictment delivered to him last night. Suspected and
+Denounced enemy of the Republic, Aristocrat, one of a family of tyrants,
+one of a race proscribed, for that they had used their abolished
+privileges to the infamous oppression of the people. Charles Evremonde,
+called Darnay, in right of such proscription, absolutely Dead in Law.
+
+To this effect, in as few or fewer words, the Public Prosecutor.
+
+The President asked, was the Accused openly denounced or secretly?
+
+“Openly, President.”
+
+“By whom?”
+
+“Three voices. Ernest Defarge, wine-vendor of St. Antoine.”
+
+“Good.”
+
+“Therese Defarge, his wife.”
+
+“Good.”
+
+“Alexandre Manette, physician.”
+
+A great uproar took place in the court, and in the midst of it, Doctor
+Manette was seen, pale and trembling, standing where he had been seated.
+
+“President, I indignantly protest to you that this is a forgery and
+a fraud. You know the accused to be the husband of my daughter. My
+daughter, and those dear to her, are far dearer to me than my life. Who
+and where is the false conspirator who says that I denounce the husband
+of my child!”
+
+“Citizen Manette, be tranquil. To fail in submission to the authority of
+the Tribunal would be to put yourself out of Law. As to what is dearer
+to you than life, nothing can be so dear to a good citizen as the
+Republic.”
+
+Loud acclamations hailed this rebuke. The President rang his bell, and
+with warmth resumed.
+
+“If the Republic should demand of you the sacrifice of your child
+herself, you would have no duty but to sacrifice her. Listen to what is
+to follow. In the meanwhile, be silent!”
+
+Frantic acclamations were again raised. Doctor Manette sat down, with
+his eyes looking around, and his lips trembling; his daughter drew
+closer to him. The craving man on the jury rubbed his hands together,
+and restored the usual hand to his mouth.
+
+Defarge was produced, when the court was quiet enough to admit of his
+being heard, and rapidly expounded the story of the imprisonment, and of
+his having been a mere boy in the Doctor’s service, and of the release,
+and of the state of the prisoner when released and delivered to him.
+This short examination followed, for the court was quick with its work.
+
+“You did good service at the taking of the Bastille, citizen?”
+
+“I believe so.”
+
+Here, an excited woman screeched from the crowd: “You were one of the
+best patriots there. Why not say so? You were a cannonier that day
+there, and you were among the first to enter the accursed fortress when
+it fell. Patriots, I speak the truth!”
+
+It was The Vengeance who, amidst the warm commendations of the audience,
+thus assisted the proceedings. The President rang his bell; but, The
+Vengeance, warming with encouragement, shrieked, “I defy that bell!”
+ wherein she was likewise much commended.
+
+“Inform the Tribunal of what you did that day within the Bastille,
+citizen.”
+
+“I knew,” said Defarge, looking down at his wife, who stood at the
+bottom of the steps on which he was raised, looking steadily up at him;
+“I knew that this prisoner, of whom I speak, had been confined in a cell
+known as One Hundred and Five, North Tower. I knew it from himself. He
+knew himself by no other name than One Hundred and Five, North Tower,
+when he made shoes under my care. As I serve my gun that day, I resolve,
+when the place shall fall, to examine that cell. It falls. I mount to
+the cell, with a fellow-citizen who is one of the Jury, directed by a
+gaoler. I examine it, very closely. In a hole in the chimney, where a
+stone has been worked out and replaced, I find a written paper. This is
+that written paper. I have made it my business to examine some specimens
+of the writing of Doctor Manette. This is the writing of Doctor Manette.
+I confide this paper, in the writing of Doctor Manette, to the hands of
+the President.”
+
+“Let it be read.”
+
+In a dead silence and stillness--the prisoner under trial looking
+lovingly at his wife, his wife only looking from him to look with
+solicitude at her father, Doctor Manette keeping his eyes fixed on the
+reader, Madame Defarge never taking hers from the prisoner, Defarge
+never taking his from his feasting wife, and all the other eyes there
+intent upon the Doctor, who saw none of them--the paper was read, as
+follows.
+
+
+
+
+X. The Substance of the Shadow
+
+
+“I, Alexandre Manette, unfortunate physician, native of Beauvais, and
+afterwards resident in Paris, write this melancholy paper in my doleful
+cell in the Bastille, during the last month of the year, 1767. I write
+it at stolen intervals, under every difficulty. I design to secrete it
+in the wall of the chimney, where I have slowly and laboriously made a
+place of concealment for it. Some pitying hand may find it there, when I
+and my sorrows are dust.
+
+“These words are formed by the rusty iron point with which I write with
+difficulty in scrapings of soot and charcoal from the chimney, mixed
+with blood, in the last month of the tenth year of my captivity. Hope
+has quite departed from my breast. I know from terrible warnings I have
+noted in myself that my reason will not long remain unimpaired, but I
+solemnly declare that I am at this time in the possession of my right
+mind--that my memory is exact and circumstantial--and that I write the
+truth as I shall answer for these my last recorded words, whether they
+be ever read by men or not, at the Eternal Judgment-seat.
+
+“One cloudy moonlight night, in the third week of December (I think the
+twenty-second of the month) in the year 1757, I was walking on a retired
+part of the quay by the Seine for the refreshment of the frosty air,
+at an hour’s distance from my place of residence in the Street of the
+School of Medicine, when a carriage came along behind me, driven very
+fast. As I stood aside to let that carriage pass, apprehensive that it
+might otherwise run me down, a head was put out at the window, and a
+voice called to the driver to stop.
+
+“The carriage stopped as soon as the driver could rein in his horses,
+and the same voice called to me by my name. I answered. The carriage
+was then so far in advance of me that two gentlemen had time to open the
+door and alight before I came up with it.
+
+“I observed that they were both wrapped in cloaks, and appeared to
+conceal themselves. As they stood side by side near the carriage door,
+I also observed that they both looked of about my own age, or rather
+younger, and that they were greatly alike, in stature, manner, voice,
+and (as far as I could see) face too.
+
+“‘You are Doctor Manette?’ said one.
+
+“I am.”
+
+“‘Doctor Manette, formerly of Beauvais,’ said the other; ‘the young
+physician, originally an expert surgeon, who within the last year or two
+has made a rising reputation in Paris?’
+
+“‘Gentlemen,’ I returned, ‘I am that Doctor Manette of whom you speak so
+graciously.’
+
+“‘We have been to your residence,’ said the first, ‘and not being
+so fortunate as to find you there, and being informed that you were
+probably walking in this direction, we followed, in the hope of
+overtaking you. Will you please to enter the carriage?’
+
+“The manner of both was imperious, and they both moved, as these words
+were spoken, so as to place me between themselves and the carriage door.
+They were armed. I was not.
+
+“‘Gentlemen,’ said I, ‘pardon me; but I usually inquire who does me
+the honour to seek my assistance, and what is the nature of the case to
+which I am summoned.’
+
+“The reply to this was made by him who had spoken second. ‘Doctor,
+your clients are people of condition. As to the nature of the case,
+our confidence in your skill assures us that you will ascertain it for
+yourself better than we can describe it. Enough. Will you please to
+enter the carriage?’
+
+“I could do nothing but comply, and I entered it in silence. They both
+entered after me--the last springing in, after putting up the steps. The
+carriage turned about, and drove on at its former speed.
+
+“I repeat this conversation exactly as it occurred. I have no doubt that
+it is, word for word, the same. I describe everything exactly as it took
+place, constraining my mind not to wander from the task. Where I make
+the broken marks that follow here, I leave off for the time, and put my
+paper in its hiding-place.
+
+        *****
+
+“The carriage left the streets behind, passed the North Barrier, and
+emerged upon the country road. At two-thirds of a league from the
+Barrier--I did not estimate the distance at that time, but afterwards
+when I traversed it--it struck out of the main avenue, and presently
+stopped at a solitary house, We all three alighted, and walked, by
+a damp soft footpath in a garden where a neglected fountain had
+overflowed, to the door of the house. It was not opened immediately, in
+answer to the ringing of the bell, and one of my two conductors struck
+the man who opened it, with his heavy riding glove, across the face.
+
+“There was nothing in this action to attract my particular attention,
+for I had seen common people struck more commonly than dogs. But, the
+other of the two, being angry likewise, struck the man in like manner
+with his arm; the look and bearing of the brothers were then so exactly
+alike, that I then first perceived them to be twin brothers.
+
+“From the time of our alighting at the outer gate (which we found
+locked, and which one of the brothers had opened to admit us, and had
+relocked), I had heard cries proceeding from an upper chamber. I was
+conducted to this chamber straight, the cries growing louder as we
+ascended the stairs, and I found a patient in a high fever of the brain,
+lying on a bed.
+
+“The patient was a woman of great beauty, and young; assuredly not much
+past twenty. Her hair was torn and ragged, and her arms were bound to
+her sides with sashes and handkerchiefs. I noticed that these bonds were
+all portions of a gentleman’s dress. On one of them, which was a fringed
+scarf for a dress of ceremony, I saw the armorial bearings of a Noble,
+and the letter E.
+
+“I saw this, within the first minute of my contemplation of the patient;
+for, in her restless strivings she had turned over on her face on the
+edge of the bed, had drawn the end of the scarf into her mouth, and was
+in danger of suffocation. My first act was to put out my hand to relieve
+her breathing; and in moving the scarf aside, the embroidery in the
+corner caught my sight.
+
+“I turned her gently over, placed my hands upon her breast to calm her
+and keep her down, and looked into her face. Her eyes were dilated and
+wild, and she constantly uttered piercing shrieks, and repeated the
+words, ‘My husband, my father, and my brother!’ and then counted up to
+twelve, and said, ‘Hush!’ For an instant, and no more, she would pause
+to listen, and then the piercing shrieks would begin again, and she
+would repeat the cry, ‘My husband, my father, and my brother!’ and
+would count up to twelve, and say, ‘Hush!’ There was no variation in the
+order, or the manner. There was no cessation, but the regular moment’s
+pause, in the utterance of these sounds.
+
+“‘How long,’ I asked, ‘has this lasted?’
+
+“To distinguish the brothers, I will call them the elder and the
+younger; by the elder, I mean him who exercised the most authority. It
+was the elder who replied, ‘Since about this hour last night.’
+
+“‘She has a husband, a father, and a brother?’
+
+“‘A brother.’
+
+“‘I do not address her brother?’
+
+“He answered with great contempt, ‘No.’
+
+“‘She has some recent association with the number twelve?’
+
+“The younger brother impatiently rejoined, ‘With twelve o’clock?’
+
+“‘See, gentlemen,’ said I, still keeping my hands upon her breast, ‘how
+useless I am, as you have brought me! If I had known what I was coming
+to see, I could have come provided. As it is, time must be lost. There
+are no medicines to be obtained in this lonely place.’
+
+“The elder brother looked to the younger, who said haughtily, ‘There is
+a case of medicines here;’ and brought it from a closet, and put it on
+the table.
+
+        *****
+
+“I opened some of the bottles, smelt them, and put the stoppers to my
+lips. If I had wanted to use anything save narcotic medicines that were
+poisons in themselves, I would not have administered any of those.
+
+“‘Do you doubt them?’ asked the younger brother.
+
+“‘You see, monsieur, I am going to use them,’ I replied, and said no
+more.
+
+“I made the patient swallow, with great difficulty, and after many
+efforts, the dose that I desired to give. As I intended to repeat it
+after a while, and as it was necessary to watch its influence, I then
+sat down by the side of the bed. There was a timid and suppressed woman
+in attendance (wife of the man down-stairs), who had retreated into
+a corner. The house was damp and decayed, indifferently
+furnished--evidently, recently occupied and temporarily used. Some thick
+old hangings had been nailed up before the windows, to deaden the
+sound of the shrieks. They continued to be uttered in their regular
+succession, with the cry, ‘My husband, my father, and my brother!’ the
+counting up to twelve, and ‘Hush!’ The frenzy was so violent, that I had
+not unfastened the bandages restraining the arms; but, I had looked to
+them, to see that they were not painful. The only spark of encouragement
+in the case, was, that my hand upon the sufferer’s breast had this much
+soothing influence, that for minutes at a time it tranquillised the
+figure. It had no effect upon the cries; no pendulum could be more
+regular.
+
+“For the reason that my hand had this effect (I assume), I had sat by
+the side of the bed for half an hour, with the two brothers looking on,
+before the elder said:
+
+“‘There is another patient.’
+
+“I was startled, and asked, ‘Is it a pressing case?’
+
+“‘You had better see,’ he carelessly answered; and took up a light.
+
+        *****
+
+“The other patient lay in a back room across a second staircase, which
+was a species of loft over a stable. There was a low plastered ceiling
+to a part of it; the rest was open, to the ridge of the tiled roof, and
+there were beams across. Hay and straw were stored in that portion of
+the place, fagots for firing, and a heap of apples in sand. I had to
+pass through that part, to get at the other. My memory is circumstantial
+and unshaken. I try it with these details, and I see them all, in
+this my cell in the Bastille, near the close of the tenth year of my
+captivity, as I saw them all that night.
+
+“On some hay on the ground, with a cushion thrown under his head, lay a
+handsome peasant boy--a boy of not more than seventeen at the most.
+He lay on his back, with his teeth set, his right hand clenched on his
+breast, and his glaring eyes looking straight upward. I could not see
+where his wound was, as I kneeled on one knee over him; but, I could see
+that he was dying of a wound from a sharp point.
+
+“‘I am a doctor, my poor fellow,’ said I. ‘Let me examine it.’
+
+“‘I do not want it examined,’ he answered; ‘let it be.’
+
+“It was under his hand, and I soothed him to let me move his hand away.
+The wound was a sword-thrust, received from twenty to twenty-four hours
+before, but no skill could have saved him if it had been looked to
+without delay. He was then dying fast. As I turned my eyes to the elder
+brother, I saw him looking down at this handsome boy whose life was
+ebbing out, as if he were a wounded bird, or hare, or rabbit; not at all
+as if he were a fellow-creature.
+
+“‘How has this been done, monsieur?’ said I.
+
+“‘A crazed young common dog! A serf! Forced my brother to draw upon him,
+and has fallen by my brother’s sword--like a gentleman.’
+
+“There was no touch of pity, sorrow, or kindred humanity, in this
+answer. The speaker seemed to acknowledge that it was inconvenient to
+have that different order of creature dying there, and that it would
+have been better if he had died in the usual obscure routine of his
+vermin kind. He was quite incapable of any compassionate feeling about
+the boy, or about his fate.
+
+“The boy’s eyes had slowly moved to him as he had spoken, and they now
+slowly moved to me.
+
+“‘Doctor, they are very proud, these Nobles; but we common dogs are
+proud too, sometimes. They plunder us, outrage us, beat us, kill us; but
+we have a little pride left, sometimes. She--have you seen her, Doctor?’
+
+“The shrieks and the cries were audible there, though subdued by the
+distance. He referred to them, as if she were lying in our presence.
+
+“I said, ‘I have seen her.’
+
+“‘She is my sister, Doctor. They have had their shameful rights, these
+Nobles, in the modesty and virtue of our sisters, many years, but we
+have had good girls among us. I know it, and have heard my father say
+so. She was a good girl. She was betrothed to a good young man, too: a
+tenant of his. We were all tenants of his--that man’s who stands there.
+The other is his brother, the worst of a bad race.’
+
+“It was with the greatest difficulty that the boy gathered bodily force
+to speak; but, his spirit spoke with a dreadful emphasis.
+
+“‘We were so robbed by that man who stands there, as all we common dogs
+are by those superior Beings--taxed by him without mercy, obliged to
+work for him without pay, obliged to grind our corn at his mill, obliged
+to feed scores of his tame birds on our wretched crops, and forbidden
+for our lives to keep a single tame bird of our own, pillaged and
+plundered to that degree that when we chanced to have a bit of meat, we
+ate it in fear, with the door barred and the shutters closed, that his
+people should not see it and take it from us--I say, we were so robbed,
+and hunted, and were made so poor, that our father told us it was a
+dreadful thing to bring a child into the world, and that what we should
+most pray for, was, that our women might be barren and our miserable
+race die out!’
+
+“I had never before seen the sense of being oppressed, bursting forth
+like a fire. I had supposed that it must be latent in the people
+somewhere; but, I had never seen it break out, until I saw it in the
+dying boy.
+
+“‘Nevertheless, Doctor, my sister married. He was ailing at that time,
+poor fellow, and she married her lover, that she might tend and comfort
+him in our cottage--our dog-hut, as that man would call it. She had not
+been married many weeks, when that man’s brother saw her and admired
+her, and asked that man to lend her to him--for what are husbands among
+us! He was willing enough, but my sister was good and virtuous, and
+hated his brother with a hatred as strong as mine. What did the two
+then, to persuade her husband to use his influence with her, to make her
+willing?’
+
+“The boy’s eyes, which had been fixed on mine, slowly turned to the
+looker-on, and I saw in the two faces that all he said was true. The two
+opposing kinds of pride confronting one another, I can see, even in this
+Bastille; the gentleman’s, all negligent indifference; the peasant’s, all
+trodden-down sentiment, and passionate revenge.
+
+“‘You know, Doctor, that it is among the Rights of these Nobles to
+harness us common dogs to carts, and drive us. They so harnessed him and
+drove him. You know that it is among their Rights to keep us in their
+grounds all night, quieting the frogs, in order that their noble sleep
+may not be disturbed. They kept him out in the unwholesome mists at
+night, and ordered him back into his harness in the day. But he was
+not persuaded. No! Taken out of harness one day at noon, to feed--if he
+could find food--he sobbed twelve times, once for every stroke of the
+bell, and died on her bosom.’
+
+“Nothing human could have held life in the boy but his determination to
+tell all his wrong. He forced back the gathering shadows of death, as
+he forced his clenched right hand to remain clenched, and to cover his
+wound.
+
+“‘Then, with that man’s permission and even with his aid, his
+brother took her away; in spite of what I know she must have told his
+brother--and what that is, will not be long unknown to you, Doctor, if
+it is now--his brother took her away--for his pleasure and diversion,
+for a little while. I saw her pass me on the road. When I took the
+tidings home, our father’s heart burst; he never spoke one of the words
+that filled it. I took my young sister (for I have another) to a place
+beyond the reach of this man, and where, at least, she will never be
+_his_ vassal. Then, I tracked the brother here, and last night climbed
+in--a common dog, but sword in hand.--Where is the loft window? It was
+somewhere here?’
+
+“The room was darkening to his sight; the world was narrowing around
+him. I glanced about me, and saw that the hay and straw were trampled
+over the floor, as if there had been a struggle.
+
+“‘She heard me, and ran in. I told her not to come near us till he was
+dead. He came in and first tossed me some pieces of money; then struck
+at me with a whip. But I, though a common dog, so struck at him as to
+make him draw. Let him break into as many pieces as he will, the sword
+that he stained with my common blood; he drew to defend himself--thrust
+at me with all his skill for his life.’
+
+“My glance had fallen, but a few moments before, on the fragments of
+a broken sword, lying among the hay. That weapon was a gentleman’s. In
+another place, lay an old sword that seemed to have been a soldier’s.
+
+“‘Now, lift me up, Doctor; lift me up. Where is he?’
+
+“‘He is not here,’ I said, supporting the boy, and thinking that he
+referred to the brother.
+
+“‘He! Proud as these nobles are, he is afraid to see me. Where is the
+man who was here? Turn my face to him.’
+
+“I did so, raising the boy’s head against my knee. But, invested for the
+moment with extraordinary power, he raised himself completely: obliging
+me to rise too, or I could not have still supported him.
+
+“‘Marquis,’ said the boy, turned to him with his eyes opened wide, and
+his right hand raised, ‘in the days when all these things are to be
+answered for, I summon you and yours, to the last of your bad race, to
+answer for them. I mark this cross of blood upon you, as a sign that
+I do it. In the days when all these things are to be answered for,
+I summon your brother, the worst of the bad race, to answer for them
+separately. I mark this cross of blood upon him, as a sign that I do
+it.’
+
+“Twice, he put his hand to the wound in his breast, and with his
+forefinger drew a cross in the air. He stood for an instant with the
+finger yet raised, and as it dropped, he dropped with it, and I laid him
+down dead.
+
+        *****
+
+“When I returned to the bedside of the young woman, I found her raving
+in precisely the same order of continuity. I knew that this might last
+for many hours, and that it would probably end in the silence of the
+grave.
+
+“I repeated the medicines I had given her, and I sat at the side of
+the bed until the night was far advanced. She never abated the piercing
+quality of her shrieks, never stumbled in the distinctness or the order
+of her words. They were always ‘My husband, my father, and my brother!
+One, two, three, four, five, six, seven, eight, nine, ten, eleven,
+twelve. Hush!’
+
+“This lasted twenty-six hours from the time when I first saw her. I had
+come and gone twice, and was again sitting by her, when she began to
+falter. I did what little could be done to assist that opportunity, and
+by-and-bye she sank into a lethargy, and lay like the dead.
+
+“It was as if the wind and rain had lulled at last, after a long and
+fearful storm. I released her arms, and called the woman to assist me to
+compose her figure and the dress she had torn. It was then that I knew
+her condition to be that of one in whom the first expectations of being
+a mother have arisen; and it was then that I lost the little hope I had
+had of her.
+
+“‘Is she dead?’ asked the Marquis, whom I will still describe as the
+elder brother, coming booted into the room from his horse.
+
+“‘Not dead,’ said I; ‘but like to die.’
+
+“‘What strength there is in these common bodies!’ he said, looking down
+at her with some curiosity.
+
+“‘There is prodigious strength,’ I answered him, ‘in sorrow and
+despair.’
+
+“He first laughed at my words, and then frowned at them. He moved a
+chair with his foot near to mine, ordered the woman away, and said in a
+subdued voice,
+
+“‘Doctor, finding my brother in this difficulty with these hinds, I
+recommended that your aid should be invited. Your reputation is high,
+and, as a young man with your fortune to make, you are probably mindful
+of your interest. The things that you see here, are things to be seen,
+and not spoken of.’
+
+“I listened to the patient’s breathing, and avoided answering.
+
+“‘Do you honour me with your attention, Doctor?’
+
+“‘Monsieur,’ said I, ‘in my profession, the communications of patients
+are always received in confidence.’ I was guarded in my answer, for I
+was troubled in my mind with what I had heard and seen.
+
+“Her breathing was so difficult to trace, that I carefully tried the
+pulse and the heart. There was life, and no more. Looking round as I
+resumed my seat, I found both the brothers intent upon me.
+
+        *****
+
+“I write with so much difficulty, the cold is so severe, I am so
+fearful of being detected and consigned to an underground cell and total
+darkness, that I must abridge this narrative. There is no confusion or
+failure in my memory; it can recall, and could detail, every word that
+was ever spoken between me and those brothers.
+
+“She lingered for a week. Towards the last, I could understand some few
+syllables that she said to me, by placing my ear close to her lips. She
+asked me where she was, and I told her; who I was, and I told her. It
+was in vain that I asked her for her family name. She faintly shook her
+head upon the pillow, and kept her secret, as the boy had done.
+
+“I had no opportunity of asking her any question, until I had told the
+brothers she was sinking fast, and could not live another day. Until
+then, though no one was ever presented to her consciousness save the
+woman and myself, one or other of them had always jealously sat behind
+the curtain at the head of the bed when I was there. But when it came to
+that, they seemed careless what communication I might hold with her; as
+if--the thought passed through my mind--I were dying too.
+
+“I always observed that their pride bitterly resented the younger
+brother’s (as I call him) having crossed swords with a peasant, and that
+peasant a boy. The only consideration that appeared to affect the mind
+of either of them was the consideration that this was highly degrading
+to the family, and was ridiculous. As often as I caught the younger
+brother’s eyes, their expression reminded me that he disliked me deeply,
+for knowing what I knew from the boy. He was smoother and more polite to
+me than the elder; but I saw this. I also saw that I was an incumbrance
+in the mind of the elder, too.
+
+“My patient died, two hours before midnight--at a time, by my watch,
+answering almost to the minute when I had first seen her. I was alone
+with her, when her forlorn young head drooped gently on one side, and
+all her earthly wrongs and sorrows ended.
+
+“The brothers were waiting in a room down-stairs, impatient to ride
+away. I had heard them, alone at the bedside, striking their boots with
+their riding-whips, and loitering up and down.
+
+“‘At last she is dead?’ said the elder, when I went in.
+
+“‘She is dead,’ said I.
+
+“‘I congratulate you, my brother,’ were his words as he turned round.
+
+“He had before offered me money, which I had postponed taking. He now
+gave me a rouleau of gold. I took it from his hand, but laid it on
+the table. I had considered the question, and had resolved to accept
+nothing.
+
+“‘Pray excuse me,’ said I. ‘Under the circumstances, no.’
+
+“They exchanged looks, but bent their heads to me as I bent mine to
+them, and we parted without another word on either side.
+
+        *****
+
+“I am weary, weary, weary--worn down by misery. I cannot read what I
+have written with this gaunt hand.
+
+“Early in the morning, the rouleau of gold was left at my door in a
+little box, with my name on the outside. From the first, I had anxiously
+considered what I ought to do. I decided, that day, to write privately
+to the Minister, stating the nature of the two cases to which I had been
+summoned, and the place to which I had gone: in effect, stating all the
+circumstances. I knew what Court influence was, and what the immunities
+of the Nobles were, and I expected that the matter would never be
+heard of; but, I wished to relieve my own mind. I had kept the matter a
+profound secret, even from my wife; and this, too, I resolved to state
+in my letter. I had no apprehension whatever of my real danger; but
+I was conscious that there might be danger for others, if others were
+compromised by possessing the knowledge that I possessed.
+
+“I was much engaged that day, and could not complete my letter that
+night. I rose long before my usual time next morning to finish it.
+It was the last day of the year. The letter was lying before me just
+completed, when I was told that a lady waited, who wished to see me.
+
+        *****
+
+“I am growing more and more unequal to the task I have set myself. It is
+so cold, so dark, my senses are so benumbed, and the gloom upon me is so
+dreadful.
+
+“The lady was young, engaging, and handsome, but not marked for long
+life. She was in great agitation. She presented herself to me as the
+wife of the Marquis St. Evremonde. I connected the title by which the
+boy had addressed the elder brother, with the initial letter embroidered
+on the scarf, and had no difficulty in arriving at the conclusion that I
+had seen that nobleman very lately.
+
+“My memory is still accurate, but I cannot write the words of our
+conversation. I suspect that I am watched more closely than I was, and I
+know not at what times I may be watched. She had in part suspected, and
+in part discovered, the main facts of the cruel story, of her husband’s
+share in it, and my being resorted to. She did not know that the girl
+was dead. Her hope had been, she said in great distress, to show her,
+in secret, a woman’s sympathy. Her hope had been to avert the wrath of
+Heaven from a House that had long been hateful to the suffering many.
+
+“She had reasons for believing that there was a young sister living, and
+her greatest desire was, to help that sister. I could tell her nothing
+but that there was such a sister; beyond that, I knew nothing. Her
+inducement to come to me, relying on my confidence, had been the hope
+that I could tell her the name and place of abode. Whereas, to this
+wretched hour I am ignorant of both.
+
+        *****
+
+“These scraps of paper fail me. One was taken from me, with a warning,
+yesterday. I must finish my record to-day.
+
+“She was a good, compassionate lady, and not happy in her marriage. How
+could she be! The brother distrusted and disliked her, and his influence
+was all opposed to her; she stood in dread of him, and in dread of her
+husband too. When I handed her down to the door, there was a child, a
+pretty boy from two to three years old, in her carriage.
+
+“‘For his sake, Doctor,’ she said, pointing to him in tears, ‘I would do
+all I can to make what poor amends I can. He will never prosper in his
+inheritance otherwise. I have a presentiment that if no other innocent
+atonement is made for this, it will one day be required of him. What
+I have left to call my own--it is little beyond the worth of a few
+jewels--I will make it the first charge of his life to bestow, with the
+compassion and lamenting of his dead mother, on this injured family, if
+the sister can be discovered.’
+
+“She kissed the boy, and said, caressing him, ‘It is for thine own dear
+sake. Thou wilt be faithful, little Charles?’ The child answered her
+bravely, ‘Yes!’ I kissed her hand, and she took him in her arms, and
+went away caressing him. I never saw her more.
+
+“As she had mentioned her husband’s name in the faith that I knew it,
+I added no mention of it to my letter. I sealed my letter, and, not
+trusting it out of my own hands, delivered it myself that day.
+
+“That night, the last night of the year, towards nine o’clock, a man in
+a black dress rang at my gate, demanded to see me, and softly followed
+my servant, Ernest Defarge, a youth, up-stairs. When my servant came
+into the room where I sat with my wife--O my wife, beloved of my heart!
+My fair young English wife!--we saw the man, who was supposed to be at
+the gate, standing silent behind him.
+
+“An urgent case in the Rue St. Honore, he said. It would not detain me,
+he had a coach in waiting.
+
+“It brought me here, it brought me to my grave. When I was clear of the
+house, a black muffler was drawn tightly over my mouth from behind, and
+my arms were pinioned. The two brothers crossed the road from a dark
+corner, and identified me with a single gesture. The Marquis took from
+his pocket the letter I had written, showed it me, burnt it in the light
+of a lantern that was held, and extinguished the ashes with his foot.
+Not a word was spoken. I was brought here, I was brought to my living
+grave.
+
+“If it had pleased _God_ to put it in the hard heart of either of the
+brothers, in all these frightful years, to grant me any tidings of
+my dearest wife--so much as to let me know by a word whether alive or
+dead--I might have thought that He had not quite abandoned them. But,
+now I believe that the mark of the red cross is fatal to them, and that
+they have no part in His mercies. And them and their descendants, to the
+last of their race, I, Alexandre Manette, unhappy prisoner, do this last
+night of the year 1767, in my unbearable agony, denounce to the times
+when all these things shall be answered for. I denounce them to Heaven
+and to earth.”
+
+A terrible sound arose when the reading of this document was done. A
+sound of craving and eagerness that had nothing articulate in it but
+blood. The narrative called up the most revengeful passions of the time,
+and there was not a head in the nation but must have dropped before it.
+
+Little need, in presence of that tribunal and that auditory, to show
+how the Defarges had not made the paper public, with the other captured
+Bastille memorials borne in procession, and had kept it, biding their
+time. Little need to show that this detested family name had long been
+anathematised by Saint Antoine, and was wrought into the fatal register.
+The man never trod ground whose virtues and services would have
+sustained him in that place that day, against such denunciation.
+
+And all the worse for the doomed man, that the denouncer was a
+well-known citizen, his own attached friend, the father of his wife. One
+of the frenzied aspirations of the populace was, for imitations of
+the questionable public virtues of antiquity, and for sacrifices and
+self-immolations on the people’s altar. Therefore when the President
+said (else had his own head quivered on his shoulders), that the good
+physician of the Republic would deserve better still of the Republic by
+rooting out an obnoxious family of Aristocrats, and would doubtless feel
+a sacred glow and joy in making his daughter a widow and her child an
+orphan, there was wild excitement, patriotic fervour, not a touch of
+human sympathy.
+
+“Much influence around him, has that Doctor?” murmured Madame Defarge,
+smiling to The Vengeance. “Save him now, my Doctor, save him!”
+
+At every juryman’s vote, there was a roar. Another and another. Roar and
+roar.
+
+Unanimously voted. At heart and by descent an Aristocrat, an enemy
+of the Republic, a notorious oppressor of the People. Back to the
+Conciergerie, and Death within four-and-twenty hours!
+
+
+
+
+XI. Dusk
+
+
+The wretched wife of the innocent man thus doomed to die, fell under
+the sentence, as if she had been mortally stricken. But, she uttered no
+sound; and so strong was the voice within her, representing that it was
+she of all the world who must uphold him in his misery and not augment
+it, that it quickly raised her, even from that shock.
+
+The Judges having to take part in a public demonstration out of doors,
+the Tribunal adjourned. The quick noise and movement of the court’s
+emptying itself by many passages had not ceased, when Lucie stood
+stretching out her arms towards her husband, with nothing in her face
+but love and consolation.
+
+“If I might touch him! If I might embrace him once! O, good citizens, if
+you would have so much compassion for us!”
+
+There was but a gaoler left, along with two of the four men who had
+taken him last night, and Barsad. The people had all poured out to the
+show in the streets. Barsad proposed to the rest, “Let her embrace
+him then; it is but a moment.” It was silently acquiesced in, and they
+passed her over the seats in the hall to a raised place, where he, by
+leaning over the dock, could fold her in his arms.
+
+“Farewell, dear darling of my soul. My parting blessing on my love. We
+shall meet again, where the weary are at rest!”
+
+They were her husband’s words, as he held her to his bosom.
+
+“I can bear it, dear Charles. I am supported from above: don’t suffer
+for me. A parting blessing for our child.”
+
+“I send it to her by you. I kiss her by you. I say farewell to her by
+you.”
+
+“My husband. No! A moment!” He was tearing himself apart from her.
+“We shall not be separated long. I feel that this will break my heart
+by-and-bye; but I will do my duty while I can, and when I leave her, God
+will raise up friends for her, as He did for me.”
+
+Her father had followed her, and would have fallen on his knees to both
+of them, but that Darnay put out a hand and seized him, crying:
+
+“No, no! What have you done, what have you done, that you should kneel
+to us! We know now, what a struggle you made of old. We know, now what
+you underwent when you suspected my descent, and when you knew it. We
+know now, the natural antipathy you strove against, and conquered, for
+her dear sake. We thank you with all our hearts, and all our love and
+duty. Heaven be with you!”
+
+Her father’s only answer was to draw his hands through his white hair,
+and wring them with a shriek of anguish.
+
+“It could not be otherwise,” said the prisoner. “All things have worked
+together as they have fallen out. It was the always-vain endeavour to
+discharge my poor mother’s trust that first brought my fatal presence
+near you. Good could never come of such evil, a happier end was not in
+nature to so unhappy a beginning. Be comforted, and forgive me. Heaven
+bless you!”
+
+As he was drawn away, his wife released him, and stood looking after him
+with her hands touching one another in the attitude of prayer, and
+with a radiant look upon her face, in which there was even a comforting
+smile. As he went out at the prisoners’ door, she turned, laid her head
+lovingly on her father’s breast, tried to speak to him, and fell at his
+feet.
+
+Then, issuing from the obscure corner from which he had never moved,
+Sydney Carton came and took her up. Only her father and Mr. Lorry were
+with her. His arm trembled as it raised her, and supported her head.
+Yet, there was an air about him that was not all of pity--that had a
+flush of pride in it.
+
+“Shall I take her to a coach? I shall never feel her weight.”
+
+He carried her lightly to the door, and laid her tenderly down in a
+coach. Her father and their old friend got into it, and he took his seat
+beside the driver.
+
+When they arrived at the gateway where he had paused in the dark not
+many hours before, to picture to himself on which of the rough stones of
+the street her feet had trodden, he lifted her again, and carried her up
+the staircase to their rooms. There, he laid her down on a couch, where
+her child and Miss Pross wept over her.
+
+“Don’t recall her to herself,” he said, softly, to the latter, “she is
+better so. Don’t revive her to consciousness, while she only faints.”
+
+“Oh, Carton, Carton, dear Carton!” cried little Lucie, springing up and
+throwing her arms passionately round him, in a burst of grief. “Now that
+you have come, I think you will do something to help mamma, something to
+save papa! O, look at her, dear Carton! Can you, of all the people who
+love her, bear to see her so?”
+
+He bent over the child, and laid her blooming cheek against his face. He
+put her gently from him, and looked at her unconscious mother.
+
+“Before I go,” he said, and paused--“I may kiss her?”
+
+It was remembered afterwards that when he bent down and touched her face
+with his lips, he murmured some words. The child, who was nearest to
+him, told them afterwards, and told her grandchildren when she was a
+handsome old lady, that she heard him say, “A life you love.”
+
+When he had gone out into the next room, he turned suddenly on Mr. Lorry
+and her father, who were following, and said to the latter:
+
+“You had great influence but yesterday, Doctor Manette; let it at least
+be tried. These judges, and all the men in power, are very friendly to
+you, and very recognisant of your services; are they not?”
+
+“Nothing connected with Charles was concealed from me. I had the
+strongest assurances that I should save him; and I did.” He returned the
+answer in great trouble, and very slowly.
+
+“Try them again. The hours between this and to-morrow afternoon are few
+and short, but try.”
+
+“I intend to try. I will not rest a moment.”
+
+“That’s well. I have known such energy as yours do great things before
+now--though never,” he added, with a smile and a sigh together, “such
+great things as this. But try! Of little worth as life is when we misuse
+it, it is worth that effort. It would cost nothing to lay down if it
+were not.”
+
+“I will go,” said Doctor Manette, “to the Prosecutor and the President
+straight, and I will go to others whom it is better not to name. I will
+write too, and--But stay! There is a Celebration in the streets, and no
+one will be accessible until dark.”
+
+“That’s true. Well! It is a forlorn hope at the best, and not much the
+forlorner for being delayed till dark. I should like to know how you
+speed; though, mind! I expect nothing! When are you likely to have seen
+these dread powers, Doctor Manette?”
+
+“Immediately after dark, I should hope. Within an hour or two from
+this.”
+
+“It will be dark soon after four. Let us stretch the hour or two. If I
+go to Mr. Lorry’s at nine, shall I hear what you have done, either from
+our friend or from yourself?”
+
+“Yes.”
+
+“May you prosper!”
+
+Mr. Lorry followed Sydney to the outer door, and, touching him on the
+shoulder as he was going away, caused him to turn.
+
+“I have no hope,” said Mr. Lorry, in a low and sorrowful whisper.
+
+“Nor have I.”
+
+“If any one of these men, or all of these men, were disposed to spare
+him--which is a large supposition; for what is his life, or any man’s
+to them!--I doubt if they durst spare him after the demonstration in the
+court.”
+
+“And so do I. I heard the fall of the axe in that sound.”
+
+Mr. Lorry leaned his arm upon the door-post, and bowed his face upon it.
+
+“Don’t despond,” said Carton, very gently; “don’t grieve. I encouraged
+Doctor Manette in this idea, because I felt that it might one day be
+consolatory to her. Otherwise, she might think ‘his life was wantonly
+thrown away or wasted,’ and that might trouble her.”
+
+“Yes, yes, yes,” returned Mr. Lorry, drying his eyes, “you are right.
+But he will perish; there is no real hope.”
+
+“Yes. He will perish: there is no real hope,” echoed Carton.
+
+And walked with a settled step, down-stairs.
+
+
+
+
+XII. Darkness
+
+
+Sydney Carton paused in the street, not quite decided where to go. “At
+Tellson’s banking-house at nine,” he said, with a musing face. “Shall I
+do well, in the mean time, to show myself? I think so. It is best that
+these people should know there is such a man as I here; it is a sound
+precaution, and may be a necessary preparation. But care, care, care!
+Let me think it out!”
+
+Checking his steps which had begun to tend towards an object, he took a
+turn or two in the already darkening street, and traced the thought
+in his mind to its possible consequences. His first impression was
+confirmed. “It is best,” he said, finally resolved, “that these people
+should know there is such a man as I here.” And he turned his face
+towards Saint Antoine.
+
+Defarge had described himself, that day, as the keeper of a wine-shop in
+the Saint Antoine suburb. It was not difficult for one who knew the city
+well, to find his house without asking any question. Having ascertained
+its situation, Carton came out of those closer streets again, and dined
+at a place of refreshment and fell sound asleep after dinner. For the
+first time in many years, he had no strong drink. Since last night he
+had taken nothing but a little light thin wine, and last night he had
+dropped the brandy slowly down on Mr. Lorry’s hearth like a man who had
+done with it.
+
+It was as late as seven o’clock when he awoke refreshed, and went out
+into the streets again. As he passed along towards Saint Antoine, he
+stopped at a shop-window where there was a mirror, and slightly altered
+the disordered arrangement of his loose cravat, and his coat-collar, and
+his wild hair. This done, he went on direct to Defarge’s, and went in.
+
+There happened to be no customer in the shop but Jacques Three, of the
+restless fingers and the croaking voice. This man, whom he had seen upon
+the Jury, stood drinking at the little counter, in conversation with the
+Defarges, man and wife. The Vengeance assisted in the conversation, like
+a regular member of the establishment.
+
+As Carton walked in, took his seat and asked (in very indifferent
+French) for a small measure of wine, Madame Defarge cast a careless
+glance at him, and then a keener, and then a keener, and then advanced
+to him herself, and asked him what it was he had ordered.
+
+He repeated what he had already said.
+
+“English?” asked Madame Defarge, inquisitively raising her dark
+eyebrows.
+
+After looking at her, as if the sound of even a single French word were
+slow to express itself to him, he answered, in his former strong foreign
+accent. “Yes, madame, yes. I am English!”
+
+Madame Defarge returned to her counter to get the wine, and, as he
+took up a Jacobin journal and feigned to pore over it puzzling out its
+meaning, he heard her say, “I swear to you, like Evremonde!”
+
+Defarge brought him the wine, and gave him Good Evening.
+
+“How?”
+
+“Good evening.”
+
+“Oh! Good evening, citizen,” filling his glass. “Ah! and good wine. I
+drink to the Republic.”
+
+Defarge went back to the counter, and said, “Certainly, a little like.”
+ Madame sternly retorted, “I tell you a good deal like.” Jacques Three
+pacifically remarked, “He is so much in your mind, see you, madame.”
+ The amiable Vengeance added, with a laugh, “Yes, my faith! And you
+are looking forward with so much pleasure to seeing him once more
+to-morrow!”
+
+Carton followed the lines and words of his paper, with a slow
+forefinger, and with a studious and absorbed face. They were all leaning
+their arms on the counter close together, speaking low. After a silence
+of a few moments, during which they all looked towards him without
+disturbing his outward attention from the Jacobin editor, they resumed
+their conversation.
+
+“It is true what madame says,” observed Jacques Three. “Why stop? There
+is great force in that. Why stop?”
+
+“Well, well,” reasoned Defarge, “but one must stop somewhere. After all,
+the question is still where?”
+
+“At extermination,” said madame.
+
+“Magnificent!” croaked Jacques Three. The Vengeance, also, highly
+approved.
+
+“Extermination is good doctrine, my wife,” said Defarge, rather
+troubled; “in general, I say nothing against it. But this Doctor has
+suffered much; you have seen him to-day; you have observed his face when
+the paper was read.”
+
+“I have observed his face!” repeated madame, contemptuously and angrily.
+“Yes. I have observed his face. I have observed his face to be not the
+face of a true friend of the Republic. Let him take care of his face!”
+
+“And you have observed, my wife,” said Defarge, in a deprecatory manner,
+“the anguish of his daughter, which must be a dreadful anguish to him!”
+
+“I have observed his daughter,” repeated madame; “yes, I have observed
+his daughter, more times than one. I have observed her to-day, and I
+have observed her other days. I have observed her in the court, and
+I have observed her in the street by the prison. Let me but lift my
+finger--!” She seemed to raise it (the listener’s eyes were always on
+his paper), and to let it fall with a rattle on the ledge before her, as
+if the axe had dropped.
+
+“The citizeness is superb!” croaked the Juryman.
+
+“She is an Angel!” said The Vengeance, and embraced her.
+
+“As to thee,” pursued madame, implacably, addressing her husband, “if it
+depended on thee--which, happily, it does not--thou wouldst rescue this
+man even now.”
+
+“No!” protested Defarge. “Not if to lift this glass would do it! But I
+would leave the matter there. I say, stop there.”
+
+“See you then, Jacques,” said Madame Defarge, wrathfully; “and see you,
+too, my little Vengeance; see you both! Listen! For other crimes as
+tyrants and oppressors, I have this race a long time on my register,
+doomed to destruction and extermination. Ask my husband, is that so.”
+
+“It is so,” assented Defarge, without being asked.
+
+“In the beginning of the great days, when the Bastille falls, he finds
+this paper of to-day, and he brings it home, and in the middle of the
+night when this place is clear and shut, we read it, here on this spot,
+by the light of this lamp. Ask him, is that so.”
+
+“It is so,” assented Defarge.
+
+“That night, I tell him, when the paper is read through, and the lamp is
+burnt out, and the day is gleaming in above those shutters and between
+those iron bars, that I have now a secret to communicate. Ask him, is
+that so.”
+
+“It is so,” assented Defarge again.
+
+“I communicate to him that secret. I smite this bosom with these two
+hands as I smite it now, and I tell him, ‘Defarge, I was brought up
+among the fishermen of the sea-shore, and that peasant family so injured
+by the two Evremonde brothers, as that Bastille paper describes, is my
+family. Defarge, that sister of the mortally wounded boy upon the ground
+was my sister, that husband was my sister’s husband, that unborn child
+was their child, that brother was my brother, that father was my father,
+those dead are my dead, and that summons to answer for those things
+descends to me!’ Ask him, is that so.”
+
+“It is so,” assented Defarge once more.
+
+“Then tell Wind and Fire where to stop,” returned madame; “but don’t
+tell me.”
+
+Both her hearers derived a horrible enjoyment from the deadly nature
+of her wrath--the listener could feel how white she was, without seeing
+her--and both highly commended it. Defarge, a weak minority, interposed
+a few words for the memory of the compassionate wife of the Marquis; but
+only elicited from his own wife a repetition of her last reply. “Tell
+the Wind and the Fire where to stop; not me!”
+
+Customers entered, and the group was broken up. The English customer
+paid for what he had had, perplexedly counted his change, and asked, as
+a stranger, to be directed towards the National Palace. Madame Defarge
+took him to the door, and put her arm on his, in pointing out the road.
+The English customer was not without his reflections then, that it might
+be a good deed to seize that arm, lift it, and strike under it sharp and
+deep.
+
+But, he went his way, and was soon swallowed up in the shadow of the
+prison wall. At the appointed hour, he emerged from it to present
+himself in Mr. Lorry’s room again, where he found the old gentleman
+walking to and fro in restless anxiety. He said he had been with Lucie
+until just now, and had only left her for a few minutes, to come and
+keep his appointment. Her father had not been seen, since he quitted the
+banking-house towards four o’clock. She had some faint hopes that his
+mediation might save Charles, but they were very slight. He had been
+more than five hours gone: where could he be?
+
+Mr. Lorry waited until ten; but, Doctor Manette not returning, and
+he being unwilling to leave Lucie any longer, it was arranged that he
+should go back to her, and come to the banking-house again at midnight.
+In the meanwhile, Carton would wait alone by the fire for the Doctor.
+
+He waited and waited, and the clock struck twelve; but Doctor Manette
+did not come back. Mr. Lorry returned, and found no tidings of him, and
+brought none. Where could he be?
+
+They were discussing this question, and were almost building up some
+weak structure of hope on his prolonged absence, when they heard him on
+the stairs. The instant he entered the room, it was plain that all was
+lost.
+
+Whether he had really been to any one, or whether he had been all that
+time traversing the streets, was never known. As he stood staring at
+them, they asked him no question, for his face told them everything.
+
+“I cannot find it,” said he, “and I must have it. Where is it?”
+
+His head and throat were bare, and, as he spoke with a helpless look
+straying all around, he took his coat off, and let it drop on the floor.
+
+“Where is my bench? I have been looking everywhere for my bench, and I
+can’t find it. What have they done with my work? Time presses: I must
+finish those shoes.”
+
+They looked at one another, and their hearts died within them.
+
+“Come, come!” said he, in a whimpering miserable way; “let me get to
+work. Give me my work.”
+
+Receiving no answer, he tore his hair, and beat his feet upon the
+ground, like a distracted child.
+
+“Don’t torture a poor forlorn wretch,” he implored them, with a dreadful
+cry; “but give me my work! What is to become of us, if those shoes are
+not done to-night?”
+
+Lost, utterly lost!
+
+It was so clearly beyond hope to reason with him, or try to restore him,
+that--as if by agreement--they each put a hand upon his shoulder, and
+soothed him to sit down before the fire, with a promise that he should
+have his work presently. He sank into the chair, and brooded over the
+embers, and shed tears. As if all that had happened since the garret
+time were a momentary fancy, or a dream, Mr. Lorry saw him shrink into
+the exact figure that Defarge had had in keeping.
+
+Affected, and impressed with terror as they both were, by this spectacle
+of ruin, it was not a time to yield to such emotions. His lonely
+daughter, bereft of her final hope and reliance, appealed to them both
+too strongly. Again, as if by agreement, they looked at one another with
+one meaning in their faces. Carton was the first to speak:
+
+“The last chance is gone: it was not much. Yes; he had better be taken
+to her. But, before you go, will you, for a moment, steadily attend to
+me? Don’t ask me why I make the stipulations I am going to make, and
+exact the promise I am going to exact; I have a reason--a good one.”
+
+“I do not doubt it,” answered Mr. Lorry. “Say on.”
+
+The figure in the chair between them, was all the time monotonously
+rocking itself to and fro, and moaning. They spoke in such a tone as
+they would have used if they had been watching by a sick-bed in the
+night.
+
+Carton stooped to pick up the coat, which lay almost entangling his
+feet. As he did so, a small case in which the Doctor was accustomed to
+carry the lists of his day’s duties, fell lightly on the floor. Carton
+took it up, and there was a folded paper in it. “We should look
+at this!” he said. Mr. Lorry nodded his consent. He opened it, and
+exclaimed, “Thank _God!_”
+
+“What is it?” asked Mr. Lorry, eagerly.
+
+“A moment! Let me speak of it in its place. First,” he put his hand in
+his coat, and took another paper from it, “that is the certificate which
+enables me to pass out of this city. Look at it. You see--Sydney Carton,
+an Englishman?”
+
+Mr. Lorry held it open in his hand, gazing in his earnest face.
+
+“Keep it for me until to-morrow. I shall see him to-morrow, you
+remember, and I had better not take it into the prison.”
+
+“Why not?”
+
+“I don’t know; I prefer not to do so. Now, take this paper that Doctor
+Manette has carried about him. It is a similar certificate, enabling him
+and his daughter and her child, at any time, to pass the barrier and the
+frontier! You see?”
+
+“Yes!”
+
+“Perhaps he obtained it as his last and utmost precaution against evil,
+yesterday. When is it dated? But no matter; don’t stay to look; put it
+up carefully with mine and your own. Now, observe! I never doubted until
+within this hour or two, that he had, or could have such a paper. It is
+good, until recalled. But it may be soon recalled, and, I have reason to
+think, will be.”
+
+“They are not in danger?”
+
+“They are in great danger. They are in danger of denunciation by Madame
+Defarge. I know it from her own lips. I have overheard words of that
+woman’s, to-night, which have presented their danger to me in strong
+colours. I have lost no time, and since then, I have seen the spy. He
+confirms me. He knows that a wood-sawyer, living by the prison wall,
+is under the control of the Defarges, and has been rehearsed by
+Madame Defarge as to his having seen Her”--he never mentioned Lucie’s
+name--“making signs and signals to prisoners. It is easy to foresee that
+the pretence will be the common one, a prison plot, and that it will
+involve her life--and perhaps her child’s--and perhaps her father’s--for
+both have been seen with her at that place. Don’t look so horrified. You
+will save them all.”
+
+“Heaven grant I may, Carton! But how?”
+
+“I am going to tell you how. It will depend on you, and it could depend
+on no better man. This new denunciation will certainly not take place
+until after to-morrow; probably not until two or three days afterwards;
+more probably a week afterwards. You know it is a capital crime, to
+mourn for, or sympathise with, a victim of the Guillotine. She and her
+father would unquestionably be guilty of this crime, and this woman (the
+inveteracy of whose pursuit cannot be described) would wait to add that
+strength to her case, and make herself doubly sure. You follow me?”
+
+“So attentively, and with so much confidence in what you say, that for
+the moment I lose sight,” touching the back of the Doctor’s chair, “even
+of this distress.”
+
+“You have money, and can buy the means of travelling to the seacoast
+as quickly as the journey can be made. Your preparations have been
+completed for some days, to return to England. Early to-morrow have your
+horses ready, so that they may be in starting trim at two o’clock in the
+afternoon.”
+
+“It shall be done!”
+
+His manner was so fervent and inspiring, that Mr. Lorry caught the
+flame, and was as quick as youth.
+
+“You are a noble heart. Did I say we could depend upon no better man?
+Tell her, to-night, what you know of her danger as involving her child
+and her father. Dwell upon that, for she would lay her own fair head
+beside her husband’s cheerfully.” He faltered for an instant; then went
+on as before. “For the sake of her child and her father, press upon her
+the necessity of leaving Paris, with them and you, at that hour. Tell
+her that it was her husband’s last arrangement. Tell her that more
+depends upon it than she dare believe, or hope. You think that her
+father, even in this sad state, will submit himself to her; do you not?”
+
+“I am sure of it.”
+
+“I thought so. Quietly and steadily have all these arrangements made in
+the courtyard here, even to the taking of your own seat in the carriage.
+The moment I come to you, take me in, and drive away.”
+
+“I understand that I wait for you under all circumstances?”
+
+“You have my certificate in your hand with the rest, you know, and will
+reserve my place. Wait for nothing but to have my place occupied, and
+then for England!”
+
+“Why, then,” said Mr. Lorry, grasping his eager but so firm and steady
+hand, “it does not all depend on one old man, but I shall have a young
+and ardent man at my side.”
+
+“By the help of Heaven you shall! Promise me solemnly that nothing will
+influence you to alter the course on which we now stand pledged to one
+another.”
+
+“Nothing, Carton.”
+
+“Remember these words to-morrow: change the course, or delay in it--for
+any reason--and no life can possibly be saved, and many lives must
+inevitably be sacrificed.”
+
+“I will remember them. I hope to do my part faithfully.”
+
+“And I hope to do mine. Now, good bye!”
+
+Though he said it with a grave smile of earnestness, and though he even
+put the old man’s hand to his lips, he did not part from him then. He
+helped him so far to arouse the rocking figure before the dying embers,
+as to get a cloak and hat put upon it, and to tempt it forth to find
+where the bench and work were hidden that it still moaningly besought
+to have. He walked on the other side of it and protected it to the
+courtyard of the house where the afflicted heart--so happy in
+the memorable time when he had revealed his own desolate heart to
+it--outwatched the awful night. He entered the courtyard and remained
+there for a few moments alone, looking up at the light in the window of
+her room. Before he went away, he breathed a blessing towards it, and a
+Farewell.
+
+
+
+
+XIII. Fifty-two
+
+
+In the black prison of the Conciergerie, the doomed of the day awaited
+their fate. They were in number as the weeks of the year. Fifty-two were
+to roll that afternoon on the life-tide of the city to the boundless
+everlasting sea. Before their cells were quit of them, new occupants
+were appointed; before their blood ran into the blood spilled yesterday,
+the blood that was to mingle with theirs to-morrow was already set
+apart.
+
+Two score and twelve were told off. From the farmer-general of seventy,
+whose riches could not buy his life, to the seamstress of twenty, whose
+poverty and obscurity could not save her. Physical diseases, engendered
+in the vices and neglects of men, will seize on victims of all degrees;
+and the frightful moral disorder, born of unspeakable suffering,
+intolerable oppression, and heartless indifference, smote equally
+without distinction.
+
+Charles Darnay, alone in a cell, had sustained himself with no
+flattering delusion since he came to it from the Tribunal. In every line
+of the narrative he had heard, he had heard his condemnation. He had
+fully comprehended that no personal influence could possibly save him,
+that he was virtually sentenced by the millions, and that units could
+avail him nothing.
+
+Nevertheless, it was not easy, with the face of his beloved wife fresh
+before him, to compose his mind to what it must bear. His hold on life
+was strong, and it was very, very hard, to loosen; by gradual efforts
+and degrees unclosed a little here, it clenched the tighter there; and
+when he brought his strength to bear on that hand and it yielded,
+this was closed again. There was a hurry, too, in all his thoughts,
+a turbulent and heated working of his heart, that contended against
+resignation. If, for a moment, he did feel resigned, then his wife and
+child who had to live after him, seemed to protest and to make it a
+selfish thing.
+
+But, all this was at first. Before long, the consideration that there
+was no disgrace in the fate he must meet, and that numbers went the same
+road wrongfully, and trod it firmly every day, sprang up to stimulate
+him. Next followed the thought that much of the future peace of mind
+enjoyable by the dear ones, depended on his quiet fortitude. So,
+by degrees he calmed into the better state, when he could raise his
+thoughts much higher, and draw comfort down.
+
+Before it had set in dark on the night of his condemnation, he had
+travelled thus far on his last way. Being allowed to purchase the means
+of writing, and a light, he sat down to write until such time as the
+prison lamps should be extinguished.
+
+He wrote a long letter to Lucie, showing her that he had known nothing
+of her father’s imprisonment, until he had heard of it from herself,
+and that he had been as ignorant as she of his father’s and uncle’s
+responsibility for that misery, until the paper had been read. He had
+already explained to her that his concealment from herself of the name
+he had relinquished, was the one condition--fully intelligible now--that
+her father had attached to their betrothal, and was the one promise he
+had still exacted on the morning of their marriage. He entreated her,
+for her father’s sake, never to seek to know whether her father had
+become oblivious of the existence of the paper, or had had it recalled
+to him (for the moment, or for good), by the story of the Tower, on
+that old Sunday under the dear old plane-tree in the garden. If he had
+preserved any definite remembrance of it, there could be no doubt that
+he had supposed it destroyed with the Bastille, when he had found no
+mention of it among the relics of prisoners which the populace had
+discovered there, and which had been described to all the world. He
+besought her--though he added that he knew it was needless--to console
+her father, by impressing him through every tender means she could think
+of, with the truth that he had done nothing for which he could justly
+reproach himself, but had uniformly forgotten himself for their joint
+sakes. Next to her preservation of his own last grateful love and
+blessing, and her overcoming of her sorrow, to devote herself to their
+dear child, he adjured her, as they would meet in Heaven, to comfort her
+father.
+
+To her father himself, he wrote in the same strain; but, he told her
+father that he expressly confided his wife and child to his care. And
+he told him this, very strongly, with the hope of rousing him from any
+despondency or dangerous retrospect towards which he foresaw he might be
+tending.
+
+To Mr. Lorry, he commended them all, and explained his worldly affairs.
+That done, with many added sentences of grateful friendship and warm
+attachment, all was done. He never thought of Carton. His mind was so
+full of the others, that he never once thought of him.
+
+He had time to finish these letters before the lights were put out. When
+he lay down on his straw bed, he thought he had done with this world.
+
+But, it beckoned him back in his sleep, and showed itself in shining
+forms. Free and happy, back in the old house in Soho (though it had
+nothing in it like the real house), unaccountably released and light of
+heart, he was with Lucie again, and she told him it was all a dream, and
+he had never gone away. A pause of forgetfulness, and then he had even
+suffered, and had come back to her, dead and at peace, and yet there
+was no difference in him. Another pause of oblivion, and he awoke in the
+sombre morning, unconscious where he was or what had happened, until it
+flashed upon his mind, “this is the day of my death!”
+
+Thus, had he come through the hours, to the day when the fifty-two heads
+were to fall. And now, while he was composed, and hoped that he could
+meet the end with quiet heroism, a new action began in his waking
+thoughts, which was very difficult to master.
+
+He had never seen the instrument that was to terminate his life. How
+high it was from the ground, how many steps it had, where he would be
+stood, how he would be touched, whether the touching hands would be dyed
+red, which way his face would be turned, whether he would be the first,
+or might be the last: these and many similar questions, in nowise
+directed by his will, obtruded themselves over and over again, countless
+times. Neither were they connected with fear: he was conscious of no
+fear. Rather, they originated in a strange besetting desire to know what
+to do when the time came; a desire gigantically disproportionate to the
+few swift moments to which it referred; a wondering that was more like
+the wondering of some other spirit within his, than his own.
+
+The hours went on as he walked to and fro, and the clocks struck the
+numbers he would never hear again. Nine gone for ever, ten gone for
+ever, eleven gone for ever, twelve coming on to pass away. After a hard
+contest with that eccentric action of thought which had last perplexed
+him, he had got the better of it. He walked up and down, softly
+repeating their names to himself. The worst of the strife was over.
+He could walk up and down, free from distracting fancies, praying for
+himself and for them.
+
+Twelve gone for ever.
+
+He had been apprised that the final hour was Three, and he knew he would
+be summoned some time earlier, inasmuch as the tumbrils jolted heavily
+and slowly through the streets. Therefore, he resolved to keep Two
+before his mind, as the hour, and so to strengthen himself in the
+interval that he might be able, after that time, to strengthen others.
+
+Walking regularly to and fro with his arms folded on his breast, a very
+different man from the prisoner, who had walked to and fro at La Force,
+he heard One struck away from him, without surprise. The hour had
+measured like most other hours. Devoutly thankful to Heaven for his
+recovered self-possession, he thought, “There is but another now,” and
+turned to walk again.
+
+Footsteps in the stone passage outside the door. He stopped.
+
+The key was put in the lock, and turned. Before the door was opened, or
+as it opened, a man said in a low voice, in English: “He has never seen
+me here; I have kept out of his way. Go you in alone; I wait near. Lose
+no time!”
+
+The door was quickly opened and closed, and there stood before him
+face to face, quiet, intent upon him, with the light of a smile on his
+features, and a cautionary finger on his lip, Sydney Carton.
+
+There was something so bright and remarkable in his look, that, for the
+first moment, the prisoner misdoubted him to be an apparition of his own
+imagining. But, he spoke, and it was his voice; he took the prisoner’s
+hand, and it was his real grasp.
+
+“Of all the people upon earth, you least expected to see me?” he said.
+
+“I could not believe it to be you. I can scarcely believe it now. You
+are not”--the apprehension came suddenly into his mind--“a prisoner?”
+
+“No. I am accidentally possessed of a power over one of the keepers
+here, and in virtue of it I stand before you. I come from her--your
+wife, dear Darnay.”
+
+The prisoner wrung his hand.
+
+“I bring you a request from her.”
+
+“What is it?”
+
+“A most earnest, pressing, and emphatic entreaty, addressed to you
+in the most pathetic tones of the voice so dear to you, that you well
+remember.”
+
+The prisoner turned his face partly aside.
+
+“You have no time to ask me why I bring it, or what it means; I have
+no time to tell you. You must comply with it--take off those boots you
+wear, and draw on these of mine.”
+
+There was a chair against the wall of the cell, behind the prisoner.
+Carton, pressing forward, had already, with the speed of lightning, got
+him down into it, and stood over him, barefoot.
+
+“Draw on these boots of mine. Put your hands to them; put your will to
+them. Quick!”
+
+“Carton, there is no escaping from this place; it never can be done. You
+will only die with me. It is madness.”
+
+“It would be madness if I asked you to escape; but do I? When I ask you
+to pass out at that door, tell me it is madness and remain here. Change
+that cravat for this of mine, that coat for this of mine. While you do
+it, let me take this ribbon from your hair, and shake out your hair like
+this of mine!”
+
+With wonderful quickness, and with a strength both of will and action,
+that appeared quite supernatural, he forced all these changes upon him.
+The prisoner was like a young child in his hands.
+
+“Carton! Dear Carton! It is madness. It cannot be accomplished, it never
+can be done, it has been attempted, and has always failed. I implore you
+not to add your death to the bitterness of mine.”
+
+“Do I ask you, my dear Darnay, to pass the door? When I ask that,
+refuse. There are pen and ink and paper on this table. Is your hand
+steady enough to write?”
+
+“It was when you came in.”
+
+“Steady it again, and write what I shall dictate. Quick, friend, quick!”
+
+Pressing his hand to his bewildered head, Darnay sat down at the table.
+Carton, with his right hand in his breast, stood close beside him.
+
+“Write exactly as I speak.”
+
+“To whom do I address it?”
+
+“To no one.” Carton still had his hand in his breast.
+
+“Do I date it?”
+
+“No.”
+
+The prisoner looked up, at each question. Carton, standing over him with
+his hand in his breast, looked down.
+
+“‘If you remember,’” said Carton, dictating, “‘the words that passed
+between us, long ago, you will readily comprehend this when you see it.
+You do remember them, I know. It is not in your nature to forget them.’”
+
+He was drawing his hand from his breast; the prisoner chancing to look
+up in his hurried wonder as he wrote, the hand stopped, closing upon
+something.
+
+“Have you written ‘forget them’?” Carton asked.
+
+“I have. Is that a weapon in your hand?”
+
+“No; I am not armed.”
+
+“What is it in your hand?”
+
+“You shall know directly. Write on; there are but a few words more.” He
+dictated again. “‘I am thankful that the time has come, when I can prove
+them. That I do so is no subject for regret or grief.’” As he said these
+words with his eyes fixed on the writer, his hand slowly and softly
+moved down close to the writer’s face.
+
+The pen dropped from Darnay’s fingers on the table, and he looked about
+him vacantly.
+
+“What vapour is that?” he asked.
+
+“Vapour?”
+
+“Something that crossed me?”
+
+“I am conscious of nothing; there can be nothing here. Take up the pen
+and finish. Hurry, hurry!”
+
+As if his memory were impaired, or his faculties disordered, the
+prisoner made an effort to rally his attention. As he looked at Carton
+with clouded eyes and with an altered manner of breathing, Carton--his
+hand again in his breast--looked steadily at him.
+
+“Hurry, hurry!”
+
+The prisoner bent over the paper, once more.
+
+“‘If it had been otherwise;’” Carton’s hand was again watchfully and
+softly stealing down; “‘I never should have used the longer opportunity.
+If it had been otherwise;’” the hand was at the prisoner’s face; “‘I
+should but have had so much the more to answer for. If it had been
+otherwise--’” Carton looked at the pen and saw it was trailing off into
+unintelligible signs.
+
+Carton’s hand moved back to his breast no more. The prisoner sprang up
+with a reproachful look, but Carton’s hand was close and firm at his
+nostrils, and Carton’s left arm caught him round the waist. For a few
+seconds he faintly struggled with the man who had come to lay down his
+life for him; but, within a minute or so, he was stretched insensible on
+the ground.
+
+Quickly, but with hands as true to the purpose as his heart was, Carton
+dressed himself in the clothes the prisoner had laid aside, combed back
+his hair, and tied it with the ribbon the prisoner had worn. Then, he
+softly called, “Enter there! Come in!” and the Spy presented himself.
+
+“You see?” said Carton, looking up, as he kneeled on one knee beside the
+insensible figure, putting the paper in the breast: “is your hazard very
+great?”
+
+“Mr. Carton,” the Spy answered, with a timid snap of his fingers, “my
+hazard is not _that_, in the thick of business here, if you are true to
+the whole of your bargain.”
+
+“Don’t fear me. I will be true to the death.”
+
+“You must be, Mr. Carton, if the tale of fifty-two is to be right. Being
+made right by you in that dress, I shall have no fear.”
+
+“Have no fear! I shall soon be out of the way of harming you, and the
+rest will soon be far from here, please God! Now, get assistance and
+take me to the coach.”
+
+“You?” said the Spy nervously.
+
+“Him, man, with whom I have exchanged. You go out at the gate by which
+you brought me in?”
+
+“Of course.”
+
+“I was weak and faint when you brought me in, and I am fainter now you
+take me out. The parting interview has overpowered me. Such a thing has
+happened here, often, and too often. Your life is in your own hands.
+Quick! Call assistance!”
+
+“You swear not to betray me?” said the trembling Spy, as he paused for a
+last moment.
+
+“Man, man!” returned Carton, stamping his foot; “have I sworn by no
+solemn vow already, to go through with this, that you waste the precious
+moments now? Take him yourself to the courtyard you know of, place
+him yourself in the carriage, show him yourself to Mr. Lorry, tell him
+yourself to give him no restorative but air, and to remember my words of
+last night, and his promise of last night, and drive away!”
+
+The Spy withdrew, and Carton seated himself at the table, resting his
+forehead on his hands. The Spy returned immediately, with two men.
+
+“How, then?” said one of them, contemplating the fallen figure. “So
+afflicted to find that his friend has drawn a prize in the lottery of
+Sainte Guillotine?”
+
+“A good patriot,” said the other, “could hardly have been more afflicted
+if the Aristocrat had drawn a blank.”
+
+They raised the unconscious figure, placed it on a litter they had
+brought to the door, and bent to carry it away.
+
+“The time is short, Evremonde,” said the Spy, in a warning voice.
+
+“I know it well,” answered Carton. “Be careful of my friend, I entreat
+you, and leave me.”
+
+“Come, then, my children,” said Barsad. “Lift him, and come away!”
+
+The door closed, and Carton was left alone. Straining his powers of
+listening to the utmost, he listened for any sound that might denote
+suspicion or alarm. There was none. Keys turned, doors clashed,
+footsteps passed along distant passages: no cry was raised, or hurry
+made, that seemed unusual. Breathing more freely in a little while, he
+sat down at the table, and listened again until the clock struck Two.
+
+Sounds that he was not afraid of, for he divined their meaning, then
+began to be audible. Several doors were opened in succession, and
+finally his own. A gaoler, with a list in his hand, looked in, merely
+saying, “Follow me, Evremonde!” and he followed into a large dark room,
+at a distance. It was a dark winter day, and what with the shadows
+within, and what with the shadows without, he could but dimly discern
+the others who were brought there to have their arms bound. Some were
+standing; some seated. Some were lamenting, and in restless motion;
+but, these were few. The great majority were silent and still, looking
+fixedly at the ground.
+
+As he stood by the wall in a dim corner, while some of the fifty-two
+were brought in after him, one man stopped in passing, to embrace him,
+as having a knowledge of him. It thrilled him with a great dread of
+discovery; but the man went on. A very few moments after that, a young
+woman, with a slight girlish form, a sweet spare face in which there was
+no vestige of colour, and large widely opened patient eyes, rose from
+the seat where he had observed her sitting, and came to speak to him.
+
+“Citizen Evremonde,” she said, touching him with her cold hand. “I am a
+poor little seamstress, who was with you in La Force.”
+
+He murmured for answer: “True. I forget what you were accused of?”
+
+“Plots. Though the just Heaven knows that I am innocent of any. Is it
+likely? Who would think of plotting with a poor little weak creature
+like me?”
+
+The forlorn smile with which she said it, so touched him, that tears
+started from his eyes.
+
+“I am not afraid to die, Citizen Evremonde, but I have done nothing. I
+am not unwilling to die, if the Republic which is to do so much good
+to us poor, will profit by my death; but I do not know how that can be,
+Citizen Evremonde. Such a poor weak little creature!”
+
+As the last thing on earth that his heart was to warm and soften to, it
+warmed and softened to this pitiable girl.
+
+“I heard you were released, Citizen Evremonde. I hoped it was true?”
+
+“It was. But, I was again taken and condemned.”
+
+“If I may ride with you, Citizen Evremonde, will you let me hold your
+hand? I am not afraid, but I am little and weak, and it will give me
+more courage.”
+
+As the patient eyes were lifted to his face, he saw a sudden doubt in
+them, and then astonishment. He pressed the work-worn, hunger-worn young
+fingers, and touched his lips.
+
+“Are you dying for him?” she whispered.
+
+“And his wife and child. Hush! Yes.”
+
+“O you will let me hold your brave hand, stranger?”
+
+“Hush! Yes, my poor sister; to the last.”
+
+        *****
+
+The same shadows that are falling on the prison, are falling, in that
+same hour of the early afternoon, on the Barrier with the crowd about
+it, when a coach going out of Paris drives up to be examined.
+
+“Who goes here? Whom have we within? Papers!”
+
+The papers are handed out, and read.
+
+“Alexandre Manette. Physician. French. Which is he?”
+
+This is he; this helpless, inarticulately murmuring, wandering old man
+pointed out.
+
+“Apparently the Citizen-Doctor is not in his right mind? The
+Revolution-fever will have been too much for him?”
+
+Greatly too much for him.
+
+“Hah! Many suffer with it. Lucie. His daughter. French. Which is she?”
+
+This is she.
+
+“Apparently it must be. Lucie, the wife of Evremonde; is it not?”
+
+It is.
+
+“Hah! Evremonde has an assignation elsewhere. Lucie, her child. English.
+This is she?”
+
+She and no other.
+
+“Kiss me, child of Evremonde. Now, thou hast kissed a good Republican;
+something new in thy family; remember it! Sydney Carton. Advocate.
+English. Which is he?”
+
+He lies here, in this corner of the carriage. He, too, is pointed out.
+
+“Apparently the English advocate is in a swoon?”
+
+It is hoped he will recover in the fresher air. It is represented that
+he is not in strong health, and has separated sadly from a friend who is
+under the displeasure of the Republic.
+
+“Is that all? It is not a great deal, that! Many are under the
+displeasure of the Republic, and must look out at the little window.
+Jarvis Lorry. Banker. English. Which is he?”
+
+“I am he. Necessarily, being the last.”
+
+It is Jarvis Lorry who has replied to all the previous questions. It
+is Jarvis Lorry who has alighted and stands with his hand on the coach
+door, replying to a group of officials. They leisurely walk round the
+carriage and leisurely mount the box, to look at what little luggage it
+carries on the roof; the country-people hanging about, press nearer to
+the coach doors and greedily stare in; a little child, carried by its
+mother, has its short arm held out for it, that it may touch the wife of
+an aristocrat who has gone to the Guillotine.
+
+“Behold your papers, Jarvis Lorry, countersigned.”
+
+“One can depart, citizen?”
+
+“One can depart. Forward, my postilions! A good journey!”
+
+“I salute you, citizens.--And the first danger passed!”
+
+These are again the words of Jarvis Lorry, as he clasps his hands, and
+looks upward. There is terror in the carriage, there is weeping, there
+is the heavy breathing of the insensible traveller.
+
+“Are we not going too slowly? Can they not be induced to go faster?”
+ asks Lucie, clinging to the old man.
+
+“It would seem like flight, my darling. I must not urge them too much;
+it would rouse suspicion.”
+
+“Look back, look back, and see if we are pursued!”
+
+“The road is clear, my dearest. So far, we are not pursued.”
+
+Houses in twos and threes pass by us, solitary farms, ruinous buildings,
+dye-works, tanneries, and the like, open country, avenues of leafless
+trees. The hard uneven pavement is under us, the soft deep mud is on
+either side. Sometimes, we strike into the skirting mud, to avoid the
+stones that clatter us and shake us; sometimes, we stick in ruts and
+sloughs there. The agony of our impatience is then so great, that in our
+wild alarm and hurry we are for getting out and running--hiding--doing
+anything but stopping.
+
+Out of the open country, in again among ruinous buildings, solitary
+farms, dye-works, tanneries, and the like, cottages in twos and threes,
+avenues of leafless trees. Have these men deceived us, and taken us back
+by another road? Is not this the same place twice over? Thank Heaven,
+no. A village. Look back, look back, and see if we are pursued! Hush!
+the posting-house.
+
+Leisurely, our four horses are taken out; leisurely, the coach stands in
+the little street, bereft of horses, and with no likelihood upon it
+of ever moving again; leisurely, the new horses come into visible
+existence, one by one; leisurely, the new postilions follow, sucking and
+plaiting the lashes of their whips; leisurely, the old postilions count
+their money, make wrong additions, and arrive at dissatisfied results.
+All the time, our overfraught hearts are beating at a rate that would
+far outstrip the fastest gallop of the fastest horses ever foaled.
+
+At length the new postilions are in their saddles, and the old are left
+behind. We are through the village, up the hill, and down the hill, and
+on the low watery grounds. Suddenly, the postilions exchange speech with
+animated gesticulation, and the horses are pulled up, almost on their
+haunches. We are pursued?
+
+“Ho! Within the carriage there. Speak then!”
+
+“What is it?” asks Mr. Lorry, looking out at window.
+
+“How many did they say?”
+
+“I do not understand you.”
+
+“--At the last post. How many to the Guillotine to-day?”
+
+“Fifty-two.”
+
+“I said so! A brave number! My fellow-citizen here would have it
+forty-two; ten more heads are worth having. The Guillotine goes
+handsomely. I love it. Hi forward. Whoop!”
+
+The night comes on dark. He moves more; he is beginning to revive, and
+to speak intelligibly; he thinks they are still together; he asks him,
+by his name, what he has in his hand. O pity us, kind Heaven, and help
+us! Look out, look out, and see if we are pursued.
+
+The wind is rushing after us, and the clouds are flying after us, and
+the moon is plunging after us, and the whole wild night is in pursuit of
+us; but, so far, we are pursued by nothing else.
+
+
+
+
+XIV. The Knitting Done
+
+
+In that same juncture of time when the Fifty-Two awaited their fate
+Madame Defarge held darkly ominous council with The Vengeance and
+Jacques Three of the Revolutionary Jury. Not in the wine-shop did Madame
+Defarge confer with these ministers, but in the shed of the wood-sawyer,
+erst a mender of roads. The sawyer himself did not participate in the
+conference, but abided at a little distance, like an outer satellite who
+was not to speak until required, or to offer an opinion until invited.
+
+“But our Defarge,” said Jacques Three, “is undoubtedly a good
+Republican? Eh?”
+
+“There is no better,” the voluble Vengeance protested in her shrill
+notes, “in France.”
+
+“Peace, little Vengeance,” said Madame Defarge, laying her hand with
+a slight frown on her lieutenant’s lips, “hear me speak. My husband,
+fellow-citizen, is a good Republican and a bold man; he has deserved
+well of the Republic, and possesses its confidence. But my husband has
+his weaknesses, and he is so weak as to relent towards this Doctor.”
+
+“It is a great pity,” croaked Jacques Three, dubiously shaking his head,
+with his cruel fingers at his hungry mouth; “it is not quite like a good
+citizen; it is a thing to regret.”
+
+“See you,” said madame, “I care nothing for this Doctor, I. He may wear
+his head or lose it, for any interest I have in him; it is all one to
+me. But, the Evremonde people are to be exterminated, and the wife and
+child must follow the husband and father.”
+
+“She has a fine head for it,” croaked Jacques Three. “I have seen blue
+eyes and golden hair there, and they looked charming when Samson held
+them up.” Ogre that he was, he spoke like an epicure.
+
+Madame Defarge cast down her eyes, and reflected a little.
+
+“The child also,” observed Jacques Three, with a meditative enjoyment
+of his words, “has golden hair and blue eyes. And we seldom have a child
+there. It is a pretty sight!”
+
+“In a word,” said Madame Defarge, coming out of her short abstraction,
+“I cannot trust my husband in this matter. Not only do I feel, since
+last night, that I dare not confide to him the details of my projects;
+but also I feel that if I delay, there is danger of his giving warning,
+and then they might escape.”
+
+“That must never be,” croaked Jacques Three; “no one must escape. We
+have not half enough as it is. We ought to have six score a day.”
+
+“In a word,” Madame Defarge went on, “my husband has not my reason for
+pursuing this family to annihilation, and I have not his reason for
+regarding this Doctor with any sensibility. I must act for myself,
+therefore. Come hither, little citizen.”
+
+The wood-sawyer, who held her in the respect, and himself in the
+submission, of mortal fear, advanced with his hand to his red cap.
+
+“Touching those signals, little citizen,” said Madame Defarge, sternly,
+“that she made to the prisoners; you are ready to bear witness to them
+this very day?”
+
+“Ay, ay, why not!” cried the sawyer. “Every day, in all weathers, from
+two to four, always signalling, sometimes with the little one, sometimes
+without. I know what I know. I have seen with my eyes.”
+
+He made all manner of gestures while he spoke, as if in incidental
+imitation of some few of the great diversity of signals that he had
+never seen.
+
+“Clearly plots,” said Jacques Three. “Transparently!”
+
+“There is no doubt of the Jury?” inquired Madame Defarge, letting her
+eyes turn to him with a gloomy smile.
+
+“Rely upon the patriotic Jury, dear citizeness. I answer for my
+fellow-Jurymen.”
+
+“Now, let me see,” said Madame Defarge, pondering again. “Yet once more!
+Can I spare this Doctor to my husband? I have no feeling either way. Can
+I spare him?”
+
+“He would count as one head,” observed Jacques Three, in a low voice.
+“We really have not heads enough; it would be a pity, I think.”
+
+“He was signalling with her when I saw her,” argued Madame Defarge; “I
+cannot speak of one without the other; and I must not be silent, and
+trust the case wholly to him, this little citizen here. For, I am not a
+bad witness.”
+
+The Vengeance and Jacques Three vied with each other in their fervent
+protestations that she was the most admirable and marvellous of
+witnesses. The little citizen, not to be outdone, declared her to be a
+celestial witness.
+
+“He must take his chance,” said Madame Defarge. “No, I cannot spare
+him! You are engaged at three o’clock; you are going to see the batch of
+to-day executed.--You?”
+
+The question was addressed to the wood-sawyer, who hurriedly replied in
+the affirmative: seizing the occasion to add that he was the most ardent
+of Republicans, and that he would be in effect the most desolate of
+Republicans, if anything prevented him from enjoying the pleasure of
+smoking his afternoon pipe in the contemplation of the droll national
+barber. He was so very demonstrative herein, that he might have been
+suspected (perhaps was, by the dark eyes that looked contemptuously at
+him out of Madame Defarge’s head) of having his small individual fears
+for his own personal safety, every hour in the day.
+
+“I,” said madame, “am equally engaged at the same place. After it is
+over--say at eight to-night--come you to me, in Saint Antoine, and we
+will give information against these people at my Section.”
+
+The wood-sawyer said he would be proud and flattered to attend the
+citizeness. The citizeness looking at him, he became embarrassed, evaded
+her glance as a small dog would have done, retreated among his wood, and
+hid his confusion over the handle of his saw.
+
+Madame Defarge beckoned the Juryman and The Vengeance a little nearer to
+the door, and there expounded her further views to them thus:
+
+“She will now be at home, awaiting the moment of his death. She will
+be mourning and grieving. She will be in a state of mind to impeach the
+justice of the Republic. She will be full of sympathy with its enemies.
+I will go to her.”
+
+“What an admirable woman; what an adorable woman!” exclaimed Jacques
+Three, rapturously. “Ah, my cherished!” cried The Vengeance; and
+embraced her.
+
+“Take you my knitting,” said Madame Defarge, placing it in her
+lieutenant’s hands, “and have it ready for me in my usual seat. Keep
+me my usual chair. Go you there, straight, for there will probably be a
+greater concourse than usual, to-day.”
+
+“I willingly obey the orders of my Chief,” said The Vengeance with
+alacrity, and kissing her cheek. “You will not be late?”
+
+“I shall be there before the commencement.”
+
+“And before the tumbrils arrive. Be sure you are there, my soul,” said
+The Vengeance, calling after her, for she had already turned into the
+street, “before the tumbrils arrive!”
+
+Madame Defarge slightly waved her hand, to imply that she heard, and
+might be relied upon to arrive in good time, and so went through the
+mud, and round the corner of the prison wall. The Vengeance and the
+Juryman, looking after her as she walked away, were highly appreciative
+of her fine figure, and her superb moral endowments.
+
+There were many women at that time, upon whom the time laid a dreadfully
+disfiguring hand; but, there was not one among them more to be dreaded
+than this ruthless woman, now taking her way along the streets. Of a
+strong and fearless character, of shrewd sense and readiness, of great
+determination, of that kind of beauty which not only seems to impart
+to its possessor firmness and animosity, but to strike into others an
+instinctive recognition of those qualities; the troubled time would have
+heaved her up, under any circumstances. But, imbued from her childhood
+with a brooding sense of wrong, and an inveterate hatred of a class,
+opportunity had developed her into a tigress. She was absolutely without
+pity. If she had ever had the virtue in her, it had quite gone out of
+her.
+
+It was nothing to her, that an innocent man was to die for the sins of
+his forefathers; she saw, not him, but them. It was nothing to her, that
+his wife was to be made a widow and his daughter an orphan; that was
+insufficient punishment, because they were her natural enemies and
+her prey, and as such had no right to live. To appeal to her, was made
+hopeless by her having no sense of pity, even for herself. If she had
+been laid low in the streets, in any of the many encounters in which
+she had been engaged, she would not have pitied herself; nor, if she had
+been ordered to the axe to-morrow, would she have gone to it with any
+softer feeling than a fierce desire to change places with the man who
+sent her there.
+
+Such a heart Madame Defarge carried under her rough robe. Carelessly
+worn, it was a becoming robe enough, in a certain weird way, and her
+dark hair looked rich under her coarse red cap. Lying hidden in her
+bosom, was a loaded pistol. Lying hidden at her waist, was a sharpened
+dagger. Thus accoutred, and walking with the confident tread of such
+a character, and with the supple freedom of a woman who had habitually
+walked in her girlhood, bare-foot and bare-legged, on the brown
+sea-sand, Madame Defarge took her way along the streets.
+
+Now, when the journey of the travelling coach, at that very moment
+waiting for the completion of its load, had been planned out last night,
+the difficulty of taking Miss Pross in it had much engaged Mr. Lorry’s
+attention. It was not merely desirable to avoid overloading the coach,
+but it was of the highest importance that the time occupied in examining
+it and its passengers, should be reduced to the utmost; since their
+escape might depend on the saving of only a few seconds here and there.
+Finally, he had proposed, after anxious consideration, that Miss Pross
+and Jerry, who were at liberty to leave the city, should leave it at
+three o’clock in the lightest-wheeled conveyance known to that period.
+Unencumbered with luggage, they would soon overtake the coach, and,
+passing it and preceding it on the road, would order its horses in
+advance, and greatly facilitate its progress during the precious hours
+of the night, when delay was the most to be dreaded.
+
+Seeing in this arrangement the hope of rendering real service in that
+pressing emergency, Miss Pross hailed it with joy. She and Jerry had
+beheld the coach start, had known who it was that Solomon brought, had
+passed some ten minutes in tortures of suspense, and were now concluding
+their arrangements to follow the coach, even as Madame Defarge,
+taking her way through the streets, now drew nearer and nearer to the
+else-deserted lodging in which they held their consultation.
+
+“Now what do you think, Mr. Cruncher,” said Miss Pross, whose agitation
+was so great that she could hardly speak, or stand, or move, or live:
+“what do you think of our not starting from this courtyard? Another
+carriage having already gone from here to-day, it might awaken
+suspicion.”
+
+“My opinion, miss,” returned Mr. Cruncher, “is as you’re right. Likewise
+wot I’ll stand by you, right or wrong.”
+
+“I am so distracted with fear and hope for our precious creatures,” said
+Miss Pross, wildly crying, “that I am incapable of forming any plan. Are
+_you_ capable of forming any plan, my dear good Mr. Cruncher?”
+
+“Respectin’ a future spear o’ life, miss,” returned Mr. Cruncher, “I
+hope so. Respectin’ any present use o’ this here blessed old head o’
+mine, I think not. Would you do me the favour, miss, to take notice o’
+two promises and wows wot it is my wishes fur to record in this here
+crisis?”
+
+“Oh, for gracious sake!” cried Miss Pross, still wildly crying, “record
+them at once, and get them out of the way, like an excellent man.”
+
+“First,” said Mr. Cruncher, who was all in a tremble, and who spoke with
+an ashy and solemn visage, “them poor things well out o’ this, never no
+more will I do it, never no more!”
+
+“I am quite sure, Mr. Cruncher,” returned Miss Pross, “that you
+never will do it again, whatever it is, and I beg you not to think it
+necessary to mention more particularly what it is.”
+
+“No, miss,” returned Jerry, “it shall not be named to you. Second: them
+poor things well out o’ this, and never no more will I interfere with
+Mrs. Cruncher’s flopping, never no more!”
+
+“Whatever housekeeping arrangement that may be,” said Miss Pross,
+striving to dry her eyes and compose herself, “I have no doubt it
+is best that Mrs. Cruncher should have it entirely under her own
+superintendence.--O my poor darlings!”
+
+“I go so far as to say, miss, moreover,” proceeded Mr. Cruncher, with a
+most alarming tendency to hold forth as from a pulpit--“and let my words
+be took down and took to Mrs. Cruncher through yourself--that wot my
+opinions respectin’ flopping has undergone a change, and that wot I only
+hope with all my heart as Mrs. Cruncher may be a flopping at the present
+time.”
+
+“There, there, there! I hope she is, my dear man,” cried the distracted
+Miss Pross, “and I hope she finds it answering her expectations.”
+
+“Forbid it,” proceeded Mr. Cruncher, with additional solemnity,
+additional slowness, and additional tendency to hold forth and hold
+out, “as anything wot I have ever said or done should be wisited on my
+earnest wishes for them poor creeturs now! Forbid it as we shouldn’t all
+flop (if it was anyways conwenient) to get ‘em out o’ this here dismal
+risk! Forbid it, miss! Wot I say, for-_bid_ it!” This was Mr. Cruncher’s
+conclusion after a protracted but vain endeavour to find a better one.
+
+And still Madame Defarge, pursuing her way along the streets, came
+nearer and nearer.
+
+“If we ever get back to our native land,” said Miss Pross, “you may rely
+upon my telling Mrs. Cruncher as much as I may be able to remember and
+understand of what you have so impressively said; and at all events
+you may be sure that I shall bear witness to your being thoroughly in
+earnest at this dreadful time. Now, pray let us think! My esteemed Mr.
+Cruncher, let us think!”
+
+Still, Madame Defarge, pursuing her way along the streets, came nearer
+and nearer.
+
+“If you were to go before,” said Miss Pross, “and stop the vehicle and
+horses from coming here, and were to wait somewhere for me; wouldn’t
+that be best?”
+
+Mr. Cruncher thought it might be best.
+
+“Where could you wait for me?” asked Miss Pross.
+
+Mr. Cruncher was so bewildered that he could think of no locality but
+Temple Bar. Alas! Temple Bar was hundreds of miles away, and Madame
+Defarge was drawing very near indeed.
+
+“By the cathedral door,” said Miss Pross. “Would it be much out of
+the way, to take me in, near the great cathedral door between the two
+towers?”
+
+“No, miss,” answered Mr. Cruncher.
+
+“Then, like the best of men,” said Miss Pross, “go to the posting-house
+straight, and make that change.”
+
+“I am doubtful,” said Mr. Cruncher, hesitating and shaking his head,
+“about leaving of you, you see. We don’t know what may happen.”
+
+“Heaven knows we don’t,” returned Miss Pross, “but have no fear for me.
+Take me in at the cathedral, at Three o’Clock, or as near it as you can,
+and I am sure it will be better than our going from here. I feel certain
+of it. There! Bless you, Mr. Cruncher! Think-not of me, but of the lives
+that may depend on both of us!”
+
+This exordium, and Miss Pross’s two hands in quite agonised entreaty
+clasping his, decided Mr. Cruncher. With an encouraging nod or two, he
+immediately went out to alter the arrangements, and left her by herself
+to follow as she had proposed.
+
+The having originated a precaution which was already in course of
+execution, was a great relief to Miss Pross. The necessity of composing
+her appearance so that it should attract no special notice in the
+streets, was another relief. She looked at her watch, and it was twenty
+minutes past two. She had no time to lose, but must get ready at once.
+
+Afraid, in her extreme perturbation, of the loneliness of the deserted
+rooms, and of half-imagined faces peeping from behind every open door
+in them, Miss Pross got a basin of cold water and began laving her eyes,
+which were swollen and red. Haunted by her feverish apprehensions, she
+could not bear to have her sight obscured for a minute at a time by the
+dripping water, but constantly paused and looked round to see that there
+was no one watching her. In one of those pauses she recoiled and cried
+out, for she saw a figure standing in the room.
+
+The basin fell to the ground broken, and the water flowed to the feet of
+Madame Defarge. By strange stern ways, and through much staining blood,
+those feet had come to meet that water.
+
+Madame Defarge looked coldly at her, and said, “The wife of Evremonde;
+where is she?”
+
+It flashed upon Miss Pross’s mind that the doors were all standing open,
+and would suggest the flight. Her first act was to shut them. There were
+four in the room, and she shut them all. She then placed herself before
+the door of the chamber which Lucie had occupied.
+
+Madame Defarge’s dark eyes followed her through this rapid movement,
+and rested on her when it was finished. Miss Pross had nothing beautiful
+about her; years had not tamed the wildness, or softened the grimness,
+of her appearance; but, she too was a determined woman in her different
+way, and she measured Madame Defarge with her eyes, every inch.
+
+“You might, from your appearance, be the wife of Lucifer,” said Miss
+Pross, in her breathing. “Nevertheless, you shall not get the better of
+me. I am an Englishwoman.”
+
+Madame Defarge looked at her scornfully, but still with something of
+Miss Pross’s own perception that they two were at bay. She saw a tight,
+hard, wiry woman before her, as Mr. Lorry had seen in the same figure a
+woman with a strong hand, in the years gone by. She knew full well that
+Miss Pross was the family’s devoted friend; Miss Pross knew full well
+that Madame Defarge was the family’s malevolent enemy.
+
+“On my way yonder,” said Madame Defarge, with a slight movement of
+her hand towards the fatal spot, “where they reserve my chair and my
+knitting for me, I am come to make my compliments to her in passing. I
+wish to see her.”
+
+“I know that your intentions are evil,” said Miss Pross, “and you may
+depend upon it, I’ll hold my own against them.”
+
+Each spoke in her own language; neither understood the other’s words;
+both were very watchful, and intent to deduce from look and manner, what
+the unintelligible words meant.
+
+“It will do her no good to keep herself concealed from me at this
+moment,” said Madame Defarge. “Good patriots will know what that means.
+Let me see her. Go tell her that I wish to see her. Do you hear?”
+
+“If those eyes of yours were bed-winches,” returned Miss Pross, “and I
+was an English four-poster, they shouldn’t loose a splinter of me. No,
+you wicked foreign woman; I am your match.”
+
+Madame Defarge was not likely to follow these idiomatic remarks in
+detail; but, she so far understood them as to perceive that she was set
+at naught.
+
+“Woman imbecile and pig-like!” said Madame Defarge, frowning. “I take no
+answer from you. I demand to see her. Either tell her that I demand
+to see her, or stand out of the way of the door and let me go to her!”
+ This, with an angry explanatory wave of her right arm.
+
+“I little thought,” said Miss Pross, “that I should ever want to
+understand your nonsensical language; but I would give all I have,
+except the clothes I wear, to know whether you suspect the truth, or any
+part of it.”
+
+Neither of them for a single moment released the other’s eyes. Madame
+Defarge had not moved from the spot where she stood when Miss Pross
+first became aware of her; but, she now advanced one step.
+
+“I am a Briton,” said Miss Pross, “I am desperate. I don’t care an
+English Twopence for myself. I know that the longer I keep you here, the
+greater hope there is for my Ladybird. I’ll not leave a handful of that
+dark hair upon your head, if you lay a finger on me!”
+
+Thus Miss Pross, with a shake of her head and a flash of her eyes
+between every rapid sentence, and every rapid sentence a whole breath.
+Thus Miss Pross, who had never struck a blow in her life.
+
+But, her courage was of that emotional nature that it brought the
+irrepressible tears into her eyes. This was a courage that Madame
+Defarge so little comprehended as to mistake for weakness. “Ha, ha!” she
+laughed, “you poor wretch! What are you worth! I address myself to that
+Doctor.” Then she raised her voice and called out, “Citizen Doctor! Wife
+of Evremonde! Child of Evremonde! Any person but this miserable fool,
+answer the Citizeness Defarge!”
+
+Perhaps the following silence, perhaps some latent disclosure in the
+expression of Miss Pross’s face, perhaps a sudden misgiving apart from
+either suggestion, whispered to Madame Defarge that they were gone.
+Three of the doors she opened swiftly, and looked in.
+
+“Those rooms are all in disorder, there has been hurried packing, there
+are odds and ends upon the ground. There is no one in that room behind
+you! Let me look.”
+
+“Never!” said Miss Pross, who understood the request as perfectly as
+Madame Defarge understood the answer.
+
+“If they are not in that room, they are gone, and can be pursued and
+brought back,” said Madame Defarge to herself.
+
+“As long as you don’t know whether they are in that room or not, you are
+uncertain what to do,” said Miss Pross to herself; “and you shall not
+know that, if I can prevent your knowing it; and know that, or not know
+that, you shall not leave here while I can hold you.”
+
+“I have been in the streets from the first, nothing has stopped me,
+I will tear you to pieces, but I will have you from that door,” said
+Madame Defarge.
+
+“We are alone at the top of a high house in a solitary courtyard, we are
+not likely to be heard, and I pray for bodily strength to keep you here,
+while every minute you are here is worth a hundred thousand guineas to
+my darling,” said Miss Pross.
+
+Madame Defarge made at the door. Miss Pross, on the instinct of the
+moment, seized her round the waist in both her arms, and held her tight.
+It was in vain for Madame Defarge to struggle and to strike; Miss Pross,
+with the vigorous tenacity of love, always so much stronger than hate,
+clasped her tight, and even lifted her from the floor in the struggle
+that they had. The two hands of Madame Defarge buffeted and tore her
+face; but, Miss Pross, with her head down, held her round the waist, and
+clung to her with more than the hold of a drowning woman.
+
+Soon, Madame Defarge’s hands ceased to strike, and felt at her encircled
+waist. “It is under my arm,” said Miss Pross, in smothered tones, “you
+shall not draw it. I am stronger than you, I bless Heaven for it. I hold
+you till one or other of us faints or dies!”
+
+Madame Defarge’s hands were at her bosom. Miss Pross looked up, saw
+what it was, struck at it, struck out a flash and a crash, and stood
+alone--blinded with smoke.
+
+All this was in a second. As the smoke cleared, leaving an awful
+stillness, it passed out on the air, like the soul of the furious woman
+whose body lay lifeless on the ground.
+
+In the first fright and horror of her situation, Miss Pross passed the
+body as far from it as she could, and ran down the stairs to call for
+fruitless help. Happily, she bethought herself of the consequences of
+what she did, in time to check herself and go back. It was dreadful to
+go in at the door again; but, she did go in, and even went near it, to
+get the bonnet and other things that she must wear. These she put on,
+out on the staircase, first shutting and locking the door and taking
+away the key. She then sat down on the stairs a few moments to breathe
+and to cry, and then got up and hurried away.
+
+By good fortune she had a veil on her bonnet, or she could hardly have
+gone along the streets without being stopped. By good fortune, too, she
+was naturally so peculiar in appearance as not to show disfigurement
+like any other woman. She needed both advantages, for the marks of
+gripping fingers were deep in her face, and her hair was torn, and her
+dress (hastily composed with unsteady hands) was clutched and dragged a
+hundred ways.
+
+In crossing the bridge, she dropped the door key in the river. Arriving
+at the cathedral some few minutes before her escort, and waiting there,
+she thought, what if the key were already taken in a net, what if
+it were identified, what if the door were opened and the remains
+discovered, what if she were stopped at the gate, sent to prison, and
+charged with murder! In the midst of these fluttering thoughts, the
+escort appeared, took her in, and took her away.
+
+“Is there any noise in the streets?” she asked him.
+
+“The usual noises,” Mr. Cruncher replied; and looked surprised by the
+question and by her aspect.
+
+“I don’t hear you,” said Miss Pross. “What do you say?”
+
+It was in vain for Mr. Cruncher to repeat what he said; Miss Pross could
+not hear him. “So I’ll nod my head,” thought Mr. Cruncher, amazed, “at
+all events she’ll see that.” And she did.
+
+“Is there any noise in the streets now?” asked Miss Pross again,
+presently.
+
+Again Mr. Cruncher nodded his head.
+
+“I don’t hear it.”
+
+“Gone deaf in an hour?” said Mr. Cruncher, ruminating, with his mind
+much disturbed; “wot’s come to her?”
+
+“I feel,” said Miss Pross, “as if there had been a flash and a crash,
+and that crash was the last thing I should ever hear in this life.”
+
+“Blest if she ain’t in a queer condition!” said Mr. Cruncher, more and
+more disturbed. “Wot can she have been a takin’, to keep her courage up?
+Hark! There’s the roll of them dreadful carts! You can hear that, miss?”
+
+“I can hear,” said Miss Pross, seeing that he spoke to her, “nothing. O,
+my good man, there was first a great crash, and then a great stillness,
+and that stillness seems to be fixed and unchangeable, never to be
+broken any more as long as my life lasts.”
+
+“If she don’t hear the roll of those dreadful carts, now very nigh their
+journey’s end,” said Mr. Cruncher, glancing over his shoulder, “it’s my
+opinion that indeed she never will hear anything else in this world.”
+
+And indeed she never did.
+
+
+
+
+XV. The Footsteps Die Out For Ever
+
+
+Along the Paris streets, the death-carts rumble, hollow and harsh. Six
+tumbrils carry the day’s wine to La Guillotine. All the devouring and
+insatiate Monsters imagined since imagination could record itself,
+are fused in the one realisation, Guillotine. And yet there is not in
+France, with its rich variety of soil and climate, a blade, a leaf,
+a root, a sprig, a peppercorn, which will grow to maturity under
+conditions more certain than those that have produced this horror. Crush
+humanity out of shape once more, under similar hammers, and it will
+twist itself into the same tortured forms. Sow the same seed of
+rapacious license and oppression over again, and it will surely yield
+the same fruit according to its kind.
+
+Six tumbrils roll along the streets. Change these back again to what
+they were, thou powerful enchanter, Time, and they shall be seen to be
+the carriages of absolute monarchs, the equipages of feudal nobles, the
+toilettes of flaring Jezebels, the churches that are not my father’s
+house but dens of thieves, the huts of millions of starving peasants!
+No; the great magician who majestically works out the appointed order
+of the Creator, never reverses his transformations. “If thou be changed
+into this shape by the will of God,” say the seers to the enchanted, in
+the wise Arabian stories, “then remain so! But, if thou wear this
+form through mere passing conjuration, then resume thy former aspect!”
+ Changeless and hopeless, the tumbrils roll along.
+
+As the sombre wheels of the six carts go round, they seem to plough up
+a long crooked furrow among the populace in the streets. Ridges of faces
+are thrown to this side and to that, and the ploughs go steadily onward.
+So used are the regular inhabitants of the houses to the spectacle, that
+in many windows there are no people, and in some the occupation of the
+hands is not so much as suspended, while the eyes survey the faces in
+the tumbrils. Here and there, the inmate has visitors to see the sight;
+then he points his finger, with something of the complacency of a
+curator or authorised exponent, to this cart and to this, and seems to
+tell who sat here yesterday, and who there the day before.
+
+Of the riders in the tumbrils, some observe these things, and all
+things on their last roadside, with an impassive stare; others, with
+a lingering interest in the ways of life and men. Some, seated with
+drooping heads, are sunk in silent despair; again, there are some so
+heedful of their looks that they cast upon the multitude such glances as
+they have seen in theatres, and in pictures. Several close their eyes,
+and think, or try to get their straying thoughts together. Only one, and
+he a miserable creature, of a crazed aspect, is so shattered and made
+drunk by horror, that he sings, and tries to dance. Not one of the whole
+number appeals by look or gesture, to the pity of the people.
+
+There is a guard of sundry horsemen riding abreast of the tumbrils,
+and faces are often turned up to some of them, and they are asked some
+question. It would seem to be always the same question, for, it is
+always followed by a press of people towards the third cart. The
+horsemen abreast of that cart, frequently point out one man in it with
+their swords. The leading curiosity is, to know which is he; he stands
+at the back of the tumbril with his head bent down, to converse with a
+mere girl who sits on the side of the cart, and holds his hand. He has
+no curiosity or care for the scene about him, and always speaks to the
+girl. Here and there in the long street of St. Honore, cries are raised
+against him. If they move him at all, it is only to a quiet smile, as he
+shakes his hair a little more loosely about his face. He cannot easily
+touch his face, his arms being bound.
+
+On the steps of a church, awaiting the coming-up of the tumbrils, stands
+the Spy and prison-sheep. He looks into the first of them: not there.
+He looks into the second: not there. He already asks himself, “Has he
+sacrificed me?” when his face clears, as he looks into the third.
+
+“Which is Evremonde?” says a man behind him.
+
+“That. At the back there.”
+
+“With his hand in the girl’s?”
+
+“Yes.”
+
+The man cries, “Down, Evremonde! To the Guillotine all aristocrats!
+Down, Evremonde!”
+
+“Hush, hush!” the Spy entreats him, timidly.
+
+“And why not, citizen?”
+
+“He is going to pay the forfeit: it will be paid in five minutes more.
+Let him be at peace.”
+
+But the man continuing to exclaim, “Down, Evremonde!” the face of
+Evremonde is for a moment turned towards him. Evremonde then sees the
+Spy, and looks attentively at him, and goes his way.
+
+The clocks are on the stroke of three, and the furrow ploughed among the
+populace is turning round, to come on into the place of execution, and
+end. The ridges thrown to this side and to that, now crumble in and
+close behind the last plough as it passes on, for all are following
+to the Guillotine. In front of it, seated in chairs, as in a garden of
+public diversion, are a number of women, busily knitting. On one of the
+fore-most chairs, stands The Vengeance, looking about for her friend.
+
+“Therese!” she cries, in her shrill tones. “Who has seen her? Therese
+Defarge!”
+
+“She never missed before,” says a knitting-woman of the sisterhood.
+
+“No; nor will she miss now,” cries The Vengeance, petulantly. “Therese.”
+
+“Louder,” the woman recommends.
+
+Ay! Louder, Vengeance, much louder, and still she will scarcely hear
+thee. Louder yet, Vengeance, with a little oath or so added, and yet
+it will hardly bring her. Send other women up and down to seek her,
+lingering somewhere; and yet, although the messengers have done dread
+deeds, it is questionable whether of their own wills they will go far
+enough to find her!
+
+“Bad Fortune!” cries The Vengeance, stamping her foot in the chair, “and
+here are the tumbrils! And Evremonde will be despatched in a wink, and
+she not here! See her knitting in my hand, and her empty chair ready for
+her. I cry with vexation and disappointment!”
+
+As The Vengeance descends from her elevation to do it, the tumbrils
+begin to discharge their loads. The ministers of Sainte Guillotine are
+robed and ready. Crash!--A head is held up, and the knitting-women who
+scarcely lifted their eyes to look at it a moment ago when it could
+think and speak, count One.
+
+The second tumbril empties and moves on; the third comes up. Crash!--And
+the knitting-women, never faltering or pausing in their Work, count Two.
+
+The supposed Evremonde descends, and the seamstress is lifted out next
+after him. He has not relinquished her patient hand in getting out, but
+still holds it as he promised. He gently places her with her back to the
+crashing engine that constantly whirrs up and falls, and she looks into
+his face and thanks him.
+
+“But for you, dear stranger, I should not be so composed, for I am
+naturally a poor little thing, faint of heart; nor should I have been
+able to raise my thoughts to Him who was put to death, that we might
+have hope and comfort here to-day. I think you were sent to me by
+Heaven.”
+
+“Or you to me,” says Sydney Carton. “Keep your eyes upon me, dear child,
+and mind no other object.”
+
+“I mind nothing while I hold your hand. I shall mind nothing when I let
+it go, if they are rapid.”
+
+“They will be rapid. Fear not!”
+
+The two stand in the fast-thinning throng of victims, but they speak as
+if they were alone. Eye to eye, voice to voice, hand to hand, heart to
+heart, these two children of the Universal Mother, else so wide apart
+and differing, have come together on the dark highway, to repair home
+together, and to rest in her bosom.
+
+“Brave and generous friend, will you let me ask you one last question? I
+am very ignorant, and it troubles me--just a little.”
+
+“Tell me what it is.”
+
+“I have a cousin, an only relative and an orphan, like myself, whom I
+love very dearly. She is five years younger than I, and she lives in a
+farmer’s house in the south country. Poverty parted us, and she knows
+nothing of my fate--for I cannot write--and if I could, how should I
+tell her! It is better as it is.”
+
+“Yes, yes: better as it is.”
+
+“What I have been thinking as we came along, and what I am still
+thinking now, as I look into your kind strong face which gives me so
+much support, is this:--If the Republic really does good to the poor,
+and they come to be less hungry, and in all ways to suffer less, she may
+live a long time: she may even live to be old.”
+
+“What then, my gentle sister?”
+
+“Do you think:” the uncomplaining eyes in which there is so much
+endurance, fill with tears, and the lips part a little more and tremble:
+“that it will seem long to me, while I wait for her in the better land
+where I trust both you and I will be mercifully sheltered?”
+
+“It cannot be, my child; there is no Time there, and no trouble there.”
+
+“You comfort me so much! I am so ignorant. Am I to kiss you now? Is the
+moment come?”
+
+“Yes.”
+
+She kisses his lips; he kisses hers; they solemnly bless each other.
+The spare hand does not tremble as he releases it; nothing worse than
+a sweet, bright constancy is in the patient face. She goes next before
+him--is gone; the knitting-women count Twenty-Two.
+
+“I am the Resurrection and the Life, saith the Lord: he that believeth
+in me, though he were dead, yet shall he live: and whosoever liveth and
+believeth in me shall never die.”
+
+The murmuring of many voices, the upturning of many faces, the pressing
+on of many footsteps in the outskirts of the crowd, so that it swells
+forward in a mass, like one great heave of water, all flashes away.
+Twenty-Three.
+
+        *****
+
+They said of him, about the city that night, that it was the
+peacefullest man’s face ever beheld there. Many added that he looked
+sublime and prophetic.
+
+One of the most remarkable sufferers by the same axe--a woman--had asked
+at the foot of the same scaffold, not long before, to be allowed to
+write down the thoughts that were inspiring her. If he had given any
+utterance to his, and they were prophetic, they would have been these:
+
+“I see Barsad, and Cly, Defarge, The Vengeance, the Juryman, the Judge,
+long ranks of the new oppressors who have risen on the destruction of
+the old, perishing by this retributive instrument, before it shall cease
+out of its present use. I see a beautiful city and a brilliant people
+rising from this abyss, and, in their struggles to be truly free, in
+their triumphs and defeats, through long years to come, I see the evil
+of this time and of the previous time of which this is the natural
+birth, gradually making expiation for itself and wearing out.
+
+“I see the lives for which I lay down my life, peaceful, useful,
+prosperous and happy, in that England which I shall see no more. I see
+Her with a child upon her bosom, who bears my name. I see her father,
+aged and bent, but otherwise restored, and faithful to all men in his
+healing office, and at peace. I see the good old man, so long their
+friend, in ten years’ time enriching them with all he has, and passing
+tranquilly to his reward.
+
+“I see that I hold a sanctuary in their hearts, and in the hearts of
+their descendants, generations hence. I see her, an old woman, weeping
+for me on the anniversary of this day. I see her and her husband, their
+course done, lying side by side in their last earthly bed, and I know
+that each was not more honoured and held sacred in the other’s soul,
+than I was in the souls of both.
+
+“I see that child who lay upon her bosom and who bore my name, a man
+winning his way up in that path of life which once was mine. I see him
+winning it so well, that my name is made illustrious there by the
+light of his. I see the blots I threw upon it, faded away. I see him,
+fore-most of just judges and honoured men, bringing a boy of my name,
+with a forehead that I know and golden hair, to this place--then fair to
+look upon, with not a trace of this day’s disfigurement--and I hear him
+tell the child my story, with a tender and a faltering voice.
+
+“It is a far, far better thing that I do, than I have ever done; it is a
+far, far better rest that I go to than I have ever known.”
+
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of A Tale of Two Cities, by Charles Dickens
+
+*** END OF THIS PROJECT GUTENBERG EBOOK A TALE OF TWO CITIES ***
+
+***** This file should be named 98-0.txt or 98-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/9/98/
+
+Produced by Judith Boss
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/adventures-of-sherlock-holmes.txt
+++ b/jet/tf-idf/src/main/resources/books/adventures-of-sherlock-holmes.txt
@@ -1,0 +1,12759 @@
+﻿Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+
+Title: Adventures of Sherlock Holmes
+       Illustrated
+
+Author: A. Conan Doyle
+
+Release Date: February 20, 2015 [EBook #48320]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+
+
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+
+
+
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+
+
+
+[Illustration:
+
+  “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”
+                                           [Page 238
+]
+
+
+
+
+  ADVENTURES
+  OF
+  SHERLOCK HOLMES
+
+  BY
+  A. CONAN DOYLE
+
+  AUTHOR OF “MICAH CLARKE” ETC.
+
+  ILLUSTRATED
+
+  NEW YORK
+  HARPER & BROTHERS, FRANKLIN SQUARE
+
+
+
+
+  Copyright, 1892, by HARPER & BROTHERS.
+  _All rights reserved._
+
+
+
+
+CONTENTS
+
+
+                                                 PAGE
+
+     I.—A SCANDAL IN BOHEMIA                        3
+
+    II.—THE RED-HEADED LEAGUE                      29
+
+   III.—A CASE OF IDENTITY                         56
+
+    IV.—THE BOSCOMBE VALLEY MYSTERY                76
+
+     V.—THE FIVE ORANGE PIPS                      104
+
+    VI.—THE MAN WITH THE TWISTED LIP              126
+
+   VII.—THE ADVENTURE OF THE BLUE CARBUNCLE       153
+
+  VIII.—THE ADVENTURE OF THE SPECKLED BAND        176
+
+    IX.—THE ADVENTURE OF THE ENGINEER’S THUMB     205
+
+     X.—THE ADVENTURE OF THE NOBLE BACHELOR       229
+
+    XI.—THE ADVENTURE OF THE BERYL CORONET        253
+
+   XII.—THE ADVENTURE OF THE COPPER BEECHES       280
+
+
+
+
+ILLUSTRATIONS
+
+
+    “THE GENTLEMAN IN THE PEW HANDED IT UP TO HER”  _Frontispiece_
+
+    “A MAN ENTERED”                                 _Facing p._  8
+
+    “THE DOOR WAS SHUT AND LOCKED”                         ″     40
+
+    “ALL AFTERNOON HE SAT IN THE STALLS”                   ″     46
+
+    “SHERLOCK HOLMES WELCOMED HER”                         ″     60
+
+    “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”              ″     72
+
+    “THEY FOUND THE BODY”                                  ″     80
+
+    “THE MAID SHOWED US THE BOOTS”                         ″     92
+
+    “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”                ″    122
+
+    “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+        SCOUNDREL”                                         ″    134
+
+    “‘HAVE MERCY!’ HE SHRIEKED”                            ″    172
+
+    “‘GOOD-BYE, AND BE BRAVE’”                             ″    196
+
+    “‘NOT A WORD TO A SOUL’”                               ″    214
+
+    “‘I WILL WISH YOU ALL A VERY GOOD NIGHT’”              ″    250
+
+    “I CLAPPED A PISTOL TO HIS HEAD”                       ″    278
+
+    “‘I AM SO DELIGHTED THAT YOU HAVE COME’”               ″    292
+
+
+
+
+ADVENTURES OF SHERLOCK HOLMES
+
+Adventure I
+
+A SCANDAL IN BOHEMIA
+
+
+I
+
+To Sherlock Holmes she is always _the_ woman. I have seldom heard
+him mention her under any other name. In his eyes she eclipses and
+predominates the whole of her sex. It was not that he felt any emotion
+akin to love for Irene Adler. All emotions, and that one particularly,
+were abhorrent to his cold, precise, but admirably balanced mind. He
+was, I take it, the most perfect reasoning and observing machine that
+the world has seen; but, as a lover, he would have placed himself in a
+false position. He never spoke of the softer passions, save with a gibe
+and a sneer. They were admirable things for the observer—excellent
+for drawing the veil from men’s motives and actions. But for the
+trained reasoner to admit such intrusions into his own delicate and
+finely adjusted temperament was to introduce a distracting factor which
+might throw a doubt upon all his mental results. Grit in a sensitive
+instrument, or a crack in one of his own high-power lenses, would not
+be more disturbing than a strong emotion in a nature such as his. And
+yet there was but one woman to him, and that woman was the late Irene
+Adler, of dubious and questionable memory.
+
+I had seen little of Holmes lately. My marriage had drifted us away
+from each other. My own complete happiness, and the home-centred
+interests which rise up around the man who first finds himself master
+of his own establishment, were sufficient to absorb all my attention;
+while Holmes, who loathed every form of society with his whole
+Bohemian soul, remained in our lodgings in Baker Street, buried among
+his old books, and alternating from week to week between cocaine and
+ambition, the drowsiness of the drug, and the fierce energy of his
+own keen nature. He was still, as ever, deeply attracted by the study
+of crime, and occupied his immense faculties and extraordinary powers
+of observation in following out those clues, and clearing up those
+mysteries, which had been abandoned as hopeless by the official police.
+From time to time I heard some vague account of his doings: of his
+summons to Odessa in the case of the Trepoff murder, of his clearing
+up of the singular tragedy of the Atkinson brothers at Trincomalee,
+and finally of the mission which he had accomplished so delicately and
+successfully for the reigning family of Holland. Beyond these signs of
+his activity, however, which I merely shared with all the readers of
+the daily press, I knew little of my former friend and companion.
+
+One night—it was on the 20th of March, 1888—I was returning from a
+journey to a patient (for I had now returned to civil practice), when
+my way led me through Baker Street. As I passed the well-remembered
+door, which must always be associated in my mind with my wooing, and
+with the dark incidents of the Study in Scarlet, I was seized with a
+keen desire to see Holmes again, and to know how he was employing his
+extraordinary powers. His rooms were brilliantly lit, and, even as I
+looked up, I saw his tall, spare figure pass twice in a dark silhouette
+against the blind. He was pacing the room swiftly, eagerly, with his
+head sunk upon his chest and his hands clasped behind him. To me, who
+knew his every mood and habit, his attitude and manner told their own
+story. He was at work again. He had arisen out of his drug-created
+dreams, and was hot upon the scent of some new problem. I rang the
+bell, and was shown up to the chamber which had formerly been in part
+my own.
+
+His manner was not effusive. It seldom was; but he was glad, I think,
+to see me. With hardly a word spoken, but with a kindly eye, he waved
+me to an arm-chair, threw across his case of cigars, and indicated a
+spirit case and a gasogene in the corner. Then he stood before the
+fire, and looked me over in his singular introspective fashion.
+
+“Wedlock suits you,” he remarked. “I think, Watson, that you have put
+on seven and a half pounds since I saw you.”
+
+“Seven!” I answered.
+
+“Indeed, I should have thought a little more. Just a trifle more, I
+fancy, Watson. And in practice again, I observe. You did not tell me
+that you intended to go into harness.”
+
+“Then, how do you know?”
+
+“I see it, I deduce it. How do I know that you have been getting
+yourself very wet lately, and that you have a most clumsy and careless
+servant girl?”
+
+“My dear Holmes,” said I, “this is too much. You would certainly have
+been burned, had you lived a few centuries ago. It is true that I had
+a country walk on Thursday and came home in a dreadful mess; but, as I
+have changed my clothes, I can’t imagine how you deduce it. As to Mary
+Jane, she is incorrigible, and my wife has given her notice; but there,
+again, I fail to see how you work it out.”
+
+He chuckled to himself and rubbed his long, nervous hands together.
+
+“It is simplicity itself,” said he; “my eyes tell me that on the
+inside of your left shoe, just where the firelight strikes it, the
+leather is scored by six almost parallel cuts. Obviously they have
+been caused by some one who has very carelessly scraped round the
+edges of the sole in order to remove crusted mud from it. Hence, you
+see, my double deduction that you had been out in vile weather, and
+that you had a particularly malignant boot-slitting specimen of the
+London slavey. As to your practice, if a gentleman walks into my rooms
+smelling of iodoform, with a black mark of nitrate of silver upon his
+right forefinger, and a bulge on the side of his top-hat to show where
+he has secreted his stethoscope, I must be dull, indeed, if I do not
+pronounce him to be an active member of the medical profession.”
+
+I could not help laughing at the ease with which he explained his
+process of deduction. “When I hear you give your reasons,” I remarked,
+“the thing always appears to me to be so ridiculously simple that I
+could easily do it myself, though at each successive instance of your
+reasoning I am baffled, until you explain your process. And yet I
+believe that my eyes are as good as yours.”
+
+“Quite so,” he answered, lighting a cigarette, and throwing himself
+down into an arm-chair. “You see, but you do not observe. The
+distinction is clear. For example, you have frequently seen the steps
+which lead up from the hall to this room.”
+
+“Frequently.”
+
+“How often?”
+
+“Well, some hundreds of times.”
+
+“Then how many are there?”
+
+“How many? I don’t know.”
+
+“Quite so! You have not observed. And yet you have seen. That is just
+my point. Now, I know that there are seventeen steps, because I have
+both seen and observed. By-the-way, since you are interested in these
+little problems, and since you are good enough to chronicle one or two
+of my trifling experiences, you may be interested in this.” He threw
+over a sheet of thick, pink-tinted note-paper which had been lying open
+upon the table. “It came by the last post,” said he. “Read it aloud.”
+
+The note was undated, and without either signature or address.
+
+“There will call upon you to-night, at a quarter to eight o’clock,”
+it said, “a gentleman who desires to consult you upon a matter of the
+very deepest moment. Your recent services to one of the royal houses
+of Europe have shown that you are one who may safely be trusted with
+matters which are of an importance which can hardly be exaggerated.
+This account of you we have from all quarters received. Be in your
+chamber then at that hour, and do not take it amiss if your visitor
+wear a mask.”
+
+“This is indeed a mystery,” I remarked. “What do you imagine that it
+means?”
+
+“I have no data yet. It is a capital mistake to theorize before one has
+data. Insensibly one begins to twist facts to suit theories, instead of
+theories to suit facts. But the note itself. What do you deduce from
+it?”
+
+I carefully examined the writing, and the paper upon which it was
+written.
+
+“The man who wrote it was presumably well to do,” I remarked,
+endeavoring to imitate my companion’s processes. “Such paper could not
+be bought under half a crown a packet. It is peculiarly strong and
+stiff.”
+
+“Peculiar—that is the very word,” said Holmes. “It is not an English
+paper at all. Hold it up to the light.”
+
+I did so, and saw a large _E_ with a small _g_, a _P_, and a large _G_
+with a small _t_ woven into the texture of the paper.
+
+“What do you make of that?” asked Holmes.
+
+“The name of the maker, no doubt; or his monogram, rather.”
+
+“Not at all. The _G_ with the small _t_ stands for ‘Gesellschaft,’
+which is the German for ‘Company.’ It is a customary contraction like
+our ‘Co.’ _P_, of course, stands for ‘Papier.’ Now for the _Eg_. Let us
+glance at our Continental Gazetteer.” He took down a heavy brown volume
+from his shelves. “Eglow, Eglonitz—here we are, Egria. It is in a
+German-speaking country—in Bohemia, not far from Carlsbad. ‘Remarkable
+as being the scene of the death of Wallenstein, and for its numerous
+glass-factories and paper-mills.’ Ha, ha, my boy, what do you make of
+that?” His eyes sparkled, and he sent up a great blue triumphant cloud
+from his cigarette.
+
+“The paper was made in Bohemia,” I said.
+
+“Precisely. And the man who wrote the note is a German. Do you note the
+peculiar construction of the sentence—‘This account of you we have
+from all quarters received.’ A Frenchman or Russian could not have
+written that. It is the German who is so uncourteous to his verbs. It
+only remains, therefore, to discover what is wanted by this German
+who writes upon Bohemian paper, and prefers wearing a mask to showing
+his face. And here he comes, if I am not mistaken, to resolve all our
+doubts.”
+
+As he spoke there was the sharp sound of horses’ hoofs and grating
+wheels against the curb, followed by a sharp pull at the bell. Holmes
+whistled.
+
+“A pair, by the sound,” said he. “Yes,” he continued, glancing out of
+the window. “A nice little brougham and a pair of beauties. A hundred
+and fifty guineas apiece. There’s money in this case, Watson, if there
+is nothing else.”
+
+“I think that I had better go, Holmes.”
+
+“Not a bit, doctor. Stay where you are. I am lost without my Boswell.
+And this promises to be interesting. It would be a pity to miss it.”
+
+“But your client—”
+
+“Never mind him. I may want your help, and so may he. Here he comes.
+Sit down in that arm-chair, doctor, and give us your best attention.”
+
+A slow and heavy step, which had been heard upon the stairs and in the
+passage, paused immediately outside the door. Then there was a loud and
+authoritative tap.
+
+“Come in!” said Holmes.
+
+[Illustration: “A MAN ENTERED”]
+
+A man entered who could hardly have been less than six feet six inches
+in height, with the chest and limbs of a Hercules. His dress was rich
+with a richness which would, in England, be looked upon as akin to bad
+taste. Heavy bands of Astrakhan were slashed across the sleeves and
+fronts of his double-breasted coat, while the deep blue cloak which
+was thrown over his shoulders was lined with flame-colored silk, and
+secured at the neck with a brooch which consisted of a single flaming
+beryl. Boots which extended half-way up his calves, and which were
+trimmed at the tops with rich brown fur, completed the impression of
+barbaric opulence which was suggested by his whole appearance. He
+carried a broad-brimmed hat in his hand, while he wore across the upper
+part of his face, extending down past the cheekbones, a black vizard
+mask, which he had apparently adjusted that very moment, for his hand
+was still raised to it as he entered. From the lower part of the face
+he appeared to be a man of strong character, with a thick, hanging
+lip, and a long, straight chin, suggestive of resolution pushed to the
+length of obstinacy.
+
+“You had my note?” he asked, with a deep harsh voice and a strongly
+marked German accent. “I told you that I would call.” He looked from
+one to the other of us, as if uncertain which to address.
+
+“Pray take a seat,” said Holmes. “This is my friend and colleague, Dr.
+Watson, who is occasionally good enough to help me in my cases. Whom
+have I the honor to address?”
+
+“You may address me as the Count Von Kramm, a Bohemian nobleman.
+I understand that this gentleman, your friend, is a man of honor
+and discretion, whom I may trust with a matter of the most extreme
+importance. If not, I should much prefer to communicate with you alone.”
+
+I rose to go, but Holmes caught me by the wrist and pushed me back into
+my chair. “It is both, or none,” said he. “You may say before this
+gentleman anything which you may say to me.”
+
+The count shrugged his broad shoulders. “Then I must begin,” said he,
+“by binding you both to absolute secrecy for two years, at the end of
+that time the matter will be of no importance. At present it is not too
+much to say that it is of such weight it may have an influence upon
+European history.”
+
+“I promise,” said Holmes.
+
+“And I.”
+
+“You will excuse this mask,” continued our strange visitor. “The august
+person who employs me wishes his agent to be unknown to you, and I may
+confess at once that the title by which I have just called myself is
+not exactly my own.”
+
+“I was aware of it,” said Holmes, dryly.
+
+“The circumstances are of great delicacy, and every precaution has
+to be taken to quench what might grow to be an immense scandal and
+seriously compromise one of the reigning families of Europe. To speak
+plainly, the matter implicates the great House of Ormstein, hereditary
+kings of Bohemia.”
+
+“I was also aware of that,” murmured Holmes, settling himself down in
+his arm-chair and closing his eyes.
+
+Our visitor glanced with some apparent surprise at the languid,
+lounging figure of the man who had been no doubt depicted to him as
+the most incisive reasoner and most energetic agent in Europe. Holmes
+slowly reopened his eyes and looked impatiently at his gigantic client.
+
+“If your Majesty would condescend to state your case,” he remarked, “I
+should be better able to advise you.”
+
+The man sprang from his chair and paced up and down the room in
+uncontrollable agitation. Then, with a gesture of desperation, he tore
+the mask from his face and hurled it upon the ground. “You are right,”
+he cried; “I am the King. Why should I attempt to conceal it?”
+
+“Why, indeed?” murmured Holmes. “Your Majesty had not spoken before
+I was aware that I was addressing Wilhelm Gottsreich Sigismond von
+Ormstein, Grand Duke of Cassel-Felstein, and hereditary King of
+Bohemia.”
+
+“But you can understand,” said our strange visitor, sitting down once
+more and passing his hand over his high, white forehead, “you can
+understand that I am not accustomed to doing such business in my own
+person. Yet the matter was so delicate that I could not confide it to
+an agent without putting myself in his power. I have come _incognito_
+from Prague for the purpose of consulting you.”
+
+“Then, pray consult,” said Holmes, shutting his eyes once more.
+
+“The facts are briefly these: Some five years ago, during a lengthy
+visit to Warsaw, I made the acquaintance of the well-known
+adventuress, Irene Adler. The name is no doubt familiar to you.”
+
+“Kindly look her up in my index, doctor,” murmured Holmes, without
+opening his eyes. For many years he had adopted a system of docketing
+all paragraphs concerning men and things, so that it was difficult
+to name a subject or a person on which he could not at once furnish
+information. In this case I found her biography sandwiched in between
+that of a Hebrew Rabbi and that of a staff-commander who had written a
+monograph upon the deep-sea fishes.
+
+“Let me see!” said Holmes. “Hum! Born in New Jersey in the year
+1858. Contralto—hum! La Scala, hum! Prima donna Imperial Opera of
+Warsaw—Yes! Retired from operatic stage—ha! Living in London—quite
+so! Your Majesty, as I understand, became entangled with this young
+person, wrote her some compromising letters, and is now desirous of
+getting those letters back.”
+
+“Precisely so. But how—”
+
+“Was there a secret marriage?”
+
+“None.”
+
+“No legal papers or certificates?”
+
+“None.”
+
+“Then I fail to follow your Majesty. If this young person should
+produce her letters for blackmailing or other purposes, how is she to
+prove their authenticity?”
+
+“There is the writing.”
+
+“Pooh, pooh! Forgery.”
+
+“My private note-paper.”
+
+“Stolen.”
+
+“My own seal.”
+
+“Imitated.”
+
+“My photograph.”
+
+“Bought.”
+
+“We were both in the photograph.”
+
+“Oh dear! That is very bad! Your Majesty has indeed committed an
+indiscretion.”
+
+“I was mad—insane.”
+
+“You have compromised yourself seriously.”
+
+“I was only Crown Prince then. I was young. I am but thirty now.”
+
+“It must be recovered.”
+
+“We have tried and failed.”
+
+“Your Majesty must pay. It must be bought.”
+
+“She will not sell.”
+
+“Stolen, then.”
+
+“Five attempts have been made. Twice burglars in my pay ransacked her
+house. Once we diverted her luggage when she travelled. Twice she has
+been waylaid. There has been no result.”
+
+“No sign of it?”
+
+“Absolutely none.”
+
+Holmes laughed. “It is quite a pretty little problem,” said he.
+
+“But a very serious one to me,” returned the King, reproachfully.
+
+“Very, indeed. And what does she propose to do with the photograph?”
+
+“To ruin me.”
+
+“But how?”
+
+“I am about to be married.”
+
+“So I have heard.”
+
+“To Clotilde Lothman von Saxe-Meningen, second daughter of the King of
+Scandinavia. You may know the strict principles of her family. She is
+herself the very soul of delicacy. A shadow of a doubt as to my conduct
+would bring the matter to an end.”
+
+“And Irene Adler?”
+
+“Threatens to send them the photograph. And she will do it. I know that
+she will do it. You do not know her, but she has a soul of steel. She
+has the face of the most beautiful of women, and the mind of the most
+resolute of men. Rather than I should marry another woman, there are
+no lengths to which she would not go—none.”
+
+“You are sure that she has not sent it yet?”
+
+“I am sure.”
+
+“And why?”
+
+“Because she has said that she would send it on the day when the
+betrothal was publicly proclaimed. That will be next Monday.”
+
+“Oh, then, we have three days yet,” said Holmes, with a yawn. “That is
+very fortunate, as I have one or two matters of importance to look into
+just at present. Your Majesty will, of course, stay in London for the
+present?”
+
+“Certainly. You will find me at the Langham, under the name of the
+Count Von Kramm.”
+
+“Then I shall drop you a line to let you know how we progress.”
+
+“Pray do so. I shall be all anxiety.”
+
+“Then, as to money?”
+
+“You have _carte blanche_.”
+
+“Absolutely?”
+
+“I tell you that I would give one of the provinces of my kingdom to
+have that photograph.”
+
+“And for present expenses?”
+
+The king took a heavy chamois leather bag from under his cloak and laid
+it on the table.
+
+“There are three hundred pounds in gold and seven hundred in notes,” he
+said.
+
+Holmes scribbled a receipt upon a sheet of his note-book and handed it
+to him.
+
+“And mademoiselle’s address?” he asked.
+
+“Is Briony Lodge, Serpentine Avenue, St. John’s Wood.”
+
+Holmes took a note of it. “One other question,” said he. “Was the
+photograph a cabinet?”
+
+“It was.”
+
+“Then, good-night, your Majesty, and I trust that we shall soon have
+some good news for you. And good-night, Watson,” he added, as the
+wheels of the royal brougham rolled down the street. “If you will be
+good enough to call to-morrow afternoon, at three o’clock, I should
+like to chat this little matter over with you.”
+
+
+II
+
+At three o’clock precisely I was at Baker Street, but Holmes had not
+yet returned. The landlady informed me that he had left the house
+shortly after eight o’clock in the morning. I sat down beside the
+fire, however, with the intention of awaiting him, however long he
+might be. I was already deeply interested in his inquiry, for, though
+it was surrounded by none of the grim and strange features which
+were associated with the two crimes which I have already recorded,
+still, the nature of the case and the exalted station of his client
+gave it a character of its own. Indeed, apart from the nature of the
+investigation which my friend had on hand, there was something in his
+masterly grasp of a situation, and his keen, incisive reasoning, which
+made it a pleasure to me to study his system of work, and to follow the
+quick, subtle methods by which he disentangled the most inextricable
+mysteries. So accustomed was I to his invariable success that the very
+possibility of his failing had ceased to enter into my head.
+
+It was close upon four before the door opened, and a drunken-looking
+groom, ill-kempt and side-whiskered, with an inflamed face and
+disreputable clothes, walked into the room. Accustomed as I was to
+my friend’s amazing powers in the use of disguises, I had to look
+three times before I was certain that it was indeed he. With a nod
+he vanished into the bedroom, whence he emerged in five minutes
+tweed-suited and respectable, as of old. Putting his hands into his
+pockets, he stretched out his legs in front of the fire, and laughed
+heartily for some minutes.
+
+“Well, really!” he cried, and then he choked; and laughed again until
+he was obliged to lie back, limp and helpless, in the chair.
+
+“What is it?”
+
+“It’s quite too funny. I am sure you could never guess how I employed
+my morning, or what I ended by doing.”
+
+“I can’t imagine. I suppose that you have been watching the habits, and
+perhaps the house, of Miss Irene Adler.”
+
+“Quite so; but the sequel was rather unusual. I will tell you, however.
+I left the house a little after eight o’clock this morning, in the
+character of a groom out of work. There is a wonderful sympathy and
+freemasonry among horsey men. Be one of them, and you will know all
+that there is to know. I soon found Briony Lodge. It is a _bijou_
+villa, with a garden at the back, but built out in front right up to
+the road, two stories. Chubb lock to the door. Large sitting-room on
+the right side, well furnished, with long windows almost to the floor,
+and those preposterous English window fasteners which a child could
+open. Behind there was nothing remarkable, save that the passage window
+could be reached from the top of the coach-house. I walked round it
+and examined it closely from every point of view, but without noting
+anything else of interest.
+
+“I then lounged down the street, and found, as I expected, that there
+was a mews in a lane which runs down by one wall of the garden. I lent
+the ostlers a hand in rubbing down their horses, and I received in
+exchange twopence, a glass of half-and-half, two fills of shag tobacco,
+and as much information as I could desire about Miss Adler, to say
+nothing of half a dozen other people in the neighborhood in whom I was
+not in the least interested, but whose biographies I was compelled to
+listen to.”
+
+“And what of Irene Adler?” I asked.
+
+“Oh, she has turned all the men’s heads down in that part. She
+is the daintiest thing under a bonnet on this planet. So say the
+Serpentine-mews, to a man. She lives quietly, sings at concerts, drives
+out at five every day, and returns at seven sharp for dinner. Seldom
+goes out at other times, except when she sings. Has only one male
+visitor, but a good deal of him. He is dark, handsome, and dashing,
+never calls less than once a day, and often twice. He is a Mr. Godfrey
+Norton, of the Inner Temple. See the advantages of a cabman as a
+confidant. They had driven him home a dozen times from Serpentine-mews,
+and knew all about him. When I had listened to all that they had to
+tell, I began to walk up and down near Briony Lodge once more, and to
+think over my plan of campaign.
+
+“This Godfrey Norton was evidently an important factor in the
+matter. He was a lawyer. That sounded ominous. What was the relation
+between them, and what the object of his repeated visits? Was she
+his client, his friend, or his mistress? If the former, she had
+probably transferred the photograph to his keeping. If the latter,
+it was less likely. On the issue of this question depended whether I
+should continue my work at Briony Lodge, or turn my attention to the
+gentleman’s chambers in the Temple. It was a delicate point, and it
+widened the field of my inquiry. I fear that I bore you with these
+details, but I have to let you see my little difficulties, if you are
+to understand the situation.”
+
+“I am following you closely,” I answered.
+
+“I was still balancing the matter in my mind, when a hansom cab drove
+up to Briony Lodge, and a gentleman sprang out. He was a remarkably
+handsome man, dark, aquiline, and mustached—evidently the man of whom
+I had heard. He appeared to be in a great hurry, shouted to the cabman
+to wait, and brushed past the maid who opened the door with the air of
+a man who was thoroughly at home.
+
+“He was in the house about half an hour, and I could catch glimpses of
+him in the windows of the sitting-room, pacing up and down, talking
+excitedly, and waving his arms. Of her I could see nothing. Presently
+he emerged, looking even more flurried than before. As he stepped up
+to the cab, he pulled a gold watch from his pocket and looked at it
+earnestly. ‘Drive like the devil,’ he shouted, ‘first to Gross &
+Hankey’s in Regent Street, and then to the church of St. Monica in the
+Edgware Road. Half a guinea if you do it in twenty minutes!’
+
+“Away they went, and I was just wondering whether I should not do
+well to follow them, when up the lane came a neat little landau, the
+coachman with his coat only half-buttoned, and his tie under his ear,
+while all the tags of his harness were sticking out of the buckles. It
+hadn’t pulled up before she shot out of the hall door and into it. I
+only caught a glimpse of her at the moment, but she was a lovely woman,
+with a face that a man might die for.
+
+“‘The Church of St. Monica, John,’ she cried, ‘and half a sovereign if
+you reach it in twenty minutes.’
+
+“This was quite too good to lose, Watson. I was just balancing whether
+I should run for it, or whether I should perch behind her landau,
+when a cab came through the street. The driver looked twice at such a
+shabby fare; but I jumped in before he could object. ‘The Church of
+St. Monica,’ said I, ‘and half a sovereign if you reach it in twenty
+minutes.’ It was twenty-five minutes to twelve, and of course it was
+clear enough what was in the wind.
+
+“My cabby drove fast. I don’t think I ever drove faster, but the others
+were there before us. The cab and the landau with their steaming horses
+were in front of the door when I arrived. I paid the man and hurried
+into the church. There was not a soul there save the two whom I had
+followed and a surpliced clergyman, who seemed to be expostulating with
+them. They were all three standing in a knot in front of the altar. I
+lounged up the side aisle like any other idler who has dropped into a
+church. Suddenly, to my surprise, the three at the altar faced round to
+me, and Godfrey Norton came running as hard as he could towards me.”
+
+“Thank God!” he cried. “You’ll do. Come! Come!”
+
+“What then?” I asked.
+
+“Come, man, come, only three minutes, or it won’t be legal.”
+
+“I was half-dragged up to the altar, and, before I knew where I was, I
+found myself mumbling responses which were whispered in my ear, and
+vouching for things of which I knew nothing, and generally assisting
+in the secure tying up of Irene Adler, spinster, to Godfrey Norton,
+bachelor. It was all done in an instant, and there was the gentleman
+thanking me on the one side and the lady on the other, while the
+clergyman beamed on me in front. It was the most preposterous position
+in which I ever found myself in my life, and it was the thought of
+it that started me laughing just now. It seems that there had been
+some informality about their license, that the clergyman absolutely
+refused to marry them without a witness of some sort, and that my lucky
+appearance saved the bridegroom from having to sally out into the
+streets in search of a best man. The bride gave me a sovereign, and I
+mean to wear it on my watch-chain in memory of the occasion.”
+
+“This is a very unexpected turn of affairs,” said I; “and what then?”
+
+“Well, I found my plans very seriously menaced. It looked as if the
+pair might take an immediate departure, and so necessitate very prompt
+and energetic measures on my part. At the church door, however, they
+separated, he driving back to the Temple, and she to her own house. ‘I
+shall drive out in the park at five as usual,’ she said, as she left
+him. I heard no more. They drove away in different directions, and I
+went off to make my own arrangements.”
+
+“Which are?”
+
+“Some cold beef and a glass of beer,” he answered, ringing the bell. “I
+have been too busy to think of food, and I am likely to be busier still
+this evening. By the way, doctor, I shall want your co-operation.”
+
+“I shall be delighted.”
+
+“You don’t mind breaking the law?”
+
+“Not in the least.”
+
+“Nor running a chance of arrest?”
+
+“Not in a good cause.”
+
+“Oh, the cause is excellent!”
+
+“Then I am your man.”
+
+“I was sure that I might rely on you.”
+
+“But what is it you wish?”
+
+“When Mrs. Turner has brought in the tray I will make it clear to
+you. Now,” he said, as he turned hungrily on the simple fare that our
+landlady had provided, “I must discuss it while I eat, for I have not
+much time. It is nearly five now. In two hours we must be on the scene
+of action. Miss Irene, or Madame, rather, returns from her drive at
+seven. We must be at Briony Lodge to meet her.”
+
+“And what then?”
+
+“You must leave that to me. I have already arranged what is to occur.
+There is only one point on which I must insist. You must not interfere,
+come what may. You understand?”
+
+“I am to be neutral?”
+
+“To do nothing whatever. There will probably be some small
+unpleasantness. Do not join in it. It will end in my being conveyed
+into the house. Four or five minutes afterwards the sitting-room window
+will open. You are to station yourself close to that open window.”
+
+“Yes.”
+
+“You are to watch me, for I will be visible to you.”
+
+“Yes.”
+
+“And when I raise my hand—so—you will throw into the room what I give
+you to throw, and will, at the same time, raise the cry of fire. You
+quite follow me?”
+
+“Entirely.”
+
+“It is nothing very formidable,” he said, taking a long cigar-shaped
+roll from his pocket. “It is an ordinary plumber’s smoke-rocket,
+fitted with a cap at either end to make it self-lighting. Your task is
+confined to that. When you raise your cry of fire, it will be taken
+up by quite a number of people. You may then walk to the end of the
+street, and I will rejoin you in ten minutes. I hope that I have made
+myself clear?”
+
+“I am to remain neutral, to get near the window, to watch you, and, at
+the signal, to throw in this object, then to raise the cry of fire, and
+to wait you at the corner of the street.”
+
+“Precisely.”
+
+“Then you may entirely rely on me.”
+
+“That is excellent. I think, perhaps, it is almost time that I prepare
+for the new role I have to play.”
+
+He disappeared into his bedroom, and returned in a few minutes in the
+character of an amiable and simple-minded Nonconformist clergyman. His
+broad black hat, his baggy trousers, his white tie, his sympathetic
+smile, and general look of peering and benevolent curiosity were such
+as Mr. John Hare alone could have equalled. It was not merely that
+Holmes changed his costume. His expression, his manner, his very soul
+seemed to vary with every fresh part that he assumed. The stage lost a
+fine actor, even as science lost an acute reasoner, when he became a
+specialist in crime.
+
+It was a quarter past six when we left Baker Street, and it still
+wanted ten minutes to the hour when we found ourselves in Serpentine
+Avenue. It was already dusk, and the lamps were just being lighted as
+we paced up and down in front of Briony Lodge, waiting for the coming
+of its occupant. The house was just such as I had pictured it from
+Sherlock Holmes’s succinct description, but the locality appeared to
+be less private that I expected. On the contrary, for a small street
+in a quiet neighborhood, it was remarkably animated. There was a
+group of shabbily-dressed men smoking and laughing in a corner, a
+scissors-grinder with his wheel, two guardsmen who were flirting with a
+nurse-girl, and several well-dressed young men who were lounging up and
+down with cigars in their mouths.
+
+“You see,” remarked Holmes, as we paced to and fro in front of the
+house, “this marriage rather simplifies matters. The photograph becomes
+a double-edged weapon now. The chances are that she would be as averse
+to its being seen by Mr. Godfrey Norton, as our client is to its coming
+to the eyes of his princess. Now the question is, Where are we to find
+the photograph?”
+
+“Where, indeed?”
+
+“It is most unlikely that she carries it about with her. It is cabinet
+size. Too large for easy concealment about a woman’s dress. She knows
+that the King is capable of having her waylaid and searched. Two
+attempts of the sort have already been made. We may take it, then, that
+she does not carry it about with her.”
+
+“Where, then?”
+
+“Her banker or her lawyer. There is that double possibility. But I am
+inclined to think neither. Women are naturally secretive, and they
+like to do their own secreting. Why should she hand it over to any one
+else? She could trust her own guardianship, but she could not tell
+what indirect or political influence might be brought to bear upon a
+business man. Besides, remember that she had resolved to use it within
+a few days. It must be where she can lay her hands upon it. It must be
+in her own house.”
+
+“But it has twice been burgled.”
+
+“Pshaw! They did not know how to look.”
+
+“But how will you look?”
+
+“I will not look.”
+
+“What then?”
+
+“I will get her to show me.”
+
+“But she will refuse.”
+
+“She will not be able to. But I hear the rumble of wheels. It is her
+carriage. Now carry out my orders to the letter.”
+
+As he spoke the gleam of the side-lights of a carriage came round the
+curve of the avenue. It was a smart little landau which rattled up to
+the door of Briony Lodge. As it pulled up, one of the loafing men at
+the corner dashed forward to open the door in the hope of earning a
+copper, but was elbowed away by another loafer, who had rushed up with
+the same intention. A fierce quarrel broke out, which was increased by
+the two guardsmen, who took sides with one of the loungers, and by the
+scissors-grinder, who was equally hot upon the other side. A blow was
+struck, and in an instant the lady, who had stepped from her carriage,
+was the centre of a little knot of flushed and struggling men, who
+struck savagely at each other with their fists and sticks. Holmes
+dashed into the crowd to protect the lady; but just as he reached her
+he gave a cry and dropped to the ground, with the blood running freely
+down his face. At his fall the guardsmen took to their heels in one
+direction and the loungers in the other, while a number of better
+dressed people, who had watched the scuffle without taking part in it,
+crowded in to help the lady and to attend to the injured man. Irene
+Adler, as I will still call her, had hurried up the steps; but she
+stood at the top with her superb figure outlined against the lights of
+the hall, looking back into the street.
+
+“Is the poor gentleman much hurt?” she asked.
+
+“He is dead,” cried several voices.
+
+“No, no, there’s life in him!” shouted another. “But he’ll be gone
+before you can get him to hospital.”
+
+“He’s a brave fellow,” said a woman. “They would have had the lady’s
+purse and watch if it hadn’t been for him. They were a gang, and a
+rough one, too. Ah, he’s breathing now.”
+
+“He can’t lie in the street. May we bring him in, marm?”
+
+“Surely. Bring him into the sitting-room. There is a comfortable sofa.
+This way, please!”
+
+Slowly and solemnly he was borne into Briony Lodge and laid out in the
+principal room, while I still observed the proceedings from my post
+by the window. The lamps had been lit, but the blinds had not been
+drawn, so that I could see Holmes as he lay upon the couch. I do not
+know whether he was seized with compunction at that moment for the part
+he was playing, but I know that I never felt more heartily ashamed of
+myself in my life than when I saw the beautiful creature against whom
+I was conspiring, or the grace and kindliness with which she waited
+upon the injured man. And yet it would be the blackest treachery to
+Holmes to draw back now from the part which he had intrusted to me.
+I hardened my heart, and took the smoke-rocket from under my ulster.
+After all, I thought, we are not injuring her. We are but preventing
+her from injuring another.
+
+Holmes had sat up upon the couch, and I saw him motion like a man who
+is in need of air. A maid rushed across and threw open the window. At
+the same instant I saw him raise his hand, and at the signal I tossed
+my rocket into the room with a cry of “Fire!” The word was no sooner
+out of my mouth than the whole crowd of spectators, well dressed and
+ill—gentlemen, ostlers, and servant-maids—joined in a general shriek
+of “Fire!” Thick clouds of smoke curled through the room and out at
+the open window. I caught a glimpse of rushing figures, and a moment
+later the voice of Holmes from within assuring them that it was a false
+alarm. Slipping through the shouting crowd I made my way to the corner
+of the street, and in ten minutes was rejoiced to find my friend’s arm
+in mine, and to get away from the scene of uproar. He walked swiftly
+and in silence for some few minutes, until we had turned down one of
+the quiet streets which lead towards the Edgware Road.
+
+“You did it very nicely, doctor,” he remarked. “Nothing could have been
+better. It is all right.”
+
+“You have the photograph?”
+
+“I know where it is.”
+
+“And how did you find out?”
+
+“She showed me, as I told you that she would.”
+
+“I am still in the dark.”
+
+“I do not wish to make a mystery,” said he, laughing. “The matter was
+perfectly simple. You, of course, saw that every one in the street was
+an accomplice. They were all engaged for the evening.”
+
+“I guessed as much.”
+
+“Then, when the row broke out, I had a little moist red paint in the
+palm of my hand. I rushed forward, fell down, clapped my hand to my
+face, and became a piteous spectacle. It is an old trick.”
+
+“That also I could fathom.”
+
+“Then they carried me in. She was bound to have me in. What else could
+she do? And into her sitting-room, which was the very room which I
+suspected. It lay between that and her bedroom, and I was determined
+to see which. They laid me on a couch, I motioned for air, they were
+compelled to open the window, and you had your chance.”
+
+“How did that help you?”
+
+“It was all-important. When a woman thinks that her house is on fire,
+her instinct is at once to rush to the thing which she values most. It
+is a perfectly overpowering impulse, and I have more than once taken
+advantage of it. In the case of the Darlington Substitution Scandal it
+was of use to me, and also in the Arnsworth Castle business. A married
+woman grabs at her baby; an unmarried one reaches for her jewel-box.
+Now it was clear to me that our lady of to-day had nothing in the house
+more precious to her than what we are in quest of. She would rush to
+secure it. The alarm of fire was admirably done. The smoke and shouting
+were enough to shake nerves of steel. She responded beautifully. The
+photograph is in a recess behind a sliding panel just above the right
+bell-pull. She was there in an instant, and I caught a glimpse of it as
+she half-drew it out. When I cried out that it was a false alarm, she
+replaced it, glanced at the rocket, rushed from the room, and I have
+not seen her since. I rose, and, making my excuses, escaped from the
+house. I hesitated whether to attempt to secure the photograph at once;
+but the coachman had come in, and as he was watching me narrowly, it
+seemed safer to wait. A little over-precipitance may ruin all.”
+
+“And now?” I asked.
+
+“Our quest is practically finished. I shall call with the King
+to-morrow, and with you, if you care to come with us. We will be shown
+into the sitting-room to wait for the lady, but it is probable that
+when she comes she may find neither us nor the photograph. It might be
+a satisfaction to His Majesty to regain it with his own hands.”
+
+“And when will you call?”
+
+“At eight in the morning. She will not be up, so that we shall have a
+clear field. Besides, we must be prompt, for this marriage may mean a
+complete change in her life and habits. I must wire to the King without
+delay.”
+
+We had reached Baker Street, and had stopped at the door. He was
+searching his pockets for the key, when some one passing said:
+
+“Good-night, Mister Sherlock Holmes.”
+
+There were several people on the pavement at the time, but the greeting
+appeared to come from a slim youth in an ulster who had hurried by.
+
+“I’ve heard that voice before,” said Holmes, staring down the dimly-lit
+street. “Now, I wonder who the deuce that could have been.”
+
+
+III
+
+I slept at Baker Street that night, and we were engaged upon our toast
+and coffee in the morning when the King of Bohemia rushed into the room.
+
+“You have really got it!” he cried, grasping Sherlock Holmes by either
+shoulder, and looking eagerly into his face.
+
+“Not yet.”
+
+“But you have hopes?”
+
+“I have hopes.”
+
+“Then, come. I am all impatience to be gone.”
+
+“We must have a cab.”
+
+“No, my brougham is waiting.”
+
+“Then that will simplify matters.” We descended, and started off once
+more for Briony Lodge.
+
+“Irene Adler is married,” remarked Holmes.
+
+“Married! When?”
+
+“Yesterday.”
+
+“But to whom?”
+
+“To an English lawyer named Norton.”
+
+“But she could not love him?”
+
+“I am in hopes that she does.”
+
+“And why in hopes?”
+
+“Because it would spare your Majesty all fear of future annoyance. If
+the lady loves her husband, she does not love your Majesty. If she does
+not love your Majesty, there is no reason why she should interfere with
+your Majesty’s plan.”
+
+“It is true. And yet—Well! I wish she had been of my own station! What
+a queen she would have made!” He relapsed into a moody silence, which
+was not broken until we drew up in Serpentine Avenue.
+
+The door of Briony Lodge was open, and an elderly woman stood upon
+the steps. She watched us with a sardonic eye as we stepped from the
+brougham.
+
+“Mr. Sherlock Holmes, I believe?” said she.
+
+“I am Mr. Holmes,” answered my companion, looking at her with a
+questioning and rather startled gaze.
+
+“Indeed! My mistress told me that you were likely to call. She left
+this morning with her husband by the 5.15 train from Charing Cross for
+the Continent.”
+
+“What!” Sherlock Holmes staggered back, white with chagrin and
+surprise. “Do you mean that she has left England?”
+
+“Never to return.”
+
+“And the papers?” asked the King, hoarsely. “All is lost.”
+
+“We shall see.” He pushed past the servant and rushed into the
+drawing-room, followed by the King and myself. The furniture was
+scattered about in every direction, with dismantled shelves and open
+drawers, as if the lady had hurriedly ransacked them before her flight.
+Holmes rushed at the bell-pull, tore back a small sliding shutter,
+and, plunging in his hand, pulled out a photograph and a letter. The
+photograph was of Irene Adler herself in evening dress, the letter was
+superscribed to “Sherlock Holmes, Esq. To be left till called for.” My
+friend tore it open, and we all three read it together. It was dated at
+midnight of the preceding night, and ran in this way:
+
+  “MY DEAR MR. SHERLOCK HOLMES,—You really did it very
+  well. You took me in completely. Until after the alarm of
+  fire, I had not a suspicion. But then, when I found how I had
+  betrayed myself, I began to think. I had been warned against
+  you months ago. I had been told that, if the King employed an
+  agent, it would certainly be you. And your address had been
+  given me. Yet, with all this, you made me reveal what you
+  wanted to know. Even after I became suspicious, I found it hard
+  to think evil of such a dear, kind old clergyman. But, you
+  know, I have been trained as an actress myself. Male costume
+  is nothing new to me. I often take advantage of the freedom
+  which it gives. I sent John, the coachman, to watch you, ran
+  up-stairs, got into my walking-clothes, as I call them, and
+  came down just as you departed.
+
+  “Well, I followed you to your door, and so made sure that I was
+  really an object of interest to the celebrated Mr. Sherlock
+  Holmes. Then I, rather imprudently, wished you good-night, and
+  started for the Temple to see my husband.
+
+  “We both thought the best resource was flight, when pursued by
+  so formidable an antagonist; so you will find the nest empty
+  when you call to-morrow. As to the photograph, your client may
+  rest in peace. I love and am loved by a better man than he.
+  The King may do what he will without hinderance from one whom
+  he has cruelly wronged. I keep it only to safeguard myself,
+  and to preserve a weapon which will always secure me from any
+  steps which he might take in the future. I leave a photograph
+  which he might care to possess; and I remain, dear Mr. Sherlock
+  Holmes, very truly yours,      IRENE NORTON, _née_ ADLER.”
+
+“What a woman—oh, what a woman!” cried the King of Bohemia, when we
+had all three read this epistle. “Did I not tell you how quick and
+resolute she was? Would she not have made an admirable queen? Is it not
+a pity that she was not on my level?”
+
+“From what I have seen of the lady she seems indeed to be on a very
+different level to your Majesty,” said Holmes, coldly. “I am sorry
+that I have not been able to bring your Majesty’s business to a more
+successful conclusion.”
+
+“On the contrary, my dear sir,” cried the King; “nothing could be more
+successful. I know that her word is inviolate. The photograph is now as
+safe as if it were in the fire.”
+
+“I am glad to hear your Majesty say so.”
+
+“I am immensely indebted to you. Pray tell me in what way I can reward
+you. This ring—” He slipped an emerald snake ring from his finger and
+held it out upon the palm of his hand.
+
+“Your Majesty has something which I should value even more highly,”
+said Holmes.
+
+“You have but to name it.”
+
+“This photograph!”
+
+The King stared at him in amazement.
+
+“Irene’s photograph!” he cried. “Certainly, if you wish it.”
+
+“I thank your Majesty. Then there is no more to be done in the matter.
+I have the honor to wish you a very good-morning.” He bowed, and,
+turning away without observing the hand which the King had stretched
+out to him, he set off in my company for his chambers.
+
+       *       *       *       *       *
+
+And that was how a great scandal threatened to affect the kingdom of
+Bohemia, and how the best plans of Mr. Sherlock Holmes were beaten by
+a woman’s wit. He used to make merry over the cleverness of women, but
+I have not heard him do it of late. And when he speaks of Irene Adler,
+or when he refers to her photograph, it is always under the honorable
+title of _the_ woman.
+
+
+
+
+Adventure II
+
+THE RED-HEADED LEAGUE
+
+
+I had called upon my friend, Mr. Sherlock Holmes, one day in the autumn
+of last year, and found him in deep conversation with a very stout,
+florid-faced, elderly gentleman, with fiery red hair. With an apology
+for my intrusion, I was about to withdraw, when Holmes pulled me
+abruptly into the room and closed the door behind me.
+
+“You could not possibly have come at a better time, my dear Watson,” he
+said, cordially.
+
+“I was afraid that you were engaged.”
+
+“So I am. Very much so.”
+
+“Then I can wait in the next room.”
+
+“Not at all. This gentleman, Mr. Wilson, has been my partner and helper
+in many of my most successful cases, and I have no doubt that he will
+be of the utmost use to me in yours also.”
+
+The stout gentleman half-rose from his chair and gave a bob of
+greeting, with a quick, little, questioning glance from his small,
+fat-encircled eyes.
+
+“Try the settee,” said Holmes, relapsing into his arm-chair and putting
+his finger-tips together, as was his custom when in judicial moods. “I
+know, my dear Watson, that you share my love of all that is bizarre and
+outside the conventions and humdrum routine of every-day life. You have
+shown your relish for it by the enthusiasm which has prompted you to
+chronicle, and, if you will excuse my saying so, somewhat to embellish
+so many of my own little adventures.”
+
+“Your cases have indeed been of the greatest interest to me,” I
+observed.
+
+“You will remember that I remarked the other day, just before we went
+into the very simple problem presented by Miss Mary Sutherland, that
+for strange effects and extraordinary combinations we must go to
+life itself, which is always far more daring than any effort of the
+imagination.”
+
+“A proposition which I took the liberty of doubting.”
+
+“You did, doctor, but none the less you must come round to my view,
+for otherwise I shall keep on piling fact upon fact on you, until your
+reason breaks down under them and acknowledges me to be right. Now, Mr.
+Jabez Wilson here has been good enough to call upon me this morning,
+and to begin a narrative which promises to be one of the most singular
+which I have listened to for some time. You have heard me remark that
+the strangest and most unique things are very often connected not with
+the larger but with the smaller crimes, and occasionally, indeed, where
+there is room for doubt whether any positive crime has been committed.
+As far as I have heard it is impossible for me to say whether the
+present case is an instance of crime or not, but the course of events
+is certainly among the most singular that I have ever listened to.
+Perhaps, Mr. Wilson, you would have the great kindness to recommence
+your narrative. I ask you, not merely because my friend Dr. Watson has
+not heard the opening part, but also because the peculiar nature of the
+story makes me anxious to have every possible detail from your lips.
+As a rule, when I have heard some slight indication of the course of
+events, I am able to guide myself by the thousands of other similar
+cases which occur to my memory. In the present instance I am forced to
+admit that the facts are, to the best of my belief, unique.”
+
+The portly client puffed out his chest with an appearance of some
+little pride, and pulled a dirty and wrinkled newspaper from the inside
+pocket of his great-coat. As he glanced down the advertisement column,
+with his head thrust forward, and the paper flattened out upon his
+knee, I took a good look at the man, and endeavored, after the fashion
+of my companion, to read the indications which might be presented by
+his dress or appearance.
+
+I did not gain very much, however, by my inspection. Our visitor bore
+every mark of being an average commonplace British tradesman, obese,
+pompous, and slow. He wore rather baggy gray shepherd’s check trousers,
+a not over-clean black frock-coat, unbuttoned in the front, and a drab
+waistcoat with a heavy brassy Albert chain, and a square pierced bit of
+metal dangling down as an ornament. A frayed top-hat and a faded brown
+overcoat with a wrinkled velvet collar lay upon a chair beside him.
+Altogether, look as I would, there was nothing remarkable about the man
+save his blazing red head, and the expression of extreme chagrin and
+discontent upon his features.
+
+Sherlock Holmes’s quick eye took in my occupation, and he shook his
+head with a smile as he noticed my questioning glances. “Beyond the
+obvious facts that he has at some time done manual labor, that he takes
+snuff, that he is a Freemason, that he has been in China, and that he
+has done a considerable amount of writing lately, I can deduce nothing
+else.”
+
+Mr. Jabez Wilson started up in his chair, with his forefinger upon the
+paper, but his eyes upon my companion.
+
+“How, in the name of good-fortune, did you know all that, Mr. Holmes?”
+he asked. “How did you know, for example, that I did manual labor. It’s
+as true as gospel, for I began as a ship’s carpenter.”
+
+“Your hands, my dear sir. Your right hand is quite a size larger than
+your left. You have worked with it, and the muscles are more developed.”
+
+“Well, the snuff, then, and the Freemasonry?”
+
+“I won’t insult your intelligence by telling you how I read that,
+especially as, rather against the strict rules of your order, you use
+an arc-and-compass breastpin.”
+
+“Ah, of course, I forgot that. But the writing?”
+
+“What else can be indicated by that right cuff so very shiny for five
+inches, and the left one with the smooth patch near the elbow where you
+rest it upon the desk.”
+
+“Well, but China?”
+
+“The fish that you have tattooed immediately above your right wrist
+could only have been done in China. I have made a small study of tattoo
+marks, and have even contributed to the literature of the subject.
+That trick of staining the fishes’ scales of a delicate pink is quite
+peculiar to China. When, in addition, I see a Chinese coin hanging from
+your watch-chain, the matter becomes even more simple.”
+
+Mr. Jabez Wilson laughed heavily. “Well, I never!” said he. “I thought
+at first that you had done something clever, but I see that there was
+nothing in it, after all.”
+
+“I begin to think, Watson,” said Holmes, “that I make a mistake in
+explaining. ‘Omne ignotum pro magnifico,’ you know, and my poor little
+reputation, such as it is, will suffer shipwreck if I am so candid. Can
+you not find the advertisement, Mr. Wilson?”
+
+“Yes, I have got it now,” he answered, with his thick, red finger
+planted half-way down the column. “Here it is. This is what began it
+all. You just read it for yourself, sir.”
+
+I took the paper from him, and read as follows:
+
+  “TO THE RED-HEADED LEAGUE: On account of the bequest of the
+  late Ezekiah Hopkins, of Lebanon, Pa., U.S.A., there is now
+  another vacancy open which entitles a member of the League
+  to a salary of £4 a week for purely nominal services. All
+  red-headed men who are sound in body and mind, and above
+  the age of twenty-one years, are eligible. Apply in person on
+  Monday, at eleven o’clock, to Duncan Ross, at the offices of
+  the League, 7 Pope’s Court, Fleet Street.”
+
+“What on earth does this mean?” I ejaculated, after I had twice read
+over the extraordinary announcement.
+
+Holmes chuckled, and wriggled in his chair, as was his habit when in
+high spirits. “It is a little off the beaten track, isn’t it?” said
+he. “And now, Mr. Wilson, off you go at scratch, and tell us all about
+yourself, your household, and the effect which this advertisement had
+upon your fortunes. You will first make a note, doctor, of the paper
+and the date.”
+
+“It is _The Morning Chronicle_, of April 27, 1890. Just two months ago.”
+
+“Very good. Now, Mr. Wilson?”
+
+“Well, it is just as I have been telling you, Mr. Sherlock Holmes,”
+said Jabez Wilson, mopping his forehead; “I have a small pawnbroker’s
+business at Coburg Square, near the city. It’s not a very large affair,
+and of late years it has not done more than just give me a living. I
+used to be able to keep two assistants, but now I only keep one; and I
+would have a job to pay him, but that he is willing to come for half
+wages, so as to learn the business.”
+
+“What is the name of this obliging youth?” asked Sherlock Holmes.
+
+“His name is Vincent Spaulding, and he’s not such a youth, either. It’s
+hard to say his age. I should not wish a smarter assistant, Mr. Holmes;
+and I know very well that he could better himself, and earn twice what
+I am able to give him. But, after all, if he is satisfied, why should I
+put ideas in his head?”
+
+“Why, indeed? You seem most fortunate in having an _employé_ who
+comes under the full market price. It is not a common experience among
+employers in this age. I don’t know that your assistant is not as
+remarkable as your advertisement.”
+
+“Oh, he has his faults, too,” said Mr. Wilson. “Never was such a fellow
+for photography. Snapping away with a camera when he ought to be
+improving his mind, and then diving down into the cellar like a rabbit
+into its hole to develope his pictures. That is his main fault; but, on
+the whole, he’s a good worker. There’s no vice in him.”
+
+“He is still with you, I presume?”
+
+“Yes, sir. He and a girl of fourteen, who does a bit of simple cooking,
+and keeps the place clean—that’s all I have in the house, for I am a
+widower, and never had any family. We live very quietly, sir, the three
+of us; and we keep a roof over our heads, and pay our debts, if we do
+nothing more.
+
+“The first thing that put us out was that advertisement. Spaulding, he
+came down into the office just this day eight weeks, with this very
+paper in his hand, and he says:
+
+“‘I wish to the Lord, Mr. Wilson, that I was a red-headed man.’
+
+“‘Why that?’ I asks.
+
+“‘Why,’ says he, ‘here’s another vacancy on the League of the
+Red-headed Men. It’s worth quite a little fortune to any man who gets
+it, and I understand that there are more vacancies than there are men,
+so that the trustees are at their wits’ end what to do with the money.
+If my hair would only change color, here’s a nice little crib all ready
+for me to step into.’
+
+“‘Why, what is it, then?’ I asked. You see, Mr. Holmes, I am a very
+stay-at-home man, and as my business came to me instead of my having
+to go to it, I was often weeks on end without putting my foot over the
+door-mat. In that way I didn’t know much of what was going on outside,
+and I was always glad of a bit of news.
+
+“‘Have you never heard of the League of the Red-headed Men?’ he asked,
+with his eyes open.
+
+“‘Never.’
+
+“‘Why, I wonder at that, for you are eligible yourself for one of the
+vacancies.’
+
+“‘And what are they worth?’ I asked.
+
+“‘Oh, merely a couple of hundred a year, but the work is slight, and it
+need not interfere very much with one’s other occupations.’
+
+“Well, you can easily think that that made me prick up my ears, for the
+business has not been over-good for some years, and an extra couple of
+hundred would have been very handy.
+
+“‘Tell me all about it,’ said I.
+
+“‘Well,’ said he, showing me the advertisement, ‘you can see for
+yourself that the League has a vacancy, and there is the address
+where you should apply for particulars. As far as I can make out, the
+League was founded by an American millionaire, Ezekiah Hopkins, who
+was very peculiar in his ways. He was himself red-headed, and he had a
+great sympathy for all red-headed men; so, when he died, it was found
+that he had left his enormous fortune in the hands of trustees, with
+instructions to apply the interest to the providing of easy berths to
+men whose hair is of that color. From all I hear it is splendid pay,
+and very little to do.’
+
+“‘But,’ said I, ‘there would be millions of red-headed men who would
+apply.’
+
+“‘Not so many as you might think,’ he answered. ‘You see it is really
+confined to Londoners, and to grown men. This American had started from
+London when he was young, and he wanted to do the old town a good turn.
+Then, again, I have heard it is no use your applying if your hair is
+light red, or dark red, or anything but real bright, blazing, fiery
+red. Now, if you cared to apply, Mr. Wilson, you would just walk in;
+but perhaps it would hardly be worth your while to put yourself out of
+the way for the sake of a few hundred pounds.’
+
+“Now, it is a fact, gentlemen, as you may see for yourselves, that my
+hair is of a very full and rich tint, so that it seemed to me that, if
+there was to be any competition in the matter, I stood as good a chance
+as any man that I had ever met. Vincent Spaulding seemed to know so
+much about it that I thought he might prove useful, so I just ordered
+him to put up the shutters for the day, and to come right away with me.
+He was very willing to have a holiday, so we shut the business up, and
+started off for the address that was given us in the advertisement.
+
+“I never hope to see such a sight as that again, Mr. Holmes. From
+north, south, east, and west every man who had a shade of red in his
+hair had tramped into the city to answer the advertisement. Fleet
+Street was choked with red-headed folk, and Pope’s Court looked
+like a coster’s orange barrow. I should not have thought there were
+so many in the whole country as were brought together by that single
+advertisement. Every shade of color they were—straw, lemon, orange,
+brick, Irish-setter, liver, clay; but, as Spaulding said, there were
+not many who had the real vivid flame-colored tint. When I saw how many
+were waiting, I would have given it up in despair; but Spaulding would
+not hear of it. How he did it I could not imagine, but he pushed and
+pulled and butted until he got me through the crowd, and right up to
+the steps which led to the office. There was a double stream upon the
+stair, some going up in hope, and some coming back dejected; but we
+wedged in as well as we could, and soon found ourselves in the office.”
+
+“Your experience has been a most entertaining one,” remarked Holmes, as
+his client paused and refreshed his memory with a huge pinch of snuff.
+“Pray continue your very interesting statement.”
+
+“There was nothing in the office but a couple of wooden chairs and a
+deal table, behind which sat a small man, with a head that was even
+redder than mine. He said a few words to each candidate as he came
+up, and then he always managed to find some fault in them which would
+disqualify them. Getting a vacancy did not seem to be such a very easy
+matter, after all. However, when our turn came, the little man was much
+more favorable to me than to any of the others, and he closed the door
+as we entered, so that he might have a private word with us.
+
+“‘This is Mr. Jabez Wilson,’ said my assistant, ‘and he is willing to
+fill a vacancy in the League.’
+
+“‘And he is admirably suited for it,’ the other answered. ‘He has every
+requirement. I cannot recall when I have seen anything so fine.’ He
+took a step backward, cocked his head on one side, and gazed at my hair
+until I felt quite bashful. Then suddenly he plunged forward, wrung my
+hand, and congratulated me warmly on my success.
+
+“‘It would be injustice to hesitate,’ said he. ‘You will, however, I am
+sure, excuse me for taking an obvious precaution.’ With that he seized
+my hair in both his hands, and tugged until I yelled with the pain.
+‘There is water in your eyes,’ said he, as he released me. ‘I perceive
+that all is as it should be. But we have to be careful, for we have
+twice been deceived by wigs and once by paint. I could tell you tales
+of cobbler’s wax which would disgust you with human nature.’ He stepped
+over to the window, and shouted through it at the top of his voice that
+the vacancy was filled. A groan of disappointment came up from below,
+and the folk all trooped away in different directions, until there was
+not a red head to be seen except my own and that of the manager.
+
+“‘My name,’ said he, ‘is Mr. Duncan Ross, and I am myself one of the
+pensioners upon the fund left by our noble benefactor. Are you a
+married man, Mr. Wilson? Have you a family?’
+
+“I answered that I had not.
+
+“His face fell immediately.
+
+“‘Dear me!’ he said, gravely, ‘that is very serious indeed! I am sorry
+to hear you say that. The fund was, of course, for the propagation
+and spread of the red-heads as well as for their maintenance. It is
+exceedingly unfortunate that you should be a bachelor.’
+
+“My face lengthened at this, Mr. Holmes, for I thought that I was not
+to have the vacancy after all; but, after thinking it over for a few
+minutes, he said that it would be all right.
+
+“‘In the case of another,’ said he, ‘the objection might be fatal, but
+we must stretch a point in favor of a man with such a head of hair as
+yours. When shall you be able to enter upon your new duties?’
+
+“‘Well, it is a little awkward, for I have a business already,’ said I.
+
+“‘Oh, never mind about that, Mr. Wilson!’ said Vincent Spaulding. ‘I
+shall be able to look after that for you.’
+
+“‘What would be the hours?’ I asked.
+
+“‘Ten to two.’
+
+“Now a pawnbroker’s business is mostly done of an evening, Mr. Holmes,
+especially Thursday and Friday evening, which is just before pay-day;
+so it would suit me very well to earn a little in the mornings.
+Besides, I knew that my assistant was a good man, and that he would see
+to anything that turned up.
+
+“‘That would suit me very well,’ said I. ‘And the pay?’
+
+“‘Is £4 a week.’
+
+“‘And the work?’
+
+“‘Is purely nominal.’
+
+“‘What do you call purely nominal?’
+
+“‘Well, you have to be in the office, or at least in the building, the
+whole time. If you leave, you forfeit your whole position forever.
+The will is very clear upon that point. You don’t comply with the
+conditions if you budge from the office during that time.’
+
+“‘It’s only four hours a day, and I should not think of leaving,’ said
+I.
+
+“‘No excuse will avail,’ said Mr. Duncan Ross, ‘neither sickness nor
+business nor anything else. There you must stay, or you lose your
+billet.’
+
+“‘And the work?’
+
+“‘Is to copy out the “Encyclopædia Britannica.” There is the first
+volume of it in that press. You must find your own ink, pens, and
+blotting-paper, but we provide this table and chair. Will you be ready
+to-morrow?’
+
+“‘Certainly,’ I answered.
+
+“‘Then, good-bye, Mr. Jabez Wilson, and let me congratulate you once
+more on the important position which you have been fortunate enough to
+gain.’ He bowed me out of the room, and I went home with my assistant,
+hardly knowing what to say or do, I was so pleased at my own good
+fortune.
+
+“Well, I thought over the matter all day, and by evening I was in
+low spirits again; for I had quite persuaded myself that the whole
+affair must be some great hoax or fraud, though what its object might
+be I could not imagine. It seemed altogether past belief that any one
+could make such a will, or that they would pay such a sum for doing
+anything so simple as copying out the ‘Encyclopædia Britannica.’
+Vincent Spaulding did what he could to cheer me up, but by bedtime I
+had reasoned myself out of the whole thing. However, in the morning
+I determined to have a look at it anyhow, so I bought a penny bottle
+of ink, and with a quill-pen, and seven sheets of foolscap paper, I
+started off for Pope’s Court.
+
+“Well, to my surprise and delight, everything was as right as possible.
+The table was set out ready for me, and Mr. Duncan Ross was there to
+see that I got fairly to work. He started me off upon the letter A, and
+then he left me; but he would drop in from time to time to see that all
+was right with me. At two o’clock he bade me good-day, complimented me
+upon the amount that I had written, and locked the door of the office
+after me.
+
+“This went on day after day, Mr. Holmes, and on Saturday the manager
+came in and planked down four golden sovereigns for my week’s work.
+It was the same next week, and the same the week after. Every morning
+I was there at ten, and every afternoon I left at two. By degrees Mr.
+Duncan Ross took to coming in only once of a morning, and then, after
+a time, he did not come in at all. Still, of course, I never dared to
+leave the room for an instant, for I was not sure when he might come,
+and the billet was such a good one, and suited me so well, that I would
+not risk the loss of it.
+
+“Eight weeks passed away like this, and I had written about Abbots and
+Archery and Armor and Architecture and Attica, and hoped with diligence
+that I might get on to the B’s before very long. It cost me something
+in foolscap, and I had pretty nearly filled a shelf with my writings.
+And then suddenly the whole business came to an end.”
+
+“To an end?”
+
+“Yes, sir. And no later than this morning. I went to my work as usual
+at ten o’clock, but the door was shut and locked, with a little square
+of card-board hammered on to the middle of the panel with a tack. Here
+it is, and you can read for yourself.”
+
+He held up a piece of white card-board about the size of a sheet of
+note-paper. It read in this fashion:
+
+  “THE RED-HEADED LEAGUE
+   IS
+   DISSOLVED.
+   _October 9, 1890._”
+
+Sherlock Holmes and I surveyed this curt announcement and the rueful
+face behind it, until the comical side of the affair so completely
+overtopped every other consideration that we both burst out into a roar
+of laughter.
+
+“I cannot see that there is anything very funny,” cried our client,
+flushing up to the roots of his flaming head. “If you can do nothing
+better than laugh at me, I can go elsewhere.”
+
+“No, no,” cried Holmes, shoving him back into the chair from which he
+had half risen. “I really wouldn’t miss your case for the world. It is
+most refreshingly unusual. But there is, if you will excuse my saying
+so, something just a little funny about it. Pray what steps did you
+take when you found the card upon the door?”
+
+“I was staggered, sir. I did not know what to do. Then I called at
+the offices round, but none of them seemed to know anything about it.
+Finally, I went to the landlord, who is an accountant living on the
+ground-floor, and I asked him if he could tell me what had become of
+the Red-headed League. He said that he had never heard of any such
+body. Then I asked him who Mr. Duncan Ross was. He answered that the
+name was new to him.
+
+[Illustration: “THE DOOR WAS SHUT AND LOCKED”]
+
+“‘Well,’ said I, ‘the gentleman at No. 4.’
+
+“‘What, the red-headed man?’
+
+“‘Yes.’
+
+“‘Oh,’ said he, ‘his name was William Morris. He was a solicitor, and
+was using my room as a temporary convenience until his new premises
+were ready. He moved out yesterday.’
+
+“‘Where could I find him?’
+
+“‘Oh, at his new offices. He did tell me the address. Yes, 17 King
+Edward Street, near St. Paul’s.’
+
+“I started off, Mr. Holmes, but when I got to that address it was a
+manufactory of artificial knee-caps, and no one in it had ever heard of
+either Mr. William Morris or Mr. Duncan Ross.”
+
+“And what did you do then?” asked Holmes.
+
+“I went home to Saxe-Coburg Square, and I took the advice of my
+assistant. But he could not help me in any way. He could only say that
+if I waited I should hear by post. But that was not quite good enough,
+Mr. Holmes. I did not wish to lose such a place without a struggle, so,
+as I had heard that you were good enough to give advice to poor folk
+who were in need of it, I came right away to you.”
+
+“And you did very wisely,” said Holmes. “Your case is an exceedingly
+remarkable one, and I shall be happy to look into it. From what you
+have told me I think that it is possible that graver issues hang from
+it than might at first sight appear.”
+
+“Grave enough!” said Mr. Jabez Wilson. “Why, I have lost four pound a
+week.”
+
+“As far as you are personally concerned,” remarked Holmes, “I do not
+see that you have any grievance against this extraordinary league. On
+the contrary, you are, as I understand, richer by some £30, to say
+nothing of the minute knowledge which you have gained on every subject
+which comes under the letter A. You have lost nothing by them.”
+
+“No, sir. But I want to find out about them, and who they are, and what
+their object was in playing this prank—if it was a prank—upon me. It
+was a pretty expensive joke for them, for it cost them two and thirty
+pounds.”
+
+“We shall endeavor to clear up these points for you. And, first, one
+or two questions, Mr. Wilson. This assistant of yours who first called
+your attention to the advertisement—how long had he been with you?”
+
+“About a month then.”
+
+“How did he come?”
+
+“In answer to an advertisement.”
+
+“Was he the only applicant?”
+
+“No, I had a dozen.”
+
+“Why did you pick him?”
+
+“Because he was handy, and would come cheap.”
+
+“At half-wages, in fact.”
+
+“Yes.”
+
+“What is he like, this Vincent Spaulding?”
+
+“Small, stout-built, very quick in his ways, no hair on his face,
+though he’s not short of thirty. Has a white splash of acid upon his
+forehead.”
+
+Holmes sat up in his chair in considerable excitement. “I thought as
+much,” said he. “Have you ever observed that his ears are pierced for
+earrings?”
+
+“Yes, sir. He told me that a gypsy had done it for him when he was a
+lad.”
+
+“Hum!” said Holmes, sinking back in deep thought. “He is still with
+you?”
+
+“Oh yes, sir; I have only just left him.”
+
+“And has your business been attended to in your absence?”
+
+“Nothing to complain of, sir. There’s never very much to do of a
+morning.”
+
+“That will do, Mr. Wilson. I shall be happy to give you an opinion upon
+the subject in the course of a day or two. To-day is Saturday, and I
+hope that by Monday we may come to a conclusion.”
+
+“Well, Watson,” said Holmes, when our visitor had left us, “what do you
+make of it all?”
+
+“I make nothing of it,” I answered, frankly. “It is a most mysterious
+business.”
+
+“As a rule,” said Holmes, “the more bizarre a thing is the less
+mysterious it proves to be. It is your commonplace, featureless crimes
+which are really puzzling, just as a commonplace face is the most
+difficult to identify. But I must be prompt over this matter.”
+
+“What are you going to do, then?” I asked.
+
+“To smoke,” he answered. “It is quite a three-pipe problem, and I beg
+that you won’t speak to me for fifty minutes.” He curled himself up
+in his chair, with his thin knees drawn up to his hawk-like nose, and
+there he sat with his eyes closed and his black clay pipe thrusting out
+like the bill of some strange bird. I had come to the conclusion that
+he had dropped asleep, and indeed was nodding myself, when he suddenly
+sprang out of his chair with the gesture of a man who has made up his
+mind, and put his pipe down upon the mantel-piece.
+
+“Sarasate plays at the St. James’s Hall this afternoon,” he remarked.
+“What do you think, Watson? Could your patients spare you for a few
+hours?”
+
+“I have nothing to do to-day. My practice is never very absorbing.”
+
+“Then put on your hat and come. I am going through the city first, and
+we can have some lunch on the way. I observe that there is a good deal
+of German music on the programme, which is rather more to my taste than
+Italian or French. It is introspective, and I want to introspect. Come
+along!”
+
+We travelled by the Underground as far as Aldersgate; and a short walk
+took us to Saxe-Coburg Square, the scene of the singular story which we
+had listened to in the morning. It was a pokey, little, shabby-genteel
+place, where four lines of dingy two-storied brick houses looked out
+into a small railed-in enclosure, where a lawn of weedy grass and
+a few clumps of faded laurel-bushes made a hard fight against a
+smoke-laden and uncongenial atmosphere. Three gilt balls and a brown
+board with “JABEZ WILSON” in white letters, upon a corner
+house, announced the place where our red-headed client carried on his
+business. Sherlock Holmes stopped in front of it with his head on one
+side, and looked it all over, with his eyes shining brightly between
+puckered lids. Then he walked slowly up the street, and then down again
+to the corner, still looking keenly at the houses. Finally he returned
+to the pawnbroker’s, and, having thumped vigorously upon the pavement
+with his stick two or three times, he went up to the door and knocked.
+It was instantly opened by a bright-looking, clean-shaven young fellow,
+who asked him to step in.
+
+“Thank you,” said Holmes, “I only wished to ask you how you would go
+from here to the Strand.”
+
+“Third right, fourth left,” answered the assistant, promptly, closing
+the door.
+
+“Smart fellow, that,” observed Holmes, as we walked away. “He is, in my
+judgment, the fourth smartest man in London, and for daring I am not
+sure that he has not a claim to be third. I have known something of him
+before.”
+
+“Evidently,” said I, “Mr. Wilson’s assistant counts for a good deal in
+this mystery of the Red-headed League. I am sure that you inquired your
+way merely in order that you might see him.”
+
+“Not him.”
+
+“What then?”
+
+“The knees of his trousers.”
+
+“And what did you see?”
+
+“What I expected to see.”
+
+“Why did you beat the pavement?”
+
+“My dear doctor, this is a time for observation, not for talk. We are
+spies in an enemy’s country. We know something of Saxe-Coburg Square.
+Let us now explore the parts which lie behind it.”
+
+The road in which we found ourselves as we turned round the corner
+from the retired Saxe-Coburg Square presented as great a contrast to
+it as the front of a picture does to the back. It was one of the main
+arteries which convey the traffic of the city to the north and west.
+The roadway was blocked with the immense stream of commerce flowing
+in a double tide inward and outward, while the foot-paths were black
+with the hurrying swarm of pedestrians. It was difficult to realize
+as we looked at the line of fine shops and stately business premises
+that they really abutted on the other side upon the faded and stagnant
+square which we had just quitted.
+
+“Let me see,” said Holmes, standing at the corner, and glancing along
+the line, “I should like just to remember the order of the houses here.
+It is a hobby of mine to have an exact knowledge of London. There is
+Mortimer’s, the tobacconist, the little newspaper shop, the Coburg
+branch of the City and Suburban Bank, the Vegetarian Restaurant, and
+McFarlane’s carriage-building depot. That carries us right on to the
+other block. And now, doctor, we’ve done our work, so it’s time we had
+some play. A sandwich and a cup of coffee, and then off to violin-land,
+where all is sweetness and delicacy and harmony, and there are no
+red-headed clients to vex us with their conundrums.”
+
+My friend was an enthusiastic musician, being himself not only a
+very capable performer, but a composer of no ordinary merit. All the
+afternoon he sat in the stalls wrapped in the most perfect happiness,
+gently waving his long, thin fingers in time to the music, while his
+gently smiling face and his languid, dreamy eyes were as unlike those
+of Holmes, the sleuth-hound, Holmes the relentless, keen-witted,
+ready-handed criminal agent, as it was possible to conceive. In his
+singular character the dual nature alternately asserted itself, and
+his extreme exactness and astuteness represented, as I have often
+thought, the reaction against the poetic and contemplative mood which
+occasionally predominated in him. The swing of his nature took him from
+extreme languor to devouring energy; and, as I knew well, he was never
+so truly formidable as when, for days on end, he had been lounging in
+his arm-chair amid his improvisations and his black-letter editions.
+Then it was that the lust of the chase would suddenly come upon him,
+and that his brilliant reasoning power would rise to the level of
+intuition, until those who were unacquainted with his methods would
+look askance at him as on a man whose knowledge was not that of other
+mortals. When I saw him that afternoon so enrapt in the music at St.
+James’s Hall I felt that an evil time might be coming upon those whom
+he had set himself to hunt down.
+
+“You want to go home, no doubt, doctor,” he remarked, as we emerged.
+
+“Yes, it would be as well.”
+
+“And I have some business to do which will take some hours. This
+business at Coburg Square is serious.”
+
+“Why serious?”
+
+“A considerable crime is in contemplation. I have every reason to
+believe that we shall be in time to stop it. But to-day being Saturday
+rather complicates matters. I shall want your help to-night.”
+
+“At what time?”
+
+“Ten will be early enough.”
+
+“I shall be at Baker Street at ten.”
+
+“Very well. And, I say, doctor, there may be some little danger, so
+kindly put your army revolver in your pocket.” He waved his hand,
+turned on his heel, and disappeared in an instant among the crowd.
+
+[Illustration: “ALL AFTERNOON HE SAT IN THE STALLS”]
+
+I trust that I am not more dense than my neighbors, but I was always
+oppressed with a sense of my own stupidity in my dealings with Sherlock
+Holmes. Here I had heard what he had heard, I had seen what he had
+seen, and yet from his words it was evident that he saw clearly not
+only what had happened, but what was about to happen, while to me the
+whole business was still confused and grotesque. As I drove home to
+my house in Kensington I thought over it all, from the extraordinary
+story of the red-headed copier of the “Encyclopædia” down to the visit
+to Saxe-Coburg Square, and the ominous words with which he had parted
+from me. What was this nocturnal expedition, and why should I go armed?
+Where were we going, and what were we to do? I had the hint from Holmes
+that this smooth-faced pawnbroker’s assistant was a formidable man—a
+man who might play a deep game. I tried to puzzle it out, but gave it
+up in despair, and set the matter aside until night should bring an
+explanation.
+
+It was a quarter past nine when I started from home and made my way
+across the Park, and so through Oxford Street to Baker Street. Two
+hansoms were standing at the door, and, as I entered the passage, I
+heard the sound of voices from above. On entering his room I found
+Holmes in animated conversation with two men, one of whom I recognized
+as Peter Jones, the official police agent, while the other was a long,
+thin, sad-faced man, with a very shiny hat and oppressively respectable
+frock-coat.
+
+“Ha! our party is complete,” said Holmes, buttoning up his pea-jacket,
+and taking his heavy hunting crop from the rack. “Watson, I think
+you know Mr. Jones, of Scotland Yard? Let me introduce you to Mr.
+Merryweather, who is to be our companion in to-night’s adventure.”
+
+“We’re hunting in couples again, doctor, you see,” said Jones, in his
+consequential way. “Our friend here is a wonderful man for starting a
+chase. All he wants is an old dog to help him to do the running down.”
+
+“I hope a wild goose may not prove to be the end of our chase,”
+observed Mr. Merryweather, gloomily.
+
+“You may place considerable confidence in Mr. Holmes, sir,” said the
+police agent, loftily. “He has his own little methods, which are, if he
+won’t mind my saying so, just a little too theoretical and fantastic,
+but he has the makings of a detective in him. It is not too much to
+say that once or twice, as in that business of the Sholto murder and
+the Agra treasure, he has been more nearly correct than the official
+force.”
+
+“Oh, if you say so, Mr. Jones, it is all right,” said the stranger,
+with deference. “Still, I confess that I miss my rubber. It is the
+first Saturday night for seven-and-twenty years that I have not had my
+rubber.”
+
+“I think you will find,” said Sherlock Holmes, “that you will play for
+a higher stake to-night than you have ever done yet, and that the play
+will be more exciting. For you, Mr. Merryweather, the stake will be
+some £30,000; and for you, Jones, it will be the man upon whom you wish
+to lay your hands.”
+
+“John Clay, the murderer, thief, smasher, and forger. He’s a young man,
+Mr. Merryweather, but he is at the head of his profession, and I would
+rather have my bracelets on him than on any criminal in London. He’s a
+remarkable man, is young John Clay. His grandfather was a royal duke,
+and he himself has been to Eton and Oxford. His brain is as cunning as
+his fingers, and though we meet signs of him at every turn, we never
+know where to find the man himself. He’ll crack a crib in Scotland one
+week, and be raising money to build an orphanage in Cornwall the next.
+I’ve been on his track for years, and have never set eyes on him yet.”
+
+“I hope that I may have the pleasure of introducing you to-night. I’ve
+had one or two little turns also with Mr. John Clay, and I agree with
+you that he is at the head of his profession. It is past ten, however,
+and quite time that we started. If you two will take the first hansom,
+Watson and I will follow in the second.”
+
+Sherlock Holmes was not very communicative during the long drive,
+and lay back in the cab humming the tunes which he had heard in the
+afternoon. We rattled through an endless labyrinth of gas-lit streets
+until we emerged into Farringdon Street.
+
+“We are close there now,” my friend remarked. “This fellow Merryweather
+is a bank director, and personally interested in the matter. I thought
+it as well to have Jones with us also. He is not a bad fellow, though
+an absolute imbecile in his profession. He has one positive virtue. He
+is as brave as a bull-dog, and as tenacious as a lobster if he gets his
+claws upon any one. Here we are, and they are waiting for us.”
+
+We had reached the same crowded thoroughfare in which we had found
+ourselves in the morning. Our cabs were dismissed, and, following
+the guidance of Mr. Merryweather, we passed down a narrow passage
+and through a side door, which he opened for us. Within there was a
+small corridor, which ended in a very massive iron gate. This also was
+opened, and led down a flight of winding stone steps, which terminated
+at another formidable gate. Mr. Merryweather stopped to light a
+lantern, and then conducted us down a dark, earth-smelling passage, and
+so, after opening a third door, into a huge vault or cellar, which was
+piled all round with crates and massive boxes.
+
+“You are not very vulnerable from above,” Holmes remarked, as he held
+up the lantern and gazed about him.
+
+“Nor from below,” said Mr. Merryweather, striking his stick upon the
+flags which lined the floor. “Why, dear me, it sounds quite hollow!” he
+remarked, looking up in surprise.
+
+“I must really ask you to be a little more quiet,” said Holmes,
+severely. “You have already imperilled the whole success of our
+expedition. Might I beg that you would have the goodness to sit down
+upon one of those boxes, and not to interfere?”
+
+The solemn Mr. Merryweather perched himself upon a crate, with a very
+injured expression upon his face, while Holmes fell upon his knees
+upon the floor, and, with the lantern and a magnifying lens, began to
+examine minutely the cracks between the stones. A few seconds sufficed
+to satisfy him, for he sprang to his feet again, and put his glass in
+his pocket.
+
+“We have at least an hour before us,” he remarked; “for they can
+hardly take any steps until the good pawnbroker is safely in bed.
+Then they will not lose a minute, for the sooner they do their work
+the longer time they will have for their escape. We are at present,
+doctor—as no doubt you have divined—in the cellar of the city branch
+of one of the principal London banks. Mr. Merryweather is the chairman
+of directors, and he will explain to you that there are reasons why the
+more daring criminals of London should take a considerable interest in
+this cellar at present.”
+
+“It is our French gold,” whispered the director. “We have had several
+warnings that an attempt might be made upon it.”
+
+“Your French gold?”
+
+“Yes. We had occasion some months ago to strengthen our resources, and
+borrowed, for that purpose, 30,000 napoleons from the Bank of France.
+It has become known that we have never had occasion to unpack the
+money, and that it is still lying in our cellar. The crate upon which
+I sit contains 2000 napoleons packed between layers of lead foil. Our
+reserve of bullion is much larger at present than is usually kept in a
+single branch office, and the directors have had misgivings upon the
+subject.”
+
+“Which were very well justified,” observed Holmes. “And now it is time
+that we arranged our little plans. I expect that within an hour matters
+will come to a head. In the mean time, Mr. Merryweather, we must put
+the screen over that dark lantern.”
+
+“And sit in the dark?”
+
+“I am afraid so. I had brought a pack of cards in my pocket, and I
+thought that, as we were a _partie carrée_, you might have your rubber
+after all. But I see that the enemy’s preparations have gone so far
+that we cannot risk the presence of a light. And, first of all, we must
+choose our positions. These are daring men, and though we shall take
+them at a disadvantage, they may do us some harm unless we are careful.
+I shall stand behind this crate, and do you conceal yourselves behind
+those. Then, when I flash a light upon them, close in swiftly. If they
+fire, Watson, have no compunction about shooting them down.”
+
+I placed my revolver, cocked, upon the top of the wooden case behind
+which I crouched. Holmes shot the slide across the front of his
+lantern, and left us in pitch darkness—such an absolute darkness
+as I have never before experienced. The smell of hot metal remained
+to assure us that the light was still there, ready to flash out at
+a moment’s notice. To me, with my nerves worked up to a pitch of
+expectancy, there was something depressing and subduing in the sudden
+gloom, and in the cold, dank air of the vault.
+
+“They have but one retreat,” whispered Holmes. “That is back through
+the house into Saxe-Coburg Square. I hope that you have done what I
+asked you, Jones?”
+
+“I have an inspector and two officers waiting at the front door.”
+
+“Then we have stopped all the holes. And now we must be silent and
+wait.”
+
+What a time it seemed! From comparing notes afterwards it was but an
+hour and a quarter, yet it appeared to me that the night must have
+almost gone, and the dawn be breaking above us. My limbs were weary and
+stiff, for I feared to change my position; yet my nerves were worked
+up to the highest pitch of tension, and my hearing was so acute that I
+could not only hear the gentle breathing of my companions, but I could
+distinguish the deeper, heavier in-breath of the bulky Jones from the
+thin, sighing note of the bank director. From my position I could look
+over the case in the direction of the floor. Suddenly my eyes caught
+the glint of a light.
+
+At first it was but a lurid spark upon the stone pavement. Then it
+lengthened out until it became a yellow line, and then, without any
+warning or sound, a gash seemed to open and a hand appeared; a white,
+almost womanly hand, which felt about in the centre of the little area
+of light. For a minute or more the hand, with its writhing fingers,
+protruded out of the floor. Then it was withdrawn as suddenly as it
+appeared, and all was dark again save the single lurid spark which
+marked a chink between the stones.
+
+Its disappearance, however, was but momentary. With a rending, tearing
+sound, one of the broad, white stones turned over upon its side, and
+left a square, gaping hole, through which streamed the light of a
+lantern. Over the edge there peeped a clean-cut, boyish face, which
+looked keenly about it, and then, with a hand on either side of the
+aperture, drew itself shoulder-high and waist-high, until one knee
+rested upon the edge. In another instant he stood at the side of the
+hole, and was hauling after him a companion, lithe and small like
+himself, with a pale face and a shock of very red hair.
+
+“It’s all clear,” he whispered. “Have you the chisel and the bags.
+Great Scott! Jump, Archie, jump, and I’ll swing for it!”
+
+Sherlock Holmes had sprung out and seized the intruder by the collar.
+The other dived down the hole, and I heard the sound of rending cloth
+as Jones clutched at his skirts. The light flashed upon the barrel of a
+revolver, but Holmes’s hunting crop came down on the man’s wrist, and
+the pistol clinked upon the stone floor.
+
+“It’s no use, John Clay,” said Holmes, blandly. “You have no chance at
+all.”
+
+“So I see,” the other answered, with the utmost coolness. “I fancy that
+my pal is all right, though I see you have got his coat-tails.”
+
+“There are three men waiting for him at the door,” said Holmes.
+
+“Oh, indeed! You seem to have done the thing very completely. I must
+compliment you.”
+
+“And I you,” Holmes answered. “Your red-headed idea was very new and
+effective.”
+
+“You’ll see your pal again presently,” said Jones. “He’s quicker at
+climbing down holes than I am. Just hold out while I fix the derbies.”
+
+“I beg that you will not touch me with your filthy hands,” remarked
+our prisoner, as the handcuffs clattered upon his wrists. “You may not
+be aware that I have royal blood in my veins. Have the goodness, also,
+when you address me always to say ‘sir’ and ‘please.’”
+
+“All right,” said Jones, with a stare and a snigger. “Well, would you
+please, sir, march up-stairs, where we can get a cab to carry your
+highness to the police-station?”
+
+“That is better,” said John Clay, serenely. He made a sweeping bow to
+the three of us, and walked quietly off in the custody of the detective.
+
+“Really Mr. Holmes,” said Mr. Merryweather, as we followed them from
+the cellar, “I do not know how the bank can thank you or repay you.
+There is no doubt that you have detected and defeated in the most
+complete manner one of the most determined attempts at bank robbery
+that have ever come within my experience.”
+
+“I have had one or two little scores of my own to settle with Mr.
+John Clay,” said Holmes. “I have been at some small expense over this
+matter, which I shall expect the bank to refund, but beyond that I am
+amply repaid by having had an experience which is in many ways unique,
+and by hearing the very remarkable narrative of the Red-headed League.”
+
+       *       *       *       *       *
+
+“You see, Watson,” he explained, in the early hours of the morning,
+as we sat over a glass of whiskey-and-soda in Baker Street, “it was
+perfectly obvious from the first that the only possible object of this
+rather fantastic business of the advertisement of the League, and the
+copying of the ‘Encyclopædia,’ must be to get this not over-bright
+pawnbroker out of the way for a number of hours every day. It was a
+curious way of managing it, but, really, it would be difficult to
+suggest a better. The method was no doubt suggested to Clay’s ingenious
+mind by the color of his accomplice’s hair. The £4 a week was a lure
+which must draw him, and what was it to them, who were playing for
+thousands? They put in the advertisement, one rogue has the temporary
+office, the other rogue incites the man to apply for it, and together
+they manage to secure his absence every morning in the week. From
+the time that I heard of the assistant having come for half wages,
+it was obvious to me that he had some strong motive for securing the
+situation.”
+
+“But how could you guess what the motive was?”
+
+“Had there been women in the house, I should have suspected a mere
+vulgar intrigue. That, however, was out of the question. The man’s
+business was a small one, and there was nothing in his house which
+could account for such elaborate preparations, and such an expenditure
+as they were at. It must, then, be something out of the house. What
+could it be? I thought of the assistant’s fondness for photography,
+and his trick of vanishing into the cellar. The cellar! There was the
+end of this tangled clue. Then I made inquiries as to this mysterious
+assistant, and found that I had to deal with one of the coolest
+and most daring criminals in London. He was doing something in the
+cellar—something which took many hours a day for months on end. What
+could it be, once more? I could think of nothing save that he was
+running a tunnel to some other building.
+
+“So far I had got when we went to visit the scene of action. I
+surprised you by beating upon the pavement with my stick. I was
+ascertaining whether the cellar stretched out in front or behind.
+It was not in front. Then I rang the bell, and, as I hoped, the
+assistant answered it. We have had some skirmishes, but we had never
+set eyes upon each other before. I hardly looked at his face. His
+knees were what I wished to see. You must yourself have remarked how
+worn, wrinkled, and stained they were. They spoke of those hours of
+burrowing. The only remaining point was what they were burrowing for. I
+walked round the corner, saw that the City and Suburban Bank abutted on
+our friend’s premises, and felt that I had solved my problem. When you
+drove home after the concert I called upon Scotland Yard, and upon the
+chairman of the bank directors, with the result that you have seen.”
+
+“And how could you tell that they would make their attempt to-night?” I
+asked.
+
+“Well, when they closed their League offices that was a sign that they
+cared no longer about Mr. Jabez Wilson’s presence—in other words,
+that they had completed their tunnel. But it was essential that they
+should use it soon, as it might be discovered, or the bullion might
+be removed. Saturday would suit them better than any other day, as it
+would give them two days for their escape. For all these reasons I
+expected them to come to-night.”
+
+“You reasoned it out beautifully,” I exclaimed, in unfeigned
+admiration. “It is so long a chain, and yet every link rings true.”
+
+“It saved me from ennui,” he answered, yawning. “Alas! I already feel
+it closing in upon me. My life is spent in one long effort to escape
+from the commonplaces of existence. These little problems help me to do
+so.”
+
+“And you are a benefactor of the race,” said I.
+
+He shrugged his shoulders. “Well, perhaps, after all, it is of some
+little use,” he remarked. “‘L’homme c’est rien—l’oeuvre c’est
+tout,’ as Gustave Flaubert wrote to Georges Sand.”
+
+
+
+
+Adventure III
+
+A CASE OF IDENTITY
+
+
+“My dear fellow,” said Sherlock Holmes, as we sat on either side
+of the fire in his lodgings at Baker Street, “life is infinitely
+stranger than anything which the mind of man could invent. We would
+not dare to conceive the things which are really mere commonplaces of
+existence. If we could fly out of that window hand in hand, hover over
+this great city, gently remove the roofs, and peep in at the queer
+things which are going on, the strange coincidences, the plannings,
+the cross-purposes, the wonderful chains of events, working through
+generations, and leading to the most _outré_ results, it would make all
+fiction with its conventionalities and foreseen conclusions most stale
+and unprofitable.”
+
+“And yet I am not convinced of it,” I answered. “The cases which come
+to light in the papers are, as a rule, bald enough, and vulgar enough.
+We have in our police reports realism pushed to its extreme limits,
+and yet the result is, it must be confessed, neither fascinating nor
+artistic.”
+
+“A certain selection and discretion must be used in producing a
+realistic effect,” remarked Holmes. “This is wanting in the police
+report, where more stress is laid, perhaps, upon the platitudes of the
+magistrate than upon the details, which to an observer contain the
+vital essence of the whole matter. Depend upon it there is nothing so
+unnatural as the commonplace.”
+
+I smiled and shook my head. “I can quite understand you thinking so,”
+I said. “Of course, in your position of unofficial adviser and helper
+to everybody who is absolutely puzzled, throughout three continents,
+you are brought in contact with all that is strange and bizarre. But
+here”—I picked up the morning paper from the ground—“let us put it
+to a practical test. Here is the first heading upon which I come. ‘A
+husband’s cruelty to his wife.’ There is half a column of print, but
+I know without reading it that it is all perfectly familiar to me.
+There is, of course, the other woman, the drink, the push, the blow,
+the bruise, the sympathetic sister or landlady. The crudest of writers
+could invent nothing more crude.”
+
+“Indeed, your example is an unfortunate one for your argument,”
+said Holmes, taking the paper and glancing his eye down it. “This
+is the Dundas separation case, and, as it happens, I was engaged in
+clearing up some small points in connection with it. The husband was
+a teetotaler, there was no other woman, and the conduct complained of
+was that he had drifted into the habit of winding up every meal by
+taking out his false teeth and hurling them at his wife, which, you
+will allow, is not an action likely to occur to the imagination of the
+average story-teller. Take a pinch of snuff, doctor, and acknowledge
+that I have scored over you in your example.”
+
+He held out his snuffbox of old gold, with a great amethyst in the
+centre of the lid. Its splendor was in such contrast to his homely ways
+and simple life that I could not help commenting upon it.
+
+“Ah,” said he, “I forgot that I had not seen you for some weeks. It is
+a little souvenir from the King of Bohemia in return for my assistance
+in the case of the Irene Adler papers.”
+
+“And the ring?” I asked, glancing at a remarkable brilliant which
+sparkled upon his finger.
+
+“It was from the reigning family of Holland, though the matter in which
+I served them was of such delicacy that I cannot confide it even to
+you, who have been good enough to chronicle one or two of my little
+problems.”
+
+“And have you any on hand just now?” I asked, with interest.
+
+“Some ten or twelve, but none which present any feature of interest.
+They are important, you understand, without being interesting. Indeed,
+I have found that it is usually in unimportant matters that there is
+a field for the observation, and for the quick analysis of cause and
+effect which gives the charm to an investigation. The larger crimes are
+apt to be the simpler, for the bigger the crime, the more obvious, as
+a rule, is the motive. In these cases, save for one rather intricate
+matter which has been referred to me from Marseilles, there is nothing
+which presents any features of interest. It is possible, however, that
+I may have something better before very many minutes are over, for this
+is one of my clients, or I am much mistaken.”
+
+He had risen from his chair, and was standing between the parted
+blinds, gazing down into the dull, neutral-tinted London street.
+Looking over his shoulder, I saw that on the pavement opposite there
+stood a large woman with a heavy fur boa round her neck, and a large
+curling red feather in a broad-brimmed hat which was tilted in a
+coquettish Duchess-of-Devonshire fashion over her ear. From under
+this great panoply she peeped up in a nervous, hesitating fashion at
+our windows, while her body oscillated backward and forward, and her
+fingers fidgetted with her glove buttons. Suddenly, with a plunge, as
+of the swimmer who leaves the bank, she hurried across the road, and we
+heard the sharp clang of the bell.
+
+“I have seen those symptoms before,” said Holmes, throwing his
+cigarette into the fire. “Oscillation upon the pavement always means an
+_affaire de cœur_. She would like advice, but is not sure that the
+matter is not too delicate for communication. And yet even here we may
+discriminate. When a woman has been seriously wronged by a man she no
+longer oscillates, and the usual symptom is a broken bell wire. Here we
+may take it that there is a love matter, but that the maiden is not so
+much angry as perplexed, or grieved. But here she comes in person to
+resolve our doubts.”
+
+As he spoke there was a tap at the door, and the boy in buttons entered
+to announce Miss Mary Sutherland, while the lady herself loomed behind
+his small black figure like a full-sailed merchant-man behind a tiny
+pilot boat. Sherlock Holmes welcomed her with the easy courtesy for
+which he was remarkable, and having closed the door, and bowed her into
+an arm-chair, he looked her over in the minute, and yet abstracted
+fashion which was peculiar to him.
+
+“Do you not find,” he said, “that with your short sight it is a little
+trying to do so much type-writing?”
+
+“I did at first,” she answered, “but now I know where the letters
+are without looking.” Then, suddenly realizing the full purport of
+his words, she gave a violent start and looked up, with fear and
+astonishment upon her broad, good-humored face. “You’ve heard about me,
+Mr. Holmes,” she cried, “else how could you know all that?”
+
+“Never mind,” said Holmes, laughing; “it is my business to know things.
+Perhaps I have trained myself to see what others overlook. If not, why
+should you come to consult me?”
+
+“I came to you, sir, because I heard of you from Mrs. Etherege, whose
+husband you found so easy when the police and every one had given him
+up for dead. Oh, Mr. Holmes, I wish you would do as much for me. I’m
+not rich, but still I have a hundred a year in my own right, besides
+the little that I make by the machine, and I would give it all to know
+what has become of Mr. Hosmer Angel.”
+
+“Why did you come away to consult me in such a hurry?” asked Sherlock
+Holmes, with his finger-tips together, and his eyes to the ceiling.
+
+Again a startled look came over the somewhat vacuous face of Miss Mary
+Sutherland. “Yes, I did bang out of the house,” she said, “for it
+made me angry to see the easy way in which Mr. Windibank—that is, my
+father—took it all. He would not go to the police, and he would not
+go to you, and so at last, as he would do nothing, and kept on saying
+that there was no harm done, it made me mad, and I just on with my
+things and came right away to you.”
+
+“Your father,” said Holmes, “your step-father, surely, since the name
+is different.”
+
+“Yes, my step-father. I call him father, though it sounds funny, too,
+for he is only five years and two months older than myself.”
+
+“And your mother is alive?”
+
+“Oh yes, mother is alive and well. I wasn’t best pleased, Mr. Holmes,
+when she married again so soon after father’s death, and a man who was
+nearly fifteen years younger than herself. Father was a plumber in the
+Tottenham Court Road, and he left a tidy business behind him, which
+mother carried on with Mr. Hardy, the foreman; but when Mr. Windibank
+came he made her sell the business, for he was very superior, being a
+traveller in wines. They got £4700 for the goodwill and interest, which
+wasn’t near as much as father could have got if he had been alive.”
+
+I had expected to see Sherlock Holmes impatient under this rambling and
+inconsequential narrative, but, on the contrary, he had listened with
+the greatest concentration of attention.
+
+“Your own little income,” he asked, “does it come out of the business?”
+
+“Oh no, sir. It is quite separate, and was left me by my Uncle Ned
+in Auckland. It is in New Zealand stock, paying 4-1/2 per cent. Two
+thousand five hundred pounds was the amount, but I can only touch the
+interest.”
+
+“You interest me extremely,” said Holmes. “And since you draw so large
+a sum as a hundred a year, with what you earn into the bargain, you no
+doubt travel a little, and indulge yourself in every way. I believe
+that a single lady can get on very nicely upon an income of about £60.”
+
+[Illustration: “SHERLOCK HOLMES WELCOMED HER”]
+
+“I could do with much less than that, Mr. Holmes, but you understand
+that as long as I live at home I don’t wish to be a burden to them, and
+so they have the use of the money just while I am staying with them. Of
+course, that is only just for the time. Mr. Windibank draws my interest
+every quarter, and pays it over to mother, and I find that I can do
+pretty well with what I earn at type-writing. It brings me twopence a
+sheet, and I can often do from fifteen to twenty sheets in a day.”
+
+“You have made your position very clear to me,” said Holmes. “This is
+my friend, Dr. Watson, before whom you can speak as freely as before
+myself. Kindly tell us now all about your connection with Mr. Hosmer
+Angel.”
+
+A flush stole over Miss Sutherland’s face, and she picked nervously at
+the fringe of her jacket. “I met him first at the gasfitters’ ball,”
+she said. “They used to send father tickets when he was alive, and then
+afterwards they remembered us, and sent them to mother. Mr. Windibank
+did not wish us to go. He never did wish us to go anywhere. He would
+get quite mad if I wanted so much as to join a Sunday-school treat.
+But this time I was set on going, and I would go; for what right had
+he to prevent? He said the folk were not fit for us to know, when all
+father’s friends were to be there. And he said that I had nothing fit
+to wear, when I had my purple plush that I had never so much as taken
+out of the drawer. At last, when nothing else would do, he went off
+to France upon the business of the firm, but we went, mother and I,
+with Mr. Hardy, who used to be our foreman, and it was there I met Mr.
+Hosmer Angel.”
+
+“I suppose,” said Holmes, “that when Mr. Windibank came back from
+France he was very annoyed at your having gone to the ball.”
+
+“Oh, well, he was very good about it. He laughed, I remember, and
+shrugged his shoulders, and said there was no use denying anything to a
+woman, for she would have her way.”
+
+“I see. Then at the gasfitters’ ball you met, as I understand, a
+gentleman called Mr. Hosmer Angel.”
+
+“Yes, sir. I met him that night, and he called next day to ask if we
+had got home all safe, and after that we met him—that is to say, Mr.
+Holmes, I met him twice for walks, but after that father came back
+again, and Mr. Hosmer Angel could not come to the house any more.”
+
+“No?”
+
+“Well, you know, father didn’t like anything of the sort. He wouldn’t
+have any visitors if he could help it, and he used to say that a woman
+should be happy in her own family circle. But then, as I used to say to
+mother, a woman wants her own circle to begin with, and I had not got
+mine yet.”
+
+“But how about Mr. Hosmer Angel? Did he make no attempt to see you?”
+
+“Well, father was going off to France again in a week, and Hosmer wrote
+and said that it would be safer and better not to see each other until
+he had gone. We could write in the mean time, and he used to write
+every day. I took the letters in in the morning, so there was no need
+for father to know.”
+
+“Were you engaged to the gentleman at this time?”
+
+“Oh yes, Mr. Holmes. We were engaged after the first walk that we
+took. Hosmer—Mr. Angel—was a cashier in an office in Leadenhall
+Street—and—”
+
+“What office?”
+
+“That’s the worst of it, Mr. Holmes, I don’t know.”
+
+“Where did he live, then?”
+
+“He slept on the premises.”
+
+“And you don’t know his address?”
+
+“No—except that it was Leadenhall Street.”
+
+“Where did you address your letters, then?”
+
+“To the Leadenhall Street Post-office, to be left till called for. He
+said that if they were sent to the office he would be chaffed by all
+the other clerks about having letters from a lady, so I offered to
+type-write them, like he did his, but he wouldn’t have that, for he
+said that when I wrote them they seemed to come from me, but when they
+were type-written he always felt that the machine had come between us.
+That will just show you how fond he was of me, Mr. Holmes, and the
+little things that he would think of.”
+
+“It was most suggestive,” said Holmes. “It has long been an axiom of
+mine that the little things are infinitely the most important. Can you
+remember any other little things about Mr. Hosmer Angel?”
+
+“He was a very shy man, Mr. Holmes. He would rather walk with me in
+the evening than in the daylight, for he said that he hated to be
+conspicuous. Very retiring and gentlemanly he was. Even his voice was
+gentle. He’d had the quinsy and swollen glands when he was young, he
+told me, and it had left him with a weak throat, and a hesitating,
+whispering fashion of speech. He was always well dressed, very neat and
+plain, but his eyes were weak, just as mine are, and he wore tinted
+glasses against the glare.”
+
+“Well, and what happened when Mr. Windibank, your step-father, returned
+to France?”
+
+“Mr. Hosmer Angel came to the house again, and proposed that we should
+marry before father came back. He was in dreadful earnest, and made
+me swear, with my hands on the Testament, that whatever happened I
+would always be true to him. Mother said he was quite right to make me
+swear, and that it was a sign of his passion. Mother was all in his
+favor from the first, and was even fonder of him than I was. Then, when
+they talked of marrying within the week, I began to ask about father;
+but they both said never to mind about father, but just to tell him
+afterwards, and mother said she would make it all right with him. I
+didn’t quite like that, Mr. Holmes. It seemed funny that I should ask
+his leave, as he was only a few years older than me; but I didn’t want
+to do anything on the sly, so I wrote to father at Bordeaux, where the
+company has its French offices, but the letter came back to me on the
+very morning of the wedding.”
+
+“It missed him, then?”
+
+“Yes, sir; for he had started to England just before it arrived.”
+
+“Ha! that was unfortunate. Your wedding was arranged, then, for the
+Friday. Was it to be in church?”
+
+“Yes, sir, but very quietly. It was to be at St. Saviour’s, near King’s
+Cross, and we were to have breakfast afterwards at the St. Pancras
+Hotel. Hosmer came for us in a hansom, but as there were two of us, he
+put us both into it, and stepped himself into a four-wheeler, which
+happened to be the only other cab in the street. We got to the church
+first, and when the four-wheeler drove up we waited for him to step
+out, but he never did, and when the cabman got down from the box and
+looked, there was no one there! The cabman said that he could not
+imagine what had become of him, for he had seen him get in with his own
+eyes. That was last Friday, Mr. Holmes, and I have never seen or heard
+anything since then to throw any light upon what became of him.”
+
+“It seems to me that you have been very shamefully treated,” said
+Holmes.
+
+“Oh no, sir! He was too good and kind to leave me so. Why, all the
+morning he was saying to me that, whatever happened, I was to be true;
+and that even if something quite unforeseen occurred to separate
+us, I was always to remember that I was pledged to him, and that he
+would claim his pledge sooner or later. It seemed strange talk for a
+wedding-morning, but what has happened since gives a meaning to it.”
+
+“Most certainly it does. Your own opinion is, then, that some
+unforeseen catastrophe has occurred to him?”
+
+“Yes, sir. I believe that he foresaw some danger, or else he would not
+have talked so. And then I think that what he foresaw happened.”
+
+“But you have no notion as to what it could have been?”
+
+“None.”
+
+“One more question. How did your mother take the matter?”
+
+“She was angry, and said that I was never to speak of the matter again.”
+
+“And your father? Did you tell him?”
+
+“Yes; and he seemed to think, with me, that something had happened, and
+that I should hear of Hosmer again. As he said, what interest could any
+one have in bringing me to the doors of the church, and then leaving
+me? Now, if he had borrowed my money, or if he had married me and got
+my money settled on him, there might be some reason; but Hosmer was
+very independent about money, and never would look at a shilling of
+mine. And yet, what could have happened? And why could he not write?
+Oh, it drives me half-mad to think of! and I can’t sleep a wink at
+night.” She pulled a little handkerchief out of her muff, and began to
+sob heavily into it.
+
+“I shall glance into the case for you,” said Holmes, rising; “and I
+have no doubt that we shall reach some definite result. Let the weight
+of the matter rest upon me now, and do not let your mind dwell upon
+it further. Above all, try to let Mr. Hosmer Angel vanish from your
+memory, as he has done from your life.”
+
+“Then you don’t think I’ll see him again?”
+
+“I fear not.”
+
+“Then what has happened to him?”
+
+“You will leave that question in my hands. I should like an accurate
+description of him, and any letters of his which you can spare.”
+
+“I advertised for him in last Saturday’s _Chronicle_,” said she. “Here
+is the slip, and here are four letters from him.”
+
+“Thank you. And your address?”
+
+“No. 31 Lyon Place, Camberwell.”
+
+“Mr. Angel’s address you never had, I understand. Where is your
+father’s place of business?”
+
+“He travels for Westhouse & Marbank, the great claret importers of
+Fenchurch Street.”
+
+“Thank you. You have made your statement very clearly. You will leave
+the papers here, and remember the advice which I have given you. Let
+the whole incident be a sealed book, and do not allow it to affect your
+life.”
+
+“You are very kind, Mr. Holmes, but I cannot do that. I shall be true
+to Hosmer. He shall find me ready when he comes back.”
+
+For all the preposterous hat and the vacuous face, there was something
+noble in the simple faith of our visitor which compelled our respect.
+She laid her little bundle of papers upon the table, and went her way,
+with a promise to come again whenever she might be summoned.
+
+Sherlock Holmes sat silent for a few minutes with his finger-tips still
+pressed together, his legs stretched out in front of him, and his gaze
+directed upward to the ceiling. Then he took down from the rack the
+old and oily clay pipe, which was to him as a counsellor, and, having
+lit it, he leaned back in his chair, with the thick blue cloud-wreaths
+spinning up from him, and a look of infinite languor in his face.
+
+“Quite an interesting study, that maiden,” he observed. “I found her
+more interesting than her little problem, which, by the way, is rather
+a trite one. You will find parallel cases, if you consult my index, in
+Andover in ’77, and there was something of the sort at The Hague last
+year. Old as is the idea, however, there were one or two details which
+were new to me. But the maiden herself was most instructive.”
+
+“You appeared to read a good deal upon her which was quite invisible to
+me,” I remarked.
+
+“Not invisible, but unnoticed, Watson. You did not know where to look,
+and so you missed all that was important. I can never bring you to
+realize the importance of sleeves, the suggestiveness of thumb-nails,
+or the great issues that may hang from a boot-lace. Now, what did you
+gather from that woman’s appearance? Describe it.”
+
+“Well, she had a slate-colored, broad-brimmed straw hat, with a feather
+of a brickish red. Her jacket was black, with black beads sewn upon it,
+and a fringe of little black jet ornaments. Her dress was brown, rather
+darker than coffee color, with a little purple plush at the neck and
+sleeves. Her gloves were grayish, and were worn through at the right
+forefinger. Her boots I didn’t observe. She had small, round, hanging
+gold ear-rings, and a general air of being fairly well-to-do, in a
+vulgar, comfortable, easy-going way.”
+
+Sherlock Holmes clapped his hands softly together and chuckled.
+
+“’Pon my word, Watson, you are coming along wonderfully. You have
+really done very well indeed. It is true that you have missed
+everything of importance, but you have hit upon the method, and you
+have a quick eye for color. Never trust to general impressions, my boy,
+but concentrate yourself upon details. My first glance is always at a
+woman’s sleeve. In a man it is perhaps better first to take the knee
+of the trouser. As you observe, this woman had plush upon her sleeves,
+which is a most useful material for showing traces. The double line
+a little above the wrist, where the type-writist presses against the
+table, was beautifully defined. The sewing-machine, of the hand type,
+leaves a similar mark, but only on the left arm, and on the side of it
+farthest from the thumb, instead of being right across the broadest
+part, as this was. I then glanced at her face, and observing the dint
+of a pince-nez at either side of her nose, I ventured a remark upon
+short sight and type-writing, which seemed to surprise her.”
+
+“It surprised me.”
+
+“But, surely, it was very obvious. I was then much surprised and
+interested on glancing down to observe that, though the boots which she
+was wearing were not unlike each other, they were really odd ones; the
+one having a slightly decorated toe-cap, and the other a plain one.
+One was buttoned only in the two lower buttons out of five, and the
+other at the first, third, and fifth. Now, when you see that a young
+lady, otherwise neatly dressed, has come away from home with odd boots,
+half-buttoned, it is no great deduction to say that she came away in a
+hurry.”
+
+“And what else?” I asked, keenly interested, as I always was, by my
+friend’s incisive reasoning.
+
+“I noted, in passing, that she had written a note before leaving home,
+but after being fully dressed. You observed that her right glove was
+torn at the forefinger, but you did not apparently see that both glove
+and finger were stained with violet ink. She had written in a hurry,
+and dipped her pen too deep. It must have been this morning, or the
+mark would not remain clear upon the finger. All this is amusing,
+though rather elementary, but I must go back to business, Watson. Would
+you mind reading me the advertised description of Mr. Hosmer Angel?”
+
+I held the little printed slip to the light. “Missing,” it said, “on
+the morning of the 14th, a gentleman named Hosmer Angel. About 5 ft. 7
+in. in height; strongly built, sallow complexion, black hair, a little
+bald in the centre, bushy, black side-whiskers and mustache; tinted
+glasses, slight infirmity of speech. Was dressed, when last seen, in
+black frock-coat faced with silk, black waistcoat, gold Albert chain,
+and gray Harris tweed trousers, with brown gaiters over elastic-sided
+boots. Known to have been employed in an office in Leadenhall Street.
+Anybody bringing,” etc., etc.
+
+“That will do,” said Holmes. “As to the letters,” he continued,
+glancing over them, “they are very commonplace. Absolutely no clew
+in them to Mr. Angel, save that he quotes Balzac once. There is one
+remarkable point, however, which will no doubt strike you.”
+
+“They are type-written,” I remarked.
+
+“Not only that, but the signature is type-written. Look at the neat
+little ‘Hosmer Angel’ at the bottom. There is a date, you see, but no
+superscription except Leadenhall Street, which is rather vague. The
+point about the signature is very suggestive—in fact, we may call it
+conclusive.”
+
+“Of what?”
+
+“My dear fellow, is it possible you do not see how strongly it bears
+upon the case?”
+
+“I cannot say that I do, unless it were that he wished to be able to
+deny his signature if an action for breach of promise were instituted.”
+
+“No, that was not the point. However, I shall write two letters, which
+should settle the matter. One is to a firm in the city, the other is
+to the young lady’s step-father, Mr. Windibank, asking him whether he
+could meet us here at six o’clock to-morrow evening. It is just as well
+that we should do business with the male relatives. And now, doctor, we
+can do nothing until the answers to those letters come, so we may put
+our little problem upon the shelf for the interim.”
+
+I had had so many reasons to believe in my friend’s subtle powers of
+reasoning, and extraordinary energy in action, that I felt that he must
+have some solid grounds for the assured and easy demeanor with which he
+treated the singular mystery which he had been called upon to fathom.
+Once only had I known him to fail, in the case of the King of Bohemia
+and of the Irene Adler photograph; but when I looked back to the weird
+business of the Sign of Four, and the extraordinary circumstances
+connected with the Study in Scarlet, I felt that it would be a strange
+tangle indeed which he could not unravel.
+
+I left him then, still puffing at his black clay pipe, with the
+conviction that when I came again on the next evening I would find that
+he held in his hands all the clews which would lead up to the identity
+of the disappearing bridegroom of Miss Mary Sutherland.
+
+A professional case of great gravity was engaging my own attention at
+the time, and the whole of next day I was busy at the bedside of the
+sufferer. It was not until close upon six o’clock that I found myself
+free, and was able to spring into a hansom and drive to Baker Street,
+half afraid that I might be too late to assist at the _dénouement_
+of the little mystery. I found Sherlock Holmes alone, however, half
+asleep, with his long, thin form curled up in the recesses of his
+arm-chair. A formidable array of bottles and test-tubes, with the
+pungent cleanly smell of hydrochloric acid, told me that he had spent
+his day in the chemical work which was so dear to him.
+
+“Well, have you solved it?” I asked, as I entered.
+
+“Yes. It was the bisulphate of baryta.”
+
+“No, no, the mystery!” I cried.
+
+“Oh, that! I thought of the salt that I have been working upon. There
+was never any mystery in the matter, though, as I said yesterday, some
+of the details are of interest. The only drawback is that there is no
+law, I fear, that can touch the scoundrel.”
+
+“Who was he, then, and what was his object in deserting Miss
+Sutherland?”
+
+The question was hardly out of my mouth, and Holmes had not yet opened
+his lips to reply, when we heard a heavy footfall in the passage, and a
+tap at the door.
+
+“This is the girl’s step-father, Mr. James Windibank,” said Holmes. “He
+has written to me to say that he would be here at six. Come in!”
+
+The man who entered was a sturdy, middle-sized fellow, some thirty
+years of age, clean shaven, and sallow skinned, with a bland,
+insinuating manner, and a pair of wonderfully sharp and penetrating
+gray eyes. He shot a questioning glance at each of us, placed his shiny
+top hat upon the sideboard, and with a slight bow sidled down into the
+nearest chair.
+
+“Good-evening, Mr. James Windibank,” said Holmes. “I think that this
+type-written letter is from you, in which you made an appointment with
+me for six o’clock?”
+
+“Yes, sir. I am afraid that I am a little late, but I am not quite my
+own master, you know. I am sorry that Miss Sutherland has troubled you
+about this little matter, for I think it is far better not to wash
+linen of the sort in public. It was quite against my wishes that she
+came, but she is a very excitable, impulsive girl, as you may have
+noticed, and she is not easily controlled when she has made up her
+mind on a point. Of course, I did not mind you so much, as you are not
+connected with the official police, but it is not pleasant to have a
+family misfortune like this noised abroad. Besides, it is a useless
+expense, for how could you possibly find this Hosmer Angel?”
+
+“On the contrary,” said Holmes, quietly; “I have every reason to
+believe that I will succeed in discovering Mr. Hosmer Angel.”
+
+Mr. Windibank gave a violent start, and dropped his gloves. “I am
+delighted to hear it,” he said.
+
+“It is a curious thing,” remarked Holmes, “that a type-writer has
+really quite as much individuality as a man’s handwriting. Unless they
+are quite new, no two of them write exactly alike. Some letters get
+more worn than others, and some wear only on one side. Now, you remark
+in this note of yours, Mr. Windibank, that in every case there is some
+little slurring over of the ‘e,’ and a slight defect in the tail of the
+‘r.’ There are fourteen other characteristics, but those are the more
+obvious.”
+
+“We do all our correspondence with this machine at the office, and no
+doubt it is a little worn,” our visitor answered, glancing keenly at
+Holmes with his bright little eyes.
+
+“And now I will show you what is really a very interesting study,
+Mr. Windibank,” Holmes continued. “I think of writing another little
+monograph some of these days on the type-writer and its relation to
+crime. It is a subject to which I have devoted some little attention.
+I have here four letters which purport to come from the missing man.
+They are all type-written. In each case, not only are the ‘e’s’ slurred
+and the ‘r’s’ tailless, but you will observe, if you care to use my
+magnifying lens, that the fourteen other characteristics to which I
+have alluded are there as well.”
+
+Mr. Windibank sprang out of his chair, and picked up his hat. “I cannot
+waste time over this sort of fantastic talk, Mr. Holmes,” he said. “If
+you can catch the man, catch him, and let me know when you have done
+it.”
+
+“Certainly,” said Holmes, stepping over and turning the key in the
+door. “I let you know, then, that I have caught him!”
+
+“What! where?” shouted Mr. Windibank, turning white to his lips, and
+glancing about him like a rat in a trap.
+
+“Oh, it won’t do—really it won’t,” said Holmes, suavely. “There is no
+possible getting out of it, Mr. Windibank. It is quite too transparent,
+and it was a very bad compliment when you said that it was impossible
+for me to solve so simple a question. That’s right! Sit down, and let
+us talk it over.”
+
+Our visitor collapsed into a chair, with a ghastly face, and a glitter
+of moisture on his brow. “It—it’s not actionable,” he stammered.
+
+“I am very much afraid that it is not. But between ourselves,
+Windibank, it was as cruel and selfish and heartless a trick in a petty
+way as ever came before me. Now, let me just run over the course of
+events, and you will contradict me if I go wrong.”
+
+The man sat huddled up in his chair, with his head sunk upon his
+breast, like one who is utterly crushed. Holmes stuck his feet up on
+the corner of the mantel-piece, and, leaning back with his hands in his
+pockets, began talking, rather to himself, as it seemed, than to us.
+
+“The man married a woman very much older than himself for her money,”
+said he, “and he enjoyed the use of the money of the daughter as long
+as she lived with them. It was a considerable sum, for people in their
+position, and the loss of it would have made a serious difference.
+It was worth an effort to preserve it. The daughter was of a good,
+amiable disposition, but affectionate and warm-hearted in her ways, so
+that it was evident that with her fair personal advantages, and her
+little income, she would not be allowed to remain single long. Now her
+marriage would mean, of course, the loss of a hundred a year, so what
+does her step-father do to prevent it? He takes the obvious course of
+keeping her at home, and forbidding her to seek the company of people
+of her own age. But soon he found that that would not answer forever.
+She became restive, insisted upon her rights, and finally announced her
+positive intention of going to a certain ball. What does her clever
+step-father do then? He conceives an idea more creditable to his head
+than to his heart. With the connivance and assistance of his wife he
+disguised himself, covered those keen eyes with tinted glasses, masked
+the face with a mustache and a pair of bushy whiskers, sunk that clear
+voice into an insinuating whisper, and doubly secure on account of the
+girl’s short sight, he appears as Mr. Hosmer Angel, and keeps off other
+lovers by making love himself.”
+
+[Illustration: “GLANCING ABOUT HIM LIKE A RAT IN A TRAP”]
+
+“It was only a joke at first,” groaned our visitor. “We never thought
+that she would have been so carried away.”
+
+“Very likely not. However that may be, the young lady was very
+decidedly carried away, and having quite made up her mind that her
+step-father was in France, the suspicion of treachery never for
+an instant entered her mind. She was flattered by the gentleman’s
+attentions, and the effect was increased by the loudly expressed
+admiration of her mother. Then Mr. Angel began to call, for it was
+obvious that the matter should be pushed as far as it would go,
+if a real effect were to be produced. There were meetings, and an
+engagement, which would finally secure the girl’s affections from
+turning towards any one else. But the deception could not be kept up
+forever. These pretended journeys to France were rather cumbrous. The
+thing to do was clearly to bring the business to an end in such a
+dramatic manner that it would leave a permanent impression upon the
+young lady’s mind, and prevent her from looking upon any other suitor
+for some time to come. Hence those vows of fidelity exacted upon a
+Testament, and hence also the allusions to a possibility of something
+happening on the very morning of the wedding. James Windibank wished
+Miss Sutherland to be so bound to Hosmer Angel, and so uncertain as to
+his fate, that for ten years to come, at any rate, she would not listen
+to another man. As far as the church door he brought her, and then, as
+he could go no farther, he conveniently vanished away by the old trick
+of stepping in at one door of a four-wheeler, and out at the other. I
+think that that was the chain of events, Mr. Windibank!”
+
+Our visitor had recovered something of his assurance while Holmes had
+been talking, and he rose from his chair now with a cold sneer upon his
+pale face.
+
+“It may be so, or it may not, Mr. Holmes,” said he, “but if you are so
+very sharp you ought to be sharp enough to know that it is you who are
+breaking the law now, and not me. I have done nothing actionable from
+the first, but as long as you keep that door locked you lay yourself
+open to an action for assault and illegal constraint.”
+
+“The law cannot, as you say, touch you,” said Holmes, unlocking and
+throwing open the door, “yet there never was a man who deserved
+punishment more. If the young lady has a brother or a friend, he ought
+to lay a whip across your shoulders. By Jove!” he continued, flushing
+up at the sight of the bitter sneer upon the man’s face, “it is not
+part of my duties to my client, but here’s a hunting crop handy, and I
+think I shall just treat myself to—” He took two swift steps to the
+whip, but before he could grasp it there was a wild clatter of steps
+upon the stairs, the heavy hall door banged, and from the window we
+could see Mr. James Windibank running at the top of his speed down the
+road.
+
+“There’s a cold-blooded scoundrel!” said Holmes, laughing, as he threw
+himself down into his chair once more. “That fellow will rise from
+crime to crime until he does something very bad, and ends on a gallows.
+The case has, in some respects, been not entirely devoid of interest.”
+
+“I cannot now entirely see all the steps of your reasoning,” I remarked.
+
+“Well, of course it was obvious from the first that this Mr. Hosmer
+Angel must have some strong object for his curious conduct, and it was
+equally clear that the only man who really profited by the incident,
+as far as we could see, was the step-father. Then the fact that the
+two men were never together, but that the one always appeared when
+the other was away, was suggestive. So were the tinted spectacles and
+the curious voice, which both hinted at a disguise, as did the bushy
+whiskers. My suspicions were all confirmed by his peculiar action
+in type-writing his signature, which, of course, inferred that his
+handwriting was so familiar to her that she would recognize even the
+smallest sample of it. You see all these isolated facts, together with
+many minor ones, all pointed in the same direction.”
+
+“And how did you verify them?”
+
+“Having once spotted my man, it was easy to get corroboration. I
+knew the firm for which this man worked. Having taken the printed
+description, I eliminated everything from it which could be the result
+of a disguise—the whiskers, the glasses, the voice, and I sent it
+to the firm, with a request that they would inform me whether it
+answered to the description of any of their travellers. I had already
+noticed the peculiarities of the type-writer, and I wrote to the man
+himself at his business address, asking him if he would come here. As
+I expected, his reply was type-written, and revealed the same trivial
+but characteristic defects. The same post brought me a letter from
+Westhouse & Marbank, of Fenchurch Street, to say that the description
+tallied in every respect with that of their employé, James Windibank.
+_Voila tout!_”
+
+“And Miss Sutherland?”
+
+“If I tell her she will not believe me. You may remember the old
+Persian saying, ‘There is danger for him who taketh the tiger cub, and
+danger also for whoso snatches a delusion from a woman.’ There is as
+much sense in Hafiz as in Horace, and as much knowledge of the world.”
+
+
+
+
+Adventure IV
+
+THE BOSCOMBE VALLEY MYSTERY
+
+
+We were seated at breakfast one morning, my wife and I, when the maid
+brought in a telegram. It was from Sherlock Holmes, and ran in this way:
+
+“Have you a couple of days to spare? Have just been wired for from
+the West of England in connection with Boscombe Valley tragedy. Shall
+be glad if you will come with me. Air and scenery perfect. Leave
+Paddington by the 11.15.”
+
+“What do you say, dear?” said my wife, looking across at me. “Will you
+go?”
+
+“I really don’t know what to say. I have a fairly long list at present.”
+
+“Oh, Anstruther would do your work for you. You have been looking a
+little pale lately. I think that the change would do you good, and you
+are always so interested in Mr. Sherlock Holmes’s cases.”
+
+“I should be ungrateful if I were not, seeing what I gained through one
+of them,” I answered. “But if I am to go, I must pack at once, for I
+have only half an hour.”
+
+My experience of camp life in Afghanistan had at least had the effect
+of making me a prompt and ready traveller. My wants were few and
+simple, so that in less than the time stated I was in a cab with my
+valise, rattling away to Paddington Station. Sherlock Holmes was pacing
+up and down the platform, his tall, gaunt figure made even gaunter and
+taller by his long gray travelling-cloak and close-fitting cloth cap.
+
+“It is really very good of you to come, Watson,” said he. “It makes a
+considerable difference to me, having some one with me on whom I can
+thoroughly rely. Local aid is always either worthless or else biassed.
+If you will keep the two corner seats I shall get the tickets.”
+
+We had the carriage to ourselves save for an immense litter of papers
+which Holmes had brought with him. Among these he rummaged and read,
+with intervals of note-taking and of meditation, until we were past
+Reading. Then he suddenly rolled them all into a gigantic ball, and
+tossed them up onto the rack.
+
+“Have you heard anything of the case?” he asked.
+
+“Not a word. I have not seen a paper for some days.”
+
+“The London press has not had very full accounts. I have just
+been looking through all the recent papers in order to master the
+particulars. It seems, from what I gather, to be one of those simple
+cases which are so extremely difficult.”
+
+“That sounds a little paradoxical.”
+
+“But it is profoundly true. Singularity is almost invariably a clew.
+The more featureless and commonplace a crime is, the more difficult is
+it to bring it home. In this case, however, they have established a
+very serious case against the son of the murdered man.”
+
+“It is a murder, then?”
+
+“Well, it is conjectured to be so. I shall take nothing for granted
+until I have the opportunity of looking personally into it. I will
+explain the state of things to you, as far as I have been able to
+understand it, in a very few words.
+
+“Boscombe Valley is a country district not very far from Ross, in
+Herefordshire. The largest landed proprietor in that part is a Mr. John
+Turner, who made his money in Australia, and returned some years ago to
+the old country. One of the farms which he held, that of Hatherley, was
+let to Mr. Charles McCarthy, who was also an ex-Australian. The men had
+known each other in the colonies, so that it was not unnatural that
+when they came to settle down they should do so as near each other as
+possible. Turner was apparently the richer man, so McCarthy became his
+tenant, but still remained, it seems, upon terms of perfect equality,
+as they were frequently together. McCarthy had one son, a lad of
+eighteen, and Turner had an only daughter of the same age, but neither
+of them had wives living. They appear to have avoided the society of
+the neighboring English families, and to have led retired lives, though
+both the McCarthys were fond of sport, and were frequently seen at
+the race-meetings of the neighborhood. McCarthy kept two servants—a
+man and a girl. Turner had a considerable household, some half-dozen
+at the least. That is as much as I have been able to gather about the
+families. Now for the facts.
+
+“On June 3, that is, on Monday last, McCarthy left his house at
+Hatherley about three in the afternoon, and walked down to the Boscombe
+Pool, which is a small lake formed by the spreading out of the
+stream which runs down the Boscombe Valley. He had been out with his
+serving-man in the morning at Ross, and he had told the man that he
+must hurry, as he had an appointment of importance to keep at three.
+From that appointment he never came back alive.
+
+“From Hatherley Farm-house to the Boscombe Pool is a quarter of a mile,
+and two people saw him as he passed over this ground. One was an old
+woman, whose name is not mentioned, and the other was William Crowder,
+a game-keeper in the employ of Mr. Turner. Both these witnesses depose
+that Mr. McCarthy was walking alone. The game-keeper adds that within
+a few minutes of his seeing Mr. McCarthy pass he had seen his son, Mr.
+James McCarthy, going the same way with a gun under his arm. To the
+best of his belief, the father was actually in sight at the time, and
+the son was following him. He thought no more of the matter until he
+heard in the evening of the tragedy that had occurred.
+
+“The two McCarthys were seen after the time when William Crowder, the
+game-keeper, lost sight of them. The Boscombe Pool is thickly-wooded
+round, with just a fringe of grass and of reeds round the edge. A girl
+of fourteen, Patience Moran, who is the daughter of the lodge-keeper of
+the Boscombe Valley estate, was in one of the woods picking flowers.
+She states that while she was there she saw, at the border of the wood
+and close by the lake, Mr. McCarthy and his son, and that they appeared
+to be having a violent quarrel. She heard Mr. McCarthy the elder using
+very strong language to his son, and she saw the latter raise up
+his hand as if to strike his father. She was so frightened by their
+violence that she ran away, and told her mother when she reached home
+that she had left the two McCarthys quarrelling near Boscombe Pool, and
+that she was afraid that they were going to fight. She had hardly said
+the words when young Mr. McCarthy came running up to the lodge to say
+that he had found his father dead in the wood, and to ask for the help
+of the lodge-keeper. He was much excited, without either his gun or his
+hat, and his right hand and sleeve were observed to be stained with
+fresh blood. On following him they found the dead body stretched out
+upon the grass beside the Pool. The head had been beaten in by repeated
+blows of some heavy and blunt weapon. The injuries were such as might
+very well have been inflicted by the butt-end of his son’s gun, which
+was found lying on the grass within a few paces of the body. Under
+these circumstances the young man was instantly arrested, and a verdict
+of ‘Wilful Murder’ having been returned at the inquest on Tuesday,
+he was on Wednesday brought before the magistrates at Ross, who have
+referred the case to the next assizes. Those are the main facts of the
+case as they came out before the coroner and at the police-court.”
+
+“I could hardly imagine a more damning case,” I remarked. “If ever
+circumstantial evidence pointed to a criminal it does so here.”
+
+“Circumstantial evidence is a very tricky thing,” answered Holmes,
+thoughtfully. “It may seem to point very straight to one thing, but if
+you shift your own point of view a little, you may find it pointing
+in an equally uncompromising manner to something entirely different.
+It must be confessed, however, that the case looks exceedingly grave
+against the young man, and it is very possible that he is indeed the
+culprit. There are several people in the neighborhood, however, and
+among them Miss Turner, the daughter of the neighboring land-owner,
+who believe in his innocence, and who have retained Lestrade, whom you
+may recollect in connection with the Study in Scarlet, to work out the
+case in his interest. Lestrade, being rather puzzled, has referred the
+case to me, and hence it is that two middle-aged gentlemen are flying
+westward at fifty miles an hour, instead of quietly digesting their
+breakfasts at home.”
+
+“I am afraid,” said I, “that the facts are so obvious that you will
+find little credit to be gained out of this case.”
+
+“There is nothing more deceptive than an obvious fact,” he answered,
+laughing. “Besides, we may chance to hit upon some other obvious facts
+which may have been by no means obvious to Mr. Lestrade. You know me
+too well to think that I am boasting when I say that I shall either
+confirm or destroy his theory by means which he is quite incapable of
+employing, or even of understanding. To take the first example to hand,
+I very clearly perceive that in your bedroom the window is upon the
+right-hand side, and yet I question whether Mr. Lestrade would have
+noted even so self-evident a thing as that.”
+
+“How on earth—”
+
+“My dear fellow, I know you well. I know the military neatness which
+characterizes you. You shave every morning, and in this season you
+shave by the sunlight; but since your shaving is less and less complete
+as we get farther back on the left side, until it becomes positively
+slovenly as we get round the angle of the jaw, it is surely very clear
+that that side is less well illuminated than the other. I could not
+imagine a man of your habits looking at himself in an equal light, and
+being satisfied with such a result. I only quote this as a trivial
+example of observation and inference. Therein lies my _métier_, and it
+is just possible that it may be of some service in the investigation
+which lies before us. There are one or two minor points which were
+brought out in the inquest, and which are worth considering.”
+
+[Illustration: “THEY FOUND THE BODY”]
+
+“What are they?”
+
+“It appears that his arrest did not take place at once, but after the
+return to Hatherley Farm. On the inspector of constabulary informing
+him that he was a prisoner, he remarked that he was not surprised to
+hear it, and that it was no more than his deserts. This observation of
+his had the natural effect of removing any traces of doubt which might
+have remained in the minds of the coroner’s jury.”
+
+“It was a confession,” I ejaculated.
+
+“No, for it was followed by a protestation of innocence.”
+
+“Coming on the top of such a damning series of events, it was at least
+a most suspicious remark.”
+
+“On the contrary,” said Holmes, “it is the brightest rift which I can
+at present see in the clouds. However innocent he might be, he could
+not be such an absolute imbecile as not to see that the circumstances
+were very black against him. Had he appeared surprised at his own
+arrest, or feigned indignation at it, I should have looked upon it as
+highly suspicious, because such surprise or anger would not be natural
+under the circumstances, and yet might appear to be the best policy
+to a scheming man. His frank acceptance of the situation marks him as
+either an innocent man, or else as a man of considerable self-restraint
+and firmness. As to his remark about his deserts, it was also not
+unnatural if you consider that he stood beside the dead body of his
+father, and that there is no doubt that he had that very day so far
+forgotten his filial duty as to bandy words with him, and even,
+according to the little girl whose evidence is so important, to raise
+his hand as if to strike him. The self-reproach and contrition which
+are displayed in his remark appear to me to be the signs of a healthy
+mind, rather than of a guilty one.”
+
+I shook my head. “Many men have been hanged on far slighter evidence,”
+I remarked.
+
+“So they have. And many men have been wrongfully hanged.”
+
+“What is the young man’s own account of the matter?”
+
+“It is, I am afraid, not very encouraging to his supporters, though
+there are one or two points in it which are suggestive. You will find
+it here, and may read it for yourself.”
+
+He picked out from his bundle a copy of the local Herefordshire paper,
+and having turned down the sheet, he pointed out the paragraph in which
+the unfortunate young man had given his own statement of what had
+occurred. I settled myself down in the corner of the carriage, and read
+it very carefully. It ran in this way:
+
+“Mr. James McCarthy, the only son of the deceased, was then called, and
+gave evidence as follows: ‘I had been away from home for three days at
+Bristol, and had only just returned upon the morning of last Monday,
+the 3rd. My father was absent from home at the time of my arrival, and
+I was informed by the maid that he had driven over to Ross with John
+Cobb, the groom. Shortly after my return I heard the wheels of his trap
+in the yard, and, looking out of my window, I saw him get out and walk
+rapidly out of the yard, though I was not aware in which direction he
+was going. I then took my gun, and strolled out in the direction of
+the Boscombe Pool, with the intention of visiting the rabbit-warren
+which is upon the other side. On my way I saw William Crowder, the
+game-keeper, as he had stated in his evidence; but he is mistaken in
+thinking that I was following my father. I had no idea that he was in
+front of me. When about a hundred yards from the Pool I heard a cry of
+“Cooee!” which was a usual signal between my father and myself. I then
+hurried forward, and found him standing by the Pool. He appeared to be
+much surprised at seeing me, and asked me rather roughly what I was
+doing there. A conversation ensued which led to high words, and almost
+to blows, for my father was a man of a very violent temper. Seeing
+that his passion was becoming ungovernable, I left him, and returned
+towards Hatherley Farm. I had not gone more than 150 yards, however,
+when I heard a hideous outcry behind me, which caused me to run back
+again. I found my father expiring upon the ground, with his head
+terribly injured. I dropped my gun, and held him in my arms, but he
+almost instantly expired. I knelt beside him for some minutes, and then
+made my way to Mr. Turner’s lodge-keeper, his house being the nearest,
+to ask for assistance. I saw no one near my father when I returned, and
+I have no idea how he came by his injuries. He was not a popular man,
+being somewhat cold and forbidding in his manners; but he had, as far
+as I know, no active enemies. I know nothing further of the matter.’
+
+“The Coroner: Did your father make any statement to you before he died?
+
+“Witness: He mumbled a few words, but I could only catch some allusion
+to a rat.
+
+“The Coroner: What did you understand by that?
+
+“Witness: It conveyed no meaning to me. I thought that he was delirious.
+
+“The Coroner: What was the point upon which you and your father had
+this final quarrel?
+
+“Witness: I should prefer not to answer.
+
+“The Coroner: I am afraid that I must press it.
+
+“Witness: It is really impossible for me to tell you. I can assure you
+that it has nothing to do with the sad tragedy which followed.
+
+“The Coroner: That is for the court to decide. I need not point out to
+you that your refusal to answer will prejudice your case considerably
+in any future proceedings which may arise.
+
+“Witness: I must still refuse.
+
+“The Coroner: I understand that the cry of ‘Cooee’ was a common signal
+between you and your father?
+
+“Witness: It was.
+
+“The Coroner: How was it, then, that he uttered it before he saw you,
+and before he even knew that you had returned from Bristol?
+
+“Witness (with considerable confusion): I do not know.
+
+“A Juryman: Did you see nothing which aroused your suspicions when you
+returned on hearing the cry, and found your father fatally injured?
+
+“Witness: Nothing definite.
+
+“The Coroner: What do you mean?
+
+“Witness: I was so disturbed and excited as I rushed out into the open,
+that I could think of nothing except of my father. Yet I have a vague
+impression that as I ran forward something lay upon the ground to the
+left of me. It seemed to me to be something gray in color, a coat of
+some sort, or a plaid perhaps. When I rose from my father I looked
+round for it, but it was gone.
+
+“‘Do you mean that it disappeared before you went for help?’
+
+“‘Yes, it was gone.’
+
+“‘You cannot say what it was?’
+
+“‘No, I had a feeling something was there.’
+
+“‘How far from the body?’
+
+“‘A dozen yards or so.’
+
+“‘And how far from the edge of the wood?’
+
+“‘About the same.’
+
+“‘Then if it was removed it was while you were within a dozen yards of
+it?’
+
+“‘Yes, but with my back towards it.’
+
+“This concluded the examination of the witness.”
+
+“I see,” said I, as I glanced down the column, “that the coroner in
+his concluding remarks was rather severe upon young McCarthy. He calls
+attention, and with reason, to the discrepancy about his father having
+signalled to him before seeing him, also to his refusal to give details
+of his conversation with his father, and his singular account of his
+father’s dying words. They are all, as he remarks, very much against
+the son.”
+
+Holmes laughed softly to himself, and stretched himself out upon the
+cushioned seat. “Both you and the coroner have been at some pains,”
+said he, “to single out the very strongest points in the young man’s
+favor. Don’t you see that you alternately give him credit for having
+too much imagination and too little. Too little, if he could not invent
+a cause of quarrel which would give him the sympathy of the jury;
+too much, if he evolved from his own inner consciousness anything
+so _outré_ as a dying reference to a rat, and the incident of the
+vanishing cloth. No, sir, I shall approach this case from the point of
+view that what this young man says is true, and we shall see whither
+that hypothesis will lead us. And now here is my pocket Petrarch, and
+not another word shall I say of this case until we are on the scene of
+action. We lunch at Swindon, and I see that we shall be there in twenty
+minutes.”
+
+It was nearly four o’clock when we at last, after passing through
+the beautiful Stroud Valley, and over the broad gleaming Severn,
+found ourselves at the pretty little country-town of Ross. A lean,
+ferret-like man, furtive and sly-looking, was waiting for us upon the
+platform. In spite of the light brown dustcoat and leather-leggings
+which he wore in deference to his rustic surroundings, I had no
+difficulty in recognizing Lestrade, of Scotland Yard. With him we drove
+to the Hereford Arms, where a room had already been engaged for us.
+
+“I have ordered a carriage,” said Lestrade, as we sat over a cup of
+tea. “I knew your energetic nature, and that you would not be happy
+until you had been on the scene of the crime.”
+
+“It was very nice and complimentary of you,” Holmes answered. “It is
+entirely a question of barometric pressure.”
+
+Lestrade looked startled. “I do not quite follow,” he said.
+
+“How is the glass? Twenty-nine, I see. No wind, and not a cloud in the
+sky. I have a caseful of cigarettes here which need smoking, and the
+sofa is very much superior to the usual country hotel abomination. I do
+not think that it is probable that I shall use the carriage to-night.”
+
+Lestrade laughed indulgently. “You have, no doubt, already formed your
+conclusions from the newspapers,” he said. “The case is as plain as a
+pikestaff, and the more one goes into it the plainer it becomes. Still,
+of course, one can’t refuse a lady, and such a very positive one, too.
+She had heard of you, and would have your opinion, though I repeatedly
+told her that there was nothing which you could do which I had not
+already done. Why, bless my soul! here is her carriage at the door.”
+
+He had hardly spoken before there rushed into the room one of the most
+lovely young women that I have ever seen in my life. Her violet eyes
+shining, her lips parted, a pink flush upon her cheeks, all thought of
+her natural reserve lost in her overpowering excitement and concern.
+
+“Oh, Mr. Sherlock Holmes!” she cried, glancing from one to the other
+of us, and finally, with a woman’s quick intuition, fastening upon my
+companion, “I am so glad that you have come. I have driven down to tell
+you so. I know that James didn’t do it. I know it, and I want you to
+start upon your work knowing it, too. Never let yourself doubt upon
+that point. We have known each other since we were little children, and
+I know his faults as no one else does; but he is too tender-hearted to
+hurt a fly. Such a charge is absurd to any one who really knows him.”
+
+“I hope we may clear him, Miss Turner,” said Sherlock Holmes. “You may
+rely upon my doing all that I can.”
+
+“But you have read the evidence. You have formed some conclusion? Do
+you not see some loophole, some flaw? Do you not yourself think that he
+is innocent?”
+
+“I think that it is very probable.”
+
+“There, now!” she cried, throwing back her head, and looking defiantly
+at Lestrade. “You hear! He gives me hopes.”
+
+Lestrade shrugged his shoulders. “I am afraid that my colleague has
+been a little quick in forming his conclusions,” he said.
+
+“But he is right. Oh! I know that he is right. James never did it. And
+about his quarrel with his father, I am sure that the reason why he
+would not speak about it to the coroner was because I was concerned in
+it.”
+
+“In what way?” asked Holmes.
+
+“It is no time for me to hide anything. James and his father had many
+disagreements about me. Mr. McCarthy was very anxious that there should
+be a marriage between us. James and I have always loved each other as
+brother and sister; but of course he is young, and has seen very little
+of life yet, and—and—well, he naturally did not wish to do anything
+like that yet. So there were quarrels, and this, I am sure, was one of
+them.”
+
+“And your father?” asked Holmes. “Was he in favor of such a union?”
+
+“No, he was averse to it also. No one but Mr. McCarthy was in favor of
+it.” A quick blush passed over her fresh young face as Holmes shot one
+of his keen, questioning glances at her.
+
+“Thank you for this information,” said he. “May I see your father if I
+call to-morrow?”
+
+“I am afraid the doctor won’t allow it.”
+
+“The doctor?”
+
+“Yes, have you not heard? Poor father has never been strong for years
+back, but this has broken him down completely. He has taken to his bed,
+and Dr. Willows says that he is a wreck, and that his nervous system is
+shattered. Mr. McCarthy was the only man alive who had known dad in the
+old days in Victoria.”
+
+“Ha! In Victoria! That is important.”
+
+“Yes, at the mines.”
+
+“Quite so; at the gold-mines, where, as I understand, Mr. Turner made
+his money.”
+
+“Yes, certainly.”
+
+“Thank you, Miss Turner. You have been of material assistance to me.”
+
+“You will tell me if you have any news to-morrow. No doubt you will go
+to the prison to see James. Oh, if you do, Mr. Holmes, do tell him that
+I know him to be innocent.”
+
+“I will, Miss Turner.”
+
+“I must go home now, for dad is very ill, and he misses me so if I
+leave him. Good-bye, and God help you in your undertaking.” She hurried
+from the room as impulsively as she had entered, and we heard the
+wheels of her carriage rattle off down the street.
+
+“I am ashamed of you, Holmes,” said Lestrade, with dignity, after a few
+minutes’ silence. “Why should you raise up hopes which you are bound to
+disappoint? I am not over-tender of heart, but I call it cruel.”
+
+“I think that I see my way to clearing James McCarthy,” said Holmes.
+“Have you an order to see him in prison?”
+
+“Yes, but only for you and me.”
+
+“Then I shall reconsider my resolution about going out. We have still
+time to take a train to Hereford and see him to-night?”
+
+“Ample.”
+
+“Then let us do so. Watson, I fear that you will find it very slow, but
+I shall only be away a couple of hours.”
+
+I walked down to the station with them, and then wandered through the
+streets of the little town, finally returning to the hotel, where I
+lay upon the sofa and tried to interest myself in a yellow-backed
+novel. The puny plot of the story was so thin, however, when compared
+to the deep mystery through which we were groping, and I found my
+attention wander so continually from the fiction to the fact, that I
+at last flung it across the room, and gave myself up entirely to a
+consideration of the events of the day. Supposing that this unhappy
+young man’s story was absolutely true, then what hellish thing, what
+absolutely unforeseen and extraordinary calamity could have occurred
+between the time when he parted from his father, and the moment when,
+drawn back by his screams, he rushed into the glade? It was something
+terrible and deadly. What could it be? Might not the nature of the
+injuries reveal something to my medical instincts? I rang the bell,
+and called for the weekly county paper, which contained a verbatim
+account of the inquest. In the surgeon’s deposition it was stated that
+the posterior third of the left parietal bone and the left half of the
+occipital bone had been shattered by a heavy blow from a blunt weapon.
+I marked the spot upon my own head. Clearly such a blow must have been
+struck from behind. That was to some extent in favor of the accused,
+as when seen quarrelling he was face to face with his father. Still,
+it did not go for very much, for the older man might have turned his
+back before the blow fell. Still, it might be worth while to call
+Holmes’s attention to it. Then there was the peculiar dying reference
+to a rat. What could that mean? It could not be delirium. A man dying
+from a sudden blow does not commonly become delirious. No, it was more
+likely to be an attempt to explain how he met his fate. But what could
+it indicate? I cudgelled my brains to find some possible explanation.
+And then the incident of the gray cloth, seen by young McCarthy. If
+that were true, the murderer must have dropped some part of his dress,
+presumably his overcoat, in his flight, and must have had the hardihood
+to return and to carry it away at the instant when the son was kneeling
+with his back turned not a dozen paces off. What a tissue of mysteries
+and improbabilities the whole thing was! I did not wonder at Lestrade’s
+opinion, and yet I had so much faith in Sherlock Holmes’s insight that
+I could not lose hope as long as every fresh fact seemed to strengthen
+his conviction of young McCarthy’s innocence.
+
+It was late before Sherlock Holmes returned. He came back alone, for
+Lestrade was staying in lodgings in the town.
+
+“The glass still keeps very high,” he remarked, as he sat down. “It is
+of importance that it should not rain before we are able to go over the
+ground. On the other hand, a man should be at his very best and keenest
+for such nice work as that, and I did not wish to do it when fagged by
+a long journey. I have seen young McCarthy.”
+
+“And what did you learn from him?”
+
+“Nothing.”
+
+“Could he throw no light?”
+
+“None at all. I was inclined to think at one time that he knew who had
+done it, and was screening him or her, but I am convinced now that he
+is as puzzled as every one else. He is not a very quick-witted youth,
+though comely to look at, and, I should think, sound at heart.”
+
+“I cannot admire his taste,” I remarked, “if it is indeed a fact that
+he was averse to a marriage with so charming a young lady as this Miss
+Turner.”
+
+“Ah, thereby hangs a rather painful tale. This fellow is madly,
+insanely in love with her, but some two years ago, when he was only a
+lad, and before he really knew her, for she had been away five years at
+a boarding-school, what does the idiot do but get into the clutches of
+a barmaid in Bristol, and marry her at a registry office? No one knows
+a word of the matter, but you can imagine how maddening it must be to
+him to be upbraided for not doing what he would give his very eyes to
+do, but what he knows to be absolutely impossible. It was sheer frenzy
+of this sort which made him throw his hands up into the air when his
+father, at their last interview, was goading him on to propose to Miss
+Turner. On the other hand, he had no means of supporting himself, and
+his father, who was by all accounts a very hard man, would have thrown
+him over utterly had he known the truth. It was with his barmaid wife
+that he had spent the last three days in Bristol, and his father did
+not know where he was. Mark that point. It is of importance. Good has
+come out of evil, however, for the barmaid, finding from the papers
+that he is in serious trouble, and likely to be hanged, has thrown
+him over utterly, and has written to him to say that she has a husband
+already in the Bermuda Dockyard, so that there is really no tie between
+them. I think that that bit of news has consoled young McCarthy for all
+that he has suffered.”
+
+“But if he is innocent, who has done it?”
+
+“Ah! who? I would call your attention very particularly to two points.
+One is that the murdered man had an appointment with some one at the
+Pool, and that the some one could not have been his son, for his son
+was away, and he did not know when he would return. The second is that
+the murdered man was heard to cry ‘Cooee!’ before he knew that his son
+had returned. Those are the crucial points upon which the case depends.
+And now let us talk about George Meredith, if you please, and we shall
+leave all minor matters until to-morrow.”
+
+There was no rain, as Holmes had foretold, and the morning broke
+bright and cloudless. At nine o’clock Lestrade called for us with the
+carriage, and we set off for Hatherley Farm and the Boscombe Pool.
+
+“There is serious news this morning,” Lestrade observed. “It is said
+that Mr. Turner, of the Hall, is so ill that his life is despaired of.”
+
+“An elderly man, I presume?” said Holmes.
+
+“About sixty; but his constitution has been shattered by his life
+abroad, and he has been in failing health for some time. This business
+has had a very bad effect upon him. He was an old friend of McCarthy’s,
+and, I may add, a great benefactor to him, for I have learned that he
+gave him Hatherley Farm rent free.”
+
+“Indeed! That is interesting,” said Holmes.
+
+“Oh yes! In a hundred other ways he has helped him. Everybody about
+here speaks of his kindness to him.”
+
+“Really! Does it not strike you as a little singular that this
+McCarthy, who appears to have had little of his own, and to have been
+under such obligations to Turner, should still talk of marrying his
+son to Turner’s daughter, who is, presumably, heiress to the estate,
+and that in such a very cocksure manner, as if it were merely a case of
+a proposal and all else would follow? It is the more strange, since we
+know that Turner himself was averse to the idea. The daughter told us
+as much. Do you not deduce something from that?”
+
+“We have got to the deductions and the inferences,” said Lestrade,
+winking at me. “I find it hard enough to tackle facts, Holmes, without
+flying away after theories and fancies.”
+
+“You are right,” said Holmes, demurely; “you do find it very hard to
+tackle the facts.”
+
+“Anyhow, I have grasped one fact which you seem to find it difficult to
+get hold of,” replied Lestrade, with some warmth.
+
+“And that is—”
+
+“That McCarthy, senior, met his death from McCarthy, junior, and that
+all theories to the contrary are the merest moonshine.”
+
+“Well, moonshine is a brighter thing than fog,” said Holmes, laughing.
+“But I am very much mistaken if this is not Hatherley Farm upon the
+left.”
+
+“Yes, that is it.” It was a wide-spread, comfortable-looking building,
+two-storied, slate roofed, with great yellow blotches of lichen upon
+the gray walls. The drawn blinds and the smokeless chimneys, however,
+gave it a stricken look, as though the weight of this horror still
+lay heavy upon it. We called at the door, when the maid, at Holmes’s
+request, showed us the boots which her master wore at the time of his
+death, and also a pair of the son’s, though not the pair which he had
+then had. Having measured these very carefully from seven or eight
+different points, Holmes desired to be led to the court-yard, from
+which we all followed the winding track which led to Boscombe Pool.
+
+[Illustration: “THE MAID SHOWED US THE BOOTS.”]
+
+Sherlock Holmes was transformed when he was hot upon such a scent
+as this. Men who had only known the quiet thinker and logician of
+Baker Street would have failed to recognize him. His face flushed and
+darkened. His brows were drawn into two hard, black lines, while his
+eyes shone out from beneath them with a steely glitter. His face was
+bent downward, his shoulders bowed, his lips compressed, and the veins
+stood out like whip-cord in his long, sinewy neck. His nostrils seemed
+to dilate with a purely animal lust for the chase, and his mind was so
+absolutely concentrated upon the matter before him, that a question
+or remark fell unheeded upon his ears, or, at the most, only provoked
+a quick, impatient snarl in reply. Swiftly and silently he made his
+way along the track which ran through the meadows, and so by way of
+the woods to the Boscombe Pool. It was damp, marshy ground, as is all
+that district, and there were marks of many feet, both upon the path
+and amid the short grass which bounded it on either side. Sometimes
+Holmes would hurry on, sometimes stop dead, and once he made quite a
+little _détour_ into the meadow. Lestrade and I walked behind him, the
+detective indifferent and contemptuous, while I watched my friend with
+the interest which sprang from the conviction that every one of his
+actions was directed towards a definite end.
+
+The Boscombe Pool, which is a little reed-girt sheet of water some
+fifty yards across, is situated at the boundary between the Hatherley
+Farm and the private park of the wealthy Mr. Turner. Above the woods
+which lined it upon the farther side we could see the red, jutting
+pinnacles which marked the site of the rich land-owner’s dwelling. On
+the Hatherley side of the Pool the woods grew very thick, and there was
+a narrow belt of sodden grass twenty paces across between the edge of
+the trees and the reeds which lined the lake. Lestrade showed us the
+exact spot at which the body had been found, and, indeed, so moist was
+the ground, that I could plainly see the traces which had been left by
+the fall of the stricken man. To Holmes, as I could see by his eager
+face and peering eyes, very many other things were to be read upon the
+trampled grass. He ran round, like a dog who is picking up a scent, and
+then turned upon my companion.
+
+“What did you go into the Pool for?” he asked.
+
+“I fished about with a rake. I thought there might be some weapon or
+other trace. But how on earth—”
+
+“Oh, tut, tut! I have no time! That left foot of yours with its inward
+twist is all over the place. A mole could trace it, and there it
+vanishes among the reeds. Oh, how simple it would all have been had I
+been here before they came like a herd of buffalo, and wallowed all
+over it. Here is where the party with the lodge-keeper came, and they
+have covered all tracks for six or eight feet round the body. But
+here are three separate tracks of the same feet.” He drew out a lens,
+and lay down upon his waterproof to have a better view, talking all
+the time rather to himself than to us. “These are young McCarthy’s
+feet. Twice he was walking, and once he ran swiftly so that the soles
+are deeply marked, and the heels hardly visible. That bears out his
+story. He ran when he saw his father on the ground. Then here are the
+father’s feet as he paced up and down. What is this, then? It is the
+butt-end of the gun as the son stood listening. And this? Ha, ha! What
+have we here? Tiptoes! tiptoes! Square, too, quite unusual boots! They
+come, they go, they come again—of course that was for the cloak.
+Now where did they come from?” He ran up and down, sometimes losing,
+sometimes finding the track until we were well within the edge of the
+wood, and under the shadow of a great beech, the largest tree in the
+neighborhood. Holmes traced his way to the farther side of this, and
+lay down once more upon his face with a little cry of satisfaction.
+For a long time he remained there, turning over the leaves and dried
+sticks, gathering up what seemed to me to be dust into an envelope, and
+examining with his lens not only the ground, but even the bark of the
+tree as far as he could reach. A jagged stone was lying among the moss,
+and this also he carefully examined and retained. Then he followed a
+pathway through the wood until he came to the high-road, where all
+traces were lost.
+
+“It has been a case of considerable interest,” he remarked, returning
+to his natural manner. “I fancy that this gray house on the right must
+be the lodge. I think that I will go in and have a word with Moran, and
+perhaps write a little note. Having done that, we may drive back to our
+luncheon. You may walk to the cab, and I shall be with you presently.”
+
+It was about ten minutes before we regained our cab, and drove back
+into Ross, Holmes still carrying with him the stone which he had picked
+up in the wood.
+
+“This may interest you, Lestrade,” he remarked, holding it out. “The
+murder was done with it.”
+
+“I see no marks.”
+
+“There are none.”
+
+“How do you know, then?”
+
+“The grass was growing under it. It had only lain there a few days.
+There was no sign of a place whence it had been taken. It corresponds
+with the injuries. There is no sign of any other weapon.”
+
+“And the murderer?”
+
+“Is a tall man, left-handed, limps with the right leg, wears
+thick-soled shooting-boots and a gray cloak, smokes Indian cigars, uses
+a cigar-holder, and carries a blunt penknife in his pocket. There are
+several other indications, but these may be enough to aid us in our
+search.”
+
+Lestrade laughed. “I am afraid that I am still a sceptic,” he said.
+“Theories are all very well, but we have to deal with a hard-headed
+British jury.”
+
+“_Nous verrons_,” answered Holmes, calmly. “You work your own method,
+and I shall work mine. I shall be busy this afternoon, and shall
+probably return to London by the evening train.”
+
+“And leave your case unfinished?”
+
+“No, finished.”
+
+“But the mystery?”
+
+“It is solved.”
+
+“Who was the criminal, then?”
+
+“The gentleman I describe.”
+
+“But who is he?”
+
+“Surely it would not be difficult to find out. This is not such a
+populous neighborhood.”
+
+Lestrade shrugged his shoulders. “I am a practical man,” he said,
+“and I really cannot undertake to go about the country looking
+for a left-handed gentleman with a game-leg. I should become the
+laughing-stock of Scotland Yard.”
+
+“All right,” said Holmes, quietly. “I have given you the chance. Here
+are your lodgings. Good-bye. I shall drop you a line before I leave.”
+
+Having left Lestrade at his rooms, we drove to our hotel, where we
+found lunch upon the table. Holmes was silent and buried in thought
+with a pained expression upon his face, as one who finds himself in a
+perplexing position.
+
+“Look here, Watson,” he said, when the cloth was cleared; “just sit
+down in this chair and let me preach to you for a little. I don’t quite
+know what to do, and I should value your advice. Light a cigar, and let
+me expound.”
+
+“Pray do so.”
+
+“Well, now, in considering this case there are two points about young
+McCarthy’s narrative which struck us both instantly, although they
+impressed me in his favor and you against him. One was the fact that
+his father should, according to his account, cry ‘Cooee!’ before seeing
+him. The other was his singular dying reference to a rat. He mumbled
+several words, you understand, but that was all that caught the son’s
+ear. Now from this double point our research must commence, and we will
+begin it by presuming that what the lad says is absolutely true.”
+
+“What of this ‘Cooee!’ then?”
+
+“Well, obviously it could not have been meant for the son. The son, as
+far as he knew, was in Bristol. It was mere chance that he was within
+ear-shot. The ‘Cooee!’ was meant to attract the attention of whoever
+it was that he had the appointment with. But ‘Cooee’ is a distinctly
+Australian cry, and one which is used between Australians. There is a
+strong presumption that the person whom McCarthy expected to meet him
+at Boscombe Pool was some one who had been in Australia.”
+
+“What of the rat, then?”
+
+Sherlock Holmes took a folded paper from his pocket and flattened it
+out on the table. “This is a map of the Colony of Victoria,” he said.
+“I wired to Bristol for it last night.” He put his hand over part of
+the map. “What do you read?” he asked.
+
+“ARAT,” I read.
+
+“And now?” He raised his hand.
+
+“BALLARAT.”
+
+“Quite so. That was the word the man uttered, and of which his son only
+caught the last two syllables. He was trying to utter the name of his
+murderer. So-and-so, of Ballarat.”
+
+“It is wonderful!” I exclaimed.
+
+“It is obvious. And now, you see, I had narrowed the field down
+considerably. The possession of a gray garment was a third point
+which, granting the son’s statement to be correct, was a certainty. We
+have come now out of mere vagueness to the definite conception of an
+Australian from Ballarat with a gray cloak.”
+
+“Certainly.”
+
+“And one who was at home in the district, for the Pool can only be
+approached by the farm or by the estate, where strangers could hardly
+wander.”
+
+“Quite so.”
+
+“Then comes our expedition of to-day. By an examination of the ground I
+gained the trifling details which I gave to that imbecile Lestrade, as
+to the personality of the criminal.”
+
+“But how did you gain them?”
+
+“You know my method. It is founded upon the observance of trifles.”
+
+“His height I know that you might roughly judge from the length of his
+stride. His boots, too, might be told from their traces.”
+
+“Yes, they were peculiar boots.”
+
+“But his lameness?”
+
+“The impression of his right foot was always less distinct than his
+left. He put less weight upon it. Why? Because he limped—he was lame.”
+
+“But his left-handedness.”
+
+“You were yourself struck by the nature of the injury as recorded
+by the surgeon at the inquest. The blow was struck from immediately
+behind, and yet was upon the left side. Now, how can that be unless it
+were by a left-handed man? He had stood behind that tree during the
+interview between the father and son. He had even smoked there. I found
+the ash of a cigar, which my special knowledge of tobacco ashes enabled
+me to pronounce as an Indian cigar. I have, as you know, devoted some
+attention to this, and written a little monograph on the ashes of 140
+different varieties of pipe, cigar, and cigarette tobacco. Having found
+the ash, I then looked round and discovered the stump among the moss
+where he had tossed it. It was an Indian cigar, of the variety which
+are rolled in Rotterdam.”
+
+“And the cigar-holder?”
+
+“I could see that the end had not been in his mouth. Therefore he used
+a holder. The tip had been cut off, not bitten off, but the cut was not
+a clean one, so I deduced a blunt pen-knife.”
+
+“Holmes,” I said, “you have drawn a net round this man from which he
+cannot escape, and you have saved an innocent human life as truly as
+if you had cut the cord which was hanging him. I see the direction in
+which all this points. The culprit is—”
+
+“Mr. John Turner,” cried the hotel waiter, opening the door of our
+sitting-room, and ushering in a visitor.
+
+The man who entered was a strange and impressive figure. His slow,
+limping step and bowed shoulders gave the appearance of decrepitude,
+and yet his hard, deep-lined, craggy features, and his enormous
+limbs showed that he was possessed of unusual strength of body and
+of character. His tangled beard, grizzled hair, and outstanding,
+drooping eyebrows combined to give an air of dignity and power to his
+appearance, but his face was of an ashen white, while his lips and the
+corners of his nostrils were tinged with a shade of blue. It was clear
+to me at a glance that he was in the grip of some deadly and chronic
+disease.
+
+“Pray sit down on the sofa,” said Holmes, gently. “You had my note?”
+
+“Yes, the lodge-keeper brought it up. You said that you wished to see
+me here to avoid scandal.”
+
+“I thought people would talk if I went to the Hall.”
+
+“And why did you wish to see me?” He looked across at my companion with
+despair in his weary eyes, as though his question was already answered.
+
+“Yes,” said Holmes, answering the look rather than the words. “It is
+so. I know all about McCarthy.”
+
+The old man sank his face in his hands. “God help me!” he cried. “But I
+would not have let the young man come to harm. I give you my word that
+I would have spoken out if it went against him at the Assizes.”
+
+“I am glad to hear you say so,” said Holmes, gravely.
+
+“I would have spoken now had it not been for my dear girl. It would
+break her heart—it will break her heart when she hears that I am
+arrested.”
+
+“It may not come to that,” said Holmes.
+
+“What!”
+
+“I am no official agent. I understand that it was your daughter who
+required my presence here, and I am acting in her interests. Young
+McCarthy must be got off, however.”
+
+“I am a dying man,” said old Turner. “I have had diabetes for years. My
+doctor says it is a question whether I shall live a month. Yet I would
+rather die under my own roof than in a jail.”
+
+Holmes rose and sat down at the table with his pen in his hand and a
+bundle of paper before him. “Just tell us the truth,” he said. “I
+shall jot down the facts. You will sign it, and Watson here can witness
+it. Then I could produce your confession at the last extremity to save
+young McCarthy. I promise you that I shall not use it unless it is
+absolutely needed.”
+
+“It’s as well,” said the old man; “it’s a question whether I shall live
+to the Assizes, so it matters little to me, but I should wish to spare
+Alice the shock. And now I will make the thing clear to you; it has
+been a long time in the acting, but will not take me long to tell.
+
+“You didn’t know this dead man, McCarthy. He was a devil incarnate. I
+tell you that. God keep you out of the clutches of such a man as he.
+His grip has been upon me these twenty years, and he has blasted my
+life. I’ll tell you first how I came to be in his power.
+
+“It was in the early sixties at the diggings. I was a young chap then,
+hot-blooded and reckless, ready to turn my hand at anything; I got
+among bad companions, took to drink, had no luck with my claim, took to
+the bush, and in a word became what you would call over here a highway
+robber. There were six of us, and we had a wild, free life of it,
+sticking up a station from time to time, or stopping the wagons on the
+road to the diggings. Black Jack of Ballarat was the name I went under,
+and our party is still remembered in the colony as the Ballarat Gang.
+
+“One day a gold convoy came down from Ballarat to Melbourne, and we
+lay in wait for it and attacked it. There were six troopers and six of
+us, so it was a close thing, but we emptied four of their saddles at
+the first volley. Three of our boys were killed, however, before we
+got the swag. I put my pistol to the head of the wagon-driver, who was
+this very man McCarthy. I wish to the Lord that I had shot him then,
+but I spared him, though I saw his wicked little eyes fixed on my face,
+as though to remember every feature. We got away with the gold, became
+wealthy men, and made our way over to England without being suspected.
+There I parted from my old pals, and determined to settle down to a
+quiet and respectable life. I bought this estate, which chanced to be
+in the market, and I set myself to do a little good with my money,
+to make up for the way in which I had earned it. I married, too, and
+though my wife died young, she left me my dear little Alice. Even when
+she was just a baby her wee hand seemed to lead me down the right path
+as nothing else had ever done. In a word, I turned over a new leaf, and
+did my best to make up for the past. All was going well when McCarthy
+laid his grip upon me.
+
+“I had gone up to town about an investment, and I met him in Regent
+Street with hardly a coat to his back or a boot to his foot.
+
+“‘Here we are, Jack,’ says he, touching me on the arm; ‘we’ll be as
+good as a family to you. There’s two of us, me and my son, and you can
+have the keeping of us. If you don’t—it’s a fine, law-abiding country
+is England, and there’s always a policeman within hail.’
+
+“Well, down they came to the West country, there was no shaking them
+off, and there they have lived rent free on my best land ever since.
+There was no rest for me, no peace, no forgetfulness; turn where I
+would, there was his cunning, grinning face at my elbow. It grew worse
+as Alice grew up, for he soon saw I was more afraid of her knowing my
+past than of the police. Whatever he wanted he must have, and whatever
+it was I gave him without question, land, money, houses, until at last
+he asked a thing which I could not give. He asked for Alice.
+
+“His son, you see, had grown up, and so had my girl, and as I was known
+to be in weak health, it seemed a fine stroke to him that his lad
+should step into the whole property. But there I was firm. I would not
+have his cursed stock mixed with mine; not that I had any dislike to
+the lad, but his blood was in him, and that was enough. I stood firm.
+McCarthy threatened. I braved him to do his worst. We were to meet at
+the Pool midway between our houses to talk it over.
+
+“When I went down there I found him talking with his son, so I smoked
+a cigar, and waited behind a tree until he should be alone. But as I
+listened to his talk all that was black and bitter in me seemed to
+come uppermost. He was urging his son to marry my daughter with as
+little regard for what she might think as if she were a slut from off
+the streets. It drove me mad to think that I and all that I held most
+dear should be in the power of such a man as this. Could I not snap the
+bond? I was already a dying and a desperate man. Though clear of mind
+and fairly strong of limb, I knew that my own fate was sealed. But my
+memory and my girl! Both could be saved, if I could but silence that
+foul tongue. I did it, Mr. Holmes. I would do it again. Deeply as I
+have sinned, I have led a life of martyrdom to atone for it. But that
+my girl should be entangled in the same meshes which held me was more
+than I could suffer. I struck him down with no more compunction than if
+he had been some foul and venomous beast. His cry brought back his son;
+but I had gained the cover of the wood, though I was forced to go back
+to fetch the cloak which I had dropped in my flight. That is the true
+story, gentlemen, of all that occurred.”
+
+“Well, it is not for me to judge you,” said Holmes, as the old man
+signed the statement which had been drawn out. “I pray that we may
+never be exposed to such a temptation.”
+
+“I pray not, sir. And what do you intend to do?”
+
+“In view of your health, nothing. You are yourself aware that you will
+soon have to answer for your deed at a higher court than the Assizes.
+I will keep your confession, and, if McCarthy is condemned, I shall be
+forced to use it. If not, it shall never be seen by mortal eye; and
+your secret, whether you be alive or dead, shall be safe with us.”
+
+“Farewell, then,” said the old man, solemnly. “Your own death-beds,
+when they come, will be the easier for the thought of the peace which
+you have given to mine.” Tottering and shaking in all his giant frame,
+he stumbled slowly from the room.
+
+“God help us!” said Holmes, after a long silence. “Why does fate play
+such tricks with poor, helpless worms? I never hear of such a case as
+this that I do not think of Baxter’s words, and say, ‘There, but for
+the grace of God, goes Sherlock Holmes.’”
+
+James McCarthy was acquitted at the Assizes, on the strength of a
+number of objections which had been drawn out by Holmes, and submitted
+to the defending counsel. Old Turner lived for seven months after our
+interview, but he is now dead; and there is every prospect that the son
+and daughter may come to live happily together, in ignorance of the
+black cloud which rests upon their past.
+
+
+
+
+Adventure V
+
+THE FIVE ORANGE PIPS
+
+
+When I glance over my notes and records of the Sherlock Holmes cases
+between the years ’82 and ’90, I am faced by so many which present
+strange and interesting features that it is no easy matter to know
+which to choose and which to leave. Some, however, have already gained
+publicity through the papers, and others have not offered a field
+for those peculiar qualities which my friend possessed in so high a
+degree, and which it is the object of these papers to illustrate. Some,
+too, have baffled his analytical skill, and would be, as narratives,
+beginnings without an ending, while others have been but partially
+cleared up, and have their explanations founded rather upon conjecture
+and surmise than on that absolute logical proof which was so dear to
+him. There is, however, one of these last which was so remarkable in
+its details and so startling in its results that I am tempted to give
+some account of it, in spite of the fact that there are points in
+connection with it which never have been, and probably never will be,
+entirely cleared up.
+
+The year ’87 furnished us with a long series of cases of greater
+or less interest, of which I retain the records. Among my headings
+under this one twelve months I find an account of the adventure of
+the Paradol Chamber, of the Amateur Mendicant Society, who held a
+luxurious club in the lower vault of a furniture warehouse, of the
+facts connected with the loss of the British bark _Sophy Anderson_, of
+the singular adventures of the Grice Patersons in the island of Uffa,
+and finally of the Camberwell poisoning case. In the latter, as may
+be remembered, Sherlock Holmes was able, by winding up the dead man’s
+watch, to prove that it had been wound up two hours before, and that
+therefore the deceased had gone to bed within that time—a deduction
+which was of the greatest importance in clearing up the case. All these
+I may sketch out at some future date, but none of them present such
+singular features as the strange train of circumstances which I have
+now taken up my pen to describe.
+
+It was in the latter days of September, and the equinoctial gales had
+set in with exceptional violence. All day the wind had screamed and the
+rain had beaten against the windows, so that even here in the heart
+of great, hand-made London we were forced to raise our minds for the
+instant from the routine of life, and to recognize the presence of
+those great elemental forces which shriek at mankind through the bars
+of his civilization, like untamed beasts in a cage. As evening drew in,
+the storm grew higher and louder, and the wind cried and sobbed like a
+child in the chimney. Sherlock Holmes sat moodily at one side of the
+fireplace cross-indexing his records of crime, while I at the other was
+deep in one of Clark Russell’s fine sea-stories, until the howl of the
+gale from without seemed to blend with the text, and the splash of the
+rain to lengthen out into the long swash of the sea waves. My wife was
+on a visit to her mother’s, and for a few days I was a dweller once
+more in my old quarters at Baker Street.
+
+“Why,” said I, glancing up at my companion, “that was surely the bell.
+Who could come to-night? Some friend of yours, perhaps?”
+
+“Except yourself I have none,” he answered. “I do not encourage
+visitors.”
+
+“A client, then?”
+
+“If so, it is a serious case. Nothing less would bring a man out on
+such a day and at such an hour. But I take it that it is more likely to
+be some crony of the landlady’s.”
+
+Sherlock Holmes was wrong in his conjecture, however, for there came
+a step in the passage and a tapping at the door. He stretched out his
+long arm to turn the lamp away from himself and towards the vacant
+chair upon which a new-comer must sit. “Come in!” said he.
+
+The man who entered was young, some two-and-twenty at the outside,
+well-groomed and trimly clad, with something of refinement and delicacy
+in his bearing. The steaming umbrella which he held in his hand, and
+his long shining waterproof told of the fierce weather through which he
+had come. He looked about him anxiously in the glare of the lamp, and
+I could see that his face was pale and his eyes heavy, like those of a
+man who is weighed down with some great anxiety.
+
+“I owe you an apology,” he said, raising his golden _pince-nez_ to his
+eyes. “I trust that I am not intruding. I fear that I have brought some
+traces of the storm and rain into your snug chamber.”
+
+“Give me your coat and umbrella,” said Holmes. “They may rest here
+on the hook, and will be dry presently. You have come up from the
+south-west, I see.”
+
+“Yes, from Horsham.”
+
+“That clay and chalk mixture which I see upon your toe-caps is quite
+distinctive.”
+
+“I have come for advice.”
+
+“That is easily got.”
+
+“And help.”
+
+“That is not always so easy.”
+
+“I have heard of you, Mr. Holmes. I heard from Major Prendergast how
+you saved him in the Tankerville Club Scandal.”
+
+“Ah, of course. He was wrongfully accused of cheating at cards.”
+
+“He said that you could solve anything.”
+
+“He said too much.”
+
+“That you are never beaten.”
+
+“I have been beaten four times—three times by men, and once by a
+woman.”
+
+“But what is that compared with the number of your successes?”
+
+“It is true that I have been generally successful.”
+
+“Then you may be so with me.”
+
+“I beg that you will draw your chair up to the fire, and favor me with
+some details as to your case.”
+
+“It is no ordinary one.”
+
+“None of those which come to me are. I am the last court of appeal.”
+
+“And yet I question, sir, whether, in all your experience, you have
+ever listened to a more mysterious and inexplicable chain of events
+than those which have happened in my own family.”
+
+“You fill me with interest,” said Holmes. “Pray give us the essential
+facts from the commencement, and I can afterwards question you as to
+those details which seem to me to be most important.”
+
+The young man pulled his chair up, and pushed his wet feet out towards
+the blaze.
+
+“My name,” said he, “is John Openshaw, but my own affairs have, as far
+as I can understand it, little to do with this awful business. It is an
+hereditary matter; so in order to give you an idea of the facts, I must
+go back to the commencement of the affair.
+
+“You must know that my grandfather had two sons—my uncle Elias and
+my father Joseph. My father had a small factory at Coventry, which
+he enlarged at the time of the invention of bicycling. He was the
+patentee of the Openshaw unbreakable tire, and his business met with
+such success that he was able to sell it, and to retire upon a handsome
+competence.
+
+“My uncle Elias emigrated to America when he was a young man, and
+became a planter in Florida, where he was reported to have done
+very well. At the time of the war he fought in Jackson’s army, and
+afterwards under Hood, where he rose to be a colonel. When Lee laid
+down his arms my uncle returned to his plantation, where he remained
+for three or four years. About 1869 or 1870 he came back to Europe,
+and took a small estate in Sussex, near Horsham. He had made a very
+considerable fortune in the States, and his reason for leaving them was
+his aversion to the negroes, and his dislike of the Republican policy
+in extending the franchise to them. He was a singular man, fierce and
+quick-tempered, very foul-mouthed when he was angry, and of a most
+retiring disposition. During all the years that he lived at Horsham I
+doubt if ever he set foot in the town. He had a garden and two or three
+fields round his house, and there he would take his exercise, though
+very often for weeks on end he would never leave his room. He drank
+a great deal of brandy, and smoked very heavily, but he would see no
+society, and did not want any friends, not even his own brother.
+
+“He didn’t mind me, in fact, he took a fancy to me, for at the time
+when he saw me first I was a youngster of twelve or so. This would be
+in the year 1878, after he had been eight or nine years in England. He
+begged my father to let me live with him, and he was very kind to me
+in his way. When he was sober he used to be fond of playing backgammon
+and draughts with me, and he would make me his representative both with
+the servants and with the tradespeople, so that by the time that I was
+sixteen I was quite master of the house. I kept all the keys, and could
+go where I liked and do what I liked, so long as I did not disturb him
+in his privacy. There was one singular exception, however, for he had
+a single room, a lumber-room up among the attics, which was invariably
+locked, and which he would never permit either me or anyone else to
+enter. With a boy’s curiosity I have peeped through the key-hole, but
+I was never able to see more than such a collection of old trunks and
+bundles as would be expected in such a room.
+
+“One day—it was in March, 1883—a letter with a foreign stamp lay
+upon the table in front of the Colonel’s plate. It was not a common
+thing for him to receive letters, for his bills were all paid in
+ready money, and he had no friends of any sort. ‘From India!’ said he,
+as he took it up, ‘Pondicherry postmark! What can this be?’ Opening
+it hurriedly, out there jumped five little dried orange pips, which
+pattered down upon his plate. I began to laugh at this, but the laugh
+was struck from my lips at the sight of his face. His lip had fallen,
+his eyes were protruding, his skin the color of putty, and he glared at
+the envelope which he still held in his trembling hand. ‘K. K. K.!’ he
+shrieked, and then, ‘My God, my God, my sins have overtaken me!’
+
+“‘What is it, uncle?’ I cried.
+
+“‘Death,’ said he, and rising from the table he retired to his room,
+leaving me palpitating with horror. I took up the envelope, and saw
+scrawled in red ink upon the inner flap, just above the gum, the letter
+K three times repeated. There was nothing else save the five dried
+pips. What could be the reason of his overpowering terror? I left the
+breakfast-table, and as I ascended the stair I met him coming down with
+an old rusty key, which must have belonged to the attic, in one hand,
+and a small brass box, like a cash-box, in the other.
+
+“‘They may do what they like, but I’ll checkmate them still,’ said he,
+with an oath. ‘Tell Mary that I shall want a fire in my room to-day,
+and send down to Fordham, the Horsham lawyer.’
+
+“I did as he ordered, and when the lawyer arrived I was asked to step
+up to the room. The fire was burning brightly, and in the grate there
+was a mass of black, fluffy ashes, as of burned paper, while the brass
+box stood open and empty beside it. As I glanced at the box I noticed,
+with a start, that upon the lid were printed the treble K which I had
+read in the morning upon the envelope.
+
+“‘I wish you, John,’ said my uncle, ‘to witness my will. I leave
+my estate, with all its advantages and all its disadvantages to my
+brother, your father, whence it will, no doubt, descend to you. If you
+can enjoy it in peace, well and good! If you find you cannot, take my
+advice, my boy, and leave it to your deadliest enemy. I am sorry to
+give you such a two-edged thing, but I can’t say what turn things are
+going to take. Kindly sign the paper where Mr. Fordham shows you.’
+
+“I signed the paper as directed, and the lawyer took it away with him.
+The singular incident made, as you may think, the deepest impression
+upon me, and I pondered over it, and turned it every way in my mind
+without being able to make anything of it. Yet I could not shake off
+the vague feeling of dread which it left behind though the sensation
+grew less keen as the weeks passed, and nothing happened to disturb
+the usual routine of our lives. I could see a change in my uncle,
+however. He drank more than ever, and he was less inclined for any
+sort of society. Most of his time he would spend in his room, with the
+door locked upon the inside, but sometimes he would emerge in a sort
+of drunken frenzy, and would burst out of the house and tear about the
+garden with a revolver in his hand, screaming out that he was afraid
+of no man, and that he was not to be cooped up, like a sheep in a pen,
+by man or devil. When these hot fits were over, however, he would rush
+tumultuously in at the door, and lock and bar it behind him, like a man
+who can brazen it out no longer against the terror which lies at the
+roots of his soul. At such times I have seen his face, even on a cold
+day, glisten with moisture, as though it were new raised from a basin.
+
+“Well, to come to an end of the matter, Mr. Holmes, and not to abuse
+your patience, there came a night when he made one of those drunken
+sallies from which he never came back. We found him, when we went to
+search for him, face downward in a little green-scummed pool, which lay
+at the foot of the garden. There was no sign of any violence, and the
+water was but two feet deep, so that the jury, having regard to his
+known eccentricity, brought in a verdict of suicide. But I, who knew
+how he winced from the very thought of death, had much ado to persuade
+myself that he had gone out of his way to meet it. The matter passed,
+however, and my father entered into possession of the estate, and of
+some £14,000, which lay to his credit at the bank.”
+
+“One moment,” Holmes interposed. “Your statement is, I foresee, one
+of the most remarkable to which I have ever listened. Let me have the
+date of the reception by your uncle of the letter, and the date of his
+supposed suicide.”
+
+“The latter arrived on March 10, 1883. His death was seven weeks later,
+upon the night of May 2d.”
+
+“Thank you. Pray proceed.”
+
+“When my father took over the Horsham property, he, at my request, made
+a careful examination of the attic, which had been always locked up. We
+found the brass box there, although its contents had been destroyed. On
+the inside of the cover was a paper label, with the initials of K. K.
+K. repeated upon it, and ‘Letters, memoranda, receipts, and a register’
+written beneath. These, we presume, indicated the nature of the papers
+which had been destroyed by Colonel Openshaw. For the rest, there was
+nothing of much importance in the attic, save a great many scattered
+papers and note-books bearing upon my uncle’s life in America. Some
+of them were of the war time, and showed that he had done his duty
+well, and had borne the repute of a brave soldier. Others were of a
+date during the reconstruction of the Southern States, and were mostly
+concerned with politics, for he had evidently taken a strong part in
+opposing the carpet-bag politicians who had been sent down from the
+North.
+
+“Well, it was the beginning of ’84 when my father came to live at
+Horsham, and all went as well as possible with us until the January
+of ’85. On the fourth day after the new year I heard my father give a
+sharp cry of surprise as we sat together at the breakfast-table. There
+he was, sitting with a newly-opened envelope in one hand and five dried
+orange pips in the outstretched palm of the other one. He had always
+laughed at what he called my cock-and-a-bull story about the Colonel,
+but he looked very scared and puzzled now that the same thing had come
+upon himself.
+
+“‘Why, what on earth does this mean, John?’ he stammered.
+
+“My heart had turned to lead. ‘It is K. K. K.,’ said I.
+
+“He looked inside the envelope. ‘So it is,’ he cried. ‘Here are the
+very letters. But what is this written above them?’
+
+“‘Put the papers on the sundial,’ I read, peeping over his shoulder.
+
+“‘What papers? What sundial?’ he asked.
+
+“‘The sundial in the garden. There is no other,’ said I; ‘but the
+papers must be those that are destroyed.’
+
+“‘Pooh!’ said he, gripping hard at his courage. ‘We are in a civilized
+land here, and we can’t have tomfoolery of this kind. Where does the
+thing come from?’
+
+“‘From Dundee,’ I answered, glancing at the post-mark.
+
+“‘Some preposterous practical joke,’ said he. ‘What have I to do with
+sundials and papers? I shall take no notice of such nonsense.’
+
+“‘I should certainly speak to the police,’ I said.
+
+“‘And be laughed at for my pains. Nothing of the sort.’
+
+“‘Then let me do so?’
+
+“‘No, I forbid you. I won’t have a fuss made about such nonsense.’
+
+“It was in vain to argue with him, for he was a very obstinate man. I
+went about, however, with a heart which was full of forebodings.
+
+“On the third day after the coming of the letter my father went from
+home to visit an old friend of his, Major Freebody, who is in command
+of one of the forts upon Portsdown Hill. I was glad that he should go,
+for it seemed to me that he was farther from danger when he was away
+from home. In that, however, I was in error. Upon the second day of his
+absence I received a telegram from the Major, imploring me to come at
+once. My father had fallen over one of the deep chalk-pits which abound
+in the neighborhood, and was lying senseless, with a shattered skull. I
+hurried to him, but he passed away without having ever recovered his
+consciousness. He had, as it appears, been returning from Fareham in
+the twilight, and as the country was unknown to him, and the chalk-pit
+unfenced, the jury had no hesitation in bringing in a verdict of ‘Death
+from accidental causes.’ Carefully as I examined every fact connected
+with his death, I was unable to find anything which could suggest the
+idea of murder. There were no signs of violence, no footmarks, no
+robbery, no record of strangers having been seen upon the roads. And
+yet I need not tell you that my mind was far from at ease, and that I
+was wellnigh certain that some foul plot had been woven round him.
+
+“In this sinister way I came into my inheritance. You will ask me why
+I did not dispose of it? I answer, because I was well convinced that
+our troubles were in some way dependent upon an incident in my uncle’s
+life, and that the danger would be as pressing in one house as in
+another.
+
+“It was in January, ’85, that my poor father met his end, and two years
+and eight months have elapsed since then. During that time I have lived
+happily at Horsham, and I had begun to hope that this curse had passed
+away from the family, and that it had ended with the last generation. I
+had begun to take comfort too soon, however; yesterday morning the blow
+fell in the very shape in which it had come upon my father.”
+
+The young man took from his waistcoat a crumpled envelope, and, turning
+to the table, he shook out upon it five little dried orange pips.
+
+“This is the envelope,” he continued. “The post-mark is London—eastern
+division. Within are the very words which were upon my father’s last
+message: ‘K. K. K.’; and then ‘Put the papers on the sundial.’”
+
+“What have you done?” asked Holmes.
+
+“Nothing.”
+
+“Nothing?”
+
+“To tell the truth”—he sank his face into his thin, white hands—“I
+have felt helpless. I have felt like one of those poor rabbits when
+the snake is writhing towards it. I seem to be in the grasp of some
+resistless, inexorable evil, which no foresight and no precautions can
+guard against.”
+
+“Tut! tut!” cried Sherlock Holmes. “You must act, man, or you are lost.
+Nothing but energy can save you. This is no time for despair.”
+
+“I have seen the police.”
+
+“Ah!”
+
+“But they listened to my story with a smile. I am convinced that the
+inspector has formed the opinion that the letters are all practical
+jokes, and that the deaths of my relations were really accidents, as
+the jury stated, and were not to be connected with the warnings.”
+
+Holmes shook his clenched hands in the air. “Incredible imbecility!” he
+cried.
+
+“They have, however, allowed me a policeman, who may remain in the
+house with me.”
+
+“Has he come with you to-night?”
+
+“No. His orders were to stay in the house.”
+
+Again Holmes raved in the air.
+
+“Why did you come to me?” he said; “and, above all, why did you not
+come at once?”
+
+“I did not know. It was only to-day that I spoke to Major Prendergast
+about my troubles, and was advised by him to come to you.”
+
+“It is really two days since you had the letter. We should have acted
+before this. You have no further evidence, I suppose, than that which
+you have placed before us—no suggestive detail which might help us?”
+
+“There is one thing,” said John Openshaw. He rummaged in his coat
+pocket, and drawing out a piece of discolored, blue-tinted paper, he
+laid it out upon the table. “I have some remembrance,” said he, “that
+on the day when my uncle burned the papers I observed that the small,
+unburned margins which lay amid the ashes were of this particular
+color. I found this single sheet upon the floor of his room, and I am
+inclined to think that it may be one of the papers which has, perhaps,
+fluttered out from among the others, and in that way have escaped
+destruction. Beyond the mention of pips, I do not see that it helps us
+much. I think myself that it is a page from some private diary. The
+writing is undoubtedly my uncle’s.”
+
+Holmes moved the lamp, and we both bent over the sheet of paper, which
+showed by its ragged edge that it had indeed been torn from a book. It
+was headed, “March, 1869,” and beneath were the following enigmatical
+notices:
+
+“4th. Hudson came. Same old platform.
+
+“7th. Set the pips on McCauley, Paramore, and John Swain, of St.
+Augustine.
+
+“9th. McCauley cleared.
+
+“10th. John Swain cleared.
+
+“12th. Visited Paramore. All well.”
+
+“Thank you!” said Holmes, folding up the paper, and returning it to
+our visitor. “And now you must on no account lose another instant. We
+cannot spare time even to discuss what you have told me. You must get
+home instantly and act.”
+
+“What shall I do?”
+
+“There is but one thing to do. It must be done at once. You must put
+this piece of paper which you have shown us into the brass box which
+you have described. You must also put in a note to say that all the
+other papers were burned by your uncle, and that this is the only
+one which remains. You must assert that in such words as will carry
+conviction with them. Having done this, you must at once put the box
+out upon the sundial, as directed. Do you understand?”
+
+“Entirely.”
+
+“Do not think of revenge, or anything of the sort, at present. I think
+that we may gain that by means of the law; but we have our web to
+weave, while theirs is already woven. The first consideration is to
+remove the pressing danger which threatens you. The second is to clear
+up the mystery and to punish the guilty parties.”
+
+“I thank you,” said the young man, rising, and pulling on his overcoat.
+“You have given me fresh life and hope. I shall certainly do as you
+advise.”
+
+“Do not lose an instant. And, above all, take care of yourself in the
+meanwhile, for I do not think that there can be a doubt that you are
+threatened by a very real and imminent danger. How do you go back?”
+
+“By train from Waterloo.”
+
+“It is not yet nine. The streets will be crowded, so I trust that you
+may be in safety. And yet you cannot guard yourself too closely.”
+
+“I am armed.”
+
+“That is well. To-morrow I shall set to work upon your case.”
+
+“I shall see you at Horsham, then?”
+
+“No, your secret lies in London. It is there that I shall seek it.”
+
+“Then I shall call upon you in a day, or in two days, with news as to
+the box and the papers. I shall take your advice in every particular.”
+He shook hands with us, and took his leave. Outside the wind still
+screamed, and the rain splashed and pattered against the windows.
+This strange, wild story seemed to have come to us from amid the mad
+elements—blown in upon us like a sheet of sea-weed in a gale—and now
+to have been reabsorbed by them once more.
+
+Sherlock Holmes sat for some time in silence, with his head sunk
+forward and his eyes bent upon the red glow of the fire. Then he lit
+his pipe, and leaning back in his chair he watched the blue smoke-rings
+as they chased each other up to the ceiling.
+
+“I think, Watson,” he remarked at last, “that of all our cases we have
+had none more fantastic than this.”
+
+“Save, perhaps, the Sign of Four.”
+
+“Well, yes. Save, perhaps, that. And yet this John Openshaw seems to
+me to be walking amid even greater perils than did the Sholtos.”
+
+“But have you,” I asked, “formed any definite conception as to what
+these perils are?”
+
+“There can be no question as to their nature,” he answered.
+
+“Then what are they? Who is this K. K. K., and why does he pursue this
+unhappy family?”
+
+Sherlock Holmes closed his eyes and placed his elbows upon the arms
+of his chair, with his finger-tips together. “The ideal reasoner,” he
+remarked, “would, when he had once been shown a single fact in all
+its bearings, deduce from it not only all the chain of events which
+led up to it, but also all the results which would follow from it. As
+Cuvier could correctly describe a whole animal by the contemplation of
+a single bone, so the observer who has thoroughly understood one link
+in a series of incidents, should be able to accurately state all the
+other ones, both before and after. We have not yet grasped the results
+which the reason alone can attain to. Problems may be solved in the
+study which have baffled all those who have sought a solution by the
+aid of their senses. To carry the art, however, to its highest pitch,
+it is necessary that the reasoner should be able to utilize all the
+facts which have come to his knowledge; and this in itself implies,
+as you will readily see, a possession of all knowledge, which, even
+in these days of free education and encyclopædias, is a somewhat rare
+accomplishment. It is not so impossible, however, that a man should
+possess all knowledge which is likely to be useful to him in his work,
+and this I have endeavored in my case to do. If I remember rightly, you
+on one occasion, in the early days of our friendship, defined my limits
+in a very precise fashion.”
+
+“Yes,” I answered, laughing. “It was a singular document. Philosophy,
+astronomy, and politics were marked at zero, I remember. Botany
+variable, geology profound as regards the mud-stains from any region
+within fifty miles of town, chemistry eccentric, anatomy unsystematic,
+sensational literature and crime records unique, violin-player, boxer,
+swordsman, lawyer, and self-poisoner by cocaine and tobacco. Those, I
+think, were the main points of my analysis.”
+
+Holmes grinned at the last item. “Well,” he said, “I say now, as I said
+then, that a man should keep his little brain-attic stocked with all
+the furniture that he is likely to use, and the rest he can put away
+in the lumber-room of his library, where he can get it if he wants
+it. Now, for such a case as the one which has been submitted to us
+to-night, we need certainly to muster all our resources. Kindly hand
+me down the letter K of the American Encyclopædia which stands upon
+the shelf beside you. Thank you. Now let us consider the situation,
+and see what may be deduced from it. In the first place, we may start
+with a strong presumption that Colonel Openshaw had some very strong
+reason for leaving America. Men at his time of life do not change all
+their habits, and exchange willingly the charming climate of Florida
+for the lonely life of an English provincial town. His extreme love of
+solitude in England suggests the idea that he was in fear of some one
+or something, so we may assume as a working hypothesis that it was fear
+of some one or something which drove him from America. As to what it
+was he feared, we can only deduce that by considering the formidable
+letters which were received by himself and his successors. Did you
+remark the post-marks of those letters?”
+
+“The first was from Pondicherry, the second from Dundee, and the third
+from London.”
+
+“From East London. What do you deduce from that?”
+
+“They are all seaports. That the writer was on board of a ship.”
+
+“Excellent. We have already a clew. There can be no doubt that the
+probability—the strong probability—is that the writer was on board
+of a ship. And now let us consider another point. In the case of
+Pondicherry, seven weeks elapsed between the threat and its fulfilment,
+in Dundee it was only some three or four days. Does that suggest
+anything?”
+
+“A greater distance to travel.”
+
+“But the letter had also a greater distance to come.”
+
+“Then I do not see the point.”
+
+“There is at least a presumption that the vessel in which the man
+or men are is a sailing-ship. It looks as if they always sent their
+singular warning or token before them when starting upon their mission.
+You see how quickly the deed followed the sign when it came from
+Dundee. If they had come from Pondicherry in a steamer they would
+have arrived almost as soon as their letter. But as a matter of fact
+seven weeks elapsed. I think that those seven weeks represented the
+difference between the mail-boat which brought the letter, and the
+sailing-vessel which brought the writer.”
+
+“It is possible.”
+
+“More than that. It is probable. And now you see the deadly urgency of
+this new case, and why I urged young Openshaw to caution. The blow has
+always fallen at the end of the time which it would take the senders to
+travel the distance. But this one comes from London, and therefore we
+cannot count upon delay.”
+
+“Good God!” I cried; “what can it mean, this relentless persecution?”
+
+“The papers which Openshaw carried are obviously of vital importance
+to the person or persons in the sailing-ship. I think that it is quite
+clear that there must be more than one of them. A single man could not
+have carried out two deaths in such a way as to deceive a coroner’s
+jury. There must have been several in it, and they must have been men
+of resource and determination. Their papers they mean to have, be the
+holder of them who it may. In this way you see K. K. K. ceases to be
+the initials of an individual, and becomes the badge of a society.”
+
+“But of what society?”
+
+“Have you never—” said Sherlock Holmes, bending forward and sinking
+his voice—“have you never heard of the Ku Klux Klan?”
+
+“I never have.”
+
+Holmes turned over the leaves of the book upon his knee. “Here it
+is,” said he, presently, “‘Ku Klux Klan. A name derived from the
+fanciful resemblance to the sound produced by cocking a rifle. This
+terrible secret society was formed by some ex-Confederate soldiers in
+the Southern States after the Civil War, and it rapidly formed local
+branches in different parts of the country, notably in Tennessee,
+Louisiana, the Carolinas, Georgia, and Florida. Its power was used
+for political purposes, principally for the terrorizing of the negro
+voters, and the murdering and driving from the country of those who
+were opposed to its views. Its outrages were usually preceded by
+a warning sent to the marked man in some fantastic but generally
+recognized shape—a sprig of oak-leaves in some parts, melon seeds or
+orange pips in others. On receiving this the victim might either openly
+abjure his former ways, or might fly from the country. If he braved the
+matter out, death would unfailingly come upon him, and usually in some
+strange and unforeseen manner. So perfect was the organization of the
+society, and so systematic its methods, that there is hardly a case
+upon record where any man succeeded in braving it with impunity, or in
+which any of its outrages were traced home to the perpetrators. For
+some years the organization flourished, in spite of the efforts of the
+United States Government and of the better classes of the community in
+the South. Eventually, in the year 1869, the movement rather suddenly
+collapsed, although there have been sporadic outbreaks of the same sort
+since that date.’
+
+“You will observe,” said Holmes, laying down the volume, “that the
+sudden breaking up of the society was coincident with the disappearance
+of Openshaw from America with their papers. It may well have been cause
+and effect. It is no wonder that he and his family have some of the
+more implacable spirits upon their track. You can understand that this
+register and diary may implicate some of the first men in the South,
+and that there may be many who will not sleep easy at night until it is
+recovered.”
+
+“Then the page we have seen—”
+
+“Is such as we might expect. It ran, if I remember right, ‘sent the
+pips to A, B, and C,’—that is, sent the society’s warning to them.
+Then there are successive entries that A and B cleared, or left the
+country, and finally that C was visited, with, I fear, a sinister
+result for C. Well, I think, Doctor, that we may let some light into
+this dark place, and I believe that the only chance young Openshaw has
+in the mean time is to do what I have told him. There is nothing more
+to be said or to be done to-night, so hand me over my violin, and let
+us try to forget for half an hour the miserable weather and the still
+more miserable ways of our fellow-men.”
+
+       *       *       *       *       *
+
+It had cleared in the morning, and the sun was shining with a subdued
+brightness through the dim veil which hangs over the great city.
+Sherlock Holmes was already at breakfast when I came down.
+
+“You will excuse me for not waiting for you,” said he; “I have, I
+foresee, a very busy day before me in looking into this case of young
+Openshaw’s.”
+
+“What steps will you take?” I asked.
+
+“It will very much depend upon the results of my first inquiries. I may
+have to go down to Horsham, after all.”
+
+“You will not go there first?”
+
+“No, I shall commence with the city. Just ring the bell, and the maid
+will bring up your coffee.”
+
+As I waited, I lifted the unopened newspaper from the table and glanced
+my eye over it. It rested upon a heading which sent a chill to my heart.
+
+“Holmes,” I cried, “you are too late.”
+
+“Ah!” said he, laying down his cup, “I feared as much. How was it
+done?” He spoke calmly, but I could see that he was deeply moved.
+
+“My eye caught the name of Openshaw, and the heading, ‘Tragedy near
+Waterloo Bridge.’ Here is the account: ‘Between nine and ten last
+night Police-constable Cook, of the H Division, on duty near Waterloo
+Bridge, heard a cry for help and a splash in the water. The night,
+however, was extremely dark and stormy, so that, in spite of the help
+of several passers-by, it was quite impossible to effect a rescue.
+The alarm, however, was given, and, by the aid of the water-police,
+the body was eventually recovered. It proved to be that of a young
+gentleman whose name, as it appears from an envelope which was found in
+his pocket, was John Openshaw, and whose residence is near Horsham. It
+is conjectured that he may have been hurrying down to catch the last
+train from Waterloo Station, and that in his haste and the extreme
+darkness he missed his path and walked over the edge of one of the
+small landing-places for river steamboats. The body exhibited no traces
+of violence, and there can be no doubt that the deceased had been
+the victim of an unfortunate accident, which should have the effect
+of calling the attention of the authorities to the condition of the
+river-side landing-stages.’”
+
+We sat in silence for some minutes, Holmes more depressed and shaken
+than I had ever seen him.
+
+“That hurts my pride, Watson,” he said, at last. “It is a petty
+feeling, no doubt, but it hurts my pride. It becomes a personal matter
+with me now, and, if God sends me health, I shall set my hand upon this
+gang. That he should come to me for help, and that I should send him
+away to his death—!” He sprang from his chair and paced about the room
+in uncontrollable agitation, with a flush upon his sallow cheeks, and a
+nervous clasping and unclasping of his long, thin hands.
+
+“They must be cunning devils,” he exclaimed, at last. “How could they
+have decoyed him down there? The Embankment is not on the direct line
+to the station. The bridge, no doubt, was too crowded, even on such a
+night, for their purpose. Well, Watson, we shall see who will win in
+the long run. I am going out now!”
+
+[Illustration: “‘HOLMES,’ I CRIED, ‘YOU ARE TOO LATE’”]
+
+“To the police?”
+
+“No; I shall be my own police. When I have spun the web they may take
+the flies, but not before.”
+
+All day I was engaged in my professional work, and it was late in the
+evening before I returned to Baker Street. Sherlock Holmes had not come
+back yet. It was nearly ten o’clock before he entered, looking pale
+and worn. He walked up to the sideboard, and, tearing a piece from the
+loaf, he devoured it voraciously, washing it down with a long draught
+of water.
+
+“You are hungry,” I remarked.
+
+“Starving. It had escaped my memory. I have had nothing since
+breakfast.”
+
+“Nothing?”
+
+“Not a bite. I had no time to think of it.”
+
+“And how have you succeeded?”
+
+“Well.”
+
+“You have a clew?”
+
+“I have them in the hollow of my hand. Young Openshaw shall not long
+remain unavenged. Why, Watson, let us put their own devilish trade-mark
+upon them. It is well thought of!”
+
+“What do you mean?”
+
+He took an orange from the cupboard, and, tearing it to pieces, he
+squeezed out the pips upon the table. Of these he took five, and thrust
+them into an envelope. On the inside of the flap he wrote “S. H. for J.
+O.” Then he sealed it and addressed it to “Captain James Calhoun, Bark
+_Lone Star_, Savannah, Georgia.”
+
+“That will await him when he enters port,” said he, chuckling. “It may
+give him a sleepless night. He will find it as sure a precursor of his
+fate as Openshaw did before him.”
+
+“And who is this Captain Calhoun?”
+
+“The leader of the gang. I shall have the others, but he first.”
+
+“How did you trace it, then?”
+
+He took a large sheet of paper from his pocket, all covered with dates
+and names.
+
+“I have spent the whole day,” said he, “over Lloyd’s registers and the
+files of the old papers, following the future career of every vessel
+which touched at Pondicherry in January and February in ’83. There
+were thirty-six ships of fair tonnage which were reported there during
+those months. Of these, one, the _Lone Star_, instantly attracted my
+attention, since, although it was reported as having cleared from
+London, the name is that which is given to one of the States of the
+Union.”
+
+“Texas, I think.”
+
+“I was not and am not sure which; but I knew that the ship must have an
+American origin.”
+
+“What then?”
+
+“I searched the Dundee records, and when I found that the bark _Lone
+Star_ was there in January, ’85, my suspicion became a certainty. I
+then inquired as to the vessels which lay at present in the port of
+London.”
+
+“Yes?”
+
+“The _Lone Star_ had arrived here last week. I went down to the Albert
+Dock, and found that she had been taken down the river by the early
+tide this morning, homeward bound to Savannah. I wired to Gravesend,
+and learned that she had passed some time ago; and as the wind is
+easterly, I have no doubt that she is now past the Goodwins, and not
+very far from the Isle of Wight.”
+
+“What will you do, then?”
+
+“Oh, I have my hand upon him. He and the two mates, are, as I learn,
+the only native-born Americans in the ship. The others are Finns and
+Germans. I know, also, that they were all three away from the ship last
+night. I had it from the stevedore who has been loading their cargo. By
+the time that their sailing-ship reaches Savannah the mail-boat will
+have carried this letter, and the cable will have informed the police
+of Savannah that these three gentlemen are badly wanted here upon a
+charge of murder.”
+
+There is ever a flaw, however, in the best laid of human plans, and
+the murderers of John Openshaw were never to receive the orange pips
+which would show them that another, as cunning and as resolute as
+themselves, was upon their track. Very long and very severe were the
+equinoctial gales that year. We waited long for news of the _Lone
+Star_ of Savannah, but none ever reached us. We did at last hear that
+somewhere far out in the Atlantic a shattered stern-post of a boat was
+seen swinging in the trough of a wave, with the letters “L. S.” carved
+upon it, and that is all which we shall ever know of the fate of the
+_Lone Star_.
+
+
+
+
+Adventure VI
+
+THE MAN WITH THE TWISTED LIP
+
+
+Isa Whitney, brother of the late Elias Whitney, D.D., Principal of the
+Theological College of St. George’s, was much addicted to opium. The
+habit grew upon him, as I understand, from some foolish freak when he
+was at college; for having read De Quincey’s description of his dreams
+and sensations, he had drenched his tobacco with laudanum in an attempt
+to produce the same effects. He found, as so many more have done, that
+the practice is easier to attain than to get rid of, and for many years
+he continued to be a slave to the drug, an object of mingled horror
+and pity to his friends and relatives. I can see him now, with yellow,
+pasty face, drooping lids, and pin-point pupils, all huddled in a
+chair, the wreck and ruin of a noble man.
+
+One night—it was in June, ’89—there came a ring to my bell, about the
+hour when a man gives his first yawn and glances at the clock. I sat up
+in my chair, and my wife laid her needle-work down in her lap and made
+a little face of disappointment.
+
+“A patient!” said she. “You’ll have to go out.”
+
+I groaned, for I was newly come back from a weary day.
+
+We heard the door open, a few hurried words, and then quick steps
+upon the linoleum. Our own door flew open, and a lady, clad in some
+dark-colored stuff, with a black veil, entered the room.
+
+“You will excuse my calling so late,” she began, and then, suddenly
+losing her self-control, she ran forward, threw her arms about my
+wife’s neck, and sobbed upon her shoulder. “Oh, I’m in such trouble!”
+she cried; “I do so want a little help.”
+
+“Why,” said my wife, pulling up her veil, “it is Kate Whitney. How you
+startled me, Kate! I had not an idea who you were when you came in.”
+
+“I didn’t know what to do, so I came straight to you.” That was always
+the way. Folk who were in grief came to my wife like birds to a
+light-house.
+
+“It was very sweet of you to come. Now, you must have some wine and
+water, and sit here comfortably and tell us all about it. Or should you
+rather that I sent James off to bed?”
+
+“Oh, no, no! I want the Doctor’s advice and help, too. It’s about Isa.
+He has not been home for two days. I am so frightened about him!”
+
+It was not the first time that she had spoken to us of her husband’s
+trouble, to me as a doctor, to my wife as an old friend and school
+companion. We soothed and comforted her by such words as we could find.
+Did she know where her husband was? Was it possible that we could bring
+him back to her?
+
+It seemed that it was. She had the surest information that of late he
+had, when the fit was on him, made use of an opium den in the farthest
+east of the city. Hitherto his orgies had always been confined to one
+day, and he had come back, twitching and shattered, in the evening.
+But now the spell had been upon him eight-and-forty hours, and he lay
+there, doubtless among the dregs of the docks, breathing in the poison
+or sleeping off the effects. There he was to be found, she was sure of
+it, at the “Bar of Gold,” in Upper Swandam Lane. But what was she to
+do? How could she, a young and timid woman, make her way into such a
+place, and pluck her husband out from among the ruffians who surrounded
+him?
+
+There was the case, and of course there was but one way out of it.
+Might I not escort her to this place? And then, as a second thought,
+why should she come at all? I was Isa Whitney’s medical adviser, and
+as such I had influence over him. I could manage it better if I were
+alone. I promised her on my word that I would send him home in a
+cab within two hours if he were indeed at the address which she had
+given me. And so in ten minutes I had left my arm-chair and cheery
+sitting-room behind me, and was speeding eastward in a hansom on a
+strange errand, as it seemed to me at the time, though the future only
+could show how strange it was to be.
+
+But there was no great difficulty in the first stage of my adventure.
+Upper Swandam Lane is a vile alley lurking behind the high wharves
+which line the north side of the river to the east of London Bridge.
+Between a slop-shop and a gin-shop, approached by a steep flight of
+steps leading down to a black gap like the mouth of a cave, I found the
+den of which I was in search. Ordering my cab to wait, I passed down
+the steps, worn hollow in the centre by the ceaseless tread of drunken
+feet, and by the light of a flickering oil-lamp above the door I found
+the latch, and made my way into a long, low room, thick and heavy
+with the brown opium smoke, and terraced with wooden berths, like the
+forecastle of an emigrant ship.
+
+Through the gloom one could dimly catch a glimpse of bodies lying in
+strange fantastic poses, bowed shoulders, bent knees, heads thrown back
+and chins pointing upward, with here and there a dark, lack-lustre eye
+turned upon the new-comer. Out of the black shadows there glimmered
+little red circles of light, now bright, now faint, as the burning
+poison waxed or waned in the bowls of the metal pipes. The most lay
+silent, but some muttered to themselves, and others talked together in
+a strange, low, monotonous voice, their conversation coming in gushes,
+and then suddenly tailing off into silence, each mumbling out his own
+thoughts, and paying little heed to the words of his neighbor. At the
+farther end was a small brazier of burning charcoal, beside which on a
+three-legged wooden stool there sat a tall, thin old man, with his jaw
+resting upon his two fists, and his elbows upon his knees, staring into
+the fire.
+
+As I entered, a sallow Malay attendant had hurried up with a pipe for
+me and a supply of the drug, beckoning me to an empty berth.
+
+“Thank you. I have not come to stay,” said I. “There is a friend of
+mine here, Mr. Isa Whitney, and I wish to speak with him.”
+
+There was a movement and an exclamation from my right, and, peering
+through the gloom, I saw Whitney, pale, haggard, and unkempt, staring
+out at me.
+
+“My God! It’s Watson,” said he. He was in a pitiable state of reaction,
+with every nerve in a twitter. “I say, Watson, what o’clock is it?”
+
+“Nearly eleven.”
+
+“Of what day?”
+
+“Of Friday, June 19th.”
+
+“Good heavens! I thought it was Wednesday. It is Wednesday. What d’you
+want to frighten a chap for?” He sank his face onto his arms, and began
+to sob in a high treble key.
+
+“I tell you that it is Friday, man. Your wife has been waiting this two
+days for you. You should be ashamed of yourself!”
+
+“So I am. But you’ve got mixed, Watson, for I have only been here a few
+hours, three pipes, four pipes—I forget how many. But I’ll go home
+with you. I wouldn’t frighten Kate—poor little Kate. Give me your
+hand! Have you a cab?”
+
+“Yes, I have one waiting.”
+
+“Then I shall go in it. But I must owe something. Find what I owe,
+Watson. I am all off color. I can do nothing for myself.”
+
+I walked down the narrow passage between the double row of sleepers,
+holding my breath to keep out the vile, stupefying fumes of the drug,
+and looking about for the manager. As I passed the tall man who sat
+by the brazier I felt a sudden pluck at my skirt, and a low voice
+whispered, “Walk past me, and then look back at me.” The words fell
+quite distinctly upon my ear. I glanced down. They could only have come
+from the old man at my side, and yet he sat now as absorbed as ever,
+very thin, very wrinkled, bent with age, an opium pipe dangling down
+from between his knees, as though it had dropped in sheer lassitude
+from his fingers. I took two steps forward and looked back. It took
+all my self-control to prevent me from breaking out into a cry of
+astonishment. He had turned his back so that none could see him but
+I. His form had filled out, his wrinkles were gone, the dull eyes had
+regained their fire, and there, sitting by the fire, and grinning at
+my surprise, was none other than Sherlock Holmes. He made a slight
+motion to me to approach him, and instantly, as he turned his face half
+round to the company once more, subsided into a doddering, loose-lipped
+senility.
+
+“Holmes!” I whispered, “what on earth are you doing in this den?”
+
+“As low as you can,” he answered; “I have excellent ears. If you would
+have the great kindness to get rid of that sottish friend of yours I
+should be exceedingly glad to have a little talk with you.”
+
+“I have a cab outside.”
+
+“Then pray send him home in it. You may safely trust him, for he
+appears to be too limp to get into any mischief. I should recommend you
+also to send a note by the cabman to your wife to say that you have
+thrown in your lot with me. If you will wait outside, I shall be with
+you in five minutes.”
+
+It was difficult to refuse any of Sherlock Holmes’s requests, for they
+were always so exceedingly definite, and put forward with such a quiet
+air of mastery. I felt, however, that when Whitney was once confined
+in the cab my mission was practically accomplished, and for the rest,
+I could not wish anything better than to be associated with my friend
+in one of those singular adventures which were the normal condition of
+his existence. In a few minutes I had written my note, paid Whitney’s
+bill, led him out to the cab, and seen him driven through the darkness.
+In a very short time a decrepit figure had emerged from the opium
+den, and I was walking down the street with Sherlock Holmes. For two
+streets he shuffled along with a bent back and an uncertain foot. Then,
+glancing quickly round, he straightened himself out and burst into a
+hearty fit of laughter.
+
+“I suppose, Watson,” said he, “that you imagine that I have added
+opium-smoking to cocaine injections, and all the other little
+weaknesses on which you have favored me with your medical views.”
+
+“I was certainly surprised to find you there.”
+
+“But not more so than I to find you.”
+
+“I came to find a friend.”
+
+“And I to find an enemy.”
+
+“An enemy?”
+
+“Yes; one of my natural enemies, or, shall I say, my natural prey.
+Briefly, Watson, I am in the midst of a very remarkable inquiry, and
+I have hoped to find a clew in the incoherent ramblings of these
+sots, as I have done before now. Had I been recognized in that den my
+life would not have been worth an hour’s purchase; for I have used it
+before now for my own purposes, and the rascally Lascar who runs it has
+sworn to have vengeance upon me. There is a trap-door at the back of
+that building, near the corner of Paul’s Wharf, which could tell some
+strange tales of what has passed through it upon the moonless nights.”
+
+“What! You do not mean bodies?”
+
+“Aye, bodies, Watson. We should be rich men if we had £1000 for every
+poor devil who has been done to death in that den. It is the vilest
+murder-trap on the whole river-side, and I fear that Neville St. Clair
+has entered it never to leave it more. But our trap should be here.”
+He put his two forefingers between his teeth and whistled shrilly—a
+signal which was answered by a similar whistle from the distance,
+followed shortly by the rattle of wheels and the clink of horses’
+hoofs.
+
+“Now, Watson,” said Holmes, as a tall dog-cart dashed up through the
+gloom, throwing out two golden tunnels of yellow light from its side
+lanterns. “You’ll come with me, won’t you?”
+
+“If I can be of use.”
+
+“Oh, a trusty comrade is always of use; and a chronicler still more so.
+My room at ‘The Cedars’ is a double-bedded one.”
+
+“‘The Cedars?’”
+
+“Yes; that is Mr. St. Clair’s house. I am staying there while I conduct
+the inquiry.”
+
+“Where is it, then?”
+
+“Near Lee, in Kent. We have a seven-mile drive before us.”
+
+“But I am all in the dark.”
+
+“Of course you are. You’ll know all about it presently. Jump up here.
+All right, John; we shall not need you. Here’s half a crown. Look out
+for me to-morrow, about eleven. Give her her head. So long, then!”
+
+He flicked the horse with his whip, and we dashed away through the
+endless succession of sombre and deserted streets, which widened
+gradually, until we were flying across a broad balustraded bridge, with
+the murky river flowing sluggishly beneath us. Beyond lay another dull
+wilderness of bricks and mortar, its silence broken only by the heavy,
+regular footfall of the policeman, or the songs and shouts of some
+belated party of revellers. A dull wrack was drifting slowly across the
+sky, and a star or two twinkled dimly here and there through the rifts
+of the clouds. Holmes drove in silence, with his head sunk upon his
+breast, and the air of a man who is lost in thought, while I sat beside
+him, curious to learn what this new quest might be which seemed to tax
+his powers so sorely, and yet afraid to break in upon the current of
+his thoughts. We had driven several miles, and were beginning to get
+to the fringe of the belt of suburban villas, when he shook himself,
+shrugged his shoulders, and lit up his pipe with the air of a man who
+has satisfied himself that he is acting for the best.
+
+“You have a grand gift of silence, Watson,” said he. “It makes you
+quite invaluable as a companion. ’Pon my word, it is a great thing
+for me to have some one to talk to, for my own thoughts are not over
+pleasant. I was wondering what I should say to this dear little woman
+to-night when she meets me at the door.”
+
+“You forget that I know nothing about it.”
+
+“I shall just have time to tell you the facts of the case before we get
+to Lee. It seems absurdly simple, and yet, somehow, I can get nothing
+to go upon. There’s plenty of thread, no doubt, but I can’t get the end
+of it into my hand. Now, I’ll state the case clearly and concisely to
+you, Watson, and maybe you can see a spark where all is dark to me.”
+
+“Proceed, then.”
+
+“Some years ago—to be definite, in May, 1884—there came to Lee a
+gentleman, Neville St. Clair by name, who appeared to have plenty
+of money. He took a large villa, laid out the grounds very nicely,
+and lived generally in good style. By degrees he made friends in the
+neighborhood, and in 1887 he married the daughter of a local brewer, by
+whom he now has two children. He had no occupation, but was interested
+in several companies, and went into town as a rule in the morning,
+returning by the 5.14 from Cannon Street every night. Mr. St. Clair is
+now thirty-seven years of age, is a man of temperate habits, a good
+husband, a very affectionate father, and a man who is popular with all
+who know him. I may add that his whole debts at the present moment,
+as far as we have been able to ascertain, amount to £88 10_s._, while
+he has £220 standing to his credit in the Capital and Counties Bank.
+There is no reason, therefore, to think that money troubles have been
+weighing upon his mind.
+
+“Last Monday Mr. Neville St. Clair went into town rather earlier
+than usual, remarking before he started that he had two important
+commissions to perform, and that he would bring his little boy home a
+box of bricks. Now, by the merest chance, his wife received a telegram
+upon this same Monday, very shortly after his departure, to the effect
+that a small parcel of considerable value which she had been expecting
+was waiting for her at the offices of the Aberdeen Shipping Company.
+Now, if you are well up in your London, you will know that the offices
+of the company is in Fresno Street, which branches out of Upper Swandam
+Lane, where you found me to-night. Mrs. St. Clair had her lunch,
+started for the city, did some shopping, proceeded to the company’s
+office, got her packet, and found herself at exactly 4.35 walking
+through Swandam Lane on her way back to the station. Have you followed
+me so far?”
+
+“It is very clear.”
+
+“If you remember, Monday was an exceedingly hot day, and Mrs. St.
+Clair walked slowly, glancing about in the hope of seeing a cab, as
+she did not like the neighborhood in which she found herself. While
+she was walking in this way down Swandam Lane, she suddenly heard an
+ejaculation or cry, and was struck cold to see her husband looking down
+at her, and, as it seemed to her, beckoning to her from a second-floor
+window. The window was open, and she distinctly saw his face, which she
+describes as being terribly agitated. He waved his hands frantically
+to her, and then vanished from the window so suddenly that it seemed
+to her that he had been plucked back by some irresistible force from
+behind. One singular point which struck her quick feminine eye was
+that, although he wore some dark coat, such as he had started to town
+in, he had on neither collar nor necktie.
+
+[Illustration: “AT THE FOOT OF THE STAIRS SHE MET THIS LASCAR
+SCOUNDREL.”]
+
+“Convinced that something was amiss with him, she rushed down the
+steps—for the house was none other than the opium den in which you
+found me to-night—and, running through the front room, she attempted
+to ascend the stairs which led to the first floor. At the foot of the
+stairs, however, she met this Lascar scoundrel of whom I have spoken,
+who thrust her back, and, aided by a Dane, who acts as assistant there,
+pushed her out into the street. Filled with the most maddening doubts
+and fears, she rushed down the lane, and, by rare good-fortune, met, in
+Fresno Street, a number of constables with an inspector, all on their
+way to their beat. The inspector and two men accompanied her back, and,
+in spite of the continued resistance of the proprietor, they made their
+way to the room in which Mr. St. Clair had last been seen. There was no
+sign of him there. In fact, in the whole of that floor there was no one
+to be found, save a crippled wretch of hideous aspect, who, it seems,
+made his home there. Both he and the Lascar stoutly swore that no one
+else had been in the front room during the afternoon. So determined
+was their denial that the inspector was staggered, and had almost come
+to believe that Mrs. St. Clair had been deluded, when, with a cry, she
+sprang at a small deal box which lay upon the table, and tore the lid
+from it. Out there fell a cascade of children’s bricks. It was the toy
+which he had promised to bring home.
+
+“This discovery, and the evident confusion which the cripple showed,
+made the inspector realize that the matter was serious. The rooms were
+carefully examined, and results all pointed to an abominable crime.
+The front room was plainly furnished as a sitting-room, and led into a
+small bedroom, which looked out upon the back of one of the wharves.
+Between the wharf and the bedroom window is a narrow strip, which is
+dry at low tide, but is covered at high tide with at least four and
+a half feet of water. The bedroom window was a broad one, and opened
+from below. On examination traces of blood were to be seen upon the
+window-sill, and several scattered drops were visible upon the wooden
+floor of the bedroom. Thrust away behind a curtain in the front room
+were all the clothes of Mr. Neville St. Clair, with the exception of
+his coat. His boots, his socks, his hat, and his watch—all were there.
+There were no signs of violence upon any of these garments, and there
+were no other traces of Mr. Neville St. Clair. Out of the window he
+must apparently have gone, for no other exit could be discovered, and
+the ominous blood-stains upon the sill gave little promise that he
+could save himself by swimming, for the tide was at its very highest at
+the moment of the tragedy.
+
+“And now as to the villains who seemed to be immediately implicated in
+the matter. The Lascar was known to be a man of the vilest antecedents,
+but as, by Mrs. St. Clair’s story, he was known to have been at the
+foot of the stair within a very few seconds of her husband’s appearance
+at the window, he could hardly have been more than an accessory to the
+crime. His defense was one of absolute ignorance, and he protested that
+he had no knowledge as to the doings of Hugh Boone, his lodger, and
+that he could not account in any way for the presence of the missing
+gentleman’s clothes.
+
+“So much for the Lascar manager. Now for the sinister cripple who lives
+upon the second floor of the opium den, and who was certainly the
+last human being whose eyes rested upon Neville St. Clair. His name
+is Hugh Boone, and his hideous face is one which is familiar to every
+man who goes much to the city. He is a professional beggar, though,
+in order to avoid the police regulations, he pretends to a small
+trade in wax vestas. Some little distance down Threadneedle Street,
+upon the left-hand side, there is, as you may have remarked, a small
+angle in the wall. Here it is that this creature takes his daily seat,
+cross-legged, with his tiny stock of matches on his lap, and, as he is
+a piteous spectacle, a small rain of charity descends into the greasy
+leather cap which lies upon the pavement beside him. I have watched the
+fellow more than once, before ever I thought of making his professional
+acquaintance, and I have been surprised at the harvest which he has
+reaped in a short time. His appearance, you see, is so remarkable that
+no one can pass him without observing him. A shock of orange hair, a
+pale face disfigured by a horrible scar, which, by its contraction,
+has turned up the outer edge of his upper lip, a bull-dog chin, and a
+pair of very penetrating dark eyes, which present a singular contrast
+to the color of his hair, all mark him out from amid the common
+crowd of mendicants, and so, too, does his wit, for he is ever ready
+with a reply to any piece of chaff which may be thrown at him by the
+passers-by. This is the man whom we now learn to have been the lodger
+at the opium den, and to have been the last man to see the gentleman of
+whom we are in quest.”
+
+“But a cripple!” said I. “What could he have done single-handed against
+a man in the prime of life?”
+
+“He is a cripple in the sense that he walks with a limp; but in other
+respects he appears to be a powerful and well-nurtured man. Surely your
+medical experience would tell you, Watson, that weakness in one limb is
+often compensated for by exceptional strength in the others.”
+
+“Pray continue your narrative.”
+
+“Mrs. St. Clair had fainted at the sight of the blood upon the window,
+and she was escorted home in a cab by the police, as her presence
+could be of no help to them in their investigations. Inspector Barton,
+who had charge of the case, made a very careful examination of the
+premises, but without finding anything which threw any light upon the
+matter. One mistake had been made in not arresting Boone instantly, as
+he was allowed some few minutes during which he might have communicated
+with his friend the Lascar, but this fault was soon remedied, and he
+was seized and searched, without anything being found which could
+incriminate him. There were, it is true, some blood-stains upon his
+right shirt-sleeve, but he pointed to his ring-finger, which had been
+cut near the nail, and explained that the bleeding came from there,
+adding that he had been to the window not long before, and that the
+stains which had been observed there came doubtless from the same
+source. He denied strenuously having ever seen Mr. Neville St. Clair,
+and swore that the presence of the clothes in his room was as much
+a mystery to him as to the police. As to Mrs. St. Clair’s assertion
+that she had actually seen her husband at the window, he declared that
+she must have been either mad or dreaming. He was removed, loudly
+protesting, to the police-station, while the inspector remained upon
+the premises in the hope that the ebbing tide might afford some fresh
+clew.
+
+“And it did, though they hardly found upon the mud-bank what they had
+feared to find. It was Neville St. Clair’s coat, and not Neville St.
+Clair, which lay uncovered as the tide receded. And what do you think
+they found in the pockets?”
+
+“I cannot imagine.”
+
+“No, I don’t think you would guess. Every pocket stuffed with pennies
+and half-pennies—421 pennies and 270 half-pennies. It was no wonder
+that it had not been swept away by the tide. But a human body is a
+different matter. There is a fierce eddy between the wharf and the
+house. It seemed likely enough that the weighted coat had remained when
+the stripped body had been sucked away into the river.”
+
+“But I understand that all the other clothes were found in the room.
+Would the body be dressed in a coat alone?”
+
+“No, sir, but the facts might be met speciously enough. Suppose that
+this man Boone had thrust Neville St. Clair through the window, there
+is no human eye which could have seen the deed. What would he do then?
+It would of course instantly strike him that he must get rid of the
+tell-tale garments. He would seize the coat, then, and be in the act of
+throwing it out, when it would occur to him that it would swim and not
+sink. He has little time, for he has heard the scuffle down-stairs when
+the wife tried to force her way up, and perhaps he has already heard
+from his Lascar confederate that the police are hurrying up the street.
+There is not an instant to be lost. He rushes to some secret horde,
+where he has accumulated the fruits of his beggary, and he stuffs all
+the coins upon which he can lay his hands into the pockets to make sure
+of the coat’s sinking. He throws it out, and would have done the same
+with the other garments had not he heard the rush of steps below, and
+only just had time to close the window when the police appeared.”
+
+“It certainly sounds feasible.”
+
+“Well, we will take it as a working hypothesis for want of a better.
+Boone, as I have told you, was arrested and taken to the station, but
+it could not be shown that there had ever before been anything against
+him. He had for years been known as a professional beggar, but his life
+appeared to have been a very quiet and innocent one. There the matter
+stands at present, and the questions which have to be solved—what
+Neville St. Clair was doing in the opium den, what happened to him
+when there, where is he now, and what Hugh Boone had to do with his
+disappearance—are all as far from a solution as ever. I confess that I
+cannot recall any case within my experience which looked at the first
+glance so simple, and yet which presented such difficulties.”
+
+While Sherlock Holmes had been detailing this singular series of
+events, we had been whirling through the outskirts of the great town
+until the last straggling houses had been left behind, and we rattled
+along with a country hedge upon either side of us. Just as he finished,
+however, we drove through two scattered villages, where a few lights
+still glimmered in the windows.
+
+“We are on the outskirts of Lee,” said my companion. “We have touched
+on three English counties in our short drive, starting in Middlesex,
+passing over an angle of Surrey, and ending in Kent. See that light
+among the trees? That is ‘The Cedars,’ and beside that lamp sits a
+woman whose anxious ears have already, I have little doubt, caught the
+clink of our horse’s feet.”
+
+“But why are you not conducting the case from Baker Street?” I asked.
+
+“Because there are many inquiries which must be made out here. Mrs.
+St. Clair has most kindly put two rooms at my disposal, and you may
+rest assured that she will have nothing but a welcome for my friend
+and colleague. I hate to meet her, Watson, when I have no news of her
+husband. Here we are. Whoa, there, whoa!”
+
+We had pulled up in front of a large villa which stood within its own
+grounds. A stable-boy had run out to the horse’s head, and, springing
+down, I followed Holmes up the small, winding gravel-drive which led to
+the house. As we approached, the door flew open, and a little blonde
+woman stood in the opening, clad in some sort of light mousseline de
+soie, with a touch of fluffy pink chiffon at her neck and wrists. She
+stood with her figure outlined against the flood of light, one hand
+upon the door, one half-raised in her eagerness, her body slightly
+bent, her head and face protruded, with eager eyes and parted lips, a
+standing question.
+
+“Well?” she cried, “well?” And then, seeing that there were two of
+us, she gave a cry of hope which sank into a groan as she saw that my
+companion shook his head and shrugged his shoulders.
+
+“No good news?”
+
+“None.”
+
+“No bad?”
+
+“No.”
+
+“Thank God for that. But come in. You must be weary, for you have had a
+long day.”
+
+“This is my friend, Dr. Watson. He has been of most vital use to me in
+several of my cases, and a lucky chance has made it possible for me to
+bring him out and associate him with this investigation.”
+
+“I am delighted to see you,” said she, pressing my hand warmly.
+“You will, I am sure, forgive anything that may be wanting in our
+arrangements, when you consider the blow which has come so suddenly
+upon us.”
+
+“My dear madam,” said I, “I am an old campaigner, and if I were not,
+I can very well see that no apology is needed. If I can be of any
+assistance, either to you or to my friend here, I shall be indeed
+happy.”
+
+“Now, Mr. Sherlock Holmes,” said the lady, as we entered a well-lit
+dining-room, upon the table of which a cold supper had been laid out,
+“I should very much like to ask you one or two plain questions, to
+which I beg that you will give a plain answer.”
+
+“Certainly, madam.”
+
+“Do not trouble about my feelings. I am not hysterical, nor given to
+fainting. I simply wish to hear your real, real opinion.”
+
+“Upon what point?”
+
+“In your heart of hearts do you think that Neville is alive?”
+
+Sherlock Holmes seemed to be embarrassed by the question. “Frankly,
+now!” she repeated, standing upon the rug and looking keenly down at
+him as he leaned back in a basket-chair.
+
+“Frankly, then, madam, I do not.”
+
+“You think that he is dead?”
+
+“I do.”
+
+“Murdered?”
+
+“I don’t say that. Perhaps.”
+
+“And on what day did he meet his death?”
+
+“On Monday.”
+
+“Then perhaps, Mr. Holmes, you will be good enough to explain how it is
+that I have received a letter from him to-day.”
+
+Sherlock Holmes sprang out of his chair as if he had been galvanized.
+
+“What!” he roared.
+
+“Yes, to-day.” She stood smiling, holding up a little slip of paper in
+the air.
+
+“May I see it?”
+
+“Certainly.”
+
+He snatched it from her in his eagerness, and smoothing it out upon
+the table, he drew over the lamp, and examined it intently. I had left
+my chair, and was gazing at it over his shoulder. The envelope was a
+very coarse one, and was stamped with the Gravesend post-mark, and with
+the date of that very day, or rather of the day before, for it was
+considerably after midnight.
+
+“Coarse writing,” murmured Holmes. “Surely this is not your husband’s
+writing, madam.”
+
+“No, but the enclosure is.”
+
+“I perceive also that whoever addressed the envelope had to go and
+inquire as to the address.”
+
+“How can you tell that?”
+
+“The name, you see, is in perfectly black ink, which has dried itself.
+The rest is of the grayish color, which shows that blotting-paper has
+been used. If it had been written straight off, and then blotted, none
+would be of a deep black shade. This man has written the name, and
+there has then been a pause before he wrote the address, which can only
+mean that he was not familiar with it. It is, of course, a trifle, but
+there is nothing so important as trifles. Let us now see the letter.
+Ha! there has been an enclosure here!”
+
+“Yes, there was a ring. His signet-ring.”
+
+“And you are sure that this is your husband’s hand?”
+
+“One of his hands.”
+
+“One?”
+
+“His hand when he wrote hurriedly. It is very unlike his usual writing,
+and yet I know it well.”
+
+“‘Dearest do not be frightened. All will come well. There is a
+huge error which it may take some little time to rectify. Wait in
+patience.—Neville.’ Written in pencil upon the fly-leaf of a book,
+octavo size, no water-mark. Hum! Posted to-day in Gravesend by a man
+with a dirty thumb. Ha! And the flap has been gummed, if I am not very
+much in error, by a person who had been chewing tobacco. And you have
+no doubt that it is your husband’s hand, madam?”
+
+“None. Neville wrote those words.”
+
+“And they were posted to-day at Gravesend. Well, Mrs. St. Clair, the
+clouds lighten, though I should not venture to say that the danger is
+over.”
+
+“But he must be alive, Mr. Holmes.”
+
+“Unless this is a clever forgery to put us on the wrong scent. The
+ring, after all, proves nothing. It may have been taken from him.”
+
+“No, no; it is, it is, it is his very own writing!”
+
+“Very well. It may, however, have been written on Monday, and only
+posted to-day.”
+
+“That is possible.”
+
+“If so, much may have happened between.”
+
+“Oh, you must not discourage me, Mr. Holmes. I know that all is well
+with him. There is so keen a sympathy between us that I should know if
+evil came upon him. On the very day that I saw him last he cut himself
+in the bedroom, and yet I in the dining-room rushed up-stairs instantly
+with the utmost certainty that something had happened. Do you think
+that I would respond to such a trifle, and yet be ignorant of his
+death?”
+
+“I have seen too much not to know that the impression of a woman may
+be more valuable than the conclusion of an analytical reasoner. And
+in this letter you certainly have a very strong piece of evidence to
+corroborate your view. But if your husband is alive, and able to write
+letters, why should he remain away from you?”
+
+“I cannot imagine. It is unthinkable.”
+
+“And on Monday he made no remarks before leaving you?”
+
+“No.”
+
+“And you were surprised to see him in Swandam Lane?”
+
+“Very much so.”
+
+“Was the window open?”
+
+“Yes.”
+
+“Then he might have called to you?”
+
+“He might.”
+
+“He only, as I understand, gave an inarticulate cry?”
+
+“Yes.”
+
+“A call for help, you thought?”
+
+“Yes. He waved his hands.”
+
+“But it might have been a cry of surprise. Astonishment at the
+unexpected sight of you might cause him to throw up his hands?”
+
+“It is possible.”
+
+“And you thought he was pulled back?”
+
+“He disappeared so suddenly.”
+
+“He might have leaped back. You did not see any one else in the room?”
+
+“No, but this horrible man confessed to having been there, and the
+Lascar was at the foot of the stairs.”
+
+“Quite so. Your husband, as far as you could see, had his ordinary
+clothes on?”
+
+“But without his collar or tie. I distinctly saw his bare throat.”
+
+“Had he ever spoken of Swandam Lane?”
+
+“Never.”
+
+“Had he ever showed any signs of having taken opium?”
+
+“Never.”
+
+“Thank you, Mrs. St. Clair. Those are the principal points about which
+I wished to be absolutely clear. We shall now have a little supper and
+then retire, for we may have a very busy day to-morrow.”
+
+A large and comfortable double-bedded room had been placed at our
+disposal, and I was quickly between the sheets, for I was weary after
+my night of adventure. Sherlock Holmes was a man, however, who, when
+he had an unsolved problem upon his mind, would go for days, and even
+for a week, without rest, turning it over, rearranging his facts,
+looking at it from every point of view, until he had either fathomed
+it, or convinced himself that his data were insufficient. It was soon
+evident to me that he was now preparing for an all-night sitting. He
+took off his coat and waistcoat, put on a large blue dressing-gown,
+and then wandered about the room collecting pillows from his bed and
+cushions from the sofa and arm-chairs. With these he constructed a sort
+of Eastern divan, upon which he perched himself cross-legged, with an
+ounce of shag tobacco and a box of matches laid out in front of him.
+In the dim light of the lamp I saw him sitting there, an old briar
+pipe between his lips, his eyes fixed vacantly upon the corner of the
+ceiling, the blue smoke curling up from him, silent, motionless, with
+the light shining upon his strong-set aquiline features. So he sat as I
+dropped off to sleep, and so he sat when a sudden ejaculation caused me
+to wake up, and I found the summer sun shining into the apartment. The
+pipe was still between his lips, the smoke still curled upward, and the
+room was full of a dense tobacco haze, but nothing remained of the heap
+of shag which I had seen upon the previous night.
+
+“Awake, Watson?” he asked.
+
+“Yes.”
+
+“Game for a morning drive?”
+
+“Certainly.”
+
+“Then dress. No one is stirring yet, but I know where the stable-boy
+sleeps, and we shall soon have the trap out.” He chuckled to himself
+as he spoke, his eyes twinkled, and he seemed a different man to the
+sombre thinker of the previous night.
+
+As I dressed I glanced at my watch. It was no wonder that no one was
+stirring. It was twenty-five minutes past four. I had hardly finished
+when Holmes returned with the news that the boy was putting in the
+horse.
+
+“I want to test a little theory of mine,” said he, pulling on his
+boots. “I think, Watson, that you are now standing in the presence of
+one of the most absolute fools in Europe. I deserve to be kicked from
+here to Charing Cross. But I think I have the key of the affair now.”
+
+“And where is it?” I asked, smiling.
+
+“In the bath-room,” he answered. “Oh yes, I am not joking,” he
+continued, seeing my look of incredulity. “I have just been there, and
+I have taken it out, and I have got it in this Gladstone bag. Come on,
+my boy, and we shall see whether it will not fit the lock.”
+
+We made our way down-stairs as quietly as possible, and out into the
+bright morning sunshine. In the road stood our horse and trap, with
+the half-clad stable-boy waiting at the head. We both sprang in, and
+away we dashed down the London Road. A few country carts were stirring,
+bearing in vegetables to the metropolis, but the lines of villas on
+either side were as silent and lifeless as some city in a dream.
+
+“It has been in some points a singular case,” said Holmes, flicking the
+horse on into a gallop. “I confess that I have been as blind as a mole,
+but it is better to learn wisdom late than never to learn it at all.”
+
+In town the earliest risers were just beginning to look sleepily from
+their windows as we drove through the streets of the Surrey side.
+Passing down the Waterloo Bridge Road we crossed over the river, and
+dashing up Wellington Street wheeled sharply to the right, and found
+ourselves in Bow Street. Sherlock Holmes was well known to the Force,
+and the two constables at the door saluted him. One of them held the
+horse’s head while the other led us in.
+
+“Who is on duty?” asked Holmes.
+
+“Inspector Bradstreet, sir.”
+
+“Ah, Bradstreet, how are you?” A tall, stout official had come down the
+stone-flagged passage, in a peaked cap and frogged jacket. “I wish to
+have a quiet word with you, Bradstreet.”
+
+“Certainly, Mr. Holmes. Step into my room here.”
+
+It was a small, office-like room, with a huge ledger upon the table,
+and a telephone projecting from the wall. The inspector sat down at his
+desk.
+
+“What can I do for you, Mr. Holmes?”
+
+“I called about that beggarman, Boone—the one who was charged with
+being concerned in the disappearance of Mr. Neville St. Clair, of Lee.”
+
+“Yes. He was brought up and remanded for further inquiries.”
+
+“So I heard. You have him here?”
+
+“In the cells.”
+
+“Is he quiet?”
+
+“Oh, he gives no trouble. But he is a dirty scoundrel.”
+
+“Dirty?”
+
+“Yes, it is all we can do to make him wash his hands, and his face is
+as black as a tinker’s. Well, when once his case has been settled, he
+will have a regular prison bath; and I think, if you saw him, you would
+agree with me that he needed it.”
+
+“I should like to see him very much.”
+
+“Would you? That is easily done. Come this way. You can leave your bag.”
+
+“No, I think that I’ll take it.”
+
+“Very good. Come this way, if you please.” He led us down a passage,
+opened a barred door, passed down a winding stair, and brought us to a
+whitewashed corridor with a line of doors on each side.
+
+“The third on the right is his,” said the inspector. “Here it is!” He
+quietly shot back a panel in the upper part of the door and glanced
+through.
+
+“He is asleep,” said he. “You can see him very well.”
+
+We both put our eyes to the grating. The prisoner lay with his face
+towards us, in a very deep sleep, breathing slowly and heavily. He was
+a middle-sized man, coarsely clad as became his calling, with a colored
+shirt protruding through the rent in his tattered coat. He was, as the
+inspector had said, extremely dirty, but the grime which covered his
+face could not conceal its repulsive ugliness. A broad wheal from an
+old scar ran right across it from eye to chin, and by its contraction
+had turned up one side of the upper lip, so that three teeth were
+exposed in a perpetual snarl. A shock of very bright red hair grew low
+over his eyes and forehead.
+
+“He’s a beauty, isn’t he?” said the inspector.
+
+“He certainly needs a wash,” remarked Holmes. “I had an idea that he
+might, and I took the liberty of bringing the tools with me.” He opened
+the Gladstone bag as he spoke, and took out, to my astonishment, a very
+large bath-sponge.
+
+“He! he! You are a funny one,” chuckled the inspector.
+
+“Now, if you will have the great goodness to open that door very
+quietly, we will soon make him cut a much more respectable figure.”
+
+“Well, I don’t know why not,” said the inspector. “He doesn’t look
+a credit to the Bow Street cells, does he?” He slipped his key into
+the lock, and we all very quietly entered the cell. The sleeper half
+turned, and then settled down once more into a deep slumber. Holmes
+stooped to the water-jug, moistened his sponge, and then rubbed it
+twice vigorously across and down the prisoner’s face.
+
+“Let me introduce you,” he shouted, “to Mr. Neville St. Clair, of Lee,
+in the county of Kent.”
+
+Never in my life have I seen such a sight. The man’s face peeled off
+under the sponge like the bark from a tree. Gone was the coarse brown
+tint! Gone, too, was the horrid scar which had seamed it across, and
+the twisted lip which had given the repulsive sneer to the face! A
+twitch brought away the tangled red hair, and there, sitting up in
+his bed, was a pale, sad-faced, refined-looking man, black-haired and
+smooth-skinned, rubbing his eyes, and staring about him with sleepy
+bewilderment. Then suddenly realizing the exposure, he broke into a
+scream, and threw himself down with his face to the pillow.
+
+“Great heavens!” cried the inspector, “it is, indeed, the missing man.
+I know him from the photograph.”
+
+The prisoner turned with the reckless air of a man who abandons himself
+to his destiny. “Be it so,” said he. “And pray, what am I charged with?”
+
+“With making away with Mr. Neville St.—— Oh, come, you can’t be
+charged with that, unless they make a case of attempted suicide of it,”
+said the inspector, with a grin. “Well, I have been twenty-seven years
+in the force, but this really takes the cake.”
+
+“If I am Mr. Neville St. Clair, then it is obvious that no crime has
+been committed, and that, therefore, I am illegally detained.”
+
+“No crime, but a very great error has been committed,” said Holmes.
+“You would have done better to have trusted your wife.”
+
+“It was not the wife, it was the children,” groaned the prisoner. “God
+help me, I would not have them ashamed of their father. My God! What an
+exposure! What can I do?”
+
+Sherlock Holmes sat down beside him on the couch and patted him kindly
+on the shoulder.
+
+“If you leave it to a court of law to clear the matter up,” said he,
+“of course you can hardly avoid publicity. On the other hand, if you
+convince the police authorities that there is no possible case against
+you, I do not know that there is any reason that the details should
+find their way into the papers. Inspector Bradstreet would, I am sure,
+make notes upon anything which you might tell us, and submit it to the
+proper authorities. The case would then never go into court at all.”
+
+“God bless you!” cried the prisoner, passionately. “I would have
+endured imprisonment, aye, even execution, rather than have left my
+miserable secret as a family blot to my children.
+
+“You are the first who have ever heard my story. My father was
+a school-master in Chesterfield, where I received an excellent
+education. I travelled in my youth, took to the stage, and finally
+became a reporter on an evening paper in London. One day my editor
+wished to have a series of articles upon begging in the metropolis,
+and I volunteered to supply them. There was the point from which all
+my adventures started. It was only by trying begging as an amateur
+that I could get the facts upon which to base my articles. When an
+actor I had, of course, learned all the secrets of making up, and had
+been famous in the greenroom for my skill. I took advantage now of
+my attainments. I painted my face, and to make myself as pitiable as
+possible I made a good scar and fixed one side of my lip in a twist
+by the aid of a small slip of flesh-colored plaster. Then with a red
+head of hair, and an appropriate dress, I took my station in the
+busiest part of the city, ostensibly as a match-seller, but really as a
+beggar. For seven hours I plied my trade, and when I returned home in
+the evening I found, to my surprise, that I had received no less than
+26_s._ 4_d._
+
+“I wrote my articles, and thought little more of the matter until, some
+time later, I backed a bill for a friend, and had a writ served upon
+me for £25. I was at my wits’ end where to get the money, but a sudden
+idea came to me. I begged a fortnight’s grace from the creditor, asked
+for a holiday from my employers, and spent the time in begging in the
+city under my disguise. In ten days I had the money, and had paid the
+debt.
+
+“Well, you can imagine how hard it was to settle down to arduous
+work at £2 a week, when I knew that I could earn as much in a day by
+smearing my face with a little paint, laying my cap on the ground, and
+sitting still. It was a long fight between my pride and the money,
+but the dollars won at last, and I threw up reporting, and sat day
+after day in the corner which I had first chosen, inspiring pity by my
+ghastly face, and filling my pockets with coppers. Only one man knew
+my secret. He was the keeper of a low den in which I used to lodge in
+Swandam Lane, where I could every morning emerge as a squalid beggar,
+and in the evenings transform myself into a well-dressed man about
+town. This fellow, a Lascar, was well paid by me for his rooms, so that
+I knew that my secret was safe in his possession.
+
+“Well, very soon I found that I was saving considerable sums of money.
+I do not mean that any beggar in the streets of London could earn £700
+a year—which is less than my average takings—but I had exceptional
+advantages in my power of making up, and also in a facility of
+repartee, which improved by practice, and made me quite a recognized
+character in the city. All day a stream of pennies, varied by silver,
+poured in upon me, and it was a very bad day in which I failed to take
+£2.
+
+“As I grew richer I grew more ambitious, took a house in the country,
+and eventually married, without any one having a suspicion as to my
+real occupation. My dear wife knew that I had business in the city. She
+little knew what.
+
+“Last Monday I had finished for the day, and was dressing in my room
+above the opium den, when I looked out of my window, and saw, to my
+horror and astonishment, that my wife was standing in the street, with
+her eyes fixed full upon me. I gave a cry of surprise, threw up my arms
+to cover my face, and, rushing to my confidant, the Lascar, entreated
+him to prevent any one from coming up to me. I heard her voice
+down-stairs, but I knew that she could not ascend. Swiftly I threw off
+my clothes, pulled on those of a beggar, and put on my pigments and
+wig. Even a wife’s eyes could not pierce so complete a disguise. But
+then it occurred to me that there might be a search in the room, and
+that the clothes might betray me. I threw open the window, reopening
+by my violence a small cut which I had inflicted upon myself in the
+bedroom that morning. Then I seized my coat, which was weighted by
+the coppers which I had just transferred to it from the leather bag
+in which I carried my takings. I hurled it out of the window, and it
+disappeared into the Thames. The other clothes would have followed, but
+at that moment there was a rush of constables up the stair, and a few
+minutes after I found, rather, I confess, to my relief, that instead
+of being identified as Mr. Neville St. Clair, I was arrested as his
+murderer.
+
+“I do not know that there is anything else for me to explain. I was
+determined to preserve my disguise as long as possible, and hence my
+preference for a dirty face. Knowing that my wife would be terribly
+anxious, I slipped off my ring, and confided it to the Lascar at a
+moment when no constable was watching me, together with a hurried
+scrawl, telling her that she had no cause to fear.”
+
+“That note only reached her yesterday,” said Holmes.
+
+“Good God! What a week she must have spent!”
+
+“The police have watched this Lascar,” said Inspector Bradstreet, “and
+I can quite understand that he might find it difficult to post a letter
+unobserved. Probably he handed it to some sailor customer of his, who
+forgot all about it for some days.”
+
+“That was it,” said Holmes, nodding approvingly; “I have no doubt of
+it. But have you never been prosecuted for begging?”
+
+“Many times; but what was a fine to me?”
+
+“It must stop here, however,” said Bradstreet. “If the police are to
+hush this thing up, there must be no more of Hugh Boone.”
+
+“I have sworn it by the most solemn oaths which a man can take.”
+
+“In that case I think that it is probable that no further steps may be
+taken. But if you are found again, then all must come out. I am sure,
+Mr. Holmes, that we are very much indebted to you for having cleared
+the matter up. I wish I knew how you reach your results.”
+
+“I reached this one,” said my friend, “by sitting upon five pillows and
+consuming an ounce of shag. I think, Watson, that if we drive to Baker
+Street we shall just be in time for breakfast.”
+
+
+
+
+Adventure VII
+
+THE ADVENTURE OF THE BLUE CARBUNCLE
+
+
+I had called upon my friend Sherlock Holmes upon the second morning
+after Christmas, with the intention of wishing him the compliments of
+the season. He was lounging upon the sofa in a purple dressing-gown,
+a pipe-rack within his reach upon the right, and a pile of crumpled
+morning papers, evidently newly studied, near at hand. Beside the couch
+was a wooden chair, and on the angle of the back hung a very seedy
+and disreputable hard-felt hat, much the worse for wear, and cracked
+in several places. A lens and a forceps lying upon the seat of the
+chair suggested that the hat had been suspended in this manner for the
+purpose of examination.
+
+“You are engaged,” said I; “perhaps I interrupt you.”
+
+“Not at all. I am glad to have a friend with whom I can discuss my
+results. The matter is a perfectly trivial one” (he jerked his thumb in
+the direction of the old hat), “but there are points in connection with
+it which are not entirely devoid of interest and even of instruction.”
+
+I seated myself in his arm-chair and warmed my hands before his
+crackling fire, for a sharp frost had set in, and the windows were
+thick with the ice crystals. “I suppose,” I remarked, “that, homely as
+it looks, this thing has some deadly story linked on to it—that it is
+the clew which will guide you in the solution of some mystery and the
+punishment of some crime.”
+
+“No, no. No crime,” said Sherlock Holmes, laughing. “Only one of
+those whimsical little incidents which will happen when you have
+four million human beings all jostling each other within the space of
+a few square miles. Amid the action and reaction of so dense a swarm
+of humanity, every possible combination of events may be expected to
+take place, and many a little problem will be presented which may
+be striking and bizarre without being criminal. We have already had
+experience of such.”
+
+“So much so,” I remarked, “that of the last six cases which I have
+added to my notes, three have been entirely free of any legal crime.”
+
+“Precisely. You allude to my attempt to recover the Irene Adler papers,
+to the singular case of Miss Mary Sutherland, and to the adventure of
+the man with the twisted lip. Well, I have no doubt that this small
+matter will fall into the same innocent category. You know Peterson,
+the commissionaire?”
+
+“Yes.”
+
+“It is to him that this trophy belongs.”
+
+“It is his hat.”
+
+“No, no; he found it. Its owner is unknown. I beg that you will look
+upon it, not as a battered billycock, but as an intellectual problem.
+And, first, as to how it came here. It arrived upon Christmas morning,
+in company with a good fat goose, which is, I have no doubt, roasting
+at this moment in front of Peterson’s fire. The facts are these: about
+four o’clock on Christmas morning, Peterson, who, as you know, is a
+very honest fellow, was returning from some small jollification, and
+was making his way homeward down Tottenham Court Road. In front of him
+he saw, in the gaslight, a tallish man, walking with a slight stagger,
+and carrying a white goose slung over his shoulder. As he reached the
+corner of Goodge Street, a row broke out between this stranger and a
+little knot of roughs. One of the latter knocked off the man’s hat, on
+which he raised his stick to defend himself, and, swinging it over his
+head, smashed the shop window behind him. Peterson had rushed forward
+to protect the stranger from his assailants; but the man, shocked at
+having broken the window, and seeing an official-looking person in
+uniform rushing towards him, dropped his goose, took to his heels, and
+vanished amid the labyrinth of small streets which lie at the back of
+Tottenham Court Road. The roughs had also fled at the appearance of
+Peterson, so that he was left in possession of the field of battle, and
+also of the spoils of victory in the shape of this battered hat and a
+most unimpeachable Christmas goose.”
+
+“Which surely he restored to their owner?”
+
+“My dear fellow, there lies the problem. It is true that ‘For Mrs.
+Henry Baker’ was printed upon a small card which was tied to the bird’s
+left leg, and it is also true that the initials ‘H. B.’ are legible
+upon the lining of this hat; but as there are some thousands of Bakers,
+and some hundreds of Henry Bakers in this city of ours, it is not easy
+to restore lost property to any one of them.”
+
+“What, then, did Peterson do?”
+
+“He brought round both hat and goose to me on Christmas morning,
+knowing that even the smallest problems are of interest to me. The
+goose we retained until this morning, when there were signs that, in
+spite of the slight frost, it would be well that it should be eaten
+without unnecessary delay. Its finder has carried it off, therefore, to
+fulfil the ultimate destiny of a goose, while I continue to retain the
+hat of the unknown gentleman who lost his Christmas dinner.”
+
+“Did he not advertise?”
+
+“No.”
+
+“Then, what clue could you have as to his identity?”
+
+“Only as much as we can deduce.”
+
+“From his hat?”
+
+“Precisely.”
+
+“But you are joking. What can you gather from this old battered felt?”
+
+“Here is my lens. You know my methods. What can you gather yourself as
+to the individuality of the man who has worn this article?”
+
+I took the tattered object in my hands and turned it over rather
+ruefully. It was a very ordinary black hat of the usual round shape,
+hard, and much the worse for wear. The lining had been of red silk, but
+was a good deal discolored. There was no maker’s name; but, as Holmes
+had remarked, the initials “H. B.” were scrawled upon one side. It was
+pierced in the brim for a hat-securer, but the elastic was missing. For
+the rest, it was cracked, exceedingly dusty, and spotted in several
+places, although there seemed to have been some attempt to hide the
+discolored patches by smearing them with ink.
+
+“I can see nothing,” said I, handing it back to my friend.
+
+“On the contrary, Watson, you can see everything. You fail, however, to
+reason from what you see. You are too timid in drawing your inferences.”
+
+“Then, pray tell me what it is that you can infer from this hat?”
+
+He picked it up and gazed at it in the peculiar introspective fashion
+which was characteristic of him. “It is perhaps less suggestive than
+it might have been,” he remarked, “and yet there are a few inferences
+which are very distinct, and a few others which represent at least a
+strong balance of probability. That the man was highly intellectual
+is of course obvious upon the face of it, and also that he was fairly
+well-to-do within the last three years, although he has now fallen upon
+evil days. He had foresight, but has less now than formerly, pointing
+to a moral retrogression, which, when taken with the decline of his
+fortunes, seems to indicate some evil influence, probably drink, at
+work upon him. This may account also for the obvious fact that his wife
+has ceased to love him.”
+
+“My dear Holmes!”
+
+“He has, however, retained some degree of self-respect,” he continued,
+disregarding my remonstrance. “He is a man who leads a sedentary
+life, goes out little, is out of training entirely, is middle-aged,
+has grizzled hair which he has had cut within the last few days, and
+which he anoints with lime-cream. These are the more patent facts which
+are to be deduced from his hat. Also, by-the-way, that it is extremely
+improbable that he has gas laid on in his house.”
+
+“You are certainly joking, Holmes.”
+
+“Not in the least. Is it possible that even now, when I give you these
+results, you are unable to see how they are attained?”
+
+“I have no doubt that I am very stupid; but I must confess that I am
+unable to follow you. For example, how did you deduce that this man was
+intellectual?”
+
+For answer Holmes clapped the hat upon his head. It came right over the
+forehead and settled upon the bridge of his nose. “It is a question
+of cubic capacity,” said he; “a man with so large a brain must have
+something in it.”
+
+“The decline of his fortunes, then?”
+
+“This hat is three years old. These flat brims curled at the edge came
+in then. It is a hat of the very best quality. Look at the band of
+ribbed silk and the excellent lining. If this man could afford to buy
+so expensive a hat three years ago, and has had no hat since, then he
+has assuredly gone down in the world.”
+
+“Well, that is clear enough, certainly. But how about the foresight and
+the moral retrogression?”
+
+Sherlock Holmes laughed. “Here is the foresight,” said he, putting
+his finger upon the little disk and loop of the hat-securer. “They
+are never sold upon hats. If this man ordered one, it is a sign of a
+certain amount of foresight, since he went out of his way to take this
+precaution against the wind. But since we see that he has broken the
+elastic, and has not troubled to replace it, it is obvious that he
+has less foresight now than formerly, which is a distinct proof of a
+weakening nature. On the other hand, he has endeavored to conceal some
+of these stains upon the felt by daubing them with ink, which is a
+sign that he has not entirely lost his self-respect.”
+
+“Your reasoning is certainly plausible.”
+
+“The further points, that he is middle-aged, that his hair is grizzled,
+that it has been recently cut, and that he uses lime-cream, are all
+to be gathered from a close examination of the lower part of the
+lining. The lens discloses a large number of hair-ends, clean cut by
+the scissors of the barber. They all appear to be adhesive, and there
+is a distinct odor of lime-cream. This dust, you will observe, is not
+the gritty, gray dust of the street, but the fluffy brown dust of the
+house, showing that it has been hung up in-doors most of the time;
+while the marks of moisture upon the inside are proof positive that the
+wearer perspired very freely, and could, therefore, hardly be in the
+best of training.”
+
+“But his wife—you said that she had ceased to love him.”
+
+“This hat has not been brushed for weeks. When I see you, my dear
+Watson, with a week’s accumulation of dust upon your hat, and when your
+wife allows you to go out in such a state, I shall fear that you also
+have been unfortunate enough to lose your wife’s affection.”
+
+“But he might be a bachelor.”
+
+“Nay, he was bringing home the goose as a peace-offering to his wife.
+Remember the card upon the bird’s leg.”
+
+“You have an answer to everything. But how on earth do you deduce that
+the gas is not laid on in his house?”
+
+“One tallow stain, or even two, might come by chance; but when I
+see no less than five, I think that there can be little doubt that
+the individual must be brought into frequent contact with burning
+tallow—walks up-stairs at night probably with his hat in one hand and
+a guttering candle in the other. Anyhow, he never got tallow-stains
+from a gas-jet. Are you satisfied?”
+
+“Well, it is very ingenious,” said I, laughing; “but since, as you said
+just now, there has been no crime committed, and no harm done, save
+the loss of a goose, all this seems to be rather a waste of energy.”
+
+Sherlock Holmes had opened his mouth to reply, when the door flew
+open, and Peterson, the commissionaire, rushed into the apartment with
+flushed cheeks and the face of a man who is dazed with astonishment.
+
+“The goose, Mr. Holmes! The goose, sir!” he gasped.
+
+“Eh? What of it, then? Has it returned to life and flapped off through
+the kitchen window?” Holmes twisted himself round upon the sofa to get
+a fairer view of the man’s excited face.
+
+“See here, sir! See what my wife found in its crop!” He held out
+his hand and displayed upon the centre of the palm a brilliantly
+scintillating blue stone, rather smaller than a bean in size, but of
+such purity and radiance that it twinkled like an electric point in the
+dark hollow of his hand.
+
+Sherlock Holmes sat up with a whistle. “By Jove, Peterson!” said he,
+“this is treasure trove indeed. I suppose you know what you have got?”
+
+“A diamond, sir? A precious stone. It cuts into glass as though it were
+putty.”
+
+“It’s more than a precious stone. It is _the_ precious stone.”
+
+“Not the Countess of Morcar’s blue carbuncle!” I ejaculated.
+
+“Precisely so. I ought to know its size and shape, seeing that I have
+read the advertisement about it in _The Times_ every day lately. It
+is absolutely unique, and its value can only be conjectured, but the
+reward offered of £1000 is certainly not within a twentieth part of the
+market price.”
+
+“A thousand pounds! Great Lord of mercy!” The commissionaire plumped
+down into a chair, and stared from one to the other of us.
+
+“That is the reward, and I have reason to know that there are
+sentimental considerations in the background which would induce the
+countess to part with half her fortune if she could but recover the
+gem.”
+
+“It was lost, if I remember aright, at the ‘Hotel Cosmopolitan,’” I
+remarked.
+
+“Precisely so, on December 22d, just five days ago. John Horner,
+a plumber, was accused of having abstracted it from the lady’s
+jewel-case. The evidence against him was so strong that the case has
+been referred to the Assizes. I have some account of the matter here,
+I believe.” He rummaged amid his newspapers, glancing over the dates,
+until at last he smoothed one out, doubled it over, and read the
+following paragraph:
+
+“‘Hotel Cosmopolitan Jewel Robbery. John Horner, 26, plumber, was
+brought up upon the charge of having upon the 22d inst. abstracted from
+the jewel-case of the Countess of Morcar the valuable gem known as the
+blue carbuncle. James Ryder, upper-attendant at the hotel, gave his
+evidence to the effect that he had shown Horner up to the dressing-room
+of the Countess of Morcar upon the day of the robbery, in order that
+he might solder the second bar of the grate, which was loose. He had
+remained with Horner some little time, but had finally been called
+away. On returning, he found that Horner had disappeared, that the
+bureau had been forced open, and that the small morocco casket in
+which, as it afterwards transpired, the countess was accustomed to keep
+her jewel, was lying empty upon the dressing-table. Ryder instantly
+gave the alarm, and Horner was arrested the same evening; but the stone
+could not be found either upon his person or in his rooms. Catherine
+Cusack, maid to the countess, deposed to having heard Ryder’s cry of
+dismay on discovering the robbery, and to having rushed into the room,
+where she found matters as described by the last witness. Inspector
+Bradstreet, B division, gave evidence as to the arrest of Horner, who
+struggled frantically, and protested his innocence in the strongest
+terms. Evidence of a previous conviction for robbery having been given
+against the prisoner, the magistrate refused to deal summarily with
+the offence, but referred it to the Assizes. Horner, who had shown
+signs of intense emotion during the proceedings, fainted away at the
+conclusion, and was carried out of court.’
+
+“Hum! So much for the police-court,” said Holmes, thoughtfully, tossing
+aside the paper. “The question for us now to solve is the sequence
+of events leading from a rifled jewel-case at one end to the crop of
+a goose in Tottenham Court Road at the other. You see, Watson, our
+little deductions have suddenly assumed a much more important and less
+innocent aspect. Here is the stone; the stone came from the goose, and
+the goose came from Mr. Henry Baker, the gentleman with the bad hat
+and all the other characteristics with which I have bored you. So now
+we must set ourselves very seriously to finding this gentleman, and
+ascertaining what part he has played in this little mystery. To do
+this, we must try the simplest means first, and these lie undoubtedly
+in an advertisement in all the evening papers. If this fails, I shall
+have recourse to other methods.”
+
+“What will you say?”
+
+“Give me a pencil and that slip of paper. Now, then: ‘Found at the
+corner of Goodge Street, a goose and a black felt hat. Mr. Henry Baker
+can have the same by applying at 6.30 this evening at 221B,
+Baker Street.’ That is clear and concise.”
+
+“Very. But will he see it?”
+
+“Well, he is sure to keep an eye on the papers, since, to a poor man,
+the loss was a heavy one. He was clearly so scared by his mischance
+in breaking the window and by the approach of Peterson, that he
+thought of nothing but flight; but since then he must have bitterly
+regretted the impulse which caused him to drop his bird. Then, again,
+the introduction of his name will cause him to see it, for every one
+who knows him will direct his attention to it. Here you are, Peterson,
+run down to the advertising agency, and have this put in the evening
+papers.”
+
+“In which, sir?”
+
+“Oh, in the _Globe_, _Star_, _Pall Mall_, _St. James’s_, _Evening
+News_, _Standard_, _Echo_, and any others that occur to you.”
+
+“Very well, sir. And this stone?”
+
+“Ah, yes, I shall keep the stone. Thank you. And, I say, Peterson,
+just buy a goose on your way back, and leave it here with me, for we
+must have one to give to this gentleman in place of the one which your
+family is now devouring.”
+
+When the commissionaire had gone, Holmes took up the stone and held
+it against the light. “It’s a bonny thing,” said he. “Just see how it
+glints and sparkles. Of course it is a nucleus and focus of crime.
+Every good stone is. They are the devil’s pet baits. In the larger and
+older jewels every facet may stand for a bloody deed. This stone is not
+yet twenty years old. It was found in the banks of the Amoy River in
+Southern China, and is remarkable in having every characteristic of the
+carbuncle, save that it is blue in shade, instead of ruby red. In spite
+of its youth, it has already a sinister history. There have been two
+murders, a vitriol-throwing, a suicide, and several robberies brought
+about for the sake of this forty-grain weight of crystallized charcoal.
+Who would think that so pretty a toy would be a purveyor to the gallows
+and the prison? I’ll lock it up in my strong box now, and drop a line
+to the countess to say that we have it.”
+
+“Do you think that this man Horner is innocent?”
+
+“I cannot tell.”
+
+“Well, then, do you imagine that this other one, Henry Baker, had
+anything to do with the matter?”
+
+“It is, I think, much more likely that Henry Baker is an absolutely
+innocent man, who had no idea that the bird which he was carrying was
+of considerably more value than if it were made of solid gold. That,
+however, I shall determine by a very simple test, if we have an answer
+to our advertisement.”
+
+“And you can do nothing until then?”
+
+“Nothing.”
+
+“In that case I shall continue my professional round. But I shall come
+back in the evening at the hour you have mentioned, for I should like
+to see the solution of so tangled a business.”
+
+“Very glad to see you. I dine at seven. There is a woodcock, I believe.
+By-the-way, in view of recent occurrences, perhaps I ought to ask Mrs.
+Hudson to examine its crop.”
+
+I had been delayed at a case, and it was a little after half-past
+six when I found myself in Baker Street once more. As I approached
+the house I saw a tall man in a Scotch bonnet with a coat which was
+buttoned up to his chin, waiting outside in the bright semicircle which
+was thrown from the fanlight. Just as I arrived, the door was opened,
+and we were shown up together to Holmes’s room.
+
+“Mr. Henry Baker, I believe,” said he, rising from his arm-chair, and
+greeting his visitor with the easy air of geniality which he could so
+readily assume. “Pray take this chair by the fire, Mr. Baker. It is a
+cold night, and I observe that your circulation is more adapted for
+summer than for winter. Ah, Watson, you have just come at the right
+time. Is that your hat, Mr. Baker?”
+
+“Yes, sir, that is undoubtedly my hat.”
+
+He was a large man, with rounded shoulders, a massive head, and a
+broad, intelligent face, sloping down to a pointed beard of grizzled
+brown. A touch of red in nose and cheeks, with a slight tremor of his
+extended hand, recalled Holmes’s surmise as to his habits. His rusty
+black frock-coat was buttoned right up in front, with the collar turned
+up, and his lank wrists protruded from his sleeves without a sign of
+cuff or shirt. He spoke in a slow staccato fashion, choosing his words
+with care, and gave the impression generally of a man of learning and
+letters who had had ill-usage at the hands of fortune.
+
+“We have retained these things for some days,” said Holmes, “because we
+expected to see an advertisement from you giving your address. I am at
+a loss to know now why you did not advertise.”
+
+Our visitor gave a rather shamefaced laugh. “Shillings have not been
+so plentiful with me as they once were,” he remarked. “I had no doubt
+that the gang of roughs who assaulted me had carried off both my hat
+and the bird. I did not care to spend more money in a hopeless attempt
+at recovering them.”
+
+“Very naturally. By-the-way, about the bird, we were compelled to eat
+it.”
+
+“To eat it!” Our visitor half rose from his chair in his excitement.
+
+“Yes, it would have been of no use to any one had we not done so. But
+I presume that this other goose upon the sideboard, which is about the
+same weight and perfectly fresh, will answer your purpose equally well?”
+
+“Oh, certainly, certainly;” answered Mr. Baker, with a sigh of relief.
+
+“Of course, we still have the feathers, legs, crop, and so on of your
+own bird, so if you wish—”
+
+The man burst into a hearty laugh. “They might be useful to me as
+relics of my adventure,” said he, “but beyond that I can hardly see
+what use the _disjecta membra_ of my late acquaintance are going to be
+to me. No, sir, I think that, with your permission, I will confine my
+attentions to the excellent bird which I perceive upon the sideboard.”
+
+Sherlock Holmes glanced sharply across at me with a slight shrug of his
+shoulders.
+
+“There is your hat, then, and there your bird,” said he. “By-the-way,
+would it bore you to tell me where you got the other one from? I am
+somewhat of a fowl fancier, and I have seldom seen a better grown
+goose.”
+
+“Certainly, sir,” said Baker, who had risen and tucked his newly-gained
+property under his arm. “There are a few of us who frequent the ‘Alpha
+Inn,’ near the Museum—we are to be found in the Museum itself during
+the day, you understand. This year our good host, Windigate by name,
+instituted a goose club, by which, on consideration of some few pence
+every week, we were each to receive a bird at Christmas. My pence were
+duly paid, and the rest is familiar to you. I am much indebted to you,
+sir, for a Scotch bonnet is fitted neither to my years nor my gravity.”
+With a comical pomposity of manner he bowed solemnly to both of us and
+strode off upon his way.
+
+“So much for Mr. Henry Baker,” said Holmes, when he had closed the door
+behind him. “It is quite certain that he knows nothing whatever about
+the matter. Are you hungry, Watson?”
+
+“Not particularly.”
+
+“Then I suggest that we turn our dinner into a supper, and follow up
+this clew while it is still hot.”
+
+“By all means.”
+
+It was a bitter night, so we drew on our ulsters and wrapped cravats
+about our throats. Outside, the stars were shining coldly in a
+cloudless sky, and the breath of the passers-by blew out into smoke
+like so many pistol shots. Our footfalls rang out crisply and loudly
+as we swung through the Doctors’ quarter, Wimpole Street, Harley
+Street, and so through Wigmore Street into Oxford Street. In a quarter
+of an hour we were in Bloomsbury at the “Alpha Inn,” which is a small
+public-house at the corner of one of the streets which runs down into
+Holborn. Holmes pushed open the door of the private bar, and ordered
+two glasses of beer from the ruddy-faced, white-aproned landlord.
+
+“Your beer should be excellent if it is as good as your geese,” said he.
+
+“My geese!” The man seemed surprised.
+
+“Yes. I was speaking only half an hour ago to Mr. Henry Baker, who was
+a member of your goose club.”
+
+“Ah! yes, I see. But you see, sir, them’s not _our_ geese.”
+
+“Indeed! Whose, then?”
+
+“Well, I got the two dozen from a salesman in Covent Garden.”
+
+“Indeed? I know some of them. Which was it?”
+
+“Breckinridge is his name.”
+
+“Ah! I don’t know him. Well, here’s your good health, landlord, and
+prosperity to your house. Good-night?”
+
+“Now for Mr. Breckinridge,” he continued, buttoning up his coat, as we
+came out into the frosty air. “Remember, Watson, that though we have
+so homely a thing as a goose at one end of this chain, we have at the
+other a man who will certainly get seven years’ penal servitude unless
+we can establish his innocence. It is possible that our inquiry may but
+confirm his guilt; but, in any case, we have a line of investigation
+which has been missed by the police, and which a singular chance has
+placed in our hands. Let us follow it out to the bitter end. Faces to
+the south, then, and quick march!”
+
+We passed across Holborn, down Endell Street, and so through a zigzag
+of slums to Covent Garden Market. One of the largest stalls bore the
+name of Breckinridge upon it, and the proprietor, a horsey-looking man,
+with a sharp face and trim side-whiskers, was helping a boy to put up
+the shutters.
+
+“Good-evening. It’s a cold night,” said Holmes.
+
+The salesman nodded, and shot a questioning glance at my companion.
+
+“Sold out of geese, I see,” continued Holmes, pointing at the bare
+slabs of marble.
+
+“Let you have 500 to-morrow morning.”
+
+“That’s no good.”
+
+“Well, there are some on the stall with the gas-flare.”
+
+“Ah, but I was recommended to you.”
+
+“Who by?”
+
+“The landlord of the ‘Alpha.’”
+
+“Oh, yes; I sent him a couple of dozen.”
+
+“Fine birds they were, too. Now where did you get them from?”
+
+To my surprise the question provoked a burst of anger from the salesman.
+
+“Now, then, mister,” said he, with his head cocked and his arms
+akimbo, “what are you driving at? Let’s have it straight, now.”
+
+“It is straight enough. I should like to know who sold you the geese
+which you supplied to the ‘Alpha.’”
+
+“Well, then, I sha’n’t tell you. So now!”
+
+“Oh, it is a matter of no importance; but I don’t know why you should
+be so warm over such a trifle.”
+
+“Warm! You’d be as warm, maybe, if you were as pestered as I am. When
+I pay good money for a good article there should be an end of the
+business; but it’s ‘Where are the geese?’ and ‘Who did you sell the
+geese to?’ and ‘What will you take for the geese?’ One would think they
+were the only geese in the world, to hear the fuss that is made over
+them.”
+
+“Well, I have no connection with any other people who have been making
+inquiries,” said Holmes, carelessly. “If you won’t tell us the bet is
+off, that is all. But I’m always ready to back my opinion on a matter
+of fowls, and I have a fiver on it that the bird I ate is country bred.”
+
+“Well, then, you’ve lost your fiver, for it’s town bred,” snapped the
+salesman.
+
+“It’s nothing of the kind.”
+
+“I say it is.”
+
+“I don’t believe it.”
+
+“D’you think you know more about fowls than I, who have handled them
+ever since I was a nipper? I tell you, all those birds that went to the
+‘Alpha’ were town bred.”
+
+“You’ll never persuade me to believe that.”
+
+“Will you bet, then?”
+
+“It’s merely taking your money, for I know that I am right. But I’ll
+have a sovereign on with you, just to teach you not to be obstinate.”
+
+The salesman chuckled grimly. “Bring me the books, Bill,” said he.
+
+The small boy brought round a small thin volume and a great
+greasy-backed one, laying them out together beneath the hanging lamp.
+
+“Now then, Mr. Cocksure,” said the salesman, “I thought that I was out
+of geese, but before I finish you’ll find that there is still one left
+in my shop. You see this little book?”
+
+“Well?”
+
+“That’s the list of the folk from whom I buy. D’you see? Well, then,
+here on this page are the country folk, and the numbers after their
+names are where their accounts are in the big ledger. Now, then!
+You see this other page in red ink? Well, that is a list of my town
+suppliers. Now, look at that third name. Just read it out to me.”
+
+“Mrs. Oakshott, 117, Brixton Road—249,” read Holmes.
+
+“Quite so. Now turn that up in the ledger.”
+
+Holmes turned to the page indicated. “Here you are, ‘Mrs. Oakshott,
+117, Brixton Road, egg and poultry supplier.’”
+
+“Now, then, what’s the last entry?”
+
+“‘December 22. Twenty-four geese at 7_s._ 6_d._’”
+
+“Quite so. There you are. And underneath?”
+
+“‘Sold to Mr. Windigate of the ‘Alpha,’ at 12_s._’”
+
+“What have you to say now?”
+
+Sherlock Holmes looked deeply chagrined. He drew a sovereign from his
+pocket and threw it down upon the slab, turning away with the air of
+a man whose disgust is too deep for words. A few yards off he stopped
+under a lamp-post, and laughed in the hearty, noiseless fashion which
+was peculiar to him.
+
+“When you see a man with whiskers of that cut and the ‘pink ‘un’
+protruding out of his pocket, you can always draw him by a bet,” said
+he. “I dare say that if I had put £100 down in front of him, that man
+would not have given me such complete information as was drawn from
+him by the idea that he was doing me on a wager. Well, Watson, we
+are, I fancy, nearing the end of our quest, and the only point which
+remains to be determined is whether we should go on to this Mrs.
+Oakshott to-night, or whether we should reserve it for to-morrow. It is
+clear from what that surly fellow said that there are others besides
+ourselves who are anxious about the matter, and I should—”
+
+His remarks were suddenly cut short by a loud hubbub which broke out
+from the stall which we had just left. Turning round we saw a little
+rat-faced fellow standing in the centre of the circle of yellow light
+which was thrown by the swinging lamp, while Breckinridge the salesman,
+framed in the door of his stall, was shaking his fists fiercely at the
+cringing figure.
+
+“I’ve had enough of you and your geese,” he shouted. “I wish you were
+all at the devil together. If you come pestering me any more with your
+silly talk I’ll set the dog at you. You bring Mrs. Oakshott here and
+I’ll answer her, but what have you to do with it? Did I buy the geese
+off you?”
+
+“No; but one of them was mine all the same,” whined the little man.
+
+“Well, then, ask Mrs. Oakshott for it.”
+
+“She told me to ask you.”
+
+“Well, you can ask the King of Proosia, for all I care. I’ve had enough
+of it. Get out of this!” He rushed fiercely forward, and the inquirer
+flitted away into the darkness.
+
+“Ha! this may save us a visit to Brixton Road,” whispered Holmes. “Come
+with me, and we will see what is to be made of this fellow.” Striding
+through the scattered knots of people who lounged round the flaring
+stalls, my companion speedily overtook the little man and touched him
+upon the shoulder. He sprang round, and I could see in the gaslight
+that every vestige of color had been driven from his face.
+
+“Who are you, then? What do you want?” he asked, in a quavering voice.
+
+“You will excuse me,” said Holmes, blandly, “but I could not help
+overhearing the questions which you put to the salesman just now. I
+think that I could be of assistance to you.”
+
+“You? Who are you? How could you know anything of the matter?”
+
+“My name is Sherlock Holmes. It is my business to know what other
+people don’t know.”
+
+“But you can know nothing of this?”
+
+“Excuse me, I know everything of it. You are endeavoring to trace some
+geese which were sold by Mrs. Oakshott, of Brixton Road, to a salesman
+named Breckinridge, by him in turn to Mr. Windigate, of the ‘Alpha,’
+and by him to his club, of which Mr. Henry Baker is a member.”
+
+“Oh, sir, you are the very man whom I have longed to meet,” cried the
+little fellow, with outstretched hands and quivering fingers. “I can
+hardly explain to you how interested I am in this matter.”
+
+Sherlock Holmes hailed a four-wheeler which was passing. “In that case
+we had better discuss it in a cosey room rather than in this windswept
+market-place,” said he. “But pray tell me, before we go farther, who it
+is that I have the pleasure of assisting.”
+
+The man hesitated for an instant. “My name is John Robinson,” he
+answered, with a sidelong glance.
+
+“No, no; the real name,” said Holmes, sweetly. “It is always awkward
+doing business with an _alias_.”
+
+A flush sprang to the white cheeks of the stranger. “Well, then,” said
+he, “my real name is James Ryder.”
+
+“Precisely so. Head attendant at the ‘Hotel Cosmopolitan.’ Pray step
+into the cab, and I shall soon be able to tell you everything which you
+would wish to know.”
+
+The little man stood glancing from one to the other of us with
+half-frightened, half-hopeful eyes, as one who is not sure whether he
+is on the verge of a windfall or of a catastrophe. Then he stepped into
+the cab, and in half an hour we were back in the sitting-room at Baker
+Street. Nothing had been said during our drive, but the high, thin
+breathing of our new companion, and the claspings and unclaspings of
+his hands, spoke of the nervous tension within him.
+
+“Here we are!” said Holmes, cheerily, as we filed into the room. “The
+fire looks very seasonable in this weather. You look cold, Mr. Ryder.
+Pray take the basket-chair. I will just put on my slippers before we
+settle this little matter of yours. Now, then! You want to know what
+became of those geese?”
+
+“Yes, sir.”
+
+“Or rather, I fancy, of that goose. It was one bird, I imagine, in
+which you were interested—white, with a black bar across the tail.”
+
+Ryder quivered with emotion. “Oh, sir,” he cried, “can you tell me
+where it went to?”
+
+“It came here.”
+
+“Here?”
+
+“Yes, and a most remarkable bird it proved. I don’t wonder that you
+should take an interest in it. It laid an egg after it was dead—the
+bonniest, brightest little blue egg that ever was seen. I have it here
+in my museum.”
+
+Our visitor staggered to his feet and clutched the mantel-piece with
+his right hand. Holmes unlocked his strong-box, and held up the blue
+carbuncle, which shone out like a star, with a cold, brilliant,
+many-pointed radiance. Ryder stood glaring with a drawn face, uncertain
+whether to claim or to disown it.
+
+“The game’s up, Ryder,” said Holmes, quietly. “Hold up, man, or you’ll
+be into the fire! Give him an arm back into his chair, Watson. He’s not
+got blood enough to go in for felony with impunity. Give him a dash of
+brandy. So! Now he looks a little more human. What a shrimp it is, to
+be sure!”
+
+For a moment he had staggered and nearly fallen, but the brandy brought
+a tinge of color into his cheeks, and he sat staring with frightened
+eyes at his accuser.
+
+“I have almost every link in my hands, and all the proofs which I could
+possibly need, so there is little which you need tell me. Still, that
+little may as well be cleared up to make the case complete. You had
+heard, Ryder, of this blue stone of the Countess of Morcar’s?”
+
+“It was Catherine Cusack who told me of it,” said he, in a crackling
+voice.
+
+“I see—her ladyship’s waiting-maid. Well, the temptation of sudden
+wealth so easily acquired was too much for you, as it has been for
+better men before you; but you were not very scrupulous in the means
+you used. It seems to me, Ryder, that there is the making of a very
+pretty villain in you. You knew that this man Horner, the plumber, had
+been concerned in some such matter before, and that suspicion would
+rest the more readily upon him. What did you do, then? You made some
+small job in my lady’s room—you and your confederate Cusack—and you
+managed that he should be the man sent for. Then, when he had left, you
+rifled the jewel-case, raised the alarm, and had this unfortunate man
+arrested. You then—”
+
+Ryder threw himself down suddenly upon the rug and clutched at my
+companion’s knees. “For God’s sake, have mercy!” he shrieked. “Think
+of my father! of my mother! It would break their hearts. I never went
+wrong before! I never will again. I swear it. I’ll swear it on a Bible.
+Oh, don’t bring it into court! For Christ’s sake, don’t!”
+
+“Get back into your chair!” said Holmes, sternly. “It is very well to
+cringe and crawl now, but you thought little enough of this poor Horner
+in the dock for a crime of which he knew nothing.”
+
+“I will fly, Mr. Holmes. I will leave the country, sir. Then the charge
+against him will break down.”
+
+“Hum! We will talk about that. And now let us hear a true account of
+the next act. How came the stone into the goose, and how came the goose
+into the open market? Tell us the truth, for there lies your only hope
+of safety.”
+
+[Illustration: “‘HAVE MERCY!’ HE SHRIEKED”]
+
+Ryder passed his tongue over his parched lips. “I will tell you it
+just as it happened, sir,” said he. “When Horner had been arrested, it
+seemed to me that it would be best for me to get away with the stone
+at once, for I did not know at what moment the police might not take
+it into their heads to search me and my room. There was no place about
+the hotel where it would be safe. I went out, as if on some commission,
+and I made for my sister’s house. She had married a man named Oakshott,
+and lived in Brixton Road, where she fattened fowls for the market.
+All the way there every man I met seemed to me to be a policeman or a
+detective; and, for all that it was a cold night, the sweat was pouring
+down my face before I came to the Brixton Road. My sister asked me what
+was the matter, and why I was so pale; but I told her that I had been
+upset by the jewel robbery at the hotel. Then I went into the back yard
+and smoked a pipe, and wondered what it would be best to do.
+
+“I had a friend once called Maudsley, who went to the bad, and has just
+been serving his time in Pentonville. One day he had met me, and fell
+into talk about the ways of thieves, and how they could get rid of what
+they stole. I knew that he would be true to me, for I knew one or two
+things about him; so I made up my mind to go right on to Kilburn, where
+he lived, and take him into my confidence. He would show me how to
+turn the stone into money. But how to get to him in safety? I thought
+of the agonies I had gone through in coming from the hotel. I might
+at any moment be seized and searched, and there would be the stone
+in my waistcoat pocket. I was leaning against the wall at the time,
+and looking at the geese which were waddling about round my feet, and
+suddenly an idea came into my head which showed me how I could beat the
+best detective that ever lived.
+
+“My sister had told me some weeks before that I might have the pick of
+her geese for a Christmas present, and I knew that she was always as
+good as her word. I would take my goose now, and in it I would carry
+my stone to Kilburn. There was a little shed in the yard, and behind
+this I drove one of the birds—a fine big one, white, with a barred
+tail. I caught it, and, prying its bill open, I thrust the stone down
+its throat as far as my finger could reach. The bird gave a gulp, and I
+felt the stone pass along its gullet and down into its crop. But the
+creature flapped and struggled, and out came my sister to know what
+was the matter. As I turned to speak to her the brute broke loose and
+fluttered off among the others.
+
+“‘Whatever were you doing with that bird, Jem?’ says she.
+
+“‘Well,’ said I, ‘you said you’d give me one for Christmas, and I was
+feeling which was the fattest.’
+
+“‘Oh,’ says she, ‘we’ve set yours aside for you—Jem’s bird, we call
+it. It’s the big white one over yonder. There’s twenty-six of them,
+which makes one for you, and one for us, and two dozen for the market.’
+
+“‘Thank you, Maggie,’ says I; ‘but if it is all the same to you, I’d
+rather have that one I was handling just now.’
+
+“‘The other is a good three pound heavier,’ said she, ‘and we fattened
+it expressly for you.’
+
+“‘Never mind. I’ll have the other, and I’ll take it now,’ said I.
+
+“‘Oh, just as you like,’ said she, a little huffed. ‘Which is it you
+want, then?’
+
+“‘That white one with the barred tail, right in the middle of the
+flock.’
+
+“‘Oh, very well. Kill it and take it with you.’
+
+“Well, I did what she said, Mr. Holmes, and I carried the bird all the
+way to Kilburn. I told my pal what I had done, for he was a man that
+it was easy to tell a thing like that to. He laughed until he choked,
+and we got a knife and opened the goose. My heart turned to water, for
+there was no sign of the stone, and I knew that some terrible mistake
+had occurred. I left the bird, rushed back to my sister’s, and hurried
+into the back yard. There was not a bird to be seen there.
+
+“‘Where are they all, Maggie?’ I cried.
+
+“‘Gone to the dealer’s, Jem.’
+
+“‘Which dealer’s?’
+
+“‘Breckinridge, of Covent Garden.’
+
+“‘But was there another with a barred tail?’ I asked, ‘the same as the
+one I chose?’
+
+“‘Yes, Jem; there were two barred-tailed ones, and I could never tell
+them apart.’
+
+“Well, then, of course I saw it all, and I ran off as hard as my feet
+would carry me to this man Breckinridge; but he had sold the lot at
+once, and not one word would he tell me as to where they had gone. You
+heard him yourselves to-night. Well, he has always answered me like
+that. My sister thinks that I am going mad. Sometimes I think that I
+am myself. And now—and now I am myself a branded thief, without ever
+having touched the wealth for which I sold my character. God help me!
+God help me!” He burst into convulsive sobbing, with his face buried in
+his hands.
+
+There was a long silence, broken only by his heavy breathing, and by
+the measured tapping of Sherlock Holmes’s finger-tips upon the edge of
+the table. Then my friend rose and threw open the door.
+
+“Get out!” said he.
+
+“What, sir! Oh, heaven bless you!”
+
+“No more words. Get out!”
+
+And no more words were needed. There was a rush, a clatter upon the
+stairs, the bang of a door, and the crisp rattle of running footfalls
+from the street.
+
+“After all, Watson,” said Holmes, reaching up his hand for his clay
+pipe, “I am not retained by the police to supply their deficiencies. If
+Horner were in danger it would be another thing; but this fellow will
+not appear against him, and the case must collapse. I suppose that I am
+commuting a felony, but it is just possible that I am saving a soul.
+This fellow will not go wrong again; he is too terribly frightened.
+Send him to jail now, and you make him a jail-bird for life. Besides,
+it is the season of forgiveness. Chance has put in our way a most
+singular and whimsical problem, and its solution is its own reward.
+If you will have the goodness to touch the bell, doctor, we will
+begin another investigation, in which, also, a bird will be the chief
+feature.”
+
+
+
+
+Adventure VIII
+
+THE ADVENTURE OF THE SPECKLED BAND
+
+
+On glancing over my notes of the seventy odd cases in which I have
+during the last eight years studied the methods of my friend Sherlock
+Holmes, I find many tragic, some comic, a large number merely strange,
+but none commonplace; for, working as he did rather for the love of his
+art than for the acquirement of wealth, he refused to associate himself
+with any investigation which did not tend towards the unusual, and even
+the fantastic. Of all these varied cases, however, I cannot recall any
+which presented more singular features than that which was associated
+with the well-known Surrey family of the Roylotts of Stoke Moran. The
+events in question occurred in the early days of my association with
+Holmes, when we were sharing rooms as bachelors in Baker Street. It
+is possible that I might have placed them upon record before, but a
+promise of secrecy was made at the time, from which I have only been
+freed during the last month by the untimely death of the lady to whom
+the pledge was given. It is perhaps as well that the facts should now
+come to light, for I have reasons to know that there are wide-spread
+rumors as to the death of Dr. Grimesby Roylott which tend to make the
+matter even more terrible than the truth.
+
+It was early in April in the year ’83 that I woke one morning to find
+Sherlock Holmes standing, fully dressed, by the side of my bed. He was
+a late riser as a rule, and as the clock on the mantel-piece showed
+me that it was only a quarter past seven, I blinked up at him in some
+surprise, and perhaps just a little resentment, for I was myself
+regular in my habits.
+
+“Very sorry to knock you up, Watson,” said he, “but it’s the common lot
+this morning. Mrs. Hudson has been knocked up, she retorted upon me,
+and I on you.”
+
+“What is it, then—a fire?”
+
+“No; a client. It seems that a young lady has arrived in a considerable
+state of excitement, who insists upon seeing me. She is waiting now in
+the sitting-room. Now, when young ladies wander about the metropolis
+at this hour of the morning, and knock sleepy people up out of their
+beds, I presume that it is something very pressing which they have to
+communicate. Should it prove to be an interesting case, you would, I am
+sure, wish to follow it from the outset. I thought, at any rate, that I
+should call you and give you the chance.”
+
+“My dear fellow, I would not miss it for anything.”
+
+I had no keener pleasure than in following Holmes in his professional
+investigations, and in admiring the rapid deductions, as swift as
+intuitions, and yet always founded on a logical basis, with which he
+unravelled the problems which were submitted to him. I rapidly threw on
+my clothes, and was ready in a few minutes to accompany my friend down
+to the sitting-room. A lady dressed in black and heavily veiled, who
+had been sitting in the window, rose as we entered.
+
+“Good-morning, madam,” said Holmes, cheerily. “My name is Sherlock
+Holmes. This is my intimate friend and associate, Dr. Watson, before
+whom you can speak as freely as before myself. Ha! I am glad to see
+that Mrs. Hudson has had the good sense to light the fire. Pray draw up
+to it, and I shall order you a cup of hot coffee, for I observe that
+you are shivering.”
+
+“It is not cold which makes me shiver,” said the woman, in a low voice,
+changing her seat as requested.
+
+“What, then?”
+
+“It is fear, Mr. Holmes. It is terror.” She raised her veil as she
+spoke, and we could see that she was indeed in a pitiable state of
+agitation, her face all drawn and gray, with restless, frightened eyes,
+like those of some hunted animal. Her features and figure were those of
+a woman of thirty, but her hair was shot with premature gray, and her
+expression was weary and haggard. Sherlock Holmes ran her over with one
+of his quick, all-comprehensive glances.
+
+“You must not fear,” said he, soothingly, bending forward and patting
+her forearm. “We shall soon set matters right, I have no doubt. You
+have come in by train this morning, I see.”
+
+“You know me, then?”
+
+“No, but I observe the second half of a return ticket in the palm of
+your left glove. You must have started early, and yet you had a good
+drive in a dog-cart, along heavy roads, before you reached the station.”
+
+The lady gave a violent start, and stared in bewilderment at my
+companion.
+
+“There is no mystery, my dear madam,” said he, smiling. “The left arm
+of your jacket is spattered with mud in no less than seven places. The
+marks are perfectly fresh. There is no vehicle save a dog-cart which
+throws up mud in that way, and then only when you sit on the left-hand
+side of the driver.”
+
+“Whatever your reasons may be, you are perfectly correct,” said she. “I
+started from home before six, reached Leatherhead at twenty past, and
+came in by the first train to Waterloo. Sir, I can stand this strain no
+longer; I shall go mad if it continues. I have no one to turn to—none,
+save only one, who cares for me, and he, poor fellow, can be of little
+aid. I have heard of you, Mr. Holmes; I have heard of you from Mrs.
+Farintosh, whom you helped in the hour of her sore need. It was from
+her that I had your address. Oh, sir, do you not think that you could
+help me, too, and at least throw a little light through the dense
+darkness which surrounds me? At present it is out of my power to reward
+you for your services, but in a month or six weeks I shall be married,
+with the control of my own income, and then at least you shall not
+find me ungrateful.”
+
+Holmes turned to his desk, and unlocking it, drew out a small
+case-book, which he consulted.
+
+“Farintosh,” said he. “Ah yes, I recall the case; it was concerned with
+an opal tiara. I think it was before your time, Watson. I can only say,
+madam, that I shall be happy to devote the same care to your case as
+I did to that of your friend. As to reward, my profession is its own
+reward; but you are at liberty to defray whatever expenses I may be put
+to, at the time which suits you best. And now I beg that you will lay
+before us everything that may help us in forming an opinion upon the
+matter.”
+
+“Alas!” replied our visitor, “the very horror of my situation lies
+in the fact that my fears are so vague, and my suspicions depend so
+entirely upon small points, which might seem trivial to another, that
+even he to whom of all others I have a right to look for help and
+advice looks upon all that I tell him about it as the fancies of a
+nervous woman. He does not say so, but I can read it from his soothing
+answers and averted eyes. But I have heard, Mr. Holmes, that you can
+see deeply into the manifold wickedness of the human heart. You may
+advise me how to walk amid the dangers which encompass me.”
+
+“I am all attention, madam.”
+
+“My name is Helen Stoner, and I am living with my step-father, who is
+the last survivor of one of the oldest Saxon families in England, the
+Roylotts of Stoke Moran, on the western border of Surrey.”
+
+Holmes nodded his head. “The name is familiar to me,” said he.
+
+“The family was at one time among the richest in England, and the
+estates extended over the borders into Berkshire in the north, and
+Hampshire in the west. In the last century, however, four successive
+heirs were of a dissolute and wasteful disposition, and the family
+ruin was eventually completed by a gambler in the days of the
+Regency. Nothing was left save a few acres of ground, and the
+two-hundred-year-old house, which is itself crushed under a heavy
+mortgage. The last squire dragged out his existence there, living
+the horrible life of an aristocratic pauper; but his only son, my
+step-father, seeing that he must adapt himself to the new conditions,
+obtained an advance from a relative, which enabled him to take a
+medical degree, and went out to Calcutta, where, by his professional
+skill and his force of character, he established a large practice.
+In a fit of anger, however, caused by some robberies which had been
+perpetrated in the house, he beat his native butler to death, and
+narrowly escaped a capital sentence. As it was, he suffered a long
+term of imprisonment, and afterwards returned to England a morose and
+disappointed man.
+
+“When Dr. Roylott was in India he married my mother, Mrs. Stoner, the
+young widow of Major-general Stoner, of the Bengal Artillery. My sister
+Julia and I were twins, and we were only two years old at the time of
+my mother’s re-marriage. She had a considerable sum of money—not less
+than £1000 a year—and this she bequeathed to Dr. Roylott entirely
+while we resided with him, with a provision that a certain annual sum
+should be allowed to each of us in the event of our marriage. Shortly
+after our return to England my mother died—she was killed eight years
+ago in a railway accident near Crewe. Dr. Roylott then abandoned his
+attempts to establish himself in practice in London, and took us to
+live with him in the old ancestral house at Stoke Moran. The money
+which my mother had left was enough for all our wants, and there seemed
+to be no obstacle to our happiness.
+
+“But a terrible change came over our step-father about this time.
+Instead of making friends and exchanging visits with our neighbors, who
+had at first been overjoyed to see a Roylott of Stoke Moran back in
+the old family seat, he shut himself up in his house, and seldom came
+out save to indulge in ferocious quarrels with whoever might cross his
+path. Violence of temper approaching to mania has been hereditary in
+the men of the family, and in my step-father’s case it had, I believe,
+been intensified by his long residence in the tropics. A series of
+disgraceful brawls took place, two of which ended in the police-court,
+until at last he became the terror of the village, and the folks
+would fly at his approach, for he is a man of immense strength, and
+absolutely uncontrollable in his anger.
+
+“Last week he hurled the local blacksmith over a parapet into a stream,
+and it was only by paying over all the money which I could gather
+together that I was able to avert another public exposure. He had no
+friends at all save the wandering gypsies, and he would give these
+vagabonds leave to encamp upon the few acres of bramble-covered land
+which represent the family estate, and would accept in return the
+hospitality of their tents, wandering away with them sometimes for
+weeks on end. He has a passion also for Indian animals, which are sent
+over to him by a correspondent, and he has at this moment a cheetah and
+a baboon, which wander freely over his grounds, and are feared by the
+villagers almost as much as their master.
+
+“You can imagine from what I say that my poor sister Julia and I had no
+great pleasure in our lives. No servant would stay with us, and for a
+long time we did all the work of the house. She was but thirty at the
+time of her death, and yet her hair had already begun to whiten, even
+as mine has.”
+
+“Your sister is dead, then?”
+
+“She died just two years ago, and it is of her death that I wish to
+speak to you. You can understand that, living the life which I have
+described, we were little likely to see anyone of our own age and
+position. We had, however, an aunt, my mother’s maiden sister, Miss
+Honoria Westphail, who lives near Harrow, and we were occasionally
+allowed to pay short visits at this lady’s house. Julia went there at
+Christmas two years ago, and met there a half-pay major of marines,
+to whom she became engaged. My step-father learned of the engagement
+when my sister returned, and offered no objection to the marriage; but
+within a fortnight of the day which had been fixed for the wedding, the
+terrible event occurred which has deprived me of my only companion.”
+
+Sherlock Holmes had been leaning back in his chair with his eyes closed
+and his head sunk in a cushion, but he half opened his lids now and
+glanced across at his visitor.
+
+“Pray be precise as to details,” said he.
+
+“It is easy for me to be so, for every event of that dreadful time is
+seared into my memory. The manor-house is, as I have already said, very
+old, and only one wing is now inhabited. The bedrooms in this wing are
+on the ground floor, the sitting-rooms being in the central block of
+the buildings. Of these bedrooms the first is Dr. Roylott’s, the second
+my sister’s, and the third my own. There is no communication between
+them, but they all open out into the same corridor. Do I make myself
+plain?”
+
+“Perfectly so.”
+
+“The windows of the three rooms open out upon the lawn. That fatal
+night Dr. Roylott had gone to his room early, though we knew that he
+had not retired to rest, for my sister was troubled by the smell of
+the strong Indian cigars which it was his custom to smoke. She left
+her room, therefore, and came into mine, where she sat for some time,
+chatting about her approaching wedding. At eleven o’clock she rose to
+leave me but she paused at the door and looked back.
+
+“‘Tell me, Helen,’ said she, ‘have you ever heard any one whistle in
+the dead of the night?’
+
+“‘Never,’ said I.
+
+“‘I suppose that you could not possibly whistle, yourself, in your
+sleep?’
+
+“‘Certainly not. But why?’
+
+“‘Because during the last few nights I have always, about three in
+the morning, heard a low, clear whistle. I am a light sleeper, and it
+has awakened me. I cannot tell where it came from—perhaps from the
+next room, perhaps from the lawn. I thought that I would just ask you
+whether you had heard it.’
+
+“‘No, I have not. It must be those wretched gypsies in the plantation.’
+
+“‘Very likely. And yet if it were on the lawn, I wonder that you did
+not hear it also.’
+
+“‘Ah, but I sleep more heavily than you.’
+
+“‘Well, it is of no great consequence, at any rate.’ She smiled back at
+me, closed my door, and a few moments later I heard her key turn in the
+lock.”
+
+“Indeed,” said Holmes. “Was it your custom always to lock yourselves in
+at night?”
+
+“Always.”
+
+“And why?”
+
+“I think that I mentioned to you that the doctor kept a cheetah and a
+baboon. We had no feeling of security unless our doors were locked.”
+
+“Quite so. Pray proceed with your statement.”
+
+“I could not sleep that night. A vague feeling of impending misfortune
+impressed me. My sister and I, you will recollect, were twins, and you
+know how subtle are the links which bind two souls which are so closely
+allied. It was a wild night. The wind was howling outside, and the rain
+was beating and splashing against the windows. Suddenly, amid all the
+hubbub of the gale, there burst forth the wild scream of a terrified
+woman. I knew that it was my sister’s voice. I sprang from my bed,
+wrapped a shawl round me, and rushed into the corridor. As I opened my
+door I seemed to hear a low whistle, such as my sister described, and a
+few moments later a clanging sound, as if a mass of metal had fallen.
+As I ran down the passage, my sister’s door was unlocked, and revolved
+slowly upon its hinges. I stared at it horror-stricken, not knowing
+what was about to issue from it. By the light of the corridor-lamp I
+saw my sister appear at the opening, her face blanched with terror, her
+hands groping for help, her whole figure swaying to and fro like that
+of a drunkard. I ran to her and threw my arms round her, but at that
+moment her knees seemed to give way and she fell to the ground. She
+writhed as one who is in terrible pain, and her limbs were dreadfully
+convulsed. At first I thought that she had not recognized me, but as I
+bent over her she suddenly shrieked out in a voice which I shall never
+forget, ‘Oh, my God! Helen! It was the band! The speckled band!’ There
+was something else which she would fain have said, and she stabbed with
+her finger into the air in the direction of the doctor’s room, but a
+fresh convulsion seized her and choked her words. I rushed out, calling
+loudly for my step-father, and I met him hastening from his room in his
+dressing-gown. When he reached my sister’s side she was unconscious,
+and though he poured brandy down her throat and sent for medical aid
+from the village, all efforts were in vain, for she slowly sank and
+died without having recovered her consciousness. Such was the dreadful
+end of my beloved sister.”
+
+“One moment,” said Holmes; “are you sure about this whistle and
+metallic sound? Could you swear to it?”
+
+“That was what the county coroner asked me at the inquiry. It is my
+strong impression that I heard it, and yet, among the crash of the gale
+and the creaking of an old house, I may possibly have been deceived.”
+
+“Was your sister dressed?”
+
+“No, she was in her night-dress. In her right hand was found the
+charred stump of a match, and in her left a matchbox.”
+
+“Showing that she had struck a light and looked about her when the
+alarm took place. That is important. And what conclusions did the
+coroner come to?”
+
+“He investigated the case with great care, for Dr. Roylott’s conduct
+had long been notorious in the county, but he was unable to find any
+satisfactory cause of death. My evidence showed that the door had
+been fastened upon the inner side, and the windows were blocked by
+old-fashioned shutters with broad iron bars, which were secured every
+night. The walls were carefully sounded, and were shown to be quite
+solid all round, and the flooring was also thoroughly examined, with
+the same result. The chimney is wide, but is barred up by four large
+staples. It is certain, therefore, that my sister was quite alone when
+she met her end. Besides, there were no marks of any violence upon her.”
+
+“How about poison?”
+
+“The doctors examined her for it, but without success.”
+
+“What do you think that this unfortunate lady died of, then?”
+
+“It is my belief that she died of pure fear and nervous shock, though
+what it was that frightened her I cannot imagine.”
+
+“Were there gypsies in the plantation at the time?”
+
+“Yes, there are nearly always some there.”
+
+“Ah, and what did you gather from this allusion to a band—a speckled
+band?”
+
+“Sometimes I have thought that it was merely the wild talk of delirium,
+sometimes that it may have referred to some band of people, perhaps to
+these very gypsies in the plantation. I do not know whether the spotted
+handkerchiefs which so many of them wear over their heads might have
+suggested the strange adjective which she used.”
+
+Holmes shook his head like a man who is far from being satisfied.
+
+“These are very deep waters,” said he; “pray go on with your narrative.”
+
+“Two years have passed since then, and my life has been until lately
+lonelier than ever. A month ago, however, a dear friend, whom I have
+known for many years, has done me the honor to ask my hand in marriage.
+His name is Armitage—Percy Armitage—the second son of Mr. Armitage,
+of Crane Water, near Reading. My step-father has offered no opposition
+to the match, and we are to be married in the course of the spring. Two
+days ago some repairs were started in the west wing of the building,
+and my bedroom wall has been pierced, so that I have had to move into
+the chamber in which my sister died, and to sleep in the very bed in
+which she slept. Imagine, then, my thrill of terror when last night,
+as I lay awake, thinking over her terrible fate, I suddenly heard in
+the silence of the night the low whistle which had been the herald of
+her own death. I sprang up and lit the lamp, but nothing was to be
+seen in the room. I was too shaken to go to bed again, however, so I
+dressed, and as soon as it was daylight I slipped down, got a dog-cart
+at the ‘Crown Inn,’ which is opposite, and drove to Leatherhead, from
+whence I have come on this morning with the one object of seeing you
+and asking your advice.”
+
+“You have done wisely,” said my friend. “But have you told me all?”
+
+“Yes, all.”
+
+“Miss Roylott, you have not. You are screening your step-father.”
+
+“Why, what do you mean?”
+
+For answer Holmes pushed back the frill of black lace which fringed the
+hand that lay upon our visitor’s knee. Five little livid spots, the
+marks of four fingers and a thumb, were printed upon the white wrist.
+
+“You have been cruelly used,” said Holmes.
+
+The lady colored deeply and covered over her injured wrist. “He is a
+hard man,” she said, “and perhaps he hardly knows his own strength.”
+
+There was a long silence, during which Holmes leaned his chin upon his
+hands and stared into the crackling fire.
+
+“This is a very deep business,” he said, at last. “There are a thousand
+details which I should desire to know before I decide upon our course
+of action. Yet we have not a moment to lose. If we were to come to
+Stoke Moran to-day, would it be possible for us to see over these rooms
+without the knowledge of your step-father?”
+
+“As it happens, he spoke of coming into town to-day upon some most
+important business. It is probable that he will be away all day, and
+that there would be nothing to disturb you. We have a house-keeper
+now, but she is old and foolish, and I could easily get her out of the
+way.”
+
+“Excellent. You are not averse to this trip, Watson?”
+
+“By no means.”
+
+“Then we shall both come. What are you going to do yourself?”
+
+“I have one or two things which I would wish to do now that I am in
+town. But I shall return by the twelve o’clock train, so as to be there
+in time for your coming.”
+
+“And you may expect us early in the afternoon. I have myself some small
+business matters to attend to. Will you not wait and breakfast?”
+
+“No, I must go. My heart is lightened already since I have confided
+my trouble to you. I shall look forward to seeing you again this
+afternoon.” She dropped her thick black veil over her face and glided
+from the room.
+
+“And what do you think of it all, Watson?” asked Sherlock Holmes,
+leaning back in his chair.
+
+“It seems to me to be a most dark and sinister business.”
+
+“Dark enough and sinister enough.”
+
+“Yet if the lady is correct in saying that the flooring and walls are
+sound, and that the door, window, and chimney are impassable, then her
+sister must have been undoubtedly alone when she met her mysterious
+end.”
+
+“What becomes, then, of these nocturnal whistles, and what of the very
+peculiar words of the dying woman?”
+
+“I cannot think.”
+
+“When you combine the ideas of whistles at night, the presence of a
+band of gypsies who are on intimate terms with this old doctor, the
+fact that we have every reason to believe that the doctor has an
+interest in preventing his step-daughter’s marriage, the dying allusion
+to a band, and, finally, the fact that Miss Helen Stoner heard a
+metallic clang, which might have been caused by one of those metal bars
+which secured the shutters falling back into their place, I think that
+there is good ground to think that the mystery may be cleared along
+those lines.”
+
+“But what, then, did the gypsies do?”
+
+“I cannot imagine.”
+
+“I see many objections to any such theory.”
+
+“And so do I. It is precisely for that reason that we are going to
+Stoke Moran this day. I want to see whether the objections are fatal,
+or if they may be explained away. But what in the name of the devil!”
+
+The ejaculation had been drawn from my companion by the fact that our
+door had been suddenly dashed open, and that a huge man had framed
+himself in the aperture. His costume was a peculiar mixture of the
+professional and of the agricultural, having a black top-hat, a long
+frock-coat, and a pair of high gaiters, with a hunting-crop swinging in
+his hand. So tall was he that his hat actually brushed the cross bar
+of the doorway, and his breadth seemed to span it across from side to
+side. A large face, seared with a thousand wrinkles, burned yellow with
+the sun, and marked with every evil passion, was turned from one to the
+other of us, while his deep-set, bile-shot eyes, and his high, thin,
+fleshless nose, gave him somewhat the resemblance to a fierce old bird
+of prey.
+
+“Which of you is Holmes?” asked this apparition.
+
+“My name, sir; but you have the advantage of me,” said my companion,
+quietly.
+
+“I am Dr. Grimesby Roylott, of Stoke Moran.”
+
+“Indeed, doctor,” said Holmes, blandly. “Pray take a seat.”
+
+“I will do nothing of the kind. My step-daughter has been here. I have
+traced her. What has she been saying to you?”
+
+“It is a little cold for the time of the year,” said Holmes.
+
+“What has she been saying to you?” screamed the old man, furiously.
+
+“But I have heard that the crocuses promise well,” continued my
+companion, imperturbably.
+
+“Ha! You put me off, do you?” said our new visitor, taking a step
+forward and shaking his hunting-crop. “I know you, you scoundrel! I
+have heard of you before. You are Holmes, the meddler.”
+
+My friend smiled.
+
+“Holmes, the busybody!”
+
+His smile broadened.
+
+“Holmes, the Scotland-yard Jack-in-office!”
+
+Holmes chuckled heartily. “Your conversation is most entertaining,”
+said he. “When you go out close the door, for there is a decided
+draught.”
+
+“I will go when I have said my say. Don’t you dare to meddle with my
+affairs. I know that Miss Stoner has been here. I traced her! I am a
+dangerous man to fall foul of! See here.” He stepped swiftly forward,
+seized the poker, and bent it into a curve with his huge brown hands.
+
+“See that you keep yourself out of my grip,” he snarled, and hurling
+the twisted poker into the fireplace, he strode out of the room.
+
+“He seems a very amiable person,” said Holmes, laughing. “I am not
+quite so bulky, but if he had remained I might have shown him that my
+grip was not much more feeble than his own.” As he spoke he picked up
+the steel poker, and with a sudden effort straightened it out again.
+
+“Fancy his having the insolence to confound me with the official
+detective force! This incident gives zest to our investigation,
+however, and I only trust that our little friend will not suffer from
+her imprudence in allowing this brute to trace her. And now, Watson,
+we shall order breakfast, and afterwards I shall walk down to Doctors’
+Commons, where I hope to get some data which may help us in this
+matter.”
+
+       *       *       *       *       *
+
+It was nearly one o’clock when Sherlock Holmes returned from his
+excursion. He held in his hand a sheet of blue paper, scrawled over
+with notes and figures.
+
+“I have seen the will of the deceased wife,” said he. “To determine
+its exact meaning I have been obliged to work out the present prices
+of the investments with which it is concerned. The total income, which
+at the time of the wife’s death was little short of £1100, is now,
+through the fall in agricultural prices, not more than £750. Each
+daughter can claim an income of £250, in case of marriage. It is
+evident, therefore, that if both girls had married, this beauty would
+have had a mere pittance, while even one of them would cripple him to
+a very serious extent. My morning’s work has not been wasted, since it
+has proved that he has the very strongest motives for standing in the
+way of anything of the sort. And now, Watson, this is too serious for
+dawdling, especially as the old man is aware that we are interesting
+ourselves in his affairs; so if you are ready, we shall call a cab and
+drive to Waterloo. I should be very much obliged if you would slip your
+revolver into your pocket. An Eley’s No. 2 is an excellent argument
+with gentlemen who can twist steel pokers into knots. That and a
+tooth-brush are, I think, all that we need.”
+
+At Waterloo we were fortunate in catching a train for Leatherhead,
+where we hired a trap at the station inn, and drove for four or five
+miles through the lovely Surrey lanes. It was a perfect day, with
+a bright sun and a few fleecy clouds in the heavens. The trees and
+way-side hedges were just throwing out their first green shoots, and
+the air was full of the pleasant smell of the moist earth. To me at
+least there was a strange contrast between the sweet promise of the
+spring and this sinister quest upon which we were engaged. My companion
+sat in the front of the trap, his arms folded, his hat pulled down over
+his eyes, and his chin sunk upon his breast, buried in the deepest
+thought. Suddenly, however, he started, tapped me on the shoulder, and
+pointed over the meadows.
+
+“Look there!” said he.
+
+A heavily-timbered park stretched up in a gentle slope, thickening into
+a grove at the highest point. From amid the branches there jutted out
+the gray gables and high roof-tree of a very old mansion.
+
+“Stoke Moran?” said he.
+
+“Yes, sir, that be the house of Dr. Grimesby Roylott,” remarked the
+driver.
+
+“There is some building going on there,” said Holmes; “that is where we
+are going.”
+
+“There’s the village,” said the driver, pointing to a cluster of roofs
+some distance to the left; “but if you want to get to the house, you’ll
+find it shorter to get over this stile, and so by the foot-path over
+the fields. There it is, where the lady is walking.”
+
+“And the lady, I fancy, is Miss Stoner,” observed Holmes, shading his
+eyes. “Yes, I think we had better do as you suggest.”
+
+We got off, paid our fare, and the trap rattled back on its way to
+Leatherhead.
+
+“I thought it as well,” said Holmes, as we climbed the stile, “that
+this fellow should think we had come here as architects, or on some
+definite business. It may stop his gossip. Good-afternoon, Miss Stoner.
+You see that we have been as good as our word.”
+
+Our client of the morning had hurried forward to meet us with a face
+which spoke her joy. “I have been waiting so eagerly for you,” she
+cried, shaking hands with us warmly. “All has turned out splendidly.
+Dr. Roylott has gone to town, and it is unlikely that he will be back
+before evening.”
+
+“We have had the pleasure of making the doctor’s acquaintance,” said
+Holmes, and in a few words he sketched out what had occurred. Miss
+Stoner turned white to the lips as she listened.
+
+“Good heavens!” she cried, “he has followed me, then.”
+
+“So it appears.”
+
+“He is so cunning that I never know when I am safe from him. What will
+he say when he returns?”
+
+“He must guard himself, for he may find that there is some one more
+cunning than himself upon his track. You must lock yourself up from him
+to-night. If he is violent, we shall take you away to your aunt’s at
+Harrow. Now, we must make the best use of our time, so kindly take us
+at once to the rooms which we are to examine.”
+
+The building was of gray, lichen-blotched stone, with a high central
+portion, and two curving wings, like the claws of a crab, thrown out
+on each side. In one of these wings the windows were broken, and
+blocked with wooden boards, while the roof was partly caved in, a
+picture of ruin. The central portion was in little better repair, but
+the right-hand block was comparatively modern, and the blinds in the
+windows, with the blue smoke curling up from the chimneys, showed that
+this was where the family resided. Some scaffolding had been erected
+against the end wall, and the stone-work had been broken into, but
+there were no signs of any workmen at the moment of our visit. Holmes
+walked slowly up and down the ill-trimmed lawn, and examined with deep
+attention the outsides of the windows.
+
+“This, I take it, belongs to the room in which you used to sleep, the
+centre one to your sister’s, and the one next to the main building to
+Dr. Roylott’s chamber?”
+
+“Exactly so. But I am now sleeping in the middle one.”
+
+“Pending the alterations, as I understand. By-the-way, there does not
+seem to be any very pressing need for repairs at that end wall.”
+
+“There were none. I believe that it was an excuse to move me from my
+room.”
+
+“Ah! that is suggestive. Now, on the other side of this narrow wing
+runs the corridor from which these three rooms open. There are windows
+in it, of course?”
+
+“Yes, but very small ones. Too narrow for any one to pass through.”
+
+“As you both locked your doors at night, your rooms were unapproachable
+from that side. Now, would you have the kindness to go into your room
+and bar your shutters.”
+
+Miss Stoner did so, and Holmes, after a careful examination through
+the open window, endeavored in every way to force the shutter open,
+but without success. There was no slit through which a knife could be
+passed to raise the bar. Then with his lens he tested the hinges, but
+they were of solid iron, built firmly into the massive masonry. “Hum!”
+said he, scratching his chin in some perplexity; “my theory certainly
+presents some difficulties. No one could pass these shutters if they
+were bolted. Well, we shall see if the inside throws any light upon the
+matter.”
+
+A small side door led into the whitewashed corridor from which the
+three bedrooms opened. Holmes refused to examine the third chamber,
+so we passed at once to the second, that in which Miss Stoner was now
+sleeping, and in which her sister had met with her fate. It was a
+homely little room, with a low ceiling and a gaping fireplace, after
+the fashion of old country-houses. A brown chest of drawers stood
+in one corner, a narrow white-counterpaned bed in another, and a
+dressing-table on the left-hand side of the window. These articles,
+with two small wicker-work chairs, made up all the furniture in the
+room, save for a square of Wilton carpet in the centre. The boards
+round and the panelling of the walls were of brown, worm-eaten oak, so
+old and discolored that it may have dated from the original building of
+the house. Holmes drew one of the chairs into a corner and sat silent,
+while his eyes travelled round and round and up and down, taking in
+every detail of the apartment.
+
+“Where does that bell communicate with?” he asked, at last, pointing to
+a thick bell-rope which hung down beside the bed, the tassel actually
+lying upon the pillow.
+
+“It goes to the house-keeper’s room.”
+
+“It looks newer than the other things?”
+
+“Yes, it was only put there a couple of years ago.”
+
+“Your sister asked for it, I suppose?”
+
+“No, I never heard of her using it. We used always to get what we
+wanted for ourselves.”
+
+“Indeed, it seemed unnecessary to put so nice a bell-pull there. You
+will excuse me for a few minutes while I satisfy myself as to this
+floor.” He threw himself down upon his face with his lens in his hand,
+and crawled swiftly backward and forward, examining minutely the cracks
+between the boards. Then he did the same with the wood-work with which
+the chamber was panelled. Finally he walked over to the bed, and spent
+some time in staring at it, and in running his eye up and down the
+wall. Finally he took the bell-rope in his hand and gave it a brisk tug.
+
+“Why, it’s a dummy,” said he.
+
+“Won’t it ring?”
+
+“No, it is not even attached to a wire. This is very interesting. You
+can see now that it is fastened to a hook just above where the little
+opening for the ventilator is.”
+
+“How very absurd! I never noticed that before.”
+
+“Very strange!” muttered Holmes, pulling at the rope. “There are one or
+two very singular points about this room. For example, what a fool a
+builder must be to open a ventilator into another room, when, with the
+same trouble, he might have communicated with the outside air!”
+
+“That is also quite modern,” said the lady.
+
+“Done about the same time as the bell-rope?” remarked Holmes.
+
+“Yes, there were several little changes carried out about that time.”
+
+“They seem to have been of a most interesting character—dummy
+bell-ropes, and ventilators which do not ventilate. With your
+permission, Miss Stoner, we shall now carry our researches into the
+inner apartment.”
+
+Dr. Grimesby Roylott’s chamber was larger than that of his
+step-daughter, but was as plainly furnished. A camp-bed, a small wooden
+shelf full of books, mostly of a technical character, an arm-chair
+beside the bed, a plain wooden chair against the wall, a round table,
+and a large iron safe were the principal things which met the eye.
+Holmes walked slowly round and examined each and all of them with the
+keenest interest.
+
+“What’s in here?” he asked, tapping the safe.
+
+“My step-father’s business papers.”
+
+“Oh! you have seen inside, then?”
+
+“Only once, some years ago. I remember that it was full of papers.”
+
+“There isn’t a cat in it, for example?”
+
+“No. What a strange idea!”
+
+“Well, look at this!” He took up a small saucer of milk which stood on
+the top of it.
+
+“No; we don’t keep a cat. But there is a cheetah and a baboon.”
+
+“Ah, yes, of course! Well, a cheetah is just a big cat, and yet a
+saucer of milk does not go very far in satisfying its wants, I dare
+say. There is one point which I should wish to determine.” He squatted
+down in front of the wooden chair, and examined the seat of it with the
+greatest attention.
+
+“Thank you. That is quite settled,” said he, rising and putting his
+lens in his pocket. “Hello! Here is something interesting!”
+
+The object which had caught his eye was a small dog-lash hung on one
+corner of the bed. The lash, however, was curled upon itself, and tied
+so as to make a loop of whip-cord.
+
+“What do you make of that, Watson?”
+
+“It’s a common enough lash. But I don’t know why it should be tied.”
+
+“That is not quite so common, is it? Ah, me! it’s a wicked world,
+and when a clever man turns his brains to crime it is the worst of
+all. I think that I have seen enough now, Miss Stoner, and with your
+permission we shall walk out upon the lawn.”
+
+I had never seen my friend’s face so grim or his brow so dark as it
+was when we turned from the scene of this investigation. We had walked
+several times up and down the lawn, neither Miss Stoner nor myself
+liking to break in upon his thoughts before he roused himself from his
+reverie.
+
+“It is very essential, Miss Stoner,” said he, “that you should
+absolutely follow my advice in every respect.”
+
+“I shall most certainly do so.”
+
+“The matter is too serious for any hesitation. Your life may depend
+upon your compliance.”
+
+“I assure you that I am in your hands.”
+
+“In the first place, both my friend and I must spend the night in your
+room.”
+
+Both Miss Stoner and I gazed at him in astonishment.
+
+“Yes, it must be so. Let me explain. I believe that that is the village
+inn over there?”
+
+“Yes, that is the ‘Crown.’”
+
+“Very good. Your windows would be visible from there?”
+
+“Certainly.”
+
+“You must confine yourself to your room, on pretence of a headache,
+when your step-father comes back. Then when you hear him retire for
+the night, you must open the shutters of your window, undo the hasp,
+put your lamp there as a signal to us, and then withdraw quietly with
+everything which you are likely to want into the room which you used to
+occupy. I have no doubt that, in spite of the repairs, you could manage
+there for one night.”
+
+“Oh yes, easily.”
+
+“The rest you will leave in our hands.”
+
+“But what will you do?”
+
+“We shall spend the night in your room, and we shall investigate the
+cause of this noise which has disturbed you.”
+
+“I believe, Mr. Holmes, that you have already made up your mind,” said
+Miss Stoner, laying her hand upon my companion’s sleeve.
+
+“Perhaps I have.”
+
+“Then for pity’s sake tell me what was the cause of my sister’s death.”
+
+“I should prefer to have clearer proofs before I speak.”
+
+“You can at least tell me whether my own thought is correct, and if she
+died from some sudden fright.”
+
+[Illustration: “‘GOOD-BYE, AND BE BRAVE’”]
+
+“No, I do not think so. I think that there was probably some more
+tangible cause. And now, Miss Stoner, we must leave you, for if Dr.
+Roylott returned and saw us, our journey would be in vain. Good-bye,
+and be brave, for if you will do what I have told you, you may rest
+assured that we shall soon drive away the dangers that threaten you.”
+
+Sherlock Holmes and I had no difficulty in engaging a bedroom and
+sitting-room at the “Crown Inn.” They were on the upper floor, and
+from our window we could command a view of the avenue gate, and of the
+inhabited wing of Stoke Moran Manor House. At dusk we saw Dr. Grimesby
+Roylott drive past, his huge form looming up beside the little figure
+of the lad who drove him. The boy had some slight difficulty in undoing
+the heavy iron gates, and we heard the hoarse roar of the doctor’s
+voice, and saw the fury with which he shook his clinched fists at him.
+The trap drove on, and a few minutes later we saw a sudden light spring
+up among the trees as the lamp was lit in one of the sitting-rooms.
+
+“Do you know, Watson,” said Holmes, as we sat together in the gathering
+darkness, “I have really some scruples as to taking you to-night. There
+is a distinct element of danger.”
+
+“Can I be of assistance?”
+
+“Your presence might be invaluable.”
+
+“Then I shall certainly come.”
+
+“It is very kind of you.”
+
+“You speak of danger. You have evidently seen more in these rooms than
+was visible to me.”
+
+“No, but I fancy that I may have deduced a little more. I imagine that
+you saw all that I did.”
+
+“I saw nothing remarkable save the bell-rope, and what purpose that
+could answer I confess is more than I can imagine.”
+
+“You saw the ventilator, too?”
+
+“Yes, but I do not think that it is such a very unusual thing to have
+a small opening between two rooms. It was so small that a rat could
+hardly pass through.”
+
+“I knew that we should find a ventilator before ever we came to Stoke
+Moran.”
+
+“My dear Holmes!”
+
+“Oh yes, I did. You remember in her statement she said that her sister
+could smell Dr. Roylott’s cigar. Now, of course that suggested at once
+that there must be a communication between the two rooms. It could only
+be a small one, or it would have been remarked upon at the coroner’s
+inquiry. I deduced a ventilator.”
+
+“But what harm can there be in that?”
+
+“Well, there is at least a curious coincidence of dates. A ventilator
+is made, a cord is hung, and a lady who sleeps in the bed dies. Does
+not that strike you?”
+
+“I cannot as yet see any connection.”
+
+“Did you observe anything very peculiar about that bed?”
+
+“No.”
+
+“It was clamped to the floor. Did you ever see a bed fastened like that
+before?”
+
+“I cannot say that I have.”
+
+“The lady could not move her bed. It must always be in the same
+relative position to the ventilator and to the rope—for so we may call
+it, since it was clearly never meant for a bell-pull.”
+
+“Holmes,” I cried, “I seem to see dimly what you are hinting at. We are
+only just in time to prevent some subtle and horrible crime.”
+
+“Subtle enough and horrible enough. When a doctor does go wrong, he is
+the first of criminals. He has nerve and he has knowledge. Palmer and
+Pritchard were among the heads of their profession. This man strikes
+even deeper, but I think, Watson, that we shall be able to strike
+deeper still. But we shall have horrors enough before the night is
+over; for goodness’ sake let us have a quiet pipe, and turn our minds
+for a few hours to something more cheerful.”
+
+       *       *       *       *       *
+
+About nine o’clock the light among the trees was extinguished, and all
+was dark in the direction of the Manor House. Two hours passed slowly
+away, and then, suddenly, just at the stroke of eleven, a single
+bright light shone out right in front of us.
+
+“That is our signal,” said Holmes, springing to his feet; “it comes
+from the middle window.”
+
+As we passed out he exchanged a few words with the landlord, explaining
+that we were going on a late visit to an acquaintance, and that it was
+possible that we might spend the night there. A moment later we were
+out on the dark road, a chill wind blowing in our faces, and one yellow
+light twinkling in front of us through the gloom to guide us on our
+sombre errand.
+
+There was little difficulty in entering the grounds, for unrepaired
+breaches gaped in the old park wall. Making our way among the trees,
+we reached the lawn, crossed it, and were about to enter through the
+window, when out from a clump of laurel bushes there darted what seemed
+to be a hideous and distorted child, who threw itself upon the grass
+with writhing limbs, and then ran swiftly across the lawn into the
+darkness.
+
+“My God!” I whispered; “did you see it?”
+
+Holmes was for the moment as startled as I. His hand closed like a vice
+upon my wrist in his agitation. Then he broke into a low laugh, and put
+his lips to my ear.
+
+“It is a nice household,” he murmured. “That is the baboon.”
+
+I had forgotten the strange pets which the doctor affected. There was
+a cheetah, too; perhaps we might find it upon our shoulders at any
+moment. I confess that I felt easier in my mind when, after following
+Holmes’s example and slipping off my shoes, I found myself inside the
+bedroom. My companion noiselessly closed the shutters, moved the lamp
+onto the table, and cast his eyes round the room. All was as we had
+seen it in the daytime. Then creeping up to me and making a trumpet of
+his hand, he whispered into my ear again so gently that it was all that
+I could do to distinguish the words:
+
+“The least sound would be fatal to our plans.”
+
+I nodded to show that I had heard.
+
+“We must sit without light. He would see it through the ventilator.”
+
+I nodded again.
+
+“Do not go asleep; your very life may depend upon it. Have your pistol
+ready in case we should need it. I will sit on the side of the bed, and
+you in that chair.”
+
+I took out my revolver and laid it on the corner of the table.
+
+Holmes had brought up a long thin cane, and this he placed upon the bed
+beside him. By it he laid the box of matches and the stump of a candle.
+Then he turned down the lamp, and we were left in darkness.
+
+How shall I ever forget that dreadful vigil? I could not hear a sound,
+not even the drawing of a breath, and yet I knew that my companion
+sat open-eyed, within a few feet of me, in the same state of nervous
+tension in which I was myself. The shutters cut off the least ray
+of light, and we waited in absolute darkness. From outside came the
+occasional cry of a night-bird, and once at our very window a long
+drawn cat-like whine, which told us that the cheetah was indeed at
+liberty. Far away we could hear the deep tones of the parish clock,
+which boomed out every quarter of an hour. How long they seemed, those
+quarters! Twelve struck, and one and two and three, and still we sat
+waiting silently for whatever might befall.
+
+Suddenly there was the momentary gleam of a light up in the direction
+of the ventilator, which vanished immediately, but was succeeded by
+a strong smell of burning oil and heated metal. Some one in the next
+room had lit a dark-lantern. I heard a gentle sound of movement, and
+then all was silent once more, though the smell grew stronger. For half
+an hour I sat with straining ears. Then suddenly another sound became
+audible—a very gentle, soothing sound, like that of a small jet of
+steam escaping continually from a kettle. The instant that we heard it,
+Holmes sprang from the bed, struck a match, and lashed furiously with
+his cane at the bell-pull.
+
+“You see it, Watson?” he yelled. “You see it?”
+
+But I saw nothing. At the moment when Holmes struck the light I heard
+a low, clear whistle, but the sudden glare flashing into my weary eyes
+made it impossible for me to tell what it was at which my friend lashed
+so savagely. I could, however, see that his face was deadly pale, and
+filled with horror and loathing.
+
+He had ceased to strike, and was gazing up at the ventilator, when
+suddenly there broke from the silence of the night the most horrible
+cry to which I have ever listened. It swelled up louder and louder, a
+hoarse yell of pain and fear and anger all mingled in the one dreadful
+shriek. They say that away down in the village, and even in the distant
+parsonage, that cry raised the sleepers from their beds. It struck cold
+to our hearts, and I stood gazing at Holmes, and he at me, until the
+last echoes of it had died away into the silence from which it rose.
+
+“What can it mean?” I gasped.
+
+“It means that it is all over,” Holmes answered. “And perhaps, after
+all, it is for the best. Take your pistol, and we will enter Dr.
+Roylott’s room.”
+
+With a grave face he lit the lamp and led the way down the corridor.
+Twice he struck at the chamber door without any reply from within.
+Then he turned the handle and entered, I at his heels, with the cocked
+pistol in my hand.
+
+It was a singular sight which met our eyes. On the table stood a
+dark-lantern with the shutter half open, throwing a brilliant beam
+of light upon the iron safe, the door of which was ajar. Beside this
+table, on the wooden chair, sat Dr. Grimesby Roylott, clad in a long
+gray dressing-gown, his bare ankles protruding beneath, and his feet
+thrust into red heelless Turkish slippers. Across his lap lay the short
+stock with the long lash which we had noticed during the day. His chin
+was cocked upward and his eyes were fixed in a dreadful, rigid stare
+at the corner of the ceiling. Round his brow he had a peculiar yellow
+band, with brownish speckles, which seemed to be bound tightly round
+his head. As we entered he made neither sound nor motion.
+
+“The band! the speckled band!” whispered Holmes.
+
+I took a step forward. In an instant his strange head-gear began
+to move, and there reared itself from among his hair the squat
+diamond-shaped head and puffed neck of a loathsome serpent.
+
+“It is a swamp adder!” cried Holmes; “the deadliest snake in India. He
+has died within ten seconds of being bitten. Violence does, in truth,
+recoil upon the violent, and the schemer falls into the pit which he
+digs for another. Let us thrust this creature back into its den, and
+we can then remove Miss Stoner to some place of shelter, and let the
+county police know what has happened.”
+
+As he spoke he drew the dog-whip swiftly from the dead man’s lap, and
+throwing the noose round the reptile’s neck, he drew it from its horrid
+perch, and carrying it at arm’s length, threw it into the iron safe,
+which he closed upon it.
+
+       *       *       *       *       *
+
+Such are the true facts of the death of Dr. Grimesby Roylott, of Stoke
+Moran. It is not necessary that I should prolong a narrative which has
+already run to too great a length, by telling how we broke the sad news
+to the terrified girl, how we conveyed her by the morning train to the
+care of her good aunt at Harrow, of how the slow process of official
+inquiry came to the conclusion that the doctor met his fate while
+indiscreetly playing with a dangerous pet. The little which I had yet
+to learn of the case was told me by Sherlock Holmes as we travelled
+back next day.
+
+“I had,” said he, “come to an entirely erroneous conclusion, which
+shows, my dear Watson, how dangerous it always is to reason from
+insufficient data. The presence of the gypsies, and the use of the
+word ‘band,’ which was used by the poor girl, no doubt to explain the
+appearance which she had caught a hurried glimpse of by the light of
+her match, were sufficient to put me upon an entirely wrong scent. I
+can only claim the merit that I instantly reconsidered my position
+when, however, it became clear to me that whatever danger threatened
+an occupant of the room could not come either from the window or the
+door. My attention was speedily drawn, as I have already remarked to
+you, to this ventilator, and to the bell-rope which hung down to the
+bed. The discovery that this was a dummy, and that the bed was clamped
+to the floor, instantly gave rise to the suspicion that the rope was
+there as bridge for something passing through the hole, and coming
+to the bed. The idea of a snake instantly occurred to me, and when
+I coupled it with my knowledge that the doctor was furnished with a
+supply of creatures from India, I felt that I was probably on the right
+track. The idea of using a form of poison which could not possibly be
+discovered by any chemical test was just such a one as would occur to a
+clever and ruthless man who had had an Eastern training. The rapidity
+with which such a poison would take effect would also, from his point
+of view, be an advantage. It would be a sharp-eyed coroner, indeed, who
+could distinguish the two little dark punctures which would show where
+the poison fangs had done their work. Then I thought of the whistle. Of
+course he must recall the snake before the morning light revealed it to
+the victim. He had trained it, probably by the use of the milk which
+we saw, to return to him when summoned. He would put it through this
+ventilator at the hour that he thought best, with the certainty that it
+would crawl down the rope and land on the bed. It might or might not
+bite the occupant, perhaps she might escape every night for a week, but
+sooner or later she must fall a victim.
+
+“I had come to these conclusions before ever I had entered his room.
+An inspection of his chair showed me that he had been in the habit of
+standing on it, which of course would be necessary in order that he
+should reach the ventilator. The sight of the safe, the saucer of milk,
+and the loop of whip-cord were enough to finally dispel any doubts
+which may have remained. The metallic clang heard by Miss Stoner was
+obviously caused by her step-father hastily closing the door of his
+safe upon its terrible occupant. Having once made up my mind, you know
+the steps which I took in order to put the matter to the proof. I
+heard the creature hiss, as I have no doubt that you did also, and I
+instantly lit the light and attacked it.”
+
+“With the result of driving it through the ventilator.”
+
+“And also with the result of causing it to turn upon its master at the
+other side. Some of the blows of my cane came home, and roused its
+snakish temper, so that it flew upon the first person it saw. In this
+way I am no doubt indirectly responsible for Dr. Grimesby Roylott’s
+death, and I cannot say that it is likely to weigh very heavily upon my
+conscience.”
+
+
+
+
+Adventure IX
+
+THE ADVENTURE OF THE ENGINEER’S THUMB
+
+
+Of all the problems which have been submitted to my friend Mr. Sherlock
+Holmes for solution during the years of our intimacy, there were only
+two which I was the means of introducing to his notice—that of Mr.
+Hatherley’s thumb, and that of Colonel Warburton’s madness. Of these
+the latter may have afforded a finer field for an acute and original
+observer, but the other was so strange in its inception and so dramatic
+in its details, that it may be the more worthy of being placed upon
+record, even if it gave my friend fewer openings for those deductive
+methods of reasoning by which he achieved such remarkable results. The
+story has, I believe, been told more than once in the newspapers, but,
+like all such narratives, its effect is much less striking when set
+forth _en bloc_ in a single half-column of print than when the facts
+slowly evolve before your own eyes, and the mystery clears gradually
+away as each new discovery furnishes a step which leads on to the
+complete truth. At the time the circumstances made a deep impression
+upon me, and the lapse of two years has hardly served to weaken the
+effect.
+
+It was in the summer of ’89, not long after my marriage, that the
+events occurred which I am now about to summarize. I had returned to
+civil practice, and had finally abandoned Holmes in his Baker Street
+rooms, although I continually visited him, and occasionally even
+persuaded him to forego his Bohemian habits so far as to come and visit
+us. My practice had steadily increased, and as I happened to live at
+no very great distance from Paddington Station, I got a few patients
+from among the officials. One of these, whom I had cured of a painful
+and lingering disease, was never weary of advertising my virtues, and
+of endeavoring to send me on every sufferer over whom he might have any
+influence.
+
+One morning, at a little before seven o’clock, I was awakened by
+the maid tapping at the door, to announce that two men had come
+from Paddington, and were waiting in the consulting-room. I dressed
+hurriedly, for I knew by experience that railway cases were seldom
+trivial, and hastened down-stairs. As I descended, my old ally, the
+guard, came out of the room and closed the door tightly behind him.
+
+“I’ve got him here,” he whispered, jerking his thumb over his shoulder;
+“he’s all right.”
+
+“What is it, then?” I asked, for his manner suggested that it was some
+strange creature which he had caged up in my room.
+
+“It’s a new patient,” he whispered. “I thought I’d bring him round
+myself; then he couldn’t slip away. There he is, all safe and sound. I
+must go now, doctor; I have my dooties, just the same as you.” And off
+he went, this trusty tout, without even giving me time to thank him.
+
+I entered my consulting-room and found a gentleman seated by the
+table. He was quietly dressed in a suit of heather tweed, with a soft
+cloth cap, which he had laid down upon my books. Round one of his
+hands he had a handkerchief wrapped, which was mottled all over with
+blood-stains. He was young, not more than five-and-twenty, I should
+say, with a strong, masculine face; but he was exceedingly pale, and
+gave me the impression of a man who was suffering from some strong
+agitation, which it took all his strength of mind to control.
+
+“I am sorry to knock you up so early, doctor,” said he, “but I have
+had a very serious accident during the night. I came in by train this
+morning, and on inquiring at Paddington as to where I might find a
+doctor, a worthy fellow very kindly escorted me here. I gave the maid a
+card, but I see that she has left it upon the side-table.”
+
+I took it up and glanced at it. “Mr. Victor Hatherley, hydraulic
+engineer, 16A, Victoria Street (3d floor).” That was the name,
+style, and abode of my morning visitor. “I regret that I have kept you
+waiting,” said I, sitting down in my library-chair. “You are fresh
+from a night journey, I understand, which is in itself a monotonous
+occupation.”
+
+“Oh, my night could not be called monotonous,” said he, and laughed. He
+laughed very heartily, with a high, ringing note, leaning back in his
+chair and shaking his sides. All my medical instincts rose up against
+that laugh.
+
+“Stop it!” I cried; “pull yourself together!” and I poured out some
+water from a caraffe.
+
+It was useless, however. He was off in one of those hysterical
+outbursts which come upon a strong nature when some great crisis is
+over and gone. Presently he came to himself once more, very weary and
+blushing hotly.
+
+“I have been making a fool of myself,” he gasped.
+
+“Not at all. Drink this.” I dashed some brandy into the water, and the
+color began to come back to his bloodless cheeks.
+
+“That’s better!” said he. “And now, doctor, perhaps you would kindly
+attend to my thumb, or rather to the place where my thumb used to be.”
+
+He unwound the handkerchief and held out his hand. It gave even my
+hardened nerves a shudder to look at it. There were four protruding
+fingers and a horrid red, spongy surface where the thumb should have
+been. It had been hacked or torn right out from the roots.
+
+“Good heavens!” I cried, “this is a terrible injury. It must have bled
+considerably.”
+
+“Yes, it did. I fainted when it was done, and I think that I must have
+been senseless for a long time. When I came to I found that it was
+still bleeding, so I tied one end of my handkerchief very tightly
+round the wrist, and braced it up with a twig.”
+
+“Excellent! You should have been a surgeon.”
+
+“It is a question of hydraulics, you see, and came within my own
+province.”
+
+“This has been done,” said I, examining the wound, “by a very heavy and
+sharp instrument.”
+
+“A thing like a cleaver,” said he.
+
+“An accident, I presume?”
+
+“By no means.”
+
+“What! a murderous attack?”
+
+“Very murderous indeed.”
+
+“You horrify me.”
+
+I sponged the wound, cleaned it, dressed it, and finally covered it
+over with cotton wadding and carbolized bandages. He lay back without
+wincing, though he bit his lip from time to time.
+
+“How is that?” I asked, when I had finished.
+
+“Capital! Between your brandy and your bandage, I feel a new man. I was
+very weak, but I have had a good deal to go through.”
+
+“Perhaps you had better not speak of the matter. It is evidently trying
+to your nerves.”
+
+“Oh no, not now. I shall have to tell my tale to the police; but,
+between ourselves, if it were not for the convincing evidence of this
+wound of mine, I should be surprised if they believed my statement; for
+it is a very extraordinary one, and I have not much in the way of proof
+with which to back it up; and, even if they believe me, the clews which
+I can give them are so vague that it is a question whether justice will
+be done.”
+
+“Ha!” cried I, “if it is anything in the nature of a problem which you
+desire to see solved, I should strongly recommend you to come to my
+friend Mr. Sherlock Holmes before you go to the official police.”
+
+“Oh, I have heard of that fellow,” answered my visitor, “and I should
+be very glad if he would take the matter up, though of course I must
+use the official police as well. Would you give me an introduction to
+him?”
+
+“I’ll do better. I’ll take you round to him myself.”
+
+“I should be immensely obliged to you.”
+
+“We’ll call a cab and go together. We shall just be in time to have a
+little breakfast with him. Do you feel equal to it?”
+
+“Yes; I shall not feel easy until I have told my story.”
+
+“Then my servant will call a cab, and I shall be with you in an
+instant.” I rushed up-stairs, explained the matter shortly to my
+wife, and in five minutes was inside a hansom, driving with my new
+acquaintance to Baker Street.
+
+Sherlock Holmes was, as I expected, lounging about his sitting-room in
+his dressing-gown, reading the agony column of _The Times_, and smoking
+his before-breakfast pipe, which was composed of all the plugs and
+dottels left from his smokes of the day before, all carefully dried
+and collected on the corner of the mantel-piece. He received us in his
+quietly genial fashion, ordered fresh rashers and eggs, and joined us
+in a hearty meal. When it was concluded he settled our new acquaintance
+upon the sofa, placed a pillow beneath his head, and laid a glass of
+brandy-and-water within his reach.
+
+“It is easy to see that your experience has been no common one, Mr.
+Hatherley,” said he. “Pray, lie down there and make yourself absolutely
+at home. Tell us what you can, but stop when you are tired, and keep up
+your strength with a little stimulant.”
+
+“Thank you,” said my patient, “but I have felt another man since the
+doctor bandaged me, and I think that your breakfast has completed the
+cure. I shall take up as little of your valuable time as possible, so I
+shall start at once upon my peculiar experiences.”
+
+Holmes sat in his big arm-chair with the weary, heavy-lidded expression
+which veiled his keen and eager nature, while I sat opposite to him,
+and we listened in silence to the strange story which our visitor
+detailed to us.
+
+“You must know,” said he, “that I am an orphan and a bachelor, residing
+alone in lodgings in London. By profession I am an hydraulic engineer,
+and I have had considerable experience of my work during the seven
+years that I was apprenticed to Venner & Matheson, the well-known
+firm, of Greenwich. Two years ago, having served my time, and having
+also come into a fair sum of money through my poor father’s death,
+I determined to start in business for myself, and took professional
+chambers in Victoria Street.
+
+“I suppose that every one finds his first independent start in business
+a dreary experience. To me it has been exceptionally so. During two
+years I have had three consultations and one small job, and that is
+absolutely all that my profession has brought me. My gross takings
+amount to £27 10_s._ Every day, from nine in the morning until four in
+the afternoon, I waited in my little den, until at last my heart began
+to sink, and I came to believe that I should never have any practice at
+all.
+
+“Yesterday, however, just as I was thinking of leaving the office,
+my clerk entered to say there was a gentleman waiting who wished to
+see me upon business. He brought up a card, too, with the name of
+‘Colonel Lysander Stark’ engraved upon it. Close at his heels came the
+colonel himself, a man rather over the middle size, but of an exceeding
+thinness. I do not think that I have ever seen so thin a man. His whole
+face sharpened away into nose and chin, and the skin of his cheeks
+was drawn quite tense over his outstanding bones. Yet this emaciation
+seemed to be his natural habit, and due to no disease, for his eye was
+bright, his step brisk, and his bearing assured. He was plainly but
+neatly dressed, and his age, I should judge, would be nearer forty than
+thirty.
+
+“‘Mr. Hatherley?’ said he, with something of a German accent. ‘You
+have been recommended to me, Mr. Hatherley, as being a man who is not
+only proficient in his profession, but is also discreet and capable of
+preserving a secret.’
+
+“I bowed, feeling as flattered as any young man would at such an
+address. ‘May I ask who it was who gave me so good a character?’
+
+“‘Well, perhaps it is better that I should not tell you that just at
+this moment. I have it from the same source that you are both an orphan
+and a bachelor, and are residing alone in London.’
+
+“‘That is quite correct,’ I answered, ‘but you will excuse me if
+I say that I cannot see how all this bears upon my professional
+qualifications. I understood that it was on a professional matter that
+you wished to speak to me?’
+
+“‘Undoubtedly so. But you will find that all I say is really to the
+point. I have a professional commission for you, but absolute secrecy
+is quite essential—_absolute_ secrecy, you understand, and of course
+we may expect that more from a man who is alone than from one who lives
+in the bosom of his family.’
+
+“‘If I promise to keep a secret,’ said I, ‘you may absolutely depend
+upon my doing so.’
+
+“He looked very hard at me as I spoke, and it seemed to me that I had
+never seen so suspicious and questioning an eye.
+
+“‘Do you promise, then?’ said he, at last.
+
+“‘Yes, I promise.’
+
+“‘Absolute and complete silence before, during, and after? No reference
+to the matter at all, either in word or writing?’
+
+“‘I have already given you my word.’
+
+“‘Very good.’ He suddenly sprang up, and darting like lightning across
+the room, he flung open the door. The passage outside was empty.
+
+“‘That’s all right,’ said he, coming back. ‘I know that clerks are
+sometimes curious as to their master’s affairs. Now we can talk in
+safety.’ He drew up his chair very close to mine, and began to stare at
+me again with the same questioning and thoughtful look.
+
+“A feeling of repulsion, and of something akin to fear had begun to
+rise within me at the strange antics of this fleshless man. Even
+my dread of losing a client could not restrain me from showing my
+impatience.
+
+“‘I beg that you will state your business, sir,’ said I; ‘my time is of
+value.’ Heaven forgive me for that last sentence, but the words came to
+my lips.
+
+“‘How would fifty guineas for a night’s work suit you?’ he asked.
+
+“‘Most admirably.’
+
+“‘I say a night’s work, but an hour’s would be nearer the mark. I
+simply want your opinion about a hydraulic stamping machine which has
+got out of gear. If you show us what is wrong we shall soon set it
+right ourselves. What do you think of such a commission as that?’
+
+“‘The work appears to be light and the pay munificent.’
+
+“‘Precisely so. We shall want you to come to-night by the last train.’
+
+“‘Where to?’
+
+“‘To Eyford, in Berkshire. It is a little place near the borders of
+Oxfordshire, and within seven miles of Reading. There is a train from
+Paddington which would bring you there at about 11.15.’
+
+“‘Very good.’
+
+“‘I shall come down in a carriage to meet you.’
+
+“‘There is a drive, then?’
+
+“‘Yes, our little place is quite out in the country. It is a good seven
+miles from Eyford Station.’
+
+“‘Then we can hardly get there before midnight. I suppose there would
+be no chance of a train back. I should be compelled to stop the night.’
+
+“‘Yes, we could easily give you a shake-down.’
+
+“‘That is very awkward. Could I not come at some more convenient hour?’
+
+“‘We have judged it best that you should come late. It is to recompense
+you for any inconvenience that we are paying to you, a young and
+unknown man, a fee which would buy an opinion from the very heads of
+your profession. Still, of course, if you would like to draw out of
+the business, there is plenty of time to do so.’
+
+“I thought of the fifty guineas, and of how very useful they would be
+to me. ‘Not at all,’ said I, ‘I shall be very happy to accommodate
+myself to your wishes. I should like, however, to understand a little
+more clearly what it is that you wish me to do.’
+
+“‘Quite so. It is very natural that the pledge of secrecy which we have
+exacted from you should have aroused your curiosity. I have no wish to
+commit you to anything without your having it all laid before you. I
+suppose that we are absolutely safe from eavesdroppers?’
+
+“‘Entirely.’
+
+“‘Then the matter stands thus. You are probably aware that
+fuller’s-earth is a valuable product, and that it is only found in one
+or two places in England?’
+
+“‘I have heard so.’
+
+“‘Some little time ago I bought a small place—a very small
+place—within ten miles of Reading. I was fortunate enough to discover
+that there was a deposit of fuller’s-earth in one of my fields. On
+examining it, however, I found that this deposit was a comparatively
+small one, and that it formed a link between two very much larger ones
+upon the right and left—both of them, however, in the grounds of my
+neighbors. These good people were absolutely ignorant that their land
+contained that which was quite as valuable as a gold-mine. Naturally,
+it was to my interest to buy their land before they discovered its true
+value; but, unfortunately, I had no capital by which I could do this. I
+took a few of my friends into the secret, however, and they suggested
+that we should quietly and secretly work our own little deposit, and
+that in this way we should earn the money which would enable us to buy
+the neighboring fields. This we have now been doing for some time, and
+in order to help us in our operations we erected an hydraulic press.
+This press, as I have already explained, has got out of order, and we
+wish your advice upon the subject. We guard our secret very jealously,
+however, and if it once became known that we had hydraulic engineers
+coming to our little house, it would soon rouse inquiry, and then, if
+the facts came out, it would be good-bye to any chance of getting these
+fields and carrying out our plans. That is why I have made you promise
+me that you will not tell a human being that you are going to Eyford
+to-night. I hope that I make it all plain?’
+
+“‘I quite follow you,’ said I. ‘The only point which I could not
+quite understand, was what use you could make of an hydraulic press
+in excavating fuller’s-earth, which, as I understand, is dug out like
+gravel from a pit.’
+
+“‘Ah!’ said he, carelessly, ‘we have our own process. We compress
+the earth into bricks, so as to remove them without revealing what
+they are. But that is a mere detail. I have taken you fully into my
+confidence now, Mr. Hatherley, and I have shown you how I trust you.’
+He rose as he spoke. ‘I shall expect you, then, at Eyford at 11.15.’
+
+“‘I shall certainly be there.’
+
+“‘And not a word to a soul.’ He looked at me with a last, long,
+questioning gaze, and then, pressing my hand in a cold, dank grasp, he
+hurried from the room.
+
+“Well, when I came to think it all over in cool blood I was very much
+astonished, as you may both think, at this sudden commission which had
+been intrusted to me. On the one hand, of course, I was glad, for the
+fee was at least tenfold what I should have asked had I set a price
+upon my own services, and it was possible that this order might lead
+to other ones. On the other hand, the face and manner of my patron
+had made an unpleasant impression upon me, and I could not think that
+his explanation of the fuller’s-earth was sufficient to explain the
+necessity for my coming at midnight, and his extreme anxiety lest I
+should tell any one of my errand. However, I threw all fears to the
+winds, ate a hearty supper, drove to Paddington, and started off,
+having obeyed to the letter the injunction as to holding my tongue.
+
+[Illustration: “‘NOT A WORD TO A SOUL’”]
+
+“At Reading I had to change not only my carriage, but my station.
+However, I was in time for the last train to Eyford, and I reached the
+little dim-lit station after eleven o’clock. I was the only passenger
+who got out there, and there was no one upon the platform save a single
+sleepy porter with a lantern. As I passed out through the wicket gate,
+however, I found my acquaintance of the morning waiting in the shadow
+upon the other side. Without a word he grasped my arm and hurried me
+into a carriage, the door of which was standing open. He drew up the
+windows on either side, tapped on the wood-work, and away we went as
+fast as the horse could go.”
+
+“One horse?” interjected Holmes.
+
+“Yes, only one.”
+
+“Did you observe the color?”
+
+“Yes, I saw it by the side-lights when I was stepping into the
+carriage. It was a chestnut.”
+
+“Tired-looking or fresh?”
+
+“Oh, fresh and glossy.”
+
+“Thank you. I am sorry to have interrupted you. Pray continue your most
+interesting statement.”
+
+“Away we went then, and we drove for at least an hour. Colonel Lysander
+Stark had said that it was only seven miles, but I should think, from
+the rate that we seemed to go, and from the time that we took, that
+it must have been nearer twelve. He sat at my side in silence all the
+time, and I was aware, more than once when I glanced in his direction,
+that he was looking at me with great intensity. The country roads seem
+to be not very good in that part of the world, for we lurched and
+jolted terribly. I tried to look out of the windows to see something of
+where we were, but they were made of frosted glass, and I could make
+out nothing save the occasional bright blur of a passing light. Now
+and then I hazarded some remark to break the monotony of the journey,
+but the colonel answered only in monosyllables, and the conversation
+soon flagged. At last, however, the bumping of the road was exchanged
+for the crisp smoothness of a gravel-drive, and the carriage came to
+a stand. Colonel Lysander Stark sprang out, and, as I followed after
+him, pulled me swiftly into a porch which gaped in front of us. We
+stepped, as it were, right out of the carriage and into the hall, so
+that I failed to catch the most fleeting glance of the front of the
+house. The instant that I had crossed the threshold the door slammed
+heavily behind us, and I heard faintly the rattle of the wheels as the
+carriage drove away.
+
+“It was pitch dark inside the house, and the colonel fumbled about
+looking for matches, and muttering under his breath. Suddenly a door
+opened at the other end of the passage, and a long, golden bar of light
+shot out in our direction. It grew broader, and a woman appeared with
+a lamp in her hand, which she held above her head, pushing her face
+forward and peering at us. I could see that she was pretty, and from
+the gloss with which the light shone upon her dark dress I knew that
+it was a rich material. She spoke a few words in a foreign tongue in a
+tone as though asking a question, and when my companion answered in a
+gruff monosyllable she gave such a start that the lamp nearly fell from
+her hand. Colonel Stark went up to her, whispered something in her ear,
+and then, pushing her back into the room from whence she had come, he
+walked towards me again with the lamp in his hand.
+
+“‘Perhaps you will have the kindness to wait in this room for a few
+minutes,’ said he, throwing open another door. It was a quiet, little,
+plainly-furnished room, with a round table in the centre, on which
+several German books were scattered. Colonel Stark laid down the lamp
+on the top of a harmonium beside the door. ‘I shall not keep you
+waiting an instant,’ said he, and vanished into the darkness.
+
+“I glanced at the books upon the table, and in spite of my ignorance
+of German I could see that two of them were treatises on science, the
+others being volumes of poetry. Then I walked across to the window,
+hoping that I might catch some glimpse of the country-side, but an oak
+shutter, heavily barred, was folded across it. It was a wonderfully
+silent house. There was an old clock ticking loudly somewhere in the
+passage, but otherwise everything was deadly still. A vague feeling of
+uneasiness began to steal over me. Who were these German people, and
+what were they doing, living in this strange, out-of-the-way place?
+And where was the place? I was ten miles or so from Eyford, that was
+all I knew, but whether north, south, east, or west I had no idea.
+For that matter, Reading, and possibly other large towns, were within
+that radius, so the place might not be so secluded, after all. Yet it
+was quite certain, from the absolute stillness, that we were in the
+country. I paced up and down the room, humming a tune under my breath
+to keep up my spirits, and feeling that I was thoroughly earning my
+fifty-guinea fee.
+
+“Suddenly, without any preliminary sound in the midst of the utter
+stillness, the door of my room swung slowly open. The woman was
+standing in the aperture, the darkness of the hall behind her, the
+yellow light from my lamp beating upon her eager and beautiful face. I
+could see at a glance that she was sick with fear, and the sight sent a
+chill to my own heart. She held up one shaking finger to warn me to be
+silent, and she shot a few whispered words of broken English at me, her
+eyes glancing back, like those of a frightened horse, into the gloom
+behind her.
+
+“‘I would go,’ said she, trying hard, as it seemed to me, to speak
+calmly; ‘I would go. I should not stay here. There is no good for you
+to do.’
+
+“‘But, madam,’ said I, ‘I have not yet done what I came for. I cannot
+possibly leave until I have seen the machine.’
+
+“‘It is not worth your while to wait,’ she went on. ‘You can pass
+through the door; no one hinders.’ And then, seeing that I smiled and
+shook my head, she suddenly threw aside her constraint and made a step
+forward, with her hands wrung together. ‘For the love of Heaven!’ she
+whispered, ‘get away from here before it is too late!’
+
+“But I am somewhat headstrong by nature, and the more ready to engage
+in an affair when there is some obstacle in the way. I thought of my
+fifty-guinea fee, of my wearisome journey, and of the unpleasant night
+which seemed to be before me. Was it all to go for nothing? Why should
+I slink away without having carried out my commission, and without
+the payment which was my due? This woman might, for all I knew, be a
+monomaniac. With a stout bearing, therefore, though her manner had
+shaken me more than I cared to confess, I still shook my head, and
+declared my intention of remaining where I was. She was about to renew
+her entreaties, when a door slammed overhead, and the sound of several
+footsteps were heard upon the stairs. She listened for an instant,
+threw up her hands with a despairing gesture, and vanished as suddenly
+and as noiselessly as she had come.
+
+“The new-comers were Colonel Lysander Stark and a short, thick man with
+a chinchilla beard growing out of the creases of his double chin, who
+was introduced to me as Mr. Ferguson.
+
+“‘This is my secretary and manager,’ said the colonel. ‘By-the-way, I
+was under the impression that I left this door shut just now. I fear
+that you have felt the draught.’
+
+“‘On the contrary,’ said I, ‘I opened the door myself, because I felt
+the room to be a little close.’
+
+“He shot one of his suspicious looks at me. ‘Perhaps we had better
+proceed to business, then,’ said he. ‘Mr. Ferguson and I will take you
+up to see the machine.’
+
+“‘I had better put my hat on, I suppose.’
+
+“‘Oh no, it is in the house.’
+
+“‘What, you dig fuller’s-earth in the house?’
+
+“‘No, no. This is only where we compress it. But never mind that. All
+we wish you to do is to examine the machine, and to let us know what is
+wrong with it.’
+
+“We went up-stairs together, the colonel first with the lamp, the fat
+manager, and I behind him. It was a labyrinth of an old house, with
+corridors, passages, narrow winding staircases, and little low doors,
+the thresholds of which were hollowed out by the generations who had
+crossed them. There were no carpets and no signs of any furniture
+above the ground floor, while the plaster was peeling off the walls,
+and the damp was breaking through in green, unhealthy blotches. I tried
+to put on as unconcerned an air as possible, but I had not forgotten
+the warnings of the lady, even though I disregarded them, and I kept a
+keen eye upon my two companions. Ferguson appeared to be a morose and
+silent man, but I could see from the little that he said that he was at
+least a fellow-countryman.
+
+“Colonel Lysander Stark stopped at last before a low door, which he
+unlocked. Within was a small, square room, in which the three of us
+could hardly get at one time. Ferguson remained outside, and the
+colonel ushered me in.
+
+“‘We are now,’ said he, ‘actually within the hydraulic press, and it
+would be a particularly unpleasant thing for us if any one were to
+turn it on. The ceiling of this small chamber is really the end of the
+descending piston, and it comes down with the force of many tons upon
+this metal floor. There are small lateral columns of water outside
+which receive the force, and which transmit and multiply it in the
+manner which is familiar to you. The machine goes readily enough, but
+there is some stiffness in the working of it, and it has lost a little
+of its force. Perhaps you will have the goodness to look it over and to
+show us how we can set it right.’
+
+“I took the lamp from him, and I examined the machine very thoroughly.
+It was indeed a gigantic one, and capable of exercising enormous
+pressure. When I passed outside, however, and pressed down the levers
+which controlled it, I knew at once by the whishing sound that there
+was a slight leakage, which allowed a regurgitation of water through
+one of the side cylinders. An examination showed that one of the
+india-rubber bands which was round the head of a driving-rod had shrunk
+so as not quite to fill the socket along which it worked. This was
+clearly the cause of the loss of power, and I pointed it out to my
+companions, who followed my remarks very carefully, and asked several
+practical questions as to how they should proceed to set it right. When
+I had made it clear to them, I returned to the main chamber of the
+machine and took a good look at it to satisfy my own curiosity. It was
+obvious at a glance that the story of the fuller’s-earth was the merest
+fabrication, for it would be absurd to suppose that so powerful an
+engine could be designed for so inadequate a purpose. The walls were of
+wood, but the floor consisted of a large iron trough, and when I came
+to examine it I could see a crust of metallic deposit all over it. I
+had stooped and was scraping at this to see exactly what it was, when I
+heard a muttered exclamation in German, and saw the cadaverous face of
+the colonel looking down at me.
+
+“‘What are you doing there?’ he asked.
+
+“I felt angry at having been tricked by so elaborate a story as that
+which he had told me. ‘I was admiring your fuller’s-earth,’ said I; ‘I
+think that I should be better able to advise you as to your machine if
+I knew what the exact purpose was for which it was used.’
+
+“The instant that I uttered the words I regretted the rashness of my
+speech. His face set hard, and a baleful light sprang up in his gray
+eyes.
+
+“‘Very well,’ said he, ‘you shall know all about the machine.’ He took
+a step backward, slammed the little door, and turned the key in the
+lock. I rushed towards it and pulled at the handle, but it was quite
+secure, and did not give in the least to my kicks and shoves. ‘Hello!’
+I yelled. ‘Hello! Colonel! Let me out!’
+
+“And then suddenly in the silence I heard a sound which sent my heart
+into my mouth. It was the clank of the levers and the swish of the
+leaking cylinder. He had set the engine at work. The lamp still stood
+upon the floor where I had placed it when examining the trough. By its
+light I saw that the black ceiling was coming down upon me, slowly,
+jerkily, but, as none knew better than myself, with a force which
+must within a minute grind me to a shapeless pulp. I threw myself,
+screaming, against the door, and dragged with my nails at the lock. I
+implored the colonel to let me out, but the remorseless clanking of the
+levers drowned my cries. The ceiling was only a foot or two above my
+head, and with my hand upraised I could feel its hard, rough surface.
+Then it flashed through my mind that the pain of my death would depend
+very much upon the position in which I met it. If I lay on my face
+the weight would come upon my spine, and I shuddered to think of that
+dreadful snap. Easier the other way, perhaps; and yet, had I the nerve
+to lie and look up at that deadly black shadow wavering down upon me?
+Already I was unable to stand erect, when my eye caught something which
+brought a gush of hope back to my heart.
+
+“I have said that though the floor and ceiling were of iron, the walls
+were of wood. As I gave a last hurried glance around, I saw a thin
+line of yellow light between two of the boards, which broadened and
+broadened as a small panel was pushed backward. For an instant I could
+hardly believe that here was indeed a door which led away from death.
+The next instant I threw myself through, and lay half-fainting upon the
+other side. The panel had closed again behind me, but the crash of the
+lamp, and a few moments afterwards the clang of the two slabs of metal,
+told me how narrow had been my escape.
+
+“I was recalled to myself by a frantic plucking at my wrist, and I
+found myself lying upon the stone floor of a narrow corridor, while a
+woman bent over me and tugged at me with her left hand, while she held
+a candle in her right. It was the same good friend whose warning I had
+so foolishly rejected.
+
+“‘Come! come!’ she cried, breathlessly. ‘They will be here in a moment.
+They will see that you are not there. Oh, do not waste the so-precious
+time, but come!’
+
+“This time, at least, I did not scorn her advice. I staggered to my
+feet and ran with her along the corridor and down a winding stair. The
+latter led to another broad passage, and, just as we reached it, we
+heard the sound of running feet and the shouting of two voices, one
+answering the other, from the floor on which we were and from the one
+beneath. My guide stopped and looked about her like one who is at her
+wits’ end. Then she threw open a door which led into a bedroom, through
+the window of which the moon was shining brightly.
+
+“‘It is your only chance,’ said she. ‘It is high, but it may be that
+you can jump it.’
+
+“As she spoke a light sprang into view at the further end of the
+passage, and I saw the lean figure of Colonel Lysander Stark rushing
+forward with a lantern in one hand and a weapon like a butcher’s
+cleaver in the other. I rushed across the bedroom, flung open the
+window, and looked out. How quiet and sweet and wholesome the garden
+looked in the moonlight, and it could not be more than thirty feet
+down. I clambered out upon the sill, but I hesitated to jump until I
+should have heard what passed between my savior and the ruffian who
+pursued me. If she were ill-used, then at any risks I was determined to
+go back to her assistance. The thought had hardly flashed through my
+mind before he was at the door, pushing his way past her; but she threw
+her arms round him and tried to hold him back.
+
+“‘Fritz! Fritz!’ she cried, in English, ‘remember your promise after
+the last time. You said it should not be again. He will be silent! Oh,
+he will be silent!’
+
+“‘You are mad, Elise!’ he shouted, struggling to break away from her.
+‘You will be the ruin of us. He has seen too much. Let me pass, I say!’
+He dashed her to one side, and, rushing to the window, cut at me with
+his heavy weapon. I had let myself go, and was hanging by the hands to
+the sill, when his blow fell. I was conscious of a dull pain, my grip
+loosened, and I fell into the garden below.
+
+“I was shaken but not hurt by the fall; so I picked myself up and
+rushed off among the bushes as hard as I could run, for I understood
+that I was far from being out of danger yet. Suddenly, however, as I
+ran, a deadly dizziness and sickness came over me. I glanced down at
+my hand, which was throbbing painfully, and then, for the first time,
+saw that my thumb had been cut off and that the blood was pouring from
+my wound. I endeavored to tie my handkerchief round it, but there came
+a sudden buzzing in my ears, and next moment I fell in a dead faint
+among the rose-bushes.
+
+“How long I remained unconscious I cannot tell. It must have been
+a very long time, for the moon had sunk, and a bright morning was
+breaking when I came to myself. My clothes were all sodden with dew,
+and my coat-sleeve was drenched with blood from my wounded thumb.
+The smarting of it recalled in an instant all the particulars of my
+night’s adventure, and I sprang to my feet with the feeling that I
+might hardly yet be safe from my pursuers. But, to my astonishment,
+when I came to look round me, neither house nor garden were to be seen.
+I had been lying in an angle of the hedge close by the high-road, and
+just a little lower down was a long building, which proved, upon my
+approaching it, to be the very station at which I had arrived upon the
+previous night. Were it not for the ugly wound upon my hand, all that
+had passed during those dreadful hours might have been an evil dream.
+
+“Half dazed, I went into the station and asked about the morning train.
+There would be one to Reading in less than an hour. The same porter
+was on duty, I found, as had been there when I arrived. I inquired of
+him whether he had ever heard of Colonel Lysander Stark. The name was
+strange to him. Had he observed a carriage the night before waiting for
+me? No, he had not. Was there a police-station anywhere near? There was
+one about three miles off.
+
+“It was too far for me to go, weak and ill as I was. I determined to
+wait until I got back to town before telling my story to the police. It
+was a little past six when I arrived, so I went first to have my wound
+dressed, and then the doctor was kind enough to bring me along here. I
+put the case into your hands, and shall do exactly what you advise.”
+
+We both sat in silence for some little time after, listening to this
+extraordinary narrative. Then Sherlock Holmes pulled down from the
+shelf one of the ponderous commonplace books in which he placed his
+cuttings.
+
+“Here is an advertisement which will interest you,” said he. “It
+appeared in all the papers about a year ago. Listen to this: ‘Lost,
+on the 9th inst., Mr. Jeremiah Hayling, aged twenty-six, an hydraulic
+engineer. Left his lodgings at ten o’clock at night, and has not been
+heard of since. Was dressed in,’ etc., etc. Ha! That represents the
+last time that the colonel needed to have his machine overhauled, I
+fancy.”
+
+“Good heavens!” cried my patient. “Then that explains what the girl
+said.”
+
+“Undoubtedly. It is quite clear that the colonel was a cool and
+desperate man, who was absolutely determined that nothing should stand
+in the way of his little game, like those out-and-out pirates who will
+leave no survivor from a captured ship. Well, every moment now is
+precious, so if you feel equal to it, we shall go down to Scotland Yard
+at once as a preliminary to starting for Eyford.”
+
+Some three hours or so afterwards we were all in the train together,
+bound from Reading to the little Berkshire village. There were Sherlock
+Holmes, the hydraulic engineer, Inspector Bradstreet, of Scotland Yard,
+a plain-clothes man, and myself. Bradstreet had spread an ordnance
+map of the county out upon the seat, and was busy with his compasses
+drawing a circle with Eyford for its centre.
+
+“There you are,” said he. “That circle is drawn at a radius of ten
+miles from the village. The place we want must be somewhere near that
+line. You said ten miles, I think, sir.”
+
+“It was an hour’s good drive.”
+
+“And you think that they brought you back all that way when you were
+unconscious?”
+
+“They must have done so. I have a confused memory, too, of having been
+lifted and conveyed somewhere.”
+
+“What I cannot understand,” said I, “is why they should have spared you
+when they found you lying fainting in the garden. Perhaps the villain
+was softened by the woman’s entreaties.”
+
+“I hardly think that likely. I never saw a more inexorable face in my
+life.”
+
+“Oh, we shall soon clear up all that,” said Bradstreet. “Well, I have
+drawn my circle, and I only wish I knew at what point upon it the folk
+that we are in search of are to be found.”
+
+“I think I could lay my finger on it,” said Holmes, quietly.
+
+“Really, now!” cried the inspector, “you have formed your opinion!
+Come, now, we shall see who agrees with you. I say it is south, for the
+country is more deserted there.”
+
+“And I say east,” said my patient.
+
+“I am for west,” remarked the plain-clothes man. “There are several
+quiet little villages up there.”
+
+“And I am for north,” said I, “because there are no hills there, and
+our friend says that he did not notice the carriage go up any.”
+
+“Come,” cried the inspector, laughing; “it’s a very pretty diversity
+of opinion. We have boxed the compass among us. Who do you give your
+casting vote to?”
+
+“You are all wrong.”
+
+“But we can’t _all_ be.”
+
+“Oh yes, you can. This is my point;” he placed his finger in the centre
+of the circle. “This is where we shall find them.”
+
+“But the twelve-mile drive?” gasped Hatherley.
+
+“Six out and six back. Nothing simpler. You say yourself that the horse
+was fresh and glossy when you got in. How could it be that if it had
+gone twelve miles over heavy roads?”
+
+“Indeed, it is a likely ruse enough,” observed Bradstreet,
+thoughtfully. “Of course there can be no doubt as to the nature of this
+gang.”
+
+“None at all,” said Holmes. “They are coiners on a large scale, and
+have used the machine to form the amalgam which has taken the place of
+silver.”
+
+“We have known for some time that a clever gang was at work,” said the
+inspector. “They have been turning out half-crowns by the thousand. We
+even traced them as far as Reading, but could get no farther, for they
+had covered their traces in a way that showed that they were very old
+hands. But now, thanks to this lucky chance, I think that we have got
+them right enough.”
+
+But the inspector was mistaken, for those criminals were not destined
+to fall into the hands of justice. As we rolled into Eyford Station we
+saw a gigantic column of smoke which streamed up from behind a small
+clump of trees in the neighborhood, and hung like an immense ostrich
+feather over the landscape.
+
+“A house on fire?” asked Bradstreet, as the train steamed off again on
+its way.
+
+“Yes, sir!” said the station-master.
+
+“When did it break out?”
+
+“I hear that it was during the night, sir, but it has got worse, and
+the whole place is in a blaze.”
+
+“Whose house is it?”
+
+“Dr. Becher’s.”
+
+“Tell me,” broke in the engineer, “is Dr. Becher a German, very thin,
+with a long, sharp nose?”
+
+The station-master laughed heartily. “No, sir, Dr. Becher is an
+Englishman, and there isn’t a man in the parish who has a better-lined
+waistcoat. But he has a gentleman staying with him, a patient, as
+I understand, who is a foreigner, and he looks as if a little good
+Berkshire beef would do him no harm.”
+
+The station-master had not finished his speech before we were all
+hastening in the direction of the fire. The road topped a low hill,
+and there was a great wide-spread whitewashed building in front of us,
+spouting fire at every chink and window, while in the garden in front
+three fire-engines were vainly striving to keep the flames under.
+
+“That’s it!” cried Hatherley, in intense excitement. “There is the
+gravel-drive, and there are the rose-bushes where I lay. That second
+window is the one that I jumped from.”
+
+“Well, at least,” said Holmes, “you have had your revenge upon them.
+There can be no question that it was your oil-lamp which, when it was
+crushed in the press, set fire to the wooden walls, though no doubt
+they were too excited in the chase after you to observe it at the time.
+Now keep your eyes open in this crowd for your friends of last night,
+though I very much fear that they are a good hundred miles off by now.”
+
+And Holmes’s fears came to be realized, for from that day to this no
+word has ever been heard either of the beautiful woman, the sinister
+German, or the morose Englishman. Early that morning a peasant had met
+a cart containing several people and some very bulky boxes driving
+rapidly in the direction of Reading, but there all traces of the
+fugitives disappeared, and even Holmes’s ingenuity failed ever to
+discover the least clew as to their whereabouts.
+
+The firemen had been much perturbed at the strange arrangements which
+they had found within, and still more so by discovering a newly severed
+human thumb upon a window-sill of the second floor. About sunset,
+however, their efforts were at last successful, and they subdued the
+flames, but not before the roof had fallen in, and the whole place been
+reduced to such absolute ruin that, save some twisted cylinders and
+iron piping, not a trace remained of the machinery which had cost our
+unfortunate acquaintance so dearly. Large masses of nickel and of tin
+were discovered stored in an out-house, but no coins were to be found,
+which may have explained the presence of those bulky boxes which have
+been already referred to.
+
+How our hydraulic engineer had been conveyed from the garden to the
+spot where he recovered his senses might have remained forever a
+mystery were it not for the soft mould, which told us a very plain
+tale. He had evidently been carried down by two persons, one of whom
+had remarkably small feet and the other unusually large ones. On the
+whole, it was most probable that the silent Englishman, being less bold
+or less murderous than his companion, had assisted the woman to bear
+the unconscious man out of the way of danger.
+
+“Well,” said our engineer ruefully, as we took our seats to return once
+more to London, “it has been a pretty business for me! I have lost my
+thumb and I have lost a fifty-guinea fee, and what have I gained?”
+
+“Experience,” said Holmes, laughing. “Indirectly it may be of value,
+you know; you have only to put it into words to gain the reputation of
+being excellent company for the remainder of your existence.”
+
+
+
+
+Adventure X
+
+THE ADVENTURE OF THE NOBLE BACHELOR
+
+
+The Lord St. Simon marriage, and its curious termination, have long
+ceased to be a subject of interest in those exalted circles in which
+the unfortunate bridegroom moves. Fresh scandals have eclipsed it,
+and their more piquant details have drawn the gossips away from this
+four-year-old drama. As I have reason to believe, however, that the
+full facts have never been revealed to the general public, and as my
+friend Sherlock Holmes had a considerable share in clearing the matter
+up, I feel that no memoir of him would be complete without some little
+sketch of this remarkable episode.
+
+It was a few weeks before my own marriage, during the days when I was
+still sharing rooms with Holmes in Baker Street, that he came home from
+an afternoon stroll to find a letter on the table waiting for him.
+I had remained in-doors all day, for the weather had taken a sudden
+turn to rain, with high autumnal winds, and the jezail bullet which I
+had brought back in one of my limbs as a relic of my Afghan campaign,
+throbbed with dull persistency. With my body in one easy-chair and my
+legs upon another, I had surrounded myself with a cloud of newspapers,
+until at last, saturated with the news of the day, I tossed them all
+aside and lay listless, watching the huge crest and monogram upon the
+envelope upon the table, and wondering lazily who my friend’s noble
+correspondent could be.
+
+“Here is a very fashionable epistle,” I remarked, as he entered. “Your
+morning letters, if I remember right, were from a fish-monger and a
+tide-waiter.”
+
+“Yes, my correspondence has certainly the charm of variety,” he
+answered, smiling, “and the humbler are usually the more interesting.
+This looks like one of those unwelcome social summonses which call upon
+a man either to be bored or to lie.”
+
+He broke the seal and glanced over the contents.
+
+“Oh, come, it may prove to be something of interest after all.”
+
+“Not social, then?”
+
+“No, distinctly professional.”
+
+“And from a noble client?”
+
+“One of the highest in England.”
+
+“My dear fellow, I congratulate you.”
+
+“I assure you, Watson, without affectation, that the status of my
+client is a matter of less moment to me than the interest of his case.
+It is just possible, however, that that also may not be wanting in this
+new investigation. You have been reading the papers diligently of late,
+have you not?”
+
+“It looks like it,” said I, ruefully, pointing to a huge bundle in the
+corner. “I have had nothing else to do.”
+
+“It is fortunate, for you will perhaps be able to post me up. I read
+nothing except the criminal news and the agony column. The latter is
+always instructive. But if you have followed recent events so closely
+you must have read about Lord St. Simon and his wedding?”
+
+“Oh yes, with the deepest interest.”
+
+“That is well. The letter which I hold in my hand is from Lord St.
+Simon. I will read it to you, and in return you must turn over these
+papers and let me have whatever bears upon the matter. This is what he
+says:
+
+  “‘MY DEAR MR. SHERLOCK HOLMES,—Lord Backwater tells me that I
+  may place implicit reliance upon your judgment and discretion.
+  I have determined, therefore, to call upon you, and to consult
+  you in reference to the very painful event which has occurred
+  in connection with my wedding. Mr. Lestrade, of Scotland Yard,
+  is acting already in the matter, but he assures me that he sees
+  no objection to your co-operation, and that he even thinks that
+  it might be of some assistance. I will call at four o’clock in
+  the afternoon, and, should you have any other engagement at
+  that time, I hope that you will postpone it, as this matter is
+  of paramount importance.    Yours faithfully,   ST. SIMON.’
+
+“It is dated from Grosvenor Mansions, written with a quill pen, and the
+noble lord has had the misfortune to get a smear of ink upon the outer
+side of his right little finger,” remarked Holmes, as he folded up the
+epistle.
+
+“He says four o’clock. It is three now. He will be here in an hour.”
+
+“Then I have just time, with your assistance, to get clear upon the
+subject. Turn over those papers, and arrange the extracts in their
+order of time, while I take a glance as to who our client is.” He
+picked a red-covered volume from a line of books of reference beside
+the mantel-piece. “Here he is,” said he, sitting down and flattening it
+out upon his knee. “Lord Robert Walsingham de Vere St. Simon, second
+son of the Duke of Balmoral—Hum! Arms: Azure, three caltrops in chief
+over a fess sable. Born in 1846. He’s forty-one years of age, which
+is mature for marriage. Was Undersecretary for the Colonies in a late
+Administration. The Duke, his father, was at one time Secretary for
+Foreign Affairs. They inherit Plantagenet blood by direct descent, and
+Tudor on the distaff side. Ha! Well, there is nothing very instructive
+in all this. I think that I must turn to you, Watson, for something
+more solid.”
+
+“I have very little difficulty in finding what I want,” said I, “for
+the facts are quite recent, and the matter struck me as remarkable. I
+feared to refer them to you, however, as I knew that you had an inquiry
+on hand, and that you disliked the intrusion of other matters.”
+
+“Oh, you mean the little problem of the Grosvenor Square furniture
+van. That is quite cleared up now—though, indeed, it was obvious from
+the first. Pray give me the results of your newspaper selections.”
+
+“Here is the first notice which I can find. It is in the personal
+column of _The Morning Post_, and dates, as you see, some weeks back.
+‘A marriage has been arranged,’ it says, ‘and will, if rumor is
+correct, very shortly take place, between Lord Robert St. Simon, second
+son of the Duke of Balmoral, and Miss Hatty Doran, the only daughter of
+Aloysius Doran, Esq., of San Francisco, Cal., U.S.A.’ That is all.”
+
+“Terse and to the point,” remarked Holmes, stretching his long, thin
+legs towards the fire.
+
+“There was a paragraph amplifying this in one of the society papers
+of the same week. Ah, here it is. ‘There will soon be a call for
+protection in the marriage market, for the present free-trade principle
+appears to tell heavily against our home product. One by one the
+management of the noble houses of Great Britain is passing into the
+hands of our fair cousins from across the Atlantic. An important
+addition has been made during the last week to the list of the prizes
+which have been borne away by these charming invaders. Lord St. Simon,
+who has shown himself for over twenty years proof against the little
+god’s arrows, has now definitely announced his approaching marriage
+with Miss Hatty Doran, the fascinating daughter of a California
+millionaire. Miss Doran, whose graceful figure and striking face
+attracted much attention at the Westbury House festivities, is an
+only child, and it is currently reported that her dowry will run to
+considerably over the six figures, with expectancies for the future.
+As it is an open secret that the Duke of Balmoral has been compelled
+to sell his pictures within the last few years, and as Lord St. Simon
+has no property of his own, save the small estate of Birchmoor, it
+is obvious that the Californian heiress is not the only gainer by an
+alliance which will enable her to make the easy and common transition
+from a Republican lady to a British peeress.’”
+
+“Anything else?” asked Holmes, yawning.
+
+“Oh yes; plenty. Then there is another note in _The Morning Post_ to
+say that the marriage would be an absolutely quiet one, that it would
+be at St. George’s, Hanover Square, that only half a dozen intimate
+friends would be invited, and that the party would return to the
+furnished house at Lancaster Gate which has been taken by Mr. Aloysius
+Doran. Two days later—that is, on Wednesday last—there is a curt
+announcement that the wedding had taken place, and that the honey-moon
+would be passed at Lord Backwater’s place, near Petersfield. Those are
+all the notices which appeared before the disappearance of the bride.”
+
+“Before the what?” asked Holmes, with a start.
+
+“The vanishing of the lady.”
+
+“When did she vanish, then?”
+
+“At the wedding breakfast.”
+
+“Indeed. This is more interesting than it promised to be; quite
+dramatic, in fact.”
+
+“Yes; it struck me as being a little out of the common.”
+
+“They often vanish before the ceremony, and occasionally during the
+honey-moon; but I cannot call to mind anything quite so prompt as this.
+Pray let me have the details.”
+
+“I warn you that they are very incomplete.”
+
+“Perhaps we may make them less so.”
+
+“Such as they are, they are set forth in a single article of a morning
+paper of yesterday, which I will read to you. It is headed, ‘Singular
+Occurrence at a Fashionable Wedding’:
+
+“‘The family of Lord Robert St. Simon has been thrown into the
+greatest consternation by the strange and painful episodes which have
+taken place in connection with his wedding. The ceremony, as shortly
+announced in the papers of yesterday, occurred on the previous morning;
+but it is only now that it has been possible to confirm the strange
+rumors which have been so persistently floating about. In spite of
+the attempts of the friends to hush the matter up, so much public
+attention has now been drawn to it that no good purpose can be served
+by affecting to disregard what is a common subject for conversation.
+
+“‘The ceremony, which was performed at St. George’s, Hanover Square,
+was a very quiet one, no one being present save the father of the
+bride, Mr. Aloysius Doran, the Duchess of Balmoral, Lord Backwater,
+Lord Eustace, and Lady Clara St. Simon (the younger brother and sister
+of the bridegroom), and Lady Alicia Whittington. The whole party
+proceeded afterwards to the house of Mr. Aloysius Doran, at Lancaster
+Gate, where breakfast had been prepared. It appears that some little
+trouble was caused by a woman, whose name has not been ascertained,
+who endeavored to force her way into the house after the bridal party,
+alleging that she had some claim upon Lord St. Simon. It was only after
+a painful and prolonged scene that she was ejected by the butler and
+the footman. The bride, who had fortunately entered the house before
+this unpleasant interruption, had sat down to breakfast with the rest,
+when she complained of a sudden indisposition, and retired to her room.
+Her prolonged absence having caused some comment, her father followed
+her, but learned from her maid that she had only come up to her chamber
+for an instant, caught up an ulster and bonnet, and hurried down to
+the passage. One of the footmen declared that he had seen a lady leave
+the house thus apparelled, but had refused to credit that it was his
+mistress, believing her to be with the company. On ascertaining that
+his daughter had disappeared, Mr. Aloysius Doran, in conjunction with
+the bridegroom, instantly put themselves into communication with
+the police, and very energetic inquiries are being made, which will
+probably result in a speedy clearing up of this very singular business.
+Up to a late hour last night, however, nothing had transpired as to
+the whereabouts of the missing lady. There are rumors of foul play in
+the matter, and it is said that the police have caused the arrest of
+the woman who had caused the original disturbance, in the belief that,
+from jealousy or some other motive, she may have been concerned in the
+strange disappearance of the bride.’”
+
+“And is that all?”
+
+“Only one little item in another of the morning papers, but it is a
+suggestive one.”
+
+“And it is—”
+
+“That Miss Flora Millar, the lady who had caused the disturbance, has
+actually been arrested. It appears that she was formerly a _danseuse_
+at the ‘Allegro,’ and that she has known the bridegroom for some years.
+There are no further particulars, and the whole case is in your hands
+now—so far as it has been set forth in the public press.”
+
+“And an exceedingly interesting case it appears to be. I would not have
+missed it for worlds. But there is a ring at the bell, Watson, and as
+the clock makes it a few minutes after four, I have no doubt that this
+will prove to be our noble client. Do not dream of going, Watson, for I
+very much prefer having a witness, if only as a check to my own memory.”
+
+“Lord Robert St. Simon,” announced our page-boy, throwing open the
+door. A gentleman entered, with a pleasant, cultured face, high-nosed
+and pale, with something perhaps of petulance about the mouth, and
+with the steady, well-opened eye of a man whose pleasant lot it had
+ever been to command and to be obeyed. His manner was brisk, and yet
+his general appearance gave an undue impression of age, for he had a
+slight forward stoop and a little bend of the knees as he walked. His
+hair, too, as he swept off his very curly-brimmed hat, was grizzled
+round the edges and thin upon the top. As to his dress, it was careful
+to the verge of foppishness, with high collar, black frock-coat, white
+waistcoat, yellow gloves, patent-leather shoes, and light-colored
+gaiters. He advanced slowly into the room, turning his head from left
+to right, and swinging in his right hand the cord which held his golden
+eye-glasses.
+
+“Good-day, Lord St. Simon,” said Holmes, rising and bowing. “Pray take
+the basket-chair. This is my friend and colleague, Dr. Watson. Draw up
+a little to the fire, and we will talk this matter over.”
+
+“A most painful matter to me, as you can most readily imagine, Mr.
+Holmes. I have been cut to the quick. I understand that you have
+already managed several delicate cases of this sort, sir, though I
+presume that they were hardly from the same class of society.”
+
+“No, I am descending.”
+
+“I beg pardon.”
+
+“My last client of the sort was a king.”
+
+“Oh, really! I had no idea. And which king?”
+
+“The King of Scandinavia.”
+
+“What! Had he lost his wife?”
+
+“You can understand,” said Holmes, suavely, “that I extend to the
+affairs of my other clients the same secrecy which I promise to you in
+yours.”
+
+“Of course! Very right! very right! I’m sure I beg pardon. As to my own
+case, I am ready to give you any information which may assist you in
+forming an opinion.”
+
+“Thank you. I have already learned all that is in the public prints,
+nothing more. I presume that I may take it as correct—this article,
+for example, as to the disappearance of the bride.”
+
+Lord St. Simon glanced over it. “Yes, it is correct, as far as it goes.”
+
+“But it needs a great deal of supplementing before any one could offer
+an opinion. I think that I may arrive at my facts most directly by
+questioning you.”
+
+“Pray do so.”
+
+“When did you first meet Miss Hatty Doran?”
+
+“In San Francisco, a year ago.”
+
+“You were travelling in the States?”
+
+“Yes.”
+
+“Did you become engaged then?”
+
+“No.”
+
+“But you were on a friendly footing?”
+
+“I was amused by her society, and she could see that I was amused.”
+
+“Her father is very rich?”
+
+“He is said to be the richest man on the Pacific slope.”
+
+“And how did he make his money?”
+
+“In mining. He had nothing a few years ago. Then he struck gold,
+invested it, and came up by leaps and bounds.”
+
+“Now, what is your own impression as to the young lady’s—your wife’s
+character?”
+
+The nobleman swung his glasses a little faster and stared down into the
+fire. “You see, Mr. Holmes,” said he, “my wife was twenty before her
+father became a rich man. During that time she ran free in a mining
+camp, and wandered through woods or mountains, so that her education
+has come from Nature rather than from the school-master. She is what
+we call in England a tomboy, with a strong nature, wild and free,
+unfettered by any sort of traditions. She is impetuous—volcanic, I
+was about to say. She is swift in making up her mind, and fearless
+in carrying out her resolutions. On the other hand, I would not have
+given her the name which I have the honor to bear”—he gave a little
+stately cough—“had not I thought her to be at bottom a noble woman. I
+believe that she is capable of heroic self-sacrifice, and that anything
+dishonorable would be repugnant to her.”
+
+“Have you her photograph?”
+
+“I brought this with me.” He opened a locket, and showed us the full
+face of a very lovely woman. It was not a photograph, but an ivory
+miniature, and the artist had brought out the full effect of the
+lustrous black hair, the large dark eyes, and the exquisite mouth.
+Holmes gazed long and earnestly at it. Then he closed the locket and
+handed it back to Lord St. Simon.
+
+“The young lady came to London, then, and you renewed your
+acquaintance?”
+
+“Yes, her father brought her over for this last London season. I met
+her several times, became engaged to her, and have now married her.”
+
+“She brought, I understand, a considerable dowry?”
+
+“A fair dowry. Not more than is usual in my family.”
+
+“And this, of course, remains to you, since the marriage is a _fait
+accompli_?”
+
+“I really have made no inquiries on the subject.”
+
+“Very naturally not. Did you see Miss Doran on the day before the
+wedding?”
+
+“Yes.”
+
+“Was she in good spirits?”
+
+“Never better. She kept talking of what we should do in our future
+lives.”
+
+“Indeed! That is very interesting. And on the morning of the wedding?”
+
+“She was as bright as possible—at least, until after the ceremony.”
+
+“And did you observe any change in her then?”
+
+“Well, to tell the truth, I saw then the first signs that I had ever
+seen that her temper was just a little sharp. The incident, however,
+was too trivial to relate, and can have no possible bearing upon the
+case.”
+
+“Pray let us have it, for all that.”
+
+“Oh, it is childish. She dropped her bouquet as we went towards the
+vestry. She was passing the front pew at the time, and it fell over
+into the pew. There was a moment’s delay, but the gentleman in the
+pew handed it up to her again, and it did not appear to be the worse
+for the fall. Yet, when I spoke to her of the matter, she answered me
+abruptly; and in the carriage, on our way home, she seemed absurdly
+agitated over this trifling cause.”
+
+“Indeed! You say that there was a gentleman in the pew. Some of the
+general public were present, then?”
+
+“Oh yes. It is impossible to exclude them when the church is open.”
+
+“This gentleman was not one of your wife’s friends?”
+
+“No, no; I call him a gentleman by courtesy, but he was quite a
+common-looking person. I hardly noticed his appearance. But really I
+think that we are wandering rather far from the point.”
+
+“Lady St. Simon, then, returned from the wedding in a less cheerful
+frame of mind than she had gone to it. What did she do on re-entering
+her father’s house?”
+
+“I saw her in conversation with her maid.”
+
+“And who is her maid?”
+
+“Alice is her name. She is an American, and came from California with
+her.”
+
+“A confidential servant?”
+
+“A little too much so. It seemed to me that her mistress allowed her to
+take great liberties. Still, of course, in America they look upon these
+things in a different way.”
+
+“How long did she speak to this Alice?”
+
+“Oh, a few minutes. I had something else to think of.”
+
+“You did not overhear what they said?”
+
+“Lady St. Simon said something about ‘jumping a claim.’ She was
+accustomed to use slang of the kind. I have no idea what she meant.”
+
+“American slang is very expressive sometimes. And what did your wife do
+when she finished speaking to her maid?”
+
+“She walked into the breakfast-room.”
+
+“On your arm?”
+
+“No, alone. She was very independent in little matters like that.
+Then, after we had sat down for ten minutes or so, she rose hurriedly,
+muttered some words of apology, and left the room. She never came back.”
+
+“But this maid, Alice, as I understand, deposes that she went to her
+room, covered her bride’s dress with a long ulster, put on a bonnet,
+and went out.”
+
+“Quite so. And she was afterwards seen walking into Hyde Park in
+company with Flora Millar, a woman who is now in custody, and who had
+already made a disturbance at Mr. Doran’s house that morning.”
+
+“Ah, yes. I should like a few particulars as to this young lady, and
+your relations to her.”
+
+Lord St. Simon shrugged his shoulders and raised his eyebrows. “We
+have been on a friendly footing for some years—I may say on a _very_
+friendly footing. She used to be at the ‘Allegro.’ I have not treated
+her ungenerously, and she has no just cause of complaint against me;
+but you know what women are, Mr. Holmes. Flora was a dear little thing,
+but exceedingly hot-headed, and devotedly attached to me. She wrote me
+dreadful letters when she heard that I was about to be married; and, to
+tell the truth, the reason why I had the marriage celebrated so quietly
+was that I feared lest there might be a scandal in the church. She came
+to Mr. Doran’s door just after we returned, and she endeavored to push
+her way in, uttering very abusive expressions towards my wife, and even
+threatening her, but I had foreseen the possibility of something of the
+sort, and I had two police fellows there in private clothes, who soon
+pushed her out again. She was quiet when she saw that there was no good
+in making a row.”
+
+“Did your wife hear all this?”
+
+“No, thank goodness, she did not.”
+
+“And she was seen walking with this very woman afterwards?”
+
+“Yes. That is what Mr. Lestrade, of Scotland Yard, looks upon as so
+serious. It is thought that Flora decoyed my wife out, and laid some
+terrible trap for her.”
+
+“Well, it is a possible supposition.”
+
+“You think so, too?”
+
+“I did not say a probable one. But you do not yourself look upon this
+as likely?”
+
+“I do not think Flora would hurt a fly.”
+
+“Still, jealousy is a strange transformer of characters. Pray what is
+your own theory as to what took place?”
+
+“Well, really, I came to seek a theory, not to propound one. I have
+given you all the facts. Since you ask me, however, I may say that it
+has occurred to me as possible that the excitement of this affair, the
+consciousness that she had made so immense a social stride, had the
+effect of causing some little nervous disturbance in my wife.”
+
+“In short, that she had become suddenly deranged?”
+
+“Well, really, when I consider that she has turned her back—I will
+not say upon me, but upon so much that many have aspired to without
+success—I can hardly explain it in any other fashion.”
+
+“Well, certainly that is also a conceivable hypothesis,” said Holmes,
+smiling. “And now, Lord St. Simon, I think that I have nearly all my
+data. May I ask whether you were seated at the breakfast-table so that
+you could see out of the window?”
+
+“We could see the other side of the road and the Park.”
+
+“Quite so. Then I do not think that I need to detain you longer. I
+shall communicate with you.”
+
+“Should you be fortunate enough to solve this problem,” said our
+client, rising.
+
+“I have solved it.”
+
+“Eh? What was that?”
+
+“I say that I have solved it.”
+
+“Where, then, is my wife?”
+
+“That is a detail which I shall speedily supply.”
+
+Lord St. Simon shook his head. “I am afraid that it will take wiser
+heads than yours or mine,” he remarked, and bowing in a stately,
+old-fashioned manner, he departed.
+
+“It is very good of Lord St. Simon to honor my head by putting it
+on a level with his own,” said Sherlock Holmes, laughing. “I think
+that I shall have a whiskey-and-soda and a cigar after all this
+cross-questioning. I had formed my conclusions as to the case before
+our client came into the room.”
+
+“My dear Holmes!”
+
+“I have notes of several similar cases, though none, as I remarked
+before, which were quite as prompt. My whole examination served to
+turn my conjecture into a certainty. Circumstantial evidence is
+occasionally very convincing, as when you find a trout in the milk, to
+quote Thoreau’s example.”
+
+“But I have heard all that you have heard.”
+
+“Without, however, the knowledge of pre-existing cases which serves me
+so well. There was a parallel instance in Aberdeen some years back,
+and something on very much the same lines at Munich the year after the
+Franco-Prussian war. It is one of these cases—but, hello, here is
+Lestrade! Good-afternoon, Lestrade! You will find an extra tumbler upon
+the sideboard, and there are cigars in the box.”
+
+The official detective was attired in a pea-jacket and cravat, which
+gave him a decidedly nautical appearance, and he carried a black canvas
+bag in his hand. With a short greeting he seated himself and lit the
+cigar which had been offered to him.
+
+“What’s up, then?” asked Holmes, with a twinkle in his eye. “You look
+dissatisfied.”
+
+“And I feel dissatisfied. It is this infernal St. Simon marriage case.
+I can make neither head nor tail of the business.”
+
+“Really! You surprise me.”
+
+“Who ever heard of such a mixed affair? Every clew seems to slip
+through my fingers. I have been at work upon it all day.”
+
+“And very wet it seems to have made you,” said Holmes, laying his hand
+upon the arm of the pea-jacket.
+
+“Yes, I have been dragging the Serpentine.”
+
+“In Heaven’s name, what for?”
+
+“In search of the body of Lady St. Simon.”
+
+Sherlock Holmes leaned back in his chair and laughed heartily.
+
+“Have you dragged the basin of Trafalgar Square fountain?” he asked.
+
+“Why? What do you mean?”
+
+“Because you have just as good a chance of finding this lady in the one
+as in the other.”
+
+Lestrade shot an angry glance at my companion. “I suppose you know all
+about it,” he snarled.
+
+“Well, I have only just heard the facts, but my mind is made up.”
+
+“Oh, indeed! Then you think that the Serpentine plays no part in the
+matter?”
+
+“I think it very unlikely.”
+
+“Then perhaps you will kindly explain how it is that we found this
+in it?” He opened his bag as he spoke, and tumbled onto the floor a
+wedding-dress of watered silk, a pair of white satin shoes, and a
+bride’s wreath and veil, all discolored and soaked in water. “There,”
+said he, putting a new wedding-ring upon the top of the pile. “There is
+a little nut for you to crack, Master Holmes.”
+
+“Oh, indeed!” said my friend, blowing blue rings into the air. “You
+dragged them from the Serpentine?”
+
+“No. They were found floating near the margin by a park-keeper. They
+have been identified as her clothes, and it seemed to me that if the
+clothes were there the body would not be far off.”
+
+“By the same brilliant reasoning, every man’s body is to be found in
+the neighborhood of his wardrobe. And pray what did you hope to arrive
+at through this?”
+
+“At some evidence implicating Flora Millar in the disappearance.”
+
+“I am afraid that you will find it difficult.”
+
+“Are you, indeed, now?” cried Lestrade, with some bitterness. “I am
+afraid, Holmes, that you are not very practical with your deductions
+and your inferences. You have made two blunders in as many minutes.
+This dress does implicate Miss Flora Millar.”
+
+“And how?”
+
+“In the dress is a pocket. In the pocket is a card-case. In the
+card-case is a note. And here is the very note.” He slapped it down
+upon the table in front of him. “Listen to this: ‘You will see me when
+all is ready. Come at once. F. H. M.’ Now my theory all along has been
+that Lady St. Simon was decoyed away by Flora Millar, and that she,
+with confederates, no doubt, was responsible for her disappearance.
+Here, signed with her initials, is the very note which was no doubt
+quietly slipped into her hand at the door, and which lured her within
+their reach.”
+
+“Very good, Lestrade,” said Holmes, laughing. “You really are very fine
+indeed. Let me see it.” He took up the paper in a listless way, but
+his attention instantly became riveted, and he gave a little cry of
+satisfaction. “This is indeed important,” said he.
+
+“Ha! you find it so?”
+
+“Extremely so. I congratulate you warmly.”
+
+Lestrade rose in his triumph and bent his head to look. “Why,” he
+shrieked, “you’re looking at the wrong side!”
+
+“On the contrary, this is the right side.”
+
+“The right side? You’re mad! Here is the note written in pencil over
+here.”
+
+“And over here is what appears to be the fragment of a hotel bill,
+which interests me deeply.”
+
+“There’s nothing in it. I looked at it before,” said Lestrade. “‘Oct.
+4th, rooms 8_s._, breakfast 2_s._ 6_d._, cocktail 1_s._, lunch 2_s._
+6_d._, glass sherry, 8_d._’ I see nothing in that.”
+
+“Very likely not. It is most important, all the same. As to the note,
+it is important also, or at least the initials are, so I congratulate
+you again.”
+
+“I’ve wasted time enough,” said Lestrade, rising. “I believe in hard
+work, and not in sitting by the fire spinning fine theories. Good-day,
+Mr. Holmes, and we shall see which gets to the bottom of the matter
+first.” He gathered up the garments, thrust them into the bag, and made
+for the door.
+
+“Just one hint to you, Lestrade,” drawled Holmes, before his rival
+vanished; “I will tell you the true solution of the matter. Lady St.
+Simon is a myth. There is not, and there never has been, any such
+person.”
+
+Lestrade looked sadly at my companion. Then he turned to me, tapped
+his forehead three times, shook his head solemnly, and hurried away.
+
+He had hardly shut the door behind him when Holmes rose and put on his
+overcoat. “There is something in what the fellow says about out-door
+work,” he remarked, “so I think, Watson, that I must leave you to your
+papers for a little.”
+
+It was after five o’clock when Sherlock Holmes left me, but I had no
+time to be lonely, for within an hour there arrived a confectioner’s
+man with a very large flat box. This he unpacked with the help of a
+youth whom he had brought with him, and presently, to my very great
+astonishment, a quite epicurean little cold supper began to be laid out
+upon our humble lodging-house mahogany. There were a couple of brace of
+cold woodcock, a pheasant, a _pâté de foie gras_ pie, with a group of
+ancient and cobwebby bottles. Having laid out all these luxuries, my
+two visitors vanished away, like the genii of the Arabian Nights, with
+no explanation save that the things had been paid for and were ordered
+to this address.
+
+Just before nine o’clock Sherlock Holmes stepped briskly into the room.
+His features were gravely set, but there was a light in his eye which
+made me think that he had not been disappointed in his conclusions.
+
+“They have laid the supper, then,” he said, rubbing his hands.
+
+“You seem to expect company. They have laid for five.”
+
+“Yes, I fancy we may have some company dropping in,” said he. “I am
+surprised that Lord St. Simon has not already arrived. Ha! I fancy that
+I hear his step now upon the stairs.”
+
+It was indeed our visitor of the morning who came bustling in, dangling
+his glasses more vigorously than ever, and with a very perturbed
+expression upon his aristocratic features.
+
+“My messenger reached you, then?” asked Holmes.
+
+“Yes, and I confess that the contents startled me beyond measure. Have
+you good authority for what you say?”
+
+“The best possible.”
+
+Lord St. Simon sank into a chair and passed his hand over his forehead.
+
+“What will the duke say,” he murmured, “when he hears that one of the
+family has been subjected to such humiliation?”
+
+“It is the purest accident. I cannot allow that there is any
+humiliation.”
+
+“Ah, you look on these things from another stand-point.”
+
+“I fail to see that any one is to blame. I can hardly see how the lady
+could have acted otherwise, though her abrupt method of doing it was
+undoubtedly to be regretted. Having no mother, she had no one to advise
+her at such a crisis.”
+
+“It was a slight, sir, a public slight,” said Lord St. Simon, tapping
+his fingers upon the table.
+
+“You must make allowance for this poor girl, placed in so unprecedented
+a position.”
+
+“I will make no allowance. I am very angry indeed, and I have been
+shamefully used.”
+
+“I think that I heard a ring,” said Holmes. “Yes, there are steps on
+the landing. If I cannot persuade you to take a lenient view of the
+matter, Lord St. Simon, I have brought an advocate here who may be more
+successful.” He opened the door and ushered in a lady and gentleman.
+“Lord St. Simon,” said he, “allow me to introduce you to Mr. and Mrs.
+Francis Hay Moulton. The lady, I think, you have already met.”
+
+At the sight of these new-comers our client had sprung from his seat
+and stood very erect, with his eyes cast down and his hand thrust into
+the breast of his frock-coat, a picture of offended dignity. The lady
+had taken a quick step forward and had held out her hand to him, but
+he still refused to raise his eyes. It was as well for his resolution,
+perhaps, for her pleading face was one which it was hard to resist.
+
+“You’re angry, Robert,” said she. “Well, I guess you have every cause
+to be.”
+
+“Pray make no apology to me,” said Lord St. Simon, bitterly.
+
+“Oh yes, I know that I have treated you real bad, and that I should
+have spoken to you before I went; but I was kind of rattled, and from
+the time when I saw Frank here again I just didn’t know what I was
+doing or saying. I only wonder I didn’t fall down and do a faint right
+there before the altar.”
+
+“Perhaps, Mrs. Moulton, you would like my friend and me to leave the
+room while you explain this matter?”
+
+“If I may give an opinion,” remarked the strange gentleman, “we’ve had
+just a little too much secrecy over this business already. For my part,
+I should like all Europe and America to hear the rights of it.” He was
+a small, wiry, sunburnt man, clean shaven, with a sharp face and alert
+manner.
+
+“Then I’ll tell our story right away,” said the lady. “Frank here and I
+met in ’84, in McQuire’s camp, near the Rockies, where pa was working
+a claim. We were engaged to each other, Frank and I; but then one day
+father struck a rich pocket and made a pile, while poor Frank here had
+a claim that petered out and came to nothing. The richer pa grew, the
+poorer was Frank; so at last pa wouldn’t hear of our engagement lasting
+any longer, and he took me away to ’Frisco. Frank wouldn’t throw up
+his hand, though; so he followed me there, and he saw me without pa
+knowing anything about it. It would only have made him mad to know, so
+we just fixed it all up for ourselves. Frank said that he would go and
+make his pile, too, and never come back to claim me until he had as
+much as pa. So then I promised to wait for him to the end of time, and
+pledged myself not to marry any one else while he lived. ‘Why shouldn’t
+we be married right away, then,’ said he, ‘and then I will feel sure of
+you; and I won’t claim to be your husband until I come back?’ Well, we
+talked it over, and he had fixed it all up so nicely, with a clergyman
+all ready in waiting, that we just did it right there; and then Frank
+went off to seek his fortune, and I went back to pa.
+
+“The next I heard of Frank was that he was in Montana, and then he went
+prospecting in Arizona, and then I heard of him from New Mexico. After
+that came a long newspaper story about how a miners’ camp had been
+attacked by Apache Indians, and there was my Frank’s name among the
+killed. I fainted dead away, and I was very sick for months after. Pa
+thought I had a decline, and took me to half the doctors in ’Frisco.
+Not a word of news came for a year and more, so that I never doubted
+that Frank was really dead. Then Lord St. Simon came to ’Frisco, and we
+came to London, and a marriage was arranged, and pa was very pleased,
+but I felt all the time that no man on this earth would ever take the
+place in my heart that had been given to my poor Frank.
+
+“Still, if I had married Lord St. Simon, of course I’d have done my
+duty by him. We can’t command our love, but we can our actions. I went
+to the altar with him with the intention to make him just as good a
+wife as it was in me to be. But you may imagine what I felt when, just
+as I came to the altar rails, I glanced back and saw Frank standing
+and looking at me out of the first pew. I thought it was his ghost at
+first; but when I looked again, there he was still, with a kind of
+question in his eyes as if to ask me whether I were glad or sorry to
+see him. I wonder I didn’t drop. I know that everything was turning
+round, and the words of the clergyman were just like the buzz of a bee
+in my ear. I didn’t know what to do. Should I stop the service and make
+a scene in the church? I glanced at him again, and he seemed to know
+what I was thinking, for he raised his finger to his lips to tell me to
+be still. Then I saw him scribble on a piece of paper, and I knew that
+he was writing me a note. As I passed his pew on the way out I dropped
+my bouquet over to him, and he slipped the note into my hand when he
+returned me the flowers. It was only a line asking me to join him when
+he made the sign to me to do so. Of course I never doubted for a moment
+that my first duty was now to him, and I determined to do just whatever
+he might direct.
+
+“When I got back I told my maid, who had known him in California, and
+had always been his friend. I ordered her to say nothing, but to get a
+few things packed and my ulster ready. I know I ought to have spoken
+to Lord St. Simon, but it was dreadful hard before his mother and all
+those great people. I just made up my mind to run away and explain
+afterwards. I hadn’t been at the table ten minutes before I saw Frank
+out of the window at the other side of the road. He beckoned to me, and
+then began walking into the Park. I slipped out, put on my things, and
+followed him. Some woman came talking something or other about Lord
+St. Simon to me—seemed to me from the little I heard as if he had a
+little secret of his own before marriage also—but I managed to get
+away from her, and soon overtook Frank. We got into a cab together, and
+away we drove to some lodgings he had taken in Gordon Square, and that
+was my true wedding after all those years of waiting. Frank had been a
+prisoner among the Apaches, had escaped, came on to ’Frisco, found that
+I had given him up for dead and had gone to England, followed me there,
+and had come upon me at last on the very morning of my second wedding.”
+
+“I saw it in a paper,” explained the American. “It gave the name and
+the church, but not where the lady lived.”
+
+“Then we had a talk as to what we should do, and Frank was all for
+openness, but I was so ashamed of it all that I felt as if I should
+like to vanish away and never see any of them again—just sending
+a line to pa, perhaps, to show him that I was alive. It was awful
+to me to think of all those lords and ladies sitting round that
+breakfast-table and waiting for me to come back. So Frank took my
+wedding-clothes and things and made a bundle of them, so that I should
+not be traced, and dropped them away somewhere where no one could find
+them. It is likely that we should have gone on to Paris to-morrow, only
+that this good gentleman, Mr. Holmes, came round to us this evening,
+though how he found us is more than I can think, and he showed us very
+clearly and kindly that I was wrong and that Frank was right, and that
+we should be putting ourselves in the wrong if we were so secret. Then
+he offered to give us a chance of talking to Lord St. Simon alone, and
+so we came right away round to his rooms at once. Now, Robert, you have
+heard it all, and I am very sorry if I have given you pain, and I hope
+that you do not think very meanly of me.”
+
+Lord St. Simon had by no means relaxed his rigid attitude, but had
+listened with a frowning brow and a compressed lip to this long
+narrative.
+
+“Excuse me,” he said, “but it is not my custom to discuss my most
+intimate personal affairs in this public manner.”
+
+“Then you won’t forgive me? You won’t shake hands before I go?”
+
+“Oh, certainly, if it would give you any pleasure.” He put out his hand
+and coldly grasped that which she extended to him.
+
+“I had hoped,” suggested Holmes, “that you would have joined us in a
+friendly supper.”
+
+“I think that there you ask a little too much,” responded his lordship.
+“I may be forced to acquiesce in these recent developments, but I can
+hardly be expected to make merry over them. I think that, with your
+permission, I will now wish you all a very good-night.” He included us
+all in a sweeping bow and stalked out of the room.
+
+“Then I trust that you at least will honor me with your company,” said
+Sherlock Holmes. “It is always a joy to meet an American, Mr. Moulton,
+for I am one of those who believe that the folly of a monarch and
+the blundering of a minister in far-gone years will not prevent our
+children from being some day citizens of the same world-wide country
+under a flag which shall be a quartering of the Union Jack with the
+Stars and Stripes.”
+
+       *       *       *       *       *
+
+“The case has been an interesting one,” remarked Holmes, when our
+visitors had left us, “because it serves to show very clearly how
+simple the explanation may be of an affair which at first sight seems
+to be almost inexplicable. Nothing could be more natural than the
+sequence of events as narrated by this lady, and nothing stranger than
+the result when viewed, for instance, by Mr. Lestrade, of Scotland
+Yard.”
+
+[Illustration: “‘I WILL WISH YOU ALL A VERY GOOD NIGHT.’”]
+
+“You were not yourself at fault at all, then?”
+
+“From the first, two facts were very obvious to me, the one that the
+lady had been quite willing to undergo the wedding ceremony, the other
+that she had repented of it within a few minutes of returning home.
+Obviously something had occurred during the morning, then, to cause her
+to change her mind. What could that something be? She could not have
+spoken to any one when she was out, for she had been in the company
+of the bridegroom. Had she seen some one, then? If she had, it must
+be some one from America, because she had spent so short a time in
+this country that she could hardly have allowed any one to acquire so
+deep an influence over her that the mere sight of him would induce her
+to change her plans so completely. You see we have already arrived,
+by a process of exclusion, at the idea that she might have seen an
+American. Then who could this American be, and why should he possess so
+much influence over her? It might be a lover; it might be a husband.
+Her young womanhood had, I knew, been spent in rough scenes and under
+strange conditions. So far I had got before I ever heard Lord St.
+Simon’s narrative. When he told us of a man in a pew, of the change in
+the bride’s manner, of so transparent a device for obtaining a note as
+the dropping of a bouquet, of her resort to her confidential maid, and
+of her very significant allusion to claim-jumping—which in miners’
+parlance means taking possession of that which another person has a
+prior claim to—the whole situation became absolutely clear. She had
+gone off with a man, and the man was either a lover or was a previous
+husband—the chances being in favor of the latter.”
+
+“And how in the world did you find them?”
+
+“It might have been difficult, but friend Lestrade held information in
+his hands the value of which he did not himself know. The initials were
+of course of the highest importance, but more valuable still was it
+to know that within a week he had settled his bill at one of the most
+select London hotels.”
+
+“How did you deduce the select?”
+
+“By the select prices. Eight shillings for a bed and eight-pence for a
+glass of sherry pointed to one of the most expensive hotels. There are
+not many in London which charge at that rate. In the second one which
+I visited in Northumberland Avenue, I learned by an inspection of the
+book that Francis H. Moulton, an American gentleman, had left only the
+day before, and on looking over the entries against him, I came upon
+the very items which I had seen in the duplicate bill. His letters
+were to be forwarded to 226 Gordon Square; so thither I travelled, and
+being fortunate enough to find the loving couple at home, I ventured to
+give them some paternal advice, and to point out to them that it would
+be better in every way that they should make their position a little
+clearer both to the general public and to Lord St. Simon in particular.
+I invited them to meet him here, and, as you see, I made him keep the
+appointment.”
+
+“But with no very good result,” I remarked. “His conduct was certainly
+not very gracious.”
+
+“Ah, Watson,” said Holmes, smiling, “perhaps you would not be very
+gracious either, if, after all the trouble of wooing and wedding, you
+found yourself deprived in an instant of wife and of fortune. I think
+that we may judge Lord St. Simon very mercifully, and thank our stars
+that we are never likely to find ourselves in the same position. Draw
+your chair up, and hand me my violin, for the only problem we have
+still to solve is how to while away these bleak autumnal evenings.”
+
+
+
+
+Adventure XI
+
+THE ADVENTURE OF THE BERYL CORONET
+
+
+“Holmes,” said I, as I stood one morning in our bow-window looking down
+the street, “here is a madman coming along. It seems rather sad that
+his relatives should allow him to come out alone.”
+
+My friend rose lazily from his arm-chair and stood with his hands in
+the pockets of his dressing-gown, looking over my shoulder. It was a
+bright, crisp February morning, and the snow of the day before still
+lay deep upon the ground, shimmering brightly in the wintry sun. Down
+the centre of Baker Street it had been ploughed into a brown crumbly
+band by the traffic, but at either side and on the heaped-up edges of
+the foot-paths it still lay as white as when it fell. The gray pavement
+had been cleaned and scraped, but was still dangerously slippery, so
+that there were fewer passengers than usual. Indeed, from the direction
+of the Metropolitan Station no one was coming save the single gentleman
+whose eccentric conduct had drawn my attention.
+
+He was a man of about fifty, tall, portly, and imposing, with a
+massive, strongly marked face and a commanding figure. He was dressed
+in a sombre yet rich style, in black frock-coat, shining hat, neat
+brown gaiters, and well-cut pearl-gray trousers. Yet his actions were
+in absurd contrast to the dignity of his dress and features, for he
+was running hard, with occasional little springs, such as a weary man
+gives who is little accustomed to set any tax upon his legs. As he ran
+he jerked his hands up and down, waggled his head, and writhed his face
+into the most extraordinary contortions.
+
+“What on earth can be the matter with him?” I asked. “He is looking up
+at the numbers of the houses.”
+
+“I believe that he is coming here,” said Holmes, rubbing his hands.
+
+“Here?”
+
+“Yes; I rather think he is coming to consult me professionally. I think
+that I recognize the symptoms. Ha! did I not tell you?” As he spoke,
+the man, puffing and blowing, rushed at our door and pulled at our bell
+until the whole house resounded with the clanging.
+
+A few moments later he was in our room, still puffing, still
+gesticulating, but with so fixed a look of grief and despair in his
+eyes that our smiles were turned in an instant to horror and pity. For
+a while he could not get his words out, but swayed his body and plucked
+at his hair like one who has been driven to the extreme limits of his
+reason. Then, suddenly springing to his feet, he beat his head against
+the wall with such force that we both rushed upon him and tore him away
+to the centre of the room. Sherlock Holmes pushed him down into the
+easy-chair, and, sitting beside him, patted his hand, and chatted with
+him in the easy, soothing tones which he knew so well how to employ.
+
+“You have come to me to tell your story, have you not?” said he. “You
+are fatigued with your haste. Pray wait until you have recovered
+yourself, and then I shall be most happy to look into any little
+problem which you may submit to me.”
+
+The man sat for a minute or more with a heaving chest, fighting against
+his emotion. Then he passed his handkerchief over his brow, set his
+lips tight, and turned his face towards us.
+
+“No doubt you think me mad?” said he.
+
+“I see that you have had some great trouble,” responded Holmes.
+
+“God knows I have!—a trouble which is enough to unseat my reason,
+so sudden and so terrible is it. Public disgrace I might have faced,
+although I am a man whose character has never yet borne a stain.
+Private affliction also is the lot of every man; but the two coming
+together, and in so frightful a form, have been enough to shake my very
+soul. Besides, it is not I alone. The very noblest in the land may
+suffer, unless some way be found out of this horrible affair.”
+
+“Pray compose yourself, sir,” said Holmes, “and let me have a clear
+account of who you are, and what it is that has befallen you.”
+
+“My name,” answered our visitor, “is probably familiar to your ears.
+I am Alexander Holder, of the banking firm of Holder & Stevenson, of
+Threadneedle Street.”
+
+The name was indeed well known to us as belonging to the senior partner
+in the second largest private banking concern in the City of London.
+What could have happened, then, to bring one of the foremost citizens
+of London to this most pitiable pass? We waited, all curiosity, until
+with another effort he braced himself to tell his story.
+
+“I feel that time is of value,” said he; “that is why I hastened
+here when the police inspector suggested that I should secure your
+co-operation. I came to Baker Street by the Underground, and hurried
+from there on foot, for the cabs go slowly through this snow. That
+is why I was so out of breath, for I am a man who takes very little
+exercise. I feel better now, and I will put the facts before you as
+shortly and yet as clearly as I can.
+
+“It is, of course, well known to you that in a successful banking
+business as much depends upon our being able to find remunerative
+investments for our funds as upon our increasing our connection and the
+number of our depositors. One of our most lucrative means of laying out
+money is in the shape of loans, where the security is unimpeachable. We
+have done a good deal in this direction during the last few years, and
+there are many noble families to whom we have advanced large sums upon
+the security of their pictures, libraries, or plate.
+
+“Yesterday morning I was seated in my office at the bank when a card
+was brought in to me by one of the clerks. I started when I saw the
+name, for it was that of none other than—well, perhaps even to you I
+had better say no more than that it was a name which is a household
+word all over the earth—one of the highest, noblest, most exalted
+names in England. I was overwhelmed by the honor, and attempted, when
+he entered, to say so, but he plunged at once into business with the
+air of a man who wishes to hurry quickly through a disagreeable task.
+
+“‘Mr. Holder,’ said he, ‘I have been informed that you are in the habit
+of advancing money.’
+
+“‘The firm do so when the security is good,’ I answered.
+
+“‘It is absolutely essential to me,’ said he, ‘that I should have
+£50,000 at once. I could of course borrow so trifling a sum ten
+times over from my friends, but I much prefer to make it a matter of
+business, and to carry out that business myself. In my position you
+can readily understand that it is unwise to place one’s self under
+obligations.’
+
+“‘For how long, may I ask, do you want this sum?’ I asked.
+
+“‘Next Monday I have a large sum due to me, and I shall then most
+certainly repay what you advance, with whatever interest you think it
+right to charge. But it is very essential to me that the money should
+be paid at once.’
+
+“‘I should be happy to advance it without further parley from my own
+private purse,’ said I, ‘were it not that the strain would be rather
+more than it could bear. If, on the other hand, I am to do it in the
+name of the firm, then in justice to my partner I must insist that,
+even in your case, every business-like precaution should be taken.’
+
+“‘I should much prefer to have it so,’ said he, raising up a square,
+black morocco case which he had laid beside his chair. ‘You have
+doubtless heard of the Beryl Coronet?’
+
+“‘One of the most precious public possessions of the empire,’ said I.
+
+“‘Precisely.’ He opened the case, and there, imbedded in soft,
+flesh-colored velvet, lay the magnificent piece of jewelry which he
+had named. ‘There are thirty-nine enormous beryls,’ said he, ‘and the
+price of the gold chasing is incalculable. The lowest estimate would
+put the worth of the coronet at double the sum which I have asked. I am
+prepared to leave it with you as my security.’
+
+“I took the precious case into my hands and looked in some perplexity
+from it to my illustrious client.
+
+“‘You doubt its value?’ he asked.
+
+“‘Not at all. I only doubt—’
+
+“‘The propriety of my leaving it. You may set your mind at rest about
+that. I should not dream of doing so were it not absolutely certain
+that I should be able in four days to reclaim it. It is a pure matter
+of form. Is the security sufficient?’
+
+“‘Ample.’
+
+“‘You understand, Mr. Holder, that I am giving you a strong proof of
+the confidence which I have in you, founded upon all that I have heard
+of you. I rely upon you not only to be discreet and to refrain from all
+gossip upon the matter, but, above all, to preserve this coronet with
+every possible precaution, because I need not say that a great public
+scandal would be caused if any harm were to befall it. Any injury to
+it would be almost as serious as its complete loss, for there are no
+beryls in the world to match these, and it would be impossible to
+replace them. I leave it with you, however, with every confidence, and
+I shall call for it in person on Monday morning.’
+
+“Seeing that my client was anxious to leave, I said no more; but,
+calling for my cashier, I ordered him to pay over fifty £1000 notes.
+When I was alone once more, however, with the precious case lying upon
+the table in front of me, I could not but think with some misgivings of
+the immense responsibility which it entailed upon me. There could be no
+doubt that, as it was a national possession, a horrible scandal would
+ensue if any misfortune should occur to it. I already regretted having
+ever consented to take charge of it. However, it was too late to alter
+the matter now, so I locked it up in my private safe, and turned once
+more to my work.
+
+“When evening came I felt that it would be an imprudence to leave so
+precious a thing in the office behind me. Bankers’ safes had been
+forced before now, and why should not mine be? If so, how terrible
+would be the position in which I should find myself! I determined,
+therefore, that for the next few days I would always carry the case
+backward and forward with me, so that it might never be really out
+of my reach. With this intention, I called a cab, and drove out to
+my house at Streatham, carrying the jewel with me. I did not breathe
+freely until I had taken it up-stairs and locked it in the bureau of my
+dressing-room.
+
+“And now a word as to my household, Mr. Holmes, for I wish you to
+thoroughly understand the situation. My groom and my page sleep out of
+the house, and may be set aside altogether. I have three maid-servants
+who have been with me a number of years, and whose absolute reliability
+is quite above suspicion. Another, Lucy Parr, the second waiting-maid,
+has only been in my service a few months. She came with an excellent
+character, however, and has always given me satisfaction. She is a very
+pretty girl, and has attracted admirers who have occasionally hung
+about the place. That is the only drawback which we have found to her,
+but we believe her to be a thoroughly good girl in every way.
+
+“So much for the servants. My family itself is so small that it will
+not take me long to describe it. I am a widower, and have an only son,
+Arthur. He has been a disappointment to me, Mr. Holmes—a grievous
+disappointment. I have no doubt that I am myself to blame. People tell
+me that I have spoiled him. Very likely I have. When my dear wife died
+I felt that he was all I had to love. I could not bear to see the smile
+fade even for a moment from his face. I have never denied him a wish.
+Perhaps it would have been better for both of us had I been sterner,
+but I meant it for the best.
+
+“It was naturally my intention that he should succeed me in my
+business, but he was not of a business turn. He was wild, wayward, and,
+to speak the truth, I could not trust him in the handling of large
+sums of money. When he was young he became a member of an aristocratic
+club, and there, having charming manners, he was soon the intimate of a
+number of men with long purses and expensive habits. He learned to play
+heavily at cards and to squander money on the turf, until he had again
+and again to come to me and implore me to give him an advance upon his
+allowance, that he might settle his debts of honor. He tried more than
+once to break away from the dangerous company which he was keeping, but
+each time the influence of his friend Sir George Burnwell was enough to
+draw him back again.
+
+“And, indeed, I could not wonder that such a man as Sir George Burnwell
+should gain an influence over him, for he has frequently brought him
+to my house, and I have found myself that I could hardly resist the
+fascination of his manner. He is older than Arthur, a man of the world
+to his finger-tips, one who had been everywhere, seen everything, a
+brilliant talker, and a man of great personal beauty. Yet when I think
+of him in cold blood, far away from the glamour of his presence, I am
+convinced from his cynical speech, and the look which I have caught in
+his eyes, that he is one who should be deeply distrusted. So I think,
+and so, too, thinks my little Mary, who has a woman’s quick insight
+into character.
+
+“And now there is only she to be described. She is my niece; but when
+my brother died five years ago and left her alone in the world I
+adopted her, and have looked upon her ever since as my daughter. She is
+a sunbeam in my house—sweet, loving, beautiful, a wonderful manager
+and house-keeper, yet as tender and quiet and gentle as a woman could
+be. She is my right hand. I do not know what I could do without her. In
+only one matter has she ever gone against my wishes. Twice my boy has
+asked her to marry him, for he loves her devotedly, but each time she
+has refused him. I think that if any one could have drawn him into the
+right path it would have been she, and that his marriage might have
+changed his whole life; but now, alas! it is too late—for ever too
+late!
+
+“Now, Mr. Holmes, you know the people who live under my roof, and I
+shall continue with my miserable story.
+
+“When we were taking coffee in the drawing-room that night, after
+dinner, I told Arthur and Mary my experience, and of the precious
+treasure which we had under our roof, suppressing only the name of my
+client. Lucy Parr, who had brought in the coffee, had, I am sure, left
+the room; but I cannot swear that the door was closed. Mary and Arthur
+were much interested, and wished to see the famous coronet, but I
+thought it better not to disturb it.
+
+“‘Where have you put it?’ asked Arthur.
+
+“‘In my own bureau.’
+
+“‘Well, I hope to goodness the house won’t be burgled during the
+night,’ said he.
+
+“‘It is locked up,’ I answered.
+
+“‘Oh, any old key will fit that bureau. When I was a youngster I have
+opened it myself with the key of the box-room cupboard.’
+
+“He often had a wild way of talking, so that I thought little of what
+he said. He followed me to my room, however, that night with a very
+grave face.
+
+“‘Look here, dad,’ said he, with his eyes cast down, ‘can you let me
+have £200?’
+
+“‘No, I cannot!’ I answered, sharply. ‘I have been far too generous
+with you in money matters.’
+
+“‘You have been very kind,’ said he: ‘but I must have this money, or
+else I can never show my face inside the club again.’
+
+“‘And a very good thing, too!’ I cried.
+
+“‘Yes, but you would not have me leave it a dishonored man,’ said he.
+‘I could not bear the disgrace. I must raise the money in some way, and
+if you will not let me have it, then I must try other means.’
+
+“I was very angry, for this was the third demand during the month. ‘You
+shall not have a farthing from me,’ I cried; on which he bowed and left
+the room without another word.
+
+“When he was gone I unlocked my bureau, made sure that my treasure was
+safe, and locked it again. Then I started to go round the house to see
+that all was secure—a duty which I usually leave to Mary, but which I
+thought it well to perform myself that night. As I came down the stairs
+I saw Mary herself at the side window of the hall, which she closed and
+fastened as I approached.
+
+“‘Tell me, dad,’ said she, looking, I thought, a little disturbed, ‘did
+you give Lucy, the maid, leave to go out to-night?’
+
+“‘Certainly not.’
+
+“‘She came in just now by the back door. I have no doubt that she has
+only been to the side gate to see some one; but I think that it is
+hardly safe, and should be stopped.”
+
+“‘You must speak to her in the morning, or I will, if you prefer it.
+Are you sure that everything is fastened?’
+
+“‘Quite sure, dad.’
+
+“‘Then, good-night.’ I kissed her, and went up to my bedroom again,
+where I was soon asleep.
+
+“I am endeavoring to tell you everything, Mr. Holmes, which may have
+any bearing upon the case, but I beg that you will question me upon any
+point which I do not make clear.”
+
+“On the contrary, your statement is singularly lucid.”
+
+“I come to a part of my story now in which I should wish to be
+particularly so. I am not a very heavy sleeper, and the anxiety in my
+mind tended, no doubt, to make me even less so than usual. About two
+in the morning, then, I was awakened by some sound in the house. It
+had ceased ere I was wide awake, but it had left an impression behind
+it as though a window had gently closed somewhere. I lay listening
+with all my ears. Suddenly, to my horror, there was a distinct sound
+of footsteps moving softly in the next room. I slipped out of bed, all
+palpitating with fear, and peeped round the corner of my dressing-room
+door.
+
+“‘Arthur!’ I screamed, ‘you villain! you thief! How dare you touch that
+coronet?’
+
+“The gas was half up, as I had left it, and my unhappy boy, dressed
+only in his shirt and trousers, was standing beside the light, holding
+the coronet in his hands. He appeared to be wrenching at it, or bending
+it with all his strength. At my cry he dropped it from his grasp, and
+turned as pale as death. I snatched it up and examined it. One of the
+gold corners, with three of the beryls in it, was missing.
+
+“‘You blackguard!’ I shouted, beside myself with rage. ‘You have
+destroyed it! You have dishonored me for ever! Where are the jewels
+which you have stolen?’
+
+“‘Stolen!’ he cried.
+
+“‘Yes, you thief!’ I roared, shaking him by the shoulder.
+
+“‘There are none missing. There cannot be any missing,’ said he.
+
+“‘There are three missing. And you know where they are. Must I call you
+a liar as well as a thief? Did I not see you trying to tear off another
+piece?’
+
+“‘You have called me names enough,’ said he; ‘I will not stand it any
+longer. I shall not say another word about this business since you have
+chosen to insult me. I will leave your house in the morning and make my
+own way in the world.’
+
+“‘You shall leave it in the hands of the police!’ I cried, half-mad
+with grief and rage. ‘I shall have this matter probed to the bottom.’
+
+“‘You shall learn nothing from me,’ said he, with a passion such as I
+should not have thought was in his nature. ‘If you choose to call the
+police, let the police find what they can.’
+
+“By this time the whole house was astir, for I had raised my voice in
+my anger. Mary was the first to rush into my room, and, at the sight of
+the coronet and of Arthur’s face, she read the whole story, and, with
+a scream, fell down senseless on the ground. I sent the house-maid for
+the police, and put the investigation into their hands at once. When
+the inspector and a constable entered the house, Arthur, who had stood
+sullenly with his arms folded, asked me whether it was my intention to
+charge him with theft. I answered that it had ceased to be a private
+matter, but had become a public one, since the ruined coronet was
+national property. I was determined that the law should have its way in
+everything.
+
+“‘At least,’ said he, ‘you will not have me arrested at once. It would
+be to your advantage as well as mine if I might leave the house for
+five minutes.’
+
+“‘That you may get away, or perhaps that you may conceal what you have
+stolen,’ said I. And then realizing the dreadful position in which I
+was placed, I implored him to remember that not only my honor, but that
+of one who was far greater than I was at stake; and that he threatened
+to raise a scandal which would convulse the nation. He might avert it
+all if he would but tell me what he had done with the three missing
+stones.
+
+“‘You may as well face the matter,’ said I; ‘you have been caught in
+the act, and no confession could make your guilt more heinous. If you
+but make such reparation as is in your power, by telling us where the
+beryls are, all shall be forgiven and forgotten.’
+
+“‘Keep your forgiveness for those who ask for it,’ he answered, turning
+away from me, with a sneer. I saw that he was too hardened for any
+words of mine to influence him. There was but one way for it. I called
+in the inspector, and gave him into custody. A search was made at once,
+not only of his person, but of his room, and of every portion of the
+house where he could possibly have concealed the gems; but no trace of
+them could be found, nor would the wretched boy open his mouth for all
+our persuasions and our threats. This morning he was removed to a cell,
+and I, after going through all the police formalities, have hurried
+round to you, to implore you to use your skill in unravelling the
+matter. The police have openly confessed that they can at present make
+nothing of it. You may go to any expense which you think necessary. I
+have already offered a reward of £1000. My God, what shall I do! I have
+lost my honor, my gems, and my son in one night. Oh, what shall I do!”
+
+He put a hand on either side of his head, and rocked himself to and
+fro, droning to himself like a child whose grief has got beyond words.
+
+Sherlock Holmes sat silent for some few minutes, with his brows knitted
+and his eyes fixed upon the fire.
+
+“Do you receive much company?” he asked.
+
+“None, save my partner with his family, and an occasional friend of
+Arthur’s. Sir George Burnwell has been several times lately. No one
+else, I think.”
+
+“Do you go out much in society?”
+
+“Arthur does. Mary and I stay at home. We neither of us care for it.”
+
+“That is unusual in a young girl.”
+
+“She is of a quiet nature. Besides, she is not so very young. She is
+four-and-twenty.”
+
+“This matter, from what you say, seems to have been a shock to her
+also.”
+
+“Terrible! She is even more affected than I.”
+
+“You have neither of you any doubt as to your son’s guilt?”
+
+“How can we have, when I saw him with my own eyes with the coronet in
+his hands.”
+
+“I hardly consider that a conclusive proof. Was the remainder of the
+coronet at all injured?”
+
+“Yes, it was twisted.”
+
+“Do you not think, then, that he might have been trying to straighten
+it?”
+
+“God bless you! You are doing what you can for him and for me. But it
+is too heavy a task. What was he doing there at all? If his purpose
+were innocent, why did he not say so?”
+
+“Precisely. And if it were guilty, why did he not invent a lie? His
+silence appears to me to cut both ways. There are several singular
+points about the case. What did the police think of the noise which
+awoke you from your sleep?”
+
+“They considered that it might be caused by Arthur’s closing his
+bedroom door.”
+
+“A likely story! As if a man bent on felony would slam his door so as
+to wake a household. What did they say, then, of the disappearance of
+these gems?”
+
+“They are still sounding the planking and probing the furniture in the
+hope of finding them.”
+
+“Have they thought of looking outside the house?”
+
+“Yes, they have shown extraordinary energy. The whole garden has
+already been minutely examined.”
+
+“Now, my dear sir,” said Holmes, “is it not obvious to you now that
+this matter really strikes very much deeper than either you or the
+police were at first inclined to think? It appeared to you to be a
+simple case; to me it seems exceedingly complex. Consider what is
+involved by your theory. You suppose that your son came down from his
+bed, went, at great risk, to your dressing-room, opened your bureau,
+took out your coronet, broke off by main force a small portion of
+it, went off to some other place, concealed three gems out of the
+thirty-nine, with such skill that nobody can find them, and then
+returned with the other thirty-six into the room in which he exposed
+himself to the greatest danger of being discovered. I ask you now, is
+such a theory tenable?”
+
+“But what other is there?” cried the banker, with a gesture of despair.
+“If his motives were innocent, why does he not explain them?”
+
+“It is our task to find that out,” replied Holmes; “so now, if you
+please, Mr. Holder, we will set off for Streatham together, and devote
+an hour to glancing a little more closely into details.”
+
+My friend insisted upon my accompanying them in their expedition,
+which I was eager enough to do, for my curiosity and sympathy were
+deeply stirred by the story to which we had listened. I confess that
+the guilt of the banker’s son appeared to me to be as obvious as it
+did to his unhappy father, but still I had such faith in Holmes’s
+judgment that I felt that there must be some grounds for hope as long
+as he was dissatisfied with the accepted explanation. He hardly spoke
+a word the whole way out to the southern suburb, but sat with his chin
+upon his breast and his hat drawn over his eyes, sunk in the deepest
+thought. Our client appeared to have taken fresh heart at the little
+glimpse of hope which had been presented to him, and he even broke into
+a desultory chat with me over his business affairs. A short railway
+journey and a shorter walk brought us to Fairbank, the modest residence
+of the great financier.
+
+Fairbank was a good-sized square house of white stone, standing back
+a little from the road. A double carriage-sweep, with a snow-clad
+lawn, stretched down in front to two large iron gates which closed the
+entrance. On the right side was a small wooden thicket, which led into
+a narrow path between two neat hedges stretching from the road to the
+kitchen door, and forming the tradesmen’s entrance. On the left ran a
+lane which led to the stables, and was not itself within the grounds
+at all, being a public, though little used, thoroughfare. Holmes left
+us standing at the door, and walked slowly all round the house, across
+the front, down the tradesmen’s path, and so round by the garden behind
+into the stable lane. So long was he that Mr. Holder and I went into
+the dining-room and waited by the fire until he should return. We were
+sitting there in silence when the door opened and a young lady came in.
+She was rather above the middle height, slim, with dark hair and eyes,
+which seemed the darker against the absolute pallor of her skin. I do
+not think that I have ever seen such deadly paleness in a woman’s face.
+Her lips, too, were bloodless, but her eyes were flushed with crying.
+As she swept silently into the room she impressed me with a greater
+sense of grief than the banker had done in the morning, and it was the
+more striking in her as she was evidently a woman of strong character,
+with immense capacity for self-restraint. Disregarding my presence,
+she went straight to her uncle, and passed her hand over his head with
+a sweet womanly caress.
+
+“You have given orders that Arthur should be liberated, have you not,
+dad?” she asked.
+
+“No, no, my girl, the matter must be probed to the bottom.”
+
+“But I am so sure that he is innocent. You know what women’s instincts
+are. I know that he has done no harm and that you will be sorry for
+having acted so harshly.”
+
+“Why is he silent, then, if he is innocent?”
+
+“Who knows? Perhaps because he was so angry that you should suspect
+him.”
+
+“How could I help suspecting him, when I actually saw him with the
+coronet in his hand?”
+
+“Oh, but he had only picked it up to look at it. Oh do, do take my word
+for it that he is innocent. Let the matter drop and say no more. It is
+so dreadful to think of our dear Arthur in prison!”
+
+“I shall never let it drop until the gems are found—never, Mary! Your
+affection for Arthur blinds you as to the awful consequences to me. Far
+from hushing the thing up, I have brought a gentleman down from London
+to inquire more deeply into it.”
+
+“This gentleman?” she asked, facing round to me.
+
+“No, his friend. He wished us to leave him alone. He is round in the
+stable lane now.”
+
+“The stable lane?” She raised her dark eyebrows. “What can he hope to
+find there? Ah! this, I suppose, is he. I trust, sir, that you will
+succeed in proving, what I feel sure is the truth, that my cousin
+Arthur is innocent of this crime.”
+
+“I fully share your opinion, and I trust, with you, that we may prove
+it,” returned Holmes, going back to the mat to knock the snow from his
+shoes. “I believe I have the honor of addressing Miss Mary Holder.
+Might I ask you a question or two?”
+
+“Pray do, sir, if it may help to clear this horrible affair up.”
+
+“You heard nothing yourself last night?”
+
+“Nothing, until my uncle here began to speak loudly. I heard that, and
+I came down.”
+
+“You shut up the windows and doors the night before. Did you fasten all
+the windows?”
+
+“Yes.”
+
+“Were they all fastened this morning?”
+
+“Yes.”
+
+“You have a maid who has a sweetheart? I think that you remarked to
+your uncle last night that she had been out to see him?”
+
+“Yes, and she was the girl who waited in the drawing-room, and who may
+have heard uncle’s remarks about the coronet.”
+
+“I see. You infer that she may have gone out to tell her sweetheart,
+and that the two may have planned the robbery.”
+
+“But what is the good of all these vague theories,” cried the banker,
+impatiently, “when I have told you that I saw Arthur with the coronet
+in his hands?”
+
+“Wait a little, Mr. Holder. We must come back to that. About this girl,
+Miss Holder. You saw her return by the kitchen door, I presume?”
+
+“Yes; when I went to see if the door was fastened for the night I met
+her slipping in. I saw the man, too, in the gloom.”
+
+“Do you know him?”
+
+“Oh yes; he is the green-grocer who brings our vegetables round. His
+name is Francis Prosper.”
+
+“He stood,” said Holmes, “to the left of the door—that is to say,
+farther up the path than is necessary to reach the door?”
+
+“Yes, he did.”
+
+“And he is a man with a wooden leg?”
+
+Something like fear sprang up in the young lady’s expressive black
+eyes. “Why, you are like a magician,” said she. “How do you know that?”
+She smiled, but there was no answering smile in Holmes’s thin, eager
+face.
+
+“I should be very glad now to go up-stairs,” said he. “I shall probably
+wish to go over the outside of the house again. Perhaps I had better
+take a look at the lower windows before I go up.”
+
+He walked swiftly round from one to the other, pausing only at the
+large one which looked from the hall onto the stable lane. This he
+opened, and made a very careful examination of the sill with his
+powerful magnifying lens. “Now we shall go up-stairs,” said he, at last.
+
+The banker’s dressing-room was a plainly furnished little chamber, with
+a gray carpet, a large bureau, and a long mirror. Holmes went to the
+bureau first and looked hard at the lock.
+
+“Which key was used to open it?” he asked.
+
+“That which my son himself indicated—that of the cupboard of the
+lumber-room.”
+
+“Have you it here?”
+
+“That is it on the dressing-table.”
+
+Sherlock Holmes took it up and opened the bureau.
+
+“It is a noiseless lock,” said he. “It is no wonder that it did not
+wake you. This case, I presume, contains the coronet. We must have a
+look at it.” He opened the case, and, taking out the diadem, he laid it
+upon the table. It was a magnificent specimen of the jeweller’s art,
+and the thirty-six stones were the finest that I have ever seen. At one
+side of the coronet was a cracked edge, where a corner holding three
+gems had been torn away.
+
+“Now, Mr. Holder,” said Holmes, “here is the corner which corresponds
+to that which has been so unfortunately lost. Might I beg that you will
+break it off.”
+
+The banker recoiled in horror. “I should not dream of trying,” said he.
+
+“Then I will.” Holmes suddenly bent his strength upon it, but without
+result. “I feel it give a little,” said he; “but, though I am
+exceptionally strong in the fingers, it would take me all my time to
+break it. An ordinary man could not do it. Now, what do you think would
+happen if I did break it, Mr. Holder? There would be a noise like a
+pistol shot. Do you tell me that all this happened within a few yards
+of your bed, and that you heard nothing of it?”
+
+“I do not know what to think. It is all dark to me.”
+
+“But perhaps it may grow lighter as we go. What do you think, Miss
+Holder?”
+
+“I confess that I still share my uncle’s perplexity.”
+
+“Your son had no shoes or slippers on when you saw him?”
+
+“He had nothing on save only his trousers and shirt.”
+
+“Thank you. We have certainly been favored with extraordinary luck
+during this inquiry, and it will be entirely our own fault if we do not
+succeed in clearing the matter up. With your permission, Mr. Holder, I
+shall now continue my investigations outside.”
+
+He went alone, at his own request, for he explained that any
+unnecessary footmarks might make his task more difficult. For an hour
+or more he was at work, returning at last with his feet heavy with snow
+and his features as inscrutable as ever.
+
+“I think that I have seen now all that there is to see, Mr. Holder,”
+said he; “I can serve you best by returning to my rooms.”
+
+“But the gems, Mr. Holmes. Where are they?”
+
+“I cannot tell.”
+
+The banker wrung his hands. “I shall never see them again!” he cried.
+“And my son? You give me hopes?”
+
+“My opinion is in no way altered.”
+
+“Then, for God’s sake, what was this dark business which was acted in
+my house last night?”
+
+“If you can call upon me at my Baker Street rooms to-morrow morning
+between nine and ten I shall be happy to do what I can to make it
+clearer. I understand that you give me _carte blanche_ to act for you,
+provided only that I get back the gems, and that you place no limit on
+the sum I may draw.”
+
+“I would give my fortune to have them back.”
+
+“Very good. I shall look into the matter between this and then.
+Good-bye; it is just possible that I may have to come over here again
+before evening.”
+
+It was obvious to me that my companion’s mind was now made up about
+the case, although what his conclusions were was more than I could
+even dimly imagine. Several times during our homeward journey I
+endeavored to sound him upon the point, but he always glided away to
+some other topic, until at last I gave it over in despair. It was not
+yet three when we found ourselves in our room once more. He hurried to
+his chamber, and was down again in a few minutes dressed as a common
+loafer. With his collar turned up, his shiny, seedy coat, his red
+cravat, and his worn boots, he was a perfect sample of the class.
+
+“I think that this should do,” said he, glancing into the glass above
+the fireplace. “I only wish that you could come with me, Watson, but
+I fear that it won’t do. I may be on the trail in this matter, or I
+may be following a will-of-the-wisp, but I shall soon know which it
+is. I hope that I may be back in a few hours.” He cut a slice of beef
+from the joint upon the sideboard, sandwiched it between two rounds of
+bread, and, thrusting this rude meal into his pocket, he started off
+upon his expedition.
+
+I had just finished my tea when he returned, evidently in excellent
+spirits, swinging an old elastic-sided boot in his hand. He chucked it
+down into a corner and helped himself to a cup of tea.
+
+“I only looked in as I passed,” said he. “I am going right on.”
+
+“Where to?”
+
+“Oh, to the other side of the West End. It may be some time before I
+get back. Don’t wait up for me in case I should be late.”
+
+“How are you getting on?”
+
+“Oh, so so. Nothing to complain of. I have been out to Streatham since
+I saw you last, but I did not call at the house. It is a very sweet
+little problem, and I would not have missed it for a good deal.
+However, I must not sit gossiping here, but must get these disreputable
+clothes off and return to my highly respectable self.”
+
+I could see by his manner that he had stronger reasons for satisfaction
+than his words alone would imply. His eyes twinkled, and there was even
+a touch of color upon his sallow cheeks. He hastened up-stairs, and a
+few minutes later I heard the slam of the hall door, which told me that
+he was off once more upon his congenial hunt.
+
+I waited until midnight, but there was no sign of his return, so I
+retired to my room. It was no uncommon thing for him to be away for
+days and nights on end when he was hot upon a scent, so that his
+lateness caused me no surprise. I do not know at what hour he came in,
+but when I came down to breakfast in the morning, there he was with a
+cup of coffee in one hand and the paper in the other, as fresh and trim
+as possible.
+
+“You will excuse my beginning without you, Watson,” said he; “but you
+remember that our client has rather an early appointment this morning.”
+
+“Why, it is after nine now,” I answered. “I should not be surprised if
+that were he. I thought I heard a ring.”
+
+It was, indeed, our friend the financier. I was shocked by the change
+which had come over him, for his face, which was naturally of a broad
+and massive mould, was now pinched and fallen in, while his hair seemed
+to me at least a shade whiter. He entered with a weariness and lethargy
+which was even more painful than his violence of the morning before,
+and he dropped heavily into the arm-chair which I pushed forward for
+him.
+
+“I do not know what I have done to be so severely tried,” said he.
+“Only two days ago I was a happy and prosperous man, without a care in
+the world. Now I am left to a lonely and dishonored age. One sorrow
+comes close upon the heels of another. My niece, Mary, has deserted me.”
+
+“Deserted you?”
+
+“Yes. Her bed this morning had not been slept in, her room was empty,
+and a note for me lay upon the hall table. I had said to her last
+night, in sorrow and not in anger, that if she had married my boy all
+might have been well with him. Perhaps it was thoughtless of me to say
+so. It is to that remark that she refers in this note:
+
+  “‘MY DEAREST UNCLE,—I feel that I have brought trouble
+  upon you, and that if I had acted differently this terrible
+  misfortune might never have occurred. I cannot, with this
+  thought in my mind, ever again be happy under your roof, and
+  I feel that I must leave you for ever. Do not worry about my
+  future, for that is provided for; and, above all, do not search
+  for me, for it will be fruitless labor and an ill-service to
+  me. In life or in death, I am ever your loving       MARY.’
+
+“What could she mean by that note, Mr. Holmes? Do you think it points
+to suicide?”
+
+“No, no, nothing of the kind. It is perhaps the best possible solution.
+I trust, Mr. Holder, that you are nearing the end of your troubles.”
+
+“Ha! You say so! You have heard something, Mr. Holmes; you have learned
+something! Where are the gems?”
+
+“You would not think £1000 apiece an excessive sum for them?”
+
+“I would pay ten.”
+
+“That would be unnecessary. Three thousand will cover the matter. And
+there is a little reward, I fancy. Have you your check-book? Here is a
+pen. Better make it out for £4000 pounds.”
+
+With a dazed face the banker made out the required check. Holmes walked
+over to his desk, took out a little triangular piece of gold with three
+gems in it, and threw it down upon the table.
+
+With a shriek of joy our client clutched it up.
+
+“You have it!” he gasped. “I am saved! I am saved!”
+
+The reaction of joy was as passionate as his grief had been, and he
+hugged his recovered gems to his bosom.
+
+“There is one other thing you owe, Mr. Holder,” said Sherlock Holmes,
+rather sternly.
+
+“Owe!” He caught up a pen. “Name the sum, and I will pay it.”
+
+“No, the debt is not to me. You owe a very humble apology to that noble
+lad, your son, who has carried himself in this matter as I should be
+proud to see my own son do, should I ever chance to have one.”
+
+“Then it was not Arthur who took them?”
+
+“I told you yesterday, and I repeat to-day, that it was not.”
+
+“You are sure of it! Then let us hurry to him at once, to let him know
+that the truth is known.”
+
+“He knows it already. When I had cleared it all up I had an interview
+with him, and, finding that he would not tell me the story, I told it
+to him, on which he had to confess that I was right, and to add the
+very few details which were not yet quite clear to me. Your news of
+this morning, however, may open his lips.”
+
+“For Heaven’s sake, tell me, then, what is this extraordinary mystery!”
+
+“I will do so, and I will show you the steps by which I reached it. And
+let me say to you, first, that which it is hardest for me to say and
+for you to hear: there has been an understanding between Sir George
+Burnwell and your niece Mary. They have now fled together.”
+
+“My Mary? Impossible!”
+
+“It is, unfortunately, more than possible; it is certain. Neither you
+nor your son knew the true character of this man when you admitted
+him into your family circle. He is one of the most dangerous men in
+England—a ruined gambler, an absolutely desperate villain, a man
+without heart or conscience. Your niece knew nothing of such men. When
+he breathed his vows to her, as he had done to a hundred before her,
+she flattered herself that she alone had touched his heart. The devil
+knows best what he said, but at least she became his tool, and was in
+the habit of seeing him nearly every evening.”
+
+“I cannot, and I will not, believe it!” cried the banker, with an ashen
+face.
+
+“I will tell you, then, what occurred in your house last night. Your
+niece, when you had, as she thought, gone to your room, slipped down
+and talked to her lover through the window which leads into the stable
+lane. His footmarks had pressed right through the snow, so long had
+he stood there. She told him of the coronet. His wicked lust for gold
+kindled at the news, and he bent her to his will. I have no doubt
+that she loved you, but there are women in whom the love of a lover
+extinguishes all other loves, and I think that she must have been one.
+She had hardly listened to his instructions when she saw you coming
+down-stairs, on which she closed the window rapidly, and told you about
+one of the servants’ escapade with her wooden-legged lover, which was
+all perfectly true.
+
+“Your boy, Arthur, went to bed after his interview with you, but
+he slept badly on account of his uneasiness about his club debts.
+In the middle of the night he heard a soft tread pass his door, so
+he rose, and looking out, was surprised to see his cousin walking
+very stealthily along the passage, until she disappeared into your
+dressing-room. Petrified with astonishment, the lad slipped on some
+clothes, and waited there in the dark to see what would come of this
+strange affair. Presently she emerged from the room again, and in the
+light of the passage-lamp your son saw that she carried the precious
+coronet in her hands. She passed down the stairs, and he, thrilling
+with horror, ran along and slipped behind the curtain near your door,
+whence he could see what passed in the hall beneath. He saw her
+stealthily open the window, hand out the coronet to some one in the
+gloom, and then closing it once more hurry back to her room, passing
+quite close to where he stood hid behind the curtain.
+
+“As long as she was on the scene he could not take any action without
+a horrible exposure of the woman whom he loved. But the instant that
+she was gone he realized how crushing a misfortune this would be for
+you, and how all-important it was to set it right. He rushed down, just
+as he was, in his bare feet, opened the window, sprang out into the
+snow, and ran down the lane, where he could see a dark figure in the
+moonlight. Sir George Burnwell tried to get away, but Arthur caught
+him, and there was a struggle between them, your lad tugging at one
+side of the coronet, and his opponent at the other. In the scuffle,
+your son struck Sir George, and cut him over the eye. Then something
+suddenly snapped, and your son, finding that he had the coronet in his
+hands, rushed back, closed the window, ascended to your room, and had
+just observed that the coronet had been twisted in the struggle, and
+was endeavoring to straighten it when you appeared upon the scene.”
+
+“Is it possible?” gasped the banker.
+
+“You then roused his anger by calling him names at a moment when he
+felt that he had deserved your warmest thanks. He could not explain
+the true state of affairs without betraying one who certainly deserved
+little enough consideration at his hands. He took the more chivalrous
+view, however, and preserved her secret.”
+
+“And that was why she shrieked and fainted when she saw the coronet,”
+cried Mr. Holder. “Oh, my God! what a blind fool I have been! And his
+asking to be allowed to go out for five minutes! The dear fellow wanted
+to see if the missing piece were at the scene of the struggle. How
+cruelly I have misjudged him!”
+
+“When I arrived at the house,” continued Holmes, “I at once went very
+carefully round it to observe if there were any traces in the snow
+which might help me. I knew that none had fallen since the evening
+before, and also that there had been a strong frost to preserve
+impressions. I passed along the tradesmen’s path, but found it all
+trampled down and indistinguishable. Just beyond it, however, at the
+far side of the kitchen door, a woman had stood and talked with a man,
+whose round impressions on one side showed that he had a wooden leg.
+I could even tell that they had been disturbed, for the woman had run
+back swiftly to the door, as was shown by the deep toe and light heel
+marks, while Wooden-leg had waited a little, and then had gone away.
+I thought at the time that this might be the maid and her sweetheart,
+of whom you had already spoken to me, and inquiry showed it was so.
+I passed round the garden without seeing anything more than random
+tracks, which I took to be the police; but when I got into the stable
+lane a very long and complex story was written in the snow in front of
+me.
+
+“There was a double line of tracks of a booted man, and a second double
+line which I saw with delight belonged to a man with naked feet. I was
+at once convinced from what you had told me that the latter was your
+son. The first had walked both ways, but the other had run swiftly,
+and, as his tread was marked in places over the depression of the boot,
+it was obvious that he had passed after the other. I followed them up,
+and found that they led to the hall window, where Boots had worn all
+the snow away while waiting. Then I walked to the other end, which was
+a hundred yards or more down the lane. I saw where Boots had faced
+round, where the snow was cut up as though there had been a struggle,
+and, finally, where a few drops of blood had fallen, to show me that I
+was not mistaken. Boots had then run down the lane, and another little
+smudge of blood showed that it was he who had been hurt. When he came
+to the high-road at the other end, I found that the pavement had been
+cleared, so there was an end to that clew.
+
+“On entering the house, however, I examined, as you remember, the sill
+and framework of the hall window with my lens, and I could at once
+see that some one had passed out. I could distinguish the outline of
+an instep where the wet foot had been placed in coming in. I was then
+beginning to be able to form an opinion as to what had occurred. A man
+had waited outside the window, some one had brought the gems; the deed
+had been overseen by your son, he had pursued the thief, had struggled
+with him, they had each tugged at the coronet, their united strength
+causing injuries which neither alone could have effected. He had
+returned with the prize, but had left a fragment in the grasp of his
+opponent. So far I was clear. The question now was, who was the man,
+and who was it brought him the coronet?
+
+“It is an old maxim of mine that when you have excluded the impossible,
+whatever remains, however improbable, must be the truth. Now, I knew
+that it was not you who had brought it down, so there only remained
+your niece and the maids. But if it were the maids, why should your son
+allow himself to be accused in their place? There could be no possible
+reason. As he loved his cousin, however, there was an excellent
+explanation why he should retain her secret—the more so as the secret
+was a disgraceful one. When I remembered that you had seen her at
+that window, and how she had fainted on seeing the coronet again, my
+conjecture became a certainty.
+
+“And who could it be who was her confederate? A lover evidently, for
+who else could outweigh the love and gratitude which she must feel to
+you? I knew that you went out little, and that your circle of friends
+was a very limited one. But among them was Sir George Burnwell. I had
+heard of him before as being a man of evil reputation among women. It
+must have been he who wore those boots and retained the missing gems.
+Even though he knew that Arthur had discovered him, he might still
+flatter himself that he was safe, for the lad could not say a word
+without compromising his own family.
+
+“Well, your own good sense will suggest what measures I took next. I
+went in the shape of a loafer to Sir George’s house, managed to pick
+up an acquaintance with his valet, learned that his master had cut his
+head the night before, and, finally, at the expense of six shillings,
+made all sure by buying a pair of his cast-off shoes. With these I
+journeyed down to Streatham, and saw that they exactly fitted the
+tracks.”
+
+[Illustration: “I CLAPPED A PISTOL TO HIS HEAD”]
+
+“I saw an ill-dressed vagabond in the lane yesterday evening,” said Mr.
+Holder.
+
+“Precisely. It was I. I found that I had my man, so I came home and
+changed my clothes. It was a delicate part which I had to play then,
+for I saw that a prosecution must be avoided to avert scandal, and I
+knew that so astute a villain would see that our hands were tied in the
+matter. I went and saw him. At first, of course, he denied everything.
+But when I gave him every particular that had occurred, he tried to
+bluster, and took down a life-preserver from the wall. I knew my man,
+however, and I clapped a pistol to his head before he could strike.
+Then he became a little more reasonable. I told him that we would give
+him a price for the stones he held—£1000 apiece. That brought out the
+first signs of grief that he had shown. ‘Why, dash it all!’ said he,
+‘I’ve let them go at six hundred for the three!’ I soon managed to get
+the address of the receiver who had them, on promising him that there
+would be no prosecution. Off I set to him, and after much chaffering I
+got our stones at £1000 apiece. Then I looked in upon your son, told
+him that all was right, and eventually got to my bed about two o’clock,
+after what I may call a really hard day’s work.”
+
+“A day which has saved England from a great public scandal,” said the
+banker, rising. “Sir, I cannot find words to thank you, but you shall
+not find me ungrateful for what you have done. Your skill has indeed
+exceeded all that I have heard of it. And now I must fly to my dear boy
+to apologize to him for the wrong which I have done him. As to what you
+tell me of poor Mary, it goes to my very heart. Not even your skill can
+inform me where she is now.”
+
+“I think that we may safely say,” returned Holmes, “that she is
+wherever Sir George Burnwell is. It is equally certain, too, that
+whatever her sins are, they will soon receive a more than sufficient
+punishment.”
+
+
+
+
+Adventure XII
+
+THE ADVENTURE OF THE COPPER BEECHES
+
+
+“To the man who loves art for its own sake,” remarked Sherlock Holmes,
+tossing aside the advertisement sheet of _The Daily Telegraph_, “it is
+frequently in its least important and lowliest manifestations that the
+keenest pleasure is to be derived. It is pleasant to me to observe,
+Watson, that you have so far grasped this truth that in these little
+records of our cases which you have been good enough to draw up, and, I
+am bound to say, occasionally to embellish, you have given prominence
+not so much to the many _causes célèbres_ and sensational trials in
+which I have figured, but rather to those incidents which may have been
+trivial in themselves, but which have given room for those faculties
+of deduction and of logical synthesis which I have made my special
+province.”
+
+“And yet,” said I, smiling, “I cannot quite hold myself absolved from
+the charge of sensationalism which has been urged against my records.”
+
+“You have erred, perhaps,” he observed, taking up a glowing cinder with
+the tongs, and lighting with it the long cherry-wood pipe which was
+wont to replace his clay when he was in a disputatious, rather than a
+meditative mood—“you have erred perhaps in attempting to put color and
+life into each of your statements, instead of confining yourself to the
+task of placing upon record that severe reasoning from cause to effect
+which is really the only notable feature about the thing.”
+
+“It seems to me that I have done you full justice in the matter,” I
+remarked, with some coldness, for I was repelled by the egotism which
+I had more than once observed to be a strong factor in my friend’s
+singular character.
+
+“No, it is not selfishness or conceit,” said he, answering, as was his
+wont, my thoughts rather than my words. “If I claim full justice for my
+art, it is because it is an impersonal thing—a thing beyond myself.
+Crime is common. Logic is rare. Therefore it is upon the logic rather
+than upon the crime that you should dwell. You have degraded what
+should have been a course of lectures into a series of tales.”
+
+It was a cold morning of the early spring, and we sat after breakfast
+on either side of a cheery fire in the old room at Baker Street. A
+thick fog rolled down between the lines of dun-colored houses, and the
+opposing windows loomed like dark, shapeless blurs through the heavy
+yellow wreaths. Our gas was lit, and shone on the white cloth and
+glimmer of china and metal, for the table had not been cleared yet.
+Sherlock Holmes had been silent all the morning, dipping continuously
+into the advertisement columns of a succession of papers, until at
+last, having apparently given up his search, he had emerged in no very
+sweet temper to lecture me upon my literary shortcomings.
+
+“At the same time,” he remarked, after a pause, during which he had sat
+puffing at his long pipe and gazing down into the fire, “you can hardly
+be open to a charge of sensationalism, for out of these cases which you
+have been so kind as to interest yourself in, a fair proportion do not
+treat of crime, in its legal sense, at all. The small matter in which I
+endeavored to help the King of Bohemia, the singular experience of Miss
+Mary Sutherland, the problem connected with the man with the twisted
+lip, and the incident of the noble bachelor, were all matters which are
+outside the pale of the law. But in avoiding the sensational, I fear
+that you may have bordered on the trivial.”
+
+“The end may have been so,” I answered, “but the methods I hold to have
+been novel and of interest.”
+
+“Pshaw, my dear fellow, what do the public, the great unobservant
+public, who could hardly tell a weaver by his tooth or a compositor by
+his left thumb, care about the finer shades of analysis and deduction!
+But, indeed, if you are trivial, I cannot blame you, for the days of
+the great cases are past. Man, or at least criminal man, has lost all
+enterprise and originality. As to my own little practice, it seems to
+be degenerating into an agency for recovering lost lead pencils and
+giving advice to young ladies from boarding-schools. I think that I
+have touched bottom at last, however. This note I had this morning
+marks my zero-point, I fancy. Read it!” He tossed a crumpled letter
+across to me.
+
+It was dated from Montague Place upon the preceding evening, and ran
+thus:
+
+  “DEAR MR. HOLMES,—I am very anxious to consult you as
+  to whether I should or should not accept a situation which has
+  been offered to me as governess. I shall call at half-past ten
+  to-morrow, if I do not inconvenience you.
+
+  “Yours faithfully,     VIOLET HUNTER.”
+
+“Do you know the young lady?” I asked.
+
+“Not I.”
+
+“It is half-past ten now.”
+
+“Yes, and I have no doubt that is her ring.”
+
+“It may turn out to be of more interest than you think. You remember
+that the affair of the blue carbuncle, which appeared to be a mere whim
+at first, developed into a serious investigation. It may be so in this
+case, also.”
+
+“Well, let us hope so. But our doubts will very soon be solved, for
+here, unless I am much mistaken, is the person in question.”
+
+As he spoke the door opened and a young lady entered the room. She was
+plainly but neatly dressed, with a bright, quick face, freckled like a
+plover’s egg, and with the brisk manner of a woman who has had her own
+way to make in the world.
+
+“You will excuse my troubling you, I am sure,” said she, as my
+companion rose to greet her; “but I have had a very strange experience,
+and as I have no parents or relations of any sort from whom I could ask
+advice, I thought that perhaps you would be kind enough to tell me what
+I should do.”
+
+“Pray take a seat, Miss Hunter. I shall be happy to do anything that I
+can to serve you.”
+
+I could see that Holmes was favorably impressed by the manner and
+speech of his new client. He looked her over in his searching fashion,
+and then composed himself, with his lids drooping and his finger tips
+together, to listen to her story.
+
+“I have been a governess for five years,” said she, “in the family
+of Colonel Spence Munro, but two months ago the colonel received an
+appointment at Halifax, in Nova Scotia, and took his children over
+to America with him, so that I found myself without a situation. I
+advertised, and I answered advertisements, but without success. At last
+the little money which I had saved began to run short, and I was at my
+wits’ end as to what I should do.
+
+“There is a well-known agency for governesses in the West End called
+Westaway’s, and there I used to call about once a week in order to
+see whether anything had turned up which might suit me. Westaway was
+the name of the founder of the business, but it is really managed by
+Miss Stoper. She sits in her own little office, and the ladies who are
+seeking employment wait in an ante-room, and are then shown in one by
+one, when she consults her ledgers, and sees whether she has anything
+which would suit them.
+
+“Well, when I called last week I was shown into the little office as
+usual, but I found that Miss Stoper was not alone. A prodigiously stout
+man with a very smiling face, and a great heavy chin which rolled down
+in fold upon fold over his throat, sat at her elbow with a pair of
+glasses on his nose, looking very earnestly at the ladies who entered.
+As I came in he gave quite a jump in his chair, and turned quickly to
+Miss Stoper:
+
+“‘That will do,’ said he; ‘I could not ask for anything better. Capital!
+capital!’ He seemed quite enthusiastic, and rubbed his hands together
+in the most genial fashion. He was such a comfortable-looking man that
+it was quite a pleasure to look at him.
+
+“‘You are looking for a situation, miss?’ he asked.
+
+“‘Yes, sir.’
+
+“‘As governess?’
+
+“‘Yes, sir.’
+
+“‘And what salary do you ask?’
+
+“‘I had £4 a month in my last place with Colonel Spence Munro.’
+
+“‘Oh, tut, tut! sweating—rank sweating!’ he cried, throwing his fat
+hands out into the air like a man who is in a boiling passion. ‘How
+could any one offer so pitiful a sum to a lady with such attractions
+and accomplishments?’
+
+“‘My accomplishments, sir, may be less than you imagine,’ said I. ‘A
+little French, a little German, music, and drawing—’
+
+“‘Tut, tut!’ he cried. ‘This is all quite beside the question. The
+point is, have you or have you not the bearing and deportment of a
+lady? There it is in a nutshell. If you have not, you are not fitted
+for the rearing of a child who may some day play a considerable part
+in the history of the country. But if you have, why, then, how could
+any gentleman ask you to condescend to accept anything under the three
+figures? Your salary with me, madam, would commence at £100 a year.’
+
+“You may imagine, Mr. Holmes, that to me, destitute as I was, such an
+offer seemed almost too good to be true. The gentleman, however, seeing
+perhaps the look of incredulity upon my face, opened a pocket-book and
+took out a note.
+
+“‘It is also my custom,’ said he, smiling in the most pleasant fashion
+until his eyes were just two little shining slits amid the white
+creases of his face, ‘to advance to my young ladies half their salary
+beforehand, so that they may meet any little expenses of their journey
+and their wardrobe.’
+
+“It seemed to me that I had never met so fascinating and so thoughtful
+a man. As I was already in debt to my tradesmen, the advance was a
+great convenience, and yet there was something unnatural about the
+whole transaction which made me wish to know a little more before I
+quite committed myself.
+
+“‘May I ask where you live, sir?’ said I.
+
+“‘Hampshire. Charming rural place. The Copper Beeches, five miles on the
+far side of Winchester. It is the most lovely country, my dear young
+lady, and the dearest old country-house.’
+
+“‘And my duties, sir? I should be glad to know what they would be.’
+
+“‘One child—one dear little romper just six years old. Oh, if you could
+see him killing cockroaches with a slipper! Smack! smack! smack! Three
+gone before you could wink!’ He leaned back in his chair and laughed
+his eyes into his head again.
+
+“I was a little startled at the nature of the child’s amusement, but
+the father’s laughter made me think that perhaps he was joking.
+
+“‘My sole duties, then,’ I asked, ‘are to take charge of a single child?’
+
+“‘No, no, not the sole, not the sole, my dear young lady,’ he cried.
+‘Your duty would be, as I am sure your good sense would suggest, to
+obey any little commands my wife might give, provided always that they
+were such commands as a lady might with propriety obey. You see no
+difficulty, heh?’
+
+“‘I should be happy to make myself useful.’
+
+“‘Quite so. In dress now, for example. We are faddy people, you
+know—faddy but kind-hearted. If you were asked to wear any dress which
+we might give you, you would not object to our little whim. Heh?’
+
+“‘No,’ said I, considerably astonished at his words.
+
+“‘Or to sit here, or sit there, that would not be offensive to you?’
+
+“‘Oh, no.’
+
+“‘Or to cut your hair quite short before you come to us?’
+
+“I could hardly believe my ears. As you may observe, Mr. Holmes, my
+hair is somewhat luxuriant, and of a rather peculiar tint of chestnut.
+It has been considered artistic. I could not dream of sacrificing it in
+this off-hand fashion.
+
+“‘I am afraid that that is quite impossible,’ said I. He had been
+watching me eagerly out of his small eyes, and I could see a shadow
+pass over his face as I spoke.
+
+“‘I am afraid that it is quite essential,’ said he. ‘It is a little
+fancy of my wife’s, and ladies’ fancies, you know, madam, ladies’
+fancies must be consulted. And so you won’t cut your hair?’
+
+“‘No, sir, I really could not,’ I answered, firmly.
+
+“‘Ah, very well; then that quite settles the matter. It is a pity,
+because in other respects you would really have done very nicely. In
+that case, Miss Stoper, I had best inspect a few more of your young
+ladies.’
+
+“The manageress had sat all this while busy with her papers without a
+word to either of us, but she glanced at me now with so much annoyance
+upon her face that I could not help suspecting that she had lost a
+handsome commission through my refusal.
+
+“‘Do you desire your name to be kept upon the books?’ she asked.
+
+“‘If you please, Miss Stoper.’
+
+“‘Well, really, it seems rather useless, since you refuse the most
+excellent offers in this fashion,’ said she, sharply. ‘You can hardly
+expect us to exert ourselves to find another such opening for you.
+Good-day to you, Miss Hunter.’ She struck a gong upon the table, and I
+was shown out by the page.
+
+“Well, Mr. Holmes, when I got back to my lodgings and found little
+enough in the cupboard, and two or three bills upon the table, I began
+to ask myself whether I had not done a very foolish thing. After all,
+if these people had strange fads, and expected obedience on the most
+extraordinary matters, they were at least ready to pay for their
+eccentricity. Very few governesses in England are getting £100 a
+year. Besides, what use was my hair to me? Many people are improved by
+wearing it short, and perhaps I should be among the number. Next day I
+was inclined to think that I had made a mistake, and by the day after
+I was sure of it. I had almost overcome my pride, so far as to go back
+to the agency and inquire whether the place was still open, when I
+received this letter from the gentleman himself. I have it here, and I
+will read it to you:
+
+    “‘The Copper Beeches, near Winchester.
+
+    “‘DEAR MISS HUNTER,—Miss Stoper has very kindly given me your
+    address, and I write from here to ask you whether you have
+    reconsidered your decision. My wife is very anxious that you
+    should come, for she has been much attracted by my description
+    of you. We are willing to give £30 a quarter, or £120 a year, so
+    as to recompense you for any little inconvenience which our fads
+    may cause you. They are not very exacting, after all. My wife
+    is fond of a particular shade of electric blue, and would like
+    you to wear such a dress in-doors in the morning. You need not,
+    however, go to the expense of purchasing one, as we have one
+    belonging to my dear daughter Alice (now in Philadelphia), which
+    would, I should think, fit you very well. Then, as to sitting
+    here or there, or amusing yourself in any manner indicated, that
+    need cause you no inconvenience. As regards your hair, it is
+    no doubt a pity, especially as I could not help remarking its
+    beauty during our short interview, but I am afraid that I must
+    remain firm upon this point, and I only hope that the increased
+    salary may recompense you for the loss. Your duties, as far as
+    the child is concerned, are very light. Now do try to come, and
+    I shall meet you with the dog-cart at Winchester. Let me know
+    your train.         Yours faithfully,      JEPHRO RUCASTLE.’
+
+“That is the letter which I have just received, Mr. Holmes, and my mind
+is made up that I will accept it. I thought, however, that before
+taking the final step I should like to submit the whole matter to your
+consideration.”
+
+“Well, Miss Hunter, if your mind is made up, that settles the
+question,” said Holmes, smiling.
+
+“But you would not advise me to refuse?”
+
+“I confess that it is not the situation which I should like to see a
+sister of mine apply for.”
+
+“What is the meaning of it all, Mr. Holmes?”
+
+“Ah, I have no data. I cannot tell. Perhaps you have yourself formed
+some opinion?”
+
+“Well, there seems to me to be only one possible solution. Mr. Rucastle
+seemed to be a very kind, good-natured man. Is it not possible that his
+wife is a lunatic, that he desires to keep the matter quiet for fear
+she should be taken to an asylum, and that he humors her fancies in
+every way in order to prevent an outbreak.”
+
+“That is a possible solution—in fact, as matters stand, it is the most
+probable one. But in any case it does not seem to be a nice household
+for a young lady.”
+
+“But the money, Mr. Holmes, the money!”
+
+“Well, yes, of course the pay is good—too good. That is what makes
+me uneasy. Why should they give you £120 a year, when they could have
+their pick for £40? There must be some strong reason behind.”
+
+“I thought that if I told you the circumstances you would understand
+afterwards if I wanted your help. I should feel so much stronger if I
+felt that you were at the back of me.”
+
+“Oh, you may carry that feeling away with you. I assure you that your
+little problem promises to be the most interesting which has come my
+way for some months. There is something distinctly novel about some of
+the features. If you should find yourself in doubt or in danger—”
+
+“Danger! What danger do you foresee?”
+
+Holmes shook his head gravely. “It would cease to be a danger if we
+could define it,” said he. “But at any time, day or night, a telegram
+would bring me down to your help.”
+
+“That is enough.” She rose briskly from her chair with the anxiety
+all swept from her face. “I shall go down to Hampshire quite easy in
+my mind now. I shall write to Mr. Rucastle at once, sacrifice my poor
+hair to-night, and start for Winchester to-morrow.” With a few grateful
+words to Holmes she bade us both good-night and bustled off upon her
+way.
+
+“At least,” said I, as we heard her quick, firm step descending the
+stairs, “she seems to be a young lady who is very well able to take
+care of herself.”
+
+“And she would need to be,” said Holmes, gravely; “I am much mistaken
+if we do not hear from her before many days are past.”
+
+It was not very long before my friend’s prediction was fulfilled. A
+fortnight went by, during which I frequently found my thoughts turning
+in her direction, and wondering what strange side-alley of human
+experience this lonely woman had strayed into. The unusual salary,
+the curious conditions, the light duties, all pointed to something
+abnormal, though whether a fad or a plot, or whether the man were
+a philanthropist or a villain, it was quite beyond my powers to
+determine. As to Holmes, I observed that he sat frequently for half an
+hour on end, with knitted brows and an abstracted air, but he swept the
+matter away with a wave of his hand when I mentioned it. “Data! data!
+data!” he cried, impatiently. “I can’t make bricks without clay.” And
+yet he would always wind up by muttering that no sister of his should
+ever have accepted such a situation.
+
+The telegram which we eventually received came late one night, just as
+I was thinking of turning in, and Holmes was settling down to one of
+those all-night chemical researches which he frequently indulged in,
+when I would leave him stooping over a retort and a test-tube at night,
+and find him in the same position when I came down to breakfast in
+the morning. He opened the yellow envelope, and then, glancing at the
+message, threw it across to me.
+
+“Just look up the trains in Bradshaw,” said he, and turned back to his
+chemical studies.
+
+The summons was a brief and urgent one.
+
+  “Please be at the ‘Black Swan’ Hotel at Winchester at
+  mid-day to-morrow,” it said. “Do come! I am at my wits’
+  end.                                       HUNTER.”
+
+“Will you come with me?” asked Holmes, glancing up.
+
+“I should wish to.”
+
+“Just look it up, then.”
+
+“There is a train at half-past nine,” said I, glancing over my
+Bradshaw. “It is due at Winchester at 11.30.”
+
+“That will do very nicely. Then perhaps I had better postpone my
+analysis of the acetones, as we may need to be at our best in the
+morning.”
+
+       *       *       *       *       *
+
+By eleven o’clock the next day we were well upon our way to the old
+English capital. Holmes had been buried in the morning papers all the
+way down, but after we had passed the Hampshire border he threw them
+down, and began to admire the scenery. It was an ideal spring day, a
+light blue sky, flecked with little fleecy white clouds drifting across
+from west to east. The sun was shining very brightly, and yet there was
+an exhilarating nip in the air, which set an edge to a man’s energy.
+All over the country-side, away to the rolling hills around Aldershot,
+the little red and gray roofs of the farm-steadings peeped out from
+amid the light green of the new foliage.
+
+“Are they not fresh and beautiful?” I cried, with all the enthusiasm of
+a man fresh from the fogs of Baker Street.
+
+But Holmes shook his head gravely.
+
+“Do you know, Watson,” said he, “that it is one of the curses of a mind
+with a turn like mine that I must look at everything with reference to
+my own special subject. You look at these scattered houses, and you are
+impressed by their beauty. I look at them, and the only thought which
+comes to me is a feeling of their isolation and of the impunity with
+which crime may be committed there.”
+
+“Good heavens!” I cried. “Who would associate crime with these dear old
+homesteads?”
+
+“They always fill me with a certain horror. It is my belief, Watson,
+founded upon my experience, that the lowest and vilest alleys in London
+do not present a more dreadful record of sin than does the smiling and
+beautiful country-side.”
+
+“You horrify me!”
+
+“But the reason is very obvious. The pressure of public opinion can
+do in the town what the law cannot accomplish. There is no lane so
+vile that the scream of a tortured child, or the thud of a drunkard’s
+blow, does not beget sympathy and indignation among the neighbors, and
+then the whole machinery of justice is ever so close that a word of
+complaint can set it going, and there is but a step between the crime
+and the dock. But look at these lonely houses, each in its own fields,
+filled for the most part with poor ignorant folk who know little of
+the law. Think of the deeds of hellish cruelty, the hidden wickedness
+which may go on, year in, year out, in such places, and none the wiser.
+Had this lady who appeals to us for help gone to live in Winchester, I
+should never have had a fear for her. It is the five miles of country
+which makes the danger. Still, it is clear that she is not personally
+threatened.”
+
+“No. If she can come to Winchester to meet us she can get away.”
+
+“Quite so. She has her freedom.”
+
+“What _can_ be the matter, then? Can you suggest no explanation?”
+
+“I have devised seven separate explanations, each of which would cover
+the facts as far as we know them. But which of these is correct can
+only be determined by the fresh information which we shall no doubt
+find waiting for us. Well, there is the tower of the cathedral, and we
+shall soon learn all that Miss Hunter has to tell.”
+
+The “Black Swan” is an inn of repute in the High Street, at no
+distance from the station, and there we found the young lady waiting
+for us. She had engaged a sitting-room, and our lunch awaited us upon
+the table.
+
+“I am so delighted that you have come,” she said, earnestly. “It is so
+very kind of you both; but indeed I do not know what I should do. Your
+advice will be altogether invaluable to me.”
+
+“Pray tell us what has happened to you.”
+
+“I will do so, and I must be quick, for I have promised Mr. Rucastle to
+be back before three. I got his leave to come into town this morning,
+though he little knew for what purpose.”
+
+“Let us have everything in its due order.” Holmes thrust his long thin
+legs out towards the fire and composed himself to listen.
+
+“In the first place, I may say that I have met, on the whole, with no
+actual ill-treatment from Mr. and Mrs. Rucastle. It is only fair to
+them to say that. But I cannot understand them, and I am not easy in my
+mind about them.”
+
+“What can you not understand?”
+
+“Their reasons for their conduct. But you shall have it all just as
+it occurred. When I came down, Mr. Rucastle met me here, and drove me
+in his dog-cart to the Copper Beeches. It is, as he said, beautifully
+situated, but it is not beautiful in itself, for it is a large square
+block of a house, whitewashed, but all stained and streaked with damp
+and bad weather. There are grounds round it, woods on three sides, and
+on the fourth a field which slopes down to the Southampton high-road,
+which curves past about a hundred yards from the front door. This
+ground in front belongs to the house, but the woods all round are part
+of Lord Southerton’s preserves. A clump of copper beeches immediately
+in front of the hall door has given its name to the place.
+
+[Illustration: “‘I AM SO DELIGHTED THAT YOU HAVE COME’”]
+
+“I was driven over by my employer, who was as amiable as ever, and was
+introduced by him that evening to his wife and the child. There was no
+truth, Mr. Holmes, in the conjecture which seemed to us to be probable
+in your rooms at Baker Street. Mrs. Rucastle is not mad. I found her
+to be a silent, pale-faced woman, much younger than her husband, not
+more than thirty, I should think, while he can hardly be less than
+forty-five. From their conversation I have gathered that they have been
+married about seven years, that he was a widower, and that his only
+child by the first wife was the daughter who has gone to Philadelphia.
+Mr. Rucastle told me in private that the reason why she had left them
+was that she had an unreasoning aversion to her step-mother. As the
+daughter could not have been less than twenty, I can quite imagine that
+her position must have been uncomfortable with her father’s young wife.
+
+“Mrs. Rucastle seemed to me to be colorless in mind as well as in
+feature. She impressed me neither favorably nor the reverse. She was a
+nonentity. It was easy to see that she was passionately devoted both
+to her husband and to her little son. Her light gray eyes wandered
+continually from one to the other, noting every little want and
+forestalling it if possible. He was kind to her also in his bluff,
+boisterous fashion, and on the whole they seemed to be a happy couple.
+And yet she had some secret sorrow, this woman. She would often be lost
+in deep thought, with the saddest look upon her face. More than once I
+have surprised her in tears. I have thought sometimes that it was the
+disposition of her child which weighed upon her mind, for I have never
+met so utterly spoilt and so ill-natured a little creature. He is small
+for his age, with a head which is quite disproportionately large. His
+whole life appears to be spent in an alternation between savage fits of
+passion and gloomy intervals of sulking. Giving pain to any creature
+weaker than himself seems to be his one idea of amusement, and he
+shows quite remarkable talent in planning the capture of mice, little
+birds, and insects. But I would rather not talk about the creature, Mr.
+Holmes, and, indeed, he has little to do with my story.”
+
+“I am glad of all details,” remarked my friend, “whether they seem to
+you to be relevant or not.”
+
+“I shall try not to miss anything of importance. The one unpleasant
+thing about the house, which struck me at once, was the appearance
+and conduct of the servants. There are only two, a man and his wife.
+Toller, for that is his name, is a rough, uncouth man, with grizzled
+hair and whiskers, and a perpetual smell of drink. Twice since I have
+been with them he has been quite drunk, and yet Mr. Rucastle seemed to
+take no notice of it. His wife is a very tall and strong woman with a
+sour face, as silent as Mrs. Rucastle, and much less amiable. They are
+a most unpleasant couple, but fortunately I spend most of my time in
+the nursery and my own room, which are next to each other in one corner
+of the building.
+
+“For two days after my arrival at the Copper Beeches my life was very
+quiet; on the third, Mrs. Rucastle came down just after breakfast and
+whispered something to her husband.
+
+“‘Oh yes,’ said he, turning to me; ‘we are very much obliged to you,
+Miss Hunter, for falling in with our whims so far as to cut your hair.
+I assure you that it has not detracted in the tiniest iota from your
+appearance. We shall now see how the electric-blue dress will become
+you. You will find it laid out upon the bed in your room, and if you
+would be so good as to put it on we should both be extremely obliged.’
+
+“The dress which I found waiting for me was of a peculiar shade of
+blue. It was of excellent material, a sort of beige, but it bore
+unmistakable signs of having been worn before. It could not have been
+a better fit if I had been measured for it. Both Mr. and Mrs. Rucastle
+expressed a delight at the look of it, which seemed quite exaggerated
+in its vehemence. They were waiting for me in the drawing-room, which
+is a very large room, stretching along the entire front of the house,
+with three long windows reaching down to the floor. A chair had been
+placed close to the central window, with its back turned towards it. In
+this I was asked to sit, and then Mr. Rucastle, walking up and down on
+the other side of the room, began to tell me a series of the funniest
+stories that I have ever listened to. You cannot imagine how comical he
+was, and I laughed until I was quite weary. Mrs. Rucastle, however, who
+has evidently no sense of humor, never so much as smiled, but sat with
+her hands in her lap, and a sad, anxious look upon her face. After an
+hour or so, Mr. Rucastle suddenly remarked that it was time to commence
+the duties of the day, and that I might change my dress and go to
+little Edward in the nursery.
+
+“Two days later this same performance was gone through under exactly
+similar circumstances. Again I changed my dress, again I sat in the
+window, and again I laughed very heartily at the funny stories of which
+my employer had an immense _répertoire_, and which he told inimitably.
+Then he handed me a yellow-backed novel, and, moving my chair a little
+sideways, that my own shadow might not fall upon the page, he begged me
+to read aloud to him. I read for about ten minutes, beginning in the
+heart of a chapter, and then suddenly, in the middle of a sentence, he
+ordered me to cease and to change my dress.
+
+“You can easily imagine, Mr. Holmes, how curious I became as to what
+the meaning of this extraordinary performance could possibly be. They
+were always very careful, I observed, to turn my face away from the
+window, so that I became consumed with the desire to see what was going
+on behind my back. At first it seemed to be impossible, but I soon
+devised a means. My hand-mirror had been broken, so a happy thought
+seized me, and I concealed a piece of the glass in my handkerchief. On
+the next occasion, in the midst of my laughter, I put my handkerchief
+up to my eyes, and was able with a little management to see all that
+there was behind me. I confess that I was disappointed. There was
+nothing. At least that was my first impression. At the second glance,
+however, I perceived that there was a man standing in the Southampton
+Road, a small bearded man in a gray suit, who seemed to be looking in
+my direction. The road is an important highway, and there are usually
+people there. This man, however, was leaning against the railings
+which bordered our field, and was looking earnestly up. I lowered my
+handkerchief and glanced at Mrs. Rucastle, to find her eyes fixed upon
+me with a most searching gaze. She said nothing, but I am convinced
+that she had divined that I had a mirror in my hand, and had seen what
+was behind me. She rose at once.
+
+“‘Jephro,’ said she, ‘there is an impertinent fellow upon the road
+there who stares up at Miss Hunter.’
+
+“‘No friend of yours, Miss Hunter?’ he asked.
+
+“‘No; I know no one in these parts.’
+
+“‘Dear me! How very impertinent! Kindly turn round and motion to him to
+go away.’
+
+“‘Surely it would be better to take no notice.’
+
+“‘No, no, we should have him loitering here always. Kindly turn round
+and wave him away like that.’
+
+“I did as I was told, and at the same instant Mrs. Rucastle drew down
+the blind. That was a week ago, and from that time I have not sat again
+in the window, nor have I worn the blue dress, nor seen the man in the
+road.”
+
+“Pray continue,” said Holmes. “Your narrative promises to be a most
+interesting one.”
+
+“You will find it rather disconnected, I fear, and there may prove to
+be little relation between the different incidents of which I speak.
+On the very first day that I was at the Copper Beeches, Mr. Rucastle
+took me to a small out-house which stands near the kitchen door. As we
+approached it I heard the sharp rattling of a chain, and the sound as
+of a large animal moving about.
+
+“‘Look in here!’ said Mr. Rucastle, showing me a slit between two
+planks. ‘Is he not a beauty?’
+
+“I looked through, and was conscious of two glowing eyes, and of a
+vague figure huddled up in the darkness.
+
+“‘Don’t be frightened,’ said my employer, laughing at the start which I
+had given. ‘It’s only Carlo, my mastiff. I call him mine, but really
+old Toller, my groom, is the only man who can do anything with him. We
+feed him once a day, and not too much then, so that he is always as
+keen as mustard. Toller lets him loose every night, and God help the
+trespasser whom he lays his fangs upon. For goodness’ sake don’t you
+ever on any pretext set your foot over the threshold at night, for it
+is as much as your life is worth.’
+
+“The warning was no idle one, for two nights later I happened to look
+out of my bedroom window about two o’clock in the morning. It was a
+beautiful moonlight night, and the lawn in front of the house was
+silvered over and almost as bright as day. I was standing, rapt in
+the peaceful beauty of the scene, when I was aware that something was
+moving under the shadow of the copper beeches. As it emerged into the
+moonshine I saw what it was. It was a giant dog, as large as a calf,
+tawny tinted, with hanging jowl, black muzzle, and huge projecting
+bones. It walked slowly across the lawn and vanished into the shadow
+upon the other side. That dreadful silent sentinel sent a chill to my
+heart which I do not think that any burglar could have done.
+
+“And now I have a very strange experience to tell you. I had, as you
+know, cut off my hair in London, and I had placed it in a great coil
+at the bottom of my trunk. One evening, after the child was in bed,
+I began to amuse myself by examining the furniture of my room and by
+rearranging my own little things. There was an old chest of drawers
+in the room, the two upper ones empty and open, the lower one locked.
+I had filled the first two with my linen, and, as I had still much
+to pack away, I was naturally annoyed at not having the use of the
+third drawer. It struck me that it might have been fastened by a mere
+oversight, so I took out my bunch of keys and tried to open it. The
+very first key fitted to perfection, and I drew the drawer open. There
+was only one thing in it, but I am sure that you would never guess what
+it was. It was my coil of hair.
+
+“I took it up and examined it. It was of the same peculiar tint, and
+the same thickness. But then the impossibility of the thing obtruded
+itself upon me. How _could_ my hair have been locked in the drawer?
+With trembling hands I undid my trunk, turned out the contents, and
+drew from the bottom my own hair. I laid the two tresses together, and
+I assure you that they were identical. Was it not extraordinary? Puzzle
+as I would, I could make nothing at all of what it meant. I returned
+the strange hair to the drawer, and I said nothing of the matter to the
+Rucastles, as I felt that I had put myself in the wrong by opening a
+drawer which they had locked.
+
+“I am naturally observant, as you may have remarked, Mr. Holmes, and I
+soon had a pretty good plan of the whole house in my head. There was
+one wing, however, which appeared not to be inhabited at all. A door
+which faced that which led into the quarters of the Tollers opened
+into this suite, but it was invariably locked. One day, however, as I
+ascended the stair, I met Mr. Rucastle coming out through this door,
+his keys in his hand, and a look on his face which made him a very
+different person to the round, jovial man to whom I was accustomed. His
+cheeks were red, his brow was all crinkled with anger, and the veins
+stood out at his temples with passion. He locked the door and hurried
+past me without a word or a look.
+
+“This aroused my curiosity; so when I went out for a walk in the
+grounds with my charge, I strolled round to the side from which I could
+see the windows of this part of the house. There were four of them in a
+row, three of which were simply dirty, while the fourth was shuttered
+up. They were evidently all deserted. As I strolled up and down,
+glancing at them occasionally, Mr. Rucastle came out to me, looking as
+merry and jovial as ever.
+
+“‘Ah!’ said he, ‘you must not think me rude if I passed you without a
+word, my dear young lady. I was preoccupied with business matters.’
+
+“I assured him that I was not offended. ‘By-the-way,’ said I, ‘you
+seem to have quite a suite of spare rooms up there, and one of them has
+the shutters up.’
+
+“He looked surprised, and, as it seemed to me, a little startled at my
+remark.
+
+“‘Photography is one of my hobbies,’ said he. ‘I have made my dark room
+up there. But, dear me! what an observant young lady we have come upon.
+Who would have believed it? Who would have ever believed it?’ He spoke
+in a jesting tone, but there was no jest in his eyes as he looked at
+me. I read suspicion there and annoyance, but no jest.
+
+“Well, Mr. Holmes, from the moment that I understood that there was
+something about that suite of rooms which I was not to know, I was all
+on fire to go over them. It was not mere curiosity, though I have my
+share of that. It was more a feeling of duty—a feeling that some good
+might come from my penetrating to this place. They talk of woman’s
+instinct; perhaps it was woman’s instinct which gave me that feeling.
+At any rate, it was there, and I was keenly on the lookout for any
+chance to pass the forbidden door.
+
+“It was only yesterday that the chance came. I may tell you that,
+besides Mr. Rucastle, both Toller and his wife find something to do in
+these deserted rooms, and I once saw him carrying a large black linen
+bag with him through the door. Recently he has been drinking hard, and
+yesterday evening he was very drunk; and, when I came up-stairs, there
+was the key in the door. I have no doubt at all that he had left it
+there. Mr. and Mrs. Rucastle were both down-stairs, and the child was
+with them, so that I had an admirable opportunity. I turned the key
+gently in the lock, opened the door, and slipped through.
+
+“There was a little passage in front of me, unpapered and uncarpeted,
+which turned at a right angle at the farther end. Round this corner
+were three doors in a line, the first and third of which were open.
+They each led into an empty room, dusty and cheerless, with two windows
+in the one and one in the other, so thick with dirt that the evening
+light glimmered dimly through them. The centre door was closed, and
+across the outside of it had been fastened one of the broad bars of
+an iron bed, padlocked at one end to a ring in the wall, and fastened
+at the other with stout cord. The door itself was locked as well, and
+the key was not there. This barricaded door corresponded clearly with
+the shuttered window outside, and yet I could see by the glimmer from
+beneath it that the room was not in darkness. Evidently there was a
+skylight which let in light from above. As I stood in the passage
+gazing at the sinister door, and wondering what secret it might veil,
+I suddenly heard the sound of steps within the room, and saw a shadow
+pass backward and forward against the little slit of dim light which
+shone out from under the door. A mad, unreasoning terror rose up in
+me at the sight, Mr. Holmes. My overstrung nerves failed me suddenly,
+and I turned and ran—ran as though some dreadful hand were behind me
+clutching at the skirt of my dress. I rushed down the passage, through
+the door, and straight into the arms of Mr. Rucastle, who was waiting
+outside.
+
+“‘So,’ said he, smiling, ‘it was you, then. I thought that it must be
+when I saw the door open.’
+
+“‘Oh, I am so frightened!’ I panted.
+
+“‘My dear young lady! my dear young lady!’—you cannot think how
+caressing and soothing his manner was—‘and what has frightened you, my
+dear young lady?’
+
+“But his voice was just a little too coaxing. He overdid it. I was
+keenly on my guard against him.
+
+“‘I was foolish enough to go into the empty wing,’ I answered. ‘But it
+is so lonely and eerie in this dim light that I was frightened and ran
+out again. Oh, it is so dreadfully still in there!’
+
+“‘Only that?’ said he, looking at me keenly.
+
+“‘Why, what did you think?’ I asked.
+
+“‘Why do you think that I lock this door?’
+
+“‘I am sure that I do not know.’
+
+“‘It is to keep people out who have no business there. Do you see?’ He
+was still smiling in the most amiable manner.
+
+“‘I am sure if I had known—’
+
+“‘Well, then, you know now. And if you ever put your foot over that
+threshold again—’ here in an instant the smile hardened into a grin of
+rage, and he glared down at me with the face of a demon—‘I’ll throw
+you to the mastiff.’
+
+“I was so terrified that I do not know what I did. I suppose that I
+must have rushed past him into my room. I remember nothing until I
+found myself lying on my bed trembling all over. Then I thought of you,
+Mr. Holmes. I could not live there longer without some advice. I was
+frightened of the house, of the man, of the woman, of the servants,
+even of the child. They were all horrible to me. If I could only bring
+you down all would be well. Of course I might have fled from the house,
+but my curiosity was almost as strong as my fears. My mind was soon
+made up. I would send you a wire. I put on my hat and cloak, went down
+to the office, which is about half a mile from the house, and then
+returned, feeling very much easier. A horrible doubt came into my mind
+as I approached the door lest the dog might be loose, but I remembered
+that Toller had drunk himself into a state of insensibility that
+evening, and I knew that he was the only one in the household who had
+any influence with the savage creature, or who would venture to set him
+free. I slipped in in safety, and lay awake half the night in my joy at
+the thought of seeing you. I had no difficulty in getting leave to come
+into Winchester this morning, but I must be back before three o’clock,
+for Mr. and Mrs. Rucastle are going on a visit, and will be away all
+the evening, so that I must look after the child. Now I have told you
+all my adventures, Mr. Holmes, and I should be very glad if you could
+tell me what it all means, and, above all, what I should do.”
+
+Holmes and I had listened spellbound to this extraordinary story. My
+friend rose now and paced up and down the room, his hands in his
+pockets, and an expression of the most profound gravity upon his face.
+
+“Is Toller still drunk?” he asked.
+
+“Yes. I heard his wife tell Mrs. Rucastle that she could do nothing
+with him.”
+
+“That is well. And the Rucastles go out to-night?”
+
+“Yes.”
+
+“Is there a cellar with a good strong lock?”
+
+“Yes, the wine-cellar.”
+
+“You seem to me to have acted all through this matter like a very brave
+and sensible girl, Miss Hunter. Do you think that you could perform one
+more feat? I should not ask it of you if I did not think you a quite
+exceptional woman.”
+
+“I will try. What is it?”
+
+“We shall be at the Copper Beeches by seven o’clock, my friend and I.
+The Rucastles will be gone by that time, and Toller will, we hope, be
+incapable. There only remains Mrs. Toller, who might give the alarm. If
+you could send her into the cellar on some errand, and then turn the
+key upon her, you would facilitate matters immensely.”
+
+“I will do it.”
+
+“Excellent! We shall then look thoroughly into the affair. Of course
+there is only one feasible explanation. You have been brought there to
+personate some one, and the real person is imprisoned in this chamber.
+That is obvious. As to who this prisoner is, I have no doubt that it is
+the daughter, Miss Alice Rucastle, if I remember right, who was said
+to have gone to America. You were chosen, doubtless, as resembling her
+in height, figure, and the color of your hair. Hers had been cut off,
+very possibly in some illness through which she has passed, and so, of
+course, yours had to be sacrificed also. By a curious chance you came
+upon her tresses. The man in the road was, undoubtedly, some friend of
+hers—possibly her _fiancé_—and no doubt, as you wore the girl’s dress
+and were so like her, he was convinced from your laughter, whenever
+he saw you, and afterwards from your gesture, that Miss Rucastle was
+perfectly happy, and that she no longer desired his attentions. The dog
+is let loose at night to prevent him from endeavoring to communicate
+with her. So much is fairly clear. The most serious point in the case
+is the disposition of the child.”
+
+“What on earth has that to do with it?” I ejaculated.
+
+“My dear Watson, you as a medical man are continually gaining light as
+to the tendencies of a child by the study of the parents. Don’t you see
+that the converse is equally valid. I have frequently gained my first
+real insight into the character of parents by studying their children.
+This child’s disposition is abnormally cruel, merely for cruelty’s
+sake, and whether he derives this from his smiling father, as I should
+suspect, or from his mother, it bodes evil for the poor girl who is in
+their power.”
+
+“I am sure that you are right, Mr. Holmes,” cried our client. “A
+thousand things come back to me which make me certain that you have
+hit it. Oh, let us lose not an instant in bringing help to this poor
+creature.”
+
+“We must be circumspect, for we are dealing with a very cunning man. We
+can do nothing until seven o’clock. At that hour we shall be with you,
+and it will not be long before we solve the mystery.”
+
+We were as good as our word, for it was just seven when we reached the
+Copper Beeches, having put up our trap at a way-side public-house. The
+group of trees, with their dark leaves shining like burnished metal in
+the light of the setting sun, were sufficient to mark the house even
+had Miss Hunter not been standing smiling on the door-step.
+
+“Have you managed it?” asked Holmes.
+
+A loud thudding noise came from somewhere down-stairs. “That is
+Mrs. Toller in the cellar,” said she. “Her husband lies snoring on
+the kitchen rug. Here are his keys, which are the duplicates of Mr.
+Rucastle’s.”
+
+“You have done well indeed!” cried Holmes, with enthusiasm. “Now lead
+the way, and we shall soon see the end of this black business.”
+
+We passed up the stair, unlocked the door, followed on down a passage,
+and found ourselves in front of the barricade which Miss Hunter had
+described. Holmes cut the cord and removed the transverse bar. Then he
+tried the various keys in the lock, but without success. No sound came
+from within, and at the silence Holmes’s face clouded over.
+
+“I trust that we are not too late,” said he. “I think, Miss Hunter,
+that we had better go in without you. Now, Watson, put your shoulder to
+it, and we shall see whether we cannot make our way in.”
+
+It was an old rickety door, and gave at once before our united
+strength. Together we rushed into the room. It was empty. There was no
+furniture save a little pallet bed, a small table, and a basketful of
+linen. The skylight above was open, and the prisoner gone.
+
+“There has been some villainy here,” said Holmes; “this beauty has
+guessed Miss Hunter’s intentions, and has carried his victim off.”
+
+“But how?”
+
+“Through the skylight. We shall soon see how he managed it.” He swung
+himself up onto the roof. “Ah, yes,” he cried; “here’s the end of a
+long light ladder against the eaves. That is how he did it.”
+
+“But it is impossible,” said Miss Hunter; “the ladder was not there
+when the Rucastles went away.”
+
+“He has come back and done it. I tell you that he is a clever and
+dangerous man. I should not be very much surprised if this were he
+whose step I hear now upon the stair. I think, Watson, that it would be
+as well for you to have your pistol ready.”
+
+The words were hardly out of his mouth before a man appeared at the
+door of the room, a very fat and burly man, with a heavy stick in his
+hand. Miss Hunter screamed and shrunk against the wall at the sight of
+him, but Sherlock Holmes sprang forward and confronted him.
+
+“You villain!” said he, “where’s your daughter?”
+
+The fat man cast his eyes round, and then up at the open skylight.
+
+“It is for me to ask you that,” he shrieked, “you thieves! Spies and
+thieves! I have caught you, have I? You are in my power. I’ll serve
+you!” He turned and clattered down the stairs as hard as he could go.
+
+“He’s gone for the dog!” cried Miss Hunter.
+
+“I have my revolver,” said I.
+
+“Better close the front door,” cried Holmes, and we all rushed down
+the stairs together. We had hardly reached the hall when we heard the
+baying of a hound, and then a scream of agony, with a horrible worrying
+sound which it was dreadful to listen to. An elderly man with a red
+face and shaking limbs came staggering out at a side door.
+
+“My God!” he cried. “Some one has loosed the dog. It’s not been fed for
+two days. Quick, quick, or it’ll be too late!”
+
+Holmes and I rushed out and round the angle of the house, with Toller
+hurrying behind us. There was the huge famished brute, its black muzzle
+buried in Rucastle’s throat, while he writhed and screamed upon the
+ground. Running up, I blew its brains out, and it fell over with its
+keen white teeth still meeting in the great creases of his neck. With
+much labor we separated them, and carried him, living but horribly
+mangled, into the house. We laid him upon the drawing-room sofa, and,
+having despatched the sobered Toller to bear the news to his wife, I
+did what I could to relieve his pain. We were all assembled round him
+when the door opened, and a tall, gaunt woman entered the room.
+
+“Mrs. Toller!” cried Miss Hunter.
+
+“Yes, miss. Mr. Rucastle let me out when he came back before he went
+up to you. Ah, miss, it is a pity you didn’t let me know what you were
+planning, for I would have told you that your pains were wasted.”
+
+“Ha!” said Holmes, looking keenly at her. “It is clear that Mrs. Toller
+knows more about this matter than any one else.”
+
+“Yes, sir, I do, and I am ready enough to tell what I know.”
+
+“Then, pray, sit down, and let us hear it, for there are several points
+on which I must confess that I am still in the dark.”
+
+“I will soon make it clear to you,” said she; “and I’d have done
+so before now if I could ha’ got out from the cellar. If there’s
+police-court business over this, you’ll remember that I was the one
+that stood your friend, and that I was Miss Alice’s friend too.
+
+“She was never happy at home, Miss Alice wasn’t, from the time that
+her father married again. She was slighted like, and had no say in
+anything; but it never really became bad for her until after she met
+Mr. Fowler at a friend’s house. As well as I could learn, Miss Alice
+had rights of her own by will, but she was so quiet and patient, she
+was, that she never said a word about them, but just left everything in
+Mr. Rucastle’s hands. He knew he was safe with her; but when there was
+a chance of a husband coming forward, who would ask for all that the
+law would give him, then her father thought it time to put a stop on
+it. He wanted her to sign a paper, so that whether she married or not,
+he could use her money. When she wouldn’t do it, he kept on worrying
+her until she got brain-fever, and for six weeks was at death’s door.
+Then she got better at last, all worn to a shadow, and with her
+beautiful hair cut off; but that didn’t make no change in her young
+man, and he stuck to her as true as man could be.”
+
+“Ah,” said Holmes, “I think that what you have been good enough to
+tell us makes the matter fairly clear, and that I can deduce all
+that remains. Mr. Rucastle then, I presume, took to this system of
+imprisonment?”
+
+“Yes, sir.”
+
+“And brought Miss Hunter down from London in order to get rid of the
+disagreeable persistence of Mr. Fowler.”
+
+“That was it, sir.”
+
+“But Mr. Fowler being a persevering man, as a good seaman should
+be, blockaded the house, and, having met you, succeeded by certain
+arguments, metallic or otherwise, in convincing you that your interests
+were the same as his.”
+
+“Mr. Fowler was a very kind-spoken, free-handed gentleman,” said Mrs.
+Toller, serenely.
+
+“And in this way he managed that your good man should have no want of
+drink, and that a ladder should be ready at the moment when your master
+had gone out.”
+
+“You have it, sir, just as it happened.”
+
+“I am sure we owe you an apology, Mrs. Toller,” said Holmes, “for you
+have certainly cleared up everything which puzzled us. And here comes
+the country surgeon and Mrs. Rucastle, so I think, Watson, that we had
+best escort Miss Hunter back to Winchester, as it seems to me that our
+_locus standi_ now is rather a questionable one.”
+
+And thus was solved the mystery of the sinister house with the copper
+beeches in front of the door. Mr. Rucastle survived, but was always a
+broken man, kept alive solely through the care of his devoted wife.
+They still live with their old servants, who probably know so much of
+Rucastle’s past life that he finds it difficult to part from them.
+Mr. Fowler and Miss Rucastle were married, by special license, in
+Southampton the day after their flight, and he is now the holder of a
+Government appointment in the Island of Mauritius. As to Miss Violet
+Hunter, my friend Holmes, rather to my disappointment, manifested no
+further interest in her when once she had ceased to be the centre of
+one of his problems, and she is now the head of a private school at
+Walsall, where I believe that she has met with considerable success.
+
+
+THE END
+
+
+
+
+BY W. D. HOWELLS.
+
+
+  THE QUALITY OF MERCY. A Novel. 12mo, Cloth, $1 50; Paper,
+    75 cents.
+
+  AN IMPERATIVE DUTY. A Novel. 12mo, Cloth, $1 00.
+
+  A HAZARD OF NEW FORTUNES. A Novel. 2 Volumes. 12mo, Cloth,
+    $2 00; Illustrated. 12mo, Paper, $1 00.
+
+  THE SHADOW OF A DREAM. A Story. 12mo, Cloth, $1 00; Paper,
+    50 cents.
+
+  ANNIE KILBURN. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  APRIL HOPES. A Novel. 12mo, Cloth, $1 50; Paper, 75 cents.
+
+  CHRISTMAS EVERY DAY, AND OTHER STORIES. Illustrated. Post 8vo,
+    Cloth, $1 25.
+
+  A BOY’S TOWN. Illustrated. Post 8vo, Cloth, $1 25.
+
+  CRITICISM AND FICTION. With Portrait. 16mo, Cloth, $1 00.
+
+  MODERN ITALIAN POETS. With Portraits. 12mo, Half Cloth, $2 00.
+
+  THE MOUSE-TRAP, AND OTHER FARCES. Illustrated. 12mo, Cloth,
+    $1 00.
+
+  A LETTER OF INTRODUCTION. A Farce. Illustrated. 32mo, Cloth,
+    50 cents.
+
+  A LITTLE SWISS SOJOURN. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE ALBANY DEPOT. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+  THE GARROTERS. A Farce. Illustrated. 32mo, Cloth, 50 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above works are for sale by all booksellers, or will be sent
+by the publishers, postage prepaid, to any part of the United States,
+Canada, or Mexico, on receipt of the price._
+
+
+
+
+R. D. BLACKMORE’S NOVELS.
+
+
+His descriptions are wonderfully vivid and natural. His pages are
+brightened everywhere with great humor; the quaint, dry turns of
+thought remind you occasionally of Fielding.—_London Times._
+
+Mr. Blackmore always writes like a scholar and a
+gentleman—_Athenæum_, London.
+
+His tales, all of them, are pre-eminently meritorious. They are
+remarkable for their careful elaboration, the conscientious finish of
+their workmanship, their affluence of striking dramatic and narrative
+incident, their close observation and general interpretation of nature,
+their profusion of picturesque description, and their quiet and
+sustained humor. Besides, they are pervaded by a bright and elastic
+atmosphere which diffuses a cheery feeling of healthful and robust
+vigor. While they charm us by their sprightly vivacity and their
+naturalness, they never in the slightest degree transcend the limits
+of delicacy or good taste. While radiating warmth and brightness, they
+are as pure as the new-fallen snow.... Their literary execution is
+admirable, and their dramatic power is as exceptional as their moral
+purity.—_Christian Intelligencer_, N. Y.
+
+  LORNA DOONE. Illustrated. 12mo, Cloth, $1 00; 8vo, Paper,
+    40 cents.
+
+  KIT AND KITTY. 12mo, Cloth, $1 25; Paper, 35 cents.
+
+  SPRINGHAVEN. Illustrated. 12mo, Cloth, $1 50; 4to, Paper,
+    25 cents.
+
+  CHRISTOWELL. 4to, Paper, 20 cents.
+
+  CRADOCK NOWELL. 8vo, Paper, 60 cents.
+
+  EREMA; OR, MY FATHER’S SIN. 8vo, Paper, 50 cents.
+
+  MARY ANERLEY. 16mo, Cloth, $1 00; 4to, Paper, 15 cents.
+
+  TOMMY UPMORE. 16mo, Cloth, 50 cents; Paper, 35 cents; 4to,
+    Paper, 20 cents.
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works will be sent by mail, postage prepaid,
+to any part of the United States, Canada, or Mexico, on receipt of
+the price._
+
+
+
+
+By CAPT. CHARLES KING.
+
+
+  CAMPAIGNING WITH CROOK, AND STORIES OF ARMY LIFE. Post 8vo,
+      Cloth, $1 25.
+
+  A WAR-TIME WOOING. Illustrated by R. F. ZOGBAUM. pp. iv.,
+      196. Post 8vo, Cloth, $1 00.
+
+  BETWEEN THE LINES. A Story of the War. Illustrated by GILBERT
+      GAUL. pp. iv., 312. Post 8vo, Cloth, $1 25.
+
+In all of Captain King’s stories the author holds to lofty ideals of
+manhood and womanhood, and inculcates the lessons of honor, generosity,
+courage, and self-control.—_Literary World_, Boston.
+
+The vivacity and charm which signally distinguish Captain King’s
+pen.... He occupies a position in American literature entirely
+his own.... His is the literature of honest sentiment, pure and
+tender.—_N. Y. Press._
+
+A romance by Captain King is always a pleasure, because he has so
+complete a mastery of the subjects with which he deals.... Captain
+King has few rivals in his domain.... The general tone of Captain
+King’s stories is highly commendable. The heroes are simple, frank,
+and soldierly; the heroines are dignified and maidenly in the most
+unconventional situations.—_Epoch_, N. Y.
+
+All Captain King’s stories are full of spirit and with the true ring
+about them.—_Philadelphia Item._
+
+Captain King’s stories of army life are so brilliant and intense, they
+have such a ring of true experience, and his characters are so lifelike
+and vivid that the announcement of a new one is always received with
+pleasure.—_New Haven Palladium._
+
+Captain King is a delightful story-teller.—_Washington Post._
+
+In the delineation of war scenes Captain King’s style is crisp and
+vigorous, inspiring in the breast of the reader a thrill of genuine
+patriotic fervor.—_Boston Commonwealth._
+
+Captain King is almost without a rival in the field he has chosen....
+His style is at once vigorous and sentimental in the best sense of that
+word, so that his novels are pleasing to young men as well as young
+women.—_Pittsburgh Bulletin._
+
+It is good to think that there is at least one man who believes that
+all the spirit of romance and chivalry has not yet died out of the
+world, and that there are as brave and honest hearts to-day as there
+were in the days of knights and paladins.—_Philadelphia Record._
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _Any of the above works sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+BEN-HUR: A TALE OF THE CHRIST.
+
+
+  By LEW. WALLACE. 16mo, Cloth, $1 50. _Garfield Edition._
+    Two Volumes. Twenty Full-page Photogravures. Over 1000
+    Illustrations as Marginal Drawings by WILLIAM MARTIN JOHNSON.
+    Crown 8vo, Printed on Fine Super-calendered Plate-paper, Uncut
+    Edges and Gilt Tops, Bound in Silk and Gold, $7 00. (_In a
+    Gladstone Box._)
+
+Anything so startling, new, and distinctive as the leading feature of
+this romance does not often appear in works of fiction.... Some of Mr.
+Wallace’s writing is remarkable for its pathetic eloquence. The scenes
+described in the New Testament are rewritten with the power and skill
+of an accomplished master of style.—_N. Y. Times._
+
+Its real basis is a description of the life of the Jews and Romans
+at the beginning of the Christian era, and this is both forcible and
+brilliant.... We are carried through a surprising variety of scenes;
+we witness a sea-fight, a chariot-race, the internal economy of a
+Roman galley, domestic interiors at Antioch, at Jerusalem, and among
+the tribes of the desert; palaces, prisons, the haunts of dissipated
+Roman youth, the houses of pious families of Israel. There is plenty of
+exciting incident; everything is animated, vivid and glowing.—_N. Y.
+Tribune._
+
+From the opening of the volume to the very close the reader’s interest
+will be kept at the highest pitch, and the novel will be pronounced by
+all one of the greatest novels of the day.—_Boston Post._
+
+“Ben Hur” is interesting, and its characterization is fine and strong.
+Meanwhile it evinces careful study of the period in which the scene
+is laid, and will help those who read it with reasonable attention to
+realize the nature and conditions of Hebrew life in Jerusalem and Roman
+life at Antioch at the time of our Saviour’s advent.—_Examiner_, N. Y.
+
+The book is one of unquestionable power, and will be read with unwonted
+interest by many readers who are weary of the conventional novel and
+romance.—_Boston Journal._
+
+One of the most remarkable and delightful books. It is as real and
+warm as life itself, and as attractive as the grandest and most heroic
+chapters of history.—_Indianapolis Journal._
+
+
+PUBLISHED BY HARPER & BROTHERS, NEW YORK.
+
+—> _The above work will be sent by mail, postage prepaid, to any part
+of the United States, Canada, or Mexico, on receipt of the price._
+
+
+
+
+Transcriber’s Note:
+
+The text published in the original publication has been
+preserved except as follows:
+
+  Punctuation has been standardised.
+
+  Page 5
+  scored by six almost paralled _changed to_
+  scored by six almost parallel
+
+  Page 20
+  Sherlock Holmes’ succinct description _changed to_
+  Sherlock Holmes’s succinct description
+
+  Page 37
+  injustice to hestitate _changed to_
+  injustice to hesitate
+
+  Page 46
+  I saw him that afternoon so enwrapped _changed to_
+  I saw him that afternoon so enrapt
+
+  Page 81
+  his had the natural ef-effect _changed to_
+  his had the natural effect
+
+  Page 87
+  brother and siser; but of course _changed to_
+  brother and sister; but of course
+
+  Page 93
+  at this. Men who had only know _changed to_
+  as this. Men who had only know
+
+  Page 148
+  and we very all quietly entered _changed to_
+  and we all very quietly entered
+
+  Page 156
+  had remarked, the initals “H. B.” _changed to_
+  had remarked, the initials “H. B.”
+
+  Page 161
+  If this fail _changed to_
+  If this fails
+
+  Page 174
+  Gone to the dealer’s, Jim _changed to_
+  Gone to the dealer’s, Jem
+
+  Page 185
+  delirum, sometimes that it _changed to_
+  delirium, sometimes that it
+
+  Page 192
+  The centra portion was in _changed to_
+  The central portion was in
+
+  Page 200
+  waiting silently for for whatever _changed to_
+  waiting silently for whatever
+
+  Page 215
+  save the occasional bright blurr _changed to_
+  save the occasional bright blur
+
+  Page 245
+  a _pâtè de foie gras_ pie _changed to_
+  a _pâté de foie gras_ pie
+
+  Page 250
+  permision, I will now wish _changed to_
+  permission, I will now wish
+
+  Page 293
+  boisterious fashion, and on the whole _changed to_
+  boisterous fashion, and on the whole
+
+  Page 297
+  wrapt in the peaceful beauty _changed to_
+  rapt in the peaceful beauty
+
+
+
+
+
+
+
+End of Project Gutenberg's Adventures of Sherlock Holmes, by A. Conan Doyle
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ADVENTURES OF SHERLOCK HOLMES ***
+
+***** This file should be named 48320-0.txt or 48320-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/4/8/3/2/48320/
+
+Produced by The Online Distributed Proofreading Team at
+http://www.pgdp.net (This file was produced from images
+generously made available by The Internet Archive/American
+Libraries.)
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org/license
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/anderson-fairy-tales.txt
+++ b/jet/tf-idf/src/main/resources/books/anderson-fairy-tales.txt
@@ -1,0 +1,6206 @@
+﻿Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Andersen’s Fairy Tales
+
+Author: Hans Christian Andersen
+
+Posting Date: October 10, 2008 [EBook #1597]
+Release Date: January, 1999
+Last Updated: October 8, 2016
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+
+
+
+Produced by Dianne Bean
+
+
+
+
+
+ANDERSEN’S FAIRY TALES
+
+By Hans Christian Andersen
+
+
+
+CONTENTS
+
+
+     The Emperor’s New Clothes
+     The Swineherd
+     The Real Princess
+     The Shoes of Fortune
+     The Fir Tree
+     The Snow Queen
+     The Leap-Frog
+     The Elderbush
+     The Bell
+     The Old House
+     The Happy Family
+     The Story of a Mother
+     The False Collar
+     The Shadow
+     The Little Match Girl
+     The Dream of Little Tuk
+     The Naughty Boy
+     The Red Shoes
+
+
+
+
+THE EMPEROR’S NEW CLOTHES
+
+Many years ago, there was an Emperor, who was so excessively fond of
+new clothes, that he spent all his money in dress. He did not trouble
+himself in the least about his soldiers; nor did he care to go either to
+the theatre or the chase, except for the opportunities then afforded him
+for displaying his new clothes. He had a different suit for each hour of
+the day; and as of any other king or emperor, one is accustomed to say,
+“he is sitting in council,” it was always said of him, “The Emperor is
+sitting in his wardrobe.”
+
+Time passed merrily in the large town which was his capital; strangers
+arrived every day at the court. One day, two rogues, calling themselves
+weavers, made their appearance. They gave out that they knew how to
+weave stuffs of the most beautiful colors and elaborate patterns, the
+clothes manufactured from which should have the wonderful property of
+remaining invisible to everyone who was unfit for the office he held, or
+who was extraordinarily simple in character.
+
+“These must, indeed, be splendid clothes!” thought the Emperor. “Had I
+such a suit, I might at once find out what men in my realms are unfit
+for their office, and also be able to distinguish the wise from the
+foolish! This stuff must be woven for me immediately.” And he caused
+large sums of money to be given to both the weavers in order that they
+might begin their work directly.
+
+So the two pretended weavers set up two looms, and affected to work very
+busily, though in reality they did nothing at all. They asked for the
+most delicate silk and the purest gold thread; put both into their own
+knapsacks; and then continued their pretended work at the empty looms
+until late at night.
+
+“I should like to know how the weavers are getting on with my cloth,”
+ said the Emperor to himself, after some little time had elapsed; he was,
+however, rather embarrassed, when he remembered that a simpleton, or
+one unfit for his office, would be unable to see the manufacture. To be
+sure, he thought he had nothing to risk in his own person; but yet, he
+would prefer sending somebody else, to bring him intelligence about the
+weavers, and their work, before he troubled himself in the affair. All
+the people throughout the city had heard of the wonderful property the
+cloth was to possess; and all were anxious to learn how wise, or how
+ignorant, their neighbors might prove to be.
+
+“I will send my faithful old minister to the weavers,” said the Emperor
+at last, after some deliberation, “he will be best able to see how the
+cloth looks; for he is a man of sense, and no one can be more suitable
+for his office than he is.”
+
+So the faithful old minister went into the hall, where the knaves were
+working with all their might, at their empty looms. “What can be the
+meaning of this?” thought the old man, opening his eyes very wide. “I
+cannot discover the least bit of thread on the looms.” However, he did
+not express his thoughts aloud.
+
+The impostors requested him very courteously to be so good as to come
+nearer their looms; and then asked him whether the design pleased
+him, and whether the colors were not very beautiful; at the same time
+pointing to the empty frames. The poor old minister looked and looked,
+he could not discover anything on the looms, for a very good reason,
+viz: there was nothing there. “What!” thought he again. “Is it possible
+that I am a simpleton? I have never thought so myself; and no one must
+know it now if I am so. Can it be, that I am unfit for my office? No,
+that must not be said either. I will never confess that I could not see
+the stuff.”
+
+“Well, Sir Minister!” said one of the knaves, still pretending to work.
+“You do not say whether the stuff pleases you.”
+
+“Oh, it is excellent!” replied the old minister, looking at the loom
+through his spectacles. “This pattern, and the colors, yes, I will tell
+the Emperor without delay, how very beautiful I think them.”
+
+“We shall be much obliged to you,” said the impostors, and then they
+named the different colors and described the pattern of the pretended
+stuff. The old minister listened attentively to their words, in order
+that he might repeat them to the Emperor; and then the knaves asked for
+more silk and gold, saying that it was necessary to complete what
+they had begun. However, they put all that was given them into their
+knapsacks; and continued to work with as much apparent diligence as
+before at their empty looms.
+
+The Emperor now sent another officer of his court to see how the men
+were getting on, and to ascertain whether the cloth would soon be
+ready. It was just the same with this gentleman as with the minister;
+he surveyed the looms on all sides, but could see nothing at all but the
+empty frames.
+
+“Does not the stuff appear as beautiful to you, as it did to my lord the
+minister?” asked the impostors of the Emperor’s second ambassador; at
+the same time making the same gestures as before, and talking of the
+design and colors which were not there.
+
+“I certainly am not stupid!” thought the messenger. “It must be, that I
+am not fit for my good, profitable office! That is very odd; however, no
+one shall know anything about it.” And accordingly he praised the stuff
+he could not see, and declared that he was delighted with both colors
+and patterns. “Indeed, please your Imperial Majesty,” said he to his
+sovereign when he returned, “the cloth which the weavers are preparing
+is extraordinarily magnificent.”
+
+The whole city was talking of the splendid cloth which the Emperor had
+ordered to be woven at his own expense.
+
+And now the Emperor himself wished to see the costly manufacture, while
+it was still in the loom. Accompanied by a select number of officers of
+the court, among whom were the two honest men who had already admired
+the cloth, he went to the crafty impostors, who, as soon as they were
+aware of the Emperor’s approach, went on working more diligently than
+ever; although they still did not pass a single thread through the
+looms.
+
+“Is not the work absolutely magnificent?” said the two officers of the
+crown, already mentioned. “If your Majesty will only be pleased to look
+at it! What a splendid design! What glorious colors!” and at the same
+time they pointed to the empty frames; for they imagined that everyone
+else could see this exquisite piece of workmanship.
+
+“How is this?” said the Emperor to himself. “I can see nothing! This
+is indeed a terrible affair! Am I a simpleton, or am I unfit to be an
+Emperor? That would be the worst thing that could happen--Oh! the cloth
+is charming,” said he, aloud. “It has my complete approbation.” And he
+smiled most graciously, and looked closely at the empty looms; for on no
+account would he say that he could not see what two of the officers of
+his court had praised so much. All his retinue now strained their eyes,
+hoping to discover something on the looms, but they could see no more
+than the others; nevertheless, they all exclaimed, “Oh, how beautiful!”
+ and advised his majesty to have some new clothes made from this splendid
+material, for the approaching procession. “Magnificent! Charming!
+Excellent!” resounded on all sides; and everyone was uncommonly gay. The
+Emperor shared in the general satisfaction; and presented the impostors
+with the riband of an order of knighthood, to be worn in their
+button-holes, and the title of “Gentlemen Weavers.”
+
+The rogues sat up the whole of the night before the day on which the
+procession was to take place, and had sixteen lights burning, so that
+everyone might see how anxious they were to finish the Emperor’s new
+suit. They pretended to roll the cloth off the looms; cut the air with
+their scissors; and sewed with needles without any thread in them.
+“See!” cried they, at last. “The Emperor’s new clothes are ready!”
+
+And now the Emperor, with all the grandees of his court, came to the
+weavers; and the rogues raised their arms, as if in the act of holding
+something up, saying, “Here are your Majesty’s trousers! Here is the
+scarf! Here is the mantle! The whole suit is as light as a cobweb;
+one might fancy one has nothing at all on, when dressed in it; that,
+however, is the great virtue of this delicate cloth.”
+
+“Yes indeed!” said all the courtiers, although not one of them could see
+anything of this exquisite manufacture.
+
+“If your Imperial Majesty will be graciously pleased to take off your
+clothes, we will fit on the new suit, in front of the looking glass.”
+
+The Emperor was accordingly undressed, and the rogues pretended to
+array him in his new suit; the Emperor turning round, from side to side,
+before the looking glass.
+
+“How splendid his Majesty looks in his new clothes, and how well they
+fit!” everyone cried out. “What a design! What colors! These are indeed
+royal robes!”
+
+“The canopy which is to be borne over your Majesty, in the procession,
+is waiting,” announced the chief master of the ceremonies.
+
+“I am quite ready,” answered the Emperor. “Do my new clothes fit well?”
+ asked he, turning himself round again before the looking glass, in order
+that he might appear to be examining his handsome suit.
+
+The lords of the bedchamber, who were to carry his Majesty’s train felt
+about on the ground, as if they were lifting up the ends of the mantle;
+and pretended to be carrying something; for they would by no means
+betray anything like simplicity, or unfitness for their office.
+
+So now the Emperor walked under his high canopy in the midst of the
+procession, through the streets of his capital; and all the people
+standing by, and those at the windows, cried out, “Oh! How beautiful
+are our Emperor’s new clothes! What a magnificent train there is to
+the mantle; and how gracefully the scarf hangs!” in short, no one would
+allow that he could not see these much-admired clothes; because, in
+doing so, he would have declared himself either a simpleton or unfit
+for his office. Certainly, none of the Emperor’s various suits, had ever
+made so great an impression, as these invisible ones.
+
+“But the Emperor has nothing at all on!” said a little child.
+
+“Listen to the voice of innocence!” exclaimed his father; and what the
+child had said was whispered from one to another.
+
+“But he has nothing at all on!” at last cried out all the people.
+The Emperor was vexed, for he knew that the people were right; but he
+thought the procession must go on now! And the lords of the bedchamber
+took greater pains than ever, to appear holding up a train, although, in
+reality, there was no train to hold.
+
+
+
+
+THE SWINEHERD
+
+There was once a poor Prince, who had a kingdom. His kingdom was very
+small, but still quite large enough to marry upon; and he wished to
+marry.
+
+It was certainly rather cool of him to say to the Emperor’s daughter,
+“Will you have me?” But so he did; for his name was renowned far and
+wide; and there were a hundred princesses who would have answered,
+“Yes!” and “Thank you kindly.” We shall see what this princess said.
+
+Listen!
+
+It happened that where the Prince’s father lay buried, there grew a rose
+tree--a most beautiful rose tree, which blossomed only once in every
+five years, and even then bore only one flower, but that was a rose!
+It smelt so sweet that all cares and sorrows were forgotten by him who
+inhaled its fragrance.
+
+And furthermore, the Prince had a nightingale, who could sing in such a
+manner that it seemed as though all sweet melodies dwelt in her little
+throat. So the Princess was to have the rose, and the nightingale; and
+they were accordingly put into large silver caskets, and sent to her.
+
+The Emperor had them brought into a large hall, where the Princess was
+playing at “Visiting,” with the ladies of the court; and when she saw
+the caskets with the presents, she clapped her hands for joy.
+
+“Ah, if it were but a little pussy-cat!” said she; but the rose tree,
+with its beautiful rose came to view.
+
+“Oh, how prettily it is made!” said all the court ladies.
+
+“It is more than pretty,” said the Emperor, “it is charming!”
+
+But the Princess touched it, and was almost ready to cry.
+
+“Fie, papa!” said she. “It is not made at all, it is natural!”
+
+“Let us see what is in the other casket, before we get into a bad
+humor,” said the Emperor. So the nightingale came forth and sang so
+delightfully that at first no one could say anything ill-humored of her.
+
+“Superbe! Charmant!” exclaimed the ladies; for they all used to chatter
+French, each one worse than her neighbor.
+
+“How much the bird reminds me of the musical box that belonged to our
+blessed Empress,” said an old knight. “Oh yes! These are the same tones,
+the same execution.”
+
+“Yes! yes!” said the Emperor, and he wept like a child at the
+remembrance.
+
+“I will still hope that it is not a real bird,” said the Princess.
+
+“Yes, it is a real bird,” said those who had brought it. “Well then let
+the bird fly,” said the Princess; and she positively refused to see the
+Prince.
+
+However, he was not to be discouraged; he daubed his face over brown and
+black; pulled his cap over his ears, and knocked at the door.
+
+“Good day to my lord, the Emperor!” said he. “Can I have employment at
+the palace?”
+
+“Why, yes,” said the Emperor. “I want some one to take care of the pigs,
+for we have a great many of them.”
+
+So the Prince was appointed “Imperial Swineherd.” He had a dirty little
+room close by the pigsty; and there he sat the whole day, and worked. By
+the evening he had made a pretty little kitchen-pot. Little bells were
+hung all round it; and when the pot was boiling, these bells tinkled in
+the most charming manner, and played the old melody,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”*
+
+    * “Ah! dear Augustine!
+    All is gone, gone, gone!”
+
+
+But what was still more curious, whoever held his finger in the smoke of
+the kitchen-pot, immediately smelt all the dishes that were cooking on
+every hearth in the city--this, you see, was something quite different
+from the rose.
+
+Now the Princess happened to walk that way; and when she heard the tune,
+she stood quite still, and seemed pleased; for she could play “Lieber
+Augustine”; it was the only piece she knew; and she played it with one
+finger.
+
+“Why there is my piece,” said the Princess. “That swineherd must
+certainly have been well educated! Go in and ask him the price of the
+instrument.”
+
+So one of the court-ladies must run in; however, she drew on wooden
+slippers first.
+
+“What will you take for the kitchen-pot?” said the lady.
+
+“I will have ten kisses from the Princess,” said the swineherd.
+
+“Yes, indeed!” said the lady.
+
+“I cannot sell it for less,” rejoined the swineherd.
+
+“He is an impudent fellow!” said the Princess, and she walked on; but
+when she had gone a little way, the bells tinkled so prettily
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+“Stay,” said the Princess. “Ask him if he will have ten kisses from the
+ladies of my court.”
+
+“No, thank you!” said the swineherd. “Ten kisses from the Princess, or I
+keep the kitchen-pot myself.”
+
+“That must not be, either!” said the Princess. “But do you all stand
+before me that no one may see us.”
+
+And the court-ladies placed themselves in front of her, and spread
+out their dresses--the swineherd got ten kisses, and the Princess--the
+kitchen-pot.
+
+That was delightful! The pot was boiling the whole evening, and the
+whole of the following day. They knew perfectly well what was cooking at
+every fire throughout the city, from the chamberlain’s to the cobbler’s;
+the court-ladies danced and clapped their hands.
+
+“We know who has soup, and who has pancakes for dinner to-day, who has
+cutlets, and who has eggs. How interesting!”
+
+“Yes, but keep my secret, for I am an Emperor’s daughter.”
+
+The swineherd--that is to say--the Prince, for no one knew that he was
+other than an ill-favored swineherd, let not a day pass without working
+at something; he at last constructed a rattle, which, when it was swung
+round, played all the waltzes and jig tunes, which have ever been heard
+since the creation of the world.
+
+“Ah, that is superbe!” said the Princess when she passed by. “I have
+never heard prettier compositions! Go in and ask him the price of the
+instrument; but mind, he shall have no more kisses!”
+
+“He will have a hundred kisses from the Princess!” said the lady who had
+been to ask.
+
+“I think he is not in his right senses!” said the Princess, and walked
+on, but when she had gone a little way, she stopped again. “One must
+encourage art,” said she, “I am the Emperor’s daughter. Tell him he
+shall, as on yesterday, have ten kisses from me, and may take the rest
+from the ladies of the court.”
+
+“Oh--but we should not like that at all!” said they. “What are you
+muttering?” asked the Princess. “If I can kiss him, surely you can.
+Remember that you owe everything to me.” So the ladies were obliged to
+go to him again.
+
+“A hundred kisses from the Princess,” said he, “or else let everyone
+keep his own!”
+
+“Stand round!” said she; and all the ladies stood round her whilst the
+kissing was going on.
+
+“What can be the reason for such a crowd close by the pigsty?” said the
+Emperor, who happened just then to step out on the balcony; he rubbed
+his eyes, and put on his spectacles. “They are the ladies of the
+court; I must go down and see what they are about!” So he pulled up his
+slippers at the heel, for he had trodden them down.
+
+As soon as he had got into the court-yard, he moved very softly, and the
+ladies were so much engrossed with counting the kisses, that all might
+go on fairly, that they did not perceive the Emperor. He rose on his
+tiptoes.
+
+“What is all this?” said he, when he saw what was going on, and he boxed
+the Princess’s ears with his slipper, just as the swineherd was taking
+the eighty-sixth kiss.
+
+“March out!” said the Emperor, for he was very angry; and both Princess
+and swineherd were thrust out of the city.
+
+The Princess now stood and wept, the swineherd scolded, and the rain
+poured down.
+
+“Alas! Unhappy creature that I am!” said the Princess. “If I had but
+married the handsome young Prince! Ah! how unfortunate I am!”
+
+And the swineherd went behind a tree, washed the black and brown color
+from his face, threw off his dirty clothes, and stepped forth in his
+princely robes; he looked so noble that the Princess could not help
+bowing before him.
+
+“I am come to despise thee,” said he. “Thou would’st not have an
+honorable Prince! Thou could’st not prize the rose and the nightingale,
+but thou wast ready to kiss the swineherd for the sake of a trumpery
+plaything. Thou art rightly served.”
+
+He then went back to his own little kingdom, and shut the door of his
+palace in her face. Now she might well sing,
+
+    “Ach! du lieber Augustin,
+    Alles ist weg, weg, weg!”
+
+
+
+
+THE REAL PRINCESS
+
+There was once a Prince who wished to marry a Princess; but then she
+must be a real Princess. He travelled all over the world in hopes of
+finding such a lady; but there was always something wrong. Princesses he
+found in plenty; but whether they were real Princesses it was impossible
+for him to decide, for now one thing, now another, seemed to him not
+quite right about the ladies. At last he returned to his palace quite
+cast down, because he wished so much to have a real Princess for his
+wife.
+
+One evening a fearful tempest arose, it thundered and lightened, and the
+rain poured down from the sky in torrents: besides, it was as dark as
+pitch. All at once there was heard a violent knocking at the door, and
+the old King, the Prince’s father, went out himself to open it.
+
+It was a Princess who was standing outside the door. What with the rain
+and the wind, she was in a sad condition; the water trickled down from
+her hair, and her clothes clung to her body. She said she was a real
+Princess.
+
+“Ah! we shall soon see that!” thought the old Queen-mother; however, she
+said not a word of what she was going to do; but went quietly into the
+bedroom, took all the bed-clothes off the bed, and put three little peas
+on the bedstead. She then laid twenty mattresses one upon another over
+the three peas, and put twenty feather beds over the mattresses.
+
+Upon this bed the Princess was to pass the night.
+
+The next morning she was asked how she had slept. “Oh, very badly
+indeed!” she replied. “I have scarcely closed my eyes the whole night
+through. I do not know what was in my bed, but I had something hard
+under me, and am all over black and blue. It has hurt me so much!”
+
+Now it was plain that the lady must be a real Princess, since she had
+been able to feel the three little peas through the twenty mattresses
+and twenty feather beds. None but a real Princess could have had such a
+delicate sense of feeling.
+
+The Prince accordingly made her his wife; being now convinced that he
+had found a real Princess. The three peas were however put into the
+cabinet of curiosities, where they are still to be seen, provided they
+are not lost.
+
+Wasn’t this a lady of real delicacy?
+
+
+
+
+THE SHOES OF FORTUNE
+
+I. A Beginning
+
+Every author has some peculiarity in his descriptions or in his style
+of writing. Those who do not like him, magnify it, shrug up their
+shoulders, and exclaim--there he is again! I, for my part, know very
+well how I can bring about this movement and this exclamation. It would
+happen immediately if I were to begin here, as I intended to do, with:
+“Rome has its Corso, Naples its Toledo”--“Ah! that Andersen; there he is
+again!” they would cry; yet I must, to please my fancy, continue quite
+quietly, and add: “But Copenhagen has its East Street.”
+
+Here, then, we will stay for the present. In one of the houses not far
+from the new market a party was invited--a very large party, in order,
+as is often the case, to get a return invitation from the others. One
+half of the company was already seated at the card-table, the other half
+awaited the result of the stereotype preliminary observation of the lady
+of the house:
+
+“Now let us see what we can do to amuse ourselves.”
+
+They had got just so far, and the conversation began to crystallise,
+as it could but do with the scanty stream which the commonplace world
+supplied. Amongst other things they spoke of the middle ages: some
+praised that period as far more interesting, far more poetical than our
+own too sober present; indeed Councillor Knap defended this opinion
+so warmly, that the hostess declared immediately on his side, and both
+exerted themselves with unwearied eloquence. The Councillor boldly
+declared the time of King Hans to be the noblest and the most happy
+period.*
+
+* A.D. 1482-1513
+
+
+While the conversation turned on this subject, and was only for a moment
+interrupted by the arrival of a journal that contained nothing worth
+reading, we will just step out into the antechamber, where cloaks,
+mackintoshes, sticks, umbrellas, and shoes, were deposited. Here sat two
+female figures, a young and an old one. One might have thought at first
+they were servants come to accompany their mistresses home; but on
+looking nearer, one soon saw they could scarcely be mere servants; their
+forms were too noble for that, their skin too fine, the cut of their
+dress too striking. Two fairies were they; the younger, it is true,
+was not Dame Fortune herself, but one of the waiting-maids of her
+handmaidens who carry about the lesser good things that she distributes;
+the other looked extremely gloomy--it was Care. She always attends to
+her own serious business herself, as then she is sure of having it done
+properly.
+
+They were telling each other, with a confidential interchange of ideas,
+where they had been during the day. The messenger of Fortune had only
+executed a few unimportant commissions, such as saving a new bonnet from
+a shower of rain, etc.; but what she had yet to perform was something
+quite unusual.
+
+“I must tell you,” said she, “that to-day is my birthday; and in honor
+of it, a pair of walking-shoes or galoshes has been entrusted to me,
+which I am to carry to mankind. These shoes possess the property of
+instantly transporting him who has them on to the place or the period
+in which he most wishes to be; every wish, as regards time or place, or
+state of being, will be immediately fulfilled, and so at last man will
+be happy, here below.”
+
+“Do you seriously believe it?” replied Care, in a severe tone of
+reproach. “No; he will be very unhappy, and will assuredly bless the
+moment when he feels that he has freed himself from the fatal shoes.”
+
+“Stupid nonsense!” said the other angrily. “I will put them here by
+the door. Some one will make a mistake for certain and take the wrong
+ones--he will be a happy man.”
+
+Such was their conversation.
+
+
+II. What Happened to the Councillor
+
+It was late; Councillor Knap, deeply occupied with the times of King
+Hans, intended to go home, and malicious Fate managed matters so that
+his feet, instead of finding their way to his own galoshes, slipped
+into those of Fortune. Thus caparisoned the good man walked out of the
+well-lighted rooms into East Street. By the magic power of the shoes he
+was carried back to the times of King Hans; on which account his foot
+very naturally sank in the mud and puddles of the street, there having
+been in those days no pavement in Copenhagen.
+
+“Well! This is too bad! How dirty it is here!” sighed the Councillor.
+“As to a pavement, I can find no traces of one, and all the lamps, it
+seems, have gone to sleep.”
+
+The moon was not yet very high; it was besides rather foggy, so that
+in the darkness all objects seemed mingled in chaotic confusion. At the
+next corner hung a votive lamp before a Madonna, but the light it gave
+was little better than none at all; indeed, he did not observe it before
+he was exactly under it, and his eyes fell upon the bright colors of the
+pictures which represented the well-known group of the Virgin and the
+infant Jesus.
+
+“That is probably a wax-work show,” thought he; “and the people delay
+taking down their sign in hopes of a late visitor or two.”
+
+A few persons in the costume of the time of King Hans passed quickly by
+him.
+
+“How strange they look! The good folks come probably from a masquerade!”
+
+Suddenly was heard the sound of drums and fifes; the bright blaze of a
+fire shot up from time to time, and its ruddy gleams seemed to contend
+with the bluish light of the torches. The Councillor stood still, and
+watched a most strange procession pass by. First came a dozen drummers,
+who understood pretty well how to handle their instruments; then came
+halberdiers, and some armed with cross-bows. The principal person in the
+procession was a priest. Astonished at what he saw, the Councillor asked
+what was the meaning of all this mummery, and who that man was.
+
+“That’s the Bishop of Zealand,” was the answer.
+
+“Good Heavens! What has taken possession of the Bishop?” sighed the
+Councillor, shaking his head. It certainly could not be the Bishop; even
+though he was considered the most absent man in the whole kingdom, and
+people told the drollest anecdotes about him. Reflecting on the matter,
+and without looking right or left, the Councillor went through East
+Street and across the Habro-Platz. The bridge leading to Palace Square
+was not to be found; scarcely trusting his senses, the nocturnal
+wanderer discovered a shallow piece of water, and here fell in with two
+men who very comfortably were rocking to and fro in a boat.
+
+“Does your honor want to cross the ferry to the Holme?” asked they.
+
+“Across to the Holme!” said the Councillor, who knew nothing of the age
+in which he at that moment was. “No, I am going to Christianshafen, to
+Little Market Street.”
+
+Both men stared at him in astonishment.
+
+“Only just tell me where the bridge is,” said he. “It is really
+unpardonable that there are no lamps here; and it is as dirty as if one
+had to wade through a morass.”
+
+The longer he spoke with the boatmen, the more unintelligible did their
+language become to him.
+
+“I don’t understand your Bornholmish dialect,” said he at last, angrily,
+and turning his back upon them. He was unable to find the bridge: there
+was no railway either. “It is really disgraceful what a state this place
+is in,” muttered he to himself. Never had his age, with which, however,
+he was always grumbling, seemed so miserable as on this evening. “I’ll
+take a hackney-coach!” thought he. But where were the hackney-coaches?
+Not one was to be seen.
+
+“I must go back to the New Market; there, it is to be hoped, I
+shall find some coaches; for if I don’t, I shall never get safe to
+Christianshafen.”
+
+So off he went in the direction of East Street, and had nearly got to
+the end of it when the moon shone forth.
+
+“God bless me! What wooden scaffolding is that which they have set up
+there?” cried he involuntarily, as he looked at East Gate, which, in
+those days, was at the end of East Street.
+
+He found, however, a little side-door open, and through this he went,
+and stepped into our New Market of the present time. It was a huge
+desolate plain; some wild bushes stood up here and there, while across
+the field flowed a broad canal or river. Some wretched hovels for the
+Dutch sailors, resembling great boxes, and after which the place was
+named, lay about in confused disorder on the opposite bank.
+
+“I either behold a fata morgana, or I am regularly tipsy,” whimpered out
+the Councillor. “But what’s this?”
+
+He turned round anew, firmly convinced that he was seriously ill. He
+gazed at the street formerly so well known to him, and now so strange in
+appearance, and looked at the houses more attentively: most of them were
+of wood, slightly put together; and many had a thatched roof.
+
+“No--I am far from well,” sighed he; “and yet I drank only one glass of
+punch; but I cannot suppose it--it was, too, really very wrong to give
+us punch and hot salmon for supper. I shall speak about it at the first
+opportunity. I have half a mind to go back again, and say what I suffer.
+But no, that would be too silly; and Heaven only knows if they are up
+still.”
+
+He looked for the house, but it had vanished.
+
+“It is really dreadful,” groaned he with increasing anxiety; “I cannot
+recognise East Street again; there is not a single decent shop from one
+end to the other! Nothing but wretched huts can I see anywhere; just
+as if I were at Ringstead. Oh! I am ill! I can scarcely bear myself any
+longer. Where the deuce can the house be? It must be here on this very
+spot; yet there is not the slightest idea of resemblance, to such a
+degree has everything changed this night! At all events here are some
+people up and stirring. Oh! oh! I am certainly very ill.”
+
+He now hit upon a half-open door, through a chink of which a faint light
+shone. It was a sort of hostelry of those times; a kind of public-house.
+The room had some resemblance to the clay-floored halls in Holstein; a
+pretty numerous company, consisting of seamen, Copenhagen burghers, and
+a few scholars, sat here in deep converse over their pewter cans, and
+gave little heed to the person who entered.
+
+“By your leave!” said the Councillor to the Hostess, who came bustling
+towards him. “I’ve felt so queer all of a sudden; would you have the
+goodness to send for a hackney-coach to take me to Christianshafen?”
+
+The woman examined him with eyes of astonishment, and shook her head;
+she then addressed him in German. The Councillor thought she did not
+understand Danish, and therefore repeated his wish in German. This, in
+connection with his costume, strengthened the good woman in the belief
+that he was a foreigner. That he was ill, she comprehended directly; so
+she brought him a pitcher of water, which tasted certainly pretty strong
+of the sea, although it had been fetched from the well.
+
+The Councillor supported his head on his hand, drew a long breath, and
+thought over all the wondrous things he saw around him.
+
+“Is this the Daily News of this evening?” he asked mechanically, as he
+saw the Hostess push aside a large sheet of paper.
+
+The meaning of this councillorship query remained, of course, a riddle
+to her, yet she handed him the paper without replying. It was a coarse
+wood-cut, representing a splendid meteor “as seen in the town of
+Cologne,” which was to be read below in bright letters.
+
+“That is very old!” said the Councillor, whom this piece of antiquity
+began to make considerably more cheerful. “Pray how did you come into
+possession of this rare print? It is extremely interesting, although the
+whole is a mere fable. Such meteorous appearances are to be explained in
+this way--that they are the reflections of the Aurora Borealis, and it
+is highly probable they are caused principally by electricity.”
+
+Those persons who were sitting nearest him and heard his speech,
+stared at him in wonderment; and one of them rose, took off his hat
+respectfully, and said with a serious countenance, “You are no doubt a
+very learned man, Monsieur.”
+
+“Oh no,” answered the Councillor, “I can only join in conversation on
+this topic and on that, as indeed one must do according to the demands
+of the world at present.”
+
+“Modestia is a fine virtue,” continued the gentleman; “however, as to
+your speech, I must say mihi secus videtur: yet I am willing to suspend
+my judicium.”
+
+“May I ask with whom I have the pleasure of speaking?” asked the
+Councillor.
+
+“I am a Bachelor in Theologia,” answered the gentleman with a stiff
+reverence.
+
+This reply fully satisfied the Councillor; the title suited the dress.
+“He is certainly,” thought he, “some village schoolmaster--some queer
+old fellow, such as one still often meets with in Jutland.”
+
+“This is no locus docendi, it is true,” began the clerical gentleman;
+“yet I beg you earnestly to let us profit by your learning. Your reading
+in the ancients is, sine dubio, of vast extent?”
+
+“Oh yes, I’ve read something, to be sure,” replied the Councillor. “I
+like reading all useful works; but I do not on that account despise the
+modern ones; ‘tis only the unfortunate ‘Tales of Every-day Life’ that I
+cannot bear--we have enough and more than enough such in reality.”
+
+“‘Tales of Every-day Life?’” said our Bachelor inquiringly.
+
+“I mean those new fangled novels, twisting and writhing themselves in
+the dust of commonplace, which also expect to find a reading public.”
+
+“Oh,” exclaimed the clerical gentleman smiling, “there is much wit in
+them; besides they are read at court. The King likes the history of Sir
+Iffven and Sir Gaudian particularly, which treats of King Arthur, and
+his Knights of the Round Table; he has more than once joked about it
+with his high vassals.”
+
+“I have not read that novel,” said the Councillor; “it must be quite a
+new one, that Heiberg has published lately.”
+
+“No,” answered the theologian of the time of King Hans: “that book is
+not written by a Heiberg, but was imprinted by Godfrey von Gehmen.”
+
+“Oh, is that the author’s name?” said the Councillor. “It is a very
+old name, and, as well as I recollect, he was the first printer that
+appeared in Denmark.”
+
+“Yes, he is our first printer,” replied the clerical gentleman hastily.
+
+So far all went on well. Some one of the worthy burghers now spoke of
+the dreadful pestilence that had raged in the country a few years back,
+meaning that of 1484. The Councillor imagined it was the cholera that
+was meant, which people made so much fuss about; and the discourse
+passed off satisfactorily enough. The war of the buccaneers of 1490 was
+so recent that it could not fail being alluded to; the English
+pirates had, they said, most shamefully taken their ships while in the
+roadstead; and the Councillor, before whose eyes the Herostratic [*]
+event of 1801 still floated vividly, agreed entirely with the others in
+abusing the rascally English. With other topics he was not so fortunate;
+every moment brought about some new confusion, and threatened to become
+a perfect Babel; for the worthy Bachelor was really too ignorant, and
+the simplest observations of the Councillor sounded to him too daring
+and phantastical. They looked at one another from the crown of the head
+to the soles of the feet; and when matters grew to too high a
+pitch, then the Bachelor talked Latin, in the hope of being better
+understood--but it was of no use after all.
+
+     * Herostratus, or Eratostratus--an Ephesian, who wantonly
+     set fire to the famous temple of Diana, in order to
+     commemorate his name by so uncommon an action.
+
+“What’s the matter?” asked the Hostess, plucking the Councillor by the
+sleeve; and now his recollection returned, for in the course of the
+conversation he had entirely forgotten all that had preceded it.
+
+“Merciful God, where am I!” exclaimed he in agony; and while he so
+thought, all his ideas and feelings of overpowering dizziness, against
+which he struggled with the utmost power of desperation, encompassed
+him with renewed force. “Let us drink claret and mead, and Bremen beer,”
+ shouted one of the guests--“and you shall drink with us!”
+
+Two maidens approached. One wore a cap of two staring colors, denoting
+the class of persons to which she belonged. They poured out the liquor,
+and made the most friendly gesticulations; while a cold perspiration
+trickled down the back of the poor Councillor.
+
+“What’s to be the end of this! What’s to become of me!” groaned he; but
+he was forced, in spite of his opposition, to drink with the rest. They
+took hold of the worthy man; who, hearing on every side that he was
+intoxicated, did not in the least doubt the truth of this certainly
+not very polite assertion; but on the contrary, implored the ladies
+and gentlemen present to procure him a hackney-coach: they, however,
+imagined he was talking Russian.
+
+Never before, he thought, had he been in such a coarse and ignorant
+company; one might almost fancy the people had turned heathens again.
+“It is the most dreadful moment of my life: the whole world is leagued
+against me!” But suddenly it occurred to him that he might stoop down
+under the table, and then creep unobserved out of the door. He did so;
+but just as he was going, the others remarked what he was about; they
+laid hold of him by the legs; and now, happily for him, off fell his
+fatal shoes--and with them the charm was at an end.
+
+The Councillor saw quite distinctly before him a lantern burning, and
+behind this a large handsome house. All seemed to him in proper order as
+usual; it was East Street, splendid and elegant as we now see it. He lay
+with his feet towards a doorway, and exactly opposite sat the watchman
+asleep.
+
+“Gracious Heaven!” said he. “Have I lain here in the street and dreamed?
+Yes; ‘tis East Street! How splendid and light it is! But really it is
+terrible what an effect that one glass of punch must have had on me!”
+
+Two minutes later, he was sitting in a hackney-coach and driving to
+Frederickshafen. He thought of the distress and agony he had endured,
+and praised from the very bottom of his heart the happy reality--our own
+time--which, with all its deficiencies, is yet much better than that in
+which, so much against his inclination, he had lately been.
+
+
+III. The Watchman’s Adventure
+
+“Why, there is a pair of galoshes, as sure as I’m alive!” said the
+watchman, awaking from a gentle slumber. “They belong no doubt to the
+lieutenant who lives over the way. They lie close to the door.”
+
+The worthy man was inclined to ring and deliver them at the house, for
+there was still a light in the window; but he did not like disturbing
+the other people in their beds, and so very considerately he left the
+matter alone.
+
+“Such a pair of shoes must be very warm and comfortable,” said he; “the
+leather is so soft and supple.” They fitted his feet as though they
+had been made for him. “‘Tis a curious world we live in,” continued he,
+soliloquizing. “There is the lieutenant, now, who might go quietly to
+bed if he chose, where no doubt he could stretch himself at his ease;
+but does he do it? No; he saunters up and down his room, because,
+probably, he has enjoyed too many of the good things of this world at
+his dinner. That’s a happy fellow! He has neither an infirm mother, nor
+a whole troop of everlastingly hungry children to torment him. Every
+evening he goes to a party, where his nice supper costs him nothing:
+would to Heaven I could but change with him! How happy should I be!”
+
+While expressing his wish, the charm of the shoes, which he had put on,
+began to work; the watchman entered into the being and nature of the
+lieutenant. He stood in the handsomely furnished apartment, and held
+between his fingers a small sheet of rose-colored paper, on which some
+verses were written--written indeed by the officer himself; for who has
+not, at least once in his life, had a lyrical moment? And if one then
+marks down one’s thoughts, poetry is produced. But here was written:
+
+                  OH, WERE I RICH!
+
+     “Oh, were I rich! Such was my wish, yea such
+      When hardly three feet high, I longed for much.
+       Oh, were I rich! an officer were I,
+       With sword, and uniform, and plume so high.
+       And the time came, and officer was I!
+     But yet I grew not rich. Alas, poor me!
+     Have pity, Thou, who all man’s wants dost see.
+
+        “I sat one evening sunk in dreams of bliss,
+      A maid of seven years old gave me a kiss,
+       I at that time was rich in poesy
+       And tales of old, though poor as poor could be;
+       But all she asked for was this poesy.
+     Then was I rich, but not in gold, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich! Oft asked I for this boon.
+      The child grew up to womanhood full soon.
+       She is so pretty, clever, and so kind
+     Oh, did she know what’s hidden in my mind--
+       A tale of old. Would she to me were kind!
+     But I’m condemned to silence! oh, poor me!
+     As Thou dost know, who all men’s hearts canst see.
+
+        “Oh, were I rich in calm and peace of mind,
+      My grief you then would not here written find!
+       O thou, to whom I do my heart devote,
+       Oh read this page of glad days now remote,
+       A dark, dark tale, which I tonight devote!
+     Dark is the future now. Alas, poor me!
+     Have pity Thou, who all men’s pains dost see.”
+
+Such verses as these people write when they are in love! But no man
+in his senses ever thinks of printing them. Here one of the sorrows of
+life, in which there is real poetry, gave itself vent; not that
+barren grief which the poet may only hint at, but never depict in its
+detail--misery and want: that animal necessity, in short, to snatch
+at least at a fallen leaf of the bread-fruit tree, if not at the fruit
+itself. The higher the position in which one finds oneself transplanted,
+the greater is the suffering. Everyday necessity is the stagnant pool of
+life--no lovely picture reflects itself therein. Lieutenant, love, and
+lack of money--that is a symbolic triangle, or much the same as the
+half of the shattered die of Fortune. This the lieutenant felt most
+poignantly, and this was the reason he leant his head against the
+window, and sighed so deeply.
+
+“The poor watchman out there in the street is far happier than I. He
+knows not what I term privation. He has a home, a wife, and children,
+who weep with him over his sorrows, who rejoice with him when he is
+glad. Oh, far happier were I, could I exchange with him my being--with
+his desires and with his hopes perform the weary pilgrimage of life! Oh,
+he is a hundred times happier than I!”
+
+In the same moment the watchman was again watchman. It was the shoes
+that caused the metamorphosis by means of which, unknown to himself, he
+took upon him the thoughts and feelings of the officer; but, as we have
+just seen, he felt himself in his new situation much less contented,
+and now preferred the very thing which but some minutes before he had
+rejected. So then the watchman was again watchman.
+
+“That was an unpleasant dream,” said he; “but ‘twas droll enough
+altogether. I fancied that I was the lieutenant over there: and yet
+the thing was not very much to my taste after all. I missed my good old
+mother and the dear little ones; who almost tear me to pieces for sheer
+love.”
+
+He seated himself once more and nodded: the dream continued to haunt
+him, for he still had the shoes on his feet. A falling star shone in the
+dark firmament.
+
+“There falls another star,” said he: “but what does it matter; there
+are always enough left. I should not much mind examining the little
+glimmering things somewhat nearer, especially the moon; for that would
+not slip so easily through a man’s fingers. When we die--so at least
+says the student, for whom my wife does the washing--we shall fly about
+as light as a feather from one such a star to the other. That’s, of
+course, not true: but ‘twould be pretty enough if it were so. If I could
+but once take a leap up there, my body might stay here on the steps for
+what I care.”
+
+Behold--there are certain things in the world to which one ought never
+to give utterance except with the greatest caution; but doubly careful
+must one be when we have the Shoes of Fortune on our feet. Now just
+listen to what happened to the watchman.
+
+As to ourselves, we all know the speed produced by the employment of
+steam; we have experienced it either on railroads, or in boats when
+crossing the sea; but such a flight is like the travelling of a sloth in
+comparison with the velocity with which light moves. It flies nineteen
+million times faster than the best race-horse; and yet electricity is
+quicker still. Death is an electric shock which our heart receives; the
+freed soul soars upwards on the wings of electricity. The sun’s light
+wants eight minutes and some seconds to perform a journey of more than
+twenty million of our Danish [*] miles; borne by electricity, the soul
+wants even some minutes less to accomplish the same flight. To it the
+space between the heavenly bodies is not greater than the distance
+between the homes of our friends in town is for us, even if they live a
+short way from each other; such an electric shock in the heart, however,
+costs us the use of the body here below; unless, like the watchman of
+East Street, we happen to have on the Shoes of Fortune.
+
+     * A Danish mile is nearly 4 3/4 English.
+
+
+In a few seconds the watchman had done the fifty-two thousand of our
+miles up to the moon, which, as everyone knows, was formed out of
+matter much lighter than our earth; and is, so we should say, as soft
+as newly-fallen snow. He found himself on one of the many circumjacent
+mountain-ridges with which we are acquainted by means of Dr. Madler’s
+“Map of the Moon.” Within, down it sunk perpendicularly into a caldron,
+about a Danish mile in depth; while below lay a town, whose appearance
+we can, in some measure, realize to ourselves by beating the white of
+an egg in a glass of water. The matter of which it was built was just as
+soft, and formed similar towers, and domes, and pillars, transparent and
+rocking in the thin air; while above his head our earth was rolling like
+a large fiery ball.
+
+He perceived immediately a quantity of beings who were certainly what
+we call “men”; yet they looked different to us. A far more correct
+imagination than that of the pseudo-Herschel* had created them; and
+if they had been placed in rank and file, and copied by some skilful
+painter’s hand, one would, without doubt, have exclaimed involuntarily,
+“What a beautiful arabesque!”
+
+*This relates to a book published some years ago in Germany, and said
+to be by Herschel, which contained a description of the moon and its
+inhabitants, written with such a semblance of truth that many were
+deceived by the imposture.
+
+Probably a translation of the celebrated Moon hoax, written by Richard
+A. Locke, and originally published in New York.
+
+
+They had a language too; but surely nobody can expect that the soul of
+the watchman should understand it. Be that as it may, it did comprehend
+it; for in our souls there germinate far greater powers than we poor
+mortals, despite all our cleverness, have any notion of. Does she
+not show us--she the queen in the land of enchantment--her astounding
+dramatic talent in all our dreams? There every acquaintance appears and
+speaks upon the stage, so entirely in character, and with the same tone
+of voice, that none of us, when awake, were able to imitate it. How
+well can she recall persons to our mind, of whom we have not thought for
+years; when suddenly they step forth “every inch a man,” resembling the
+real personages, even to the finest features, and become the heroes
+or heroines of our world of dreams. In reality, such remembrances are
+rather unpleasant: every sin, every evil thought, may, like a clock with
+alarm or chimes, be repeated at pleasure; then the question is if we can
+trust ourselves to give an account of every unbecoming word in our heart
+and on our lips.
+
+The watchman’s spirit understood the language of the inhabitants of the
+moon pretty well. The Selenites* disputed variously about our earth,
+and expressed their doubts if it could be inhabited: the air, they said,
+must certainly be too dense to allow any rational dweller in the moon
+the necessary free respiration. They considered the moon alone to
+be inhabited: they imagined it was the real heart of the universe or
+planetary system, on which the genuine Cosmopolites, or citizens of the
+world, dwelt. What strange things men--no, what strange things Selenites
+sometimes take into their heads!
+
+* Dwellers in the moon.
+
+
+About politics they had a good deal to say. But little Denmark must
+take care what it is about, and not run counter to the moon; that
+great realm, that might in an ill-humor bestir itself, and dash down a
+hail-storm in our faces, or force the Baltic to overflow the sides of
+its gigantic basin.
+
+We will, therefore, not listen to what was spoken, and on no condition
+run in the possibility of telling tales out of school; but we will
+rather proceed, like good quiet citizens, to East Street, and observe
+what happened meanwhile to the body of the watchman.
+
+He sat lifeless on the steps: the morning-star,* that is to say, the
+heavy wooden staff, headed with iron spikes, and which had nothing else
+in common with its sparkling brother in the sky, had glided from his
+hand; while his eyes were fixed with glassy stare on the moon, looking
+for the good old fellow of a spirit which still haunted it.
+
+*The watchmen in Germany, had formerly, and in some places they still
+carry with them, on their rounds at night, a sort of mace or club, known
+in ancient times by the above denomination.
+
+
+“What’s the hour, watchman?” asked a passer-by. But when the watchman
+gave no reply, the merry roysterer, who was now returning home from a
+noisy drinking bout, took it into his head to try what a tweak of the
+nose would do, on which the supposed sleeper lost his balance, the body
+lay motionless, stretched out on the pavement: the man was dead. When
+the patrol came up, all his comrades, who comprehended nothing of the
+whole affair, were seized with a dreadful fright, for dead he was,
+and he remained so. The proper authorities were informed of the
+circumstance, people talked a good deal about it, and in the morning the
+body was carried to the hospital.
+
+Now that would be a very pretty joke, if the spirit when it came back
+and looked for the body in East Street, were not to find one. No doubt
+it would, in its anxiety, run off to the police, and then to the
+“Hue and Cry” office, to announce that “the finder will be handsomely
+rewarded,” and at last away to the hospital; yet we may boldly assert
+that the soul is shrewdest when it shakes off every fetter, and every
+sort of leading-string--the body only makes it stupid.
+
+The seemingly dead body of the watchman wandered, as we have said, to
+the hospital, where it was brought into the general viewing-room:
+and the first thing that was done here was naturally to pull off the
+galoshes--when the spirit, that was merely gone out on adventures, must
+have returned with the quickness of lightning to its earthly tenement.
+It took its direction towards the body in a straight line; and a few
+seconds after, life began to show itself in the man. He asserted that
+the preceding night had been the worst that ever the malice of fate had
+allotted him; he would not for two silver marks again go through what he
+had endured while moon-stricken; but now, however, it was over.
+
+The same day he was discharged from the hospital as perfectly cured; but
+the Shoes meanwhile remained behind.
+
+
+IV. A Moment of Head Importance--An Evening’s “Dramatic Readings”--A
+Most Strange Journey
+
+Every inhabitant of Copenhagen knows, from personal inspection, how
+the entrance to Frederick’s Hospital looks; but as it is possible that
+others, who are not Copenhagen people, may also read this little work,
+we will beforehand give a short description of it.
+
+The extensive building is separated from the street by a pretty high
+railing, the thick iron bars of which are so far apart, that in
+all seriousness, it is said, some very thin fellow had of a night
+occasionally squeezed himself through to go and pay his little visits
+in the town. The part of the body most difficult to manage on such
+occasions was, no doubt, the head; here, as is so often the case in
+the world, long-headed people get through best. So much, then, for the
+introduction.
+
+One of the young men, whose head, in a physical sense only, might be
+said to be of the thickest, had the watch that evening. The rain poured
+down in torrents; yet despite these two obstacles, the young man was
+obliged to go out, if it were but for a quarter of an hour; and as
+to telling the door-keeper about it, that, he thought, was quite
+unnecessary, if, with a whole skin, he were able to slip through the
+railings. There, on the floor lay the galoshes, which the watchman
+had forgotten; he never dreamed for a moment that they were those of
+Fortune; and they promised to do him good service in the wet; so he put
+them on. The question now was, if he could squeeze himself through the
+grating, for he had never tried before. Well, there he stood.
+
+“Would to Heaven I had got my head through!” said he, involuntarily; and
+instantly through it slipped, easily and without pain, notwithstanding
+it was pretty large and thick. But now the rest of the body was to be
+got through!
+
+“Ah! I am much too stout,” groaned he aloud, while fixed as in a vice.
+“I had thought the head was the most difficult part of the matter--oh!
+oh! I really cannot squeeze myself through!”
+
+He now wanted to pull his over-hasty head back again, but he could not.
+For his neck there was room enough, but for nothing more. His first
+feeling was of anger; his next that his temper fell to zero. The
+Shoes of Fortune had placed him in the most dreadful situation; and,
+unfortunately, it never occurred to him to wish himself free. The
+pitch-black clouds poured down their contents in still heavier torrents;
+not a creature was to be seen in the streets. To reach up to the bell
+was what he did not like; to cry aloud for help would have availed him
+little; besides, how ashamed would he have been to be found caught in a
+trap, like an outwitted fox! How was he to twist himself through! He saw
+clearly that it was his irrevocable destiny to remain a prisoner till
+dawn, or, perhaps, even late in the morning; then the smith must be
+fetched to file away the bars; but all that would not be done so quickly
+as he could think about it. The whole Charity School, just opposite,
+would be in motion; all the new booths, with their not very
+courtier-like swarm of seamen, would join them out of curiosity, and
+would greet him with a wild “hurrah!” while he was standing in his
+pillory: there would be a mob, a hissing, and rejoicing, and jeering,
+ten times worse than in the rows about the Jews some years ago--“Oh, my
+blood is mounting to my brain; ‘tis enough to drive one mad! I shall go
+wild! I know not what to do. Oh! were I but loose; my dizziness would
+then cease; oh, were my head but loose!”
+
+You see he ought to have said that sooner; for the moment he expressed
+the wish his head was free; and cured of all his paroxysms of love, he
+hastened off to his room, where the pains consequent on the fright the
+Shoes had prepared for him, did not so soon take their leave.
+
+But you must not think that the affair is over now; it grows much worse.
+
+The night passed, the next day also; but nobody came to fetch the Shoes.
+
+In the evening “Dramatic Readings” were to be given at the little
+theatre in King Street. The house was filled to suffocation; and among
+other pieces to be recited was a new poem by H. C. Andersen, called, My
+Aunt’s Spectacles; the contents of which were pretty nearly as follows:
+
+“A certain person had an aunt, who boasted of particular skill in
+fortune-telling with cards, and who was constantly being stormed by
+persons that wanted to have a peep into futurity. But she was full of
+mystery about her art, in which a certain pair of magic spectacles
+did her essential service. Her nephew, a merry boy, who was his aunt’s
+darling, begged so long for these spectacles, that, at last, she lent
+him the treasure, after having informed him, with many exhortations,
+that in order to execute the interesting trick, he need only repair to
+some place where a great many persons were assembled; and then, from a
+higher position, whence he could overlook the crowd, pass the company in
+review before him through his spectacles. Immediately ‘the inner man’ of
+each individual would be displayed before him, like a game of cards, in
+which he unerringly might read what the future of every person presented
+was to be. Well pleased the little magician hastened away to prove the
+powers of the spectacles in the theatre; no place seeming to him more
+fitted for such a trial. He begged permission of the worthy audience,
+and set his spectacles on his nose. A motley phantasmagoria presents
+itself before him, which he describes in a few satirical touches, yet
+without expressing his opinion openly: he tells the people enough to set
+them all thinking and guessing; but in order to hurt nobody, he wraps
+his witty oracular judgments in a transparent veil, or rather in a lurid
+thundercloud, shooting forth bright sparks of wit, that they may fall in
+the powder-magazine of the expectant audience.”
+
+The humorous poem was admirably recited, and the speaker much applauded.
+Among the audience was the young man of the hospital, who seemed to have
+forgotten his adventure of the preceding night. He had on the Shoes; for
+as yet no lawful owner had appeared to claim them; and besides it was so
+very dirty out-of-doors, they were just the thing for him, he thought.
+
+The beginning of the poem he praised with great generosity: he even
+found the idea original and effective. But that the end of it, like the
+Rhine, was very insignificant, proved, in his opinion, the author’s
+want of invention; he was without genius, etc. This was an excellent
+opportunity to have said something clever.
+
+Meanwhile he was haunted by the idea--he should like to possess such a
+pair of spectacles himself; then, perhaps, by using them circumspectly,
+one would be able to look into people’s hearts, which, he thought, would
+be far more interesting than merely to see what was to happen next year;
+for that we should all know in proper time, but the other never.
+
+“I can now,” said he to himself, “fancy the whole row of ladies and
+gentlemen sitting there in the front row; if one could but see into
+their hearts--yes, that would be a revelation--a sort of bazar. In that
+lady yonder, so strangely dressed, I should find for certain a large
+milliner’s shop; in that one the shop is empty, but it wants cleaning
+plain enough. But there would also be some good stately shops among
+them. Alas!” sighed he, “I know one in which all is stately; but there
+sits already a spruce young shopman, which is the only thing that’s
+amiss in the whole shop. All would be splendidly decked out, and we
+should hear, ‘Walk in, gentlemen, pray walk in; here you will find all
+you please to want.’ Ah! I wish to Heaven I could walk in and take a
+trip right through the hearts of those present!”
+
+And behold! to the Shoes of Fortune this was the cue; the whole man
+shrunk together and a most uncommon journey through the hearts of the
+front row of spectators, now began. The first heart through which he
+came, was that of a middle-aged lady, but he instantly fancied himself
+in the room of the “Institution for the cure of the crooked and
+deformed,” where casts of mis-shapen limbs are displayed in naked
+reality on the wall. Yet there was this difference, in the institution
+the casts were taken at the entry of the patient; but here they were
+retained and guarded in the heart while the sound persons went away.
+They were, namely, casts of female friends, whose bodily or mental
+deformities were here most faithfully preserved.
+
+With the snake-like writhings of an idea he glided into another female
+heart; but this seemed to him like a large holy fane. [*] The white dove of
+innocence fluttered over the altar. How gladly would he have sunk upon
+his knees; but he must away to the next heart; yet he still heard the
+pealing tones of the organ, and he himself seemed to have become a newer
+and a better man; he felt unworthy to tread the neighboring sanctuary
+which a poor garret, with a sick bed-rid mother, revealed. But God’s
+warm sun streamed through the open window; lovely roses nodded from
+the wooden flower-boxes on the roof, and two sky-blue birds sang
+rejoicingly, while the sick mother implored God’s richest blessings on
+her pious daughter.
+
+     * temple
+
+
+He now crept on hands and feet through a butcher’s shop; at least on
+every side, and above and below, there was nought but flesh. It was the
+heart of a most respectable rich man, whose name is certain to be found
+in the Directory.
+
+He was now in the heart of the wife of this worthy gentleman. It was an
+old, dilapidated, mouldering dovecot. The husband’s portrait was used as
+a weather-cock, which was connected in some way or other with the doors,
+and so they opened and shut of their own accord, whenever the stern old
+husband turned round.
+
+Hereupon he wandered into a boudoir formed entirely of mirrors, like
+the one in Castle Rosenburg; but here the glasses magnified to an
+astonishing degree. On the floor, in the middle of the room, sat, like a
+Dalai-Lama, the insignificant “Self” of the person, quite confounded at
+his own greatness. He then imagined he had got into a needle-case full
+of pointed needles of every size.
+
+“This is certainly the heart of an old maid,” thought he. But he was
+mistaken. It was the heart of a young military man; a man, as people
+said, of talent and feeling.
+
+In the greatest perplexity, he now came out of the last heart in the
+row; he was unable to put his thoughts in order, and fancied that his
+too lively imagination had run away with him.
+
+“Good Heavens!” sighed he. “I have surely a disposition to madness--‘tis
+dreadfully hot here; my blood boils in my veins and my head is burning
+like a coal.” And he now remembered the important event of the evening
+before, how his head had got jammed in between the iron railings of the
+hospital. “That’s what it is, no doubt,” said he. “I must do something
+in time: under such circumstances a Russian bath might do me good. I
+only wish I were already on the upper bank.” [*]
+
+     *In these Russian (vapor) baths the person extends himself
+     on a bank or form, and as he gets accustomed to the heat,
+     moves to another higher up towards the ceiling, where, of
+     course, the vapor is warmest. In this manner he ascends
+     gradually to the highest.
+
+And so there he lay on the uppermost bank in the vapor-bath; but with
+all his clothes on, in his boots and galoshes, while the hot drops fell
+scalding from the ceiling on his face.
+
+“Holloa!” cried he, leaping down. The bathing attendant, on his side,
+uttered a loud cry of astonishment when he beheld in the bath, a man
+completely dressed.
+
+The other, however, retained sufficient presence of mind to whisper to
+him, “‘Tis a bet, and I have won it!” But the first thing he did as soon
+as he got home, was to have a large blister put on his chest and back to
+draw out his madness.
+
+The next morning he had a sore chest and a bleeding back; and, excepting
+the fright, that was all that he had gained by the Shoes of Fortune.
+
+
+V. Metamorphosis of the Copying-Clerk
+
+The watchman, whom we have certainly not forgotten, thought meanwhile
+of the galoshes he had found and taken with him to the hospital; he now
+went to fetch them; and as neither the lieutenant, nor anybody else in
+the street, claimed them as his property, they were delivered over to
+the police-office.*
+
+*As on the continent, in all law and police practices nothing is verbal,
+but any circumstance, however trifling, is reduced to writing, the
+labor, as well as the number of papers that thus accumulate, is
+enormous. In a police-office, consequently, we find copying-clerks among
+many other scribes of various denominations, of which, it seems, our
+hero was one.
+
+
+“Why, I declare the Shoes look just like my own,” said one of the
+clerks, eying the newly-found treasure, whose hidden powers, even he,
+sharp as he was, was not able to discover. “One must have more than
+the eye of a shoemaker to know one pair from the other,” said he,
+soliloquizing; and putting, at the same time, the galoshes in search of
+an owner, beside his own in the corner.
+
+“Here, sir!” said one of the men, who panting brought him a tremendous
+pile of papers.
+
+The copying-clerk turned round and spoke awhile with the man about the
+reports and legal documents in question; but when he had finished, and
+his eye fell again on the Shoes, he was unable to say whether those to
+the left or those to the right belonged to him. “At all events it must
+be those which are wet,” thought he; but this time, in spite of his
+cleverness, he guessed quite wrong, for it was just those of Fortune
+which played as it were into his hands, or rather on his feet. And why,
+I should like to know, are the police never to be wrong? So he put them
+on quickly, stuck his papers in his pocket, and took besides a few under
+his arm, intending to look them through at home to make the necessary
+notes. It was noon; and the weather, that had threatened rain, began
+to clear up, while gaily dressed holiday folks filled the streets. “A
+little trip to Fredericksburg would do me no great harm,” thought he;
+“for I, poor beast of burden that I am, have so much to annoy me, that I
+don’t know what a good appetite is. ‘Tis a bitter crust, alas! at which
+I am condemned to gnaw!”
+
+Nobody could be more steady or quiet than this young man; we therefore
+wish him joy of the excursion with all our heart; and it will certainly
+be beneficial for a person who leads so sedentary a life. In the park
+he met a friend, one of our young poets, who told him that the following
+day he should set out on his long-intended tour.
+
+“So you are going away again!” said the clerk. “You are a very free
+and happy being; we others are chained by the leg and held fast to our
+desk.”
+
+“Yes; but it is a chain, friend, which ensures you the blessed bread
+of existence,” answered the poet. “You need feel no care for the coming
+morrow: when you are old, you receive a pension.”
+
+“True,” said the clerk, shrugging his shoulders; “and yet you are
+the better off. To sit at one’s ease and poetise--that is a pleasure;
+everybody has something agreeable to say to you, and you are always your
+own master. No, friend, you should but try what it is to sit from one
+year’s end to the other occupied with and judging the most trivial
+matters.”
+
+The poet shook his head, the copying-clerk did the same. Each one kept
+to his own opinion, and so they separated.
+
+“It’s a strange race, those poets!” said the clerk, who was very fond of
+soliloquizing. “I should like some day, just for a trial, to take such
+nature upon me, and be a poet myself; I am very sure I should make
+no such miserable verses as the others. Today, methinks, is a most
+delicious day for a poet. Nature seems anew to celebrate her awakening
+into life. The air is so unusually clear, the clouds sail on so
+buoyantly, and from the green herbage a fragrance is exhaled that fills
+me with delight. For many a year have I not felt as at this moment.”
+
+We see already, by the foregoing effusion, that he is become a poet; to
+give further proof of it, however, would in most cases be insipid, for
+it is a most foolish notion to fancy a poet different from other men.
+Among the latter there may be far more poetical natures than many an
+acknowledged poet, when examined more closely, could boast of; the
+difference only is, that the poet possesses a better mental memory, on
+which account he is able to retain the feeling and the thought till they
+can be embodied by means of words; a faculty which the others do not
+possess. But the transition from a commonplace nature to one that is
+richly endowed, demands always a more or less breakneck leap over a
+certain abyss which yawns threateningly below; and thus must the sudden
+change with the clerk strike the reader.
+
+“The sweet air!” continued he of the police-office, in his dreamy
+imaginings; “how it reminds me of the violets in the garden of my aunt
+Magdalena! Yes, then I was a little wild boy, who did not go to school
+very regularly. O heavens! ‘tis a long time since I have thought on
+those times. The good old soul! She lived behind the Exchange. She
+always had a few twigs or green shoots in water--let the winter rage
+without as it might. The violets exhaled their sweet breath, whilst I
+pressed against the windowpanes covered with fantastic frost-work the
+copper coin I had heated on the stove, and so made peep-holes.
+What splendid vistas were then opened to my view! What change--what
+magnificence! Yonder in the canal lay the ships frozen up, and deserted
+by their whole crews, with a screaming crow for the sole occupant. But
+when the spring, with a gentle stirring motion, announced her arrival,
+a new and busy life arose; with songs and hurrahs the ice was sawn
+asunder, the ships were fresh tarred and rigged, that they might sail
+away to distant lands. But I have remained here--must always remain
+here, sitting at my desk in the office, and patiently see other people
+fetch their passports to go abroad. Such is my fate! Alas!”--sighed he,
+and was again silent. “Great Heaven! What is come to me! Never have I
+thought or felt like this before! It must be the summer air that affects
+me with feelings almost as disquieting as they are refreshing.”
+
+He felt in his pocket for the papers. “These police-reports will soon
+stem the torrent of my ideas, and effectually hinder any rebellious
+overflowing of the time-worn banks of official duties”; he said to
+himself consolingly, while his eye ran over the first page. “DAME
+TIGBRITH, tragedy in five acts.” “What is that? And yet it is undeniably
+my own handwriting. Have I written the tragedy? Wonderful, very
+wonderful!--And this--what have I here? ‘INTRIGUE ON THE RAMPARTS; or
+THE DAY OF REPENTANCE: vaudeville with new songs to the most favorite
+airs.’ The deuce! Where did I get all this rubbish? Some one must have
+slipped it slyly into my pocket for a joke. There is too a letter to me;
+a crumpled letter and the seal broken.”
+
+Yes; it was not a very polite epistle from the manager of a theatre, in
+which both pieces were flatly refused.
+
+“Hem! hem!” said the clerk breathlessly, and quite exhausted he seated
+himself on a bank. His thoughts were so elastic, his heart so tender;
+and involuntarily he picked one of the nearest flowers. It is a simple
+daisy, just bursting out of the bud. What the botanist tells us after
+a number of imperfect lectures, the flower proclaimed in a minute. It
+related the mythus of its birth, told of the power of the sun-light that
+spread out its delicate leaves, and forced them to impregnate the air
+with their incense--and then he thought of the manifold struggles of
+life, which in like manner awaken the budding flowers of feeling in our
+bosom. Light and air contend with chivalric emulation for the love of
+the fair flower that bestowed her chief favors on the latter; full of
+longing she turned towards the light, and as soon as it vanished, rolled
+her tender leaves together and slept in the embraces of the air. “It is
+the light which adorns me,” said the flower.
+
+“But ‘tis the air which enables thee to breathe,” said the poet’s voice.
+
+Close by stood a boy who dashed his stick into a wet ditch. The drops of
+water splashed up to the green leafy roof, and the clerk thought of the
+million of ephemera which in a single drop were thrown up to a height,
+that was as great doubtless for their size, as for us if we were to
+be hurled above the clouds. While he thought of this and of the whole
+metamorphosis he had undergone, he smiled and said, “I sleep and dream;
+but it is wonderful how one can dream so naturally, and know besides so
+exactly that it is but a dream. If only to-morrow on awaking, I could
+again call all to mind so vividly! I seem in unusually good spirits; my
+perception of things is clear, I feel as light and cheerful as though
+I were in heaven; but I know for a certainty, that if to-morrow a dim
+remembrance of it should swim before my mind, it will then seem nothing
+but stupid nonsense, as I have often experienced already--especially
+before I enlisted under the banner of the police, for that dispels like
+a whirlwind all the visions of an unfettered imagination. All we hear
+or say in a dream that is fair and beautiful is like the gold of the
+subterranean spirits; it is rich and splendid when it is given us, but
+viewed by daylight we find only withered leaves. Alas!” he sighed quite
+sorrowful, and gazed at the chirping birds that hopped contentedly from
+branch to branch, “they are much better off than I! To fly must be a
+heavenly art; and happy do I prize that creature in which it is innate.
+Yes! Could I exchange my nature with any other creature, I fain would be
+such a happy little lark!”
+
+He had hardly uttered these hasty words when the skirts and sleeves
+of his coat folded themselves together into wings; the clothes became
+feathers, and the galoshes claws. He observed it perfectly, and laughed
+in his heart. “Now then, there is no doubt that I am dreaming; but I
+never before was aware of such mad freaks as these.” And up he flew into
+the green roof and sang; but in the song there was no poetry, for the
+spirit of the poet was gone. The Shoes, as is the case with anybody who
+does what he has to do properly, could only attend to one thing at a
+time. He wanted to be a poet, and he was one; he now wished to be a
+merry chirping bird: but when he was metamorphosed into one, the former
+peculiarities ceased immediately. “It is really pleasant enough,” said
+he: “the whole day long I sit in the office amid the driest
+law-papers, and at night I fly in my dream as a lark in the gardens of
+Fredericksburg; one might really write a very pretty comedy upon it.” He
+now fluttered down into the grass, turned his head gracefully on every
+side, and with his bill pecked the pliant blades of grass, which, in
+comparison to his present size, seemed as majestic as the palm-branches
+of northern Africa.
+
+Unfortunately the pleasure lasted but a moment. Presently black night
+overshadowed our enthusiast, who had so entirely missed his part of
+copying-clerk at a police-office; some vast object seemed to be thrown
+over him. It was a large oil-skin cap, which a sailor-boy of the quay
+had thrown over the struggling bird; a coarse hand sought its way
+carefully in under the broad rim, and seized the clerk over the back
+and wings. In the first moment of fear, he called, indeed, as loud as
+he could--“You impudent little blackguard! I am a copying-clerk at
+the police-office; and you know you cannot insult any belonging to the
+constabulary force without a chastisement. Besides, you good-for-nothing
+rascal, it is strictly forbidden to catch birds in the royal gardens of
+Fredericksburg; but your blue uniform betrays where you come from.”
+ This fine tirade sounded, however, to the ungodly sailor-boy like a mere
+“Pippi-pi.” He gave the noisy bird a knock on his beak, and walked on.
+
+He was soon met by two schoolboys of the upper class--that is to say as
+individuals, for with regard to learning they were in the lowest class
+in the school; and they bought the stupid bird. So the copying-clerk
+came to Copenhagen as guest, or rather as prisoner in a family living in
+Gother Street.
+
+“‘Tis well that I’m dreaming,” said the clerk, “or I really should get
+angry. First I was a poet; now sold for a few pence as a lark; no doubt
+it was that accursed poetical nature which has metamorphosed me
+into such a poor harmless little creature. It is really pitiable,
+particularly when one gets into the hands of a little blackguard,
+perfect in all sorts of cruelty to animals: all I should like to know
+is, how the story will end.”
+
+The two schoolboys, the proprietors now of the transformed clerk,
+carried him into an elegant room. A stout stately dame received them
+with a smile; but she expressed much dissatisfaction that a common
+field-bird, as she called the lark, should appear in such high society.
+For to-day, however, she would allow it; and they must shut him in the
+empty cage that was standing in the window. “Perhaps he will amuse my
+good Polly,” added the lady, looking with a benignant smile at a large
+green parrot that swung himself backwards and forwards most comfortably
+in his ring, inside a magnificent brass-wired cage. “To-day is Polly’s
+birthday,” said she with stupid simplicity: “and the little brown
+field-bird must wish him joy.”
+
+Mr. Polly uttered not a syllable in reply, but swung to and fro with
+dignified condescension; while a pretty canary, as yellow as gold, that
+had lately been brought from his sunny fragrant home, began to sing
+aloud.
+
+“Noisy creature! Will you be quiet!” screamed the lady of the house,
+covering the cage with an embroidered white pocket handkerchief.
+
+“Chirp, chirp!” sighed he. “That was a dreadful snowstorm”; and he
+sighed again, and was silent.
+
+The copying-clerk, or, as the lady said, the brown field-bird, was
+put into a small cage, close to the Canary, and not far from “my good
+Polly.” The only human sounds that the Parrot could bawl out
+were, “Come, let us be men!” Everything else that he said was as
+unintelligible to everybody as the chirping of the Canary, except to the
+clerk, who was now a bird too: he understood his companion perfectly.
+
+“I flew about beneath the green palms and the blossoming almond-trees,”
+ sang the Canary; “I flew around, with my brothers and sisters, over
+the beautiful flowers, and over the glassy lakes, where the bright
+water-plants nodded to me from below. There, too, I saw many
+splendidly-dressed paroquets, that told the drollest stories, and the
+wildest fairy tales without end.”
+
+“Oh! those were uncouth birds,” answered the Parrot. “They had no
+education, and talked of whatever came into their head.
+
+“If my mistress and all her friends can laugh at what I say, so may you
+too, I should think. It is a great fault to have no taste for what is
+witty or amusing--come, let us be men.”
+
+“Ah, you have no remembrance of love for the charming maidens that
+danced beneath the outspread tents beside the bright fragrant flowers?
+Do you no longer remember the sweet fruits, and the cooling juice in
+the wild plants of our never-to-be-forgotten home?” said the former
+inhabitant of the Canary Isles, continuing his dithyrambic.
+
+“Oh, yes,” said the Parrot; “but I am far better off here. I am well
+fed, and get friendly treatment. I know I am a clever fellow; and that
+is all I care about. Come, let us be men. You are of a poetical nature,
+as it is called--I, on the contrary, possess profound knowledge and
+inexhaustible wit. You have genius; but clear-sighted, calm discretion
+does not take such lofty flights, and utter such high natural tones.
+For this they have covered you over--they never do the like to me; for
+I cost more. Besides, they are afraid of my beak; and I have always a
+witty answer at hand. Come, let us be men!”
+
+“O warm spicy land of my birth,” sang the Canary bird; “I will sing of
+thy dark-green bowers, of the calm bays where the pendent boughs
+kiss the surface of the water; I will sing of the rejoicing of all my
+brothers and sisters where the cactus grows in wanton luxuriance.”
+
+“Spare us your elegiac tones,” said the Parrot giggling. “Rather speak
+of something at which one may laugh heartily. Laughing is an infallible
+sign of the highest degree of mental development. Can a dog, or a horse
+laugh? No, but they can cry. The gift of laughing was given to man
+alone. Ha! ha! ha!” screamed Polly, and added his stereotype witticism.
+“Come, let us be men!”
+
+“Poor little Danish grey-bird,” said the Canary; “you have been caught
+too. It is, no doubt, cold enough in your woods, but there at least
+is the breath of liberty; therefore fly away. In the hurry they have
+forgotten to shut your cage, and the upper window is open. Fly, my
+friend; fly away. Farewell!”
+
+Instinctively the Clerk obeyed; with a few strokes of his wings he was
+out of the cage; but at the same moment the door, which was only ajar,
+and which led to the next room, began to creak, and supple and creeping
+came the large tomcat into the room, and began to pursue him. The
+frightened Canary fluttered about in his cage; the Parrot flapped his
+wings, and cried, “Come, let us be men!” The Clerk felt a mortal fright,
+and flew through the window, far away over the houses and streets. At
+last he was forced to rest a little.
+
+The neighboring house had a something familiar about it; a window stood
+open; he flew in; it was his own room. He perched upon the table.
+
+“Come, let us be men!” said he, involuntarily imitating the chatter of
+the Parrot, and at the same moment he was again a copying-clerk; but he
+was sitting in the middle of the table.
+
+“Heaven help me!” cried he. “How did I get up here--and so buried in
+sleep, too? After all, that was a very unpleasant, disagreeable dream
+that haunted me! The whole story is nothing but silly, stupid nonsense!”
+
+
+VI. The Best That the Galoshes Gave
+
+The following day, early in the morning, while the Clerk was still in
+bed, someone knocked at his door. It was his neighbor, a young Divine,
+who lived on the same floor. He walked in.
+
+“Lend me your Galoshes,” said he; “it is so wet in the garden, though
+the sun is shining most invitingly. I should like to go out a little.”
+
+He got the Galoshes, and he was soon below in a little duodecimo garden,
+where between two immense walls a plumtree and an apple-tree were
+standing. Even such a little garden as this was considered in the
+metropolis of Copenhagen as a great luxury.
+
+The young man wandered up and down the narrow paths, as well as the
+prescribed limits would allow; the clock struck six; without was heard
+the horn of a post-boy.
+
+“To travel! to travel!” exclaimed he, overcome by most painful and
+passionate remembrances. “That is the happiest thing in the world! That
+is the highest aim of all my wishes! Then at last would the agonizing
+restlessness be allayed, which destroys my existence! But it must be
+far, far away! I would behold magnificent Switzerland; I would travel to
+Italy, and--”
+
+It was a good thing that the power of the Galoshes worked as
+instantaneously as lightning in a powder-magazine would do, otherwise
+the poor man with his overstrained wishes would have travelled about
+the world too much for himself as well as for us. In short, he was
+travelling. He was in the middle of Switzerland, but packed up with
+eight other passengers in the inside of an eternally-creaking diligence;
+his head ached till it almost split, his weary neck could hardly bear
+the heavy load, and his feet, pinched by his torturing boots, were
+terribly swollen. He was in an intermediate state between sleeping and
+waking; at variance with himself, with his company, with the country,
+and with the government. In his right pocket he had his letter of
+credit, in the left, his passport, and in a small leathern purse some
+double louis d’or, carefully sewn up in the bosom of his waistcoat.
+Every dream proclaimed that one or the other of these valuables was
+lost; wherefore he started up as in a fever; and the first movement
+which his hand made, described a magic triangle from the right pocket to
+the left, and then up towards the bosom, to feel if he had them all safe
+or not. From the roof inside the carriage, umbrellas, walking-sticks,
+hats, and sundry other articles were depending, and hindered the view,
+which was particularly imposing. He now endeavored as well as he
+was able to dispel his gloom, which was caused by outward chance
+circumstances merely, and on the bosom of nature imbibe the milk of
+purest human enjoyment.
+
+Grand, solemn, and dark was the whole landscape around. The gigantic
+pine-forests, on the pointed crags, seemed almost like little tufts of
+heather, colored by the surrounding clouds. It began to snow, a cold
+wind blew and roared as though it were seeking a bride.
+
+“Augh!” sighed he, “were we only on the other side the Alps, then we
+should have summer, and I could get my letters of credit cashed. The
+anxiety I feel about them prevents me enjoying Switzerland. Were I but
+on the other side!”
+
+And so saying he was on the other side in Italy, between Florence and
+Rome. Lake Thracymene, illumined by the evening sun, lay like flaming
+gold between the dark-blue mountain-ridges; here, where Hannibal
+defeated Flaminius, the rivers now held each other in their green
+embraces; lovely, half-naked children tended a herd of black swine,
+beneath a group of fragrant laurel-trees, hard by the road-side.
+Could we render this inimitable picture properly, then would everybody
+exclaim, “Beautiful, unparalleled Italy!” But neither the young Divine
+said so, nor anyone of his grumbling companions in the coach of the
+vetturino.
+
+The poisonous flies and gnats swarmed around by thousands; in vain one
+waved myrtle-branches about like mad; the audacious insect population
+did not cease to sting; nor was there a single person in the
+well-crammed carriage whose face was not swollen and sore from their
+ravenous bites. The poor horses, tortured almost to death, suffered most
+from this truly Egyptian plague; the flies alighted upon them in large
+disgusting swarms; and if the coachman got down and scraped them off,
+hardly a minute elapsed before they were there again. The sun now set: a
+freezing cold, though of short duration pervaded the whole creation;
+it was like a horrid gust coming from a burial-vault on a warm summer’s
+day--but all around the mountains retained that wonderful green tone
+which we see in some old pictures, and which, should we not have seen a
+similar play of color in the South, we declare at once to be unnatural.
+It was a glorious prospect; but the stomach was empty, the body tired;
+all that the heart cared and longed for was good night-quarters; yet
+how would they be? For these one looked much more anxiously than for the
+charms of nature, which every where were so profusely displayed.
+
+The road led through an olive-grove, and here the solitary inn was
+situated. Ten or twelve crippled-beggars had encamped outside. The
+healthiest of them resembled, to use an expression of Marryat’s,
+“Hunger’s eldest son when he had come of age”; the others were either
+blind, had withered legs and crept about on their hands, or withered
+arms and fingerless hands. It was the most wretched misery, dragged
+from among the filthiest rags. “Excellenza, miserabili!” sighed they,
+thrusting forth their deformed limbs to view. Even the hostess, with
+bare feet, uncombed hair, and dressed in a garment of doubtful color,
+received the guests grumblingly. The doors were fastened with a loop of
+string; the floor of the rooms presented a stone paving half torn
+up; bats fluttered wildly about the ceiling; and as to the smell
+therein--no--that was beyond description.
+
+“You had better lay the cloth below in the stable,” said one of the
+travellers; “there, at all events, one knows what one is breathing.”
+
+The windows were quickly opened, to let in a little fresh air. Quicker,
+however, than the breeze, the withered, sallow arms of the beggars were
+thrust in, accompanied by the eternal whine of “Miserabili, miserabili,
+excellenza!” On the walls were displayed innumerable inscriptions,
+written in nearly every language of Europe, some in verse, some in
+prose, most of them not very laudatory of “bella Italia.”
+
+The meal was served. It consisted of a soup of salted water, seasoned
+with pepper and rancid oil. The last ingredient played a very prominent
+part in the salad; stale eggs and roasted cocks’-combs furnished the
+grand dish of the repast; the wine even was not without a disgusting
+taste--it was like a medicinal draught.
+
+At night the boxes and other effects of the passengers were placed
+against the rickety doors. One of the travellers kept watch while the
+others slept. The sentry was our young Divine. How close it was in the
+chamber! The heat oppressive to suffocation--the gnats hummed and stung
+unceasingly--the “miserabili” without whined and moaned in their sleep.
+
+“Travelling would be agreeable enough,” said he groaning, “if one only
+had no body, or could send it to rest while the spirit went on its
+pilgrimage unhindered, whither the voice within might call it. Wherever
+I go, I am pursued by a longing that is insatiable--that I cannot
+explain to myself, and that tears my very heart. I want something better
+than what is but what is fled in an instant. But what is it, and where
+is it to be found? Yet, I know in reality what it is I wish for. Oh!
+most happy were I, could I but reach one aim--could but reach the
+happiest of all!”
+
+And as he spoke the word he was again in his home; the long white
+curtains hung down from the windows, and in the middle of the floor
+stood the black coffin; in it he lay in the sleep of death. His wish
+was fulfilled--the body rested, while the spirit went unhindered on its
+pilgrimage. “Let no one deem himself happy before his end,” were the
+words of Solon; and here was a new and brilliant proof of the wisdom of
+the old apothegm.
+
+Every corpse is a sphynx of immortality; here too on the black coffin
+the sphynx gave us no answer to what he who lay within had written two
+days before:
+
+     “O mighty Death! thy silence teaches nought,
+       Thou leadest only to the near grave’s brink;
+      Is broken now the ladder of my thoughts?
+     Do I instead of mounting only sink?
+
+     Our heaviest grief the world oft seeth not,
+      Our sorest pain we hide from stranger eyes:
+      And for the sufferer there is nothing left
+     But the green mound that o’er the coffin lies.”
+
+Two figures were moving in the chamber. We knew them both; it was the
+fairy of Care, and the emissary of Fortune. They both bent over the
+corpse.
+
+“Do you now see,” said Care, “what happiness your Galoshes have brought
+to mankind?”
+
+“To him, at least, who slumbers here, they have brought an imperishable
+blessing,” answered the other.
+
+“Ah no!” replied Care. “He took his departure himself; he was not called
+away. His mental powers here below were not strong enough to reach the
+treasures lying beyond this life, and which his destiny ordained he
+should obtain. I will now confer a benefit on him.”
+
+And she took the Galoshes from his feet; his sleep of death was ended;
+and he who had been thus called back again to life arose from his
+dread couch in all the vigor of youth. Care vanished, and with her the
+Galoshes. She has no doubt taken them for herself, to keep them to all
+eternity.
+
+
+
+
+THE FIR TREE
+
+Out in the woods stood a nice little Fir Tree. The place he had was a
+very good one: the sun shone on him: as to fresh air, there was enough
+of that, and round him grew many large-sized comrades, pines as well as
+firs. But the little Fir wanted so very much to be a grown-up tree.
+
+He did not think of the warm sun and of the fresh air; he did not care
+for the little cottage children that ran about and prattled when they
+were in the woods looking for wild-strawberries. The children often came
+with a whole pitcher full of berries, or a long row of them threaded on
+a straw, and sat down near the young tree and said, “Oh, how pretty he
+is! What a nice little fir!” But this was what the Tree could not bear
+to hear.
+
+At the end of a year he had shot up a good deal, and after another year
+he was another long bit taller; for with fir trees one can always tell
+by the shoots how many years old they are.
+
+“Oh! Were I but such a high tree as the others are,” sighed he. “Then I
+should be able to spread out my branches, and with the tops to look into
+the wide world! Then would the birds build nests among my branches: and
+when there was a breeze, I could bend with as much stateliness as the
+others!”
+
+Neither the sunbeams, nor the birds, nor the red clouds which morning
+and evening sailed above him, gave the little Tree any pleasure.
+
+In winter, when the snow lay glittering on the ground, a hare would
+often come leaping along, and jump right over the little Tree. Oh, that
+made him so angry! But two winters were past, and in the third the Tree
+was so large that the hare was obliged to go round it. “To grow and
+grow, to get older and be tall,” thought the Tree--“that, after all, is
+the most delightful thing in the world!”
+
+In autumn the wood-cutters always came and felled some of the largest
+trees. This happened every year; and the young Fir Tree, that had now
+grown to a very comely size, trembled at the sight; for the magnificent
+great trees fell to the earth with noise and cracking, the branches were
+lopped off, and the trees looked long and bare; they were hardly to be
+recognised; and then they were laid in carts, and the horses dragged
+them out of the wood.
+
+Where did they go to? What became of them?
+
+In spring, when the swallows and the storks came, the Tree asked them,
+“Don’t you know where they have been taken? Have you not met them
+anywhere?”
+
+The swallows did not know anything about it; but the Stork looked
+musing, nodded his head, and said, “Yes; I think I know; I met many
+ships as I was flying hither from Egypt; on the ships were magnificent
+masts, and I venture to assert that it was they that smelt so of fir.
+I may congratulate you, for they lifted themselves on high most
+majestically!”
+
+“Oh, were I but old enough to fly across the sea! But how does the sea
+look in reality? What is it like?”
+
+“That would take a long time to explain,” said the Stork, and with these
+words off he went.
+
+“Rejoice in thy growth!” said the Sunbeams. “Rejoice in thy vigorous
+growth, and in the fresh life that moveth within thee!”
+
+And the Wind kissed the Tree, and the Dew wept tears over him; but the
+Fir understood it not.
+
+When Christmas came, quite young trees were cut down: trees which often
+were not even as large or of the same age as this Fir Tree, who could
+never rest, but always wanted to be off. These young trees, and they
+were always the finest looking, retained their branches; they were laid
+on carts, and the horses drew them out of the wood.
+
+“Where are they going to?” asked the Fir. “They are not taller than
+I; there was one indeed that was considerably shorter; and why do they
+retain all their branches? Whither are they taken?”
+
+“We know! We know!” chirped the Sparrows. “We have peeped in at the
+windows in the town below! We know whither they are taken! The greatest
+splendor and the greatest magnificence one can imagine await them. We
+peeped through the windows, and saw them planted in the middle of the
+warm room and ornamented with the most splendid things, with gilded
+apples, with gingerbread, with toys, and many hundred lights!”
+
+“And then?” asked the Fir Tree, trembling in every bough. “And then?
+What happens then?”
+
+“We did not see anything more: it was incomparably beautiful.”
+
+“I would fain know if I am destined for so glorious a career,” cried
+the Tree, rejoicing. “That is still better than to cross the sea! What
+a longing do I suffer! Were Christmas but come! I am now tall, and my
+branches spread like the others that were carried off last year! Oh!
+were I but already on the cart! Were I in the warm room with all the
+splendor and magnificence! Yes; then something better, something still
+grander, will surely follow, or wherefore should they thus ornament me?
+Something better, something still grander must follow--but what? Oh, how
+I long, how I suffer! I do not know myself what is the matter with me!”
+
+“Rejoice in our presence!” said the Air and the Sunlight. “Rejoice in
+thy own fresh youth!”
+
+But the Tree did not rejoice at all; he grew and grew, and was green
+both winter and summer. People that saw him said, “What a fine tree!”
+ and towards Christmas he was one of the first that was cut down. The axe
+struck deep into the very pith; the Tree fell to the earth with a sigh;
+he felt a pang--it was like a swoon; he could not think of happiness,
+for he was sorrowful at being separated from his home, from the place
+where he had sprung up. He well knew that he should never see his dear
+old comrades, the little bushes and flowers around him, anymore; perhaps
+not even the birds! The departure was not at all agreeable.
+
+The Tree only came to himself when he was unloaded in a court-yard with
+the other trees, and heard a man say, “That one is splendid! We don’t
+want the others.” Then two servants came in rich livery and carried the
+Fir Tree into a large and splendid drawing-room. Portraits were hanging
+on the walls, and near the white porcelain stove stood two large Chinese
+vases with lions on the covers. There, too, were large easy-chairs,
+silken sofas, large tables full of picture-books and full of toys, worth
+hundreds and hundreds of crowns--at least the children said so. And the
+Fir Tree was stuck upright in a cask that was filled with sand; but no
+one could see that it was a cask, for green cloth was hung all round it,
+and it stood on a large gaily-colored carpet. Oh! how the Tree quivered!
+What was to happen? The servants, as well as the young ladies, decorated
+it. On one branch there hung little nets cut out of colored paper, and
+each net was filled with sugarplums; and among the other boughs gilded
+apples and walnuts were suspended, looking as though they had grown
+there, and little blue and white tapers were placed among the leaves.
+Dolls that looked for all the world like men--the Tree had never beheld
+such before--were seen among the foliage, and at the very top a
+large star of gold tinsel was fixed. It was really splendid--beyond
+description splendid.
+
+“This evening!” they all said. “How it will shine this evening!”
+
+“Oh!” thought the Tree. “If the evening were but come! If the tapers
+were but lighted! And then I wonder what will happen! Perhaps the other
+trees from the forest will come to look at me! Perhaps the sparrows will
+beat against the windowpanes! I wonder if I shall take root here, and
+winter and summer stand covered with ornaments!”
+
+He knew very much about the matter--but he was so impatient that for
+sheer longing he got a pain in his back, and this with trees is the same
+thing as a headache with us.
+
+The candles were now lighted--what brightness! What splendor! The
+Tree trembled so in every bough that one of the tapers set fire to the
+foliage. It blazed up famously.
+
+“Help! Help!” cried the young ladies, and they quickly put out the fire.
+
+Now the Tree did not even dare tremble. What a state he was in! He was
+so uneasy lest he should lose something of his splendor, that he was
+quite bewildered amidst the glare and brightness; when suddenly both
+folding-doors opened and a troop of children rushed in as if they would
+upset the Tree. The older persons followed quietly; the little ones
+stood quite still. But it was only for a moment; then they shouted that
+the whole place re-echoed with their rejoicing; they danced round the
+Tree, and one present after the other was pulled off.
+
+“What are they about?” thought the Tree. “What is to happen now!” And
+the lights burned down to the very branches, and as they burned down
+they were put out one after the other, and then the children had
+permission to plunder the Tree. So they fell upon it with such violence
+that all its branches cracked; if it had not been fixed firmly in the
+ground, it would certainly have tumbled down.
+
+The children danced about with their beautiful playthings; no one looked
+at the Tree except the old nurse, who peeped between the branches; but
+it was only to see if there was a fig or an apple left that had been
+forgotten.
+
+“A story! A story!” cried the children, drawing a little fat man towards
+the Tree. He seated himself under it and said, “Now we are in the shade,
+and the Tree can listen too. But I shall tell only one story. Now which
+will you have; that about Ivedy-Avedy, or about Humpy-Dumpy, who
+tumbled downstairs, and yet after all came to the throne and married the
+princess?”
+
+“Ivedy-Avedy,” cried some; “Humpy-Dumpy,” cried the others. There was
+such a bawling and screaming--the Fir Tree alone was silent, and he
+thought to himself, “Am I not to bawl with the rest? Am I to do nothing
+whatever?” for he was one of the company, and had done what he had to
+do.
+
+And the man told about Humpy-Dumpy that tumbled down, who
+notwithstanding came to the throne, and at last married the princess.
+And the children clapped their hands, and cried. “Oh, go on! Do go on!”
+ They wanted to hear about Ivedy-Avedy too, but the little man only told
+them about Humpy-Dumpy. The Fir Tree stood quite still and absorbed
+in thought; the birds in the wood had never related the like of this.
+“Humpy-Dumpy fell downstairs, and yet he married the princess! Yes, yes!
+That’s the way of the world!” thought the Fir Tree, and believed it all,
+because the man who told the story was so good-looking. “Well, well! who
+knows, perhaps I may fall downstairs, too, and get a princess as wife!”
+ And he looked forward with joy to the morrow, when he hoped to be decked
+out again with lights, playthings, fruits, and tinsel.
+
+“I won’t tremble to-morrow!” thought the Fir Tree. “I will enjoy to
+the full all my splendor! To-morrow I shall hear again the story of
+Humpy-Dumpy, and perhaps that of Ivedy-Avedy too.” And the whole night
+the Tree stood still and in deep thought.
+
+In the morning the servant and the housemaid came in.
+
+“Now then the splendor will begin again,” thought the Fir. But they
+dragged him out of the room, and up the stairs into the loft: and here,
+in a dark corner, where no daylight could enter, they left him. “What’s
+the meaning of this?” thought the Tree. “What am I to do here? What
+shall I hear now, I wonder?” And he leaned against the wall lost in
+reverie. Time enough had he too for his reflections; for days and nights
+passed on, and nobody came up; and when at last somebody did come, it
+was only to put some great trunks in a corner, out of the way. There
+stood the Tree quite hidden; it seemed as if he had been entirely
+forgotten.
+
+“‘Tis now winter out-of-doors!” thought the Tree. “The earth is hard and
+covered with snow; men cannot plant me now, and therefore I have been
+put up here under shelter till the spring-time comes! How thoughtful
+that is! How kind man is, after all! If it only were not so dark here,
+and so terribly lonely! Not even a hare! And out in the woods it was
+so pleasant, when the snow was on the ground, and the hare leaped by;
+yes--even when he jumped over me; but I did not like it then! It is
+really terribly lonely here!”
+
+“Squeak! Squeak!” said a little Mouse, at the same moment, peeping out
+of his hole. And then another little one came. They snuffed about the
+Fir Tree, and rustled among the branches.
+
+“It is dreadfully cold,” said the Mouse. “But for that, it would be
+delightful here, old Fir, wouldn’t it?”
+
+“I am by no means old,” said the Fir Tree. “There’s many a one
+considerably older than I am.”
+
+“Where do you come from,” asked the Mice; “and what can you do?” They
+were so extremely curious. “Tell us about the most beautiful spot on the
+earth. Have you never been there? Were you never in the larder, where
+cheeses lie on the shelves, and hams hang from above; where one dances
+about on tallow candles: that place where one enters lean, and comes out
+again fat and portly?”
+
+“I know no such place,” said the Tree. “But I know the wood, where the
+sun shines and where the little birds sing.” And then he told all about
+his youth; and the little Mice had never heard the like before; and they
+listened and said,
+
+“Well, to be sure! How much you have seen! How happy you must have
+been!”
+
+“I!” said the Fir Tree, thinking over what he had himself related.
+“Yes, in reality those were happy times.” And then he told about
+Christmas-eve, when he was decked out with cakes and candles.
+
+“Oh,” said the little Mice, “how fortunate you have been, old Fir Tree!”
+
+“I am by no means old,” said he. “I came from the wood this winter; I am
+in my prime, and am only rather short for my age.”
+
+“What delightful stories you know,” said the Mice: and the next night
+they came with four other little Mice, who were to hear what the Tree
+recounted: and the more he related, the more he remembered himself; and
+it appeared as if those times had really been happy times. “But they may
+still come--they may still come! Humpy-Dumpy fell downstairs, and yet
+he got a princess!” and he thought at the moment of a nice little Birch
+Tree growing out in the woods: to the Fir, that would be a real charming
+princess.
+
+“Who is Humpy-Dumpy?” asked the Mice. So then the Fir Tree told the
+whole fairy tale, for he could remember every single word of it; and the
+little Mice jumped for joy up to the very top of the Tree. Next night
+two more Mice came, and on Sunday two Rats even; but they said the
+stories were not interesting, which vexed the little Mice; and they,
+too, now began to think them not so very amusing either.
+
+“Do you know only one story?” asked the Rats.
+
+“Only that one,” answered the Tree. “I heard it on my happiest evening;
+but I did not then know how happy I was.”
+
+“It is a very stupid story! Don’t you know one about bacon and tallow
+candles? Can’t you tell any larder stories?”
+
+“No,” said the Tree.
+
+“Then good-bye,” said the Rats; and they went home.
+
+At last the little Mice stayed away also; and the Tree sighed: “After
+all, it was very pleasant when the sleek little Mice sat round me, and
+listened to what I told them. Now that too is over. But I will take good
+care to enjoy myself when I am brought out again.”
+
+But when was that to be? Why, one morning there came a quantity of
+people and set to work in the loft. The trunks were moved, the tree was
+pulled out and thrown--rather hard, it is true--down on the floor, but a
+man drew him towards the stairs, where the daylight shone.
+
+“Now a merry life will begin again,” thought the Tree. He felt the fresh
+air, the first sunbeam--and now he was out in the courtyard. All passed
+so quickly, there was so much going on around him, the Tree quite forgot
+to look to himself. The court adjoined a garden, and all was in flower;
+the roses hung so fresh and odorous over the balustrade, the lindens
+were in blossom, the Swallows flew by, and said, “Quirre-vit! My husband
+is come!” but it was not the Fir Tree that they meant.
+
+“Now, then, I shall really enjoy life,” said he exultingly, and spread
+out his branches; but, alas, they were all withered and yellow! It was
+in a corner that he lay, among weeds and nettles. The golden star of
+tinsel was still on the top of the Tree, and glittered in the sunshine.
+
+In the court-yard some of the merry children were playing who had danced
+at Christmas round the Fir Tree, and were so glad at the sight of him.
+One of the youngest ran and tore off the golden star.
+
+“Only look what is still on the ugly old Christmas tree!” said he,
+trampling on the branches, so that they all cracked beneath his feet.
+
+And the Tree beheld all the beauty of the flowers, and the freshness in
+the garden; he beheld himself, and wished he had remained in his dark
+corner in the loft; he thought of his first youth in the wood, of the
+merry Christmas-eve, and of the little Mice who had listened with so
+much pleasure to the story of Humpy-Dumpy.
+
+“‘Tis over--‘tis past!” said the poor Tree. “Had I but rejoiced when I
+had reason to do so! But now ‘tis past, ‘tis past!”
+
+And the gardener’s boy chopped the Tree into small pieces; there was a
+whole heap lying there. The wood flamed up splendidly under the large
+brewing copper, and it sighed so deeply! Each sigh was like a shot.
+
+The boys played about in the court, and the youngest wore the gold star
+on his breast which the Tree had had on the happiest evening of his
+life. However, that was over now--the Tree gone, the story at an end.
+All, all was over--every tale must end at last.
+
+
+
+
+THE SNOW QUEEN
+
+FIRST STORY. Which Treats of a Mirror and of the Splinters
+
+Now then, let us begin. When we are at the end of the story, we shall
+know more than we know now: but to begin.
+
+Once upon a time there was a wicked sprite, indeed he was the most
+mischievous of all sprites. One day he was in a very good humor, for
+he had made a mirror with the power of causing all that was good and
+beautiful when it was reflected therein, to look poor and mean; but
+that which was good-for-nothing and looked ugly was shown magnified
+and increased in ugliness. In this mirror the most beautiful landscapes
+looked like boiled spinach, and the best persons were turned into
+frights, or appeared to stand on their heads; their faces were so
+distorted that they were not to be recognised; and if anyone had a mole,
+you might be sure that it would be magnified and spread over both nose
+and mouth.
+
+“That’s glorious fun!” said the sprite. If a good thought passed through
+a man’s mind, then a grin was seen in the mirror, and the sprite laughed
+heartily at his clever discovery. All the little sprites who went to his
+school--for he kept a sprite school--told each other that a miracle had
+happened; and that now only, as they thought, it would be possible to
+see how the world really looked. They ran about with the mirror; and at
+last there was not a land or a person who was not represented distorted
+in the mirror. So then they thought they would fly up to the sky,
+and have a joke there. The higher they flew with the mirror, the more
+terribly it grinned: they could hardly hold it fast. Higher and higher
+still they flew, nearer and nearer to the stars, when suddenly the
+mirror shook so terribly with grinning, that it flew out of their hands
+and fell to the earth, where it was dashed in a hundred million and more
+pieces. And now it worked much more evil than before; for some of these
+pieces were hardly so large as a grain of sand, and they flew about in
+the wide world, and when they got into people’s eyes, there they stayed;
+and then people saw everything perverted, or only had an eye for that
+which was evil. This happened because the very smallest bit had the
+same power which the whole mirror had possessed. Some persons even got
+a splinter in their heart, and then it made one shudder, for their heart
+became like a lump of ice. Some of the broken pieces were so large that
+they were used for windowpanes, through which one could not see one’s
+friends. Other pieces were put in spectacles; and that was a sad affair
+when people put on their glasses to see well and rightly. Then the
+wicked sprite laughed till he almost choked, for all this tickled his
+fancy. The fine splinters still flew about in the air: and now we shall
+hear what happened next.
+
+
+SECOND STORY. A Little Boy and a Little Girl
+
+In a large town, where there are so many houses, and so many people,
+that there is no roof left for everybody to have a little garden; and
+where, on this account, most persons are obliged to content themselves
+with flowers in pots; there lived two little children, who had a garden
+somewhat larger than a flower-pot. They were not brother and sister; but
+they cared for each other as much as if they were. Their parents lived
+exactly opposite. They inhabited two garrets; and where the roof of the
+one house joined that of the other, and the gutter ran along the extreme
+end of it, there was to each house a small window: one needed only to
+step over the gutter to get from one window to the other.
+
+The children’s parents had large wooden boxes there, in which vegetables
+for the kitchen were planted, and little rosetrees besides: there was a
+rose in each box, and they grew splendidly. They now thought of placing
+the boxes across the gutter, so that they nearly reached from one window
+to the other, and looked just like two walls of flowers. The tendrils
+of the peas hung down over the boxes; and the rose-trees shot up long
+branches, twined round the windows, and then bent towards each other: it
+was almost like a triumphant arch of foliage and flowers. The boxes were
+very high, and the children knew that they must not creep over them; so
+they often obtained permission to get out of the windows to each other,
+and to sit on their little stools among the roses, where they could play
+delightfully. In winter there was an end of this pleasure. The windows
+were often frozen over; but then they heated copper farthings on the
+stove, and laid the hot farthing on the windowpane, and then they had a
+capital peep-hole, quite nicely rounded; and out of each peeped a gentle
+friendly eye--it was the little boy and the little girl who were looking
+out. His name was Kay, hers was Gerda. In summer, with one jump, they
+could get to each other; but in winter they were obliged first to
+go down the long stairs, and then up the long stairs again: and
+out-of-doors there was quite a snow-storm.
+
+“It is the white bees that are swarming,” said Kay’s old grandmother.
+
+“Do the white bees choose a queen?” asked the little boy; for he knew
+that the honey-bees always have one.
+
+“Yes,” said the grandmother, “she flies where the swarm hangs in the
+thickest clusters. She is the largest of all; and she can never remain
+quietly on the earth, but goes up again into the black clouds. Many a
+winter’s night she flies through the streets of the town, and peeps in
+at the windows; and they then freeze in so wondrous a manner that they
+look like flowers.”
+
+“Yes, I have seen it,” said both the children; and so they knew that it
+was true.
+
+“Can the Snow Queen come in?” said the little girl.
+
+“Only let her come in!” said the little boy. “Then I’d put her on the
+stove, and she’d melt.”
+
+And then his grandmother patted his head and told him other stories.
+
+In the evening, when little Kay was at home, and half undressed, he
+climbed up on the chair by the window, and peeped out of the little
+hole. A few snow-flakes were falling, and one, the largest of all,
+remained lying on the edge of a flower-pot.
+
+The flake of snow grew larger and larger; and at last it was like a
+young lady, dressed in the finest white gauze, made of a million little
+flakes like stars. She was so beautiful and delicate, but she was of
+ice, of dazzling, sparkling ice; yet she lived; her eyes gazed fixedly,
+like two stars; but there was neither quiet nor repose in them. She
+nodded towards the window, and beckoned with her hand. The little boy
+was frightened, and jumped down from the chair; it seemed to him as if,
+at the same moment, a large bird flew past the window.
+
+The next day it was a sharp frost--and then the spring came; the sun
+shone, the green leaves appeared, the swallows built their nests, the
+windows were opened, and the little children again sat in their pretty
+garden, high up on the leads at the top of the house.
+
+That summer the roses flowered in unwonted beauty. The little girl had
+learned a hymn, in which there was something about roses; and then she
+thought of her own flowers; and she sang the verse to the little boy,
+who then sang it with her:
+
+     “The rose in the valley is blooming so sweet,
+     And angels descend there the children to greet.”
+
+And the children held each other by the hand, kissed the roses, looked
+up at the clear sunshine, and spoke as though they really saw angels
+there. What lovely summer-days those were! How delightful to be out in
+the air, near the fresh rose-bushes, that seem as if they would never
+finish blossoming!
+
+Kay and Gerda looked at the picture-book full of beasts and of birds;
+and it was then--the clock in the church-tower was just striking
+five--that Kay said, “Oh! I feel such a sharp pain in my heart; and now
+something has got into my eye!”
+
+The little girl put her arms around his neck. He winked his eyes; now
+there was nothing to be seen.
+
+“I think it is out now,” said he; but it was not. It was just one of
+those pieces of glass from the magic mirror that had got into his eye;
+and poor Kay had got another piece right in his heart. It will soon
+become like ice. It did not hurt any longer, but there it was.
+
+“What are you crying for?” asked he. “You look so ugly! There’s nothing
+the matter with me. Ah,” said he at once, “that rose is cankered! And
+look, this one is quite crooked! After all, these roses are very ugly!
+They are just like the box they are planted in!” And then he gave the
+box a good kick with his foot, and pulled both the roses up.
+
+“What are you doing?” cried the little girl; and as he perceived her
+fright, he pulled up another rose, got in at the window, and hastened
+off from dear little Gerda.
+
+Afterwards, when she brought her picture-book, he asked, “What horrid
+beasts have you there?” And if his grandmother told them stories, he
+always interrupted her; besides, if he could manage it, he would get
+behind her, put on her spectacles, and imitate her way of speaking; he
+copied all her ways, and then everybody laughed at him. He was soon able
+to imitate the gait and manner of everyone in the street. Everything
+that was peculiar and displeasing in them--that Kay knew how to imitate:
+and at such times all the people said, “The boy is certainly very
+clever!” But it was the glass he had got in his eye; the glass that was
+sticking in his heart, which made him tease even little Gerda, whose
+whole soul was devoted to him.
+
+His games now were quite different to what they had formerly been, they
+were so very knowing. One winter’s day, when the flakes of snow were
+flying about, he spread the skirts of his blue coat, and caught the snow
+as it fell.
+
+“Look through this glass, Gerda,” said he. And every flake seemed
+larger, and appeared like a magnificent flower, or beautiful star; it
+was splendid to look at!
+
+“Look, how clever!” said Kay. “That’s much more interesting than real
+flowers! They are as exact as possible; there is not a fault in them, if
+they did not melt!”
+
+It was not long after this, that Kay came one day with large gloves on,
+and his little sledge at his back, and bawled right into Gerda’s ears,
+“I have permission to go out into the square where the others are
+playing”; and off he was in a moment.
+
+There, in the market-place, some of the boldest of the boys used to tie
+their sledges to the carts as they passed by, and so they were pulled
+along, and got a good ride. It was so capital! Just as they were in the
+very height of their amusement, a large sledge passed by: it was painted
+quite white, and there was someone in it wrapped up in a rough white
+mantle of fur, with a rough white fur cap on his head. The sledge drove
+round the square twice, and Kay tied on his sledge as quickly as he
+could, and off he drove with it. On they went quicker and quicker into
+the next street; and the person who drove turned round to Kay, and
+nodded to him in a friendly manner, just as if they knew each other.
+Every time he was going to untie his sledge, the person nodded to him,
+and then Kay sat quiet; and so on they went till they came outside
+the gates of the town. Then the snow began to fall so thickly that the
+little boy could not see an arm’s length before him, but still on he
+went: when suddenly he let go the string he held in his hand in order
+to get loose from the sledge, but it was of no use; still the little
+vehicle rushed on with the quickness of the wind. He then cried as loud
+as he could, but no one heard him; the snow drifted and the sledge flew
+on, and sometimes it gave a jerk as though they were driving over hedges
+and ditches. He was quite frightened, and he tried to repeat the
+Lord’s Prayer; but all he could do, he was only able to remember the
+multiplication table.
+
+The snow-flakes grew larger and larger, till at last they looked just
+like great white fowls. Suddenly they flew on one side; the large sledge
+stopped, and the person who drove rose up. It was a lady; her cloak and
+cap were of snow. She was tall and of slender figure, and of a dazzling
+whiteness. It was the Snow Queen.
+
+“We have travelled fast,” said she; “but it is freezingly cold. Come
+under my bearskin.” And she put him in the sledge beside her,
+wrapped the fur round him, and he felt as though he were sinking in a
+snow-wreath.
+
+“Are you still cold?” asked she; and then she kissed his forehead.
+Ah! it was colder than ice; it penetrated to his very heart, which was
+already almost a frozen lump; it seemed to him as if he were about to
+die--but a moment more and it was quite congenial to him, and he did not
+remark the cold that was around him.
+
+“My sledge! Do not forget my sledge!” It was the first thing he thought
+of. It was there tied to one of the white chickens, who flew along with
+it on his back behind the large sledge. The Snow Queen kissed Kay once
+more, and then he forgot little Gerda, grandmother, and all whom he had
+left at his home.
+
+“Now you will have no more kisses,” said she, “or else I should kiss you
+to death!”
+
+Kay looked at her. She was very beautiful; a more clever, or a more
+lovely countenance he could not fancy to himself; and she no longer
+appeared of ice as before, when she sat outside the window, and beckoned
+to him; in his eyes she was perfect, he did not fear her at all, and
+told her that he could calculate in his head and with fractions, even;
+that he knew the number of square miles there were in the different
+countries, and how many inhabitants they contained; and she smiled while
+he spoke. It then seemed to him as if what he knew was not enough, and
+he looked upwards in the large huge empty space above him, and on she
+flew with him; flew high over the black clouds, while the storm moaned
+and whistled as though it were singing some old tune. On they flew
+over woods and lakes, over seas, and many lands; and beneath them the
+chilling storm rushed fast, the wolves howled, the snow crackled; above
+them flew large screaming crows, but higher up appeared the moon, quite
+large and bright; and it was on it that Kay gazed during the long long
+winter’s night; while by day he slept at the feet of the Snow Queen.
+
+
+THIRD STORY. Of the Flower-Garden At the Old Woman’s Who Understood
+Witchcraft
+
+But what became of little Gerda when Kay did not return? Where could he
+be? Nobody knew; nobody could give any intelligence. All the boys knew
+was, that they had seen him tie his sledge to another large and splendid
+one, which drove down the street and out of the town. Nobody knew
+where he was; many sad tears were shed, and little Gerda wept long and
+bitterly; at last she said he must be dead; that he had been drowned in
+the river which flowed close to the town. Oh! those were very long and
+dismal winter evenings!
+
+At last spring came, with its warm sunshine.
+
+“Kay is dead and gone!” said little Gerda.
+
+“That I don’t believe,” said the Sunshine.
+
+“Kay is dead and gone!” said she to the Swallows.
+
+“That I don’t believe,” said they: and at last little Gerda did not
+think so any longer either.
+
+“I’ll put on my red shoes,” said she, one morning; “Kay has never seen
+them, and then I’ll go down to the river and ask there.”
+
+It was quite early; she kissed her old grandmother, who was still
+asleep, put on her red shoes, and went alone to the river.
+
+“Is it true that you have taken my little playfellow? I will make you a
+present of my red shoes, if you will give him back to me.”
+
+And, as it seemed to her, the blue waves nodded in a strange manner;
+then she took off her red shoes, the most precious things she possessed,
+and threw them both into the river. But they fell close to the bank, and
+the little waves bore them immediately to land; it was as if the stream
+would not take what was dearest to her; for in reality it had not got
+little Kay; but Gerda thought that she had not thrown the shoes out far
+enough, so she clambered into a boat which lay among the rushes, went
+to the farthest end, and threw out the shoes. But the boat was not
+fastened, and the motion which she occasioned, made it drift from the
+shore. She observed this, and hastened to get back; but before she could
+do so, the boat was more than a yard from the land, and was gliding
+quickly onward.
+
+Little Gerda was very frightened, and began to cry; but no one heard her
+except the sparrows, and they could not carry her to land; but they flew
+along the bank, and sang as if to comfort her, “Here we are! Here we
+are!” The boat drifted with the stream, little Gerda sat quite still
+without shoes, for they were swimming behind the boat, but she could not
+reach them, because the boat went much faster than they did.
+
+The banks on both sides were beautiful; lovely flowers, venerable trees,
+and slopes with sheep and cows, but not a human being was to be seen.
+
+“Perhaps the river will carry me to little Kay,” said she; and then
+she grew less sad. She rose, and looked for many hours at the beautiful
+green banks. Presently she sailed by a large cherry-orchard, where was
+a little cottage with curious red and blue windows; it was thatched,
+and before it two wooden soldiers stood sentry, and presented arms when
+anyone went past.
+
+Gerda called to them, for she thought they were alive; but they, of
+course, did not answer. She came close to them, for the stream drifted
+the boat quite near the land.
+
+Gerda called still louder, and an old woman then came out of the
+cottage, leaning upon a crooked stick. She had a large broad-brimmed hat
+on, painted with the most splendid flowers.
+
+“Poor little child!” said the old woman. “How did you get upon the large
+rapid river, to be driven about so in the wide world!” And then the
+old woman went into the water, caught hold of the boat with her crooked
+stick, drew it to the bank, and lifted little Gerda out.
+
+And Gerda was so glad to be on dry land again; but she was rather afraid
+of the strange old woman.
+
+“But come and tell me who you are, and how you came here,” said she.
+
+And Gerda told her all; and the old woman shook her head and said,
+“A-hem! a-hem!” and when Gerda had told her everything, and asked her if
+she had not seen little Kay, the woman answered that he had not passed
+there, but he no doubt would come; and she told her not to be cast down,
+but taste her cherries, and look at her flowers, which were finer than
+any in a picture-book, each of which could tell a whole story. She then
+took Gerda by the hand, led her into the little cottage, and locked the
+door.
+
+The windows were very high up; the glass was red, blue, and green, and
+the sunlight shone through quite wondrously in all sorts of colors. On
+the table stood the most exquisite cherries, and Gerda ate as many as
+she chose, for she had permission to do so. While she was eating, the
+old woman combed her hair with a golden comb, and her hair curled and
+shone with a lovely golden color around that sweet little face, which
+was so round and so like a rose.
+
+“I have often longed for such a dear little girl,” said the old woman.
+“Now you shall see how well we agree together”; and while she combed
+little Gerda’s hair, the child forgot her foster-brother Kay more and
+more, for the old woman understood magic; but she was no evil being, she
+only practised witchcraft a little for her own private amusement, and
+now she wanted very much to keep little Gerda. She therefore went out
+in the garden, stretched out her crooked stick towards the rose-bushes,
+which, beautifully as they were blowing, all sank into the earth and no
+one could tell where they had stood. The old woman feared that if Gerda
+should see the roses, she would then think of her own, would remember
+little Kay, and run away from her.
+
+She now led Gerda into the flower-garden. Oh, what odour and what
+loveliness was there! Every flower that one could think of, and of every
+season, stood there in fullest bloom; no picture-book could be gayer or
+more beautiful. Gerda jumped for joy, and played till the sun set behind
+the tall cherry-tree; she then had a pretty bed, with a red silken
+coverlet filled with blue violets. She fell asleep, and had as pleasant
+dreams as ever a queen on her wedding-day.
+
+The next morning she went to play with the flowers in the warm sunshine,
+and thus passed away a day. Gerda knew every flower; and, numerous as
+they were, it still seemed to Gerda that one was wanting, though she
+did not know which. One day while she was looking at the hat of the old
+woman painted with flowers, the most beautiful of them all seemed to her
+to be a rose. The old woman had forgotten to take it from her hat
+when she made the others vanish in the earth. But so it is when one’s
+thoughts are not collected. “What!” said Gerda. “Are there no roses
+here?” and she ran about amongst the flowerbeds, and looked, and looked,
+but there was not one to be found. She then sat down and wept; but her
+hot tears fell just where a rose-bush had sunk; and when her warm tears
+watered the ground, the tree shot up suddenly as fresh and blooming as
+when it had been swallowed up. Gerda kissed the roses, thought of her
+own dear roses at home, and with them of little Kay.
+
+“Oh, how long I have stayed!” said the little girl. “I intended to look
+for Kay! Don’t you know where he is?” she asked of the roses. “Do you
+think he is dead and gone?”
+
+“Dead he certainly is not,” said the Roses. “We have been in the earth
+where all the dead are, but Kay was not there.”
+
+“Many thanks!” said little Gerda; and she went to the other flowers,
+looked into their cups, and asked, “Don’t you know where little Kay is?”
+
+But every flower stood in the sunshine, and dreamed its own fairy tale
+or its own story: and they all told her very many things, but not one
+knew anything of Kay.
+
+Well, what did the Tiger-Lily say?
+
+“Hearest thou not the drum? Bum! Bum! Those are the only two tones.
+Always bum! Bum! Hark to the plaintive song of the old woman, to the
+call of the priests! The Hindoo woman in her long robe stands upon the
+funeral pile; the flames rise around her and her dead husband, but the
+Hindoo woman thinks on the living one in the surrounding circle; on him
+whose eyes burn hotter than the flames--on him, the fire of whose eyes
+pierces her heart more than the flames which soon will burn her body to
+ashes. Can the heart’s flame die in the flame of the funeral pile?”
+
+“I don’t understand that at all,” said little Gerda.
+
+“That is my story,” said the Lily.
+
+What did the Convolvulus say?
+
+“Projecting over a narrow mountain-path there hangs an old feudal
+castle. Thick evergreens grow on the dilapidated walls, and around the
+altar, where a lovely maiden is standing: she bends over the railing and
+looks out upon the rose. No fresher rose hangs on the branches than she;
+no appleblossom carried away by the wind is more buoyant! How her silken
+robe is rustling!
+
+“‘Is he not yet come?’”
+
+“Is it Kay that you mean?” asked little Gerda.
+
+“I am speaking about my story--about my dream,” answered the
+Convolvulus.
+
+What did the Snowdrops say?
+
+“Between the trees a long board is hanging--it is a swing. Two little
+girls are sitting in it, and swing themselves backwards and forwards;
+their frocks are as white as snow, and long green silk ribands flutter
+from their bonnets. Their brother, who is older than they are, stands up
+in the swing; he twines his arms round the cords to hold himself fast,
+for in one hand he has a little cup, and in the other a clay-pipe. He is
+blowing soap-bubbles. The swing moves, and the bubbles float in charming
+changing colors: the last is still hanging to the end of the pipe, and
+rocks in the breeze. The swing moves. The little black dog, as light as
+a soap-bubble, jumps up on his hind legs to try to get into the swing.
+It moves, the dog falls down, barks, and is angry. They tease him; the
+bubble bursts! A swing, a bursting bubble--such is my song!”
+
+“What you relate may be very pretty, but you tell it in so melancholy a
+manner, and do not mention Kay.”
+
+What do the Hyacinths say?
+
+“There were once upon a time three sisters, quite transparent, and very
+beautiful. The robe of the one was red, that of the second blue, and
+that of the third white. They danced hand in hand beside the calm
+lake in the clear moonshine. They were not elfin maidens, but mortal
+children. A sweet fragrance was smelt, and the maidens vanished in the
+wood; the fragrance grew stronger--three coffins, and in them three
+lovely maidens, glided out of the forest and across the lake: the
+shining glow-worms flew around like little floating lights. Do the
+dancing maidens sleep, or are they dead? The odour of the flowers says
+they are corpses; the evening bell tolls for the dead!”
+
+“You make me quite sad,” said little Gerda. “I cannot help thinking of
+the dead maidens. Oh! is little Kay really dead? The Roses have been in
+the earth, and they say no.”
+
+“Ding, dong!” sounded the Hyacinth bells. “We do not toll for little
+Kay; we do not know him. That is our way of singing, the only one we
+have.”
+
+And Gerda went to the Ranunculuses, that looked forth from among the
+shining green leaves.
+
+“You are a little bright sun!” said Gerda. “Tell me if you know where I
+can find my playfellow.”
+
+And the Ranunculus shone brightly, and looked again at Gerda. What
+song could the Ranunculus sing? It was one that said nothing about Kay
+either.
+
+“In a small court the bright sun was shining in the first days of
+spring. The beams glided down the white walls of a neighbor’s house, and
+close by the fresh yellow flowers were growing, shining like gold in
+the warm sun-rays. An old grandmother was sitting in the air; her
+grand-daughter, the poor and lovely servant just come for a short visit.
+She knows her grandmother. There was gold, pure virgin gold in that
+blessed kiss. There, that is my little story,” said the Ranunculus.
+
+“My poor old grandmother!” sighed Gerda. “Yes, she is longing for me,
+no doubt: she is sorrowing for me, as she did for little Kay. But I
+will soon come home, and then I will bring Kay with me. It is of no use
+asking the flowers; they only know their own old rhymes, and can tell me
+nothing.” And she tucked up her frock, to enable her to run quicker; but
+the Narcissus gave her a knock on the leg, just as she was going to
+jump over it. So she stood still, looked at the long yellow flower, and
+asked, “You perhaps know something?” and she bent down to the Narcissus.
+And what did it say?
+
+“I can see myself--I can see myself! Oh, how odorous I am! Up in the
+little garret there stands, half-dressed, a little Dancer. She stands
+now on one leg, now on both; she despises the whole world; yet she lives
+only in imagination. She pours water out of the teapot over a piece of
+stuff which she holds in her hand; it is the bodice; cleanliness is a
+fine thing. The white dress is hanging on the hook; it was washed in the
+teapot, and dried on the roof. She puts it on, ties a saffron-colored
+kerchief round her neck, and then the gown looks whiter. I can see
+myself--I can see myself!”
+
+“That’s nothing to me,” said little Gerda. “That does not concern me.”
+ And then off she ran to the further end of the garden.
+
+The gate was locked, but she shook the rusted bolt till it was loosened,
+and the gate opened; and little Gerda ran off barefooted into the wide
+world. She looked round her thrice, but no one followed her. At last she
+could run no longer; she sat down on a large stone, and when she looked
+about her, she saw that the summer had passed; it was late in the
+autumn, but that one could not remark in the beautiful garden, where
+there was always sunshine, and where there were flowers the whole year
+round.
+
+“Dear me, how long I have staid!” said Gerda. “Autumn is come. I must
+not rest any longer.” And she got up to go further.
+
+Oh, how tender and wearied her little feet were! All around it looked
+so cold and raw: the long willow-leaves were quite yellow, and the fog
+dripped from them like water; one leaf fell after the other: the sloes
+only stood full of fruit, which set one’s teeth on edge. Oh, how dark
+and comfortless it was in the dreary world!
+
+
+FOURTH STORY. The Prince and Princess
+
+Gerda was obliged to rest herself again, when, exactly opposite to her,
+a large Raven came hopping over the white snow. He had long been looking
+at Gerda and shaking his head; and now he said, “Caw! Caw!” Good day!
+Good day! He could not say it better; but he felt a sympathy for the
+little girl, and asked her where she was going all alone. The word
+“alone” Gerda understood quite well, and felt how much was expressed
+by it; so she told the Raven her whole history, and asked if he had not
+seen Kay.
+
+The Raven nodded very gravely, and said, “It may be--it may be!”
+
+“What, do you really think so?” cried the little girl; and she nearly
+squeezed the Raven to death, so much did she kiss him.
+
+“Gently, gently,” said the Raven. “I think I know; I think that it may
+be little Kay. But now he has forgotten you for the Princess.”
+
+“Does he live with a Princess?” asked Gerda.
+
+“Yes--listen,” said the Raven; “but it will be difficult for me to
+speak your language. If you understand the Raven language I can tell you
+better.”
+
+“No, I have not learnt it,” said Gerda; “but my grandmother understands
+it, and she can speak gibberish too. I wish I had learnt it.”
+
+“No matter,” said the Raven; “I will tell you as well as I can; however,
+it will be bad enough.” And then he told all he knew.
+
+“In the kingdom where we now are there lives a Princess, who is
+extraordinarily clever; for she has read all the newspapers in the whole
+world, and has forgotten them again--so clever is she. She was lately,
+it is said, sitting on her throne--which is not very amusing after
+all--when she began humming an old tune, and it was just, ‘Oh, why
+should I not be married?’ ‘That song is not without its meaning,’ said
+she, and so then she was determined to marry; but she would have a
+husband who knew how to give an answer when he was spoken to--not
+one who looked only as if he were a great personage, for that is so
+tiresome. She then had all the ladies of the court drummed together; and
+when they heard her intention, all were very pleased, and said, ‘We are
+very glad to hear it; it is the very thing we were thinking of.’ You may
+believe every word I say,” said the Raven; “for I have a tame sweetheart
+that hops about in the palace quite free, and it was she who told me all
+this.
+
+“The newspapers appeared forthwith with a border of hearts and the
+initials of the Princess; and therein you might read that every
+good-looking young man was at liberty to come to the palace and speak to
+the Princess; and he who spoke in such wise as showed he felt himself at
+home there, that one the Princess would choose for her husband.
+
+“Yes, Yes,” said the Raven, “you may believe it; it is as true as I am
+sitting here. People came in crowds; there was a crush and a hurry, but
+no one was successful either on the first or second day. They could all
+talk well enough when they were out in the street; but as soon as
+they came inside the palace gates, and saw the guard richly dressed
+in silver, and the lackeys in gold on the staircase, and the large
+illuminated saloons, then they were abashed; and when they stood before
+the throne on which the Princess was sitting, all they could do was
+to repeat the last word they had uttered, and to hear it again did not
+interest her very much. It was just as if the people within were under
+a charm, and had fallen into a trance till they came out again into the
+street; for then--oh, then--they could chatter enough. There was a whole
+row of them standing from the town-gates to the palace. I was there
+myself to look,” said the Raven. “They grew hungry and thirsty; but from
+the palace they got nothing whatever, not even a glass of water. Some
+of the cleverest, it is true, had taken bread and butter with them:
+but none shared it with his neighbor, for each thought, ‘Let him look
+hungry, and then the Princess won’t have him.’”
+
+“But Kay--little Kay,” said Gerda, “when did he come? Was he among the
+number?”
+
+“Patience, patience; we are just come to him. It was on the third day
+when a little personage without horse or equipage, came marching right
+boldly up to the palace; his eyes shone like yours, he had beautiful
+long hair, but his clothes were very shabby.”
+
+“That was Kay,” cried Gerda, with a voice of delight. “Oh, now I’ve
+found him!” and she clapped her hands for joy.
+
+“He had a little knapsack at his back,” said the Raven.
+
+“No, that was certainly his sledge,” said Gerda; “for when he went away
+he took his sledge with him.”
+
+“That may be,” said the Raven; “I did not examine him so minutely; but
+I know from my tame sweetheart, that when he came into the court-yard
+of the palace, and saw the body-guard in silver, the lackeys on the
+staircase, he was not the least abashed; he nodded, and said to them,
+‘It must be very tiresome to stand on the stairs; for my part, I shall
+go in.’ The saloons were gleaming with lustres--privy councillors and
+excellencies were walking about barefooted, and wore gold keys; it was
+enough to make any one feel uncomfortable. His boots creaked, too, so
+loudly, but still he was not at all afraid.”
+
+“That’s Kay for certain,” said Gerda. “I know he had on new boots; I
+have heard them creaking in grandmama’s room.”
+
+“Yes, they creaked,” said the Raven. “And on he went boldly up to the
+Princess, who was sitting on a pearl as large as a spinning-wheel.
+All the ladies of the court, with their attendants and attendants’
+attendants, and all the cavaliers, with their gentlemen and gentlemen’s
+gentlemen, stood round; and the nearer they stood to the door, the
+prouder they looked. It was hardly possible to look at the gentleman’s
+gentleman, so very haughtily did he stand in the doorway.”
+
+“It must have been terrible,” said little Gerda. “And did Kay get the
+Princess?”
+
+“Were I not a Raven, I should have taken the Princess myself, although
+I am promised. It is said he spoke as well as I speak when I talk Raven
+language; this I learned from my tame sweetheart. He was bold and nicely
+behaved; he had not come to woo the Princess, but only to hear her
+wisdom. She pleased him, and he pleased her.”
+
+“Yes, yes; for certain that was Kay,” said Gerda. “He was so clever;
+he could reckon fractions in his head. Oh, won’t you take me to the
+palace?”
+
+“That is very easily said,” answered the Raven. “But how are we to
+manage it? I’ll speak to my tame sweetheart about it: she must advise
+us; for so much I must tell you, such a little girl as you are will
+never get permission to enter.”
+
+“Oh, yes I shall,” said Gerda; “when Kay hears that I am here, he will
+come out directly to fetch me.”
+
+“Wait for me here on these steps,” said the Raven. He moved his head
+backwards and forwards and flew away.
+
+The evening was closing in when the Raven returned. “Caw--caw!” said he.
+“She sends you her compliments; and here is a roll for you. She took
+it out of the kitchen, where there is bread enough. You are hungry,
+no doubt. It is not possible for you to enter the palace, for you are
+barefooted: the guards in silver, and the lackeys in gold, would not
+allow it; but do not cry, you shall come in still. My sweetheart knows a
+little back stair that leads to the bedchamber, and she knows where she
+can get the key of it.”
+
+And they went into the garden in the large avenue, where one leaf was
+falling after the other; and when the lights in the palace had all
+gradually disappeared, the Raven led little Gerda to the back door,
+which stood half open.
+
+Oh, how Gerda’s heart beat with anxiety and longing! It was just as if
+she had been about to do something wrong; and yet she only wanted to
+know if little Kay was there. Yes, he must be there. She called to mind
+his intelligent eyes, and his long hair, so vividly, she could quite see
+him as he used to laugh when they were sitting under the roses at home.
+“He will, no doubt, be glad to see you--to hear what a long way you have
+come for his sake; to know how unhappy all at home were when he did not
+come back.”
+
+Oh, what a fright and a joy it was!
+
+They were now on the stairs. A single lamp was burning there; and on the
+floor stood the tame Raven, turning her head on every side and looking
+at Gerda, who bowed as her grandmother had taught her to do.
+
+“My intended has told me so much good of you, my dear young lady,” said
+the tame Raven. “Your tale is very affecting. If you will take the lamp,
+I will go before. We will go straight on, for we shall meet no one.”
+
+“I think there is somebody just behind us,” said Gerda; and something
+rushed past: it was like shadowy figures on the wall; horses with
+flowing manes and thin legs, huntsmen, ladies and gentlemen on
+horseback.
+
+“They are only dreams,” said the Raven. “They come to fetch the thoughts
+of the high personages to the chase; ‘tis well, for now you can observe
+them in bed all the better. But let me find, when you enjoy honor and
+distinction, that you possess a grateful heart.”
+
+“Tut! That’s not worth talking about,” said the Raven of the woods.
+
+They now entered the first saloon, which was of rose-colored satin, with
+artificial flowers on the wall. Here the dreams were rushing past,
+but they hastened by so quickly that Gerda could not see the high
+personages. One hall was more magnificent than the other; one might
+indeed well be abashed; and at last they came into the bedchamber. The
+ceiling of the room resembled a large palm-tree with leaves of glass,
+of costly glass; and in the middle, from a thick golden stem, hung two
+beds, each of which resembled a lily. One was white, and in this lay the
+Princess; the other was red, and it was here that Gerda was to look for
+little Kay. She bent back one of the red leaves, and saw a brown neck.
+Oh! that was Kay! She called him quite loud by name, held the lamp
+towards him--the dreams rushed back again into the chamber--he awoke,
+turned his head, and--it was not little Kay!
+
+The Prince was only like him about the neck; but he was young and
+handsome. And out of the white lily leaves the Princess peeped, too,
+and asked what was the matter. Then little Gerda cried, and told her her
+whole history, and all that the Ravens had done for her.
+
+“Poor little thing!” said the Prince and the Princess. They praised the
+Ravens very much, and told them they were not at all angry with them,
+but they were not to do so again. However, they should have a reward.
+“Will you fly about here at liberty,” asked the Princess; “or would you
+like to have a fixed appointment as court ravens, with all the broken
+bits from the kitchen?”
+
+And both the Ravens nodded, and begged for a fixed appointment; for
+they thought of their old age, and said, “It is a good thing to have a
+provision for our old days.”
+
+And the Prince got up and let Gerda sleep in his bed, and more than this
+he could not do. She folded her little hands and thought, “How good men
+and animals are!” and she then fell asleep and slept soundly. All the
+dreams flew in again, and they now looked like the angels; they drew
+a little sledge, in which little Kay sat and nodded his head; but the
+whole was only a dream, and therefore it all vanished as soon as she
+awoke.
+
+The next day she was dressed from head to foot in silk and velvet. They
+offered to let her stay at the palace, and lead a happy life; but she
+begged to have a little carriage with a horse in front, and for a small
+pair of shoes; then, she said, she would again go forth in the wide
+world and look for Kay.
+
+Shoes and a muff were given her; she was, too, dressed very nicely; and
+when she was about to set off, a new carriage stopped before the door.
+It was of pure gold, and the arms of the Prince and Princess shone
+like a star upon it; the coachman, the footmen, and the outriders, for
+outriders were there, too, all wore golden crowns. The Prince and the
+Princess assisted her into the carriage themselves, and wished her all
+success. The Raven of the woods, who was now married, accompanied her
+for the first three miles. He sat beside Gerda, for he could not bear
+riding backwards; the other Raven stood in the doorway, and flapped her
+wings; she could not accompany Gerda, because she suffered from headache
+since she had had a fixed appointment and ate so much. The carriage
+was lined inside with sugar-plums, and in the seats were fruits and
+gingerbread.
+
+“Farewell! Farewell!” cried Prince and Princess; and Gerda wept, and
+the Raven wept. Thus passed the first miles; and then the Raven bade her
+farewell, and this was the most painful separation of all. He flew into
+a tree, and beat his black wings as long as he could see the carriage,
+that shone from afar like a sunbeam.
+
+
+FIFTH STORY. The Little Robber Maiden
+
+They drove through the dark wood; but the carriage shone like a torch,
+and it dazzled the eyes of the robbers, so that they could not bear to
+look at it.
+
+“‘Tis gold! ‘Tis gold!” they cried; and they rushed forward, seized
+the horses, knocked down the little postilion, the coachman, and the
+servants, and pulled little Gerda out of the carriage.
+
+“How plump, how beautiful she is! She must have been fed on
+nut-kernels,” said the old female robber, who had a long, scrubby beard,
+and bushy eyebrows that hung down over her eyes. “She is as good as a
+fatted lamb! How nice she will be!” And then she drew out a knife, the
+blade of which shone so that it was quite dreadful to behold.
+
+“Oh!” cried the woman at the same moment. She had been bitten in the ear
+by her own little daughter, who hung at her back; and who was so wild
+and unmanageable, that it was quite amusing to see her. “You naughty
+child!” said the mother: and now she had not time to kill Gerda.
+
+“She shall play with me,” said the little robber child. “She shall give
+me her muff, and her pretty frock; she shall sleep in my bed!” And then
+she gave her mother another bite, so that she jumped, and ran round with
+the pain; and the Robbers laughed, and said, “Look, how she is dancing
+with the little one!”
+
+“I will go into the carriage,” said the little robber maiden; and she
+would have her will, for she was very spoiled and very headstrong. She
+and Gerda got in; and then away they drove over the stumps of felled
+trees, deeper and deeper into the woods. The little robber maiden was as
+tall as Gerda, but stronger, broader-shouldered, and of dark complexion;
+her eyes were quite black; they looked almost melancholy. She embraced
+little Gerda, and said, “They shall not kill you as long as I am not
+displeased with you. You are, doubtless, a Princess?”
+
+“No,” said little Gerda; who then related all that had happened to her,
+and how much she cared about little Kay.
+
+The little robber maiden looked at her with a serious air, nodded her
+head slightly, and said, “They shall not kill you, even if I am angry
+with you: then I will do it myself”; and she dried Gerda’s eyes, and put
+both her hands in the handsome muff, which was so soft and warm.
+
+At length the carriage stopped. They were in the midst of the court-yard
+of a robber’s castle. It was full of cracks from top to bottom; and out
+of the openings magpies and rooks were flying; and the great bull-dogs,
+each of which looked as if he could swallow a man, jumped up, but they
+did not bark, for that was forbidden.
+
+In the midst of the large, old, smoking hall burnt a great fire on the
+stone floor. The smoke disappeared under the stones, and had to seek
+its own egress. In an immense caldron soup was boiling; and rabbits and
+hares were being roasted on a spit.
+
+“You shall sleep with me to-night, with all my animals,” said the little
+robber maiden. They had something to eat and drink; and then went into
+a corner, where straw and carpets were lying. Beside them, on laths and
+perches, sat nearly a hundred pigeons, all asleep, seemingly; but yet
+they moved a little when the robber maiden came. “They are all mine,”
+ said she, at the same time seizing one that was next to her by the legs
+and shaking it so that its wings fluttered. “Kiss it,” cried the little
+girl, and flung the pigeon in Gerda’s face. “Up there is the rabble of
+the wood,” continued she, pointing to several laths which were fastened
+before a hole high up in the wall; “that’s the rabble; they would all
+fly away immediately, if they were not well fastened in. And here is my
+dear old Bac”; and she laid hold of the horns of a reindeer, that had a
+bright copper ring round its neck, and was tethered to the spot. “We are
+obliged to lock this fellow in too, or he would make his escape. Every
+evening I tickle his neck with my sharp knife; he is so frightened at
+it!” and the little girl drew forth a long knife, from a crack in the
+wall, and let it glide over the Reindeer’s neck. The poor animal kicked;
+the girl laughed, and pulled Gerda into bed with her.
+
+“Do you intend to keep your knife while you sleep?” asked Gerda; looking
+at it rather fearfully.
+
+“I always sleep with the knife,” said the little robber maiden. “There
+is no knowing what may happen. But tell me now, once more, all about
+little Kay; and why you have started off in the wide world alone.” And
+Gerda related all, from the very beginning: the Wood-pigeons cooed above
+in their cage, and the others slept. The little robber maiden wound her
+arm round Gerda’s neck, held the knife in the other hand, and snored so
+loud that everybody could hear her; but Gerda could not close her eyes,
+for she did not know whether she was to live or die. The robbers sat
+round the fire, sang and drank; and the old female robber jumped about
+so, that it was quite dreadful for Gerda to see her.
+
+Then the Wood-pigeons said, “Coo! Coo! We have seen little Kay! A white
+hen carries his sledge; he himself sat in the carriage of the Snow
+Queen, who passed here, down just over the wood, as we lay in our nest.
+She blew upon us young ones; and all died except we two. Coo! Coo!”
+
+“What is that you say up there?” cried little Gerda. “Where did the Snow
+Queen go to? Do you know anything about it?”
+
+“She is no doubt gone to Lapland; for there is always snow and ice
+there. Only ask the Reindeer, who is tethered there.”
+
+“Ice and snow is there! There it is, glorious and beautiful!” said the
+Reindeer. “One can spring about in the large shining valleys! The Snow
+Queen has her summer-tent there; but her fixed abode is high up towards
+the North Pole, on the Island called Spitzbergen.”
+
+“Oh, Kay! Poor little Kay!” sighed Gerda.
+
+“Do you choose to be quiet?” said the robber maiden. “If you don’t, I
+shall make you.”
+
+In the morning Gerda told her all that the Wood-pigeons had said; and
+the little maiden looked very serious, but she nodded her head, and
+said, “That’s no matter--that’s no matter. Do you know where Lapland
+lies!” she asked of the Reindeer.
+
+“Who should know better than I?” said the animal; and his eyes rolled in
+his head. “I was born and bred there--there I leapt about on the fields
+of snow.”
+
+“Listen,” said the robber maiden to Gerda. “You see that the men are
+gone; but my mother is still here, and will remain. However, towards
+morning she takes a draught out of the large flask, and then she sleeps
+a little: then I will do something for you.” She now jumped out of bed,
+flew to her mother; with her arms round her neck, and pulling her by the
+beard, said, “Good morrow, my own sweet nanny-goat of a mother.” And her
+mother took hold of her nose, and pinched it till it was red and blue;
+but this was all done out of pure love.
+
+When the mother had taken a sup at her flask, and was having a nap, the
+little robber maiden went to the Reindeer, and said, “I should very much
+like to give you still many a tickling with the sharp knife, for then
+you are so amusing; however, I will untether you, and help you out,
+so that you may go back to Lapland. But you must make good use of your
+legs; and take this little girl for me to the palace of the Snow Queen,
+where her playfellow is. You have heard, I suppose, all she said; for
+she spoke loud enough, and you were listening.”
+
+The Reindeer gave a bound for joy. The robber maiden lifted up little
+Gerda, and took the precaution to bind her fast on the Reindeer’s back;
+she even gave her a small cushion to sit on. “Here are your worsted
+leggins, for it will be cold; but the muff I shall keep for myself, for
+it is so very pretty. But I do not wish you to be cold. Here is a pair
+of lined gloves of my mother’s; they just reach up to your elbow. On
+with them! Now you look about the hands just like my ugly old mother!”
+
+And Gerda wept for joy.
+
+“I can’t bear to see you fretting,” said the little robber maiden. “This
+is just the time when you ought to look pleased. Here are two loaves and
+a ham for you, so that you won’t starve.” The bread and the meat were
+fastened to the Reindeer’s back; the little maiden opened the door,
+called in all the dogs, and then with her knife cut the rope that
+fastened the animal, and said to him, “Now, off with you; but take good
+care of the little girl!”
+
+And Gerda stretched out her hands with the large wadded gloves towards
+the robber maiden, and said, “Farewell!” and the Reindeer flew on over
+bush and bramble through the great wood, over moor and heath, as fast as
+he could go.
+
+“Ddsa! Ddsa!” was heard in the sky. It was just as if somebody was
+sneezing.
+
+“These are my old northern-lights,” said the Reindeer, “look how they
+gleam!” And on he now sped still quicker--day and night on he went: the
+loaves were consumed, and the ham too; and now they were in Lapland.
+
+
+SIXTH STORY. The Lapland Woman and the Finland Woman
+
+Suddenly they stopped before a little house, which looked very
+miserable. The roof reached to the ground; and the door was so low, that
+the family were obliged to creep upon their stomachs when they went in
+or out. Nobody was at home except an old Lapland woman, who was dressing
+fish by the light of an oil lamp. And the Reindeer told her the whole
+of Gerda’s history, but first of all his own; for that seemed to him of
+much greater importance. Gerda was so chilled that she could not speak.
+
+“Poor thing,” said the Lapland woman, “you have far to run still. You
+have more than a hundred miles to go before you get to Finland; there
+the Snow Queen has her country-house, and burns blue lights every
+evening. I will give you a few words from me, which I will write on a
+dried haberdine, for paper I have none; this you can take with you to
+the Finland woman, and she will be able to give you more information
+than I can.”
+
+When Gerda had warmed herself, and had eaten and drunk, the Lapland
+woman wrote a few words on a dried haberdine, begged Gerda to take care
+of them, put her on the Reindeer, bound her fast, and away sprang the
+animal. “Ddsa! Ddsa!” was again heard in the air; the most charming
+blue lights burned the whole night in the sky, and at last they came to
+Finland. They knocked at the chimney of the Finland woman; for as to a
+door, she had none.
+
+There was such a heat inside that the Finland woman herself went about
+almost naked. She was diminutive and dirty. She immediately loosened
+little Gerda’s clothes, pulled off her thick gloves and boots; for
+otherwise the heat would have been too great--and after laying a piece
+of ice on the Reindeer’s head, read what was written on the fish-skin.
+She read it three times: she then knew it by heart; so she put the fish
+into the cupboard--for it might very well be eaten, and she never threw
+anything away.
+
+Then the Reindeer related his own story first, and afterwards that of
+little Gerda; and the Finland woman winked her eyes, but said nothing.
+
+“You are so clever,” said the Reindeer; “you can, I know, twist all the
+winds of the world together in a knot. If the seaman loosens one knot,
+then he has a good wind; if a second, then it blows pretty stiffly; if
+he undoes the third and fourth, then it rages so that the forests are
+upturned. Will you give the little maiden a potion, that she may possess
+the strength of twelve men, and vanquish the Snow Queen?”
+
+“The strength of twelve men!” said the Finland woman. “Much good that
+would be!” Then she went to a cupboard, and drew out a large skin rolled
+up. When she had unrolled it, strange characters were to be seen written
+thereon; and the Finland woman read at such a rate that the perspiration
+trickled down her forehead.
+
+But the Reindeer begged so hard for little Gerda, and Gerda looked so
+imploringly with tearful eyes at the Finland woman, that she winked, and
+drew the Reindeer aside into a corner, where they whispered together,
+while the animal got some fresh ice put on his head.
+
+“‘Tis true little Kay is at the Snow Queen’s, and finds everything there
+quite to his taste; and he thinks it the very best place in the world;
+but the reason of that is, he has a splinter of glass in his eye, and in
+his heart. These must be got out first; otherwise he will never go back
+to mankind, and the Snow Queen will retain her power over him.”
+
+“But can you give little Gerda nothing to take which will endue her with
+power over the whole?”
+
+“I can give her no more power than what she has already. Don’t you see
+how great it is? Don’t you see how men and animals are forced to serve
+her; how well she gets through the world barefooted? She must not hear
+of her power from us; that power lies in her heart, because she is
+a sweet and innocent child! If she cannot get to the Snow Queen by
+herself, and rid little Kay of the glass, we cannot help her. Two miles
+hence the garden of the Snow Queen begins; thither you may carry the
+little girl. Set her down by the large bush with red berries, standing
+in the snow; don’t stay talking, but hasten back as fast as possible.”
+ And now the Finland woman placed little Gerda on the Reindeer’s back,
+and off he ran with all imaginable speed.
+
+“Oh! I have not got my boots! I have not brought my gloves!” cried
+little Gerda. She remarked she was without them from the cutting frost;
+but the Reindeer dared not stand still; on he ran till he came to the
+great bush with the red berries, and there he set Gerda down, kissed her
+mouth, while large bright tears flowed from the animal’s eyes, and then
+back he went as fast as possible. There stood poor Gerda now, without
+shoes or gloves, in the very middle of dreadful icy Finland.
+
+She ran on as fast as she could. There then came a whole regiment of
+snow-flakes, but they did not fall from above, and they were quite
+bright and shining from the Aurora Borealis. The flakes ran along
+the ground, and the nearer they came the larger they grew. Gerda well
+remembered how large and strange the snow-flakes appeared when she
+once saw them through a magnifying-glass; but now they were large and
+terrific in another manner--they were all alive. They were the outposts
+of the Snow Queen. They had the most wondrous shapes; some looked like
+large ugly porcupines; others like snakes knotted together, with their
+heads sticking out; and others, again, like small fat bears, with the
+hair standing on end: all were of dazzling whiteness--all were living
+snow-flakes.
+
+Little Gerda repeated the Lord’s Prayer. The cold was so intense that
+she could see her own breath, which came like smoke out of her mouth. It
+grew thicker and thicker, and took the form of little angels, that grew
+more and more when they touched the earth. All had helms on their heads,
+and lances and shields in their hands; they increased in numbers; and
+when Gerda had finished the Lord’s Prayer, she was surrounded by a whole
+legion. They thrust at the horrid snow-flakes with their spears, so that
+they flew into a thousand pieces; and little Gerda walked on bravely and
+in security. The angels patted her hands and feet; and then she felt the
+cold less, and went on quickly towards the palace of the Snow Queen.
+
+But now we shall see how Kay fared. He never thought of Gerda, and least
+of all that she was standing before the palace.
+
+
+SEVENTH STORY. What Took Place in the Palace of the Snow Queen, and what
+Happened Afterward.
+
+The walls of the palace were of driving snow, and the windows and doors
+of cutting winds. There were more than a hundred halls there, according
+as the snow was driven by the winds. The largest was many miles in
+extent; all were lighted up by the powerful Aurora Borealis, and all
+were so large, so empty, so icy cold, and so resplendent! Mirth never
+reigned there; there was never even a little bear-ball, with the storm
+for music, while the polar bears went on their hind legs and showed off
+their steps. Never a little tea-party of white young lady foxes; vast,
+cold, and empty were the halls of the Snow Queen. The northern-lights
+shone with such precision that one could tell exactly when they were
+at their highest or lowest degree of brightness. In the middle of the
+empty, endless hall of snow, was a frozen lake; it was cracked in a
+thousand pieces, but each piece was so like the other, that it seemed
+the work of a cunning artificer. In the middle of this lake sat the Snow
+Queen when she was at home; and then she said she was sitting in the
+Mirror of Understanding, and that this was the only one and the best
+thing in the world.
+
+Little Kay was quite blue, yes nearly black with cold; but he did not
+observe it, for she had kissed away all feeling of cold from his body,
+and his heart was a lump of ice. He was dragging along some pointed
+flat pieces of ice, which he laid together in all possible ways, for he
+wanted to make something with them; just as we have little flat pieces
+of wood to make geometrical figures with, called the Chinese Puzzle.
+Kay made all sorts of figures, the most complicated, for it was
+an ice-puzzle for the understanding. In his eyes the figures were
+extraordinarily beautiful, and of the utmost importance; for the bit
+of glass which was in his eye caused this. He found whole figures which
+represented a written word; but he never could manage to represent just
+the word he wanted--that word was “eternity”; and the Snow Queen had
+said, “If you can discover that figure, you shall be your own master,
+and I will make you a present of the whole world and a pair of new
+skates.” But he could not find it out.
+
+“I am going now to warm lands,” said the Snow Queen. “I must have a look
+down into the black caldrons.” It was the volcanoes Vesuvius and Etna
+that she meant. “I will just give them a coating of white, for that is
+as it ought to be; besides, it is good for the oranges and the grapes.”
+ And then away she flew, and Kay sat quite alone in the empty halls of
+ice that were miles long, and looked at the blocks of ice, and thought
+and thought till his skull was almost cracked. There he sat quite
+benumbed and motionless; one would have imagined he was frozen to death.
+
+Suddenly little Gerda stepped through the great portal into the palace.
+The gate was formed of cutting winds; but Gerda repeated her evening
+prayer, and the winds were laid as though they slept; and the little
+maiden entered the vast, empty, cold halls. There she beheld Kay: she
+recognised him, flew to embrace him, and cried out, her arms firmly
+holding him the while, “Kay, sweet little Kay! Have I then found you at
+last?”
+
+But he sat quite still, benumbed and cold. Then little Gerda shed
+burning tears; and they fell on his bosom, they penetrated to his
+heart, they thawed the lumps of ice, and consumed the splinters of the
+looking-glass; he looked at her, and she sang the hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+Hereupon Kay burst into tears; he wept so much that the splinter rolled
+out of his eye, and he recognised her, and shouted, “Gerda, sweet little
+Gerda! Where have you been so long? And where have I been?” He looked
+round him. “How cold it is here!” said he. “How empty and cold!” And he
+held fast by Gerda, who laughed and wept for joy. It was so beautiful,
+that even the blocks of ice danced about for joy; and when they were
+tired and laid themselves down, they formed exactly the letters which
+the Snow Queen had told him to find out; so now he was his own master,
+and he would have the whole world and a pair of new skates into the
+bargain.
+
+Gerda kissed his cheeks, and they grew quite blooming; she kissed his
+eyes, and they shone like her own; she kissed his hands and feet, and he
+was again well and merry. The Snow Queen might come back as soon as she
+liked; there stood his discharge written in resplendent masses of ice.
+
+They took each other by the hand, and wandered forth out of the large
+hall; they talked of their old grandmother, and of the roses upon the
+roof; and wherever they went, the winds ceased raging, and the sun burst
+forth. And when they reached the bush with the red berries, they found
+the Reindeer waiting for them. He had brought another, a young one, with
+him, whose udder was filled with milk, which he gave to the little ones,
+and kissed their lips. They then carried Kay and Gerda--first to the
+Finland woman, where they warmed themselves in the warm room, and
+learned what they were to do on their journey home; and they went to
+the Lapland woman, who made some new clothes for them and repaired their
+sledges.
+
+The Reindeer and the young hind leaped along beside them, and
+accompanied them to the boundary of the country. Here the first
+vegetation peeped forth; here Kay and Gerda took leave of the Lapland
+woman. “Farewell! Farewell!” they all said. And the first green buds
+appeared, the first little birds began to chirrup; and out of the wood
+came, riding on a magnificent horse, which Gerda knew (it was one of the
+leaders in the golden carriage), a young damsel with a bright-red cap on
+her head, and armed with pistols. It was the little robber maiden, who,
+tired of being at home, had determined to make a journey to the north;
+and afterwards in another direction, if that did not please her. She
+recognised Gerda immediately, and Gerda knew her too. It was a joyful
+meeting.
+
+“You are a fine fellow for tramping about,” said she to little Kay; “I
+should like to know, faith, if you deserve that one should run from one
+end of the world to the other for your sake?”
+
+But Gerda patted her cheeks, and inquired for the Prince and Princess.
+
+“They are gone abroad,” said the other.
+
+“But the Raven?” asked little Gerda.
+
+“Oh! The Raven is dead,” she answered. “His tame sweetheart is a
+widow, and wears a bit of black worsted round her leg; she laments most
+piteously, but it’s all mere talk and stuff! Now tell me what you’ve
+been doing and how you managed to catch him.”
+
+And Gerda and Kay both told their story.
+
+And “Schnipp-schnapp-schnurre-basselurre,” said the robber maiden; and
+she took the hands of each, and promised that if she should some day
+pass through the town where they lived, she would come and visit them;
+and then away she rode. Kay and Gerda took each other’s hand: it was
+lovely spring weather, with abundance of flowers and of verdure. The
+church-bells rang, and the children recognised the high towers, and the
+large town; it was that in which they dwelt. They entered and hastened
+up to their grandmother’s room, where everything was standing as
+formerly. The clock said “tick! tack!” and the finger moved round; but
+as they entered, they remarked that they were now grown up. The roses
+on the leads hung blooming in at the open window; there stood the little
+children’s chairs, and Kay and Gerda sat down on them, holding each
+other by the hand; they both had forgotten the cold empty splendor of
+the Snow Queen, as though it had been a dream. The grandmother sat in
+the bright sunshine, and read aloud from the Bible: “Unless ye become as
+little children, ye cannot enter the kingdom of heaven.”
+
+And Kay and Gerda looked in each other’s eyes, and all at once they
+understood the old hymn:
+
+“The rose in the valley is blooming so sweet, And angels descend there
+the children to greet.”
+
+There sat the two grown-up persons; grown-up, and yet children; children
+at least in heart; and it was summer-time; summer, glorious summer!
+
+
+
+
+THE LEAP-FROG
+
+A Flea, a Grasshopper, and a Leap-frog once wanted to see which could
+jump highest; and they invited the whole world, and everybody else
+besides who chose to come to see the festival. Three famous jumpers were
+they, as everyone would say, when they all met together in the room.
+
+“I will give my daughter to him who jumps highest,” exclaimed the King;
+“for it is not so amusing where there is no prize to jump for.”
+
+The Flea was the first to step forward. He had exquisite manners, and
+bowed to the company on all sides; for he had noble blood, and was,
+moreover, accustomed to the society of man alone; and that makes a great
+difference.
+
+Then came the Grasshopper. He was considerably heavier, but he was
+well-mannered, and wore a green uniform, which he had by right of birth;
+he said, moreover, that he belonged to a very ancient Egyptian family,
+and that in the house where he then was, he was thought much of. The
+fact was, he had been just brought out of the fields, and put in a
+pasteboard house, three stories high, all made of court-cards, with the
+colored side inwards; and doors and windows cut out of the body of
+the Queen of Hearts. “I sing so well,” said he, “that sixteen native
+grasshoppers who have chirped from infancy, and yet got no house built
+of cards to live in, grew thinner than they were before for sheer
+vexation when they heard me.”
+
+It was thus that the Flea and the Grasshopper gave an account of
+themselves, and thought they were quite good enough to marry a Princess.
+
+The Leap-frog said nothing; but people gave it as their opinion, that
+he therefore thought the more; and when the housedog snuffed at him
+with his nose, he confessed the Leap-frog was of good family. The old
+councillor, who had had three orders given him to make him hold his
+tongue, asserted that the Leap-frog was a prophet; for that one could
+see on his back, if there would be a severe or mild winter, and that
+was what one could not see even on the back of the man who writes the
+almanac.
+
+“I say nothing, it is true,” exclaimed the King; “but I have my own
+opinion, notwithstanding.”
+
+Now the trial was to take place. The Flea jumped so high that nobody
+could see where he went to; so they all asserted he had not jumped at
+all; and that was dishonorable.
+
+The Grasshopper jumped only half as high; but he leaped into the King’s
+face, who said that was ill-mannered.
+
+The Leap-frog stood still for a long time lost in thought; it was
+believed at last he would not jump at all.
+
+“I only hope he is not unwell,” said the house-dog; when, pop! he made a
+jump all on one side into the lap of the Princess, who was sitting on a
+little golden stool close by.
+
+Hereupon the King said, “There is nothing above my daughter; therefore
+to bound up to her is the highest jump that can be made; but for this,
+one must possess understanding, and the Leap-frog has shown that he has
+understanding. He is brave and intellectual.”
+
+And so he won the Princess.
+
+“It’s all the same to me,” said the Flea. “She may have the old
+Leap-frog, for all I care. I jumped the highest; but in this world
+merit seldom meets its reward. A fine exterior is what people look at
+now-a-days.”
+
+The Flea then went into foreign service, where, it is said, he was
+killed.
+
+The Grasshopper sat without on a green bank, and reflected on worldly
+things; and he said too, “Yes, a fine exterior is everything--a fine
+exterior is what people care about.” And then he began chirping his
+peculiar melancholy song, from which we have taken this history; and
+which may, very possibly, be all untrue, although it does stand here
+printed in black and white.
+
+
+
+
+THE ELDERBUSH
+
+Once upon a time there was a little boy who had taken cold. He had
+gone out and got his feet wet; though nobody could imagine how it had
+happened, for it was quite dry weather. So his mother undressed him, put
+him to bed, and had the tea-pot brought in, to make him a good cup of
+Elderflower tea. Just at that moment the merry old man came in who
+lived up a-top of the house all alone; for he had neither wife nor
+children--but he liked children very much, and knew so many fairy tales,
+that it was quite delightful.
+
+“Now drink your tea,” said the boy’s mother; “then, perhaps, you may
+hear a fairy tale.”
+
+“If I had but something new to tell,” said the old man. “But how did the
+child get his feet wet?”
+
+“That is the very thing that nobody can make out,” said his mother.
+
+“Am I to hear a fairy tale?” asked the little boy.
+
+“Yes, if you can tell me exactly--for I must know that first--how deep
+the gutter is in the little street opposite, that you pass through in
+going to school.”
+
+“Just up to the middle of my boot,” said the child; “but then I must go
+into the deep hole.”
+
+“Ah, ah! That’s where the wet feet came from,” said the old man. “I
+ought now to tell you a story; but I don’t know any more.”
+
+“You can make one in a moment,” said the little boy. “My mother says
+that all you look at can be turned into a fairy tale: and that you can
+find a story in everything.”
+
+“Yes, but such tales and stories are good for nothing. The right sort
+come of themselves; they tap at my forehead and say, ‘Here we are.’”
+
+“Won’t there be a tap soon?” asked the little boy. And his mother
+laughed, put some Elder-flowers in the tea-pot, and poured boiling water
+upon them.
+
+“Do tell me something! Pray do!”
+
+“Yes, if a fairy tale would come of its own accord; but they are proud
+and haughty, and come only when they choose. Stop!” said he, all on a
+sudden. “I have it! Pay attention! There is one in the tea-pot!”
+
+And the little boy looked at the tea-pot. The cover rose more and more;
+and the Elder-flowers came forth so fresh and white, and shot up long
+branches. Out of the spout even did they spread themselves on all sides,
+and grew larger and larger; it was a splendid Elderbush, a whole tree;
+and it reached into the very bed, and pushed the curtains aside. How
+it bloomed! And what an odour! In the middle of the bush sat a
+friendly-looking old woman in a most strange dress. It was quite
+green, like the leaves of the elder, and was trimmed with large white
+Elder-flowers; so that at first one could not tell whether it was a
+stuff, or a natural green and real flowers.
+
+“What’s that woman’s name?” asked the little boy.
+
+“The Greeks and Romans,” said the old man, “called her a Dryad; but that
+we do not understand. The people who live in the New Booths [*] have a much
+better name for her; they call her ‘old Granny’--and she it is to
+whom you are to pay attention. Now listen, and look at the beautiful
+Elderbush.
+
+     * A row of buildings for seamen in Copenhagen.
+
+“Just such another large blooming Elder Tree stands near the New Booths.
+It grew there in the corner of a little miserable court-yard; and under
+it sat, of an afternoon, in the most splendid sunshine, two old
+people; an old, old seaman, and his old, old wife. They had
+great-grand-children, and were soon to celebrate the fiftieth
+anniversary of their marriage; but they could not exactly recollect the
+date: and old Granny sat in the tree, and looked as pleased as now. ‘I
+know the date,’ said she; but those below did not hear her, for they
+were talking about old times.
+
+“‘Yes, can’t you remember when we were very little,’ said the old
+seaman, ‘and ran and played about? It was the very same court-yard where
+we now are, and we stuck slips in the ground, and made a garden.’
+
+“‘I remember it well,’ said the old woman; ‘I remember it quite well. We
+watered the slips, and one of them was an Elderbush. It took root, put
+forth green shoots, and grew up to be the large tree under which we old
+folks are now sitting.’
+
+“‘To be sure,’ said he. ‘And there in the corner stood a waterpail,
+where I used to swim my boats.’
+
+“‘True; but first we went to school to learn somewhat,’ said she; ‘and
+then we were confirmed. We both cried; but in the afternoon we went up
+the Round Tower, and looked down on Copenhagen, and far, far away over
+the water; then we went to Friedericksberg, where the King and the Queen
+were sailing about in their splendid barges.’
+
+“‘But I had a different sort of sailing to that, later; and that, too,
+for many a year; a long way off, on great voyages.’
+
+“‘Yes, many a time have I wept for your sake,’ said she. ‘I thought you
+were dead and gone, and lying down in the deep waters. Many a night have
+I got up to see if the wind had not changed: and changed it had, sure
+enough; but you never came. I remember so well one day, when the rain
+was pouring down in torrents, the scavengers were before the house where
+I was in service, and I had come up with the dust, and remained standing
+at the door--it was dreadful weather--when just as I was there, the
+postman came and gave me a letter. It was from you! What a tour that
+letter had made! I opened it instantly and read: I laughed and wept.
+I was so happy. In it I read that you were in warm lands where the
+coffee-tree grows. What a blessed land that must be! You related so
+much, and I saw it all the while the rain was pouring down, and I
+standing there with the dust-box. At the same moment came someone who
+embraced me.’
+
+“‘Yes; but you gave him a good box on his ear that made it tingle!’
+
+“‘But I did not know it was you. You arrived as soon as your letter,
+and you were so handsome--that you still are--and had a long yellow silk
+handkerchief round your neck, and a bran new hat on; oh, you were so
+dashing! Good heavens! What weather it was, and what a state the street
+was in!’
+
+“‘And then we married,’ said he. ‘Don’t you remember? And then we
+had our first little boy, and then Mary, and Nicholas, and Peter, and
+Christian.’
+
+“‘Yes, and how they all grew up to be honest people, and were beloved by
+everybody.’
+
+“‘And their children also have children,’ said the old sailor; ‘yes,
+those are our grand-children, full of strength and vigor. It was,
+methinks about this season that we had our wedding.’
+
+“‘Yes, this very day is the fiftieth anniversary of the marriage,’ said
+old Granny, sticking her head between the two old people; who thought
+it was their neighbor who nodded to them. They looked at each other and
+held one another by the hand. Soon after came their children, and their
+grand-children; for they knew well enough that it was the day of the
+fiftieth anniversary, and had come with their gratulations that very
+morning; but the old people had forgotten it, although they were able
+to remember all that had happened many years ago. And the Elderbush sent
+forth a strong odour in the sun, that was just about to set, and shone
+right in the old people’s faces. They both looked so rosy-cheeked; and
+the youngest of the grandchildren danced around them, and called out
+quite delighted, that there was to be something very splendid that
+evening--they were all to have hot potatoes. And old Nanny nodded in the
+bush, and shouted ‘hurrah!’ with the rest.”
+
+“But that is no fairy tale,” said the little boy, who was listening to
+the story.
+
+“The thing is, you must understand it,” said the narrator; “let us ask
+old Nanny.”
+
+“That was no fairy tale, ‘tis true,” said old Nanny; “but now it’s
+coming. The most wonderful fairy tales grow out of that which is
+reality; were that not the case, you know, my magnificent Elderbush
+could not have grown out of the tea-pot.” And then she took the little
+boy out of bed, laid him on her bosom, and the branches of the Elder
+Tree, full of flowers, closed around her. They sat in an aerial
+dwelling, and it flew with them through the air. Oh, it was wondrous
+beautiful! Old Nanny had grown all of a sudden a young and pretty
+maiden; but her robe was still the same green stuff with white flowers,
+which she had worn before. On her bosom she had a real Elderflower,
+and in her yellow waving hair a wreath of the flowers; her eyes were so
+large and blue that it was a pleasure to look at them; she kissed the
+boy, and now they were of the same age and felt alike.
+
+Hand in hand they went out of the bower, and they were standing in the
+beautiful garden of their home. Near the green lawn papa’s walking-stick
+was tied, and for the little ones it seemed to be endowed with life; for
+as soon as they got astride it, the round polished knob was turned into
+a magnificent neighing head, a long black mane fluttered in the breeze,
+and four slender yet strong legs shot out. The animal was strong and
+handsome, and away they went at full gallop round the lawn.
+
+“Huzza! Now we are riding miles off,” said the boy. “We are riding away
+to the castle where we were last year!”
+
+And on they rode round the grass-plot; and the little maiden, who, we
+know, was no one else but old Nanny, kept on crying out, “Now we are in
+the country! Don’t you see the farm-house yonder? And there is an Elder
+Tree standing beside it; and the cock is scraping away the earth for the
+hens, look, how he struts! And now we are close to the church. It lies
+high upon the hill, between the large oak-trees, one of which is half
+decayed. And now we are by the smithy, where the fire is blazing, and
+where the half-naked men are banging with their hammers till the sparks
+fly about. Away! away! To the beautiful country-seat!”
+
+And all that the little maiden, who sat behind on the stick, spoke of,
+flew by in reality. The boy saw it all, and yet they were only going
+round the grass-plot. Then they played in a side avenue, and marked out
+a little garden on the earth; and they took Elder-blossoms from their
+hair, planted them, and they grew just like those the old people planted
+when they were children, as related before. They went hand in hand, as
+the old people had done when they were children; but not to the Round
+Tower, or to Friedericksberg; no, the little damsel wound her arms round
+the boy, and then they flew far away through all Denmark. And spring
+came, and summer; and then it was autumn, and then winter; and a
+thousand pictures were reflected in the eye and in the heart of the boy;
+and the little girl always sang to him, “This you will never forget.”
+ And during their whole flight the Elder Tree smelt so sweet and odorous;
+he remarked the roses and the fresh beeches, but the Elder Tree had
+a more wondrous fragrance, for its flowers hung on the breast of the
+little maiden; and there, too, did he often lay his head during the
+flight.
+
+“It is lovely here in spring!” said the young maiden. And they stood in
+a beech-wood that had just put on its first green, where the woodroof [*]
+at their feet sent forth its fragrance, and the pale-red anemony looked
+so pretty among the verdure. “Oh, would it were always spring in the
+sweetly-smelling Danish beech-forests!”
+
+     * Asperula odorata.
+
+“It is lovely here in summer!” said she. And she flew past old castles
+of by-gone days of chivalry, where the red walls and the embattled
+gables were mirrored in the canal, where the swans were swimming, and
+peered up into the old cool avenues. In the fields the corn was waving
+like the sea; in the ditches red and yellow flowers were growing; while
+wild-drone flowers, and blooming convolvuluses were creeping in the
+hedges; and towards evening the moon rose round and large, and the
+haycocks in the meadows smelt so sweetly. “This one never forgets!”
+
+“It is lovely here in autumn!” said the little maiden. And suddenly the
+atmosphere grew as blue again as before; the forest grew red, and green,
+and yellow-colored. The dogs came leaping along, and whole flocks of
+wild-fowl flew over the cairn, where blackberry-bushes were hanging
+round the old stones. The sea was dark blue, covered with ships full
+of white sails; and in the barn old women, maidens, and children were
+sitting picking hops into a large cask; the young sang songs, but the
+old told fairy tales of mountain-sprites and soothsayers. Nothing could
+be more charming.
+
+“It is delightful here in winter!” said the little maiden. And all the
+trees were covered with hoar-frost; they looked like white corals; the
+snow crackled under foot, as if one had new boots on; and one falling
+star after the other was seen in the sky. The Christmas-tree was lighted
+in the room; presents were there, and good-humor reigned. In the country
+the violin sounded in the room of the peasant; the newly-baked cakes
+were attacked; even the poorest child said, “It is really delightful
+here in winter!”
+
+Yes, it was delightful; and the little maiden showed the boy everything;
+and the Elder Tree still was fragrant, and the red flag, with the white
+cross, was still waving: the flag under which the old seaman in the New
+Booths had sailed. And the boy grew up to be a lad, and was to go forth
+in the wide world-far, far away to warm lands, where the coffee-tree
+grows; but at his departure the little maiden took an Elder-blossom from
+her bosom, and gave it him to keep; and it was placed between the leaves
+of his Prayer-Book; and when in foreign lands he opened the book, it
+was always at the place where the keepsake-flower lay; and the more he
+looked at it, the fresher it became; he felt as it were, the fragrance
+of the Danish groves; and from among the leaves of the flowers he could
+distinctly see the little maiden, peeping forth with her bright blue
+eyes--and then she whispered, “It is delightful here in Spring, Summer,
+Autumn, and Winter”; and a hundred visions glided before his mind.
+
+Thus passed many years, and he was now an old man, and sat with his old
+wife under the blooming tree. They held each other by the hand, as the
+old grand-father and grand-mother yonder in the New Booths did, and they
+talked exactly like them of old times, and of the fiftieth anniversary
+of their wedding. The little maiden, with the blue eyes, and with
+Elder-blossoms in her hair, sat in the tree, nodded to both of them,
+and said, “To-day is the fiftieth anniversary!” And then she took two
+flowers out of her hair, and kissed them. First, they shone like silver,
+then like gold; and when they laid them on the heads of the old people,
+each flower became a golden crown. So there they both sat, like a king
+and a queen, under the fragrant tree, that looked exactly like an elder:
+the old man told his wife the story of “Old Nanny,” as it had been told
+him when a boy. And it seemed to both of them it contained much that
+resembled their own history; and those parts that were like it pleased
+them best.
+
+“Thus it is,” said the little maiden in the tree, “some call me ‘Old
+Nanny,’ others a ‘Dryad,’ but, in reality, my name is ‘Remembrance’;
+‘tis I who sit in the tree that grows and grows! I can remember; I can
+tell things! Let me see if you have my flower still?”
+
+And the old man opened his Prayer-Book. There lay the Elder-blossom,
+as fresh as if it had been placed there but a short time before; and
+Remembrance nodded, and the old people, decked with crowns of gold, sat
+in the flush of the evening sun. They closed their eyes, and--and--!
+Yes, that’s the end of the story!
+
+The little boy lay in his bed; he did not know if he had dreamed or
+not, or if he had been listening while someone told him the story. The
+tea-pot was standing on the table, but no Elder Tree was growing out
+of it! And the old man, who had been talking, was just on the point of
+going out at the door, and he did go.
+
+“How splendid that was!” said the little boy. “Mother, I have been to
+warm countries.”
+
+“So I should think,” said his mother. “When one has drunk two good
+cupfuls of Elder-flower tea, ‘tis likely enough one goes into warm
+climates”; and she tucked him up nicely, least he should take cold. “You
+have had a good sleep while I have been sitting here, and arguing with
+him whether it was a story or a fairy tale.”
+
+“And where is old Nanny?” asked the little boy.
+
+“In the tea-pot,” said his mother; “and there she may remain.”
+
+
+
+
+THE BELL
+
+People said “The Evening Bell is sounding, the sun is setting.” For a
+strange wondrous tone was heard in the narrow streets of a large town.
+It was like the sound of a church-bell: but it was only heard for a
+moment, for the rolling of the carriages and the voices of the multitude
+made too great a noise.
+
+Those persons who were walking outside the town, where the houses were
+farther apart, with gardens or little fields between them, could see
+the evening sky still better, and heard the sound of the bell much
+more distinctly. It was as if the tones came from a church in the still
+forest; people looked thitherward, and felt their minds attuned most
+solemnly.
+
+A long time passed, and people said to each other--“I wonder if there
+is a church out in the wood? The bell has a tone that is wondrous sweet;
+let us stroll thither, and examine the matter nearer.” And the rich
+people drove out, and the poor walked, but the way seemed strangely
+long to them; and when they came to a clump of willows which grew on the
+skirts of the forest, they sat down, and looked up at the long
+branches, and fancied they were now in the depth of the green wood. The
+confectioner of the town came out, and set up his booth there; and soon
+after came another confectioner, who hung a bell over his stand, as
+a sign or ornament, but it had no clapper, and it was tarred over to
+preserve it from the rain. When all the people returned home, they said
+it had been very romantic, and that it was quite a different sort of
+thing to a pic-nic or tea-party. There were three persons who asserted
+they had penetrated to the end of the forest, and that they had always
+heard the wonderful sounds of the bell, but it had seemed to them as if
+it had come from the town. One wrote a whole poem about it, and said the
+bell sounded like the voice of a mother to a good dear child, and
+that no melody was sweeter than the tones of the bell. The king of the
+country was also observant of it, and vowed that he who could discover
+whence the sounds proceeded, should have the title of “Universal
+Bell-ringer,” even if it were not really a bell.
+
+Many persons now went to the wood, for the sake of getting the place,
+but one only returned with a sort of explanation; for nobody went far
+enough, that one not further than the others. However, he said that
+the sound proceeded from a very large owl, in a hollow tree; a sort of
+learned owl, that continually knocked its head against the branches. But
+whether the sound came from his head or from the hollow tree, that no
+one could say with certainty. So now he got the place of “Universal
+Bell-ringer,” and wrote yearly a short treatise “On the Owl”; but
+everybody was just as wise as before.
+
+It was the day of confirmation. The clergyman had spoken so touchingly,
+the children who were confirmed had been greatly moved; it was
+an eventful day for them; from children they become all at once
+grown-up-persons; it was as if their infant souls were now to fly all
+at once into persons with more understanding. The sun was shining
+gloriously; the children that had been confirmed went out of the town;
+and from the wood was borne towards them the sounds of the unknown bell
+with wonderful distinctness. They all immediately felt a wish to go
+thither; all except three. One of them had to go home to try on a
+ball-dress; for it was just the dress and the ball which had caused her
+to be confirmed this time, for otherwise she would not have come;
+the other was a poor boy, who had borrowed his coat and boots to be
+confirmed in from the innkeeper’s son, and he was to give them back by
+a certain hour; the third said that he never went to a strange place
+if his parents were not with him--that he had always been a good boy
+hitherto, and would still be so now that he was confirmed, and that one
+ought not to laugh at him for it: the others, however, did make fun of
+him, after all.
+
+There were three, therefore, that did not go; the others hastened on.
+The sun shone, the birds sang, and the children sang too, and each held
+the other by the hand; for as yet they had none of them any high office,
+and were all of equal rank in the eye of God.
+
+But two of the youngest soon grew tired, and both returned to town; two
+little girls sat down, and twined garlands, so they did not go either;
+and when the others reached the willow-tree, where the confectioner was,
+they said, “Now we are there! In reality the bell does not exist; it is
+only a fancy that people have taken into their heads!”
+
+At the same moment the bell sounded deep in the wood, so clear and
+solemnly that five or six determined to penetrate somewhat further. It
+was so thick, and the foliage so dense, that it was quite fatiguing
+to proceed. Woodroof and anemonies grew almost too high; blooming
+convolvuluses and blackberry-bushes hung in long garlands from tree to
+tree, where the nightingale sang and the sunbeams were playing: it was
+very beautiful, but it was no place for girls to go; their clothes would
+get so torn. Large blocks of stone lay there, overgrown with moss of
+every color; the fresh spring bubbled forth, and made a strange gurgling
+sound.
+
+“That surely cannot be the bell,” said one of the children, lying down
+and listening. “This must be looked to.” So he remained, and let the
+others go on without him.
+
+They afterwards came to a little house, made of branches and the bark of
+trees; a large wild apple-tree bent over it, as if it would shower down
+all its blessings on the roof, where roses were blooming. The long stems
+twined round the gable, on which there hung a small bell.
+
+Was it that which people had heard? Yes, everybody was unanimous on the
+subject, except one, who said that the bell was too small and too fine
+to be heard at so great a distance, and besides it was very different
+tones to those that could move a human heart in such a manner. It was a
+king’s son who spoke; whereon the others said, “Such people always want
+to be wiser than everybody else.”
+
+They now let him go on alone; and as he went, his breast was filled more
+and more with the forest solitude; but he still heard the little bell
+with which the others were so satisfied, and now and then, when the
+wind blew, he could also hear the people singing who were sitting at tea
+where the confectioner had his tent; but the deep sound of the bell rose
+louder; it was almost as if an organ were accompanying it, and the tones
+came from the left hand, the side where the heart is placed. A rustling
+was heard in the bushes, and a little boy stood before the King’s Son, a
+boy in wooden shoes, and with so short a jacket that one could see what
+long wrists he had. Both knew each other: the boy was that one among
+the children who could not come because he had to go home and return his
+jacket and boots to the innkeeper’s son. This he had done, and was now
+going on in wooden shoes and in his humble dress, for the bell sounded
+with so deep a tone, and with such strange power, that proceed he must.
+
+“Why, then, we can go together,” said the King’s Son. But the poor
+child that had been confirmed was quite ashamed; he looked at his wooden
+shoes, pulled at the short sleeves of his jacket, and said that he was
+afraid he could not walk so fast; besides, he thought that the bell must
+be looked for to the right; for that was the place where all sorts of
+beautiful things were to be found.
+
+“But there we shall not meet,” said the King’s Son, nodding at the same
+time to the poor boy, who went into the darkest, thickest part of the
+wood, where thorns tore his humble dress, and scratched his face and
+hands and feet till they bled. The King’s Son got some scratches too;
+but the sun shone on his path, and it is him that we will follow, for he
+was an excellent and resolute youth.
+
+“I must and will find the bell,” said he, “even if I am obliged to go to
+the end of the world.”
+
+The ugly apes sat upon the trees, and grinned. “Shall we thrash him?”
+ said they. “Shall we thrash him? He is the son of a king!”
+
+But on he went, without being disheartened, deeper and deeper into the
+wood, where the most wonderful flowers were growing. There stood white
+lilies with blood-red stamina, skyblue tulips, which shone as they waved
+in the winds, and apple-trees, the apples of which looked exactly like
+large soapbubbles: so only think how the trees must have sparkled in the
+sunshine! Around the nicest green meads, where the deer were playing in
+the grass, grew magnificent oaks and beeches; and if the bark of one of
+the trees was cracked, there grass and long creeping plants grew in
+the crevices. And there were large calm lakes there too, in which white
+swans were swimming, and beat the air with their wings. The King’s Son
+often stood still and listened. He thought the bell sounded from the
+depths of these still lakes; but then he remarked again that the tone
+proceeded not from there, but farther off, from out the depths of the
+forest.
+
+The sun now set: the atmosphere glowed like fire. It was still in the
+woods, so very still; and he fell on his knees, sung his evening hymn,
+and said: “I cannot find what I seek; the sun is going down, and night
+is coming--the dark, dark night. Yet perhaps I may be able once more
+to see the round red sun before he entirely disappears. I will climb up
+yonder rock.”
+
+And he seized hold of the creeping-plants, and the roots of
+trees--climbed up the moist stones where the water-snakes were writhing
+and the toads were croaking--and he gained the summit before the sun
+had quite gone down. How magnificent was the sight from this height! The
+sea--the great, the glorious sea, that dashed its long waves against the
+coast--was stretched out before him. And yonder, where sea and sky meet,
+stood the sun, like a large shining altar, all melted together in the
+most glowing colors. And the wood and the sea sang a song of rejoicing,
+and his heart sang with the rest: all nature was a vast holy church,
+in which the trees and the buoyant clouds were the pillars, flowers and
+grass the velvet carpeting, and heaven itself the large cupola. The red
+colors above faded away as the sun vanished, but a million stars were
+lighted, a million lamps shone; and the King’s Son spread out his arms
+towards heaven, and wood, and sea; when at the same moment, coming by
+a path to the right, appeared, in his wooden shoes and jacket, the poor
+boy who had been confirmed with him. He had followed his own path, and
+had reached the spot just as soon as the son of the king had done. They
+ran towards each other, and stood together hand in hand in the vast
+church of nature and of poetry, while over them sounded the invisible
+holy bell: blessed spirits floated around them, and lifted up their
+voices in a rejoicing hallelujah!
+
+
+
+
+THE OLD HOUSE
+
+In the street, up there, was an old, a very old house--it was almost
+three hundred years old, for that might be known by reading the great
+beam on which the date of the year was carved: together with tulips and
+hop-binds there were whole verses spelled as in former times, and over
+every window was a distorted face cut out in the beam. The one story
+stood forward a great way over the other; and directly under the eaves
+was a leaden spout with a dragon’s head; the rain-water should have run
+out of the mouth, but it ran out of the belly, for there was a hole in
+the spout.
+
+All the other houses in the street were so new and so neat, with large
+window panes and smooth walls, one could easily see that they would have
+nothing to do with the old house: they certainly thought, “How long is
+that old decayed thing to stand here as a spectacle in the street? And
+then the projecting windows stand so far out, that no one can see from
+our windows what happens in that direction! The steps are as broad as
+those of a palace, and as high as to a church tower. The iron railings
+look just like the door to an old family vault, and then they have brass
+tops--that’s so stupid!”
+
+On the other side of the street were also new and neat houses, and they
+thought just as the others did; but at the window opposite the old house
+there sat a little boy with fresh rosy cheeks and bright beaming eyes:
+he certainly liked the old house best, and that both in sunshine and
+moonshine. And when he looked across at the wall where the mortar
+had fallen out, he could sit and find out there the strangest figures
+imaginable; exactly as the street had appeared before, with steps,
+projecting windows, and pointed gables; he could see soldiers with
+halberds, and spouts where the water ran, like dragons and serpents.
+That was a house to look at; and there lived an old man, who wore plush
+breeches; and he had a coat with large brass buttons, and a wig that one
+could see was a real wig. Every morning there came an old fellow to him
+who put his rooms in order, and went on errands; otherwise, the old man
+in the plush breeches was quite alone in the old house. Now and then he
+came to the window and looked out, and the little boy nodded to him,
+and the old man nodded again, and so they became acquaintances, and then
+they were friends, although they had never spoken to each other--but
+that made no difference. The little boy heard his parents say, “The old
+man opposite is very well off, but he is so very, very lonely!”
+
+The Sunday following, the little boy took something, and wrapped it up
+in a piece of paper, went downstairs, and stood in the doorway; and when
+the man who went on errands came past, he said to him--
+
+“I say, master! will you give this to the old man over the way from me?
+I have two pewter soldiers--this is one of them, and he shall have it,
+for I know he is so very, very lonely.”
+
+And the old errand man looked quite pleased, nodded, and took the pewter
+soldier over to the old house. Afterwards there came a message; it was
+to ask if the little boy himself had not a wish to come over and pay a
+visit; and so he got permission of his parents, and then went over to
+the old house.
+
+And the brass balls on the iron railings shone much brighter than ever;
+one would have thought they were polished on account of the visit; and
+it was as if the carved-out trumpeters--for there were trumpeters, who
+stood in tulips, carved out on the door--blew with all their
+might, their cheeks appeared so much rounder than before. Yes, they
+blew--“Trateratra! The little boy comes! Trateratra!”--and then the door
+opened.
+
+The whole passage was hung with portraits of knights in armor, and
+ladies in silken gowns; and the armor rattled, and the silken gowns
+rustled! And then there was a flight of stairs which went a good way
+upwards, and a little way downwards, and then one came on a balcony
+which was in a very dilapidated state, sure enough, with large holes and
+long crevices, but grass grew there and leaves out of them altogether,
+for the whole balcony outside, the yard, and the walls, were overgrown
+with so much green stuff, that it looked like a garden; only a balcony.
+Here stood old flower-pots with faces and asses’ ears, and the flowers
+grew just as they liked. One of the pots was quite overrun on all sides
+with pinks, that is to say, with the green part; shoot stood by shoot,
+and it said quite distinctly, “The air has cherished me, the sun has
+kissed me, and promised me a little flower on Sunday! a little flower on
+Sunday!”
+
+And then they entered a chamber where the walls were covered with hog’s
+leather, and printed with gold flowers.
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+said the walls.
+
+And there stood easy-chairs, with such high backs, and so carved out,
+and with arms on both sides. “Sit down! sit down!” said they. “Ugh! how
+I creak; now I shall certainly get the gout, like the old clothespress,
+ugh!”
+
+And then the little boy came into the room where the projecting windows
+were, and where the old man sat.
+
+“I thank you for the pewter soldier, my little friend!” said the old
+man. “And I thank you because you come over to me.”
+
+“Thankee! thankee!” or “cranky! cranky!” sounded from all the furniture;
+there was so much of it, that each article stood in the other’s way, to
+get a look at the little boy.
+
+In the middle of the wall hung a picture representing a beautiful lady,
+so young, so glad, but dressed quite as in former times, with clothes
+that stood quite stiff, and with powder in her hair; she neither said
+“thankee, thankee!” nor “cranky, cranky!” but looked with her mild eyes
+at the little boy, who directly asked the old man, “Where did you get
+her?”
+
+“Yonder, at the broker’s,” said the old man, “where there are so many
+pictures hanging. No one knows or cares about them, for they are all of
+them buried; but I knew her in by-gone days, and now she has been dead
+and gone these fifty years!”
+
+Under the picture, in a glazed frame, there hung a bouquet of withered
+flowers; they were almost fifty years old; they looked so very old!
+
+The pendulum of the great clock went to and fro, and the hands turned,
+and everything in the room became still older; but they did not observe
+it.
+
+“They say at home,” said the little boy, “that you are so very, very
+lonely!”
+
+“Oh!” said he. “The old thoughts, with what they may bring with them,
+come and visit me, and now you also come! I am very well off!”
+
+Then he took a book with pictures in it down from the shelf; there were
+whole long processions and pageants, with the strangest characters,
+which one never sees now-a-days; soldiers like the knave of clubs,
+and citizens with waving flags: the tailors had theirs, with a pair of
+shears held by two lions--and the shoemakers theirs, without boots,
+but with an eagle that had two heads, for the shoemakers must have
+everything so that they can say, it is a pair! Yes, that was a picture
+book!
+
+The old man now went into the other room to fetch preserves, apples, and
+nuts--yes, it was delightful over there in the old house.
+
+“I cannot bear it any longer!” said the pewter soldier, who sat on the
+drawers. “It is so lonely and melancholy here! But when one has been in
+a family circle one cannot accustom oneself to this life! I cannot bear
+it any longer! The whole day is so long, and the evenings are still
+longer! Here it is not at all as it is over the way at your home, where
+your father and mother spoke so pleasantly, and where you and all your
+sweet children made such a delightful noise. Nay, how lonely the old man
+is--do you think that he gets kisses? Do you think he gets mild eyes,
+or a Christmas tree? He will get nothing but a grave! I can bear it no
+longer!”
+
+“You must not let it grieve you so much,” said the little boy. “I find
+it so very delightful here, and then all the old thoughts, with what
+they may bring with them, they come and visit here.”
+
+“Yes, it’s all very well, but I see nothing of them, and I don’t know
+them!” said the pewter soldier. “I cannot bear it!”
+
+“But you must!” said the little boy.
+
+Then in came the old man with the most pleased and happy face, the most
+delicious preserves, apples, and nuts, and so the little boy thought no
+more about the pewter soldier.
+
+The little boy returned home happy and pleased, and weeks and days
+passed away, and nods were made to the old house, and from the old
+house, and then the little boy went over there again.
+
+The carved trumpeters blew, “Trateratra! There is the little boy!
+Trateratra!” and the swords and armor on the knights’ portraits rattled,
+and the silk gowns rustled; the hog’s leather spoke, and the old chairs
+had the gout in their legs and rheumatism in their backs: Ugh! it was
+exactly like the first time, for over there one day and hour was just
+like another.
+
+“I cannot bear it!” said the pewter soldier. “I have shed pewter tears!
+It is too melancholy! Rather let me go to the wars and lose arms and
+legs! It would at least be a change. I cannot bear it longer! Now, I
+know what it is to have a visit from one’s old thoughts, with what they
+may bring with them! I have had a visit from mine, and you may be sure
+it is no pleasant thing in the end; I was at last about to jump down
+from the drawers.
+
+“I saw you all over there at home so distinctly, as if you really were
+here; it was again that Sunday morning; all you children stood before
+the table and sung your Psalms, as you do every morning. You stood
+devoutly with folded hands; and father and mother were just as pious;
+and then the door was opened, and little sister Mary, who is not two
+years old yet, and who always dances when she hears music or singing, of
+whatever kind it may be, was put into the room--though she ought not to
+have been there--and then she began to dance, but could not keep time,
+because the tones were so long; and then she stood, first on the one
+leg, and bent her head forwards, and then on the other leg, and bent
+her head forwards--but all would not do. You stood very seriously all
+together, although it was difficult enough; but I laughed to myself, and
+then I fell off the table, and got a bump, which I have still--for it
+was not right of me to laugh. But the whole now passes before me again
+in thought, and everything that I have lived to see; and these are the
+old thoughts, with what they may bring with them.
+
+“Tell me if you still sing on Sundays? Tell me something about little
+Mary! And how my comrade, the other pewter soldier, lives! Yes, he is
+happy enough, that’s sure! I cannot bear it any longer!”
+
+“You are given away as a present!” said the little boy. “You must
+remain. Can you not understand that?”
+
+The old man now came with a drawer, in which there was much to be seen,
+both “tin boxes” and “balsam boxes,” old cards, so large and so gilded,
+such as one never sees them now. And several drawers were opened, and
+the piano was opened; it had landscapes on the inside of the lid, and it
+was so hoarse when the old man played on it! and then he hummed a song.
+
+“Yes, she could sing that!” said he, and nodded to the portrait, which
+he had bought at the broker’s, and the old man’s eyes shone so bright!
+
+“I will go to the wars! I will go to the wars!” shouted the pewter
+soldier as loud as he could, and threw himself off the drawers right
+down on the floor. What became of him? The old man sought, and the
+little boy sought; he was away, and he stayed away.
+
+“I shall find him!” said the old man; but he never found him. The floor
+was too open--the pewter soldier had fallen through a crevice, and there
+he lay as in an open tomb.
+
+That day passed, and the little boy went home, and that week passed,
+and several weeks too. The windows were quite frozen, the little boy was
+obliged to sit and breathe on them to get a peep-hole over to the old
+house, and there the snow had been blown into all the carved work and
+inscriptions; it lay quite up over the steps, just as if there was no
+one at home--nor was there any one at home--the old man was dead!
+
+In the evening there was a hearse seen before the door, and he was borne
+into it in his coffin: he was now to go out into the country, to lie in
+his grave. He was driven out there, but no one followed; all his friends
+were dead, and the little boy kissed his hand to the coffin as it was
+driven away.
+
+Some days afterwards there was an auction at the old house, and the
+little boy saw from his window how they carried the old knights and the
+old ladies away, the flower-pots with the long ears, the old chairs, and
+the old clothes-presses. Something came here, and something came there;
+the portrait of her who had been found at the broker’s came to the
+broker’s again; and there it hung, for no one knew her more--no one
+cared about the old picture.
+
+In the spring they pulled the house down, for, as people said, it was
+a ruin. One could see from the street right into the room with the
+hog’s-leather hanging, which was slashed and torn; and the green grass
+and leaves about the balcony hung quite wild about the falling beams.
+And then it was put to rights.
+
+“That was a relief,” said the neighboring houses.
+
+A fine house was built there, with large windows, and smooth white
+walls; but before it, where the old house had in fact stood, was a
+little garden laid out, and a wild grapevine ran up the wall of the
+neighboring house. Before the garden there was a large iron railing
+with an iron door, it looked quite splendid, and people stood still and
+peeped in, and the sparrows hung by scores in the vine, and chattered
+away at each other as well as they could, but it was not about the old
+house, for they could not remember it, so many years had passed--so many
+that the little boy had grown up to a whole man, yes, a clever man, and
+a pleasure to his parents; and he had just been married, and, together
+with his little wife, had come to live in the house here, where the
+garden was; and he stood by her there whilst she planted a field-flower
+that she found so pretty; she planted it with her little hand, and
+pressed the earth around it with her fingers. Oh! what was that? She
+had stuck herself. There sat something pointed, straight out of the soft
+mould.
+
+It was--yes, guess! It was the pewter soldier, he that was lost up at
+the old man’s, and had tumbled and turned about amongst the timber and
+the rubbish, and had at last laid for many years in the ground.
+
+The young wife wiped the dirt off the soldier, first with a green leaf,
+and then with her fine handkerchief--it had such a delightful smell,
+that it was to the pewter soldier just as if he had awaked from a
+trance.
+
+“Let me see him,” said the young man. He laughed, and then shook his
+head. “Nay, it cannot be he; but he reminds me of a story about a pewter
+soldier which I had when I was a little boy!” And then he told his wife
+about the old house, and the old man, and about the pewter soldier that
+he sent over to him because he was so very, very lonely; and he told it
+as correctly as it had really been, so that the tears came into the eyes
+of his young wife, on account of the old house and the old man.
+
+“It may possibly be, however, that it is the same pewter soldier!” said
+she. “I will take care of it, and remember all that you have told me;
+but you must show me the old man’s grave!”
+
+“But I do not know it,” said he, “and no one knows it! All his friends
+were dead, no one took care of it, and I was then a little boy!”
+
+“How very, very lonely he must have been!” said she.
+
+“Very, very lonely!” said the pewter soldier. “But it is delightful not
+to be forgotten!”
+
+“Delightful!” shouted something close by; but no one, except the pewter
+soldier, saw that it was a piece of the hog’s-leather hangings; it had
+lost all its gilding, it looked like a piece of wet clay, but it had an
+opinion, and it gave it:
+
+   “The gilding decays,
+   But hog’s leather stays!”
+
+This the pewter soldier did not believe.
+
+
+
+
+THE HAPPY FAMILY
+
+Really, the largest green leaf in this country is a dock-leaf; if one
+holds it before one, it is like a whole apron, and if one holds it over
+one’s head in rainy weather, it is almost as good as an umbrella, for
+it is so immensely large. The burdock never grows alone, but where there
+grows one there always grow several: it is a great delight, and all this
+delightfulness is snails’ food. The great white snails which persons of
+quality in former times made fricassees of, ate, and said, “Hem,
+hem! how delicious!” for they thought it tasted so delicate--lived on
+dock-leaves, and therefore burdock seeds were sown.
+
+Now, there was an old manor-house, where they no longer ate snails, they
+were quite extinct; but the burdocks were not extinct, they grew and
+grew all over the walks and all the beds; they could not get the mastery
+over them--it was a whole forest of burdocks. Here and there stood an
+apple and a plum-tree, or else one never would have thought that it was
+a garden; all was burdocks, and there lived the two last venerable old
+snails.
+
+They themselves knew not how old they were, but they could remember
+very well that there had been many more; that they were of a family
+from foreign lands, and that for them and theirs the whole forest was
+planted. They had never been outside it, but they knew that there was
+still something more in the world, which was called the manor-house, and
+that there they were boiled, and then they became black, and were then
+placed on a silver dish; but what happened further they knew not; or, in
+fact, what it was to be boiled, and to lie on a silver dish, they could
+not possibly imagine; but it was said to be delightful, and particularly
+genteel. Neither the chafers, the toads, nor the earth-worms, whom they
+asked about it could give them any information--none of them had been
+boiled or laid on a silver dish.
+
+The old white snails were the first persons of distinction in the
+world, that they knew; the forest was planted for their sake, and the
+manor-house was there that they might be boiled and laid on a silver
+dish.
+
+Now they lived a very lonely and happy life; and as they had no children
+themselves, they had adopted a little common snail, which they brought
+up as their own; but the little one would not grow, for he was of a
+common family; but the old ones, especially Dame Mother Snail, thought
+they could observe how he increased in size, and she begged father,
+if he could not see it, that he would at least feel the little snail’s
+shell; and then he felt it, and found the good dame was right.
+
+One day there was a heavy storm of rain.
+
+“Hear how it beats like a drum on the dock-leaves!” said Father Snail.
+
+“There are also rain-drops!” said Mother Snail. “And now the rain pours
+right down the stalk! You will see that it will be wet here! I am very
+happy to think that we have our good house, and the little one has
+his also! There is more done for us than for all other creatures, sure
+enough; but can you not see that we are folks of quality in the world?
+We are provided with a house from our birth, and the burdock forest is
+planted for our sakes! I should like to know how far it extends, and
+what there is outside!”
+
+“There is nothing at all,” said Father Snail. “No place can be better
+than ours, and I have nothing to wish for!”
+
+“Yes,” said the dame. “I would willingly go to the manorhouse, be
+boiled, and laid on a silver dish; all our forefathers have been treated
+so; there is something extraordinary in it, you may be sure!”
+
+“The manor-house has most likely fallen to ruin!” said Father Snail. “Or
+the burdocks have grown up over it, so that they cannot come out. There
+need not, however, be any haste about that; but you are always in such a
+tremendous hurry, and the little one is beginning to be the same. Has he
+not been creeping up that stalk these three days? It gives me a headache
+when I look up to him!”
+
+“You must not scold him,” said Mother Snail. “He creeps so carefully; he
+will afford us much pleasure--and we have nothing but him to live for!
+But have you not thought of it? Where shall we get a wife for him? Do
+you not think that there are some of our species at a great distance in
+the interior of the burdock forest?”
+
+“Black snails, I dare say, there are enough of,” said the old one.
+“Black snails without a house--but they are so common, and so conceited.
+But we might give the ants a commission to look out for us; they run
+to and fro as if they had something to do, and they certainly know of a
+wife for our little snail!”
+
+“I know one, sure enough--the most charming one!” said one of the ants.
+“But I am afraid we shall hardly succeed, for she is a queen!”
+
+“That is nothing!” said the old folks. “Has she a house?”
+
+“She has a palace!” said the ant. “The finest ant’s palace, with seven
+hundred passages!”
+
+“I thank you!” said Mother Snail. “Our son shall not go into an
+ant-hill; if you know nothing better than that, we shall give the
+commission to the white gnats. They fly far and wide, in rain and
+sunshine; they know the whole forest here, both within and without.”
+
+“We have a wife for him,” said the gnats. “At a hundred human paces from
+here there sits a little snail in her house, on a gooseberry bush; she
+is quite lonely, and old enough to be married. It is only a hundred
+human paces!”
+
+“Well, then, let her come to him!” said the old ones. “He has a whole
+forest of burdocks, she has only a bush!”
+
+And so they went and fetched little Miss Snail. It was a whole week
+before she arrived; but therein was just the very best of it, for one
+could thus see that she was of the same species.
+
+And then the marriage was celebrated. Six earth-worms shone as well as
+they could. In other respects the whole went off very quietly, for the
+old folks could not bear noise and merriment; but old Dame Snail made
+a brilliant speech. Father Snail could not speak, he was too much
+affected; and so they gave them as a dowry and inheritance, the whole
+forest of burdocks, and said--what they had always said--that it was
+the best in the world; and if they lived honestly and decently, and
+increased and multiplied, they and their children would once in the
+course of time come to the manor-house, be boiled black, and laid on
+silver dishes. After this speech was made, the old ones crept into their
+shells, and never more came out. They slept; the young couple governed
+in the forest, and had a numerous progeny, but they were never boiled,
+and never came on the silver dishes; so from this they concluded that
+the manor-house had fallen to ruins, and that all the men in the world
+were extinct; and as no one contradicted them, so, of course it was so.
+And the rain beat on the dock-leaves to make drum-music for their sake,
+and the sun shone in order to give the burdock forest a color for their
+sakes; and they were very happy, and the whole family was happy; for
+they, indeed were so.
+
+
+
+
+THE STORY OF A MOTHER
+
+A mother sat there with her little child. She was so downcast, so
+afraid that it should die! It was so pale, the small eyes had closed
+themselves, and it drew its breath so softly, now and then, with a
+deep respiration, as if it sighed; and the mother looked still more
+sorrowfully on the little creature.
+
+Then a knocking was heard at the door, and in came a poor old man
+wrapped up as in a large horse-cloth, for it warms one, and he needed
+it, as it was the cold winter season! Everything out-of-doors was
+covered with ice and snow, and the wind blew so that it cut the face.
+
+As the old man trembled with cold, and the little child slept a moment,
+the mother went and poured some ale into a pot and set it on the stove,
+that it might be warm for him; the old man sat and rocked the cradle,
+and the mother sat down on a chair close by him, and looked at her
+little sick child that drew its breath so deep, and raised its little
+hand.
+
+“Do you not think that I shall save him?” said she. “Our Lord will not
+take him from me!”
+
+And the old man--it was Death himself--he nodded so strangely, it could
+just as well signify yes as no. And the mother looked down in her lap,
+and the tears ran down over her cheeks; her head became so heavy--she
+had not closed her eyes for three days and nights; and now she slept,
+but only for a minute, when she started up and trembled with cold.
+
+“What is that?” said she, and looked on all sides; but the old man was
+gone, and her little child was gone--he had taken it with him; and the
+old clock in the corner burred, and burred, the great leaden weight ran
+down to the floor, bump! and then the clock also stood still.
+
+But the poor mother ran out of the house and cried aloud for her child.
+
+Out there, in the midst of the snow, there sat a woman in long, black
+clothes; and she said, “Death has been in thy chamber, and I saw him
+hasten away with thy little child; he goes faster than the wind, and he
+never brings back what he takes!”
+
+“Oh, only tell me which way he went!” said the mother. “Tell me the way,
+and I shall find him!”
+
+“I know it!” said the woman in the black clothes. “But before I tell it,
+thou must first sing for me all the songs thou hast sung for thy child!
+I am fond of them. I have heard them before; I am Night; I saw thy tears
+whilst thou sang’st them!”
+
+“I will sing them all, all!” said the mother. “But do not stop me now--I
+may overtake him--I may find my child!”
+
+But Night stood still and mute. Then the mother wrung her hands, sang
+and wept, and there were many songs, but yet many more tears; and then
+Night said, “Go to the right, into the dark pine forest; thither I saw
+Death take his way with thy little child!”
+
+The roads crossed each other in the depths of the forest, and she no
+longer knew whither she should go! then there stood a thorn-bush;
+there was neither leaf nor flower on it, it was also in the cold winter
+season, and ice-flakes hung on the branches.
+
+“Hast thou not seen Death go past with my little child?” said the
+mother.
+
+“Yes,” said the thorn-bush; “but I will not tell thee which way he took,
+unless thou wilt first warm me up at thy heart. I am freezing to death;
+I shall become a lump of ice!”
+
+And she pressed the thorn-bush to her breast, so firmly, that it might
+be thoroughly warmed, and the thorns went right into her flesh, and her
+blood flowed in large drops, but the thornbush shot forth fresh green
+leaves, and there came flowers on it in the cold winter night, the heart
+of the afflicted mother was so warm; and the thorn-bush told her the way
+she should go.
+
+She then came to a large lake, where there was neither ship nor boat.
+The lake was not frozen sufficiently to bear her; neither was it open,
+nor low enough that she could wade through it; and across it she must go
+if she would find her child! Then she lay down to drink up the lake, and
+that was an impossibility for a human being, but the afflicted mother
+thought that a miracle might happen nevertheless.
+
+“Oh, what would I not give to come to my child!” said the weeping
+mother; and she wept still more, and her eyes sunk down in the depths of
+the waters, and became two precious pearls; but the water bore her up,
+as if she sat in a swing, and she flew in the rocking waves to the shore
+on the opposite side, where there stood a mile-broad, strange house, one
+knew not if it were a mountain with forests and caverns, or if it were
+built up; but the poor mother could not see it; she had wept her eyes
+out.
+
+“Where shall I find Death, who took away my little child?” said she.
+
+“He has not come here yet!” said the old grave woman, who was appointed
+to look after Death’s great greenhouse! “How have you been able to find
+the way hither? And who has helped you?”
+
+“OUR LORD has helped me,” said she. “He is merciful, and you will also
+be so! Where shall I find my little child?”
+
+“Nay, I know not,” said the woman, “and you cannot see! Many flowers and
+trees have withered this night; Death will soon come and plant them over
+again! You certainly know that every person has his or her life’s tree
+or flower, just as everyone happens to be settled; they look like other
+plants, but they have pulsations of the heart. Children’s hearts can
+also beat; go after yours, perhaps you may know your child’s; but what
+will you give me if I tell you what you shall do more?”
+
+“I have nothing to give,” said the afflicted mother, “but I will go to
+the world’s end for you!”
+
+“Nay, I have nothing to do there!” said the woman. “But you can give
+me your long black hair; you know yourself that it is fine, and that
+I like! You shall have my white hair instead, and that’s always
+something!”
+
+“Do you demand nothing else?” said she. “That I will gladly give you!”
+ And she gave her her fine black hair, and got the old woman’s snow-white
+hair instead.
+
+So they went into Death’s great greenhouse, where flowers and trees
+grew strangely into one another. There stood fine hyacinths under glass
+bells, and there stood strong-stemmed peonies; there grew water plants,
+some so fresh, others half sick, the water-snakes lay down on them,
+and black crabs pinched their stalks. There stood beautiful palm-trees,
+oaks, and plantains; there stood parsley and flowering thyme: every tree
+and every flower had its name; each of them was a human life, the human
+frame still lived--one in China, and another in Greenland--round about
+in the world. There were large trees in small pots, so that they stood
+so stunted in growth, and ready to burst the pots; in other places,
+there was a little dull flower in rich mould, with moss round about it,
+and it was so petted and nursed. But the distressed mother bent down
+over all the smallest plants, and heard within them how the human heart
+beat; and amongst millions she knew her child’s.
+
+“There it is!” cried she, and stretched her hands out over a little blue
+crocus, that hung quite sickly on one side.
+
+“Don’t touch the flower!” said the old woman. “But place yourself here,
+and when Death comes--I expect him every moment--do not let him pluck
+the flower up, but threaten him that you will do the same with the
+others. Then he will be afraid! He is responsible for them to OUR LORD,
+and no one dares to pluck them up before HE gives leave.”
+
+All at once an icy cold rushed through the great hall, and the blind
+mother could feel that it was Death that came.
+
+“How hast thou been able to find thy way hither?” he asked. “How couldst
+thou come quicker than I?”
+
+“I am a mother,” said she.
+
+And Death stretched out his long hand towards the fine little flower,
+but she held her hands fast around his, so tight, and yet afraid that
+she should touch one of the leaves. Then Death blew on her hands, and
+she felt that it was colder than the cold wind, and her hands fell down
+powerless.
+
+“Thou canst not do anything against me!” said Death.
+
+“But OUR LORD can!” said she.
+
+“I only do His bidding!” said Death. “I am His gardener, I take all His
+flowers and trees, and plant them out in the great garden of Paradise,
+in the unknown land; but how they grow there, and how it is there I dare
+not tell thee.”
+
+“Give me back my child!” said the mother, and she wept and prayed. At
+once she seized hold of two beautiful flowers close by, with each hand,
+and cried out to Death, “I will tear all thy flowers off, for I am in
+despair.”
+
+“Touch them not!” said Death. “Thou say’st that thou art so unhappy, and
+now thou wilt make another mother equally unhappy.”
+
+“Another mother!” said the poor woman, and directly let go her hold of
+both the flowers.
+
+“There, thou hast thine eyes,” said Death; “I fished them up from the
+lake, they shone so bright; I knew not they were thine. Take them again,
+they are now brighter than before; now look down into the deep well
+close by; I shall tell thee the names of the two flowers thou wouldst
+have torn up, and thou wilt see their whole future life--their whole
+human existence: and see what thou wast about to disturb and destroy.”
+
+And she looked down into the well; and it was a happiness to see how the
+one became a blessing to the world, to see how much happiness and joy
+were felt everywhere. And she saw the other’s life, and it was sorrow
+and distress, horror, and wretchedness.
+
+“Both of them are God’s will!” said Death.
+
+“Which of them is Misfortune’s flower and which is that of Happiness?”
+ asked she.
+
+“That I will not tell thee,” said Death; “but this thou shalt know from
+me, that the one flower was thy own child! it was thy child’s fate thou
+saw’st--thy own child’s future life!”
+
+Then the mother screamed with terror, “Which of them was my child? Tell
+it me! Save the innocent! Save my child from all that misery! Rather
+take it away! Take it into God’s kingdom! Forget my tears, forget my
+prayers, and all that I have done!”
+
+“I do not understand thee!” said Death. “Wilt thou have thy child again,
+or shall I go with it there, where thou dost not know!”
+
+Then the mother wrung her hands, fell on her knees, and prayed to our
+Lord: “Oh, hear me not when I pray against Thy will, which is the best!
+hear me not! hear me not!”
+
+And she bowed her head down in her lap, and Death took her child and
+went with it into the unknown land.
+
+
+
+
+THE FALSE COLLAR
+
+There was once a fine gentleman, all of whose moveables were a boot-jack
+and a hair-comb: but he had the finest false collars in the world; and
+it is about one of these collars that we are now to hear a story.
+
+It was so old, that it began to think of marriage; and it happened that
+it came to be washed in company with a garter.
+
+“Nay!” said the collar. “I never did see anything so slender and so
+fine, so soft and so neat. May I not ask your name?”
+
+“That I shall not tell you!” said the garter.
+
+“Where do you live?” asked the collar.
+
+But the garter was so bashful, so modest, and thought it was a strange
+question to answer.
+
+“You are certainly a girdle,” said the collar; “that is to say an inside
+girdle. I see well that you are both for use and ornament, my dear young
+lady.”
+
+“I will thank you not to speak to me,” said the garter. “I think I have
+not given the least occasion for it.”
+
+“Yes! When one is as handsome as you,” said the collar, “that is
+occasion enough.”
+
+“Don’t come so near me, I beg of you!” said the garter. “You look so
+much like those men-folks.”
+
+“I am also a fine gentleman,” said the collar. “I have a bootjack and a
+hair-comb.”
+
+But that was not true, for it was his master who had them: but he
+boasted.
+
+“Don’t come so near me,” said the garter: “I am not accustomed to it.”
+
+“Prude!” exclaimed the collar; and then it was taken out of the
+washing-tub. It was starched, hung over the back of a chair in the
+sunshine, and was then laid on the ironing-blanket; then came the warm
+box-iron. “Dear lady!” said the collar. “Dear widow-lady! I feel quite
+hot. I am quite changed. I begin to unfold myself. You will burn a hole
+in me. Oh! I offer you my hand.”
+
+“Rag!” said the box-iron; and went proudly over the collar: for she
+fancied she was a steam-engine, that would go on the railroad and draw
+the waggons. “Rag!” said the box-iron.
+
+The collar was a little jagged at the edge, and so came the long
+scissors to cut off the jagged part. “Oh!” said the collar. “You are
+certainly the first opera dancer. How well you can stretch your legs
+out! It is the most graceful performance I have ever seen. No one can
+imitate you.”
+
+“I know it,” said the scissors.
+
+“You deserve to be a baroness,” said the collar. “All that I have is a
+fine gentleman, a boot-jack, and a hair-comb. If I only had the barony!”
+
+“Do you seek my hand?” said the scissors; for she was angry; and without
+more ado, she CUT HIM, and then he was condemned.
+
+“I shall now be obliged to ask the hair-comb. It is surprising how well
+you preserve your teeth, Miss,” said the collar. “Have you never thought
+of being betrothed?”
+
+“Yes, of course! you may be sure of that,” said the hair-comb. “I AM
+betrothed--to the boot-jack!”
+
+“Betrothed!” exclaimed the collar. Now there was no other to court, and
+so he despised it.
+
+A long time passed away, then the collar came into the rag chest at the
+paper mill; there was a large company of rags, the fine by themselves,
+and the coarse by themselves, just as it should be. They all had much to
+say, but the collar the most; for he was a real boaster.
+
+“I have had such an immense number of sweethearts!” said the collar.
+“I could not be in peace! It is true, I was always a fine starched-up
+gentleman! I had both a boot-jack and a hair-comb, which I never used!
+You should have seen me then, you should have seen me when I lay down!
+I shall never forget MY FIRST LOVE--she was a girdle, so fine, so soft,
+and so charming, she threw herself into a tub of water for my sake!
+There was also a widow, who became glowing hot, but I left her standing
+till she got black again; there was also the first opera dancer, she
+gave me that cut which I now go with, she was so ferocious! My
+own hair-comb was in love with me, she lost all her teeth from the
+heart-ache; yes, I have lived to see much of that sort of thing; but I
+am extremely sorry for the garter--I mean the girdle--that went into the
+water-tub. I have much on my conscience, I want to become white paper!”
+
+And it became so, all the rags were turned into white paper; but the
+collar came to be just this very piece of white paper we here see,
+and on which the story is printed; and that was because it boasted so
+terribly afterwards of what had never happened to it. It would be well
+for us to beware, that we may not act in a similar manner, for we can
+never know if we may not, in the course of time, also come into the
+rag chest, and be made into white paper, and then have our whole life’s
+history printed on it, even the most secret, and be obliged to run about
+and tell it ourselves, just like this collar.
+
+
+
+
+THE SHADOW
+
+It is in the hot lands that the sun burns, sure enough! there the people
+become quite a mahogany brown, ay, and in the HOTTEST lands they are
+burnt to Negroes. But now it was only to the HOT lands that a learned
+man had come from the cold; there he thought that he could run about
+just as when at home, but he soon found out his mistake.
+
+He, and all sensible folks, were obliged to stay within doors--the
+window-shutters and doors were closed the whole day; it looked as if the
+whole house slept, or there was no one at home.
+
+The narrow street with the high houses, was built so that the sunshine
+must fall there from morning till evening--it was really not to be
+borne.
+
+The learned man from the cold lands--he was a young man, and seemed to
+be a clever man--sat in a glowing oven; it took effect on him, he became
+quite meagre--even his shadow shrunk in, for the sun had also an effect
+on it. It was first towards evening when the sun was down, that they
+began to freshen up again.
+
+In the warm lands every window has a balcony, and the people came out on
+all the balconies in the street--for one must have air, even if one be
+accustomed to be mahogany!* It was lively both up and down the
+street. Tailors, and shoemakers, and all the folks, moved out into the
+street--chairs and tables were brought forth--and candles burnt--yes,
+above a thousand lights were burning--and the one talked and the other
+sung; and people walked and church-bells rang, and asses went along with
+a dingle-dingle-dong! for they too had bells on. The street boys were
+screaming and hooting, and shouting and shooting, with devils and
+detonating balls--and there came corpse bearers and hood wearers--for
+there were funerals with psalm and hymn--and then the din of carriages
+driving and company arriving: yes, it was, in truth, lively enough down
+in the street. Only in that single house, which stood opposite that in
+which the learned foreigner lived, it was quite still; and yet some one
+lived there, for there stood flowers in the balcony--they grew so
+well in the sun’s heat! and that they could not do unless they were
+watered--and some one must water them--there must be somebody there.
+The door opposite was also opened late in the evening, but it was dark
+within, at least in the front room; further in there was heard the sound
+of music. The learned foreigner thought it quite marvellous, but now--it
+might be that he only imagined it--for he found everything marvellous
+out there, in the warm lands, if there had only been no sun. The
+stranger’s landlord said that he didn’t know who had taken the house
+opposite, one saw no person about, and as to the music, it appeared
+to him to be extremely tiresome. “It is as if some one sat there, and
+practised a piece that he could not master--always the same piece. ‘I
+shall master it!’ says he; but yet he cannot master it, however long he
+plays.”
+
+* The word mahogany can be understood, in Danish, as having two
+meanings. In general, it means the reddish-brown wood itself; but in
+jest, it signifies “excessively fine,” which arose from an anecdote of
+Nyboder, in Copenhagen, (the seamen’s quarter.) A sailor’s wife, who was
+always proud and fine, in her way, came to her neighbor, and complained
+that she had got a splinter in her finger. “What of?” asked the
+neighbor’s wife. “It is a mahogany splinter,” said the other. “Mahogany!
+It cannot be less with you!” exclaimed the woman--and thence the
+proverb, “It is so mahogany!”--(that is, so excessively fine)--is
+derived.
+
+
+One night the stranger awoke--he slept with the doors of the balcony
+open--the curtain before it was raised by the wind, and he thought
+that a strange lustre came from the opposite neighbor’s house; all the
+flowers shone like flames, in the most beautiful colors, and in the
+midst of the flowers stood a slender, graceful maiden--it was as if she
+also shone; the light really hurt his eyes. He now opened them quite
+wide--yes, he was quite awake; with one spring he was on the floor; he
+crept gently behind the curtain, but the maiden was gone; the flowers
+shone no longer, but there they stood, fresh and blooming as ever;
+the door was ajar, and, far within, the music sounded so soft and
+delightful, one could really melt away in sweet thoughts from it. Yet
+it was like a piece of enchantment. And who lived there? Where was the
+actual entrance? The whole of the ground-floor was a row of shops, and
+there people could not always be running through.
+
+One evening the stranger sat out on the balcony. The light burnt in the
+room behind him; and thus it was quite natural that his shadow should
+fall on his opposite neighbor’s wall. Yes! there it sat, directly
+opposite, between the flowers on the balcony; and when the stranger
+moved, the shadow also moved: for that it always does.
+
+“I think my shadow is the only living thing one sees over there,” said
+the learned man. “See, how nicely it sits between the flowers. The door
+stands half-open: now the shadow should be cunning, and go into the
+room, look about, and then come and tell me what it had seen. Come, now!
+Be useful, and do me a service,” said he, in jest. “Have the kindness to
+step in. Now! Art thou going?” and then he nodded to the shadow, and the
+shadow nodded again. “Well then, go! But don’t stay away.”
+
+The stranger rose, and his shadow on the opposite neighbor’s balcony
+rose also; the stranger turned round and the shadow also turned round.
+Yes! if anyone had paid particular attention to it, they would have
+seen, quite distinctly, that the shadow went in through the half-open
+balcony-door of their opposite neighbor, just as the stranger went into
+his own room, and let the long curtain fall down after him.
+
+Next morning, the learned man went out to drink coffee and read the
+newspapers.
+
+“What is that?” said he, as he came out into the sunshine. “I have no
+shadow! So then, it has actually gone last night, and not come again. It
+is really tiresome!”
+
+This annoyed him: not so much because the shadow was gone, but because
+he knew there was a story about a man without a shadow.* It was known
+to everybody at home, in the cold lands; and if the learned man now came
+there and told his story, they would say that he was imitating it, and
+that he had no need to do. He would, therefore, not talk about it at
+all; and that was wisely thought.
+
+*Peter Schlemihl, the shadowless man.
+
+
+In the evening he went out again on the balcony. He had placed the light
+directly behind him, for he knew that the shadow would always have its
+master for a screen, but he could not entice it. He made himself little;
+he made himself great: but no shadow came again. He said, “Hem! hem!”
+ but it was of no use.
+
+It was vexatious; but in the warm lands everything grows so quickly; and
+after the lapse of eight days he observed, to his great joy, that a new
+shadow came in the sunshine. In the course of three weeks he had a very
+fair shadow, which, when he set out for his home in the northern lands,
+grew more and more in the journey, so that at last it was so long and so
+large, that it was more than sufficient.
+
+The learned man then came home, and he wrote books about what was true
+in the world, and about what was good and what was beautiful; and there
+passed days and years--yes! many years passed away.
+
+One evening, as he was sitting in his room, there was a gentle knocking
+at the door.
+
+“Come in!” said he; but no one came in; so he opened the door, and there
+stood before him such an extremely lean man, that he felt quite strange.
+As to the rest, the man was very finely dressed--he must be a gentleman.
+
+“Whom have I the honor of speaking?” asked the learned man.
+
+“Yes! I thought as much,” said the fine man. “I thought you would not
+know me. I have got so much body. I have even got flesh and clothes. You
+certainly never thought of seeing me so well off. Do you not know your
+old shadow? You certainly thought I should never more return. Things
+have gone on well with me since I was last with you. I have, in all
+respects, become very well off. Shall I purchase my freedom from
+service? If so, I can do it”; and then he rattled a whole bunch of
+valuable seals that hung to his watch, and he stuck his hand in the
+thick gold chain he wore around his neck--nay! how all his fingers
+glittered with diamond rings; and then all were pure gems.
+
+“Nay; I cannot recover from my surprise!” said the learned man. “What is
+the meaning of all this?”
+
+“Something common, is it not,” said the shadow. “But you yourself do not
+belong to the common order; and I, as you know well, have from a child
+followed in your footsteps. As soon as you found I was capable to go
+out alone in the world, I went my own way. I am in the most brilliant
+circumstances, but there came a sort of desire over me to see you once
+more before you die; you will die, I suppose? I also wished to see this
+land again--for you know we always love our native land. I know you have
+got another shadow again; have I anything to pay to it or you? If so,
+you will oblige me by saying what it is.”
+
+“Nay, is it really thou?” said the learned man. “It is most remarkable:
+I never imagined that one’s old shadow could come again as a man.”
+
+“Tell me what I have to pay,” said the shadow; “for I don’t like to be
+in any sort of debt.”
+
+“How canst thou talk so?” said the learned man. “What debt is there to
+talk about? Make thyself as free as anyone else. I am extremely glad to
+hear of thy good fortune: sit down, old friend, and tell me a little
+how it has gone with thee, and what thou hast seen at our opposite
+neighbor’s there--in the warm lands.”
+
+“Yes, I will tell you all about it,” said the shadow, and sat down: “but
+then you must also promise me, that, wherever you may meet me, you will
+never say to anyone here in the town that I have been your shadow. I
+intend to get betrothed, for I can provide for more than one family.”
+
+“Be quite at thy ease about that,” said the learned man; “I shall not
+say to anyone who thou actually art: here is my hand--I promise it, and
+a man’s bond is his word.”
+
+“A word is a shadow,” said the shadow, “and as such it must speak.”
+
+It was really quite astonishing how much of a man it was. It was dressed
+entirely in black, and of the very finest cloth; it had patent leather
+boots, and a hat that could be folded together, so that it was bare
+crown and brim; not to speak of what we already know it had--seals, gold
+neck-chain, and diamond rings; yes, the shadow was well-dressed, and it
+was just that which made it quite a man.
+
+“Now I shall tell you my adventures,” said the shadow; and then he
+sat, with the polished boots, as heavily as he could, on the arm of the
+learned man’s new shadow, which lay like a poodle-dog at his feet.
+Now this was perhaps from arrogance; and the shadow on the ground kept
+itself so still and quiet, that it might hear all that passed: it wished
+to know how it could get free, and work its way up, so as to become its
+own master.
+
+“Do you know who lived in our opposite neighbor’s house?” said the
+shadow. “It was the most charming of all beings, it was Poesy! I was
+there for three weeks, and that has as much effect as if one had lived
+three thousand years, and read all that was composed and written;
+that is what I say, and it is right. I have seen everything and I know
+everything!”
+
+“Poesy!” cried the learned man. “Yes, yes, she often dwells a recluse
+in large cities! Poesy! Yes, I have seen her--a single short moment,
+but sleep came into my eyes! She stood on the balcony and shone as the
+Aurora Borealis shines. Go on, go on--thou wert on the balcony, and went
+through the doorway, and then--”
+
+“Then I was in the antechamber,” said the shadow. “You always sat and
+looked over to the antechamber. There was no light; there was a sort
+of twilight, but the one door stood open directly opposite the other
+through a long row of rooms and saloons, and there it was lighted up. I
+should have been completely killed if I had gone over to the maiden; but
+I was circumspect, I took time to think, and that one must always do.”
+
+“And what didst thou then see?” asked the learned man.
+
+“I saw everything, and I shall tell all to you: but--it is no pride on
+my part--as a free man, and with the knowledge I have, not to speak of
+my position in life, my excellent circumstances--I certainly wish that
+you would say YOU* to me!”
+
+* It is the custom in Denmark for intimate acquaintances to use the
+second person singular, “Du,” (thou) when speaking to each other. When
+a friendship is formed between men, they generally affirm it, when
+occasion offers, either in public or private, by drinking to each other
+and exclaiming, “thy health,” at the same time striking their glasses
+together. This is called drinking “Duus”: they are then, “Duus Brodre,”
+ (thou brothers) and ever afterwards use the pronoun “thou,” to each
+other, it being regarded as more familiar than “De,” (you). Father and
+mother, sister and brother say thou to one another--without regard to
+age or rank. Master and mistress say thou to their servants the superior
+to the inferior. But servants and inferiors do not use the same term
+to their masters, or superiors--nor is it ever used when speaking to a
+stranger, or anyone with whom they are but slightly acquainted--they
+then say as in English--you.
+
+
+“I beg your pardon,” said the learned man; “it is an old habit with me.
+YOU are perfectly right, and I shall remember it; but now you must tell
+me all YOU saw!”
+
+“Everything!” said the shadow. “For I saw everything, and I know
+everything!”
+
+“How did it look in the furthest saloon?” asked the learned man. “Was it
+there as in the fresh woods? Was it there as in a holy church? Were the
+saloons like the starlit firmament when we stand on the high mountains?”
+
+“Everything was there!” said the shadow. “I did not go quite in, I
+remained in the foremost room, in the twilight, but I stood there
+quite well; I saw everything, and I know everything! I have been in the
+antechamber at the court of Poesy.”
+
+“But WHAT DID you see? Did all the gods of the olden times pass through
+the large saloons? Did the old heroes combat there? Did sweet children
+play there, and relate their dreams?”
+
+“I tell you I was there, and you can conceive that I saw everything
+there was to be seen. Had you come over there, you would not have been
+a man; but I became so! And besides, I learned to know my inward nature,
+my innate qualities, the relationship I had with Poesy. At the time I
+was with you, I thought not of that, but always--you know it well--when
+the sun rose, and when the sun went down, I became so strangely great;
+in the moonlight I was very near being more distinct than yourself; at
+that time I did not understand my nature; it was revealed to me in the
+antechamber! I became a man! I came out matured; but you were no longer
+in the warm lands; as a man I was ashamed to go as I did. I was in
+want of boots, of clothes, of the whole human varnish that makes a man
+perceptible. I took my way--I tell it to you, but you will not put it in
+any book--I took my way to the cake woman--I hid myself behind her;
+the woman didn’t think how much she concealed. I went out first in the
+evening; I ran about the streets in the moonlight; I made myself long up
+the walls--it tickles the back so delightfully! I ran up, and ran down,
+peeped into the highest windows, into the saloons, and on the roofs, I
+peeped in where no one could peep, and I saw what no one else saw, what
+no one else should see! This is, in fact, a base world! I would not be a
+man if it were not now once accepted and regarded as something to be so!
+I saw the most unimaginable things with the women, with the men, with
+parents, and with the sweet, matchless children; I saw,” said the
+shadow, “what no human being must know, but what they would all
+so willingly know--what is bad in their neighbor. Had I written a
+newspaper, it would have been read! But I wrote direct to the persons
+themselves, and there was consternation in all the towns where I came.
+They were so afraid of me, and yet they were so excessively fond of
+me. The professors made a professor of me; the tailors gave me new
+clothes--I am well furnished; the master of the mint struck new coin for
+me, and the women said I was so handsome! And so I became the man I am.
+And I now bid you farewell. Here is my card--I live on the sunny side
+of the street, and am always at home in rainy weather!” And so away went
+the shadow. “That was most extraordinary!” said the learned man. Years
+and days passed away, then the shadow came again. “How goes it?” said
+the shadow.
+
+“Alas!” said the learned man. “I write about the true, and the good,
+and the beautiful, but no one cares to hear such things; I am quite
+desperate, for I take it so much to heart!”
+
+“But I don’t!” said the shadow. “I become fat, and it is that one wants
+to become! You do not understand the world. You will become ill by it.
+You must travel! I shall make a tour this summer; will you go with me?
+I should like to have a travelling companion! Will you go with me, as
+shadow? It will be a great pleasure for me to have you with me; I shall
+pay the travelling expenses!”
+
+“Nay, this is too much!” said the learned man.
+
+“It is just as one takes it!” said the shadow. “It will do you much good
+to travel! Will you be my shadow? You shall have everything free on the
+journey!”
+
+“Nay, that is too bad!” said the learned man.
+
+“But it is just so with the world!” said the shadow, “and so it will
+be!” and away it went again.
+
+The learned man was not at all in the most enviable state; grief and
+torment followed him, and what he said about the true, and the good, and
+the beautiful, was, to most persons, like roses for a cow! He was quite
+ill at last.
+
+“You really look like a shadow!” said his friends to him; and the
+learned man trembled, for he thought of it.
+
+“You must go to a watering-place!” said the shadow, who came and visited
+him. “There is nothing else for it! I will take you with me for old
+acquaintance’ sake; I will pay the travelling expenses, and you write
+the descriptions--and if they are a little amusing for me on the way!
+I will go to a watering-place--my beard does not grow out as it
+ought--that is also a sickness--and one must have a beard! Now you be
+wise and accept the offer; we shall travel as comrades!”
+
+And so they travelled; the shadow was master, and the master was the
+shadow; they drove with each other, they rode and walked together, side
+by side, before and behind, just as the sun was; the shadow always took
+care to keep itself in the master’s place. Now the learned man didn’t
+think much about that; he was a very kind-hearted man, and particularly
+mild and friendly, and so he said one day to the shadow: “As we have
+now become companions, and in this way have grown up together from
+childhood, shall we not drink ‘thou’ together, it is more familiar?”
+
+“You are right,” said the shadow, who was now the proper master. “It is
+said in a very straight-forward and well-meant manner. You, as a learned
+man, certainly know how strange nature is. Some persons cannot bear to
+touch grey paper, or they become ill; others shiver in every limb if one
+rub a pane of glass with a nail: I have just such a feeling on hearing
+you say thou to me; I feel myself as if pressed to the earth in my first
+situation with you. You see that it is a feeling; that it is not pride:
+I cannot allow you to say THOU to me, but I will willingly say THOU to
+you, so it is half done!”
+
+So the shadow said THOU to its former master.
+
+“This is rather too bad,” thought he, “that I must say YOU and he say
+THOU,” but he was now obliged to put up with it.
+
+So they came to a watering-place where there were many strangers, and
+amongst them was a princess, who was troubled with seeing too well; and
+that was so alarming!
+
+She directly observed that the stranger who had just come was quite a
+different sort of person to all the others; “He has come here in order
+to get his beard to grow, they say, but I see the real cause, he cannot
+cast a shadow.”
+
+She had become inquisitive; and so she entered into conversation
+directly with the strange gentleman, on their promenades. As the
+daughter of a king, she needed not to stand upon trifles, so she said,
+“Your complaint is, that you cannot cast a shadow?”
+
+“Your Royal Highness must be improving considerably,” said the shadow,
+“I know your complaint is, that you see too clearly, but it has
+decreased, you are cured. I just happen to have a very unusual shadow!
+Do you not see that person who always goes with me? Other persons have
+a common shadow, but I do not like what is common to all. We give our
+servants finer cloth for their livery than we ourselves use, and so I
+had my shadow trimmed up into a man: yes, you see I have even given him
+a shadow. It is somewhat expensive, but I like to have something for
+myself!”
+
+“What!” thought the princess. “Should I really be cured! These baths are
+the first in the world! In our time water has wonderful powers. But I
+shall not leave the place, for it now begins to be amusing here. I am
+extremely fond of that stranger: would that his beard should not grow,
+for in that case he will leave us!”
+
+In the evening, the princess and the shadow danced together in the large
+ball-room. She was light, but he was still lighter; she had never had
+such a partner in the dance. She told him from what land she came, and
+he knew that land; he had been there, but then she was not at home; he
+had peeped in at the window, above and below--he had seen both the
+one and the other, and so he could answer the princess, and make
+insinuations, so that she was quite astonished; he must be the wisest
+man in the whole world! She felt such respect for what he knew! So that
+when they again danced together she fell in love with him; and that the
+shadow could remark, for she almost pierced him through with her eyes.
+So they danced once more together; and she was about to declare herself,
+but she was discreet; she thought of her country and kingdom, and of the
+many persons she would have to reign over.
+
+“He is a wise man,” said she to herself--“It is well; and he dances
+delightfully--that is also good; but has he solid knowledge? That is
+just as important! He must be examined.”
+
+So she began, by degrees, to question him about the most difficult
+things she could think of, and which she herself could not have
+answered; so that the shadow made a strange face.
+
+“You cannot answer these questions?” said the princess.
+
+“They belong to my childhood’s learning,” said the shadow. “I really
+believe my shadow, by the door there, can answer them!”
+
+“Your shadow!” said the princess. “That would indeed be marvellous!”
+
+“I will not say for a certainty that he can,” said the shadow, “but I
+think so; he has now followed me for so many years, and listened to my
+conversation--I should think it possible. But your royal highness will
+permit me to observe, that he is so proud of passing himself off for
+a man, that when he is to be in a proper humor--and he must be so to
+answer well--he must be treated quite like a man.”
+
+“Oh! I like that!” said the princess.
+
+So she went to the learned man by the door, and she spoke to him about
+the sun and the moon, and about persons out of and in the world, and he
+answered with wisdom and prudence.
+
+“What a man that must be who has so wise a shadow!” thought she. “It
+will be a real blessing to my people and kingdom if I choose him for my
+consort--I will do it!”
+
+They were soon agreed, both the princess and the shadow; but no one was
+to know about it before she arrived in her own kingdom.
+
+“No one--not even my shadow!” said the shadow, and he had his own
+thoughts about it!
+
+Now they were in the country where the princess reigned when she was at
+home.
+
+“Listen, my good friend,” said the shadow to the learned man. “I have
+now become as happy and mighty as anyone can be; I will, therefore, do
+something particular for thee! Thou shalt always live with me in the
+palace, drive with me in my royal carriage, and have ten thousand
+pounds a year; but then thou must submit to be called SHADOW by all and
+everyone; thou must not say that thou hast ever been a man; and once
+a year, when I sit on the balcony in the sunshine, thou must lie at my
+feet, as a shadow shall do! I must tell thee: I am going to marry the
+king’s daughter, and the nuptials are to take place this evening!”
+
+“Nay, this is going too far!” said the learned man. “I will not have it;
+I will not do it! It is to deceive the whole country and the princess
+too! I will tell everything! That I am a man, and that thou art a
+shadow--thou art only dressed up!”
+
+“There is no one who will believe it!” said the shadow. “Be reasonable,
+or I will call the guard!”
+
+“I will go directly to the princess!” said the learned man.
+
+“But I will go first!” said the shadow. “And thou wilt go to prison!”
+ and that he was obliged to do--for the sentinels obeyed him whom they
+knew the king’s daughter was to marry.
+
+“You tremble!” said the princess, as the shadow came into her chamber.
+“Has anything happened? You must not be unwell this evening, now that we
+are to have our nuptials celebrated.”
+
+“I have lived to see the most cruel thing that anyone can live to
+see!” said the shadow. “Only imagine--yes, it is true, such a poor
+shadow-skull cannot bear much--only think, my shadow has become mad;
+he thinks that he is a man, and that I--now only think--that I am his
+shadow!”
+
+“It is terrible!” said the princess; “but he is confined, is he not?”
+
+“That he is. I am afraid that he will never recover.”
+
+“Poor shadow!” said the princess. “He is very unfortunate; it would be
+a real work of charity to deliver him from the little life he has, and,
+when I think properly over the matter, I am of opinion that it will be
+necessary to do away with him in all stillness!”
+
+“It is certainly hard,” said the shadow, “for he was a faithful
+servant!” and then he gave a sort of sigh.
+
+“You are a noble character!” said the princess.
+
+The whole city was illuminated in the evening, and the cannons went off
+with a bum! bum! and the soldiers presented arms. That was a marriage!
+The princess and the shadow went out on the balcony to show themselves,
+and get another hurrah!
+
+The learned man heard nothing of all this--for they had deprived him of
+life.
+
+
+
+
+THE LITTLE MATCH GIRL
+
+Most terribly cold it was; it snowed, and was nearly quite dark, and
+evening--the last evening of the year. In this cold and darkness there
+went along the street a poor little girl, bareheaded, and with naked
+feet. When she left home she had slippers on, it is true; but what was
+the good of that? They were very large slippers, which her mother had
+hitherto worn; so large were they; and the poor little thing lost them
+as she scuffled away across the street, because of two carriages that
+rolled by dreadfully fast.
+
+One slipper was nowhere to be found; the other had been laid hold of by
+an urchin, and off he ran with it; he thought it would do capitally for
+a cradle when he some day or other should have children himself. So the
+little maiden walked on with her tiny naked feet, that were quite red
+and blue from cold. She carried a quantity of matches in an old apron,
+and she held a bundle of them in her hand. Nobody had bought anything of
+her the whole livelong day; no one had given her a single farthing.
+
+She crept along trembling with cold and hunger--a very picture of
+sorrow, the poor little thing!
+
+The flakes of snow covered her long fair hair, which fell in beautiful
+curls around her neck; but of that, of course, she never once now
+thought. From all the windows the candles were gleaming, and it smelt so
+deliciously of roast goose, for you know it was New Year’s Eve; yes, of
+that she thought.
+
+In a corner formed by two houses, of which one advanced more than the
+other, she seated herself down and cowered together. Her little feet
+she had drawn close up to her, but she grew colder and colder, and to go
+home she did not venture, for she had not sold any matches and could
+not bring a farthing of money: from her father she would certainly get
+blows, and at home it was cold too, for above her she had only the roof,
+through which the wind whistled, even though the largest cracks were
+stopped up with straw and rags.
+
+Her little hands were almost numbed with cold. Oh! a match might afford
+her a world of comfort, if she only dared take a single one out of the
+bundle, draw it against the wall, and warm her fingers by it. She drew
+one out. “Rischt!” how it blazed, how it burnt! It was a warm, bright
+flame, like a candle, as she held her hands over it: it was a wonderful
+light. It seemed really to the little maiden as though she were sitting
+before a large iron stove, with burnished brass feet and a brass
+ornament at top. The fire burned with such blessed influence; it warmed
+so delightfully. The little girl had already stretched out her feet to
+warm them too; but--the small flame went out, the stove vanished: she
+had only the remains of the burnt-out match in her hand.
+
+She rubbed another against the wall: it burned brightly, and where the
+light fell on the wall, there the wall became transparent like a
+veil, so that she could see into the room. On the table was spread a
+snow-white tablecloth; upon it was a splendid porcelain service, and the
+roast goose was steaming famously with its stuffing of apple and dried
+plums. And what was still more capital to behold was, the goose hopped
+down from the dish, reeled about on the floor with knife and fork in its
+breast, till it came up to the poor little girl; when--the match went
+out and nothing but the thick, cold, damp wall was left behind.
+She lighted another match. Now there she was sitting under the most
+magnificent Christmas tree: it was still larger, and more decorated than
+the one which she had seen through the glass door in the rich merchant’s
+house.
+
+Thousands of lights were burning on the green branches, and
+gaily-colored pictures, such as she had seen in the shop-windows, looked
+down upon her. The little maiden stretched out her hands towards them
+when--the match went out. The lights of the Christmas tree rose higher
+and higher, she saw them now as stars in heaven; one fell down and
+formed a long trail of fire.
+
+“Someone is just dead!” said the little girl; for her old grandmother,
+the only person who had loved her, and who was now no more, had told
+her, that when a star falls, a soul ascends to God.
+
+She drew another match against the wall: it was again light, and in the
+lustre there stood the old grandmother, so bright and radiant, so mild,
+and with such an expression of love.
+
+“Grandmother!” cried the little one. “Oh, take me with you! You go
+away when the match burns out; you vanish like the warm stove, like the
+delicious roast goose, and like the magnificent Christmas tree!” And
+she rubbed the whole bundle of matches quickly against the wall, for
+she wanted to be quite sure of keeping her grandmother near her. And
+the matches gave such a brilliant light that it was brighter than at
+noon-day: never formerly had the grandmother been so beautiful and
+so tall. She took the little maiden, on her arm, and both flew in
+brightness and in joy so high, so very high, and then above was neither
+cold, nor hunger, nor anxiety--they were with God.
+
+But in the corner, at the cold hour of dawn, sat the poor girl, with
+rosy cheeks and with a smiling mouth, leaning against the wall--frozen
+to death on the last evening of the old year. Stiff and stark sat the
+child there with her matches, of which one bundle had been burnt. “She
+wanted to warm herself,” people said. No one had the slightest suspicion
+of what beautiful things she had seen; no one even dreamed of the
+splendor in which, with her grandmother she had entered on the joys of a
+new year.
+
+
+
+
+THE DREAM OF LITTLE TUK
+
+Ah! yes, that was little Tuk: in reality his name was not Tuk, but that
+was what he called himself before he could speak plain: he meant it for
+Charles, and it is all well enough if one does but know it. He had now
+to take care of his little sister Augusta, who was much younger than
+himself, and he was, besides, to learn his lesson at the same time; but
+these two things would not do together at all. There sat the poor little
+fellow, with his sister on his lap, and he sang to her all the songs he
+knew; and he glanced the while from time to time into the geography-book
+that lay open before him. By the next morning he was to have learnt
+all the towns in Zealand by heart, and to know about them all that is
+possible to be known.
+
+His mother now came home, for she had been out, and took little Augusta
+on her arm. Tuk ran quickly to the window, and read so eagerly that he
+pretty nearly read his eyes out; for it got darker and darker, but his
+mother had no money to buy a candle.
+
+“There goes the old washerwoman over the way,” said his mother, as she
+looked out of the window. “The poor woman can hardly drag herself along,
+and she must now drag the pail home from the fountain. Be a good boy,
+Tukey, and run across and help the old woman, won’t you?”
+
+So Tuk ran over quickly and helped her; but when he came back again into
+the room it was quite dark, and as to a light, there was no thought of
+such a thing. He was now to go to bed; that was an old turn-up bedstead;
+in it he lay and thought about his geography lesson, and of Zealand, and
+of all that his master had told him. He ought, to be sure, to have read
+over his lesson again, but that, you know, he could not do. He therefore
+put his geography-book under his pillow, because he had heard that was
+a very good thing to do when one wants to learn one’s lesson; but one
+cannot, however, rely upon it entirely. Well, there he lay, and thought
+and thought, and all at once it was just as if someone kissed his eyes
+and mouth: he slept, and yet he did not sleep; it was as though the old
+washerwoman gazed on him with her mild eyes and said, “It were a great
+sin if you were not to know your lesson tomorrow morning. You have aided
+me, I therefore will now help you; and the loving God will do so at all
+times.” And all of a sudden the book under Tuk’s pillow began scraping
+and scratching.
+
+“Kickery-ki! kluk! kluk! kluk!”--that was an old hen who came creeping
+along, and she was from Kjoge. “I am a Kjoger hen,” [*] said she, and then
+she related how many inhabitants there were there, and about the battle
+that had taken place, and which, after all, was hardly worth talking
+about.
+
+     * Kjoge, a town in the bay of Kjoge. “To see the Kjoge
+     hens,” is an expression similar to “showing a child London,”
+      which is said to be done by taking his head in both bands,
+     and so lifting him off the ground. At the invasion of the
+     English in 1807, an encounter of a no very glorious nature
+     took place between the British troops and the undisciplined
+     Danish militia.
+
+“Kribledy, krabledy--plump!” down fell somebody: it was a wooden bird,
+the popinjay used at the shooting-matches at Prastoe. Now he said that
+there were just as many inhabitants as he had nails in his body; and he
+was very proud. “Thorwaldsen lived almost next door to me.* Plump! Here
+I lie capitally.”
+
+* Prastoe, a still smaller town than Kjoge. Some hundred paces from
+it lies the manor-house Ny Soe, where Thorwaldsen, the famed sculptor,
+generally sojourned during his stay in Denmark, and where he called many
+of his immortal works into existence.
+
+
+But little Tuk was no longer lying down: all at once he was on
+horseback. On he went at full gallop, still galloping on and on. A
+knight with a gleaming plume, and most magnificently dressed, held him
+before him on the horse, and thus they rode through the wood to the old
+town of Bordingborg, and that was a large and very lively town. High
+towers rose from the castle of the king, and the brightness of many
+candles streamed from all the windows; within was dance and song,
+and King Waldemar and the young, richly-attired maids of honor danced
+together. The morn now came; and as soon as the sun appeared, the whole
+town and the king’s palace crumbled together, and one tower after the
+other; and at last only a single one remained standing where the castle
+had been before,* and the town was so small and poor, and the school
+boys came along with their books under their arms, and said, “2000
+inhabitants!” but that was not true, for there were not so many.
+
+*Bordingborg, in the reign of King Waldemar, a considerable place, now
+an unimportant little town. One solitary tower only, and some remains of
+a wall, show where the castle once stood.
+
+
+And little Tukey lay in his bed: it seemed to him as if he dreamed, and
+yet as if he were not dreaming; however, somebody was close beside him.
+
+“Little Tukey! Little Tukey!” cried someone near. It was a seaman,
+quite a little personage, so little as if he were a midshipman; but a
+midshipman it was not.
+
+“Many remembrances from Corsor.* That is a town that is just rising
+into importance; a lively town that has steam-boats and stagecoaches:
+formerly people called it ugly, but that is no longer true. I lie on
+the sea,” said Corsor; “I have high roads and gardens, and I have given
+birth to a poet who was witty and amusing, which all poets are not. I
+once intended to equip a ship that was to sail all round the earth; but
+I did not do it, although I could have done so: and then, too, I smell
+so deliciously, for close before the gate bloom the most beautiful
+roses.”
+
+*Corsor, on the Great Belt, called, formerly, before the introduction
+of steam-vessels, when travellers were often obliged to wait a long time
+for a favorable wind, “the most tiresome of towns.” The poet Baggesen
+was born here.
+
+
+Little Tuk looked, and all was red and green before his eyes; but as
+soon as the confusion of colors was somewhat over, all of a sudden there
+appeared a wooded slope close to the bay, and high up above stood a
+magnificent old church, with two high pointed towers. From out the
+hill-side spouted fountains in thick streams of water, so that there
+was a continual splashing; and close beside them sat an old king with
+a golden crown upon his white head: that was King Hroar, near the
+fountains, close to the town of Roeskilde, as it is now called. And up
+the slope into the old church went all the kings and queens of Denmark,
+hand in hand, all with their golden crowns; and the organ played and
+the fountains rustled. Little Tuk saw all, heard all. “Do not forget the
+diet,” said King Hroar.*
+
+*Roeskilde, once the capital of Denmark. The town takes its name from
+King Hroar, and the many fountains in the neighborhood. In the beautiful
+cathedral the greater number of the kings and queens of Denmark are
+interred. In Roeskilde, too, the members of the Danish Diet assemble.
+
+
+Again all suddenly disappeared. Yes, and whither? It seemed to him
+just as if one turned over a leaf in a book. And now stood there an
+old peasant-woman, who came from Soroe,* where grass grows in the
+market-place. She had an old grey linen apron hanging over her head and
+back: it was so wet, it certainly must have been raining. “Yes, that it
+has,” said she; and she now related many pretty things out of Holberg’s
+comedies, and about Waldemar and Absalon; but all at once she cowered
+together, and her head began shaking backwards and forwards, and she
+looked as she were going to make a spring. “Croak! croak!” said she.
+“It is wet, it is wet; there is such a pleasant deathlike stillness in
+Sorbe!” She was now suddenly a frog, “Croak”; and now she was an old
+woman. “One must dress according to the weather,” said she. “It is wet;
+it is wet. My town is just like a bottle; and one gets in by the neck,
+and by the neck one must get out again! In former times I had the
+finest fish, and now I have fresh rosy-cheeked boys at the bottom of the
+bottle, who learn wisdom, Hebrew, Greek--Croak!”
+
+* Sorbe, a very quiet little town, beautifully situated, surrounded by
+woods and lakes. Holberg, Denmark’s Moliere, founded here an academy
+for the sons of the nobles. The poets Hauch and Ingemann were appointed
+professors here. The latter lives there still.
+
+
+When she spoke it sounded just like the noise of frogs, or as if one
+walked with great boots over a moor; always the same tone, so uniform
+and so tiring that little Tuk fell into a good sound sleep, which, by
+the bye, could not do him any harm.
+
+But even in this sleep there came a dream, or whatever else it was: his
+little sister Augusta, she with the blue eyes and the fair curling hair,
+was suddenly a tall, beautiful girl, and without having wings was yet
+able to fly; and she now flew over Zealand--over the green woods and the
+blue lakes.
+
+“Do you hear the cock crow, Tukey? Cock-a-doodle-doo! The cocks are
+flying up from Kjoge! You will have a farm-yard, so large, oh! so very
+large! You will suffer neither hunger nor thirst! You will get on in the
+world! You will be a rich and happy man! Your house will exalt itself
+like King Waldemar’s tower, and will be richly decorated with marble
+statues, like that at Prastoe. You understand what I mean. Your name
+shall circulate with renown all round the earth, like unto the ship that
+was to have sailed from Corsor; and in Roeskilde--”
+
+“Do not forget the diet!” said King Hroar.
+
+“Then you will speak well and wisely, little Tukey; and when at last you
+sink into your grave, you shall sleep as quietly--”
+
+“As if I lay in Soroe,” said Tuk, awaking. It was bright day, and he was
+now quite unable to call to mind his dream; that, however, was not at
+all necessary, for one may not know what the future will bring.
+
+And out of bed he jumped, and read in his book, and now all at once he
+knew his whole lesson. And the old washerwoman popped her head in at the
+door, nodded to him friendly, and said, “Thanks, many thanks, my good
+child, for your help! May the good ever-loving God fulfil your loveliest
+dream!”
+
+Little Tukey did not at all know what he had dreamed, but the loving God
+knew it.
+
+
+
+
+THE NAUGHTY BOY
+
+Along time ago, there lived an old poet, a thoroughly kind old poet. As
+he was sitting one evening in his room, a dreadful storm arose without,
+and the rain streamed down from heaven; but the old poet sat warm
+and comfortable in his chimney-corner, where the fire blazed and the
+roasting apple hissed.
+
+“Those who have not a roof over their heads will be wetted to the skin,”
+ said the good old poet.
+
+“Oh let me in! Let me in! I am cold, and I’m so wet!” exclaimed suddenly
+a child that stood crying at the door and knocking for admittance, while
+the rain poured down, and the wind made all the windows rattle.
+
+“Poor thing!” said the old poet, as he went to open the door. There
+stood a little boy, quite naked, and the water ran down from his long
+golden hair; he trembled with cold, and had he not come into a warm room
+he would most certainly have perished in the frightful tempest.
+
+“Poor child!” said the old poet, as he took the boy by the hand. “Come
+in, come in, and I will soon restore thee! Thou shalt have wine and
+roasted apples, for thou art verily a charming child!” And the boy was
+so really. His eyes were like two bright stars; and although the water
+trickled down his hair, it waved in beautiful curls. He looked exactly
+like a little angel, but he was so pale, and his whole body trembled
+with cold. He had a nice little bow in his hand, but it was quite
+spoiled by the rain, and the tints of his many-colored arrows ran one
+into the other.
+
+The old poet seated himself beside his hearth, and took the little
+fellow on his lap; he squeezed the water out of his dripping hair,
+warmed his hands between his own, and boiled for him some sweet wine.
+Then the boy recovered, his cheeks again grew rosy, he jumped down from
+the lap where he was sitting, and danced round the kind old poet.
+
+“You are a merry fellow,” said the old man. “What’s your name?”
+
+“My name is Cupid,” answered the boy. “Don’t you know me? There lies my
+bow; it shoots well, I can assure you! Look, the weather is now clearing
+up, and the moon is shining clear again through the window.”
+
+“Why, your bow is quite spoiled,” said the old poet.
+
+“That were sad indeed,” said the boy, and he took the bow in his hand
+and examined it on every side. “Oh, it is dry again, and is not hurt at
+all; the string is quite tight. I will try it directly.” And he bent his
+bow, took aim, and shot an arrow at the old poet, right into his heart.
+“You see now that my bow was not spoiled,” said he laughing; and away he
+ran.
+
+The naughty boy, to shoot the old poet in that way; he who had taken him
+into his warm room, who had treated him so kindly, and who had given him
+warm wine and the very best apples!
+
+The poor poet lay on the earth and wept, for the arrow had really flown
+into his heart.
+
+“Fie!” said he. “How naughty a boy Cupid is! I will tell all children
+about him, that they may take care and not play with him, for he will
+only cause them sorrow and many a heartache.”
+
+And all good children to whom he related this story, took great heed
+of this naughty Cupid; but he made fools of them still, for he is
+astonishingly cunning. When the university students come from the
+lectures, he runs beside them in a black coat, and with a book under his
+arm. It is quite impossible for them to know him, and they walk along
+with him arm in arm, as if he, too, were a student like themselves; and
+then, unperceived, he thrusts an arrow to their bosom. When the young
+maidens come from being examined by the clergyman, or go to church to
+be confirmed, there he is again close behind them. Yes, he is forever
+following people. At the play, he sits in the great chandelier and burns
+in bright flames, so that people think it is really a flame, but they
+soon discover it is something else. He roves about in the garden of the
+palace and upon the ramparts: yes, once he even shot your father and
+mother right in the heart. Ask them only and you will hear what they’ll
+tell you. Oh, he is a naughty boy, that Cupid; you must never have
+anything to do with him. He is forever running after everybody. Only
+think, he shot an arrow once at your old grandmother! But that is a
+long time ago, and it is all past now; however, a thing of that sort she
+never forgets. Fie, naughty Cupid! But now you know him, and you know,
+too, how ill-behaved he is!
+
+
+
+
+THE RED SHOES
+
+There was once a little girl who was very pretty and delicate, but in
+summer she was forced to run about with bare feet, she was so poor, and
+in winter wear very large wooden shoes, which made her little insteps
+quite red, and that looked so dangerous!
+
+In the middle of the village lived old Dame Shoemaker; she sat and sewed
+together, as well as she could, a little pair of shoes out of old red
+strips of cloth; they were very clumsy, but it was a kind thought. They
+were meant for the little girl. The little girl was called Karen.
+
+On the very day her mother was buried, Karen received the red shoes,
+and wore them for the first time. They were certainly not intended for
+mourning, but she had no others, and with stockingless feet she followed
+the poor straw coffin in them.
+
+Suddenly a large old carriage drove up, and a large old lady sat in it:
+she looked at the little girl, felt compassion for her, and then said to
+the clergyman:
+
+“Here, give me the little girl. I will adopt her!”
+
+And Karen believed all this happened on account of the red shoes, but
+the old lady thought they were horrible, and they were burnt. But Karen
+herself was cleanly and nicely dressed; she must learn to read and sew;
+and people said she was a nice little thing, but the looking-glass said:
+“Thou art more than nice, thou art beautiful!”
+
+Now the queen once travelled through the land, and she had her little
+daughter with her. And this little daughter was a princess, and people
+streamed to the castle, and Karen was there also, and the little
+princess stood in her fine white dress, in a window, and let herself be
+stared at; she had neither a train nor a golden crown, but splendid
+red morocco shoes. They were certainly far handsomer than those Dame
+Shoemaker had made for little Karen. Nothing in the world can be
+compared with red shoes.
+
+Now Karen was old enough to be confirmed; she had new clothes and was to
+have new shoes also. The rich shoemaker in the city took the measure of
+her little foot. This took place at his house, in his room; where stood
+large glass-cases, filled with elegant shoes and brilliant boots. All
+this looked charming, but the old lady could not see well, and so had
+no pleasure in them. In the midst of the shoes stood a pair of red ones,
+just like those the princess had worn. How beautiful they were! The
+shoemaker said also they had been made for the child of a count, but had
+not fitted.
+
+“That must be patent leather!” said the old lady. “They shine so!”
+
+“Yes, they shine!” said Karen, and they fitted, and were bought, but the
+old lady knew nothing about their being red, else she would never have
+allowed Karen to have gone in red shoes to be confirmed. Yet such was
+the case.
+
+Everybody looked at her feet; and when she stepped through the chancel
+door on the church pavement, it seemed to her as if the old figures on
+the tombs, those portraits of old preachers and preachers’ wives, with
+stiff ruffs, and long black dresses, fixed their eyes on her red shoes.
+And she thought only of them as the clergyman laid his hand upon her
+head, and spoke of the holy baptism, of the covenant with God, and how
+she should be now a matured Christian; and the organ pealed so solemnly;
+the sweet children’s voices sang, and the old music-directors sang, but
+Karen only thought of her red shoes.
+
+In the afternoon, the old lady heard from everyone that the shoes had
+been red, and she said that it was very wrong of Karen, that it was not
+at all becoming, and that in future Karen should only go in black shoes
+to church, even when she should be older.
+
+The next Sunday there was the sacrament, and Karen looked at the black
+shoes, looked at the red ones--looked at them again, and put on the red
+shoes.
+
+The sun shone gloriously; Karen and the old lady walked along the path
+through the corn; it was rather dusty there.
+
+At the church door stood an old soldier with a crutch, and with a
+wonderfully long beard, which was more red than white, and he bowed to
+the ground, and asked the old lady whether he might dust her shoes. And
+Karen stretched out her little foot.
+
+“See, what beautiful dancing shoes!” said the soldier. “Sit firm when
+you dance”; and he put his hand out towards the soles.
+
+And the old lady gave the old soldier alms, and went into the church
+with Karen.
+
+And all the people in the church looked at Karen’s red shoes, and all
+the pictures, and as Karen knelt before the altar, and raised the cup to
+her lips, she only thought of the red shoes, and they seemed to swim
+in it; and she forgot to sing her psalm, and she forgot to pray, “Our
+Father in Heaven!”
+
+Now all the people went out of church, and the old lady got into her
+carriage. Karen raised her foot to get in after her, when the old
+soldier said,
+
+“Look, what beautiful dancing shoes!”
+
+And Karen could not help dancing a step or two, and when she began her
+feet continued to dance; it was just as though the shoes had power over
+them. She danced round the church corner, she could not leave off; the
+coachman was obliged to run after and catch hold of her, and he lifted
+her in the carriage, but her feet continued to dance so that she trod on
+the old lady dreadfully. At length she took the shoes off, and then her
+legs had peace.
+
+The shoes were placed in a closet at home, but Karen could not avoid
+looking at them.
+
+Now the old lady was sick, and it was said she could not recover. She
+must be nursed and waited upon, and there was no one whose duty it was
+so much as Karen’s. But there was a great ball in the city, to which
+Karen was invited. She looked at the old lady, who could not recover,
+she looked at the red shoes, and she thought there could be no sin in
+it; she put on the red shoes, she might do that also, she thought. But
+then she went to the ball and began to dance.
+
+When she wanted to dance to the right, the shoes would dance to the
+left, and when she wanted to dance up the room, the shoes danced back
+again, down the steps, into the street, and out of the city gate. She
+danced, and was forced to dance straight out into the gloomy wood.
+
+Then it was suddenly light up among the trees, and she fancied it must
+be the moon, for there was a face; but it was the old soldier with
+the red beard; he sat there, nodded his head, and said, “Look, what
+beautiful dancing shoes!”
+
+Then she was terrified, and wanted to fling off the red shoes, but they
+clung fast; and she pulled down her stockings, but the shoes seemed to
+have grown to her feet. And she danced, and must dance, over fields and
+meadows, in rain and sunshine, by night and day; but at night it was the
+most fearful.
+
+She danced over the churchyard, but the dead did not dance--they had
+something better to do than to dance. She wished to seat herself on a
+poor man’s grave, where the bitter tansy grew; but for her there was
+neither peace nor rest; and when she danced towards the open church
+door, she saw an angel standing there. He wore long, white garments; he
+had wings which reached from his shoulders to the earth; his countenance
+was severe and grave; and in his hand he held a sword, broad and
+glittering.
+
+“Dance shalt thou!” said he. “Dance in thy red shoes till thou art pale
+and cold! Till thy skin shrivels up and thou art a skeleton! Dance shalt
+thou from door to door, and where proud, vain children dwell, thou shalt
+knock, that they may hear thee and tremble! Dance shalt thou--!”
+
+“Mercy!” cried Karen. But she did not hear the angel’s reply, for the
+shoes carried her through the gate into the fields, across roads and
+bridges, and she must keep ever dancing.
+
+One morning she danced past a door which she well knew. Within sounded
+a psalm; a coffin, decked with flowers, was borne forth. Then she knew
+that the old lady was dead, and felt that she was abandoned by all, and
+condemned by the angel of God.
+
+She danced, and she was forced to dance through the gloomy night. The
+shoes carried her over stack and stone; she was torn till she bled; she
+danced over the heath till she came to a little house. Here, she knew,
+dwelt the executioner; and she tapped with her fingers at the window,
+and said, “Come out! Come out! I cannot come in, for I am forced to
+dance!”
+
+And the executioner said, “Thou dost not know who I am, I fancy? I
+strike bad people’s heads off; and I hear that my axe rings!”
+
+“Don’t strike my head off!” said Karen. “Then I can’t repent of my sins!
+But strike off my feet in the red shoes!”
+
+And then she confessed her entire sin, and the executioner struck off
+her feet with the red shoes, but the shoes danced away with the little
+feet across the field into the deep wood.
+
+And he carved out little wooden feet for her, and crutches, taught
+her the psalm criminals always sing; and she kissed the hand which had
+wielded the axe, and went over the heath.
+
+“Now I have suffered enough for the red shoes!” said she. “Now I will
+go into the church that people may see me!” And she hastened towards the
+church door: but when she was near it, the red shoes danced before her,
+and she was terrified, and turned round. The whole week she was unhappy,
+and wept many bitter tears; but when Sunday returned, she said, “Well,
+now I have suffered and struggled enough! I really believe I am as good
+as many a one who sits in the church, and holds her head so high!”
+
+And away she went boldly; but she had not got farther than the
+churchyard gate before she saw the red shoes dancing before her; and she
+was frightened, and turned back, and repented of her sin from her heart.
+
+And she went to the parsonage, and begged that they would take her
+into service; she would be very industrious, she said, and would do
+everything she could; she did not care about the wages, only she wished
+to have a home, and be with good people. And the clergyman’s wife was
+sorry for her and took her into service; and she was industrious and
+thoughtful. She sat still and listened when the clergyman read the Bible
+in the evenings. All the children thought a great deal of her; but when
+they spoke of dress, and grandeur, and beauty, she shook her head.
+
+The following Sunday, when the family was going to church, they asked
+her whether she would not go with them; but she glanced sorrowfully,
+with tears in her eyes, at her crutches. The family went to hear the
+word of God; but she went alone into her little chamber; there was only
+room for a bed and chair to stand in it; and here she sat down with her
+Prayer-Book; and whilst she read with a pious mind, the wind bore
+the strains of the organ towards her, and she raised her tearful
+countenance, and said, “O God, help me!”
+
+And the sun shone so clearly, and straight before her stood the angel
+of God in white garments, the same she had seen that night at the church
+door; but he no longer carried the sharp sword, but in its stead a
+splendid green spray, full of roses. And he touched the ceiling with the
+spray, and the ceiling rose so high, and where he had touched it there
+gleamed a golden star. And he touched the walls, and they widened out,
+and she saw the organ which was playing; she saw the old pictures of the
+preachers and the preachers’ wives. The congregation sat in cushioned
+seats, and sang out of their Prayer-Books. For the church itself had
+come to the poor girl in her narrow chamber, or else she had come into
+the church. She sat in the pew with the clergyman’s family, and when
+they had ended the psalm and looked up, they nodded and said, “It is
+right that thou art come!”
+
+“It was through mercy!” she said.
+
+And the organ pealed, and the children’s voices in the choir sounded so
+sweet and soft! The clear sunshine streamed so warmly through the window
+into the pew where Karen sat! Her heart was so full of sunshine, peace,
+and joy, that it broke. Her soul flew on the sunshine to God, and there
+no one asked after the RED SHOES.
+
+
+
+
+
+End of Project Gutenberg’s Andersen’s Fairy Tales, by Hans Christian Andersen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK ANDERSEN’S FAIRY TALES ***
+
+***** This file should be named 1597-0.txt or 1597-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/5/9/1597/
+
+Produced by Dianne Bean
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/around-the-world-in-eighty-days.txt
+++ b/jet/tf-idf/src/main/resources/books/around-the-world-in-eighty-days.txt
@@ -1,0 +1,8406 @@
+﻿The Project Gutenberg EBook of Around the World in 80 Days, by Jules Verne
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Around the World in 80 Days
+
+Author: Jules Verne
+
+Release Date: May 15, 2008 [EBook #103]
+Last updated: February 18, 2012
+Last updated: May 5, 2012
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+
+
+
+
+
+
+
+
+
+
+
+
+AROUND THE WORLD IN EIGHTY DAYS
+
+
+
+CONTENTS
+
+
+CHAPTER
+
+      I  IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER, THE
+         ONE AS MASTER, THE OTHER AS MAN
+
+     II  IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND
+         HIS IDEAL
+
+    III  IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST
+         PHILEAS FOGG DEAR
+
+     IV  IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+      V  IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN,
+         APPEARS ON 'CHANGE
+
+     VI  IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+    VII  WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS
+         AIDS TO dETECTIVES
+
+   VIII  IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+     IX  IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS
+         TO THE DESIGNS OF PHILEAS FOGG
+
+      X  IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS
+         OF HIS SHOES
+
+     XI  IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE
+         AT A FABULOUS PRICE
+
+    XII  IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE
+         INDIAN FORESTS, AND WHAT ENSUED
+
+   XIII  IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS
+         THE BRAVE
+
+    XIV  IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL
+         VALLEY OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+     XV  IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS
+         MORE
+
+    XVI  IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS
+         SAID TO HIM
+
+   XVII  SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+  XVIII  IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS
+         BUSINESS
+
+    XIX  IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER,
+         AND WHAT COMES OF IT
+
+     XX  IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+    XXI  IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING
+         A REWARD OF TWO HUNDRED POUNDS
+
+   XXII  IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES,
+         IT IS CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+  XXIII  IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+  XXIV  DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+    XXV  IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+   XXVI  IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+  XXVII  IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN
+         HOUR, A COURSE OF MORMON HISTORY
+
+ XXVIII  IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN
+         TO REASON
+
+   XXIX  IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET
+         WITH ON AMERICAN RAILROADS
+
+    XXX  IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+   XXXI  IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS
+         OF PHILEAS FOGG
+
+  XXXII  IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD
+         FORTUNE
+
+ XXXIII  IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+  XXXIV  IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+   XXXV  IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+         PASSEPARTOUT TWICE
+
+  XXXVI  IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+ XXXVII  IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+         AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+
+
+Chapter I
+
+IN WHICH PHILEAS FOGG AND PASSEPARTOUT ACCEPT EACH OTHER,
+THE ONE AS MASTER, THE OTHER AS MAN
+
+
+Mr. Phileas Fogg lived, in 1872, at No. 7, Saville Row, Burlington
+Gardens, the house in which Sheridan died in 1814.  He was one of the
+most noticeable members of the Reform Club, though he seemed always to
+avoid attracting attention; an enigmatical personage, about whom little
+was known, except that he was a polished man of the world.  People said
+that he resembled Byron--at least that his head was Byronic; but he was
+a bearded, tranquil Byron, who might live on a thousand years without
+growing old.
+
+Certainly an Englishman, it was more doubtful whether Phileas Fogg was
+a Londoner.  He was never seen on 'Change, nor at the Bank, nor in the
+counting-rooms of the "City"; no ships ever came into London docks of
+which he was the owner; he had no public employment; he had never been
+entered at any of the Inns of Court, either at the Temple, or Lincoln's
+Inn, or Gray's Inn; nor had his voice ever resounded in the Court of
+Chancery, or in the Exchequer, or the Queen's Bench, or the
+Ecclesiastical Courts.  He certainly was not a manufacturer; nor was he
+a merchant or a gentleman farmer.  His name was strange to the
+scientific and learned societies, and he never was known to take part
+in the sage deliberations of the Royal Institution or the London
+Institution, the Artisan's Association, or the Institution of Arts and
+Sciences.  He belonged, in fact, to none of the numerous societies
+which swarm in the English capital, from the Harmonic to that of the
+Entomologists, founded mainly for the purpose of abolishing pernicious
+insects.
+
+Phileas Fogg was a member of the Reform, and that was all.
+
+The way in which he got admission to this exclusive club was simple
+enough.
+
+He was recommended by the Barings, with whom he had an open credit.
+His cheques were regularly paid at sight from his account current,
+which was always flush.
+
+Was Phileas Fogg rich?  Undoubtedly.  But those who knew him best could
+not imagine how he had made his fortune, and Mr. Fogg was the last
+person to whom to apply for the information.  He was not lavish, nor,
+on the contrary, avaricious; for, whenever he knew that money was
+needed for a noble, useful, or benevolent purpose, he supplied it
+quietly and sometimes anonymously.  He was, in short, the least
+communicative of men.  He talked very little, and seemed all the more
+mysterious for his taciturn manner.  His daily habits were quite open
+to observation; but whatever he did was so exactly the same thing that
+he had always done before, that the wits of the curious were fairly
+puzzled.
+
+Had he travelled?  It was likely, for no one seemed to know the world
+more familiarly; there was no spot so secluded that he did not appear
+to have an intimate acquaintance with it.  He often corrected, with a
+few clear words, the thousand conjectures advanced by members of the
+club as to lost and unheard-of travellers, pointing out the true
+probabilities, and seeming as if gifted with a sort of second sight, so
+often did events justify his predictions.  He must have travelled
+everywhere, at least in the spirit.
+
+It was at least certain that Phileas Fogg had not absented himself from
+London for many years.  Those who were honoured by a better
+acquaintance with him than the rest, declared that nobody could pretend
+to have ever seen him anywhere else.  His sole pastimes were reading
+the papers and playing whist.  He often won at this game, which, as a
+silent one, harmonised with his nature; but his winnings never went
+into his purse, being reserved as a fund for his charities.  Mr. Fogg
+played, not to win, but for the sake of playing.  The game was in his
+eyes a contest, a struggle with a difficulty, yet a motionless,
+unwearying struggle, congenial to his tastes.
+
+Phileas Fogg was not known to have either wife or children, which may
+happen to the most honest people; either relatives or near friends,
+which is certainly more unusual.  He lived alone in his house in
+Saville Row, whither none penetrated.  A single domestic sufficed to
+serve him.  He breakfasted and dined at the club, at hours
+mathematically fixed, in the same room, at the same table, never taking
+his meals with other members, much less bringing a guest with him; and
+went home at exactly midnight, only to retire at once to bed.  He never
+used the cosy chambers which the Reform provides for its favoured
+members.  He passed ten hours out of the twenty-four in Saville Row,
+either in sleeping or making his toilet.  When he chose to take a walk
+it was with a regular step in the entrance hall with its mosaic
+flooring, or in the circular gallery with its dome supported by twenty
+red porphyry Ionic columns, and illumined by blue painted windows.
+When he breakfasted or dined all the resources of the club--its
+kitchens and pantries, its buttery and dairy--aided to crowd his table
+with their most succulent stores; he was served by the gravest waiters,
+in dress coats, and shoes with swan-skin soles, who proffered the
+viands in special porcelain, and on the finest linen; club decanters,
+of a lost mould, contained his sherry, his port, and his
+cinnamon-spiced claret; while his beverages were refreshingly cooled
+with ice, brought at great cost from the American lakes.
+
+If to live in this style is to be eccentric, it must be confessed that
+there is something good in eccentricity.
+
+The mansion in Saville Row, though not sumptuous, was exceedingly
+comfortable.  The habits of its occupant were such as to demand but
+little from the sole domestic, but Phileas Fogg required him to be
+almost superhumanly prompt and regular.  On this very 2nd of October he
+had dismissed James Forster, because that luckless youth had brought
+him shaving-water at eighty-four degrees Fahrenheit instead of
+eighty-six; and he was awaiting his successor, who was due at the house
+between eleven and half-past.
+
+Phileas Fogg was seated squarely in his armchair, his feet close
+together like those of a grenadier on parade, his hands resting on his
+knees, his body straight, his head erect; he was steadily watching a
+complicated clock which indicated the hours, the minutes, the seconds,
+the days, the months, and the years.  At exactly half-past eleven Mr.
+Fogg would, according to his daily habit, quit Saville Row, and repair
+to the Reform.
+
+A rap at this moment sounded on the door of the cosy apartment where
+Phileas Fogg was seated, and James Forster, the dismissed servant,
+appeared.
+
+"The new servant," said he.
+
+A young man of thirty advanced and bowed.
+
+"You are a Frenchman, I believe," asked Phileas Fogg, "and your name is
+John?"
+
+"Jean, if monsieur pleases," replied the newcomer, "Jean Passepartout,
+a surname which has clung to me because I have a natural aptness for
+going out of one business into another.  I believe I'm honest,
+monsieur, but, to be outspoken, I've had several trades.  I've been an
+itinerant singer, a circus-rider, when I used to vault like Leotard,
+and dance on a rope like Blondin.  Then I got to be a professor of
+gymnastics, so as to make better use of my talents; and then I was a
+sergeant fireman at Paris, and assisted at many a big fire.  But I
+quitted France five years ago, and, wishing to taste the sweets of
+domestic life, took service as a valet here in England.  Finding myself
+out of place, and hearing that Monsieur Phileas Fogg was the most exact
+and settled gentleman in the United Kingdom, I have come to monsieur in
+the hope of living with him a tranquil life, and forgetting even the
+name of Passepartout."
+
+"Passepartout suits me," responded Mr. Fogg.  "You are well recommended
+to me; I hear a good report of you.  You know my conditions?"
+
+"Yes, monsieur."
+
+"Good!  What time is it?"
+
+"Twenty-two minutes after eleven," returned Passepartout, drawing an
+enormous silver watch from the depths of his pocket.
+
+"You are too slow," said Mr. Fogg.
+
+"Pardon me, monsieur, it is impossible--"
+
+"You are four minutes too slow.  No matter; it's enough to mention the
+error.  Now from this moment, twenty-nine minutes after eleven, a.m.,
+this Wednesday, 2nd October, you are in my service."
+
+Phileas Fogg got up, took his hat in his left hand, put it on his head
+with an automatic motion, and went off without a word.
+
+Passepartout heard the street door shut once; it was his new master
+going out.  He heard it shut again; it was his predecessor, James
+Forster, departing in his turn.  Passepartout remained alone in the
+house in Saville Row.
+
+
+
+
+Chapter II
+
+IN WHICH PASSEPARTOUT IS CONVINCED THAT HE HAS AT LAST FOUND HIS IDEAL
+
+
+"Faith," muttered Passepartout, somewhat flurried, "I've seen people at
+Madame Tussaud's as lively as my new master!"
+
+Madame Tussaud's "people," let it be said, are of wax, and are much
+visited in London; speech is all that is wanting to make them human.
+
+During his brief interview with Mr. Fogg, Passepartout had been
+carefully observing him.  He appeared to be a man about forty years of
+age, with fine, handsome features, and a tall, well-shaped figure; his
+hair and whiskers were light, his forehead compact and unwrinkled, his
+face rather pale, his teeth magnificent.  His countenance possessed in
+the highest degree what physiognomists call "repose in action," a
+quality of those who act rather than talk.  Calm and phlegmatic, with a
+clear eye, Mr. Fogg seemed a perfect type of that English composure
+which Angelica Kauffmann has so skilfully represented on canvas.  Seen
+in the various phases of his daily life, he gave the idea of being
+perfectly well-balanced, as exactly regulated as a Leroy chronometer.
+Phileas Fogg was, indeed, exactitude personified, and this was betrayed
+even in the expression of his very hands and feet; for in men, as well
+as in animals, the limbs themselves are expressive of the passions.
+
+He was so exact that he was never in a hurry, was always ready, and was
+economical alike of his steps and his motions.  He never took one step
+too many, and always went to his destination by the shortest cut; he
+made no superfluous gestures, and was never seen to be moved or
+agitated.  He was the most deliberate person in the world, yet always
+reached his destination at the exact moment.
+
+He lived alone, and, so to speak, outside of every social relation; and
+as he knew that in this world account must be taken of friction, and
+that friction retards, he never rubbed against anybody.
+
+As for Passepartout, he was a true Parisian of Paris.  Since he had
+abandoned his own country for England, taking service as a valet, he
+had in vain searched for a master after his own heart.  Passepartout
+was by no means one of those pert dunces depicted by Moliere with a
+bold gaze and a nose held high in the air; he was an honest fellow,
+with a pleasant face, lips a trifle protruding, soft-mannered and
+serviceable, with a good round head, such as one likes to see on the
+shoulders of a friend.  His eyes were blue, his complexion rubicund,
+his figure almost portly and well-built, his body muscular, and his
+physical powers fully developed by the exercises of his younger days.
+His brown hair was somewhat tumbled; for, while the ancient sculptors
+are said to have known eighteen methods of arranging Minerva's tresses,
+Passepartout was familiar with but one of dressing his own: three
+strokes of a large-tooth comb completed his toilet.
+
+It would be rash to predict how Passepartout's lively nature would
+agree with Mr. Fogg.  It was impossible to tell whether the new servant
+would turn out as absolutely methodical as his master required;
+experience alone could solve the question.  Passepartout had been a
+sort of vagrant in his early years, and now yearned for repose; but so
+far he had failed to find it, though he had already served in ten
+English houses.  But he could not take root in any of these; with
+chagrin, he found his masters invariably whimsical and irregular,
+constantly running about the country, or on the look-out for adventure.
+His last master, young Lord Longferry, Member of Parliament, after
+passing his nights in the Haymarket taverns, was too often brought home
+in the morning on policemen's shoulders.  Passepartout, desirous of
+respecting the gentleman whom he served, ventured a mild remonstrance
+on such conduct; which, being ill-received, he took his leave.  Hearing
+that Mr. Phileas Fogg was looking for a servant, and that his life was
+one of unbroken regularity, that he neither travelled nor stayed from
+home overnight, he felt sure that this would be the place he was after.
+He presented himself, and was accepted, as has been seen.
+
+At half-past eleven, then, Passepartout found himself alone in the
+house in Saville Row.  He began its inspection without delay, scouring
+it from cellar to garret.  So clean, well-arranged, solemn a mansion
+pleased him; it seemed to him like a snail's shell, lighted and warmed
+by gas, which sufficed for both these purposes.  When Passepartout
+reached the second story he recognised at once the room which he was to
+inhabit, and he was well satisfied with it.  Electric bells and
+speaking-tubes afforded communication with the lower stories; while on
+the mantel stood an electric clock, precisely like that in Mr. Fogg's
+bedchamber, both beating the same second at the same instant.  "That's
+good, that'll do," said Passepartout to himself.
+
+He suddenly observed, hung over the clock, a card which, upon
+inspection, proved to be a programme of the daily routine of the house.
+It comprised all that was required of the servant, from eight in the
+morning, exactly at which hour Phileas Fogg rose, till half-past
+eleven, when he left the house for the Reform Club--all the details of
+service, the tea and toast at twenty-three minutes past eight, the
+shaving-water at thirty-seven minutes past nine, and the toilet at
+twenty minutes before ten.  Everything was regulated and foreseen that
+was to be done from half-past eleven a.m. till midnight, the hour at
+which the methodical gentleman retired.
+
+Mr. Fogg's wardrobe was amply supplied and in the best taste.  Each
+pair of trousers, coat, and vest bore a number, indicating the time of
+year and season at which they were in turn to be laid out for wearing;
+and the same system was applied to the master's shoes.  In short, the
+house in Saville Row, which must have been a very temple of disorder
+and unrest under the illustrious but dissipated Sheridan, was cosiness,
+comfort, and method idealised.  There was no study, nor were there
+books, which would have been quite useless to Mr. Fogg; for at the
+Reform two libraries, one of general literature and the other of law
+and politics, were at his service.  A moderate-sized safe stood in his
+bedroom, constructed so as to defy fire as well as burglars; but
+Passepartout found neither arms nor hunting weapons anywhere;
+everything betrayed the most tranquil and peaceable habits.
+
+Having scrutinised the house from top to bottom, he rubbed his hands, a
+broad smile overspread his features, and he said joyfully, "This is
+just what I wanted!  Ah, we shall get on together, Mr. Fogg and I!
+What a domestic and regular gentleman!  A real machine; well, I don't
+mind serving a machine."
+
+
+
+
+Chapter III
+
+IN WHICH A CONVERSATION TAKES PLACE WHICH SEEMS LIKELY TO COST PHILEAS
+FOGG DEAR
+
+
+Phileas Fogg, having shut the door of his house at half-past eleven,
+and having put his right foot before his left five hundred and
+seventy-five times, and his left foot before his right five hundred and
+seventy-six times, reached the Reform Club, an imposing edifice in Pall
+Mall, which could not have cost less than three millions.  He repaired
+at once to the dining-room, the nine windows of which open upon a
+tasteful garden, where the trees were already gilded with an autumn
+colouring; and took his place at the habitual table, the cover of which
+had already been laid for him.  His breakfast consisted of a side-dish,
+a broiled fish with Reading sauce, a scarlet slice of roast beef
+garnished with mushrooms, a rhubarb and gooseberry tart, and a morsel
+of Cheshire cheese, the whole being washed down with several cups of
+tea, for which the Reform is famous.  He rose at thirteen minutes to
+one, and directed his steps towards the large hall, a sumptuous
+apartment adorned with lavishly-framed paintings.  A flunkey handed him
+an uncut Times, which he proceeded to cut with a skill which betrayed
+familiarity with this delicate operation.  The perusal of this paper
+absorbed Phileas Fogg until a quarter before four, whilst the Standard,
+his next task, occupied him till the dinner hour.  Dinner passed as
+breakfast had done, and Mr. Fogg re-appeared in the reading-room and
+sat down to the Pall Mall at twenty minutes before six.  Half an hour
+later several members of the Reform came in and drew up to the
+fireplace, where a coal fire was steadily burning.  They were Mr.
+Fogg's usual partners at whist: Andrew Stuart, an engineer; John
+Sullivan and Samuel Fallentin, bankers; Thomas Flanagan, a brewer; and
+Gauthier Ralph, one of the Directors of the Bank of England--all rich
+and highly respectable personages, even in a club which comprises the
+princes of English trade and finance.
+
+"Well, Ralph," said Thomas Flanagan, "what about that robbery?"
+
+"Oh," replied Stuart, "the Bank will lose the money."
+
+"On the contrary," broke in Ralph, "I hope we may put our hands on the
+robber.  Skilful detectives have been sent to all the principal ports
+of America and the Continent, and he'll be a clever fellow if he slips
+through their fingers."
+
+"But have you got the robber's description?" asked Stuart.
+
+"In the first place, he is no robber at all," returned Ralph,
+positively.
+
+"What! a fellow who makes off with fifty-five thousand pounds, no
+robber?"
+
+"No."
+
+"Perhaps he's a manufacturer, then."
+
+"The Daily Telegraph says that he is a gentleman."
+
+It was Phileas Fogg, whose head now emerged from behind his newspapers,
+who made this remark.  He bowed to his friends, and entered into the
+conversation.  The affair which formed its subject, and which was town
+talk, had occurred three days before at the Bank of England.  A package
+of banknotes, to the value of fifty-five thousand pounds, had been
+taken from the principal cashier's table, that functionary being at the
+moment engaged in registering the receipt of three shillings and
+sixpence.  Of course, he could not have his eyes everywhere.  Let it be
+observed that the Bank of England reposes a touching confidence in the
+honesty of the public.  There are neither guards nor gratings to
+protect its treasures; gold, silver, banknotes are freely exposed, at
+the mercy of the first comer.  A keen observer of English customs
+relates that, being in one of the rooms of the Bank one day, he had the
+curiosity to examine a gold ingot weighing some seven or eight pounds.
+He took it up, scrutinised it, passed it to his neighbour, he to the
+next man, and so on until the ingot, going from hand to hand, was
+transferred to the end of a dark entry; nor did it return to its place
+for half an hour.  Meanwhile, the cashier had not so much as raised his
+head.  But in the present instance things had not gone so smoothly.
+The package of notes not being found when five o'clock sounded from the
+ponderous clock in the "drawing office," the amount was passed to the
+account of profit and loss.  As soon as the robbery was discovered,
+picked detectives hastened off to Liverpool, Glasgow, Havre, Suez,
+Brindisi, New York, and other ports, inspired by the proffered reward
+of two thousand pounds, and five per cent. on the sum that might be
+recovered.  Detectives were also charged with narrowly watching those
+who arrived at or left London by rail, and a judicial examination was
+at once entered upon.
+
+There were real grounds for supposing, as the Daily Telegraph said,
+that the thief did not belong to a professional band.  On the day of
+the robbery a well-dressed gentleman of polished manners, and with a
+well-to-do air, had been observed going to and fro in the paying room
+where the crime was committed.  A description of him was easily
+procured and sent to the detectives; and some hopeful spirits, of whom
+Ralph was one, did not despair of his apprehension.  The papers and
+clubs were full of the affair, and everywhere people were discussing
+the probabilities of a successful pursuit; and the Reform Club was
+especially agitated, several of its members being Bank officials.
+
+Ralph would not concede that the work of the detectives was likely to
+be in vain, for he thought that the prize offered would greatly
+stimulate their zeal and activity.  But Stuart was far from sharing
+this confidence; and, as they placed themselves at the whist-table,
+they continued to argue the matter.  Stuart and Flanagan played
+together, while Phileas Fogg had Fallentin for his partner.  As the
+game proceeded the conversation ceased, excepting between the rubbers,
+when it revived again.
+
+"I maintain," said Stuart, "that the chances are in favour of the
+thief, who must be a shrewd fellow."
+
+"Well, but where can he fly to?" asked Ralph.  "No country is safe for
+him."
+
+"Pshaw!"
+
+"Where could he go, then?"
+
+"Oh, I don't know that.  The world is big enough."
+
+"It was once," said Phileas Fogg, in a low tone.  "Cut, sir," he added,
+handing the cards to Thomas Flanagan.
+
+The discussion fell during the rubber, after which Stuart took up its
+thread.
+
+"What do you mean by `once'?  Has the world grown smaller?"
+
+"Certainly," returned Ralph.  "I agree with Mr. Fogg.  The world has
+grown smaller, since a man can now go round it ten times more quickly
+than a hundred years ago.  And that is why the search for this thief
+will be more likely to succeed."
+
+"And also why the thief can get away more easily."
+
+"Be so good as to play, Mr. Stuart," said Phileas Fogg.
+
+But the incredulous Stuart was not convinced, and when the hand was
+finished, said eagerly: "You have a strange way, Ralph, of proving that
+the world has grown smaller.  So, because you can go round it in three
+months--"
+
+"In eighty days," interrupted Phileas Fogg.
+
+"That is true, gentlemen," added John Sullivan.  "Only eighty days, now
+that the section between Rothal and Allahabad, on the Great Indian
+Peninsula Railway, has been opened.  Here is the estimate made by the
+Daily Telegraph:
+
+  From London to Suez via Mont Cenis and
+    Brindisi, by rail and steamboats .................  7 days
+  From Suez to Bombay, by steamer .................... 13  "
+  From Bombay to Calcutta, by rail ...................  3  "
+  From Calcutta to Hong Kong, by steamer ............. 13  "
+  From Hong Kong to Yokohama (Japan), by steamer .....  6  "
+  From Yokohama to San Francisco, by steamer ......... 22  "
+  From San Francisco to New York, by rail ............. 7  "
+  From New York to London, by steamer and rail ........ 9  "
+                                                       ------
+    Total ............................................ 80 days."
+
+"Yes, in eighty days!" exclaimed Stuart, who in his excitement made a
+false deal.  "But that doesn't take into account bad weather, contrary
+winds, shipwrecks, railway accidents, and so on."
+
+"All included," returned Phileas Fogg, continuing to play despite the
+discussion.
+
+"But suppose the Hindoos or Indians pull up the rails," replied Stuart;
+"suppose they stop the trains, pillage the luggage-vans, and scalp the
+passengers!"
+
+"All included," calmly retorted Fogg; adding, as he threw down the
+cards, "Two trumps."
+
+Stuart, whose turn it was to deal, gathered them up, and went on: "You
+are right, theoretically, Mr. Fogg, but practically--"
+
+"Practically also, Mr. Stuart."
+
+"I'd like to see you do it in eighty days."
+
+"It depends on you.  Shall we go?"
+
+"Heaven preserve me!  But I would wager four thousand pounds that such
+a journey, made under these conditions, is impossible."
+
+"Quite possible, on the contrary," returned Mr. Fogg.
+
+"Well, make it, then!"
+
+"The journey round the world in eighty days?"
+
+"Yes."
+
+"I should like nothing better."
+
+"When?"
+
+"At once.  Only I warn you that I shall do it at your expense."
+
+"It's absurd!" cried Stuart, who was beginning to be annoyed at the
+persistency of his friend.  "Come, let's go on with the game."
+
+"Deal over again, then," said Phileas Fogg.  "There's a false deal."
+
+Stuart took up the pack with a feverish hand; then suddenly put them
+down again.
+
+"Well, Mr. Fogg," said he, "it shall be so: I will wager the four
+thousand on it."
+
+"Calm yourself, my dear Stuart," said Fallentin.  "It's only a joke."
+
+"When I say I'll wager," returned Stuart, "I mean it."  
+
+"All right," said Mr. Fogg; and, turning to the others, he continued:
+"I have a deposit of twenty thousand at Baring's which I will willingly
+risk upon it."
+
+"Twenty thousand pounds!" cried Sullivan.  "Twenty thousand pounds,
+which you would lose by a single accidental delay!"
+
+"The unforeseen does not exist," quietly replied Phileas Fogg.
+
+"But, Mr. Fogg, eighty days are only the estimate of the least possible
+time in which the journey can be made."
+
+"A well-used minimum suffices for everything."
+
+"But, in order not to exceed it, you must jump mathematically from the
+trains upon the steamers, and from the steamers upon the trains again."
+
+"I will jump--mathematically."
+
+"You are joking."
+
+"A true Englishman doesn't joke when he is talking about so serious a
+thing as a wager," replied Phileas Fogg, solemnly.  "I will bet twenty
+thousand pounds against anyone who wishes that I will make the tour of
+the world in eighty days or less; in nineteen hundred and twenty hours,
+or a hundred and fifteen thousand two hundred minutes.  Do you accept?"
+
+"We accept," replied Messrs. Stuart, Fallentin, Sullivan, Flanagan, and
+Ralph, after consulting each other.
+
+"Good," said Mr. Fogg.  "The train leaves for Dover at a quarter before
+nine.  I will take it."
+
+"This very evening?" asked Stuart.
+
+"This very evening," returned Phileas Fogg.  He took out and consulted
+a pocket almanac, and added,  "As today is Wednesday, the 2nd of
+October, I shall be due in London in this very room of the Reform Club,
+on Saturday, the 21st of December, at a quarter before nine p.m.; or
+else the twenty thousand pounds, now deposited in my name at Baring's,
+will belong to you, in fact and in right, gentlemen.  Here is a cheque
+for the amount."
+
+A memorandum of the wager was at once drawn up and signed by the six
+parties, during which Phileas Fogg preserved a stoical composure.  He
+certainly did not bet to win, and had only staked the twenty thousand
+pounds, half of his fortune, because he foresaw that he might have to
+expend the other half to carry out this difficult, not to say
+unattainable, project.  As for his antagonists, they seemed much
+agitated; not so much by the value of their stake, as because they had
+some scruples about betting under conditions so difficult to their
+friend.
+
+The clock struck seven, and the party offered to suspend the game so
+that Mr. Fogg might make his preparations for departure.
+
+"I am quite ready now," was his tranquil response.  "Diamonds are
+trumps: be so good as to play, gentlemen."
+
+
+
+
+Chapter IV
+
+IN WHICH PHILEAS FOGG ASTOUNDS PASSEPARTOUT, HIS SERVANT
+
+
+Having won twenty guineas at whist, and taken leave of his friends,
+Phileas Fogg, at twenty-five minutes past seven, left the Reform Club.
+
+Passepartout, who had conscientiously studied the programme of his
+duties, was more than surprised to see his master guilty of the
+inexactness of appearing at this unaccustomed hour; for, according to
+rule, he was not due in Saville Row until precisely midnight.
+
+Mr. Fogg repaired to his bedroom, and called out, "Passepartout!"
+
+Passepartout did not reply.  It could not be he who was called; it was
+not the right hour.
+
+"Passepartout!" repeated Mr. Fogg, without raising his voice.
+
+Passepartout made his appearance.
+
+"I've called you twice," observed his master.
+
+"But it is not midnight," responded the other, showing his watch.
+
+"I know it; I don't blame you.  We start for Dover and Calais in ten
+minutes."
+
+A puzzled grin overspread Passepartout's round face; clearly he had not
+comprehended his master.
+
+"Monsieur is going to leave home?"
+
+"Yes," returned Phileas Fogg.  "We are going round the world."
+
+Passepartout opened wide his eyes, raised his eyebrows, held up his
+hands, and seemed about to collapse, so overcome was he with stupefied
+astonishment.
+
+"Round the world!" he murmured.
+
+"In eighty days," responded Mr. Fogg.  "So we haven't a moment to lose."
+
+"But the trunks?" gasped Passepartout, unconsciously swaying his head
+from right to left.
+
+"We'll have no trunks; only a carpet-bag, with two shirts and three
+pairs of stockings for me, and the same for you.  We'll buy our clothes
+on the way.  Bring down my mackintosh and traveling-cloak, and some
+stout shoes, though we shall do little walking.  Make haste!"
+
+Passepartout tried to reply, but could not.  He went out, mounted to
+his own room, fell into a chair, and muttered: "That's good, that is!
+And I, who wanted to remain quiet!"
+
+He mechanically set about making the preparations for departure.
+Around the world in eighty days!  Was his master a fool?  No.  Was this
+a joke, then?  They were going to Dover; good!  To Calais; good again!
+After all, Passepartout, who had been away from France five years,
+would not be sorry to set foot on his native soil again.  Perhaps they
+would go as far as Paris, and it would do his eyes good to see Paris
+once more.  But surely a gentleman so chary of his steps would stop
+there; no doubt--but, then, it was none the less true that he was
+going away, this so domestic person hitherto!
+
+By eight o'clock Passepartout had packed the modest carpet-bag,
+containing the wardrobes of his master and himself; then, still
+troubled in mind, he carefully shut the door of his room, and descended
+to Mr. Fogg.
+
+Mr. Fogg was quite ready.  Under his arm might have been observed a
+red-bound copy of Bradshaw's Continental Railway Steam Transit and
+General Guide, with its timetables showing the arrival and departure of
+steamers and railways.  He took the carpet-bag, opened it, and slipped
+into it a goodly roll of Bank of England notes, which would pass
+wherever he might go.
+
+"You have forgotten nothing?" asked he.
+
+"Nothing, monsieur."
+
+"My mackintosh and cloak?"
+
+"Here they are."
+
+"Good!  Take this carpet-bag," handing it to Passepartout.  "Take good
+care of it, for there are twenty thousand pounds in it."
+
+Passepartout nearly dropped the bag, as if the twenty thousand pounds
+were in gold, and weighed him down.
+
+Master and man then descended, the street-door was double-locked, and
+at the end of Saville Row they took a cab and drove rapidly to Charing
+Cross.  The cab stopped before the railway station at twenty minutes
+past eight.  Passepartout jumped off the box and followed his master,
+who, after paying the cabman, was about to enter the station, when a
+poor beggar-woman, with a child in her arms, her naked feet smeared
+with mud, her head covered with a wretched bonnet, from which hung a
+tattered feather, and her shoulders shrouded in a ragged shawl,
+approached, and mournfully asked for alms.
+
+Mr. Fogg took out the twenty guineas he had just won at whist, and
+handed them to the beggar, saying, "Here, my good woman.  I'm glad that
+I met you;" and passed on.
+
+Passepartout had a moist sensation about the eyes; his master's action
+touched his susceptible heart.
+
+Two first-class tickets for Paris having been speedily purchased, Mr.
+Fogg was crossing the station to the train, when he perceived his five
+friends of the Reform.
+
+"Well, gentlemen," said he, "I'm off, you see; and, if you will examine
+my passport when I get back, you will be able to judge whether I have
+accomplished the journey agreed upon."
+
+"Oh, that would be quite unnecessary, Mr. Fogg," said Ralph politely.
+"We will trust your word, as a gentleman of honour."
+
+"You do not forget when you are due in London again?"  asked Stuart.
+
+"In eighty days; on Saturday, the 21st of December, 1872, at a quarter
+before nine p.m.  Good-bye, gentlemen."
+
+Phileas Fogg and his servant seated themselves in a first-class
+carriage at twenty minutes before nine; five minutes later the whistle
+screamed, and the train slowly glided out of the station.
+
+The night was dark, and a fine, steady rain was falling.  Phileas Fogg,
+snugly ensconced in his corner, did not open his lips.  Passepartout,
+not yet recovered from his stupefaction, clung mechanically to the
+carpet-bag, with its enormous treasure.
+
+Just as the train was whirling through Sydenham, Passepartout suddenly
+uttered a cry of despair.
+
+"What's the matter?" asked Mr. Fogg.
+
+"Alas!  In my hurry--I--I forgot--"
+
+"What?"
+
+"To turn off the gas in my room!"
+
+"Very well, young man," returned Mr. Fogg, coolly; "it will burn--at
+your expense."
+
+
+
+
+Chapter V
+
+
+IN WHICH A NEW SPECIES OF FUNDS, UNKNOWN TO THE MONEYED MEN, APPEARS ON
+'CHANGE
+
+
+Phileas Fogg rightly suspected that his departure from London would
+create a lively sensation at the West End.  The news of the bet spread
+through the Reform Club, and afforded an exciting topic of conversation
+to its members.  From the club it soon got into the papers throughout
+England.  The boasted "tour of the world" was talked about, disputed,
+argued with as much warmth as if the subject were another Alabama
+claim.  Some took sides with Phileas Fogg, but the large majority shook
+their heads and declared against him; it was absurd, impossible, they
+declared, that the tour of the world could be made, except
+theoretically and on paper, in this minimum of time, and with the
+existing means of travelling.  The Times, Standard, Morning Post, and
+Daily News, and twenty other highly respectable newspapers scouted Mr.
+Fogg's project as madness; the Daily Telegraph alone hesitatingly
+supported him.  People in general thought him a lunatic, and blamed his
+Reform Club friends for having accepted a wager which betrayed the
+mental aberration of its proposer.
+
+Articles no less passionate than logical appeared on the question, for
+geography is one of the pet subjects of the English; and the columns
+devoted to Phileas Fogg's venture were eagerly devoured by all classes
+of readers.  At first some rash individuals, principally of the gentler
+sex, espoused his cause, which became still more popular when the
+Illustrated London News came out with his portrait, copied from a
+photograph in the Reform Club.  A few readers of the Daily Telegraph
+even dared to say, "Why not, after all?  Stranger things have come to
+pass."
+
+At last a long article appeared, on the 7th of October, in the bulletin
+of the Royal Geographical Society, which treated the question from
+every point of view, and demonstrated the utter folly of the enterprise.
+
+Everything, it said, was against the travellers, every obstacle imposed
+alike by man and by nature.  A miraculous agreement of the times of
+departure and arrival, which was impossible, was absolutely necessary
+to his success.  He might, perhaps, reckon on the arrival of trains at
+the designated hours, in Europe, where the distances were relatively
+moderate; but when he calculated upon crossing India in three days, and
+the United States in seven, could he rely beyond misgiving upon
+accomplishing his task?  There were accidents to machinery, the
+liability of trains to run off the line, collisions, bad weather, the
+blocking up by snow--were not all these against Phileas Fogg?  Would he
+not find himself, when travelling by steamer in winter, at the mercy of
+the winds and fogs?  Is it uncommon for the best ocean steamers to be
+two or three days behind time?  But a single delay would suffice to
+fatally break the chain of communication; should Phileas Fogg once
+miss, even by an hour; a steamer, he would have to wait for the next,
+and that would irrevocably render his attempt vain.
+
+This article made a great deal of noise, and, being copied into all the
+papers, seriously depressed the advocates of the rash tourist.
+
+Everybody knows that England is the world of betting men, who are of a
+higher class than mere gamblers; to bet is in the English temperament.
+Not only the members of the Reform, but the general public, made heavy
+wagers for or against Phileas Fogg, who was set down in the betting
+books as if he were a race-horse.  Bonds were issued, and made their
+appearance on 'Change; "Phileas Fogg bonds" were offered at par or at a
+premium, and a great business was done in them.  But five days after
+the article in the bulletin of the Geographical Society appeared, the
+demand began to subside:  "Phileas Fogg" declined.  They were offered
+by packages, at first of five, then of ten, until at last nobody would
+take less than twenty, fifty, a hundred!
+
+Lord Albemarle, an elderly paralytic gentleman, was now the only
+advocate of Phileas Fogg left.  This noble lord, who was fastened to
+his chair, would have given his fortune to be able to make the tour of
+the world, if it took ten years; and he bet five thousand pounds on
+Phileas Fogg.  When the folly as well as the uselessness of the
+adventure was pointed out to him, he contented himself with replying,
+"If the thing is feasible, the first to do it ought to be an
+Englishman."
+
+The Fogg party dwindled more and more, everybody was going against him,
+and the bets stood a hundred and fifty and two hundred to one; and a
+week after his departure an incident occurred which deprived him of
+backers at any price.
+
+The commissioner of police was sitting in his office at nine o'clock
+one evening, when the following telegraphic dispatch was put into his
+hands:
+
+Suez to London.
+
+Rowan, Commissioner of Police, Scotland Yard:
+
+I've found the bank robber, Phileas Fogg.  Send with out delay warrant
+of arrest to Bombay.
+
+Fix, Detective.
+
+The effect of this dispatch was instantaneous.  The polished gentleman
+disappeared to give place to the bank robber.  His photograph, which
+was hung with those of the rest of the members at the Reform Club, was
+minutely examined, and it betrayed, feature by feature, the description
+of the robber which had been provided to the police.  The mysterious
+habits of Phileas Fogg were recalled; his solitary ways, his sudden
+departure; and it seemed clear that, in undertaking a tour round the
+world on the pretext of a wager, he had had no other end in view than
+to elude the detectives, and throw them off his track.
+
+
+
+
+Chapter VI
+
+IN WHICH FIX, THE DETECTIVE, BETRAYS A VERY NATURAL IMPATIENCE
+
+
+The circumstances under which this telegraphic dispatch about Phileas
+Fogg was sent were as follows:
+
+The steamer Mongolia, belonging to the Peninsular and Oriental Company,
+built of iron, of two thousand eight hundred tons burden, and five
+hundred horse-power, was due at eleven o'clock a.m. on Wednesday, the
+9th of October, at Suez.  The Mongolia plied regularly between Brindisi
+and Bombay via the Suez Canal, and was one of the fastest steamers
+belonging to the company, always making more than ten knots an hour
+between Brindisi and Suez, and nine and a half between Suez and Bombay.
+
+Two men were promenading up and down the wharves, among the crowd of
+natives and strangers who were sojourning at this once straggling
+village--now, thanks to the enterprise of M. Lesseps, a fast-growing
+town.  One was the British consul at Suez, who, despite the prophecies
+of the English Government, and the unfavourable predictions of
+Stephenson, was in the habit of seeing, from his office window, English
+ships daily passing to and fro on the great canal, by which the old
+roundabout route from England to India by the Cape of Good Hope was
+abridged by at least a half.  The other was a small, slight-built
+personage, with a nervous, intelligent face, and bright eyes peering
+out from under eyebrows which he was incessantly twitching.  He was
+just now manifesting unmistakable signs of impatience, nervously pacing
+up and down, and unable to stand still for a moment.  This was Fix, one
+of the detectives who had been dispatched from England in search of the
+bank robber; it was his task to narrowly watch every passenger who
+arrived at Suez, and to follow up all who seemed to be suspicious
+characters, or bore a resemblance to the description of the criminal,
+which he had received two days before from the police headquarters at
+London.  The detective was evidently inspired by the hope of obtaining
+the splendid reward which would be the prize of success, and awaited
+with a feverish impatience, easy to understand, the arrival of the
+steamer Mongolia.
+
+"So you say, consul," asked he for the twentieth time, "that this
+steamer is never behind time?"
+
+"No, Mr. Fix," replied the consul.  "She was bespoken yesterday at Port
+Said, and the rest of the way is of no account to such a craft.  I
+repeat that the Mongolia has been in advance of the time required by
+the company's regulations, and gained the prize awarded for excess of
+speed."
+
+"Does she come directly from Brindisi?"
+
+"Directly from Brindisi; she takes on the Indian mails there, and she
+left there Saturday at five p.m.  Have patience, Mr. Fix; she will not
+be late.  But really, I don't see how, from the description you have,
+you will be able to recognise your man, even if he is on board the
+Mongolia."
+
+"A man rather feels the presence of these fellows, consul, than
+recognises them.  You must have a scent for them, and a scent is like a
+sixth sense which combines hearing, seeing, and smelling.  I've
+arrested more than one of these gentlemen in my time, and, if my thief
+is on board, I'll answer for it; he'll not slip through my fingers."
+
+"I hope so, Mr. Fix, for it was a heavy robbery."
+
+"A magnificent robbery, consul; fifty-five thousand pounds!  We don't
+often have such windfalls.  Burglars are getting to be so contemptible
+nowadays!  A fellow gets hung for a handful of shillings!"
+
+"Mr. Fix," said the consul, "I like your way of talking, and hope
+you'll succeed; but I fear you will find it far from easy.  Don't you
+see, the description which you have there has a singular resemblance to
+an honest man?"
+
+"Consul," remarked the detective, dogmatically, "great robbers always
+resemble honest folks.  Fellows who have rascally faces have only one
+course to take, and that is to remain honest; otherwise they would be
+arrested off-hand.  The artistic thing is, to unmask honest
+countenances; it's no light task, I admit, but a real art."
+
+Mr. Fix evidently was not wanting in a tinge of self-conceit.
+
+Little by little the scene on the quay became more animated; sailors of
+various nations, merchants, ship-brokers, porters, fellahs, bustled to
+and fro as if the steamer were immediately expected.  The weather was
+clear, and slightly chilly.  The minarets of the town loomed above the
+houses in the pale rays of the sun.  A jetty pier, some two thousand
+yards along, extended into the roadstead.  A number of fishing-smacks
+and coasting boats, some retaining the fantastic fashion of ancient
+galleys, were discernible on the Red Sea.
+
+As he passed among the busy crowd, Fix, according to habit, scrutinised
+the passers-by with a keen, rapid glance.
+
+It was now half-past ten.
+
+"The steamer doesn't come!" he exclaimed, as the port clock struck.
+
+"She can't be far off now," returned his companion.
+
+"How long will she stop at Suez?"
+
+"Four hours; long enough to get in her coal.  It is thirteen hundred
+and ten miles from Suez to Aden, at the other end of the Red Sea, and
+she has to take in a fresh coal supply."
+
+"And does she go from Suez directly to Bombay?"
+
+"Without putting in anywhere."
+
+"Good!" said Fix.  "If the robber is on board he will no doubt get off
+at Suez, so as to reach the Dutch or French colonies in Asia by some
+other route.  He ought to know that he would not be safe an hour in
+India, which is English soil."
+
+"Unless," objected the consul, "he is exceptionally shrewd.  An English
+criminal, you know, is always better concealed in London than anywhere
+else."
+
+This observation furnished the detective food for thought, and
+meanwhile the consul went away to his office.  Fix, left alone, was
+more impatient than ever, having a presentiment that the robber was on
+board the Mongolia.  If he had indeed left London intending to reach
+the New World, he would naturally take the route via India, which was
+less watched and more difficult to watch than that of the Atlantic.
+But Fix's reflections were soon interrupted by a succession of sharp
+whistles, which announced the arrival of the Mongolia.  The porters and
+fellahs rushed down the quay, and a dozen boats pushed off from the
+shore to go and meet the steamer.  Soon her gigantic hull appeared
+passing along between the banks, and eleven o'clock struck as she
+anchored in the road.  She brought an unusual number of passengers,
+some of whom remained on deck to scan the picturesque panorama of the
+town, while the greater part disembarked in the boats, and landed on
+the quay.
+
+Fix took up a position, and carefully examined each face and figure
+which made its appearance.  Presently one of the passengers, after
+vigorously pushing his way through the importunate crowd of porters,
+came up to him and politely asked if he could point out the English
+consulate, at the same time showing a passport which he wished to have
+visaed.  Fix instinctively took the passport, and with a rapid glance
+read the description of its bearer.  An involuntary motion of surprise
+nearly escaped him, for the description in the passport was identical
+with that of the bank robber which he had received from Scotland Yard.
+
+"Is this your passport?" asked he.
+
+"No, it's my master's."
+
+"And your master is--"
+
+"He stayed on board."
+
+"But he must go to the consul's in person, so as to establish his
+identity."
+
+"Oh, is that necessary?"
+
+"Quite indispensable."
+
+"And where is the consulate?"
+
+"There, on the corner of the square," said Fix, pointing to a house two
+hundred steps off.
+
+"I'll go and fetch my master, who won't be much pleased, however, to be
+disturbed."
+
+The passenger bowed to Fix, and returned to the steamer.
+
+
+
+
+Chapter VII
+
+WHICH ONCE MORE DEMONSTRATES THE USELESSNESS OF PASSPORTS AS AIDS TO
+DETECTIVES
+
+
+The detective passed down the quay, and rapidly made his way to the
+consul's office, where he was at once admitted to the presence of that
+official.
+
+"Consul," said he, without preamble, "I have strong reasons for
+believing that my man is a passenger on the Mongolia." And he narrated
+what had just passed concerning the passport.
+
+"Well, Mr. Fix," replied the consul, "I shall not be sorry to see the
+rascal's face; but perhaps he won't come here--that is, if he is the
+person you suppose him to be.  A robber doesn't quite like to leave
+traces of his flight behind him; and, besides, he is not obliged to
+have his passport countersigned."
+
+"If he is as shrewd as I think he is, consul, he will come."
+
+"To have his passport visaed?"
+
+"Yes.  Passports are only good for annoying honest folks, and aiding in
+the flight of rogues.  I assure you it will be quite the thing for him
+to do; but I hope you will not visa the passport."
+
+"Why not?  If the passport is genuine I have no right to refuse."
+
+"Still, I must keep this man here until I can get a warrant to arrest
+him from London."
+
+"Ah, that's your look-out.  But I cannot--"
+
+The consul did not finish his sentence, for as he spoke a knock was
+heard at the door, and two strangers entered, one of whom was the
+servant whom Fix had met on the quay.  The other, who was his master,
+held out his passport with the request that the consul would do him the
+favour to visa it.  The consul took the document and carefully read it,
+whilst Fix observed, or rather devoured, the stranger with his eyes
+from a corner of the room.
+
+"You are Mr. Phileas Fogg?" said the consul, after reading the passport.
+
+"I am."
+
+"And this man is your servant?"
+
+"He is: a Frenchman, named Passepartout."
+
+"You are from London?"
+
+"Yes."
+
+"And you are going--"
+
+"To Bombay."
+
+"Very good, sir.  You know that a visa is useless, and that no passport
+is required?"
+
+"I know it, sir," replied Phileas Fogg; "but I wish to prove, by your
+visa, that I came by Suez."
+
+"Very well, sir."
+
+The consul proceeded to sign and date the passport, after which he
+added his official seal.  Mr. Fogg paid the customary fee, coldly
+bowed, and went out, followed by his servant.
+
+"Well?" queried the detective.
+
+"Well, he looks and acts like a perfectly honest man," replied the
+consul.
+
+"Possibly; but that is not the question.  Do you think, consul, that
+this phlegmatic gentleman resembles, feature by feature, the robber
+whose description I have received?"
+
+"I concede that; but then, you know, all descriptions--"
+
+"I'll make certain of it," interrupted Fix.  "The servant seems to me
+less mysterious than the master; besides, he's a Frenchman, and can't
+help talking.  Excuse me for a little while, consul."
+
+Fix started off in search of Passepartout.
+
+Meanwhile Mr. Fogg, after leaving the consulate, repaired to the quay,
+gave some orders to Passepartout, went off to the    Mongolia in a
+boat, and descended to his cabin.  He took up his note-book, which
+contained the following memoranda:
+
+"Left London, Wednesday, October 2nd, at 8.45 p.m.  "Reached Paris,
+Thursday, October 3rd, at 7.20 a.m.  "Left Paris, Thursday, at 8.40
+a.m.  "Reached Turin by Mont Cenis, Friday, October 4th, at 6.35 a.m.
+"Left Turin, Friday, at 7.20 a.m.  "Arrived at Brindisi, Saturday,
+October 5th, at 4 p.m.  "Sailed on the Mongolia, Saturday, at 5 p.m.
+"Reached Suez, Wednesday, October 9th, at 11 a.m.  "Total of hours
+spent, 158+; or, in days, six days and a half."
+
+These dates were inscribed in an itinerary divided into columns,
+indicating the month, the day of the month, and the day for the
+stipulated and actual arrivals at each principal point Paris, Brindisi,
+Suez, Bombay, Calcutta, Singapore, Hong Kong, Yokohama, San Francisco,
+New York, and London--from the 2nd of October to the 21st of December;
+and giving a space for setting down the gain made or the loss suffered
+on arrival at each locality.  This methodical record thus contained an
+account of everything needed, and Mr. Fogg always knew whether he was
+behind-hand or in advance of his time.  On this Friday, October 9th, he
+noted his arrival at Suez, and observed that he had as yet neither
+gained nor lost.  He sat down quietly to breakfast in his cabin, never
+once thinking of inspecting the town, being one of those Englishmen who
+are wont to see foreign countries through the eyes of their domestics.
+
+
+
+
+Chapter VIII
+
+IN WHICH PASSEPARTOUT TALKS RATHER MORE, PERHAPS, THAN IS PRUDENT
+
+
+Fix soon rejoined Passepartout, who was lounging and looking about on
+the quay, as if he did not feel that he, at least, was obliged not to
+see anything.
+
+"Well, my friend," said the detective, coming up with him, "is your
+passport visaed?"
+
+"Ah, it's you, is it, monsieur?" responded Passepartout.  "Thanks, yes,
+the passport is all right."
+
+"And you are looking about you?"
+
+"Yes; but we travel so fast that I seem to be journeying in a dream.
+So this is Suez?"
+
+"Yes."
+
+"In Egypt?"
+
+"Certainly, in Egypt."
+
+"And in Africa?"
+
+"In Africa."
+
+"In Africa!" repeated Passepartout.  "Just think, monsieur, I had no
+idea that we should go farther than Paris; and all that I saw of Paris
+was between twenty minutes past seven and twenty minutes before nine in
+the morning, between the Northern and the Lyons stations, through the
+windows of a car, and in a driving rain!  How I regret not having seen
+once more Pere la Chaise and the circus in the Champs Elysees!"
+
+"You are in a great hurry, then?"
+
+"I am not, but my master is.  By the way, I must buy some shoes and
+shirts.  We came away without trunks, only with a carpet-bag."
+
+"I will show you an excellent shop for getting what you want."
+
+"Really, monsieur, you are very kind."
+
+And they walked off together, Passepartout chatting volubly as they
+went along.
+
+"Above all," said he; "don't let me lose the steamer."
+
+"You have plenty of time; it's only twelve o'clock."
+
+Passepartout pulled out his big watch.  "Twelve!" he exclaimed; "why,
+it's only eight minutes before ten."
+
+"Your watch is slow."
+
+"My watch?  A family watch, monsieur, which has come down from my
+great-grandfather!  It doesn't vary five minutes in the year.  It's a
+perfect chronometer, look you."
+
+"I see how it is," said Fix.  "You have kept London time, which is two
+hours behind that of Suez.  You ought to regulate your watch at noon in
+each country."
+
+"I regulate my watch?  Never!"
+
+"Well, then, it will not agree with the sun."
+
+"So much the worse for the sun, monsieur.  The sun will be wrong, then!"
+
+And the worthy fellow returned the watch to its fob with a defiant
+gesture.  After a few minutes silence, Fix resumed: "You left London
+hastily, then?"
+
+"I rather think so!  Last Friday at eight o'clock in the evening,
+Monsieur Fogg came home from his club, and three-quarters of an hour
+afterwards we were off."
+
+"But where is your master going?"
+
+"Always straight ahead.  He is going round the world."
+
+"Round the world?" cried Fix.
+
+"Yes, and in eighty days!  He says it is on a wager; but, between us, I
+don't believe a word of it.  That wouldn't be common sense.  There's
+something else in the wind."
+
+"Ah!  Mr. Fogg is a character, is he?"
+
+"I should say he was."
+
+"Is he rich?"
+
+"No doubt, for he is carrying an enormous sum in brand new banknotes
+with him.  And he doesn't spare the money on the way, either: he has
+offered a large reward to the engineer of the Mongolia if he gets us to
+Bombay well in advance of time."
+
+"And you have known your master a long time?"
+
+"Why, no; I entered his service the very day we left London."
+
+The effect of these replies upon the already suspicious and excited
+detective may be imagined.  The hasty departure from London soon after
+the robbery; the large sum carried by Mr. Fogg; his eagerness to reach
+distant countries; the pretext of an eccentric and foolhardy bet--all
+confirmed Fix in his theory.  He continued to pump poor Passepartout,
+and learned that he really knew little or nothing of his master, who
+lived a solitary existence in London, was said to be rich, though no
+one knew whence came his riches, and was mysterious and impenetrable in
+his affairs and habits.  Fix felt sure that Phileas Fogg would not land
+at Suez, but was really going on to Bombay.
+
+"Is Bombay far from here?" asked Passepartout.
+
+"Pretty far.  It is a ten days' voyage by sea."
+
+"And in what country is Bombay?"
+
+"India."
+
+"In Asia?"
+
+"Certainly."
+
+"The deuce!  I was going to tell you there's one thing that worries
+me--my burner!"
+
+"What burner?"
+
+"My gas-burner, which I forgot to turn off, and which is at this moment
+burning at my expense.  I have calculated, monsieur, that I lose two
+shillings every four and twenty hours, exactly sixpence more than I
+earn; and you will understand that the longer our journey--"
+
+Did Fix pay any attention to Passepartout's trouble about the gas?  It
+is not probable.  He was not listening, but was cogitating a project.
+Passepartout and he had now reached the shop, where Fix left his
+companion to make his purchases, after recommending him not to miss the
+steamer, and hurried back to the consulate.  Now that he was fully
+convinced, Fix had quite recovered his equanimity.
+
+"Consul," said he, "I have no longer any doubt.  I have spotted my man.
+He passes himself off as an odd stick who is going round the world in
+eighty days."
+
+"Then he's a sharp fellow," returned the consul, "and counts on
+returning to London after putting the police of the two countries off
+his track."
+
+"We'll see about that," replied Fix.
+
+"But are you not mistaken?"
+
+"I am not mistaken."
+
+"Why was this robber so anxious to prove, by the visa, that he had
+passed through Suez?"
+
+"Why?  I have no idea; but listen to me."
+
+He reported in a few words the most important parts of his conversation
+with Passepartout.
+
+"In short," said the consul, "appearances are wholly against this man.
+And what are you going to do?"
+
+"Send a dispatch to London for a warrant of arrest to be dispatched
+instantly to Bombay, take passage on board the Mongolia, follow my
+rogue to India, and there, on English ground, arrest him politely, with
+my warrant in my hand, and my hand on his shoulder."
+
+Having uttered these words with a cool, careless air, the detective
+took leave of the consul, and repaired to the telegraph office, whence
+he sent the dispatch which we have seen to the London police office.  A
+quarter of an hour later found Fix, with a small bag in his hand,
+proceeding on board the Mongolia; and, ere many moments longer, the
+noble steamer rode out at full steam upon the waters of the Red Sea.
+
+
+
+
+Chapter IX
+
+IN WHICH THE RED SEA AND THE INDIAN OCEAN PROVE PROPITIOUS TO THE
+DESIGNS OF PHILEAS FOGG
+
+
+The distance between Suez and Aden is precisely thirteen hundred and
+ten miles, and the regulations of the company allow the steamers one
+hundred and thirty-eight hours in which to traverse it.  The Mongolia,
+thanks to the vigorous exertions of the engineer, seemed likely, so
+rapid was her speed, to reach her destination considerably within that
+time.  The greater part of the passengers from Brindisi were bound for
+India some for Bombay, others for Calcutta by way of Bombay, the
+nearest route thither, now that a railway crosses the Indian peninsula.
+Among the passengers was a number of officials and military officers of
+various grades, the latter being either attached to the regular British
+forces or commanding the Sepoy troops, and receiving high salaries ever
+since the central government has assumed the powers of the East India
+Company: for the sub-lieutenants get 280 pounds, brigadiers, 2,400
+pounds, and generals of divisions, 4,000 pounds.  What with the
+military men, a number of rich young Englishmen on their travels, and
+the hospitable efforts of the purser, the time passed quickly on the
+Mongolia.  The best of fare was spread upon the cabin tables at
+breakfast, lunch, dinner, and the eight o'clock supper, and the ladies
+scrupulously changed their toilets twice a day; and the hours were
+whirled away, when the sea was tranquil, with music, dancing, and games.
+
+But the Red Sea is full of caprice, and often boisterous, like most
+long and narrow gulfs.  When the wind came from the African or Asian
+coast the Mongolia, with her long hull, rolled fearfully.  Then the
+ladies speedily disappeared below; the pianos were silent; singing and
+dancing suddenly ceased.  Yet the good ship ploughed straight on,
+unretarded by wind or wave, towards the straits of Bab-el-Mandeb.  What
+was Phileas Fogg doing all this time?  It might be thought that, in his
+anxiety, he would be constantly watching the changes of the wind, the
+disorderly raging of the billows--every chance, in short, which might
+force the Mongolia to slacken her speed, and thus interrupt his
+journey.  But, if he thought of these possibilities, he did not betray
+the fact by any outward sign.
+
+Always the same impassible member of the Reform Club, whom no incident
+could surprise, as unvarying as the ship's chronometers, and seldom
+having the curiosity even to go upon the deck, he passed through the
+memorable scenes of the Red Sea with cold indifference; did not care to
+recognise the historic towns and villages which, along its borders,
+raised their picturesque outlines against the sky; and betrayed no fear
+of the dangers of the Arabic Gulf, which the old historians always
+spoke of with horror, and upon which the ancient navigators never
+ventured without propitiating the gods by ample sacrifices.  How did
+this eccentric personage pass his time on the Mongolia?  He made his
+four hearty meals every day, regardless of the most persistent rolling
+and pitching on the part of the steamer; and he played whist
+indefatigably, for he had found partners as enthusiastic in the game as
+himself.  A tax-collector, on the way to his post at Goa; the Rev.
+Decimus Smith, returning to his parish at Bombay; and a
+brigadier-general of the English army, who was about to rejoin his
+brigade at Benares, made up the party, and, with Mr. Fogg, played whist
+by the hour together in absorbing silence.
+
+As for Passepartout, he, too, had escaped sea-sickness, and took his
+meals conscientiously in the forward cabin.  He rather enjoyed the
+voyage, for he was well fed and well lodged, took a great interest in
+the scenes through which they were passing, and consoled himself with
+the delusion that his master's whim would end at Bombay.  He was
+pleased, on the day after leaving Suez, to find on deck the obliging
+person with whom he had walked and chatted on the quays.
+
+"If I am not mistaken," said he, approaching this person, with his most
+amiable smile, "you are the gentleman who so kindly volunteered to
+guide me at Suez?"
+
+"Ah!  I quite recognise you.  You are the servant of the strange
+Englishman--"
+
+"Just so, monsieur--"
+
+"Fix."
+
+"Monsieur Fix," resumed Passepartout, "I'm charmed to find you on
+board.  Where are you bound?"
+
+"Like you, to Bombay."
+
+"That's capital!  Have you made this trip before?"
+
+"Several times.  I am one of the agents of the Peninsular Company."
+
+"Then you know India?"
+
+"Why yes," replied Fix, who spoke cautiously.
+
+"A curious place, this India?"
+
+"Oh, very curious.  Mosques, minarets, temples, fakirs, pagodas,
+tigers, snakes, elephants!  I hope you will have ample time to see the
+sights."
+
+"I hope so, Monsieur Fix.  You see, a man of sound sense ought not to
+spend his life jumping from a steamer upon a railway train, and from a
+railway train upon a steamer again, pretending to make the tour of the
+world in eighty days!  No; all these gymnastics, you may be sure, will
+cease at Bombay."
+
+"And Mr. Fogg is getting on well?" asked Fix, in the most natural tone
+in the world.
+
+"Quite well, and I too.  I eat like a famished ogre; it's the sea air."
+
+"But I never see your master on deck."
+
+"Never; he hasn't the least curiosity."
+
+"Do you know, Mr. Passepartout, that this pretended tour in eighty days
+may conceal some secret errand--perhaps a diplomatic mission?"
+
+"Faith, Monsieur Fix, I assure you I know nothing about it, nor would I
+give half a crown to find out."
+
+After this meeting, Passepartout and Fix got into the habit of chatting
+together, the latter making it a point to gain the worthy man's
+confidence.  He frequently offered him a glass of whiskey or pale ale
+in the steamer bar-room, which Passepartout never failed to accept with
+graceful alacrity, mentally pronouncing Fix the best of good fellows.
+
+Meanwhile the Mongolia was pushing forward rapidly; on the 13th, Mocha,
+surrounded by its ruined walls whereon date-trees were growing, was
+sighted, and on the mountains beyond were espied vast coffee-fields.
+Passepartout was ravished to behold this celebrated place, and thought
+that, with its circular walls and dismantled fort, it looked like an
+immense coffee-cup and saucer. The following night they passed through
+the Strait of Bab-el-Mandeb, which means in Arabic The Bridge of Tears,
+and the next day they put in at Steamer Point, north-west of Aden
+harbour, to take in coal.  This matter of fuelling steamers is a
+serious one at such distances from the coal-mines; it costs the
+Peninsular Company some eight hundred thousand pounds a year.  In these
+distant seas, coal is worth three or four pounds sterling a ton.
+
+The Mongolia had still sixteen hundred and fifty miles to traverse
+before reaching Bombay, and was obliged to remain four hours at Steamer
+Point to coal up.  But this delay, as it was foreseen, did not affect
+Phileas Fogg's programme; besides, the Mongolia, instead of reaching
+Aden on the morning of the 15th, when she was due, arrived there on the
+evening of the 14th, a gain of fifteen hours.
+
+Mr. Fogg and his servant went ashore at Aden to have the passport again
+visaed; Fix, unobserved, followed them.  The visa procured, Mr. Fogg
+returned on board to resume his former habits; while Passepartout,
+according to custom, sauntered about among the mixed population of
+Somalis, Banyans, Parsees, Jews, Arabs, and Europeans who comprise the
+twenty-five thousand inhabitants of Aden.  He gazed with wonder upon
+the fortifications which make this place the Gibraltar of the Indian
+Ocean, and the vast cisterns where the English engineers were still at
+work, two thousand years after the engineers of Solomon.
+
+"Very curious, very curious," said Passepartout to himself, on
+returning to the steamer.  "I see that it is by no means useless to
+travel, if a man wants to see something new."  At six p.m.  the
+Mongolia slowly moved out of the roadstead, and was soon once more on
+the Indian Ocean.  She had a hundred and sixty-eight hours in which to
+reach Bombay, and the sea was favourable, the wind being in the
+north-west, and all sails aiding the engine.  The steamer rolled but
+little, the ladies, in fresh toilets, reappeared on deck, and the
+singing and dancing were resumed.  The trip was being accomplished most
+successfully, and Passepartout was enchanted with the congenial
+companion which chance had secured him in the person of the delightful
+Fix.  On Sunday, October 20th, towards noon, they came in sight of the
+Indian coast: two hours later the pilot came on board.  A range of
+hills lay against the sky in the horizon, and soon the rows of palms
+which adorn Bombay came distinctly into view.  The steamer entered the
+road formed by the islands in the bay, and at half-past four she hauled
+up at the quays of Bombay.
+
+Phileas Fogg was in the act of finishing the thirty-third rubber of the
+voyage, and his partner and himself having, by a bold stroke, captured
+all thirteen of the tricks, concluded this fine campaign with a
+brilliant victory.
+
+The Mongolia was due at Bombay on the 22nd; she arrived on the 20th.
+This was a gain to Phileas Fogg of two days since his departure from
+London, and he calmly entered the fact in the itinerary, in the column
+of gains.
+
+
+
+
+Chapter X
+
+IN WHICH PASSEPARTOUT IS ONLY TOO GLAD TO GET OFF WITH THE LOSS OF HIS
+SHOES
+
+
+Everybody knows that the great reversed triangle of land, with its base
+in the north and its apex in the south, which is called India, embraces
+fourteen hundred thousand square miles, upon which is spread unequally
+a population of one hundred and eighty millions of souls.  The British
+Crown exercises a real and despotic dominion over the larger portion of
+this vast country, and has a governor-general stationed at Calcutta,
+governors at Madras, Bombay, and in Bengal, and a lieutenant-governor
+at Agra.
+
+But British India, properly so called, only embraces seven hundred
+thousand square miles, and a population of from one hundred to one
+hundred and ten millions of inhabitants.  A considerable portion of
+India is still free from British authority; and there are certain
+ferocious rajahs in the interior who are absolutely independent.  The
+celebrated East India Company was all-powerful from 1756, when the
+English first gained a foothold on the spot where now stands the city
+of Madras, down to the time of the great Sepoy insurrection.  It
+gradually annexed province after province, purchasing them of the
+native chiefs, whom it seldom paid, and appointed the governor-general
+and his subordinates, civil and military.  But the East India Company
+has now passed away, leaving the British possessions in India directly
+under the control of the Crown.  The aspect of the country, as well as
+the manners and distinctions of race, is daily changing.
+
+Formerly one was obliged to travel in India by the old cumbrous methods
+of going on foot or on horseback, in palanquins or unwieldy coaches;
+now fast steamboats ply on the Indus and the Ganges, and a great
+railway, with branch lines joining the main line at many points on its
+route, traverses the peninsula from Bombay to Calcutta in three days.
+This railway does not run in a direct line across India.  The distance
+between Bombay and Calcutta, as the bird flies, is only from one
+thousand to eleven hundred miles; but the deflections of the road
+increase this distance by more than a third.
+
+The general route of the Great Indian Peninsula Railway is as follows:
+Leaving Bombay, it passes through Salcette, crossing to the continent
+opposite Tannah, goes over the chain of the Western Ghauts, runs thence
+north-east as far as Burhampoor, skirts the nearly independent
+territory of Bundelcund, ascends to Allahabad, turns thence eastwardly,
+meeting the Ganges at Benares, then departs from the river a little,
+and, descending south-eastward by Burdivan and the French town of
+Chandernagor, has its terminus at Calcutta.
+
+The passengers of the Mongolia went ashore at half-past four p.m.; at
+exactly eight the train would start for Calcutta.
+
+Mr. Fogg, after bidding good-bye to his whist partners, left the
+steamer, gave his servant several errands to do, urged it upon him to
+be at the station promptly at eight, and, with his regular step, which
+beat to the second, like an astronomical clock, directed his steps to
+the passport office.  As for the wonders of Bombay--its famous city
+hall, its splendid library, its forts and docks, its bazaars, mosques,
+synagogues, its Armenian churches, and the noble pagoda on Malabar
+Hill, with its two polygonal towers--he cared not a straw to see them.
+He would not deign to examine even the masterpieces of Elephanta, or
+the mysterious hypogea, concealed south-east from the docks, or those
+fine remains of Buddhist architecture, the Kanherian grottoes of the
+island of Salcette.
+
+Having transacted his business at the passport office, Phileas Fogg
+repaired quietly to the railway station, where he ordered dinner.
+Among the dishes served up to him, the landlord especially recommended
+a certain giblet of "native rabbit," on which he prided himself.
+
+Mr. Fogg accordingly tasted the dish, but, despite its spiced sauce,
+found it far from palatable.  He rang for the landlord, and, on his
+appearance, said, fixing his clear eyes upon him, "Is this rabbit, sir?"
+
+"Yes, my lord," the rogue boldly replied, "rabbit from the jungles."
+
+"And this rabbit did not mew when he was killed?"
+
+"Mew, my lord!  What, a rabbit mew!  I swear to you--"
+
+"Be so good, landlord, as not to swear, but remember this: cats were
+formerly considered, in India, as sacred animals.  That was a good
+time."
+
+"For the cats, my lord?"
+
+"Perhaps for the travellers as well!"
+
+After which Mr. Fogg quietly continued his dinner.  Fix had gone on
+shore shortly after Mr. Fogg, and his first destination was the
+headquarters of the Bombay police.  He made himself known as a London
+detective, told his business at Bombay, and the position of affairs
+relative to the supposed robber, and nervously asked if a warrant had
+arrived from London.  It had not reached the office; indeed, there had
+not yet been time for it to arrive.  Fix was sorely disappointed, and
+tried to obtain an order of arrest from the director of the Bombay
+police.  This the director refused, as the matter concerned the London
+office, which alone could legally deliver the warrant.  Fix did not
+insist, and was fain to resign himself to await the arrival of the
+important document; but he was determined not to lose sight of the
+mysterious rogue as long as he stayed in Bombay.  He did not doubt for
+a moment, any more than Passepartout, that Phileas Fogg would remain
+there, at least until it was time for the warrant to arrive.
+
+Passepartout, however, had no sooner heard his master's orders on
+leaving the Mongolia than he saw at once that they were to leave Bombay
+as they had done Suez and Paris, and that the journey would be extended
+at least as far as Calcutta, and perhaps beyond that place.  He began
+to ask himself if this bet that Mr. Fogg talked about was not really in
+good earnest, and whether his fate was not in truth forcing him,
+despite his love of repose, around the world in eighty days!
+
+Having purchased the usual quota of shirts and shoes, he took a
+leisurely promenade about the streets, where crowds of people of many
+nationalities--Europeans, Persians with pointed caps, Banyas with round
+turbans, Sindes with square bonnets, Parsees with black mitres, and
+long-robed Armenians--were collected.  It happened to be the day of a
+Parsee festival.  These descendants of the sect of Zoroaster--the most
+thrifty, civilised, intelligent, and austere of the East Indians, among
+whom are counted the richest native merchants of Bombay--were
+celebrating a sort of religious carnival, with processions and shows,
+in the midst of which Indian dancing-girls, clothed in rose-coloured
+gauze, looped up with gold and silver, danced airily, but with perfect
+modesty, to the sound of viols and the clanging of tambourines.  It is
+needless to say that Passepartout watched these curious ceremonies with
+staring eyes and gaping mouth, and that his countenance was that of the
+greenest booby imaginable.
+
+Unhappily for his master, as well as himself, his curiosity drew him
+unconsciously farther off than he intended to go.  At last, having seen
+the Parsee carnival wind away in the distance, he was turning his steps
+towards the station, when he happened to espy the splendid pagoda on
+Malabar Hill, and was seized with an irresistible desire to see its
+interior.  He was quite ignorant that it is forbidden to Christians to
+enter certain Indian temples, and that even the faithful must not go in
+without first leaving their shoes outside the door.  It may be said
+here that the wise policy of the British Government severely punishes a
+disregard of the practices of the native religions.
+
+Passepartout, however, thinking no harm, went in like a simple tourist,
+and was soon lost in admiration of the splendid Brahmin ornamentation
+which everywhere met his eyes, when of a sudden he found himself
+sprawling on the sacred flagging.  He looked up to behold three enraged
+priests, who forthwith fell upon him; tore off his shoes, and began to
+beat him with loud, savage exclamations.  The agile Frenchman was soon
+upon his feet again, and lost no time in knocking down two of his
+long-gowned adversaries with his fists and a vigorous application of
+his toes; then, rushing out of the pagoda as fast as his legs could
+carry him, he soon escaped the third priest by mingling with the crowd
+in the streets.
+
+At five minutes before eight, Passepartout, hatless, shoeless, and
+having in the squabble lost his package of shirts and shoes, rushed
+breathlessly into the station.
+
+Fix, who had followed Mr. Fogg to the station, and saw that he was
+really going to leave Bombay, was there, upon the platform.  He had
+resolved to follow the supposed robber to Calcutta, and farther, if
+necessary.  Passepartout did not observe the detective, who stood in an
+obscure corner; but Fix heard him relate his adventures in a few words
+to Mr. Fogg.
+
+"I hope that this will not happen again," said Phileas Fogg coldly, as
+he got into the train.  Poor Passepartout, quite crestfallen, followed
+his master without a word.  Fix was on the point of entering another
+carriage, when an idea struck him which induced him to alter his plan.
+
+"No, I'll stay," muttered he.  "An offence has been committed on Indian
+soil.  I've got my man."
+
+Just then the locomotive gave a sharp screech, and the train passed out
+into the darkness of the night.
+
+
+
+
+Chapter XI
+
+IN WHICH PHILEAS FOGG SECURES A CURIOUS MEANS OF CONVEYANCE AT A
+FABULOUS PRICE
+
+
+The train had started punctually.  Among the passengers were a number
+of officers, Government officials, and opium and indigo merchants,
+whose business called them to the eastern coast.  Passepartout rode in
+the same carriage with his master, and a third passenger occupied a
+seat opposite to them.  This was Sir Francis Cromarty, one of Mr.
+Fogg's whist partners on the Mongolia, now on his way to join his corps
+at Benares.  Sir Francis was a tall, fair man of fifty, who had greatly
+distinguished himself in the last Sepoy revolt.  He made India his
+home, only paying brief visits to England at rare intervals; and was
+almost as familiar as a native with the customs, history, and character
+of India and its people.  But Phileas Fogg, who was not travelling, but
+only describing a circumference, took no pains to inquire into these
+subjects; he was a solid body, traversing an orbit around the
+terrestrial globe, according to the laws of rational mechanics.  He was
+at this moment calculating in his mind the number of hours spent since
+his departure from London, and, had it been in his nature to make a
+useless demonstration, would have rubbed his hands for satisfaction.
+Sir Francis Cromarty had observed the oddity of his travelling
+companion--although the only opportunity he had for studying him had
+been while he was dealing the cards, and between two rubbers--and
+questioned himself whether a human heart really beat beneath this cold
+exterior, and whether Phileas Fogg had any sense of the beauties of
+nature.  The brigadier-general was free to mentally confess that, of
+all the eccentric persons he had ever met, none was comparable to this
+product of the exact sciences.
+
+Phileas Fogg had not concealed from Sir Francis his design of going
+round the world, nor the circumstances under which he set out; and the
+general only saw in the wager a useless eccentricity and a lack of
+sound common sense.  In the way this strange gentleman was going on, he
+would leave the world without having done any good to himself or
+anybody else.
+
+An hour after leaving Bombay the train had passed the viaducts and the
+Island of Salcette, and had got into the open country.  At Callyan they
+reached the junction of the branch line which descends towards
+south-eastern India by Kandallah and Pounah; and, passing Pauwell, they
+entered the defiles of the mountains, with their basalt bases, and
+their summits crowned with thick and verdant forests.  Phileas Fogg and
+Sir Francis Cromarty exchanged a few words from time to time, and now
+Sir Francis, reviving the conversation, observed, "Some years ago, Mr.
+Fogg, you would have met with a delay at this point which would
+probably have lost you your wager."
+
+"How so, Sir Francis?"
+
+"Because the railway stopped at the base of these mountains, which the
+passengers were obliged to cross in palanquins or on ponies to
+Kandallah, on the other side."
+
+"Such a delay would not have deranged my plans in the least," said Mr.
+Fogg.  "I have constantly foreseen the likelihood of certain obstacles."
+
+"But, Mr. Fogg," pursued Sir Francis, "you run the risk of having some
+difficulty about this worthy fellow's adventure at the pagoda."
+Passepartout, his feet comfortably wrapped in his travelling-blanket,
+was sound asleep and did not dream that anybody was talking about him.
+"The Government is very severe upon that kind of offence.  It takes
+particular care that the religious customs of the Indians should be
+respected, and if your servant were caught--"
+
+"Very well, Sir Francis," replied Mr. Fogg; "if he had been caught he
+would have been condemned and punished, and then would have quietly
+returned to Europe.  I don't see how this affair could have delayed his
+master."
+
+The conversation fell again.  During the night the train left the
+mountains behind, and passed Nassik, and the next day proceeded over
+the flat, well-cultivated country of the Khandeish, with its straggling
+villages, above which rose the minarets of the pagodas.  This fertile
+territory is watered by numerous small rivers and limpid streams,
+mostly tributaries of the Godavery.
+
+Passepartout, on waking and looking out, could not realise that he was
+actually crossing India in a railway train.  The locomotive, guided by
+an English engineer and fed with English coal, threw out its smoke upon
+cotton, coffee, nutmeg, clove, and pepper plantations, while the steam
+curled in spirals around groups of palm-trees, in the midst of which
+were seen picturesque bungalows, viharis (sort of abandoned
+monasteries), and marvellous temples enriched by the exhaustless
+ornamentation of Indian architecture.  Then they came upon vast tracts
+extending to the horizon, with jungles inhabited by snakes and tigers,
+which fled at the noise of the train; succeeded by forests penetrated
+by the railway, and still haunted by elephants which, with pensive
+eyes, gazed at the train as it passed.  The travellers crossed, beyond
+Milligaum, the fatal country so often stained with blood by the
+sectaries of the goddess Kali.  Not far off rose Ellora, with its
+graceful pagodas, and the famous Aurungabad, capital of the ferocious
+Aureng-Zeb, now the chief town of one of the detached provinces of the
+kingdom of the Nizam.  It was thereabouts that Feringhea, the Thuggee
+chief, king of the stranglers, held his sway.  These ruffians, united
+by a secret bond, strangled victims of every age in honour of the
+goddess Death, without ever shedding blood; there was a period when
+this part of the country could scarcely be travelled over without
+corpses being found in every direction.  The English Government has
+succeeded in greatly diminishing these murders, though the Thuggees
+still exist, and pursue the exercise of their horrible rites.
+
+At half-past twelve the train stopped at Burhampoor where Passepartout
+was able to purchase some Indian slippers, ornamented with false
+pearls, in which, with evident vanity, he proceeded to encase his feet.
+The travellers made a hasty breakfast and started off for Assurghur,
+after skirting for a little the banks of the small river Tapty, which
+empties into the Gulf of Cambray, near Surat.
+
+Passepartout was now plunged into absorbing reverie.  Up to his arrival
+at Bombay, he had entertained hopes that their journey would end there;
+but, now that they were plainly whirling across India at full speed, a
+sudden change had come over the spirit of his dreams.  His old vagabond
+nature returned to him; the fantastic ideas of his youth once more took
+possession of him.  He came to regard his master's project as intended
+in good earnest, believed in the reality of the bet, and therefore in
+the tour of the world and the necessity of making it without fail
+within the designated period.  Already he began to worry about possible
+delays, and accidents which might happen on the way.  He recognised
+himself as being personally interested in the wager, and trembled at
+the thought that he might have been the means of losing it by his
+unpardonable folly of the night before.  Being much less cool-headed
+than Mr. Fogg, he was much more restless, counting and recounting the
+days passed over, uttering maledictions when the train stopped, and
+accusing it of sluggishness, and mentally blaming Mr. Fogg for not
+having bribed the engineer.  The worthy fellow was ignorant that, while
+it was possible by such means to hasten the rate of a steamer, it could
+not be done on the railway.
+
+The train entered the defiles of the Sutpour Mountains, which separate
+the Khandeish from Bundelcund, towards evening.  The next day Sir
+Francis Cromarty asked Passepartout what time it was; to which, on
+consulting his watch, he replied that it was three in the morning.
+This famous timepiece, always regulated on the Greenwich meridian,
+which was now some seventy-seven degrees westward, was at least four
+hours slow.  Sir Francis corrected Passepartout's time, whereupon the
+latter made the same remark that he had done to Fix; and upon the
+general insisting that the watch should be regulated in each new
+meridian, since he was constantly going eastward, that is in the face
+of the sun, and therefore the days were shorter by four minutes for
+each degree gone over, Passepartout obstinately refused to alter his
+watch, which he kept at London time.  It was an innocent delusion which
+could harm no one.
+
+The train stopped, at eight o'clock, in the midst of a glade some
+fifteen miles beyond Rothal, where there were several bungalows, and
+workmen's cabins.  The conductor, passing along the carriages, shouted,
+"Passengers will get out here!"
+
+Phileas Fogg looked at Sir Francis Cromarty for an explanation; but the
+general could not tell what meant a halt in the midst of this forest of
+dates and acacias.
+
+Passepartout, not less surprised, rushed out and speedily returned,
+crying: "Monsieur, no more railway!"
+
+"What do you mean?" asked Sir Francis.
+
+"I mean to say that the train isn't going on."
+
+The general at once stepped out, while Phileas Fogg calmly followed
+him, and they proceeded together to the conductor.
+
+"Where are we?" asked Sir Francis.
+
+"At the hamlet of Kholby."
+
+"Do we stop here?"
+
+"Certainly.  The railway isn't finished."
+
+"What! not finished?"
+
+"No.  There's still a matter of fifty miles to be laid from here to
+Allahabad, where the line begins again."
+
+"But the papers announced the opening of the railway throughout."
+
+"What would you have, officer?  The papers were mistaken."
+
+"Yet you sell tickets from Bombay to Calcutta," retorted Sir Francis,
+who was growing warm.
+
+"No doubt," replied the conductor; "but the passengers know that they
+must provide means of transportation for themselves from Kholby to
+Allahabad."
+
+Sir Francis was furious.  Passepartout would willingly have knocked the
+conductor down, and did not dare to look at his master.
+
+"Sir Francis," said Mr. Fogg quietly, "we will, if you please, look
+about for some means of conveyance to Allahabad."
+
+"Mr. Fogg, this is a delay greatly to your disadvantage."
+
+"No, Sir Francis; it was foreseen."
+
+"What!  You knew that the way--"
+
+"Not at all; but I knew that some obstacle or other would sooner or
+later arise on my route.  Nothing, therefore, is lost. I have two days,
+which I have already gained, to sacrifice.  A steamer leaves Calcutta
+for Hong Kong at noon, on the 25th.  This is the 22nd, and we shall
+reach Calcutta in time."
+
+There was nothing to say to so confident a response.
+
+It was but too true that the railway came to a termination at this
+point.  The papers were like some watches, which have a way of getting
+too fast, and had been premature in their announcement of the
+completion of the line.  The greater part of the travellers were aware
+of this interruption, and, leaving the train, they began to engage such
+vehicles as the village could provide four-wheeled palkigharis, waggons
+drawn by zebus, carriages that looked like perambulating pagodas,
+palanquins, ponies, and what not.
+
+Mr. Fogg and Sir Francis Cromarty, after searching the village from end
+to end, came back without having found anything.
+
+"I shall go afoot," said Phileas Fogg.
+
+Passepartout, who had now rejoined his master, made a wry grimace, as
+he thought of his magnificent, but too frail Indian shoes.  Happily he
+too had been looking about him, and, after a moment's hesitation, said,
+"Monsieur, I think I have found a means of conveyance."
+
+"What?"
+
+"An elephant!  An elephant that belongs to an Indian who lives but a
+hundred steps from here."
+
+"Let's go and see the elephant," replied Mr. Fogg.
+
+They soon reached a small hut, near which, enclosed within some high
+palings, was the animal in question.  An Indian came out of the hut,
+and, at their request, conducted them within the enclosure.  The
+elephant, which its owner had reared, not for a beast of burden, but
+for warlike purposes, was half domesticated.  The Indian had begun
+already, by often irritating him, and feeding him every three months on
+sugar and butter, to impart to him a ferocity not in his nature, this
+method being often employed by those who train the Indian elephants for
+battle.  Happily, however, for Mr. Fogg, the animal's instruction in
+this direction had not gone far, and the elephant still preserved his
+natural gentleness.  Kiouni--this was the name of the beast--could
+doubtless travel rapidly for a long time, and, in default of any other
+means of conveyance, Mr. Fogg resolved to hire him.  But elephants are
+far from cheap in India, where they are becoming scarce, the males,
+which alone are suitable for circus shows, are much sought, especially
+as but few of them are domesticated.  When therefore Mr. Fogg proposed
+to the Indian to hire Kiouni, he refused point-blank.  Mr. Fogg
+persisted, offering the excessive sum of ten pounds an hour for the
+loan of the beast to Allahabad.  Refused.  Twenty pounds?  Refused
+also.  Forty pounds?  Still refused.  Passepartout jumped at each
+advance; but the Indian declined to be tempted.  Yet the offer was an
+alluring one, for, supposing it took the elephant fifteen hours to
+reach Allahabad, his owner would receive no less than six hundred
+pounds sterling.
+
+Phileas Fogg, without getting in the least flurried, then proposed to
+purchase the animal outright, and at first offered a thousand pounds
+for him.  The Indian, perhaps thinking he was going to make a great
+bargain, still refused.
+
+Sir Francis Cromarty took Mr. Fogg aside, and begged him to reflect
+before he went any further; to which that gentleman replied that he was
+not in the habit of acting rashly, that a bet of twenty thousand pounds
+was at stake, that the elephant was absolutely necessary to him, and
+that he would secure him if he had to pay twenty times his value.
+Returning to the Indian, whose small, sharp eyes, glistening with
+avarice, betrayed that with him it was only a question of how great a
+price he could obtain.  Mr. Fogg offered first twelve hundred, then
+fifteen hundred, eighteen hundred, two thousand pounds.  Passepartout,
+usually so rubicund, was fairly white with suspense.
+
+At two thousand pounds the Indian yielded.
+
+"What a price, good heavens!" cried Passepartout, "for an elephant."
+
+It only remained now to find a guide, which was comparatively easy.  A
+young Parsee, with an intelligent face, offered his services, which Mr.
+Fogg accepted, promising so generous a reward as to materially
+stimulate his zeal.  The elephant was led out and equipped.  The
+Parsee, who was an accomplished elephant driver, covered his back with
+a sort of saddle-cloth, and attached to each of his flanks some
+curiously uncomfortable howdahs.  Phileas Fogg paid the Indian with
+some banknotes which he extracted from the famous carpet-bag, a
+proceeding that seemed to deprive poor Passepartout of his vitals.
+Then he offered to carry Sir Francis to Allahabad, which the brigadier
+gratefully accepted, as one traveller the more would not be likely to
+fatigue the gigantic beast.  Provisions were purchased at Kholby, and,
+while Sir Francis and Mr. Fogg took the howdahs on either side,
+Passepartout got astride the saddle-cloth between them.  The Parsee
+perched himself on the elephant's neck, and at nine o'clock they set
+out from the village, the animal marching off through the dense forest
+of palms by the shortest cut.
+
+
+
+
+Chapter XII
+
+IN WHICH PHILEAS FOGG AND HIS COMPANIONS VENTURE ACROSS THE INDIAN
+FORESTS, AND WHAT ENSUED
+
+
+In order to shorten the journey, the guide passed to the left of the
+line where the railway was still in process of being built.  This line,
+owing to the capricious turnings of the Vindhia Mountains, did not
+pursue a straight course.  The Parsee, who was quite familiar with the
+roads and paths in the district, declared that they would gain twenty
+miles by striking directly through the forest.
+
+Phileas Fogg and Sir Francis Cromarty, plunged to the neck in the
+peculiar howdahs provided for them, were horribly jostled by the swift
+trotting of the elephant, spurred on as he was by the skilful Parsee;
+but they endured the discomfort with true British phlegm, talking
+little, and scarcely able to catch a glimpse of each other.  As for
+Passepartout, who was mounted on the beast's back, and received the
+direct force of each concussion as he trod along, he was very careful,
+in accordance with his master's advice, to keep his tongue from between
+his teeth, as it would otherwise have been bitten off short.  The
+worthy fellow bounced from the elephant's neck to his rump, and vaulted
+like a clown on a spring-board; yet he laughed in the midst of his
+bouncing, and from time to time took a piece of sugar out of his
+pocket, and inserted it in Kiouni's trunk, who received it without in
+the least slackening his regular trot.
+
+After two hours the guide stopped the elephant, and gave him an hour
+for rest, during which Kiouni, after quenching his thirst at a
+neighbouring spring, set to devouring the branches and shrubs round
+about him.  Neither Sir Francis nor Mr. Fogg regretted the delay, and
+both descended with a feeling of relief.  "Why, he's made of iron!"
+exclaimed the general, gazing admiringly on Kiouni.
+
+"Of forged iron," replied Passepartout, as he set about preparing a
+hasty breakfast.
+
+At noon the Parsee gave the signal of departure.  The country soon
+presented a very savage aspect.  Copses of dates and dwarf-palms
+succeeded the dense forests; then vast, dry plains, dotted with scanty
+shrubs, and sown with great blocks of syenite.  All this portion of
+Bundelcund, which is little frequented by travellers, is inhabited by a
+fanatical population, hardened in the most horrible practices of the
+Hindoo faith.  The English have not been able to secure complete
+dominion over this territory, which is subjected to the influence of
+rajahs, whom it is almost impossible to reach in their inaccessible
+mountain fastnesses. The travellers several times saw bands of
+ferocious Indians, who, when they perceived the elephant striding
+across-country, made angry and threatening motions.  The Parsee avoided
+them as much as possible.  Few animals were observed on the route; even
+the monkeys hurried from their path with contortions and grimaces which
+convulsed Passepartout with laughter.
+
+In the midst of his gaiety, however, one thought troubled the worthy
+servant.  What would Mr. Fogg do with the elephant when he got to
+Allahabad?  Would he carry him on with him?  Impossible!  The cost of
+transporting him would make him ruinously expensive.  Would he sell
+him, or set him free?  The estimable beast certainly deserved some
+consideration.  Should Mr. Fogg choose to make him, Passepartout, a
+present of Kiouni, he would be very much embarrassed; and these
+thoughts did not cease worrying him for a long time.
+
+The principal chain of the Vindhias was crossed by eight in the
+evening, and another halt was made on the northern slope, in a ruined
+bungalow.  They had gone nearly twenty-five miles that day, and an
+equal distance still separated them from the station of Allahabad.
+
+The night was cold.  The Parsee lit a fire in the bungalow with a few
+dry branches, and the warmth was very grateful, provisions purchased at
+Kholby sufficed for supper, and the travellers ate ravenously.  The
+conversation, beginning with a few disconnected phrases, soon gave
+place to loud and steady snores.  The guide watched Kiouni, who slept
+standing, bolstering himself against the trunk of a large tree.
+Nothing occurred during the night to disturb the slumberers, although
+occasional growls from panthers and chatterings of monkeys broke the
+silence; the more formidable beasts made no cries or hostile
+demonstration against the occupants of the bungalow.  Sir Francis slept
+heavily, like an honest soldier overcome with fatigue.  Passepartout
+was wrapped in uneasy dreams of the bouncing of the day before.  As for
+Mr. Fogg, he slumbered as peacefully as if he had been in his serene
+mansion in Saville Row.
+
+The journey was resumed at six in the morning; the guide hoped to reach
+Allahabad by evening.  In that case, Mr. Fogg would only lose a part of
+the forty-eight hours saved since the beginning of the tour.  Kiouni,
+resuming his rapid gait, soon descended the lower spurs of the
+Vindhias, and towards noon they passed by the village of Kallenger, on
+the Cani, one of the branches of the Ganges.  The guide avoided
+inhabited places, thinking it safer to keep the open country, which
+lies along the first depressions of the basin of the great river.
+Allahabad was now only twelve miles to the north-east.  They stopped
+under a clump of bananas, the fruit of which, as healthy as bread and
+as succulent as cream, was amply partaken of and appreciated.
+
+At two o'clock the guide entered a thick forest which extended several
+miles; he preferred to travel under cover of the woods.  They had not
+as yet had any unpleasant encounters, and the journey seemed on the
+point of being successfully accomplished, when the elephant, becoming
+restless, suddenly stopped.
+
+It was then four o'clock.
+
+"What's the matter?" asked Sir Francis, putting out his head.
+
+"I don't know, officer," replied the Parsee, listening attentively to a
+confused murmur which came through the thick branches.
+
+The murmur soon became more distinct; it now seemed like a distant
+concert of human voices accompanied by brass instruments.  Passepartout
+was all eyes and ears.  Mr. Fogg patiently waited without a word.  The
+Parsee jumped to the ground, fastened the elephant to a tree, and
+plunged into the thicket.  He soon returned, saying:
+
+"A procession of Brahmins is coming this way.  We must prevent their
+seeing us, if possible."
+
+The guide unloosed the elephant and led him into a thicket, at the same
+time asking the travellers not to stir.  He held himself ready to
+bestride the animal at a moment's notice, should flight become
+necessary; but he evidently thought that the procession of the faithful
+would pass without perceiving them amid the thick foliage, in which
+they were wholly concealed.
+
+The discordant tones of the voices and instruments drew nearer, and now
+droning songs mingled with the sound of the tambourines and cymbals.
+The head of the procession soon appeared beneath the trees, a hundred
+paces away; and the strange figures who performed the religious
+ceremony were easily distinguished through the branches.  First came
+the priests, with mitres on their heads, and clothed in long lace
+robes.  They were surrounded by men, women, and children, who sang a
+kind of lugubrious psalm, interrupted at regular intervals by the
+tambourines and cymbals; while behind them was drawn a car with large
+wheels, the spokes of which represented serpents entwined with each
+other.  Upon the car, which was drawn by four richly caparisoned zebus,
+stood a hideous statue with four arms, the body coloured a dull red,
+with haggard eyes, dishevelled hair, protruding tongue, and lips tinted
+with betel.  It stood upright upon the figure of a prostrate and
+headless giant.
+
+Sir Francis, recognising the statue, whispered, "The goddess Kali; the
+goddess of love and death."
+
+"Of death, perhaps," muttered back Passepartout, "but of love--that
+ugly old hag?  Never!"
+
+The Parsee made a motion to keep silence.
+
+A group of old fakirs were capering and making a wild ado round the
+statue; these were striped with ochre, and covered with cuts whence
+their blood issued drop by drop--stupid fanatics, who, in the great
+Indian ceremonies, still throw themselves under the wheels of
+Juggernaut.  Some Brahmins, clad in all the sumptuousness of Oriental
+apparel, and leading a woman who faltered at every step, followed.
+This woman was young, and as fair as a European.  Her head and neck,
+shoulders, ears, arms, hands, and toes were loaded down with jewels and
+gems with bracelets, earrings, and rings; while a tunic bordered with
+gold, and covered with a light muslin robe, betrayed the outline of her
+form.
+
+The guards who followed the young woman presented a violent contrast to
+her, armed as they were with naked sabres hung at their waists, and
+long damascened pistols, and bearing a corpse on a palanquin.  It was
+the body of an old man, gorgeously arrayed in the habiliments of a
+rajah, wearing, as in life, a turban embroidered with pearls, a robe of
+tissue of silk and gold, a scarf of cashmere sewed with diamonds, and
+the magnificent weapons of a Hindoo prince.  Next came the musicians
+and a rearguard of capering fakirs, whose cries sometimes drowned the
+noise of the instruments; these closed the procession.
+
+Sir Francis watched the procession with a sad countenance, and, turning
+to the guide, said, "A suttee."
+
+The Parsee nodded, and put his finger to his lips.  The procession
+slowly wound under the trees, and soon its last ranks disappeared in
+the depths of the wood.  The songs gradually died away; occasionally
+cries were heard in the distance, until at last all was silence again.
+
+Phileas Fogg had heard what Sir Francis said, and, as soon as the
+procession had disappeared, asked: "What is a suttee?"
+
+"A suttee," returned the general, "is a human sacrifice, but a
+voluntary one.  The woman you have just seen will be burned to-morrow
+at the dawn of day."
+
+"Oh, the scoundrels!" cried Passepartout, who could not repress his
+indignation.
+
+"And the corpse?" asked Mr. Fogg.
+
+"Is that of the prince, her husband," said the guide; "an independent
+rajah of Bundelcund."
+
+"Is it possible," resumed Phileas Fogg, his voice betraying not the
+least emotion, "that these barbarous customs still exist in India, and
+that the English have been unable to put a stop to them?"
+
+"These sacrifices do not occur in the larger portion of India," replied
+Sir Francis; "but we have no power over these savage territories, and
+especially here in Bundelcund.  The whole district north of the
+Vindhias is the theatre of incessant murders and pillage."
+
+"The poor wretch!" exclaimed Passepartout, "to be burned alive!"
+
+"Yes," returned Sir Francis, "burned alive.  And, if she were not, you
+cannot conceive what treatment she would be obliged to submit to from
+her relatives.  They would shave off her hair, feed her on a scanty
+allowance of rice, treat her with contempt; she would be looked upon as
+an unclean creature, and would die in some corner, like a scurvy dog.
+The prospect of so frightful an existence drives these poor creatures
+to the sacrifice much more than love or religious fanaticism.
+Sometimes, however, the sacrifice is really voluntary, and it requires
+the active interference of the Government to prevent it.  Several years
+ago, when I was living at Bombay, a young widow asked permission of the
+governor to be burned along with her husband's body; but, as you may
+imagine, he refused.  The woman left the town, took refuge with an
+independent rajah, and there carried out her self-devoted purpose."
+
+While Sir Francis was speaking, the guide shook his head several times,
+and now said: "The sacrifice which will take place to-morrow at dawn is
+not a voluntary one."
+
+"How do you know?"
+
+"Everybody knows about this affair in Bundelcund."
+
+"But the wretched creature did not seem to be making any resistance,"
+observed Sir Francis.
+
+"That was because they had intoxicated her with fumes of hemp and
+opium."
+
+"But where are they taking her?"
+
+"To the pagoda of Pillaji, two miles from here; she will pass the night
+there."
+
+"And the sacrifice will take place--"
+
+"To-morrow, at the first light of dawn."
+
+The guide now led the elephant out of the thicket, and leaped upon his
+neck.  Just at the moment that he was about to urge Kiouni forward with
+a peculiar whistle, Mr. Fogg stopped him, and, turning to Sir Francis
+Cromarty, said, "Suppose we save this woman."
+
+"Save the woman, Mr. Fogg!"
+
+"I have yet twelve hours to spare; I can devote them to that."
+
+"Why, you are a man of heart!"
+
+"Sometimes," replied Phileas Fogg, quietly; "when I have the time."
+
+
+
+
+Chapter XIII
+
+IN WHICH PASSEPARTOUT RECEIVES A NEW PROOF THAT FORTUNE FAVORS THE BRAVE
+
+
+The project was a bold one, full of difficulty, perhaps impracticable.
+Mr. Fogg was going to risk life, or at least liberty, and therefore the
+success of his tour.  But he did not hesitate, and he found in Sir
+Francis Cromarty an enthusiastic ally.
+
+As for Passepartout, he was ready for anything that might be proposed.
+His master's idea charmed him; he perceived a heart, a soul, under that
+icy exterior.  He began to love Phileas Fogg.
+
+There remained the guide: what course would he adopt?  Would he not
+take part with the Indians?  In default of his assistance, it was
+necessary to be assured of his neutrality.
+
+Sir Francis frankly put the question to him.
+
+"Officers," replied the guide, "I am a Parsee, and this woman is a
+Parsee.  Command me as you will."
+
+"Excellent!" said Mr. Fogg.
+
+"However," resumed the guide, "it is certain, not only that we shall
+risk our lives, but horrible tortures, if we are taken."
+
+"That is foreseen," replied Mr. Fogg.  "I think we must wait till night
+before acting."
+
+"I think so," said the guide.
+
+The worthy Indian then gave some account of the victim, who, he said,
+was a celebrated beauty of the Parsee race, and the daughter of a
+wealthy Bombay merchant.  She had received a thoroughly English
+education in that city, and, from her manners and intelligence, would
+be thought an European.  Her name was Aouda.  Left an orphan, she was
+married against her will to the old rajah of Bundelcund; and, knowing
+the fate that awaited her, she escaped, was retaken, and devoted by the
+rajah's relatives, who had an interest in her death, to the sacrifice
+from which it seemed she could not escape.
+
+The Parsee's narrative only confirmed Mr. Fogg and his companions in
+their generous design.  It was decided that the guide should direct the
+elephant towards the pagoda of Pillaji, which he accordingly approached
+as quickly as possible.  They halted, half an hour afterwards, in a
+copse, some five hundred feet from the pagoda, where they were well
+concealed; but they could hear the groans and cries of the fakirs
+distinctly.
+
+They then discussed the means of getting at the victim.  The guide was
+familiar with the pagoda of Pillaji, in which, as he declared, the
+young woman was imprisoned.  Could they enter any of its doors while
+the whole party of Indians was plunged in a drunken sleep, or was it
+safer to attempt to make a hole in the walls?  This could only be
+determined at the moment and the place themselves; but it was certain
+that the abduction must be made that night, and not when, at break of
+day, the victim was led to her funeral pyre.  Then no human
+intervention could save her.
+
+As soon as night fell, about six o'clock, they decided to make a
+reconnaissance around the pagoda.  The cries of the fakirs were just
+ceasing; the Indians were in the act of plunging themselves into the
+drunkenness caused by liquid opium mingled with hemp, and it might be
+possible to slip between them to the temple itself.
+
+The Parsee, leading the others, noiselessly crept through the wood, and
+in ten minutes they found themselves on the banks of a small stream,
+whence, by the light of the rosin torches, they perceived a pyre of
+wood, on the top of which lay the embalmed body of the rajah, which was
+to be burned with his wife.  The pagoda, whose minarets loomed above
+the trees in the deepening dusk, stood a hundred steps away.
+
+"Come!" whispered the guide.
+
+He slipped more cautiously than ever through the brush, followed by his
+companions; the silence around was only broken by the low murmuring of
+the wind among the branches.
+
+Soon the Parsee stopped on the borders of the glade, which was lit up
+by the torches.  The ground was covered by groups of the Indians,
+motionless in their drunken sleep; it seemed a battlefield strewn with
+the dead.  Men, women, and children lay together.
+
+In the background, among the trees, the pagoda of Pillaji loomed
+distinctly.  Much to the guide's disappointment, the guards of the
+rajah, lighted by torches, were watching at the doors and marching to
+and fro with naked sabres; probably the priests, too, were watching
+within.
+
+The Parsee, now convinced that it was impossible to force an entrance
+to the temple, advanced no farther, but led his companions back again.
+Phileas Fogg and Sir Francis Cromarty also saw that nothing could be
+attempted in that direction.  They stopped, and engaged in a whispered
+colloquy.
+
+"It is only eight now," said the brigadier, "and these guards may also
+go to sleep."
+
+"It is not impossible," returned the Parsee.
+
+They lay down at the foot of a tree, and waited.
+
+The time seemed long; the guide ever and anon left them to take an
+observation on the edge of the wood, but the guards watched steadily by
+the glare of the torches, and a dim light crept through the windows of
+the pagoda.
+
+They waited till midnight; but no change took place among the guards,
+and it became apparent that their yielding to sleep could not be
+counted on.  The other plan must be carried out; an opening in the
+walls of the pagoda must be made.  It remained to ascertain whether the
+priests were watching by the side of their victim as assiduously as
+were the soldiers at the door.
+
+After a last consultation, the guide announced that he was ready for
+the attempt, and advanced, followed by the others.  They took a
+roundabout way, so as to get at the pagoda on the rear.  They reached
+the walls about half-past twelve, without having met anyone; here there
+was no guard, nor were there either windows or doors.
+
+The night was dark.  The moon, on the wane, scarcely left the horizon,
+and was covered with heavy clouds; the height of the trees deepened the
+darkness.
+
+It was not enough to reach the walls; an opening in them must be
+accomplished, and to attain this purpose the party only had their
+pocket-knives.  Happily the temple walls were built of brick and wood,
+which could be penetrated with little difficulty; after one brick had
+been taken out, the rest would yield easily.
+
+They set noiselessly to work, and the Parsee on one side and
+Passepartout on the other began to loosen the bricks so as to make an
+aperture two feet wide.  They were getting on rapidly, when suddenly a
+cry was heard in the interior of the temple, followed almost instantly
+by other cries replying from the outside.  Passepartout and the guide
+stopped.  Had they been heard?  Was the alarm being given?  Common
+prudence urged them to retire, and they did so, followed by Phileas
+Fogg and Sir Francis.  They again hid themselves in the wood, and
+waited till the disturbance, whatever it might be, ceased, holding
+themselves ready to resume their attempt without delay.  But, awkwardly
+enough, the guards now appeared at the rear of the temple, and there
+installed themselves, in readiness to prevent a surprise.
+
+It would be difficult to describe the disappointment of the party, thus
+interrupted in their work.  They could not now reach the victim; how,
+then, could they save her?  Sir Francis shook his fists, Passepartout
+was beside himself, and the guide gnashed his teeth with rage.  The
+tranquil Fogg waited, without betraying any emotion.
+
+"We have nothing to do but to go away," whispered Sir Francis.
+
+"Nothing but to go away," echoed the guide.
+
+"Stop," said Fogg.  "I am only due at Allahabad tomorrow before noon."
+
+"But what can you hope to do?" asked Sir Francis.  "In a few hours it
+will be daylight, and--"
+
+"The chance which now seems lost may present itself at the last moment."
+
+Sir Francis would have liked to read Phileas Fogg's eyes.  What was
+this cool Englishman thinking of?  Was he planning to make a rush for
+the young woman at the very moment of the sacrifice, and boldly snatch
+her from her executioners?
+
+This would be utter folly, and it was hard to admit that Fogg was such
+a fool.  Sir Francis consented, however, to remain to the end of this
+terrible drama.  The guide led them to the rear of the glade, where
+they were able to observe the sleeping groups.
+
+Meanwhile Passepartout, who had perched himself on the lower branches
+of a tree, was resolving an idea which had at first struck him like a
+flash, and which was now firmly lodged in his brain.
+
+He had commenced by saying to himself, "What folly!" and then he
+repeated, "Why not, after all?  It's a chance,--perhaps the only one; and
+with such sots!" Thinking thus, he slipped, with the suppleness of a
+serpent, to the lowest branches, the ends of which bent almost to the
+ground.
+
+The hours passed, and the lighter shades now announced the approach of
+day, though it was not yet light.  This was the moment.  The slumbering
+multitude became animated, the tambourines sounded, songs and cries
+arose; the hour of the sacrifice had come.  The doors of the pagoda
+swung open, and a bright light escaped from its interior, in the midst
+of which Mr. Fogg and Sir Francis espied the victim.  She seemed,
+having shaken off the stupor of intoxication, to be striving to escape
+from her executioner.  Sir Francis's heart throbbed; and, convulsively
+seizing Mr. Fogg's hand, found in it an open knife.  Just at this
+moment the crowd began to move.  The young woman had again fallen into
+a stupor caused by the fumes of hemp, and passed among the fakirs, who
+escorted her with their wild, religious cries.
+
+Phileas Fogg and his companions, mingling in the rear ranks of the
+crowd, followed; and in two minutes they reached the banks of the
+stream, and stopped fifty paces from the pyre, upon which still lay the
+rajah's corpse.  In the semi-obscurity they saw the victim, quite
+senseless, stretched out beside her husband's body. Then a torch was
+brought, and the wood, heavily soaked with oil, instantly took fire.
+
+At this moment Sir Francis and the guide seized Phileas Fogg, who, in
+an instant of mad generosity, was about to rush upon the pyre.  But he
+had quickly pushed them aside, when the whole scene suddenly changed.
+A cry of terror arose.  The whole multitude prostrated themselves,
+terror-stricken, on the ground.
+
+The old rajah was not dead, then, since he rose of a sudden, like a
+spectre, took up his wife in his arms, and descended from the pyre in
+the midst of the clouds of smoke, which only heightened his ghostly
+appearance.
+
+Fakirs and soldiers and priests, seized with instant terror, lay there,
+with their faces on the ground, not daring to lift their eyes and
+behold such a prodigy.
+
+The inanimate victim was borne along by the vigorous arms which
+supported her, and which she did not seem in the least to burden.  Mr.
+Fogg and Sir Francis stood erect, the Parsee bowed his head, and
+Passepartout was, no doubt, scarcely less stupefied.
+
+The resuscitated rajah approached Sir Francis and Mr. Fogg, and, in an
+abrupt tone, said, "Let us be off!"
+
+It was Passepartout himself, who had slipped upon the pyre in the midst
+of the smoke and, profiting by the still overhanging darkness, had
+delivered the young woman from death!  It was Passepartout who, playing
+his part with a happy audacity, had passed through the crowd amid the
+general terror.
+
+A moment after all four of the party had disappeared in the woods, and
+the elephant was bearing them away at a rapid pace. But the cries and
+noise, and a ball which whizzed through Phileas Fogg's hat, apprised
+them that the trick had been discovered.
+
+The old rajah's body, indeed, now appeared upon the burning pyre; and
+the priests, recovered from their terror, perceived that an abduction
+had taken place.  They hastened into the forest, followed by the
+soldiers, who fired a volley after the fugitives; but the latter
+rapidly increased the distance between them, and ere long found
+themselves beyond the reach of the bullets and arrows.
+
+
+
+
+Chapter XIV
+
+IN WHICH PHILEAS FOGG DESCENDS THE WHOLE LENGTH OF THE BEAUTIFUL VALLEY
+OF THE GANGES WITHOUT EVER THINKING OF SEEING IT
+
+
+The rash exploit had been accomplished; and for an hour Passepartout
+laughed gaily at his success.  Sir Francis pressed the worthy fellow's
+hand, and his master said, "Well done!" which, from him, was high
+commendation; to which Passepartout replied that all the credit of the
+affair belonged to Mr. Fogg.  As for him, he had only been struck with
+a "queer" idea; and he laughed to think that for a few moments he,
+Passepartout, the ex-gymnast, ex-sergeant fireman, had been the spouse
+of a charming woman, a venerable, embalmed rajah!  As for the young
+Indian woman, she had been unconscious throughout of what was passing,
+and now, wrapped up in a travelling-blanket, was reposing in one of the
+howdahs.
+
+The elephant, thanks to the skilful guidance of the Parsee, was
+advancing rapidly through the still darksome forest, and, an hour after
+leaving the pagoda, had crossed a vast plain.  They made a halt at
+seven o'clock, the young woman being still in a state of complete
+prostration.  The guide made her drink a little brandy and water, but
+the drowsiness which stupefied her could not yet be shaken off.  Sir
+Francis, who was familiar with the effects of the intoxication produced
+by the fumes of hemp, reassured his companions on her account.  But he
+was more disturbed at the prospect of her future fate.  He told Phileas
+Fogg that, should Aouda remain in India, she would inevitably fall
+again into the hands of her executioners.  These fanatics were
+scattered throughout the county, and would, despite the English police,
+recover their victim at Madras, Bombay, or Calcutta.  She would only be
+safe by quitting India for ever.
+
+Phileas Fogg replied that he would reflect upon the matter.
+
+The station at Allahabad was reached about ten o'clock, and, the
+interrupted line of railway being resumed, would enable them to reach
+Calcutta in less than twenty-four hours.  Phileas Fogg would thus be
+able to arrive in time to take the steamer which left Calcutta the next
+day, October 25th, at noon, for Hong Kong.
+
+The young woman was placed in one of the waiting-rooms of the station,
+whilst Passepartout was charged with purchasing for her various
+articles of toilet, a dress, shawl, and some furs; for which his master
+gave him unlimited credit.  Passepartout started off forthwith, and
+found himself in the streets of Allahabad, that is, the City of God,
+one of the most venerated in India, being built at the junction of the
+two sacred rivers, Ganges and Jumna, the waters of which attract
+pilgrims from every part of the peninsula.  The Ganges, according to
+the legends of the Ramayana, rises in heaven, whence, owing to Brahma's
+agency, it descends to the earth.
+
+Passepartout made it a point, as he made his purchases, to take a good
+look at the city.  It was formerly defended by a noble fort, which has
+since become a state prison; its commerce has dwindled away, and
+Passepartout in vain looked about him for such a bazaar as he used to
+frequent in Regent Street.  At last he came upon an elderly, crusty
+Jew, who sold second-hand articles, and from whom he purchased a dress
+of Scotch stuff, a large mantle, and a fine otter-skin pelisse, for
+which he did not hesitate to pay seventy-five pounds.  He then returned
+triumphantly to the station.
+
+The influence to which the priests of Pillaji had subjected Aouda began
+gradually to yield, and she became more herself, so that her fine eyes
+resumed all their soft Indian expression.
+
+When the poet-king, Ucaf Uddaul, celebrates the charms of the queen of
+Ahmehnagara, he speaks thus:
+
+"Her shining tresses, divided in two parts, encircle the harmonious
+contour of her white and delicate cheeks, brilliant in their glow and
+freshness.  Her ebony brows have the form and charm of the bow of Kama,
+the god of love, and beneath her long silken lashes the purest
+reflections and a celestial light swim, as in the sacred lakes of
+Himalaya, in the black pupils of her great clear eyes.  Her teeth,
+fine, equal, and white, glitter between her smiling lips like dewdrops
+in a passion-flower's half-enveloped breast.  Her delicately formed
+ears, her vermilion hands, her little feet, curved and tender as the
+lotus-bud, glitter with the brilliancy of the loveliest pearls of
+Ceylon, the most dazzling diamonds of Golconda.  Her narrow and supple
+waist, which a hand may clasp around, sets forth the outline of her
+rounded figure and the beauty of her bosom, where youth in its flower
+displays the wealth of its treasures; and beneath the silken folds of
+her tunic she seems to have been modelled in pure silver by the godlike
+hand of Vicvarcarma, the immortal sculptor."
+
+It is enough to say, without applying this poetical rhapsody to Aouda,
+that she was a charming woman, in all the European acceptation of the
+phrase.  She spoke English with great purity, and the guide had not
+exaggerated in saying that the young Parsee had been transformed by her
+bringing up.
+
+The train was about to start from Allahabad, and Mr. Fogg proceeded to
+pay the guide the price agreed upon for his service, and not a farthing
+more; which astonished Passepartout, who remembered all that his master
+owed to the guide's devotion.  He had, indeed, risked his life in the
+adventure at Pillaji, and, if he should be caught afterwards by the
+Indians, he would with difficulty escape their vengeance.  Kiouni,
+also, must be disposed of.  What should be done with the elephant,
+which had been so dearly purchased?  Phileas Fogg had already
+determined this question.
+
+"Parsee," said he to the guide, "you have been serviceable and devoted.
+I have paid for your service, but not for your devotion.  Would you
+like to have this elephant?  He is yours."
+
+The guide's eyes glistened.
+
+"Your honour is giving me a fortune!" cried he.
+
+"Take him, guide," returned Mr. Fogg, "and I shall still be your
+debtor."
+
+"Good!" exclaimed Passepartout.  "Take him, friend.  Kiouni is a brave
+and faithful beast."  And, going up to the elephant, he gave him
+several lumps of sugar, saying, "Here, Kiouni, here, here."
+
+The elephant grunted out his satisfaction, and, clasping Passepartout
+around the waist with his trunk, lifted him as high as his head.
+Passepartout, not in the least alarmed, caressed the animal, which
+replaced him gently on the ground.
+
+Soon after, Phileas Fogg, Sir Francis Cromarty, and Passepartout,
+installed in a carriage with Aouda, who had the best seat, were
+whirling at full speed towards Benares.  It was a run of eighty miles,
+and was accomplished in two hours.  During the journey, the young woman
+fully recovered her senses.  What was her astonishment to find herself
+in this carriage, on the railway, dressed in European habiliments, and
+with travellers who were quite strangers to her!  Her companions first
+set about fully reviving her with a little liquor, and then Sir Francis
+narrated to her what had passed, dwelling upon the courage with which
+Phileas Fogg had not hesitated to risk his life to save her, and
+recounting the happy sequel of the venture, the result of
+Passepartout's rash idea.  Mr. Fogg said nothing; while Passepartout,
+abashed, kept repeating that "it wasn't worth telling."
+
+Aouda pathetically thanked her deliverers, rather with tears than
+words; her fine eyes interpreted her gratitude better than her lips.
+Then, as her thoughts strayed back to the scene of the sacrifice, and
+recalled the dangers which still menaced her, she shuddered with terror.
+
+Phileas Fogg understood what was passing in Aouda's mind, and offered,
+in order to reassure her, to escort her to Hong Kong, where she might
+remain safely until the affair was hushed up--an offer which she
+eagerly and gratefully accepted.  She had, it seems, a Parsee relation,
+who was one of the principal merchants of Hong Kong, which is wholly an
+English city, though on an island on the Chinese coast.
+
+At half-past twelve the train stopped at Benares.  The Brahmin legends
+assert that this city is built on the site of the ancient Casi, which,
+like Mahomet's tomb, was once suspended between heaven and earth;
+though the Benares of to-day, which the Orientalists call the Athens of
+India, stands quite unpoetically on the solid earth, Passepartout
+caught glimpses of its brick houses and clay huts, giving an aspect of
+desolation to the place, as the train entered it.
+
+Benares was Sir Francis Cromarty's destination, the troops he was
+rejoining being encamped some miles northward of the city.  He bade
+adieu to Phileas Fogg, wishing him all success, and expressing the hope
+that he would come that way again in a less original but more
+profitable fashion.  Mr. Fogg lightly pressed him by the hand.  The
+parting of Aouda, who did not forget what she owed to Sir Francis,
+betrayed more warmth; and, as for Passepartout, he received a hearty
+shake of the hand from the gallant general.
+
+The railway, on leaving Benares, passed for a while along the valley of
+the Ganges.  Through the windows of their carriage the travellers had
+glimpses of the diversified landscape of Behar, with its mountains
+clothed in verdure, its fields of barley, wheat, and corn, its jungles
+peopled with green alligators, its neat villages, and its still
+thickly-leaved forests.  Elephants were bathing in the waters of the
+sacred river, and groups of Indians, despite the advanced season and
+chilly air, were performing solemnly their pious ablutions.  These were
+fervent Brahmins, the bitterest foes of Buddhism, their deities being
+Vishnu, the solar god, Shiva, the divine impersonation of natural
+forces, and Brahma, the supreme ruler of priests and legislators.  What
+would these divinities think of India, anglicised as it is to-day, with
+steamers whistling and scudding along the Ganges, frightening the gulls
+which float upon its surface, the turtles swarming along its banks, and
+the faithful dwelling upon its borders?
+
+The panorama passed before their eyes like a flash, save when the steam
+concealed it fitfully from the view; the travellers could scarcely
+discern the fort of Chupenie, twenty miles south-westward from Benares,
+the ancient stronghold of the rajahs of Behar; or Ghazipur and its
+famous rose-water factories; or the tomb of Lord Cornwallis, rising on
+the left bank of the Ganges; the fortified town of Buxar, or Patna, a
+large manufacturing and trading-place, where is held the principal
+opium market of India; or Monghir, a more than European town, for it is
+as English as Manchester or Birmingham, with its iron foundries,
+edgetool factories, and high chimneys puffing clouds of black smoke
+heavenward.
+
+Night came on; the train passed on at full speed, in the midst of the
+roaring of the tigers, bears, and wolves which fled before the
+locomotive; and the marvels of Bengal, Golconda ruined Gour,
+Murshedabad, the ancient capital, Burdwan, Hugly, and the French town
+of Chandernagor, where Passepartout would have been proud to see his
+country's flag flying, were hidden from their view in the darkness.
+
+Calcutta was reached at seven in the morning, and the packet left for
+Hong Kong at noon; so that Phileas Fogg had five hours before him.
+
+According to his journal, he was due at Calcutta on the 25th of
+October, and that was the exact date of his actual arrival.  He was
+therefore neither behind-hand nor ahead of time.  The two days gained
+between London and Bombay had been lost, as has been seen, in the
+journey across India.  But it is not to be supposed that Phileas Fogg
+regretted them.
+
+
+
+
+Chapter XV
+
+IN WHICH THE BAG OF BANKNOTES DISGORGES SOME THOUSANDS OF POUNDS MORE
+
+
+The train entered the station, and Passepartout jumping out first, was
+followed by Mr. Fogg, who assisted his fair companion to descend.
+Phileas Fogg intended to proceed at once to the Hong Kong steamer, in
+order to get Aouda comfortably settled for the voyage.  He was
+unwilling to leave her while they were still on dangerous ground.
+
+Just as he was leaving the station a policeman came up to him, and
+said, "Mr. Phileas Fogg?"
+
+"I am he."
+
+"Is this man your servant?" added the policeman, pointing to
+Passepartout.
+
+"Yes."
+
+"Be so good, both of you, as to follow me."
+
+Mr. Fogg betrayed no surprise whatever.  The policeman was a
+representative of the law, and law is sacred to an Englishman.
+Passepartout tried to reason about the matter, but the policeman tapped
+him with his stick, and Mr. Fogg made him a signal to obey.
+
+"May this young lady go with us?" asked he.
+
+"She may," replied the policeman.
+
+Mr. Fogg, Aouda, and Passepartout were conducted to a palkigahri, a
+sort of four-wheeled carriage, drawn by two horses, in which they took
+their places and were driven away.  No one spoke during the twenty
+minutes which elapsed before they reached their destination.  They
+first passed through the "black town," with its narrow streets, its
+miserable, dirty huts, and squalid population; then through the
+"European town," which presented a relief in its bright brick mansions,
+shaded by coconut-trees and bristling with masts, where, although it
+was early morning, elegantly dressed horsemen and handsome equipages
+were passing back and forth.
+
+The carriage stopped before a modest-looking house, which, however, did
+not have the appearance of a private mansion.  The policeman having
+requested his prisoners--for so, truly, they might be called--to descend,
+conducted them into a room with barred windows, and said:  "You will
+appear before Judge Obadiah at half-past eight."
+
+He then retired, and closed the door.
+
+"Why, we are prisoners!" exclaimed Passepartout, falling into a chair.
+
+Aouda, with an emotion she tried to conceal, said to Mr. Fogg: "Sir,
+you must leave me to my fate!  It is on my account that you receive
+this treatment, it is for having saved me!"
+
+Phileas Fogg contented himself with saying that it was impossible.  It
+was quite unlikely that he should be arrested for preventing a suttee.
+The complainants would not dare present themselves with such a charge.
+There was some mistake.  Moreover, he would not, in any event, abandon
+Aouda, but would escort her to Hong Kong.
+
+"But the steamer leaves at noon!" observed Passepartout, nervously.
+
+"We shall be on board by noon," replied his master, placidly.
+
+It was said so positively that Passepartout could not help muttering to
+himself, "Parbleu that's certain!  Before noon we shall be on board."
+But he was by no means reassured.
+
+At half-past eight the door opened, the policeman appeared, and,
+requesting them to follow him, led the way to an adjoining hall.  It
+was evidently a court-room, and a crowd of Europeans and natives
+already occupied the rear of the apartment.
+
+Mr. Fogg and his two companions took their places on a bench opposite
+the desks of the magistrate and his clerk.  Immediately after, Judge
+Obadiah, a fat, round man, followed by the clerk, entered.  He
+proceeded to take down a wig which was hanging on a nail, and put it
+hurriedly on his head.
+
+"The first case," said he.  Then, putting his hand to his head, he
+exclaimed, "Heh!  This is not my wig!"
+
+"No, your worship," returned the clerk, "it is mine."
+
+"My dear Mr. Oysterpuff, how can a judge give a wise sentence in a
+clerk's wig?"
+
+The wigs were exchanged.
+
+Passepartout was getting nervous, for the hands on the face of the big
+clock over the judge seemed to go around with terrible rapidity.
+
+"The first case," repeated Judge Obadiah.
+
+"Phileas Fogg?" demanded Oysterpuff.
+
+"I am here," replied Mr. Fogg.
+
+"Passepartout?"
+
+"Present," responded Passepartout.
+
+"Good," said the judge.  "You have been looked for, prisoners, for two
+days on the trains from Bombay."
+
+"But of what are we accused?" asked Passepartout, impatiently.
+
+"You are about to be informed."
+
+"I am an English subject, sir," said Mr. Fogg, "and I have the right--"
+
+"Have you been ill-treated?"
+
+"Not at all."
+
+"Very well; let the complainants come in."
+
+A door was swung open by order of the judge, and three Indian priests
+entered.
+
+"That's it," muttered Passepartout; "these are the rogues who were
+going to burn our young lady."
+
+The priests took their places in front of the judge, and the clerk
+proceeded to read in a loud voice a complaint of sacrilege against
+Phileas Fogg and his servant, who were accused of having violated a
+place held consecrated by the Brahmin religion.
+
+"You hear the charge?" asked the judge.
+
+"Yes, sir," replied Mr. Fogg, consulting his watch, "and I admit it."
+
+"You admit it?"
+
+"I admit it, and I wish to hear these priests admit, in their turn,
+what they were going to do at the pagoda of Pillaji."
+
+The priests looked at each other; they did not seem to understand what
+was said.
+
+"Yes," cried Passepartout, warmly; "at the pagoda of Pillaji, where
+they were on the point of burning their victim."
+
+The judge stared with astonishment, and the priests were stupefied.
+
+"What victim?" said Judge Obadiah.  "Burn whom?  In Bombay itself?"
+
+"Bombay?" cried Passepartout.
+
+"Certainly.  We are not talking of the pagoda of Pillaji, but of the
+pagoda of Malabar Hill, at Bombay."
+
+"And as a proof," added the clerk, "here are the desecrator's very
+shoes, which he left behind him."
+
+Whereupon he placed a pair of shoes on his desk.
+
+"My shoes!" cried Passepartout, in his surprise permitting this
+imprudent exclamation to escape him.
+
+The confusion of master and man, who had quite forgotten the affair at
+Bombay, for which they were now detained at Calcutta, may be imagined.
+
+Fix the detective, had foreseen the advantage which Passepartout's
+escapade gave him, and, delaying his departure for twelve hours, had
+consulted the priests of Malabar Hill.  Knowing that the English
+authorities dealt very severely with this kind of misdemeanour, he
+promised them a goodly sum in damages, and sent them forward to
+Calcutta by the next train.  Owing to the delay caused by the rescue of
+the young widow, Fix and the priests reached the Indian capital before
+Mr. Fogg and his servant, the magistrates having been already warned by
+a dispatch to arrest them should they arrive.  Fix's disappointment
+when he learned that Phileas Fogg had not made his appearance in
+Calcutta may be imagined.  He made up his mind that the robber had
+stopped somewhere on the route and taken refuge in the southern
+provinces.  For twenty-four hours Fix watched the station with feverish
+anxiety; at last he was rewarded by seeing Mr. Fogg and Passepartout
+arrive, accompanied by a young woman, whose presence he was wholly at a
+loss to explain.  He hastened for a policeman; and this was how the
+party came to be arrested and brought before Judge Obadiah.
+
+Had Passepartout been a little less preoccupied, he would have espied
+the detective ensconced in a corner of the court-room, watching the
+proceedings with an interest easily understood; for the warrant had
+failed to reach him at Calcutta, as it had done at Bombay and Suez.
+
+Judge Obadiah had unfortunately caught Passepartout's rash exclamation,
+which the poor fellow would have given the world to recall.
+
+"The facts are admitted?" asked the judge.
+
+"Admitted," replied Mr. Fogg, coldly.
+
+"Inasmuch," resumed the judge, "as the English law protects equally and
+sternly the religions of the Indian people, and as the man Passepartout
+has admitted that he violated the sacred pagoda of Malabar Hill, at
+Bombay, on the 20th of October, I condemn the said Passepartout to
+imprisonment for fifteen days and a fine of three hundred pounds."
+
+"Three hundred pounds!" cried Passepartout, startled at the largeness
+of the sum.
+
+"Silence!" shouted the constable.
+
+"And inasmuch," continued the judge, "as it is not proved that the act
+was not done by the connivance of the master with the servant, and as
+the master in any case must be held responsible for the acts of his
+paid servant, I condemn Phileas Fogg to a week's imprisonment and a
+fine of one hundred and fifty pounds."
+
+Fix rubbed his hands softly with satisfaction; if Phileas Fogg could be
+detained in Calcutta a week, it would be more than time for the warrant
+to arrive.  Passepartout was stupefied.  This sentence ruined his
+master.  A wager of twenty thousand pounds lost, because he, like a
+precious fool, had gone into that abominable pagoda!
+
+Phileas Fogg, as self-composed as if the judgment did not in the least
+concern him, did not even lift his eyebrows while it was being
+pronounced.  Just as the clerk was calling the next case, he rose, and
+said, "I offer bail."
+
+"You have that right," returned the judge.
+
+Fix's blood ran cold, but he resumed his composure when he heard the
+judge announce that the bail required for each prisoner would be one
+thousand pounds.
+
+"I will pay it at once," said Mr. Fogg, taking a roll of bank-bills
+from the carpet-bag, which Passepartout had by him, and placing them on
+the clerk's desk.
+
+"This sum will be restored to you upon your release from prison," said
+the judge.  "Meanwhile, you are liberated on bail."
+
+"Come!" said Phileas Fogg to his servant.
+
+"But let them at least give me back my shoes!" cried Passepartout
+angrily.
+
+"Ah, these are pretty dear shoes!" he muttered, as they were handed to
+him.  "More than a thousand pounds apiece; besides, they pinch my feet."
+
+Mr. Fogg, offering his arm to Aouda, then departed, followed by the
+crestfallen Passepartout.  Fix still nourished hopes that the robber
+would not, after all, leave the two thousand pounds behind him, but
+would decide to serve out his week in jail, and issued forth on Mr.
+Fogg's traces.  That gentleman took a carriage, and the party were soon
+landed on one of the quays.
+
+The Rangoon was moored half a mile off in the harbour, its signal of
+departure hoisted at the mast-head.  Eleven o'clock was striking; Mr.
+Fogg was an hour in advance of time.  Fix saw them leave the carriage
+and push off in a boat for the steamer, and stamped his feet with
+disappointment.
+
+"The rascal is off, after all!" he exclaimed.  "Two thousand pounds
+sacrificed!  He's as prodigal as a thief!  I'll follow him to the end
+of the world if necessary; but, at the rate he is going on, the stolen
+money will soon be exhausted."
+
+The detective was not far wrong in making this conjecture.  Since
+leaving London, what with travelling expenses, bribes, the purchase of
+the elephant, bails, and fines, Mr. Fogg had already spent more than
+five thousand pounds on the way, and the percentage of the sum
+recovered from the bank robber promised to the detectives, was rapidly
+diminishing.
+
+
+
+
+Chapter XVI
+
+IN WHICH FIX DOES NOT SEEM TO UNDERSTAND IN THE LEAST WHAT IS SAID TO
+HIM
+
+
+The Rangoon--one of the Peninsular and Oriental Company's boats plying
+in the Chinese and Japanese seas--was a screw steamer, built of iron,
+weighing about seventeen hundred and seventy tons, and with engines of
+four hundred horse-power.  She was as fast, but not as well fitted up,
+as the Mongolia, and Aouda was not as comfortably provided for on board
+of her as Phileas Fogg could have wished.  However, the trip from
+Calcutta to Hong Kong only comprised some three thousand five hundred
+miles, occupying from ten to twelve days, and the young woman was not
+difficult to please.
+
+During the first days of the journey Aouda became better acquainted
+with her protector, and constantly gave evidence of her deep gratitude
+for what he had done.  The phlegmatic gentleman listened to her,
+apparently at least, with coldness, neither his voice nor his manner
+betraying the slightest emotion; but he seemed to be always on the
+watch that nothing should be wanting to Aouda's comfort.  He visited
+her regularly each day at certain hours, not so much to talk himself,
+as to sit and hear her talk.  He treated her with the strictest
+politeness, but with the precision of an automaton, the movements of
+which had been arranged for this purpose.  Aouda did not quite know
+what to make of him, though Passepartout had given her some hints of
+his master's eccentricity, and made her smile by telling her of the
+wager which was sending him round the world.  After all, she owed
+Phileas Fogg her life, and she always regarded him through the exalting
+medium of her gratitude.
+
+Aouda confirmed the Parsee guide's narrative of her touching history.
+She did, indeed, belong to the highest of the native races of India.
+Many of the Parsee merchants have made great fortunes there by dealing
+in cotton; and one of them, Sir Jametsee Jeejeebhoy, was made a baronet
+by the English government.  Aouda was a relative of this great man, and
+it was his cousin, Jeejeeh, whom she hoped to join at Hong Kong.
+Whether she would find a protector in him she could not tell; but Mr.
+Fogg essayed to calm her anxieties, and to assure her that everything
+would be mathematically--he used the very word--arranged.  Aouda
+fastened her great eyes, "clear as the sacred lakes of the Himalaya,"
+upon him; but the intractable Fogg, as reserved as ever, did not seem
+at all inclined to throw himself into this lake.
+
+The first few days of the voyage passed prosperously, amid favourable
+weather and propitious winds, and they soon came in sight of the great
+Andaman, the principal of the islands in the Bay of Bengal, with its
+picturesque Saddle Peak, two thousand four hundred feet high, looming
+above the waters.  The steamer passed along near the shores, but the
+savage Papuans, who are in the lowest scale of humanity, but are not,
+as has been asserted, cannibals, did not make their appearance.
+
+The panorama of the islands, as they steamed by them, was superb.  Vast
+forests of palms, arecs, bamboo, teakwood, of the gigantic mimosa, and
+tree-like ferns covered the foreground, while behind, the graceful
+outlines of the mountains were traced against the sky; and along the
+coasts swarmed by thousands the precious swallows whose nests furnish a
+luxurious dish to the tables of the Celestial Empire.  The varied
+landscape afforded by the Andaman Islands was soon passed, however, and
+the Rangoon rapidly approached the Straits of Malacca, which gave
+access to the China seas.
+
+What was detective Fix, so unluckily drawn on from country to country,
+doing all this while?  He had managed to embark on the Rangoon at
+Calcutta without being seen by Passepartout, after leaving orders that,
+if the warrant should arrive, it should be forwarded to him at Hong
+Kong; and he hoped to conceal his presence to the end of the voyage.
+It would have been difficult to explain why he was on board without
+awakening Passepartout's suspicions, who thought him still at Bombay.
+But necessity impelled him, nevertheless, to renew his acquaintance
+with the worthy servant, as will be seen.
+
+All the detective's hopes and wishes were now centred on Hong Kong; for
+the steamer's stay at Singapore would be too brief to enable him to
+take any steps there.  The arrest must be made at Hong Kong, or the
+robber would probably escape him for ever.  Hong Kong was the last
+English ground on which he would set foot; beyond, China, Japan,
+America offered to Fogg an almost certain refuge.  If the warrant
+should at last make its appearance at Hong Kong, Fix could arrest him
+and give him into the hands of the local police, and there would be no
+further trouble.  But beyond Hong Kong, a simple warrant would be of no
+avail; an extradition warrant would be necessary, and that would result
+in delays and obstacles, of which the rascal would take advantage to
+elude justice.
+
+Fix thought over these probabilities during the long hours which he
+spent in his cabin, and kept repeating to himself, "Now, either the
+warrant will be at Hong Kong, in which case I shall arrest my man, or
+it will not be there; and this time it is absolutely necessary that I
+should delay his departure.  I have failed at Bombay, and I have failed
+at Calcutta; if I fail at Hong Kong, my reputation is lost:  Cost what
+it may, I must succeed!  But how shall I prevent his departure, if that
+should turn out to be my last resource?"
+
+Fix made up his mind that, if worst came to worst, he would make a
+confidant of Passepartout, and tell him what kind of a fellow his
+master really was.  That Passepartout was not Fogg's accomplice, he was
+very certain.  The servant, enlightened by his disclosure, and afraid
+of being himself implicated in the crime, would doubtless become an
+ally of the detective.  But this method was a dangerous one, only to be
+employed when everything else had failed.  A word from Passepartout to
+his master would ruin all.  The detective was therefore in a sore
+strait.  But suddenly a new idea struck him.  The presence of Aouda on
+the Rangoon, in company with Phileas Fogg, gave him new material for
+reflection.
+
+Who was this woman?  What combination of events had made her Fogg's
+travelling companion?  They had evidently met somewhere between Bombay
+and Calcutta; but where?  Had they met accidentally, or had Fogg gone
+into the interior purposely in quest of this charming damsel?  Fix was
+fairly puzzled.  He asked himself whether there had not been a wicked
+elopement; and this idea so impressed itself upon his mind that he
+determined to make use of the supposed intrigue.  Whether the young
+woman were married or not, he would be able to create such difficulties
+for Mr. Fogg at Hong Kong that he could not escape by paying any amount
+of money.
+
+But could he even wait till they reached Hong Kong?  Fogg had an
+abominable way of jumping from one boat to another, and, before
+anything could be effected, might get full under way again for Yokohama.
+
+Fix decided that he must warn the English authorities, and signal the
+Rangoon before her arrival.  This was easy to do, since the steamer
+stopped at Singapore, whence there is a telegraphic wire to Hong Kong.
+He finally resolved, moreover, before acting more positively, to
+question Passepartout.  It would not be difficult to make him talk;
+and, as there was no time to lose, Fix prepared to make himself known.
+
+It was now the 30th of October, and on the following day the Rangoon
+was due at Singapore.
+
+Fix emerged from his cabin and went on deck.  Passepartout was
+promenading up and down in the forward part of the steamer.  The
+detective rushed forward with every appearance of extreme surprise, and
+exclaimed, "You here, on the Rangoon?"
+
+"What, Monsieur Fix, are you on board?" returned the really astonished
+Passepartout, recognising his crony of the Mongolia.  "Why, I left you
+at Bombay, and here you are, on the way to Hong Kong!  Are you going
+round the world too?"
+
+"No, no," replied Fix; "I shall stop at Hong Kong--at least for some
+days."
+
+"Hum!" said Passepartout, who seemed for an instant perplexed.  "But
+how is it I have not seen you on board since we left Calcutta?"
+
+"Oh, a trifle of sea-sickness--I've been staying in my berth.  The Gulf
+of Bengal does not agree with me as well as the Indian Ocean.  And how
+is Mr. Fogg?"
+
+"As well and as punctual as ever, not a day behind time!  But, Monsieur
+Fix, you don't know that we have a young lady with us."
+
+"A young lady?" replied the detective, not seeming to comprehend what
+was said.
+
+Passepartout thereupon recounted Aouda's history, the affair at the
+Bombay pagoda, the purchase of the elephant for two thousand pounds,
+the rescue, the arrest, and sentence of the Calcutta court, and the
+restoration of Mr. Fogg and himself to liberty on bail.  Fix, who was
+familiar with the last events, seemed to be equally ignorant of all
+that Passepartout related; and the later was charmed to find so
+interested a listener.
+
+"But does your master propose to carry this young woman to Europe?"
+
+"Not at all.  We are simply going to place her under the protection of
+one of her relatives, a rich merchant at Hong Kong."
+
+"Nothing to be done there," said Fix to himself, concealing his
+disappointment.  "A glass of gin, Mr. Passepartout?"
+
+"Willingly, Monsieur Fix.  We must at least have a friendly glass on
+board the Rangoon."
+
+
+
+
+Chapter XVII
+
+SHOWING WHAT HAPPENED ON THE VOYAGE FROM SINGAPORE TO HONG KONG
+
+
+The detective and Passepartout met often on deck after this interview,
+though Fix was reserved, and did not attempt to induce his companion to
+divulge any more facts concerning Mr. Fogg.  He caught a glimpse of
+that mysterious gentleman once or twice; but Mr. Fogg usually confined
+himself to the cabin, where he kept Aouda company, or, according to his
+inveterate habit, took a hand at whist.
+
+Passepartout began very seriously to conjecture what strange chance
+kept Fix still on the route that his master was pursuing.  It was
+really worth considering why this certainly very amiable and complacent
+person, whom he had first met at Suez, had then encountered on board
+the Mongolia, who disembarked at Bombay, which he announced as his
+destination, and now turned up so unexpectedly on the Rangoon, was
+following Mr. Fogg's tracks step by step.  What was Fix's object?
+Passepartout was ready to wager his Indian shoes--which he religiously
+preserved--that Fix would also leave Hong Kong at the same time with
+them, and probably on the same steamer.
+
+Passepartout might have cudgelled his brain for a century without
+hitting upon the real object which the detective had in view.  He never
+could have imagined that Phileas Fogg was being tracked as a robber
+around the globe.  But, as it is in human nature to attempt the
+solution of every mystery, Passepartout suddenly discovered an
+explanation of Fix's movements, which was in truth far from
+unreasonable.  Fix, he thought, could only be an agent of Mr. Fogg's
+friends at the Reform Club, sent to follow him up, and to ascertain
+that he really went round the world as had been agreed upon.
+
+"It's clear!" repeated the worthy servant to himself, proud of his
+shrewdness.  "He's a spy sent to keep us in view!  That isn't quite the
+thing, either, to be spying Mr. Fogg, who is so honourable a man!  Ah,
+gentlemen of the Reform, this shall cost you dear!"
+
+Passepartout, enchanted with his discovery, resolved to say nothing to
+his master, lest he should be justly offended at this mistrust on the
+part of his adversaries.  But he determined to chaff Fix, when he had
+the chance, with mysterious allusions, which, however, need not betray
+his real suspicions.
+
+During the afternoon of Wednesday, 30th October, the Rangoon entered
+the Strait of Malacca, which separates the peninsula of that name from
+Sumatra.  The mountainous and craggy islets intercepted the beauties of
+this noble island from the view of the travellers.  The Rangoon weighed
+anchor at Singapore the next day at four a.m., to receive coal, having
+gained half a day on the prescribed time of her arrival.  Phileas Fogg
+noted this gain in his journal, and then, accompanied by Aouda, who
+betrayed a desire for a walk on shore, disembarked.
+
+Fix, who suspected Mr. Fogg's every movement, followed them cautiously,
+without being himself perceived; while Passepartout, laughing in his
+sleeve at Fix's manoeuvres, went about his usual errands.
+
+The island of Singapore is not imposing in aspect, for there are no
+mountains; yet its appearance is not without attractions.  It is a park
+checkered by pleasant highways and avenues.  A handsome carriage, drawn
+by a sleek pair of New Holland horses, carried Phileas Fogg and Aouda
+into the midst of rows of palms with brilliant foliage, and of
+clove-trees, whereof the cloves form the heart of a half-open flower.
+Pepper plants replaced the prickly hedges of European fields;
+sago-bushes, large ferns with gorgeous branches, varied the aspect of
+this tropical clime; while nutmeg-trees in full foliage filled the air
+with a penetrating perfume.  Agile and grinning bands of monkeys
+skipped about in the trees, nor were tigers wanting in the jungles.
+
+After a drive of two hours through the country, Aouda and Mr. Fogg
+returned to the town, which is a vast collection of heavy-looking,
+irregular houses, surrounded by charming gardens rich in tropical
+fruits and plants; and at ten o'clock they re-embarked, closely
+followed by the detective, who had kept them constantly in sight.
+
+Passepartout, who had been purchasing several dozen mangoes--a fruit
+as large as good-sized apples, of a dark-brown colour outside and a
+bright red within, and whose white pulp, melting in the mouth, affords
+gourmands a delicious sensation--was waiting for them on deck.  He was
+only too glad to offer some mangoes to Aouda, who thanked him very
+gracefully for them.
+
+At eleven o'clock the Rangoon rode out of Singapore harbour, and in a
+few hours the high mountains of Malacca, with their forests, inhabited
+by the most beautifully-furred tigers in the world, were lost to view.
+Singapore is distant some thirteen hundred miles from the island of
+Hong Kong, which is a little English colony near the Chinese coast.
+Phileas Fogg hoped to accomplish the journey in six days, so as to be
+in time for the steamer which would leave on the 6th of November for
+Yokohama, the principal Japanese port.
+
+The Rangoon had a large quota of passengers, many of whom disembarked
+at Singapore, among them a number of Indians, Ceylonese, Chinamen,
+Malays, and Portuguese, mostly second-class travellers.
+
+The weather, which had hitherto been fine, changed with the last
+quarter of the moon.  The sea rolled heavily, and the wind at intervals
+rose almost to a storm, but happily blew from the south-west, and thus
+aided the steamer's progress.  The captain as often as possible put up
+his sails, and under the double action of steam and sail the vessel
+made rapid progress along the coasts of Anam and Cochin China.  Owing
+to the defective construction of the Rangoon, however, unusual
+precautions became necessary in unfavourable weather; but the loss of
+time which resulted from this cause, while it nearly drove Passepartout
+out of his senses, did not seem to affect his master in the least.
+Passepartout blamed the captain, the engineer, and the crew, and
+consigned all who were connected with the ship to the land where the
+pepper grows.  Perhaps the thought of the gas, which was remorselessly
+burning at his expense in Saville Row, had something to do with his hot
+impatience.
+
+"You are in a great hurry, then," said Fix to him one day, "to reach
+Hong Kong?"
+
+"A very great hurry!"
+
+"Mr. Fogg, I suppose, is anxious to catch the steamer for Yokohama?"
+
+"Terribly anxious."
+
+"You believe in this journey around the world, then?"
+
+"Absolutely.  Don't you, Mr. Fix?"
+
+"I?  I don't believe a word of it."
+
+"You're a sly dog!" said Passepartout, winking at him.
+
+This expression rather disturbed Fix, without his knowing why.  Had the
+Frenchman guessed his real purpose?  He knew not what to think.  But
+how could Passepartout have discovered that he was a detective?  Yet,
+in speaking as he did, the man evidently meant more than he expressed.
+
+Passepartout went still further the next day; he could not hold his
+tongue.
+
+"Mr. Fix," said he, in a bantering tone, "shall we be so unfortunate as
+to lose you when we get to Hong Kong?"
+
+"Why," responded Fix, a little embarrassed, "I don't know; perhaps--"
+
+"Ah, if you would only go on with us!  An agent of the Peninsular
+Company, you know, can't stop on the way!  You were only going to
+Bombay, and here you are in China.  America is not far off, and from
+America to Europe is only a step."
+
+Fix looked intently at his companion, whose countenance was as serene
+as possible, and laughed with him.  But Passepartout persisted in
+chaffing him by asking him if he made much by his present occupation.
+
+"Yes, and no," returned Fix; "there is good and bad luck in such
+things.  But you must understand that I don't travel at my own expense."
+
+"Oh, I am quite sure of that!" cried Passepartout, laughing heartily.
+
+Fix, fairly puzzled, descended to his cabin and gave himself up to his
+reflections.  He was evidently suspected; somehow or other the
+Frenchman had found out that he was a detective.  But had he told his
+master?  What part was he playing in all this: was he an accomplice or
+not?  Was the game, then, up?  Fix spent several hours turning these
+things over in his mind, sometimes thinking that all was lost, then
+persuading himself that Fogg was ignorant of his presence, and then
+undecided what course it was best to take.
+
+Nevertheless, he preserved his coolness of mind, and at last resolved
+to deal plainly with Passepartout.  If he did not find it practicable
+to arrest Fogg at Hong Kong, and if Fogg made preparations to leave
+that last foothold of English territory, he, Fix, would tell
+Passepartout all.  Either the servant was the accomplice of his master,
+and in this case the master knew of his operations, and he should fail;
+or else the servant knew nothing about the robbery, and then his
+interest would be to abandon the robber.
+
+Such was the situation between Fix and Passepartout.  Meanwhile Phileas
+Fogg moved about above them in the most majestic and unconscious
+indifference.  He was passing methodically in his orbit around the
+world, regardless of the lesser stars which gravitated around him.  Yet
+there was near by what the astronomers would call a disturbing star,
+which might have produced an agitation in this gentleman's heart.  But
+no! the charms of Aouda failed to act, to Passepartout's great
+surprise; and the disturbances, if they existed, would have been more
+difficult to calculate than those of Uranus which led to the discovery
+of Neptune.
+
+It was every day an increasing wonder to Passepartout, who read in
+Aouda's eyes the depths of her gratitude to his master.  Phileas Fogg,
+though brave and gallant, must be, he thought, quite heartless.  As to
+the sentiment which this journey might have awakened in him, there was
+clearly no trace of such a thing; while poor Passepartout existed in
+perpetual reveries.
+
+One day he was leaning on the railing of the engine-room, and was
+observing the engine, when a sudden pitch of the steamer threw the
+screw out of the water.  The steam came hissing out of the valves; and
+this made Passepartout indignant.
+
+"The valves are not sufficiently charged!" he exclaimed.  "We are not
+going.  Oh, these English!  If this was an American craft, we should
+blow up, perhaps, but we should at all events go faster!"
+
+
+
+
+Chapter XVIII
+
+IN WHICH PHILEAS FOGG, PASSEPARTOUT, AND FIX GO EACH ABOUT HIS BUSINESS
+
+
+The weather was bad during the latter days of the voyage.  The wind,
+obstinately remaining in the north-west, blew a gale, and retarded the
+steamer.  The Rangoon rolled heavily and the passengers became
+impatient of the long, monstrous waves which the wind raised before
+their path.  A sort of tempest arose on the 3rd of November, the squall
+knocking the vessel about with fury, and the waves running high.  The
+Rangoon reefed all her sails, and even the rigging proved too much,
+whistling and shaking amid the squall.  The steamer was forced to
+proceed slowly, and the captain estimated that she would reach Hong
+Kong twenty hours behind time, and more if the storm lasted.
+
+Phileas Fogg gazed at the tempestuous sea, which seemed to be
+struggling especially to delay him, with his habitual tranquillity.  He
+never changed countenance for an instant, though a delay of twenty
+hours, by making him too late for the Yokohama boat, would almost
+inevitably cause the loss of the wager.  But this man of nerve
+manifested neither impatience nor annoyance; it seemed as if the storm
+were a part of his programme, and had been foreseen.  Aouda was amazed
+to find him as calm as he had been from the first time she saw him.
+
+Fix did not look at the state of things in the same light.  The storm
+greatly pleased him.  His satisfaction would have been complete had the
+Rangoon been forced to retreat before the violence of wind and waves.
+Each delay filled him with hope, for it became more and more probable
+that Fogg would be obliged to remain some days at Hong Kong; and now
+the heavens themselves became his allies, with the gusts and squalls.
+It mattered not that they made him sea-sick--he made no account of this
+inconvenience; and, whilst his body was writhing under their effects,
+his spirit bounded with hopeful exultation.
+
+Passepartout was enraged beyond expression by the unpropitious weather.
+Everything had gone so well till now!  Earth and sea had seemed to be
+at his master's service; steamers and railways obeyed him; wind and
+steam united to speed his journey.  Had the hour of adversity come?
+Passepartout was as much excited as if the twenty thousand pounds were
+to come from his own pocket.  The storm exasperated him, the gale made
+him furious, and he longed to lash the obstinate sea into obedience.
+Poor fellow!  Fix carefully concealed from him his own satisfaction,
+for, had he betrayed it, Passepartout could scarcely have restrained
+himself from personal violence.
+
+Passepartout remained on deck as long as the tempest lasted, being
+unable to remain quiet below, and taking it into his head to aid the
+progress of the ship by lending a hand with the crew.  He overwhelmed
+the captain, officers, and sailors, who could not help laughing at his
+impatience, with all sorts of questions.  He wanted to know exactly how
+long the storm was going to last; whereupon he was referred to the
+barometer, which seemed to have no intention of rising.  Passepartout
+shook it, but with no perceptible effect; for neither shaking nor
+maledictions could prevail upon it to change its mind.
+
+On the 4th, however, the sea became more calm, and the storm lessened
+its violence; the wind veered southward, and was once more favourable.
+Passepartout cleared up with the weather.  Some of the sails were
+unfurled, and the Rangoon resumed its most rapid speed.  The time lost
+could not, however, be regained.  Land was not signalled until five
+o'clock on the morning of the 6th; the steamer was due on the 5th.
+Phileas Fogg was twenty-four hours behind-hand, and the Yokohama
+steamer would, of course, be missed.
+
+The pilot went on board at six, and took his place on the bridge, to
+guide the Rangoon through the channels to the port of Hong Kong.
+Passepartout longed to ask him if the steamer had left for Yokohama;
+but he dared not, for he wished to preserve the spark of hope, which
+still remained till the last moment.  He had confided his anxiety to
+Fix who--the sly rascal!--tried to console him by saying that Mr. Fogg
+would be in time if he took the next boat; but this only put
+Passepartout in a passion.
+
+Mr. Fogg, bolder than his servant, did not hesitate to approach the
+pilot, and tranquilly ask him if he knew when a steamer would leave
+Hong Kong for Yokohama.
+
+"At high tide to-morrow morning," answered the pilot.
+
+"Ah!" said Mr. Fogg, without betraying any astonishment.
+
+Passepartout, who heard what passed, would willingly have embraced the
+pilot, while Fix would have been glad to twist his neck.
+
+"What is the steamer's name?" asked Mr. Fogg.
+
+"The Carnatic."
+
+"Ought she not to have gone yesterday?"
+
+"Yes, sir; but they had to repair one of her boilers, and so her
+departure was postponed till to-morrow."
+
+"Thank you," returned Mr. Fogg, descending mathematically to the saloon.
+
+Passepartout clasped the pilot's hand and shook it heartily in his
+delight, exclaiming, "Pilot, you are the best of good fellows!"
+
+The pilot probably does not know to this day why his responses won him
+this enthusiastic greeting.  He remounted the bridge, and guided the
+steamer through the flotilla of junks, tankas, and fishing boats which
+crowd the harbour of Hong Kong.
+
+At one o'clock the Rangoon was at the quay, and the passengers were
+going ashore.
+
+Chance had strangely favoured Phileas Fogg, for had not the Carnatic
+been forced to lie over for repairing her boilers, she would have left
+on the 6th of November, and the passengers for Japan would have been
+obliged to await for a week the sailing of the next steamer.  Mr. Fogg
+was, it is true, twenty-four hours behind his time; but this could not
+seriously imperil the remainder of his tour.
+
+The steamer which crossed the Pacific from Yokohama to San Francisco
+made a direct connection with that from Hong Kong, and it could not
+sail until the latter reached Yokohama; and if Mr. Fogg was twenty-four
+hours late on reaching Yokohama, this time would no doubt be easily
+regained in the voyage of twenty-two days across the Pacific.  He found
+himself, then, about twenty-four hours behind-hand, thirty-five days
+after leaving London.
+
+The Carnatic was announced to leave Hong Kong at five the next morning.
+Mr. Fogg had sixteen hours in which to attend to his business there,
+which was to deposit Aouda safely with her wealthy relative.
+
+On landing, he conducted her to a palanquin, in which they repaired to
+the Club Hotel.  A room was engaged for the young woman, and Mr. Fogg,
+after seeing that she wanted for nothing, set out in search of her
+cousin Jeejeeh.  He instructed Passepartout to remain at the hotel
+until his return, that Aouda might not be left entirely alone.
+
+Mr. Fogg repaired to the Exchange, where, he did not doubt, every one
+would know so wealthy and considerable a personage as the Parsee
+merchant.  Meeting a broker, he made the inquiry, to learn that Jeejeeh
+had left China two years before, and, retiring from business with an
+immense fortune, had taken up his residence in Europe--in Holland the
+broker thought, with the merchants of which country he had principally
+traded.  Phileas Fogg returned to the hotel, begged a moment's
+conversation with Aouda, and without more ado, apprised her that
+Jeejeeh was no longer at Hong Kong, but probably in Holland.
+
+Aouda at first said nothing.  She passed her hand across her forehead,
+and reflected a few moments.  Then, in her sweet, soft voice, she said:
+"What ought I to do, Mr. Fogg?"
+
+"It is very simple," responded the gentleman.  "Go on to Europe."
+
+"But I cannot intrude--"
+
+"You do not intrude, nor do you in the least embarrass my project.
+Passepartout!"
+
+"Monsieur."
+
+"Go to the Carnatic, and engage three cabins."
+
+Passepartout, delighted that the young woman, who was very gracious to
+him, was going to continue the journey with them, went off at a brisk
+gait to obey his master's order.
+
+
+
+
+Chapter XIX
+
+IN WHICH PASSEPARTOUT TAKES A TOO GREAT INTEREST IN HIS MASTER, AND
+WHAT COMES OF IT
+
+
+Hong Kong is an island which came into the possession of the English by
+the Treaty of Nankin, after the war of 1842; and the colonising genius
+of the English has created upon it an important city and an excellent
+port.  The island is situated at the mouth of the Canton River, and is
+separated by about sixty miles from the Portuguese town of Macao, on
+the opposite coast.  Hong Kong has beaten Macao in the struggle for the
+Chinese trade, and now the greater part of the transportation of
+Chinese goods finds its depot at the former place.  Docks, hospitals,
+wharves, a Gothic cathedral, a government house, macadamised streets,
+give to Hong Kong the appearance of a town in Kent or Surrey
+transferred by some strange magic to the antipodes.
+
+Passepartout wandered, with his hands in his pockets, towards the
+Victoria port, gazing as he went at the curious palanquins and other
+modes of conveyance, and the groups of Chinese, Japanese, and Europeans
+who passed to and fro in the streets.  Hong Kong seemed to him not
+unlike Bombay, Calcutta, and Singapore, since, like them, it betrayed
+everywhere the evidence of English supremacy.  At the Victoria port he
+found a confused mass of ships of all nations: English, French,
+American, and Dutch, men-of-war and trading vessels, Japanese and
+Chinese junks, sempas, tankas, and flower-boats, which formed so many
+floating parterres.  Passepartout noticed in the crowd a number of the
+natives who seemed very old and were dressed in yellow.  On going into
+a barber's to get shaved he learned that these ancient men were all at
+least eighty years old, at which age they are permitted to wear yellow,
+which is the Imperial colour.  Passepartout, without exactly knowing
+why, thought this very funny.
+
+On reaching the quay where they were to embark on the Carnatic, he was
+not astonished to find Fix walking up and down.  The detective seemed
+very much disturbed and disappointed.
+
+"This is bad," muttered Passepartout, "for the gentlemen of the Reform
+Club!"  He accosted Fix with a merry smile, as if he had not perceived
+that gentleman's chagrin.  The detective had, indeed, good reasons to
+inveigh against the bad luck which pursued him.  The warrant had not
+come!  It was certainly on the way, but as certainly it could not now
+reach Hong Kong for several days; and, this being the last English
+territory on Mr. Fogg's route, the robber would escape, unless he could
+manage to detain him.
+
+"Well, Monsieur Fix," said Passepartout, "have you decided to go with
+us so far as America?"
+
+"Yes," returned Fix, through his set teeth.
+
+"Good!" exclaimed Passepartout, laughing heartily.  "I knew you could
+not persuade yourself to separate from us.  Come and engage your berth."
+
+They entered the steamer office and secured cabins for four persons.
+The clerk, as he gave them the tickets, informed them that, the repairs
+on the Carnatic having been completed, the steamer would leave that
+very evening, and not next morning, as had been announced.
+
+"That will suit my master all the better," said Passepartout.  "I will
+go and let him know."
+
+Fix now decided to make a bold move; he resolved to tell Passepartout
+all.  It seemed to be the only possible means of keeping Phileas Fogg
+several days longer at Hong Kong.  He accordingly invited his companion
+into a tavern which caught his eye on the quay.  On entering, they
+found themselves in a large room handsomely decorated, at the end of
+which was a large camp-bed furnished with cushions.  Several persons
+lay upon this bed in a deep sleep.  At the small tables which were
+arranged about the room some thirty customers were drinking English
+beer, porter, gin, and brandy; smoking, the while, long red clay pipes
+stuffed with little balls of opium mingled with essence of rose.  From
+time to time one of the smokers, overcome with the narcotic, would slip
+under the table, whereupon the waiters, taking him by the head and
+feet, carried and laid him upon the bed.  The bed already supported
+twenty of these stupefied sots.
+
+Fix and Passepartout saw that they were in a smoking-house haunted by
+those wretched, cadaverous, idiotic creatures to whom the English
+merchants sell every year the miserable drug called opium, to the
+amount of one million four hundred thousand pounds--thousands devoted
+to one of the most despicable vices which afflict humanity!  The
+Chinese government has in vain attempted to deal with the evil by
+stringent laws.  It passed gradually from the rich, to whom it was at
+first exclusively reserved, to the lower classes, and then its ravages
+could not be arrested.  Opium is smoked everywhere, at all times, by
+men and women, in the Celestial Empire; and, once accustomed to it, the
+victims cannot dispense with it, except by suffering horrible bodily
+contortions and agonies.  A great smoker can smoke as many as eight
+pipes a day; but he dies in five years.  It was in one of these dens
+that Fix and Passepartout, in search of a friendly glass, found
+themselves.  Passepartout had no money, but willingly accepted Fix's
+invitation in the hope of returning the obligation at some future time.
+
+They ordered two bottles of port, to which the Frenchman did ample
+justice, whilst Fix observed him with close attention.  They chatted
+about the journey, and Passepartout was especially merry at the idea
+that Fix was going to continue it with them.  When the bottles were
+empty, however, he rose to go and tell his master of the change in the
+time of the sailing of the Carnatic.
+
+Fix caught him by the arm, and said, "Wait a moment."
+
+"What for, Mr. Fix?"
+
+"I want to have a serious talk with you."
+
+"A serious talk!" cried Passepartout, drinking up the little wine that
+was left in the bottom of his glass.  "Well, we'll talk about it
+to-morrow; I haven't time now."
+
+"Stay!  What I have to say concerns your master."
+
+Passepartout, at this, looked attentively at his companion.  Fix's face
+seemed to have a singular expression.  He resumed his seat.
+
+"What is it that you have to say?"
+
+Fix placed his hand upon Passepartout's arm, and, lowering his voice,
+said, "You have guessed who I am?"
+
+"Parbleu!" said Passepartout, smiling.
+
+"Then I'm going to tell you everything--"
+
+"Now that I know everything, my friend!  Ah! that's very good.  But go
+on, go on.  First, though, let me tell you that those gentlemen have
+put themselves to a useless expense."
+
+"Useless!" said Fix.  "You speak confidently.  It's clear that you
+don't know how large the sum is."
+
+"Of course I do," returned Passepartout.  "Twenty thousand pounds."
+
+"Fifty-five thousand!" answered Fix, pressing his companion's hand.
+
+"What!" cried the Frenchman.  "Has Monsieur Fogg dared--fifty-five
+thousand pounds!  Well, there's all the more reason for not losing an
+instant," he continued, getting up hastily.
+
+Fix pushed Passepartout back in his chair, and resumed: "Fifty-five
+thousand pounds; and if I succeed, I get two thousand pounds.  If
+you'll help me, I'll let you have five hundred of them."
+
+"Help you?" cried Passepartout, whose eyes were standing wide open.
+
+"Yes; help me keep Mr. Fogg here for two or three days."
+
+"Why, what are you saying?  Those gentlemen are not satisfied with
+following my master and suspecting his honour, but they must try to put
+obstacles in his way!  I blush for them!"
+
+"What do you mean?"
+
+"I mean that it is a piece of shameful trickery.  They might as well
+waylay Mr. Fogg and put his money in their pockets!"
+
+"That's just what we count on doing."
+
+"It's a conspiracy, then," cried Passepartout, who became more and more
+excited as the liquor mounted in his head, for he drank without
+perceiving it.  "A real conspiracy!  And gentlemen, too. Bah!"
+
+Fix began to be puzzled.
+
+"Members of the Reform Club!" continued Passepartout.  "You must know,
+Monsieur Fix, that my master is an honest man, and that, when he makes
+a wager, he tries to win it fairly!"
+
+"But who do you think I am?" asked Fix, looking at him intently.
+
+"Parbleu!  An agent of the members of the Reform Club, sent out here to
+interrupt my master's journey.  But, though I found you out some time
+ago, I've taken good care to say nothing about it to Mr. Fogg."
+
+"He knows nothing, then?"
+
+"Nothing," replied Passepartout, again emptying his glass.
+
+The detective passed his hand across his forehead, hesitating before he
+spoke again.  What should he do?  Passepartout's mistake seemed
+sincere, but it made his design more difficult.  It was evident that
+the servant was not the master's accomplice, as Fix had been inclined
+to suspect.
+
+"Well," said the detective to himself, "as he is not an accomplice, he
+will help me."
+
+He had no time to lose: Fogg must be detained at Hong Kong, so he
+resolved to make a clean breast of it.
+
+"Listen to me," said Fix abruptly.  "I am not, as you think, an agent
+of the members of the Reform Club--"
+
+"Bah!" retorted Passepartout, with an air of raillery.
+
+"I am a police detective, sent out here by the London office."
+
+"You, a detective?"
+
+"I will prove it.  Here is my commission."
+
+Passepartout was speechless with astonishment when Fix displayed this
+document, the genuineness of which could not be doubted.
+
+"Mr. Fogg's wager," resumed Fix, "is only a pretext, of which you and
+the gentlemen of the Reform are dupes.  He had a motive for securing
+your innocent complicity."
+
+"But why?"
+
+"Listen.  On the 28th of last September a robbery of fifty-five
+thousand pounds was committed at the Bank of England by a person whose
+description was fortunately secured.  Here is his description; it
+answers exactly to that of Mr. Phileas Fogg."
+
+"What nonsense!" cried Passepartout, striking the table with his fist.
+"My master is the most honourable of men!"
+
+"How can you tell?  You know scarcely anything about him.  You went
+into his service the day he came away; and he came away on a foolish
+pretext, without trunks, and carrying a large amount in banknotes.  And
+yet you are bold enough to assert that he is an honest man!"
+
+"Yes, yes," repeated the poor fellow, mechanically.
+
+"Would you like to be arrested as his accomplice?"
+
+Passepartout, overcome by what he had heard, held his head between his
+hands, and did not dare to look at the detective.  Phileas Fogg, the
+saviour of Aouda, that brave and generous man, a robber!  And yet how
+many presumptions there were against him!  Passepartout essayed to
+reject the suspicions which forced themselves upon his mind; he did not
+wish to believe that his master was guilty.
+
+"Well, what do you want of me?" said he, at last, with an effort.
+
+"See here," replied Fix; "I have tracked Mr. Fogg to this place, but as
+yet I have failed to receive the warrant of arrest for which I sent to
+London.  You must help me to keep him here in Hong Kong--"
+
+"I!  But I--"
+
+"I will share with you the two thousand pounds reward offered by the
+Bank of England."
+
+"Never!" replied Passepartout, who tried to rise, but fell back,
+exhausted in mind and body.
+
+"Mr. Fix," he stammered, "even should what you say be true--if my
+master is really the robber you are seeking for--which I deny--I have
+been, am, in his service; I have seen his generosity and goodness; and
+I will never betray him--not for all the gold in the world.  I come
+from a village where they don't eat that kind of bread!"
+
+"You refuse?"
+
+"I refuse."
+
+"Consider that I've said nothing," said Fix; "and let us drink."
+
+"Yes; let us drink!"
+
+Passepartout felt himself yielding more and more to the effects of the
+liquor.  Fix, seeing that he must, at all hazards, be separated from
+his master, wished to entirely overcome him.  Some pipes full of opium
+lay upon the table.  Fix slipped one into Passepartout's hand.  He took
+it, put it between his lips, lit it, drew several puffs, and his head,
+becoming heavy under the influence of the narcotic, fell upon the table.
+
+"At last!" said Fix, seeing Passepartout unconscious.  "Mr. Fogg will
+not be informed of the Carnatic's departure; and, if he is, he will
+have to go without this cursed Frenchman!"
+
+And, after paying his bill, Fix left the tavern.
+
+
+
+
+Chapter XX
+
+IN WHICH FIX COMES FACE TO FACE WITH PHILEAS FOGG
+
+
+While these events were passing at the opium-house, Mr. Fogg,
+unconscious of the danger he was in of losing the steamer, was quietly
+escorting Aouda about the streets of the English quarter, making the
+necessary purchases for the long voyage before them.  It was all very
+well for an Englishman like Mr. Fogg to make the tour of the world with
+a carpet-bag; a lady could not be expected to travel comfortably under
+such conditions.  He acquitted his task with characteristic serenity,
+and invariably replied to the remonstrances of his fair companion, who
+was confused by his patience and generosity:
+
+"It is in the interest of my journey--a part of my programme."
+
+The purchases made, they returned to the hotel, where they dined at a
+sumptuously served table-d'hote; after which Aouda, shaking hands with
+her protector after the English fashion, retired to her room for rest.
+Mr. Fogg absorbed himself throughout the evening in the perusal of The
+Times and Illustrated London News.
+
+Had he been capable of being astonished at anything, it would have been
+not to see his servant return at bedtime.  But, knowing that the
+steamer was not to leave for Yokohama until the next morning, he did
+not disturb himself about the matter.  When Passepartout did not appear
+the next morning to answer his master's bell, Mr. Fogg, not betraying
+the least vexation, contented himself with taking his carpet-bag,
+calling Aouda, and sending for a palanquin.
+
+It was then eight o'clock; at half-past nine, it being then high tide,
+the Carnatic would leave the harbour.  Mr. Fogg and Aouda got into the
+palanquin, their luggage being brought after on a wheelbarrow, and half
+an hour later stepped upon the quay whence they were to embark.  Mr.
+Fogg then learned that the Carnatic had sailed the evening before.  He
+had expected to find not only the steamer, but his domestic, and was
+forced to give up both; but no sign of disappointment appeared on his
+face, and he merely remarked to Aouda, "It is an accident, madam;
+nothing more."
+
+At this moment a man who had been observing him attentively approached.
+It was Fix, who, bowing, addressed Mr. Fogg:  "Were you not, like me,
+sir, a passenger by the Rangoon, which arrived yesterday?"
+
+"I was, sir," replied Mr. Fogg coldly.  "But I have not the honour--"
+
+"Pardon me; I thought I should find your servant here."
+
+"Do you know where he is, sir?" asked Aouda anxiously.
+
+"What!" responded Fix, feigning surprise.  "Is he not with you?"
+
+"No," said Aouda.  "He has not made his appearance since yesterday.
+Could he have gone on board the Carnatic without us?"
+
+"Without you, madam?" answered the detective.  "Excuse me, did you
+intend to sail in the Carnatic?"
+
+"Yes, sir."
+
+"So did I, madam, and I am excessively disappointed.  The Carnatic, its
+repairs being completed, left Hong Kong twelve hours before the stated
+time, without any notice being given; and we must now wait a week for
+another steamer."
+
+As he said "a week" Fix felt his heart leap for joy.  Fogg detained at
+Hong Kong for a week!  There would be time for the warrant to arrive,
+and fortune at last favoured the representative of the law.  His horror
+may be imagined when he heard Mr. Fogg say, in his placid voice, "But
+there are other vessels besides the Carnatic, it seems to me, in the
+harbour of Hong Kong."
+
+And, offering his arm to Aouda, he directed his steps toward the docks
+in search of some craft about to start.  Fix, stupefied, followed; it
+seemed as if he were attached to Mr. Fogg by an invisible thread.
+Chance, however, appeared really to have abandoned the man it had
+hitherto served so well.  For three hours Phileas Fogg wandered about
+the docks, with the determination, if necessary, to charter a vessel to
+carry him to Yokohama; but he could only find vessels which were
+loading or unloading, and which could not therefore set sail.  Fix
+began to hope again.
+
+But Mr. Fogg, far from being discouraged, was continuing his search,
+resolved not to stop if he had to resort to Macao, when he was accosted
+by a sailor on one of the wharves.
+
+"Is your honour looking for a boat?"
+
+"Have you a boat ready to sail?"
+
+"Yes, your honour; a pilot-boat--No. 43--the best in the harbour."
+
+"Does she go fast?"
+
+"Between eight and nine knots the hour.  Will you look at her?"
+
+"Yes."
+
+"Your honour will be satisfied with her.  Is it for a sea excursion?"
+
+"No; for a voyage."
+
+"A voyage?"
+
+"Yes, will you agree to take me to Yokohama?"
+
+The sailor leaned on the railing, opened his eyes wide, and said, "Is
+your honour joking?"
+
+"No.  I have missed the Carnatic, and I must get to Yokohama by the
+14th at the latest, to take the boat for San Francisco."
+
+"I am sorry," said the sailor; "but it is impossible."
+
+"I offer you a hundred pounds per day, and an additional reward of two
+hundred pounds if I reach Yokohama in time."
+
+"Are you in earnest?"
+
+"Very much so."
+
+The pilot walked away a little distance, and gazed out to sea,
+evidently struggling between the anxiety to gain a large sum and the
+fear of venturing so far.  Fix was in mortal suspense.
+
+Mr. Fogg turned to Aouda and asked her, "You would not be afraid, would
+you, madam?"
+
+"Not with you, Mr. Fogg," was her answer.
+
+The pilot now returned, shuffling his hat in his hands.
+
+"Well, pilot?" said Mr. Fogg.
+
+"Well, your honour," replied he, "I could not risk myself, my men, or
+my little boat of scarcely twenty tons on so long a voyage at this time
+of year.  Besides, we could not reach Yokohama in time, for it is
+sixteen hundred and sixty miles from Hong Kong."
+
+"Only sixteen hundred," said Mr. Fogg.
+
+"It's the same thing."
+
+Fix breathed more freely.
+
+"But," added the pilot, "it might be arranged another way."
+
+Fix ceased to breathe at all.
+
+"How?" asked Mr. Fogg.
+
+"By going to Nagasaki, at the extreme south of Japan, or even to
+Shanghai, which is only eight hundred miles from here.  In going to
+Shanghai we should not be forced to sail wide of the Chinese coast,
+which would be a great advantage, as the currents run northward, and
+would aid us."
+
+"Pilot," said Mr. Fogg, "I must take the American steamer at Yokohama,
+and not at Shanghai or Nagasaki."
+
+"Why not?" returned the pilot.  "The San Francisco steamer does not
+start from Yokohama.  It puts in at Yokohama and Nagasaki, but it
+starts from Shanghai."
+
+"You are sure of that?"
+
+"Perfectly."
+
+"And when does the boat leave Shanghai?"
+
+"On the 11th, at seven in the evening.  We have, therefore, four days
+before us, that is ninety-six hours; and in that time, if we had good
+luck and a south-west wind, and the sea was calm, we could make those
+eight hundred miles to Shanghai."
+
+"And you could go--"
+
+"In an hour; as soon as provisions could be got aboard and the sails
+put up."
+
+"It is a bargain.  Are you the master of the boat?"
+
+"Yes; John Bunsby, master of the Tankadere."
+
+"Would you like some earnest-money?"
+
+"If it would not put your honour out--"
+
+"Here are two hundred pounds on account sir," added Phileas Fogg,
+turning to Fix, "if you would like to take advantage--"
+
+"Thanks, sir; I was about to ask the favour."
+
+"Very well.  In half an hour we shall go on board."
+
+"But poor Passepartout?" urged Aouda, who was much disturbed by the
+servant's disappearance.
+
+"I shall do all I can to find him," replied Phileas Fogg.
+
+While Fix, in a feverish, nervous state, repaired to the pilot-boat,
+the others directed their course to the police-station at Hong Kong.
+Phileas Fogg there gave Passepartout's description, and left a sum of
+money to be spent in the search for him.  The same formalities having
+been gone through at the French consulate, and the palanquin having
+stopped at the hotel for the luggage, which had been sent back there,
+they returned to the wharf.
+
+It was now three o'clock; and pilot-boat No. 43, with its crew on
+board, and its provisions stored away, was ready for departure.
+
+The Tankadere was a neat little craft of twenty tons, as gracefully
+built as if she were a racing yacht.  Her shining copper sheathing, her
+galvanised iron-work, her deck, white as ivory, betrayed the pride
+taken by John Bunsby in making her presentable.  Her two masts leaned a
+trifle backward; she carried brigantine, foresail, storm-jib, and
+standing-jib, and was well rigged for running before the wind; and she
+seemed capable of brisk speed, which, indeed, she had already proved by
+gaining several prizes in pilot-boat races.  The crew of the Tankadere
+was composed of John Bunsby, the master, and four hardy mariners, who
+were familiar with the Chinese seas.  John Bunsby, himself, a man of
+forty-five or thereabouts, vigorous, sunburnt, with a sprightly
+expression of the eye, and energetic and self-reliant countenance,
+would have inspired confidence in the most timid.
+
+Phileas Fogg and Aouda went on board, where they found Fix already
+installed.  Below deck was a square cabin, of which the walls bulged
+out in the form of cots, above a circular divan; in the centre was a
+table provided with a swinging lamp.  The accommodation was confined,
+but neat.
+
+"I am sorry to have nothing better to offer you," said Mr. Fogg to Fix,
+who bowed without responding.
+
+The detective had a feeling akin to humiliation in profiting by the
+kindness of Mr. Fogg.
+
+"It's certain," thought he, "though rascal as he is, he is a polite
+one!"
+
+The sails and the English flag were hoisted at ten minutes past three.
+Mr. Fogg and Aouda, who were seated on deck, cast a last glance at the
+quay, in the hope of espying Passepartout.  Fix was not without his
+fears lest chance should direct the steps of the unfortunate servant,
+whom he had so badly treated, in this direction; in which case an
+explanation the reverse of satisfactory to the detective must have
+ensued.  But the Frenchman did not appear, and, without doubt, was
+still lying under the stupefying influence of the opium.
+
+John Bunsby, master, at length gave the order to start, and the
+Tankadere, taking the wind under her brigantine, foresail, and
+standing-jib, bounded briskly forward over the waves.
+
+
+
+
+Chapter XXI
+
+IN WHICH THE MASTER OF THE "TANKADERE" RUNS GREAT RISK OF LOSING A
+REWARD OF TWO HUNDRED POUNDS
+
+
+This voyage of eight hundred miles was a perilous venture on a craft of
+twenty tons, and at that season of the year.  The Chinese seas are
+usually boisterous, subject to terrible gales of wind, and especially
+during the equinoxes; and it was now early November.
+
+It would clearly have been to the master's advantage to carry his
+passengers to Yokohama, since he was paid a certain sum per day; but he
+would have been rash to attempt such a voyage, and it was imprudent
+even to attempt to reach Shanghai.  But John Bunsby believed in the
+Tankadere, which rode on the waves like a seagull; and perhaps he was
+not wrong.
+
+Late in the day they passed through the capricious channels of Hong
+Kong, and the Tankadere, impelled by favourable winds, conducted
+herself admirably.
+
+"I do not need, pilot," said Phileas Fogg, when they got into the open
+sea, "to advise you to use all possible speed."
+
+"Trust me, your honour.  We are carrying all the sail the wind will let
+us.  The poles would add nothing, and are only used when we are going
+into port."
+
+"It's your trade, not mine, pilot, and I confide in you."
+
+Phileas Fogg, with body erect and legs wide apart, standing like a
+sailor, gazed without staggering at the swelling waters.  The young
+woman, who was seated aft, was profoundly affected as she looked out
+upon the ocean, darkening now with the twilight, on which she had
+ventured in so frail a vessel.  Above her head rustled the white sails,
+which seemed like great white wings.  The boat, carried forward by the
+wind, seemed to be flying in the air.
+
+Night came.  The moon was entering her first quarter, and her
+insufficient light would soon die out in the mist on the horizon.
+Clouds were rising from the east, and already overcast a part of the
+heavens.
+
+The pilot had hung out his lights, which was very necessary in these
+seas crowded with vessels bound landward; for collisions are not
+uncommon occurrences, and, at the speed she was going, the least shock
+would shatter the gallant little craft.
+
+Fix, seated in the bow, gave himself up to meditation.  He kept apart
+from his fellow-travellers, knowing Mr. Fogg's taciturn tastes;
+besides, he did not quite like to talk to the man whose favours he had
+accepted.  He was thinking, too, of the future.  It seemed certain that
+Fogg would not stop at Yokohama, but would at once take the boat for
+San Francisco; and the vast extent of America would ensure him impunity
+and safety.  Fogg's plan appeared to him the simplest in the world.
+Instead of sailing directly from England to the United States, like a
+common villain, he had traversed three quarters of the globe, so as to
+gain the American continent more surely; and there, after throwing the
+police off his track, he would quietly enjoy himself with the fortune
+stolen from the bank.  But, once in the United States, what should he,
+Fix, do?  Should he abandon this man?  No, a hundred times no!  Until
+he had secured his extradition, he would not lose sight of him for an
+hour.  It was his duty, and he would fulfil it to the end.  At all
+events, there was one thing to be thankful for; Passepartout was not
+with his master; and it was above all important, after the confidences
+Fix had imparted to him, that the servant should never have speech with
+his master.
+
+Phileas Fogg was also thinking of Passepartout, who had so strangely
+disappeared.  Looking at the matter from every point of view, it did
+not seem to him impossible that, by some mistake, the man might have
+embarked on the Carnatic at the last moment; and this was also Aouda's
+opinion, who regretted very much the loss of the worthy fellow to whom
+she owed so much.  They might then find him at Yokohama; for, if the
+Carnatic was carrying him thither, it would be easy to ascertain if he
+had been on board.
+
+A brisk breeze arose about ten o'clock; but, though it might have been
+prudent to take in a reef, the pilot, after carefully examining the
+heavens, let the craft remain rigged as before.  The Tankadere bore
+sail admirably, as she drew a great deal of water, and everything was
+prepared for high speed in case of a gale.
+
+Mr. Fogg and Aouda descended into the cabin at midnight, having been
+already preceded by Fix, who had lain down on one of the cots.  The
+pilot and crew remained on deck all night.
+
+At sunrise the next day, which was 8th November, the boat had made more
+than one hundred miles.  The log indicated a mean speed of between
+eight and nine miles.  The Tankadere still carried all sail, and was
+accomplishing her greatest capacity of speed.  If the wind held as it
+was, the chances would be in her favour.  During the day she kept along
+the coast, where the currents were favourable; the coast, irregular in
+profile, and visible sometimes across the clearings, was at most five
+miles distant.  The sea was less boisterous, since the wind came off
+land--a fortunate circumstance for the boat, which would suffer, owing
+to its small tonnage, by a heavy surge on the sea.
+
+The breeze subsided a little towards noon, and set in from the
+south-west.  The pilot put up his poles, but took them down again
+within two hours, as the wind freshened up anew.
+
+Mr. Fogg and Aouda, happily unaffected by the roughness of the sea, ate
+with a good appetite, Fix being invited to share their repast, which he
+accepted with secret chagrin.  To travel at this man's expense and live
+upon his provisions was not palatable to him.  Still, he was obliged to
+eat, and so he ate.
+
+When the meal was over, he took Mr. Fogg apart, and said, "sir"--this
+"sir" scorched his lips, and he had to control himself to avoid
+collaring this "gentleman"--"sir, you have been very kind to give me a
+passage on this boat.  But, though my means will not admit of my
+expending them as freely as you, I must ask to pay my share--"
+
+"Let us not speak of that, sir," replied Mr. Fogg.
+
+"But, if I insist--"
+
+"No, sir," repeated Mr. Fogg, in a tone which did not admit of a reply.
+"This enters into my general expenses."
+
+Fix, as he bowed, had a stifled feeling, and, going forward, where he
+ensconced himself, did not open his mouth for the rest of the day.
+
+Meanwhile they were progressing famously, and John Bunsby was in high
+hope.  He several times assured Mr. Fogg that they would reach Shanghai
+in time; to which that gentleman responded that he counted upon it.
+The crew set to work in good earnest, inspired by the reward to be
+gained.  There was not a sheet which was not tightened, not a sail which
+was not vigorously hoisted; not a lurch could be charged to the man at
+the helm.  They worked as desperately as if they were contesting in a
+Royal yacht regatta.
+
+By evening, the log showed that two hundred and twenty miles had been
+accomplished from Hong Kong, and Mr. Fogg might hope that he would be
+able to reach Yokohama without recording any delay in his journal; in
+which case, the many misadventures which had overtaken him since he
+left London would not seriously affect his journey.
+
+The Tankadere entered the Straits of Fo-Kien, which separate the island
+of Formosa from the Chinese coast, in the small hours of the night, and
+crossed the Tropic of Cancer.  The sea was very rough in the straits,
+full of eddies formed by the counter-currents, and the chopping waves
+broke her course, whilst it became very difficult to stand on deck.
+
+At daybreak the wind began to blow hard again, and the heavens seemed
+to predict a gale.  The barometer announced a speedy change, the
+mercury rising and falling capriciously; the sea also, in the
+south-east, raised long surges which indicated a tempest.  The sun had
+set the evening before in a red mist, in the midst of the
+phosphorescent scintillations of the ocean.
+
+John Bunsby long examined the threatening aspect of the heavens,
+muttering indistinctly between his teeth.  At last he said in a low
+voice to Mr. Fogg, "Shall I speak out to your honour?"
+
+"Of course."
+
+"Well, we are going to have a squall."
+
+"Is the wind north or south?" asked Mr. Fogg quietly.
+
+"South.  Look! a typhoon is coming up."
+
+"Glad it's a typhoon from the south, for it will carry us forward."
+
+"Oh, if you take it that way," said John Bunsby, "I've nothing more to
+say." John Bunsby's suspicions were confirmed.  At a less advanced
+season of the year the typhoon, according to a famous meteorologist,
+would have passed away like a luminous cascade of electric flame; but
+in the winter equinox it was to be feared that it would burst upon them
+with great violence.
+
+The pilot took his precautions in advance.  He reefed all sail, the
+pole-masts were dispensed with; all hands went forward to the bows.  A
+single triangular sail, of strong canvas, was hoisted as a storm-jib,
+so as to hold the wind from behind.  Then they waited.
+
+John Bunsby had requested his passengers to go below; but this
+imprisonment in so narrow a space, with little air, and the boat
+bouncing in the gale, was far from pleasant.  Neither Mr. Fogg, Fix,
+nor Aouda consented to leave the deck.
+
+The storm of rain and wind descended upon them towards eight o'clock.
+With but its bit of sail, the Tankadere was lifted like a feather by a
+wind, an idea of whose violence can scarcely be given.  To compare her
+speed to four times that of a locomotive going on full steam would be
+below the truth.
+
+The boat scudded thus northward during the whole day, borne on by
+monstrous waves, preserving always, fortunately, a speed equal to
+theirs.  Twenty times she seemed almost to be submerged by these
+mountains of water which rose behind her; but the adroit management of
+the pilot saved her.  The passengers were often bathed in spray, but
+they submitted to it philosophically.  Fix cursed it, no doubt; but
+Aouda, with her eyes fastened upon her protector, whose coolness amazed
+her, showed herself worthy of him, and bravely weathered the storm.  As
+for Phileas Fogg, it seemed just as if the typhoon were a part of his
+programme.
+
+Up to this time the Tankadere had always held her course to the north;
+but towards evening the wind, veering three quarters, bore down from
+the north-west.  The boat, now lying in the trough of the waves, shook
+and rolled terribly; the sea struck her with fearful violence.  At
+night the tempest increased in violence.  John Bunsby saw the approach
+of darkness and the rising of the storm with dark misgivings.  He
+thought awhile, and then asked his crew if it was not time to slacken
+speed.  After a consultation he approached Mr. Fogg, and said, "I
+think, your honour, that we should do well to make for one of the ports
+on the coast."
+
+"I think so too."
+
+"Ah!" said the pilot.  "But which one?"
+
+"I know of but one," returned Mr. Fogg tranquilly.
+
+"And that is--"
+
+"Shanghai."
+
+The pilot, at first, did not seem to comprehend; he could scarcely
+realise so much determination and tenacity.  Then he cried, "Well--yes!
+Your honour is right.  To Shanghai!"
+
+So the Tankadere kept steadily on her northward track.
+
+The night was really terrible; it would be a miracle if the craft did
+not founder.  Twice it could have been all over with her if the crew
+had not been constantly on the watch.  Aouda was exhausted, but did not
+utter a complaint.  More than once Mr. Fogg rushed to protect her from
+the violence of the waves.
+
+Day reappeared.  The tempest still raged with undiminished fury; but
+the wind now returned to the south-east.  It was a favourable change,
+and the Tankadere again bounded forward on this mountainous sea, though
+the waves crossed each other, and imparted shocks and counter-shocks
+which would have crushed a craft less solidly built.  From time to time
+the coast was visible through the broken mist, but no vessel was in
+sight.  The Tankadere was alone upon the sea.
+
+There were some signs of a calm at noon, and these became more distinct
+as the sun descended toward the horizon.  The tempest had been as brief
+as terrific.  The passengers, thoroughly exhausted, could now eat a
+little, and take some repose.
+
+The night was comparatively quiet.  Some of the sails were again
+hoisted, and the speed of the boat was very good.  The next morning at
+dawn they espied the coast, and John Bunsby was able to assert that
+they were not one hundred miles from Shanghai.  A hundred miles, and
+only one day to traverse them!  That very evening Mr. Fogg was due at
+Shanghai, if he did not wish to miss the steamer to Yokohama.  Had
+there been no storm, during which several hours were lost, they would
+be at this moment within thirty miles of their destination.
+
+The wind grew decidedly calmer, and happily the sea fell with it.  All
+sails were now hoisted, and at noon the Tankadere was within forty-five
+miles of Shanghai.  There remained yet six hours in which to accomplish
+that distance.  All on board feared that it could not be done, and
+every one--Phileas Fogg, no doubt, excepted--felt his heart beat with
+impatience.  The boat must keep up an average of nine miles an hour,
+and the wind was becoming calmer every moment!  It was a capricious
+breeze, coming from the coast, and after it passed the sea became
+smooth.  Still, the Tankadere was so light, and her fine sails caught
+the fickle zephyrs so well, that, with the aid of the currents John
+Bunsby found himself at six o'clock not more than ten miles from the
+mouth of Shanghai River.  Shanghai itself is situated at least twelve
+miles up the stream.  At seven they were still three miles from
+Shanghai.  The pilot swore an angry oath; the reward of two hundred
+pounds was evidently on the point of escaping him.  He looked at Mr.
+Fogg.  Mr. Fogg was perfectly tranquil; and yet his whole fortune was
+at this moment at stake.
+
+At this moment, also, a long black funnel, crowned with wreaths of
+smoke, appeared on the edge of the waters.  It was the American
+steamer, leaving for Yokohama at the appointed time.
+
+"Confound her!" cried John Bunsby, pushing back the rudder with a
+desperate jerk.
+
+"Signal her!" said Phileas Fogg quietly.
+
+A small brass cannon stood on the forward deck of the Tankadere, for
+making signals in the fogs.  It was loaded to the muzzle; but just as
+the pilot was about to apply a red-hot coal to the touchhole, Mr. Fogg
+said, "Hoist your flag!"
+
+The flag was run up at half-mast, and, this being the signal of
+distress, it was hoped that the American steamer, perceiving it, would
+change her course a little, so as to succour the pilot-boat.
+
+"Fire!" said Mr. Fogg.  And the booming of the little cannon resounded
+in the air.
+
+
+
+
+Chapter XXII
+
+IN WHICH PASSEPARTOUT FINDS OUT THAT, EVEN AT THE ANTIPODES, IT IS
+CONVENIENT TO HAVE SOME MONEY IN ONE'S POCKET
+
+
+The Carnatic, setting sail from Hong Kong at half-past six on the 7th
+of November, directed her course at full steam towards Japan.  She
+carried a large cargo and a well-filled cabin of passengers.  Two
+state-rooms in the rear were, however, unoccupied--those which had been
+engaged by Phileas Fogg.
+
+The next day a passenger with a half-stupefied eye, staggering gait,
+and disordered hair, was seen to emerge from the second cabin, and to
+totter to a seat on deck.
+
+It was Passepartout; and what had happened to him was as follows:
+Shortly after Fix left the opium den, two waiters had lifted the
+unconscious Passepartout, and had carried him to the bed reserved for
+the smokers.  Three hours later, pursued even in his dreams by a fixed
+idea, the poor fellow awoke, and struggled against the stupefying
+influence of the narcotic.  The thought of a duty unfulfilled shook off
+his torpor, and he hurried from the abode of drunkenness.  Staggering
+and holding himself up by keeping against the walls, falling down and
+creeping up again, and irresistibly impelled by a kind of instinct, he
+kept crying out, "The Carnatic! the Carnatic!"
+
+The steamer lay puffing alongside the quay, on the point of starting.
+Passepartout had but few steps to go; and, rushing upon the plank, he
+crossed it, and fell unconscious on the deck, just as the Carnatic was
+moving off.  Several sailors, who were evidently accustomed to this
+sort of scene, carried the poor Frenchman down into the second cabin,
+and Passepartout did not wake until they were one hundred and fifty
+miles away from China.  Thus he found himself the next morning on the
+deck of the Carnatic, and eagerly inhaling the exhilarating sea-breeze.
+The pure air sobered him.  He began to collect his sense, which he
+found a difficult task; but at last he recalled the events of the
+evening before, Fix's revelation, and the opium-house.
+
+"It is evident," said he to himself, "that I have been abominably
+drunk!  What will Mr. Fogg say?  At least I have not missed the
+steamer, which is the most important thing."
+
+Then, as Fix occurred to him: "As for that rascal, I hope we are well
+rid of him, and that he has not dared, as he proposed, to follow us on
+board the Carnatic.  A detective on the track of Mr. Fogg, accused of
+robbing the Bank of England!  Pshaw!  Mr. Fogg is no more a robber than
+I am a murderer."
+
+Should he divulge Fix's real errand to his master?  Would it do to tell
+the part the detective was playing?  Would it not be better to wait
+until Mr. Fogg reached London again, and then impart to him that an
+agent of the metropolitan police had been following him round the
+world, and have a good laugh over it?  No doubt; at least, it was worth
+considering.  The first thing to do was to find Mr. Fogg, and apologise
+for his singular behaviour.
+
+Passepartout got up and proceeded, as well as he could with the rolling
+of the steamer, to the after-deck.  He saw no one who resembled either
+his master or Aouda.  "Good!"  muttered he; "Aouda has not got up yet,
+and Mr. Fogg has probably found some partners at whist."
+
+He descended to the saloon.  Mr. Fogg was not there.  Passepartout had
+only, however, to ask the purser the number of his master's state-room.
+The purser replied that he did not know any passenger by the name of
+Fogg.
+
+"I beg your pardon," said Passepartout persistently.  "He is a tall
+gentleman, quiet, and not very talkative, and has with him a young
+lady--"
+
+"There is no young lady on board," interrupted the purser.  "Here is a
+list of the passengers; you may see for yourself."
+
+Passepartout scanned the list, but his master's name was not upon it.
+All at once an idea struck him.
+
+"Ah! am I on the Carnatic?"
+
+"Yes."
+
+"On the way to Yokohama?"
+
+"Certainly."
+
+Passepartout had for an instant feared that he was on the wrong boat;
+but, though he was really on the Carnatic, his master was not there.
+
+He fell thunderstruck on a seat.  He saw it all now.  He remembered
+that the time of sailing had been changed, that he should have informed
+his master of that fact, and that he had not done so.  It was his
+fault, then, that Mr. Fogg and Aouda had missed the steamer.  Yes, but
+it was still more the fault of the traitor who, in order to separate
+him from his master, and detain the latter at Hong Kong, had inveigled
+him into getting drunk!  He now saw the detective's trick; and at this
+moment Mr. Fogg was certainly ruined, his bet was lost, and he himself
+perhaps arrested and imprisoned!  At this thought Passepartout tore his
+hair.  Ah, if Fix ever came within his reach, what a settling of
+accounts there would be!
+
+After his first depression, Passepartout became calmer, and began to
+study his situation.  It was certainly not an enviable one.  He found
+himself on the way to Japan, and what should he do when he got there?
+His pocket was empty; he had not a solitary shilling, not so much as a
+penny.  His passage had fortunately been paid for in advance; and he
+had five or six days in which to decide upon his future course.  He
+fell to at meals with an appetite, and ate for Mr. Fogg, Aouda, and
+himself.  He helped himself as generously as if Japan were a desert,
+where nothing to eat was to be looked for.
+
+At dawn on the 13th the Carnatic entered the port of Yokohama.  This is
+an important port of call in the Pacific, where all the mail-steamers,
+and those carrying travellers between North America, China, Japan, and
+the Oriental islands put in.  It is situated in the bay of Yeddo, and
+at but a short distance from that second capital of the Japanese
+Empire, and the residence of the Tycoon, the civil Emperor, before the
+Mikado, the spiritual Emperor, absorbed his office in his own.  The
+Carnatic anchored at the quay near the custom-house, in the midst of a
+crowd of ships bearing the flags of all nations.
+
+Passepartout went timidly ashore on this so curious territory of the
+Sons of the Sun.  He had nothing better to do than, taking chance for
+his guide, to wander aimlessly through the streets of Yokohama.  He
+found himself at first in a thoroughly European quarter, the houses
+having low fronts, and being adorned with verandas, beneath which he
+caught glimpses of neat peristyles.  This quarter occupied, with its
+streets, squares, docks, and warehouses, all the space between the
+"promontory of the Treaty" and the river.  Here, as at Hong Kong and
+Calcutta, were mixed crowds of all races, Americans and English,
+Chinamen and Dutchmen, mostly merchants ready to buy or sell anything.
+The Frenchman felt himself as much alone among them as if he had
+dropped down in the midst of Hottentots.
+
+He had, at least, one resource,--to call on the French and English
+consuls at Yokohama for assistance.  But he shrank from telling the
+story of his adventures, intimately connected as it was with that of
+his master; and, before doing so, he determined to exhaust all other
+means of aid.  As chance did not favour him in the European quarter, he
+penetrated that inhabited by the native Japanese, determined, if
+necessary, to push on to Yeddo.
+
+The Japanese quarter of Yokohama is called Benten, after the goddess of
+the sea, who is worshipped on the islands round about.  There
+Passepartout beheld beautiful fir and cedar groves, sacred gates of a
+singular architecture, bridges half hid in the midst of bamboos and
+reeds, temples shaded by immense cedar-trees, holy retreats where were
+sheltered Buddhist priests and sectaries of Confucius, and interminable
+streets, where a perfect harvest of rose-tinted and red-cheeked
+children, who looked as if they had been cut out of Japanese screens,
+and who were playing in the midst of short-legged poodles and yellowish
+cats, might have been gathered.
+
+The streets were crowded with people.  Priests were passing in
+processions, beating their dreary tambourines; police and custom-house
+officers with pointed hats encrusted with lac and carrying two sabres
+hung to their waists; soldiers, clad in blue cotton with white stripes,
+and bearing guns; the Mikado's guards, enveloped in silken doubles,
+hauberks and coats of mail; and numbers of military folk of all
+ranks--for the military profession is as much respected in Japan as it
+is despised in China--went hither and thither in groups and pairs.
+Passepartout saw, too, begging friars, long-robed pilgrims, and simple
+civilians, with their warped and jet-black hair, big heads, long busts,
+slender legs, short stature, and complexions varying from copper-colour
+to a dead white, but never yellow, like the Chinese, from whom the
+Japanese widely differ.  He did not fail to observe the curious
+equipages--carriages and palanquins, barrows supplied with sails, and
+litters made of bamboo; nor the women--whom he thought not especially
+handsome--who took little steps with their little feet, whereon they
+wore canvas shoes, straw sandals, and clogs of worked wood, and who
+displayed tight-looking eyes, flat chests, teeth fashionably blackened,
+and gowns crossed with silken scarfs, tied in an enormous knot behind
+an ornament which the modern Parisian ladies seem to have borrowed from
+the dames of Japan.
+
+Passepartout wandered for several hours in the midst of this motley
+crowd, looking in at the windows of the rich and curious shops, the
+jewellery establishments glittering with quaint Japanese ornaments, the
+restaurants decked with streamers and banners, the tea-houses, where
+the odorous beverage was being drunk with saki, a liquor concocted from
+the fermentation of rice, and the comfortable smoking-houses, where
+they were puffing, not opium, which is almost unknown in Japan, but a
+very fine, stringy tobacco.  He went on till he found himself in the
+fields, in the midst of vast rice plantations.  There he saw dazzling
+camellias expanding themselves, with flowers which were giving forth
+their last colours and perfumes, not on bushes, but on trees, and
+within bamboo enclosures, cherry, plum, and apple trees, which the
+Japanese cultivate rather for their blossoms than their fruit, and
+which queerly-fashioned, grinning scarecrows protected from the
+sparrows, pigeons, ravens, and other voracious birds.  On the branches
+of the cedars were perched large eagles; amid the foliage of the
+weeping willows were herons, solemnly standing on one leg; and on every
+hand were crows, ducks, hawks, wild birds, and a multitude of cranes,
+which the Japanese consider sacred, and which to their minds symbolise
+long life and prosperity.
+
+As he was strolling along, Passepartout espied some violets among the
+shrubs.
+
+"Good!" said he; "I'll have some supper."
+
+But, on smelling them, he found that they were odourless.
+
+"No chance there," thought he.
+
+The worthy fellow had certainly taken good care to eat as hearty a
+breakfast as possible before leaving the Carnatic; but, as he had been
+walking about all day, the demands of hunger were becoming importunate.
+He observed that the butchers stalls contained neither mutton, goat,
+nor pork; and, knowing also that it is a sacrilege to kill cattle,
+which are preserved solely for farming, he made up his mind that meat
+was far from plentiful in Yokohama--nor was he mistaken; and, in
+default of butcher's meat, he could have wished for a quarter of wild
+boar or deer, a partridge, or some quails, some game or fish, which,
+with rice, the Japanese eat almost exclusively.  But he found it
+necessary to keep up a stout heart, and to postpone the meal he craved
+till the following morning.  Night came, and Passepartout re-entered
+the native quarter, where he wandered through the streets, lit by
+vari-coloured lanterns, looking on at the dancers, who were executing
+skilful steps and boundings, and the astrologers who stood in the open
+air with their telescopes.  Then he came to the harbour, which was lit
+up by the resin torches of the fishermen, who were fishing from their
+boats.
+
+The streets at last became quiet, and the patrol, the officers of
+which, in their splendid costumes, and surrounded by their suites,
+Passepartout thought seemed like ambassadors, succeeded the bustling
+crowd.  Each time a company passed, Passepartout chuckled, and said to
+himself: "Good! another Japanese embassy departing for Europe!"
+
+
+
+
+Chapter XXIII
+
+IN WHICH PASSEPARTOUT'S NOSE BECOMES OUTRAGEOUSLY LONG
+
+
+The next morning poor, jaded, famished Passepartout said to himself
+that he must get something to eat at all hazards, and the sooner he did
+so the better.  He might, indeed, sell his watch; but he would have
+starved first.  Now or never he must use the strong, if not melodious
+voice which nature had bestowed upon him.  He knew several French and
+English songs, and resolved to try them upon the Japanese, who must be
+lovers of music, since they were for ever pounding on their cymbals,
+tam-tams, and tambourines, and could not but appreciate European talent.
+
+It was, perhaps, rather early in the morning to get up a concert, and
+the audience prematurely aroused from their slumbers, might not
+possibly pay their entertainer with coin bearing the Mikado's features.
+Passepartout therefore decided to wait several hours; and, as he was
+sauntering along, it occurred to him that he would seem rather too well
+dressed for a wandering artist.  The idea struck him to change his
+garments for clothes more in harmony with his project; by which he
+might also get a little money to satisfy the immediate cravings of
+hunger.  The resolution taken, it remained to carry it out.
+
+It was only after a long search that Passepartout discovered a native
+dealer in old clothes, to whom he applied for an exchange.  The man
+liked the European costume, and ere long Passepartout issued from his
+shop accoutred in an old Japanese coat, and a sort of one-sided turban,
+faded with long use.  A few small pieces of silver, moreover, jingled
+in his pocket.
+
+"Good!" thought he.  "I will imagine I am at the Carnival!"
+
+His first care, after being thus "Japanesed," was to enter a tea-house
+of modest appearance, and, upon half a bird and a little rice, to
+breakfast like a man for whom dinner was as yet a problem to be solved.
+
+"Now," thought he, when he had eaten heartily, "I mustn't lose my head.
+I can't sell this costume again for one still more Japanese.  I must
+consider how to leave this country of the Sun, of which I shall not
+retain the most delightful of memories, as quickly as possible."
+
+It occurred to him to visit the steamers which were about to leave for
+America.  He would offer himself as a cook or servant, in payment of
+his passage and meals.  Once at San Francisco, he would find some means
+of going on.  The difficulty was, how to traverse the four thousand
+seven hundred miles of the Pacific which lay between Japan and the New
+World.
+
+Passepartout was not the man to let an idea go begging, and directed
+his steps towards the docks.  But, as he approached them, his project,
+which at first had seemed so simple, began to grow more and more
+formidable to his mind.  What need would they have of a cook or servant
+on an American steamer, and what confidence would they put in him,
+dressed as he was?  What references could he give?
+
+As he was reflecting in this wise, his eyes fell upon an immense
+placard which a sort of clown was carrying through the streets.  This
+placard, which was in English, read as follows:
+
+          ACROBATIC JAPANESE TROUPE,
+   HONOURABLE WILLIAM BATULCAR, PROPRIETOR,
+           LAST REPRESENTATIONS,
+PRIOR TO THEIR DEPARTURE TO THE UNITED STATES,
+                  OF THE
+        LONG NOSES!   LONG NOSES!
+UNDER THE DIRECT PATRONAGE OF THE GOD TINGOU!
+           GREAT ATTRACTION!
+
+"The United States!" said Passepartout; "that's just what I want!"
+
+He followed the clown, and soon found himself once more in the Japanese
+quarter.  A quarter of an hour later he stopped before a large cabin,
+adorned with several clusters of streamers, the exterior walls of which
+were designed to represent, in violent colours and without perspective,
+a company of jugglers.
+
+This was the Honourable William Batulcar's establishment.  That
+gentleman was a sort of Barnum, the director of a troupe of
+mountebanks, jugglers, clowns, acrobats, equilibrists, and gymnasts,
+who, according to the placard, was giving his last performances before
+leaving the Empire of the Sun for the States of the Union.
+
+Passepartout entered and asked for Mr. Batulcar, who straightway
+appeared in person.
+
+"What do you want?" said he to Passepartout, whom he at first took for
+a native.
+
+"Would you like a servant, sir?" asked Passepartout.
+
+"A servant!" cried Mr. Batulcar, caressing the thick grey beard which
+hung from his chin.  "I already have two who are obedient and faithful,
+have never left me, and serve me for their nourishment and here they
+are," added he, holding out his two robust arms, furrowed with veins as
+large as the strings of a bass-viol.
+
+"So I can be of no use to you?"
+
+"None."
+
+"The devil!  I should so like to cross the Pacific with you!"
+
+"Ah!" said the Honourable Mr. Batulcar.  "You are no more a Japanese
+than I am a monkey!  Who are you dressed up in that way?"
+
+"A man dresses as he can."
+
+"That's true.  You are a Frenchman, aren't you?"
+
+"Yes; a Parisian of Paris."
+
+"Then you ought to know how to make grimaces?"
+
+"Why," replied Passepartout, a little vexed that his nationality should
+cause this question, "we Frenchmen know how to make grimaces, it is
+true but not any better than the Americans do."
+
+"True.  Well, if I can't take you as a servant, I can as a clown.  You
+see, my friend, in France they exhibit foreign clowns, and in foreign
+parts French clowns."
+
+"Ah!"
+
+"You are pretty strong, eh?"
+
+"Especially after a good meal."
+
+"And you can sing?"
+
+"Yes," returned Passepartout, who had formerly been wont to sing in the
+streets.
+
+"But can you sing standing on your head, with a top spinning on your
+left foot, and a sabre balanced on your right?"
+
+"Humph!  I think so," replied Passepartout, recalling the exercises of
+his younger days.
+
+"Well, that's enough," said the Honourable William Batulcar.
+
+The engagement was concluded there and then.
+
+Passepartout had at last found something to do.  He was engaged to act
+in the celebrated Japanese troupe.  It was not a very dignified
+position, but within a week he would be on his way to San Francisco.
+
+The performance, so noisily announced by the Honourable Mr. Batulcar,
+was to commence at three o'clock, and soon the deafening instruments of
+a Japanese orchestra resounded at the door.  Passepartout, though he
+had not been able to study or rehearse a part, was designated to lend
+the aid of his sturdy shoulders in the great exhibition of the "human
+pyramid," executed by the Long Noses of the god Tingou.  This "great
+attraction" was to close the performance.
+
+Before three o'clock the large shed was invaded by the spectators,
+comprising Europeans and natives, Chinese and Japanese, men, women and
+children, who precipitated themselves upon the narrow benches and into
+the boxes opposite the stage.  The musicians took up a position inside,
+and were vigorously performing on their gongs, tam-tams, flutes, bones,
+tambourines, and immense drums.
+
+The performance was much like all acrobatic displays; but it must be
+confessed that the Japanese are the first equilibrists in the world.
+
+One, with a fan and some bits of paper, performed the graceful trick of
+the butterflies and the flowers; another traced in the air, with the
+odorous smoke of his pipe, a series of blue words, which composed a
+compliment to the audience; while a third juggled with some lighted
+candles, which he extinguished successively as they passed his lips,
+and relit again without interrupting for an instant his juggling.
+Another reproduced the most singular combinations with a spinning-top;
+in his hands the revolving tops seemed to be animated with a life of
+their own in their interminable whirling; they ran over pipe-stems, the
+edges of sabres, wires and even hairs stretched across the stage; they
+turned around on the edges of large glasses, crossed bamboo ladders,
+dispersed into all the corners, and produced strange musical effects by
+the combination of their various pitches of tone.  The jugglers tossed
+them in the air, threw them like shuttlecocks with wooden battledores,
+and yet they kept on spinning; they put them into their pockets, and
+took them out still whirling as before.
+
+It is useless to describe the astonishing performances of the acrobats
+and gymnasts.  The turning on ladders, poles, balls, barrels, &c., was
+executed with wonderful precision.
+
+But the principal attraction was the exhibition of the Long Noses, a
+show to which Europe is as yet a stranger.
+
+The Long Noses form a peculiar company, under the direct patronage of
+the god Tingou.  Attired after the fashion of the Middle Ages, they
+bore upon their shoulders a splendid pair of wings; but what especially
+distinguished them was the long noses which were fastened to their
+faces, and the uses which they made of them.  These noses were made of
+bamboo, and were five, six, and even ten feet long, some straight,
+others curved, some ribboned, and some having imitation warts upon
+them.  It was upon these appendages, fixed tightly on their real noses,
+that they performed their gymnastic exercises.  A dozen of these
+sectaries of Tingou lay flat upon their backs, while others, dressed to
+represent lightning-rods, came and frolicked on their noses, jumping
+from one to another, and performing the most skilful leapings and
+somersaults.
+
+As a last scene, a "human pyramid" had been announced, in which fifty
+Long Noses were to represent the Car of Juggernaut.  But, instead of
+forming a pyramid by mounting each other's shoulders, the artists were
+to group themselves on top of the noses.  It happened that the
+performer who had hitherto formed the base of the Car had quitted the
+troupe, and as, to fill this part, only strength and adroitness were
+necessary, Passepartout had been chosen to take his place.
+
+The poor fellow really felt sad when--melancholy reminiscence of his
+youth!--he donned his costume, adorned with vari-coloured wings, and
+fastened to his natural feature a false nose six feet long.  But he
+cheered up when he thought that this nose was winning him something to
+eat.
+
+He went upon the stage, and took his place beside the rest who were to
+compose the base of the Car of Juggernaut.  They all stretched
+themselves on the floor, their noses pointing to the ceiling.  A second
+group of artists disposed themselves on these long appendages, then a
+third above these, then a fourth, until a human monument reaching to
+the very cornices of the theatre soon arose on top of the noses.  This
+elicited loud applause, in the midst of which the orchestra was just
+striking up a deafening air, when the pyramid tottered, the balance was
+lost, one of the lower noses vanished from the pyramid, and the human
+monument was shattered like a castle built of cards!
+
+It was Passepartout's fault.  Abandoning his position, clearing the
+footlights without the aid of his wings, and, clambering up to the
+right-hand gallery, he fell at the feet of one of the spectators,
+crying, "Ah, my master! my master!"
+
+"You here?"
+
+"Myself."
+
+"Very well; then let us go to the steamer, young man!"
+
+Mr. Fogg, Aouda, and Passepartout passed through the lobby of the
+theatre to the outside, where they encountered the Honourable Mr.
+Batulcar, furious with rage.  He demanded damages for the "breakage" of
+the pyramid; and Phileas Fogg appeased him by giving him a handful of
+banknotes.
+
+At half-past six, the very hour of departure, Mr. Fogg and Aouda,
+followed by Passepartout, who in his hurry had retained his wings, and
+nose six feet long, stepped upon the American steamer.
+
+
+
+
+Chapter XXIV
+
+DURING WHICH MR. FOGG AND PARTY CROSS THE PACIFIC OCEAN
+
+
+What happened when the pilot-boat came in sight of Shanghai will be
+easily guessed.  The signals made by the Tankadere had been seen by the
+captain of the Yokohama steamer, who, espying the flag at half-mast,
+had directed his course towards the little craft.  Phileas Fogg, after
+paying the stipulated price of his passage to John Busby, and rewarding
+that worthy with the additional sum of five hundred and fifty pounds,
+ascended the steamer with Aouda and Fix; and they started at once for
+Nagasaki and Yokohama.
+
+They reached their destination on the morning of the 14th of November.
+Phileas Fogg lost no time in going on board the Carnatic, where he
+learned, to Aouda's great delight--and perhaps to his own, though he
+betrayed no emotion--that Passepartout, a Frenchman, had really arrived
+on her the day before.
+
+The San Francisco steamer was announced to leave that very evening, and
+it became necessary to find Passepartout, if possible, without delay.
+Mr. Fogg applied in vain to the French and English consuls, and, after
+wandering through the streets a long time, began to despair of finding
+his missing servant.  Chance, or perhaps a kind of presentiment, at
+last led him into the Honourable Mr. Batulcar's theatre.  He certainly
+would not have recognised Passepartout in the eccentric mountebank's
+costume; but the latter, lying on his back, perceived his master in the
+gallery.  He could not help starting, which so changed the position of
+his nose as to bring the "pyramid" pell-mell upon the stage.
+
+All this Passepartout learned from Aouda, who recounted to him what had
+taken place on the voyage from Hong Kong to Shanghai on the Tankadere,
+in company with one Mr. Fix.
+
+Passepartout did not change countenance on hearing this name.  He
+thought that the time had not yet arrived to divulge to his master what
+had taken place between the detective and himself; and, in the account
+he gave of his absence, he simply excused himself for having been
+overtaken by drunkenness, in smoking opium at a tavern in Hong Kong.
+
+Mr. Fogg heard this narrative coldly, without a word; and then
+furnished his man with funds necessary to obtain clothing more in
+harmony with his position.  Within an hour the Frenchman had cut off
+his nose and parted with his wings, and retained nothing about him
+which recalled the sectary of the god Tingou.
+
+The steamer which was about to depart from Yokohama to San Francisco
+belonged to the Pacific Mail Steamship Company, and was named the
+General Grant.  She was a large paddle-wheel steamer of two thousand
+five hundred tons; well equipped and very fast.  The massive
+walking-beam rose and fell above the deck; at one end a piston-rod
+worked up and down; and at the other was a connecting-rod which, in
+changing the rectilinear motion to a circular one, was directly
+connected with the shaft of the paddles.  The General Grant was rigged
+with three masts, giving a large capacity for sails, and thus
+materially aiding the steam power.  By making twelve miles an hour, she
+would cross the ocean in twenty-one days.  Phileas Fogg was therefore
+justified in hoping that he would reach San Francisco by the 2nd of
+December, New York by the 11th, and London on the 20th--thus gaining
+several hours on the fatal date of the 21st of December.
+
+There was a full complement of passengers on board, among them English,
+many Americans, a large number of coolies on their way to California,
+and several East Indian officers, who were spending their vacation in
+making the tour of the world.  Nothing of moment happened on the
+voyage; the steamer, sustained on its large paddles, rolled but little,
+and the Pacific almost justified its name.  Mr. Fogg was as calm and
+taciturn as ever.  His young companion felt herself more and more
+attached to him by other ties than gratitude; his silent but generous
+nature impressed her more than she thought; and it was almost
+unconsciously that she yielded to emotions which did not seem to have
+the least effect upon her protector.  Aouda took the keenest interest
+in his plans, and became impatient at any incident which seemed likely
+to retard his journey.
+
+She often chatted with Passepartout, who did not fail to perceive the
+state of the lady's heart; and, being the most faithful of domestics,
+he never exhausted his eulogies of Phileas Fogg's honesty, generosity,
+and devotion.  He took pains to calm Aouda's doubts of a successful
+termination of the journey, telling her that the most difficult part of
+it had passed, that now they were beyond the fantastic countries of
+Japan and China, and were fairly on their way to civilised places
+again.  A railway train from San Francisco to New York, and a
+transatlantic steamer from New York to Liverpool, would doubtless bring
+them to the end of this impossible journey round the world within the
+period agreed upon.
+
+On the ninth day after leaving Yokohama, Phileas Fogg had traversed
+exactly one half of the terrestrial globe.  The General Grant passed,
+on the 23rd of November, the one hundred and eightieth meridian, and
+was at the very antipodes of London.  Mr. Fogg had, it is true,
+exhausted fifty-two of the eighty days in which he was to complete the
+tour, and there were only twenty-eight left.  But, though he was only
+half-way by the difference of meridians, he had really gone over
+two-thirds of the whole journey; for he had been obliged to make long
+circuits from London to Aden, from Aden to Bombay, from Calcutta to
+Singapore, and from Singapore to Yokohama.  Could he have followed
+without deviation the fiftieth parallel, which is that of London, the
+whole distance would only have been about twelve thousand miles;
+whereas he would be forced, by the irregular methods of locomotion, to
+traverse twenty-six thousand, of which he had, on the 23rd of November,
+accomplished seventeen thousand five hundred.  And now the course was a
+straight one, and Fix was no longer there to put obstacles in their way!
+
+It happened also, on the 23rd of November, that Passepartout made a
+joyful discovery.  It will be remembered that the obstinate fellow had
+insisted on keeping his famous family watch at London time, and on
+regarding that of the countries he had passed through as quite false
+and unreliable.  Now, on this day, though he had not changed the hands,
+he found that his watch exactly agreed with the ship's chronometers.
+His triumph was hilarious.  He would have liked to know what Fix would
+say if he were aboard!
+
+"The rogue told me a lot of stories," repeated Passepartout, "about the
+meridians, the sun, and the moon!  Moon, indeed!  moonshine more
+likely!  If one listened to that sort of people, a pretty sort of time
+one would keep!  I was sure that the sun would some day regulate itself
+by my watch!"
+
+Passepartout was ignorant that, if the face of his watch had been
+divided into twenty-four hours, like the Italian clocks, he would have
+no reason for exultation; for the hands of his watch would then,
+instead of as now indicating nine o'clock in the morning, indicate nine
+o'clock in the evening, that is, the twenty-first hour after midnight
+precisely the difference between London time and that of the one
+hundred and eightieth meridian.  But if Fix had been able to explain
+this purely physical effect, Passepartout would not have admitted, even
+if he had comprehended it.  Moreover, if the detective had been on
+board at that moment, Passepartout would have joined issue with him on
+a quite different subject, and in an entirely different manner.
+
+Where was Fix at that moment?
+
+He was actually on board the General Grant.
+
+On reaching Yokohama, the detective, leaving Mr. Fogg, whom he expected
+to meet again during the day, had repaired at once to the English
+consulate, where he at last found the warrant of arrest.  It had
+followed him from Bombay, and had come by the Carnatic, on which
+steamer he himself was supposed to be.  Fix's disappointment may be
+imagined when he reflected that the warrant was now useless.  Mr. Fogg
+had left English ground, and it was now necessary to procure his
+extradition!
+
+"Well," thought Fix, after a moment of anger, "my warrant is not good
+here, but it will be in England.  The rogue evidently intends to return
+to his own country, thinking he has thrown the police off his track.
+Good!  I will follow him across the Atlantic.  As for the money, heaven
+grant there may be some left!  But the fellow has already spent in
+travelling, rewards, trials, bail, elephants, and all sorts of charges,
+more than five thousand pounds.  Yet, after all, the Bank is rich!"
+
+His course decided on, he went on board the General Grant, and was
+there when Mr. Fogg and Aouda arrived.  To his utter amazement, he
+recognised Passepartout, despite his theatrical disguise.  He quickly
+concealed himself in his cabin, to avoid an awkward explanation, and
+hoped--thanks to the number of passengers--to remain unperceived by Mr.
+Fogg's servant.
+
+On that very day, however, he met Passepartout face to face on the
+forward deck.  The latter, without a word, made a rush for him, grasped
+him by the throat, and, much to the amusement of a group of Americans,
+who immediately began to bet on him, administered to the detective a
+perfect volley of blows, which proved the great superiority of French
+over English pugilistic skill.
+
+When Passepartout had finished, he found himself relieved and
+comforted.  Fix got up in a somewhat rumpled condition, and, looking at
+his adversary, coldly said, "Have you done?"
+
+"For this time--yes."
+
+"Then let me have a word with you."
+
+"But I--"
+
+"In your master's interests."
+
+Passepartout seemed to be vanquished by Fix's coolness, for he quietly
+followed him, and they sat down aside from the rest of the passengers.
+
+"You have given me a thrashing," said Fix.  "Good, I expected it.  Now,
+listen to me.  Up to this time I have been Mr. Fogg's adversary.  I am
+now in his game."
+
+"Aha!" cried Passepartout; "you are convinced he is an honest man?"
+
+"No," replied Fix coldly, "I think him a rascal.  Sh! don't budge, and
+let me speak.  As long as Mr. Fogg was on English ground, it was for my
+interest to detain him there until my warrant of arrest arrived.  I did
+everything I could to keep him back.  I sent the Bombay priests after
+him, I got you intoxicated at Hong Kong, I separated you from him, and
+I made him miss the Yokohama steamer."
+
+Passepartout listened, with closed fists.
+
+"Now," resumed Fix, "Mr. Fogg seems to be going back to England.  Well,
+I will follow him there.  But hereafter I will do as much to keep
+obstacles out of his way as I have done up to this time to put them in
+his path.  I've changed my game, you see, and simply because it was for
+my interest to change it.  Your interest is the same as mine; for it is
+only in England that you will ascertain whether you are in the service
+of a criminal or an honest man."
+
+Passepartout listened very attentively to Fix, and was convinced that
+he spoke with entire good faith.
+
+"Are we friends?" asked the detective.
+
+"Friends?--no," replied Passepartout; "but allies, perhaps.  At the
+least sign of treason, however, I'll twist your neck for you."
+
+"Agreed," said the detective quietly.
+
+Eleven days later, on the 3rd of December, the General Grant entered
+the bay of the Golden Gate, and reached San Francisco.
+
+Mr. Fogg had neither gained nor lost a single day.
+
+
+
+
+Chapter XXV
+
+IN WHICH A SLIGHT GLIMPSE IS HAD OF SAN FRANCISCO
+
+
+It was seven in the morning when Mr. Fogg, Aouda, and Passepartout set
+foot upon the American continent, if this name can be given to the
+floating quay upon which they disembarked.  These quays, rising and
+falling with the tide, thus facilitate the loading and unloading of
+vessels.  Alongside them were clippers of all sizes, steamers of all
+nationalities, and the steamboats, with several decks rising one above
+the other, which ply on the Sacramento and its tributaries.  There were
+also heaped up the products of a commerce which extends to Mexico,
+Chili, Peru, Brazil, Europe, Asia, and all the Pacific islands.
+
+Passepartout, in his joy on reaching at last the American continent,
+thought he would manifest it by executing a perilous vault in fine
+style; but, tumbling upon some worm-eaten planks, he fell through them.
+Put out of countenance by the manner in which he thus "set foot" upon
+the New World, he uttered a loud cry, which so frightened the
+innumerable cormorants and pelicans that are always perched upon these
+movable quays, that they flew noisily away.
+
+Mr. Fogg, on reaching shore, proceeded to find out at what hour the
+first train left for New York, and learned that this was at six o'clock
+p.m.; he had, therefore, an entire day to spend in the Californian
+capital.  Taking a carriage at a charge of three dollars, he and Aouda
+entered it, while Passepartout mounted the box beside the driver, and
+they set out for the International Hotel.
+
+From his exalted position Passepartout observed with much curiosity the
+wide streets, the low, evenly ranged houses, the Anglo-Saxon Gothic
+churches, the great docks, the palatial wooden and brick warehouses,
+the numerous conveyances, omnibuses, horse-cars, and upon the
+side-walks, not only Americans and Europeans, but Chinese and Indians.
+Passepartout was surprised at all he saw.  San Francisco was no longer
+the legendary city of 1849--a city of banditti, assassins, and
+incendiaries, who had flocked hither in crowds in pursuit of plunder; a
+paradise of outlaws, where they gambled with gold-dust, a revolver in
+one hand and a bowie-knife in the other: it was now a great commercial
+emporium.
+
+The lofty tower of its City Hall overlooked the whole panorama of the
+streets and avenues, which cut each other at right-angles, and in the
+midst of which appeared pleasant, verdant squares, while beyond
+appeared the Chinese quarter, seemingly imported from the Celestial
+Empire in a toy-box.  Sombreros and red shirts and plumed Indians were
+rarely to be seen; but there were silk hats and black coats everywhere
+worn by a multitude of nervously active, gentlemanly-looking men.  Some
+of the streets--especially Montgomery Street, which is to San Francisco
+what Regent Street is to London, the Boulevard des Italiens to Paris,
+and Broadway to New York--were lined with splendid and spacious
+stores, which exposed in their windows the products of the entire world.
+
+When Passepartout reached the International Hotel, it did not seem to
+him as if he had left England at all.
+
+The ground floor of the hotel was occupied by a large bar, a sort of
+restaurant freely open to all passers-by, who might partake of dried
+beef, oyster soup, biscuits, and cheese, without taking out their
+purses.  Payment was made only for the ale, porter, or sherry which was
+drunk.  This seemed "very American" to Passepartout.  The hotel
+refreshment-rooms were comfortable, and Mr. Fogg and Aouda, installing
+themselves at a table, were abundantly served on diminutive plates by
+negroes of darkest hue.
+
+After breakfast, Mr. Fogg, accompanied by Aouda, started for the
+English consulate to have his passport visaed.  As he was going out, he
+met Passepartout, who asked him if it would not be well, before taking
+the train, to purchase some dozens of Enfield rifles and Colt's
+revolvers.  He had been listening to stories of attacks upon the trains
+by the Sioux and Pawnees.  Mr. Fogg thought it a useless precaution,
+but told him to do as he thought best, and went on to the consulate.
+
+He had not proceeded two hundred steps, however, when, "by the greatest
+chance in the world," he met Fix.  The detective seemed wholly taken by
+surprise.  What!  Had Mr. Fogg and himself crossed the Pacific
+together, and not met on the steamer!  At least Fix felt honoured to
+behold once more the gentleman to whom he owed so much, and, as his
+business recalled him to Europe, he should be delighted to continue the
+journey in such pleasant company.
+
+Mr. Fogg replied that the honour would be his; and the detective--who
+was determined not to lose sight of him--begged permission to accompany
+them in their walk about San Francisco--a request which Mr. Fogg
+readily granted.
+
+They soon found themselves in Montgomery Street, where a great crowd
+was collected; the side-walks, street, horsecar rails, the shop-doors,
+the windows of the houses, and even the roofs, were full of people.
+Men were going about carrying large posters, and flags and streamers
+were floating in the wind; while loud cries were heard on every hand.
+
+"Hurrah for Camerfield!"
+
+"Hurrah for Mandiboy!"
+
+It was a political meeting; at least so Fix conjectured, who said to
+Mr. Fogg, "Perhaps we had better not mingle with the crowd.  There may
+be danger in it."
+
+"Yes," returned Mr. Fogg; "and blows, even if they are political are
+still blows."
+
+Fix smiled at this remark; and, in order to be able to see without
+being jostled about, the party took up a position on the top of a
+flight of steps situated at the upper end of Montgomery Street.
+Opposite them, on the other side of the street, between a coal wharf
+and a petroleum warehouse, a large platform had been erected in the
+open air, towards which the current of the crowd seemed to be directed.
+
+For what purpose was this meeting?  What was the occasion of this
+excited assemblage?  Phileas Fogg could not imagine.  Was it to
+nominate some high official--a governor or member of Congress?  It was
+not improbable, so agitated was the multitude before them.
+
+Just at this moment there was an unusual stir in the human mass.  All
+the hands were raised in the air.  Some, tightly closed, seemed to
+disappear suddenly in the midst of the cries--an energetic way, no
+doubt, of casting a vote.  The crowd swayed back, the banners and flags
+wavered, disappeared an instant, then reappeared in tatters.  The
+undulations of the human surge reached the steps, while all the heads
+floundered on the surface like a sea agitated by a squall.  Many of the
+black hats disappeared, and the greater part of the crowd seemed to
+have diminished in height.
+
+"It is evidently a meeting," said Fix, "and its object must be an
+exciting one.  I should not wonder if it were about the Alabama,
+despite the fact that that question is settled."
+
+"Perhaps," replied Mr. Fogg, simply.
+
+"At least, there are two champions in presence of each other, the
+Honourable Mr. Camerfield and the Honourable Mr. Mandiboy."
+
+Aouda, leaning upon Mr. Fogg's arm, observed the tumultuous scene with
+surprise, while Fix asked a man near him what the cause of it all was.
+Before the man could reply, a fresh agitation arose; hurrahs and
+excited shouts were heard; the staffs of the banners began to be used
+as offensive weapons; and fists flew about in every direction.  Thumps
+were exchanged from the tops of the carriages and omnibuses which had
+been blocked up in the crowd.  Boots and shoes went whirling through
+the air, and Mr. Fogg thought he even heard the crack of revolvers
+mingling in the din, the rout approached the stairway, and flowed over
+the lower step.  One of the parties had evidently been repulsed; but
+the mere lookers-on could not tell whether Mandiboy or Camerfield had
+gained the upper hand.
+
+"It would be prudent for us to retire," said Fix, who was anxious that
+Mr. Fogg should not receive any injury, at least until they got back to
+London.  "If there is any question about England in all this, and we
+were recognised, I fear it would go hard with us."
+
+"An English subject--" began Mr. Fogg.
+
+He did not finish his sentence; for a terrific hubbub now arose on the
+terrace behind the flight of steps where they stood, and there were
+frantic shouts of, "Hurrah for Mandiboy!  Hip, hip, hurrah!"
+
+It was a band of voters coming to the rescue of their allies, and
+taking the Camerfield forces in flank.  Mr. Fogg, Aouda, and Fix found
+themselves between two fires; it was too late to escape.  The torrent
+of men, armed with loaded canes and sticks, was irresistible.  Phileas
+Fogg and Fix were roughly hustled in their attempts to protect their
+fair companion; the former, as cool as ever, tried to defend himself
+with the weapons which nature has placed at the end of every
+Englishman's arm, but in vain.  A big brawny fellow with a red beard,
+flushed face, and broad shoulders, who seemed to be the chief of the
+band, raised his clenched fist to strike Mr. Fogg, whom he would have
+given a crushing blow, had not Fix rushed in and received it in his
+stead.  An enormous bruise immediately made its appearance under the
+detective's silk hat, which was completely smashed in.
+
+"Yankee!" exclaimed Mr. Fogg, darting a contemptuous look at the
+ruffian.
+
+"Englishman!" returned the other.  "We will meet again!"
+
+"When you please."
+
+"What is your name?"
+
+"Phileas Fogg.  And yours?"
+
+"Colonel Stamp Proctor."
+
+The human tide now swept by, after overturning Fix, who speedily got
+upon his feet again, though with tattered clothes.  Happily, he was not
+seriously hurt.  His travelling overcoat was divided into two unequal
+parts, and his trousers resembled those of certain Indians, which fit
+less compactly than they are easy to put on.  Aouda had escaped
+unharmed, and Fix alone bore marks of the fray in his black and blue
+bruise.
+
+"Thanks," said Mr. Fogg to the detective, as soon as they were out of
+the crowd.
+
+"No thanks are necessary," replied.  Fix; "but let us go."
+
+"Where?"
+
+"To a tailor's."
+
+Such a visit was, indeed, opportune.  The clothing of both Mr. Fogg and
+Fix was in rags, as if they had themselves been actively engaged in the
+contest between Camerfield and Mandiboy.  An hour after, they were once
+more suitably attired, and with Aouda returned to the International
+Hotel.
+
+Passepartout was waiting for his master, armed with half a dozen
+six-barrelled revolvers.  When he perceived Fix, he knit his brows; but
+Aouda having, in a few words, told him of their adventure, his
+countenance resumed its placid expression.  Fix evidently was no longer
+an enemy, but an ally; he was faithfully keeping his word.
+
+Dinner over, the coach which was to convey the passengers and their
+luggage to the station drew up to the door.  As he was getting in, Mr.
+Fogg said to Fix, "You have not seen this Colonel Proctor again?"
+
+"No."
+
+"I will come back to America to find him," said Phileas Fogg calmly.
+"It would not be right for an Englishman to permit himself to be
+treated in that way, without retaliating."
+
+The detective smiled, but did not reply.  It was clear that Mr. Fogg
+was one of those Englishmen who, while they do not tolerate duelling at
+home, fight abroad when their honour is attacked.
+
+At a quarter before six the travellers reached the station, and found
+the train ready to depart.  As he was about to enter it, Mr. Fogg
+called a porter, and said to him: "My friend, was there not some
+trouble to-day in San Francisco?"
+
+"It was a political meeting, sir," replied the porter.
+
+"But I thought there was a great deal of disturbance in the streets."
+
+"It was only a meeting assembled for an election."
+
+"The election of a general-in-chief, no doubt?" asked Mr. Fogg.
+
+"No, sir; of a justice of the peace."
+
+Phileas Fogg got into the train, which started off at full speed.
+
+
+
+
+Chapter XXVI
+
+IN WHICH PHILEAS FOGG AND PARTY TRAVEL BY THE PACIFIC RAILROAD
+
+
+"From ocean to ocean"--so say the Americans; and these four words
+compose the general designation of the "great trunk line" which crosses
+the entire width of the United States.  The Pacific Railroad is,
+however, really divided into two distinct lines: the Central Pacific,
+between San Francisco and Ogden, and the Union Pacific, between Ogden
+and Omaha.  Five main lines connect Omaha with New York.
+
+New York and San Francisco are thus united by an uninterrupted metal
+ribbon, which measures no less than three thousand seven hundred and
+eighty-six miles.  Between Omaha and the Pacific the railway crosses a
+territory which is still infested by Indians and wild beasts, and a
+large tract which the Mormons, after they were driven from Illinois in
+1845, began to colonise.
+
+The journey from New York to San Francisco consumed, formerly, under
+the most favourable conditions, at least six months.  It is now
+accomplished in seven days.
+
+It was in 1862 that, in spite of the Southern Members of Congress, who
+wished a more southerly route, it was decided to lay the road between
+the forty-first and forty-second parallels.  President Lincoln himself
+fixed the end of the line at Omaha, in Nebraska.  The work was at once
+commenced, and pursued with true American energy; nor did the rapidity
+with which it went on injuriously affect its good execution.  The road
+grew, on the prairies, a mile and a half a day.  A locomotive, running
+on the rails laid down the evening before, brought the rails to be laid
+on the morrow, and advanced upon them as fast as they were put in
+position.
+
+The Pacific Railroad is joined by several branches in Iowa, Kansas,
+Colorado, and Oregon.  On leaving Omaha, it passes along the left bank
+of the Platte River as far as the junction of its northern branch,
+follows its southern branch, crosses the Laramie territory and the
+Wahsatch Mountains, turns the Great Salt Lake, and reaches Salt Lake
+City, the Mormon capital, plunges into the Tuilla Valley, across the
+American Desert, Cedar and Humboldt Mountains, the Sierra Nevada, and
+descends, via Sacramento, to the Pacific--its grade, even on the Rocky
+Mountains, never exceeding one hundred and twelve feet to the mile.
+
+Such was the road to be traversed in seven days, which would enable
+Phileas Fogg--at least, so he hoped--to take the Atlantic steamer at
+New York on the 11th for Liverpool.
+
+The car which he occupied was a sort of long omnibus on eight wheels,
+and with no compartments in the interior.  It was supplied with two
+rows of seats, perpendicular to the direction of the train on either
+side of an aisle which conducted to the front and rear platforms.
+These platforms were found throughout the train, and the passengers
+were able to pass from one end of the train to the other.  It was
+supplied with saloon cars, balcony cars, restaurants, and smoking-cars;
+theatre cars alone were wanting, and they will have these some day.
+
+Book and news dealers, sellers of edibles, drinkables, and cigars, who
+seemed to have plenty of customers, were continually circulating in the
+aisles.
+
+The train left Oakland station at six o'clock.  It was already night,
+cold and cheerless, the heavens being overcast with clouds which seemed
+to threaten snow.  The train did not proceed rapidly; counting the
+stoppages, it did not run more than twenty miles an hour, which was a
+sufficient speed, however, to enable it to reach Omaha within its
+designated time.
+
+There was but little conversation in the car, and soon many of the
+passengers were overcome with sleep.  Passepartout found himself beside
+the detective; but he did not talk to him.  After recent events, their
+relations with each other had grown somewhat cold; there could no
+longer be mutual sympathy or intimacy between them.  Fix's manner had
+not changed; but Passepartout was very reserved, and ready to strangle
+his former friend on the slightest provocation.
+
+Snow began to fall an hour after they started, a fine snow, however,
+which happily could not obstruct the train; nothing could be seen from
+the windows but a vast, white sheet, against which the smoke of the
+locomotive had a greyish aspect.
+
+At eight o'clock a steward entered the car and announced that the time
+for going to bed had arrived; and in a few minutes the car was
+transformed into a dormitory.  The backs of the seats were thrown back,
+bedsteads carefully packed were rolled out by an ingenious system,
+berths were suddenly improvised, and each traveller had soon at his
+disposition a comfortable bed, protected from curious eyes by thick
+curtains.  The sheets were clean and the pillows soft.  It only
+remained to go to bed and sleep which everybody did--while the train
+sped on across the State of California.
+
+The country between San Francisco and Sacramento is not very hilly.
+The Central Pacific, taking Sacramento for its starting-point, extends
+eastward to meet the road from Omaha.  The line from San Francisco to
+Sacramento runs in a north-easterly direction, along the American
+River, which empties into San Pablo Bay.  The one hundred and twenty
+miles between these cities were accomplished in six hours, and towards
+midnight, while fast asleep, the travellers passed through Sacramento;
+so that they saw nothing of that important place, the seat of the State
+government, with its fine quays, its broad streets, its noble hotels,
+squares, and churches.
+
+The train, on leaving Sacramento, and passing the junction, Roclin,
+Auburn, and Colfax, entered the range of the Sierra Nevada.  'Cisco was
+reached at seven in the morning; and an hour later the dormitory was
+transformed into an ordinary car, and the travellers could observe the
+picturesque beauties of the mountain region through which they were
+steaming.  The railway track wound in and out among the passes, now
+approaching the mountain-sides, now suspended over precipices, avoiding
+abrupt angles by bold curves, plunging into narrow defiles, which
+seemed to have no outlet.  The locomotive, its great funnel emitting a
+weird light, with its sharp bell, and its cow-catcher extended like a
+spur, mingled its shrieks and bellowings with the noise of torrents and
+cascades, and twined its smoke among the branches of the gigantic pines.
+
+There were few or no bridges or tunnels on the route.  The railway
+turned around the sides of the mountains, and did not attempt to
+violate nature by taking the shortest cut from one point to another.
+
+The train entered the State of Nevada through the Carson Valley about
+nine o'clock, going always northeasterly; and at midday reached Reno,
+where there was a delay of twenty minutes for breakfast.
+
+From this point the road, running along Humboldt River, passed
+northward for several miles by its banks; then it turned eastward, and
+kept by the river until it reached the Humboldt Range, nearly at the
+extreme eastern limit of Nevada.
+
+Having breakfasted, Mr. Fogg and his companions resumed their places in
+the car, and observed the varied landscape which unfolded itself as
+they passed along the vast prairies, the mountains lining the horizon,
+and the creeks, with their frothy, foaming streams.  Sometimes a great
+herd of buffaloes, massing together in the distance, seemed like a
+moveable dam.  These innumerable multitudes of ruminating beasts often
+form an insurmountable obstacle to the passage of the trains; thousands
+of them have been seen passing over the track for hours together, in
+compact ranks.  The locomotive is then forced to stop and wait till the
+road is once more clear.
+
+This happened, indeed, to the train in which Mr. Fogg was travelling.
+About twelve o'clock a troop of ten or twelve thousand head of buffalo
+encumbered the track.  The locomotive, slackening its speed, tried to
+clear the way with its cow-catcher; but the mass of animals was too
+great.  The buffaloes marched along with a tranquil gait, uttering now
+and then deafening bellowings.  There was no use of interrupting them,
+for, having taken a particular direction, nothing can moderate and
+change their course; it is a torrent of living flesh which no dam could
+contain.
+
+The travellers gazed on this curious spectacle from the platforms; but
+Phileas Fogg, who had the most reason of all to be in a hurry, remained
+in his seat, and waited philosophically until it should please the
+buffaloes to get out of the way.
+
+Passepartout was furious at the delay they occasioned, and longed to
+discharge his arsenal of revolvers upon them.
+
+"What a country!" cried he.  "Mere cattle stop the trains, and go by in
+a procession, just as if they were not impeding travel!  Parbleu!  I
+should like to know if Mr. Fogg foresaw this mishap in his programme!
+And here's an engineer who doesn't dare to run the locomotive into this
+herd of beasts!"
+
+The engineer did not try to overcome the obstacle, and he was wise.  He
+would have crushed the first buffaloes, no doubt, with the cow-catcher;
+but the locomotive, however powerful, would soon have been checked, the
+train would inevitably have been thrown off the track, and would then
+have been helpless.
+
+The best course was to wait patiently, and regain the lost time by
+greater speed when the obstacle was removed.  The procession of
+buffaloes lasted three full hours, and it was night before the track
+was clear.  The last ranks of the herd were now passing over the rails,
+while the first had already disappeared below the southern horizon.
+
+It was eight o'clock when the train passed through the defiles of the
+Humboldt Range, and half-past nine when it penetrated Utah, the region
+of the Great Salt Lake, the singular colony of the Mormons.
+
+
+
+
+Chapter XXVII
+
+IN WHICH PASSEPARTOUT UNDERGOES, AT A SPEED OF TWENTY MILES AN HOUR, A
+COURSE OF MORMON HISTORY
+
+
+During the night of the 5th of December, the train ran south-easterly
+for about fifty miles; then rose an equal distance in a north-easterly
+direction, towards the Great Salt Lake.
+
+Passepartout, about nine o'clock, went out upon the platform to take
+the air.  The weather was cold, the heavens grey, but it was not
+snowing.  The sun's disc, enlarged by the mist, seemed an enormous ring
+of gold, and Passepartout was amusing himself by calculating its value
+in pounds sterling, when he was diverted from this interesting study by
+a strange-looking personage who made his appearance on the platform.
+
+This personage, who had taken the train at Elko, was tall and dark,
+with black moustache, black stockings, a black silk hat, a black
+waistcoat, black trousers, a white cravat, and dogskin gloves.  He
+might have been taken for a clergyman.  He went from one end of the
+train to the other, and affixed to the door of each car a notice
+written in manuscript.
+
+Passepartout approached and read one of these notices, which stated
+that Elder William Hitch, Mormon missionary, taking advantage of his
+presence on train No. 48, would deliver a lecture on Mormonism in car
+No. 117, from eleven to twelve o'clock; and that he invited all who
+were desirous of being instructed concerning the mysteries of the
+religion of the "Latter Day Saints" to attend.
+
+"I'll go," said Passepartout to himself.  He knew nothing of Mormonism
+except the custom of polygamy, which is its foundation.
+
+The news quickly spread through the train, which contained about one
+hundred passengers, thirty of whom, at most, attracted by the notice,
+ensconced themselves in car No. 117.  Passepartout took one of the
+front seats.  Neither Mr. Fogg nor Fix cared to attend.
+
+At the appointed hour Elder William Hitch rose, and, in an irritated
+voice, as if he had already been contradicted, said, "I tell you that
+Joe Smith is a martyr, that his brother Hiram is a martyr, and that the
+persecutions of the United States Government against the prophets will
+also make a martyr of Brigham Young.  Who dares to say the contrary?"
+
+No one ventured to gainsay the missionary, whose excited tone
+contrasted curiously with his naturally calm visage.  No doubt his
+anger arose from the hardships to which the Mormons were actually
+subjected.  The government had just succeeded, with some difficulty, in
+reducing these independent fanatics to its rule.  It had made itself
+master of Utah, and subjected that territory to the laws of the Union,
+after imprisoning Brigham Young on a charge of rebellion and polygamy.
+The disciples of the prophet had since redoubled their efforts, and
+resisted, by words at least, the authority of Congress.  Elder Hitch,
+as is seen, was trying to make proselytes on the very railway trains.
+
+Then, emphasising his words with his loud voice and frequent gestures,
+he related the history of the Mormons from Biblical times: how that, in
+Israel, a Mormon prophet of the tribe of Joseph published the annals of
+the new religion, and bequeathed them to his son Mormon; how, many
+centuries later, a translation of this precious book, which was written
+in Egyptian, was made by Joseph Smith, junior, a Vermont farmer, who
+revealed himself as a mystical prophet in 1825; and how, in short, the
+celestial messenger appeared to him in an illuminated forest, and gave
+him the annals of the Lord.
+
+Several of the audience, not being much interested in the missionary's
+narrative, here left the car; but Elder Hitch, continuing his lecture,
+related how Smith, junior, with his father, two brothers, and a few
+disciples, founded the church of the "Latter Day Saints," which,
+adopted not only in America, but in England, Norway and Sweden, and
+Germany, counts many artisans, as well as men engaged in the liberal
+professions, among its members; how a colony was established in Ohio, a
+temple erected there at a cost of two hundred thousand dollars, and a
+town built at Kirkland; how Smith became an enterprising banker, and
+received from a simple mummy showman a papyrus scroll written by
+Abraham and several famous Egyptians.
+
+The Elder's story became somewhat wearisome, and his audience grew
+gradually less, until it was reduced to twenty passengers.  But this
+did not disconcert the enthusiast, who proceeded with the story of
+Joseph Smith's bankruptcy in 1837, and how his ruined creditors gave
+him a coat of tar and feathers; his reappearance some years afterwards,
+more honourable and honoured than ever, at Independence, Missouri, the
+chief of a flourishing colony of three thousand disciples, and his
+pursuit thence by outraged Gentiles, and retirement into the Far West.
+
+Ten hearers only were now left, among them honest Passepartout, who was
+listening with all his ears.  Thus he learned that, after long
+persecutions, Smith reappeared in Illinois, and in 1839 founded a
+community at Nauvoo, on the Mississippi, numbering twenty-five thousand
+souls, of which he became mayor, chief justice, and general-in-chief;
+that he announced himself, in 1843, as a candidate for the Presidency
+of the United States; and that finally, being drawn into ambuscade at
+Carthage, he was thrown into prison, and assassinated by a band of men
+disguised in masks.
+
+Passepartout was now the only person left in the car, and the Elder,
+looking him full in the face, reminded him that, two years after the
+assassination of Joseph Smith, the inspired prophet, Brigham Young, his
+successor, left Nauvoo for the banks of the Great Salt Lake, where, in
+the midst of that fertile region, directly on the route of the
+emigrants who crossed Utah on their way to California, the new colony,
+thanks to the polygamy practised by the Mormons, had flourished beyond
+expectations.
+
+"And this," added Elder William Hitch, "this is why the jealousy of
+Congress has been aroused against us!  Why have the soldiers of the
+Union invaded the soil of Utah?  Why has Brigham Young, our chief, been
+imprisoned, in contempt of all justice?  Shall we yield to force?
+Never!  Driven from Vermont, driven from Illinois, driven from Ohio,
+driven from Missouri, driven from Utah, we shall yet find some
+independent territory on which to plant our tents.  And you, my
+brother," continued the Elder, fixing his angry eyes upon his single
+auditor, "will you not plant yours there, too, under the shadow of our
+flag?"
+
+"No!" replied Passepartout courageously, in his turn retiring from the
+car, and leaving the Elder to preach to vacancy.
+
+During the lecture the train had been making good progress, and towards
+half-past twelve it reached the northwest border of the Great Salt
+Lake.  Thence the passengers could observe the vast extent of this
+interior sea, which is also called the Dead Sea, and into which flows
+an American Jordan.  It is a picturesque expanse, framed in lofty crags
+in large strata, encrusted with white salt--a superb sheet of water,
+which was formerly of larger extent than now, its shores having
+encroached with the lapse of time, and thus at once reduced its breadth
+and increased its depth.
+
+The Salt Lake, seventy miles long and thirty-five wide, is situated
+three miles eight hundred feet above the sea.  Quite different from
+Lake Asphaltite, whose depression is twelve hundred feet below the sea,
+it contains considerable salt, and one quarter of the weight of its
+water is solid matter, its specific weight being 1,170, and, after
+being distilled, 1,000.  Fishes are, of course, unable to live in it,
+and those which descend through the Jordan, the Weber, and other
+streams soon perish.
+
+The country around the lake was well cultivated, for the Mormons are
+mostly farmers; while ranches and pens for domesticated animals, fields
+of wheat, corn, and other cereals, luxuriant prairies, hedges of wild
+rose, clumps of acacias and milk-wort, would have been seen six months
+later.  Now the ground was covered with a thin powdering of snow.
+
+The train reached Ogden at two o'clock, where it rested for six hours,
+Mr. Fogg and his party had time to pay a visit to Salt Lake City,
+connected with Ogden by a branch road; and they spent two hours in this
+strikingly American town, built on the pattern of other cities of the
+Union, like a checker-board, "with the sombre sadness of right-angles,"
+as Victor Hugo expresses it.  The founder of the City of the Saints
+could not escape from the taste for symmetry which distinguishes the
+Anglo-Saxons.  In this strange country, where the people are certainly
+not up to the level of their institutions, everything is done
+"squarely"--cities, houses, and follies.
+
+The travellers, then, were promenading, at three o'clock, about the
+streets of the town built between the banks of the Jordan and the spurs
+of the Wahsatch Range.  They saw few or no churches, but the prophet's
+mansion, the court-house, and the arsenal, blue-brick houses with
+verandas and porches, surrounded by gardens bordered with acacias,
+palms, and locusts.  A clay and pebble wall, built in 1853, surrounded
+the town; and in the principal street were the market and several
+hotels adorned with pavilions.  The place did not seem thickly
+populated.  The streets were almost deserted, except in the vicinity of
+the temple, which they only reached after having traversed several
+quarters surrounded by palisades.  There were many women, which was
+easily accounted for by the "peculiar institution" of the Mormons; but
+it must not be supposed that all the Mormons are polygamists.  They are
+free to marry or not, as they please; but it is worth noting that it is
+mainly the female citizens of Utah who are anxious to marry, as,
+according to the Mormon religion, maiden ladies are not admitted to the
+possession of its highest joys.  These poor creatures seemed to be
+neither well off nor happy.  Some--the more well-to-do, no doubt--wore
+short, open, black silk dresses, under a hood or modest shawl; others
+were habited in Indian fashion.
+
+Passepartout could not behold without a certain fright these women,
+charged, in groups, with conferring happiness on a single Mormon.  His
+common sense pitied, above all, the husband.  It seemed to him a
+terrible thing to have to guide so many wives at once across the
+vicissitudes of life, and to conduct them, as it were, in a body to the
+Mormon paradise with the prospect of seeing them in the company of the
+glorious Smith, who doubtless was the chief ornament of that delightful
+place, to all eternity.  He felt decidedly repelled from such a
+vocation, and he imagined--perhaps he was mistaken--that the fair ones
+of Salt Lake City cast rather alarming glances on his person.  Happily,
+his stay there was but brief.  At four the party found themselves again
+at the station, took their places in the train, and the whistle sounded
+for starting.  Just at the moment, however, that the locomotive wheels
+began to move, cries of "Stop! stop!" were heard.
+
+Trains, like time and tide, stop for no one.  The gentleman who uttered
+the cries was evidently a belated Mormon.  He was breathless with
+running.  Happily for him, the station had neither gates nor barriers.
+He rushed along the track, jumped on the rear platform of the train,
+and fell, exhausted, into one of the seats.
+
+Passepartout, who had been anxiously watching this amateur gymnast,
+approached him with lively interest, and learned that he had taken
+flight after an unpleasant domestic scene.
+
+When the Mormon had recovered his breath, Passepartout ventured to ask
+him politely how many wives he had; for, from the manner in which he
+had decamped, it might be thought that he had twenty at least.
+
+"One, sir," replied the Mormon, raising his arms heavenward--"one, and
+that was enough!"
+
+
+
+
+Chapter XXVIII
+
+IN WHICH PASSEPARTOUT DOES NOT SUCCEED IN MAKING ANYBODY LISTEN TO
+REASON
+
+
+The train, on leaving Great Salt Lake at Ogden, passed northward for an
+hour as far as Weber River, having completed nearly nine hundred miles
+from San Francisco.  From this point it took an easterly direction
+towards the jagged Wahsatch Mountains.  It was in the section included
+between this range and the Rocky Mountains that the American engineers
+found the most formidable difficulties in laying the road, and that the
+government granted a subsidy of forty-eight thousand dollars per mile,
+instead of sixteen thousand allowed for the work done on the plains.
+But the engineers, instead of violating nature, avoided its
+difficulties by winding around, instead of penetrating the rocks.  One
+tunnel only, fourteen thousand feet in length, was pierced in order to
+arrive at the great basin.
+
+The track up to this time had reached its highest elevation at the
+Great Salt Lake.  From this point it described a long curve, descending
+towards Bitter Creek Valley, to rise again to the dividing ridge of the
+waters between the Atlantic and the Pacific.  There were many creeks in
+this mountainous region, and it was necessary to cross Muddy Creek,
+Green Creek, and others, upon culverts.
+
+Passepartout grew more and more impatient as they went on, while Fix
+longed to get out of this difficult region, and was more anxious than
+Phileas Fogg himself to be beyond the danger of delays and accidents,
+and set foot on English soil.
+
+At ten o'clock at night the train stopped at Fort Bridger station, and
+twenty minutes later entered Wyoming Territory, following the valley of
+Bitter Creek throughout.  The next day, 7th December, they stopped for
+a quarter of an hour at Green River station.  Snow had fallen
+abundantly during the night, but, being mixed with rain, it had half
+melted, and did not interrupt their progress.  The bad weather,
+however, annoyed Passepartout; for the accumulation of snow, by
+blocking the wheels of the cars, would certainly have been fatal to Mr.
+Fogg's tour.
+
+"What an idea!" he said to himself.  "Why did my master make this
+journey in winter?  Couldn't he have waited for the good season to
+increase his chances?"
+
+While the worthy Frenchman was absorbed in the state of the sky and the
+depression of the temperature, Aouda was experiencing fears from a
+totally different cause.
+
+Several passengers had got off at Green River, and were walking up and
+down the platforms; and among these Aouda recognised Colonel Stamp
+Proctor, the same who had so grossly insulted Phileas Fogg at the San
+Francisco meeting.  Not wishing to be recognised, the young woman drew
+back from the window, feeling much alarm at her discovery.  She was
+attached to the man who, however coldly, gave her daily evidences of
+the most absolute devotion.  She did not comprehend, perhaps, the depth
+of the sentiment with which her protector inspired her, which she
+called gratitude, but which, though she was unconscious of it, was
+really more than that.  Her heart sank within her when she recognised
+the man whom Mr. Fogg desired, sooner or later, to call to account for
+his conduct.  Chance alone, it was clear, had brought Colonel Proctor
+on this train; but there he was, and it was necessary, at all hazards,
+that Phileas Fogg should not perceive his adversary.
+
+Aouda seized a moment when Mr. Fogg was asleep to tell Fix and
+Passepartout whom she had seen.
+
+"That Proctor on this train!" cried Fix.  "Well, reassure yourself,
+madam; before he settles with Mr. Fogg; he has got to deal with me!  It
+seems to me that I was the more insulted of the two."
+
+"And, besides," added Passepartout, "I'll take charge of him, colonel
+as he is."
+
+"Mr. Fix," resumed Aouda, "Mr. Fogg will allow no one to avenge him.
+He said that he would come back to America to find this man.  Should he
+perceive Colonel Proctor, we could not prevent a collision which might
+have terrible results.  He must not see him."
+
+"You are right, madam," replied Fix; "a meeting between them might ruin
+all.  Whether he were victorious or beaten, Mr. Fogg would be delayed,
+and--"
+
+"And," added Passepartout, "that would play the game of the gentlemen
+of the Reform Club.  In four days we shall be in New York.  Well, if my
+master does not leave this car during those four days, we may hope that
+chance will not bring him face to face with this confounded American.
+We must, if possible, prevent his stirring out of it."
+
+The conversation dropped.  Mr. Fogg had just woke up, and was looking
+out of the window.  Soon after Passepartout, without being heard by his
+master or Aouda, whispered to the detective, "Would you really fight
+for him?"
+
+"I would do anything," replied Fix, in a tone which betrayed determined
+will, "to get him back living to Europe!"
+
+Passepartout felt something like a shudder shoot through his frame, but
+his confidence in his master remained unbroken.
+
+Was there any means of detaining Mr. Fogg in the car, to avoid a
+meeting between him and the colonel?  It ought not to be a difficult
+task, since that gentleman was naturally sedentary and little curious.
+The detective, at least, seemed to have found a way; for, after a few
+moments, he said to Mr. Fogg, "These are long and slow hours, sir, that
+we are passing on the railway."
+
+"Yes," replied Mr. Fogg; "but they pass."
+
+"You were in the habit of playing whist," resumed Fix, "on the
+steamers."
+
+"Yes; but it would be difficult to do so here.  I have neither cards
+nor partners."
+
+"Oh, but we can easily buy some cards, for they are sold on all the
+American trains.  And as for partners, if madam plays--"
+
+"Certainly, sir," Aouda quickly replied; "I understand whist.  It is
+part of an English education."
+
+"I myself have some pretensions to playing a good game.  Well, here are
+three of us, and a dummy--"
+
+"As you please, sir," replied Phileas Fogg, heartily glad to resume his
+favourite pastime even on the railway.
+
+Passepartout was dispatched in search of the steward, and soon returned
+with two packs of cards, some pins, counters, and a shelf covered with
+cloth.
+
+The game commenced.  Aouda understood whist sufficiently well, and even
+received some compliments on her playing from Mr. Fogg.  As for the
+detective, he was simply an adept, and worthy of being matched against
+his present opponent.
+
+"Now," thought Passepartout, "we've got him.  He won't budge."
+
+At eleven in the morning the train had reached the dividing ridge of
+the waters at Bridger Pass, seven thousand five hundred and twenty-four
+feet above the level of the sea, one of the highest points attained by
+the track in crossing the Rocky Mountains.  After going about two
+hundred miles, the travellers at last found themselves on one of those
+vast plains which extend to the Atlantic, and which nature has made so
+propitious for laying the iron road.
+
+On the declivity of the Atlantic basin the first streams, branches of
+the North Platte River, already appeared.  The whole northern and
+eastern horizon was bounded by the immense semi-circular curtain which
+is formed by the southern portion of the Rocky Mountains, the highest
+being Laramie Peak.  Between this and the railway extended vast plains,
+plentifully irrigated.  On the right rose the lower spurs of the
+mountainous mass which extends southward to the sources of the Arkansas
+River, one of the great tributaries of the Missouri.
+
+At half-past twelve the travellers caught sight for an instant of Fort
+Halleck, which commands that section; and in a few more hours the Rocky
+Mountains were crossed.  There was reason to hope, then, that no
+accident would mark the journey through this difficult country.  The
+snow had ceased falling, and the air became crisp and cold.  Large
+birds, frightened by the locomotive, rose and flew off in the distance.
+No wild beast appeared on the plain.  It was a desert in its vast
+nakedness.
+
+After a comfortable breakfast, served in the car, Mr. Fogg and his
+partners had just resumed whist, when a violent whistling was heard,
+and the train stopped.  Passepartout put his head out of the door, but
+saw nothing to cause the delay; no station was in view.
+
+Aouda and Fix feared that Mr. Fogg might take it into his head to get
+out; but that gentleman contented himself with saying to his servant,
+"See what is the matter."
+
+Passepartout rushed out of the car.  Thirty or forty passengers had
+already descended, amongst them Colonel Stamp Proctor.
+
+The train had stopped before a red signal which blocked the way.  The
+engineer and conductor were talking excitedly with a signal-man, whom
+the station-master at Medicine Bow, the next stopping place, had sent
+on before.  The passengers drew around and took part in the discussion,
+in which Colonel Proctor, with his insolent manner, was conspicuous.
+
+Passepartout, joining the group, heard the signal-man say, "No! you
+can't pass.  The bridge at Medicine Bow is shaky, and would not bear
+the weight of the train."
+
+This was a suspension-bridge thrown over some rapids, about a mile from
+the place where they now were.  According to the signal-man, it was in
+a ruinous condition, several of the iron wires being broken; and it was
+impossible to risk the passage.  He did not in any way exaggerate the
+condition of the bridge.  It may be taken for granted that, rash as the
+Americans usually are, when they are prudent there is good reason for
+it.
+
+Passepartout, not daring to apprise his master of what he heard,
+listened with set teeth, immovable as a statue.
+
+"Hum!" cried Colonel Proctor; "but we are not going to stay here, I
+imagine, and take root in the snow?"
+
+"Colonel," replied the conductor, "we have telegraphed to Omaha for a
+train, but it is not likely that it will reach Medicine Bow in less
+than six hours."
+
+"Six hours!" cried Passepartout.
+
+"Certainly," returned the conductor, "besides, it will take us as long
+as that to reach Medicine Bow on foot."
+
+"But it is only a mile from here," said one of the passengers.
+
+"Yes, but it's on the other side of the river."
+
+"And can't we cross that in a boat?" asked the colonel.
+
+"That's impossible.  The creek is swelled by the rains.  It is a rapid,
+and we shall have to make a circuit of ten miles to the north to find a
+ford."
+
+The colonel launched a volley of oaths, denouncing the railway company
+and the conductor; and Passepartout, who was furious, was not
+disinclined to make common cause with him.  Here was an obstacle,
+indeed, which all his master's banknotes could not remove.
+
+There was a general disappointment among the passengers, who, without
+reckoning the delay, saw themselves compelled to trudge fifteen miles
+over a plain covered with snow.  They grumbled and protested, and would
+certainly have thus attracted Phileas Fogg's attention if he had not
+been completely absorbed in his game.
+
+Passepartout found that he could not avoid telling his master what had
+occurred, and, with hanging head, he was turning towards the car, when
+the engineer, a true Yankee, named Forster called out, "Gentlemen,
+perhaps there is a way, after all, to get over."
+
+"On the bridge?" asked a passenger.
+
+"On the bridge."
+
+"With our train?"
+
+"With our train."
+
+Passepartout stopped short, and eagerly listened to the engineer.
+
+"But the bridge is unsafe," urged the conductor.
+
+"No matter," replied Forster; "I think that by putting on the very
+highest speed we might have a chance of getting over."
+
+"The devil!" muttered Passepartout.
+
+But a number of the passengers were at once attracted by the engineer's
+proposal, and Colonel Proctor was especially delighted, and found the
+plan a very feasible one.  He told stories about engineers leaping
+their trains over rivers without bridges, by putting on full steam; and
+many of those present avowed themselves of the engineer's mind.
+
+"We have fifty chances out of a hundred of getting over," said one.
+
+"Eighty! ninety!"
+
+Passepartout was astounded, and, though ready to attempt anything to
+get over Medicine Creek, thought the experiment proposed a little too
+American.  "Besides," thought he, "there's a still more simple way, and
+it does not even occur to any of these people!  Sir," said he aloud to
+one of the passengers, "the engineer's plan seems to me a little
+dangerous, but--"
+
+"Eighty chances!" replied the passenger, turning his back on him.
+
+"I know it," said Passepartout, turning to another passenger, "but a
+simple idea--"
+
+"Ideas are no use," returned the American, shrugging his shoulders, "as
+the engineer assures us that we can pass."
+
+"Doubtless," urged Passepartout, "we can pass, but perhaps it would be
+more prudent--"
+
+"What!  Prudent!" cried Colonel Proctor, whom this word seemed to
+excite prodigiously.  "At full speed, don't you see, at full speed!"
+
+"I know--I see," repeated Passepartout; "but it would be, if not more
+prudent, since that word displeases you, at least more natural--"
+
+"Who!  What!  What's the matter with this fellow?" cried several.
+
+The poor fellow did not know to whom to address himself.
+
+"Are you afraid?" asked Colonel Proctor.
+
+"I afraid?  Very well; I will show these people that a Frenchman can be
+as American as they!"
+
+"All aboard!" cried the conductor.
+
+"Yes, all aboard!" repeated Passepartout, and immediately.  "But they
+can't prevent me from thinking that it would be more natural for us to
+cross the bridge on foot, and let the train come after!"
+
+But no one heard this sage reflection, nor would anyone have
+acknowledged its justice.  The passengers resumed their places in the
+cars.  Passepartout took his seat without telling what had passed.  The
+whist-players were quite absorbed in their game.
+
+The locomotive whistled vigorously; the engineer, reversing the steam,
+backed the train for nearly a mile--retiring, like a jumper, in order
+to take a longer leap.  Then, with another whistle, he began to move
+forward; the train increased its speed, and soon its rapidity became
+frightful; a prolonged screech issued from the locomotive; the piston
+worked up and down twenty strokes to the second.  They perceived that
+the whole train, rushing on at the rate of a hundred miles an hour,
+hardly bore upon the rails at all.
+
+And they passed over!  It was like a flash.  No one saw the bridge.
+The train leaped, so to speak, from one bank to the other, and the
+engineer could not stop it until it had gone five miles beyond the
+station.  But scarcely had the train passed the river, when the bridge,
+completely ruined, fell with a crash into the rapids of Medicine Bow.
+
+
+
+
+Chapter XXIX
+
+IN WHICH CERTAIN INCIDENTS ARE NARRATED WHICH ARE ONLY TO BE MET WITH
+ON AMERICAN RAILROADS
+
+
+The train pursued its course, that evening, without interruption,
+passing Fort Saunders, crossing Cheyne Pass, and reaching Evans Pass.
+The road here attained the highest elevation of the journey, eight
+thousand and ninety-two feet above the level of the sea.  The
+travellers had now only to descend to the Atlantic by limitless plains,
+levelled by nature.  A branch of the "grand trunk" led off southward to
+Denver, the capital of Colorado.  The country round about is rich in
+gold and silver, and more than fifty thousand inhabitants are already
+settled there.
+
+Thirteen hundred and eighty-two miles had been passed over from San
+Francisco, in three days and three nights; four days and nights more
+would probably bring them to New York.  Phileas Fogg was not as yet
+behind-hand.
+
+During the night Camp Walbach was passed on the left; Lodge Pole Creek
+ran parallel with the road, marking the boundary between the
+territories of Wyoming and Colorado.  They entered Nebraska at eleven,
+passed near Sedgwick, and touched at Julesburg, on the southern branch
+of the Platte River.
+
+It was here that the Union Pacific Railroad was inaugurated on the 23rd
+of October, 1867, by the chief engineer, General Dodge.  Two powerful
+locomotives, carrying nine cars of invited guests, amongst whom was
+Thomas C. Durant, vice-president of the road, stopped at this point;
+cheers were given, the Sioux and Pawnees performed an imitation Indian
+battle, fireworks were let off, and the first number of the Railway
+Pioneer was printed by a press brought on the train.  Thus was
+celebrated the inauguration of this great railroad, a mighty instrument
+of progress and civilisation, thrown across the desert, and destined to
+link together cities and towns which do not yet exist.  The whistle of
+the locomotive, more powerful than Amphion's lyre, was about to bid
+them rise from American soil.
+
+Fort McPherson was left behind at eight in the morning, and three
+hundred and fifty-seven miles had yet to be traversed before reaching
+Omaha.  The road followed the capricious windings of the southern
+branch of the Platte River, on its left bank.  At nine the train
+stopped at the important town of North Platte, built between the two
+arms of the river, which rejoin each other around it and form a single
+artery, a large tributary, whose waters empty into the Missouri a
+little above Omaha.
+
+The one hundred and first meridian was passed.
+
+Mr. Fogg and his partners had resumed their game; no one--not even the
+dummy--complained of the length of the trip.  Fix had begun by winning
+several guineas, which he seemed likely to lose; but he showed himself
+a not less eager whist-player than Mr. Fogg.  During the morning,
+chance distinctly favoured that gentleman.  Trumps and honours were
+showered upon his hands.
+
+Once, having resolved on a bold stroke, he was on the point of playing
+a spade, when a voice behind him said, "I should play a diamond."
+
+Mr. Fogg, Aouda, and Fix raised their heads, and beheld Colonel Proctor.
+
+Stamp Proctor and Phileas Fogg recognised each other at once.
+
+"Ah! it's you, is it, Englishman?" cried the colonel; "it's you who are
+going to play a spade!"
+
+"And who plays it," replied Phileas Fogg coolly, throwing down the ten
+of spades.
+
+"Well, it pleases me to have it diamonds," replied Colonel Proctor, in
+an insolent tone.
+
+He made a movement as if to seize the card which had just been played,
+adding, "You don't understand anything about whist."
+
+"Perhaps I do, as well as another," said Phileas Fogg, rising.
+
+"You have only to try, son of John Bull," replied the colonel.
+
+Aouda turned pale, and her blood ran cold.  She seized Mr. Fogg's arm
+and gently pulled him back.  Passepartout was ready to pounce upon the
+American, who was staring insolently at his opponent.  But Fix got up,
+and, going to Colonel Proctor said, "You forget that it is I with whom
+you have to deal, sir; for it was I whom you not only insulted, but
+struck!"
+
+"Mr. Fix," said Mr. Fogg, "pardon me, but this affair is mine, and mine
+only.  The colonel has again insulted me, by insisting that I should
+not play a spade, and he shall give me satisfaction for it."
+
+"When and where you will," replied the American, "and with whatever
+weapon you choose."
+
+Aouda in vain attempted to retain Mr. Fogg; as vainly did the detective
+endeavour to make the quarrel his.  Passepartout wished to throw the
+colonel out of the window, but a sign from his master checked him.
+Phileas Fogg left the car, and the American followed him upon the
+platform.  "Sir," said Mr. Fogg to his adversary, "I am in a great
+hurry to get back to Europe, and any delay whatever will be greatly to
+my disadvantage."
+
+"Well, what's that to me?" replied Colonel Proctor.
+
+"Sir," said Mr. Fogg, very politely, "after our meeting at San
+Francisco, I determined to return to America and find you as soon as I
+had completed the business which called me to England."
+
+"Really!"
+
+"Will you appoint a meeting for six months hence?"
+
+"Why not ten years hence?"
+
+"I say six months," returned Phileas Fogg; "and I shall be at the place
+of meeting promptly."
+
+"All this is an evasion," cried Stamp Proctor.  "Now or never!"
+
+"Very good.  You are going to New York?"
+
+"No."
+
+"To Chicago?"
+
+"No."
+
+"To Omaha?"
+
+"What difference is it to you?  Do you know Plum Creek?"
+
+"No," replied Mr. Fogg.
+
+"It's the next station.  The train will be there in an hour, and will
+stop there ten minutes.  In ten minutes several revolver-shots could be
+exchanged."
+
+"Very well," said Mr. Fogg.  "I will stop at Plum Creek."
+
+"And I guess you'll stay there too," added the American insolently.
+
+"Who knows?" replied Mr. Fogg, returning to the car as coolly as usual.
+He began to reassure Aouda, telling her that blusterers were never to
+be feared, and begged Fix to be his second at the approaching duel, a
+request which the detective could not refuse.  Mr. Fogg resumed the
+interrupted game with perfect calmness.
+
+At eleven o'clock the locomotive's whistle announced that they were
+approaching Plum Creek station.  Mr. Fogg rose, and, followed by Fix,
+went out upon the platform.  Passepartout accompanied him, carrying a
+pair of revolvers.  Aouda remained in the car, as pale as death.
+
+The door of the next car opened, and Colonel Proctor appeared on the
+platform, attended by a Yankee of his own stamp as his second.  But
+just as the combatants were about to step from the train, the conductor
+hurried up, and shouted, "You can't get off, gentlemen!"
+
+"Why not?" asked the colonel.
+
+"We are twenty minutes late, and we shall not stop."
+
+"But I am going to fight a duel with this gentleman."
+
+"I am sorry," said the conductor; "but we shall be off at once.
+There's the bell ringing now."
+
+The train started.
+
+"I'm really very sorry, gentlemen," said the conductor.  "Under any
+other circumstances I should have been happy to oblige you.  But, after
+all, as you have not had time to fight here, why not fight as we go
+along?"
+
+"That wouldn't be convenient, perhaps, for this gentleman," said the
+colonel, in a jeering tone.
+
+"It would be perfectly so," replied Phileas Fogg.
+
+"Well, we are really in America," thought Passepartout, "and the
+conductor is a gentleman of the first order!"
+
+So muttering, he followed his master.
+
+The two combatants, their seconds, and the conductor passed through the
+cars to the rear of the train.  The last car was only occupied by a
+dozen passengers, whom the conductor politely asked if they would not
+be so kind as to leave it vacant for a few moments, as two gentlemen
+had an affair of honour to settle.  The passengers granted the request
+with alacrity, and straightway disappeared on the platform.
+
+The car, which was some fifty feet long, was very convenient for their
+purpose.  The adversaries might march on each other in the aisle, and
+fire at their ease.  Never was duel more easily arranged.  Mr. Fogg and
+Colonel Proctor, each provided with two six-barrelled revolvers,
+entered the car.  The seconds, remaining outside, shut them in.  They
+were to begin firing at the first whistle of the locomotive.  After an
+interval of two minutes, what remained of the two gentlemen would be
+taken from the car.
+
+Nothing could be more simple.  Indeed, it was all so simple that Fix
+and Passepartout felt their hearts beating as if they would crack.
+They were listening for the whistle agreed upon, when suddenly savage
+cries resounded in the air, accompanied by reports which certainly did
+not issue from the car where the duellists were.  The reports continued
+in front and the whole length of the train.  Cries of terror proceeded
+from the interior of the cars.
+
+Colonel Proctor and Mr. Fogg, revolvers in hand, hastily quitted their
+prison, and rushed forward where the noise was most clamorous.  They
+then perceived that the train was attacked by a band of Sioux.
+
+This was not the first attempt of these daring Indians, for more than
+once they had waylaid trains on the road.  A hundred of them had,
+according to their habit, jumped upon the steps without stopping the
+train, with the ease of a clown mounting a horse at full gallop.
+
+The Sioux were armed with guns, from which came the reports, to which
+the passengers, who were almost all armed, responded by revolver-shots.
+
+The Indians had first mounted the engine, and half stunned the engineer
+and stoker with blows from their muskets.  A Sioux chief, wishing to
+stop the train, but not knowing how to work the regulator, had opened
+wide instead of closing the steam-valve, and the locomotive was
+plunging forward with terrific velocity.
+
+The Sioux had at the same time invaded the cars, skipping like enraged
+monkeys over the roofs, thrusting open the doors, and fighting hand to
+hand with the passengers.  Penetrating the baggage-car, they pillaged
+it, throwing the trunks out of the train.  The cries and shots were
+constant.  The travellers defended themselves bravely; some of the cars
+were barricaded, and sustained a siege, like moving forts, carried
+along at a speed of a hundred miles an hour.
+
+Aouda behaved courageously from the first.  She defended herself like a
+true heroine with a revolver, which she shot through the broken windows
+whenever a savage made his appearance.  Twenty Sioux had fallen
+mortally wounded to the ground, and the wheels crushed those who fell
+upon the rails as if they had been worms.  Several passengers, shot or
+stunned, lay on the seats.
+
+It was necessary to put an end to the struggle, which had lasted for
+ten minutes, and which would result in the triumph of the Sioux if the
+train was not stopped.  Fort Kearney station, where there was a
+garrison, was only two miles distant; but, that once passed, the Sioux
+would be masters of the train between Fort Kearney and the station
+beyond.
+
+The conductor was fighting beside Mr. Fogg, when he was shot and fell.
+At the same moment he cried, "Unless the train is stopped in five
+minutes, we are lost!"
+
+"It shall be stopped," said Phileas Fogg, preparing to rush from the
+car.
+
+"Stay, monsieur," cried Passepartout; "I will go."
+
+Mr. Fogg had not time to stop the brave fellow, who, opening a door
+unperceived by the Indians, succeeded in slipping under the car; and
+while the struggle continued and the balls whizzed across each other
+over his head, he made use of his old acrobatic experience, and with
+amazing agility worked his way under the cars, holding on to the
+chains, aiding himself by the brakes and edges of the sashes, creeping
+from one car to another with marvellous skill, and thus gaining the
+forward end of the train.
+
+There, suspended by one hand between the baggage-car and the tender,
+with the other he loosened the safety chains; but, owing to the
+traction, he would never have succeeded in unscrewing the yoking-bar,
+had not a violent concussion jolted this bar out.  The train, now
+detached from the engine, remained a little behind, whilst the
+locomotive rushed forward with increased speed.
+
+Carried on by the force already acquired, the train still moved for
+several minutes; but the brakes were worked and at last they stopped,
+less than a hundred feet from Kearney station.
+
+The soldiers of the fort, attracted by the shots, hurried up; the Sioux
+had not expected them, and decamped in a body before the train entirely
+stopped.
+
+But when the passengers counted each other on the station platform
+several were found missing; among others the courageous Frenchman,
+whose devotion had just saved them.
+
+
+
+
+Chapter XXX
+
+IN WHICH PHILEAS FOGG SIMPLY DOES HIS DUTY
+
+
+Three passengers including Passepartout had disappeared.  Had they been
+killed in the struggle?  Were they taken prisoners by the Sioux?  It
+was impossible to tell.
+
+There were many wounded, but none mortally.  Colonel Proctor was one of
+the most seriously hurt; he had fought bravely, and a ball had entered
+his groin.  He was carried into the station with the other wounded
+passengers, to receive such attention as could be of avail.
+
+Aouda was safe; and Phileas Fogg, who had been in the thickest of the
+fight, had not received a scratch.  Fix was slightly wounded in the
+arm.  But Passepartout was not to be found, and tears coursed down
+Aouda's cheeks.
+
+All the passengers had got out of the train, the wheels of which were
+stained with blood.  From the tyres and spokes hung ragged pieces of
+flesh.  As far as the eye could reach on the white plain behind, red
+trails were visible.  The last Sioux were disappearing in the south,
+along the banks of Republican River.
+
+Mr. Fogg, with folded arms, remained motionless.  He had a serious
+decision to make.  Aouda, standing near him, looked at him without
+speaking, and he understood her look.  If his servant was a prisoner,
+ought he not to risk everything to rescue him from the Indians?  "I
+will find him, living or dead," said he quietly to Aouda.
+
+"Ah, Mr.--Mr. Fogg!" cried she, clasping his hands and covering them
+with tears.
+
+"Living," added Mr. Fogg, "if we do not lose a moment."
+
+Phileas Fogg, by this resolution, inevitably sacrificed himself; he
+pronounced his own doom.  The delay of a single day would make him lose
+the steamer at New York, and his bet would be certainly lost.  But as
+he thought, "It is my duty," he did not hesitate.
+
+The commanding officer of Fort Kearney was there.  A hundred of his
+soldiers had placed themselves in a position to defend the station,
+should the Sioux attack it.
+
+"Sir," said Mr. Fogg to the captain, "three passengers have
+disappeared."
+
+"Dead?" asked the captain.
+
+"Dead or prisoners; that is the uncertainty which must be solved.  Do
+you propose to pursue the Sioux?"
+
+"That's a serious thing to do, sir," returned the captain.  "These
+Indians may retreat beyond the Arkansas, and I cannot leave the fort
+unprotected."
+
+"The lives of three men are in question, sir," said Phileas Fogg.
+
+"Doubtless; but can I risk the lives of fifty men to save three?"
+
+"I don't know whether you can, sir; but you ought to do so."
+
+"Nobody here," returned the other, "has a right to teach me my duty."
+
+"Very well," said Mr. Fogg, coldly.  "I will go alone."
+
+"You, sir!" cried Fix, coming up; "you go alone in pursuit of the
+Indians?"
+
+"Would you have me leave this poor fellow to perish--him to whom every
+one present owes his life?  I shall go."
+
+"No, sir, you shall not go alone," cried the captain, touched in spite
+of himself.  "No! you are a brave man.  Thirty volunteers!" he added,
+turning to the soldiers.
+
+The whole company started forward at once.  The captain had only to
+pick his men.  Thirty were chosen, and an old sergeant placed at their
+head.
+
+"Thanks, captain," said Mr. Fogg.
+
+"Will you let me go with you?" asked Fix.
+
+"Do as you please, sir.  But if you wish to do me a favour, you will
+remain with Aouda.  In case anything should happen to me--"
+
+A sudden pallor overspread the detective's face.  Separate himself from
+the man whom he had so persistently followed step by step!  Leave him
+to wander about in this desert!  Fix gazed attentively at Mr. Fogg,
+and, despite his suspicions and of the struggle which was going on
+within him, he lowered his eyes before that calm and frank look.
+
+"I will stay," said he.
+
+A few moments after, Mr. Fogg pressed the young woman's hand, and,
+having confided to her his precious carpet-bag, went off with the
+sergeant and his little squad.  But, before going, he had said to the
+soldiers, "My friends, I will divide five thousand dollars among you,
+if we save the prisoners."
+
+It was then a little past noon.
+
+Aouda retired to a waiting-room, and there she waited alone, thinking
+of the simple and noble generosity, the tranquil courage of Phileas
+Fogg.  He had sacrificed his fortune, and was now risking his life, all
+without hesitation, from duty, in silence.
+
+Fix did not have the same thoughts, and could scarcely conceal his
+agitation.  He walked feverishly up and down the platform, but soon
+resumed his outward composure.  He now saw the folly of which he had
+been guilty in letting Fogg go alone.  What!  This man, whom he had
+just followed around the world, was permitted now to separate himself
+from him!  He began to accuse and abuse himself, and, as if he were
+director of police, administered to himself a sound lecture for his
+greenness.
+
+"I have been an idiot!" he thought, "and this man will see it.  He has
+gone, and won't come back!  But how is it that I, Fix, who have in my
+pocket a warrant for his arrest, have been so fascinated by him?
+Decidedly, I am nothing but an ass!"
+
+So reasoned the detective, while the hours crept by all too slowly.  He
+did not know what to do.  Sometimes he was tempted to tell Aouda all;
+but he could not doubt how the young woman would receive his
+confidences.  What course should he take?  He thought of pursuing Fogg
+across the vast white plains; it did not seem impossible that he might
+overtake him.  Footsteps were easily printed on the snow!  But soon,
+under a new sheet, every imprint would be effaced.
+
+Fix became discouraged.  He felt a sort of insurmountable longing to
+abandon the game altogether.  He could now leave Fort Kearney station,
+and pursue his journey homeward in peace.
+
+Towards two o'clock in the afternoon, while it was snowing hard, long
+whistles were heard approaching from the east.  A great shadow,
+preceded by a wild light, slowly advanced, appearing still larger
+through the mist, which gave it a fantastic aspect.  No train was
+expected from the east, neither had there been time for the succour
+asked for by telegraph to arrive; the train from Omaha to San Francisco
+was not due till the next day.  The mystery was soon explained.
+
+The locomotive, which was slowly approaching with deafening whistles,
+was that which, having been detached from the train, had continued its
+route with such terrific rapidity, carrying off the unconscious
+engineer and stoker.  It had run several miles, when, the fire becoming
+low for want of fuel, the steam had slackened; and it had finally
+stopped an hour after, some twenty miles beyond Fort Kearney.  Neither
+the engineer nor the stoker was dead, and, after remaining for some
+time in their swoon, had come to themselves.  The train had then
+stopped.  The engineer, when he found himself in the desert, and the
+locomotive without cars, understood what had happened.  He could not
+imagine how the locomotive had become separated from the train; but he
+did not doubt that the train left behind was in distress.
+
+He did not hesitate what to do.  It would be prudent to continue on to
+Omaha, for it would be dangerous to return to the train, which the
+Indians might still be engaged in pillaging.  Nevertheless, he began to
+rebuild the fire in the furnace; the pressure again mounted, and the
+locomotive returned, running backwards to Fort Kearney.  This it was
+which was whistling in the mist.
+
+The travellers were glad to see the locomotive resume its place at the
+head of the train.  They could now continue the journey so terribly
+interrupted.
+
+Aouda, on seeing the locomotive come up, hurried out of the station,
+and asked the conductor, "Are you going to start?"
+
+"At once, madam."
+
+"But the prisoners, our unfortunate fellow-travellers--"
+
+"I cannot interrupt the trip," replied the conductor.  "We are already
+three hours behind time."
+
+"And when will another train pass here from San Francisco?"
+
+"To-morrow evening, madam."
+
+"To-morrow evening!  But then it will be too late!  We must wait--"
+
+"It is impossible," responded the conductor.  "If you wish to go,
+please get in."
+
+"I will not go," said Aouda.
+
+Fix had heard this conversation.  A little while before, when there was
+no prospect of proceeding on the journey, he had made up his mind to
+leave Fort Kearney; but now that the train was there, ready to start,
+and he had only to take his seat in the car, an irresistible influence
+held him back.  The station platform burned his feet, and he could not
+stir.  The conflict in his mind again began; anger and failure stifled
+him.  He wished to struggle on to the end.
+
+Meanwhile the passengers and some of the wounded, among them Colonel
+Proctor, whose injuries were serious, had taken their places in the
+train.  The buzzing of the over-heated boiler was heard, and the steam
+was escaping from the valves.  The engineer whistled, the train
+started, and soon disappeared, mingling its white smoke with the eddies
+of the densely falling snow.
+
+The detective had remained behind.
+
+Several hours passed.  The weather was dismal, and it was very cold.
+Fix sat motionless on a bench in the station; he might have been
+thought asleep.  Aouda, despite the storm, kept coming out of the
+waiting-room, going to the end of the platform, and peering through the
+tempest of snow, as if to pierce the mist which narrowed the horizon
+around her, and to hear, if possible, some welcome sound.  She heard
+and saw nothing.  Then she would return, chilled through, to issue out
+again after the lapse of a few moments, but always in vain.
+
+Evening came, and the little band had not returned.  Where could they
+be?  Had they found the Indians, and were they having a conflict with
+them, or were they still wandering amid the mist?  The commander of the
+fort was anxious, though he tried to conceal his apprehensions.  As
+night approached, the snow fell less plentifully, but it became
+intensely cold.  Absolute silence rested on the plains.  Neither flight
+of bird nor passing of beast troubled the perfect calm.
+
+Throughout the night Aouda, full of sad forebodings, her heart stifled
+with anguish, wandered about on the verge of the plains.  Her
+imagination carried her far off, and showed her innumerable dangers.
+What she suffered through the long hours it would be impossible to
+describe.
+
+Fix remained stationary in the same place, but did not sleep.  Once a
+man approached and spoke to him, and the detective merely replied by
+shaking his head.
+
+Thus the night passed.  At dawn, the half-extinguished disc of the sun
+rose above a misty horizon; but it was now possible to recognise
+objects two miles off.  Phileas Fogg and the squad had gone southward;
+in the south all was still vacancy.  It was then seven o'clock.
+
+The captain, who was really alarmed, did not know what course to take.
+
+Should he send another detachment to the rescue of the first?  Should
+he sacrifice more men, with so few chances of saving those already
+sacrificed?  His hesitation did not last long, however.  Calling one of
+his lieutenants, he was on the point of ordering a reconnaissance, when
+gunshots were heard.  Was it a signal?  The soldiers rushed out of the
+fort, and half a mile off they perceived a little band returning in
+good order.
+
+Mr. Fogg was marching at their head, and just behind him were
+Passepartout and the other two travellers, rescued from the Sioux.
+
+They had met and fought the Indians ten miles south of Fort Kearney.
+Shortly before the detachment arrived, Passepartout and his companions
+had begun to struggle with their captors, three of whom the Frenchman
+had felled with his fists, when his master and the soldiers hastened up
+to their relief.
+
+All were welcomed with joyful cries.  Phileas Fogg distributed the
+reward he had promised to the soldiers, while Passepartout, not without
+reason, muttered to himself, "It must certainly be confessed that I
+cost my master dear!"
+
+Fix, without saying a word, looked at Mr. Fogg, and it would have been
+difficult to analyse the thoughts which struggled within him.  As for
+Aouda, she took her protector's hand and pressed it in her own, too
+much moved to speak.
+
+Meanwhile, Passepartout was looking about for the train; he thought he
+should find it there, ready to start for Omaha, and he hoped that the
+time lost might be regained.
+
+"The train! the train!" cried he.
+
+"Gone," replied Fix.
+
+"And when does the next train pass here?" said Phileas Fogg.
+
+"Not till this evening."
+
+"Ah!" returned the impassible gentleman quietly.
+
+
+
+
+Chapter XXXI
+
+IN WHICH FIX, THE DETECTIVE, CONSIDERABLY FURTHERS THE INTERESTS OF
+PHILEAS FOGG
+
+
+Phileas Fogg found himself twenty hours behind time.  Passepartout, the
+involuntary cause of this delay, was desperate.  He had ruined his
+master!
+
+At this moment the detective approached Mr. Fogg, and, looking him
+intently in the face, said:
+
+"Seriously, sir, are you in great haste?"
+
+"Quite seriously."
+
+"I have a purpose in asking," resumed Fix.  "Is it absolutely necessary
+that you should be in New York on the 11th, before nine o'clock in the
+evening, the time that the steamer leaves for Liverpool?"
+
+"It is absolutely necessary."
+
+"And, if your journey had not been interrupted by these Indians, you
+would have reached New York on the morning of the 11th?"
+
+"Yes; with eleven hours to spare before the steamer left."
+
+"Good! you are therefore twenty hours behind.  Twelve from twenty
+leaves eight.  You must regain eight hours.  Do you wish to try to do
+so?"
+
+"On foot?" asked Mr. Fogg.
+
+"No; on a sledge," replied Fix.  "On a sledge with sails.  A man has
+proposed such a method to me."
+
+It was the man who had spoken to Fix during the night, and whose offer
+he had refused.
+
+Phileas Fogg did not reply at once; but Fix, having pointed out the
+man, who was walking up and down in front of the station, Mr. Fogg went
+up to him.  An instant after, Mr. Fogg and the American, whose name was
+Mudge, entered a hut built just below the fort.
+
+There Mr. Fogg examined a curious vehicle, a kind of frame on two long
+beams, a little raised in front like the runners of a sledge, and upon
+which there was room for five or six persons.  A high mast was fixed on
+the frame, held firmly by metallic lashings, to which was attached a
+large brigantine sail.  This mast held an iron stay upon which to hoist
+a jib-sail.  Behind, a sort of rudder served to guide the vehicle.  It
+was, in short, a sledge rigged like a sloop.  During the winter, when
+the trains are blocked up by the snow, these sledges make extremely
+rapid journeys across the frozen plains from one station to another.
+Provided with more sails than a cutter, and with the wind behind them,
+they slip over the surface of the prairies with a speed equal if not
+superior to that of the express trains.
+
+Mr. Fogg readily made a bargain with the owner of this land-craft.  The
+wind was favourable, being fresh, and blowing from the west.  The snow
+had hardened, and Mudge was very confident of being able to transport
+Mr. Fogg in a few hours to Omaha.  Thence the trains eastward run
+frequently to Chicago and New York.  It was not impossible that the
+lost time might yet be recovered; and such an opportunity was not to be
+rejected.
+
+Not wishing to expose Aouda to the discomforts of travelling in the
+open air, Mr. Fogg proposed to leave her with Passepartout at Fort
+Kearney, the servant taking upon himself to escort her to Europe by a
+better route and under more favourable conditions.  But Aouda refused
+to separate from Mr. Fogg, and Passepartout was delighted with her
+decision; for nothing could induce him to leave his master while Fix
+was with him.
+
+It would be difficult to guess the detective's thoughts.  Was this
+conviction shaken by Phileas Fogg's return, or did he still regard him
+as an exceedingly shrewd rascal, who, his journey round the world
+completed, would think himself absolutely safe in England?  Perhaps
+Fix's opinion of Phileas Fogg was somewhat modified; but he was
+nevertheless resolved to do his duty, and to hasten the return of the
+whole party to England as much as possible.
+
+At eight o'clock the sledge was ready to start.  The passengers took
+their places on it, and wrapped themselves up closely in their
+travelling-cloaks.  The two great sails were hoisted, and under the
+pressure of the wind the sledge slid over the hardened snow with a
+velocity of forty miles an hour.
+
+The distance between Fort Kearney and Omaha, as the birds fly, is at
+most two hundred miles.  If the wind held good, the distance might be
+traversed in five hours; if no accident happened the sledge might reach
+Omaha by one o'clock.
+
+What a journey!  The travellers, huddled close together, could not
+speak for the cold, intensified by the rapidity at which they were
+going.  The sledge sped on as lightly as a boat over the waves.  When
+the breeze came skimming the earth the sledge seemed to be lifted off
+the ground by its sails.  Mudge, who was at the rudder, kept in a
+straight line, and by a turn of his hand checked the lurches which the
+vehicle had a tendency to make.  All the sails were up, and the jib was
+so arranged as not to screen the brigantine.  A top-mast was hoisted,
+and another jib, held out to the wind, added its force to the other
+sails.  Although the speed could not be exactly estimated, the sledge
+could not be going at less than forty miles an hour.
+
+"If nothing breaks," said Mudge, "we shall get there!"
+
+Mr. Fogg had made it for Mudge's interest to reach Omaha within the
+time agreed on, by the offer of a handsome reward.
+
+The prairie, across which the sledge was moving in a straight line, was
+as flat as a sea.  It seemed like a vast frozen lake.  The railroad
+which ran through this section ascended from the south-west to the
+north-west by Great Island, Columbus, an important Nebraska town,
+Schuyler, and Fremont, to Omaha.  It followed throughout the right bank
+of the Platte River.  The sledge, shortening this route, took a chord
+of the arc described by the railway.  Mudge was not afraid of being
+stopped by the Platte River, because it was frozen.  The road, then,
+was quite clear of obstacles, and Phileas Fogg had but two things to
+fear--an accident to the sledge, and a change or calm in the wind.
+
+But the breeze, far from lessening its force, blew as if to bend the
+mast, which, however, the metallic lashings held firmly.  These
+lashings, like the chords of a stringed instrument, resounded as if
+vibrated by a violin bow.  The sledge slid along in the midst of a
+plaintively intense melody.
+
+"Those chords give the fifth and the octave," said Mr. Fogg.
+
+These were the only words he uttered during the journey.  Aouda, cosily
+packed in furs and cloaks, was sheltered as much as possible from the
+attacks of the freezing wind.  As for Passepartout, his face was as red
+as the sun's disc when it sets in the mist, and he laboriously inhaled
+the biting air.  With his natural buoyancy of spirits, he began to hope
+again.  They would reach New York on the evening, if not on the
+morning, of the 11th, and there was still some chances that it would be
+before the steamer sailed for Liverpool.
+
+Passepartout even felt a strong desire to grasp his ally, Fix, by the
+hand.  He remembered that it was the detective who procured the sledge,
+the only means of reaching Omaha in time; but, checked by some
+presentiment, he kept his usual reserve.  One thing, however,
+Passepartout would never forget, and that was the sacrifice which Mr.
+Fogg had made, without hesitation, to rescue him from the Sioux.  Mr.
+Fogg had risked his fortune and his life. No!  His servant would never
+forget that!
+
+While each of the party was absorbed in reflections so different, the
+sledge flew past over the vast carpet of snow.  The creeks it passed
+over were not perceived.  Fields and streams disappeared under the
+uniform whiteness.  The plain was absolutely deserted.  Between the
+Union Pacific road and the branch which unites Kearney with Saint
+Joseph it formed a great uninhabited island.  Neither village, station,
+nor fort appeared.  From time to time they sped by some phantom-like
+tree, whose white skeleton twisted and rattled in the wind.  Sometimes
+flocks of wild birds rose, or bands of gaunt, famished, ferocious
+prairie-wolves ran howling after the sledge.  Passepartout, revolver in
+hand, held himself ready to fire on those which came too near.  Had an
+accident then happened to the sledge, the travellers, attacked by these
+beasts, would have been in the most terrible danger; but it held on its
+even course, soon gained on the wolves, and ere long left the howling
+band at a safe distance behind.
+
+About noon Mudge perceived by certain landmarks that he was crossing
+the Platte River.  He said nothing, but he felt certain that he was now
+within twenty miles of Omaha.  In less than an hour he left the rudder
+and furled his sails, whilst the sledge, carried forward by the great
+impetus the wind had given it, went on half a mile further with its
+sails unspread.
+
+It stopped at last, and Mudge, pointing to a mass of roofs white with
+snow, said: "We have got there!"
+
+Arrived!  Arrived at the station which is in daily communication, by
+numerous trains, with the Atlantic seaboard!
+
+Passepartout and Fix jumped off, stretched their stiffened limbs, and
+aided Mr. Fogg and the young woman to descend from the sledge.  Phileas
+Fogg generously rewarded Mudge, whose hand Passepartout warmly grasped,
+and the party directed their steps to the Omaha railway station.
+
+The Pacific Railroad proper finds its terminus at this important
+Nebraska town.  Omaha is connected with Chicago by the Chicago and Rock
+Island Railroad, which runs directly east, and passes fifty stations.
+
+A train was ready to start when Mr. Fogg and his party reached the
+station, and they only had time to get into the cars.  They had seen
+nothing of Omaha; but Passepartout confessed to himself that this was
+not to be regretted, as they were not travelling to see the sights.
+
+The train passed rapidly across the State of Iowa, by Council Bluffs,
+Des Moines, and Iowa City.  During the night it crossed the Mississippi
+at Davenport, and by Rock Island entered Illinois.  The next day, which
+was the 10th, at four o'clock in the evening, it reached Chicago,
+already risen from its ruins, and more proudly seated than ever on the
+borders of its beautiful Lake Michigan.
+
+Nine hundred miles separated Chicago from New York; but trains are not
+wanting at Chicago.  Mr. Fogg passed at once from one to the other, and
+the locomotive of the Pittsburgh, Fort Wayne, and Chicago Railway left
+at full speed, as if it fully comprehended that that gentleman had no
+time to lose.  It traversed Indiana, Ohio, Pennsylvania, and New Jersey
+like a flash, rushing through towns with antique names, some of which
+had streets and car-tracks, but as yet no houses.  At last the Hudson
+came into view; and, at a quarter-past eleven in the evening of the
+11th, the train stopped in the station on the right bank of the river,
+before the very pier of the Cunard line.
+
+The China, for Liverpool, had started three-quarters of an hour before!
+
+
+
+
+Chapter XXXII
+
+IN WHICH PHILEAS FOGG ENGAGES IN A DIRECT STRUGGLE WITH BAD FORTUNE
+
+
+The China, in leaving, seemed to have carried off Phileas Fogg's last
+hope.  None of the other steamers were able to serve his projects.  The
+Pereire, of the French Transatlantic Company, whose admirable steamers
+are equal to any in speed and comfort, did not leave until the 14th;
+the Hamburg boats did not go directly to Liverpool or London, but to
+Havre; and the additional trip from Havre to Southampton would render
+Phileas Fogg's last efforts of no avail.  The Inman steamer did not
+depart till the next day, and could not cross the Atlantic in time to
+save the wager.
+
+Mr. Fogg learned all this in consulting his Bradshaw, which gave him
+the daily movements of the trans-Atlantic steamers.
+
+Passepartout was crushed; it overwhelmed him to lose the boat by
+three-quarters of an hour.  It was his fault, for, instead of helping
+his master, he had not ceased putting obstacles in his path!  And when
+he recalled all the incidents of the tour, when he counted up the sums
+expended in pure loss and on his own account, when he thought that the
+immense stake, added to the heavy charges of this useless journey,
+would completely ruin Mr. Fogg, he overwhelmed himself with bitter
+self-accusations.  Mr. Fogg, however, did not reproach him; and, on
+leaving the Cunard pier, only said: "We will consult about what is best
+to-morrow.  Come."
+
+The party crossed the Hudson in the Jersey City ferryboat, and drove in
+a carriage to the St. Nicholas Hotel, on Broadway.  Rooms were engaged,
+and the night passed, briefly to Phileas Fogg, who slept profoundly,
+but very long to Aouda and the others, whose agitation did not permit
+them to rest.
+
+The next day was the 12th of December.  From seven in the morning of
+the 12th to a quarter before nine in the evening of the 21st there were
+nine days, thirteen hours, and forty-five minutes.  If Phileas Fogg had
+left in the China, one of the fastest steamers on the Atlantic, he
+would have reached Liverpool, and then London, within the period agreed
+upon.
+
+Mr. Fogg left the hotel alone, after giving Passepartout instructions
+to await his return, and inform Aouda to be ready at an instant's
+notice.  He proceeded to the banks of the Hudson, and looked about
+among the vessels moored or anchored in the river, for any that were
+about to depart.  Several had departure signals, and were preparing to
+put to sea at morning tide; for in this immense and admirable port
+there is not one day in a hundred that vessels do not set out for every
+quarter of the globe.  But they were mostly sailing vessels, of which,
+of course, Phileas Fogg could make no use.
+
+He seemed about to give up all hope, when he espied, anchored at the
+Battery, a cable's length off at most, a trading vessel, with a screw,
+well-shaped, whose funnel, puffing a cloud of smoke, indicated that she
+was getting ready for departure.
+
+Phileas Fogg hailed a boat, got into it, and soon found himself on
+board the Henrietta, iron-hulled, wood-built above.  He ascended to the
+deck, and asked for the captain, who forthwith presented himself.  He
+was a man of fifty, a sort of sea-wolf, with big eyes, a complexion of
+oxidised copper, red hair and thick neck, and a growling voice.
+
+"The captain?" asked Mr. Fogg.
+
+"I am the captain."
+
+"I am Phileas Fogg, of London."
+
+"And I am Andrew Speedy, of Cardiff."
+
+"You are going to put to sea?"
+
+"In an hour."
+
+"You are bound for--"
+
+"Bordeaux."
+
+"And your cargo?"
+
+"No freight.  Going in ballast."
+
+"Have you any passengers?"
+
+"No passengers.  Never have passengers.  Too much in the way."
+
+"Is your vessel a swift one?"
+
+"Between eleven and twelve knots.  The Henrietta, well known."
+
+"Will you carry me and three other persons to Liverpool?"
+
+"To Liverpool?  Why not to China?"
+
+"I said Liverpool."
+
+"No!"
+
+"No?"
+
+"No.  I am setting out for Bordeaux, and shall go to Bordeaux."
+
+"Money is no object?"
+
+"None."
+
+The captain spoke in a tone which did not admit of a reply.
+
+"But the owners of the Henrietta--" resumed Phileas Fogg.
+
+"The owners are myself," replied the captain.  "The vessel belongs to
+me."
+
+"I will freight it for you."
+
+"No."
+
+"I will buy it of you."
+
+"No."
+
+Phileas Fogg did not betray the least disappointment; but the situation
+was a grave one.  It was not at New York as at Hong Kong, nor with the
+captain of the Henrietta as with the captain of the Tankadere.  Up to
+this time money had smoothed away every obstacle.  Now money failed.
+
+Still, some means must be found to cross the Atlantic on a boat, unless
+by balloon--which would have been venturesome, besides not being
+capable of being put in practice.  It seemed that Phileas Fogg had an
+idea, for he said to the captain, "Well, will you carry me to Bordeaux?"
+
+"No, not if you paid me two hundred dollars."
+
+"I offer you two thousand."
+
+"Apiece?"
+
+"Apiece."
+
+"And there are four of you?"
+
+"Four."
+
+Captain Speedy began to scratch his head.  There were eight thousand
+dollars to gain, without changing his route; for which it was well
+worth conquering the repugnance he had for all kinds of passengers.
+Besides, passengers at two thousand dollars are no longer passengers,
+but valuable merchandise.  "I start at nine o'clock," said Captain
+Speedy, simply.  "Are you and your party ready?"
+
+"We will be on board at nine o'clock," replied, no less simply, Mr.
+Fogg.
+
+It was half-past eight.  To disembark from the Henrietta, jump into a
+hack, hurry to the St. Nicholas, and return with Aouda, Passepartout,
+and even the inseparable Fix was the work of a brief time, and was
+performed by Mr. Fogg with the coolness which never abandoned him.
+They were on board when the Henrietta made ready to weigh anchor.
+
+When Passepartout heard what this last voyage was going to cost, he
+uttered a prolonged "Oh!" which extended throughout his vocal gamut.
+
+As for Fix, he said to himself that the Bank of England would certainly
+not come out of this affair well indemnified.  When they reached
+England, even if Mr. Fogg did not throw some handfuls of bank-bills
+into the sea, more than seven thousand pounds would have been spent!
+
+
+
+
+Chapter XXXIII
+
+IN WHICH PHILEAS FOGG SHOWS HIMSELF EQUAL TO THE OCCASION
+
+
+An hour after, the Henrietta passed the lighthouse which marks the
+entrance of the Hudson, turned the point of Sandy Hook, and put to sea.
+During the day she skirted Long Island, passed Fire Island, and
+directed her course rapidly eastward.
+
+At noon the next day, a man mounted the bridge to ascertain the
+vessel's position.  It might be thought that this was Captain Speedy.
+Not the least in the world.  It was Phileas Fogg, Esquire.  As for
+Captain Speedy, he was shut up in his cabin under lock and key, and was
+uttering loud cries, which signified an anger at once pardonable and
+excessive.
+
+What had happened was very simple.  Phileas Fogg wished to go to
+Liverpool, but the captain would not carry him there.  Then Phileas
+Fogg had taken passage for Bordeaux, and, during the thirty hours he
+had been on board, had so shrewdly managed with his banknotes that the
+sailors and stokers, who were only an occasional crew, and were not on
+the best terms with the captain, went over to him in a body.  This was
+why Phileas Fogg was in command instead of Captain Speedy; why the
+captain was a prisoner in his cabin; and why, in short, the Henrietta
+was directing her course towards Liverpool.  It was very clear, to see
+Mr. Fogg manage the craft, that he had been a sailor.
+
+How the adventure ended will be seen anon.  Aouda was anxious, though
+she said nothing.  As for Passepartout, he thought Mr. Fogg's manoeuvre
+simply glorious.  The captain had said "between eleven and twelve
+knots," and the Henrietta confirmed his prediction.
+
+If, then--for there were "ifs" still--the sea did not become too
+boisterous, if the wind did not veer round to the east, if no accident
+happened to the boat or its machinery, the Henrietta might cross the
+three thousand miles from New York to Liverpool in the nine days,
+between the 12th and the 21st of December.  It is true that, once
+arrived, the affair on board the Henrietta, added to that of the Bank
+of England, might create more difficulties for Mr. Fogg than he
+imagined or could desire.
+
+During the first days, they went along smoothly enough.  The sea was
+not very unpropitious, the wind seemed stationary in the north-east,
+the sails were hoisted, and the Henrietta ploughed across the waves
+like a real trans-Atlantic steamer.
+
+Passepartout was delighted.  His master's last exploit, the
+consequences of which he ignored, enchanted him.  Never had the crew
+seen so jolly and dexterous a fellow.  He formed warm friendships with
+the sailors, and amazed them with his acrobatic feats.  He thought they
+managed the vessel like gentlemen, and that the stokers fired up like
+heroes.  His loquacious good-humour infected everyone.  He had
+forgotten the past, its vexations and delays.  He only thought of the
+end, so nearly accomplished; and sometimes he boiled over with
+impatience, as if heated by the furnaces of the Henrietta.  Often,
+also, the worthy fellow revolved around Fix, looking at him with a
+keen, distrustful eye; but he did not speak to him, for their old
+intimacy no longer existed.
+
+Fix, it must be confessed, understood nothing of what was going on.
+The conquest of the Henrietta, the bribery of the crew, Fogg managing
+the boat like a skilled seaman, amazed and confused him.  He did not
+know what to think.  For, after all, a man who began by stealing
+fifty-five thousand pounds might end by stealing a vessel; and Fix was
+not unnaturally inclined to conclude that the Henrietta under Fogg's
+command, was not going to Liverpool at all, but to some part of the
+world where the robber, turned into a pirate, would quietly put himself
+in safety.  The conjecture was at least a plausible one, and the
+detective began to seriously regret that he had embarked on the affair.
+
+As for Captain Speedy, he continued to howl and growl in his cabin; and
+Passepartout, whose duty it was to carry him his meals, courageous as
+he was, took the greatest precautions.  Mr. Fogg did not seem even to
+know that there was a captain on board.
+
+On the 13th they passed the edge of the Banks of Newfoundland, a
+dangerous locality; during the winter, especially, there are frequent
+fogs and heavy gales of wind.  Ever since the evening before the
+barometer, suddenly falling, had indicated an approaching change in the
+atmosphere; and during the night the temperature varied, the cold
+became sharper, and the wind veered to the south-east.
+
+This was a misfortune.  Mr. Fogg, in order not to deviate from his
+course, furled his sails and increased the force of the steam; but the
+vessel's speed slackened, owing to the state of the sea, the long waves
+of which broke against the stern.  She pitched violently, and this
+retarded her progress.  The breeze little by little swelled into a
+tempest, and it was to be feared that the Henrietta might not be able
+to maintain herself upright on the waves.
+
+Passepartout's visage darkened with the skies, and for two days the
+poor fellow experienced constant fright.  But Phileas Fogg was a bold
+mariner, and knew how to maintain headway against the sea; and he kept
+on his course, without even decreasing his steam.  The Henrietta, when
+she could not rise upon the waves, crossed them, swamping her deck, but
+passing safely.  Sometimes the screw rose out of the water, beating its
+protruding end, when a mountain of water raised the stern above the
+waves; but the craft always kept straight ahead.
+
+The wind, however, did not grow as boisterous as might have been
+feared; it was not one of those tempests which burst, and rush on with
+a speed of ninety miles an hour.  It continued fresh, but, unhappily,
+it remained obstinately in the south-east, rendering the sails useless.
+
+The 16th of December was the seventy-fifth day since Phileas Fogg's
+departure from London, and the Henrietta had not yet been seriously
+delayed.  Half of the voyage was almost accomplished, and the worst
+localities had been passed.  In summer, success would have been
+well-nigh certain.  In winter, they were at the mercy of the bad
+season.  Passepartout said nothing; but he cherished hope in secret,
+and comforted himself with the reflection that, if the wind failed
+them, they might still count on the steam.
+
+On this day the engineer came on deck, went up to Mr. Fogg, and began
+to speak earnestly with him.  Without knowing why it was a
+presentiment, perhaps Passepartout became vaguely uneasy.  He would
+have given one of his ears to hear with the other what the engineer was
+saying.  He finally managed to catch a few words, and was sure he heard
+his master say, "You are certain of what you tell me?"
+
+"Certain, sir," replied the engineer.  "You must remember that, since
+we started, we have kept up hot fires in all our furnaces, and, though
+we had coal enough to go on short steam from New York to Bordeaux, we
+haven't enough to go with all steam from New York to Liverpool." "I
+will consider," replied Mr. Fogg.
+
+Passepartout understood it all; he was seized with mortal anxiety.  The
+coal was giving out!  "Ah, if my master can get over that," muttered
+he, "he'll be a famous man!"  He could not help imparting to Fix what
+he had overheard.
+
+"Then you believe that we really are going to Liverpool?"
+
+"Of course."
+
+"Ass!" replied the detective, shrugging his shoulders and turning on
+his heel.
+
+Passepartout was on the point of vigorously resenting the epithet, the
+reason of which he could not for the life of him comprehend; but he
+reflected that the unfortunate Fix was probably very much disappointed
+and humiliated in his self-esteem, after having so awkwardly followed a
+false scent around the world, and refrained.
+
+And now what course would Phileas Fogg adopt?  It was difficult to
+imagine.  Nevertheless he seemed to have decided upon one, for that
+evening he sent for the engineer, and said to him, "Feed all the fires
+until the coal is exhausted."
+
+A few moments after, the funnel of the Henrietta vomited forth torrents
+of smoke.  The vessel continued to proceed with all steam on; but on
+the 18th, the engineer, as he had predicted, announced that the coal
+would give out in the course of the day.
+
+"Do not let the fires go down," replied Mr. Fogg.  "Keep them up to the
+last.  Let the valves be filled."
+
+Towards noon Phileas Fogg, having ascertained their position, called
+Passepartout, and ordered him to go for Captain Speedy.  It was as if
+the honest fellow had been commanded to unchain a tiger.  He went to
+the poop, saying to himself, "He will be like a madman!"
+
+In a few moments, with cries and oaths, a bomb appeared on the
+poop-deck.  The bomb was Captain Speedy.  It was clear that he was on
+the point of bursting.  "Where are we?"  were the first words his anger
+permitted him to utter.  Had the poor man been an apoplectic, he could
+never have recovered from his paroxysm of wrath.
+
+"Where are we?" he repeated, with purple face.
+
+"Seven hundred and seven miles from Liverpool," replied Mr. Fogg, with
+imperturbable calmness.
+
+"Pirate!" cried Captain Speedy.
+
+"I have sent for you, sir--"
+
+"Pickaroon!"
+
+"--sir," continued Mr. Fogg, "to ask you to sell me your vessel."
+
+"No!  By all the devils, no!"
+
+"But I shall be obliged to burn her."
+
+"Burn the Henrietta!"
+
+"Yes; at least the upper part of her.  The coal has given out."
+
+"Burn my vessel!" cried Captain Speedy, who could scarcely pronounce
+the words.  "A vessel worth fifty thousand dollars!"
+
+"Here are sixty thousand," replied Phileas Fogg, handing the captain a
+roll of bank-bills.  This had a prodigious effect on Andrew Speedy.  An
+American can scarcely remain unmoved at the sight of sixty thousand
+dollars.  The captain forgot in an instant his anger, his imprisonment,
+and all his grudges against his passenger.  The Henrietta was twenty
+years old; it was a great bargain.  The bomb would not go off after
+all.  Mr. Fogg had taken away the match.
+
+"And I shall still have the iron hull," said the captain in a softer
+tone.
+
+"The iron hull and the engine.  Is it agreed?"
+
+"Agreed."
+
+And Andrew Speedy, seizing the banknotes, counted them and consigned
+them to his pocket.
+
+During this colloquy, Passepartout was as white as a sheet, and Fix
+seemed on the point of having an apoplectic fit.  Nearly twenty
+thousand pounds had been expended, and Fogg left the hull and engine to
+the captain, that is, near the whole value of the craft!  It was true,
+however, that fifty-five thousand pounds had been stolen from the Bank.
+
+When Andrew Speedy had pocketed the money, Mr. Fogg said to him, "Don't
+let this astonish you, sir.  You must know that I shall lose twenty
+thousand pounds, unless I arrive in London by a quarter before nine on
+the evening of the 21st of December.  I missed the steamer at New York,
+and as you refused to take me to Liverpool--"
+
+"And I did well!" cried Andrew Speedy; "for I have gained at least
+forty thousand dollars by it!"  He added, more sedately, "Do you know
+one thing, Captain--"
+
+"Fogg."
+
+"Captain Fogg, you've got something of the Yankee about you."
+
+And, having paid his passenger what he considered a high compliment, he
+was going away, when Mr. Fogg said, "The vessel now belongs to me?"
+
+"Certainly, from the keel to the truck of the masts--all the wood, that
+is."
+
+"Very well.  Have the interior seats, bunks, and frames pulled down,
+and burn them."
+
+It was necessary to have dry wood to keep the steam up to the adequate
+pressure, and on that day the poop, cabins, bunks, and the spare deck
+were sacrificed.  On the next day, the 19th of December, the masts,
+rafts, and spars were burned; the crew worked lustily, keeping up the
+fires.  Passepartout hewed, cut, and sawed away with all his might.
+There was a perfect rage for demolition.
+
+The railings, fittings, the greater part of the deck, and top sides
+disappeared on the 20th, and the Henrietta was now only a flat hulk.
+But on this day they sighted the Irish coast and Fastnet Light.  By ten
+in the evening they were passing Queenstown.  Phileas Fogg had only
+twenty-four hours more in which to get to London; that length of time
+was necessary to reach Liverpool, with all steam on.  And the steam was
+about to give out altogether!
+
+"Sir," said Captain Speedy, who was now deeply interested in Mr. Fogg's
+project, "I really commiserate you.  Everything is against you.  We are
+only opposite Queenstown."
+
+"Ah," said Mr. Fogg, "is that place where we see the lights Queenstown?"
+
+"Yes."
+
+"Can we enter the harbour?"
+
+"Not under three hours.  Only at high tide."
+
+"Stay," replied Mr. Fogg calmly, without betraying in his features that
+by a supreme inspiration he was about to attempt once more to conquer
+ill-fortune.
+
+Queenstown is the Irish port at which the trans-Atlantic steamers stop
+to put off the mails.  These mails are carried to Dublin by express
+trains always held in readiness to start; from Dublin they are sent on
+to Liverpool by the most rapid boats, and thus gain twelve hours on the
+Atlantic steamers.
+
+Phileas Fogg counted on gaining twelve hours in the same way.  Instead
+of arriving at Liverpool the next evening by the Henrietta, he would be
+there by noon, and would therefore have time to reach London before a
+quarter before nine in the evening.
+
+The Henrietta entered Queenstown Harbour at one o'clock in the morning,
+it then being high tide; and Phileas Fogg, after being grasped heartily
+by the hand by Captain Speedy, left that gentleman on the levelled hulk
+of his craft, which was still worth half what he had sold it for.
+
+The party went on shore at once.  Fix was greatly tempted to arrest Mr.
+Fogg on the spot; but he did not.  Why?  What struggle was going on
+within him?  Had he changed his mind about "his man"?  Did he
+understand that he had made a grave mistake?  He did not, however,
+abandon Mr. Fogg.  They all got upon the train, which was just ready to
+start, at half-past one; at dawn of day they were in Dublin; and they
+lost no time in embarking on a steamer which, disdaining to rise upon
+the waves, invariably cut through them.
+
+Phileas Fogg at last disembarked on the Liverpool quay, at twenty
+minutes before twelve, 21st December.  He was only six hours distant
+from London.
+
+But at this moment Fix came up, put his hand upon Mr. Fogg's shoulder,
+and, showing his warrant, said, "You are really Phileas Fogg?"
+
+"I am."
+
+"I arrest you in the Queen's name!"
+
+
+
+
+Chapter XXXIV
+
+IN WHICH PHILEAS FOGG AT LAST REACHES LONDON
+
+
+Phileas Fogg was in prison.  He had been shut up in the Custom House,
+and he was to be transferred to London the next day.
+
+Passepartout, when he saw his master arrested, would have fallen upon
+Fix had he not been held back by some policemen.  Aouda was
+thunderstruck at the suddenness of an event which she could not
+understand.  Passepartout explained to her how it was that the honest
+and courageous Fogg was arrested as a robber.  The young woman's heart
+revolted against so heinous a charge, and when she saw that she could
+attempt to do nothing to save her protector, she wept bitterly.
+
+As for Fix, he had arrested Mr. Fogg because it was his duty, whether
+Mr. Fogg were guilty or not.
+
+The thought then struck Passepartout, that he was the cause of this new
+misfortune!  Had he not concealed Fix's errand from his master?  When
+Fix revealed his true character and purpose, why had he not told Mr.
+Fogg?  If the latter had been warned, he would no doubt have given Fix
+proof of his innocence, and satisfied him of his mistake; at least, Fix
+would not have continued his journey at the expense and on the heels of
+his master, only to arrest him the moment he set foot on English soil.
+Passepartout wept till he was blind, and felt like blowing his brains
+out.
+
+Aouda and he had remained, despite the cold, under the portico of the
+Custom House.  Neither wished to leave the place; both were anxious to
+see Mr. Fogg again.
+
+That gentleman was really ruined, and that at the moment when he was
+about to attain his end.  This arrest was fatal.  Having arrived at
+Liverpool at twenty minutes before twelve on the 21st of December, he
+had till a quarter before nine that evening to reach the Reform Club,
+that is, nine hours and a quarter; the journey from Liverpool to London
+was six hours.
+
+If anyone, at this moment, had entered the Custom House, he would have
+found Mr. Fogg seated, motionless, calm, and without apparent anger,
+upon a wooden bench.  He was not, it is true, resigned; but this last
+blow failed to force him into an outward betrayal of any emotion.  Was
+he being devoured by one of those secret rages, all the more terrible
+because contained, and which only burst forth, with an irresistible
+force, at the last moment?  No one could tell.  There he sat, calmly
+waiting--for what?  Did he still cherish hope?  Did he still believe,
+now that the door of this prison was closed upon him, that he would
+succeed?
+
+However that may have been, Mr. Fogg carefully put his watch upon the
+table, and observed its advancing hands.  Not a word escaped his lips,
+but his look was singularly set and stern.  The situation, in any
+event, was a terrible one, and might be thus stated: if Phileas Fogg
+was honest he was ruined; if he was a knave, he was caught.
+
+Did escape occur to him?  Did he examine to see if there were any
+practicable outlet from his prison?  Did he think of escaping from it?
+Possibly; for once he walked slowly around the room.  But the door was
+locked, and the window heavily barred with iron rods.  He sat down
+again, and drew his journal from his pocket.  On the line where these
+words were written, "21st December, Saturday, Liverpool," he added,
+"80th day, 11.40 a.m.," and waited.
+
+The Custom House clock struck one.  Mr. Fogg observed that his watch
+was two hours too fast.
+
+Two hours!  Admitting that he was at this moment taking an express
+train, he could reach London and the Reform Club by a quarter before
+nine, p.m.  His forehead slightly wrinkled.
+
+At thirty-three minutes past two he heard a singular noise outside,
+then a hasty opening of doors.  Passepartout's voice was audible, and
+immediately after that of Fix.  Phileas Fogg's eyes brightened for an
+instant.
+
+The door swung open, and he saw Passepartout, Aouda, and Fix, who
+hurried towards him.
+
+Fix was out of breath, and his hair was in disorder.  He could not
+speak.  "Sir," he stammered, "sir--forgive me--most--unfortunate
+resemblance--robber arrested three days ago--you are free!"
+
+Phileas Fogg was free!  He walked to the detective, looked him steadily
+in the face, and with the only rapid motion he had ever made in his
+life, or which he ever would make, drew back his arms, and with the
+precision of a machine knocked Fix down.
+
+"Well hit!" cried Passepartout, "Parbleu! that's what you might call a
+good application of English fists!"
+
+Fix, who found himself on the floor, did not utter a word.  He had only
+received his deserts.  Mr. Fogg, Aouda, and Passepartout left the
+Custom House without delay, got into a cab, and in a few moments
+descended at the station.
+
+Phileas Fogg asked if there was an express train about to leave for
+London.  It was forty minutes past two.  The express train had left
+thirty-five minutes before.  Phileas Fogg then ordered a special train.
+
+There were several rapid locomotives on hand; but the railway
+arrangements did not permit the special train to leave until three
+o'clock.
+
+At that hour Phileas Fogg, having stimulated the engineer by the offer
+of a generous reward, at last set out towards London with Aouda and his
+faithful servant.
+
+It was necessary to make the journey in five hours and a half; and this
+would have been easy on a clear road throughout.  But there were forced
+delays, and when Mr. Fogg stepped from the train at the terminus, all
+the clocks in London were striking ten minutes before nine.
+
+Having made the tour of the world, he was behind-hand five minutes.  He
+had lost the wager!
+
+
+
+
+Chapter XXXV
+
+IN WHICH PHILEAS FOGG DOES NOT HAVE TO REPEAT HIS ORDERS TO
+PASSEPARTOUT TWICE
+
+
+The dwellers in Saville Row would have been surprised the next day, if
+they had been told that Phileas Fogg had returned home.  His doors and
+windows were still closed, no appearance of change was visible.
+
+After leaving the station, Mr. Fogg gave Passepartout instructions to
+purchase some provisions, and quietly went to his domicile.
+
+He bore his misfortune with his habitual tranquillity.  Ruined!  And by
+the blundering of the detective!  After having steadily traversed that
+long journey, overcome a hundred obstacles, braved many dangers, and
+still found time to do some good on his way, to fail near the goal by a
+sudden event which he could not have foreseen, and against which he was
+unarmed; it was terrible!  But a few pounds were left of the large sum
+he had carried with him.  There only remained of his fortune the twenty
+thousand pounds deposited at Barings, and this amount he owed to his
+friends of the Reform Club.  So great had been the expense of his tour
+that, even had he won, it would not have enriched him; and it is
+probable that he had not sought to enrich himself, being a man who
+rather laid wagers for honour's sake than for the stake proposed.  But
+this wager totally ruined him.
+
+Mr. Fogg's course, however, was fully decided upon; he knew what
+remained for him to do.
+
+A room in the house in Saville Row was set apart for Aouda, who was
+overwhelmed with grief at her protector's misfortune.  From the words
+which Mr. Fogg dropped, she saw that he was meditating some serious
+project.
+
+Knowing that Englishmen governed by a fixed idea sometimes resort to
+the desperate expedient of suicide, Passepartout kept a narrow watch
+upon his master, though he carefully concealed the appearance of so
+doing.
+
+First of all, the worthy fellow had gone up to his room, and had
+extinguished the gas burner, which had been burning for eighty days.
+He had found in the letter-box a bill from the gas company, and he
+thought it more than time to put a stop to this expense, which he had
+been doomed to bear.
+
+The night passed.  Mr. Fogg went to bed, but did he sleep?  Aouda did
+not once close her eyes.  Passepartout watched all night, like a
+faithful dog, at his master's door.
+
+Mr. Fogg called him in the morning, and told him to get Aouda's
+breakfast, and a cup of tea and a chop for himself.  He desired Aouda
+to excuse him from breakfast and dinner, as his time would be absorbed
+all day in putting his affairs to rights.  In the evening he would ask
+permission to have a few moment's conversation with the young lady.
+
+Passepartout, having received his orders, had nothing to do but obey
+them.  He looked at his imperturbable master, and could scarcely bring
+his mind to leave him.  His heart was full, and his conscience tortured
+by remorse; for he accused himself more bitterly than ever of being the
+cause of the irretrievable disaster.  Yes! if he had warned Mr. Fogg,
+and had betrayed Fix's projects to him, his master would certainly not
+have given the detective passage to Liverpool, and then--
+
+Passepartout could hold in no longer.
+
+"My master!  Mr. Fogg!" he cried, "why do you not curse me?  It was my
+fault that--"
+
+"I blame no one," returned Phileas Fogg, with perfect calmness.  "Go!"
+
+Passepartout left the room, and went to find Aouda, to whom he
+delivered his master's message.
+
+"Madam," he added, "I can do nothing myself--nothing!  I have no
+influence over my master; but you, perhaps--"
+
+"What influence could I have?" replied Aouda.  "Mr. Fogg is influenced
+by no one.  Has he ever understood that my gratitude to him is
+overflowing?  Has he ever read my heart?  My friend, he must not be
+left alone an instant!  You say he is going to speak with me this
+evening?"
+
+"Yes, madam; probably to arrange for your protection and comfort in
+England."
+
+"We shall see," replied Aouda, becoming suddenly pensive.
+
+Throughout this day (Sunday) the house in Saville Row was as if
+uninhabited, and Phileas Fogg, for the first time since he had lived in
+that house, did not set out for his club when Westminster clock struck
+half-past eleven.
+
+Why should he present himself at the Reform?  His friends no longer
+expected him there.  As Phileas Fogg had not appeared in the saloon on
+the evening before (Saturday, the 21st of December, at a quarter before
+nine), he had lost his wager.  It was not even necessary that he should
+go to his bankers for the twenty thousand pounds; for his antagonists
+already had his cheque in their hands, and they had only to fill it out
+and send it to the Barings to have the amount transferred to their
+credit.
+
+Mr. Fogg, therefore, had no reason for going out, and so he remained at
+home.  He shut himself up in his room, and busied himself putting his
+affairs in order.  Passepartout continually ascended and descended the
+stairs.  The hours were long for him. He listened at his master's door,
+and looked through the keyhole, as if he had a perfect right so to do,
+and as if he feared that something terrible might happen at any moment.
+Sometimes he thought of Fix, but no longer in anger.  Fix, like all the
+world, had been mistaken in Phileas Fogg, and had only done his duty in
+tracking and arresting him; while he, Passepartout. . . .  This thought
+haunted him, and he never ceased cursing his miserable folly.
+
+Finding himself too wretched to remain alone, he knocked at Aouda's
+door, went into her room, seated himself, without speaking, in a
+corner, and looked ruefully at the young woman. Aouda was still pensive.
+
+About half-past seven in the evening Mr. Fogg sent to know if Aouda
+would receive him, and in a few moments he found himself alone with her.
+
+Phileas Fogg took a chair, and sat down near the fireplace, opposite
+Aouda.  No emotion was visible on his face.  Fogg returned was exactly
+the Fogg who had gone away; there was the same calm, the same
+impassibility.
+
+He sat several minutes without speaking; then, bending his eyes on
+Aouda, "Madam," said he, "will you pardon me for bringing you to
+England?"
+
+"I, Mr. Fogg!" replied Aouda, checking the pulsations of her heart.
+
+"Please let me finish," returned Mr. Fogg.  "When I decided to bring
+you far away from the country which was so unsafe for you, I was rich,
+and counted on putting a portion of my fortune at your disposal; then
+your existence would have been free and happy.  But now I am ruined."
+
+"I know it, Mr. Fogg," replied Aouda; "and I ask you in my turn, will
+you forgive me for having followed you, and--who knows?--for having,
+perhaps, delayed you, and thus contributed to your ruin?"
+
+"Madam, you could not remain in India, and your safety could only be
+assured by bringing you to such a distance that your persecutors could
+not take you."
+
+"So, Mr. Fogg," resumed Aouda, "not content with rescuing me from a
+terrible death, you thought yourself bound to secure my comfort in a
+foreign land?"
+
+"Yes, madam; but circumstances have been against me.  Still, I beg to
+place the little I have left at your service."
+
+"But what will become of you, Mr. Fogg?"
+
+"As for me, madam," replied the gentleman, coldly, "I have need of
+nothing."
+
+"But how do you look upon the fate, sir, which awaits you?"
+
+"As I am in the habit of doing."
+
+"At least," said Aouda, "want should not overtake a man like you.  Your
+friends--"
+
+"I have no friends, madam."
+
+"Your relatives--"
+
+"I have no longer any relatives."
+
+"I pity you, then, Mr. Fogg, for solitude is a sad thing, with no heart
+to which to confide your griefs.  They say, though, that misery itself,
+shared by two sympathetic souls, may be borne with patience."
+
+"They say so, madam."
+
+"Mr. Fogg," said Aouda, rising and seizing his hand, "do you wish at
+once a kinswoman and friend?  Will you have me for your wife?"
+
+Mr. Fogg, at this, rose in his turn.  There was an unwonted light in
+his eyes, and a slight trembling of his lips.  Aouda looked into his
+face.  The sincerity, rectitude, firmness, and sweetness of this soft
+glance of a noble woman, who could dare all to save him to whom she
+owed all, at first astonished, then penetrated him.  He shut his eyes
+for an instant, as if to avoid her look.  When he opened them again, "I
+love you!" he said, simply.  "Yes, by all that is holiest, I love you,
+and I am entirely yours!"
+
+"Ah!" cried Aouda, pressing his hand to her heart.
+
+Passepartout was summoned and appeared immediately.  Mr. Fogg still
+held Aouda's hand in his own; Passepartout understood, and his big,
+round face became as radiant as the tropical sun at its zenith.
+
+Mr. Fogg asked him if it was not too late to notify the Reverend Samuel
+Wilson, of Marylebone parish, that evening.
+
+Passepartout smiled his most genial smile, and said, "Never too late."
+
+It was five minutes past eight.
+
+"Will it be for to-morrow, Monday?"
+
+"For to-morrow, Monday," said Mr. Fogg, turning to Aouda.
+
+"Yes; for to-morrow, Monday," she replied.
+
+Passepartout hurried off as fast as his legs could carry him.
+
+
+
+
+Chapter XXXVI
+
+IN WHICH PHILEAS FOGG'S NAME IS ONCE MORE AT A PREMIUM ON 'CHANGE
+
+
+It is time to relate what a change took place in English public opinion
+when it transpired that the real bankrobber, a certain James Strand,
+had been arrested, on the 17th day of December, at Edinburgh.  Three
+days before, Phileas Fogg had been a criminal, who was being
+desperately followed up by the police; now he was an honourable
+gentleman, mathematically pursuing his eccentric journey round the
+world.
+
+The papers resumed their discussion about the wager; all those who had
+laid bets, for or against him, revived their interest, as if by magic;
+the "Phileas Fogg bonds" again became negotiable, and many new wagers
+were made.  Phileas Fogg's name was once more at a premium on 'Change.
+
+His five friends of the Reform Club passed these three days in a state
+of feverish suspense.  Would Phileas Fogg, whom they had forgotten,
+reappear before their eyes!  Where was he at this moment?  The 17th of
+December, the day of James Strand's arrest, was the seventy-sixth since
+Phileas Fogg's departure, and no news of him had been received.  Was he
+dead?  Had he abandoned the effort, or was he continuing his journey
+along the route agreed upon?  And would he appear on Saturday, the 21st
+of December, at a quarter before nine in the evening, on the threshold
+of the Reform Club saloon?
+
+The anxiety in which, for three days, London society existed, cannot be
+described.  Telegrams were sent to America and Asia for news of Phileas
+Fogg.  Messengers were dispatched to the house in Saville Row morning
+and evening.  No news.  The police were ignorant what had become of the
+detective, Fix, who had so unfortunately followed up a false scent.
+Bets increased, nevertheless, in number and value.  Phileas Fogg, like
+a racehorse, was drawing near his last turning-point.  The bonds were
+quoted, no longer at a hundred below par, but at twenty, at ten, and at
+five; and paralytic old Lord Albemarle bet even in his favour.
+
+A great crowd was collected in Pall Mall and the neighbouring streets
+on Saturday evening; it seemed like a multitude of brokers permanently
+established around the Reform Club.  Circulation was impeded, and
+everywhere disputes, discussions, and financial transactions were going
+on.  The police had great difficulty in keeping back the crowd, and as
+the hour when Phileas Fogg was due approached, the excitement rose to
+its highest pitch.
+
+The five antagonists of Phileas Fogg had met in the great saloon of the
+club.  John Sullivan and Samuel Fallentin, the bankers, Andrew Stuart,
+the engineer, Gauthier Ralph, the director of the Bank of England, and
+Thomas Flanagan, the brewer, one and all waited anxiously.
+
+When the clock indicated twenty minutes past eight, Andrew Stuart got
+up, saying, "Gentlemen, in twenty minutes the time agreed upon between
+Mr. Fogg and ourselves will have expired."
+
+"What time did the last train arrive from Liverpool?"  asked Thomas
+Flanagan.
+
+"At twenty-three minutes past seven," replied Gauthier Ralph; "and the
+next does not arrive till ten minutes after twelve."
+
+"Well, gentlemen," resumed Andrew Stuart, "if Phileas Fogg had come in
+the 7:23 train, he would have got here by this time.  We can,
+therefore, regard the bet as won."
+
+"Wait; don't let us be too hasty," replied Samuel Fallentin.  "You know
+that Mr. Fogg is very eccentric.  His punctuality is well known; he
+never arrives too soon, or too late; and I should not be surprised if
+he appeared before us at the last minute."
+
+"Why," said Andrew Stuart nervously, "if I should see him, I should not
+believe it was he."
+
+"The fact is," resumed Thomas Flanagan, "Mr. Fogg's project was
+absurdly foolish.  Whatever his punctuality, he could not prevent the
+delays which were certain to occur; and a delay of only two or three
+days would be fatal to his tour."
+
+"Observe, too," added John Sullivan, "that we have received no
+intelligence from him, though there are telegraphic lines all along his
+route."
+
+"He has lost, gentleman," said Andrew Stuart, "he has a hundred times
+lost!  You know, besides, that the China the only steamer he could have
+taken from New York to get here in time arrived yesterday.  I have seen
+a list of the passengers, and the name of Phileas Fogg is not among
+them.  Even if we admit that fortune has favoured him, he can scarcely
+have reached America.  I think he will be at least twenty days
+behind-hand, and that Lord Albemarle will lose a cool five thousand."
+
+"It is clear," replied Gauthier Ralph; "and we have nothing to do but
+to present Mr. Fogg's cheque at Barings to-morrow."
+
+At this moment, the hands of the club clock pointed to twenty minutes
+to nine.
+
+"Five minutes more," said Andrew Stuart.
+
+The five gentlemen looked at each other.  Their anxiety was becoming
+intense; but, not wishing to betray it, they readily assented to Mr.
+Fallentin's proposal of a rubber.
+
+"I wouldn't give up my four thousand of the bet," said Andrew Stuart,
+as he took his seat, "for three thousand nine hundred and ninety-nine."
+
+The clock indicated eighteen minutes to nine.
+
+The players took up their cards, but could not keep their eyes off the
+clock.  Certainly, however secure they felt, minutes had never seemed
+so long to them!
+
+"Seventeen minutes to nine," said Thomas Flanagan, as he cut the cards
+which Ralph handed to him.
+
+Then there was a moment of silence.  The great saloon was perfectly
+quiet; but the murmurs of the crowd outside were heard, with now and
+then a shrill cry.  The pendulum beat the seconds, which each player
+eagerly counted, as he listened, with mathematical regularity.
+
+"Sixteen minutes to nine!" said John Sullivan, in a voice which
+betrayed his emotion.
+
+One minute more, and the wager would be won.  Andrew Stuart and his
+partners suspended their game.  They left their cards, and counted the
+seconds.
+
+At the fortieth second, nothing.  At the fiftieth, still nothing.
+
+At the fifty-fifth, a loud cry was heard in the street, followed by
+applause, hurrahs, and some fierce growls.
+
+The players rose from their seats.
+
+At the fifty-seventh second the door of the saloon opened; and the
+pendulum had not beat the sixtieth second when Phileas Fogg appeared,
+followed by an excited crowd who had forced their way through the club
+doors, and in his calm voice, said, "Here I am, gentlemen!"
+
+
+
+
+Chapter XXXVII
+
+IN WHICH IT IS SHOWN THAT PHILEAS FOGG GAINED NOTHING BY HIS TOUR
+AROUND THE WORLD, UNLESS IT WERE HAPPINESS
+
+
+Yes; Phileas Fogg in person.
+
+The reader will remember that at five minutes past eight in the
+evening--about five and twenty hours after the arrival of the
+travellers in London--Passepartout had been sent by his master to
+engage the services of the Reverend Samuel Wilson in a certain marriage
+ceremony, which was to take place the next day.
+
+Passepartout went on his errand enchanted.  He soon reached the
+clergyman's house, but found him not at home.  Passepartout waited a
+good twenty minutes, and when he left the reverend gentleman, it was
+thirty-five minutes past eight.  But in what a state he was!  With his
+hair in disorder, and without his hat, he ran along the street as never
+man was seen to run before, overturning passers-by, rushing over the
+sidewalk like a waterspout.
+
+In three minutes he was in Saville Row again, and staggered back into
+Mr. Fogg's room.
+
+He could not speak.
+
+"What is the matter?" asked Mr. Fogg.
+
+"My master!" gasped Passepartout--"marriage--impossible--"
+
+"Impossible?"
+
+"Impossible--for to-morrow."
+
+"Why so?"
+
+"Because to-morrow--is Sunday!"
+
+"Monday," replied Mr. Fogg.
+
+"No--to-day is Saturday."
+
+"Saturday?  Impossible!"
+
+"Yes, yes, yes, yes!" cried Passepartout.  "You have made a mistake of
+one day!  We arrived twenty-four hours ahead of time; but there are
+only ten minutes left!"
+
+Passepartout had seized his master by the collar, and was dragging him
+along with irresistible force.
+
+Phileas Fogg, thus kidnapped, without having time to think, left his
+house, jumped into a cab, promised a hundred pounds to the cabman, and,
+having run over two dogs and overturned five carriages, reached the
+Reform Club.
+
+The clock indicated a quarter before nine when he appeared in the great
+saloon.
+
+Phileas Fogg had accomplished the journey round the world in eighty
+days!
+
+Phileas Fogg had won his wager of twenty thousand pounds!
+
+How was it that a man so exact and fastidious could have made this
+error of a day?  How came he to think that he had arrived in London on
+Saturday, the twenty-first day of December, when it was really Friday,
+the twentieth, the seventy-ninth day only from his departure?
+
+The cause of the error is very simple.
+
+Phileas Fogg had, without suspecting it, gained one day on his journey,
+and this merely because he had travelled constantly eastward; he would,
+on the contrary, have lost a day had he gone in the opposite direction,
+that is, westward.
+
+In journeying eastward he had gone towards the sun, and the days
+therefore diminished for him as many times four minutes as he crossed
+degrees in this direction.  There are three hundred and sixty degrees
+on the circumference of the earth; and these three hundred and sixty
+degrees, multiplied by four minutes, gives precisely twenty-four
+hours--that is, the day unconsciously gained.  In other words, while
+Phileas Fogg, going eastward, saw the sun pass the meridian eighty
+times, his friends in London only saw it pass the meridian seventy-nine
+times.  This is why they awaited him at the Reform Club on Saturday,
+and not Sunday, as Mr. Fogg thought.
+
+And Passepartout's famous family watch, which had always kept London
+time, would have betrayed this fact, if it had marked the days as well
+as the hours and the minutes!
+
+Phileas Fogg, then, had won the twenty thousand pounds; but, as he had
+spent nearly nineteen thousand on the way, the pecuniary gain was
+small.  His object was, however, to be victorious, and not to win
+money.  He divided the one thousand pounds that remained between
+Passepartout and the unfortunate Fix, against whom he cherished no
+grudge.  He deducted, however, from Passepartout's share the cost of
+the gas which had burned in his room for nineteen hundred and twenty
+hours, for the sake of regularity.
+
+That evening, Mr. Fogg, as tranquil and phlegmatic as ever, said to
+Aouda: "Is our marriage still agreeable to you?"
+
+"Mr. Fogg," replied she, "it is for me to ask that question.  You were
+ruined, but now you are rich again."
+
+"Pardon me, madam; my fortune belongs to you.  If you had not suggested
+our marriage, my servant would not have gone to the Reverend Samuel
+Wilson's, I should not have been apprised of my error, and--"
+
+"Dear Mr. Fogg!" said the young woman.
+
+"Dear Aouda!" replied Phileas Fogg.
+
+It need not be said that the marriage took place forty-eight hours
+after, and that Passepartout, glowing and dazzling, gave the bride
+away.  Had he not saved her, and was he not entitled to this honour?
+
+The next day, as soon as it was light, Passepartout rapped vigorously
+at his master's door.  Mr. Fogg opened it, and asked, "What's the
+matter, Passepartout?"
+
+"What is it, sir?  Why, I've just this instant found out--"
+
+"What?"
+
+"That we might have made the tour of the world in only seventy-eight
+days."
+
+"No doubt," returned Mr. Fogg, "by not crossing India.  But if I had
+not crossed India, I should not have saved Aouda; she would not have
+been my wife, and--"
+
+Mr. Fogg quietly shut the door.
+
+Phileas Fogg had won his wager, and had made his journey around the
+world in eighty days.  To do this he had employed every means of
+conveyance--steamers, railways, carriages, yachts, trading-vessels,
+sledges, elephants.  The eccentric gentleman had throughout displayed
+all his marvellous qualities of coolness and exactitude.  But what
+then?  What had he really gained by all this trouble?  What had he
+brought back from this long and weary journey?
+
+Nothing, say you?  Perhaps so; nothing but a charming woman, who,
+strange as it may appear, made him the happiest of men!
+
+Truly, would you not for less than that make the tour around the world?
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's Around the World in 80 Days, by Jules Verne
+
+*** END OF THIS PROJECT GUTENBERG EBOOK AROUND THE WORLD IN 80 DAYS ***
+
+***** This file should be named 103.txt or 103.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/0/103/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/dorian-gray.txt
+++ b/jet/tf-idf/src/main/resources/books/dorian-gray.txt
@@ -1,0 +1,8904 @@
+﻿The Project Gutenberg EBook of The Picture of Dorian Gray, by Oscar Wilde
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Picture of Dorian Gray
+
+Author: Oscar Wilde
+
+Release Date: June 9, 2008 [EBook #174]
+[This file last updated on July 2, 2011]
+[This file last updated on July 23, 2014]
+
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+
+
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+The Picture of Dorian Gray
+
+by
+
+Oscar Wilde
+
+
+
+
+THE PREFACE
+
+The artist is the creator of beautiful things.  To reveal art and
+conceal the artist is art's aim.  The critic is he who can translate
+into another manner or a new material his impression of beautiful
+things.
+
+The highest as the lowest form of criticism is a mode of autobiography.
+Those who find ugly meanings in beautiful things are corrupt without
+being charming.  This is a fault.
+
+Those who find beautiful meanings in beautiful things are the
+cultivated.  For these there is hope.  They are the elect to whom
+beautiful things mean only beauty.
+
+There is no such thing as a moral or an immoral book.  Books are well
+written, or badly written.  That is all.
+
+The nineteenth century dislike of realism is the rage of Caliban seeing
+his own face in a glass.
+
+The nineteenth century dislike of romanticism is the rage of Caliban
+not seeing his own face in a glass.  The moral life of man forms part
+of the subject-matter of the artist, but the morality of art consists
+in the perfect use of an imperfect medium.  No artist desires to prove
+anything.  Even things that are true can be proved.  No artist has
+ethical sympathies.  An ethical sympathy in an artist is an
+unpardonable mannerism of style.  No artist is ever morbid.  The artist
+can express everything.  Thought and language are to the artist
+instruments of an art.  Vice and virtue are to the artist materials for
+an art.  From the point of view of form, the type of all the arts is
+the art of the musician.  From the point of view of feeling, the
+actor's craft is the type.  All art is at once surface and symbol.
+Those who go beneath the surface do so at their peril.  Those who read
+the symbol do so at their peril.  It is the spectator, and not life,
+that art really mirrors.  Diversity of opinion about a work of art
+shows that the work is new, complex, and vital.  When critics disagree,
+the artist is in accord with himself.  We can forgive a man for making
+a useful thing as long as he does not admire it.  The only excuse for
+making a useless thing is that one admires it intensely.
+
+               All art is quite useless.
+
+                            OSCAR WILDE
+
+
+
+
+CHAPTER 1
+
+The studio was filled with the rich odour of roses, and when the light
+summer wind stirred amidst the trees of the garden, there came through
+the open door the heavy scent of the lilac, or the more delicate
+perfume of the pink-flowering thorn.
+
+From the corner of the divan of Persian saddle-bags on which he was
+lying, smoking, as was his custom, innumerable cigarettes, Lord Henry
+Wotton could just catch the gleam of the honey-sweet and honey-coloured
+blossoms of a laburnum, whose tremulous branches seemed hardly able to
+bear the burden of a beauty so flamelike as theirs; and now and then
+the fantastic shadows of birds in flight flitted across the long
+tussore-silk curtains that were stretched in front of the huge window,
+producing a kind of momentary Japanese effect, and making him think of
+those pallid, jade-faced painters of Tokyo who, through the medium of
+an art that is necessarily immobile, seek to convey the sense of
+swiftness and motion.  The sullen murmur of the bees shouldering their
+way through the long unmown grass, or circling with monotonous
+insistence round the dusty gilt horns of the straggling woodbine,
+seemed to make the stillness more oppressive.  The dim roar of London
+was like the bourdon note of a distant organ.
+
+In the centre of the room, clamped to an upright easel, stood the
+full-length portrait of a young man of extraordinary personal beauty,
+and in front of it, some little distance away, was sitting the artist
+himself, Basil Hallward, whose sudden disappearance some years ago
+caused, at the time, such public excitement and gave rise to so many
+strange conjectures.
+
+As the painter looked at the gracious and comely form he had so
+skilfully mirrored in his art, a smile of pleasure passed across his
+face, and seemed about to linger there.  But he suddenly started up,
+and closing his eyes, placed his fingers upon the lids, as though he
+sought to imprison within his brain some curious dream from which he
+feared he might awake.
+
+"It is your best work, Basil, the best thing you have ever done," said
+Lord Henry languidly.  "You must certainly send it next year to the
+Grosvenor.  The Academy is too large and too vulgar.  Whenever I have
+gone there, there have been either so many people that I have not been
+able to see the pictures, which was dreadful, or so many pictures that
+I have not been able to see the people, which was worse.  The Grosvenor
+is really the only place."
+
+"I don't think I shall send it anywhere," he answered, tossing his head
+back in that odd way that used to make his friends laugh at him at
+Oxford.  "No, I won't send it anywhere."
+
+Lord Henry elevated his eyebrows and looked at him in amazement through
+the thin blue wreaths of smoke that curled up in such fanciful whorls
+from his heavy, opium-tainted cigarette.  "Not send it anywhere?  My
+dear fellow, why?  Have you any reason?  What odd chaps you painters
+are!  You do anything in the world to gain a reputation.  As soon as
+you have one, you seem to want to throw it away.  It is silly of you,
+for there is only one thing in the world worse than being talked about,
+and that is not being talked about.  A portrait like this would set you
+far above all the young men in England, and make the old men quite
+jealous, if old men are ever capable of any emotion."
+
+"I know you will laugh at me," he replied, "but I really can't exhibit
+it.  I have put too much of myself into it."
+
+Lord Henry stretched himself out on the divan and laughed.
+
+"Yes, I knew you would; but it is quite true, all the same."
+
+"Too much of yourself in it! Upon my word, Basil, I didn't know you
+were so vain; and I really can't see any resemblance between you, with
+your rugged strong face and your coal-black hair, and this young
+Adonis, who looks as if he was made out of ivory and rose-leaves. Why,
+my dear Basil, he is a Narcissus, and you--well, of course you have an
+intellectual expression and all that.  But beauty, real beauty, ends
+where an intellectual expression begins.  Intellect is in itself a mode
+of exaggeration, and destroys the harmony of any face.  The moment one
+sits down to think, one becomes all nose, or all forehead, or something
+horrid.  Look at the successful men in any of the learned professions.
+How perfectly hideous they are!  Except, of course, in the Church.  But
+then in the Church they don't think.  A bishop keeps on saying at the
+age of eighty what he was told to say when he was a boy of eighteen,
+and as a natural consequence he always looks absolutely delightful.
+Your mysterious young friend, whose name you have never told me, but
+whose picture really fascinates me, never thinks.  I feel quite sure of
+that.  He is some brainless beautiful creature who should be always
+here in winter when we have no flowers to look at, and always here in
+summer when we want something to chill our intelligence.  Don't flatter
+yourself, Basil:  you are not in the least like him."
+
+"You don't understand me, Harry," answered the artist.  "Of course I am
+not like him.  I know that perfectly well.  Indeed, I should be sorry
+to look like him.  You shrug your shoulders?  I am telling you the
+truth.  There is a fatality about all physical and intellectual
+distinction, the sort of fatality that seems to dog through history the
+faltering steps of kings.  It is better not to be different from one's
+fellows.  The ugly and the stupid have the best of it in this world.
+They can sit at their ease and gape at the play.  If they know nothing
+of victory, they are at least spared the knowledge of defeat.  They
+live as we all should live--undisturbed, indifferent, and without
+disquiet.  They neither bring ruin upon others, nor ever receive it
+from alien hands.  Your rank and wealth, Harry; my brains, such as they
+are--my art, whatever it may be worth; Dorian Gray's good looks--we
+shall all suffer for what the gods have given us, suffer terribly."
+
+"Dorian Gray?  Is that his name?" asked Lord Henry, walking across the
+studio towards Basil Hallward.
+
+"Yes, that is his name.  I didn't intend to tell it to you."
+
+"But why not?"
+
+"Oh, I can't explain.  When I like people immensely, I never tell their
+names to any one.  It is like surrendering a part of them.  I have
+grown to love secrecy.  It seems to be the one thing that can make
+modern life mysterious or marvellous to us.  The commonest thing is
+delightful if one only hides it.  When I leave town now I never tell my
+people where I am going.  If I did, I would lose all my pleasure.  It
+is a silly habit, I dare say, but somehow it seems to bring a great
+deal of romance into one's life.  I suppose you think me awfully
+foolish about it?"
+
+"Not at all," answered Lord Henry, "not at all, my dear Basil.  You
+seem to forget that I am married, and the one charm of marriage is that
+it makes a life of deception absolutely necessary for both parties.  I
+never know where my wife is, and my wife never knows what I am doing.
+When we meet--we do meet occasionally, when we dine out together, or go
+down to the Duke's--we tell each other the most absurd stories with the
+most serious faces.  My wife is very good at it--much better, in fact,
+than I am.  She never gets confused over her dates, and I always do.
+But when she does find me out, she makes no row at all.  I sometimes
+wish she would; but she merely laughs at me."
+
+"I hate the way you talk about your married life, Harry," said Basil
+Hallward, strolling towards the door that led into the garden.  "I
+believe that you are really a very good husband, but that you are
+thoroughly ashamed of your own virtues.  You are an extraordinary
+fellow.  You never say a moral thing, and you never do a wrong thing.
+Your cynicism is simply a pose."
+
+"Being natural is simply a pose, and the most irritating pose I know,"
+cried Lord Henry, laughing; and the two young men went out into the
+garden together and ensconced themselves on a long bamboo seat that
+stood in the shade of a tall laurel bush.  The sunlight slipped over
+the polished leaves.  In the grass, white daisies were tremulous.
+
+After a pause, Lord Henry pulled out his watch.  "I am afraid I must be
+going, Basil," he murmured, "and before I go, I insist on your
+answering a question I put to you some time ago."
+
+"What is that?" said the painter, keeping his eyes fixed on the ground.
+
+"You know quite well."
+
+"I do not, Harry."
+
+"Well, I will tell you what it is.  I want you to explain to me why you
+won't exhibit Dorian Gray's picture.  I want the real reason."
+
+"I told you the real reason."
+
+"No, you did not.  You said it was because there was too much of
+yourself in it.  Now, that is childish."
+
+"Harry," said Basil Hallward, looking him straight in the face, "every
+portrait that is painted with feeling is a portrait of the artist, not
+of the sitter.  The sitter is merely the accident, the occasion.  It is
+not he who is revealed by the painter; it is rather the painter who, on
+the coloured canvas, reveals himself.  The reason I will not exhibit
+this picture is that I am afraid that I have shown in it the secret of
+my own soul."
+
+Lord Henry laughed.  "And what is that?" he asked.
+
+"I will tell you," said Hallward; but an expression of perplexity came
+over his face.
+
+"I am all expectation, Basil," continued his companion, glancing at him.
+
+"Oh, there is really very little to tell, Harry," answered the painter;
+"and I am afraid you will hardly understand it.  Perhaps you will
+hardly believe it."
+
+Lord Henry smiled, and leaning down, plucked a pink-petalled daisy from
+the grass and examined it.  "I am quite sure I shall understand it," he
+replied, gazing intently at the little golden, white-feathered disk,
+"and as for believing things, I can believe anything, provided that it
+is quite incredible."
+
+The wind shook some blossoms from the trees, and the heavy
+lilac-blooms, with their clustering stars, moved to and fro in the
+languid air.  A grasshopper began to chirrup by the wall, and like a
+blue thread a long thin dragon-fly floated past on its brown gauze
+wings.  Lord Henry felt as if he could hear Basil Hallward's heart
+beating, and wondered what was coming.
+
+"The story is simply this," said the painter after some time.  "Two
+months ago I went to a crush at Lady Brandon's. You know we poor
+artists have to show ourselves in society from time to time, just to
+remind the public that we are not savages.  With an evening coat and a
+white tie, as you told me once, anybody, even a stock-broker, can gain
+a reputation for being civilized.  Well, after I had been in the room
+about ten minutes, talking to huge overdressed dowagers and tedious
+academicians, I suddenly became conscious that some one was looking at
+me.  I turned half-way round and saw Dorian Gray for the first time.
+When our eyes met, I felt that I was growing pale.  A curious sensation
+of terror came over me.  I knew that I had come face to face with some
+one whose mere personality was so fascinating that, if I allowed it to
+do so, it would absorb my whole nature, my whole soul, my very art
+itself.  I did not want any external influence in my life.  You know
+yourself, Harry, how independent I am by nature.  I have always been my
+own master; had at least always been so, till I met Dorian Gray.
+Then--but I don't know how to explain it to you.  Something seemed to
+tell me that I was on the verge of a terrible crisis in my life.  I had
+a strange feeling that fate had in store for me exquisite joys and
+exquisite sorrows.  I grew afraid and turned to quit the room.  It was
+not conscience that made me do so:  it was a sort of cowardice.  I take
+no credit to myself for trying to escape."
+
+"Conscience and cowardice are really the same things, Basil.
+Conscience is the trade-name of the firm.  That is all."
+
+"I don't believe that, Harry, and I don't believe you do either.
+However, whatever was my motive--and it may have been pride, for I used
+to be very proud--I certainly struggled to the door.  There, of course,
+I stumbled against Lady Brandon.  'You are not going to run away so
+soon, Mr. Hallward?' she screamed out.  You know her curiously shrill
+voice?"
+
+"Yes; she is a peacock in everything but beauty," said Lord Henry,
+pulling the daisy to bits with his long nervous fingers.
+
+"I could not get rid of her.  She brought me up to royalties, and
+people with stars and garters, and elderly ladies with gigantic tiaras
+and parrot noses.  She spoke of me as her dearest friend.  I had only
+met her once before, but she took it into her head to lionize me.  I
+believe some picture of mine had made a great success at the time, at
+least had been chattered about in the penny newspapers, which is the
+nineteenth-century standard of immortality.  Suddenly I found myself
+face to face with the young man whose personality had so strangely
+stirred me.  We were quite close, almost touching.  Our eyes met again.
+It was reckless of me, but I asked Lady Brandon to introduce me to him.
+Perhaps it was not so reckless, after all.  It was simply inevitable.
+We would have spoken to each other without any introduction.  I am sure
+of that.  Dorian told me so afterwards.  He, too, felt that we were
+destined to know each other."
+
+"And how did Lady Brandon describe this wonderful young man?" asked his
+companion.  "I know she goes in for giving a rapid _precis_ of all her
+guests.  I remember her bringing me up to a truculent and red-faced old
+gentleman covered all over with orders and ribbons, and hissing into my
+ear, in a tragic whisper which must have been perfectly audible to
+everybody in the room, the most astounding details.  I simply fled.  I
+like to find out people for myself.  But Lady Brandon treats her guests
+exactly as an auctioneer treats his goods.  She either explains them
+entirely away, or tells one everything about them except what one wants
+to know."
+
+"Poor Lady Brandon!  You are hard on her, Harry!" said Hallward
+listlessly.
+
+"My dear fellow, she tried to found a _salon_, and only succeeded in
+opening a restaurant.  How could I admire her?  But tell me, what did
+she say about Mr. Dorian Gray?"
+
+"Oh, something like, 'Charming boy--poor dear mother and I absolutely
+inseparable.  Quite forget what he does--afraid he--doesn't do
+anything--oh, yes, plays the piano--or is it the violin, dear Mr.
+Gray?'  Neither of us could help laughing, and we became friends at
+once."
+
+"Laughter is not at all a bad beginning for a friendship, and it is far
+the best ending for one," said the young lord, plucking another daisy.
+
+Hallward shook his head.  "You don't understand what friendship is,
+Harry," he murmured--"or what enmity is, for that matter.  You like
+every one; that is to say, you are indifferent to every one."
+
+"How horribly unjust of you!" cried Lord Henry, tilting his hat back
+and looking up at the little clouds that, like ravelled skeins of
+glossy white silk, were drifting across the hollowed turquoise of the
+summer sky.  "Yes; horribly unjust of you.  I make a great difference
+between people.  I choose my friends for their good looks, my
+acquaintances for their good characters, and my enemies for their good
+intellects.  A man cannot be too careful in the choice of his enemies.
+I have not got one who is a fool.  They are all men of some
+intellectual power, and consequently they all appreciate me.  Is that
+very vain of me?  I think it is rather vain."
+
+"I should think it was, Harry.  But according to your category I must
+be merely an acquaintance."
+
+"My dear old Basil, you are much more than an acquaintance."
+
+"And much less than a friend.  A sort of brother, I suppose?"
+
+"Oh, brothers!  I don't care for brothers.  My elder brother won't die,
+and my younger brothers seem never to do anything else."
+
+"Harry!" exclaimed Hallward, frowning.
+
+"My dear fellow, I am not quite serious.  But I can't help detesting my
+relations.  I suppose it comes from the fact that none of us can stand
+other people having the same faults as ourselves.  I quite sympathize
+with the rage of the English democracy against what they call the vices
+of the upper orders.  The masses feel that drunkenness, stupidity, and
+immorality should be their own special property, and that if any one of
+us makes an ass of himself, he is poaching on their preserves.  When
+poor Southwark got into the divorce court, their indignation was quite
+magnificent.  And yet I don't suppose that ten per cent of the
+proletariat live correctly."
+
+"I don't agree with a single word that you have said, and, what is
+more, Harry, I feel sure you don't either."
+
+Lord Henry stroked his pointed brown beard and tapped the toe of his
+patent-leather boot with a tasselled ebony cane.  "How English you are
+Basil!  That is the second time you have made that observation.  If one
+puts forward an idea to a true Englishman--always a rash thing to
+do--he never dreams of considering whether the idea is right or wrong.
+The only thing he considers of any importance is whether one believes
+it oneself.  Now, the value of an idea has nothing whatsoever to do
+with the sincerity of the man who expresses it.  Indeed, the
+probabilities are that the more insincere the man is, the more purely
+intellectual will the idea be, as in that case it will not be coloured
+by either his wants, his desires, or his prejudices.  However, I don't
+propose to discuss politics, sociology, or metaphysics with you.  I
+like persons better than principles, and I like persons with no
+principles better than anything else in the world.  Tell me more about
+Mr. Dorian Gray.  How often do you see him?"
+
+"Every day.  I couldn't be happy if I didn't see him every day.  He is
+absolutely necessary to me."
+
+"How extraordinary!  I thought you would never care for anything but
+your art."
+
+"He is all my art to me now," said the painter gravely.  "I sometimes
+think, Harry, that there are only two eras of any importance in the
+world's history.  The first is the appearance of a new medium for art,
+and the second is the appearance of a new personality for art also.
+What the invention of oil-painting was to the Venetians, the face of
+Antinous was to late Greek sculpture, and the face of Dorian Gray will
+some day be to me.  It is not merely that I paint from him, draw from
+him, sketch from him.  Of course, I have done all that.  But he is much
+more to me than a model or a sitter.  I won't tell you that I am
+dissatisfied with what I have done of him, or that his beauty is such
+that art cannot express it.  There is nothing that art cannot express,
+and I know that the work I have done, since I met Dorian Gray, is good
+work, is the best work of my life.  But in some curious way--I wonder
+will you understand me?--his personality has suggested to me an
+entirely new manner in art, an entirely new mode of style.  I see
+things differently, I think of them differently.  I can now recreate
+life in a way that was hidden from me before.  'A dream of form in days
+of thought'--who is it who says that?  I forget; but it is what Dorian
+Gray has been to me.  The merely visible presence of this lad--for he
+seems to me little more than a lad, though he is really over
+twenty--his merely visible presence--ah!  I wonder can you realize all
+that that means?  Unconsciously he defines for me the lines of a fresh
+school, a school that is to have in it all the passion of the romantic
+spirit, all the perfection of the spirit that is Greek.  The harmony of
+soul and body--how much that is!  We in our madness have separated the
+two, and have invented a realism that is vulgar, an ideality that is
+void.  Harry! if you only knew what Dorian Gray is to me!  You remember
+that landscape of mine, for which Agnew offered me such a huge price
+but which I would not part with?  It is one of the best things I have
+ever done.  And why is it so?  Because, while I was painting it, Dorian
+Gray sat beside me.  Some subtle influence passed from him to me, and
+for the first time in my life I saw in the plain woodland the wonder I
+had always looked for and always missed."
+
+"Basil, this is extraordinary!  I must see Dorian Gray."
+
+Hallward got up from the seat and walked up and down the garden.  After
+some time he came back.  "Harry," he said, "Dorian Gray is to me simply
+a motive in art.  You might see nothing in him.  I see everything in
+him.  He is never more present in my work than when no image of him is
+there.  He is a suggestion, as I have said, of a new manner.  I find
+him in the curves of certain lines, in the loveliness and subtleties of
+certain colours.  That is all."
+
+"Then why won't you exhibit his portrait?" asked Lord Henry.
+
+"Because, without intending it, I have put into it some expression of
+all this curious artistic idolatry, of which, of course, I have never
+cared to speak to him.  He knows nothing about it.  He shall never know
+anything about it.  But the world might guess it, and I will not bare
+my soul to their shallow prying eyes.  My heart shall never be put
+under their microscope.  There is too much of myself in the thing,
+Harry--too much of myself!"
+
+"Poets are not so scrupulous as you are.  They know how useful passion
+is for publication.  Nowadays a broken heart will run to many editions."
+
+"I hate them for it," cried Hallward.  "An artist should create
+beautiful things, but should put nothing of his own life into them.  We
+live in an age when men treat art as if it were meant to be a form of
+autobiography.  We have lost the abstract sense of beauty.  Some day I
+will show the world what it is; and for that reason the world shall
+never see my portrait of Dorian Gray."
+
+"I think you are wrong, Basil, but I won't argue with you.  It is only
+the intellectually lost who ever argue.  Tell me, is Dorian Gray very
+fond of you?"
+
+The painter considered for a few moments.  "He likes me," he answered
+after a pause; "I know he likes me.  Of course I flatter him
+dreadfully.  I find a strange pleasure in saying things to him that I
+know I shall be sorry for having said.  As a rule, he is charming to
+me, and we sit in the studio and talk of a thousand things.  Now and
+then, however, he is horribly thoughtless, and seems to take a real
+delight in giving me pain.  Then I feel, Harry, that I have given away
+my whole soul to some one who treats it as if it were a flower to put
+in his coat, a bit of decoration to charm his vanity, an ornament for a
+summer's day."
+
+"Days in summer, Basil, are apt to linger," murmured Lord Henry.
+"Perhaps you will tire sooner than he will.  It is a sad thing to think
+of, but there is no doubt that genius lasts longer than beauty.  That
+accounts for the fact that we all take such pains to over-educate
+ourselves.  In the wild struggle for existence, we want to have
+something that endures, and so we fill our minds with rubbish and
+facts, in the silly hope of keeping our place.  The thoroughly
+well-informed man--that is the modern ideal.  And the mind of the
+thoroughly well-informed man is a dreadful thing.  It is like a
+_bric-a-brac_ shop, all monsters and dust, with everything priced above
+its proper value.  I think you will tire first, all the same.  Some day
+you will look at your friend, and he will seem to you to be a little
+out of drawing, or you won't like his tone of colour, or something.
+You will bitterly reproach him in your own heart, and seriously think
+that he has behaved very badly to you.  The next time he calls, you
+will be perfectly cold and indifferent.  It will be a great pity, for
+it will alter you.  What you have told me is quite a romance, a romance
+of art one might call it, and the worst of having a romance of any kind
+is that it leaves one so unromantic."
+
+"Harry, don't talk like that.  As long as I live, the personality of
+Dorian Gray will dominate me.  You can't feel what I feel.  You change
+too often."
+
+"Ah, my dear Basil, that is exactly why I can feel it.  Those who are
+faithful know only the trivial side of love: it is the faithless who
+know love's tragedies."  And Lord Henry struck a light on a dainty
+silver case and began to smoke a cigarette with a self-conscious and
+satisfied air, as if he had summed up the world in a phrase.  There was
+a rustle of chirruping sparrows in the green lacquer leaves of the ivy,
+and the blue cloud-shadows chased themselves across the grass like
+swallows.  How pleasant it was in the garden!  And how delightful other
+people's emotions were!--much more delightful than their ideas, it
+seemed to him.  One's own soul, and the passions of one's
+friends--those were the fascinating things in life.  He pictured to
+himself with silent amusement the tedious luncheon that he had missed
+by staying so long with Basil Hallward.  Had he gone to his aunt's, he
+would have been sure to have met Lord Goodbody there, and the whole
+conversation would have been about the feeding of the poor and the
+necessity for model lodging-houses. Each class would have preached the
+importance of those virtues, for whose exercise there was no necessity
+in their own lives.  The rich would have spoken on the value of thrift,
+and the idle grown eloquent over the dignity of labour.  It was
+charming to have escaped all that!  As he thought of his aunt, an idea
+seemed to strike him.  He turned to Hallward and said, "My dear fellow,
+I have just remembered."
+
+"Remembered what, Harry?"
+
+"Where I heard the name of Dorian Gray."
+
+"Where was it?" asked Hallward, with a slight frown.
+
+"Don't look so angry, Basil.  It was at my aunt, Lady Agatha's.  She
+told me she had discovered a wonderful young man who was going to help
+her in the East End, and that his name was Dorian Gray.  I am bound to
+state that she never told me he was good-looking. Women have no
+appreciation of good looks; at least, good women have not.  She said
+that he was very earnest and had a beautiful nature.  I at once
+pictured to myself a creature with spectacles and lank hair, horribly
+freckled, and tramping about on huge feet.  I wish I had known it was
+your friend."
+
+"I am very glad you didn't, Harry."
+
+"Why?"
+
+"I don't want you to meet him."
+
+"You don't want me to meet him?"
+
+"No."
+
+"Mr. Dorian Gray is in the studio, sir," said the butler, coming into
+the garden.
+
+"You must introduce me now," cried Lord Henry, laughing.
+
+The painter turned to his servant, who stood blinking in the sunlight.
+"Ask Mr. Gray to wait, Parker:  I shall be in in a few moments." The
+man bowed and went up the walk.
+
+Then he looked at Lord Henry.  "Dorian Gray is my dearest friend," he
+said.  "He has a simple and a beautiful nature.  Your aunt was quite
+right in what she said of him.  Don't spoil him.  Don't try to
+influence him.  Your influence would be bad.  The world is wide, and
+has many marvellous people in it.  Don't take away from me the one
+person who gives to my art whatever charm it possesses:  my life as an
+artist depends on him.  Mind, Harry, I trust you."  He spoke very
+slowly, and the words seemed wrung out of him almost against his will.
+
+"What nonsense you talk!" said Lord Henry, smiling, and taking Hallward
+by the arm, he almost led him into the house.
+
+
+
+CHAPTER 2
+
+As they entered they saw Dorian Gray.  He was seated at the piano, with
+his back to them, turning over the pages of a volume of Schumann's
+"Forest Scenes."  "You must lend me these, Basil," he cried.  "I want
+to learn them.  They are perfectly charming."
+
+"That entirely depends on how you sit to-day, Dorian."
+
+"Oh, I am tired of sitting, and I don't want a life-sized portrait of
+myself," answered the lad, swinging round on the music-stool in a
+wilful, petulant manner.  When he caught sight of Lord Henry, a faint
+blush coloured his cheeks for a moment, and he started up.  "I beg your
+pardon, Basil, but I didn't know you had any one with you."
+
+"This is Lord Henry Wotton, Dorian, an old Oxford friend of mine.  I
+have just been telling him what a capital sitter you were, and now you
+have spoiled everything."
+
+"You have not spoiled my pleasure in meeting you, Mr. Gray," said Lord
+Henry, stepping forward and extending his hand.  "My aunt has often
+spoken to me about you.  You are one of her favourites, and, I am
+afraid, one of her victims also."
+
+"I am in Lady Agatha's black books at present," answered Dorian with a
+funny look of penitence.  "I promised to go to a club in Whitechapel
+with her last Tuesday, and I really forgot all about it.  We were to
+have played a duet together--three duets, I believe.  I don't know what
+she will say to me.  I am far too frightened to call."
+
+"Oh, I will make your peace with my aunt.  She is quite devoted to you.
+And I don't think it really matters about your not being there.  The
+audience probably thought it was a duet.  When Aunt Agatha sits down to
+the piano, she makes quite enough noise for two people."
+
+"That is very horrid to her, and not very nice to me," answered Dorian,
+laughing.
+
+Lord Henry looked at him.  Yes, he was certainly wonderfully handsome,
+with his finely curved scarlet lips, his frank blue eyes, his crisp
+gold hair.  There was something in his face that made one trust him at
+once.  All the candour of youth was there, as well as all youth's
+passionate purity.  One felt that he had kept himself unspotted from
+the world.  No wonder Basil Hallward worshipped him.
+
+"You are too charming to go in for philanthropy, Mr. Gray--far too
+charming." And Lord Henry flung himself down on the divan and opened
+his cigarette-case.
+
+The painter had been busy mixing his colours and getting his brushes
+ready.  He was looking worried, and when he heard Lord Henry's last
+remark, he glanced at him, hesitated for a moment, and then said,
+"Harry, I want to finish this picture to-day. Would you think it
+awfully rude of me if I asked you to go away?"
+
+Lord Henry smiled and looked at Dorian Gray.  "Am I to go, Mr. Gray?"
+he asked.
+
+"Oh, please don't, Lord Henry.  I see that Basil is in one of his sulky
+moods, and I can't bear him when he sulks.  Besides, I want you to tell
+me why I should not go in for philanthropy."
+
+"I don't know that I shall tell you that, Mr. Gray.  It is so tedious a
+subject that one would have to talk seriously about it.  But I
+certainly shall not run away, now that you have asked me to stop.  You
+don't really mind, Basil, do you?  You have often told me that you
+liked your sitters to have some one to chat to."
+
+Hallward bit his lip.  "If Dorian wishes it, of course you must stay.
+Dorian's whims are laws to everybody, except himself."
+
+Lord Henry took up his hat and gloves.  "You are very pressing, Basil,
+but I am afraid I must go.  I have promised to meet a man at the
+Orleans.  Good-bye, Mr. Gray.  Come and see me some afternoon in Curzon
+Street.  I am nearly always at home at five o'clock. Write to me when
+you are coming.  I should be sorry to miss you."
+
+"Basil," cried Dorian Gray, "if Lord Henry Wotton goes, I shall go,
+too.  You never open your lips while you are painting, and it is
+horribly dull standing on a platform and trying to look pleasant.  Ask
+him to stay.  I insist upon it."
+
+"Stay, Harry, to oblige Dorian, and to oblige me," said Hallward,
+gazing intently at his picture.  "It is quite true, I never talk when I
+am working, and never listen either, and it must be dreadfully tedious
+for my unfortunate sitters.  I beg you to stay."
+
+"But what about my man at the Orleans?"
+
+The painter laughed.  "I don't think there will be any difficulty about
+that.  Sit down again, Harry.  And now, Dorian, get up on the platform,
+and don't move about too much, or pay any attention to what Lord Henry
+says.  He has a very bad influence over all his friends, with the
+single exception of myself."
+
+Dorian Gray stepped up on the dais with the air of a young Greek
+martyr, and made a little _moue_ of discontent to Lord Henry, to whom he
+had rather taken a fancy.  He was so unlike Basil.  They made a
+delightful contrast.  And he had such a beautiful voice.  After a few
+moments he said to him, "Have you really a very bad influence, Lord
+Henry?  As bad as Basil says?"
+
+"There is no such thing as a good influence, Mr. Gray.  All influence
+is immoral--immoral from the scientific point of view."
+
+"Why?"
+
+"Because to influence a person is to give him one's own soul.  He does
+not think his natural thoughts, or burn with his natural passions.  His
+virtues are not real to him.  His sins, if there are such things as
+sins, are borrowed.  He becomes an echo of some one else's music, an
+actor of a part that has not been written for him.  The aim of life is
+self-development. To realize one's nature perfectly--that is what each
+of us is here for.  People are afraid of themselves, nowadays.  They
+have forgotten the highest of all duties, the duty that one owes to
+one's self.  Of course, they are charitable.  They feed the hungry and
+clothe the beggar.  But their own souls starve, and are naked.  Courage
+has gone out of our race.  Perhaps we never really had it.  The terror
+of society, which is the basis of morals, the terror of God, which is
+the secret of religion--these are the two things that govern us.  And
+yet--"
+
+"Just turn your head a little more to the right, Dorian, like a good
+boy," said the painter, deep in his work and conscious only that a look
+had come into the lad's face that he had never seen there before.
+
+"And yet," continued Lord Henry, in his low, musical voice, and with
+that graceful wave of the hand that was always so characteristic of
+him, and that he had even in his Eton days, "I believe that if one man
+were to live out his life fully and completely, were to give form to
+every feeling, expression to every thought, reality to every dream--I
+believe that the world would gain such a fresh impulse of joy that we
+would forget all the maladies of mediaevalism, and return to the
+Hellenic ideal--to something finer, richer than the Hellenic ideal, it
+may be.  But the bravest man amongst us is afraid of himself.  The
+mutilation of the savage has its tragic survival in the self-denial
+that mars our lives.  We are punished for our refusals.  Every impulse
+that we strive to strangle broods in the mind and poisons us.  The body
+sins once, and has done with its sin, for action is a mode of
+purification.  Nothing remains then but the recollection of a pleasure,
+or the luxury of a regret.  The only way to get rid of a temptation is
+to yield to it.  Resist it, and your soul grows sick with longing for
+the things it has forbidden to itself, with desire for what its
+monstrous laws have made monstrous and unlawful.  It has been said that
+the great events of the world take place in the brain.  It is in the
+brain, and the brain only, that the great sins of the world take place
+also.  You, Mr. Gray, you yourself, with your rose-red youth and your
+rose-white boyhood, you have had passions that have made you afraid,
+thoughts that have filled you with terror, day-dreams and sleeping
+dreams whose mere memory might stain your cheek with shame--"
+
+"Stop!" faltered Dorian Gray, "stop! you bewilder me.  I don't know
+what to say.  There is some answer to you, but I cannot find it.  Don't
+speak.  Let me think.  Or, rather, let me try not to think."
+
+For nearly ten minutes he stood there, motionless, with parted lips and
+eyes strangely bright.  He was dimly conscious that entirely fresh
+influences were at work within him.  Yet they seemed to him to have
+come really from himself.  The few words that Basil's friend had said
+to him--words spoken by chance, no doubt, and with wilful paradox in
+them--had touched some secret chord that had never been touched before,
+but that he felt was now vibrating and throbbing to curious pulses.
+
+Music had stirred him like that.  Music had troubled him many times.
+But music was not articulate.  It was not a new world, but rather
+another chaos, that it created in us.  Words!  Mere words!  How
+terrible they were!  How clear, and vivid, and cruel!  One could not
+escape from them.  And yet what a subtle magic there was in them!  They
+seemed to be able to give a plastic form to formless things, and to
+have a music of their own as sweet as that of viol or of lute.  Mere
+words!  Was there anything so real as words?
+
+Yes; there had been things in his boyhood that he had not understood.
+He understood them now.  Life suddenly became fiery-coloured to him.
+It seemed to him that he had been walking in fire.  Why had he not
+known it?
+
+With his subtle smile, Lord Henry watched him.  He knew the precise
+psychological moment when to say nothing.  He felt intensely
+interested.  He was amazed at the sudden impression that his words had
+produced, and, remembering a book that he had read when he was sixteen,
+a book which had revealed to him much that he had not known before, he
+wondered whether Dorian Gray was passing through a similar experience.
+He had merely shot an arrow into the air.  Had it hit the mark?  How
+fascinating the lad was!
+
+Hallward painted away with that marvellous bold touch of his, that had
+the true refinement and perfect delicacy that in art, at any rate comes
+only from strength.  He was unconscious of the silence.
+
+"Basil, I am tired of standing," cried Dorian Gray suddenly.  "I must
+go out and sit in the garden.  The air is stifling here."
+
+"My dear fellow, I am so sorry.  When I am painting, I can't think of
+anything else.  But you never sat better.  You were perfectly still.
+And I have caught the effect I wanted--the half-parted lips and the
+bright look in the eyes.  I don't know what Harry has been saying to
+you, but he has certainly made you have the most wonderful expression.
+I suppose he has been paying you compliments.  You mustn't believe a
+word that he says."
+
+"He has certainly not been paying me compliments.  Perhaps that is the
+reason that I don't believe anything he has told me."
+
+"You know you believe it all," said Lord Henry, looking at him with his
+dreamy languorous eyes.  "I will go out to the garden with you.  It is
+horribly hot in the studio.  Basil, let us have something iced to
+drink, something with strawberries in it."
+
+"Certainly, Harry.  Just touch the bell, and when Parker comes I will
+tell him what you want.  I have got to work up this background, so I
+will join you later on.  Don't keep Dorian too long.  I have never been
+in better form for painting than I am to-day. This is going to be my
+masterpiece.  It is my masterpiece as it stands."
+
+Lord Henry went out to the garden and found Dorian Gray burying his
+face in the great cool lilac-blossoms, feverishly drinking in their
+perfume as if it had been wine.  He came close to him and put his hand
+upon his shoulder.  "You are quite right to do that," he murmured.
+"Nothing can cure the soul but the senses, just as nothing can cure the
+senses but the soul."
+
+The lad started and drew back.  He was bareheaded, and the leaves had
+tossed his rebellious curls and tangled all their gilded threads.
+There was a look of fear in his eyes, such as people have when they are
+suddenly awakened.  His finely chiselled nostrils quivered, and some
+hidden nerve shook the scarlet of his lips and left them trembling.
+
+"Yes," continued Lord Henry, "that is one of the great secrets of
+life--to cure the soul by means of the senses, and the senses by means
+of the soul.  You are a wonderful creation.  You know more than you
+think you know, just as you know less than you want to know."
+
+Dorian Gray frowned and turned his head away.  He could not help liking
+the tall, graceful young man who was standing by him.  His romantic,
+olive-coloured face and worn expression interested him.  There was
+something in his low languid voice that was absolutely fascinating.
+His cool, white, flowerlike hands, even, had a curious charm.  They
+moved, as he spoke, like music, and seemed to have a language of their
+own.  But he felt afraid of him, and ashamed of being afraid.  Why had
+it been left for a stranger to reveal him to himself?  He had known
+Basil Hallward for months, but the friendship between them had never
+altered him.  Suddenly there had come some one across his life who
+seemed to have disclosed to him life's mystery.  And, yet, what was
+there to be afraid of?  He was not a schoolboy or a girl.  It was
+absurd to be frightened.
+
+"Let us go and sit in the shade," said Lord Henry.  "Parker has brought
+out the drinks, and if you stay any longer in this glare, you will be
+quite spoiled, and Basil will never paint you again.  You really must
+not allow yourself to become sunburnt.  It would be unbecoming."
+
+"What can it matter?" cried Dorian Gray, laughing, as he sat down on
+the seat at the end of the garden.
+
+"It should matter everything to you, Mr. Gray."
+
+"Why?"
+
+"Because you have the most marvellous youth, and youth is the one thing
+worth having."
+
+"I don't feel that, Lord Henry."
+
+"No, you don't feel it now.  Some day, when you are old and wrinkled
+and ugly, when thought has seared your forehead with its lines, and
+passion branded your lips with its hideous fires, you will feel it, you
+will feel it terribly.  Now, wherever you go, you charm the world.
+Will it always be so? ... You have a wonderfully beautiful face, Mr.
+Gray.  Don't frown.  You have.  And beauty is a form of genius--is
+higher, indeed, than genius, as it needs no explanation.  It is of the
+great facts of the world, like sunlight, or spring-time, or the
+reflection in dark waters of that silver shell we call the moon.  It
+cannot be questioned.  It has its divine right of sovereignty.  It
+makes princes of those who have it.  You smile?  Ah! when you have lost
+it you won't smile.... People say sometimes that beauty is only
+superficial.  That may be so, but at least it is not so superficial as
+thought is.  To me, beauty is the wonder of wonders.  It is only
+shallow people who do not judge by appearances.  The true mystery of
+the world is the visible, not the invisible.... Yes, Mr. Gray, the
+gods have been good to you.  But what the gods give they quickly take
+away.  You have only a few years in which to live really, perfectly,
+and fully.  When your youth goes, your beauty will go with it, and then
+you will suddenly discover that there are no triumphs left for you, or
+have to content yourself with those mean triumphs that the memory of
+your past will make more bitter than defeats.  Every month as it wanes
+brings you nearer to something dreadful.  Time is jealous of you, and
+wars against your lilies and your roses.  You will become sallow, and
+hollow-cheeked, and dull-eyed.  You will suffer horribly.... Ah!
+realize your youth while you have it.  Don't squander the gold of your
+days, listening to the tedious, trying to improve the hopeless failure,
+or giving away your life to the ignorant, the common, and the vulgar.
+These are the sickly aims, the false ideals, of our age.  Live!  Live
+the wonderful life that is in you!  Let nothing be lost upon you.  Be
+always searching for new sensations.  Be afraid of nothing.... A new
+Hedonism--that is what our century wants.  You might be its visible
+symbol.  With your personality there is nothing you could not do.  The
+world belongs to you for a season.... The moment I met you I saw that
+you were quite unconscious of what you really are, of what you really
+might be.  There was so much in you that charmed me that I felt I must
+tell you something about yourself.  I thought how tragic it would be if
+you were wasted.  For there is such a little time that your youth will
+last--such a little time.  The common hill-flowers wither, but they
+blossom again.  The laburnum will be as yellow next June as it is now.
+In a month there will be purple stars on the clematis, and year after
+year the green night of its leaves will hold its purple stars.  But we
+never get back our youth.  The pulse of joy that beats in us at twenty
+becomes sluggish.  Our limbs fail, our senses rot.  We degenerate into
+hideous puppets, haunted by the memory of the passions of which we were
+too much afraid, and the exquisite temptations that we had not the
+courage to yield to.  Youth!  Youth!  There is absolutely nothing in
+the world but youth!"
+
+Dorian Gray listened, open-eyed and wondering.  The spray of lilac fell
+from his hand upon the gravel.  A furry bee came and buzzed round it
+for a moment.  Then it began to scramble all over the oval stellated
+globe of the tiny blossoms.  He watched it with that strange interest
+in trivial things that we try to develop when things of high import
+make us afraid, or when we are stirred by some new emotion for which we
+cannot find expression, or when some thought that terrifies us lays
+sudden siege to the brain and calls on us to yield.  After a time the
+bee flew away.  He saw it creeping into the stained trumpet of a Tyrian
+convolvulus.  The flower seemed to quiver, and then swayed gently to
+and fro.
+
+Suddenly the painter appeared at the door of the studio and made
+staccato signs for them to come in.  They turned to each other and
+smiled.
+
+"I am waiting," he cried.  "Do come in.  The light is quite perfect,
+and you can bring your drinks."
+
+They rose up and sauntered down the walk together.  Two green-and-white
+butterflies fluttered past them, and in the pear-tree at the corner of
+the garden a thrush began to sing.
+
+"You are glad you have met me, Mr. Gray," said Lord Henry, looking at
+him.
+
+"Yes, I am glad now.  I wonder shall I always be glad?"
+
+"Always!  That is a dreadful word.  It makes me shudder when I hear it.
+Women are so fond of using it.  They spoil every romance by trying to
+make it last for ever.  It is a meaningless word, too.  The only
+difference between a caprice and a lifelong passion is that the caprice
+lasts a little longer."
+
+As they entered the studio, Dorian Gray put his hand upon Lord Henry's
+arm.  "In that case, let our friendship be a caprice," he murmured,
+flushing at his own boldness, then stepped up on the platform and
+resumed his pose.
+
+Lord Henry flung himself into a large wicker arm-chair and watched him.
+The sweep and dash of the brush on the canvas made the only sound that
+broke the stillness, except when, now and then, Hallward stepped back
+to look at his work from a distance.  In the slanting beams that
+streamed through the open doorway the dust danced and was golden.  The
+heavy scent of the roses seemed to brood over everything.
+
+After about a quarter of an hour Hallward stopped painting, looked for
+a long time at Dorian Gray, and then for a long time at the picture,
+biting the end of one of his huge brushes and frowning.  "It is quite
+finished," he cried at last, and stooping down he wrote his name in
+long vermilion letters on the left-hand corner of the canvas.
+
+Lord Henry came over and examined the picture.  It was certainly a
+wonderful work of art, and a wonderful likeness as well.
+
+"My dear fellow, I congratulate you most warmly," he said.  "It is the
+finest portrait of modern times.  Mr. Gray, come over and look at
+yourself."
+
+The lad started, as if awakened from some dream.
+
+"Is it really finished?" he murmured, stepping down from the platform.
+
+"Quite finished," said the painter.  "And you have sat splendidly
+to-day. I am awfully obliged to you."
+
+"That is entirely due to me," broke in Lord Henry.  "Isn't it, Mr.
+Gray?"
+
+Dorian made no answer, but passed listlessly in front of his picture
+and turned towards it.  When he saw it he drew back, and his cheeks
+flushed for a moment with pleasure.  A look of joy came into his eyes,
+as if he had recognized himself for the first time.  He stood there
+motionless and in wonder, dimly conscious that Hallward was speaking to
+him, but not catching the meaning of his words.  The sense of his own
+beauty came on him like a revelation.  He had never felt it before.
+Basil Hallward's compliments had seemed to him to be merely the
+charming exaggeration of friendship.  He had listened to them, laughed
+at them, forgotten them.  They had not influenced his nature.  Then had
+come Lord Henry Wotton with his strange panegyric on youth, his
+terrible warning of its brevity.  That had stirred him at the time, and
+now, as he stood gazing at the shadow of his own loveliness, the full
+reality of the description flashed across him.  Yes, there would be a
+day when his face would be wrinkled and wizen, his eyes dim and
+colourless, the grace of his figure broken and deformed.  The scarlet
+would pass away from his lips and the gold steal from his hair.  The
+life that was to make his soul would mar his body.  He would become
+dreadful, hideous, and uncouth.
+
+As he thought of it, a sharp pang of pain struck through him like a
+knife and made each delicate fibre of his nature quiver.  His eyes
+deepened into amethyst, and across them came a mist of tears.  He felt
+as if a hand of ice had been laid upon his heart.
+
+"Don't you like it?" cried Hallward at last, stung a little by the
+lad's silence, not understanding what it meant.
+
+"Of course he likes it," said Lord Henry.  "Who wouldn't like it?  It
+is one of the greatest things in modern art.  I will give you anything
+you like to ask for it.  I must have it."
+
+"It is not my property, Harry."
+
+"Whose property is it?"
+
+"Dorian's, of course," answered the painter.
+
+"He is a very lucky fellow."
+
+"How sad it is!" murmured Dorian Gray with his eyes still fixed upon
+his own portrait.  "How sad it is!  I shall grow old, and horrible, and
+dreadful.  But this picture will remain always young.  It will never be
+older than this particular day of June.... If it were only the other
+way!  If it were I who was to be always young, and the picture that was
+to grow old!  For that--for that--I would give everything!  Yes, there
+is nothing in the whole world I would not give!  I would give my soul
+for that!"
+
+"You would hardly care for such an arrangement, Basil," cried Lord
+Henry, laughing.  "It would be rather hard lines on your work."
+
+"I should object very strongly, Harry," said Hallward.
+
+Dorian Gray turned and looked at him.  "I believe you would, Basil.
+You like your art better than your friends.  I am no more to you than a
+green bronze figure.  Hardly as much, I dare say."
+
+The painter stared in amazement.  It was so unlike Dorian to speak like
+that.  What had happened?  He seemed quite angry.  His face was flushed
+and his cheeks burning.
+
+"Yes," he continued, "I am less to you than your ivory Hermes or your
+silver Faun.  You will like them always.  How long will you like me?
+Till I have my first wrinkle, I suppose.  I know, now, that when one
+loses one's good looks, whatever they may be, one loses everything.
+Your picture has taught me that.  Lord Henry Wotton is perfectly right.
+Youth is the only thing worth having.  When I find that I am growing
+old, I shall kill myself."
+
+Hallward turned pale and caught his hand.  "Dorian!  Dorian!" he cried,
+"don't talk like that.  I have never had such a friend as you, and I
+shall never have such another.  You are not jealous of material things,
+are you?--you who are finer than any of them!"
+
+"I am jealous of everything whose beauty does not die.  I am jealous of
+the portrait you have painted of me.  Why should it keep what I must
+lose?  Every moment that passes takes something from me and gives
+something to it.  Oh, if it were only the other way!  If the picture
+could change, and I could be always what I am now!  Why did you paint
+it?  It will mock me some day--mock me horribly!"  The hot tears welled
+into his eyes; he tore his hand away and, flinging himself on the
+divan, he buried his face in the cushions, as though he was praying.
+
+"This is your doing, Harry," said the painter bitterly.
+
+Lord Henry shrugged his shoulders.  "It is the real Dorian Gray--that
+is all."
+
+"It is not."
+
+"If it is not, what have I to do with it?"
+
+"You should have gone away when I asked you," he muttered.
+
+"I stayed when you asked me," was Lord Henry's answer.
+
+"Harry, I can't quarrel with my two best friends at once, but between
+you both you have made me hate the finest piece of work I have ever
+done, and I will destroy it.  What is it but canvas and colour?  I will
+not let it come across our three lives and mar them."
+
+Dorian Gray lifted his golden head from the pillow, and with pallid
+face and tear-stained eyes, looked at him as he walked over to the deal
+painting-table that was set beneath the high curtained window.  What
+was he doing there?  His fingers were straying about among the litter
+of tin tubes and dry brushes, seeking for something.  Yes, it was for
+the long palette-knife, with its thin blade of lithe steel.  He had
+found it at last.  He was going to rip up the canvas.
+
+With a stifled sob the lad leaped from the couch, and, rushing over to
+Hallward, tore the knife out of his hand, and flung it to the end of
+the studio.  "Don't, Basil, don't!" he cried.  "It would be murder!"
+
+"I am glad you appreciate my work at last, Dorian," said the painter
+coldly when he had recovered from his surprise.  "I never thought you
+would."
+
+"Appreciate it?  I am in love with it, Basil.  It is part of myself.  I
+feel that."
+
+"Well, as soon as you are dry, you shall be varnished, and framed, and
+sent home.  Then you can do what you like with yourself." And he walked
+across the room and rang the bell for tea.  "You will have tea, of
+course, Dorian?  And so will you, Harry?  Or do you object to such
+simple pleasures?"
+
+"I adore simple pleasures," said Lord Henry.  "They are the last refuge
+of the complex.  But I don't like scenes, except on the stage.  What
+absurd fellows you are, both of you!  I wonder who it was defined man
+as a rational animal.  It was the most premature definition ever given.
+Man is many things, but he is not rational.  I am glad he is not, after
+all--though I wish you chaps would not squabble over the picture.  You
+had much better let me have it, Basil.  This silly boy doesn't really
+want it, and I really do."
+
+"If you let any one have it but me, Basil, I shall never forgive you!"
+cried Dorian Gray; "and I don't allow people to call me a silly boy."
+
+"You know the picture is yours, Dorian.  I gave it to you before it
+existed."
+
+"And you know you have been a little silly, Mr. Gray, and that you
+don't really object to being reminded that you are extremely young."
+
+"I should have objected very strongly this morning, Lord Henry."
+
+"Ah! this morning!  You have lived since then."
+
+There came a knock at the door, and the butler entered with a laden
+tea-tray and set it down upon a small Japanese table.  There was a
+rattle of cups and saucers and the hissing of a fluted Georgian urn.
+Two globe-shaped china dishes were brought in by a page.  Dorian Gray
+went over and poured out the tea.  The two men sauntered languidly to
+the table and examined what was under the covers.
+
+"Let us go to the theatre to-night," said Lord Henry.  "There is sure
+to be something on, somewhere.  I have promised to dine at White's, but
+it is only with an old friend, so I can send him a wire to say that I
+am ill, or that I am prevented from coming in consequence of a
+subsequent engagement.  I think that would be a rather nice excuse:  it
+would have all the surprise of candour."
+
+"It is such a bore putting on one's dress-clothes," muttered Hallward.
+"And, when one has them on, they are so horrid."
+
+"Yes," answered Lord Henry dreamily, "the costume of the nineteenth
+century is detestable.  It is so sombre, so depressing.  Sin is the
+only real colour-element left in modern life."
+
+"You really must not say things like that before Dorian, Harry."
+
+"Before which Dorian?  The one who is pouring out tea for us, or the
+one in the picture?"
+
+"Before either."
+
+"I should like to come to the theatre with you, Lord Henry," said the
+lad.
+
+"Then you shall come; and you will come, too, Basil, won't you?"
+
+"I can't, really.  I would sooner not.  I have a lot of work to do."
+
+"Well, then, you and I will go alone, Mr. Gray."
+
+"I should like that awfully."
+
+The painter bit his lip and walked over, cup in hand, to the picture.
+"I shall stay with the real Dorian," he said, sadly.
+
+"Is it the real Dorian?" cried the original of the portrait, strolling
+across to him.  "Am I really like that?"
+
+"Yes; you are just like that."
+
+"How wonderful, Basil!"
+
+"At least you are like it in appearance.  But it will never alter,"
+sighed Hallward.  "That is something."
+
+"What a fuss people make about fidelity!" exclaimed Lord Henry.  "Why,
+even in love it is purely a question for physiology.  It has nothing to
+do with our own will.  Young men want to be faithful, and are not; old
+men want to be faithless, and cannot: that is all one can say."
+
+"Don't go to the theatre to-night, Dorian," said Hallward.  "Stop and
+dine with me."
+
+"I can't, Basil."
+
+"Why?"
+
+"Because I have promised Lord Henry Wotton to go with him."
+
+"He won't like you the better for keeping your promises.  He always
+breaks his own.  I beg you not to go."
+
+Dorian Gray laughed and shook his head.
+
+"I entreat you."
+
+The lad hesitated, and looked over at Lord Henry, who was watching them
+from the tea-table with an amused smile.
+
+"I must go, Basil," he answered.
+
+"Very well," said Hallward, and he went over and laid down his cup on
+the tray.  "It is rather late, and, as you have to dress, you had
+better lose no time.  Good-bye, Harry.  Good-bye, Dorian.  Come and see
+me soon.  Come to-morrow."
+
+"Certainly."
+
+"You won't forget?"
+
+"No, of course not," cried Dorian.
+
+"And ... Harry!"
+
+"Yes, Basil?"
+
+"Remember what I asked you, when we were in the garden this morning."
+
+"I have forgotten it."
+
+"I trust you."
+
+"I wish I could trust myself," said Lord Henry, laughing.  "Come, Mr.
+Gray, my hansom is outside, and I can drop you at your own place.
+Good-bye, Basil.  It has been a most interesting afternoon."
+
+As the door closed behind them, the painter flung himself down on a
+sofa, and a look of pain came into his face.
+
+
+
+CHAPTER 3
+
+At half-past twelve next day Lord Henry Wotton strolled from Curzon
+Street over to the Albany to call on his uncle, Lord Fermor, a genial
+if somewhat rough-mannered old bachelor, whom the outside world called
+selfish because it derived no particular benefit from him, but who was
+considered generous by Society as he fed the people who amused him.
+His father had been our ambassador at Madrid when Isabella was young
+and Prim unthought of, but had retired from the diplomatic service in a
+capricious moment of annoyance on not being offered the Embassy at
+Paris, a post to which he considered that he was fully entitled by
+reason of his birth, his indolence, the good English of his dispatches,
+and his inordinate passion for pleasure.  The son, who had been his
+father's secretary, had resigned along with his chief, somewhat
+foolishly as was thought at the time, and on succeeding some months
+later to the title, had set himself to the serious study of the great
+aristocratic art of doing absolutely nothing.  He had two large town
+houses, but preferred to live in chambers as it was less trouble, and
+took most of his meals at his club.  He paid some attention to the
+management of his collieries in the Midland counties, excusing himself
+for this taint of industry on the ground that the one advantage of
+having coal was that it enabled a gentleman to afford the decency of
+burning wood on his own hearth.  In politics he was a Tory, except when
+the Tories were in office, during which period he roundly abused them
+for being a pack of Radicals.  He was a hero to his valet, who bullied
+him, and a terror to most of his relations, whom he bullied in turn.
+Only England could have produced him, and he always said that the
+country was going to the dogs.  His principles were out of date, but
+there was a good deal to be said for his prejudices.
+
+When Lord Henry entered the room, he found his uncle sitting in a rough
+shooting-coat, smoking a cheroot and grumbling over _The Times_.  "Well,
+Harry," said the old gentleman, "what brings you out so early?  I
+thought you dandies never got up till two, and were not visible till
+five."
+
+"Pure family affection, I assure you, Uncle George.  I want to get
+something out of you."
+
+"Money, I suppose," said Lord Fermor, making a wry face.  "Well, sit
+down and tell me all about it.  Young people, nowadays, imagine that
+money is everything."
+
+"Yes," murmured Lord Henry, settling his button-hole in his coat; "and
+when they grow older they know it.  But I don't want money.  It is only
+people who pay their bills who want that, Uncle George, and I never pay
+mine.  Credit is the capital of a younger son, and one lives charmingly
+upon it.  Besides, I always deal with Dartmoor's tradesmen, and
+consequently they never bother me.  What I want is information:  not
+useful information, of course; useless information."
+
+"Well, I can tell you anything that is in an English Blue Book, Harry,
+although those fellows nowadays write a lot of nonsense.  When I was in
+the Diplomatic, things were much better.  But I hear they let them in
+now by examination.  What can you expect?  Examinations, sir, are pure
+humbug from beginning to end.  If a man is a gentleman, he knows quite
+enough, and if he is not a gentleman, whatever he knows is bad for him."
+
+"Mr. Dorian Gray does not belong to Blue Books, Uncle George," said
+Lord Henry languidly.
+
+"Mr. Dorian Gray?  Who is he?" asked Lord Fermor, knitting his bushy
+white eyebrows.
+
+"That is what I have come to learn, Uncle George.  Or rather, I know
+who he is.  He is the last Lord Kelso's grandson.  His mother was a
+Devereux, Lady Margaret Devereux.  I want you to tell me about his
+mother.  What was she like?  Whom did she marry?  You have known nearly
+everybody in your time, so you might have known her.  I am very much
+interested in Mr. Gray at present.  I have only just met him."
+
+"Kelso's grandson!" echoed the old gentleman.  "Kelso's grandson! ...
+Of course.... I knew his mother intimately.  I believe I was at her
+christening.  She was an extraordinarily beautiful girl, Margaret
+Devereux, and made all the men frantic by running away with a penniless
+young fellow--a mere nobody, sir, a subaltern in a foot regiment, or
+something of that kind.  Certainly.  I remember the whole thing as if
+it happened yesterday.  The poor chap was killed in a duel at Spa a few
+months after the marriage.  There was an ugly story about it.  They
+said Kelso got some rascally adventurer, some Belgian brute, to insult
+his son-in-law in public--paid him, sir, to do it, paid him--and that
+the fellow spitted his man as if he had been a pigeon.  The thing was
+hushed up, but, egad, Kelso ate his chop alone at the club for some
+time afterwards.  He brought his daughter back with him, I was told,
+and she never spoke to him again.  Oh, yes; it was a bad business.  The
+girl died, too, died within a year.  So she left a son, did she?  I had
+forgotten that.  What sort of boy is he?  If he is like his mother, he
+must be a good-looking chap."
+
+"He is very good-looking," assented Lord Henry.
+
+"I hope he will fall into proper hands," continued the old man.  "He
+should have a pot of money waiting for him if Kelso did the right thing
+by him.  His mother had money, too.  All the Selby property came to
+her, through her grandfather.  Her grandfather hated Kelso, thought him
+a mean dog.  He was, too.  Came to Madrid once when I was there.  Egad,
+I was ashamed of him.  The Queen used to ask me about the English noble
+who was always quarrelling with the cabmen about their fares.  They
+made quite a story of it.  I didn't dare show my face at Court for a
+month.  I hope he treated his grandson better than he did the jarvies."
+
+"I don't know," answered Lord Henry.  "I fancy that the boy will be
+well off.  He is not of age yet.  He has Selby, I know.  He told me so.
+And ... his mother was very beautiful?"
+
+"Margaret Devereux was one of the loveliest creatures I ever saw,
+Harry.  What on earth induced her to behave as she did, I never could
+understand.  She could have married anybody she chose.  Carlington was
+mad after her.  She was romantic, though.  All the women of that family
+were.  The men were a poor lot, but, egad! the women were wonderful.
+Carlington went on his knees to her.  Told me so himself.  She laughed
+at him, and there wasn't a girl in London at the time who wasn't after
+him.  And by the way, Harry, talking about silly marriages, what is
+this humbug your father tells me about Dartmoor wanting to marry an
+American?  Ain't English girls good enough for him?"
+
+"It is rather fashionable to marry Americans just now, Uncle George."
+
+"I'll back English women against the world, Harry," said Lord Fermor,
+striking the table with his fist.
+
+"The betting is on the Americans."
+
+"They don't last, I am told," muttered his uncle.
+
+"A long engagement exhausts them, but they are capital at a
+steeplechase.  They take things flying.  I don't think Dartmoor has a
+chance."
+
+"Who are her people?" grumbled the old gentleman.  "Has she got any?"
+
+Lord Henry shook his head.  "American girls are as clever at concealing
+their parents, as English women are at concealing their past," he said,
+rising to go.
+
+"They are pork-packers, I suppose?"
+
+"I hope so, Uncle George, for Dartmoor's sake.  I am told that
+pork-packing is the most lucrative profession in America, after
+politics."
+
+"Is she pretty?"
+
+"She behaves as if she was beautiful.  Most American women do.  It is
+the secret of their charm."
+
+"Why can't these American women stay in their own country?  They are
+always telling us that it is the paradise for women."
+
+"It is.  That is the reason why, like Eve, they are so excessively
+anxious to get out of it," said Lord Henry.  "Good-bye, Uncle George.
+I shall be late for lunch, if I stop any longer.  Thanks for giving me
+the information I wanted.  I always like to know everything about my
+new friends, and nothing about my old ones."
+
+"Where are you lunching, Harry?"
+
+"At Aunt Agatha's. I have asked myself and Mr. Gray.  He is her latest
+_protege_."
+
+"Humph! tell your Aunt Agatha, Harry, not to bother me any more with
+her charity appeals.  I am sick of them.  Why, the good woman thinks
+that I have nothing to do but to write cheques for her silly fads."
+
+"All right, Uncle George, I'll tell her, but it won't have any effect.
+Philanthropic people lose all sense of humanity.  It is their
+distinguishing characteristic."
+
+The old gentleman growled approvingly and rang the bell for his
+servant.  Lord Henry passed up the low arcade into Burlington Street
+and turned his steps in the direction of Berkeley Square.
+
+So that was the story of Dorian Gray's parentage.  Crudely as it had
+been told to him, it had yet stirred him by its suggestion of a
+strange, almost modern romance.  A beautiful woman risking everything
+for a mad passion.  A few wild weeks of happiness cut short by a
+hideous, treacherous crime.  Months of voiceless agony, and then a
+child born in pain.  The mother snatched away by death, the boy left to
+solitude and the tyranny of an old and loveless man.  Yes; it was an
+interesting background.  It posed the lad, made him more perfect, as it
+were.  Behind every exquisite thing that existed, there was something
+tragic.  Worlds had to be in travail, that the meanest flower might
+blow.... And how charming he had been at dinner the night before, as
+with startled eyes and lips parted in frightened pleasure he had sat
+opposite to him at the club, the red candleshades staining to a richer
+rose the wakening wonder of his face.  Talking to him was like playing
+upon an exquisite violin.  He answered to every touch and thrill of the
+bow.... There was something terribly enthralling in the exercise of
+influence.  No other activity was like it.  To project one's soul into
+some gracious form, and let it tarry there for a moment; to hear one's
+own intellectual views echoed back to one with all the added music of
+passion and youth; to convey one's temperament into another as though
+it were a subtle fluid or a strange perfume: there was a real joy in
+that--perhaps the most satisfying joy left to us in an age so limited
+and vulgar as our own, an age grossly carnal in its pleasures, and
+grossly common in its aims.... He was a marvellous type, too, this lad,
+whom by so curious a chance he had met in Basil's studio, or could be
+fashioned into a marvellous type, at any rate.  Grace was his, and the
+white purity of boyhood, and beauty such as old Greek marbles kept for
+us.  There was nothing that one could not do with him.  He could be
+made a Titan or a toy.  What a pity it was that such beauty was
+destined to fade! ...  And Basil?  From a psychological point of view,
+how interesting he was!  The new manner in art, the fresh mode of
+looking at life, suggested so strangely by the merely visible presence
+of one who was unconscious of it all; the silent spirit that dwelt in
+dim woodland, and walked unseen in open field, suddenly showing
+herself, Dryadlike and not afraid, because in his soul who sought for
+her there had been wakened that wonderful vision to which alone are
+wonderful things revealed; the mere shapes and patterns of things
+becoming, as it were, refined, and gaining a kind of symbolical value,
+as though they were themselves patterns of some other and more perfect
+form whose shadow they made real:  how strange it all was!  He
+remembered something like it in history.  Was it not Plato, that artist
+in thought, who had first analyzed it?  Was it not Buonarotti who had
+carved it in the coloured marbles of a sonnet-sequence? But in our own
+century it was strange.... Yes; he would try to be to Dorian Gray
+what, without knowing it, the lad was to the painter who had fashioned
+the wonderful portrait.  He would seek to dominate him--had already,
+indeed, half done so.  He would make that wonderful spirit his own.
+There was something fascinating in this son of love and death.
+
+Suddenly he stopped and glanced up at the houses.  He found that he had
+passed his aunt's some distance, and, smiling to himself, turned back.
+When he entered the somewhat sombre hall, the butler told him that they
+had gone in to lunch.  He gave one of the footmen his hat and stick and
+passed into the dining-room.
+
+"Late as usual, Harry," cried his aunt, shaking her head at him.
+
+He invented a facile excuse, and having taken the vacant seat next to
+her, looked round to see who was there.  Dorian bowed to him shyly from
+the end of the table, a flush of pleasure stealing into his cheek.
+Opposite was the Duchess of Harley, a lady of admirable good-nature and
+good temper, much liked by every one who knew her, and of those ample
+architectural proportions that in women who are not duchesses are
+described by contemporary historians as stoutness.  Next to her sat, on
+her right, Sir Thomas Burdon, a Radical member of Parliament, who
+followed his leader in public life and in private life followed the
+best cooks, dining with the Tories and thinking with the Liberals, in
+accordance with a wise and well-known rule.  The post on her left was
+occupied by Mr. Erskine of Treadley, an old gentleman of considerable
+charm and culture, who had fallen, however, into bad habits of silence,
+having, as he explained once to Lady Agatha, said everything that he
+had to say before he was thirty.  His own neighbour was Mrs. Vandeleur,
+one of his aunt's oldest friends, a perfect saint amongst women, but so
+dreadfully dowdy that she reminded one of a badly bound hymn-book.
+Fortunately for him she had on the other side Lord Faudel, a most
+intelligent middle-aged mediocrity, as bald as a ministerial statement
+in the House of Commons, with whom she was conversing in that intensely
+earnest manner which is the one unpardonable error, as he remarked once
+himself, that all really good people fall into, and from which none of
+them ever quite escape.
+
+"We are talking about poor Dartmoor, Lord Henry," cried the duchess,
+nodding pleasantly to him across the table.  "Do you think he will
+really marry this fascinating young person?"
+
+"I believe she has made up her mind to propose to him, Duchess."
+
+"How dreadful!" exclaimed Lady Agatha.  "Really, some one should
+interfere."
+
+"I am told, on excellent authority, that her father keeps an American
+dry-goods store," said Sir Thomas Burdon, looking supercilious.
+
+"My uncle has already suggested pork-packing, Sir Thomas."
+
+"Dry-goods! What are American dry-goods?" asked the duchess, raising
+her large hands in wonder and accentuating the verb.
+
+"American novels," answered Lord Henry, helping himself to some quail.
+
+The duchess looked puzzled.
+
+"Don't mind him, my dear," whispered Lady Agatha.  "He never means
+anything that he says."
+
+"When America was discovered," said the Radical member--and he began to
+give some wearisome facts.  Like all people who try to exhaust a
+subject, he exhausted his listeners.  The duchess sighed and exercised
+her privilege of interruption.  "I wish to goodness it never had been
+discovered at all!" she exclaimed.  "Really, our girls have no chance
+nowadays.  It is most unfair."
+
+"Perhaps, after all, America never has been discovered," said Mr.
+Erskine; "I myself would say that it had merely been detected."
+
+"Oh! but I have seen specimens of the inhabitants," answered the
+duchess vaguely.  "I must confess that most of them are extremely
+pretty.  And they dress well, too.  They get all their dresses in
+Paris.  I wish I could afford to do the same."
+
+"They say that when good Americans die they go to Paris," chuckled Sir
+Thomas, who had a large wardrobe of Humour's cast-off clothes.
+
+"Really!  And where do bad Americans go to when they die?" inquired the
+duchess.
+
+"They go to America," murmured Lord Henry.
+
+Sir Thomas frowned.  "I am afraid that your nephew is prejudiced
+against that great country," he said to Lady Agatha.  "I have travelled
+all over it in cars provided by the directors, who, in such matters,
+are extremely civil.  I assure you that it is an education to visit it."
+
+"But must we really see Chicago in order to be educated?" asked Mr.
+Erskine plaintively.  "I don't feel up to the journey."
+
+Sir Thomas waved his hand.  "Mr. Erskine of Treadley has the world on
+his shelves. We practical men like to see things, not to read about
+them. The Americans are an extremely interesting people. They are
+absolutely reasonable. I think that is their distinguishing
+characteristic. Yes, Mr. Erskine, an absolutely reasonable people. I
+assure you there is no nonsense about the Americans."
+
+"How dreadful!" cried Lord Henry.  "I can stand brute force, but brute
+reason is quite unbearable.  There is something unfair about its use.
+It is hitting below the intellect."
+
+"I do not understand you," said Sir Thomas, growing rather red.
+
+"I do, Lord Henry," murmured Mr. Erskine, with a smile.
+
+"Paradoxes are all very well in their way...." rejoined the baronet.
+
+"Was that a paradox?" asked Mr. Erskine.  "I did not think so.  Perhaps
+it was.  Well, the way of paradoxes is the way of truth.  To test
+reality we must see it on the tight rope.  When the verities become
+acrobats, we can judge them."
+
+"Dear me!" said Lady Agatha, "how you men argue!  I am sure I never can
+make out what you are talking about.  Oh!  Harry, I am quite vexed with
+you.  Why do you try to persuade our nice Mr. Dorian Gray to give up
+the East End?  I assure you he would be quite invaluable.  They would
+love his playing."
+
+"I want him to play to me," cried Lord Henry, smiling, and he looked
+down the table and caught a bright answering glance.
+
+"But they are so unhappy in Whitechapel," continued Lady Agatha.
+
+"I can sympathize with everything except suffering," said Lord Henry,
+shrugging his shoulders.  "I cannot sympathize with that.  It is too
+ugly, too horrible, too distressing.  There is something terribly
+morbid in the modern sympathy with pain.  One should sympathize with
+the colour, the beauty, the joy of life.  The less said about life's
+sores, the better."
+
+"Still, the East End is a very important problem," remarked Sir Thomas
+with a grave shake of the head.
+
+"Quite so," answered the young lord.  "It is the problem of slavery,
+and we try to solve it by amusing the slaves."
+
+The politician looked at him keenly.  "What change do you propose,
+then?" he asked.
+
+Lord Henry laughed.  "I don't desire to change anything in England
+except the weather," he answered.  "I am quite content with philosophic
+contemplation.  But, as the nineteenth century has gone bankrupt
+through an over-expenditure of sympathy, I would suggest that we should
+appeal to science to put us straight.  The advantage of the emotions is
+that they lead us astray, and the advantage of science is that it is
+not emotional."
+
+"But we have such grave responsibilities," ventured Mrs. Vandeleur
+timidly.
+
+"Terribly grave," echoed Lady Agatha.
+
+Lord Henry looked over at Mr. Erskine.  "Humanity takes itself too
+seriously.  It is the world's original sin.  If the caveman had known
+how to laugh, history would have been different."
+
+"You are really very comforting," warbled the duchess.  "I have always
+felt rather guilty when I came to see your dear aunt, for I take no
+interest at all in the East End.  For the future I shall be able to
+look her in the face without a blush."
+
+"A blush is very becoming, Duchess," remarked Lord Henry.
+
+"Only when one is young," she answered.  "When an old woman like myself
+blushes, it is a very bad sign.  Ah!  Lord Henry, I wish you would tell
+me how to become young again."
+
+He thought for a moment.  "Can you remember any great error that you
+committed in your early days, Duchess?" he asked, looking at her across
+the table.
+
+"A great many, I fear," she cried.
+
+"Then commit them over again," he said gravely.  "To get back one's
+youth, one has merely to repeat one's follies."
+
+"A delightful theory!" she exclaimed.  "I must put it into practice."
+
+"A dangerous theory!" came from Sir Thomas's tight lips.  Lady Agatha
+shook her head, but could not help being amused.  Mr. Erskine listened.
+
+"Yes," he continued, "that is one of the great secrets of life.
+Nowadays most people die of a sort of creeping common sense, and
+discover when it is too late that the only things one never regrets are
+one's mistakes."
+
+A laugh ran round the table.
+
+He played with the idea and grew wilful; tossed it into the air and
+transformed it; let it escape and recaptured it; made it iridescent
+with fancy and winged it with paradox.  The praise of folly, as he went
+on, soared into a philosophy, and philosophy herself became young, and
+catching the mad music of pleasure, wearing, one might fancy, her
+wine-stained robe and wreath of ivy, danced like a Bacchante over the
+hills of life, and mocked the slow Silenus for being sober.  Facts fled
+before her like frightened forest things.  Her white feet trod the huge
+press at which wise Omar sits, till the seething grape-juice rose round
+her bare limbs in waves of purple bubbles, or crawled in red foam over
+the vat's black, dripping, sloping sides.  It was an extraordinary
+improvisation.  He felt that the eyes of Dorian Gray were fixed on him,
+and the consciousness that amongst his audience there was one whose
+temperament he wished to fascinate seemed to give his wit keenness and
+to lend colour to his imagination.  He was brilliant, fantastic,
+irresponsible.  He charmed his listeners out of themselves, and they
+followed his pipe, laughing.  Dorian Gray never took his gaze off him,
+but sat like one under a spell, smiles chasing each other over his lips
+and wonder growing grave in his darkening eyes.
+
+At last, liveried in the costume of the age, reality entered the room
+in the shape of a servant to tell the duchess that her carriage was
+waiting.  She wrung her hands in mock despair.  "How annoying!" she
+cried.  "I must go.  I have to call for my husband at the club, to take
+him to some absurd meeting at Willis's Rooms, where he is going to be
+in the chair.  If I am late he is sure to be furious, and I couldn't
+have a scene in this bonnet.  It is far too fragile.  A harsh word
+would ruin it.  No, I must go, dear Agatha.  Good-bye, Lord Henry, you
+are quite delightful and dreadfully demoralizing.  I am sure I don't
+know what to say about your views.  You must come and dine with us some
+night.  Tuesday?  Are you disengaged Tuesday?"
+
+"For you I would throw over anybody, Duchess," said Lord Henry with a
+bow.
+
+"Ah! that is very nice, and very wrong of you," she cried; "so mind you
+come"; and she swept out of the room, followed by Lady Agatha and the
+other ladies.
+
+When Lord Henry had sat down again, Mr. Erskine moved round, and taking
+a chair close to him, placed his hand upon his arm.
+
+"You talk books away," he said; "why don't you write one?"
+
+"I am too fond of reading books to care to write them, Mr. Erskine.  I
+should like to write a novel certainly, a novel that would be as lovely
+as a Persian carpet and as unreal.  But there is no literary public in
+England for anything except newspapers, primers, and encyclopaedias.
+Of all people in the world the English have the least sense of the
+beauty of literature."
+
+"I fear you are right," answered Mr. Erskine.  "I myself used to have
+literary ambitions, but I gave them up long ago.  And now, my dear
+young friend, if you will allow me to call you so, may I ask if you
+really meant all that you said to us at lunch?"
+
+"I quite forget what I said," smiled Lord Henry.  "Was it all very bad?"
+
+"Very bad indeed.  In fact I consider you extremely dangerous, and if
+anything happens to our good duchess, we shall all look on you as being
+primarily responsible.  But I should like to talk to you about life.
+The generation into which I was born was tedious.  Some day, when you
+are tired of London, come down to Treadley and expound to me your
+philosophy of pleasure over some admirable Burgundy I am fortunate
+enough to possess."
+
+"I shall be charmed.  A visit to Treadley would be a great privilege.
+It has a perfect host, and a perfect library."
+
+"You will complete it," answered the old gentleman with a courteous
+bow.  "And now I must bid good-bye to your excellent aunt.  I am due at
+the Athenaeum.  It is the hour when we sleep there."
+
+"All of you, Mr. Erskine?"
+
+"Forty of us, in forty arm-chairs. We are practising for an English
+Academy of Letters."
+
+Lord Henry laughed and rose.  "I am going to the park," he cried.
+
+As he was passing out of the door, Dorian Gray touched him on the arm.
+"Let me come with you," he murmured.
+
+"But I thought you had promised Basil Hallward to go and see him,"
+answered Lord Henry.
+
+"I would sooner come with you; yes, I feel I must come with you.  Do
+let me.  And you will promise to talk to me all the time?  No one talks
+so wonderfully as you do."
+
+"Ah!  I have talked quite enough for to-day," said Lord Henry, smiling.
+"All I want now is to look at life.  You may come and look at it with
+me, if you care to."
+
+
+
+CHAPTER 4
+
+One afternoon, a month later, Dorian Gray was reclining in a luxurious
+arm-chair, in the little library of Lord Henry's house in Mayfair.  It
+was, in its way, a very charming room, with its high panelled
+wainscoting of olive-stained oak, its cream-coloured frieze and ceiling
+of raised plasterwork, and its brickdust felt carpet strewn with silk,
+long-fringed Persian rugs.  On a tiny satinwood table stood a statuette
+by Clodion, and beside it lay a copy of Les Cent Nouvelles, bound for
+Margaret of Valois by Clovis Eve and powdered with the gilt daisies
+that Queen had selected for her device.  Some large blue china jars and
+parrot-tulips were ranged on the mantelshelf, and through the small
+leaded panes of the window streamed the apricot-coloured light of a
+summer day in London.
+
+Lord Henry had not yet come in.  He was always late on principle, his
+principle being that punctuality is the thief of time.  So the lad was
+looking rather sulky, as with listless fingers he turned over the pages
+of an elaborately illustrated edition of Manon Lescaut that he had
+found in one of the book-cases. The formal monotonous ticking of the
+Louis Quatorze clock annoyed him.  Once or twice he thought of going
+away.
+
+At last he heard a step outside, and the door opened.  "How late you
+are, Harry!" he murmured.
+
+"I am afraid it is not Harry, Mr. Gray," answered a shrill voice.
+
+He glanced quickly round and rose to his feet.  "I beg your pardon.  I
+thought--"
+
+"You thought it was my husband.  It is only his wife.  You must let me
+introduce myself.  I know you quite well by your photographs.  I think
+my husband has got seventeen of them."
+
+"Not seventeen, Lady Henry?"
+
+"Well, eighteen, then.  And I saw you with him the other night at the
+opera."  She laughed nervously as she spoke, and watched him with her
+vague forget-me-not eyes.  She was a curious woman, whose dresses
+always looked as if they had been designed in a rage and put on in a
+tempest.  She was usually in love with somebody, and, as her passion
+was never returned, she had kept all her illusions.  She tried to look
+picturesque, but only succeeded in being untidy.  Her name was
+Victoria, and she had a perfect mania for going to church.
+
+"That was at Lohengrin, Lady Henry, I think?"
+
+"Yes; it was at dear Lohengrin.  I like Wagner's music better than
+anybody's. It is so loud that one can talk the whole time without other
+people hearing what one says.  That is a great advantage, don't you
+think so, Mr. Gray?"
+
+The same nervous staccato laugh broke from her thin lips, and her
+fingers began to play with a long tortoise-shell paper-knife.
+
+Dorian smiled and shook his head:  "I am afraid I don't think so, Lady
+Henry.  I never talk during music--at least, during good music.  If one
+hears bad music, it is one's duty to drown it in conversation."
+
+"Ah! that is one of Harry's views, isn't it, Mr. Gray?  I always hear
+Harry's views from his friends.  It is the only way I get to know of
+them.  But you must not think I don't like good music.  I adore it, but
+I am afraid of it.  It makes me too romantic.  I have simply worshipped
+pianists--two at a time, sometimes, Harry tells me.  I don't know what
+it is about them.  Perhaps it is that they are foreigners.  They all
+are, ain't they?  Even those that are born in England become foreigners
+after a time, don't they?  It is so clever of them, and such a
+compliment to art.  Makes it quite cosmopolitan, doesn't it?  You have
+never been to any of my parties, have you, Mr. Gray?  You must come.  I
+can't afford orchids, but I spare no expense in foreigners.  They make
+one's rooms look so picturesque.  But here is Harry!  Harry, I came in
+to look for you, to ask you something--I forget what it was--and I
+found Mr. Gray here.  We have had such a pleasant chat about music.  We
+have quite the same ideas.  No; I think our ideas are quite different.
+But he has been most pleasant.  I am so glad I've seen him."
+
+"I am charmed, my love, quite charmed," said Lord Henry, elevating his
+dark, crescent-shaped eyebrows and looking at them both with an amused
+smile.  "So sorry I am late, Dorian.  I went to look after a piece of
+old brocade in Wardour Street and had to bargain for hours for it.
+Nowadays people know the price of everything and the value of nothing."
+
+"I am afraid I must be going," exclaimed Lady Henry, breaking an
+awkward silence with her silly sudden laugh.  "I have promised to drive
+with the duchess.  Good-bye, Mr. Gray.  Good-bye, Harry.  You are
+dining out, I suppose?  So am I. Perhaps I shall see you at Lady
+Thornbury's."
+
+"I dare say, my dear," said Lord Henry, shutting the door behind her
+as, looking like a bird of paradise that had been out all night in the
+rain, she flitted out of the room, leaving a faint odour of
+frangipanni.  Then he lit a cigarette and flung himself down on the
+sofa.
+
+"Never marry a woman with straw-coloured hair, Dorian," he said after a
+few puffs.
+
+"Why, Harry?"
+
+"Because they are so sentimental."
+
+"But I like sentimental people."
+
+"Never marry at all, Dorian.  Men marry because they are tired; women,
+because they are curious:  both are disappointed."
+
+"I don't think I am likely to marry, Harry.  I am too much in love.
+That is one of your aphorisms.  I am putting it into practice, as I do
+everything that you say."
+
+"Who are you in love with?" asked Lord Henry after a pause.
+
+"With an actress," said Dorian Gray, blushing.
+
+Lord Henry shrugged his shoulders.  "That is a rather commonplace
+_debut_."
+
+"You would not say so if you saw her, Harry."
+
+"Who is she?"
+
+"Her name is Sibyl Vane."
+
+"Never heard of her."
+
+"No one has.  People will some day, however.  She is a genius."
+
+"My dear boy, no woman is a genius.  Women are a decorative sex.  They
+never have anything to say, but they say it charmingly.  Women
+represent the triumph of matter over mind, just as men represent the
+triumph of mind over morals."
+
+"Harry, how can you?"
+
+"My dear Dorian, it is quite true.  I am analysing women at present, so
+I ought to know.  The subject is not so abstruse as I thought it was.
+I find that, ultimately, there are only two kinds of women, the plain
+and the coloured.  The plain women are very useful.  If you want to
+gain a reputation for respectability, you have merely to take them down
+to supper.  The other women are very charming.  They commit one
+mistake, however.  They paint in order to try and look young.  Our
+grandmothers painted in order to try and talk brilliantly.  _Rouge_ and
+_esprit_ used to go together.  That is all over now.  As long as a woman
+can look ten years younger than her own daughter, she is perfectly
+satisfied.  As for conversation, there are only five women in London
+worth talking to, and two of these can't be admitted into decent
+society.  However, tell me about your genius.  How long have you known
+her?"
+
+"Ah!  Harry, your views terrify me."
+
+"Never mind that.  How long have you known her?"
+
+"About three weeks."
+
+"And where did you come across her?"
+
+"I will tell you, Harry, but you mustn't be unsympathetic about it.
+After all, it never would have happened if I had not met you.  You
+filled me with a wild desire to know everything about life.  For days
+after I met you, something seemed to throb in my veins.  As I lounged
+in the park, or strolled down Piccadilly, I used to look at every one
+who passed me and wonder, with a mad curiosity, what sort of lives they
+led.  Some of them fascinated me.  Others filled me with terror.  There
+was an exquisite poison in the air.  I had a passion for sensations....
+Well, one evening about seven o'clock, I determined to go out in search
+of some adventure.  I felt that this grey monstrous London of ours,
+with its myriads of people, its sordid sinners, and its splendid sins,
+as you once phrased it, must have something in store for me.  I fancied
+a thousand things.  The mere danger gave me a sense of delight.  I
+remembered what you had said to me on that wonderful evening when we
+first dined together, about the search for beauty being the real secret
+of life.  I don't know what I expected, but I went out and wandered
+eastward, soon losing my way in a labyrinth of grimy streets and black
+grassless squares.  About half-past eight I passed by an absurd little
+theatre, with great flaring gas-jets and gaudy play-bills.  A hideous
+Jew, in the most amazing waistcoat I ever beheld in my life, was
+standing at the entrance, smoking a vile cigar.  He had greasy
+ringlets, and an enormous diamond blazed in the centre of a soiled
+shirt. 'Have a box, my Lord?' he said, when he saw me, and he took off
+his hat with an air of gorgeous servility.  There was something about
+him, Harry, that amused me.  He was such a monster.  You will laugh at
+me, I know, but I really went in and paid a whole guinea for the
+stage-box. To the present day I can't make out why I did so; and yet if
+I hadn't--my dear Harry, if I hadn't--I should have missed the greatest
+romance of my life.  I see you are laughing.  It is horrid of you!"
+
+"I am not laughing, Dorian; at least I am not laughing at you.  But you
+should not say the greatest romance of your life.  You should say the
+first romance of your life.  You will always be loved, and you will
+always be in love with love.  A _grande passion_ is the privilege of
+people who have nothing to do.  That is the one use of the idle classes
+of a country.  Don't be afraid.  There are exquisite things in store
+for you.  This is merely the beginning."
+
+"Do you think my nature so shallow?" cried Dorian Gray angrily.
+
+"No; I think your nature so deep."
+
+"How do you mean?"
+
+"My dear boy, the people who love only once in their lives are really
+the shallow people.  What they call their loyalty, and their fidelity,
+I call either the lethargy of custom or their lack of imagination.
+Faithfulness is to the emotional life what consistency is to the life
+of the intellect--simply a confession of failure.  Faithfulness!  I
+must analyse it some day.  The passion for property is in it.  There
+are many things that we would throw away if we were not afraid that
+others might pick them up.  But I don't want to interrupt you.  Go on
+with your story."
+
+"Well, I found myself seated in a horrid little private box, with a
+vulgar drop-scene staring me in the face.  I looked out from behind the
+curtain and surveyed the house.  It was a tawdry affair, all Cupids and
+cornucopias, like a third-rate wedding-cake. The gallery and pit were
+fairly full, but the two rows of dingy stalls were quite empty, and
+there was hardly a person in what I suppose they called the
+dress-circle.  Women went about with oranges and ginger-beer, and there
+was a terrible consumption of nuts going on."
+
+"It must have been just like the palmy days of the British drama."
+
+"Just like, I should fancy, and very depressing.  I began to wonder
+what on earth I should do when I caught sight of the play-bill.  What
+do you think the play was, Harry?"
+
+"I should think 'The Idiot Boy', or 'Dumb but Innocent'.  Our fathers
+used to like that sort of piece, I believe.  The longer I live, Dorian,
+the more keenly I feel that whatever was good enough for our fathers is
+not good enough for us.  In art, as in politics, _les grandperes ont
+toujours tort_."
+
+"This play was good enough for us, Harry.  It was Romeo and Juliet.  I
+must admit that I was rather annoyed at the idea of seeing Shakespeare
+done in such a wretched hole of a place.  Still, I felt interested, in
+a sort of way.  At any rate, I determined to wait for the first act.
+There was a dreadful orchestra, presided over by a young Hebrew who sat
+at a cracked piano, that nearly drove me away, but at last the
+drop-scene was drawn up and the play began.  Romeo was a stout elderly
+gentleman, with corked eyebrows, a husky tragedy voice, and a figure
+like a beer-barrel. Mercutio was almost as bad.  He was played by the
+low-comedian, who had introduced gags of his own and was on most
+friendly terms with the pit.  They were both as grotesque as the
+scenery, and that looked as if it had come out of a country-booth. But
+Juliet!  Harry, imagine a girl, hardly seventeen years of age, with a
+little, flowerlike face, a small Greek head with plaited coils of
+dark-brown hair, eyes that were violet wells of passion, lips that were
+like the petals of a rose.  She was the loveliest thing I had ever seen
+in my life.  You said to me once that pathos left you unmoved, but that
+beauty, mere beauty, could fill your eyes with tears.  I tell you,
+Harry, I could hardly see this girl for the mist of tears that came
+across me.  And her voice--I never heard such a voice.  It was very low
+at first, with deep mellow notes that seemed to fall singly upon one's
+ear.  Then it became a little louder, and sounded like a flute or a
+distant hautboy.  In the garden-scene it had all the tremulous ecstasy
+that one hears just before dawn when nightingales are singing.  There
+were moments, later on, when it had the wild passion of violins.  You
+know how a voice can stir one.  Your voice and the voice of Sibyl Vane
+are two things that I shall never forget.  When I close my eyes, I hear
+them, and each of them says something different.  I don't know which to
+follow.  Why should I not love her?  Harry, I do love her.  She is
+everything to me in life.  Night after night I go to see her play.  One
+evening she is Rosalind, and the next evening she is Imogen.  I have
+seen her die in the gloom of an Italian tomb, sucking the poison from
+her lover's lips.  I have watched her wandering through the forest of
+Arden, disguised as a pretty boy in hose and doublet and dainty cap.
+She has been mad, and has come into the presence of a guilty king, and
+given him rue to wear and bitter herbs to taste of.  She has been
+innocent, and the black hands of jealousy have crushed her reedlike
+throat.  I have seen her in every age and in every costume.  Ordinary
+women never appeal to one's imagination.  They are limited to their
+century.  No glamour ever transfigures them.  One knows their minds as
+easily as one knows their bonnets.  One can always find them.  There is
+no mystery in any of them.  They ride in the park in the morning and
+chatter at tea-parties in the afternoon.  They have their stereotyped
+smile and their fashionable manner.  They are quite obvious.  But an
+actress!  How different an actress is!  Harry! why didn't you tell me
+that the only thing worth loving is an actress?"
+
+"Because I have loved so many of them, Dorian."
+
+"Oh, yes, horrid people with dyed hair and painted faces."
+
+"Don't run down dyed hair and painted faces.  There is an extraordinary
+charm in them, sometimes," said Lord Henry.
+
+"I wish now I had not told you about Sibyl Vane."
+
+"You could not have helped telling me, Dorian.  All through your life
+you will tell me everything you do."
+
+"Yes, Harry, I believe that is true.  I cannot help telling you things.
+You have a curious influence over me.  If I ever did a crime, I would
+come and confess it to you.  You would understand me."
+
+"People like you--the wilful sunbeams of life--don't commit crimes,
+Dorian.  But I am much obliged for the compliment, all the same.  And
+now tell me--reach me the matches, like a good boy--thanks--what are
+your actual relations with Sibyl Vane?"
+
+Dorian Gray leaped to his feet, with flushed cheeks and burning eyes.
+"Harry!  Sibyl Vane is sacred!"
+
+"It is only the sacred things that are worth touching, Dorian," said
+Lord Henry, with a strange touch of pathos in his voice.  "But why
+should you be annoyed?  I suppose she will belong to you some day.
+When one is in love, one always begins by deceiving one's self, and one
+always ends by deceiving others.  That is what the world calls a
+romance.  You know her, at any rate, I suppose?"
+
+"Of course I know her.  On the first night I was at the theatre, the
+horrid old Jew came round to the box after the performance was over and
+offered to take me behind the scenes and introduce me to her.  I was
+furious with him, and told him that Juliet had been dead for hundreds
+of years and that her body was lying in a marble tomb in Verona.  I
+think, from his blank look of amazement, that he was under the
+impression that I had taken too much champagne, or something."
+
+"I am not surprised."
+
+"Then he asked me if I wrote for any of the newspapers.  I told him I
+never even read them.  He seemed terribly disappointed at that, and
+confided to me that all the dramatic critics were in a conspiracy
+against him, and that they were every one of them to be bought."
+
+"I should not wonder if he was quite right there.  But, on the other
+hand, judging from their appearance, most of them cannot be at all
+expensive."
+
+"Well, he seemed to think they were beyond his means," laughed Dorian.
+"By this time, however, the lights were being put out in the theatre,
+and I had to go.  He wanted me to try some cigars that he strongly
+recommended.  I declined.  The next night, of course, I arrived at the
+place again.  When he saw me, he made me a low bow and assured me that
+I was a munificent patron of art.  He was a most offensive brute,
+though he had an extraordinary passion for Shakespeare.  He told me
+once, with an air of pride, that his five bankruptcies were entirely
+due to 'The Bard,' as he insisted on calling him.  He seemed to think
+it a distinction."
+
+"It was a distinction, my dear Dorian--a great distinction.  Most
+people become bankrupt through having invested too heavily in the prose
+of life.  To have ruined one's self over poetry is an honour.  But when
+did you first speak to Miss Sibyl Vane?"
+
+"The third night.  She had been playing Rosalind.  I could not help
+going round.  I had thrown her some flowers, and she had looked at
+me--at least I fancied that she had.  The old Jew was persistent.  He
+seemed determined to take me behind, so I consented.  It was curious my
+not wanting to know her, wasn't it?"
+
+"No; I don't think so."
+
+"My dear Harry, why?"
+
+"I will tell you some other time.  Now I want to know about the girl."
+
+"Sibyl?  Oh, she was so shy and so gentle.  There is something of a
+child about her.  Her eyes opened wide in exquisite wonder when I told
+her what I thought of her performance, and she seemed quite unconscious
+of her power.  I think we were both rather nervous.  The old Jew stood
+grinning at the doorway of the dusty greenroom, making elaborate
+speeches about us both, while we stood looking at each other like
+children.  He would insist on calling me 'My Lord,' so I had to assure
+Sibyl that I was not anything of the kind.  She said quite simply to
+me, 'You look more like a prince.  I must call you Prince Charming.'"
+
+"Upon my word, Dorian, Miss Sibyl knows how to pay compliments."
+
+"You don't understand her, Harry.  She regarded me merely as a person
+in a play.  She knows nothing of life.  She lives with her mother, a
+faded tired woman who played Lady Capulet in a sort of magenta
+dressing-wrapper on the first night, and looks as if she had seen
+better days."
+
+"I know that look.  It depresses me," murmured Lord Henry, examining
+his rings.
+
+"The Jew wanted to tell me her history, but I said it did not interest
+me."
+
+"You were quite right.  There is always something infinitely mean about
+other people's tragedies."
+
+"Sibyl is the only thing I care about.  What is it to me where she came
+from?  From her little head to her little feet, she is absolutely and
+entirely divine.  Every night of my life I go to see her act, and every
+night she is more marvellous."
+
+"That is the reason, I suppose, that you never dine with me now.  I
+thought you must have some curious romance on hand.  You have; but it
+is not quite what I expected."
+
+"My dear Harry, we either lunch or sup together every day, and I have
+been to the opera with you several times," said Dorian, opening his
+blue eyes in wonder.
+
+"You always come dreadfully late."
+
+"Well, I can't help going to see Sibyl play," he cried, "even if it is
+only for a single act.  I get hungry for her presence; and when I think
+of the wonderful soul that is hidden away in that little ivory body, I
+am filled with awe."
+
+"You can dine with me to-night, Dorian, can't you?"
+
+He shook his head.  "To-night she is Imogen," he answered, "and
+to-morrow night she will be Juliet."
+
+"When is she Sibyl Vane?"
+
+"Never."
+
+"I congratulate you."
+
+"How horrid you are!  She is all the great heroines of the world in
+one.  She is more than an individual.  You laugh, but I tell you she
+has genius.  I love her, and I must make her love me.  You, who know
+all the secrets of life, tell me how to charm Sibyl Vane to love me!  I
+want to make Romeo jealous.  I want the dead lovers of the world to
+hear our laughter and grow sad.  I want a breath of our passion to stir
+their dust into consciousness, to wake their ashes into pain.  My God,
+Harry, how I worship her!"  He was walking up and down the room as he
+spoke.  Hectic spots of red burned on his cheeks.  He was terribly
+excited.
+
+Lord Henry watched him with a subtle sense of pleasure.  How different
+he was now from the shy frightened boy he had met in Basil Hallward's
+studio!  His nature had developed like a flower, had borne blossoms of
+scarlet flame.  Out of its secret hiding-place had crept his soul, and
+desire had come to meet it on the way.
+
+"And what do you propose to do?" said Lord Henry at last.
+
+"I want you and Basil to come with me some night and see her act.  I
+have not the slightest fear of the result.  You are certain to
+acknowledge her genius.  Then we must get her out of the Jew's hands.
+She is bound to him for three years--at least for two years and eight
+months--from the present time.  I shall have to pay him something, of
+course.  When all that is settled, I shall take a West End theatre and
+bring her out properly.  She will make the world as mad as she has made
+me."
+
+"That would be impossible, my dear boy."
+
+"Yes, she will.  She has not merely art, consummate art-instinct, in
+her, but she has personality also; and you have often told me that it
+is personalities, not principles, that move the age."
+
+"Well, what night shall we go?"
+
+"Let me see.  To-day is Tuesday.  Let us fix to-morrow. She plays
+Juliet to-morrow."
+
+"All right.  The Bristol at eight o'clock; and I will get Basil."
+
+"Not eight, Harry, please.  Half-past six.  We must be there before the
+curtain rises.  You must see her in the first act, where she meets
+Romeo."
+
+"Half-past six!  What an hour!  It will be like having a meat-tea, or
+reading an English novel.  It must be seven.  No gentleman dines before
+seven.  Shall you see Basil between this and then?  Or shall I write to
+him?"
+
+"Dear Basil!  I have not laid eyes on him for a week.  It is rather
+horrid of me, as he has sent me my portrait in the most wonderful
+frame, specially designed by himself, and, though I am a little jealous
+of the picture for being a whole month younger than I am, I must admit
+that I delight in it.  Perhaps you had better write to him.  I don't
+want to see him alone.  He says things that annoy me.  He gives me good
+advice."
+
+Lord Henry smiled.  "People are very fond of giving away what they need
+most themselves.  It is what I call the depth of generosity."
+
+"Oh, Basil is the best of fellows, but he seems to me to be just a bit
+of a Philistine.  Since I have known you, Harry, I have discovered
+that."
+
+"Basil, my dear boy, puts everything that is charming in him into his
+work.  The consequence is that he has nothing left for life but his
+prejudices, his principles, and his common sense.  The only artists I
+have ever known who are personally delightful are bad artists.  Good
+artists exist simply in what they make, and consequently are perfectly
+uninteresting in what they are.  A great poet, a really great poet, is
+the most unpoetical of all creatures.  But inferior poets are
+absolutely fascinating.  The worse their rhymes are, the more
+picturesque they look.  The mere fact of having published a book of
+second-rate sonnets makes a man quite irresistible.  He lives the
+poetry that he cannot write.  The others write the poetry that they
+dare not realize."
+
+"I wonder is that really so, Harry?" said Dorian Gray, putting some
+perfume on his handkerchief out of a large, gold-topped bottle that
+stood on the table.  "It must be, if you say it.  And now I am off.
+Imogen is waiting for me.  Don't forget about to-morrow. Good-bye."
+
+As he left the room, Lord Henry's heavy eyelids drooped, and he began
+to think.  Certainly few people had ever interested him so much as
+Dorian Gray, and yet the lad's mad adoration of some one else caused
+him not the slightest pang of annoyance or jealousy.  He was pleased by
+it.  It made him a more interesting study.  He had been always
+enthralled by the methods of natural science, but the ordinary
+subject-matter of that science had seemed to him trivial and of no
+import.  And so he had begun by vivisecting himself, as he had ended by
+vivisecting others.  Human life--that appeared to him the one thing
+worth investigating.  Compared to it there was nothing else of any
+value.  It was true that as one watched life in its curious crucible of
+pain and pleasure, one could not wear over one's face a mask of glass,
+nor keep the sulphurous fumes from troubling the brain and making the
+imagination turbid with monstrous fancies and misshapen dreams.  There
+were poisons so subtle that to know their properties one had to sicken
+of them.  There were maladies so strange that one had to pass through
+them if one sought to understand their nature.  And, yet, what a great
+reward one received!  How wonderful the whole world became to one!  To
+note the curious hard logic of passion, and the emotional coloured life
+of the intellect--to observe where they met, and where they separated,
+at what point they were in unison, and at what point they were at
+discord--there was a delight in that!  What matter what the cost was?
+One could never pay too high a price for any sensation.
+
+He was conscious--and the thought brought a gleam of pleasure into his
+brown agate eyes--that it was through certain words of his, musical
+words said with musical utterance, that Dorian Gray's soul had turned
+to this white girl and bowed in worship before her.  To a large extent
+the lad was his own creation.  He had made him premature.  That was
+something.  Ordinary people waited till life disclosed to them its
+secrets, but to the few, to the elect, the mysteries of life were
+revealed before the veil was drawn away.  Sometimes this was the effect
+of art, and chiefly of the art of literature, which dealt immediately
+with the passions and the intellect.  But now and then a complex
+personality took the place and assumed the office of art, was indeed,
+in its way, a real work of art, life having its elaborate masterpieces,
+just as poetry has, or sculpture, or painting.
+
+Yes, the lad was premature.  He was gathering his harvest while it was
+yet spring.  The pulse and passion of youth were in him, but he was
+becoming self-conscious. It was delightful to watch him.  With his
+beautiful face, and his beautiful soul, he was a thing to wonder at.
+It was no matter how it all ended, or was destined to end.  He was like
+one of those gracious figures in a pageant or a play, whose joys seem
+to be remote from one, but whose sorrows stir one's sense of beauty,
+and whose wounds are like red roses.
+
+Soul and body, body and soul--how mysterious they were!  There was
+animalism in the soul, and the body had its moments of spirituality.
+The senses could refine, and the intellect could degrade.  Who could
+say where the fleshly impulse ceased, or the psychical impulse began?
+How shallow were the arbitrary definitions of ordinary psychologists!
+And yet how difficult to decide between the claims of the various
+schools!  Was the soul a shadow seated in the house of sin?  Or was the
+body really in the soul, as Giordano Bruno thought?  The separation of
+spirit from matter was a mystery, and the union of spirit with matter
+was a mystery also.
+
+He began to wonder whether we could ever make psychology so absolute a
+science that each little spring of life would be revealed to us.  As it
+was, we always misunderstood ourselves and rarely understood others.
+Experience was of no ethical value.  It was merely the name men gave to
+their mistakes.  Moralists had, as a rule, regarded it as a mode of
+warning, had claimed for it a certain ethical efficacy in the formation
+of character, had praised it as something that taught us what to follow
+and showed us what to avoid.  But there was no motive power in
+experience.  It was as little of an active cause as conscience itself.
+All that it really demonstrated was that our future would be the same
+as our past, and that the sin we had done once, and with loathing, we
+would do many times, and with joy.
+
+It was clear to him that the experimental method was the only method by
+which one could arrive at any scientific analysis of the passions; and
+certainly Dorian Gray was a subject made to his hand, and seemed to
+promise rich and fruitful results.  His sudden mad love for Sibyl Vane
+was a psychological phenomenon of no small interest.  There was no
+doubt that curiosity had much to do with it, curiosity and the desire
+for new experiences, yet it was not a simple, but rather a very complex
+passion.  What there was in it of the purely sensuous instinct of
+boyhood had been transformed by the workings of the imagination,
+changed into something that seemed to the lad himself to be remote from
+sense, and was for that very reason all the more dangerous.  It was the
+passions about whose origin we deceived ourselves that tyrannized most
+strongly over us.  Our weakest motives were those of whose nature we
+were conscious.  It often happened that when we thought we were
+experimenting on others we were really experimenting on ourselves.
+
+While Lord Henry sat dreaming on these things, a knock came to the
+door, and his valet entered and reminded him it was time to dress for
+dinner.  He got up and looked out into the street.  The sunset had
+smitten into scarlet gold the upper windows of the houses opposite.
+The panes glowed like plates of heated metal.  The sky above was like a
+faded rose.  He thought of his friend's young fiery-coloured life and
+wondered how it was all going to end.
+
+When he arrived home, about half-past twelve o'clock, he saw a telegram
+lying on the hall table.  He opened it and found it was from Dorian
+Gray.  It was to tell him that he was engaged to be married to Sibyl
+Vane.
+
+
+
+CHAPTER 5
+
+"Mother, Mother, I am so happy!" whispered the girl, burying her face
+in the lap of the faded, tired-looking woman who, with back turned to
+the shrill intrusive light, was sitting in the one arm-chair that their
+dingy sitting-room contained.  "I am so happy!" she repeated, "and you
+must be happy, too!"
+
+Mrs. Vane winced and put her thin, bismuth-whitened hands on her
+daughter's head.  "Happy!" she echoed, "I am only happy, Sibyl, when I
+see you act.  You must not think of anything but your acting.  Mr.
+Isaacs has been very good to us, and we owe him money."
+
+The girl looked up and pouted.  "Money, Mother?" she cried, "what does
+money matter?  Love is more than money."
+
+"Mr. Isaacs has advanced us fifty pounds to pay off our debts and to
+get a proper outfit for James.  You must not forget that, Sibyl.  Fifty
+pounds is a very large sum.  Mr. Isaacs has been most considerate."
+
+"He is not a gentleman, Mother, and I hate the way he talks to me,"
+said the girl, rising to her feet and going over to the window.
+
+"I don't know how we could manage without him," answered the elder
+woman querulously.
+
+Sibyl Vane tossed her head and laughed.  "We don't want him any more,
+Mother.  Prince Charming rules life for us now." Then she paused.  A
+rose shook in her blood and shadowed her cheeks.  Quick breath parted
+the petals of her lips.  They trembled.  Some southern wind of passion
+swept over her and stirred the dainty folds of her dress.  "I love
+him," she said simply.
+
+"Foolish child! foolish child!" was the parrot-phrase flung in answer.
+The waving of crooked, false-jewelled fingers gave grotesqueness to the
+words.
+
+The girl laughed again.  The joy of a caged bird was in her voice.  Her
+eyes caught the melody and echoed it in radiance, then closed for a
+moment, as though to hide their secret.  When they opened, the mist of
+a dream had passed across them.
+
+Thin-lipped wisdom spoke at her from the worn chair, hinted at
+prudence, quoted from that book of cowardice whose author apes the name
+of common sense.  She did not listen.  She was free in her prison of
+passion.  Her prince, Prince Charming, was with her.  She had called on
+memory to remake him.  She had sent her soul to search for him, and it
+had brought him back.  His kiss burned again upon her mouth.  Her
+eyelids were warm with his breath.
+
+Then wisdom altered its method and spoke of espial and discovery.  This
+young man might be rich.  If so, marriage should be thought of.
+Against the shell of her ear broke the waves of worldly cunning.  The
+arrows of craft shot by her.  She saw the thin lips moving, and smiled.
+
+Suddenly she felt the need to speak.  The wordy silence troubled her.
+"Mother, Mother," she cried, "why does he love me so much?  I know why
+I love him.  I love him because he is like what love himself should be.
+But what does he see in me?  I am not worthy of him.  And yet--why, I
+cannot tell--though I feel so much beneath him, I don't feel humble.  I
+feel proud, terribly proud.  Mother, did you love my father as I love
+Prince Charming?"
+
+The elder woman grew pale beneath the coarse powder that daubed her
+cheeks, and her dry lips twitched with a spasm of pain.  Sybil rushed
+to her, flung her arms round her neck, and kissed her.  "Forgive me,
+Mother.  I know it pains you to talk about our father.  But it only
+pains you because you loved him so much.  Don't look so sad.  I am as
+happy to-day as you were twenty years ago.  Ah! let me be happy for
+ever!"
+
+"My child, you are far too young to think of falling in love.  Besides,
+what do you know of this young man?  You don't even know his name.  The
+whole thing is most inconvenient, and really, when James is going away
+to Australia, and I have so much to think of, I must say that you
+should have shown more consideration.  However, as I said before, if he
+is rich ..."
+
+"Ah!  Mother, Mother, let me be happy!"
+
+Mrs. Vane glanced at her, and with one of those false theatrical
+gestures that so often become a mode of second nature to a
+stage-player, clasped her in her arms.  At this moment, the door opened
+and a young lad with rough brown hair came into the room.  He was
+thick-set of figure, and his hands and feet were large and somewhat
+clumsy in movement.  He was not so finely bred as his sister.  One
+would hardly have guessed the close relationship that existed between
+them.  Mrs. Vane fixed her eyes on him and intensified her smile.  She
+mentally elevated her son to the dignity of an audience.  She felt sure
+that the _tableau_ was interesting.
+
+"You might keep some of your kisses for me, Sibyl, I think," said the
+lad with a good-natured grumble.
+
+"Ah! but you don't like being kissed, Jim," she cried.  "You are a
+dreadful old bear."  And she ran across the room and hugged him.
+
+James Vane looked into his sister's face with tenderness.  "I want you
+to come out with me for a walk, Sibyl.  I don't suppose I shall ever
+see this horrid London again.  I am sure I don't want to."
+
+"My son, don't say such dreadful things," murmured Mrs. Vane, taking up
+a tawdry theatrical dress, with a sigh, and beginning to patch it.  She
+felt a little disappointed that he had not joined the group.  It would
+have increased the theatrical picturesqueness of the situation.
+
+"Why not, Mother?  I mean it."
+
+"You pain me, my son.  I trust you will return from Australia in a
+position of affluence.  I believe there is no society of any kind in
+the Colonies--nothing that I would call society--so when you have made
+your fortune, you must come back and assert yourself in London."
+
+"Society!" muttered the lad.  "I don't want to know anything about
+that.  I should like to make some money to take you and Sibyl off the
+stage.  I hate it."
+
+"Oh, Jim!" said Sibyl, laughing, "how unkind of you!  But are you
+really going for a walk with me?  That will be nice!  I was afraid you
+were going to say good-bye to some of your friends--to Tom Hardy, who
+gave you that hideous pipe, or Ned Langton, who makes fun of you for
+smoking it.  It is very sweet of you to let me have your last
+afternoon.  Where shall we go?  Let us go to the park."
+
+"I am too shabby," he answered, frowning.  "Only swell people go to the
+park."
+
+"Nonsense, Jim," she whispered, stroking the sleeve of his coat.
+
+He hesitated for a moment.  "Very well," he said at last, "but don't be
+too long dressing."  She danced out of the door.  One could hear her
+singing as she ran upstairs.  Her little feet pattered overhead.
+
+He walked up and down the room two or three times.  Then he turned to
+the still figure in the chair.  "Mother, are my things ready?" he asked.
+
+"Quite ready, James," she answered, keeping her eyes on her work.  For
+some months past she had felt ill at ease when she was alone with this
+rough stern son of hers.  Her shallow secret nature was troubled when
+their eyes met.  She used to wonder if he suspected anything.  The
+silence, for he made no other observation, became intolerable to her.
+She began to complain.  Women defend themselves by attacking, just as
+they attack by sudden and strange surrenders.  "I hope you will be
+contented, James, with your sea-faring life," she said.  "You must
+remember that it is your own choice.  You might have entered a
+solicitor's office.  Solicitors are a very respectable class, and in
+the country often dine with the best families."
+
+"I hate offices, and I hate clerks," he replied.  "But you are quite
+right.  I have chosen my own life.  All I say is, watch over Sibyl.
+Don't let her come to any harm.  Mother, you must watch over her."
+
+"James, you really talk very strangely.  Of course I watch over Sibyl."
+
+"I hear a gentleman comes every night to the theatre and goes behind to
+talk to her.  Is that right?  What about that?"
+
+"You are speaking about things you don't understand, James.  In the
+profession we are accustomed to receive a great deal of most gratifying
+attention.  I myself used to receive many bouquets at one time.  That
+was when acting was really understood.  As for Sibyl, I do not know at
+present whether her attachment is serious or not.  But there is no
+doubt that the young man in question is a perfect gentleman.  He is
+always most polite to me.  Besides, he has the appearance of being
+rich, and the flowers he sends are lovely."
+
+"You don't know his name, though," said the lad harshly.
+
+"No," answered his mother with a placid expression in her face.  "He
+has not yet revealed his real name.  I think it is quite romantic of
+him.  He is probably a member of the aristocracy."
+
+James Vane bit his lip.  "Watch over Sibyl, Mother," he cried, "watch
+over her."
+
+"My son, you distress me very much.  Sibyl is always under my special
+care.  Of course, if this gentleman is wealthy, there is no reason why
+she should not contract an alliance with him.  I trust he is one of the
+aristocracy.  He has all the appearance of it, I must say.  It might be
+a most brilliant marriage for Sibyl.  They would make a charming
+couple.  His good looks are really quite remarkable; everybody notices
+them."
+
+The lad muttered something to himself and drummed on the window-pane
+with his coarse fingers.  He had just turned round to say something
+when the door opened and Sibyl ran in.
+
+"How serious you both are!" she cried.  "What is the matter?"
+
+"Nothing," he answered.  "I suppose one must be serious sometimes.
+Good-bye, Mother; I will have my dinner at five o'clock. Everything is
+packed, except my shirts, so you need not trouble."
+
+"Good-bye, my son," she answered with a bow of strained stateliness.
+
+She was extremely annoyed at the tone he had adopted with her, and
+there was something in his look that had made her feel afraid.
+
+"Kiss me, Mother," said the girl.  Her flowerlike lips touched the
+withered cheek and warmed its frost.
+
+"My child! my child!" cried Mrs. Vane, looking up to the ceiling in
+search of an imaginary gallery.
+
+"Come, Sibyl," said her brother impatiently.  He hated his mother's
+affectations.
+
+They went out into the flickering, wind-blown sunlight and strolled
+down the dreary Euston Road.  The passersby glanced in wonder at the
+sullen heavy youth who, in coarse, ill-fitting clothes, was in the
+company of such a graceful, refined-looking girl.  He was like a common
+gardener walking with a rose.
+
+Jim frowned from time to time when he caught the inquisitive glance of
+some stranger.  He had that dislike of being stared at, which comes on
+geniuses late in life and never leaves the commonplace.  Sibyl,
+however, was quite unconscious of the effect she was producing.  Her
+love was trembling in laughter on her lips.  She was thinking of Prince
+Charming, and, that she might think of him all the more, she did not
+talk of him, but prattled on about the ship in which Jim was going to
+sail, about the gold he was certain to find, about the wonderful
+heiress whose life he was to save from the wicked, red-shirted
+bushrangers.  For he was not to remain a sailor, or a supercargo, or
+whatever he was going to be.  Oh, no!  A sailor's existence was
+dreadful.  Fancy being cooped up in a horrid ship, with the hoarse,
+hump-backed waves trying to get in, and a black wind blowing the masts
+down and tearing the sails into long screaming ribands!  He was to
+leave the vessel at Melbourne, bid a polite good-bye to the captain,
+and go off at once to the gold-fields. Before a week was over he was to
+come across a large nugget of pure gold, the largest nugget that had
+ever been discovered, and bring it down to the coast in a waggon
+guarded by six mounted policemen.  The bushrangers were to attack them
+three times, and be defeated with immense slaughter.  Or, no.  He was
+not to go to the gold-fields at all.  They were horrid places, where
+men got intoxicated, and shot each other in bar-rooms, and used bad
+language.  He was to be a nice sheep-farmer, and one evening, as he was
+riding home, he was to see the beautiful heiress being carried off by a
+robber on a black horse, and give chase, and rescue her.  Of course,
+she would fall in love with him, and he with her, and they would get
+married, and come home, and live in an immense house in London.  Yes,
+there were delightful things in store for him.  But he must be very
+good, and not lose his temper, or spend his money foolishly.  She was
+only a year older than he was, but she knew so much more of life.  He
+must be sure, also, to write to her by every mail, and to say his
+prayers each night before he went to sleep.  God was very good, and
+would watch over him.  She would pray for him, too, and in a few years
+he would come back quite rich and happy.
+
+The lad listened sulkily to her and made no answer.  He was heart-sick
+at leaving home.
+
+Yet it was not this alone that made him gloomy and morose.
+Inexperienced though he was, he had still a strong sense of the danger
+of Sibyl's position.  This young dandy who was making love to her could
+mean her no good.  He was a gentleman, and he hated him for that, hated
+him through some curious race-instinct for which he could not account,
+and which for that reason was all the more dominant within him.  He was
+conscious also of the shallowness and vanity of his mother's nature,
+and in that saw infinite peril for Sibyl and Sibyl's happiness.
+Children begin by loving their parents; as they grow older they judge
+them; sometimes they forgive them.
+
+His mother!  He had something on his mind to ask of her, something that
+he had brooded on for many months of silence.  A chance phrase that he
+had heard at the theatre, a whispered sneer that had reached his ears
+one night as he waited at the stage-door, had set loose a train of
+horrible thoughts.  He remembered it as if it had been the lash of a
+hunting-crop across his face.  His brows knit together into a wedge-like
+furrow, and with a twitch of pain he bit his underlip.
+
+"You are not listening to a word I am saying, Jim," cried Sibyl, "and I
+am making the most delightful plans for your future.  Do say something."
+
+"What do you want me to say?"
+
+"Oh! that you will be a good boy and not forget us," she answered,
+smiling at him.
+
+He shrugged his shoulders.  "You are more likely to forget me than I am
+to forget you, Sibyl."
+
+She flushed.  "What do you mean, Jim?" she asked.
+
+"You have a new friend, I hear.  Who is he?  Why have you not told me
+about him?  He means you no good."
+
+"Stop, Jim!" she exclaimed.  "You must not say anything against him.  I
+love him."
+
+"Why, you don't even know his name," answered the lad.  "Who is he?  I
+have a right to know."
+
+"He is called Prince Charming.  Don't you like the name.  Oh! you silly
+boy! you should never forget it.  If you only saw him, you would think
+him the most wonderful person in the world.  Some day you will meet
+him--when you come back from Australia.  You will like him so much.
+Everybody likes him, and I ... love him.  I wish you could come to the
+theatre to-night. He is going to be there, and I am to play Juliet.
+Oh! how I shall play it!  Fancy, Jim, to be in love and play Juliet!
+To have him sitting there!  To play for his delight!  I am afraid I may
+frighten the company, frighten or enthrall them.  To be in love is to
+surpass one's self.  Poor dreadful Mr. Isaacs will be shouting 'genius'
+to his loafers at the bar.  He has preached me as a dogma; to-night he
+will announce me as a revelation.  I feel it.  And it is all his, his
+only, Prince Charming, my wonderful lover, my god of graces.  But I am
+poor beside him.  Poor?  What does that matter?  When poverty creeps in
+at the door, love flies in through the window.  Our proverbs want
+rewriting.  They were made in winter, and it is summer now; spring-time
+for me, I think, a very dance of blossoms in blue skies."
+
+"He is a gentleman," said the lad sullenly.
+
+"A prince!" she cried musically.  "What more do you want?"
+
+"He wants to enslave you."
+
+"I shudder at the thought of being free."
+
+"I want you to beware of him."
+
+"To see him is to worship him; to know him is to trust him."
+
+"Sibyl, you are mad about him."
+
+She laughed and took his arm.  "You dear old Jim, you talk as if you
+were a hundred.  Some day you will be in love yourself.  Then you will
+know what it is.  Don't look so sulky.  Surely you should be glad to
+think that, though you are going away, you leave me happier than I have
+ever been before.  Life has been hard for us both, terribly hard and
+difficult.  But it will be different now.  You are going to a new
+world, and I have found one.  Here are two chairs; let us sit down and
+see the smart people go by."
+
+They took their seats amidst a crowd of watchers.  The tulip-beds
+across the road flamed like throbbing rings of fire.  A white
+dust--tremulous cloud of orris-root it seemed--hung in the panting air.
+The brightly coloured parasols danced and dipped like monstrous
+butterflies.
+
+She made her brother talk of himself, his hopes, his prospects.  He
+spoke slowly and with effort.  They passed words to each other as
+players at a game pass counters.  Sibyl felt oppressed.  She could not
+communicate her joy.  A faint smile curving that sullen mouth was all
+the echo she could win.  After some time she became silent.  Suddenly
+she caught a glimpse of golden hair and laughing lips, and in an open
+carriage with two ladies Dorian Gray drove past.
+
+She started to her feet.  "There he is!" she cried.
+
+"Who?" said Jim Vane.
+
+"Prince Charming," she answered, looking after the victoria.
+
+He jumped up and seized her roughly by the arm.  "Show him to me.
+Which is he?  Point him out.  I must see him!" he exclaimed; but at
+that moment the Duke of Berwick's four-in-hand came between, and when
+it had left the space clear, the carriage had swept out of the park.
+
+"He is gone," murmured Sibyl sadly.  "I wish you had seen him."
+
+"I wish I had, for as sure as there is a God in heaven, if he ever does
+you any wrong, I shall kill him."
+
+She looked at him in horror.  He repeated his words.  They cut the air
+like a dagger.  The people round began to gape.  A lady standing close
+to her tittered.
+
+"Come away, Jim; come away," she whispered.  He followed her doggedly
+as she passed through the crowd.  He felt glad at what he had said.
+
+When they reached the Achilles Statue, she turned round.  There was
+pity in her eyes that became laughter on her lips.  She shook her head
+at him.  "You are foolish, Jim, utterly foolish; a bad-tempered boy,
+that is all.  How can you say such horrible things?  You don't know
+what you are talking about.  You are simply jealous and unkind.  Ah!  I
+wish you would fall in love.  Love makes people good, and what you said
+was wicked."
+
+"I am sixteen," he answered, "and I know what I am about.  Mother is no
+help to you.  She doesn't understand how to look after you.  I wish now
+that I was not going to Australia at all.  I have a great mind to chuck
+the whole thing up.  I would, if my articles hadn't been signed."
+
+"Oh, don't be so serious, Jim.  You are like one of the heroes of those
+silly melodramas Mother used to be so fond of acting in.  I am not
+going to quarrel with you.  I have seen him, and oh! to see him is
+perfect happiness.  We won't quarrel.  I know you would never harm any
+one I love, would you?"
+
+"Not as long as you love him, I suppose," was the sullen answer.
+
+"I shall love him for ever!" she cried.
+
+"And he?"
+
+"For ever, too!"
+
+"He had better."
+
+She shrank from him.  Then she laughed and put her hand on his arm.  He
+was merely a boy.
+
+At the Marble Arch they hailed an omnibus, which left them close to
+their shabby home in the Euston Road.  It was after five o'clock, and
+Sibyl had to lie down for a couple of hours before acting.  Jim
+insisted that she should do so.  He said that he would sooner part with
+her when their mother was not present.  She would be sure to make a
+scene, and he detested scenes of every kind.
+
+In Sybil's own room they parted.  There was jealousy in the lad's
+heart, and a fierce murderous hatred of the stranger who, as it seemed
+to him, had come between them.  Yet, when her arms were flung round his
+neck, and her fingers strayed through his hair, he softened and kissed
+her with real affection.  There were tears in his eyes as he went
+downstairs.
+
+His mother was waiting for him below.  She grumbled at his
+unpunctuality, as he entered.  He made no answer, but sat down to his
+meagre meal.  The flies buzzed round the table and crawled over the
+stained cloth.  Through the rumble of omnibuses, and the clatter of
+street-cabs, he could hear the droning voice devouring each minute that
+was left to him.
+
+After some time, he thrust away his plate and put his head in his
+hands.  He felt that he had a right to know.  It should have been told
+to him before, if it was as he suspected.  Leaden with fear, his mother
+watched him.  Words dropped mechanically from her lips.  A tattered
+lace handkerchief twitched in her fingers.  When the clock struck six,
+he got up and went to the door.  Then he turned back and looked at her.
+Their eyes met.  In hers he saw a wild appeal for mercy.  It enraged
+him.
+
+"Mother, I have something to ask you," he said.  Her eyes wandered
+vaguely about the room.  She made no answer.  "Tell me the truth.  I
+have a right to know.  Were you married to my father?"
+
+She heaved a deep sigh.  It was a sigh of relief.  The terrible moment,
+the moment that night and day, for weeks and months, she had dreaded,
+had come at last, and yet she felt no terror.  Indeed, in some measure
+it was a disappointment to her.  The vulgar directness of the question
+called for a direct answer.  The situation had not been gradually led
+up to.  It was crude.  It reminded her of a bad rehearsal.
+
+"No," she answered, wondering at the harsh simplicity of life.
+
+"My father was a scoundrel then!" cried the lad, clenching his fists.
+
+She shook her head.  "I knew he was not free.  We loved each other very
+much.  If he had lived, he would have made provision for us.  Don't
+speak against him, my son.  He was your father, and a gentleman.
+Indeed, he was highly connected."
+
+An oath broke from his lips.  "I don't care for myself," he exclaimed,
+"but don't let Sibyl.... It is a gentleman, isn't it, who is in love
+with her, or says he is?  Highly connected, too, I suppose."
+
+For a moment a hideous sense of humiliation came over the woman.  Her
+head drooped.  She wiped her eyes with shaking hands.  "Sibyl has a
+mother," she murmured; "I had none."
+
+The lad was touched.  He went towards her, and stooping down, he kissed
+her.  "I am sorry if I have pained you by asking about my father," he
+said, "but I could not help it.  I must go now.  Good-bye. Don't forget
+that you will have only one child now to look after, and believe me
+that if this man wrongs my sister, I will find out who he is, track him
+down, and kill him like a dog.  I swear it."
+
+The exaggerated folly of the threat, the passionate gesture that
+accompanied it, the mad melodramatic words, made life seem more vivid
+to her.  She was familiar with the atmosphere.  She breathed more
+freely, and for the first time for many months she really admired her
+son.  She would have liked to have continued the scene on the same
+emotional scale, but he cut her short.  Trunks had to be carried down
+and mufflers looked for.  The lodging-house drudge bustled in and out.
+There was the bargaining with the cabman.  The moment was lost in
+vulgar details.  It was with a renewed feeling of disappointment that
+she waved the tattered lace handkerchief from the window, as her son
+drove away.  She was conscious that a great opportunity had been
+wasted.  She consoled herself by telling Sibyl how desolate she felt
+her life would be, now that she had only one child to look after.  She
+remembered the phrase.  It had pleased her.  Of the threat she said
+nothing.  It was vividly and dramatically expressed.  She felt that
+they would all laugh at it some day.
+
+
+
+CHAPTER 6
+
+"I suppose you have heard the news, Basil?" said Lord Henry that
+evening as Hallward was shown into a little private room at the Bristol
+where dinner had been laid for three.
+
+"No, Harry," answered the artist, giving his hat and coat to the bowing
+waiter.  "What is it?  Nothing about politics, I hope!  They don't
+interest me.  There is hardly a single person in the House of Commons
+worth painting, though many of them would be the better for a little
+whitewashing."
+
+"Dorian Gray is engaged to be married," said Lord Henry, watching him
+as he spoke.
+
+Hallward started and then frowned.  "Dorian engaged to be married!" he
+cried.  "Impossible!"
+
+"It is perfectly true."
+
+"To whom?"
+
+"To some little actress or other."
+
+"I can't believe it.  Dorian is far too sensible."
+
+"Dorian is far too wise not to do foolish things now and then, my dear
+Basil."
+
+"Marriage is hardly a thing that one can do now and then, Harry."
+
+"Except in America," rejoined Lord Henry languidly.  "But I didn't say
+he was married.  I said he was engaged to be married.  There is a great
+difference.  I have a distinct remembrance of being married, but I have
+no recollection at all of being engaged.  I am inclined to think that I
+never was engaged."
+
+"But think of Dorian's birth, and position, and wealth.  It would be
+absurd for him to marry so much beneath him."
+
+"If you want to make him marry this girl, tell him that, Basil.  He is
+sure to do it, then.  Whenever a man does a thoroughly stupid thing, it
+is always from the noblest motives."
+
+"I hope the girl is good, Harry.  I don't want to see Dorian tied to
+some vile creature, who might degrade his nature and ruin his
+intellect."
+
+"Oh, she is better than good--she is beautiful," murmured Lord Henry,
+sipping a glass of vermouth and orange-bitters. "Dorian says she is
+beautiful, and he is not often wrong about things of that kind.  Your
+portrait of him has quickened his appreciation of the personal
+appearance of other people.  It has had that excellent effect, amongst
+others.  We are to see her to-night, if that boy doesn't forget his
+appointment."
+
+"Are you serious?"
+
+"Quite serious, Basil.  I should be miserable if I thought I should
+ever be more serious than I am at the present moment."
+
+"But do you approve of it, Harry?" asked the painter, walking up and
+down the room and biting his lip.  "You can't approve of it, possibly.
+It is some silly infatuation."
+
+"I never approve, or disapprove, of anything now.  It is an absurd
+attitude to take towards life.  We are not sent into the world to air
+our moral prejudices.  I never take any notice of what common people
+say, and I never interfere with what charming people do.  If a
+personality fascinates me, whatever mode of expression that personality
+selects is absolutely delightful to me.  Dorian Gray falls in love with
+a beautiful girl who acts Juliet, and proposes to marry her.  Why not?
+If he wedded Messalina, he would be none the less interesting.  You
+know I am not a champion of marriage.  The real drawback to marriage is
+that it makes one unselfish.  And unselfish people are colourless.
+They lack individuality.  Still, there are certain temperaments that
+marriage makes more complex.  They retain their egotism, and add to it
+many other egos.  They are forced to have more than one life.  They
+become more highly organized, and to be highly organized is, I should
+fancy, the object of man's existence.  Besides, every experience is of
+value, and whatever one may say against marriage, it is certainly an
+experience.  I hope that Dorian Gray will make this girl his wife,
+passionately adore her for six months, and then suddenly become
+fascinated by some one else.  He would be a wonderful study."
+
+"You don't mean a single word of all that, Harry; you know you don't.
+If Dorian Gray's life were spoiled, no one would be sorrier than
+yourself.  You are much better than you pretend to be."
+
+Lord Henry laughed.  "The reason we all like to think so well of others
+is that we are all afraid for ourselves.  The basis of optimism is
+sheer terror.  We think that we are generous because we credit our
+neighbour with the possession of those virtues that are likely to be a
+benefit to us.  We praise the banker that we may overdraw our account,
+and find good qualities in the highwayman in the hope that he may spare
+our pockets.  I mean everything that I have said.  I have the greatest
+contempt for optimism.  As for a spoiled life, no life is spoiled but
+one whose growth is arrested.  If you want to mar a nature, you have
+merely to reform it.  As for marriage, of course that would be silly,
+but there are other and more interesting bonds between men and women.
+I will certainly encourage them.  They have the charm of being
+fashionable.  But here is Dorian himself.  He will tell you more than I
+can."
+
+"My dear Harry, my dear Basil, you must both congratulate me!" said the
+lad, throwing off his evening cape with its satin-lined wings and
+shaking each of his friends by the hand in turn.  "I have never been so
+happy.  Of course, it is sudden--all really delightful things are.  And
+yet it seems to me to be the one thing I have been looking for all my
+life." He was flushed with excitement and pleasure, and looked
+extraordinarily handsome.
+
+"I hope you will always be very happy, Dorian," said Hallward, "but I
+don't quite forgive you for not having let me know of your engagement.
+You let Harry know."
+
+"And I don't forgive you for being late for dinner," broke in Lord
+Henry, putting his hand on the lad's shoulder and smiling as he spoke.
+"Come, let us sit down and try what the new _chef_ here is like, and then
+you will tell us how it all came about."
+
+"There is really not much to tell," cried Dorian as they took their
+seats at the small round table.  "What happened was simply this.  After
+I left you yesterday evening, Harry, I dressed, had some dinner at that
+little Italian restaurant in Rupert Street you introduced me to, and
+went down at eight o'clock to the theatre.  Sibyl was playing Rosalind.
+Of course, the scenery was dreadful and the Orlando absurd.  But Sibyl!
+You should have seen her!  When she came on in her boy's clothes, she
+was perfectly wonderful.  She wore a moss-coloured velvet jerkin with
+cinnamon sleeves, slim, brown, cross-gartered hose, a dainty little
+green cap with a hawk's feather caught in a jewel, and a hooded cloak
+lined with dull red.  She had never seemed to me more exquisite.  She
+had all the delicate grace of that Tanagra figurine that you have in
+your studio, Basil.  Her hair clustered round her face like dark leaves
+round a pale rose.  As for her acting--well, you shall see her
+to-night. She is simply a born artist.  I sat in the dingy box
+absolutely enthralled.  I forgot that I was in London and in the
+nineteenth century.  I was away with my love in a forest that no man
+had ever seen.  After the performance was over, I went behind and spoke
+to her.  As we were sitting together, suddenly there came into her eyes
+a look that I had never seen there before.  My lips moved towards hers.
+We kissed each other.  I can't describe to you what I felt at that
+moment.  It seemed to me that all my life had been narrowed to one
+perfect point of rose-coloured joy.  She trembled all over and shook
+like a white narcissus.  Then she flung herself on her knees and kissed
+my hands.  I feel that I should not tell you all this, but I can't help
+it.  Of course, our engagement is a dead secret.  She has not even told
+her own mother.  I don't know what my guardians will say.  Lord Radley
+is sure to be furious.  I don't care.  I shall be of age in less than a
+year, and then I can do what I like.  I have been right, Basil, haven't
+I, to take my love out of poetry and to find my wife in Shakespeare's
+plays?  Lips that Shakespeare taught to speak have whispered their
+secret in my ear.  I have had the arms of Rosalind around me, and
+kissed Juliet on the mouth."
+
+"Yes, Dorian, I suppose you were right," said Hallward slowly.
+
+"Have you seen her to-day?" asked Lord Henry.
+
+Dorian Gray shook his head.  "I left her in the forest of Arden; I
+shall find her in an orchard in Verona."
+
+Lord Henry sipped his champagne in a meditative manner.  "At what
+particular point did you mention the word marriage, Dorian?  And what
+did she say in answer?  Perhaps you forgot all about it."
+
+"My dear Harry, I did not treat it as a business transaction, and I did
+not make any formal proposal.  I told her that I loved her, and she
+said she was not worthy to be my wife.  Not worthy!  Why, the whole
+world is nothing to me compared with her."
+
+"Women are wonderfully practical," murmured Lord Henry, "much more
+practical than we are.  In situations of that kind we often forget to
+say anything about marriage, and they always remind us."
+
+Hallward laid his hand upon his arm.  "Don't, Harry.  You have annoyed
+Dorian.  He is not like other men.  He would never bring misery upon
+any one.  His nature is too fine for that."
+
+Lord Henry looked across the table.  "Dorian is never annoyed with me,"
+he answered.  "I asked the question for the best reason possible, for
+the only reason, indeed, that excuses one for asking any
+question--simple curiosity.  I have a theory that it is always the
+women who propose to us, and not we who propose to the women.  Except,
+of course, in middle-class life.  But then the middle classes are not
+modern."
+
+Dorian Gray laughed, and tossed his head.  "You are quite incorrigible,
+Harry; but I don't mind.  It is impossible to be angry with you.  When
+you see Sibyl Vane, you will feel that the man who could wrong her
+would be a beast, a beast without a heart.  I cannot understand how any
+one can wish to shame the thing he loves.  I love Sibyl Vane.  I want
+to place her on a pedestal of gold and to see the world worship the
+woman who is mine.  What is marriage?  An irrevocable vow.  You mock at
+it for that.  Ah! don't mock.  It is an irrevocable vow that I want to
+take.  Her trust makes me faithful, her belief makes me good.  When I
+am with her, I regret all that you have taught me.  I become different
+from what you have known me to be.  I am changed, and the mere touch of
+Sibyl Vane's hand makes me forget you and all your wrong, fascinating,
+poisonous, delightful theories."
+
+"And those are ...?" asked Lord Henry, helping himself to some salad.
+
+"Oh, your theories about life, your theories about love, your theories
+about pleasure.  All your theories, in fact, Harry."
+
+"Pleasure is the only thing worth having a theory about," he answered
+in his slow melodious voice.  "But I am afraid I cannot claim my theory
+as my own.  It belongs to Nature, not to me.  Pleasure is Nature's
+test, her sign of approval.  When we are happy, we are always good, but
+when we are good, we are not always happy."
+
+"Ah! but what do you mean by good?" cried Basil Hallward.
+
+"Yes," echoed Dorian, leaning back in his chair and looking at Lord
+Henry over the heavy clusters of purple-lipped irises that stood in the
+centre of the table, "what do you mean by good, Harry?"
+
+"To be good is to be in harmony with one's self," he replied, touching
+the thin stem of his glass with his pale, fine-pointed fingers.
+"Discord is to be forced to be in harmony with others.  One's own
+life--that is the important thing.  As for the lives of one's
+neighbours, if one wishes to be a prig or a Puritan, one can flaunt
+one's moral views about them, but they are not one's concern.  Besides,
+individualism has really the higher aim.  Modern morality consists in
+accepting the standard of one's age.  I consider that for any man of
+culture to accept the standard of his age is a form of the grossest
+immorality."
+
+"But, surely, if one lives merely for one's self, Harry, one pays a
+terrible price for doing so?" suggested the painter.
+
+"Yes, we are overcharged for everything nowadays.  I should fancy that
+the real tragedy of the poor is that they can afford nothing but
+self-denial. Beautiful sins, like beautiful things, are the privilege
+of the rich."
+
+"One has to pay in other ways but money."
+
+"What sort of ways, Basil?"
+
+"Oh!  I should fancy in remorse, in suffering, in ... well, in the
+consciousness of degradation."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, mediaeval art is
+charming, but mediaeval emotions are out of date.  One can use them in
+fiction, of course.  But then the only things that one can use in
+fiction are the things that one has ceased to use in fact.  Believe me,
+no civilized man ever regrets a pleasure, and no uncivilized man ever
+knows what a pleasure is."
+
+"I know what pleasure is," cried Dorian Gray.  "It is to adore some
+one."
+
+"That is certainly better than being adored," he answered, toying with
+some fruits.  "Being adored is a nuisance.  Women treat us just as
+humanity treats its gods.  They worship us, and are always bothering us
+to do something for them."
+
+"I should have said that whatever they ask for they had first given to
+us," murmured the lad gravely.  "They create love in our natures.  They
+have a right to demand it back."
+
+"That is quite true, Dorian," cried Hallward.
+
+"Nothing is ever quite true," said Lord Henry.
+
+"This is," interrupted Dorian.  "You must admit, Harry, that women give
+to men the very gold of their lives."
+
+"Possibly," he sighed, "but they invariably want it back in such very
+small change.  That is the worry.  Women, as some witty Frenchman once
+put it, inspire us with the desire to do masterpieces and always
+prevent us from carrying them out."
+
+"Harry, you are dreadful!  I don't know why I like you so much."
+
+"You will always like me, Dorian," he replied.  "Will you have some
+coffee, you fellows?  Waiter, bring coffee, and _fine-champagne_, and
+some cigarettes.  No, don't mind the cigarettes--I have some.  Basil, I
+can't allow you to smoke cigars.  You must have a cigarette.  A
+cigarette is the perfect type of a perfect pleasure.  It is exquisite,
+and it leaves one unsatisfied.  What more can one want?  Yes, Dorian,
+you will always be fond of me.  I represent to you all the sins you
+have never had the courage to commit."
+
+"What nonsense you talk, Harry!" cried the lad, taking a light from a
+fire-breathing silver dragon that the waiter had placed on the table.
+"Let us go down to the theatre.  When Sibyl comes on the stage you will
+have a new ideal of life.  She will represent something to you that you
+have never known."
+
+"I have known everything," said Lord Henry, with a tired look in his
+eyes, "but I am always ready for a new emotion.  I am afraid, however,
+that, for me at any rate, there is no such thing.  Still, your
+wonderful girl may thrill me.  I love acting.  It is so much more real
+than life.  Let us go.  Dorian, you will come with me.  I am so sorry,
+Basil, but there is only room for two in the brougham.  You must follow
+us in a hansom."
+
+They got up and put on their coats, sipping their coffee standing.  The
+painter was silent and preoccupied.  There was a gloom over him.  He
+could not bear this marriage, and yet it seemed to him to be better
+than many other things that might have happened.  After a few minutes,
+they all passed downstairs.  He drove off by himself, as had been
+arranged, and watched the flashing lights of the little brougham in
+front of him.  A strange sense of loss came over him.  He felt that
+Dorian Gray would never again be to him all that he had been in the
+past.  Life had come between them.... His eyes darkened, and the
+crowded flaring streets became blurred to his eyes.  When the cab drew
+up at the theatre, it seemed to him that he had grown years older.
+
+
+
+CHAPTER 7
+
+For some reason or other, the house was crowded that night, and the fat
+Jew manager who met them at the door was beaming from ear to ear with
+an oily tremulous smile.  He escorted them to their box with a sort of
+pompous humility, waving his fat jewelled hands and talking at the top
+of his voice.  Dorian Gray loathed him more than ever.  He felt as if
+he had come to look for Miranda and had been met by Caliban.  Lord
+Henry, upon the other hand, rather liked him.  At least he declared he
+did, and insisted on shaking him by the hand and assuring him that he
+was proud to meet a man who had discovered a real genius and gone
+bankrupt over a poet.  Hallward amused himself with watching the faces
+in the pit.  The heat was terribly oppressive, and the huge sunlight
+flamed like a monstrous dahlia with petals of yellow fire.  The youths
+in the gallery had taken off their coats and waistcoats and hung them
+over the side.  They talked to each other across the theatre and shared
+their oranges with the tawdry girls who sat beside them.  Some women
+were laughing in the pit.  Their voices were horribly shrill and
+discordant.  The sound of the popping of corks came from the bar.
+
+"What a place to find one's divinity in!" said Lord Henry.
+
+"Yes!" answered Dorian Gray.  "It was here I found her, and she is
+divine beyond all living things.  When she acts, you will forget
+everything.  These common rough people, with their coarse faces and
+brutal gestures, become quite different when she is on the stage.  They
+sit silently and watch her.  They weep and laugh as she wills them to
+do.  She makes them as responsive as a violin.  She spiritualizes them,
+and one feels that they are of the same flesh and blood as one's self."
+
+"The same flesh and blood as one's self!  Oh, I hope not!" exclaimed
+Lord Henry, who was scanning the occupants of the gallery through his
+opera-glass.
+
+"Don't pay any attention to him, Dorian," said the painter.  "I
+understand what you mean, and I believe in this girl.  Any one you love
+must be marvellous, and any girl who has the effect you describe must
+be fine and noble.  To spiritualize one's age--that is something worth
+doing.  If this girl can give a soul to those who have lived without
+one, if she can create the sense of beauty in people whose lives have
+been sordid and ugly, if she can strip them of their selfishness and
+lend them tears for sorrows that are not their own, she is worthy of
+all your adoration, worthy of the adoration of the world.  This
+marriage is quite right.  I did not think so at first, but I admit it
+now.  The gods made Sibyl Vane for you.  Without her you would have
+been incomplete."
+
+"Thanks, Basil," answered Dorian Gray, pressing his hand.  "I knew that
+you would understand me.  Harry is so cynical, he terrifies me.  But
+here is the orchestra.  It is quite dreadful, but it only lasts for
+about five minutes.  Then the curtain rises, and you will see the girl
+to whom I am going to give all my life, to whom I have given everything
+that is good in me."
+
+A quarter of an hour afterwards, amidst an extraordinary turmoil of
+applause, Sibyl Vane stepped on to the stage.  Yes, she was certainly
+lovely to look at--one of the loveliest creatures, Lord Henry thought,
+that he had ever seen.  There was something of the fawn in her shy
+grace and startled eyes.  A faint blush, like the shadow of a rose in a
+mirror of silver, came to her cheeks as she glanced at the crowded
+enthusiastic house.  She stepped back a few paces and her lips seemed
+to tremble.  Basil Hallward leaped to his feet and began to applaud.
+Motionless, and as one in a dream, sat Dorian Gray, gazing at her.
+Lord Henry peered through his glasses, murmuring, "Charming! charming!"
+
+The scene was the hall of Capulet's house, and Romeo in his pilgrim's
+dress had entered with Mercutio and his other friends.  The band, such
+as it was, struck up a few bars of music, and the dance began.  Through
+the crowd of ungainly, shabbily dressed actors, Sibyl Vane moved like a
+creature from a finer world.  Her body swayed, while she danced, as a
+plant sways in the water.  The curves of her throat were the curves of
+a white lily.  Her hands seemed to be made of cool ivory.
+
+Yet she was curiously listless.  She showed no sign of joy when her
+eyes rested on Romeo.  The few words she had to speak--
+
+    Good pilgrim, you do wrong your hand too much,
+        Which mannerly devotion shows in this;
+    For saints have hands that pilgrims' hands do touch,
+        And palm to palm is holy palmers' kiss--
+
+with the brief dialogue that follows, were spoken in a thoroughly
+artificial manner.  The voice was exquisite, but from the point of view
+of tone it was absolutely false.  It was wrong in colour.  It took away
+all the life from the verse.  It made the passion unreal.
+
+Dorian Gray grew pale as he watched her.  He was puzzled and anxious.
+Neither of his friends dared to say anything to him.  She seemed to
+them to be absolutely incompetent.  They were horribly disappointed.
+
+Yet they felt that the true test of any Juliet is the balcony scene of
+the second act.  They waited for that.  If she failed there, there was
+nothing in her.
+
+She looked charming as she came out in the moonlight.  That could not
+be denied.  But the staginess of her acting was unbearable, and grew
+worse as she went on.  Her gestures became absurdly artificial.  She
+overemphasized everything that she had to say.  The beautiful passage--
+
+    Thou knowest the mask of night is on my face,
+    Else would a maiden blush bepaint my cheek
+    For that which thou hast heard me speak to-night--
+
+was declaimed with the painful precision of a schoolgirl who has been
+taught to recite by some second-rate professor of elocution. When she
+leaned over the balcony and came to those wonderful lines--
+
+        Although I joy in thee,
+    I have no joy of this contract to-night:
+    It is too rash, too unadvised, too sudden;
+    Too like the lightning, which doth cease to be
+    Ere one can say, "It lightens."  Sweet, good-night!
+    This bud of love by summer's ripening breath
+    May prove a beauteous flower when next we meet--
+
+she spoke the words as though they conveyed no meaning to her. It was
+not nervousness. Indeed, so far from being nervous, she was absolutely
+self-contained. It was simply bad art. She was a complete failure.
+
+Even the common uneducated audience of the pit and gallery lost their
+interest in the play. They got restless, and began to talk loudly and
+to whistle. The Jew manager, who was standing at the back of the
+dress-circle, stamped and swore with rage. The only person unmoved was
+the girl herself.
+
+When the second act was over, there came a storm of hisses, and Lord
+Henry got up from his chair and put on his coat.  "She is quite
+beautiful, Dorian," he said, "but she can't act.  Let us go."
+
+"I am going to see the play through," answered the lad, in a hard
+bitter voice.  "I am awfully sorry that I have made you waste an
+evening, Harry.  I apologize to you both."
+
+"My dear Dorian, I should think Miss Vane was ill," interrupted
+Hallward.  "We will come some other night."
+
+"I wish she were ill," he rejoined.  "But she seems to me to be simply
+callous and cold.  She has entirely altered.  Last night she was a
+great artist.  This evening she is merely a commonplace mediocre
+actress."
+
+"Don't talk like that about any one you love, Dorian.  Love is a more
+wonderful thing than art."
+
+"They are both simply forms of imitation," remarked Lord Henry.  "But
+do let us go.  Dorian, you must not stay here any longer.  It is not
+good for one's morals to see bad acting.  Besides, I don't suppose you
+will want your wife to act, so what does it matter if she plays Juliet
+like a wooden doll?  She is very lovely, and if she knows as little
+about life as she does about acting, she will be a delightful
+experience.  There are only two kinds of people who are really
+fascinating--people who know absolutely everything, and people who know
+absolutely nothing.  Good heavens, my dear boy, don't look so tragic!
+The secret of remaining young is never to have an emotion that is
+unbecoming.  Come to the club with Basil and myself.  We will smoke
+cigarettes and drink to the beauty of Sibyl Vane.  She is beautiful.
+What more can you want?"
+
+"Go away, Harry," cried the lad.  "I want to be alone.  Basil, you must
+go.  Ah! can't you see that my heart is breaking?"  The hot tears came
+to his eyes.  His lips trembled, and rushing to the back of the box, he
+leaned up against the wall, hiding his face in his hands.
+
+"Let us go, Basil," said Lord Henry with a strange tenderness in his
+voice, and the two young men passed out together.
+
+A few moments afterwards the footlights flared up and the curtain rose
+on the third act.  Dorian Gray went back to his seat.  He looked pale,
+and proud, and indifferent.  The play dragged on, and seemed
+interminable.  Half of the audience went out, tramping in heavy boots
+and laughing.  The whole thing was a _fiasco_.  The last act was played
+to almost empty benches.  The curtain went down on a titter and some
+groans.
+
+As soon as it was over, Dorian Gray rushed behind the scenes into the
+greenroom.  The girl was standing there alone, with a look of triumph
+on her face.  Her eyes were lit with an exquisite fire.  There was a
+radiance about her.  Her parted lips were smiling over some secret of
+their own.
+
+When he entered, she looked at him, and an expression of infinite joy
+came over her.  "How badly I acted to-night, Dorian!" she cried.
+
+"Horribly!" he answered, gazing at her in amazement.  "Horribly!  It
+was dreadful.  Are you ill?  You have no idea what it was.  You have no
+idea what I suffered."
+
+The girl smiled.  "Dorian," she answered, lingering over his name with
+long-drawn music in her voice, as though it were sweeter than honey to
+the red petals of her mouth.  "Dorian, you should have understood.  But
+you understand now, don't you?"
+
+"Understand what?" he asked, angrily.
+
+"Why I was so bad to-night. Why I shall always be bad.  Why I shall
+never act well again."
+
+He shrugged his shoulders.  "You are ill, I suppose.  When you are ill
+you shouldn't act.  You make yourself ridiculous.  My friends were
+bored.  I was bored."
+
+She seemed not to listen to him.  She was transfigured with joy.  An
+ecstasy of happiness dominated her.
+
+"Dorian, Dorian," she cried, "before I knew you, acting was the one
+reality of my life.  It was only in the theatre that I lived.  I
+thought that it was all true.  I was Rosalind one night and Portia the
+other.  The joy of Beatrice was my joy, and the sorrows of Cordelia
+were mine also.  I believed in everything.  The common people who acted
+with me seemed to me to be godlike.  The painted scenes were my world.
+I knew nothing but shadows, and I thought them real.  You came--oh, my
+beautiful love!--and you freed my soul from prison.  You taught me what
+reality really is.  To-night, for the first time in my life, I saw
+through the hollowness, the sham, the silliness of the empty pageant in
+which I had always played.  To-night, for the first time, I became
+conscious that the Romeo was hideous, and old, and painted, that the
+moonlight in the orchard was false, that the scenery was vulgar, and
+that the words I had to speak were unreal, were not my words, were not
+what I wanted to say.  You had brought me something higher, something
+of which all art is but a reflection.  You had made me understand what
+love really is.  My love!  My love!  Prince Charming!  Prince of life!
+I have grown sick of shadows.  You are more to me than all art can ever
+be.  What have I to do with the puppets of a play?  When I came on
+to-night, I could not understand how it was that everything had gone
+from me.  I thought that I was going to be wonderful.  I found that I
+could do nothing.  Suddenly it dawned on my soul what it all meant.
+The knowledge was exquisite to me.  I heard them hissing, and I smiled.
+What could they know of love such as ours?  Take me away, Dorian--take
+me away with you, where we can be quite alone.  I hate the stage.  I
+might mimic a passion that I do not feel, but I cannot mimic one that
+burns me like fire.  Oh, Dorian, Dorian, you understand now what it
+signifies?  Even if I could do it, it would be profanation for me to
+play at being in love.  You have made me see that."
+
+He flung himself down on the sofa and turned away his face.  "You have
+killed my love," he muttered.
+
+She looked at him in wonder and laughed.  He made no answer.  She came
+across to him, and with her little fingers stroked his hair.  She knelt
+down and pressed his hands to her lips.  He drew them away, and a
+shudder ran through him.
+
+Then he leaped up and went to the door.  "Yes," he cried, "you have
+killed my love.  You used to stir my imagination.  Now you don't even
+stir my curiosity.  You simply produce no effect.  I loved you because
+you were marvellous, because you had genius and intellect, because you
+realized the dreams of great poets and gave shape and substance to the
+shadows of art.  You have thrown it all away.  You are shallow and
+stupid.  My God! how mad I was to love you!  What a fool I have been!
+You are nothing to me now.  I will never see you again.  I will never
+think of you.  I will never mention your name.  You don't know what you
+were to me, once.  Why, once ... Oh, I can't bear to think of it!  I
+wish I had never laid eyes upon you!  You have spoiled the romance of
+my life.  How little you can know of love, if you say it mars your art!
+Without your art, you are nothing.  I would have made you famous,
+splendid, magnificent.  The world would have worshipped you, and you
+would have borne my name.  What are you now?  A third-rate actress with
+a pretty face."
+
+The girl grew white, and trembled.  She clenched her hands together,
+and her voice seemed to catch in her throat.  "You are not serious,
+Dorian?" she murmured.  "You are acting."
+
+"Acting!  I leave that to you.  You do it so well," he answered
+bitterly.
+
+She rose from her knees and, with a piteous expression of pain in her
+face, came across the room to him.  She put her hand upon his arm and
+looked into his eyes.  He thrust her back.  "Don't touch me!" he cried.
+
+A low moan broke from her, and she flung herself at his feet and lay
+there like a trampled flower.  "Dorian, Dorian, don't leave me!" she
+whispered.  "I am so sorry I didn't act well.  I was thinking of you
+all the time.  But I will try--indeed, I will try.  It came so suddenly
+across me, my love for you.  I think I should never have known it if
+you had not kissed me--if we had not kissed each other.  Kiss me again,
+my love.  Don't go away from me.  I couldn't bear it.  Oh! don't go
+away from me.  My brother ... No; never mind.  He didn't mean it.  He
+was in jest.... But you, oh! can't you forgive me for to-night? I will
+work so hard and try to improve.  Don't be cruel to me, because I love
+you better than anything in the world.  After all, it is only once that
+I have not pleased you.  But you are quite right, Dorian.  I should
+have shown myself more of an artist.  It was foolish of me, and yet I
+couldn't help it.  Oh, don't leave me, don't leave me." A fit of
+passionate sobbing choked her.  She crouched on the floor like a
+wounded thing, and Dorian Gray, with his beautiful eyes, looked down at
+her, and his chiselled lips curled in exquisite disdain.  There is
+always something ridiculous about the emotions of people whom one has
+ceased to love.  Sibyl Vane seemed to him to be absurdly melodramatic.
+Her tears and sobs annoyed him.
+
+"I am going," he said at last in his calm clear voice.  "I don't wish
+to be unkind, but I can't see you again.  You have disappointed me."
+
+She wept silently, and made no answer, but crept nearer.  Her little
+hands stretched blindly out, and appeared to be seeking for him.  He
+turned on his heel and left the room.  In a few moments he was out of
+the theatre.
+
+Where he went to he hardly knew.  He remembered wandering through dimly
+lit streets, past gaunt, black-shadowed archways and evil-looking
+houses.  Women with hoarse voices and harsh laughter had called after
+him.  Drunkards had reeled by, cursing and chattering to themselves
+like monstrous apes.  He had seen grotesque children huddled upon
+door-steps, and heard shrieks and oaths from gloomy courts.
+
+As the dawn was just breaking, he found himself close to Covent Garden.
+The darkness lifted, and, flushed with faint fires, the sky hollowed
+itself into a perfect pearl.  Huge carts filled with nodding lilies
+rumbled slowly down the polished empty street.  The air was heavy with
+the perfume of the flowers, and their beauty seemed to bring him an
+anodyne for his pain.  He followed into the market and watched the men
+unloading their waggons.  A white-smocked carter offered him some
+cherries.  He thanked him, wondered why he refused to accept any money
+for them, and began to eat them listlessly.  They had been plucked at
+midnight, and the coldness of the moon had entered into them.  A long
+line of boys carrying crates of striped tulips, and of yellow and red
+roses, defiled in front of him, threading their way through the huge,
+jade-green piles of vegetables.  Under the portico, with its grey,
+sun-bleached pillars, loitered a troop of draggled bareheaded girls,
+waiting for the auction to be over.  Others crowded round the swinging
+doors of the coffee-house in the piazza.  The heavy cart-horses slipped
+and stamped upon the rough stones, shaking their bells and trappings.
+Some of the drivers were lying asleep on a pile of sacks.  Iris-necked
+and pink-footed, the pigeons ran about picking up seeds.
+
+After a little while, he hailed a hansom and drove home.  For a few
+moments he loitered upon the doorstep, looking round at the silent
+square, with its blank, close-shuttered windows and its staring blinds.
+The sky was pure opal now, and the roofs of the houses glistened like
+silver against it.  From some chimney opposite a thin wreath of smoke
+was rising.  It curled, a violet riband, through the nacre-coloured air.
+
+In the huge gilt Venetian lantern, spoil of some Doge's barge, that
+hung from the ceiling of the great, oak-panelled hall of entrance,
+lights were still burning from three flickering jets: thin blue petals
+of flame they seemed, rimmed with white fire.  He turned them out and,
+having thrown his hat and cape on the table, passed through the library
+towards the door of his bedroom, a large octagonal chamber on the
+ground floor that, in his new-born feeling for luxury, he had just had
+decorated for himself and hung with some curious Renaissance tapestries
+that had been discovered stored in a disused attic at Selby Royal.  As
+he was turning the handle of the door, his eye fell upon the portrait
+Basil Hallward had painted of him.  He started back as if in surprise.
+Then he went on into his own room, looking somewhat puzzled.  After he
+had taken the button-hole out of his coat, he seemed to hesitate.
+Finally, he came back, went over to the picture, and examined it.  In
+the dim arrested light that struggled through the cream-coloured silk
+blinds, the face appeared to him to be a little changed.  The
+expression looked different.  One would have said that there was a
+touch of cruelty in the mouth.  It was certainly strange.
+
+He turned round and, walking to the window, drew up the blind.  The
+bright dawn flooded the room and swept the fantastic shadows into dusky
+corners, where they lay shuddering.  But the strange expression that he
+had noticed in the face of the portrait seemed to linger there, to be
+more intensified even.  The quivering ardent sunlight showed him the
+lines of cruelty round the mouth as clearly as if he had been looking
+into a mirror after he had done some dreadful thing.
+
+He winced and, taking up from the table an oval glass framed in ivory
+Cupids, one of Lord Henry's many presents to him, glanced hurriedly
+into its polished depths.  No line like that warped his red lips.  What
+did it mean?
+
+He rubbed his eyes, and came close to the picture, and examined it
+again.  There were no signs of any change when he looked into the
+actual painting, and yet there was no doubt that the whole expression
+had altered.  It was not a mere fancy of his own.  The thing was
+horribly apparent.
+
+He threw himself into a chair and began to think.  Suddenly there
+flashed across his mind what he had said in Basil Hallward's studio the
+day the picture had been finished.  Yes, he remembered it perfectly.
+He had uttered a mad wish that he himself might remain young, and the
+portrait grow old; that his own beauty might be untarnished, and the
+face on the canvas bear the burden of his passions and his sins; that
+the painted image might be seared with the lines of suffering and
+thought, and that he might keep all the delicate bloom and loveliness
+of his then just conscious boyhood.  Surely his wish had not been
+fulfilled?  Such things were impossible.  It seemed monstrous even to
+think of them.  And, yet, there was the picture before him, with the
+touch of cruelty in the mouth.
+
+Cruelty!  Had he been cruel?  It was the girl's fault, not his.  He had
+dreamed of her as a great artist, had given his love to her because he
+had thought her great.  Then she had disappointed him.  She had been
+shallow and unworthy.  And, yet, a feeling of infinite regret came over
+him, as he thought of her lying at his feet sobbing like a little
+child.  He remembered with what callousness he had watched her.  Why
+had he been made like that?  Why had such a soul been given to him?
+But he had suffered also.  During the three terrible hours that the
+play had lasted, he had lived centuries of pain, aeon upon aeon of
+torture.  His life was well worth hers.  She had marred him for a
+moment, if he had wounded her for an age.  Besides, women were better
+suited to bear sorrow than men.  They lived on their emotions.  They
+only thought of their emotions.  When they took lovers, it was merely
+to have some one with whom they could have scenes.  Lord Henry had told
+him that, and Lord Henry knew what women were.  Why should he trouble
+about Sibyl Vane?  She was nothing to him now.
+
+But the picture?  What was he to say of that?  It held the secret of
+his life, and told his story.  It had taught him to love his own
+beauty.  Would it teach him to loathe his own soul?  Would he ever look
+at it again?
+
+No; it was merely an illusion wrought on the troubled senses.  The
+horrible night that he had passed had left phantoms behind it.
+Suddenly there had fallen upon his brain that tiny scarlet speck that
+makes men mad.  The picture had not changed.  It was folly to think so.
+
+Yet it was watching him, with its beautiful marred face and its cruel
+smile.  Its bright hair gleamed in the early sunlight.  Its blue eyes
+met his own.  A sense of infinite pity, not for himself, but for the
+painted image of himself, came over him.  It had altered already, and
+would alter more.  Its gold would wither into grey.  Its red and white
+roses would die.  For every sin that he committed, a stain would fleck
+and wreck its fairness.  But he would not sin.  The picture, changed or
+unchanged, would be to him the visible emblem of conscience.  He would
+resist temptation.  He would not see Lord Henry any more--would not, at
+any rate, listen to those subtle poisonous theories that in Basil
+Hallward's garden had first stirred within him the passion for
+impossible things.  He would go back to Sibyl Vane, make her amends,
+marry her, try to love her again.  Yes, it was his duty to do so.  She
+must have suffered more than he had.  Poor child!  He had been selfish
+and cruel to her.  The fascination that she had exercised over him
+would return.  They would be happy together.  His life with her would
+be beautiful and pure.
+
+He got up from his chair and drew a large screen right in front of the
+portrait, shuddering as he glanced at it.  "How horrible!" he murmured
+to himself, and he walked across to the window and opened it.  When he
+stepped out on to the grass, he drew a deep breath.  The fresh morning
+air seemed to drive away all his sombre passions.  He thought only of
+Sibyl.  A faint echo of his love came back to him.  He repeated her
+name over and over again.  The birds that were singing in the
+dew-drenched garden seemed to be telling the flowers about her.
+
+
+
+CHAPTER 8
+
+It was long past noon when he awoke.  His valet had crept several times
+on tiptoe into the room to see if he was stirring, and had wondered
+what made his young master sleep so late.  Finally his bell sounded,
+and Victor came in softly with a cup of tea, and a pile of letters, on
+a small tray of old Sevres china, and drew back the olive-satin
+curtains, with their shimmering blue lining, that hung in front of the
+three tall windows.
+
+"Monsieur has well slept this morning," he said, smiling.
+
+"What o'clock is it, Victor?" asked Dorian Gray drowsily.
+
+"One hour and a quarter, Monsieur."
+
+How late it was!  He sat up, and having sipped some tea, turned over
+his letters.  One of them was from Lord Henry, and had been brought by
+hand that morning.  He hesitated for a moment, and then put it aside.
+The others he opened listlessly.  They contained the usual collection
+of cards, invitations to dinner, tickets for private views, programmes
+of charity concerts, and the like that are showered on fashionable
+young men every morning during the season.  There was a rather heavy
+bill for a chased silver Louis-Quinze toilet-set that he had not yet
+had the courage to send on to his guardians, who were extremely
+old-fashioned people and did not realize that we live in an age when
+unnecessary things are our only necessities; and there were several
+very courteously worded communications from Jermyn Street money-lenders
+offering to advance any sum of money at a moment's notice and at the
+most reasonable rates of interest.
+
+After about ten minutes he got up, and throwing on an elaborate
+dressing-gown of silk-embroidered cashmere wool, passed into the
+onyx-paved bathroom.  The cool water refreshed him after his long
+sleep.  He seemed to have forgotten all that he had gone through.  A
+dim sense of having taken part in some strange tragedy came to him once
+or twice, but there was the unreality of a dream about it.
+
+As soon as he was dressed, he went into the library and sat down to a
+light French breakfast that had been laid out for him on a small round
+table close to the open window.  It was an exquisite day.  The warm air
+seemed laden with spices.  A bee flew in and buzzed round the
+blue-dragon bowl that, filled with sulphur-yellow roses, stood before
+him.  He felt perfectly happy.
+
+Suddenly his eye fell on the screen that he had placed in front of the
+portrait, and he started.
+
+"Too cold for Monsieur?" asked his valet, putting an omelette on the
+table.  "I shut the window?"
+
+Dorian shook his head.  "I am not cold," he murmured.
+
+Was it all true?  Had the portrait really changed?  Or had it been
+simply his own imagination that had made him see a look of evil where
+there had been a look of joy?  Surely a painted canvas could not alter?
+The thing was absurd.  It would serve as a tale to tell Basil some day.
+It would make him smile.
+
+And, yet, how vivid was his recollection of the whole thing!  First in
+the dim twilight, and then in the bright dawn, he had seen the touch of
+cruelty round the warped lips.  He almost dreaded his valet leaving the
+room.  He knew that when he was alone he would have to examine the
+portrait.  He was afraid of certainty.  When the coffee and cigarettes
+had been brought and the man turned to go, he felt a wild desire to
+tell him to remain.  As the door was closing behind him, he called him
+back.  The man stood waiting for his orders.  Dorian looked at him for
+a moment.  "I am not at home to any one, Victor," he said with a sigh.
+The man bowed and retired.
+
+Then he rose from the table, lit a cigarette, and flung himself down on
+a luxuriously cushioned couch that stood facing the screen.  The screen
+was an old one, of gilt Spanish leather, stamped and wrought with a
+rather florid Louis-Quatorze pattern.  He scanned it curiously,
+wondering if ever before it had concealed the secret of a man's life.
+
+Should he move it aside, after all?  Why not let it stay there?  What
+was the use of knowing? If the thing was true, it was terrible.  If it
+was not true, why trouble about it?  But what if, by some fate or
+deadlier chance, eyes other than his spied behind and saw the horrible
+change?  What should he do if Basil Hallward came and asked to look at
+his own picture?  Basil would be sure to do that.  No; the thing had to
+be examined, and at once.  Anything would be better than this dreadful
+state of doubt.
+
+He got up and locked both doors.  At least he would be alone when he
+looked upon the mask of his shame.  Then he drew the screen aside and
+saw himself face to face.  It was perfectly true.  The portrait had
+altered.
+
+As he often remembered afterwards, and always with no small wonder, he
+found himself at first gazing at the portrait with a feeling of almost
+scientific interest.  That such a change should have taken place was
+incredible to him.  And yet it was a fact.  Was there some subtle
+affinity between the chemical atoms that shaped themselves into form
+and colour on the canvas and the soul that was within him?  Could it be
+that what that soul thought, they realized?--that what it dreamed, they
+made true?  Or was there some other, more terrible reason?  He
+shuddered, and felt afraid, and, going back to the couch, lay there,
+gazing at the picture in sickened horror.
+
+One thing, however, he felt that it had done for him.  It had made him
+conscious how unjust, how cruel, he had been to Sibyl Vane.  It was not
+too late to make reparation for that.  She could still be his wife.
+His unreal and selfish love would yield to some higher influence, would
+be transformed into some nobler passion, and the portrait that Basil
+Hallward had painted of him would be a guide to him through life, would
+be to him what holiness is to some, and conscience to others, and the
+fear of God to us all.  There were opiates for remorse, drugs that
+could lull the moral sense to sleep.  But here was a visible symbol of
+the degradation of sin.  Here was an ever-present sign of the ruin men
+brought upon their souls.
+
+Three o'clock struck, and four, and the half-hour rang its double
+chime, but Dorian Gray did not stir.  He was trying to gather up the
+scarlet threads of life and to weave them into a pattern; to find his
+way through the sanguine labyrinth of passion through which he was
+wandering.  He did not know what to do, or what to think.  Finally, he
+went over to the table and wrote a passionate letter to the girl he had
+loved, imploring her forgiveness and accusing himself of madness.  He
+covered page after page with wild words of sorrow and wilder words of
+pain.  There is a luxury in self-reproach. When we blame ourselves, we
+feel that no one else has a right to blame us.  It is the confession,
+not the priest, that gives us absolution.  When Dorian had finished the
+letter, he felt that he had been forgiven.
+
+Suddenly there came a knock to the door, and he heard Lord Henry's
+voice outside.  "My dear boy, I must see you.  Let me in at once.  I
+can't bear your shutting yourself up like this."
+
+He made no answer at first, but remained quite still.  The knocking
+still continued and grew louder.  Yes, it was better to let Lord Henry
+in, and to explain to him the new life he was going to lead, to quarrel
+with him if it became necessary to quarrel, to part if parting was
+inevitable.  He jumped up, drew the screen hastily across the picture,
+and unlocked the door.
+
+"I am so sorry for it all, Dorian," said Lord Henry as he entered.
+"But you must not think too much about it."
+
+"Do you mean about Sibyl Vane?" asked the lad.
+
+"Yes, of course," answered Lord Henry, sinking into a chair and slowly
+pulling off his yellow gloves.  "It is dreadful, from one point of
+view, but it was not your fault.  Tell me, did you go behind and see
+her, after the play was over?"
+
+"Yes."
+
+"I felt sure you had.  Did you make a scene with her?"
+
+"I was brutal, Harry--perfectly brutal.  But it is all right now.  I am
+not sorry for anything that has happened.  It has taught me to know
+myself better."
+
+"Ah, Dorian, I am so glad you take it in that way!  I was afraid I
+would find you plunged in remorse and tearing that nice curly hair of
+yours."
+
+"I have got through all that," said Dorian, shaking his head and
+smiling.  "I am perfectly happy now.  I know what conscience is, to
+begin with.  It is not what you told me it was.  It is the divinest
+thing in us.  Don't sneer at it, Harry, any more--at least not before
+me.  I want to be good.  I can't bear the idea of my soul being
+hideous."
+
+"A very charming artistic basis for ethics, Dorian!  I congratulate you
+on it.  But how are you going to begin?"
+
+"By marrying Sibyl Vane."
+
+"Marrying Sibyl Vane!" cried Lord Henry, standing up and looking at him
+in perplexed amazement.  "But, my dear Dorian--"
+
+"Yes, Harry, I know what you are going to say.  Something dreadful
+about marriage.  Don't say it.  Don't ever say things of that kind to
+me again.  Two days ago I asked Sibyl to marry me.  I am not going to
+break my word to her.  She is to be my wife."
+
+"Your wife!  Dorian! ... Didn't you get my letter?  I wrote to you this
+morning, and sent the note down by my own man."
+
+"Your letter?  Oh, yes, I remember.  I have not read it yet, Harry.  I
+was afraid there might be something in it that I wouldn't like.  You
+cut life to pieces with your epigrams."
+
+"You know nothing then?"
+
+"What do you mean?"
+
+Lord Henry walked across the room, and sitting down by Dorian Gray,
+took both his hands in his own and held them tightly.  "Dorian," he
+said, "my letter--don't be frightened--was to tell you that Sibyl Vane
+is dead."
+
+A cry of pain broke from the lad's lips, and he leaped to his feet,
+tearing his hands away from Lord Henry's grasp.  "Dead!  Sibyl dead!
+It is not true!  It is a horrible lie!  How dare you say it?"
+
+"It is quite true, Dorian," said Lord Henry, gravely.  "It is in all
+the morning papers.  I wrote down to you to ask you not to see any one
+till I came.  There will have to be an inquest, of course, and you must
+not be mixed up in it.  Things like that make a man fashionable in
+Paris.  But in London people are so prejudiced.  Here, one should never
+make one's _debut_ with a scandal.  One should reserve that to give an
+interest to one's old age.  I suppose they don't know your name at the
+theatre?  If they don't, it is all right.  Did any one see you going
+round to her room?  That is an important point."
+
+Dorian did not answer for a few moments.  He was dazed with horror.
+Finally he stammered, in a stifled voice, "Harry, did you say an
+inquest?  What did you mean by that?  Did Sibyl--? Oh, Harry, I can't
+bear it!  But be quick.  Tell me everything at once."
+
+"I have no doubt it was not an accident, Dorian, though it must be put
+in that way to the public.  It seems that as she was leaving the
+theatre with her mother, about half-past twelve or so, she said she had
+forgotten something upstairs.  They waited some time for her, but she
+did not come down again.  They ultimately found her lying dead on the
+floor of her dressing-room. She had swallowed something by mistake,
+some dreadful thing they use at theatres.  I don't know what it was,
+but it had either prussic acid or white lead in it.  I should fancy it
+was prussic acid, as she seems to have died instantaneously."
+
+"Harry, Harry, it is terrible!" cried the lad.
+
+"Yes; it is very tragic, of course, but you must not get yourself mixed
+up in it.  I see by _The Standard_ that she was seventeen.  I should have
+thought she was almost younger than that.  She looked such a child, and
+seemed to know so little about acting.  Dorian, you mustn't let this
+thing get on your nerves.  You must come and dine with me, and
+afterwards we will look in at the opera.  It is a Patti night, and
+everybody will be there.  You can come to my sister's box.  She has got
+some smart women with her."
+
+"So I have murdered Sibyl Vane," said Dorian Gray, half to himself,
+"murdered her as surely as if I had cut her little throat with a knife.
+Yet the roses are not less lovely for all that.  The birds sing just as
+happily in my garden.  And to-night I am to dine with you, and then go
+on to the opera, and sup somewhere, I suppose, afterwards.  How
+extraordinarily dramatic life is!  If I had read all this in a book,
+Harry, I think I would have wept over it.  Somehow, now that it has
+happened actually, and to me, it seems far too wonderful for tears.
+Here is the first passionate love-letter I have ever written in my
+life.  Strange, that my first passionate love-letter should have been
+addressed to a dead girl.  Can they feel, I wonder, those white silent
+people we call the dead?  Sibyl!  Can she feel, or know, or listen?
+Oh, Harry, how I loved her once!  It seems years ago to me now.  She
+was everything to me.  Then came that dreadful night--was it really
+only last night?--when she played so badly, and my heart almost broke.
+She explained it all to me.  It was terribly pathetic.  But I was not
+moved a bit.  I thought her shallow.  Suddenly something happened that
+made me afraid.  I can't tell you what it was, but it was terrible.  I
+said I would go back to her.  I felt I had done wrong.  And now she is
+dead.  My God!  My God!  Harry, what shall I do?  You don't know the
+danger I am in, and there is nothing to keep me straight.  She would
+have done that for me.  She had no right to kill herself.  It was
+selfish of her."
+
+"My dear Dorian," answered Lord Henry, taking a cigarette from his case
+and producing a gold-latten matchbox, "the only way a woman can ever
+reform a man is by boring him so completely that he loses all possible
+interest in life.  If you had married this girl, you would have been
+wretched.  Of course, you would have treated her kindly.  One can
+always be kind to people about whom one cares nothing.  But she would
+have soon found out that you were absolutely indifferent to her.  And
+when a woman finds that out about her husband, she either becomes
+dreadfully dowdy, or wears very smart bonnets that some other woman's
+husband has to pay for.  I say nothing about the social mistake, which
+would have been abject--which, of course, I would not have allowed--but
+I assure you that in any case the whole thing would have been an
+absolute failure."
+
+"I suppose it would," muttered the lad, walking up and down the room
+and looking horribly pale.  "But I thought it was my duty.  It is not
+my fault that this terrible tragedy has prevented my doing what was
+right.  I remember your saying once that there is a fatality about good
+resolutions--that they are always made too late.  Mine certainly were."
+
+"Good resolutions are useless attempts to interfere with scientific
+laws.  Their origin is pure vanity.  Their result is absolutely _nil_.
+They give us, now and then, some of those luxurious sterile emotions
+that have a certain charm for the weak.  That is all that can be said
+for them.  They are simply cheques that men draw on a bank where they
+have no account."
+
+"Harry," cried Dorian Gray, coming over and sitting down beside him,
+"why is it that I cannot feel this tragedy as much as I want to?  I
+don't think I am heartless.  Do you?"
+
+"You have done too many foolish things during the last fortnight to be
+entitled to give yourself that name, Dorian," answered Lord Henry with
+his sweet melancholy smile.
+
+The lad frowned.  "I don't like that explanation, Harry," he rejoined,
+"but I am glad you don't think I am heartless.  I am nothing of the
+kind.  I know I am not.  And yet I must admit that this thing that has
+happened does not affect me as it should.  It seems to me to be simply
+like a wonderful ending to a wonderful play.  It has all the terrible
+beauty of a Greek tragedy, a tragedy in which I took a great part, but
+by which I have not been wounded."
+
+"It is an interesting question," said Lord Henry, who found an
+exquisite pleasure in playing on the lad's unconscious egotism, "an
+extremely interesting question.  I fancy that the true explanation is
+this:  It often happens that the real tragedies of life occur in such
+an inartistic manner that they hurt us by their crude violence, their
+absolute incoherence, their absurd want of meaning, their entire lack
+of style.  They affect us just as vulgarity affects us.  They give us
+an impression of sheer brute force, and we revolt against that.
+Sometimes, however, a tragedy that possesses artistic elements of
+beauty crosses our lives.  If these elements of beauty are real, the
+whole thing simply appeals to our sense of dramatic effect.  Suddenly
+we find that we are no longer the actors, but the spectators of the
+play.  Or rather we are both.  We watch ourselves, and the mere wonder
+of the spectacle enthralls us.  In the present case, what is it that
+has really happened?  Some one has killed herself for love of you.  I
+wish that I had ever had such an experience.  It would have made me in
+love with love for the rest of my life.  The people who have adored
+me--there have not been very many, but there have been some--have
+always insisted on living on, long after I had ceased to care for them,
+or they to care for me.  They have become stout and tedious, and when I
+meet them, they go in at once for reminiscences.  That awful memory of
+woman!  What a fearful thing it is!  And what an utter intellectual
+stagnation it reveals!  One should absorb the colour of life, but one
+should never remember its details.  Details are always vulgar."
+
+"I must sow poppies in my garden," sighed Dorian.
+
+"There is no necessity," rejoined his companion.  "Life has always
+poppies in her hands.  Of course, now and then things linger.  I once
+wore nothing but violets all through one season, as a form of artistic
+mourning for a romance that would not die.  Ultimately, however, it did
+die.  I forget what killed it.  I think it was her proposing to
+sacrifice the whole world for me.  That is always a dreadful moment.
+It fills one with the terror of eternity.  Well--would you believe
+it?--a week ago, at Lady Hampshire's, I found myself seated at dinner
+next the lady in question, and she insisted on going over the whole
+thing again, and digging up the past, and raking up the future.  I had
+buried my romance in a bed of asphodel.  She dragged it out again and
+assured me that I had spoiled her life.  I am bound to state that she
+ate an enormous dinner, so I did not feel any anxiety.  But what a lack
+of taste she showed!  The one charm of the past is that it is the past.
+But women never know when the curtain has fallen.  They always want a
+sixth act, and as soon as the interest of the play is entirely over,
+they propose to continue it.  If they were allowed their own way, every
+comedy would have a tragic ending, and every tragedy would culminate in
+a farce.  They are charmingly artificial, but they have no sense of
+art.  You are more fortunate than I am.  I assure you, Dorian, that not
+one of the women I have known would have done for me what Sibyl Vane
+did for you.  Ordinary women always console themselves.  Some of them
+do it by going in for sentimental colours.  Never trust a woman who
+wears mauve, whatever her age may be, or a woman over thirty-five who
+is fond of pink ribbons.  It always means that they have a history.
+Others find a great consolation in suddenly discovering the good
+qualities of their husbands.  They flaunt their conjugal felicity in
+one's face, as if it were the most fascinating of sins.  Religion
+consoles some.  Its mysteries have all the charm of a flirtation, a
+woman once told me, and I can quite understand it.  Besides, nothing
+makes one so vain as being told that one is a sinner.  Conscience makes
+egotists of us all.  Yes; there is really no end to the consolations
+that women find in modern life.  Indeed, I have not mentioned the most
+important one."
+
+"What is that, Harry?" said the lad listlessly.
+
+"Oh, the obvious consolation.  Taking some one else's admirer when one
+loses one's own.  In good society that always whitewashes a woman.  But
+really, Dorian, how different Sibyl Vane must have been from all the
+women one meets!  There is something to me quite beautiful about her
+death.  I am glad I am living in a century when such wonders happen.
+They make one believe in the reality of the things we all play with,
+such as romance, passion, and love."
+
+"I was terribly cruel to her.  You forget that."
+
+"I am afraid that women appreciate cruelty, downright cruelty, more
+than anything else.  They have wonderfully primitive instincts.  We
+have emancipated them, but they remain slaves looking for their
+masters, all the same.  They love being dominated.  I am sure you were
+splendid.  I have never seen you really and absolutely angry, but I can
+fancy how delightful you looked.  And, after all, you said something to
+me the day before yesterday that seemed to me at the time to be merely
+fanciful, but that I see now was absolutely true, and it holds the key
+to everything."
+
+"What was that, Harry?"
+
+"You said to me that Sibyl Vane represented to you all the heroines of
+romance--that she was Desdemona one night, and Ophelia the other; that
+if she died as Juliet, she came to life as Imogen."
+
+"She will never come to life again now," muttered the lad, burying his
+face in his hands.
+
+"No, she will never come to life.  She has played her last part.  But
+you must think of that lonely death in the tawdry dressing-room simply
+as a strange lurid fragment from some Jacobean tragedy, as a wonderful
+scene from Webster, or Ford, or Cyril Tourneur.  The girl never really
+lived, and so she has never really died.  To you at least she was
+always a dream, a phantom that flitted through Shakespeare's plays and
+left them lovelier for its presence, a reed through which Shakespeare's
+music sounded richer and more full of joy.  The moment she touched
+actual life, she marred it, and it marred her, and so she passed away.
+Mourn for Ophelia, if you like.  Put ashes on your head because
+Cordelia was strangled.  Cry out against Heaven because the daughter of
+Brabantio died.  But don't waste your tears over Sibyl Vane.  She was
+less real than they are."
+
+There was a silence.  The evening darkened in the room.  Noiselessly,
+and with silver feet, the shadows crept in from the garden.  The
+colours faded wearily out of things.
+
+After some time Dorian Gray looked up.  "You have explained me to
+myself, Harry," he murmured with something of a sigh of relief.  "I
+felt all that you have said, but somehow I was afraid of it, and I
+could not express it to myself.  How well you know me!  But we will not
+talk again of what has happened.  It has been a marvellous experience.
+That is all.  I wonder if life has still in store for me anything as
+marvellous."
+
+"Life has everything in store for you, Dorian.  There is nothing that
+you, with your extraordinary good looks, will not be able to do."
+
+"But suppose, Harry, I became haggard, and old, and wrinkled?  What
+then?"
+
+"Ah, then," said Lord Henry, rising to go, "then, my dear Dorian, you
+would have to fight for your victories.  As it is, they are brought to
+you.  No, you must keep your good looks.  We live in an age that reads
+too much to be wise, and that thinks too much to be beautiful.  We
+cannot spare you.  And now you had better dress and drive down to the
+club.  We are rather late, as it is."
+
+"I think I shall join you at the opera, Harry.  I feel too tired to eat
+anything.  What is the number of your sister's box?"
+
+"Twenty-seven, I believe.  It is on the grand tier.  You will see her
+name on the door.  But I am sorry you won't come and dine."
+
+"I don't feel up to it," said Dorian listlessly.  "But I am awfully
+obliged to you for all that you have said to me.  You are certainly my
+best friend.  No one has ever understood me as you have."
+
+"We are only at the beginning of our friendship, Dorian," answered Lord
+Henry, shaking him by the hand.  "Good-bye. I shall see you before
+nine-thirty, I hope.  Remember, Patti is singing."
+
+As he closed the door behind him, Dorian Gray touched the bell, and in
+a few minutes Victor appeared with the lamps and drew the blinds down.
+He waited impatiently for him to go.  The man seemed to take an
+interminable time over everything.
+
+As soon as he had left, he rushed to the screen and drew it back.  No;
+there was no further change in the picture.  It had received the news
+of Sibyl Vane's death before he had known of it himself.  It was
+conscious of the events of life as they occurred.  The vicious cruelty
+that marred the fine lines of the mouth had, no doubt, appeared at the
+very moment that the girl had drunk the poison, whatever it was.  Or
+was it indifferent to results?  Did it merely take cognizance of what
+passed within the soul?  He wondered, and hoped that some day he would
+see the change taking place before his very eyes, shuddering as he
+hoped it.
+
+Poor Sibyl!  What a romance it had all been!  She had often mimicked
+death on the stage.  Then Death himself had touched her and taken her
+with him.  How had she played that dreadful last scene?  Had she cursed
+him, as she died?  No; she had died for love of him, and love would
+always be a sacrament to him now.  She had atoned for everything by the
+sacrifice she had made of her life.  He would not think any more of
+what she had made him go through, on that horrible night at the
+theatre.  When he thought of her, it would be as a wonderful tragic
+figure sent on to the world's stage to show the supreme reality of
+love.  A wonderful tragic figure?  Tears came to his eyes as he
+remembered her childlike look, and winsome fanciful ways, and shy
+tremulous grace.  He brushed them away hastily and looked again at the
+picture.
+
+He felt that the time had really come for making his choice.  Or had
+his choice already been made?  Yes, life had decided that for
+him--life, and his own infinite curiosity about life.  Eternal youth,
+infinite passion, pleasures subtle and secret, wild joys and wilder
+sins--he was to have all these things.  The portrait was to bear the
+burden of his shame: that was all.
+
+A feeling of pain crept over him as he thought of the desecration that
+was in store for the fair face on the canvas.  Once, in boyish mockery
+of Narcissus, he had kissed, or feigned to kiss, those painted lips
+that now smiled so cruelly at him.  Morning after morning he had sat
+before the portrait wondering at its beauty, almost enamoured of it, as
+it seemed to him at times.  Was it to alter now with every mood to
+which he yielded?  Was it to become a monstrous and loathsome thing, to
+be hidden away in a locked room, to be shut out from the sunlight that
+had so often touched to brighter gold the waving wonder of its hair?
+The pity of it! the pity of it!
+
+For a moment, he thought of praying that the horrible sympathy that
+existed between him and the picture might cease.  It had changed in
+answer to a prayer; perhaps in answer to a prayer it might remain
+unchanged.  And yet, who, that knew anything about life, would
+surrender the chance of remaining always young, however fantastic that
+chance might be, or with what fateful consequences it might be fraught?
+Besides, was it really under his control?  Had it indeed been prayer
+that had produced the substitution?  Might there not be some curious
+scientific reason for it all?  If thought could exercise its influence
+upon a living organism, might not thought exercise an influence upon
+dead and inorganic things?  Nay, without thought or conscious desire,
+might not things external to ourselves vibrate in unison with our moods
+and passions, atom calling to atom in secret love or strange affinity?
+But the reason was of no importance.  He would never again tempt by a
+prayer any terrible power.  If the picture was to alter, it was to
+alter.  That was all.  Why inquire too closely into it?
+
+For there would be a real pleasure in watching it.  He would be able to
+follow his mind into its secret places.  This portrait would be to him
+the most magical of mirrors.  As it had revealed to him his own body,
+so it would reveal to him his own soul.  And when winter came upon it,
+he would still be standing where spring trembles on the verge of
+summer.  When the blood crept from its face, and left behind a pallid
+mask of chalk with leaden eyes, he would keep the glamour of boyhood.
+Not one blossom of his loveliness would ever fade.  Not one pulse of
+his life would ever weaken.  Like the gods of the Greeks, he would be
+strong, and fleet, and joyous.  What did it matter what happened to the
+coloured image on the canvas?  He would be safe.  That was everything.
+
+He drew the screen back into its former place in front of the picture,
+smiling as he did so, and passed into his bedroom, where his valet was
+already waiting for him.  An hour later he was at the opera, and Lord
+Henry was leaning over his chair.
+
+
+
+CHAPTER 9
+
+As he was sitting at breakfast next morning, Basil Hallward was shown
+into the room.
+
+"I am so glad I have found you, Dorian," he said gravely.  "I called
+last night, and they told me you were at the opera.  Of course, I knew
+that was impossible.  But I wish you had left word where you had really
+gone to.  I passed a dreadful evening, half afraid that one tragedy
+might be followed by another.  I think you might have telegraphed for
+me when you heard of it first.  I read of it quite by chance in a late
+edition of _The Globe_ that I picked up at the club.  I came here at once
+and was miserable at not finding you.  I can't tell you how
+heart-broken I am about the whole thing.  I know what you must suffer.
+But where were you?  Did you go down and see the girl's mother?  For a
+moment I thought of following you there.  They gave the address in the
+paper.  Somewhere in the Euston Road, isn't it?  But I was afraid of
+intruding upon a sorrow that I could not lighten.  Poor woman!  What a
+state she must be in!  And her only child, too!  What did she say about
+it all?"
+
+"My dear Basil, how do I know?" murmured Dorian Gray, sipping some
+pale-yellow wine from a delicate, gold-beaded bubble of Venetian glass
+and looking dreadfully bored.  "I was at the opera.  You should have
+come on there.  I met Lady Gwendolen, Harry's sister, for the first
+time.  We were in her box.  She is perfectly charming; and Patti sang
+divinely.  Don't talk about horrid subjects.  If one doesn't talk about
+a thing, it has never happened.  It is simply expression, as Harry
+says, that gives reality to things.  I may mention that she was not the
+woman's only child.  There is a son, a charming fellow, I believe.  But
+he is not on the stage.  He is a sailor, or something.  And now, tell
+me about yourself and what you are painting."
+
+"You went to the opera?" said Hallward, speaking very slowly and with a
+strained touch of pain in his voice.  "You went to the opera while
+Sibyl Vane was lying dead in some sordid lodging?  You can talk to me
+of other women being charming, and of Patti singing divinely, before
+the girl you loved has even the quiet of a grave to sleep in?  Why,
+man, there are horrors in store for that little white body of hers!"
+
+"Stop, Basil!  I won't hear it!" cried Dorian, leaping to his feet.
+"You must not tell me about things.  What is done is done.  What is
+past is past."
+
+"You call yesterday the past?"
+
+"What has the actual lapse of time got to do with it?  It is only
+shallow people who require years to get rid of an emotion.  A man who
+is master of himself can end a sorrow as easily as he can invent a
+pleasure.  I don't want to be at the mercy of my emotions.  I want to
+use them, to enjoy them, and to dominate them."
+
+"Dorian, this is horrible!  Something has changed you completely.  You
+look exactly the same wonderful boy who, day after day, used to come
+down to my studio to sit for his picture.  But you were simple,
+natural, and affectionate then.  You were the most unspoiled creature
+in the whole world.  Now, I don't know what has come over you.  You
+talk as if you had no heart, no pity in you.  It is all Harry's
+influence.  I see that."
+
+The lad flushed up and, going to the window, looked out for a few
+moments on the green, flickering, sun-lashed garden.  "I owe a great
+deal to Harry, Basil," he said at last, "more than I owe to you.  You
+only taught me to be vain."
+
+"Well, I am punished for that, Dorian--or shall be some day."
+
+"I don't know what you mean, Basil," he exclaimed, turning round.  "I
+don't know what you want.  What do you want?"
+
+"I want the Dorian Gray I used to paint," said the artist sadly.
+
+"Basil," said the lad, going over to him and putting his hand on his
+shoulder, "you have come too late.  Yesterday, when I heard that Sibyl
+Vane had killed herself--"
+
+"Killed herself!  Good heavens! is there no doubt about that?" cried
+Hallward, looking up at him with an expression of horror.
+
+"My dear Basil!  Surely you don't think it was a vulgar accident?  Of
+course she killed herself."
+
+The elder man buried his face in his hands.  "How fearful," he
+muttered, and a shudder ran through him.
+
+"No," said Dorian Gray, "there is nothing fearful about it.  It is one
+of the great romantic tragedies of the age.  As a rule, people who act
+lead the most commonplace lives.  They are good husbands, or faithful
+wives, or something tedious.  You know what I mean--middle-class virtue
+and all that kind of thing.  How different Sibyl was!  She lived her
+finest tragedy.  She was always a heroine.  The last night she
+played--the night you saw her--she acted badly because she had known
+the reality of love.  When she knew its unreality, she died, as Juliet
+might have died.  She passed again into the sphere of art.  There is
+something of the martyr about her.  Her death has all the pathetic
+uselessness of martyrdom, all its wasted beauty.  But, as I was saying,
+you must not think I have not suffered.  If you had come in yesterday
+at a particular moment--about half-past five, perhaps, or a quarter to
+six--you would have found me in tears.  Even Harry, who was here, who
+brought me the news, in fact, had no idea what I was going through.  I
+suffered immensely.  Then it passed away.  I cannot repeat an emotion.
+No one can, except sentimentalists.  And you are awfully unjust, Basil.
+You come down here to console me.  That is charming of you.  You find
+me consoled, and you are furious.  How like a sympathetic person!  You
+remind me of a story Harry told me about a certain philanthropist who
+spent twenty years of his life in trying to get some grievance
+redressed, or some unjust law altered--I forget exactly what it was.
+Finally he succeeded, and nothing could exceed his disappointment.  He
+had absolutely nothing to do, almost died of _ennui_, and became a
+confirmed misanthrope.  And besides, my dear old Basil, if you really
+want to console me, teach me rather to forget what has happened, or to
+see it from a proper artistic point of view.  Was it not Gautier who
+used to write about _la consolation des arts_?  I remember picking up a
+little vellum-covered book in your studio one day and chancing on that
+delightful phrase.  Well, I am not like that young man you told me of
+when we were down at Marlow together, the young man who used to say
+that yellow satin could console one for all the miseries of life.  I
+love beautiful things that one can touch and handle.  Old brocades,
+green bronzes, lacquer-work, carved ivories, exquisite surroundings,
+luxury, pomp--there is much to be got from all these.  But the artistic
+temperament that they create, or at any rate reveal, is still more to
+me.  To become the spectator of one's own life, as Harry says, is to
+escape the suffering of life.  I know you are surprised at my talking
+to you like this.  You have not realized how I have developed.  I was a
+schoolboy when you knew me.  I am a man now.  I have new passions, new
+thoughts, new ideas.  I am different, but you must not like me less.  I
+am changed, but you must always be my friend.  Of course, I am very
+fond of Harry.  But I know that you are better than he is.  You are not
+stronger--you are too much afraid of life--but you are better.  And how
+happy we used to be together!  Don't leave me, Basil, and don't quarrel
+with me.  I am what I am.  There is nothing more to be said."
+
+The painter felt strangely moved.  The lad was infinitely dear to him,
+and his personality had been the great turning point in his art.  He
+could not bear the idea of reproaching him any more.  After all, his
+indifference was probably merely a mood that would pass away.  There
+was so much in him that was good, so much in him that was noble.
+
+"Well, Dorian," he said at length, with a sad smile, "I won't speak to
+you again about this horrible thing, after to-day.  I only trust your
+name won't be mentioned in connection with it.  The inquest is to take
+place this afternoon.  Have they summoned you?"
+
+Dorian shook his head, and a look of annoyance passed over his face at
+the mention of the word "inquest."  There was something so crude and
+vulgar about everything of the kind.  "They don't know my name," he
+answered.
+
+"But surely she did?"
+
+"Only my Christian name, and that I am quite sure she never mentioned
+to any one.  She told me once that they were all rather curious to
+learn who I was, and that she invariably told them my name was Prince
+Charming.  It was pretty of her.  You must do me a drawing of Sibyl,
+Basil.  I should like to have something more of her than the memory of
+a few kisses and some broken pathetic words."
+
+"I will try and do something, Dorian, if it would please you.  But you
+must come and sit to me yourself again.  I can't get on without you."
+
+"I can never sit to you again, Basil.  It is impossible!" he exclaimed,
+starting back.
+
+The painter stared at him.  "My dear boy, what nonsense!" he cried.
+"Do you mean to say you don't like what I did of you?  Where is it?
+Why have you pulled the screen in front of it?  Let me look at it.  It
+is the best thing I have ever done.  Do take the screen away, Dorian.
+It is simply disgraceful of your servant hiding my work like that.  I
+felt the room looked different as I came in."
+
+"My servant has nothing to do with it, Basil.  You don't imagine I let
+him arrange my room for me?  He settles my flowers for me
+sometimes--that is all.  No; I did it myself.  The light was too strong
+on the portrait."
+
+"Too strong!  Surely not, my dear fellow?  It is an admirable place for
+it.  Let me see it."  And Hallward walked towards the corner of the
+room.
+
+A cry of terror broke from Dorian Gray's lips, and he rushed between
+the painter and the screen.  "Basil," he said, looking very pale, "you
+must not look at it.  I don't wish you to."
+
+"Not look at my own work!  You are not serious.  Why shouldn't I look
+at it?" exclaimed Hallward, laughing.
+
+"If you try to look at it, Basil, on my word of honour I will never
+speak to you again as long as I live.  I am quite serious.  I don't
+offer any explanation, and you are not to ask for any.  But, remember,
+if you touch this screen, everything is over between us."
+
+Hallward was thunderstruck.  He looked at Dorian Gray in absolute
+amazement.  He had never seen him like this before.  The lad was
+actually pallid with rage.  His hands were clenched, and the pupils of
+his eyes were like disks of blue fire.  He was trembling all over.
+
+"Dorian!"
+
+"Don't speak!"
+
+"But what is the matter?  Of course I won't look at it if you don't
+want me to," he said, rather coldly, turning on his heel and going over
+towards the window.  "But, really, it seems rather absurd that I
+shouldn't see my own work, especially as I am going to exhibit it in
+Paris in the autumn.  I shall probably have to give it another coat of
+varnish before that, so I must see it some day, and why not to-day?"
+
+"To exhibit it!  You want to exhibit it?" exclaimed Dorian Gray, a
+strange sense of terror creeping over him.  Was the world going to be
+shown his secret?  Were people to gape at the mystery of his life?
+That was impossible.  Something--he did not know what--had to be done
+at once.
+
+"Yes; I don't suppose you will object to that.  Georges Petit is going
+to collect all my best pictures for a special exhibition in the Rue de
+Seze, which will open the first week in October.  The portrait will
+only be away a month.  I should think you could easily spare it for
+that time.  In fact, you are sure to be out of town.  And if you keep
+it always behind a screen, you can't care much about it."
+
+Dorian Gray passed his hand over his forehead.  There were beads of
+perspiration there.  He felt that he was on the brink of a horrible
+danger.  "You told me a month ago that you would never exhibit it," he
+cried.  "Why have you changed your mind?  You people who go in for
+being consistent have just as many moods as others have.  The only
+difference is that your moods are rather meaningless.  You can't have
+forgotten that you assured me most solemnly that nothing in the world
+would induce you to send it to any exhibition.  You told Harry exactly
+the same thing." He stopped suddenly, and a gleam of light came into
+his eyes.  He remembered that Lord Henry had said to him once, half
+seriously and half in jest, "If you want to have a strange quarter of
+an hour, get Basil to tell you why he won't exhibit your picture.  He
+told me why he wouldn't, and it was a revelation to me."  Yes, perhaps
+Basil, too, had his secret.  He would ask him and try.
+
+"Basil," he said, coming over quite close and looking him straight in
+the face, "we have each of us a secret.  Let me know yours, and I shall
+tell you mine.  What was your reason for refusing to exhibit my
+picture?"
+
+The painter shuddered in spite of himself.  "Dorian, if I told you, you
+might like me less than you do, and you would certainly laugh at me.  I
+could not bear your doing either of those two things.  If you wish me
+never to look at your picture again, I am content.  I have always you
+to look at.  If you wish the best work I have ever done to be hidden
+from the world, I am satisfied.  Your friendship is dearer to me than
+any fame or reputation."
+
+"No, Basil, you must tell me," insisted Dorian Gray.  "I think I have a
+right to know."  His feeling of terror had passed away, and curiosity
+had taken its place.  He was determined to find out Basil Hallward's
+mystery.
+
+"Let us sit down, Dorian," said the painter, looking troubled.  "Let us
+sit down.  And just answer me one question.  Have you noticed in the
+picture something curious?--something that probably at first did not
+strike you, but that revealed itself to you suddenly?"
+
+"Basil!" cried the lad, clutching the arms of his chair with trembling
+hands and gazing at him with wild startled eyes.
+
+"I see you did.  Don't speak.  Wait till you hear what I have to say.
+Dorian, from the moment I met you, your personality had the most
+extraordinary influence over me.  I was dominated, soul, brain, and
+power, by you.  You became to me the visible incarnation of that unseen
+ideal whose memory haunts us artists like an exquisite dream.  I
+worshipped you.  I grew jealous of every one to whom you spoke.  I
+wanted to have you all to myself.  I was only happy when I was with
+you.  When you were away from me, you were still present in my art....
+Of course, I never let you know anything about this.  It would have
+been impossible.  You would not have understood it.  I hardly
+understood it myself.  I only knew that I had seen perfection face to
+face, and that the world had become wonderful to my eyes--too
+wonderful, perhaps, for in such mad worships there is peril, the peril
+of losing them, no less than the peril of keeping them....  Weeks and
+weeks went on, and I grew more and more absorbed in you.  Then came a
+new development.  I had drawn you as Paris in dainty armour, and as
+Adonis with huntsman's cloak and polished boar-spear. Crowned with
+heavy lotus-blossoms you had sat on the prow of Adrian's barge, gazing
+across the green turbid Nile.  You had leaned over the still pool of
+some Greek woodland and seen in the water's silent silver the marvel of
+your own face.  And it had all been what art should be--unconscious,
+ideal, and remote.  One day, a fatal day I sometimes think, I
+determined to paint a wonderful portrait of you as you actually are,
+not in the costume of dead ages, but in your own dress and in your own
+time.  Whether it was the realism of the method, or the mere wonder of
+your own personality, thus directly presented to me without mist or
+veil, I cannot tell.  But I know that as I worked at it, every flake
+and film of colour seemed to me to reveal my secret.  I grew afraid
+that others would know of my idolatry.  I felt, Dorian, that I had told
+too much, that I had put too much of myself into it.  Then it was that
+I resolved never to allow the picture to be exhibited.  You were a
+little annoyed; but then you did not realize all that it meant to me.
+Harry, to whom I talked about it, laughed at me.  But I did not mind
+that.  When the picture was finished, and I sat alone with it, I felt
+that I was right.... Well, after a few days the thing left my studio,
+and as soon as I had got rid of the intolerable fascination of its
+presence, it seemed to me that I had been foolish in imagining that I
+had seen anything in it, more than that you were extremely good-looking
+and that I could paint.  Even now I cannot help feeling that it is a
+mistake to think that the passion one feels in creation is ever really
+shown in the work one creates.  Art is always more abstract than we
+fancy.  Form and colour tell us of form and colour--that is all.  It
+often seems to me that art conceals the artist far more completely than
+it ever reveals him.  And so when I got this offer from Paris, I
+determined to make your portrait the principal thing in my exhibition.
+It never occurred to me that you would refuse.  I see now that you were
+right.  The picture cannot be shown.  You must not be angry with me,
+Dorian, for what I have told you.  As I said to Harry, once, you are
+made to be worshipped."
+
+Dorian Gray drew a long breath.  The colour came back to his cheeks,
+and a smile played about his lips.  The peril was over.  He was safe
+for the time.  Yet he could not help feeling infinite pity for the
+painter who had just made this strange confession to him, and wondered
+if he himself would ever be so dominated by the personality of a
+friend.  Lord Henry had the charm of being very dangerous.  But that
+was all.  He was too clever and too cynical to be really fond of.
+Would there ever be some one who would fill him with a strange
+idolatry?  Was that one of the things that life had in store?
+
+"It is extraordinary to me, Dorian," said Hallward, "that you should
+have seen this in the portrait.  Did you really see it?"
+
+"I saw something in it," he answered, "something that seemed to me very
+curious."
+
+"Well, you don't mind my looking at the thing now?"
+
+Dorian shook his head.  "You must not ask me that, Basil.  I could not
+possibly let you stand in front of that picture."
+
+"You will some day, surely?"
+
+"Never."
+
+"Well, perhaps you are right.  And now good-bye, Dorian.  You have been
+the one person in my life who has really influenced my art.  Whatever I
+have done that is good, I owe to you.  Ah! you don't know what it cost
+me to tell you all that I have told you."
+
+"My dear Basil," said Dorian, "what have you told me?  Simply that you
+felt that you admired me too much.  That is not even a compliment."
+
+"It was not intended as a compliment.  It was a confession.  Now that I
+have made it, something seems to have gone out of me.  Perhaps one
+should never put one's worship into words."
+
+"It was a very disappointing confession."
+
+"Why, what did you expect, Dorian?  You didn't see anything else in the
+picture, did you?  There was nothing else to see?"
+
+"No; there was nothing else to see.  Why do you ask?  But you mustn't
+talk about worship.  It is foolish.  You and I are friends, Basil, and
+we must always remain so."
+
+"You have got Harry," said the painter sadly.
+
+"Oh, Harry!" cried the lad, with a ripple of laughter.  "Harry spends
+his days in saying what is incredible and his evenings in doing what is
+improbable.  Just the sort of life I would like to lead.  But still I
+don't think I would go to Harry if I were in trouble.  I would sooner
+go to you, Basil."
+
+"You will sit to me again?"
+
+"Impossible!"
+
+"You spoil my life as an artist by refusing, Dorian.  No man comes
+across two ideal things.  Few come across one."
+
+"I can't explain it to you, Basil, but I must never sit to you again.
+There is something fatal about a portrait.  It has a life of its own.
+I will come and have tea with you.  That will be just as pleasant."
+
+"Pleasanter for you, I am afraid," murmured Hallward regretfully.  "And
+now good-bye. I am sorry you won't let me look at the picture once
+again.  But that can't be helped.  I quite understand what you feel
+about it."
+
+As he left the room, Dorian Gray smiled to himself.  Poor Basil!  How
+little he knew of the true reason!  And how strange it was that,
+instead of having been forced to reveal his own secret, he had
+succeeded, almost by chance, in wresting a secret from his friend!  How
+much that strange confession explained to him!  The painter's absurd
+fits of jealousy, his wild devotion, his extravagant panegyrics, his
+curious reticences--he understood them all now, and he felt sorry.
+There seemed to him to be something tragic in a friendship so coloured
+by romance.
+
+He sighed and touched the bell.  The portrait must be hidden away at
+all costs.  He could not run such a risk of discovery again.  It had
+been mad of him to have allowed the thing to remain, even for an hour,
+in a room to which any of his friends had access.
+
+
+
+CHAPTER 10
+
+When his servant entered, he looked at him steadfastly and wondered if
+he had thought of peering behind the screen.  The man was quite
+impassive and waited for his orders.  Dorian lit a cigarette and walked
+over to the glass and glanced into it.  He could see the reflection of
+Victor's face perfectly.  It was like a placid mask of servility.
+There was nothing to be afraid of, there.  Yet he thought it best to be
+on his guard.
+
+Speaking very slowly, he told him to tell the house-keeper that he
+wanted to see her, and then to go to the frame-maker and ask him to
+send two of his men round at once.  It seemed to him that as the man
+left the room his eyes wandered in the direction of the screen.  Or was
+that merely his own fancy?
+
+After a few moments, in her black silk dress, with old-fashioned thread
+mittens on her wrinkled hands, Mrs. Leaf bustled into the library.  He
+asked her for the key of the schoolroom.
+
+"The old schoolroom, Mr. Dorian?" she exclaimed.  "Why, it is full of
+dust.  I must get it arranged and put straight before you go into it.
+It is not fit for you to see, sir.  It is not, indeed."
+
+"I don't want it put straight, Leaf.  I only want the key."
+
+"Well, sir, you'll be covered with cobwebs if you go into it.  Why, it
+hasn't been opened for nearly five years--not since his lordship died."
+
+He winced at the mention of his grandfather.  He had hateful memories
+of him.  "That does not matter," he answered.  "I simply want to see
+the place--that is all.  Give me the key."
+
+"And here is the key, sir," said the old lady, going over the contents
+of her bunch with tremulously uncertain hands.  "Here is the key.  I'll
+have it off the bunch in a moment.  But you don't think of living up
+there, sir, and you so comfortable here?"
+
+"No, no," he cried petulantly.  "Thank you, Leaf.  That will do."
+
+She lingered for a few moments, and was garrulous over some detail of
+the household.  He sighed and told her to manage things as she thought
+best.  She left the room, wreathed in smiles.
+
+As the door closed, Dorian put the key in his pocket and looked round
+the room.  His eye fell on a large, purple satin coverlet heavily
+embroidered with gold, a splendid piece of late seventeenth-century
+Venetian work that his grandfather had found in a convent near Bologna.
+Yes, that would serve to wrap the dreadful thing in.  It had perhaps
+served often as a pall for the dead.  Now it was to hide something that
+had a corruption of its own, worse than the corruption of death
+itself--something that would breed horrors and yet would never die.
+What the worm was to the corpse, his sins would be to the painted image
+on the canvas.  They would mar its beauty and eat away its grace.  They
+would defile it and make it shameful.  And yet the thing would still
+live on.  It would be always alive.
+
+He shuddered, and for a moment he regretted that he had not told Basil
+the true reason why he had wished to hide the picture away.  Basil
+would have helped him to resist Lord Henry's influence, and the still
+more poisonous influences that came from his own temperament.  The love
+that he bore him--for it was really love--had nothing in it that was
+not noble and intellectual.  It was not that mere physical admiration
+of beauty that is born of the senses and that dies when the senses
+tire.  It was such love as Michelangelo had known, and Montaigne, and
+Winckelmann, and Shakespeare himself.  Yes, Basil could have saved him.
+But it was too late now.  The past could always be annihilated.
+Regret, denial, or forgetfulness could do that.  But the future was
+inevitable.  There were passions in him that would find their terrible
+outlet, dreams that would make the shadow of their evil real.
+
+He took up from the couch the great purple-and-gold texture that
+covered it, and, holding it in his hands, passed behind the screen.
+Was the face on the canvas viler than before?  It seemed to him that it
+was unchanged, and yet his loathing of it was intensified.  Gold hair,
+blue eyes, and rose-red lips--they all were there.  It was simply the
+expression that had altered.  That was horrible in its cruelty.
+Compared to what he saw in it of censure or rebuke, how shallow Basil's
+reproaches about Sibyl Vane had been!--how shallow, and of what little
+account!  His own soul was looking out at him from the canvas and
+calling him to judgement.  A look of pain came across him, and he flung
+the rich pall over the picture.  As he did so, a knock came to the
+door.  He passed out as his servant entered.
+
+"The persons are here, Monsieur."
+
+He felt that the man must be got rid of at once.  He must not be
+allowed to know where the picture was being taken to.  There was
+something sly about him, and he had thoughtful, treacherous eyes.
+Sitting down at the writing-table he scribbled a note to Lord Henry,
+asking him to send him round something to read and reminding him that
+they were to meet at eight-fifteen that evening.
+
+"Wait for an answer," he said, handing it to him, "and show the men in
+here."
+
+In two or three minutes there was another knock, and Mr. Hubbard
+himself, the celebrated frame-maker of South Audley Street, came in
+with a somewhat rough-looking young assistant.  Mr. Hubbard was a
+florid, red-whiskered little man, whose admiration for art was
+considerably tempered by the inveterate impecuniosity of most of the
+artists who dealt with him.  As a rule, he never left his shop.  He
+waited for people to come to him.  But he always made an exception in
+favour of Dorian Gray.  There was something about Dorian that charmed
+everybody.  It was a pleasure even to see him.
+
+"What can I do for you, Mr. Gray?" he said, rubbing his fat freckled
+hands.  "I thought I would do myself the honour of coming round in
+person.  I have just got a beauty of a frame, sir.  Picked it up at a
+sale.  Old Florentine.  Came from Fonthill, I believe.  Admirably
+suited for a religious subject, Mr. Gray."
+
+"I am so sorry you have given yourself the trouble of coming round, Mr.
+Hubbard.  I shall certainly drop in and look at the frame--though I
+don't go in much at present for religious art--but to-day I only want a
+picture carried to the top of the house for me.  It is rather heavy, so
+I thought I would ask you to lend me a couple of your men."
+
+"No trouble at all, Mr. Gray.  I am delighted to be of any service to
+you.  Which is the work of art, sir?"
+
+"This," replied Dorian, moving the screen back.  "Can you move it,
+covering and all, just as it is?  I don't want it to get scratched
+going upstairs."
+
+"There will be no difficulty, sir," said the genial frame-maker,
+beginning, with the aid of his assistant, to unhook the picture from
+the long brass chains by which it was suspended.  "And, now, where
+shall we carry it to, Mr. Gray?"
+
+"I will show you the way, Mr. Hubbard, if you will kindly follow me.
+Or perhaps you had better go in front.  I am afraid it is right at the
+top of the house.  We will go up by the front staircase, as it is
+wider."
+
+He held the door open for them, and they passed out into the hall and
+began the ascent.  The elaborate character of the frame had made the
+picture extremely bulky, and now and then, in spite of the obsequious
+protests of Mr. Hubbard, who had the true tradesman's spirited dislike
+of seeing a gentleman doing anything useful, Dorian put his hand to it
+so as to help them.
+
+"Something of a load to carry, sir," gasped the little man when they
+reached the top landing.  And he wiped his shiny forehead.
+
+"I am afraid it is rather heavy," murmured Dorian as he unlocked the
+door that opened into the room that was to keep for him the curious
+secret of his life and hide his soul from the eyes of men.
+
+He had not entered the place for more than four years--not, indeed,
+since he had used it first as a play-room when he was a child, and then
+as a study when he grew somewhat older.  It was a large,
+well-proportioned room, which had been specially built by the last Lord
+Kelso for the use of the little grandson whom, for his strange likeness
+to his mother, and also for other reasons, he had always hated and
+desired to keep at a distance.  It appeared to Dorian to have but
+little changed.  There was the huge Italian _cassone_, with its
+fantastically painted panels and its tarnished gilt mouldings, in which
+he had so often hidden himself as a boy.  There the satinwood book-case
+filled with his dog-eared schoolbooks.  On the wall behind it was
+hanging the same ragged Flemish tapestry where a faded king and queen
+were playing chess in a garden, while a company of hawkers rode by,
+carrying hooded birds on their gauntleted wrists.  How well he
+remembered it all!  Every moment of his lonely childhood came back to
+him as he looked round.  He recalled the stainless purity of his boyish
+life, and it seemed horrible to him that it was here the fatal portrait
+was to be hidden away.  How little he had thought, in those dead days,
+of all that was in store for him!
+
+But there was no other place in the house so secure from prying eyes as
+this.  He had the key, and no one else could enter it.  Beneath its
+purple pall, the face painted on the canvas could grow bestial, sodden,
+and unclean.  What did it matter?  No one could see it.  He himself
+would not see it.  Why should he watch the hideous corruption of his
+soul?  He kept his youth--that was enough.  And, besides, might not
+his nature grow finer, after all?  There was no reason that the future
+should be so full of shame.  Some love might come across his life, and
+purify him, and shield him from those sins that seemed to be already
+stirring in spirit and in flesh--those curious unpictured sins whose
+very mystery lent them their subtlety and their charm.  Perhaps, some
+day, the cruel look would have passed away from the scarlet sensitive
+mouth, and he might show to the world Basil Hallward's masterpiece.
+
+No; that was impossible.  Hour by hour, and week by week, the thing
+upon the canvas was growing old.  It might escape the hideousness of
+sin, but the hideousness of age was in store for it.  The cheeks would
+become hollow or flaccid.  Yellow crow's feet would creep round the
+fading eyes and make them horrible.  The hair would lose its
+brightness, the mouth would gape or droop, would be foolish or gross,
+as the mouths of old men are.  There would be the wrinkled throat, the
+cold, blue-veined hands, the twisted body, that he remembered in the
+grandfather who had been so stern to him in his boyhood.  The picture
+had to be concealed.  There was no help for it.
+
+"Bring it in, Mr. Hubbard, please," he said, wearily, turning round.
+"I am sorry I kept you so long.  I was thinking of something else."
+
+"Always glad to have a rest, Mr. Gray," answered the frame-maker, who
+was still gasping for breath.  "Where shall we put it, sir?"
+
+"Oh, anywhere.  Here:  this will do.  I don't want to have it hung up.
+Just lean it against the wall.  Thanks."
+
+"Might one look at the work of art, sir?"
+
+Dorian started.  "It would not interest you, Mr. Hubbard," he said,
+keeping his eye on the man.  He felt ready to leap upon him and fling
+him to the ground if he dared to lift the gorgeous hanging that
+concealed the secret of his life.  "I shan't trouble you any more now.
+I am much obliged for your kindness in coming round."
+
+"Not at all, not at all, Mr. Gray.  Ever ready to do anything for you,
+sir." And Mr. Hubbard tramped downstairs, followed by the assistant,
+who glanced back at Dorian with a look of shy wonder in his rough
+uncomely face.  He had never seen any one so marvellous.
+
+When the sound of their footsteps had died away, Dorian locked the door
+and put the key in his pocket.  He felt safe now.  No one would ever
+look upon the horrible thing.  No eye but his would ever see his shame.
+
+On reaching the library, he found that it was just after five o'clock
+and that the tea had been already brought up.  On a little table of
+dark perfumed wood thickly incrusted with nacre, a present from Lady
+Radley, his guardian's wife, a pretty professional invalid who had
+spent the preceding winter in Cairo, was lying a note from Lord Henry,
+and beside it was a book bound in yellow paper, the cover slightly torn
+and the edges soiled.  A copy of the third edition of _The St. James's
+Gazette_ had been placed on the tea-tray. It was evident that Victor had
+returned.  He wondered if he had met the men in the hall as they were
+leaving the house and had wormed out of them what they had been doing.
+He would be sure to miss the picture--had no doubt missed it already,
+while he had been laying the tea-things. The screen had not been set
+back, and a blank space was visible on the wall.  Perhaps some night he
+might find him creeping upstairs and trying to force the door of the
+room.  It was a horrible thing to have a spy in one's house.  He had
+heard of rich men who had been blackmailed all their lives by some
+servant who had read a letter, or overheard a conversation, or picked
+up a card with an address, or found beneath a pillow a withered flower
+or a shred of crumpled lace.
+
+He sighed, and having poured himself out some tea, opened Lord Henry's
+note.  It was simply to say that he sent him round the evening paper,
+and a book that might interest him, and that he would be at the club at
+eight-fifteen. He opened _The St. James's_ languidly, and looked through
+it.  A red pencil-mark on the fifth page caught his eye.  It drew
+attention to the following paragraph:
+
+
+INQUEST ON AN ACTRESS.--An inquest was held this morning at the Bell
+Tavern, Hoxton Road, by Mr. Danby, the District Coroner, on the body of
+Sibyl Vane, a young actress recently engaged at the Royal Theatre,
+Holborn.  A verdict of death by misadventure was returned.
+Considerable sympathy was expressed for the mother of the deceased, who
+was greatly affected during the giving of her own evidence, and that of
+Dr. Birrell, who had made the post-mortem examination of the deceased.
+
+
+He frowned, and tearing the paper in two, went across the room and
+flung the pieces away.  How ugly it all was!  And how horribly real
+ugliness made things!  He felt a little annoyed with Lord Henry for
+having sent him the report.  And it was certainly stupid of him to have
+marked it with red pencil.  Victor might have read it.  The man knew
+more than enough English for that.
+
+Perhaps he had read it and had begun to suspect something.  And, yet,
+what did it matter?  What had Dorian Gray to do with Sibyl Vane's
+death?  There was nothing to fear.  Dorian Gray had not killed her.
+
+His eye fell on the yellow book that Lord Henry had sent him.  What was
+it, he wondered.  He went towards the little, pearl-coloured octagonal
+stand that had always looked to him like the work of some strange
+Egyptian bees that wrought in silver, and taking up the volume, flung
+himself into an arm-chair and began to turn over the leaves.  After a
+few minutes he became absorbed.  It was the strangest book that he had
+ever read.  It seemed to him that in exquisite raiment, and to the
+delicate sound of flutes, the sins of the world were passing in dumb
+show before him.  Things that he had dimly dreamed of were suddenly
+made real to him.  Things of which he had never dreamed were gradually
+revealed.
+
+It was a novel without a plot and with only one character, being,
+indeed, simply a psychological study of a certain young Parisian who
+spent his life trying to realize in the nineteenth century all the
+passions and modes of thought that belonged to every century except his
+own, and to sum up, as it were, in himself the various moods through
+which the world-spirit had ever passed, loving for their mere
+artificiality those renunciations that men have unwisely called virtue,
+as much as those natural rebellions that wise men still call sin.  The
+style in which it was written was that curious jewelled style, vivid
+and obscure at once, full of _argot_ and of archaisms, of technical
+expressions and of elaborate paraphrases, that characterizes the work
+of some of the finest artists of the French school of _Symbolistes_.
+There were in it metaphors as monstrous as orchids and as subtle in
+colour.  The life of the senses was described in the terms of mystical
+philosophy.  One hardly knew at times whether one was reading the
+spiritual ecstasies of some mediaeval saint or the morbid confessions
+of a modern sinner.  It was a poisonous book.  The heavy odour of
+incense seemed to cling about its pages and to trouble the brain.  The
+mere cadence of the sentences, the subtle monotony of their music, so
+full as it was of complex refrains and movements elaborately repeated,
+produced in the mind of the lad, as he passed from chapter to chapter,
+a form of reverie, a malady of dreaming, that made him unconscious of
+the falling day and creeping shadows.
+
+Cloudless, and pierced by one solitary star, a copper-green sky gleamed
+through the windows.  He read on by its wan light till he could read no
+more.  Then, after his valet had reminded him several times of the
+lateness of the hour, he got up, and going into the next room, placed
+the book on the little Florentine table that always stood at his
+bedside and began to dress for dinner.
+
+It was almost nine o'clock before he reached the club, where he found
+Lord Henry sitting alone, in the morning-room, looking very much bored.
+
+"I am so sorry, Harry," he cried, "but really it is entirely your
+fault.  That book you sent me so fascinated me that I forgot how the
+time was going."
+
+"Yes, I thought you would like it," replied his host, rising from his
+chair.
+
+"I didn't say I liked it, Harry.  I said it fascinated me.  There is a
+great difference."
+
+"Ah, you have discovered that?" murmured Lord Henry.  And they passed
+into the dining-room.
+
+
+
+CHAPTER 11
+
+For years, Dorian Gray could not free himself from the influence of
+this book.  Or perhaps it would be more accurate to say that he never
+sought to free himself from it.  He procured from Paris no less than
+nine large-paper copies of the first edition, and had them bound in
+different colours, so that they might suit his various moods and the
+changing fancies of a nature over which he seemed, at times, to have
+almost entirely lost control.  The hero, the wonderful young Parisian
+in whom the romantic and the scientific temperaments were so strangely
+blended, became to him a kind of prefiguring type of himself.  And,
+indeed, the whole book seemed to him to contain the story of his own
+life, written before he had lived it.
+
+In one point he was more fortunate than the novel's fantastic hero.  He
+never knew--never, indeed, had any cause to know--that somewhat
+grotesque dread of mirrors, and polished metal surfaces, and still
+water which came upon the young Parisian so early in his life, and was
+occasioned by the sudden decay of a beau that had once, apparently,
+been so remarkable.  It was with an almost cruel joy--and perhaps in
+nearly every joy, as certainly in every pleasure, cruelty has its
+place--that he used to read the latter part of the book, with its
+really tragic, if somewhat overemphasized, account of the sorrow and
+despair of one who had himself lost what in others, and the world, he
+had most dearly valued.
+
+For the wonderful beauty that had so fascinated Basil Hallward, and
+many others besides him, seemed never to leave him.  Even those who had
+heard the most evil things against him--and from time to time strange
+rumours about his mode of life crept through London and became the
+chatter of the clubs--could not believe anything to his dishonour when
+they saw him.  He had always the look of one who had kept himself
+unspotted from the world.  Men who talked grossly became silent when
+Dorian Gray entered the room.  There was something in the purity of his
+face that rebuked them.  His mere presence seemed to recall to them the
+memory of the innocence that they had tarnished.  They wondered how one
+so charming and graceful as he was could have escaped the stain of an
+age that was at once sordid and sensual.
+
+Often, on returning home from one of those mysterious and prolonged
+absences that gave rise to such strange conjecture among those who were
+his friends, or thought that they were so, he himself would creep
+upstairs to the locked room, open the door with the key that never left
+him now, and stand, with a mirror, in front of the portrait that Basil
+Hallward had painted of him, looking now at the evil and aging face on
+the canvas, and now at the fair young face that laughed back at him
+from the polished glass.  The very sharpness of the contrast used to
+quicken his sense of pleasure.  He grew more and more enamoured of his
+own beauty, more and more interested in the corruption of his own soul.
+He would examine with minute care, and sometimes with a monstrous and
+terrible delight, the hideous lines that seared the wrinkling forehead
+or crawled around the heavy sensual mouth, wondering sometimes which
+were the more horrible, the signs of sin or the signs of age.  He would
+place his white hands beside the coarse bloated hands of the picture,
+and smile.  He mocked the misshapen body and the failing limbs.
+
+There were moments, indeed, at night, when, lying sleepless in his own
+delicately scented chamber, or in the sordid room of the little
+ill-famed tavern near the docks which, under an assumed name and in
+disguise, it was his habit to frequent, he would think of the ruin he
+had brought upon his soul with a pity that was all the more poignant
+because it was purely selfish.  But moments such as these were rare.
+That curiosity about life which Lord Henry had first stirred in him, as
+they sat together in the garden of their friend, seemed to increase
+with gratification.  The more he knew, the more he desired to know.  He
+had mad hungers that grew more ravenous as he fed them.
+
+Yet he was not really reckless, at any rate in his relations to
+society.  Once or twice every month during the winter, and on each
+Wednesday evening while the season lasted, he would throw open to the
+world his beautiful house and have the most celebrated musicians of the
+day to charm his guests with the wonders of their art.  His little
+dinners, in the settling of which Lord Henry always assisted him, were
+noted as much for the careful selection and placing of those invited,
+as for the exquisite taste shown in the decoration of the table, with
+its subtle symphonic arrangements of exotic flowers, and embroidered
+cloths, and antique plate of gold and silver.  Indeed, there were many,
+especially among the very young men, who saw, or fancied that they saw,
+in Dorian Gray the true realization of a type of which they had often
+dreamed in Eton or Oxford days, a type that was to combine something of
+the real culture of the scholar with all the grace and distinction and
+perfect manner of a citizen of the world.  To them he seemed to be of
+the company of those whom Dante describes as having sought to "make
+themselves perfect by the worship of beauty."  Like Gautier, he was one
+for whom "the visible world existed."
+
+And, certainly, to him life itself was the first, the greatest, of the
+arts, and for it all the other arts seemed to be but a preparation.
+Fashion, by which what is really fantastic becomes for a moment
+universal, and dandyism, which, in its own way, is an attempt to assert
+the absolute modernity of beauty, had, of course, their fascination for
+him.  His mode of dressing, and the particular styles that from time to
+time he affected, had their marked influence on the young exquisites of
+the Mayfair balls and Pall Mall club windows, who copied him in
+everything that he did, and tried to reproduce the accidental charm of
+his graceful, though to him only half-serious, fopperies.
+
+For, while he was but too ready to accept the position that was almost
+immediately offered to him on his coming of age, and found, indeed, a
+subtle pleasure in the thought that he might really become to the
+London of his own day what to imperial Neronian Rome the author of the
+Satyricon once had been, yet in his inmost heart he desired to be
+something more than a mere _arbiter elegantiarum_, to be consulted on the
+wearing of a jewel, or the knotting of a necktie, or the conduct of a
+cane.  He sought to elaborate some new scheme of life that would have
+its reasoned philosophy and its ordered principles, and find in the
+spiritualizing of the senses its highest realization.
+
+The worship of the senses has often, and with much justice, been
+decried, men feeling a natural instinct of terror about passions and
+sensations that seem stronger than themselves, and that they are
+conscious of sharing with the less highly organized forms of existence.
+But it appeared to Dorian Gray that the true nature of the senses had
+never been understood, and that they had remained savage and animal
+merely because the world had sought to starve them into submission or
+to kill them by pain, instead of aiming at making them elements of a
+new spirituality, of which a fine instinct for beauty was to be the
+dominant characteristic.  As he looked back upon man moving through
+history, he was haunted by a feeling of loss.  So much had been
+surrendered! and to such little purpose!  There had been mad wilful
+rejections, monstrous forms of self-torture and self-denial, whose
+origin was fear and whose result was a degradation infinitely more
+terrible than that fancied degradation from which, in their ignorance,
+they had sought to escape; Nature, in her wonderful irony, driving out
+the anchorite to feed with the wild animals of the desert and giving to
+the hermit the beasts of the field as his companions.
+
+Yes:  there was to be, as Lord Henry had prophesied, a new Hedonism
+that was to recreate life and to save it from that harsh uncomely
+puritanism that is having, in our own day, its curious revival.  It was
+to have its service of the intellect, certainly, yet it was never to
+accept any theory or system that would involve the sacrifice of any
+mode of passionate experience.  Its aim, indeed, was to be experience
+itself, and not the fruits of experience, sweet or bitter as they might
+be.  Of the asceticism that deadens the senses, as of the vulgar
+profligacy that dulls them, it was to know nothing.  But it was to
+teach man to concentrate himself upon the moments of a life that is
+itself but a moment.
+
+There are few of us who have not sometimes wakened before dawn, either
+after one of those dreamless nights that make us almost enamoured of
+death, or one of those nights of horror and misshapen joy, when through
+the chambers of the brain sweep phantoms more terrible than reality
+itself, and instinct with that vivid life that lurks in all grotesques,
+and that lends to Gothic art its enduring vitality, this art being, one
+might fancy, especially the art of those whose minds have been troubled
+with the malady of reverie.  Gradually white fingers creep through the
+curtains, and they appear to tremble.  In black fantastic shapes, dumb
+shadows crawl into the corners of the room and crouch there.  Outside,
+there is the stirring of birds among the leaves, or the sound of men
+going forth to their work, or the sigh and sob of the wind coming down
+from the hills and wandering round the silent house, as though it
+feared to wake the sleepers and yet must needs call forth sleep from
+her purple cave.  Veil after veil of thin dusky gauze is lifted, and by
+degrees the forms and colours of things are restored to them, and we
+watch the dawn remaking the world in its antique pattern.  The wan
+mirrors get back their mimic life.  The flameless tapers stand where we
+had left them, and beside them lies the half-cut book that we had been
+studying, or the wired flower that we had worn at the ball, or the
+letter that we had been afraid to read, or that we had read too often.
+Nothing seems to us changed.  Out of the unreal shadows of the night
+comes back the real life that we had known.  We have to resume it where
+we had left off, and there steals over us a terrible sense of the
+necessity for the continuance of energy in the same wearisome round of
+stereotyped habits, or a wild longing, it may be, that our eyelids
+might open some morning upon a world that had been refashioned anew in
+the darkness for our pleasure, a world in which things would have fresh
+shapes and colours, and be changed, or have other secrets, a world in
+which the past would have little or no place, or survive, at any rate,
+in no conscious form of obligation or regret, the remembrance even of
+joy having its bitterness and the memories of pleasure their pain.
+
+It was the creation of such worlds as these that seemed to Dorian Gray
+to be the true object, or amongst the true objects, of life; and in his
+search for sensations that would be at once new and delightful, and
+possess that element of strangeness that is so essential to romance, he
+would often adopt certain modes of thought that he knew to be really
+alien to his nature, abandon himself to their subtle influences, and
+then, having, as it were, caught their colour and satisfied his
+intellectual curiosity, leave them with that curious indifference that
+is not incompatible with a real ardour of temperament, and that,
+indeed, according to certain modern psychologists, is often a condition
+of it.
+
+It was rumoured of him once that he was about to join the Roman
+Catholic communion, and certainly the Roman ritual had always a great
+attraction for him.  The daily sacrifice, more awful really than all
+the sacrifices of the antique world, stirred him as much by its superb
+rejection of the evidence of the senses as by the primitive simplicity
+of its elements and the eternal pathos of the human tragedy that it
+sought to symbolize.  He loved to kneel down on the cold marble
+pavement and watch the priest, in his stiff flowered dalmatic, slowly
+and with white hands moving aside the veil of the tabernacle, or
+raising aloft the jewelled, lantern-shaped monstrance with that pallid
+wafer that at times, one would fain think, is indeed the "_panis
+caelestis_," the bread of angels, or, robed in the garments of the
+Passion of Christ, breaking the Host into the chalice and smiting his
+breast for his sins.  The fuming censers that the grave boys, in their
+lace and scarlet, tossed into the air like great gilt flowers had their
+subtle fascination for him.  As he passed out, he used to look with
+wonder at the black confessionals and long to sit in the dim shadow of
+one of them and listen to men and women whispering through the worn
+grating the true story of their lives.
+
+But he never fell into the error of arresting his intellectual
+development by any formal acceptance of creed or system, or of
+mistaking, for a house in which to live, an inn that is but suitable
+for the sojourn of a night, or for a few hours of a night in which
+there are no stars and the moon is in travail.  Mysticism, with its
+marvellous power of making common things strange to us, and the subtle
+antinomianism that always seems to accompany it, moved him for a
+season; and for a season he inclined to the materialistic doctrines of
+the _Darwinismus_ movement in Germany, and found a curious pleasure in
+tracing the thoughts and passions of men to some pearly cell in the
+brain, or some white nerve in the body, delighting in the conception of
+the absolute dependence of the spirit on certain physical conditions,
+morbid or healthy, normal or diseased.  Yet, as has been said of him
+before, no theory of life seemed to him to be of any importance
+compared with life itself.  He felt keenly conscious of how barren all
+intellectual speculation is when separated from action and experiment.
+He knew that the senses, no less than the soul, have their spiritual
+mysteries to reveal.
+
+And so he would now study perfumes and the secrets of their
+manufacture, distilling heavily scented oils and burning odorous gums
+from the East.  He saw that there was no mood of the mind that had not
+its counterpart in the sensuous life, and set himself to discover their
+true relations, wondering what there was in frankincense that made one
+mystical, and in ambergris that stirred one's passions, and in violets
+that woke the memory of dead romances, and in musk that troubled the
+brain, and in champak that stained the imagination; and seeking often
+to elaborate a real psychology of perfumes, and to estimate the several
+influences of sweet-smelling roots and scented, pollen-laden flowers;
+of aromatic balms and of dark and fragrant woods; of spikenard, that
+sickens; of hovenia, that makes men mad; and of aloes, that are said to
+be able to expel melancholy from the soul.
+
+At another time he devoted himself entirely to music, and in a long
+latticed room, with a vermilion-and-gold ceiling and walls of
+olive-green lacquer, he used to give curious concerts in which mad
+gipsies tore wild music from little zithers, or grave, yellow-shawled
+Tunisians plucked at the strained strings of monstrous lutes, while
+grinning Negroes beat monotonously upon copper drums and, crouching
+upon scarlet mats, slim turbaned Indians blew through long pipes of
+reed or brass and charmed--or feigned to charm--great hooded snakes and
+horrible horned adders.  The harsh intervals and shrill discords of
+barbaric music stirred him at times when Schubert's grace, and Chopin's
+beautiful sorrows, and the mighty harmonies of Beethoven himself, fell
+unheeded on his ear.  He collected together from all parts of the world
+the strangest instruments that could be found, either in the tombs of
+dead nations or among the few savage tribes that have survived contact
+with Western civilizations, and loved to touch and try them.  He had
+the mysterious _juruparis_ of the Rio Negro Indians, that women are not
+allowed to look at and that even youths may not see till they have been
+subjected to fasting and scourging, and the earthen jars of the
+Peruvians that have the shrill cries of birds, and flutes of human
+bones such as Alfonso de Ovalle heard in Chile, and the sonorous green
+jaspers that are found near Cuzco and give forth a note of singular
+sweetness.  He had painted gourds filled with pebbles that rattled when
+they were shaken; the long _clarin_ of the Mexicans, into which the
+performer does not blow, but through which he inhales the air; the
+harsh _ture_ of the Amazon tribes, that is sounded by the sentinels who
+sit all day long in high trees, and can be heard, it is said, at a
+distance of three leagues; the _teponaztli_, that has two vibrating
+tongues of wood and is beaten with sticks that are smeared with an
+elastic gum obtained from the milky juice of plants; the _yotl_-bells of
+the Aztecs, that are hung in clusters like grapes; and a huge
+cylindrical drum, covered with the skins of great serpents, like the
+one that Bernal Diaz saw when he went with Cortes into the Mexican
+temple, and of whose doleful sound he has left us so vivid a
+description.  The fantastic character of these instruments fascinated
+him, and he felt a curious delight in the thought that art, like
+Nature, has her monsters, things of bestial shape and with hideous
+voices.  Yet, after some time, he wearied of them, and would sit in his
+box at the opera, either alone or with Lord Henry, listening in rapt
+pleasure to "Tannhauser" and seeing in the prelude to that great work
+of art a presentation of the tragedy of his own soul.
+
+On one occasion he took up the study of jewels, and appeared at a
+costume ball as Anne de Joyeuse, Admiral of France, in a dress covered
+with five hundred and sixty pearls.  This taste enthralled him for
+years, and, indeed, may be said never to have left him.  He would often
+spend a whole day settling and resettling in their cases the various
+stones that he had collected, such as the olive-green chrysoberyl that
+turns red by lamplight, the cymophane with its wirelike line of silver,
+the pistachio-coloured peridot, rose-pink and wine-yellow topazes,
+carbuncles of fiery scarlet with tremulous, four-rayed stars, flame-red
+cinnamon-stones, orange and violet spinels, and amethysts with their
+alternate layers of ruby and sapphire.  He loved the red gold of the
+sunstone, and the moonstone's pearly whiteness, and the broken rainbow
+of the milky opal.  He procured from Amsterdam three emeralds of
+extraordinary size and richness of colour, and had a turquoise _de la
+vieille roche_ that was the envy of all the connoisseurs.
+
+He discovered wonderful stories, also, about jewels.  In Alphonso's
+Clericalis Disciplina a serpent was mentioned with eyes of real
+jacinth, and in the romantic history of Alexander, the Conqueror of
+Emathia was said to have found in the vale of Jordan snakes "with
+collars of real emeralds growing on their backs." There was a gem in
+the brain of the dragon, Philostratus told us, and "by the exhibition
+of golden letters and a scarlet robe" the monster could be thrown into
+a magical sleep and slain.  According to the great alchemist, Pierre de
+Boniface, the diamond rendered a man invisible, and the agate of India
+made him eloquent.  The cornelian appeased anger, and the hyacinth
+provoked sleep, and the amethyst drove away the fumes of wine.  The
+garnet cast out demons, and the hydropicus deprived the moon of her
+colour.  The selenite waxed and waned with the moon, and the meloceus,
+that discovers thieves, could be affected only by the blood of kids.
+Leonardus Camillus had seen a white stone taken from the brain of a
+newly killed toad, that was a certain antidote against poison.  The
+bezoar, that was found in the heart of the Arabian deer, was a charm
+that could cure the plague.  In the nests of Arabian birds was the
+aspilates, that, according to Democritus, kept the wearer from any
+danger by fire.
+
+The King of Ceilan rode through his city with a large ruby in his hand,
+as the ceremony of his coronation.  The gates of the palace of John the
+Priest were "made of sardius, with the horn of the horned snake
+inwrought, so that no man might bring poison within." Over the gable
+were "two golden apples, in which were two carbuncles," so that the
+gold might shine by day and the carbuncles by night.  In Lodge's
+strange romance 'A Margarite of America', it was stated that in the
+chamber of the queen one could behold "all the chaste ladies of the
+world, inchased out of silver, looking through fair mirrours of
+chrysolites, carbuncles, sapphires, and greene emeraults." Marco Polo
+had seen the inhabitants of Zipangu place rose-coloured pearls in the
+mouths of the dead.  A sea-monster had been enamoured of the pearl that
+the diver brought to King Perozes, and had slain the thief, and mourned
+for seven moons over its loss.  When the Huns lured the king into the
+great pit, he flung it away--Procopius tells the story--nor was it ever
+found again, though the Emperor Anastasius offered five hundred-weight
+of gold pieces for it.  The King of Malabar had shown to a certain
+Venetian a rosary of three hundred and four pearls, one for every god
+that he worshipped.
+
+When the Duke de Valentinois, son of Alexander VI, visited Louis XII of
+France, his horse was loaded with gold leaves, according to Brantome,
+and his cap had double rows of rubies that threw out a great light.
+Charles of England had ridden in stirrups hung with four hundred and
+twenty-one diamonds.  Richard II had a coat, valued at thirty thousand
+marks, which was covered with balas rubies.  Hall described Henry VIII,
+on his way to the Tower previous to his coronation, as wearing "a
+jacket of raised gold, the placard embroidered with diamonds and other
+rich stones, and a great bauderike about his neck of large balasses."
+The favourites of James I wore ear-rings of emeralds set in gold
+filigrane.  Edward II gave to Piers Gaveston a suit of red-gold armour
+studded with jacinths, a collar of gold roses set with
+turquoise-stones, and a skull-cap _parseme_ with pearls.  Henry II wore
+jewelled gloves reaching to the elbow, and had a hawk-glove sewn with
+twelve rubies and fifty-two great orients.  The ducal hat of Charles
+the Rash, the last Duke of Burgundy of his race, was hung with
+pear-shaped pearls and studded with sapphires.
+
+How exquisite life had once been!  How gorgeous in its pomp and
+decoration!  Even to read of the luxury of the dead was wonderful.
+
+Then he turned his attention to embroideries and to the tapestries that
+performed the office of frescoes in the chill rooms of the northern
+nations of Europe.  As he investigated the subject--and he always had
+an extraordinary faculty of becoming absolutely absorbed for the moment
+in whatever he took up--he was almost saddened by the reflection of the
+ruin that time brought on beautiful and wonderful things.  He, at any
+rate, had escaped that.  Summer followed summer, and the yellow
+jonquils bloomed and died many times, and nights of horror repeated the
+story of their shame, but he was unchanged.  No winter marred his face
+or stained his flowerlike bloom.  How different it was with material
+things!  Where had they passed to?  Where was the great crocus-coloured
+robe, on which the gods fought against the giants, that had been worked
+by brown girls for the pleasure of Athena?  Where the huge velarium
+that Nero had stretched across the Colosseum at Rome, that Titan sail
+of purple on which was represented the starry sky, and Apollo driving a
+chariot drawn by white, gilt-reined steeds?  He longed to see the
+curious table-napkins wrought for the Priest of the Sun, on which were
+displayed all the dainties and viands that could be wanted for a feast;
+the mortuary cloth of King Chilperic, with its three hundred golden
+bees; the fantastic robes that excited the indignation of the Bishop of
+Pontus and were figured with "lions, panthers, bears, dogs, forests,
+rocks, hunters--all, in fact, that a painter can copy from nature"; and
+the coat that Charles of Orleans once wore, on the sleeves of which
+were embroidered the verses of a song beginning "_Madame, je suis tout
+joyeux_," the musical accompaniment of the words being wrought in gold
+thread, and each note, of square shape in those days, formed with four
+pearls.  He read of the room that was prepared at the palace at Rheims
+for the use of Queen Joan of Burgundy and was decorated with "thirteen
+hundred and twenty-one parrots, made in broidery, and blazoned with the
+king's arms, and five hundred and sixty-one butterflies, whose wings
+were similarly ornamented with the arms of the queen, the whole worked
+in gold."  Catherine de Medicis had a mourning-bed made for her of
+black velvet powdered with crescents and suns.  Its curtains were of
+damask, with leafy wreaths and garlands, figured upon a gold and silver
+ground, and fringed along the edges with broideries of pearls, and it
+stood in a room hung with rows of the queen's devices in cut black
+velvet upon cloth of silver.  Louis XIV had gold embroidered caryatides
+fifteen feet high in his apartment.  The state bed of Sobieski, King of
+Poland, was made of Smyrna gold brocade embroidered in turquoises with
+verses from the Koran.  Its supports were of silver gilt, beautifully
+chased, and profusely set with enamelled and jewelled medallions.  It
+had been taken from the Turkish camp before Vienna, and the standard of
+Mohammed had stood beneath the tremulous gilt of its canopy.
+
+And so, for a whole year, he sought to accumulate the most exquisite
+specimens that he could find of textile and embroidered work, getting
+the dainty Delhi muslins, finely wrought with gold-thread palmates and
+stitched over with iridescent beetles' wings; the Dacca gauzes, that
+from their transparency are known in the East as "woven air," and
+"running water," and "evening dew"; strange figured cloths from Java;
+elaborate yellow Chinese hangings; books bound in tawny satins or fair
+blue silks and wrought with _fleurs-de-lis_, birds and images; veils of
+_lacis_ worked in Hungary point; Sicilian brocades and stiff Spanish
+velvets; Georgian work, with its gilt coins, and Japanese _Foukousas_,
+with their green-toned golds and their marvellously plumaged birds.
+
+He had a special passion, also, for ecclesiastical vestments, as indeed
+he had for everything connected with the service of the Church.  In the
+long cedar chests that lined the west gallery of his house, he had
+stored away many rare and beautiful specimens of what is really the
+raiment of the Bride of Christ, who must wear purple and jewels and
+fine linen that she may hide the pallid macerated body that is worn by
+the suffering that she seeks for and wounded by self-inflicted pain.
+He possessed a gorgeous cope of crimson silk and gold-thread damask,
+figured with a repeating pattern of golden pomegranates set in
+six-petalled formal blossoms, beyond which on either side was the
+pine-apple device wrought in seed-pearls. The orphreys were divided
+into panels representing scenes from the life of the Virgin, and the
+coronation of the Virgin was figured in coloured silks upon the hood.
+This was Italian work of the fifteenth century.  Another cope was of
+green velvet, embroidered with heart-shaped groups of acanthus-leaves,
+from which spread long-stemmed white blossoms, the details of which
+were picked out with silver thread and coloured crystals.  The morse
+bore a seraph's head in gold-thread raised work.  The orphreys were
+woven in a diaper of red and gold silk, and were starred with
+medallions of many saints and martyrs, among whom was St. Sebastian.
+He had chasubles, also, of amber-coloured silk, and blue silk and gold
+brocade, and yellow silk damask and cloth of gold, figured with
+representations of the Passion and Crucifixion of Christ, and
+embroidered with lions and peacocks and other emblems; dalmatics of
+white satin and pink silk damask, decorated with tulips and dolphins
+and _fleurs-de-lis_; altar frontals of crimson velvet and blue linen; and
+many corporals, chalice-veils, and sudaria.  In the mystic offices to
+which such things were put, there was something that quickened his
+imagination.
+
+For these treasures, and everything that he collected in his lovely
+house, were to be to him means of forgetfulness, modes by which he
+could escape, for a season, from the fear that seemed to him at times
+to be almost too great to be borne.  Upon the walls of the lonely
+locked room where he had spent so much of his boyhood, he had hung with
+his own hands the terrible portrait whose changing features showed him
+the real degradation of his life, and in front of it had draped the
+purple-and-gold pall as a curtain.  For weeks he would not go there,
+would forget the hideous painted thing, and get back his light heart,
+his wonderful joyousness, his passionate absorption in mere existence.
+Then, suddenly, some night he would creep out of the house, go down to
+dreadful places near Blue Gate Fields, and stay there, day after day,
+until he was driven away.  On his return he would sit in front of the
+picture, sometimes loathing it and himself, but filled, at other
+times, with that pride of individualism that is half the
+fascination of sin, and smiling with secret pleasure at the misshapen
+shadow that had to bear the burden that should have been his own.
+
+After a few years he could not endure to be long out of England, and
+gave up the villa that he had shared at Trouville with Lord Henry, as
+well as the little white walled-in house at Algiers where they had more
+than once spent the winter.  He hated to be separated from the picture
+that was such a part of his life, and was also afraid that during his
+absence some one might gain access to the room, in spite of the
+elaborate bars that he had caused to be placed upon the door.
+
+He was quite conscious that this would tell them nothing.  It was true
+that the portrait still preserved, under all the foulness and ugliness
+of the face, its marked likeness to himself; but what could they learn
+from that?  He would laugh at any one who tried to taunt him.  He had
+not painted it.  What was it to him how vile and full of shame it
+looked?  Even if he told them, would they believe it?
+
+Yet he was afraid.  Sometimes when he was down at his great house in
+Nottinghamshire, entertaining the fashionable young men of his own rank
+who were his chief companions, and astounding the county by the wanton
+luxury and gorgeous splendour of his mode of life, he would suddenly
+leave his guests and rush back to town to see that the door had not
+been tampered with and that the picture was still there.  What if it
+should be stolen?  The mere thought made him cold with horror.  Surely
+the world would know his secret then.  Perhaps the world already
+suspected it.
+
+For, while he fascinated many, there were not a few who distrusted him.
+He was very nearly blackballed at a West End club of which his birth
+and social position fully entitled him to become a member, and it was
+said that on one occasion, when he was brought by a friend into the
+smoking-room of the Churchill, the Duke of Berwick and another
+gentleman got up in a marked manner and went out.  Curious stories
+became current about him after he had passed his twenty-fifth year.  It
+was rumoured that he had been seen brawling with foreign sailors in a
+low den in the distant parts of Whitechapel, and that he consorted with
+thieves and coiners and knew the mysteries of their trade.  His
+extraordinary absences became notorious, and, when he used to reappear
+again in society, men would whisper to each other in corners, or pass
+him with a sneer, or look at him with cold searching eyes, as though
+they were determined to discover his secret.
+
+Of such insolences and attempted slights he, of course, took no notice,
+and in the opinion of most people his frank debonair manner, his
+charming boyish smile, and the infinite grace of that wonderful youth
+that seemed never to leave him, were in themselves a sufficient answer
+to the calumnies, for so they termed them, that were circulated about
+him.  It was remarked, however, that some of those who had been most
+intimate with him appeared, after a time, to shun him.  Women who had
+wildly adored him, and for his sake had braved all social censure and
+set convention at defiance, were seen to grow pallid with shame or
+horror if Dorian Gray entered the room.
+
+Yet these whispered scandals only increased in the eyes of many his
+strange and dangerous charm.  His great wealth was a certain element of
+security.  Society--civilized society, at least--is never very ready to
+believe anything to the detriment of those who are both rich and
+fascinating.  It feels instinctively that manners are of more
+importance than morals, and, in its opinion, the highest respectability
+is of much less value than the possession of a good _chef_.  And, after
+all, it is a very poor consolation to be told that the man who has
+given one a bad dinner, or poor wine, is irreproachable in his private
+life.  Even the cardinal virtues cannot atone for half-cold _entrees_, as
+Lord Henry remarked once, in a discussion on the subject, and there is
+possibly a good deal to be said for his view.  For the canons of good
+society are, or should be, the same as the canons of art.  Form is
+absolutely essential to it.  It should have the dignity of a ceremony,
+as well as its unreality, and should combine the insincere character of
+a romantic play with the wit and beauty that make such plays delightful
+to us.  Is insincerity such a terrible thing?  I think not.  It is
+merely a method by which we can multiply our personalities.
+
+Such, at any rate, was Dorian Gray's opinion.  He used to wonder at the
+shallow psychology of those who conceive the ego in man as a thing
+simple, permanent, reliable, and of one essence.  To him, man was a
+being with myriad lives and myriad sensations, a complex multiform
+creature that bore within itself strange legacies of thought and
+passion, and whose very flesh was tainted with the monstrous maladies
+of the dead.  He loved to stroll through the gaunt cold picture-gallery
+of his country house and look at the various portraits of those whose
+blood flowed in his veins.  Here was Philip Herbert, described by
+Francis Osborne, in his Memoires on the Reigns of Queen Elizabeth and
+King James, as one who was "caressed by the Court for his handsome
+face, which kept him not long company."  Was it young Herbert's life
+that he sometimes led?  Had some strange poisonous germ crept from body
+to body till it had reached his own?  Was it some dim sense of that
+ruined grace that had made him so suddenly, and almost without cause,
+give utterance, in Basil Hallward's studio, to the mad prayer that had
+so changed his life?  Here, in gold-embroidered red doublet, jewelled
+surcoat, and gilt-edged ruff and wristbands, stood Sir Anthony Sherard,
+with his silver-and-black armour piled at his feet.  What had this
+man's legacy been?  Had the lover of Giovanna of Naples bequeathed him
+some inheritance of sin and shame?  Were his own actions merely the
+dreams that the dead man had not dared to realize?  Here, from the
+fading canvas, smiled Lady Elizabeth Devereux, in her gauze hood, pearl
+stomacher, and pink slashed sleeves.  A flower was in her right hand,
+and her left clasped an enamelled collar of white and damask roses.  On
+a table by her side lay a mandolin and an apple.  There were large
+green rosettes upon her little pointed shoes.  He knew her life, and
+the strange stories that were told about her lovers.  Had he something
+of her temperament in him?  These oval, heavy-lidded eyes seemed to
+look curiously at him.  What of George Willoughby, with his powdered
+hair and fantastic patches?  How evil he looked!  The face was
+saturnine and swarthy, and the sensual lips seemed to be twisted with
+disdain.  Delicate lace ruffles fell over the lean yellow hands that
+were so overladen with rings.  He had been a macaroni of the eighteenth
+century, and the friend, in his youth, of Lord Ferrars.  What of the
+second Lord Beckenham, the companion of the Prince Regent in his
+wildest days, and one of the witnesses at the secret marriage with Mrs.
+Fitzherbert?  How proud and handsome he was, with his chestnut curls
+and insolent pose!  What passions had he bequeathed?  The world had
+looked upon him as infamous.  He had led the orgies at Carlton House.
+The star of the Garter glittered upon his breast.  Beside him hung the
+portrait of his wife, a pallid, thin-lipped woman in black.  Her blood,
+also, stirred within him.  How curious it all seemed!  And his mother
+with her Lady Hamilton face and her moist, wine-dashed lips--he knew
+what he had got from her.  He had got from her his beauty, and his
+passion for the beauty of others.  She laughed at him in her loose
+Bacchante dress.  There were vine leaves in her hair.  The purple
+spilled from the cup she was holding.  The carnations of the painting
+had withered, but the eyes were still wonderful in their depth and
+brilliancy of colour.  They seemed to follow him wherever he went.
+
+Yet one had ancestors in literature as well as in one's own race,
+nearer perhaps in type and temperament, many of them, and certainly
+with an influence of which one was more absolutely conscious.  There
+were times when it appeared to Dorian Gray that the whole of history
+was merely the record of his own life, not as he had lived it in act
+and circumstance, but as his imagination had created it for him, as it
+had been in his brain and in his passions.  He felt that he had known
+them all, those strange terrible figures that had passed across the
+stage of the world and made sin so marvellous and evil so full of
+subtlety.  It seemed to him that in some mysterious way their lives had
+been his own.
+
+The hero of the wonderful novel that had so influenced his life had
+himself known this curious fancy.  In the seventh chapter he tells how,
+crowned with laurel, lest lightning might strike him, he had sat, as
+Tiberius, in a garden at Capri, reading the shameful books of
+Elephantis, while dwarfs and peacocks strutted round him and the
+flute-player mocked the swinger of the censer; and, as Caligula, had
+caroused with the green-shirted jockeys in their stables and supped in
+an ivory manger with a jewel-frontleted horse; and, as Domitian, had
+wandered through a corridor lined with marble mirrors, looking round
+with haggard eyes for the reflection of the dagger that was to end his
+days, and sick with that ennui, that terrible _taedium vitae_, that comes
+on those to whom life denies nothing; and had peered through a clear
+emerald at the red shambles of the circus and then, in a litter of
+pearl and purple drawn by silver-shod mules, been carried through the
+Street of Pomegranates to a House of Gold and heard men cry on Nero
+Caesar as he passed by; and, as Elagabalus, had painted his face with
+colours, and plied the distaff among the women, and brought the Moon
+from Carthage and given her in mystic marriage to the Sun.
+
+Over and over again Dorian used to read this fantastic chapter, and the
+two chapters immediately following, in which, as in some curious
+tapestries or cunningly wrought enamels, were pictured the awful and
+beautiful forms of those whom vice and blood and weariness had made
+monstrous or mad:  Filippo, Duke of Milan, who slew his wife and
+painted her lips with a scarlet poison that her lover might suck death
+from the dead thing he fondled; Pietro Barbi, the Venetian, known as
+Paul the Second, who sought in his vanity to assume the title of
+Formosus, and whose tiara, valued at two hundred thousand florins, was
+bought at the price of a terrible sin; Gian Maria Visconti, who used
+hounds to chase living men and whose murdered body was covered with
+roses by a harlot who had loved him; the Borgia on his white horse,
+with Fratricide riding beside him and his mantle stained with the blood
+of Perotto; Pietro Riario, the young Cardinal Archbishop of Florence,
+child and minion of Sixtus IV, whose beauty was equalled only by his
+debauchery, and who received Leonora of Aragon in a pavilion of white
+and crimson silk, filled with nymphs and centaurs, and gilded a boy
+that he might serve at the feast as Ganymede or Hylas; Ezzelin, whose
+melancholy could be cured only by the spectacle of death, and who had a
+passion for red blood, as other men have for red wine--the son of the
+Fiend, as was reported, and one who had cheated his father at dice when
+gambling with him for his own soul; Giambattista Cibo, who in mockery
+took the name of Innocent and into whose torpid veins the blood of
+three lads was infused by a Jewish doctor; Sigismondo Malatesta, the
+lover of Isotta and the lord of Rimini, whose effigy was burned at Rome
+as the enemy of God and man, who strangled Polyssena with a napkin, and
+gave poison to Ginevra d'Este in a cup of emerald, and in honour of a
+shameful passion built a pagan church for Christian worship; Charles
+VI, who had so wildly adored his brother's wife that a leper had warned
+him of the insanity that was coming on him, and who, when his brain had
+sickened and grown strange, could only be soothed by Saracen cards
+painted with the images of love and death and madness; and, in his
+trimmed jerkin and jewelled cap and acanthuslike curls, Grifonetto
+Baglioni, who slew Astorre with his bride, and Simonetto with his page,
+and whose comeliness was such that, as he lay dying in the yellow
+piazza of Perugia, those who had hated him could not choose but weep,
+and Atalanta, who had cursed him, blessed him.
+
+There was a horrible fascination in them all.  He saw them at night,
+and they troubled his imagination in the day.  The Renaissance knew of
+strange manners of poisoning--poisoning by a helmet and a lighted
+torch, by an embroidered glove and a jewelled fan, by a gilded pomander
+and by an amber chain.  Dorian Gray had been poisoned by a book.  There
+were moments when he looked on evil simply as a mode through which he
+could realize his conception of the beautiful.
+
+
+
+CHAPTER 12
+
+It was on the ninth of November, the eve of his own thirty-eighth
+birthday, as he often remembered afterwards.
+
+He was walking home about eleven o'clock from Lord Henry's, where he
+had been dining, and was wrapped in heavy furs, as the night was cold
+and foggy.  At the corner of Grosvenor Square and South Audley Street,
+a man passed him in the mist, walking very fast and with the collar of
+his grey ulster turned up.  He had a bag in his hand.  Dorian
+recognized him.  It was Basil Hallward.  A strange sense of fear, for
+which he could not account, came over him.  He made no sign of
+recognition and went on quickly in the direction of his own house.
+
+But Hallward had seen him.  Dorian heard him first stopping on the
+pavement and then hurrying after him.  In a few moments, his hand was
+on his arm.
+
+"Dorian!  What an extraordinary piece of luck!  I have been waiting for
+you in your library ever since nine o'clock. Finally I took pity on
+your tired servant and told him to go to bed, as he let me out.  I am
+off to Paris by the midnight train, and I particularly wanted to see
+you before I left.  I thought it was you, or rather your fur coat, as
+you passed me.  But I wasn't quite sure.  Didn't you recognize me?"
+
+"In this fog, my dear Basil?  Why, I can't even recognize Grosvenor
+Square.  I believe my house is somewhere about here, but I don't feel
+at all certain about it.  I am sorry you are going away, as I have not
+seen you for ages.  But I suppose you will be back soon?"
+
+"No:  I am going to be out of England for six months.  I intend to take
+a studio in Paris and shut myself up till I have finished a great
+picture I have in my head.  However, it wasn't about myself I wanted to
+talk.  Here we are at your door.  Let me come in for a moment.  I have
+something to say to you."
+
+"I shall be charmed.  But won't you miss your train?" said Dorian Gray
+languidly as he passed up the steps and opened the door with his
+latch-key.
+
+The lamplight struggled out through the fog, and Hallward looked at his
+watch.  "I have heaps of time," he answered.  "The train doesn't go
+till twelve-fifteen, and it is only just eleven.  In fact, I was on my
+way to the club to look for you, when I met you.  You see, I shan't
+have any delay about luggage, as I have sent on my heavy things.  All I
+have with me is in this bag, and I can easily get to Victoria in twenty
+minutes."
+
+Dorian looked at him and smiled.  "What a way for a fashionable painter
+to travel!  A Gladstone bag and an ulster!  Come in, or the fog will
+get into the house.  And mind you don't talk about anything serious.
+Nothing is serious nowadays.  At least nothing should be."
+
+Hallward shook his head, as he entered, and followed Dorian into the
+library.  There was a bright wood fire blazing in the large open
+hearth.  The lamps were lit, and an open Dutch silver spirit-case
+stood, with some siphons of soda-water and large cut-glass tumblers, on
+a little marqueterie table.
+
+"You see your servant made me quite at home, Dorian.  He gave me
+everything I wanted, including your best gold-tipped cigarettes.  He is
+a most hospitable creature.  I like him much better than the Frenchman
+you used to have.  What has become of the Frenchman, by the bye?"
+
+Dorian shrugged his shoulders.  "I believe he married Lady Radley's
+maid, and has established her in Paris as an English dressmaker.
+Anglomania is very fashionable over there now, I hear.  It seems silly
+of the French, doesn't it?  But--do you know?--he was not at all a bad
+servant.  I never liked him, but I had nothing to complain about.  One
+often imagines things that are quite absurd.  He was really very
+devoted to me and seemed quite sorry when he went away.  Have another
+brandy-and-soda? Or would you like hock-and-seltzer? I always take
+hock-and-seltzer myself.  There is sure to be some in the next room."
+
+"Thanks, I won't have anything more," said the painter, taking his cap
+and coat off and throwing them on the bag that he had placed in the
+corner.  "And now, my dear fellow, I want to speak to you seriously.
+Don't frown like that.  You make it so much more difficult for me."
+
+"What is it all about?" cried Dorian in his petulant way, flinging
+himself down on the sofa.  "I hope it is not about myself.  I am tired
+of myself to-night. I should like to be somebody else."
+
+"It is about yourself," answered Hallward in his grave deep voice, "and
+I must say it to you.  I shall only keep you half an hour."
+
+Dorian sighed and lit a cigarette.  "Half an hour!" he murmured.
+
+"It is not much to ask of you, Dorian, and it is entirely for your own
+sake that I am speaking.  I think it right that you should know that
+the most dreadful things are being said against you in London."
+
+"I don't wish to know anything about them.  I love scandals about other
+people, but scandals about myself don't interest me.  They have not got
+the charm of novelty."
+
+"They must interest you, Dorian.  Every gentleman is interested in his
+good name.  You don't want people to talk of you as something vile and
+degraded.  Of course, you have your position, and your wealth, and all
+that kind of thing.  But position and wealth are not everything.  Mind
+you, I don't believe these rumours at all.  At least, I can't believe
+them when I see you.  Sin is a thing that writes itself across a man's
+face.  It cannot be concealed.  People talk sometimes of secret vices.
+There are no such things.  If a wretched man has a vice, it shows
+itself in the lines of his mouth, the droop of his eyelids, the
+moulding of his hands even.  Somebody--I won't mention his name, but
+you know him--came to me last year to have his portrait done.  I had
+never seen him before, and had never heard anything about him at the
+time, though I have heard a good deal since.  He offered an extravagant
+price.  I refused him.  There was something in the shape of his fingers
+that I hated.  I know now that I was quite right in what I fancied
+about him.  His life is dreadful.  But you, Dorian, with your pure,
+bright, innocent face, and your marvellous untroubled youth--I can't
+believe anything against you.  And yet I see you very seldom, and you
+never come down to the studio now, and when I am away from you, and I
+hear all these hideous things that people are whispering about you, I
+don't know what to say.  Why is it, Dorian, that a man like the Duke of
+Berwick leaves the room of a club when you enter it?  Why is it that so
+many gentlemen in London will neither go to your house or invite you to
+theirs?  You used to be a friend of Lord Staveley.  I met him at dinner
+last week.  Your name happened to come up in conversation, in
+connection with the miniatures you have lent to the exhibition at the
+Dudley.  Staveley curled his lip and said that you might have the most
+artistic tastes, but that you were a man whom no pure-minded girl
+should be allowed to know, and whom no chaste woman should sit in the
+same room with.  I reminded him that I was a friend of yours, and asked
+him what he meant.  He told me.  He told me right out before everybody.
+It was horrible!  Why is your friendship so fatal to young men?  There
+was that wretched boy in the Guards who committed suicide.  You were
+his great friend.  There was Sir Henry Ashton, who had to leave England
+with a tarnished name.  You and he were inseparable.  What about Adrian
+Singleton and his dreadful end?  What about Lord Kent's only son and
+his career?  I met his father yesterday in St. James's Street.  He
+seemed broken with shame and sorrow.  What about the young Duke of
+Perth?  What sort of life has he got now?  What gentleman would
+associate with him?"
+
+"Stop, Basil.  You are talking about things of which you know nothing,"
+said Dorian Gray, biting his lip, and with a note of infinite contempt
+in his voice.  "You ask me why Berwick leaves a room when I enter it.
+It is because I know everything about his life, not because he knows
+anything about mine.  With such blood as he has in his veins, how could
+his record be clean?  You ask me about Henry Ashton and young Perth.
+Did I teach the one his vices, and the other his debauchery?  If Kent's
+silly son takes his wife from the streets, what is that to me?  If
+Adrian Singleton writes his friend's name across a bill, am I his
+keeper?  I know how people chatter in England.  The middle classes air
+their moral prejudices over their gross dinner-tables, and whisper
+about what they call the profligacies of their betters in order to try
+and pretend that they are in smart society and on intimate terms with
+the people they slander.  In this country, it is enough for a man to
+have distinction and brains for every common tongue to wag against him.
+And what sort of lives do these people, who pose as being moral, lead
+themselves?  My dear fellow, you forget that we are in the native land
+of the hypocrite."
+
+"Dorian," cried Hallward, "that is not the question.  England is bad
+enough I know, and English society is all wrong.  That is the reason
+why I want you to be fine.  You have not been fine.  One has a right to
+judge of a man by the effect he has over his friends.  Yours seem to
+lose all sense of honour, of goodness, of purity.  You have filled them
+with a madness for pleasure.  They have gone down into the depths.  You
+led them there.  Yes:  you led them there, and yet you can smile, as
+you are smiling now.  And there is worse behind.  I know you and Harry
+are inseparable.  Surely for that reason, if for none other, you should
+not have made his sister's name a by-word."
+
+"Take care, Basil.  You go too far."
+
+"I must speak, and you must listen.  You shall listen.  When you met
+Lady Gwendolen, not a breath of scandal had ever touched her.  Is there
+a single decent woman in London now who would drive with her in the
+park?  Why, even her children are not allowed to live with her.  Then
+there are other stories--stories that you have been seen creeping at
+dawn out of dreadful houses and slinking in disguise into the foulest
+dens in London.  Are they true?  Can they be true?  When I first heard
+them, I laughed.  I hear them now, and they make me shudder.  What
+about your country-house and the life that is led there?  Dorian, you
+don't know what is said about you.  I won't tell you that I don't want
+to preach to you.  I remember Harry saying once that every man who
+turned himself into an amateur curate for the moment always began by
+saying that, and then proceeded to break his word.  I do want to preach
+to you.  I want you to lead such a life as will make the world respect
+you.  I want you to have a clean name and a fair record.  I want you to
+get rid of the dreadful people you associate with.  Don't shrug your
+shoulders like that.  Don't be so indifferent.  You have a wonderful
+influence.  Let it be for good, not for evil.  They say that you
+corrupt every one with whom you become intimate, and that it is quite
+sufficient for you to enter a house for shame of some kind to follow
+after.  I don't know whether it is so or not.  How should I know?  But
+it is said of you.  I am told things that it seems impossible to doubt.
+Lord Gloucester was one of my greatest friends at Oxford.  He showed me
+a letter that his wife had written to him when she was dying alone in
+her villa at Mentone.  Your name was implicated in the most terrible
+confession I ever read.  I told him that it was absurd--that I knew you
+thoroughly and that you were incapable of anything of the kind.  Know
+you?  I wonder do I know you?  Before I could answer that, I should
+have to see your soul."
+
+"To see my soul!" muttered Dorian Gray, starting up from the sofa and
+turning almost white from fear.
+
+"Yes," answered Hallward gravely, and with deep-toned sorrow in his
+voice, "to see your soul.  But only God can do that."
+
+A bitter laugh of mockery broke from the lips of the younger man.  "You
+shall see it yourself, to-night!" he cried, seizing a lamp from the
+table.  "Come:  it is your own handiwork.  Why shouldn't you look at
+it?  You can tell the world all about it afterwards, if you choose.
+Nobody would believe you.  If they did believe you, they would like me
+all the better for it.  I know the age better than you do, though you
+will prate about it so tediously.  Come, I tell you.  You have
+chattered enough about corruption.  Now you shall look on it face to
+face."
+
+There was the madness of pride in every word he uttered.  He stamped
+his foot upon the ground in his boyish insolent manner.  He felt a
+terrible joy at the thought that some one else was to share his secret,
+and that the man who had painted the portrait that was the origin of
+all his shame was to be burdened for the rest of his life with the
+hideous memory of what he had done.
+
+"Yes," he continued, coming closer to him and looking steadfastly into
+his stern eyes, "I shall show you my soul.  You shall see the thing
+that you fancy only God can see."
+
+Hallward started back.  "This is blasphemy, Dorian!" he cried.  "You
+must not say things like that.  They are horrible, and they don't mean
+anything."
+
+"You think so?"  He laughed again.
+
+"I know so.  As for what I said to you to-night, I said it for your
+good.  You know I have been always a stanch friend to you."
+
+"Don't touch me.  Finish what you have to say."
+
+A twisted flash of pain shot across the painter's face.  He paused for
+a moment, and a wild feeling of pity came over him.  After all, what
+right had he to pry into the life of Dorian Gray?  If he had done a
+tithe of what was rumoured about him, how much he must have suffered!
+Then he straightened himself up, and walked over to the fire-place, and
+stood there, looking at the burning logs with their frostlike ashes and
+their throbbing cores of flame.
+
+"I am waiting, Basil," said the young man in a hard clear voice.
+
+He turned round.  "What I have to say is this," he cried.  "You must
+give me some answer to these horrible charges that are made against
+you.  If you tell me that they are absolutely untrue from beginning to
+end, I shall believe you.  Deny them, Dorian, deny them!  Can't you see
+what I am going through?  My God! don't tell me that you are bad, and
+corrupt, and shameful."
+
+Dorian Gray smiled.  There was a curl of contempt in his lips.  "Come
+upstairs, Basil," he said quietly.  "I keep a diary of my life from day
+to day, and it never leaves the room in which it is written.  I shall
+show it to you if you come with me."
+
+"I shall come with you, Dorian, if you wish it.  I see I have missed my
+train.  That makes no matter.  I can go to-morrow. But don't ask me to
+read anything to-night. All I want is a plain answer to my question."
+
+"That shall be given to you upstairs.  I could not give it here.  You
+will not have to read long."
+
+
+
+CHAPTER 13
+
+He passed out of the room and began the ascent, Basil Hallward
+following close behind.  They walked softly, as men do instinctively at
+night.  The lamp cast fantastic shadows on the wall and staircase.  A
+rising wind made some of the windows rattle.
+
+When they reached the top landing, Dorian set the lamp down on the
+floor, and taking out the key, turned it in the lock.  "You insist on
+knowing, Basil?" he asked in a low voice.
+
+"Yes."
+
+"I am delighted," he answered, smiling.  Then he added, somewhat
+harshly, "You are the one man in the world who is entitled to know
+everything about me.  You have had more to do with my life than you
+think"; and, taking up the lamp, he opened the door and went in.  A
+cold current of air passed them, and the light shot up for a moment in
+a flame of murky orange.  He shuddered.  "Shut the door behind you," he
+whispered, as he placed the lamp on the table.
+
+Hallward glanced round him with a puzzled expression.  The room looked
+as if it had not been lived in for years.  A faded Flemish tapestry, a
+curtained picture, an old Italian _cassone_, and an almost empty
+book-case--that was all that it seemed to contain, besides a chair and
+a table.  As Dorian Gray was lighting a half-burned candle that was
+standing on the mantelshelf, he saw that the whole place was covered
+with dust and that the carpet was in holes.  A mouse ran scuffling
+behind the wainscoting.  There was a damp odour of mildew.
+
+"So you think that it is only God who sees the soul, Basil?  Draw that
+curtain back, and you will see mine."
+
+The voice that spoke was cold and cruel.  "You are mad, Dorian, or
+playing a part," muttered Hallward, frowning.
+
+"You won't? Then I must do it myself," said the young man, and he tore
+the curtain from its rod and flung it on the ground.
+
+An exclamation of horror broke from the painter's lips as he saw in the
+dim light the hideous face on the canvas grinning at him.  There was
+something in its expression that filled him with disgust and loathing.
+Good heavens! it was Dorian Gray's own face that he was looking at!
+The horror, whatever it was, had not yet entirely spoiled that
+marvellous beauty.  There was still some gold in the thinning hair and
+some scarlet on the sensual mouth.  The sodden eyes had kept something
+of the loveliness of their blue, the noble curves had not yet
+completely passed away from chiselled nostrils and from plastic throat.
+Yes, it was Dorian himself.  But who had done it?  He seemed to
+recognize his own brushwork, and the frame was his own design.  The
+idea was monstrous, yet he felt afraid.  He seized the lighted candle,
+and held it to the picture.  In the left-hand corner was his own name,
+traced in long letters of bright vermilion.
+
+It was some foul parody, some infamous ignoble satire.  He had never
+done that.  Still, it was his own picture.  He knew it, and he felt as
+if his blood had changed in a moment from fire to sluggish ice.  His
+own picture!  What did it mean?  Why had it altered?  He turned and
+looked at Dorian Gray with the eyes of a sick man.  His mouth twitched,
+and his parched tongue seemed unable to articulate.  He passed his hand
+across his forehead.  It was dank with clammy sweat.
+
+The young man was leaning against the mantelshelf, watching him with
+that strange expression that one sees on the faces of those who are
+absorbed in a play when some great artist is acting.  There was neither
+real sorrow in it nor real joy.  There was simply the passion of the
+spectator, with perhaps a flicker of triumph in his eyes.  He had taken
+the flower out of his coat, and was smelling it, or pretending to do so.
+
+"What does this mean?" cried Hallward, at last.  His own voice sounded
+shrill and curious in his ears.
+
+"Years ago, when I was a boy," said Dorian Gray, crushing the flower in
+his hand, "you met me, flattered me, and taught me to be vain of my
+good looks.  One day you introduced me to a friend of yours, who
+explained to me the wonder of youth, and you finished a portrait of me
+that revealed to me the wonder of beauty.  In a mad moment that, even
+now, I don't know whether I regret or not, I made a wish, perhaps you
+would call it a prayer...."
+
+"I remember it!  Oh, how well I remember it!  No! the thing is
+impossible.  The room is damp.  Mildew has got into the canvas.  The
+paints I used had some wretched mineral poison in them.  I tell you the
+thing is impossible."
+
+"Ah, what is impossible?" murmured the young man, going over to the
+window and leaning his forehead against the cold, mist-stained glass.
+
+"You told me you had destroyed it."
+
+"I was wrong.  It has destroyed me."
+
+"I don't believe it is my picture."
+
+"Can't you see your ideal in it?" said Dorian bitterly.
+
+"My ideal, as you call it..."
+
+"As you called it."
+
+"There was nothing evil in it, nothing shameful.  You were to me such
+an ideal as I shall never meet again.  This is the face of a satyr."
+
+"It is the face of my soul."
+
+"Christ! what a thing I must have worshipped!  It has the eyes of a
+devil."
+
+"Each of us has heaven and hell in him, Basil," cried Dorian with a
+wild gesture of despair.
+
+Hallward turned again to the portrait and gazed at it.  "My God!  If it
+is true," he exclaimed, "and this is what you have done with your life,
+why, you must be worse even than those who talk against you fancy you
+to be!" He held the light up again to the canvas and examined it.  The
+surface seemed to be quite undisturbed and as he had left it.  It was
+from within, apparently, that the foulness and horror had come.
+Through some strange quickening of inner life the leprosies of sin were
+slowly eating the thing away.  The rotting of a corpse in a watery
+grave was not so fearful.
+
+His hand shook, and the candle fell from its socket on the floor and
+lay there sputtering.  He placed his foot on it and put it out.  Then
+he flung himself into the rickety chair that was standing by the table
+and buried his face in his hands.
+
+"Good God, Dorian, what a lesson!  What an awful lesson!" There was no
+answer, but he could hear the young man sobbing at the window.  "Pray,
+Dorian, pray," he murmured.  "What is it that one was taught to say in
+one's boyhood?  'Lead us not into temptation.  Forgive us our sins.
+Wash away our iniquities.'  Let us say that together.  The prayer of
+your pride has been answered.  The prayer of your repentance will be
+answered also.  I worshipped you too much.  I am punished for it.  You
+worshipped yourself too much.  We are both punished."
+
+Dorian Gray turned slowly around and looked at him with tear-dimmed
+eyes.  "It is too late, Basil," he faltered.
+
+"It is never too late, Dorian.  Let us kneel down and try if we cannot
+remember a prayer.  Isn't there a verse somewhere, 'Though your sins be
+as scarlet, yet I will make them as white as snow'?"
+
+"Those words mean nothing to me now."
+
+"Hush!  Don't say that.  You have done enough evil in your life.  My
+God!  Don't you see that accursed thing leering at us?"
+
+Dorian Gray glanced at the picture, and suddenly an uncontrollable
+feeling of hatred for Basil Hallward came over him, as though it had
+been suggested to him by the image on the canvas, whispered into his
+ear by those grinning lips.  The mad passions of a hunted animal
+stirred within him, and he loathed the man who was seated at the table,
+more than in his whole life he had ever loathed anything.  He glanced
+wildly around.  Something glimmered on the top of the painted chest
+that faced him.  His eye fell on it.  He knew what it was.  It was a
+knife that he had brought up, some days before, to cut a piece of cord,
+and had forgotten to take away with him.  He moved slowly towards it,
+passing Hallward as he did so.  As soon as he got behind him, he seized
+it and turned round.  Hallward stirred in his chair as if he was going
+to rise.  He rushed at him and dug the knife into the great vein that
+is behind the ear, crushing the man's head down on the table and
+stabbing again and again.
+
+There was a stifled groan and the horrible sound of some one choking
+with blood.  Three times the outstretched arms shot up convulsively,
+waving grotesque, stiff-fingered hands in the air.  He stabbed him
+twice more, but the man did not move.  Something began to trickle on
+the floor.  He waited for a moment, still pressing the head down.  Then
+he threw the knife on the table, and listened.
+
+He could hear nothing, but the drip, drip on the threadbare carpet.  He
+opened the door and went out on the landing.  The house was absolutely
+quiet.  No one was about.  For a few seconds he stood bending over the
+balustrade and peering down into the black seething well of darkness.
+Then he took out the key and returned to the room, locking himself in
+as he did so.
+
+The thing was still seated in the chair, straining over the table with
+bowed head, and humped back, and long fantastic arms.  Had it not been
+for the red jagged tear in the neck and the clotted black pool that was
+slowly widening on the table, one would have said that the man was
+simply asleep.
+
+How quickly it had all been done!  He felt strangely calm, and walking
+over to the window, opened it and stepped out on the balcony.  The wind
+had blown the fog away, and the sky was like a monstrous peacock's
+tail, starred with myriads of golden eyes.  He looked down and saw the
+policeman going his rounds and flashing the long beam of his lantern on
+the doors of the silent houses.  The crimson spot of a prowling hansom
+gleamed at the corner and then vanished.  A woman in a fluttering shawl
+was creeping slowly by the railings, staggering as she went.  Now and
+then she stopped and peered back.  Once, she began to sing in a hoarse
+voice.  The policeman strolled over and said something to her.  She
+stumbled away, laughing.  A bitter blast swept across the square.  The
+gas-lamps flickered and became blue, and the leafless trees shook their
+black iron branches to and fro.  He shivered and went back, closing the
+window behind him.
+
+Having reached the door, he turned the key and opened it.  He did not
+even glance at the murdered man.  He felt that the secret of the whole
+thing was not to realize the situation.  The friend who had painted the
+fatal portrait to which all his misery had been due had gone out of his
+life.  That was enough.
+
+Then he remembered the lamp.  It was a rather curious one of Moorish
+workmanship, made of dull silver inlaid with arabesques of burnished
+steel, and studded with coarse turquoises.  Perhaps it might be missed
+by his servant, and questions would be asked.  He hesitated for a
+moment, then he turned back and took it from the table.  He could not
+help seeing the dead thing.  How still it was!  How horribly white the
+long hands looked!  It was like a dreadful wax image.
+
+Having locked the door behind him, he crept quietly downstairs.  The
+woodwork creaked and seemed to cry out as if in pain.  He stopped
+several times and waited.  No:  everything was still.  It was merely
+the sound of his own footsteps.
+
+When he reached the library, he saw the bag and coat in the corner.
+They must be hidden away somewhere.  He unlocked a secret press that
+was in the wainscoting, a press in which he kept his own curious
+disguises, and put them into it.  He could easily burn them afterwards.
+Then he pulled out his watch.  It was twenty minutes to two.
+
+He sat down and began to think.  Every year--every month, almost--men
+were strangled in England for what he had done.  There had been a
+madness of murder in the air.  Some red star had come too close to the
+earth.... And yet, what evidence was there against him?  Basil Hallward
+had left the house at eleven.  No one had seen him come in again.  Most
+of the servants were at Selby Royal.  His valet had gone to bed....
+Paris!  Yes.  It was to Paris that Basil had gone, and by the midnight
+train, as he had intended.  With his curious reserved habits, it would
+be months before any suspicions would be roused.  Months!  Everything
+could be destroyed long before then.
+
+A sudden thought struck him.  He put on his fur coat and hat and went
+out into the hall.  There he paused, hearing the slow heavy tread of
+the policeman on the pavement outside and seeing the flash of the
+bull's-eye reflected in the window.  He waited and held his breath.
+
+After a few moments he drew back the latch and slipped out, shutting
+the door very gently behind him.  Then he began ringing the bell.  In
+about five minutes his valet appeared, half-dressed and looking very
+drowsy.
+
+"I am sorry to have had to wake you up, Francis," he said, stepping in;
+"but I had forgotten my latch-key. What time is it?"
+
+"Ten minutes past two, sir," answered the man, looking at the clock and
+blinking.
+
+"Ten minutes past two?  How horribly late!  You must wake me at nine
+to-morrow. I have some work to do."
+
+"All right, sir."
+
+"Did any one call this evening?"
+
+"Mr. Hallward, sir.  He stayed here till eleven, and then he went away
+to catch his train."
+
+"Oh!  I am sorry I didn't see him.  Did he leave any message?"
+
+"No, sir, except that he would write to you from Paris, if he did not
+find you at the club."
+
+"That will do, Francis.  Don't forget to call me at nine to-morrow."
+
+"No, sir."
+
+The man shambled down the passage in his slippers.
+
+Dorian Gray threw his hat and coat upon the table and passed into the
+library.  For a quarter of an hour he walked up and down the room,
+biting his lip and thinking.  Then he took down the Blue Book from one
+of the shelves and began to turn over the leaves.  "Alan Campbell, 152,
+Hertford Street, Mayfair."  Yes; that was the man he wanted.
+
+
+
+CHAPTER 14
+
+At nine o'clock the next morning his servant came in with a cup of
+chocolate on a tray and opened the shutters.  Dorian was sleeping quite
+peacefully, lying on his right side, with one hand underneath his
+cheek.  He looked like a boy who had been tired out with play, or study.
+
+The man had to touch him twice on the shoulder before he woke, and as
+he opened his eyes a faint smile passed across his lips, as though he
+had been lost in some delightful dream.  Yet he had not dreamed at all.
+His night had been untroubled by any images of pleasure or of pain.
+But youth smiles without any reason.  It is one of its chiefest charms.
+
+He turned round, and leaning upon his elbow, began to sip his
+chocolate.  The mellow November sun came streaming into the room.  The
+sky was bright, and there was a genial warmth in the air.  It was
+almost like a morning in May.
+
+Gradually the events of the preceding night crept with silent,
+blood-stained feet into his brain and reconstructed themselves there
+with terrible distinctness.  He winced at the memory of all that he had
+suffered, and for a moment the same curious feeling of loathing for
+Basil Hallward that had made him kill him as he sat in the chair came
+back to him, and he grew cold with passion.  The dead man was still
+sitting there, too, and in the sunlight now.  How horrible that was!
+Such hideous things were for the darkness, not for the day.
+
+He felt that if he brooded on what he had gone through he would sicken
+or grow mad.  There were sins whose fascination was more in the memory
+than in the doing of them, strange triumphs that gratified the pride
+more than the passions, and gave to the intellect a quickened sense of
+joy, greater than any joy they brought, or could ever bring, to the
+senses.  But this was not one of them.  It was a thing to be driven out
+of the mind, to be drugged with poppies, to be strangled lest it might
+strangle one itself.
+
+When the half-hour struck, he passed his hand across his forehead, and
+then got up hastily and dressed himself with even more than his usual
+care, giving a good deal of attention to the choice of his necktie and
+scarf-pin and changing his rings more than once.  He spent a long time
+also over breakfast, tasting the various dishes, talking to his valet
+about some new liveries that he was thinking of getting made for the
+servants at Selby, and going through his correspondence.  At some of
+the letters, he smiled.  Three of them bored him.  One he read several
+times over and then tore up with a slight look of annoyance in his
+face.  "That awful thing, a woman's memory!" as Lord Henry had once
+said.
+
+After he had drunk his cup of black coffee, he wiped his lips slowly
+with a napkin, motioned to his servant to wait, and going over to the
+table, sat down and wrote two letters.  One he put in his pocket, the
+other he handed to the valet.
+
+"Take this round to 152, Hertford Street, Francis, and if Mr. Campbell
+is out of town, get his address."
+
+As soon as he was alone, he lit a cigarette and began sketching upon a
+piece of paper, drawing first flowers and bits of architecture, and
+then human faces.  Suddenly he remarked that every face that he drew
+seemed to have a fantastic likeness to Basil Hallward.  He frowned, and
+getting up, went over to the book-case and took out a volume at hazard.
+He was determined that he would not think about what had happened until
+it became absolutely necessary that he should do so.
+
+When he had stretched himself on the sofa, he looked at the title-page
+of the book.  It was Gautier's Emaux et Camees, Charpentier's
+Japanese-paper edition, with the Jacquemart etching.  The binding was
+of citron-green leather, with a design of gilt trellis-work and dotted
+pomegranates.  It had been given to him by Adrian Singleton.  As he
+turned over the pages, his eye fell on the poem about the hand of
+Lacenaire, the cold yellow hand "_du supplice encore mal lavee_," with
+its downy red hairs and its "_doigts de faune_."  He glanced at his own
+white taper fingers, shuddering slightly in spite of himself, and
+passed on, till he came to those lovely stanzas upon Venice:
+
+     Sur une gamme chromatique,
+       Le sein de peries ruisselant,
+     La Venus de l'Adriatique
+       Sort de l'eau son corps rose et blanc.
+
+     Les domes, sur l'azur des ondes
+       Suivant la phrase au pur contour,
+     S'enflent comme des gorges rondes
+       Que souleve un soupir d'amour.
+
+     L'esquif aborde et me depose,
+       Jetant son amarre au pilier,
+     Devant une facade rose,
+       Sur le marbre d'un escalier.
+
+
+How exquisite they were!  As one read them, one seemed to be floating
+down the green water-ways of the pink and pearl city, seated in a black
+gondola with silver prow and trailing curtains.  The mere lines looked
+to him like those straight lines of turquoise-blue that follow one as
+one pushes out to the Lido.  The sudden flashes of colour reminded him
+of the gleam of the opal-and-iris-throated birds that flutter round the
+tall honeycombed Campanile, or stalk, with such stately grace, through
+the dim, dust-stained arcades.  Leaning back with half-closed eyes, he
+kept saying over and over to himself:
+
+     "Devant une facade rose,
+        Sur le marbre d'un escalier."
+
+The whole of Venice was in those two lines.  He remembered the autumn
+that he had passed there, and a wonderful love that had stirred him to
+mad delightful follies.  There was romance in every place.  But Venice,
+like Oxford, had kept the background for romance, and, to the true
+romantic, background was everything, or almost everything.  Basil had
+been with him part of the time, and had gone wild over Tintoret.  Poor
+Basil!  What a horrible way for a man to die!
+
+He sighed, and took up the volume again, and tried to forget.  He read
+of the swallows that fly in and out of the little _cafe_ at Smyrna where
+the Hadjis sit counting their amber beads and the turbaned merchants
+smoke their long tasselled pipes and talk gravely to each other; he
+read of the Obelisk in the Place de la Concorde that weeps tears of
+granite in its lonely sunless exile and longs to be back by the hot,
+lotus-covered Nile, where there are Sphinxes, and rose-red ibises, and
+white vultures with gilded claws, and crocodiles with small beryl eyes
+that crawl over the green steaming mud; he began to brood over those
+verses which, drawing music from kiss-stained marble, tell of that
+curious statue that Gautier compares to a contralto voice, the "_monstre
+charmant_" that couches in the porphyry-room of the Louvre.  But after a
+time the book fell from his hand.  He grew nervous, and a horrible fit
+of terror came over him.  What if Alan Campbell should be out of
+England?  Days would elapse before he could come back.  Perhaps he
+might refuse to come.  What could he do then?  Every moment was of
+vital importance.
+
+They had been great friends once, five years before--almost
+inseparable, indeed.  Then the intimacy had come suddenly to an end.
+When they met in society now, it was only Dorian Gray who smiled:  Alan
+Campbell never did.
+
+He was an extremely clever young man, though he had no real
+appreciation of the visible arts, and whatever little sense of the
+beauty of poetry he possessed he had gained entirely from Dorian.  His
+dominant intellectual passion was for science.  At Cambridge he had
+spent a great deal of his time working in the laboratory, and had taken
+a good class in the Natural Science Tripos of his year.  Indeed, he was
+still devoted to the study of chemistry, and had a laboratory of his
+own in which he used to shut himself up all day long, greatly to the
+annoyance of his mother, who had set her heart on his standing for
+Parliament and had a vague idea that a chemist was a person who made up
+prescriptions.  He was an excellent musician, however, as well, and
+played both the violin and the piano better than most amateurs.  In
+fact, it was music that had first brought him and Dorian Gray
+together--music and that indefinable attraction that Dorian seemed to
+be able to exercise whenever he wished--and, indeed, exercised often
+without being conscious of it.  They had met at Lady Berkshire's the
+night that Rubinstein played there, and after that used to be always
+seen together at the opera and wherever good music was going on.  For
+eighteen months their intimacy lasted.  Campbell was always either at
+Selby Royal or in Grosvenor Square.  To him, as to many others, Dorian
+Gray was the type of everything that is wonderful and fascinating in
+life.  Whether or not a quarrel had taken place between them no one
+ever knew.  But suddenly people remarked that they scarcely spoke when
+they met and that Campbell seemed always to go away early from any
+party at which Dorian Gray was present.  He had changed, too--was
+strangely melancholy at times, appeared almost to dislike hearing
+music, and would never himself play, giving as his excuse, when he was
+called upon, that he was so absorbed in science that he had no time
+left in which to practise.  And this was certainly true.  Every day he
+seemed to become more interested in biology, and his name appeared once
+or twice in some of the scientific reviews in connection with certain
+curious experiments.
+
+This was the man Dorian Gray was waiting for.  Every second he kept
+glancing at the clock.  As the minutes went by he became horribly
+agitated.  At last he got up and began to pace up and down the room,
+looking like a beautiful caged thing.  He took long stealthy strides.
+His hands were curiously cold.
+
+The suspense became unbearable.  Time seemed to him to be crawling with
+feet of lead, while he by monstrous winds was being swept towards the
+jagged edge of some black cleft of precipice.  He knew what was waiting
+for him there; saw it, indeed, and, shuddering, crushed with dank hands
+his burning lids as though he would have robbed the very brain of sight
+and driven the eyeballs back into their cave.  It was useless.  The
+brain had its own food on which it battened, and the imagination, made
+grotesque by terror, twisted and distorted as a living thing by pain,
+danced like some foul puppet on a stand and grinned through moving
+masks.  Then, suddenly, time stopped for him.  Yes:  that blind,
+slow-breathing thing crawled no more, and horrible thoughts, time being
+dead, raced nimbly on in front, and dragged a hideous future from its
+grave, and showed it to him.  He stared at it.  Its very horror made
+him stone.
+
+At last the door opened and his servant entered.  He turned glazed eyes
+upon him.
+
+"Mr. Campbell, sir," said the man.
+
+A sigh of relief broke from his parched lips, and the colour came back
+to his cheeks.
+
+"Ask him to come in at once, Francis."  He felt that he was himself
+again.  His mood of cowardice had passed away.
+
+The man bowed and retired.  In a few moments, Alan Campbell walked in,
+looking very stern and rather pale, his pallor being intensified by his
+coal-black hair and dark eyebrows.
+
+"Alan!  This is kind of you.  I thank you for coming."
+
+"I had intended never to enter your house again, Gray.  But you said it
+was a matter of life and death."  His voice was hard and cold.  He
+spoke with slow deliberation.  There was a look of contempt in the
+steady searching gaze that he turned on Dorian.  He kept his hands in
+the pockets of his Astrakhan coat, and seemed not to have noticed the
+gesture with which he had been greeted.
+
+"Yes:  it is a matter of life and death, Alan, and to more than one
+person.  Sit down."
+
+Campbell took a chair by the table, and Dorian sat opposite to him.
+The two men's eyes met.  In Dorian's there was infinite pity.  He knew
+that what he was going to do was dreadful.
+
+After a strained moment of silence, he leaned across and said, very
+quietly, but watching the effect of each word upon the face of him he
+had sent for, "Alan, in a locked room at the top of this house, a room
+to which nobody but myself has access, a dead man is seated at a table.
+He has been dead ten hours now.  Don't stir, and don't look at me like
+that.  Who the man is, why he died, how he died, are matters that do
+not concern you.  What you have to do is this--"
+
+"Stop, Gray.  I don't want to know anything further.  Whether what you
+have told me is true or not true doesn't concern me.  I entirely
+decline to be mixed up in your life.  Keep your horrible secrets to
+yourself.  They don't interest me any more."
+
+"Alan, they will have to interest you.  This one will have to interest
+you.  I am awfully sorry for you, Alan.  But I can't help myself.  You
+are the one man who is able to save me.  I am forced to bring you into
+the matter.  I have no option.  Alan, you are scientific.  You know
+about chemistry and things of that kind.  You have made experiments.
+What you have got to do is to destroy the thing that is upstairs--to
+destroy it so that not a vestige of it will be left.  Nobody saw this
+person come into the house.  Indeed, at the present moment he is
+supposed to be in Paris.  He will not be missed for months.  When he is
+missed, there must be no trace of him found here.  You, Alan, you must
+change him, and everything that belongs to him, into a handful of ashes
+that I may scatter in the air."
+
+"You are mad, Dorian."
+
+"Ah!  I was waiting for you to call me Dorian."
+
+"You are mad, I tell you--mad to imagine that I would raise a finger to
+help you, mad to make this monstrous confession.  I will have nothing
+to do with this matter, whatever it is.  Do you think I am going to
+peril my reputation for you?  What is it to me what devil's work you
+are up to?"
+
+"It was suicide, Alan."
+
+"I am glad of that.  But who drove him to it?  You, I should fancy."
+
+"Do you still refuse to do this for me?"
+
+"Of course I refuse.  I will have absolutely nothing to do with it.  I
+don't care what shame comes on you.  You deserve it all.  I should not
+be sorry to see you disgraced, publicly disgraced.  How dare you ask
+me, of all men in the world, to mix myself up in this horror?  I should
+have thought you knew more about people's characters.  Your friend Lord
+Henry Wotton can't have taught you much about psychology, whatever else
+he has taught you.  Nothing will induce me to stir a step to help you.
+You have come to the wrong man.  Go to some of your friends.  Don't
+come to me."
+
+"Alan, it was murder.  I killed him.  You don't know what he had made
+me suffer.  Whatever my life is, he had more to do with the making or
+the marring of it than poor Harry has had.  He may not have intended
+it, the result was the same."
+
+"Murder!  Good God, Dorian, is that what you have come to?  I shall not
+inform upon you.  It is not my business.  Besides, without my stirring
+in the matter, you are certain to be arrested.  Nobody ever commits a
+crime without doing something stupid.  But I will have nothing to do
+with it."
+
+"You must have something to do with it.  Wait, wait a moment; listen to
+me.  Only listen, Alan.  All I ask of you is to perform a certain
+scientific experiment.  You go to hospitals and dead-houses, and the
+horrors that you do there don't affect you.  If in some hideous
+dissecting-room or fetid laboratory you found this man lying on a
+leaden table with red gutters scooped out in it for the blood to flow
+through, you would simply look upon him as an admirable subject.  You
+would not turn a hair.  You would not believe that you were doing
+anything wrong.  On the contrary, you would probably feel that you were
+benefiting the human race, or increasing the sum of knowledge in the
+world, or gratifying intellectual curiosity, or something of that kind.
+What I want you to do is merely what you have often done before.
+Indeed, to destroy a body must be far less horrible than what you are
+accustomed to work at.  And, remember, it is the only piece of evidence
+against me.  If it is discovered, I am lost; and it is sure to be
+discovered unless you help me."
+
+"I have no desire to help you.  You forget that.  I am simply
+indifferent to the whole thing.  It has nothing to do with me."
+
+"Alan, I entreat you.  Think of the position I am in.  Just before you
+came I almost fainted with terror.  You may know terror yourself some
+day.  No! don't think of that.  Look at the matter purely from the
+scientific point of view.  You don't inquire where the dead things on
+which you experiment come from.  Don't inquire now.  I have told you
+too much as it is.  But I beg of you to do this.  We were friends once,
+Alan."
+
+"Don't speak about those days, Dorian--they are dead."
+
+"The dead linger sometimes.  The man upstairs will not go away.  He is
+sitting at the table with bowed head and outstretched arms.  Alan!
+Alan!  If you don't come to my assistance, I am ruined.  Why, they will
+hang me, Alan!  Don't you understand?  They will hang me for what I
+have done."
+
+"There is no good in prolonging this scene.  I absolutely refuse to do
+anything in the matter.  It is insane of you to ask me."
+
+"You refuse?"
+
+"Yes."
+
+"I entreat you, Alan."
+
+"It is useless."
+
+The same look of pity came into Dorian Gray's eyes.  Then he stretched
+out his hand, took a piece of paper, and wrote something on it.  He
+read it over twice, folded it carefully, and pushed it across the
+table.  Having done this, he got up and went over to the window.
+
+Campbell looked at him in surprise, and then took up the paper, and
+opened it.  As he read it, his face became ghastly pale and he fell
+back in his chair.  A horrible sense of sickness came over him.  He
+felt as if his heart was beating itself to death in some empty hollow.
+
+After two or three minutes of terrible silence, Dorian turned round and
+came and stood behind him, putting his hand upon his shoulder.
+
+"I am so sorry for you, Alan," he murmured, "but you leave me no
+alternative.  I have a letter written already.  Here it is.  You see
+the address.  If you don't help me, I must send it.  If you don't help
+me, I will send it.  You know what the result will be.  But you are
+going to help me.  It is impossible for you to refuse now.  I tried to
+spare you.  You will do me the justice to admit that.  You were stern,
+harsh, offensive.  You treated me as no man has ever dared to treat
+me--no living man, at any rate.  I bore it all.  Now it is for me to
+dictate terms."
+
+Campbell buried his face in his hands, and a shudder passed through him.
+
+"Yes, it is my turn to dictate terms, Alan.  You know what they are.
+The thing is quite simple.  Come, don't work yourself into this fever.
+The thing has to be done.  Face it, and do it."
+
+A groan broke from Campbell's lips and he shivered all over.  The
+ticking of the clock on the mantelpiece seemed to him to be dividing
+time into separate atoms of agony, each of which was too terrible to be
+borne.  He felt as if an iron ring was being slowly tightened round his
+forehead, as if the disgrace with which he was threatened had already
+come upon him.  The hand upon his shoulder weighed like a hand of lead.
+It was intolerable.  It seemed to crush him.
+
+"Come, Alan, you must decide at once."
+
+"I cannot do it," he said, mechanically, as though words could alter
+things.
+
+"You must.  You have no choice.  Don't delay."
+
+He hesitated a moment.  "Is there a fire in the room upstairs?"
+
+"Yes, there is a gas-fire with asbestos."
+
+"I shall have to go home and get some things from the laboratory."
+
+"No, Alan, you must not leave the house.  Write out on a sheet of
+notepaper what you want and my servant will take a cab and bring the
+things back to you."
+
+Campbell scrawled a few lines, blotted them, and addressed an envelope
+to his assistant.  Dorian took the note up and read it carefully.  Then
+he rang the bell and gave it to his valet, with orders to return as
+soon as possible and to bring the things with him.
+
+As the hall door shut, Campbell started nervously, and having got up
+from the chair, went over to the chimney-piece. He was shivering with a
+kind of ague.  For nearly twenty minutes, neither of the men spoke.  A
+fly buzzed noisily about the room, and the ticking of the clock was
+like the beat of a hammer.
+
+As the chime struck one, Campbell turned round, and looking at Dorian
+Gray, saw that his eyes were filled with tears.  There was something in
+the purity and refinement of that sad face that seemed to enrage him.
+"You are infamous, absolutely infamous!" he muttered.
+
+"Hush, Alan.  You have saved my life," said Dorian.
+
+"Your life?  Good heavens! what a life that is!  You have gone from
+corruption to corruption, and now you have culminated in crime.  In
+doing what I am going to do--what you force me to do--it is not of your
+life that I am thinking."
+
+"Ah, Alan," murmured Dorian with a sigh, "I wish you had a thousandth
+part of the pity for me that I have for you." He turned away as he
+spoke and stood looking out at the garden.  Campbell made no answer.
+
+After about ten minutes a knock came to the door, and the servant
+entered, carrying a large mahogany chest of chemicals, with a long coil
+of steel and platinum wire and two rather curiously shaped iron clamps.
+
+"Shall I leave the things here, sir?" he asked Campbell.
+
+"Yes," said Dorian.  "And I am afraid, Francis, that I have another
+errand for you.  What is the name of the man at Richmond who supplies
+Selby with orchids?"
+
+"Harden, sir."
+
+"Yes--Harden.  You must go down to Richmond at once, see Harden
+personally, and tell him to send twice as many orchids as I ordered,
+and to have as few white ones as possible.  In fact, I don't want any
+white ones.  It is a lovely day, Francis, and Richmond is a very pretty
+place--otherwise I wouldn't bother you about it."
+
+"No trouble, sir.  At what time shall I be back?"
+
+Dorian looked at Campbell.  "How long will your experiment take, Alan?"
+he said in a calm indifferent voice.  The presence of a third person in
+the room seemed to give him extraordinary courage.
+
+Campbell frowned and bit his lip.  "It will take about five hours," he
+answered.
+
+"It will be time enough, then, if you are back at half-past seven,
+Francis.  Or stay:  just leave my things out for dressing.  You can
+have the evening to yourself.  I am not dining at home, so I shall not
+want you."
+
+"Thank you, sir," said the man, leaving the room.
+
+"Now, Alan, there is not a moment to be lost.  How heavy this chest is!
+I'll take it for you.  You bring the other things."  He spoke rapidly
+and in an authoritative manner.  Campbell felt dominated by him.  They
+left the room together.
+
+When they reached the top landing, Dorian took out the key and turned
+it in the lock.  Then he stopped, and a troubled look came into his
+eyes.  He shuddered.  "I don't think I can go in, Alan," he murmured.
+
+"It is nothing to me.  I don't require you," said Campbell coldly.
+
+Dorian half opened the door.  As he did so, he saw the face of his
+portrait leering in the sunlight.  On the floor in front of it the torn
+curtain was lying.  He remembered that the night before he had
+forgotten, for the first time in his life, to hide the fatal canvas,
+and was about to rush forward, when he drew back with a shudder.
+
+What was that loathsome red dew that gleamed, wet and glistening, on
+one of the hands, as though the canvas had sweated blood?  How horrible
+it was!--more horrible, it seemed to him for the moment, than the
+silent thing that he knew was stretched across the table, the thing
+whose grotesque misshapen shadow on the spotted carpet showed him that
+it had not stirred, but was still there, as he had left it.
+
+He heaved a deep breath, opened the door a little wider, and with
+half-closed eyes and averted head, walked quickly in, determined that
+he would not look even once upon the dead man.  Then, stooping down and
+taking up the gold-and-purple hanging, he flung it right over the
+picture.
+
+There he stopped, feeling afraid to turn round, and his eyes fixed
+themselves on the intricacies of the pattern before him.  He heard
+Campbell bringing in the heavy chest, and the irons, and the other
+things that he had required for his dreadful work.  He began to wonder
+if he and Basil Hallward had ever met, and, if so, what they had
+thought of each other.
+
+"Leave me now," said a stern voice behind him.
+
+He turned and hurried out, just conscious that the dead man had been
+thrust back into the chair and that Campbell was gazing into a
+glistening yellow face.  As he was going downstairs, he heard the key
+being turned in the lock.
+
+It was long after seven when Campbell came back into the library.  He
+was pale, but absolutely calm.  "I have done what you asked me to do,"
+he muttered. "And now, good-bye. Let us never see each other again."
+
+"You have saved me from ruin, Alan.  I cannot forget that," said Dorian
+simply.
+
+As soon as Campbell had left, he went upstairs.  There was a horrible
+smell of nitric acid in the room.  But the thing that had been sitting
+at the table was gone.
+
+
+
+CHAPTER 15
+
+That evening, at eight-thirty, exquisitely dressed and wearing a large
+button-hole of Parma violets, Dorian Gray was ushered into Lady
+Narborough's drawing-room by bowing servants.  His forehead was
+throbbing with maddened nerves, and he felt wildly excited, but his
+manner as he bent over his hostess's hand was as easy and graceful as
+ever.  Perhaps one never seems so much at one's ease as when one has to
+play a part.  Certainly no one looking at Dorian Gray that night could
+have believed that he had passed through a tragedy as horrible as any
+tragedy of our age.  Those finely shaped fingers could never have
+clutched a knife for sin, nor those smiling lips have cried out on God
+and goodness.  He himself could not help wondering at the calm of his
+demeanour, and for a moment felt keenly the terrible pleasure of a
+double life.
+
+It was a small party, got up rather in a hurry by Lady Narborough, who
+was a very clever woman with what Lord Henry used to describe as the
+remains of really remarkable ugliness.  She had proved an excellent
+wife to one of our most tedious ambassadors, and having buried her
+husband properly in a marble mausoleum, which she had herself designed,
+and married off her daughters to some rich, rather elderly men, she
+devoted herself now to the pleasures of French fiction, French cookery,
+and French _esprit_ when she could get it.
+
+Dorian was one of her especial favourites, and she always told him that
+she was extremely glad she had not met him in early life.  "I know, my
+dear, I should have fallen madly in love with you," she used to say,
+"and thrown my bonnet right over the mills for your sake.  It is most
+fortunate that you were not thought of at the time.  As it was, our
+bonnets were so unbecoming, and the mills were so occupied in trying to
+raise the wind, that I never had even a flirtation with anybody.
+However, that was all Narborough's fault.  He was dreadfully
+short-sighted, and there is no pleasure in taking in a husband who
+never sees anything."
+
+Her guests this evening were rather tedious.  The fact was, as she
+explained to Dorian, behind a very shabby fan, one of her married
+daughters had come up quite suddenly to stay with her, and, to make
+matters worse, had actually brought her husband with her.  "I think it
+is most unkind of her, my dear," she whispered.  "Of course I go and
+stay with them every summer after I come from Homburg, but then an old
+woman like me must have fresh air sometimes, and besides, I really wake
+them up.  You don't know what an existence they lead down there.  It is
+pure unadulterated country life.  They get up early, because they have
+so much to do, and go to bed early, because they have so little to
+think about.  There has not been a scandal in the neighbourhood since
+the time of Queen Elizabeth, and consequently they all fall asleep
+after dinner.  You shan't sit next either of them.  You shall sit by me
+and amuse me."
+
+Dorian murmured a graceful compliment and looked round the room.  Yes:
+it was certainly a tedious party.  Two of the people he had never seen
+before, and the others consisted of Ernest Harrowden, one of those
+middle-aged mediocrities so common in London clubs who have no enemies,
+but are thoroughly disliked by their friends; Lady Ruxton, an
+overdressed woman of forty-seven, with a hooked nose, who was always
+trying to get herself compromised, but was so peculiarly plain that to
+her great disappointment no one would ever believe anything against
+her; Mrs. Erlynne, a pushing nobody, with a delightful lisp and
+Venetian-red hair; Lady Alice Chapman, his hostess's daughter, a dowdy
+dull girl, with one of those characteristic British faces that, once
+seen, are never remembered; and her husband, a red-cheeked,
+white-whiskered creature who, like so many of his class, was under the
+impression that inordinate joviality can atone for an entire lack of
+ideas.
+
+He was rather sorry he had come, till Lady Narborough, looking at the
+great ormolu gilt clock that sprawled in gaudy curves on the
+mauve-draped mantelshelf, exclaimed:  "How horrid of Henry Wotton to be
+so late!  I sent round to him this morning on chance and he promised
+faithfully not to disappoint me."
+
+It was some consolation that Harry was to be there, and when the door
+opened and he heard his slow musical voice lending charm to some
+insincere apology, he ceased to feel bored.
+
+But at dinner he could not eat anything.  Plate after plate went away
+untasted.  Lady Narborough kept scolding him for what she called "an
+insult to poor Adolphe, who invented the _menu_ specially for you," and
+now and then Lord Henry looked across at him, wondering at his silence
+and abstracted manner.  From time to time the butler filled his glass
+with champagne.  He drank eagerly, and his thirst seemed to increase.
+
+"Dorian," said Lord Henry at last, as the _chaud-froid_ was being handed
+round, "what is the matter with you to-night? You are quite out of
+sorts."
+
+"I believe he is in love," cried Lady Narborough, "and that he is
+afraid to tell me for fear I should be jealous.  He is quite right.  I
+certainly should."
+
+"Dear Lady Narborough," murmured Dorian, smiling, "I have not been in
+love for a whole week--not, in fact, since Madame de Ferrol left town."
+
+"How you men can fall in love with that woman!" exclaimed the old lady.
+"I really cannot understand it."
+
+"It is simply because she remembers you when you were a little girl,
+Lady Narborough," said Lord Henry.  "She is the one link between us and
+your short frocks."
+
+"She does not remember my short frocks at all, Lord Henry.  But I
+remember her very well at Vienna thirty years ago, and how _decolletee_
+she was then."
+
+"She is still _decolletee_," he answered, taking an olive in his long
+fingers; "and when she is in a very smart gown she looks like an
+_edition de luxe_ of a bad French novel.  She is really wonderful, and
+full of surprises.  Her capacity for family affection is extraordinary.
+When her third husband died, her hair turned quite gold from grief."
+
+"How can you, Harry!" cried Dorian.
+
+"It is a most romantic explanation," laughed the hostess.  "But her
+third husband, Lord Henry!  You don't mean to say Ferrol is the fourth?"
+
+"Certainly, Lady Narborough."
+
+"I don't believe a word of it."
+
+"Well, ask Mr. Gray.  He is one of her most intimate friends."
+
+"Is it true, Mr. Gray?"
+
+"She assures me so, Lady Narborough," said Dorian.  "I asked her
+whether, like Marguerite de Navarre, she had their hearts embalmed and
+hung at her girdle.  She told me she didn't, because none of them had
+had any hearts at all."
+
+"Four husbands!  Upon my word that is _trop de zele_."
+
+"_Trop d'audace_, I tell her," said Dorian.
+
+"Oh! she is audacious enough for anything, my dear.  And what is Ferrol
+like?  I don't know him."
+
+"The husbands of very beautiful women belong to the criminal classes,"
+said Lord Henry, sipping his wine.
+
+Lady Narborough hit him with her fan.  "Lord Henry, I am not at all
+surprised that the world says that you are extremely wicked."
+
+"But what world says that?" asked Lord Henry, elevating his eyebrows.
+"It can only be the next world.  This world and I are on excellent
+terms."
+
+"Everybody I know says you are very wicked," cried the old lady,
+shaking her head.
+
+Lord Henry looked serious for some moments.  "It is perfectly
+monstrous," he said, at last, "the way people go about nowadays saying
+things against one behind one's back that are absolutely and entirely
+true."
+
+"Isn't he incorrigible?" cried Dorian, leaning forward in his chair.
+
+"I hope so," said his hostess, laughing.  "But really, if you all
+worship Madame de Ferrol in this ridiculous way, I shall have to marry
+again so as to be in the fashion."
+
+"You will never marry again, Lady Narborough," broke in Lord Henry.
+"You were far too happy.  When a woman marries again, it is because she
+detested her first husband.  When a man marries again, it is because he
+adored his first wife.  Women try their luck; men risk theirs."
+
+"Narborough wasn't perfect," cried the old lady.
+
+"If he had been, you would not have loved him, my dear lady," was the
+rejoinder.  "Women love us for our defects.  If we have enough of them,
+they will forgive us everything, even our intellects.  You will never
+ask me to dinner again after saying this, I am afraid, Lady Narborough,
+but it is quite true."
+
+"Of course it is true, Lord Henry.  If we women did not love you for
+your defects, where would you all be?  Not one of you would ever be
+married.  You would be a set of unfortunate bachelors.  Not, however,
+that that would alter you much.  Nowadays all the married men live like
+bachelors, and all the bachelors like married men."
+
+"_Fin de siecle_," murmured Lord Henry.
+
+"_Fin du globe_," answered his hostess.
+
+"I wish it were _fin du globe_," said Dorian with a sigh.  "Life is a
+great disappointment."
+
+"Ah, my dear," cried Lady Narborough, putting on her gloves, "don't
+tell me that you have exhausted life.  When a man says that one knows
+that life has exhausted him.  Lord Henry is very wicked, and I
+sometimes wish that I had been; but you are made to be good--you look
+so good.  I must find you a nice wife.  Lord Henry, don't you think
+that Mr. Gray should get married?"
+
+"I am always telling him so, Lady Narborough," said Lord Henry with a
+bow.
+
+"Well, we must look out for a suitable match for him.  I shall go
+through Debrett carefully to-night and draw out a list of all the
+eligible young ladies."
+
+"With their ages, Lady Narborough?" asked Dorian.
+
+"Of course, with their ages, slightly edited.  But nothing must be done
+in a hurry.  I want it to be what _The Morning Post_ calls a suitable
+alliance, and I want you both to be happy."
+
+"What nonsense people talk about happy marriages!" exclaimed Lord
+Henry.  "A man can be happy with any woman, as long as he does not love
+her."
+
+"Ah! what a cynic you are!" cried the old lady, pushing back her chair
+and nodding to Lady Ruxton.  "You must come and dine with me soon
+again.  You are really an admirable tonic, much better than what Sir
+Andrew prescribes for me.  You must tell me what people you would like
+to meet, though.  I want it to be a delightful gathering."
+
+"I like men who have a future and women who have a past," he answered.
+"Or do you think that would make it a petticoat party?"
+
+"I fear so," she said, laughing, as she stood up.  "A thousand pardons,
+my dear Lady Ruxton," she added, "I didn't see you hadn't finished your
+cigarette."
+
+"Never mind, Lady Narborough.  I smoke a great deal too much.  I am
+going to limit myself, for the future."
+
+"Pray don't, Lady Ruxton," said Lord Henry.  "Moderation is a fatal
+thing.  Enough is as bad as a meal.  More than enough is as good as a
+feast."
+
+Lady Ruxton glanced at him curiously.  "You must come and explain that
+to me some afternoon, Lord Henry.  It sounds a fascinating theory," she
+murmured, as she swept out of the room.
+
+"Now, mind you don't stay too long over your politics and scandal,"
+cried Lady Narborough from the door.  "If you do, we are sure to
+squabble upstairs."
+
+The men laughed, and Mr. Chapman got up solemnly from the foot of the
+table and came up to the top.  Dorian Gray changed his seat and went
+and sat by Lord Henry.  Mr. Chapman began to talk in a loud voice about
+the situation in the House of Commons.  He guffawed at his adversaries.
+The word _doctrinaire_--word full of terror to the British
+mind--reappeared from time to time between his explosions.  An
+alliterative prefix served as an ornament of oratory.  He hoisted the
+Union Jack on the pinnacles of thought.  The inherited stupidity of the
+race--sound English common sense he jovially termed it--was shown to be
+the proper bulwark for society.
+
+A smile curved Lord Henry's lips, and he turned round and looked at
+Dorian.
+
+"Are you better, my dear fellow?" he asked.  "You seemed rather out of
+sorts at dinner."
+
+"I am quite well, Harry.  I am tired.  That is all."
+
+"You were charming last night.  The little duchess is quite devoted to
+you.  She tells me she is going down to Selby."
+
+"She has promised to come on the twentieth."
+
+"Is Monmouth to be there, too?"
+
+"Oh, yes, Harry."
+
+"He bores me dreadfully, almost as much as he bores her.  She is very
+clever, too clever for a woman.  She lacks the indefinable charm of
+weakness.  It is the feet of clay that make the gold of the image
+precious.  Her feet are very pretty, but they are not feet of clay.
+White porcelain feet, if you like.  They have been through the fire,
+and what fire does not destroy, it hardens.  She has had experiences."
+
+"How long has she been married?" asked Dorian.
+
+"An eternity, she tells me.  I believe, according to the peerage, it is
+ten years, but ten years with Monmouth must have been like eternity,
+with time thrown in.  Who else is coming?"
+
+"Oh, the Willoughbys, Lord Rugby and his wife, our hostess, Geoffrey
+Clouston, the usual set.  I have asked Lord Grotrian."
+
+"I like him," said Lord Henry.  "A great many people don't, but I find
+him charming.  He atones for being occasionally somewhat overdressed by
+being always absolutely over-educated. He is a very modern type."
+
+"I don't know if he will be able to come, Harry.  He may have to go to
+Monte Carlo with his father."
+
+"Ah! what a nuisance people's people are!  Try and make him come.  By
+the way, Dorian, you ran off very early last night.  You left before
+eleven.  What did you do afterwards?  Did you go straight home?"
+
+Dorian glanced at him hurriedly and frowned.
+
+"No, Harry," he said at last, "I did not get home till nearly three."
+
+"Did you go to the club?"
+
+"Yes," he answered.  Then he bit his lip.  "No, I don't mean that.  I
+didn't go to the club.  I walked about.  I forget what I did.... How
+inquisitive you are, Harry!  You always want to know what one has been
+doing.  I always want to forget what I have been doing.  I came in at
+half-past two, if you wish to know the exact time.  I had left my
+latch-key at home, and my servant had to let me in.  If you want any
+corroborative evidence on the subject, you can ask him."
+
+Lord Henry shrugged his shoulders.  "My dear fellow, as if I cared!
+Let us go up to the drawing-room. No sherry, thank you, Mr. Chapman.
+Something has happened to you, Dorian.  Tell me what it is.  You are
+not yourself to-night."
+
+"Don't mind me, Harry.  I am irritable, and out of temper.  I shall
+come round and see you to-morrow, or next day.  Make my excuses to Lady
+Narborough.  I shan't go upstairs.  I shall go home.  I must go home."
+
+"All right, Dorian.  I dare say I shall see you to-morrow at tea-time.
+The duchess is coming."
+
+"I will try to be there, Harry," he said, leaving the room.  As he
+drove back to his own house, he was conscious that the sense of terror
+he thought he had strangled had come back to him.  Lord Henry's casual
+questioning had made him lose his nerve for the moment, and he wanted
+his nerve still.  Things that were dangerous had to be destroyed.  He
+winced.  He hated the idea of even touching them.
+
+Yet it had to be done.  He realized that, and when he had locked the
+door of his library, he opened the secret press into which he had
+thrust Basil Hallward's coat and bag.  A huge fire was blazing.  He
+piled another log on it.  The smell of the singeing clothes and burning
+leather was horrible.  It took him three-quarters of an hour to consume
+everything.  At the end he felt faint and sick, and having lit some
+Algerian pastilles in a pierced copper brazier, he bathed his hands and
+forehead with a cool musk-scented vinegar.
+
+Suddenly he started.  His eyes grew strangely bright, and he gnawed
+nervously at his underlip.  Between two of the windows stood a large
+Florentine cabinet, made out of ebony and inlaid with ivory and blue
+lapis.  He watched it as though it were a thing that could fascinate
+and make afraid, as though it held something that he longed for and yet
+almost loathed.  His breath quickened.  A mad craving came over him.
+He lit a cigarette and then threw it away.  His eyelids drooped till
+the long fringed lashes almost touched his cheek.  But he still watched
+the cabinet.  At last he got up from the sofa on which he had been
+lying, went over to it, and having unlocked it, touched some hidden
+spring.  A triangular drawer passed slowly out.  His fingers moved
+instinctively towards it, dipped in, and closed on something.  It was a
+small Chinese box of black and gold-dust lacquer, elaborately wrought,
+the sides patterned with curved waves, and the silken cords hung with
+round crystals and tasselled in plaited metal threads.  He opened it.
+Inside was a green paste, waxy in lustre, the odour curiously heavy and
+persistent.
+
+He hesitated for some moments, with a strangely immobile smile upon his
+face.  Then shivering, though the atmosphere of the room was terribly
+hot, he drew himself up and glanced at the clock.  It was twenty
+minutes to twelve.  He put the box back, shutting the cabinet doors as
+he did so, and went into his bedroom.
+
+As midnight was striking bronze blows upon the dusky air, Dorian Gray,
+dressed commonly, and with a muffler wrapped round his throat, crept
+quietly out of his house.  In Bond Street he found a hansom with a good
+horse.  He hailed it and in a low voice gave the driver an address.
+
+The man shook his head.  "It is too far for me," he muttered.
+
+"Here is a sovereign for you," said Dorian.  "You shall have another if
+you drive fast."
+
+"All right, sir," answered the man, "you will be there in an hour," and
+after his fare had got in he turned his horse round and drove rapidly
+towards the river.
+
+
+
+CHAPTER 16
+
+A cold rain began to fall, and the blurred street-lamps looked ghastly
+in the dripping mist.  The public-houses were just closing, and dim men
+and women were clustering in broken groups round their doors.  From
+some of the bars came the sound of horrible laughter.  In others,
+drunkards brawled and screamed.
+
+Lying back in the hansom, with his hat pulled over his forehead, Dorian
+Gray watched with listless eyes the sordid shame of the great city, and
+now and then he repeated to himself the words that Lord Henry had said
+to him on the first day they had met, "To cure the soul by means of the
+senses, and the senses by means of the soul."  Yes, that was the
+secret.  He had often tried it, and would try it again now.  There were
+opium dens where one could buy oblivion, dens of horror where the
+memory of old sins could be destroyed by the madness of sins that were
+new.
+
+The moon hung low in the sky like a yellow skull.  From time to time a
+huge misshapen cloud stretched a long arm across and hid it.  The
+gas-lamps grew fewer, and the streets more narrow and gloomy.  Once the
+man lost his way and had to drive back half a mile.  A steam rose from
+the horse as it splashed up the puddles.  The sidewindows of the hansom
+were clogged with a grey-flannel mist.
+
+"To cure the soul by means of the senses, and the senses by means of
+the soul!"  How the words rang in his ears!  His soul, certainly, was
+sick to death.  Was it true that the senses could cure it?  Innocent
+blood had been spilled.  What could atone for that?  Ah! for that there
+was no atonement; but though forgiveness was impossible, forgetfulness
+was possible still, and he was determined to forget, to stamp the thing
+out, to crush it as one would crush the adder that had stung one.
+Indeed, what right had Basil to have spoken to him as he had done?  Who
+had made him a judge over others?  He had said things that were
+dreadful, horrible, not to be endured.
+
+On and on plodded the hansom, going slower, it seemed to him, at each
+step.  He thrust up the trap and called to the man to drive faster.
+The hideous hunger for opium began to gnaw at him.  His throat burned
+and his delicate hands twitched nervously together.  He struck at the
+horse madly with his stick.  The driver laughed and whipped up.  He
+laughed in answer, and the man was silent.
+
+The way seemed interminable, and the streets like the black web of some
+sprawling spider.  The monotony became unbearable, and as the mist
+thickened, he felt afraid.
+
+Then they passed by lonely brickfields.  The fog was lighter here, and
+he could see the strange, bottle-shaped kilns with their orange,
+fanlike tongues of fire.  A dog barked as they went by, and far away in
+the darkness some wandering sea-gull screamed.  The horse stumbled in a
+rut, then swerved aside and broke into a gallop.
+
+After some time they left the clay road and rattled again over
+rough-paven streets.  Most of the windows were dark, but now and then
+fantastic shadows were silhouetted against some lamplit blind.  He
+watched them curiously.  They moved like monstrous marionettes and made
+gestures like live things.  He hated them.  A dull rage was in his
+heart.  As they turned a corner, a woman yelled something at them from
+an open door, and two men ran after the hansom for about a hundred
+yards.  The driver beat at them with his whip.
+
+It is said that passion makes one think in a circle.  Certainly with
+hideous iteration the bitten lips of Dorian Gray shaped and reshaped
+those subtle words that dealt with soul and sense, till he had found in
+them the full expression, as it were, of his mood, and justified, by
+intellectual approval, passions that without such justification would
+still have dominated his temper.  From cell to cell of his brain crept
+the one thought; and the wild desire to live, most terrible of all
+man's appetites, quickened into force each trembling nerve and fibre.
+Ugliness that had once been hateful to him because it made things real,
+became dear to him now for that very reason.  Ugliness was the one
+reality.  The coarse brawl, the loathsome den, the crude violence of
+disordered life, the very vileness of thief and outcast, were more
+vivid, in their intense actuality of impression, than all the gracious
+shapes of art, the dreamy shadows of song.  They were what he needed
+for forgetfulness.  In three days he would be free.
+
+Suddenly the man drew up with a jerk at the top of a dark lane.  Over
+the low roofs and jagged chimney-stacks of the houses rose the black
+masts of ships.  Wreaths of white mist clung like ghostly sails to the
+yards.
+
+"Somewhere about here, sir, ain't it?" he asked huskily through the
+trap.
+
+Dorian started and peered round.  "This will do," he answered, and
+having got out hastily and given the driver the extra fare he had
+promised him, he walked quickly in the direction of the quay.  Here and
+there a lantern gleamed at the stern of some huge merchantman.  The
+light shook and splintered in the puddles.  A red glare came from an
+outward-bound steamer that was coaling.  The slimy pavement looked like
+a wet mackintosh.
+
+He hurried on towards the left, glancing back now and then to see if he
+was being followed.  In about seven or eight minutes he reached a small
+shabby house that was wedged in between two gaunt factories.  In one of
+the top-windows stood a lamp.  He stopped and gave a peculiar knock.
+
+After a little time he heard steps in the passage and the chain being
+unhooked.  The door opened quietly, and he went in without saying a
+word to the squat misshapen figure that flattened itself into the
+shadow as he passed.  At the end of the hall hung a tattered green
+curtain that swayed and shook in the gusty wind which had followed him
+in from the street.  He dragged it aside and entered a long low room
+which looked as if it had once been a third-rate dancing-saloon. Shrill
+flaring gas-jets, dulled and distorted in the fly-blown mirrors that
+faced them, were ranged round the walls.  Greasy reflectors of ribbed
+tin backed them, making quivering disks of light.  The floor was
+covered with ochre-coloured sawdust, trampled here and there into mud,
+and stained with dark rings of spilled liquor.  Some Malays were
+crouching by a little charcoal stove, playing with bone counters and
+showing their white teeth as they chattered.  In one corner, with his
+head buried in his arms, a sailor sprawled over a table, and by the
+tawdrily painted bar that ran across one complete side stood two
+haggard women, mocking an old man who was brushing the sleeves of his
+coat with an expression of disgust.  "He thinks he's got red ants on
+him," laughed one of them, as Dorian passed by.  The man looked at her
+in terror and began to whimper.
+
+At the end of the room there was a little staircase, leading to a
+darkened chamber.  As Dorian hurried up its three rickety steps, the
+heavy odour of opium met him.  He heaved a deep breath, and his
+nostrils quivered with pleasure.  When he entered, a young man with
+smooth yellow hair, who was bending over a lamp lighting a long thin
+pipe, looked up at him and nodded in a hesitating manner.
+
+"You here, Adrian?" muttered Dorian.
+
+"Where else should I be?" he answered, listlessly.  "None of the chaps
+will speak to me now."
+
+"I thought you had left England."
+
+"Darlington is not going to do anything.  My brother paid the bill at
+last.  George doesn't speak to me either.... I don't care," he added
+with a sigh.  "As long as one has this stuff, one doesn't want friends.
+I think I have had too many friends."
+
+Dorian winced and looked round at the grotesque things that lay in such
+fantastic postures on the ragged mattresses.  The twisted limbs, the
+gaping mouths, the staring lustreless eyes, fascinated him.  He knew in
+what strange heavens they were suffering, and what dull hells were
+teaching them the secret of some new joy.  They were better off than he
+was.  He was prisoned in thought.  Memory, like a horrible malady, was
+eating his soul away.  From time to time he seemed to see the eyes of
+Basil Hallward looking at him.  Yet he felt he could not stay.  The
+presence of Adrian Singleton troubled him.  He wanted to be where no
+one would know who he was.  He wanted to escape from himself.
+
+"I am going on to the other place," he said after a pause.
+
+"On the wharf?"
+
+"Yes."
+
+"That mad-cat is sure to be there.  They won't have her in this place
+now."
+
+Dorian shrugged his shoulders.  "I am sick of women who love one.
+Women who hate one are much more interesting.  Besides, the stuff is
+better."
+
+"Much the same."
+
+"I like it better.  Come and have something to drink.  I must have
+something."
+
+"I don't want anything," murmured the young man.
+
+"Never mind."
+
+Adrian Singleton rose up wearily and followed Dorian to the bar.  A
+half-caste, in a ragged turban and a shabby ulster, grinned a hideous
+greeting as he thrust a bottle of brandy and two tumblers in front of
+them.  The women sidled up and began to chatter.  Dorian turned his
+back on them and said something in a low voice to Adrian Singleton.
+
+A crooked smile, like a Malay crease, writhed across the face of one of
+the women.  "We are very proud to-night," she sneered.
+
+"For God's sake don't talk to me," cried Dorian, stamping his foot on
+the ground.  "What do you want?  Money?  Here it is.  Don't ever talk
+to me again."
+
+Two red sparks flashed for a moment in the woman's sodden eyes, then
+flickered out and left them dull and glazed.  She tossed her head and
+raked the coins off the counter with greedy fingers.  Her companion
+watched her enviously.
+
+"It's no use," sighed Adrian Singleton.  "I don't care to go back.
+What does it matter?  I am quite happy here."
+
+"You will write to me if you want anything, won't you?" said Dorian,
+after a pause.
+
+"Perhaps."
+
+"Good night, then."
+
+"Good night," answered the young man, passing up the steps and wiping
+his parched mouth with a handkerchief.
+
+Dorian walked to the door with a look of pain in his face.  As he drew
+the curtain aside, a hideous laugh broke from the painted lips of the
+woman who had taken his money.  "There goes the devil's bargain!" she
+hiccoughed, in a hoarse voice.
+
+"Curse you!" he answered, "don't call me that."
+
+She snapped her fingers.  "Prince Charming is what you like to be
+called, ain't it?" she yelled after him.
+
+The drowsy sailor leaped to his feet as she spoke, and looked wildly
+round.  The sound of the shutting of the hall door fell on his ear.  He
+rushed out as if in pursuit.
+
+Dorian Gray hurried along the quay through the drizzling rain.  His
+meeting with Adrian Singleton had strangely moved him, and he wondered
+if the ruin of that young life was really to be laid at his door, as
+Basil Hallward had said to him with such infamy of insult.  He bit his
+lip, and for a few seconds his eyes grew sad.  Yet, after all, what did
+it matter to him?  One's days were too brief to take the burden of
+another's errors on one's shoulders.  Each man lived his own life and
+paid his own price for living it.  The only pity was one had to pay so
+often for a single fault.  One had to pay over and over again, indeed.
+In her dealings with man, destiny never closed her accounts.
+
+There are moments, psychologists tell us, when the passion for sin, or
+for what the world calls sin, so dominates a nature that every fibre of
+the body, as every cell of the brain, seems to be instinct with fearful
+impulses.  Men and women at such moments lose the freedom of their
+will.  They move to their terrible end as automatons move.  Choice is
+taken from them, and conscience is either killed, or, if it lives at
+all, lives but to give rebellion its fascination and disobedience its
+charm.  For all sins, as theologians weary not of reminding us, are
+sins of disobedience.  When that high spirit, that morning star of
+evil, fell from heaven, it was as a rebel that he fell.
+
+Callous, concentrated on evil, with stained mind, and soul hungry for
+rebellion, Dorian Gray hastened on, quickening his step as he went, but
+as he darted aside into a dim archway, that had served him often as a
+short cut to the ill-famed place where he was going, he felt himself
+suddenly seized from behind, and before he had time to defend himself,
+he was thrust back against the wall, with a brutal hand round his
+throat.
+
+He struggled madly for life, and by a terrible effort wrenched the
+tightening fingers away.  In a second he heard the click of a revolver,
+and saw the gleam of a polished barrel, pointing straight at his head,
+and the dusky form of a short, thick-set man facing him.
+
+"What do you want?" he gasped.
+
+"Keep quiet," said the man.  "If you stir, I shoot you."
+
+"You are mad.  What have I done to you?"
+
+"You wrecked the life of Sibyl Vane," was the answer, "and Sibyl Vane
+was my sister.  She killed herself.  I know it.  Her death is at your
+door.  I swore I would kill you in return.  For years I have sought
+you.  I had no clue, no trace.  The two people who could have described
+you were dead.  I knew nothing of you but the pet name she used to call
+you.  I heard it to-night by chance.  Make your peace with God, for
+to-night you are going to die."
+
+Dorian Gray grew sick with fear.  "I never knew her," he stammered.  "I
+never heard of her.  You are mad."
+
+"You had better confess your sin, for as sure as I am James Vane, you
+are going to die."  There was a horrible moment.  Dorian did not know
+what to say or do.  "Down on your knees!" growled the man.  "I give you
+one minute to make your peace--no more.  I go on board to-night for
+India, and I must do my job first.  One minute.  That's all."
+
+Dorian's arms fell to his side.  Paralysed with terror, he did not know
+what to do.  Suddenly a wild hope flashed across his brain.  "Stop," he
+cried.  "How long ago is it since your sister died?  Quick, tell me!"
+
+"Eighteen years," said the man.  "Why do you ask me?  What do years
+matter?"
+
+"Eighteen years," laughed Dorian Gray, with a touch of triumph in his
+voice.  "Eighteen years!  Set me under the lamp and look at my face!"
+
+James Vane hesitated for a moment, not understanding what was meant.
+Then he seized Dorian Gray and dragged him from the archway.
+
+Dim and wavering as was the wind-blown light, yet it served to show him
+the hideous error, as it seemed, into which he had fallen, for the face
+of the man he had sought to kill had all the bloom of boyhood, all the
+unstained purity of youth.  He seemed little more than a lad of twenty
+summers, hardly older, if older indeed at all, than his sister had been
+when they had parted so many years ago.  It was obvious that this was
+not the man who had destroyed her life.
+
+He loosened his hold and reeled back.  "My God! my God!" he cried, "and
+I would have murdered you!"
+
+Dorian Gray drew a long breath.  "You have been on the brink of
+committing a terrible crime, my man," he said, looking at him sternly.
+"Let this be a warning to you not to take vengeance into your own
+hands."
+
+"Forgive me, sir," muttered James Vane.  "I was deceived.  A chance
+word I heard in that damned den set me on the wrong track."
+
+"You had better go home and put that pistol away, or you may get into
+trouble," said Dorian, turning on his heel and going slowly down the
+street.
+
+James Vane stood on the pavement in horror.  He was trembling from head
+to foot.  After a little while, a black shadow that had been creeping
+along the dripping wall moved out into the light and came close to him
+with stealthy footsteps.  He felt a hand laid on his arm and looked
+round with a start.  It was one of the women who had been drinking at
+the bar.
+
+"Why didn't you kill him?" she hissed out, putting haggard face quite
+close to his.  "I knew you were following him when you rushed out from
+Daly's. You fool!  You should have killed him.  He has lots of money,
+and he's as bad as bad."
+
+"He is not the man I am looking for," he answered, "and I want no man's
+money.  I want a man's life.  The man whose life I want must be nearly
+forty now.  This one is little more than a boy.  Thank God, I have not
+got his blood upon my hands."
+
+The woman gave a bitter laugh.  "Little more than a boy!" she sneered.
+"Why, man, it's nigh on eighteen years since Prince Charming made me
+what I am."
+
+"You lie!" cried James Vane.
+
+She raised her hand up to heaven.  "Before God I am telling the truth,"
+she cried.
+
+"Before God?"
+
+"Strike me dumb if it ain't so.  He is the worst one that comes here.
+They say he has sold himself to the devil for a pretty face.  It's nigh
+on eighteen years since I met him.  He hasn't changed much since then.
+I have, though," she added, with a sickly leer.
+
+"You swear this?"
+
+"I swear it," came in hoarse echo from her flat mouth.  "But don't give
+me away to him," she whined; "I am afraid of him.  Let me have some
+money for my night's lodging."
+
+He broke from her with an oath and rushed to the corner of the street,
+but Dorian Gray had disappeared.  When he looked back, the woman had
+vanished also.
+
+
+
+CHAPTER 17
+
+A week later Dorian Gray was sitting in the conservatory at Selby
+Royal, talking to the pretty Duchess of Monmouth, who with her husband,
+a jaded-looking man of sixty, was amongst his guests.  It was tea-time,
+and the mellow light of the huge, lace-covered lamp that stood on the
+table lit up the delicate china and hammered silver of the service at
+which the duchess was presiding.  Her white hands were moving daintily
+among the cups, and her full red lips were smiling at something that
+Dorian had whispered to her.  Lord Henry was lying back in a
+silk-draped wicker chair, looking at them.  On a peach-coloured divan
+sat Lady Narborough, pretending to listen to the duke's description of
+the last Brazilian beetle that he had added to his collection.  Three
+young men in elaborate smoking-suits were handing tea-cakes to some of
+the women.  The house-party consisted of twelve people, and there were
+more expected to arrive on the next day.
+
+"What are you two talking about?" said Lord Henry, strolling over to
+the table and putting his cup down.  "I hope Dorian has told you about
+my plan for rechristening everything, Gladys.  It is a delightful idea."
+
+"But I don't want to be rechristened, Harry," rejoined the duchess,
+looking up at him with her wonderful eyes.  "I am quite satisfied with
+my own name, and I am sure Mr. Gray should be satisfied with his."
+
+"My dear Gladys, I would not alter either name for the world.  They are
+both perfect.  I was thinking chiefly of flowers.  Yesterday I cut an
+orchid, for my button-hole. It was a marvellous spotted thing, as
+effective as the seven deadly sins.  In a thoughtless moment I asked
+one of the gardeners what it was called.  He told me it was a fine
+specimen of _Robinsoniana_, or something dreadful of that kind.  It is a
+sad truth, but we have lost the faculty of giving lovely names to
+things.  Names are everything.  I never quarrel with actions.  My one
+quarrel is with words.  That is the reason I hate vulgar realism in
+literature.  The man who could call a spade a spade should be compelled
+to use one.  It is the only thing he is fit for."
+
+"Then what should we call you, Harry?" she asked.
+
+"His name is Prince Paradox," said Dorian.
+
+"I recognize him in a flash," exclaimed the duchess.
+
+"I won't hear of it," laughed Lord Henry, sinking into a chair.  "From
+a label there is no escape!  I refuse the title."
+
+"Royalties may not abdicate," fell as a warning from pretty lips.
+
+"You wish me to defend my throne, then?"
+
+"Yes."
+
+"I give the truths of to-morrow."
+
+"I prefer the mistakes of to-day," she answered.
+
+"You disarm me, Gladys," he cried, catching the wilfulness of her mood.
+
+"Of your shield, Harry, not of your spear."
+
+"I never tilt against beauty," he said, with a wave of his hand.
+
+"That is your error, Harry, believe me.  You value beauty far too much."
+
+"How can you say that?  I admit that I think that it is better to be
+beautiful than to be good.  But on the other hand, no one is more ready
+than I am to acknowledge that it is better to be good than to be ugly."
+
+"Ugliness is one of the seven deadly sins, then?" cried the duchess.
+"What becomes of your simile about the orchid?"
+
+"Ugliness is one of the seven deadly virtues, Gladys.  You, as a good
+Tory, must not underrate them.  Beer, the Bible, and the seven deadly
+virtues have made our England what she is."
+
+"You don't like your country, then?" she asked.
+
+"I live in it."
+
+"That you may censure it the better."
+
+"Would you have me take the verdict of Europe on it?" he inquired.
+
+"What do they say of us?"
+
+"That Tartuffe has emigrated to England and opened a shop."
+
+"Is that yours, Harry?"
+
+"I give it to you."
+
+"I could not use it.  It is too true."
+
+"You need not be afraid.  Our countrymen never recognize a description."
+
+"They are practical."
+
+"They are more cunning than practical.  When they make up their ledger,
+they balance stupidity by wealth, and vice by hypocrisy."
+
+"Still, we have done great things."
+
+"Great things have been thrust on us, Gladys."
+
+"We have carried their burden."
+
+"Only as far as the Stock Exchange."
+
+She shook her head.  "I believe in the race," she cried.
+
+"It represents the survival of the pushing."
+
+"It has development."
+
+"Decay fascinates me more."
+
+"What of art?" she asked.
+
+"It is a malady."
+
+"Love?"
+
+"An illusion."
+
+"Religion?"
+
+"The fashionable substitute for belief."
+
+"You are a sceptic."
+
+"Never!  Scepticism is the beginning of faith."
+
+"What are you?"
+
+"To define is to limit."
+
+"Give me a clue."
+
+"Threads snap.  You would lose your way in the labyrinth."
+
+"You bewilder me.  Let us talk of some one else."
+
+"Our host is a delightful topic.  Years ago he was christened Prince
+Charming."
+
+"Ah! don't remind me of that," cried Dorian Gray.
+
+"Our host is rather horrid this evening," answered the duchess,
+colouring.  "I believe he thinks that Monmouth married me on purely
+scientific principles as the best specimen he could find of a modern
+butterfly."
+
+"Well, I hope he won't stick pins into you, Duchess," laughed Dorian.
+
+"Oh! my maid does that already, Mr. Gray, when she is annoyed with me."
+
+"And what does she get annoyed with you about, Duchess?"
+
+"For the most trivial things, Mr. Gray, I assure you.  Usually because
+I come in at ten minutes to nine and tell her that I must be dressed by
+half-past eight."
+
+"How unreasonable of her!  You should give her warning."
+
+"I daren't, Mr. Gray.  Why, she invents hats for me.  You remember the
+one I wore at Lady Hilstone's garden-party?  You don't, but it is nice
+of you to pretend that you do.  Well, she made it out of nothing.  All
+good hats are made out of nothing."
+
+"Like all good reputations, Gladys," interrupted Lord Henry.  "Every
+effect that one produces gives one an enemy.  To be popular one must be
+a mediocrity."
+
+"Not with women," said the duchess, shaking her head; "and women rule
+the world.  I assure you we can't bear mediocrities.  We women, as some
+one says, love with our ears, just as you men love with your eyes, if
+you ever love at all."
+
+"It seems to me that we never do anything else," murmured Dorian.
+
+"Ah! then, you never really love, Mr. Gray," answered the duchess with
+mock sadness.
+
+"My dear Gladys!" cried Lord Henry.  "How can you say that?  Romance
+lives by repetition, and repetition converts an appetite into an art.
+Besides, each time that one loves is the only time one has ever loved.
+Difference of object does not alter singleness of passion.  It merely
+intensifies it.  We can have in life but one great experience at best,
+and the secret of life is to reproduce that experience as often as
+possible."
+
+"Even when one has been wounded by it, Harry?" asked the duchess after
+a pause.
+
+"Especially when one has been wounded by it," answered Lord Henry.
+
+The duchess turned and looked at Dorian Gray with a curious expression
+in her eyes.  "What do you say to that, Mr. Gray?" she inquired.
+
+Dorian hesitated for a moment.  Then he threw his head back and
+laughed.  "I always agree with Harry, Duchess."
+
+"Even when he is wrong?"
+
+"Harry is never wrong, Duchess."
+
+"And does his philosophy make you happy?"
+
+"I have never searched for happiness.  Who wants happiness?  I have
+searched for pleasure."
+
+"And found it, Mr. Gray?"
+
+"Often.  Too often."
+
+The duchess sighed.  "I am searching for peace," she said, "and if I
+don't go and dress, I shall have none this evening."
+
+"Let me get you some orchids, Duchess," cried Dorian, starting to his
+feet and walking down the conservatory.
+
+"You are flirting disgracefully with him," said Lord Henry to his
+cousin.  "You had better take care.  He is very fascinating."
+
+"If he were not, there would be no battle."
+
+"Greek meets Greek, then?"
+
+"I am on the side of the Trojans.  They fought for a woman."
+
+"They were defeated."
+
+"There are worse things than capture," she answered.
+
+"You gallop with a loose rein."
+
+"Pace gives life," was the _riposte_.
+
+"I shall write it in my diary to-night."
+
+"What?"
+
+"That a burnt child loves the fire."
+
+"I am not even singed.  My wings are untouched."
+
+"You use them for everything, except flight."
+
+"Courage has passed from men to women.  It is a new experience for us."
+
+"You have a rival."
+
+"Who?"
+
+He laughed.  "Lady Narborough," he whispered.  "She perfectly adores
+him."
+
+"You fill me with apprehension.  The appeal to antiquity is fatal to us
+who are romanticists."
+
+"Romanticists!  You have all the methods of science."
+
+"Men have educated us."
+
+"But not explained you."
+
+"Describe us as a sex," was her challenge.
+
+"Sphinxes without secrets."
+
+She looked at him, smiling.  "How long Mr. Gray is!" she said.  "Let us
+go and help him.  I have not yet told him the colour of my frock."
+
+"Ah! you must suit your frock to his flowers, Gladys."
+
+"That would be a premature surrender."
+
+"Romantic art begins with its climax."
+
+"I must keep an opportunity for retreat."
+
+"In the Parthian manner?"
+
+"They found safety in the desert.  I could not do that."
+
+"Women are not always allowed a choice," he answered, but hardly had he
+finished the sentence before from the far end of the conservatory came
+a stifled groan, followed by the dull sound of a heavy fall.  Everybody
+started up.  The duchess stood motionless in horror.  And with fear in
+his eyes, Lord Henry rushed through the flapping palms to find Dorian
+Gray lying face downwards on the tiled floor in a deathlike swoon.
+
+He was carried at once into the blue drawing-room and laid upon one of
+the sofas.  After a short time, he came to himself and looked round
+with a dazed expression.
+
+"What has happened?" he asked.  "Oh!  I remember.  Am I safe here,
+Harry?" He began to tremble.
+
+"My dear Dorian," answered Lord Henry, "you merely fainted.  That was
+all.  You must have overtired yourself.  You had better not come down
+to dinner.  I will take your place."
+
+"No, I will come down," he said, struggling to his feet.  "I would
+rather come down.  I must not be alone."
+
+He went to his room and dressed.  There was a wild recklessness of
+gaiety in his manner as he sat at table, but now and then a thrill of
+terror ran through him when he remembered that, pressed against the
+window of the conservatory, like a white handkerchief, he had seen the
+face of James Vane watching him.
+
+
+
+CHAPTER 18
+
+The next day he did not leave the house, and, indeed, spent most of the
+time in his own room, sick with a wild terror of dying, and yet
+indifferent to life itself.  The consciousness of being hunted, snared,
+tracked down, had begun to dominate him.  If the tapestry did but
+tremble in the wind, he shook.  The dead leaves that were blown against
+the leaded panes seemed to him like his own wasted resolutions and wild
+regrets.  When he closed his eyes, he saw again the sailor's face
+peering through the mist-stained glass, and horror seemed once more to
+lay its hand upon his heart.
+
+But perhaps it had been only his fancy that had called vengeance out of
+the night and set the hideous shapes of punishment before him.  Actual
+life was chaos, but there was something terribly logical in the
+imagination.  It was the imagination that set remorse to dog the feet
+of sin.  It was the imagination that made each crime bear its misshapen
+brood.  In the common world of fact the wicked were not punished, nor
+the good rewarded.  Success was given to the strong, failure thrust
+upon the weak.  That was all.  Besides, had any stranger been prowling
+round the house, he would have been seen by the servants or the
+keepers.  Had any foot-marks been found on the flower-beds, the
+gardeners would have reported it.  Yes, it had been merely fancy.
+Sibyl Vane's brother had not come back to kill him.  He had sailed away
+in his ship to founder in some winter sea.  From him, at any rate, he
+was safe.  Why, the man did not know who he was, could not know who he
+was.  The mask of youth had saved him.
+
+And yet if it had been merely an illusion, how terrible it was to think
+that conscience could raise such fearful phantoms, and give them
+visible form, and make them move before one!  What sort of life would
+his be if, day and night, shadows of his crime were to peer at him from
+silent corners, to mock him from secret places, to whisper in his ear
+as he sat at the feast, to wake him with icy fingers as he lay asleep!
+As the thought crept through his brain, he grew pale with terror, and
+the air seemed to him to have become suddenly colder.  Oh! in what a
+wild hour of madness he had killed his friend!  How ghastly the mere
+memory of the scene!  He saw it all again.  Each hideous detail came
+back to him with added horror.  Out of the black cave of time, terrible
+and swathed in scarlet, rose the image of his sin.  When Lord Henry
+came in at six o'clock, he found him crying as one whose heart will
+break.
+
+It was not till the third day that he ventured to go out.  There was
+something in the clear, pine-scented air of that winter morning that
+seemed to bring him back his joyousness and his ardour for life.  But
+it was not merely the physical conditions of environment that had
+caused the change.  His own nature had revolted against the excess of
+anguish that had sought to maim and mar the perfection of its calm.
+With subtle and finely wrought temperaments it is always so.  Their
+strong passions must either bruise or bend.  They either slay the man,
+or themselves die.  Shallow sorrows and shallow loves live on.  The
+loves and sorrows that are great are destroyed by their own plenitude.
+Besides, he had convinced himself that he had been the victim of a
+terror-stricken imagination, and looked back now on his fears with
+something of pity and not a little of contempt.
+
+After breakfast, he walked with the duchess for an hour in the garden
+and then drove across the park to join the shooting-party. The crisp
+frost lay like salt upon the grass.  The sky was an inverted cup of
+blue metal.  A thin film of ice bordered the flat, reed-grown lake.
+
+At the corner of the pine-wood he caught sight of Sir Geoffrey
+Clouston, the duchess's brother, jerking two spent cartridges out of
+his gun.  He jumped from the cart, and having told the groom to take
+the mare home, made his way towards his guest through the withered
+bracken and rough undergrowth.
+
+"Have you had good sport, Geoffrey?" he asked.
+
+"Not very good, Dorian.  I think most of the birds have gone to the
+open.  I dare say it will be better after lunch, when we get to new
+ground."
+
+Dorian strolled along by his side.  The keen aromatic air, the brown
+and red lights that glimmered in the wood, the hoarse cries of the
+beaters ringing out from time to time, and the sharp snaps of the guns
+that followed, fascinated him and filled him with a sense of delightful
+freedom.  He was dominated by the carelessness of happiness, by the
+high indifference of joy.
+
+Suddenly from a lumpy tussock of old grass some twenty yards in front
+of them, with black-tipped ears erect and long hinder limbs throwing it
+forward, started a hare.  It bolted for a thicket of alders.  Sir
+Geoffrey put his gun to his shoulder, but there was something in the
+animal's grace of movement that strangely charmed Dorian Gray, and he
+cried out at once, "Don't shoot it, Geoffrey.  Let it live."
+
+"What nonsense, Dorian!" laughed his companion, and as the hare bounded
+into the thicket, he fired.  There were two cries heard, the cry of a
+hare in pain, which is dreadful, the cry of a man in agony, which is
+worse.
+
+"Good heavens!  I have hit a beater!" exclaimed Sir Geoffrey.  "What an
+ass the man was to get in front of the guns!  Stop shooting there!" he
+called out at the top of his voice.  "A man is hurt."
+
+The head-keeper came running up with a stick in his hand.
+
+"Where, sir?  Where is he?" he shouted.  At the same time, the firing
+ceased along the line.
+
+"Here," answered Sir Geoffrey angrily, hurrying towards the thicket.
+"Why on earth don't you keep your men back?  Spoiled my shooting for
+the day."
+
+Dorian watched them as they plunged into the alder-clump, brushing the
+lithe swinging branches aside.  In a few moments they emerged, dragging
+a body after them into the sunlight.  He turned away in horror.  It
+seemed to him that misfortune followed wherever he went.  He heard Sir
+Geoffrey ask if the man was really dead, and the affirmative answer of
+the keeper.  The wood seemed to him to have become suddenly alive with
+faces.  There was the trampling of myriad feet and the low buzz of
+voices.  A great copper-breasted pheasant came beating through the
+boughs overhead.
+
+After a few moments--that were to him, in his perturbed state, like
+endless hours of pain--he felt a hand laid on his shoulder.  He started
+and looked round.
+
+"Dorian," said Lord Henry, "I had better tell them that the shooting is
+stopped for to-day. It would not look well to go on."
+
+"I wish it were stopped for ever, Harry," he answered bitterly.  "The
+whole thing is hideous and cruel.  Is the man ...?"
+
+He could not finish the sentence.
+
+"I am afraid so," rejoined Lord Henry.  "He got the whole charge of
+shot in his chest.  He must have died almost instantaneously.  Come;
+let us go home."
+
+They walked side by side in the direction of the avenue for nearly
+fifty yards without speaking.  Then Dorian looked at Lord Henry and
+said, with a heavy sigh, "It is a bad omen, Harry, a very bad omen."
+
+"What is?" asked Lord Henry.  "Oh! this accident, I suppose.  My dear
+fellow, it can't be helped.  It was the man's own fault.  Why did he
+get in front of the guns?  Besides, it is nothing to us.  It is rather
+awkward for Geoffrey, of course.  It does not do to pepper beaters.  It
+makes people think that one is a wild shot.  And Geoffrey is not; he
+shoots very straight.  But there is no use talking about the matter."
+
+Dorian shook his head.  "It is a bad omen, Harry.  I feel as if
+something horrible were going to happen to some of us.  To myself,
+perhaps," he added, passing his hand over his eyes, with a gesture of
+pain.
+
+The elder man laughed.  "The only horrible thing in the world is _ennui_,
+Dorian.  That is the one sin for which there is no forgiveness.  But we
+are not likely to suffer from it unless these fellows keep chattering
+about this thing at dinner.  I must tell them that the subject is to be
+tabooed.  As for omens, there is no such thing as an omen.  Destiny
+does not send us heralds.  She is too wise or too cruel for that.
+Besides, what on earth could happen to you, Dorian?  You have
+everything in the world that a man can want.  There is no one who would
+not be delighted to change places with you."
+
+"There is no one with whom I would not change places, Harry.  Don't
+laugh like that.  I am telling you the truth.  The wretched peasant who
+has just died is better off than I am.  I have no terror of death.  It
+is the coming of death that terrifies me.  Its monstrous wings seem to
+wheel in the leaden air around me.  Good heavens! don't you see a man
+moving behind the trees there, watching me, waiting for me?"
+
+Lord Henry looked in the direction in which the trembling gloved hand
+was pointing.  "Yes," he said, smiling, "I see the gardener waiting for
+you.  I suppose he wants to ask you what flowers you wish to have on
+the table to-night. How absurdly nervous you are, my dear fellow!  You
+must come and see my doctor, when we get back to town."
+
+Dorian heaved a sigh of relief as he saw the gardener approaching.  The
+man touched his hat, glanced for a moment at Lord Henry in a hesitating
+manner, and then produced a letter, which he handed to his master.
+"Her Grace told me to wait for an answer," he murmured.
+
+Dorian put the letter into his pocket.  "Tell her Grace that I am
+coming in," he said, coldly.  The man turned round and went rapidly in
+the direction of the house.
+
+"How fond women are of doing dangerous things!" laughed Lord Henry.
+"It is one of the qualities in them that I admire most.  A woman will
+flirt with anybody in the world as long as other people are looking on."
+
+"How fond you are of saying dangerous things, Harry!  In the present
+instance, you are quite astray.  I like the duchess very much, but I
+don't love her."
+
+"And the duchess loves you very much, but she likes you less, so you
+are excellently matched."
+
+"You are talking scandal, Harry, and there is never any basis for
+scandal."
+
+"The basis of every scandal is an immoral certainty," said Lord Henry,
+lighting a cigarette.
+
+"You would sacrifice anybody, Harry, for the sake of an epigram."
+
+"The world goes to the altar of its own accord," was the answer.
+
+"I wish I could love," cried Dorian Gray with a deep note of pathos in
+his voice.  "But I seem to have lost the passion and forgotten the
+desire.  I am too much concentrated on myself.  My own personality has
+become a burden to me.  I want to escape, to go away, to forget.  It
+was silly of me to come down here at all.  I think I shall send a wire
+to Harvey to have the yacht got ready.  On a yacht one is safe."
+
+"Safe from what, Dorian?  You are in some trouble.  Why not tell me
+what it is?  You know I would help you."
+
+"I can't tell you, Harry," he answered sadly.  "And I dare say it is
+only a fancy of mine.  This unfortunate accident has upset me.  I have
+a horrible presentiment that something of the kind may happen to me."
+
+"What nonsense!"
+
+"I hope it is, but I can't help feeling it.  Ah! here is the duchess,
+looking like Artemis in a tailor-made gown.  You see we have come back,
+Duchess."
+
+"I have heard all about it, Mr. Gray," she answered.  "Poor Geoffrey is
+terribly upset.  And it seems that you asked him not to shoot the hare.
+How curious!"
+
+"Yes, it was very curious.  I don't know what made me say it.  Some
+whim, I suppose.  It looked the loveliest of little live things.  But I
+am sorry they told you about the man.  It is a hideous subject."
+
+"It is an annoying subject," broke in Lord Henry.  "It has no
+psychological value at all.  Now if Geoffrey had done the thing on
+purpose, how interesting he would be!  I should like to know some one
+who had committed a real murder."
+
+"How horrid of you, Harry!" cried the duchess.  "Isn't it, Mr. Gray?
+Harry, Mr. Gray is ill again.  He is going to faint."
+
+Dorian drew himself up with an effort and smiled.  "It is nothing,
+Duchess," he murmured; "my nerves are dreadfully out of order.  That is
+all.  I am afraid I walked too far this morning.  I didn't hear what
+Harry said.  Was it very bad?  You must tell me some other time.  I
+think I must go and lie down.  You will excuse me, won't you?"
+
+They had reached the great flight of steps that led from the
+conservatory on to the terrace.  As the glass door closed behind
+Dorian, Lord Henry turned and looked at the duchess with his slumberous
+eyes.  "Are you very much in love with him?" he asked.
+
+She did not answer for some time, but stood gazing at the landscape.
+"I wish I knew," she said at last.
+
+He shook his head.  "Knowledge would be fatal.  It is the uncertainty
+that charms one.  A mist makes things wonderful."
+
+"One may lose one's way."
+
+"All ways end at the same point, my dear Gladys."
+
+"What is that?"
+
+"Disillusion."
+
+"It was my _debut_ in life," she sighed.
+
+"It came to you crowned."
+
+"I am tired of strawberry leaves."
+
+"They become you."
+
+"Only in public."
+
+"You would miss them," said Lord Henry.
+
+"I will not part with a petal."
+
+"Monmouth has ears."
+
+"Old age is dull of hearing."
+
+"Has he never been jealous?"
+
+"I wish he had been."
+
+He glanced about as if in search of something.  "What are you looking
+for?" she inquired.
+
+"The button from your foil," he answered.  "You have dropped it."
+
+She laughed.  "I have still the mask."
+
+"It makes your eyes lovelier," was his reply.
+
+She laughed again.  Her teeth showed like white seeds in a scarlet
+fruit.
+
+Upstairs, in his own room, Dorian Gray was lying on a sofa, with terror
+in every tingling fibre of his body.  Life had suddenly become too
+hideous a burden for him to bear.  The dreadful death of the unlucky
+beater, shot in the thicket like a wild animal, had seemed to him to
+pre-figure death for himself also.  He had nearly swooned at what Lord
+Henry had said in a chance mood of cynical jesting.
+
+At five o'clock he rang his bell for his servant and gave him orders to
+pack his things for the night-express to town, and to have the brougham
+at the door by eight-thirty. He was determined not to sleep another
+night at Selby Royal.  It was an ill-omened place.  Death walked there
+in the sunlight.  The grass of the forest had been spotted with blood.
+
+Then he wrote a note to Lord Henry, telling him that he was going up to
+town to consult his doctor and asking him to entertain his guests in
+his absence.  As he was putting it into the envelope, a knock came to
+the door, and his valet informed him that the head-keeper wished to see
+him.  He frowned and bit his lip.  "Send him in," he muttered, after
+some moments' hesitation.
+
+As soon as the man entered, Dorian pulled his chequebook out of a
+drawer and spread it out before him.
+
+"I suppose you have come about the unfortunate accident of this
+morning, Thornton?" he said, taking up a pen.
+
+"Yes, sir," answered the gamekeeper.
+
+"Was the poor fellow married?  Had he any people dependent on him?"
+asked Dorian, looking bored.  "If so, I should not like them to be left
+in want, and will send them any sum of money you may think necessary."
+
+"We don't know who he is, sir.  That is what I took the liberty of
+coming to you about."
+
+"Don't know who he is?" said Dorian, listlessly.  "What do you mean?
+Wasn't he one of your men?"
+
+"No, sir.  Never saw him before.  Seems like a sailor, sir."
+
+The pen dropped from Dorian Gray's hand, and he felt as if his heart
+had suddenly stopped beating.  "A sailor?" he cried out.  "Did you say
+a sailor?"
+
+"Yes, sir.  He looks as if he had been a sort of sailor; tattooed on
+both arms, and that kind of thing."
+
+"Was there anything found on him?" said Dorian, leaning forward and
+looking at the man with startled eyes.  "Anything that would tell his
+name?"
+
+"Some money, sir--not much, and a six-shooter. There was no name of any
+kind.  A decent-looking man, sir, but rough-like. A sort of sailor we
+think."
+
+Dorian started to his feet.  A terrible hope fluttered past him.  He
+clutched at it madly.  "Where is the body?" he exclaimed.  "Quick!  I
+must see it at once."
+
+"It is in an empty stable in the Home Farm, sir.  The folk don't like
+to have that sort of thing in their houses.  They say a corpse brings
+bad luck."
+
+"The Home Farm!  Go there at once and meet me.  Tell one of the grooms
+to bring my horse round.  No. Never mind.  I'll go to the stables
+myself.  It will save time."
+
+In less than a quarter of an hour, Dorian Gray was galloping down the
+long avenue as hard as he could go.  The trees seemed to sweep past him
+in spectral procession, and wild shadows to fling themselves across his
+path.  Once the mare swerved at a white gate-post and nearly threw him.
+He lashed her across the neck with his crop.  She cleft the dusky air
+like an arrow.  The stones flew from her hoofs.
+
+At last he reached the Home Farm.  Two men were loitering in the yard.
+He leaped from the saddle and threw the reins to one of them.  In the
+farthest stable a light was glimmering.  Something seemed to tell him
+that the body was there, and he hurried to the door and put his hand
+upon the latch.
+
+There he paused for a moment, feeling that he was on the brink of a
+discovery that would either make or mar his life.  Then he thrust the
+door open and entered.
+
+On a heap of sacking in the far corner was lying the dead body of a man
+dressed in a coarse shirt and a pair of blue trousers.  A spotted
+handkerchief had been placed over the face.  A coarse candle, stuck in
+a bottle, sputtered beside it.
+
+Dorian Gray shuddered.  He felt that his could not be the hand to take
+the handkerchief away, and called out to one of the farm-servants to
+come to him.
+
+"Take that thing off the face.  I wish to see it," he said, clutching
+at the door-post for support.
+
+When the farm-servant had done so, he stepped forward.  A cry of joy
+broke from his lips.  The man who had been shot in the thicket was
+James Vane.
+
+He stood there for some minutes looking at the dead body.  As he rode
+home, his eyes were full of tears, for he knew he was safe.
+
+
+
+CHAPTER 19
+
+"There is no use your telling me that you are going to be good," cried
+Lord Henry, dipping his white fingers into a red copper bowl filled
+with rose-water. "You are quite perfect.  Pray, don't change."
+
+Dorian Gray shook his head.  "No, Harry, I have done too many dreadful
+things in my life.  I am not going to do any more.  I began my good
+actions yesterday."
+
+"Where were you yesterday?"
+
+"In the country, Harry.  I was staying at a little inn by myself."
+
+"My dear boy," said Lord Henry, smiling, "anybody can be good in the
+country.  There are no temptations there.  That is the reason why
+people who live out of town are so absolutely uncivilized.
+Civilization is not by any means an easy thing to attain to.  There are
+only two ways by which man can reach it.  One is by being cultured, the
+other by being corrupt.  Country people have no opportunity of being
+either, so they stagnate."
+
+"Culture and corruption," echoed Dorian.  "I have known something of
+both.  It seems terrible to me now that they should ever be found
+together.  For I have a new ideal, Harry.  I am going to alter.  I
+think I have altered."
+
+"You have not yet told me what your good action was.  Or did you say
+you had done more than one?" asked his companion as he spilled into his
+plate a little crimson pyramid of seeded strawberries and, through a
+perforated, shell-shaped spoon, snowed white sugar upon them.
+
+"I can tell you, Harry.  It is not a story I could tell to any one
+else.  I spared somebody.  It sounds vain, but you understand what I
+mean.  She was quite beautiful and wonderfully like Sibyl Vane.  I
+think it was that which first attracted me to her.  You remember Sibyl,
+don't you?  How long ago that seems!  Well, Hetty was not one of our
+own class, of course.  She was simply a girl in a village.  But I
+really loved her.  I am quite sure that I loved her.  All during this
+wonderful May that we have been having, I used to run down and see her
+two or three times a week.  Yesterday she met me in a little orchard.
+The apple-blossoms kept tumbling down on her hair, and she was
+laughing.  We were to have gone away together this morning at dawn.
+Suddenly I determined to leave her as flowerlike as I had found her."
+
+"I should think the novelty of the emotion must have given you a thrill
+of real pleasure, Dorian," interrupted Lord Henry.  "But I can finish
+your idyll for you.  You gave her good advice and broke her heart.
+That was the beginning of your reformation."
+
+"Harry, you are horrible!  You mustn't say these dreadful things.
+Hetty's heart is not broken.  Of course, she cried and all that.  But
+there is no disgrace upon her.  She can live, like Perdita, in her
+garden of mint and marigold."
+
+"And weep over a faithless Florizel," said Lord Henry, laughing, as he
+leaned back in his chair.  "My dear Dorian, you have the most curiously
+boyish moods.  Do you think this girl will ever be really content now
+with any one of her own rank?  I suppose she will be married some day
+to a rough carter or a grinning ploughman.  Well, the fact of having
+met you, and loved you, will teach her to despise her husband, and she
+will be wretched.  From a moral point of view, I cannot say that I
+think much of your great renunciation.  Even as a beginning, it is
+poor.  Besides, how do you know that Hetty isn't floating at the
+present moment in some starlit mill-pond, with lovely water-lilies
+round her, like Ophelia?"
+
+"I can't bear this, Harry!  You mock at everything, and then suggest
+the most serious tragedies.  I am sorry I told you now.  I don't care
+what you say to me.  I know I was right in acting as I did.  Poor
+Hetty!  As I rode past the farm this morning, I saw her white face at
+the window, like a spray of jasmine.  Don't let us talk about it any
+more, and don't try to persuade me that the first good action I have
+done for years, the first little bit of self-sacrifice I have ever
+known, is really a sort of sin.  I want to be better.  I am going to be
+better.  Tell me something about yourself.  What is going on in town?
+I have not been to the club for days."
+
+"The people are still discussing poor Basil's disappearance."
+
+"I should have thought they had got tired of that by this time," said
+Dorian, pouring himself out some wine and frowning slightly.
+
+"My dear boy, they have only been talking about it for six weeks, and
+the British public are really not equal to the mental strain of having
+more than one topic every three months.  They have been very fortunate
+lately, however.  They have had my own divorce-case and Alan Campbell's
+suicide.  Now they have got the mysterious disappearance of an artist.
+Scotland Yard still insists that the man in the grey ulster who left
+for Paris by the midnight train on the ninth of November was poor
+Basil, and the French police declare that Basil never arrived in Paris
+at all.  I suppose in about a fortnight we shall be told that he has
+been seen in San Francisco.  It is an odd thing, but every one who
+disappears is said to be seen at San Francisco.  It must be a
+delightful city, and possess all the attractions of the next world."
+
+"What do you think has happened to Basil?" asked Dorian, holding up his
+Burgundy against the light and wondering how it was that he could
+discuss the matter so calmly.
+
+"I have not the slightest idea.  If Basil chooses to hide himself, it
+is no business of mine.  If he is dead, I don't want to think about
+him.  Death is the only thing that ever terrifies me.  I hate it."
+
+"Why?" said the younger man wearily.
+
+"Because," said Lord Henry, passing beneath his nostrils the gilt
+trellis of an open vinaigrette box, "one can survive everything
+nowadays except that.  Death and vulgarity are the only two facts in
+the nineteenth century that one cannot explain away.  Let us have our
+coffee in the music-room, Dorian.  You must play Chopin to me.  The man
+with whom my wife ran away played Chopin exquisitely.  Poor Victoria!
+I was very fond of her.  The house is rather lonely without her.  Of
+course, married life is merely a habit, a bad habit.  But then one
+regrets the loss even of one's worst habits.  Perhaps one regrets them
+the most.  They are such an essential part of one's personality."
+
+Dorian said nothing, but rose from the table, and passing into the next
+room, sat down to the piano and let his fingers stray across the white
+and black ivory of the keys.  After the coffee had been brought in, he
+stopped, and looking over at Lord Henry, said, "Harry, did it ever
+occur to you that Basil was murdered?"
+
+Lord Henry yawned.  "Basil was very popular, and always wore a
+Waterbury watch.  Why should he have been murdered?  He was not clever
+enough to have enemies.  Of course, he had a wonderful genius for
+painting.  But a man can paint like Velasquez and yet be as dull as
+possible.  Basil was really rather dull.  He only interested me once,
+and that was when he told me, years ago, that he had a wild adoration
+for you and that you were the dominant motive of his art."
+
+"I was very fond of Basil," said Dorian with a note of sadness in his
+voice.  "But don't people say that he was murdered?"
+
+"Oh, some of the papers do.  It does not seem to me to be at all
+probable.  I know there are dreadful places in Paris, but Basil was not
+the sort of man to have gone to them.  He had no curiosity.  It was his
+chief defect."
+
+"What would you say, Harry, if I told you that I had murdered Basil?"
+said the younger man.  He watched him intently after he had spoken.
+
+"I would say, my dear fellow, that you were posing for a character that
+doesn't suit you.  All crime is vulgar, just as all vulgarity is crime.
+It is not in you, Dorian, to commit a murder.  I am sorry if I hurt
+your vanity by saying so, but I assure you it is true.  Crime belongs
+exclusively to the lower orders.  I don't blame them in the smallest
+degree.  I should fancy that crime was to them what art is to us,
+simply a method of procuring extraordinary sensations."
+
+"A method of procuring sensations?  Do you think, then, that a man who
+has once committed a murder could possibly do the same crime again?
+Don't tell me that."
+
+"Oh! anything becomes a pleasure if one does it too often," cried Lord
+Henry, laughing.  "That is one of the most important secrets of life.
+I should fancy, however, that murder is always a mistake.  One should
+never do anything that one cannot talk about after dinner.  But let us
+pass from poor Basil.  I wish I could believe that he had come to such
+a really romantic end as you suggest, but I can't. I dare say he fell
+into the Seine off an omnibus and that the conductor hushed up the
+scandal.  Yes:  I should fancy that was his end.  I see him lying now
+on his back under those dull-green waters, with the heavy barges
+floating over him and long weeds catching in his hair.  Do you know, I
+don't think he would have done much more good work.  During the last
+ten years his painting had gone off very much."
+
+Dorian heaved a sigh, and Lord Henry strolled across the room and began
+to stroke the head of a curious Java parrot, a large, grey-plumaged
+bird with pink crest and tail, that was balancing itself upon a bamboo
+perch.  As his pointed fingers touched it, it dropped the white scurf
+of crinkled lids over black, glasslike eyes and began to sway backwards
+and forwards.
+
+"Yes," he continued, turning round and taking his handkerchief out of
+his pocket; "his painting had quite gone off.  It seemed to me to have
+lost something.  It had lost an ideal.  When you and he ceased to be
+great friends, he ceased to be a great artist.  What was it separated
+you?  I suppose he bored you.  If so, he never forgave you.  It's a
+habit bores have.  By the way, what has become of that wonderful
+portrait he did of you?  I don't think I have ever seen it since he
+finished it.  Oh!  I remember your telling me years ago that you had
+sent it down to Selby, and that it had got mislaid or stolen on the
+way.  You never got it back?  What a pity! it was really a
+masterpiece.  I remember I wanted to buy it.  I wish I had now.  It
+belonged to Basil's best period.  Since then, his work was that curious
+mixture of bad painting and good intentions that always entitles a man
+to be called a representative British artist.  Did you advertise for
+it?  You should."
+
+"I forget," said Dorian.  "I suppose I did.  But I never really liked
+it.  I am sorry I sat for it.  The memory of the thing is hateful to
+me.  Why do you talk of it?  It used to remind me of those curious
+lines in some play--Hamlet, I think--how do they run?--
+
+    "Like the painting of a sorrow,
+     A face without a heart."
+
+Yes:  that is what it was like."
+
+Lord Henry laughed.  "If a man treats life artistically, his brain is
+his heart," he answered, sinking into an arm-chair.
+
+Dorian Gray shook his head and struck some soft chords on the piano.
+"'Like the painting of a sorrow,'" he repeated, "'a face without a
+heart.'"
+
+The elder man lay back and looked at him with half-closed eyes.  "By
+the way, Dorian," he said after a pause, "'what does it profit a man if
+he gain the whole world and lose--how does the quotation run?--his own
+soul'?"
+
+The music jarred, and Dorian Gray started and stared at his friend.
+"Why do you ask me that, Harry?"
+
+"My dear fellow," said Lord Henry, elevating his eyebrows in surprise,
+"I asked you because I thought you might be able to give me an answer.
+That is all.  I was going through the park last Sunday, and close by
+the Marble Arch there stood a little crowd of shabby-looking people
+listening to some vulgar street-preacher. As I passed by, I heard the
+man yelling out that question to his audience.  It struck me as being
+rather dramatic.  London is very rich in curious effects of that kind.
+A wet Sunday, an uncouth Christian in a mackintosh, a ring of sickly
+white faces under a broken roof of dripping umbrellas, and a wonderful
+phrase flung into the air by shrill hysterical lips--it was really very
+good in its way, quite a suggestion.  I thought of telling the prophet
+that art had a soul, but that man had not.  I am afraid, however, he
+would not have understood me."
+
+"Don't, Harry.  The soul is a terrible reality.  It can be bought, and
+sold, and bartered away.  It can be poisoned, or made perfect.  There
+is a soul in each one of us.  I know it."
+
+"Do you feel quite sure of that, Dorian?"
+
+"Quite sure."
+
+"Ah! then it must be an illusion.  The things one feels absolutely
+certain about are never true.  That is the fatality of faith, and the
+lesson of romance.  How grave you are!  Don't be so serious.  What have
+you or I to do with the superstitions of our age?  No:  we have given
+up our belief in the soul.  Play me something.  Play me a nocturne,
+Dorian, and, as you play, tell me, in a low voice, how you have kept
+your youth.  You must have some secret.  I am only ten years older than
+you are, and I am wrinkled, and worn, and yellow.  You are really
+wonderful, Dorian.  You have never looked more charming than you do
+to-night. You remind me of the day I saw you first.  You were rather
+cheeky, very shy, and absolutely extraordinary.  You have changed, of
+course, but not in appearance.  I wish you would tell me your secret.
+To get back my youth I would do anything in the world, except take
+exercise, get up early, or be respectable.  Youth!  There is nothing
+like it.  It's absurd to talk of the ignorance of youth.  The only
+people to whose opinions I listen now with any respect are people much
+younger than myself.  They seem in front of me.  Life has revealed to
+them her latest wonder.  As for the aged, I always contradict the aged.
+I do it on principle.  If you ask them their opinion on something that
+happened yesterday, they solemnly give you the opinions current in
+1820, when people wore high stocks, believed in everything, and knew
+absolutely nothing.  How lovely that thing you are playing is!  I
+wonder, did Chopin write it at Majorca, with the sea weeping round the
+villa and the salt spray dashing against the panes?  It is marvellously
+romantic.  What a blessing it is that there is one art left to us that
+is not imitative!  Don't stop.  I want music to-night. It seems to me
+that you are the young Apollo and that I am Marsyas listening to you.
+I have sorrows, Dorian, of my own, that even you know nothing of.  The
+tragedy of old age is not that one is old, but that one is young.  I am
+amazed sometimes at my own sincerity.  Ah, Dorian, how happy you are!
+What an exquisite life you have had!  You have drunk deeply of
+everything.  You have crushed the grapes against your palate.  Nothing
+has been hidden from you.  And it has all been to you no more than the
+sound of music.  It has not marred you.  You are still the same."
+
+"I am not the same, Harry."
+
+"Yes, you are the same.  I wonder what the rest of your life will be.
+Don't spoil it by renunciations.  At present you are a perfect type.
+Don't make yourself incomplete.  You are quite flawless now.  You need
+not shake your head:  you know you are.  Besides, Dorian, don't deceive
+yourself.  Life is not governed by will or intention.  Life is a
+question of nerves, and fibres, and slowly built-up cells in which
+thought hides itself and passion has its dreams.  You may fancy
+yourself safe and think yourself strong.  But a chance tone of colour
+in a room or a morning sky, a particular perfume that you had once
+loved and that brings subtle memories with it, a line from a forgotten
+poem that you had come across again, a cadence from a piece of music
+that you had ceased to play--I tell you, Dorian, that it is on things
+like these that our lives depend.  Browning writes about that
+somewhere; but our own senses will imagine them for us.  There are
+moments when the odour of _lilas blanc_ passes suddenly across me, and I
+have to live the strangest month of my life over again.  I wish I could
+change places with you, Dorian.  The world has cried out against us
+both, but it has always worshipped you.  It always will worship you.
+You are the type of what the age is searching for, and what it is
+afraid it has found.  I am so glad that you have never done anything,
+never carved a statue, or painted a picture, or produced anything
+outside of yourself!  Life has been your art.  You have set yourself to
+music.  Your days are your sonnets."
+
+Dorian rose up from the piano and passed his hand through his hair.
+"Yes, life has been exquisite," he murmured, "but I am not going to
+have the same life, Harry.  And you must not say these extravagant
+things to me.  You don't know everything about me.  I think that if you
+did, even you would turn from me.  You laugh.  Don't laugh."
+
+"Why have you stopped playing, Dorian?  Go back and give me the
+nocturne over again.  Look at that great, honey-coloured moon that
+hangs in the dusky air.  She is waiting for you to charm her, and if
+you play she will come closer to the earth.  You won't?  Let us go to
+the club, then.  It has been a charming evening, and we must end it
+charmingly.  There is some one at White's who wants immensely to know
+you--young Lord Poole, Bournemouth's eldest son.  He has already copied
+your neckties, and has begged me to introduce him to you.  He is quite
+delightful and rather reminds me of you."
+
+"I hope not," said Dorian with a sad look in his eyes.  "But I am tired
+to-night, Harry.  I shan't go to the club.  It is nearly eleven, and I
+want to go to bed early."
+
+"Do stay.  You have never played so well as to-night. There was
+something in your touch that was wonderful.  It had more expression
+than I had ever heard from it before."
+
+"It is because I am going to be good," he answered, smiling.  "I am a
+little changed already."
+
+"You cannot change to me, Dorian," said Lord Henry.  "You and I will
+always be friends."
+
+"Yet you poisoned me with a book once.  I should not forgive that.
+Harry, promise me that you will never lend that book to any one.  It
+does harm."
+
+"My dear boy, you are really beginning to moralize.  You will soon be
+going about like the converted, and the revivalist, warning people
+against all the sins of which you have grown tired.  You are much too
+delightful to do that.  Besides, it is no use.  You and I are what we
+are, and will be what we will be.  As for being poisoned by a book,
+there is no such thing as that.  Art has no influence upon action.  It
+annihilates the desire to act.  It is superbly sterile.  The books that
+the world calls immoral are books that show the world its own shame.
+That is all.  But we won't discuss literature.  Come round to-morrow. I
+am going to ride at eleven.  We might go together, and I will take you
+to lunch afterwards with Lady Branksome.  She is a charming woman, and
+wants to consult you about some tapestries she is thinking of buying.
+Mind you come.  Or shall we lunch with our little duchess?  She says
+she never sees you now.  Perhaps you are tired of Gladys?  I thought
+you would be.  Her clever tongue gets on one's nerves.  Well, in any
+case, be here at eleven."
+
+"Must I really come, Harry?"
+
+"Certainly.  The park is quite lovely now.  I don't think there have
+been such lilacs since the year I met you."
+
+"Very well.  I shall be here at eleven," said Dorian.  "Good night,
+Harry."  As he reached the door, he hesitated for a moment, as if he
+had something more to say.  Then he sighed and went out.
+
+
+
+CHAPTER 20
+
+It was a lovely night, so warm that he threw his coat over his arm and
+did not even put his silk scarf round his throat.  As he strolled home,
+smoking his cigarette, two young men in evening dress passed him.  He
+heard one of them whisper to the other, "That is Dorian Gray." He
+remembered how pleased he used to be when he was pointed out, or stared
+at, or talked about.  He was tired of hearing his own name now.  Half
+the charm of the little village where he had been so often lately was
+that no one knew who he was.  He had often told the girl whom he had
+lured to love him that he was poor, and she had believed him.  He had
+told her once that he was wicked, and she had laughed at him and
+answered that wicked people were always very old and very ugly.  What a
+laugh she had!--just like a thrush singing.  And how pretty she had
+been in her cotton dresses and her large hats!  She knew nothing, but
+she had everything that he had lost.
+
+When he reached home, he found his servant waiting up for him.  He sent
+him to bed, and threw himself down on the sofa in the library, and
+began to think over some of the things that Lord Henry had said to him.
+
+Was it really true that one could never change?  He felt a wild longing
+for the unstained purity of his boyhood--his rose-white boyhood, as
+Lord Henry had once called it.  He knew that he had tarnished himself,
+filled his mind with corruption and given horror to his fancy; that he
+had been an evil influence to others, and had experienced a terrible
+joy in being so; and that of the lives that had crossed his own, it had
+been the fairest and the most full of promise that he had brought to
+shame.  But was it all irretrievable?  Was there no hope for him?
+
+Ah! in what a monstrous moment of pride and passion he had prayed that
+the portrait should bear the burden of his days, and he keep the
+unsullied splendour of eternal youth!  All his failure had been due to
+that.  Better for him that each sin of his life had brought its sure
+swift penalty along with it.  There was purification in punishment.
+Not "Forgive us our sins" but "Smite us for our iniquities" should be
+the prayer of man to a most just God.
+
+The curiously carved mirror that Lord Henry had given to him, so many
+years ago now, was standing on the table, and the white-limbed Cupids
+laughed round it as of old.  He took it up, as he had done on that
+night of horror when he had first noted the change in the fatal
+picture, and with wild, tear-dimmed eyes looked into its polished
+shield.  Once, some one who had terribly loved him had written to him a
+mad letter, ending with these idolatrous words: "The world is changed
+because you are made of ivory and gold.  The curves of your lips
+rewrite history."  The phrases came back to his memory, and he repeated
+them over and over to himself.  Then he loathed his own beauty, and
+flinging the mirror on the floor, crushed it into silver splinters
+beneath his heel.  It was his beauty that had ruined him, his beauty
+and the youth that he had prayed for.  But for those two things, his
+life might have been free from stain.  His beauty had been to him but a
+mask, his youth but a mockery.  What was youth at best?  A green, an
+unripe time, a time of shallow moods, and sickly thoughts.  Why had he
+worn its livery?  Youth had spoiled him.
+
+It was better not to think of the past.  Nothing could alter that.  It
+was of himself, and of his own future, that he had to think.  James
+Vane was hidden in a nameless grave in Selby churchyard.  Alan Campbell
+had shot himself one night in his laboratory, but had not revealed the
+secret that he had been forced to know.  The excitement, such as it
+was, over Basil Hallward's disappearance would soon pass away.  It was
+already waning.  He was perfectly safe there.  Nor, indeed, was it the
+death of Basil Hallward that weighed most upon his mind.  It was the
+living death of his own soul that troubled him.  Basil had painted the
+portrait that had marred his life.  He could not forgive him that.  It
+was the portrait that had done everything.  Basil had said things to
+him that were unbearable, and that he had yet borne with patience.  The
+murder had been simply the madness of a moment.  As for Alan Campbell,
+his suicide had been his own act.  He had chosen to do it.  It was
+nothing to him.
+
+A new life!  That was what he wanted.  That was what he was waiting
+for.  Surely he had begun it already.  He had spared one innocent
+thing, at any rate.  He would never again tempt innocence.  He would be
+good.
+
+As he thought of Hetty Merton, he began to wonder if the portrait in
+the locked room had changed.  Surely it was not still so horrible as it
+had been?  Perhaps if his life became pure, he would be able to expel
+every sign of evil passion from the face.  Perhaps the signs of evil
+had already gone away.  He would go and look.
+
+He took the lamp from the table and crept upstairs.  As he unbarred the
+door, a smile of joy flitted across his strangely young-looking face
+and lingered for a moment about his lips.  Yes, he would be good, and
+the hideous thing that he had hidden away would no longer be a terror
+to him.  He felt as if the load had been lifted from him already.
+
+He went in quietly, locking the door behind him, as was his custom, and
+dragged the purple hanging from the portrait.  A cry of pain and
+indignation broke from him.  He could see no change, save that in the
+eyes there was a look of cunning and in the mouth the curved wrinkle of
+the hypocrite.  The thing was still loathsome--more loathsome, if
+possible, than before--and the scarlet dew that spotted the hand seemed
+brighter, and more like blood newly spilled.  Then he trembled.  Had it
+been merely vanity that had made him do his one good deed?  Or the
+desire for a new sensation, as Lord Henry had hinted, with his mocking
+laugh?  Or that passion to act a part that sometimes makes us do things
+finer than we are ourselves?  Or, perhaps, all these?  And why was the
+red stain larger than it had been?  It seemed to have crept like a
+horrible disease over the wrinkled fingers.  There was blood on the
+painted feet, as though the thing had dripped--blood even on the hand
+that had not held the knife.  Confess?  Did it mean that he was to
+confess?  To give himself up and be put to death?  He laughed.  He felt
+that the idea was monstrous.  Besides, even if he did confess, who
+would believe him?  There was no trace of the murdered man anywhere.
+Everything belonging to him had been destroyed.  He himself had burned
+what had been below-stairs. The world would simply say that he was mad.
+They would shut him up if he persisted in his story.... Yet it was
+his duty to confess, to suffer public shame, and to make public
+atonement.  There was a God who called upon men to tell their sins to
+earth as well as to heaven.  Nothing that he could do would cleanse him
+till he had told his own sin.  His sin?  He shrugged his shoulders.
+The death of Basil Hallward seemed very little to him.  He was thinking
+of Hetty Merton.  For it was an unjust mirror, this mirror of his soul
+that he was looking at.  Vanity?  Curiosity?  Hypocrisy?  Had there
+been nothing more in his renunciation than that?  There had been
+something more.  At least he thought so.  But who could tell? ... No.
+There had been nothing more.  Through vanity he had spared her.  In
+hypocrisy he had worn the mask of goodness.  For curiosity's sake he
+had tried the denial of self.  He recognized that now.
+
+But this murder--was it to dog him all his life?  Was he always to be
+burdened by his past?  Was he really to confess?  Never.  There was
+only one bit of evidence left against him.  The picture itself--that
+was evidence.  He would destroy it.  Why had he kept it so long?  Once
+it had given him pleasure to watch it changing and growing old.  Of
+late he had felt no such pleasure.  It had kept him awake at night.
+When he had been away, he had been filled with terror lest other eyes
+should look upon it.  It had brought melancholy across his passions.
+Its mere memory had marred many moments of joy.  It had been like
+conscience to him.  Yes, it had been conscience.  He would destroy it.
+
+He looked round and saw the knife that had stabbed Basil Hallward.  He
+had cleaned it many times, till there was no stain left upon it.  It
+was bright, and glistened.  As it had killed the painter, so it would
+kill the painter's work, and all that that meant.  It would kill the
+past, and when that was dead, he would be free.  It would kill this
+monstrous soul-life, and without its hideous warnings, he would be at
+peace.  He seized the thing, and stabbed the picture with it.
+
+There was a cry heard, and a crash.  The cry was so horrible in its
+agony that the frightened servants woke and crept out of their rooms.
+Two gentlemen, who were passing in the square below, stopped and looked
+up at the great house.  They walked on till they met a policeman and
+brought him back.  The man rang the bell several times, but there was
+no answer.  Except for a light in one of the top windows, the house was
+all dark.  After a time, he went away and stood in an adjoining portico
+and watched.
+
+"Whose house is that, Constable?" asked the elder of the two gentlemen.
+
+"Mr. Dorian Gray's, sir," answered the policeman.
+
+They looked at each other, as they walked away, and sneered.  One of
+them was Sir Henry Ashton's uncle.
+
+Inside, in the servants' part of the house, the half-clad domestics
+were talking in low whispers to each other.  Old Mrs. Leaf was crying
+and wringing her hands.  Francis was as pale as death.
+
+After about a quarter of an hour, he got the coachman and one of the
+footmen and crept upstairs.  They knocked, but there was no reply.
+They called out.  Everything was still.  Finally, after vainly trying
+to force the door, they got on the roof and dropped down on to the
+balcony.  The windows yielded easily--their bolts were old.
+
+When they entered, they found hanging upon the wall a splendid portrait
+of their master as they had last seen him, in all the wonder of his
+exquisite youth and beauty.  Lying on the floor was a dead man, in
+evening dress, with a knife in his heart.  He was withered, wrinkled,
+and loathsome of visage.  It was not till they had examined the rings
+that they recognized who it was.
+
+
+
+
+
+
+
+
+
+End of Project Gutenberg's The Picture of Dorian Gray, by Oscar Wilde
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE PICTURE OF DORIAN GRAY ***
+
+***** This file should be named 174.txt or 174.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/174/
+
+Produced by Judith Boss.  HTML version by Al Haines.
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/edgar-allan-poe-works-1.txt
+++ b/jet/tf-idf/src/main/resources/books/edgar-allan-poe-works-1.txt
@@ -1,0 +1,9226 @@
+﻿Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Works of Edgar Allan Poe
+       Volume 1 (of 5) of the Raven Edition
+
+Author: Edgar Allan Poe
+
+Release Date: May 19, 2008 [EBook #2147]
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+
+
+
+Produced by David Widger and Carlo Traverso
+
+
+
+
+
+
+
+
+THE WORKS OF EDGAR ALLAN POE
+
+IN FIVE VOLUMES
+
+
+The Raven Edition
+
+
+
+
+VOLUME I
+
+
+Contents:
+
+     Edgar Allan Poe, An Appreciation
+     Life of Poe, by James Russell Lowell
+     Death of Poe, by N. P. Willis
+     The Unparalleled Adventures of One Hans Pfaall
+     The Gold-Bug
+     Four Beasts in One
+     The Murders in the Rue Morgue
+     The Mystery of Marie Rogêt
+     The Balloon-Hoax
+     MS. Found in a Bottle
+     The Oval Portrait
+
+
+
+
+EDGAR ALLAN POE
+
+AN APPRECIATION
+
+
+   Caught from some unhappy master whom unmerciful Disaster
+   Followed fast and followed faster till his songs one burden bore--
+   Till the dirges of his Hope that melancholy burden bore
+         Of “never--never more!”
+
+THIS stanza from “The Raven” was recommended by James Russell Lowell as
+an inscription upon the Baltimore monument which marks the resting place
+of Edgar Allan Poe, the most interesting and original figure in American
+letters. And, to signify that peculiar musical quality of Poe’s genius
+which inthralls every reader, Mr. Lowell suggested this additional
+verse, from the “Haunted Palace”:
+
+   And all with pearl and ruby glowing
+    Was the fair palace door,
+   Through which came flowing, flowing, flowing,
+    And sparkling ever more,
+   A troop of Echoes, whose sweet duty
+    Was but to sing,
+   In voices of surpassing beauty,
+    The wit and wisdom of their king.
+
+
+Born in poverty at Boston, January 19, 1809, dying under painful
+circumstances at Baltimore, October 7, 1849, his whole literary career
+of scarcely fifteen years a pitiful struggle for mere subsistence, his
+memory malignantly misrepresented by his earliest biographer, Griswold,
+how completely has truth at last routed falsehood and how magnificently
+has Poe come into his own. For “The Raven,” first published in 1845,
+and, within a few months, read, recited and parodied wherever the
+English language was spoken, the half-starved poet received $10! Less
+than a year later his brother poet, N. P. Willis, issued this touching
+appeal to the admirers of genius on behalf of the neglected author, his
+dying wife and her devoted mother, then living under very straitened
+circumstances in a little cottage at Fordham, N. Y.:
+
+“Here is one of the finest scholars, one of the most original men of
+genius, and one of the most industrious of the literary profession of
+our country, whose temporary suspension of labor, from bodily illness,
+drops him immediately to a level with the common objects of public
+charity. There is no intermediate stopping-place, no respectful shelter,
+where, with the delicacy due to genius and culture, he might secure
+aid, till, with returning health, he would resume his labors, and his
+unmortified sense of independence.”
+
+And this was the tribute paid by the American public to the master who
+had given to it such tales of conjuring charm, of witchery and mystery
+as “The Fall of the House of Usher” and “Ligeia”; such fascinating
+hoaxes as “The Unparalleled Adventure of Hans Pfaall,” “MSS. Found in a
+Bottle,” “A Descent Into a Maelstrom” and “The Balloon-Hoax”; such tales
+of conscience as “William Wilson,” “The Black Cat” and “The Tell-tale
+Heart,” wherein the retributions of remorse are portrayed with an awful
+fidelity; such tales of natural beauty as “The Island of the Fay” and
+“The Domain of Arnheim”; such marvellous studies in ratiocination as the
+“Gold-bug,” “The Murders in the Rue Morgue,” “The Purloined Letter”
+ and “The Mystery of Marie Roget,” the latter, a recital of fact,
+demonstrating the author’s wonderful capability of correctly analyzing
+the mysteries of the human mind; such tales of illusion and banter
+as “The Premature Burial” and “The System of Dr. Tarr and Professor
+Fether”; such bits of extravaganza as “The Devil in the Belfry” and “The
+Angel of the Odd”; such tales of adventure as “The Narrative of Arthur
+Gordon Pym”; such papers of keen criticism and review as won for Poe the
+enthusiastic admiration of Charles Dickens, although they made him many
+enemies among the over-puffed minor American writers so mercilessly
+exposed by him; such poems of beauty and melody as “The Bells,” “The
+Haunted Palace,” “Tamerlane,” “The City in the Sea” and “The Raven.”
+ What delight for the jaded senses of the reader is this enchanted domain
+of wonder-pieces! What an atmosphere of beauty, music, color! What
+resources of imagination, construction, analysis and absolute art! One
+might almost sympathize with Sarah Helen Whitman, who, confessing to
+a half faith in the old superstition of the significance of anagrams,
+found, in the transposed letters of Edgar Poe’s name, the words “a
+God-peer.” His mind, she says, was indeed a “Haunted Palace,” echoing to
+the footfalls of angels and demons.
+
+“No man,” Poe himself wrote, “has recorded, no man has dared to record,
+the wonders of his inner life.”
+
+In these twentieth century days--of lavish recognition--artistic,
+popular and material--of genius, what rewards might not a Poe claim!
+
+Edgar’s father, a son of General David Poe, the American revolutionary
+patriot and friend of Lafayette, had married Mrs. Hopkins, an English
+actress, and, the match meeting with parental disapproval, had himself
+taken to the stage as a profession. Notwithstanding Mrs. Poe’s beauty
+and talent the young couple had a sorry struggle for existence. When
+Edgar, at the age of two years, was orphaned, the family was in the
+utmost destitution. Apparently the future poet was to be cast upon the
+world homeless and friendless. But fate decreed that a few glimmers of
+sunshine were to illumine his life, for the little fellow was adopted
+by John Allan, a wealthy merchant of Richmond, Va. A brother and sister,
+the remaining children, were cared for by others.
+
+In his new home Edgar found all the luxury and advantages money could
+provide. He was petted, spoiled and shown off to strangers. In Mrs.
+Allan he found all the affection a childless wife could bestow. Mr.
+Allan took much pride in the captivating, precocious lad. At the age of
+five the boy recited, with fine effect, passages of English poetry to
+the visitors at the Allan house.
+
+From his eighth to his thirteenth year he attended the Manor House
+school, at Stoke-Newington, a suburb of London. It was the Rev. Dr.
+Bransby, head of the school, whom Poe so quaintly portrayed in “William
+Wilson.” Returning to Richmond in 1820 Edgar was sent to the school
+of Professor Joseph H. Clarke. He proved an apt pupil. Years afterward
+Professor Clarke thus wrote:
+
+“While the other boys wrote mere mechanical verses, Poe wrote genuine
+poetry; the boy was a born poet. As a scholar he was ambitious to
+excel. He was remarkable for self-respect, without haughtiness. He had
+a sensitive and tender heart and would do anything for a friend. His
+nature was entirely free from selfishness.”
+
+At the age of seventeen Poe entered the University of Virginia at
+Charlottesville. He left that institution after one session. Official
+records prove that he was not expelled. On the contrary, he gained
+a creditable record as a student, although it is admitted that he
+contracted debts and had “an ungovernable passion for card-playing.”
+ These debts may have led to his quarrel with Mr. Allan which eventually
+compelled him to make his own way in the world.
+
+Early in 1827 Poe made his first literary venture. He induced Calvin
+Thomas, a poor and youthful printer, to publish a small volume of his
+verses under the title “Tamerlane and Other Poems.” In 1829 we find Poe
+in Baltimore with another manuscript volume of verses, which was soon
+published. Its title was “Al Aaraaf, Tamerlane and Other Poems.” Neither
+of these ventures seems to have attracted much attention.
+
+Soon after Mrs. Allan’s death, which occurred in 1829, Poe, through
+the aid of Mr. Allan, secured admission to the United States Military
+Academy at West Point. Any glamour which may have attached to cadet life
+in Poe’s eyes was speedily lost, for discipline at West Point was never
+so severe nor were the accommodations ever so poor. Poe’s bent was
+more and more toward literature. Life at the academy daily became
+increasingly distasteful. Soon he began to purposely neglect his studies
+and to disregard his duties, his aim being to secure his dismissal from
+the United States service. In this he succeeded. On March 7, 1831, Poe
+found himself free. Mr. Allan’s second marriage had thrown the lad on
+his own resources. His literary career was to begin.
+
+Poe’s first genuine victory was won in 1833, when he was the successful
+competitor for a prize of $100 offered by a Baltimore periodical for the
+best prose story. “A MSS. Found in a Bottle” was the winning tale. Poe
+had submitted six stories in a volume. “Our only difficulty,” says Mr.
+Latrobe, one of the judges, “was in selecting from the rich contents of
+the volume.”
+
+During the fifteen years of his literary life Poe was connected with
+various newspapers and magazines in Richmond, Philadelphia and New York.
+He was faithful, punctual, industrious, thorough. N. P. Willis, who for
+some time employed Poe as critic and sub-editor on the “Evening Mirror,”
+ wrote thus:
+
+“With the highest admiration for Poe’s genius, and a willingness to
+let it alone for more than ordinary irregularity, we were led by
+common report to expect a very capricious attention to his duties, and
+occasionally a scene of violence and difficulty. Time went on,
+however, and he was invariably punctual and industrious. We saw but
+one presentiment of the man-a quiet, patient, industrious and most
+gentlemanly person.
+
+“We heard, from one who knew him well (what should be stated in all
+mention of his lamentable irregularities), that with a single glass of
+wine his whole nature was reversed, the demon became uppermost, and,
+though none of the usual signs of intoxication were visible, his will
+was palpably insane. In this reversed character, we repeat, it was never
+our chance to meet him.”
+
+On September 22, 1835, Poe married his cousin, Virginia Clemm, in
+Baltimore. She had barely turned thirteen years, Poe himself was but
+twenty-six. He then was a resident of Richmond and a regular contributor
+to the “Southern Literary Messenger.” It was not until a year later that
+the bride and her widowed mother followed him thither.
+
+Poe’s devotion to his child-wife was one of the most beautiful features
+of his life. Many of his famous poetic productions were inspired by her
+beauty and charm. Consumption had marked her for its victim, and the
+constant efforts of husband and mother were to secure for her all the
+comfort and happiness their slender means permitted. Virginia died
+January 30, 1847, when but twenty-five years of age. A friend of the
+family pictures the death-bed scene--mother and husband trying to impart
+warmth to her by chafing her hands and her feet, while her pet cat was
+suffered to nestle upon her bosom for the sake of added warmth.
+
+These verses from “Annabel Lee,” written by Poe in 1849, the last year
+of his life, tell of his sorrow at the loss of his child-wife:
+
+     I was a child and _she_ was a child,
+      In a kingdom by the sea;
+
+     But we loved with _a _love that was more than love--
+       I and my Annabel Lee;
+
+     With a love that the winged seraphs of heaven
+      Coveted her and me.
+     And this was the reason that, long ago;
+      In this kingdom by the sea.
+     A wind blew out of a cloud, chilling
+      My beautiful Annabel Lee;
+
+     So that her high-born kinsmen came
+      And bore her away from me,
+     To shut her up in a sepulchre
+      In this kingdom by the sea,
+
+
+Poe was connected at various times and in various capacities with the
+“Southern Literary Messenger” in Richmond, Va.; “Graham’s Magazine” and
+the “Gentleman’s Magazine” in Philadelphia; the “Evening Mirror,” the
+“Broadway Journal,” and “Godey’s Lady’s Book” in New York. Everywhere
+Poe’s life was one of unremitting toil. No tales and poems were ever
+produced at a greater cost of brain and spirit.
+
+Poe’s initial salary with the “Southern Literary Messenger,” to which
+he contributed the first drafts of a number of his best-known tales,
+was $10 a week! Two years later his salary was but $600 a year. Even in
+1844, when his literary reputation was established securely, he wrote to
+a friend expressing his pleasure because a magazine to which he was to
+contribute had agreed to pay him $20 monthly for two pages of criticism.
+
+Those were discouraging times in American literature, but Poe never
+lost faith. He was finally to triumph wherever pre-eminent talents win
+admirers. His genius has had no better description than in this stanza
+from William Winter’s poem, read at the dedication exercises of the
+Actors’ Monument to Poe, May 4, 1885, in New York:
+
+     He was the voice of beauty and of woe,
+     Passion and mystery and the dread unknown;
+     Pure as the mountains of perpetual snow,
+     Cold as the icy winds that round them moan,
+     Dark as the caves wherein earth’s thunders groan,
+     Wild as the tempests of the upper sky,
+     Sweet as the faint, far-off celestial tone of angel
+         whispers, fluttering from on high,
+     And tender as love’s tear when youth and beauty die.
+
+
+In the two and a half score years that have elapsed since Poe’s death
+he has come fully into his own. For a while Griswold’s malignant
+misrepresentations colored the public estimate of Poe as man and as
+writer. But, thanks to J. H. Ingram, W. F. Gill, Eugene Didier, Sarah
+Helen Whitman and others these scandals have been dispelled and Poe is
+seen as he actually was-not as a man without failings, it is true, but
+as the finest and most original genius in American letters. As the
+years go on his fame increases. His works have been translated into
+many foreign languages. His is a household name in France and England-in
+fact, the latter nation has often uttered the reproach that Poe’s own
+country has been slow to appreciate him. But that reproach, if it ever
+was warranted, certainly is untrue.
+
+                                     W. H. R.
+
+
+
+
+EDGAR ALLAN POE
+
+By James Russell Lowell
+
+
+THE situation of American literature is anomalous. It has no centre, or,
+if it have, it is like that of the sphere of Hermes. It is divided
+into many systems, each revolving round its several suns, and often
+presenting to the rest only the faint glimmer of a milk-and-water way.
+Our capital city, unlike London or Paris, is not a great central heart
+from which life and vigor radiate to the extremities, but resembles more
+an isolated umbilicus stuck down as near as may be to the centre of the
+land, and seeming rather to tell a legend of former usefulness than to
+serve any present need. Boston, New York, Philadelphia, each has its
+literature almost more distinct than those of the different dialects
+of Germany; and the Young Queen of the West has also one of her own,
+of which some articulate rumor barely has reached us dwellers by the
+Atlantic.
+
+Perhaps there is no task more difficult than the just criticism of
+contemporary literature. It is even more grateful to give praise where
+it is needed than where it is deserved, and friendship so often seduces
+the iron stylus of justice into a vague flourish, that she writes what
+seems rather like an epitaph than a criticism. Yet if praise be given
+as an alms, we could not drop so poisonous a one into any man’s hat. The
+critic’s ink may suffer equally from too large an infusion of nutgalls
+or of sugar. But it is easier to be generous than to be just, and we
+might readily put faith in that fabulous direction to the hiding place
+of truth, did we judge from the amount of water which we usually find
+mixed with it.
+
+Remarkable experiences are usually confined to the inner life of
+imaginative men, but Mr. Poe’s biography displays a vicissitude and
+peculiarity of interest such as is rarely met with. The offspring of a
+romantic marriage, and left an orphan at an early age, he was adopted
+by Mr. Allan, a wealthy Virginian, whose barren marriage-bed seemed the
+warranty of a large estate to the young poet.
+
+Having received a classical education in England, he returned home and
+entered the University of Virginia, where, after an extravagant course,
+followed by reformation at the last extremity, he was graduated with
+the highest honors of his class. Then came a boyish attempt to join the
+fortunes of the insurgent Greeks, which ended at St. Petersburg, where
+he got into difficulties through want of a passport, from which he
+was rescued by the American consul and sent home. He now entered the
+military academy at West Point, from which he obtained a dismissal
+on hearing of the birth of a son to his adopted father, by a second
+marriage, an event which cut off his expectations as an heir. The death
+of Mr. Allan, in whose will his name was not mentioned, soon after
+relieved him of all doubt in this regard, and he committed himself at
+once to authorship for a support. Previously to this, however, he had
+published (in 1827) a small volume of poems, which soon ran through
+three editions, and excited high expectations of its author’s future
+distinction in the minds of many competent judges.
+
+That no certain augury can be drawn from a poet’s earliest lispings
+there are instances enough to prove. Shakespeare’s first poems, though
+brimful of vigor and youth and picturesqueness, give but a very faint
+promise of the directness, condensation and overflowing moral of his
+maturer works. Perhaps, however, Shakespeare is hardly a case in
+point, his “Venus and Adonis” having been published, we believe, in his
+twenty-sixth year. Milton’s Latin verses show tenderness, a fine eye for
+nature, and a delicate appreciation of classic models, but give no hint
+of the author of a new style in poetry. Pope’s youthful pieces have
+all the sing-song, wholly unrelieved by the glittering malignity
+and eloquent irreligion of his later productions. Collins’ callow
+namby-pamby died and gave no sign of the vigorous and original genius
+which he afterward displayed. We have never thought that the world lost
+more in the “marvellous boy,” Chatterton, than a very ingenious imitator
+of obscure and antiquated dulness. Where he becomes original (as it is
+called), the interest of ingenuity ceases and he becomes stupid. Kirke
+White’s promises were indorsed by the respectable name of Mr. Southey,
+but surely with no authority from Apollo. They have the merit of a
+traditional piety, which to our mind, if uttered at all, had been less
+objectionable in the retired closet of a diary, and in the sober raiment
+of prose. They do not clutch hold of the memory with the drowning
+pertinacity of Watts; neither have they the interest of his occasional
+simple, lucky beauty. Burns having fortunately been rescued by his
+humble station from the contaminating society of the “Best models,”
+ wrote well and naturally from the first. Had he been unfortunate enough
+to have had an educated taste, we should have had a series of poems from
+which, as from his letters, we could sift here and there a kernel from
+the mass of chaff. Coleridge’s youthful efforts give no promise whatever
+of that poetical genius which produced at once the wildest, tenderest,
+most original and most purely imaginative poems of modern times. Byron’s
+“Hours of Idleness” would never find a reader except from an intrepid
+and indefatigable curiosity. In Wordsworth’s first preludings there
+is but a dim foreboding of the creator of an era. From Southey’s early
+poems, a safer augury might have been drawn. They show the patient
+investigator, the close student of history, and the unwearied explorer
+of the beauties of predecessors, but they give no assurances of a man
+who should add aught to stock of household words, or to the rarer
+and more sacred delights of the fireside or the arbor. The earliest
+specimens of Shelley’s poetic mind already, also, give tokens of that
+ethereal sublimation in which the spirit seems to soar above the regions
+of words, but leaves its body, the verse, to be entombed, without hope
+of resurrection, in a mass of them. Cowley is generally instanced as a
+wonder of precocity. But his early insipidities show only a capacity
+for rhyming and for the metrical arrangement of certain conventional
+combinations of words, a capacity wholly dependent on a delicate
+physical organization, and an unhappy memory. An early poem is only
+remarkable when it displays an effort of _reason, _and the rudest verses
+in which we can trace some conception of the ends of poetry, are worth
+all the miracles of smooth juvenile versification. A school-boy, one
+would say, might acquire the regular see-saw of Pope merely by an
+association with the motion of the play-ground tilt.
+
+Mr. Poe’s early productions show that he could see through the verse to
+the spirit beneath, and that he already had a feeling that all the life
+and grace of the one must depend on and be modulated by the will of the
+other. We call them the most remarkable boyish poems that we have
+ever read. We know of none that can compare with them for maturity of
+purpose, and a nice understanding of the effects of language and metre.
+Such pieces are only valuable when they display what we can only express
+by the contradictory phrase of _innate experience. _We copy one of the
+shorter poems, written when the author was only fourteen. There is a
+little dimness in the filling up, but the grace and symmetry of the
+outline are such as few poets ever attain. There is a smack of ambrosia
+about it.
+
+     TO HELEN
+
+     Helen, thy beauty is to me
+       Like those Nicean barks of yore,
+     That gently, o’er a perfumed sea,
+       The weary, way-worn wanderer bore
+     To his own native shore.
+
+     On desperate seas long wont to roam,
+       Thy hyacinth hair, thy classic face,
+     Thy Naiad airs have brought me home
+       To the glory that was Greece
+     And the grandeur that was Rome.
+
+     Lo! in yon brilliant window-niche
+       How statue-like I see thee stand!
+     The agate lamp within thy hand,
+       Ah! Psyche, from the regions which
+     Are Holy Land!
+
+
+It is the tendency of the young poet that impresses us. Here is no
+“withering scorn,” no heart “blighted” ere it has safely got into its
+teens, none of the drawing-room sansculottism which Byron had brought
+into vogue. All is limpid and serene, with a pleasant dash of the Greek
+Helicon in it. The melody of the whole, too, is remarkable. It is not of
+that kind which can be demonstrated arithmetically upon the tips of
+the fingers. It is of that finer sort which the inner ear alone
+_can _estimate. It seems simple, like a Greek column, because of its
+perfection. In a poem named “Ligeia,” under which title he intended
+to personify the music of nature, our boy-poet gives us the following
+exquisite picture:
+
+       Ligeia! Ligeia!
+     My beautiful one,
+       Whose harshest idea
+     Will to melody run,
+       Say, is it thy will,
+     On the breezes to toss,
+       Or, capriciously still,
+     Like the lone albatross,
+       Incumbent on night,
+     As she on the air,
+       To keep watch with delight
+     On the harmony there?
+
+John Neal, himself a man of genius, and whose lyre has been too long
+capriciously silent, appreciated the high merit of these and similar
+passages, and drew a proud horoscope for their author.
+
+Mr. Poe had that indescribable something which men have agreed to call
+_genius_. No man could ever tell us precisely what it is, and yet there
+is none who is not inevitably aware of its presence and its power. Let
+talent writhe and contort itself as it may, it has no such magnetism.
+Larger of bone and sinew it may be, but the wings are wanting. Talent
+sticks fast to earth, and its most perfect works have still one foot of
+clay. Genius claims kindred with the very workings of Nature herself, so
+that a sunset shall seem like a quotation from Dante, and if Shakespeare
+be read in the very presence of the sea itself, his verses shall but
+seem nobler for the sublime criticism of ocean. Talent may make friends
+for itself, but only genius can give to its creations the divine power
+of winning love and veneration. Enthusiasm cannot cling to what itself
+is unenthusiastic, nor will he ever have disciples who has not himself
+impulsive zeal enough to be a disciple. Great wits are allied to madness
+only inasmuch as they are possessed and carried away by their demon,
+while talent keeps him, as Paracelsus did, securely prisoned in the
+pommel of his sword. To the eye of genius, the veil of the spiritual
+world is ever rent asunder that it may perceive the ministers of good
+and evil who throng continually around it. No man of mere talent ever
+flung his inkstand at the devil.
+
+When we say that Mr. Poe had genius, we do not mean to say that he has
+produced evidence of the highest. But to say that he possesses it at
+all is to say that he needs only zeal, industry, and a reverence for the
+trust reposed in him, to achieve the proudest triumphs and the greenest
+laurels. If we may believe the Longinuses and Aristotles of our
+newspapers, we have quite too many geniuses of the loftiest order to
+render a place among them at all desirable, whether for its hardness
+of attainment or its seclusion. The highest peak of our Parnassus is,
+according to these gentlemen, by far the most thickly settled portion
+of the country, a circumstance which must make it an uncomfortable
+residence for individuals of a poetical temperament, if love of
+solitude be, as immemorial tradition asserts, a necessary part of their
+idiosyncrasy.
+
+Mr. Poe has two of the prime qualities of genius, a faculty of vigorous
+yet minute analysis, and a wonderful fecundity of imagination. The first
+of these faculties is as needful to the artist in words, as a knowledge
+of anatomy is to the artist in colors or in stone. This enables him to
+conceive truly, to maintain a proper relation of parts, and to draw a
+correct outline, while the second groups, fills up and colors. Both
+of these Mr. Poe has displayed with singular distinctness in his prose
+works, the last predominating in his earlier tales, and the first in his
+later ones. In judging of the merit of an author, and assigning him his
+niche among our household gods, we have a right to regard him from
+our own point of view, and to measure him by our own standard. But,
+in estimating the amount of power displayed in his works, we must be
+governed by his own design, and placing them by the side of his own
+ideal, find how much is wanting. We differ from Mr. Poe in his opinions
+of the objects of art. He esteems that object to be the creation of
+Beauty, and perhaps it is only in the definition of that word that we
+disagree with him. But in what we shall say of his writings, we shall
+take his own standard as our guide. The temple of the god of song is
+equally accessible from every side, and there is room enough in it for
+all who bring offerings, or seek in oracle.
+
+In his tales, Mr. Poe has chosen to exhibit his power chiefly in that
+dim region which stretches from the very utmost limits of the probable
+into the weird confines of superstition and unreality. He combines in
+a very remarkable manner two faculties which are seldom found united; a
+power of influencing the mind of the reader by the impalpable shadows
+of mystery, and a minuteness of detail which does not leave a pin or
+a button unnoticed. Both are, in truth, the natural results of the
+predominating quality of his mind, to which we have before alluded,
+analysis. It is this which distinguishes the artist. His mind at once
+reaches forward to the effect to be produced. Having resolved to bring
+about certain emotions in the reader, he makes all subordinate parts
+tend strictly to the common centre. Even his mystery is mathematical
+to his own mind. To him X is a known quantity all along. In any picture
+that he paints he understands the chemical properties of all his
+colors. However vague some of his figures may seem, however formless
+the shadows, to him the outline is as clear and distinct as that of
+a geometrical diagram. For this reason Mr. Poe has no sympathy with
+Mysticism. The Mystic dwells in the mystery, is enveloped with it; it
+colors all his thoughts; it affects his optic nerve especially, and the
+commonest things get a rainbow edging from it. Mr. Poe, on the other
+hand, is a spectator _ab extra_. He analyzes, he dissects, he watches
+
+        “with an eye serene,
+     The very pulse of the machine,”
+
+
+for such it practically is to him, with wheels and cogs and piston-rods,
+all working to produce a certain end.
+
+This analyzing tendency of his mind balances the poetical, and by giving
+him the patience to be minute, enables him to throw a wonderful reality
+into his most unreal fancies. A monomania he paints with great power. He
+loves to dissect one of these cancers of the mind, and to trace all the
+subtle ramifications of its roots. In raising images of horror, also,
+he has strange success, conveying to us sometimes by a dusky hint
+some terrible _doubt _which is the secret of all horror. He leaves to
+imagination the task of finishing the picture, a task to which only she
+is competent.
+
+     “For much imaginary work was there;
+     Conceit deceitful, so compact, so kind,
+     That for Achilles’ image stood his spear
+     Grasped in an armed hand; himself behind
+     Was left unseen, save to the eye of mind.”
+
+Besides the merit of conception, Mr. Poe’s writings have also that of
+form.
+
+His style is highly finished, graceful and truly classical. It would be
+hard to find a living author who had displayed such varied powers. As an
+example of his style we would refer to one of his tales, “The House
+of Usher,” in the first volume of his “Tales of the Grotesque and
+Arabesque.” It has a singular charm for us, and we think that no one
+could read it without being strongly moved by its serene and sombre
+beauty. Had its author written nothing else, it would alone have been
+enough to stamp him as a man of genius, and the master of a classic
+style. In this tale occurs, perhaps, the most beautiful of his poems.
+
+The great masters of imagination have seldom resorted to the vague and
+the unreal as sources of effect. They have not used dread and horror
+alone, but only in combination with other qualities, as means of
+subjugating the fancies of their readers. The loftiest muse has ever a
+household and fireside charm about her. Mr. Poe’s secret lies mainly in
+the skill with which he has employed the strange fascination of mystery
+and terror. In this his success is so great and striking as to deserve
+the name of art, not artifice. We cannot call his materials the noblest
+or purest, but we must concede to him the highest merit of construction.
+
+As a critic, Mr. Poe was aesthetically deficient. Unerring in his
+analysis of dictions, metres and plots, he seemed wanting in the faculty
+of perceiving the profounder ethics of art. His criticisms are, however,
+distinguished for scientific precision and coherence of logic. They
+have the exactness, and at the same time, the coldness of mathematical
+demonstrations. Yet they stand in strikingly refreshing contrast with
+the vague generalisms and sharp personalities of the day. If deficient
+in warmth, they are also without the heat of partisanship. They are
+especially valuable as illustrating the great truth, too generally
+overlooked, that analytic power is a subordinate quality of the critic.
+
+On the whole, it may be considered certain that Mr. Poe has attained an
+individual eminence in our literature which he will keep. He has given
+proof of power and originality. He has done that which could only be
+done once with success or safety, and the imitation or repetition of
+which would produce weariness.
+
+
+
+
+DEATH OF EDGAR A. POE
+
+By N. P. Willis
+
+
+THE ancient fable of two antagonistic spirits imprisoned in one body,
+equally powerful and having the complete mastery by turns-of one man,
+that is to say, inhabited by both a devil and an angel seems to
+have been realized, if all we hear is true, in the character of the
+extraordinary man whose name we have written above. Our own impression
+of the nature of Edgar A. Poe, differs in some important degree,
+however, from that which has been generally conveyed in the notices of
+his death. Let us, before telling what we personally know of him, copy
+a graphic and highly finished portraiture, from the pen of Dr. Rufus W.
+Griswold, which appeared in a recent number of the “Tribune”:
+
+“Edgar Allen Poe is dead. He died in Baltimore on Sunday, October 7th.
+This announcement will startle many, but few will be grieved by it. The
+poet was known, personally or by reputation, in all this country; he had
+readers in England and in several of the states of Continental Europe;
+but he had few or no friends; and the regrets for his death will be
+suggested principally by the consideration that in him literary art has
+lost one of its most brilliant but erratic stars.
+
+“His conversation was at times almost supramortal in its eloquence. His
+voice was modulated with astonishing skill, and his large and variably
+expressive eyes looked repose or shot fiery tumult into theirs who
+listened, while his own face glowed, or was changeless in pallor, as his
+imagination quickened his blood or drew it back frozen to his heart. His
+imagery was from the worlds which no mortals can see but with the vision
+of genius. Suddenly starting from a proposition, exactly and sharply
+defined, in terms of utmost simplicity and clearness, he rejected the
+forms of customary logic, and by a crystalline process of accretion,
+built up his ocular demonstrations in forms of gloomiest and ghastliest
+grandeur, or in those of the most airy and delicious beauty, so minutely
+and distinctly, yet so rapidly, that the attention which was yielded
+to him was chained till it stood among his wonderful creations, till he
+himself dissolved the spell, and brought his hearers back to common
+and base existence, by vulgar fancies or exhibitions of the ignoblest
+passion.
+
+“He was at all times a dreamer dwelling in ideal realms, in heaven or
+hell, peopled with the creatures and the accidents of his brain. He
+walked the streets, in madness or melancholy, with lips moving in
+indistinct curses, or with eyes upturned in passionate prayer (never for
+himself, for he felt, or professed to feel, that he was already damned,
+but) for their happiness who at the moment were objects of his idolatry;
+or with his glances introverted to a heart gnawed with anguish, and with
+a face shrouded in gloom, he would brave the wildest storms, and all
+night, with drenched garments and arms beating the winds and rains,
+would speak as if the spirits that at such times only could be evoked by
+him from the Aidenn, close by whose portals his disturbed soul sought to
+forget the ills to which his constitution subjected him--close by the
+Aidenn where were those he loved--the Aidenn which he might never see,
+but in fitful glimpses, as its gates opened to receive the less fiery
+and more happy natures whose destiny to sin did not involve the doom of
+death.
+
+“He seemed, except when some fitful pursuit subjugated his will and
+engrossed his faculties, always to bear the memory of some controlling
+sorrow. The remarkable poem of ‘The Raven’ was probably much more nearly
+than has been supposed, even by those who were very intimate with him, a
+reflection and an echo of his own history. _He_ was that bird’s
+
+     “‘Unhappy master whom unmerciful Disaster
+     Followed fast and followed faster till his songs one burden bore--
+     Till the dirges of his Hope that melancholy burden bore
+          Of ‘Never-never more.’
+
+
+“Every genuine author in a greater or less degree leaves in his works,
+whatever their design, traces of his personal character: elements of his
+immortal being, in which the individual survives the person. While we
+read the pages of the ‘Fall of the House of Usher,’ or of ‘Mesmeric
+Revelations,’ we see in the solemn and stately gloom which invests one,
+and in the subtle metaphysical analysis of both, indications of the
+idiosyncrasies of what was most remarkable and peculiar in the author’s
+intellectual nature. But we see here only the better phases of his
+nature, only the symbols of his juster action, for his harsh experience
+had deprived him of all faith in man or woman. He had made up his mind
+upon the numberless complexities of the social world, and the whole
+system with him was an imposture. This conviction gave a direction to
+his shrewd and naturally unamiable character. Still, though he regarded
+society as composed altogether of villains, the sharpness of his
+intellect was not of that kind which enabled him to cope with villany,
+while it continually caused him by overshots to fail of the success of
+honesty. He was in many respects like Francis Vivian in Bulwer’s novel
+of ‘The Caxtons.’ Passion, in him, comprehended--many of the worst
+emotions which militate against human happiness. You could not
+contradict him, but you raised quick choler; you could not speak of
+wealth, but his cheek paled with gnawing envy. The astonishing natural
+advantages of this poor boy--his beauty, his readiness, the daring
+spirit that breathed around him like a fiery atmosphere--had raised his
+constitutional self-confidence into an arrogance that turned his
+very claims to admiration into prejudices against him. Irascible,
+envious--bad enough, but not the worst, for these salient angles were
+all varnished over with a cold, repellant cynicism, his passions vented
+themselves in sneers. There seemed to him no moral susceptibility; and,
+what was more remarkable in a proud nature, little or nothing of the
+true point of honor. He had, to a morbid excess, that, desire to rise
+which is vulgarly called ambition, but no wish for the esteem or the
+love of his species; only the hard wish to succeed-not shine, not
+serve--succeed, that he might have the right to despise a world which
+galled his self-conceit.
+
+“We have suggested the influence of his aims and vicissitudes upon his
+literature. It was more conspicuous in his later than in his
+earlier writings. Nearly all that he wrote in the last two or three
+years-including much of his best poetry-was in some sense biographical;
+in draperies of his imagination, those who had taken the trouble to
+trace his steps, could perceive, but slightly concealed, the figure of
+himself.”
+
+Apropos of the disparaging portion of the above well-written sketch, let
+us truthfully say:
+
+Some four or five years since, when editing a daily paper in this
+city, Mr. Poe was employed by us, for several months, as critic and
+sub-editor. This was our first personal acquaintance with him. He
+resided with his wife and mother at Fordham, a few miles out of town,
+but was at his desk in the office, from nine in the morning till the
+evening paper went to press. With the highest admiration for his genius,
+and a willingness to let it atone for more than ordinary irregularity,
+we were led by common report to expect a very capricious attention to
+his duties, and occasionally a scene of violence and difficulty. Time
+went on, however, and he was invariably punctual and industrious. With
+his pale, beautiful, and intellectual face, as a reminder of what genius
+was in him, it was impossible, of course, not to treat him always with
+deferential courtesy, and, to our occasional request that he would not
+probe too deep in a criticism, or that he would erase a passage colored
+too highly with his resentments against society and mankind, he readily
+and courteously assented-far more yielding than most men, we thought,
+on points so excusably sensitive. With a prospect of taking the lead in
+another periodical, he, at last, voluntarily gave up his employment
+with us, and, through all this considerable period, we had seen but
+one presentment of the man-a quiet, patient, industrious, and most
+gentlemanly person, commanding the utmost respect and good feeling by
+his unvarying deportment and ability.
+
+Residing as he did in the country, we never met Mr. Poe in hours of
+leisure; but he frequently called on us afterward at our place of
+business, and we met him often in the street-invariably the same sad
+mannered, winning and refined gentleman, such as we had always known
+him. It was by rumor only, up to the day of his death, that we knew of
+any other development of manner or character. We heard, from one who
+knew him well (what should be stated in all mention of his lamentable
+irregularities), that, with a single glass of wine, his whole nature
+was reversed, the demon became uppermost, and, though none of the
+usual signs of intoxication were visible, his will was palpably insane.
+Possessing his reasoning faculties in excited activity, at such times,
+and seeking his acquaintances with his wonted look and memory, he easily
+seemed personating only another phase of his natural character, and was
+accused, accordingly, of insulting arrogance and bad-heartedness. In
+this reversed character, we repeat, it was never our chance to see him.
+We know it from hearsay, and we mention it in connection with this sad
+infirmity of physical constitution; which puts it upon very nearly the
+ground of a temporary and almost irresponsible insanity.
+
+The arrogance, vanity, and depravity of heart, of which Mr. Poe was
+generally accused, seem to us referable altogether to this reversed
+phase of his character. Under that degree of intoxication which only
+acted upon him by demonizing his sense of truth and right, he doubtless
+said and did much that was wholly irreconcilable with his better nature;
+but, when himself, and as we knew him only, his modesty and unaffected
+humility, as to his own deservings, were a constant charm to his
+character. His letters, of which the constant application for autographs
+has taken from us, we are sorry to confess, the greater portion,
+exhibited this quality very strongly. In one of the carelessly written
+notes of which we chance still to retain possession, for instance, he
+speaks of “The Raven”--that extraordinary poem which electrified the
+world of imaginative readers, and has become the type of a school of
+poetry of its own-and, in evident earnest, attributes its success to
+the few words of commendation with which we had prefaced it in this
+paper.--It will throw light on his sane character to give a literal copy
+of the note:
+
+                                  “FORDHAM, April 20, 1849
+
+
+“My DEAR WILLIS--The poem which I inclose, and which I am so vain as to
+hope you will like, in some respects, has been just published in a paper
+for which sheer necessity compels me to write, now and then. It pays
+well as times go-but unquestionably it ought to pay ten prices; for
+whatever I send it I feel I am consigning to the tomb of the Capulets.
+The verses accompanying this, may I beg you to take out of the tomb, and
+bring them to light in the ‘Home journal?’ If you can oblige me so far
+as to copy them, I do not think it will be necessary to say ‘From the
+----, that would be too bad; and, perhaps, ‘From a late ---- paper,’
+would do.
+
+“I have not forgotten how a ‘good word in season’ from you made ‘The
+Raven,’ and made ‘Ulalume’ (which by-the-way, people have done me the
+honor of attributing to you), therefore, I would ask you (if I dared) to
+say something of these lines if they please you.
+
+                      “Truly yours ever,
+
+                        “EDGAR A. POE.”
+
+
+In double proof of his earnest disposition to do the best for himself,
+and of the trustful and grateful nature which has been denied him, we
+give another of the only three of his notes which we chance to retain:
+
+                          “FORDHAM, January 22, 1848.
+
+
+“My DEAR MR. WILLIS--I am about to make an effort at re-establishing
+myself in the literary world, and _feel _that I may depend upon your
+aid.
+
+“My general aim is to start a Magazine, to be called ‘The Stylus,’ but
+it would be useless to me, even when established, if not entirely out of
+the control of a publisher. I mean, therefore, to get up a journal which
+shall be _my own_ at all points. With this end in view, I must get a
+list of at least five hundred subscribers to begin with; nearly two
+hundred I have already. I propose, however, to go South and West,
+among my personal and literary friends--old college and West Point
+acquaintances--and see what I can do. In order to get the means of
+taking the first step, I propose to lecture at the Society Library,
+on Thursday, the 3d of February, and, that there may be no cause of
+_squabbling_, my subject shall _not be literary _at all. I have chosen a
+broad text: ‘The Universe.’
+
+“Having thus given you _the facts_ of the case, I leave all the rest
+to the suggestions of your own tact and generosity. Gratefully, _most
+gratefully,_
+
+                         _“Your friend always,_
+
+                             _“EDGAR A. POE._”
+
+
+Brief and chance-taken as these letters are, we think they sufficiently
+prove the existence of the very qualities denied to Mr. Poe-humility,
+willingness to persevere, belief in another’s friendship, and capability
+of cordial and grateful friendship! Such he assuredly was when sane.
+Such only he has invariably seemed to us, in all we have happened
+personally to know of him, through a friendship of five or six years.
+And so much easier is it to believe what we have seen and known, than
+what we hear of only, that we remember him but with admiration and
+respect; these descriptions of him, when morally insane, seeming to
+us like portraits, painted in sickness, of a man we have only known in
+health.
+
+But there is another, more touching, and far more forcible evidence that
+there was _goodness _in Edgar A. Poe. To reveal it we are obliged to
+venture upon the lifting of the veil which sacredly covers grief and
+refinement in poverty; but we think it may be excused, if so we can
+brighten the memory of the poet, even were there not a more needed and
+immediate service which it may render to the nearest link broken by his
+death.
+
+Our first knowledge of Mr. Poe’s removal to this city was by a call
+which we received from a lady who introduced herself to us as the mother
+of his wife. She was in search of employment for him, and she excused
+her errand by mentioning that he was ill, that her daughter was a
+confirmed invalid, and that their circumstances were such as compelled
+her taking it upon herself. The countenance of this lady, made beautiful
+and saintly with an evidently complete giving up of her life to
+privation and sorrowful tenderness, her gentle and mournful voice urging
+its plea, her long-forgotten but habitually and unconsciously refined
+manners, and her appealing and yet appreciative mention of the claims
+and abilities of her son, disclosed at once the presence of one of those
+angels upon earth that women in adversity can be. It was a hard fate
+that she was watching over. Mr. Poe wrote with fastidious difficulty,
+and in a style too much above the popular level to be well paid. He was
+always in pecuniary difficulty, and, with his sick wife, frequently in
+want of the merest necessaries of life. Winter after winter, for
+years, the most touching sight to us, in this whole city, has been that
+tireless minister to genius, thinly and insufficiently clad, going from
+office to office with a poem, or an article on some literary subject, to
+sell, sometimes simply pleading in a broken voice that he was ill, and
+begging for him, mentioning nothing but that “he was ill,” whatever
+might be the reason for his writing nothing, and never, amid all her
+tears and recitals of distress, suffering one syllable to escape her
+lips that could convey a doubt of him, or a complaint, or a lessening of
+pride in his genius and good intentions. Her daughter died a year and
+a half since, but she did not desert him. She continued his ministering
+angel--living with him, caring for him, guarding him against exposure,
+and when he was carried away by temptation, amid grief and the
+loneliness of feelings unreplied to, and awoke from his self abandonment
+prostrated in destitution and suffering, _begging _for him still. If
+woman’s devotion, born with a first love, and fed with human passion,
+hallow its object, as it is allowed to do, what does not a devotion
+like this-pure, disinterested and holy as the watch of an invisible
+spirit-say for him who inspired it?
+
+We have a letter before us, written by this lady, Mrs. Clemm, on the
+morning in which she heard of the death of this object of her untiring
+care. It is merely a request that we would call upon her, but we will
+copy a few of its words--sacred as its privacy is--to warrant the truth
+of the picture we have drawn above, and add force to the appeal we wish
+to make for her:
+
+“I have this morning heard of the death of my darling Eddie.... Can you
+give me any circumstances or particulars?... Oh! do not desert your
+poor friend in his bitter affliction!... Ask Mr. ---- to come, as I must
+deliver a message to him from my poor Eddie.... I need not ask you to
+notice his death and to speak well of him. I know you will. But say what
+an affectionate son he was to me, his poor desolate mother...”
+
+To hedge round a grave with respect, what choice is there, between the
+relinquished wealth and honors of the world, and the story of such a
+woman’s unrewarded devotion! Risking what we do, in delicacy, by making
+it public, we feel--other reasons aside--that it betters the world to
+make known that there are such ministrations to its erring and gifted.
+What we have said will speak to some hearts. There are those who will
+be glad to know how the lamp, whose light of poetry has beamed on their
+far-away recognition, was watched over with care and pain, that they
+may send to her, who is more darkened than they by its extinction, some
+token of their sympathy. She is destitute and alone. If any, far or
+near, will send to us what may aid and cheer her through the remainder
+of her life, we will joyfully place it in her hands.
+
+
+
+
+
+THE UNPARALLELED ADVENTURES OF ONE HANS PFAALL (*1)
+
+BY late accounts from Rotterdam, that city seems to be in a high state
+of philosophical excitement. Indeed, phenomena have there occurred of
+a nature so completely unexpected--so entirely novel--so utterly at
+variance with preconceived opinions--as to leave no doubt on my mind
+that long ere this all Europe is in an uproar, all physics in a ferment,
+all reason and astronomy together by the ears.
+
+It appears that on the---- day of---- (I am not positive about the
+date), a vast crowd of people, for purposes not specifically
+mentioned, were assembled in the great square of the Exchange in the
+well-conditioned city of Rotterdam. The day was warm--unusually so for
+the season--there was hardly a breath of air stirring; and the multitude
+were in no bad humor at being now and then besprinkled with friendly
+showers of momentary duration, that fell from large white masses
+of cloud which chequered in a fitful manner the blue vault of the
+firmament. Nevertheless, about noon, a slight but remarkable agitation
+became apparent in the assembly: the clattering of ten thousand tongues
+succeeded; and, in an instant afterward, ten thousand faces were
+upturned toward the heavens, ten thousand pipes descended simultaneously
+from the corners of ten thousand mouths, and a shout, which could be
+compared to nothing but the roaring of Niagara, resounded long, loudly,
+and furiously, through all the environs of Rotterdam.
+
+The origin of this hubbub soon became sufficiently evident. From behind
+the huge bulk of one of those sharply-defined masses of cloud already
+mentioned, was seen slowly to emerge into an open area of blue space, a
+queer, heterogeneous, but apparently solid substance, so oddly shaped,
+so whimsically put together, as not to be in any manner comprehended,
+and never to be sufficiently admired, by the host of sturdy burghers who
+stood open-mouthed below. What could it be? In the name of all the vrows
+and devils in Rotterdam, what could it possibly portend? No one knew, no
+one could imagine; no one--not even the burgomaster Mynheer Superbus Von
+Underduk--had the slightest clew by which to unravel the mystery; so, as
+nothing more reasonable could be done, every one to a man replaced his
+pipe carefully in the corner of his mouth, and cocking up his right
+eye towards the phenomenon, puffed, paused, waddled about, and grunted
+significantly--then waddled back, grunted, paused, and finally--puffed
+again.
+
+In the meantime, however, lower and still lower toward the goodly city,
+came the object of so much curiosity, and the cause of so much smoke. In
+a very few minutes it arrived near enough to be accurately discerned. It
+appeared to be--yes! it was undoubtedly a species of balloon; but surely
+no such balloon had ever been seen in Rotterdam before. For who, let me
+ask, ever heard of a balloon manufactured entirely of dirty newspapers?
+No man in Holland certainly; yet here, under the very noses of the
+people, or rather at some distance above their noses was the identical
+thing in question, and composed, I have it on the best authority, of
+the precise material which no one had ever before known to be used for
+a similar purpose. It was an egregious insult to the good sense of the
+burghers of Rotterdam. As to the shape of the phenomenon, it was even
+still more reprehensible. Being little or nothing better than a huge
+foolscap turned upside down. And this similitude was regarded as by no
+means lessened when, upon nearer inspection, there was perceived a large
+tassel depending from its apex, and, around the upper rim or base of the
+cone, a circle of little instruments, resembling sheep-bells, which kept
+up a continual tinkling to the tune of Betty Martin. But still worse.
+Suspended by blue ribbons to the end of this fantastic machine,
+there hung, by way of car, an enormous drab beaver hat, with a brim
+superlatively broad, and a hemispherical crown with a black band and a
+silver buckle. It is, however, somewhat remarkable that many citizens
+of Rotterdam swore to having seen the same hat repeatedly before; and
+indeed the whole assembly seemed to regard it with eyes of familiarity;
+while the vrow Grettel Pfaall, upon sight of it, uttered an exclamation
+of joyful surprise, and declared it to be the identical hat of her good
+man himself. Now this was a circumstance the more to be observed, as
+Pfaall, with three companions, had actually disappeared from Rotterdam
+about five years before, in a very sudden and unaccountable manner, and
+up to the date of this narrative all attempts had failed of obtaining
+any intelligence concerning them whatsoever. To be sure, some bones
+which were thought to be human, mixed up with a quantity of odd-looking
+rubbish, had been lately discovered in a retired situation to the east
+of Rotterdam, and some people went so far as to imagine that in this
+spot a foul murder had been committed, and that the sufferers were in
+all probability Hans Pfaall and his associates. But to return.
+
+The balloon (for such no doubt it was) had now descended to within
+a hundred feet of the earth, allowing the crowd below a sufficiently
+distinct view of the person of its occupant. This was in truth a very
+droll little somebody. He could not have been more than two feet in
+height; but this altitude, little as it was, would have been sufficient
+to destroy his equilibrium, and tilt him over the edge of his tiny
+car, but for the intervention of a circular rim reaching as high as
+the breast, and rigged on to the cords of the balloon. The body of the
+little man was more than proportionately broad, giving to his entire
+figure a rotundity highly absurd. His feet, of course, could not be seen
+at all, although a horny substance of suspicious nature was occasionally
+protruded through a rent in the bottom of the car, or to speak more
+properly, in the top of the hat. His hands were enormously large. His
+hair was extremely gray, and collected in a cue behind. His nose was
+prodigiously long, crooked, and inflammatory; his eyes full, brilliant,
+and acute; his chin and cheeks, although wrinkled with age, were broad,
+puffy, and double; but of ears of any kind or character there was not a
+semblance to be discovered upon any portion of his head. This odd little
+gentleman was dressed in a loose surtout of sky-blue satin, with tight
+breeches to match, fastened with silver buckles at the knees. His vest
+was of some bright yellow material; a white taffety cap was set jauntily
+on one side of his head; and, to complete his equipment, a blood-red
+silk handkerchief enveloped his throat, and fell down, in a dainty
+manner, upon his bosom, in a fantastic bow-knot of super-eminent
+dimensions.
+
+Having descended, as I said before, to about one hundred feet from the
+surface of the earth, the little old gentleman was suddenly seized
+with a fit of trepidation, and appeared disinclined to make any nearer
+approach to terra firma. Throwing out, therefore, a quantity of sand
+from a canvas bag, which, he lifted with great difficulty, he became
+stationary in an instant. He then proceeded, in a hurried and agitated
+manner, to extract from a side-pocket in his surtout a large morocco
+pocket-book. This he poised suspiciously in his hand, then eyed it with
+an air of extreme surprise, and was evidently astonished at its weight.
+He at length opened it, and drawing there from a huge letter sealed with
+red sealing-wax and tied carefully with red tape, let it fall precisely
+at the feet of the burgomaster, Superbus Von Underduk. His Excellency
+stooped to take it up. But the aeronaut, still greatly discomposed, and
+having apparently no farther business to detain him in Rotterdam, began
+at this moment to make busy preparations for departure; and it being
+necessary to discharge a portion of ballast to enable him to reascend,
+the half dozen bags which he threw out, one after another, without
+taking the trouble to empty their contents, tumbled, every one of them,
+most unfortunately upon the back of the burgomaster, and rolled him over
+and over no less than one-and-twenty times, in the face of every man in
+Rotterdam. It is not to be supposed, however, that the great Underduk
+suffered this impertinence on the part of the little old man to pass off
+with impunity. It is said, on the contrary, that during each and every
+one of his one-and twenty circumvolutions he emitted no less than
+one-and-twenty distinct and furious whiffs from his pipe, to which he
+held fast the whole time with all his might, and to which he intends
+holding fast until the day of his death.
+
+In the meantime the balloon arose like a lark, and, soaring far away
+above the city, at length drifted quietly behind a cloud similar to that
+from which it had so oddly emerged, and was thus lost forever to the
+wondering eyes of the good citizens of Rotterdam. All attention was
+now directed to the letter, the descent of which, and the consequences
+attending thereupon, had proved so fatally subversive of both person and
+personal dignity to his Excellency, the illustrious Burgomaster Mynheer
+Superbus Von Underduk. That functionary, however, had not failed, during
+his circumgyratory movements, to bestow a thought upon the important
+subject of securing the packet in question, which was seen, upon
+inspection, to have fallen into the most proper hands, being actually
+addressed to himself and Professor Rub-a-dub, in their official
+capacities of President and Vice-President of the Rotterdam College of
+Astronomy. It was accordingly opened by those dignitaries upon the
+spot, and found to contain the following extraordinary, and indeed very
+serious, communications.
+
+To their Excellencies Von Underduk and Rub-a-dub, President and
+Vice-President of the States’ College of Astronomers, in the city of
+Rotterdam.
+
+“Your Excellencies may perhaps be able to remember an humble artizan, by
+name Hans Pfaall, and by occupation a mender of bellows, who, with three
+others, disappeared from Rotterdam, about five years ago, in a manner
+which must have been considered by all parties at once sudden, and
+extremely unaccountable. If, however, it so please your Excellencies, I,
+the writer of this communication, am the identical Hans Pfaall himself.
+It is well known to most of my fellow citizens, that for the period of
+forty years I continued to occupy the little square brick building, at
+the head of the alley called Sauerkraut, in which I resided at the time
+of my disappearance. My ancestors have also resided therein time out of
+mind--they, as well as myself, steadily following the respectable and
+indeed lucrative profession of mending of bellows. For, to speak the
+truth, until of late years, that the heads of all the people have been
+set agog with politics, no better business than my own could an
+honest citizen of Rotterdam either desire or deserve. Credit was good,
+employment was never wanting, and on all hands there was no lack of
+either money or good-will. But, as I was saying, we soon began to feel
+the effects of liberty and long speeches, and radicalism, and all that
+sort of thing. People who were formerly, the very best customers in the
+world, had now not a moment of time to think of us at all. They had, so
+they said, as much as they could do to read about the revolutions, and
+keep up with the march of intellect and the spirit of the age. If a fire
+wanted fanning, it could readily be fanned with a newspaper, and as the
+government grew weaker, I have no doubt that leather and iron acquired
+durability in proportion, for, in a very short time, there was not a
+pair of bellows in all Rotterdam that ever stood in need of a stitch or
+required the assistance of a hammer. This was a state of things not
+to be endured. I soon grew as poor as a rat, and, having a wife and
+children to provide for, my burdens at length became intolerable, and I
+spent hour after hour in reflecting upon the most convenient method of
+putting an end to my life. Duns, in the meantime, left me little leisure
+for contemplation. My house was literally besieged from morning till
+night, so that I began to rave, and foam, and fret like a caged
+tiger against the bars of his enclosure. There were three fellows in
+particular who worried me beyond endurance, keeping watch continually
+about my door, and threatening me with the law. Upon these three I
+internally vowed the bitterest revenge, if ever I should be so happy as
+to get them within my clutches; and I believe nothing in the world but
+the pleasure of this anticipation prevented me from putting my plan
+of suicide into immediate execution, by blowing my brains out with a
+blunderbuss. I thought it best, however, to dissemble my wrath, and to
+treat them with promises and fair words, until, by some good turn of
+fate, an opportunity of vengeance should be afforded me.
+
+“One day, having given my creditors the slip, and feeling more than
+usually dejected, I continued for a long time to wander about the most
+obscure streets without object whatever, until at length I chanced to
+stumble against the corner of a bookseller’s stall. Seeing a chair close
+at hand, for the use of customers, I threw myself doggedly into it,
+and, hardly knowing why, opened the pages of the first volume which
+came within my reach. It proved to be a small pamphlet treatise on
+Speculative Astronomy, written either by Professor Encke of Berlin or
+by a Frenchman of somewhat similar name. I had some little tincture of
+information on matters of this nature, and soon became more and more
+absorbed in the contents of the book, reading it actually through twice
+before I awoke to a recollection of what was passing around me. By this
+time it began to grow dark, and I directed my steps toward home. But
+the treatise had made an indelible impression on my mind, and, as I
+sauntered along the dusky streets, I revolved carefully over in my
+memory the wild and sometimes unintelligible reasonings of the writer.
+There are some particular passages which affected my imagination in a
+powerful and extraordinary manner. The longer I meditated upon these
+the more intense grew the interest which had been excited within me.
+The limited nature of my education in general, and more especially my
+ignorance on subjects connected with natural philosophy, so far from
+rendering me diffident of my own ability to comprehend what I had read,
+or inducing me to mistrust the many vague notions which had arisen in
+consequence, merely served as a farther stimulus to imagination; and I
+was vain enough, or perhaps reasonable enough, to doubt whether
+those crude ideas which, arising in ill-regulated minds, have all the
+appearance, may not often in effect possess all the force, the reality,
+and other inherent properties, of instinct or intuition; whether, to
+proceed a step farther, profundity itself might not, in matters of a
+purely speculative nature, be detected as a legitimate source of falsity
+and error. In other words, I believed, and still do believe, that truth,
+is frequently of its own essence, superficial, and that, in many cases,
+the depth lies more in the abysses where we seek her, than in the actual
+situations wherein she may be found. Nature herself seemed to afford
+me corroboration of these ideas. In the contemplation of the heavenly
+bodies it struck me forcibly that I could not distinguish a star with
+nearly as much precision, when I gazed on it with earnest, direct and
+undeviating attention, as when I suffered my eye only to glance in
+its vicinity alone. I was not, of course, at that time aware that this
+apparent paradox was occasioned by the center of the visual area being
+less susceptible of feeble impressions of light than the exterior
+portions of the retina. This knowledge, and some of another kind, came
+afterwards in the course of an eventful five years, during which I
+have dropped the prejudices of my former humble situation in life, and
+forgotten the bellows-mender in far different occupations. But at the
+epoch of which I speak, the analogy which a casual observation of a star
+offered to the conclusions I had already drawn, struck me with the force
+of positive conformation, and I then finally made up my mind to the
+course which I afterwards pursued.
+
+“It was late when I reached home, and I went immediately to bed. My
+mind, however, was too much occupied to sleep, and I lay the whole night
+buried in meditation. Arising early in the morning, and contriving
+again to escape the vigilance of my creditors, I repaired eagerly to the
+bookseller’s stall, and laid out what little ready money I possessed,
+in the purchase of some volumes of Mechanics and Practical Astronomy.
+Having arrived at home safely with these, I devoted every spare moment
+to their perusal, and soon made such proficiency in studies of this
+nature as I thought sufficient for the execution of my plan. In the
+intervals of this period, I made every endeavor to conciliate the
+three creditors who had given me so much annoyance. In this I finally
+succeeded--partly by selling enough of my household furniture to satisfy
+a moiety of their claim, and partly by a promise of paying the balance
+upon completion of a little project which I told them I had in view, and
+for assistance in which I solicited their services. By these means--for
+they were ignorant men--I found little difficulty in gaining them over
+to my purpose.
+
+“Matters being thus arranged, I contrived, by the aid of my wife and
+with the greatest secrecy and caution, to dispose of what property I had
+remaining, and to borrow, in small sums, under various pretences,
+and without paying any attention to my future means of repayment, no
+inconsiderable quantity of ready money. With the means thus accruing I
+proceeded to procure at intervals, cambric muslin, very fine, in pieces
+of twelve yards each; twine; a lot of the varnish of caoutchouc; a
+large and deep basket of wicker-work, made to order; and several other
+articles necessary in the construction and equipment of a balloon of
+extraordinary dimensions. This I directed my wife to make up as soon as
+possible, and gave her all requisite information as to the particular
+method of proceeding. In the meantime I worked up the twine into
+a net-work of sufficient dimensions; rigged it with a hoop and the
+necessary cords; bought a quadrant, a compass, a spy-glass, a common
+barometer with some important modifications, and two astronomical
+instruments not so generally known. I then took opportunities of
+conveying by night, to a retired situation east of Rotterdam, five
+iron-bound casks, to contain about fifty gallons each, and one of a
+larger size; six tinned ware tubes, three inches in diameter, properly
+shaped, and ten feet in length; a quantity of a particular metallic
+substance, or semi-metal, which I shall not name, and a dozen demijohns
+of a very common acid. The gas to be formed from these latter materials
+is a gas never yet generated by any other person than myself--or at
+least never applied to any similar purpose. The secret I would make no
+difficulty in disclosing, but that it of right belongs to a citizen of
+Nantz, in France, by whom it was conditionally communicated to myself.
+The same individual submitted to me, without being at all aware of my
+intentions, a method of constructing balloons from the membrane of a
+certain animal, through which substance any escape of gas was nearly an
+impossibility. I found it, however, altogether too expensive, and was
+not sure, upon the whole, whether cambric muslin with a coating of
+gum caoutchouc, was not equally as good. I mention this circumstance,
+because I think it probable that hereafter the individual in question
+may attempt a balloon ascension with the novel gas and material I have
+spoken of, and I do not wish to deprive him of the honor of a very
+singular invention.
+
+“On the spot which I intended each of the smaller casks to occupy
+respectively during the inflation of the balloon, I privately dug a hole
+two feet deep; the holes forming in this manner a circle twenty-five
+feet in diameter. In the centre of this circle, being the station
+designed for the large cask, I also dug a hole three feet in depth. In
+each of the five smaller holes, I deposited a canister containing
+fifty pounds, and in the larger one a keg holding one hundred and fifty
+pounds, of cannon powder. These--the keg and canisters--I connected in
+a proper manner with covered trains; and having let into one of the
+canisters the end of about four feet of slow match, I covered up the
+hole, and placed the cask over it, leaving the other end of the match
+protruding about an inch, and barely visible beyond the cask. I then
+filled up the remaining holes, and placed the barrels over them in their
+destined situation.
+
+“Besides the articles above enumerated, I conveyed to the depot, and
+there secreted, one of M. Grimm’s improvements upon the apparatus for
+condensation of the atmospheric air. I found this machine, however,
+to require considerable alteration before it could be adapted to the
+purposes to which I intended making it applicable. But, with severe
+labor and unremitting perseverance, I at length met with entire success
+in all my preparations. My balloon was soon completed. It would contain
+more than forty thousand cubic feet of gas; would take me up easily, I
+calculated, with all my implements, and, if I managed rightly, with
+one hundred and seventy-five pounds of ballast into the bargain. It
+had received three coats of varnish, and I found the cambric muslin to
+answer all the purposes of silk itself, quite as strong and a good deal
+less expensive.
+
+“Everything being now ready, I exacted from my wife an oath of secrecy
+in relation to all my actions from the day of my first visit to the
+bookseller’s stall; and promising, on my part, to return as soon as
+circumstances would permit, I gave her what little money I had left,
+and bade her farewell. Indeed I had no fear on her account. She was
+what people call a notable woman, and could manage matters in the world
+without my assistance. I believe, to tell the truth, she always looked
+upon me as an idle boy, a mere make-weight, good for nothing but
+building castles in the air, and was rather glad to get rid of me.
+It was a dark night when I bade her good-bye, and taking with me, as
+aides-de-camp, the three creditors who had given me so much trouble,
+we carried the balloon, with the car and accoutrements, by a roundabout
+way, to the station where the other articles were deposited. We there
+found them all unmolested, and I proceeded immediately to business.
+
+“It was the first of April. The night, as I said before, was dark; there
+was not a star to be seen; and a drizzling rain, falling at intervals,
+rendered us very uncomfortable. But my chief anxiety was concerning
+the balloon, which, in spite of the varnish with which it was defended,
+began to grow rather heavy with the moisture; the powder also was liable
+to damage. I therefore kept my three duns working with great diligence,
+pounding down ice around the central cask, and stirring the acid in the
+others. They did not cease, however, importuning me with questions as
+to what I intended to do with all this apparatus, and expressed much
+dissatisfaction at the terrible labor I made them undergo. They could
+not perceive, so they said, what good was likely to result from
+their getting wet to the skin, merely to take a part in such horrible
+incantations. I began to get uneasy, and worked away with all my might,
+for I verily believe the idiots supposed that I had entered into a
+compact with the devil, and that, in short, what I was now doing was
+nothing better than it should be. I was, therefore, in great fear of
+their leaving me altogether. I contrived, however, to pacify them by
+promises of payment of all scores in full, as soon as I could bring
+the present business to a termination. To these speeches they gave, of
+course, their own interpretation; fancying, no doubt, that at all events
+I should come into possession of vast quantities of ready money; and
+provided I paid them all I owed, and a trifle more, in consideration of
+their services, I dare say they cared very little what became of either
+my soul or my carcass.
+
+“In about four hours and a half I found the balloon sufficiently
+inflated. I attached the car, therefore, and put all my implements in
+it--not forgetting the condensing apparatus, a copious supply of water,
+and a large quantity of provisions, such as pemmican, in which much
+nutriment is contained in comparatively little bulk. I also secured in
+the car a pair of pigeons and a cat. It was now nearly daybreak, and I
+thought it high time to take my departure. Dropping a lighted cigar on
+the ground, as if by accident, I took the opportunity, in stooping to
+pick it up, of igniting privately the piece of slow match, whose end,
+as I said before, protruded a very little beyond the lower rim of one of
+the smaller casks. This manoeuvre was totally unperceived on the part of
+the three duns; and, jumping into the car, I immediately cut the single
+cord which held me to the earth, and was pleased to find that I shot
+upward, carrying with all ease one hundred and seventy-five pounds of
+leaden ballast, and able to have carried up as many more.
+
+“Scarcely, however, had I attained the height of fifty yards, when,
+roaring and rumbling up after me in the most horrible and tumultuous
+manner, came so dense a hurricane of fire, and smoke, and sulphur, and
+legs and arms, and gravel, and burning wood, and blazing metal, that
+my very heart sunk within me, and I fell down in the bottom of the car,
+trembling with unmitigated terror. Indeed, I now perceived that I had
+entirely overdone the business, and that the main consequences of the
+shock were yet to be experienced. Accordingly, in less than a second,
+I felt all the blood in my body rushing to my temples, and immediately
+thereupon, a concussion, which I shall never forget, burst abruptly
+through the night and seemed to rip the very firmament asunder. When
+I afterward had time for reflection, I did not fail to attribute the
+extreme violence of the explosion, as regarded myself, to its proper
+cause--my situation directly above it, and in the line of its greatest
+power. But at the time, I thought only of preserving my life. The
+balloon at first collapsed, then furiously expanded, then whirled round
+and round with horrible velocity, and finally, reeling and staggering
+like a drunken man, hurled me with great force over the rim of the car,
+and left me dangling, at a terrific height, with my head downward, and
+my face outwards, by a piece of slender cord about three feet in
+length, which hung accidentally through a crevice near the bottom of
+the wicker-work, and in which, as I fell, my left foot became most
+providentially entangled. It is impossible--utterly impossible--to form
+any adequate idea of the horror of my situation. I gasped convulsively
+for breath--a shudder resembling a fit of the ague agitated every nerve
+and muscle of my frame--I felt my eyes starting from their sockets--a
+horrible nausea overwhelmed me--and at length I fainted away.
+
+“How long I remained in this state it is impossible to say. It must,
+however, have been no inconsiderable time, for when I partially
+recovered the sense of existence, I found the day breaking, the balloon
+at a prodigious height over a wilderness of ocean, and not a trace
+of land to be discovered far and wide within the limits of the vast
+horizon. My sensations, however, upon thus recovering, were by no means
+so rife with agony as might have been anticipated. Indeed, there was
+much of incipient madness in the calm survey which I began to take of my
+situation. I drew up to my eyes each of my hands, one after the other,
+and wondered what occurrence could have given rise to the swelling of
+the veins, and the horrible blackness of the fingernails. I afterward
+carefully examined my head, shaking it repeatedly, and feeling it with
+minute attention, until I succeeded in satisfying myself that it was
+not, as I had more than half suspected, larger than my balloon. Then,
+in a knowing manner, I felt in both my breeches pockets, and, missing
+therefrom a set of tablets and a toothpick case, endeavored to account
+for their disappearance, and not being able to do so, felt inexpressibly
+chagrined. It now occurred to me that I suffered great uneasiness in the
+joint of my left ankle, and a dim consciousness of my situation began to
+glimmer through my mind. But, strange to say! I was neither astonished
+nor horror-stricken. If I felt any emotion at all, it was a kind of
+chuckling satisfaction at the cleverness I was about to display in
+extricating myself from this dilemma; and I never, for a moment, looked
+upon my ultimate safety as a question susceptible of doubt. For a few
+minutes I remained wrapped in the profoundest meditation. I have a
+distinct recollection of frequently compressing my lips, putting
+my forefinger to the side of my nose, and making use of other
+gesticulations and grimaces common to men who, at ease in their
+arm-chairs, meditate upon matters of intricacy or importance. Having,
+as I thought, sufficiently collected my ideas, I now, with great caution
+and deliberation, put my hands behind my back, and unfastened the large
+iron buckle which belonged to the waistband of my inexpressibles. This
+buckle had three teeth, which, being somewhat rusty, turned with great
+difficulty on their axis. I brought them, however, after some trouble,
+at right angles to the body of the buckle, and was glad to find them
+remain firm in that position. Holding the instrument thus obtained
+within my teeth, I now proceeded to untie the knot of my cravat. I had
+to rest several times before I could accomplish this manoeuvre, but it
+was at length accomplished. To one end of the cravat I then made fast
+the buckle, and the other end I tied, for greater security, tightly
+around my wrist. Drawing now my body upwards, with a prodigious exertion
+of muscular force, I succeeded, at the very first trial, in throwing
+the buckle over the car, and entangling it, as I had anticipated, in the
+circular rim of the wicker-work.
+
+“My body was now inclined towards the side of the car, at an angle
+of about forty-five degrees; but it must not be understood that I was
+therefore only forty-five degrees below the perpendicular. So far from
+it, I still lay nearly level with the plane of the horizon; for the
+change of situation which I had acquired, had forced the bottom of the
+car considerably outwards from my position, which was accordingly one
+of the most imminent and deadly peril. It should be remembered, however,
+that when I fell in the first instance, from the car, if I had fallen
+with my face turned toward the balloon, instead of turned outwardly from
+it, as it actually was; or if, in the second place, the cord by which
+I was suspended had chanced to hang over the upper edge, instead of
+through a crevice near the bottom of the car,--I say it may be readily
+conceived that, in either of these supposed cases, I should have been
+unable to accomplish even as much as I had now accomplished, and the
+wonderful adventures of Hans Pfaall would have been utterly lost to
+posterity, I had therefore every reason to be grateful; although, in
+point of fact, I was still too stupid to be anything at all, and hung
+for, perhaps, a quarter of an hour in that extraordinary manner, without
+making the slightest farther exertion whatsoever, and in a singularly
+tranquil state of idiotic enjoyment. But this feeling did not fail to
+die rapidly away, and thereunto succeeded horror, and dismay, and a
+chilling sense of utter helplessness and ruin. In fact, the blood so
+long accumulating in the vessels of my head and throat, and which had
+hitherto buoyed up my spirits with madness and delirium, had now begun
+to retire within their proper channels, and the distinctness which was
+thus added to my perception of the danger, merely served to deprive me
+of the self-possession and courage to encounter it. But this weakness
+was, luckily for me, of no very long duration. In good time came to my
+rescue the spirit of despair, and, with frantic cries and struggles, I
+jerked my way bodily upwards, till at length, clutching with a vise-like
+grip the long-desired rim, I writhed my person over it, and fell
+headlong and shuddering within the car.
+
+“It was not until some time afterward that I recovered myself
+sufficiently to attend to the ordinary cares of the balloon. I then,
+however, examined it with attention, and found it, to my great relief,
+uninjured. My implements were all safe, and, fortunately, I had lost
+neither ballast nor provisions. Indeed, I had so well secured them in
+their places, that such an accident was entirely out of the question.
+Looking at my watch, I found it six o’clock. I was still rapidly
+ascending, and my barometer gave a present altitude of three and
+three-quarter miles. Immediately beneath me in the ocean, lay a small
+black object, slightly oblong in shape, seemingly about the size, and
+in every way bearing a great resemblance to one of those childish
+toys called a domino. Bringing my telescope to bear upon it, I plainly
+discerned it to be a British ninety four-gun ship, close-hauled, and
+pitching heavily in the sea with her head to the W.S.W. Besides this
+ship, I saw nothing but the ocean and the sky, and the sun, which had
+long arisen.
+
+“It is now high time that I should explain to your Excellencies the
+object of my perilous voyage. Your Excellencies will bear in mind that
+distressed circumstances in Rotterdam had at length driven me to the
+resolution of committing suicide. It was not, however, that to life
+itself I had any, positive disgust, but that I was harassed beyond
+endurance by the adventitious miseries attending my situation. In this
+state of mind, wishing to live, yet wearied with life, the treatise at
+the stall of the bookseller opened a resource to my imagination. I then
+finally made up my mind. I determined to depart, yet live--to leave the
+world, yet continue to exist--in short, to drop enigmas, I resolved, let
+what would ensue, to force a passage, if I could, to the moon. Now, lest
+I should be supposed more of a madman than I actually am, I will detail,
+as well as I am able, the considerations which led me to believe that
+an achievement of this nature, although without doubt difficult, and
+incontestably full of danger, was not absolutely, to a bold spirit,
+beyond the confines of the possible.
+
+“The moon’s actual distance from the earth was the first thing to be
+attended to. Now, the mean or average interval between the centres of
+the two planets is 59.9643 of the earth’s equatorial radii, or only
+about 237,000 miles. I say the mean or average interval. But it must
+be borne in mind that the form of the moon’s orbit being an ellipse of
+eccentricity amounting to no less than 0.05484 of the major semi-axis of
+the ellipse itself, and the earth’s centre being situated in its focus,
+if I could, in any manner, contrive to meet the moon, as it were, in its
+perigee, the above mentioned distance would be materially diminished.
+But, to say nothing at present of this possibility, it was very certain
+that, at all events, from the 237,000 miles I would have to deduct the
+radius of the earth, say 4,000, and the radius of the moon, say 1080,
+in all 5,080, leaving an actual interval to be traversed, under average
+circumstances, of 231,920 miles. Now this, I reflected, was no
+very extraordinary distance. Travelling on land has been repeatedly
+accomplished at the rate of thirty miles per hour, and indeed a much
+greater speed may be anticipated. But even at this velocity, it would
+take me no more than 322 days to reach the surface of the moon. There
+were, however, many particulars inducing me to believe that my average
+rate of travelling might possibly very much exceed that of thirty miles
+per hour, and, as these considerations did not fail to make a deep
+impression upon my mind, I will mention them more fully hereafter.
+
+“The next point to be regarded was a matter of far greater importance.
+From indications afforded by the barometer, we find that, in ascensions
+from the surface of the earth we have, at the height of 1,000 feet, left
+below us about one-thirtieth of the entire mass of atmospheric air, that
+at 10,600 we have ascended through nearly one-third; and that at 18,000,
+which is not far from the elevation of Cotopaxi, we have surmounted
+one-half the material, or, at all events, one-half the ponderable,
+body of air incumbent upon our globe. It is also calculated that at an
+altitude not exceeding the hundredth part of the earth’s diameter--that
+is, not exceeding eighty miles--the rarefaction would be so excessive
+that animal life could in no manner be sustained, and, moreover, that
+the most delicate means we possess of ascertaining the presence of the
+atmosphere would be inadequate to assure us of its existence. But I
+did not fail to perceive that these latter calculations are founded
+altogether on our experimental knowledge of the properties of air, and
+the mechanical laws regulating its dilation and compression, in what may
+be called, comparatively speaking, the immediate vicinity of the earth
+itself; and, at the same time, it is taken for granted that animal
+life is and must be essentially incapable of modification at any given
+unattainable distance from the surface. Now, all such reasoning and from
+such data must, of course, be simply analogical. The greatest height
+ever reached by man was that of 25,000 feet, attained in the aeronautic
+expedition of Messieurs Gay-Lussac and Biot. This is a moderate
+altitude, even when compared with the eighty miles in question; and I
+could not help thinking that the subject admitted room for doubt and
+great latitude for speculation.
+
+“But, in point of fact, an ascension being made to any given altitude,
+the ponderable quantity of air surmounted in any farther ascension is
+by no means in proportion to the additional height ascended (as may
+be plainly seen from what has been stated before), but in a ratio
+constantly decreasing. It is therefore evident that, ascend as high as
+we may, we cannot, literally speaking, arrive at a limit beyond which
+no atmosphere is to be found. It must exist, I argued; although it may
+exist in a state of infinite rarefaction.
+
+“On the other hand, I was aware that arguments have not been wanting
+to prove the existence of a real and definite limit to the atmosphere,
+beyond which there is absolutely no air whatsoever. But a circumstance
+which has been left out of view by those who contend for such a limit
+seemed to me, although no positive refutation of their creed, still
+a point worthy very serious investigation. On comparing the intervals
+between the successive arrivals of Encke’s comet at its perihelion,
+after giving credit, in the most exact manner, for all the disturbances
+due to the attractions of the planets, it appears that the periods are
+gradually diminishing; that is to say, the major axis of the comet’s
+ellipse is growing shorter, in a slow but perfectly regular decrease.
+Now, this is precisely what ought to be the case, if we suppose a
+resistance experienced from the comet from an extremely rare ethereal
+medium pervading the regions of its orbit. For it is evident that such
+a medium must, in retarding the comet’s velocity, increase its
+centripetal, by weakening its centrifugal force. In other words, the
+sun’s attraction would be constantly attaining greater power, and the
+comet would be drawn nearer at every revolution. Indeed, there is no
+other way of accounting for the variation in question. But again. The
+real diameter of the same comet’s nebulosity is observed to contract
+rapidly as it approaches the sun, and dilate with equal rapidity in its
+departure towards its aphelion. Was I not justifiable in supposing with
+M. Valz, that this apparent condensation of volume has its origin in
+the compression of the same ethereal medium I have spoken of before,
+and which is only denser in proportion to its solar vicinity? The
+lenticular-shaped phenomenon, also called the zodiacal light, was a
+matter worthy of attention. This radiance, so apparent in the tropics,
+and which cannot be mistaken for any meteoric lustre, extends from the
+horizon obliquely upward, and follows generally the direction of the
+sun’s equator. It appeared to me evidently in the nature of a rare
+atmosphere extending from the sun outward, beyond the orbit of Venus at
+least, and I believed indefinitely farther.(*2) Indeed, this medium I
+could not suppose confined to the path of the comet’s ellipse, or to
+the immediate neighborhood of the sun. It was easy, on the contrary,
+to imagine it pervading the entire regions of our planetary system,
+condensed into what we call atmosphere at the planets themselves, and
+perhaps at some of them modified by considerations, so to speak, purely
+geological.
+
+“Having adopted this view of the subject, I had little further
+hesitation. Granting that on my passage I should meet with atmosphere
+essentially the same as at the surface of the earth, I conceived that,
+by means of the very ingenious apparatus of M. Grimm, I should readily
+be enabled to condense it in sufficient quantity for the purposes of
+respiration. This would remove the chief obstacle in a journey to the
+moon. I had indeed spent some money and great labor in adapting the
+apparatus to the object intended, and confidently looked forward to its
+successful application, if I could manage to complete the voyage within
+any reasonable period. This brings me back to the rate at which it might
+be possible to travel.
+
+“It is true that balloons, in the first stage of their ascensions from
+the earth, are known to rise with a velocity comparatively moderate.
+Now, the power of elevation lies altogether in the superior lightness of
+the gas in the balloon compared with the atmospheric air; and, at
+first sight, it does not appear probable that, as the balloon acquires
+altitude, and consequently arrives successively in atmospheric strata
+of densities rapidly diminishing--I say, it does not appear at all
+reasonable that, in this its progress upwards, the original velocity
+should be accelerated. On the other hand, I was not aware that, in any
+recorded ascension, a diminution was apparent in the absolute rate
+of ascent; although such should have been the case, if on account
+of nothing else, on account of the escape of gas through balloons
+ill-constructed, and varnished with no better material than the ordinary
+varnish. It seemed, therefore, that the effect of such escape was only
+sufficient to counterbalance the effect of some accelerating power. I
+now considered that, provided in my passage I found the medium I
+had imagined, and provided that it should prove to be actually
+and essentially what we denominate atmospheric air, it could make
+comparatively little difference at what extreme state of rarefaction
+I should discover it--that is to say, in regard to my power of
+ascending--for the gas in the balloon would not only be itself subject
+to rarefaction partially similar (in proportion to the occurrence of
+which, I could suffer an escape of so much as would be requisite to
+prevent explosion), but, being what it was, would, at all events,
+continue specifically lighter than any compound whatever of mere
+nitrogen and oxygen. In the meantime, the force of gravitation would be
+constantly diminishing, in proportion to the squares of the distances,
+and thus, with a velocity prodigiously accelerating, I should at
+length arrive in those distant regions where the force of the earth’s
+attraction would be superseded by that of the moon. In accordance with
+these ideas, I did not think it worth while to encumber myself with more
+provisions than would be sufficient for a period of forty days.
+
+“There was still, however, another difficulty, which occasioned me some
+little disquietude. It has been observed, that, in balloon ascensions to
+any considerable height, besides the pain attending respiration, great
+uneasiness is experienced about the head and body, often accompanied
+with bleeding at the nose, and other symptoms of an alarming kind,
+and growing more and more inconvenient in proportion to the altitude
+attained.(*3) This was a reflection of a nature somewhat startling. Was
+it not probable that these symptoms would increase indefinitely, or at
+least until terminated by death itself? I finally thought not. Their
+origin was to be looked for in the progressive removal of the customary
+atmospheric pressure upon the surface of the body, and consequent
+distention of the superficial blood-vessels--not in any positive
+disorganization of the animal system, as in the case of difficulty in
+breathing, where the atmospheric density is chemically insufficient
+for the due renovation of blood in a ventricle of the heart. Unless for
+default of this renovation, I could see no reason, therefore, why
+life could not be sustained even in a vacuum; for the expansion and
+compression of chest, commonly called breathing, is action purely
+muscular, and the cause, not the effect, of respiration. In a word,
+I conceived that, as the body should become habituated to the want
+of atmospheric pressure, the sensations of pain would gradually
+diminish--and to endure them while they continued, I relied with
+confidence upon the iron hardihood of my constitution.
+
+“Thus, may it please your Excellencies, I have detailed some, though by
+no means all, the considerations which led me to form the project of
+a lunar voyage. I shall now proceed to lay before you the result of an
+attempt so apparently audacious in conception, and, at all events, so
+utterly unparalleled in the annals of mankind.
+
+“Having attained the altitude before mentioned, that is to say three
+miles and three-quarters, I threw out from the car a quantity of
+feathers, and found that I still ascended with sufficient rapidity;
+there was, therefore, no necessity for discharging any ballast. I was
+glad of this, for I wished to retain with me as much weight as I could
+carry, for reasons which will be explained in the sequel. I as yet
+suffered no bodily inconvenience, breathing with great freedom, and
+feeling no pain whatever in the head. The cat was lying very demurely
+upon my coat, which I had taken off, and eyeing the pigeons with an air
+of nonchalance. These latter being tied by the leg, to prevent their
+escape, were busily employed in picking up some grains of rice scattered
+for them in the bottom of the car.
+
+“At twenty minutes past six o’clock, the barometer showed an elevation
+of 26,400 feet, or five miles to a fraction. The prospect seemed
+unbounded. Indeed, it is very easily calculated by means of spherical
+geometry, what a great extent of the earth’s area I beheld. The convex
+surface of any segment of a sphere is, to the entire surface of the
+sphere itself, as the versed sine of the segment to the diameter of the
+sphere. Now, in my case, the versed sine--that is to say, the thickness
+of the segment beneath me--was about equal to my elevation, or the
+elevation of the point of sight above the surface. ‘As five miles, then,
+to eight thousand,’ would express the proportion of the earth’s area
+seen by me. In other words, I beheld as much as a sixteen-hundredth
+part of the whole surface of the globe. The sea appeared unruffled as a
+mirror, although, by means of the spy-glass, I could perceive it to be
+in a state of violent agitation. The ship was no longer visible, having
+drifted away, apparently to the eastward. I now began to experience, at
+intervals, severe pain in the head, especially about the ears--still,
+however, breathing with tolerable freedom. The cat and pigeons seemed to
+suffer no inconvenience whatsoever.
+
+“At twenty minutes before seven, the balloon entered a long series of
+dense cloud, which put me to great trouble, by damaging my condensing
+apparatus and wetting me to the skin. This was, to be sure, a singular
+recontre, for I had not believed it possible that a cloud of this nature
+could be sustained at so great an elevation. I thought it best, however,
+to throw out two five-pound pieces of ballast, reserving still a weight
+of one hundred and sixty-five pounds. Upon so doing, I soon rose above
+the difficulty, and perceived immediately, that I had obtained a great
+increase in my rate of ascent. In a few seconds after my leaving the
+cloud, a flash of vivid lightning shot from one end of it to the other,
+and caused it to kindle up, throughout its vast extent, like a mass of
+ignited and glowing charcoal. This, it must be remembered, was in the
+broad light of day. No fancy may picture the sublimity which might have
+been exhibited by a similar phenomenon taking place amid the darkness of
+the night. Hell itself might have been found a fitting image. Even as
+it was, my hair stood on end, while I gazed afar down within the yawning
+abysses, letting imagination descend, as it were, and stalk about in the
+strange vaulted halls, and ruddy gulfs, and red ghastly chasms of the
+hideous and unfathomable fire. I had indeed made a narrow escape. Had
+the balloon remained a very short while longer within the cloud--that
+is to say--had not the inconvenience of getting wet, determined me to
+discharge the ballast, inevitable ruin would have been the consequence.
+Such perils, although little considered, are perhaps the greatest which
+must be encountered in balloons. I had by this time, however, attained
+too great an elevation to be any longer uneasy on this head.
+
+“I was now rising rapidly, and by seven o’clock the barometer indicated
+an altitude of no less than nine miles and a half. I began to find great
+difficulty in drawing my breath. My head, too, was excessively painful;
+and, having felt for some time a moisture about my cheeks, I at length
+discovered it to be blood, which was oozing quite fast from the drums of
+my ears. My eyes, also, gave me great uneasiness. Upon passing the
+hand over them they seemed to have protruded from their sockets in no
+inconsiderable degree; and all objects in the car, and even the balloon
+itself, appeared distorted to my vision. These symptoms were more than
+I had expected, and occasioned me some alarm. At this juncture, very
+imprudently, and without consideration, I threw out from the car three
+five-pound pieces of ballast. The accelerated rate of ascent thus
+obtained, carried me too rapidly, and without sufficient gradation, into
+a highly rarefied stratum of the atmosphere, and the result had nearly
+proved fatal to my expedition and to myself. I was suddenly seized with
+a spasm which lasted for more than five minutes, and even when this, in
+a measure, ceased, I could catch my breath only at long intervals, and
+in a gasping manner--bleeding all the while copiously at the nose and
+ears, and even slightly at the eyes. The pigeons appeared distressed
+in the extreme, and struggled to escape; while the cat mewed piteously,
+and, with her tongue hanging out of her mouth, staggered to and fro in
+the car as if under the influence of poison. I now too late discovered
+the great rashness of which I had been guilty in discharging the
+ballast, and my agitation was excessive. I anticipated nothing less than
+death, and death in a few minutes. The physical suffering I underwent
+contributed also to render me nearly incapable of making any exertion
+for the preservation of my life. I had, indeed, little power of
+reflection left, and the violence of the pain in my head seemed to be
+greatly on the increase. Thus I found that my senses would shortly give
+way altogether, and I had already clutched one of the valve ropes with
+the view of attempting a descent, when the recollection of the trick I
+had played the three creditors, and the possible consequences to myself,
+should I return, operated to deter me for the moment. I lay down in the
+bottom of the car, and endeavored to collect my faculties. In this I
+so far succeeded as to determine upon the experiment of losing blood.
+Having no lancet, however, I was constrained to perform the operation in
+the best manner I was able, and finally succeeded in opening a vein
+in my right arm, with the blade of my penknife. The blood had hardly
+commenced flowing when I experienced a sensible relief, and by the time
+I had lost about half a moderate basin full, most of the worst symptoms
+had abandoned me entirely. I nevertheless did not think it expedient to
+attempt getting on my feet immediately; but, having tied up my arm as
+well as I could, I lay still for about a quarter of an hour. At the end
+of this time I arose, and found myself freer from absolute pain of any
+kind than I had been during the last hour and a quarter of my ascension.
+The difficulty of breathing, however, was diminished in a very slight
+degree, and I found that it would soon be positively necessary to make
+use of my condenser. In the meantime, looking toward the cat, who was
+again snugly stowed away upon my coat, I discovered to my infinite
+surprise, that she had taken the opportunity of my indisposition to
+bring into light a litter of three little kittens. This was an addition
+to the number of passengers on my part altogether unexpected; but I was
+pleased at the occurrence. It would afford me a chance of bringing to a
+kind of test the truth of a surmise, which, more than anything else,
+had influenced me in attempting this ascension. I had imagined that the
+habitual endurance of the atmospheric pressure at the surface of
+the earth was the cause, or nearly so, of the pain attending animal
+existence at a distance above the surface. Should the kittens be found
+to suffer uneasiness in an equal degree with their mother, I must
+consider my theory in fault, but a failure to do so I should look upon
+as a strong confirmation of my idea.
+
+“By eight o’clock I had actually attained an elevation of seventeen
+miles above the surface of the earth. Thus it seemed to me evident that
+my rate of ascent was not only on the increase, but that the progression
+would have been apparent in a slight degree even had I not discharged
+the ballast which I did. The pains in my head and ears returned, at
+intervals, with violence, and I still continued to bleed occasionally at
+the nose; but, upon the whole, I suffered much less than might have
+been expected. I breathed, however, at every moment, with more and
+more difficulty, and each inhalation was attended with a troublesome
+spasmodic action of the chest. I now unpacked the condensing apparatus,
+and got it ready for immediate use.
+
+“The view of the earth, at this period of my ascension, was beautiful
+indeed. To the westward, the northward, and the southward, as far as I
+could see, lay a boundless sheet of apparently unruffled ocean, which
+every moment gained a deeper and a deeper tint of blue and began already
+to assume a slight appearance of convexity. At a vast distance to the
+eastward, although perfectly discernible, extended the islands of Great
+Britain, the entire Atlantic coasts of France and Spain, with a small
+portion of the northern part of the continent of Africa. Of individual
+edifices not a trace could be discovered, and the proudest cities of
+mankind had utterly faded away from the face of the earth. From the rock
+of Gibraltar, now dwindled into a dim speck, the dark Mediterranean sea,
+dotted with shining islands as the heaven is dotted with stars, spread
+itself out to the eastward as far as my vision extended, until its
+entire mass of waters seemed at length to tumble headlong over the abyss
+of the horizon, and I found myself listening on tiptoe for the echoes
+of the mighty cataract. Overhead, the sky was of a jetty black, and the
+stars were brilliantly visible.
+
+“The pigeons about this time seeming to undergo much suffering, I
+determined upon giving them their liberty. I first untied one of them,
+a beautiful gray-mottled pigeon, and placed him upon the rim of the
+wicker-work. He appeared extremely uneasy, looking anxiously around him,
+fluttering his wings, and making a loud cooing noise, but could not be
+persuaded to trust himself from off the car. I took him up at last,
+and threw him to about half a dozen yards from the balloon. He made,
+however, no attempt to descend as I had expected, but struggled with
+great vehemence to get back, uttering at the same time very shrill and
+piercing cries. He at length succeeded in regaining his former station
+on the rim, but had hardly done so when his head dropped upon his
+breast, and he fell dead within the car. The other one did not prove so
+unfortunate. To prevent his following the example of his companion, and
+accomplishing a return, I threw him downward with all my force, and was
+pleased to find him continue his descent, with great velocity, making
+use of his wings with ease, and in a perfectly natural manner. In a very
+short time he was out of sight, and I have no doubt he reached home in
+safety. Puss, who seemed in a great measure recovered from her illness,
+now made a hearty meal of the dead bird and then went to sleep with much
+apparent satisfaction. Her kittens were quite lively, and so far evinced
+not the slightest sign of any uneasiness whatever.
+
+“At a quarter-past eight, being no longer able to draw breath without
+the most intolerable pain, I proceeded forthwith to adjust around
+the car the apparatus belonging to the condenser. This apparatus will
+require some little explanation, and your Excellencies will please to
+bear in mind that my object, in the first place, was to surround myself
+and cat entirely with a barricade against the highly rarefied atmosphere
+in which I was existing, with the intention of introducing within this
+barricade, by means of my condenser, a quantity of this same atmosphere
+sufficiently condensed for the purposes of respiration. With this object
+in view I had prepared a very strong perfectly air-tight, but flexible
+gum-elastic bag. In this bag, which was of sufficient dimensions, the
+entire car was in a manner placed. That is to say, it (the bag) was
+drawn over the whole bottom of the car, up its sides, and so on, along
+the outside of the ropes, to the upper rim or hoop where the net-work
+is attached. Having pulled the bag up in this way, and formed a complete
+enclosure on all sides, and at bottom, it was now necessary to fasten
+up its top or mouth, by passing its material over the hoop of the
+net-work--in other words, between the net-work and the hoop. But if the
+net-work were separated from the hoop to admit this passage, what was
+to sustain the car in the meantime? Now the net-work was not permanently
+fastened to the hoop, but attached by a series of running loops or
+nooses. I therefore undid only a few of these loops at one time, leaving
+the car suspended by the remainder. Having thus inserted a portion of
+the cloth forming the upper part of the bag, I refastened the loops--not
+to the hoop, for that would have been impossible, since the cloth
+now intervened--but to a series of large buttons, affixed to the cloth
+itself, about three feet below the mouth of the bag, the intervals
+between the buttons having been made to correspond to the intervals
+between the loops. This done, a few more of the loops were unfastened
+from the rim, a farther portion of the cloth introduced, and the
+disengaged loops then connected with their proper buttons. In this way
+it was possible to insert the whole upper part of the bag between the
+net-work and the hoop. It is evident that the hoop would now drop down
+within the car, while the whole weight of the car itself, with all its
+contents, would be held up merely by the strength of the buttons. This,
+at first sight, would seem an inadequate dependence; but it was by no
+means so, for the buttons were not only very strong in themselves, but
+so close together that a very slight portion of the whole weight was
+supported by any one of them. Indeed, had the car and contents been
+three times heavier than they were, I should not have been at
+all uneasy. I now raised up the hoop again within the covering of
+gum-elastic, and propped it at nearly its former height by means of
+three light poles prepared for the occasion. This was done, of course,
+to keep the bag distended at the top, and to preserve the lower part
+of the net-work in its proper situation. All that now remained was to
+fasten up the mouth of the enclosure; and this was readily accomplished
+by gathering the folds of the material together, and twisting them up
+very tightly on the inside by means of a kind of stationary tourniquet.
+
+“In the sides of the covering thus adjusted round the car, had been
+inserted three circular panes of thick but clear glass, through which I
+could see without difficulty around me in every horizontal direction.
+In that portion of the cloth forming the bottom, was likewise, a fourth
+window, of the same kind, and corresponding with a small aperture in the
+floor of the car itself. This enabled me to see perpendicularly
+down, but having found it impossible to place any similar contrivance
+overhead, on account of the peculiar manner of closing up the opening
+there, and the consequent wrinkles in the cloth, I could expect to see
+no objects situated directly in my zenith. This, of course, was a matter
+of little consequence; for had I even been able to place a window at
+top, the balloon itself would have prevented my making any use of it.
+
+“About a foot below one of the side windows was a circular opening,
+eight inches in diameter, and fitted with a brass rim adapted in its
+inner edge to the windings of a screw. In this rim was screwed the large
+tube of the condenser, the body of the machine being, of course, within
+the chamber of gum-elastic. Through this tube a quantity of the rare
+atmosphere circumjacent being drawn by means of a vacuum created in the
+body of the machine, was thence discharged, in a state of condensation,
+to mingle with the thin air already in the chamber. This operation being
+repeated several times, at length filled the chamber with atmosphere
+proper for all the purposes of respiration. But in so confined a space
+it would, in a short time, necessarily become foul, and unfit for use
+from frequent contact with the lungs. It was then ejected by a small
+valve at the bottom of the car--the dense air readily sinking into the
+thinner atmosphere below. To avoid the inconvenience of making a total
+vacuum at any moment within the chamber, this purification was never
+accomplished all at once, but in a gradual manner--the valve being
+opened only for a few seconds, then closed again, until one or two
+strokes from the pump of the condenser had supplied the place of the
+atmosphere ejected. For the sake of experiment I had put the cat and
+kittens in a small basket, and suspended it outside the car to a button
+at the bottom, close by the valve, through which I could feed them at
+any moment when necessary. I did this at some little risk, and before
+closing the mouth of the chamber, by reaching under the car with one of
+the poles before mentioned to which a hook had been attached.
+
+“By the time I had fully completed these arrangements and filled the
+chamber as explained, it wanted only ten minutes of nine o’clock. During
+the whole period of my being thus employed, I endured the most terrible
+distress from difficulty of respiration, and bitterly did I repent the
+negligence or rather fool-hardiness, of which I had been guilty, of
+putting off to the last moment a matter of so much importance. But
+having at length accomplished it, I soon began to reap the benefit of
+my invention. Once again I breathed with perfect freedom and ease--and
+indeed why should I not? I was also agreeably surprised to find myself,
+in a great measure, relieved from the violent pains which had hitherto
+tormented me. A slight headache, accompanied with a sensation of fulness
+or distention about the wrists, the ankles, and the throat, was nearly
+all of which I had now to complain. Thus it seemed evident that a
+greater part of the uneasiness attending the removal of atmospheric
+pressure had actually worn off, as I had expected, and that much of
+the pain endured for the last two hours should have been attributed
+altogether to the effects of a deficient respiration.
+
+“At twenty minutes before nine o’clock--that is to say, a short time
+prior to my closing up the mouth of the chamber, the mercury attained
+its limit, or ran down, in the barometer, which, as I mentioned before,
+was one of an extended construction. It then indicated an altitude on
+my part of 132,000 feet, or five-and-twenty miles, and I consequently
+surveyed at that time an extent of the earth’s area amounting to no less
+than the three hundred-and-twentieth part of its entire superficies.
+At nine o’clock I had again lost sight of land to the eastward, but not
+before I became aware that the balloon was drifting rapidly to the N.
+N. W. The convexity of the ocean beneath me was very evident indeed,
+although my view was often interrupted by the masses of cloud which
+floated to and fro. I observed now that even the lightest vapors never
+rose to more than ten miles above the level of the sea.
+
+“At half past nine I tried the experiment of throwing out a handful of
+feathers through the valve. They did not float as I had expected; but
+dropped down perpendicularly, like a bullet, en masse, and with the
+greatest velocity--being out of sight in a very few seconds. I did not
+at first know what to make of this extraordinary phenomenon; not being
+able to believe that my rate of ascent had, of a sudden, met with
+so prodigious an acceleration. But it soon occurred to me that the
+atmosphere was now far too rare to sustain even the feathers; that they
+actually fell, as they appeared to do, with great rapidity; and that I
+had been surprised by the united velocities of their descent and my own
+elevation.
+
+“By ten o’clock I found that I had very little to occupy my immediate
+attention. Affairs went swimmingly, and I believed the balloon to be
+going upward with a speed increasing momently although I had no longer
+any means of ascertaining the progression of the increase. I suffered no
+pain or uneasiness of any kind, and enjoyed better spirits than I had
+at any period since my departure from Rotterdam, busying myself now in
+examining the state of my various apparatus, and now in regenerating the
+atmosphere within the chamber. This latter point I determined to
+attend to at regular intervals of forty minutes, more on account of
+the preservation of my health, than from so frequent a renovation
+being absolutely necessary. In the meanwhile I could not help making
+anticipations. Fancy revelled in the wild and dreamy regions of the
+moon. Imagination, feeling herself for once unshackled, roamed at will
+among the ever-changing wonders of a shadowy and unstable land. Now
+there were hoary and time-honored forests, and craggy precipices, and
+waterfalls tumbling with a loud noise into abysses without a bottom.
+Then I came suddenly into still noonday solitudes, where no wind of
+heaven ever intruded, and where vast meadows of poppies, and slender,
+lily-looking flowers spread themselves out a weary distance, all silent
+and motionless forever. Then again I journeyed far down away into
+another country where it was all one dim and vague lake, with a boundary
+line of clouds. And out of this melancholy water arose a forest of tall
+eastern trees, like a wilderness of dreams. And I have in mind that
+the shadows of the trees which fell upon the lake remained not on
+the surface where they fell, but sunk slowly and steadily down, and
+commingled with the waves, while from the trunks of the trees other
+shadows were continually coming out, and taking the place of their
+brothers thus entombed. “This then,” I said thoughtfully, “is the very
+reason why the waters of this lake grow blacker with age, and more
+melancholy as the hours run on.” But fancies such as these were not the
+sole possessors of my brain. Horrors of a nature most stern and most
+appalling would too frequently obtrude themselves upon my mind, and
+shake the innermost depths of my soul with the bare supposition of their
+possibility. Yet I would not suffer my thoughts for any length of time
+to dwell upon these latter speculations, rightly judging the real and
+palpable dangers of the voyage sufficient for my undivided attention.
+
+“At five o’clock, p.m., being engaged in regenerating the atmosphere
+within the chamber, I took that opportunity of observing the cat and
+kittens through the valve. The cat herself appeared to suffer again very
+much, and I had no hesitation in attributing her uneasiness chiefly to a
+difficulty in breathing; but my experiment with the kittens had resulted
+very strangely. I had expected, of course, to see them betray a sense of
+pain, although in a less degree than their mother, and this would have
+been sufficient to confirm my opinion concerning the habitual endurance
+of atmospheric pressure. But I was not prepared to find them, upon close
+examination, evidently enjoying a high degree of health, breathing with
+the greatest ease and perfect regularity, and evincing not the slightest
+sign of any uneasiness whatever. I could only account for all this by
+extending my theory, and supposing that the highly rarefied atmosphere
+around might perhaps not be, as I had taken for granted, chemically
+insufficient for the purposes of life, and that a person born in such
+a medium might, possibly, be unaware of any inconvenience attending its
+inhalation, while, upon removal to the denser strata near the earth,
+he might endure tortures of a similar nature to those I had so lately
+experienced. It has since been to me a matter of deep regret that an
+awkward accident, at this time, occasioned me the loss of my little
+family of cats, and deprived me of the insight into this matter which a
+continued experiment might have afforded. In passing my hand through
+the valve, with a cup of water for the old puss, the sleeves of my shirt
+became entangled in the loop which sustained the basket, and thus, in
+a moment, loosened it from the bottom. Had the whole actually vanished
+into air, it could not have shot from my sight in a more abrupt and
+instantaneous manner. Positively, there could not have intervened the
+tenth part of a second between the disengagement of the basket and its
+absolute and total disappearance with all that it contained. My good
+wishes followed it to the earth, but of course, I had no hope that
+either cat or kittens would ever live to tell the tale of their
+misfortune.
+
+“At six o’clock, I perceived a great portion of the earth’s visible area
+to the eastward involved in thick shadow, which continued to advance
+with great rapidity, until, at five minutes before seven, the whole
+surface in view was enveloped in the darkness of night. It was not,
+however, until long after this time that the rays of the setting sun
+ceased to illumine the balloon; and this circumstance, although of
+course fully anticipated, did not fail to give me an infinite deal
+of pleasure. It was evident that, in the morning, I should behold the
+rising luminary many hours at least before the citizens of Rotterdam, in
+spite of their situation so much farther to the eastward, and thus, day
+after day, in proportion to the height ascended, would I enjoy the light
+of the sun for a longer and a longer period. I now determined to keep a
+journal of my passage, reckoning the days from one to twenty-four
+hours continuously, without taking into consideration the intervals of
+darkness.
+
+“At ten o’clock, feeling sleepy, I determined to lie down for the rest
+of the night; but here a difficulty presented itself, which, obvious as
+it may appear, had escaped my attention up to the very moment of which
+I am now speaking. If I went to sleep as I proposed, how could the
+atmosphere in the chamber be regenerated in the interim? To breathe
+it for more than an hour, at the farthest, would be a matter of
+impossibility, or, if even this term could be extended to an hour and a
+quarter, the most ruinous consequences might ensue. The consideration
+of this dilemma gave me no little disquietude; and it will hardly be
+believed, that, after the dangers I had undergone, I should look
+upon this business in so serious a light, as to give up all hope of
+accomplishing my ultimate design, and finally make up my mind to the
+necessity of a descent. But this hesitation was only momentary. I
+reflected that man is the veriest slave of custom, and that many points
+in the routine of his existence are deemed essentially important, which
+are only so at all by his having rendered them habitual. It was very
+certain that I could not do without sleep; but I might easily bring
+myself to feel no inconvenience from being awakened at intervals of an
+hour during the whole period of my repose. It would require but five
+minutes at most to regenerate the atmosphere in the fullest manner, and
+the only real difficulty was to contrive a method of arousing myself
+at the proper moment for so doing. But this was a question which, I am
+willing to confess, occasioned me no little trouble in its solution. To
+be sure, I had heard of the student who, to prevent his falling asleep
+over his books, held in one hand a ball of copper, the din of whose
+descent into a basin of the same metal on the floor beside his chair,
+served effectually to startle him up, if, at any moment, he should
+be overcome with drowsiness. My own case, however, was very different
+indeed, and left me no room for any similar idea; for I did not wish to
+keep awake, but to be aroused from slumber at regular intervals of time.
+I at length hit upon the following expedient, which, simple as it may
+seem, was hailed by me, at the moment of discovery, as an invention
+fully equal to that of the telescope, the steam-engine, or the art of
+printing itself.
+
+“It is necessary to premise, that the balloon, at the elevation now
+attained, continued its course upward with an even and undeviating
+ascent, and the car consequently followed with a steadiness so perfect
+that it would have been impossible to detect in it the slightest
+vacillation whatever. This circumstance favored me greatly in the
+project I now determined to adopt. My supply of water had been put on
+board in kegs containing five gallons each, and ranged very securely
+around the interior of the car. I unfastened one of these, and taking
+two ropes tied them tightly across the rim of the wicker-work from one
+side to the other; placing them about a foot apart and parallel so as to
+form a kind of shelf, upon which I placed the keg, and steadied it in a
+horizontal position. About eight inches immediately below these ropes,
+and four feet from the bottom of the car I fastened another shelf--but
+made of thin plank, being the only similar piece of wood I had. Upon
+this latter shelf, and exactly beneath one of the rims of the keg, a
+small earthern pitcher was deposited. I now bored a hole in the end of
+the keg over the pitcher, and fitted in a plug of soft wood, cut in a
+tapering or conical shape. This plug I pushed in or pulled out, as might
+happen, until, after a few experiments, it arrived at that exact degree
+of tightness, at which the water, oozing from the hole, and falling into
+the pitcher below, would fill the latter to the brim in the period
+of sixty minutes. This, of course, was a matter briefly and easily
+ascertained, by noticing the proportion of the pitcher filled in any
+given time. Having arranged all this, the rest of the plan is obvious.
+My bed was so contrived upon the floor of the car, as to bring my
+head, in lying down, immediately below the mouth of the pitcher. It was
+evident, that, at the expiration of an hour, the pitcher, getting full,
+would be forced to run over, and to run over at the mouth, which was
+somewhat lower than the rim. It was also evident, that the water thus
+falling from a height of more than four feet, could not do otherwise
+than fall upon my face, and that the sure consequences would be, to
+waken me up instantaneously, even from the soundest slumber in the
+world.
+
+“It was fully eleven by the time I had completed these arrangements,
+and I immediately betook myself to bed, with full confidence in the
+efficiency of my invention. Nor in this matter was I disappointed.
+Punctually every sixty minutes was I aroused by my trusty chronometer,
+when, having emptied the pitcher into the bung-hole of the keg, and
+performed the duties of the condenser, I retired again to bed. These
+regular interruptions to my slumber caused me even less discomfort than
+I had anticipated; and when I finally arose for the day, it was seven
+o’clock, and the sun had attained many degrees above the line of my
+horizon.
+
+“April 3d. I found the balloon at an immense height indeed, and the
+earth’s apparent convexity increased in a material degree. Below me in
+the ocean lay a cluster of black specks, which undoubtedly were islands.
+Far away to the northward I perceived a thin, white, and exceedingly
+brilliant line, or streak, on the edge of the horizon, and I had no
+hesitation in supposing it to be the southern disk of the ices of the
+Polar Sea. My curiosity was greatly excited, for I had hopes of passing
+on much farther to the north, and might possibly, at some period, find
+myself placed directly above the Pole itself. I now lamented that my
+great elevation would, in this case, prevent my taking as accurate a
+survey as I could wish. Much, however, might be ascertained. Nothing
+else of an extraordinary nature occurred during the day. My apparatus
+all continued in good order, and the balloon still ascended without any
+perceptible vacillation. The cold was intense, and obliged me to wrap
+up closely in an overcoat. When darkness came over the earth, I betook
+myself to bed, although it was for many hours afterward broad daylight
+all around my immediate situation. The water-clock was punctual in its
+duty, and I slept until next morning soundly, with the exception of the
+periodical interruption.
+
+“April 4th. Arose in good health and spirits, and was astonished at the
+singular change which had taken place in the appearance of the sea.
+It had lost, in a great measure, the deep tint of blue it had hitherto
+worn, being now of a grayish-white, and of a lustre dazzling to the eye.
+The islands were no longer visible; whether they had passed down the
+horizon to the southeast, or whether my increasing elevation had left
+them out of sight, it is impossible to say. I was inclined, however, to
+the latter opinion. The rim of ice to the northward was growing more
+and more apparent. Cold by no means so intense. Nothing of importance
+occurred, and I passed the day in reading, having taken care to supply
+myself with books.
+
+“April 5th. Beheld the singular phenomenon of the sun rising while
+nearly the whole visible surface of the earth continued to be involved
+in darkness. In time, however, the light spread itself over all, and I
+again saw the line of ice to the northward. It was now very distinct,
+and appeared of a much darker hue than the waters of the ocean. I was
+evidently approaching it, and with great rapidity. Fancied I could
+again distinguish a strip of land to the eastward, and one also to the
+westward, but could not be certain. Weather moderate. Nothing of any
+consequence happened during the day. Went early to bed.
+
+“April 6th. Was surprised at finding the rim of ice at a very moderate
+distance, and an immense field of the same material stretching away off
+to the horizon in the north. It was evident that if the balloon held its
+present course, it would soon arrive above the Frozen Ocean, and I had
+now little doubt of ultimately seeing the Pole. During the whole of the
+day I continued to near the ice. Toward night the limits of my horizon
+very suddenly and materially increased, owing undoubtedly to the
+earth’s form being that of an oblate spheroid, and my arriving above the
+flattened regions in the vicinity of the Arctic circle. When darkness at
+length overtook me, I went to bed in great anxiety, fearing to pass over
+the object of so much curiosity when I should have no opportunity of
+observing it.
+
+“April 7th. Arose early, and, to my great joy, at length beheld what
+there could be no hesitation in supposing the northern Pole itself. It
+was there, beyond a doubt, and immediately beneath my feet; but, alas! I
+had now ascended to so vast a distance, that nothing could with accuracy
+be discerned. Indeed, to judge from the progression of the numbers
+indicating my various altitudes, respectively, at different periods,
+between six A.M. on the second of April, and twenty minutes before nine
+A.M. of the same day (at which time the barometer ran down), it might be
+fairly inferred that the balloon had now, at four o’clock in the morning
+of April the seventh, reached a height of not less, certainly, than
+7,254 miles above the surface of the sea. This elevation may appear
+immense, but the estimate upon which it is calculated gave a result in
+all probability far inferior to the truth. At all events I undoubtedly
+beheld the whole of the earth’s major diameter; the entire northern
+hemisphere lay beneath me like a chart orthographically projected: and
+the great circle of the equator itself formed the boundary line of
+my horizon. Your Excellencies may, however, readily imagine that the
+confined regions hitherto unexplored within the limits of the Arctic
+circle, although situated directly beneath me, and therefore seen
+without any appearance of being foreshortened, were still, in
+themselves, comparatively too diminutive, and at too great a distance
+from the point of sight, to admit of any very accurate examination.
+Nevertheless, what could be seen was of a nature singular and exciting.
+Northwardly from that huge rim before mentioned, and which, with slight
+qualification, may be called the limit of human discovery in these
+regions, one unbroken, or nearly unbroken, sheet of ice continues to
+extend. In the first few degrees of this its progress, its surface is
+very sensibly flattened, farther on depressed into a plane, and finally,
+becoming not a little concave, it terminates, at the Pole itself, in a
+circular centre, sharply defined, whose apparent diameter subtended at
+the balloon an angle of about sixty-five seconds, and whose dusky hue,
+varying in intensity, was, at all times, darker than any other spot upon
+the visible hemisphere, and occasionally deepened into the most
+absolute and impenetrable blackness. Farther than this, little could
+be ascertained. By twelve o’clock the circular centre had materially
+decreased in circumference, and by seven P.M. I lost sight of it
+entirely; the balloon passing over the western limb of the ice, and
+floating away rapidly in the direction of the equator.
+
+“April 8th. Found a sensible diminution in the earth’s apparent
+diameter, besides a material alteration in its general color and
+appearance. The whole visible area partook in different degrees of a
+tint of pale yellow, and in some portions had acquired a brilliancy even
+painful to the eye. My view downward was also considerably impeded by
+the dense atmosphere in the vicinity of the surface being loaded with
+clouds, between whose masses I could only now and then obtain a glimpse
+of the earth itself. This difficulty of direct vision had troubled me
+more or less for the last forty-eight hours; but my present enormous
+elevation brought closer together, as it were, the floating bodies of
+vapor, and the inconvenience became, of course, more and more palpable
+in proportion to my ascent. Nevertheless, I could easily perceive that
+the balloon now hovered above the range of great lakes in the continent
+of North America, and was holding a course, due south, which would bring
+me to the tropics. This circumstance did not fail to give me the most
+heartful satisfaction, and I hailed it as a happy omen of ultimate
+success. Indeed, the direction I had hitherto taken, had filled me with
+uneasiness; for it was evident that, had I continued it much longer,
+there would have been no possibility of my arriving at the moon at all,
+whose orbit is inclined to the ecliptic at only the small angle of 5
+degrees 8’ 48”.
+
+“April 9th. To-day the earth’s diameter was greatly diminished, and the
+color of the surface assumed hourly a deeper tint of yellow. The balloon
+kept steadily on her course to the southward, and arrived, at nine P.M.,
+over the northern edge of the Mexican Gulf.
+
+“April 10th. I was suddenly aroused from slumber, about five o’clock
+this morning, by a loud, crackling, and terrific sound, for which I
+could in no manner account. It was of very brief duration, but, while
+it lasted resembled nothing in the world of which I had any previous
+experience. It is needless to say that I became excessively alarmed,
+having, in the first instance, attributed the noise to the bursting of
+the balloon. I examined all my apparatus, however, with great attention,
+and could discover nothing out of order. Spent a great part of the day
+in meditating upon an occurrence so extraordinary, but could find no
+means whatever of accounting for it. Went to bed dissatisfied, and in a
+state of great anxiety and agitation.
+
+“April 11th. Found a startling diminution in the apparent diameter of
+the earth, and a considerable increase, now observable for the first
+time, in that of the moon itself, which wanted only a few days of being
+full. It now required long and excessive labor to condense within the
+chamber sufficient atmospheric air for the sustenance of life.
+
+“April 12th. A singular alteration took place in regard to the direction
+of the balloon, and although fully anticipated, afforded me the most
+unequivocal delight. Having reached, in its former course, about the
+twentieth parallel of southern latitude, it turned off suddenly, at an
+acute angle, to the eastward, and thus proceeded throughout the day,
+keeping nearly, if not altogether, in the exact plane of the lunar
+elipse. What was worthy of remark, a very perceptible vacillation in
+the car was a consequence of this change of route--a vacillation which
+prevailed, in a more or less degree, for a period of many hours.
+
+“April 13th. Was again very much alarmed by a repetition of the loud,
+crackling noise which terrified me on the tenth. Thought long upon
+the subject, but was unable to form any satisfactory conclusion. Great
+decrease in the earth’s apparent diameter, which now subtended from the
+balloon an angle of very little more than twenty-five degrees. The moon
+could not be seen at all, being nearly in my zenith. I still continued
+in the plane of the elipse, but made little progress to the eastward.
+
+“April 14th. Extremely rapid decrease in the diameter of the earth.
+To-day I became strongly impressed with the idea, that the balloon was
+now actually running up the line of apsides to the point of perigee--in
+other words, holding the direct course which would bring it immediately
+to the moon in that part of its orbit the nearest to the earth. The moon
+itself was directly overhead, and consequently hidden from my view.
+Great and long-continued labor necessary for the condensation of the
+atmosphere.
+
+“April 15th. Not even the outlines of continents and seas could now
+be traced upon the earth with anything approaching distinctness. About
+twelve o’clock I became aware, for the third time, of that appalling
+sound which had so astonished me before. It now, however, continued for
+some moments, and gathered intensity as it continued. At length, while,
+stupefied and terror-stricken, I stood in expectation of I knew not what
+hideous destruction, the car vibrated with excessive violence, and
+a gigantic and flaming mass of some material which I could not
+distinguish, came with a voice of a thousand thunders, roaring and
+booming by the balloon. When my fears and astonishment had in some
+degree subsided, I had little difficulty in supposing it to be some
+mighty volcanic fragment ejected from that world to which I was so
+rapidly approaching, and, in all probability, one of that singular class
+of substances occasionally picked up on the earth, and termed meteoric
+stones for want of a better appellation.
+
+“April 16th. To-day, looking upward as well as I could, through each
+of the side windows alternately, I beheld, to my great delight, a very
+small portion of the moon’s disk protruding, as it were, on all sides
+beyond the huge circumference of the balloon. My agitation was extreme;
+for I had now little doubt of soon reaching the end of my perilous
+voyage. Indeed, the labor now required by the condenser had increased
+to a most oppressive degree, and allowed me scarcely any respite from
+exertion. Sleep was a matter nearly out of the question. I became quite
+ill, and my frame trembled with exhaustion. It was impossible that human
+nature could endure this state of intense suffering much longer. During
+the now brief interval of darkness a meteoric stone again passed in my
+vicinity, and the frequency of these phenomena began to occasion me much
+apprehension.
+
+“April 17th. This morning proved an epoch in my voyage. It will be
+remembered that, on the thirteenth, the earth subtended an angular
+breadth of twenty-five degrees. On the fourteenth this had greatly
+diminished; on the fifteenth a still more remarkable decrease was
+observable; and, on retiring on the night of the sixteenth, I had
+noticed an angle of no more than about seven degrees and fifteen
+minutes. What, therefore, must have been my amazement, on awakening
+from a brief and disturbed slumber, on the morning of this day,
+the seventeenth, at finding the surface beneath me so suddenly and
+wonderfully augmented in volume, as to subtend no less than thirty-nine
+degrees in apparent angular diameter! I was thunderstruck! No words
+can give any adequate idea of the extreme, the absolute horror and
+astonishment, with which I was seized possessed, and altogether
+overwhelmed. My knees tottered beneath me--my teeth chattered--my hair
+started up on end. “The balloon, then, had actually burst!” These were
+the first tumultuous ideas that hurried through my mind: “The balloon
+had positively burst!--I was falling--falling with the most impetuous,
+the most unparalleled velocity! To judge by the immense distance already
+so quickly passed over, it could not be more than ten minutes, at the
+farthest, before I should meet the surface of the earth, and be hurled
+into annihilation!” But at length reflection came to my relief. I
+paused; I considered; and I began to doubt. The matter was impossible.
+I could not in any reason have so rapidly come down. Besides, although
+I was evidently approaching the surface below me, it was with a speed
+by no means commensurate with the velocity I had at first so horribly
+conceived. This consideration served to calm the perturbation of my
+mind, and I finally succeeded in regarding the phenomenon in its proper
+point of view. In fact, amazement must have fairly deprived me of my
+senses, when I could not see the vast difference, in appearance, between
+the surface below me, and the surface of my mother earth. The latter
+was indeed over my head, and completely hidden by the balloon, while the
+moon--the moon itself in all its glory--lay beneath me, and at my feet.
+
+“The stupor and surprise produced in my mind by this extraordinary
+change in the posture of affairs was perhaps, after all, that part of
+the adventure least susceptible of explanation. For the bouleversement
+in itself was not only natural and inevitable, but had been long
+actually anticipated as a circumstance to be expected whenever I should
+arrive at that exact point of my voyage where the attraction of the
+planet should be superseded by the attraction of the satellite--or, more
+precisely, where the gravitation of the balloon toward the earth should
+be less powerful than its gravitation toward the moon. To be sure I
+arose from a sound slumber, with all my senses in confusion, to the
+contemplation of a very startling phenomenon, and one which, although
+expected, was not expected at the moment. The revolution itself must, of
+course, have taken place in an easy and gradual manner, and it is by no
+means clear that, had I even been awake at the time of the occurrence,
+I should have been made aware of it by any internal evidence of an
+inversion--that is to say, by any inconvenience or disarrangement,
+either about my person or about my apparatus.
+
+“It is almost needless to say that, upon coming to a due sense of my
+situation, and emerging from the terror which had absorbed every faculty
+of my soul, my attention was, in the first place, wholly directed to
+the contemplation of the general physical appearance of the moon. It
+lay beneath me like a chart--and although I judged it to be still at no
+inconsiderable distance, the indentures of its surface were defined
+to my vision with a most striking and altogether unaccountable
+distinctness. The entire absence of ocean or sea, and indeed of any lake
+or river, or body of water whatsoever, struck me, at first glance, as
+the most extraordinary feature in its geological condition. Yet, strange
+to say, I beheld vast level regions of a character decidedly alluvial,
+although by far the greater portion of the hemisphere in sight was
+covered with innumerable volcanic mountains, conical in shape, and
+having more the appearance of artificial than of natural protuberance.
+The highest among them does not exceed three and three-quarter miles
+in perpendicular elevation; but a map of the volcanic districts of the
+Campi Phlegraei would afford to your Excellencies a better idea of their
+general surface than any unworthy description I might think proper to
+attempt. The greater part of them were in a state of evident eruption,
+and gave me fearfully to understand their fury and their power, by the
+repeated thunders of the miscalled meteoric stones, which now rushed
+upward by the balloon with a frequency more and more appalling.
+
+“April 18th. To-day I found an enormous increase in the moon’s apparent
+bulk--and the evidently accelerated velocity of my descent began to fill
+me with alarm. It will be remembered, that, in the earliest stage of
+my speculations upon the possibility of a passage to the moon, the
+existence, in its vicinity, of an atmosphere, dense in proportion to the
+bulk of the planet, had entered largely into my calculations; this too
+in spite of many theories to the contrary, and, it may be added, in
+spite of a general disbelief in the existence of any lunar atmosphere at
+all. But, in addition to what I have already urged in regard to Encke’s
+comet and the zodiacal light, I had been strengthened in my opinion by
+certain observations of Mr. Schroeter, of Lilienthal. He observed the
+moon when two days and a half old, in the evening soon after sunset,
+before the dark part was visible, and continued to watch it until it
+became visible. The two cusps appeared tapering in a very sharp faint
+prolongation, each exhibiting its farthest extremity faintly illuminated
+by the solar rays, before any part of the dark hemisphere was
+visible. Soon afterward, the whole dark limb became illuminated. This
+prolongation of the cusps beyond the semicircle, I thought, must have
+arisen from the refraction of the sun’s rays by the moon’s atmosphere. I
+computed, also, the height of the atmosphere (which could refract light
+enough into its dark hemisphere to produce a twilight more luminous than
+the light reflected from the earth when the moon is about 32 degrees
+from the new) to be 1,356 Paris feet; in this view, I supposed the
+greatest height capable of refracting the solar ray, to be 5,376 feet.
+My ideas on this topic had also received confirmation by a passage in
+the eighty-second volume of the Philosophical Transactions, in which
+it is stated that at an occultation of Jupiter’s satellites, the third
+disappeared after having been about 1” or 2” of time indistinct, and the
+fourth became indiscernible near the limb.(*4)
+
+“Cassini frequently observed Saturn, Jupiter, and the fixed stars,
+when approaching the moon to occultation, to have their circular figure
+changed into an oval one; and, in other occultations, he found no
+alteration of figure at all. Hence it might be supposed, that at some
+times and not at others, there is a dense matter encompassing the moon
+wherein the rays of the stars are refracted.
+
+“Upon the resistance or, more properly, upon the support of an
+atmosphere, existing in the state of density imagined, I had, of course,
+entirely depended for the safety of my ultimate descent. Should I then,
+after all, prove to have been mistaken, I had in consequence nothing
+better to expect, as a finale to my adventure, than being dashed into
+atoms against the rugged surface of the satellite. And, indeed, I
+had now every reason to be terrified. My distance from the moon was
+comparatively trifling, while the labor required by the condenser was
+diminished not at all, and I could discover no indication whatever of a
+decreasing rarity in the air.
+
+“April 19th. This morning, to my great joy, about nine o’clock, the
+surface of the moon being frightfully near, and my apprehensions excited
+to the utmost, the pump of my condenser at length gave evident tokens
+of an alteration in the atmosphere. By ten, I had reason to believe
+its density considerably increased. By eleven, very little labor was
+necessary at the apparatus; and at twelve o’clock, with some hesitation,
+I ventured to unscrew the tourniquet, when, finding no inconvenience
+from having done so, I finally threw open the gum-elastic chamber, and
+unrigged it from around the car. As might have been expected, spasms
+and violent headache were the immediate consequences of an experiment
+so precipitate and full of danger. But these and other difficulties
+attending respiration, as they were by no means so great as to put me
+in peril of my life, I determined to endure as I best could, in
+consideration of my leaving them behind me momently in my approach
+to the denser strata near the moon. This approach, however, was still
+impetuous in the extreme; and it soon became alarmingly certain that,
+although I had probably not been deceived in the expectation of an
+atmosphere dense in proportion to the mass of the satellite, still I
+had been wrong in supposing this density, even at the surface, at all
+adequate to the support of the great weight contained in the car of my
+balloon. Yet this should have been the case, and in an equal degree
+as at the surface of the earth, the actual gravity of bodies at either
+planet supposed in the ratio of the atmospheric condensation. That
+it was not the case, however, my precipitous downfall gave testimony
+enough; why it was not so, can only be explained by a reference to those
+possible geological disturbances to which I have formerly alluded. At
+all events I was now close upon the planet, and coming down with the
+most terrible impetuosity. I lost not a moment, accordingly, in throwing
+overboard first my ballast, then my water-kegs, then my condensing
+apparatus and gum-elastic chamber, and finally every article within the
+car. But it was all to no purpose. I still fell with horrible rapidity,
+and was now not more than half a mile from the surface. As a last
+resource, therefore, having got rid of my coat, hat, and boots, I cut
+loose from the balloon the car itself, which was of no inconsiderable
+weight, and thus, clinging with both hands to the net-work, I had barely
+time to observe that the whole country, as far as the eye could reach,
+was thickly interspersed with diminutive habitations, ere I tumbled
+headlong into the very heart of a fantastical-looking city, and into the
+middle of a vast crowd of ugly little people, who none of them uttered
+a single syllable, or gave themselves the least trouble to render me
+assistance, but stood, like a parcel of idiots, grinning in a ludicrous
+manner, and eyeing me and my balloon askant, with their arms set
+a-kimbo. I turned from them in contempt, and, gazing upward at the earth
+so lately left, and left perhaps for ever, beheld it like a huge, dull,
+copper shield, about two degrees in diameter, fixed immovably in the
+heavens overhead, and tipped on one of its edges with a crescent
+border of the most brilliant gold. No traces of land or water could be
+discovered, and the whole was clouded with variable spots, and belted
+with tropical and equatorial zones.
+
+“Thus, may it please your Excellencies, after a series of great
+anxieties, unheard of dangers, and unparalleled escapes, I had, at
+length, on the nineteenth day of my departure from Rotterdam, arrived in
+safety at the conclusion of a voyage undoubtedly the most extraordinary,
+and the most momentous, ever accomplished, undertaken, or conceived by
+any denizen of earth. But my adventures yet remain to be related. And
+indeed your Excellencies may well imagine that, after a residence of
+five years upon a planet not only deeply interesting in its own peculiar
+character, but rendered doubly so by its intimate connection, in
+capacity of satellite, with the world inhabited by man, I may have
+intelligence for the private ear of the States’ College of Astronomers
+of far more importance than the details, however wonderful, of the mere
+voyage which so happily concluded. This is, in fact, the case. I
+have much--very much which it would give me the greatest pleasure to
+communicate. I have much to say of the climate of the planet; of its
+wonderful alternations of heat and cold, of unmitigated and burning
+sunshine for one fortnight, and more than polar frigidity for the next;
+of a constant transfer of moisture, by distillation like that in vacuo,
+from the point beneath the sun to the point the farthest from it; of
+a variable zone of running water, of the people themselves; of their
+manners, customs, and political institutions; of their peculiar physical
+construction; of their ugliness; of their want of ears, those useless
+appendages in an atmosphere so peculiarly modified; of their consequent
+ignorance of the use and properties of speech; of their substitute
+for speech in a singular method of inter-communication; of the
+incomprehensible connection between each particular individual in
+the moon with some particular individual on the earth--a connection
+analogous with, and depending upon, that of the orbs of the planet and
+the satellites, and by means of which the lives and destinies of the
+inhabitants of the one are interwoven with the lives and destinies
+of the inhabitants of the other; and above all, if it so please your
+Excellencies--above all, of those dark and hideous mysteries which lie
+in the outer regions of the moon--regions which, owing to the almost
+miraculous accordance of the satellite’s rotation on its own axis with
+its sidereal revolution about the earth, have never yet been turned,
+and, by God’s mercy, never shall be turned, to the scrutiny of the
+telescopes of man. All this, and more--much more--would I most
+willingly detail. But, to be brief, I must have my reward. I am pining
+for a return to my family and to my home, and as the price of any
+farther communication on my part--in consideration of the light which
+I have it in my power to throw upon many very important branches of
+physical and metaphysical science--I must solicit, through the influence
+of your honorable body, a pardon for the crime of which I have been
+guilty in the death of the creditors upon my departure from Rotterdam.
+This, then, is the object of the present paper. Its bearer, an
+inhabitant of the moon, whom I have prevailed upon, and properly
+instructed, to be my messenger to the earth, will await your
+Excellencies’ pleasure, and return to me with the pardon in question, if
+it can, in any manner, be obtained.
+
+“I have the honor to be, etc., your Excellencies’ very humble servant,
+
+“HANS PFAALL.”
+
+Upon finishing the perusal of this very extraordinary document,
+Professor Rub-a-dub, it is said, dropped his pipe upon the ground in
+the extremity of his surprise, and Mynheer Superbus Von Underduk having
+taken off his spectacles, wiped them, and deposited them in his pocket,
+so far forgot both himself and his dignity, as to turn round three times
+upon his heel in the quintessence of astonishment and admiration. There
+was no doubt about the matter--the pardon should be obtained. So at
+least swore, with a round oath, Professor Rub-a-dub, and so finally
+thought the illustrious Von Underduk, as he took the arm of his brother
+in science, and without saying a word, began to make the best of his way
+home to deliberate upon the measures to be adopted. Having reached the
+door, however, of the burgomaster’s dwelling, the professor ventured to
+suggest that as the messenger had thought proper to disappear--no
+doubt frightened to death by the savage appearance of the burghers of
+Rotterdam--the pardon would be of little use, as no one but a man of
+the moon would undertake a voyage to so vast a distance. To the truth of
+this observation the burgomaster assented, and the matter was therefore
+at an end. Not so, however, rumors and speculations. The letter, having
+been published, gave rise to a variety of gossip and opinion. Some of
+the over-wise even made themselves ridiculous by decrying the whole
+business; as nothing better than a hoax. But hoax, with these sort
+of people, is, I believe, a general term for all matters above their
+comprehension. For my part, I cannot conceive upon what data they have
+founded such an accusation. Let us see what they say:
+
+Imprimus. That certain wags in Rotterdam have certain especial
+antipathies to certain burgomasters and astronomers.
+
+Don’t understand at all.
+
+Secondly. That an odd little dwarf and bottle conjurer, both of whose
+ears, for some misdemeanor, have been cut off close to his head, has
+been missing for several days from the neighboring city of Bruges.
+
+Well--what of that?
+
+Thirdly. That the newspapers which were stuck all over the little
+balloon were newspapers of Holland, and therefore could not have been
+made in the moon. They were dirty papers--very dirty--and Gluck, the
+printer, would take his Bible oath to their having been printed in
+Rotterdam.
+
+He was mistaken--undoubtedly--mistaken.
+
+Fourthly, That Hans Pfaall himself, the drunken villain, and the three
+very idle gentlemen styled his creditors, were all seen, no longer than
+two or three days ago, in a tippling house in the suburbs, having just
+returned, with money in their pockets, from a trip beyond the sea.
+
+Don’t believe it--don’t believe a word of it.
+
+Lastly. That it is an opinion very generally received, or which ought
+to be generally received, that the College of Astronomers in the city
+of Rotterdam, as well as other colleges in all other parts of the
+world,--not to mention colleges and astronomers in general,--are, to say
+the least of the matter, not a whit better, nor greater, nor wiser than
+they ought to be.
+
+~~~ End of Text ~~~
+
+Notes to Hans Pfaal
+
+(*1) NOTE--Strictly speaking, there is but little similarity between the
+above sketchy trifle and the celebrated “Moon-Story” of Mr. Locke; but
+as both have the character of _hoaxes _(although the one is in a tone of
+banter, the other of downright earnest), and as both hoaxes are on the
+same subject, the moon--moreover, as both attempt to give plausibility
+by scientific detail--the author of “Hans Pfaall” thinks it necessary to
+say, in _self-defence, _that his own _jeu d’esprit _was published in the
+“Southern Literary Messenger” about three weeks before the commencement
+of Mr. L’s in the “New York Sun.” Fancying a likeness which, perhaps,
+does not exist, some of the New York papers copied “Hans Pfaall,” and
+collated it with the “Moon-Hoax,” by way of detecting the writer of the
+one in the writer of the other.
+
+As many more persons were actually gulled by the “Moon-Hoax” than would
+be willing to acknowledge the fact, it may here afford some little
+amusement to show why no one should have been deceived-to point out
+those particulars of the story which should have been sufficient to
+establish its real character. Indeed, however rich the imagination
+displayed in this ingenious fiction, it wanted much of the force which
+might have been given it by a more scrupulous attention to facts and
+to general analogy. That the public were misled, even for an instant,
+merely proves the gross ignorance which is so generally prevalent upon
+subjects of an astronomical nature.
+
+The moon’s distance from the earth is, in round numbers, 240,000 miles.
+If we desire to ascertain how near, apparently, a lens would bring the
+satellite (or any distant object), we, of course, have but to divide the
+distance by the magnifying or, more strictly, by the space-penetrating
+power of the glass. Mr. L. makes his lens have a power of 42,000 times.
+By this divide 240,000 (the moon’s real distance), and we have five
+miles and five sevenths, as the apparent distance. No animal at all
+could be seen so far; much less the minute points particularized in the
+story. Mr. L. speaks about Sir John Herschel’s perceiving flowers (the
+Papaver rheas, etc.), and even detecting the color and the shape of the
+eyes of small birds. Shortly before, too, he has himself observed that
+the lens would not render perceptible objects of less than eighteen
+inches in diameter; but even this, as I have said, is giving the glass
+by far too great power. It may be observed, in passing, that this
+prodigious glass is said to have been molded at the glasshouse of
+Messrs. Hartley and Grant, in Dumbarton; but Messrs. H. and G.’s
+establishment had ceased operations for many years previous to the
+publication of the hoax.
+
+On page 13, pamphlet edition, speaking of “a hairy veil” over the eyes
+of a species of bison, the author says: “It immediately occurred to the
+acute mind of Dr. Herschel that this was a providential contrivance
+to protect the eyes of the animal from the great extremes of light
+and darkness to which all the inhabitants of our side of the moon are
+periodically subjected.” But this cannot be thought a very “acute”
+ observation of the Doctor’s. The inhabitants of our side of the moon
+have, evidently, no darkness at all, so there can be nothing of the
+“extremes” mentioned. In the absence of the sun they have a light from
+the earth equal to that of thirteen full unclouded moons.
+
+The topography throughout, even when professing to accord with Blunt’s
+Lunar Chart, is entirely at variance with that or any other lunar chart,
+and even grossly at variance with itself. The points of the compass,
+too, are in inextricable confusion; the writer appearing to be ignorant
+that, on a lunar map, these are not in accordance with terrestrial
+points; the east being to the left, etc.
+
+Deceived, perhaps, by the vague titles, Mare Nubium, Mare
+Tranquillitatis, Mare Faecunditatis, etc., given to the dark spots by
+former astronomers, Mr. L. has entered into details regarding oceans
+and other large bodies of water in the moon; whereas there is no
+astronomical point more positively ascertained than that no such bodies
+exist there. In examining the boundary between light and darkness (in
+the crescent or gibbous moon) where this boundary crosses any of the
+dark places, the line of division is found to be rough and jagged; but,
+were these dark places liquid, it would evidently be even.
+
+The description of the wings of the man-bat, on page 21, is but a
+literal copy of Peter Wilkins’ account of the wings of his flying
+islanders. This simple fact should have induced suspicion, at least, it
+might be thought.
+
+On page 23, we have the following: “What a prodigious influence must our
+thirteen times larger globe have exercised upon this satellite when an
+embryo in the womb of time, the passive subject of chemical affinity!”
+ This is very fine; but it should be observed that no astronomer would
+have made such remark, especially to any journal of Science; for the
+earth, in the sense intended, is not only thirteen, but forty-nine times
+larger than the moon. A similar objection applies to the whole of the
+concluding pages, where, by way of introduction to some discoveries in
+Saturn, the philosophical correspondent enters into a minute schoolboy
+account of that planet--this to the “Edinburgh journal of Science!”
+
+But there is one point, in particular, which should have betrayed the
+fiction. Let us imagine the power actually possessed of seeing animals
+upon the moon’s surface--what would first arrest the attention of an
+observer from the earth? Certainly neither their shape, size, nor any
+other such peculiarity, so soon as their remarkable _situation_. They
+would appear to be walking, with heels up and head down, in the manner
+of flies on a ceiling. The _real_ observer would have uttered an instant
+ejaculation of surprise (however prepared by previous knowledge) at the
+singularity of their position; the _fictitious_ observer has not even
+mentioned the subject, but speaks of seeing the entire bodies of such
+creatures, when it is demonstrable that he could have seen only the
+diameter of their heads!
+
+It might as well be remarked, in conclusion, that the size, and
+particularly the powers of the man-bats (for example, their ability to
+fly in so rare an atmosphere--if, indeed, the moon have any), with most
+of the other fancies in regard to animal and vegetable existence, are at
+variance, generally, with all analogical reasoning on these themes; and
+that analogy here will often amount to conclusive demonstration. It is,
+perhaps, scarcely necessary to add, that all the suggestions attributed
+to Brewster and Herschel, in the beginning of the article, about “a
+transfusion of artificial light through the focal object of vision,”
+ etc., etc., belong to that species of figurative writing which comes,
+most properly, under the denomination of rigmarole.
+
+There is a real and very definite limit to optical discovery among the
+stars--a limit whose nature need only be stated to be understood. If,
+indeed, the casting of large lenses were all that is required, man’s
+ingenuity would ultimately prove equal to the task, and we might have
+them of any size demanded. But, unhappily, in proportion to the increase
+of size in the lens, and consequently of space-penetrating power, is the
+diminution of light from the object, by diffusion of its rays. And for
+this evil there is no remedy within human ability; for an object is seen
+by means of that light alone which proceeds from itself, whether direct
+or reflected. Thus the only “artificial” light which could avail
+Mr. Locke, would be some artificial light which he should be able to
+throw-not upon the “focal object of vision,” but upon the real object
+to be viewed-to wit: upon the moon. It has been easily calculated that,
+when the light proceeding from a star becomes so diffused as to be as
+weak as the natural light proceeding from the whole of the stars, in
+a clear and moonless night, then the star is no longer visible for any
+practical purpose.
+
+The Earl of Ross’s telescope, lately constructed in England, has
+a _speculum_ with a reflecting surface of 4,071 square inches; the
+Herschel telescope having one of only 1,811. The metal of the Earl of
+Ross’s is 6 feet diameter; it is 5 1/2 inches thick at the edges, and 5
+at the centre. The weight is 3 tons. The focal length is 50 feet.
+
+I have lately read a singular and somewhat ingenious little book, whose
+title-page runs thus: “L’Homme dans la lvne ou le Voyage Chimerique
+fait au Monde de la Lvne, nouellement decouvert par Dominique Gonzales,
+Aduanturier Espagnol, autrem?t dit le Courier volant. Mis en notre
+langve par J. B. D. A. Paris, chez Francois Piot, pres la Fontaine de
+Saint Benoist. Et chez J. Goignard, au premier pilier de la grand’salle
+du Palais, proche les Consultations, MDCXLVII.” Pp. 76.
+
+The writer professes to have translated his work from the English of one
+Mr. D’Avisson (Davidson?) although there is a terrible ambiguity in the
+statement. “J’ en ai eu,” says he “l’original de Monsieur D’Avisson,
+medecin des mieux versez qui soient aujourd’huy dans la cõnoissance des
+Belles Lettres, et sur tout de la Philosophic Naturelle. Je lui ai cette
+obligation entre les autres, de m’ auoir non seulement mis en main
+cc Livre en anglois, mais encore le Manuscrit du Sieur Thomas D’Anan,
+gentilhomme Eccossois, recommandable pour sa vertu, sur la version
+duquel j’ advoue que j’ ay tiré le plan de la mienne.”
+
+After some irrelevant adventures, much in the manner of Gil Blas, and
+which occupy the first thirty pages, the author relates that, being
+ill during a sea voyage, the crew abandoned him, together with a
+negro servant, on the island of St. Helena. To increase the chances of
+obtaining food, the two separate, and live as far apart as possible.
+This brings about a training of birds, to serve the purpose of
+carrier-pigeons between them. By and by these are taught to carry
+parcels of some weight-and this weight is gradually increased. At length
+the idea is entertained of uniting the force of a great number of the
+birds, with a view to raising the author himself. A machine is contrived
+for the purpose, and we have a minute description of it, which is
+materially helped out by a steel engraving. Here we perceive the
+Signor Gonzales, with point ruffles and a huge periwig, seated astride
+something which resembles very closely a broomstick, and borne aloft by
+a multitude of wild swans _(ganzas) _who had strings reaching from their
+tails to the machine.
+
+The main event detailed in the Signor’s narrative depends upon a very
+important fact, of which the reader is kept in ignorance until near the
+end of the book. The _ganzas, _with whom he had become so familiar, were
+not really denizens of St. Helena, but of the moon. Thence it had been
+their custom, time out of mind, to migrate annually to some portion of
+the earth. In proper season, of course, they would return home; and
+the author, happening, one day, to require their services for a short
+voyage, is unexpectedly carried straight tip, and in a very brief period
+arrives at the satellite. Here he finds, among other odd things, that
+the people enjoy extreme happiness; that they have no _law; _that they
+die without pain; that they are from ten to thirty feet in height;
+that they live five thousand years; that they have an emperor called
+Irdonozur; and that they can jump sixty feet high, when, being out of
+the gravitating influence, they fly about with fans.
+
+I cannot forbear giving a specimen of the general _philosophy _of the
+volume.
+
+“I must not forget here, that the stars appeared only on that side of
+the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also me and the earth. As to the
+stars, _since there was no night where I was, they always had the same
+appearance; not brilliant, as usual, but pale, and very nearly like the
+moon of a morning. _But few of them were visible, and these ten times
+larger (as well as I could judge) than they seem to the inhabitants
+of the earth. The moon, which wanted two days of being full, was of a
+terrible bigness.
+
+ “I must not forget here, that the stars appeared only on that side
+of the globe turned toward the moon, and that the closer they were to it
+the larger they seemed. I have also to inform you that, whether it was
+calm weather or stormy, I found myself _always immediately between the
+moon and the earth._ I_ _was convinced of this for two reasons-because
+my birds always flew in a straight line; and because whenever we
+attempted to rest, _we were carried insensibly around the globe of the
+earth. _For I admit the opinion of Copernicus, who maintains that it
+never ceases to revolve _from the east to the west, _not upon the poles
+of the Equinoctial, commonly called the poles of the world, but upon
+those of the Zodiac, a question of which I propose to speak more at
+length here-after, when I shall have leisure to refresh my memory in
+regard to the astrology which I learned at Salamanca when young, and
+have since forgotten.”
+
+Notwithstanding the blunders italicized, the book is not without
+some claim to attention, as affording a naive specimen of the current
+astronomical notions of the time. One of these assumed, that the
+“gravitating power” extended but a short distance from the earth’s
+surface, and, accordingly, we find our voyager “carried insensibly
+around the globe,” etc.
+
+There have been other “voyages to the moon,” but none of higher merit
+than the one just mentioned. That of Bergerac is utterly meaningless. In
+the third volume of the “American Quarterly Review” will be found
+quite an elaborate criticism upon a certain “journey” of the kind in
+question--a criticism in which it is difficult to say whether the critic
+most exposes the stupidity of the book, or his own absurd ignorance of
+astronomy. I forget the title of the work; but the _means _of the voyage
+are more deplorably ill conceived than are even the _ganzas _of our
+friend the Signor Gonzales. The adventurer, in digging the earth,
+happens to discover a peculiar metal for which the moon has a strong
+attraction, and straightway constructs of it a box, which, when cast
+loose from its terrestrial fastenings, flies with him, forthwith, to
+the satellite. The “Flight of Thomas O’Rourke,” is a _jeu d’ esprit _not
+altogether contemptible, and has been translated into German. Thomas,
+the hero, was, in fact, the gamekeeper of an Irish peer, whose
+eccentricities gave rise to the tale. The “flight” is made on an eagle’s
+back, from Hungry Hill, a lofty mountain at the end of Bantry Bay.
+
+In these various _brochures _the aim is always satirical; the theme
+being a description of Lunarian customs as compared with ours. In none
+is there any effort at _plausibility _in the details of the voyage
+itself. The writers seem, in each instance, to be utterly uninformed in
+respect to astronomy. In “Hans Pfaall” the design is original, inasmuch
+as regards an attempt at _verisimilitude, _in the application of
+scientific principles (so far as the whimsical nature of the subject
+would permit), to the actual passage between the earth and the moon.
+
+(*2) The zodiacal light is probably what the ancients called Trabes.
+Emicant Trabes quos docos vocant.--Pliny, lib. 2, p. 26.
+
+(*3) Since the original publication of Hans Pfaall, I find that Mr.
+Green, of Nassau balloon notoriety, and other late aeronauts, deny
+the assertions of Humboldt, in this respect, and speak of a decreasing
+inconvenience,--precisely in accordance with the theory here urged in a
+mere spirit of banter.
+
+(*4) Havelius writes that he has several times found, in skies
+perfectly clear, when even stars of the sixth and seventh magnitude
+were conspicuous, that, at the same altitude of the moon, at the
+same elongation from the earth, and with one and the same excellent
+telescope, the moon and its maculae did not appear equally lucid at all
+times. From the circumstances of the observation, it is evident that the
+cause of this phenomenon is not either in our air, in the tube, in
+the moon, or in the eye of the spectator, but must be looked for in
+something (an atmosphere?) existing about the moon.
+
+
+
+
+THE GOLD-BUG
+
+          What ho! what ho! this fellow is dancing mad!
+
+               He hath been bitten by the Tarantula.
+
+                    _--All in the Wrong._
+
+MANY years ago, I contracted an intimacy with a Mr. William Legrand.
+He was of an ancient Huguenot family, and had once been wealthy; but
+a series of misfortunes had reduced him to want. To avoid the
+mortification consequent upon his disasters, he left New Orleans, the
+city of his forefathers, and took up his residence at Sullivan’s Island,
+near Charleston, South Carolina. This Island is a very singular one.
+It consists of little else than the sea sand, and is about three
+miles long. Its breadth at no point exceeds a quarter of a mile. It is
+separated from the main land by a scarcely perceptible creek, oozing its
+way through a wilderness of reeds and slime, a favorite resort of the
+marsh hen. The vegetation, as might be supposed, is scant, or at least
+dwarfish. No trees of any magnitude are to be seen. Near the western
+extremity, where Fort Moultrie stands, and where are some miserable
+frame buildings, tenanted, during summer, by the fugitives from
+Charleston dust and fever, may be found, indeed, the bristly palmetto;
+but the whole island, with the exception of this western point, and
+a line of hard, white beach on the seacoast, is covered with a dense
+undergrowth of the sweet myrtle, so much prized by the horticulturists
+of England. The shrub here often attains the height of fifteen or twenty
+feet, and forms an almost impenetrable coppice, burthening the air with
+its fragrance.
+
+In the inmost recesses of this coppice, not far from the eastern or more
+remote end of the island, Legrand had built himself a small hut, which
+he occupied when I first, by mere accident, made his acquaintance.
+This soon ripened into friendship--for there was much in the recluse
+to excite interest and esteem. I found him well educated, with unusual
+powers of mind, but infected with misanthropy, and subject to perverse
+moods of alternate enthusiasm and melancholy. He had with him many
+books, but rarely employed them. His chief amusements were gunning and
+fishing, or sauntering along the beach and through the myrtles, in quest
+of shells or entomological specimens;--his collection of the latter
+might have been envied by a Swammerdamm. In these excursions he was
+usually accompanied by an old negro, called Jupiter, who had been
+manumitted before the reverses of the family, but who could be induced,
+neither by threats nor by promises, to abandon what he considered his
+right of attendance upon the footsteps of his young “Massa Will.” It
+is not improbable that the relatives of Legrand, conceiving him to be
+somewhat unsettled in intellect, had contrived to instil this obstinacy
+into Jupiter, with a view to the supervision and guardianship of the
+wanderer.
+
+The winters in the latitude of Sullivan’s Island are seldom very severe,
+and in the fall of the year it is a rare event indeed when a fire is
+considered necessary. About the middle of October, 18-, there occurred,
+however, a day of remarkable chilliness. Just before sunset I scrambled
+my way through the evergreens to the hut of my friend, whom I had
+not visited for several weeks--my residence being, at that time,
+in Charleston, a distance of nine miles from the Island, while the
+facilities of passage and re-passage were very far behind those of
+the present day. Upon reaching the hut I rapped, as was my custom,
+and getting no reply, sought for the key where I knew it was secreted,
+unlocked the door and went in. A fine fire was blazing upon the hearth.
+It was a novelty, and by no means an ungrateful one. I threw off an
+overcoat, took an arm-chair by the crackling logs, and awaited patiently
+the arrival of my hosts.
+
+Soon after dark they arrived, and gave me a most cordial welcome.
+Jupiter, grinning from ear to ear, bustled about to prepare some
+marsh-hens for supper. Legrand was in one of his fits--how else shall
+I term them?--of enthusiasm. He had found an unknown bivalve, forming
+a new genus, and, more than this, he had hunted down and secured, with
+Jupiter’s assistance, a scarabæus which he believed to be totally new,
+but in respect to which he wished to have my opinion on the morrow.
+
+“And why not to-night?” I asked, rubbing my hands over the blaze, and
+wishing the whole tribe of scarabæi at the devil.
+
+“Ah, if I had only known you were here!” said Legrand, “but it’s so long
+since I saw you; and how could I foresee that you would pay me a visit
+this very night of all others? As I was coming home I met Lieutenant
+G--, from the fort, and, very foolishly, I lent him the bug; so it will
+be impossible for you to see it until the morning. Stay here to-night,
+and I will send Jup down for it at sunrise. It is the loveliest thing in
+creation!”
+
+“What?--sunrise?”
+
+“Nonsense! no!--the bug. It is of a brilliant gold color--about the size
+of a large hickory-nut--with two jet black spots near one extremity of
+the back, and another, somewhat longer, at the other. The antennæ are--”
+
+“Dey aint no tin in him, Massa Will, I keep a tellin on you,” here
+interrupted Jupiter; “de bug is a goole bug, solid, ebery bit of him,
+inside and all, sep him wing--neber feel half so hebby a bug in my
+life.”
+
+“Well, suppose it is, Jup,” replied Legrand, somewhat more earnestly,
+it seemed to me, than the case demanded, “is that any reason for your
+letting the birds burn? The color”--here he turned to me--“is really
+almost enough to warrant Jupiter’s idea. You never saw a more brilliant
+metallic lustre than the scales emit--but of this you cannot judge
+till tomorrow. In the mean time I can give you some idea of the shape.”
+ Saying this, he seated himself at a small table, on which were a pen and
+ink, but no paper. He looked for some in a drawer, but found none.
+
+“Never mind,” said he at length, “this will answer;” and he drew from
+his waistcoat pocket a scrap of what I took to be very dirty foolscap,
+and made upon it a rough drawing with the pen. While he did this, I
+retained my seat by the fire, for I was still chilly. When the design
+was complete, he handed it to me without rising. As I received it, a
+loud growl was heard, succeeded by a scratching at the door. Jupiter
+opened it, and a large Newfoundland, belonging to Legrand, rushed in,
+leaped upon my shoulders, and loaded me with caresses; for I had shown
+him much attention during previous visits. When his gambols were over, I
+looked at the paper, and, to speak the truth, found myself not a little
+puzzled at what my friend had depicted.
+
+“Well!” I said, after contemplating it for some minutes, “this is a
+strange scarabæus, I must confess: new to me: never saw anything like it
+before--unless it was a skull, or a death’s-head--which it more nearly
+resembles than anything else that has come under my observation.”
+
+“A death’s-head!” echoed Legrand--“Oh--yes--well, it has something of
+that appearance upon paper, no doubt. The two upper black spots look
+like eyes, eh? and the longer one at the bottom like a mouth--and then
+the shape of the whole is oval.”
+
+“Perhaps so,” said I; “but, Legrand, I fear you are no artist. I must
+wait until I see the beetle itself, if I am to form any idea of its
+personal appearance.”
+
+“Well, I don’t know,” said he, a little nettled, “I draw
+tolerably--should do it at least--have had good masters, and flatter
+myself that I am not quite a blockhead.”
+
+“But, my dear fellow, you are joking then,” said I, “this is a very
+passable skull--indeed, I may say that it is a very excellent skull,
+according to the vulgar notions about such specimens of physiology--and
+your scarabæus must be the queerest scarabæus in the world if it
+resembles it. Why, we may get up a very thrilling bit of superstition
+upon this hint. I presume you will call the bug scarabæus caput hominis,
+or something of that kind--there are many similar titles in the Natural
+Histories. But where are the antennæ you spoke of?”
+
+“The antennæ!” said Legrand, who seemed to be getting unaccountably warm
+upon the subject; “I am sure you must see the antennæ. I made them
+as distinct as they are in the original insect, and I presume that is
+sufficient.”
+
+“Well, well,” I said, “perhaps you have--still I don’t see them;” and
+I handed him the paper without additional remark, not wishing to ruffle
+his temper; but I was much surprised at the turn affairs had taken; his
+ill humor puzzled me--and, as for the drawing of the beetle, there
+were positively no antennæ visible, and the whole did bear a very close
+resemblance to the ordinary cuts of a death’s-head.
+
+He received the paper very peevishly, and was about to crumple it,
+apparently to throw it in the fire, when a casual glance at the design
+seemed suddenly to rivet his attention. In an instant his face grew
+violently red--in another as excessively pale. For some minutes he
+continued to scrutinize the drawing minutely where he sat. At length he
+arose, took a candle from the table, and proceeded to seat himself upon
+a sea-chest in the farthest corner of the room. Here again he made an
+anxious examination of the paper; turning it in all directions. He said
+nothing, however, and his conduct greatly astonished me; yet I thought
+it prudent not to exacerbate the growing moodiness of his temper by any
+comment. Presently he took from his coat pocket a wallet, placed the
+paper carefully in it, and deposited both in a writing-desk, which he
+locked. He now grew more composed in his demeanor; but his original air
+of enthusiasm had quite disappeared. Yet he seemed not so much sulky as
+abstracted. As the evening wore away he became more and more absorbed in
+reverie, from which no sallies of mine could arouse him. It had been my
+intention to pass the night at the hut, as I had frequently done before,
+but, seeing my host in this mood, I deemed it proper to take leave. He
+did not press me to remain, but, as I departed, he shook my hand with
+even more than his usual cordiality.
+
+It was about a month after this (and during the interval I had seen
+nothing of Legrand) when I received a visit, at Charleston, from his
+man, Jupiter. I had never seen the good old negro look so dispirited,
+and I feared that some serious disaster had befallen my friend.
+
+“Well, Jup,” said I, “what is the matter now?--how is your master?”
+
+“Why, to speak de troof, massa, him not so berry well as mought be.”
+
+“Not well! I am truly sorry to hear it. What does he complain of?”
+
+“Dar! dat’s it!--him neber plain of notin--but him berry sick for all
+dat.”
+
+“Very sick, Jupiter!--why didn’t you say so at once? Is he confined to
+bed?”
+
+“No, dat he aint!--he aint find nowhar--dat’s just whar de shoe
+pinch--my mind is got to be berry hebby bout poor Massa Will.”
+
+“Jupiter, I should like to understand what it is you are talking about.
+You say your master is sick. Hasn’t he told you what ails him?”
+
+“Why, massa, taint worf while for to git mad about de matter--Massa
+Will say noffin at all aint de matter wid him--but den what make him go
+about looking dis here way, wid he head down and he soldiers up, and as
+white as a gose? And den he keep a syphon all de time--”
+
+“Keeps a what, Jupiter?”
+
+“Keeps a syphon wid de figgurs on de slate--de queerest figgurs I ebber
+did see. Ise gittin to be skeered, I tell you. Hab for to keep mighty
+tight eye pon him noovers. Todder day he gib me slip fore de sun up and
+was gone de whole ob de blessed day. I had a big stick ready cut for to
+gib him deuced good beating when he did come--but Ise sich a fool dat I
+hadn’t de heart arter all--he look so berry poorly.”
+
+“Eh?--what?--ah yes!--upon the whole I think you had better not be too
+severe with the poor fellow--don’t flog him, Jupiter--he can’t very well
+stand it--but can you form no idea of what has occasioned this illness,
+or rather this change of conduct? Has anything unpleasant happened since
+I saw you?”
+
+“No, massa, dey aint bin noffin unpleasant since den--‘twas fore den I’m
+feared--‘twas de berry day you was dare.”
+
+“How? what do you mean?”
+
+“Why, massa, I mean de bug--dare now.”
+
+“The what?”
+
+“De bug,--I’m berry sartain dat Massa Will bin bit somewhere bout de
+head by dat goole-bug.”
+
+“And what cause have you, Jupiter, for such a supposition?”
+
+“Claws enuff, massa, and mouth too. I nebber did see sick a deuced
+bug--he kick and he bite ebery ting what cum near him. Massa Will cotch
+him fuss, but had for to let him go gin mighty quick, I tell you--den
+was de time he must ha got de bite. I did n’t like de look oh de bug
+mouff, myself, no how, so I would n’t take hold ob him wid my finger,
+but I cotch him wid a piece ob paper dat I found. I rap him up in de
+paper and stuff piece ob it in he mouff--dat was de way.”
+
+“And you think, then, that your master was really bitten by the beetle,
+and that the bite made him sick?”
+
+“I do n’t tink noffin about it--I nose it. What make him dream bout de
+goole so much, if taint cause he bit by de goole-bug? Ise heerd bout dem
+goole-bugs fore dis.”
+
+“But how do you know he dreams about gold?”
+
+“How I know? why cause he talk about it in he sleep--dat’s how I nose.”
+
+“Well, Jup, perhaps you are right; but to what fortunate circumstance am
+I to attribute the honor of a visit from you to-day?”
+
+“What de matter, massa?”
+
+“Did you bring any message from Mr. Legrand?”
+
+“No, massa, I bring dis here pissel;” and here Jupiter handed me a note
+which ran thus:
+
+    MY DEAR ----
+
+Why have I not seen you for so long a time? I hope you have not been so
+foolish as to take offence at any little _brusquerie_ of mine; but no,
+that is improbable. Since I saw you I have had great cause for anxiety.
+I have something to tell you, yet scarcely know how to tell it, or
+whether I should tell it at all.
+
+I have not been quite well for some days past, and poor old Jup annoys
+me, almost beyond endurance, by his well-meant attentions Would you
+believe it?--he had prepared a huge stick, the other day, with which
+to chastise me for giving him the slip, and spending the day, _solus_,
+among the hills on the main land. I verily believe that my ill looks
+alone saved me a flogging.
+
+I have made no addition to my cabinet since we met.
+
+If you can, in any way, make it convenient, come over with Jupiter.
+_Do_ come. I wish to see you to-_night_, upon business of importance. I
+assure you that it is of the _highest_ importance.
+
+        Ever yours,                     WILLIAM LEGRAND.
+
+There was something in the tone of this note which gave me great
+uneasiness. Its whole style differed materially from that of Legrand.
+What could he be dreaming of? What new crotchet possessed his excitable
+brain? What “business of the highest importance” could he possibly have
+to transact? Jupiter’s account of him boded no good. I dreaded lest the
+continued pressure of misfortune had, at length, fairly unsettled
+the reason of my friend. Without a moment’s hesitation, therefore, I
+prepared to accompany the negro.
+
+Upon reaching the wharf, I noticed a scythe and three spades, all
+apparently new, lying in the bottom of the boat in which we were to
+embark.
+
+“What is the meaning of all this, Jup?” I inquired.
+
+“Him syfe, massa, and spade.”
+
+“Very true; but what are they doing here?”
+
+“Him de syfe and de spade what Massa Will sis pon my buying for him in
+de town, and de debbils own lot of money I had to gib for em.”
+
+“But what, in the name of all that is mysterious, is your ‘Massa Will’
+going to do with scythes and spades?”
+
+“Dat’s more dan I know, and debbil take me if I don’t blieve ‘tis more
+dan he know, too. But it’s all cum ob do bug.”
+
+Finding that no satisfaction was to be obtained of Jupiter, whose whole
+intellect seemed to be absorbed by “de bug,” I now stepped into the boat
+and made sail. With a fair and strong breeze we soon ran into the little
+cove to the northward of Fort Moultrie, and a walk of some two miles
+brought us to the hut. It was about three in the afternoon when we
+arrived. Legrand had been awaiting us in eager expectation. He grasped
+my hand with a nervous empressement which alarmed me and strengthened
+the suspicions already entertained. His countenance was pale even to
+ghastliness, and his deep-set eyes glared with unnatural lustre. After
+some inquiries respecting his health, I asked him, not knowing what
+better to say, if he had yet obtained the scarabæus from Lieutenant
+G ----.
+
+“Oh, yes,” he replied, coloring violently, “I got it from him the next
+morning. Nothing should tempt me to part with that scarabæus. Do you
+know that Jupiter is quite right about it?”
+
+“In what way?” I asked, with a sad foreboding at heart.
+
+“In supposing it to be a bug of real gold.” He said this with an air of
+profound seriousness, and I felt inexpressibly shocked.
+
+“This bug is to make my fortune,” he continued, with a triumphant smile,
+“to reinstate me in my family possessions. Is it any wonder, then, that
+I prize it? Since Fortune has thought fit to bestow it upon me, I have
+only to use it properly and I shall arrive at the gold of which it is
+the index. Jupiter; bring me that scarabæus!”
+
+“What! de bug, massa? I’d rudder not go fer trubble dat bug--you mus git
+him for your own self.” Hereupon Legrand arose, with a grave and
+stately air, and brought me the beetle from a glass case in which it was
+enclosed. It was a beautiful scarabæus, and, at that time, unknown to
+naturalists--of course a great prize in a scientific point of view.
+There were two round, black spots near one extremity of the back, and
+a long one near the other. The scales were exceedingly hard and glossy,
+with all the appearance of burnished gold. The weight of the insect
+was very remarkable, and, taking all things into consideration, I could
+hardly blame Jupiter for his opinion respecting it; but what to make of
+Legrand’s concordance with that opinion, I could not, for the life of
+me, tell.
+
+“I sent for you,” said he, in a grandiloquent tone, when I had completed
+my examination of the beetle, “I sent for you, that I might have your
+counsel and assistance in furthering the views of Fate and of the bug”--
+
+“My dear Legrand,” I cried, interrupting him, “you are certainly unwell,
+and had better use some little precautions. You shall go to bed, and
+I will remain with you a few days, until you get over this. You are
+feverish and”--
+
+“Feel my pulse,” said he.
+
+I felt it, and, to say the truth, found not the slightest indication of
+fever.
+
+“But you may be ill and yet have no fever. Allow me this once to
+prescribe for you. In the first place, go to bed. In the next”--
+
+“You are mistaken,” he interposed, “I am as well as I can expect to be
+under the excitement which I suffer. If you really wish me well, you
+will relieve this excitement.”
+
+“And how is this to be done?”
+
+“Very easily. Jupiter and myself are going upon an expedition into the
+hills, upon the main land, and, in this expedition we shall need the
+aid of some person in whom we can confide. You are the only one we can
+trust. Whether we succeed or fail, the excitement which you now perceive
+in me will be equally allayed.”
+
+“I am anxious to oblige you in any way,” I replied; “but do you mean to
+say that this infernal beetle has any connection with your expedition
+into the hills?”
+
+“It has.”
+
+“Then, Legrand, I can become a party to no such absurd proceeding.”
+
+“I am sorry--very sorry--for we shall have to try it by ourselves.”
+
+“Try it by yourselves! The man is surely mad!--but stay!--how long do
+you propose to be absent?”
+
+“Probably all night. We shall start immediately, and be back, at all
+events, by sunrise.”
+
+“And will you promise me, upon your honor, that when this freak of yours
+is over, and the bug business (good God!) settled to your satisfaction,
+you will then return home and follow my advice implicitly, as that of
+your physician?”
+
+“Yes; I promise; and now let us be off, for we have no time to lose.”
+
+With a heavy heart I accompanied my friend. We started about four
+o’clock--Legrand, Jupiter, the dog, and myself. Jupiter had with him the
+scythe and spades--the whole of which he insisted upon carrying--more
+through fear, it seemed to me, of trusting either of the implements
+within reach of his master, than from any excess of industry or
+complaisance. His demeanor was dogged in the extreme, and “dat deuced
+bug” were the sole words which escaped his lips during the journey. For
+my own part, I had charge of a couple of dark lanterns, while Legrand
+contented himself with the scarabæus, which he carried attached to the
+end of a bit of whip-cord; twirling it to and fro, with the air of a
+conjuror, as he went. When I observed this last, plain evidence of my
+friend’s aberration of mind, I could scarcely refrain from tears. I
+thought it best, however, to humor his fancy, at least for the present,
+or until I could adopt some more energetic measures with a chance of
+success. In the mean time I endeavored, but all in vain, to sound him in
+regard to the object of the expedition. Having succeeded in inducing
+me to accompany him, he seemed unwilling to hold conversation upon any
+topic of minor importance, and to all my questions vouchsafed no other
+reply than “we shall see!”
+
+We crossed the creek at the head of the island by means of a skiff; and,
+ascending the high grounds on the shore of the main land, proceeded in a
+northwesterly direction, through a tract of country excessively wild and
+desolate, where no trace of a human footstep was to be seen. Legrand led
+the way with decision; pausing only for an instant, here and there, to
+consult what appeared to be certain landmarks of his own contrivance
+upon a former occasion.
+
+In this manner we journeyed for about two hours, and the sun was just
+setting when we entered a region infinitely more dreary than any yet
+seen. It was a species of table land, near the summit of an almost
+inaccessible hill, densely wooded from base to pinnacle, and
+interspersed with huge crags that appeared to lie loosely upon the soil,
+and in many cases were prevented from precipitating themselves into the
+valleys below, merely by the support of the trees against which they
+reclined. Deep ravines, in various directions, gave an air of still
+sterner solemnity to the scene.
+
+The natural platform to which we had clambered was thickly overgrown
+with brambles, through which we soon discovered that it would have
+been impossible to force our way but for the scythe; and Jupiter, by
+direction of his master, proceeded to clear for us a path to the foot of
+an enormously tall tulip-tree, which stood, with some eight or ten oaks,
+upon the level, and far surpassed them all, and all other trees which I
+had then ever seen, in the beauty of its foliage and form, in the wide
+spread of its branches, and in the general majesty of its appearance.
+When we reached this tree, Legrand turned to Jupiter, and asked him if
+he thought he could climb it. The old man seemed a little staggered
+by the question, and for some moments made no reply. At length he
+approached the huge trunk, walked slowly around it, and examined it with
+minute attention. When he had completed his scrutiny, he merely said,
+
+“Yes, massa, Jup climb any tree he ebber see in he life.”
+
+“Then up with you as soon as possible, for it will soon be too dark to
+see what we are about.”
+
+“How far mus go up, massa?” inquired Jupiter.
+
+“Get up the main trunk first, and then I will tell you which way to
+go--and here--stop! take this beetle with you.”
+
+“De bug, Massa Will!--de goole bug!” cried the negro, drawing back in
+dismay--“what for mus tote de bug way up de tree?--d-n if I do!”
+
+“If you are afraid, Jup, a great big negro like you, to take hold of
+a harmless little dead beetle, why you can carry it up by this
+string--but, if you do not take it up with you in some way, I shall be
+under the necessity of breaking your head with this shovel.”
+
+“What de matter now, massa?” said Jup, evidently shamed into compliance;
+“always want for to raise fuss wid old nigger. Was only funnin any how.
+Me feered de bug! what I keer for de bug?” Here he took cautiously hold
+of the extreme end of the string, and, maintaining the insect as far
+from his person as circumstances would permit, prepared to ascend the
+tree.
+
+In youth, the tulip-tree, or Liriodendron Tulipferum, the most
+magnificent of American foresters, has a trunk peculiarly smooth, and
+often rises to a great height without lateral branches; but, in its
+riper age, the bark becomes gnarled and uneven, while many short limbs
+make their appearance on the stem. Thus the difficulty of ascension, in
+the present case, lay more in semblance than in reality. Embracing the
+huge cylinder, as closely as possible, with his arms and knees, seizing
+with his hands some projections, and resting his naked toes upon
+others, Jupiter, after one or two narrow escapes from falling, at length
+wriggled himself into the first great fork, and seemed to consider the
+whole business as virtually accomplished. The risk of the achievement
+was, in fact, now over, although the climber was some sixty or seventy
+feet from the ground.
+
+“Which way mus go now, Massa Will?” he asked.
+
+“Keep up the largest branch--the one on this side,” said Legrand. The
+negro obeyed him promptly, and apparently with but little trouble;
+ascending higher and higher, until no glimpse of his squat figure could
+be obtained through the dense foliage which enveloped it. Presently his
+voice was heard in a sort of halloo.
+
+“How much fudder is got for go?”
+
+“How high up are you?” asked Legrand.
+
+“Ebber so fur,” replied the negro; “can see de sky fru de top ob de
+tree.”
+
+“Never mind the sky, but attend to what I say. Look down the trunk and
+count the limbs below you on this side. How many limbs have you passed?”
+
+“One, two, tree, four, fibe--I done pass fibe big limb, massa, pon dis
+side.”
+
+“Then go one limb higher.”
+
+In a few minutes the voice was heard again, announcing that the seventh
+limb was attained.
+
+“Now, Jup,” cried Legrand, evidently much excited, “I want you to work
+your way out upon that limb as far as you can. If you see anything
+strange, let me know.” By this time what little doubt I might have
+entertained of my poor friend’s insanity, was put finally at rest. I had
+no alternative but to conclude him stricken with lunacy, and I became
+seriously anxious about getting him home. While I was pondering upon
+what was best to be done, Jupiter’s voice was again heard.
+
+“Mos feerd for to ventur pon dis limb berry far--tis dead limb putty
+much all de way.”
+
+“Did you say it was a dead limb, Jupiter?” cried Legrand in a quavering
+voice.
+
+“Yes, massa, him dead as de door-nail--done up for sartain--done
+departed dis here life.”
+
+“What in the name heaven shall I do?” asked Legrand, seemingly in the
+greatest distress. “Do!” said I, glad of an opportunity to interpose
+a word, “why come home and go to bed. Come now!--that’s a fine fellow.
+It’s getting late, and, besides, you remember your promise.”
+
+“Jupiter,” cried he, without heeding me in the least, “do you hear me?”
+
+“Yes, Massa Will, hear you ebber so plain.”
+
+“Try the wood well, then, with your knife, and see if you think it very
+rotten.”
+
+“Him rotten, massa, sure nuff,” replied the negro in a few moments, “but
+not so berry rotten as mought be. Mought ventur out leetle way pon de
+limb by myself, dat’s true.”
+
+“By yourself!--what do you mean?”
+
+“Why I mean de bug. ‘Tis berry hebby bug. Spose I drop him down fuss,
+and den de limb won’t break wid just de weight ob one nigger.”
+
+“You infernal scoundrel!” cried Legrand, apparently much relieved, “what
+do you mean by telling me such nonsense as that? As sure as you drop
+that beetle I’ll break your neck. Look here, Jupiter, do you hear me?”
+
+“Yes, massa, needn’t hollo at poor nigger dat style.”
+
+“Well! now listen!--if you will venture out on the limb as far as you
+think safe, and not let go the beetle, I’ll make you a present of a
+silver dollar as soon as you get down.”
+
+“I’m gwine, Massa Will--deed I is,” replied the negro very
+promptly--“mos out to the eend now.”
+
+“Out to the end!” here fairly screamed Legrand, “do you say you are out
+to the end of that limb?”
+
+“Soon be to de eend, massa,--o-o-o-o-oh! Lor-gol-a-marcy! what is dis
+here pon de tree?”
+
+“Well!” cried Legrand, highly delighted, “what is it?”
+
+“Why taint noffin but a skull--somebody bin lef him head up de tree, and
+de crows done gobble ebery bit ob de meat off.”
+
+“A skull, you say!--very well!--how is it fastened to the limb?--what
+holds it on?”
+
+“Sure nuff, massa; mus look. Why dis berry curous sarcumstance, pon my
+word--dare’s a great big nail in de skull, what fastens ob it on to de
+tree.”
+
+“Well now, Jupiter, do exactly as I tell you--do you hear?”
+
+“Yes, massa.”
+
+“Pay attention, then!--find the left eye of the skull.”
+
+“Hum! hoo! dat’s good! why dare aint no eye lef at all.”
+
+“Curse your stupidity! do you know your right hand from your left?”
+
+“Yes, I nose dat--nose all bout dat--tis my lef hand what I chops de
+wood wid.”
+
+“To be sure! you are left-handed; and your left eye is on the same
+side as your left hand. Now, I suppose, you can find the left eye of the
+skull, or the place where the left eye has been. Have you found it?”
+
+Here was a long pause. At length the negro asked,
+
+“Is de lef eye of de skull pon de same side as de lef hand of de skull,
+too?--cause de skull aint got not a bit ob a hand at all--nebber mind!
+I got de lef eye now--here de lef eye! what mus do wid it?”
+
+“Let the beetle drop through it, as far as the string will reach--but
+be careful and not let go your hold of the string.”
+
+“All dat done, Massa Will; mighty easy ting for to put de bug fru de
+hole--look out for him dare below!”
+
+During this colloquy no portion of Jupiter’s person could be seen; but
+the beetle, which he had suffered to descend, was now visible at the
+end of the string, and glistened, like a globe of burnished gold, in the
+last rays of the setting sun, some of which still faintly illumined
+the eminence upon which we stood. The scarabæus hung quite clear of
+any branches, and, if allowed to fall, would have fallen at our feet.
+Legrand immediately took the scythe, and cleared with it a circular
+space, three or four yards in diameter, just beneath the insect, and,
+having accomplished this, ordered Jupiter to let go the string and come
+down from the tree.
+
+Driving a peg, with great nicety, into the ground, at the precise spot
+where the beetle fell, my friend now produced from his pocket a tape
+measure. Fastening one end of this at that point of the trunk, of the
+tree which was nearest the peg, he unrolled it till it reached the peg,
+and thence farther unrolled it, in the direction already established
+by the two points of the tree and the peg, for the distance of fifty
+feet--Jupiter clearing away the brambles with the scythe. At the spot
+thus attained a second peg was driven, and about this, as a centre, a
+rude circle, about four feet in diameter, described. Taking now a spade
+himself, and giving one to Jupiter and one to me, Legrand begged us to
+set about digging as quickly as possible.
+
+To speak the truth, I had no especial relish for such amusement at any
+time, and, at that particular moment, would most willingly have declined
+it; for the night was coming on, and I felt much fatigued with the
+exercise already taken; but I saw no mode of escape, and was fearful
+of disturbing my poor friend’s equanimity by a refusal. Could I have
+depended, indeed, upon Jupiter’s aid, I would have had no hesitation in
+attempting to get the lunatic home by force; but I was too well assured
+of the old negro’s disposition, to hope that he would assist me, under
+any circumstances, in a personal contest with his master. I made no
+doubt that the latter had been infected with some of the innumerable
+Southern superstitions about money buried, and that his phantasy had
+received confirmation by the finding of the scarabæus, or, perhaps, by
+Jupiter’s obstinacy in maintaining it to be “a bug of real gold.” A
+mind disposed to lunacy would readily be led away by such
+suggestions--especially if chiming in with favorite preconceived
+ideas--and then I called to mind the poor fellow’s speech about the
+beetle’s being “the index of his fortune.” Upon the whole, I was sadly
+vexed and puzzled, but, at length, I concluded to make a virtue of
+necessity--to dig with a good will, and thus the sooner to convince the
+visionary, by ocular demonstration, of the fallacy of the opinions he
+entertained.
+
+The lanterns having been lit, we all fell to work with a zeal worthy
+a more rational cause; and, as the glare fell upon our persons and
+implements, I could not help thinking how picturesque a group we
+composed, and how strange and suspicious our labors must have appeared
+to any interloper who, by chance, might have stumbled upon our
+whereabouts.
+
+We dug very steadily for two hours. Little was said; and our chief
+embarrassment lay in the yelpings of the dog, who took exceeding
+interest in our proceedings. He, at length, became so obstreperous
+that we grew fearful of his giving the alarm to some stragglers in
+the vicinity;--or, rather, this was the apprehension of Legrand;--for
+myself, I should have rejoiced at any interruption which might have
+enabled me to get the wanderer home. The noise was, at length, very
+effectually silenced by Jupiter, who, getting out of the hole with a
+dogged air of deliberation, tied the brute’s mouth up with one of his
+suspenders, and then returned, with a grave chuckle, to his task.
+
+When the time mentioned had expired, we had reached a depth of five
+feet, and yet no signs of any treasure became manifest. A general pause
+ensued, and I began to hope that the farce was at an end. Legrand,
+however, although evidently much disconcerted, wiped his brow
+thoughtfully and recommenced. We had excavated the entire circle of four
+feet diameter, and now we slightly enlarged the limit, and went to the
+farther depth of two feet. Still nothing appeared. The gold-seeker, whom
+I sincerely pitied, at length clambered from the pit, with the bitterest
+disappointment imprinted upon every feature, and proceeded, slowly
+and reluctantly, to put on his coat, which he had thrown off at the
+beginning of his labor. In the mean time I made no remark. Jupiter, at a
+signal from his master, began to gather up his tools. This done, and the
+dog having been unmuzzled, we turned in profound silence towards home.
+
+We had taken, perhaps, a dozen steps in this direction, when, with a
+loud oath, Legrand strode up to Jupiter, and seized him by the collar.
+The astonished negro opened his eyes and mouth to the fullest extent,
+let fall the spades, and fell upon his knees.
+
+“You scoundrel,” said Legrand, hissing out the syllables from between
+his clenched teeth--“you infernal black villain!--speak, I tell
+you!--answer me this instant, without prevarication!--which--which is
+your left eye?”
+
+“Oh, my golly, Massa Will! aint dis here my lef eye for sartain?” roared
+the terrified Jupiter, placing his hand upon his right organ of vision,
+and holding it there with a desperate pertinacity, as if in immediate
+dread of his master’s attempt at a gouge.
+
+“I thought so!--I knew it! hurrah!” vociferated Legrand, letting the
+negro go, and executing a series of curvets and caracols, much to the
+astonishment of his valet, who, arising from his knees, looked, mutely,
+from his master to myself, and then from myself to his master.
+
+“Come! we must go back,” said the latter, “the game’s not up yet;” and
+he again led the way to the tulip-tree.
+
+“Jupiter,” said he, when we reached its foot, “come here! was the skull
+nailed to the limb with the face outwards, or with the face to the
+limb?”
+
+“De face was out, massa, so dat de crows could get at de eyes good,
+widout any trouble.”
+
+“Well, then, was it this eye or that through which you dropped the
+beetle?”--here Legrand touched each of Jupiter’s eyes.
+
+“Twas dis eye, massa--de lef eye--jis as you tell me,” and here it was
+his right eye that the negro indicated.
+
+“That will do--must try it again.”
+
+Here my friend, about whose madness I now saw, or fancied that I saw,
+certain indications of method, removed the peg which marked the spot
+where the beetle fell, to a spot about three inches to the westward
+of its former position. Taking, now, the tape measure from the nearest
+point of the trunk to the peg, as before, and continuing the extension
+in a straight line to the distance of fifty feet, a spot was indicated,
+removed, by several yards, from the point at which we had been digging.
+
+Around the new position a circle, somewhat larger than in the former
+instance, was now described, and we again set to work with the spades.
+I was dreadfully weary, but, scarcely understanding what had occasioned
+the change in my thoughts, I felt no longer any great aversion from the
+labor imposed. I had become most unaccountably interested--nay, even
+excited. Perhaps there was something, amid all the extravagant demeanor
+of Legrand--some air of forethought, or of deliberation, which impressed
+me. I dug eagerly, and now and then caught myself actually looking,
+with something that very much resembled expectation, for the fancied
+treasure, the vision of which had demented my unfortunate companion. At
+a period when such vagaries of thought most fully possessed me, and
+when we had been at work perhaps an hour and a half, we were again
+interrupted by the violent howlings of the dog. His uneasiness, in the
+first instance, had been, evidently, but the result of playfulness or
+caprice, but he now assumed a bitter and serious tone. Upon Jupiter’s
+again attempting to muzzle him, he made furious resistance, and, leaping
+into the hole, tore up the mould frantically with his claws. In a few
+seconds he had uncovered a mass of human bones, forming two complete
+skeletons, intermingled with several buttons of metal, and what appeared
+to be the dust of decayed woollen. One or two strokes of a spade
+upturned the blade of a large Spanish knife, and, as we dug farther,
+three or four loose pieces of gold and silver coin came to light.
+
+At sight of these the joy of Jupiter could scarcely be restrained, but
+the countenance of his master wore an air of extreme disappointment He
+urged us, however, to continue our exertions, and the words were hardly
+uttered when I stumbled and fell forward, having caught the toe of my
+boot in a large ring of iron that lay half buried in the loose earth.
+
+We now worked in earnest, and never did I pass ten minutes of more
+intense excitement. During this interval we had fairly unearthed an
+oblong chest of wood, which, from its perfect preservation and
+wonderful hardness, had plainly been subjected to some mineralizing
+process--perhaps that of the Bi-chloride of Mercury. This box was three
+feet and a half long, three feet broad, and two and a half feet deep. It
+was firmly secured by bands of wrought iron, riveted, and forming a kind
+of open trelliswork over the whole. On each side of the chest, near the
+top, were three rings of iron--six in all--by means of which a firm hold
+could be obtained by six persons. Our utmost united endeavors served
+only to disturb the coffer very slightly in its bed. We at once saw
+the impossibility of removing so great a weight. Luckily, the sole
+fastenings of the lid consisted of two sliding bolts. These we drew
+back--trembling and panting with anxiety. In an instant, a treasure of
+incalculable value lay gleaming before us. As the rays of the lanterns
+fell within the pit, there flashed upwards a glow and a glare, from a
+confused heap of gold and of jewels, that absolutely dazzled our eyes.
+
+I shall not pretend to describe the feelings with which I gazed.
+Amazement was, of course, predominant. Legrand appeared exhausted with
+excitement, and spoke very few words. Jupiter’s countenance wore, for
+some minutes, as deadly a pallor as it is possible, in nature of things,
+for any negro’s visage to assume. He seemed stupified--thunderstricken.
+Presently he fell upon his knees in the pit, and, burying his naked
+arms up to the elbows in gold, let them there remain, as if enjoying the
+luxury of a bath. At length, with a deep sigh, he exclaimed, as if in a
+soliloquy,
+
+“And dis all cum ob de goole-bug! de putty goole bug! de poor little
+goole-bug, what I boosed in dat sabage kind ob style! Aint you shamed ob
+yourself, nigger?--answer me dat!”
+
+It became necessary, at last, that I should arouse both master and valet
+to the expediency of removing the treasure. It was growing late, and
+it behooved us to make exertion, that we might get every thing housed
+before daylight. It was difficult to say what should be done, and much
+time was spent in deliberation--so confused were the ideas of all. We,
+finally, lightened the box by removing two thirds of its contents,
+when we were enabled, with some trouble, to raise it from the hole. The
+articles taken out were deposited among the brambles, and the dog
+left to guard them, with strict orders from Jupiter neither, upon any
+pretence, to stir from the spot, nor to open his mouth until our return.
+We then hurriedly made for home with the chest; reaching the hut in
+safety, but after excessive toil, at one o’clock in the morning. Worn
+out as we were, it was not in human nature to do more immediately. We
+rested until two, and had supper; starting for the hills immediately
+afterwards, armed with three stout sacks, which, by good luck, were upon
+the premises. A little before four we arrived at the pit, divided the
+remainder of the booty, as equally as might be, among us, and, leaving
+the holes unfilled, again set out for the hut, at which, for the second
+time, we deposited our golden burthens, just as the first faint streaks
+of the dawn gleamed from over the tree-tops in the East.
+
+We were now thoroughly broken down; but the intense excitement of the
+time denied us repose. After an unquiet slumber of some three or four
+hours’ duration, we arose, as if by preconcert, to make examination of
+our treasure.
+
+The chest had been full to the brim, and we spent the whole day, and the
+greater part of the next night, in a scrutiny of its contents. There had
+been nothing like order or arrangement. Every thing had been heaped
+in promiscuously. Having assorted all with care, we found ourselves
+possessed of even vaster wealth than we had at first supposed. In
+coin there was rather more than four hundred and fifty thousand
+dollars--estimating the value of the pieces, as accurately as we could,
+by the tables of the period. There was not a particle of silver. All was
+gold of antique date and of great variety--French, Spanish, and German
+money, with a few English guineas, and some counters, of which we had
+never seen specimens before. There were several very large and heavy
+coins, so worn that we could make nothing of their inscriptions. There
+was no American money. The value of the jewels we found more difficulty
+in estimating. There were diamonds--some of them exceedingly large and
+fine--a hundred and ten in all, and not one of them small; eighteen
+rubies of remarkable brilliancy;--three hundred and ten emeralds, all
+very beautiful; and twenty-one sapphires, with an opal. These stones had
+all been broken from their settings and thrown loose in the chest. The
+settings themselves, which we picked out from among the other gold,
+appeared to have been beaten up with hammers, as if to prevent
+identification. Besides all this, there was a vast quantity of solid
+gold ornaments;--nearly two hundred massive finger and earrings;--rich
+chains--thirty of these, if I remember;--eighty-three very large and
+heavy crucifixes;--five gold censers of great value;--a prodigious
+golden punch bowl, ornamented with richly chased vine-leaves and
+Bacchanalian figures; with two sword-handles exquisitely embossed, and
+many other smaller articles which I cannot recollect. The weight of
+these valuables exceeded three hundred and fifty pounds avoirdupois; and
+in this estimate I have not included one hundred and ninety-seven superb
+gold watches; three of the number being worth each five hundred dollars,
+if one. Many of them were very old, and as time keepers valueless; the
+works having suffered, more or less, from corrosion--but all were richly
+jewelled and in cases of great worth. We estimated the entire contents
+of the chest, that night, at a million and a half of dollars; and upon
+the subsequent disposal of the trinkets and jewels (a few being retained
+for our own use), it was found that we had greatly undervalued the
+treasure. When, at length, we had concluded our examination, and the
+intense excitement of the time had, in some measure, subsided, Legrand,
+who saw that I was dying with impatience for a solution of this
+most extraordinary riddle, entered into a full detail of all the
+circumstances connected with it.
+
+“You remember;” said he, “the night when I handed you the rough sketch I
+had made of the scarabæus. You recollect also, that I became quite vexed
+at you for insisting that my drawing resembled a death’s-head. When you
+first made this assertion I thought you were jesting; but afterwards
+I called to mind the peculiar spots on the back of the insect, and
+admitted to myself that your remark had some little foundation in fact.
+Still, the sneer at my graphic powers irritated me--for I am considered
+a good artist--and, therefore, when you handed me the scrap of
+parchment, I was about to crumple it up and throw it angrily into the
+fire.”
+
+“The scrap of paper, you mean,” said I.
+
+“No; it had much of the appearance of paper, and at first I supposed it
+to be such, but when I came to draw upon it, I discovered it, at once,
+to be a piece of very thin parchment. It was quite dirty, you remember.
+Well, as I was in the very act of crumpling it up, my glance fell
+upon the sketch at which you had been looking, and you may imagine my
+astonishment when I perceived, in fact, the figure of a death’s-head
+just where, it seemed to me, I had made the drawing of the beetle. For
+a moment I was too much amazed to think with accuracy. I knew that my
+design was very different in detail from this--although there was a
+certain similarity in general outline. Presently I took a candle, and
+seating myself at the other end of the room, proceeded to scrutinize the
+parchment more closely. Upon turning it over, I saw my own sketch
+upon the reverse, just as I had made it. My first idea, now, was mere
+surprise at the really remarkable similarity of outline--at the singular
+coincidence involved in the fact, that unknown to me, there should have
+been a skull upon the other side of the parchment, immediately beneath
+my figure of the scarabæus, and that this skull, not only in outline,
+but in size, should so closely resemble my drawing. I say the
+singularity of this coincidence absolutely stupified me for a time.
+This is the usual effect of such coincidences. The mind struggles to
+establish a connexion--a sequence of cause and effect--and, being
+unable to do so, suffers a species of temporary paralysis. But, when I
+recovered from this stupor, there dawned upon me gradually a conviction
+which startled me even far more than the coincidence. I began
+distinctly, positively, to remember that there had been no drawing upon
+the parchment when I made my sketch of the scarabæus. I became perfectly
+certain of this; for I recollected turning up first one side and then
+the other, in search of the cleanest spot. Had the skull been then
+there, of course I could not have failed to notice it. Here was indeed
+a mystery which I felt it impossible to explain; but, even at that early
+moment, there seemed to glimmer, faintly, within the most remote and
+secret chambers of my intellect, a glow-worm-like conception of
+that truth which last night’s adventure brought to so magnificent a
+demonstration. I arose at once, and putting the parchment securely away,
+dismissed all farther reflection until I should be alone.
+
+“When you had gone, and when Jupiter was fast asleep, I betook myself
+to a more methodical investigation of the affair. In the first place
+I considered the manner in which the parchment had come into my
+possession. The spot where we discovered the scarabaeus was on the coast
+of the main land, about a mile eastward of the island, and but a short
+distance above high water mark. Upon my taking hold of it, it gave me a
+sharp bite, which caused me to let it drop. Jupiter, with his accustomed
+caution, before seizing the insect, which had flown towards him, looked
+about him for a leaf, or something of that nature, by which to take hold
+of it. It was at this moment that his eyes, and mine also, fell upon the
+scrap of parchment, which I then supposed to be paper. It was lying half
+buried in the sand, a corner sticking up. Near the spot where we found
+it, I observed the remnants of the hull of what appeared to have been a
+ship’s long boat. The wreck seemed to have been there for a very great
+while; for the resemblance to boat timbers could scarcely be traced.
+
+“Well, Jupiter picked up the parchment, wrapped the beetle in it, and
+gave it to me. Soon afterwards we turned to go home, and on the way met
+Lieutenant G-. I showed him the insect, and he begged me to let him
+take it to the fort. Upon my consenting, he thrust it forthwith into his
+waistcoat pocket, without the parchment in which it had been wrapped,
+and which I had continued to hold in my hand during his inspection.
+Perhaps he dreaded my changing my mind, and thought it best to make sure
+of the prize at once--you know how enthusiastic he is on all subjects
+connected with Natural History. At the same time, without being
+conscious of it, I must have deposited the parchment in my own pocket.
+
+“You remember that when I went to the table, for the purpose of making
+a sketch of the beetle, I found no paper where it was usually kept.
+I looked in the drawer, and found none there. I searched my pockets,
+hoping to find an old letter, when my hand fell upon the parchment. I
+thus detail the precise mode in which it came into my possession; for
+the circumstances impressed me with peculiar force.
+
+“No doubt you will think me fanciful--but I had already established a
+kind of connexion. I had put together two links of a great chain. There
+was a boat lying upon a sea-coast, and not far from the boat was a
+parchment--not a paper--with a skull depicted upon it. You will,
+of course, ask ‘where is the connexion?’ I reply that the skull, or
+death’s-head, is the well-known emblem of the pirate. The flag of the
+death’s head is hoisted in all engagements.
+
+“I have said that the scrap was parchment, and not paper. Parchment
+is durable--almost imperishable. Matters of little moment are rarely
+consigned to parchment; since, for the mere ordinary purposes of drawing
+or writing, it is not nearly so well adapted as paper. This reflection
+suggested some meaning--some relevancy--in the death’s-head. I did not
+fail to observe, also, the form of the parchment. Although one of its
+corners had been, by some accident, destroyed, it could be seen that the
+original form was oblong. It was just such a slip, indeed, as might
+have been chosen for a memorandum--for a record of something to be long
+remembered and carefully preserved.”
+
+“But,” I interposed, “you say that the skull was not upon the parchment
+when you made the drawing of the beetle. How then do you trace any
+connexion between the boat and the skull--since this latter, according
+to your own admission, must have been designed (God only knows how or by
+whom) at some period subsequent to your sketching the scarabæus?”
+
+“Ah, hereupon turns the whole mystery; although the secret, at this
+point, I had comparatively little difficulty in solving. My steps were
+sure, and could afford but a single result. I reasoned, for example,
+thus: When I drew the scarabæus, there was no skull apparent upon
+the parchment. When I had completed the drawing I gave it to you, and
+observed you narrowly until you returned it. You, therefore, did not
+design the skull, and no one else was present to do it. Then it was not
+done by human agency. And nevertheless it was done.
+
+“At this stage of my reflections I endeavored to remember, and did
+remember, with entire distinctness, every incident which occurred about
+the period in question. The weather was chilly (oh rare and happy
+accident!), and a fire was blazing upon the hearth. I was heated with
+exercise and sat near the table. You, however, had drawn a chair close
+to the chimney. Just as I placed the parchment in your hand, and as you
+were in the act of inspecting it, Wolf, the Newfoundland, entered,
+and leaped upon your shoulders. With your left hand you caressed him and
+kept him off, while your right, holding the parchment, was permitted to
+fall listlessly between your knees, and in close proximity to the fire.
+At one moment I thought the blaze had caught it, and was about to
+caution you, but, before I could speak, you had withdrawn it, and were
+engaged in its examination. When I considered all these particulars, I
+doubted not for a moment that heat had been the agent in bringing to
+light, upon the parchment, the skull which I saw designed upon it. You
+are well aware that chemical preparations exist, and have existed time
+out of mind, by means of which it is possible to write upon either paper
+or vellum, so that the characters shall become visible only when
+subjected to the action of fire. Zaffre, digested in aqua regia, and
+diluted with four times its weight of water, is sometimes employed; a
+green tint results. The regulus of cobalt, dissolved in spirit of nitre,
+gives a red. These colors disappear at longer or shorter intervals after
+the material written upon cools, but again become apparent upon the
+re-application of heat.
+
+“I now scrutinized the death’s-head with care. Its outer edges--the
+edges of the drawing nearest the edge of the vellum--were far more
+distinct than the others. It was clear that the action of the caloric
+had been imperfect or unequal. I immediately kindled a fire, and
+subjected every portion of the parchment to a glowing heat. At first,
+the only effect was the strengthening of the faint lines in the skull;
+but, upon persevering in the experiment, there became visible, at
+the corner of the slip, diagonally opposite to the spot in which the
+death’s-head was delineated, the figure of what I at first supposed to
+be a goat. A closer scrutiny, however, satisfied me that it was intended
+for a kid.”
+
+“Ha! ha!” said I, “to be sure I have no right to laugh at you--a million
+and a half of money is too serious a matter for mirth--but you are not
+about to establish a third link in your chain--you will not find any
+especial connexion between your pirates and a goat--pirates, you know,
+have nothing to do with goats; they appertain to the farming interest.”
+
+“But I have just said that the figure was not that of a goat.”
+
+“Well, a kid then--pretty much the same thing.”
+
+“Pretty much, but not altogether,” said Legrand. “You may have heard of
+one Captain Kidd. I at once looked upon the figure of the animal as a
+kind of punning or hieroglyphical signature. I say signature; because
+its position upon the vellum suggested this idea. The death’s-head at
+the corner diagonally opposite, had, in the same manner, the air of a
+stamp, or seal. But I was sorely put out by the absence of all else--of
+the body to my imagined instrument--of the text for my context.”
+
+“I presume you expected to find a letter between the stamp and the
+signature.”
+
+“Something of that kind. The fact is, I felt irresistibly impressed with
+a presentiment of some vast good fortune impending. I can scarcely
+say why. Perhaps, after all, it was rather a desire than an actual
+belief;--but do you know that Jupiter’s silly words, about the bug
+being of solid gold, had a remarkable effect upon my fancy? And then the
+series of accidents and coincidences--these were so very extraordinary.
+Do you observe how mere an accident it was that these events should have
+occurred upon the sole day of all the year in which it has been, or may
+be, sufficiently cool for fire, and that without the fire, or without
+the intervention of the dog at the precise moment in which he appeared,
+I should never have become aware of the death’s-head, and so never the
+possessor of the treasure?”
+
+“But proceed--I am all impatience.”
+
+“Well; you have heard, of course, the many stories current--the thousand
+vague rumors afloat about money buried, somewhere upon the Atlantic
+coast, by Kidd and his associates. These rumors must have had some
+foundation in fact. And that the rumors have existed so long and so
+continuous, could have resulted, it appeared to me, only from the
+circumstance of the buried treasure still remaining entombed. Had Kidd
+concealed his plunder for a time, and afterwards reclaimed it, the
+rumors would scarcely have reached us in their present unvarying form.
+You will observe that the stories told are all about money-seekers,
+not about money-finders. Had the pirate recovered his money, there the
+affair would have dropped. It seemed to me that some accident--say the
+loss of a memorandum indicating its locality--had deprived him of the
+means of recovering it, and that this accident had become known to his
+followers, who otherwise might never have heard that treasure had been
+concealed at all, and who, busying themselves in vain, because unguided
+attempts, to regain it, had given first birth, and then universal
+currency, to the reports which are now so common. Have you ever heard of
+any important treasure being unearthed along the coast?”
+
+“Never.”
+
+“But that Kidd’s accumulations were immense, is well known. I took it
+for granted, therefore, that the earth still held them; and you will
+scarcely be surprised when I tell you that I felt a hope, nearly
+amounting to certainty, that the parchment so strangely found, involved
+a lost record of the place of deposit.”
+
+“But how did you proceed?”
+
+“I held the vellum again to the fire, after increasing the heat; but
+nothing appeared. I now thought it possible that the coating of dirt
+might have something to do with the failure; so I carefully rinsed the
+parchment by pouring warm water over it, and, having done this, I
+placed it in a tin pan, with the skull downwards, and put the pan upon
+a furnace of lighted charcoal. In a few minutes, the pan having become
+thoroughly heated, I removed the slip, and, to my inexpressible joy,
+found it spotted, in several places, with what appeared to be figures
+arranged in lines. Again I placed it in the pan, and suffered it to
+remain another minute. Upon taking it off, the whole was just as you see
+it now.” Here Legrand, having re-heated the parchment, submitted it to
+my inspection. The following characters were rudely traced, in a red
+tint, between the death’s-head and the goat:
+
+  “53‡‡†305))6*;4826)4‡)4‡);806*;48†8¶60))85;1‡);:‡
+  *8†83(88)5*†;46(;88*96*?;8)*‡(;485);5*†2:*‡(;4956*
+  2(5*--4)8¶8*;4069285);)6†8)4‡‡;1(‡9;48081;8:8‡1;4
+  8†85;4)485†528806*81(‡9;48;(88;4(‡?34;48)4‡;161;:
+  188;‡?;”
+
+“But,” said I, returning him the slip, “I am as much in the dark as
+ever. Were all the jewels of Golconda awaiting me upon my solution of
+this enigma, I am quite sure that I should be unable to earn them.”
+
+“And yet,” said Legrand, “the solution is by no means so difficult as
+you might be lead to imagine from the first hasty inspection of the
+characters. These characters, as any one might readily guess, form a
+cipher--that is to say, they convey a meaning; but then, from what is
+known of Kidd, I could not suppose him capable of constructing any of
+the more abstruse cryptographs. I made up my mind, at once, that this
+was of a simple species--such, however, as would appear, to the crude
+intellect of the sailor, absolutely insoluble without the key.”
+
+“And you really solved it?”
+
+“Readily; I have solved others of an abstruseness ten thousand times
+greater. Circumstances, and a certain bias of mind, have led me to
+take interest in such riddles, and it may well be doubted whether human
+ingenuity can construct an enigma of the kind which human ingenuity may
+not, by proper application, resolve. In fact, having once established
+connected and legible characters, I scarcely gave a thought to the mere
+difficulty of developing their import.
+
+“In the present case--indeed in all cases of secret writing--the first
+question regards the language of the cipher; for the principles of
+solution, so far, especially, as the more simple ciphers are concerned,
+depend upon, and are varied by, the genius of the particular idiom.
+In general, there is no alternative but experiment (directed by
+probabilities) of every tongue known to him who attempts the solution,
+until the true one be attained. But, with the cipher now before us, all
+difficulty was removed by the signature. The pun upon the word ‘Kidd’
+is appreciable in no other language than the English. But for this
+consideration I should have begun my attempts with the Spanish and
+French, as the tongues in which a secret of this kind would most
+naturally have been written by a pirate of the Spanish main. As it was,
+I assumed the cryptograph to be English.
+
+“You observe there are no divisions between the words. Had there been
+divisions, the task would have been comparatively easy. In such case
+I should have commenced with a collation and analysis of the shorter
+words, and, had a word of a single letter occurred, as is most likely,
+(a or I, for example,) I should have considered the solution as assured.
+But, there being no division, my first step was to ascertain the
+predominant letters, as well as the least frequent. Counting all, I
+constructed a table, thus:
+
+Of the character 8 there are 33.
+
+                          ;        “     26.
+                          4        “     19.
+                        ‡ )        “     16.
+                          *        “     13.
+                          5        “     12.
+                          6        “     11.
+                        † 1        “      8.
+                          0        “      6.
+                        9 2        “      5.
+                        : 3        “      4.
+                          ?        “      3.
+                          ¶        “      2.
+                         -.        “      1.
+
+“Now, in English, the letter which most frequently occurs is e.
+Afterwards, succession runs thus: _a o i d h n r s t u y c f g l m w b k
+p q x z_. _E_ predominates so remarkably that an individual sentence of
+any length is rarely seen, in which it is not the prevailing character.
+
+“Here, then, we leave, in the very beginning, the groundwork for
+something more than a mere guess. The general use which may be made of
+the table is obvious--but, in this particular cipher, we shall only very
+partially require its aid. As our predominant character is 8, we will
+commence by assuming it as the _e_ of the natural alphabet. To verify
+the supposition, let us observe if the 8 be seen often in couples--for
+_e_ is doubled with great frequency in English--in such words, for
+example, as ‘meet,’ ‘.fleet,’ ‘speed,’ ‘seen,’ been,’ ‘agree,’ &c. In
+the present instance we see it doubled no less than five times, although
+the cryptograph is brief.
+
+“Let us assume 8, then, as _e_. Now, of all _words_ in the language,
+‘the’ is most usual; let us see, therefore, whether there are not
+repetitions of any three characters, in the same order of collocation,
+the last of them being 8. If we discover repetitions of such letters,
+so arranged, they will most probably represent the word ‘the.’ Upon
+inspection, we find no less than seven such arrangements, the characters
+being;48. We may, therefore, assume that; represents _t_, 4 represents
+_h_, and 8 represents _e_--the last being now well confirmed. Thus a
+great step has been taken.
+
+“But, having established a single word, we are enabled to establish
+a vastly important point; that is to say, several commencements and
+terminations of other words. Let us refer, for example, to the last
+instance but one, in which the combination;48 occurs--not far from
+the end of the cipher. We know that the; immediately ensuing is the
+commencement of a word, and, of the six characters succeeding this
+‘the,’ we are cognizant of no less than five. Let us set these
+characters down, thus, by the letters we know them to represent, leaving
+a space for the unknown--
+
+t eeth.
+
+“Here we are enabled, at once, to discard the ‘th,’ as forming no
+portion of the word commencing with the first t; since, by experiment
+of the entire alphabet for a letter adapted to the vacancy, we perceive
+that no word can be formed of which this _th_ can be a part. We are thus
+narrowed into
+
+t ee,
+
+and, going through the alphabet, if necessary, as before, we arrive
+at the word ‘tree,’ as the sole possible reading. We thus gain
+another letter, _r_, represented by (, with the words ‘the tree’ in
+juxtaposition.
+
+“Looking beyond these words, for a short distance, we again see
+the combination;48, and employ it by way of _termination_ to what
+immediately precedes. We have thus this arrangement:
+
+the tree;4(‡?34 the,
+
+or, substituting the natural letters, where known, it reads thus:
+
+the tree thr‡?3h the.
+
+“Now, if, in place of the unknown characters, we leave blank spaces, or
+substitute dots, we read thus:
+
+the tree thr...h the,
+
+when the word ‘_through_’ makes itself evident at once. But this
+discovery gives us three new letters, _o_, _u_ and _g_, represented by
+‡? and 3.
+
+“Looking now, narrowly, through the cipher for combinations of known
+characters, we find, not very far from the beginning, this arrangement,
+
+83(88, or egree,
+
+which, plainly, is the conclusion of the word ‘degree,’ and gives us
+another letter, _d_, represented by †.
+
+“Four letters beyond the word ‘degree,’ we perceive the combination
+
+;46(;88.
+
+“Translating the known characters, and representing the unknown by dots,
+as before, we read thus: th rtee. an arrangement immediately suggestive
+of the word ‘thirteen,’ and again furnishing us with two new characters,
+_i_ and _n_, represented by 6 and *.
+
+“Referring, now, to the beginning of the cryptograph, we find the
+combination,
+
+53‡‡†.
+
+“Translating, as before, we obtain
+
+good,
+
+which assures us that the first letter is _A_, and that the first two
+words are ‘A good.’
+
+“It is now time that we arrange our key, as far as discovered, in a
+tabular form, to avoid confusion. It will stand thus:
+
+                5 represents      a
+                †       “         d
+                8       “         e
+                3       “         g
+                4       “         h
+                6       “         i
+                *       “         n
+                ‡       “         o
+                (       “         r
+                ;       “         t
+
+“We have, therefore, no less than ten of the most important letters
+represented, and it will be unnecessary to proceed with the details of
+the solution. I have said enough to convince you that ciphers of this
+nature are readily soluble, and to give you some insight into the
+rationale of their development. But be assured that the specimen before
+us appertains to the very simplest species of cryptograph. It now only
+remains to give you the full translation of the characters upon the
+parchment, as unriddled. Here it is:
+
+“‘_A good glass in the bishop’s hostel in the devil’s seat forty-one
+degrees and thirteen minutes northeast and by north main branch seventh
+limb east side shoot from the left eye of the death’s-head a bee line
+from the tree through the shot fifty feet out_.’”
+
+“But,” said I, “the enigma seems still in as bad a condition as ever.
+How is it possible to extort a meaning from all this jargon about
+‘devil’s seats,’ ‘death’s heads,’ and ‘bishop’s hotels?’”
+
+“I confess,” replied Legrand, “that the matter still wears a serious
+aspect, when regarded with a casual glance. My first endeavor was
+to divide the sentence into the natural division intended by the
+cryptographist.”
+
+“You mean, to punctuate it?”
+
+“Something of that kind.”
+
+“But how was it possible to effect this?”
+
+“I reflected that it had been a point with the writer to run his words
+together without division, so as to increase the difficulty of solution.
+Now, a not over-acute man, in pursuing such an object would be nearly
+certain to overdo the matter. When, in the course of his composition, he
+arrived at a break in his subject which would naturally require a pause,
+or a point, he would be exceedingly apt to run his characters, at this
+place, more than usually close together. If you will observe the MS., in
+the present instance, you will easily detect five such cases of unusual
+crowding. Acting upon this hint, I made the division thus: ‘A good
+glass in the Bishop’s hostel in the Devil’s seat--forty-one degrees and
+thirteen minutes--northeast and by north--main branch seventh limb east
+side--shoot from the left eye of the death’s-head--a bee-line from the
+tree through the shot fifty feet out.’”
+
+“Even this division,” said I, “leaves me still in the dark.”
+
+“It left me also in the dark,” replied Legrand, “for a few days; during
+which I made diligent inquiry, in the neighborhood of Sullivan’s Island,
+for any building which went by the name of the ‘Bishop’s Hotel;’ for, of
+course, I dropped the obsolete word ‘hostel.’ Gaining no information on
+the subject, I was on the point of extending my sphere of search, and
+proceeding in a more systematic manner, when, one morning, it entered
+into my head, quite suddenly, that this ‘Bishop’s Hostel’ might have
+some reference to an old family, of the name of Bessop, which, time out
+of mind, had held possession of an ancient manor-house, about four
+miles to the northward of the Island. I accordingly went over to the
+plantation, and re-instituted my inquiries among the older negroes of
+the place. At length one of the most aged of the women said that she
+had heard of such a place as Bessop’s Castle, and thought that she could
+guide me to it, but that it was not a castle nor a tavern, but a high
+rock.
+
+“I offered to pay her well for her trouble, and, after some demur,
+she consented to accompany me to the spot. We found it without much
+difficulty, when, dismissing her, I proceeded to examine the place. The
+‘castle’ consisted of an irregular assemblage of cliffs and rocks--one
+of the latter being quite remarkable for its height as well as for its
+insulated and artificial appearance I clambered to its apex, and then
+felt much at a loss as to what should be next done.
+
+“While I was busied in reflection, my eyes fell upon a narrow ledge in
+the eastern face of the rock, perhaps a yard below the summit upon which
+I stood. This ledge projected about eighteen inches, and was not more
+than a foot wide, while a niche in the cliff just above it, gave it
+a rude resemblance to one of the hollow-backed chairs used by our
+ancestors. I made no doubt that here was the ‘devil’s seat’ alluded to
+in the MS., and now I seemed to grasp the full secret of the riddle.
+
+“The ‘good glass,’ I knew, could have reference to nothing but a
+telescope; for the word ‘glass’ is rarely employed in any other sense
+by seamen. Now here, I at once saw, was a telescope to be used, and a
+definite point of view, admitting no variation, from which to use it.
+Nor did I hesitate to believe that the phrases, “forty-one degrees
+and thirteen minutes,’ and ‘northeast and by north,’ were intended as
+directions for the levelling of the glass. Greatly excited by these
+discoveries, I hurried home, procured a telescope, and returned to the
+rock.
+
+“I let myself down to the ledge, and found that it was impossible to
+retain a seat upon it except in one particular position. This fact
+confirmed my preconceived idea. I proceeded to use the glass. Of course,
+the ‘forty-one degrees and thirteen minutes’ could allude to nothing but
+elevation above the visible horizon, since the horizontal direction was
+clearly indicated by the words, ‘northeast and by north.’ This latter
+direction I at once established by means of a pocket-compass; then,
+pointing the glass as nearly at an angle of forty-one degrees of
+elevation as I could do it by guess, I moved it cautiously up or down,
+until my attention was arrested by a circular rift or opening in the
+foliage of a large tree that overtopped its fellows in the distance.
+In the centre of this rift I perceived a white spot, but could not, at
+first, distinguish what it was. Adjusting the focus of the telescope, I
+again looked, and now made it out to be a human skull.
+
+“Upon this discovery I was so sanguine as to consider the enigma solved;
+for the phrase ‘main branch, seventh limb, east side,’ could refer only
+to the position of the skull upon the tree, while ‘shoot from the left
+eye of the death’s head’ admitted, also, of but one interpretation, in
+regard to a search for buried treasure. I perceived that the design was
+to drop a bullet from the left eye of the skull, and that a bee-line,
+or, in other words, a straight line, drawn from the nearest point of
+the trunk through ‘the shot,’ (or the spot where the bullet fell,) and
+thence extended to a distance of fifty feet, would indicate a definite
+point--and beneath this point I thought it at least possible that a
+deposit of value lay concealed.”
+
+“All this,” I said, “is exceedingly clear, and, although ingenious,
+still simple and explicit. When you left the Bishop’s Hotel, what then?”
+
+“Why, having carefully taken the bearings of the tree, I turned
+homewards. The instant that I left ‘the devil’s seat,’ however, the
+circular rift vanished; nor could I get a glimpse of it afterwards, turn
+as I would. What seems to me the chief ingenuity in this whole business,
+is the fact (for repeated experiment has convinced me it is a fact) that
+the circular opening in question is visible from no other attainable
+point of view than that afforded by the narrow ledge upon the face of
+the rock.
+
+“In this expedition to the ‘Bishop’s Hotel’ I had been attended
+by Jupiter, who had, no doubt, observed, for some weeks past, the
+abstraction of my demeanor, and took especial care not to leave me
+alone. But, on the next day, getting up very early, I contrived to give
+him the slip, and went into the hills in search of the tree. After much
+toil I found it. When I came home at night my valet proposed to give
+me a flogging. With the rest of the adventure I believe you are as well
+acquainted as myself.”
+
+“I suppose,” said I, “you missed the spot, in the first attempt at
+digging, through Jupiter’s stupidity in letting the bug fall through the
+right instead of through the left eye of the skull.”
+
+“Precisely. This mistake made a difference of about two inches and a
+half in the ‘shot’--that is to say, in the position of the peg nearest
+the tree; and had the treasure been beneath the ‘shot,’ the error would
+have been of little moment; but ‘the shot,’ together with the nearest
+point of the tree, were merely two points for the establishment of
+a line of direction; of course the error, however trivial in the
+beginning, increased as we proceeded with the line, and by the time
+we had gone fifty feet, threw us quite off the scent. But for my
+deep-seated impressions that treasure was here somewhere actually
+buried, we might have had all our labor in vain.”
+
+“But your grandiloquence, and your conduct in swinging the beetle--how
+excessively odd! I was sure you were mad. And why did you insist upon
+letting fall the bug, instead of a bullet, from the skull?”
+
+“Why, to be frank, I felt somewhat annoyed by your evident suspicions
+touching my sanity, and so resolved to punish you quietly, in my own
+way, by a little bit of sober mystification. For this reason I swung
+the beetle, and for this reason I let it fall it from the tree. An
+observation of yours about its great weight suggested the latter idea.”
+
+“Yes, I perceive; and now there is only one point which puzzles me. What
+are we to make of the skeletons found in the hole?”
+
+“That is a question I am no more able to answer than yourself. There
+seems, however, only one plausible way of accounting for them--and yet
+it is dreadful to believe in such atrocity as my suggestion would imply.
+It is clear that Kidd--if Kidd indeed secreted this treasure, which I
+doubt not--it is clear that he must have had assistance in the labor.
+But this labor concluded, he may have thought it expedient to remove
+all participants in his secret. Perhaps a couple of blows with a mattock
+were sufficient, while his coadjutors were busy in the pit; perhaps it
+required a dozen--who shall tell?”
+
+
+
+
+FOUR BEASTS IN ONE--THE HOMO-CAMELEOPARD
+
+                     Chacun a ses vertus.
+                        --_Crebillon’s Xerxes._
+
+ANTIOCHUS EPIPHANES is very generally looked upon as the Gog of the
+prophet Ezekiel. This honor is, however, more properly attributable to
+Cambyses, the son of Cyrus. And, indeed, the character of the
+Syrian monarch does by no means stand in need of any adventitious
+embellishment. His accession to the throne, or rather his usurpation of
+the sovereignty, a hundred and seventy-one years before the coming
+of Christ; his attempt to plunder the temple of Diana at Ephesus; his
+implacable hostility to the Jews; his pollution of the Holy of Holies;
+and his miserable death at Taba, after a tumultuous reign of eleven
+years, are circumstances of a prominent kind, and therefore more
+generally noticed by the historians of his time than the impious,
+dastardly, cruel, silly, and whimsical achievements which make up the
+sum total of his private life and reputation.
+
+Let us suppose, gentle reader, that it is now the year of the world
+three thousand eight hundred and thirty, and let us, for a few minutes,
+imagine ourselves at that most grotesque habitation of man, the
+remarkable city of Antioch. To be sure there were, in Syria and other
+countries, sixteen cities of that appellation, besides the one to which
+I more particularly allude. But ours is that which went by the name of
+Antiochia Epidaphne, from its vicinity to the little village of Daphne,
+where stood a temple to that divinity. It was built (although about this
+matter there is some dispute) by Seleucus Nicanor, the first king of the
+country after Alexander the Great, in memory of his father Antiochus,
+and became immediately the residence of the Syrian monarchy. In the
+flourishing times of the Roman Empire, it was the ordinary station of
+the prefect of the eastern provinces; and many of the emperors of the
+queen city (among whom may be mentioned, especially, Verus and Valens)
+spent here the greater part of their time. But I perceive we have
+arrived at the city itself. Let us ascend this battlement, and throw our
+eyes upon the town and neighboring country.
+
+“What broad and rapid river is that which forces its way, with
+innumerable falls, through the mountainous wilderness, and finally
+through the wilderness of buildings?”
+
+That is the Orontes, and it is the only water in sight, with the
+exception of the Mediterranean, which stretches, like a broad mirror,
+about twelve miles off to the southward. Every one has seen the
+Mediterranean; but let me tell you, there are few who have had a peep at
+Antioch. By few, I mean, few who, like you and me, have had, at the same
+time, the advantages of a modern education. Therefore cease to regard
+that sea, and give your whole attention to the mass of houses that lie
+beneath us. You will remember that it is now the year of the world three
+thousand eight hundred and thirty. Were it later--for example, were
+it the year of our Lord eighteen hundred and forty-five, we should be
+deprived of this extraordinary spectacle. In the nineteenth century
+Antioch is--that is to say, Antioch will be--in a lamentable state
+of decay. It will have been, by that time, totally destroyed, at three
+different periods, by three successive earthquakes. Indeed, to say the
+truth, what little of its former self may then remain, will be found in
+so desolate and ruinous a state that the patriarch shall have removed
+his residence to Damascus. This is well. I see you profit by my advice,
+and are making the most of your time in inspecting the premises--in
+
+-satisfying your eyes
+
+With the memorials and the things of fame
+
+That most renown this city.--
+
+I beg pardon; I had forgotten that Shakespeare will not flourish for
+seventeen hundred and fifty years to come. But does not the appearance
+of Epidaphne justify me in calling it grotesque?
+
+“It is well fortified; and in this respect is as much indebted to nature
+as to art.”
+
+Very true.
+
+“There are a prodigious number of stately palaces.”
+
+There are.
+
+“And the numerous temples, sumptuous and magnificent, may bear
+comparison with the most lauded of antiquity.”
+
+All this I must acknowledge. Still there is an infinity of mud huts, and
+abominable hovels. We cannot help perceiving abundance of filth in
+every kennel, and, were it not for the over-powering fumes of idolatrous
+incense, I have no doubt we should find a most intolerable stench.
+Did you ever behold streets so insufferably narrow, or houses so
+miraculously tall? What gloom their shadows cast upon the ground! It
+is well the swinging lamps in those endless colonnades are kept burning
+throughout the day; we should otherwise have the darkness of Egypt in
+the time of her desolation.
+
+“It is certainly a strange place! What is the meaning of yonder singular
+building? See! it towers above all others, and lies to the eastward of
+what I take to be the royal palace.”
+
+That is the new Temple of the Sun, who is adored in Syria under the
+title of Elah Gabalah. Hereafter a very notorious Roman Emperor
+will institute this worship in Rome, and thence derive a cognomen,
+Heliogabalus. I dare say you would like to take a peep at the divinity
+of the temple. You need not look up at the heavens; his Sunship is not
+there--at least not the Sunship adored by the Syrians. That deity will
+be found in the interior of yonder building. He is worshipped under the
+figure of a large stone pillar terminating at the summit in a cone or
+pyramid, whereby is denoted Fire.
+
+“Hark--behold!--who can those ridiculous beings be, half naked, with
+their faces painted, shouting and gesticulating to the rabble?”
+
+Some few are mountebanks. Others more particularly belong to the race
+of philosophers. The greatest portion, however--those especially who
+belabor the populace with clubs--are the principal courtiers of the
+palace, executing as in duty bound, some laudable comicality of the
+king’s.
+
+“But what have we here? Heavens! the town is swarming with wild beasts!
+How terrible a spectacle!--how dangerous a peculiarity!”
+
+Terrible, if you please; but not in the least degree dangerous. Each
+animal if you will take the pains to observe, is following, very
+quietly, in the wake of its master. Some few, to be sure, are led with a
+rope about the neck, but these are chiefly the lesser or timid species.
+The lion, the tiger, and the leopard are entirely without restraint.
+They have been trained without difficulty to their present
+profession, and attend upon their respective owners in the capacity of
+valets-de-chambre. It is true, there are occasions when Nature asserts
+her violated dominions;--but then the devouring of a man-at-arms, or the
+throttling of a consecrated bull, is a circumstance of too little moment
+to be more than hinted at in Epidaphne.
+
+“But what extraordinary tumult do I hear? Surely this is a loud noise
+even for Antioch! It argues some commotion of unusual interest.”
+
+Yes--undoubtedly. The king has ordered some novel spectacle--some
+gladiatorial exhibition at the hippodrome--or perhaps the massacre of
+the Scythian prisoners--or the conflagration of his new palace--or the
+tearing down of a handsome temple--or, indeed, a bonfire of a few Jews.
+The uproar increases. Shouts of laughter ascend the skies. The air
+becomes dissonant with wind instruments, and horrible with clamor of a
+million throats. Let us descend, for the love of fun, and see what is
+going on! This way--be careful! Here we are in the principal street,
+which is called the street of Timarchus. The sea of people is coming
+this way, and we shall find a difficulty in stemming the tide. They are
+pouring through the alley of Heraclides, which leads directly from the
+palace;--therefore the king is most probably among the rioters. Yes;--I
+hear the shouts of the herald proclaiming his approach in the pompous
+phraseology of the East. We shall have a glimpse of his person as
+he passes by the temple of Ashimah. Let us ensconce ourselves in the
+vestibule of the sanctuary; he will be here anon. In the meantime let
+us survey this image. What is it? Oh! it is the god Ashimah in proper
+person. You perceive, however, that he is neither a lamb, nor a
+goat, nor a satyr, neither has he much resemblance to the Pan of the
+Arcadians. Yet all these appearances have been given--I beg pardon--will
+be given--by the learned of future ages, to the Ashimah of the Syrians.
+Put on your spectacles, and tell me what it is. What is it?
+
+“Bless me! it is an ape!”
+
+True--a baboon; but by no means the less a deity. His name is a
+derivation of the Greek Simia--what great fools are antiquarians! But
+see!--see!--yonder scampers a ragged little urchin. Where is he going?
+What is he bawling about? What does he say? Oh! he says the king
+is coming in triumph; that he is dressed in state; that he has just
+finished putting to death, with his own hand, a thousand chained
+Israelitish prisoners! For this exploit the ragamuffin is lauding him to
+the skies. Hark! here comes a troop of a similar description. They have
+made a Latin hymn upon the valor of the king, and are singing it as they
+go:
+
+Mille, mille, mille,
+
+Mille, mille, mille,
+
+Decollavimus, unus homo!
+
+Mille, mille, mille, mille, decollavimus!
+
+Mille, mille, mille,
+
+Vivat qui mille mille occidit!
+
+Tantum vini habet nemo
+
+Quantum sanguinis effudit!(*1)
+
+Which may be thus paraphrased:
+
+A thousand, a thousand, a thousand,
+
+A thousand, a thousand, a thousand,
+
+We, with one warrior, have slain!
+
+A thousand, a thousand, a thousand, a thousand.
+
+Sing a thousand over again!
+
+Soho!--let us sing
+
+Long life to our king,
+
+Who knocked over a thousand so fine!
+
+Soho!--let us roar,
+
+He has given us more
+
+Red gallons of gore
+
+Than all Syria can furnish of wine!
+
+“Do you hear that flourish of trumpets?”
+
+Yes: the king is coming! See! the people are aghast with admiration,
+and lift up their eyes to the heavens in reverence. He comes;--he is
+coming;--there he is!
+
+“Who?--where?--the king?--do not behold him--cannot say that I perceive
+him.”
+
+Then you must be blind.
+
+“Very possible. Still I see nothing but a tumultuous mob of idiots
+and madmen, who are busy in prostrating themselves before a gigantic
+cameleopard, and endeavoring to obtain a kiss of the animal’s hoofs.
+See! the beast has very justly kicked one of the rabble over--and
+another--and another--and another. Indeed, I cannot help admiring the
+animal for the excellent use he is making of his feet.”
+
+Rabble, indeed!--why these are the noble and free citizens of Epidaphne!
+Beasts, did you say?--take care that you are not overheard. Do you not
+perceive that the animal has the visage of a man? Why, my dear sir,
+that cameleopard is no other than Antiochus Epiphanes, Antiochus the
+Illustrious, King of Syria, and the most potent of all the autocrats
+of the East! It is true, that he is entitled, at times, Antiochus
+Epimanes--Antiochus the madman--but that is because all people have not
+the capacity to appreciate his merits. It is also certain that he is at
+present ensconced in the hide of a beast, and is doing his best to play
+the part of a cameleopard; but this is done for the better sustaining
+his dignity as king. Besides, the monarch is of gigantic stature,
+and the dress is therefore neither unbecoming nor over large. We may,
+however, presume he would not have adopted it but for some occasion
+of especial state. Such, you will allow, is the massacre of a thousand
+Jews. With how superior a dignity the monarch perambulates on all fours!
+His tail, you perceive, is held aloft by his two principal concubines,
+Elline and Argelais; and his whole appearance would be infinitely
+prepossessing, were it not for the protuberance of his eyes, which will
+certainly start out of his head, and the queer color of his face, which
+has become nondescript from the quantity of wine he has swallowed. Let
+us follow him to the hippodrome, whither he is proceeding, and listen to
+the song of triumph which he is commencing:
+
+Who is king but Epiphanes?
+
+Say--do you know?
+
+Who is king but Epiphanes?
+
+Bravo!--bravo!
+
+There is none but Epiphanes,
+
+No--there is none:
+
+So tear down the temples,
+
+And put out the sun!
+
+Well and strenuously sung! The populace are hailing him ‘Prince of
+Poets,’ as well as ‘Glory of the East,’ ‘Delight of the Universe,’ and
+‘Most Remarkable of Cameleopards.’ They have encored his effusion,
+and do you hear?--he is singing it over again. When he arrives at the
+hippodrome, he will be crowned with the poetic wreath, in anticipation
+of his victory at the approaching Olympics.
+
+“But, good Jupiter! what is the matter in the crowd behind us?”
+
+Behind us, did you say?--oh! ah!--I perceive. My friend, it is well
+that you spoke in time. Let us get into a place of safety as soon as
+possible. Here!--let us conceal ourselves in the arch of this aqueduct,
+and I will inform you presently of the origin of the commotion. It has
+turned out as I have been anticipating. The singular appearance of the
+cameleopard and the head of a man, has, it seems, given offence to
+the notions of propriety entertained, in general, by the wild animals
+domesticated in the city. A mutiny has been the result; and, as is usual
+upon such occasions, all human efforts will be of no avail in quelling
+the mob. Several of the Syrians have already been devoured; but the
+general voice of the four-footed patriots seems to be for eating up the
+cameleopard. ‘The Prince of Poets,’ therefore, is upon his hinder legs,
+running for his life. His courtiers have left him in the lurch, and
+his concubines have followed so excellent an example. ‘Delight of the
+Universe,’ thou art in a sad predicament! ‘Glory of the East,’ thou art
+in danger of mastication! Therefore never regard so piteously thy tail;
+it will undoubtedly be draggled in the mud, and for this there is no
+help. Look not behind thee, then, at its unavoidable degradation; but
+take courage, ply thy legs with vigor, and scud for the hippodrome!
+Remember that thou art Antiochus Epiphanes. Antiochus the
+Illustrious!--also ‘Prince of Poets,’ ‘Glory of the East,’ ‘Delight of
+the Universe,’ and ‘Most Remarkable of Cameleopards!’ Heavens! what a
+power of speed thou art displaying! What a capacity for leg-bail
+thou art developing! Run, Prince!--Bravo, Epiphanes! Well done,
+Cameleopard!--Glorious Antiochus!--He runs!--he leaps!--he flies! Like
+an arrow from a catapult he approaches the hippodrome! He leaps!--he
+shrieks!--he is there! This is well; for hadst thou, ‘Glory of
+the East,’ been half a second longer in reaching the gates of the
+Amphitheatre, there is not a bear’s cub in Epidaphne that would not
+have had a nibble at thy carcase. Let us be off--let us take our
+departure!--for we shall find our delicate modern ears unable to endure
+the vast uproar which is about to commence in celebration of the king’s
+escape! Listen! it has already commenced. See!--the whole town is
+topsy-turvy.
+
+“Surely this is the most populous city of the East! What a wilderness
+of people! what a jumble of all ranks and ages! what a multiplicity
+of sects and nations! what a variety of costumes! what a Babel of
+languages! what a screaming of beasts! what a tinkling of instruments!
+what a parcel of philosophers!”
+
+Come let us be off.
+
+“Stay a moment! I see a vast hubbub in the hippodrome; what is the
+meaning of it, I beseech you?”
+
+That?--oh, nothing! The noble and free citizens of Epidaphne being, as
+they declare, well satisfied of the faith, valor, wisdom, and divinity
+of their king, and having, moreover, been eye-witnesses of his late
+superhuman agility, do think it no more than their duty to invest his
+brows (in addition to the poetic crown) with the wreath of victory
+in the footrace--a wreath which it is evident he must obtain at the
+celebration of the next Olympiad, and which, therefore, they now give
+him in advance.
+
+
+Footnotes--Four Beasts
+
+(*1) Flavius Vospicus says, that the hymn here introduced was sung by
+the rabble upon the occasion of Aurelian, in the Sarmatic war, having
+slain, with his own hand, nine hundred and fifty of the enemy.
+
+
+
+
+THE MURDERS IN THE RUE MORGUE
+
+  What song the Syrens sang, or what name Achilles assumed when he hid
+  himself among women, although puzzling questions, are not beyond
+  _all_ conjecture.
+
+                    --_Sir Thomas Browne._
+
+
+The mental features discoursed of as the analytical, are, in themselves,
+but little susceptible of analysis. We appreciate them only in their
+effects. We know of them, among other things, that they are always to
+their possessor, when inordinately possessed, a source of the liveliest
+enjoyment. As the strong man exults in his physical ability, delighting
+in such exercises as call his muscles into action, so glories the
+analyst in that moral activity which _disentangles._ He derives pleasure
+from even the most trivial occupations bringing his talent into play. He
+is fond of enigmas, of conundrums, of hieroglyphics; exhibiting in his
+solutions of each a degree of _acumen_ which appears to the ordinary
+apprehension præternatural. His results, brought about by the very soul
+and essence of method, have, in truth, the whole air of intuition.
+
+The faculty of re-solution is possibly much invigorated by mathematical
+study, and especially by that highest branch of it which, unjustly, and
+merely on account of its retrograde operations, has been called, as
+if _par excellence_, analysis. Yet to calculate is not in itself to
+analyse. A chess-player, for example, does the one without effort at
+the other. It follows that the game of chess, in its effects upon mental
+character, is greatly misunderstood. I am not now writing a treatise,
+but simply prefacing a somewhat peculiar narrative by observations very
+much at random; I will, therefore, take occasion to assert that the
+higher powers of the reflective intellect are more decidedly and more
+usefully tasked by the unostentatious game of draughts than by all the
+elaborate frivolity of chess. In this latter, where the pieces have
+different and _bizarre_ motions, with various and variable values, what
+is only complex is mistaken (a not unusual error) for what is profound.
+The _attention_ is here called powerfully into play. If it flag for an
+instant, an oversight is committed resulting in injury or defeat. The
+possible moves being not only manifold but involute, the chances of such
+oversights are multiplied; and in nine cases out of ten it is the
+more concentrative rather than the more acute player who conquers. In
+draughts, on the contrary, where the moves are _unique_ and have but
+little variation, the probabilities of inadvertence are diminished, and
+the mere attention being left comparatively unemployed, what advantages
+are obtained by either party are obtained by superior _acumen_. To be
+less abstract--Let us suppose a game of draughts where the pieces are
+reduced to four kings, and where, of course, no oversight is to be
+expected. It is obvious that here the victory can be decided (the
+players being at all equal) only by some _recherché_ movement, the
+result of some strong exertion of the intellect. Deprived of ordinary
+resources, the analyst throws himself into the spirit of his opponent,
+identifies himself therewith, and not unfrequently sees thus, at a
+glance, the sole methods (sometime indeed absurdly simple ones) by which
+he may seduce into error or hurry into miscalculation.
+
+Whist has long been noted for its influence upon what is termed the
+calculating power; and men of the highest order of intellect have been
+known to take an apparently unaccountable delight in it, while eschewing
+chess as frivolous. Beyond doubt there is nothing of a similar nature
+so greatly tasking the faculty of analysis. The best chess-player in
+Christendom _may_ be little more than the best player of chess; but
+proficiency in whist implies capacity for success in all those more
+important undertakings where mind struggles with mind. When I say
+proficiency, I mean that perfection in the game which includes a
+comprehension of _all_ the sources whence legitimate advantage may be
+derived. These are not only manifold but multiform, and lie frequently
+among recesses of thought altogether inaccessible to the ordinary
+understanding. To observe attentively is to remember distinctly; and,
+so far, the concentrative chess-player will do very well at whist; while
+the rules of Hoyle (themselves based upon the mere mechanism of the
+game) are sufficiently and generally comprehensible. Thus to have a
+retentive memory, and to proceed by “the book,” are points commonly
+regarded as the sum total of good playing. But it is in matters beyond
+the limits of mere rule that the skill of the analyst is evinced. He
+makes, in silence, a host of observations and inferences. So, perhaps,
+do his companions; and the difference in the extent of the information
+obtained, lies not so much in the validity of the inference as in the
+quality of the observation. The necessary knowledge is that of _what_ to
+observe. Our player confines himself not at all; nor, because the game
+is the object, does he reject deductions from things external to the
+game. He examines the countenance of his partner, comparing it carefully
+with that of each of his opponents. He considers the mode of assorting
+the cards in each hand; often counting trump by trump, and honor by
+honor, through the glances bestowed by their holders upon each. He notes
+every variation of face as the play progresses, gathering a fund
+of thought from the differences in the expression of certainty, of
+surprise, of triumph, or of chagrin. From the manner of gathering up
+a trick he judges whether the person taking it can make another in the
+suit. He recognises what is played through feint, by the air with
+which it is thrown upon the table. A casual or inadvertent word; the
+accidental dropping or turning of a card, with the accompanying anxiety
+or carelessness in regard to its concealment; the counting of the
+tricks, with the order of their arrangement; embarrassment, hesitation,
+eagerness or trepidation--all afford, to his apparently intuitive
+perception, indications of the true state of affairs. The first two
+or three rounds having been played, he is in full possession of the
+contents of each hand, and thenceforward puts down his cards with as
+absolute a precision of purpose as if the rest of the party had turned
+outward the faces of their own.
+
+The analytical power should not be confounded with ample ingenuity; for
+while the analyst is necessarily ingenious, the ingenious man is often
+remarkably incapable of analysis. The constructive or combining power,
+by which ingenuity is usually manifested, and to which the phrenologists
+(I believe erroneously) have assigned a separate organ, supposing it a
+primitive faculty, has been so frequently seen in those whose intellect
+bordered otherwise upon idiocy, as to have attracted general observation
+among writers on morals. Between ingenuity and the analytic ability
+there exists a difference far greater, indeed, than that between the
+fancy and the imagination, but of a character very strictly analogous.
+It will be found, in fact, that the ingenious are always fanciful, and
+the _truly_ imaginative never otherwise than analytic.
+
+The narrative which follows will appear to the reader somewhat in the
+light of a commentary upon the propositions just advanced.
+
+Residing in Paris during the spring and part of the summer of 18--, I
+there became acquainted with a Monsieur C. Auguste Dupin. This young
+gentleman was of an excellent--indeed of an illustrious family, but, by
+a variety of untoward events, had been reduced to such poverty that the
+energy of his character succumbed beneath it, and he ceased to bestir
+himself in the world, or to care for the retrieval of his fortunes.
+By courtesy of his creditors, there still remained in his possession a
+small remnant of his patrimony; and, upon the income arising from this,
+he managed, by means of a rigorous economy, to procure the necessaries
+of life, without troubling himself about its superfluities. Books,
+indeed, were his sole luxuries, and in Paris these are easily obtained.
+
+Our first meeting was at an obscure library in the Rue Montmartre, where
+the accident of our both being in search of the same very rare and very
+remarkable volume, brought us into closer communion. We saw each other
+again and again. I was deeply interested in the little family history
+which he detailed to me with all that candor which a Frenchman indulges
+whenever mere self is his theme. I was astonished, too, at the vast
+extent of his reading; and, above all, I felt my soul enkindled within
+me by the wild fervor, and the vivid freshness of his imagination.
+Seeking in Paris the objects I then sought, I felt that the society of
+such a man would be to me a treasure beyond price; and this feeling I
+frankly confided to him. It was at length arranged that we should live
+together during my stay in the city; and as my worldly circumstances
+were somewhat less embarrassed than his own, I was permitted to be
+at the expense of renting, and furnishing in a style which suited the
+rather fantastic gloom of our common temper, a time-eaten and grotesque
+mansion, long deserted through superstitions into which we did not
+inquire, and tottering to its fall in a retired and desolate portion of
+the Faubourg St. Germain.
+
+Had the routine of our life at this place been known to the world, we
+should have been regarded as madmen--although, perhaps, as madmen of
+a harmless nature. Our seclusion was perfect. We admitted no visitors.
+Indeed the locality of our retirement had been carefully kept a secret
+from my own former associates; and it had been many years since Dupin
+had ceased to know or be known in Paris. We existed within ourselves
+alone.
+
+It was a freak of fancy in my friend (for what else shall I call it?) to
+be enamored of the Night for her own sake; and into this _bizarrerie_,
+as into all his others, I quietly fell; giving myself up to his wild
+whims with a perfect _abandon_. The sable divinity would not herself
+dwell with us always; but we could counterfeit her presence. At the
+first dawn of the morning we closed all the messy shutters of our old
+building; lighting a couple of tapers which, strongly perfumed, threw
+out only the ghastliest and feeblest of rays. By the aid of these we
+then busied our souls in dreams--reading, writing, or conversing, until
+warned by the clock of the advent of the true Darkness. Then we sallied
+forth into the streets arm in arm, continuing the topics of the day, or
+roaming far and wide until a late hour, seeking, amid the wild lights
+and shadows of the populous city, that infinity of mental excitement
+which quiet observation can afford.
+
+At such times I could not help remarking and admiring (although from
+his rich ideality I had been prepared to expect it) a peculiar analytic
+ability in Dupin. He seemed, too, to take an eager delight in its
+exercise--if not exactly in its display--and did not hesitate to confess
+the pleasure thus derived. He boasted to me, with a low chuckling laugh,
+that most men, in respect to himself, wore windows in their bosoms,
+and was wont to follow up such assertions by direct and very startling
+proofs of his intimate knowledge of my own. His manner at these moments
+was frigid and abstract; his eyes were vacant in expression; while his
+voice, usually a rich tenor, rose into a treble which would have sounded
+petulantly but for the deliberateness and entire distinctness of the
+enunciation. Observing him in these moods, I often dwelt meditatively
+upon the old philosophy of the Bi-Part Soul, and amused myself with the
+fancy of a double Dupin--the creative and the resolvent.
+
+Let it not be supposed, from what I have just said, that I am detailing
+any mystery, or penning any romance. What I have described in the
+Frenchman, was merely the result of an excited, or perhaps of a diseased
+intelligence. But of the character of his remarks at the periods in
+question an example will best convey the idea.
+
+We were strolling one night down a long dirty street in the vicinity of
+the Palais Royal. Being both, apparently, occupied with thought, neither
+of us had spoken a syllable for fifteen minutes at least. All at once
+Dupin broke forth with these words:
+
+“He is a very little fellow, that’s true, and would do better for the
+_Théâtre des Variétés_.”
+
+“There can be no doubt of that,” I replied unwittingly, and not at first
+observing (so much had I been absorbed in reflection) the extraordinary
+manner in which the speaker had chimed in with my meditations. In
+an instant afterward I recollected myself, and my astonishment was
+profound.
+
+“Dupin,” said I, gravely, “this is beyond my comprehension. I do not
+hesitate to say that I am amazed, and can scarcely credit my senses. How
+was it possible you should know I was thinking of -----?” Here I paused,
+to ascertain beyond a doubt whether he really knew of whom I thought.
+
+--“of Chantilly,” said he, “why do you pause? You were remarking to
+yourself that his diminutive figure unfitted him for tragedy.”
+
+This was precisely what had formed the subject of my reflections.
+Chantilly was a _quondam_ cobbler of the Rue St. Denis, who, becoming
+stage-mad, had attempted the _rôle_ of Xerxes, in Crébillon’s tragedy so
+called, and been notoriously Pasquinaded for his pains.
+
+“Tell me, for Heaven’s sake,” I exclaimed, “the method--if method there
+is--by which you have been enabled to fathom my soul in this matter.” In
+fact I was even more startled than I would have been willing to express.
+
+“It was the fruiterer,” replied my friend, “who brought you to the
+conclusion that the mender of soles was not of sufficient height for
+Xerxes _et id genus omne_.”
+
+“The fruiterer!--you astonish me--I know no fruiterer whomsoever.”
+
+“The man who ran up against you as we entered the street--it may have
+been fifteen minutes ago.”
+
+I now remembered that, in fact, a fruiterer, carrying upon his head a
+large basket of apples, had nearly thrown me down, by accident, as we
+passed from the Rue C ---- into the thoroughfare where we stood; but
+what this had to do with Chantilly I could not possibly understand.
+
+There was not a particle of _charlatanerie_ about Dupin. “I will
+explain,” he said, “and that you may comprehend all clearly, we will
+first retrace the course of your meditations, from the moment in which
+I spoke to you until that of the _rencontre_ with the fruiterer in
+question. The larger links of the chain run thus--Chantilly, Orion, Dr.
+Nichols, Epicurus, Stereotomy, the street stones, the fruiterer.”
+
+There are few persons who have not, at some period of their lives,
+amused themselves in retracing the steps by which particular conclusions
+of their own minds have been attained. The occupation is often full of
+interest and he who attempts it for the first time is astonished by
+the apparently illimitable distance and incoherence between the
+starting-point and the goal. What, then, must have been my amazement
+when I heard the Frenchman speak what he had just spoken, and when I
+could not help acknowledging that he had spoken the truth. He continued:
+
+“We had been talking of horses, if I remember aright, just before
+leaving the Rue C ----. This was the last subject we discussed. As we
+crossed into this street, a fruiterer, with a large basket upon his
+head, brushing quickly past us, thrust you upon a pile of paving stones
+collected at a spot where the causeway is undergoing repair. You stepped
+upon one of the loose fragments, slipped, slightly strained your ankle,
+appeared vexed or sulky, muttered a few words, turned to look at the
+pile, and then proceeded in silence. I was not particularly attentive to
+what you did; but observation has become with me, of late, a species of
+necessity.
+
+“You kept your eyes upon the ground--glancing, with a petulant
+expression, at the holes and ruts in the pavement, (so that I saw you
+were still thinking of the stones,) until we reached the little alley
+called Lamartine, which has been paved, by way of experiment, with the
+overlapping and riveted blocks. Here your countenance brightened up,
+and, perceiving your lips move, I could not doubt that you murmured the
+word ‘stereotomy,’ a term very affectedly applied to this species of
+pavement. I knew that you could not say to yourself ‘stereotomy’ without
+being brought to think of atomies, and thus of the theories of Epicurus;
+and since, when we discussed this subject not very long ago, I mentioned
+to you how singularly, yet with how little notice, the vague guesses
+of that noble Greek had met with confirmation in the late nebular
+cosmogony, I felt that you could not avoid casting your eyes upward to
+the great _nebula_ in Orion, and I certainly expected that you would do
+so. You did look up; and I was now assured that I had correctly followed
+your steps. But in that bitter _tirade_ upon Chantilly, which appeared
+in yesterday’s ‘_Musée_,’ the satirist, making some disgraceful
+allusions to the cobbler’s change of name upon assuming the buskin,
+quoted a Latin line about which we have often conversed. I mean the line
+
+     Perdidit antiquum litera sonum.
+
+“I had told you that this was in reference to Orion, formerly written
+Urion; and, from certain pungencies connected with this explanation, I
+was aware that you could not have forgotten it. It was clear, therefore,
+that you would not fail to combine the two ideas of Orion and Chantilly.
+That you did combine them I saw by the character of the smile which
+passed over your lips. You thought of the poor cobbler’s immolation. So
+far, you had been stooping in your gait; but now I saw you draw yourself
+up to your full height. I was then sure that you reflected upon the
+diminutive figure of Chantilly. At this point I interrupted your
+meditations to remark that as, in fact, he was a very little
+fellow--that Chantilly--he would do better at the _Théâtre des
+Variétés_.”
+
+Not long after this, we were looking over an evening edition of the
+“Gazette des Tribunaux,” when the following paragraphs arrested our
+attention.
+
+“EXTRAORDINARY MURDERS.--This morning, about three o’clock, the
+inhabitants of the Quartier St. Roch were aroused from sleep by a
+succession of terrific shrieks, issuing, apparently, from the fourth
+story of a house in the Rue Morgue, known to be in the sole occupancy of
+one Madame L’Espanaye, and her daughter Mademoiselle Camille L’Espanaye.
+After some delay, occasioned by a fruitless attempt to procure admission
+in the usual manner, the gateway was broken in with a crowbar, and eight
+or ten of the neighbors entered accompanied by two _gendarmes_. By this
+time the cries had ceased; but, as the party rushed up the first
+flight of stairs, two or more rough voices in angry contention were
+distinguished and seemed to proceed from the upper part of the house.
+As the second landing was reached, these sounds, also, had ceased and
+everything remained perfectly quiet. The party spread themselves and
+hurried from room to room. Upon arriving at a large back chamber in
+the fourth story, (the door of which, being found locked, with the key
+inside, was forced open,) a spectacle presented itself which struck
+every one present not less with horror than with astonishment.
+
+“The apartment was in the wildest disorder--the furniture broken and
+thrown about in all directions. There was only one bedstead; and from
+this the bed had been removed, and thrown into the middle of the floor.
+On a chair lay a razor, besmeared with blood. On the hearth were two or
+three long and thick tresses of grey human hair, also dabbled in blood,
+and seeming to have been pulled out by the roots. Upon the floor were
+found four Napoleons, an ear-ring of topaz, three large silver spoons,
+three smaller of_ métal d’Alger_, and two bags, containing nearly four
+thousand francs in gold. The drawers of a _bureau_, which stood in
+one corner were open, and had been, apparently, rifled, although many
+articles still remained in them. A small iron safe was discovered under
+the _bed_ (not under the bedstead). It was open, with the key still in
+the door. It had no contents beyond a few old letters, and other papers
+of little consequence.
+
+“Of Madame L’Espanaye no traces were here seen; but an unusual quantity
+of soot being observed in the fire-place, a search was made in the
+chimney, and (horrible to relate!) the corpse of the daughter, head
+downward, was dragged therefrom; it having been thus forced up the
+narrow aperture for a considerable distance. The body was quite warm.
+Upon examining it, many excoriations were perceived, no doubt occasioned
+by the violence with which it had been thrust up and disengaged. Upon
+the face were many severe scratches, and, upon the throat, dark bruises,
+and deep indentations of finger nails, as if the deceased had been
+throttled to death.
+
+“After a thorough investigation of every portion of the house, without
+farther discovery, the party made its way into a small paved yard in
+the rear of the building, where lay the corpse of the old lady, with her
+throat so entirely cut that, upon an attempt to raise her, the head fell
+off. The body, as well as the head, was fearfully mutilated--the former
+so much so as scarcely to retain any semblance of humanity.
+
+“To this horrible mystery there is not as yet, we believe, the slightest
+clew.”
+
+The next day’s paper had these additional particulars.
+
+“_The Tragedy in the Rue Morgue._ Many individuals have been examined
+in relation to this most extraordinary and frightful affair. [The word
+‘affaire’ has not yet, in France, that levity of import which it conveys
+with us,] “but nothing whatever has transpired to throw light upon it.
+We give below all the material testimony elicited.
+
+“_Pauline Dubourg_, laundress, deposes that she has known both the
+deceased for three years, having washed for them during that period.
+The old lady and her daughter seemed on good terms--very affectionate
+towards each other. They were excellent pay. Could not speak in regard
+to their mode or means of living. Believed that Madame L. told fortunes
+for a living. Was reputed to have money put by. Never met any persons
+in the house when she called for the clothes or took them home. Was sure
+that they had no servant in employ. There appeared to be no furniture in
+any part of the building except in the fourth story.
+
+“_Pierre Moreau_, tobacconist, deposes that he has been in the habit of
+selling small quantities of tobacco and snuff to Madame L’Espanaye for
+nearly four years. Was born in the neighborhood, and has always resided
+there. The deceased and her daughter had occupied the house in which the
+corpses were found, for more than six years. It was formerly occupied by
+a jeweller, who under-let the upper rooms to various persons. The house
+was the property of Madame L. She became dissatisfied with the abuse of
+the premises by her tenant, and moved into them herself, refusing to let
+any portion. The old lady was childish. Witness had seen the daughter
+some five or six times during the six years. The two lived an
+exceedingly retired life--were reputed to have money. Had heard it said
+among the neighbors that Madame L. told fortunes--did not believe it.
+Had never seen any person enter the door except the old lady and her
+daughter, a porter once or twice, and a physician some eight or ten
+times.
+
+“Many other persons, neighbors, gave evidence to the same effect. No one
+was spoken of as frequenting the house. It was not known whether there
+were any living connexions of Madame L. and her daughter. The shutters
+of the front windows were seldom opened. Those in the rear were always
+closed, with the exception of the large back room, fourth story. The
+house was a good house--not very old.
+
+“_Isidore Muset_, _gendarme_, deposes that he was called to the house
+about three o’clock in the morning, and found some twenty or thirty
+persons at the gateway, endeavoring to gain admittance. Forced it open,
+at length, with a bayonet--not with a crowbar. Had but little difficulty
+in getting it open, on account of its being a double or folding gate,
+and bolted neither at bottom not top. The shrieks were continued until
+the gate was forced--and then suddenly ceased. They seemed to be screams
+of some person (or persons) in great agony--were loud and drawn out,
+not short and quick. Witness led the way up stairs. Upon reaching the
+first landing, heard two voices in loud and angry contention--the one
+a gruff voice, the other much shriller--a very strange voice. Could
+distinguish some words of the former, which was that of a Frenchman. Was
+positive that it was not a woman’s voice. Could distinguish the words
+‘_sacré_’ and ‘_diable._’ The shrill voice was that of a foreigner.
+Could not be sure whether it was the voice of a man or of a woman. Could
+not make out what was said, but believed the language to be Spanish. The
+state of the room and of the bodies was described by this witness as we
+described them yesterday.
+
+“_Henri Duval_, a neighbor, and by trade a silver-smith, deposes that
+he was one of the party who first entered the house. Corroborates the
+testimony of Muset in general. As soon as they forced an entrance, they
+reclosed the door, to keep out the crowd, which collected very fast,
+notwithstanding the lateness of the hour. The shrill voice, this witness
+thinks, was that of an Italian. Was certain it was not French. Could not
+be sure that it was a man’s voice. It might have been a woman’s. Was not
+acquainted with the Italian language. Could not distinguish the words,
+but was convinced by the intonation that the speaker was an Italian.
+Knew Madame L. and her daughter. Had conversed with both frequently. Was
+sure that the shrill voice was not that of either of the deceased.
+
+“--_Odenheimer, restaurateur._ This witness volunteered his testimony.
+Not speaking French, was examined through an interpreter. Is a native of
+Amsterdam. Was passing the house at the time of the shrieks. They lasted
+for several minutes--probably ten. They were long and loud--very awful
+and distressing. Was one of those who entered the building. Corroborated
+the previous evidence in every respect but one. Was sure that the shrill
+voice was that of a man--of a Frenchman. Could not distinguish the
+words uttered. They were loud and quick--unequal--spoken apparently in
+fear as well as in anger. The voice was harsh--not so much shrill as
+harsh. Could not call it a shrill voice. The gruff voice said repeatedly
+‘_sacré_,’ ‘_diable_,’ and once ‘_mon Dieu._’
+
+“_Jules Mignaud_, banker, of the firm of Mignaud et Fils, Rue Deloraine.
+Is the elder Mignaud. Madame L’Espanaye had some property. Had opened an
+account with his banking house in the spring of the year--(eight years
+previously). Made frequent deposits in small sums. Had checked for
+nothing until the third day before her death, when she took out in
+person the sum of 4000 francs. This sum was paid in gold, and a clerk
+went home with the money.
+
+“_Adolphe Le Bon_, clerk to Mignaud et Fils, deposes that on the day in
+question, about noon, he accompanied Madame L’Espanaye to her residence
+with the 4000 francs, put up in two bags. Upon the door being opened,
+Mademoiselle L. appeared and took from his hands one of the bags, while
+the old lady relieved him of the other. He then bowed and departed. Did
+not see any person in the street at the time. It is a bye-street--very
+lonely.
+
+“_William Bird_, tailor deposes that he was one of the party who entered
+the house. Is an Englishman. Has lived in Paris two years. Was one of
+the first to ascend the stairs. Heard the voices in contention. The
+gruff voice was that of a Frenchman. Could make out several words, but
+cannot now remember all. Heard distinctly ‘_sacré_’ and ‘_mon Dieu._’
+There was a sound at the moment as if of several persons struggling--a
+scraping and scuffling sound. The shrill voice was very loud--louder
+than the gruff one. Is sure that it was not the voice of an Englishman.
+Appeared to be that of a German. Might have been a woman’s voice. Does
+not understand German.
+
+“Four of the above-named witnesses, being recalled, deposed that the
+door of the chamber in which was found the body of Mademoiselle L.
+was locked on the inside when the party reached it. Every thing was
+perfectly silent--no groans or noises of any kind. Upon forcing the door
+no person was seen. The windows, both of the back and front room, were
+down and firmly fastened from within. A door between the two rooms was
+closed, but not locked. The door leading from the front room into the
+passage was locked, with the key on the inside. A small room in the
+front of the house, on the fourth story, at the head of the passage was
+open, the door being ajar. This room was crowded with old beds, boxes,
+and so forth. These were carefully removed and searched. There was not
+an inch of any portion of the house which was not carefully searched.
+Sweeps were sent up and down the chimneys. The house was a four story
+one, with garrets (_mansardes._) A trap-door on the roof was nailed down
+very securely--did not appear to have been opened for years. The
+time elapsing between the hearing of the voices in contention and the
+breaking open of the room door, was variously stated by the witnesses.
+Some made it as short as three minutes--some as long as five. The door
+was opened with difficulty.
+
+“_Alfonzo Garcio_, undertaker, deposes that he resides in the Rue
+Morgue. Is a native of Spain. Was one of the party who entered the
+house. Did not proceed up stairs. Is nervous, and was apprehensive of
+the consequences of agitation. Heard the voices in contention. The gruff
+voice was that of a Frenchman. Could not distinguish what was said.
+The shrill voice was that of an Englishman--is sure of this. Does not
+understand the English language, but judges by the intonation.
+
+“_Alberto Montani_, confectioner, deposes that he was among the first
+to ascend the stairs. Heard the voices in question. The gruff voice was
+that of a Frenchman. Distinguished several words. The speaker appeared
+to be expostulating. Could not make out the words of the shrill voice.
+Spoke quick and unevenly. Thinks it the voice of a Russian. Corroborates
+the general testimony. Is an Italian. Never conversed with a native of
+Russia.
+
+“Several witnesses, recalled, here testified that the chimneys of all
+the rooms on the fourth story were too narrow to admit the passage of a
+human being. By ‘sweeps’ were meant cylindrical sweeping brushes, such
+as are employed by those who clean chimneys. These brushes were passed
+up and down every flue in the house. There is no back passage by which
+any one could have descended while the party proceeded up stairs. The
+body of Mademoiselle L’Espanaye was so firmly wedged in the chimney that
+it could not be got down until four or five of the party united their
+strength.
+
+“_Paul Dumas_, physician, deposes that he was called to view the
+bodies about day-break. They were both then lying on the sacking of the
+bedstead in the chamber where Mademoiselle L. was found. The corpse of
+the young lady was much bruised and excoriated. The fact that it
+had been thrust up the chimney would sufficiently account for these
+appearances. The throat was greatly chafed. There were several deep
+scratches just below the chin, together with a series of livid spots
+which were evidently the impression of fingers. The face was fearfully
+discolored, and the eye-balls protruded. The tongue had been partially
+bitten through. A large bruise was discovered upon the pit of the
+stomach, produced, apparently, by the pressure of a knee. In the opinion
+of M. Dumas, Mademoiselle L’Espanaye had been throttled to death by
+some person or persons unknown. The corpse of the mother was horribly
+mutilated. All the bones of the right leg and arm were more or less
+shattered. The left _tibia_ much splintered, as well as all the ribs of
+the left side. Whole body dreadfully bruised and discolored. It was not
+possible to say how the injuries had been inflicted. A heavy club of
+wood, or a broad bar of iron--a chair--any large, heavy, and obtuse
+weapon would have produced such results, if wielded by the hands of
+a very powerful man. No woman could have inflicted the blows with any
+weapon. The head of the deceased, when seen by witness, was entirely
+separated from the body, and was also greatly shattered. The throat
+had evidently been cut with some very sharp instrument--probably with a
+razor.
+
+“_Alexandre Etienne_, surgeon, was called with M. Dumas to view the
+bodies. Corroborated the testimony, and the opinions of M. Dumas.
+
+“Nothing farther of importance was elicited, although several other
+persons were examined. A murder so mysterious, and so perplexing in all
+its particulars, was never before committed in Paris--if indeed a murder
+has been committed at all. The police are entirely at fault--an unusual
+occurrence in affairs of this nature. There is not, however, the shadow
+of a clew apparent.”
+
+The evening edition of the paper stated that the greatest excitement
+still continued in the Quartier St. Roch--that the premises in question
+had been carefully re-searched, and fresh examinations of witnesses
+instituted, but all to no purpose. A postscript, however, mentioned
+that Adolphe Le Bon had been arrested and imprisoned--although nothing
+appeared to criminate him, beyond the facts already detailed.
+
+Dupin seemed singularly interested in the progress of this affair--at
+least so I judged from his manner, for he made no comments. It was only
+after the announcement that Le Bon had been imprisoned, that he asked me
+my opinion respecting the murders.
+
+I could merely agree with all Paris in considering them an insoluble
+mystery. I saw no means by which it would be possible to trace the
+murderer.
+
+“We must not judge of the means,” said Dupin, “by this shell of an
+examination. The Parisian police, so much extolled for _acumen_, are
+cunning, but no more. There is no method in their proceedings, beyond
+the method of the moment. They make a vast parade of measures; but, not
+unfrequently, these are so ill adapted to the objects proposed, as
+to put us in mind of Monsieur Jourdain’s calling for his
+_robe-de-chambre--pour mieux entendre la musique._ The results attained
+by them are not unfrequently surprising, but, for the most part, are
+brought about by simple diligence and activity. When these qualities are
+unavailing, their schemes fail. Vidocq, for example, was a good
+guesser and a persevering man. But, without educated thought, he erred
+continually by the very intensity of his investigations. He impaired his
+vision by holding the object too close. He might see, perhaps, one or
+two points with unusual clearness, but in so doing he, necessarily, lost
+sight of the matter as a whole. Thus there is such a thing as being too
+profound. Truth is not always in a well. In fact, as regards the more
+important knowledge, I do believe that she is invariably superficial.
+The depth lies in the valleys where we seek her, and not upon the
+mountain-tops where she is found. The modes and sources of this kind of
+error are well typified in the contemplation of the heavenly bodies.
+To look at a star by glances--to view it in a side-long way, by turning
+toward it the exterior portions of the _retina_ (more susceptible of
+feeble impressions of light than the interior), is to behold the star
+distinctly--is to have the best appreciation of its lustre--a lustre
+which grows dim just in proportion as we turn our vision _fully_ upon
+it. A greater number of rays actually fall upon the eye in the latter
+case, but, in the former, there is the more refined capacity for
+comprehension. By undue profundity we perplex and enfeeble thought; and
+it is possible to make even Venus herself vanish from the firmanent by a
+scrutiny too sustained, too concentrated, or too direct.
+
+“As for these murders, let us enter into some examinations for
+ourselves, before we make up an opinion respecting them. An inquiry will
+afford us amusement,” [I thought this an odd term, so applied, but said
+nothing] “and, besides, Le Bon once rendered me a service for which I
+am not ungrateful. We will go and see the premises with our own eyes.
+I know G----, the Prefect of Police, and shall have no difficulty in
+obtaining the necessary permission.”
+
+The permission was obtained, and we proceeded at once to the Rue Morgue.
+This is one of those miserable thoroughfares which intervene between the
+Rue Richelieu and the Rue St. Roch. It was late in the afternoon when we
+reached it; as this quarter is at a great distance from that in which we
+resided. The house was readily found; for there were still many persons
+gazing up at the closed shutters, with an objectless curiosity, from
+the opposite side of the way. It was an ordinary Parisian house, with
+a gateway, on one side of which was a glazed watch-box, with a sliding
+panel in the window, indicating a _loge de concierge._ Before going in
+we walked up the street, turned down an alley, and then, again turning,
+passed in the rear of the building--Dupin, meanwhile examining the whole
+neighborhood, as well as the house, with a minuteness of attention for
+which I could see no possible object.
+
+Retracing our steps, we came again to the front of the dwelling, rang,
+and, having shown our credentials, were admitted by the agents
+in charge. We went up stairs--into the chamber where the body of
+Mademoiselle L’Espanaye had been found, and where both the deceased
+still lay. The disorders of the room had, as usual, been suffered to
+exist. I saw nothing beyond what had been stated in the “Gazette des
+Tribunaux.” Dupin scrutinized every thing--not excepting the bodies of
+the victims. We then went into the other rooms, and into the yard; a
+_gendarme_ accompanying us throughout. The examination occupied us until
+dark, when we took our departure. On our way home my companion stepped
+in for a moment at the office of one of the daily papers.
+
+I have said that the whims of my friend were manifold, and that _Je les
+ménageais_:--for this phrase there is no English equivalent. It was his
+humor, now, to decline all conversation on the subject of the murder,
+until about noon the next day. He then asked me, suddenly, if I had
+observed any thing _peculiar_ at the scene of the atrocity.
+
+There was something in his manner of emphasizing the word “peculiar,”
+ which caused me to shudder, without knowing why.
+
+“No, nothing _peculiar_,” I said; “nothing more, at least, than we both
+saw stated in the paper.”
+
+“The ‘Gazette,’” he replied, “has not entered, I fear, into the unusual
+horror of the thing. But dismiss the idle opinions of this print. It
+appears to me that this mystery is considered insoluble, for the very
+reason which should cause it to be regarded as easy of solution--I mean
+for the _outré_ character of its features. The police are confounded by
+the seeming absence of motive--not for the murder itself--but for
+the atrocity of the murder. They are puzzled, too, by the seeming
+impossibility of reconciling the voices heard in contention, with
+the facts that no one was discovered up stairs but the assassinated
+Mademoiselle L’Espanaye, and that there were no means of egress without
+the notice of the party ascending. The wild disorder of the room; the
+corpse thrust, with the head downward, up the chimney; the frightful
+mutilation of the body of the old lady; these considerations, with those
+just mentioned, and others which I need not mention, have sufficed
+to paralyze the powers, by putting completely at fault the boasted
+_acumen_, of the government agents. They have fallen into the gross but
+common error of confounding the unusual with the abstruse. But it is by
+these deviations from the plane of the ordinary, that reason feels its
+way, if at all, in its search for the true. In investigations such as we
+are now pursuing, it should not be so much asked ‘what has occurred,’
+as ‘what has occurred that has never occurred before.’ In fact, the
+facility with which I shall arrive, or have arrived, at the solution of
+this mystery, is in the direct ratio of its apparent insolubility in the
+eyes of the police.”
+
+I stared at the speaker in mute astonishment.
+
+“I am now awaiting,” continued he, looking toward the door of our
+apartment--“I am now awaiting a person who, although perhaps not
+the perpetrator of these butcheries, must have been in some measure
+implicated in their perpetration. Of the worst portion of the crimes
+committed, it is probable that he is innocent. I hope that I am right
+in this supposition; for upon it I build my expectation of reading the
+entire riddle. I look for the man here--in this room--every moment. It
+is true that he may not arrive; but the probability is that he will.
+Should he come, it will be necessary to detain him. Here are pistols;
+and we both know how to use them when occasion demands their use.”
+
+I took the pistols, scarcely knowing what I did, or believing what
+I heard, while Dupin went on, very much as if in a soliloquy. I have
+already spoken of his abstract manner at such times. His discourse was
+addressed to myself; but his voice, although by no means loud, had that
+intonation which is commonly employed in speaking to some one at a great
+distance. His eyes, vacant in expression, regarded only the wall.
+
+“That the voices heard in contention,” he said, “by the party upon the
+stairs, were not the voices of the women themselves, was fully proved
+by the evidence. This relieves us of all doubt upon the question whether
+the old lady could have first destroyed the daughter and afterward have
+committed suicide. I speak of this point chiefly for the sake of method;
+for the strength of Madame L’Espanaye would have been utterly unequal
+to the task of thrusting her daughter’s corpse up the chimney as it
+was found; and the nature of the wounds upon her own person entirely
+preclude the idea of self-destruction. Murder, then, has been committed
+by some third party; and the voices of this third party were those heard
+in contention. Let me now advert--not to the whole testimony respecting
+these voices--but to what was _peculiar_ in that testimony. Did you
+observe any thing peculiar about it?”
+
+I remarked that, while all the witnesses agreed in supposing the gruff
+voice to be that of a Frenchman, there was much disagreement in regard
+to the shrill, or, as one individual termed it, the harsh voice.
+
+“That was the evidence itself,” said Dupin, “but it was not the
+peculiarity of the evidence. You have observed nothing distinctive.
+Yet there _was_ something to be observed. The witnesses, as you remark,
+agreed about the gruff voice; they were here unanimous. But in regard to
+the shrill voice, the peculiarity is--not that they disagreed--but
+that, while an Italian, an Englishman, a Spaniard, a Hollander, and a
+Frenchman attempted to describe it, each one spoke of it as that _of
+a foreigner_. Each is sure that it was not the voice of one of his own
+countrymen. Each likens it--not to the voice of an individual of any
+nation with whose language he is conversant--but the converse.
+The Frenchman supposes it the voice of a Spaniard, and ‘might have
+distinguished some words _had he been acquainted with the Spanish._’ The
+Dutchman maintains it to have been that of a Frenchman; but we find it
+stated that ‘_not understanding French this witness was examined through
+an interpreter._’ The Englishman thinks it the voice of a German, and
+‘_does not understand German._’ The Spaniard ‘is sure’ that it was that
+of an Englishman, but ‘judges by the intonation’ altogether, ‘_as he has
+no knowledge of the English._’ The Italian believes it the voice of a
+Russian, but ‘_has never conversed with a native of Russia._’ A second
+Frenchman differs, moreover, with the first, and is positive that the
+voice was that of an Italian; but, _not being cognizant of that tongue_,
+is, like the Spaniard, ‘convinced by the intonation.’ Now, how strangely
+unusual must that voice have really been, about which such testimony as
+this _could_ have been elicited!--in whose _tones_, even, denizens of
+the five great divisions of Europe could recognise nothing familiar! You
+will say that it might have been the voice of an Asiatic--of an African.
+Neither Asiatics nor Africans abound in Paris; but, without denying the
+inference, I will now merely call your attention to three points.
+The voice is termed by one witness ‘harsh rather than shrill.’ It
+is represented by two others to have been ‘quick and _unequal._’ No
+words--no sounds resembling words--were by any witness mentioned as
+distinguishable.
+
+“I know not,” continued Dupin, “what impression I may have made, so
+far, upon your own understanding; but I do not hesitate to say that
+legitimate deductions even from this portion of the testimony--the
+portion respecting the gruff and shrill voices--are in themselves
+sufficient to engender a suspicion which should give direction to all
+farther progress in the investigation of the mystery. I said ‘legitimate
+deductions;’ but my meaning is not thus fully expressed. I designed
+to imply that the deductions are the _sole_ proper ones, and that the
+suspicion arises _inevitably_ from them as the single result. What the
+suspicion is, however, I will not say just yet. I merely wish you to
+bear in mind that, with myself, it was sufficiently forcible to give a
+definite form--a certain tendency--to my inquiries in the chamber.
+
+“Let us now transport ourselves, in fancy, to this chamber. What shall
+we first seek here? The means of egress employed by the murderers. It is
+not too much to say that neither of us believe in præternatural events.
+Madame and Mademoiselle L’Espanaye were not destroyed by spirits. The
+doers of the deed were material, and escaped materially. Then how?
+Fortunately, there is but one mode of reasoning upon the point, and that
+mode _must_ lead us to a definite decision.--Let us examine, each by
+each, the possible means of egress. It is clear that the assassins were
+in the room where Mademoiselle L’Espanaye was found, or at least in the
+room adjoining, when the party ascended the stairs. It is then only from
+these two apartments that we have to seek issues. The police have laid
+bare the floors, the ceilings, and the masonry of the walls, in every
+direction. No _secret_ issues could have escaped their vigilance. But,
+not trusting to _their_ eyes, I examined with my own. There were, then,
+no secret issues. Both doors leading from the rooms into the passage
+were securely locked, with the keys inside. Let us turn to the chimneys.
+These, although of ordinary width for some eight or ten feet above the
+hearths, will not admit, throughout their extent, the body of a large
+cat. The impossibility of egress, by means already stated, being thus
+absolute, we are reduced to the windows. Through those of the front room
+no one could have escaped without notice from the crowd in the street.
+The murderers _must_ have passed, then, through those of the back room.
+Now, brought to this conclusion in so unequivocal a manner as we are,
+it is not our part, as reasoners, to reject it on account of apparent
+impossibilities. It is only left for us to prove that these apparent
+‘impossibilities’ are, in reality, not such.
+
+“There are two windows in the chamber. One of them is unobstructed by
+furniture, and is wholly visible. The lower portion of the other is
+hidden from view by the head of the unwieldy bedstead which is thrust
+close up against it. The former was found securely fastened from within.
+It resisted the utmost force of those who endeavored to raise it. A
+large gimlet-hole had been pierced in its frame to the left, and a very
+stout nail was found fitted therein, nearly to the head. Upon examining
+the other window, a similar nail was seen similarly fitted in it; and
+a vigorous attempt to raise this sash, failed also. The police were now
+entirely satisfied that egress had not been in these directions. And,
+_therefore_, it was thought a matter of supererogation to withdraw the
+nails and open the windows.
+
+“My own examination was somewhat more particular, and was so for the
+reason I have just given--because here it was, I knew, that all apparent
+impossibilities _must_ be proved to be not such in reality.
+
+“I proceeded to think thus--_a posteriori_. The murderers did escape
+from one of these windows. This being so, they could not have refastened
+the sashes from the inside, as they were found fastened;--the
+consideration which put a stop, through its obviousness, to the scrutiny
+of the police in this quarter. Yet the sashes _were_ fastened. They
+_must_, then, have the power of fastening themselves. There was no
+escape from this conclusion. I stepped to the unobstructed casement,
+withdrew the nail with some difficulty and attempted to raise the sash.
+It resisted all my efforts, as I had anticipated. A concealed spring
+must, I now know, exist; and this corroboration of my idea convinced
+me that my premises at least, were correct, however mysterious still
+appeared the circumstances attending the nails. A careful search soon
+brought to light the hidden spring. I pressed it, and, satisfied with
+the discovery, forbore to upraise the sash.
+
+“I now replaced the nail and regarded it attentively. A person passing
+out through this window might have reclosed it, and the spring would
+have caught--but the nail could not have been replaced. The conclusion
+was plain, and again narrowed in the field of my investigations. The
+assassins _must_ have escaped through the other window. Supposing, then,
+the springs upon each sash to be the same, as was probable, there _must_
+be found a difference between the nails, or at least between the modes
+of their fixture. Getting upon the sacking of the bedstead, I looked
+over the head-board minutely at the second casement. Passing my hand
+down behind the board, I readily discovered and pressed the spring,
+which was, as I had supposed, identical in character with its neighbor.
+I now looked at the nail. It was as stout as the other, and apparently
+fitted in the same manner--driven in nearly up to the head.
+
+“You will say that I was puzzled; but, if you think so, you must have
+misunderstood the nature of the inductions. To use a sporting phrase,
+I had not been once ‘at fault.’ The scent had never for an instant
+been lost. There was no flaw in any link of the chain. I had traced the
+secret to its ultimate result,--and that result was _the nail._ It
+had, I say, in every respect, the appearance of its fellow in the other
+window; but this fact was an absolute nullity (conclusive us it might
+seem to be) when compared with the consideration that here, at this
+point, terminated the clew. ‘There _must_ be something wrong,’ I said,
+‘about the nail.’ I touched it; and the head, with about a quarter of an
+inch of the shank, came off in my fingers. The rest of the shank was in
+the gimlet-hole where it had been broken off. The fracture was an old
+one (for its edges were incrusted with rust), and had apparently been
+accomplished by the blow of a hammer, which had partially imbedded,
+in the top of the bottom sash, the head portion of the nail. I now
+carefully replaced this head portion in the indentation whence I had
+taken it, and the resemblance to a perfect nail was complete--the
+fissure was invisible. Pressing the spring, I gently raised the sash
+for a few inches; the head went up with it, remaining firm in its bed.
+I closed the window, and the semblance of the whole nail was again
+perfect.
+
+“The riddle, so far, was now unriddled. The assassin had escaped through
+the window which looked upon the bed. Dropping of its own accord upon
+his exit (or perhaps purposely closed), it had become fastened by the
+spring; and it was the retention of this spring which had been mistaken
+by the police for that of the nail,--farther inquiry being thus
+considered unnecessary.
+
+“The next question is that of the mode of descent. Upon this point I had
+been satisfied in my walk with you around the building. About five feet
+and a half from the casement in question there runs a lightning-rod.
+From this rod it would have been impossible for any one to reach the
+window itself, to say nothing of entering it. I observed, however, that
+the shutters of the fourth story were of the peculiar kind called by
+Parisian carpenters _ferrades_--a kind rarely employed at the present
+day, but frequently seen upon very old mansions at Lyons and Bordeaux.
+They are in the form of an ordinary door, (a single, not a folding door)
+except that the lower half is latticed or worked in open trellis--thus
+affording an excellent hold for the hands. In the present instance these
+shutters are fully three feet and a half broad. When we saw them from
+the rear of the house, they were both about half open--that is to say,
+they stood off at right angles from the wall. It is probable that the
+police, as well as myself, examined the back of the tenement; but, if
+so, in looking at these _ferrades_ in the line of their breadth (as they
+must have done), they did not perceive this great breadth itself, or,
+at all events, failed to take it into due consideration. In fact, having
+once satisfied themselves that no egress could have been made in this
+quarter, they would naturally bestow here a very cursory examination.
+It was clear to me, however, that the shutter belonging to the window
+at the head of the bed, would, if swung fully back to the wall, reach
+to within two feet of the lightning-rod. It was also evident that, by
+exertion of a very unusual degree of activity and courage, an entrance
+into the window, from the rod, might have been thus effected.--By
+reaching to the distance of two feet and a half (we now suppose the
+shutter open to its whole extent) a robber might have taken a firm grasp
+upon the trellis-work. Letting go, then, his hold upon the rod, placing
+his feet securely against the wall, and springing boldly from it, he
+might have swung the shutter so as to close it, and, if we imagine the
+window open at the time, might even have swung himself into the room.
+
+“I wish you to bear especially in mind that I have spoken of a _very_
+unusual degree of activity as requisite to success in so hazardous and
+so difficult a feat. It is my design to show you, first, that the thing
+might possibly have been accomplished:--but, secondly and _chiefly_, I
+wish to impress upon your understanding the _very extraordinary_--the
+almost præternatural character of that agility which could have
+accomplished it.
+
+“You will say, no doubt, using the language of the law, that ‘to make
+out my case,’ I should rather undervalue, than insist upon a full
+estimation of the activity required in this matter. This may be the
+practice in law, but it is not the usage of reason. My ultimate object
+is only the truth. My immediate purpose is to lead you to place in
+juxtaposition, that _very unusual_ activity of which I have just spoken
+with that _very peculiar_ shrill (or harsh) and _unequal_ voice, about
+whose nationality no two persons could be found to agree, and in whose
+utterance no syllabification could be detected.”
+
+At these words a vague and half-formed conception of the meaning
+of Dupin flitted over my mind. I seemed to be upon the verge of
+comprehension without power to comprehend--men, at times, find
+themselves upon the brink of remembrance without being able, in the end,
+to remember. My friend went on with his discourse.
+
+“You will see,” he said, “that I have shifted the question from the mode
+of egress to that of ingress. It was my design to convey the idea that
+both were effected in the same manner, at the same point. Let us now
+revert to the interior of the room. Let us survey the appearances here.
+The drawers of the bureau, it is said, had been rifled, although many
+articles of apparel still remained within them. The conclusion here is
+absurd. It is a mere guess--a very silly one--and no more. How are
+we to know that the articles found in the drawers were not all these
+drawers had originally contained? Madame L’Espanaye and her daughter
+lived an exceedingly retired life--saw no company--seldom went out--had
+little use for numerous changes of habiliment. Those found were at least
+of as good quality as any likely to be possessed by these ladies. If a
+thief had taken any, why did he not take the best--why did he not take
+all? In a word, why did he abandon four thousand francs in gold to
+encumber himself with a bundle of linen? The gold _was _abandoned.
+Nearly the whole sum mentioned by Monsieur Mignaud, the banker, was
+discovered, in bags, upon the floor. I wish you, therefore, to discard
+from your thoughts the blundering idea of _motive_, engendered in the
+brains of the police by that portion of the evidence which speaks of
+money delivered at the door of the house. Coincidences ten times as
+remarkable as this (the delivery of the money, and murder committed
+within three days upon the party receiving it), happen to all of us
+every hour of our lives, without attracting even momentary notice.
+Coincidences, in general, are great stumbling-blocks in the way of that
+class of thinkers who have been educated to know nothing of the theory
+of probabilities--that theory to which the most glorious objects of
+human research are indebted for the most glorious of illustration. In
+the present instance, had the gold been gone, the fact of its delivery
+three days before would have formed something more than a coincidence.
+It would have been corroborative of this idea of motive. But, under the
+real circumstances of the case, if we are to suppose gold the motive
+of this outrage, we must also imagine the perpetrator so vacillating an
+idiot as to have abandoned his gold and his motive together.
+
+“Keeping now steadily in mind the points to which I have drawn your
+attention--that peculiar voice, that unusual agility, and that startling
+absence of motive in a murder so singularly atrocious as this--let us
+glance at the butchery itself. Here is a woman strangled to death
+by manual strength, and thrust up a chimney, head downward. Ordinary
+assassins employ no such modes of murder as this. Least of all, do they
+thus dispose of the murdered. In the manner of thrusting the corpse
+up the chimney, you will admit that there was something _excessively
+outré_--something altogether irreconcilable with our common notions of
+human action, even when we suppose the actors the most depraved of men.
+Think, too, how great must have been that strength which could have
+thrust the body _up_ such an aperture so forcibly that the united vigor
+of several persons was found barely sufficient to drag it _down!_
+
+“Turn, now, to other indications of the employment of a vigor most
+marvellous. On the hearth were thick tresses--very thick tresses--of
+grey human hair. These had been torn out by the roots. You are aware of
+the great force necessary in tearing thus from the head even twenty or
+thirty hairs together. You saw the locks in question as well as myself.
+Their roots (a hideous sight!) were clotted with fragments of the flesh
+of the scalp--sure token of the prodigious power which had been exerted
+in uprooting perhaps half a million of hairs at a time. The throat of
+the old lady was not merely cut, but the head absolutely severed from
+the body: the instrument was a mere razor. I wish you also to look at
+the _brutal_ ferocity of these deeds. Of the bruises upon the body
+of Madame L’Espanaye I do not speak. Monsieur Dumas, and his worthy
+coadjutor Monsieur Etienne, have pronounced that they were inflicted by
+some obtuse instrument; and so far these gentlemen are very correct. The
+obtuse instrument was clearly the stone pavement in the yard, upon which
+the victim had fallen from the window which looked in upon the bed. This
+idea, however simple it may now seem, escaped the police for the same
+reason that the breadth of the shutters escaped them--because, by the
+affair of the nails, their perceptions had been hermetically sealed
+against the possibility of the windows having ever been opened at all.
+
+“If now, in addition to all these things, you have properly reflected
+upon the odd disorder of the chamber, we have gone so far as to combine
+the ideas of an agility astounding, a strength superhuman, a ferocity
+brutal, a butchery without motive, a _grotesquerie_ in horror absolutely
+alien from humanity, and a voice foreign in tone to the ears of men
+of many nations, and devoid of all distinct or intelligible
+syllabification. What result, then, has ensued? What impression have I
+made upon your fancy?”
+
+I felt a creeping of the flesh as Dupin asked me the question. “A
+madman,” I said, “has done this deed--some raving maniac, escaped from a
+neighboring _Maison de Santé._”
+
+“In some respects,” he replied, “your idea is not irrelevant. But the
+voices of madmen, even in their wildest paroxysms, are never found to
+tally with that peculiar voice heard upon the stairs. Madmen are of some
+nation, and their language, however incoherent in its words, has always
+the coherence of syllabification. Besides, the hair of a madman is not
+such as I now hold in my hand. I disentangled this little tuft from the
+rigidly clutched fingers of Madame L’Espanaye. Tell me what you can make
+of it.”
+
+“Dupin!” I said, completely unnerved; “this hair is most unusual--this
+is no _human_ hair.”
+
+“I have not asserted that it is,” said he; “but, before we decide this
+point, I wish you to glance at the little sketch I have here traced upon
+this paper. It is a _fac-simile_ drawing of what has been described in
+one portion of the testimony as ‘dark bruises, and deep indentations
+of finger nails,’ upon the throat of Mademoiselle L’Espanaye, and in
+another, (by Messrs. Dumas and Etienne,) as a ‘series of livid spots,
+evidently the impression of fingers.’
+
+“You will perceive,” continued my friend, spreading out the paper upon
+the table before us, “that this drawing gives the idea of a firm
+and fixed hold. There is no _slipping_ apparent. Each finger has
+retained--possibly until the death of the victim--the fearful grasp by
+which it originally imbedded itself. Attempt, now, to place all your
+fingers, at the same time, in the respective impressions as you see
+them.”
+
+I made the attempt in vain.
+
+“We are possibly not giving this matter a fair trial,” he said. “The
+paper is spread out upon a plane surface; but the human throat is
+cylindrical. Here is a billet of wood, the circumference of which
+is about that of the throat. Wrap the drawing around it, and try the
+experiment again.”
+
+I did so; but the difficulty was even more obvious than before. “This,”
+ I said, “is the mark of no human hand.”
+
+“Read now,” replied Dupin, “this passage from Cuvier.”
+
+It was a minute anatomical and generally descriptive account of the
+large fulvous Ourang-Outang of the East Indian Islands. The gigantic
+stature, the prodigious strength and activity, the wild ferocity, and
+the imitative propensities of these mammalia are sufficiently well known
+to all. I understood the full horrors of the murder at once.
+
+“The description of the digits,” said I, as I made an end of reading,
+“is in exact accordance with this drawing. I see that no animal but an
+Ourang-Outang, of the species here mentioned, could have impressed the
+indentations as you have traced them. This tuft of tawny hair, too, is
+identical in character with that of the beast of Cuvier. But I cannot
+possibly comprehend the particulars of this frightful mystery. Besides,
+there were _two_ voices heard in contention, and one of them was
+unquestionably the voice of a Frenchman.”
+
+“True; and you will remember an expression attributed almost
+unanimously, by the evidence, to this voice,--the expression, ‘_mon
+Dieu!_’ This, under the circumstances, has been justly characterized by
+one of the witnesses (Montani, the confectioner,) as an expression of
+remonstrance or expostulation. Upon these two words, therefore, I have
+mainly built my hopes of a full solution of the riddle. A Frenchman
+was cognizant of the murder. It is possible--indeed it is far more
+than probable--that he was innocent of all participation in the bloody
+transactions which took place. The Ourang-Outang may have escaped from
+him. He may have traced it to the chamber; but, under the agitating
+circumstances which ensued, he could never have re-captured it. It is
+still at large. I will not pursue these guesses--for I have no right to
+call them more--since the shades of reflection upon which they are based
+are scarcely of sufficient depth to be appreciable by my own intellect,
+and since I could not pretend to make them intelligible to the
+understanding of another. We will call them guesses then, and speak
+of them as such. If the Frenchman in question is indeed, as I suppose,
+innocent of this atrocity, this advertisement which I left last night,
+upon our return home, at the office of ‘Le Monde,’ (a paper devoted to
+the shipping interest, and much sought by sailors,) will bring him to
+our residence.”
+
+He handed me a paper, and I read thus:
+
+CAUGHT--_In the Bois de Boulogne, early in the morning of the--inst.,_
+(the morning of the murder,) _a very large, tawny Ourang-Outang of
+the Bornese species. The owner, (who is ascertained to be a sailor,
+belonging to a Maltese vessel,) may have the animal again, upon
+identifying it satisfactorily, and paying a few charges arising from
+its capture and keeping. Call at No. ----, Rue ----, Faubourg St.
+Germain--au troisiême._
+
+“How was it possible,” I asked, “that you should know the man to be a
+sailor, and belonging to a Maltese vessel?”
+
+“I do _not_ know it,” said Dupin. “I am not _sure_ of it. Here, however,
+is a small piece of ribbon, which from its form, and from its greasy
+appearance, has evidently been used in tying the hair in one of those
+long _queues_ of which sailors are so fond. Moreover, this knot is one
+which few besides sailors can tie, and is peculiar to the Maltese. I
+picked the ribbon up at the foot of the lightning-rod. It could not have
+belonged to either of the deceased. Now if, after all, I am wrong in my
+induction from this ribbon, that the Frenchman was a sailor belonging to
+a Maltese vessel, still I can have done no harm in saying what I did in
+the advertisement. If I am in error, he will merely suppose that I have
+been misled by some circumstance into which he will not take the trouble
+to inquire. But if I am right, a great point is gained. Cognizant
+although innocent of the murder, the Frenchman will naturally hesitate
+about replying to the advertisement--about demanding the Ourang-Outang.
+He will reason thus:--‘I am innocent; I am poor; my Ourang-Outang is of
+great value--to one in my circumstances a fortune of itself--why should
+I lose it through idle apprehensions of danger? Here it is, within my
+grasp. It was found in the Bois de Boulogne--at a vast distance from the
+scene of that butchery. How can it ever be suspected that a brute beast
+should have done the deed? The police are at fault--they have failed to
+procure the slightest clew. Should they even trace the animal, it would
+be impossible to prove me cognizant of the murder, or to implicate me
+in guilt on account of that cognizance. Above all, _I am known._ The
+advertiser designates me as the possessor of the beast. I am not sure to
+what limit his knowledge may extend. Should I avoid claiming a property
+of so great value, which it is known that I possess, I will render the
+animal at least, liable to suspicion. It is not my policy to attract
+attention either to myself or to the beast. I will answer the
+advertisement, get the Ourang-Outang, and keep it close until this
+matter has blown over.’”
+
+At this moment we heard a step upon the stairs.
+
+“Be ready,” said Dupin, “with your pistols, but neither use them nor
+show them until at a signal from myself.”
+
+The front door of the house had been left open, and the visiter had
+entered, without ringing, and advanced several steps upon the staircase.
+Now, however, he seemed to hesitate. Presently we heard him descending.
+Dupin was moving quickly to the door, when we again heard him coming up.
+He did not turn back a second time, but stepped up with decision, and
+rapped at the door of our chamber.
+
+“Come in,” said Dupin, in a cheerful and hearty tone.
+
+A man entered. He was a sailor, evidently,--a tall, stout, and
+muscular-looking person, with a certain dare-devil expression of
+countenance, not altogether unprepossessing. His face, greatly sunburnt,
+was more than half hidden by whisker and _mustachio._ He had with him
+a huge oaken cudgel, but appeared to be otherwise unarmed. He bowed
+awkwardly, and bade us “good evening,” in French accents, which,
+although somewhat Neufchatelish, were still sufficiently indicative of a
+Parisian origin.
+
+“Sit down, my friend,” said Dupin. “I suppose you have called about the
+Ourang-Outang. Upon my word, I almost envy you the possession of him;
+a remarkably fine, and no doubt a very valuable animal. How old do you
+suppose him to be?”
+
+The sailor drew a long breath, with the air of a man relieved of some
+intolerable burden, and then replied, in an assured tone:
+
+“I have no way of telling--but he can’t be more than four or five years
+old. Have you got him here?”
+
+“Oh no, we had no conveniences for keeping him here. He is at a livery
+stable in the Rue Dubourg, just by. You can get him in the morning. Of
+course you are prepared to identify the property?”
+
+“To be sure I am, sir.”
+
+“I shall be sorry to part with him,” said Dupin.
+
+“I don’t mean that you should be at all this trouble for nothing, sir,”
+ said the man. “Couldn’t expect it. Am very willing to pay a reward for
+the finding of the animal--that is to say, any thing in reason.”
+
+“Well,” replied my friend, “that is all very fair, to be sure. Let me
+think!--what should I have? Oh! I will tell you. My reward shall be
+this. You shall give me all the information in your power about these
+murders in the Rue Morgue.”
+
+Dupin said the last words in a very low tone, and very quietly. Just as
+quietly, too, he walked toward the door, locked it and put the key in
+his pocket. He then drew a pistol from his bosom and placed it, without
+the least flurry, upon the table.
+
+The sailor’s face flushed up as if he were struggling with suffocation.
+He started to his feet and grasped his cudgel, but the next moment he
+fell back into his seat, trembling violently, and with the countenance
+of death itself. He spoke not a word. I pitied him from the bottom of my
+heart.
+
+“My friend,” said Dupin, in a kind tone, “you are alarming yourself
+unnecessarily--you are indeed. We mean you no harm whatever. I pledge
+you the honor of a gentleman, and of a Frenchman, that we intend you no
+injury. I perfectly well know that you are innocent of the atrocities
+in the Rue Morgue. It will not do, however, to deny that you are in some
+measure implicated in them. From what I have already said, you must know
+that I have had means of information about this matter--means of which
+you could never have dreamed. Now the thing stands thus. You have done
+nothing which you could have avoided--nothing, certainly, which renders
+you culpable. You were not even guilty of robbery, when you might have
+robbed with impunity. You have nothing to conceal. You have no reason
+for concealment. On the other hand, you are bound by every principle
+of honor to confess all you know. An innocent man is now imprisoned,
+charged with that crime of which you can point out the perpetrator.”
+
+The sailor had recovered his presence of mind, in a great measure, while
+Dupin uttered these words; but his original boldness of bearing was all
+gone.
+
+“So help me God,” said he, after a brief pause, “I will tell you all I
+know about this affair;--but I do not expect you to believe one half I
+say--I would be a fool indeed if I did. Still, I am innocent, and I will
+make a clean breast if I die for it.”
+
+What he stated was, in substance, this. He had lately made a voyage
+to the Indian Archipelago. A party, of which he formed one, landed
+at Borneo, and passed into the interior on an excursion of pleasure.
+Himself and a companion had captured the Ourang-Outang. This companion
+dying, the animal fell into his own exclusive possession. After great
+trouble, occasioned by the intractable ferocity of his captive during
+the home voyage, he at length succeeded in lodging it safely at his own
+residence in Paris, where, not to attract toward himself the unpleasant
+curiosity of his neighbors, he kept it carefully secluded, until such
+time as it should recover from a wound in the foot, received from a
+splinter on board ship. His ultimate design was to sell it.
+
+Returning home from some sailors’ frolic the night, or rather in the
+morning of the murder, he found the beast occupying his own bed-room,
+into which it had broken from a closet adjoining, where it had been, as
+was thought, securely confined. Razor in hand, and fully lathered, it
+was sitting before a looking-glass, attempting the operation of shaving,
+in which it had no doubt previously watched its master through the
+key-hole of the closet. Terrified at the sight of so dangerous a weapon
+in the possession of an animal so ferocious, and so well able to use
+it, the man, for some moments, was at a loss what to do. He had been
+accustomed, however, to quiet the creature, even in its fiercest moods,
+by the use of a whip, and to this he now resorted. Upon sight of it, the
+Ourang-Outang sprang at once through the door of the chamber, down
+the stairs, and thence, through a window, unfortunately open, into the
+street.
+
+The Frenchman followed in despair; the ape, razor still in hand,
+occasionally stopping to look back and gesticulate at its pursuer, until
+the latter had nearly come up with it. It then again made off. In this
+manner the chase continued for a long time. The streets were profoundly
+quiet, as it was nearly three o’clock in the morning. In passing down
+an alley in the rear of the Rue Morgue, the fugitive’s attention was
+arrested by a light gleaming from the open window of Madame L’Espanaye’s
+chamber, in the fourth story of her house. Rushing to the building, it
+perceived the lightning rod, clambered up with inconceivable agility,
+grasped the shutter, which was thrown fully back against the wall, and,
+by its means, swung itself directly upon the headboard of the bed. The
+whole feat did not occupy a minute. The shutter was kicked open again by
+the Ourang-Outang as it entered the room.
+
+The sailor, in the meantime, was both rejoiced and perplexed. He had
+strong hopes of now recapturing the brute, as it could scarcely escape
+from the trap into which it had ventured, except by the rod, where it
+might be intercepted as it came down. On the other hand, there was
+much cause for anxiety as to what it might do in the house. This latter
+reflection urged the man still to follow the fugitive. A lightning rod
+is ascended without difficulty, especially by a sailor; but, when he had
+arrived as high as the window, which lay far to his left, his career was
+stopped; the most that he could accomplish was to reach over so as to
+obtain a glimpse of the interior of the room. At this glimpse he nearly
+fell from his hold through excess of horror. Now it was that those
+hideous shrieks arose upon the night, which had startled from slumber
+the inmates of the Rue Morgue. Madame L’Espanaye and her daughter,
+habited in their night clothes, had apparently been occupied in
+arranging some papers in the iron chest already mentioned, which had
+been wheeled into the middle of the room. It was open, and its contents
+lay beside it on the floor. The victims must have been sitting with
+their backs toward the window; and, from the time elapsing between the
+ingress of the beast and the screams, it seems probable that it was not
+immediately perceived. The flapping-to of the shutter would naturally
+have been attributed to the wind.
+
+As the sailor looked in, the gigantic animal had seized Madame
+L’Espanaye by the hair, (which was loose, as she had been combing
+it,) and was flourishing the razor about her face, in imitation of the
+motions of a barber. The daughter lay prostrate and motionless; she had
+swooned. The screams and struggles of the old lady (during which the
+hair was torn from her head) had the effect of changing the probably
+pacific purposes of the Ourang-Outang into those of wrath. With one
+determined sweep of its muscular arm it nearly severed her head from her
+body. The sight of blood inflamed its anger into phrenzy. Gnashing its
+teeth, and flashing fire from its eyes, it flew upon the body of the
+girl, and imbedded its fearful talons in her throat, retaining its grasp
+until she expired. Its wandering and wild glances fell at this moment
+upon the head of the bed, over which the face of its master, rigid with
+horror, was just discernible. The fury of the beast, who no doubt bore
+still in mind the dreaded whip, was instantly converted into fear.
+Conscious of having deserved punishment, it seemed desirous of
+concealing its bloody deeds, and skipped about the chamber in an agony
+of nervous agitation; throwing down and breaking the furniture as it
+moved, and dragging the bed from the bedstead. In conclusion, it seized
+first the corpse of the daughter, and thrust it up the chimney, as
+it was found; then that of the old lady, which it immediately hurled
+through the window headlong.
+
+As the ape approached the casement with its mutilated burden, the sailor
+shrank aghast to the rod, and, rather gliding than clambering down it,
+hurried at once home--dreading the consequences of the butchery, and
+gladly abandoning, in his terror, all solicitude about the fate of the
+Ourang-Outang. The words heard by the party upon the staircase were the
+Frenchman’s exclamations of horror and affright, commingled with the
+fiendish jabberings of the brute.
+
+I have scarcely anything to add. The Ourang-Outang must have escaped
+from the chamber, by the rod, just before the break of the door. It
+must have closed the window as it passed through it. It was subsequently
+caught by the owner himself, who obtained for it a very large sum at the
+_Jardin des Plantes._ Le Don was instantly released, upon our narration
+of the circumstances (with some comments from Dupin) at the bureau of
+the Prefect of Police. This functionary, however well disposed to my
+friend, could not altogether conceal his chagrin at the turn which
+affairs had taken, and was fain to indulge in a sarcasm or two, about
+the propriety of every person minding his own business.
+
+“Let him talk,” said Dupin, who had not thought it necessary to reply.
+“Let him discourse; it will ease his conscience, I am satisfied with
+having defeated him in his own castle. Nevertheless, that he failed
+in the solution of this mystery, is by no means that matter for wonder
+which he supposes it; for, in truth, our friend the Prefect is somewhat
+too cunning to be profound. In his wisdom is no _stamen._ It is all head
+and no body, like the pictures of the Goddess Laverna,--or, at best, all
+head and shoulders, like a codfish. But he is a good creature after all.
+I like him especially for one master stroke of cant, by which he has
+attained his reputation for ingenuity. I mean the way he has ‘_de nier
+ce qui est, et d’expliquer ce qui n’est pas._’” (*)
+
+(*) Rousseau--Nouvelle Heloise.
+
+
+
+
+THE MYSTERY OF MARIE ROGET.(*1)
+
+A SEQUEL TO “THE MURDERS IN THE RUE MORGUE.”
+
+
+  Es giebt eine Reihe idealischer Begebenheiten, die der Wirklichkeit
+  parallel lauft. Selten fallen sie zusammen. Menschen und zufalle
+  modifieiren gewohulich die idealische Begebenheit, so dass sie
+  unvollkommen erscheint, und ihre Folgen gleichfalls unvollkommen
+  sind. So bei der Reformation; statt des Protestantismus kam das
+  Lutherthum hervor.
+
+  There are ideal series of events which run parallel with the real
+  ones. They rarely coincide. Men and circumstances generally modify
+  the ideal train of events, so that it seems imperfect, and its
+  consequences are equally imperfect. Thus with the Reformation;
+  instead of Protestantism came Lutheranism.
+
+              --Novalis. (*2) Moral Ansichten.
+
+THERE are few persons, even among the calmest thinkers, who have not
+occasionally been startled into a vague yet thrilling half-credence in
+the supernatural, by coincidences of so seemingly marvellous a character
+that, as mere coincidences, the intellect has been unable to receive
+them. Such sentiments--for the half-credences of which I speak have
+never the full force of thought--such sentiments are seldom thoroughly
+stifled unless by reference to the doctrine of chance, or, as it is
+technically termed, the Calculus of Probabilities. Now this Calculus is,
+in its essence, purely mathematical; and thus we have the anomaly of the
+most rigidly exact in science applied to the shadow and spirituality of
+the most intangible in speculation.
+
+The extraordinary details which I am now called upon to make public,
+will be found to form, as regards sequence of time, the primary branch
+of a series of scarcely intelligible coincidences, whose secondary or
+concluding branch will be recognized by all readers in the late murder
+of Mary Cecila Rogers, at New York.
+
+When, in an article entitled “The Murders in the Rue Morgue,” I
+endeavored, about a year ago, to depict some very remarkable features
+in the mental character of my friend, the Chevalier C. Auguste Dupin,
+it did not occur to me that I should ever resume the subject. This
+depicting of character constituted my design; and this design was
+thoroughly fulfilled in the wild train of circumstances brought to
+instance Dupin’s idiosyncrasy. I might have adduced other examples, but
+I should have proven no more. Late events, however, in their surprising
+development, have startled me into some farther details, which will
+carry with them the air of extorted confession. Hearing what I have
+lately heard, it would be indeed strange should I remain silent in
+regard to what I both heard and saw so long ago.
+
+Upon the winding up of the tragedy involved in the deaths of Madame
+L’Espanaye and her daughter, the Chevalier dismissed the affair at once
+from his attention, and relapsed into his old habits of moody reverie.
+Prone, at all times, to abstraction, I readily fell in with his humor;
+and, continuing to occupy our chambers in the Faubourg Saint Germain, we
+gave the Future to the winds, and slumbered tranquilly in the Present,
+weaving the dull world around us into dreams.
+
+But these dreams were not altogether uninterrupted. It may readily be
+supposed that the part played by my friend, in the drama at the Rue
+Morgue, had not failed of its impression upon the fancies of the
+Parisian police. With its emissaries, the name of Dupin had grown into a
+household word. The simple character of those inductions by which he
+had disentangled the mystery never having been explained even to the
+Prefect, or to any other individual than myself, of course it is not
+surprising that the affair was regarded as little less than miraculous,
+or that the Chevalier’s analytical abilities acquired for him the
+credit of intuition. His frankness would have led him to disabuse every
+inquirer of such prejudice; but his indolent humor forbade all farther
+agitation of a topic whose interest to himself had long ceased. It thus
+happened that he found himself the cynosure of the political eyes; and
+the cases were not few in which attempt was made to engage his services
+at the Prefecture. One of the most remarkable instances was that of the
+murder of a young girl named Marie Rogêt.
+
+This event occurred about two years after the atrocity in the Rue
+Morgue. Marie, whose Christian and family name will at once arrest
+attention from their resemblance to those of the unfortunate
+“cigargirl,” was the only daughter of the widow Estelle Rogêt. The
+father had died during the child’s infancy, and from the period of his
+death, until within eighteen months before the assassination which forms
+the subject of our narrative, the mother and daughter had dwelt together
+in the Rue Pavée Saint Andrée; (*3) Madame there keeping a pension,
+assisted by Marie. Affairs went on thus until the latter had attained
+her twenty-second year, when her great beauty attracted the notice of a
+perfumer, who occupied one of the shops in the basement of the Palais
+Royal, and whose custom lay chiefly among the desperate adventurers
+infesting that neighborhood. Monsieur Le Blanc (*4) was not unaware of
+the advantages to be derived from the attendance of the fair Marie in
+his perfumery; and his liberal proposals were accepted eagerly by the
+girl, although with somewhat more of hesitation by Madame.
+
+The anticipations of the shopkeeper were realized, and his rooms soon
+became notorious through the charms of the sprightly grisette. She had
+been in his employ about a year, when her admirers were thrown info
+confusion by her sudden disappearance from the shop. Monsieur Le Blanc
+was unable to account for her absence, and Madame Rogêt was distracted
+with anxiety and terror. The public papers immediately took up
+the theme, and the police were upon the point of making serious
+investigations, when, one fine morning, after the lapse of a week,
+Marie, in good health, but with a somewhat saddened air, made her
+re-appearance at her usual counter in the perfumery. All inquiry, except
+that of a private character, was of course immediately hushed. Monsieur
+Le Blanc professed total ignorance, as before. Marie, with Madame,
+replied to all questions, that the last week had been spent at the
+house of a relation in the country. Thus the affair died away, and was
+generally forgotten; for the girl, ostensibly to relieve herself from
+the impertinence of curiosity, soon bade a final adieu to the perfumer,
+and sought the shelter of her mother’s residence in the Rue Pavée Saint
+Andrée.
+
+It was about five months after this return home, that her friends were
+alarmed by her sudden disappearance for the second time. Three days
+elapsed, and nothing was heard of her. On the fourth her corpse was
+found floating in the Seine, * near the shore which is opposite the
+Quartier of the Rue Saint Andree, and at a point not very far distant
+from the secluded neighborhood of the Barrière du Roule. (*6)
+
+The atrocity of this murder, (for it was at once evident that murder had
+been committed,) the youth and beauty of the victim, and, above all, her
+previous notoriety, conspired to produce intense excitement in the minds
+of the sensitive Parisians. I can call to mind no similar occurrence
+producing so general and so intense an effect. For several weeks, in
+the discussion of this one absorbing theme, even the momentous political
+topics of the day were forgotten. The Prefect made unusual exertions;
+and the powers of the whole Parisian police were, of course, tasked to
+the utmost extent.
+
+Upon the first discovery of the corpse, it was not supposed that the
+murderer would be able to elude, for more than a very brief period,
+the inquisition which was immediately set on foot. It was not until the
+expiration of a week that it was deemed necessary to offer a reward; and
+even then this reward was limited to a thousand francs. In the mean time
+the investigation proceeded with vigor, if not always with judgment, and
+numerous individuals were examined to no purpose; while, owing to the
+continual absence of all clue to the mystery, the popular excitement
+greatly increased. At the end of the tenth day it was thought advisable
+to double the sum originally proposed; and, at length, the second week
+having elapsed without leading to any discoveries, and the prejudice
+which always exists in Paris against the Police having given vent to
+itself in several serious émeutes, the Prefect took it upon himself
+to offer the sum of twenty thousand francs “for the conviction of the
+assassin,” or, if more than one should prove to have been implicated,
+“for the conviction of any one of the assassins.” In the proclamation
+setting forth this reward, a full pardon was promised to any accomplice
+who should come forward in evidence against his fellow; and to the whole
+was appended, wherever it appeared, the private placard of a committee
+of citizens, offering ten thousand francs, in addition to the amount
+proposed by the Prefecture. The entire reward thus stood at no less than
+thirty thousand francs, which will be regarded as an extraordinary
+sum when we consider the humble condition of the girl, and the great
+frequency, in large cities, of such atrocities as the one described.
+
+No one doubted now that the mystery of this murder would be immediately
+brought to light. But although, in one or two instances, arrests were
+made which promised elucidation, yet nothing was elicited which could
+implicate the parties suspected; and they were discharged forthwith.
+Strange as it may appear, the third week from the discovery of the body
+had passed, and passed without any light being thrown upon the subject,
+before even a rumor of the events which had so agitated the public
+mind, reached the ears of Dupin and myself. Engaged in researches which
+absorbed our whole attention, it had been nearly a month since either of
+us had gone abroad, or received a visiter, or more than glanced at
+the leading political articles in one of the daily papers. The first
+intelligence of the murder was brought us by G ----, in person. He
+called upon us early in the afternoon of the thirteenth of July, 18--,
+and remained with us until late in the night. He had been piqued by
+the failure of all his endeavors to ferret out the assassins. His
+reputation--so he said with a peculiarly Parisian air--was at stake.
+Even his honor was concerned. The eyes of the public were upon him; and
+there was really no sacrifice which he would not be willing to make for
+the development of the mystery. He concluded a somewhat droll speech
+with a compliment upon what he was pleased to term the tact of Dupin,
+and made him a direct, and certainly a liberal proposition, the precise
+nature of which I do not feel myself at liberty to disclose, but which
+has no bearing upon the proper subject of my narrative.
+
+The compliment my friend rebutted as best he could, but the proposition
+he accepted at once, although its advantages were altogether
+provisional. This point being settled, the Prefect broke forth at
+once into explanations of his own views, interspersing them with
+long comments upon the evidence; of which latter we were not yet in
+possession. He discoursed much, and beyond doubt, learnedly; while
+I hazarded an occasional suggestion as the night wore drowsily away.
+Dupin, sitting steadily in his accustomed arm-chair, was the embodiment
+of respectful attention. He wore spectacles, during the whole interview;
+and an occasional signal glance beneath their green glasses, sufficed
+to convince me that he slept not the less soundly, because silently,
+throughout the seven or eight leaden-footed hours which immediately
+preceded the departure of the Prefect.
+
+In the morning, I procured, at the Prefecture, a full report of all
+the evidence elicited, and, at the various newspaper offices, a copy
+of every paper in which, from first to last, had been published any
+decisive information in regard to this sad affair. Freed from all that
+was positively disproved, this mass of information stood thus:
+
+Marie Rogêt left the residence of her mother, in the Rue Pavée
+St. Andrée, about nine o’clock in the morning of Sunday June the
+twenty-second, 18--. In going out, she gave notice to a Monsieur Jacques
+St. Eustache, (*7) and to him only, of her intent intention to spend the
+day with an aunt who resided in the Rue des Drômes. The Rue des Drômes
+is a short and narrow but populous thoroughfare, not far from the banks
+of the river, and at a distance of some two miles, in the most direct
+course possible, from the pension of Madame Rogêt. St. Eustache was the
+accepted suitor of Marie, and lodged, as well as took his meals, at
+the pension. He was to have gone for his betrothed at dusk, and to
+have escorted her home. In the afternoon, however, it came on to rain
+heavily; and, supposing that she would remain all night at her aunt’s,
+(as she had done under similar circumstances before,) he did not think
+it necessary to keep his promise. As night drew on, Madame Rogêt (who
+was an infirm old lady, seventy years of age,) was heard to express
+a fear “that she should never see Marie again;” but this observation
+attracted little attention at the time.
+
+On Monday, it was ascertained that the girl had not been to the Rue des
+Drômes; and when the day elapsed without tidings of her, a tardy search
+was instituted at several points in the city, and its environs. It was
+not, however until the fourth day from the period of disappearance that
+any thing satisfactory was ascertained respecting her. On this day,
+(Wednesday, the twenty-fifth of June,) a Monsieur Beauvais, (*8) who,
+with a friend, had been making inquiries for Marie near the Barrière
+du Roule, on the shore of the Seine which is opposite the Rue Pavée St.
+Andrée, was informed that a corpse had just been towed ashore by some
+fishermen, who had found it floating in the river. Upon seeing the
+body, Beauvais, after some hesitation, identified it as that of the
+perfumery-girl. His friend recognized it more promptly.
+
+The face was suffused with dark blood, some of which issued from the
+mouth. No foam was seen, as in the case of the merely drowned. There was
+no discoloration in the cellular tissue. About the throat were bruises
+and impressions of fingers. The arms were bent over on the chest and
+were rigid. The right hand was clenched; the left partially open. On
+the left wrist were two circular excoriations, apparently the effect
+of ropes, or of a rope in more than one volution. A part of the right
+wrist, also, was much chafed, as well as the back throughout its extent,
+but more especially at the shoulder-blades. In bringing the body to
+the shore the fishermen had attached to it a rope; but none of the
+excoriations had been effected by this. The flesh of the neck was much
+swollen. There were no cuts apparent, or bruises which appeared the
+effect of blows. A piece of lace was found tied so tightly around the
+neck as to be hidden from sight; it was completely buried in the flesh,
+and was fasted by a knot which lay just under the left ear. This alone
+would have sufficed to produce death. The medical testimony spoke
+confidently of the virtuous character of the deceased. She had been
+subjected, it said, to brutal violence. The corpse was in such condition
+when found, that there could have been no difficulty in its recognition
+by friends.
+
+The dress was much torn and otherwise disordered. In the outer garment,
+a slip, about a foot wide, had been torn upward from the bottom hem to
+the waist, but not torn off. It was wound three times around the waist,
+and secured by a sort of hitch in the back. The dress immediately
+beneath the frock was of fine muslin; and from this a slip eighteen
+inches wide had been torn entirely out--torn very evenly and with great
+care. It was found around her neck, fitting loosely, and secured with a
+hard knot. Over this muslin slip and the slip of lace, the strings of a
+bonnet were attached; the bonnet being appended. The knot by which the
+strings of the bonnet were fastened, was not a lady’s, but a slip or
+sailor’s knot.
+
+After the recognition of the corpse, it was not, as usual, taken to the
+Morgue, (this formality being superfluous,) but hastily interred not far
+from the spot at which it was brought ashore. Through the exertions of
+Beauvais, the matter was industriously hushed up, as far as possible;
+and several days had elapsed before any public emotion resulted. A
+weekly paper, (*9) however, at length took up the theme; the corpse was
+disinterred, and a re-examination instituted; but nothing was elicited
+beyond what has been already noted. The clothes, however, were
+now submitted to the mother and friends of the deceased, and fully
+identified as those worn by the girl upon leaving home.
+
+Meantime, the excitement increased hourly. Several individuals were
+arrested and discharged. St. Eustache fell especially under suspicion;
+and he failed, at first, to give an intelligible account of his
+whereabouts during the Sunday on which Marie left home. Subsequently,
+however, he submitted to Monsieur G----, affidavits, accounting
+satisfactorily for every hour of the day in question. As time passed and
+no discovery ensued, a thousand contradictory rumors were circulated,
+and journalists busied themselves in suggestions. Among these, the one
+which attracted the most notice, was the idea that Marie Rogêt still
+lived--that the corpse found in the Seine was that of some other
+unfortunate. It will be proper that I submit to the reader some passages
+which embody the suggestion alluded to. These passages are literal
+translations from L’Etoile, (*10) a paper conducted, in general, with
+much ability.
+
+“Mademoiselle Rogêt left her mother’s house on Sunday morning, June the
+twenty-second, 18--, with the ostensible purpose of going to see her
+aunt, or some other connexion, in the Rue des Drômes. From that hour,
+nobody is proved to have seen her. There is no trace or tidings of her
+at all.... There has no person, whatever, come forward, so far, who
+saw her at all, on that day, after she left her mother’s door.... Now,
+though we have no evidence that Marie Rogêt was in the land of the
+living after nine o’clock on Sunday, June the twenty-second, we have
+proof that, up to that hour, she was alive. On Wednesday noon, at
+twelve, a female body was discovered afloat on the shore of the Barrière
+de Roule. This was, even if we presume that Marie Rogêt was thrown into
+the river within three hours after she left her mother’s house, only
+three days from the time she left her home--three days to an hour. But
+it is folly to suppose that the murder, if murder was committed on
+her body, could have been consummated soon enough to have enabled her
+murderers to throw the body into the river before midnight. Those who
+are guilty of such horrid crimes, choose darkness rather the light....
+Thus we see that if the body found in the river was that of Marie Rogêt,
+it could only have been in the water two and a half days, or three at
+the outside. All experience has shown that drowned bodies, or bodies
+thrown into the water immediately after death by violence, require from
+six to ten days for decomposition to take place to bring them to the top
+of the water. Even where a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again, if let
+alone. Now, we ask, what was there in this cave to cause a departure
+from the ordinary course of nature?... If the body had been kept in its
+mangled state on shore until Tuesday night, some trace would be found on
+shore of the murderers. It is a doubtful point, also, whether the body
+would be so soon afloat, even were it thrown in after having been
+dead two days. And, furthermore, it is exceedingly improbable that any
+villains who had committed such a murder as is here supposed, would
+have thrown the body in without weight to sink it, when such a precaution
+could have so easily been taken.”
+
+The editor here proceeds to argue that the body must have been in the
+water “not three days merely, but, at least, five times three days,”
+ because it was so far decomposed that Beauvais had great difficulty
+in recognizing it. This latter point, however, was fully disproved. I
+continue the translation:
+
+“What, then, are the facts on which M. Beauvais says that he has no
+doubt the body was that of Marie Rogêt? He ripped up the gown sleeve,
+and says he found marks which satisfied him of the identity. The public
+generally supposed those marks to have consisted of some description
+of scars. He rubbed the arm and found hair upon it--something as
+indefinite, we think, as can readily be imagined--as little conclusive
+as finding an arm in the sleeve. M. Beauvais did not return that night,
+but sent word to Madame Rogêt, at seven o’clock, on Wednesday evening,
+that an investigation was still in progress respecting her daughter. If
+we allow that Madame Rogêt, from her age and grief, could not go over,
+(which is allowing a great deal,) there certainly must have been some
+one who would have thought it worth while to go over and attend the
+investigation, if they thought the body was that of Marie. Nobody went
+over. There was nothing said or heard about the matter in the Rue Pavée
+St. Andrée, that reached even the occupants of the same building. M. St.
+Eustache, the lover and intended husband of Marie, who boarded in her
+mother’s house, deposes that he did not hear of the discovery of the
+body of his intended until the next morning, when M. Beauvais came
+into his chamber and told him of it. For an item of news like this, it
+strikes us it was very coolly received.”
+
+In this way the journal endeavored to create the impression of an apathy
+on the part of the relatives of Marie, inconsistent with the supposition
+that these relatives believed the corpse to be hers. Its insinuations
+amount to this:--that Marie, with the connivance of her friends, had
+absented herself from the city for reasons involving a charge against
+her chastity; and that these friends, upon the discovery of a corpse in
+the Seine, somewhat resembling that of the girl, had availed themselves
+of the opportunity to impress the public with the belief of her
+death. But L’Etoile was again over-hasty. It was distinctly proved
+that no apathy, such as was imagined, existed; that the old lady was
+exceedingly feeble, and so agitated as to be unable to attend to any
+duty, that St. Eustache, so far from receiving the news coolly, was
+distracted with grief, and bore himself so frantically, that M. Beauvais
+prevailed upon a friend and relative to take charge of him, and prevent
+his attending the examination at the disinterment. Moreover, although
+it was stated by L’Etoile, that the corpse was re-interred at the public
+expense--that an advantageous offer of private sculpture was absolutely
+declined by the family--and that no member of the family attended the
+ceremonial:--although, I say, all this was asserted by L’Etoile in
+furtherance of the impression it designed to convey--yet all this
+was satisfactorily disproved. In a subsequent number of the paper, an
+attempt was made to throw suspicion upon Beauvais himself. The editor
+says:
+
+“Now, then, a change comes over the matter. We are told that on one
+occasion, while a Madame B---- was at Madame Rogêt’s house, M. Beauvais,
+who was going out, told her that a gendarme was expected there, and she,
+Madame B., must not say anything to the gendarme until he returned,
+but let the matter be for him.... In the present posture of affairs,
+M. Beauvais appears to have the whole matter locked up in his head. A
+single step cannot be taken without M. Beauvais; for, go which way you
+will, you run against him.... For some reason, he determined that nobody
+shall have any thing to do with the proceedings but himself, and he
+has elbowed the male relatives out of the way, according to their
+representations, in a very singular manner. He seems to have been very
+much averse to permitting the relatives to see the body.”
+
+By the following fact, some color was given to the suspicion thus thrown
+upon Beauvais. A visiter at his office, a few days prior to the girl’s
+disappearance, and during the absence of its occupant, had observed a
+rose in the key-hole of the door, and the name “Marie” inscribed upon a
+slate which hung near at hand.
+
+The general impression, so far as we were enabled to glean it from the
+newspapers, seemed to be, that Marie had been the victim of a gang
+of desperadoes--that by these she had been borne across the river,
+maltreated and murdered. Le Commerciel, (*11) however, a print of
+extensive influence, was earnest in combating this popular idea. I quote
+a passage or two from its columns:
+
+“We are persuaded that pursuit has hitherto been on a false scent, so
+far as it has been directed to the Barrière du Roule. It is impossible
+that a person so well known to thousands as this young woman was, should
+have passed three blocks without some one having seen her; and any one
+who saw her would have remembered it, for she interested all who knew
+her. It was when the streets were full of people, when she went out....
+It is impossible that she could have gone to the Barrière du Roule, or
+to the Rue des Drômes, without being recognized by a dozen persons; yet
+no one has come forward who saw her outside of her mother’s door, and
+there is no evidence, except the testimony concerning her expressed
+intentions, that she did go out at all. Her gown was torn, bound round
+her, and tied; and by that the body was carried as a bundle. If the
+murder had been committed at the Barrière du Roule, there would have
+been no necessity for any such arrangement. The fact that the body was
+found floating near the Barrière, is no proof as to where it was thrown
+into the water..... A piece of one of the unfortunate girl’s petticoats,
+two feet long and one foot wide, was torn out and tied under her chin
+around the back of her head, probably to prevent screams. This was done
+by fellows who had no pocket-handkerchief.”
+
+A day or two before the Prefect called upon us, however, some important
+information reached the police, which seemed to overthrow, at least,
+the chief portion of Le Commerciel’s argument. Two small boys, sons of a
+Madame Deluc, while roaming among the woods near the Barrière du Roule,
+chanced to penetrate a close thicket, within which were three or four
+large stones, forming a kind of seat, with a back and footstool. On
+the upper stone lay a white petticoat; on the second a silk scarf. A
+parasol, gloves, and a pocket-handkerchief were also here found. The
+handkerchief bore the name “Marie Rogêt.” Fragments of dress were
+discovered on the brambles around. The earth was trampled, the bushes
+were broken, and there was every evidence of a struggle. Between the
+thicket and the river, the fences were found taken down, and the ground
+bore evidence of some heavy burthen having been dragged along it.
+
+A weekly paper, Le Soleil,(*12) had the following comments upon this
+discovery--comments which merely echoed the sentiment of the whole
+Parisian press:
+
+“The things had all evidently been there at least three or four weeks;
+they were all mildewed down hard with the action of the rain and stuck
+together from mildew. The grass had grown around and over some of them.
+The silk on the parasol was strong, but the threads of it were run
+together within. The upper part, where it had been doubled and folded,
+was all mildewed and rotten, and tore on its being opened..... The
+pieces of her frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock, and it had been
+mended; the other piece was part of the skirt, not the hem. They looked
+like strips torn off, and were on the thorn bush, about a foot from
+the ground..... There can be no doubt, therefore, that the spot of this
+appalling outrage has been discovered.”
+
+Consequent upon this discovery, new evidence appeared. Madame Deluc
+testified that she keeps a roadside inn not far from the bank of the
+river, opposite the Barrière du Roule. The neighborhood is
+secluded--particularly so. It is the usual Sunday resort of blackguards
+from the city, who cross the river in boats. About three o’clock, in the
+afternoon of the Sunday in question, a young girl arrived at the inn,
+accompanied by a young man of dark complexion. The two remained here for
+some time. On their departure, they took the road to some thick woods in
+the vicinity. Madame Deluc’s attention was called to the dress worn by
+the girl, on account of its resemblance to one worn by a deceased
+relative. A scarf was particularly noticed. Soon after the departure of
+the couple, a gang of miscreants made their appearance, behaved
+boisterously, ate and drank without making payment, followed in the
+route of the young man and girl, returned to the inn about dusk, and
+re-crossed the river as if in great haste.
+
+It was soon after dark, upon this same evening, that Madame Deluc, as
+well as her eldest son, heard the screams of a female in the vicinity
+of the inn. The screams were violent but brief. Madame D. recognized not
+only the scarf which was found in the thicket, but the dress which was
+discovered upon the corpse. An omnibus driver, Valence, (*13) now also
+testified that he saw Marie Rogêt cross a ferry on the Seine, on the
+Sunday in question, in company with a young man of dark complexion.
+He, Valence, knew Marie, and could not be mistaken in her identity. The
+articles found in the thicket were fully identified by the relatives of
+Marie.
+
+The items of evidence and information thus collected by myself, from
+the newspapers, at the suggestion of Dupin, embraced only one more
+point--but this was a point of seemingly vast consequence. It appears
+that, immediately after the discovery of the clothes as above described,
+the lifeless, or nearly lifeless body of St. Eustache, Marie’s
+betrothed, was found in the vicinity of what all now supposed the scene
+of the outrage. A phial labelled “laudanum,” and emptied, was found near
+him. His breath gave evidence of the poison. He died without speaking.
+Upon his person was found a letter, briefly stating his love for Marie,
+with his design of self-destruction.
+
+“I need scarcely tell you,” said Dupin, as he finished the perusal of
+my notes, “that this is a far more intricate case than that of the
+Rue Morgue; from which it differs in one important respect. This is
+an ordinary, although an atrocious instance of crime. There is nothing
+peculiarly outré about it. You will observe that, for this reason, the
+mystery has been considered easy, when, for this reason, it should have
+been considered difficult, of solution. Thus; at first, it was thought
+unnecessary to offer a reward. The myrmidons of G---- were able at once
+to comprehend how and why such an atrocity might have been committed.
+They could picture to their imaginations a mode--many modes--and a
+motive--many motives; and because it was not impossible that either of
+these numerous modes and motives could have been the actual one, they
+have taken it for granted that one of them must. But the case with which
+these variable fancies were entertained, and the very plausibility which
+each assumed, should have been understood as indicative rather of the
+difficulties than of the facilities which must attend elucidation. I
+have before observed that it is by prominences above the plane of the
+ordinary, that reason feels her way, if at all, in her search for the
+true, and that the proper question in cases such as this, is not so
+much ‘what has occurred?’ as ‘what has occurred that has never occurred
+before?’ In the investigations at the house of Madame L’Espanaye,
+(*14) the agents of G---- were discouraged and confounded by that
+very unusualness which, to a properly regulated intellect, would have
+afforded the surest omen of success; while this same intellect might
+have been plunged in despair at the ordinary character of all that met
+the eye in the case of the perfumery-girl, and yet told of nothing but
+easy triumph to the functionaries of the Prefecture.
+
+“In the case of Madame L’Espanaye and her daughter there was, even
+at the beginning of our investigation, no doubt that murder had been
+committed. The idea of suicide was excluded at once. Here, too, we are
+freed, at the commencement, from all supposition of self-murder. The
+body found at the Barrière du Roule, was found under such circumstances
+as to leave us no room for embarrassment upon this important point. But
+it has been suggested that the corpse discovered, is not that of the
+Marie Rogêt for the conviction of whose assassin, or assassins, the
+reward is offered, and respecting whom, solely, our agreement has been
+arranged with the Prefect. We both know this gentleman well. It will not
+do to trust him too far. If, dating our inquiries from the body found,
+and thence tracing a murderer, we yet discover this body to be that of
+some other individual than Marie; or, if starting from the living Marie,
+we find her, yet find her unassassinated--in either case we lose our
+labor; since it is Monsieur G---- with whom we have to deal. For our
+own purpose, therefore, if not for the purpose of justice, it is
+indispensable that our first step should be the determination of the
+identity of the corpse with the Marie Rogêt who is missing.
+
+“With the public the arguments of L’Etoile have had weight; and that the
+journal itself is convinced of their importance would appear from
+the manner in which it commences one of its essays upon the
+subject--‘Several of the morning papers of the day,’ it says, ‘speak of
+the _conclusive_ article in Monday’s Etoile.’ To me, this article
+appears conclusive of little beyond the zeal of its inditer. We should
+bear in mind that, in general, it is the object of our newspapers rather
+to create a sensation--to make a point--than to further the cause of
+truth. The latter end is only pursued when it seems coincident with the
+former. The print which merely falls in with ordinary opinion (however
+well founded this opinion may be) earns for itself no credit with the
+mob. The mass of the people regard as profound only him who suggests
+_pungent contradictions_ of the general idea. In ratiocination, not less
+than in literature, it is the epigram which is the most immediately and
+the most universally appreciated. In both, it is of the lowest order of
+merit.
+
+“What I mean to say is, that it is the mingled epigram and melodrame
+of the idea, that Marie Rogêt still lives, rather than any true
+plausibility in this idea, which have suggested it to L’Etoile, and
+secured it a favorable reception with the public. Let us examine the
+heads of this journal’s argument; endeavoring to avoid the incoherence
+with which it is originally set forth.
+
+“The first aim of the writer is to show, from the brevity of the
+interval between Marie’s disappearance and the finding of the floating
+corpse, that this corpse cannot be that of Marie. The reduction of this
+interval to its smallest possible dimension, becomes thus, at once, an
+object with the reasoner. In the rash pursuit of this object, he rushes
+into mere assumption at the outset. ‘It is folly to suppose,’ he says,
+‘that the murder, if murder was committed on her body, could have been
+consummated soon enough to have enabled her murderers to throw the body
+into the river before midnight.’ We demand at once, and very naturally,
+why? Why is it folly to suppose that the murder was committed _within
+five minutes_ after the girl’s quitting her mother’s house? Why is it
+folly to suppose that the murder was committed at any given period
+of the day? There have been assassinations at all hours. But, had the
+murder taken place at any moment between nine o’clock in the morning of
+Sunday, and a quarter before midnight, there would still have been
+time enough ‘to throw the body into the river before midnight.’ This
+assumption, then, amounts precisely to this--that the murder was not
+committed on Sunday at all--and, if we allow L’Etoile to assume this,
+we may permit it any liberties whatever. The paragraph beginning ‘It is
+folly to suppose that the murder, etc.,’ however it appears as printed
+in L’Etoile, may be imagined to have existed actually thus in the brain
+of its inditer--‘It is folly to suppose that the murder, if murder was
+committed on the body, could have been committed soon enough to have
+enabled her murderers to throw the body into the river before midnight;
+it is folly, we say, to suppose all this, and to suppose at the same
+time, (as we are resolved to suppose,) that the body was not thrown
+in until after midnight’--a sentence sufficiently inconsequential in
+itself, but not so utterly preposterous as the one printed.
+
+“Were it my purpose,” continued Dupin, “merely to _make out a case_
+against this passage of L’Etoile’s argument, I might safely leave it
+where it is. It is not, however, with L’Etoile that we have to do, but
+with the truth. The sentence in question has but one meaning, as it
+stands; and this meaning I have fairly stated: but it is material
+that we go behind the mere words, for an idea which these words have
+obviously intended, and failed to convey. It was the design of the
+journalist to say that, at whatever period of the day or night of Sunday
+this murder was committed, it was improbable that the assassins would
+have ventured to bear the corpse to the river before midnight. And
+herein lies, really, the assumption of which I complain. It is assumed
+that the murder was committed at such a position, and under such
+circumstances, that the bearing it to the river became necessary. Now,
+the assassination might have taken place upon the river’s brink, or on
+the river itself; and, thus, the throwing the corpse in the water might
+have been resorted to, at any period of the day or night, as the most
+obvious and most immediate mode of disposal. You will understand that I
+suggest nothing here as probable, or as cöincident with my own opinion.
+My design, so far, has no reference to the facts of the case. I wish
+merely to caution you against the whole tone of L’Etoile’s suggestion,
+by calling your attention to its ex parte character at the outset.
+
+“Having prescribed thus a limit to suit its own preconceived notions;
+having assumed that, if this were the body of Marie, it could have been
+in the water but a very brief time; the journal goes on to say:
+
+‘All experience has shown that drowned bodies, or bodies thrown into the
+water immediately after death by violence, require from six to ten days
+for sufficient decomposition to take place to bring them to the top
+of the water. Even when a cannon is fired over a corpse, and it rises
+before at least five or six days’ immersion, it sinks again if let
+alone.’
+
+“These assertions have been tacitly received by every paper in Paris,
+with the exception of Le Moniteur. (*15) This latter print endeavors
+to combat that portion of the paragraph which has reference to ‘drowned
+bodies’ only, by citing some five or six instances in which the bodies
+of individuals known to be drowned were found floating after the lapse
+of less time than is insisted upon by L’Etoile. But there is something
+excessively unphilosophical in the attempt on the part of Le Moniteur,
+to rebut the general assertion of L’Etoile, by a citation of particular
+instances militating against that assertion. Had it been possible to
+adduce fifty instead of five examples of bodies found floating at the
+end of two or three days, these fifty examples could still have been
+properly regarded only as exceptions to L’Etoile’s rule, until such time
+as the rule itself should be confuted. Admitting the rule, (and this
+Le Moniteur does not deny, insisting merely upon its exceptions,) the
+argument of L’Etoile is suffered to remain in full force; for this
+argument does not pretend to involve more than a question of the
+probability of the body having risen to the surface in less than three
+days; and this probability will be in favor of L’Etoile’s position until
+the instances so childishly adduced shall be sufficient in number to
+establish an antagonistical rule.
+
+“You will see at once that all argument upon this head should be urged,
+if at all, against the rule itself; and for this end we must examine the
+rationale of the rule. Now the human body, in general, is neither much
+lighter nor much heavier than the water of the Seine; that is to say,
+the specific gravity of the human body, in its natural condition, is
+about equal to the bulk of fresh water which it displaces. The bodies
+of fat and fleshy persons, with small bones, and of women generally,
+are lighter than those of the lean and large-boned, and of men; and the
+specific gravity of the water of a river is somewhat influenced by the
+presence of the tide from sea. But, leaving this tide out of question,
+it may be said that very few human bodies will sink at all, even in
+fresh water, of their own accord. Almost any one, falling into a river,
+will be enabled to float, if he suffer the specific gravity of the water
+fairly to be adduced in comparison with his own--that is to say, if
+he suffer his whole person to be immersed, with as little exception as
+possible. The proper position for one who cannot swim, is the upright
+position of the walker on land, with the head thrown fully back, and
+immersed; the mouth and nostrils alone remaining above the surface.
+Thus circumstanced, we shall find that we float without difficulty and
+without exertion. It is evident, however, that the gravities of the
+body, and of the bulk of water displaced, are very nicely balanced, and
+that a trifle will cause either to preponderate. An arm, for instance,
+uplifted from the water, and thus deprived of its support, is an
+additional weight sufficient to immerse the whole head, while the
+accidental aid of the smallest piece of timber will enable us to elevate
+the head so as to look about. Now, in the struggles of one unused to
+swimming, the arms are invariably thrown upwards, while an attempt is
+made to keep the head in its usual perpendicular position. The result
+is the immersion of the mouth and nostrils, and the inception, during
+efforts to breathe while beneath the surface, of water into the lungs.
+Much is also received into the stomach, and the whole body becomes
+heavier by the difference between the weight of the air originally
+distending these cavities, and that of the fluid which now fills them.
+This difference is sufficient to cause the body to sink, as a general
+rule; but is insufficient in the cases of individuals with small bones
+and an abnormal quantity of flaccid or fatty matter. Such individuals
+float even after drowning.
+
+“The corpse, being supposed at the bottom of the river, will there
+remain until, by some means, its specific gravity again becomes less
+than that of the bulk of water which it displaces. This effect
+is brought about by decomposition, or otherwise. The result of
+decomposition is the generation of gas, distending the cellular tissues
+and all the cavities, and giving the puffed appearance which is so
+horrible. When this distension has so far progressed that the bulk of
+the corpse is materially increased without a corresponding increase of
+mass or weight, its specific gravity becomes less than that of the water
+displaced, and it forthwith makes its appearance at the surface. But
+decomposition is modified by innumerable circumstances--is hastened or
+retarded by innumerable agencies; for example, by the heat or cold of
+the season, by the mineral impregnation or purity of the water, by its
+depth or shallowness, by its currency or stagnation, by the temperament
+of the body, by its infection or freedom from disease before death.
+Thus it is evident that we can assign no period, with any thing like
+accuracy, at which the corpse shall rise through decomposition. Under
+certain conditions this result would be brought about within an hour;
+under others, it might not take place at all. There are chemical
+infusions by which the animal frame can be preserved forever from
+corruption; the Bi-chloride of Mercury is one. But, apart from
+decomposition, there may be, and very usually is, a generation of gas
+within the stomach, from the acetous fermentation of vegetable matter
+(or within other cavities from other causes) sufficient to induce a
+distension which will bring the body to the surface. The effect produced
+by the firing of a cannon is that of simple vibration. This may either
+loosen the corpse from the soft mud or ooze in which it is imbedded,
+thus permitting it to rise when other agencies have already prepared
+it for so doing; or it may overcome the tenacity of some putrescent
+portions of the cellular tissue; allowing the cavities to distend under
+the influence of the gas.
+
+“Having thus before us the whole philosophy of this subject, we can
+easily test by it the assertions of L’Etoile. ‘All experience shows,’
+says this paper, ‘that drowned bodies, or bodies thrown into the water
+immediately after death by violence, require from six to ten days for
+sufficient decomposition to take place to bring them to the top of the
+water. Even when a cannon is fired over a corpse, and it rises before at
+least five or six days’ immersion, it sinks again if let alone.’
+
+“The whole of this paragraph must now appear a tissue of inconsequence
+and incoherence. All experience does not show that ‘drowned bodies’
+require from six to ten days for sufficient decomposition to take place
+to bring them to the surface. Both science and experience show that the
+period of their rising is, and necessarily must be, indeterminate. If,
+moreover, a body has risen to the surface through firing of cannon,
+it will not ‘sink again if let alone,’ until decomposition has so far
+progressed as to permit the escape of the generated gas. But I wish to
+call your attention to the distinction which is made between ‘drowned
+bodies,’ and ‘bodies thrown into the water immediately after death by
+violence.’ Although the writer admits the distinction, he yet includes
+them all in the same category. I have shown how it is that the body of
+a drowning man becomes specifically heavier than its bulk of water,
+and that he would not sink at all, except for the struggles by which
+he elevates his arms above the surface, and his gasps for breath while
+beneath the surface--gasps which supply by water the place of the
+original air in the lungs. But these struggles and these gasps would
+not occur in the body ‘thrown into the water immediately after death by
+violence.’ Thus, in the latter instance, the body, as a general rule,
+would not sink at all--a fact of which L’Etoile is evidently ignorant.
+When decomposition had proceeded to a very great extent--when the flesh
+had in a great measure left the bones--then, indeed, but not till then,
+should we lose sight of the corpse.
+
+“And now what are we to make of the argument, that the body found could
+not be that of Marie Rogêt, because, three days only having elapsed,
+this body was found floating? If drowned, being a woman, she might never
+have sunk; or having sunk, might have reappeared in twenty-four hours,
+or less. But no one supposes her to have been drowned; and, dying before
+being thrown into the river, she might have been found floating at any
+period afterwards whatever.
+
+“‘But,’ says L’Etoile, ‘if the body had been kept in its mangled state
+on shore until Tuesday night, some trace would be found on shore of the
+murderers.’ Here it is at first difficult to perceive the intention
+of the reasoner. He means to anticipate what he imagines would be an
+objection to his theory--viz: that the body was kept on shore two days,
+suffering rapid decomposition--more rapid than if immersed in water. He
+supposes that, had this been the case, it might have appeared at the
+surface on the Wednesday, and thinks that only under such circumstances
+it could so have appeared. He is accordingly in haste to show that it
+was not kept on shore; for, if so, ‘some trace would be found on shore
+of the murderers.’ I presume you smile at the sequitur. You cannot
+be made to see how the mere duration of the corpse on the shore could
+operate to multiply traces of the assassins. Nor can I.
+
+“‘And furthermore it is exceedingly improbable,’ continues our journal,
+‘that any villains who had committed such a murder as is here supposed,
+would have thrown the body in without weight to sink it, when such
+a precaution could have so easily been taken.’ Observe, here, the
+laughable confusion of thought! No one--not even L’Etoile--disputes
+the murder committed _on the body found_. The marks of violence are too
+obvious. It is our reasoner’s object merely to show that this body is
+not Marie’s. He wishes to prove that Marie is not assassinated--not that
+the corpse was not. Yet his observation proves only the latter point.
+Here is a corpse without weight attached. Murderers, casting it in,
+would not have failed to attach a weight. Therefore it was not thrown in
+by murderers. This is all which is proved, if any thing is. The question
+of identity is not even approached, and L’Etoile has been at great pains
+merely to gainsay now what it has admitted only a moment before. ‘We
+are perfectly convinced,’ it says, ‘that the body found was that of a
+murdered female.’
+
+“Nor is this the sole instance, even in this division of his subject,
+where our reasoner unwittingly reasons against himself. His evident
+object, I have already said, is to reduce, as much as possible, the
+interval between Marie’s disappearance and the finding of the corpse.
+Yet we find him urging the point that no person saw the girl from the
+moment of her leaving her mother’s house. ‘We have no evidence,’ he
+says, ‘that Marie Rogêt was in the land of the living after nine o’clock
+on Sunday, June the twenty-second.’ As his argument is obviously an ex
+parte one, he should, at least, have left this matter out of sight; for
+had any one been known to see Marie, say on Monday, or on Tuesday,
+the interval in question would have been much reduced, and, by his own
+ratiocination, the probability much diminished of the corpse being that
+of the grisette. It is, nevertheless, amusing to observe that L’Etoile
+insists upon its point in the full belief of its furthering its general
+argument.
+
+“Reperuse now that portion of this argument which has reference to the
+identification of the corpse by Beauvais. In regard to the hair upon the
+arm, L’Etoile has been obviously disingenuous. M. Beauvais, not being an
+idiot, could never have urged, in identification of the corpse, simply
+hair upon its arm. No arm is without hair. The generality of the
+expression of L’Etoile is a mere perversion of the witness’ phraseology.
+He must have spoken of some peculiarity in this hair. It must have been
+a peculiarity of color, of quantity, of length, or of situation.
+
+“‘Her foot,’ says the journal, ‘was small--so are thousands of feet. Her
+garter is no proof whatever--nor is her shoe--for shoes and garters are
+sold in packages. The same may be said of the flowers in her hat. One
+thing upon which M. Beauvais strongly insists is, that the clasp on the
+garter found, had been set back to take it in. This amounts to nothing;
+for most women find it proper to take a pair of garters home and fit
+them to the size of the limbs they are to encircle, rather than to try
+them in the store where they purchase.’ Here it is difficult to suppose
+the reasoner in earnest. Had M. Beauvais, in his search for the body of
+Marie, discovered a corpse corresponding in general size and appearance
+to the missing girl, he would have been warranted (without reference to
+the question of habiliment at all) in forming an opinion that his search
+had been successful. If, in addition to the point of general size and
+contour, he had found upon the arm a peculiar hairy appearance which he
+had observed upon the living Marie, his opinion might have been justly
+strengthened; and the increase of positiveness might well have been in
+the ratio of the peculiarity, or unusualness, of the hairy mark. If,
+the feet of Marie being small, those of the corpse were also small, the
+increase of probability that the body was that of Marie would not be an
+increase in a ratio merely arithmetical, but in one highly geometrical,
+or accumulative. Add to all this shoes such as she had been known to
+wear upon the day of her disappearance, and, although these shoes may be
+‘sold in packages,’ you so far augment the probability as to verge upon
+the certain. What, of itself, would be no evidence of identity, becomes
+through its corroborative position, proof most sure. Give us, then,
+flowers in the hat corresponding to those worn by the missing girl, and
+we seek for nothing farther. If only one flower, we seek for nothing
+farther--what then if two or three, or more? Each successive one
+is multiple evidence--proof not _added_ to proof, but multiplied by
+hundreds or thousands. Let us now discover, upon the deceased, garters
+such as the living used, and it is almost folly to proceed. But these
+garters are found to be tightened, by the setting back of a clasp,
+in just such a manner as her own had been tightened by Marie, shortly
+previous to her leaving home. It is now madness or hypocrisy to doubt.
+What L’Etoile says in respect to this abbreviation of the garter’s being
+an usual occurrence, shows nothing beyond its own pertinacity in error.
+The elastic nature of the clasp-garter is self-demonstration of the
+unusualness of the abbreviation. What is made to adjust itself, must of
+necessity require foreign adjustment but rarely. It must have been by an
+accident, in its strictest sense, that these garters of Marie needed
+the tightening described. They alone would have amply established her
+identity. But it is not that the corpse was found to have the garters
+of the missing girl, or found to have her shoes, or her bonnet, or the
+flowers of her bonnet, or her feet, or a peculiar mark upon the arm,
+or her general size and appearance--it is that the corpse had each,
+and _all collectively_. Could it be proved that the editor of L’Etoile
+_really_ entertained a doubt, under the circumstances, there would be
+no need, in his case, of a commission de lunatico inquirendo. He has
+thought it sagacious to echo the small talk of the lawyers, who, for the
+most part, content themselves with echoing the rectangular precepts of
+the courts. I would here observe that very much of what is rejected as
+evidence by a court, is the best of evidence to the intellect. For
+the court, guiding itself by the general principles of evidence--the
+recognized and _booked_ principles--is averse from swerving at
+particular instances. And this steadfast adherence to principle, with
+rigorous disregard of the conflicting exception, is a sure mode of
+attaining the maximum of attainable truth, in any long sequence of time.
+The practice, in mass, is therefore philosophical; but it is not the
+less certain that it engenders vast individual error. (*16)
+
+“In respect to the insinuations levelled at Beauvais, you will be
+willing to dismiss them in a breath. You have already fathomed the
+true character of this good gentleman. He is a busy-body, with much
+of romance and little of wit. Any one so constituted will readily so
+conduct himself, upon occasion of real excitement, as to render himself
+liable to suspicion on the part of the over acute, or the ill-disposed.
+M. Beauvais (as it appears from your notes) had some personal interviews
+with the editor of L’Etoile, and offended him by venturing an opinion
+that the corpse, notwithstanding the theory of the editor, was, in sober
+fact, that of Marie. ‘He persists,’ says the paper, ‘in asserting the
+corpse to be that of Marie, but cannot give a circumstance, in addition
+to those which we have commented upon, to make others believe.’ Now,
+without re-adverting to the fact that stronger evidence ‘to make others
+believe,’ could never have been adduced, it may be remarked that a man
+may very well be understood to believe, in a case of this kind, without
+the ability to advance a single reason for the belief of a second party.
+Nothing is more vague than impressions of individual identity. Each man
+recognizes his neighbor, yet there are few instances in which any one
+is prepared to give a reason for his recognition. The editor of L’Etoile
+had no right to be offended at M. Beauvais’ unreasoning belief.
+
+“The suspicious circumstances which invest him, will be found to tally
+much better with my hypothesis of romantic busy-bodyism, than with
+the reasoner’s suggestion of guilt. Once adopting the more charitable
+interpretation, we shall find no difficulty in comprehending the rose
+in the key-hole; the ‘Marie’ upon the slate; the ‘elbowing the male
+relatives out of the way;’ the ‘aversion to permitting them to see
+the body;’ the caution given to Madame B----, that she must hold no
+conversation with the gendarme until his return (Beauvais’); and,
+lastly, his apparent determination ‘that nobody should have anything to
+do with the proceedings except himself.’ It seems to me unquestionable
+that Beauvais was a suitor of Marie’s; that she coquetted with him; and
+that he was ambitious of being thought to enjoy her fullest intimacy
+and confidence. I shall say nothing more upon this point; and, as the
+evidence fully rebuts the assertion of L’Etoile, touching the matter
+of apathy on the part of the mother and other relatives--an apathy
+inconsistent with the supposition of their believing the corpse to be
+that of the perfumery-girl--we shall now proceed as if the question of
+identity were settled to our perfect satisfaction.”
+
+“And what,” I here demanded, “do you think of the opinions of Le
+Commerciel?”
+
+“That, in spirit, they are far more worthy of attention than any which
+have been promulgated upon the subject. The deductions from the premises
+are philosophical and acute; but the premises, in two instances, at
+least, are founded in imperfect observation. Le Commerciel wishes to
+intimate that Marie was seized by some gang of low ruffians not far from
+her mother’s door. ‘It is impossible,’ it urges, ‘that a person so well
+known to thousands as this young woman was, should have passed three
+blocks without some one having seen her.’ This is the idea of a man long
+resident in Paris--a public man--and one whose walks to and fro in the
+city, have been mostly limited to the vicinity of the public offices.
+He is aware that he seldom passes so far as a dozen blocks from his own
+bureau, without being recognized and accosted. And, knowing the extent
+of his personal acquaintance with others, and of others with him, he
+compares his notoriety with that of the perfumery-girl, finds no great
+difference between them, and reaches at once the conclusion that she, in
+her walks, would be equally liable to recognition with himself in
+his. This could only be the case were her walks of the same unvarying,
+methodical character, and within the same species of limited region
+as are his own. He passes to and fro, at regular intervals, within a
+confined periphery, abounding in individuals who are led to observation
+of his person through interest in the kindred nature of his occupation
+with their own. But the walks of Marie may, in general, be supposed
+discursive. In this particular instance, it will be understood as most
+probable, that she proceeded upon a route of more than average diversity
+from her accustomed ones. The parallel which we imagine to have existed
+in the mind of Le Commerciel would only be sustained in the event of the
+two individuals’ traversing the whole city. In this case, granting the
+personal acquaintances to be equal, the chances would be also equal that
+an equal number of personal rencounters would be made. For my own
+part, I should hold it not only as possible, but as very far more than
+probable, that Marie might have proceeded, at any given period, by any
+one of the many routes between her own residence and that of her aunt,
+without meeting a single individual whom she knew, or by whom she was
+known. In viewing this question in its full and proper light, we must
+hold steadily in mind the great disproportion between the personal
+acquaintances of even the most noted individual in Paris, and the entire
+population of Paris itself.
+
+“But whatever force there may still appear to be in the suggestion of Le
+Commerciel, will be much diminished when we take into consideration the
+hour at which the girl went abroad. ‘It was when the streets were full
+of people,’ says Le Commerciel, ‘that she went out.’ But not so. It was
+at nine o’clock in the morning. Now at nine o’clock of every morning in
+the week, _with the exception of Sunday_, the streets of the city are,
+it is true, thronged with people. At nine on Sunday, the populace are
+chiefly within doors _preparing for church_. No observing person can
+have failed to notice the peculiarly deserted air of the town, from
+about eight until ten on the morning of every Sabbath. Between ten and
+eleven the streets are thronged, but not at so early a period as that
+designated.
+
+“There is another point at which there seems a deficiency of observation
+on the part of Le Commerciel. ‘A piece,’ it says, ‘of one of the
+unfortunate girl’s petticoats, two feet long, and one foot wide, was
+torn out and tied under her chin, and around the back of her head,
+probably to prevent screams. This was done, by fellows who had no
+pocket-handkerchiefs.’ Whether this idea is, or is not well founded,
+we will endeavor to see hereafter; but by ‘fellows who have no
+pocket-handkerchiefs’ the editor intends the lowest class of ruffians.
+These, however, are the very description of people who will always be
+found to have handkerchiefs even when destitute of shirts. You must have
+had occasion to observe how absolutely indispensable, of late years, to
+the thorough blackguard, has become the pocket-handkerchief.”
+
+“And what are we to think,” I asked, “of the article in Le Soleil?”
+
+“That it is a vast pity its inditer was not born a parrot--in which
+case he would have been the most illustrious parrot of his race. He has
+merely repeated the individual items of the already published opinion;
+collecting them, with a laudable industry, from this paper and from
+that. ‘The things had all evidently been there,’ he says, ‘at least,
+three or four weeks, and there can be _no doubt_ that the spot of this
+appalling outrage has been discovered.’ The facts here re-stated by
+Le Soleil, are very far indeed from removing my own doubts upon this
+subject, and we will examine them more particularly hereafter in
+connexion with another division of the theme.
+
+“At present we must occupy ourselves with other investigations. You
+cannot fail to have remarked the extreme laxity of the examination of
+the corpse. To be sure, the question of identity was readily determined,
+or should have been; but there were other points to be ascertained. Had
+the body been in any respect despoiled? Had the deceased any articles
+of jewelry about her person upon leaving home? if so, had she any when
+found? These are important questions utterly untouched by the evidence;
+and there are others of equal moment, which have met with no attention.
+We must endeavor to satisfy ourselves by personal inquiry. The case of
+St. Eustache must be re-examined. I have no suspicion of this person;
+but let us proceed methodically. We will ascertain beyond a doubt the
+validity of the affidavits in regard to his whereabouts on the Sunday.
+Affidavits of this character are readily made matter of mystification.
+Should there be nothing wrong here, however, we will dismiss St.
+Eustache from our investigations. His suicide, however corroborative of
+suspicion, were there found to be deceit in the affidavits, is, without
+such deceit, in no respect an unaccountable circumstance, or one which
+need cause us to deflect from the line of ordinary analysis.
+
+“In that which I now propose, we will discard the interior points of
+this tragedy, and concentrate our attention upon its outskirts. Not the
+least usual error, in investigations such as this, is the limiting of
+inquiry to the immediate, with total disregard of the collateral or
+circumstantial events. It is the mal-practice of the courts to confine
+evidence and discussion to the bounds of apparent relevancy. Yet
+experience has shown, and a true philosophy will always show, that a
+vast, perhaps the larger portion of truth, arises from the seemingly
+irrelevant. It is through the spirit of this principle, if not precisely
+through its letter, that modern science has resolved to calculate upon
+the unforeseen. But perhaps you do not comprehend me. The history of
+human knowledge has so uninterruptedly shown that to collateral, or
+incidental, or accidental events we are indebted for the most numerous
+and most valuable discoveries, that it has at length become necessary,
+in any prospective view of improvement, to make not only large, but the
+largest allowances for inventions that shall arise by chance, and quite
+out of the range of ordinary expectation. It is no longer philosophical
+to base, upon what has been, a vision of what is to be. Accident is
+admitted as a portion of the substructure. We make chance a matter of
+absolute calculation. We subject the unlooked for and unimagined, to the
+mathematical _formulae_ of the schools.
+
+“I repeat that it is no more than fact, that the larger portion of all
+truth has sprung from the collateral; and it is but in accordance with
+the spirit of the principle involved in this fact, that I would divert
+inquiry, in the present case, from the trodden and hitherto unfruitful
+ground of the event itself, to the contemporary circumstances which
+surround it. While you ascertain the validity of the affidavits, I will
+examine the newspapers more generally than you have as yet done. So far,
+we have only reconnoitred the field of investigation; but it will be
+strange indeed if a comprehensive survey, such as I propose, of the
+public prints, will not afford us some minute points which shall
+establish a direction for inquiry.”
+
+In pursuance of Dupin’s suggestion, I made scrupulous examination of
+the affair of the affidavits. The result was a firm conviction of their
+validity, and of the consequent innocence of St. Eustache. In the mean
+time my friend occupied himself, with what seemed to me a minuteness
+altogether objectless, in a scrutiny of the various newspaper files. At
+the end of a week he placed before me the following extracts:
+
+“About three years and a half ago, a disturbance very similar to the
+present, was caused by the disappearance of this same Marie Rogêt, from
+the parfumerie of Monsieur Le Blanc, in the Palais Royal. At the end of
+a week, however, she re-appeared at her customary comptoir, as well as
+ever, with the exception of a slight paleness not altogether usual. It
+was given out by Monsieur Le Blanc and her mother, that she had merely
+been on a visit to some friend in the country; and the affair was
+speedily hushed up. We presume that the present absence is a freak of
+the same nature, and that, at the expiration of a week, or perhaps of
+a month, we shall have her among us again.”--Evening Paper--Monday June
+23. (*17)
+
+“An evening journal of yesterday, refers to a former mysterious
+disappearance of Mademoiselle Rogêt. It is well known that, during the
+week of her absence from Le Blanc’s parfumerie, she was in the company
+of a young naval officer, much noted for his debaucheries. A quarrel, it
+is supposed, providentially led to her return home. We have the name of
+the Lothario in question, who is, at present, stationed in Paris, but,
+for obvious reasons, forbear to make it public.”--Le Mercurie--Tuesday
+Morning, June 24. (*18)
+
+“An outrage of the most atrocious character was perpetrated near this
+city the day before yesterday. A gentleman, with his wife and daughter,
+engaged, about dusk, the services of six young men, who were idly rowing
+a boat to and fro near the banks of the Seine, to convey him across the
+river. Upon reaching the opposite shore, the three passengers stepped
+out, and had proceeded so far as to be beyond the view of the boat,
+when the daughter discovered that she had left in it her parasol. She
+returned for it, was seized by the gang, carried out into the stream,
+gagged, brutally treated, and finally taken to the shore at a point
+not far from that at which she had originally entered the boat with her
+parents. The villains have escaped for the time, but the police are upon
+their trail, and some of them will soon be taken.”--Morning Paper--June
+25. (*19)
+
+“We have received one or two communications, the object of which is to
+fasten the crime of the late atrocity upon Mennais; (*20) but as this
+gentleman has been fully exonerated by a loyal inquiry, and as the
+arguments of our several correspondents appear to be more zealous than
+profound, we do not think it advisable to make them public.”--Morning
+Paper--June 28. (*21)
+
+“We have received several forcibly written communications, apparently
+from various sources, and which go far to render it a matter of
+certainty that the unfortunate Marie Rogêt has become a victim of one of
+the numerous bands of blackguards which infest the vicinity of the city
+upon Sunday. Our own opinion is decidedly in favor of this
+supposition. We shall endeavor to make room for some of these arguments
+hereafter.”--Evening Paper--Tuesday, June 31. (*22)
+
+“On Monday, one of the bargemen connected with the revenue service, saw
+a empty boat floating down the Seine. Sails were lying in the bottom of
+the boat. The bargeman towed it under the barge office. The next morning
+it was taken from thence, without the knowledge of any of the officers.
+The rudder is now at the barge office.”--Le Diligence--Thursday, June
+26.
+
+Upon reading these various extracts, they not only seemed to me
+irrelevant, but I could perceive no mode in which any one of them
+could be brought to bear upon the matter in hand. I waited for some
+explanation from Dupin.
+
+“It is not my present design,” he said, “to dwell upon the first and
+second of those extracts. I have copied them chiefly to show you the
+extreme remissness of the police, who, as far as I can understand from
+the Prefect, have not troubled themselves, in any respect, with an
+examination of the naval officer alluded to. Yet it is mere folly to say
+that between the first and second disappearance of Marie, there is
+no _supposable_ connection. Let us admit the first elopement to have
+resulted in a quarrel between the lovers, and the return home of the
+betrayed. We are now prepared to view a second elopement (if we know
+that an elopement has again taken place) as indicating a renewal of the
+betrayer’s advances, rather than as the result of new proposals by a
+second individual--we are prepared to regard it as a ‘making up’ of the
+old amour, rather than as the commencement of a new one. The chances are
+ten to one, that he who had once eloped with Marie, would again propose
+an elopement, rather than that she to whom proposals of elopement had
+been made by one individual, should have them made to her by another.
+And here let me call your attention to the fact, that the time elapsing
+between the first ascertained, and the second supposed elopement, is
+a few months more than the general period of the cruises of our
+men-of-war. Had the lover been interrupted in his first villany by the
+necessity of departure to sea, and had he seized the first moment of his
+return to renew the base designs not yet altogether accomplished--or
+not yet altogether accomplished by _him?_ Of all these things we know
+nothing.
+
+“You will say, however, that, in the second instance, there was no
+elopement as imagined. Certainly not--but are we prepared to say that
+there was not the frustrated design? Beyond St. Eustache, and perhaps
+Beauvais, we find no recognized, no open, no honorable suitors of Marie.
+Of none other is there any thing said. Who, then, is the secret lover,
+of whom the relatives (at least most of them) know nothing, but whom
+Marie meets upon the morning of Sunday, and who is so deeply in her
+confidence, that she hesitates not to remain with him until the shades
+of the evening descend, amid the solitary groves of the Barrière du
+Roule? Who is that secret lover, I ask, of whom, at least, most of the
+relatives know nothing? And what means the singular prophecy of Madame
+Rogêt on the morning of Marie’s departure?--‘I fear that I shall never
+see Marie again.’
+
+“But if we cannot imagine Madame Rogêt privy to the design of elopement,
+may we not at least suppose this design entertained by the girl? Upon
+quitting home, she gave it to be understood that she was about to visit
+her aunt in the Rue des Drômes and St. Eustache was requested to call
+for her at dark. Now, at first glance, this fact strongly militates
+against my suggestion;--but let us reflect. That she did meet some
+companion, and proceed with him across the river, reaching the Barrière
+du Roule at so late an hour as three o’clock in the afternoon, is
+known. But in consenting so to accompany this individual, (_for whatever
+purpose--to her mother known or unknown,_) she must have thought of her
+expressed intention when leaving home, and of the surprise and suspicion
+aroused in the bosom of her affianced suitor, St. Eustache, when,
+calling for her, at the hour appointed, in the Rue des Drômes, he should
+find that she had not been there, and when, moreover, upon returning to
+the pension with this alarming intelligence, he should become aware of
+her continued absence from home. She must have thought of these things,
+I say. She must have foreseen the chagrin of St. Eustache, the suspicion
+of all. She could not have thought of returning to brave this suspicion;
+but the suspicion becomes a point of trivial importance to her, if we
+suppose her not intending to return.
+
+“We may imagine her thinking thus--‘I am to meet a certain person for
+the purpose of elopement, or for certain other purposes known only to
+myself. It is necessary that there be no chance of interruption--there
+must be sufficient time given us to elude pursuit--I will give it to be
+understood that I shall visit and spend the day with my aunt at the Rue
+des Drômes--I well tell St. Eustache not to call for me until dark--in
+this way, my absence from home for the longest possible period, without
+causing suspicion or anxiety, will be accounted for, and I shall gain
+more time than in any other manner. If I bid St. Eustache call for me
+at dark, he will be sure not to call before; but, if I wholly neglect
+to bid him call, my time for escape will be diminished, since it will
+be expected that I return the earlier, and my absence will the sooner
+excite anxiety. Now, if it were my design to return at all--if I had in
+contemplation merely a stroll with the individual in question--it would
+not be my policy to bid St. Eustache call; for, calling, he will be sure
+to ascertain that I have played him false--a fact of which I might keep
+him for ever in ignorance, by leaving home without notifying him of my
+intention, by returning before dark, and by then stating that I had been
+to visit my aunt in the Rue des Drômes. But, as it is my design never
+to return--or not for some weeks--or not until certain concealments are
+effected--the gaining of time is the only point about which I need give
+myself any concern.’
+
+“You have observed, in your notes, that the most general opinion in
+relation to this sad affair is, and was from the first, that the girl
+had been the victim of a gang of blackguards. Now, the popular opinion,
+under certain conditions, is not to be disregarded. When arising of
+itself--when manifesting itself in a strictly spontaneous manner--we
+should look upon it as analogous with that _intuition_ which is the
+idiosyncrasy of the individual man of genius. In ninety-nine cases from
+the hundred I would abide by its decision. But it is important that we
+find no palpable traces of _suggestion_. The opinion must be rigorously
+_the public’s own_; and the distinction is often exceedingly difficult
+to perceive and to maintain. In the present instance, it appears to me
+that this ‘public opinion’ in respect to a gang, has been superinduced
+by the collateral event which is detailed in the third of my extracts.
+All Paris is excited by the discovered corpse of Marie, a girl young,
+beautiful and notorious. This corpse is found, bearing marks of
+violence, and floating in the river. But it is now made known that, at
+the very period, or about the very period, in which it is supposed that
+the girl was assassinated, an outrage similar in nature to that endured
+by the deceased, although less in extent, was perpetuated, by a gang
+of young ruffians, upon the person of a second young female. Is it
+wonderful that the one known atrocity should influence the popular
+judgment in regard to the other unknown? This judgment awaited
+direction, and the known outrage seemed so opportunely to afford it!
+Marie, too, was found in the river; and upon this very river was this
+known outrage committed. The connexion of the two events had about it so
+much of the palpable, that the true wonder would have been a failure
+of the populace to appreciate and to seize it. But, in fact, the one
+atrocity, known to be so committed, is, if any thing, evidence that the
+other, committed at a time nearly coincident, was not so committed.
+It would have been a miracle indeed, if, while a gang of ruffians were
+perpetrating, at a given locality, a most unheard-of wrong, there should
+have been another similar gang, in a similar locality, in the same
+city, under the same circumstances, with the same means and appliances,
+engaged in a wrong of precisely the same aspect, at precisely the
+same period of time! Yet in what, if not in this marvellous train of
+coincidence, does the accidentally suggested opinion of the populace
+call upon us to believe?
+
+“Before proceeding farther, let us consider the supposed scene of the
+assassination, in the thicket at the Barrière du Roule. This thicket,
+although dense, was in the close vicinity of a public road. Within
+were three or four large stones, forming a kind of seat with a back and
+footstool. On the upper stone was discovered a white petticoat; on the
+second, a silk scarf. A parasol, gloves, and a pocket-handkerchief,
+were also here found. The handkerchief bore the name, ‘Marie Rogêt.’
+Fragments of dress were seen on the branches around. The earth was
+trampled, the bushes were broken, and there was every evidence of a
+violent struggle.
+
+“Notwithstanding the acclamation with which the discovery of this
+thicket was received by the press, and the unanimity with which it
+was supposed to indicate the precise scene of the outrage, it must be
+admitted that there was some very good reason for doubt. That it was the
+scene, I may or I may not believe--but there was excellent reason for
+doubt. Had the true scene been, as Le Commerciel suggested, in the
+neighborhood of the Rue Pavée St. Andrée, the perpetrators of the
+crime, supposing them still resident in Paris, would naturally have been
+stricken with terror at the public attention thus acutely directed into
+the proper channel; and, in certain classes of minds, there would have
+arisen, at once, a sense of the necessity of some exertion to redivert
+this attention. And thus, the thicket of the Barrière du Roule having
+been already suspected, the idea of placing the articles where they were
+found, might have been naturally entertained. There is no real evidence,
+although Le Soleil so supposes, that the articles discovered had
+been more than a very few days in the thicket; while there is much
+circumstantial proof that they could not have remained there, without
+attracting attention, during the twenty days elapsing between the fatal
+Sunday and the afternoon upon which they were found by the boys. ‘They
+were all _mildewed_ down hard,’ says Le Soleil, adopting the opinions of
+its predecessors, ‘with the action of the rain, and stuck together from
+_mildew_. The grass had grown around and over some of them. The silk of
+the parasol was strong, but the threads of it were run together within.
+The upper part, where it had been doubled and folded, was all _mildewed_
+and rotten, and tore on being opened.’ In respect to the grass having
+‘grown around and over some of them,’ it is obvious that the fact
+could only have been ascertained from the words, and thus from the
+recollections, of two small boys; for these boys removed the articles
+and took them home before they had been seen by a third party. But grass
+will grow, especially in warm and damp weather, (such as was that of the
+period of the murder,) as much as two or three inches in a single day.
+A parasol lying upon a newly turfed ground, might, in a single week,
+be entirely concealed from sight by the upspringing grass. And touching
+that mildew upon which the editor of Le Soleil so pertinaciously
+insists, that he employs the word no less than three times in the
+brief paragraph just quoted, is he really unaware of the nature of this
+mildew? Is he to be told that it is one of the many classes of fungus,
+of which the most ordinary feature is its upspringing and decadence
+within twenty-four hours?
+
+“Thus we see, at a glance, that what has been most triumphantly adduced
+in support of the idea that the articles had been ‘for at least three
+or four weeks’ in the thicket, is most absurdly null as regards any
+evidence of that fact. On the other hand, it is exceedingly difficult
+to believe that these articles could have remained in the thicket
+specified, for a longer period than a single week--for a longer period
+than from one Sunday to the next. Those who know any thing of the
+vicinity of Paris, know the extreme difficulty of finding seclusion
+unless at a great distance from its suburbs. Such a thing as an
+unexplored, or even an unfrequently visited recess, amid its woods or
+groves, is not for a moment to be imagined. Let any one who, being at
+heart a lover of nature, is yet chained by duty to the dust and heat
+of this great metropolis--let any such one attempt, even during the
+weekdays, to slake his thirst for solitude amid the scenes of natural
+loveliness which immediately surround us. At every second step, he will
+find the growing charm dispelled by the voice and personal intrusion
+of some ruffian or party of carousing blackguards. He will seek privacy
+amid the densest foliage, all in vain. Here are the very nooks where the
+unwashed most abound--here are the temples most desecrate. With sickness
+of the heart the wanderer will flee back to the polluted Paris as to
+a less odious because less incongruous sink of pollution. But if the
+vicinity of the city is so beset during the working days of the week,
+how much more so on the Sabbath! It is now especially that, released
+from the claims of labor, or deprived of the customary opportunities of
+crime, the town blackguard seeks the precincts of the town, not through
+love of the rural, which in his heart he despises, but by way of escape
+from the restraints and conventionalities of society. He desires
+less the fresh air and the green trees, than the utter license of the
+country. Here, at the road-side inn, or beneath the foliage of the
+woods, he indulges, unchecked by any eye except those of his boon
+companions, in all the mad excess of a counterfeit hilarity--the joint
+offspring of liberty and of rum. I say nothing more than what must
+be obvious to every dispassionate observer, when I repeat that the
+circumstance of the articles in question having remained undiscovered,
+for a longer period--than from one Sunday to another, in any thicket in
+the immediate neighborhood of Paris, is to be looked upon as little less
+than miraculous.
+
+“But there are not wanting other grounds for the suspicion that the
+articles were placed in the thicket with the view of diverting attention
+from the real scene of the outrage. And, first, let me direct your
+notice to the date of the discovery of the articles. Collate this with
+the date of the fifth extract made by myself from the newspapers. You
+will find that the discovery followed, almost immediately, the urgent
+communications sent to the evening paper. These communications, although
+various and apparently from various sources, tended all to the same
+point--viz., the directing of attention to a gang as the perpetrators
+of the outrage, and to the neighborhood of the Barrière du Roule as its
+scene. Now here, of course, the suspicion is not that, in consequence of
+these communications, or of the public attention by them directed, the
+articles were found by the boys; but the suspicion might and may well
+have been, that the articles were not before found by the boys, for the
+reason that the articles had not before been in the thicket; having
+been deposited there only at so late a period as at the date, or shortly
+prior to the date of the communications by the guilty authors of these
+communications themselves.
+
+“This thicket was a singular--an exceedingly singular one. It was
+unusually dense. Within its naturally walled enclosure were three
+extraordinary stones, forming a seat with a back and footstool. And this
+thicket, so full of a natural art, was in the immediate vicinity, within
+a few rods, of the dwelling of Madame Deluc, whose boys were in the
+habit of closely examining the shrubberies about them in search of
+the bark of the sassafras. Would it be a rash wager--a wager of one
+thousand to one--that a day never passed over the heads of these boys
+without finding at least one of them ensconced in the umbrageous hall,
+and enthroned upon its natural throne? Those who would hesitate at such
+a wager, have either never been boys themselves, or have forgotten the
+boyish nature. I repeat--it is exceedingly hard to comprehend how the
+articles could have remained in this thicket undiscovered, for a longer
+period than one or two days; and that thus there is good ground for
+suspicion, in spite of the dogmatic ignorance of Le Soleil, that they
+were, at a comparatively late date, deposited where found.
+
+“But there are still other and stronger reasons for believing them so
+deposited, than any which I have as yet urged. And, now, let me beg
+your notice to the highly artificial arrangement of the articles. On the
+upper stone lay a white petticoat; on the second a silk scarf; scattered
+around, were a parasol, gloves, and a pocket-handkerchief bearing the
+name, ‘Marie Rogêt.’ Here is just such an arrangement as would naturally
+be made by a not over-acute person wishing to dispose the articles
+naturally. But it is by no means a really natural arrangement. I
+should rather have looked to see the things all lying on the ground and
+trampled under foot. In the narrow limits of that bower, it would have
+been scarcely possible that the petticoat and scarf should have retained
+a position upon the stones, when subjected to the brushing to and fro
+of many struggling persons. ‘There was evidence,’ it is said, ‘of a
+struggle; and the earth was trampled, the bushes were broken,’--but the
+petticoat and the scarf are found deposited as if upon shelves. ‘The
+pieces of the frock torn out by the bushes were about three inches wide
+and six inches long. One part was the hem of the frock and it had been
+mended. They looked like strips torn off.’ Here, inadvertently, Le
+Soleil has employed an exceedingly suspicious phrase. The pieces, as
+described, do indeed ‘look like strips torn off;’ but purposely and by
+hand. It is one of the rarest of accidents that a piece is ‘torn off,’
+from any garment such as is now in question, by the agency of a thorn.
+From the very nature of such fabrics, a thorn or nail becoming entangled
+in them, tears them rectangularly--divides them into two longitudinal
+rents, at right angles with each other, and meeting at an apex where the
+thorn enters--but it is scarcely possible to conceive the piece ‘torn
+off.’ I never so knew it, nor did you. To tear a piece off from such
+fabric, two distinct forces, in different directions, will be, in almost
+every case, required. If there be two edges to the fabric--if, for
+example, it be a pocket-handkerchief, and it is desired to tear from it
+a slip, then, and then only, will the one force serve the purpose. But
+in the present case the question is of a dress, presenting but one edge.
+To tear a piece from the interior, where no edge is presented, could
+only be effected by a miracle through the agency of thorns, and no one
+thorn could accomplish it. But, even where an edge is presented, two
+thorns will be necessary, operating, the one in two distinct directions,
+and the other in one. And this in the supposition that the edge is
+unhemmed. If hemmed, the matter is nearly out of the question. We thus
+see the numerous and great obstacles in the way of pieces being ‘torn
+off’ through the simple agency of ‘thorns;’ yet we are required to
+believe not only that one piece but that many have been so torn. ‘And
+one part,’ too, ‘was the hem of the frock!’ Another piece was ‘part
+of the skirt, not the hem,’--that is to say, was torn completely out
+through the agency of thorns, from the uncaged interior of the
+dress! These, I say, are things which one may well be pardoned for
+disbelieving; yet, taken collectedly, they form, perhaps, less of
+reasonable ground for suspicion, than the one startling circumstance of
+the articles’ having been left in this thicket at all, by any murderers
+who had enough precaution to think of removing the corpse. You will not
+have apprehended me rightly, however, if you suppose it my design to
+deny this thicket as the scene of the outrage. There might have been a
+wrong here, or, more possibly, an accident at Madame Deluc’s. But, in
+fact, this is a point of minor importance. We are not engaged in an
+attempt to discover the scene, but to produce the perpetrators of the
+murder. What I have adduced, notwithstanding the minuteness with which I
+have adduced it, has been with the view, first, to show the folly of the
+positive and headlong assertions of Le Soleil, but secondly and chiefly,
+to bring you, by the most natural route, to a further contemplation of
+the doubt whether this assassination has, or has not been, the work of a
+gang.
+
+“We will resume this question by mere allusion to the revolting details
+of the surgeon examined at the inquest. It is only necessary to say that
+his published inferences, in regard to the number of ruffians, have been
+properly ridiculed as unjust and totally baseless, by all the reputable
+anatomists of Paris. Not that the matter might not have been as
+inferred, but that there was no ground for the inference:--was there not
+much for another?
+
+“Let us reflect now upon ‘the traces of a struggle;’ and let me ask what
+these traces have been supposed to demonstrate. A gang. But do they not
+rather demonstrate the absence of a gang? What struggle could have taken
+place--what struggle so violent and so enduring as to have left its
+‘traces’ in all directions--between a weak and defenceless girl and the
+gang of ruffians imagined? The silent grasp of a few rough arms and all
+would have been over. The victim must have been absolutely passive at
+their will. You will here bear in mind that the arguments urged against
+the thicket as the scene, are applicable in chief part, only against it
+as the scene of an outrage committed by more than a single individual.
+If we imagine but one violator, we can conceive, and thus only conceive,
+the struggle of so violent and so obstinate a nature as to have left the
+‘traces’ apparent.
+
+“And again. I have already mentioned the suspicion to be excited by the
+fact that the articles in question were suffered to remain at all in
+the thicket where discovered. It seems almost impossible that these
+evidences of guilt should have been accidentally left where found. There
+was sufficient presence of mind (it is supposed) to remove the corpse;
+and yet a more positive evidence than the corpse itself (whose features
+might have been quickly obliterated by decay,) is allowed to lie
+conspicuously in the scene of the outrage--I allude to the handkerchief
+with the name of the deceased. If this was accident, it was not
+the accident of a gang. We can imagine it only the accident of an
+individual. Let us see. An individual has committed the murder. He
+is alone with the ghost of the departed. He is appalled by what lies
+motionless before him. The fury of his passion is over, and there is
+abundant room in his heart for the natural awe of the deed. His is none
+of that confidence which the presence of numbers inevitably inspires.
+He is alone with the dead. He trembles and is bewildered. Yet there is
+a necessity for disposing of the corpse. He bears it to the river, but
+leaves behind him the other evidences of guilt; for it is difficult, if
+not impossible to carry all the burthen at once, and it will be easy to
+return for what is left. But in his toilsome journey to the water his
+fears redouble within him. The sounds of life encompass his path. A
+dozen times he hears or fancies the step of an observer. Even the very
+lights from the city bewilder him. Yet, in time and by long and frequent
+pauses of deep agony, he reaches the river’s brink, and disposes of
+his ghastly charge--perhaps through the medium of a boat. But now what
+treasure does the world hold--what threat of vengeance could it hold
+out--which would have power to urge the return of that lonely murderer
+over that toilsome and perilous path, to the thicket and its blood
+chilling recollections? He returns not, let the consequences be what
+they may. He could not return if he would. His sole thought is immediate
+escape. He turns his back forever upon those dreadful shrubberies and
+flees as from the wrath to come.
+
+“But how with a gang? Their number would have inspired them with
+confidence; if, indeed confidence is ever wanting in the breast of the
+arrant blackguard; and of arrant blackguards alone are the supposed
+gangs ever constituted. Their number, I say, would have prevented the
+bewildering and unreasoning terror which I have imagined to paralyze the
+single man. Could we suppose an oversight in one, or two, or three, this
+oversight would have been remedied by a fourth. They would have left
+nothing behind them; for their number would have enabled them to carry
+all at once. There would have been no need of return.
+
+“Consider now the circumstance that in the outer garment of the corpse
+when found, ‘a slip, about a foot wide had been torn upward from the
+bottom hem to the waist wound three times round the waist, and secured
+by a sort of hitch in the back.’ This was done with the obvious design
+of affording a handle by which to carry the body. But would any number
+of men have dreamed of resorting to such an expedient? To three or four,
+the limbs of the corpse would have afforded not only a sufficient, but
+the best possible hold. The device is that of a single individual; and
+this brings us to the fact that ‘between the thicket and the river, the
+rails of the fences were found taken down, and the ground bore evident
+traces of some heavy burden having been dragged along it!’ But would a
+number of men have put themselves to the superfluous trouble of taking
+down a fence, for the purpose of dragging through it a corpse which they
+might have lifted over any fence in an instant? Would a number of men
+have so dragged a corpse at all as to have left evident traces of the
+dragging?
+
+“And here we must refer to an observation of Le Commerciel; an
+observation upon which I have already, in some measure, commented. ‘A
+piece,’ says this journal, ‘of one of the unfortunate girl’s petticoats
+was torn out and tied under her chin, and around the back of her
+head, probably to prevent screams. This was done by fellows who had no
+pocket-handkerchiefs.’
+
+“I have before suggested that a genuine blackguard is never without a
+pocket-handkerchief. But it is not to this fact that I now especially
+advert. That it was not through want of a handkerchief for the purpose
+imagined by Le Commerciel, that this bandage was employed, is rendered
+apparent by the handkerchief left in the thicket; and that the object
+was not ‘to prevent screams’ appears, also, from the bandage having been
+employed in preference to what would so much better have answered
+the purpose. But the language of the evidence speaks of the strip in
+question as ‘found around the neck, fitting loosely, and secured with
+a hard knot.’ These words are sufficiently vague, but differ materially
+from those of Le Commerciel. The slip was eighteen inches wide, and
+therefore, although of muslin, would form a strong band when folded or
+rumpled longitudinally. And thus rumpled it was discovered. My inference
+is this. The solitary murderer, having borne the corpse, for some
+distance, (whether from the thicket or elsewhere) by means of the
+bandage hitched around its middle, found the weight, in this mode
+of procedure, too much for his strength. He resolved to drag the
+burthen--the evidence goes to show that it was dragged. With this object
+in view, it became necessary to attach something like a rope to one of
+the extremities. It could be best attached about the neck, where the
+head would prevent its slipping off. And, now, the murderer bethought
+him, unquestionably, of the bandage about the loins. He would have used
+this, but for its volution about the corpse, the hitch which embarrassed
+it, and the reflection that it had not been ‘torn off’ from the garment.
+It was easier to tear a new slip from the petticoat. He tore it, made
+it fast about the neck, and so dragged his victim to the brink of the
+river. That this ‘bandage,’ only attainable with trouble and delay, and
+but imperfectly answering its purpose--that this bandage was employed
+at all, demonstrates that the necessity for its employment sprang from
+circumstances arising at a period when the handkerchief was no longer
+attainable--that is to say, arising, as we have imagined, after quitting
+the thicket, (if the thicket it was), and on the road between the
+thicket and the river.
+
+“But the evidence, you will say, of Madame Deluc, (!) points especially
+to the presence of a gang, in the vicinity of the thicket, at or about
+the epoch of the murder. This I grant. I doubt if there were not a dozen
+gangs, such as described by Madame Deluc, in and about the vicinity of
+the Barrière du Roule at or about the period of this tragedy. But the
+gang which has drawn upon itself the pointed animadversion, although the
+somewhat tardy and very suspicious evidence of Madame Deluc, is the
+only gang which is represented by that honest and scrupulous old lady
+as having eaten her cakes and swallowed her brandy, without putting
+themselves to the trouble of making her payment. Et hinc illæ iræ?
+
+“But what is the precise evidence of Madame Deluc? ‘A gang of miscreants
+made their appearance, behaved boisterously, ate and drank without
+making payment, followed in the route of the young man and girl,
+returned to the inn about dusk, and recrossed the river as if in great
+haste.’
+
+“Now this ‘great haste’ very possibly seemed greater haste in the eyes
+of Madame Deluc, since she dwelt lingeringly and lamentingly upon her
+violated cakes and ale--cakes and ale for which she might still have
+entertained a faint hope of compensation. Why, otherwise, since it was
+about dusk, should she make a point of the haste? It is no cause for
+wonder, surely, that even a gang of blackguards should make haste to
+get home, when a wide river is to be crossed in small boats, when storm
+impends, and when night approaches.
+
+“I say approaches; for the night had not yet arrived. It was only about
+dusk that the indecent haste of these ‘miscreants’ offended the sober
+eyes of Madame Deluc. But we are told that it was upon this very evening
+that Madame Deluc, as well as her eldest son, ‘heard the screams of a
+female in the vicinity of the inn.’ And in what words does Madame Deluc
+designate the period of the evening at which these screams were heard?
+‘It was soon after dark,’ she says. But ‘soon after dark,’ is, at least,
+dark; and ‘about dusk’ is as certainly daylight. Thus it is abundantly
+clear that the gang quitted the Barrière du Roule prior to the screams
+overheard (?) by Madame Deluc. And although, in all the many reports of
+the evidence, the relative expressions in question are distinctly and
+invariably employed just as I have employed them in this conversation
+with yourself, no notice whatever of the gross discrepancy has, as yet,
+been taken by any of the public journals, or by any of the Myrmidons of
+police.
+
+“I shall add but one to the arguments against a gang; but this one has,
+to my own understanding at least, a weight altogether irresistible.
+Under the circumstances of large reward offered, and full pardon to
+any King’s evidence, it is not to be imagined, for a moment, that some
+member of a gang of low ruffians, or of any body of men, would not long
+ago have betrayed his accomplices. Each one of a gang so placed, is not
+so much greedy of reward, or anxious for escape, as fearful of betrayal.
+He betrays eagerly and early that he may not himself be betrayed. That
+the secret has not been divulged, is the very best of proof that it is,
+in fact, a secret. The horrors of this dark deed are known only to one,
+or two, living human beings, and to God.
+
+“Let us sum up now the meagre yet certain fruits of our long analysis.
+We have attained the idea either of a fatal accident under the roof of
+Madame Deluc, or of a murder perpetrated, in the thicket at the Barrière
+du Roule, by a lover, or at least by an intimate and secret associate of
+the deceased. This associate is of swarthy complexion. This complexion,
+the ‘hitch’ in the bandage, and the ‘sailor’s knot,’ with which the
+bonnet-ribbon is tied, point to a seaman. His companionship with the
+deceased, a gay, but not an abject young girl, designates him as
+above the grade of the common sailor. Here the well written and urgent
+communications to the journals are much in the way of corroboration. The
+circumstance of the first elopement, as mentioned by Le Mercurie, tends
+to blend the idea of this seaman with that of the ‘naval officer’ who is
+first known to have led the unfortunate into crime.
+
+“And here, most fitly, comes the consideration of the continued
+absence of him of the dark complexion. Let me pause to observe that the
+complexion of this man is dark and swarthy; it was no common swarthiness
+which constituted the sole point of remembrance, both as regards Valence
+and Madame Deluc. But why is this man absent? Was he murdered by the
+gang? If so, why are there only traces of the assassinated girl? The
+scene of the two outrages will naturally be supposed identical. And
+where is his corpse? The assassins would most probably have disposed
+of both in the same way. But it may be said that this man lives, and is
+deterred from making himself known, through dread of being charged with
+the murder. This consideration might be supposed to operate upon him
+now--at this late period--since it has been given in evidence that he
+was seen with Marie--but it would have had no force at the period of the
+deed. The first impulse of an innocent man would have been to announce
+the outrage, and to aid in identifying the ruffians. This policy would
+have suggested. He had been seen with the girl. He had crossed the river
+with her in an open ferry-boat. The denouncing of the assassins would
+have appeared, even to an idiot, the surest and sole means of relieving
+himself from suspicion. We cannot suppose him, on the night of the fatal
+Sunday, both innocent himself and incognizant of an outrage committed.
+Yet only under such circumstances is it possible to imagine that he
+would have failed, if alive, in the denouncement of the assassins.
+
+“And what means are ours, of attaining the truth? We shall find these
+means multiplying and gathering distinctness as we proceed. Let us sift
+to the bottom this affair of the first elopement. Let us know the
+full history of ‘the officer,’ with his present circumstances, and
+his whereabouts at the precise period of the murder. Let us carefully
+compare with each other the various communications sent to the evening
+paper, in which the object was to inculpate a gang. This done, let us
+compare these communications, both as regards style and MS., with
+those sent to the morning paper, at a previous period, and insisting so
+vehemently upon the guilt of Mennais. And, all this done, let us again
+compare these various communications with the known MSS. of the officer.
+Let us endeavor to ascertain, by repeated questionings of Madame Deluc
+and her boys, as well as of the omnibus driver, Valence, something more
+of the personal appearance and bearing of the ‘man of dark complexion.’
+Queries, skilfully directed, will not fail to elicit, from some of
+these parties, information on this particular point (or upon
+others)--information which the parties themselves may not even be aware
+of possessing. And let us now trace the boat picked up by the bargeman
+on the morning of Monday the twenty-third of June, and which was
+removed from the barge-office, without the cognizance of the officer
+in attendance, and without the rudder, at some period prior to the
+discovery of the corpse. With a proper caution and perseverance we shall
+infallibly trace this boat; for not only can the bargeman who picked
+it up identify it, but the rudder is at hand. The rudder of a sail-boat
+would not have been abandoned, without inquiry, by one altogether at
+ease in heart. And here let me pause to insinuate a question. There was
+no advertisement of the picking up of this boat. It was silently
+taken to the barge-office, and as silently removed. But its owner or
+employer--how happened he, at so early a period as Tuesday morning, to
+be informed, without the agency of advertisement, of the locality of
+the boat taken up on Monday, unless we imagine some connexion with the
+navy--some personal permanent connexion leading to cognizance of its
+minute in interests--its petty local news?
+
+“In speaking of the lonely assassin dragging his burden to the shore,
+I have already suggested the probability of his availing himself of a
+boat. Now we are to understand that Marie Rogêt was precipitated from a
+boat. This would naturally have been the case. The corpse could not have
+been trusted to the shallow waters of the shore. The peculiar marks on
+the back and shoulders of the victim tell of the bottom ribs of a boat.
+That the body was found without weight is also corroborative of the
+idea. If thrown from the shore a weight would have been attached. We can
+only account for its absence by supposing the murderer to have neglected
+the precaution of supplying himself with it before pushing off. In the
+act of consigning the corpse to the water, he would unquestionably have
+noticed his oversight; but then no remedy would have been at hand.
+Any risk would have been preferred to a return to that accursed shore.
+Having rid himself of his ghastly charge, the murderer would have
+hastened to the city. There, at some obscure wharf, he would have leaped
+on land. But the boat--would he have secured it? He would have been
+in too great haste for such things as securing a boat. Moreover, in
+fastening it to the wharf, he would have felt as if securing evidence
+against himself. His natural thought would have been to cast from him,
+as far as possible, all that had held connection with his crime. He
+would not only have fled from the wharf, but he would not have permitted
+the boat to remain. Assuredly he would have cast it adrift. Let us
+pursue our fancies.--In the morning, the wretch is stricken with
+unutterable horror at finding that the boat has been picked up and
+detained at a locality which he is in the daily habit of frequenting
+--at a locality, perhaps, which his duty compels him to frequent. The
+next night, without daring to ask for the rudder, he removes it. Now
+where is that rudderless boat? Let it be one of our first purposes
+to discover. With the first glimpse we obtain of it, the dawn of our
+success shall begin. This boat shall guide us, with a rapidity which
+will surprise even ourselves, to him who employed it in the midnight of
+the fatal Sabbath. Corroboration will rise upon corroboration, and the
+murderer will be traced.”
+
+[For reasons which we shall not specify, but which to many readers will
+appear obvious, we have taken the liberty of here omitting, from the
+MSS. placed in our hands, such portion as details the following up of
+the apparently slight clew obtained by Dupin. We feel it advisable only
+to state, in brief, that the result desired was brought to pass; and
+that the Prefect fulfilled punctually, although with reluctance, the
+terms of his compact with the Chevalier. Mr. Poe’s article concludes
+with the following words.--Eds. (*23)]
+
+It will be understood that I speak of coincidences and no more. What
+I have said above upon this topic must suffice. In my own heart there
+dwells no faith in præter-nature. That Nature and its God are two, no
+man who thinks, will deny. That the latter, creating the former, can, at
+will, control or modify it, is also unquestionable. I say “at will;” for
+the question is of will, and not, as the insanity of logic has assumed,
+of power. It is not that the Deity cannot modify his laws, but that we
+insult him in imagining a possible necessity for modification. In their
+origin these laws were fashioned to embrace all contingencies which
+could lie in the Future. With God all is Now.
+
+I repeat, then, that I speak of these things only as of coincidences.
+And farther: in what I relate it will be seen that between the fate of
+the unhappy Mary Cecilia Rogers, so far as that fate is known, and the
+fate of one Marie Rogêt up to a certain epoch in her history, there has
+existed a parallel in the contemplation of whose wonderful exactitude
+the reason becomes embarrassed. I say all this will be seen. But let it
+not for a moment be supposed that, in proceeding with the sad narrative
+of Marie from the epoch just mentioned, and in tracing to its dénouement
+the mystery which enshrouded her, it is my covert design to hint at an
+extension of the parallel, or even to suggest that the measures adopted
+in Paris for the discovery of the assassin of a grisette, or measures
+founded in any similar ratiocination, would produce any similar result.
+
+For, in respect to the latter branch of the supposition, it should be
+considered that the most trifling variation in the facts of the
+two cases might give rise to the most important miscalculations,
+by diverting thoroughly the two courses of events; very much as,
+in arithmetic, an error which, in its own individuality, may be
+inappreciable, produces, at length, by dint of multiplication at all
+points of the process, a result enormously at variance with truth. And,
+in regard to the former branch, we must not fail to hold in view that
+the very Calculus of Probabilities to which I have referred, forbids all
+idea of the extension of the parallel:--forbids it with a positiveness
+strong and decided just in proportion as this parallel has already been
+long-drawn and exact. This is one of those anomalous propositions which,
+seemingly appealing to thought altogether apart from the mathematical,
+is yet one which only the mathematician can fully entertain. Nothing,
+for example, is more difficult than to convince the merely general
+reader that the fact of sixes having been thrown twice in succession by
+a player at dice, is sufficient cause for betting the largest odds that
+sixes will not be thrown in the third attempt. A suggestion to this
+effect is usually rejected by the intellect at once. It does not
+appear that the two throws which have been completed, and which lie now
+absolutely in the Past, can have influence upon the throw which exists
+only in the Future. The chance for throwing sixes seems to be precisely
+as it was at any ordinary time--that is to say, subject only to the
+influence of the various other throws which may be made by the dice. And
+this is a reflection which appears so exceedingly obvious that attempts
+to controvert it are received more frequently with a derisive smile
+than with anything like respectful attention. The error here involved--a
+gross error redolent of mischief--I cannot pretend to expose within the
+limits assigned me at present; and with the philosophical it needs
+no exposure. It may be sufficient here to say that it forms one of an
+infinite series of mistakes which arise in the path of Reason through
+her propensity for seeking truth in detail.
+
+Footnotes--Marie Rogêt
+
+(*1) Upon the original publication of “Marie Roget,” the foot-notes now
+appended were considered unnecessary; but the lapse of several years
+since the tragedy upon which the tale is based, renders it expedient
+to give them, and also to say a few words in explanation of the general
+design. A young girl, Mary Cecilia Rogers, was murdered in the
+vicinity of New York; and, although her death occasioned an intense and
+long-enduring excitement, the mystery attending it had remained
+unsolved at the period when the present paper was written and published
+(November, 1842). Herein, under pretence of relating the fate of
+a Parisian grisette, the author has followed in minute detail, the
+essential, while merely paralleling the inessential facts of the real
+murder of Mary Rogers. Thus all argument founded upon the fiction is
+applicable to the truth: and the investigation of the truth was the
+object. The “Mystery of Marie Roget” was composed at a distance from the
+scene of the atrocity, and with no other means of investigation than the
+newspapers afforded. Thus much escaped the writer of which he could have
+availed himself had he been upon the spot, and visited the localities.
+It may not be improper to record, nevertheless, that the confessions of
+two persons, (one of them the Madame Deluc of the narrative) made, at
+different periods, long subsequent to the publication, confirmed, in
+full, not only the general conclusion, but absolutely all the chief
+hypothetical details by which that conclusion was attained.
+
+(*2) The nom de plume of Von Hardenburg.
+
+(*3) Nassau Street.
+
+(*4) Anderson.
+
+(*5) The Hudson.
+
+(*6) Weehawken.
+
+(*7) Payne.
+
+(*8) Crommelin.
+
+(*9) The New York “Mercury.”
+
+(*10) The New York “Brother Jonathan,” edited by H. Hastings Weld, Esq.
+
+(*11) New York “Journal of Commerce.”
+
+(*12) Philadelphia “Saturday Evening Post,” edited by C. I. Peterson,
+Esq.
+
+(*13) Adam
+
+(*14) See “Murders in the Rue Morgue.”
+
+(*15) The New York “Commercial Advertiser,” edited by Col. Stone.
+
+(*16) “A theory based on the qualities of an object, will prevent its
+being unfolded according to its objects; and he who arranges topics in
+reference to their causes, will cease to value them according to their
+results. Thus the jurisprudence of every nation will show that, when law
+becomes a science and a system, it ceases to be justice. The errors
+into which a blind devotion to principles of classification has led the
+common law, will be seen by observing how often the legislature has
+been obliged to come forward to restore the equity its scheme had
+lost.”--Landor.
+
+(*17) New York “Express”
+
+(*18) New York “Herald.”
+
+(*19) New York “Courier and Inquirer.”
+
+(*20) Mennais was one of the parties originally suspected and arrested,
+but discharged through total lack of evidence.
+
+(*21) New York “Courier and Inquirer.”
+
+(*22) New York “Evening Post.”
+
+(*23) Of the Magazine in which the article was originally published.
+
+
+
+
+THE BALLOON-HOAX
+
+ [Astounding News by Express, _via_ Norfolk!--The Atlantic
+ crossed in Three Days!  Signal Triumph of Mr. Monck Mason’s Flying
+ Machine!--Arrival at Sullivan’s Island, near Charlestown, S.C., of
+ Mr. Mason, Mr. Robert Holland, Mr. Henson, Mr. Harrison Ainsworth,
+ and four others, in the Steering Balloon, “Victoria,” after a passage
+ of Seventy-five Hours from Land to Land!  Full Particulars of the
+ Voyage!
+
+ The subjoined _jeu d’esprit_ with the preceding heading in
+ magnificent capitals, well interspersed with notes of admiration, was
+ originally published, as matter of fact, in the “New York Sun,” a
+ daily newspaper, and therein fully subserved the purpose of creating
+ indigestible aliment for the _quidnuncs_ during the few hours
+ intervening between a couple of the Charleston mails.  The rush for
+ the “sole paper which had the news,” was something beyond even the
+ prodigious;  and, in fact, if (as some assert) the “Victoria” _did_
+ not absolutely accomplish the voyage recorded, it will be difficult
+ to assign a reason why she _should_ not have accomplished it.]
+
+THE great problem is at length solved! The air, as well as the earth
+and the ocean, has been subdued by science, and will become a common and
+convenient highway for mankind. _The Atlantic has been actually crossed
+in a Balloon!_ and this too without difficulty--without any great
+apparent danger--with thorough control of the machine--and in the
+inconceivably brief period of seventy-five hours from shore to shore!
+By the energy of an agent at Charleston, S.C., we are enabled to be
+the first to furnish the public with a detailed account of this most
+extraordinary voyage, which was performed between Saturday, the 6th
+instant, at 11, A.M., and 2, P.M., on Tuesday, the 9th instant, by Sir
+Everard Bringhurst; Mr. Osborne, a nephew of Lord Bentinck’s; Mr. Monck
+Mason and Mr. Robert Holland, the well-known æronauts; Mr. Harrison
+Ainsworth, author of “Jack Sheppard,” &c.; and Mr. Henson, the
+projector of the late unsuccessful flying machine--with two seamen from
+Woolwich--in all, eight persons. The particulars furnished below may be
+relied on as authentic and accurate in every respect, as, with a slight
+exception, they are copied _verbatim_ from the joint diaries of Mr.
+Monck Mason and Mr. Harrison Ainsworth, to whose politeness our agent is
+also indebted for much verbal information respecting the balloon itself,
+its construction, and other matters of interest. The only alteration in
+the MS. received, has been made for the purpose of throwing the hurried
+account of our agent, Mr. Forsyth, into a connected and intelligible
+form.
+
+“THE BALLOON.
+
+“Two very decided failures, of late--those of Mr. Henson and Sir George
+Cayley--had much weakened the public interest in the subject of aerial
+navigation. Mr. Henson’s scheme (which at first was considered very
+feasible even by men of science,) was founded upon the principle of an
+inclined plane, started from an eminence by an extrinsic force, applied
+and continued by the revolution of impinging vanes, in form and number
+resembling the vanes of a windmill. But, in all the experiments made
+with models at the Adelaide Gallery, it was found that the operation of
+these fans not only did not propel the machine, but actually impeded
+its flight. The only propelling force it ever exhibited, was the mere
+_impetus_ acquired from the descent of the inclined plane; and this
+_impetus_ carried the machine farther when the vanes were at rest, than
+when they were in motion--a fact which sufficiently demonstrates their
+inutility; and in the absence of the propelling, which was also the
+_sustaining_ power, the whole fabric would necessarily descend.
+This consideration led Sir George Cayley to think only of adapting
+a propeller to some machine having of itself an independent power of
+support--in a word, to a balloon; the idea, however, being novel,
+or original, with Sir George, only so far as regards the mode of its
+application to practice. He exhibited a model of his invention at the
+Polytechnic Institution. The propelling principle, or power, was here,
+also, applied to interrupted surfaces, or vanes, put in revolution.
+These vanes were four in number, but were found entirely ineffectual in
+moving the balloon, or in aiding its ascending power. The whole project
+was thus a complete failure.
+
+“It was at this juncture that Mr. Monck Mason (whose voyage from Dover
+to Weilburg in the balloon, “Nassau,” occasioned so much excitement in
+1837,) conceived the idea of employing the principle of the Archimedean
+screw for the purpose of propulsion through the air--rightly
+attributing the failure of Mr. Henson’s scheme, and of Sir George
+Cayley’s, to the interruption of surface in the independent vanes.
+He made the first public experiment at Willis’s Rooms, but afterward
+removed his model to the Adelaide Gallery.
+
+“Like Sir George Cayley’s balloon, his own was an ellipsoid. Its
+length was thirteen feet six inches--height, six feet eight inches. It
+contained about three hundred and twenty cubic feet of gas, which, if
+pure hydrogen, would support twenty-one pounds upon its first inflation,
+before the gas has time to deteriorate or escape. The weight of the
+whole machine and apparatus was seventeen pounds--leaving about four
+pounds to spare. Beneath the centre of the balloon, was a frame of light
+wood, about nine feet long, and rigged on to the balloon itself with
+a network in the customary manner. From this framework was suspended a
+wicker basket or car.
+
+“The screw consists of an axis of hollow brass tube, eighteen inches in
+length, through which, upon a semi-spiral inclined at fifteen degrees,
+pass a series of steel wire radii, two feet long, and thus projecting a
+foot on either side. These radii are connected at the outer extremities
+by two bands of flattened wire--the whole in this manner forming the
+framework of the screw, which is completed by a covering of oiled silk
+cut into gores, and tightened so as to present a tolerably uniform
+surface. At each end of its axis this screw is supported by pillars of
+hollow brass tube descending from the hoop. In the lower ends of these
+tubes are holes in which the pivots of the axis revolve. From the end
+of the axis which is next the car, proceeds a shaft of steel, connecting
+the screw with the pinion of a piece of spring machinery fixed in the
+car. By the operation of this spring, the screw is made to revolve with
+great rapidity, communicating a progressive motion to the whole. By
+means of the rudder, the machine was readily turned in any direction.
+The spring was of great power, compared with its dimensions, being
+capable of raising forty-five pounds upon a barrel of four inches
+diameter, after the first turn, and gradually increasing as it was wound
+up. It weighed, altogether, eight pounds six ounces. The rudder was
+a light frame of cane covered with silk, shaped somewhat like a
+battle-door, and was about three feet long, and at the widest, one foot.
+Its weight was about two ounces. It could be turned _flat_, and directed
+upwards or downwards, as well as to the right or left; and thus enabled
+the æronaut to transfer the resistance of the air which in an inclined
+position it must generate in its passage, to any side upon which he
+might desire to act; thus determining the balloon in the opposite
+direction.
+
+“This model (which, through want of time, we have necessarily described
+in an imperfect manner,) was put in action at the Adelaide Gallery,
+where it accomplished a velocity of five miles per hour; although,
+strange to say, it excited very little interest in comparison with the
+previous complex machine of Mr. Henson--so resolute is the world
+to despise anything which carries with it an air of simplicity. To
+accomplish the great desideratum of ærial navigation, it was very
+generally supposed that some exceedingly complicated application must be
+made of some unusually profound principle in dynamics.
+
+“So well satisfied, however, was Mr. Mason of the ultimate success of
+his invention, that he determined to construct immediately, if possible,
+a balloon of sufficient capacity to test the question by a voyage of
+some extent--the original design being to cross the British Channel, as
+before, in the Nassau balloon. To carry out his views, he solicited and
+obtained the patronage of Sir Everard Bringhurst and Mr. Osborne, two
+gentlemen well known for scientific acquirement, and especially for the
+interest they have exhibited in the progress of ærostation. The project,
+at the desire of Mr. Osborne, was kept a profound secret from the
+public--the only persons entrusted with the design being those actually
+engaged in the construction of the machine, which was built (under the
+superintendence of Mr. Mason, Mr. Holland, Sir Everard Bringhurst, and
+Mr. Osborne,) at the seat of the latter gentleman near Penstruthal, in
+Wales. Mr. Henson, accompanied by his friend Mr. Ainsworth, was admitted
+to a private view of the balloon, on Saturday last--when the two
+gentlemen made final arrangements to be included in the adventure. We
+are not informed for what reason the two seamen were also included in
+the party--but, in the course of a day or two, we shall put our readers
+in possession of the minutest particulars respecting this extraordinary
+voyage.
+
+“The balloon is composed of silk, varnished with the liquid gum
+caoutchouc. It is of vast dimensions, containing more than 40,000 cubic
+feet of gas; but as coal gas was employed in place of the more expensive
+and inconvenient hydrogen, the supporting power of the machine, when
+fully inflated, and immediately after inflation, is not more than about
+2500 pounds. The coal gas is not only much less costly, but is easily
+procured and managed.
+
+“For its introduction into common use for purposes of aerostation, we
+are indebted to Mr. Charles Green. Up to his discovery, the process of
+inflation was not only exceedingly expensive, but uncertain. Two, and
+even three days, have frequently been wasted in futile attempts to
+procure a sufficiency of hydrogen to fill a balloon, from which it
+had great tendency to escape, owing to its extreme subtlety, and its
+affinity for the surrounding atmosphere. In a balloon sufficiently
+perfect to retain its contents of coal-gas unaltered, in quantity or
+amount, for six months, an equal quantity of hydrogen could not be
+maintained in equal purity for six weeks.
+
+“The supporting power being estimated at 2500 pounds, and the united
+weights of the party amounting only to about 1200, there was left a
+surplus of 1300, of which again 1200 was exhausted by ballast, arranged
+in bags of different sizes, with their respective weights marked upon
+them--by cordage, barometers, telescopes, barrels containing provision
+for a fortnight, water-casks, cloaks, carpet-bags, and various other
+indispensable matters, including a coffee-warmer, contrived for warming
+coffee by means of slack-lime, so as to dispense altogether with fire,
+if it should be judged prudent to do so. All these articles, with the
+exception of the ballast, and a few trifles, were suspended from the
+hoop overhead. The car is much smaller and lighter, in proportion, than
+the one appended to the model. It is formed of a light wicker, and is
+wonderfully strong, for so frail looking a machine. Its rim is about
+four feet deep. The rudder is also very much larger, in proportion, than
+that of the model; and the screw is considerably smaller. The balloon is
+furnished besides with a grapnel, and a guide-rope; which latter is of
+the most indispensable importance. A few words, in explanation, will
+here be necessary for such of our readers as are not conversant with the
+details of aerostation.
+
+“As soon as the balloon quits the earth, it is subjected to the
+influence of many circumstances tending to create a difference in its
+weight; augmenting or diminishing its ascending power. For example,
+there may be a deposition of dew upon the silk, to the extent, even,
+of several hundred pounds; ballast has then to be thrown out, or the
+machine may descend. This ballast being discarded, and a clear sunshine
+evaporating the dew, and at the same time expanding the gas in the silk,
+the whole will again rapidly ascend. To check this ascent, the only
+recourse is, (or rather _was_, until Mr. Green’s invention of the
+guide-rope,) the permission of the escape of gas from the valve; but, in
+the loss of gas, is a proportionate general loss of ascending power; so
+that, in a comparatively brief period, the best-constructed balloon must
+necessarily exhaust all its resources, and come to the earth. This was
+the great obstacle to voyages of length.
+
+“The guide-rope remedies the difficulty in the simplest manner
+conceivable. It is merely a very long rope which is suffered to trail
+from the car, and the effect of which is to prevent the balloon from
+changing its level in any material degree. If, for example, there should
+be a deposition of moisture upon the silk, and the machine begins to
+descend in consequence, there will be no necessity for discharging
+ballast to remedy the increase of weight, for it is remedied, or
+counteracted, in an exactly just proportion, by the deposit on the
+ground of just so much of the end of the rope as is necessary. If,
+on the other hand, any circumstances should cause undue levity, and
+consequent ascent, this levity is immediately counteracted by the
+additional weight of rope upraised from the earth. Thus, the balloon
+can neither ascend or descend, except within very narrow limits, and its
+resources, either in gas or ballast, remain comparatively unimpaired.
+When passing over an expanse of water, it becomes necessary to employ
+small kegs of copper or wood, filled with liquid ballast of a lighter
+nature than water. These float, and serve all the purposes of a mere
+rope on land. Another most important office of the guide-rope, is to
+point out the _direction_ of the balloon. The rope _drags_, either on
+land or sea, while the balloon is free; the latter, consequently, is
+always in advance, when any progress whatever is made: a comparison,
+therefore, by means of the compass, of the relative positions of the two
+objects, will always indicate the _course_. In the same way, the angle
+formed by the rope with the vertical axis of the machine, indicates
+the _velocity_. When there is _no_ angle--in other words, when the rope
+hangs perpendicularly, the whole apparatus is stationary; but the larger
+the angle, that is to say, the farther the balloon precedes the end of
+the rope, the greater the velocity; and the converse.
+
+“As the original design was to cross the British Channel, and alight as
+near Paris as possible, the voyagers had taken the precaution to prepare
+themselves with passports directed to all parts of the Continent,
+specifying the nature of the expedition, as in the case of the Nassau
+voyage, and entitling the adventurers to exemption from the usual
+formalities of office: unexpected events, however, rendered these
+passports superfluous.
+
+“The inflation was commenced very quietly at daybreak, on Saturday
+morning, the 6th instant, in the Court-Yard of Weal-Vor House, Mr.
+Osborne’s seat, about a mile from Penstruthal, in North Wales; and at 7
+minutes past 11, every thing being ready for departure, the balloon was
+set free, rising gently but steadily, in a direction nearly South; no
+use being made, for the first half hour, of either the screw or the
+rudder. We proceed now with the journal, as transcribed by Mr. Forsyth
+from the joint MSS. Of Mr. Monck Mason, and Mr. Ainsworth. The body of
+the journal, as given, is in the hand-writing of Mr. Mason, and a P.
+S. is appended, each day, by Mr. Ainsworth, who has in preparation, and
+will shortly give the public a more minute, and no doubt, a thrillingly
+interesting account of the voyage.
+
+“THE JOURNAL.
+
+“_Saturday, April the 6th_.--Every preparation likely to embarrass us,
+having been made over night, we commenced the inflation this morning at
+daybreak; but owing to a thick fog, which encumbered the folds of the
+silk and rendered it unmanageable, we did not get through before nearly
+eleven o’clock. Cut loose, then, in high spirits, and rose gently but
+steadily, with a light breeze at North, which bore us in the direction
+of the British Channel. Found the ascending force greater than we had
+expected; and as we arose higher and so got clear of the cliffs, and
+more in the sun’s rays, our ascent became very rapid. I did not wish,
+however, to lose gas at so early a period of the adventure, and so
+concluded to ascend for the present. We soon ran out our guide-rope;
+but even when we had raised it clear of the earth, we still went up very
+rapidly. The balloon was unusually steady, and looked beautifully. In
+about ten minutes after starting, the barometer indicated an altitude
+of 15,000 feet. The weather was remarkably fine, and the view of the
+subjacent country--a most romantic one when seen from any point,--was
+now especially sublime. The numerous deep gorges presented the
+appearance of lakes, on account of the dense vapors with which they
+were filled, and the pinnacles and crags to the South East, piled in
+inextricable confusion, resembling nothing so much as the giant cities
+of eastern fable. We were rapidly approaching the mountains in the
+South; but our elevation was more than sufficient to enable us to pass
+them in safety. In a few minutes we soared over them in fine style; and
+Mr. Ainsworth, with the seamen, was surprised at their apparent want of
+altitude when viewed from the car, the tendency of great elevation in a
+balloon being to reduce inequalities of the surface below, to nearly
+a dead level. At half-past eleven still proceeding nearly South, we
+obtained our first view of the Bristol Channel; and, in fifteen minutes
+afterward, the line of breakers on the coast appeared immediately
+beneath us, and we were fairly out at sea. We now resolved to let off
+enough gas to bring our guide-rope, with the buoys affixed, into the
+water. This was immediately done, and we commenced a gradual descent.
+In about twenty minutes our first buoy dipped, and at the touch of the
+second soon afterwards, we remained stationary as to elevation. We were
+all now anxious to test the efficiency of the rudder and screw, and we
+put them both into requisition forthwith, for the purpose of altering
+our direction more to the eastward, and in a line for Paris. By means of
+the rudder we instantly effected the necessary change of direction, and
+our course was brought nearly at right angles to that of the wind; when
+we set in motion the spring of the screw, and were rejoiced to find it
+propel us readily as desired. Upon this we gave nine hearty cheers, and
+dropped in the sea a bottle, enclosing a slip of parchment with a brief
+account of the principle of the invention. Hardly, however, had we
+done with our rejoicings, when an unforeseen accident occurred which
+discouraged us in no little degree. The steel rod connecting the spring
+with the propeller was suddenly jerked out of place, at the car end, (by
+a swaying of the car through some movement of one of the two seamen we
+had taken up,) and in an instant hung dangling out of reach, from the
+pivot of the axis of the screw. While we were endeavoring to regain it,
+our attention being completely absorbed, we became involved in a strong
+current of wind from the East, which bore us, with rapidly increasing
+force, towards the Atlantic. We soon found ourselves driving out to sea
+at the rate of not less, certainly, than fifty or sixty miles an hour,
+so that we came up with Cape Clear, at some forty miles to our North,
+before we had secured the rod, and had time to think what we were about.
+It was now that Mr. Ainsworth made an extraordinary, but to my fancy,
+a by no means unreasonable or chimerical proposition, in which he was
+instantly seconded by Mr. Holland--viz.: that we should take advantage
+of the strong gale which bore us on, and in place of beating back to
+Paris, make an attempt to reach the coast of North America. After slight
+reflection I gave a willing assent to this bold proposition, which
+(strange to say) met with objection from the two seamen only. As the
+stronger party, however, we overruled their fears, and kept resolutely
+upon our course. We steered due West; but as the trailing of the buoys
+materially impeded our progress, and we had the balloon abundantly at
+command, either for ascent or descent, we first threw out fifty pounds
+of ballast, and then wound up (by means of a windlass) so much of the
+rope as brought it quite clear of the sea. We perceived the effect of
+this manoeuvre immediately, in a vastly increased rate of progress; and,
+as the gale freshened, we flew with a velocity nearly inconceivable; the
+guide-rope flying out behind the car, like a streamer from a vessel. It
+is needless to say that a very short time sufficed us to lose sight of
+the coast. We passed over innumerable vessels of all kinds, a few of
+which were endeavoring to beat up, but the most of them lying to. We
+occasioned the greatest excitement on board all--an excitement greatly
+relished by ourselves, and especially by our two men, who, now under the
+influence of a dram of Geneva, seemed resolved to give all scruple, or
+fear, to the wind. Many of the vessels fired signal guns; and in all
+we were saluted with loud cheers (which we heard with surprising
+distinctness) and the waving of caps and handkerchiefs. We kept on in
+this manner throughout the day, with no material incident, and, as
+the shades of night closed around us, we made a rough estimate of the
+distance traversed. It could not have been less than five hundred
+miles, and was probably much more. The propeller was kept in constant
+operation, and, no doubt, aided our progress materially. As the sun
+went down, the gale freshened into an absolute hurricane, and the ocean
+beneath was clearly visible on account of its phosphorescence. The wind
+was from the East all night, and gave us the brightest omen of success.
+We suffered no little from cold, and the dampness of the atmosphere was
+most unpleasant; but the ample space in the car enabled us to lie down,
+and by means of cloaks and a few blankets, we did sufficiently well.
+
+“P.S. (by Mr. Ainsworth.) The last nine hours have been unquestionably
+the most exciting of my life. I can conceive nothing more sublimating
+than the strange peril and novelty of an adventure such as this. May
+God grant that we succeed! I ask not success for mere safety to my
+insignificant person, but for the sake of human knowledge and--for the
+vastness of the triumph. And yet the feat is only so evidently feasible
+that the sole wonder is why men have scrupled to attempt it before. One
+single gale such as now befriends us--let such a tempest whirl forward
+a balloon for four or five days (these gales often last longer) and the
+voyager will be easily borne, in that period, from coast to coast. In
+view of such a gale the broad Atlantic becomes a mere lake. I am more
+struck, just now, with the supreme silence which reigns in the
+sea beneath us, notwithstanding its agitation, than with any other
+phenomenon presenting itself. The waters give up no voice to
+the heavens. The immense flaming ocean writhes and is tortured
+uncomplainingly. The mountainous surges suggest the idea of innumerable
+dumb gigantic fiends struggling in impotent agony. In a night such as is
+this to me, a man _lives_--lives a whole century of ordinary life--nor
+would I forego this rapturous delight for that of a whole century of
+ordinary existence.
+
+“_Sunday, the seventh_. [Mr. Mason’s MS.] This morning the gale, by 10,
+had subsided to an eight or nine--knot breeze, (for a vessel at sea,)
+and bears us, perhaps, thirty miles per hour, or more. It has veered,
+however, very considerably to the north; and now, at sundown, we are
+holding our course due west, principally by the screw and rudder, which
+answer their purposes to admiration. I regard the project as thoroughly
+successful, and the easy navigation of the air in any direction (not
+exactly in the teeth of a gale) as no longer problematical. We could not
+have made head against the strong wind of yesterday; but, by ascending,
+we might have got out of its influence, if requisite. Against a pretty
+stiff breeze, I feel convinced, we can make our way with the propeller.
+At noon, to-day, ascended to an elevation of nearly 25,000 feet, by
+discharging ballast. Did this to search for a more direct current, but
+found none so favorable as the one we are now in. We have an abundance
+of gas to take us across this small pond, even should the voyage
+last three weeks. I have not the slightest fear for the result. The
+difficulty has been strangely exaggerated and misapprehended. I can
+choose my current, and should I find _all_ currents against me, I can
+make very tolerable headway with the propeller. We have had no incidents
+worth recording. The night promises fair.
+
+P.S. [By Mr. Ainsworth.] I have little to record, except the fact (to me
+quite a surprising one) that, at an elevation equal to that of Cotopaxi,
+I experienced neither very intense cold, nor headache, nor difficulty
+of breathing; neither, I find, did Mr. Mason, nor Mr. Holland, nor Sir
+Everard. Mr. Osborne complained of constriction of the chest--but this
+soon wore off. We have flown at a great rate during the day, and we
+must be more than half way across the Atlantic. We have passed over
+some twenty or thirty vessels of various kinds, and all seem to be
+delightfully astonished. Crossing the ocean in a balloon is not so
+difficult a feat after all. _Omne ignotum pro magnifico. Mem:_ at
+25,000 feet elevation the sky appears nearly black, and the stars are
+distinctly visible; while the sea does not seem convex (as one might
+suppose) but absolutely and most unequivocally _concave_.(*1)
+
+“_Monday, the 8th_. [Mr. Mason’s MS.] This morning we had again some
+little trouble with the rod of the propeller, which must be entirely
+remodelled, for fear of serious accident--I mean the steel rod--not
+the vanes. The latter could not be improved. The wind has been blowing
+steadily and strongly from the north-east all day and so far fortune
+seems bent upon favoring us. Just before day, we were all somewhat
+alarmed at some odd noises and concussions in the balloon, accompanied
+with the apparent rapid subsidence of the whole machine. These phenomena
+were occasioned by the expansion of the gas, through increase of heat in
+the atmosphere, and the consequent disruption of the minute particles of
+ice with which the network had become encrusted during the night. Threw
+down several bottles to the vessels below. Saw one of them picked up by
+a large ship--seemingly one of the New York line packets. Endeavored to
+make out her name, but could not be sure of it. Mr. Osborne’s telescope
+made it out something like “Atalanta.” It is now 12, at night, and we
+are still going nearly west, at a rapid pace. The sea is peculiarly
+phosphorescent.
+
+“P.S. [By Mr. Ainsworth.] It is now 2, A.M., and nearly calm, as well as
+I can judge--but it is very difficult to determine this point, since
+we move _with_ the air so completely. I have not slept since quitting
+Wheal-Vor, but can stand it no longer, and must take a nap. We cannot be
+far from the American coast.
+
+“_Tuesday, the _9_th_. [Mr. Ainsworth’s MS.] _One, P.M. We are in
+full view of the low coast of South Carolina_. The great problem is
+accomplished. We have crossed the Atlantic--fairly and _easily_
+crossed it in a balloon! God be praised! Who shall say that anything is
+impossible hereafter?”
+
+The Journal here ceases. Some particulars of the descent were
+communicated, however, by Mr. Ainsworth to Mr. Forsyth. It was nearly
+dead calm when the voyagers first came in view of the coast, which
+was immediately recognized by both the seamen, and by Mr. Osborne.
+The latter gentleman having acquaintances at Fort Moultrie, it was
+immediately resolved to descend in its vicinity. The balloon was brought
+over the beach (the tide being out and the sand hard, smooth, and
+admirably adapted for a descent,) and the grapnel let go, which took
+firm hold at once. The inhabitants of the island, and of the fort,
+thronged out, of course, to see the balloon; but it was with the
+greatest difficulty that any one could be made to credit the actual
+voyage--_the crossing of the Atlantic_. The grapnel caught at 2, P.M.,
+precisely; and thus the whole voyage was completed in seventy-five
+hours; or rather less, counting from shore to shore. No serious accident
+occurred. No real danger was at any time apprehended. The balloon was
+exhausted and secured without trouble; and when the MS.  from which this
+narrative is compiled was despatched from Charleston, the party were
+still at Fort Moultrie. Their farther intentions were not ascertained;
+but we can safely promise our readers some additional information either
+on Monday or in the course of the next day, at farthest.
+
+This is unquestionably the most stupendous, the most interesting, and
+the most important undertaking, ever accomplished or even attempted by
+man. What magnificent events may ensue, it would be useless now to think
+of determining.
+
+(*1) _Note_.--Mr. Ainsworth has not attempted to account for this
+phenomenon, which, however, is quite susceptible of explanation. A line
+dropped from an elevation of 25,000 feet, perpendicularly to the surface
+of the earth (or sea), would form the perpendicular of a right-angled
+triangle, of which the base would extend from the right angle to the
+horizon, and the hypothenuse from the horizon to the balloon. But the
+25,000 feet of altitude is little or nothing, in comparison with the
+extent of the prospect. In other words, the base and hypothenuse of the
+supposed triangle would be so long when compared with the perpendicular,
+that the two former may be regarded as nearly parallel. In this manner
+the horizon of the æronaut would appear to be _on a level_ with the
+car. But, as the point immediately beneath him seems, and is, at a great
+distance below him, it seems, of course, also, at a great distance below
+the horizon. Hence the impression of _concavity_; and this impression
+must remain, until the elevation shall bear so great a proportion to
+the extent of prospect, that the apparent parallelism of the base and
+hypothenuse disappears--when the earth’s real convexity must become
+apparent.
+
+
+
+
+MS. FOUND IN A BOTTLE
+
+               Qui n’a plus qu’un moment a vivre
+
+               N’a plus rien a dissimuler.
+
+                            --Quinault--Atys.
+
+OF my country and of my family I have little to say. Ill usage and
+length of years have driven me from the one, and estranged me from the
+other. Hereditary wealth afforded me an education of no common order,
+and a contemplative turn of mind enabled me to methodize the stores
+which early study very diligently garnered up.--Beyond all things,
+the study of the German moralists gave me great delight; not from any
+ill-advised admiration of their eloquent madness, but from the ease with
+which my habits of rigid thought enabled me to detect their falsities.
+I have often been reproached with the aridity of my genius; a deficiency
+of imagination has been imputed to me as a crime; and the Pyrrhonism
+of my opinions has at all times rendered me notorious. Indeed, a strong
+relish for physical philosophy has, I fear, tinctured my mind with
+a very common error of this age--I mean the habit of referring
+occurrences, even the least susceptible of such reference, to the
+principles of that science. Upon the whole, no person could be less
+liable than myself to be led away from the severe precincts of truth by
+the ignes fatui of superstition. I have thought proper to premise thus
+much, lest the incredible tale I have to tell should be considered
+rather the raving of a crude imagination, than the positive experience
+of a mind to which the reveries of fancy have been a dead letter and a
+nullity.
+
+After many years spent in foreign travel, I sailed in the year 18-- ,
+from the port of Batavia, in the rich and populous island of Java, on
+a voyage to the Archipelago of the Sunda islands. I went as
+passenger--having no other inducement than a kind of nervous
+restlessness which haunted me as a fiend.
+
+Our vessel was a beautiful ship of about four hundred tons,
+copper-fastened, and built at Bombay of Malabar teak. She was freighted
+with cotton-wool and oil, from the Lachadive islands. We had also on
+board coir, jaggeree, ghee, cocoa-nuts, and a few cases of opium. The
+stowage was clumsily done, and the vessel consequently crank.
+
+We got under way with a mere breath of wind, and for many days stood
+along the eastern coast of Java, without any other incident to beguile
+the monotony of our course than the occasional meeting with some of the
+small grabs of the Archipelago to which we were bound.
+
+One evening, leaning over the taffrail, I observed a very singular,
+isolated cloud, to the N.W. It was remarkable, as well for its color, as
+from its being the first we had seen since our departure from Batavia.
+I watched it attentively until sunset, when it spread all at once to
+the eastward and westward, girting in the horizon with a narrow strip
+of vapor, and looking like a long line of low beach. My notice was soon
+afterwards attracted by the dusky-red appearance of the moon, and the
+peculiar character of the sea. The latter was undergoing a rapid change,
+and the water seemed more than usually transparent. Although I could
+distinctly see the bottom, yet, heaving the lead, I found the ship in
+fifteen fathoms. The air now became intolerably hot, and was loaded with
+spiral exhalations similar to those arising from heat iron. As night
+came on, every breath of wind died away, an more entire calm it is
+impossible to conceive. The flame of a candle burned upon the poop
+without the least perceptible motion, and a long hair, held between the
+finger and thumb, hung without the possibility of detecting a vibration.
+However, as the captain said he could perceive no indication of danger,
+and as we were drifting in bodily to shore, he ordered the sails to
+be furled, and the anchor let go. No watch was set, and the crew,
+consisting principally of Malays, stretched themselves deliberately upon
+deck. I went below--not without a full presentiment of evil. Indeed,
+every appearance warranted me in apprehending a Simoom. I told the
+captain my fears; but he paid no attention to what I said, and left me
+without deigning to give a reply. My uneasiness, however, prevented me
+from sleeping, and about midnight I went upon deck.--As I placed my foot
+upon the upper step of the companion-ladder, I was startled by a
+loud, humming noise, like that occasioned by the rapid revolution of a
+mill-wheel, and before I could ascertain its meaning, I found the ship
+quivering to its centre. In the next instant, a wilderness of foam
+hurled us upon our beam-ends, and, rushing over us fore and aft, swept
+the entire decks from stem to stern.
+
+The extreme fury of the blast proved, in a great measure, the salvation
+of the ship. Although completely water-logged, yet, as her masts had
+gone by the board, she rose, after a minute, heavily from the sea, and,
+staggering awhile beneath the immense pressure of the tempest, finally
+righted.
+
+By what miracle I escaped destruction, it is impossible to say. Stunned
+by the shock of the water, I found myself, upon recovery, jammed in
+between the stern-post and rudder. With great difficulty I gained my
+feet, and looking dizzily around, was, at first, struck with the idea of
+our being among breakers; so terrific, beyond the wildest imagination,
+was the whirlpool of mountainous and foaming ocean within which we were
+engulfed. After a while, I heard the voice of an old Swede, who had
+shipped with us at the moment of our leaving port. I hallooed to
+him with all my strength, and presently he came reeling aft. We soon
+discovered that we were the sole survivors of the accident. All on deck,
+with the exception of ourselves, had been swept overboard;--the captain
+and mates must have perished as they slept, for the cabins were deluged
+with water. Without assistance, we could expect to do little for the
+security of the ship, and our exertions were at first paralyzed by the
+momentary expectation of going down. Our cable had, of course, parted
+like pack-thread, at the first breath of the hurricane, or we should
+have been instantaneously overwhelmed. We scudded with frightful
+velocity before the sea, and the water made clear breaches over us. The
+frame-work of our stern was shattered excessively, and, in almost every
+respect, we had received considerable injury; but to our extreme Joy we
+found the pumps unchoked, and that we had made no great shifting of
+our ballast. The main fury of the blast had already blown over, and we
+apprehended little danger from the violence of the wind; but we looked
+forward to its total cessation with dismay; well believing, that, in our
+shattered condition, we should inevitably perish in the tremendous swell
+which would ensue. But this very just apprehension seemed by no means
+likely to be soon verified. For five entire days and nights--during
+which our only subsistence was a small quantity of jaggeree, procured
+with great difficulty from the forecastle--the hulk flew at a rate
+defying computation, before rapidly succeeding flaws of wind, which,
+without equalling the first violence of the Simoom, were still more
+terrific than any tempest I had before encountered. Our course for the
+first four days was, with trifling variations, S.E. and by S.; and we
+must have run down the coast of New Holland.--On the fifth day the cold
+became extreme, although the wind had hauled round a point more to the
+northward.--The sun arose with a sickly yellow lustre, and clambered a
+very few degrees above the horizon--emitting no decisive light.--There
+were no clouds apparent, yet the wind was upon the increase, and blew
+with a fitful and unsteady fury. About noon, as nearly as we could
+guess, our attention was again arrested by the appearance of the sun.
+It gave out no light, properly so called, but a dull and sullen glow
+without reflection, as if all its rays were polarized. Just before
+sinking within the turgid sea, its central fires suddenly went out, as
+if hurriedly extinguished by some unaccountable power. It was a dim,
+sliver-like rim, alone, as it rushed down the unfathomable ocean.
+
+We waited in vain for the arrival of the sixth day--that day to me
+has not arrived--to the Swede, never did arrive. Thenceforward we were
+enshrouded in patchy darkness, so that we could not have seen an object
+at twenty paces from the ship. Eternal night continued to envelop us,
+all unrelieved by the phosphoric sea-brilliancy to which we had been
+accustomed in the tropics. We observed too, that, although the tempest
+continued to rage with unabated violence, there was no longer to be
+discovered the usual appearance of surf, or foam, which had hitherto
+attended us. All around were horror, and thick gloom, and a black
+sweltering desert of ebony.--Superstitious terror crept by degrees into
+the spirit of the old Swede, and my own soul was wrapped up in silent
+wonder. We neglected all care of the ship, as worse than useless, and
+securing ourselves, as well as possible, to the stump of the mizen-mast,
+looked out bitterly into the world of ocean. We had no means of
+calculating time, nor could we form any guess of our situation. We were,
+however, well aware of having made farther to the southward than any
+previous navigators, and felt great amazement at not meeting with the
+usual impediments of ice. In the meantime every moment threatened to be
+our last--every mountainous billow hurried to overwhelm us. The swell
+surpassed anything I had imagined possible, and that we were not
+instantly buried is a miracle. My companion spoke of the lightness of
+our cargo, and reminded me of the excellent qualities of our ship; but
+I could not help feeling the utter hopelessness of hope itself, and
+prepared myself gloomily for that death which I thought nothing could
+defer beyond an hour, as, with every knot of way the ship made,
+the swelling of the black stupendous seas became more dismally
+appalling. At times we gasped for breath at an elevation beyond the
+albatross--at times became dizzy with the velocity of our descent into
+some watery hell, where the air grew stagnant, and no sound disturbed
+the slumbers of the kraken.
+
+We were at the bottom of one of these abysses, when a quick scream
+from my companion broke fearfully upon the night. “See! see!” cried he,
+shrieking in my ears, “Almighty God! see! see!” As he spoke, I became
+aware of a dull, sullen glare of red light which streamed down the sides
+of the vast chasm where we lay, and threw a fitful brilliancy upon our
+deck. Casting my eyes upwards, I beheld a spectacle which froze the
+current of my blood. At a terrific height directly above us, and upon
+the very verge of the precipitous descent, hovered a gigantic ship of,
+perhaps, four thousand tons. Although upreared upon the summit of a wave
+more than a hundred times her own altitude, her apparent size exceeded
+that of any ship of the line or East Indiaman in existence. Her huge
+hull was of a deep dingy black, unrelieved by any of the customary
+carvings of a ship. A single row of brass cannon protruded from her open
+ports, and dashed from their polished surfaces the fires of innumerable
+battle-lanterns, which swung to and fro about her rigging. But what
+mainly inspired us with horror and astonishment, was that she bore up
+under a press of sail in the very teeth of that supernatural sea, and of
+that ungovernable hurricane. When we first discovered her, her bows
+were alone to be seen, as she rose slowly from the dim and horrible gulf
+beyond her. For a moment of intense terror she paused upon the giddy
+pinnacle, as if in contemplation of her own sublimity, then trembled and
+tottered, and--came down.
+
+At this instant, I know not what sudden self-possession came over my
+spirit. Staggering as far aft as I could, I awaited fearlessly the ruin
+that was to overwhelm. Our own vessel was at length ceasing from her
+struggles, and sinking with her head to the sea. The shock of the
+descending mass struck her, consequently, in that portion of her frame
+which was already under water, and the inevitable result was to hurl me,
+with irresistible violence, upon the rigging of the stranger.
+
+As I fell, the ship hove in stays, and went about; and to the confusion
+ensuing I attributed my escape from the notice of the crew. With little
+difficulty I made my way unperceived to the main hatchway, which was
+partially open, and soon found an opportunity of secreting myself in the
+hold. Why I did so I can hardly tell. An indefinite sense of awe, which
+at first sight of the navigators of the ship had taken hold of my mind,
+was perhaps the principle of my concealment. I was unwilling to trust
+myself with a race of people who had offered, to the cursory glance I
+had taken, so many points of vague novelty, doubt, and apprehension. I
+therefore thought proper to contrive a hiding-place in the hold. This I
+did by removing a small portion of the shifting-boards, in such a manner
+as to afford me a convenient retreat between the huge timbers of the
+ship.
+
+I had scarcely completed my work, when a footstep in the hold forced me
+to make use of it. A man passed by my place of concealment with a feeble
+and unsteady gait. I could not see his face, but had an opportunity
+of observing his general appearance. There was about it an evidence of
+great age and infirmity. His knees tottered beneath a load of years, and
+his entire frame quivered under the burthen. He muttered to himself,
+in a low broken tone, some words of a language which I could not
+understand, and groped in a corner among a pile of singular-looking
+instruments, and decayed charts of navigation. His manner was a wild
+mixture of the peevishness of second childhood, and the solemn dignity
+of a God. He at length went on deck, and I saw him no more.
+
+* * * * *
+
+A feeling, for which I have no name, has taken possession of my soul
+--a sensation which will admit of no analysis, to which the lessons of
+bygone times are inadequate, and for which I fear futurity itself
+will offer me no key. To a mind constituted like my own, the latter
+consideration is an evil. I shall never--I know that I shall
+never--be satisfied with regard to the nature of my conceptions. Yet it
+is not wonderful that these conceptions are indefinite, since they have
+their origin in sources so utterly novel. A new sense--a new entity is
+added to my soul.
+
+* * * * *
+
+It is long since I first trod the deck of this terrible ship, and the
+rays of my destiny are, I think, gathering to a focus. Incomprehensible
+men! Wrapped up in meditations of a kind which I cannot divine, they
+pass me by unnoticed. Concealment is utter folly on my part, for the
+people will not see. It was but just now that I passed directly before
+the eyes of the mate--it was no long while ago that I ventured into the
+captain’s own private cabin, and took thence the materials with which
+I write, and have written. I shall from time to time continue this
+Journal. It is true that I may not find an opportunity of transmitting
+it to the world, but I will not fall to make the endeavour. At the last
+moment I will enclose the MS. in a bottle, and cast it within the sea.
+
+* * * * *
+
+An incident has occurred which has given me new room for meditation. Are
+such things the operation of ungoverned Chance? I had ventured upon deck
+and thrown myself down, without attracting any notice, among a pile of
+ratlin-stuff and old sails in the bottom of the yawl. While musing upon
+the singularity of my fate, I unwittingly daubed with a tar-brush the
+edges of a neatly-folded studding-sail which lay near me on a barrel.
+The studding-sail is now bent upon the ship, and the thoughtless touches
+of the brush are spread out into the word DISCOVERY.
+
+I have made many observations lately upon the structure of the vessel.
+Although well armed, she is not, I think, a ship of war. Her rigging,
+build, and general equipment, all negative a supposition of this
+kind. What she is not, I can easily perceive--what she is I fear it is
+impossible to say. I know not how it is, but in scrutinizing her strange
+model and singular cast of spars, her huge size and overgrown suits
+of canvas, her severely simple bow and antiquated stern, there will
+occasionally flash across my mind a sensation of familiar things, and
+there is always mixed up with such indistinct shadows of recollection,
+an unaccountable memory of old foreign chronicles and ages long ago.
+
+* * * * *
+
+I have been looking at the timbers of the ship. She is built of a
+material to which I am a stranger. There is a peculiar character about
+the wood which strikes me as rendering it unfit for the purpose to
+which it has been applied. I mean its extreme porousness, considered
+independently by the worm-eaten condition which is a consequence of
+navigation in these seas, and apart from the rottenness attendant upon
+age. It will appear perhaps an observation somewhat over-curious, but
+this wood would have every characteristic of Spanish oak, if Spanish oak
+were distended by any unnatural means.
+
+In reading the above sentence a curious apothegm of an old
+weather-beaten Dutch navigator comes full upon my recollection. “It
+is as sure,” he was wont to say, when any doubt was entertained of his
+veracity, “as sure as there is a sea where the ship itself will grow in
+bulk like the living body of the seaman.”
+
+* * * * *
+
+About an hour ago, I made bold to thrust myself among a group of the
+crew. They paid me no manner of attention, and, although I stood in the
+very midst of them all, seemed utterly unconscious of my presence. Like
+the one I had at first seen in the hold, they all bore about them the
+marks of a hoary old age. Their knees trembled with infirmity; their
+shoulders were bent double with decrepitude; their shrivelled skins
+rattled in the wind; their voices were low, tremulous and broken; their
+eyes glistened with the rheum of years; and their gray hairs streamed
+terribly in the tempest. Around them, on every part of the deck, lay
+scattered mathematical instruments of the most quaint and obsolete
+construction.
+
+* * * * *
+
+I mentioned some time ago the bending of a studding-sail. From that
+period the ship, being thrown dead off the wind, has continued her
+terrific course due south, with every rag of canvas packed upon her,
+from her trucks to her lower studding-sail booms, and rolling every
+moment her top-gallant yard-arms into the most appalling hell of water
+which it can enter into the mind of a man to imagine. I have just left
+the deck, where I find it impossible to maintain a footing, although the
+crew seem to experience little inconvenience. It appears to me a miracle
+of miracles that our enormous bulk is not swallowed up at once and
+forever. We are surely doomed to hover continually upon the brink of
+Eternity, without taking a final plunge into the abyss. From billows a
+thousand times more stupendous than any I have ever seen, we glide away
+with the facility of the arrowy sea-gull; and the colossal waters rear
+their heads above us like demons of the deep, but like demons confined
+to simple threats and forbidden to destroy. I am led to attribute these
+frequent escapes to the only natural cause which can account for such
+effect.--I must suppose the ship to be within the influence of some
+strong current, or impetuous under-tow.
+
+* * * * *
+
+I have seen the captain face to face, and in his own cabin--but, as I
+expected, he paid me no attention. Although in his appearance there is,
+to a casual observer, nothing which might bespeak him more or less than
+man--still a feeling of irrepressible reverence and awe mingled with the
+sensation of wonder with which I regarded him. In stature he is nearly
+my own height; that is, about five feet eight inches. He is of a
+well-knit and compact frame of body, neither robust nor remarkably
+otherwise. But it is the singularity of the expression which reigns upon
+the face--it is the intense, the wonderful, the thrilling evidence of
+old age, so utter, so extreme, which excites within my spirit a sense--a
+sentiment ineffable. His forehead, although little wrinkled, seems to
+bear upon it the stamp of a myriad of years.--His gray hairs are records
+of the past, and his grayer eyes are Sybils of the future. The cabin
+floor was thickly strewn with strange, iron-clasped folios, and
+mouldering instruments of science, and obsolete long-forgotten charts.
+His head was bowed down upon his hands, and he pored, with a fiery
+unquiet eye, over a paper which I took to be a commission, and which, at
+all events, bore the signature of a monarch. He muttered to himself, as
+did the first seaman whom I saw in the hold, some low peevish syllables
+of a foreign tongue, and although the speaker was close at my elbow, his
+voice seemed to reach my ears from the distance of a mile.
+
+* * * * *
+
+The ship and all in it are imbued with the spirit of Eld. The crew glide
+to and fro like the ghosts of buried centuries; their eyes have an eager
+and uneasy meaning; and when their fingers fall athwart my path in the
+wild glare of the battle-lanterns, I feel as I have never felt before,
+although I have been all my life a dealer in antiquities, and have
+imbibed the shadows of fallen columns at Balbec, and Tadmor, and
+Persepolis, until my very soul has become a ruin.
+
+* * * * *
+
+When I look around me I feel ashamed of my former apprehensions. If I
+trembled at the blast which has hitherto attended us, shall I not stand
+aghast at a warring of wind and ocean, to convey any idea of which
+the words tornado and simoom are trivial and ineffective? All in the
+immediate vicinity of the ship is the blackness of eternal night, and a
+chaos of foamless water; but, about a league on either side of us, may
+be seen, indistinctly and at intervals, stupendous ramparts of ice,
+towering away into the desolate sky, and looking like the walls of the
+universe.
+
+* * * * *
+
+As I imagined, the ship proves to be in a current; if that appellation
+can properly be given to a tide which, howling and shrieking by the
+white ice, thunders on to the southward with a velocity like the
+headlong dashing of a cataract.
+
+* * * * *
+
+To conceive the horror of my sensations is, I presume, utterly
+impossible; yet a curiosity to penetrate the mysteries of these awful
+regions, predominates even over my despair, and will reconcile me to the
+most hideous aspect of death. It is evident that we are hurrying onwards
+to some exciting knowledge--some never-to-be-imparted secret, whose
+attainment is destruction. Perhaps this current leads us to the southern
+pole itself. It must be confessed that a supposition apparently so wild
+has every probability in its favor.
+
+* * * * *
+
+The crew pace the deck with unquiet and tremulous step; but there is
+upon their countenances an expression more of the eagerness of hope than
+of the apathy of despair.
+
+In the meantime the wind is still in our poop, and, as we carry a crowd
+of canvas, the ship is at times lifted bodily from out the sea--Oh,
+horror upon horror! the ice opens suddenly to the right, and to the
+left, and we are whirling dizzily, in immense concentric circles, round
+and round the borders of a gigantic amphitheatre, the summit of whose
+walls is lost in the darkness and the distance. But little time will be
+left me to ponder upon my destiny--the circles rapidly grow small--we
+are plunging madly within the grasp of the whirlpool--and amid a
+roaring, and bellowing, and thundering of ocean and of tempest, the ship
+is quivering, oh God! and--going down.
+
+NOTE.--The “MS. Found in a Bottle,” was originally published in 1831,
+and it was not until many years afterwards that I became acquainted with
+the maps of Mercator, in which the ocean is represented as rushing, by
+four mouths, into the (northern) Polar Gulf, to be absorbed into the
+bowels of the earth; the Pole itself being represented by a black rock,
+towering to a prodigious height.
+
+
+
+
+THE OVAL PORTRAIT
+
+THE chateau into which my valet had ventured to make forcible entrance,
+rather than permit me, in my desperately wounded condition, to pass a
+night in the open air, was one of those piles of commingled gloom and
+grandeur which have so long frowned among the Appennines, not less in
+fact than in the fancy of Mrs. Radcliffe. To all appearance it had been
+temporarily and very lately abandoned. We established ourselves in one
+of the smallest and least sumptuously furnished apartments. It lay in a
+remote turret of the building. Its decorations were rich, yet tattered
+and antique. Its walls were hung with tapestry and bedecked with
+manifold and multiform armorial trophies, together with an unusually
+great number of very spirited modern paintings in frames of rich golden
+arabesque. In these paintings, which depended from the walls not only
+in their main surfaces, but in very many nooks which the bizarre
+architecture of the chateau rendered necessary--in these paintings my
+incipient delirium, perhaps, had caused me to take deep interest; so
+that I bade Pedro to close the heavy shutters of the room--since it was
+already night--to light the tongues of a tall candelabrum which stood by
+the head of my bed--and to throw open far and wide the fringed curtains
+of black velvet which enveloped the bed itself. I wished all this done
+that I might resign myself, if not to sleep, at least alternately to the
+contemplation of these pictures, and the perusal of a small volume which
+had been found upon the pillow, and which purported to criticise and
+describe them.
+
+Long--long I read--and devoutly, devotedly I gazed. Rapidly and
+gloriously the hours flew by and the deep midnight came. The position of
+the candelabrum displeased me, and outreaching my hand with difficulty,
+rather than disturb my slumbering valet, I placed it so as to throw its
+rays more fully upon the book.
+
+But the action produced an effect altogether unanticipated. The rays of
+the numerous candles (for there were many) now fell within a niche of
+the room which had hitherto been thrown into deep shade by one of the
+bed-posts. I thus saw in vivid light a picture all unnoticed before. It
+was the portrait of a young girl just ripening into womanhood. I glanced
+at the painting hurriedly, and then closed my eyes. Why I did this
+was not at first apparent even to my own perception. But while my lids
+remained thus shut, I ran over in my mind my reason for so shutting
+them. It was an impulsive movement to gain time for thought--to make
+sure that my vision had not deceived me--to calm and subdue my fancy for
+a more sober and more certain gaze. In a very few moments I again looked
+fixedly at the painting.
+
+That I now saw aright I could not and would not doubt; for the first
+flashing of the candles upon that canvas had seemed to dissipate the
+dreamy stupor which was stealing over my senses, and to startle me at
+once into waking life.
+
+The portrait, I have already said, was that of a young girl. It was a
+mere head and shoulders, done in what is technically termed a vignette
+manner; much in the style of the favorite heads of Sully. The arms, the
+bosom, and even the ends of the radiant hair melted imperceptibly into
+the vague yet deep shadow which formed the back-ground of the whole. The
+frame was oval, richly gilded and filigreed in Moresque. As a thing of
+art nothing could be more admirable than the painting itself. But it
+could have been neither the execution of the work, nor the immortal
+beauty of the countenance, which had so suddenly and so vehemently moved
+me. Least of all, could it have been that my fancy, shaken from its half
+slumber, had mistaken the head for that of a living person. I saw at
+once that the peculiarities of the design, of the vignetting, and of the
+frame, must have instantly dispelled such idea--must have prevented even
+its momentary entertainment. Thinking earnestly upon these points, I
+remained, for an hour perhaps, half sitting, half reclining, with my
+vision riveted upon the portrait. At length, satisfied with the true
+secret of its effect, I fell back within the bed. I had found the spell
+of the picture in an absolute life-likeliness of expression, which, at
+first startling, finally confounded, subdued, and appalled me. With deep
+and reverent awe I replaced the candelabrum in its former position. The
+cause of my deep agitation being thus shut from view, I sought eagerly
+the volume which discussed the paintings and their histories. Turning
+to the number which designated the oval portrait, I there read the vague
+and quaint words which follow:
+
+“She was a maiden of rarest beauty, and not more lovely than full of
+glee. And evil was the hour when she saw, and loved, and wedded the
+painter. He, passionate, studious, austere, and having already a bride
+in his Art; she a maiden of rarest beauty, and not more lovely than full
+of glee; all light and smiles, and frolicsome as the young fawn; loving
+and cherishing all things; hating only the Art which was her rival;
+dreading only the pallet and brushes and other untoward instruments
+which deprived her of the countenance of her lover. It was thus a
+terrible thing for this lady to hear the painter speak of his desire to
+portray even his young bride. But she was humble and obedient, and sat
+meekly for many weeks in the dark, high turret-chamber where the light
+dripped upon the pale canvas only from overhead. But he, the painter,
+took glory in his work, which went on from hour to hour, and from day to
+day. And he was a passionate, and wild, and moody man, who became lost
+in reveries; so that he would not see that the light which fell so
+ghastly in that lone turret withered the health and the spirits of his
+bride, who pined visibly to all but him. Yet she smiled on and still on,
+uncomplainingly, because she saw that the painter (who had high renown)
+took a fervid and burning pleasure in his task, and wrought day and
+night to depict her who so loved him, yet who grew daily more dispirited
+and weak. And in sooth some who beheld the portrait spoke of its
+resemblance in low words, as of a mighty marvel, and a proof not less of
+the power of the painter than of his deep love for her whom he depicted
+so surpassingly well. But at length, as the labor drew nearer to its
+conclusion, there were admitted none into the turret; for the painter
+had grown wild with the ardor of his work, and turned his eyes from
+canvas merely, even to regard the countenance of his wife. And he would
+not see that the tints which he spread upon the canvas were drawn from
+the cheeks of her who sate beside him. And when many weeks had passed,
+and but little remained to do, save one brush upon the mouth and one
+tint upon the eye, the spirit of the lady again flickered up as the
+flame within the socket of the lamp. And then the brush was given,
+and then the tint was placed; and, for one moment, the painter stood
+entranced before the work which he had wrought; but in the next, while
+he yet gazed, he grew tremulous and very pallid, and aghast, and crying
+with a loud voice, ‘This is indeed Life itself!’ turned suddenly to
+regard his beloved:--She was dead!”
+
+
+
+
+
+
+
+End of Project Gutenberg’s The Works of Edgar Allan Poe, by Edgar Allan Poe
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE ***
+
+***** This file should be named 2147-0.txt or 2147-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/1/4/2147/
+
+Produced by David Widger and Carlo Traverso
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/frankenstein.txt
+++ b/jet/tf-idf/src/main/resources/books/frankenstein.txt
@@ -1,0 +1,7653 @@
+﻿Project Gutenberg's Frankenstein, by Mary Wollstonecraft (Godwin) Shelley
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: Frankenstein
+       or The Modern Prometheus
+
+Author: Mary Wollstonecraft (Godwin) Shelley
+
+Release Date: June 17, 2008 [EBook #84]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+
+
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+
+
+
+
+
+
+
+
+Frankenstein,
+
+or the Modern Prometheus
+
+
+by
+
+Mary Wollstonecraft (Godwin) Shelley
+
+
+
+
+Letter 1
+
+
+St. Petersburgh, Dec. 11th, 17--
+
+TO Mrs. Saville, England
+
+You will rejoice to hear that no disaster has accompanied the
+commencement of an enterprise which you have regarded with such evil
+forebodings.  I arrived here yesterday, and my first task is to assure
+my dear sister of my welfare and increasing confidence in the success
+of my undertaking.
+
+I am already far north of London, and as I walk in the streets of
+Petersburgh, I feel a cold northern breeze play upon my cheeks, which
+braces my nerves and fills me with delight.  Do you understand this
+feeling?  This breeze, which has travelled from the regions towards
+which I am advancing, gives me a foretaste of those icy climes.
+Inspirited by this wind of promise, my daydreams become more fervent
+and vivid.  I try in vain to be persuaded that the pole is the seat of
+frost and desolation; it ever presents itself to my imagination as the
+region of beauty and delight.  There, Margaret, the sun is forever
+visible, its broad disk just skirting the horizon and diffusing a
+perpetual splendour.  There--for with your leave, my sister, I will put
+some trust in preceding navigators--there snow and frost are banished;
+and, sailing over a calm sea, we may be wafted to a land surpassing in
+wonders and in beauty every region hitherto discovered on the habitable
+globe.  Its productions and features may be without example, as the
+phenomena of the heavenly bodies undoubtedly are in those undiscovered
+solitudes.  What may not be expected in a country of eternal light?  I
+may there discover the wondrous power which attracts the needle and may
+regulate a thousand celestial observations that require only this
+voyage to render their seeming eccentricities consistent forever.  I
+shall satiate my ardent curiosity with the sight of a part of the world
+never before visited, and may tread a land never before imprinted by
+the foot of man. These are my enticements, and they are sufficient to
+conquer all fear of danger or death and to induce me to commence this
+laborious voyage with the joy a child feels when he embarks in a little
+boat, with his holiday mates, on an expedition of discovery up his
+native river. But supposing all these conjectures to be false, you
+cannot contest the inestimable benefit which I shall confer on all
+mankind, to the last generation, by discovering a passage near the pole
+to those countries, to reach which at present so many months are
+requisite; or by ascertaining the secret of the magnet, which, if at
+all possible, can only be effected by an undertaking such as mine.
+
+These reflections have dispelled the agitation with which I began my
+letter, and I feel my heart glow with an enthusiasm which elevates me
+to heaven, for nothing contributes so much to tranquillize the mind as
+a steady purpose--a point on which the soul may fix its intellectual
+eye.  This expedition has been the favourite dream of my early years. I
+have read with ardour the accounts of the various voyages which have
+been made in the prospect of arriving at the North Pacific Ocean
+through the seas which surround the pole.  You may remember that a
+history of all the voyages made for purposes of discovery composed the
+whole of our good Uncle Thomas' library.  My education was neglected,
+yet I was passionately fond of reading.  These volumes were my study
+day and night, and my familiarity with them increased that regret which
+I had felt, as a child, on learning that my father's dying injunction
+had forbidden my uncle to allow me to embark in a seafaring life.
+
+These visions faded when I perused, for the first time, those poets
+whose effusions entranced my soul and lifted it to heaven.  I also
+became a poet and for one year lived in a paradise of my own creation;
+I imagined that I also might obtain a niche in the temple where the
+names of Homer and Shakespeare are consecrated.  You are well
+acquainted with my failure and how heavily I bore the disappointment.
+But just at that time I inherited the fortune of my cousin, and my
+thoughts were turned into the channel of their earlier bent.
+
+Six years have passed since I resolved on my present undertaking.  I
+can, even now, remember the hour from which I dedicated myself to this
+great enterprise.  I commenced by inuring my body to hardship.  I
+accompanied the whale-fishers on several expeditions to the North Sea;
+I voluntarily endured cold, famine, thirst, and want of sleep; I often
+worked harder than the common sailors during the day and devoted my
+nights to the study of mathematics, the theory of medicine, and those
+branches of physical science from which a naval adventurer might derive
+the greatest practical advantage.  Twice I actually hired myself as an
+under-mate in a Greenland whaler, and acquitted myself to admiration. I
+must own I felt a little proud when my captain offered me the second
+dignity in the vessel and entreated me to remain with the greatest
+earnestness, so valuable did he consider my services.  And now, dear
+Margaret, do I not deserve to accomplish some great purpose?  My life
+might have been passed in ease and luxury, but I preferred glory to
+every enticement that wealth placed in my path.  Oh, that some
+encouraging voice would answer in the affirmative!  My courage and my
+resolution is firm; but my hopes fluctuate, and my spirits are often
+depressed.  I am about to proceed on a long and difficult voyage, the
+emergencies of which will demand all my fortitude:  I am required not
+only to raise the spirits of others, but sometimes to sustain my own,
+when theirs are failing.
+
+This is the most favourable period for travelling in Russia.  They fly
+quickly over the snow in their sledges; the motion is pleasant, and, in
+my opinion, far more agreeable than that of an English stagecoach.  The
+cold is not excessive, if you are wrapped in furs--a dress which I have
+already adopted, for there is a great difference between walking the
+deck and remaining seated motionless for hours, when no exercise
+prevents the blood from actually freezing in your veins.  I have no
+ambition to lose my life on the post-road between St. Petersburgh and
+Archangel. I shall depart for the latter town in a fortnight or three
+weeks; and my intention is to hire a ship there, which can easily be
+done by paying the insurance for the owner, and to engage as many
+sailors as I think necessary among those who are accustomed to the
+whale-fishing.  I do not intend to sail until the month of June; and
+when shall I return?  Ah, dear sister, how can I answer this question?
+If I succeed, many, many months, perhaps years, will pass before you
+and I may meet.  If I fail, you will see me again soon, or never.
+Farewell, my dear, excellent Margaret. Heaven shower down blessings on
+you, and save me, that I may again and again testify my gratitude for
+all your love and kindness.
+
+Your affectionate brother,
+  R. Walton
+
+
+
+Letter 2
+
+
+Archangel, 28th March, 17--
+
+To Mrs. Saville, England
+
+How slowly the time passes here, encompassed as I am by frost and snow!
+Yet a second step is taken towards my enterprise.  I have hired a
+vessel and am occupied in collecting my sailors; those whom I have
+already engaged appear to be men on whom I can depend and are certainly
+possessed of dauntless courage.
+
+But I have one want which I have never yet been able to satisfy, and
+the absence of the object of which I now feel as a most severe evil, I
+have no friend, Margaret:  when I am glowing with the enthusiasm of
+success, there will be none to participate my joy; if I am assailed by
+disappointment, no one will endeavour to sustain me in dejection. I
+shall commit my thoughts to paper, it is true; but that is a poor
+medium for the communication of feeling.  I desire the company of a man
+who could sympathize with me, whose eyes would reply to mine. You may
+deem me romantic, my dear sister, but I bitterly feel the want of a
+friend.  I have no one near me, gentle yet courageous, possessed of a
+cultivated as well as of a capacious mind, whose tastes are like my
+own, to approve or amend my plans.  How would such a friend repair the
+faults of your poor brother!  I am too ardent in execution and too
+impatient of difficulties.  But it is a still greater evil to me that I
+am self-educated:  for the first fourteen years of my life I ran wild
+on a common and read nothing but our Uncle Thomas' books of voyages. At
+that age I became acquainted with the celebrated poets of our own
+country; but it was only when it had ceased to be in my power to derive
+its most important benefits from such a conviction that I perceived the
+necessity of becoming acquainted with more languages than that of my
+native country.  Now I am twenty-eight and am in reality more
+illiterate than many schoolboys of fifteen.  It is true that I have
+thought more and that my daydreams are more extended and magnificent,
+but they want (as the painters call it) KEEPING; and I greatly need a
+friend who would have sense enough not to despise me as romantic, and
+affection enough for me to endeavour to regulate my mind.  Well, these
+are useless complaints; I shall certainly find no friend on the wide
+ocean, nor even here in Archangel, among merchants and seamen.  Yet
+some feelings, unallied to the dross of human nature, beat even in
+these rugged bosoms.  My lieutenant, for instance, is a man of
+wonderful courage and enterprise; he is madly desirous of glory, or
+rather, to word my phrase more characteristically, of advancement in
+his profession.  He is an Englishman, and in the midst of national and
+professional prejudices, unsoftened by cultivation, retains some of the
+noblest endowments of humanity.  I first became acquainted with him on
+board a whale vessel; finding that he was unemployed in this city, I
+easily engaged him to assist in my enterprise.  The master is a person
+of an excellent disposition and is remarkable in the ship for his
+gentleness and the mildness of his discipline.  This circumstance,
+added to his well-known integrity and dauntless courage, made me very
+desirous to engage him.  A youth passed in solitude, my best years
+spent under your gentle and feminine fosterage, has so refined the
+groundwork of my character that I cannot overcome an intense distaste
+to the usual brutality exercised on board ship:  I have never believed
+it to be necessary, and when I heard of a mariner equally noted for his
+kindliness of heart and the respect and obedience paid to him by his
+crew, I felt myself peculiarly fortunate in being able to secure his
+services.  I heard of him first in rather a romantic manner, from a
+lady who owes to him the happiness of her life.  This, briefly, is his
+story.  Some years ago he loved a young Russian lady of moderate
+fortune, and having amassed a considerable sum in prize-money, the
+father of the girl consented to the match.  He saw his mistress once
+before the destined ceremony; but she was bathed in tears, and throwing
+herself at his feet, entreated him to spare her, confessing at the same
+time that she loved another, but that he was poor, and that her father
+would never consent to the union.  My generous friend reassured the
+suppliant, and on being informed of the name of her lover, instantly
+abandoned his pursuit.  He had already bought a farm with his money, on
+which he had designed to pass the remainder of his life; but he
+bestowed the whole on his rival, together with the remains of his
+prize-money to purchase stock, and then himself solicited the young
+woman's father to consent to her marriage with her lover.  But the old
+man decidedly refused, thinking himself bound in honour to my friend,
+who, when he found the father inexorable, quitted his country, nor
+returned until he heard that his former mistress was married according
+to her inclinations.  "What a noble fellow!" you will exclaim.  He is
+so; but then he is wholly uneducated:  he is as silent as a Turk, and a
+kind of ignorant carelessness attends him, which, while it renders his
+conduct the more astonishing, detracts from the interest and sympathy
+which otherwise he would command.
+
+Yet do not suppose, because I complain a little or because I can
+conceive a consolation for my toils which I may never know, that I am
+wavering in my resolutions.  Those are as fixed as fate, and my voyage
+is only now delayed until the weather shall permit my embarkation.  The
+winter has been dreadfully severe, but the spring promises well, and it
+is considered as a remarkably early season, so that perhaps I may sail
+sooner than I expected.  I shall do nothing rashly:  you know me
+sufficiently to confide in my prudence and considerateness whenever the
+safety of others is committed to my care.
+
+I cannot describe to you my sensations on the near prospect of my
+undertaking.  It is impossible to communicate to you a conception of
+the trembling sensation, half pleasurable and half fearful, with which
+I am preparing to depart.  I am going to unexplored regions, to "the
+land of mist and snow," but I shall kill no albatross; therefore do not
+be alarmed for my safety or if I should come back to you as worn and
+woeful as the "Ancient Mariner."  You will smile at my allusion, but I
+will disclose a secret.  I have often attributed my attachment to, my
+passionate enthusiasm for, the dangerous mysteries of ocean to that
+production of the most imaginative of modern poets.  There is something
+at work in my soul which I do not understand.  I am practically
+industrious--painstaking, a workman to execute with perseverance and
+labour--but besides this there is a love for the marvellous, a belief
+in the marvellous, intertwined in all my projects, which hurries me out
+of the common pathways of men, even to the wild sea and unvisited
+regions I am about to explore. But to return to dearer considerations.
+Shall I meet you again, after having traversed immense seas, and
+returned by the most southern cape of Africa or America?  I dare not
+expect such success, yet I cannot bear to look on the reverse of the
+picture.  Continue for the present to write to me by every opportunity:
+I may receive your letters on some occasions when I need them most to
+support my spirits.  I love you very tenderly.  Remember me with
+affection, should you never hear from me again.
+
+Your affectionate brother,
+  Robert Walton
+
+
+
+Letter 3
+
+
+
+July 7th, 17--
+
+To Mrs. Saville, England
+
+My dear Sister,
+
+I write a few lines in haste to say that I am safe--and well advanced
+on my voyage.  This letter will reach England by a merchantman now on
+its homeward voyage from Archangel; more fortunate than I, who may not
+see my native land, perhaps, for many years.  I am, however, in good
+spirits:  my men are bold and apparently firm of purpose, nor do the
+floating sheets of ice that continually pass us, indicating the dangers
+of the region towards which we are advancing, appear to dismay them. We
+have already reached a very high latitude; but it is the height of
+summer, and although not so warm as in England, the southern gales,
+which blow us speedily towards those shores which I so ardently desire
+to attain, breathe a degree of renovating warmth which I had not
+expected.
+
+No incidents have hitherto befallen us that would make a figure in a
+letter.  One or two stiff gales and the springing of a leak are
+accidents which experienced navigators scarcely remember to record, and
+I shall be well content if nothing worse happen to us during our voyage.
+
+Adieu, my dear Margaret.  Be assured that for my own sake, as well as
+yours, I will not rashly encounter danger.  I will be cool,
+persevering, and prudent.
+
+But success SHALL crown my endeavours.  Wherefore not?  Thus far I have
+gone, tracing a secure way over the pathless seas, the very stars
+themselves being witnesses and testimonies of my triumph.  Why not
+still proceed over the untamed yet obedient element?  What can stop the
+determined heart and resolved will of man?
+
+My swelling heart involuntarily pours itself out thus.  But I must
+finish.  Heaven bless my beloved sister!
+
+R.W.
+
+
+
+Letter 4
+
+
+
+August 5th, 17--
+
+To Mrs. Saville, England
+
+So strange an accident has happened to us that I cannot forbear
+recording it, although it is very probable that you will see me before
+these papers can come into your possession.
+
+Last Monday (July 31st) we were nearly surrounded by ice, which closed
+in the ship on all sides, scarcely leaving her the sea-room in which
+she floated.  Our situation was somewhat dangerous, especially as we
+were compassed round by a very thick fog.  We accordingly lay to,
+hoping that some change would take place in the atmosphere and weather.
+
+About two o'clock the mist cleared away, and we beheld, stretched out
+in every direction, vast and irregular plains of ice, which seemed to
+have no end.  Some of my comrades groaned, and my own mind began to
+grow watchful with anxious thoughts, when a strange sight suddenly
+attracted our attention and diverted our solicitude from our own
+situation.  We perceived a low carriage, fixed on a sledge and drawn by
+dogs, pass on towards the north, at the distance of half a mile; a
+being which had the shape of a man, but apparently of gigantic stature,
+sat in the sledge and guided the dogs.  We watched the rapid progress
+of the traveller with our telescopes until he was lost among the
+distant inequalities of the ice.  This appearance excited our
+unqualified wonder.  We were, as we believed, many hundred miles from
+any land; but this apparition seemed to denote that it was not, in
+reality, so distant as we had supposed.  Shut in, however, by ice, it
+was impossible to follow his track, which we had observed with the
+greatest attention.  About two hours after this occurrence we heard the
+ground sea, and before night the ice broke and freed our ship.  We,
+however, lay to until the morning, fearing to encounter in the dark
+those large loose masses which float about after the breaking up of the
+ice.  I profited of this time to rest for a few hours.
+
+In the morning, however, as soon as it was light, I went upon deck and
+found all the sailors busy on one side of the vessel, apparently
+talking to someone in the sea.  It was, in fact, a sledge, like that we
+had seen before, which had drifted towards us in the night on a large
+fragment of ice.  Only one dog remained alive; but there was a human
+being within it whom the sailors were persuading to enter the vessel.
+He was not, as the other traveller seemed to be, a savage inhabitant of
+some undiscovered island, but a European.  When I appeared on deck the
+master said, "Here is our captain, and he will not allow you to perish
+on the open sea."
+
+On perceiving me, the stranger addressed me in English, although with a
+foreign accent.  "Before I come on board your vessel," said he, "will
+you have the kindness to inform me whither you are bound?"
+
+You may conceive my astonishment on hearing such a question addressed
+to me from a man on the brink of destruction and to whom I should have
+supposed that my vessel would have been a resource which he would not
+have exchanged for the most precious wealth the earth can afford.  I
+replied, however, that we were on a voyage of discovery towards the
+northern pole.
+
+Upon hearing this he appeared satisfied and consented to come on board.
+Good God!  Margaret, if you had seen the man who thus capitulated for
+his safety, your surprise would have been boundless.  His limbs were
+nearly frozen, and his body dreadfully emaciated by fatigue and
+suffering.  I never saw a man in so wretched a condition.  We attempted
+to carry him into the cabin, but as soon as he had quitted the fresh
+air he fainted.  We accordingly brought him back to the deck and
+restored him to animation by rubbing him with brandy and forcing him to
+swallow a small quantity.  As soon as he showed signs of life we
+wrapped him up in blankets and placed him near the chimney of the
+kitchen stove.  By slow degrees he recovered and ate a little soup,
+which restored him wonderfully.
+
+Two days passed in this manner before he was able to speak, and I often
+feared that his sufferings had deprived him of understanding.  When he
+had in some measure recovered, I removed him to my own cabin and
+attended on him as much as my duty would permit.  I never saw a more
+interesting creature:  his eyes have generally an expression of
+wildness, and even madness, but there are moments when, if anyone
+performs an act of kindness towards him or does him any the most
+trifling service, his whole countenance is lighted up, as it were, with
+a beam of benevolence and sweetness that I never saw equalled.  But he
+is generally melancholy and despairing, and sometimes he gnashes his
+teeth, as if impatient of the weight of woes that oppresses him.
+
+When my guest was a little recovered I had great trouble to keep off
+the men, who wished to ask him a thousand questions; but I would not
+allow him to be tormented by their idle curiosity, in a state of body
+and mind whose restoration evidently depended upon entire repose.
+Once, however, the lieutenant asked why he had come so far upon the ice
+in so strange a vehicle.
+
+His countenance instantly assumed an aspect of the deepest gloom, and
+he replied, "To seek one who fled from me."
+
+"And did the man whom you pursued travel in the same fashion?"
+
+"Yes."
+
+"Then I fancy we have seen him, for the day before we picked you up we
+saw some dogs drawing a sledge, with a man in it, across the ice."
+
+This aroused the stranger's attention, and he asked a multitude of
+questions concerning the route which the demon, as he called him, had
+pursued.  Soon after, when he was alone with me, he said, "I have,
+doubtless, excited your curiosity, as well as that of these good
+people; but you are too considerate to make inquiries."
+
+"Certainly; it would indeed be very impertinent and inhuman in me to
+trouble you with any inquisitiveness of mine."
+
+"And yet you rescued me from a strange and perilous situation; you have
+benevolently restored me to life."
+
+Soon after this he inquired if I thought that the breaking up of the
+ice had destroyed the other sledge.  I replied that I could not answer
+with any degree of certainty, for the ice had not broken until near
+midnight, and the traveller might have arrived at a place of safety
+before that time; but of this I could not judge.  From this time a new
+spirit of life animated the decaying frame of the stranger.  He
+manifested the greatest eagerness to be upon deck to watch for the
+sledge which had before appeared; but I have persuaded him to remain in
+the cabin, for he is far too weak to sustain the rawness of the
+atmosphere.  I have promised that someone should watch for him and give
+him instant notice if any new object should appear in sight.
+
+Such is my journal of what relates to this strange occurrence up to the
+present day.  The stranger has gradually improved in health but is very
+silent and appears uneasy when anyone except myself enters his cabin.
+Yet his manners are so conciliating and gentle that the sailors are all
+interested in him, although they have had very little communication
+with him.  For my own part, I begin to love him as a brother, and his
+constant and deep grief fills me with sympathy and compassion.  He must
+have been a noble creature in his better days, being even now in wreck
+so attractive and amiable.  I said in one of my letters, my dear
+Margaret, that I should find no friend on the wide ocean; yet I have
+found a man who, before his spirit had been broken by misery, I should
+have been happy to have possessed as the brother of my heart.
+
+I shall continue my journal concerning the stranger at intervals,
+should I have any fresh incidents to record.
+
+
+August 13th, 17--
+
+My affection for my guest increases every day.  He excites at once my
+admiration and my pity to an astonishing degree.  How can I see so
+noble a creature destroyed by misery without feeling the most poignant
+grief?  He is so gentle, yet so wise; his mind is so cultivated, and
+when he speaks, although his words are culled with the choicest art,
+yet they flow with rapidity and unparalleled eloquence.  He is now much
+recovered from his illness and is continually on the deck, apparently
+watching for the sledge that preceded his own.  Yet, although unhappy,
+he is not so utterly occupied by his own misery but that he interests
+himself deeply in the projects of others.  He has frequently conversed
+with me on mine, which I have communicated to him without disguise.  He
+entered attentively into all my arguments in favour of my eventual
+success and into every minute detail of the measures I had taken to
+secure it.  I was easily led by the sympathy which he evinced to use
+the language of my heart, to give utterance to the burning ardour of my
+soul and to say, with all the fervour that warmed me, how gladly I
+would sacrifice my fortune, my existence, my every hope, to the
+furtherance of my enterprise.  One man's life or death were but a small
+price to pay for the acquirement of the knowledge which I sought, for
+the dominion I should acquire and transmit over the elemental foes of
+our race.  As I spoke, a dark gloom spread over my listener's
+countenance.  At first I perceived that he tried to suppress his
+emotion; he placed his hands before his eyes, and my voice quivered and
+failed me as I beheld tears trickle fast from between his fingers; a
+groan burst from his heaving breast.  I paused; at length he spoke, in
+broken accents:  "Unhappy man!  Do you share my madness?  Have you
+drunk also of the intoxicating draught?  Hear me; let me reveal my
+tale, and you will dash the cup from your lips!"
+
+Such words, you may imagine, strongly excited my curiosity; but the
+paroxysm of grief that had seized the stranger overcame his weakened
+powers, and many hours of repose and tranquil conversation were
+necessary to restore his composure.  Having conquered the violence of
+his feelings, he appeared to despise himself for being the slave of
+passion; and quelling the dark tyranny of despair, he led me again to
+converse concerning myself personally.  He asked me the history of my
+earlier years.  The tale was quickly told, but it awakened various
+trains of reflection.  I spoke of my desire of finding a friend, of my
+thirst for a more intimate sympathy with a fellow mind than had ever
+fallen to my lot, and expressed my conviction that a man could boast of
+little happiness who did not enjoy this blessing.  "I agree with you,"
+replied the stranger; "we are unfashioned creatures, but half made up,
+if one wiser, better, dearer than ourselves--such a friend ought to
+be--do not lend his aid to perfectionate our weak and faulty natures. I
+once had a friend, the most noble of human creatures, and am entitled,
+therefore, to judge respecting friendship.  You have hope, and the
+world before you, and have no cause for despair.  But I--I have lost
+everything and cannot begin life anew."
+
+As he said this his countenance became expressive of a calm, settled
+grief that touched me to the heart.  But he was silent and presently
+retired to his cabin.
+
+Even broken in spirit as he is, no one can feel more deeply than he
+does the beauties of nature.  The starry sky, the sea, and every sight
+afforded by these wonderful regions seem still to have the power of
+elevating his soul from earth.  Such a man has a double existence:  he
+may suffer misery and be overwhelmed by disappointments, yet when he
+has retired into himself, he will be like a celestial spirit that has a
+halo around him, within whose circle no grief or folly ventures.
+
+Will you smile at the enthusiasm I express concerning this divine
+wanderer?  You would not if you saw him.  You have been tutored and
+refined by books and retirement from the world, and you are therefore
+somewhat fastidious; but this only renders you the more fit to
+appreciate the extraordinary merits of this wonderful man.  Sometimes I
+have endeavoured to discover what quality it is which he possesses that
+elevates him so immeasurably above any other person I ever knew.  I
+believe it to be an intuitive discernment, a quick but never-failing
+power of judgment, a penetration into the causes of things, unequalled
+for clearness and precision; add to this a facility of expression and a
+voice whose varied intonations are soul-subduing music.
+
+
+August 19, 17--
+
+Yesterday the stranger said to me, "You may easily perceive, Captain
+Walton, that I have suffered great and unparalleled misfortunes.  I had
+determined at one time that the memory of these evils should die with
+me, but you have won me to alter my determination.  You seek for
+knowledge and wisdom, as I once did; and I ardently hope that the
+gratification of your wishes may not be a serpent to sting you, as mine
+has been.  I do not know that the relation of my disasters will be
+useful to you; yet, when I reflect that you are pursuing the same
+course, exposing yourself to the same dangers which have rendered me
+what I am, I imagine that you may deduce an apt moral from my tale, one
+that may direct you if you succeed in your undertaking and console you
+in case of failure.  Prepare to hear of occurrences which are usually
+deemed marvellous.  Were we among the tamer scenes of nature I might
+fear to encounter your unbelief, perhaps your ridicule; but many things
+will appear possible in these wild and mysterious regions which would
+provoke the laughter of those unacquainted with the ever-varied powers
+of nature; nor can I doubt but that my tale conveys in its series
+internal evidence of the truth of the events of which it is composed."
+
+You may easily imagine that I was much gratified by the offered
+communication, yet I could not endure that he should renew his grief by
+a recital of his misfortunes.  I felt the greatest eagerness to hear
+the promised narrative, partly from curiosity and partly from a strong
+desire to ameliorate his fate if it were in my power.  I expressed
+these feelings in my answer.
+
+"I thank you," he replied, "for your sympathy, but it is useless; my
+fate is nearly fulfilled.  I wait but for one event, and then I shall
+repose in peace.  I understand your feeling," continued he, perceiving
+that I wished to interrupt him; "but you are mistaken, my friend, if
+thus you will allow me to name you; nothing can alter my destiny;
+listen to my history, and you will perceive how irrevocably it is
+determined."
+
+He then told me that he would commence his narrative the next day when
+I should be at leisure.  This promise drew from me the warmest thanks.
+I have resolved every night, when I am not imperatively occupied by my
+duties, to record, as nearly as possible in his own words, what he has
+related during the day.  If I should be engaged, I will at least make
+notes.  This manuscript will doubtless afford you the greatest
+pleasure; but to me, who know him, and who hear it from his own
+lips--with what interest and sympathy shall I read it in some future
+day!  Even now, as I commence my task, his full-toned voice swells in
+my ears; his lustrous eyes dwell on me with all their melancholy
+sweetness; I see his thin hand raised in animation, while the
+lineaments of his face are irradiated by the soul within.
+
+Strange and harrowing must be his story, frightful the storm which
+embraced the gallant vessel on its course and wrecked it--thus!
+
+
+
+Chapter 1
+
+I am by birth a Genevese, and my family is one of the most
+distinguished of that republic.  My ancestors had been for many years
+counsellors and syndics, and my father had filled several public
+situations with honour and reputation.  He was respected by all who
+knew him for his integrity and indefatigable attention to public
+business.  He passed his younger days perpetually occupied by the
+affairs of his country; a variety of circumstances had prevented his
+marrying early, nor was it until the decline of life that he became a
+husband and the father of a family.
+
+As the circumstances of his marriage illustrate his character, I cannot
+refrain from relating them.  One of his most intimate friends was a
+merchant who, from a flourishing state, fell, through numerous
+mischances, into poverty.  This man, whose name was Beaufort, was of a
+proud and unbending disposition and could not bear to live in poverty
+and oblivion in the same country where he had formerly been
+distinguished for his rank and magnificence.  Having paid his debts,
+therefore, in the most honourable manner, he retreated with his
+daughter to the town of Lucerne, where he lived unknown and in
+wretchedness.  My father loved Beaufort with the truest friendship and
+was deeply grieved by his retreat in these unfortunate circumstances.
+He bitterly deplored the false pride which led his friend to a conduct
+so little worthy of the affection that united them.  He lost no time in
+endeavouring to seek him out, with the hope of persuading him to begin
+the world again through his credit and assistance.
+
+Beaufort had taken effectual measures to conceal himself, and it was ten
+months before my father discovered his abode.  Overjoyed at this
+discovery, he hastened to the house, which was situated in a mean street
+near the Reuss.  But when he entered, misery and despair alone welcomed
+him.  Beaufort had saved but a very small sum of money from the wreck of
+his fortunes, but it was sufficient to provide him with sustenance for
+some months, and in the meantime he hoped to procure some respectable
+employment in a merchant's house.  The interval was, consequently, spent
+in inaction; his grief only became more deep and rankling when he had
+leisure for reflection, and at length it took so fast hold of his mind
+that at the end of three months he lay on a bed of sickness, incapable
+of any exertion.
+
+His daughter attended him with the greatest tenderness, but she saw
+with despair that their little fund was rapidly decreasing and that
+there was no other prospect of support.  But Caroline Beaufort
+possessed a mind of an uncommon mould, and her courage rose to support
+her in her adversity.  She procured plain work; she plaited straw and
+by various means contrived to earn a pittance scarcely sufficient to
+support life.
+
+Several months passed in this manner.  Her father grew worse; her time
+was more entirely occupied in attending him; her means of subsistence
+decreased; and in the tenth month her father died in her arms, leaving
+her an orphan and a beggar.  This last blow overcame her, and she knelt
+by Beaufort's coffin weeping bitterly, when my father entered the
+chamber.  He came like a protecting spirit to the poor girl, who
+committed herself to his care; and after the interment of his friend he
+conducted her to Geneva and placed her under the protection of a
+relation.  Two years after this event Caroline became his wife.
+
+There was a considerable difference between the ages of my parents, but
+this circumstance seemed to unite them only closer in bonds of devoted
+affection.  There was a sense of justice in my father's upright mind
+which rendered it necessary that he should approve highly to love
+strongly.  Perhaps during former years he had suffered from the
+late-discovered unworthiness of one beloved and so was disposed to set
+a greater value on tried worth.  There was a show of gratitude and
+worship in his attachment to my mother, differing wholly from the
+doting fondness of age, for it was inspired by reverence for her
+virtues and a desire to be the means of, in some degree, recompensing
+her for the sorrows she had endured, but which gave inexpressible grace
+to his behaviour to her.  Everything was made to yield to her wishes
+and her convenience.  He strove to shelter her, as a fair exotic is
+sheltered by the gardener, from every rougher wind and to surround her
+with all that could tend to excite pleasurable emotion in her soft and
+benevolent mind.  Her health, and even the tranquillity of her hitherto
+constant spirit, had been shaken by what she had gone through.  During
+the two years that had elapsed previous to their marriage my father had
+gradually relinquished all his public functions; and immediately after
+their union they sought the pleasant climate of Italy, and the change
+of scene and interest attendant on a tour through that land of wonders,
+as a restorative for her weakened frame.
+
+From Italy they visited Germany and France.  I, their eldest child, was
+born at Naples, and as an infant accompanied them in their rambles.  I
+remained for several years their only child.  Much as they were
+attached to each other, they seemed to draw inexhaustible stores of
+affection from a very mine of love to bestow them upon me.  My mother's
+tender caresses and my father's smile of benevolent pleasure while
+regarding me are my first recollections.  I was their plaything and
+their idol, and something better--their child, the innocent and
+helpless creature bestowed on them by heaven, whom to bring up to good,
+and whose future lot it was in their hands to direct to happiness or
+misery, according as they fulfilled their duties towards me.  With this
+deep consciousness of what they owed towards the being to which they
+had given life, added to the active spirit of tenderness that animated
+both, it may be imagined that while during every hour of my infant life
+I received a lesson of patience, of charity, and of self-control, I was
+so guided by a silken cord that all seemed but one train of enjoyment
+to me. For a long time I was their only care.  My mother had much
+desired to have a daughter, but I continued their single offspring.
+When I was about five years old, while making an excursion beyond the
+frontiers of Italy, they passed a week on the shores of the Lake of
+Como.  Their benevolent disposition often made them enter the cottages
+of the poor.  This, to my mother, was more than a duty; it was a
+necessity, a passion--remembering what she had suffered, and how she
+had been relieved--for her to act in her turn the guardian angel to the
+afflicted.  During one of their walks a poor cot in the foldings of a
+vale attracted their notice as being singularly disconsolate, while the
+number of half-clothed children gathered about it spoke of penury in
+its worst shape.  One day, when my father had gone by himself to Milan,
+my mother, accompanied by me, visited this abode.  She found a peasant
+and his wife, hard working, bent down by care and labour, distributing
+a scanty meal to five hungry babes.  Among these there was one which
+attracted my mother far above all the rest.  She appeared of a
+different stock.  The four others were dark-eyed, hardy little
+vagrants; this child was thin and very fair.  Her hair was the
+brightest living gold, and despite the poverty of her clothing, seemed
+to set a crown of distinction on her head.  Her brow was clear and
+ample, her blue eyes cloudless, and her lips and the moulding of her
+face so expressive of sensibility and sweetness that none could behold
+her without looking on her as of a distinct species, a being
+heaven-sent, and bearing a celestial stamp in all her features. The
+peasant woman, perceiving that my mother fixed eyes of wonder and
+admiration on this lovely girl, eagerly communicated her history.  She
+was not her child, but the daughter of a Milanese nobleman.  Her mother
+was a German and had died on giving her birth.  The infant had been
+placed with these good people to nurse:  they were better off then.
+They had not been long married, and their eldest child was but just
+born.  The father of their charge was one of those Italians nursed in
+the memory of the antique glory of Italy--one among the schiavi ognor
+frementi, who exerted himself to obtain the liberty of his country.  He
+became the victim of its weakness.  Whether he had died or still
+lingered in the dungeons of Austria was not known.  His property was
+confiscated; his child became an orphan and a beggar.  She continued
+with her foster parents and bloomed in their rude abode, fairer than a
+garden rose among dark-leaved brambles.  When my father returned from
+Milan, he found playing with me in the hall of our villa a child fairer
+than pictured cherub--a creature who seemed to shed radiance from her
+looks and whose form and motions were lighter than the chamois of the
+hills.  The apparition was soon explained.  With his permission my
+mother prevailed on her rustic guardians to yield their charge to her.
+They were fond of the sweet orphan.  Her presence had seemed a blessing
+to them, but it would be unfair to her to keep her in poverty and want
+when Providence afforded her such powerful protection.  They consulted
+their village priest, and the result was that Elizabeth Lavenza became
+the inmate of my parents' house--my more than sister--the beautiful and
+adored companion of all my occupations and my pleasures.
+
+Everyone loved Elizabeth.  The passionate and almost reverential
+attachment with which all regarded her became, while I shared it, my
+pride and my delight.  On the evening previous to her being brought to
+my home, my mother had said playfully, "I have a pretty present for my
+Victor--tomorrow he shall have it."  And when, on the morrow, she
+presented Elizabeth to me as her promised gift, I, with childish
+seriousness, interpreted her words literally and looked upon Elizabeth
+as mine--mine to protect, love, and cherish.  All praises bestowed on
+her I received as made to a possession of my own.  We called each other
+familiarly by the name of cousin.  No word, no expression could body
+forth the kind of relation in which she stood to me--my more than
+sister, since till death she was to be mine only.
+
+
+
+Chapter 2
+
+We were brought up together; there was not quite a year difference in
+our ages.  I need not say that we were strangers to any species of
+disunion or dispute.  Harmony was the soul of our companionship, and
+the diversity and contrast that subsisted in our characters drew us
+nearer together.  Elizabeth was of a calmer and more concentrated
+disposition; but, with all my ardour, I was capable of a more intense
+application and was more deeply smitten with the thirst for knowledge.
+She busied herself with following the aerial creations of the poets;
+and in the majestic and wondrous scenes which surrounded our Swiss home
+--the sublime shapes of the mountains, the changes of the seasons,
+tempest and calm, the silence of winter, and the life and turbulence of
+our Alpine summers--she found ample scope for admiration and delight.
+While my companion contemplated with a serious and satisfied spirit the
+magnificent appearances of things, I delighted in investigating their
+causes.  The world was to me a secret which I desired to divine.
+Curiosity, earnest research to learn the hidden laws of nature,
+gladness akin to rapture, as they were unfolded to me, are among the
+earliest sensations I can remember.
+
+On the birth of a second son, my junior by seven years, my parents gave
+up entirely their wandering life and fixed themselves in their native
+country.  We possessed a house in Geneva, and a campagne on Belrive,
+the eastern shore of the lake, at the distance of rather more than a
+league from the city.  We resided principally in the latter, and the
+lives of my parents were passed in considerable seclusion.  It was my
+temper to avoid a crowd and to attach myself fervently to a few.  I was
+indifferent, therefore, to my school-fellows in general; but I united
+myself in the bonds of the closest friendship to one among them.  Henry
+Clerval was the son of a merchant of Geneva.  He was a boy of singular
+talent and fancy.  He loved enterprise, hardship, and even danger for
+its own sake.  He was deeply read in books of chivalry and romance.  He
+composed heroic songs and began to write many a tale of enchantment and
+knightly adventure.  He tried to make us act plays and to enter into
+masquerades, in which the characters were drawn from the heroes of
+Roncesvalles, of the Round Table of King Arthur, and the chivalrous
+train who shed their blood to redeem the holy sepulchre from the hands
+of the infidels.
+
+No human being could have passed a happier childhood than myself.  My
+parents were possessed by the very spirit of kindness and indulgence.
+We felt that they were not the tyrants to rule our lot according to
+their caprice, but the agents and creators of all the many delights
+which we enjoyed.  When I mingled with other families I distinctly
+discerned how peculiarly fortunate my lot was, and gratitude assisted
+the development of filial love.
+
+My temper was sometimes violent, and my passions vehement; but by some
+law in my temperature they were turned not towards childish pursuits
+but to an eager desire to learn, and not to learn all things
+indiscriminately.  I confess that neither the structure of languages,
+nor the code of governments, nor the politics of various states
+possessed attractions for me.  It was the secrets of heaven and earth
+that I desired to learn; and whether it was the outward substance of
+things or the inner spirit of nature and the mysterious soul of man
+that occupied me, still my inquiries were directed to the metaphysical,
+or in its highest sense, the physical secrets of the world.
+
+Meanwhile Clerval occupied himself, so to speak, with the moral
+relations of things.  The busy stage of life, the virtues of heroes,
+and the actions of men were his theme; and his hope and his dream was
+to become one among those whose names are recorded in story as the
+gallant and adventurous benefactors of our species.  The saintly soul
+of Elizabeth shone like a shrine-dedicated lamp in our peaceful home.
+Her sympathy was ours; her smile, her soft voice, the sweet glance of
+her celestial eyes, were ever there to bless and animate us.  She was
+the living spirit of love to soften and attract; I might have become
+sullen in my study, rough through the ardour of my nature, but that
+she was there to subdue me to a semblance of her own gentleness.  And
+Clerval--could aught ill entrench on the noble spirit of Clerval?  Yet
+he might not have been so perfectly humane, so thoughtful in his
+generosity, so full of kindness and tenderness amidst his passion for
+adventurous exploit, had she not unfolded to him the real loveliness of
+beneficence and made the doing good the end and aim of his soaring
+ambition.
+
+I feel exquisite pleasure in dwelling on the recollections of
+childhood, before misfortune had tainted my mind and changed its bright
+visions of extensive usefulness into gloomy and narrow reflections upon
+self.  Besides, in drawing the picture of my early days, I also record
+those events which led, by insensible steps, to my after tale of
+misery, for when I would account to myself for the birth of that
+passion which afterwards ruled my destiny I find it arise, like a
+mountain river, from ignoble and almost forgotten sources; but,
+swelling as it proceeded, it became the torrent which, in its course,
+has swept away all my hopes and joys.  Natural philosophy is the genius
+that has regulated my fate; I desire, therefore, in this narration, to
+state those facts which led to my predilection for that science.  When
+I was thirteen years of age we all went on a party of pleasure to the
+baths near Thonon; the inclemency of the weather obliged us to remain a
+day confined to the inn.  In this house I chanced to find a volume of
+the works of Cornelius Agrippa.  I opened it with apathy; the theory
+which he attempts to demonstrate and the wonderful facts which he
+relates soon changed this feeling into enthusiasm.  A new light seemed
+to dawn upon my mind, and bounding with joy, I communicated my
+discovery to my father.  My father looked carelessly at the title page
+of my book and said, "Ah!  Cornelius Agrippa!  My dear Victor, do not
+waste your time upon this; it is sad trash."
+
+If, instead of this remark, my father had taken the pains to explain to
+me that the principles of Agrippa had been entirely exploded and that a
+modern system of science had been introduced which possessed much
+greater powers than the ancient, because the powers of the latter were
+chimerical, while those of the former were real and practical, under
+such circumstances I should certainly have thrown Agrippa aside and
+have contented my imagination, warmed as it was, by returning with
+greater ardour to my former studies.  It is even possible that the
+train of my ideas would never have received the fatal impulse that led
+to my ruin.  But the cursory glance my father had taken of my volume by
+no means assured me that he was acquainted with its contents, and I
+continued to read with the greatest avidity.  When I returned home my
+first care was to procure the whole works of this author, and
+afterwards of Paracelsus and Albertus Magnus.  I read and studied the
+wild fancies of these writers with delight; they appeared to me
+treasures known to few besides myself.  I have described myself as
+always having been imbued with a fervent longing to penetrate the
+secrets of nature.  In spite of the intense labour and wonderful
+discoveries of modern philosophers, I always came from my studies
+discontented and unsatisfied.  Sir Isaac Newton is said to have avowed
+that he felt like a child picking up shells beside the great and
+unexplored ocean of truth.  Those of his successors in each branch of
+natural philosophy with whom I was acquainted appeared even to my boy's
+apprehensions as tyros engaged in the same pursuit.
+
+The untaught peasant beheld the elements around him and was acquainted
+with their practical uses.  The most learned philosopher knew little
+more.  He had partially unveiled the face of Nature, but her immortal
+lineaments were still a wonder and a mystery.  He might dissect,
+anatomize, and give names; but, not to speak of a final cause, causes
+in their secondary and tertiary grades were utterly unknown to him.  I
+had gazed upon the fortifications and impediments that seemed to keep
+human beings from entering the citadel of nature, and rashly and
+ignorantly I had repined.
+
+But here were books, and here were men who had penetrated deeper and
+knew more.  I took their word for all that they averred, and I became
+their disciple.  It may appear strange that such should arise in the
+eighteenth century; but while I followed the routine of education in
+the schools of Geneva, I was, to a great degree, self-taught with
+regard to my favourite studies.  My father was not scientific, and I
+was left to struggle with a child's blindness, added to a student's
+thirst for knowledge.  Under the guidance of my new preceptors I
+entered with the greatest diligence into the search of the
+philosopher's stone and the elixir of life; but the latter soon
+obtained my undivided attention.  Wealth was an inferior object, but
+what glory would attend the discovery if I could banish disease from
+the human frame and render man invulnerable to any but a violent death!
+Nor were these my only visions.  The raising of ghosts or devils was a
+promise liberally accorded by my favourite authors, the fulfilment of
+which I most eagerly sought; and if my incantations were always
+unsuccessful, I attributed the failure rather to my own inexperience
+and mistake than to a want of skill or fidelity in my instructors.  And
+thus for a time I was occupied by exploded systems, mingling, like an
+unadept, a thousand contradictory theories and floundering desperately
+in a very slough of multifarious knowledge, guided by an ardent
+imagination and childish reasoning, till an accident again changed the
+current of my ideas.  When I was about fifteen years old we had retired
+to our house near Belrive, when we witnessed a most violent and
+terrible thunderstorm.  It advanced from behind the mountains of Jura,
+and the thunder burst at once with frightful loudness from various
+quarters of the heavens.  I remained, while the storm lasted, watching
+its progress with curiosity and delight.  As I stood at the door, on a
+sudden I beheld a stream of fire issue from an old and beautiful oak
+which stood about twenty yards from our house; and so soon as the
+dazzling light vanished, the oak had disappeared, and nothing remained
+but a blasted stump.  When we visited it the next morning, we found the
+tree shattered in a singular manner.  It was not splintered by the
+shock, but entirely reduced to thin ribbons of wood.  I never beheld
+anything so utterly destroyed.
+
+Before this I was not unacquainted with the more obvious laws of
+electricity.  On this occasion a man of great research in natural
+philosophy was with us, and excited by this catastrophe, he entered on
+the explanation of a theory which he had formed on the subject of
+electricity and galvanism, which was at once new and astonishing to me.
+All that he said threw greatly into the shade Cornelius Agrippa,
+Albertus Magnus, and Paracelsus, the lords of my imagination; but by
+some fatality the overthrow of these men disinclined me to pursue my
+accustomed studies.  It seemed to me as if nothing would or could ever
+be known.  All that had so long engaged my attention suddenly grew
+despicable.  By one of those caprices of the mind which we are perhaps
+most subject to in early youth, I at once gave up my former
+occupations, set down natural history and all its progeny as a deformed
+and abortive creation, and entertained the greatest disdain for a
+would-be science which could never even step within the threshold of
+real knowledge.  In this mood of mind I betook myself to the
+mathematics and the branches of study appertaining to that science as
+being built upon secure foundations, and so worthy of my consideration.
+
+Thus strangely are our souls constructed, and by such slight ligaments
+are we bound to prosperity or ruin.  When I look back, it seems to me
+as if this almost miraculous change of inclination and will was the
+immediate suggestion of the guardian angel of my life--the last effort
+made by the spirit of preservation to avert the storm that was even
+then hanging in the stars and ready to envelop me.  Her victory was
+announced by an unusual tranquillity and gladness of soul which
+followed the relinquishing of my ancient and latterly tormenting
+studies.  It was thus that I was to be taught to associate evil with
+their prosecution, happiness with their disregard.
+
+It was a strong effort of the spirit of good, but it was ineffectual.
+Destiny was too potent, and her immutable laws had decreed my utter and
+terrible destruction.
+
+
+
+Chapter 3
+
+When I had attained the age of seventeen my parents resolved that I
+should become a student at the university of Ingolstadt.  I had
+hitherto attended the schools of Geneva, but my father thought it
+necessary for the completion of my education that I should be made
+acquainted with other customs than those of my native country.  My
+departure was therefore fixed at an early date, but before the day
+resolved upon could arrive, the first misfortune of my life
+occurred--an omen, as it were, of my future misery.  Elizabeth had
+caught the scarlet fever; her illness was severe, and she was in the
+greatest danger.  During her illness many arguments had been urged to
+persuade my mother to refrain from attending upon her.  She had at
+first yielded to our entreaties, but when she heard that the life of
+her favourite was menaced, she could no longer control her anxiety. She
+attended her sickbed; her watchful attentions triumphed over the
+malignity of the distemper--Elizabeth was saved, but the consequences
+of this imprudence were fatal to her preserver.  On the third day my
+mother sickened; her fever was accompanied by the most alarming
+symptoms, and the looks of her medical attendants prognosticated the
+worst event.  On her deathbed the fortitude and benignity of this best
+of women did not desert her.  She joined the hands of Elizabeth and
+myself.  "My children," she said, "my firmest hopes of future happiness
+were placed on the prospect of your union.  This expectation will now
+be the consolation of your father.  Elizabeth, my love, you must supply
+my place to my younger children.  Alas!  I regret that I am taken from
+you; and, happy and beloved as I have been, is it not hard to quit you
+all?  But these are not thoughts befitting me; I will endeavour to
+resign myself cheerfully to death and will indulge a hope of meeting
+you in another world."
+
+She died calmly, and her countenance expressed affection even in death.
+I need not describe the feelings of those whose dearest ties are rent
+by that most irreparable evil, the void that presents itself to the
+soul, and the despair that is exhibited on the countenance.  It is so
+long before the mind can persuade itself that she whom we saw every day
+and whose very existence appeared a part of our own can have departed
+forever--that the brightness of a beloved eye can have been
+extinguished and the sound of a voice so familiar and dear to the ear
+can be hushed, never more to be heard.  These are the reflections of
+the first days; but when the lapse of time proves the reality of the
+evil, then the actual bitterness of grief commences.  Yet from whom has
+not that rude hand rent away some dear connection?  And why should I
+describe a sorrow which all have felt, and must feel?  The time at
+length arrives when grief is rather an indulgence than a necessity; and
+the smile that plays upon the lips, although it may be deemed a
+sacrilege, is not banished.  My mother was dead, but we had still
+duties which we ought to perform; we must continue our course with the
+rest and learn to think ourselves fortunate whilst one remains whom the
+spoiler has not seized.
+
+My departure for Ingolstadt, which had been deferred by these events,
+was now again determined upon.  I obtained from my father a respite of
+some weeks.  It appeared to me sacrilege so soon to leave the repose,
+akin to death, of the house of mourning and to rush into the thick of
+life.  I was new to sorrow, but it did not the less alarm me.  I was
+unwilling to quit the sight of those that remained to me, and above
+all, I desired to see my sweet Elizabeth in some degree consoled.
+
+She indeed veiled her grief and strove to act the comforter to us all.
+She looked steadily on life and assumed its duties with courage and
+zeal.  She devoted herself to those whom she had been taught to call
+her uncle and cousins.  Never was she so enchanting as at this time,
+when she recalled the sunshine of her smiles and spent them upon us.
+She forgot even her own regret in her endeavours to make us forget.
+
+The day of my departure at length arrived.  Clerval spent the last
+evening with us.  He had endeavoured to persuade his father to permit
+him to accompany me and to become my fellow student, but in vain.  His
+father was a narrow-minded trader and saw idleness and ruin in the
+aspirations and ambition of his son.  Henry deeply felt the misfortune
+of being debarred from a liberal education.  He said little, but when
+he spoke I read in his kindling eye and in his animated glance a
+restrained but firm resolve not to be chained to the miserable details
+of commerce.
+
+We sat late.  We could not tear ourselves away from each other nor
+persuade ourselves to say the word "Farewell!"  It was said, and we
+retired under the pretence of seeking repose, each fancying that the
+other was deceived; but when at morning's dawn I descended to the
+carriage which was to convey me away, they were all there--my father
+again to bless me, Clerval to press my hand once more, my Elizabeth to
+renew her entreaties that I would write often and to bestow the last
+feminine attentions on her playmate and friend.
+
+I threw myself into the chaise that was to convey me away and indulged
+in the most melancholy reflections.  I, who had ever been surrounded by
+amiable companions, continually engaged in endeavouring to bestow
+mutual pleasure--I was now alone.  In the university whither I was
+going I must form my own friends and be my own protector.  My life had
+hitherto been remarkably secluded and domestic, and this had given me
+invincible repugnance to new countenances.  I loved my brothers,
+Elizabeth, and Clerval; these were "old familiar faces," but I believed
+myself totally unfitted for the company of strangers.  Such were my
+reflections as I commenced my journey; but as I proceeded, my spirits
+and hopes rose.  I ardently desired the acquisition of knowledge.  I
+had often, when at home, thought it hard to remain during my youth
+cooped up in one place and had longed to enter the world and take my
+station among other human beings.  Now my desires were complied with,
+and it would, indeed, have been folly to repent.
+
+I had sufficient leisure for these and many other reflections during my
+journey to Ingolstadt, which was long and fatiguing.  At length the
+high white steeple of the town met my eyes.  I alighted and was
+conducted to my solitary apartment to spend the evening as I pleased.
+
+The next morning I delivered my letters of introduction and paid a
+visit to some of the principal professors.  Chance--or rather the evil
+influence, the Angel of Destruction, which asserted omnipotent sway
+over me from the moment I turned my reluctant steps from my father's
+door--led me first to M. Krempe, professor of natural philosophy.  He
+was an uncouth man, but deeply imbued in the secrets of his science. He
+asked me several questions concerning my progress in the different
+branches of science appertaining to natural philosophy.  I replied
+carelessly, and partly in contempt, mentioned the names of my
+alchemists as the principal authors I had studied.  The professor
+stared.  "Have you," he said, "really spent your time in studying such
+nonsense?"
+
+I replied in the affirmative.  "Every minute," continued M. Krempe with
+warmth, "every instant that you have wasted on those books is utterly
+and entirely lost.  You have burdened your memory with exploded systems
+and useless names.  Good God!  In what desert land have you lived,
+where no one was kind enough to inform you that these fancies which you
+have so greedily imbibed are a thousand years old and as musty as they
+are ancient?  I little expected, in this enlightened and scientific
+age, to find a disciple of Albertus Magnus and Paracelsus.  My dear
+sir, you must begin your studies entirely anew."
+
+So saying, he stepped aside and wrote down a list of several books
+treating of natural philosophy which he desired me to procure, and
+dismissed me after mentioning that in the beginning of the following
+week he intended to commence a course of lectures upon natural
+philosophy in its general relations, and that M. Waldman, a fellow
+professor, would lecture upon chemistry the alternate days that he
+omitted.
+
+I returned home not disappointed, for I have said that I had long
+considered those authors useless whom the professor reprobated; but I
+returned not at all the more inclined to recur to these studies in any
+shape.  M. Krempe was a little squat man with a gruff voice and a
+repulsive countenance; the teacher, therefore, did not prepossess me in
+favour of his pursuits.  In rather a too philosophical and connected a
+strain, perhaps, I have given an account of the conclusions I had come
+to concerning them in my early years.  As a child I had not been
+content with the results promised by the modern professors of natural
+science.  With a confusion of ideas only to be accounted for by my
+extreme youth and my want of a guide on such matters, I had retrod the
+steps of knowledge along the paths of time and exchanged the
+discoveries of recent inquirers for the dreams of forgotten alchemists.
+Besides, I had a contempt for the uses of modern natural philosophy.
+It was very different when the masters of the science sought
+immortality and power; such views, although futile, were grand; but now
+the scene was changed.  The ambition of the inquirer seemed to limit
+itself to the annihilation of those visions on which my interest in
+science was chiefly founded.  I was required to exchange chimeras of
+boundless grandeur for realities of little worth.
+
+Such were my reflections during the first two or three days of my
+residence at Ingolstadt, which were chiefly spent in becoming
+acquainted with the localities and the principal residents in my new
+abode.  But as the ensuing week commenced, I thought of the information
+which M. Krempe had given me concerning the lectures.  And although I
+could not consent to go and hear that little conceited fellow deliver
+sentences out of a pulpit, I recollected what he had said of M.
+Waldman, whom I had never seen, as he had hitherto been out of town.
+
+Partly from curiosity and partly from idleness, I went into the
+lecturing room, which M. Waldman entered shortly after.  This professor
+was very unlike his colleague.  He appeared about fifty years of age,
+but with an aspect expressive of the greatest benevolence; a few grey
+hairs covered his temples, but those at the back of his head were
+nearly black.  His person was short but remarkably erect and his voice
+the sweetest I had ever heard.  He began his lecture by a
+recapitulation of the history of chemistry and the various improvements
+made by different men of learning, pronouncing with fervour the names
+of the most distinguished discoverers.  He then took a cursory view of
+the present state of the science and explained many of its elementary
+terms.  After having made a few preparatory experiments, he concluded
+with a panegyric upon modern chemistry, the terms of which I shall
+never forget:  "The ancient teachers of this science," said he,
+"promised impossibilities and performed nothing.  The modern masters
+promise very little; they know that metals cannot be transmuted and
+that the elixir of life is a chimera but these philosophers, whose
+hands seem only made to dabble in dirt, and their eyes to pore over the
+microscope or crucible, have indeed performed miracles.  They penetrate
+into the recesses of nature and show how she works in her
+hiding-places.  They ascend into the heavens; they have discovered how
+the blood circulates, and the nature of the air we breathe.  They have
+acquired new and almost unlimited powers; they can command the thunders
+of heaven, mimic the earthquake, and even mock the invisible world with
+its own shadows."
+
+Such were the professor's words--rather let me say such the words of
+the fate--enounced to destroy me.  As he went on I felt as if my soul
+were grappling with a palpable enemy; one by one the various keys were
+touched which formed the mechanism of my being; chord after chord was
+sounded, and soon my mind was filled with one thought, one conception,
+one purpose.  So much has been done, exclaimed the soul of
+Frankenstein--more, far more, will I achieve; treading in the steps
+already marked, I will pioneer a new way, explore unknown powers, and
+unfold to the world the deepest mysteries of creation.
+
+I closed not my eyes that night.  My internal being was in a state of
+insurrection and turmoil; I felt that order would thence arise, but I
+had no power to produce it.  By degrees, after the morning's dawn,
+sleep came.  I awoke, and my yesternight's thoughts were as a dream.
+There only remained a resolution to return to my ancient studies and to
+devote myself to a science for which I believed myself to possess a
+natural talent.  On the same day I paid M. Waldman a visit.  His
+manners in private were even more mild and attractive than in public,
+for there was a certain dignity in his mien during his lecture which in
+his own house was replaced by the greatest affability and kindness.  I
+gave him pretty nearly the same account of my former pursuits as I had
+given to his fellow professor.  He heard with attention the little
+narration concerning my studies and smiled at the names of Cornelius
+Agrippa and Paracelsus, but without the contempt that M. Krempe had
+exhibited. He said that "These were men to whose indefatigable zeal
+modern philosophers were indebted for most of the foundations of their
+knowledge.  They had left to us, as an easier task, to give new names
+and arrange in connected classifications the facts which they in a
+great degree had been the instruments of bringing to light.  The
+labours of men of genius, however erroneously directed, scarcely ever
+fail in ultimately turning to the solid advantage of mankind."  I
+listened to his statement, which was delivered without any presumption
+or affectation, and then added that his lecture had removed my
+prejudices against modern chemists; I expressed myself in measured
+terms, with the modesty and deference due from a youth to his
+instructor, without letting escape (inexperience in life would have
+made me ashamed) any of the enthusiasm which stimulated my intended
+labours.  I requested his advice concerning the books I ought to
+procure.
+
+"I am happy," said M. Waldman, "to have gained a disciple; and if your
+application equals your ability, I have no doubt of your success.
+Chemistry is that branch of natural philosophy in which the greatest
+improvements have been and may be made; it is on that account that I
+have made it my peculiar study; but at the same time, I have not
+neglected the other branches of science.  A man would make but a very
+sorry chemist if he attended to that department of human knowledge
+alone.  If your wish is to become really a man of science and not
+merely a petty experimentalist, I should advise you to apply to every
+branch of natural philosophy, including mathematics."  He then took me
+into his laboratory and explained to me the uses of his various
+machines, instructing me as to what I ought to procure and promising me
+the use of his own when I should have advanced far enough in the
+science not to derange their mechanism.  He also gave me the list of
+books which I had requested, and I took my leave.
+
+Thus ended a day memorable to me; it decided my future destiny.
+
+
+
+Chapter 4
+
+From this day natural philosophy, and particularly chemistry, in the
+most comprehensive sense of the term, became nearly my sole occupation.
+I read with ardour those works, so full of genius and discrimination,
+which modern inquirers have written on these subjects.  I attended the
+lectures and cultivated the acquaintance of the men of science of the
+university, and I found even in M. Krempe a great deal of sound sense
+and real information, combined, it is true, with a repulsive
+physiognomy and manners, but not on that account the less valuable.  In
+M. Waldman I found a true friend.  His gentleness was never tinged by
+dogmatism, and his instructions were given with an air of frankness and
+good nature that banished every idea of pedantry.  In a thousand ways
+he smoothed for me the path of knowledge and made the most abstruse
+inquiries clear and facile to my apprehension.  My application was at
+first fluctuating and uncertain; it gained strength as I proceeded and
+soon became so ardent and eager that the stars often disappeared in the
+light of morning whilst I was yet engaged in my laboratory.
+
+As I applied so closely, it may be easily conceived that my progress
+was rapid.  My ardour was indeed the astonishment of the students, and
+my proficiency that of the masters.  Professor Krempe often asked me,
+with a sly smile, how Cornelius Agrippa went on, whilst M. Waldman
+expressed the most heartfelt exultation in my progress.  Two years
+passed in this manner, during which I paid no visit to Geneva, but was
+engaged, heart and soul, in the pursuit of some discoveries which I
+hoped to make.  None but those who have experienced them can conceive
+of the enticements of science.  In other studies you go as far as
+others have gone before you, and there is nothing more to know; but in
+a scientific pursuit there is continual food for discovery and wonder.
+A mind of moderate capacity which closely pursues one study must
+infallibly arrive at great proficiency in that study; and I, who
+continually sought the attainment of one object of pursuit and was
+solely wrapped up in this, improved so rapidly that at the end of two
+years I made some discoveries in the improvement of some chemical
+instruments, which procured me great esteem and admiration at the
+university.  When I had arrived at this point and had become as well
+acquainted with the theory and practice of natural philosophy as
+depended on the lessons of any of the professors at Ingolstadt, my
+residence there being no longer conducive to my improvements, I thought
+of returning to my friends and my native town, when an incident
+happened that protracted my stay.
+
+One of the phenomena which had peculiarly attracted my attention was
+the structure of the human frame, and, indeed, any animal endued with
+life.  Whence, I often asked myself, did the principle of life proceed?
+It was a bold question, and one which has ever been considered as a
+mystery; yet with how many things are we upon the brink of becoming
+acquainted, if cowardice or carelessness did not restrain our
+inquiries.  I revolved these circumstances in my mind and determined
+thenceforth to apply myself more particularly to those branches of
+natural philosophy which relate to physiology.  Unless I had been
+animated by an almost supernatural enthusiasm, my application to this
+study would have been irksome and almost intolerable.  To examine the
+causes of life, we must first have recourse to death.  I became
+acquainted with the science of anatomy, but this was not sufficient; I
+must also observe the natural decay and corruption of the human body.
+In my education my father had taken the greatest precautions that my
+mind should be impressed with no supernatural horrors.  I do not ever
+remember to have trembled at a tale of superstition or to have feared
+the apparition of a spirit.  Darkness had no effect upon my fancy, and
+a churchyard was to me merely the receptacle of bodies deprived of
+life, which, from being the seat of beauty and strength, had become
+food for the worm.  Now I was led to examine the cause and progress of
+this decay and forced to spend days and nights in vaults and
+charnel-houses.  My attention was fixed upon every object the most
+insupportable to the delicacy of the human feelings.  I saw how the
+fine form of man was degraded and wasted; I beheld the corruption of
+death succeed to the blooming cheek of life; I saw how the worm
+inherited the wonders of the eye and brain.  I paused, examining and
+analysing all the minutiae of causation, as exemplified in the change
+from life to death, and death to life, until from the midst of this
+darkness a sudden light broke in upon me--a light so brilliant and
+wondrous, yet so simple, that while I became dizzy with the immensity
+of the prospect which it illustrated, I was surprised that among so
+many men of genius who had directed their inquiries towards the same
+science, that I alone should be reserved to discover so astonishing a
+secret.
+
+Remember, I am not recording the vision of a madman.  The sun does not
+more certainly shine in the heavens than that which I now affirm is
+true.  Some miracle might have produced it, yet the stages of the
+discovery were distinct and probable.  After days and nights of
+incredible labour and fatigue, I succeeded in discovering the cause of
+generation and life; nay, more, I became myself capable of bestowing
+animation upon lifeless matter.
+
+The astonishment which I had at first experienced on this discovery
+soon gave place to delight and rapture.  After so much time spent in
+painful labour, to arrive at once at the summit of my desires was the
+most gratifying consummation of my toils.  But this discovery was so
+great and overwhelming that all the steps by which I had been
+progressively led to it were obliterated, and I beheld only the result.
+What had been the study and desire of the wisest men since the creation
+of the world was now within my grasp.  Not that, like a magic scene, it
+all opened upon me at once:  the information I had obtained was of a
+nature rather to direct my endeavours so soon as I should point them
+towards the object of my search than to exhibit that object already
+accomplished.  I was like the Arabian who had been buried with the dead
+and found a passage to life, aided only by one glimmering and seemingly
+ineffectual light.
+
+I see by your eagerness and the wonder and hope which your eyes
+express, my friend, that you expect to be informed of the secret with
+which I am acquainted; that cannot be; listen patiently until the end
+of my story, and you will easily perceive why I am reserved upon that
+subject.  I will not lead you on, unguarded and ardent as I then was,
+to your destruction and infallible misery.  Learn from me, if not by my
+precepts, at least by my example, how dangerous is the acquirement of
+knowledge and how much happier that man is who believes his native town
+to be the world, than he who aspires to become greater than his nature
+will allow.
+
+When I found so astonishing a power placed within my hands, I hesitated
+a long time concerning the manner in which I should employ it.
+Although I possessed the capacity of bestowing animation, yet to
+prepare a frame for the reception of it, with all its intricacies of
+fibres, muscles, and veins, still remained a work of inconceivable
+difficulty and labour.  I doubted at first whether I should attempt the
+creation of a being like myself, or one of simpler organization; but my
+imagination was too much exalted by my first success to permit me to
+doubt of my ability to give life to an animal as complex and wonderful
+as man.  The materials at present within my command hardly appeared
+adequate to so arduous an undertaking, but I doubted not that I should
+ultimately succeed.  I prepared myself for a multitude of reverses; my
+operations might be incessantly baffled, and at last my work be
+imperfect, yet when I considered the improvement which every day takes
+place in science and mechanics, I was encouraged to hope my present
+attempts would at least lay the foundations of future success.  Nor
+could I consider the magnitude and complexity of my plan as any
+argument of its impracticability.  It was with these feelings that I
+began the creation of a human being.  As the minuteness of the parts
+formed a great hindrance to my speed, I resolved, contrary to my first
+intention, to make the being of a gigantic stature, that is to say,
+about eight feet in height, and proportionably large.  After having
+formed this determination and having spent some months in successfully
+collecting and arranging my materials, I began.
+
+No one can conceive the variety of feelings which bore me onwards, like
+a hurricane, in the first enthusiasm of success.  Life and death
+appeared to me ideal bounds, which I should first break through, and
+pour a torrent of light into our dark world.  A new species would bless
+me as its creator and source; many happy and excellent natures would
+owe their being to me.  No father could claim the gratitude of his
+child so completely as I should deserve theirs.  Pursuing these
+reflections, I thought that if I could bestow animation upon lifeless
+matter, I might in process of time (although I now found it impossible)
+renew life where death had apparently devoted the body to corruption.
+
+These thoughts supported my spirits, while I pursued my undertaking
+with unremitting ardour.  My cheek had grown pale with study, and my
+person had become emaciated with confinement.  Sometimes, on the very
+brink of certainty, I failed; yet still I clung to the hope which the
+next day or the next hour might realize.  One secret which I alone
+possessed was the hope to which I had dedicated myself; and the moon
+gazed on my midnight labours, while, with unrelaxed and breathless
+eagerness, I pursued nature to her hiding-places.  Who shall conceive
+the horrors of my secret toil as I dabbled among the unhallowed damps
+of the grave or tortured the living animal to animate the lifeless
+clay?  My limbs now tremble, and my eyes swim with the remembrance; but
+then a resistless and almost frantic impulse urged me forward; I seemed
+to have lost all soul or sensation but for this one pursuit.  It was
+indeed but a passing trance, that only made me feel with renewed
+acuteness so soon as, the unnatural stimulus ceasing to operate, I had
+returned to my old habits.  I collected bones from charnel-houses and
+disturbed, with profane fingers, the tremendous secrets of the human
+frame.  In a solitary chamber, or rather cell, at the top of the house,
+and separated from all the other apartments by a gallery and staircase,
+I kept my workshop of filthy creation; my eyeballs were starting from
+their sockets in attending to the details of my employment.  The
+dissecting room and the slaughter-house furnished many of my materials;
+and often did my human nature turn with loathing from my occupation,
+whilst, still urged on by an eagerness which perpetually increased, I
+brought my work near to a conclusion.
+
+The summer months passed while I was thus engaged, heart and soul, in
+one pursuit.  It was a most beautiful season; never did the fields
+bestow a more plentiful harvest or the vines yield a more luxuriant
+vintage, but my eyes were insensible to the charms of nature.  And the
+same feelings which made me neglect the scenes around me caused me also
+to forget those friends who were so many miles absent, and whom I had
+not seen for so long a time.  I knew my silence disquieted them, and I
+well remembered the words of my father:  "I know that while you are
+pleased with yourself you will think of us with affection, and we shall
+hear regularly from you.  You must pardon me if I regard any
+interruption in your correspondence as a proof that your other duties
+are equally neglected."
+
+I knew well therefore what would be my father's feelings, but I could
+not tear my thoughts from my employment, loathsome in itself, but which
+had taken an irresistible hold of my imagination.  I wished, as it
+were, to procrastinate all that related to my feelings of affection
+until the great object, which swallowed up every habit of my nature,
+should be completed.
+
+I then thought that my father would be unjust if he ascribed my neglect
+to vice or faultiness on my part, but I am now convinced that he was
+justified in conceiving that I should not be altogether free from
+blame.  A human being in perfection ought always to preserve a calm and
+peaceful mind and never to allow passion or a transitory desire to
+disturb his tranquillity.  I do not think that the pursuit of knowledge
+is an exception to this rule.  If the study to which you apply yourself
+has a tendency to weaken your affections and to destroy your taste for
+those simple pleasures in which no alloy can possibly mix, then that
+study is certainly unlawful, that is to say, not befitting the human
+mind.  If this rule were always observed; if no man allowed any pursuit
+whatsoever to interfere with the tranquillity of his domestic
+affections, Greece had not been enslaved, Caesar would have spared his
+country, America would have been discovered more gradually, and the
+empires of Mexico and Peru had not been destroyed.
+
+But I forget that I am moralizing in the most interesting part of my
+tale, and your looks remind me to proceed.  My father made no reproach
+in his letters and only took notice of my silence by inquiring into my
+occupations more particularly than before.  Winter, spring, and summer
+passed away during my labours; but I did not watch the blossom or the
+expanding leaves--sights which before always yielded me supreme
+delight--so deeply was I engrossed in my occupation.  The leaves of
+that year had withered before my work drew near to a close, and now
+every day showed me more plainly how well I had succeeded.  But my
+enthusiasm was checked by my anxiety, and I appeared rather like one
+doomed by slavery to toil in the mines, or any other unwholesome trade
+than an artist occupied by his favourite employment.  Every night I was
+oppressed by a slow fever, and I became nervous to a most painful
+degree; the fall of a leaf startled me, and I shunned my fellow
+creatures as if I had been guilty of a crime.  Sometimes I grew alarmed
+at the wreck I perceived that I had become; the energy of my purpose
+alone sustained me:  my labours would soon end, and I believed that
+exercise and amusement would then drive away incipient disease; and I
+promised myself both of these when my creation should be complete.
+
+
+
+Chapter 5
+
+It was on a dreary night of November that I beheld the accomplishment
+of my toils.  With an anxiety that almost amounted to agony, I
+collected the instruments of life around me, that I might infuse a
+spark of being into the lifeless thing that lay at my feet.  It was
+already one in the morning; the rain pattered dismally against the
+panes, and my candle was nearly burnt out, when, by the glimmer of the
+half-extinguished light, I saw the dull yellow eye of the creature
+open; it breathed hard, and a convulsive motion agitated its limbs.
+
+How can I describe my emotions at this catastrophe, or how delineate
+the wretch whom with such infinite pains and care I had endeavoured to
+form?  His limbs were in proportion, and I had selected his features as
+beautiful.  Beautiful!  Great God!  His yellow skin scarcely covered
+the work of muscles and arteries beneath; his hair was of a lustrous
+black, and flowing; his teeth of a pearly whiteness; but these
+luxuriances only formed a more horrid contrast with his watery eyes,
+that seemed almost of the same colour as the dun-white sockets in which
+they were set, his shrivelled complexion and straight black lips.
+
+The different accidents of life are not so changeable as the feelings
+of human nature.  I had worked hard for nearly two years, for the sole
+purpose of infusing life into an inanimate body.  For this I had
+deprived myself of rest and health.  I had desired it with an ardour
+that far exceeded moderation; but now that I had finished, the beauty
+of the dream vanished, and breathless horror and disgust filled my
+heart.  Unable to endure the aspect of the being I had created, I
+rushed out of the room and continued a long time traversing my
+bed-chamber, unable to compose my mind to sleep.  At length lassitude
+succeeded to the tumult I had before endured, and I threw myself on the
+bed in my clothes, endeavouring to seek a few moments of forgetfulness.
+But it was in vain; I slept, indeed, but I was disturbed by the wildest
+dreams.  I thought I saw Elizabeth, in the bloom of health, walking in
+the streets of Ingolstadt.  Delighted and surprised, I embraced her,
+but as I imprinted the first kiss on her lips, they became livid with
+the hue of death; her features appeared to change, and I thought that I
+held the corpse of my dead mother in my arms; a shroud enveloped her
+form, and I saw the grave-worms crawling in the folds of the flannel.
+I started from my sleep with horror; a cold dew covered my forehead, my
+teeth chattered, and every limb became convulsed; when, by the dim and
+yellow light of the moon, as it forced its way through the window
+shutters, I beheld the wretch--the miserable monster whom I had
+created.  He held up the curtain of the bed; and his eyes, if eyes they
+may be called, were fixed on me.  His jaws opened, and he muttered some
+inarticulate sounds, while a grin wrinkled his cheeks.  He might have
+spoken, but I did not hear; one hand was stretched out, seemingly to
+detain me, but I escaped and rushed downstairs.  I took refuge in the
+courtyard belonging to the house which I inhabited, where I remained
+during the rest of the night, walking up and down in the greatest
+agitation, listening attentively, catching and fearing each sound as if
+it were to announce the approach of the demoniacal corpse to which I
+had so miserably given life.
+
+Oh!  No mortal could support the horror of that countenance.  A mummy
+again endued with animation could not be so hideous as that wretch.  I
+had gazed on him while unfinished; he was ugly then, but when those
+muscles and joints were rendered capable of motion, it became a thing
+such as even Dante could not have conceived.
+
+I passed the night wretchedly.  Sometimes my pulse beat so quickly and
+hardly that I felt the palpitation of every artery; at others, I nearly
+sank to the ground through languor and extreme weakness.  Mingled with
+this horror, I felt the bitterness of disappointment; dreams that had
+been my food and pleasant rest for so long a space were now become a
+hell to me; and the change was so rapid, the overthrow so complete!
+
+Morning, dismal and wet, at length dawned and discovered to my
+sleepless and aching eyes the church of Ingolstadt, its white steeple
+and clock, which indicated the sixth hour.  The porter opened the gates
+of the court, which had that night been my asylum, and I issued into
+the streets, pacing them with quick steps, as if I sought to avoid the
+wretch whom I feared every turning of the street would present to my
+view.  I did not dare return to the apartment which I inhabited, but
+felt impelled to hurry on, although drenched by the rain which poured
+from a black and comfortless sky.
+
+I continued walking in this manner for some time, endeavouring by
+bodily exercise to ease the load that weighed upon my mind.  I
+traversed the streets without any clear conception of where I was or
+what I was doing.  My heart palpitated in the sickness of fear, and I
+hurried on with irregular steps, not daring to look about me:
+
+
+  Like one who, on a lonely road,
+  Doth walk in fear and dread,
+  And, having once turned round, walks on,
+  And turns no more his head;
+  Because he knows a frightful fiend
+  Doth close behind him tread.
+
+  [Coleridge's "Ancient Mariner."]
+
+
+Continuing thus, I came at length opposite to the inn at which the
+various diligences and carriages usually stopped.  Here I paused, I
+knew not why; but I remained some minutes with my eyes fixed on a coach
+that was coming towards me from the other end of the street.  As it
+drew nearer I observed that it was the Swiss diligence; it stopped just
+where I was standing, and on the door being opened, I perceived Henry
+Clerval, who, on seeing me, instantly sprung out.  "My dear
+Frankenstein," exclaimed he, "how glad I am to see you!  How fortunate
+that you should be here at the very moment of my alighting!"
+
+Nothing could equal my delight on seeing Clerval; his presence brought
+back to my thoughts my father, Elizabeth, and all those scenes of home
+so dear to my recollection.  I grasped his hand, and in a moment forgot
+my horror and misfortune; I felt suddenly, and for the first time
+during many months, calm and serene joy.  I welcomed my friend,
+therefore, in the most cordial manner, and we walked towards my
+college.  Clerval continued talking for some time about our mutual
+friends and his own good fortune in being permitted to come to
+Ingolstadt.  "You may easily believe," said he, "how great was the
+difficulty to persuade my father that all necessary knowledge was not
+comprised in the noble art of book-keeping; and, indeed, I believe I
+left him incredulous to the last, for his constant answer to my
+unwearied entreaties was the same as that of the Dutch schoolmaster in
+The Vicar of Wakefield:  'I have ten thousand florins a year without
+Greek, I eat heartily without Greek.'  But his affection for me at
+length overcame his dislike of learning, and he has permitted me to
+undertake a voyage of discovery to the land of knowledge."
+
+"It gives me the greatest delight to see you; but tell me how you left
+my father, brothers, and Elizabeth."
+
+"Very well, and very happy, only a little uneasy that they hear from
+you so seldom.  By the by, I mean to lecture you a little upon their
+account myself.  But, my dear Frankenstein," continued he, stopping
+short and gazing full in my face, "I did not before remark how very ill
+you appear; so thin and pale; you look as if you had been watching for
+several nights."
+
+"You have guessed right; I have lately been so deeply engaged in one
+occupation that I have not allowed myself sufficient rest, as you see;
+but I hope, I sincerely hope, that all these employments are now at an
+end and that I am at length free."
+
+I trembled excessively; I could not endure to think of, and far less to
+allude to, the occurrences of the preceding night.  I walked with a
+quick pace, and we soon arrived at my college.  I then reflected, and
+the thought made me shiver, that the creature whom I had left in my
+apartment might still be there, alive and walking about.  I dreaded to
+behold this monster, but I feared still more that Henry should see him.
+Entreating him, therefore, to remain a few minutes at the bottom of the
+stairs, I darted up towards my own room.  My hand was already on the
+lock of the door before I recollected myself.  I then paused, and a
+cold shivering came over me.  I threw the door forcibly open, as
+children are accustomed to do when they expect a spectre to stand in
+waiting for them on the other side; but nothing appeared.  I stepped
+fearfully in:  the apartment was empty, and my bedroom was also freed
+from its hideous guest.  I could hardly believe that so great a good
+fortune could have befallen me, but when I became assured that my enemy
+had indeed fled, I clapped my hands for joy and ran down to Clerval.
+
+We ascended into my room, and the servant presently brought breakfast;
+but I was unable to contain myself.  It was not joy only that possessed
+me; I felt my flesh tingle with excess of sensitiveness, and my pulse
+beat rapidly.  I was unable to remain for a single instant in the same
+place; I jumped over the chairs, clapped my hands, and laughed aloud.
+Clerval at first attributed my unusual spirits to joy on his arrival,
+but when he observed me more attentively, he saw a wildness in my eyes
+for which he could not account, and my loud, unrestrained, heartless
+laughter frightened and astonished him.
+
+"My dear Victor," cried he, "what, for God's sake, is the matter?  Do
+not laugh in that manner.  How ill you are!  What is the cause of all
+this?"
+
+"Do not ask me," cried I, putting my hands before my eyes, for I
+thought I saw the dreaded spectre glide into the room; "HE can tell.
+Oh, save me!  Save me!"  I imagined that the monster seized me; I
+struggled furiously and fell down in a fit.
+
+Poor Clerval!  What must have been his feelings?  A meeting, which he
+anticipated with such joy, so strangely turned to bitterness.  But I
+was not the witness of his grief, for I was lifeless and did not
+recover my senses for a long, long time.
+
+This was the commencement of a nervous fever which confined me for
+several months.  During all that time Henry was my only nurse.  I
+afterwards learned that, knowing my father's advanced age and unfitness
+for so long a journey, and how wretched my sickness would make
+Elizabeth, he spared them this grief by concealing the extent of my
+disorder.  He knew that I could not have a more kind and attentive
+nurse than himself; and, firm in the hope he felt of my recovery, he
+did not doubt that, instead of doing harm, he performed the kindest
+action that he could towards them.
+
+But I was in reality very ill, and surely nothing but the unbounded and
+unremitting attentions of my friend could have restored me to life.
+The form of the monster on whom I had bestowed existence was forever
+before my eyes, and I raved incessantly concerning him.  Doubtless my
+words surprised Henry; he at first believed them to be the wanderings
+of my disturbed imagination, but the pertinacity with which I
+continually recurred to the same subject persuaded him that my disorder
+indeed owed its origin to some uncommon and terrible event.
+
+By very slow degrees, and with frequent relapses that alarmed and
+grieved my friend, I recovered.  I remember the first time I became
+capable of observing outward objects with any kind of pleasure, I
+perceived that the fallen leaves had disappeared and that the young
+buds were shooting forth from the trees that shaded my window.  It was
+a divine spring, and the season contributed greatly to my
+convalescence.  I felt also sentiments of joy and affection revive in
+my bosom; my gloom disappeared, and in a short time I became as
+cheerful as before I was attacked by the fatal passion.
+
+"Dearest Clerval," exclaimed I, "how kind, how very good you are to me.
+This whole winter, instead of being spent in study, as you promised
+yourself, has been consumed in my sick room.  How shall I ever repay
+you?  I feel the greatest remorse for the disappointment of which I
+have been the occasion, but you will forgive me."
+
+"You will repay me entirely if you do not discompose yourself, but get
+well as fast as you can; and since you appear in such good spirits, I
+may speak to you on one subject, may I not?"
+
+I trembled.  One subject!  What could it be?  Could he allude to an
+object on whom I dared not even think?  "Compose yourself," said
+Clerval, who observed my change of colour, "I will not mention it if it
+agitates you; but your father and cousin would be very happy if they
+received a letter from you in your own handwriting.  They hardly know
+how ill you have been and are uneasy at your long silence."
+
+"Is that all, my dear Henry?  How could you suppose that my first
+thought would not fly towards those dear, dear friends whom I love and
+who are so deserving of my love?"
+
+"If this is your present temper, my friend, you will perhaps be glad to
+see a letter that has been lying here some days for you; it is from
+your cousin, I believe."
+
+
+
+Chapter 6
+
+Clerval then put the following letter into my hands.  It was from my
+own Elizabeth:
+
+"My dearest Cousin,
+
+"You have been ill, very ill, and even the constant letters of dear
+kind Henry are not sufficient to reassure me on your account.  You are
+forbidden to write--to hold a pen; yet one word from you, dear Victor,
+is necessary to calm our apprehensions.  For a long time I have thought
+that each post would bring this line, and my persuasions have
+restrained my uncle from undertaking a journey to Ingolstadt.  I have
+prevented his encountering the inconveniences and perhaps dangers of so
+long a journey, yet how often have I regretted not being able to
+perform it myself!  I figure to myself that the task of attending on
+your sickbed has devolved on some mercenary old nurse, who could never
+guess your wishes nor minister to them with the care and affection of
+your poor cousin.  Yet that is over now:  Clerval writes that indeed
+you are getting better.  I eagerly hope that you will confirm this
+intelligence soon in your own handwriting.
+
+"Get well--and return to us.  You will find a happy, cheerful home and
+friends who love you dearly.  Your father's health is vigorous, and he
+asks but to see you, but to be assured that you are well; and not a
+care will ever cloud his benevolent countenance.  How pleased you would
+be to remark the improvement of our Ernest!  He is now sixteen and full
+of activity and spirit.  He is desirous to be a true Swiss and to enter
+into foreign service, but we cannot part with him, at least until his
+elder brother returns to us.  My uncle is not pleased with the idea of
+a military career in a distant country, but Ernest never had your
+powers of application.  He looks upon study as an odious fetter; his
+time is spent in the open air, climbing the hills or rowing on the
+lake.  I fear that he will become an idler unless we yield the point
+and permit him to enter on the profession which he has selected.
+
+"Little alteration, except the growth of our dear children, has taken
+place since you left us.  The blue lake and snow-clad mountains--they
+never change; and I think our placid home and our contented hearts are
+regulated by the same immutable laws.  My trifling occupations take up
+my time and amuse me, and I am rewarded for any exertions by seeing
+none but happy, kind faces around me.  Since you left us, but one
+change has taken place in our little household.  Do you remember on
+what occasion Justine Moritz entered our family?  Probably you do not;
+I will relate her history, therefore in a few words.  Madame Moritz,
+her mother, was a widow with four children, of whom Justine was the
+third.  This girl had always been the favourite of her father, but
+through a strange perversity, her mother could not endure her, and
+after the death of M. Moritz, treated her very ill.  My aunt observed
+this, and when Justine was twelve years of age, prevailed on her mother
+to allow her to live at our house.  The republican institutions of our
+country have produced simpler and happier manners than those which
+prevail in the great monarchies that surround it.  Hence there is less
+distinction between the several classes of its inhabitants; and the
+lower orders, being neither so poor nor so despised, their manners are
+more refined and moral.  A servant in Geneva does not mean the same
+thing as a servant in France and England.  Justine, thus received in
+our family, learned the duties of a servant, a condition which, in our
+fortunate country, does not include the idea of ignorance and a
+sacrifice of the dignity of a human being.
+
+"Justine, you may remember, was a great favourite of yours; and I
+recollect you once remarked that if you were in an ill humour, one
+glance from Justine could dissipate it, for the same reason that
+Ariosto gives concerning the beauty of Angelica--she looked so
+frank-hearted and happy.  My aunt conceived a great attachment for her,
+by which she was induced to give her an education superior to that
+which she had at first intended.  This benefit was fully repaid;
+Justine was the most grateful little creature in the world:  I do not
+mean that she made any professions I never heard one pass her lips, but
+you could see by her eyes that she almost adored her protectress.
+Although her disposition was gay and in many respects inconsiderate,
+yet she paid the greatest attention to every gesture of my aunt.  She
+thought her the model of all excellence and endeavoured to imitate her
+phraseology and manners, so that even now she often reminds me of her.
+
+"When my dearest aunt died every one was too much occupied in their own
+grief to notice poor Justine, who had attended her during her illness
+with the most anxious affection.  Poor Justine was very ill; but other
+trials were reserved for her.
+
+"One by one, her brothers and sister died; and her mother, with the
+exception of her neglected daughter, was left childless.  The
+conscience of the woman was troubled; she began to think that the
+deaths of her favourites was a judgement from heaven to chastise her
+partiality.  She was a Roman Catholic; and I believe her confessor
+confirmed the idea which she had conceived.  Accordingly, a few months
+after your departure for Ingolstadt, Justine was called home by her
+repentant mother.  Poor girl!  She wept when she quitted our house; she
+was much altered since the death of my aunt; grief had given softness
+and a winning mildness to her manners, which had before been remarkable
+for vivacity.  Nor was her residence at her mother's house of a nature
+to restore her gaiety.  The poor woman was very vacillating in her
+repentance.  She sometimes begged Justine to forgive her unkindness,
+but much oftener accused her of having caused the deaths of her
+brothers and sister.  Perpetual fretting at length threw Madame Moritz
+into a decline, which at first increased her irritability, but she is
+now at peace for ever.  She died on the first approach of cold weather,
+at the beginning of this last winter.  Justine has just returned to us;
+and I assure you I love her tenderly.  She is very clever and gentle,
+and extremely pretty; as I mentioned before, her mien and her
+expression continually remind me of my dear aunt.
+
+"I must say also a few words to you, my dear cousin, of little darling
+William.  I wish you could see him; he is very tall of his age, with
+sweet laughing blue eyes, dark eyelashes, and curling hair.  When he
+smiles, two little dimples appear on each cheek, which are rosy with
+health.  He has already had one or two little WIVES, but Louisa Biron
+is his favourite, a pretty little girl of five years of age.
+
+"Now, dear Victor, I dare say you wish to be indulged in a little
+gossip concerning the good people of Geneva.  The pretty Miss Mansfield
+has already received the congratulatory visits on her approaching
+marriage with a young Englishman, John Melbourne, Esq.  Her ugly
+sister, Manon, married M. Duvillard, the rich banker, last autumn. Your
+favourite schoolfellow, Louis Manoir, has suffered several misfortunes
+since the departure of Clerval from Geneva.  But he has already
+recovered his spirits, and is reported to be on the point of marrying a
+lively pretty Frenchwoman, Madame Tavernier.  She is a widow, and much
+older than Manoir; but she is very much admired, and a favourite with
+everybody.
+
+"I have written myself into better spirits, dear cousin; but my anxiety
+returns upon me as I conclude.  Write, dearest Victor,--one line--one
+word will be a blessing to us.  Ten thousand thanks to Henry for his
+kindness, his affection, and his many letters; we are sincerely
+grateful.  Adieu!  my cousin; take care of your self; and, I entreat
+you, write!
+
+"Elizabeth Lavenza.
+
+"Geneva, March 18, 17--."
+
+
+"Dear, dear Elizabeth!" I exclaimed, when I had read her letter:  "I
+will write instantly and relieve them from the anxiety they must feel."
+I wrote, and this exertion greatly fatigued me; but my convalescence
+had commenced, and proceeded regularly.  In another fortnight I was
+able to leave my chamber.
+
+One of my first duties on my recovery was to introduce Clerval to the
+several professors of the university.  In doing this, I underwent a
+kind of rough usage, ill befitting the wounds that my mind had
+sustained.  Ever since the fatal night, the end of my labours, and the
+beginning of my misfortunes, I had conceived a violent antipathy even
+to the name of natural philosophy.  When I was otherwise quite restored
+to health, the sight of a chemical instrument would renew all the agony
+of my nervous symptoms.  Henry saw this, and had removed all my
+apparatus from my view.  He had also changed my apartment; for he
+perceived that I had acquired a dislike for the room which had
+previously been my laboratory.  But these cares of Clerval were made of
+no avail when I visited the professors.  M. Waldman inflicted torture
+when he praised, with kindness and warmth, the astonishing progress I
+had made in the sciences.  He soon perceived that I disliked the
+subject; but not guessing the real cause, he attributed my feelings to
+modesty, and changed the subject from my improvement, to the science
+itself, with a desire, as I evidently saw, of drawing me out.  What
+could I do?  He meant to please, and he tormented me.  I felt as if he
+had placed carefully, one by one, in my view those instruments which
+were to be afterwards used in putting me to a slow and cruel death.  I
+writhed under his words, yet dared not exhibit the pain I felt.
+Clerval, whose eyes and feelings were always quick in discerning the
+sensations of others, declined the subject, alleging, in excuse, his
+total ignorance; and the conversation took a more general turn.  I
+thanked my friend from my heart, but I did not speak.  I saw plainly
+that he was surprised, but he never attempted to draw my secret from
+me; and although I loved him with a mixture of affection and reverence
+that knew no bounds, yet I could never persuade myself to confide in
+him that event which was so often present to my recollection, but which
+I feared the detail to another would only impress more deeply.
+
+M. Krempe was not equally docile; and in my condition at that time, of
+almost insupportable sensitiveness, his harsh blunt encomiums gave me
+even more pain than the benevolent approbation of M. Waldman.  "D--n
+the fellow!" cried he; "why, M. Clerval, I assure you he has outstript
+us all.  Ay, stare if you please; but it is nevertheless true.  A
+youngster who, but a few years ago, believed in Cornelius Agrippa as
+firmly as in the gospel, has now set himself at the head of the
+university; and if he is not soon pulled down, we shall all be out of
+countenance.--Ay, ay," continued he, observing my face expressive of
+suffering, "M. Frankenstein is modest; an excellent quality in a young
+man.  Young men should be diffident of themselves, you know, M.
+Clerval:  I was myself when young; but that wears out in a very short
+time."
+
+M. Krempe had now commenced an eulogy on himself, which happily turned
+the conversation from a subject that was so annoying to me.
+
+Clerval had never sympathized in my tastes for natural science; and his
+literary pursuits differed wholly from those which had occupied me.  He
+came to the university with the design of making himself complete
+master of the oriental languages, and thus he should open a field for
+the plan of life he had marked out for himself.  Resolved to pursue no
+inglorious career, he turned his eyes toward the East, as affording
+scope for his spirit of enterprise.  The Persian, Arabic, and Sanskrit
+languages engaged his attention, and I was easily induced to enter on
+the same studies.  Idleness had ever been irksome to me, and now that I
+wished to fly from reflection, and hated my former studies, I felt
+great relief in being the fellow-pupil with my friend, and found not
+only instruction but consolation in the works of the orientalists.  I
+did not, like him, attempt a critical knowledge of their dialects, for
+I did not contemplate making any other use of them than temporary
+amusement.  I read merely to understand their meaning, and they well
+repaid my labours.  Their melancholy is soothing, and their joy
+elevating, to a degree I never experienced in studying the authors of
+any other country.  When you read their writings, life appears to
+consist in a warm sun and a garden of roses,--in the smiles and frowns
+of a fair enemy, and the fire that consumes your own heart.  How
+different from the manly and heroical poetry of Greece and Rome!
+
+Summer passed away in these occupations, and my return to Geneva was
+fixed for the latter end of autumn; but being delayed by several
+accidents, winter and snow arrived, the roads were deemed impassable,
+and my journey was retarded until the ensuing spring.  I felt this
+delay very bitterly; for I longed to see my native town and my beloved
+friends.  My return had only been delayed so long, from an
+unwillingness to leave Clerval in a strange place, before he had become
+acquainted with any of its inhabitants.  The winter, however, was spent
+cheerfully; and although the spring was uncommonly late, when it came
+its beauty compensated for its dilatoriness.
+
+The month of May had already commenced, and I expected the letter daily
+which was to fix the date of my departure, when Henry proposed a
+pedestrian tour in the environs of Ingolstadt, that I might bid a
+personal farewell to the country I had so long inhabited.  I acceded
+with pleasure to this proposition:  I was fond of exercise, and Clerval
+had always been my favourite companion in the ramble of this nature
+that I had taken among the scenes of my native country.
+
+We passed a fortnight in these perambulations:  my health and spirits
+had long been restored, and they gained additional strength from the
+salubrious air I breathed, the natural incidents of our progress, and
+the conversation of my friend.  Study had before secluded me from the
+intercourse of my fellow-creatures, and rendered me unsocial; but
+Clerval called forth the better feelings of my heart; he again taught
+me to love the aspect of nature, and the cheerful faces of children.
+Excellent friend!  how sincerely you did love me, and endeavour to
+elevate my mind until it was on a level with your own.  A selfish
+pursuit had cramped and narrowed me, until your gentleness and
+affection warmed and opened my senses; I became the same happy creature
+who, a few years ago, loved and beloved by all, had no sorrow or care.
+When happy, inanimate nature had the power of bestowing on me the most
+delightful sensations.  A serene sky and verdant fields filled me with
+ecstasy.  The present season was indeed divine; the flowers of spring
+bloomed in the hedges, while those of summer were already in bud.  I
+was undisturbed by thoughts which during the preceding year had pressed
+upon me, notwithstanding my endeavours to throw them off, with an
+invincible burden.
+
+Henry rejoiced in my gaiety, and sincerely sympathised in my feelings:
+he exerted himself to amuse me, while he expressed the sensations that
+filled his soul.  The resources of his mind on this occasion were truly
+astonishing:  his conversation was full of imagination; and very often,
+in imitation of the Persian and Arabic writers, he invented tales of
+wonderful fancy and passion.  At other times he repeated my favourite
+poems, or drew me out into arguments, which he supported with great
+ingenuity.  We returned to our college on a Sunday afternoon:  the
+peasants were dancing, and every one we met appeared gay and happy.  My
+own spirits were high, and I bounded along with feelings of unbridled
+joy and hilarity.
+
+
+
+Chapter 7
+
+On my return, I found the following letter from my father:--
+
+
+"My dear Victor,
+
+"You have probably waited impatiently for a letter to fix the date of
+your return to us; and I was at first tempted to write only a few
+lines, merely mentioning the day on which I should expect you.  But
+that would be a cruel kindness, and I dare not do it.  What would be
+your surprise, my son, when you expected a happy and glad welcome, to
+behold, on the contrary, tears and wretchedness?  And how, Victor, can
+I relate our misfortune?  Absence cannot have rendered you callous to
+our joys and griefs; and how shall I inflict pain on my long absent
+son?  I wish to prepare you for the woeful news, but I know it is
+impossible; even now your eye skims over the page to seek the words
+which are to convey to you the horrible tidings.
+
+"William is dead!--that sweet child, whose smiles delighted and warmed
+my heart, who was so gentle, yet so gay!  Victor, he is murdered!
+
+"I will not attempt to console you; but will simply relate the
+circumstances of the transaction.
+
+"Last Thursday (May 7th), I, my niece, and your two brothers, went to
+walk in Plainpalais.  The evening was warm and serene, and we prolonged
+our walk farther than usual.  It was already dusk before we thought of
+returning; and then we discovered that William and Ernest, who had gone
+on before, were not to be found.  We accordingly rested on a seat until
+they should return.  Presently Ernest came, and enquired if we had seen
+his brother; he said, that he had been playing with him, that William
+had run away to hide himself, and that he vainly sought for him, and
+afterwards waited for a long time, but that he did not return.
+
+"This account rather alarmed us, and we continued to search for him
+until night fell, when Elizabeth conjectured that he might have
+returned to the house.  He was not there.  We returned again, with
+torches; for I could not rest, when I thought that my sweet boy had
+lost himself, and was exposed to all the damps and dews of night;
+Elizabeth also suffered extreme anguish.  About five in the morning I
+discovered my lovely boy, whom the night before I had seen blooming and
+active in health, stretched on the grass livid and motionless; the
+print of the murder's finger was on his neck.
+
+"He was conveyed home, and the anguish that was visible in my
+countenance betrayed the secret to Elizabeth.  She was very earnest to
+see the corpse.  At first I attempted to prevent her but she persisted,
+and entering the room where it lay, hastily examined the neck of the
+victim, and clasping her hands exclaimed, 'O God!  I have murdered my
+darling child!'
+
+"She fainted, and was restored with extreme difficulty.  When she again
+lived, it was only to weep and sigh.  She told me, that that same
+evening William had teased her to let him wear a very valuable
+miniature that she possessed of your mother.  This picture is gone, and
+was doubtless the temptation which urged the murderer to the deed.  We
+have no trace of him at present, although our exertions to discover him
+are unremitted; but they will not restore my beloved William!
+
+"Come, dearest Victor; you alone can console Elizabeth.  She weeps
+continually, and accuses herself unjustly as the cause of his death;
+her words pierce my heart.  We are all unhappy; but will not that be an
+additional motive for you, my son, to return and be our comforter?
+Your dear mother!  Alas, Victor!  I now say, Thank God she did not live
+to witness the cruel, miserable death of her youngest darling!
+
+"Come, Victor; not brooding thoughts of vengeance against the assassin,
+but with feelings of peace and gentleness, that will heal, instead of
+festering, the wounds of our minds.  Enter the house of mourning, my
+friend, but with kindness and affection for those who love you, and not
+with hatred for your enemies.
+
+               "Your affectionate and afflicted father,
+                              "Alphonse Frankenstein.
+
+
+
+"Geneva, May 12th, 17--."
+
+Clerval, who had watched my countenance as I read this letter, was
+surprised to observe the despair that succeeded the joy I at first
+expressed on receiving new from my friends.  I threw the letter on the
+table, and covered my face with my hands.
+
+"My dear Frankenstein," exclaimed Henry, when he perceived me weep with
+bitterness, "are you always to be unhappy?  My dear friend, what has
+happened?"
+
+I motioned him to take up the letter, while I walked up and down the
+room in the extremest agitation.  Tears also gushed from the eyes of
+Clerval, as he read the account of my misfortune.
+
+"I can offer you no consolation, my friend," said he; "your disaster is
+irreparable.  What do you intend to do?"
+
+"To go instantly to Geneva: come with me, Henry, to order the horses."
+
+During our walk, Clerval endeavoured to say a few words of consolation;
+he could only express his heartfelt sympathy.  "Poor William!" said he,
+"dear lovely child, he now sleeps with his angel mother!  Who that had
+seen him bright and joyous in his young beauty, but must weep over his
+untimely loss!  To die so miserably; to feel the murderer's grasp!  How
+much more a murdered that could destroy radiant innocence!  Poor little
+fellow! one only consolation have we; his friends mourn and weep, but
+he is at rest. The pang is over, his sufferings are at an end for ever.
+A sod covers his gentle form, and he knows no pain.  He can no longer
+be a subject for pity; we must reserve that for his miserable
+survivors."
+
+Clerval spoke thus as we hurried through the streets; the words
+impressed themselves on my mind and I remembered them afterwards in
+solitude.  But now, as soon as the horses arrived, I hurried into a
+cabriolet, and bade farewell to my friend.
+
+My journey was very melancholy.  At first I wished to hurry on, for I
+longed to console and sympathise with my loved and sorrowing friends;
+but when I drew near my native town, I slackened my progress.  I could
+hardly sustain the multitude of feelings that crowded into my mind.  I
+passed through scenes familiar to my youth, but which I had not seen
+for nearly six years.  How altered every thing might be during that
+time!  One sudden and desolating change had taken place; but a thousand
+little circumstances might have by degrees worked other alterations,
+which, although they were done more tranquilly, might not be the less
+decisive.  Fear overcame me; I dared no advance, dreading a thousand
+nameless evils that made me tremble, although I was unable to define
+them.  I remained two days at Lausanne, in this painful state of mind.
+I contemplated the lake:  the waters were placid; all around was calm;
+and the snowy mountains, 'the palaces of nature,' were not changed.  By
+degrees the calm and heavenly scene restored me, and I continued my
+journey towards Geneva.
+
+The road ran by the side of the lake, which became narrower as I
+approached my native town.  I discovered more distinctly the black
+sides of Jura, and the bright summit of Mont Blanc.  I wept like a
+child.  "Dear mountains! my own beautiful lake! how do you welcome your
+wanderer?  Your summits are clear; the sky and lake are blue and
+placid.  Is this to prognosticate peace, or to mock at my unhappiness?"
+
+I fear, my friend, that I shall render myself tedious by dwelling on
+these preliminary circumstances; but they were days of comparative
+happiness, and I think of them with pleasure.  My country, my beloved
+country! who but a native can tell the delight I took in again
+beholding thy streams, thy mountains, and, more than all, thy lovely
+lake!
+
+Yet, as I drew nearer home, grief and fear again overcame me.  Night
+also closed around; and when I could hardly see the dark mountains, I
+felt still more gloomily.  The picture appeared a vast and dim scene of
+evil, and I foresaw obscurely that I was destined to become the most
+wretched of human beings.  Alas!  I prophesied truly, and failed only
+in one single circumstance, that in all the misery I imagined and
+dreaded, I did not conceive the hundredth part of the anguish I was
+destined to endure.  It was completely dark when I arrived in the
+environs of Geneva; the gates of the town were already shut; and I was
+obliged to pass the night at Secheron, a village at the distance of
+half a league from the city.  The sky was serene; and, as I was unable
+to rest, I resolved to visit the spot where my poor William had been
+murdered.  As I could not pass through the town, I was obliged to cross
+the lake in a boat to arrive at Plainpalais.  During this short voyage
+I saw the lightning playing on the summit of Mont Blanc in the most
+beautiful figures.  The storm appeared to approach rapidly, and, on
+landing, I ascended a low hill, that I might observe its progress.  It
+advanced; the heavens were clouded, and I soon felt the rain coming
+slowly in large drops, but its violence quickly increased.
+
+I quitted my seat, and walked on, although the darkness and storm
+increased every minute, and the thunder burst with a terrific crash
+over my head.  It was echoed from Saleve, the Juras, and the Alps of
+Savoy; vivid flashes of lightning dazzled my eyes, illuminating the
+lake, making it appear like a vast sheet of fire; then for an instant
+every thing seemed of a pitchy darkness, until the eye recovered itself
+from the preceding flash.  The storm, as is often the case in
+Switzerland, appeared at once in various parts of the heavens.  The
+most violent storm hung exactly north of the town, over the part of the
+lake which lies between the promontory of Belrive and the village of
+Copet.  Another storm enlightened Jura with faint flashes; and another
+darkened and sometimes disclosed the Mole, a peaked mountain to the
+east of the lake.
+
+While I watched the tempest, so beautiful yet terrific, I wandered on
+with a hasty step.  This noble war in the sky elevated my spirits; I
+clasped my hands, and exclaimed aloud, "William, dear angel! this is
+thy funeral, this thy dirge!" As I said these words, I perceived in the
+gloom a figure which stole from behind a clump of trees near me; I
+stood fixed, gazing intently:  I could not be mistaken.  A flash of
+lightning illuminated the object, and discovered its shape plainly to
+me; its gigantic stature, and the deformity of its aspect more hideous
+than belongs to humanity, instantly informed me that it was the wretch,
+the filthy daemon, to whom I had given life.  What did he there?  Could
+he be (I shuddered at the conception) the murderer of my brother?  No
+sooner did that idea cross my imagination, than I became convinced of
+its truth; my teeth chattered, and I was forced to lean against a tree
+for support.  The figure passed me quickly, and I lost it in the gloom.
+
+Nothing in human shape could have destroyed the fair child.  HE was the
+murderer!  I could not doubt it.  The mere presence of the idea was an
+irresistible proof of the fact.  I thought of pursuing the devil; but
+it would have been in vain, for another flash discovered him to me
+hanging among the rocks of the nearly perpendicular ascent of Mont
+Saleve, a hill that bounds Plainpalais on the south.  He soon reached
+the summit, and disappeared.
+
+I remained motionless.  The thunder ceased; but the rain still
+continued, and the scene was enveloped in an impenetrable darkness.  I
+revolved in my mind the events which I had until now sought to forget:
+the whole train of my progress toward the creation; the appearance of
+the works of my own hands at my bedside; its departure.  Two years had
+now nearly elapsed since the night on which he first received life; and
+was this his first crime?  Alas!  I had turned loose into the world a
+depraved wretch, whose delight was in carnage and misery; had he not
+murdered my brother?
+
+No one can conceive the anguish I suffered during the remainder of the
+night, which I spent, cold and wet, in the open air.  But I did not
+feel the inconvenience of the weather; my imagination was busy in
+scenes of evil and despair.  I considered the being whom I had cast
+among mankind, and endowed with the will and power to effect purposes
+of horror, such as the deed which he had now done, nearly in the light
+of my own vampire, my own spirit let loose from the grave, and forced
+to destroy all that was dear to me.
+
+Day dawned; and I directed my steps towards the town.  The gates were
+open, and I hastened to my father's house.  My first thought was to
+discover what I knew of the murderer, and cause instant pursuit to be
+made.  But I paused when I reflected on the story that I had to tell. A
+being whom I myself had formed, and endued with life, had met me at
+midnight among the precipices of an inaccessible mountain.  I
+remembered also the nervous fever with which I had been seized just at
+the time that I dated my creation, and which would give an air of
+delirium to a tale otherwise so utterly improbable.  I well knew that
+if any other had communicated such a relation to me, I should have
+looked upon it as the ravings of insanity.  Besides, the strange nature
+of the animal would elude all pursuit, even if I were so far credited
+as to persuade my relatives to commence it.  And then of what use would
+be pursuit?  Who could arrest a creature capable of scaling the
+overhanging sides of Mont Saleve?  These reflections determined me, and
+I resolved to remain silent.
+
+It was about five in the morning when I entered my father's house.  I
+told the servants not to disturb the family, and went into the library
+to attend their usual hour of rising.
+
+Six years had elapsed, passed in a dream but for one indelible trace,
+and I stood in the same place where I had last embraced my father
+before my departure for Ingolstadt.  Beloved and venerable parent!  He
+still remained to me.  I gazed on the picture of my mother, which stood
+over the mantel-piece.  It was an historical subject, painted at my
+father's desire, and represented Caroline Beaufort in an agony of
+despair, kneeling by the coffin of her dead father.  Her garb was
+rustic, and her cheek pale; but there was an air of dignity and beauty,
+that hardly permitted the sentiment of pity.  Below this picture was a
+miniature of William; and my tears flowed when I looked upon it.  While
+I was thus engaged, Ernest entered:  he had heard me arrive, and
+hastened to welcome me:  "Welcome, my dearest Victor," said he.  "Ah! I
+wish you had come three months ago, and then you would have found us
+all joyous and delighted.  You come to us now to share a misery which
+nothing can alleviate; yet your presence will, I hope, revive our
+father, who seems sinking under his misfortune; and your persuasions
+will induce poor Elizabeth to cease her vain and tormenting
+self-accusations.--Poor William! he was our darling and our pride!"
+
+Tears, unrestrained, fell from my brother's eyes; a sense of mortal
+agony crept over my frame.  Before, I had only imagined the
+wretchedness of my desolated home; the reality came on me as a new, and
+a not less terrible, disaster.  I tried to calm Ernest; I enquired more
+minutely concerning my father, and here I named my cousin.
+
+"She most of all," said Ernest, "requires consolation; she accused
+herself of having caused the death of my brother, and that made her
+very wretched.  But since the murderer has been discovered--"
+
+"The murderer discovered!  Good God! how can that be? who could attempt
+to pursue him?  It is impossible; one might as well try to overtake the
+winds, or confine a mountain-stream with a straw.  I saw him too; he
+was free last night!"
+
+"I do not know what you mean," replied my brother, in accents of
+wonder, "but to us the discovery we have made completes our misery.  No
+one would believe it at first; and even now Elizabeth will not be
+convinced, notwithstanding all the evidence.  Indeed, who would credit
+that Justine Moritz, who was so amiable, and fond of all the family,
+could suddenly become so capable of so frightful, so appalling a crime?"
+
+"Justine Moritz!  Poor, poor girl, is she the accused?  But it is
+wrongfully; every one knows that; no one believes it, surely, Ernest?"
+
+"No one did at first; but several circumstances came out, that have
+almost forced conviction upon us; and her own behaviour has been so
+confused, as to add to the evidence of facts a weight that, I fear,
+leaves no hope for doubt.  But she will be tried today, and you will
+then hear all."
+
+He then related that, the morning on which the murder of poor William
+had been discovered, Justine had been taken ill, and confined to her
+bed for several days.  During this interval, one of the servants,
+happening to examine the apparel she had worn on the night of the
+murder, had discovered in her pocket the picture of my mother, which
+had been judged to be the temptation of the murderer.  The servant
+instantly showed it to one of the others, who, without saying a word to
+any of the family, went to a magistrate; and, upon their deposition,
+Justine was apprehended.  On being charged with the fact, the poor girl
+confirmed the suspicion in a great measure by her extreme confusion of
+manner.
+
+This was a strange tale, but it did not shake my faith; and I replied
+earnestly, "You are all mistaken; I know the murderer.  Justine, poor,
+good Justine, is innocent."
+
+At that instant my father entered.  I saw unhappiness deeply impressed
+on his countenance, but he endeavoured to welcome me cheerfully; and,
+after we had exchanged our mournful greeting, would have introduced
+some other topic than that of our disaster, had not Ernest exclaimed,
+"Good God, papa!  Victor says that he knows who was the murderer of
+poor William."
+
+"We do also, unfortunately," replied my father, "for indeed I had
+rather have been for ever ignorant than have discovered so much
+depravity and ungratitude in one I valued so highly."
+
+"My dear father, you are mistaken; Justine is innocent."
+
+"If she is, God forbid that she should suffer as guilty.  She is to be
+tried today, and I hope, I sincerely hope, that she will be acquitted."
+
+This speech calmed me.  I was firmly convinced in my own mind that
+Justine, and indeed every human being, was guiltless of this murder.  I
+had no fear, therefore, that any circumstantial evidence could be
+brought forward strong enough to convict her.  My tale was not one to
+announce publicly; its astounding horror would be looked upon as
+madness by the vulgar.  Did any one indeed exist, except I, the
+creator, who would believe, unless his senses convinced him, in the
+existence of the living monument of presumption and rash ignorance
+which I had let loose upon the world?
+
+We were soon joined by Elizabeth.  Time had altered her since I last
+beheld her; it had endowed her with loveliness surpassing the beauty of
+her childish years.  There was the same candour, the same vivacity, but
+it was allied to an expression more full of sensibility and intellect.
+She welcomed me with the greatest affection.  "Your arrival, my dear
+cousin," said she, "fills me with hope.  You perhaps will find some
+means to justify my poor guiltless Justine.  Alas! who is safe, if she
+be convicted of crime?  I rely on her innocence as certainly as I do
+upon my own.  Our misfortune is doubly hard to us; we have not only
+lost that lovely darling boy, but this poor girl, whom I sincerely
+love, is to be torn away by even a worse fate.  If she is condemned, I
+never shall know joy more.  But she will not, I am sure she will not;
+and then I shall be happy again, even after the sad death of my little
+William."
+
+"She is innocent, my Elizabeth," said I, "and that shall be proved;
+fear nothing, but let your spirits be cheered by the assurance of her
+acquittal."
+
+"How kind and generous you are! every one else believes in her guilt,
+and that made me wretched, for I knew that it was impossible:  and to
+see every one else prejudiced in so deadly a manner rendered me
+hopeless and despairing."  She wept.
+
+"Dearest niece," said my father, "dry your tears.  If she is, as you
+believe, innocent, rely on the justice of our laws, and the activity
+with which I shall prevent the slightest shadow of partiality."
+
+
+
+Chapter 8
+
+We passed a few sad hours until eleven o'clock, when the trial was to
+commence.  My father and the rest of the family being obliged to attend
+as witnesses, I accompanied them to the court.  During the whole of
+this wretched mockery of justice I suffered living torture.  It was to
+be decided whether the result of my curiosity and lawless devices would
+cause the death of two of my fellow beings:  one a smiling babe full of
+innocence and joy, the other far more dreadfully murdered, with every
+aggravation of infamy that could make the murder memorable in horror.
+Justine also was a girl of merit and possessed qualities which promised
+to render her life happy; now all was to be obliterated in an
+ignominious grave, and I the cause!  A thousand times rather would I
+have confessed myself guilty of the crime ascribed to Justine, but I
+was absent when it was committed, and such a declaration would have
+been considered as the ravings of a madman and would not have
+exculpated her who suffered through me.
+
+The appearance of Justine was calm.  She was dressed in mourning, and
+her countenance, always engaging, was rendered, by the solemnity of her
+feelings, exquisitely beautiful.  Yet she appeared confident in
+innocence and did not tremble, although gazed on and execrated by
+thousands, for all the kindness which her beauty might otherwise have
+excited was obliterated in the minds of the spectators by the
+imagination of the enormity she was supposed to have committed.  She
+was tranquil, yet her tranquillity was evidently constrained; and as
+her confusion had before been adduced as a proof of her guilt, she
+worked up her mind to an appearance of courage.  When she entered the
+court she threw her eyes round it and quickly discovered where we were
+seated.  A tear seemed to dim her eye when she saw us, but she quickly
+recovered herself, and a look of sorrowful affection seemed to attest
+her utter guiltlessness.
+
+The trial began, and after the advocate against her had stated the
+charge, several witnesses were called.  Several strange facts combined
+against her, which might have staggered anyone who had not such proof
+of her innocence as I had.  She had been out the whole of the night on
+which the murder had been committed and towards morning had been
+perceived by a market-woman not far from the spot where the body of the
+murdered child had been afterwards found.  The woman asked her what she
+did there, but she looked very strangely and only returned a confused
+and unintelligible answer.  She returned to the house about eight
+o'clock, and when one inquired where she had passed the night, she
+replied that she had been looking for the child and demanded earnestly
+if anything had been heard concerning him.  When shown the body, she
+fell into violent hysterics and kept her bed for several days.  The
+picture was then produced which the servant had found in her pocket;
+and when Elizabeth, in a faltering voice, proved that it was the same
+which, an hour before the child had been missed, she had placed round
+his neck, a murmur of horror and indignation filled the court.
+
+Justine was called on for her defence.  As the trial had proceeded, her
+countenance had altered.  Surprise, horror, and misery were strongly
+expressed.  Sometimes she struggled with her tears, but when she was
+desired to plead, she collected her powers and spoke in an audible
+although variable voice.
+
+"God knows," she said, "how entirely I am innocent.  But I do not
+pretend that my protestations should acquit me; I rest my innocence on
+a plain and simple explanation of the facts which have been adduced
+against me, and I hope the character I have always borne will incline
+my judges to a favourable interpretation where any circumstance appears
+doubtful or suspicious."
+
+She then related that, by the permission of Elizabeth, she had passed
+the evening of the night on which the murder had been committed at the
+house of an aunt at Chene, a village situated at about a league from
+Geneva.  On her return, at about nine o'clock, she met a man who asked
+her if she had seen anything of the child who was lost.  She was
+alarmed by this account and passed several hours in looking for him,
+when the gates of Geneva were shut, and she was forced to remain
+several hours of the night in a barn belonging to a cottage, being
+unwilling to call up the inhabitants, to whom she was well known.  Most
+of the night she spent here watching; towards morning she believed that
+she slept for a few minutes; some steps disturbed her, and she awoke.
+It was dawn, and she quitted her asylum, that she might again endeavour
+to find my brother.  If she had gone near the spot where his body lay,
+it was without her knowledge.  That she had been bewildered when
+questioned by the market-woman was not surprising, since she had passed
+a sleepless night and the fate of poor William was yet uncertain.
+Concerning the picture she could give no account.
+
+"I know," continued the unhappy victim, "how heavily and fatally this
+one circumstance weighs against me, but I have no power of explaining
+it; and when I have expressed my utter ignorance, I am only left to
+conjecture concerning the probabilities by which it might have been
+placed in my pocket.  But here also I am checked.  I believe that I
+have no enemy on earth, and none surely would have been so wicked as to
+destroy me wantonly.  Did the murderer place it there?  I know of no
+opportunity afforded him for so doing; or, if I had, why should he have
+stolen the jewel, to part with it again so soon?
+
+"I commit my cause to the justice of my judges, yet I see no room for
+hope.  I beg permission to have a few witnesses examined concerning my
+character, and if their testimony shall not overweigh my supposed
+guilt, I must be condemned, although I would pledge my salvation on my
+innocence."
+
+Several witnesses were called who had known her for many years, and
+they spoke well of her; but fear and hatred of the crime of which they
+supposed her guilty rendered them timorous and unwilling to come
+forward.  Elizabeth saw even this last resource, her excellent
+dispositions and irreproachable conduct, about to fail the accused,
+when, although violently agitated, she desired permission to address
+the court.
+
+"I am," said she, "the cousin of the unhappy child who was murdered, or
+rather his sister, for I was educated by and have lived with his
+parents ever since and even long before his birth.  It may therefore be
+judged indecent in me to come forward on this occasion, but when I see
+a fellow creature about to perish through the cowardice of her
+pretended friends, I wish to be allowed to speak, that I may say what I
+know of her character.  I am well acquainted with the accused.  I have
+lived in the same house with her, at one time for five and at another
+for nearly two years.  During all that period she appeared to me the
+most amiable and benevolent of human creatures.  She nursed Madame
+Frankenstein, my aunt, in her last illness, with the greatest affection
+and care and afterwards attended her own mother during a tedious
+illness, in a manner that excited the admiration of all who knew her,
+after which she again lived in my uncle's house, where she was beloved
+by all the family.  She was warmly attached to the child who is now
+dead and acted towards him like a most affectionate mother.  For my own
+part, I do not hesitate to say that, notwithstanding all the evidence
+produced against her, I believe and rely on her perfect innocence.  She
+had no temptation for such an action; as to the bauble on which the
+chief proof rests, if she had earnestly desired it, I should have
+willingly given it to her, so much do I esteem and value her."
+
+A murmur of approbation followed Elizabeth's simple and powerful
+appeal, but it was excited by her generous interference, and not in
+favour of poor Justine, on whom the public indignation was turned with
+renewed violence, charging her with the blackest ingratitude.  She
+herself wept as Elizabeth spoke, but she did not answer.  My own
+agitation and anguish was extreme during the whole trial.  I believed
+in her innocence; I knew it.  Could the demon who had (I did not for a
+minute doubt) murdered my brother also in his hellish sport have
+betrayed the innocent to death and ignominy?  I could not sustain the
+horror of my situation, and when I perceived that the popular voice and
+the countenances of the judges had already condemned my unhappy victim,
+I rushed out of the court in agony.  The tortures of the accused did
+not equal mine; she was sustained by innocence, but the fangs of
+remorse tore my bosom and would not forgo their hold.
+
+I passed a night of unmingled wretchedness.  In the morning I went to
+the court; my lips and throat were parched.  I dared not ask the fatal
+question, but I was known, and the officer guessed the cause of my
+visit.  The ballots had been thrown; they were all black, and Justine
+was condemned.
+
+I cannot pretend to describe what I then felt.  I had before
+experienced sensations of horror, and I have endeavoured to bestow upon
+them adequate expressions, but words cannot convey an idea of the
+heart-sickening despair that I then endured.  The person to whom I
+addressed myself added that Justine had already confessed her guilt.
+"That evidence," he observed, "was hardly required in so glaring a
+case, but I am glad of it, and, indeed, none of our judges like to
+condemn a criminal upon circumstantial evidence, be it ever so
+decisive."
+
+This was strange and unexpected intelligence; what could it mean?  Had
+my eyes deceived me?  And was I really as mad as the whole world would
+believe me to be if I disclosed the object of my suspicions?  I
+hastened to return home, and Elizabeth eagerly demanded the result.
+
+"My cousin," replied I, "it is decided as you may have expected; all
+judges had rather that ten innocent should suffer than that one guilty
+should escape.  But she has confessed."
+
+This was a dire blow to poor Elizabeth, who had relied with firmness
+upon Justine's innocence.  "Alas!" said she.  "How shall I ever again
+believe in human goodness?  Justine, whom I loved and esteemed as my
+sister, how could she put on those smiles of innocence only to betray?
+Her mild eyes seemed incapable of any severity or guile, and yet she
+has committed a murder."
+
+Soon after we heard that the poor victim had expressed a desire to see
+my cousin.  My father wished her not to go but said that he left it to
+her own judgment and feelings to decide.  "Yes," said Elizabeth, "I
+will go, although she is guilty; and you, Victor, shall accompany me; I
+cannot go alone."  The idea of this visit was torture to me, yet I
+could not refuse.  We entered the gloomy prison chamber and beheld
+Justine sitting on some straw at the farther end; her hands were
+manacled, and her head rested on her knees.  She rose on seeing us
+enter, and when we were left alone with her, she threw herself at the
+feet of Elizabeth, weeping bitterly.  My cousin wept also.
+
+"Oh, Justine!" said she.  "Why did you rob me of my last consolation?
+I relied on your innocence, and although I was then very wretched, I
+was not so miserable as I am now."
+
+"And do you also believe that I am so very, very wicked?  Do you also
+join with my enemies to crush me, to condemn me as a murderer?" Her
+voice was suffocated with sobs.
+
+"Rise, my poor girl," said Elizabeth; "why do you kneel, if you are
+innocent?  I am not one of your enemies, I believed you guiltless,
+notwithstanding every evidence, until I heard that you had yourself
+declared your guilt.  That report, you say, is false; and be assured,
+dear Justine, that nothing can shake my confidence in you for a moment,
+but your own confession."
+
+"I did confess, but I confessed a lie.  I confessed, that I might
+obtain absolution; but now that falsehood lies heavier at my heart than
+all my other sins.  The God of heaven forgive me!  Ever since I was
+condemned, my confessor has besieged me; he threatened and menaced,
+until I almost began to think that I was the monster that he said I
+was.  He threatened excommunication and hell fire in my last moments if
+I continued obdurate.  Dear lady, I had none to support me; all looked
+on me as a wretch doomed to ignominy and perdition.  What could I do?
+In an evil hour I subscribed to a lie; and now only am I truly
+miserable."
+
+She paused, weeping, and then continued, "I thought with horror, my
+sweet lady, that you should believe your Justine, whom your blessed
+aunt had so highly honoured, and whom you loved, was a creature capable
+of a crime which none but the devil himself could have perpetrated.
+Dear William! dearest blessed child!  I soon shall see you again in
+heaven, where we shall all be happy; and that consoles me, going as I
+am to suffer ignominy and death."
+
+"Oh, Justine!  Forgive me for having for one moment distrusted you.
+Why did you confess?  But do not mourn, dear girl.  Do not fear.  I
+will proclaim, I will prove your innocence.  I will melt the stony
+hearts of your enemies by my tears and prayers.  You shall not die!
+You, my playfellow, my companion, my sister, perish on the scaffold!
+No!  No!  I never could survive so horrible a misfortune."
+
+Justine shook her head mournfully.  "I do not fear to die," she said;
+"that pang is past.  God raises my weakness and gives me courage to
+endure the worst.  I leave a sad and bitter world; and if you remember
+me and think of me as of one unjustly condemned, I am resigned to the
+fate awaiting me.  Learn from me, dear lady, to submit in patience to
+the will of heaven!"
+
+During this conversation I had retired to a corner of the prison room,
+where I could conceal the horrid anguish that possessed me.  Despair!
+Who dared talk of that?  The poor victim, who on the morrow was to pass
+the awful boundary between life and death, felt not, as I did, such
+deep and bitter agony.  I gnashed my teeth and ground them together,
+uttering a groan that came from my inmost soul.  Justine started.  When
+she saw who it was, she approached me and said, "Dear sir, you are very
+kind to visit me; you, I hope, do not believe that I am guilty?"
+
+I could not answer.  "No, Justine," said Elizabeth; "he is more
+convinced of your innocence than I was, for even when he heard that you
+had confessed, he did not credit it."
+
+"I truly thank him.  In these last moments I feel the sincerest
+gratitude towards those who think of me with kindness.  How sweet is
+the affection of others to such a wretch as I am!  It removes more than
+half my misfortune, and I feel as if I could die in peace now that my
+innocence is acknowledged by you, dear lady, and your cousin."
+
+Thus the poor sufferer tried to comfort others and herself.  She indeed
+gained the resignation she desired.  But I, the true murderer, felt the
+never-dying worm alive in my bosom, which allowed of no hope or
+consolation.  Elizabeth also wept and was unhappy, but hers also was
+the misery of innocence, which, like a cloud that passes over the fair
+moon, for a while hides but cannot tarnish its brightness.  Anguish and
+despair had penetrated into the core of my heart; I bore a hell within
+me which nothing could extinguish.  We stayed several hours with
+Justine, and it was with great difficulty that Elizabeth could tear
+herself away.  "I wish," cried she, "that I were to die with you; I
+cannot live in this world of misery."
+
+Justine assumed an air of cheerfulness, while she with difficulty
+repressed her bitter tears.  She embraced Elizabeth and said in a voice
+of half-suppressed emotion, "Farewell, sweet lady, dearest Elizabeth,
+my beloved and only friend; may heaven, in its bounty, bless and
+preserve you; may this be the last misfortune that you will ever
+suffer!  Live, and be happy, and make others so."
+
+And on the morrow Justine died.  Elizabeth's heart-rending eloquence
+failed to move the judges from their settled conviction in the
+criminality of the saintly sufferer.  My passionate and indignant
+appeals were lost upon them.  And when I received their cold answers
+and heard the harsh, unfeeling reasoning of these men, my purposed
+avowal died away on my lips.  Thus I might proclaim myself a madman,
+but not revoke the sentence passed upon my wretched victim.  She
+perished on the scaffold as a murderess!
+
+From the tortures of my own heart, I turned to contemplate the deep and
+voiceless grief of my Elizabeth.  This also was my doing!  And my
+father's woe, and the desolation of that late so smiling home all was
+the work of my thrice-accursed hands!  Ye weep, unhappy ones, but these
+are not your last tears!  Again shall you raise the funeral wail, and
+the sound of your lamentations shall again and again be heard!
+Frankenstein, your son, your kinsman, your early, much-loved friend; he
+who would spend each vital drop of blood for your sakes, who has no
+thought nor sense of joy except as it is mirrored also in your dear
+countenances, who would fill the air with blessings and spend his life
+in serving you--he bids you weep, to shed countless tears; happy beyond
+his hopes, if thus inexorable fate be satisfied, and if the destruction
+pause before the peace of the grave have succeeded to your sad torments!
+
+Thus spoke my prophetic soul, as, torn by remorse, horror, and despair,
+I beheld those I loved spend vain sorrow upon the graves of William and
+Justine, the first hapless victims to my unhallowed arts.
+
+
+
+Chapter 9
+
+Nothing is more painful to the human mind than, after the feelings have
+been worked up by a quick succession of events, the dead calmness of
+inaction and certainty which follows and deprives the soul both of hope
+and fear.  Justine died, she rested, and I was alive.  The blood flowed
+freely in my veins, but a weight of despair and remorse pressed on my
+heart which nothing could remove.  Sleep fled from my eyes; I wandered
+like an evil spirit, for I had committed deeds of mischief beyond
+description horrible, and more, much more (I persuaded myself) was yet
+behind.  Yet my heart overflowed with kindness and the love of virtue.
+I had begun life with benevolent intentions and thirsted for the moment
+when I should put them in practice and make myself useful to my fellow
+beings.  Now all was blasted; instead of that serenity of conscience
+which allowed me to look back upon the past with self-satisfaction, and
+from thence to gather promise of new hopes, I was seized by remorse and
+the sense of guilt, which hurried me away to a hell of intense tortures
+such as no language can describe.
+
+This state of mind preyed upon my health, which had perhaps never
+entirely recovered from the first shock it had sustained.  I shunned
+the face of man; all sound of joy or complacency was torture to me;
+solitude was my only consolation--deep, dark, deathlike solitude.
+
+My father observed with pain the alteration perceptible in my
+disposition and habits and endeavoured by arguments deduced from the
+feelings of his serene conscience and guiltless life to inspire me with
+fortitude and awaken in me the courage to dispel the dark cloud which
+brooded over me.  "Do you think, Victor," said he, "that I do not
+suffer also?  No one could love a child more than I loved your
+brother"--tears came into his eyes as he spoke--"but is it not a duty
+to the survivors that we should refrain from augmenting their
+unhappiness by an appearance of immoderate grief?  It is also a duty
+owed to yourself, for excessive sorrow prevents improvement or
+enjoyment, or even the discharge of daily usefulness, without which no
+man is fit for society."
+
+This advice, although good, was totally inapplicable to my case; I
+should have been the first to hide my grief and console my friends if
+remorse had not mingled its bitterness, and terror its alarm, with my
+other sensations.  Now I could only answer my father with a look of
+despair and endeavour to hide myself from his view.
+
+About this time we retired to our house at Belrive.  This change was
+particularly agreeable to me.  The shutting of the gates regularly at
+ten o'clock and the impossibility of remaining on the lake after that
+hour had rendered our residence within the walls of Geneva very irksome
+to me.  I was now free.  Often, after the rest of the family had
+retired for the night, I took the boat and passed many hours upon the
+water.  Sometimes, with my sails set, I was carried by the wind; and
+sometimes, after rowing into the middle of the lake, I left the boat to
+pursue its own course and gave way to my own miserable reflections.  I
+was often tempted, when all was at peace around me, and I the only
+unquiet thing that wandered restless in a scene so beautiful and
+heavenly--if I except some bat, or the frogs, whose harsh and
+interrupted croaking was heard only when I approached the shore--often,
+I say, I was tempted to plunge into the silent lake, that the waters
+might close over me and my calamities forever.  But I was restrained,
+when I thought of the heroic and suffering Elizabeth, whom I tenderly
+loved, and whose existence was bound up in mine.  I thought also of my
+father and surviving brother; should I by my base desertion leave them
+exposed and unprotected to the malice of the fiend whom I had let loose
+among them?
+
+At these moments I wept bitterly and wished that peace would revisit my
+mind only that I might afford them consolation and happiness.  But that
+could not be.  Remorse extinguished every hope.  I had been the author
+of unalterable evils, and I lived in daily fear lest the monster whom I
+had created should perpetrate some new wickedness.  I had an obscure
+feeling that all was not over and that he would still commit some
+signal crime, which by its enormity should almost efface the
+recollection of the past.  There was always scope for fear so long as
+anything I loved remained behind.  My abhorrence of this fiend cannot
+be conceived.  When I thought of him I gnashed my teeth, my eyes became
+inflamed, and I ardently wished to extinguish that life which I had so
+thoughtlessly bestowed.  When I reflected on his crimes and malice, my
+hatred and revenge burst all bounds of moderation.  I would have made a
+pilgrimage to the highest peak of the Andes, could I when there have
+precipitated him to their base.  I wished to see him again, that I
+might wreak the utmost extent of abhorrence on his head and avenge the
+deaths of William and Justine.  Our house was the house of mourning. My
+father's health was deeply shaken by the horror of the recent events.
+Elizabeth was sad and desponding; she no longer took delight in her
+ordinary occupations; all pleasure seemed to her sacrilege toward the
+dead; eternal woe and tears she then thought was the just tribute she
+should pay to innocence so blasted and destroyed.  She was no longer
+that happy creature who in earlier youth wandered with me on the banks
+of the lake and talked with ecstasy of our future prospects.  The first
+of those sorrows which are sent to wean us from the earth had visited
+her, and its dimming influence quenched her dearest smiles.
+
+"When I reflect, my dear cousin," said she, "on the miserable death of
+Justine Moritz, I no longer see the world and its works as they before
+appeared to me.  Before, I looked upon the accounts of vice and
+injustice that I read in books or heard from others as tales of ancient
+days or imaginary evils; at least they were remote and more familiar to
+reason than to the imagination; but now misery has come home, and men
+appear to me as monsters thirsting for each other's blood.  Yet I am
+certainly unjust.  Everybody believed that poor girl to be guilty; and
+if she could have committed the crime for which she suffered, assuredly
+she would have been the most depraved of human creatures.  For the sake
+of a few jewels, to have murdered the son of her benefactor and friend,
+a child whom she had nursed from its birth, and appeared to love as if
+it had been her own!  I could not consent to the death of any human
+being, but certainly I should have thought such a creature unfit to
+remain in the society of men.  But she was innocent.  I know, I feel
+she was innocent; you are of the same opinion, and that confirms me.
+Alas!  Victor, when falsehood can look so like the truth, who can
+assure themselves of certain happiness?  I feel as if I were walking on
+the edge of a precipice, towards which thousands are crowding and
+endeavouring to plunge me into the abyss.  William and Justine were
+assassinated, and the murderer escapes; he walks about the world free,
+and perhaps respected.  But even if I were condemned to suffer on the
+scaffold for the same crimes, I would not change places with such a
+wretch."
+
+I listened to this discourse with the extremest agony.  I, not in deed,
+but in effect, was the true murderer.  Elizabeth read my anguish in my
+countenance, and kindly taking my hand, said, "My dearest friend, you
+must calm yourself.  These events have affected me, God knows how
+deeply; but I am not so wretched as you are.  There is an expression of
+despair, and sometimes of revenge, in your countenance that makes me
+tremble.  Dear Victor, banish these dark passions.  Remember the
+friends around you, who centre all their hopes in you.  Have we lost
+the power of rendering you happy?  Ah!  While we love, while we are
+true to each other, here in this land of peace and beauty, your native
+country, we may reap every tranquil blessing--what can disturb our
+peace?"
+
+And could not such words from her whom I fondly prized before every
+other gift of fortune suffice to chase away the fiend that lurked in my
+heart?  Even as she spoke I drew near to her, as if in terror, lest at
+that very moment the destroyer had been near to rob me of her.
+
+Thus not the tenderness of friendship, nor the beauty of earth, nor of
+heaven, could redeem my soul from woe; the very accents of love were
+ineffectual.  I was encompassed by a cloud which no beneficial
+influence could penetrate.  The wounded deer dragging its fainting
+limbs to some untrodden brake, there to gaze upon the arrow which had
+pierced it, and to die, was but a type of me.
+
+Sometimes I could cope with the sullen despair that overwhelmed me, but
+sometimes the whirlwind passions of my soul drove me to seek, by bodily
+exercise and by change of place, some relief from my intolerable
+sensations.  It was during an access of this kind that I suddenly left
+my home, and bending my steps towards the near Alpine valleys, sought
+in the magnificence, the eternity of such scenes, to forget myself and
+my ephemeral, because human, sorrows.  My wanderings were directed
+towards the valley of Chamounix.  I had visited it frequently during my
+boyhood.  Six years had passed since then:  _I_ was a wreck, but nought
+had changed in those savage and enduring scenes.
+
+I performed the first part of my journey on horseback.  I afterwards
+hired a mule, as the more sure-footed and least liable to receive
+injury on these rugged roads.  The weather was fine; it was about the
+middle of the month of August, nearly two months after the death of
+Justine, that miserable epoch from which I dated all my woe.  The
+weight upon my spirit was sensibly lightened as I plunged yet deeper in
+the ravine of Arve.  The immense mountains and precipices that overhung
+me on every side, the sound of the river raging among the rocks, and
+the dashing of the waterfalls around spoke of a power mighty as
+Omnipotence--and I ceased to fear or to bend before any being less
+almighty than that which had created and ruled the elements, here
+displayed in their most terrific guise.  Still, as I ascended higher,
+the valley assumed a more magnificent and astonishing character.
+Ruined castles hanging on the precipices of piny mountains, the
+impetuous Arve, and cottages every here and there peeping forth from
+among the trees formed a scene of singular beauty.  But it was
+augmented and rendered sublime by the mighty Alps, whose white and
+shining pyramids and domes towered above all, as belonging to another
+earth, the habitations of another race of beings.
+
+I passed the bridge of Pelissier, where the ravine, which the river
+forms, opened before me, and I began to ascend the mountain that
+overhangs it.  Soon after, I entered the valley of Chamounix.  This
+valley is more wonderful and sublime, but not so beautiful and
+picturesque as that of Servox, through which I had just passed.  The
+high and snowy mountains were its immediate boundaries, but I saw no
+more ruined castles and fertile fields.  Immense glaciers approached
+the road; I heard the rumbling thunder of the falling avalanche and
+marked the smoke of its passage.  Mont Blanc, the supreme and
+magnificent Mont Blanc, raised itself from the surrounding aiguilles,
+and its tremendous dome overlooked the valley.
+
+A tingling long-lost sense of pleasure often came across me during this
+journey.  Some turn in the road, some new object suddenly perceived and
+recognized, reminded me of days gone by, and were associated with the
+lighthearted gaiety of boyhood.  The very winds whispered in soothing
+accents, and maternal Nature bade me weep no more.  Then again the
+kindly influence ceased to act--I found myself fettered again to grief
+and indulging in all the misery of reflection.  Then I spurred on my
+animal, striving so to forget the world, my fears, and more than all,
+myself--or, in a more desperate fashion, I alighted and threw myself on
+the grass, weighed down by horror and despair.
+
+At length I arrived at the village of Chamounix.  Exhaustion succeeded
+to the extreme fatigue both of body and of mind which I had endured.
+For a short space of time I remained at the window watching the pallid
+lightnings that played above Mont Blanc and listening to the rushing of
+the Arve, which pursued its noisy way beneath.  The same lulling sounds
+acted as a lullaby to my too keen sensations; when I placed my head
+upon my pillow, sleep crept over me; I felt it as it came and blessed
+the giver of oblivion.
+
+
+
+Chapter 10
+
+I spent the following day roaming through the valley.  I stood beside
+the sources of the Arveiron, which take their rise in a glacier, that
+with slow pace is advancing down from the summit of the hills to
+barricade the valley.  The abrupt sides of vast mountains were before
+me; the icy wall of the glacier overhung me; a few shattered pines were
+scattered around; and the solemn silence of this glorious
+presence-chamber of imperial nature was broken only by the brawling
+waves or the fall of some vast fragment, the thunder sound of the
+avalanche or the cracking, reverberated along the mountains, of the
+accumulated ice, which, through the silent working of immutable laws,
+was ever and anon rent and torn, as if it had been but a plaything in
+their hands.  These sublime and magnificent scenes afforded me the
+greatest consolation that I was capable of receiving.  They elevated me
+from all littleness of feeling, and although they did not remove my
+grief, they subdued and tranquillized it.  In some degree, also, they
+diverted my mind from the thoughts over which it had brooded for the
+last month.  I retired to rest at night; my slumbers, as it were,
+waited on and ministered to by the assemblance of grand shapes which I
+had contemplated during the day.  They congregated round me; the
+unstained snowy mountain-top, the glittering pinnacle, the pine woods,
+and ragged bare ravine, the eagle, soaring amidst the clouds--they all
+gathered round me and bade me be at peace.
+
+Where had they fled when the next morning I awoke?  All of
+soul-inspiriting fled with sleep, and dark melancholy clouded every
+thought.  The rain was pouring in torrents, and thick mists hid the
+summits of the mountains, so that I even saw not the faces of those
+mighty friends.  Still I would penetrate their misty veil and seek them
+in their cloudy retreats.  What were rain and storm to me?  My mule was
+brought to the door, and I resolved to ascend to the summit of
+Montanvert.  I remembered the effect that the view of the tremendous
+and ever-moving glacier had produced upon my mind when I first saw it.
+It had then filled me with a sublime ecstasy that gave wings to the
+soul and allowed it to soar from the obscure world to light and joy.
+The sight of the awful and majestic in nature had indeed always the
+effect of solemnizing my mind and causing me to forget the passing
+cares of life.  I determined to go without a guide, for I was well
+acquainted with the path, and the presence of another would destroy the
+solitary grandeur of the scene.
+
+The ascent is precipitous, but the path is cut into continual and short
+windings, which enable you to surmount the perpendicularity of the
+mountain.  It is a scene terrifically desolate.  In a thousand spots
+the traces of the winter avalanche may be perceived, where trees lie
+broken and strewed on the ground, some entirely destroyed, others bent,
+leaning upon the jutting rocks of the mountain or transversely upon
+other trees.  The path, as you ascend higher, is intersected by ravines
+of snow, down which stones continually roll from above; one of them is
+particularly dangerous, as the slightest sound, such as even speaking
+in a loud voice, produces a concussion of air sufficient to draw
+destruction upon the head of the speaker.  The pines are not tall or
+luxuriant, but they are sombre and add an air of severity to the scene.
+I looked on the valley beneath; vast mists were rising from the rivers
+which ran through it and curling in thick wreaths around the opposite
+mountains, whose summits were hid in the uniform clouds, while rain
+poured from the dark sky and added to the melancholy impression I
+received from the objects around me.  Alas!  Why does man boast of
+sensibilities superior to those apparent in the brute; it only renders
+them more necessary beings.  If our impulses were confined to hunger,
+thirst, and desire, we might be nearly free; but now we are moved by
+every wind that blows and a chance word or scene that that word may
+convey to us.
+
+
+  We rest; a dream has power to poison sleep.
+   We rise; one wand'ring thought pollutes the day.
+  We feel, conceive, or reason; laugh or weep,
+   Embrace fond woe, or cast our cares away;
+  It is the same:  for, be it joy or sorrow,
+   The path of its departure still is free.
+  Man's yesterday may ne'er be like his morrow;
+   Nought may endure but mutability!
+
+
+It was nearly noon when I arrived at the top of the ascent.  For some
+time I sat upon the rock that overlooks the sea of ice.  A mist covered
+both that and the surrounding mountains.  Presently a breeze dissipated
+the cloud, and I descended upon the glacier.  The surface is very
+uneven, rising like the waves of a troubled sea, descending low, and
+interspersed by rifts that sink deep.  The field of ice is almost a
+league in width, but I spent nearly two hours in crossing it.  The
+opposite mountain is a bare perpendicular rock.  From the side where I
+now stood Montanvert was exactly opposite, at the distance of a league;
+and above it rose Mont Blanc, in awful majesty.  I remained in a recess
+of the rock, gazing on this wonderful and stupendous scene.  The sea,
+or rather the vast river of ice, wound among its dependent mountains,
+whose aerial summits hung over its recesses.  Their icy and glittering
+peaks shone in the sunlight over the clouds.  My heart, which was
+before sorrowful, now swelled with something like joy; I exclaimed,
+"Wandering spirits, if indeed ye wander, and do not rest in your narrow
+beds, allow me this faint happiness, or take me, as your companion,
+away from the joys of life."
+
+As I said this I suddenly beheld the figure of a man, at some distance,
+advancing towards me with superhuman speed.  He bounded over the
+crevices in the ice, among which I had walked with caution; his
+stature, also, as he approached, seemed to exceed that of man.  I was
+troubled; a mist came over my eyes, and I felt a faintness seize me,
+but I was quickly restored by the cold gale of the mountains.  I
+perceived, as the shape came nearer (sight tremendous and abhorred!)
+that it was the wretch whom I had created.  I trembled with rage and
+horror, resolving to wait his approach and then close with him in
+mortal combat.  He approached; his countenance bespoke bitter anguish,
+combined with disdain and malignity, while its unearthly ugliness
+rendered it almost too horrible for human eyes.  But I scarcely
+observed this; rage and hatred had at first deprived me of utterance,
+and I recovered only to overwhelm him with words expressive of furious
+detestation and contempt.
+
+"Devil," I exclaimed, "do you dare approach me?  And do not you fear
+the fierce vengeance of my arm wreaked on your miserable head?  Begone,
+vile insect!  Or rather, stay, that I may trample you to dust!  And,
+oh!  That I could, with the extinction of your miserable existence,
+restore those victims whom you have so diabolically murdered!"
+
+"I expected this reception," said the daemon.  "All men hate the
+wretched; how, then, must I be hated, who am miserable beyond all
+living things!  Yet you, my creator, detest and spurn me, thy creature,
+to whom thou art bound by ties only dissoluble by the annihilation of
+one of us.  You purpose to kill me.  How dare you sport thus with life?
+Do your duty towards me, and I will do mine towards you and the rest of
+mankind.  If you will comply with my conditions, I will leave them and
+you at peace; but if you refuse, I will glut the maw of death, until it
+be satiated with the blood of your remaining friends."
+
+"Abhorred monster!  Fiend that thou art!  The tortures of hell are too
+mild a vengeance for thy crimes.  Wretched devil!  You reproach me with
+your creation, come on, then, that I may extinguish the spark which I
+so negligently bestowed."
+
+My rage was without bounds; I sprang on him, impelled by all the
+feelings which can arm one being against the existence of another.
+
+He easily eluded me and said,
+
+"Be calm!  I entreat you to hear me before you give vent to your hatred
+on my devoted head.  Have I not suffered enough, that you seek to
+increase my misery?  Life, although it may only be an accumulation of
+anguish, is dear to me, and I will defend it.  Remember, thou hast made
+me more powerful than thyself; my height is superior to thine, my
+joints more supple.  But I will not be tempted to set myself in
+opposition to thee.  I am thy creature, and I will be even mild and
+docile to my natural lord and king if thou wilt also perform thy part,
+the which thou owest me.  Oh, Frankenstein, be not equitable to every
+other and trample upon me alone, to whom thy justice, and even thy
+clemency and affection, is most due.  Remember that I am thy creature;
+I ought to be thy Adam, but I am rather the fallen angel, whom thou
+drivest from joy for no misdeed.  Everywhere I see bliss, from which I
+alone am irrevocably excluded.  I was benevolent and good; misery made
+me a fiend.  Make me happy, and I shall again be virtuous."
+
+"Begone!  I will not hear you.  There can be no community between you
+and me; we are enemies.  Begone, or let us try our strength in a fight,
+in which one must fall."
+
+"How can I move thee?  Will no entreaties cause thee to turn a
+favourable eye upon thy creature, who implores thy goodness and
+compassion?  Believe me, Frankenstein, I was benevolent; my soul glowed
+with love and humanity; but am I not alone, miserably alone?  You, my
+creator, abhor me; what hope can I gather from your fellow creatures,
+who owe me nothing?  They spurn and hate me.  The desert mountains and
+dreary glaciers are my refuge.  I have wandered here many days; the
+caves of ice, which I only do not fear, are a dwelling to me, and the
+only one which man does not grudge.  These bleak skies I hail, for they
+are kinder to me than your fellow beings.  If the multitude of mankind
+knew of my existence, they would do as you do, and arm themselves for
+my destruction.  Shall I not then hate them who abhor me?  I will keep
+no terms with my enemies.  I am miserable, and they shall share my
+wretchedness.  Yet it is in your power to recompense me, and deliver
+them from an evil which it only remains for you to make so great, that
+not only you and your family, but thousands of others, shall be
+swallowed up in the whirlwinds of its rage.  Let your compassion be
+moved, and do not disdain me.  Listen to my tale; when you have heard
+that, abandon or commiserate me, as you shall judge that I deserve.
+But hear me.  The guilty are allowed, by human laws, bloody as they
+are, to speak in their own defence before they are condemned.  Listen
+to me, Frankenstein.  You accuse me of murder, and yet you would, with
+a satisfied conscience, destroy your own creature.  Oh, praise the
+eternal justice of man!  Yet I ask you not to spare me; listen to me,
+and then, if you can, and if you will, destroy the work of your hands."
+
+"Why do you call to my remembrance," I rejoined, "circumstances of
+which I shudder to reflect, that I have been the miserable origin and
+author?  Cursed be the day, abhorred devil, in which you first saw
+light!  Cursed (although I curse myself) be the hands that formed you!
+You have made me wretched beyond expression.  You have left me no power
+to consider whether I am just to you or not.  Begone!  Relieve me from
+the sight of your detested form."
+
+"Thus I relieve thee, my creator," he said, and placed his hated hands
+before my eyes, which I flung from me with violence; "thus I take from
+thee a sight which you abhor.  Still thou canst listen to me and grant
+me thy compassion.  By the virtues that I once possessed, I demand this
+from you.  Hear my tale; it is long and strange, and the temperature of
+this place is not fitting to your fine sensations; come to the hut upon
+the mountain.  The sun is yet high in the heavens; before it descends
+to hide itself behind your snowy precipices and illuminate another
+world, you will have heard my story and can decide.  On you it rests,
+whether I quit forever the neighbourhood of man and lead a harmless
+life, or become the scourge of your fellow creatures and the author of
+your own speedy ruin."
+
+As he said this he led the way across the ice; I followed.  My heart
+was full, and I did not answer him, but as I proceeded, I weighed the
+various arguments that he had used and determined at least to listen to
+his tale.  I was partly urged by curiosity, and compassion confirmed my
+resolution.  I had hitherto supposed him to be the murderer of my
+brother, and I eagerly sought a confirmation or denial of this opinion.
+For the first time, also, I felt what the duties of a creator towards
+his creature were, and that I ought to render him happy before I
+complained of his wickedness.  These motives urged me to comply with
+his demand.  We crossed the ice, therefore, and ascended the opposite
+rock.  The air was cold, and the rain again began to descend; we
+entered the hut, the fiend with an air of exultation, I with a heavy
+heart and depressed spirits.  But I consented to listen, and seating
+myself by the fire which my odious companion had lighted, he thus began
+his tale.
+
+
+
+Chapter 11
+
+"It is with considerable difficulty that I remember the original era of
+my being; all the events of that period appear confused and indistinct.
+A strange multiplicity of sensations seized me, and I saw, felt, heard,
+and smelt at the same time; and it was, indeed, a long time before I
+learned to distinguish between the operations of my various senses.  By
+degrees, I remember, a stronger light pressed upon my nerves, so that I
+was obliged to shut my eyes.  Darkness then came over me and troubled
+me, but hardly had I felt this when, by opening my eyes, as I now
+suppose, the light poured in upon me again.  I walked and, I believe,
+descended, but I presently found a great alteration in my sensations.
+Before, dark and opaque bodies had surrounded me, impervious to my
+touch or sight; but I now found that I could wander on at liberty, with
+no obstacles which I could not either surmount or avoid.  The light
+became more and more oppressive to me, and the heat wearying me as I
+walked, I sought a place where I could receive shade.  This was the
+forest near Ingolstadt; and here I lay by the side of a brook resting
+from my fatigue, until I felt tormented by hunger and thirst.  This
+roused me from my nearly dormant state, and I ate some berries which I
+found hanging on the trees or lying on the ground.  I slaked my thirst
+at the brook, and then lying down, was overcome by sleep.
+
+"It was dark when I awoke; I felt cold also, and half frightened, as it
+were, instinctively, finding myself so desolate.  Before I had quitted
+your apartment, on a sensation of cold, I had covered myself with some
+clothes, but these were insufficient to secure me from the dews of
+night.  I was a poor, helpless, miserable wretch; I knew, and could
+distinguish, nothing; but feeling pain invade me on all sides, I sat
+down and wept.
+
+"Soon a gentle light stole over the heavens and gave me a sensation of
+pleasure.  I started up and beheld a radiant form rise from among the
+trees.  [The moon]  I gazed with a kind of wonder.  It moved slowly,
+but it enlightened my path, and I again went out in search of berries.
+I was still cold when under one of the trees I found a huge cloak, with
+which I covered myself, and sat down upon the ground.  No distinct
+ideas occupied my mind; all was confused.  I felt light, and hunger,
+and thirst, and darkness; innumerable sounds rang in my ears, and on
+all sides various scents saluted me; the only object that I could
+distinguish was the bright moon, and I fixed my eyes on that with
+pleasure.
+
+"Several changes of day and night passed, and the orb of night had
+greatly lessened, when I began to distinguish my sensations from each
+other.  I gradually saw plainly the clear stream that supplied me with
+drink and the trees that shaded me with their foliage.  I was delighted
+when I first discovered that a pleasant sound, which often saluted my
+ears, proceeded from the throats of the little winged animals who had
+often intercepted the light from my eyes.  I began also to observe,
+with greater accuracy, the forms that surrounded me and to perceive the
+boundaries of the radiant roof of light which canopied me.  Sometimes I
+tried to imitate the pleasant songs of the birds but was unable.
+Sometimes I wished to express my sensations in my own mode, but the
+uncouth and inarticulate sounds which broke from me frightened me into
+silence again.
+
+"The moon had disappeared from the night, and again, with a lessened
+form, showed itself, while I still remained in the forest.  My
+sensations had by this time become distinct, and my mind received every
+day additional ideas.  My eyes became accustomed to the light and to
+perceive objects in their right forms; I distinguished the insect from
+the herb, and by degrees, one herb from another.  I found that the
+sparrow uttered none but harsh notes, whilst those of the blackbird and
+thrush were sweet and enticing.
+
+"One day, when I was oppressed by cold, I found a fire which had been
+left by some wandering beggars, and was overcome with delight at the
+warmth I experienced from it.  In my joy I thrust my hand into the live
+embers, but quickly drew it out again with a cry of pain.  How strange,
+I thought, that the same cause should produce such opposite effects!  I
+examined the materials of the fire, and to my joy found it to be
+composed of wood.  I quickly collected some branches, but they were wet
+and would not burn.  I was pained at this and sat still watching the
+operation of the fire.  The wet wood which I had placed near the heat
+dried and itself became inflamed.  I reflected on this, and by touching
+the various branches, I discovered the cause and busied myself in
+collecting a great quantity of wood, that I might dry it and have a
+plentiful supply of fire.  When night came on and brought sleep with
+it, I was in the greatest fear lest my fire should be extinguished.  I
+covered it carefully with dry wood and leaves and placed wet branches
+upon it; and then, spreading my cloak, I lay on the ground and sank
+into sleep.
+
+"It was morning when I awoke, and my first care was to visit the fire.
+I uncovered it, and a gentle breeze quickly fanned it into a flame.  I
+observed this also and contrived a fan of branches, which roused the
+embers when they were nearly extinguished.  When night came again I
+found, with pleasure, that the fire gave light as well as heat and that
+the discovery of this element was useful to me in my food, for I found
+some of the offals that the travellers had left had been roasted, and
+tasted much more savoury than the berries I gathered from the trees.  I
+tried, therefore, to dress my food in the same manner, placing it on
+the live embers.  I found that the berries were spoiled by this
+operation, and the nuts and roots much improved.
+
+"Food, however, became scarce, and I often spent the whole day
+searching in vain for a few acorns to assuage the pangs of hunger. When
+I found this, I resolved to quit the place that I had hitherto
+inhabited, to seek for one where the few wants I experienced would be
+more easily satisfied.  In this emigration I exceedingly lamented the
+loss of the fire which I had obtained through accident and knew not how
+to reproduce it.  I gave several hours to the serious consideration of
+this difficulty, but I was obliged to relinquish all attempt to supply
+it, and wrapping myself up in my cloak, I struck across the wood
+towards the setting sun.  I passed three days in these rambles and at
+length discovered the open country.  A great fall of snow had taken
+place the night before, and the fields were of one uniform white; the
+appearance was disconsolate, and I found my feet chilled by the cold
+damp substance that covered the ground.
+
+"It was about seven in the morning, and I longed to obtain food and
+shelter; at length I perceived a small hut, on a rising ground, which
+had doubtless been built for the convenience of some shepherd.  This
+was a new sight to me, and I examined the structure with great
+curiosity.  Finding the door open, I entered.  An old man sat in it,
+near a fire, over which he was preparing his breakfast.  He turned on
+hearing a noise, and perceiving me, shrieked loudly, and quitting the
+hut, ran across the fields with a speed of which his debilitated form
+hardly appeared capable.  His appearance, different from any I had ever
+before seen, and his flight somewhat surprised me.  But I was enchanted
+by the appearance of the hut; here the snow and rain could not
+penetrate; the ground was dry; and it presented to me then as exquisite
+and divine a retreat as Pandemonium appeared to the demons of hell
+after their sufferings in the lake of fire.  I greedily devoured the
+remnants of the shepherd's breakfast, which consisted of bread, cheese,
+milk, and wine; the latter, however, I did not like.  Then, overcome by
+fatigue, I lay down among some straw and fell asleep.
+
+"It was noon when I awoke, and allured by the warmth of the sun, which
+shone brightly on the white ground, I determined to recommence my
+travels; and, depositing the remains of the peasant's breakfast in a
+wallet I found, I proceeded across the fields for several hours, until
+at sunset I arrived at a village.  How miraculous did this appear!  The
+huts, the neater cottages, and stately houses engaged my admiration by
+turns.  The vegetables in the gardens, the milk and cheese that I saw
+placed at the windows of some of the cottages, allured my appetite. One
+of the best of these I entered, but I had hardly placed my foot within
+the door before the children shrieked, and one of the women fainted.
+The whole village was roused; some fled, some attacked me, until,
+grievously bruised by stones and many other kinds of missile weapons, I
+escaped to the open country and fearfully took refuge in a low hovel,
+quite bare, and making a wretched appearance after the palaces I had
+beheld in the village.  This hovel however, joined a cottage of a neat
+and pleasant appearance, but after my late dearly bought experience, I
+dared not enter it.  My place of refuge was constructed of wood, but so
+low that I could with difficulty sit upright in it.  No wood, however,
+was placed on the earth, which formed the floor, but it was dry; and
+although the wind entered it by innumerable chinks, I found it an
+agreeable asylum from the snow and rain.
+
+"Here, then, I retreated and lay down happy to have found a shelter,
+however miserable, from the inclemency of the season, and still more
+from the barbarity of man.  As soon as morning dawned I crept from my
+kennel, that I might view the adjacent cottage and discover if I could
+remain in the habitation I had found.  It was situated against the back
+of the cottage and surrounded on the sides which were exposed by a pig
+sty and a clear pool of water.  One part was open, and by that I had
+crept in; but now I covered every crevice by which I might be perceived
+with stones and wood, yet in such a manner that I might move them on
+occasion to pass out; all the light I enjoyed came through the sty, and
+that was sufficient for me.
+
+"Having thus arranged my dwelling and carpeted it with clean straw, I
+retired, for I saw the figure of a man at a distance, and I remembered
+too well my treatment the night before to trust myself in his power.  I
+had first, however, provided for my sustenance for that day by a loaf
+of coarse bread, which I purloined, and a cup with which I could drink
+more conveniently than from my hand of the pure water which flowed by
+my retreat.  The floor was a little raised, so that it was kept
+perfectly dry, and by its vicinity to the chimney of the cottage it was
+tolerably warm.
+
+"Being thus provided, I resolved to reside in this hovel until
+something should occur which might alter my determination.  It was
+indeed a paradise compared to the bleak forest, my former residence,
+the rain-dropping branches, and dank earth.  I ate my breakfast with
+pleasure and was about to remove a plank to procure myself a little
+water when I heard a step, and looking through a small chink, I beheld
+a young creature, with a pail on her head, passing before my hovel. The
+girl was young and of gentle demeanour, unlike what I have since found
+cottagers and farmhouse servants to be.  Yet she was meanly dressed, a
+coarse blue petticoat and a linen jacket being her only garb; her fair
+hair was plaited but not adorned:  she looked patient yet sad.  I lost
+sight of her, and in about a quarter of an hour she returned bearing
+the pail, which was now partly filled with milk.  As she walked along,
+seemingly incommoded by the burden, a young man met her, whose
+countenance expressed a deeper despondence.  Uttering a few sounds with
+an air of melancholy, he took the pail from her head and bore it to the
+cottage himself.  She followed, and they disappeared.  Presently I saw
+the young man again, with some tools in his hand, cross the field
+behind the cottage; and the girl was also busied, sometimes in the
+house and sometimes in the yard.
+
+"On examining my dwelling, I found that one of the windows of the
+cottage had formerly occupied a part of it, but the panes had been
+filled up with wood. In one of these was a small and almost
+imperceptible chink through which the eye could just penetrate.
+Through this crevice a small room was visible, whitewashed and clean
+but very bare of furniture. In one corner, near a small fire, sat an
+old man, leaning his head on his hands in a disconsolate attitude. The
+young girl was occupied in arranging the cottage; but presently she
+took something out of a drawer, which employed her hands, and she sat
+down beside the old man, who, taking up an instrument, began to play
+and to produce sounds sweeter than the voice of the thrush or the
+nightingale. It was a lovely sight, even to me, poor wretch who had
+never beheld aught beautiful before. The silver hair and benevolent
+countenance of the aged cottager won my reverence, while the gentle
+manners of the girl enticed my love. He played a sweet mournful air
+which I perceived drew tears from the eyes of his amiable companion, of
+which the old man took no notice, until she sobbed audibly; he then
+pronounced a few sounds, and the fair creature, leaving her work, knelt
+at his feet. He raised her and smiled with such kindness and affection
+that I felt sensations of a peculiar and overpowering nature; they were
+a mixture of pain and pleasure, such as I had never before experienced,
+either from hunger or cold, warmth or food; and I withdrew from the
+window, unable to bear these emotions.
+
+"Soon after this the young man returned, bearing on his shoulders a
+load of wood.  The girl met him at the door, helped to relieve him of
+his burden, and taking some of the fuel into the cottage, placed it on
+the fire; then she and the youth went apart into a nook of the cottage,
+and he showed her a large loaf and a piece of cheese.  She seemed
+pleased and went into the garden for some roots and plants, which she
+placed in water, and then upon the fire.  She afterwards continued her
+work, whilst the young man went into the garden and appeared busily
+employed in digging and pulling up roots.  After he had been employed
+thus about an hour, the young woman joined him and they entered the
+cottage together.
+
+"The old man had, in the meantime, been pensive, but on the appearance
+of his companions he assumed a more cheerful air, and they sat down to
+eat.  The meal was quickly dispatched.  The young woman was again
+occupied in arranging the cottage, the old man walked before the
+cottage in the sun for a few minutes, leaning on the arm of the youth.
+Nothing could exceed in beauty the contrast between these two excellent
+creatures.  One was old, with silver hairs and a countenance beaming
+with benevolence and love; the younger was slight and graceful in his
+figure, and his features were moulded with the finest symmetry, yet his
+eyes and attitude expressed the utmost sadness and despondency.  The
+old man returned to the cottage, and the youth, with tools different
+from those he had used in the morning, directed his steps across the
+fields.
+
+"Night quickly shut in, but to my extreme wonder, I found that the
+cottagers had a means of prolonging light by the use of tapers, and was
+delighted to find that the setting of the sun did not put an end to the
+pleasure I experienced in watching my human neighbours.  In the evening
+the young girl and her companion were employed in various occupations
+which I did not understand; and the old man again took up the
+instrument which produced the divine sounds that had enchanted me in
+the morning.  So soon as he had finished, the youth began, not to play,
+but to utter sounds that were monotonous, and neither resembling the
+harmony of the old man's instrument nor the songs of the birds; I since
+found that he read aloud, but at that time I knew nothing of the
+science of words or letters.
+
+"The family, after having been thus occupied for a short time,
+extinguished their lights and retired, as I conjectured, to rest."
+
+
+
+Chapter 12
+
+"I lay on my straw, but I could not sleep.  I thought of the
+occurrences of the day.  What chiefly struck me was the gentle manners
+of these people, and I longed to join them, but dared not.  I
+remembered too well the treatment I had suffered the night before from
+the barbarous villagers, and resolved, whatever course of conduct I
+might hereafter think it right to pursue, that for the present I would
+remain quietly in my hovel, watching and endeavouring to discover the
+motives which influenced their actions.
+
+"The cottagers arose the next morning before the sun.  The young woman
+arranged the cottage and prepared the food, and the youth departed
+after the first meal.
+
+"This day was passed in the same routine as that which preceded it.
+The young man was constantly employed out of doors, and the girl in
+various laborious occupations within.  The old man, whom I soon
+perceived to be blind, employed his leisure hours on his instrument or
+in contemplation.  Nothing could exceed the love and respect which the
+younger cottagers exhibited towards their venerable companion.  They
+performed towards him every little office of affection and duty with
+gentleness, and he rewarded them by his benevolent smiles.
+
+"They were not entirely happy.  The young man and his companion often
+went apart and appeared to weep.  I saw no cause for their unhappiness,
+but I was deeply affected by it.  If such lovely creatures were
+miserable, it was less strange that I, an imperfect and solitary being,
+should be wretched.  Yet why were these gentle beings unhappy?  They
+possessed a delightful house (for such it was in my eyes) and every
+luxury; they had a fire to warm them when chill and delicious viands
+when hungry; they were dressed in excellent clothes; and, still more,
+they enjoyed one another's company and speech, interchanging each day
+looks of affection and kindness.  What did their tears imply?  Did they
+really express pain?  I was at first unable to solve these questions,
+but perpetual attention and time explained to me many appearances which
+were at first enigmatic.
+
+"A considerable period elapsed before I discovered one of the causes of
+the uneasiness of this amiable family:  it was poverty, and they
+suffered that evil in a very distressing degree.  Their nourishment
+consisted entirely of the vegetables of their garden and the milk of
+one cow, which gave very little during the winter, when its masters
+could scarcely procure food to support it.  They often, I believe,
+suffered the pangs of hunger very poignantly, especially the two
+younger cottagers, for several times they placed food before the old
+man when they reserved none for themselves.
+
+"This trait of kindness moved me sensibly.  I had been accustomed,
+during the night, to steal a part of their store for my own
+consumption, but when I found that in doing this I inflicted pain on
+the cottagers, I abstained and satisfied myself with berries, nuts, and
+roots which I gathered from a neighbouring wood.
+
+"I discovered also another means through which I was enabled to assist
+their labours.  I found that the youth spent a great part of each day
+in collecting wood for the family fire, and during the night I often
+took his tools, the use of which I quickly discovered, and brought home
+firing sufficient for the consumption of several days.
+
+"I remember, the first time that I did this, the young woman, when she
+opened the door in the morning, appeared greatly astonished on seeing a
+great pile of wood on the outside.  She uttered some words in a loud
+voice, and the youth joined her, who also expressed surprise.  I
+observed, with pleasure, that he did not go to the forest that day, but
+spent it in repairing the cottage and cultivating the garden.
+
+"By degrees I made a discovery of still greater moment.  I found that
+these people possessed a method of communicating their experience and
+feelings to one another by articulate sounds.  I perceived that the
+words they spoke sometimes produced pleasure or pain, smiles or
+sadness, in the minds and countenances of the hearers.  This was indeed
+a godlike science, and I ardently desired to become acquainted with it.
+But I was baffled in every attempt I made for this purpose.  Their
+pronunciation was quick, and the words they uttered, not having any
+apparent connection with visible objects, I was unable to discover any
+clue by which I could unravel the mystery of their reference.  By great
+application, however, and after having remained during the space of
+several revolutions of the moon in my hovel, I discovered the names
+that were given to some of the most familiar objects of discourse; I
+learned and applied the words, 'fire,' 'milk,' 'bread,' and 'wood.'  I
+learned also the names of the cottagers themselves.  The youth and his
+companion had each of them several names, but the old man had only one,
+which was 'father.' The girl was called 'sister' or 'Agatha,' and the
+youth 'Felix,' 'brother,' or 'son.'  I cannot describe the delight I
+felt when I learned the ideas appropriated to each of these sounds and
+was able to pronounce them.  I distinguished several other words
+without being able as yet to understand or apply them, such as 'good,'
+'dearest,' 'unhappy.'
+
+"I spent the winter in this manner.  The gentle manners and beauty of
+the cottagers greatly endeared them to me; when they were unhappy, I
+felt depressed; when they rejoiced, I sympathized in their joys.  I saw
+few human beings besides them, and if any other happened to enter the
+cottage, their harsh manners and rude gait only enhanced to me the
+superior accomplishments of my friends.  The old man, I could perceive,
+often endeavoured to encourage his children, as sometimes I found that
+he called them, to cast off their melancholy.  He would talk in a
+cheerful accent, with an expression of goodness that bestowed pleasure
+even upon me.  Agatha listened with respect, her eyes sometimes filled
+with tears, which she endeavoured to wipe away unperceived; but I
+generally found that her countenance and tone were more cheerful after
+having listened to the exhortations of her father.  It was not thus
+with Felix.  He was always the saddest of the group, and even to my
+unpractised senses, he appeared to have suffered more deeply than his
+friends.  But if his countenance was more sorrowful, his voice was more
+cheerful than that of his sister, especially when he addressed the old
+man.
+
+"I could mention innumerable instances which, although slight, marked
+the dispositions of these amiable cottagers.  In the midst of poverty
+and want, Felix carried with pleasure to his sister the first little
+white flower that peeped out from beneath the snowy ground.  Early in
+the morning, before she had risen, he cleared away the snow that
+obstructed her path to the milk-house, drew water from the well, and
+brought the wood from the outhouse, where, to his perpetual
+astonishment, he found his store always replenished by an invisible
+hand.  In the day, I believe, he worked sometimes for a neighbouring
+farmer, because he often went forth and did not return until dinner,
+yet brought no wood with him.  At other times he worked in the garden,
+but as there was little to do in the frosty season, he read to the old
+man and Agatha.
+
+"This reading had puzzled me extremely at first, but by degrees I
+discovered that he uttered many of the same sounds when he read as when
+he talked.  I conjectured, therefore, that he found on the paper signs
+for speech which he understood, and I ardently longed to comprehend
+these also; but how was that possible when I did not even understand
+the sounds for which they stood as signs?  I improved, however,
+sensibly in this science, but not sufficiently to follow up any kind of
+conversation, although I applied my whole mind to the endeavour, for I
+easily perceived that, although I eagerly longed to discover myself to
+the cottagers, I ought not to make the attempt until I had first become
+master of their language, which knowledge might enable me to make them
+overlook the deformity of my figure, for with this also the contrast
+perpetually presented to my eyes had made me acquainted.
+
+"I had admired the perfect forms of my cottagers--their grace, beauty,
+and delicate complexions; but how was I terrified when I viewed myself
+in a transparent pool!  At first I started back, unable to believe that
+it was indeed I who was reflected in the mirror; and when I became
+fully convinced that I was in reality the monster that I am, I was
+filled with the bitterest sensations of despondence and mortification.
+Alas!  I did not yet entirely know the fatal effects of this miserable
+deformity.
+
+"As the sun became warmer and the light of day longer, the snow
+vanished, and I beheld the bare trees and the black earth.  From this
+time Felix was more employed, and the heart-moving indications of
+impending famine disappeared.  Their food, as I afterwards found, was
+coarse, but it was wholesome; and they procured a sufficiency of it.
+Several new kinds of plants sprang up in the garden, which they
+dressed; and these signs of comfort increased daily as the season
+advanced.
+
+"The old man, leaning on his son, walked each day at noon, when it did
+not rain, as I found it was called when the heavens poured forth its
+waters.  This frequently took place, but a high wind quickly dried the
+earth, and the season became far more pleasant than it had been.
+
+"My mode of life in my hovel was uniform.  During the morning I
+attended the motions of the cottagers, and when they were dispersed in
+various occupations, I slept; the remainder of the day was spent in
+observing my friends.  When they had retired to rest, if there was any
+moon or the night was star-light, I went into the woods and collected
+my own food and fuel for the cottage.  When I returned, as often as it
+was necessary, I cleared their path from the snow and performed those
+offices that I had seen done by Felix.  I afterwards found that these
+labours, performed by an invisible hand, greatly astonished them; and
+once or twice I heard them, on these occasions, utter the words 'good
+spirit,' 'wonderful'; but I did not then understand the signification
+of these terms.
+
+"My thoughts now became more active, and I longed to discover the
+motives and feelings of these lovely creatures; I was inquisitive to
+know why Felix appeared so miserable and Agatha so sad.  I thought
+(foolish wretch!) that it might be in my power to restore happiness to
+these deserving people.  When I slept or was absent, the forms of the
+venerable blind father, the gentle Agatha, and the excellent Felix
+flitted before me.  I looked upon them as superior beings who would be
+the arbiters of my future destiny.  I formed in my imagination a
+thousand pictures of presenting myself to them, and their reception of
+me.  I imagined that they would be disgusted, until, by my gentle
+demeanour and conciliating words, I should first win their favour and
+afterwards their love.
+
+"These thoughts exhilarated me and led me to apply with fresh ardour to
+the acquiring the art of language.  My organs were indeed harsh, but
+supple; and although my voice was very unlike the soft music of their
+tones, yet I pronounced such words as I understood with tolerable ease.
+It was as the ass and the lap-dog; yet surely the gentle ass whose
+intentions were affectionate, although his manners were rude, deserved
+better treatment than blows and execration.
+
+"The pleasant showers and genial warmth of spring greatly altered the
+aspect of the earth.  Men who before this change seemed to have been
+hid in caves dispersed themselves and were employed in various arts of
+cultivation.  The birds sang in more cheerful notes, and the leaves
+began to bud forth on the trees.  Happy, happy earth!  Fit habitation
+for gods, which, so short a time before, was bleak, damp, and
+unwholesome.  My spirits were elevated by the enchanting appearance of
+nature; the past was blotted from my memory, the present was tranquil,
+and the future gilded by bright rays of hope and anticipations of joy."
+
+
+
+Chapter 13
+
+"I now hasten to the more moving part of my story.  I shall relate
+events that impressed me with feelings which, from what I had been,
+have made me what I am.
+
+"Spring advanced rapidly; the weather became fine and the skies
+cloudless.  It surprised me that what before was desert and gloomy
+should now bloom with the most beautiful flowers and verdure.  My
+senses were gratified and refreshed by a thousand scents of delight and
+a thousand sights of beauty.
+
+"It was on one of these days, when my cottagers periodically rested
+from labour--the old man played on his guitar, and the children
+listened to him--that I observed the countenance of Felix was
+melancholy beyond expression; he sighed frequently, and once his father
+paused in his music, and I conjectured by his manner that he inquired
+the cause of his son's sorrow.  Felix replied in a cheerful accent, and
+the old man was recommencing his music when someone tapped at the door.
+
+"It was a lady on horseback, accompanied by a country-man as a guide.
+The lady was dressed in a dark suit and covered with a thick black
+veil.  Agatha asked a question, to which the stranger only replied by
+pronouncing, in a sweet accent, the name of Felix.  Her voice was
+musical but unlike that of either of my friends.  On hearing this word,
+Felix came up hastily to the lady, who, when she saw him, threw up her
+veil, and I beheld a countenance of angelic beauty and expression.  Her
+hair of a shining raven black, and curiously braided; her eyes were
+dark, but gentle, although animated; her features of a regular
+proportion, and her complexion wondrously fair, each cheek tinged with
+a lovely pink.
+
+"Felix seemed ravished with delight when he saw her, every trait of
+sorrow vanished from his face, and it instantly expressed a degree of
+ecstatic joy, of which I could hardly have believed it capable; his
+eyes sparkled, as his cheek flushed with pleasure; and at that moment I
+thought him as beautiful as the stranger.  She appeared affected by
+different feelings; wiping a few tears from her lovely eyes, she held
+out her hand to Felix, who kissed it rapturously and called her, as
+well as I could distinguish, his sweet Arabian.  She did not appear to
+understand him, but smiled.  He assisted her to dismount, and
+dismissing her guide, conducted her into the cottage.  Some
+conversation took place between him and his father, and the young
+stranger knelt at the old man's feet and would have kissed his hand,
+but he raised her and embraced her affectionately.
+
+"I soon perceived that although the stranger uttered articulate sounds
+and appeared to have a language of her own, she was neither understood
+by nor herself understood the cottagers.  They made many signs which I
+did not comprehend, but I saw that her presence diffused gladness
+through the cottage, dispelling their sorrow as the sun dissipates the
+morning mists.  Felix seemed peculiarly happy and with smiles of
+delight welcomed his Arabian.  Agatha, the ever-gentle Agatha, kissed
+the hands of the lovely stranger, and pointing to her brother, made
+signs which appeared to me to mean that he had been sorrowful until she
+came.  Some hours passed thus, while they, by their countenances,
+expressed joy, the cause of which I did not comprehend.  Presently I
+found, by the frequent recurrence of some sound which the stranger
+repeated after them, that she was endeavouring to learn their language;
+and the idea instantly occurred to me that I should make use of the
+same instructions to the same end.  The stranger learned about twenty
+words at the first lesson; most of them, indeed, were those which I had
+before understood, but I profited by the others.
+
+"As night came on, Agatha and the Arabian retired early.  When they
+separated Felix kissed the hand of the stranger and said, 'Good night
+sweet Safie.'  He sat up much longer, conversing with his father, and
+by the frequent repetition of her name I conjectured that their lovely
+guest was the subject of their conversation.  I ardently desired to
+understand them, and bent every faculty towards that purpose, but found
+it utterly impossible.
+
+"The next morning Felix went out to his work, and after the usual
+occupations of Agatha were finished, the Arabian sat at the feet of the
+old man, and taking his guitar, played some airs so entrancingly
+beautiful that they at once drew tears of sorrow and delight from my
+eyes.  She sang, and her voice flowed in a rich cadence, swelling or
+dying away like a nightingale of the woods.
+
+"When she had finished, she gave the guitar to Agatha, who at first
+declined it.  She played a simple air, and her voice accompanied it in
+sweet accents, but unlike the wondrous strain of the stranger.  The old
+man appeared enraptured and said some words which Agatha endeavoured to
+explain to Safie, and by which he appeared to wish to express that she
+bestowed on him the greatest delight by her music.
+
+"The days now passed as peaceably as before, with the sole alteration
+that joy had taken place of sadness in the countenances of my friends.
+Safie was always gay and happy; she and I improved rapidly in the
+knowledge of language, so that in two months I began to comprehend most
+of the words uttered by my protectors.
+
+"In the meanwhile also the black ground was covered with herbage, and
+the green banks interspersed with innumerable flowers, sweet to the
+scent and the eyes, stars of pale radiance among the moonlight woods;
+the sun became warmer, the nights clear and balmy; and my nocturnal
+rambles were an extreme pleasure to me, although they were considerably
+shortened by the late setting and early rising of the sun, for I never
+ventured abroad during daylight, fearful of meeting with the same
+treatment I had formerly endured in the first village which I entered.
+
+"My days were spent in close attention, that I might more speedily
+master the language; and I may boast that I improved more rapidly than
+the Arabian, who understood very little and conversed in broken
+accents, whilst I comprehended and could imitate almost every word that
+was spoken.
+
+"While I improved in speech, I also learned the science of letters as
+it was taught to the stranger, and this opened before me a wide field
+for wonder and delight.
+
+"The book from which Felix instructed Safie was Volney's Ruins of
+Empires.  I should not have understood the purport of this book had not
+Felix, in reading it, given very minute explanations.  He had chosen
+this work, he said, because the declamatory style was framed in
+imitation of the Eastern authors.  Through this work I obtained a
+cursory knowledge of history and a view of the several empires at
+present existing in the world; it gave me an insight into the manners,
+governments, and religions of the different nations of the earth.  I
+heard of the slothful Asiatics, of the stupendous genius and mental
+activity of the Grecians, of the wars and wonderful virtue of the early
+Romans--of their subsequent degenerating--of the decline of that mighty
+empire, of chivalry, Christianity, and kings.  I heard of the discovery
+of the American hemisphere and wept with Safie over the hapless fate of
+its original inhabitants.
+
+"These wonderful narrations inspired me with strange feelings.  Was
+man, indeed, at once so powerful, so virtuous and magnificent, yet so
+vicious and base?  He appeared at one time a mere scion of the evil
+principle and at another as all that can be conceived of noble and
+godlike.  To be a great and virtuous man appeared the highest honour
+that can befall a sensitive being; to be base and vicious, as many on
+record have been, appeared the lowest degradation, a condition more
+abject than that of the blind mole or harmless worm.  For a long time I
+could not conceive how one man could go forth to murder his fellow, or
+even why there were laws and governments; but when I heard details of
+vice and bloodshed, my wonder ceased and I turned away with disgust and
+loathing.
+
+"Every conversation of the cottagers now opened new wonders to me.
+While I listened to the instructions which Felix bestowed upon the
+Arabian, the strange system of human society was explained to me.  I
+heard of the division of property, of immense wealth and squalid
+poverty, of rank, descent, and noble blood.
+
+"The words induced me to turn towards myself.  I learned that the
+possessions most esteemed by your fellow creatures were high and
+unsullied descent united with riches.  A man might be respected with
+only one of these advantages, but without either he was considered,
+except in very rare instances, as a vagabond and a slave, doomed to
+waste his powers for the profits of the chosen few!  And what was I? Of
+my creation and creator I was absolutely ignorant, but I knew that I
+possessed no money, no friends, no kind of property.  I was, besides,
+endued with a figure hideously deformed and loathsome; I was not even
+of the same nature as man.  I was more agile than they and could
+subsist upon coarser diet; I bore the extremes of heat and cold with
+less injury to my frame; my stature far exceeded theirs.  When I looked
+around I saw and heard of none like me.  Was I, then, a monster, a blot
+upon the earth, from which all men fled and whom all men disowned?
+
+"I cannot describe to you the agony that these reflections inflicted
+upon me; I tried to dispel them, but sorrow only increased with
+knowledge.  Oh, that I had forever remained in my native wood, nor
+known nor felt beyond the sensations of hunger, thirst, and heat!
+
+"Of what a strange nature is knowledge!  It clings to the mind when it
+has once seized on it like a lichen on the rock.  I wished sometimes to
+shake off all thought and feeling, but I learned that there was but one
+means to overcome the sensation of pain, and that was death--a state
+which I feared yet did not understand.  I admired virtue and good
+feelings and loved the gentle manners and amiable qualities of my
+cottagers, but I was shut out from intercourse with them, except
+through means which I obtained by stealth, when I was unseen and
+unknown, and which rather increased than satisfied the desire I had of
+becoming one among my fellows.  The gentle words of Agatha and  the
+animated smiles of the charming Arabian were not for me.  The mild
+exhortations of the old man and the lively conversation of the loved
+Felix were not for me. Miserable, unhappy wretch!
+
+"Other lessons were impressed upon me even more deeply.  I heard of the
+difference of sexes, and the birth and growth of children, how the
+father doted on the smiles of the infant, and the lively sallies of the
+older child, how all the life and cares of the mother were wrapped up
+in the precious charge, how the mind of youth expanded and gained
+knowledge, of brother, sister, and all the various relationships which
+bind one human being to another in mutual bonds.
+
+"But where were my friends and relations?  No father had watched my
+infant days, no mother had blessed me with smiles and caresses; or if
+they had, all my past life was now a blot, a blind vacancy in which I
+distinguished nothing.  From my earliest remembrance I had been as I
+then was in height and proportion.  I had never yet seen a being
+resembling me or who claimed any intercourse with me.  What was I?  The
+question again recurred, to be answered only with groans.
+
+"I will soon explain to what these feelings tended, but allow me now to
+return to the cottagers, whose story excited in me such various
+feelings of indignation, delight, and wonder, but which all terminated
+in additional love and reverence for my protectors (for so I loved, in
+an innocent, half-painful self-deceit, to call them)."
+
+
+
+Chapter 14
+
+"Some time elapsed before I learned the history of my friends.  It was
+one which could not fail to impress itself deeply on my mind, unfolding
+as it did a number of circumstances, each interesting and wonderful to
+one so utterly inexperienced as I was.
+
+"The name of the old man was De Lacey.  He was descended from a good
+family in France, where he had lived for many years in affluence,
+respected by his superiors and beloved by his equals.  His son was bred
+in the service of his country, and Agatha had ranked with ladies of the
+highest distinction.  A few months before my arrival they had lived in
+a large and luxurious city called Paris, surrounded by friends and
+possessed of every enjoyment which virtue, refinement of intellect, or
+taste, accompanied by a moderate fortune, could afford.
+
+"The father of Safie had been the cause of their ruin.  He was a
+Turkish merchant and had inhabited Paris for many years, when, for some
+reason which I could not learn, he became obnoxious to the government.
+He was seized and cast into prison the very day that Safie arrived from
+Constantinople to join him.  He was tried and condemned to death.  The
+injustice of his sentence was very flagrant; all Paris was indignant;
+and it was judged that his religion and wealth rather than the crime
+alleged against him had been the cause of his condemnation.
+
+"Felix had accidentally been present at the trial; his horror and
+indignation were uncontrollable when he heard the decision of the
+court.  He made, at that moment, a solemn vow to deliver him and then
+looked around for the means.  After many fruitless attempts to gain
+admittance to the prison, he found a strongly grated window in an
+unguarded part of the building, which lighted the dungeon of the
+unfortunate Muhammadan, who, loaded with chains, waited in despair the
+execution of the barbarous sentence.  Felix visited the grate at night
+and made known to the prisoner his intentions in his favour.  The Turk,
+amazed and delighted, endeavoured to kindle the zeal of his deliverer
+by promises of reward and wealth.  Felix rejected his offers with
+contempt, yet when he saw the lovely Safie, who was allowed to visit
+her father and who by her gestures expressed her lively gratitude, the
+youth could not help owning to his own mind that the captive possessed
+a treasure which would fully reward his toil and hazard.
+
+"The Turk quickly perceived the impression that his daughter had made
+on the heart of Felix and endeavoured to secure him more entirely in
+his interests by the promise of her hand in marriage so soon as he
+should be conveyed to a place of safety.  Felix was too delicate to
+accept this offer, yet he looked forward to the probability of the
+event as to the consummation of his happiness.
+
+"During the ensuing days, while the preparations were going forward for
+the escape of the merchant, the zeal of Felix was warmed by several
+letters that he received from this lovely girl, who found means to
+express her thoughts in the language of her lover by the aid of an old
+man, a servant of her father who understood French.  She thanked him in
+the most ardent terms for his intended services towards her parent, and
+at the same time she gently deplored her own fate.
+
+"I have copies of these letters, for I found means, during my residence
+in the hovel, to procure the implements of writing; and the letters
+were often in the hands of Felix or Agatha.  Before I depart I will
+give them to you; they will prove the truth of my tale; but at present,
+as the sun is already far declined, I shall only have time to repeat
+the substance of them to you.
+
+"Safie related that her mother was a Christian Arab, seized and made a
+slave by the Turks; recommended by her beauty, she had won the heart of
+the father of Safie, who married her.  The young girl spoke in high and
+enthusiastic terms of her mother, who, born in freedom, spurned the
+bondage to which she was now reduced.  She instructed her daughter in
+the tenets of her religion and taught her to aspire to higher powers of
+intellect and an independence of spirit forbidden to the female
+followers of Muhammad.  This lady died, but her lessons were indelibly
+impressed on the mind of Safie, who sickened at the prospect of again
+returning to Asia and being immured within the walls of a harem,
+allowed only to occupy herself with infantile amusements, ill-suited to
+the temper of her soul, now accustomed to grand ideas and a noble
+emulation for virtue.  The prospect of marrying a Christian and
+remaining in a country where women were allowed to take a rank in
+society was enchanting to her.
+
+"The day for the execution of the Turk was fixed, but on the night
+previous to it he quitted his prison and before morning was distant
+many leagues from Paris.  Felix had procured passports in the name of
+his father, sister, and himself.  He had previously communicated his
+plan to the former, who aided the deceit by quitting his house, under
+the pretence of a journey and concealed himself, with his daughter, in
+an obscure part of Paris.
+
+"Felix conducted the fugitives through France to Lyons and across Mont
+Cenis to Leghorn, where the merchant had decided to wait a favourable
+opportunity of passing into some part of the Turkish dominions.
+
+"Safie resolved to remain with her father until the moment of his
+departure, before which time the Turk renewed his promise that she
+should be united to his deliverer; and Felix remained with them in
+expectation of that event; and in the meantime he enjoyed the society
+of the Arabian, who exhibited towards him the simplest and tenderest
+affection.  They conversed with one another through the means of an
+interpreter, and sometimes with the interpretation of looks; and Safie
+sang to him the divine airs of her native country.
+
+"The Turk allowed this intimacy to take place and encouraged the hopes
+of the youthful lovers, while in his heart he had formed far other
+plans.  He loathed the idea that his daughter should be united to a
+Christian, but he feared the resentment of Felix if he should appear
+lukewarm, for he knew that he was still in the power of his deliverer
+if he should choose to betray him to the Italian state which they
+inhabited.  He revolved a thousand plans by which he should be enabled
+to prolong the deceit until it might be no longer necessary, and
+secretly to take his daughter with him when he departed.  His plans
+were facilitated by the news which arrived from Paris.
+
+"The government of France were greatly enraged at the escape of their
+victim and spared no pains to detect and punish his deliverer.  The
+plot of Felix was quickly discovered, and De Lacey and Agatha were
+thrown into prison.  The news reached Felix and roused him from his
+dream of pleasure.  His blind and aged father and his gentle sister lay
+in a noisome dungeon while he enjoyed the free air and the society of
+her whom he loved.  This idea was torture to him.  He quickly arranged
+with the Turk that if the latter should find a favourable opportunity
+for escape before Felix could return to Italy, Safie should remain as a
+boarder at a convent at Leghorn; and then, quitting the lovely Arabian,
+he hastened to Paris and delivered himself up to the vengeance of the
+law, hoping to free De Lacey and Agatha by this proceeding.
+
+"He did not succeed.  They remained confined for five months before the
+trial took place, the result of which deprived them of their fortune
+and condemned them to a perpetual exile from their native country.
+
+"They found a miserable asylum in the cottage in Germany, where I
+discovered them.  Felix soon learned that the treacherous Turk, for
+whom he and his family endured such unheard-of oppression, on
+discovering that his deliverer was thus reduced to poverty and ruin,
+became a traitor to good feeling and honour and had quitted Italy with
+his daughter, insultingly sending Felix a pittance of money to aid him,
+as he said, in some plan of future maintenance.
+
+"Such were the events that preyed on the heart of Felix and rendered
+him, when I first saw him, the most miserable of his family.  He could
+have endured poverty, and while this distress had been the meed of his
+virtue, he gloried in it; but the ingratitude of the Turk and the loss
+of his beloved Safie were misfortunes more bitter and irreparable.  The
+arrival of the Arabian now infused new life into his soul.
+
+"When the news reached Leghorn that Felix was deprived of his wealth
+and rank, the merchant commanded his daughter to think no more of her
+lover, but to prepare to return to her native country.  The generous
+nature of Safie was outraged by this command; she attempted to
+expostulate with her father, but he left her angrily, reiterating his
+tyrannical mandate.
+
+"A few days after, the Turk entered his daughter's apartment and told
+her hastily that he had reason to believe that his residence at Leghorn
+had been divulged and that he should speedily be delivered up to the
+French government; he had consequently hired a vessel to convey him to
+Constantinople, for which city he should sail in a few hours.  He
+intended to leave his daughter under the care of a confidential
+servant, to follow at her leisure with the greater part of his
+property, which had not yet arrived at Leghorn.
+
+"When alone, Safie resolved in her own mind the plan of conduct that it
+would become her to pursue in this emergency.  A residence in Turkey
+was abhorrent to her; her religion and her feelings were alike averse
+to it.  By some papers of her father which fell into her hands she
+heard of the exile of her lover and learnt the name of the spot where
+he then resided.  She hesitated some time, but at length she formed her
+determination.  Taking with her some jewels that belonged to her and a
+sum of money, she quitted Italy with an attendant, a native of Leghorn,
+but who understood the common language of Turkey, and departed for
+Germany.
+
+"She arrived in safety at a town about twenty leagues from the cottage
+of De Lacey, when her attendant fell dangerously ill.  Safie nursed her
+with the most devoted affection, but the poor girl died, and the
+Arabian was left alone, unacquainted with the language of the country
+and utterly ignorant of the customs of the world.  She fell, however,
+into good hands.  The Italian had mentioned the name of the spot for
+which they were bound, and after her death the woman of the house in
+which they had lived took care that Safie should arrive in safety at
+the cottage of her lover."
+
+
+
+Chapter 15
+
+"Such was the history of my beloved cottagers.  It impressed me deeply.
+I learned, from the views of social life which it developed, to admire
+their virtues and to deprecate the vices of mankind.
+
+"As yet I looked upon crime as a distant evil, benevolence and
+generosity were ever present before me, inciting within me a desire to
+become an actor in the busy scene where so many admirable qualities
+were called forth and displayed.  But in giving an account of the
+progress of my intellect, I must not omit a circumstance which occurred
+in the beginning of the month of August of the same year.
+
+"One night during my accustomed visit to the neighbouring wood where I
+collected my own food and brought home firing for my protectors, I
+found on the ground a leathern portmanteau containing several articles
+of dress and some books.  I eagerly seized the prize and returned with
+it to my hovel.  Fortunately the books were written in the language,
+the elements of which I had acquired at the cottage; they consisted of
+Paradise Lost, a volume of Plutarch's Lives, and the Sorrows of Werter.
+The possession of these treasures gave me extreme delight; I now
+continually studied and exercised my mind upon these histories, whilst
+my friends were employed in their ordinary occupations.
+
+"I can hardly describe to you the effect of these books.  They produced
+in me an infinity of new images and feelings, that sometimes raised me
+to ecstasy, but more frequently sunk me into the lowest dejection.  In
+the Sorrows of Werter, besides the interest of its simple and affecting
+story, so many opinions are canvassed and so many lights thrown upon
+what had hitherto been to me obscure subjects that I found in it a
+never-ending source of speculation and astonishment.  The gentle and
+domestic manners it described, combined with lofty sentiments and
+feelings, which had for their object something out of self, accorded
+well with my experience among my protectors and with the wants which
+were forever alive in my own bosom.  But I thought Werter himself a
+more divine being than I had ever beheld or imagined; his character
+contained no pretension, but it sank deep.  The disquisitions upon
+death and suicide were calculated to fill  me with wonder.  I did not
+pretend to enter into the merits of the case, yet I inclined towards
+the opinions of the hero, whose extinction I wept, without precisely
+understanding it.
+
+"As I read, however, I applied much personally to my own feelings and
+condition.  I found myself similar yet at the same time strangely
+unlike to the beings concerning whom I read and to whose conversation I
+was a listener.  I sympathized with and partly understood them, but I
+was unformed in mind; I was dependent on none and related to none.
+'The path of my departure was free,' and there was none to lament my
+annihilation.  My person was hideous and my stature gigantic.  What did
+this mean?  Who was I?  What was I?  Whence did I come?  What was my
+destination?  These questions continually recurred, but I was unable to
+solve them.
+
+"The volume of Plutarch's Lives which I possessed contained the
+histories of the first founders of the ancient republics.  This book
+had a far different effect upon me from the Sorrows of Werter.  I
+learned from Werter's imaginations despondency and gloom, but Plutarch
+taught me high thoughts; he elevated me above the wretched sphere of my
+own reflections, to admire and love the heroes of past ages.  Many
+things I read surpassed my understanding and experience.  I had a very
+confused knowledge of kingdoms, wide extents of country, mighty rivers,
+and boundless seas.  But I was perfectly unacquainted with towns and
+large assemblages of men. The cottage of my protectors had been the
+only school in which I had studied human nature, but this book
+developed new and mightier scenes of action.  I read of men concerned
+in public affairs, governing or massacring their species.  I felt the
+greatest ardour for virtue rise within me, and abhorrence for vice, as
+far as I understood the signification of those terms, relative as they
+were, as I applied them, to pleasure and pain alone.  Induced by these
+feelings, I was of course led to admire peaceable lawgivers, Numa,
+Solon, and Lycurgus, in preference to Romulus and Theseus.  The
+patriarchal lives of my protectors caused these impressions to take a
+firm hold on my mind; perhaps, if my first introduction to humanity had
+been made by a young soldier, burning for glory and slaughter, I should
+have been imbued with different sensations.
+
+"But Paradise Lost excited different and far deeper emotions.  I read
+it, as I had read the other volumes which had fallen into my hands, as
+a true history.  It moved every feeling of wonder and awe that the
+picture of an omnipotent God warring with his creatures was capable of
+exciting.  I often referred the several situations, as their similarity
+struck me, to my own.  Like Adam, I was apparently united by no link to
+any other being in existence; but his state was far different from mine
+in every other respect.  He had come forth from the hands of God a
+perfect creature, happy and prosperous, guarded by the especial care of
+his Creator; he was allowed to converse with and acquire knowledge from
+beings of a superior nature, but I was wretched, helpless, and alone.
+Many times I considered Satan as the fitter emblem of my condition, for
+often, like him, when I viewed the bliss of my protectors, the bitter
+gall of envy rose within me.
+
+"Another circumstance strengthened and confirmed these feelings.  Soon
+after my arrival in the hovel I discovered some papers in the pocket of
+the dress which I had taken from your laboratory.  At first I had
+neglected them, but now that I was able to decipher the characters in
+which they were written, I began to study them with diligence.  It was
+your journal of the four months that preceded my creation.  You
+minutely described in these papers every step you took in the progress
+of your work; this history was mingled with accounts of domestic
+occurrences.  You doubtless recollect these papers.  Here they are.
+Everything is related in them which bears reference to my accursed
+origin; the whole detail of that series of disgusting circumstances
+which produced it is set in view; the minutest description of my odious
+and loathsome person is given, in language which painted your own
+horrors and rendered mine indelible.  I sickened as I read.  'Hateful
+day when I received life!' I exclaimed in agony.  'Accursed creator!
+Why did you form a monster so hideous that even YOU turned from me in
+disgust?  God, in pity, made man beautiful and alluring, after his own
+image; but my form is a filthy type of yours, more horrid even from the
+very resemblance.  Satan had his companions, fellow devils, to admire
+and encourage him, but I am solitary and abhorred.'
+
+"These were the reflections of my hours of despondency and solitude;
+but when I contemplated the virtues of the cottagers, their amiable and
+benevolent dispositions, I persuaded myself that when they should
+become acquainted with my admiration of their virtues they  would
+compassionate me and overlook my personal deformity.  Could they turn
+from their door one, however monstrous, who solicited their compassion
+and friendship?  I resolved, at least, not to despair, but in every way
+to fit myself for an interview with them which would decide my fate.  I
+postponed this attempt for some months longer, for the importance
+attached to its success inspired me with a dread lest I should fail.
+Besides, I found that my understanding improved so much with every
+day's experience that I was unwilling to commence this undertaking
+until a few more months should have added to my sagacity.
+
+"Several changes, in the meantime, took place in the cottage.  The
+presence of Safie diffused happiness among its inhabitants, and I also
+found that a greater degree of plenty reigned there.  Felix and Agatha
+spent more time in amusement and conversation, and were assisted in
+their labours by servants.  They did not appear rich, but they were
+contented and happy; their feelings were serene and peaceful, while
+mine became every day more tumultuous.  Increase of knowledge only
+discovered to me more clearly what a wretched outcast I was.  I
+cherished hope, it is true, but it vanished when I beheld my person
+reflected in water or my shadow in the moonshine, even as that frail
+image and that inconstant shade.
+
+"I endeavoured to crush these fears and to fortify myself for the trial
+which in a few months I resolved to undergo; and sometimes I allowed my
+thoughts, unchecked by reason, to ramble in the fields of Paradise, and
+dared to fancy amiable and lovely creatures sympathizing with my
+feelings and cheering my gloom; their angelic countenances breathed
+smiles of consolation.  But it was all a dream; no Eve soothed my
+sorrows nor shared my thoughts; I was alone.  I remembered Adam's
+supplication to his Creator.  But where was mine?  He had abandoned me,
+and in the bitterness of my heart I cursed him.
+
+"Autumn passed thus.  I saw, with surprise and grief, the leaves decay
+and fall, and nature again assume the barren and bleak appearance it
+had worn when I first beheld the woods and the lovely moon.  Yet I did
+not heed the bleakness of the weather; I was better fitted by my
+conformation for the endurance of cold than heat.  But my chief
+delights were the sight of the flowers, the birds, and all the gay
+apparel of summer; when those deserted me, I turned with more attention
+towards the cottagers.  Their happiness was not decreased by the
+absence of summer.  They loved and sympathized with one another; and
+their joys, depending on each other, were not interrupted by the
+casualties that took place around them.  The more I saw of them, the
+greater became my desire to claim their protection and kindness; my
+heart yearned to be known and loved by these amiable creatures; to see
+their sweet looks directed towards me with affection was the utmost
+limit of my ambition.  I dared not think that they would turn them from
+me with disdain and horror.  The poor that stopped at their door were
+never driven away.  I asked, it is true, for greater treasures than a
+little food or rest:  I required kindness and sympathy; but I did not
+believe myself utterly unworthy of it.
+
+"The winter advanced, and an entire revolution of the seasons had taken
+place since I awoke into life.  My attention at this time was solely
+directed towards my plan of introducing myself into the cottage of my
+protectors.  I revolved many projects, but that on which I finally
+fixed was to enter the dwelling when the blind old man should be alone.
+I had sagacity enough to discover that the unnatural hideousness of my
+person was the chief object of horror with those who had formerly
+beheld me.  My voice, although harsh, had nothing terrible in it; I
+thought, therefore, that if in the absence of his children I could gain
+the good will and mediation of the old De Lacey, I might by his means
+be tolerated by my younger protectors.
+
+"One day, when the sun shone on the red leaves that strewed the ground
+and diffused cheerfulness, although it denied warmth, Safie, Agatha,
+and Felix departed on a long country walk, and the old man, at his own
+desire, was left alone in the cottage.  When his children had departed,
+he took up his guitar and played several mournful but sweet airs, more
+sweet and mournful than I had ever heard him play before.  At first his
+countenance was illuminated with pleasure, but as he continued,
+thoughtfulness and sadness succeeded; at length, laying aside the
+instrument, he sat absorbed in reflection.
+
+"My heart beat quick; this was the hour and moment of trial, which
+would decide my hopes or realize my fears.  The servants were gone to a
+neighbouring fair.  All was silent in and around the cottage; it was an
+excellent opportunity; yet, when I proceeded to execute my plan, my
+limbs failed me and I sank to the ground.  Again I rose, and exerting
+all the firmness of which I was master, removed the planks which I had
+placed before my hovel to conceal my retreat.  The fresh air revived
+me, and with renewed determination I approached the door of their
+cottage.
+
+"I knocked.  'Who is there?' said the old man.  'Come in.'
+
+"I entered.  'Pardon this intrusion,' said I; 'I am a traveller in want
+of a little rest; you would greatly oblige me if you would allow me to
+remain a few minutes before the fire.'
+
+"'Enter,' said De Lacey, 'and I will try in what manner I can to
+relieve your wants; but, unfortunately, my children are from home, and
+as I am blind, I am afraid I shall find it difficult to procure food
+for you.'
+
+"'Do not trouble yourself, my kind host; I have food; it is warmth and
+rest only that I need.'
+
+"I sat down, and a silence ensued.  I knew that every minute was
+precious to me, yet I remained irresolute in what manner to commence
+the interview, when the old man addressed me.  'By your language,
+stranger, I suppose you are my countryman; are you French?'
+
+"'No; but I was educated by a French family and understand that
+language only.  I am now going to claim the protection of some friends,
+whom I sincerely love, and of whose favour I have some hopes.'
+
+"'Are they Germans?'
+
+"'No, they are French.  But let us change the subject.  I am an
+unfortunate and deserted creature, I look around and I have no relation
+or friend upon earth.  These amiable people to whom I go have never
+seen me and know little of me.  I am full of fears, for if I fail
+there, I am an outcast in the world forever.'
+
+"'Do not despair.  To be friendless is indeed to be unfortunate, but
+the hearts of men, when unprejudiced by any obvious self-interest, are
+full of brotherly love and charity.  Rely, therefore, on your hopes;
+and if these friends are good and amiable, do not despair.'
+
+"'They are kind--they are the most excellent creatures in the world;
+but, unfortunately, they are prejudiced against me.  I have good
+dispositions; my life has been hitherto harmless and in some degree
+beneficial; but a fatal prejudice clouds their eyes, and where they
+ought to see a feeling and kind friend, they behold only a detestable
+monster.'
+
+"'That is indeed unfortunate; but if you are really blameless, cannot
+you undeceive them?'
+
+"'I am about to undertake that task; and it is on that account that I
+feel so many overwhelming terrors.  I tenderly love these friends; I
+have, unknown to them, been for many months in the habits of daily
+kindness towards them; but they believe that I wish to injure them, and
+it is that prejudice which I wish to overcome.'
+
+"'Where do these friends reside?'
+
+"'Near this spot.'
+
+"The old man paused and then continued, 'If you will unreservedly
+confide to me the particulars of your tale, I perhaps may be of use in
+undeceiving them.  I am blind and cannot judge of your countenance, but
+there is something in your words which persuades me that you are
+sincere.  I am poor and an exile, but it will afford me true pleasure
+to be in any way serviceable to a human creature.'
+
+"'Excellent man!  I thank you and accept your generous offer.  You
+raise me from the dust by this kindness; and I trust that, by your aid,
+I shall not be driven from the society and sympathy of your fellow
+creatures.'
+
+"'Heaven forbid!  Even if you were really criminal, for that can only
+drive you to desperation, and not instigate you to virtue.  I also am
+unfortunate; I and my family have been condemned, although innocent;
+judge, therefore, if I do not feel for your misfortunes.'
+
+"'How can I thank you, my best and only benefactor?  From your lips
+first have I heard the voice of kindness directed towards me; I shall
+be forever grateful; and your present humanity assures me of success
+with those friends whom I am on the point of meeting.'
+
+"'May I know the names and residence of those friends?'
+
+"I paused. This, I thought, was the moment of decision, which was to
+rob me of or bestow happiness on me forever.  I struggled vainly for
+firmness sufficient to answer him, but the effort destroyed all my
+remaining strength; I sank on the chair and sobbed aloud.  At that
+moment I heard the steps of my younger protectors.  I had not a moment
+to lose, but seizing the hand of the old man, I cried, 'Now is the
+time!  Save and protect me!  You and your family are the friends whom I
+seek.  Do not you desert me in the hour of trial!'
+
+"'Great God!' exclaimed the old man.  'Who are you?'
+
+"At that instant the cottage door was opened, and Felix, Safie, and
+Agatha entered.  Who can describe their horror and consternation on
+beholding me?  Agatha fainted, and Safie, unable to attend to her
+friend, rushed out of the cottage.  Felix darted forward, and with
+supernatural force tore me from his father, to whose knees I clung, in
+a transport of fury, he dashed me to the ground and struck me violently
+with a stick.  I could have torn him limb from limb, as the lion rends
+the antelope.  But my heart sank within me as with bitter sickness, and
+I refrained.  I saw him on the point of repeating his blow, when,
+overcome by pain and anguish, I quitted the cottage, and in the general
+tumult escaped unperceived to my hovel."
+
+
+
+Chapter 16
+
+"Cursed, cursed creator!  Why did I live?  Why, in that instant, did I
+not extinguish the spark of existence which you had so wantonly
+bestowed?  I know not; despair had not yet taken possession of me; my
+feelings were those of rage and revenge.  I could with pleasure have
+destroyed the cottage and its inhabitants and have glutted myself with
+their shrieks and misery.
+
+"When night came I quitted my retreat and wandered in the wood; and
+now, no longer restrained by the fear of discovery, I gave vent to my
+anguish in fearful howlings.  I was like a wild beast that had broken
+the toils, destroying the objects that obstructed me and ranging
+through the wood with a stag-like swiftness.  Oh!  What a miserable
+night I passed!  The cold stars shone in mockery, and the bare trees
+waved their branches above me; now and then the sweet voice of a bird
+burst forth amidst the universal stillness.  All, save I, were at rest
+or in enjoyment; I, like the arch-fiend, bore a hell within me, and
+finding myself unsympathized with, wished to tear up the trees, spread
+havoc and destruction around me, and then to have sat down and enjoyed
+the ruin.
+
+"But this was a luxury of sensation that could not endure; I became
+fatigued with excess of bodily exertion and sank on the damp grass in
+the sick impotence of despair.  There was none among the myriads of men
+that existed who would pity or assist me; and should I feel kindness
+towards my enemies?  No; from that moment I declared everlasting war
+against the species, and more than all, against him who had formed me
+and sent me forth to this insupportable misery.
+
+"The sun rose; I heard the voices of men and knew that it was
+impossible to return to my retreat during that day.  Accordingly I hid
+myself in some thick underwood, determining to devote the ensuing hours
+to reflection on my situation.
+
+"The pleasant sunshine and the pure air of day restored me to some
+degree of tranquillity; and when I considered what had passed at the
+cottage, I could not help believing that I had been too hasty in my
+conclusions.  I had certainly acted imprudently.  It was apparent that
+my conversation had interested the father in my behalf, and  I was a
+fool in having exposed my person to the horror of his children.  I
+ought to have familiarized the old De Lacey to me, and by degrees to
+have discovered myself to the rest of his family, when they should have
+been  prepared for my approach.  But I did not believe my errors to be
+irretrievable, and after much consideration I resolved to return to the
+cottage, seek the old man, and by my representations win him to my
+party.
+
+"These thoughts calmed me, and in the afternoon I sank into a profound
+sleep; but the fever of my blood did not allow me to be visited by
+peaceful dreams.  The horrible scene of the preceding day was forever
+acting before my eyes; the females were flying and the enraged Felix
+tearing me from his father's feet.  I awoke exhausted, and finding that
+it was already night, I crept forth from my hiding-place, and went in
+search of food.
+
+"When my hunger was appeased, I directed my steps towards the
+well-known path that conducted to the cottage.  All there was at peace.
+I crept into my hovel and remained in silent expectation of the
+accustomed hour when the family arose.  That hour passed, the sun
+mounted high in the heavens, but the cottagers did not appear.  I
+trembled violently, apprehending some dreadful misfortune.  The inside
+of the cottage was dark, and I heard no motion; I cannot describe the
+agony of this suspense.
+
+"Presently two countrymen passed by, but pausing near the cottage, they
+entered into conversation, using violent gesticulations; but I did not
+understand what they said, as they spoke the language of the country,
+which differed from that of my protectors.  Soon after, however, Felix
+approached with another man; I was surprised, as I knew that he had not
+quitted the cottage that morning, and waited anxiously to discover from
+his discourse the meaning of these unusual appearances.
+
+"'Do you consider,' said his companion to him, 'that you will be
+obliged to pay three months' rent and to lose the produce of your
+garden?  I do not wish to take any unfair advantage, and I beg
+therefore that you will take some days to consider of your
+determination.'
+
+"'It is utterly useless,' replied Felix; 'we can never again inhabit
+your cottage.  The life of my father is in the greatest danger, owing
+to the dreadful circumstance that I have related.  My wife and my
+sister will never recover from their horror.  I entreat you not to
+reason with me any more.  Take possession of your tenement and let me
+fly from this place.'
+
+"Felix trembled violently as he said this.  He and his companion
+entered the cottage, in which they remained for a few minutes, and then
+departed.  I never saw any of the family of De Lacey more.
+
+"I continued for the remainder of the day in my hovel in a state of
+utter and stupid despair.  My protectors had departed and had broken
+the only link that held me to the world.  For the first time the
+feelings of revenge and hatred filled my bosom, and I did not strive to
+control them, but allowing myself to be borne away by the stream, I
+bent my mind towards injury and death.  When I thought of my friends,
+of the mild voice of De Lacey, the gentle eyes of Agatha, and the
+exquisite beauty of the Arabian, these thoughts vanished and a gush of
+tears somewhat soothed me.  But again when I reflected that they had
+spurned and deserted me, anger returned, a rage of anger, and unable to
+injure anything human, I turned my fury towards inanimate objects.  As
+night advanced I placed a variety of combustibles around the cottage,
+and after having destroyed every vestige of cultivation in the garden,
+I waited with forced impatience until the moon had sunk to commence my
+operations.
+
+"As the night advanced, a fierce wind arose from the woods and quickly
+dispersed the clouds that had loitered in the heavens; the blast tore
+along like a mighty avalanche and produced a kind of insanity in my
+spirits that burst all bounds of reason and reflection.  I lighted the
+dry branch of a tree and danced with fury around the devoted cottage,
+my eyes still fixed on the western horizon, the edge of which the moon
+nearly touched.  A part of its orb was at length hid, and I waved my
+brand; it sank, and with a loud scream I fired the straw, and heath,
+and bushes, which I had collected.  The wind fanned the fire, and the
+cottage was quickly enveloped by the flames, which clung to it and
+licked it with their forked and destroying tongues.
+
+"As soon as I was convinced that no assistance could save any part of
+the habitation, I quitted the scene and sought for refuge in the woods.
+
+"And now, with the world before me, whither should I bend my steps?  I
+resolved to fly far from the scene of my misfortunes; but to me, hated
+and despised, every country must be equally horrible.  At length the
+thought of you crossed my mind.  I learned from your papers that you
+were my father, my creator; and to whom could I apply with more fitness
+than to him who had given me life?  Among the lessons that Felix had
+bestowed upon Safie, geography had not been omitted; I had learned from
+these the relative situations of the different countries of the earth.
+You had mentioned Geneva as the name of your native town, and towards
+this place I resolved to proceed.
+
+"But how was I to direct myself?  I knew that I must travel in a
+southwesterly direction to reach my destination, but the sun was my
+only guide.  I did not know the names of the towns that I was to pass
+through, nor could I ask information from a single human being; but I
+did not despair.  From you only could I hope for succour, although
+towards you I felt no sentiment but that of hatred.  Unfeeling,
+heartless creator!  You had endowed me with perceptions and passions
+and then cast me abroad an object for the scorn and horror of mankind.
+But on you only had I any claim for pity and redress, and from you I
+determined to seek that justice which I vainly attempted to gain from
+any other being that wore the human form.
+
+"My travels were long and the sufferings I endured intense.  It was
+late in autumn when I quitted the district where I had so long resided.
+I travelled only at night, fearful of encountering the visage of a
+human being.  Nature decayed around me, and the sun became heatless;
+rain and snow poured around me; mighty rivers were frozen; the surface
+of the earth was hard and chill, and bare, and I found no shelter.  Oh,
+earth!  How often did I imprecate curses on the cause of my being!  The
+mildness of my nature had fled, and all within me was turned to gall
+and bitterness.  The nearer I approached to your habitation, the more
+deeply did I feel the spirit of revenge enkindled in my heart.  Snow
+fell, and the waters were hardened, but I rested not.  A few incidents
+now and then directed me, and I possessed a map of the country; but I
+often wandered wide from my path.  The agony of my feelings allowed me
+no respite; no incident occurred from which my rage and misery could
+not extract its food; but a circumstance that happened when I arrived
+on the confines of Switzerland, when the sun had recovered its warmth
+and the earth again began to look green, confirmed in an especial
+manner the bitterness and horror of my feelings.
+
+"I generally rested during the day and travelled only when I was
+secured by night from the view of man.  One morning, however, finding
+that my path lay through a deep wood, I ventured to continue my journey
+after the sun had risen; the day, which was one of the first of spring,
+cheered even me by the loveliness of its sunshine and the balminess of
+the air.  I felt emotions of gentleness and pleasure, that had long
+appeared dead, revive within me.  Half surprised by the novelty of
+these sensations, I allowed myself to be borne away by them, and
+forgetting my solitude and deformity, dared to be happy.  Soft tears
+again bedewed my cheeks, and I even raised my humid eyes with
+thankfulness towards the blessed sun, which bestowed such joy upon me.
+
+"I continued to wind among the paths of the wood, until I came to its
+boundary, which was skirted by a deep and rapid river, into which many
+of the trees bent their branches, now budding with the fresh spring.
+Here I paused, not exactly knowing what path to pursue, when I heard
+the sound of voices, that induced me to conceal myself under the shade
+of a cypress.  I was scarcely hid when a young girl came running
+towards the spot where I was concealed, laughing, as if she ran from
+someone in sport.  She continued her course along the precipitous sides
+of the river, when suddenly her foot slipped, and she fell into the
+rapid stream.  I rushed from my hiding-place and with extreme labour,
+from the force of the current, saved her and dragged her to shore.  She
+was senseless, and I endeavoured by every means in my power to restore
+animation, when I was suddenly interrupted by the approach of a rustic,
+who was probably the person from whom she had playfully fled.  On
+seeing me, he darted towards me, and tearing the girl from my arms,
+hastened towards the deeper parts of the wood.  I followed speedily, I
+hardly knew why; but when the man saw me draw near, he aimed a gun,
+which he carried, at my body and fired.  I sank to the ground, and my
+injurer, with increased swiftness, escaped into the wood.
+
+"This was then the reward of my benevolence!  I had saved a human being
+from destruction, and as a recompense I now writhed under the miserable
+pain of a wound which shattered the flesh and bone.  The feelings of
+kindness and gentleness which I had entertained but a few moments
+before gave place to hellish rage and gnashing of teeth.  Inflamed by
+pain, I vowed eternal hatred and vengeance to all mankind.  But the
+agony of my wound overcame me; my pulses paused, and I fainted.
+
+"For some weeks I led a miserable life in the woods, endeavouring to
+cure the wound which I had received.  The ball had entered my shoulder,
+and I knew not whether it had remained there or passed through; at any
+rate I had no means of extracting it.  My sufferings were augmented
+also by the oppressive sense of the injustice and ingratitude of their
+infliction.  My daily vows rose for revenge--a deep and deadly revenge,
+such as would alone compensate for the outrages and anguish I had
+endured.
+
+"After some weeks my wound healed, and I continued my journey.  The
+labours I endured were no longer to be alleviated by the bright sun or
+gentle breezes of spring; all joy was but a mockery which insulted my
+desolate state and made me feel more painfully that I was not made for
+the enjoyment of pleasure.
+
+"But my toils now drew near a close, and in two months from this time I
+reached the environs of Geneva.
+
+"It was evening when I arrived, and I retired to a hiding-place among
+the fields that surround it to meditate in what manner I should apply
+to you.  I was oppressed by fatigue and hunger and far too unhappy to
+enjoy the gentle breezes of evening or the prospect of the sun setting
+behind the stupendous mountains of Jura.
+
+"At this time a slight sleep relieved me from the pain of reflection,
+which was disturbed by the approach of a beautiful child, who came
+running into the recess I had chosen, with all the sportiveness of
+infancy.  Suddenly, as I gazed on him, an idea seized me that this
+little creature was unprejudiced and had lived too short a time to have
+imbibed a horror of deformity.  If, therefore, I could seize him and
+educate him as my companion and friend, I should not be so desolate in
+this peopled earth.
+
+"Urged by this impulse, I seized on the boy as he passed and drew him
+towards me.  As soon as he beheld my form, he placed his hands before
+his eyes and uttered a shrill scream; I drew his hand forcibly from his
+face and said, 'Child, what is the meaning of this?  I do not intend to
+hurt you; listen to me.'
+
+"He struggled violently.  'Let me go,' he cried; 'monster!  Ugly
+wretch!  You wish to eat me and tear me to pieces.  You are an ogre.
+Let me go, or I will tell my papa.'
+
+"'Boy, you will never see your father again; you must come with me.'
+
+"'Hideous monster!  Let me go.  My papa is a syndic--he is M.
+Frankenstein--he will punish you.  You dare not keep me.'
+
+"'Frankenstein! you belong then to my enemy--to him towards whom I have
+sworn eternal revenge; you shall be my first victim.'
+
+"The child still struggled and loaded me with epithets which carried
+despair to my heart; I grasped his throat to silence him, and in a
+moment he lay dead at my feet.
+
+"I gazed on my victim, and my heart swelled with exultation and hellish
+triumph; clapping my hands, I exclaimed, 'I too can create desolation;
+my enemy is not invulnerable; this death will carry despair to him, and
+a thousand other miseries shall torment and destroy him.'
+
+"As I fixed my eyes on the child, I saw something glittering on his
+breast.  I took it; it was a portrait of a most lovely woman.  In spite
+of my malignity, it softened and attracted me.  For a few moments I
+gazed with delight on her dark eyes, fringed by deep lashes, and her
+lovely lips; but presently my rage returned; I remembered that I was
+forever deprived of the delights that such beautiful creatures could
+bestow and that she whose resemblance I contemplated would, in
+regarding me, have changed that air of divine benignity to one
+expressive of disgust and affright.
+
+"Can you wonder that such thoughts transported me with rage?  I only
+wonder that at that moment, instead of venting my sensations in
+exclamations and agony, I did not rush among mankind and perish in the
+attempt to destroy them.
+
+"While I was overcome by these feelings, I left the spot where I had
+committed the murder, and seeking a more secluded hiding-place, I
+entered a barn which had appeared to me to be empty.  A woman was
+sleeping on some straw; she was young, not indeed so beautiful as her
+whose portrait I held, but of an agreeable aspect and blooming in the
+loveliness of youth and health.  Here, I thought, is one of those whose
+joy-imparting smiles are bestowed on all but me.  And then I bent over
+her and whispered, 'Awake, fairest, thy lover is near--he who would
+give his life but to obtain one look of affection from thine eyes; my
+beloved, awake!'
+
+"The sleeper stirred; a thrill of terror ran through me.  Should she
+indeed awake, and see me, and curse me, and denounce the murderer? Thus
+would she assuredly act if her darkened eyes opened and she beheld me.
+The thought was madness; it stirred the fiend within me--not I, but
+she, shall suffer; the murder I have committed because I am forever
+robbed of all that she could give me, she shall atone.  The crime had
+its source in her; be hers the punishment!  Thanks to the lessons of
+Felix and the sanguinary laws of man, I had learned now to work
+mischief.  I bent over her and placed the portrait securely in one of
+the folds of her dress.  She moved again, and I fled.
+
+"For some days I haunted the spot where these scenes had taken place,
+sometimes wishing to see you, sometimes resolved to quit the world and
+its miseries forever.  At length I wandered towards these mountains,
+and have ranged through their immense recesses, consumed by a burning
+passion which you alone can gratify.  We may not part until you have
+promised to comply with my requisition.  I am alone and miserable; man
+will not associate with me; but one as deformed and horrible as myself
+would not deny herself to me.  My companion must be of the same species
+and have the same defects.  This being you must create."
+
+
+
+Chapter 17
+
+The being finished speaking and fixed his looks upon me in the
+expectation of a reply.  But I was bewildered, perplexed, and unable to
+arrange my ideas sufficiently to understand the full extent of his
+proposition.  He continued,
+
+"You must create a female for me with whom I can live in the
+interchange of those sympathies necessary for my being.  This you alone
+can do, and I demand it of you as a right which you must not refuse to
+concede."
+
+The latter part of his tale had kindled anew in me the anger that had
+died away while he narrated his peaceful life among the cottagers, and
+as he said this I could no longer suppress the rage that burned within
+me.
+
+"I do refuse it," I replied; "and no torture shall ever extort a
+consent from me.  You may render me the most miserable of men, but you
+shall never make me base in my own eyes.  Shall I create another like
+yourself, whose joint wickedness might desolate the world.  Begone!  I
+have answered you; you may torture me, but I will never consent."
+
+"You are in the wrong," replied the fiend; "and instead of threatening,
+I am content to reason with you.  I am malicious because I am
+miserable.  Am I not shunned and hated by all mankind?  You, my
+creator, would tear me to pieces and triumph; remember that, and tell
+me why I should pity man more than he pities me?  You would not call it
+murder if you could precipitate me into one of those ice-rifts and
+destroy my frame, the work of your own hands.  Shall I respect man when
+he condemns me?  Let him live with me in the interchange of kindness,
+and instead of injury I would bestow every benefit upon him with tears
+of gratitude at his acceptance.  But that cannot be; the human senses
+are insurmountable barriers to our union.  Yet mine shall not be the
+submission of abject slavery.  I will revenge my injuries; if I cannot
+inspire love, I will cause fear, and chiefly towards you my arch-enemy,
+because my creator, do I swear inextinguishable hatred.  Have a care; I
+will work at your destruction, nor finish until I desolate your heart,
+so that you shall curse the hour of your birth."
+
+A fiendish rage animated him as he said this; his face was wrinkled
+into contortions too horrible for human eyes to behold; but presently
+he calmed himself and proceeded--
+
+"I intended to reason.  This passion is detrimental to me, for you do
+not reflect that YOU are the cause of its excess.  If any being felt
+emotions of benevolence towards me, I should return them a hundred and
+a hundredfold; for that one creature's sake I would make peace with the
+whole kind!  But I now indulge in dreams of bliss that cannot be
+realized.  What I ask of you is reasonable and moderate; I demand a
+creature of another sex, but as hideous as myself; the gratification is
+small, but it is all that I can receive, and it shall content me.  It
+is true, we shall be monsters, cut off from all the world; but on that
+account we shall be more attached to one another.  Our lives will not
+be happy, but they will be harmless and free from the misery I now
+feel.  Oh!  My creator, make me happy; let me feel gratitude towards
+you for one benefit!  Let me see that I excite the sympathy of some
+existing thing; do not deny me my request!"
+
+I was moved.  I shuddered when I thought of the possible consequences
+of my consent, but I felt that there was some justice in his argument.
+His tale and the feelings he now expressed proved him to be a creature
+of fine sensations, and did I not as his maker owe him all the portion
+of happiness that it was in my power to bestow?  He saw my change of
+feeling and continued,
+
+"If you consent, neither you nor any other human being shall ever see
+us again; I will go to the vast wilds of South America.  My food is not
+that of man; I do not destroy the lamb and the kid to glut my appetite;
+acorns and berries afford me sufficient nourishment.  My companion will
+be of the same nature as myself and will be content with the same fare.
+We shall make our bed of dried leaves; the sun will shine on us as on
+man and will ripen our food.  The picture I present to you is peaceful
+and human, and you must feel that you could deny it only in the
+wantonness of power and cruelty.  Pitiless as you have been towards me,
+I now see compassion in your eyes; let me seize the favourable moment
+and persuade you to promise what I so ardently desire."
+
+"You propose," replied I, "to fly from the habitations of man, to dwell
+in those wilds where the beasts of the field will be your only
+companions.  How can you, who long for the love and sympathy of man,
+persevere in this exile?  You will return and again seek their
+kindness, and you will meet with their detestation; your evil passions
+will be renewed, and you will then have a companion to aid you in the
+task of destruction.  This may not be; cease to argue the point, for I
+cannot consent."
+
+"How inconstant are your feelings!  But a moment ago you were moved by
+my representations, and why do you again harden yourself to my
+complaints?  I swear to you, by the earth which I inhabit, and by you
+that made me, that with the companion you bestow I will quit the
+neighbourhood of man and dwell, as it may chance, in the most savage of
+places.  My evil passions will have fled, for I shall meet with
+sympathy!  My life will flow quietly away, and in my dying moments I
+shall not curse my maker."
+
+His words had a strange effect upon me.  I compassionated him and
+sometimes felt a wish to console him, but when I looked upon him, when
+I saw the filthy mass that moved and talked, my heart sickened and my
+feelings were altered to those of horror and hatred.  I tried to stifle
+these sensations; I thought that as I could not sympathize with him, I
+had no right to withhold from him the small portion of happiness which
+was yet in my power to bestow.
+
+"You swear," I said, "to be harmless; but have you not already shown a
+degree of malice that should reasonably make me distrust you?  May not
+even this be a feint that will increase your triumph by affording a
+wider scope for your revenge?"
+
+"How is this?  I must not be trifled with, and I demand an answer.  If
+I have no ties and no affections, hatred and vice must be my portion;
+the love of another will destroy the cause of my crimes, and I shall
+become a thing of whose existence everyone will be ignorant.  My vices
+are the children of a forced solitude that I abhor, and my virtues will
+necessarily arise when I live in communion with an equal.  I shall feel
+the affections of a sensitive being and become linked to the chain of
+existence and events from which I am now excluded."
+
+I paused some time to reflect on all he had related and the various
+arguments which he had employed.  I thought of the promise of virtues
+which he had displayed on the opening of his existence and the
+subsequent blight of all kindly feeling by the loathing and scorn which
+his protectors had manifested towards him.  His power and threats were
+not omitted in my calculations; a creature who could exist in the ice
+caves of the glaciers and hide himself from pursuit among the ridges of
+inaccessible precipices was a being possessing faculties it would be
+vain to cope with.  After a long pause of reflection I concluded that
+the justice due both to him and my fellow creatures demanded of me that
+I should comply with his request.  Turning to him, therefore, I said,
+
+"I consent to your demand, on your solemn oath to quit Europe forever,
+and every other place in the neighbourhood of man, as soon as I shall
+deliver into your hands a female who will accompany you in your exile."
+
+"I swear," he cried, "by the sun, and by the blue sky of heaven, and by
+the fire of love that burns my heart, that if you grant my prayer,
+while they exist you shall never behold me again.  Depart to your home
+and commence your labours; I shall watch their progress with
+unutterable anxiety; and fear not but that when you are ready I shall
+appear."
+
+Saying this, he suddenly quitted me, fearful, perhaps, of any change in
+my sentiments.  I saw him descend the mountain with greater speed than
+the flight of an eagle, and quickly lost among the undulations of the
+sea of ice.
+
+His tale had occupied the whole day, and the sun was upon the verge of
+the horizon when he departed.  I knew that I ought to hasten my descent
+towards the valley, as I should soon be encompassed in darkness; but my
+heart was heavy, and my steps slow.  The labour of winding among the
+little paths of the mountain and fixing my feet firmly as I advanced
+perplexed me, occupied as I was by the emotions which the occurrences
+of the day had produced.  Night was far advanced when I came to the
+halfway resting-place and seated myself beside the fountain.  The stars
+shone at intervals as the clouds passed from over them; the dark pines
+rose before me, and every here and there a broken tree lay on the
+ground; it was a scene of wonderful solemnity and stirred strange
+thoughts within me.  I wept bitterly, and clasping my hands in agony, I
+exclaimed, "Oh!  Stars and clouds and winds, ye are all about to mock
+me; if ye really pity me, crush sensation and memory; let me become as
+nought; but if not, depart, depart, and leave me in darkness."
+
+These were wild and miserable thoughts, but I cannot describe to you
+how the eternal twinkling of the stars weighed upon me and how I
+listened to every blast of wind as if it were a dull ugly siroc on its
+way to consume me.
+
+Morning dawned before I arrived at the village of Chamounix; I took no
+rest, but returned immediately to Geneva.  Even in my own heart I could
+give no expression to my sensations--they weighed on me with a
+mountain's weight and their excess destroyed my agony beneath them.
+Thus I returned home, and entering the house, presented myself to the
+family.  My haggard and wild appearance awoke intense alarm, but I
+answered no question, scarcely did I speak.  I felt as if I were placed
+under a ban--as if I had no right to claim their sympathies--as if
+never more might I enjoy companionship with them.  Yet even thus I
+loved them to adoration; and to save them, I resolved to dedicate
+myself to my most abhorred task.  The prospect of such an occupation
+made every other circumstance of existence pass before me like a dream,
+and that thought only had to me the reality of life.
+
+
+
+Chapter 18
+
+Day after day, week after week, passed away on my return to Geneva; and
+I could not collect the courage to recommence my work.  I feared the
+vengeance of the disappointed fiend, yet I was unable to overcome my
+repugnance to the task which was enjoined me.  I found that I could not
+compose a female without again devoting several months to profound
+study and laborious disquisition.  I had heard of some discoveries
+having been made by an English philosopher, the knowledge of which was
+material to my success, and I sometimes thought of obtaining my
+father's consent to visit England for this purpose; but I clung to
+every pretence of delay and shrank from taking the first step in an
+undertaking whose immediate necessity began to appear less absolute to
+me.  A change indeed had taken place in me; my health, which had
+hitherto declined, was now much restored; and my spirits, when
+unchecked by the memory of my unhappy promise, rose proportionably.  My
+father saw this change with pleasure, and he turned his thoughts
+towards the best method of eradicating the remains of my melancholy,
+which every now and then would return by fits, and with a devouring
+blackness overcast the approaching sunshine.  At these moments I took
+refuge in the most perfect solitude.  I passed whole days on the lake
+alone in a little boat, watching the clouds and listening to the
+rippling of the waves, silent and listless.  But the fresh air and
+bright sun seldom failed to restore me to some degree of composure, and
+on my return I met the salutations of my friends with a readier smile
+and a more cheerful heart.
+
+It was after my return from one of these rambles that my father,
+calling me aside, thus addressed me,
+
+"I am happy to remark, my dear son, that you have resumed your former
+pleasures and seem to be returning to yourself.  And yet you are still
+unhappy and still avoid our society.  For some time I was lost in
+conjecture as to the cause of this, but yesterday an idea struck me,
+and if it is well founded, I conjure you to avow it.  Reserve on such a
+point would be not only useless, but draw down treble misery on us all."
+
+I trembled violently at his exordium, and my father continued--"I
+confess, my son, that I have always looked forward to your marriage
+with our dear Elizabeth as the tie of our domestic comfort and the stay
+of my declining years.  You were attached to each other from your
+earliest infancy; you studied together, and appeared, in dispositions
+and tastes, entirely suited to one another.  But so blind is the
+experience of man that what I conceived to be the best assistants to my
+plan may have entirely destroyed it.  You, perhaps, regard her as your
+sister, without any wish that she might become your wife.  Nay, you may
+have met with another whom you may love; and considering yourself as
+bound in honour to Elizabeth, this struggle may occasion the poignant
+misery which you appear to feel."
+
+"My dear father, reassure yourself.  I love my cousin tenderly and
+sincerely.  I never saw any woman who excited, as Elizabeth does, my
+warmest admiration and affection.  My future hopes and prospects are
+entirely bound up in the expectation of our union."
+
+"The expression of your sentiments of this subject, my dear Victor,
+gives me more pleasure than I have for some time experienced.  If you
+feel thus, we shall assuredly be happy, however present events may cast
+a gloom over us.  But it is this gloom which appears to have taken so
+strong a hold of your mind that I wish to dissipate.  Tell me,
+therefore, whether you object to an immediate solemnization of the
+marriage.  We have been unfortunate, and recent events have drawn us
+from that everyday tranquillity befitting my years and infirmities. You
+are younger; yet I do not suppose, possessed as you are of a competent
+fortune, that an early marriage would at all interfere with any future
+plans of honour and utility that you may have formed.  Do not suppose,
+however, that I wish to dictate happiness to you or that a delay on
+your part would cause me any serious uneasiness.  Interpret my words
+with candour and answer me, I conjure you, with confidence and
+sincerity."
+
+I listened to my father in silence and remained for some time incapable
+of offering any reply.  I revolved rapidly in my mind a multitude of
+thoughts and endeavoured to arrive at some conclusion.  Alas!  To me
+the idea of an immediate union with my Elizabeth was one of horror and
+dismay.  I was bound by a solemn promise which I had not yet fulfilled
+and dared not break, or if I did, what manifold miseries might not
+impend over me and my devoted family!  Could I enter into a festival
+with this deadly weight yet hanging round my neck and bowing me to the
+ground?  I must perform my engagement and let the monster depart with
+his mate before I allowed myself to enjoy the delight of a union from
+which I expected peace.
+
+I remembered also the necessity imposed upon me of either journeying to
+England or entering into a long correspondence with those philosophers
+of that country whose knowledge and discoveries were of indispensable
+use to me in my present undertaking.  The latter method of obtaining
+the desired intelligence was dilatory and unsatisfactory; besides, I
+had an insurmountable aversion to the idea of engaging myself in my
+loathsome task in my father's house while in habits of familiar
+intercourse with those I loved.  I knew that a thousand fearful
+accidents might occur, the slightest of which would disclose a tale to
+thrill all connected with me with horror.  I was aware also that I
+should often lose all self-command, all capacity of hiding the
+harrowing sensations that would possess me during the progress of my
+unearthly occupation.  I must absent myself from all I loved while thus
+employed.  Once commenced, it would quickly be achieved, and I might be
+restored to my family in peace and happiness.  My promise fulfilled,
+the monster would depart forever.  Or (so my fond fancy imaged) some
+accident might meanwhile occur to destroy him and put an end to my
+slavery forever.
+
+These feelings dictated my answer to my father.  I expressed a wish to
+visit England, but concealing the true reasons of this request, I
+clothed my desires under a guise which excited no suspicion, while I
+urged my desire with an earnestness that easily induced my father to
+comply.  After so long a period of an absorbing melancholy that
+resembled madness in its intensity and effects, he was glad to find
+that I was capable of taking pleasure in the idea of such a journey,
+and he hoped that change of scene and varied amusement would, before my
+return, have restored me entirely to myself.
+
+The duration of my absence was left to my own choice; a few months, or
+at most a year, was the period contemplated.  One paternal kind
+precaution he had taken to ensure my having a companion.  Without
+previously communicating with me, he had, in concert with Elizabeth,
+arranged that Clerval should join me at Strasbourg.  This interfered
+with the solitude I coveted for the prosecution of my task; yet at the
+commencement of my journey the presence of my friend could in no way be
+an impediment, and truly I rejoiced that thus I should be saved many
+hours of lonely, maddening reflection.  Nay, Henry might stand between
+me and the intrusion of my foe.  If I were alone, would he not at times
+force his abhorred presence on me to remind me of my task or to
+contemplate its progress?
+
+To England, therefore, I was bound, and it was understood that my union
+with Elizabeth should take place immediately on my return.  My father's
+age rendered him extremely averse to delay.  For myself, there was one
+reward I promised myself from my detested toils--one consolation for my
+unparalleled sufferings; it was the prospect of that day when,
+enfranchised from my miserable slavery, I might claim Elizabeth and
+forget the past in my union with her.
+
+I now made arrangements for my journey, but one feeling haunted me
+which filled me with fear and agitation.  During my absence I should
+leave my friends unconscious of the existence of their enemy and
+unprotected from his attacks, exasperated as he might be by my
+departure.  But he had promised to follow me wherever I might go, and
+would he not accompany me to England?  This imagination was dreadful in
+itself, but soothing inasmuch as it supposed the safety of my friends.
+I was agonized with the idea of the possibility that the reverse of
+this might happen.  But through the whole period during which I was the
+slave of my creature I allowed myself to be governed by the impulses of
+the moment; and my present sensations strongly intimated that the fiend
+would follow me and exempt my family from the danger of his
+machinations.
+
+It was in the latter end of September that I again quitted my native
+country.  My journey had been my own suggestion, and Elizabeth
+therefore acquiesced, but she was filled with disquiet at the idea of
+my suffering, away from her, the inroads of misery and grief.  It had
+been her care which provided me a companion in Clerval--and yet a man
+is blind to a thousand minute circumstances which call forth a woman's
+sedulous attention.  She longed to bid me hasten my return; a thousand
+conflicting emotions rendered her mute as she bade me a tearful, silent
+farewell.
+
+I threw myself into the carriage that was to convey me away, hardly
+knowing whither I was going, and careless of what was passing around.
+I remembered only, and it was with a bitter anguish that I reflected on
+it, to order that my chemical instruments should be packed to go with
+me.  Filled with dreary imaginations, I passed through many beautiful
+and majestic scenes, but my eyes were fixed and unobserving.  I could
+only think of the bourne of my travels and the work which was to occupy
+me whilst they endured.
+
+After some days spent in listless indolence, during which I traversed
+many leagues, I arrived at Strasbourg, where I waited two days for
+Clerval.  He came.  Alas, how great was the contrast between us!  He
+was alive to every new scene, joyful when he saw the beauties of the
+setting sun, and more happy when he beheld it rise and recommence a new
+day.  He pointed out to me the shifting colours of the landscape and
+the appearances of the sky.  "This is what it is to live," he cried;
+"how I enjoy existence!  But you, my dear Frankenstein, wherefore are
+you desponding and sorrowful!" In truth, I was occupied by gloomy
+thoughts and neither saw the descent of the evening star nor the golden
+sunrise reflected in the Rhine.  And you, my friend, would be far more
+amused with the journal of Clerval, who observed the scenery with an
+eye of feeling and delight, than in listening to my reflections.  I, a
+miserable wretch, haunted by a curse that shut up every avenue to
+enjoyment.
+
+We had agreed to descend the Rhine in a boat from Strasbourg to
+Rotterdam, whence we might take shipping for London.  During this
+voyage we passed many willowy islands and saw several beautiful towns.
+We stayed a day at Mannheim, and on the fifth from our departure from
+Strasbourg, arrived at Mainz.  The course of the Rhine below Mainz
+becomes much more picturesque.  The river descends rapidly and winds
+between hills, not high, but steep, and of beautiful forms.  We saw
+many ruined castles standing on the edges of precipices, surrounded by
+black woods, high and inaccessible.  This part of the Rhine, indeed,
+presents a singularly variegated landscape.  In one spot you view
+rugged hills, ruined castles overlooking tremendous precipices, with
+the dark Rhine rushing beneath; and on the sudden turn of a promontory,
+flourishing vineyards with green sloping banks and a meandering river
+and populous towns occupy the scene.
+
+We travelled at the time of the vintage and heard the song of the
+labourers as we glided down the stream.  Even I, depressed in mind, and
+my spirits continually agitated by gloomy feelings, even I was pleased.
+I lay at the bottom of the boat, and as I gazed on the cloudless blue
+sky, I seemed to drink in a tranquillity to which I had long been a
+stranger.  And if these were my sensations, who can describe those of
+Henry?  He felt as if he had been transported to fairy-land and enjoyed
+a happiness seldom tasted by man.  "I have seen," he said, "the most
+beautiful scenes of my own country; I have visited the lakes of Lucerne
+and Uri, where the snowy mountains descend almost perpendicularly to
+the water, casting black and impenetrable shades, which would cause a
+gloomy and mournful appearance were it not for the most verdant islands
+that believe the eye by their gay appearance; I have seen this lake
+agitated by a tempest, when the wind tore up whirlwinds of water and
+gave you an idea of what the water-spout must be on the great ocean;
+and the waves dash with fury the base of the mountain, where the priest
+and his mistress were overwhelmed by an avalanche and where their dying
+voices are still said to be heard amid the pauses of the nightly wind;
+I have seen the mountains of La Valais, and the Pays de Vaud; but this
+country, Victor, pleases me more than all those wonders.  The mountains
+of Switzerland are more majestic and strange, but there is a charm in
+the banks of this divine river that I never before saw equalled.  Look
+at that castle which overhangs yon precipice; and that also on the
+island, almost concealed amongst the foliage of those lovely trees; and
+now that group of labourers coming from among their vines; and that
+village half hid in the recess of the mountain.  Oh, surely the spirit
+that inhabits and guards this place has a soul more in harmony with man
+than those who pile the glacier or retire to the inaccessible peaks of
+the mountains of our own country." Clerval!  Beloved friend!  Even now
+it delights me to record your words and to dwell on the praise of which
+you are so eminently deserving.  He was a being formed in the "very
+poetry of nature." His wild and enthusiastic imagination was chastened
+by the sensibility of his heart.  His soul overflowed with ardent
+affections, and his friendship was of that devoted and wondrous nature
+that the world-minded teach us to look for only in the imagination. But
+even human sympathies were not sufficient to satisfy his eager mind.
+The scenery of external nature, which others regard only with
+admiration, he loved with ardour:--
+
+
+     ----The sounding cataract
+     Haunted him like a passion:  the tall rock,
+     The mountain, and the deep and gloomy wood,
+     Their colours and their forms, were then to him
+     An appetite; a feeling, and a love,
+     That had no need of a remoter charm,
+     By thought supplied, or any interest
+     Unborrow'd from the eye.
+
+                    [Wordsworth's "Tintern Abbey".]
+
+
+And where does he now exist?  Is this gentle and lovely being lost
+forever?  Has this mind, so replete with ideas, imaginations fanciful
+and magnificent, which formed a world, whose existence depended on the
+life of its creator;--has this mind perished?  Does it now only exist
+in my memory?  No, it is not thus; your form so divinely wrought, and
+beaming with beauty, has decayed, but your spirit still visits and
+consoles your unhappy friend.
+
+Pardon this gush of sorrow; these ineffectual words are but a slight
+tribute to the unexampled worth of Henry, but they soothe my heart,
+overflowing with the anguish which his remembrance creates.  I will
+proceed with my tale.
+
+Beyond Cologne we descended to the plains of Holland; and we resolved
+to post the remainder of our way, for the wind was contrary and the
+stream of the river was too gentle to aid us.  Our journey here lost
+the interest arising from beautiful scenery, but we arrived in a few
+days at Rotterdam, whence we proceeded by sea to England.  It was on a
+clear morning, in the latter days of December, that I first saw the
+white cliffs of Britain.  The banks of the Thames presented a new
+scene; they were flat but fertile, and almost every town was marked by
+the remembrance of some story.  We saw Tilbury Fort and remembered the
+Spanish Armada, Gravesend, Woolwich, and Greenwich--places which I had
+heard of even in my country.
+
+At length we saw the numerous steeples of London, St. Paul's towering
+above all, and the Tower famed in English history.
+
+
+
+Chapter 19
+
+London was our present point of rest; we determined to remain several
+months in this wonderful and celebrated city.  Clerval desired the
+intercourse of the men of genius and talent who flourished at this
+time, but this was with me a secondary object; I was principally
+occupied with the means of obtaining the information necessary for the
+completion of my promise and quickly availed myself of the letters of
+introduction that I had brought with me, addressed to the most
+distinguished natural philosophers.
+
+If this journey had taken place during my days of study and happiness,
+it would have afforded me inexpressible pleasure.  But a blight had
+come over my existence, and I only visited these people for the sake of
+the information they might give me on the subject in which my interest
+was so terribly profound.  Company was irksome to me; when alone, I
+could fill my mind with the sights of heaven and earth; the voice of
+Henry soothed me, and I could thus cheat myself into a transitory
+peace.  But busy, uninteresting, joyous faces brought back despair to
+my heart.  I saw an insurmountable barrier placed between me and my
+fellow men; this barrier was sealed with the blood of William and
+Justine, and to reflect on the events connected with those names filled
+my soul with anguish.
+
+But in Clerval I saw the image of my former self; he was inquisitive
+and anxious to gain experience and instruction.  The difference of
+manners which he observed was to him an inexhaustible source of
+instruction and amusement.  He was also pursuing an object he had long
+had in view.  His design was to visit India, in the belief that he had
+in his knowledge of its various languages, and in the views he had
+taken of its society, the means of materially assisting the progress of
+European colonization and trade.  In Britain only could he further the
+execution of his plan.  He was forever busy, and the only check to his
+enjoyments was my sorrowful and dejected mind.  I tried to conceal this
+as much as possible, that I might not debar him from the pleasures
+natural to one who was entering on a new scene of life, undisturbed by
+any care or bitter recollection.  I often refused to accompany him,
+alleging another engagement, that I might remain alone.  I now also
+began to collect the materials necessary for my new creation, and this
+was to me like the torture of single drops of water continually falling
+on the head.  Every thought that was devoted to it was an extreme
+anguish, and every word that I spoke in allusion to it caused my lips
+to quiver, and my heart to palpitate.
+
+After passing some months in London, we received a letter from a person
+in Scotland who had formerly been our visitor at Geneva.  He mentioned
+the beauties of his native country and asked us if those were not
+sufficient allurements to induce us to prolong our journey as far north
+as Perth, where he resided.  Clerval eagerly desired to accept this
+invitation, and I, although I abhorred society, wished to view again
+mountains and streams and all the wondrous works with which Nature
+adorns her chosen dwelling-places.  We had arrived in England at the
+beginning of October, and it was now February.  We accordingly
+determined to commence our journey towards the north at the expiration
+of another month.  In this expedition we did not intend to follow the
+great road to Edinburgh, but to visit Windsor, Oxford, Matlock, and the
+Cumberland lakes, resolving to arrive at the completion of this tour
+about the end of July.  I packed up my chemical instruments and the
+materials I had collected, resolving to finish my labours in some
+obscure nook in the northern highlands of Scotland.
+
+We quitted London on the 27th of March and remained a few days at
+Windsor, rambling in its beautiful forest.  This was a new scene to us
+mountaineers; the majestic oaks, the quantity of game, and the herds of
+stately deer were all novelties to us.
+
+From thence we proceeded to Oxford.  As we entered this city our minds
+were filled with the remembrance of the events that had been transacted
+there more than a century and a half before.  It was here that Charles
+I. had collected his forces.  This city had remained faithful to him,
+after the whole nation had forsaken his cause to join the standard of
+Parliament and liberty.  The memory of that unfortunate king and his
+companions, the amiable Falkland, the insolent Goring, his queen, and
+son, gave a peculiar interest to every part of the city which they
+might be supposed to have inhabited.  The spirit of elder days found a
+dwelling here, and we delighted to trace its footsteps.  If these
+feelings had not found an imaginary gratification, the appearance of
+the city had yet in itself sufficient beauty to obtain our admiration.
+The colleges are ancient and picturesque; the streets are almost
+magnificent; and the lovely Isis, which flows beside it through meadows
+of exquisite verdure, is spread forth into a placid expanse of waters,
+which reflects its majestic assemblage of towers, and spires, and
+domes, embosomed among aged trees.
+
+I enjoyed this scene, and yet my enjoyment was embittered both by the
+memory of the past and the anticipation of the future.  I was formed
+for peaceful happiness.  During my youthful days discontent never
+visited my mind, and if I was ever overcome by ennui, the sight of what
+is beautiful in nature or the study of what is excellent and sublime in
+the productions of man could always interest my heart and communicate
+elasticity to my spirits.  But I am a blasted tree; the bolt has
+entered my soul; and I felt then that I should survive to exhibit what
+I shall soon cease to be--a miserable spectacle of wrecked humanity,
+pitiable to others and intolerable to myself.
+
+We passed a considerable period at Oxford, rambling among its environs
+and endeavouring to identify every spot which might relate to the most
+animating epoch of English history.  Our little voyages of discovery
+were often prolonged by the successive objects that presented
+themselves.  We visited the tomb of the illustrious Hampden and the
+field on which that patriot fell.  For a moment my soul was elevated
+from its debasing and miserable fears to contemplate the divine ideas
+of liberty and self sacrifice of which these sights were the monuments
+and the remembrancers.  For an instant I dared to shake off my chains
+and look around me with a free and lofty spirit, but the iron had eaten
+into my flesh, and I sank again, trembling and hopeless, into my
+miserable self.
+
+We left Oxford with regret and proceeded to Matlock, which was our next
+place of rest.  The country in the neighbourhood of this village
+resembled, to a greater degree, the scenery of Switzerland; but
+everything is on a lower scale, and the green hills want the crown of
+distant white Alps which always attend on the piny mountains of my
+native country.  We visited the wondrous cave and the little cabinets
+of natural history, where the curiosities are disposed in the same
+manner as in the collections at Servox and Chamounix.  The latter name
+made me tremble when pronounced by Henry, and I hastened to quit
+Matlock, with which that terrible scene was thus associated.
+
+From Derby, still journeying northwards, we passed two months in
+Cumberland and Westmorland.  I could now almost fancy myself among the
+Swiss mountains.  The little patches of snow which yet lingered on the
+northern sides of the mountains, the lakes, and the dashing of the
+rocky streams were all familiar and dear sights to me.  Here also we
+made some acquaintances, who almost contrived to cheat me into
+happiness.  The delight of Clerval was proportionably greater than
+mine; his mind expanded in the company of men of talent, and he found
+in his own nature greater capacities and resources than he could have
+imagined himself to have possessed while he associated with his
+inferiors.  "I could pass my life here," said he to me; "and among
+these mountains I should scarcely regret Switzerland and the Rhine."
+
+But he found that a traveller's life is one that includes much pain
+amidst its enjoyments.  His feelings are forever on the stretch; and
+when he begins to sink into repose, he finds himself obliged to quit
+that on which he rests in pleasure for something new, which again
+engages his attention, and which also he forsakes for other novelties.
+
+We had scarcely visited the various lakes of Cumberland and Westmorland
+and conceived an affection for some of the inhabitants when the period
+of our appointment with our Scotch friend approached, and we left them
+to travel on.  For my own part I was not sorry.  I had now neglected my
+promise for some time, and I feared the effects of the daemon's
+disappointment.  He might remain in Switzerland and wreak his vengeance
+on my relatives.  This idea pursued me and tormented me at every moment
+from which I might otherwise have snatched repose and peace.  I waited
+for my letters with feverish impatience; if they were delayed I was
+miserable and overcome by a thousand fears; and when they arrived and I
+saw the superscription of Elizabeth or my father, I hardly dared to
+read and ascertain my fate.  Sometimes I thought that the fiend
+followed me and might expedite my remissness by murdering my companion.
+When these thoughts possessed me, I would not quit Henry for a moment,
+but followed him as his shadow, to protect him from the fancied rage of
+his destroyer.  I felt as if I had committed some great crime, the
+consciousness of which haunted me.  I was guiltless, but I had indeed
+drawn down a horrible curse upon my head, as mortal as that of crime.
+
+I visited Edinburgh with languid eyes and mind; and yet that city might
+have interested the most unfortunate being.  Clerval did not like it so
+well as Oxford, for the antiquity of the latter city was more pleasing
+to him.  But the beauty and regularity of the new town of Edinburgh,
+its romantic castle and its environs, the most delightful in the world,
+Arthur's Seat, St. Bernard's Well, and the Pentland Hills compensated
+him for the change and filled him with cheerfulness and admiration. But
+I was impatient to arrive at the termination of my journey.
+
+We left Edinburgh in a week, passing through Coupar, St. Andrew's, and
+along the banks of the Tay, to Perth, where our friend expected us.
+But I was in no mood to laugh and talk with strangers or enter into
+their feelings or plans with the good humour expected from a guest; and
+accordingly I told Clerval that I wished to make the tour of Scotland
+alone.  "Do you," said I, "enjoy yourself, and let this be our
+rendezvous.  I may be absent a month or two; but do not interfere with
+my motions, I entreat you; leave me to peace and solitude for a short
+time; and when I return, I hope it will be with a lighter heart, more
+congenial to your own temper."
+
+Henry wished to dissuade me, but seeing me bent on this plan, ceased to
+remonstrate.  He entreated me to write often.  "I had rather be with
+you," he said, "in your solitary rambles, than with these Scotch
+people, whom I do not know; hasten, then, my dear  friend, to return,
+that I may again feel myself somewhat at home, which I cannot do in
+your absence."
+
+Having parted from my friend, I determined to visit some remote spot of
+Scotland and finish my work in solitude.  I did not doubt but that the
+monster followed me and would discover himself to me when I should have
+finished, that he might receive his companion.  With this resolution I
+traversed the northern highlands and fixed on one of the remotest of
+the Orkneys as the scene of my labours.  It was a place fitted for such
+a work, being hardly more than a rock whose high sides were continually
+beaten upon by the waves.  The soil was barren, scarcely affording
+pasture for a few miserable cows, and oatmeal for its inhabitants,
+which consisted of five persons, whose gaunt and scraggy limbs gave
+tokens of their miserable fare.  Vegetables and bread, when they
+indulged in such luxuries, and even fresh water, was to be procured
+from the mainland, which was about five miles distant.
+
+On the whole island there were but three miserable huts, and one of
+these was vacant when I arrived.  This I hired.  It contained but two
+rooms, and these exhibited all the squalidness of the most miserable
+penury.  The thatch had fallen in, the walls were unplastered, and the
+door was off its hinges.  I ordered it to be repaired, bought some
+furniture, and took possession, an incident which would doubtless have
+occasioned some surprise had not all the senses of the cottagers been
+benumbed by want and squalid poverty.  As it was, I lived ungazed at
+and unmolested, hardly thanked for the pittance of food and clothes
+which I gave, so much does suffering blunt even the coarsest sensations
+of men.
+
+In this retreat I devoted the morning to labour; but in the evening,
+when the weather permitted, I walked on the stony beach of the sea to
+listen to the waves as they roared and dashed at my feet.  It was a
+monotonous yet ever-changing scene.  I thought of Switzerland; it was
+far different from this desolate and appalling landscape.  Its hills
+are covered with vines, and its cottages are scattered thickly in the
+plains.  Its fair lakes reflect a blue and gentle sky, and when
+troubled by the winds, their tumult is but as the play of a lively
+infant when compared to the roarings of the giant ocean.
+
+In this manner I distributed my occupations when I first arrived, but
+as I proceeded in my labour, it became every day more horrible and
+irksome to me.  Sometimes I could not prevail on myself to enter my
+laboratory for several days, and at other times I toiled day and night
+in order to complete my work.  It was, indeed, a filthy process in
+which I was engaged.  During my first experiment, a kind of
+enthusiastic frenzy had blinded me to the horror of my employment; my
+mind was intently fixed on the consummation of my labour, and my eyes
+were shut to the horror of my proceedings.  But now I went to it in
+cold blood, and my heart often sickened at the work of my hands.
+
+Thus situated, employed in the most detestable occupation, immersed in
+a solitude where nothing could for an instant call my attention from
+the actual scene in which I was engaged, my spirits became unequal; I
+grew restless and nervous.  Every moment I feared to meet my
+persecutor.  Sometimes I sat with my eyes fixed on the ground, fearing
+to raise them lest they should encounter the object which I so much
+dreaded to behold.  I feared to wander from the sight of my fellow
+creatures lest when alone he should come to claim his companion.
+
+In the mean time I worked on, and my labour was already considerably
+advanced.  I looked towards its completion with a tremulous and eager
+hope, which I dared not trust myself to question but which was
+intermixed with obscure forebodings of evil that made my heart sicken
+in my bosom.
+
+
+
+Chapter 20
+
+I sat one evening in my laboratory; the sun had set, and the moon was
+just rising from the sea; I had not sufficient light for my employment,
+and I remained idle, in a pause of consideration of whether I should
+leave my labour for the night or hasten its conclusion by an
+unremitting attention to it.  As I sat, a train of reflection occurred
+to me which led me to consider the effects of what I was now doing.
+Three years before, I was engaged in the same manner and had created a
+fiend whose unparalleled barbarity had desolated my heart and filled it
+forever with the bitterest remorse.  I was now about to form another
+being of whose dispositions I was alike ignorant; she might become ten
+thousand times more malignant than her mate and delight, for its own
+sake, in murder and wretchedness.  He had sworn to quit the
+neighbourhood of man and hide himself in deserts, but she had not; and
+she, who in all probability was to become a thinking and reasoning
+animal, might refuse to comply with a compact made before her creation.
+They might even hate each other; the creature who already lived loathed
+his own deformity, and might he not conceive a greater abhorrence for
+it when it came before his eyes in the female form?  She also might
+turn with disgust from him to the superior beauty of man; she might
+quit him, and he be again alone, exasperated by the fresh provocation
+of being deserted by one of his own species.  Even if they were to
+leave Europe and inhabit the deserts of the new world, yet one of the
+first results of those sympathies for which the daemon thirsted would
+be children, and a race of devils would be propagated upon the earth
+who might make the very existence of the species of man a condition
+precarious and full of terror.  Had I right, for my own benefit, to
+inflict this curse upon everlasting generations?  I had before been
+moved by the sophisms of the being I had created; I had been struck
+senseless by his fiendish threats; but now, for the first time, the
+wickedness of my promise burst upon me; I shuddered to think that
+future ages might curse me as their pest, whose selfishness had not
+hesitated to buy its own peace at the price, perhaps, of the existence
+of the whole human race.
+
+I trembled and my heart failed within me, when, on looking up, I saw by
+the light of the moon the daemon at the casement.  A ghastly grin
+wrinkled his lips as he gazed on me, where I sat fulfilling the task
+which he had allotted to me.  Yes, he had followed me in my travels; he
+had loitered in forests, hid himself in caves, or taken refuge in wide
+and desert heaths; and he now came to mark my progress and claim the
+fulfilment of my promise.
+
+As I looked on him, his countenance expressed the utmost extent of
+malice and treachery.  I thought with a sensation of madness on my
+promise of creating another like to him, and trembling with passion,
+tore to pieces the thing on which I was engaged.  The wretch saw me
+destroy the creature on whose future existence he depended for
+happiness, and with a howl of devilish despair and revenge, withdrew.
+
+I left the room, and locking the door, made a solemn vow in my own
+heart never to resume my labours; and then, with trembling steps, I
+sought my own apartment. I was alone; none were near me to dissipate
+the gloom and relieve me from the sickening oppression of the most
+terrible reveries.
+
+Several hours passed, and I remained near my window gazing on the sea;
+it was almost motionless, for the winds were hushed, and all nature
+reposed under the eye of the quiet moon.  A few fishing vessels alone
+specked the water, and now and then the gentle breeze wafted the sound
+of voices as the fishermen called to one another.  I felt the silence,
+although I was hardly conscious of its extreme profundity, until my ear
+was suddenly arrested by the paddling of oars near the shore, and a
+person landed close to my house.
+
+In a few minutes after, I heard the creaking of my door, as if some one
+endeavoured to open it softly.  I trembled from head to foot; I felt a
+presentiment of who it was and wished to rouse one of the peasants who
+dwelt in a cottage not far from mine; but I was overcome by the
+sensation of helplessness, so often felt in frightful dreams, when you
+in vain endeavour to fly from an impending danger, and was rooted to
+the spot. Presently I heard the sound of footsteps along the passage;
+the door opened, and the wretch whom I dreaded appeared.
+
+Shutting the door, he approached me and said in a smothered voice, "You
+have destroyed the work which you began; what is it that you intend?
+Do you dare to break your promise?  I have endured toil and misery; I
+left Switzerland with you; I crept along the shores of the Rhine, among
+its willow islands and over the summits of its hills.  I have dwelt
+many months in the heaths of England and among the deserts of Scotland.
+I have endured incalculable fatigue, and cold, and hunger; do you dare
+destroy my hopes?"
+
+"Begone!  I do break my promise; never will I create another like
+yourself, equal in deformity and wickedness."
+
+"Slave, I before reasoned with you, but you have proved yourself
+unworthy of my condescension.  Remember that I have power; you believe
+yourself miserable, but I can make you so wretched that the light of
+day will be hateful to you.  You are my creator, but I am your master;
+obey!"
+
+"The hour of my irresolution is past, and the period of your power is
+arrived.  Your threats cannot move me to do an act of wickedness; but
+they confirm me in a determination of not creating you a companion in
+vice.  Shall I, in cool blood, set loose upon the earth a daemon whose
+delight is in death and wretchedness?  Begone!  I am firm, and your
+words will only exasperate my rage."
+
+The monster saw my determination in my face and gnashed his teeth in
+the impotence of anger.  "Shall each man," cried he, "find a wife for
+his bosom, and each beast have his mate, and I be alone?  I had
+feelings of affection, and they were requited by detestation and scorn.
+Man!  You may hate, but beware!  Your hours will pass in dread and
+misery, and soon the bolt  will fall which must ravish from you your
+happiness forever.  Are you to be happy while I grovel in the intensity
+of my wretchedness?  You can blast my other passions, but revenge
+remains--revenge, henceforth dearer than light or food!  I may die, but
+first you, my tyrant and tormentor, shall curse the sun that gazes on
+your misery.  Beware, for I am fearless and therefore powerful.  I will
+watch with the wiliness of a snake, that I may sting with its venom.
+Man, you shall repent of the injuries you inflict."
+
+"Devil, cease; and do not poison the air with these sounds of malice.
+I have declared my resolution to you, and I am no coward to bend
+beneath words.  Leave me; I am inexorable."
+
+"It is well.  I go; but remember, I shall be with you on your
+wedding-night."
+
+I started forward and exclaimed, "Villain!  Before you sign my
+death-warrant, be sure that you are yourself safe."
+
+I would have seized him, but he eluded me and quitted the house with
+precipitation.  In a few moments I saw him in his boat, which shot
+across the waters with an arrowy swiftness and was soon lost amidst the
+waves.
+
+All was again silent, but his words rang in my ears.  I burned with
+rage to pursue the murderer of my peace and precipitate him into the
+ocean.  I walked up and down my room hastily and perturbed, while my
+imagination conjured up a thousand images to torment and sting me.  Why
+had I not followed him and closed with him in mortal strife?  But I had
+suffered him to depart, and he had directed his course towards the
+mainland.  I shuddered to think who might be the next victim sacrificed
+to his insatiate revenge.  And then I thought again of his words--"I
+WILL BE WITH YOU ON YOUR WEDDING-NIGHT."  That, then, was the period
+fixed for the fulfilment of my destiny.  In that hour I should die and
+at once satisfy and extinguish his malice.  The prospect did not move
+me to fear; yet when I thought of my beloved Elizabeth, of her tears
+and endless sorrow, when she should find her lover so barbarously
+snatched from her, tears, the first I had shed for many months,
+streamed from my eyes, and I resolved not to fall before my enemy
+without a bitter struggle.
+
+The night passed away, and the sun rose from the ocean; my feelings
+became calmer, if it may be called calmness when the violence of rage
+sinks into the depths of despair.  I left the house, the horrid scene
+of the last night's contention, and walked on the beach of the sea,
+which I almost regarded as an insuperable barrier between me and my
+fellow creatures; nay, a wish that such should prove the fact stole
+across me.
+
+I desired that I might pass my life on that barren rock, wearily, it is
+true, but uninterrupted by any sudden shock of misery.  If I returned,
+it was to be sacrificed or to see those whom I most loved die under the
+grasp of a daemon whom I had myself created.
+
+I walked about the isle like a restless spectre, separated from all it
+loved and miserable in the separation.  When it became noon, and the
+sun rose higher, I lay down on the grass and was overpowered by a deep
+sleep.  I had been awake the whole of the preceding night, my nerves
+were agitated, and my eyes inflamed by watching and misery.  The sleep
+into which I now sank refreshed me; and when I awoke, I again felt as
+if I belonged to a race of human beings like myself, and I began to
+reflect upon what had passed with greater composure; yet still the
+words of the fiend rang in my ears like a death-knell; they appeared
+like a dream, yet distinct and oppressive as a reality.
+
+The sun had far descended, and I still sat on the shore, satisfying my
+appetite, which had become ravenous, with an oaten cake, when I saw a
+fishing-boat land close to me, and one of the men brought me a packet;
+it contained letters from Geneva, and one from Clerval entreating me to
+join him.  He said that he was wearing away his time fruitlessly where
+he was, that letters from the friends he had formed in London desired
+his return to complete the negotiation they had entered into for his
+Indian enterprise.  He could not any longer delay his departure; but as
+his journey to London might be followed, even sooner than he now
+conjectured, by his longer voyage, he entreated me to bestow as much of
+my society on him as I could spare.  He besought me, therefore, to
+leave my solitary isle and to meet him at Perth, that we might proceed
+southwards together.  This letter in a degree recalled me to life, and
+I determined to quit my island at the expiration of two days.  Yet,
+before I departed, there was a task to perform, on which I shuddered to
+reflect; I must pack up my chemical instruments, and for that purpose I
+must enter the room which had been the scene of my odious work, and I
+must handle those utensils the sight of which was sickening to me. The
+next morning, at daybreak, I summoned sufficient courage and unlocked
+the door of my laboratory.  The remains of the half-finished creature,
+whom I had destroyed, lay scattered on the floor, and I almost felt as
+if I had mangled the living flesh of a human being.  I paused to
+collect myself and then entered the chamber.  With trembling hand I
+conveyed the instruments out of the room, but I reflected that I ought
+not to leave the relics of my work to excite the horror and suspicion
+of the peasants; and I accordingly put them into a basket, with a great
+quantity of stones, and laying them up, determined to throw them into
+the sea that very night; and in the meantime I sat upon the beach,
+employed in cleaning and arranging my chemical apparatus.
+
+Nothing could be more complete than the alteration that had taken place
+in my feelings since the night of the appearance of the daemon.  I had
+before regarded my promise with a gloomy despair as a thing that, with
+whatever consequences, must be fulfilled; but I now felt as if a film
+had been taken from before my eyes and that I for the first time saw
+clearly.  The idea of renewing my labours did not for one instant occur
+to me; the threat I had heard weighed on my thoughts, but I did not
+reflect that a voluntary act of mine could avert it.  I had resolved in
+my own mind that to create another like the fiend I had first made
+would be an act of the basest and most atrocious selfishness, and I
+banished from my mind every thought that could lead to a different
+conclusion.
+
+Between two and three in the morning the moon rose; and I then, putting
+my basket aboard a little skiff, sailed out about four miles from the
+shore.  The scene was perfectly solitary; a few boats were returning
+towards land, but I sailed away from them.  I felt as if I was about
+the commission of a dreadful crime and avoided with shuddering anxiety
+any encounter with my fellow creatures.  At one time the moon, which
+had before been clear, was suddenly overspread by a thick cloud, and I
+took advantage of the moment of darkness and cast my basket into the
+sea; I listened to the gurgling sound as it sank and then sailed away
+from the spot.  The sky became clouded, but the air was pure, although
+chilled by the northeast breeze that was then rising.  But it refreshed
+me and filled me with such agreeable sensations that I resolved to
+prolong my stay on the water, and fixing the rudder in a direct
+position, stretched myself at the bottom of the boat.  Clouds hid the
+moon, everything was obscure, and I heard only the sound of the boat as
+its keel cut through the waves; the murmur lulled me, and in a short
+time I slept soundly. I do not know how long I remained in this
+situation, but when I awoke I found that the sun had already mounted
+considerably.  The wind was high, and the waves continually threatened
+the safety of my little skiff.  I found that the wind was northeast and
+must have driven me far from the coast from which I had embarked.  I
+endeavoured to change my course but quickly found that if I again made
+the attempt the boat would be instantly filled with water.  Thus
+situated, my only resource was to drive before the wind.  I confess
+that I felt a few sensations of terror.  I had no compass with me and
+was so slenderly acquainted with the geography of this part of the
+world that the sun was of little benefit to me.  I might be driven into
+the wide Atlantic and feel all the tortures of starvation or be
+swallowed up in the immeasurable waters that roared and buffeted around
+me.  I had already been out many hours and felt the torment of a
+burning thirst, a prelude to my other sufferings.  I looked on the
+heavens, which were covered by clouds that flew before the wind, only
+to be replaced by others; I looked upon the sea; it was to be my grave.
+"Fiend," I exclaimed, "your task is already fulfilled!"  I thought of
+Elizabeth, of my father, and of Clerval--all left behind, on whom the
+monster might satisfy his sanguinary and merciless passions.  This idea
+plunged me into a reverie so despairing and frightful that even now,
+when the scene is on the point of closing before me forever, I shudder
+to reflect on it.
+
+Some hours passed thus; but by degrees, as the sun declined towards the
+horizon, the wind died away into a gentle breeze and the sea became
+free from breakers.  But these gave place to a heavy swell; I felt sick
+and hardly able to hold the rudder, when suddenly I saw a line of high
+land towards the south.
+
+Almost spent, as I was, by fatigue and the dreadful suspense I endured
+for several hours, this sudden certainty of life rushed like a flood of
+warm joy to my heart, and tears gushed from my eyes.
+
+How mutable are our feelings, and how strange is that clinging love we
+have of life even in the excess of misery!  I constructed another sail
+with a part of my dress and eagerly steered my course towards the land.
+It had a wild and rocky appearance, but as I approached nearer I easily
+perceived the traces of cultivation.  I saw vessels near the shore and
+found myself suddenly transported back to the neighbourhood of
+civilized man.  I carefully traced the windings of the land and hailed
+a steeple which I at length saw issuing from behind a small promontory.
+As I was in a state of extreme debility, I resolved to sail directly
+towards the town, as a place where I could most easily procure
+nourishment.  Fortunately I had money with me.
+
+As I turned the promontory I perceived a small neat town and a good
+harbour, which I entered, my heart bounding with joy at my unexpected
+escape.
+
+As I was occupied in fixing the boat and arranging the sails, several
+people crowded towards the spot.  They seemed much surprised at my
+appearance, but instead of offering me any assistance, whispered
+together with gestures that at any other time might have produced in me
+a slight sensation of alarm. As it was, I merely remarked that they
+spoke English, and I therefore addressed them in that language.  "My
+good friends," said I, "will you be so kind as to tell me the name of
+this town and inform me where I am?"
+
+"You will know that soon enough," replied a man with a hoarse voice.
+"Maybe you are come to a place that will not prove much to your taste,
+but you will not be consulted as to your quarters, I promise you."
+
+I was exceedingly surprised on receiving so rude an answer from a
+stranger, and I was also disconcerted on perceiving the frowning and
+angry countenances of his companions.  "Why do you answer me so
+roughly?"  I replied.  "Surely it is not the custom of Englishmen to
+receive strangers so inhospitably."
+
+"I do not know," said the man, "what the custom of the English may be,
+but it is the custom of the Irish to hate villains." While this strange
+dialogue continued, I perceived the crowd rapidly increase.  Their
+faces expressed a mixture of curiosity and anger, which annoyed  and in
+some degree alarmed me.
+
+I inquired the way to the inn, but no one replied.  I then moved
+forward, and a murmuring sound arose from the crowd as they followed
+and surrounded me, when an ill-looking man approaching tapped me on the
+shoulder and said, "Come, sir, you must follow me to Mr. Kirwin's to
+give an account of yourself."
+
+"Who is Mr. Kirwin?  Why am I to give an account of myself?  Is not
+this a free country?"
+
+"Ay, sir, free enough for honest folks.  Mr. Kirwin is a magistrate,
+and you are to give an account of the death of a gentleman who was
+found murdered here last night."
+
+This answer startled me, but I presently recovered myself.  I was
+innocent; that could easily be proved; accordingly I followed my
+conductor in silence and was led to one of the best houses in the town.
+I was ready to sink from fatigue and hunger, but being surrounded by a
+crowd, I thought it politic to rouse all my strength, that no physical
+debility might be construed into apprehension or conscious guilt.
+Little did I then expect the calamity that was in a few moments to
+overwhelm me and extinguish in horror and despair all fear of ignominy
+or death. I must pause here, for it requires all my fortitude to recall
+the memory of the frightful events which I am about to relate, in
+proper detail, to my recollection.
+
+
+
+Chapter 21
+
+I was soon introduced into the presence of the magistrate, an old
+benevolent man with calm and mild manners.  He looked upon me, however,
+with some degree of severity, and then, turning towards my conductors,
+he asked who appeared as witnesses on this occasion.
+
+About half a dozen men came forward; and, one being selected by the
+magistrate, he deposed that he had been out fishing the night before
+with his son and brother-in-law, Daniel Nugent, when, about ten
+o'clock, they observed a strong northerly blast rising, and they
+accordingly put in for port.  It was a very dark night, as the moon had
+not yet risen; they did not land at the harbour, but, as they had been
+accustomed, at a creek about two miles below.  He walked on first,
+carrying a part of the fishing tackle, and his companions followed him
+at some distance.
+
+As he was proceeding along the sands, he struck his foot against
+something and fell at his length on the ground. His companions came up
+to assist him, and by the light of their lantern they found that he had
+fallen on the body of a man, who was to all appearance dead.  Their
+first supposition was that it was the corpse of some person who had
+been drowned and was thrown on shore by the waves, but on examination
+they found that the clothes were not wet and even that the body was not
+then cold.  They instantly carried it to the cottage of an old woman
+near the spot and endeavoured, but in vain, to restore it to life.  It
+appeared to be a handsome young man, about five and twenty years of
+age.  He had apparently been strangled, for there was no sign of any
+violence except the black mark of fingers on his neck.
+
+The first part of this deposition did not in the least interest me, but
+when the mark of the fingers was mentioned I remembered the murder of
+my brother and felt myself extremely agitated; my limbs trembled, and a
+mist came over my eyes, which obliged me to lean on a chair for
+support.  The magistrate observed me with a keen eye and of course drew
+an unfavourable augury from my manner.
+
+The son confirmed his father's account, but when Daniel Nugent was
+called he swore positively that just before the fall of his companion,
+he saw a boat, with a single man in it, at a short distance from the
+shore; and as far as he could judge by the light of a few stars, it was
+the same boat in which I had just landed.  A woman deposed that she
+lived near the beach and was standing at the door of her cottage,
+waiting for the return of the fishermen, about an hour before she heard
+of the discovery of the body, when she saw a boat with only one man in
+it push off from that part of the shore where the corpse was afterwards
+found.
+
+Another woman confirmed the account of the fishermen having brought the
+body into her house; it was not cold.  They put it into a bed and
+rubbed it, and Daniel went to the town for an apothecary, but life was
+quite gone.
+
+Several other men were examined concerning my landing, and they agreed
+that, with the strong north wind that had arisen during the night, it
+was very probable that I had beaten about for many hours and had been
+obliged to return nearly to the same spot from which I had departed.
+Besides, they observed that it appeared that I had brought the body
+from another place, and it was likely that as I did not appear to know
+the shore, I might have put into the harbour ignorant of the distance
+of the town of ---- from the place where I had deposited the corpse.
+
+Mr. Kirwin, on hearing this evidence, desired that I should be taken
+into the room where the body lay for interment, that it might be
+observed what effect the sight of it would produce upon me.  This idea
+was probably suggested by the extreme agitation I had exhibited when
+the mode of the murder had been described.  I was accordingly
+conducted, by the magistrate and several other persons, to the inn.  I
+could not help being struck by the strange coincidences that had taken
+place during this eventful night; but, knowing that I had been
+conversing with several persons in the island I had inhabited about the
+time that the body had been found, I was perfectly tranquil as to the
+consequences of the affair.  I entered the room where the corpse lay
+and was led up to the coffin.  How can I describe my sensations on
+beholding it?  I feel yet parched with horror, nor can I reflect on
+that terrible moment without shuddering and agony.  The examination,
+the presence of the magistrate and witnesses, passed like a dream from
+my memory when I saw the lifeless form of Henry Clerval stretched
+before me.  I gasped for breath, and throwing myself on the body, I
+exclaimed, "Have my murderous machinations deprived you also, my
+dearest Henry, of life?  Two I have already destroyed; other victims
+await their destiny; but you, Clerval, my friend, my benefactor--"
+
+The human frame could no longer support the agonies that I endured, and
+I was carried out of the room in strong convulsions.  A fever succeeded
+to this.  I lay for two months on the point of death; my ravings, as I
+afterwards heard, were frightful; I called myself the murderer of
+William, of Justine, and of Clerval.  Sometimes I entreated my
+attendants to assist me in the destruction of the fiend by whom I was
+tormented; and at others I felt the fingers of the monster already
+grasping my neck, and screamed aloud with agony and terror.
+Fortunately, as I spoke my native language, Mr. Kirwin alone understood
+me; but my gestures and bitter cries were sufficient to affright the
+other witnesses.  Why did I not die?  More miserable than man ever was
+before, why did I not sink into forgetfulness and rest?  Death snatches
+away many blooming children, the only hopes of their doting parents;
+how many brides and youthful lovers have been one day in the bloom of
+health and hope, and the next a prey for worms and the decay of the
+tomb!  Of what materials was I made that I could thus resist so many
+shocks, which, like the turning of the wheel, continually renewed the
+torture?
+
+But I was doomed to live and in two months found myself as awaking from
+a dream, in a prison, stretched on a wretched bed, surrounded by
+jailers, turnkeys, bolts, and all the miserable apparatus of a dungeon.
+It was morning, I remember, when I thus awoke to understanding; I had
+forgotten the particulars of what had happened and only felt as if some
+great misfortune had suddenly overwhelmed me; but when I looked around
+and saw the barred windows and the squalidness of the room in which I
+was, all flashed across my memory and I groaned bitterly.
+
+This sound disturbed an old woman who was sleeping in a chair beside
+me.  She was a hired nurse, the wife of one of the turnkeys, and her
+countenance expressed all those bad qualities which often characterize
+that class.  The lines of her face were hard and rude, like that of
+persons accustomed to see without sympathizing in sights of misery. Her
+tone expressed her entire indifference; she addressed me in English,
+and the voice struck me as one that I had heard during my sufferings.
+"Are you better now, sir?" said she.
+
+I replied in the same language, with a feeble voice, "I believe I am;
+but if it be all true, if indeed I did not dream, I am sorry that I am
+still alive to feel this misery and horror."
+
+"For that matter," replied the old woman, "if you mean about the
+gentleman you murdered, I believe that it were better for you if you
+were dead, for I fancy it will go hard with you!  However, that's none
+of my business; I am sent to nurse you and get you well; I do my duty
+with a safe conscience; it were well if everybody did the same."
+
+I turned with loathing from the woman who could utter so unfeeling a
+speech to a person just saved, on the very edge of death; but I felt
+languid and unable to reflect on all that had passed.  The whole series
+of my life appeared to me as a dream; I sometimes doubted if indeed it
+were all true, for it never presented itself to my mind with the force
+of reality.
+
+As the images that floated before me became more distinct, I grew
+feverish; a darkness pressed around me; no one was near me who soothed
+me with the gentle voice of love; no dear hand supported me.  The
+physician came and prescribed medicines, and the old woman prepared
+them for me; but utter carelessness was visible in the first, and the
+expression of brutality was strongly marked in the visage of the
+second.  Who could be interested in the fate of a murderer but the
+hangman who would gain his fee?
+
+These were my first reflections, but I soon learned that Mr. Kirwin had
+shown me extreme kindness.  He had caused the best room in the prison
+to be prepared for me (wretched indeed was the best); and it was he who
+had provided a physician and a nurse.  It is true, he seldom came to
+see me, for although he ardently desired to relieve the sufferings of
+every human creature, he did not wish to be present at the agonies and
+miserable ravings of a murderer.  He came, therefore, sometimes to see
+that I was not neglected, but his visits were short and with long
+intervals.  One day, while I was gradually recovering, I was seated in
+a chair, my eyes half open and my cheeks livid like those in death.  I
+was overcome by gloom and misery and often reflected I had better seek
+death than desire to remain in a world which to me was replete with
+wretchedness.  At one time I considered whether I should not declare
+myself guilty and suffer the penalty of the law, less innocent than
+poor Justine had been.  Such were my thoughts when the door of my
+apartment was opened and Mr. Kirwin entered.  His countenance expressed
+sympathy and compassion; he drew a chair close to mine and addressed me
+in French, "I fear that this place is very shocking to you; can I do
+anything to make you more comfortable?"
+
+"I thank you, but all that you mention is nothing to me; on the whole
+earth there is no comfort which I am capable of receiving."
+
+"I know that the sympathy of a stranger can be but of little relief to
+one borne down as you are by so strange a misfortune.  But you will, I
+hope, soon quit this melancholy abode, for doubtless evidence can
+easily be brought to free you from the criminal charge."
+
+"That is my least concern; I am, by a course of strange events, become
+the most miserable of mortals.  Persecuted and tortured as I am and
+have been, can death be any evil to me?"
+
+"Nothing indeed could be more unfortunate and agonizing than the
+strange chances that have lately occurred.  You were thrown, by some
+surprising accident, on this shore, renowned for its hospitality,
+seized immediately, and charged with murder.  The first sight that was
+presented to your eyes was the body of your friend, murdered in so
+unaccountable a manner and placed, as it were, by some fiend across
+your path."
+
+As Mr. Kirwin said this, notwithstanding the agitation I endured on
+this retrospect of my sufferings, I also felt considerable surprise at
+the knowledge he seemed to possess concerning me.  I suppose some
+astonishment was exhibited in my countenance, for Mr. Kirwin hastened
+to say, "Immediately upon your being taken ill, all the papers that
+were on your person were brought me, and I examined them that I might
+discover some trace by which I could send to your relations an account
+of your misfortune and illness. I found several letters, and, among
+others, one which I discovered from its commencement to be from your
+father.  I instantly wrote to Geneva; nearly two months have elapsed
+since the departure of my letter.  But you are ill; even now you
+tremble; you are unfit for agitation of any kind."
+
+"This suspense is a thousand times worse than the most horrible event;
+tell me what new scene of death has been acted, and whose murder I am
+now to lament?"
+
+"Your family is perfectly well," said Mr. Kirwin with gentleness; "and
+someone, a friend, is come to visit you."
+
+I know not by what chain of thought the idea presented itself, but it
+instantly darted into my mind that the murderer had come to mock at my
+misery and taunt me with the death of Clerval, as a new incitement for
+me to comply with his hellish desires.  I put my hand before my eyes,
+and cried out in agony, "Oh! Take him away!  I cannot see him; for
+God's sake, do not let him enter!"
+
+Mr. Kirwin regarded me with a troubled countenance.  He could not help
+regarding my exclamation as a presumption of my guilt and said in
+rather a severe tone, "I should have thought, young man, that the
+presence of your father would have been welcome instead of inspiring
+such violent repugnance."
+
+"My father!" cried I, while every feature and every muscle was relaxed
+from anguish to pleasure.  "Is my father indeed come?  How kind, how
+very kind!  But where is he, why does he not hasten to me?"
+
+My change of manner surprised and pleased the magistrate; perhaps he
+thought that my former exclamation was a momentary return of delirium,
+and now he instantly resumed his former benevolence.  He rose and
+quitted the room with my nurse, and in a moment my father entered it.
+
+Nothing, at this moment, could have given me greater pleasure than the
+arrival of my father.  I stretched out my hand to him and cried, "Are
+you, then, safe--and Elizabeth--and Ernest?" My father calmed me with
+assurances of their welfare and endeavoured, by dwelling on these
+subjects so interesting to my heart, to raise my desponding spirits;
+but he soon felt that a prison cannot be the abode of cheerfulness.
+
+"What a place is this that you inhabit, my son!" said he, looking
+mournfully at the barred windows and wretched appearance of the room.
+"You travelled to seek happiness, but a fatality seems to pursue you.
+And poor Clerval--"
+
+The name of my unfortunate and murdered friend was an agitation too
+great to be endured in my weak state; I shed tears.  "Alas!  Yes, my
+father," replied I; "some destiny of the most horrible kind hangs over
+me, and I must live to fulfil it, or surely I should have died on the
+coffin of Henry."
+
+We were not allowed to converse for any length of time, for the
+precarious state of my health rendered every precaution necessary that
+could ensure tranquillity.  Mr. Kirwin came in and insisted that my
+strength should not be exhausted by too much exertion.  But the
+appearance of my father was to me like that of my good angel, and I
+gradually recovered my health.
+
+As my sickness quitted me, I was absorbed by a gloomy and black
+melancholy that nothing could dissipate.  The image of Clerval was
+forever before me, ghastly and murdered.  More than once the agitation
+into which these reflections threw me made my friends dread a dangerous
+relapse.  Alas!  Why did they preserve so miserable and detested a
+life?  It was surely that I might fulfil my destiny, which is now
+drawing to a close.  Soon, oh, very soon, will death extinguish these
+throbbings and relieve me from the mighty weight of anguish that bears
+me to the dust; and, in executing the award of justice, I shall also
+sink to rest.  Then the appearance of death was distant, although the
+wish was ever present to my thoughts; and I often sat for hours
+motionless and speechless, wishing for some mighty revolution that
+might bury me and my destroyer in its ruins.
+
+The season of the assizes approached.  I had already been three months
+in prison, and although I was still weak and in continual danger of a
+relapse, I was obliged to travel nearly a hundred miles to the country
+town where the court was held.  Mr. Kirwin charged himself with every
+care of collecting witnesses and arranging my defence.  I was spared
+the disgrace of appearing publicly as a criminal, as the case was not
+brought before the court that decides on life and death.  The grand
+jury rejected the bill, on its being proved that I was on the Orkney
+Islands at the hour the body of my friend was found; and a fortnight
+after my removal I was liberated from prison.
+
+My father was enraptured on finding me freed from the vexations of a
+criminal charge, that I was again allowed to breathe the fresh
+atmosphere and permitted to return to my native country.  I did not
+participate in these feelings, for to me the walls of a dungeon or a
+palace were alike hateful.  The cup of life was poisoned forever, and
+although the sun shone upon me, as upon the happy and gay of heart, I
+saw around me nothing but a dense and frightful darkness, penetrated by
+no light but the glimmer of two eyes that glared upon me.  Sometimes
+they were the expressive eyes of Henry, languishing in death, the dark
+orbs nearly covered by the lids and the long black lashes that fringed
+them; sometimes it was the watery, clouded eyes of the monster, as I
+first saw them in my chamber at Ingolstadt.
+
+My father tried to awaken in me the feelings of affection.  He talked
+of Geneva, which I should soon visit, of Elizabeth and Ernest; but
+these words only drew deep groans from me.  Sometimes, indeed, I felt a
+wish for happiness and thought with melancholy delight of my beloved
+cousin or longed, with a devouring maladie du pays, to see once more
+the blue lake and rapid Rhone, that had been so dear to me in early
+childhood; but my general state of feeling was a torpor in which a
+prison was as welcome a residence as the divinest scene in nature; and
+these fits were seldom interrupted but by paroxysms of anguish and
+despair.  At these moments I often endeavoured to put an end to the
+existence I loathed, and it required unceasing attendance and vigilance
+to restrain me from committing some dreadful act of violence.
+
+Yet one duty remained to me, the recollection of which finally
+triumphed over my selfish despair.  It was necessary that I should
+return without delay to Geneva, there to watch over the lives of those
+I so fondly loved and to lie in wait for the murderer, that if any
+chance led me to the place of his concealment, or if he dared again to
+blast me by his presence, I might, with unfailing aim, put an end to
+the existence of the monstrous image which  I had endued with the
+mockery of a soul still more monstrous.  My father still desired to
+delay our departure, fearful that I could not sustain the fatigues of a
+journey, for I was a shattered wreck--the shadow of a human being.  My
+strength was gone.  I was a mere skeleton, and fever night and day
+preyed upon my wasted frame.  Still, as I urged our leaving Ireland
+with such inquietude and impatience, my father thought it best to
+yield.  We took our passage on board a vessel bound for Havre-de-Grace
+and sailed with a fair wind from the Irish shores.  It was midnight.  I
+lay on the deck looking at the stars and listening to the dashing of
+the waves.  I hailed the darkness that shut Ireland from my sight, and
+my pulse beat with a feverish joy when I reflected that I should soon
+see Geneva.  The past appeared to me in the light of a frightful dream;
+yet the vessel in which I was, the wind that blew me from the detested
+shore of Ireland, and the sea which surrounded me told me too forcibly
+that I was deceived by no vision and that Clerval, my friend and
+dearest companion, had fallen a victim to me and the monster of my
+creation.  I repassed, in my memory, my whole life--my quiet happiness
+while residing with my family in Geneva, the death of my mother, and my
+departure for Ingolstadt.  I remembered, shuddering, the mad enthusiasm
+that hurried me on to the creation of my hideous enemy, and I called to
+mind the night in which he first lived.  I was unable to pursue the
+train of thought; a thousand feelings pressed upon me, and I wept
+bitterly.  Ever since my recovery from the fever I had been in the
+custom of taking every night a small quantity of laudanum, for it was
+by means of this drug only that I was enabled to gain the rest
+necessary for the preservation of life.  Oppressed by the recollection
+of my various misfortunes, I now swallowed double my usual quantity and
+soon slept profoundly.  But sleep did not afford me respite from
+thought and misery; my dreams presented a thousand objects that scared
+me.  Towards morning I was possessed by a kind of nightmare; I felt the
+fiend's grasp in my neck and could not free myself from it; groans and
+cries rang in my ears.  My father, who was watching over me, perceiving
+my restlessness, awoke me; the dashing waves were around, the cloudy
+sky above, the fiend was not here: a sense of security, a feeling that
+a truce was established between the present hour and the irresistible,
+disastrous future imparted to me a kind of calm forgetfulness, of which
+the human mind is by its structure peculiarly susceptible.
+
+
+
+Chapter 22
+
+The voyage came to an end.  We landed, and proceeded to Paris.  I soon
+found that I had overtaxed my strength and that I must repose before I
+could continue my journey.  My father's care and attentions were
+indefatigable, but he did not know the origin of my sufferings and
+sought erroneous methods to remedy the incurable ill.  He wished me to
+seek amusement in society.  I abhorred the face of man.  Oh, not
+abhorred!  They were my brethren, my fellow beings, and I felt
+attracted even to the most repulsive among them, as to creatures of an
+angelic nature and celestial mechanism.  But I felt that I had no right
+to share their intercourse.  I had unchained an enemy among them whose
+joy it was to shed their blood and to revel in their groans.  How they
+would, each and all, abhor me and hunt me from the world did they know
+my unhallowed acts and the crimes which had their source in me!
+
+My father yielded at length to my desire to avoid society and strove by
+various arguments to banish my despair.  Sometimes he thought that I
+felt deeply the degradation of being obliged to answer a charge of
+murder, and he endeavoured to prove to me the futility of pride.
+
+"Alas!  My father," said I, "how little do you know me.  Human beings,
+their feelings and passions, would indeed be degraded if such a wretch
+as I felt pride.  Justine, poor unhappy Justine, was as innocent as I,
+and she suffered the same charge; she died for it; and I am the cause
+of this--I murdered her.  William, Justine, and Henry--they all died by
+my hands."
+
+My father had often, during my imprisonment, heard me make the same
+assertion; when I thus accused myself, he sometimes seemed to desire an
+explanation, and at others he appeared to consider it as the offspring
+of delirium, and that, during my illness, some idea of this kind had
+presented itself to my imagination, the remembrance of which I
+preserved in my convalescence.
+
+I avoided explanation and maintained a continual silence concerning the
+wretch I had created.  I had a persuasion that I should be supposed
+mad, and this in itself would forever have chained my tongue.  But,
+besides, I could not bring myself to disclose a secret which would fill
+my hearer with consternation and make fear and unnatural horror the
+inmates of his breast.  I checked, therefore, my impatient thirst for
+sympathy and was silent when I would have given the world to have
+confided the fatal secret.  Yet, still, words like those I have
+recorded would burst uncontrollably from me.  I could offer no
+explanation of them, but their truth in part relieved the burden of my
+mysterious woe.  Upon this occasion my father said, with an expression
+of unbounded wonder, "My dearest Victor, what infatuation is this?  My
+dear son, I entreat you never to make such an assertion again."
+
+"I am not mad," I cried energetically; "the sun and the heavens, who
+have viewed my operations, can bear witness of my truth.  I am the
+assassin of those most innocent victims; they died by my machinations.
+A thousand times would I have shed my own blood, drop by drop, to have
+saved their lives; but I could not, my father, indeed I could not
+sacrifice the whole human race."
+
+The conclusion of this speech convinced my father that my ideas were
+deranged, and he instantly changed the subject of our conversation and
+endeavoured to alter the course of my thoughts.  He wished as much as
+possible to obliterate the memory of the scenes that had taken place in
+Ireland and never alluded to them or suffered me to speak of my
+misfortunes.
+
+As time passed away I became more calm; misery had her dwelling in my
+heart, but I no longer talked in the same incoherent manner of my own
+crimes; sufficient for me was the consciousness of them.  By the utmost
+self-violence I curbed the imperious voice of wretchedness, which
+sometimes desired to declare itself to the whole world, and my manners
+were calmer and more composed than they had ever been since my journey
+to the sea of ice.  A few days before we left Paris on our way to
+Switzerland, I received the following letter from Elizabeth:
+
+
+"My dear Friend,
+
+"It gave me the greatest pleasure to receive a letter from my uncle
+dated at Paris; you are no longer at a formidable distance, and I may
+hope to see you in less than a fortnight.  My poor cousin, how much you
+must have suffered!  I expect to see you looking even more ill than
+when you quitted Geneva.  This winter has been passed most miserably,
+tortured as I have been by anxious suspense; yet I hope to see peace in
+your countenance and to find that your heart is not totally void of
+comfort and tranquillity.
+
+"Yet I fear that the same feelings now exist that made you so miserable
+a year ago, even perhaps augmented by time.  I would not disturb you at
+this period, when so many misfortunes weigh upon you, but a
+conversation that I had with my uncle previous to his departure renders
+some explanation necessary before we meet.   Explanation!  You may
+possibly say, What can Elizabeth have to explain?  If you really say
+this, my questions are answered and all my doubts satisfied.  But you
+are distant from me, and it is possible that you may dread and yet be
+pleased with this explanation; and in a probability of this being the
+case, I dare not any longer postpone writing what, during your absence,
+I have often wished to express to you but have never had the courage to
+begin.
+
+"You well know, Victor, that our union had been the favourite plan of
+your parents ever since our infancy.  We were told this when young, and
+taught to look forward to it as an event that would certainly take
+place.  We were affectionate playfellows during childhood, and, I
+believe, dear and valued friends to one another as we grew older. But
+as brother and sister often entertain a lively affection towards each
+other without desiring a more intimate union, may not such also be our
+case?  Tell me, dearest Victor.  Answer me, I conjure you by our mutual
+happiness, with simple truth--Do you not love another?
+
+"You have travelled; you have spent several years of your life at
+Ingolstadt; and I confess to you, my friend, that when I saw you last
+autumn so unhappy, flying to solitude from the society of every
+creature, I could not help supposing that you might regret our
+connection and believe yourself bound in honour to fulfil the wishes of
+your parents, although they opposed themselves to your inclinations.
+But this is false reasoning.  I confess to you, my friend, that I love
+you and that in my airy dreams of futurity you have been my constant
+friend and companion.   But it is your happiness I desire as well as my
+own when I declare to you that our marriage would render me eternally
+miserable unless it were the dictate of your own free choice.  Even now
+I weep to think that, borne down as you are by the cruellest
+misfortunes, you may stifle, by the word 'honour,' all hope of that
+love and happiness which would alone restore you to yourself.  I, who
+have so disinterested an affection for you, may increase your miseries
+tenfold by being an obstacle to your wishes.  Ah! Victor, be assured
+that your cousin and playmate has too sincere a love for you not to be
+made miserable by this supposition.  Be happy, my friend; and if you
+obey me in this one request, remain satisfied that nothing on earth
+will have the power to interrupt my tranquillity.
+
+"Do not let this letter disturb you; do not answer tomorrow, or the
+next day, or even until you come, if it will give you pain.  My uncle
+will send me news of your health, and if I see but one smile on your
+lips when we meet, occasioned by this or any other exertion of mine, I
+shall need no other happiness.
+
+                                                "Elizabeth Lavenza
+
+
+    "Geneva, May 18th, 17--"
+
+
+This letter revived in my memory what I had before forgotten, the
+threat of the fiend--"I WILL BE WITH YOU ON YOUR WEDDING-NIGHT!" Such
+was my sentence, and on that night would the daemon employ every art to
+destroy me and tear me from the glimpse of happiness which promised
+partly to console my sufferings.  On that night he had determined to
+consummate his crimes by my death.  Well, be it so; a deadly struggle
+would then assuredly take place, in which if he were victorious I
+should be at peace and his power over me be at an end.  If he were
+vanquished, I should be a free man.  Alas!  What freedom?  Such as the
+peasant enjoys when his family have been massacred before his eyes, his
+cottage burnt, his lands laid waste, and he is turned adrift, homeless,
+penniless, and alone, but free. Such would be my liberty except that in
+my Elizabeth I possessed a treasure, alas, balanced by those horrors of
+remorse and guilt which would pursue me until death.
+
+Sweet and beloved Elizabeth!  I read and reread her letter, and some
+softened feelings stole into my heart and dared to whisper paradisiacal
+dreams of love and joy; but the apple was already eaten, and the
+angel's arm bared to drive me from all hope.  Yet I would die to make
+her happy.  If the monster executed his threat, death was inevitable;
+yet, again, I considered whether my marriage would hasten my fate.  My
+destruction might indeed arrive a few months sooner, but if my torturer
+should suspect that I postponed it, influenced by his menaces, he would
+surely find other and perhaps more dreadful means of revenge.
+
+He had vowed TO BE WITH ME ON MY WEDDING-NIGHT, yet he did not consider
+that threat as binding him to peace in the meantime, for as if to show
+me that he was not yet satiated with blood, he had murdered Clerval
+immediately after the enunciation of his threats.  I resolved,
+therefore, that if my immediate union with my cousin would conduce
+either to hers or my father's happiness, my adversary's designs against
+my life should not retard it a single hour.
+
+In this state of mind I wrote to Elizabeth.  My letter was calm and
+affectionate.  "I fear, my beloved girl," I said, "little happiness
+remains for us on earth; yet all that I may one day enjoy is centred in
+you.  Chase away your idle fears; to you alone do I consecrate my life
+and my endeavours for contentment.  I have one secret, Elizabeth, a
+dreadful one; when revealed to you, it will chill your frame with
+horror, and then, far from being surprised at my misery, you will only
+wonder that I survive what I have endured.  I will confide this tale of
+misery and terror to you the day after our marriage shall take place,
+for, my sweet cousin, there must be perfect confidence between us.  But
+until then, I conjure you, do not mention or allude to it.  This I most
+earnestly entreat, and I know you will comply."
+
+In about a week after the arrival of Elizabeth's letter we returned to
+Geneva.  The sweet girl welcomed me with warm affection, yet tears were
+in her eyes as she beheld my emaciated frame and feverish  cheeks.  I
+saw a change in her also.  She was thinner and had lost much of that
+heavenly vivacity that had before charmed me; but her gentleness and
+soft looks of compassion made her a more fit companion for one blasted
+and miserable as I was.  The tranquillity which I now enjoyed did not
+endure.  Memory brought madness with it, and when I thought of what had
+passed, a real insanity possessed me; sometimes I was furious and burnt
+with rage, sometimes low and despondent.  I neither spoke nor looked at
+anyone, but sat motionless, bewildered by the multitude of miseries
+that overcame me.
+
+Elizabeth alone had the power to draw me from these fits; her gentle
+voice would soothe me when transported by passion and inspire me with
+human feelings when sunk in torpor.  She wept with me and for me.  When
+reason returned, she would remonstrate and endeavour to inspire me with
+resignation.  Ah!  It is well for the unfortunate to be resigned, but
+for the guilty there is no peace.  The agonies of remorse poison the
+luxury there is otherwise sometimes found in indulging the excess of
+grief.  Soon after my arrival my father spoke of my immediate marriage
+with Elizabeth.  I remained silent.
+
+"Have you, then, some other attachment?"
+
+"None on earth.  I love Elizabeth and look forward to our union with
+delight.  Let the day therefore be fixed; and on it I will consecrate
+myself, in life or death, to the happiness of my cousin."
+
+"My dear Victor, do not speak thus.  Heavy misfortunes have befallen
+us, but let us only cling closer to what remains and transfer our love
+for those whom we have lost to those who yet live.  Our circle will be
+small but bound close by the ties of affection and mutual misfortune.
+And when time shall have softened your despair, new and dear objects of
+care will be born to replace those of whom we have been so cruelly
+deprived."
+
+Such were the lessons of my father.  But to me the remembrance of the
+threat returned; nor can you wonder that, omnipotent as the fiend had
+yet been in his deeds of blood, I should almost regard him as
+invincible, and that when he had pronounced the words "I SHALL BE WITH
+YOU ON YOUR WEDDING-NIGHT," I should regard the threatened fate as
+unavoidable.  But death was no evil to me if the loss of Elizabeth were
+balanced with it, and I therefore, with a contented and even cheerful
+countenance, agreed with my father that if my cousin would consent, the
+ceremony should take place in ten days, and thus put, as I imagined,
+the seal to my fate.
+
+Great God!  If for one instant I had thought what might be the hellish
+intention of my fiendish adversary, I would rather have banished myself
+forever from my native country and wandered a friendless outcast over
+the earth than have consented to this miserable marriage.  But, as if
+possessed of magic powers, the monster had blinded me to his real
+intentions; and when I thought that I had prepared only my own death, I
+hastened that of a far dearer victim.
+
+As the period fixed for our marriage drew nearer, whether from
+cowardice or a prophetic feeling, I felt my heart sink within me.  But
+I concealed my feelings by an appearance of hilarity that brought
+smiles and joy to the countenance of my father, but hardly deceived the
+ever-watchful and nicer eye of Elizabeth.  She looked forward to our
+union with placid contentment, not unmingled with a little fear, which
+past misfortunes had impressed, that what now appeared certain and
+tangible happiness might soon dissipate into an airy dream and leave no
+trace but deep and everlasting regret.  Preparations were made for the
+event, congratulatory visits were received, and all wore a smiling
+appearance.  I shut up, as well as I could, in my own heart the anxiety
+that preyed there and entered with seeming earnestness into the plans
+of my father, although they might only serve as the decorations of my
+tragedy.  Through my father's exertions a part of the inheritance of
+Elizabeth had been restored to her by the Austrian government.  A small
+possession on the shores of Como belonged to her.  It was agreed that,
+immediately after our union, we should proceed to Villa Lavenza and
+spend our first days of happiness beside the beautiful lake near which
+it stood.
+
+In the meantime I took every precaution to defend my person in case the
+fiend should openly attack me.  I carried pistols and a dagger
+constantly about me and was ever on the watch to prevent artifice, and
+by these means gained a greater degree of tranquillity.  Indeed, as the
+period approached, the threat appeared more as a delusion, not to be
+regarded as worthy to disturb my peace, while the happiness I hoped for
+in my marriage wore a greater appearance of certainty as the day fixed
+for its solemnization drew nearer and I heard it continually spoken of
+as an occurrence which no accident could possibly prevent.
+
+Elizabeth seemed happy; my tranquil demeanour contributed greatly to
+calm her mind.  But on the day that was to fulfil my wishes and my
+destiny, she was melancholy, and a presentiment of evil pervaded her;
+and perhaps also she thought of the dreadful secret which I had
+promised to reveal to her on the following day.  My father was in the
+meantime overjoyed and in the bustle of preparation only recognized in
+the melancholy of his niece the diffidence of a bride.
+
+After the ceremony was performed a large party assembled at my
+father's, but it was agreed that Elizabeth and I should commence our
+journey by water, sleeping that night at Evian and continuing our
+voyage on the following day.  The day was fair, the wind favourable;
+all smiled on our nuptial embarkation.
+
+Those were the last moments of my life during which I enjoyed the
+feeling of happiness.  We passed rapidly along; the sun was hot, but we
+were sheltered from its rays by a kind of canopy while we enjoyed the
+beauty of the scene, sometimes on one side of the lake, where we saw
+Mont Saleve, the pleasant banks of Montalegre, and at a distance,
+surmounting all, the beautiful Mont Blanc and the assemblage of snowy
+mountains that in vain endeavour to emulate her; sometimes coasting the
+opposite banks, we saw the mighty Jura opposing its dark side to the
+ambition that would quit its native country, and an almost
+insurmountable barrier to the invader who should wish to enslave it.
+
+I took the hand of Elizabeth.  "You are sorrowful, my love.  Ah!  If
+you knew what I have suffered and what I may yet endure, you would
+endeavour to let me taste the quiet and freedom from despair that this
+one day at least permits me to enjoy."
+
+"Be happy, my dear Victor," replied Elizabeth; "there is, I hope,
+nothing to distress you; and be assured that if a lively joy is not
+painted in my face, my heart is contented.  Something whispers to me
+not to depend too much on the prospect that is opened before us, but I
+will not listen to such a sinister voice.  Observe how fast we move
+along and how the clouds, which sometimes obscure and sometimes rise
+above the dome of Mont Blanc, render this scene of beauty still more
+interesting.  Look also at the innumerable fish that are swimming in
+the clear waters, where we can distinguish every pebble that lies at
+the bottom.  What a divine day!  How happy and serene all nature
+appears!"
+
+Thus Elizabeth endeavoured to divert her thoughts and mine from all
+reflection upon melancholy subjects.  But her temper was fluctuating;
+joy for a few instants shone in her eyes, but it continually gave place
+to distraction and reverie.
+
+The sun sank lower in the heavens; we passed the river Drance and
+observed its path through the chasms of the higher and the glens of the
+lower hills.  The Alps here come closer to the lake, and we approached
+the amphitheatre of mountains which forms its eastern boundary.  The
+spire of Evian shone under the woods that surrounded it and the range
+of mountain above mountain by which it was overhung.
+
+The wind, which had hitherto carried us along with amazing rapidity,
+sank at sunset to a light breeze; the soft air just ruffled the water
+and caused a pleasant motion among the trees as we approached the
+shore, from which it wafted the most delightful scent of flowers and
+hay.  The sun sank beneath the horizon as we landed, and as I touched
+the shore I felt those cares and fears revive which soon were to clasp
+me and cling to me forever.
+
+
+
+Chapter 23
+
+It was eight o'clock when we landed; we walked for a short time on the
+shore, enjoying the transitory light, and then retired to the inn and
+contemplated the lovely scene of waters, woods, and mountains, obscured
+in darkness, yet still displaying their black outlines.
+
+The wind, which had fallen in the south, now rose with great violence
+in the west.  The moon had reached her summit in the heavens and was
+beginning to descend; the clouds swept across it swifter than the
+flight of the vulture and dimmed her rays, while the lake reflected the
+scene of the busy heavens, rendered still busier by the restless waves
+that were beginning to rise.  Suddenly a heavy storm of rain descended.
+
+I had been calm during the day, but so soon as night obscured the
+shapes of objects, a thousand fears arose in my mind.  I was anxious
+and watchful, while my right hand grasped a pistol which was hidden in
+my bosom; every sound terrified me, but I resolved that I would sell my
+life dearly and not shrink from the conflict until my own life or that
+of my adversary was extinguished.  Elizabeth observed my agitation for
+some time in timid and fearful silence, but there was something in my
+glance which communicated terror to her, and trembling, she asked,
+"What is it that agitates you, my dear Victor?  What is it you fear?"
+
+"Oh!  Peace, peace, my love," replied I; "this night, and all will be
+safe; but this night is dreadful, very dreadful."
+
+I passed an hour in this state of mind, when suddenly I reflected how
+fearful the combat which I momentarily expected would be to my wife,
+and I earnestly entreated her to retire, resolving not to join her
+until I had obtained some knowledge as to the situation of my enemy.
+
+She left me, and I continued some time walking up and down the passages
+of the house and inspecting every corner that might afford a retreat to
+my adversary.  But I discovered no trace of him and was beginning to
+conjecture that some fortunate chance had intervened to prevent the
+execution of his menaces when suddenly I heard a shrill and dreadful
+scream.  It came from the room into which Elizabeth had retired.  As I
+heard it, the whole truth rushed into my mind, my arms dropped, the
+motion of every muscle and fibre was suspended; I could feel the blood
+trickling in my veins and tingling in the extremities of my limbs. This
+state lasted but for an instant; the scream was repeated, and I rushed
+into the room.  Great God!  Why did I not then expire!  Why am I here
+to relate the destruction of the best hope and the purest creature on
+earth?  She was there, lifeless and inanimate, thrown across the bed,
+her head hanging down and her pale and distorted features half covered
+by her hair.  Everywhere I turn I see the same figure--her bloodless
+arms and relaxed form flung by the murderer on its bridal bier.  Could
+I behold this and live?  Alas!  Life is obstinate and clings closest
+where it is most hated.  For a moment only did I lose recollection; I
+fell senseless on the ground.
+
+When I recovered I found myself surrounded by the people of the inn;
+their countenances expressed a breathless terror, but the horror of
+others appeared only as a mockery, a shadow of the feelings that
+oppressed me.  I escaped from them to the room where lay the body of
+Elizabeth, my love, my wife, so lately living, so dear, so worthy.  She
+had been moved from the posture in which I had first beheld her, and
+now, as she lay, her head upon her arm and a handkerchief thrown across
+her face and neck, I might have supposed her asleep. I rushed towards
+her and embraced her with ardour, but the deadly languor and coldness
+of the limbs told me that what I now held in my arms had ceased to be
+the Elizabeth whom I had loved and cherished.  The murderous mark of
+the fiend's grasp was on her neck, and the breath had ceased to issue
+from her lips.  While I still hung over her in the agony of despair, I
+happened to look up.  The windows of the room had before been darkened,
+and I felt a kind of panic on seeing the pale yellow light of the moon
+illuminate the chamber.  The shutters had been thrown back, and with a
+sensation of horror not to be described, I saw at the open window a
+figure the most hideous and abhorred.  A grin was on the face of the
+monster; he seemed to jeer, as with his fiendish finger he pointed
+towards the corpse of my wife.  I rushed towards the window, and
+drawing a pistol from my bosom, fired; but he eluded me, leaped from
+his station, and running with the swiftness of lightning, plunged into
+the lake.
+
+The report of the pistol brought a crowd into the room. I pointed to
+the spot where he had disappeared, and we followed the track with
+boats; nets were cast, but in vain.  After passing several hours, we
+returned hopeless, most of my companions believing it to have been a
+form conjured up by my fancy.  After having landed, they proceeded to
+search the country, parties going in different directions among the
+woods and vines.
+
+I attempted to accompany them and proceeded a short distance from the
+house, but my head whirled round, my steps were like those of a drunken
+man, I fell at last in a state of utter exhaustion; a film covered my
+eyes, and my skin was parched with the heat of fever.  In this state I
+was carried back and placed on a bed, hardly conscious of what had
+happened; my eyes wandered round the room as if to seek something that
+I had lost.
+
+After an interval I arose, and as if by instinct, crawled into the room
+where the corpse of my beloved lay.  There were women weeping around; I
+hung over it and joined my sad tears to theirs; all this time no
+distinct idea presented itself to my mind, but my thoughts rambled to
+various subjects, reflecting confusedly on my misfortunes and their
+cause.  I was bewildered, in a cloud of wonder and horror.  The death
+of William, the execution of Justine, the murder of Clerval, and lastly
+of my wife; even at that moment I knew not that my only remaining
+friends were safe from the malignity of the fiend; my father even now
+might be writhing under his grasp, and Ernest might be dead at his
+feet.  This idea made me shudder and recalled me to action.  I started
+up and resolved to return to Geneva with all possible speed.
+
+There were no horses to be procured, and I must return by the lake; but
+the wind was unfavourable, and the rain fell in torrents.  However, it
+was hardly morning, and I might reasonably hope to arrive by night.  I
+hired men to row and took an oar myself, for I had always experienced
+relief from mental torment in bodily exercise.  But the overflowing
+misery I now felt, and the excess of agitation that I endured rendered
+me incapable of any exertion.  I threw down the oar, and leaning my
+head upon my hands, gave way to every gloomy idea that arose.  If I
+looked up, I saw scenes which were familiar to me in my happier time
+and which I had contemplated but the day before in the company of her
+who was now but a shadow and a recollection.  Tears streamed from my
+eyes.  The rain had ceased for a moment, and I saw the fish play in the
+waters as they had done a few hours before; they had then been observed
+by Elizabeth.  Nothing is so painful to the human mind as a great and
+sudden change.  The sun might shine or the clouds might lower, but
+nothing could appear to me as it had done the day before.  A fiend had
+snatched from me every hope of future happiness; no creature had ever
+been so miserable as I was; so frightful an event is single in the
+history of man. But why should I dwell upon the incidents that followed
+this last overwhelming event?  Mine has been a tale of horrors; I have
+reached their acme, and what I must now relate can but be tedious to
+you.  Know that, one by one, my friends were snatched away; I was left
+desolate.  My own strength is exhausted, and I must tell, in a few
+words, what remains of my hideous narration. I arrived at Geneva.  My
+father and Ernest yet lived, but the former sunk under the tidings that
+I bore.  I see him now, excellent and venerable old man!  His eyes
+wandered in vacancy, for they had lost their charm and their
+delight--his Elizabeth, his more than daughter, whom he doted on with
+all that affection which a man feels, who in the decline of life,
+having few affections, clings more earnestly to those that remain.
+Cursed, cursed be the fiend that brought misery on his grey hairs and
+doomed him to waste in wretchedness!  He could not live under the
+horrors that were accumulated around him; the springs of existence
+suddenly gave way; he was unable to rise from his bed, and in a few
+days he died in my arms.
+
+What then became of me?  I know not; I lost sensation, and chains and
+darkness were the only objects that pressed upon me.  Sometimes,
+indeed, I dreamt that I wandered in flowery meadows and pleasant vales
+with the friends of my youth, but I awoke and found myself in a
+dungeon.  Melancholy followed, but by degrees I gained a clear
+conception of my miseries and situation and was then released from my
+prison.  For they had called me mad, and during many months, as I
+understood, a solitary cell had been my habitation.
+
+Liberty, however, had been a useless gift to me, had I not, as I
+awakened to reason, at the same time awakened to revenge.  As the
+memory of past misfortunes pressed upon me, I began to reflect on their
+cause--the monster whom I had created, the miserable daemon whom I had
+sent abroad into the world for my destruction.  I was possessed by a
+maddening rage when I thought of him, and desired and ardently prayed
+that I might have him within my grasp to wreak a great and signal
+revenge on his cursed head.
+
+Nor did my hate long confine itself to useless wishes; I began to
+reflect on the best means of securing him; and for this purpose, about
+a month after my release, I repaired to a criminal judge in the town
+and told him that I had an accusation to make, that I knew the
+destroyer of my family, and that I required him to exert his whole
+authority for the apprehension of the murderer.  The magistrate
+listened to me with attention and kindness.
+
+"Be assured, sir," said he, "no pains or exertions on my part shall be
+spared to discover the villain."
+
+"I thank you," replied I; "listen, therefore, to the deposition that I
+have to make.  It is indeed a tale so strange that I should fear you
+would not credit it were there not something in truth which, however
+wonderful, forces conviction.  The story is too connected to be
+mistaken for a dream, and I have no motive for falsehood." My manner as
+I thus addressed him was impressive but calm; I had formed in my own
+heart a resolution to pursue my destroyer to death, and this purpose
+quieted my agony and for an interval reconciled me to life.  I now
+related my history briefly but with firmness and precision, marking the
+dates with accuracy and never deviating into invective or exclamation.
+
+The magistrate appeared at first perfectly incredulous, but as I
+continued he became more attentive and interested; I saw him sometimes
+shudder with horror; at others a lively surprise, unmingled with
+disbelief, was painted on his countenance.  When I had concluded my
+narration I said, "This is the being whom I accuse and for whose
+seizure and punishment I call upon you to exert your whole power.  It
+is your duty as a magistrate, and I believe and hope that your feelings
+as a man will not revolt from the execution of those functions on this
+occasion."  This address caused a considerable change in the
+physiognomy of my own auditor.  He had heard my story with that half
+kind of belief that is given to a tale of spirits and supernatural
+events; but when he was called upon to act officially in consequence,
+the whole tide of his incredulity returned.  He, however, answered
+mildly, "I would willingly afford you every aid in your pursuit, but
+the creature of whom you speak appears to have powers which would put
+all my exertions to defiance.  Who can follow an animal which can
+traverse the sea of ice and inhabit caves and dens where no man would
+venture to intrude?  Besides, some months have elapsed since the
+commission of his crimes, and no one can conjecture to what place he
+has wandered or what region he may now inhabit."
+
+"I do not doubt that he hovers near the spot which I inhabit, and if he
+has indeed taken refuge in the Alps, he may be hunted like the chamois
+and destroyed as a beast of prey.  But I perceive your thoughts; you do
+not credit my narrative and do not intend to pursue my enemy with the
+punishment which is his desert." As I spoke, rage sparkled in my eyes;
+the magistrate was intimidated.  "You are mistaken," said he.  "I will
+exert myself, and if it is in my power to seize the monster, be assured
+that he shall suffer punishment proportionate to his crimes.  But I
+fear, from what you have yourself described to be his properties, that
+this will prove impracticable; and thus, while every proper measure is
+pursued, you should make up your mind to disappointment."
+
+"That cannot be; but all that I can say will be of little avail.  My
+revenge is of no moment to you; yet, while I allow it to be a vice, I
+confess that it is the devouring and only passion of my soul.  My rage
+is unspeakable when I reflect that the murderer, whom I have turned
+loose upon society, still exists.  You refuse my just demand; I have
+but one resource, and I devote myself, either in my life or death, to
+his destruction."
+
+I trembled with excess of agitation as I said this; there was a frenzy
+in my manner, and something, I doubt not, of that haughty fierceness
+which the martyrs of old are said to have possessed.  But to a Genevan
+magistrate, whose mind was occupied by far other ideas than those of
+devotion and heroism, this elevation of mind had much the appearance of
+madness.  He endeavoured to soothe me as a nurse does a child and
+reverted to my tale as the effects of delirium.
+
+"Man," I cried, "how ignorant art thou in thy pride of wisdom!  Cease;
+you know not what it is you say."
+
+I broke from the house angry and disturbed and retired to meditate on
+some other mode of action.
+
+
+
+Chapter 24
+
+My present situation was one in which all voluntary thought was
+swallowed up and lost.  I was hurried away by fury; revenge alone
+endowed me with strength and composure; it moulded my feelings and
+allowed me to be calculating and calm at periods when otherwise
+delirium or death would have been my portion.
+
+My first resolution was to quit Geneva forever; my country, which, when
+I was happy and beloved, was dear to me, now, in my adversity, became
+hateful.  I provided myself with a sum of money, together with a few
+jewels which had belonged to my mother, and departed.  And now my
+wanderings began which are to cease but with life.  I have traversed a
+vast portion of the earth and have endured all the hardships which
+travellers in deserts and barbarous countries are wont to meet.  How I
+have lived I hardly know; many times have I stretched my failing limbs
+upon the sandy plain and prayed for death.  But revenge kept me alive;
+I dared not die and leave my adversary in being.
+
+When I quitted Geneva my first labour was to gain some clue by which I
+might trace the steps of my fiendish enemy.  But my plan was unsettled,
+and I wandered many hours round the confines of the town, uncertain
+what path I should pursue.  As night approached I found myself at the
+entrance of the cemetery where William, Elizabeth, and my father
+reposed.  I entered it and approached the tomb which marked their
+graves.  Everything was silent except the leaves of the trees, which
+were gently agitated by the wind; the night was nearly dark, and the
+scene would have been solemn and affecting even to an uninterested
+observer.  The spirits of the departed seemed to flit around and to
+cast a shadow, which was felt but not seen, around the head of the
+mourner.
+
+The deep grief which this scene had at first excited quickly gave way
+to rage and despair.  They were dead, and I lived; their murderer also
+lived, and to destroy him I must drag out my weary existence.  I knelt
+on the grass and kissed the earth and with quivering lips exclaimed,
+"By the sacred earth on which I kneel, by the shades that wander near
+me, by the deep and eternal grief that I feel, I swear; and by thee, O
+Night, and the spirits that preside over thee, to pursue the daemon who
+caused this misery, until he or I shall perish in mortal conflict.  For
+this purpose I will preserve my life; to execute this dear revenge will
+I again behold the sun and tread the green herbage of earth, which
+otherwise should vanish from my eyes forever.  And I call on you,
+spirits of the dead, and on you, wandering ministers of vengeance, to
+aid and conduct me in my work.  Let the cursed and hellish monster
+drink deep of agony; let him feel the despair that now torments me."  I
+had begun my adjuration with solemnity and an awe which almost assured
+me that the shades of my murdered friends heard and approved my
+devotion, but the furies possessed me as I concluded, and rage choked
+my utterance.
+
+I was answered through the stillness of night by a loud and fiendish
+laugh.  It rang on my ears long and heavily; the mountains re-echoed
+it, and I felt as if all hell surrounded me with mockery and laughter.
+Surely in that moment I should have been possessed by frenzy and have
+destroyed my miserable existence but that my vow was heard and that I
+was reserved for vengeance.  The laughter died away, when a well-known
+and abhorred voice, apparently close to my ear, addressed me in an
+audible whisper, "I am satisfied, miserable wretch!  You have
+determined to live, and I am satisfied."
+
+I darted towards the spot from which the sound proceeded, but the devil
+eluded my grasp.  Suddenly the broad disk of the moon arose and shone
+full upon his ghastly and distorted shape as he fled with more than
+mortal speed.
+
+I pursued him, and for many months this has been my task.  Guided by a
+slight clue, I followed the windings of the Rhone, but vainly.  The
+blue Mediterranean appeared, and by a strange chance, I saw the fiend
+enter by night and hide himself in a vessel bound for the Black Sea.  I
+took my passage in the same ship, but he escaped, I know not how.
+
+Amidst the wilds of Tartary and Russia, although he still evaded me, I
+have ever followed in his track.  Sometimes the peasants, scared by
+this horrid apparition, informed me of his path; sometimes he himself,
+who feared that if I lost all trace of him I should despair and die,
+left some mark to guide me.  The snows descended on my head, and I saw
+the print of his huge step on the white plain.  To you first entering
+on life, to whom care is new and agony unknown, how can you understand
+what I have felt and still feel?  Cold, want, and fatigue were the
+least pains which I was destined to endure; I was cursed by some devil
+and carried about with me my eternal hell; yet still a spirit of good
+followed and directed my steps and when I most murmured would suddenly
+extricate me from seemingly insurmountable difficulties.  Sometimes,
+when nature, overcome by hunger, sank under the exhaustion, a repast
+was prepared for me in the desert that restored and inspirited me.  The
+fare was, indeed, coarse, such as the peasants of the country ate, but
+I will not doubt that it was set there by the spirits that I had
+invoked to aid me.  Often, when all was dry, the heavens cloudless, and
+I was parched by thirst, a slight cloud would bedim the sky, shed the
+few drops that revived me, and vanish.
+
+I followed, when I could, the courses of the rivers; but the daemon
+generally avoided these, as it was here that the population of the
+country chiefly collected.  In other places human beings were seldom
+seen, and I generally subsisted on the wild animals that crossed my
+path.  I had money with me and gained the friendship of the villagers
+by distributing it; or I brought with me some food that I had killed,
+which, after taking a small part, I always presented to those who had
+provided me with fire and utensils for cooking.
+
+My life, as it passed thus, was indeed hateful to me, and it was during
+sleep alone that I could taste joy.  O blessed sleep!  Often, when most
+miserable, I sank to repose, and my dreams lulled me even to rapture.
+The spirits that guarded me had provided these moments, or rather
+hours, of happiness that I might retain strength to fulfil my
+pilgrimage.  Deprived of this respite, I should have sunk under my
+hardships.  During the day I was sustained and inspirited by the hope
+of night, for in sleep I saw my friends, my wife, and my beloved
+country; again I saw the benevolent countenance of my father, heard the
+silver tones of my Elizabeth's voice, and beheld Clerval enjoying
+health and youth.  Often, when wearied by a toilsome march, I persuaded
+myself that I was dreaming until night should come and that I should
+then enjoy reality in the arms of my dearest friends.  What agonizing
+fondness did I feel for them!  How did I cling to their dear forms, as
+sometimes they haunted even my waking hours, and persuade myself that
+they still lived!  At such moments vengeance, that burned within me,
+died in my heart, and I pursued my path towards the destruction of the
+daemon more as a task enjoined by heaven, as the mechanical impulse of
+some power of which I was unconscious, than as the ardent desire of my
+soul.  What his feelings were whom I pursued I cannot know.  Sometimes,
+indeed, he left marks in writing on the barks of the trees or cut in
+stone that guided me and instigated my fury.  "My reign is not yet
+over"--these words were legible in one of these inscriptions--"you
+live, and my power is complete.  Follow me; I seek the everlasting ices
+of the north, where you will feel the misery of cold and frost, to
+which I am impassive.  You will find near this place, if you follow not
+too tardily, a dead hare; eat and be refreshed.  Come on, my enemy; we
+have yet to wrestle for our lives, but many hard and miserable hours
+must you endure until that period shall arrive."
+
+Scoffing devil!  Again do I vow vengeance; again do I devote thee,
+miserable fiend, to torture and death.  Never will I give up my search
+until he or I perish; and then with what ecstasy shall I join my
+Elizabeth and my departed friends, who even now prepare for me the
+reward of my tedious toil and horrible pilgrimage!
+
+As I still pursued my journey to the northward, the snows thickened and
+the cold increased in a degree almost too severe to support.  The
+peasants were shut up in their hovels, and only a few of the most hardy
+ventured forth to seize the animals whom starvation had forced from
+their hiding-places to seek for prey.  The rivers were covered with
+ice, and no fish could be procured; and thus I was cut off from my
+chief article of maintenance.  The triumph of my enemy increased with
+the difficulty of my labours.  One inscription that he left was in
+these words:  "Prepare!  Your toils only begin; wrap yourself in furs
+and provide food, for we shall soon enter upon a journey where your
+sufferings will satisfy my everlasting hatred."
+
+My courage and perseverance were invigorated by these scoffing words; I
+resolved not to fail in my purpose, and calling on heaven to support
+me, I continued with unabated fervour to traverse immense deserts,
+until the ocean appeared at a distance and formed the utmost boundary
+of the horizon.  Oh!  How unlike it was to the blue seasons of the
+south!  Covered with ice, it was only to be distinguished from land by
+its superior wildness and ruggedness.  The Greeks wept for joy when
+they beheld the Mediterranean from the hills of Asia, and hailed with
+rapture the boundary of their toils.  I did not weep, but I knelt down
+and with a full heart thanked my guiding spirit for conducting me in
+safety to the place where I hoped, notwithstanding my adversary's gibe,
+to meet and grapple with him.
+
+Some weeks before this period I had procured a sledge and dogs and thus
+traversed the snows with inconceivable speed.  I know not whether the
+fiend possessed the same advantages, but I found that, as before I had
+daily lost ground in the pursuit, I now gained on him, so much so that
+when I first saw the ocean he was but one day's journey in advance, and
+I hoped to intercept him before he should reach the beach.  With new
+courage, therefore, I pressed on, and in two days arrived at a wretched
+hamlet on the seashore.  I inquired of the inhabitants concerning the
+fiend and gained accurate information.  A gigantic monster, they said,
+had arrived the night before, armed with a gun and many pistols,
+putting to flight the inhabitants of a solitary cottage through fear of
+his terrific appearance.  He had carried off their store of winter
+food, and placing it in a sledge, to draw which he had seized on a
+numerous drove of trained dogs, he had harnessed them, and the same
+night, to the joy of the horror-struck villagers, had pursued his
+journey across the sea in a direction that led to no land; and they
+conjectured that he must speedily be destroyed by the breaking of the
+ice or frozen by the eternal  frosts.
+
+On hearing this information I suffered a temporary access of despair.
+He had escaped me, and I must commence a destructive and almost endless
+journey across the mountainous ices of the ocean, amidst cold that few
+of the inhabitants could long endure and which I, the native of a
+genial and sunny climate, could not hope to survive.  Yet at the idea
+that the fiend should live and be triumphant, my rage and vengeance
+returned, and like a mighty tide, overwhelmed every other feeling.
+After a slight repose, during which the spirits of the dead hovered
+round and instigated me to toil and revenge, I prepared for my journey.
+I exchanged my land-sledge for one fashioned for the inequalities of
+the frozen ocean, and purchasing a plentiful stock of provisions, I
+departed from land.
+
+I cannot guess how many days have passed since then, but I have endured
+misery which nothing but the eternal sentiment of a just retribution
+burning within my heart could have enabled me to support.  Immense and
+rugged mountains of ice often barred up my passage, and I often heard
+the thunder of the ground sea, which threatened my destruction.  But
+again the frost came and made the paths of the sea secure.
+
+By the quantity of provision which I had consumed, I should guess that
+I had passed three weeks in this journey; and the continual protraction
+of hope, returning back upon the heart, often wrung bitter drops of
+despondency and grief from my eyes.  Despair had indeed almost secured
+her prey, and I should soon have sunk beneath this misery.  Once, after
+the poor animals that conveyed me had with incredible toil gained the
+summit of a sloping ice mountain, and one, sinking under his fatigue,
+died, I viewed the expanse before me with anguish, when suddenly my eye
+caught a dark speck upon the dusky plain.  I strained my sight to
+discover what it could be and uttered a wild cry of ecstasy when I
+distinguished a sledge and the distorted proportions of a well-known
+form within.  Oh!  With what a burning gush did hope revisit my heart!
+Warm tears filled my eyes, which I hastily wiped away, that they might
+not intercept the view I had of the daemon; but still my sight was
+dimmed by the burning drops, until, giving way to the emotions that
+oppressed me, I wept aloud.
+
+But this was not the time for delay; I disencumbered the dogs of their
+dead companion, gave them a plentiful portion of food, and after an
+hour's rest, which was absolutely necessary, and yet which was bitterly
+irksome to me, I continued my route.  The sledge was still visible, nor
+did I again lose sight of it except at the moments when for a short
+time some ice-rock concealed it with its intervening crags.  I indeed
+perceptibly gained on it, and when, after nearly two days' journey, I
+beheld my enemy at no more than a mile distant, my heart bounded within
+me.
+
+But now, when I appeared almost within grasp of my foe, my hopes were
+suddenly extinguished, and I lost all trace of him more utterly than I
+had ever done before.  A ground sea was heard; the thunder of its
+progress, as the waters rolled and swelled beneath me, became every
+moment more ominous and terrific.  I pressed on, but in vain.  The wind
+arose; the sea roared; and, as with the mighty shock of an earthquake,
+it split and cracked with a tremendous and overwhelming sound.  The
+work was soon finished; in a few minutes a tumultuous sea rolled
+between me and my enemy, and I was left drifting on a scattered piece
+of ice that was continually lessening and thus preparing for me a
+hideous death.  In this manner many appalling hours passed; several of
+my dogs died, and I myself was about to sink under the accumulation of
+distress when I saw your vessel riding at anchor and holding forth to
+me hopes of succour and life.  I had no conception that vessels ever
+came so far north and was astounded at the sight.  I quickly destroyed
+part of my sledge to construct oars, and by these means was enabled,
+with infinite fatigue, to move my ice raft in the direction of your
+ship.  I had determined, if you were going southwards, still to trust
+myself to the mercy of the seas rather than abandon my purpose.  I
+hoped to induce you to grant me a boat with which I could pursue my
+enemy.  But your direction was northwards.  You took me on board when
+my vigour was exhausted, and I should soon have sunk under my
+multiplied hardships into a death which I still dread, for my task is
+unfulfilled.
+
+Oh!  When will my guiding spirit, in conducting me to the daemon, allow
+me the rest I so much desire; or must I die, and he yet live?  If I do,
+swear to me, Walton, that he shall not escape, that you will seek him
+and satisfy my vengeance in his death.  And do I dare to ask of you to
+undertake my pilgrimage, to endure the hardships that I have undergone?
+No; I am not so selfish.  Yet, when I am dead, if he should appear, if
+the ministers of vengeance should conduct him to you, swear that he
+shall not live--swear that he shall not triumph over my accumulated
+woes and survive to add to the list of his dark crimes.  He is eloquent
+and persuasive, and once his words had even power over my heart; but
+trust him not.  His soul is as hellish as his form, full of treachery
+and fiend-like malice.  Hear him not; call on the names of William,
+Justine, Clerval, Elizabeth, my father, and of the wretched Victor, and
+thrust your sword into his heart.  I will hover near and direct the
+steel aright.
+
+
+               Walton, in continuation.
+
+
+
+                                                August 26th, 17--
+
+
+You have read this strange and terrific story, Margaret; and do you not
+feel your blood congeal with horror, like that which even now curdles
+mine?  Sometimes, seized with sudden agony, he could not continue his
+tale; at others, his voice broken, yet piercing, uttered with
+difficulty the words so replete with anguish.  His fine and lovely eyes
+were now lighted up with indignation, now subdued to downcast sorrow
+and quenched in infinite wretchedness.  Sometimes he commanded his
+countenance and tones and related the most horrible incidents with a
+tranquil voice, suppressing every mark of agitation; then, like a
+volcano bursting forth, his face would suddenly change to an expression
+of the wildest rage as he shrieked out imprecations on his persecutor.
+
+His tale is connected and told with an appearance of the simplest
+truth, yet I own to you that the letters of Felix and Safie, which he
+showed me, and the apparition of the monster seen from our ship,
+brought to me a greater conviction of the truth of his narrative than
+his asseverations, however earnest and connected.  Such a monster has,
+then, really existence!  I cannot doubt it, yet I am lost in surprise
+and admiration.  Sometimes I endeavoured to gain from Frankenstein the
+particulars of his creature's formation, but on this point he was
+impenetrable. "Are you mad, my friend?" said he.  "Or whither does your
+senseless curiosity lead you?  Would you also create for yourself and
+the world a demoniacal enemy?  Peace, peace!  Learn my miseries and do
+not seek to increase your own."  Frankenstein discovered that I made
+notes concerning his history; he asked to see them and then himself
+corrected and augmented them in many places, but principally in giving
+the life and spirit to the conversations he held with his enemy. "Since
+you have preserved my narration," said he, "I would not that a
+mutilated one should go down to posterity."
+
+Thus has a week passed away, while I have listened to the strangest
+tale that ever imagination formed.  My thoughts and every feeling of my
+soul have been drunk up by the interest for my guest which this tale
+and his own elevated and gentle manners have created.  I wish to soothe
+him, yet can I counsel one so infinitely miserable, so destitute of
+every hope of consolation, to live?  Oh, no!  The only joy that he can
+now know will be when he composes his shattered spirit to peace and
+death.  Yet he enjoys one comfort, the offspring of solitude and
+delirium; he believes that when in dreams he holds converse with his
+friends and derives from that communion consolation for his miseries or
+excitements to his vengeance, that they are not the creations of his
+fancy, but the beings themselves who visit him from the regions of a
+remote world.  This faith gives a solemnity to his reveries that render
+them to me almost as imposing and interesting as truth.
+
+Our conversations are not always confined to his own history and
+misfortunes.  On every point of general literature he displays
+unbounded knowledge and a quick and piercing apprehension.  His
+eloquence is forcible and touching; nor can I hear him, when he relates
+a pathetic incident or endeavours to move the passions of pity or love,
+without tears.  What a glorious creature must he have been in the days
+of his prosperity, when he is thus noble and godlike in ruin!  He seems
+to feel his own worth and the greatness of his fall.
+
+"When younger," said he, "I believed myself destined for some great
+enterprise.  My feelings are profound, but I possessed a  coolness of
+judgment that fitted me for illustrious achievements.  This sentiment
+of the worth of my nature supported me when others would have been
+oppressed, for I deemed it criminal to throw away in useless grief
+those talents that might be useful to my fellow creatures.  When I
+reflected on the work I had completed, no less a one than the creation
+of a sensitive and rational animal, I could not rank myself with the
+herd of common projectors.  But this thought, which supported me in the
+commencement of my career, now serves only to plunge me lower in the
+dust.  All my speculations and hopes are as nothing, and like the
+archangel who aspired to omnipotence, I am chained in an eternal hell.
+My imagination was vivid, yet my powers of analysis and application
+were intense; by the union of these qualities I conceived the idea and
+executed the creation of a man.  Even now I cannot recollect without
+passion my reveries while the work was incomplete.  I trod heaven in my
+thoughts, now exulting in my powers, now burning with the idea of their
+effects.  From my infancy I was imbued with high hopes and a lofty
+ambition; but how am I sunk!  Oh!  My friend, if you had known me as I
+once was, you would not recognize me in this state of degradation.
+Despondency rarely visited my heart; a high destiny seemed to bear me
+on, until I fell, never, never again to rise."  Must I then lose this
+admirable being?  I have longed for a friend; I have sought one who
+would sympathize with and love me.  Behold, on these desert seas I have
+found such a one, but I fear I have gained him only to know his value
+and lose him.  I would reconcile him to life, but he repulses the idea.
+
+"I thank you, Walton," he said, "for your kind intentions towards so
+miserable a wretch; but when you speak of new ties and fresh
+affections, think you that any can replace those who are gone?  Can any
+man be to me as Clerval was, or any woman another Elizabeth?  Even
+where the affections are not strongly moved by any superior excellence,
+the companions of our childhood always possess a certain power over our
+minds which hardly any later friend can obtain.  They know our
+infantine dispositions, which, however they may be afterwards modified,
+are never eradicated; and they can judge of our actions with more
+certain conclusions as to the integrity of our motives.  A sister or a
+brother can never, unless indeed such symptoms have been shown early,
+suspect the other of fraud or false dealing, when another friend,
+however strongly he may be attached, may, in spite of himself, be
+contemplated with suspicion.  But I enjoyed friends, dear not only
+through habit and association, but from their own merits; and wherever
+I am, the soothing voice of my Elizabeth and the conversation of
+Clerval will be ever whispered in my ear. They are dead, and but one
+feeling in such a solitude can persuade me to preserve my life.  If I
+were engaged in any high undertaking or design, fraught with extensive
+utility to my fellow creatures, then could I live to fulfil it.  But
+such is not my destiny; I must pursue and destroy the being to whom I
+gave existence; then my lot on earth will be fulfilled and I may die."
+
+
+
+
+September 2nd
+
+My beloved Sister,
+
+I write to you, encompassed by peril and ignorant whether I am ever
+doomed to see again dear England and the dearer friends that inhabit
+it.  I am surrounded by mountains of ice which admit of no escape and
+threaten every moment to crush my vessel.  The brave fellows whom I
+have persuaded to be my companions look towards me for aid, but I have
+none to bestow.  There is something terribly appalling in our
+situation, yet my courage and hopes do not desert me.  Yet it is
+terrible to reflect that the lives of all these men are endangered
+through me.  If we are lost, my mad schemes are the cause.
+
+And what, Margaret, will be the state of your mind?  You will not hear
+of my destruction, and you will anxiously await my return.  Years will
+pass, and you will have visitings of despair and yet be tortured by
+hope.  Oh!  My beloved sister, the sickening failing of your heart-felt
+expectations is, in prospect, more terrible to me than my own death.
+
+But you have a husband and lovely children; you may be happy.  Heaven
+bless you and make you so!
+
+My unfortunate guest regards me with the tenderest compassion.  He
+endeavours to fill me with hope and talks as if life were a possession
+which he valued.  He reminds me how often the same accidents have
+happened to other navigators who have attempted this sea, and in spite
+of myself, he fills me with cheerful auguries.  Even the sailors feel
+the power of his eloquence; when he speaks, they no longer despair; he
+rouses their energies, and while they hear his voice they believe these
+vast mountains of ice are mole-hills which will vanish before the
+resolutions of man.  These feelings are transitory; each day of
+expectation delayed fills them with fear, and I almost dread a mutiny
+caused by this despair.
+
+
+
+September 5th
+
+
+A scene has just passed of such uncommon interest that, although it is
+highly probable that these papers may never reach you, yet I cannot
+forbear recording it.
+
+We are still surrounded by mountains of ice, still in imminent danger
+of being crushed in their conflict.  The cold is excessive, and many of
+my unfortunate comrades have already found a grave amidst this scene of
+desolation.  Frankenstein has daily declined in health; a feverish fire
+still glimmers in his eyes, but he is exhausted, and when suddenly
+roused to any exertion, he speedily sinks again into apparent
+lifelessness.
+
+I mentioned in my last letter the fears I entertained of a mutiny.
+This morning, as I sat watching the wan countenance of my friend--his
+eyes half closed and his limbs hanging listlessly--I was roused by half
+a dozen of the sailors, who demanded admission into the cabin.  They
+entered, and their leader addressed me.  He told me that he and his
+companions had been chosen by the other sailors to come in deputation
+to me to make me a requisition which, in justice, I could not refuse.
+We were immured in ice and should probably never escape, but they
+feared that if, as was possible, the ice should dissipate and a free
+passage be opened, I should be rash enough to continue my voyage and
+lead them into fresh dangers, after they might happily have surmounted
+this.  They insisted, therefore, that I should engage with a solemn
+promise that if the vessel should be freed I would instantly direct my
+course southwards.
+
+This speech troubled me.  I had not despaired, nor had I yet conceived
+the idea of returning if set free.  Yet could I, in justice, or even in
+possibility, refuse this demand?  I hesitated before I answered, when
+Frankenstein, who had at first been silent, and indeed appeared hardly
+to have force enough to attend, now roused himself; his eyes sparkled,
+and his cheeks flushed with momentary vigour.  Turning towards the men,
+he said, "What do you mean?  What do you demand of your captain?  Are
+you, then, so easily turned from your design?  Did you not call this a
+glorious expedition?
+
+"And wherefore was it glorious?  Not because the way was smooth and
+placid as a southern sea, but because it was full of dangers and
+terror, because at every new incident your fortitude was to be called
+forth and your courage exhibited, because danger and death surrounded
+it, and these you were to brave and overcome.  For this was it a
+glorious, for this was it an honourable undertaking.  You were
+hereafter to be hailed as the benefactors of your species, your names
+adored as belonging to brave men who encountered death for honour and
+the benefit of mankind. And now, behold, with the first imagination of
+danger, or, if you will, the first mighty and terrific trial of your
+courage, you shrink away and are content to be handed down as men who
+had not strength enough to endure cold and peril; and so, poor souls,
+they were chilly and returned to their warm firesides.  Why, that
+requires not this preparation; ye need not have come thus far and
+dragged your captain to the shame of a defeat merely to prove
+yourselves cowards.  Oh!  Be men, or be more than men.  Be steady to
+your purposes and firm as a rock. This ice is not made of such stuff as
+your hearts may be; it is mutable and cannot withstand you if you say
+that it shall not.  Do not return to your families with the stigma of
+disgrace marked on your brows.  Return as heroes who have fought and
+conquered and who know not what it is to turn their backs on the foe."
+He spoke this with a voice so modulated to the different feelings
+expressed in his speech, with an eye so full of lofty design and
+heroism, that can you wonder that these men were moved?  They looked at
+one another and were unable to reply.  I spoke; I told them to retire
+and consider of what had been said, that I would not lead them farther
+north if they strenuously desired the contrary, but that I hoped that,
+with reflection, their courage would return.  They retired and I turned
+towards my friend, but he was sunk in languor and almost deprived of
+life.
+
+How all this will terminate, I know not, but I had rather die than
+return shamefully, my purpose unfulfilled.  Yet I fear such will be my
+fate; the men, unsupported by ideas of glory and honour, can never
+willingly continue to endure their present hardships.
+
+
+
+September 7th
+
+
+The die is cast; I have consented to return if we are not destroyed.
+Thus are my hopes blasted by cowardice and indecision; I come back
+ignorant and disappointed.  It requires more philosophy than I possess
+to bear this injustice with patience.
+
+
+
+September 12th
+
+
+It is past; I am returning to England.  I have lost my hopes of utility
+and glory; I have lost my friend.  But I will endeavour to detail these
+bitter circumstances to you, my dear sister; and while I am wafted
+towards England and towards you, I will not despond.
+
+September 9th, the ice began to move, and roarings like thunder were
+heard at a distance as the islands split and cracked in every
+direction.  We were in the most imminent peril, but as we could only
+remain passive, my chief attention was occupied by my unfortunate guest
+whose illness increased in such a degree that he was entirely confined
+to his bed.  The ice cracked behind us and was driven with force
+towards the north; a breeze sprang from the west, and on the 11th the
+passage towards the south became perfectly free.  When the sailors saw
+this and that their return to their native country was apparently
+assured, a shout of tumultuous joy broke from them, loud and
+long-continued.  Frankenstein, who was dozing, awoke and asked the
+cause of the tumult.  "They shout," I said, "because they will soon
+return to England."
+
+"Do you, then, really return?"
+
+"Alas!  Yes; I cannot withstand their demands.  I cannot lead them
+unwillingly to danger, and I must return."
+
+"Do so, if you will; but I will not.  You may give up your purpose, but
+mine is assigned to me by heaven, and I dare not.  I am weak, but
+surely the spirits who assist my vengeance will endow me with
+sufficient strength."  Saying this, he endeavoured to spring from the
+bed, but the exertion was too great for him; he fell back and fainted.
+
+It was long before he was restored, and I often thought that life was
+entirely extinct.  At length he opened his eyes; he breathed with
+difficulty and was unable to speak.  The surgeon gave him a composing
+draught and ordered us to leave him undisturbed. In the meantime he
+told me that my friend had certainly not many hours to live.
+
+His sentence was pronounced, and I could only grieve and be patient.  I
+sat by his bed, watching him; his eyes were closed, and I thought he
+slept; but presently he called to me in a feeble voice, and bidding me
+come near, said, "Alas!  The strength I relied on is gone; I feel that
+I shall soon die, and he, my enemy and persecutor, may still be in
+being.  Think not, Walton, that in the last moments of my existence I
+feel that burning hatred and ardent desire of revenge I once expressed;
+but I feel myself justified in desiring the death of my adversary.
+During these last days I have been occupied in examining my past
+conduct; nor do I find it blamable.  In a fit of enthusiastic madness I
+created a rational creature and was bound towards him to assure, as far
+as was in my power, his happiness and well-being.
+
+"This was my duty, but there was another still paramount to that.  My
+duties towards the beings of my own species had greater claims to my
+attention because they included a greater proportion of happiness or
+misery.  Urged by this view, I refused, and I did right in refusing, to
+create a companion for the first creature.  He showed unparalleled
+malignity and selfishness in evil; he destroyed my friends; he devoted
+to destruction beings who possessed exquisite sensations, happiness,
+and wisdom; nor do I know where this thirst for vengeance may end.
+Miserable himself that he may render no other wretched, he ought to
+die.  The task of his destruction was mine, but I have failed.  When
+actuated by selfish and vicious motives, I asked you to undertake my
+unfinished work, and I renew this request now, when I am only induced
+by reason and virtue.
+
+"Yet I cannot ask you to renounce your country and friends to fulfil
+this task; and now that you are returning to England, you will have
+little chance of meeting with him.  But the consideration of these
+points, and the well balancing of what you may esteem your duties, I
+leave to you; my judgment and ideas are already disturbed by the near
+approach of death.  I dare not ask you to do what I think right, for I
+may still be misled by passion.
+
+"That he should live to be an instrument of mischief disturbs me; in
+other respects, this hour, when I momentarily expect my release, is the
+only happy one which I have enjoyed for several years.  The forms of
+the beloved dead flit before me, and I hasten to their arms.  Farewell,
+Walton!  Seek happiness in tranquillity and avoid ambition, even if it
+be only the apparently innocent one of distinguishing yourself in
+science and discoveries.  Yet why do I say this?  I have myself been
+blasted in these hopes, yet another may succeed."
+
+His voice became fainter as he spoke, and at length, exhausted by his
+effort, he sank into silence.  About half an hour afterwards he
+attempted again to speak but was unable; he pressed my hand feebly, and
+his eyes closed forever, while the irradiation of a gentle smile passed
+away from his lips.
+
+Margaret, what comment can I make on the untimely extinction of this
+glorious spirit?  What can I say that will enable you to understand the
+depth of my sorrow?  All that I should express would be inadequate and
+feeble.  My tears flow; my mind is overshadowed by a cloud of
+disappointment.  But I journey towards England, and I may there find
+consolation.
+
+I am interrupted.  What do these sounds portend?  It is midnight; the
+breeze blows fairly, and the watch on deck scarcely stir.  Again there
+is a sound as of a human voice, but hoarser; it comes from the cabin
+where the remains of Frankenstein still lie.  I must arise and examine.
+Good night, my sister.
+
+Great God! what a scene has just taken place!  I am yet dizzy with the
+remembrance of it.  I hardly know whether I shall have the power to
+detail it; yet the tale which I have recorded would be incomplete
+without this final and wonderful catastrophe. I entered the cabin where
+lay the remains of my ill-fated and admirable friend.  Over him hung a
+form which I cannot find words to describe--gigantic in stature, yet
+uncouth and distorted in its proportions.  As he hung over the coffin,
+his face was concealed by long locks of ragged hair; but one vast hand
+was extended, in colour and apparent texture like that of a mummy. When
+he heard the sound of my approach, he ceased to utter exclamations of
+grief and horror and sprung towards the window.  Never did I behold a
+vision so horrible as his face, of such loathsome yet appalling
+hideousness.  I shut my eyes involuntarily and endeavoured to recollect
+what were my duties with regard to this destroyer.  I called on him to
+stay.
+
+He paused, looking on me with wonder, and again turning towards the
+lifeless form of his creator, he seemed to forget my presence, and
+every feature and gesture seemed instigated by the wildest rage of some
+uncontrollable passion.
+
+"That is also my victim!" he exclaimed.  "In his murder my crimes are
+consummated; the miserable series of my being is wound to its close!
+Oh, Frankenstein!  Generous and self-devoted being!  What does it avail
+that I now ask thee to pardon me?  I, who irretrievably destroyed thee
+by destroying all thou lovedst.  Alas!  He is cold, he cannot answer
+me." His voice seemed suffocated, and my first impulses, which had
+suggested to me the duty of obeying the dying request of my friend in
+destroying his enemy, were now suspended by a mixture of curiosity and
+compassion.  I approached this tremendous being; I dared not again
+raise my eyes to his face, there was something so scaring and unearthly
+in his ugliness.  I attempted to speak, but the words died away on my
+lips.  The monster continued to utter wild and incoherent
+self-reproaches.  At length I gathered resolution to address him in a
+pause of the tempest of his passion.
+
+"Your repentance," I said, "is now superfluous. If you had listened to
+the voice of conscience and heeded the stings of remorse before you had
+urged your diabolical vengeance to this extremity, Frankenstein would
+yet have lived."
+
+"And do you dream?" said the daemon.  "Do you think that I was then
+dead to agony and remorse?  He," he continued, pointing to the corpse,
+"he suffered not in the consummation of the deed. Oh!  Not the
+ten-thousandth portion of the anguish that was mine during the
+lingering detail of its execution.  A frightful selfishness hurried me
+on, while my heart was poisoned with remorse.  Think you that the
+groans of Clerval were music to my ears?  My heart was fashioned to be
+susceptible of love and sympathy, and when wrenched by misery to vice
+and hatred, it did not endure the violence of the change without
+torture such as you cannot even imagine.
+
+"After the murder of Clerval I returned to Switzerland, heart-broken
+and overcome.  I pitied Frankenstein; my pity amounted to horror; I
+abhorred myself.  But when I discovered that he, the author at once of
+my existence and of its unspeakable torments, dared to hope for
+happiness, that while he accumulated wretchedness and despair upon me
+he sought his own enjoyment in feelings and passions from the
+indulgence of which I was forever barred, then impotent envy and bitter
+indignation filled me with an insatiable thirst for vengeance.  I
+recollected my threat and resolved that it should be accomplished.  I
+knew that I was preparing for myself a deadly torture, but I was the
+slave, not the master, of an impulse which I detested yet could not
+disobey.  Yet when she died!  Nay, then I was not miserable.  I had
+cast off all feeling, subdued all anguish, to riot in the excess of my
+despair.  Evil thenceforth became my good.  Urged thus far, I had no
+choice but to adapt my nature to an element which I had willingly
+chosen.  The completion of my demoniacal design became an insatiable
+passion.  And now it is ended; there is my last victim!"
+
+I was at first touched by the expressions of his misery; yet, when I
+called to mind what Frankenstein had said of his powers of eloquence
+and persuasion, and when I again cast my eyes on the lifeless form of
+my friend, indignation was rekindled within me.  "Wretch!" I said.  "It
+is well that you come here to whine over the desolation that you have
+made.  You throw a torch into a pile of buildings, and when they are
+consumed, you sit among the ruins and lament the fall.  Hypocritical
+fiend!  If he whom you mourn still lived, still would he be the object,
+again would he become the prey, of your accursed vengeance.  It is not
+pity that you feel; you lament only because the victim of your
+malignity is withdrawn from your power."
+
+"Oh, it is not thus--not thus," interrupted the being.  "Yet such must
+be the impression conveyed to you by what appears to be the purport of
+my actions.  Yet I seek not a fellow feeling in my misery.  No sympathy
+may I ever find.  When I first sought it, it was the love of virtue,
+the feelings of happiness and affection with which my whole being
+overflowed, that I wished to be participated.  But now that virtue has
+become to me a shadow, and that happiness and affection are turned into
+bitter and loathing despair, in what should I seek for sympathy?  I am
+content to suffer alone while my sufferings shall endure; when I die, I
+am well satisfied that abhorrence and opprobrium should load my memory.
+Once my fancy was soothed with dreams of virtue, of fame, and of
+enjoyment.  Once I falsely hoped to meet with beings who, pardoning my
+outward form, would love me for the excellent qualities which I was
+capable of unfolding.  I was nourished with high thoughts of honour and
+devotion.  But now crime has degraded me beneath the meanest animal. No
+guilt, no mischief, no malignity, no misery, can be found comparable to
+mine.  When I run over the frightful catalogue of my sins, I cannot
+believe that I am the same creature whose thoughts were once filled
+with sublime and transcendent visions of the beauty and the majesty of
+goodness.  But it is even so; the fallen angel becomes a malignant
+devil.  Yet even that enemy of God and man had friends and associates
+in his desolation; I am alone.
+
+"You, who call Frankenstein your friend, seem to have a knowledge of my
+crimes and his misfortunes. But in the detail which he gave you of them
+he could not sum up the hours and months of misery which I endured
+wasting in impotent passions. For while I destroyed his hopes, I did
+not satisfy my own desires. They were forever ardent and craving; still
+I desired love and fellowship, and I was still spurned.  Was there no
+injustice in this? Am I to be thought the only criminal, when all
+humankind sinned against me? Why do you not hate Felix, who drove his
+friend from his door with contumely? Why do you not execrate the rustic
+who sought to destroy the saviour of his child? Nay, these are virtuous
+and immaculate beings! I, the miserable and the abandoned, am an
+abortion, to be spurned at, and kicked, and trampled on. Even now my
+blood boils at the recollection of this injustice.
+
+"But it is true that I am a wretch.  I have murdered the lovely and the
+helpless; I have strangled the innocent as they slept and grasped to
+death his throat who never injured me or any other living thing.  I
+have devoted my creator, the select specimen of all that is worthy of
+love and admiration among men, to misery; I have pursued him even to
+that irremediable ruin.
+
+"There he lies, white and cold in death.  You hate me, but your
+abhorrence cannot equal that with which I regard myself.  I look on the
+hands which executed the deed; I think on the heart in which the
+imagination of it was conceived and long for the moment when these
+hands will meet my eyes, when that imagination will haunt my thoughts
+no more.
+
+"Fear not that I shall be the instrument of future mischief.  My work
+is nearly complete.  Neither yours nor any man's death is needed to
+consummate the series of my being and accomplish that which must be
+done, but it requires my own.  Do not think that I shall be slow to
+perform this sacrifice.  I shall quit your vessel on the ice raft which
+brought me thither and shall seek the most northern extremity of the
+globe; I shall collect my funeral pile and consume to ashes this
+miserable frame, that its remains may afford no light to any curious
+and unhallowed wretch who would create such another as I have been.  I
+shall die.  I shall no longer feel the agonies which now consume me or
+be the prey of feelings unsatisfied, yet unquenched.  He is dead who
+called me into being; and when I shall be no more, the very remembrance
+of us both will speedily vanish.  I shall no longer see the sun or
+stars or feel the winds play on my cheeks.
+
+"Light, feeling, and sense will pass away; and in this condition must I
+find my happiness.  Some years ago, when the images which this world
+affords first opened upon me, when I felt the cheering warmth of summer
+and heard the rustling of the leaves and the warbling of the birds, and
+these were all to me, I should have wept to die; now it is my only
+consolation.  Polluted by crimes and torn by the bitterest remorse,
+where can I find rest but in death?
+
+"Farewell!  I leave you, and in you the last of humankind whom these
+eyes will ever behold. Farewell, Frankenstein! If thou wert yet alive
+and yet cherished a desire of revenge against me, it would be better
+satiated in my life than in my destruction. But it was not so; thou
+didst seek my extinction, that I might not cause greater wretchedness;
+and if yet, in some mode unknown to me, thou hadst not ceased to think
+and feel, thou wouldst not desire against me a vengeance greater than
+that which I feel. Blasted as thou wert, my agony was still superior to
+thine, for the bitter sting of remorse will not cease to rankle in my
+wounds until death shall close them forever.
+
+"But soon," he cried with sad and solemn enthusiasm, "I shall die, and
+what I now feel be no longer felt.  Soon these burning miseries will be
+extinct.  I shall ascend my funeral pile triumphantly and exult in the
+agony of the torturing flames. The light of that conflagration will
+fade away; my ashes will be swept into the sea by the winds.  My spirit
+will sleep in peace, or if it thinks, it will not surely think thus.
+Farewell."
+
+He sprang from the cabin window as he said this, upon the ice raft
+which lay close to the vessel.  He was soon borne away by the waves and
+lost in darkness and distance.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of Frankenstein, by
+Mary Wollstonecraft (Godwin) Shelley
+
+*** END OF THIS PROJECT GUTENBERG EBOOK FRANKENSTEIN ***
+
+***** This file should be named 84.txt or 84.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/8/84/
+
+Produced by Judith Boss, Christy Phillips, Lynn Hanninen,
+and David Meltzer. HTML version by Al Haines.
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS' WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/grimm-brothers.txt
+++ b/jet/tf-idf/src/main/resources/books/grimm-brothers.txt
@@ -1,0 +1,9571 @@
+﻿The Project Gutenberg EBook of Grimms’ Fairy Tales, by The Brothers Grimm
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Grimms’ Fairy Tales
+
+Author: The Brothers Grimm
+
+Translator: Edgar Taylor and Marian Edwardes
+
+Posting Date: December 14, 2008 [EBook #2591]
+Release Date: April, 2001
+Last Updated: November 7, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+
+
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+
+
+
+
+FAIRY TALES
+
+By The Brothers Grimm
+
+
+
+PREPARER’S NOTE
+
+     The text is based on translations from
+     the Grimms’ Kinder und Hausmarchen by
+     Edgar Taylor and Marian Edwardes.
+
+
+
+
+CONTENTS:
+
+     THE GOLDEN BIRD
+     HANS IN LUCK
+     JORINDA AND JORINDEL
+     THE TRAVELLING MUSICIANS
+     OLD SULTAN
+     THE STRAW, THE COAL, AND THE BEAN
+     BRIAR ROSE
+     THE DOG AND THE SPARROW
+     THE TWELVE DANCING PRINCESSES
+     THE FISHERMAN AND HIS WIFE
+     THE WILLOW-WREN AND THE BEAR
+     THE FROG-PRINCE
+     CAT AND MOUSE IN PARTNERSHIP
+     THE GOOSE-GIRL
+     THE ADVENTURES OF CHANTICLEER AND PARTLET
+       1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+       2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+     RAPUNZEL
+     FUNDEVOGEL
+     THE VALIANT LITTLE TAILOR
+     HANSEL AND GRETEL
+     THE MOUSE, THE BIRD, AND THE SAUSAGE
+     MOTHER HOLLE
+     LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+     THE ROBBER BRIDEGROOM
+     TOM THUMB
+     RUMPELSTILTSKIN
+     CLEVER GRETEL
+     THE OLD MAN AND HIS GRANDSON
+     THE LITTLE PEASANT
+     FREDERICK AND CATHERINE
+     SWEETHEART ROLAND
+     SNOWDROP
+     THE PINK
+     CLEVER ELSIE
+     THE MISER IN THE BUSH
+     ASHPUTTEL
+     THE WHITE SNAKE
+     THE WOLF AND THE SEVEN LITTLE KIDS
+     THE QUEEN BEE
+     THE ELVES AND THE SHOEMAKER
+     THE JUNIPER-TREE
+     the juniper-tree.
+     THE TURNIP
+     CLEVER HANS
+     THE THREE LANGUAGES
+     THE FOX AND THE CAT
+     THE FOUR CLEVER BROTHERS
+     LILY AND THE LION
+     THE FOX AND THE HORSE
+     THE BLUE LIGHT
+     THE RAVEN
+     THE GOLDEN GOOSE
+     THE WATER OF LIFE
+     THE TWELVE HUNTSMEN
+     THE KING OF THE GOLDEN MOUNTAIN
+     DOCTOR KNOWALL
+     THE SEVEN RAVENS
+     THE WEDDING OF MRS FOX
+     FIRST STORY
+     SECOND STORY
+     THE SALAD
+     THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+     KING GRISLY-BEARD
+     IRON HANS
+     CAT-SKIN
+     SNOW-WHITE AND ROSE-RED
+
+
+
+
+THE BROTHERS GRIMM FAIRY TALES
+
+
+
+
+THE GOLDEN BIRD
+
+A certain king had a beautiful garden, and in the garden stood a tree
+which bore golden apples. These apples were always counted, and about
+the time when they began to grow ripe it was found that every night one
+of them was gone. The king became very angry at this, and ordered the
+gardener to keep watch all night under the tree. The gardener set his
+eldest son to watch; but about twelve o’clock he fell asleep, and in
+the morning another of the apples was missing. Then the second son was
+ordered to watch; and at midnight he too fell asleep, and in the morning
+another apple was gone. Then the third son offered to keep watch; but
+the gardener at first would not let him, for fear some harm should come
+to him: however, at last he consented, and the young man laid himself
+under the tree to watch. As the clock struck twelve he heard a rustling
+noise in the air, and a bird came flying that was of pure gold; and as
+it was snapping at one of the apples with its beak, the gardener’s son
+jumped up and shot an arrow at it. But the arrow did the bird no harm;
+only it dropped a golden feather from its tail, and then flew away.
+The golden feather was brought to the king in the morning, and all the
+council was called together. Everyone agreed that it was worth more than
+all the wealth of the kingdom: but the king said, ‘One feather is of no
+use to me, I must have the whole bird.’
+
+Then the gardener’s eldest son set out and thought to find the golden
+bird very easily; and when he had gone but a little way, he came to a
+wood, and by the side of the wood he saw a fox sitting; so he took his
+bow and made ready to shoot at it. Then the fox said, ‘Do not shoot me,
+for I will give you good counsel; I know what your business is, and
+that you want to find the golden bird. You will reach a village in the
+evening; and when you get there, you will see two inns opposite to each
+other, one of which is very pleasant and beautiful to look at: go not in
+there, but rest for the night in the other, though it may appear to you
+to be very poor and mean.’ But the son thought to himself, ‘What can
+such a beast as this know about the matter?’ So he shot his arrow at
+the fox; but he missed it, and it set up its tail above its back and
+ran into the wood. Then he went his way, and in the evening came to
+the village where the two inns were; and in one of these were people
+singing, and dancing, and feasting; but the other looked very dirty,
+and poor. ‘I should be very silly,’ said he, ‘if I went to that shabby
+house, and left this charming place’; so he went into the smart house,
+and ate and drank at his ease, and forgot the bird, and his country too.
+
+Time passed on; and as the eldest son did not come back, and no tidings
+were heard of him, the second son set out, and the same thing happened
+to him. He met the fox, who gave him the good advice: but when he came
+to the two inns, his eldest brother was standing at the window where
+the merrymaking was, and called to him to come in; and he could not
+withstand the temptation, but went in, and forgot the golden bird and
+his country in the same manner.
+
+Time passed on again, and the youngest son too wished to set out into
+the wide world to seek for the golden bird; but his father would not
+listen to it for a long while, for he was very fond of his son, and
+was afraid that some ill luck might happen to him also, and prevent his
+coming back. However, at last it was agreed he should go, for he would
+not rest at home; and as he came to the wood, he met the fox, and heard
+the same good counsel. But he was thankful to the fox, and did not
+attempt his life as his brothers had done; so the fox said, ‘Sit upon my
+tail, and you will travel faster.’ So he sat down, and the fox began to
+run, and away they went over stock and stone so quick that their hair
+whistled in the wind.
+
+When they came to the village, the son followed the fox’s counsel, and
+without looking about him went to the shabby inn and rested there all
+night at his ease. In the morning came the fox again and met him as he
+was beginning his journey, and said, ‘Go straight forward, till you come
+to a castle, before which lie a whole troop of soldiers fast asleep and
+snoring: take no notice of them, but go into the castle and pass on and
+on till you come to a room, where the golden bird sits in a wooden cage;
+close by it stands a beautiful golden cage; but do not try to take the
+bird out of the shabby cage and put it into the handsome one, otherwise
+you will repent it.’ Then the fox stretched out his tail again, and the
+young man sat himself down, and away they went over stock and stone till
+their hair whistled in the wind.
+
+Before the castle gate all was as the fox had said: so the son went in
+and found the chamber where the golden bird hung in a wooden cage, and
+below stood the golden cage, and the three golden apples that had been
+lost were lying close by it. Then thought he to himself, ‘It will be a
+very droll thing to bring away such a fine bird in this shabby cage’; so
+he opened the door and took hold of it and put it into the golden cage.
+But the bird set up such a loud scream that all the soldiers awoke, and
+they took him prisoner and carried him before the king. The next morning
+the court sat to judge him; and when all was heard, it sentenced him to
+die, unless he should bring the king the golden horse which could run as
+swiftly as the wind; and if he did this, he was to have the golden bird
+given him for his own.
+
+So he set out once more on his journey, sighing, and in great despair,
+when on a sudden his friend the fox met him, and said, ‘You see now
+what has happened on account of your not listening to my counsel. I will
+still, however, tell you how to find the golden horse, if you will do as
+I bid you. You must go straight on till you come to the castle where the
+horse stands in his stall: by his side will lie the groom fast asleep
+and snoring: take away the horse quietly, but be sure to put the old
+leathern saddle upon him, and not the golden one that is close by it.’
+Then the son sat down on the fox’s tail, and away they went over stock
+and stone till their hair whistled in the wind.
+
+All went right, and the groom lay snoring with his hand upon the golden
+saddle. But when the son looked at the horse, he thought it a great pity
+to put the leathern saddle upon it. ‘I will give him the good one,’
+said he; ‘I am sure he deserves it.’ As he took up the golden saddle the
+groom awoke and cried out so loud, that all the guards ran in and took
+him prisoner, and in the morning he was again brought before the court
+to be judged, and was sentenced to die. But it was agreed, that, if he
+could bring thither the beautiful princess, he should live, and have the
+bird and the horse given him for his own.
+
+Then he went his way very sorrowful; but the old fox came and said, ‘Why
+did not you listen to me? If you had, you would have carried away
+both the bird and the horse; yet will I once more give you counsel. Go
+straight on, and in the evening you will arrive at a castle. At twelve
+o’clock at night the princess goes to the bathing-house: go up to her
+and give her a kiss, and she will let you lead her away; but take care
+you do not suffer her to go and take leave of her father and mother.’
+Then the fox stretched out his tail, and so away they went over stock
+and stone till their hair whistled again.
+
+As they came to the castle, all was as the fox had said, and at twelve
+o’clock the young man met the princess going to the bath and gave her the
+kiss, and she agreed to run away with him, but begged with many tears
+that he would let her take leave of her father. At first he refused,
+but she wept still more and more, and fell at his feet, till at last
+he consented; but the moment she came to her father’s house the guards
+awoke and he was taken prisoner again.
+
+Then he was brought before the king, and the king said, ‘You shall never
+have my daughter unless in eight days you dig away the hill that stops
+the view from my window.’ Now this hill was so big that the whole world
+could not take it away: and when he had worked for seven days, and had
+done very little, the fox came and said. ‘Lie down and go to sleep; I
+will work for you.’ And in the morning he awoke and the hill was gone;
+so he went merrily to the king, and told him that now that it was
+removed he must give him the princess.
+
+Then the king was obliged to keep his word, and away went the young man
+and the princess; and the fox came and said to him, ‘We will have all
+three, the princess, the horse, and the bird.’ ‘Ah!’ said the young man,
+‘that would be a great thing, but how can you contrive it?’
+
+‘If you will only listen,’ said the fox, ‘it can be done. When you come
+to the king, and he asks for the beautiful princess, you must say, “Here
+she is!” Then he will be very joyful; and you will mount the golden
+horse that they are to give you, and put out your hand to take leave of
+them; but shake hands with the princess last. Then lift her quickly on
+to the horse behind you; clap your spurs to his side, and gallop away as
+fast as you can.’
+
+All went right: then the fox said, ‘When you come to the castle where
+the bird is, I will stay with the princess at the door, and you will
+ride in and speak to the king; and when he sees that it is the right
+horse, he will bring out the bird; but you must sit still, and say that
+you want to look at it, to see whether it is the true golden bird; and
+when you get it into your hand, ride away.’
+
+This, too, happened as the fox said; they carried off the bird, the
+princess mounted again, and they rode on to a great wood. Then the fox
+came, and said, ‘Pray kill me, and cut off my head and my feet.’ But the
+young man refused to do it: so the fox said, ‘I will at any rate give
+you good counsel: beware of two things; ransom no one from the gallows,
+and sit down by the side of no river.’ Then away he went. ‘Well,’
+thought the young man, ‘it is no hard matter to keep that advice.’
+
+He rode on with the princess, till at last he came to the village where
+he had left his two brothers. And there he heard a great noise and
+uproar; and when he asked what was the matter, the people said, ‘Two men
+are going to be hanged.’ As he came nearer, he saw that the two men were
+his brothers, who had turned robbers; so he said, ‘Cannot they in any
+way be saved?’ But the people said ‘No,’ unless he would bestow all his
+money upon the rascals and buy their liberty. Then he did not stay to
+think about the matter, but paid what was asked, and his brothers were
+given up, and went on with him towards their home.
+
+And as they came to the wood where the fox first met them, it was so
+cool and pleasant that the two brothers said, ‘Let us sit down by the
+side of the river, and rest a while, to eat and drink.’ So he said,
+‘Yes,’ and forgot the fox’s counsel, and sat down on the side of the
+river; and while he suspected nothing, they came behind, and threw him
+down the bank, and took the princess, the horse, and the bird, and went
+home to the king their master, and said. ‘All this have we won by our
+labour.’ Then there was great rejoicing made; but the horse would not
+eat, the bird would not sing, and the princess wept.
+
+The youngest son fell to the bottom of the river’s bed: luckily it was
+nearly dry, but his bones were almost broken, and the bank was so steep
+that he could find no way to get out. Then the old fox came once more,
+and scolded him for not following his advice; otherwise no evil would
+have befallen him: ‘Yet,’ said he, ‘I cannot leave you here, so lay hold
+of my tail and hold fast.’ Then he pulled him out of the river, and said
+to him, as he got upon the bank, ‘Your brothers have set watch to kill
+you, if they find you in the kingdom.’ So he dressed himself as a poor
+man, and came secretly to the king’s court, and was scarcely within the
+doors when the horse began to eat, and the bird to sing, and the princess
+left off weeping. Then he went to the king, and told him all his
+brothers’ roguery; and they were seized and punished, and he had the
+princess given to him again; and after the king’s death he was heir to
+his kingdom.
+
+A long while after, he went to walk one day in the wood, and the old fox
+met him, and besought him with tears in his eyes to kill him, and cut
+off his head and feet. And at last he did so, and in a moment the
+fox was changed into a man, and turned out to be the brother of the
+princess, who had been lost a great many many years.
+
+
+
+
+HANS IN LUCK
+
+Some men are born to good luck: all they do or try to do comes
+right--all that falls to them is so much gain--all their geese are
+swans--all their cards are trumps--toss them which way you will, they
+will always, like poor puss, alight upon their legs, and only move on so
+much the faster. The world may very likely not always think of them as
+they think of themselves, but what care they for the world? what can it
+know about the matter?
+
+One of these lucky beings was neighbour Hans. Seven long years he had
+worked hard for his master. At last he said, ‘Master, my time is up; I
+must go home and see my poor mother once more: so pray pay me my wages
+and let me go.’ And the master said, ‘You have been a faithful and good
+servant, Hans, so your pay shall be handsome.’ Then he gave him a lump
+of silver as big as his head.
+
+Hans took out his pocket-handkerchief, put the piece of silver into it,
+threw it over his shoulder, and jogged off on his road homewards. As he
+went lazily on, dragging one foot after another, a man came in sight,
+trotting gaily along on a capital horse. ‘Ah!’ said Hans aloud, ‘what a
+fine thing it is to ride on horseback! There he sits as easy and happy
+as if he was at home, in the chair by his fireside; he trips against no
+stones, saves shoe-leather, and gets on he hardly knows how.’ Hans did
+not speak so softly but the horseman heard it all, and said, ‘Well,
+friend, why do you go on foot then?’ ‘Ah!’ said he, ‘I have this load to
+carry: to be sure it is silver, but it is so heavy that I can’t hold up
+my head, and you must know it hurts my shoulder sadly.’ ‘What do you say
+of making an exchange?’ said the horseman. ‘I will give you my horse,
+and you shall give me the silver; which will save you a great deal of
+trouble in carrying such a heavy load about with you.’ ‘With all my
+heart,’ said Hans: ‘but as you are so kind to me, I must tell you one
+thing--you will have a weary task to draw that silver about with you.’
+However, the horseman got off, took the silver, helped Hans up, gave him
+the bridle into one hand and the whip into the other, and said, ‘When
+you want to go very fast, smack your lips loudly together, and cry
+“Jip!”’
+
+Hans was delighted as he sat on the horse, drew himself up, squared his
+elbows, turned out his toes, cracked his whip, and rode merrily off, one
+minute whistling a merry tune, and another singing,
+
+ ‘No care and no sorrow,
+  A fig for the morrow!
+  We’ll laugh and be merry,
+  Sing neigh down derry!’
+
+After a time he thought he should like to go a little faster, so he
+smacked his lips and cried ‘Jip!’ Away went the horse full gallop; and
+before Hans knew what he was about, he was thrown off, and lay on his
+back by the road-side. His horse would have ran off, if a shepherd who
+was coming by, driving a cow, had not stopped it. Hans soon came to
+himself, and got upon his legs again, sadly vexed, and said to the
+shepherd, ‘This riding is no joke, when a man has the luck to get upon
+a beast like this that stumbles and flings him off as if it would break
+his neck. However, I’m off now once for all: I like your cow now a great
+deal better than this smart beast that played me this trick, and has
+spoiled my best coat, you see, in this puddle; which, by the by, smells
+not very like a nosegay. One can walk along at one’s leisure behind that
+cow--keep good company, and have milk, butter, and cheese, every day,
+into the bargain. What would I give to have such a prize!’ ‘Well,’ said
+the shepherd, ‘if you are so fond of her, I will change my cow for your
+horse; I like to do good to my neighbours, even though I lose by it
+myself.’ ‘Done!’ said Hans, merrily. ‘What a noble heart that good man
+has!’ thought he. Then the shepherd jumped upon the horse, wished Hans
+and the cow good morning, and away he rode.
+
+Hans brushed his coat, wiped his face and hands, rested a while, and
+then drove off his cow quietly, and thought his bargain a very lucky
+one. ‘If I have only a piece of bread (and I certainly shall always be
+able to get that), I can, whenever I like, eat my butter and cheese with
+it; and when I am thirsty I can milk my cow and drink the milk: and what
+can I wish for more?’ When he came to an inn, he halted, ate up all his
+bread, and gave away his last penny for a glass of beer. When he had
+rested himself he set off again, driving his cow towards his mother’s
+village. But the heat grew greater as soon as noon came on, till at
+last, as he found himself on a wide heath that would take him more than
+an hour to cross, he began to be so hot and parched that his tongue
+clave to the roof of his mouth. ‘I can find a cure for this,’ thought
+he; ‘now I will milk my cow and quench my thirst’: so he tied her to the
+stump of a tree, and held his leathern cap to milk into; but not a drop
+was to be had. Who would have thought that this cow, which was to bring
+him milk and butter and cheese, was all that time utterly dry? Hans had
+not thought of looking to that.
+
+While he was trying his luck in milking, and managing the matter very
+clumsily, the uneasy beast began to think him very troublesome; and at
+last gave him such a kick on the head as knocked him down; and there he
+lay a long while senseless. Luckily a butcher soon came by, driving a
+pig in a wheelbarrow. ‘What is the matter with you, my man?’ said the
+butcher, as he helped him up. Hans told him what had happened, how he
+was dry, and wanted to milk his cow, but found the cow was dry too. Then
+the butcher gave him a flask of ale, saying, ‘There, drink and refresh
+yourself; your cow will give you no milk: don’t you see she is an old
+beast, good for nothing but the slaughter-house?’ ‘Alas, alas!’ said
+Hans, ‘who would have thought it? What a shame to take my horse, and
+give me only a dry cow! If I kill her, what will she be good for? I hate
+cow-beef; it is not tender enough for me. If it were a pig now--like
+that fat gentleman you are driving along at his ease--one could do
+something with it; it would at any rate make sausages.’ ‘Well,’ said
+the butcher, ‘I don’t like to say no, when one is asked to do a kind,
+neighbourly thing. To please you I will change, and give you my fine fat
+pig for the cow.’ ‘Heaven reward you for your kindness and self-denial!’
+said Hans, as he gave the butcher the cow; and taking the pig off the
+wheel-barrow, drove it away, holding it by the string that was tied to
+its leg.
+
+So on he jogged, and all seemed now to go right with him: he had met
+with some misfortunes, to be sure; but he was now well repaid for all.
+How could it be otherwise with such a travelling companion as he had at
+last got?
+
+The next man he met was a countryman carrying a fine white goose. The
+countryman stopped to ask what was o’clock; this led to further chat;
+and Hans told him all his luck, how he had so many good bargains, and
+how all the world went gay and smiling with him. The countryman then
+began to tell his tale, and said he was going to take the goose to a
+christening. ‘Feel,’ said he, ‘how heavy it is, and yet it is only eight
+weeks old. Whoever roasts and eats it will find plenty of fat upon it,
+it has lived so well!’ ‘You’re right,’ said Hans, as he weighed it in
+his hand; ‘but if you talk of fat, my pig is no trifle.’ Meantime the
+countryman began to look grave, and shook his head. ‘Hark ye!’ said he,
+‘my worthy friend, you seem a good sort of fellow, so I can’t help doing
+you a kind turn. Your pig may get you into a scrape. In the village I
+just came from, the squire has had a pig stolen out of his sty. I was
+dreadfully afraid when I saw you that you had got the squire’s pig. If
+you have, and they catch you, it will be a bad job for you. The least
+they will do will be to throw you into the horse-pond. Can you swim?’
+
+Poor Hans was sadly frightened. ‘Good man,’ cried he, ‘pray get me out
+of this scrape. I know nothing of where the pig was either bred or born;
+but he may have been the squire’s for aught I can tell: you know this
+country better than I do, take my pig and give me the goose.’ ‘I ought
+to have something into the bargain,’ said the countryman; ‘give a fat
+goose for a pig, indeed! ‘Tis not everyone would do so much for you as
+that. However, I will not be hard upon you, as you are in trouble.’ Then
+he took the string in his hand, and drove off the pig by a side path;
+while Hans went on the way homewards free from care. ‘After all,’
+thought he, ‘that chap is pretty well taken in. I don’t care whose pig
+it is, but wherever it came from it has been a very good friend to me. I
+have much the best of the bargain. First there will be a capital roast;
+then the fat will find me in goose-grease for six months; and then there
+are all the beautiful white feathers. I will put them into my pillow,
+and then I am sure I shall sleep soundly without rocking. How happy my
+mother will be! Talk of a pig, indeed! Give me a fine fat goose.’
+
+As he came to the next village, he saw a scissor-grinder with his wheel,
+working and singing,
+
+ ‘O’er hill and o’er dale
+  So happy I roam,
+  Work light and live well,
+  All the world is my home;
+  Then who so blythe, so merry as I?’
+
+Hans stood looking on for a while, and at last said, ‘You must be well
+off, master grinder! you seem so happy at your work.’ ‘Yes,’ said the
+other, ‘mine is a golden trade; a good grinder never puts his hand
+into his pocket without finding money in it--but where did you get that
+beautiful goose?’ ‘I did not buy it, I gave a pig for it.’ ‘And where
+did you get the pig?’ ‘I gave a cow for it.’ ‘And the cow?’ ‘I gave a
+horse for it.’ ‘And the horse?’ ‘I gave a lump of silver as big as my
+head for it.’ ‘And the silver?’ ‘Oh! I worked hard for that seven long
+years.’ ‘You have thriven well in the world hitherto,’ said the grinder,
+‘now if you could find money in your pocket whenever you put your hand
+in it, your fortune would be made.’ ‘Very true: but how is that to be
+managed?’ ‘How? Why, you must turn grinder like myself,’ said the other;
+‘you only want a grindstone; the rest will come of itself. Here is one
+that is but little the worse for wear: I would not ask more than the
+value of your goose for it--will you buy?’ ‘How can you ask?’ said
+Hans; ‘I should be the happiest man in the world, if I could have money
+whenever I put my hand in my pocket: what could I want more? there’s
+the goose.’ ‘Now,’ said the grinder, as he gave him a common rough stone
+that lay by his side, ‘this is a most capital stone; do but work it well
+enough, and you can make an old nail cut with it.’
+
+Hans took the stone, and went his way with a light heart: his eyes
+sparkled for joy, and he said to himself, ‘Surely I must have been born
+in a lucky hour; everything I could want or wish for comes of itself.
+People are so kind; they seem really to think I do them a favour in
+letting them make me rich, and giving me good bargains.’
+
+Meantime he began to be tired, and hungry too, for he had given away his
+last penny in his joy at getting the cow.
+
+At last he could go no farther, for the stone tired him sadly: and he
+dragged himself to the side of a river, that he might take a drink of
+water, and rest a while. So he laid the stone carefully by his side on
+the bank: but, as he stooped down to drink, he forgot it, pushed it a
+little, and down it rolled, plump into the stream.
+
+For a while he watched it sinking in the deep clear water; then sprang
+up and danced for joy, and again fell upon his knees and thanked Heaven,
+with tears in his eyes, for its kindness in taking away his only plague,
+the ugly heavy stone.
+
+‘How happy am I!’ cried he; ‘nobody was ever so lucky as I.’ Then up he
+got with a light heart, free from all his troubles, and walked on till
+he reached his mother’s house, and told her how very easy the road to
+good luck was.
+
+
+
+
+JORINDA AND JORINDEL
+
+There was once an old castle, that stood in the middle of a deep gloomy
+wood, and in the castle lived an old fairy. Now this fairy could take
+any shape she pleased. All the day long she flew about in the form of
+an owl, or crept about the country like a cat; but at night she always
+became an old woman again. When any young man came within a hundred
+paces of her castle, he became quite fixed, and could not move a step
+till she came and set him free; which she would not do till he had given
+her his word never to come there again: but when any pretty maiden came
+within that space she was changed into a bird, and the fairy put her
+into a cage, and hung her up in a chamber in the castle. There were
+seven hundred of these cages hanging in the castle, and all with
+beautiful birds in them.
+
+Now there was once a maiden whose name was Jorinda. She was prettier
+than all the pretty girls that ever were seen before, and a shepherd
+lad, whose name was Jorindel, was very fond of her, and they were soon
+to be married. One day they went to walk in the wood, that they might be
+alone; and Jorindel said, ‘We must take care that we don’t go too near
+to the fairy’s castle.’ It was a beautiful evening; the last rays of the
+setting sun shone bright through the long stems of the trees upon
+the green underwood beneath, and the turtle-doves sang from the tall
+birches.
+
+Jorinda sat down to gaze upon the sun; Jorindel sat by her side; and
+both felt sad, they knew not why; but it seemed as if they were to be
+parted from one another for ever. They had wandered a long way; and when
+they looked to see which way they should go home, they found themselves
+at a loss to know what path to take.
+
+The sun was setting fast, and already half of its circle had sunk behind
+the hill: Jorindel on a sudden looked behind him, and saw through the
+bushes that they had, without knowing it, sat down close under the old
+walls of the castle. Then he shrank for fear, turned pale, and trembled.
+Jorinda was just singing,
+
+ ‘The ring-dove sang from the willow spray,
+  Well-a-day! Well-a-day!
+  He mourn’d for the fate of his darling mate,
+  Well-a-day!’
+
+when her song stopped suddenly. Jorindel turned to see the reason, and
+beheld his Jorinda changed into a nightingale, so that her song ended
+with a mournful _jug, jug_. An owl with fiery eyes flew three times
+round them, and three times screamed:
+
+ ‘Tu whu! Tu whu! Tu whu!’
+
+Jorindel could not move; he stood fixed as a stone, and could neither
+weep, nor speak, nor stir hand or foot. And now the sun went quite down;
+the gloomy night came; the owl flew into a bush; and a moment after the
+old fairy came forth pale and meagre, with staring eyes, and a nose and
+chin that almost met one another.
+
+She mumbled something to herself, seized the nightingale, and went away
+with it in her hand. Poor Jorindel saw the nightingale was gone--but
+what could he do? He could not speak, he could not move from the spot
+where he stood. At last the fairy came back and sang with a hoarse
+voice:
+
+ ‘Till the prisoner is fast,
+  And her doom is cast,
+  There stay! Oh, stay!
+  When the charm is around her,
+  And the spell has bound her,
+  Hie away! away!’
+
+On a sudden Jorindel found himself free. Then he fell on his knees
+before the fairy, and prayed her to give him back his dear Jorinda: but
+she laughed at him, and said he should never see her again; then she
+went her way.
+
+He prayed, he wept, he sorrowed, but all in vain. ‘Alas!’ he said, ‘what
+will become of me?’ He could not go back to his own home, so he went to
+a strange village, and employed himself in keeping sheep. Many a time
+did he walk round and round as near to the hated castle as he dared go,
+but all in vain; he heard or saw nothing of Jorinda.
+
+At last he dreamt one night that he found a beautiful purple flower,
+and that in the middle of it lay a costly pearl; and he dreamt that he
+plucked the flower, and went with it in his hand into the castle, and
+that everything he touched with it was disenchanted, and that there he
+found his Jorinda again.
+
+In the morning when he awoke, he began to search over hill and dale for
+this pretty flower; and eight long days he sought for it in vain: but
+on the ninth day, early in the morning, he found the beautiful purple
+flower; and in the middle of it was a large dewdrop, as big as a costly
+pearl. Then he plucked the flower, and set out and travelled day and
+night, till he came again to the castle.
+
+He walked nearer than a hundred paces to it, and yet he did not become
+fixed as before, but found that he could go quite close up to the door.
+Jorindel was very glad indeed to see this. Then he touched the door with
+the flower, and it sprang open; so that he went in through the court,
+and listened when he heard so many birds singing. At last he came to the
+chamber where the fairy sat, with the seven hundred birds singing in
+the seven hundred cages. When she saw Jorindel she was very angry, and
+screamed with rage; but she could not come within two yards of him, for
+the flower he held in his hand was his safeguard. He looked around at
+the birds, but alas! there were many, many nightingales, and how then
+should he find out which was his Jorinda? While he was thinking what to
+do, he saw the fairy had taken down one of the cages, and was making the
+best of her way off through the door. He ran or flew after her, touched
+the cage with the flower, and Jorinda stood before him, and threw her
+arms round his neck looking as beautiful as ever, as beautiful as when
+they walked together in the wood.
+
+Then he touched all the other birds with the flower, so that they all
+took their old forms again; and he took Jorinda home, where they were
+married, and lived happily together many years: and so did a good many
+other lads, whose maidens had been forced to sing in the old fairy’s
+cages by themselves, much longer than they liked.
+
+
+
+
+THE TRAVELLING MUSICIANS
+
+An honest farmer had once an ass that had been a faithful servant to him
+a great many years, but was now growing old and every day more and more
+unfit for work. His master therefore was tired of keeping him and
+began to think of putting an end to him; but the ass, who saw that some
+mischief was in the wind, took himself slyly off, and began his journey
+towards the great city, ‘For there,’ thought he, ‘I may turn musician.’
+
+After he had travelled a little way, he spied a dog lying by the
+roadside and panting as if he were tired. ‘What makes you pant so, my
+friend?’ said the ass. ‘Alas!’ said the dog, ‘my master was going to
+knock me on the head, because I am old and weak, and can no longer make
+myself useful to him in hunting; so I ran away; but what can I do to
+earn my livelihood?’ ‘Hark ye!’ said the ass, ‘I am going to the great
+city to turn musician: suppose you go with me, and try what you can
+do in the same way?’ The dog said he was willing, and they jogged on
+together.
+
+They had not gone far before they saw a cat sitting in the middle of the
+road and making a most rueful face. ‘Pray, my good lady,’ said the ass,
+‘what’s the matter with you? You look quite out of spirits!’ ‘Ah, me!’
+said the cat, ‘how can one be in good spirits when one’s life is in
+danger? Because I am beginning to grow old, and had rather lie at my
+ease by the fire than run about the house after the mice, my mistress
+laid hold of me, and was going to drown me; and though I have been lucky
+enough to get away from her, I do not know what I am to live upon.’
+‘Oh,’ said the ass, ‘by all means go with us to the great city; you are
+a good night singer, and may make your fortune as a musician.’ The cat
+was pleased with the thought, and joined the party.
+
+Soon afterwards, as they were passing by a farmyard, they saw a cock
+perched upon a gate, and screaming out with all his might and main.
+‘Bravo!’ said the ass; ‘upon my word, you make a famous noise; pray what
+is all this about?’ ‘Why,’ said the cock, ‘I was just now saying that
+we should have fine weather for our washing-day, and yet my mistress and
+the cook don’t thank me for my pains, but threaten to cut off my
+head tomorrow, and make broth of me for the guests that are coming
+on Sunday!’ ‘Heaven forbid!’ said the ass, ‘come with us Master
+Chanticleer; it will be better, at any rate, than staying here to have
+your head cut off! Besides, who knows? If we care to sing in tune, we
+may get up some kind of a concert; so come along with us.’ ‘With all my
+heart,’ said the cock: so they all four went on jollily together.
+
+They could not, however, reach the great city the first day; so when
+night came on, they went into a wood to sleep. The ass and the dog laid
+themselves down under a great tree, and the cat climbed up into the
+branches; while the cock, thinking that the higher he sat the safer he
+should be, flew up to the very top of the tree, and then, according to
+his custom, before he went to sleep, looked out on all sides of him to
+see that everything was well. In doing this, he saw afar off something
+bright and shining and calling to his companions said, ‘There must be a
+house no great way off, for I see a light.’ ‘If that be the case,’ said
+the ass, ‘we had better change our quarters, for our lodging is not the
+best in the world!’ ‘Besides,’ added the dog, ‘I should not be the
+worse for a bone or two, or a bit of meat.’ So they walked off together
+towards the spot where Chanticleer had seen the light, and as they drew
+near it became larger and brighter, till they at last came close to a
+house in which a gang of robbers lived.
+
+The ass, being the tallest of the company, marched up to the window and
+peeped in. ‘Well, Donkey,’ said Chanticleer, ‘what do you see?’ ‘What
+do I see?’ replied the ass. ‘Why, I see a table spread with all kinds of
+good things, and robbers sitting round it making merry.’ ‘That would
+be a noble lodging for us,’ said the cock. ‘Yes,’ said the ass, ‘if we
+could only get in’; so they consulted together how they should contrive
+to get the robbers out; and at last they hit upon a plan. The ass placed
+himself upright on his hind legs, with his forefeet resting against the
+window; the dog got upon his back; the cat scrambled up to the dog’s
+shoulders, and the cock flew up and sat upon the cat’s head. When
+all was ready a signal was given, and they began their music. The ass
+brayed, the dog barked, the cat mewed, and the cock screamed; and then
+they all broke through the window at once, and came tumbling into
+the room, amongst the broken glass, with a most hideous clatter! The
+robbers, who had been not a little frightened by the opening concert,
+had now no doubt that some frightful hobgoblin had broken in upon them,
+and scampered away as fast as they could.
+
+The coast once clear, our travellers soon sat down and dispatched what
+the robbers had left, with as much eagerness as if they had not expected
+to eat again for a month. As soon as they had satisfied themselves, they
+put out the lights, and each once more sought out a resting-place to
+his own liking. The donkey laid himself down upon a heap of straw in
+the yard, the dog stretched himself upon a mat behind the door, the
+cat rolled herself up on the hearth before the warm ashes, and the
+cock perched upon a beam on the top of the house; and, as they were all
+rather tired with their journey, they soon fell asleep.
+
+But about midnight, when the robbers saw from afar that the lights were
+out and that all seemed quiet, they began to think that they had been in
+too great a hurry to run away; and one of them, who was bolder than
+the rest, went to see what was going on. Finding everything still, he
+marched into the kitchen, and groped about till he found a match in
+order to light a candle; and then, espying the glittering fiery eyes of
+the cat, he mistook them for live coals, and held the match to them to
+light it. But the cat, not understanding this joke, sprang at his face,
+and spat, and scratched at him. This frightened him dreadfully, and away
+he ran to the back door; but there the dog jumped up and bit him in the
+leg; and as he was crossing over the yard the ass kicked him; and the
+cock, who had been awakened by the noise, crowed with all his might. At
+this the robber ran back as fast as he could to his comrades, and told
+the captain how a horrid witch had got into the house, and had spat at
+him and scratched his face with her long bony fingers; how a man with a
+knife in his hand had hidden himself behind the door, and stabbed him
+in the leg; how a black monster stood in the yard and struck him with a
+club, and how the devil had sat upon the top of the house and cried out,
+‘Throw the rascal up here!’ After this the robbers never dared to go
+back to the house; but the musicians were so pleased with their quarters
+that they took up their abode there; and there they are, I dare say, at
+this very day.
+
+
+
+
+OLD SULTAN
+
+A shepherd had a faithful dog, called Sultan, who was grown very old,
+and had lost all his teeth. And one day when the shepherd and his wife
+were standing together before the house the shepherd said, ‘I will shoot
+old Sultan tomorrow morning, for he is of no use now.’ But his wife
+said, ‘Pray let the poor faithful creature live; he has served us well a
+great many years, and we ought to give him a livelihood for the rest of
+his days.’ ‘But what can we do with him?’ said the shepherd, ‘he has not
+a tooth in his head, and the thieves don’t care for him at all; to
+be sure he has served us, but then he did it to earn his livelihood;
+tomorrow shall be his last day, depend upon it.’
+
+Poor Sultan, who was lying close by them, heard all that the shepherd
+and his wife said to one another, and was very much frightened to think
+tomorrow would be his last day; so in the evening he went to his good
+friend the wolf, who lived in the wood, and told him all his sorrows,
+and how his master meant to kill him in the morning. ‘Make yourself
+easy,’ said the wolf, ‘I will give you some good advice. Your master,
+you know, goes out every morning very early with his wife into the
+field; and they take their little child with them, and lay it down
+behind the hedge in the shade while they are at work. Now do you lie
+down close by the child, and pretend to be watching it, and I will come
+out of the wood and run away with it; you must run after me as fast as
+you can, and I will let it drop; then you may carry it back, and they
+will think you have saved their child, and will be so thankful to you
+that they will take care of you as long as you live.’ The dog liked this
+plan very well; and accordingly so it was managed. The wolf ran with the
+child a little way; the shepherd and his wife screamed out; but Sultan
+soon overtook him, and carried the poor little thing back to his master
+and mistress. Then the shepherd patted him on the head, and said, ‘Old
+Sultan has saved our child from the wolf, and therefore he shall live
+and be well taken care of, and have plenty to eat. Wife, go home, and
+give him a good dinner, and let him have my old cushion to sleep on
+as long as he lives.’ So from this time forward Sultan had all that he
+could wish for.
+
+Soon afterwards the wolf came and wished him joy, and said, ‘Now, my
+good fellow, you must tell no tales, but turn your head the other way
+when I want to taste one of the old shepherd’s fine fat sheep.’ ‘No,’
+said the Sultan; ‘I will be true to my master.’ However, the wolf
+thought he was in joke, and came one night to get a dainty morsel. But
+Sultan had told his master what the wolf meant to do; so he laid wait
+for him behind the barn door, and when the wolf was busy looking out for
+a good fat sheep, he had a stout cudgel laid about his back, that combed
+his locks for him finely.
+
+Then the wolf was very angry, and called Sultan ‘an old rogue,’ and
+swore he would have his revenge. So the next morning the wolf sent the
+boar to challenge Sultan to come into the wood to fight the matter. Now
+Sultan had nobody he could ask to be his second but the shepherd’s old
+three-legged cat; so he took her with him, and as the poor thing limped
+along with some trouble, she stuck up her tail straight in the air.
+
+The wolf and the wild boar were first on the ground; and when they
+espied their enemies coming, and saw the cat’s long tail standing
+straight in the air, they thought she was carrying a sword for Sultan to
+fight with; and every time she limped, they thought she was picking up
+a stone to throw at them; so they said they should not like this way of
+fighting, and the boar lay down behind a bush, and the wolf jumped
+up into a tree. Sultan and the cat soon came up, and looked about and
+wondered that no one was there. The boar, however, had not quite hidden
+himself, for his ears stuck out of the bush; and when he shook one of
+them a little, the cat, seeing something move, and thinking it was a
+mouse, sprang upon it, and bit and scratched it, so that the boar jumped
+up and grunted, and ran away, roaring out, ‘Look up in the tree, there
+sits the one who is to blame.’ So they looked up, and espied the wolf
+sitting amongst the branches; and they called him a cowardly rascal,
+and would not suffer him to come down till he was heartily ashamed of
+himself, and had promised to be good friends again with old Sultan.
+
+
+
+
+THE STRAW, THE COAL, AND THE BEAN
+
+In a village dwelt a poor old woman, who had gathered together a dish
+of beans and wanted to cook them. So she made a fire on her hearth, and
+that it might burn the quicker, she lighted it with a handful of straw.
+When she was emptying the beans into the pan, one dropped without her
+observing it, and lay on the ground beside a straw, and soon afterwards
+a burning coal from the fire leapt down to the two. Then the straw
+began and said: ‘Dear friends, from whence do you come here?’ The coal
+replied: ‘I fortunately sprang out of the fire, and if I had not escaped
+by sheer force, my death would have been certain,--I should have been
+burnt to ashes.’ The bean said: ‘I too have escaped with a whole skin,
+but if the old woman had got me into the pan, I should have been made
+into broth without any mercy, like my comrades.’ ‘And would a better
+fate have fallen to my lot?’ said the straw. ‘The old woman has
+destroyed all my brethren in fire and smoke; she seized sixty of them at
+once, and took their lives. I luckily slipped through her fingers.’
+
+‘But what are we to do now?’ said the coal.
+
+‘I think,’ answered the bean, ‘that as we have so fortunately escaped
+death, we should keep together like good companions, and lest a new
+mischance should overtake us here, we should go away together, and
+repair to a foreign country.’
+
+The proposition pleased the two others, and they set out on their way
+together. Soon, however, they came to a little brook, and as there was
+no bridge or foot-plank, they did not know how they were to get over
+it. The straw hit on a good idea, and said: ‘I will lay myself straight
+across, and then you can walk over on me as on a bridge.’ The straw
+therefore stretched itself from one bank to the other, and the coal,
+who was of an impetuous disposition, tripped quite boldly on to the
+newly-built bridge. But when she had reached the middle, and heard the
+water rushing beneath her, she was after all, afraid, and stood still,
+and ventured no farther. The straw, however, began to burn, broke in
+two pieces, and fell into the stream. The coal slipped after her, hissed
+when she got into the water, and breathed her last. The bean, who had
+prudently stayed behind on the shore, could not but laugh at the event,
+was unable to stop, and laughed so heartily that she burst. It would
+have been all over with her, likewise, if, by good fortune, a tailor who
+was travelling in search of work, had not sat down to rest by the brook.
+As he had a compassionate heart he pulled out his needle and thread,
+and sewed her together. The bean thanked him most prettily, but as the
+tailor used black thread, all beans since then have a black seam.
+
+
+
+
+BRIAR ROSE
+
+A king and queen once upon a time reigned in a country a great way off,
+where there were in those days fairies. Now this king and queen had
+plenty of money, and plenty of fine clothes to wear, and plenty of
+good things to eat and drink, and a coach to ride out in every day: but
+though they had been married many years they had no children, and this
+grieved them very much indeed. But one day as the queen was walking
+by the side of the river, at the bottom of the garden, she saw a poor
+little fish, that had thrown itself out of the water, and lay gasping
+and nearly dead on the bank. Then the queen took pity on the little
+fish, and threw it back again into the river; and before it swam away
+it lifted its head out of the water and said, ‘I know what your wish is,
+and it shall be fulfilled, in return for your kindness to me--you will
+soon have a daughter.’ What the little fish had foretold soon came to
+pass; and the queen had a little girl, so very beautiful that the king
+could not cease looking on it for joy, and said he would hold a great
+feast and make merry, and show the child to all the land. So he asked
+his kinsmen, and nobles, and friends, and neighbours. But the queen
+said, ‘I will have the fairies also, that they might be kind and good
+to our little daughter.’ Now there were thirteen fairies in the kingdom;
+but as the king and queen had only twelve golden dishes for them to eat
+out of, they were forced to leave one of the fairies without asking her.
+So twelve fairies came, each with a high red cap on her head, and red
+shoes with high heels on her feet, and a long white wand in her hand:
+and after the feast was over they gathered round in a ring and gave all
+their best gifts to the little princess. One gave her goodness, another
+beauty, another riches, and so on till she had all that was good in the
+world.
+
+Just as eleven of them had done blessing her, a great noise was heard in
+the courtyard, and word was brought that the thirteenth fairy was
+come, with a black cap on her head, and black shoes on her feet, and a
+broomstick in her hand: and presently up she came into the dining-hall.
+Now, as she had not been asked to the feast she was very angry, and
+scolded the king and queen very much, and set to work to take her
+revenge. So she cried out, ‘The king’s daughter shall, in her fifteenth
+year, be wounded by a spindle, and fall down dead.’ Then the twelfth of
+the friendly fairies, who had not yet given her gift, came forward, and
+said that the evil wish must be fulfilled, but that she could soften its
+mischief; so her gift was, that the king’s daughter, when the spindle
+wounded her, should not really die, but should only fall asleep for a
+hundred years.
+
+However, the king hoped still to save his dear child altogether from
+the threatened evil; so he ordered that all the spindles in the kingdom
+should be bought up and burnt. But all the gifts of the first eleven
+fairies were in the meantime fulfilled; for the princess was so
+beautiful, and well behaved, and good, and wise, that everyone who knew
+her loved her.
+
+It happened that, on the very day she was fifteen years old, the king
+and queen were not at home, and she was left alone in the palace. So she
+roved about by herself, and looked at all the rooms and chambers, till
+at last she came to an old tower, to which there was a narrow staircase
+ending with a little door. In the door there was a golden key, and when
+she turned it the door sprang open, and there sat an old lady spinning
+away very busily. ‘Why, how now, good mother,’ said the princess; ‘what
+are you doing there?’ ‘Spinning,’ said the old lady, and nodded her
+head, humming a tune, while buzz! went the wheel. ‘How prettily that
+little thing turns round!’ said the princess, and took the spindle
+and began to try and spin. But scarcely had she touched it, before the
+fairy’s prophecy was fulfilled; the spindle wounded her, and she fell
+down lifeless on the ground.
+
+However, she was not dead, but had only fallen into a deep sleep; and
+the king and the queen, who had just come home, and all their court,
+fell asleep too; and the horses slept in the stables, and the dogs in
+the court, the pigeons on the house-top, and the very flies slept upon
+the walls. Even the fire on the hearth left off blazing, and went to
+sleep; the jack stopped, and the spit that was turning about with a
+goose upon it for the king’s dinner stood still; and the cook, who was
+at that moment pulling the kitchen-boy by the hair to give him a box
+on the ear for something he had done amiss, let him go, and both fell
+asleep; the butler, who was slyly tasting the ale, fell asleep with the
+jug at his lips: and thus everything stood still, and slept soundly.
+
+A large hedge of thorns soon grew round the palace, and every year it
+became higher and thicker; till at last the old palace was surrounded
+and hidden, so that not even the roof or the chimneys could be seen. But
+there went a report through all the land of the beautiful sleeping Briar
+Rose (for so the king’s daughter was called): so that, from time to
+time, several kings’ sons came, and tried to break through the thicket
+into the palace. This, however, none of them could ever do; for the
+thorns and bushes laid hold of them, as it were with hands; and there
+they stuck fast, and died wretchedly.
+
+After many, many years there came a king’s son into that land: and an
+old man told him the story of the thicket of thorns; and how a beautiful
+palace stood behind it, and how a wonderful princess, called Briar Rose,
+lay in it asleep, with all her court. He told, too, how he had heard
+from his grandfather that many, many princes had come, and had tried to
+break through the thicket, but that they had all stuck fast in it, and
+died. Then the young prince said, ‘All this shall not frighten me; I
+will go and see this Briar Rose.’ The old man tried to hinder him, but
+he was bent upon going.
+
+Now that very day the hundred years were ended; and as the prince came
+to the thicket he saw nothing but beautiful flowering shrubs, through
+which he went with ease, and they shut in after him as thick as ever.
+Then he came at last to the palace, and there in the court lay the dogs
+asleep; and the horses were standing in the stables; and on the roof sat
+the pigeons fast asleep, with their heads under their wings. And when he
+came into the palace, the flies were sleeping on the walls; the spit
+was standing still; the butler had the jug of ale at his lips, going
+to drink a draught; the maid sat with a fowl in her lap ready to be
+plucked; and the cook in the kitchen was still holding up her hand, as
+if she was going to beat the boy.
+
+Then he went on still farther, and all was so still that he could hear
+every breath he drew; till at last he came to the old tower, and opened
+the door of the little room in which Briar Rose was; and there she lay,
+fast asleep on a couch by the window. She looked so beautiful that he
+could not take his eyes off her, so he stooped down and gave her a kiss.
+But the moment he kissed her she opened her eyes and awoke, and smiled
+upon him; and they went out together; and soon the king and queen also
+awoke, and all the court, and gazed on each other with great wonder.
+And the horses shook themselves, and the dogs jumped up and barked; the
+pigeons took their heads from under their wings, and looked about and
+flew into the fields; the flies on the walls buzzed again; the fire in
+the kitchen blazed up; round went the jack, and round went the spit,
+with the goose for the king’s dinner upon it; the butler finished his
+draught of ale; the maid went on plucking the fowl; and the cook gave
+the boy the box on his ear.
+
+And then the prince and Briar Rose were married, and the wedding feast
+was given; and they lived happily together all their lives long.
+
+
+
+
+THE DOG AND THE SPARROW
+
+A shepherd’s dog had a master who took no care of him, but often let him
+suffer the greatest hunger. At last he could bear it no longer; so he
+took to his heels, and off he ran in a very sad and sorrowful mood.
+On the road he met a sparrow that said to him, ‘Why are you so sad,
+my friend?’ ‘Because,’ said the dog, ‘I am very very hungry, and have
+nothing to eat.’ ‘If that be all,’ answered the sparrow, ‘come with me
+into the next town, and I will soon find you plenty of food.’ So on they
+went together into the town: and as they passed by a butcher’s shop,
+the sparrow said to the dog, ‘Stand there a little while till I peck you
+down a piece of meat.’ So the sparrow perched upon the shelf: and having
+first looked carefully about her to see if anyone was watching her, she
+pecked and scratched at a steak that lay upon the edge of the shelf,
+till at last down it fell. Then the dog snapped it up, and scrambled
+away with it into a corner, where he soon ate it all up. ‘Well,’ said
+the sparrow, ‘you shall have some more if you will; so come with me to
+the next shop, and I will peck you down another steak.’ When the dog had
+eaten this too, the sparrow said to him, ‘Well, my good friend, have you
+had enough now?’ ‘I have had plenty of meat,’ answered he, ‘but I should
+like to have a piece of bread to eat after it.’ ‘Come with me then,’
+said the sparrow, ‘and you shall soon have that too.’ So she took him
+to a baker’s shop, and pecked at two rolls that lay in the window, till
+they fell down: and as the dog still wished for more, she took him to
+another shop and pecked down some more for him. When that was eaten, the
+sparrow asked him whether he had had enough now. ‘Yes,’ said he; ‘and
+now let us take a walk a little way out of the town.’ So they both went
+out upon the high road; but as the weather was warm, they had not gone
+far before the dog said, ‘I am very much tired--I should like to take a
+nap.’ ‘Very well,’ answered the sparrow, ‘do so, and in the meantime
+I will perch upon that bush.’ So the dog stretched himself out on the
+road, and fell fast asleep. Whilst he slept, there came by a carter with
+a cart drawn by three horses, and loaded with two casks of wine. The
+sparrow, seeing that the carter did not turn out of the way, but would
+go on in the track in which the dog lay, so as to drive over him, called
+out, ‘Stop! stop! Mr Carter, or it shall be the worse for you.’ But the
+carter, grumbling to himself, ‘You make it the worse for me, indeed!
+what can you do?’ cracked his whip, and drove his cart over the poor
+dog, so that the wheels crushed him to death. ‘There,’ cried the
+sparrow, ‘thou cruel villain, thou hast killed my friend the dog. Now
+mind what I say. This deed of thine shall cost thee all thou art worth.’
+‘Do your worst, and welcome,’ said the brute, ‘what harm can you do me?’
+and passed on. But the sparrow crept under the tilt of the cart, and
+pecked at the bung of one of the casks till she loosened it; and then
+all the wine ran out, without the carter seeing it. At last he looked
+round, and saw that the cart was dripping, and the cask quite empty.
+‘What an unlucky wretch I am!’ cried he. ‘Not wretch enough yet!’ said
+the sparrow, as she alighted upon the head of one of the horses, and
+pecked at him till he reared up and kicked. When the carter saw this,
+he drew out his hatchet and aimed a blow at the sparrow, meaning to kill
+her; but she flew away, and the blow fell upon the poor horse’s head
+with such force, that he fell down dead. ‘Unlucky wretch that I am!’
+cried he. ‘Not wretch enough yet!’ said the sparrow. And as the carter
+went on with the other two horses, she again crept under the tilt of the
+cart, and pecked out the bung of the second cask, so that all the wine
+ran out. When the carter saw this, he again cried out, ‘Miserable wretch
+that I am!’ But the sparrow answered, ‘Not wretch enough yet!’ and
+perched on the head of the second horse, and pecked at him too. The
+carter ran up and struck at her again with his hatchet; but away she
+flew, and the blow fell upon the second horse and killed him on the
+spot. ‘Unlucky wretch that I am!’ said he. ‘Not wretch enough yet!’ said
+the sparrow; and perching upon the third horse, she began to peck him
+too. The carter was mad with fury; and without looking about him, or
+caring what he was about, struck again at the sparrow; but killed his
+third horse as he done the other two. ‘Alas! miserable wretch that I
+am!’ cried he. ‘Not wretch enough yet!’ answered the sparrow as she flew
+away; ‘now will I plague and punish thee at thy own house.’ The
+carter was forced at last to leave his cart behind him, and to go home
+overflowing with rage and vexation. ‘Alas!’ said he to his wife, ‘what
+ill luck has befallen me!--my wine is all spilt, and my horses all three
+dead.’ ‘Alas! husband,’ replied she, ‘and a wicked bird has come into
+the house, and has brought with her all the birds in the world, I am
+sure, and they have fallen upon our corn in the loft, and are eating it
+up at such a rate!’ Away ran the husband upstairs, and saw thousands of
+birds sitting upon the floor eating up his corn, with the sparrow in the
+midst of them. ‘Unlucky wretch that I am!’ cried the carter; for he saw
+that the corn was almost all gone. ‘Not wretch enough yet!’ said the
+sparrow; ‘thy cruelty shall cost thee thy life yet!’ and away she flew.
+
+The carter seeing that he had thus lost all that he had, went down
+into his kitchen; and was still not sorry for what he had done, but sat
+himself angrily and sulkily in the chimney corner. But the sparrow sat
+on the outside of the window, and cried ‘Carter! thy cruelty shall cost
+thee thy life!’ With that he jumped up in a rage, seized his hatchet,
+and threw it at the sparrow; but it missed her, and only broke the
+window. The sparrow now hopped in, perched upon the window-seat, and
+cried, ‘Carter! it shall cost thee thy life!’ Then he became mad and
+blind with rage, and struck the window-seat with such force that he
+cleft it in two: and as the sparrow flew from place to place, the carter
+and his wife were so furious, that they broke all their furniture,
+glasses, chairs, benches, the table, and at last the walls, without
+touching the bird at all. In the end, however, they caught her: and the
+wife said, ‘Shall I kill her at once?’ ‘No,’ cried he, ‘that is letting
+her off too easily: she shall die a much more cruel death; I will eat
+her.’ But the sparrow began to flutter about, and stretch out her neck
+and cried, ‘Carter! it shall cost thee thy life yet!’ With that he
+could wait no longer: so he gave his wife the hatchet, and cried, ‘Wife,
+strike at the bird and kill her in my hand.’ And the wife struck; but
+she missed her aim, and hit her husband on the head so that he fell down
+dead, and the sparrow flew quietly home to her nest.
+
+
+
+
+THE TWELVE DANCING PRINCESSES
+
+There was a king who had twelve beautiful daughters. They slept in
+twelve beds all in one room; and when they went to bed, the doors were
+shut and locked up; but every morning their shoes were found to be quite
+worn through as if they had been danced in all night; and yet nobody
+could find out how it happened, or where they had been.
+
+Then the king made it known to all the land, that if any person could
+discover the secret, and find out where it was that the princesses
+danced in the night, he should have the one he liked best for his
+wife, and should be king after his death; but whoever tried and did not
+succeed, after three days and nights, should be put to death.
+
+A king’s son soon came. He was well entertained, and in the evening was
+taken to the chamber next to the one where the princesses lay in their
+twelve beds. There he was to sit and watch where they went to dance;
+and, in order that nothing might pass without his hearing it, the door
+of his chamber was left open. But the king’s son soon fell asleep; and
+when he awoke in the morning he found that the princesses had all been
+dancing, for the soles of their shoes were full of holes. The same thing
+happened the second and third night: so the king ordered his head to be
+cut off. After him came several others; but they had all the same luck,
+and all lost their lives in the same manner.
+
+Now it chanced that an old soldier, who had been wounded in battle
+and could fight no longer, passed through the country where this king
+reigned: and as he was travelling through a wood, he met an old woman,
+who asked him where he was going. ‘I hardly know where I am going, or
+what I had better do,’ said the soldier; ‘but I think I should like very
+well to find out where it is that the princesses dance, and then in time
+I might be a king.’ ‘Well,’ said the old dame, ‘that is no very hard
+task: only take care not to drink any of the wine which one of the
+princesses will bring to you in the evening; and as soon as she leaves
+you pretend to be fast asleep.’
+
+Then she gave him a cloak, and said, ‘As soon as you put that on
+you will become invisible, and you will then be able to follow the
+princesses wherever they go.’ When the soldier heard all this good
+counsel, he determined to try his luck: so he went to the king, and said
+he was willing to undertake the task.
+
+He was as well received as the others had been, and the king ordered
+fine royal robes to be given him; and when the evening came he was led
+to the outer chamber. Just as he was going to lie down, the eldest of
+the princesses brought him a cup of wine; but the soldier threw it all
+away secretly, taking care not to drink a drop. Then he laid himself
+down on his bed, and in a little while began to snore very loud as if
+he was fast asleep. When the twelve princesses heard this they laughed
+heartily; and the eldest said, ‘This fellow too might have done a wiser
+thing than lose his life in this way!’ Then they rose up and opened
+their drawers and boxes, and took out all their fine clothes, and
+dressed themselves at the glass, and skipped about as if they were eager
+to begin dancing. But the youngest said, ‘I don’t know how it is, while
+you are so happy I feel very uneasy; I am sure some mischance will
+befall us.’ ‘You simpleton,’ said the eldest, ‘you are always afraid;
+have you forgotten how many kings’ sons have already watched in vain?
+And as for this soldier, even if I had not given him his sleeping
+draught, he would have slept soundly enough.’
+
+When they were all ready, they went and looked at the soldier; but he
+snored on, and did not stir hand or foot: so they thought they were
+quite safe; and the eldest went up to her own bed and clapped her hands,
+and the bed sank into the floor and a trap-door flew open. The soldier
+saw them going down through the trap-door one after another, the eldest
+leading the way; and thinking he had no time to lose, he jumped up, put
+on the cloak which the old woman had given him, and followed them;
+but in the middle of the stairs he trod on the gown of the youngest
+princess, and she cried out to her sisters, ‘All is not right; someone
+took hold of my gown.’ ‘You silly creature!’ said the eldest, ‘it is
+nothing but a nail in the wall.’ Then down they all went, and at the
+bottom they found themselves in a most delightful grove of trees; and
+the leaves were all of silver, and glittered and sparkled beautifully.
+The soldier wished to take away some token of the place; so he broke
+off a little branch, and there came a loud noise from the tree. Then the
+youngest daughter said again, ‘I am sure all is not right--did not you
+hear that noise? That never happened before.’ But the eldest said, ‘It
+is only our princes, who are shouting for joy at our approach.’
+
+Then they came to another grove of trees, where all the leaves were of
+gold; and afterwards to a third, where the leaves were all glittering
+diamonds. And the soldier broke a branch from each; and every time there
+was a loud noise, which made the youngest sister tremble with fear; but
+the eldest still said, it was only the princes, who were crying for joy.
+So they went on till they came to a great lake; and at the side of the
+lake there lay twelve little boats with twelve handsome princes in them,
+who seemed to be waiting there for the princesses.
+
+One of the princesses went into each boat, and the soldier stepped into
+the same boat with the youngest. As they were rowing over the lake, the
+prince who was in the boat with the youngest princess and the soldier
+said, ‘I do not know why it is, but though I am rowing with all my might
+we do not get on so fast as usual, and I am quite tired: the boat
+seems very heavy today.’ ‘It is only the heat of the weather,’ said the
+princess: ‘I feel it very warm too.’
+
+On the other side of the lake stood a fine illuminated castle, from
+which came the merry music of horns and trumpets. There they all landed,
+and went into the castle, and each prince danced with his princess; and
+the soldier, who was all the time invisible, danced with them too; and
+when any of the princesses had a cup of wine set by her, he drank it
+all up, so that when she put the cup to her mouth it was empty. At this,
+too, the youngest sister was terribly frightened, but the eldest always
+silenced her. They danced on till three o’clock in the morning, and then
+all their shoes were worn out, so that they were obliged to leave off.
+The princes rowed them back again over the lake (but this time the
+soldier placed himself in the boat with the eldest princess); and on the
+opposite shore they took leave of each other, the princesses promising
+to come again the next night.
+
+When they came to the stairs, the soldier ran on before the princesses,
+and laid himself down; and as the twelve sisters slowly came up very
+much tired, they heard him snoring in his bed; so they said, ‘Now all
+is quite safe’; then they undressed themselves, put away their fine
+clothes, pulled off their shoes, and went to bed. In the morning the
+soldier said nothing about what had happened, but determined to see more
+of this strange adventure, and went again the second and third night;
+and every thing happened just as before; the princesses danced each time
+till their shoes were worn to pieces, and then returned home. However,
+on the third night the soldier carried away one of the golden cups as a
+token of where he had been.
+
+As soon as the time came when he was to declare the secret, he was taken
+before the king with the three branches and the golden cup; and the
+twelve princesses stood listening behind the door to hear what he would
+say. And when the king asked him. ‘Where do my twelve daughters dance at
+night?’ he answered, ‘With twelve princes in a castle under ground.’ And
+then he told the king all that had happened, and showed him the three
+branches and the golden cup which he had brought with him. Then the king
+called for the princesses, and asked them whether what the soldier said
+was true: and when they saw that they were discovered, and that it was
+of no use to deny what had happened, they confessed it all. And the king
+asked the soldier which of them he would choose for his wife; and he
+answered, ‘I am not very young, so I will have the eldest.’--And they
+were married that very day, and the soldier was chosen to be the king’s
+heir.
+
+
+
+
+THE FISHERMAN AND HIS WIFE
+
+There was once a fisherman who lived with his wife in a pigsty, close
+by the seaside. The fisherman used to go out all day long a-fishing; and
+one day, as he sat on the shore with his rod, looking at the sparkling
+waves and watching his line, all on a sudden his float was dragged away
+deep into the water: and in drawing it up he pulled out a great fish.
+But the fish said, ‘Pray let me live! I am not a real fish; I am an
+enchanted prince: put me in the water again, and let me go!’ ‘Oh, ho!’
+said the man, ‘you need not make so many words about the matter; I will
+have nothing to do with a fish that can talk: so swim away, sir, as soon
+as you please!’ Then he put him back into the water, and the fish darted
+straight down to the bottom, and left a long streak of blood behind him
+on the wave.
+
+When the fisherman went home to his wife in the pigsty, he told her how
+he had caught a great fish, and how it had told him it was an enchanted
+prince, and how, on hearing it speak, he had let it go again. ‘Did not
+you ask it for anything?’ said the wife, ‘we live very wretchedly here,
+in this nasty dirty pigsty; do go back and tell the fish we want a snug
+little cottage.’
+
+The fisherman did not much like the business: however, he went to the
+seashore; and when he came back there the water looked all yellow and
+green. And he stood at the water’s edge, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+Then the fish came swimming to him, and said, ‘Well, what is her will?
+What does your wife want?’ ‘Ah!’ said the fisherman, ‘she says that when
+I had caught you, I ought to have asked you for something before I let
+you go; she does not like living any longer in the pigsty, and wants
+a snug little cottage.’ ‘Go home, then,’ said the fish; ‘she is in the
+cottage already!’ So the man went home, and saw his wife standing at the
+door of a nice trim little cottage. ‘Come in, come in!’ said she; ‘is
+not this much better than the filthy pigsty we had?’ And there was a
+parlour, and a bedchamber, and a kitchen; and behind the cottage there
+was a little garden, planted with all sorts of flowers and fruits; and
+there was a courtyard behind, full of ducks and chickens. ‘Ah!’ said the
+fisherman, ‘how happily we shall live now!’ ‘We will try to do so, at
+least,’ said his wife.
+
+Everything went right for a week or two, and then Dame Ilsabill said,
+‘Husband, there is not near room enough for us in this cottage; the
+courtyard and the garden are a great deal too small; I should like to
+have a large stone castle to live in: go to the fish again and tell him
+to give us a castle.’ ‘Wife,’ said the fisherman, ‘I don’t like to go to
+him again, for perhaps he will be angry; we ought to be easy with this
+pretty cottage to live in.’ ‘Nonsense!’ said the wife; ‘he will do it
+very willingly, I know; go along and try!’
+
+The fisherman went, but his heart was very heavy: and when he came to
+the sea, it looked blue and gloomy, though it was very calm; and he went
+close to the edge of the waves, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what does she want now?’ said the fish. ‘Ah!’ said the man,
+dolefully, ‘my wife wants to live in a stone castle.’ ‘Go home, then,’
+said the fish; ‘she is standing at the gate of it already.’ So away went
+the fisherman, and found his wife standing before the gate of a great
+castle. ‘See,’ said she, ‘is not this grand?’ With that they went into
+the castle together, and found a great many servants there, and the
+rooms all richly furnished, and full of golden chairs and tables; and
+behind the castle was a garden, and around it was a park half a
+mile long, full of sheep, and goats, and hares, and deer; and in the
+courtyard were stables and cow-houses. ‘Well,’ said the man, ‘now we
+will live cheerful and happy in this beautiful castle for the rest of
+our lives.’ ‘Perhaps we may,’ said the wife; ‘but let us sleep upon it,
+before we make up our minds to that.’ So they went to bed.
+
+The next morning when Dame Ilsabill awoke it was broad daylight, and
+she jogged the fisherman with her elbow, and said, ‘Get up, husband,
+and bestir yourself, for we must be king of all the land.’ ‘Wife, wife,’
+said the man, ‘why should we wish to be the king? I will not be king.’
+‘Then I will,’ said she. ‘But, wife,’ said the fisherman, ‘how can you
+be king--the fish cannot make you a king?’ ‘Husband,’ said she, ‘say
+no more about it, but go and try! I will be king.’ So the man went away
+quite sorrowful to think that his wife should want to be king. This time
+the sea looked a dark grey colour, and was overspread with curling waves
+and the ridges of foam as he cried out:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘Well, what would she have now?’ said the fish. ‘Alas!’ said the poor
+man, ‘my wife wants to be king.’ ‘Go home,’ said the fish; ‘she is king
+already.’
+
+Then the fisherman went home; and as he came close to the palace he saw
+a troop of soldiers, and heard the sound of drums and trumpets. And when
+he went in he saw his wife sitting on a throne of gold and diamonds,
+with a golden crown upon her head; and on each side of her stood six
+fair maidens, each a head taller than the other. ‘Well, wife,’ said the
+fisherman, ‘are you king?’ ‘Yes,’ said she, ‘I am king.’ And when he had
+looked at her for a long time, he said, ‘Ah, wife! what a fine thing it
+is to be king! Now we shall never have anything more to wish for as long
+as we live.’ ‘I don’t know how that may be,’ said she; ‘never is a long
+time. I am king, it is true; but I begin to be tired of that, and I
+think I should like to be emperor.’ ‘Alas, wife! why should you wish to
+be emperor?’ said the fisherman. ‘Husband,’ said she, ‘go to the fish!
+I say I will be emperor.’ ‘Ah, wife!’ replied the fisherman, ‘the fish
+cannot make an emperor, I am sure, and I should not like to ask him for
+such a thing.’ ‘I am king,’ said Ilsabill, ‘and you are my slave; so go
+at once!’
+
+So the fisherman was forced to go; and he muttered as he went along,
+‘This will come to no good, it is too much to ask; the fish will be
+tired at last, and then we shall be sorry for what we have done.’ He
+soon came to the seashore; and the water was quite black and muddy, and
+a mighty whirlwind blew over the waves and rolled them about, but he
+went as near as he could to the water’s brink, and said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What would she have now?’ said the fish. ‘Ah!’ said the fisherman,
+‘she wants to be emperor.’ ‘Go home,’ said the fish; ‘she is emperor
+already.’
+
+So he went home again; and as he came near he saw his wife Ilsabill
+sitting on a very lofty throne made of solid gold, with a great crown on
+her head full two yards high; and on each side of her stood her guards
+and attendants in a row, each one smaller than the other, from the
+tallest giant down to a little dwarf no bigger than my finger. And
+before her stood princes, and dukes, and earls: and the fisherman went
+up to her and said, ‘Wife, are you emperor?’ ‘Yes,’ said she, ‘I am
+emperor.’ ‘Ah!’ said the man, as he gazed upon her, ‘what a fine thing
+it is to be emperor!’ ‘Husband,’ said she, ‘why should we stop at being
+emperor? I will be pope next.’ ‘O wife, wife!’ said he, ‘how can you be
+pope? there is but one pope at a time in Christendom.’ ‘Husband,’ said
+she, ‘I will be pope this very day.’ ‘But,’ replied the husband, ‘the
+fish cannot make you pope.’ ‘What nonsense!’ said she; ‘if he can make
+an emperor, he can make a pope: go and try him.’
+
+So the fisherman went. But when he came to the shore the wind was raging
+and the sea was tossed up and down in boiling waves, and the ships were
+in trouble, and rolled fearfully upon the tops of the billows. In the
+middle of the heavens there was a little piece of blue sky, but towards
+the south all was red, as if a dreadful storm was rising. At this sight
+the fisherman was dreadfully frightened, and he trembled so that his
+knees knocked together: but still he went down near to the shore, and
+said:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said the fisherman, ‘my
+wife wants to be pope.’ ‘Go home,’ said the fish; ‘she is pope already.’
+
+Then the fisherman went home, and found Ilsabill sitting on a throne
+that was two miles high. And she had three great crowns on her head, and
+around her stood all the pomp and power of the Church. And on each side
+of her were two rows of burning lights, of all sizes, the greatest as
+large as the highest and biggest tower in the world, and the least no
+larger than a small rushlight. ‘Wife,’ said the fisherman, as he looked
+at all this greatness, ‘are you pope?’ ‘Yes,’ said she, ‘I am pope.’
+‘Well, wife,’ replied he, ‘it is a grand thing to be pope; and now
+you must be easy, for you can be nothing greater.’ ‘I will think about
+that,’ said the wife. Then they went to bed: but Dame Ilsabill could not
+sleep all night for thinking what she should be next. At last, as she
+was dropping asleep, morning broke, and the sun rose. ‘Ha!’ thought she,
+as she woke up and looked at it through the window, ‘after all I cannot
+prevent the sun rising.’ At this thought she was very angry, and wakened
+her husband, and said, ‘Husband, go to the fish and tell him I must
+be lord of the sun and moon.’ The fisherman was half asleep, but the
+thought frightened him so much that he started and fell out of bed.
+‘Alas, wife!’ said he, ‘cannot you be easy with being pope?’ ‘No,’
+said she, ‘I am very uneasy as long as the sun and moon rise without my
+leave. Go to the fish at once!’
+
+Then the man went shivering with fear; and as he was going down to
+the shore a dreadful storm arose, so that the trees and the very rocks
+shook. And all the heavens became black with stormy clouds, and the
+lightnings played, and the thunders rolled; and you might have seen in
+the sea great black waves, swelling up like mountains with crowns of
+white foam upon their heads. And the fisherman crept towards the sea,
+and cried out, as well as he could:
+
+ ‘O man of the sea!
+  Hearken to me!
+  My wife Ilsabill
+  Will have her own will,
+  And hath sent me to beg a boon of thee!’
+
+‘What does she want now?’ said the fish. ‘Ah!’ said he, ‘she wants to
+be lord of the sun and moon.’ ‘Go home,’ said the fish, ‘to your pigsty
+again.’
+
+And there they live to this very day.
+
+
+
+
+THE WILLOW-WREN AND THE BEAR
+
+Once in summer-time the bear and the wolf were walking in the forest,
+and the bear heard a bird singing so beautifully that he said: ‘Brother
+wolf, what bird is it that sings so well?’ ‘That is the King of birds,’
+said the wolf, ‘before whom we must bow down.’ In reality the bird was
+the willow-wren. ‘IF that’s the case,’ said the bear, ‘I should very
+much like to see his royal palace; come, take me thither.’ ‘That is not
+done quite as you seem to think,’ said the wolf; ‘you must wait until
+the Queen comes,’ Soon afterwards, the Queen arrived with some food in
+her beak, and the lord King came too, and they began to feed their young
+ones. The bear would have liked to go at once, but the wolf held him
+back by the sleeve, and said: ‘No, you must wait until the lord and lady
+Queen have gone away again.’ So they took stock of the hole where the
+nest lay, and trotted away. The bear, however, could not rest until he
+had seen the royal palace, and when a short time had passed, went to it
+again. The King and Queen had just flown out, so he peeped in and saw
+five or six young ones lying there. ‘Is that the royal palace?’ cried
+the bear; ‘it is a wretched palace, and you are not King’s children, you
+are disreputable children!’ When the young wrens heard that, they were
+frightfully angry, and screamed: ‘No, that we are not! Our parents are
+honest people! Bear, you will have to pay for that!’
+
+The bear and the wolf grew uneasy, and turned back and went into their
+holes. The young willow-wrens, however, continued to cry and scream, and
+when their parents again brought food they said: ‘We will not so much as
+touch one fly’s leg, no, not if we were dying of hunger, until you have
+settled whether we are respectable children or not; the bear has been
+here and has insulted us!’ Then the old King said: ‘Be easy, he shall
+be punished,’ and he at once flew with the Queen to the bear’s cave, and
+called in: ‘Old Growler, why have you insulted my children? You shall
+suffer for it--we will punish you by a bloody war.’ Thus war was
+announced to the Bear, and all four-footed animals were summoned to take
+part in it, oxen, asses, cows, deer, and every other animal the earth
+contained. And the willow-wren summoned everything which flew in the
+air, not only birds, large and small, but midges, and hornets, bees and
+flies had to come.
+
+When the time came for the war to begin, the willow-wren sent out spies
+to discover who was the enemy’s commander-in-chief. The gnat, who was
+the most crafty, flew into the forest where the enemy was assembled,
+and hid herself beneath a leaf of the tree where the password was to be
+announced. There stood the bear, and he called the fox before him
+and said: ‘Fox, you are the most cunning of all animals, you shall be
+general and lead us.’ ‘Good,’ said the fox, ‘but what signal shall we
+agree upon?’ No one knew that, so the fox said: ‘I have a fine long
+bushy tail, which almost looks like a plume of red feathers. When I lift
+my tail up quite high, all is going well, and you must charge; but if I
+let it hang down, run away as fast as you can.’ When the gnat had heard
+that, she flew away again, and revealed everything, down to the minutest
+detail, to the willow-wren. When day broke, and the battle was to begin,
+all the four-footed animals came running up with such a noise that the
+earth trembled. The willow-wren with his army also came flying through
+the air with such a humming, and whirring, and swarming that every one
+was uneasy and afraid, and on both sides they advanced against each
+other. But the willow-wren sent down the hornet, with orders to settle
+beneath the fox’s tail, and sting with all his might. When the fox felt
+the first string, he started so that he lifted one leg, from pain, but
+he bore it, and still kept his tail high in the air; at the second
+sting, he was forced to put it down for a moment; at the third, he could
+hold out no longer, screamed, and put his tail between his legs. When
+the animals saw that, they thought all was lost, and began to flee, each
+into his hole, and the birds had won the battle.
+
+Then the King and Queen flew home to their children and cried:
+‘Children, rejoice, eat and drink to your heart’s content, we have won
+the battle!’ But the young wrens said: ‘We will not eat yet, the bear
+must come to the nest, and beg for pardon and say that we are honourable
+children, before we will do that.’ Then the willow-wren flew to the
+bear’s hole and cried: ‘Growler, you are to come to the nest to my
+children, and beg their pardon, or else every rib of your body shall
+be broken.’ So the bear crept thither in the greatest fear, and begged
+their pardon. And now at last the young wrens were satisfied, and sat
+down together and ate and drank, and made merry till quite late into the
+night.
+
+
+
+
+THE FROG-PRINCE
+
+One fine evening a young princess put on her bonnet and clogs, and went
+out to take a walk by herself in a wood; and when she came to a cool
+spring of water, that rose in the midst of it, she sat herself down
+to rest a while. Now she had a golden ball in her hand, which was her
+favourite plaything; and she was always tossing it up into the air, and
+catching it again as it fell. After a time she threw it up so high that
+she missed catching it as it fell; and the ball bounded away, and rolled
+along upon the ground, till at last it fell down into the spring. The
+princess looked into the spring after her ball, but it was very deep, so
+deep that she could not see the bottom of it. Then she began to bewail
+her loss, and said, ‘Alas! if I could only get my ball again, I would
+give all my fine clothes and jewels, and everything that I have in the
+world.’
+
+Whilst she was speaking, a frog put its head out of the water, and said,
+‘Princess, why do you weep so bitterly?’ ‘Alas!’ said she, ‘what can you
+do for me, you nasty frog? My golden ball has fallen into the spring.’
+The frog said, ‘I want not your pearls, and jewels, and fine clothes;
+but if you will love me, and let me live with you and eat from off
+your golden plate, and sleep upon your bed, I will bring you your ball
+again.’ ‘What nonsense,’ thought the princess, ‘this silly frog is
+talking! He can never even get out of the spring to visit me, though
+he may be able to get my ball for me, and therefore I will tell him he
+shall have what he asks.’ So she said to the frog, ‘Well, if you will
+bring me my ball, I will do all you ask.’ Then the frog put his head
+down, and dived deep under the water; and after a little while he came
+up again, with the ball in his mouth, and threw it on the edge of the
+spring. As soon as the young princess saw her ball, she ran to pick
+it up; and she was so overjoyed to have it in her hand again, that she
+never thought of the frog, but ran home with it as fast as she could.
+The frog called after her, ‘Stay, princess, and take me with you as you
+said,’ But she did not stop to hear a word.
+
+The next day, just as the princess had sat down to dinner, she heard a
+strange noise--tap, tap--plash, plash--as if something was coming up the
+marble staircase: and soon afterwards there was a gentle knock at the
+door, and a little voice cried out and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the princess ran to the door and opened it, and there she saw
+the frog, whom she had quite forgotten. At this sight she was sadly
+frightened, and shutting the door as fast as she could came back to her
+seat. The king, her father, seeing that something had frightened her,
+asked her what was the matter. ‘There is a nasty frog,’ said she, ‘at
+the door, that lifted my ball for me out of the spring this morning: I
+told him that he should live with me here, thinking that he could never
+get out of the spring; but there he is at the door, and he wants to come
+in.’
+
+While she was speaking the frog knocked again at the door, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+Then the king said to the young princess, ‘As you have given your word
+you must keep it; so go and let him in.’ She did so, and the frog hopped
+into the room, and then straight on--tap, tap--plash, plash--from the
+bottom of the room to the top, till he came up close to the table where
+the princess sat. ‘Pray lift me upon chair,’ said he to the princess,
+‘and let me sit next to you.’ As soon as she had done this, the frog
+said, ‘Put your plate nearer to me, that I may eat out of it.’ This
+she did, and when he had eaten as much as he could, he said, ‘Now I am
+tired; carry me upstairs, and put me into your bed.’ And the princess,
+though very unwilling, took him up in her hand, and put him upon the
+pillow of her own bed, where he slept all night long. As soon as it was
+light he jumped up, hopped downstairs, and went out of the house.
+‘Now, then,’ thought the princess, ‘at last he is gone, and I shall be
+troubled with him no more.’
+
+But she was mistaken; for when night came again she heard the same
+tapping at the door; and the frog came once more, and said:
+
+ ‘Open the door, my princess dear,
+  Open the door to thy true love here!
+  And mind the words that thou and I said
+  By the fountain cool, in the greenwood shade.’
+
+And when the princess opened the door the frog came in, and slept upon
+her pillow as before, till the morning broke. And the third night he did
+the same. But when the princess awoke on the following morning she was
+astonished to see, instead of the frog, a handsome prince, gazing on her
+with the most beautiful eyes she had ever seen, and standing at the head
+of her bed.
+
+He told her that he had been enchanted by a spiteful fairy, who had
+changed him into a frog; and that he had been fated so to abide till
+some princess should take him out of the spring, and let him eat from
+her plate, and sleep upon her bed for three nights. ‘You,’ said the
+prince, ‘have broken his cruel charm, and now I have nothing to wish for
+but that you should go with me into my father’s kingdom, where I will
+marry you, and love you as long as you live.’
+
+The young princess, you may be sure, was not long in saying ‘Yes’ to
+all this; and as they spoke a gay coach drove up, with eight beautiful
+horses, decked with plumes of feathers and a golden harness; and behind
+the coach rode the prince’s servant, faithful Heinrich, who had bewailed
+the misfortunes of his dear master during his enchantment so long and so
+bitterly, that his heart had well-nigh burst.
+
+They then took leave of the king, and got into the coach with eight
+horses, and all set out, full of joy and merriment, for the prince’s
+kingdom, which they reached safely; and there they lived happily a great
+many years.
+
+
+
+
+CAT AND MOUSE IN PARTNERSHIP
+
+A certain cat had made the acquaintance of a mouse, and had said so much
+to her about the great love and friendship she felt for her, that at
+length the mouse agreed that they should live and keep house together.
+‘But we must make a provision for winter, or else we shall suffer
+from hunger,’ said the cat; ‘and you, little mouse, cannot venture
+everywhere, or you will be caught in a trap some day.’ The good advice
+was followed, and a pot of fat was bought, but they did not know where
+to put it. At length, after much consideration, the cat said: ‘I know no
+place where it will be better stored up than in the church, for no one
+dares take anything away from there. We will set it beneath the altar,
+and not touch it until we are really in need of it.’ So the pot was
+placed in safety, but it was not long before the cat had a great
+yearning for it, and said to the mouse: ‘I want to tell you something,
+little mouse; my cousin has brought a little son into the world, and has
+asked me to be godmother; he is white with brown spots, and I am to hold
+him over the font at the christening. Let me go out today, and you look
+after the house by yourself.’ ‘Yes, yes,’ answered the mouse, ‘by all
+means go, and if you get anything very good to eat, think of me. I
+should like a drop of sweet red christening wine myself.’ All this,
+however, was untrue; the cat had no cousin, and had not been asked to
+be godmother. She went straight to the church, stole to the pot of fat,
+began to lick at it, and licked the top of the fat off. Then she took a
+walk upon the roofs of the town, looked out for opportunities, and then
+stretched herself in the sun, and licked her lips whenever she thought
+of the pot of fat, and not until it was evening did she return home.
+‘Well, here you are again,’ said the mouse, ‘no doubt you have had a
+merry day.’ ‘All went off well,’ answered the cat. ‘What name did they
+give the child?’ ‘Top off!’ said the cat quite coolly. ‘Top off!’ cried
+the mouse, ‘that is a very odd and uncommon name, is it a usual one in
+your family?’ ‘What does that matter,’ said the cat, ‘it is no worse
+than Crumb-stealer, as your godchildren are called.’
+
+Before long the cat was seized by another fit of yearning. She said to
+the mouse: ‘You must do me a favour, and once more manage the house for
+a day alone. I am again asked to be godmother, and, as the child has a
+white ring round its neck, I cannot refuse.’ The good mouse consented,
+but the cat crept behind the town walls to the church, and devoured
+half the pot of fat. ‘Nothing ever seems so good as what one keeps to
+oneself,’ said she, and was quite satisfied with her day’s work. When
+she went home the mouse inquired: ‘And what was the child christened?’
+‘Half-done,’ answered the cat. ‘Half-done! What are you saying? I
+never heard the name in my life, I’ll wager anything it is not in the
+calendar!’
+
+The cat’s mouth soon began to water for some more licking. ‘All good
+things go in threes,’ said she, ‘I am asked to stand godmother again.
+The child is quite black, only it has white paws, but with that
+exception, it has not a single white hair on its whole body; this only
+happens once every few years, you will let me go, won’t you?’ ‘Top-off!
+Half-done!’ answered the mouse, ‘they are such odd names, they make me
+very thoughtful.’ ‘You sit at home,’ said the cat, ‘in your dark-grey
+fur coat and long tail, and are filled with fancies, that’s because
+you do not go out in the daytime.’ During the cat’s absence the mouse
+cleaned the house, and put it in order, but the greedy cat entirely
+emptied the pot of fat. ‘When everything is eaten up one has some
+peace,’ said she to herself, and well filled and fat she did not return
+home till night. The mouse at once asked what name had been given to
+the third child. ‘It will not please you more than the others,’ said the
+cat. ‘He is called All-gone.’ ‘All-gone,’ cried the mouse ‘that is the
+most suspicious name of all! I have never seen it in print. All-gone;
+what can that mean?’ and she shook her head, curled herself up, and lay
+down to sleep.
+
+From this time forth no one invited the cat to be godmother, but
+when the winter had come and there was no longer anything to be found
+outside, the mouse thought of their provision, and said: ‘Come, cat,
+we will go to our pot of fat which we have stored up for ourselves--we
+shall enjoy that.’ ‘Yes,’ answered the cat, ‘you will enjoy it as much
+as you would enjoy sticking that dainty tongue of yours out of the
+window.’ They set out on their way, but when they arrived, the pot of
+fat certainly was still in its place, but it was empty. ‘Alas!’ said the
+mouse, ‘now I see what has happened, now it comes to light! You are a true
+friend! You have devoured all when you were standing godmother. First
+top off, then half-done, then--’ ‘Will you hold your tongue,’ cried the
+cat, ‘one word more, and I will eat you too.’ ‘All-gone’ was already on
+the poor mouse’s lips; scarcely had she spoken it before the cat sprang
+on her, seized her, and swallowed her down. Verily, that is the way of
+the world.
+
+
+
+
+THE GOOSE-GIRL
+
+The king of a great land died, and left his queen to take care of their
+only child. This child was a daughter, who was very beautiful; and her
+mother loved her dearly, and was very kind to her. And there was a good
+fairy too, who was fond of the princess, and helped her mother to watch
+over her. When she grew up, she was betrothed to a prince who lived a
+great way off; and as the time drew near for her to be married, she
+got ready to set off on her journey to his country. Then the queen her
+mother, packed up a great many costly things; jewels, and gold, and
+silver; trinkets, fine dresses, and in short everything that became a
+royal bride. And she gave her a waiting-maid to ride with her, and give
+her into the bridegroom’s hands; and each had a horse for the journey.
+Now the princess’s horse was the fairy’s gift, and it was called Falada,
+and could speak.
+
+When the time came for them to set out, the fairy went into her
+bed-chamber, and took a little knife, and cut off a lock of her hair,
+and gave it to the princess, and said, ‘Take care of it, dear child; for
+it is a charm that may be of use to you on the road.’ Then they all took
+a sorrowful leave of the princess; and she put the lock of hair into
+her bosom, got upon her horse, and set off on her journey to her
+bridegroom’s kingdom.
+
+One day, as they were riding along by a brook, the princess began to
+feel very thirsty: and she said to her maid, ‘Pray get down, and fetch
+me some water in my golden cup out of yonder brook, for I want to
+drink.’ ‘Nay,’ said the maid, ‘if you are thirsty, get off yourself, and
+stoop down by the water and drink; I shall not be your waiting-maid any
+longer.’ Then she was so thirsty that she got down, and knelt over the
+little brook, and drank; for she was frightened, and dared not bring out
+her golden cup; and she wept and said, ‘Alas! what will become of me?’
+And the lock answered her, and said:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+But the princess was very gentle and meek, so she said nothing to her
+maid’s ill behaviour, but got upon her horse again.
+
+Then all rode farther on their journey, till the day grew so warm, and
+the sun so scorching, that the bride began to feel very thirsty again;
+and at last, when they came to a river, she forgot her maid’s rude
+speech, and said, ‘Pray get down, and fetch me some water to drink in
+my golden cup.’ But the maid answered her, and even spoke more haughtily
+than before: ‘Drink if you will, but I shall not be your waiting-maid.’
+Then the princess was so thirsty that she got off her horse, and lay
+down, and held her head over the running stream, and cried and said,
+‘What will become of me?’ And the lock of hair answered her again:
+
+ ‘Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And as she leaned down to drink, the lock of hair fell from her bosom,
+and floated away with the water. Now she was so frightened that she did
+not see it; but her maid saw it, and was very glad, for she knew the
+charm; and she saw that the poor bride would be in her power, now that
+she had lost the hair. So when the bride had done drinking, and would
+have got upon Falada again, the maid said, ‘I shall ride upon Falada,
+and you may have my horse instead’; so she was forced to give up her
+horse, and soon afterwards to take off her royal clothes and put on her
+maid’s shabby ones.
+
+At last, as they drew near the end of their journey, this treacherous
+servant threatened to kill her mistress if she ever told anyone what had
+happened. But Falada saw it all, and marked it well.
+
+Then the waiting-maid got upon Falada, and the real bride rode upon the
+other horse, and they went on in this way till at last they came to the
+royal court. There was great joy at their coming, and the prince flew to
+meet them, and lifted the maid from her horse, thinking she was the one
+who was to be his wife; and she was led upstairs to the royal chamber;
+but the true princess was told to stay in the court below.
+
+Now the old king happened just then to have nothing else to do; so he
+amused himself by sitting at his kitchen window, looking at what was
+going on; and he saw her in the courtyard. As she looked very pretty,
+and too delicate for a waiting-maid, he went up into the royal chamber
+to ask the bride who it was she had brought with her, that was thus left
+standing in the court below. ‘I brought her with me for the sake of her
+company on the road,’ said she; ‘pray give the girl some work to do,
+that she may not be idle.’ The old king could not for some time think
+of any work for her to do; but at last he said, ‘I have a lad who takes
+care of my geese; she may go and help him.’ Now the name of this lad,
+that the real bride was to help in watching the king’s geese, was
+Curdken.
+
+But the false bride said to the prince, ‘Dear husband, pray do me one
+piece of kindness.’ ‘That I will,’ said the prince. ‘Then tell one of
+your slaughterers to cut off the head of the horse I rode upon, for it
+was very unruly, and plagued me sadly on the road’; but the truth was,
+she was very much afraid lest Falada should some day or other speak, and
+tell all she had done to the princess. She carried her point, and the
+faithful Falada was killed; but when the true princess heard of it, she
+wept, and begged the man to nail up Falada’s head against a large
+dark gate of the city, through which she had to pass every morning
+and evening, that there she might still see him sometimes. Then the
+slaughterer said he would do as she wished; and cut off the head, and
+nailed it up under the dark gate.
+
+Early the next morning, as she and Curdken went out through the gate,
+she said sorrowfully:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then they went out of the city, and drove the geese on. And when she
+came to the meadow, she sat down upon a bank there, and let down her
+waving locks of hair, which were all of pure silver; and when Curdken
+saw it glitter in the sun, he ran up, and would have pulled some of the
+locks out, but she cried:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then there came a wind, so strong that it blew off Curdken’s hat; and
+away it flew over the hills: and he was forced to turn and run after
+it; till, by the time he came back, she had done combing and curling her
+hair, and had put it up again safe. Then he was very angry and sulky,
+and would not speak to her at all; but they watched the geese until it
+grew dark in the evening, and then drove them homewards.
+
+The next morning, as they were going through the dark gate, the poor
+girl looked up at Falada’s head, and cried:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answered:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+Then she drove on the geese, and sat down again in the meadow, and began
+to comb out her hair as before; and Curdken ran up to her, and wanted to
+take hold of it; but she cried out quickly:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+Then the wind came and blew away his hat; and off it flew a great way,
+over the hills and far away, so that he had to run after it; and when
+he came back she had bound up her hair again, and all was safe. So they
+watched the geese till it grew dark.
+
+In the evening, after they came home, Curdken went to the old king, and
+said, ‘I cannot have that strange girl to help me to keep the geese any
+longer.’ ‘Why?’ said the king. ‘Because, instead of doing any good, she
+does nothing but tease me all day long.’ Then the king made him tell him
+what had happened. And Curdken said, ‘When we go in the morning through
+the dark gate with our flock of geese, she cries and talks with the head
+of a horse that hangs upon the wall, and says:
+
+ ‘Falada, Falada, there thou hangest!’
+
+and the head answers:
+
+ ‘Bride, bride, there thou gangest!
+  Alas! alas! if thy mother knew it,
+  Sadly, sadly, would she rue it.’
+
+And Curdken went on telling the king what had happened upon the meadow
+where the geese fed; how his hat was blown away; and how he was forced
+to run after it, and to leave his flock of geese to themselves. But the
+old king told the boy to go out again the next day: and when morning
+came, he placed himself behind the dark gate, and heard how she spoke
+to Falada, and how Falada answered. Then he went into the field, and
+hid himself in a bush by the meadow’s side; and he soon saw with his own
+eyes how they drove the flock of geese; and how, after a little time,
+she let down her hair that glittered in the sun. And then he heard her
+say:
+
+ ‘Blow, breezes, blow!
+  Let Curdken’s hat go!
+  Blow, breezes, blow!
+  Let him after it go!
+  O’er hills, dales, and rocks,
+  Away be it whirl’d
+  Till the silvery locks
+  Are all comb’d and curl’d!
+
+And soon came a gale of wind, and carried away Curdken’s hat, and away
+went Curdken after it, while the girl went on combing and curling her
+hair. All this the old king saw: so he went home without being seen; and
+when the little goose-girl came back in the evening he called her aside,
+and asked her why she did so: but she burst into tears, and said, ‘That
+I must not tell you or any man, or I shall lose my life.’
+
+But the old king begged so hard, that she had no peace till she had told
+him all the tale, from beginning to end, word for word. And it was very
+lucky for her that she did so, for when she had done the king ordered
+royal clothes to be put upon her, and gazed on her with wonder, she was
+so beautiful. Then he called his son and told him that he had only a
+false bride; for that she was merely a waiting-maid, while the true
+bride stood by. And the young king rejoiced when he saw her beauty, and
+heard how meek and patient she had been; and without saying anything to
+the false bride, the king ordered a great feast to be got ready for all
+his court. The bridegroom sat at the top, with the false princess on one
+side, and the true one on the other; but nobody knew her again, for her
+beauty was quite dazzling to their eyes; and she did not seem at all
+like the little goose-girl, now that she had her brilliant dress on.
+
+When they had eaten and drank, and were very merry, the old king said
+he would tell them a tale. So he began, and told all the story of the
+princess, as if it was one that he had once heard; and he asked the
+true waiting-maid what she thought ought to be done to anyone who would
+behave thus. ‘Nothing better,’ said this false bride, ‘than that she
+should be thrown into a cask stuck round with sharp nails, and that
+two white horses should be put to it, and should drag it from street to
+street till she was dead.’ ‘Thou art she!’ said the old king; ‘and as
+thou has judged thyself, so shall it be done to thee.’ And the young
+king was then married to his true wife, and they reigned over the
+kingdom in peace and happiness all their lives; and the good fairy came
+to see them, and restored the faithful Falada to life again.
+
+
+
+
+THE ADVENTURES OF CHANTICLEER AND PARTLET
+
+
+1. HOW THEY WENT TO THE MOUNTAINS TO EAT NUTS
+
+‘The nuts are quite ripe now,’ said Chanticleer to his wife Partlet,
+‘suppose we go together to the mountains, and eat as many as we can,
+before the squirrel takes them all away.’ ‘With all my heart,’ said
+Partlet, ‘let us go and make a holiday of it together.’
+
+So they went to the mountains; and as it was a lovely day, they stayed
+there till the evening. Now, whether it was that they had eaten so many
+nuts that they could not walk, or whether they were lazy and would not,
+I do not know: however, they took it into their heads that it did not
+become them to go home on foot. So Chanticleer began to build a little
+carriage of nutshells: and when it was finished, Partlet jumped into
+it and sat down, and bid Chanticleer harness himself to it and draw her
+home. ‘That’s a good joke!’ said Chanticleer; ‘no, that will never do;
+I had rather by half walk home; I’ll sit on the box and be coachman,
+if you like, but I’ll not draw.’ While this was passing, a duck came
+quacking up and cried out, ‘You thieving vagabonds, what business have
+you in my grounds? I’ll give it you well for your insolence!’ and upon
+that she fell upon Chanticleer most lustily. But Chanticleer was no
+coward, and returned the duck’s blows with his sharp spurs so fiercely
+that she soon began to cry out for mercy; which was only granted her
+upon condition that she would draw the carriage home for them. This she
+agreed to do; and Chanticleer got upon the box, and drove, crying, ‘Now,
+duck, get on as fast as you can.’ And away they went at a pretty good
+pace.
+
+After they had travelled along a little way, they met a needle and a pin
+walking together along the road: and the needle cried out, ‘Stop, stop!’
+and said it was so dark that they could hardly find their way, and such
+dirty walking they could not get on at all: he told them that he and his
+friend, the pin, had been at a public-house a few miles off, and had sat
+drinking till they had forgotten how late it was; he begged therefore
+that the travellers would be so kind as to give them a lift in their
+carriage. Chanticleer observing that they were but thin fellows, and not
+likely to take up much room, told them they might ride, but made them
+promise not to dirty the wheels of the carriage in getting in, nor to
+tread on Partlet’s toes.
+
+Late at night they arrived at an inn; and as it was bad travelling in
+the dark, and the duck seemed much tired, and waddled about a good
+deal from one side to the other, they made up their minds to fix their
+quarters there: but the landlord at first was unwilling, and said his
+house was full, thinking they might not be very respectable company:
+however, they spoke civilly to him, and gave him the egg which Partlet
+had laid by the way, and said they would give him the duck, who was in
+the habit of laying one every day: so at last he let them come in, and
+they bespoke a handsome supper, and spent the evening very jollily.
+
+Early in the morning, before it was quite light, and when nobody was
+stirring in the inn, Chanticleer awakened his wife, and, fetching the
+egg, they pecked a hole in it, ate it up, and threw the shells into the
+fireplace: they then went to the pin and needle, who were fast asleep,
+and seizing them by the heads, stuck one into the landlord’s easy chair
+and the other into his handkerchief; and, having done this, they crept
+away as softly as possible. However, the duck, who slept in the open
+air in the yard, heard them coming, and jumping into the brook which ran
+close by the inn, soon swam out of their reach.
+
+An hour or two afterwards the landlord got up, and took his handkerchief
+to wipe his face, but the pin ran into him and pricked him: then he
+walked into the kitchen to light his pipe at the fire, but when he
+stirred it up the eggshells flew into his eyes, and almost blinded him.
+‘Bless me!’ said he, ‘all the world seems to have a design against my
+head this morning’: and so saying, he threw himself sulkily into his
+easy chair; but, oh dear! the needle ran into him; and this time the
+pain was not in his head. He now flew into a very great passion, and,
+suspecting the company who had come in the night before, he went to look
+after them, but they were all off; so he swore that he never again
+would take in such a troop of vagabonds, who ate a great deal, paid no
+reckoning, and gave him nothing for his trouble but their apish tricks.
+
+
+2. HOW CHANTICLEER AND PARTLET WENT TO VISIT MR KORBES
+
+Another day, Chanticleer and Partlet wished to ride out together;
+so Chanticleer built a handsome carriage with four red wheels, and
+harnessed six mice to it; and then he and Partlet got into the carriage,
+and away they drove. Soon afterwards a cat met them, and said, ‘Where
+are you going?’ And Chanticleer replied,
+
+ ‘All on our way
+  A visit to pay
+  To Mr Korbes, the fox, today.’
+
+Then the cat said, ‘Take me with you,’ Chanticleer said, ‘With all my
+heart: get up behind, and be sure you do not fall off.’
+
+ ‘Take care of this handsome coach of mine,
+  Nor dirty my pretty red wheels so fine!
+  Now, mice, be ready,
+  And, wheels, run steady!
+  For we are going a visit to pay
+  To Mr Korbes, the fox, today.’
+
+Soon after came up a millstone, an egg, a duck, and a pin; and
+Chanticleer gave them all leave to get into the carriage and go with
+them.
+
+When they arrived at Mr Korbes’s house, he was not at home; so the mice
+drew the carriage into the coach-house, Chanticleer and Partlet flew
+upon a beam, the cat sat down in the fireplace, the duck got into
+the washing cistern, the pin stuck himself into the bed pillow, the
+millstone laid himself over the house door, and the egg rolled himself
+up in the towel.
+
+When Mr Korbes came home, he went to the fireplace to make a fire; but
+the cat threw all the ashes in his eyes: so he ran to the kitchen to
+wash himself; but there the duck splashed all the water in his face; and
+when he tried to wipe himself, the egg broke to pieces in the towel all
+over his face and eyes. Then he was very angry, and went without his
+supper to bed; but when he laid his head on the pillow, the pin ran into
+his cheek: at this he became quite furious, and, jumping up, would have
+run out of the house; but when he came to the door, the millstone fell
+down on his head, and killed him on the spot.
+
+
+3. HOW PARTLET DIED AND WAS BURIED, AND HOW CHANTICLEER DIED OF GRIEF
+
+Another day Chanticleer and Partlet agreed to go again to the mountains
+to eat nuts; and it was settled that all the nuts which they found
+should be shared equally between them. Now Partlet found a very large
+nut; but she said nothing about it to Chanticleer, and kept it all to
+herself: however, it was so big that she could not swallow it, and it
+stuck in her throat. Then she was in a great fright, and cried out to
+Chanticleer, ‘Pray run as fast as you can, and fetch me some water, or I
+shall be choked.’ Chanticleer ran as fast as he could to the river, and
+said, ‘River, give me some water, for Partlet lies in the mountain, and
+will be choked by a great nut.’ The river said, ‘Run first to the bride,
+and ask her for a silken cord to draw up the water.’ Chanticleer ran to
+the bride, and said, ‘Bride, you must give me a silken cord, for then
+the river will give me water, and the water I will carry to Partlet, who
+lies on the mountain, and will be choked by a great nut.’ But the bride
+said, ‘Run first, and bring me my garland that is hanging on a willow
+in the garden.’ Then Chanticleer ran to the garden, and took the garland
+from the bough where it hung, and brought it to the bride; and then
+the bride gave him the silken cord, and he took the silken cord to
+the river, and the river gave him water, and he carried the water to
+Partlet; but in the meantime she was choked by the great nut, and lay
+quite dead, and never moved any more.
+
+Then Chanticleer was very sorry, and cried bitterly; and all the beasts
+came and wept with him over poor Partlet. And six mice built a little
+hearse to carry her to her grave; and when it was ready they harnessed
+themselves before it, and Chanticleer drove them. On the way they
+met the fox. ‘Where are you going, Chanticleer?’ said he. ‘To bury my
+Partlet,’ said the other. ‘May I go with you?’ said the fox. ‘Yes; but
+you must get up behind, or my horses will not be able to draw you.’ Then
+the fox got up behind; and presently the wolf, the bear, the goat, and
+all the beasts of the wood, came and climbed upon the hearse.
+
+So on they went till they came to a rapid stream. ‘How shall we get
+over?’ said Chanticleer. Then said a straw, ‘I will lay myself across,
+and you may pass over upon me.’ But as the mice were going over, the
+straw slipped away and fell into the water, and the six mice all fell in
+and were drowned. What was to be done? Then a large log of wood came
+and said, ‘I am big enough; I will lay myself across the stream, and you
+shall pass over upon me.’ So he laid himself down; but they managed
+so clumsily, that the log of wood fell in and was carried away by the
+stream. Then a stone, who saw what had happened, came up and kindly
+offered to help poor Chanticleer by laying himself across the stream;
+and this time he got safely to the other side with the hearse, and
+managed to get Partlet out of it; but the fox and the other mourners,
+who were sitting behind, were too heavy, and fell back into the water
+and were all carried away by the stream and drowned.
+
+Thus Chanticleer was left alone with his dead Partlet; and having dug
+a grave for her, he laid her in it, and made a little hillock over her.
+Then he sat down by the grave, and wept and mourned, till at last he
+died too; and so all were dead.
+
+
+
+
+RAPUNZEL
+
+There were once a man and a woman who had long in vain wished for a
+child. At length the woman hoped that God was about to grant her desire.
+These people had a little window at the back of their house from which
+a splendid garden could be seen, which was full of the most beautiful
+flowers and herbs. It was, however, surrounded by a high wall, and no
+one dared to go into it because it belonged to an enchantress, who had
+great power and was dreaded by all the world. One day the woman was
+standing by this window and looking down into the garden, when she saw a
+bed which was planted with the most beautiful rampion (rapunzel), and it
+looked so fresh and green that she longed for it, she quite pined away,
+and began to look pale and miserable. Then her husband was alarmed, and
+asked: ‘What ails you, dear wife?’ ‘Ah,’ she replied, ‘if I can’t eat
+some of the rampion, which is in the garden behind our house, I shall
+die.’ The man, who loved her, thought: ‘Sooner than let your wife die,
+bring her some of the rampion yourself, let it cost what it will.’
+At twilight, he clambered down over the wall into the garden of the
+enchantress, hastily clutched a handful of rampion, and took it to his
+wife. She at once made herself a salad of it, and ate it greedily. It
+tasted so good to her--so very good, that the next day she longed for it
+three times as much as before. If he was to have any rest, her husband
+must once more descend into the garden. In the gloom of evening
+therefore, he let himself down again; but when he had clambered down the
+wall he was terribly afraid, for he saw the enchantress standing before
+him. ‘How can you dare,’ said she with angry look, ‘descend into my
+garden and steal my rampion like a thief? You shall suffer for it!’
+‘Ah,’ answered he, ‘let mercy take the place of justice, I only made
+up my mind to do it out of necessity. My wife saw your rampion from the
+window, and felt such a longing for it that she would have died if she
+had not got some to eat.’ Then the enchantress allowed her anger to be
+softened, and said to him: ‘If the case be as you say, I will allow
+you to take away with you as much rampion as you will, only I make one
+condition, you must give me the child which your wife will bring into
+the world; it shall be well treated, and I will care for it like a
+mother.’ The man in his terror consented to everything, and when the
+woman was brought to bed, the enchantress appeared at once, gave the
+child the name of Rapunzel, and took it away with her.
+
+Rapunzel grew into the most beautiful child under the sun. When she was
+twelve years old, the enchantress shut her into a tower, which lay in
+a forest, and had neither stairs nor door, but quite at the top was a
+little window. When the enchantress wanted to go in, she placed herself
+beneath it and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Rapunzel had magnificent long hair, fine as spun gold, and when she
+heard the voice of the enchantress she unfastened her braided tresses,
+wound them round one of the hooks of the window above, and then the hair
+fell twenty ells down, and the enchantress climbed up by it.
+
+After a year or two, it came to pass that the king’s son rode through
+the forest and passed by the tower. Then he heard a song, which was so
+charming that he stood still and listened. This was Rapunzel, who in her
+solitude passed her time in letting her sweet voice resound. The king’s
+son wanted to climb up to her, and looked for the door of the tower,
+but none was to be found. He rode home, but the singing had so deeply
+touched his heart, that every day he went out into the forest and
+listened to it. Once when he was thus standing behind a tree, he saw
+that an enchantress came there, and he heard how she cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Then Rapunzel let down the braids of her hair, and the enchantress
+climbed up to her. ‘If that is the ladder by which one mounts, I too
+will try my fortune,’ said he, and the next day when it began to grow
+dark, he went to the tower and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+Immediately the hair fell down and the king’s son climbed up.
+
+At first Rapunzel was terribly frightened when a man, such as her eyes
+had never yet beheld, came to her; but the king’s son began to talk to
+her quite like a friend, and told her that his heart had been so stirred
+that it had let him have no rest, and he had been forced to see her.
+Then Rapunzel lost her fear, and when he asked her if she would take
+him for her husband, and she saw that he was young and handsome, she
+thought: ‘He will love me more than old Dame Gothel does’; and she said
+yes, and laid her hand in his. She said: ‘I will willingly go away with
+you, but I do not know how to get down. Bring with you a skein of silk
+every time that you come, and I will weave a ladder with it, and when
+that is ready I will descend, and you will take me on your horse.’ They
+agreed that until that time he should come to her every evening, for the
+old woman came by day. The enchantress remarked nothing of this, until
+once Rapunzel said to her: ‘Tell me, Dame Gothel, how it happens that
+you are so much heavier for me to draw up than the young king’s son--he
+is with me in a moment.’ ‘Ah! you wicked child,’ cried the enchantress.
+‘What do I hear you say! I thought I had separated you from all
+the world, and yet you have deceived me!’ In her anger she clutched
+Rapunzel’s beautiful tresses, wrapped them twice round her left hand,
+seized a pair of scissors with the right, and snip, snap, they were cut
+off, and the lovely braids lay on the ground. And she was so pitiless
+that she took poor Rapunzel into a desert where she had to live in great
+grief and misery.
+
+On the same day that she cast out Rapunzel, however, the enchantress
+fastened the braids of hair, which she had cut off, to the hook of the
+window, and when the king’s son came and cried:
+
+ ‘Rapunzel, Rapunzel,
+  Let down your hair to me.’
+
+she let the hair down. The king’s son ascended, but instead of finding
+his dearest Rapunzel, he found the enchantress, who gazed at him with
+wicked and venomous looks. ‘Aha!’ she cried mockingly, ‘you would fetch
+your dearest, but the beautiful bird sits no longer singing in the nest;
+the cat has got it, and will scratch out your eyes as well. Rapunzel is
+lost to you; you will never see her again.’ The king’s son was beside
+himself with pain, and in his despair he leapt down from the tower. He
+escaped with his life, but the thorns into which he fell pierced his
+eyes. Then he wandered quite blind about the forest, ate nothing but
+roots and berries, and did naught but lament and weep over the loss of
+his dearest wife. Thus he roamed about in misery for some years, and at
+length came to the desert where Rapunzel, with the twins to which she
+had given birth, a boy and a girl, lived in wretchedness. He heard a
+voice, and it seemed so familiar to him that he went towards it, and
+when he approached, Rapunzel knew him and fell on his neck and wept. Two
+of her tears wetted his eyes and they grew clear again, and he could
+see with them as before. He led her to his kingdom where he was
+joyfully received, and they lived for a long time afterwards, happy and
+contented.
+
+
+
+
+FUNDEVOGEL
+
+There was once a forester who went into the forest to hunt, and as
+he entered it he heard a sound of screaming as if a little child were
+there. He followed the sound, and at last came to a high tree, and at
+the top of this a little child was sitting, for the mother had fallen
+asleep under the tree with the child, and a bird of prey had seen it in
+her arms, had flown down, snatched it away, and set it on the high tree.
+
+The forester climbed up, brought the child down, and thought to himself:
+‘You will take him home with you, and bring him up with your Lina.’ He
+took it home, therefore, and the two children grew up together. And the
+one, which he had found on a tree was called Fundevogel, because a bird
+had carried it away. Fundevogel and Lina loved each other so dearly that
+when they did not see each other they were sad.
+
+Now the forester had an old cook, who one evening took two pails and
+began to fetch water, and did not go once only, but many times, out
+to the spring. Lina saw this and said, ‘Listen, old Sanna, why are you
+fetching so much water?’ ‘If you will never repeat it to anyone, I will
+tell you why.’ So Lina said, no, she would never repeat it to anyone,
+and then the cook said: ‘Early tomorrow morning, when the forester
+is out hunting, I will heat the water, and when it is boiling in the
+kettle, I will throw in Fundevogel, and will boil him in it.’
+
+Early next morning the forester got up and went out hunting, and when he
+was gone the children were still in bed. Then Lina said to Fundevogel:
+‘If you will never leave me, I too will never leave you.’ Fundevogel
+said: ‘Neither now, nor ever will I leave you.’ Then said Lina: ‘Then
+will I tell you. Last night, old Sanna carried so many buckets of water
+into the house that I asked her why she was doing that, and she said
+that if I would promise not to tell anyone, and she said that early
+tomorrow morning when father was out hunting, she would set the kettle
+full of water, throw you into it and boil you; but we will get up
+quickly, dress ourselves, and go away together.’
+
+The two children therefore got up, dressed themselves quickly, and went
+away. When the water in the kettle was boiling, the cook went into the
+bedroom to fetch Fundevogel and throw him into it. But when she came in,
+and went to the beds, both the children were gone. Then she was terribly
+alarmed, and she said to herself: ‘What shall I say now when the
+forester comes home and sees that the children are gone? They must be
+followed instantly to get them back again.’
+
+Then the cook sent three servants after them, who were to run and
+overtake the children. The children, however, were sitting outside the
+forest, and when they saw from afar the three servants running, Lina
+said to Fundevogel: ‘Never leave me, and I will never leave you.’
+Fundevogel said: ‘Neither now, nor ever.’ Then said Lina: ‘Do you become
+a rose-tree, and I the rose upon it.’ When the three servants came to
+the forest, nothing was there but a rose-tree and one rose on it, but
+the children were nowhere. Then said they: ‘There is nothing to be done
+here,’ and they went home and told the cook that they had seen nothing
+in the forest but a little rose-bush with one rose on it. Then the
+old cook scolded and said: ‘You simpletons, you should have cut the
+rose-bush in two, and have broken off the rose and brought it home with
+you; go, and do it at once.’ They had therefore to go out and look for
+the second time. The children, however, saw them coming from a distance.
+Then Lina said: ‘Fundevogel, never leave me, and I will never leave
+you.’ Fundevogel said: ‘Neither now; nor ever.’ Said Lina: ‘Then do you
+become a church, and I’ll be the chandelier in it.’ So when the three
+servants came, nothing was there but a church, with a chandelier in
+it. They said therefore to each other: ‘What can we do here, let us go
+home.’ When they got home, the cook asked if they had not found them;
+so they said no, they had found nothing but a church, and there was a
+chandelier in it. And the cook scolded them and said: ‘You fools! why
+did you not pull the church to pieces, and bring the chandelier home
+with you?’ And now the old cook herself got on her legs, and went with
+the three servants in pursuit of the children. The children, however,
+saw from afar that the three servants were coming, and the cook waddling
+after them. Then said Lina: ‘Fundevogel, never leave me, and I will
+never leave you.’ Then said Fundevogel: ‘Neither now, nor ever.’
+Said Lina: ‘Be a fishpond, and I will be the duck upon it.’ The cook,
+however, came up to them, and when she saw the pond she lay down by it,
+and was about to drink it up. But the duck swam quickly to her, seized
+her head in its beak and drew her into the water, and there the old
+witch had to drown. Then the children went home together, and were
+heartily delighted, and if they have not died, they are living still.
+
+
+
+
+THE VALIANT LITTLE TAILOR
+
+One summer’s morning a little tailor was sitting on his table by the
+window; he was in good spirits, and sewed with all his might. Then came
+a peasant woman down the street crying: ‘Good jams, cheap! Good jams,
+cheap!’ This rang pleasantly in the tailor’s ears; he stretched his
+delicate head out of the window, and called: ‘Come up here, dear woman;
+here you will get rid of your goods.’ The woman came up the three steps
+to the tailor with her heavy basket, and he made her unpack all the pots
+for him. He inspected each one, lifted it up, put his nose to it, and
+at length said: ‘The jam seems to me to be good, so weigh me out four
+ounces, dear woman, and if it is a quarter of a pound that is of no
+consequence.’ The woman who had hoped to find a good sale, gave him
+what he desired, but went away quite angry and grumbling. ‘Now, this jam
+shall be blessed by God,’ cried the little tailor, ‘and give me health
+and strength’; so he brought the bread out of the cupboard, cut himself
+a piece right across the loaf and spread the jam over it. ‘This won’t
+taste bitter,’ said he, ‘but I will just finish the jacket before I
+take a bite.’ He laid the bread near him, sewed on, and in his joy, made
+bigger and bigger stitches. In the meantime the smell of the sweet jam
+rose to where the flies were sitting in great numbers, and they were
+attracted and descended on it in hosts. ‘Hi! who invited you?’ said the
+little tailor, and drove the unbidden guests away. The flies, however,
+who understood no German, would not be turned away, but came back
+again in ever-increasing companies. The little tailor at last lost all
+patience, and drew a piece of cloth from the hole under his work-table,
+and saying: ‘Wait, and I will give it to you,’ struck it mercilessly on
+them. When he drew it away and counted, there lay before him no fewer
+than seven, dead and with legs stretched out. ‘Are you a fellow of that
+sort?’ said he, and could not help admiring his own bravery. ‘The whole
+town shall know of this!’ And the little tailor hastened to cut himself
+a girdle, stitched it, and embroidered on it in large letters: ‘Seven at
+one stroke!’ ‘What, the town!’ he continued, ‘the whole world shall hear
+of it!’ and his heart wagged with joy like a lamb’s tail. The tailor
+put on the girdle, and resolved to go forth into the world, because he
+thought his workshop was too small for his valour. Before he went away,
+he sought about in the house to see if there was anything which he could
+take with him; however, he found nothing but an old cheese, and that
+he put in his pocket. In front of the door he observed a bird which
+had caught itself in the thicket. It had to go into his pocket with the
+cheese. Now he took to the road boldly, and as he was light and nimble,
+he felt no fatigue. The road led him up a mountain, and when he had
+reached the highest point of it, there sat a powerful giant looking
+peacefully about him. The little tailor went bravely up, spoke to him,
+and said: ‘Good day, comrade, so you are sitting there overlooking the
+wide-spread world! I am just on my way thither, and want to try my luck.
+Have you any inclination to go with me?’ The giant looked contemptuously
+at the tailor, and said: ‘You ragamuffin! You miserable creature!’
+
+‘Oh, indeed?’ answered the little tailor, and unbuttoned his coat, and
+showed the giant the girdle, ‘there may you read what kind of a man I
+am!’ The giant read: ‘Seven at one stroke,’ and thought that they had
+been men whom the tailor had killed, and began to feel a little respect
+for the tiny fellow. Nevertheless, he wished to try him first, and took
+a stone in his hand and squeezed it together so that water dropped out
+of it. ‘Do that likewise,’ said the giant, ‘if you have strength.’ ‘Is
+that all?’ said the tailor, ‘that is child’s play with us!’ and put his
+hand into his pocket, brought out the soft cheese, and pressed it until
+the liquid ran out of it. ‘Faith,’ said he, ‘that was a little better,
+wasn’t it?’ The giant did not know what to say, and could not believe it
+of the little man. Then the giant picked up a stone and threw it so high
+that the eye could scarcely follow it. ‘Now, little mite of a man, do
+that likewise,’ ‘Well thrown,’ said the tailor, ‘but after all the stone
+came down to earth again; I will throw you one which shall never come
+back at all,’ and he put his hand into his pocket, took out the bird,
+and threw it into the air. The bird, delighted with its liberty,
+rose, flew away and did not come back. ‘How does that shot please you,
+comrade?’ asked the tailor. ‘You can certainly throw,’ said the giant,
+‘but now we will see if you are able to carry anything properly.’ He
+took the little tailor to a mighty oak tree which lay there felled on
+the ground, and said: ‘If you are strong enough, help me to carry the
+tree out of the forest.’ ‘Readily,’ answered the little man; ‘take you
+the trunk on your shoulders, and I will raise up the branches and twigs;
+after all, they are the heaviest.’ The giant took the trunk on his
+shoulder, but the tailor seated himself on a branch, and the giant, who
+could not look round, had to carry away the whole tree, and the little
+tailor into the bargain: he behind, was quite merry and happy, and
+whistled the song: ‘Three tailors rode forth from the gate,’ as if
+carrying the tree were child’s play. The giant, after he had dragged the
+heavy burden part of the way, could go no further, and cried: ‘Hark
+you, I shall have to let the tree fall!’ The tailor sprang nimbly down,
+seized the tree with both arms as if he had been carrying it, and said
+to the giant: ‘You are such a great fellow, and yet cannot even carry
+the tree!’
+
+They went on together, and as they passed a cherry-tree, the giant laid
+hold of the top of the tree where the ripest fruit was hanging, bent it
+down, gave it into the tailor’s hand, and bade him eat. But the little
+tailor was much too weak to hold the tree, and when the giant let it go,
+it sprang back again, and the tailor was tossed into the air with it.
+When he had fallen down again without injury, the giant said: ‘What is
+this? Have you not strength enough to hold the weak twig?’ ‘There is no
+lack of strength,’ answered the little tailor. ‘Do you think that could
+be anything to a man who has struck down seven at one blow? I leapt over
+the tree because the huntsmen are shooting down there in the thicket.
+Jump as I did, if you can do it.’ The giant made the attempt but he
+could not get over the tree, and remained hanging in the branches, so
+that in this also the tailor kept the upper hand.
+
+The giant said: ‘If you are such a valiant fellow, come with me into our
+cavern and spend the night with us.’ The little tailor was willing, and
+followed him. When they went into the cave, other giants were sitting
+there by the fire, and each of them had a roasted sheep in his hand and
+was eating it. The little tailor looked round and thought: ‘It is much
+more spacious here than in my workshop.’ The giant showed him a bed, and
+said he was to lie down in it and sleep. The bed, however, was too
+big for the little tailor; he did not lie down in it, but crept into
+a corner. When it was midnight, and the giant thought that the little
+tailor was lying in a sound sleep, he got up, took a great iron bar,
+cut through the bed with one blow, and thought he had finished off the
+grasshopper for good. With the earliest dawn the giants went into the
+forest, and had quite forgotten the little tailor, when all at once he
+walked up to them quite merrily and boldly. The giants were terrified,
+they were afraid that he would strike them all dead, and ran away in a
+great hurry.
+
+The little tailor went onwards, always following his own pointed nose.
+After he had walked for a long time, he came to the courtyard of a royal
+palace, and as he felt weary, he lay down on the grass and fell asleep.
+Whilst he lay there, the people came and inspected him on all sides, and
+read on his girdle: ‘Seven at one stroke.’ ‘Ah!’ said they, ‘what does
+the great warrior want here in the midst of peace? He must be a mighty
+lord.’ They went and announced him to the king, and gave it as their
+opinion that if war should break out, this would be a weighty and useful
+man who ought on no account to be allowed to depart. The counsel pleased
+the king, and he sent one of his courtiers to the little tailor to offer
+him military service when he awoke. The ambassador remained standing by
+the sleeper, waited until he stretched his limbs and opened his eyes,
+and then conveyed to him this proposal. ‘For this very reason have
+I come here,’ the tailor replied, ‘I am ready to enter the king’s
+service.’ He was therefore honourably received, and a special dwelling
+was assigned him.
+
+The soldiers, however, were set against the little tailor, and wished
+him a thousand miles away. ‘What is to be the end of this?’ they said
+among themselves. ‘If we quarrel with him, and he strikes about him,
+seven of us will fall at every blow; not one of us can stand against
+him.’ They came therefore to a decision, betook themselves in a body to
+the king, and begged for their dismissal. ‘We are not prepared,’ said
+they, ‘to stay with a man who kills seven at one stroke.’ The king was
+sorry that for the sake of one he should lose all his faithful servants,
+wished that he had never set eyes on the tailor, and would willingly
+have been rid of him again. But he did not venture to give him his
+dismissal, for he dreaded lest he should strike him and all his people
+dead, and place himself on the royal throne. He thought about it for a
+long time, and at last found good counsel. He sent to the little tailor
+and caused him to be informed that as he was a great warrior, he had one
+request to make to him. In a forest of his country lived two giants,
+who caused great mischief with their robbing, murdering, ravaging,
+and burning, and no one could approach them without putting himself in
+danger of death. If the tailor conquered and killed these two giants, he
+would give him his only daughter to wife, and half of his kingdom as a
+dowry, likewise one hundred horsemen should go with him to assist him.
+‘That would indeed be a fine thing for a man like me!’ thought the
+little tailor. ‘One is not offered a beautiful princess and half a
+kingdom every day of one’s life!’ ‘Oh, yes,’ he replied, ‘I will soon
+subdue the giants, and do not require the help of the hundred horsemen
+to do it; he who can hit seven with one blow has no need to be afraid of
+two.’
+
+The little tailor went forth, and the hundred horsemen followed him.
+When he came to the outskirts of the forest, he said to his followers:
+‘Just stay waiting here, I alone will soon finish off the giants.’ Then
+he bounded into the forest and looked about right and left. After a
+while he perceived both giants. They lay sleeping under a tree, and
+snored so that the branches waved up and down. The little tailor, not
+idle, gathered two pocketsful of stones, and with these climbed up the
+tree. When he was halfway up, he slipped down by a branch, until he sat
+just above the sleepers, and then let one stone after another fall on
+the breast of one of the giants. For a long time the giant felt nothing,
+but at last he awoke, pushed his comrade, and said: ‘Why are you
+knocking me?’ ‘You must be dreaming,’ said the other, ‘I am not knocking
+you.’ They laid themselves down to sleep again, and then the tailor
+threw a stone down on the second. ‘What is the meaning of this?’ cried
+the other ‘Why are you pelting me?’ ‘I am not pelting you,’ answered
+the first, growling. They disputed about it for a time, but as they were
+weary they let the matter rest, and their eyes closed once more. The
+little tailor began his game again, picked out the biggest stone, and
+threw it with all his might on the breast of the first giant. ‘That
+is too bad!’ cried he, and sprang up like a madman, and pushed his
+companion against the tree until it shook. The other paid him back in
+the same coin, and they got into such a rage that they tore up trees and
+belaboured each other so long, that at last they both fell down dead on
+the ground at the same time. Then the little tailor leapt down. ‘It is
+a lucky thing,’ said he, ‘that they did not tear up the tree on which
+I was sitting, or I should have had to sprint on to another like a
+squirrel; but we tailors are nimble.’ He drew out his sword and gave
+each of them a couple of thrusts in the breast, and then went out to the
+horsemen and said: ‘The work is done; I have finished both of them
+off, but it was hard work! They tore up trees in their sore need, and
+defended themselves with them, but all that is to no purpose when a man
+like myself comes, who can kill seven at one blow.’ ‘But are you not
+wounded?’ asked the horsemen. ‘You need not concern yourself about
+that,’ answered the tailor, ‘they have not bent one hair of mine.’ The
+horsemen would not believe him, and rode into the forest; there they
+found the giants swimming in their blood, and all round about lay the
+torn-up trees.
+
+The little tailor demanded of the king the promised reward; he, however,
+repented of his promise, and again bethought himself how he could get
+rid of the hero. ‘Before you receive my daughter, and the half of my
+kingdom,’ said he to him, ‘you must perform one more heroic deed. In
+the forest roams a unicorn which does great harm, and you must catch
+it first.’ ‘I fear one unicorn still less than two giants. Seven at one
+blow, is my kind of affair.’ He took a rope and an axe with him, went
+forth into the forest, and again bade those who were sent with him to
+wait outside. He had not long to seek. The unicorn soon came towards
+him, and rushed directly on the tailor, as if it would gore him with its
+horn without more ado. ‘Softly, softly; it can’t be done as quickly as
+that,’ said he, and stood still and waited until the animal was quite
+close, and then sprang nimbly behind the tree. The unicorn ran against
+the tree with all its strength, and stuck its horn so fast in the trunk
+that it had not the strength enough to draw it out again, and thus it
+was caught. ‘Now, I have got the bird,’ said the tailor, and came out
+from behind the tree and put the rope round its neck, and then with his
+axe he hewed the horn out of the tree, and when all was ready he led the
+beast away and took it to the king.
+
+The king still would not give him the promised reward, and made a third
+demand. Before the wedding the tailor was to catch him a wild boar that
+made great havoc in the forest, and the huntsmen should give him their
+help. ‘Willingly,’ said the tailor, ‘that is child’s play!’ He did not
+take the huntsmen with him into the forest, and they were well pleased
+that he did not, for the wild boar had several times received them in
+such a manner that they had no inclination to lie in wait for him. When
+the boar perceived the tailor, it ran on him with foaming mouth and
+whetted tusks, and was about to throw him to the ground, but the hero
+fled and sprang into a chapel which was near and up to the window at
+once, and in one bound out again. The boar ran after him, but the tailor
+ran round outside and shut the door behind it, and then the raging
+beast, which was much too heavy and awkward to leap out of the window,
+was caught. The little tailor called the huntsmen thither that they
+might see the prisoner with their own eyes. The hero, however, went to
+the king, who was now, whether he liked it or not, obliged to keep his
+promise, and gave his daughter and the half of his kingdom. Had he known
+that it was no warlike hero, but a little tailor who was standing before
+him, it would have gone to his heart still more than it did. The wedding
+was held with great magnificence and small joy, and out of a tailor a
+king was made.
+
+After some time the young queen heard her husband say in his dreams at
+night: ‘Boy, make me the doublet, and patch the pantaloons, or else I
+will rap the yard-measure over your ears.’ Then she discovered in what
+state of life the young lord had been born, and next morning complained
+of her wrongs to her father, and begged him to help her to get rid of
+her husband, who was nothing else but a tailor. The king comforted her
+and said: ‘Leave your bedroom door open this night, and my servants
+shall stand outside, and when he has fallen asleep shall go in, bind
+him, and take him on board a ship which shall carry him into the wide
+world.’ The woman was satisfied with this; but the king’s armour-bearer,
+who had heard all, was friendly with the young lord, and informed him of
+the whole plot. ‘I’ll put a screw into that business,’ said the little
+tailor. At night he went to bed with his wife at the usual time, and
+when she thought that he had fallen asleep, she got up, opened the door,
+and then lay down again. The little tailor, who was only pretending to
+be asleep, began to cry out in a clear voice: ‘Boy, make me the doublet
+and patch me the pantaloons, or I will rap the yard-measure over your
+ears. I smote seven at one blow. I killed two giants, I brought away one
+unicorn, and caught a wild boar, and am I to fear those who are standing
+outside the room.’ When these men heard the tailor speaking thus, they
+were overcome by a great dread, and ran as if the wild huntsman were
+behind them, and none of them would venture anything further against
+him. So the little tailor was and remained a king to the end of his
+life.
+
+
+
+
+HANSEL AND GRETEL
+
+Hard by a great forest dwelt a poor wood-cutter with his wife and his
+two children. The boy was called Hansel and the girl Gretel. He had
+little to bite and to break, and once when great dearth fell on the
+land, he could no longer procure even daily bread. Now when he thought
+over this by night in his bed, and tossed about in his anxiety, he
+groaned and said to his wife: ‘What is to become of us? How are we
+to feed our poor children, when we no longer have anything even for
+ourselves?’ ‘I’ll tell you what, husband,’ answered the woman, ‘early
+tomorrow morning we will take the children out into the forest to where
+it is the thickest; there we will light a fire for them, and give each
+of them one more piece of bread, and then we will go to our work and
+leave them alone. They will not find the way home again, and we shall be
+rid of them.’ ‘No, wife,’ said the man, ‘I will not do that; how can I
+bear to leave my children alone in the forest?--the wild animals would
+soon come and tear them to pieces.’ ‘O, you fool!’ said she, ‘then we
+must all four die of hunger, you may as well plane the planks for our
+coffins,’ and she left him no peace until he consented. ‘But I feel very
+sorry for the poor children, all the same,’ said the man.
+
+The two children had also not been able to sleep for hunger, and had
+heard what their stepmother had said to their father. Gretel wept
+bitter tears, and said to Hansel: ‘Now all is over with us.’ ‘Be quiet,
+Gretel,’ said Hansel, ‘do not distress yourself, I will soon find a way
+to help us.’ And when the old folks had fallen asleep, he got up, put
+on his little coat, opened the door below, and crept outside. The moon
+shone brightly, and the white pebbles which lay in front of the house
+glittered like real silver pennies. Hansel stooped and stuffed the
+little pocket of his coat with as many as he could get in. Then he went
+back and said to Gretel: ‘Be comforted, dear little sister, and sleep in
+peace, God will not forsake us,’ and he lay down again in his bed. When
+day dawned, but before the sun had risen, the woman came and awoke the
+two children, saying: ‘Get up, you sluggards! we are going into the
+forest to fetch wood.’ She gave each a little piece of bread, and said:
+‘There is something for your dinner, but do not eat it up before then,
+for you will get nothing else.’ Gretel took the bread under her apron,
+as Hansel had the pebbles in his pocket. Then they all set out together
+on the way to the forest. When they had walked a short time, Hansel
+stood still and peeped back at the house, and did so again and again.
+His father said: ‘Hansel, what are you looking at there and staying
+behind for? Pay attention, and do not forget how to use your legs.’ ‘Ah,
+father,’ said Hansel, ‘I am looking at my little white cat, which is
+sitting up on the roof, and wants to say goodbye to me.’ The wife said:
+‘Fool, that is not your little cat, that is the morning sun which is
+shining on the chimneys.’ Hansel, however, had not been looking back at
+the cat, but had been constantly throwing one of the white pebble-stones
+out of his pocket on the road.
+
+When they had reached the middle of the forest, the father said: ‘Now,
+children, pile up some wood, and I will light a fire that you may not
+be cold.’ Hansel and Gretel gathered brushwood together, as high as a
+little hill. The brushwood was lighted, and when the flames were burning
+very high, the woman said: ‘Now, children, lay yourselves down by the
+fire and rest, we will go into the forest and cut some wood. When we
+have done, we will come back and fetch you away.’
+
+Hansel and Gretel sat by the fire, and when noon came, each ate a little
+piece of bread, and as they heard the strokes of the wood-axe they
+believed that their father was near. It was not the axe, however, but
+a branch which he had fastened to a withered tree which the wind was
+blowing backwards and forwards. And as they had been sitting such a long
+time, their eyes closed with fatigue, and they fell fast asleep. When
+at last they awoke, it was already dark night. Gretel began to cry and
+said: ‘How are we to get out of the forest now?’ But Hansel comforted
+her and said: ‘Just wait a little, until the moon has risen, and then we
+will soon find the way.’ And when the full moon had risen, Hansel took
+his little sister by the hand, and followed the pebbles which shone like
+newly-coined silver pieces, and showed them the way.
+
+They walked the whole night long, and by break of day came once more
+to their father’s house. They knocked at the door, and when the woman
+opened it and saw that it was Hansel and Gretel, she said: ‘You naughty
+children, why have you slept so long in the forest?--we thought you were
+never coming back at all!’ The father, however, rejoiced, for it had cut
+him to the heart to leave them behind alone.
+
+Not long afterwards, there was once more great dearth throughout the
+land, and the children heard their mother saying at night to their
+father: ‘Everything is eaten again, we have one half loaf left, and that
+is the end. The children must go, we will take them farther into the
+wood, so that they will not find their way out again; there is no other
+means of saving ourselves!’ The man’s heart was heavy, and he thought:
+‘It would be better for you to share the last mouthful with your
+children.’ The woman, however, would listen to nothing that he had to
+say, but scolded and reproached him. He who says A must say B, likewise,
+and as he had yielded the first time, he had to do so a second time
+also.
+
+The children, however, were still awake and had heard the conversation.
+When the old folks were asleep, Hansel again got up, and wanted to go
+out and pick up pebbles as he had done before, but the woman had locked
+the door, and Hansel could not get out. Nevertheless he comforted his
+little sister, and said: ‘Do not cry, Gretel, go to sleep quietly, the
+good God will help us.’
+
+Early in the morning came the woman, and took the children out of their
+beds. Their piece of bread was given to them, but it was still smaller
+than the time before. On the way into the forest Hansel crumbled his
+in his pocket, and often stood still and threw a morsel on the ground.
+‘Hansel, why do you stop and look round?’ said the father, ‘go on.’ ‘I
+am looking back at my little pigeon which is sitting on the roof, and
+wants to say goodbye to me,’ answered Hansel. ‘Fool!’ said the woman,
+‘that is not your little pigeon, that is the morning sun that is shining
+on the chimney.’ Hansel, however little by little, threw all the crumbs
+on the path.
+
+The woman led the children still deeper into the forest, where they had
+never in their lives been before. Then a great fire was again made, and
+the mother said: ‘Just sit there, you children, and when you are tired
+you may sleep a little; we are going into the forest to cut wood, and in
+the evening when we are done, we will come and fetch you away.’ When
+it was noon, Gretel shared her piece of bread with Hansel, who had
+scattered his by the way. Then they fell asleep and evening passed, but
+no one came to the poor children. They did not awake until it was dark
+night, and Hansel comforted his little sister and said: ‘Just wait,
+Gretel, until the moon rises, and then we shall see the crumbs of bread
+which I have strewn about, they will show us our way home again.’ When
+the moon came they set out, but they found no crumbs, for the many
+thousands of birds which fly about in the woods and fields had picked
+them all up. Hansel said to Gretel: ‘We shall soon find the way,’ but
+they did not find it. They walked the whole night and all the next day
+too from morning till evening, but they did not get out of the forest,
+and were very hungry, for they had nothing to eat but two or three
+berries, which grew on the ground. And as they were so weary that their
+legs would carry them no longer, they lay down beneath a tree and fell
+asleep.
+
+It was now three mornings since they had left their father’s house. They
+began to walk again, but they always came deeper into the forest, and if
+help did not come soon, they must die of hunger and weariness. When it
+was mid-day, they saw a beautiful snow-white bird sitting on a bough,
+which sang so delightfully that they stood still and listened to it. And
+when its song was over, it spread its wings and flew away before them,
+and they followed it until they reached a little house, on the roof of
+which it alighted; and when they approached the little house they saw
+that it was built of bread and covered with cakes, but that the windows
+were of clear sugar. ‘We will set to work on that,’ said Hansel, ‘and
+have a good meal. I will eat a bit of the roof, and you Gretel, can eat
+some of the window, it will taste sweet.’ Hansel reached up above, and
+broke off a little of the roof to try how it tasted, and Gretel leant
+against the window and nibbled at the panes. Then a soft voice cried
+from the parlour:
+
+ ‘Nibble, nibble, gnaw,
+  Who is nibbling at my little house?’
+
+The children answered:
+
+ ‘The wind, the wind,
+  The heaven-born wind,’
+
+and went on eating without disturbing themselves. Hansel, who liked the
+taste of the roof, tore down a great piece of it, and Gretel pushed out
+the whole of one round window-pane, sat down, and enjoyed herself with
+it. Suddenly the door opened, and a woman as old as the hills, who
+supported herself on crutches, came creeping out. Hansel and Gretel were
+so terribly frightened that they let fall what they had in their
+hands. The old woman, however, nodded her head, and said: ‘Oh, you dear
+children, who has brought you here? do come in, and stay with me. No
+harm shall happen to you.’ She took them both by the hand, and led them
+into her little house. Then good food was set before them, milk and
+pancakes, with sugar, apples, and nuts. Afterwards two pretty little
+beds were covered with clean white linen, and Hansel and Gretel lay down
+in them, and thought they were in heaven.
+
+The old woman had only pretended to be so kind; she was in reality
+a wicked witch, who lay in wait for children, and had only built the
+little house of bread in order to entice them there. When a child fell
+into her power, she killed it, cooked and ate it, and that was a feast
+day with her. Witches have red eyes, and cannot see far, but they have
+a keen scent like the beasts, and are aware when human beings draw near.
+When Hansel and Gretel came into her neighbourhood, she laughed with
+malice, and said mockingly: ‘I have them, they shall not escape me
+again!’ Early in the morning before the children were awake, she was
+already up, and when she saw both of them sleeping and looking so
+pretty, with their plump and rosy cheeks she muttered to herself: ‘That
+will be a dainty mouthful!’ Then she seized Hansel with her shrivelled
+hand, carried him into a little stable, and locked him in behind a
+grated door. Scream as he might, it would not help him. Then she went to
+Gretel, shook her till she awoke, and cried: ‘Get up, lazy thing, fetch
+some water, and cook something good for your brother, he is in the
+stable outside, and is to be made fat. When he is fat, I will eat him.’
+Gretel began to weep bitterly, but it was all in vain, for she was
+forced to do what the wicked witch commanded.
+
+And now the best food was cooked for poor Hansel, but Gretel got nothing
+but crab-shells. Every morning the woman crept to the little stable, and
+cried: ‘Hansel, stretch out your finger that I may feel if you will soon
+be fat.’ Hansel, however, stretched out a little bone to her, and
+the old woman, who had dim eyes, could not see it, and thought it was
+Hansel’s finger, and was astonished that there was no way of fattening
+him. When four weeks had gone by, and Hansel still remained thin, she
+was seized with impatience and would not wait any longer. ‘Now, then,
+Gretel,’ she cried to the girl, ‘stir yourself, and bring some water.
+Let Hansel be fat or lean, tomorrow I will kill him, and cook him.’ Ah,
+how the poor little sister did lament when she had to fetch the water,
+and how her tears did flow down her cheeks! ‘Dear God, do help us,’ she
+cried. ‘If the wild beasts in the forest had but devoured us, we should
+at any rate have died together.’ ‘Just keep your noise to yourself,’
+said the old woman, ‘it won’t help you at all.’
+
+Early in the morning, Gretel had to go out and hang up the cauldron with
+the water, and light the fire. ‘We will bake first,’ said the old woman,
+‘I have already heated the oven, and kneaded the dough.’ She pushed poor
+Gretel out to the oven, from which flames of fire were already darting.
+‘Creep in,’ said the witch, ‘and see if it is properly heated, so that
+we can put the bread in.’ And once Gretel was inside, she intended to
+shut the oven and let her bake in it, and then she would eat her, too.
+But Gretel saw what she had in mind, and said: ‘I do not know how I am
+to do it; how do I get in?’ ‘Silly goose,’ said the old woman. ‘The door
+is big enough; just look, I can get in myself!’ and she crept up and
+thrust her head into the oven. Then Gretel gave her a push that drove
+her far into it, and shut the iron door, and fastened the bolt. Oh! then
+she began to howl quite horribly, but Gretel ran away and the godless
+witch was miserably burnt to death.
+
+Gretel, however, ran like lightning to Hansel, opened his little stable,
+and cried: ‘Hansel, we are saved! The old witch is dead!’ Then Hansel
+sprang like a bird from its cage when the door is opened. How they did
+rejoice and embrace each other, and dance about and kiss each other! And
+as they had no longer any need to fear her, they went into the witch’s
+house, and in every corner there stood chests full of pearls and jewels.
+‘These are far better than pebbles!’ said Hansel, and thrust into his
+pockets whatever could be got in, and Gretel said: ‘I, too, will take
+something home with me,’ and filled her pinafore full. ‘But now we must
+be off,’ said Hansel, ‘that we may get out of the witch’s forest.’
+
+When they had walked for two hours, they came to a great stretch of
+water. ‘We cannot cross,’ said Hansel, ‘I see no foot-plank, and no
+bridge.’ ‘And there is also no ferry,’ answered Gretel, ‘but a white
+duck is swimming there: if I ask her, she will help us over.’ Then she
+cried:
+
+ ‘Little duck, little duck, dost thou see,
+  Hansel and Gretel are waiting for thee?
+  There’s never a plank, or bridge in sight,
+  Take us across on thy back so white.’
+
+The duck came to them, and Hansel seated himself on its back, and told
+his sister to sit by him. ‘No,’ replied Gretel, ‘that will be too heavy
+for the little duck; she shall take us across, one after the other.’ The
+good little duck did so, and when they were once safely across and had
+walked for a short time, the forest seemed to be more and more familiar
+to them, and at length they saw from afar their father’s house. Then
+they began to run, rushed into the parlour, and threw themselves round
+their father’s neck. The man had not known one happy hour since he had
+left the children in the forest; the woman, however, was dead. Gretel
+emptied her pinafore until pearls and precious stones ran about the
+room, and Hansel threw one handful after another out of his pocket to
+add to them. Then all anxiety was at an end, and they lived together
+in perfect happiness. My tale is done, there runs a mouse; whosoever
+catches it, may make himself a big fur cap out of it.
+
+
+
+
+THE MOUSE, THE BIRD, AND THE SAUSAGE
+
+Once upon a time, a mouse, a bird, and a sausage, entered into
+partnership and set up house together. For a long time all went well;
+they lived in great comfort, and prospered so far as to be able to add
+considerably to their stores. The bird’s duty was to fly daily into the
+wood and bring in fuel; the mouse fetched the water, and the sausage saw
+to the cooking.
+
+When people are too well off they always begin to long for something
+new. And so it came to pass, that the bird, while out one day, met a
+fellow bird, to whom he boastfully expatiated on the excellence of his
+household arrangements. But the other bird sneered at him for being a
+poor simpleton, who did all the hard work, while the other two stayed
+at home and had a good time of it. For, when the mouse had made the fire
+and fetched in the water, she could retire into her little room and rest
+until it was time to set the table. The sausage had only to watch the
+pot to see that the food was properly cooked, and when it was near
+dinner-time, he just threw himself into the broth, or rolled in and out
+among the vegetables three or four times, and there they were, buttered,
+and salted, and ready to be served. Then, when the bird came home and
+had laid aside his burden, they sat down to table, and when they had
+finished their meal, they could sleep their fill till the following
+morning: and that was really a very delightful life.
+
+Influenced by those remarks, the bird next morning refused to bring in
+the wood, telling the others that he had been their servant long enough,
+and had been a fool into the bargain, and that it was now time to make a
+change, and to try some other way of arranging the work. Beg and pray
+as the mouse and the sausage might, it was of no use; the bird remained
+master of the situation, and the venture had to be made. They therefore
+drew lots, and it fell to the sausage to bring in the wood, to the mouse
+to cook, and to the bird to fetch the water.
+
+And now what happened? The sausage started in search of wood, the bird
+made the fire, and the mouse put on the pot, and then these two waited
+till the sausage returned with the fuel for the following day. But the
+sausage remained so long away, that they became uneasy, and the bird
+flew out to meet him. He had not flown far, however, when he came across
+a dog who, having met the sausage, had regarded him as his legitimate
+booty, and so seized and swallowed him. The bird complained to the dog
+of this bare-faced robbery, but nothing he said was of any avail, for
+the dog answered that he found false credentials on the sausage, and
+that was the reason his life had been forfeited.
+
+He picked up the wood, and flew sadly home, and told the mouse all he
+had seen and heard. They were both very unhappy, but agreed to make the
+best of things and to remain with one another.
+
+So now the bird set the table, and the mouse looked after the food and,
+wishing to prepare it in the same way as the sausage, by rolling in and
+out among the vegetables to salt and butter them, she jumped into the
+pot; but she stopped short long before she reached the bottom, having
+already parted not only with her skin and hair, but also with life.
+
+Presently the bird came in and wanted to serve up the dinner, but he
+could nowhere see the cook. In his alarm and flurry, he threw the wood
+here and there about the floor, called and searched, but no cook was to
+be found. Then some of the wood that had been carelessly thrown down,
+caught fire and began to blaze. The bird hastened to fetch some water,
+but his pail fell into the well, and he after it, and as he was unable
+to recover himself, he was drowned.
+
+
+
+
+MOTHER HOLLE
+
+Once upon a time there was a widow who had two daughters; one of them
+was beautiful and industrious, the other ugly and lazy. The mother,
+however, loved the ugly and lazy one best, because she was her own
+daughter, and so the other, who was only her stepdaughter, was made
+to do all the work of the house, and was quite the Cinderella of the
+family. Her stepmother sent her out every day to sit by the well in
+the high road, there to spin until she made her fingers bleed. Now it
+chanced one day that some blood fell on to the spindle, and as the girl
+stopped over the well to wash it off, the spindle suddenly sprang out
+of her hand and fell into the well. She ran home crying to tell of her
+misfortune, but her stepmother spoke harshly to her, and after giving
+her a violent scolding, said unkindly, ‘As you have let the spindle fall
+into the well you may go yourself and fetch it out.’
+
+The girl went back to the well not knowing what to do, and at last in
+her distress she jumped into the water after the spindle.
+
+She remembered nothing more until she awoke and found herself in a
+beautiful meadow, full of sunshine, and with countless flowers blooming
+in every direction.
+
+She walked over the meadow, and presently she came upon a baker’s oven
+full of bread, and the loaves cried out to her, ‘Take us out, take us
+out, or alas! we shall be burnt to a cinder; we were baked through long
+ago.’ So she took the bread-shovel and drew them all out.
+
+She went on a little farther, till she came to a tree full of apples.
+‘Shake me, shake me, I pray,’ cried the tree; ‘my apples, one and all,
+are ripe.’ So she shook the tree, and the apples came falling down upon
+her like rain; but she continued shaking until there was not a single
+apple left upon it. Then she carefully gathered the apples together in a
+heap and walked on again.
+
+The next thing she came to was a little house, and there she saw an old
+woman looking out, with such large teeth, that she was terrified, and
+turned to run away. But the old woman called after her, ‘What are you
+afraid of, dear child? Stay with me; if you will do the work of my house
+properly for me, I will make you very happy. You must be very careful,
+however, to make my bed in the right way, for I wish you always to shake
+it thoroughly, so that the feathers fly about; then they say, down there
+in the world, that it is snowing; for I am Mother Holle.’ The old woman
+spoke so kindly, that the girl summoned up courage and agreed to enter
+into her service.
+
+She took care to do everything according to the old woman’s bidding and
+every time she made the bed she shook it with all her might, so that the
+feathers flew about like so many snowflakes. The old woman was as good
+as her word: she never spoke angrily to her, and gave her roast and
+boiled meats every day.
+
+So she stayed on with Mother Holle for some time, and then she began
+to grow unhappy. She could not at first tell why she felt sad, but she
+became conscious at last of great longing to go home; then she knew she
+was homesick, although she was a thousand times better off with Mother
+Holle than with her mother and sister. After waiting awhile, she went
+to Mother Holle and said, ‘I am so homesick, that I cannot stay with
+you any longer, for although I am so happy here, I must return to my own
+people.’
+
+Then Mother Holle said, ‘I am pleased that you should want to go back
+to your own people, and as you have served me so well and faithfully, I
+will take you home myself.’
+
+Thereupon she led the girl by the hand up to a broad gateway. The gate
+was opened, and as the girl passed through, a shower of gold fell upon
+her, and the gold clung to her, so that she was covered with it from
+head to foot.
+
+‘That is a reward for your industry,’ said Mother Holle, and as she
+spoke she handed her the spindle which she had dropped into the well.
+
+The gate was then closed, and the girl found herself back in the old
+world close to her mother’s house. As she entered the courtyard, the
+cock who was perched on the well, called out:
+
+ ‘Cock-a-doodle-doo!
+  Your golden daughter’s come back to you.’
+
+Then she went in to her mother and sister, and as she was so richly
+covered with gold, they gave her a warm welcome. She related to them
+all that had happened, and when the mother heard how she had come by her
+great riches, she thought she should like her ugly, lazy daughter to go
+and try her fortune. So she made the sister go and sit by the well
+and spin, and the girl pricked her finger and thrust her hand into a
+thorn-bush, so that she might drop some blood on to the spindle; then
+she threw it into the well, and jumped in herself.
+
+Like her sister she awoke in the beautiful meadow, and walked over it
+till she came to the oven. ‘Take us out, take us out, or alas! we shall
+be burnt to a cinder; we were baked through long ago,’ cried the loaves
+as before. But the lazy girl answered, ‘Do you think I am going to dirty
+my hands for you?’ and walked on.
+
+Presently she came to the apple-tree. ‘Shake me, shake me, I pray; my
+apples, one and all, are ripe,’ it cried. But she only answered, ‘A nice
+thing to ask me to do, one of the apples might fall on my head,’ and
+passed on.
+
+At last she came to Mother Holle’s house, and as she had heard all about
+the large teeth from her sister, she was not afraid of them, and engaged
+herself without delay to the old woman.
+
+The first day she was very obedient and industrious, and exerted herself
+to please Mother Holle, for she thought of the gold she should get in
+return. The next day, however, she began to dawdle over her work, and
+the third day she was more idle still; then she began to lie in bed in
+the mornings and refused to get up. Worse still, she neglected to
+make the old woman’s bed properly, and forgot to shake it so that the
+feathers might fly about. So Mother Holle very soon got tired of her,
+and told her she might go. The lazy girl was delighted at this, and
+thought to herself, ‘The gold will soon be mine.’ Mother Holle led her,
+as she had led her sister, to the broad gateway; but as she was passing
+through, instead of the shower of gold, a great bucketful of pitch came
+pouring over her.
+
+‘That is in return for your services,’ said the old woman, and she shut
+the gate.
+
+So the lazy girl had to go home covered with pitch, and the cock on the
+well called out as she saw her:
+
+ ‘Cock-a-doodle-doo!
+  Your dirty daughter’s come back to you.’
+
+But, try what she would, she could not get the pitch off and it stuck to
+her as long as she lived.
+
+
+
+
+LITTLE RED-CAP [LITTLE RED RIDING HOOD]
+
+Once upon a time there was a dear little girl who was loved by everyone
+who looked at her, but most of all by her grandmother, and there was
+nothing that she would not have given to the child. Once she gave her a
+little cap of red velvet, which suited her so well that she would never
+wear anything else; so she was always called ‘Little Red-Cap.’
+
+One day her mother said to her: ‘Come, Little Red-Cap, here is a piece
+of cake and a bottle of wine; take them to your grandmother, she is ill
+and weak, and they will do her good. Set out before it gets hot, and
+when you are going, walk nicely and quietly and do not run off the path,
+or you may fall and break the bottle, and then your grandmother will
+get nothing; and when you go into her room, don’t forget to say, “Good
+morning”, and don’t peep into every corner before you do it.’
+
+‘I will take great care,’ said Little Red-Cap to her mother, and gave
+her hand on it.
+
+The grandmother lived out in the wood, half a league from the village,
+and just as Little Red-Cap entered the wood, a wolf met her. Red-Cap
+did not know what a wicked creature he was, and was not at all afraid of
+him.
+
+‘Good day, Little Red-Cap,’ said he.
+
+‘Thank you kindly, wolf.’
+
+‘Whither away so early, Little Red-Cap?’
+
+‘To my grandmother’s.’
+
+‘What have you got in your apron?’
+
+‘Cake and wine; yesterday was baking-day, so poor sick grandmother is to
+have something good, to make her stronger.’
+
+‘Where does your grandmother live, Little Red-Cap?’
+
+‘A good quarter of a league farther on in the wood; her house stands
+under the three large oak-trees, the nut-trees are just below; you
+surely must know it,’ replied Little Red-Cap.
+
+The wolf thought to himself: ‘What a tender young creature! what a nice
+plump mouthful--she will be better to eat than the old woman. I must
+act craftily, so as to catch both.’ So he walked for a short time by
+the side of Little Red-Cap, and then he said: ‘See, Little Red-Cap, how
+pretty the flowers are about here--why do you not look round? I believe,
+too, that you do not hear how sweetly the little birds are singing; you
+walk gravely along as if you were going to school, while everything else
+out here in the wood is merry.’
+
+Little Red-Cap raised her eyes, and when she saw the sunbeams dancing
+here and there through the trees, and pretty flowers growing everywhere,
+she thought: ‘Suppose I take grandmother a fresh nosegay; that would
+please her too. It is so early in the day that I shall still get there
+in good time’; and so she ran from the path into the wood to look for
+flowers. And whenever she had picked one, she fancied that she saw a
+still prettier one farther on, and ran after it, and so got deeper and
+deeper into the wood.
+
+Meanwhile the wolf ran straight to the grandmother’s house and knocked
+at the door.
+
+‘Who is there?’
+
+‘Little Red-Cap,’ replied the wolf. ‘She is bringing cake and wine; open
+the door.’
+
+‘Lift the latch,’ called out the grandmother, ‘I am too weak, and cannot
+get up.’
+
+The wolf lifted the latch, the door sprang open, and without saying a
+word he went straight to the grandmother’s bed, and devoured her. Then
+he put on her clothes, dressed himself in her cap laid himself in bed
+and drew the curtains.
+
+Little Red-Cap, however, had been running about picking flowers,
+and when she had gathered so many that she could carry no more, she
+remembered her grandmother, and set out on the way to her.
+
+She was surprised to find the cottage-door standing open, and when she
+went into the room, she had such a strange feeling that she said to
+herself: ‘Oh dear! how uneasy I feel today, and at other times I like
+being with grandmother so much.’ She called out: ‘Good morning,’ but
+received no answer; so she went to the bed and drew back the curtains.
+There lay her grandmother with her cap pulled far over her face, and
+looking very strange.
+
+‘Oh! grandmother,’ she said, ‘what big ears you have!’
+
+‘The better to hear you with, my child,’ was the reply.
+
+‘But, grandmother, what big eyes you have!’ she said.
+
+‘The better to see you with, my dear.’
+
+‘But, grandmother, what large hands you have!’
+
+‘The better to hug you with.’
+
+‘Oh! but, grandmother, what a terrible big mouth you have!’
+
+‘The better to eat you with!’
+
+And scarcely had the wolf said this, than with one bound he was out of
+bed and swallowed up Red-Cap.
+
+When the wolf had appeased his appetite, he lay down again in the bed,
+fell asleep and began to snore very loud. The huntsman was just passing
+the house, and thought to himself: ‘How the old woman is snoring! I must
+just see if she wants anything.’ So he went into the room, and when he
+came to the bed, he saw that the wolf was lying in it. ‘Do I find you
+here, you old sinner!’ said he. ‘I have long sought you!’ Then just as
+he was going to fire at him, it occurred to him that the wolf might have
+devoured the grandmother, and that she might still be saved, so he did
+not fire, but took a pair of scissors, and began to cut open the stomach
+of the sleeping wolf. When he had made two snips, he saw the little
+Red-Cap shining, and then he made two snips more, and the little girl
+sprang out, crying: ‘Ah, how frightened I have been! How dark it was
+inside the wolf’; and after that the aged grandmother came out alive
+also, but scarcely able to breathe. Red-Cap, however, quickly fetched
+great stones with which they filled the wolf’s belly, and when he awoke,
+he wanted to run away, but the stones were so heavy that he collapsed at
+once, and fell dead.
+
+Then all three were delighted. The huntsman drew off the wolf’s skin and
+went home with it; the grandmother ate the cake and drank the wine which
+Red-Cap had brought, and revived, but Red-Cap thought to herself: ‘As
+long as I live, I will never by myself leave the path, to run into the
+wood, when my mother has forbidden me to do so.’
+
+
+
+
+It also related that once when Red-Cap was again taking cakes to the old
+grandmother, another wolf spoke to her, and tried to entice her from the
+path. Red-Cap, however, was on her guard, and went straight forward on
+her way, and told her grandmother that she had met the wolf, and that he
+had said ‘good morning’ to her, but with such a wicked look in his eyes,
+that if they had not been on the public road she was certain he would
+have eaten her up. ‘Well,’ said the grandmother, ‘we will shut the door,
+that he may not come in.’ Soon afterwards the wolf knocked, and cried:
+‘Open the door, grandmother, I am Little Red-Cap, and am bringing you
+some cakes.’ But they did not speak, or open the door, so the grey-beard
+stole twice or thrice round the house, and at last jumped on the roof,
+intending to wait until Red-Cap went home in the evening, and then to
+steal after her and devour her in the darkness. But the grandmother
+saw what was in his thoughts. In front of the house was a great stone
+trough, so she said to the child: ‘Take the pail, Red-Cap; I made some
+sausages yesterday, so carry the water in which I boiled them to the
+trough.’ Red-Cap carried until the great trough was quite full. Then the
+smell of the sausages reached the wolf, and he sniffed and peeped down,
+and at last stretched out his neck so far that he could no longer keep
+his footing and began to slip, and slipped down from the roof straight
+into the great trough, and was drowned. But Red-Cap went joyously home,
+and no one ever did anything to harm her again.
+
+
+
+
+THE ROBBER BRIDEGROOM
+
+There was once a miller who had one beautiful daughter, and as she was
+grown up, he was anxious that she should be well married and provided
+for. He said to himself, ‘I will give her to the first suitable man who
+comes and asks for her hand.’ Not long after a suitor appeared, and as
+he appeared to be very rich and the miller could see nothing in him with
+which to find fault, he betrothed his daughter to him. But the girl did
+not care for the man as a girl ought to care for her betrothed husband.
+She did not feel that she could trust him, and she could not look at him
+nor think of him without an inward shudder. One day he said to her, ‘You
+have not yet paid me a visit, although we have been betrothed for some
+time.’ ‘I do not know where your house is,’ she answered. ‘My house is
+out there in the dark forest,’ he said. She tried to excuse herself by
+saying that she would not be able to find the way thither. Her betrothed
+only replied, ‘You must come and see me next Sunday; I have already
+invited guests for that day, and that you may not mistake the way, I
+will strew ashes along the path.’
+
+When Sunday came, and it was time for the girl to start, a feeling of
+dread came over her which she could not explain, and that she might
+be able to find her path again, she filled her pockets with peas and
+lentils to sprinkle on the ground as she went along. On reaching the
+entrance to the forest she found the path strewed with ashes, and these
+she followed, throwing down some peas on either side of her at every
+step she took. She walked the whole day until she came to the deepest,
+darkest part of the forest. There she saw a lonely house, looking so
+grim and mysterious, that it did not please her at all. She stepped
+inside, but not a soul was to be seen, and a great silence reigned
+throughout. Suddenly a voice cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl looked up and saw that the voice came from a bird hanging in a
+cage on the wall. Again it cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+The girl passed on, going from room to room of the house, but they were
+all empty, and still she saw no one. At last she came to the cellar,
+and there sat a very, very old woman, who could not keep her head from
+shaking. ‘Can you tell me,’ asked the girl, ‘if my betrothed husband
+lives here?’
+
+‘Ah, you poor child,’ answered the old woman, ‘what a place for you to
+come to! This is a murderers’ den. You think yourself a promised bride,
+and that your marriage will soon take place, but it is with death that
+you will keep your marriage feast. Look, do you see that large cauldron
+of water which I am obliged to keep on the fire! As soon as they have
+you in their power they will kill you without mercy, and cook and eat
+you, for they are eaters of men. If I did not take pity on you and save
+you, you would be lost.’
+
+Thereupon the old woman led her behind a large cask, which quite hid her
+from view. ‘Keep as still as a mouse,’ she said; ‘do not move or speak,
+or it will be all over with you. Tonight, when the robbers are
+all asleep, we will flee together. I have long been waiting for an
+opportunity to escape.’
+
+The words were hardly out of her mouth when the godless crew returned,
+dragging another young girl along with them. They were all drunk, and
+paid no heed to her cries and lamentations. They gave her wine to drink,
+three glasses full, one of white wine, one of red, and one of yellow,
+and with that her heart gave way and she died. Then they tore off her
+dainty clothing, laid her on a table, and cut her beautiful body into
+pieces, and sprinkled salt upon it.
+
+The poor betrothed girl crouched trembling and shuddering behind the
+cask, for she saw what a terrible fate had been intended for her by
+the robbers. One of them now noticed a gold ring still remaining on
+the little finger of the murdered girl, and as he could not draw it off
+easily, he took a hatchet and cut off the finger; but the finger sprang
+into the air, and fell behind the cask into the lap of the girl who was
+hiding there. The robber took a light and began looking for it, but he
+could not find it. ‘Have you looked behind the large cask?’ said one of
+the others. But the old woman called out, ‘Come and eat your suppers,
+and let the thing be till tomorrow; the finger won’t run away.’
+
+‘The old woman is right,’ said the robbers, and they ceased looking for
+the finger and sat down.
+
+The old woman then mixed a sleeping draught with their wine, and before
+long they were all lying on the floor of the cellar, fast asleep and
+snoring. As soon as the girl was assured of this, she came from behind
+the cask. She was obliged to step over the bodies of the sleepers, who
+were lying close together, and every moment she was filled with renewed
+dread lest she should awaken them. But God helped her, so that she
+passed safely over them, and then she and the old woman went upstairs,
+opened the door, and hastened as fast as they could from the murderers’
+den. They found the ashes scattered by the wind, but the peas and
+lentils had sprouted, and grown sufficiently above the ground, to guide
+them in the moonlight along the path. All night long they walked, and it
+was morning before they reached the mill. Then the girl told her father
+all that had happened.
+
+The day came that had been fixed for the marriage. The bridegroom
+arrived and also a large company of guests, for the miller had taken
+care to invite all his friends and relations. As they sat at the feast,
+each guest in turn was asked to tell a tale; the bride sat still and did
+not say a word.
+
+‘And you, my love,’ said the bridegroom, turning to her, ‘is there no
+tale you know? Tell us something.’
+
+‘I will tell you a dream, then,’ said the bride. ‘I went alone through a
+forest and came at last to a house; not a soul could I find within, but
+a bird that was hanging in a cage on the wall cried:
+
+ ‘Turn back, turn back, young maiden fair,
+  Linger not in this murderers’ lair.’
+
+and again a second time it said these words.’
+
+‘My darling, this is only a dream.’
+
+‘I went on through the house from room to room, but they were all empty,
+and everything was so grim and mysterious. At last I went down to the
+cellar, and there sat a very, very old woman, who could not keep her
+head still. I asked her if my betrothed lived here, and she answered,
+“Ah, you poor child, you are come to a murderers’ den; your betrothed
+does indeed live here, but he will kill you without mercy and afterwards
+cook and eat you.”’
+
+‘My darling, this is only a dream.’
+
+‘The old woman hid me behind a large cask, and scarcely had she done
+this when the robbers returned home, dragging a young girl along with
+them. They gave her three kinds of wine to drink, white, red, and
+yellow, and with that she died.’
+
+‘My darling, this is only a dream.’
+
+‘Then they tore off her dainty clothing, and cut her beautiful body into
+pieces and sprinkled salt upon it.’
+
+‘My darling, this is only a dream.’
+
+‘And one of the robbers saw that there was a gold ring still left on her
+finger, and as it was difficult to draw off, he took a hatchet and cut
+off her finger; but the finger sprang into the air and fell behind the
+great cask into my lap. And here is the finger with the ring.’ And
+with these words the bride drew forth the finger and shewed it to the
+assembled guests.
+
+The bridegroom, who during this recital had grown deadly pale, up and
+tried to escape, but the guests seized him and held him fast. They
+delivered him up to justice, and he and all his murderous band were
+condemned to death for their wicked deeds.
+
+
+
+
+TOM THUMB
+
+A poor woodman sat in his cottage one night, smoking his pipe by the
+fireside, while his wife sat by his side spinning. ‘How lonely it is,
+wife,’ said he, as he puffed out a long curl of smoke, ‘for you and me
+to sit here by ourselves, without any children to play about and amuse
+us while other people seem so happy and merry with their children!’
+‘What you say is very true,’ said the wife, sighing, and turning round
+her wheel; ‘how happy should I be if I had but one child! If it were
+ever so small--nay, if it were no bigger than my thumb--I should be very
+happy, and love it dearly.’ Now--odd as you may think it--it came to
+pass that this good woman’s wish was fulfilled, just in the very way she
+had wished it; for, not long afterwards, she had a little boy, who was
+quite healthy and strong, but was not much bigger than my thumb. So
+they said, ‘Well, we cannot say we have not got what we wished for, and,
+little as he is, we will love him dearly.’ And they called him Thomas
+Thumb.
+
+They gave him plenty of food, yet for all they could do he never grew
+bigger, but kept just the same size as he had been when he was born.
+Still, his eyes were sharp and sparkling, and he soon showed himself to
+be a clever little fellow, who always knew well what he was about.
+
+One day, as the woodman was getting ready to go into the wood to cut
+fuel, he said, ‘I wish I had someone to bring the cart after me, for I
+want to make haste.’ ‘Oh, father,’ cried Tom, ‘I will take care of that;
+the cart shall be in the wood by the time you want it.’ Then the woodman
+laughed, and said, ‘How can that be? you cannot reach up to the horse’s
+bridle.’ ‘Never mind that, father,’ said Tom; ‘if my mother will only
+harness the horse, I will get into his ear and tell him which way to
+go.’ ‘Well,’ said the father, ‘we will try for once.’
+
+When the time came the mother harnessed the horse to the cart, and put
+Tom into his ear; and as he sat there the little man told the beast how
+to go, crying out, ‘Go on!’ and ‘Stop!’ as he wanted: and thus the horse
+went on just as well as if the woodman had driven it himself into the
+wood. It happened that as the horse was going a little too fast, and Tom
+was calling out, ‘Gently! gently!’ two strangers came up. ‘What an odd
+thing that is!’ said one: ‘there is a cart going along, and I hear a
+carter talking to the horse, but yet I can see no one.’ ‘That is queer,
+indeed,’ said the other; ‘let us follow the cart, and see where it
+goes.’ So they went on into the wood, till at last they came to the
+place where the woodman was. Then Tom Thumb, seeing his father, cried
+out, ‘See, father, here I am with the cart, all right and safe! now take
+me down!’ So his father took hold of the horse with one hand, and with
+the other took his son out of the horse’s ear, and put him down upon a
+straw, where he sat as merry as you please.
+
+The two strangers were all this time looking on, and did not know what
+to say for wonder. At last one took the other aside, and said, ‘That
+little urchin will make our fortune, if we can get him, and carry him
+about from town to town as a show; we must buy him.’ So they went up to
+the woodman, and asked him what he would take for the little man. ‘He
+will be better off,’ said they, ‘with us than with you.’ ‘I won’t sell
+him at all,’ said the father; ‘my own flesh and blood is dearer to me
+than all the silver and gold in the world.’ But Tom, hearing of the
+bargain they wanted to make, crept up his father’s coat to his shoulder
+and whispered in his ear, ‘Take the money, father, and let them have me;
+I’ll soon come back to you.’
+
+So the woodman at last said he would sell Tom to the strangers for a
+large piece of gold, and they paid the price. ‘Where would you like to
+sit?’ said one of them. ‘Oh, put me on the rim of your hat; that will be
+a nice gallery for me; I can walk about there and see the country as we
+go along.’ So they did as he wished; and when Tom had taken leave of his
+father they took him away with them.
+
+They journeyed on till it began to be dusky, and then the little man
+said, ‘Let me get down, I’m tired.’ So the man took off his hat, and
+put him down on a clod of earth, in a ploughed field by the side of the
+road. But Tom ran about amongst the furrows, and at last slipped into
+an old mouse-hole. ‘Good night, my masters!’ said he, ‘I’m off! mind and
+look sharp after me the next time.’ Then they ran at once to the place,
+and poked the ends of their sticks into the mouse-hole, but all in vain;
+Tom only crawled farther and farther in; and at last it became quite
+dark, so that they were forced to go their way without their prize, as
+sulky as could be.
+
+When Tom found they were gone, he came out of his hiding-place. ‘What
+dangerous walking it is,’ said he, ‘in this ploughed field! If I were to
+fall from one of these great clods, I should undoubtedly break my neck.’
+At last, by good luck, he found a large empty snail-shell. ‘This is
+lucky,’ said he, ‘I can sleep here very well’; and in he crept.
+
+Just as he was falling asleep, he heard two men passing by, chatting
+together; and one said to the other, ‘How can we rob that rich parson’s
+house of his silver and gold?’ ‘I’ll tell you!’ cried Tom. ‘What noise
+was that?’ said the thief, frightened; ‘I’m sure I heard someone speak.’
+They stood still listening, and Tom said, ‘Take me with you, and I’ll
+soon show you how to get the parson’s money.’ ‘But where are you?’ said
+they. ‘Look about on the ground,’ answered he, ‘and listen where the
+sound comes from.’ At last the thieves found him out, and lifted him
+up in their hands. ‘You little urchin!’ they said, ‘what can you do for
+us?’ ‘Why, I can get between the iron window-bars of the parson’s house,
+and throw you out whatever you want.’ ‘That’s a good thought,’ said the
+thieves; ‘come along, we shall see what you can do.’
+
+When they came to the parson’s house, Tom slipped through the
+window-bars into the room, and then called out as loud as he could bawl,
+‘Will you have all that is here?’ At this the thieves were frightened,
+and said, ‘Softly, softly! Speak low, that you may not awaken anybody.’
+But Tom seemed as if he did not understand them, and bawled out again,
+‘How much will you have? Shall I throw it all out?’ Now the cook lay in
+the next room; and hearing a noise she raised herself up in her bed and
+listened. Meantime the thieves were frightened, and ran off a little
+way; but at last they plucked up their hearts, and said, ‘The little
+urchin is only trying to make fools of us.’ So they came back and
+whispered softly to him, saying, ‘Now let us have no more of your
+roguish jokes; but throw us out some of the money.’ Then Tom called out
+as loud as he could, ‘Very well! hold your hands! here it comes.’
+
+The cook heard this quite plain, so she sprang out of bed, and ran to
+open the door. The thieves ran off as if a wolf was at their tails: and
+the maid, having groped about and found nothing, went away for a light.
+By the time she came back, Tom had slipped off into the barn; and when
+she had looked about and searched every hole and corner, and found
+nobody, she went to bed, thinking she must have been dreaming with her
+eyes open.
+
+The little man crawled about in the hay-loft, and at last found a snug
+place to finish his night’s rest in; so he laid himself down, meaning
+to sleep till daylight, and then find his way home to his father and
+mother. But alas! how woefully he was undone! what crosses and sorrows
+happen to us all in this world! The cook got up early, before daybreak,
+to feed the cows; and going straight to the hay-loft, carried away
+a large bundle of hay, with the little man in the middle of it, fast
+asleep. He still, however, slept on, and did not awake till he found
+himself in the mouth of the cow; for the cook had put the hay into the
+cow’s rick, and the cow had taken Tom up in a mouthful of it. ‘Good
+lack-a-day!’ said he, ‘how came I to tumble into the mill?’ But he soon
+found out where he really was; and was forced to have all his wits about
+him, that he might not get between the cow’s teeth, and so be crushed to
+death. At last down he went into her stomach. ‘It is rather dark,’ said
+he; ‘they forgot to build windows in this room to let the sun in; a
+candle would be no bad thing.’
+
+Though he made the best of his bad luck, he did not like his quarters at
+all; and the worst of it was, that more and more hay was always coming
+down, and the space left for him became smaller and smaller. At last he
+cried out as loud as he could, ‘Don’t bring me any more hay! Don’t bring
+me any more hay!’
+
+The maid happened to be just then milking the cow; and hearing someone
+speak, but seeing nobody, and yet being quite sure it was the same voice
+that she had heard in the night, she was so frightened that she fell off
+her stool, and overset the milk-pail. As soon as she could pick herself
+up out of the dirt, she ran off as fast as she could to her master the
+parson, and said, ‘Sir, sir, the cow is talking!’ But the parson
+said, ‘Woman, thou art surely mad!’ However, he went with her into the
+cow-house, to try and see what was the matter.
+
+Scarcely had they set foot on the threshold, when Tom called out, ‘Don’t
+bring me any more hay!’ Then the parson himself was frightened; and
+thinking the cow was surely bewitched, told his man to kill her on the
+spot. So the cow was killed, and cut up; and the stomach, in which Tom
+lay, was thrown out upon a dunghill.
+
+Tom soon set himself to work to get out, which was not a very easy
+task; but at last, just as he had made room to get his head out, fresh
+ill-luck befell him. A hungry wolf sprang out, and swallowed up the
+whole stomach, with Tom in it, at one gulp, and ran away.
+
+Tom, however, was still not disheartened; and thinking the wolf would
+not dislike having some chat with him as he was going along, he called
+out, ‘My good friend, I can show you a famous treat.’ ‘Where’s that?’
+said the wolf. ‘In such and such a house,’ said Tom, describing his own
+father’s house. ‘You can crawl through the drain into the kitchen and
+then into the pantry, and there you will find cakes, ham, beef, cold
+chicken, roast pig, apple-dumplings, and everything that your heart can
+wish.’
+
+The wolf did not want to be asked twice; so that very night he went to
+the house and crawled through the drain into the kitchen, and then into
+the pantry, and ate and drank there to his heart’s content. As soon as
+he had had enough he wanted to get away; but he had eaten so much that
+he could not go out by the same way he came in.
+
+This was just what Tom had reckoned upon; and now he began to set up a
+great shout, making all the noise he could. ‘Will you be easy?’ said the
+wolf; ‘you’ll awaken everybody in the house if you make such a clatter.’
+‘What’s that to me?’ said the little man; ‘you have had your frolic, now
+I’ve a mind to be merry myself’; and he began, singing and shouting as
+loud as he could.
+
+The woodman and his wife, being awakened by the noise, peeped through
+a crack in the door; but when they saw a wolf was there, you may well
+suppose that they were sadly frightened; and the woodman ran for his
+axe, and gave his wife a scythe. ‘Do you stay behind,’ said the woodman,
+‘and when I have knocked him on the head you must rip him up with the
+scythe.’ Tom heard all this, and cried out, ‘Father, father! I am here,
+the wolf has swallowed me.’ And his father said, ‘Heaven be praised! we
+have found our dear child again’; and he told his wife not to use the
+scythe for fear she should hurt him. Then he aimed a great blow, and
+struck the wolf on the head, and killed him on the spot! and when he was
+dead they cut open his body, and set Tommy free. ‘Ah!’ said the father,
+‘what fears we have had for you!’ ‘Yes, father,’ answered he; ‘I have
+travelled all over the world, I think, in one way or other, since we
+parted; and now I am very glad to come home and get fresh air again.’
+‘Why, where have you been?’ said his father. ‘I have been in a
+mouse-hole--and in a snail-shell--and down a cow’s throat--and in the
+wolf’s belly; and yet here I am again, safe and sound.’
+
+‘Well,’ said they, ‘you are come back, and we will not sell you again
+for all the riches in the world.’
+
+Then they hugged and kissed their dear little son, and gave him plenty
+to eat and drink, for he was very hungry; and then they fetched new
+clothes for him, for his old ones had been quite spoiled on his journey.
+So Master Thumb stayed at home with his father and mother, in peace; for
+though he had been so great a traveller, and had done and seen so many
+fine things, and was fond enough of telling the whole story, he always
+agreed that, after all, there’s no place like HOME!
+
+
+
+
+RUMPELSTILTSKIN
+
+By the side of a wood, in a country a long way off, ran a fine stream
+of water; and upon the stream there stood a mill. The miller’s house was
+close by, and the miller, you must know, had a very beautiful daughter.
+She was, moreover, very shrewd and clever; and the miller was so proud
+of her, that he one day told the king of the land, who used to come and
+hunt in the wood, that his daughter could spin gold out of straw. Now
+this king was very fond of money; and when he heard the miller’s boast
+his greediness was raised, and he sent for the girl to be brought before
+him. Then he led her to a chamber in his palace where there was a great
+heap of straw, and gave her a spinning-wheel, and said, ‘All this must
+be spun into gold before morning, as you love your life.’ It was in vain
+that the poor maiden said that it was only a silly boast of her father,
+for that she could do no such thing as spin straw into gold: the chamber
+door was locked, and she was left alone.
+
+She sat down in one corner of the room, and began to bewail her hard
+fate; when on a sudden the door opened, and a droll-looking little man
+hobbled in, and said, ‘Good morrow to you, my good lass; what are you
+weeping for?’ ‘Alas!’ said she, ‘I must spin this straw into gold, and
+I know not how.’ ‘What will you give me,’ said the hobgoblin, ‘to do it
+for you?’ ‘My necklace,’ replied the maiden. He took her at her word,
+and sat himself down to the wheel, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+And round about the wheel went merrily; the work was quickly done, and
+the straw was all spun into gold.
+
+When the king came and saw this, he was greatly astonished and pleased;
+but his heart grew still more greedy of gain, and he shut up the poor
+miller’s daughter again with a fresh task. Then she knew not what to do,
+and sat down once more to weep; but the dwarf soon opened the door, and
+said, ‘What will you give me to do your task?’ ‘The ring on my finger,’
+said she. So her little friend took the ring, and began to work at the
+wheel again, and whistled and sang:
+
+ ‘Round about, round about,
+    Lo and behold!
+  Reel away, reel away,
+    Straw into gold!’
+
+till, long before morning, all was done again.
+
+The king was greatly delighted to see all this glittering treasure;
+but still he had not enough: so he took the miller’s daughter to a yet
+larger heap, and said, ‘All this must be spun tonight; and if it is,
+you shall be my queen.’ As soon as she was alone that dwarf came in, and
+said, ‘What will you give me to spin gold for you this third time?’
+‘I have nothing left,’ said she. ‘Then say you will give me,’ said
+the little man, ‘the first little child that you may have when you are
+queen.’ ‘That may never be,’ thought the miller’s daughter: and as she
+knew no other way to get her task done, she said she would do what he
+asked. Round went the wheel again to the old song, and the manikin once
+more spun the heap into gold. The king came in the morning, and, finding
+all he wanted, was forced to keep his word; so he married the miller’s
+daughter, and she really became queen.
+
+At the birth of her first little child she was very glad, and forgot the
+dwarf, and what she had said. But one day he came into her room, where
+she was sitting playing with her baby, and put her in mind of it. Then
+she grieved sorely at her misfortune, and said she would give him all
+the wealth of the kingdom if he would let her off, but in vain; till at
+last her tears softened him, and he said, ‘I will give you three days’
+grace, and if during that time you tell me my name, you shall keep your
+child.’
+
+Now the queen lay awake all night, thinking of all the odd names that
+she had ever heard; and she sent messengers all over the land to find
+out new ones. The next day the little man came, and she began with
+TIMOTHY, ICHABOD, BENJAMIN, JEREMIAH, and all the names she could
+remember; but to all and each of them he said, ‘Madam, that is not my
+name.’
+
+The second day she began with all the comical names she could hear of,
+BANDY-LEGS, HUNCHBACK, CROOK-SHANKS, and so on; but the little gentleman
+still said to every one of them, ‘Madam, that is not my name.’
+
+The third day one of the messengers came back, and said, ‘I have
+travelled two days without hearing of any other names; but yesterday, as
+I was climbing a high hill, among the trees of the forest where the fox
+and the hare bid each other good night, I saw a little hut; and before
+the hut burnt a fire; and round about the fire a funny little dwarf was
+dancing upon one leg, and singing:
+
+ “Merrily the feast I’ll make.
+  Today I’ll brew, tomorrow bake;
+  Merrily I’ll dance and sing,
+  For next day will a stranger bring.
+  Little does my lady dream
+  Rumpelstiltskin is my name!”
+
+When the queen heard this she jumped for joy, and as soon as her little
+friend came she sat down upon her throne, and called all her court round
+to enjoy the fun; and the nurse stood by her side with the baby in her
+arms, as if it was quite ready to be given up. Then the little man began
+to chuckle at the thought of having the poor child, to take home with
+him to his hut in the woods; and he cried out, ‘Now, lady, what is my
+name?’ ‘Is it JOHN?’ asked she. ‘No, madam!’ ‘Is it TOM?’ ‘No, madam!’
+‘Is it JEMMY?’ ‘It is not.’ ‘Can your name be RUMPELSTILTSKIN?’ said the
+lady slyly. ‘Some witch told you that!--some witch told you that!’ cried
+the little man, and dashed his right foot in a rage so deep into the
+floor, that he was forced to lay hold of it with both hands to pull it
+out.
+
+Then he made the best of his way off, while the nurse laughed and the
+baby crowed; and all the court jeered at him for having had so much
+trouble for nothing, and said, ‘We wish you a very good morning, and a
+merry feast, Mr RUMPLESTILTSKIN!’
+
+
+
+
+CLEVER GRETEL
+
+There was once a cook named Gretel, who wore shoes with red heels, and
+when she walked out with them on, she turned herself this way and that,
+was quite happy and thought: ‘You certainly are a pretty girl!’ And when
+she came home she drank, in her gladness of heart, a draught of wine,
+and as wine excites a desire to eat, she tasted the best of whatever she
+was cooking until she was satisfied, and said: ‘The cook must know what
+the food is like.’
+
+It came to pass that the master one day said to her: ‘Gretel, there is a
+guest coming this evening; prepare me two fowls very daintily.’ ‘I will
+see to it, master,’ answered Gretel. She killed two fowls, scalded them,
+plucked them, put them on the spit, and towards evening set them before
+the fire, that they might roast. The fowls began to turn brown, and were
+nearly ready, but the guest had not yet arrived. Then Gretel called out
+to her master: ‘If the guest does not come, I must take the fowls away
+from the fire, but it will be a sin and a shame if they are not eaten
+the moment they are at their juiciest.’ The master said: ‘I will run
+myself, and fetch the guest.’ When the master had turned his back,
+Gretel laid the spit with the fowls on one side, and thought: ‘Standing
+so long by the fire there, makes one sweat and thirsty; who knows
+when they will come? Meanwhile, I will run into the cellar, and take a
+drink.’ She ran down, set a jug, said: ‘God bless it for you, Gretel,’
+and took a good drink, and thought that wine should flow on, and should
+not be interrupted, and took yet another hearty draught.
+
+Then she went and put the fowls down again to the fire, basted them,
+and drove the spit merrily round. But as the roast meat smelt so good,
+Gretel thought: ‘Something might be wrong, it ought to be tasted!’
+She touched it with her finger, and said: ‘Ah! how good fowls are! It
+certainly is a sin and a shame that they are not eaten at the right
+time!’ She ran to the window, to see if the master was not coming with
+his guest, but she saw no one, and went back to the fowls and thought:
+‘One of the wings is burning! I had better take it off and eat it.’
+So she cut it off, ate it, and enjoyed it, and when she had done, she
+thought: ‘The other must go down too, or else master will observe that
+something is missing.’ When the two wings were eaten, she went and
+looked for her master, and did not see him. It suddenly occurred to
+her: ‘Who knows? They are perhaps not coming at all, and have turned in
+somewhere.’ Then she said: ‘Well, Gretel, enjoy yourself, one fowl has
+been cut into, take another drink, and eat it up entirely; when it is
+eaten you will have some peace, why should God’s good gifts be spoilt?’
+So she ran into the cellar again, took an enormous drink and ate up the
+one chicken in great glee. When one of the chickens was swallowed down,
+and still her master did not come, Gretel looked at the other and said:
+‘What one is, the other should be likewise, the two go together; what’s
+right for the one is right for the other; I think if I were to take
+another draught it would do me no harm.’ So she took another hearty
+drink, and let the second chicken follow the first.
+
+While she was making the most of it, her master came and cried: ‘Hurry
+up, Gretel, the guest is coming directly after me!’ ‘Yes, sir, I will
+soon serve up,’ answered Gretel. Meantime the master looked to see that
+the table was properly laid, and took the great knife, wherewith he was
+going to carve the chickens, and sharpened it on the steps. Presently
+the guest came, and knocked politely and courteously at the house-door.
+Gretel ran, and looked to see who was there, and when she saw the guest,
+she put her finger to her lips and said: ‘Hush! hush! go away as quickly
+as you can, if my master catches you it will be the worse for you; he
+certainly did ask you to supper, but his intention is to cut off your
+two ears. Just listen how he is sharpening the knife for it!’ The guest
+heard the sharpening, and hurried down the steps again as fast as he
+could. Gretel was not idle; she ran screaming to her master, and cried:
+‘You have invited a fine guest!’ ‘Why, Gretel? What do you mean by
+that?’ ‘Yes,’ said she, ‘he has taken the chickens which I was just
+going to serve up, off the dish, and has run away with them!’ ‘That’s a
+nice trick!’ said her master, and lamented the fine chickens. ‘If he had
+but left me one, so that something remained for me to eat.’ He called to
+him to stop, but the guest pretended not to hear. Then he ran after him
+with the knife still in his hand, crying: ‘Just one, just one,’ meaning
+that the guest should leave him just one chicken, and not take both. The
+guest, however, thought no otherwise than that he was to give up one of
+his ears, and ran as if fire were burning under him, in order to take
+them both with him.
+
+
+
+
+THE OLD MAN AND HIS GRANDSON
+
+There was once a very old man, whose eyes had become dim, his ears dull
+of hearing, his knees trembled, and when he sat at table he could hardly
+hold the spoon, and spilt the broth upon the table-cloth or let it run
+out of his mouth. His son and his son’s wife were disgusted at this, so
+the old grandfather at last had to sit in the corner behind the stove,
+and they gave him his food in an earthenware bowl, and not even enough
+of it. And he used to look towards the table with his eyes full of
+tears. Once, too, his trembling hands could not hold the bowl, and it
+fell to the ground and broke. The young wife scolded him, but he said
+nothing and only sighed. Then they brought him a wooden bowl for a few
+half-pence, out of which he had to eat.
+
+They were once sitting thus when the little grandson of four years old
+began to gather together some bits of wood upon the ground. ‘What are
+you doing there?’ asked the father. ‘I am making a little trough,’
+answered the child, ‘for father and mother to eat out of when I am big.’
+
+The man and his wife looked at each other for a while, and presently
+began to cry. Then they took the old grandfather to the table, and
+henceforth always let him eat with them, and likewise said nothing if he
+did spill a little of anything.
+
+
+
+
+THE LITTLE PEASANT
+
+There was a certain village wherein no one lived but really rich
+peasants, and just one poor one, whom they called the little peasant. He
+had not even so much as a cow, and still less money to buy one, and
+yet he and his wife did so wish to have one. One day he said to her:
+‘Listen, I have a good idea, there is our gossip the carpenter, he shall
+make us a wooden calf, and paint it brown, so that it looks like any
+other, and in time it will certainly get big and be a cow.’ the woman
+also liked the idea, and their gossip the carpenter cut and planed
+the calf, and painted it as it ought to be, and made it with its head
+hanging down as if it were eating.
+
+Next morning when the cows were being driven out, the little peasant
+called the cow-herd in and said: ‘Look, I have a little calf there,
+but it is still small and has to be carried.’ The cow-herd said: ‘All
+right,’ and took it in his arms and carried it to the pasture, and set
+it among the grass. The little calf always remained standing like one
+which was eating, and the cow-herd said: ‘It will soon run by itself,
+just look how it eats already!’ At night when he was going to drive the
+herd home again, he said to the calf: ‘If you can stand there and eat
+your fill, you can also go on your four legs; I don’t care to drag you
+home again in my arms.’ But the little peasant stood at his door, and
+waited for his little calf, and when the cow-herd drove the cows through
+the village, and the calf was missing, he inquired where it was. The
+cow-herd answered: ‘It is still standing out there eating. It would not
+stop and come with us.’ But the little peasant said: ‘Oh, but I must
+have my beast back again.’ Then they went back to the meadow together,
+but someone had stolen the calf, and it was gone. The cow-herd said: ‘It
+must have run away.’ The peasant, however, said: ‘Don’t tell me
+that,’ and led the cow-herd before the mayor, who for his carelessness
+condemned him to give the peasant a cow for the calf which had run away.
+
+And now the little peasant and his wife had the cow for which they had
+so long wished, and they were heartily glad, but they had no food for
+it, and could give it nothing to eat, so it soon had to be killed. They
+salted the flesh, and the peasant went into the town and wanted to sell
+the skin there, so that he might buy a new calf with the proceeds. On
+the way he passed by a mill, and there sat a raven with broken wings,
+and out of pity he took him and wrapped him in the skin. But as the
+weather grew so bad and there was a storm of rain and wind, he could
+go no farther, and turned back to the mill and begged for shelter. The
+miller’s wife was alone in the house, and said to the peasant: ‘Lay
+yourself on the straw there,’ and gave him a slice of bread and cheese.
+The peasant ate it, and lay down with his skin beside him, and the woman
+thought: ‘He is tired and has gone to sleep.’ In the meantime came the
+parson; the miller’s wife received him well, and said: ‘My husband is
+out, so we will have a feast.’ The peasant listened, and when he heard
+them talk about feasting he was vexed that he had been forced to make
+shift with a slice of bread and cheese. Then the woman served up four
+different things, roast meat, salad, cakes, and wine.
+
+Just as they were about to sit down and eat, there was a knocking
+outside. The woman said: ‘Oh, heavens! It is my husband!’ she quickly
+hid the roast meat inside the tiled stove, the wine under the pillow,
+the salad on the bed, the cakes under it, and the parson in the closet
+on the porch. Then she opened the door for her husband, and said: ‘Thank
+heaven, you are back again! There is such a storm, it looks as if the
+world were coming to an end.’ The miller saw the peasant lying on the
+straw, and asked, ‘What is that fellow doing there?’ ‘Ah,’ said the
+wife, ‘the poor knave came in the storm and rain, and begged for
+shelter, so I gave him a bit of bread and cheese, and showed him where
+the straw was.’ The man said: ‘I have no objection, but be quick and get
+me something to eat.’ The woman said: ‘But I have nothing but bread and
+cheese.’ ‘I am contented with anything,’ replied the husband, ‘so far as
+I am concerned, bread and cheese will do,’ and looked at the peasant and
+said: ‘Come and eat some more with me.’ The peasant did not require to
+be invited twice, but got up and ate. After this the miller saw the skin
+in which the raven was, lying on the ground, and asked: ‘What have you
+there?’ The peasant answered: ‘I have a soothsayer inside it.’ ‘Can
+he foretell anything to me?’ said the miller. ‘Why not?’ answered
+the peasant: ‘but he only says four things, and the fifth he keeps to
+himself.’ The miller was curious, and said: ‘Let him foretell something
+for once.’ Then the peasant pinched the raven’s head, so that he croaked
+and made a noise like krr, krr. The miller said: ‘What did he say?’ The
+peasant answered: ‘In the first place, he says that there is some wine
+hidden under the pillow.’ ‘Bless me!’ cried the miller, and went there
+and found the wine. ‘Now go on,’ said he. The peasant made the raven
+croak again, and said: ‘In the second place, he says that there is some
+roast meat in the tiled stove.’ ‘Upon my word!’ cried the miller, and
+went thither, and found the roast meat. The peasant made the raven
+prophesy still more, and said: ‘Thirdly, he says that there is some
+salad on the bed.’ ‘That would be a fine thing!’ cried the miller, and
+went there and found the salad. At last the peasant pinched the raven
+once more till he croaked, and said: ‘Fourthly, he says that there
+are some cakes under the bed.’ ‘That would be a fine thing!’ cried the
+miller, and looked there, and found the cakes.
+
+And now the two sat down to the table together, but the miller’s wife
+was frightened to death, and went to bed and took all the keys with
+her. The miller would have liked much to know the fifth, but the little
+peasant said: ‘First, we will quickly eat the four things, for the fifth
+is something bad.’ So they ate, and after that they bargained how much
+the miller was to give for the fifth prophecy, until they agreed on
+three hundred talers. Then the peasant once more pinched the raven’s
+head till he croaked loudly. The miller asked: ‘What did he say?’ The
+peasant replied: ‘He says that the Devil is hiding outside there in
+the closet on the porch.’ The miller said: ‘The Devil must go out,’ and
+opened the house-door; then the woman was forced to give up the keys,
+and the peasant unlocked the closet. The parson ran out as fast as he
+could, and the miller said: ‘It was true; I saw the black rascal with my
+own eyes.’ The peasant, however, made off next morning by daybreak with
+the three hundred talers.
+
+At home the small peasant gradually launched out; he built a beautiful
+house, and the peasants said: ‘The small peasant has certainly been to
+the place where golden snow falls, and people carry the gold home in
+shovels.’ Then the small peasant was brought before the mayor, and
+bidden to say from whence his wealth came. He answered: ‘I sold my cow’s
+skin in the town, for three hundred talers.’ When the peasants heard
+that, they too wished to enjoy this great profit, and ran home, killed
+all their cows, and stripped off their skins in order to sell them in
+the town to the greatest advantage. The mayor, however, said: ‘But my
+servant must go first.’ When she came to the merchant in the town, he
+did not give her more than two talers for a skin, and when the others
+came, he did not give them so much, and said: ‘What can I do with all
+these skins?’
+
+Then the peasants were vexed that the small peasant should have thus
+outwitted them, wanted to take vengeance on him, and accused him of this
+treachery before the mayor. The innocent little peasant was unanimously
+sentenced to death, and was to be rolled into the water, in a barrel
+pierced full of holes. He was led forth, and a priest was brought who
+was to say a mass for his soul. The others were all obliged to retire to
+a distance, and when the peasant looked at the priest, he recognized the
+man who had been with the miller’s wife. He said to him: ‘I set you free
+from the closet, set me free from the barrel.’ At this same moment up
+came, with a flock of sheep, the very shepherd whom the peasant knew had
+long been wishing to be mayor, so he cried with all his might: ‘No, I
+will not do it; if the whole world insists on it, I will not do it!’ The
+shepherd hearing that, came up to him, and asked: ‘What are you about?
+What is it that you will not do?’ The peasant said: ‘They want to make
+me mayor, if I will but put myself in the barrel, but I will not do it.’
+The shepherd said: ‘If nothing more than that is needful in order to be
+mayor, I would get into the barrel at once.’ The peasant said: ‘If you
+will get in, you will be mayor.’ The shepherd was willing, and got in,
+and the peasant shut the top down on him; then he took the shepherd’s
+flock for himself, and drove it away. The parson went to the crowd,
+and declared that the mass had been said. Then they came and rolled the
+barrel towards the water. When the barrel began to roll, the shepherd
+cried: ‘I am quite willing to be mayor.’ They believed no otherwise than
+that it was the peasant who was saying this, and answered: ‘That is
+what we intend, but first you shall look about you a little down below
+there,’ and they rolled the barrel down into the water.
+
+After that the peasants went home, and as they were entering the
+village, the small peasant also came quietly in, driving a flock of
+sheep and looking quite contented. Then the peasants were astonished,
+and said: ‘Peasant, from whence do you come? Have you come out of the
+water?’ ‘Yes, truly,’ replied the peasant, ‘I sank deep, deep down,
+until at last I got to the bottom; I pushed the bottom out of the
+barrel, and crept out, and there were pretty meadows on which a number
+of lambs were feeding, and from thence I brought this flock away with
+me.’ Said the peasants: ‘Are there any more there?’ ‘Oh, yes,’ said he,
+‘more than I could want.’ Then the peasants made up their minds that
+they too would fetch some sheep for themselves, a flock apiece, but the
+mayor said: ‘I come first.’ So they went to the water together, and just
+then there were some of the small fleecy clouds in the blue sky, which
+are called little lambs, and they were reflected in the water, whereupon
+the peasants cried: ‘We already see the sheep down below!’ The mayor
+pressed forward and said: ‘I will go down first, and look about me, and
+if things promise well I’ll call you.’ So he jumped in; splash! went
+the water; it sounded as if he were calling them, and the whole crowd
+plunged in after him as one man. Then the entire village was dead, and
+the small peasant, as sole heir, became a rich man.
+
+
+
+
+FREDERICK AND CATHERINE
+
+There was once a man called Frederick: he had a wife whose name was
+Catherine, and they had not long been married. One day Frederick said.
+‘Kate! I am going to work in the fields; when I come back I shall be
+hungry so let me have something nice cooked, and a good draught of ale.’
+‘Very well,’ said she, ‘it shall all be ready.’ When dinner-time drew
+nigh, Catherine took a nice steak, which was all the meat she had, and
+put it on the fire to fry. The steak soon began to look brown, and to
+crackle in the pan; and Catherine stood by with a fork and turned it:
+then she said to herself, ‘The steak is almost ready, I may as well go
+to the cellar for the ale.’ So she left the pan on the fire and took a
+large jug and went into the cellar and tapped the ale cask. The beer ran
+into the jug and Catherine stood looking on. At last it popped into her
+head, ‘The dog is not shut up--he may be running away with the steak;
+that’s well thought of.’ So up she ran from the cellar; and sure enough
+the rascally cur had got the steak in his mouth, and was making off with
+it.
+
+Away ran Catherine, and away ran the dog across the field: but he ran
+faster than she, and stuck close to the steak. ‘It’s all gone, and “what
+can’t be cured must be endured”,’ said Catherine. So she turned round;
+and as she had run a good way and was tired, she walked home leisurely
+to cool herself.
+
+Now all this time the ale was running too, for Catherine had not turned
+the cock; and when the jug was full the liquor ran upon the floor till
+the cask was empty. When she got to the cellar stairs she saw what had
+happened. ‘My stars!’ said she, ‘what shall I do to keep Frederick from
+seeing all this slopping about?’ So she thought a while; and at last
+remembered that there was a sack of fine meal bought at the last fair,
+and that if she sprinkled this over the floor it would suck up the ale
+nicely. ‘What a lucky thing,’ said she, ‘that we kept that meal! we have
+now a good use for it.’ So away she went for it: but she managed to set
+it down just upon the great jug full of beer, and upset it; and thus
+all the ale that had been saved was set swimming on the floor also. ‘Ah!
+well,’ said she, ‘when one goes another may as well follow.’ Then she
+strewed the meal all about the cellar, and was quite pleased with her
+cleverness, and said, ‘How very neat and clean it looks!’
+
+At noon Frederick came home. ‘Now, wife,’ cried he, ‘what have you for
+dinner?’ ‘O Frederick!’ answered she, ‘I was cooking you a steak; but
+while I went down to draw the ale, the dog ran away with it; and while
+I ran after him, the ale ran out; and when I went to dry up the ale
+with the sack of meal that we got at the fair, I upset the jug: but the
+cellar is now quite dry, and looks so clean!’ ‘Kate, Kate,’ said he,
+‘how could you do all this?’ Why did you leave the steak to fry, and the
+ale to run, and then spoil all the meal?’ ‘Why, Frederick,’ said she, ‘I
+did not know I was doing wrong; you should have told me before.’
+
+The husband thought to himself, ‘If my wife manages matters thus, I must
+look sharp myself.’ Now he had a good deal of gold in the house: so he
+said to Catherine, ‘What pretty yellow buttons these are! I shall put
+them into a box and bury them in the garden; but take care that you
+never go near or meddle with them.’ ‘No, Frederick,’ said she, ‘that
+I never will.’ As soon as he was gone, there came by some pedlars with
+earthenware plates and dishes, and they asked her whether she would buy.
+‘Oh dear me, I should like to buy very much, but I have no money: if
+you had any use for yellow buttons, I might deal with you.’ ‘Yellow
+buttons!’ said they: ‘let us have a look at them.’ ‘Go into the garden
+and dig where I tell you, and you will find the yellow buttons: I dare
+not go myself.’ So the rogues went: and when they found what these
+yellow buttons were, they took them all away, and left her plenty of
+plates and dishes. Then she set them all about the house for a show:
+and when Frederick came back, he cried out, ‘Kate, what have you been
+doing?’ ‘See,’ said she, ‘I have bought all these with your yellow
+buttons: but I did not touch them myself; the pedlars went themselves
+and dug them up.’ ‘Wife, wife,’ said Frederick, ‘what a pretty piece of
+work you have made! those yellow buttons were all my money: how came you
+to do such a thing?’ ‘Why,’ answered she, ‘I did not know there was any
+harm in it; you should have told me.’
+
+Catherine stood musing for a while, and at last said to her husband,
+‘Hark ye, Frederick, we will soon get the gold back: let us run after
+the thieves.’ ‘Well, we will try,’ answered he; ‘but take some butter
+and cheese with you, that we may have something to eat by the way.’
+‘Very well,’ said she; and they set out: and as Frederick walked the
+fastest, he left his wife some way behind. ‘It does not matter,’ thought
+she: ‘when we turn back, I shall be so much nearer home than he.’
+
+Presently she came to the top of a hill, down the side of which there
+was a road so narrow that the cart wheels always chafed the trees
+on each side as they passed. ‘Ah, see now,’ said she, ‘how they have
+bruised and wounded those poor trees; they will never get well.’ So she
+took pity on them, and made use of the butter to grease them all, so
+that the wheels might not hurt them so much. While she was doing this
+kind office one of her cheeses fell out of the basket, and rolled down
+the hill. Catherine looked, but could not see where it had gone; so she
+said, ‘Well, I suppose the other will go the same way and find you; he
+has younger legs than I have.’ Then she rolled the other cheese after
+it; and away it went, nobody knows where, down the hill. But she said
+she supposed that they knew the road, and would follow her, and she
+could not stay there all day waiting for them.
+
+At last she overtook Frederick, who desired her to give him something to
+eat. Then she gave him the dry bread. ‘Where are the butter and cheese?’
+said he. ‘Oh!’ answered she, ‘I used the butter to grease those poor
+trees that the wheels chafed so: and one of the cheeses ran away so I
+sent the other after it to find it, and I suppose they are both on
+the road together somewhere.’ ‘What a goose you are to do such silly
+things!’ said the husband. ‘How can you say so?’ said she; ‘I am sure
+you never told me not.’
+
+They ate the dry bread together; and Frederick said, ‘Kate, I hope you
+locked the door safe when you came away.’ ‘No,’ answered she, ‘you did
+not tell me.’ ‘Then go home, and do it now before we go any farther,’
+said Frederick, ‘and bring with you something to eat.’
+
+Catherine did as he told her, and thought to herself by the way,
+‘Frederick wants something to eat; but I don’t think he is very fond of
+butter and cheese: I’ll bring him a bag of fine nuts, and the vinegar,
+for I have often seen him take some.’
+
+When she reached home, she bolted the back door, but the front door she
+took off the hinges, and said, ‘Frederick told me to lock the door, but
+surely it can nowhere be so safe if I take it with me.’ So she took
+her time by the way; and when she overtook her husband she cried
+out, ‘There, Frederick, there is the door itself, you may watch it as
+carefully as you please.’ ‘Alas! alas!’ said he, ‘what a clever wife I
+have! I sent you to make the house fast, and you take the door away, so
+that everybody may go in and out as they please--however, as you have
+brought the door, you shall carry it about with you for your pains.’
+‘Very well,’ answered she, ‘I’ll carry the door; but I’ll not carry the
+nuts and vinegar bottle also--that would be too much of a load; so if
+you please, I’ll fasten them to the door.’
+
+Frederick of course made no objection to that plan, and they set off
+into the wood to look for the thieves; but they could not find them: and
+when it grew dark, they climbed up into a tree to spend the night there.
+Scarcely were they up, than who should come by but the very rogues they
+were looking for. They were in truth great rascals, and belonged to that
+class of people who find things before they are lost; they were tired;
+so they sat down and made a fire under the very tree where Frederick and
+Catherine were. Frederick slipped down on the other side, and picked up
+some stones. Then he climbed up again, and tried to hit the thieves on
+the head with them: but they only said, ‘It must be near morning, for
+the wind shakes the fir-apples down.’
+
+Catherine, who had the door on her shoulder, began to be very tired;
+but she thought it was the nuts upon it that were so heavy: so she said
+softly, ‘Frederick, I must let the nuts go.’ ‘No,’ answered he, ‘not
+now, they will discover us.’ ‘I can’t help that: they must go.’ ‘Well,
+then, make haste and throw them down, if you will.’ Then away rattled
+the nuts down among the boughs and one of the thieves cried, ‘Bless me,
+it is hailing.’
+
+A little while after, Catherine thought the door was still very heavy:
+so she whispered to Frederick, ‘I must throw the vinegar down.’ ‘Pray
+don’t,’ answered he, ‘it will discover us.’ ‘I can’t help that,’ said
+she, ‘go it must.’ So she poured all the vinegar down; and the thieves
+said, ‘What a heavy dew there is!’
+
+At last it popped into Catherine’s head that it was the door itself that
+was so heavy all the time: so she whispered, ‘Frederick, I must throw
+the door down soon.’ But he begged and prayed her not to do so, for he
+was sure it would betray them. ‘Here goes, however,’ said she: and down
+went the door with such a clatter upon the thieves, that they cried
+out ‘Murder!’ and not knowing what was coming, ran away as fast as they
+could, and left all the gold. So when Frederick and Catherine came down,
+there they found all their money safe and sound.
+
+
+
+
+SWEETHEART ROLAND
+
+There was once upon a time a woman who was a real witch and had two
+daughters, one ugly and wicked, and this one she loved because she was
+her own daughter, and one beautiful and good, and this one she hated,
+because she was her stepdaughter. The stepdaughter once had a pretty
+apron, which the other fancied so much that she became envious, and
+told her mother that she must and would have that apron. ‘Be quiet, my
+child,’ said the old woman, ‘and you shall have it. Your stepsister has
+long deserved death; tonight when she is asleep I will come and cut her
+head off. Only be careful that you are at the far side of the bed, and
+push her well to the front.’ It would have been all over with the poor
+girl if she had not just then been standing in a corner, and heard
+everything. All day long she dared not go out of doors, and when bedtime
+had come, the witch’s daughter got into bed first, so as to lie at the
+far side, but when she was asleep, the other pushed her gently to the
+front, and took for herself the place at the back, close by the wall. In
+the night, the old woman came creeping in, she held an axe in her right
+hand, and felt with her left to see if anyone were lying at the outside,
+and then she grasped the axe with both hands, and cut her own child’s
+head off.
+
+When she had gone away, the girl got up and went to her sweetheart, who
+was called Roland, and knocked at his door. When he came out, she said
+to him: ‘Listen, dearest Roland, we must fly in all haste; my stepmother
+wanted to kill me, but has struck her own child. When daylight comes,
+and she sees what she has done, we shall be lost.’ ‘But,’ said Roland,
+‘I counsel you first to take away her magic wand, or we cannot escape
+if she pursues us.’ The maiden fetched the magic wand, and she took the
+dead girl’s head and dropped three drops of blood on the ground, one in
+front of the bed, one in the kitchen, and one on the stairs. Then she
+hurried away with her lover.
+
+When the old witch got up next morning, she called her daughter, and
+wanted to give her the apron, but she did not come. Then the witch
+cried: ‘Where are you?’ ‘Here, on the stairs, I am sweeping,’ answered
+the first drop of blood. The old woman went out, but saw no one on the
+stairs, and cried again: ‘Where are you?’ ‘Here in the kitchen, I am
+warming myself,’ cried the second drop of blood. She went into the
+kitchen, but found no one. Then she cried again: ‘Where are you?’ ‘Ah,
+here in the bed, I am sleeping,’ cried the third drop of blood. She went
+into the room to the bed. What did she see there? Her own child,
+whose head she had cut off, bathed in her blood. The witch fell into
+a passion, sprang to the window, and as she could look forth quite far
+into the world, she perceived her stepdaughter hurrying away with her
+sweetheart Roland. ‘That shall not help you,’ cried she, ‘even if you
+have got a long way off, you shall still not escape me.’ She put on her
+many-league boots, in which she covered an hour’s walk at every step,
+and it was not long before she overtook them. The girl, however, when
+she saw the old woman striding towards her, changed, with her magic
+wand, her sweetheart Roland into a lake, and herself into a duck
+swimming in the middle of it. The witch placed herself on the shore,
+threw breadcrumbs in, and went to endless trouble to entice the duck;
+but the duck did not let herself be enticed, and the old woman had to
+go home at night as she had come. At this the girl and her sweetheart
+Roland resumed their natural shapes again, and they walked on the whole
+night until daybreak. Then the maiden changed herself into a beautiful
+flower which stood in the midst of a briar hedge, and her sweetheart
+Roland into a fiddler. It was not long before the witch came striding up
+towards them, and said to the musician: ‘Dear musician, may I pluck that
+beautiful flower for myself?’ ‘Oh, yes,’ he replied, ‘I will play to
+you while you do it.’ As she was hastily creeping into the hedge and was
+just going to pluck the flower, knowing perfectly well who the flower
+was, he began to play, and whether she would or not, she was forced
+to dance, for it was a magical dance. The faster he played, the more
+violent springs was she forced to make, and the thorns tore her clothes
+from her body, and pricked her and wounded her till she bled, and as he
+did not stop, she had to dance till she lay dead on the ground.
+
+As they were now set free, Roland said: ‘Now I will go to my father and
+arrange for the wedding.’ ‘Then in the meantime I will stay here and
+wait for you,’ said the girl, ‘and that no one may recognize me, I will
+change myself into a red stone landmark.’ Then Roland went away, and the
+girl stood like a red landmark in the field and waited for her beloved.
+But when Roland got home, he fell into the snares of another, who so
+fascinated him that he forgot the maiden. The poor girl remained there a
+long time, but at length, as he did not return at all, she was sad, and
+changed herself into a flower, and thought: ‘Someone will surely come
+this way, and trample me down.’
+
+It befell, however, that a shepherd kept his sheep in the field and saw
+the flower, and as it was so pretty, plucked it, took it with him, and
+laid it away in his chest. From that time forth, strange things happened
+in the shepherd’s house. When he arose in the morning, all the work was
+already done, the room was swept, the table and benches cleaned, the
+fire in the hearth was lighted, and the water was fetched, and at noon,
+when he came home, the table was laid, and a good dinner served. He
+could not conceive how this came to pass, for he never saw a human being
+in his house, and no one could have concealed himself in it. He was
+certainly pleased with this good attendance, but still at last he was so
+afraid that he went to a wise woman and asked for her advice. The wise
+woman said: ‘There is some enchantment behind it, listen very early some
+morning if anything is moving in the room, and if you see anything, no
+matter what it is, throw a white cloth over it, and then the magic will
+be stopped.’
+
+The shepherd did as she bade him, and next morning just as day dawned,
+he saw the chest open, and the flower come out. Swiftly he
+sprang towards it, and threw a white cloth over it. Instantly the
+transformation came to an end, and a beautiful girl stood before him,
+who admitted to him that she had been the flower, and that up to this
+time she had attended to his house-keeping. She told him her story,
+and as she pleased him he asked her if she would marry him, but she
+answered: ‘No,’ for she wanted to remain faithful to her sweetheart
+Roland, although he had deserted her. Nevertheless, she promised not to
+go away, but to continue keeping house for the shepherd.
+
+And now the time drew near when Roland’s wedding was to be celebrated,
+and then, according to an old custom in the country, it was announced
+that all the girls were to be present at it, and sing in honour of the
+bridal pair. When the faithful maiden heard of this, she grew so sad
+that she thought her heart would break, and she would not go thither,
+but the other girls came and took her. When it came to her turn to sing,
+she stepped back, until at last she was the only one left, and then she
+could not refuse. But when she began her song, and it reached Roland’s
+ears, he sprang up and cried: ‘I know the voice, that is the true
+bride, I will have no other!’ Everything he had forgotten, and which had
+vanished from his mind, had suddenly come home again to his heart. Then
+the faithful maiden held her wedding with her sweetheart Roland, and
+grief came to an end and joy began.
+
+
+
+
+SNOWDROP
+
+It was the middle of winter, when the broad flakes of snow were falling
+around, that the queen of a country many thousand miles off sat working
+at her window. The frame of the window was made of fine black ebony, and
+as she sat looking out upon the snow, she pricked her finger, and three
+drops of blood fell upon it. Then she gazed thoughtfully upon the red
+drops that sprinkled the white snow, and said, ‘Would that my little
+daughter may be as white as that snow, as red as that blood, and as
+black as this ebony windowframe!’ And so the little girl really did grow
+up; her skin was as white as snow, her cheeks as rosy as the blood, and
+her hair as black as ebony; and she was called Snowdrop.
+
+But this queen died; and the king soon married another wife, who became
+queen, and was very beautiful, but so vain that she could not bear
+to think that anyone could be handsomer than she was. She had a fairy
+looking-glass, to which she used to go, and then she would gaze upon
+herself in it, and say:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass had always answered:
+
+ ‘Thou, queen, art the fairest in all the land.’
+
+But Snowdrop grew more and more beautiful; and when she was seven years
+old she was as bright as the day, and fairer than the queen herself.
+Then the glass one day answered the queen, when she went to look in it
+as usual:
+
+ ‘Thou, queen, art fair, and beauteous to see,
+  But Snowdrop is lovelier far than thee!’
+
+When she heard this she turned pale with rage and envy, and called to
+one of her servants, and said, ‘Take Snowdrop away into the wide wood,
+that I may never see her any more.’ Then the servant led her away; but
+his heart melted when Snowdrop begged him to spare her life, and he
+said, ‘I will not hurt you, thou pretty child.’ So he left her by
+herself; and though he thought it most likely that the wild beasts would
+tear her in pieces, he felt as if a great weight were taken off his
+heart when he had made up his mind not to kill her but to leave her to
+her fate, with the chance of someone finding and saving her.
+
+Then poor Snowdrop wandered along through the wood in great fear; and
+the wild beasts roared about her, but none did her any harm. In the
+evening she came to a cottage among the hills, and went in to rest, for
+her little feet would carry her no further. Everything was spruce and
+neat in the cottage: on the table was spread a white cloth, and there
+were seven little plates, seven little loaves, and seven little glasses
+with wine in them; and seven knives and forks laid in order; and by
+the wall stood seven little beds. As she was very hungry, she picked
+a little piece of each loaf and drank a very little wine out of each
+glass; and after that she thought she would lie down and rest. So she
+tried all the little beds; but one was too long, and another was too
+short, till at last the seventh suited her: and there she laid herself
+down and went to sleep.
+
+By and by in came the masters of the cottage. Now they were seven little
+dwarfs, that lived among the mountains, and dug and searched for gold.
+They lighted up their seven lamps, and saw at once that all was not
+right. The first said, ‘Who has been sitting on my stool?’ The second,
+‘Who has been eating off my plate?’ The third, ‘Who has been picking my
+bread?’ The fourth, ‘Who has been meddling with my spoon?’ The fifth,
+‘Who has been handling my fork?’ The sixth, ‘Who has been cutting with
+my knife?’ The seventh, ‘Who has been drinking my wine?’ Then the first
+looked round and said, ‘Who has been lying on my bed?’ And the rest came
+running to him, and everyone cried out that somebody had been upon his
+bed. But the seventh saw Snowdrop, and called all his brethren to come
+and see her; and they cried out with wonder and astonishment and brought
+their lamps to look at her, and said, ‘Good heavens! what a lovely child
+she is!’ And they were very glad to see her, and took care not to wake
+her; and the seventh dwarf slept an hour with each of the other dwarfs
+in turn, till the night was gone.
+
+In the morning Snowdrop told them all her story; and they pitied her,
+and said if she would keep all things in order, and cook and wash and
+knit and spin for them, she might stay where she was, and they would
+take good care of her. Then they went out all day long to their work,
+seeking for gold and silver in the mountains: but Snowdrop was left at
+home; and they warned her, and said, ‘The queen will soon find out where
+you are, so take care and let no one in.’
+
+But the queen, now that she thought Snowdrop was dead, believed that she
+must be the handsomest lady in the land; and she went to her glass and
+said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the queen was very much frightened; for she knew that the glass
+always spoke the truth, and was sure that the servant had betrayed her.
+And she could not bear to think that anyone lived who was more beautiful
+than she was; so she dressed herself up as an old pedlar, and went
+her way over the hills, to the place where the dwarfs dwelt. Then she
+knocked at the door, and cried, ‘Fine wares to sell!’ Snowdrop looked
+out at the window, and said, ‘Good day, good woman! what have you to
+sell?’ ‘Good wares, fine wares,’ said she; ‘laces and bobbins of all
+colours.’ ‘I will let the old lady in; she seems to be a very good
+sort of body,’ thought Snowdrop, as she ran down and unbolted the door.
+‘Bless me!’ said the old woman, ‘how badly your stays are laced! Let me
+lace them up with one of my nice new laces.’ Snowdrop did not dream of
+any mischief; so she stood before the old woman; but she set to work
+so nimbly, and pulled the lace so tight, that Snowdrop’s breath was
+stopped, and she fell down as if she were dead. ‘There’s an end to all
+thy beauty,’ said the spiteful queen, and went away home.
+
+In the evening the seven dwarfs came home; and I need not say how
+grieved they were to see their faithful Snowdrop stretched out upon the
+ground, as if she was quite dead. However, they lifted her up, and when
+they found what ailed her, they cut the lace; and in a little time she
+began to breathe, and very soon came to life again. Then they said, ‘The
+old woman was the queen herself; take care another time, and let no one
+in when we are away.’
+
+When the queen got home, she went straight to her glass, and spoke to it
+as before; but to her great grief it still said:
+
+ ‘Thou, queen, art the fairest in all this land:
+  But over the hills, in the greenwood shade,
+  Where the seven dwarfs their dwelling have made,
+  There Snowdrop is hiding her head; and she
+  Is lovelier far, O queen! than thee.’
+
+Then the blood ran cold in her heart with spite and malice, to see that
+Snowdrop still lived; and she dressed herself up again, but in quite
+another dress from the one she wore before, and took with her a poisoned
+comb. When she reached the dwarfs’ cottage, she knocked at the door, and
+cried, ‘Fine wares to sell!’ But Snowdrop said, ‘I dare not let anyone
+in.’ Then the queen said, ‘Only look at my beautiful combs!’ and gave
+her the poisoned one. And it looked so pretty, that she took it up and
+put it into her hair to try it; but the moment it touched her head,
+the poison was so powerful that she fell down senseless. ‘There you may
+lie,’ said the queen, and went her way. But by good luck the dwarfs
+came in very early that evening; and when they saw Snowdrop lying on
+the ground, they thought what had happened, and soon found the poisoned
+comb. And when they took it away she got well, and told them all that
+had passed; and they warned her once more not to open the door to
+anyone.
+
+Meantime the queen went home to her glass, and shook with rage when she
+read the very same answer as before; and she said, ‘Snowdrop shall die,
+if it cost me my life.’ So she went by herself into her chamber, and got
+ready a poisoned apple: the outside looked very rosy and tempting, but
+whoever tasted it was sure to die. Then she dressed herself up as a
+peasant’s wife, and travelled over the hills to the dwarfs’ cottage,
+and knocked at the door; but Snowdrop put her head out of the window and
+said, ‘I dare not let anyone in, for the dwarfs have told me not.’ ‘Do
+as you please,’ said the old woman, ‘but at any rate take this pretty
+apple; I will give it you.’ ‘No,’ said Snowdrop, ‘I dare not take it.’
+‘You silly girl!’ answered the other, ‘what are you afraid of? Do you
+think it is poisoned? Come! do you eat one part, and I will eat the
+other.’ Now the apple was so made up that one side was good, though the
+other side was poisoned. Then Snowdrop was much tempted to taste, for
+the apple looked so very nice; and when she saw the old woman eat, she
+could wait no longer. But she had scarcely put the piece into her mouth,
+when she fell down dead upon the ground. ‘This time nothing will save
+thee,’ said the queen; and she went home to her glass, and at last it
+said:
+
+ ‘Thou, queen, art the fairest of all the fair.’
+
+And then her wicked heart was glad, and as happy as such a heart could
+be.
+
+When evening came, and the dwarfs had gone home, they found Snowdrop
+lying on the ground: no breath came from her lips, and they were afraid
+that she was quite dead. They lifted her up, and combed her hair, and
+washed her face with wine and water; but all was in vain, for the little
+girl seemed quite dead. So they laid her down upon a bier, and all seven
+watched and bewailed her three whole days; and then they thought they
+would bury her: but her cheeks were still rosy; and her face looked just
+as it did while she was alive; so they said, ‘We will never bury her in
+the cold ground.’ And they made a coffin of glass, so that they might
+still look at her, and wrote upon it in golden letters what her name
+was, and that she was a king’s daughter. And the coffin was set among
+the hills, and one of the dwarfs always sat by it and watched. And the
+birds of the air came too, and bemoaned Snowdrop; and first of all came
+an owl, and then a raven, and at last a dove, and sat by her side.
+
+And thus Snowdrop lay for a long, long time, and still only looked as
+though she was asleep; for she was even now as white as snow, and as red
+as blood, and as black as ebony. At last a prince came and called at the
+dwarfs’ house; and he saw Snowdrop, and read what was written in golden
+letters. Then he offered the dwarfs money, and prayed and besought them
+to let him take her away; but they said, ‘We will not part with her for
+all the gold in the world.’ At last, however, they had pity on him, and
+gave him the coffin; but the moment he lifted it up to carry it home
+with him, the piece of apple fell from between her lips, and Snowdrop
+awoke, and said, ‘Where am I?’ And the prince said, ‘Thou art quite safe
+with me.’
+
+Then he told her all that had happened, and said, ‘I love you far better
+than all the world; so come with me to my father’s palace, and you shall
+be my wife.’ And Snowdrop consented, and went home with the prince;
+and everything was got ready with great pomp and splendour for their
+wedding.
+
+To the feast was asked, among the rest, Snowdrop’s old enemy the queen;
+and as she was dressing herself in fine rich clothes, she looked in the
+glass and said:
+
+ ‘Tell me, glass, tell me true!
+  Of all the ladies in the land,
+  Who is fairest, tell me, who?’
+
+And the glass answered:
+
+ ‘Thou, lady, art loveliest here, I ween;
+  But lovelier far is the new-made queen.’
+
+When she heard this she started with rage; but her envy and curiosity
+were so great, that she could not help setting out to see the bride. And
+when she got there, and saw that it was no other than Snowdrop, who, as
+she thought, had been dead a long while, she choked with rage, and fell
+down and died: but Snowdrop and the prince lived and reigned happily
+over that land many, many years; and sometimes they went up into the
+mountains, and paid a visit to the little dwarfs, who had been so kind
+to Snowdrop in her time of need.
+
+
+
+
+THE PINK
+
+There was once upon a time a queen to whom God had given no children.
+Every morning she went into the garden and prayed to God in heaven to
+bestow on her a son or a daughter. Then an angel from heaven came to her
+and said: ‘Be at rest, you shall have a son with the power of wishing,
+so that whatsoever in the world he wishes for, that shall he have.’ Then
+she went to the king, and told him the joyful tidings, and when the time
+was come she gave birth to a son, and the king was filled with gladness.
+
+Every morning she went with the child to the garden where the wild
+beasts were kept, and washed herself there in a clear stream. It
+happened once when the child was a little older, that it was lying in
+her arms and she fell asleep. Then came the old cook, who knew that the
+child had the power of wishing, and stole it away, and he took a hen,
+and cut it in pieces, and dropped some of its blood on the queen’s apron
+and on her dress. Then he carried the child away to a secret place,
+where a nurse was obliged to suckle it, and he ran to the king and
+accused the queen of having allowed her child to be taken from her by
+the wild beasts. When the king saw the blood on her apron, he believed
+this, fell into such a passion that he ordered a high tower to be built,
+in which neither sun nor moon could be seen and had his wife put into
+it, and walled up. Here she was to stay for seven years without meat
+or drink, and die of hunger. But God sent two angels from heaven in the
+shape of white doves, which flew to her twice a day, and carried her
+food until the seven years were over.
+
+The cook, however, thought to himself: ‘If the child has the power of
+wishing, and I am here, he might very easily get me into trouble.’ So
+he left the palace and went to the boy, who was already big enough to
+speak, and said to him: ‘Wish for a beautiful palace for yourself with
+a garden, and all else that pertains to it.’ Scarcely were the words out
+of the boy’s mouth, when everything was there that he had wished for.
+After a while the cook said to him: ‘It is not well for you to be so
+alone, wish for a pretty girl as a companion.’ Then the king’s son
+wished for one, and she immediately stood before him, and was more
+beautiful than any painter could have painted her. The two played
+together, and loved each other with all their hearts, and the old cook
+went out hunting like a nobleman. The thought occurred to him, however,
+that the king’s son might some day wish to be with his father, and thus
+bring him into great peril. So he went out and took the maiden aside,
+and said: ‘Tonight when the boy is asleep, go to his bed and plunge this
+knife into his heart, and bring me his heart and tongue, and if you do
+not do it, you shall lose your life.’ Thereupon he went away, and when
+he returned next day she had not done it, and said: ‘Why should I shed
+the blood of an innocent boy who has never harmed anyone?’ The cook once
+more said: ‘If you do not do it, it shall cost you your own life.’ When
+he had gone away, she had a little hind brought to her, and ordered her
+to be killed, and took her heart and tongue, and laid them on a plate,
+and when she saw the old man coming, she said to the boy: ‘Lie down in
+your bed, and draw the clothes over you.’ Then the wicked wretch came in
+and said: ‘Where are the boy’s heart and tongue?’ The girl reached the
+plate to him, but the king’s son threw off the quilt, and said: ‘You old
+sinner, why did you want to kill me? Now will I pronounce thy sentence.
+You shall become a black poodle and have a gold collar round your neck,
+and shall eat burning coals, till the flames burst forth from your
+throat.’ And when he had spoken these words, the old man was changed
+into a poodle dog, and had a gold collar round his neck, and the cooks
+were ordered to bring up some live coals, and these he ate, until the
+flames broke forth from his throat. The king’s son remained there a
+short while longer, and he thought of his mother, and wondered if she
+were still alive. At length he said to the maiden: ‘I will go home to my
+own country; if you will go with me, I will provide for you.’ ‘Ah,’
+she replied, ‘the way is so long, and what shall I do in a strange land
+where I am unknown?’ As she did not seem quite willing, and as they
+could not be parted from each other, he wished that she might be changed
+into a beautiful pink, and took her with him. Then he went away to his
+own country, and the poodle had to run after him. He went to the tower
+in which his mother was confined, and as it was so high, he wished for
+a ladder which would reach up to the very top. Then he mounted up and
+looked inside, and cried: ‘Beloved mother, Lady Queen, are you still
+alive, or are you dead?’ She answered: ‘I have just eaten, and am still
+satisfied,’ for she thought the angels were there. Said he: ‘I am your
+dear son, whom the wild beasts were said to have torn from your arms;
+but I am alive still, and will soon set you free.’ Then he descended
+again, and went to his father, and caused himself to be announced as a
+strange huntsman, and asked if he could offer him service. The king said
+yes, if he was skilful and could get game for him, he should come to
+him, but that deer had never taken up their quarters in any part of the
+district or country. Then the huntsman promised to procure as much game
+for him as he could possibly use at the royal table. So he summoned all
+the huntsmen together, and bade them go out into the forest with him.
+And he went with them and made them form a great circle, open at one end
+where he stationed himself, and began to wish. Two hundred deer and more
+came running inside the circle at once, and the huntsmen shot them.
+Then they were all placed on sixty country carts, and driven home to the
+king, and for once he was able to deck his table with game, after having
+had none at all for years.
+
+Now the king felt great joy at this, and commanded that his entire
+household should eat with him next day, and made a great feast. When
+they were all assembled together, he said to the huntsman: ‘As you are
+so clever, you shall sit by me.’ He replied: ‘Lord King, your majesty
+must excuse me, I am a poor huntsman.’ But the king insisted on it,
+and said: ‘You shall sit by me,’ until he did it. Whilst he was sitting
+there, he thought of his dearest mother, and wished that one of the
+king’s principal servants would begin to speak of her, and would ask how
+it was faring with the queen in the tower, and if she were alive still,
+or had perished. Hardly had he formed the wish than the marshal began,
+and said: ‘Your majesty, we live joyously here, but how is the queen
+living in the tower? Is she still alive, or has she died?’ But the king
+replied: ‘She let my dear son be torn to pieces by wild beasts; I will
+not have her named.’ Then the huntsman arose and said: ‘Gracious lord
+father she is alive still, and I am her son, and I was not carried away
+by wild beasts, but by that wretch the old cook, who tore me from her
+arms when she was asleep, and sprinkled her apron with the blood of a
+chicken.’ Thereupon he took the dog with the golden collar, and said:
+‘That is the wretch!’ and caused live coals to be brought, and these the
+dog was compelled to devour before the sight of all, until flames burst
+forth from its throat. On this the huntsman asked the king if he would
+like to see the dog in his true shape, and wished him back into the form
+of the cook, in the which he stood immediately, with his white apron,
+and his knife by his side. When the king saw him he fell into a passion,
+and ordered him to be cast into the deepest dungeon. Then the huntsman
+spoke further and said: ‘Father, will you see the maiden who brought me
+up so tenderly and who was afterwards to murder me, but did not do it,
+though her own life depended on it?’ The king replied: ‘Yes, I would
+like to see her.’ The son said: ‘Most gracious father, I will show her
+to you in the form of a beautiful flower,’ and he thrust his hand into
+his pocket and brought forth the pink, and placed it on the royal table,
+and it was so beautiful that the king had never seen one to equal it.
+Then the son said: ‘Now will I show her to you in her own form,’ and
+wished that she might become a maiden, and she stood there looking so
+beautiful that no painter could have made her look more so.
+
+And the king sent two waiting-maids and two attendants into the tower,
+to fetch the queen and bring her to the royal table. But when she was
+led in she ate nothing, and said: ‘The gracious and merciful God who has
+supported me in the tower, will soon set me free.’ She lived three days
+more, and then died happily, and when she was buried, the two white
+doves which had brought her food to the tower, and were angels of
+heaven, followed her body and seated themselves on her grave. The aged
+king ordered the cook to be torn in four pieces, but grief consumed the
+king’s own heart, and he soon died. His son married the beautiful maiden
+whom he had brought with him as a flower in his pocket, and whether they
+are still alive or not, is known to God.
+
+
+
+
+CLEVER ELSIE
+
+There was once a man who had a daughter who was called Clever Elsie. And
+when she had grown up her father said: ‘We will get her married.’ ‘Yes,’
+said the mother, ‘if only someone would come who would have her.’ At
+length a man came from a distance and wooed her, who was called Hans;
+but he stipulated that Clever Elsie should be really smart. ‘Oh,’ said
+the father, ‘she has plenty of good sense’; and the mother said: ‘Oh,
+she can see the wind coming up the street, and hear the flies coughing.’
+‘Well,’ said Hans, ‘if she is not really smart, I won’t have her.’ When
+they were sitting at dinner and had eaten, the mother said: ‘Elsie, go
+into the cellar and fetch some beer.’ Then Clever Elsie took the pitcher
+from the wall, went into the cellar, and tapped the lid briskly as she
+went, so that the time might not appear long. When she was below she
+fetched herself a chair, and set it before the barrel so that she had
+no need to stoop, and did not hurt her back or do herself any unexpected
+injury. Then she placed the can before her, and turned the tap, and
+while the beer was running she would not let her eyes be idle, but
+looked up at the wall, and after much peering here and there, saw a
+pick-axe exactly above her, which the masons had accidentally left
+there.
+
+Then Clever Elsie began to weep and said: ‘If I get Hans, and we have
+a child, and he grows big, and we send him into the cellar here to draw
+beer, then the pick-axe will fall on his head and kill him.’ Then she
+sat and wept and screamed with all the strength of her body, over the
+misfortune which lay before her. Those upstairs waited for the drink,
+but Clever Elsie still did not come. Then the woman said to the servant:
+‘Just go down into the cellar and see where Elsie is.’ The maid went and
+found her sitting in front of the barrel, screaming loudly. ‘Elsie why
+do you weep?’ asked the maid. ‘Ah,’ she answered, ‘have I not reason to
+weep? If I get Hans, and we have a child, and he grows big, and has to
+draw beer here, the pick-axe will perhaps fall on his head, and kill
+him.’ Then said the maid: ‘What a clever Elsie we have!’ and sat down
+beside her and began loudly to weep over the misfortune. After a while,
+as the maid did not come back, and those upstairs were thirsty for the
+beer, the man said to the boy: ‘Just go down into the cellar and see
+where Elsie and the girl are.’ The boy went down, and there sat Clever
+Elsie and the girl both weeping together. Then he asked: ‘Why are you
+weeping?’ ‘Ah,’ said Elsie, ‘have I not reason to weep? If I get Hans,
+and we have a child, and he grows big, and has to draw beer here, the
+pick-axe will fall on his head and kill him.’ Then said the boy: ‘What
+a clever Elsie we have!’ and sat down by her, and likewise began to
+howl loudly. Upstairs they waited for the boy, but as he still did not
+return, the man said to the woman: ‘Just go down into the cellar and see
+where Elsie is!’ The woman went down, and found all three in the midst
+of their lamentations, and inquired what was the cause; then Elsie told
+her also that her future child was to be killed by the pick-axe, when it
+grew big and had to draw beer, and the pick-axe fell down. Then said the
+mother likewise: ‘What a clever Elsie we have!’ and sat down and wept
+with them. The man upstairs waited a short time, but as his wife did not
+come back and his thirst grew ever greater, he said: ‘I must go into the
+cellar myself and see where Elsie is.’ But when he got into the cellar,
+and they were all sitting together crying, and he heard the reason, and
+that Elsie’s child was the cause, and the Elsie might perhaps bring one
+into the world some day, and that he might be killed by the pick-axe, if
+he should happen to be sitting beneath it, drawing beer just at the very
+time when it fell down, he cried: ‘Oh, what a clever Elsie!’ and sat
+down, and likewise wept with them. The bridegroom stayed upstairs alone
+for a long time; then as no one would come back he thought: ‘They must be
+waiting for me below: I too must go there and see what they are about.’
+When he got down, the five of them were sitting screaming and lamenting
+quite piteously, each out-doing the other. ‘What misfortune has happened
+then?’ asked he. ‘Ah, dear Hans,’ said Elsie, ‘if we marry each other
+and have a child, and he is big, and we perhaps send him here to draw
+something to drink, then the pick-axe which has been left up there might
+dash his brains out if it were to fall down, so have we not reason to
+weep?’ ‘Come,’ said Hans, ‘more understanding than that is not needed
+for my household, as you are such a clever Elsie, I will have you,’ and
+seized her hand, took her upstairs with him, and married her.
+
+After Hans had had her some time, he said: ‘Wife, I am going out to work
+and earn some money for us; go into the field and cut the corn that we
+may have some bread.’ ‘Yes, dear Hans, I will do that.’ After Hans had
+gone away, she cooked herself some good broth and took it into the field
+with her. When she came to the field she said to herself: ‘What shall I
+do; shall I cut first, or shall I eat first? Oh, I will eat first.’ Then
+she drank her cup of broth and when she was fully satisfied, she once
+more said: ‘What shall I do? Shall I cut first, or shall I sleep first?
+I will sleep first.’ Then she lay down among the corn and fell asleep.
+Hans had been at home for a long time, but Elsie did not come; then said
+he: ‘What a clever Elsie I have; she is so industrious that she does not
+even come home to eat.’ But when evening came and she still stayed away,
+Hans went out to see what she had cut, but nothing was cut, and she
+was lying among the corn asleep. Then Hans hastened home and brought
+a fowler’s net with little bells and hung it round about her, and she
+still went on sleeping. Then he ran home, shut the house-door, and sat
+down in his chair and worked. At length, when it was quite dark, Clever
+Elsie awoke and when she got up there was a jingling all round about
+her, and the bells rang at each step which she took. Then she was
+alarmed, and became uncertain whether she really was Clever Elsie or
+not, and said: ‘Is it I, or is it not I?’ But she knew not what answer
+to make to this, and stood for a time in doubt; at length she thought:
+‘I will go home and ask if it be I, or if it be not I, they will be sure
+to know.’ She ran to the door of her own house, but it was shut; then
+she knocked at the window and cried: ‘Hans, is Elsie within?’ ‘Yes,’
+answered Hans, ‘she is within.’ Hereupon she was terrified, and said:
+‘Ah, heavens! Then it is not I,’ and went to another door; but when the
+people heard the jingling of the bells they would not open it, and she
+could get in nowhere. Then she ran out of the village, and no one has
+seen her since.
+
+
+
+
+THE MISER IN THE BUSH
+
+A farmer had a faithful and diligent servant, who had worked hard for
+him three years, without having been paid any wages. At last it came
+into the man’s head that he would not go on thus without pay any longer;
+so he went to his master, and said, ‘I have worked hard for you a long
+time, I will trust to you to give me what I deserve to have for my
+trouble.’ The farmer was a sad miser, and knew that his man was very
+simple-hearted; so he took out threepence, and gave him for every year’s
+service a penny. The poor fellow thought it was a great deal of money to
+have, and said to himself, ‘Why should I work hard, and live here on bad
+fare any longer? I can now travel into the wide world, and make myself
+merry.’ With that he put his money into his purse, and set out, roaming
+over hill and valley.
+
+As he jogged along over the fields, singing and dancing, a little dwarf
+met him, and asked him what made him so merry. ‘Why, what should make
+me down-hearted?’ said he; ‘I am sound in health and rich in purse, what
+should I care for? I have saved up my three years’ earnings and have it
+all safe in my pocket.’ ‘How much may it come to?’ said the little man.
+‘Full threepence,’ replied the countryman. ‘I wish you would give them
+to me,’ said the other; ‘I am very poor.’ Then the man pitied him, and
+gave him all he had; and the little dwarf said in return, ‘As you have
+such a kind honest heart, I will grant you three wishes--one for every
+penny; so choose whatever you like.’ Then the countryman rejoiced at
+his good luck, and said, ‘I like many things better than money: first, I
+will have a bow that will bring down everything I shoot at; secondly,
+a fiddle that will set everyone dancing that hears me play upon it; and
+thirdly, I should like that everyone should grant what I ask.’ The dwarf
+said he should have his three wishes; so he gave him the bow and fiddle,
+and went his way.
+
+Our honest friend journeyed on his way too; and if he was merry before,
+he was now ten times more so. He had not gone far before he met an old
+miser: close by them stood a tree, and on the topmost twig sat a thrush
+singing away most joyfully. ‘Oh, what a pretty bird!’ said the miser; ‘I
+would give a great deal of money to have such a one.’ ‘If that’s all,’
+said the countryman, ‘I will soon bring it down.’ Then he took up his
+bow, and down fell the thrush into the bushes at the foot of the tree.
+The miser crept into the bush to find it; but directly he had got into
+the middle, his companion took up his fiddle and played away, and the
+miser began to dance and spring about, capering higher and higher in
+the air. The thorns soon began to tear his clothes till they all hung
+in rags about him, and he himself was all scratched and wounded, so that
+the blood ran down. ‘Oh, for heaven’s sake!’ cried the miser, ‘Master!
+master! pray let the fiddle alone. What have I done to deserve this?’
+‘Thou hast shaved many a poor soul close enough,’ said the other; ‘thou
+art only meeting thy reward’: so he played up another tune. Then the
+miser began to beg and promise, and offered money for his liberty; but
+he did not come up to the musician’s price for some time, and he danced
+him along brisker and brisker, and the miser bid higher and higher, till
+at last he offered a round hundred of florins that he had in his purse,
+and had just gained by cheating some poor fellow. When the countryman
+saw so much money, he said, ‘I will agree to your proposal.’ So he took
+the purse, put up his fiddle, and travelled on very pleased with his
+bargain.
+
+Meanwhile the miser crept out of the bush half-naked and in a piteous
+plight, and began to ponder how he should take his revenge, and serve
+his late companion some trick. At last he went to the judge, and
+complained that a rascal had robbed him of his money, and beaten him
+into the bargain; and that the fellow who did it carried a bow at his
+back and a fiddle hung round his neck. Then the judge sent out his
+officers to bring up the accused wherever they should find him; and he
+was soon caught and brought up to be tried.
+
+The miser began to tell his tale, and said he had been robbed of
+his money. ‘No, you gave it me for playing a tune to you.’ said the
+countryman; but the judge told him that was not likely, and cut the
+matter short by ordering him off to the gallows.
+
+So away he was taken; but as he stood on the steps he said, ‘My Lord
+Judge, grant me one last request.’ ‘Anything but thy life,’ replied the
+other. ‘No,’ said he, ‘I do not ask my life; only to let me play upon
+my fiddle for the last time.’ The miser cried out, ‘Oh, no! no! for
+heaven’s sake don’t listen to him! don’t listen to him!’ But the judge
+said, ‘It is only this once, he will soon have done.’ The fact was, he
+could not refuse the request, on account of the dwarf’s third gift.
+
+Then the miser said, ‘Bind me fast, bind me fast, for pity’s sake.’ But
+the countryman seized his fiddle, and struck up a tune, and at the first
+note judge, clerks, and jailer were in motion; all began capering, and
+no one could hold the miser. At the second note the hangman let his
+prisoner go, and danced also, and by the time he had played the first
+bar of the tune, all were dancing together--judge, court, and miser, and
+all the people who had followed to look on. At first the thing was merry
+and pleasant enough; but when it had gone on a while, and there seemed
+to be no end of playing or dancing, they began to cry out, and beg him
+to leave off; but he stopped not a whit the more for their entreaties,
+till the judge not only gave him his life, but promised to return him
+the hundred florins.
+
+Then he called to the miser, and said, ‘Tell us now, you vagabond, where
+you got that gold, or I shall play on for your amusement only,’ ‘I stole
+it,’ said the miser in the presence of all the people; ‘I acknowledge
+that I stole it, and that you earned it fairly.’ Then the countryman
+stopped his fiddle, and left the miser to take his place at the gallows.
+
+
+
+
+ASHPUTTEL
+
+The wife of a rich man fell sick; and when she felt that her end drew
+nigh, she called her only daughter to her bed-side, and said, ‘Always be
+a good girl, and I will look down from heaven and watch over you.’ Soon
+afterwards she shut her eyes and died, and was buried in the garden;
+and the little girl went every day to her grave and wept, and was always
+good and kind to all about her. And the snow fell and spread a beautiful
+white covering over the grave; but by the time the spring came, and the
+sun had melted it away again, her father had married another wife. This
+new wife had two daughters of her own, that she brought home with her;
+they were fair in face but foul at heart, and it was now a sorry time
+for the poor little girl. ‘What does the good-for-nothing want in the
+parlour?’ said they; ‘they who would eat bread should first earn it;
+away with the kitchen-maid!’ Then they took away her fine clothes, and
+gave her an old grey frock to put on, and laughed at her, and turned her
+into the kitchen.
+
+There she was forced to do hard work; to rise early before daylight, to
+bring the water, to make the fire, to cook and to wash. Besides that,
+the sisters plagued her in all sorts of ways, and laughed at her. In the
+evening when she was tired, she had no bed to lie down on, but was made
+to lie by the hearth among the ashes; and as this, of course, made her
+always dusty and dirty, they called her Ashputtel.
+
+It happened once that the father was going to the fair, and asked his
+wife’s daughters what he should bring them. ‘Fine clothes,’ said the
+first; ‘Pearls and diamonds,’ cried the second. ‘Now, child,’ said he
+to his own daughter, ‘what will you have?’ ‘The first twig, dear
+father, that brushes against your hat when you turn your face to come
+homewards,’ said she. Then he bought for the first two the fine clothes
+and pearls and diamonds they had asked for: and on his way home, as he
+rode through a green copse, a hazel twig brushed against him, and almost
+pushed off his hat: so he broke it off and brought it away; and when he
+got home he gave it to his daughter. Then she took it, and went to
+her mother’s grave and planted it there; and cried so much that it was
+watered with her tears; and there it grew and became a fine tree. Three
+times every day she went to it and cried; and soon a little bird came
+and built its nest upon the tree, and talked with her, and watched over
+her, and brought her whatever she wished for.
+
+Now it happened that the king of that land held a feast, which was to
+last three days; and out of those who came to it his son was to choose
+a bride for himself. Ashputtel’s two sisters were asked to come; so they
+called her up, and said, ‘Now, comb our hair, brush our shoes, and tie
+our sashes for us, for we are going to dance at the king’s feast.’
+Then she did as she was told; but when all was done she could not help
+crying, for she thought to herself, she should so have liked to have
+gone with them to the ball; and at last she begged her mother very hard
+to let her go. ‘You, Ashputtel!’ said she; ‘you who have nothing to
+wear, no clothes at all, and who cannot even dance--you want to go to
+the ball? And when she kept on begging, she said at last, to get rid of
+her, ‘I will throw this dishful of peas into the ash-heap, and if in
+two hours’ time you have picked them all out, you shall go to the feast
+too.’
+
+Then she threw the peas down among the ashes, but the little maiden ran
+out at the back door into the garden, and cried out:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves, flying in at the kitchen window; next
+came two turtle-doves; and after them came all the little birds under
+heaven, chirping and fluttering in: and they flew down into the ashes.
+And the little doves stooped their heads down and set to work, pick,
+pick, pick; and then the others began to pick, pick, pick: and among
+them all they soon picked out all the good grain, and put it into a dish
+but left the ashes. Long before the end of the hour the work was quite
+done, and all flew out again at the windows.
+
+Then Ashputtel brought the dish to her mother, overjoyed at the thought
+that now she should go to the ball. But the mother said, ‘No, no! you
+slut, you have no clothes, and cannot dance; you shall not go.’ And when
+Ashputtel begged very hard to go, she said, ‘If you can in one hour’s
+time pick two of those dishes of peas out of the ashes, you shall go
+too.’ And thus she thought she should at least get rid of her. So she
+shook two dishes of peas into the ashes.
+
+But the little maiden went out into the garden at the back of the house,
+and cried out as before:
+
+ ‘Hither, hither, through the sky,
+  Turtle-doves and linnets, fly!
+  Blackbird, thrush, and chaffinch gay,
+  Hither, hither, haste away!
+  One and all come help me, quick!
+  Haste ye, haste ye!--pick, pick, pick!’
+
+Then first came two white doves in at the kitchen window; next came two
+turtle-doves; and after them came all the little birds under heaven,
+chirping and hopping about. And they flew down into the ashes; and the
+little doves put their heads down and set to work, pick, pick, pick; and
+then the others began pick, pick, pick; and they put all the good grain
+into the dishes, and left all the ashes. Before half an hour’s time all
+was done, and out they flew again. And then Ashputtel took the dishes to
+her mother, rejoicing to think that she should now go to the ball.
+But her mother said, ‘It is all of no use, you cannot go; you have no
+clothes, and cannot dance, and you would only put us to shame’: and off
+she went with her two daughters to the ball.
+
+Now when all were gone, and nobody left at home, Ashputtel went
+sorrowfully and sat down under the hazel-tree, and cried out:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her friend the bird flew out of the tree, and brought a gold and
+silver dress for her, and slippers of spangled silk; and she put them
+on, and followed her sisters to the feast. But they did not know her,
+and thought it must be some strange princess, she looked so fine and
+beautiful in her rich clothes; and they never once thought of Ashputtel,
+taking it for granted that she was safe at home in the dirt.
+
+The king’s son soon came up to her, and took her by the hand and danced
+with her, and no one else: and he never left her hand; but when anyone
+else came to ask her to dance, he said, ‘This lady is dancing with me.’
+
+Thus they danced till a late hour of the night; and then she wanted to
+go home: and the king’s son said, ‘I shall go and take care of you to
+your home’; for he wanted to see where the beautiful maiden lived. But
+she slipped away from him, unawares, and ran off towards home; and as
+the prince followed her, she jumped up into the pigeon-house and shut
+the door. Then he waited till her father came home, and told him that
+the unknown maiden, who had been at the feast, had hid herself in the
+pigeon-house. But when they had broken open the door they found no one
+within; and as they came back into the house, Ashputtel was lying, as
+she always did, in her dirty frock by the ashes, and her dim little
+lamp was burning in the chimney. For she had run as quickly as she could
+through the pigeon-house and on to the hazel-tree, and had there taken
+off her beautiful clothes, and put them beneath the tree, that the bird
+might carry them away, and had lain down again amid the ashes in her
+little grey frock.
+
+The next day when the feast was again held, and her father, mother, and
+sisters were gone, Ashputtel went to the hazel-tree, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+And the bird came and brought a still finer dress than the one she
+had worn the day before. And when she came in it to the ball, everyone
+wondered at her beauty: but the king’s son, who was waiting for her,
+took her by the hand, and danced with her; and when anyone asked her to
+dance, he said as before, ‘This lady is dancing with me.’
+
+When night came she wanted to go home; and the king’s son followed here
+as before, that he might see into what house she went: but she sprang
+away from him all at once into the garden behind her father’s house.
+In this garden stood a fine large pear-tree full of ripe fruit; and
+Ashputtel, not knowing where to hide herself, jumped up into it without
+being seen. Then the king’s son lost sight of her, and could not find
+out where she was gone, but waited till her father came home, and said
+to him, ‘The unknown lady who danced with me has slipped away, and I
+think she must have sprung into the pear-tree.’ The father thought to
+himself, ‘Can it be Ashputtel?’ So he had an axe brought; and they cut
+down the tree, but found no one upon it. And when they came back into
+the kitchen, there lay Ashputtel among the ashes; for she had slipped
+down on the other side of the tree, and carried her beautiful clothes
+back to the bird at the hazel-tree, and then put on her little grey
+frock.
+
+The third day, when her father and mother and sisters were gone, she
+went again into the garden, and said:
+
+ ‘Shake, shake, hazel-tree,
+  Gold and silver over me!’
+
+Then her kind friend the bird brought a dress still finer than the
+former one, and slippers which were all of gold: so that when she came
+to the feast no one knew what to say, for wonder at her beauty: and the
+king’s son danced with nobody but her; and when anyone else asked her to
+dance, he said, ‘This lady is _my_ partner, sir.’
+
+When night came she wanted to go home; and the king’s son would go with
+her, and said to himself, ‘I will not lose her this time’; but, however,
+she again slipped away from him, though in such a hurry that she dropped
+her left golden slipper upon the stairs.
+
+The prince took the shoe, and went the next day to the king his father,
+and said, ‘I will take for my wife the lady that this golden slipper
+fits.’ Then both the sisters were overjoyed to hear it; for they
+had beautiful feet, and had no doubt that they could wear the golden
+slipper. The eldest went first into the room where the slipper was, and
+wanted to try it on, and the mother stood by. But her great toe could
+not go into it, and the shoe was altogether much too small for her. Then
+the mother gave her a knife, and said, ‘Never mind, cut it off; when you
+are queen you will not care about toes; you will not want to walk.’ So
+the silly girl cut off her great toe, and thus squeezed on the shoe,
+and went to the king’s son. Then he took her for his bride, and set her
+beside him on his horse, and rode away with her homewards.
+
+But on their way home they had to pass by the hazel-tree that Ashputtel
+had planted; and on the branch sat a little dove singing:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then the prince got down and looked at her foot; and he saw, by the
+blood that streamed from it, what a trick she had played him. So he
+turned his horse round, and brought the false bride back to her home,
+and said, ‘This is not the right bride; let the other sister try and put
+on the slipper.’ Then she went into the room and got her foot into the
+shoe, all but the heel, which was too large. But her mother squeezed it
+in till the blood came, and took her to the king’s son: and he set her
+as his bride by his side on his horse, and rode away with her.
+
+But when they came to the hazel-tree the little dove sat there still,
+and sang:
+
+ ‘Back again! back again! look to the shoe!
+  The shoe is too small, and not made for you!
+  Prince! prince! look again for thy bride,
+  For she’s not the true one that sits by thy side.’
+
+Then he looked down, and saw that the blood streamed so much from the
+shoe, that her white stockings were quite red. So he turned his horse
+and brought her also back again. ‘This is not the true bride,’ said he
+to the father; ‘have you no other daughters?’ ‘No,’ said he; ‘there is
+only a little dirty Ashputtel here, the child of my first wife; I am
+sure she cannot be the bride.’ The prince told him to send her. But the
+mother said, ‘No, no, she is much too dirty; she will not dare to show
+herself.’ However, the prince would have her come; and she first washed
+her face and hands, and then went in and curtsied to him, and he reached
+her the golden slipper. Then she took her clumsy shoe off her left foot,
+and put on the golden slipper; and it fitted her as if it had been made
+for her. And when he drew near and looked at her face he knew her, and
+said, ‘This is the right bride.’ But the mother and both the sisters
+were frightened, and turned pale with anger as he took Ashputtel on his
+horse, and rode away with her. And when they came to the hazel-tree, the
+white dove sang:
+
+ ‘Home! home! look at the shoe!
+  Princess! the shoe was made for you!
+  Prince! prince! take home thy bride,
+  For she is the true one that sits by thy side!’
+
+And when the dove had done its song, it came flying, and perched upon
+her right shoulder, and so went home with her.
+
+
+
+
+THE WHITE SNAKE
+
+A long time ago there lived a king who was famed for his wisdom through
+all the land. Nothing was hidden from him, and it seemed as if news of
+the most secret things was brought to him through the air. But he had a
+strange custom; every day after dinner, when the table was cleared,
+and no one else was present, a trusty servant had to bring him one more
+dish. It was covered, however, and even the servant did not know what
+was in it, neither did anyone know, for the king never took off the
+cover to eat of it until he was quite alone.
+
+This had gone on for a long time, when one day the servant, who took
+away the dish, was overcome with such curiosity that he could not help
+carrying the dish into his room. When he had carefully locked the door,
+he lifted up the cover, and saw a white snake lying on the dish. But
+when he saw it he could not deny himself the pleasure of tasting it,
+so he cut of a little bit and put it into his mouth. No sooner had it
+touched his tongue than he heard a strange whispering of little voices
+outside his window. He went and listened, and then noticed that it was
+the sparrows who were chattering together, and telling one another of
+all kinds of things which they had seen in the fields and woods. Eating
+the snake had given him power of understanding the language of animals.
+
+Now it so happened that on this very day the queen lost her most
+beautiful ring, and suspicion of having stolen it fell upon this trusty
+servant, who was allowed to go everywhere. The king ordered the man to
+be brought before him, and threatened with angry words that unless he
+could before the morrow point out the thief, he himself should be looked
+upon as guilty and executed. In vain he declared his innocence; he was
+dismissed with no better answer.
+
+In his trouble and fear he went down into the courtyard and took thought
+how to help himself out of his trouble. Now some ducks were sitting
+together quietly by a brook and taking their rest; and, whilst they
+were making their feathers smooth with their bills, they were having a
+confidential conversation together. The servant stood by and listened.
+They were telling one another of all the places where they had been
+waddling about all the morning, and what good food they had found; and
+one said in a pitiful tone: ‘Something lies heavy on my stomach; as
+I was eating in haste I swallowed a ring which lay under the queen’s
+window.’ The servant at once seized her by the neck, carried her to the
+kitchen, and said to the cook: ‘Here is a fine duck; pray, kill her.’
+‘Yes,’ said the cook, and weighed her in his hand; ‘she has spared
+no trouble to fatten herself, and has been waiting to be roasted long
+enough.’ So he cut off her head, and as she was being dressed for the
+spit, the queen’s ring was found inside her.
+
+The servant could now easily prove his innocence; and the king, to make
+amends for the wrong, allowed him to ask a favour, and promised him
+the best place in the court that he could wish for. The servant refused
+everything, and only asked for a horse and some money for travelling, as
+he had a mind to see the world and go about a little. When his request
+was granted he set out on his way, and one day came to a pond, where he
+saw three fishes caught in the reeds and gasping for water. Now, though
+it is said that fishes are dumb, he heard them lamenting that they must
+perish so miserably, and, as he had a kind heart, he got off his
+horse and put the three prisoners back into the water. They leapt with
+delight, put out their heads, and cried to him: ‘We will remember you
+and repay you for saving us!’
+
+He rode on, and after a while it seemed to him that he heard a voice in
+the sand at his feet. He listened, and heard an ant-king complain: ‘Why
+cannot folks, with their clumsy beasts, keep off our bodies? That stupid
+horse, with his heavy hoofs, has been treading down my people without
+mercy!’ So he turned on to a side path and the ant-king cried out to
+him: ‘We will remember you--one good turn deserves another!’
+
+The path led him into a wood, and there he saw two old ravens standing
+by their nest, and throwing out their young ones. ‘Out with you, you
+idle, good-for-nothing creatures!’ cried they; ‘we cannot find food for
+you any longer; you are big enough, and can provide for yourselves.’
+But the poor young ravens lay upon the ground, flapping their wings, and
+crying: ‘Oh, what helpless chicks we are! We must shift for ourselves,
+and yet we cannot fly! What can we do, but lie here and starve?’ So the
+good young fellow alighted and killed his horse with his sword, and gave
+it to them for food. Then they came hopping up to it, satisfied their
+hunger, and cried: ‘We will remember you--one good turn deserves
+another!’
+
+And now he had to use his own legs, and when he had walked a long
+way, he came to a large city. There was a great noise and crowd in
+the streets, and a man rode up on horseback, crying aloud: ‘The king’s
+daughter wants a husband; but whoever seeks her hand must perform a hard
+task, and if he does not succeed he will forfeit his life.’ Many had
+already made the attempt, but in vain; nevertheless when the youth
+saw the king’s daughter he was so overcome by her great beauty that he
+forgot all danger, went before the king, and declared himself a suitor.
+
+So he was led out to the sea, and a gold ring was thrown into it, before
+his eyes; then the king ordered him to fetch this ring up from the
+bottom of the sea, and added: ‘If you come up again without it you will
+be thrown in again and again until you perish amid the waves.’ All the
+people grieved for the handsome youth; then they went away, leaving him
+alone by the sea.
+
+He stood on the shore and considered what he should do, when suddenly
+he saw three fishes come swimming towards him, and they were the very
+fishes whose lives he had saved. The one in the middle held a mussel in
+its mouth, which it laid on the shore at the youth’s feet, and when he
+had taken it up and opened it, there lay the gold ring in the shell.
+Full of joy he took it to the king and expected that he would grant him
+the promised reward.
+
+But when the proud princess perceived that he was not her equal in
+birth, she scorned him, and required him first to perform another
+task. She went down into the garden and strewed with her own hands ten
+sacksful of millet-seed on the grass; then she said: ‘Tomorrow morning
+before sunrise these must be picked up, and not a single grain be
+wanting.’
+
+The youth sat down in the garden and considered how it might be possible
+to perform this task, but he could think of nothing, and there he sat
+sorrowfully awaiting the break of day, when he should be led to death.
+But as soon as the first rays of the sun shone into the garden he saw
+all the ten sacks standing side by side, quite full, and not a single
+grain was missing. The ant-king had come in the night with thousands
+and thousands of ants, and the grateful creatures had by great industry
+picked up all the millet-seed and gathered them into the sacks.
+
+Presently the king’s daughter herself came down into the garden, and was
+amazed to see that the young man had done the task she had given him.
+But she could not yet conquer her proud heart, and said: ‘Although he
+has performed both the tasks, he shall not be my husband until he had
+brought me an apple from the Tree of Life.’ The youth did not know where
+the Tree of Life stood, but he set out, and would have gone on for ever,
+as long as his legs would carry him, though he had no hope of finding
+it. After he had wandered through three kingdoms, he came one evening to
+a wood, and lay down under a tree to sleep. But he heard a rustling in
+the branches, and a golden apple fell into his hand. At the same time
+three ravens flew down to him, perched themselves upon his knee, and
+said: ‘We are the three young ravens whom you saved from starving; when
+we had grown big, and heard that you were seeking the Golden Apple,
+we flew over the sea to the end of the world, where the Tree of Life
+stands, and have brought you the apple.’ The youth, full of joy, set out
+homewards, and took the Golden Apple to the king’s beautiful daughter,
+who had now no more excuses left to make. They cut the Apple of Life in
+two and ate it together; and then her heart became full of love for him,
+and they lived in undisturbed happiness to a great age.
+
+
+
+
+THE WOLF AND THE SEVEN LITTLE KIDS
+
+There was once upon a time an old goat who had seven little kids, and
+loved them with all the love of a mother for her children. One day she
+wanted to go into the forest and fetch some food. So she called all
+seven to her and said: ‘Dear children, I have to go into the forest,
+be on your guard against the wolf; if he comes in, he will devour you
+all--skin, hair, and everything. The wretch often disguises himself, but
+you will know him at once by his rough voice and his black feet.’ The
+kids said: ‘Dear mother, we will take good care of ourselves; you may go
+away without any anxiety.’ Then the old one bleated, and went on her way
+with an easy mind.
+
+It was not long before someone knocked at the house-door and called:
+‘Open the door, dear children; your mother is here, and has brought
+something back with her for each of you.’ But the little kids knew that
+it was the wolf, by the rough voice. ‘We will not open the door,’ cried
+they, ‘you are not our mother. She has a soft, pleasant voice, but
+your voice is rough; you are the wolf!’ Then the wolf went away to a
+shopkeeper and bought himself a great lump of chalk, ate this and made
+his voice soft with it. Then he came back, knocked at the door of the
+house, and called: ‘Open the door, dear children, your mother is here
+and has brought something back with her for each of you.’ But the wolf
+had laid his black paws against the window, and the children saw them
+and cried: ‘We will not open the door, our mother has not black feet
+like you: you are the wolf!’ Then the wolf ran to a baker and said: ‘I
+have hurt my feet, rub some dough over them for me.’ And when the baker
+had rubbed his feet over, he ran to the miller and said: ‘Strew some
+white meal over my feet for me.’ The miller thought to himself: ‘The
+wolf wants to deceive someone,’ and refused; but the wolf said: ‘If you
+will not do it, I will devour you.’ Then the miller was afraid, and made
+his paws white for him. Truly, this is the way of mankind.
+
+So now the wretch went for the third time to the house-door, knocked at
+it and said: ‘Open the door for me, children, your dear little mother
+has come home, and has brought every one of you something back from the
+forest with her.’ The little kids cried: ‘First show us your paws that
+we may know if you are our dear little mother.’ Then he put his paws
+in through the window and when the kids saw that they were white, they
+believed that all he said was true, and opened the door. But who should
+come in but the wolf! They were terrified and wanted to hide themselves.
+One sprang under the table, the second into the bed, the third into the
+stove, the fourth into the kitchen, the fifth into the cupboard, the
+sixth under the washing-bowl, and the seventh into the clock-case. But
+the wolf found them all, and used no great ceremony; one after the
+other he swallowed them down his throat. The youngest, who was in
+the clock-case, was the only one he did not find. When the wolf had
+satisfied his appetite he took himself off, laid himself down under a
+tree in the green meadow outside, and began to sleep. Soon afterwards
+the old goat came home again from the forest. Ah! what a sight she saw
+there! The house-door stood wide open. The table, chairs, and benches
+were thrown down, the washing-bowl lay broken to pieces, and the quilts
+and pillows were pulled off the bed. She sought her children, but they
+were nowhere to be found. She called them one after another by name, but
+no one answered. At last, when she came to the youngest, a soft voice
+cried: ‘Dear mother, I am in the clock-case.’ She took the kid out, and
+it told her that the wolf had come and had eaten all the others. Then
+you may imagine how she wept over her poor children.
+
+At length in her grief she went out, and the youngest kid ran with her.
+When they came to the meadow, there lay the wolf by the tree and snored
+so loud that the branches shook. She looked at him on every side and
+saw that something was moving and struggling in his gorged belly. ‘Ah,
+heavens,’ she said, ‘is it possible that my poor children whom he has
+swallowed down for his supper, can be still alive?’ Then the kid had to
+run home and fetch scissors, and a needle and thread, and the goat cut
+open the monster’s stomach, and hardly had she made one cut, than one
+little kid thrust its head out, and when she had cut farther, all six
+sprang out one after another, and were all still alive, and had suffered
+no injury whatever, for in his greediness the monster had swallowed them
+down whole. What rejoicing there was! They embraced their dear mother,
+and jumped like a tailor at his wedding. The mother, however, said: ‘Now
+go and look for some big stones, and we will fill the wicked beast’s
+stomach with them while he is still asleep.’ Then the seven kids dragged
+the stones thither with all speed, and put as many of them into this
+stomach as they could get in; and the mother sewed him up again in the
+greatest haste, so that he was not aware of anything and never once
+stirred.
+
+When the wolf at length had had his fill of sleep, he got on his legs,
+and as the stones in his stomach made him very thirsty, he wanted to
+go to a well to drink. But when he began to walk and to move about, the
+stones in his stomach knocked against each other and rattled. Then cried
+he:
+
+ ‘What rumbles and tumbles
+  Against my poor bones?
+  I thought ‘twas six kids,
+  But it feels like big stones.’
+
+And when he got to the well and stooped over the water to drink, the
+heavy stones made him fall in, and he drowned miserably. When the seven
+kids saw that, they came running to the spot and cried aloud: ‘The wolf
+is dead! The wolf is dead!’ and danced for joy round about the well with
+their mother.
+
+
+
+
+THE QUEEN BEE
+
+Two kings’ sons once upon a time went into the world to seek their
+fortunes; but they soon fell into a wasteful foolish way of living, so
+that they could not return home again. Then their brother, who was a
+little insignificant dwarf, went out to seek for his brothers: but when
+he had found them they only laughed at him, to think that he, who was so
+young and simple, should try to travel through the world, when they, who
+were so much wiser, had been unable to get on. However, they all set
+out on their journey together, and came at last to an ant-hill. The two
+elder brothers would have pulled it down, in order to see how the poor
+ants in their fright would run about and carry off their eggs. But the
+little dwarf said, ‘Let the poor things enjoy themselves, I will not
+suffer you to trouble them.’
+
+So on they went, and came to a lake where many many ducks were swimming
+about. The two brothers wanted to catch two, and roast them. But the
+dwarf said, ‘Let the poor things enjoy themselves, you shall not kill
+them.’ Next they came to a bees’-nest in a hollow tree, and there was
+so much honey that it ran down the trunk; and the two brothers wanted to
+light a fire under the tree and kill the bees, so as to get their honey.
+But the dwarf held them back, and said, ‘Let the pretty insects enjoy
+themselves, I cannot let you burn them.’
+
+At length the three brothers came to a castle: and as they passed by the
+stables they saw fine horses standing there, but all were of marble, and
+no man was to be seen. Then they went through all the rooms, till they
+came to a door on which were three locks: but in the middle of the door
+was a wicket, so that they could look into the next room. There they saw
+a little grey old man sitting at a table; and they called to him once or
+twice, but he did not hear: however, they called a third time, and then
+he rose and came out to them.
+
+He said nothing, but took hold of them and led them to a beautiful
+table covered with all sorts of good things: and when they had eaten and
+drunk, he showed each of them to a bed-chamber.
+
+The next morning he came to the eldest and took him to a marble table,
+where there were three tablets, containing an account of the means by
+which the castle might be disenchanted. The first tablet said: ‘In the
+wood, under the moss, lie the thousand pearls belonging to the king’s
+daughter; they must all be found: and if one be missing by set of sun,
+he who seeks them will be turned into marble.’
+
+The eldest brother set out, and sought for the pearls the whole day:
+but the evening came, and he had not found the first hundred: so he was
+turned into stone as the tablet had foretold.
+
+The next day the second brother undertook the task; but he succeeded no
+better than the first; for he could only find the second hundred of the
+pearls; and therefore he too was turned into stone.
+
+At last came the little dwarf’s turn; and he looked in the moss; but it
+was so hard to find the pearls, and the job was so tiresome!--so he sat
+down upon a stone and cried. And as he sat there, the king of the ants
+(whose life he had saved) came to help him, with five thousand ants; and
+it was not long before they had found all the pearls and laid them in a
+heap.
+
+The second tablet said: ‘The key of the princess’s bed-chamber must be
+fished up out of the lake.’ And as the dwarf came to the brink of it,
+he saw the two ducks whose lives he had saved swimming about; and they
+dived down and soon brought in the key from the bottom.
+
+The third task was the hardest. It was to choose out the youngest and
+the best of the king’s three daughters. Now they were all beautiful, and
+all exactly alike: but he was told that the eldest had eaten a piece of
+sugar, the next some sweet syrup, and the youngest a spoonful of honey;
+so he was to guess which it was that had eaten the honey.
+
+Then came the queen of the bees, who had been saved by the little dwarf
+from the fire, and she tried the lips of all three; but at last she sat
+upon the lips of the one that had eaten the honey: and so the dwarf knew
+which was the youngest. Thus the spell was broken, and all who had been
+turned into stones awoke, and took their proper forms. And the dwarf
+married the youngest and the best of the princesses, and was king after
+her father’s death; but his two brothers married the other two sisters.
+
+
+
+
+THE ELVES AND THE SHOEMAKER
+
+There was once a shoemaker, who worked very hard and was very honest:
+but still he could not earn enough to live upon; and at last all he
+had in the world was gone, save just leather enough to make one pair of
+shoes.
+
+Then he cut his leather out, all ready to make up the next day, meaning
+to rise early in the morning to his work. His conscience was clear and
+his heart light amidst all his troubles; so he went peaceably to bed,
+left all his cares to Heaven, and soon fell asleep. In the morning after
+he had said his prayers, he sat himself down to his work; when, to his
+great wonder, there stood the shoes all ready made, upon the table. The
+good man knew not what to say or think at such an odd thing happening.
+He looked at the workmanship; there was not one false stitch in the
+whole job; all was so neat and true, that it was quite a masterpiece.
+
+The same day a customer came in, and the shoes suited him so well that
+he willingly paid a price higher than usual for them; and the poor
+shoemaker, with the money, bought leather enough to make two pairs more.
+In the evening he cut out the work, and went to bed early, that he might
+get up and begin betimes next day; but he was saved all the trouble, for
+when he got up in the morning the work was done ready to his hand. Soon
+in came buyers, who paid him handsomely for his goods, so that he bought
+leather enough for four pair more. He cut out the work again overnight
+and found it done in the morning, as before; and so it went on for some
+time: what was got ready in the evening was always done by daybreak, and
+the good man soon became thriving and well off again.
+
+One evening, about Christmas-time, as he and his wife were sitting over
+the fire chatting together, he said to her, ‘I should like to sit up and
+watch tonight, that we may see who it is that comes and does my work for
+me.’ The wife liked the thought; so they left a light burning, and hid
+themselves in a corner of the room, behind a curtain that was hung up
+there, and watched what would happen.
+
+As soon as it was midnight, there came in two little naked dwarfs; and
+they sat themselves upon the shoemaker’s bench, took up all the work
+that was cut out, and began to ply with their little fingers, stitching
+and rapping and tapping away at such a rate, that the shoemaker was all
+wonder, and could not take his eyes off them. And on they went, till the
+job was quite done, and the shoes stood ready for use upon the table.
+This was long before daybreak; and then they bustled away as quick as
+lightning.
+
+The next day the wife said to the shoemaker. ‘These little wights have
+made us rich, and we ought to be thankful to them, and do them a good
+turn if we can. I am quite sorry to see them run about as they do; and
+indeed it is not very decent, for they have nothing upon their backs to
+keep off the cold. I’ll tell you what, I will make each of them a shirt,
+and a coat and waistcoat, and a pair of pantaloons into the bargain; and
+do you make each of them a little pair of shoes.’
+
+The thought pleased the good cobbler very much; and one evening, when
+all the things were ready, they laid them on the table, instead of the
+work that they used to cut out, and then went and hid themselves, to
+watch what the little elves would do.
+
+About midnight in they came, dancing and skipping, hopped round the
+room, and then went to sit down to their work as usual; but when they
+saw the clothes lying for them, they laughed and chuckled, and seemed
+mightily delighted.
+
+Then they dressed themselves in the twinkling of an eye, and danced and
+capered and sprang about, as merry as could be; till at last they danced
+out at the door, and away over the green.
+
+The good couple saw them no more; but everything went well with them
+from that time forward, as long as they lived.
+
+
+
+
+THE JUNIPER-TREE
+
+Long, long ago, some two thousand years or so, there lived a rich
+man with a good and beautiful wife. They loved each other dearly, but
+sorrowed much that they had no children. So greatly did they desire
+to have one, that the wife prayed for it day and night, but still they
+remained childless.
+
+In front of the house there was a court, in which grew a juniper-tree.
+One winter’s day the wife stood under the tree to peel some apples, and
+as she was peeling them, she cut her finger, and the blood fell on the
+snow. ‘Ah,’ sighed the woman heavily, ‘if I had but a child, as red as
+blood and as white as snow,’ and as she spoke the words, her heart grew
+light within her, and it seemed to her that her wish was granted, and
+she returned to the house feeling glad and comforted. A month passed,
+and the snow had all disappeared; then another month went by, and all
+the earth was green. So the months followed one another, and first the
+trees budded in the woods, and soon the green branches grew thickly
+intertwined, and then the blossoms began to fall. Once again the wife
+stood under the juniper-tree, and it was so full of sweet scent that her
+heart leaped for joy, and she was so overcome with her happiness, that
+she fell on her knees. Presently the fruit became round and firm, and
+she was glad and at peace; but when they were fully ripe she picked the
+berries and ate eagerly of them, and then she grew sad and ill. A little
+while later she called her husband, and said to him, weeping. ‘If I
+die, bury me under the juniper-tree.’ Then she felt comforted and happy
+again, and before another month had passed she had a little child, and
+when she saw that it was as white as snow and as red as blood, her joy
+was so great that she died.
+
+Her husband buried her under the juniper-tree, and wept bitterly for
+her. By degrees, however, his sorrow grew less, and although at times he
+still grieved over his loss, he was able to go about as usual, and later
+on he married again.
+
+He now had a little daughter born to him; the child of his first wife
+was a boy, who was as red as blood and as white as snow. The mother
+loved her daughter very much, and when she looked at her and then looked
+at the boy, it pierced her heart to think that he would always stand in
+the way of her own child, and she was continually thinking how she could
+get the whole of the property for her. This evil thought took possession
+of her more and more, and made her behave very unkindly to the boy. She
+drove him from place to place with cuffings and buffetings, so that the
+poor child went about in fear, and had no peace from the time he left
+school to the time he went back.
+
+One day the little daughter came running to her mother in the
+store-room, and said, ‘Mother, give me an apple.’ ‘Yes, my child,’ said
+the wife, and she gave her a beautiful apple out of the chest; the chest
+had a very heavy lid and a large iron lock.
+
+‘Mother,’ said the little daughter again, ‘may not brother have one
+too?’ The mother was angry at this, but she answered, ‘Yes, when he
+comes out of school.’
+
+Just then she looked out of the window and saw him coming, and it seemed
+as if an evil spirit entered into her, for she snatched the apple out
+of her little daughter’s hand, and said, ‘You shall not have one before
+your brother.’ She threw the apple into the chest and shut it to. The
+little boy now came in, and the evil spirit in the wife made her say
+kindly to him, ‘My son, will you have an apple?’ but she gave him a
+wicked look. ‘Mother,’ said the boy, ‘how dreadful you look! Yes, give
+me an apple.’ The thought came to her that she would kill him. ‘Come
+with me,’ she said, and she lifted up the lid of the chest; ‘take one
+out for yourself.’ And as he bent over to do so, the evil spirit urged
+her, and crash! down went the lid, and off went the little boy’s head.
+Then she was overwhelmed with fear at the thought of what she had done.
+‘If only I can prevent anyone knowing that I did it,’ she thought. So
+she went upstairs to her room, and took a white handkerchief out of
+her top drawer; then she set the boy’s head again on his shoulders, and
+bound it with the handkerchief so that nothing could be seen, and placed
+him on a chair by the door with an apple in his hand.
+
+Soon after this, little Marleen came up to her mother who was stirring
+a pot of boiling water over the fire, and said, ‘Mother, brother is
+sitting by the door with an apple in his hand, and he looks so pale;
+and when I asked him to give me the apple, he did not answer, and that
+frightened me.’
+
+‘Go to him again,’ said her mother, ‘and if he does not answer, give him
+a box on the ear.’ So little Marleen went, and said, ‘Brother, give me
+that apple,’ but he did not say a word; then she gave him a box on the
+ear, and his head rolled off. She was so terrified at this, that she ran
+crying and screaming to her mother. ‘Oh!’ she said, ‘I have knocked off
+brother’s head,’ and then she wept and wept, and nothing would stop her.
+
+‘What have you done!’ said her mother, ‘but no one must know about it,
+so you must keep silence; what is done can’t be undone; we will make
+him into puddings.’ And she took the little boy and cut him up, made him
+into puddings, and put him in the pot. But Marleen stood looking on,
+and wept and wept, and her tears fell into the pot, so that there was no
+need of salt.
+
+Presently the father came home and sat down to his dinner; he asked,
+‘Where is my son?’ The mother said nothing, but gave him a large dish of
+black pudding, and Marleen still wept without ceasing.
+
+The father again asked, ‘Where is my son?’
+
+‘Oh,’ answered the wife, ‘he is gone into the country to his mother’s
+great uncle; he is going to stay there some time.’
+
+‘What has he gone there for, and he never even said goodbye to me!’
+
+‘Well, he likes being there, and he told me he should be away quite six
+weeks; he is well looked after there.’
+
+‘I feel very unhappy about it,’ said the husband, ‘in case it should not
+be all right, and he ought to have said goodbye to me.’
+
+With this he went on with his dinner, and said, ‘Little Marleen, why do
+you weep? Brother will soon be back.’ Then he asked his wife for more
+pudding, and as he ate, he threw the bones under the table.
+
+Little Marleen went upstairs and took her best silk handkerchief out of
+her bottom drawer, and in it she wrapped all the bones from under the
+table and carried them outside, and all the time she did nothing but
+weep. Then she laid them in the green grass under the juniper-tree, and
+she had no sooner done so, then all her sadness seemed to leave her,
+and she wept no more. And now the juniper-tree began to move, and the
+branches waved backwards and forwards, first away from one another, and
+then together again, as it might be someone clapping their hands for
+joy. After this a mist came round the tree, and in the midst of it there
+was a burning as of fire, and out of the fire there flew a beautiful
+bird, that rose high into the air, singing magnificently, and when it
+could no more be seen, the juniper-tree stood there as before, and the
+silk handkerchief and the bones were gone.
+
+Little Marleen now felt as lighthearted and happy as if her brother were
+still alive, and she went back to the house and sat down cheerfully to
+the table and ate.
+
+The bird flew away and alighted on the house of a goldsmith and began to
+sing:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The goldsmith was in his workshop making a gold chain, when he heard the
+song of the bird on his roof. He thought it so beautiful that he got
+up and ran out, and as he crossed the threshold he lost one of his
+slippers. But he ran on into the middle of the street, with a slipper on
+one foot and a sock on the other; he still had on his apron, and still
+held the gold chain and the pincers in his hands, and so he stood gazing
+up at the bird, while the sun came shining brightly down on the street.
+
+‘Bird,’ he said, ‘how beautifully you sing! Sing me that song again.’
+
+‘Nay,’ said the bird, ‘I do not sing twice for nothing. Give that gold
+chain, and I will sing it you again.’
+
+‘Here is the chain, take it,’ said the goldsmith. ‘Only sing me that
+again.’
+
+The bird flew down and took the gold chain in his right claw, and then
+he alighted again in front of the goldsmith and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+Then he flew away, and settled on the roof of a shoemaker’s house and
+sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+The shoemaker heard him, and he jumped up and ran out in his
+shirt-sleeves, and stood looking up at the bird on the roof with his
+hand over his eyes to keep himself from being blinded by the sun.
+
+‘Bird,’ he said, ‘how beautifully you sing!’ Then he called through the
+door to his wife: ‘Wife, come out; here is a bird, come and look at it
+and hear how beautifully it sings.’ Then he called his daughter and the
+children, then the apprentices, girls and boys, and they all ran up the
+street to look at the bird, and saw how splendid it was with its red
+and green feathers, and its neck like burnished gold, and eyes like two
+bright stars in its head.
+
+‘Bird,’ said the shoemaker, ‘sing me that song again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; you must
+give me something.’
+
+‘Wife,’ said the man, ‘go into the garret; on the upper shelf you will
+see a pair of red shoes; bring them to me.’ The wife went in and fetched
+the shoes.
+
+‘There, bird,’ said the shoemaker, ‘now sing me that song again.’
+
+The bird flew down and took the red shoes in his left claw, and then he
+went back to the roof and sang:
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+When he had finished, he flew away. He had the chain in his right claw
+and the shoes in his left, and he flew right away to a mill, and the
+mill went ‘Click clack, click clack, click clack.’ Inside the mill were
+twenty of the miller’s men hewing a stone, and as they went ‘Hick hack,
+hick hack, hick hack,’ the mill went ‘Click clack, click clack, click
+clack.’
+
+The bird settled on a lime-tree in front of the mill and sang:
+
+ ‘My mother killed her little son;
+
+then one of the men left off,
+
+  My father grieved when I was gone;
+
+two more men left off and listened,
+
+  My sister loved me best of all;
+
+then four more left off,
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+now there were only eight at work,
+
+  Underneath
+
+And now only five,
+
+  the juniper-tree.
+
+And now only one,
+
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+then he looked up and the last one had left off work.
+
+‘Bird,’ he said, ‘what a beautiful song that is you sing! Let me hear it
+too; sing it again.’
+
+‘Nay,’ answered the bird, ‘I do not sing twice for nothing; give me that
+millstone, and I will sing it again.’
+
+‘If it belonged to me alone,’ said the man, ‘you should have it.’
+
+‘Yes, yes,’ said the others: ‘if he will sing again, he can have it.’
+
+The bird came down, and all the twenty millers set to and lifted up the
+stone with a beam; then the bird put his head through the hole and took
+the stone round his neck like a collar, and flew back with it to the
+tree and sang--
+
+ ‘My mother killed her little son;
+  My father grieved when I was gone;
+  My sister loved me best of all;
+  She laid her kerchief over me,
+  And took my bones that they might lie
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And when he had finished his song, he spread his wings, and with the
+chain in his right claw, the shoes in his left, and the millstone round
+his neck, he flew right away to his father’s house.
+
+The father, the mother, and little Marleen were having their dinner.
+
+‘How lighthearted I feel,’ said the father, ‘so pleased and cheerful.’
+
+‘And I,’ said the mother, ‘I feel so uneasy, as if a heavy thunderstorm
+were coming.’
+
+But little Marleen sat and wept and wept.
+
+Then the bird came flying towards the house and settled on the roof.
+
+‘I do feel so happy,’ said the father, ‘and how beautifully the sun
+shines; I feel just as if I were going to see an old friend again.’
+
+‘Ah!’ said the wife, ‘and I am so full of distress and uneasiness that
+my teeth chatter, and I feel as if there were a fire in my veins,’ and
+she tore open her dress; and all the while little Marleen sat in the
+corner and wept, and the plate on her knees was wet with her tears.
+
+The bird now flew to the juniper-tree and began singing:
+
+ ‘My mother killed her little son;
+
+the mother shut her eyes and her ears, that she might see and hear
+nothing, but there was a roaring sound in her ears like that of a
+violent storm, and in her eyes a burning and flashing like lightning:
+
+  My father grieved when I was gone;
+
+‘Look, mother,’ said the man, ‘at the beautiful bird that is singing so
+magnificently; and how warm and bright the sun is, and what a delicious
+scent of spice in the air!’
+
+  My sister loved me best of all;
+
+then little Marleen laid her head down on her knees and sobbed.
+
+‘I must go outside and see the bird nearer,’ said the man.
+
+‘Ah, do not go!’ cried the wife. ‘I feel as if the whole house were in
+flames!’
+
+But the man went out and looked at the bird.
+
+ She laid her kerchief over me,
+ And took my bones that they might lie
+ Underneath the juniper-tree
+ Kywitt, Kywitt, what a beautiful bird am I!’
+
+With that the bird let fall the gold chain, and it fell just round the
+man’s neck, so that it fitted him exactly.
+
+He went inside, and said, ‘See, what a splendid bird that is; he has
+given me this beautiful gold chain, and looks so beautiful himself.’
+
+But the wife was in such fear and trouble, that she fell on the floor,
+and her cap fell from her head.
+
+Then the bird began again:
+
+ ‘My mother killed her little son;
+
+‘Ah me!’ cried the wife, ‘if I were but a thousand feet beneath the
+earth, that I might not hear that song.’
+
+  My father grieved when I was gone;
+
+then the woman fell down again as if dead.
+
+  My sister loved me best of all;
+
+‘Well,’ said little Marleen, ‘I will go out too and see if the bird will
+give me anything.’
+
+So she went out.
+
+  She laid her kerchief over me,
+  And took my bones that they might lie
+
+and he threw down the shoes to her,
+
+  Underneath the juniper-tree
+  Kywitt, Kywitt, what a beautiful bird am I!’
+
+And she now felt quite happy and lighthearted; she put on the shoes and
+danced and jumped about in them. ‘I was so miserable,’ she said, ‘when I
+came out, but that has all passed away; that is indeed a splendid bird,
+and he has given me a pair of red shoes.’
+
+The wife sprang up, with her hair standing out from her head like flames
+of fire. ‘Then I will go out too,’ she said, ‘and see if it will lighten
+my misery, for I feel as if the world were coming to an end.’
+
+But as she crossed the threshold, crash! the bird threw the millstone
+down on her head, and she was crushed to death.
+
+The father and little Marleen heard the sound and ran out, but they only
+saw mist and flame and fire rising from the spot, and when these had
+passed, there stood the little brother, and he took the father and
+little Marleen by the hand; then they all three rejoiced, and went
+inside together and sat down to their dinners and ate.
+
+
+
+
+THE TURNIP
+
+There were two brothers who were both soldiers; the one was rich and
+the other poor. The poor man thought he would try to better himself; so,
+pulling off his red coat, he became a gardener, and dug his ground well,
+and sowed turnips.
+
+When the seed came up, there was one plant bigger than all the rest; and
+it kept getting larger and larger, and seemed as if it would never cease
+growing; so that it might have been called the prince of turnips for
+there never was such a one seen before, and never will again. At last it
+was so big that it filled a cart, and two oxen could hardly draw it; and
+the gardener knew not what in the world to do with it, nor whether it
+would be a blessing or a curse to him. One day he said to himself, ‘What
+shall I do with it? if I sell it, it will bring no more than another;
+and for eating, the little turnips are better than this; the best thing
+perhaps is to carry it and give it to the king as a mark of respect.’
+
+Then he yoked his oxen, and drew the turnip to the court, and gave it
+to the king. ‘What a wonderful thing!’ said the king; ‘I have seen many
+strange things, but such a monster as this I never saw. Where did you
+get the seed? or is it only your good luck? If so, you are a true child
+of fortune.’ ‘Ah, no!’ answered the gardener, ‘I am no child of fortune;
+I am a poor soldier, who never could get enough to live upon; so I
+laid aside my red coat, and set to work, tilling the ground. I have a
+brother, who is rich, and your majesty knows him well, and all the world
+knows him; but because I am poor, everybody forgets me.’
+
+The king then took pity on him, and said, ‘You shall be poor no
+longer. I will give you so much that you shall be even richer than your
+brother.’ Then he gave him gold and lands and flocks, and made him so
+rich that his brother’s fortune could not at all be compared with his.
+
+When the brother heard of all this, and how a turnip had made the
+gardener so rich, he envied him sorely, and bethought himself how he
+could contrive to get the same good fortune for himself. However, he
+determined to manage more cleverly than his brother, and got together a
+rich present of gold and fine horses for the king; and thought he must
+have a much larger gift in return; for if his brother had received so
+much for only a turnip, what must his present be worth?
+
+The king took the gift very graciously, and said he knew not what to
+give in return more valuable and wonderful than the great turnip; so
+the soldier was forced to put it into a cart, and drag it home with him.
+When he reached home, he knew not upon whom to vent his rage and spite;
+and at length wicked thoughts came into his head, and he resolved to
+kill his brother.
+
+So he hired some villains to murder him; and having shown them where to
+lie in ambush, he went to his brother, and said, ‘Dear brother, I have
+found a hidden treasure; let us go and dig it up, and share it between
+us.’ The other had no suspicions of his roguery: so they went out
+together, and as they were travelling along, the murderers rushed out
+upon him, bound him, and were going to hang him on a tree.
+
+But whilst they were getting all ready, they heard the trampling of a
+horse at a distance, which so frightened them that they pushed their
+prisoner neck and shoulders together into a sack, and swung him up by a
+cord to the tree, where they left him dangling, and ran away. Meantime
+he worked and worked away, till he made a hole large enough to put out
+his head.
+
+When the horseman came up, he proved to be a student, a merry fellow,
+who was journeying along on his nag, and singing as he went. As soon as
+the man in the sack saw him passing under the tree, he cried out, ‘Good
+morning! good morning to thee, my friend!’ The student looked about
+everywhere; and seeing no one, and not knowing where the voice came
+from, cried out, ‘Who calls me?’
+
+Then the man in the tree answered, ‘Lift up thine eyes, for behold here
+I sit in the sack of wisdom; here have I, in a short time, learned great
+and wondrous things. Compared to this seat, all the learning of the
+schools is as empty air. A little longer, and I shall know all that man
+can know, and shall come forth wiser than the wisest of mankind. Here
+I discern the signs and motions of the heavens and the stars; the laws
+that control the winds; the number of the sands on the seashore; the
+healing of the sick; the virtues of all simples, of birds, and of
+precious stones. Wert thou but once here, my friend, though wouldst feel
+and own the power of knowledge.
+
+The student listened to all this and wondered much; at last he said,
+‘Blessed be the day and hour when I found you; cannot you contrive to
+let me into the sack for a little while?’ Then the other answered, as if
+very unwillingly, ‘A little space I may allow thee to sit here, if thou
+wilt reward me well and entreat me kindly; but thou must tarry yet an
+hour below, till I have learnt some little matters that are yet unknown
+to me.’
+
+So the student sat himself down and waited a while; but the time hung
+heavy upon him, and he begged earnestly that he might ascend forthwith,
+for his thirst for knowledge was great. Then the other pretended to give
+way, and said, ‘Thou must let the sack of wisdom descend, by untying
+yonder cord, and then thou shalt enter.’ So the student let him down,
+opened the sack, and set him free. ‘Now then,’ cried he, ‘let me ascend
+quickly.’ As he began to put himself into the sack heels first, ‘Wait a
+while,’ said the gardener, ‘that is not the way.’ Then he pushed him
+in head first, tied up the sack, and soon swung up the searcher after
+wisdom dangling in the air. ‘How is it with thee, friend?’ said he,
+‘dost thou not feel that wisdom comes unto thee? Rest there in peace,
+till thou art a wiser man than thou wert.’
+
+So saying, he trotted off on the student’s nag, and left the poor fellow
+to gather wisdom till somebody should come and let him down.
+
+
+
+
+CLEVER HANS
+
+The mother of Hans said: ‘Whither away, Hans?’ Hans answered: ‘To
+Gretel.’ ‘Behave well, Hans.’ ‘Oh, I’ll behave well. Goodbye, mother.’
+‘Goodbye, Hans.’ Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day,
+Hans. What do you bring that is good?’ ‘I bring nothing, I want to have
+something given me.’ Gretel presents Hans with a needle, Hans says:
+‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the needle, sticks it into a hay-cart, and follows the cart
+home. ‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’
+‘With Gretel.’ ‘What did you take her?’ ‘Took nothing; had something
+given me.’ ‘What did Gretel give you?’ ‘Gave me a needle.’ ‘Where is the
+needle, Hans?’ ‘Stuck in the hay-cart.’ ‘That was ill done, Hans. You
+should have stuck the needle in your sleeve.’ ‘Never mind, I’ll do
+better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What do you bring that is
+good?’ ‘I bring nothing. I want to have something given to me.’ Gretel
+presents Hans with a knife. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans
+takes the knife, sticks it in his sleeve, and goes home. ‘Good evening,
+mother.’ ‘Good evening, Hans. Where have you been?’ ‘With Gretel.’ What
+did you take her?’ ‘Took her nothing, she gave me something.’ ‘What did
+Gretel give you?’ ‘Gave me a knife.’ ‘Where is the knife, Hans?’ ‘Stuck
+in my sleeve.’ ‘That’s ill done, Hans, you should have put the knife in
+your pocket.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a young goat. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’ Hans takes
+the goat, ties its legs, and puts it in his pocket. When he gets home it
+is suffocated. ‘Good evening, mother.’ ‘Good evening, Hans. Where have
+you been?’ ‘With Gretel.’ ‘What did you take her?’ ‘Took nothing, she
+gave me something.’ ‘What did Gretel give you?’ ‘She gave me a goat.’
+‘Where is the goat, Hans?’ ‘Put it in my pocket.’ ‘That was ill done,
+Hans, you should have put a rope round the goat’s neck.’ ‘Never mind,
+will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘Oh,
+I’ll behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to
+Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good thing do you
+bring?’ ‘I bring nothing, I want something given me.’ Gretel presents
+Hans with a piece of bacon. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the bacon, ties it to a rope, and drags it away behind him.
+The dogs come and devour the bacon. When he gets home, he has the rope
+in his hand, and there is no longer anything hanging on to it. ‘Good
+evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took her nothing, she gave me
+something.’ ‘What did Gretel give you?’ ‘Gave me a bit of bacon.’ ‘Where
+is the bacon, Hans?’ ‘I tied it to a rope, brought it home, dogs took
+it.’ ‘That was ill done, Hans, you should have carried the bacon on your
+head.’ ‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’ Hans comes to Gretel.
+‘Good day, Gretel.’ ‘Good day, Hans, What good thing do you bring?’ ‘I
+bring nothing, but would have something given.’ Gretel presents Hans
+with a calf. ‘Goodbye, Gretel.’ ‘Goodbye, Hans.’
+
+Hans takes the calf, puts it on his head, and the calf kicks his face.
+‘Good evening, mother.’ ‘Good evening, Hans. Where have you been?’ ‘With
+Gretel.’ ‘What did you take her?’ ‘I took nothing, but had something
+given me.’ ‘What did Gretel give you?’ ‘A calf.’ ‘Where have you the
+calf, Hans?’ ‘I set it on my head and it kicked my face.’ ‘That was
+ill done, Hans, you should have led the calf, and put it in the stall.’
+‘Never mind, will do better next time.’
+
+‘Whither away, Hans?’ ‘To Gretel, mother.’ ‘Behave well, Hans.’ ‘I’ll
+behave well. Goodbye, mother.’ ‘Goodbye, Hans.’
+
+Hans comes to Gretel. ‘Good day, Gretel.’ ‘Good day, Hans. What good
+thing do you bring?’ ‘I bring nothing, but would have something given.’
+Gretel says to Hans: ‘I will go with you.’
+
+Hans takes Gretel, ties her to a rope, leads her to the rack, and binds
+her fast. Then Hans goes to his mother. ‘Good evening, mother.’ ‘Good
+evening, Hans. Where have you been?’ ‘With Gretel.’ ‘What did you take
+her?’ ‘I took her nothing.’ ‘What did Gretel give you?’ ‘She gave me
+nothing, she came with me.’ ‘Where have you left Gretel?’ ‘I led her by
+the rope, tied her to the rack, and scattered some grass for her.’ ‘That
+was ill done, Hans, you should have cast friendly eyes on her.’ ‘Never
+mind, will do better.’
+
+Hans went into the stable, cut out all the calves’ and sheep’s eyes,
+and threw them in Gretel’s face. Then Gretel became angry, tore herself
+loose and ran away, and was no longer the bride of Hans.
+
+
+
+
+THE THREE LANGUAGES
+
+An aged count once lived in Switzerland, who had an only son, but he
+was stupid, and could learn nothing. Then said the father: ‘Hark you,
+my son, try as I will I can get nothing into your head. You must go from
+hence, I will give you into the care of a celebrated master, who shall
+see what he can do with you.’ The youth was sent into a strange town,
+and remained a whole year with the master. At the end of this time,
+he came home again, and his father asked: ‘Now, my son, what have you
+learnt?’ ‘Father, I have learnt what the dogs say when they bark.’ ‘Lord
+have mercy on us!’ cried the father; ‘is that all you have learnt? I
+will send you into another town, to another master.’ The youth was taken
+thither, and stayed a year with this master likewise. When he came back
+the father again asked: ‘My son, what have you learnt?’ He answered:
+‘Father, I have learnt what the birds say.’ Then the father fell into a
+rage and said: ‘Oh, you lost man, you have spent the precious time and
+learnt nothing; are you not ashamed to appear before my eyes? I will
+send you to a third master, but if you learn nothing this time also, I
+will no longer be your father.’ The youth remained a whole year with the
+third master also, and when he came home again, and his father inquired:
+‘My son, what have you learnt?’ he answered: ‘Dear father, I have this
+year learnt what the frogs croak.’ Then the father fell into the most
+furious anger, sprang up, called his people thither, and said: ‘This man
+is no longer my son, I drive him forth, and command you to take him
+out into the forest, and kill him.’ They took him forth, but when they
+should have killed him, they could not do it for pity, and let him go,
+and they cut the eyes and tongue out of a deer that they might carry
+them to the old man as a token.
+
+The youth wandered on, and after some time came to a fortress where he
+begged for a night’s lodging. ‘Yes,’ said the lord of the castle, ‘if
+you will pass the night down there in the old tower, go thither; but I
+warn you, it is at the peril of your life, for it is full of wild dogs,
+which bark and howl without stopping, and at certain hours a man has to
+be given to them, whom they at once devour.’ The whole district was in
+sorrow and dismay because of them, and yet no one could do anything to
+stop this. The youth, however, was without fear, and said: ‘Just let me
+go down to the barking dogs, and give me something that I can throw to
+them; they will do nothing to harm me.’ As he himself would have it so,
+they gave him some food for the wild animals, and led him down to the
+tower. When he went inside, the dogs did not bark at him, but wagged
+their tails quite amicably around him, ate what he set before them, and
+did not hurt one hair of his head. Next morning, to the astonishment of
+everyone, he came out again safe and unharmed, and said to the lord of
+the castle: ‘The dogs have revealed to me, in their own language, why
+they dwell there, and bring evil on the land. They are bewitched, and
+are obliged to watch over a great treasure which is below in the tower,
+and they can have no rest until it is taken away, and I have likewise
+learnt, from their discourse, how that is to be done.’ Then all who
+heard this rejoiced, and the lord of the castle said he would adopt him
+as a son if he accomplished it successfully. He went down again, and
+as he knew what he had to do, he did it thoroughly, and brought a chest
+full of gold out with him. The howling of the wild dogs was henceforth
+heard no more; they had disappeared, and the country was freed from the
+trouble.
+
+After some time he took it in his head that he would travel to Rome. On
+the way he passed by a marsh, in which a number of frogs were sitting
+croaking. He listened to them, and when he became aware of what they
+were saying, he grew very thoughtful and sad. At last he arrived in
+Rome, where the Pope had just died, and there was great doubt among
+the cardinals as to whom they should appoint as his successor. They at
+length agreed that the person should be chosen as pope who should be
+distinguished by some divine and miraculous token. And just as that was
+decided on, the young count entered into the church, and suddenly two
+snow-white doves flew on his shoulders and remained sitting there. The
+ecclesiastics recognized therein the token from above, and asked him on
+the spot if he would be pope. He was undecided, and knew not if he were
+worthy of this, but the doves counselled him to do it, and at length he
+said yes. Then was he anointed and consecrated, and thus was fulfilled
+what he had heard from the frogs on his way, which had so affected him,
+that he was to be his Holiness the Pope. Then he had to sing a mass, and
+did not know one word of it, but the two doves sat continually on his
+shoulders, and said it all in his ear.
+
+
+
+
+THE FOX AND THE CAT
+
+It happened that the cat met the fox in a forest, and as she thought to
+herself: ‘He is clever and full of experience, and much esteemed in the
+world,’ she spoke to him in a friendly way. ‘Good day, dear Mr Fox,
+how are you? How is all with you? How are you getting on in these hard
+times?’ The fox, full of all kinds of arrogance, looked at the cat from
+head to foot, and for a long time did not know whether he would give
+any answer or not. At last he said: ‘Oh, you wretched beard-cleaner, you
+piebald fool, you hungry mouse-hunter, what can you be thinking of? Have
+you the cheek to ask how I am getting on? What have you learnt? How
+many arts do you understand?’ ‘I understand but one,’ replied the
+cat, modestly. ‘What art is that?’ asked the fox. ‘When the hounds are
+following me, I can spring into a tree and save myself.’ ‘Is that all?’
+said the fox. ‘I am master of a hundred arts, and have into the bargain
+a sackful of cunning. You make me sorry for you; come with me, I will
+teach you how people get away from the hounds.’ Just then came a hunter
+with four dogs. The cat sprang nimbly up a tree, and sat down at the top
+of it, where the branches and foliage quite concealed her. ‘Open your
+sack, Mr Fox, open your sack,’ cried the cat to him, but the dogs had
+already seized him, and were holding him fast. ‘Ah, Mr Fox,’ cried the
+cat. ‘You with your hundred arts are left in the lurch! Had you been
+able to climb like me, you would not have lost your life.’
+
+
+
+
+THE FOUR CLEVER BROTHERS
+
+‘Dear children,’ said a poor man to his four sons, ‘I have nothing to
+give you; you must go out into the wide world and try your luck. Begin
+by learning some craft or another, and see how you can get on.’ So the
+four brothers took their walking-sticks in their hands, and their little
+bundles on their shoulders, and after bidding their father goodbye, went
+all out at the gate together. When they had got on some way they came
+to four crossways, each leading to a different country. Then the eldest
+said, ‘Here we must part; but this day four years we will come back
+to this spot, and in the meantime each must try what he can do for
+himself.’
+
+So each brother went his way; and as the eldest was hastening on a man
+met him, and asked him where he was going, and what he wanted. ‘I am
+going to try my luck in the world, and should like to begin by learning
+some art or trade,’ answered he. ‘Then,’ said the man, ‘go with me, and
+I will teach you to become the cunningest thief that ever was.’ ‘No,’
+said the other, ‘that is not an honest calling, and what can one look
+to earn by it in the end but the gallows?’ ‘Oh!’ said the man, ‘you need
+not fear the gallows; for I will only teach you to steal what will be
+fair game: I meddle with nothing but what no one else can get or care
+anything about, and where no one can find you out.’ So the young man
+agreed to follow his trade, and he soon showed himself so clever, that
+nothing could escape him that he had once set his mind upon.
+
+The second brother also met a man, who, when he found out what he was
+setting out upon, asked him what craft he meant to follow. ‘I do not
+know yet,’ said he. ‘Then come with me, and be a star-gazer. It is a
+noble art, for nothing can be hidden from you, when once you understand
+the stars.’ The plan pleased him much, and he soon became such a skilful
+star-gazer, that when he had served out his time, and wanted to leave
+his master, he gave him a glass, and said, ‘With this you can see all
+that is passing in the sky and on earth, and nothing can be hidden from
+you.’
+
+The third brother met a huntsman, who took him with him, and taught him
+so well all that belonged to hunting, that he became very clever in the
+craft of the woods; and when he left his master he gave him a bow, and
+said, ‘Whatever you shoot at with this bow you will be sure to hit.’
+
+The youngest brother likewise met a man who asked him what he wished to
+do. ‘Would not you like,’ said he, ‘to be a tailor?’ ‘Oh, no!’ said
+the young man; ‘sitting cross-legged from morning to night, working
+backwards and forwards with a needle and goose, will never suit me.’
+‘Oh!’ answered the man, ‘that is not my sort of tailoring; come with me,
+and you will learn quite another kind of craft from that.’ Not knowing
+what better to do, he came into the plan, and learnt tailoring from the
+beginning; and when he left his master, he gave him a needle, and said,
+‘You can sew anything with this, be it as soft as an egg or as hard as
+steel; and the joint will be so fine that no seam will be seen.’
+
+After the space of four years, at the time agreed upon, the four
+brothers met at the four cross-roads; and having welcomed each other,
+set off towards their father’s home, where they told him all that had
+happened to them, and how each had learned some craft.
+
+Then, one day, as they were sitting before the house under a very high
+tree, the father said, ‘I should like to try what each of you can do in
+this way.’ So he looked up, and said to the second son, ‘At the top of
+this tree there is a chaffinch’s nest; tell me how many eggs there are
+in it.’ The star-gazer took his glass, looked up, and said, ‘Five.’
+‘Now,’ said the father to the eldest son, ‘take away the eggs without
+letting the bird that is sitting upon them and hatching them know
+anything of what you are doing.’ So the cunning thief climbed up the
+tree, and brought away to his father the five eggs from under the bird;
+and it never saw or felt what he was doing, but kept sitting on at its
+ease. Then the father took the eggs, and put one on each corner of the
+table, and the fifth in the middle, and said to the huntsman, ‘Cut all
+the eggs in two pieces at one shot.’ The huntsman took up his bow, and
+at one shot struck all the five eggs as his father wished.
+
+‘Now comes your turn,’ said he to the young tailor; ‘sew the eggs and
+the young birds in them together again, so neatly that the shot shall
+have done them no harm.’ Then the tailor took his needle, and sewed the
+eggs as he was told; and when he had done, the thief was sent to take
+them back to the nest, and put them under the bird without its knowing
+it. Then she went on sitting, and hatched them: and in a few days they
+crawled out, and had only a little red streak across their necks, where
+the tailor had sewn them together.
+
+‘Well done, sons!’ said the old man; ‘you have made good use of your
+time, and learnt something worth the knowing; but I am sure I do not
+know which ought to have the prize. Oh, that a time might soon come for
+you to turn your skill to some account!’
+
+Not long after this there was a great bustle in the country; for the
+king’s daughter had been carried off by a mighty dragon, and the king
+mourned over his loss day and night, and made it known that whoever
+brought her back to him should have her for a wife. Then the four
+brothers said to each other, ‘Here is a chance for us; let us try
+what we can do.’ And they agreed to see whether they could not set the
+princess free. ‘I will soon find out where she is, however,’ said the
+star-gazer, as he looked through his glass; and he soon cried out, ‘I
+see her afar off, sitting upon a rock in the sea, and I can spy the
+dragon close by, guarding her.’ Then he went to the king, and asked for
+a ship for himself and his brothers; and they sailed together over the
+sea, till they came to the right place. There they found the princess
+sitting, as the star-gazer had said, on the rock; and the dragon was
+lying asleep, with his head upon her lap. ‘I dare not shoot at him,’
+said the huntsman, ‘for I should kill the beautiful young lady also.’
+‘Then I will try my skill,’ said the thief, and went and stole her away
+from under the dragon, so quietly and gently that the beast did not know
+it, but went on snoring.
+
+Then away they hastened with her full of joy in their boat towards the
+ship; but soon came the dragon roaring behind them through the air; for
+he awoke and missed the princess. But when he got over the boat, and
+wanted to pounce upon them and carry off the princess, the huntsman took
+up his bow and shot him straight through the heart so that he fell down
+dead. They were still not safe; for he was such a great beast that in
+his fall he overset the boat, and they had to swim in the open sea
+upon a few planks. So the tailor took his needle, and with a few large
+stitches put some of the planks together; and he sat down upon these,
+and sailed about and gathered up all pieces of the boat; and then tacked
+them together so quickly that the boat was soon ready, and they then
+reached the ship and got home safe.
+
+When they had brought home the princess to her father, there was great
+rejoicing; and he said to the four brothers, ‘One of you shall marry
+her, but you must settle amongst yourselves which it is to be.’ Then
+there arose a quarrel between them; and the star-gazer said, ‘If I had
+not found the princess out, all your skill would have been of no use;
+therefore she ought to be mine.’ ‘Your seeing her would have been of
+no use,’ said the thief, ‘if I had not taken her away from the dragon;
+therefore she ought to be mine.’ ‘No, she is mine,’ said the huntsman;
+‘for if I had not killed the dragon, he would, after all, have torn you
+and the princess into pieces.’ ‘And if I had not sewn the boat together
+again,’ said the tailor, ‘you would all have been drowned, therefore she
+is mine.’ Then the king put in a word, and said, ‘Each of you is right;
+and as all cannot have the young lady, the best way is for neither of
+you to have her: for the truth is, there is somebody she likes a great
+deal better. But to make up for your loss, I will give each of you, as a
+reward for his skill, half a kingdom.’ So the brothers agreed that this
+plan would be much better than either quarrelling or marrying a lady who
+had no mind to have them. And the king then gave to each half a kingdom,
+as he had said; and they lived very happily the rest of their days, and
+took good care of their father; and somebody took better care of the
+young lady, than to let either the dragon or one of the craftsmen have
+her again.
+
+
+
+
+LILY AND THE LION
+
+A merchant, who had three daughters, was once setting out upon a
+journey; but before he went he asked each daughter what gift he should
+bring back for her. The eldest wished for pearls; the second for jewels;
+but the third, who was called Lily, said, ‘Dear father, bring me a
+rose.’ Now it was no easy task to find a rose, for it was the middle
+of winter; yet as she was his prettiest daughter, and was very fond of
+flowers, her father said he would try what he could do. So he kissed all
+three, and bid them goodbye.
+
+And when the time came for him to go home, he had bought pearls and
+jewels for the two eldest, but he had sought everywhere in vain for the
+rose; and when he went into any garden and asked for such a thing, the
+people laughed at him, and asked him whether he thought roses grew in
+snow. This grieved him very much, for Lily was his dearest child; and as
+he was journeying home, thinking what he should bring her, he came to a
+fine castle; and around the castle was a garden, in one half of which it
+seemed to be summer-time and in the other half winter. On one side the
+finest flowers were in full bloom, and on the other everything looked
+dreary and buried in the snow. ‘A lucky hit!’ said he, as he called to
+his servant, and told him to go to a beautiful bed of roses that was
+there, and bring him away one of the finest flowers.
+
+This done, they were riding away well pleased, when up sprang a fierce
+lion, and roared out, ‘Whoever has stolen my roses shall be eaten up
+alive!’ Then the man said, ‘I knew not that the garden belonged to you;
+can nothing save my life?’ ‘No!’ said the lion, ‘nothing, unless you
+undertake to give me whatever meets you on your return home; if you
+agree to this, I will give you your life, and the rose too for your
+daughter.’ But the man was unwilling to do so and said, ‘It may be my
+youngest daughter, who loves me most, and always runs to meet me when
+I go home.’ Then the servant was greatly frightened, and said, ‘It may
+perhaps be only a cat or a dog.’ And at last the man yielded with a
+heavy heart, and took the rose; and said he would give the lion whatever
+should meet him first on his return.
+
+And as he came near home, it was Lily, his youngest and dearest
+daughter, that met him; she came running, and kissed him, and welcomed
+him home; and when she saw that he had brought her the rose, she was
+still more glad. But her father began to be very sorrowful, and to weep,
+saying, ‘Alas, my dearest child! I have bought this flower at a high
+price, for I have said I would give you to a wild lion; and when he has
+you, he will tear you in pieces, and eat you.’ Then he told her all that
+had happened, and said she should not go, let what would happen.
+
+But she comforted him, and said, ‘Dear father, the word you have given
+must be kept; I will go to the lion, and soothe him: perhaps he will let
+me come safe home again.’
+
+The next morning she asked the way she was to go, and took leave of her
+father, and went forth with a bold heart into the wood. But the lion was
+an enchanted prince. By day he and all his court were lions, but in the
+evening they took their right forms again. And when Lily came to the
+castle, he welcomed her so courteously that she agreed to marry him. The
+wedding-feast was held, and they lived happily together a long time. The
+prince was only to be seen as soon as evening came, and then he held his
+court; but every morning he left his bride, and went away by himself,
+she knew not whither, till the night came again.
+
+After some time he said to her, ‘Tomorrow there will be a great feast in
+your father’s house, for your eldest sister is to be married; and if
+you wish to go and visit her my lions shall lead you thither.’ Then she
+rejoiced much at the thoughts of seeing her father once more, and set
+out with the lions; and everyone was overjoyed to see her, for they had
+thought her dead long since. But she told them how happy she was, and
+stayed till the feast was over, and then went back to the wood.
+
+Her second sister was soon after married, and when Lily was asked to
+go to the wedding, she said to the prince, ‘I will not go alone this
+time--you must go with me.’ But he would not, and said that it would be
+a very hazardous thing; for if the least ray of the torch-light should
+fall upon him his enchantment would become still worse, for he should be
+changed into a dove, and be forced to wander about the world for seven
+long years. However, she gave him no rest, and said she would take care
+no light should fall upon him. So at last they set out together, and
+took with them their little child; and she chose a large hall with thick
+walls for him to sit in while the wedding-torches were lighted; but,
+unluckily, no one saw that there was a crack in the door. Then the
+wedding was held with great pomp, but as the train came from the church,
+and passed with the torches before the hall, a very small ray of light
+fell upon the prince. In a moment he disappeared, and when his wife came
+in and looked for him, she found only a white dove; and it said to her,
+‘Seven years must I fly up and down over the face of the earth, but
+every now and then I will let fall a white feather, that will show you
+the way I am going; follow it, and at last you may overtake and set me
+free.’
+
+This said, he flew out at the door, and poor Lily followed; and every
+now and then a white feather fell, and showed her the way she was to
+journey. Thus she went roving on through the wide world, and looked
+neither to the right hand nor to the left, nor took any rest, for seven
+years. Then she began to be glad, and thought to herself that the time
+was fast coming when all her troubles should end; yet repose was still
+far off, for one day as she was travelling on she missed the white
+feather, and when she lifted up her eyes she could nowhere see the dove.
+‘Now,’ thought she to herself, ‘no aid of man can be of use to me.’ So
+she went to the sun and said, ‘Thou shinest everywhere, on the hill’s
+top and the valley’s depth--hast thou anywhere seen my white dove?’
+‘No,’ said the sun, ‘I have not seen it; but I will give thee a
+casket--open it when thy hour of need comes.’
+
+So she thanked the sun, and went on her way till eventide; and when
+the moon arose, she cried unto it, and said, ‘Thou shinest through the
+night, over field and grove--hast thou nowhere seen my white dove?’
+‘No,’ said the moon, ‘I cannot help thee but I will give thee an
+egg--break it when need comes.’
+
+Then she thanked the moon, and went on till the night-wind blew; and she
+raised up her voice to it, and said, ‘Thou blowest through every tree
+and under every leaf--hast thou not seen my white dove?’ ‘No,’ said the
+night-wind, ‘but I will ask three other winds; perhaps they have seen
+it.’ Then the east wind and the west wind came, and said they too had
+not seen it, but the south wind said, ‘I have seen the white dove--he
+has fled to the Red Sea, and is changed once more into a lion, for the
+seven years are passed away, and there he is fighting with a dragon;
+and the dragon is an enchanted princess, who seeks to separate him from
+you.’ Then the night-wind said, ‘I will give thee counsel. Go to the
+Red Sea; on the right shore stand many rods--count them, and when thou
+comest to the eleventh, break it off, and smite the dragon with it; and
+so the lion will have the victory, and both of them will appear to you
+in their own forms. Then look round and thou wilt see a griffin, winged
+like bird, sitting by the Red Sea; jump on to his back with thy beloved
+one as quickly as possible, and he will carry you over the waters to
+your home. I will also give thee this nut,’ continued the night-wind.
+‘When you are half-way over, throw it down, and out of the waters will
+immediately spring up a high nut-tree on which the griffin will be able
+to rest, otherwise he would not have the strength to bear you the whole
+way; if, therefore, thou dost forget to throw down the nut, he will let
+you both fall into the sea.’
+
+So our poor wanderer went forth, and found all as the night-wind had
+said; and she plucked the eleventh rod, and smote the dragon, and the
+lion forthwith became a prince, and the dragon a princess again. But
+no sooner was the princess released from the spell, than she seized
+the prince by the arm and sprang on to the griffin’s back, and went off
+carrying the prince away with her.
+
+Thus the unhappy traveller was again forsaken and forlorn; but she
+took heart and said, ‘As far as the wind blows, and so long as the cock
+crows, I will journey on, till I find him once again.’ She went on for
+a long, long way, till at length she came to the castle whither the
+princess had carried the prince; and there was a feast got ready, and
+she heard that the wedding was about to be held. ‘Heaven aid me now!’
+said she; and she took the casket that the sun had given her, and found
+that within it lay a dress as dazzling as the sun itself. So she put it
+on, and went into the palace, and all the people gazed upon her; and
+the dress pleased the bride so much that she asked whether it was to be
+sold. ‘Not for gold and silver.’ said she, ‘but for flesh and blood.’
+The princess asked what she meant, and she said, ‘Let me speak with the
+bridegroom this night in his chamber, and I will give thee the dress.’
+At last the princess agreed, but she told her chamberlain to give the
+prince a sleeping draught, that he might not hear or see her. When
+evening came, and the prince had fallen asleep, she was led into
+his chamber, and she sat herself down at his feet, and said: ‘I have
+followed thee seven years. I have been to the sun, the moon, and the
+night-wind, to seek thee, and at last I have helped thee to overcome
+the dragon. Wilt thou then forget me quite?’ But the prince all the time
+slept so soundly, that her voice only passed over him, and seemed like
+the whistling of the wind among the fir-trees.
+
+Then poor Lily was led away, and forced to give up the golden dress; and
+when she saw that there was no help for her, she went out into a meadow,
+and sat herself down and wept. But as she sat she bethought herself of
+the egg that the moon had given her; and when she broke it, there ran
+out a hen and twelve chickens of pure gold, that played about, and then
+nestled under the old one’s wings, so as to form the most beautiful
+sight in the world. And she rose up and drove them before her, till the
+bride saw them from her window, and was so pleased that she came forth
+and asked her if she would sell the brood. ‘Not for gold or silver, but
+for flesh and blood: let me again this evening speak with the bridegroom
+in his chamber, and I will give thee the whole brood.’
+
+Then the princess thought to betray her as before, and agreed to
+what she asked: but when the prince went to his chamber he asked
+the chamberlain why the wind had whistled so in the night. And the
+chamberlain told him all--how he had given him a sleeping draught, and
+how a poor maiden had come and spoken to him in his chamber, and was
+to come again that night. Then the prince took care to throw away the
+sleeping draught; and when Lily came and began again to tell him what
+woes had befallen her, and how faithful and true to him she had been,
+he knew his beloved wife’s voice, and sprang up, and said, ‘You have
+awakened me as from a dream, for the strange princess had thrown a spell
+around me, so that I had altogether forgotten you; but Heaven hath sent
+you to me in a lucky hour.’
+
+And they stole away out of the palace by night unawares, and seated
+themselves on the griffin, who flew back with them over the Red Sea.
+When they were half-way across Lily let the nut fall into the water,
+and immediately a large nut-tree arose from the sea, whereon the griffin
+rested for a while, and then carried them safely home. There they found
+their child, now grown up to be comely and fair; and after all their
+troubles they lived happily together to the end of their days.
+
+
+
+
+THE FOX AND THE HORSE
+
+A farmer had a horse that had been an excellent faithful servant to
+him: but he was now grown too old to work; so the farmer would give him
+nothing more to eat, and said, ‘I want you no longer, so take yourself
+off out of my stable; I shall not take you back again until you are
+stronger than a lion.’ Then he opened the door and turned him adrift.
+
+The poor horse was very melancholy, and wandered up and down in the
+wood, seeking some little shelter from the cold wind and rain. Presently
+a fox met him: ‘What’s the matter, my friend?’ said he, ‘why do you hang
+down your head and look so lonely and woe-begone?’ ‘Ah!’ replied the
+horse, ‘justice and avarice never dwell in one house; my master has
+forgotten all that I have done for him so many years, and because I
+can no longer work he has turned me adrift, and says unless I become
+stronger than a lion he will not take me back again; what chance can I
+have of that? he knows I have none, or he would not talk so.’
+
+However, the fox bid him be of good cheer, and said, ‘I will help you;
+lie down there, stretch yourself out quite stiff, and pretend to be
+dead.’ The horse did as he was told, and the fox went straight to the
+lion who lived in a cave close by, and said to him, ‘A little way off
+lies a dead horse; come with me and you may make an excellent meal of
+his carcase.’ The lion was greatly pleased, and set off immediately; and
+when they came to the horse, the fox said, ‘You will not be able to eat
+him comfortably here; I’ll tell you what--I will tie you fast to
+his tail, and then you can draw him to your den, and eat him at your
+leisure.’
+
+This advice pleased the lion, so he laid himself down quietly for the
+fox to make him fast to the horse. But the fox managed to tie his legs
+together and bound all so hard and fast that with all his strength he
+could not set himself free. When the work was done, the fox clapped the
+horse on the shoulder, and said, ‘Jip! Dobbin! Jip!’ Then up he sprang,
+and moved off, dragging the lion behind him. The beast began to roar
+and bellow, till all the birds of the wood flew away for fright; but the
+horse let him sing on, and made his way quietly over the fields to his
+master’s house.
+
+‘Here he is, master,’ said he, ‘I have got the better of him’: and when
+the farmer saw his old servant, his heart relented, and he said. ‘Thou
+shalt stay in thy stable and be well taken care of.’ And so the poor old
+horse had plenty to eat, and lived--till he died.
+
+
+
+
+THE BLUE LIGHT
+
+There was once upon a time a soldier who for many years had served the
+king faithfully, but when the war came to an end could serve no longer
+because of the many wounds which he had received. The king said to him:
+‘You may return to your home, I need you no longer, and you will not
+receive any more money, for he only receives wages who renders me
+service for them.’ Then the soldier did not know how to earn a living,
+went away greatly troubled, and walked the whole day, until in the
+evening he entered a forest. When darkness came on, he saw a light,
+which he went up to, and came to a house wherein lived a witch. ‘Do give
+me one night’s lodging, and a little to eat and drink,’ said he to
+her, ‘or I shall starve.’ ‘Oho!’ she answered, ‘who gives anything to a
+run-away soldier? Yet will I be compassionate, and take you in, if you
+will do what I wish.’ ‘What do you wish?’ said the soldier. ‘That you
+should dig all round my garden for me, tomorrow.’ The soldier consented,
+and next day laboured with all his strength, but could not finish it by
+the evening. ‘I see well enough,’ said the witch, ‘that you can do no
+more today, but I will keep you yet another night, in payment for
+which you must tomorrow chop me a load of wood, and chop it small.’ The
+soldier spent the whole day in doing it, and in the evening the witch
+proposed that he should stay one night more. ‘Tomorrow, you shall only
+do me a very trifling piece of work. Behind my house, there is an old
+dry well, into which my light has fallen, it burns blue, and never goes
+out, and you shall bring it up again.’ Next day the old woman took him
+to the well, and let him down in a basket. He found the blue light, and
+made her a signal to draw him up again. She did draw him up, but when he
+came near the edge, she stretched down her hand and wanted to take the
+blue light away from him. ‘No,’ said he, perceiving her evil intention,
+‘I will not give you the light until I am standing with both feet upon
+the ground.’ The witch fell into a passion, let him fall again into the
+well, and went away.
+
+The poor soldier fell without injury on the moist ground, and the blue
+light went on burning, but of what use was that to him? He saw very well
+that he could not escape death. He sat for a while very sorrowfully,
+then suddenly he felt in his pocket and found his tobacco pipe, which
+was still half full. ‘This shall be my last pleasure,’ thought he,
+pulled it out, lit it at the blue light and began to smoke. When the
+smoke had circled about the cavern, suddenly a little black dwarf stood
+before him, and said: ‘Lord, what are your commands?’ ‘What my commands
+are?’ replied the soldier, quite astonished. ‘I must do everything you
+bid me,’ said the little man. ‘Good,’ said the soldier; ‘then in the
+first place help me out of this well.’ The little man took him by the
+hand, and led him through an underground passage, but he did not forget
+to take the blue light with him. On the way the dwarf showed him the
+treasures which the witch had collected and hidden there, and the
+soldier took as much gold as he could carry. When he was above, he said
+to the little man: ‘Now go and bind the old witch, and carry her before
+the judge.’ In a short time she came by like the wind, riding on a wild
+tom-cat and screaming frightfully. Nor was it long before the little man
+reappeared. ‘It is all done,’ said he, ‘and the witch is already hanging
+on the gallows. What further commands has my lord?’ inquired the dwarf.
+‘At this moment, none,’ answered the soldier; ‘you can return home, only
+be at hand immediately, if I summon you.’ ‘Nothing more is needed than
+that you should light your pipe at the blue light, and I will appear
+before you at once.’ Thereupon he vanished from his sight.
+
+The soldier returned to the town from which he came. He went to the
+best inn, ordered himself handsome clothes, and then bade the landlord
+furnish him a room as handsome as possible. When it was ready and the
+soldier had taken possession of it, he summoned the little black manikin
+and said: ‘I have served the king faithfully, but he has dismissed me,
+and left me to hunger, and now I want to take my revenge.’ ‘What am I to
+do?’ asked the little man. ‘Late at night, when the king’s daughter is
+in bed, bring her here in her sleep, she shall do servant’s work for
+me.’ The manikin said: ‘That is an easy thing for me to do, but a very
+dangerous thing for you, for if it is discovered, you will fare ill.’
+When twelve o’clock had struck, the door sprang open, and the manikin
+carried in the princess. ‘Aha! are you there?’ cried the soldier, ‘get
+to your work at once! Fetch the broom and sweep the chamber.’ When
+she had done this, he ordered her to come to his chair, and then he
+stretched out his feet and said: ‘Pull off my boots,’ and then he
+threw them in her face, and made her pick them up again, and clean
+and brighten them. She, however, did everything he bade her, without
+opposition, silently and with half-shut eyes. When the first cock
+crowed, the manikin carried her back to the royal palace, and laid her
+in her bed.
+
+Next morning when the princess arose she went to her father, and told
+him that she had had a very strange dream. ‘I was carried through the
+streets with the rapidity of lightning,’ said she, ‘and taken into a
+soldier’s room, and I had to wait upon him like a servant, sweep his
+room, clean his boots, and do all kinds of menial work. It was only a
+dream, and yet I am just as tired as if I really had done everything.’
+‘The dream may have been true,’ said the king. ‘I will give you a piece
+of advice. Fill your pocket full of peas, and make a small hole in the
+pocket, and then if you are carried away again, they will fall out and
+leave a track in the streets.’ But unseen by the king, the manikin was
+standing beside him when he said that, and heard all. At night when
+the sleeping princess was again carried through the streets, some peas
+certainly did fall out of her pocket, but they made no track, for the
+crafty manikin had just before scattered peas in every street there
+was. And again the princess was compelled to do servant’s work until
+cock-crow.
+
+Next morning the king sent his people out to seek the track, but it was
+all in vain, for in every street poor children were sitting, picking up
+peas, and saying: ‘It must have rained peas, last night.’ ‘We must think
+of something else,’ said the king; ‘keep your shoes on when you go to
+bed, and before you come back from the place where you are taken, hide
+one of them there, I will soon contrive to find it.’ The black manikin
+heard this plot, and at night when the soldier again ordered him to
+bring the princess, revealed it to him, and told him that he knew of no
+expedient to counteract this stratagem, and that if the shoe were found
+in the soldier’s house it would go badly with him. ‘Do what I bid you,’
+replied the soldier, and again this third night the princess was obliged
+to work like a servant, but before she went away, she hid her shoe under
+the bed.
+
+Next morning the king had the entire town searched for his daughter’s
+shoe. It was found at the soldier’s, and the soldier himself, who at the
+entreaty of the dwarf had gone outside the gate, was soon brought back,
+and thrown into prison. In his flight he had forgotten the most valuable
+things he had, the blue light and the gold, and had only one ducat in
+his pocket. And now loaded with chains, he was standing at the window of
+his dungeon, when he chanced to see one of his comrades passing by. The
+soldier tapped at the pane of glass, and when this man came up, said to
+him: ‘Be so kind as to fetch me the small bundle I have left lying in
+the inn, and I will give you a ducat for doing it.’ His comrade ran
+thither and brought him what he wanted. As soon as the soldier was alone
+again, he lighted his pipe and summoned the black manikin. ‘Have no
+fear,’ said the latter to his master. ‘Go wheresoever they take you, and
+let them do what they will, only take the blue light with you.’ Next day
+the soldier was tried, and though he had done nothing wicked, the judge
+condemned him to death. When he was led forth to die, he begged a last
+favour of the king. ‘What is it?’ asked the king. ‘That I may smoke one
+more pipe on my way.’ ‘You may smoke three,’ answered the king, ‘but do
+not imagine that I will spare your life.’ Then the soldier pulled out
+his pipe and lighted it at the blue light, and as soon as a few wreaths
+of smoke had ascended, the manikin was there with a small cudgel in his
+hand, and said: ‘What does my lord command?’ ‘Strike down to earth that
+false judge there, and his constable, and spare not the king who has
+treated me so ill.’ Then the manikin fell on them like lightning,
+darting this way and that way, and whosoever was so much as touched by
+his cudgel fell to earth, and did not venture to stir again. The king
+was terrified; he threw himself on the soldier’s mercy, and merely to
+be allowed to live at all, gave him his kingdom for his own, and his
+daughter to wife.
+
+
+
+
+THE RAVEN
+
+There was once a queen who had a little daughter, still too young to run
+alone. One day the child was very troublesome, and the mother could not
+quiet it, do what she would. She grew impatient, and seeing the ravens
+flying round the castle, she opened the window, and said: ‘I wish you
+were a raven and would fly away, then I should have a little peace.’
+Scarcely were the words out of her mouth, when the child in her arms was
+turned into a raven, and flew away from her through the open window. The
+bird took its flight to a dark wood and remained there for a long time,
+and meanwhile the parents could hear nothing of their child.
+
+Long after this, a man was making his way through the wood when he heard
+a raven calling, and he followed the sound of the voice. As he drew
+near, the raven said, ‘I am by birth a king’s daughter, but am now under
+the spell of some enchantment; you can, however, set me free.’ ‘What
+am I to do?’ he asked. She replied, ‘Go farther into the wood until you
+come to a house, wherein lives an old woman; she will offer you food and
+drink, but you must not take of either; if you do, you will fall into
+a deep sleep, and will not be able to help me. In the garden behind the
+house is a large tan-heap, and on that you must stand and watch for me.
+I shall drive there in my carriage at two o’clock in the afternoon for
+three successive days; the first day it will be drawn by four white, the
+second by four chestnut, and the last by four black horses; but if you
+fail to keep awake and I find you sleeping, I shall not be set free.’
+
+The man promised to do all that she wished, but the raven said, ‘Alas! I
+know even now that you will take something from the woman and be unable
+to save me.’ The man assured her again that he would on no account touch
+a thing to eat or drink.
+
+When he came to the house and went inside, the old woman met him, and
+said, ‘Poor man! how tired you are! Come in and rest and let me give you
+something to eat and drink.’
+
+‘No,’ answered the man, ‘I will neither eat not drink.’
+
+But she would not leave him alone, and urged him saying, ‘If you will
+not eat anything, at least you might take a draught of wine; one drink
+counts for nothing,’ and at last he allowed himself to be persuaded, and
+drank.
+
+As it drew towards the appointed hour, he went outside into the garden
+and mounted the tan-heap to await the raven. Suddenly a feeling of
+fatigue came over him, and unable to resist it, he lay down for a little
+while, fully determined, however, to keep awake; but in another minute
+his eyes closed of their own accord, and he fell into such a deep sleep,
+that all the noises in the world would not have awakened him. At two
+o’clock the raven came driving along, drawn by her four white horses;
+but even before she reached the spot, she said to herself, sighing, ‘I
+know he has fallen asleep.’ When she entered the garden, there she found
+him as she had feared, lying on the tan-heap, fast asleep. She got out
+of her carriage and went to him; she called him and shook him, but it
+was all in vain, he still continued sleeping.
+
+The next day at noon, the old woman came to him again with food and
+drink which he at first refused. At last, overcome by her persistent
+entreaties that he would take something, he lifted the glass and drank
+again.
+
+Towards two o’clock he went into the garden and on to the tan-heap to
+watch for the raven. He had not been there long before he began to feel
+so tired that his limbs seemed hardly able to support him, and he could
+not stand upright any longer; so again he lay down and fell fast asleep.
+As the raven drove along her four chestnut horses, she said sorrowfully
+to herself, ‘I know he has fallen asleep.’ She went as before to look
+for him, but he slept, and it was impossible to awaken him.
+
+The following day the old woman said to him, ‘What is this? You are not
+eating or drinking anything, do you want to kill yourself?’
+
+He answered, ‘I may not and will not either eat or drink.’
+
+But she put down the dish of food and the glass of wine in front of him,
+and when he smelt the wine, he was unable to resist the temptation, and
+took a deep draught.
+
+When the hour came round again he went as usual on to the tan-heap in
+the garden to await the king’s daughter, but he felt even more overcome
+with weariness than on the two previous days, and throwing himself down,
+he slept like a log. At two o’clock the raven could be seen approaching,
+and this time her coachman and everything about her, as well as her
+horses, were black.
+
+She was sadder than ever as she drove along, and said mournfully, ‘I
+know he has fallen asleep, and will not be able to set me free.’ She
+found him sleeping heavily, and all her efforts to awaken him were of no
+avail. Then she placed beside him a loaf, and some meat, and a flask
+of wine, of such a kind, that however much he took of them, they would
+never grow less. After that she drew a gold ring, on which her name was
+engraved, off her finger, and put it upon one of his. Finally, she laid
+a letter near him, in which, after giving him particulars of the food
+and drink she had left for him, she finished with the following words:
+‘I see that as long as you remain here you will never be able to set me
+free; if, however, you still wish to do so, come to the golden castle
+of Stromberg; this is well within your power to accomplish.’ She then
+returned to her carriage and drove to the golden castle of Stromberg.
+
+When the man awoke and found that he had been sleeping, he was grieved
+at heart, and said, ‘She has no doubt been here and driven away again,
+and it is now too late for me to save her.’ Then his eyes fell on the
+things which were lying beside him; he read the letter, and knew from it
+all that had happened. He rose up without delay, eager to start on his
+way and to reach the castle of Stromberg, but he had no idea in which
+direction he ought to go. He travelled about a long time in search of it
+and came at last to a dark forest, through which he went on walking for
+fourteen days and still could not find a way out. Once more the night
+came on, and worn out he lay down under a bush and fell asleep. Again
+the next day he pursued his way through the forest, and that evening,
+thinking to rest again, he lay down as before, but he heard such a
+howling and wailing that he found it impossible to sleep. He waited till
+it was darker and people had begun to light up their houses, and then
+seeing a little glimmer ahead of him, he went towards it.
+
+He found that the light came from a house which looked smaller than
+it really was, from the contrast of its height with that of an immense
+giant who stood in front of it. He thought to himself, ‘If the giant
+sees me going in, my life will not be worth much.’ However, after a
+while he summoned up courage and went forward. When the giant saw him,
+he called out, ‘It is lucky for that you have come, for I have not had
+anything to eat for a long time. I can have you now for my supper.’ ‘I
+would rather you let that alone,’ said the man, ‘for I do not willingly
+give myself up to be eaten; if you are wanting food I have enough to
+satisfy your hunger.’ ‘If that is so,’ replied the giant, ‘I will leave
+you in peace; I only thought of eating you because I had nothing else.’
+
+So they went indoors together and sat down, and the man brought out the
+bread, meat, and wine, which although he had eaten and drunk of them,
+were still unconsumed. The giant was pleased with the good cheer, and
+ate and drank to his heart’s content. When he had finished his supper
+the man asked him if he could direct him to the castle of Stromberg.
+The giant said, ‘I will look on my map; on it are marked all the towns,
+villages, and houses.’ So he fetched his map, and looked for the castle,
+but could not find it. ‘Never mind,’ he said, ‘I have larger maps
+upstairs in the cupboard, we will look on those,’ but they searched in
+vain, for the castle was not marked even on these. The man now thought
+he should like to continue his journey, but the giant begged him to
+remain for a day or two longer until the return of his brother, who was
+away in search of provisions. When the brother came home, they asked him
+about the castle of Stromberg, and he told them he would look on his own
+maps as soon as he had eaten and appeased his hunger. Accordingly, when
+he had finished his supper, they all went up together to his room and
+looked through his maps, but the castle was not to be found. Then he
+fetched other older maps, and they went on looking for the castle until
+at last they found it, but it was many thousand miles away. ‘How shall I
+be able to get there?’ asked the man. ‘I have two hours to spare,’ said
+the giant, ‘and I will carry you into the neighbourhood of the castle; I
+must then return to look after the child who is in our care.’
+
+The giant, thereupon, carried the man to within about a hundred leagues
+of the castle, where he left him, saying, ‘You will be able to walk the
+remainder of the way yourself.’ The man journeyed on day and night
+till he reached the golden castle of Stromberg. He found it situated,
+however, on a glass mountain, and looking up from the foot he saw the
+enchanted maiden drive round her castle and then go inside. He was
+overjoyed to see her, and longed to get to the top of the mountain, but
+the sides were so slippery that every time he attempted to climb he
+fell back again. When he saw that it was impossible to reach her, he was
+greatly grieved, and said to himself, ‘I will remain here and wait for
+her,’ so he built himself a little hut, and there he sat and watched for
+a whole year, and every day he saw the king’s daughter driving round her
+castle, but still was unable to get nearer to her.
+
+Looking out from his hut one day he saw three robbers fighting and he
+called out to them, ‘God be with you.’ They stopped when they heard the
+call, but looking round and seeing nobody, they went on again with their
+fighting, which now became more furious. ‘God be with you,’ he cried
+again, and again they paused and looked about, but seeing no one went
+back to their fighting. A third time he called out, ‘God be with you,’
+and then thinking he should like to know the cause of dispute between
+the three men, he went out and asked them why they were fighting so
+angrily with one another. One of them said that he had found a stick,
+and that he had but to strike it against any door through which he
+wished to pass, and it immediately flew open. Another told him that he
+had found a cloak which rendered its wearer invisible; and the third had
+caught a horse which would carry its rider over any obstacle, and even
+up the glass mountain. They had been unable to decide whether they
+would keep together and have the things in common, or whether they would
+separate. On hearing this, the man said, ‘I will give you something in
+exchange for those three things; not money, for that I have not got,
+but something that is of far more value. I must first, however, prove
+whether all you have told me about your three things is true.’ The
+robbers, therefore, made him get on the horse, and handed him the stick
+and the cloak, and when he had put this round him he was no longer
+visible. Then he fell upon them with the stick and beat them one after
+another, crying, ‘There, you idle vagabonds, you have got what you
+deserve; are you satisfied now!’
+
+After this he rode up the glass mountain. When he reached the gate of
+the castle, he found it closed, but he gave it a blow with his stick,
+and it flew wide open at once and he passed through. He mounted the
+steps and entered the room where the maiden was sitting, with a golden
+goblet full of wine in front of her. She could not see him for he still
+wore his cloak. He took the ring which she had given him off his finger,
+and threw it into the goblet, so that it rang as it touched the bottom.
+‘That is my own ring,’ she exclaimed, ‘and if that is so the man must
+also be here who is coming to set me free.’
+
+She sought for him about the castle, but could find him nowhere.
+Meanwhile he had gone outside again and mounted his horse and thrown off
+the cloak. When therefore she came to the castle gate she saw him, and
+cried aloud for joy. Then he dismounted and took her in his arms; and
+she kissed him, and said, ‘Now you have indeed set me free, and tomorrow
+we will celebrate our marriage.’
+
+
+
+
+THE GOLDEN GOOSE
+
+There was a man who had three sons, the youngest of whom was called
+Dummling,[*] and was despised, mocked, and sneered at on every occasion.
+
+It happened that the eldest wanted to go into the forest to hew wood,
+and before he went his mother gave him a beautiful sweet cake and a
+bottle of wine in order that he might not suffer from hunger or thirst.
+
+When he entered the forest he met a little grey-haired old man who bade
+him good day, and said: ‘Do give me a piece of cake out of your pocket,
+and let me have a draught of your wine; I am so hungry and thirsty.’ But
+the clever son answered: ‘If I give you my cake and wine, I shall have
+none for myself; be off with you,’ and he left the little man standing
+and went on.
+
+But when he began to hew down a tree, it was not long before he made a
+false stroke, and the axe cut him in the arm, so that he had to go home
+and have it bound up. And this was the little grey man’s doing.
+
+After this the second son went into the forest, and his mother gave him,
+like the eldest, a cake and a bottle of wine. The little old grey man
+met him likewise, and asked him for a piece of cake and a drink of wine.
+But the second son, too, said sensibly enough: ‘What I give you will be
+taken away from myself; be off!’ and he left the little man standing and
+went on. His punishment, however, was not delayed; when he had made a
+few blows at the tree he struck himself in the leg, so that he had to be
+carried home.
+
+Then Dummling said: ‘Father, do let me go and cut wood.’ The father
+answered: ‘Your brothers have hurt themselves with it, leave it alone,
+you do not understand anything about it.’ But Dummling begged so long
+that at last he said: ‘Just go then, you will get wiser by hurting
+yourself.’ His mother gave him a cake made with water and baked in the
+cinders, and with it a bottle of sour beer.
+
+When he came to the forest the little old grey man met him likewise,
+and greeting him, said: ‘Give me a piece of your cake and a drink out
+of your bottle; I am so hungry and thirsty.’ Dummling answered: ‘I have
+only cinder-cake and sour beer; if that pleases you, we will sit
+down and eat.’ So they sat down, and when Dummling pulled out his
+cinder-cake, it was a fine sweet cake, and the sour beer had become good
+wine. So they ate and drank, and after that the little man said: ‘Since
+you have a good heart, and are willing to divide what you have, I will
+give you good luck. There stands an old tree, cut it down, and you will
+find something at the roots.’ Then the little man took leave of him.
+
+Dummling went and cut down the tree, and when it fell there was a goose
+sitting in the roots with feathers of pure gold. He lifted her up, and
+taking her with him, went to an inn where he thought he would stay the
+night. Now the host had three daughters, who saw the goose and were
+curious to know what such a wonderful bird might be, and would have
+liked to have one of its golden feathers.
+
+The eldest thought: ‘I shall soon find an opportunity of pulling out a
+feather,’ and as soon as Dummling had gone out she seized the goose by
+the wing, but her finger and hand remained sticking fast to it.
+
+The second came soon afterwards, thinking only of how she might get a
+feather for herself, but she had scarcely touched her sister than she
+was held fast.
+
+At last the third also came with the like intent, and the others
+screamed out: ‘Keep away; for goodness’ sake keep away!’ But she did
+not understand why she was to keep away. ‘The others are there,’ she
+thought, ‘I may as well be there too,’ and ran to them; but as soon as
+she had touched her sister, she remained sticking fast to her. So they
+had to spend the night with the goose.
+
+The next morning Dummling took the goose under his arm and set out,
+without troubling himself about the three girls who were hanging on to
+it. They were obliged to run after him continually, now left, now right,
+wherever his legs took him.
+
+In the middle of the fields the parson met them, and when he saw the
+procession he said: ‘For shame, you good-for-nothing girls, why are you
+running across the fields after this young man? Is that seemly?’ At the
+same time he seized the youngest by the hand in order to pull her away,
+but as soon as he touched her he likewise stuck fast, and was himself
+obliged to run behind.
+
+Before long the sexton came by and saw his master, the parson, running
+behind three girls. He was astonished at this and called out: ‘Hi!
+your reverence, whither away so quickly? Do not forget that we have a
+christening today!’ and running after him he took him by the sleeve, but
+was also held fast to it.
+
+Whilst the five were trotting thus one behind the other, two labourers
+came with their hoes from the fields; the parson called out to them
+and begged that they would set him and the sexton free. But they had
+scarcely touched the sexton when they were held fast, and now there were
+seven of them running behind Dummling and the goose.
+
+Soon afterwards he came to a city, where a king ruled who had a daughter
+who was so serious that no one could make her laugh. So he had put forth
+a decree that whosoever should be able to make her laugh should marry
+her. When Dummling heard this, he went with his goose and all her train
+before the king’s daughter, and as soon as she saw the seven people
+running on and on, one behind the other, she began to laugh quite
+loudly, and as if she would never stop. Thereupon Dummling asked to have
+her for his wife; but the king did not like the son-in-law, and made all
+manner of excuses and said he must first produce a man who could drink
+a cellarful of wine. Dummling thought of the little grey man, who could
+certainly help him; so he went into the forest, and in the same place
+where he had felled the tree, he saw a man sitting, who had a very
+sorrowful face. Dummling asked him what he was taking to heart so
+sorely, and he answered: ‘I have such a great thirst and cannot quench
+it; cold water I cannot stand, a barrel of wine I have just emptied, but
+that to me is like a drop on a hot stone!’
+
+‘There, I can help you,’ said Dummling, ‘just come with me and you shall
+be satisfied.’
+
+He led him into the king’s cellar, and the man bent over the huge
+barrels, and drank and drank till his loins hurt, and before the day was
+out he had emptied all the barrels. Then Dummling asked once more
+for his bride, but the king was vexed that such an ugly fellow, whom
+everyone called Dummling, should take away his daughter, and he made a
+new condition; he must first find a man who could eat a whole mountain
+of bread. Dummling did not think long, but went straight into the
+forest, where in the same place there sat a man who was tying up his
+body with a strap, and making an awful face, and saying: ‘I have eaten a
+whole ovenful of rolls, but what good is that when one has such a hunger
+as I? My stomach remains empty, and I must tie myself up if I am not to
+die of hunger.’
+
+At this Dummling was glad, and said: ‘Get up and come with me; you shall
+eat yourself full.’ He led him to the king’s palace where all the
+flour in the whole Kingdom was collected, and from it he caused a huge
+mountain of bread to be baked. The man from the forest stood before it,
+began to eat, and by the end of one day the whole mountain had vanished.
+Then Dummling for the third time asked for his bride; but the king again
+sought a way out, and ordered a ship which could sail on land and on
+water. ‘As soon as you come sailing back in it,’ said he, ‘you shall
+have my daughter for wife.’
+
+Dummling went straight into the forest, and there sat the little grey
+man to whom he had given his cake. When he heard what Dummling wanted,
+he said: ‘Since you have given me to eat and to drink, I will give you
+the ship; and I do all this because you once were kind to me.’ Then he
+gave him the ship which could sail on land and water, and when the king
+saw that, he could no longer prevent him from having his daughter. The
+wedding was celebrated, and after the king’s death, Dummling inherited
+his kingdom and lived for a long time contentedly with his wife.
+
+     [*] Simpleton
+
+
+
+
+THE WATER OF LIFE
+
+Long before you or I were born, there reigned, in a country a great way
+off, a king who had three sons. This king once fell very ill--so ill
+that nobody thought he could live. His sons were very much grieved
+at their father’s sickness; and as they were walking together very
+mournfully in the garden of the palace, a little old man met them and
+asked what was the matter. They told him that their father was very ill,
+and that they were afraid nothing could save him. ‘I know what would,’
+said the little old man; ‘it is the Water of Life. If he could have a
+draught of it he would be well again; but it is very hard to get.’ Then
+the eldest son said, ‘I will soon find it’: and he went to the sick
+king, and begged that he might go in search of the Water of Life, as
+it was the only thing that could save him. ‘No,’ said the king. ‘I had
+rather die than place you in such great danger as you must meet with in
+your journey.’ But he begged so hard that the king let him go; and the
+prince thought to himself, ‘If I bring my father this water, he will
+make me sole heir to his kingdom.’
+
+Then he set out: and when he had gone on his way some time he came to a
+deep valley, overhung with rocks and woods; and as he looked around, he
+saw standing above him on one of the rocks a little ugly dwarf, with a
+sugarloaf cap and a scarlet cloak; and the dwarf called to him and said,
+‘Prince, whither so fast?’ ‘What is that to thee, you ugly imp?’ said
+the prince haughtily, and rode on.
+
+But the dwarf was enraged at his behaviour, and laid a fairy spell
+of ill-luck upon him; so that as he rode on the mountain pass became
+narrower and narrower, and at last the way was so straitened that he
+could not go to step forward: and when he thought to have turned his
+horse round and go back the way he came, he heard a loud laugh ringing
+round him, and found that the path was closed behind him, so that he was
+shut in all round. He next tried to get off his horse and make his way
+on foot, but again the laugh rang in his ears, and he found himself
+unable to move a step, and thus he was forced to abide spellbound.
+
+Meantime the old king was lingering on in daily hope of his son’s
+return, till at last the second son said, ‘Father, I will go in search
+of the Water of Life.’ For he thought to himself, ‘My brother is surely
+dead, and the kingdom will fall to me if I find the water.’ The king was
+at first very unwilling to let him go, but at last yielded to his wish.
+So he set out and followed the same road which his brother had done,
+and met with the same elf, who stopped him at the same spot in the
+mountains, saying, as before, ‘Prince, prince, whither so fast?’ ‘Mind
+your own affairs, busybody!’ said the prince scornfully, and rode on.
+
+But the dwarf put the same spell upon him as he put on his elder
+brother, and he, too, was at last obliged to take up his abode in the
+heart of the mountains. Thus it is with proud silly people, who think
+themselves above everyone else, and are too proud to ask or take advice.
+
+When the second prince had thus been gone a long time, the youngest son
+said he would go and search for the Water of Life, and trusted he should
+soon be able to make his father well again. So he set out, and the dwarf
+met him too at the same spot in the valley, among the mountains, and
+said, ‘Prince, whither so fast?’ And the prince said, ‘I am going in
+search of the Water of Life, because my father is ill, and like to die:
+can you help me? Pray be kind, and aid me if you can!’ ‘Do you know
+where it is to be found?’ asked the dwarf. ‘No,’ said the prince, ‘I do
+not. Pray tell me if you know.’ ‘Then as you have spoken to me kindly,
+and are wise enough to seek for advice, I will tell you how and where to
+go. The water you seek springs from a well in an enchanted castle; and,
+that you may be able to reach it in safety, I will give you an iron wand
+and two little loaves of bread; strike the iron door of the castle three
+times with the wand, and it will open: two hungry lions will be lying
+down inside gaping for their prey, but if you throw them the bread they
+will let you pass; then hasten on to the well, and take some of the
+Water of Life before the clock strikes twelve; for if you tarry longer
+the door will shut upon you for ever.’
+
+Then the prince thanked his little friend with the scarlet cloak for his
+friendly aid, and took the wand and the bread, and went travelling on
+and on, over sea and over land, till he came to his journey’s end, and
+found everything to be as the dwarf had told him. The door flew open at
+the third stroke of the wand, and when the lions were quieted he went on
+through the castle and came at length to a beautiful hall. Around it he
+saw several knights sitting in a trance; then he pulled off their rings
+and put them on his own fingers. In another room he saw on a table a
+sword and a loaf of bread, which he also took. Further on he came to a
+room where a beautiful young lady sat upon a couch; and she welcomed him
+joyfully, and said, if he would set her free from the spell that bound
+her, the kingdom should be his, if he would come back in a year and
+marry her. Then she told him that the well that held the Water of Life
+was in the palace gardens; and bade him make haste, and draw what he
+wanted before the clock struck twelve.
+
+He walked on; and as he walked through beautiful gardens he came to a
+delightful shady spot in which stood a couch; and he thought to himself,
+as he felt tired, that he would rest himself for a while, and gaze on
+the lovely scenes around him. So he laid himself down, and sleep
+fell upon him unawares, so that he did not wake up till the clock was
+striking a quarter to twelve. Then he sprang from the couch dreadfully
+frightened, ran to the well, filled a cup that was standing by him full
+of water, and hastened to get away in time. Just as he was going out of
+the iron door it struck twelve, and the door fell so quickly upon him
+that it snapped off a piece of his heel.
+
+When he found himself safe, he was overjoyed to think that he had got
+the Water of Life; and as he was going on his way homewards, he passed
+by the little dwarf, who, when he saw the sword and the loaf, said, ‘You
+have made a noble prize; with the sword you can at a blow slay whole
+armies, and the bread will never fail you.’ Then the prince thought
+to himself, ‘I cannot go home to my father without my brothers’; so he
+said, ‘My dear friend, cannot you tell me where my two brothers are, who
+set out in search of the Water of Life before me, and never came back?’
+‘I have shut them up by a charm between two mountains,’ said the dwarf,
+‘because they were proud and ill-behaved, and scorned to ask advice.’
+The prince begged so hard for his brothers, that the dwarf at last set
+them free, though unwillingly, saying, ‘Beware of them, for they have
+bad hearts.’ Their brother, however, was greatly rejoiced to see them,
+and told them all that had happened to him; how he had found the Water
+of Life, and had taken a cup full of it; and how he had set a beautiful
+princess free from a spell that bound her; and how she had engaged to
+wait a whole year, and then to marry him, and to give him the kingdom.
+
+Then they all three rode on together, and on their way home came to a
+country that was laid waste by war and a dreadful famine, so that it was
+feared all must die for want. But the prince gave the king of the land
+the bread, and all his kingdom ate of it. And he lent the king the
+wonderful sword, and he slew the enemy’s army with it; and thus the
+kingdom was once more in peace and plenty. In the same manner he
+befriended two other countries through which they passed on their way.
+
+When they came to the sea, they got into a ship and during their voyage
+the two eldest said to themselves, ‘Our brother has got the water which
+we could not find, therefore our father will forsake us and give him the
+kingdom, which is our right’; so they were full of envy and revenge, and
+agreed together how they could ruin him. Then they waited till he was
+fast asleep, and poured the Water of Life out of the cup, and took it
+for themselves, giving him bitter sea-water instead.
+
+When they came to their journey’s end, the youngest son brought his cup
+to the sick king, that he might drink and be healed. Scarcely, however,
+had he tasted the bitter sea-water when he became worse even than he was
+before; and then both the elder sons came in, and blamed the youngest
+for what they had done; and said that he wanted to poison their father,
+but that they had found the Water of Life, and had brought it with them.
+He no sooner began to drink of what they brought him, than he felt his
+sickness leave him, and was as strong and well as in his younger days.
+Then they went to their brother, and laughed at him, and said, ‘Well,
+brother, you found the Water of Life, did you? You have had the trouble
+and we shall have the reward. Pray, with all your cleverness, why did
+not you manage to keep your eyes open? Next year one of us will take
+away your beautiful princess, if you do not take care. You had better
+say nothing about this to our father, for he does not believe a word you
+say; and if you tell tales, you shall lose your life into the bargain:
+but be quiet, and we will let you off.’
+
+The old king was still very angry with his youngest son, and thought
+that he really meant to have taken away his life; so he called his court
+together, and asked what should be done, and all agreed that he ought to
+be put to death. The prince knew nothing of what was going on, till one
+day, when the king’s chief huntsmen went a-hunting with him, and they
+were alone in the wood together, the huntsman looked so sorrowful that
+the prince said, ‘My friend, what is the matter with you?’ ‘I cannot and
+dare not tell you,’ said he. But the prince begged very hard, and said,
+‘Only tell me what it is, and do not think I shall be angry, for I will
+forgive you.’ ‘Alas!’ said the huntsman; ‘the king has ordered me to
+shoot you.’ The prince started at this, and said, ‘Let me live, and I
+will change dresses with you; you shall take my royal coat to show to my
+father, and do you give me your shabby one.’ ‘With all my heart,’ said
+the huntsman; ‘I am sure I shall be glad to save you, for I could not
+have shot you.’ Then he took the prince’s coat, and gave him the shabby
+one, and went away through the wood.
+
+Some time after, three grand embassies came to the old king’s court,
+with rich gifts of gold and precious stones for his youngest son; now
+all these were sent from the three kings to whom he had lent his sword
+and loaf of bread, in order to rid them of their enemy and feed their
+people. This touched the old king’s heart, and he thought his son might
+still be guiltless, and said to his court, ‘O that my son were still
+alive! how it grieves me that I had him killed!’ ‘He is still alive,’
+said the huntsman; ‘and I am glad that I had pity on him, but let him
+go in peace, and brought home his royal coat.’ At this the king was
+overwhelmed with joy, and made it known throughout all his kingdom, that
+if his son would come back to his court he would forgive him.
+
+Meanwhile the princess was eagerly waiting till her deliverer should
+come back; and had a road made leading up to her palace all of shining
+gold; and told her courtiers that whoever came on horseback, and rode
+straight up to the gate upon it, was her true lover; and that they must
+let him in: but whoever rode on one side of it, they must be sure was
+not the right one; and that they must send him away at once.
+
+The time soon came, when the eldest brother thought that he would make
+haste to go to the princess, and say that he was the one who had set
+her free, and that he should have her for his wife, and the kingdom with
+her. As he came before the palace and saw the golden road, he stopped to
+look at it, and he thought to himself, ‘It is a pity to ride upon this
+beautiful road’; so he turned aside and rode on the right-hand side of
+it. But when he came to the gate, the guards, who had seen the road
+he took, said to him, he could not be what he said he was, and must go
+about his business.
+
+The second prince set out soon afterwards on the same errand; and when
+he came to the golden road, and his horse had set one foot upon it,
+he stopped to look at it, and thought it very beautiful, and said to
+himself, ‘What a pity it is that anything should tread here!’ Then he
+too turned aside and rode on the left side of it. But when he came to
+the gate the guards said he was not the true prince, and that he too
+must go away about his business; and away he went.
+
+Now when the full year was come round, the third brother left the forest
+in which he had lain hid for fear of his father’s anger, and set out in
+search of his betrothed bride. So he journeyed on, thinking of her all
+the way, and rode so quickly that he did not even see what the road was
+made of, but went with his horse straight over it; and as he came to the
+gate it flew open, and the princess welcomed him with joy, and said
+he was her deliverer, and should now be her husband and lord of the
+kingdom. When the first joy at their meeting was over, the princess told
+him she had heard of his father having forgiven him, and of his wish to
+have him home again: so, before his wedding with the princess, he went
+to visit his father, taking her with him. Then he told him everything;
+how his brothers had cheated and robbed him, and yet that he had borne
+all those wrongs for the love of his father. And the old king was very
+angry, and wanted to punish his wicked sons; but they made their escape,
+and got into a ship and sailed away over the wide sea, and where they
+went to nobody knew and nobody cared.
+
+And now the old king gathered together his court, and asked all his
+kingdom to come and celebrate the wedding of his son and the princess.
+And young and old, noble and squire, gentle and simple, came at once
+on the summons; and among the rest came the friendly dwarf, with the
+sugarloaf hat, and a new scarlet cloak.
+
+  And the wedding was held, and the merry bells run.
+  And all the good people they danced and they sung,
+  And feasted and frolick’d I can’t tell how long.
+
+
+
+
+THE TWELVE HUNTSMEN
+
+There was once a king’s son who had a bride whom he loved very much. And
+when he was sitting beside her and very happy, news came that his father
+lay sick unto death, and desired to see him once again before his end.
+Then he said to his beloved: ‘I must now go and leave you, I give you
+a ring as a remembrance of me. When I am king, I will return and fetch
+you.’ So he rode away, and when he reached his father, the latter was
+dangerously ill, and near his death. He said to him: ‘Dear son, I wished
+to see you once again before my end, promise me to marry as I wish,’ and
+he named a certain king’s daughter who was to be his wife. The son was
+in such trouble that he did not think what he was doing, and said: ‘Yes,
+dear father, your will shall be done,’ and thereupon the king shut his
+eyes, and died.
+
+When therefore the son had been proclaimed king, and the time of
+mourning was over, he was forced to keep the promise which he had given
+his father, and caused the king’s daughter to be asked in marriage, and
+she was promised to him. His first betrothed heard of this, and fretted
+so much about his faithfulness that she nearly died. Then her father
+said to her: ‘Dearest child, why are you so sad? You shall have
+whatsoever you will.’ She thought for a moment and said: ‘Dear father,
+I wish for eleven girls exactly like myself in face, figure, and size.’
+The father said: ‘If it be possible, your desire shall be fulfilled,’
+and he caused a search to be made in his whole kingdom, until eleven
+young maidens were found who exactly resembled his daughter in face,
+figure, and size.
+
+When they came to the king’s daughter, she had twelve suits of
+huntsmen’s clothes made, all alike, and the eleven maidens had to put
+on the huntsmen’s clothes, and she herself put on the twelfth suit.
+Thereupon she took her leave of her father, and rode away with them,
+and rode to the court of her former betrothed, whom she loved so dearly.
+Then she asked if he required any huntsmen, and if he would take all of
+them into his service. The king looked at her and did not know her, but
+as they were such handsome fellows, he said: ‘Yes,’ and that he would
+willingly take them, and now they were the king’s twelve huntsmen.
+
+The king, however, had a lion which was a wondrous animal, for he knew
+all concealed and secret things. It came to pass that one evening he
+said to the king: ‘You think you have twelve huntsmen?’ ‘Yes,’ said the
+king, ‘they are twelve huntsmen.’ The lion continued: ‘You are mistaken,
+they are twelve girls.’ The king said: ‘That cannot be true! How
+will you prove that to me?’ ‘Oh, just let some peas be strewn in the
+ante-chamber,’ answered the lion, ‘and then you will soon see. Men have
+a firm step, and when they walk over peas none of them stir, but girls
+trip and skip, and drag their feet, and the peas roll about.’ The king
+was well pleased with the counsel, and caused the peas to be strewn.
+
+There was, however, a servant of the king’s who favoured the huntsmen,
+and when he heard that they were going to be put to this test he went to
+them and repeated everything, and said: ‘The lion wants to make the king
+believe that you are girls.’ Then the king’s daughter thanked him, and
+said to her maidens: ‘Show some strength, and step firmly on the peas.’
+So next morning when the king had the twelve huntsmen called before
+him, and they came into the ante-chamber where the peas were lying, they
+stepped so firmly on them, and had such a strong, sure walk, that not
+one of the peas either rolled or stirred. Then they went away again,
+and the king said to the lion: ‘You have lied to me, they walk just like
+men.’ The lion said: ‘They have been informed that they were going to
+be put to the test, and have assumed some strength. Just let twelve
+spinning-wheels be brought into the ante-chamber, and they will go to
+them and be pleased with them, and that is what no man would do.’
+The king liked the advice, and had the spinning-wheels placed in the
+ante-chamber.
+
+But the servant, who was well disposed to the huntsmen, went to them,
+and disclosed the project. So when they were alone the king’s daughter
+said to her eleven girls: ‘Show some constraint, and do not look round
+at the spinning-wheels.’ And next morning when the king had his twelve
+huntsmen summoned, they went through the ante-chamber, and never once
+looked at the spinning-wheels. Then the king again said to the lion:
+‘You have deceived me, they are men, for they have not looked at the
+spinning-wheels.’ The lion replied: ‘They have restrained themselves.’
+The king, however, would no longer believe the lion.
+
+The twelve huntsmen always followed the king to the chase, and his
+liking for them continually increased. Now it came to pass that
+once when they were out hunting, news came that the king’s bride was
+approaching. When the true bride heard that, it hurt her so much that
+her heart was almost broken, and she fell fainting to the ground. The
+king thought something had happened to his dear huntsman, ran up to him,
+wanted to help him, and drew his glove off. Then he saw the ring which
+he had given to his first bride, and when he looked in her face he
+recognized her. Then his heart was so touched that he kissed her, and
+when she opened her eyes he said: ‘You are mine, and I am yours, and
+no one in the world can alter that.’ He sent a messenger to the other
+bride, and entreated her to return to her own kingdom, for he had a wife
+already, and someone who had just found an old key did not require a new
+one. Thereupon the wedding was celebrated, and the lion was again taken
+into favour, because, after all, he had told the truth.
+
+
+
+
+THE KING OF THE GOLDEN MOUNTAIN
+
+There was once a merchant who had only one child, a son, that was very
+young, and barely able to run alone. He had two richly laden ships then
+making a voyage upon the seas, in which he had embarked all his wealth,
+in the hope of making great gains, when the news came that both were
+lost. Thus from being a rich man he became all at once so very poor that
+nothing was left to him but one small plot of land; and there he often
+went in an evening to take his walk, and ease his mind of a little of
+his trouble.
+
+One day, as he was roaming along in a brown study, thinking with no
+great comfort on what he had been and what he now was, and was like
+to be, all on a sudden there stood before him a little, rough-looking,
+black dwarf. ‘Prithee, friend, why so sorrowful?’ said he to the
+merchant; ‘what is it you take so deeply to heart?’ ‘If you would do me
+any good I would willingly tell you,’ said the merchant. ‘Who knows but
+I may?’ said the little man: ‘tell me what ails you, and perhaps you
+will find I may be of some use.’ Then the merchant told him how all his
+wealth was gone to the bottom of the sea, and how he had nothing left
+but that little plot of land. ‘Oh, trouble not yourself about that,’
+said the dwarf; ‘only undertake to bring me here, twelve years hence,
+whatever meets you first on your going home, and I will give you as much
+as you please.’ The merchant thought this was no great thing to ask;
+that it would most likely be his dog or his cat, or something of that
+sort, but forgot his little boy Heinel; so he agreed to the bargain, and
+signed and sealed the bond to do what was asked of him.
+
+But as he drew near home, his little boy was so glad to see him that he
+crept behind him, and laid fast hold of his legs, and looked up in
+his face and laughed. Then the father started, trembling with fear and
+horror, and saw what it was that he had bound himself to do; but as no
+gold was come, he made himself easy by thinking that it was only a joke
+that the dwarf was playing him, and that, at any rate, when the money
+came, he should see the bearer, and would not take it in.
+
+About a month afterwards he went upstairs into a lumber-room to look
+for some old iron, that he might sell it and raise a little money; and
+there, instead of his iron, he saw a large pile of gold lying on the
+floor. At the sight of this he was overjoyed, and forgetting all about
+his son, went into trade again, and became a richer merchant than
+before.
+
+Meantime little Heinel grew up, and as the end of the twelve years drew
+near the merchant began to call to mind his bond, and became very sad
+and thoughtful; so that care and sorrow were written upon his face. The
+boy one day asked what was the matter, but his father would not tell for
+some time; at last, however, he said that he had, without knowing it,
+sold him for gold to a little, ugly-looking, black dwarf, and that the
+twelve years were coming round when he must keep his word. Then Heinel
+said, ‘Father, give yourself very little trouble about that; I shall be
+too much for the little man.’
+
+When the time came, the father and son went out together to the place
+agreed upon: and the son drew a circle on the ground, and set himself
+and his father in the middle of it. The little black dwarf soon came,
+and walked round and round about the circle, but could not find any way
+to get into it, and he either could not, or dared not, jump over it. At
+last the boy said to him. ‘Have you anything to say to us, my friend, or
+what do you want?’ Now Heinel had found a friend in a good fairy, that
+was fond of him, and had told him what to do; for this fairy knew what
+good luck was in store for him. ‘Have you brought me what you said you
+would?’ said the dwarf to the merchant. The old man held his tongue, but
+Heinel said again, ‘What do you want here?’ The dwarf said, ‘I come to
+talk with your father, not with you.’ ‘You have cheated and taken in my
+father,’ said the son; ‘pray give him up his bond at once.’ ‘Fair and
+softly,’ said the little old man; ‘right is right; I have paid my money,
+and your father has had it, and spent it; so be so good as to let me
+have what I paid it for.’ ‘You must have my consent to that first,’ said
+Heinel, ‘so please to step in here, and let us talk it over.’ The old
+man grinned, and showed his teeth, as if he should have been very glad
+to get into the circle if he could. Then at last, after a long talk,
+they came to terms. Heinel agreed that his father must give him up, and
+that so far the dwarf should have his way: but, on the other hand, the
+fairy had told Heinel what fortune was in store for him, if he followed
+his own course; and he did not choose to be given up to his hump-backed
+friend, who seemed so anxious for his company.
+
+So, to make a sort of drawn battle of the matter, it was settled that
+Heinel should be put into an open boat, that lay on the sea-shore hard
+by; that the father should push him off with his own hand, and that he
+should thus be set adrift, and left to the bad or good luck of wind and
+weather. Then he took leave of his father, and set himself in the boat,
+but before it got far off a wave struck it, and it fell with one side
+low in the water, so the merchant thought that poor Heinel was lost, and
+went home very sorrowful, while the dwarf went his way, thinking that at
+any rate he had had his revenge.
+
+The boat, however, did not sink, for the good fairy took care of her
+friend, and soon raised the boat up again, and it went safely on. The
+young man sat safe within, till at length it ran ashore upon an unknown
+land. As he jumped upon the shore he saw before him a beautiful castle
+but empty and dreary within, for it was enchanted. ‘Here,’ said he to
+himself, ‘must I find the prize the good fairy told me of.’ So he once
+more searched the whole palace through, till at last he found a white
+snake, lying coiled up on a cushion in one of the chambers.
+
+Now the white snake was an enchanted princess; and she was very glad
+to see him, and said, ‘Are you at last come to set me free? Twelve
+long years have I waited here for the fairy to bring you hither as she
+promised, for you alone can save me. This night twelve men will come:
+their faces will be black, and they will be dressed in chain armour.
+They will ask what you do here, but give no answer; and let them do
+what they will--beat, whip, pinch, prick, or torment you--bear all; only
+speak not a word, and at twelve o’clock they must go away. The second
+night twelve others will come: and the third night twenty-four, who
+will even cut off your head; but at the twelfth hour of that night their
+power is gone, and I shall be free, and will come and bring you the
+Water of Life, and will wash you with it, and bring you back to life
+and health.’ And all came to pass as she had said; Heinel bore all, and
+spoke not a word; and the third night the princess came, and fell on his
+neck and kissed him. Joy and gladness burst forth throughout the castle,
+the wedding was celebrated, and he was crowned king of the Golden
+Mountain.
+
+They lived together very happily, and the queen had a son. And thus
+eight years had passed over their heads, when the king thought of his
+father; and he began to long to see him once again. But the queen was
+against his going, and said, ‘I know well that misfortunes will come
+upon us if you go.’ However, he gave her no rest till she agreed. At his
+going away she gave him a wishing-ring, and said, ‘Take this ring, and
+put it on your finger; whatever you wish it will bring you; only promise
+never to make use of it to bring me hence to your father’s house.’ Then
+he said he would do what she asked, and put the ring on his finger, and
+wished himself near the town where his father lived.
+
+Heinel found himself at the gates in a moment; but the guards would
+not let him go in, because he was so strangely clad. So he went up to a
+neighbouring hill, where a shepherd dwelt, and borrowed his old frock,
+and thus passed unknown into the town. When he came to his father’s
+house, he said he was his son; but the merchant would not believe him,
+and said he had had but one son, his poor Heinel, who he knew was long
+since dead: and as he was only dressed like a poor shepherd, he would
+not even give him anything to eat. The king, however, still vowed that
+he was his son, and said, ‘Is there no mark by which you would know me
+if I am really your son?’ ‘Yes,’ said his mother, ‘our Heinel had a mark
+like a raspberry on his right arm.’ Then he showed them the mark, and
+they knew that what he had said was true.
+
+He next told them how he was king of the Golden Mountain, and was
+married to a princess, and had a son seven years old. But the merchant
+said, ‘that can never be true; he must be a fine king truly who travels
+about in a shepherd’s frock!’ At this the son was vexed; and forgetting
+his word, turned his ring, and wished for his queen and son. In an
+instant they stood before him; but the queen wept, and said he had
+broken his word, and bad luck would follow. He did all he could to
+soothe her, and she at last seemed to be appeased; but she was not so in
+truth, and was only thinking how she should punish him.
+
+One day he took her to walk with him out of the town, and showed her
+the spot where the boat was set adrift upon the wide waters. Then he sat
+himself down, and said, ‘I am very much tired; sit by me, I will rest my
+head in your lap, and sleep a while.’ As soon as he had fallen asleep,
+however, she drew the ring from his finger, and crept softly away, and
+wished herself and her son at home in their kingdom. And when he awoke
+he found himself alone, and saw that the ring was gone from his finger.
+‘I can never go back to my father’s house,’ said he; ‘they would say I
+am a sorcerer: I will journey forth into the world, till I come again to
+my kingdom.’
+
+So saying he set out and travelled till he came to a hill, where three
+giants were sharing their father’s goods; and as they saw him pass they
+cried out and said, ‘Little men have sharp wits; he shall part the goods
+between us.’ Now there was a sword that cut off an enemy’s head whenever
+the wearer gave the words, ‘Heads off!’; a cloak that made the owner
+invisible, or gave him any form he pleased; and a pair of boots that
+carried the wearer wherever he wished. Heinel said they must first let
+him try these wonderful things, then he might know how to set a value
+upon them. Then they gave him the cloak, and he wished himself a fly,
+and in a moment he was a fly. ‘The cloak is very well,’ said he: ‘now
+give me the sword.’ ‘No,’ said they; ‘not unless you undertake not to
+say, “Heads off!” for if you do we are all dead men.’ So they gave it
+him, charging him to try it on a tree. He next asked for the boots also;
+and the moment he had all three in his power, he wished himself at
+the Golden Mountain; and there he was at once. So the giants were left
+behind with no goods to share or quarrel about.
+
+As Heinel came near his castle he heard the sound of merry music; and
+the people around told him that his queen was about to marry another
+husband. Then he threw his cloak around him, and passed through the
+castle hall, and placed himself by the side of the queen, where no one
+saw him. But when anything to eat was put upon her plate, he took it
+away and ate it himself; and when a glass of wine was handed to her, he
+took it and drank it; and thus, though they kept on giving her meat and
+drink, her plate and cup were always empty.
+
+Upon this, fear and remorse came over her, and she went into her chamber
+alone, and sat there weeping; and he followed her there. ‘Alas!’ said
+she to herself, ‘was I not once set free? Why then does this enchantment
+still seem to bind me?’
+
+‘False and fickle one!’ said he. ‘One indeed came who set thee free, and
+he is now near thee again; but how have you used him? Ought he to
+have had such treatment from thee?’ Then he went out and sent away the
+company, and said the wedding was at an end, for that he was come back
+to the kingdom. But the princes, peers, and great men mocked at him.
+However, he would enter into no parley with them, but only asked them
+if they would go in peace or not. Then they turned upon him and tried
+to seize him; but he drew his sword. ‘Heads Off!’ cried he; and with the
+word the traitors’ heads fell before him, and Heinel was once more king
+of the Golden Mountain.
+
+
+
+
+DOCTOR KNOWALL
+
+There was once upon a time a poor peasant called Crabb, who drove with
+two oxen a load of wood to the town, and sold it to a doctor for two
+talers. When the money was being counted out to him, it so happened that
+the doctor was sitting at table, and when the peasant saw how well he
+ate and drank, his heart desired what he saw, and would willingly
+have been a doctor too. So he remained standing a while, and at length
+inquired if he too could not be a doctor. ‘Oh, yes,’ said the doctor,
+‘that is soon managed.’ ‘What must I do?’ asked the peasant. ‘In the
+first place buy yourself an A B C book of the kind which has a cock on
+the frontispiece; in the second, turn your cart and your two oxen into
+money, and get yourself some clothes, and whatsoever else pertains to
+medicine; thirdly, have a sign painted for yourself with the words: “I
+am Doctor Knowall,” and have that nailed up above your house-door.’ The
+peasant did everything that he had been told to do. When he had doctored
+people awhile, but not long, a rich and great lord had some money
+stolen. Then he was told about Doctor Knowall who lived in such and such
+a village, and must know what had become of the money. So the lord had
+the horses harnessed to his carriage, drove out to the village, and
+asked Crabb if he were Doctor Knowall. Yes, he was, he said. Then he was
+to go with him and bring back the stolen money. ‘Oh, yes, but Grete, my
+wife, must go too.’ The lord was willing, and let both of them have a
+seat in the carriage, and they all drove away together. When they came
+to the nobleman’s castle, the table was spread, and Crabb was told to
+sit down and eat. ‘Yes, but my wife, Grete, too,’ said he, and he seated
+himself with her at the table. And when the first servant came with a
+dish of delicate fare, the peasant nudged his wife, and said: ‘Grete,
+that was the first,’ meaning that was the servant who brought the first
+dish. The servant, however, thought he intended by that to say: ‘That is
+the first thief,’ and as he actually was so, he was terrified, and said
+to his comrade outside: ‘The doctor knows all: we shall fare ill, he
+said I was the first.’ The second did not want to go in at all, but was
+forced. So when he went in with his dish, the peasant nudged his wife,
+and said: ‘Grete, that is the second.’ This servant was equally alarmed,
+and he got out as fast as he could. The third fared no better, for the
+peasant again said: ‘Grete, that is the third.’ The fourth had to carry
+in a dish that was covered, and the lord told the doctor that he was to
+show his skill, and guess what was beneath the cover. Actually, there
+were crabs. The doctor looked at the dish, had no idea what to say, and
+cried: ‘Ah, poor Crabb.’ When the lord heard that, he cried: ‘There! he
+knows it; he must also know who has the money!’
+
+On this the servants looked terribly uneasy, and made a sign to the
+doctor that they wished him to step outside for a moment. When therefore
+he went out, all four of them confessed to him that they had stolen
+the money, and said that they would willingly restore it and give him a
+heavy sum into the bargain, if he would not denounce them, for if he
+did they would be hanged. They led him to the spot where the money was
+concealed. With this the doctor was satisfied, and returned to the hall,
+sat down to the table, and said: ‘My lord, now will I search in my book
+where the gold is hidden.’ The fifth servant, however, crept into the
+stove to hear if the doctor knew still more. But the doctor sat still
+and opened his A B C book, turned the pages backwards and forwards, and
+looked for the cock. As he could not find it immediately he said: ‘I
+know you are there, so you had better come out!’ Then the fellow in the
+stove thought that the doctor meant him, and full of terror, sprang out,
+crying: ‘That man knows everything!’ Then Doctor Knowall showed the lord
+where the money was, but did not say who had stolen it, and received
+from both sides much money in reward, and became a renowned man.
+
+
+
+
+THE SEVEN RAVENS
+
+There was once a man who had seven sons, and last of all one daughter.
+Although the little girl was very pretty, she was so weak and small that
+they thought she could not live; but they said she should at once be
+christened.
+
+So the father sent one of his sons in haste to the spring to get some
+water, but the other six ran with him. Each wanted to be first at
+drawing the water, and so they were in such a hurry that all let their
+pitchers fall into the well, and they stood very foolishly looking at
+one another, and did not know what to do, for none dared go home. In the
+meantime the father was uneasy, and could not tell what made the
+young men stay so long. ‘Surely,’ said he, ‘the whole seven must have
+forgotten themselves over some game of play’; and when he had waited
+still longer and they yet did not come, he flew into a rage and wished
+them all turned into ravens. Scarcely had he spoken these words when he
+heard a croaking over his head, and looked up and saw seven ravens as
+black as coal flying round and round. Sorry as he was to see his wish
+so fulfilled, he did not know how what was done could be undone, and
+comforted himself as well as he could for the loss of his seven sons
+with his dear little daughter, who soon became stronger and every day
+more beautiful.
+
+For a long time she did not know that she had ever had any brothers; for
+her father and mother took care not to speak of them before her: but one
+day by chance she heard the people about her speak of them. ‘Yes,’ said
+they, ‘she is beautiful indeed, but still ‘tis a pity that her brothers
+should have been lost for her sake.’ Then she was much grieved, and went
+to her father and mother, and asked if she had any brothers, and what
+had become of them. So they dared no longer hide the truth from her, but
+said it was the will of Heaven, and that her birth was only the innocent
+cause of it; but the little girl mourned sadly about it every day, and
+thought herself bound to do all she could to bring her brothers back;
+and she had neither rest nor ease, till at length one day she stole
+away, and set out into the wide world to find her brothers, wherever
+they might be, and free them, whatever it might cost her.
+
+She took nothing with her but a little ring which her father and mother
+had given her, a loaf of bread in case she should be hungry, a little
+pitcher of water in case she should be thirsty, and a little stool
+to rest upon when she should be weary. Thus she went on and on, and
+journeyed till she came to the world’s end; then she came to the sun,
+but the sun looked much too hot and fiery; so she ran away quickly to
+the moon, but the moon was cold and chilly, and said, ‘I smell flesh
+and blood this way!’ so she took herself away in a hurry and came to the
+stars, and the stars were friendly and kind to her, and each star sat
+upon his own little stool; but the morning star rose up and gave her a
+little piece of wood, and said, ‘If you have not this little piece of
+wood, you cannot unlock the castle that stands on the glass-mountain,
+and there your brothers live.’ The little girl took the piece of wood,
+rolled it up in a little cloth, and went on again until she came to the
+glass-mountain, and found the door shut. Then she felt for the little
+piece of wood; but when she unwrapped the cloth it was not there, and
+she saw she had lost the gift of the good stars. What was to be done?
+She wanted to save her brothers, and had no key of the castle of the
+glass-mountain; so this faithful little sister took a knife out of her
+pocket and cut off her little finger, that was just the size of the
+piece of wood she had lost, and put it in the door and opened it.
+
+As she went in, a little dwarf came up to her, and said, ‘What are you
+seeking for?’ ‘I seek for my brothers, the seven ravens,’ answered she.
+Then the dwarf said, ‘My masters are not at home; but if you will wait
+till they come, pray step in.’ Now the little dwarf was getting their
+dinner ready, and he brought their food upon seven little plates, and
+their drink in seven little glasses, and set them upon the table, and
+out of each little plate their sister ate a small piece, and out of each
+little glass she drank a small drop; but she let the ring that she had
+brought with her fall into the last glass.
+
+On a sudden she heard a fluttering and croaking in the air, and the
+dwarf said, ‘Here come my masters.’ When they came in, they wanted to
+eat and drink, and looked for their little plates and glasses. Then said
+one after the other,
+
+‘Who has eaten from my little plate? And who has been drinking out of my
+little glass?’
+
+ ‘Caw! Caw! well I ween
+  Mortal lips have this way been.’
+
+When the seventh came to the bottom of his glass, and found there the
+ring, he looked at it, and knew that it was his father’s and mother’s,
+and said, ‘O that our little sister would but come! then we should be
+free.’ When the little girl heard this (for she stood behind the door
+all the time and listened), she ran forward, and in an instant all
+the ravens took their right form again; and all hugged and kissed each
+other, and went merrily home.
+
+
+
+
+THE WEDDING OF MRS FOX
+
+
+FIRST STORY
+
+There was once upon a time an old fox with nine tails, who believed that
+his wife was not faithful to him, and wished to put her to the test. He
+stretched himself out under the bench, did not move a limb, and behaved
+as if he were stone dead. Mrs Fox went up to her room, shut herself in,
+and her maid, Miss Cat, sat by the fire, and did the cooking. When it
+became known that the old fox was dead, suitors presented themselves.
+The maid heard someone standing at the house-door, knocking. She went
+and opened it, and it was a young fox, who said:
+
+ ‘What may you be about, Miss Cat?
+  Do you sleep or do you wake?’
+
+She answered:
+
+ ‘I am not sleeping, I am waking,
+  Would you know what I am making?
+  I am boiling warm beer with butter,
+  Will you be my guest for supper?’
+
+‘No, thank you, miss,’ said the fox, ‘what is Mrs Fox doing?’ The maid
+replied:
+
+ ‘She is sitting in her room,
+  Moaning in her gloom,
+  Weeping her little eyes quite red,
+  Because old Mr Fox is dead.’
+
+‘Do just tell her, miss, that a young fox is here, who would like to woo
+her.’ ‘Certainly, young sir.’
+
+  The cat goes up the stairs trip, trap,
+  The door she knocks at tap, tap, tap,
+ ‘Mistress Fox, are you inside?’
+ ‘Oh, yes, my little cat,’ she cried.
+ ‘A wooer he stands at the door out there.’
+ ‘What does he look like, my dear?’
+
+‘Has he nine as beautiful tails as the late Mr Fox?’ ‘Oh, no,’ answered
+the cat, ‘he has only one.’ ‘Then I will not have him.’
+
+Miss Cat went downstairs and sent the wooer away. Soon afterwards there
+was another knock, and another fox was at the door who wished to woo Mrs
+Fox. He had two tails, but he did not fare better than the first. After
+this still more came, each with one tail more than the other, but they
+were all turned away, until at last one came who had nine tails, like
+old Mr Fox. When the widow heard that, she said joyfully to the cat:
+
+ ‘Now open the gates and doors all wide,
+  And carry old Mr Fox outside.’
+
+But just as the wedding was going to be solemnized, old Mr Fox stirred
+under the bench, and cudgelled all the rabble, and drove them and Mrs
+Fox out of the house.
+
+
+SECOND STORY
+
+When old Mr Fox was dead, the wolf came as a suitor, and knocked at the
+door, and the cat who was servant to Mrs Fox, opened it for him. The
+wolf greeted her, and said:
+
+ ‘Good day, Mrs Cat of Kehrewit,
+  How comes it that alone you sit?
+  What are you making good?’
+
+The cat replied:
+
+ ‘In milk I’m breaking bread so sweet,
+  Will you be my guest, and eat?’
+
+‘No, thank you, Mrs Cat,’ answered the wolf. ‘Is Mrs Fox not at home?’
+
+The cat said:
+
+ ‘She sits upstairs in her room,
+  Bewailing her sorrowful doom,
+  Bewailing her trouble so sore,
+  For old Mr Fox is no more.’
+
+The wolf answered:
+
+ ‘If she’s in want of a husband now,
+  Then will it please her to step below?’
+  The cat runs quickly up the stair,
+  And lets her tail fly here and there,
+  Until she comes to the parlour door.
+  With her five gold rings at the door she knocks:
+ ‘Are you within, good Mistress Fox?
+  If you’re in want of a husband now,
+  Then will it please you to step below?
+
+Mrs Fox asked: ‘Has the gentleman red stockings on, and has he a pointed
+mouth?’ ‘No,’ answered the cat. ‘Then he won’t do for me.’
+
+When the wolf was gone, came a dog, a stag, a hare, a bear, a lion, and
+all the beasts of the forest, one after the other. But one of the good
+qualities which old Mr Fox had possessed, was always lacking, and the
+cat had continually to send the suitors away. At length came a young
+fox. Then Mrs Fox said: ‘Has the gentleman red stockings on, and has a
+little pointed mouth?’ ‘Yes,’ said the cat, ‘he has.’ ‘Then let him come
+upstairs,’ said Mrs Fox, and ordered the servant to prepare the wedding
+feast.
+
+ ‘Sweep me the room as clean as you can,
+  Up with the window, fling out my old man!
+  For many a fine fat mouse he brought,
+  Yet of his wife he never thought,
+  But ate up every one he caught.’
+
+Then the wedding was solemnized with young Mr Fox, and there was much
+rejoicing and dancing; and if they have not left off, they are dancing
+still.
+
+
+
+
+THE SALAD
+
+As a merry young huntsman was once going briskly along through a wood,
+there came up a little old woman, and said to him, ‘Good day, good day;
+you seem merry enough, but I am hungry and thirsty; do pray give me
+something to eat.’ The huntsman took pity on her, and put his hand in
+his pocket and gave her what he had. Then he wanted to go his way; but
+she took hold of him, and said, ‘Listen, my friend, to what I am going
+to tell you; I will reward you for your kindness; go your way, and after
+a little time you will come to a tree where you will see nine birds
+sitting on a cloak. Shoot into the midst of them, and one will fall down
+dead: the cloak will fall too; take it, it is a wishing-cloak, and when
+you wear it you will find yourself at any place where you may wish to
+be. Cut open the dead bird, take out its heart and keep it, and you will
+find a piece of gold under your pillow every morning when you rise. It
+is the bird’s heart that will bring you this good luck.’
+
+The huntsman thanked her, and thought to himself, ‘If all this does
+happen, it will be a fine thing for me.’ When he had gone a hundred
+steps or so, he heard a screaming and chirping in the branches over him,
+and looked up and saw a flock of birds pulling a cloak with their bills
+and feet; screaming, fighting, and tugging at each other as if
+each wished to have it himself. ‘Well,’ said the huntsman, ‘this is
+wonderful; this happens just as the old woman said’; then he shot into
+the midst of them so that their feathers flew all about. Off went the
+flock chattering away; but one fell down dead, and the cloak with it.
+Then the huntsman did as the old woman told him, cut open the bird, took
+out the heart, and carried the cloak home with him.
+
+The next morning when he awoke he lifted up his pillow, and there lay
+the piece of gold glittering underneath; the same happened next day, and
+indeed every day when he arose. He heaped up a great deal of gold, and
+at last thought to himself, ‘Of what use is this gold to me whilst I am
+at home? I will go out into the world and look about me.’
+
+Then he took leave of his friends, and hung his bag and bow about his
+neck, and went his way. It so happened that his road one day led through
+a thick wood, at the end of which was a large castle in a green meadow,
+and at one of the windows stood an old woman with a very beautiful young
+lady by her side looking about them. Now the old woman was a witch, and
+said to the young lady, ‘There is a young man coming out of the wood who
+carries a wonderful prize; we must get it away from him, my dear child,
+for it is more fit for us than for him. He has a bird’s heart that
+brings a piece of gold under his pillow every morning.’ Meantime the
+huntsman came nearer and looked at the lady, and said to himself, ‘I
+have been travelling so long that I should like to go into this castle
+and rest myself, for I have money enough to pay for anything I want’;
+but the real reason was, that he wanted to see more of the beautiful
+lady. Then he went into the house, and was welcomed kindly; and it was
+not long before he was so much in love that he thought of nothing else
+but looking at the lady’s eyes, and doing everything that she wished.
+Then the old woman said, ‘Now is the time for getting the bird’s heart.’
+So the lady stole it away, and he never found any more gold under his
+pillow, for it lay now under the young lady’s, and the old woman took it
+away every morning; but he was so much in love that he never missed his
+prize.
+
+‘Well,’ said the old witch, ‘we have got the bird’s heart, but not the
+wishing-cloak yet, and that we must also get.’ ‘Let us leave him that,’
+said the young lady; ‘he has already lost his wealth.’ Then the witch
+was very angry, and said, ‘Such a cloak is a very rare and wonderful
+thing, and I must and will have it.’ So she did as the old woman told
+her, and set herself at the window, and looked about the country and
+seemed very sorrowful; then the huntsman said, ‘What makes you so sad?’
+‘Alas! dear sir,’ said she, ‘yonder lies the granite rock where all the
+costly diamonds grow, and I want so much to go there, that whenever I
+think of it I cannot help being sorrowful, for who can reach it? only
+the birds and the flies--man cannot.’ ‘If that’s all your grief,’ said
+the huntsman, ‘I’ll take you there with all my heart’; so he drew her under
+his cloak, and the moment he wished to be on the granite mountain they
+were both there. The diamonds glittered so on all sides that they were
+delighted with the sight and picked up the finest. But the old witch
+made a deep sleep come upon him, and he said to the young lady, ‘Let us
+sit down and rest ourselves a little, I am so tired that I cannot stand
+any longer.’ So they sat down, and he laid his head in her lap and
+fell asleep; and whilst he was sleeping on she took the cloak from
+his shoulders, hung it on her own, picked up the diamonds, and wished
+herself home again.
+
+When he awoke and found that his lady had tricked him, and left him
+alone on the wild rock, he said, ‘Alas! what roguery there is in the
+world!’ and there he sat in great grief and fear, not knowing what to
+do. Now this rock belonged to fierce giants who lived upon it; and as
+he saw three of them striding about, he thought to himself, ‘I can only
+save myself by feigning to be asleep’; so he laid himself down as if he
+were in a sound sleep. When the giants came up to him, the first pushed
+him with his foot, and said, ‘What worm is this that lies here curled
+up?’ ‘Tread upon him and kill him,’ said the second. ‘It’s not worth the
+trouble,’ said the third; ‘let him live, he’ll go climbing higher up the
+mountain, and some cloud will come rolling and carry him away.’ And they
+passed on. But the huntsman had heard all they said; and as soon as they
+were gone, he climbed to the top of the mountain, and when he had sat
+there a short time a cloud came rolling around him, and caught him in a
+whirlwind and bore him along for some time, till it settled in a garden,
+and he fell quite gently to the ground amongst the greens and cabbages.
+
+Then he looked around him, and said, ‘I wish I had something to eat, if
+not I shall be worse off than before; for here I see neither apples
+nor pears, nor any kind of fruits, nothing but vegetables.’ At last he
+thought to himself, ‘I can eat salad, it will refresh and strengthen
+me.’ So he picked out a fine head and ate of it; but scarcely had he
+swallowed two bites when he felt himself quite changed, and saw with
+horror that he was turned into an ass. However, he still felt very
+hungry, and the salad tasted very nice; so he ate on till he came
+to another kind of salad, and scarcely had he tasted it when he felt
+another change come over him, and soon saw that he was lucky enough to
+have found his old shape again.
+
+Then he laid himself down and slept off a little of his weariness; and
+when he awoke the next morning he broke off a head both of the good and
+the bad salad, and thought to himself, ‘This will help me to my fortune
+again, and enable me to pay off some folks for their treachery.’ So he
+went away to try and find the castle of his friends; and after wandering
+about a few days he luckily found it. Then he stained his face all over
+brown, so that even his mother would not have known him, and went into
+the castle and asked for a lodging; ‘I am so tired,’ said he, ‘that I
+can go no farther.’ ‘Countryman,’ said the witch, ‘who are you? and what
+is your business?’ ‘I am,’ said he, ‘a messenger sent by the king to
+find the finest salad that grows under the sun. I have been lucky
+enough to find it, and have brought it with me; but the heat of the sun
+scorches so that it begins to wither, and I don’t know that I can carry
+it farther.’
+
+When the witch and the young lady heard of his beautiful salad, they
+longed to taste it, and said, ‘Dear countryman, let us just taste it.’
+‘To be sure,’ answered he; ‘I have two heads of it with me, and will
+give you one’; so he opened his bag and gave them the bad. Then the
+witch herself took it into the kitchen to be dressed; and when it was
+ready she could not wait till it was carried up, but took a few leaves
+immediately and put them in her mouth, and scarcely were they swallowed
+when she lost her own form and ran braying down into the court in the
+form of an ass. Now the servant-maid came into the kitchen, and seeing
+the salad ready, was going to carry it up; but on the way she too felt a
+wish to taste it as the old woman had done, and ate some leaves; so she
+also was turned into an ass and ran after the other, letting the dish
+with the salad fall on the ground. The messenger sat all this time with
+the beautiful young lady, and as nobody came with the salad and she
+longed to taste it, she said, ‘I don’t know where the salad can be.’
+Then he thought something must have happened, and said, ‘I will go
+into the kitchen and see.’ And as he went he saw two asses in the court
+running about, and the salad lying on the ground. ‘All right!’ said
+he; ‘those two have had their share.’ Then he took up the rest of
+the leaves, laid them on the dish and brought them to the young lady,
+saying, ‘I bring you the dish myself that you may not wait any longer.’
+So she ate of it, and like the others ran off into the court braying
+away.
+
+Then the huntsman washed his face and went into the court that they
+might know him. ‘Now you shall be paid for your roguery,’ said he; and
+tied them all three to a rope and took them along with him till he
+came to a mill and knocked at the window. ‘What’s the matter?’ said the
+miller. ‘I have three tiresome beasts here,’ said the other; ‘if you
+will take them, give them food and room, and treat them as I tell you,
+I will pay you whatever you ask.’ ‘With all my heart,’ said the miller;
+‘but how shall I treat them?’ Then the huntsman said, ‘Give the old
+one stripes three times a day and hay once; give the next (who was
+the servant-maid) stripes once a day and hay three times; and give
+the youngest (who was the beautiful lady) hay three times a day and
+no stripes’: for he could not find it in his heart to have her beaten.
+After this he went back to the castle, where he found everything he
+wanted.
+
+Some days after, the miller came to him and told him that the old ass
+was dead; ‘The other two,’ said he, ‘are alive and eat, but are so
+sorrowful that they cannot last long.’ Then the huntsman pitied them,
+and told the miller to drive them back to him, and when they came, he
+gave them some of the good salad to eat. And the beautiful young lady
+fell upon her knees before him, and said, ‘O dearest huntsman! forgive
+me all the ill I have done you; my mother forced me to it, it was
+against my will, for I always loved you very much. Your wishing-cloak
+hangs up in the closet, and as for the bird’s heart, I will give it you
+too.’ But he said, ‘Keep it, it will be just the same thing, for I mean
+to make you my wife.’ So they were married, and lived together very
+happily till they died.
+
+
+
+
+THE STORY OF THE YOUTH WHO WENT FORTH TO LEARN WHAT FEAR WAS
+
+A certain father had two sons, the elder of who was smart and sensible,
+and could do everything, but the younger was stupid and could neither
+learn nor understand anything, and when people saw him they said:
+‘There’s a fellow who will give his father some trouble!’ When anything
+had to be done, it was always the elder who was forced to do it; but
+if his father bade him fetch anything when it was late, or in the
+night-time, and the way led through the churchyard, or any other dismal
+place, he answered: ‘Oh, no father, I’ll not go there, it makes me
+shudder!’ for he was afraid. Or when stories were told by the fire at
+night which made the flesh creep, the listeners sometimes said: ‘Oh,
+it makes us shudder!’ The younger sat in a corner and listened with
+the rest of them, and could not imagine what they could mean. ‘They are
+always saying: “It makes me shudder, it makes me shudder!” It does not
+make me shudder,’ thought he. ‘That, too, must be an art of which I
+understand nothing!’
+
+Now it came to pass that his father said to him one day: ‘Hearken to me,
+you fellow in the corner there, you are growing tall and strong, and you
+too must learn something by which you can earn your bread. Look how your
+brother works, but you do not even earn your salt.’ ‘Well, father,’ he
+replied, ‘I am quite willing to learn something--indeed, if it could but
+be managed, I should like to learn how to shudder. I don’t understand
+that at all yet.’ The elder brother smiled when he heard that, and
+thought to himself: ‘Goodness, what a blockhead that brother of mine is!
+He will never be good for anything as long as he lives! He who wants to
+be a sickle must bend himself betimes.’
+
+The father sighed, and answered him: ‘You shall soon learn what it is to
+shudder, but you will not earn your bread by that.’
+
+Soon after this the sexton came to the house on a visit, and the father
+bewailed his trouble, and told him how his younger son was so backward
+in every respect that he knew nothing and learnt nothing. ‘Just think,’
+said he, ‘when I asked him how he was going to earn his bread, he
+actually wanted to learn to shudder.’ ‘If that be all,’ replied the
+sexton, ‘he can learn that with me. Send him to me, and I will soon
+polish him.’ The father was glad to do it, for he thought: ‘It will
+train the boy a little.’ The sexton therefore took him into his house,
+and he had to ring the church bell. After a day or two, the sexton awoke
+him at midnight, and bade him arise and go up into the church tower and
+ring the bell. ‘You shall soon learn what shuddering is,’ thought he,
+and secretly went there before him; and when the boy was at the top of
+the tower and turned round, and was just going to take hold of the bell
+rope, he saw a white figure standing on the stairs opposite the sounding
+hole. ‘Who is there?’ cried he, but the figure made no reply, and did
+not move or stir. ‘Give an answer,’ cried the boy, ‘or take yourself
+off, you have no business here at night.’
+
+The sexton, however, remained standing motionless that the boy might
+think he was a ghost. The boy cried a second time: ‘What do you want
+here?--speak if you are an honest fellow, or I will throw you down the
+steps!’ The sexton thought: ‘He can’t mean to be as bad as his words,’
+uttered no sound and stood as if he were made of stone. Then the boy
+called to him for the third time, and as that was also to no purpose,
+he ran against him and pushed the ghost down the stairs, so that it fell
+down the ten steps and remained lying there in a corner. Thereupon he
+rang the bell, went home, and without saying a word went to bed, and
+fell asleep. The sexton’s wife waited a long time for her husband, but
+he did not come back. At length she became uneasy, and wakened the boy,
+and asked: ‘Do you know where my husband is? He climbed up the tower
+before you did.’ ‘No, I don’t know,’ replied the boy, ‘but someone was
+standing by the sounding hole on the other side of the steps, and as he
+would neither gave an answer nor go away, I took him for a scoundrel,
+and threw him downstairs. Just go there and you will see if it was he.
+I should be sorry if it were.’ The woman ran away and found her husband,
+who was lying moaning in the corner, and had broken his leg.
+
+She carried him down, and then with loud screams she hastened to the
+boy’s father, ‘Your boy,’ cried she, ‘has been the cause of a great
+misfortune! He has thrown my husband down the steps so that he broke his
+leg. Take the good-for-nothing fellow out of our house.’ The father was
+terrified, and ran thither and scolded the boy. ‘What wicked tricks
+are these?’ said he. ‘The devil must have put them into your head.’
+‘Father,’ he replied, ‘do listen to me. I am quite innocent. He was
+standing there by night like one intent on doing evil. I did not know
+who it was, and I entreated him three times either to speak or to go
+away.’ ‘Ah,’ said the father, ‘I have nothing but unhappiness with you.
+Go out of my sight. I will see you no more.’
+
+‘Yes, father, right willingly, wait only until it is day. Then will I
+go forth and learn how to shudder, and then I shall, at any rate,
+understand one art which will support me.’ ‘Learn what you will,’ spoke
+the father, ‘it is all the same to me. Here are fifty talers for you.
+Take these and go into the wide world, and tell no one from whence you
+come, and who is your father, for I have reason to be ashamed of you.’
+‘Yes, father, it shall be as you will. If you desire nothing more than
+that, I can easily keep it in mind.’
+
+When the day dawned, therefore, the boy put his fifty talers into his
+pocket, and went forth on the great highway, and continually said to
+himself: ‘If I could but shudder! If I could but shudder!’ Then a man
+approached who heard this conversation which the youth was holding with
+himself, and when they had walked a little farther to where they could
+see the gallows, the man said to him: ‘Look, there is the tree where
+seven men have married the ropemaker’s daughter, and are now learning
+how to fly. Sit down beneath it, and wait till night comes, and you will
+soon learn how to shudder.’ ‘If that is all that is wanted,’ answered
+the youth, ‘it is easily done; but if I learn how to shudder as fast as
+that, you shall have my fifty talers. Just come back to me early in the
+morning.’ Then the youth went to the gallows, sat down beneath it, and
+waited till evening came. And as he was cold, he lighted himself a fire,
+but at midnight the wind blew so sharply that in spite of his fire, he
+could not get warm. And as the wind knocked the hanged men against each
+other, and they moved backwards and forwards, he thought to himself:
+‘If you shiver below by the fire, how those up above must freeze and
+suffer!’ And as he felt pity for them, he raised the ladder, and climbed
+up, unbound one of them after the other, and brought down all seven.
+Then he stoked the fire, blew it, and set them all round it to warm
+themselves. But they sat there and did not stir, and the fire caught
+their clothes. So he said: ‘Take care, or I will hang you up again.’ The
+dead men, however, did not hear, but were quite silent, and let their
+rags go on burning. At this he grew angry, and said: ‘If you will not
+take care, I cannot help you, I will not be burnt with you,’ and he hung
+them up again each in his turn. Then he sat down by his fire and fell
+asleep, and the next morning the man came to him and wanted to have
+the fifty talers, and said: ‘Well do you know how to shudder?’ ‘No,’
+answered he, ‘how should I know? Those fellows up there did not open
+their mouths, and were so stupid that they let the few old rags which
+they had on their bodies get burnt.’ Then the man saw that he would not
+get the fifty talers that day, and went away saying: ‘Such a youth has
+never come my way before.’
+
+The youth likewise went his way, and once more began to mutter to
+himself: ‘Ah, if I could but shudder! Ah, if I could but shudder!’ A
+waggoner who was striding behind him heard this and asked: ‘Who are
+you?’ ‘I don’t know,’ answered the youth. Then the waggoner asked: ‘From
+whence do you come?’ ‘I know not.’ ‘Who is your father?’ ‘That I may
+not tell you.’ ‘What is it that you are always muttering between your
+teeth?’ ‘Ah,’ replied the youth, ‘I do so wish I could shudder, but
+no one can teach me how.’ ‘Enough of your foolish chatter,’ said the
+waggoner. ‘Come, go with me, I will see about a place for you.’ The
+youth went with the waggoner, and in the evening they arrived at an inn
+where they wished to pass the night. Then at the entrance of the parlour
+the youth again said quite loudly: ‘If I could but shudder! If I could
+but shudder!’ The host who heard this, laughed and said: ‘If that is
+your desire, there ought to be a good opportunity for you here.’ ‘Ah,
+be silent,’ said the hostess, ‘so many prying persons have already lost
+their lives, it would be a pity and a shame if such beautiful eyes as
+these should never see the daylight again.’
+
+But the youth said: ‘However difficult it may be, I will learn it. For
+this purpose indeed have I journeyed forth.’ He let the host have
+no rest, until the latter told him, that not far from thence stood a
+haunted castle where anyone could very easily learn what shuddering was,
+if he would but watch in it for three nights. The king had promised that
+he who would venture should have his daughter to wife, and she was the
+most beautiful maiden the sun shone on. Likewise in the castle lay great
+treasures, which were guarded by evil spirits, and these treasures would
+then be freed, and would make a poor man rich enough. Already many men
+had gone into the castle, but as yet none had come out again. Then the
+youth went next morning to the king, and said: ‘If it be allowed, I will
+willingly watch three nights in the haunted castle.’
+
+The king looked at him, and as the youth pleased him, he said: ‘You may
+ask for three things to take into the castle with you, but they must
+be things without life.’ Then he answered: ‘Then I ask for a fire, a
+turning lathe, and a cutting-board with the knife.’
+
+The king had these things carried into the castle for him during the
+day. When night was drawing near, the youth went up and made himself
+a bright fire in one of the rooms, placed the cutting-board and knife
+beside it, and seated himself by the turning-lathe. ‘Ah, if I could
+but shudder!’ said he, ‘but I shall not learn it here either.’ Towards
+midnight he was about to poke his fire, and as he was blowing it,
+something cried suddenly from one corner: ‘Au, miau! how cold we are!’
+‘You fools!’ cried he, ‘what are you crying about? If you are cold, come
+and take a seat by the fire and warm yourselves.’ And when he had said
+that, two great black cats came with one tremendous leap and sat down
+on each side of him, and looked savagely at him with their fiery
+eyes. After a short time, when they had warmed themselves, they said:
+‘Comrade, shall we have a game of cards?’ ‘Why not?’ he replied, ‘but
+just show me your paws.’ Then they stretched out their claws. ‘Oh,’ said
+he, ‘what long nails you have! Wait, I must first cut them for you.’
+Thereupon he seized them by the throats, put them on the cutting-board
+and screwed their feet fast. ‘I have looked at your fingers,’ said he,
+‘and my fancy for card-playing has gone,’ and he struck them dead and
+threw them out into the water. But when he had made away with these two,
+and was about to sit down again by his fire, out from every hole and
+corner came black cats and black dogs with red-hot chains, and more
+and more of them came until he could no longer move, and they yelled
+horribly, and got on his fire, pulled it to pieces, and tried to put
+it out. He watched them for a while quietly, but at last when they were
+going too far, he seized his cutting-knife, and cried: ‘Away with you,
+vermin,’ and began to cut them down. Some of them ran away, the others
+he killed, and threw out into the fish-pond. When he came back he fanned
+the embers of his fire again and warmed himself. And as he thus sat, his
+eyes would keep open no longer, and he felt a desire to sleep. Then he
+looked round and saw a great bed in the corner. ‘That is the very thing
+for me,’ said he, and got into it. When he was just going to shut his
+eyes, however, the bed began to move of its own accord, and went over
+the whole of the castle. ‘That’s right,’ said he, ‘but go faster.’ Then
+the bed rolled on as if six horses were harnessed to it, up and down,
+over thresholds and stairs, but suddenly hop, hop, it turned over upside
+down, and lay on him like a mountain. But he threw quilts and pillows up
+in the air, got out and said: ‘Now anyone who likes, may drive,’ and
+lay down by his fire, and slept till it was day. In the morning the king
+came, and when he saw him lying there on the ground, he thought the evil
+spirits had killed him and he was dead. Then said he: ‘After all it is a
+pity,--for so handsome a man.’ The youth heard it, got up, and said: ‘It
+has not come to that yet.’ Then the king was astonished, but very glad,
+and asked how he had fared. ‘Very well indeed,’ answered he; ‘one
+night is past, the two others will pass likewise.’ Then he went to the
+innkeeper, who opened his eyes very wide, and said: ‘I never expected to
+see you alive again! Have you learnt how to shudder yet?’ ‘No,’ said he,
+‘it is all in vain. If someone would but tell me!’
+
+The second night he again went up into the old castle, sat down by the
+fire, and once more began his old song: ‘If I could but shudder!’ When
+midnight came, an uproar and noise of tumbling about was heard; at
+first it was low, but it grew louder and louder. Then it was quiet for
+a while, and at length with a loud scream, half a man came down the
+chimney and fell before him. ‘Hullo!’ cried he, ‘another half belongs
+to this. This is not enough!’ Then the uproar began again, there was a
+roaring and howling, and the other half fell down likewise. ‘Wait,’ said
+he, ‘I will just stoke up the fire a little for you.’ When he had done
+that and looked round again, the two pieces were joined together, and a
+hideous man was sitting in his place. ‘That is no part of our bargain,’
+said the youth, ‘the bench is mine.’ The man wanted to push him away;
+the youth, however, would not allow that, but thrust him off with all
+his strength, and seated himself again in his own place. Then still more
+men fell down, one after the other; they brought nine dead men’s legs
+and two skulls, and set them up and played at nine-pins with them. The
+youth also wanted to play and said: ‘Listen you, can I join you?’ ‘Yes,
+if you have any money.’ ‘Money enough,’ replied he, ‘but your balls are
+not quite round.’ Then he took the skulls and put them in the lathe and
+turned them till they were round. ‘There, now they will roll better!’
+said he. ‘Hurrah! now we’ll have fun!’ He played with them and lost some
+of his money, but when it struck twelve, everything vanished from his
+sight. He lay down and quietly fell asleep. Next morning the king came
+to inquire after him. ‘How has it fared with you this time?’ asked he.
+‘I have been playing at nine-pins,’ he answered, ‘and have lost a couple
+of farthings.’ ‘Have you not shuddered then?’ ‘What?’ said he, ‘I have
+had a wonderful time! If I did but know what it was to shudder!’
+
+The third night he sat down again on his bench and said quite sadly:
+‘If I could but shudder.’ When it grew late, six tall men came in and
+brought a coffin. Then he said: ‘Ha, ha, that is certainly my little
+cousin, who died only a few days ago,’ and he beckoned with his finger,
+and cried: ‘Come, little cousin, come.’ They placed the coffin on the
+ground, but he went to it and took the lid off, and a dead man lay
+therein. He felt his face, but it was cold as ice. ‘Wait,’ said he, ‘I
+will warm you a little,’ and went to the fire and warmed his hand and
+laid it on the dead man’s face, but he remained cold. Then he took him
+out, and sat down by the fire and laid him on his breast and rubbed his
+arms that the blood might circulate again. As this also did no good, he
+thought to himself: ‘When two people lie in bed together, they warm each
+other,’ and carried him to the bed, covered him over and lay down by
+him. After a short time the dead man became warm too, and began to move.
+Then said the youth, ‘See, little cousin, have I not warmed you?’ The
+dead man, however, got up and cried: ‘Now will I strangle you.’
+
+‘What!’ said he, ‘is that the way you thank me? You shall at once go
+into your coffin again,’ and he took him up, threw him into it, and shut
+the lid. Then came the six men and carried him away again. ‘I cannot
+manage to shudder,’ said he. ‘I shall never learn it here as long as I
+live.’
+
+Then a man entered who was taller than all others, and looked terrible.
+He was old, however, and had a long white beard. ‘You wretch,’ cried he,
+‘you shall soon learn what it is to shudder, for you shall die.’ ‘Not so
+fast,’ replied the youth. ‘If I am to die, I shall have to have a say
+in it.’ ‘I will soon seize you,’ said the fiend. ‘Softly, softly, do not
+talk so big. I am as strong as you are, and perhaps even stronger.’
+‘We shall see,’ said the old man. ‘If you are stronger, I will let you
+go--come, we will try.’ Then he led him by dark passages to a smith’s
+forge, took an axe, and with one blow struck an anvil into the ground.
+‘I can do better than that,’ said the youth, and went to the other
+anvil. The old man placed himself near and wanted to look on, and his
+white beard hung down. Then the youth seized the axe, split the anvil
+with one blow, and in it caught the old man’s beard. ‘Now I have you,’
+said the youth. ‘Now it is your turn to die.’ Then he seized an iron bar
+and beat the old man till he moaned and entreated him to stop, when he
+would give him great riches. The youth drew out the axe and let him go.
+The old man led him back into the castle, and in a cellar showed him
+three chests full of gold. ‘Of these,’ said he, ‘one part is for the
+poor, the other for the king, the third yours.’ In the meantime it
+struck twelve, and the spirit disappeared, so that the youth stood in
+darkness. ‘I shall still be able to find my way out,’ said he, and felt
+about, found the way into the room, and slept there by his fire.
+Next morning the king came and said: ‘Now you must have learnt what
+shuddering is?’ ‘No,’ he answered; ‘what can it be? My dead cousin was
+here, and a bearded man came and showed me a great deal of money down
+below, but no one told me what it was to shudder.’ ‘Then,’ said the
+king, ‘you have saved the castle, and shall marry my daughter.’ ‘That
+is all very well,’ said he, ‘but still I do not know what it is to
+shudder!’
+
+Then the gold was brought up and the wedding celebrated; but howsoever
+much the young king loved his wife, and however happy he was, he still
+said always: ‘If I could but shudder--if I could but shudder.’ And this
+at last angered her. Her waiting-maid said: ‘I will find a cure for him;
+he shall soon learn what it is to shudder.’ She went out to the stream
+which flowed through the garden, and had a whole bucketful of gudgeons
+brought to her. At night when the young king was sleeping, his wife was
+to draw the clothes off him and empty the bucket full of cold water
+with the gudgeons in it over him, so that the little fishes would
+sprawl about him. Then he woke up and cried: ‘Oh, what makes me shudder
+so?--what makes me shudder so, dear wife? Ah! now I know what it is to
+shudder!’
+
+
+
+
+KING GRISLY-BEARD
+
+A great king of a land far away in the East had a daughter who was very
+beautiful, but so proud, and haughty, and conceited, that none of the
+princes who came to ask her in marriage was good enough for her, and she
+only made sport of them.
+
+Once upon a time the king held a great feast, and asked thither all
+her suitors; and they all sat in a row, ranged according to their
+rank--kings, and princes, and dukes, and earls, and counts, and barons,
+and knights. Then the princess came in, and as she passed by them she
+had something spiteful to say to every one. The first was too fat: ‘He’s
+as round as a tub,’ said she. The next was too tall: ‘What a maypole!’
+said she. The next was too short: ‘What a dumpling!’ said she. The
+fourth was too pale, and she called him ‘Wallface.’ The fifth was too
+red, so she called him ‘Coxcomb.’ The sixth was not straight enough;
+so she said he was like a green stick, that had been laid to dry over
+a baker’s oven. And thus she had some joke to crack upon every one: but
+she laughed more than all at a good king who was there. ‘Look at
+him,’ said she; ‘his beard is like an old mop; he shall be called
+Grisly-beard.’ So the king got the nickname of Grisly-beard.
+
+But the old king was very angry when he saw how his daughter behaved,
+and how she ill-treated all his guests; and he vowed that, willing or
+unwilling, she should marry the first man, be he prince or beggar, that
+came to the door.
+
+Two days after there came by a travelling fiddler, who began to play
+under the window and beg alms; and when the king heard him, he said,
+‘Let him come in.’ So they brought in a dirty-looking fellow; and when
+he had sung before the king and the princess, he begged a boon. Then the
+king said, ‘You have sung so well, that I will give you my daughter for
+your wife.’ The princess begged and prayed; but the king said, ‘I have
+sworn to give you to the first comer, and I will keep my word.’ So words
+and tears were of no avail; the parson was sent for, and she was married
+to the fiddler. When this was over the king said, ‘Now get ready to
+go--you must not stay here--you must travel on with your husband.’
+
+Then the fiddler went his way, and took her with him, and they soon came
+to a great wood. ‘Pray,’ said she, ‘whose is this wood?’ ‘It belongs
+to King Grisly-beard,’ answered he; ‘hadst thou taken him, all had been
+thine.’ ‘Ah! unlucky wretch that I am!’ sighed she; ‘would that I had
+married King Grisly-beard!’ Next they came to some fine meadows. ‘Whose
+are these beautiful green meadows?’ said she. ‘They belong to King
+Grisly-beard, hadst thou taken him, they had all been thine.’ ‘Ah!
+unlucky wretch that I am!’ said she; ‘would that I had married King
+Grisly-beard!’
+
+Then they came to a great city. ‘Whose is this noble city?’ said she.
+‘It belongs to King Grisly-beard; hadst thou taken him, it had all been
+thine.’ ‘Ah! wretch that I am!’ sighed she; ‘why did I not marry King
+Grisly-beard?’ ‘That is no business of mine,’ said the fiddler: ‘why
+should you wish for another husband? Am not I good enough for you?’
+
+At last they came to a small cottage. ‘What a paltry place!’ said she;
+‘to whom does that little dirty hole belong?’ Then the fiddler said,
+‘That is your and my house, where we are to live.’ ‘Where are your
+servants?’ cried she. ‘What do we want with servants?’ said he; ‘you
+must do for yourself whatever is to be done. Now make the fire, and put
+on water and cook my supper, for I am very tired.’ But the princess knew
+nothing of making fires and cooking, and the fiddler was forced to help
+her. When they had eaten a very scanty meal they went to bed; but the
+fiddler called her up very early in the morning to clean the house. Thus
+they lived for two days: and when they had eaten up all there was in the
+cottage, the man said, ‘Wife, we can’t go on thus, spending money and
+earning nothing. You must learn to weave baskets.’ Then he went out and
+cut willows, and brought them home, and she began to weave; but it made
+her fingers very sore. ‘I see this work won’t do,’ said he: ‘try and
+spin; perhaps you will do that better.’ So she sat down and tried to
+spin; but the threads cut her tender fingers till the blood ran. ‘See
+now,’ said the fiddler, ‘you are good for nothing; you can do no work:
+what a bargain I have got! However, I’ll try and set up a trade in pots
+and pans, and you shall stand in the market and sell them.’ ‘Alas!’
+sighed she, ‘if any of my father’s court should pass by and see me
+standing in the market, how they will laugh at me!’
+
+But her husband did not care for that, and said she must work, if she
+did not wish to die of hunger. At first the trade went well; for many
+people, seeing such a beautiful woman, went to buy her wares, and paid
+their money without thinking of taking away the goods. They lived on
+this as long as it lasted; and then her husband bought a fresh lot of
+ware, and she sat herself down with it in the corner of the market; but
+a drunken soldier soon came by, and rode his horse against her stall,
+and broke all her goods into a thousand pieces. Then she began to cry,
+and knew not what to do. ‘Ah! what will become of me?’ said she; ‘what
+will my husband say?’ So she ran home and told him all. ‘Who would
+have thought you would have been so silly,’ said he, ‘as to put an
+earthenware stall in the corner of the market, where everybody passes?
+but let us have no more crying; I see you are not fit for this sort of
+work, so I have been to the king’s palace, and asked if they did not
+want a kitchen-maid; and they say they will take you, and there you will
+have plenty to eat.’
+
+Thus the princess became a kitchen-maid, and helped the cook to do all
+the dirtiest work; but she was allowed to carry home some of the meat
+that was left, and on this they lived.
+
+She had not been there long before she heard that the king’s eldest son
+was passing by, going to be married; and she went to one of the windows
+and looked out. Everything was ready, and all the pomp and brightness of
+the court was there. Then she bitterly grieved for the pride and folly
+which had brought her so low. And the servants gave her some of the rich
+meats, which she put into her basket to take home.
+
+All on a sudden, as she was going out, in came the king’s son in golden
+clothes; and when he saw a beautiful woman at the door, he took her
+by the hand, and said she should be his partner in the dance; but she
+trembled for fear, for she saw that it was King Grisly-beard, who was
+making sport of her. However, he kept fast hold, and led her in; and the
+cover of the basket came off, so that the meats in it fell about. Then
+everybody laughed and jeered at her; and she was so abashed, that she
+wished herself a thousand feet deep in the earth. She sprang to the
+door to run away; but on the steps King Grisly-beard overtook her, and
+brought her back and said, ‘Fear me not! I am the fiddler who has lived
+with you in the hut. I brought you there because I really loved you. I
+am also the soldier that overset your stall. I have done all this only
+to cure you of your silly pride, and to show you the folly of your
+ill-treatment of me. Now all is over: you have learnt wisdom, and it is
+time to hold our marriage feast.’
+
+Then the chamberlains came and brought her the most beautiful robes; and
+her father and his whole court were there already, and welcomed her home
+on her marriage. Joy was in every face and every heart. The feast was
+grand; they danced and sang; all were merry; and I only wish that you
+and I had been of the party.
+
+
+
+
+IRON HANS
+
+There was once upon a time a king who had a great forest near his
+palace, full of all kinds of wild animals. One day he sent out a
+huntsman to shoot him a roe, but he did not come back. ‘Perhaps some
+accident has befallen him,’ said the king, and the next day he sent out
+two more huntsmen who were to search for him, but they too stayed away.
+Then on the third day, he sent for all his huntsmen, and said: ‘Scour
+the whole forest through, and do not give up until you have found all
+three.’ But of these also, none came home again, none were seen again.
+From that time forth, no one would any longer venture into the forest,
+and it lay there in deep stillness and solitude, and nothing was seen
+of it, but sometimes an eagle or a hawk flying over it. This lasted for
+many years, when an unknown huntsman announced himself to the king as
+seeking a situation, and offered to go into the dangerous forest. The
+king, however, would not give his consent, and said: ‘It is not safe in
+there; I fear it would fare with you no better than with the others,
+and you would never come out again.’ The huntsman replied: ‘Lord, I will
+venture it at my own risk, of fear I know nothing.’
+
+The huntsman therefore betook himself with his dog to the forest. It was
+not long before the dog fell in with some game on the way, and wanted to
+pursue it; but hardly had the dog run two steps when it stood before a
+deep pool, could go no farther, and a naked arm stretched itself out of
+the water, seized it, and drew it under. When the huntsman saw that, he
+went back and fetched three men to come with buckets and bale out the
+water. When they could see to the bottom there lay a wild man whose body
+was brown like rusty iron, and whose hair hung over his face down to his
+knees. They bound him with cords, and led him away to the castle. There
+was great astonishment over the wild man; the king, however, had him put
+in an iron cage in his courtyard, and forbade the door to be opened
+on pain of death, and the queen herself was to take the key into her
+keeping. And from this time forth everyone could again go into the
+forest with safety.
+
+The king had a son of eight years, who was once playing in the
+courtyard, and while he was playing, his golden ball fell into the cage.
+The boy ran thither and said: ‘Give me my ball out.’ ‘Not till you have
+opened the door for me,’ answered the man. ‘No,’ said the boy, ‘I will
+not do that; the king has forbidden it,’ and ran away. The next day he
+again went and asked for his ball; the wild man said: ‘Open my door,’
+but the boy would not. On the third day the king had ridden out hunting,
+and the boy went once more and said: ‘I cannot open the door even if I
+wished, for I have not the key.’ Then the wild man said: ‘It lies under
+your mother’s pillow, you can get it there.’ The boy, who wanted to have
+his ball back, cast all thought to the winds, and brought the key. The
+door opened with difficulty, and the boy pinched his fingers. When it
+was open the wild man stepped out, gave him the golden ball, and hurried
+away. The boy had become afraid; he called and cried after him: ‘Oh,
+wild man, do not go away, or I shall be beaten!’ The wild man turned
+back, took him up, set him on his shoulder, and went with hasty steps
+into the forest. When the king came home, he observed the empty cage,
+and asked the queen how that had happened. She knew nothing about it,
+and sought the key, but it was gone. She called the boy, but no one
+answered. The king sent out people to seek for him in the fields, but
+they did not find him. Then he could easily guess what had happened, and
+much grief reigned in the royal court.
+
+When the wild man had once more reached the dark forest, he took the boy
+down from his shoulder, and said to him: ‘You will never see your father
+and mother again, but I will keep you with me, for you have set me free,
+and I have compassion on you. If you do all I bid you, you shall fare
+well. Of treasure and gold have I enough, and more than anyone in the
+world.’ He made a bed of moss for the boy on which he slept, and the
+next morning the man took him to a well, and said: ‘Behold, the gold
+well is as bright and clear as crystal, you shall sit beside it, and
+take care that nothing falls into it, or it will be polluted. I will
+come every evening to see if you have obeyed my order.’ The boy placed
+himself by the brink of the well, and often saw a golden fish or a
+golden snake show itself therein, and took care that nothing fell in.
+As he was thus sitting, his finger hurt him so violently that he
+involuntarily put it in the water. He drew it quickly out again, but saw
+that it was quite gilded, and whatsoever pains he took to wash the gold
+off again, all was to no purpose. In the evening Iron Hans came back,
+looked at the boy, and said: ‘What has happened to the well?’ ‘Nothing
+nothing,’ he answered, and held his finger behind his back, that the
+man might not see it. But he said: ‘You have dipped your finger into
+the water, this time it may pass, but take care you do not again let
+anything go in.’ By daybreak the boy was already sitting by the well and
+watching it. His finger hurt him again and he passed it over his head,
+and then unhappily a hair fell down into the well. He took it quickly
+out, but it was already quite gilded. Iron Hans came, and already knew
+what had happened. ‘You have let a hair fall into the well,’ said he.
+‘I will allow you to watch by it once more, but if this happens for the
+third time then the well is polluted and you can no longer remain with
+me.’
+
+On the third day, the boy sat by the well, and did not stir his finger,
+however much it hurt him. But the time was long to him, and he looked at
+the reflection of his face on the surface of the water. And as he
+still bent down more and more while he was doing so, and trying to look
+straight into the eyes, his long hair fell down from his shoulders into
+the water. He raised himself up quickly, but the whole of the hair of
+his head was already golden and shone like the sun. You can imagine how
+terrified the poor boy was! He took his pocket-handkerchief and tied it
+round his head, in order that the man might not see it. When he came he
+already knew everything, and said: ‘Take the handkerchief off.’ Then the
+golden hair streamed forth, and let the boy excuse himself as he might,
+it was of no use. ‘You have not stood the trial and can stay here no
+longer. Go forth into the world, there you will learn what poverty is.
+But as you have not a bad heart, and as I mean well by you, there is
+one thing I will grant you; if you fall into any difficulty, come to the
+forest and cry: “Iron Hans,” and then I will come and help you. My
+power is great, greater than you think, and I have gold and silver in
+abundance.’
+
+Then the king’s son left the forest, and walked by beaten and unbeaten
+paths ever onwards until at length he reached a great city. There he
+looked for work, but could find none, and he learnt nothing by which he
+could help himself. At length he went to the palace, and asked if they
+would take him in. The people about court did not at all know what use
+they could make of him, but they liked him, and told him to stay. At
+length the cook took him into his service, and said he might carry wood
+and water, and rake the cinders together. Once when it so happened that
+no one else was at hand, the cook ordered him to carry the food to the
+royal table, but as he did not like to let his golden hair be seen, he
+kept his little cap on. Such a thing as that had never yet come under
+the king’s notice, and he said: ‘When you come to the royal table you
+must take your hat off.’ He answered: ‘Ah, Lord, I cannot; I have a bad
+sore place on my head.’ Then the king had the cook called before him
+and scolded him, and asked how he could take such a boy as that into his
+service; and that he was to send him away at once. The cook, however,
+had pity on him, and exchanged him for the gardener’s boy.
+
+And now the boy had to plant and water the garden, hoe and dig, and bear
+the wind and bad weather. Once in summer when he was working alone in
+the garden, the day was so warm he took his little cap off that the air
+might cool him. As the sun shone on his hair it glittered and flashed so
+that the rays fell into the bedroom of the king’s daughter, and up she
+sprang to see what that could be. Then she saw the boy, and cried to
+him: ‘Boy, bring me a wreath of flowers.’ He put his cap on with all
+haste, and gathered wild field-flowers and bound them together. When he
+was ascending the stairs with them, the gardener met him, and said: ‘How
+can you take the king’s daughter a garland of such common flowers? Go
+quickly, and get another, and seek out the prettiest and rarest.’ ‘Oh,
+no,’ replied the boy, ‘the wild ones have more scent, and will please
+her better.’ When he got into the room, the king’s daughter said: ‘Take
+your cap off, it is not seemly to keep it on in my presence.’ He again
+said: ‘I may not, I have a sore head.’ She, however, caught at his
+cap and pulled it off, and then his golden hair rolled down on his
+shoulders, and it was splendid to behold. He wanted to run out, but she
+held him by the arm, and gave him a handful of ducats. With these he
+departed, but he cared nothing for the gold pieces. He took them to the
+gardener, and said: ‘I present them to your children, they can play with
+them.’ The following day the king’s daughter again called to him that he
+was to bring her a wreath of field-flowers, and then he went in with it,
+she instantly snatched at his cap, and wanted to take it away from him,
+but he held it fast with both hands. She again gave him a handful of
+ducats, but he would not keep them, and gave them to the gardener for
+playthings for his children. On the third day things went just the
+same; she could not get his cap away from him, and he would not have her
+money.
+
+Not long afterwards, the country was overrun by war. The king gathered
+together his people, and did not know whether or not he could offer any
+opposition to the enemy, who was superior in strength and had a mighty
+army. Then said the gardener’s boy: ‘I am grown up, and will go to the
+wars also, only give me a horse.’ The others laughed, and said: ‘Seek
+one for yourself when we are gone, we will leave one behind us in the
+stable for you.’ When they had gone forth, he went into the stable, and
+led the horse out; it was lame of one foot, and limped hobblety jib,
+hobblety jib; nevertheless he mounted it, and rode away to the dark
+forest. When he came to the outskirts, he called ‘Iron Hans’ three
+times so loudly that it echoed through the trees. Thereupon the wild man
+appeared immediately, and said: ‘What do you desire?’ ‘I want a strong
+steed, for I am going to the wars.’ ‘That you shall have, and still more
+than you ask for.’ Then the wild man went back into the forest, and it
+was not long before a stable-boy came out of it, who led a horse that
+snorted with its nostrils, and could hardly be restrained, and behind
+them followed a great troop of warriors entirely equipped in iron, and
+their swords flashed in the sun. The youth made over his three-legged
+horse to the stable-boy, mounted the other, and rode at the head of the
+soldiers. When he got near the battlefield a great part of the king’s
+men had already fallen, and little was wanting to make the rest give
+way. Then the youth galloped thither with his iron soldiers, broke like
+a hurricane over the enemy, and beat down all who opposed him. They
+began to flee, but the youth pursued, and never stopped, until there
+was not a single man left. Instead of returning to the king, however, he
+conducted his troop by byways back to the forest, and called forth Iron
+Hans. ‘What do you desire?’ asked the wild man. ‘Take back your horse
+and your troops, and give me my three-legged horse again.’ All that he
+asked was done, and soon he was riding on his three-legged horse. When
+the king returned to his palace, his daughter went to meet him, and
+wished him joy of his victory. ‘I am not the one who carried away the
+victory,’ said he, ‘but a strange knight who came to my assistance with
+his soldiers.’ The daughter wanted to hear who the strange knight was,
+but the king did not know, and said: ‘He followed the enemy, and I did
+not see him again.’ She inquired of the gardener where his boy was, but
+he smiled, and said: ‘He has just come home on his three-legged horse,
+and the others have been mocking him, and crying: “Here comes our
+hobblety jib back again!” They asked, too: “Under what hedge have you
+been lying sleeping all the time?” So he said: “I did the best of all,
+and it would have gone badly without me.” And then he was still more
+ridiculed.’
+
+The king said to his daughter: ‘I will proclaim a great feast that shall
+last for three days, and you shall throw a golden apple. Perhaps the
+unknown man will show himself.’ When the feast was announced, the youth
+went out to the forest, and called Iron Hans. ‘What do you desire?’
+asked he. ‘That I may catch the king’s daughter’s golden apple.’ ‘It is
+as safe as if you had it already,’ said Iron Hans. ‘You shall likewise
+have a suit of red armour for the occasion, and ride on a spirited
+chestnut-horse.’ When the day came, the youth galloped to the spot, took
+his place amongst the knights, and was recognized by no one. The king’s
+daughter came forward, and threw a golden apple to the knights, but none
+of them caught it but he, only as soon as he had it he galloped away.
+
+On the second day Iron Hans equipped him as a white knight, and gave him
+a white horse. Again he was the only one who caught the apple, and
+he did not linger an instant, but galloped off with it. The king grew
+angry, and said: ‘That is not allowed; he must appear before me and tell
+his name.’ He gave the order that if the knight who caught the apple,
+should go away again they should pursue him, and if he would not come
+back willingly, they were to cut him down and stab him.
+
+On the third day, he received from Iron Hans a suit of black armour and
+a black horse, and again he caught the apple. But when he was riding off
+with it, the king’s attendants pursued him, and one of them got so near
+him that he wounded the youth’s leg with the point of his sword. The
+youth nevertheless escaped from them, but his horse leapt so violently
+that the helmet fell from the youth’s head, and they could see that he
+had golden hair. They rode back and announced this to the king.
+
+The following day the king’s daughter asked the gardener about his
+boy. ‘He is at work in the garden; the queer creature has been at the
+festival too, and only came home yesterday evening; he has likewise
+shown my children three golden apples which he has won.’
+
+The king had him summoned into his presence, and he came and again had
+his little cap on his head. But the king’s daughter went up to him and
+took it off, and then his golden hair fell down over his shoulders, and
+he was so handsome that all were amazed. ‘Are you the knight who came
+every day to the festival, always in different colours, and who caught
+the three golden apples?’ asked the king. ‘Yes,’ answered he, ‘and here
+the apples are,’ and he took them out of his pocket, and returned them
+to the king. ‘If you desire further proof, you may see the wound which
+your people gave me when they followed me. But I am likewise the knight
+who helped you to your victory over your enemies.’ ‘If you can perform
+such deeds as that, you are no gardener’s boy; tell me, who is your
+father?’ ‘My father is a mighty king, and gold have I in plenty as great
+as I require.’ ‘I well see,’ said the king, ‘that I owe my thanks to
+you; can I do anything to please you?’ ‘Yes,’ answered he, ‘that indeed
+you can. Give me your daughter to wife.’ The maiden laughed, and said:
+‘He does not stand much on ceremony, but I have already seen by his
+golden hair that he was no gardener’s boy,’ and then she went and
+kissed him. His father and mother came to the wedding, and were in great
+delight, for they had given up all hope of ever seeing their dear
+son again. And as they were sitting at the marriage-feast, the music
+suddenly stopped, the doors opened, and a stately king came in with a
+great retinue. He went up to the youth, embraced him and said: ‘I am
+Iron Hans, and was by enchantment a wild man, but you have set me free;
+all the treasures which I possess, shall be your property.’
+
+
+
+
+CAT-SKIN
+
+There was once a king, whose queen had hair of the purest gold, and was
+so beautiful that her match was not to be met with on the whole face of
+the earth. But this beautiful queen fell ill, and when she felt that her
+end drew near she called the king to her and said, ‘Promise me that you
+will never marry again, unless you meet with a wife who is as beautiful
+as I am, and who has golden hair like mine.’ Then when the king in his
+grief promised all she asked, she shut her eyes and died. But the king
+was not to be comforted, and for a long time never thought of taking
+another wife. At last, however, his wise men said, ‘this will not do;
+the king must marry again, that we may have a queen.’ So messengers were
+sent far and wide, to seek for a bride as beautiful as the late queen.
+But there was no princess in the world so beautiful; and if there had
+been, still there was not one to be found who had golden hair. So the
+messengers came home, and had had all their trouble for nothing.
+
+Now the king had a daughter, who was just as beautiful as her mother,
+and had the same golden hair. And when she was grown up, the king looked
+at her and saw that she was just like this late queen: then he said to
+his courtiers, ‘May I not marry my daughter? She is the very image of my
+dead wife: unless I have her, I shall not find any bride upon the whole
+earth, and you say there must be a queen.’ When the courtiers heard this
+they were shocked, and said, ‘Heaven forbid that a father should marry
+his daughter! Out of so great a sin no good can come.’ And his daughter
+was also shocked, but hoped the king would soon give up such thoughts;
+so she said to him, ‘Before I marry anyone I must have three dresses:
+one must be of gold, like the sun; another must be of shining silver,
+like the moon; and a third must be dazzling as the stars: besides this,
+I want a mantle of a thousand different kinds of fur put together, to
+which every beast in the kingdom must give a part of his skin.’ And thus
+she thought he would think of the matter no more. But the king made the
+most skilful workmen in his kingdom weave the three dresses: one golden,
+like the sun; another silvery, like the moon; and a third sparkling,
+like the stars: and his hunters were told to hunt out all the beasts in
+his kingdom, and to take the finest fur out of their skins: and thus a
+mantle of a thousand furs was made.
+
+When all were ready, the king sent them to her; but she got up in the
+night when all were asleep, and took three of her trinkets, a golden
+ring, a golden necklace, and a golden brooch, and packed the three
+dresses--of the sun, the moon, and the stars--up in a nutshell, and
+wrapped herself up in the mantle made of all sorts of fur, and besmeared
+her face and hands with soot. Then she threw herself upon Heaven for
+help in her need, and went away, and journeyed on the whole night, till
+at last she came to a large wood. As she was very tired, she sat herself
+down in the hollow of a tree and soon fell asleep: and there she slept
+on till it was midday.
+
+Now as the king to whom the wood belonged was hunting in it, his dogs
+came to the tree, and began to snuff about, and run round and round, and
+bark. ‘Look sharp!’ said the king to the huntsmen, ‘and see what sort
+of game lies there.’ And the huntsmen went up to the tree, and when they
+came back again said, ‘In the hollow tree there lies a most wonderful
+beast, such as we never saw before; its skin seems to be of a thousand
+kinds of fur, but there it lies fast asleep.’ ‘See,’ said the king, ‘if
+you can catch it alive, and we will take it with us.’ So the huntsmen
+took it up, and the maiden awoke and was greatly frightened, and said,
+‘I am a poor child that has neither father nor mother left; have pity on
+me and take me with you.’ Then they said, ‘Yes, Miss Cat-skin, you will
+do for the kitchen; you can sweep up the ashes, and do things of that
+sort.’ So they put her into the coach, and took her home to the king’s
+palace. Then they showed her a little corner under the staircase, where
+no light of day ever peeped in, and said, ‘Cat-skin, you may lie and
+sleep there.’ And she was sent into the kitchen, and made to fetch wood
+and water, to blow the fire, pluck the poultry, pick the herbs, sift the
+ashes, and do all the dirty work.
+
+Thus Cat-skin lived for a long time very sorrowfully. ‘Ah! pretty
+princess!’ thought she, ‘what will now become of thee?’ But it happened
+one day that a feast was to be held in the king’s castle, so she said to
+the cook, ‘May I go up a little while and see what is going on? I will
+take care and stand behind the door.’ And the cook said, ‘Yes, you may
+go, but be back again in half an hour’s time, to rake out the ashes.’
+Then she took her little lamp, and went into her cabin, and took off the
+fur skin, and washed the soot from off her face and hands, so that her
+beauty shone forth like the sun from behind the clouds. She next opened
+her nutshell, and brought out of it the dress that shone like the sun,
+and so went to the feast. Everyone made way for her, for nobody knew
+her, and they thought she could be no less than a king’s daughter. But
+the king came up to her, and held out his hand and danced with her; and
+he thought in his heart, ‘I never saw any one half so beautiful.’
+
+When the dance was at an end she curtsied; and when the king looked
+round for her, she was gone, no one knew wither. The guards that stood
+at the castle gate were called in: but they had seen no one. The truth
+was, that she had run into her little cabin, pulled off her dress,
+blackened her face and hands, put on the fur-skin cloak, and was
+Cat-skin again. When she went into the kitchen to her work, and began
+to rake the ashes, the cook said, ‘Let that alone till the morning, and
+heat the king’s soup; I should like to run up now and give a peep: but
+take care you don’t let a hair fall into it, or you will run a chance of
+never eating again.’
+
+As soon as the cook went away, Cat-skin heated the king’s soup, and
+toasted a slice of bread first, as nicely as ever she could; and when it
+was ready, she went and looked in the cabin for her little golden ring,
+and put it into the dish in which the soup was. When the dance was over,
+the king ordered his soup to be brought in; and it pleased him so well,
+that he thought he had never tasted any so good before. At the bottom
+he saw a gold ring lying; and as he could not make out how it had got
+there, he ordered the cook to be sent for. The cook was frightened when
+he heard the order, and said to Cat-skin, ‘You must have let a hair fall
+into the soup; if it be so, you will have a good beating.’ Then he went
+before the king, and he asked him who had cooked the soup. ‘I did,’
+answered the cook. But the king said, ‘That is not true; it was better
+done than you could do it.’ Then he answered, ‘To tell the truth I did
+not cook it, but Cat-skin did.’ ‘Then let Cat-skin come up,’ said the
+king: and when she came he said to her, ‘Who are you?’ ‘I am a poor
+child,’ said she, ‘that has lost both father and mother.’ ‘How came you
+in my palace?’ asked he. ‘I am good for nothing,’ said she, ‘but to be
+scullion-girl, and to have boots and shoes thrown at my head.’ ‘But how
+did you get the ring that was in the soup?’ asked the king. Then she
+would not own that she knew anything about the ring; so the king sent
+her away again about her business.
+
+After a time there was another feast, and Cat-skin asked the cook to let
+her go up and see it as before. ‘Yes,’ said he, ‘but come again in half
+an hour, and cook the king the soup that he likes so much.’ Then she
+ran to her little cabin, washed herself quickly, and took her dress
+out which was silvery as the moon, and put it on; and when she went in,
+looking like a king’s daughter, the king went up to her, and rejoiced at
+seeing her again, and when the dance began he danced with her. After the
+dance was at an end she managed to slip out, so slyly that the king did
+not see where she was gone; but she sprang into her little cabin, and
+made herself into Cat-skin again, and went into the kitchen to cook the
+soup. Whilst the cook was above stairs, she got the golden necklace and
+dropped it into the soup; then it was brought to the king, who ate it,
+and it pleased him as well as before; so he sent for the cook, who
+was again forced to tell him that Cat-skin had cooked it. Cat-skin was
+brought again before the king, but she still told him that she was only
+fit to have boots and shoes thrown at her head.
+
+But when the king had ordered a feast to be got ready for the third
+time, it happened just the same as before. ‘You must be a witch,
+Cat-skin,’ said the cook; ‘for you always put something into your soup,
+so that it pleases the king better than mine.’ However, he let her go up
+as before. Then she put on her dress which sparkled like the stars, and
+went into the ball-room in it; and the king danced with her again, and
+thought she had never looked so beautiful as she did then. So whilst
+he was dancing with her, he put a gold ring on her finger without her
+seeing it, and ordered that the dance should be kept up a long time.
+When it was at an end, he would have held her fast by the hand, but she
+slipped away, and sprang so quickly through the crowd that he lost sight
+of her: and she ran as fast as she could into her little cabin under
+the stairs. But this time she kept away too long, and stayed beyond the
+half-hour; so she had not time to take off her fine dress, and threw her
+fur mantle over it, and in her haste did not blacken herself all over
+with soot, but left one of her fingers white.
+
+Then she ran into the kitchen, and cooked the king’s soup; and as soon
+as the cook was gone, she put the golden brooch into the dish. When the
+king got to the bottom, he ordered Cat-skin to be called once more, and
+soon saw the white finger, and the ring that he had put on it whilst
+they were dancing: so he seized her hand, and kept fast hold of it, and
+when she wanted to loose herself and spring away, the fur cloak fell off
+a little on one side, and the starry dress sparkled underneath it.
+
+Then he got hold of the fur and tore it off, and her golden hair and
+beautiful form were seen, and she could no longer hide herself: so she
+washed the soot and ashes from her face, and showed herself to be the
+most beautiful princess upon the face of the earth. But the king said,
+‘You are my beloved bride, and we will never more be parted from each
+other.’ And the wedding feast was held, and a merry day it was, as ever
+was heard of or seen in that country, or indeed in any other.
+
+
+
+
+SNOW-WHITE AND ROSE-RED
+
+There was once a poor widow who lived in a lonely cottage. In front of
+the cottage was a garden wherein stood two rose-trees, one of which bore
+white and the other red roses. She had two children who were like the
+two rose-trees, and one was called Snow-white, and the other Rose-red.
+They were as good and happy, as busy and cheerful as ever two children
+in the world were, only Snow-white was more quiet and gentle than
+Rose-red. Rose-red liked better to run about in the meadows and fields
+seeking flowers and catching butterflies; but Snow-white sat at home
+with her mother, and helped her with her housework, or read to her when
+there was nothing to do.
+
+The two children were so fond of one another that they always held each
+other by the hand when they went out together, and when Snow-white said:
+‘We will not leave each other,’ Rose-red answered: ‘Never so long as we
+live,’ and their mother would add: ‘What one has she must share with the
+other.’
+
+They often ran about the forest alone and gathered red berries, and no
+beasts did them any harm, but came close to them trustfully. The little
+hare would eat a cabbage-leaf out of their hands, the roe grazed by
+their side, the stag leapt merrily by them, and the birds sat still upon
+the boughs, and sang whatever they knew.
+
+No mishap overtook them; if they had stayed too late in the forest, and
+night came on, they laid themselves down near one another upon the moss,
+and slept until morning came, and their mother knew this and did not
+worry on their account.
+
+Once when they had spent the night in the wood and the dawn had roused
+them, they saw a beautiful child in a shining white dress sitting near
+their bed. He got up and looked quite kindly at them, but said nothing
+and went into the forest. And when they looked round they found that
+they had been sleeping quite close to a precipice, and would certainly
+have fallen into it in the darkness if they had gone only a few paces
+further. And their mother told them that it must have been the angel who
+watches over good children.
+
+Snow-white and Rose-red kept their mother’s little cottage so neat that
+it was a pleasure to look inside it. In the summer Rose-red took care
+of the house, and every morning laid a wreath of flowers by her mother’s
+bed before she awoke, in which was a rose from each tree. In the winter
+Snow-white lit the fire and hung the kettle on the hob. The kettle
+was of brass and shone like gold, so brightly was it polished. In the
+evening, when the snowflakes fell, the mother said: ‘Go, Snow-white, and
+bolt the door,’ and then they sat round the hearth, and the mother took
+her spectacles and read aloud out of a large book, and the two girls
+listened as they sat and spun. And close by them lay a lamb upon the
+floor, and behind them upon a perch sat a white dove with its head
+hidden beneath its wings.
+
+One evening, as they were thus sitting comfortably together, someone
+knocked at the door as if he wished to be let in. The mother said:
+‘Quick, Rose-red, open the door, it must be a traveller who is seeking
+shelter.’ Rose-red went and pushed back the bolt, thinking that it was a
+poor man, but it was not; it was a bear that stretched his broad, black
+head within the door.
+
+Rose-red screamed and sprang back, the lamb bleated, the dove fluttered,
+and Snow-white hid herself behind her mother’s bed. But the bear began
+to speak and said: ‘Do not be afraid, I will do you no harm! I am
+half-frozen, and only want to warm myself a little beside you.’
+
+‘Poor bear,’ said the mother, ‘lie down by the fire, only take care that
+you do not burn your coat.’ Then she cried: ‘Snow-white, Rose-red, come
+out, the bear will do you no harm, he means well.’ So they both came
+out, and by-and-by the lamb and dove came nearer, and were not afraid
+of him. The bear said: ‘Here, children, knock the snow out of my coat a
+little’; so they brought the broom and swept the bear’s hide clean;
+and he stretched himself by the fire and growled contentedly and
+comfortably. It was not long before they grew quite at home, and played
+tricks with their clumsy guest. They tugged his hair with their hands,
+put their feet upon his back and rolled him about, or they took a
+hazel-switch and beat him, and when he growled they laughed. But the
+bear took it all in good part, only when they were too rough he called
+out: ‘Leave me alive, children,
+
+  Snow-white, Rose-red,
+  Will you beat your wooer dead?’
+
+When it was bed-time, and the others went to bed, the mother said to the
+bear: ‘You can lie there by the hearth, and then you will be safe from
+the cold and the bad weather.’ As soon as day dawned the two children
+let him out, and he trotted across the snow into the forest.
+
+Henceforth the bear came every evening at the same time, laid himself
+down by the hearth, and let the children amuse themselves with him as
+much as they liked; and they got so used to him that the doors were
+never fastened until their black friend had arrived.
+
+When spring had come and all outside was green, the bear said one
+morning to Snow-white: ‘Now I must go away, and cannot come back for the
+whole summer.’ ‘Where are you going, then, dear bear?’ asked Snow-white.
+‘I must go into the forest and guard my treasures from the wicked
+dwarfs. In the winter, when the earth is frozen hard, they are obliged
+to stay below and cannot work their way through; but now, when the sun
+has thawed and warmed the earth, they break through it, and come out to
+pry and steal; and what once gets into their hands, and in their caves,
+does not easily see daylight again.’
+
+Snow-white was quite sorry at his departure, and as she unbolted the
+door for him, and the bear was hurrying out, he caught against the bolt
+and a piece of his hairy coat was torn off, and it seemed to Snow-white
+as if she had seen gold shining through it, but she was not sure about
+it. The bear ran away quickly, and was soon out of sight behind the
+trees.
+
+A short time afterwards the mother sent her children into the forest
+to get firewood. There they found a big tree which lay felled on the
+ground, and close by the trunk something was jumping backwards and
+forwards in the grass, but they could not make out what it was. When
+they came nearer they saw a dwarf with an old withered face and a
+snow-white beard a yard long. The end of the beard was caught in a
+crevice of the tree, and the little fellow was jumping about like a dog
+tied to a rope, and did not know what to do.
+
+He glared at the girls with his fiery red eyes and cried: ‘Why do you
+stand there? Can you not come here and help me?’ ‘What are you up to,
+little man?’ asked Rose-red. ‘You stupid, prying goose!’ answered the
+dwarf: ‘I was going to split the tree to get a little wood for cooking.
+The little bit of food that we people get is immediately burnt up with
+heavy logs; we do not swallow so much as you coarse, greedy folk. I had
+just driven the wedge safely in, and everything was going as I wished;
+but the cursed wedge was too smooth and suddenly sprang out, and the
+tree closed so quickly that I could not pull out my beautiful white
+beard; so now it is tight and I cannot get away, and the silly, sleek,
+milk-faced things laugh! Ugh! how odious you are!’
+
+The children tried very hard, but they could not pull the beard out, it
+was caught too fast. ‘I will run and fetch someone,’ said Rose-red. ‘You
+senseless goose!’ snarled the dwarf; ‘why should you fetch someone? You
+are already two too many for me; can you not think of something better?’
+‘Don’t be impatient,’ said Snow-white, ‘I will help you,’ and she pulled
+her scissors out of her pocket, and cut off the end of the beard.
+
+As soon as the dwarf felt himself free he laid hold of a bag which lay
+amongst the roots of the tree, and which was full of gold, and lifted it
+up, grumbling to himself: ‘Uncouth people, to cut off a piece of my fine
+beard. Bad luck to you!’ and then he swung the bag upon his back, and
+went off without even once looking at the children.
+
+Some time afterwards Snow-white and Rose-red went to catch a dish
+of fish. As they came near the brook they saw something like a large
+grasshopper jumping towards the water, as if it were going to leap in.
+They ran to it and found it was the dwarf. ‘Where are you going?’ said
+Rose-red; ‘you surely don’t want to go into the water?’ ‘I am not such
+a fool!’ cried the dwarf; ‘don’t you see that the accursed fish wants
+to pull me in?’ The little man had been sitting there fishing, and
+unluckily the wind had tangled up his beard with the fishing-line; a
+moment later a big fish made a bite and the feeble creature had not
+strength to pull it out; the fish kept the upper hand and pulled the
+dwarf towards him. He held on to all the reeds and rushes, but it was of
+little good, for he was forced to follow the movements of the fish, and
+was in urgent danger of being dragged into the water.
+
+The girls came just in time; they held him fast and tried to free his
+beard from the line, but all in vain, beard and line were entangled fast
+together. There was nothing to do but to bring out the scissors and cut
+the beard, whereby a small part of it was lost. When the dwarf saw that
+he screamed out: ‘Is that civil, you toadstool, to disfigure a man’s
+face? Was it not enough to clip off the end of my beard? Now you have
+cut off the best part of it. I cannot let myself be seen by my people.
+I wish you had been made to run the soles off your shoes!’ Then he took
+out a sack of pearls which lay in the rushes, and without another word
+he dragged it away and disappeared behind a stone.
+
+It happened that soon afterwards the mother sent the two children to the
+town to buy needles and thread, and laces and ribbons. The road led them
+across a heath upon which huge pieces of rock lay strewn about. There
+they noticed a large bird hovering in the air, flying slowly round and
+round above them; it sank lower and lower, and at last settled near a
+rock not far away. Immediately they heard a loud, piteous cry. They ran
+up and saw with horror that the eagle had seized their old acquaintance
+the dwarf, and was going to carry him off.
+
+The children, full of pity, at once took tight hold of the little man,
+and pulled against the eagle so long that at last he let his booty go.
+As soon as the dwarf had recovered from his first fright he cried
+with his shrill voice: ‘Could you not have done it more carefully! You
+dragged at my brown coat so that it is all torn and full of holes, you
+clumsy creatures!’ Then he took up a sack full of precious stones, and
+slipped away again under the rock into his hole. The girls, who by
+this time were used to his ingratitude, went on their way and did their
+business in town.
+
+As they crossed the heath again on their way home they surprised the
+dwarf, who had emptied out his bag of precious stones in a clean spot,
+and had not thought that anyone would come there so late. The evening
+sun shone upon the brilliant stones; they glittered and sparkled with
+all colours so beautifully that the children stood still and stared
+at them. ‘Why do you stand gaping there?’ cried the dwarf, and his
+ashen-grey face became copper-red with rage. He was still cursing when a
+loud growling was heard, and a black bear came trotting towards them out
+of the forest. The dwarf sprang up in a fright, but he could not reach
+his cave, for the bear was already close. Then in the dread of his heart
+he cried: ‘Dear Mr Bear, spare me, I will give you all my treasures;
+look, the beautiful jewels lying there! Grant me my life; what do you
+want with such a slender little fellow as I? you would not feel me
+between your teeth. Come, take these two wicked girls, they are tender
+morsels for you, fat as young quails; for mercy’s sake eat them!’ The
+bear took no heed of his words, but gave the wicked creature a single
+blow with his paw, and he did not move again.
+
+The girls had run away, but the bear called to them: ‘Snow-white and
+Rose-red, do not be afraid; wait, I will come with you.’ Then they
+recognized his voice and waited, and when he came up to them suddenly
+his bearskin fell off, and he stood there a handsome man, clothed all in
+gold. ‘I am a king’s son,’ he said, ‘and I was bewitched by that wicked
+dwarf, who had stolen my treasures; I have had to run about the forest
+as a savage bear until I was freed by his death. Now he has got his
+well-deserved punishment.
+
+Snow-white was married to him, and Rose-red to his brother, and they
+divided between them the great treasure which the dwarf had gathered
+together in his cave. The old mother lived peacefully and happily with
+her children for many years. She took the two rose-trees with her, and
+they stood before her window, and every year bore the most beautiful
+roses, white and red.
+
+
+*****
+
+
+The Brothers Grimm, Jacob (1785-1863) and Wilhelm (1786-1859), were born
+in Hanau, near Frankfurt, in the German state of Hesse. Throughout
+their lives they remained close friends, and both studied law at Marburg
+University. Jacob was a pioneer in the study of German philology,
+and although Wilhelm’s work was hampered by poor health the brothers
+collaborated in the creation of a German dictionary, not completed until
+a century after their deaths. But they were best (and universally) known
+for the collection of over two hundred folk tales they made from oral
+sources and published in two volumes of ‘Nursery and Household Tales’ in
+1812 and 1814. Although their intention was to preserve such material as
+part of German cultural and literary history, and their collection was
+first published with scholarly notes and no illustration, the tales soon
+came into the possession of young readers. This was in part due to Edgar
+Taylor, who made the first English translation in 1823, selecting about
+fifty stories ‘with the amusement of some young friends principally in
+view.’ They have been an essential ingredient of children’s reading ever
+since.
+
+
+
+
+
+End of Project Gutenberg’s Grimms’ Fairy Tales, by The Brothers Grimm
+
+*** END OF THIS PROJECT GUTENBERG EBOOK GRIMMS’ FAIRY TALES ***
+
+***** This file should be named 2591-0.txt or 2591-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/5/9/2591/
+
+Produced by Emma Dudding, John Bickers, and Dagny
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/huckleberry-finn.txt
+++ b/jet/tf-idf/src/main/resources/books/huckleberry-finn.txt
@@ -1,0 +1,12363 @@
+﻿
+
+The Project Gutenberg EBook of Adventures of Huckleberry Finn, Complete
+by Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: Adventures of Huckleberry Finn, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #76]
+
+Last Updated: August 17, 2016]
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+Produced by David Widger
+
+
+
+
+
+ADVENTURES
+
+OF
+
+HUCKLEBERRY FINN
+
+(Tom Sawyer’s Comrade)
+
+By Mark Twain
+
+Complete
+
+
+
+
+CONTENTS.
+
+CHAPTER I. Civilizing Huck.--Miss Watson.--Tom Sawyer Waits.
+
+CHAPTER II. The Boys Escape Jim.--Torn Sawyer’s Gang.--Deep-laid Plans.
+
+CHAPTER III. A Good Going-over.--Grace Triumphant.--“One of Tom Sawyers’s
+Lies”.
+
+CHAPTER IV. Huck and the Judge.--Superstition.
+
+CHAPTER V. Huck’s Father.--The Fond Parent.--Reform.
+
+CHAPTER VI. He Went for Judge Thatcher.--Huck Decided to Leave.--Political
+Economy.--Thrashing Around.
+
+CHAPTER VII. Laying for Him.--Locked in the Cabin.--Sinking the
+Body.--Resting.
+
+CHAPTER VIII. Sleeping in the Woods.--Raising the Dead.--Exploring the
+Island.--Finding Jim.--Jim’s Escape.--Signs.--Balum.
+
+CHAPTER IX. The Cave.--The Floating House.
+
+CHAPTER X. The Find.--Old Hank Bunker.--In Disguise.
+
+CHAPTER XI. Huck and the Woman.--The Search.--Prevarication.--Going to
+Goshen.
+
+CHAPTER XII. Slow Navigation.--Borrowing Things.--Boarding the Wreck.--The
+Plotters.--Hunting for the Boat.
+
+CHAPTER XIII. Escaping from the Wreck.--The Watchman.--Sinking.
+
+CHAPTER XIV. A General Good Time.--The Harem.--French.
+
+CHAPTER XV. Huck Loses the Raft.--In the Fog.--Huck Finds the Raft.--Trash.
+
+CHAPTER XVI. Expectation.--A White Lie.--Floating Currency.--Running by
+Cairo.--Swimming Ashore.
+
+CHAPTER XVII. An Evening Call.--The Farm in Arkansaw.--Interior
+Decorations.--Stephen Dowling Bots.--Poetical Effusions.
+
+CHAPTER XVIII. Col. Grangerford.--Aristocracy.--Feuds.--The
+Testament.--Recovering the Raft.--The Wood--pile.--Pork and Cabbage.
+
+CHAPTER XIX. Tying Up Day--times.--An Astronomical Theory.--Running a
+Temperance Revival.--The Duke of Bridgewater.--The Troubles of Royalty.
+
+CHAPTER XX. Huck Explains.--Laying Out a Campaign.--Working the
+Camp--meeting.--A Pirate at the Camp--meeting.--The Duke as a Printer.
+
+CHAPTER XXI. Sword Exercise.--Hamlet’s Soliloquy.--They Loafed Around
+Town.--A Lazy Town.--Old Boggs.--Dead.
+
+CHAPTER XXII. Sherburn.--Attending the Circus.--Intoxication in the
+Ring.--The Thrilling Tragedy.
+
+CHAPTER XXIII. Sold.--Royal Comparisons.--Jim Gets Home-sick.
+
+CHAPTER XXIV. Jim in Royal Robes.--They Take a Passenger.--Getting
+Information.--Family Grief.
+
+CHAPTER XXV. Is It Them?--Singing the “Doxologer.”--Awful Square--Funeral
+Orgies.--A Bad Investment .
+
+CHAPTER XXVI. A Pious King.--The King’s Clergy.--She Asked His
+Pardon.--Hiding in the Room.--Huck Takes the Money.
+
+CHAPTER XXVII. The Funeral.--Satisfying Curiosity.--Suspicious of
+Huck,--Quick Sales and Small.
+
+CHAPTER XXVIII. The Trip to England.--“The Brute!”--Mary Jane Decides to
+Leave.--Huck Parting with Mary Jane.--Mumps.--The Opposition Line.
+
+CHAPTER XXIX. Contested Relationship.--The King Explains the Loss.--A
+Question of Handwriting.--Digging up the Corpse.--Huck Escapes.
+
+CHAPTER XXX. The King Went for Him.--A Royal Row.--Powerful Mellow.
+
+CHAPTER XXXI. Ominous Plans.--News from Jim.--Old Recollections.--A Sheep
+Story.--Valuable Information.
+
+CHAPTER XXXII. Still and Sunday--like.--Mistaken Identity.--Up a Stump.--In
+a Dilemma.
+
+CHAPTER XXXIII. A Nigger Stealer.--Southern Hospitality.--A Pretty Long
+Blessing.--Tar and Feathers.
+
+CHAPTER XXXIV. The Hut by the Ash Hopper.--Outrageous.--Climbing the
+Lightning Rod.--Troubled with Witches.
+
+CHAPTER XXXV. Escaping Properly.--Dark Schemes.--Discrimination in
+Stealing.--A Deep Hole.
+
+CHAPTER XXXVI. The Lightning Rod.--His Level Best.--A Bequest to
+Posterity.--A High Figure.
+
+CHAPTER XXXVII. The Last Shirt.--Mooning Around.--Sailing Orders.--The
+Witch Pie.
+
+CHAPTER XXXVIII. The Coat of Arms.--A Skilled Superintendent.--Unpleasant
+Glory.--A Tearful Subject.
+
+CHAPTER XXXIX. Rats.--Lively Bed--fellows.--The Straw Dummy.
+
+CHAPTER XL. Fishing.--The Vigilance Committee.--A Lively Run.--Jim Advises
+a Doctor.
+
+CHAPTER XLI. The Doctor.--Uncle Silas.--Sister Hotchkiss.--Aunt Sally in
+Trouble.
+
+CHAPTER XLII. Tom Sawyer Wounded.--The Doctor’s Story.--Tom
+Confesses.--Aunt Polly Arrives.--Hand Out Them Letters    .
+
+CHAPTER THE LAST. Out of Bondage.--Paying the Captive.--Yours Truly, Huck
+Finn.
+
+
+
+
+ILLUSTRATIONS.
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+The Widows
+
+Moses and the “Bulrushers”
+
+Miss Watson
+
+Huck Stealing Away
+
+They Tip-toed Along
+
+Jim
+
+Tom Sawyer’s Band of Robbers  
+
+Huck Creeps into his Window
+
+Miss Watson’s Lecture
+
+The Robbers Dispersed
+
+Rubbing the Lamp
+
+! ! ! !
+
+Judge Thatcher surprised
+
+Jim Listening
+
+“Pap”
+
+Huck and his Father
+
+Reforming the Drunkard
+
+Falling from Grace
+
+Getting out of the Way
+
+Solid Comfort
+
+Thinking it Over
+
+Raising a Howl
+
+“Git Up”
+
+The Shanty
+
+Shooting the Pig
+
+Taking a Rest
+
+In the Woods
+
+Watching the Boat
+
+Discovering the Camp Fire
+
+Jim and the Ghost
+
+Misto Bradish’s Nigger
+
+Exploring the Cave
+
+In the Cave
+
+Jim sees a Dead Man
+
+They Found Eight Dollars
+
+Jim and the Snake
+
+Old Hank Bunker
+
+“A Fair Fit”
+
+“Come In”
+
+“Him and another Man”
+
+She puts up a Snack
+
+“Hump Yourself”
+
+On the Raft
+
+He sometimes Lifted a Chicken
+
+“Please don’t, Bill”
+
+“It ain’t Good Morals”
+
+“Oh! Lordy, Lordy!”
+
+In a Fix
+
+“Hello, What’s Up?”
+
+The Wreck
+
+We turned in and Slept
+
+Turning over the Truck
+
+Solomon and his Million Wives
+
+The story of “Sollermun”
+
+“We Would Sell the Raft”
+
+Among the Snags
+
+Asleep on the Raft
+
+“Something being Raftsman”
+
+“Boy, that’s a Lie”
+
+“Here I is, Huck”
+
+Climbing up the Bank
+
+“Who’s There?”
+
+“Buck”
+
+“It made Her look Spidery”
+
+“They got him out and emptied Him”  
+
+The House
+
+Col. Grangerford
+
+Young Harney Shepherdson
+
+Miss Charlotte
+
+“And asked me if I Liked Her”
+
+“Behind the Wood-pile”
+
+Hiding Day-times
+
+“And Dogs a-Coming”
+
+“By rights I am a Duke!”
+
+“I am the Late Dauphin”
+
+Tail Piece
+
+On the Raft
+
+The King as Juliet
+
+“Courting on the Sly”
+
+“A Pirate for Thirty Years”
+
+Another little Job
+
+Practizing
+
+Hamlet’s Soliloquy
+
+“Gimme a Chaw”
+
+A Little Monthly Drunk
+
+The Death of Boggs
+
+Sherburn steps out
+
+A Dead Head
+
+He shed Seventeen Suits
+
+Tragedy
+
+Their Pockets Bulged
+
+Henry the Eighth in Boston Harbor
+
+Harmless
+
+Adolphus
+
+He fairly emptied that Young Fellow
+
+“Alas, our Poor Brother”
+
+“You Bet it is”
+
+Leaking
+
+Making up the “Deffisit”
+
+Going for him
+
+The Doctor
+
+The Bag of Money
+
+The Cubby
+
+Supper with the Hare-Lip
+
+Honest Injun
+
+The Duke looks under the Bed
+
+Huck takes the Money
+
+A Crack in the Dining-room Door
+
+The Undertaker
+
+“He had a Rat!”
+
+“Was you in my Room?”
+
+Jawing
+
+In Trouble
+
+Indignation
+
+How to Find Them
+
+He Wrote
+
+Hannah with the Mumps
+
+The Auction
+
+The True Brothers
+
+The Doctor leads Huck
+
+The Duke Wrote
+
+“Gentlemen, Gentlemen!”
+
+“Jim Lit Out”
+
+The King shakes Huck
+
+The Duke went for Him
+
+Spanish Moss
+
+“Who Nailed Him?”
+
+Thinking
+
+He gave him Ten Cents
+
+Striking for the Back Country
+
+Still and Sunday-like
+
+She hugged him tight
+
+“Who do you reckon it is?”
+
+“It was Tom Sawyer”
+
+“Mr. Archibald Nichols, I presume?”
+
+A pretty long Blessing
+
+Traveling By Rail
+
+Vittles
+
+A Simple Job
+
+Witches
+
+Getting Wood
+
+One of the Best Authorities
+
+The Breakfast-Horn
+
+Smouching the Knives
+
+Going down the Lightning-Rod
+
+Stealing spoons
+
+Tom advises a Witch Pie
+
+The Rubbage-Pile
+
+“Missus, dey’s a Sheet Gone”
+
+In a Tearing Way
+
+One of his Ancestors
+
+Jim’s Coat of Arms
+
+A Tough Job
+
+Buttons on their Tails
+
+Irrigation
+
+Keeping off Dull Times
+
+Sawdust Diet
+
+Trouble is Brewing
+
+Fishing
+
+Every one had a Gun
+
+Tom caught on a Splinter
+
+Jim advises a Doctor
+
+The Doctor
+
+Uncle Silas in Danger
+
+Old Mrs. Hotchkiss
+
+Aunt Sally talks to Huck
+
+Tom Sawyer wounded
+
+The Doctor speaks for Jim
+
+Tom rose square up in Bed
+
+“Hand out them Letters”
+
+Out of Bondage
+
+Tom’s Liberality
+
+Yours Truly
+
+
+
+
+EXPLANATORY
+
+IN this book a number of dialects are used, to wit:  the Missouri negro
+dialect; the extremest form of the backwoods Southwestern dialect; the
+ordinary “Pike County” dialect; and four modified varieties of this
+last. The shadings have not been done in a haphazard fashion, or by
+guesswork; but painstakingly, and with the trustworthy guidance and
+support of personal familiarity with these several forms of speech.
+
+I make this explanation for the reason that without it many readers
+would suppose that all these characters were trying to talk alike and
+not succeeding.
+
+THE AUTHOR.
+
+
+
+
+HUCKLEBERRY FINN
+
+Scene:  The Mississippi Valley Time:  Forty to fifty years ago
+
+
+
+
+CHAPTER I.
+
+YOU don’t know about me without you have read a book by the name of The
+Adventures of Tom Sawyer; but that ain’t no matter.  That book was made
+by Mr. Mark Twain, and he told the truth, mainly.  There was things
+which he stretched, but mainly he told the truth.  That is nothing.  I
+never seen anybody but lied one time or another, without it was Aunt
+Polly, or the widow, or maybe Mary.  Aunt Polly--Tom’s Aunt Polly, she
+is--and Mary, and the Widow Douglas is all told about in that book, which
+is mostly a true book, with some stretchers, as I said before.
+
+Now the way that the book winds up is this:  Tom and me found the money
+that the robbers hid in the cave, and it made us rich.  We got six
+thousand dollars apiece--all gold.  It was an awful sight of money when
+it was piled up.  Well, Judge Thatcher he took it and put it out
+at interest, and it fetched us a dollar a day apiece all the year
+round--more than a body could tell what to do with.  The Widow Douglas
+she took me for her son, and allowed she would sivilize me; but it was
+rough living in the house all the time, considering how dismal regular
+and decent the widow was in all her ways; and so when I couldn’t stand
+it no longer I lit out.  I got into my old rags and my sugar-hogshead
+again, and was free and satisfied.  But Tom Sawyer he hunted me up and
+said he was going to start a band of robbers, and I might join if I
+would go back to the widow and be respectable.  So I went back.
+
+The widow she cried over me, and called me a poor lost lamb, and she
+called me a lot of other names, too, but she never meant no harm by
+it. She put me in them new clothes again, and I couldn’t do nothing but
+sweat and sweat, and feel all cramped up.  Well, then, the old thing
+commenced again.  The widow rung a bell for supper, and you had to come
+to time. When you got to the table you couldn’t go right to eating, but
+you had to wait for the widow to tuck down her head and grumble a little
+over the victuals, though there warn’t really anything the matter with
+them,--that is, nothing only everything was cooked by itself.  In a
+barrel of odds and ends it is different; things get mixed up, and the
+juice kind of swaps around, and the things go better.
+
+After supper she got out her book and learned me about Moses and the
+Bulrushers, and I was in a sweat to find out all about him; but by and
+by she let it out that Moses had been dead a considerable long time; so
+then I didn’t care no more about him, because I don’t take no stock in
+dead people.
+
+Pretty soon I wanted to smoke, and asked the widow to let me.  But she
+wouldn’t.  She said it was a mean practice and wasn’t clean, and I must
+try to not do it any more.  That is just the way with some people.  They
+get down on a thing when they don’t know nothing about it.  Here she was
+a-bothering about Moses, which was no kin to her, and no use to anybody,
+being gone, you see, yet finding a power of fault with me for doing a
+thing that had some good in it.  And she took snuff, too; of course that
+was all right, because she done it herself.
+
+Her sister, Miss Watson, a tolerable slim old maid, with goggles on,
+had just come to live with her, and took a set at me now with a
+spelling-book. She worked me middling hard for about an hour, and then
+the widow made her ease up.  I couldn’t stood it much longer.  Then for
+an hour it was deadly dull, and I was fidgety.  Miss Watson would say,
+“Don’t put your feet up there, Huckleberry;” and “Don’t scrunch up
+like that, Huckleberry--set up straight;” and pretty soon she would
+say, “Don’t gap and stretch like that, Huckleberry--why don’t you try to
+behave?”  Then she told me all about the bad place, and I said I wished
+I was there. She got mad then, but I didn’t mean no harm.  All I wanted
+was to go somewheres; all I wanted was a change, I warn’t particular.
+ She said it was wicked to say what I said; said she wouldn’t say it for
+the whole world; she was going to live so as to go to the good place.
+ Well, I couldn’t see no advantage in going where she was going, so I
+made up my mind I wouldn’t try for it.  But I never said so, because it
+would only make trouble, and wouldn’t do no good.
+
+Now she had got a start, and she went on and told me all about the good
+place.  She said all a body would have to do there was to go around all
+day long with a harp and sing, forever and ever.  So I didn’t think
+much of it. But I never said so.  I asked her if she reckoned Tom Sawyer
+would go there, and she said not by a considerable sight.  I was glad
+about that, because I wanted him and me to be together.
+
+Miss Watson she kept pecking at me, and it got tiresome and lonesome.
+ By and by they fetched the niggers in and had prayers, and then
+everybody was off to bed.  I went up to my room with a piece of candle,
+and put it on the table.  Then I set down in a chair by the window and
+tried to think of something cheerful, but it warn’t no use.  I felt
+so lonesome I most wished I was dead.  The stars were shining, and the
+leaves rustled in the woods ever so mournful; and I heard an owl, away
+off, who-whooing about somebody that was dead, and a whippowill and a
+dog crying about somebody that was going to die; and the wind was trying
+to whisper something to me, and I couldn’t make out what it was, and so
+it made the cold shivers run over me. Then away out in the woods I heard
+that kind of a sound that a ghost makes when it wants to tell about
+something that’s on its mind and can’t make itself understood, and so
+can’t rest easy in its grave, and has to go about that way every night
+grieving.  I got so down-hearted and scared I did wish I had some
+company.  Pretty soon a spider went crawling up my shoulder, and I
+flipped it off and it lit in the candle; and before I could budge it
+was all shriveled up.  I didn’t need anybody to tell me that that was
+an awful bad sign and would fetch me some bad luck, so I was scared
+and most shook the clothes off of me. I got up and turned around in my
+tracks three times and crossed my breast every time; and then I tied
+up a little lock of my hair with a thread to keep witches away.  But
+I hadn’t no confidence.  You do that when you’ve lost a horseshoe that
+you’ve found, instead of nailing it up over the door, but I hadn’t ever
+heard anybody say it was any way to keep off bad luck when you’d killed
+a spider.
+
+I set down again, a-shaking all over, and got out my pipe for a smoke;
+for the house was all as still as death now, and so the widow wouldn’t
+know. Well, after a long time I heard the clock away off in the town
+go boom--boom--boom--twelve licks; and all still again--stiller than
+ever. Pretty soon I heard a twig snap down in the dark amongst the
+trees--something was a stirring.  I set still and listened.  Directly I
+could just barely hear a “me-yow! me-yow!” down there.  That was good!
+ Says I, “me-yow! me-yow!” as soft as I could, and then I put out the
+light and scrambled out of the window on to the shed.  Then I slipped
+down to the ground and crawled in among the trees, and, sure enough,
+there was Tom Sawyer waiting for me.
+
+
+
+
+CHAPTER II.
+
+WE went tiptoeing along a path amongst the trees back towards the end of
+the widow’s garden, stooping down so as the branches wouldn’t scrape our
+heads. When we was passing by the kitchen I fell over a root and made
+a noise.  We scrouched down and laid still.  Miss Watson’s big nigger,
+named Jim, was setting in the kitchen door; we could see him pretty
+clear, because there was a light behind him.  He got up and stretched
+his neck out about a minute, listening.  Then he says:
+
+“Who dah?”
+
+He listened some more; then he come tiptoeing down and stood right
+between us; we could a touched him, nearly.  Well, likely it was
+minutes and minutes that there warn’t a sound, and we all there so close
+together.  There was a place on my ankle that got to itching, but I
+dasn’t scratch it; and then my ear begun to itch; and next my back,
+right between my shoulders.  Seemed like I’d die if I couldn’t scratch.
+ Well, I’ve noticed that thing plenty times since.  If you are with
+the quality, or at a funeral, or trying to go to sleep when you ain’t
+sleepy--if you are anywheres where it won’t do for you to scratch, why
+you will itch all over in upwards of a thousand places. Pretty soon Jim
+says:
+
+“Say, who is you?  Whar is you?  Dog my cats ef I didn’ hear sumf’n.
+Well, I know what I’s gwyne to do:  I’s gwyne to set down here and
+listen tell I hears it agin.”
+
+So he set down on the ground betwixt me and Tom.  He leaned his back up
+against a tree, and stretched his legs out till one of them most touched
+one of mine.  My nose begun to itch.  It itched till the tears come into
+my eyes.  But I dasn’t scratch.  Then it begun to itch on the inside.
+Next I got to itching underneath.  I didn’t know how I was going to set
+still. This miserableness went on as much as six or seven minutes; but
+it seemed a sight longer than that.  I was itching in eleven different
+places now.  I reckoned I couldn’t stand it more’n a minute longer,
+but I set my teeth hard and got ready to try.  Just then Jim begun
+to breathe heavy; next he begun to snore--and then I was pretty soon
+comfortable again.
+
+Tom he made a sign to me--kind of a little noise with his mouth--and we
+went creeping away on our hands and knees.  When we was ten foot off Tom
+whispered to me, and wanted to tie Jim to the tree for fun.  But I said
+no; he might wake and make a disturbance, and then they’d find out I
+warn’t in. Then Tom said he hadn’t got candles enough, and he would slip
+in the kitchen and get some more.  I didn’t want him to try.  I said Jim
+might wake up and come.  But Tom wanted to resk it; so we slid in there
+and got three candles, and Tom laid five cents on the table for pay.
+Then we got out, and I was in a sweat to get away; but nothing would do
+Tom but he must crawl to where Jim was, on his hands and knees, and play
+something on him.  I waited, and it seemed a good while, everything was
+so still and lonesome.
+
+As soon as Tom was back we cut along the path, around the garden fence,
+and by and by fetched up on the steep top of the hill the other side of
+the house.  Tom said he slipped Jim’s hat off of his head and hung it
+on a limb right over him, and Jim stirred a little, but he didn’t wake.
+Afterwards Jim said the witches be witched him and put him in a trance,
+and rode him all over the State, and then set him under the trees again,
+and hung his hat on a limb to show who done it.  And next time Jim told
+it he said they rode him down to New Orleans; and, after that, every
+time he told it he spread it more and more, till by and by he said they
+rode him all over the world, and tired him most to death, and his back
+was all over saddle-boils.  Jim was monstrous proud about it, and he
+got so he wouldn’t hardly notice the other niggers.  Niggers would come
+miles to hear Jim tell about it, and he was more looked up to than any
+nigger in that country.  Strange niggers would stand with their mouths
+open and look him all over, same as if he was a wonder.  Niggers is
+always talking about witches in the dark by the kitchen fire; but
+whenever one was talking and letting on to know all about such things,
+Jim would happen in and say, “Hm!  What you know ‘bout witches?” and
+that nigger was corked up and had to take a back seat.  Jim always kept
+that five-center piece round his neck with a string, and said it was a
+charm the devil give to him with his own hands, and told him he could
+cure anybody with it and fetch witches whenever he wanted to just by
+saying something to it; but he never told what it was he said to it.
+ Niggers would come from all around there and give Jim anything they
+had, just for a sight of that five-center piece; but they wouldn’t touch
+it, because the devil had had his hands on it.  Jim was most ruined for
+a servant, because he got stuck up on account of having seen the devil
+and been rode by witches.
+
+Well, when Tom and me got to the edge of the hilltop we looked away down
+into the village and could see three or four lights twinkling, where
+there was sick folks, maybe; and the stars over us was sparkling ever
+so fine; and down by the village was the river, a whole mile broad, and
+awful still and grand.  We went down the hill and found Jo Harper and
+Ben Rogers, and two or three more of the boys, hid in the old tanyard.
+ So we unhitched a skiff and pulled down the river two mile and a half,
+to the big scar on the hillside, and went ashore.
+
+We went to a clump of bushes, and Tom made everybody swear to keep the
+secret, and then showed them a hole in the hill, right in the thickest
+part of the bushes.  Then we lit the candles, and crawled in on our
+hands and knees.  We went about two hundred yards, and then the cave
+opened up. Tom poked about amongst the passages, and pretty soon ducked
+under a wall where you wouldn’t a noticed that there was a hole.  We
+went along a narrow place and got into a kind of room, all damp and
+sweaty and cold, and there we stopped.  Tom says:
+
+“Now, we’ll start this band of robbers and call it Tom Sawyer’s Gang.
+Everybody that wants to join has got to take an oath, and write his name
+in blood.”
+
+Everybody was willing.  So Tom got out a sheet of paper that he had
+wrote the oath on, and read it.  It swore every boy to stick to the
+band, and never tell any of the secrets; and if anybody done anything to
+any boy in the band, whichever boy was ordered to kill that person and
+his family must do it, and he mustn’t eat and he mustn’t sleep till he
+had killed them and hacked a cross in their breasts, which was the sign
+of the band. And nobody that didn’t belong to the band could use that
+mark, and if he did he must be sued; and if he done it again he must be
+killed.  And if anybody that belonged to the band told the secrets, he
+must have his throat cut, and then have his carcass burnt up and the
+ashes scattered all around, and his name blotted off of the list with
+blood and never mentioned again by the gang, but have a curse put on it
+and be forgot forever.
+
+Everybody said it was a real beautiful oath, and asked Tom if he got
+it out of his own head.  He said, some of it, but the rest was out of
+pirate-books and robber-books, and every gang that was high-toned had
+it.
+
+Some thought it would be good to kill the _families_ of boys that told
+the secrets.  Tom said it was a good idea, so he took a pencil and wrote
+it in. Then Ben Rogers says:
+
+“Here’s Huck Finn, he hain’t got no family; what you going to do ‘bout
+him?”
+
+“Well, hain’t he got a father?” says Tom Sawyer.
+
+“Yes, he’s got a father, but you can’t never find him these days.  He
+used to lay drunk with the hogs in the tanyard, but he hain’t been seen
+in these parts for a year or more.”
+
+They talked it over, and they was going to rule me out, because they
+said every boy must have a family or somebody to kill, or else it
+wouldn’t be fair and square for the others.  Well, nobody could think of
+anything to do--everybody was stumped, and set still.  I was most ready
+to cry; but all at once I thought of a way, and so I offered them Miss
+Watson--they could kill her.  Everybody said:
+
+“Oh, she’ll do.  That’s all right.  Huck can come in.”
+
+Then they all stuck a pin in their fingers to get blood to sign with,
+and I made my mark on the paper.
+
+“Now,” says Ben Rogers, “what’s the line of business of this Gang?”
+
+“Nothing only robbery and murder,” Tom said.
+
+“But who are we going to rob?--houses, or cattle, or--”
+
+“Stuff! stealing cattle and such things ain’t robbery; it’s burglary,”
+ says Tom Sawyer.  “We ain’t burglars.  That ain’t no sort of style.  We
+are highwaymen.  We stop stages and carriages on the road, with masks
+on, and kill the people and take their watches and money.”
+
+“Must we always kill the people?”
+
+“Oh, certainly.  It’s best.  Some authorities think different, but
+mostly it’s considered best to kill them--except some that you bring to
+the cave here, and keep them till they’re ransomed.”
+
+“Ransomed?  What’s that?”
+
+“I don’t know.  But that’s what they do.  I’ve seen it in books; and so
+of course that’s what we’ve got to do.”
+
+“But how can we do it if we don’t know what it is?”
+
+“Why, blame it all, we’ve _got_ to do it.  Don’t I tell you it’s in the
+books?  Do you want to go to doing different from what’s in the books,
+and get things all muddled up?”
+
+“Oh, that’s all very fine to _say_, Tom Sawyer, but how in the nation
+are these fellows going to be ransomed if we don’t know how to do it
+to them?--that’s the thing I want to get at.  Now, what do you reckon it
+is?”
+
+“Well, I don’t know.  But per’aps if we keep them till they’re ransomed,
+it means that we keep them till they’re dead.”
+
+“Now, that’s something _like_.  That’ll answer.  Why couldn’t you said
+that before?  We’ll keep them till they’re ransomed to death; and a
+bothersome lot they’ll be, too--eating up everything, and always trying
+to get loose.”
+
+“How you talk, Ben Rogers.  How can they get loose when there’s a guard
+over them, ready to shoot them down if they move a peg?”
+
+“A guard!  Well, that _is_ good.  So somebody’s got to set up all night
+and never get any sleep, just so as to watch them.  I think that’s
+foolishness. Why can’t a body take a club and ransom them as soon as
+they get here?”
+
+“Because it ain’t in the books so--that’s why.  Now, Ben Rogers, do you
+want to do things regular, or don’t you?--that’s the idea.  Don’t you
+reckon that the people that made the books knows what’s the correct
+thing to do?  Do you reckon _you_ can learn ‘em anything?  Not by a good
+deal. No, sir, we’ll just go on and ransom them in the regular way.”
+
+“All right.  I don’t mind; but I say it’s a fool way, anyhow.  Say, do
+we kill the women, too?”
+
+“Well, Ben Rogers, if I was as ignorant as you I wouldn’t let on.  Kill
+the women?  No; nobody ever saw anything in the books like that.  You
+fetch them to the cave, and you’re always as polite as pie to them;
+and by and by they fall in love with you, and never want to go home any
+more.”
+
+“Well, if that’s the way I’m agreed, but I don’t take no stock in it.
+Mighty soon we’ll have the cave so cluttered up with women, and fellows
+waiting to be ransomed, that there won’t be no place for the robbers.
+But go ahead, I ain’t got nothing to say.”
+
+Little Tommy Barnes was asleep now, and when they waked him up he was
+scared, and cried, and said he wanted to go home to his ma, and didn’t
+want to be a robber any more.
+
+So they all made fun of him, and called him cry-baby, and that made him
+mad, and he said he would go straight and tell all the secrets.  But
+Tom give him five cents to keep quiet, and said we would all go home and
+meet next week, and rob somebody and kill some people.
+
+Ben Rogers said he couldn’t get out much, only Sundays, and so he wanted
+to begin next Sunday; but all the boys said it would be wicked to do it
+on Sunday, and that settled the thing.  They agreed to get together and
+fix a day as soon as they could, and then we elected Tom Sawyer first
+captain and Jo Harper second captain of the Gang, and so started home.
+
+I clumb up the shed and crept into my window just before day was
+breaking. My new clothes was all greased up and clayey, and I was
+dog-tired.
+
+
+
+
+CHAPTER III.
+
+WELL, I got a good going-over in the morning from old Miss Watson on
+account of my clothes; but the widow she didn’t scold, but only cleaned
+off the grease and clay, and looked so sorry that I thought I would
+behave awhile if I could.  Then Miss Watson she took me in the closet
+and prayed, but nothing come of it.  She told me to pray every day, and
+whatever I asked for I would get it.  But it warn’t so.  I tried it.
+Once I got a fish-line, but no hooks.  It warn’t any good to me without
+hooks.  I tried for the hooks three or four times, but somehow I
+couldn’t make it work.  By and by, one day, I asked Miss Watson to
+try for me, but she said I was a fool.  She never told me why, and I
+couldn’t make it out no way.
+
+I set down one time back in the woods, and had a long think about it.
+ I says to myself, if a body can get anything they pray for, why don’t
+Deacon Winn get back the money he lost on pork?  Why can’t the widow get
+back her silver snuffbox that was stole?  Why can’t Miss Watson fat up?
+No, says I to my self, there ain’t nothing in it.  I went and told the
+widow about it, and she said the thing a body could get by praying for
+it was “spiritual gifts.”  This was too many for me, but she told me
+what she meant--I must help other people, and do everything I could for
+other people, and look out for them all the time, and never think about
+myself. This was including Miss Watson, as I took it.  I went out in the
+woods and turned it over in my mind a long time, but I couldn’t see no
+advantage about it--except for the other people; so at last I reckoned
+I wouldn’t worry about it any more, but just let it go.  Sometimes the
+widow would take me one side and talk about Providence in a way to make
+a body’s mouth water; but maybe next day Miss Watson would take hold
+and knock it all down again.  I judged I could see that there was two
+Providences, and a poor chap would stand considerable show with the
+widow’s Providence, but if Miss Watson’s got him there warn’t no help
+for him any more.  I thought it all out, and reckoned I would belong
+to the widow’s if he wanted me, though I couldn’t make out how he was
+a-going to be any better off then than what he was before, seeing I was
+so ignorant, and so kind of low-down and ornery.
+
+Pap he hadn’t been seen for more than a year, and that was comfortable
+for me; I didn’t want to see him no more.  He used to always whale me
+when he was sober and could get his hands on me; though I used to take
+to the woods most of the time when he was around.  Well, about this time
+he was found in the river drownded, about twelve mile above town, so
+people said.  They judged it was him, anyway; said this drownded man was
+just his size, and was ragged, and had uncommon long hair, which was all
+like pap; but they couldn’t make nothing out of the face, because it had
+been in the water so long it warn’t much like a face at all.  They said
+he was floating on his back in the water.  They took him and buried him
+on the bank.  But I warn’t comfortable long, because I happened to think
+of something.  I knowed mighty well that a drownded man don’t float on
+his back, but on his face.  So I knowed, then, that this warn’t pap, but
+a woman dressed up in a man’s clothes.  So I was uncomfortable again.
+ I judged the old man would turn up again by and by, though I wished he
+wouldn’t.
+
+We played robber now and then about a month, and then I resigned.  All
+the boys did.  We hadn’t robbed nobody, hadn’t killed any people, but
+only just pretended.  We used to hop out of the woods and go charging
+down on hog-drivers and women in carts taking garden stuff to market,
+but we never hived any of them.  Tom Sawyer called the hogs “ingots,”
+ and he called the turnips and stuff “julery,” and we would go to the
+cave and powwow over what we had done, and how many people we had killed
+and marked.  But I couldn’t see no profit in it.  One time Tom sent a
+boy to run about town with a blazing stick, which he called a slogan
+(which was the sign for the Gang to get together), and then he said he
+had got secret news by his spies that next day a whole parcel of Spanish
+merchants and rich A-rabs was going to camp in Cave Hollow with two
+hundred elephants, and six hundred camels, and over a thousand “sumter”
+ mules, all loaded down with di’monds, and they didn’t have only a guard
+of four hundred soldiers, and so we would lay in ambuscade, as he called
+it, and kill the lot and scoop the things.  He said we must slick up
+our swords and guns, and get ready.  He never could go after even a
+turnip-cart but he must have the swords and guns all scoured up for it,
+though they was only lath and broomsticks, and you might scour at them
+till you rotted, and then they warn’t worth a mouthful of ashes more
+than what they was before.  I didn’t believe we could lick such a crowd
+of Spaniards and A-rabs, but I wanted to see the camels and elephants,
+so I was on hand next day, Saturday, in the ambuscade; and when we got
+the word we rushed out of the woods and down the hill.  But there warn’t
+no Spaniards and A-rabs, and there warn’t no camels nor no elephants.
+ It warn’t anything but a Sunday-school picnic, and only a primer-class
+at that.  We busted it up, and chased the children up the hollow; but we
+never got anything but some doughnuts and jam, though Ben Rogers got
+a rag doll, and Jo Harper got a hymn-book and a tract; and then the
+teacher charged in, and made us drop everything and cut.
+
+ I didn’t see no di’monds, and I told Tom Sawyer so.  He said there was
+loads of them there, anyway; and he said there was A-rabs there, too,
+and elephants and things.  I said, why couldn’t we see them, then?  He
+said if I warn’t so ignorant, but had read a book called Don Quixote, I
+would know without asking.  He said it was all done by enchantment.  He
+said there was hundreds of soldiers there, and elephants and treasure,
+and so on, but we had enemies which he called magicians; and they had
+turned the whole thing into an infant Sunday-school, just out of spite.
+ I said, all right; then the thing for us to do was to go for the
+magicians.  Tom Sawyer said I was a numskull.
+
+“Why,” said he, “a magician could call up a lot of genies, and they
+would hash you up like nothing before you could say Jack Robinson.  They
+are as tall as a tree and as big around as a church.”
+
+“Well,” I says, “s’pose we got some genies to help _us_--can’t we lick
+the other crowd then?”
+
+“How you going to get them?”
+
+“I don’t know.  How do _they_ get them?”
+
+“Why, they rub an old tin lamp or an iron ring, and then the genies
+come tearing in, with the thunder and lightning a-ripping around and the
+smoke a-rolling, and everything they’re told to do they up and do it.
+ They don’t think nothing of pulling a shot-tower up by the roots, and
+belting a Sunday-school superintendent over the head with it--or any
+other man.”
+
+“Who makes them tear around so?”
+
+“Why, whoever rubs the lamp or the ring.  They belong to whoever rubs
+the lamp or the ring, and they’ve got to do whatever he says.  If he
+tells them to build a palace forty miles long out of di’monds, and fill
+it full of chewing-gum, or whatever you want, and fetch an emperor’s
+daughter from China for you to marry, they’ve got to do it--and they’ve
+got to do it before sun-up next morning, too.  And more:  they’ve got
+to waltz that palace around over the country wherever you want it, you
+understand.”
+
+“Well,” says I, “I think they are a pack of flat-heads for not keeping
+the palace themselves ‘stead of fooling them away like that.  And what’s
+more--if I was one of them I would see a man in Jericho before I would
+drop my business and come to him for the rubbing of an old tin lamp.”
+
+“How you talk, Huck Finn.  Why, you’d _have_ to come when he rubbed it,
+whether you wanted to or not.”
+
+“What! and I as high as a tree and as big as a church?  All right, then;
+I _would_ come; but I lay I’d make that man climb the highest tree there
+was in the country.”
+
+“Shucks, it ain’t no use to talk to you, Huck Finn.  You don’t seem to
+know anything, somehow--perfect saphead.”
+
+I thought all this over for two or three days, and then I reckoned I
+would see if there was anything in it.  I got an old tin lamp and an
+iron ring, and went out in the woods and rubbed and rubbed till I sweat
+like an Injun, calculating to build a palace and sell it; but it warn’t
+no use, none of the genies come.  So then I judged that all that stuff
+was only just one of Tom Sawyer’s lies.  I reckoned he believed in the
+A-rabs and the elephants, but as for me I think different.  It had all
+the marks of a Sunday-school.
+
+
+
+
+CHAPTER IV.
+
+WELL, three or four months run along, and it was well into the winter
+now. I had been to school most all the time and could spell and read and
+write just a little, and could say the multiplication table up to six
+times seven is thirty-five, and I don’t reckon I could ever get any
+further than that if I was to live forever.  I don’t take no stock in
+mathematics, anyway.
+
+At first I hated the school, but by and by I got so I could stand it.
+Whenever I got uncommon tired I played hookey, and the hiding I got next
+day done me good and cheered me up.  So the longer I went to school the
+easier it got to be.  I was getting sort of used to the widow’s ways,
+too, and they warn’t so raspy on me.  Living in a house and sleeping in
+a bed pulled on me pretty tight mostly, but before the cold weather I
+used to slide out and sleep in the woods sometimes, and so that was a
+rest to me.  I liked the old ways best, but I was getting so I liked the
+new ones, too, a little bit. The widow said I was coming along slow but
+sure, and doing very satisfactory.  She said she warn’t ashamed of me.
+
+One morning I happened to turn over the salt-cellar at breakfast.
+ I reached for some of it as quick as I could to throw over my left
+shoulder and keep off the bad luck, but Miss Watson was in ahead of me,
+and crossed me off. She says, “Take your hands away, Huckleberry; what
+a mess you are always making!”  The widow put in a good word for me, but
+that warn’t going to keep off the bad luck, I knowed that well enough.
+ I started out, after breakfast, feeling worried and shaky, and
+wondering where it was going to fall on me, and what it was going to be.
+ There is ways to keep off some kinds of bad luck, but this wasn’t one
+of them kind; so I never tried to do anything, but just poked along
+low-spirited and on the watch-out.
+
+I went down to the front garden and clumb over the stile where you go
+through the high board fence.  There was an inch of new snow on the
+ground, and I seen somebody’s tracks.  They had come up from the quarry
+and stood around the stile a while, and then went on around the garden
+fence.  It was funny they hadn’t come in, after standing around so.  I
+couldn’t make it out.  It was very curious, somehow.  I was going to
+follow around, but I stooped down to look at the tracks first.  I didn’t
+notice anything at first, but next I did.  There was a cross in the left
+boot-heel made with big nails, to keep off the devil.
+
+I was up in a second and shinning down the hill.  I looked over my
+shoulder every now and then, but I didn’t see nobody.  I was at Judge
+Thatcher’s as quick as I could get there.  He said:
+
+“Why, my boy, you are all out of breath.  Did you come for your
+interest?”
+
+“No, sir,” I says; “is there some for me?”
+
+“Oh, yes, a half-yearly is in last night--over a hundred and fifty
+dollars.  Quite a fortune for you.  You had better let me invest it
+along with your six thousand, because if you take it you’ll spend it.”
+
+“No, sir,” I says, “I don’t want to spend it.  I don’t want it at
+all--nor the six thousand, nuther.  I want you to take it; I want to give
+it to you--the six thousand and all.”
+
+He looked surprised.  He couldn’t seem to make it out.  He says:
+
+“Why, what can you mean, my boy?”
+
+I says, “Don’t you ask me no questions about it, please.  You’ll take
+it--won’t you?”
+
+He says:
+
+“Well, I’m puzzled.  Is something the matter?”
+
+“Please take it,” says I, “and don’t ask me nothing--then I won’t have to
+tell no lies.”
+
+He studied a while, and then he says:
+
+“Oho-o!  I think I see.  You want to _sell_ all your property to me--not
+give it.  That’s the correct idea.”
+
+Then he wrote something on a paper and read it over, and says:
+
+“There; you see it says ‘for a consideration.’  That means I have bought
+it of you and paid you for it.  Here’s a dollar for you.  Now you sign
+it.”
+
+So I signed it, and left.
+
+Miss Watson’s nigger, Jim, had a hair-ball as big as your fist, which
+had been took out of the fourth stomach of an ox, and he used to do
+magic with it.  He said there was a spirit inside of it, and it knowed
+everything.  So I went to him that night and told him pap was here
+again, for I found his tracks in the snow.  What I wanted to know was,
+what he was going to do, and was he going to stay?  Jim got out his
+hair-ball and said something over it, and then he held it up and dropped
+it on the floor.  It fell pretty solid, and only rolled about an inch.
+ Jim tried it again, and then another time, and it acted just the same.
+ Jim got down on his knees, and put his ear against it and listened.
+ But it warn’t no use; he said it wouldn’t talk. He said sometimes it
+wouldn’t talk without money.  I told him I had an old slick counterfeit
+quarter that warn’t no good because the brass showed through the silver
+a little, and it wouldn’t pass nohow, even if the brass didn’t show,
+because it was so slick it felt greasy, and so that would tell on it
+every time.  (I reckoned I wouldn’t say nothing about the dollar I got
+from the judge.) I said it was pretty bad money, but maybe the hair-ball
+would take it, because maybe it wouldn’t know the difference.  Jim smelt
+it and bit it and rubbed it, and said he would manage so the hair-ball
+would think it was good.  He said he would split open a raw Irish potato
+and stick the quarter in between and keep it there all night, and next
+morning you couldn’t see no brass, and it wouldn’t feel greasy no more,
+and so anybody in town would take it in a minute, let alone a hair-ball.
+ Well, I knowed a potato would do that before, but I had forgot it.
+
+Jim put the quarter under the hair-ball, and got down and listened
+again. This time he said the hair-ball was all right.  He said it
+would tell my whole fortune if I wanted it to.  I says, go on.  So the
+hair-ball talked to Jim, and Jim told it to me.  He says:
+
+“Yo’ ole father doan’ know yit what he’s a-gwyne to do.  Sometimes he
+spec he’ll go ‘way, en den agin he spec he’ll stay.  De bes’ way is to
+res’ easy en let de ole man take his own way.  Dey’s two angels hoverin’
+roun’ ‘bout him.  One uv ‘em is white en shiny, en t’other one is black.
+De white one gits him to go right a little while, den de black one sail
+in en bust it all up.  A body can’t tell yit which one gwyne to fetch
+him at de las’.  But you is all right.  You gwyne to have considable
+trouble in yo’ life, en considable joy.  Sometimes you gwyne to git
+hurt, en sometimes you gwyne to git sick; but every time you’s gwyne
+to git well agin.  Dey’s two gals flyin’ ‘bout you in yo’ life.  One
+uv ‘em’s light en t’other one is dark. One is rich en t’other is po’.
+ You’s gwyne to marry de po’ one fust en de rich one by en by.  You
+wants to keep ‘way fum de water as much as you kin, en don’t run no
+resk, ‘kase it’s down in de bills dat you’s gwyne to git hung.”
+
+When I lit my candle and went up to my room that night there sat pap his
+own self!
+
+
+
+
+CHAPTER V.
+
+I had shut the door to.  Then I turned around and there he was.  I used
+to be scared of him all the time, he tanned me so much.  I reckoned I
+was scared now, too; but in a minute I see I was mistaken--that is, after
+the first jolt, as you may say, when my breath sort of hitched, he being
+so unexpected; but right away after I see I warn’t scared of him worth
+bothring about.
+
+He was most fifty, and he looked it.  His hair was long and tangled and
+greasy, and hung down, and you could see his eyes shining through
+like he was behind vines.  It was all black, no gray; so was his long,
+mixed-up whiskers.  There warn’t no color in his face, where his face
+showed; it was white; not like another man’s white, but a white to make
+a body sick, a white to make a body’s flesh crawl--a tree-toad white, a
+fish-belly white.  As for his clothes--just rags, that was all.  He had
+one ankle resting on t’other knee; the boot on that foot was busted, and
+two of his toes stuck through, and he worked them now and then.  His hat
+was laying on the floor--an old black slouch with the top caved in, like
+a lid.
+
+I stood a-looking at him; he set there a-looking at me, with his chair
+tilted back a little.  I set the candle down.  I noticed the window was
+up; so he had clumb in by the shed.  He kept a-looking me all over.  By
+and by he says:
+
+“Starchy clothes--very.  You think you’re a good deal of a big-bug,
+_don’t_ you?”
+
+“Maybe I am, maybe I ain’t,” I says.
+
+“Don’t you give me none o’ your lip,” says he.  “You’ve put on
+considerable many frills since I been away.  I’ll take you down a peg
+before I get done with you.  You’re educated, too, they say--can read and
+write.  You think you’re better’n your father, now, don’t you, because
+he can’t?  _I’ll_ take it out of you.  Who told you you might meddle
+with such hifalut’n foolishness, hey?--who told you you could?”
+
+“The widow.  She told me.”
+
+“The widow, hey?--and who told the widow she could put in her shovel
+about a thing that ain’t none of her business?”
+
+“Nobody never told her.”
+
+“Well, I’ll learn her how to meddle.  And looky here--you drop that
+school, you hear?  I’ll learn people to bring up a boy to put on airs
+over his own father and let on to be better’n what _he_ is.  You lemme
+catch you fooling around that school again, you hear?  Your mother
+couldn’t read, and she couldn’t write, nuther, before she died.  None
+of the family couldn’t before _they_ died.  I can’t; and here you’re
+a-swelling yourself up like this.  I ain’t the man to stand it--you hear?
+Say, lemme hear you read.”
+
+I took up a book and begun something about General Washington and the
+wars. When I’d read about a half a minute, he fetched the book a whack
+with his hand and knocked it across the house.  He says:
+
+“It’s so.  You can do it.  I had my doubts when you told me.  Now looky
+here; you stop that putting on frills.  I won’t have it.  I’ll lay for
+you, my smarty; and if I catch you about that school I’ll tan you good.
+First you know you’ll get religion, too.  I never see such a son.”
+
+He took up a little blue and yaller picture of some cows and a boy, and
+says:
+
+“What’s this?”
+
+“It’s something they give me for learning my lessons good.”
+
+He tore it up, and says:
+
+“I’ll give you something better--I’ll give you a cowhide.”
+
+He set there a-mumbling and a-growling a minute, and then he says:
+
+“_Ain’t_ you a sweet-scented dandy, though?  A bed; and bedclothes; and
+a look’n’-glass; and a piece of carpet on the floor--and your own father
+got to sleep with the hogs in the tanyard.  I never see such a son.  I
+bet I’ll take some o’ these frills out o’ you before I’m done with you.
+Why, there ain’t no end to your airs--they say you’re rich.  Hey?--how’s
+that?”
+
+“They lie--that’s how.”
+
+“Looky here--mind how you talk to me; I’m a-standing about all I can
+stand now--so don’t gimme no sass.  I’ve been in town two days, and I
+hain’t heard nothing but about you bein’ rich.  I heard about it
+away down the river, too.  That’s why I come.  You git me that money
+to-morrow--I want it.”
+
+“I hain’t got no money.”
+
+“It’s a lie.  Judge Thatcher’s got it.  You git it.  I want it.”
+
+“I hain’t got no money, I tell you.  You ask Judge Thatcher; he’ll tell
+you the same.”
+
+“All right.  I’ll ask him; and I’ll make him pungle, too, or I’ll know
+the reason why.  Say, how much you got in your pocket?  I want it.”
+
+“I hain’t got only a dollar, and I want that to--”
+
+“It don’t make no difference what you want it for--you just shell it
+out.”
+
+He took it and bit it to see if it was good, and then he said he was
+going down town to get some whisky; said he hadn’t had a drink all day.
+When he had got out on the shed he put his head in again, and cussed
+me for putting on frills and trying to be better than him; and when I
+reckoned he was gone he come back and put his head in again, and told me
+to mind about that school, because he was going to lay for me and lick
+me if I didn’t drop that.
+
+Next day he was drunk, and he went to Judge Thatcher’s and bullyragged
+him, and tried to make him give up the money; but he couldn’t, and then
+he swore he’d make the law force him.
+
+The judge and the widow went to law to get the court to take me away
+from him and let one of them be my guardian; but it was a new judge that
+had just come, and he didn’t know the old man; so he said courts mustn’t
+interfere and separate families if they could help it; said he’d druther
+not take a child away from its father.  So Judge Thatcher and the widow
+had to quit on the business.
+
+That pleased the old man till he couldn’t rest.  He said he’d cowhide
+me till I was black and blue if I didn’t raise some money for him.  I
+borrowed three dollars from Judge Thatcher, and pap took it and got
+drunk, and went a-blowing around and cussing and whooping and carrying
+on; and he kept it up all over town, with a tin pan, till most midnight;
+then they jailed him, and next day they had him before court, and jailed
+him again for a week.  But he said _he_ was satisfied; said he was boss
+of his son, and he’d make it warm for _him_.
+
+When he got out the new judge said he was a-going to make a man of him.
+So he took him to his own house, and dressed him up clean and nice, and
+had him to breakfast and dinner and supper with the family, and was just
+old pie to him, so to speak.  And after supper he talked to him about
+temperance and such things till the old man cried, and said he’d been
+a fool, and fooled away his life; but now he was a-going to turn over
+a new leaf and be a man nobody wouldn’t be ashamed of, and he hoped the
+judge would help him and not look down on him.  The judge said he could
+hug him for them words; so he cried, and his wife she cried again; pap
+said he’d been a man that had always been misunderstood before, and the
+judge said he believed it.  The old man said that what a man wanted
+that was down was sympathy, and the judge said it was so; so they cried
+again.  And when it was bedtime the old man rose up and held out his
+hand, and says:
+
+“Look at it, gentlemen and ladies all; take a-hold of it; shake it.
+There’s a hand that was the hand of a hog; but it ain’t so no more; it’s
+the hand of a man that’s started in on a new life, and’ll die before
+he’ll go back.  You mark them words--don’t forget I said them.  It’s a
+clean hand now; shake it--don’t be afeard.”
+
+So they shook it, one after the other, all around, and cried.  The
+judge’s wife she kissed it.  Then the old man he signed a pledge--made
+his mark. The judge said it was the holiest time on record, or something
+like that. Then they tucked the old man into a beautiful room, which was
+the spare room, and in the night some time he got powerful thirsty and
+clumb out on to the porch-roof and slid down a stanchion and traded his
+new coat for a jug of forty-rod, and clumb back again and had a good old
+time; and towards daylight he crawled out again, drunk as a fiddler, and
+rolled off the porch and broke his left arm in two places, and was most
+froze to death when somebody found him after sun-up.  And when they come
+to look at that spare room they had to take soundings before they could
+navigate it.
+
+The judge he felt kind of sore.  He said he reckoned a body could reform
+the old man with a shotgun, maybe, but he didn’t know no other way.
+
+
+
+
+CHAPTER VI.
+
+WELL, pretty soon the old man was up and around again, and then he went
+for Judge Thatcher in the courts to make him give up that money, and he
+went for me, too, for not stopping school.  He catched me a couple of
+times and thrashed me, but I went to school just the same, and dodged
+him or outrun him most of the time.  I didn’t want to go to school much
+before, but I reckoned I’d go now to spite pap.  That law trial was a
+slow business--appeared like they warn’t ever going to get started on it;
+so every now and then I’d borrow two or three dollars off of the judge
+for him, to keep from getting a cowhiding.  Every time he got money he
+got drunk; and every time he got drunk he raised Cain around town; and
+every time he raised Cain he got jailed.  He was just suited--this kind
+of thing was right in his line.
+
+He got to hanging around the widow’s too much and so she told him at
+last that if he didn’t quit using around there she would make trouble
+for him. Well, _wasn’t_ he mad?  He said he would show who was Huck
+Finn’s boss.  So he watched out for me one day in the spring, and
+catched me, and took me up the river about three mile in a skiff, and
+crossed over to the Illinois shore where it was woody and there warn’t
+no houses but an old log hut in a place where the timber was so thick
+you couldn’t find it if you didn’t know where it was.
+
+He kept me with him all the time, and I never got a chance to run off.
+We lived in that old cabin, and he always locked the door and put the
+key under his head nights.  He had a gun which he had stole, I reckon,
+and we fished and hunted, and that was what we lived on.  Every little
+while he locked me in and went down to the store, three miles, to the
+ferry, and traded fish and game for whisky, and fetched it home and got
+drunk and had a good time, and licked me.  The widow she found out where
+I was by and by, and she sent a man over to try to get hold of me; but
+pap drove him off with the gun, and it warn’t long after that till I was
+used to being where I was, and liked it--all but the cowhide part.
+
+It was kind of lazy and jolly, laying off comfortable all day, smoking
+and fishing, and no books nor study.  Two months or more run along, and
+my clothes got to be all rags and dirt, and I didn’t see how I’d ever
+got to like it so well at the widow’s, where you had to wash, and eat on
+a plate, and comb up, and go to bed and get up regular, and be forever
+bothering over a book, and have old Miss Watson pecking at you all the
+time.  I didn’t want to go back no more.  I had stopped cussing, because
+the widow didn’t like it; but now I took to it again because pap hadn’t
+no objections.  It was pretty good times up in the woods there, take it
+all around.
+
+But by and by pap got too handy with his hick’ry, and I couldn’t stand
+it. I was all over welts.  He got to going away so much, too, and
+locking me in.  Once he locked me in and was gone three days.  It was
+dreadful lonesome.  I judged he had got drownded, and I wasn’t ever
+going to get out any more.  I was scared.  I made up my mind I would fix
+up some way to leave there.  I had tried to get out of that cabin many
+a time, but I couldn’t find no way.  There warn’t a window to it big
+enough for a dog to get through.  I couldn’t get up the chimbly; it
+was too narrow.  The door was thick, solid oak slabs.  Pap was pretty
+careful not to leave a knife or anything in the cabin when he was away;
+I reckon I had hunted the place over as much as a hundred times; well, I
+was most all the time at it, because it was about the only way to put in
+the time.  But this time I found something at last; I found an old rusty
+wood-saw without any handle; it was laid in between a rafter and the
+clapboards of the roof. I greased it up and went to work.  There was an
+old horse-blanket nailed against the logs at the far end of the cabin
+behind the table, to keep the wind from blowing through the chinks and
+putting the candle out.  I got under the table and raised the blanket,
+and went to work to saw a section of the big bottom log out--big enough
+to let me through.  Well, it was a good long job, but I was getting
+towards the end of it when I heard pap’s gun in the woods.  I got rid of
+the signs of my work, and dropped the blanket and hid my saw, and pretty
+soon pap come in.
+
+Pap warn’t in a good humor--so he was his natural self.  He said he was
+down town, and everything was going wrong.  His lawyer said he reckoned
+he would win his lawsuit and get the money if they ever got started on
+the trial; but then there was ways to put it off a long time, and Judge
+Thatcher knowed how to do it. And he said people allowed there’d be
+another trial to get me away from him and give me to the widow for my
+guardian, and they guessed it would win this time.  This shook me up
+considerable, because I didn’t want to go back to the widow’s any more
+and be so cramped up and sivilized, as they called it.  Then the old man
+got to cussing, and cussed everything and everybody he could think of,
+and then cussed them all over again to make sure he hadn’t skipped any,
+and after that he polished off with a kind of a general cuss all round,
+including a considerable parcel of people which he didn’t know the names
+of, and so called them what’s-his-name when he got to them, and went
+right along with his cussing.
+
+He said he would like to see the widow get me.  He said he would watch
+out, and if they tried to come any such game on him he knowed of a place
+six or seven mile off to stow me in, where they might hunt till they
+dropped and they couldn’t find me.  That made me pretty uneasy again,
+but only for a minute; I reckoned I wouldn’t stay on hand till he got
+that chance.
+
+The old man made me go to the skiff and fetch the things he had
+got. There was a fifty-pound sack of corn meal, and a side of bacon,
+ammunition, and a four-gallon jug of whisky, and an old book and two
+newspapers for wadding, besides some tow.  I toted up a load, and went
+back and set down on the bow of the skiff to rest.  I thought it all
+over, and I reckoned I would walk off with the gun and some lines, and
+take to the woods when I run away.  I guessed I wouldn’t stay in one
+place, but just tramp right across the country, mostly night times, and
+hunt and fish to keep alive, and so get so far away that the old man nor
+the widow couldn’t ever find me any more.  I judged I would saw out and
+leave that night if pap got drunk enough, and I reckoned he would.  I
+got so full of it I didn’t notice how long I was staying till the old
+man hollered and asked me whether I was asleep or drownded.
+
+I got the things all up to the cabin, and then it was about dark.  While
+I was cooking supper the old man took a swig or two and got sort of
+warmed up, and went to ripping again.  He had been drunk over in town,
+and laid in the gutter all night, and he was a sight to look at.  A body
+would a thought he was Adam--he was just all mud.  Whenever his liquor
+begun to work he most always went for the govment, this time he says:
+
+“Call this a govment! why, just look at it and see what it’s like.
+Here’s the law a-standing ready to take a man’s son away from him--a
+man’s own son, which he has had all the trouble and all the anxiety
+and all the expense of raising.  Yes, just as that man has got that
+son raised at last, and ready to go to work and begin to do suthin’ for
+_him_ and give him a rest, the law up and goes for him.  And they call
+_that_ govment!  That ain’t all, nuther.  The law backs that old Judge
+Thatcher up and helps him to keep me out o’ my property.  Here’s what
+the law does:  The law takes a man worth six thousand dollars and
+up’ards, and jams him into an old trap of a cabin like this, and lets
+him go round in clothes that ain’t fitten for a hog. They call that
+govment!  A man can’t get his rights in a govment like this. Sometimes
+I’ve a mighty notion to just leave the country for good and all. Yes,
+and I _told_ ‘em so; I told old Thatcher so to his face.  Lots of ‘em
+heard me, and can tell what I said.  Says I, for two cents I’d leave the
+blamed country and never come a-near it agin.  Them’s the very words.  I
+says look at my hat--if you call it a hat--but the lid raises up and the
+rest of it goes down till it’s below my chin, and then it ain’t rightly
+a hat at all, but more like my head was shoved up through a jint o’
+stove-pipe.  Look at it, says I--such a hat for me to wear--one of the
+wealthiest men in this town if I could git my rights.
+
+“Oh, yes, this is a wonderful govment, wonderful.  Why, looky here.
+There was a free nigger there from Ohio--a mulatter, most as white as
+a white man.  He had the whitest shirt on you ever see, too, and the
+shiniest hat; and there ain’t a man in that town that’s got as fine
+clothes as what he had; and he had a gold watch and chain, and a
+silver-headed cane--the awfulest old gray-headed nabob in the State.  And
+what do you think?  They said he was a p’fessor in a college, and could
+talk all kinds of languages, and knowed everything.  And that ain’t the
+wust. They said he could _vote_ when he was at home.  Well, that let me
+out. Thinks I, what is the country a-coming to?  It was ‘lection day,
+and I was just about to go and vote myself if I warn’t too drunk to get
+there; but when they told me there was a State in this country where
+they’d let that nigger vote, I drawed out.  I says I’ll never vote agin.
+ Them’s the very words I said; they all heard me; and the country may
+rot for all me--I’ll never vote agin as long as I live.  And to see the
+cool way of that nigger--why, he wouldn’t a give me the road if I hadn’t
+shoved him out o’ the way.  I says to the people, why ain’t this nigger
+put up at auction and sold?--that’s what I want to know.  And what do you
+reckon they said? Why, they said he couldn’t be sold till he’d been in
+the State six months, and he hadn’t been there that long yet.  There,
+now--that’s a specimen.  They call that a govment that can’t sell a free
+nigger till he’s been in the State six months.  Here’s a govment that
+calls itself a govment, and lets on to be a govment, and thinks it is a
+govment, and yet’s got to set stock-still for six whole months before
+it can take a hold of a prowling, thieving, infernal, white-shirted free
+nigger, and--”
+
+Pap was agoing on so he never noticed where his old limber legs was
+taking him to, so he went head over heels over the tub of salt pork and
+barked both shins, and the rest of his speech was all the hottest kind
+of language--mostly hove at the nigger and the govment, though he give
+the tub some, too, all along, here and there.  He hopped around the
+cabin considerable, first on one leg and then on the other, holding
+first one shin and then the other one, and at last he let out with his
+left foot all of a sudden and fetched the tub a rattling kick.  But it
+warn’t good judgment, because that was the boot that had a couple of his
+toes leaking out of the front end of it; so now he raised a howl that
+fairly made a body’s hair raise, and down he went in the dirt, and
+rolled there, and held his toes; and the cussing he done then laid over
+anything he had ever done previous.  He said so his own self afterwards.
+ He had heard old Sowberry Hagan in his best days, and he said it laid
+over him, too; but I reckon that was sort of piling it on, maybe.
+
+After supper pap took the jug, and said he had enough whisky there
+for two drunks and one delirium tremens.  That was always his word.  I
+judged he would be blind drunk in about an hour, and then I would steal
+the key, or saw myself out, one or t’other.  He drank and drank, and
+tumbled down on his blankets by and by; but luck didn’t run my way.
+ He didn’t go sound asleep, but was uneasy.  He groaned and moaned and
+thrashed around this way and that for a long time.  At last I got so
+sleepy I couldn’t keep my eyes open all I could do, and so before I
+knowed what I was about I was sound asleep, and the candle burning.
+
+I don’t know how long I was asleep, but all of a sudden there was an
+awful scream and I was up.  There was pap looking wild, and skipping
+around every which way and yelling about snakes.  He said they was
+crawling up his legs; and then he would give a jump and scream, and say
+one had bit him on the cheek--but I couldn’t see no snakes.  He started
+and run round and round the cabin, hollering “Take him off! take him
+off! he’s biting me on the neck!”  I never see a man look so wild in the
+eyes. Pretty soon he was all fagged out, and fell down panting; then he
+rolled over and over wonderful fast, kicking things every which way,
+and striking and grabbing at the air with his hands, and screaming and
+saying there was devils a-hold of him.  He wore out by and by, and laid
+still a while, moaning.  Then he laid stiller, and didn’t make a sound.
+ I could hear the owls and the wolves away off in the woods, and it
+seemed terrible still.  He was laying over by the corner. By and by he
+raised up part way and listened, with his head to one side.  He says,
+very low:
+
+“Tramp--tramp--tramp; that’s the dead; tramp--tramp--tramp; they’re coming
+after me; but I won’t go.  Oh, they’re here! don’t touch me--don’t! hands
+off--they’re cold; let go.  Oh, let a poor devil alone!”
+
+Then he went down on all fours and crawled off, begging them to let him
+alone, and he rolled himself up in his blanket and wallowed in under the
+old pine table, still a-begging; and then he went to crying.  I could
+hear him through the blanket.
+
+By and by he rolled out and jumped up on his feet looking wild, and he
+see me and went for me.  He chased me round and round the place with a
+clasp-knife, calling me the Angel of Death, and saying he would kill me,
+and then I couldn’t come for him no more.  I begged, and told him I
+was only Huck; but he laughed _such_ a screechy laugh, and roared and
+cussed, and kept on chasing me up.  Once when I turned short and
+dodged under his arm he made a grab and got me by the jacket between my
+shoulders, and I thought I was gone; but I slid out of the jacket quick
+as lightning, and saved myself. Pretty soon he was all tired out, and
+dropped down with his back against the door, and said he would rest a
+minute and then kill me. He put his knife under him, and said he would
+sleep and get strong, and then he would see who was who.
+
+So he dozed off pretty soon.  By and by I got the old split-bottom chair
+and clumb up as easy as I could, not to make any noise, and got down the
+gun.  I slipped the ramrod down it to make sure it was loaded, then I
+laid it across the turnip barrel, pointing towards pap, and set down
+behind it to wait for him to stir.  And how slow and still the time did
+drag along.
+
+
+
+
+CHAPTER VII.
+
+“GIT up!  What you ‘bout?”
+
+I opened my eyes and looked around, trying to make out where I was.  It
+was after sun-up, and I had been sound asleep.  Pap was standing over me
+looking sour and sick, too.  He says:
+
+“What you doin’ with this gun?”
+
+I judged he didn’t know nothing about what he had been doing, so I says:
+
+“Somebody tried to get in, so I was laying for him.”
+
+“Why didn’t you roust me out?”
+
+“Well, I tried to, but I couldn’t; I couldn’t budge you.”
+
+“Well, all right.  Don’t stand there palavering all day, but out with
+you and see if there’s a fish on the lines for breakfast.  I’ll be along
+in a minute.”
+
+He unlocked the door, and I cleared out up the river-bank.  I noticed
+some pieces of limbs and such things floating down, and a sprinkling of
+bark; so I knowed the river had begun to rise.  I reckoned I would have
+great times now if I was over at the town.  The June rise used to be
+always luck for me; because as soon as that rise begins here comes
+cordwood floating down, and pieces of log rafts--sometimes a dozen logs
+together; so all you have to do is to catch them and sell them to the
+wood-yards and the sawmill.
+
+I went along up the bank with one eye out for pap and t’other one out
+for what the rise might fetch along.  Well, all at once here comes a
+canoe; just a beauty, too, about thirteen or fourteen foot long, riding
+high like a duck.  I shot head-first off of the bank like a frog,
+clothes and all on, and struck out for the canoe.  I just expected
+there’d be somebody laying down in it, because people often done that
+to fool folks, and when a chap had pulled a skiff out most to it they’d
+raise up and laugh at him.  But it warn’t so this time.  It was a
+drift-canoe sure enough, and I clumb in and paddled her ashore.  Thinks
+I, the old man will be glad when he sees this--she’s worth ten dollars.
+ But when I got to shore pap wasn’t in sight yet, and as I was running
+her into a little creek like a gully, all hung over with vines and
+willows, I struck another idea:  I judged I’d hide her good, and then,
+‘stead of taking to the woods when I run off, I’d go down the river
+about fifty mile and camp in one place for good, and not have such a
+rough time tramping on foot.
+
+It was pretty close to the shanty, and I thought I heard the old man
+coming all the time; but I got her hid; and then I out and looked around
+a bunch of willows, and there was the old man down the path a piece just
+drawing a bead on a bird with his gun.  So he hadn’t seen anything.
+
+When he got along I was hard at it taking up a “trot” line.  He abused
+me a little for being so slow; but I told him I fell in the river, and
+that was what made me so long.  I knowed he would see I was wet, and
+then he would be asking questions.  We got five catfish off the lines
+and went home.
+
+While we laid off after breakfast to sleep up, both of us being about
+wore out, I got to thinking that if I could fix up some way to keep pap
+and the widow from trying to follow me, it would be a certainer thing
+than trusting to luck to get far enough off before they missed me; you
+see, all kinds of things might happen.  Well, I didn’t see no way for a
+while, but by and by pap raised up a minute to drink another barrel of
+water, and he says:
+
+“Another time a man comes a-prowling round here you roust me out, you
+hear? That man warn’t here for no good.  I’d a shot him.  Next time you
+roust me out, you hear?”
+
+Then he dropped down and went to sleep again; but what he had been
+saying give me the very idea I wanted.  I says to myself, I can fix it
+now so nobody won’t think of following me.
+
+About twelve o’clock we turned out and went along up the bank.  The
+river was coming up pretty fast, and lots of driftwood going by on the
+rise. By and by along comes part of a log raft--nine logs fast together.
+ We went out with the skiff and towed it ashore.  Then we had dinner.
+Anybody but pap would a waited and seen the day through, so as to catch
+more stuff; but that warn’t pap’s style.  Nine logs was enough for one
+time; he must shove right over to town and sell.  So he locked me in and
+took the skiff, and started off towing the raft about half-past three.
+ I judged he wouldn’t come back that night.  I waited till I reckoned he
+had got a good start; then I out with my saw, and went to work on that
+log again.  Before he was t’other side of the river I was out of the
+hole; him and his raft was just a speck on the water away off yonder.
+
+I took the sack of corn meal and took it to where the canoe was hid, and
+shoved the vines and branches apart and put it in; then I done the same
+with the side of bacon; then the whisky-jug.  I took all the coffee and
+sugar there was, and all the ammunition; I took the wadding; I took the
+bucket and gourd; I took a dipper and a tin cup, and my old saw and two
+blankets, and the skillet and the coffee-pot.  I took fish-lines and
+matches and other things--everything that was worth a cent.  I cleaned
+out the place.  I wanted an axe, but there wasn’t any, only the one out
+at the woodpile, and I knowed why I was going to leave that.  I fetched
+out the gun, and now I was done.
+
+I had wore the ground a good deal crawling out of the hole and dragging
+out so many things.  So I fixed that as good as I could from the outside
+by scattering dust on the place, which covered up the smoothness and the
+sawdust.  Then I fixed the piece of log back into its place, and put two
+rocks under it and one against it to hold it there, for it was bent up
+at that place and didn’t quite touch ground.  If you stood four or five
+foot away and didn’t know it was sawed, you wouldn’t never notice
+it; and besides, this was the back of the cabin, and it warn’t likely
+anybody would go fooling around there.
+
+It was all grass clear to the canoe, so I hadn’t left a track.  I
+followed around to see.  I stood on the bank and looked out over the
+river.  All safe.  So I took the gun and went up a piece into the woods,
+and was hunting around for some birds when I see a wild pig; hogs soon
+went wild in them bottoms after they had got away from the prairie
+farms. I shot this fellow and took him into camp.
+
+I took the axe and smashed in the door.  I beat it and hacked it
+considerable a-doing it.  I fetched the pig in, and took him back nearly
+to the table and hacked into his throat with the axe, and laid him down
+on the ground to bleed; I say ground because it was ground--hard packed,
+and no boards.  Well, next I took an old sack and put a lot of big rocks
+in it--all I could drag--and I started it from the pig, and dragged it to
+the door and through the woods down to the river and dumped it in, and
+down it sunk, out of sight.  You could easy see that something had been
+dragged over the ground.  I did wish Tom Sawyer was there; I knowed he
+would take an interest in this kind of business, and throw in the fancy
+touches.  Nobody could spread himself like Tom Sawyer in such a thing as
+that.
+
+Well, last I pulled out some of my hair, and blooded the axe good, and
+stuck it on the back side, and slung the axe in the corner.  Then I
+took up the pig and held him to my breast with my jacket (so he couldn’t
+drip) till I got a good piece below the house and then dumped him into
+the river.  Now I thought of something else.  So I went and got the bag
+of meal and my old saw out of the canoe, and fetched them to the house.
+ I took the bag to where it used to stand, and ripped a hole in the
+bottom of it with the saw, for there warn’t no knives and forks on the
+place--pap done everything with his clasp-knife about the cooking.  Then
+I carried the sack about a hundred yards across the grass and through
+the willows east of the house, to a shallow lake that was five mile wide
+and full of rushes--and ducks too, you might say, in the season.  There
+was a slough or a creek leading out of it on the other side that went
+miles away, I don’t know where, but it didn’t go to the river.  The meal
+sifted out and made a little track all the way to the lake.  I dropped
+pap’s whetstone there too, so as to look like it had been done by
+accident. Then I tied up the rip in the meal sack with a string, so it
+wouldn’t leak no more, and took it and my saw to the canoe again.
+
+It was about dark now; so I dropped the canoe down the river under some
+willows that hung over the bank, and waited for the moon to rise.  I
+made fast to a willow; then I took a bite to eat, and by and by laid
+down in the canoe to smoke a pipe and lay out a plan.  I says to myself,
+they’ll follow the track of that sackful of rocks to the shore and then
+drag the river for me.  And they’ll follow that meal track to the lake
+and go browsing down the creek that leads out of it to find the robbers
+that killed me and took the things.  They won’t ever hunt the river for
+anything but my dead carcass. They’ll soon get tired of that, and won’t
+bother no more about me.  All right; I can stop anywhere I want to.
+Jackson’s Island is good enough for me; I know that island pretty well,
+and nobody ever comes there.  And then I can paddle over to town nights,
+and slink around and pick up things I want. Jackson’s Island’s the
+place.
+
+I was pretty tired, and the first thing I knowed I was asleep.  When
+I woke up I didn’t know where I was for a minute.  I set up and looked
+around, a little scared.  Then I remembered.  The river looked miles and
+miles across.  The moon was so bright I could a counted the drift logs
+that went a-slipping along, black and still, hundreds of yards out from
+shore. Everything was dead quiet, and it looked late, and _smelt_ late.
+You know what I mean--I don’t know the words to put it in.
+
+I took a good gap and a stretch, and was just going to unhitch and start
+when I heard a sound away over the water.  I listened.  Pretty soon I
+made it out.  It was that dull kind of a regular sound that comes from
+oars working in rowlocks when it’s a still night.  I peeped out through
+the willow branches, and there it was--a skiff, away across the water.
+ I couldn’t tell how many was in it.  It kept a-coming, and when it was
+abreast of me I see there warn’t but one man in it.  Think’s I, maybe
+it’s pap, though I warn’t expecting him.  He dropped below me with the
+current, and by and by he came a-swinging up shore in the easy water,
+and he went by so close I could a reached out the gun and touched him.
+ Well, it _was_ pap, sure enough--and sober, too, by the way he laid his
+oars.
+
+I didn’t lose no time.  The next minute I was a-spinning down stream
+soft but quick in the shade of the bank.  I made two mile and a half,
+and then struck out a quarter of a mile or more towards the middle of
+the river, because pretty soon I would be passing the ferry landing, and
+people might see me and hail me.  I got out amongst the driftwood, and
+then laid down in the bottom of the canoe and let her float.
+
+ I laid there, and had a good rest and a smoke out of my pipe, looking
+away into the sky; not a cloud in it.  The sky looks ever so deep when
+you lay down on your back in the moonshine; I never knowed it before.
+ And how far a body can hear on the water such nights!  I heard people
+talking at the ferry landing. I heard what they said, too--every word
+of it.  One man said it was getting towards the long days and the short
+nights now.  T’other one said _this_ warn’t one of the short ones, he
+reckoned--and then they laughed, and he said it over again, and they
+laughed again; then they waked up another fellow and told him, and
+laughed, but he didn’t laugh; he ripped out something brisk, and said
+let him alone.  The first fellow said he ‘lowed to tell it to his
+old woman--she would think it was pretty good; but he said that warn’t
+nothing to some things he had said in his time. I heard one man say it
+was nearly three o’clock, and he hoped daylight wouldn’t wait more than
+about a week longer.  After that the talk got further and further away,
+and I couldn’t make out the words any more; but I could hear the mumble,
+and now and then a laugh, too, but it seemed a long ways off.
+
+I was away below the ferry now.  I rose up, and there was Jackson’s
+Island, about two mile and a half down stream, heavy timbered and
+standing up out of the middle of the river, big and dark and solid, like
+a steamboat without any lights.  There warn’t any signs of the bar at
+the head--it was all under water now.
+
+It didn’t take me long to get there.  I shot past the head at a ripping
+rate, the current was so swift, and then I got into the dead water and
+landed on the side towards the Illinois shore.  I run the canoe into
+a deep dent in the bank that I knowed about; I had to part the willow
+branches to get in; and when I made fast nobody could a seen the canoe
+from the outside.
+
+I went up and set down on a log at the head of the island, and looked
+out on the big river and the black driftwood and away over to the town,
+three mile away, where there was three or four lights twinkling.  A
+monstrous big lumber-raft was about a mile up stream, coming along down,
+with a lantern in the middle of it.  I watched it come creeping down,
+and when it was most abreast of where I stood I heard a man say, “Stern
+oars, there! heave her head to stabboard!”  I heard that just as plain
+as if the man was by my side.
+
+There was a little gray in the sky now; so I stepped into the woods, and
+laid down for a nap before breakfast.
+
+
+
+
+CHAPTER VIII.
+
+THE sun was up so high when I waked that I judged it was after eight
+o’clock.  I laid there in the grass and the cool shade thinking about
+things, and feeling rested and ruther comfortable and satisfied.  I
+could see the sun out at one or two holes, but mostly it was big trees
+all about, and gloomy in there amongst them.  There was freckled places
+on the ground where the light sifted down through the leaves, and the
+freckled places swapped about a little, showing there was a little
+breeze up there.  A couple of squirrels set on a limb and jabbered at me
+very friendly.
+
+I was powerful lazy and comfortable--didn’t want to get up and cook
+breakfast.  Well, I was dozing off again when I thinks I hears a deep
+sound of “boom!” away up the river.  I rouses up, and rests on my elbow
+and listens; pretty soon I hears it again.  I hopped up, and went and
+looked out at a hole in the leaves, and I see a bunch of smoke laying
+on the water a long ways up--about abreast the ferry.  And there was the
+ferryboat full of people floating along down.  I knowed what was the
+matter now.  “Boom!” I see the white smoke squirt out of the ferryboat’s
+side.  You see, they was firing cannon over the water, trying to make my
+carcass come to the top.
+
+I was pretty hungry, but it warn’t going to do for me to start a fire,
+because they might see the smoke.  So I set there and watched the
+cannon-smoke and listened to the boom.  The river was a mile wide there,
+and it always looks pretty on a summer morning--so I was having a good
+enough time seeing them hunt for my remainders if I only had a bite to
+eat. Well, then I happened to think how they always put quicksilver in
+loaves of bread and float them off, because they always go right to the
+drownded carcass and stop there.  So, says I, I’ll keep a lookout, and
+if any of them’s floating around after me I’ll give them a show.  I
+changed to the Illinois edge of the island to see what luck I could
+have, and I warn’t disappointed.  A big double loaf come along, and I
+most got it with a long stick, but my foot slipped and she floated out
+further.  Of course I was where the current set in the closest to the
+shore--I knowed enough for that.  But by and by along comes another one,
+and this time I won.  I took out the plug and shook out the little dab
+of quicksilver, and set my teeth in.  It was “baker’s bread”--what the
+quality eat; none of your low-down corn-pone.
+
+I got a good place amongst the leaves, and set there on a log, munching
+the bread and watching the ferry-boat, and very well satisfied.  And
+then something struck me.  I says, now I reckon the widow or the parson
+or somebody prayed that this bread would find me, and here it has gone
+and done it.  So there ain’t no doubt but there is something in that
+thing--that is, there’s something in it when a body like the widow or the
+parson prays, but it don’t work for me, and I reckon it don’t work for
+only just the right kind.
+
+I lit a pipe and had a good long smoke, and went on watching.  The
+ferryboat was floating with the current, and I allowed I’d have a chance
+to see who was aboard when she come along, because she would come in
+close, where the bread did.  When she’d got pretty well along down
+towards me, I put out my pipe and went to where I fished out the bread,
+and laid down behind a log on the bank in a little open place.  Where
+the log forked I could peep through.
+
+By and by she come along, and she drifted in so close that they could
+a run out a plank and walked ashore.  Most everybody was on the boat.
+ Pap, and Judge Thatcher, and Bessie Thatcher, and Jo Harper, and Tom
+Sawyer, and his old Aunt Polly, and Sid and Mary, and plenty more.
+ Everybody was talking about the murder, but the captain broke in and
+says:
+
+“Look sharp, now; the current sets in the closest here, and maybe he’s
+washed ashore and got tangled amongst the brush at the water’s edge.  I
+hope so, anyway.”
+
+I didn’t hope so.  They all crowded up and leaned over the rails, nearly
+in my face, and kept still, watching with all their might.  I could see
+them first-rate, but they couldn’t see me.  Then the captain sung out:
+
+“Stand away!” and the cannon let off such a blast right before me that
+it made me deef with the noise and pretty near blind with the smoke, and
+I judged I was gone.  If they’d a had some bullets in, I reckon they’d
+a got the corpse they was after.  Well, I see I warn’t hurt, thanks to
+goodness. The boat floated on and went out of sight around the shoulder
+of the island.  I could hear the booming now and then, further and
+further off, and by and by, after an hour, I didn’t hear it no more.
+ The island was three mile long.  I judged they had got to the foot, and
+was giving it up.  But they didn’t yet a while.  They turned around
+the foot of the island and started up the channel on the Missouri side,
+under steam, and booming once in a while as they went.  I crossed over
+to that side and watched them. When they got abreast the head of the
+island they quit shooting and dropped over to the Missouri shore and
+went home to the town.
+
+I knowed I was all right now.  Nobody else would come a-hunting after
+me. I got my traps out of the canoe and made me a nice camp in the thick
+woods.  I made a kind of a tent out of my blankets to put my things
+under so the rain couldn’t get at them.  I catched a catfish and haggled
+him open with my saw, and towards sundown I started my camp fire and had
+supper.  Then I set out a line to catch some fish for breakfast.
+
+When it was dark I set by my camp fire smoking, and feeling pretty well
+satisfied; but by and by it got sort of lonesome, and so I went and set
+on the bank and listened to the current swashing along, and counted the
+stars and drift logs and rafts that come down, and then went to bed;
+there ain’t no better way to put in time when you are lonesome; you
+can’t stay so, you soon get over it.
+
+And so for three days and nights.  No difference--just the same thing.
+But the next day I went exploring around down through the island.  I was
+boss of it; it all belonged to me, so to say, and I wanted to know
+all about it; but mainly I wanted to put in the time.  I found plenty
+strawberries, ripe and prime; and green summer grapes, and green
+razberries; and the green blackberries was just beginning to show.  They
+would all come handy by and by, I judged.
+
+Well, I went fooling along in the deep woods till I judged I warn’t
+far from the foot of the island.  I had my gun along, but I hadn’t shot
+nothing; it was for protection; thought I would kill some game nigh
+home. About this time I mighty near stepped on a good-sized snake,
+and it went sliding off through the grass and flowers, and I after
+it, trying to get a shot at it. I clipped along, and all of a sudden I
+bounded right on to the ashes of a camp fire that was still smoking.
+
+My heart jumped up amongst my lungs.  I never waited for to look
+further, but uncocked my gun and went sneaking back on my tiptoes as
+fast as ever I could.  Every now and then I stopped a second amongst the
+thick leaves and listened, but my breath come so hard I couldn’t hear
+nothing else.  I slunk along another piece further, then listened again;
+and so on, and so on.  If I see a stump, I took it for a man; if I trod
+on a stick and broke it, it made me feel like a person had cut one of my
+breaths in two and I only got half, and the short half, too.
+
+When I got to camp I warn’t feeling very brash, there warn’t much sand
+in my craw; but I says, this ain’t no time to be fooling around.  So I
+got all my traps into my canoe again so as to have them out of sight,
+and I put out the fire and scattered the ashes around to look like an
+old last year’s camp, and then clumb a tree.
+
+I reckon I was up in the tree two hours; but I didn’t see nothing,
+I didn’t hear nothing--I only _thought_ I heard and seen as much as a
+thousand things.  Well, I couldn’t stay up there forever; so at last I
+got down, but I kept in the thick woods and on the lookout all the
+time. All I could get to eat was berries and what was left over from
+breakfast.
+
+By the time it was night I was pretty hungry.  So when it was good
+and dark I slid out from shore before moonrise and paddled over to the
+Illinois bank--about a quarter of a mile.  I went out in the woods and
+cooked a supper, and I had about made up my mind I would stay there
+all night when I hear a _plunkety-plunk, plunkety-plunk_, and says
+to myself, horses coming; and next I hear people’s voices.  I got
+everything into the canoe as quick as I could, and then went creeping
+through the woods to see what I could find out.  I hadn’t got far when I
+hear a man say:
+
+“We better camp here if we can find a good place; the horses is about
+beat out.  Let’s look around.”
+
+I didn’t wait, but shoved out and paddled away easy.  I tied up in the
+old place, and reckoned I would sleep in the canoe.
+
+I didn’t sleep much.  I couldn’t, somehow, for thinking.  And every time
+I waked up I thought somebody had me by the neck.  So the sleep didn’t
+do me no good.  By and by I says to myself, I can’t live this way; I’m
+a-going to find out who it is that’s here on the island with me; I’ll
+find it out or bust.  Well, I felt better right off.
+
+So I took my paddle and slid out from shore just a step or two, and
+then let the canoe drop along down amongst the shadows.  The moon was
+shining, and outside of the shadows it made it most as light as day.
+ I poked along well on to an hour, everything still as rocks and sound
+asleep. Well, by this time I was most down to the foot of the island.  A
+little ripply, cool breeze begun to blow, and that was as good as saying
+the night was about done.  I give her a turn with the paddle and brung
+her nose to shore; then I got my gun and slipped out and into the edge
+of the woods.  I sat down there on a log, and looked out through the
+leaves.  I see the moon go off watch, and the darkness begin to blanket
+the river. But in a little while I see a pale streak over the treetops,
+and knowed the day was coming.  So I took my gun and slipped off towards
+where I had run across that camp fire, stopping every minute or two
+to listen.  But I hadn’t no luck somehow; I couldn’t seem to find the
+place.  But by and by, sure enough, I catched a glimpse of fire away
+through the trees.  I went for it, cautious and slow.  By and by I was
+close enough to have a look, and there laid a man on the ground.  It
+most give me the fan-tods. He had a blanket around his head, and his
+head was nearly in the fire.  I set there behind a clump of bushes, in
+about six foot of him, and kept my eyes on him steady.  It was getting
+gray daylight now.  Pretty soon he gapped and stretched himself and hove
+off the blanket, and it was Miss Watson’s Jim!  I bet I was glad to see
+him.  I says:
+
+“Hello, Jim!” and skipped out.
+
+He bounced up and stared at me wild.  Then he drops down on his knees,
+and puts his hands together and says:
+
+“Doan’ hurt me--don’t!  I hain’t ever done no harm to a ghos’.  I alwuz
+liked dead people, en done all I could for ‘em.  You go en git in de
+river agin, whah you b’longs, en doan’ do nuffn to Ole Jim, ‘at ‘uz
+awluz yo’ fren’.”
+
+Well, I warn’t long making him understand I warn’t dead.  I was ever so
+glad to see Jim.  I warn’t lonesome now.  I told him I warn’t afraid of
+_him_ telling the people where I was.  I talked along, but he only set
+there and looked at me; never said nothing.  Then I says:
+
+“It’s good daylight.  Le’s get breakfast.  Make up your camp fire good.”
+
+“What’s de use er makin’ up de camp fire to cook strawbries en sich
+truck? But you got a gun, hain’t you?  Den we kin git sumfn better den
+strawbries.”
+
+“Strawberries and such truck,” I says.  “Is that what you live on?”
+
+“I couldn’ git nuffn else,” he says.
+
+“Why, how long you been on the island, Jim?”
+
+“I come heah de night arter you’s killed.”
+
+“What, all that time?”
+
+“Yes--indeedy.”
+
+“And ain’t you had nothing but that kind of rubbage to eat?”
+
+“No, sah--nuffn else.”
+
+“Well, you must be most starved, ain’t you?”
+
+“I reck’n I could eat a hoss.  I think I could. How long you ben on de
+islan’?”
+
+“Since the night I got killed.”
+
+“No!  W’y, what has you lived on?  But you got a gun.  Oh, yes, you got
+a gun.  Dat’s good.  Now you kill sumfn en I’ll make up de fire.”
+
+So we went over to where the canoe was, and while he built a fire in
+a grassy open place amongst the trees, I fetched meal and bacon and
+coffee, and coffee-pot and frying-pan, and sugar and tin cups, and the
+nigger was set back considerable, because he reckoned it was all done
+with witchcraft. I catched a good big catfish, too, and Jim cleaned him
+with his knife, and fried him.
+
+When breakfast was ready we lolled on the grass and eat it smoking hot.
+Jim laid it in with all his might, for he was most about starved.  Then
+when we had got pretty well stuffed, we laid off and lazied.  By and by
+Jim says:
+
+“But looky here, Huck, who wuz it dat ‘uz killed in dat shanty ef it
+warn’t you?”
+
+Then I told him the whole thing, and he said it was smart.  He said Tom
+Sawyer couldn’t get up no better plan than what I had.  Then I says:
+
+“How do you come to be here, Jim, and how’d you get here?”
+
+He looked pretty uneasy, and didn’t say nothing for a minute.  Then he
+says:
+
+“Maybe I better not tell.”
+
+“Why, Jim?”
+
+“Well, dey’s reasons.  But you wouldn’ tell on me ef I uz to tell you,
+would you, Huck?”
+
+“Blamed if I would, Jim.”
+
+“Well, I b’lieve you, Huck.  I--_I run off_.”
+
+“Jim!”
+
+“But mind, you said you wouldn’ tell--you know you said you wouldn’ tell,
+Huck.”
+
+“Well, I did.  I said I wouldn’t, and I’ll stick to it.  Honest _injun_,
+I will.  People would call me a low-down Abolitionist and despise me for
+keeping mum--but that don’t make no difference.  I ain’t a-going to tell,
+and I ain’t a-going back there, anyways.  So, now, le’s know all about
+it.”
+
+“Well, you see, it ‘uz dis way.  Ole missus--dat’s Miss Watson--she pecks
+on me all de time, en treats me pooty rough, but she awluz said she
+wouldn’ sell me down to Orleans.  But I noticed dey wuz a nigger trader
+roun’ de place considable lately, en I begin to git oneasy.  Well, one
+night I creeps to de do’ pooty late, en de do’ warn’t quite shet, en I
+hear old missus tell de widder she gwyne to sell me down to Orleans, but
+she didn’ want to, but she could git eight hund’d dollars for me, en it
+‘uz sich a big stack o’ money she couldn’ resis’.  De widder she try to
+git her to say she wouldn’ do it, but I never waited to hear de res’.  I
+lit out mighty quick, I tell you.
+
+“I tuck out en shin down de hill, en ‘spec to steal a skift ‘long de
+sho’ som’ers ‘bove de town, but dey wuz people a-stirring yit, so I hid
+in de ole tumble-down cooper-shop on de bank to wait for everybody to
+go ‘way. Well, I wuz dah all night.  Dey wuz somebody roun’ all de time.
+ ‘Long ‘bout six in de mawnin’ skifts begin to go by, en ‘bout eight er
+nine every skift dat went ‘long wuz talkin’ ‘bout how yo’ pap come over
+to de town en say you’s killed.  Dese las’ skifts wuz full o’ ladies en
+genlmen a-goin’ over for to see de place.  Sometimes dey’d pull up at
+de sho’ en take a res’ b’fo’ dey started acrost, so by de talk I got to
+know all ‘bout de killin’.  I ‘uz powerful sorry you’s killed, Huck, but
+I ain’t no mo’ now.
+
+“I laid dah under de shavin’s all day.  I ‘uz hungry, but I warn’t
+afeard; bekase I knowed ole missus en de widder wuz goin’ to start to
+de camp-meet’n’ right arter breakfas’ en be gone all day, en dey knows
+I goes off wid de cattle ‘bout daylight, so dey wouldn’ ‘spec to see me
+roun’ de place, en so dey wouldn’ miss me tell arter dark in de evenin’.
+De yuther servants wouldn’ miss me, kase dey’d shin out en take holiday
+soon as de ole folks ‘uz out’n de way.
+
+“Well, when it come dark I tuck out up de river road, en went ‘bout two
+mile er more to whah dey warn’t no houses.  I’d made up my mine ‘bout
+what I’s agwyne to do.  You see, ef I kep’ on tryin’ to git away afoot,
+de dogs ‘ud track me; ef I stole a skift to cross over, dey’d miss dat
+skift, you see, en dey’d know ‘bout whah I’d lan’ on de yuther side, en
+whah to pick up my track.  So I says, a raff is what I’s arter; it doan’
+_make_ no track.
+
+“I see a light a-comin’ roun’ de p’int bymeby, so I wade’ in en shove’
+a log ahead o’ me en swum more’n half way acrost de river, en got in
+‘mongst de drift-wood, en kep’ my head down low, en kinder swum agin de
+current tell de raff come along.  Den I swum to de stern uv it en tuck
+a-holt.  It clouded up en ‘uz pooty dark for a little while.  So I clumb
+up en laid down on de planks.  De men ‘uz all ‘way yonder in de middle,
+whah de lantern wuz.  De river wuz a-risin’, en dey wuz a good current;
+so I reck’n’d ‘at by fo’ in de mawnin’ I’d be twenty-five mile down de
+river, en den I’d slip in jis b’fo’ daylight en swim asho’, en take to
+de woods on de Illinois side.
+
+“But I didn’ have no luck.  When we ‘uz mos’ down to de head er de
+islan’ a man begin to come aft wid de lantern, I see it warn’t no use
+fer to wait, so I slid overboard en struck out fer de islan’.  Well, I
+had a notion I could lan’ mos’ anywhers, but I couldn’t--bank too bluff.
+ I ‘uz mos’ to de foot er de islan’ b’fo’ I found’ a good place.  I went
+into de woods en jedged I wouldn’ fool wid raffs no mo’, long as dey
+move de lantern roun’ so.  I had my pipe en a plug er dog-leg, en some
+matches in my cap, en dey warn’t wet, so I ‘uz all right.”
+
+“And so you ain’t had no meat nor bread to eat all this time?  Why
+didn’t you get mud-turkles?”
+
+“How you gwyne to git ‘m?  You can’t slip up on um en grab um; en how’s
+a body gwyne to hit um wid a rock?  How could a body do it in de night?
+ En I warn’t gwyne to show mysef on de bank in de daytime.”
+
+“Well, that’s so.  You’ve had to keep in the woods all the time, of
+course. Did you hear ‘em shooting the cannon?”
+
+“Oh, yes.  I knowed dey was arter you.  I see um go by heah--watched um
+thoo de bushes.”
+
+Some young birds come along, flying a yard or two at a time and
+lighting. Jim said it was a sign it was going to rain.  He said it was
+a sign when young chickens flew that way, and so he reckoned it was the
+same way when young birds done it.  I was going to catch some of them,
+but Jim wouldn’t let me.  He said it was death.  He said his father laid
+mighty sick once, and some of them catched a bird, and his old granny
+said his father would die, and he did.
+
+And Jim said you mustn’t count the things you are going to cook for
+dinner, because that would bring bad luck.  The same if you shook the
+table-cloth after sundown.  And he said if a man owned a beehive
+and that man died, the bees must be told about it before sun-up next
+morning, or else the bees would all weaken down and quit work and die.
+ Jim said bees wouldn’t sting idiots; but I didn’t believe that, because
+I had tried them lots of times myself, and they wouldn’t sting me.
+
+I had heard about some of these things before, but not all of them.  Jim
+knowed all kinds of signs.  He said he knowed most everything.  I said
+it looked to me like all the signs was about bad luck, and so I asked
+him if there warn’t any good-luck signs.  He says:
+
+“Mighty few--an’ _dey_ ain’t no use to a body.  What you want to know
+when good luck’s a-comin’ for?  Want to keep it off?”  And he said:  “Ef
+you’s got hairy arms en a hairy breas’, it’s a sign dat you’s agwyne
+to be rich. Well, dey’s some use in a sign like dat, ‘kase it’s so fur
+ahead. You see, maybe you’s got to be po’ a long time fust, en so you
+might git discourage’ en kill yo’sef ‘f you didn’ know by de sign dat
+you gwyne to be rich bymeby.”
+
+“Have you got hairy arms and a hairy breast, Jim?”
+
+“What’s de use to ax dat question?  Don’t you see I has?”
+
+“Well, are you rich?”
+
+“No, but I ben rich wunst, and gwyne to be rich agin.  Wunst I had
+foteen dollars, but I tuck to specalat’n’, en got busted out.”
+
+“What did you speculate in, Jim?”
+
+“Well, fust I tackled stock.”
+
+“What kind of stock?”
+
+“Why, live stock--cattle, you know.  I put ten dollars in a cow.  But
+I ain’ gwyne to resk no mo’ money in stock.  De cow up ‘n’ died on my
+han’s.”
+
+“So you lost the ten dollars.”
+
+“No, I didn’t lose it all.  I on’y los’ ‘bout nine of it.  I sole de
+hide en taller for a dollar en ten cents.”
+
+“You had five dollars and ten cents left.  Did you speculate any more?”
+
+“Yes.  You know that one-laigged nigger dat b’longs to old Misto
+Bradish? Well, he sot up a bank, en say anybody dat put in a dollar
+would git fo’ dollars mo’ at de en’ er de year.  Well, all de niggers
+went in, but dey didn’t have much.  I wuz de on’y one dat had much.  So
+I stuck out for mo’ dan fo’ dollars, en I said ‘f I didn’ git it I’d
+start a bank mysef. Well, o’ course dat nigger want’ to keep me out er
+de business, bekase he says dey warn’t business ‘nough for two banks, so
+he say I could put in my five dollars en he pay me thirty-five at de en’
+er de year.
+
+“So I done it.  Den I reck’n’d I’d inves’ de thirty-five dollars right
+off en keep things a-movin’.  Dey wuz a nigger name’ Bob, dat had
+ketched a wood-flat, en his marster didn’ know it; en I bought it off’n
+him en told him to take de thirty-five dollars when de en’ er de
+year come; but somebody stole de wood-flat dat night, en nex day de
+one-laigged nigger say de bank’s busted.  So dey didn’ none uv us git no
+money.”
+
+“What did you do with the ten cents, Jim?”
+
+“Well, I ‘uz gwyne to spen’ it, but I had a dream, en de dream tole me
+to give it to a nigger name’ Balum--Balum’s Ass dey call him for short;
+he’s one er dem chuckleheads, you know.  But he’s lucky, dey say, en I
+see I warn’t lucky.  De dream say let Balum inves’ de ten cents en he’d
+make a raise for me.  Well, Balum he tuck de money, en when he wuz in
+church he hear de preacher say dat whoever give to de po’ len’ to de
+Lord, en boun’ to git his money back a hund’d times.  So Balum he tuck
+en give de ten cents to de po’, en laid low to see what wuz gwyne to
+come of it.”
+
+“Well, what did come of it, Jim?”
+
+“Nuffn never come of it.  I couldn’ manage to k’leck dat money no way;
+en Balum he couldn’.  I ain’ gwyne to len’ no mo’ money ‘dout I see de
+security.  Boun’ to git yo’ money back a hund’d times, de preacher says!
+Ef I could git de ten _cents_ back, I’d call it squah, en be glad er de
+chanst.”
+
+“Well, it’s all right anyway, Jim, long as you’re going to be rich again
+some time or other.”
+
+“Yes; en I’s rich now, come to look at it.  I owns mysef, en I’s wuth
+eight hund’d dollars.  I wisht I had de money, I wouldn’ want no mo’.”
+
+
+
+
+CHAPTER IX.
+
+I wanted to go and look at a place right about the middle of the island
+that I’d found when I was exploring; so we started and soon got to it,
+because the island was only three miles long and a quarter of a mile
+wide.
+
+This place was a tolerable long, steep hill or ridge about forty foot
+high. We had a rough time getting to the top, the sides was so steep and
+the bushes so thick.  We tramped and clumb around all over it, and by
+and by found a good big cavern in the rock, most up to the top on the
+side towards Illinois.  The cavern was as big as two or three rooms
+bunched together, and Jim could stand up straight in it.  It was cool in
+there. Jim was for putting our traps in there right away, but I said we
+didn’t want to be climbing up and down there all the time.
+
+Jim said if we had the canoe hid in a good place, and had all the traps
+in the cavern, we could rush there if anybody was to come to the island,
+and they would never find us without dogs.  And, besides, he said them
+little birds had said it was going to rain, and did I want the things to
+get wet?
+
+So we went back and got the canoe, and paddled up abreast the cavern,
+and lugged all the traps up there.  Then we hunted up a place close by
+to hide the canoe in, amongst the thick willows.  We took some fish off
+of the lines and set them again, and begun to get ready for dinner.
+
+The door of the cavern was big enough to roll a hogshead in, and on one
+side of the door the floor stuck out a little bit, and was flat and a
+good place to build a fire on.  So we built it there and cooked dinner.
+
+We spread the blankets inside for a carpet, and eat our dinner in there.
+We put all the other things handy at the back of the cavern.  Pretty
+soon it darkened up, and begun to thunder and lighten; so the birds was
+right about it.  Directly it begun to rain, and it rained like all fury,
+too, and I never see the wind blow so.  It was one of these regular
+summer storms.  It would get so dark that it looked all blue-black
+outside, and lovely; and the rain would thrash along by so thick that
+the trees off a little ways looked dim and spider-webby; and here would
+come a blast of wind that would bend the trees down and turn up the
+pale underside of the leaves; and then a perfect ripper of a gust would
+follow along and set the branches to tossing their arms as if they
+was just wild; and next, when it was just about the bluest and
+blackest--_FST_! it was as bright as glory, and you’d have a little
+glimpse of tree-tops a-plunging about away off yonder in the storm,
+hundreds of yards further than you could see before; dark as sin again
+in a second, and now you’d hear the thunder let go with an awful crash,
+and then go rumbling, grumbling, tumbling, down the sky towards the
+under side of the world, like rolling empty barrels down stairs--where
+it’s long stairs and they bounce a good deal, you know.
+
+“Jim, this is nice,” I says.  “I wouldn’t want to be nowhere else but
+here. Pass me along another hunk of fish and some hot corn-bread.”
+
+“Well, you wouldn’t a ben here ‘f it hadn’t a ben for Jim.  You’d a ben
+down dah in de woods widout any dinner, en gittn’ mos’ drownded, too;
+dat you would, honey.  Chickens knows when it’s gwyne to rain, en so do
+de birds, chile.”
+
+The river went on raising and raising for ten or twelve days, till at
+last it was over the banks.  The water was three or four foot deep on
+the island in the low places and on the Illinois bottom.  On that side
+it was a good many miles wide, but on the Missouri side it was the same
+old distance across--a half a mile--because the Missouri shore was just a
+wall of high bluffs.
+
+Daytimes we paddled all over the island in the canoe, It was mighty cool
+and shady in the deep woods, even if the sun was blazing outside.  We
+went winding in and out amongst the trees, and sometimes the vines hung
+so thick we had to back away and go some other way.  Well, on every old
+broken-down tree you could see rabbits and snakes and such things; and
+when the island had been overflowed a day or two they got so tame, on
+account of being hungry, that you could paddle right up and put your
+hand on them if you wanted to; but not the snakes and turtles--they would
+slide off in the water.  The ridge our cavern was in was full of them.
+We could a had pets enough if we’d wanted them.
+
+One night we catched a little section of a lumber raft--nice pine planks.
+It was twelve foot wide and about fifteen or sixteen foot long, and
+the top stood above water six or seven inches--a solid, level floor.  We
+could see saw-logs go by in the daylight sometimes, but we let them go;
+we didn’t show ourselves in daylight.
+
+Another night when we was up at the head of the island, just before
+daylight, here comes a frame-house down, on the west side.  She was
+a two-story, and tilted over considerable.  We paddled out and got
+aboard--clumb in at an upstairs window.  But it was too dark to see yet,
+so we made the canoe fast and set in her to wait for daylight.
+
+The light begun to come before we got to the foot of the island.  Then
+we looked in at the window.  We could make out a bed, and a table, and
+two old chairs, and lots of things around about on the floor, and there
+was clothes hanging against the wall.  There was something laying on the
+floor in the far corner that looked like a man.  So Jim says:
+
+“Hello, you!”
+
+But it didn’t budge.  So I hollered again, and then Jim says:
+
+“De man ain’t asleep--he’s dead.  You hold still--I’ll go en see.”
+
+He went, and bent down and looked, and says:
+
+“It’s a dead man.  Yes, indeedy; naked, too.  He’s ben shot in de back.
+I reck’n he’s ben dead two er three days.  Come in, Huck, but doan’ look
+at his face--it’s too gashly.”
+
+I didn’t look at him at all.  Jim throwed some old rags over him, but
+he needn’t done it; I didn’t want to see him.  There was heaps of old
+greasy cards scattered around over the floor, and old whisky bottles,
+and a couple of masks made out of black cloth; and all over the walls
+was the ignorantest kind of words and pictures made with charcoal.
+ There was two old dirty calico dresses, and a sun-bonnet, and some
+women’s underclothes hanging against the wall, and some men’s clothing,
+too.  We put the lot into the canoe--it might come good.  There was a
+boy’s old speckled straw hat on the floor; I took that, too.  And there
+was a bottle that had had milk in it, and it had a rag stopper for a
+baby to suck.  We would a took the bottle, but it was broke.  There was
+a seedy old chest, and an old hair trunk with the hinges broke.  They
+stood open, but there warn’t nothing left in them that was any account.
+ The way things was scattered about we reckoned the people left in a
+hurry, and warn’t fixed so as to carry off most of their stuff.
+
+We got an old tin lantern, and a butcher-knife without any handle, and
+a bran-new Barlow knife worth two bits in any store, and a lot of tallow
+candles, and a tin candlestick, and a gourd, and a tin cup, and a ratty
+old bedquilt off the bed, and a reticule with needles and pins and
+beeswax and buttons and thread and all such truck in it, and a hatchet
+and some nails, and a fishline as thick as my little finger with some
+monstrous hooks on it, and a roll of buckskin, and a leather dog-collar,
+and a horseshoe, and some vials of medicine that didn’t have no label
+on them; and just as we was leaving I found a tolerable good curry-comb,
+and Jim he found a ratty old fiddle-bow, and a wooden leg.  The straps
+was broke off of it, but, barring that, it was a good enough leg, though
+it was too long for me and not long enough for Jim, and we couldn’t find
+the other one, though we hunted all around.
+
+And so, take it all around, we made a good haul.  When we was ready to
+shove off we was a quarter of a mile below the island, and it was pretty
+broad day; so I made Jim lay down in the canoe and cover up with the
+quilt, because if he set up people could tell he was a nigger a good
+ways off.  I paddled over to the Illinois shore, and drifted down most
+a half a mile doing it.  I crept up the dead water under the bank, and
+hadn’t no accidents and didn’t see nobody.  We got home all safe.
+
+
+
+
+CHAPTER X.
+
+AFTER breakfast I wanted to talk about the dead man and guess out how he
+come to be killed, but Jim didn’t want to.  He said it would fetch bad
+luck; and besides, he said, he might come and ha’nt us; he said a man
+that warn’t buried was more likely to go a-ha’nting around than one
+that was planted and comfortable.  That sounded pretty reasonable, so
+I didn’t say no more; but I couldn’t keep from studying over it and
+wishing I knowed who shot the man, and what they done it for.
+
+We rummaged the clothes we’d got, and found eight dollars in silver
+sewed up in the lining of an old blanket overcoat.  Jim said he reckoned
+the people in that house stole the coat, because if they’d a knowed the
+money was there they wouldn’t a left it.  I said I reckoned they killed
+him, too; but Jim didn’t want to talk about that.  I says:
+
+“Now you think it’s bad luck; but what did you say when I fetched in the
+snake-skin that I found on the top of the ridge day before yesterday?
+You said it was the worst bad luck in the world to touch a snake-skin
+with my hands.  Well, here’s your bad luck!  We’ve raked in all this
+truck and eight dollars besides.  I wish we could have some bad luck
+like this every day, Jim.”
+
+“Never you mind, honey, never you mind.  Don’t you git too peart.  It’s
+a-comin’.  Mind I tell you, it’s a-comin’.”
+
+It did come, too.  It was a Tuesday that we had that talk.  Well, after
+dinner Friday we was laying around in the grass at the upper end of the
+ridge, and got out of tobacco.  I went to the cavern to get some, and
+found a rattlesnake in there.  I killed him, and curled him up on the
+foot of Jim’s blanket, ever so natural, thinking there’d be some fun
+when Jim found him there.  Well, by night I forgot all about the snake,
+and when Jim flung himself down on the blanket while I struck a light
+the snake’s mate was there, and bit him.
+
+He jumped up yelling, and the first thing the light showed was the
+varmint curled up and ready for another spring.  I laid him out in a
+second with a stick, and Jim grabbed pap’s whisky-jug and begun to pour
+it down.
+
+He was barefooted, and the snake bit him right on the heel.  That all
+comes of my being such a fool as to not remember that wherever you leave
+a dead snake its mate always comes there and curls around it.  Jim told
+me to chop off the snake’s head and throw it away, and then skin the
+body and roast a piece of it.  I done it, and he eat it and said it
+would help cure him. He made me take off the rattles and tie them around
+his wrist, too.  He said that that would help.  Then I slid out quiet
+and throwed the snakes clear away amongst the bushes; for I warn’t going
+to let Jim find out it was all my fault, not if I could help it.
+
+Jim sucked and sucked at the jug, and now and then he got out of his
+head and pitched around and yelled; but every time he come to himself he
+went to sucking at the jug again.  His foot swelled up pretty big, and
+so did his leg; but by and by the drunk begun to come, and so I judged
+he was all right; but I’d druther been bit with a snake than pap’s
+whisky.
+
+Jim was laid up for four days and nights.  Then the swelling was all
+gone and he was around again.  I made up my mind I wouldn’t ever take
+a-holt of a snake-skin again with my hands, now that I see what had come
+of it. Jim said he reckoned I would believe him next time.  And he said
+that handling a snake-skin was such awful bad luck that maybe we hadn’t
+got to the end of it yet.  He said he druther see the new moon over his
+left shoulder as much as a thousand times than take up a snake-skin
+in his hand.  Well, I was getting to feel that way myself, though I’ve
+always reckoned that looking at the new moon over your left shoulder is
+one of the carelessest and foolishest things a body can do.  Old Hank
+Bunker done it once, and bragged about it; and in less than two years he
+got drunk and fell off of the shot-tower, and spread himself out so
+that he was just a kind of a layer, as you may say; and they slid him
+edgeways between two barn doors for a coffin, and buried him so, so
+they say, but I didn’t see it.  Pap told me.  But anyway it all come of
+looking at the moon that way, like a fool.
+
+Well, the days went along, and the river went down between its banks
+again; and about the first thing we done was to bait one of the big
+hooks with a skinned rabbit and set it and catch a catfish that was
+as big as a man, being six foot two inches long, and weighed over two
+hundred pounds. We couldn’t handle him, of course; he would a flung us
+into Illinois.  We just set there and watched him rip and tear around
+till he drownded.  We found a brass button in his stomach and a round
+ball, and lots of rubbage.  We split the ball open with the hatchet,
+and there was a spool in it.  Jim said he’d had it there a long time, to
+coat it over so and make a ball of it.  It was as big a fish as was ever
+catched in the Mississippi, I reckon.  Jim said he hadn’t ever seen
+a bigger one.  He would a been worth a good deal over at the village.
+ They peddle out such a fish as that by the pound in the market-house
+there; everybody buys some of him; his meat’s as white as snow and makes
+a good fry.
+
+Next morning I said it was getting slow and dull, and I wanted to get a
+stirring up some way.  I said I reckoned I would slip over the river and
+find out what was going on.  Jim liked that notion; but he said I
+must go in the dark and look sharp.  Then he studied it over and said,
+couldn’t I put on some of them old things and dress up like a girl?
+ That was a good notion, too.  So we shortened up one of the calico
+gowns, and I turned up my trouser-legs to my knees and got into it.  Jim
+hitched it behind with the hooks, and it was a fair fit.  I put on the
+sun-bonnet and tied it under my chin, and then for a body to look in
+and see my face was like looking down a joint of stove-pipe.  Jim said
+nobody would know me, even in the daytime, hardly.  I practiced around
+all day to get the hang of the things, and by and by I could do pretty
+well in them, only Jim said I didn’t walk like a girl; and he said
+I must quit pulling up my gown to get at my britches-pocket.  I took
+notice, and done better.
+
+I started up the Illinois shore in the canoe just after dark.
+
+I started across to the town from a little below the ferry-landing, and
+the drift of the current fetched me in at the bottom of the town.  I
+tied up and started along the bank.  There was a light burning in a
+little shanty that hadn’t been lived in for a long time, and I wondered
+who had took up quarters there.  I slipped up and peeped in at the
+window.  There was a woman about forty year old in there knitting by
+a candle that was on a pine table.  I didn’t know her face; she was a
+stranger, for you couldn’t start a face in that town that I didn’t know.
+ Now this was lucky, because I was weakening; I was getting afraid I had
+come; people might know my voice and find me out.  But if this woman had
+been in such a little town two days she could tell me all I wanted to
+know; so I knocked at the door, and made up my mind I wouldn’t forget I
+was a girl.
+
+
+
+
+CHAPTER XI.
+
+“COME in,” says the woman, and I did.  She says:  “Take a cheer.”
+
+I done it.  She looked me all over with her little shiny eyes, and says:
+
+“What might your name be?”
+
+“Sarah Williams.”
+
+“Where ‘bouts do you live?  In this neighborhood?’
+
+“No’m.  In Hookerville, seven mile below.  I’ve walked all the way and
+I’m all tired out.”
+
+“Hungry, too, I reckon.  I’ll find you something.”
+
+“No’m, I ain’t hungry.  I was so hungry I had to stop two miles below
+here at a farm; so I ain’t hungry no more.  It’s what makes me so late.
+My mother’s down sick, and out of money and everything, and I come to
+tell my uncle Abner Moore.  He lives at the upper end of the town, she
+says.  I hain’t ever been here before.  Do you know him?”
+
+“No; but I don’t know everybody yet.  I haven’t lived here quite two
+weeks. It’s a considerable ways to the upper end of the town.  You
+better stay here all night.  Take off your bonnet.”
+
+“No,” I says; “I’ll rest a while, I reckon, and go on.  I ain’t afeared
+of the dark.”
+
+She said she wouldn’t let me go by myself, but her husband would be in
+by and by, maybe in a hour and a half, and she’d send him along with me.
+Then she got to talking about her husband, and about her relations up
+the river, and her relations down the river, and about how much better
+off they used to was, and how they didn’t know but they’d made a mistake
+coming to our town, instead of letting well alone--and so on and so on,
+till I was afeard I had made a mistake coming to her to find out what
+was going on in the town; but by and by she dropped on to pap and the
+murder, and then I was pretty willing to let her clatter right along.
+ She told about me and Tom Sawyer finding the six thousand dollars (only
+she got it ten) and all about pap and what a hard lot he was, and what
+a hard lot I was, and at last she got down to where I was murdered.  I
+says:
+
+“Who done it?  We’ve heard considerable about these goings on down in
+Hookerville, but we don’t know who ‘twas that killed Huck Finn.”
+
+“Well, I reckon there’s a right smart chance of people _here_ that’d
+like to know who killed him.  Some think old Finn done it himself.”
+
+“No--is that so?”
+
+“Most everybody thought it at first.  He’ll never know how nigh he come
+to getting lynched.  But before night they changed around and judged it
+was done by a runaway nigger named Jim.”
+
+“Why _he_--”
+
+I stopped.  I reckoned I better keep still.  She run on, and never
+noticed I had put in at all:
+
+“The nigger run off the very night Huck Finn was killed.  So there’s a
+reward out for him--three hundred dollars.  And there’s a reward out for
+old Finn, too--two hundred dollars.  You see, he come to town the
+morning after the murder, and told about it, and was out with ‘em on the
+ferryboat hunt, and right away after he up and left.  Before night they
+wanted to lynch him, but he was gone, you see.  Well, next day they
+found out the nigger was gone; they found out he hadn’t ben seen sence
+ten o’clock the night the murder was done.  So then they put it on him,
+you see; and while they was full of it, next day, back comes old Finn,
+and went boo-hooing to Judge Thatcher to get money to hunt for the
+nigger all over Illinois with. The judge gave him some, and that evening
+he got drunk, and was around till after midnight with a couple of mighty
+hard-looking strangers, and then went off with them.  Well, he hain’t
+come back sence, and they ain’t looking for him back till this thing
+blows over a little, for people thinks now that he killed his boy and
+fixed things so folks would think robbers done it, and then he’d get
+Huck’s money without having to bother a long time with a lawsuit.
+ People do say he warn’t any too good to do it.  Oh, he’s sly, I reckon.
+ If he don’t come back for a year he’ll be all right.  You can’t prove
+anything on him, you know; everything will be quieted down then, and
+he’ll walk in Huck’s money as easy as nothing.”
+
+“Yes, I reckon so, ‘m.  I don’t see nothing in the way of it.  Has
+everybody quit thinking the nigger done it?”
+
+“Oh, no, not everybody.  A good many thinks he done it.  But they’ll get
+the nigger pretty soon now, and maybe they can scare it out of him.”
+
+“Why, are they after him yet?”
+
+“Well, you’re innocent, ain’t you!  Does three hundred dollars lay
+around every day for people to pick up?  Some folks think the nigger
+ain’t far from here.  I’m one of them--but I hain’t talked it around.  A
+few days ago I was talking with an old couple that lives next door in
+the log shanty, and they happened to say hardly anybody ever goes to
+that island over yonder that they call Jackson’s Island.  Don’t anybody
+live there? says I. No, nobody, says they.  I didn’t say any more, but
+I done some thinking.  I was pretty near certain I’d seen smoke over
+there, about the head of the island, a day or two before that, so I says
+to myself, like as not that nigger’s hiding over there; anyway, says
+I, it’s worth the trouble to give the place a hunt.  I hain’t seen any
+smoke sence, so I reckon maybe he’s gone, if it was him; but husband’s
+going over to see--him and another man.  He was gone up the river; but he
+got back to-day, and I told him as soon as he got here two hours ago.”
+
+I had got so uneasy I couldn’t set still.  I had to do something with my
+hands; so I took up a needle off of the table and went to threading
+it. My hands shook, and I was making a bad job of it.  When the woman
+stopped talking I looked up, and she was looking at me pretty curious
+and smiling a little.  I put down the needle and thread, and let on to
+be interested--and I was, too--and says:
+
+“Three hundred dollars is a power of money.  I wish my mother could get
+it. Is your husband going over there to-night?”
+
+“Oh, yes.  He went up-town with the man I was telling you of, to get a
+boat and see if they could borrow another gun.  They’ll go over after
+midnight.”
+
+“Couldn’t they see better if they was to wait till daytime?”
+
+“Yes.  And couldn’t the nigger see better, too?  After midnight he’ll
+likely be asleep, and they can slip around through the woods and hunt up
+his camp fire all the better for the dark, if he’s got one.”
+
+“I didn’t think of that.”
+
+The woman kept looking at me pretty curious, and I didn’t feel a bit
+comfortable.  Pretty soon she says,
+
+“What did you say your name was, honey?”
+
+“M--Mary Williams.”
+
+Somehow it didn’t seem to me that I said it was Mary before, so I didn’t
+look up--seemed to me I said it was Sarah; so I felt sort of cornered,
+and was afeared maybe I was looking it, too.  I wished the woman would
+say something more; the longer she set still the uneasier I was.  But
+now she says:
+
+“Honey, I thought you said it was Sarah when you first come in?”
+
+“Oh, yes’m, I did.  Sarah Mary Williams.  Sarah’s my first name.  Some
+calls me Sarah, some calls me Mary.”
+
+“Oh, that’s the way of it?”
+
+“Yes’m.”
+
+I was feeling better then, but I wished I was out of there, anyway.  I
+couldn’t look up yet.
+
+Well, the woman fell to talking about how hard times was, and how poor
+they had to live, and how the rats was as free as if they owned the
+place, and so forth and so on, and then I got easy again.  She was right
+about the rats. You’d see one stick his nose out of a hole in the corner
+every little while.  She said she had to have things handy to throw at
+them when she was alone, or they wouldn’t give her no peace.  She showed
+me a bar of lead twisted up into a knot, and said she was a good shot
+with it generly, but she’d wrenched her arm a day or two ago, and didn’t
+know whether she could throw true now.  But she watched for a chance,
+and directly banged away at a rat; but she missed him wide, and said
+“Ouch!” it hurt her arm so.  Then she told me to try for the next one.
+ I wanted to be getting away before the old man got back, but of course
+I didn’t let on.  I got the thing, and the first rat that showed his
+nose I let drive, and if he’d a stayed where he was he’d a been a
+tolerable sick rat.  She said that was first-rate, and she reckoned I
+would hive the next one.  She went and got the lump of lead and fetched
+it back, and brought along a hank of yarn which she wanted me to help
+her with.  I held up my two hands and she put the hank over them, and
+went on talking about her and her husband’s matters.  But she broke off
+to say:
+
+“Keep your eye on the rats.  You better have the lead in your lap,
+handy.”
+
+So she dropped the lump into my lap just at that moment, and I clapped
+my legs together on it and she went on talking.  But only about a
+minute. Then she took off the hank and looked me straight in the face,
+and very pleasant, and says:
+
+“Come, now, what’s your real name?”
+
+“Wh--what, mum?”
+
+“What’s your real name?  Is it Bill, or Tom, or Bob?--or what is it?”
+
+I reckon I shook like a leaf, and I didn’t know hardly what to do.  But
+I says:
+
+“Please to don’t poke fun at a poor girl like me, mum.  If I’m in the
+way here, I’ll--”
+
+“No, you won’t.  Set down and stay where you are.  I ain’t going to hurt
+you, and I ain’t going to tell on you, nuther.  You just tell me your
+secret, and trust me.  I’ll keep it; and, what’s more, I’ll help
+you. So’ll my old man if you want him to.  You see, you’re a runaway
+‘prentice, that’s all.  It ain’t anything.  There ain’t no harm in it.
+You’ve been treated bad, and you made up your mind to cut.  Bless you,
+child, I wouldn’t tell on you.  Tell me all about it now, that’s a good
+boy.”
+
+So I said it wouldn’t be no use to try to play it any longer, and I
+would just make a clean breast and tell her everything, but she musn’t
+go back on her promise.  Then I told her my father and mother was dead,
+and the law had bound me out to a mean old farmer in the country thirty
+mile back from the river, and he treated me so bad I couldn’t stand it
+no longer; he went away to be gone a couple of days, and so I took my
+chance and stole some of his daughter’s old clothes and cleared out, and
+I had been three nights coming the thirty miles.  I traveled nights,
+and hid daytimes and slept, and the bag of bread and meat I carried from
+home lasted me all the way, and I had a-plenty.  I said I believed my
+uncle Abner Moore would take care of me, and so that was why I struck
+out for this town of Goshen.
+
+“Goshen, child?  This ain’t Goshen.  This is St. Petersburg.  Goshen’s
+ten mile further up the river.  Who told you this was Goshen?”
+
+“Why, a man I met at daybreak this morning, just as I was going to turn
+into the woods for my regular sleep.  He told me when the roads forked I
+must take the right hand, and five mile would fetch me to Goshen.”
+
+“He was drunk, I reckon.  He told you just exactly wrong.”
+
+“Well, he did act like he was drunk, but it ain’t no matter now.  I got
+to be moving along.  I’ll fetch Goshen before daylight.”
+
+“Hold on a minute.  I’ll put you up a snack to eat.  You might want it.”
+
+So she put me up a snack, and says:
+
+“Say, when a cow’s laying down, which end of her gets up first?  Answer
+up prompt now--don’t stop to study over it.  Which end gets up first?”
+
+“The hind end, mum.”
+
+“Well, then, a horse?”
+
+“The for’rard end, mum.”
+
+“Which side of a tree does the moss grow on?”
+
+“North side.”
+
+“If fifteen cows is browsing on a hillside, how many of them eats with
+their heads pointed the same direction?”
+
+“The whole fifteen, mum.”
+
+“Well, I reckon you _have_ lived in the country.  I thought maybe you
+was trying to hocus me again.  What’s your real name, now?”
+
+“George Peters, mum.”
+
+“Well, try to remember it, George.  Don’t forget and tell me it’s
+Elexander before you go, and then get out by saying it’s George
+Elexander when I catch you.  And don’t go about women in that old
+calico.  You do a girl tolerable poor, but you might fool men, maybe.
+ Bless you, child, when you set out to thread a needle don’t hold the
+thread still and fetch the needle up to it; hold the needle still and
+poke the thread at it; that’s the way a woman most always does, but a
+man always does t’other way.  And when you throw at a rat or anything,
+hitch yourself up a tiptoe and fetch your hand up over your head as
+awkward as you can, and miss your rat about six or seven foot. Throw
+stiff-armed from the shoulder, like there was a pivot there for it to
+turn on, like a girl; not from the wrist and elbow, with your arm out
+to one side, like a boy.  And, mind you, when a girl tries to catch
+anything in her lap she throws her knees apart; she don’t clap them
+together, the way you did when you catched the lump of lead.  Why, I
+spotted you for a boy when you was threading the needle; and I contrived
+the other things just to make certain.  Now trot along to your uncle,
+Sarah Mary Williams George Elexander Peters, and if you get into trouble
+you send word to Mrs. Judith Loftus, which is me, and I’ll do what I can
+to get you out of it.  Keep the river road all the way, and next time
+you tramp take shoes and socks with you. The river road’s a rocky one,
+and your feet’ll be in a condition when you get to Goshen, I reckon.”
+
+I went up the bank about fifty yards, and then I doubled on my tracks
+and slipped back to where my canoe was, a good piece below the house.  I
+jumped in, and was off in a hurry.  I went up-stream far enough to
+make the head of the island, and then started across.  I took off the
+sun-bonnet, for I didn’t want no blinders on then.  When I was about the
+middle I heard the clock begin to strike, so I stops and listens; the
+sound come faint over the water but clear--eleven.  When I struck the
+head of the island I never waited to blow, though I was most winded, but
+I shoved right into the timber where my old camp used to be, and started
+a good fire there on a high and dry spot.
+
+Then I jumped in the canoe and dug out for our place, a mile and a half
+below, as hard as I could go.  I landed, and slopped through the timber
+and up the ridge and into the cavern.  There Jim laid, sound asleep on
+the ground.  I roused him out and says:
+
+“Git up and hump yourself, Jim!  There ain’t a minute to lose.  They’re
+after us!”
+
+Jim never asked no questions, he never said a word; but the way he
+worked for the next half an hour showed about how he was scared.  By
+that time everything we had in the world was on our raft, and she was
+ready to be shoved out from the willow cove where she was hid.  We
+put out the camp fire at the cavern the first thing, and didn’t show a
+candle outside after that.
+
+I took the canoe out from the shore a little piece, and took a look;
+but if there was a boat around I couldn’t see it, for stars and shadows
+ain’t good to see by.  Then we got out the raft and slipped along down
+in the shade, past the foot of the island dead still--never saying a
+word.
+
+
+
+
+CHAPTER XII.
+
+IT must a been close on to one o’clock when we got below the island at
+last, and the raft did seem to go mighty slow.  If a boat was to come
+along we was going to take to the canoe and break for the Illinois
+shore; and it was well a boat didn’t come, for we hadn’t ever thought to
+put the gun in the canoe, or a fishing-line, or anything to eat.  We
+was in ruther too much of a sweat to think of so many things.  It warn’t
+good judgment to put _everything_ on the raft.
+
+If the men went to the island I just expect they found the camp fire I
+built, and watched it all night for Jim to come.  Anyways, they stayed
+away from us, and if my building the fire never fooled them it warn’t no
+fault of mine.  I played it as low down on them as I could.
+
+When the first streak of day began to show we tied up to a towhead in a
+big bend on the Illinois side, and hacked off cottonwood branches with
+the hatchet, and covered up the raft with them so she looked like there
+had been a cave-in in the bank there.  A tow-head is a sandbar that has
+cottonwoods on it as thick as harrow-teeth.
+
+We had mountains on the Missouri shore and heavy timber on the Illinois
+side, and the channel was down the Missouri shore at that place, so we
+warn’t afraid of anybody running across us.  We laid there all day,
+and watched the rafts and steamboats spin down the Missouri shore, and
+up-bound steamboats fight the big river in the middle.  I told Jim all
+about the time I had jabbering with that woman; and Jim said she was
+a smart one, and if she was to start after us herself she wouldn’t set
+down and watch a camp fire--no, sir, she’d fetch a dog.  Well, then, I
+said, why couldn’t she tell her husband to fetch a dog?  Jim said he
+bet she did think of it by the time the men was ready to start, and he
+believed they must a gone up-town to get a dog and so they lost all that
+time, or else we wouldn’t be here on a towhead sixteen or seventeen mile
+below the village--no, indeedy, we would be in that same old town again.
+ So I said I didn’t care what was the reason they didn’t get us as long
+as they didn’t.
+
+When it was beginning to come on dark we poked our heads out of the
+cottonwood thicket, and looked up and down and across; nothing in sight;
+so Jim took up some of the top planks of the raft and built a snug
+wigwam to get under in blazing weather and rainy, and to keep the things
+dry. Jim made a floor for the wigwam, and raised it a foot or more above
+the level of the raft, so now the blankets and all the traps was out of
+reach of steamboat waves.  Right in the middle of the wigwam we made a
+layer of dirt about five or six inches deep with a frame around it for
+to hold it to its place; this was to build a fire on in sloppy weather
+or chilly; the wigwam would keep it from being seen.  We made an extra
+steering-oar, too, because one of the others might get broke on a snag
+or something. We fixed up a short forked stick to hang the old lantern
+on, because we must always light the lantern whenever we see a steamboat
+coming down-stream, to keep from getting run over; but we wouldn’t have
+to light it for up-stream boats unless we see we was in what they call
+a “crossing”; for the river was pretty high yet, very low banks being
+still a little under water; so up-bound boats didn’t always run the
+channel, but hunted easy water.
+
+This second night we run between seven and eight hours, with a current
+that was making over four mile an hour.  We catched fish and talked,
+and we took a swim now and then to keep off sleepiness.  It was kind of
+solemn, drifting down the big, still river, laying on our backs looking
+up at the stars, and we didn’t ever feel like talking loud, and it
+warn’t often that we laughed--only a little kind of a low chuckle.  We
+had mighty good weather as a general thing, and nothing ever happened to
+us at all--that night, nor the next, nor the next.
+
+Every night we passed towns, some of them away up on black hillsides,
+nothing but just a shiny bed of lights; not a house could you see.  The
+fifth night we passed St. Louis, and it was like the whole world lit up.
+In St. Petersburg they used to say there was twenty or thirty thousand
+people in St. Louis, but I never believed it till I see that wonderful
+spread of lights at two o’clock that still night.  There warn’t a sound
+there; everybody was asleep.
+
+Every night now I used to slip ashore towards ten o’clock at some little
+village, and buy ten or fifteen cents’ worth of meal or bacon or other
+stuff to eat; and sometimes I lifted a chicken that warn’t roosting
+comfortable, and took him along.  Pap always said, take a chicken when
+you get a chance, because if you don’t want him yourself you can easy
+find somebody that does, and a good deed ain’t ever forgot.  I never see
+pap when he didn’t want the chicken himself, but that is what he used to
+say, anyway.
+
+Mornings before daylight I slipped into cornfields and borrowed a
+watermelon, or a mushmelon, or a punkin, or some new corn, or things of
+that kind.  Pap always said it warn’t no harm to borrow things if you
+was meaning to pay them back some time; but the widow said it warn’t
+anything but a soft name for stealing, and no decent body would do it.
+ Jim said he reckoned the widow was partly right and pap was partly
+right; so the best way would be for us to pick out two or three things
+from the list and say we wouldn’t borrow them any more--then he reckoned
+it wouldn’t be no harm to borrow the others.  So we talked it over all
+one night, drifting along down the river, trying to make up our minds
+whether to drop the watermelons, or the cantelopes, or the mushmelons,
+or what.  But towards daylight we got it all settled satisfactory, and
+concluded to drop crabapples and p’simmons.  We warn’t feeling just
+right before that, but it was all comfortable now.  I was glad the way
+it come out, too, because crabapples ain’t ever good, and the p’simmons
+wouldn’t be ripe for two or three months yet.
+
+We shot a water-fowl now and then that got up too early in the morning
+or didn’t go to bed early enough in the evening.  Take it all round, we
+lived pretty high.
+
+The fifth night below St. Louis we had a big storm after midnight, with
+a power of thunder and lightning, and the rain poured down in a solid
+sheet. We stayed in the wigwam and let the raft take care of itself.
+When the lightning glared out we could see a big straight river ahead,
+and high, rocky bluffs on both sides.  By and by says I, “Hel-_lo_, Jim,
+looky yonder!” It was a steamboat that had killed herself on a rock.
+ We was drifting straight down for her.  The lightning showed her very
+distinct.  She was leaning over, with part of her upper deck above
+water, and you could see every little chimbly-guy clean and clear, and a
+chair by the big bell, with an old slouch hat hanging on the back of it,
+when the flashes come.
+
+Well, it being away in the night and stormy, and all so mysterious-like,
+I felt just the way any other boy would a felt when I see that wreck
+laying there so mournful and lonesome in the middle of the river.  I
+wanted to get aboard of her and slink around a little, and see what
+there was there.  So I says:
+
+“Le’s land on her, Jim.”
+
+But Jim was dead against it at first.  He says:
+
+“I doan’ want to go fool’n ‘long er no wrack.  We’s doin’ blame’ well,
+en we better let blame’ well alone, as de good book says.  Like as not
+dey’s a watchman on dat wrack.”
+
+“Watchman your grandmother,” I says; “there ain’t nothing to watch but
+the texas and the pilot-house; and do you reckon anybody’s going to resk
+his life for a texas and a pilot-house such a night as this, when
+it’s likely to break up and wash off down the river any minute?”  Jim
+couldn’t say nothing to that, so he didn’t try.  “And besides,” I says,
+“we might borrow something worth having out of the captain’s stateroom.
+ Seegars, I bet you--and cost five cents apiece, solid cash.  Steamboat
+captains is always rich, and get sixty dollars a month, and _they_ don’t
+care a cent what a thing costs, you know, long as they want it.  Stick a
+candle in your pocket; I can’t rest, Jim, till we give her a rummaging.
+ Do you reckon Tom Sawyer would ever go by this thing?  Not for pie, he
+wouldn’t. He’d call it an adventure--that’s what he’d call it; and he’d
+land on that wreck if it was his last act.  And wouldn’t he throw style
+into it?--wouldn’t he spread himself, nor nothing?  Why, you’d think it
+was Christopher C’lumbus discovering Kingdom-Come.  I wish Tom Sawyer
+_was_ here.”
+
+Jim he grumbled a little, but give in.  He said we mustn’t talk any more
+than we could help, and then talk mighty low.  The lightning showed us
+the wreck again just in time, and we fetched the stabboard derrick, and
+made fast there.
+
+The deck was high out here.  We went sneaking down the slope of it to
+labboard, in the dark, towards the texas, feeling our way slow with our
+feet, and spreading our hands out to fend off the guys, for it was so
+dark we couldn’t see no sign of them.  Pretty soon we struck the forward
+end of the skylight, and clumb on to it; and the next step fetched us in
+front of the captain’s door, which was open, and by Jimminy, away down
+through the texas-hall we see a light! and all in the same second we
+seem to hear low voices in yonder!
+
+Jim whispered and said he was feeling powerful sick, and told me to come
+along.  I says, all right, and was going to start for the raft; but just
+then I heard a voice wail out and say:
+
+“Oh, please don’t, boys; I swear I won’t ever tell!”
+
+Another voice said, pretty loud:
+
+“It’s a lie, Jim Turner.  You’ve acted this way before.  You always want
+more’n your share of the truck, and you’ve always got it, too, because
+you’ve swore ‘t if you didn’t you’d tell.  But this time you’ve said
+it jest one time too many.  You’re the meanest, treacherousest hound in
+this country.”
+
+By this time Jim was gone for the raft.  I was just a-biling with
+curiosity; and I says to myself, Tom Sawyer wouldn’t back out now,
+and so I won’t either; I’m a-going to see what’s going on here.  So I
+dropped on my hands and knees in the little passage, and crept aft
+in the dark till there warn’t but one stateroom betwixt me and the
+cross-hall of the texas.  Then in there I see a man stretched on the
+floor and tied hand and foot, and two men standing over him, and one
+of them had a dim lantern in his hand, and the other one had a pistol.
+ This one kept pointing the pistol at the man’s head on the floor, and
+saying:
+
+“I’d _like_ to!  And I orter, too--a mean skunk!”
+
+The man on the floor would shrivel up and say, “Oh, please don’t, Bill;
+I hain’t ever goin’ to tell.”
+
+And every time he said that the man with the lantern would laugh and
+say:
+
+“‘Deed you _ain’t!_  You never said no truer thing ‘n that, you bet
+you.” And once he said:  “Hear him beg! and yit if we hadn’t got the
+best of him and tied him he’d a killed us both.  And what _for_?  Jist
+for noth’n. Jist because we stood on our _rights_--that’s what for.  But
+I lay you ain’t a-goin’ to threaten nobody any more, Jim Turner.  Put
+_up_ that pistol, Bill.”
+
+Bill says:
+
+“I don’t want to, Jake Packard.  I’m for killin’ him--and didn’t he kill
+old Hatfield jist the same way--and don’t he deserve it?”
+
+“But I don’t _want_ him killed, and I’ve got my reasons for it.”
+
+“Bless yo’ heart for them words, Jake Packard!  I’ll never forgit you
+long’s I live!” says the man on the floor, sort of blubbering.
+
+Packard didn’t take no notice of that, but hung up his lantern on a nail
+and started towards where I was there in the dark, and motioned Bill
+to come.  I crawfished as fast as I could about two yards, but the boat
+slanted so that I couldn’t make very good time; so to keep from getting
+run over and catched I crawled into a stateroom on the upper side.
+ The man came a-pawing along in the dark, and when Packard got to my
+stateroom, he says:
+
+“Here--come in here.”
+
+And in he come, and Bill after him.  But before they got in I was up
+in the upper berth, cornered, and sorry I come.  Then they stood there,
+with their hands on the ledge of the berth, and talked.  I couldn’t see
+them, but I could tell where they was by the whisky they’d been having.
+ I was glad I didn’t drink whisky; but it wouldn’t made much difference
+anyway, because most of the time they couldn’t a treed me because I
+didn’t breathe.  I was too scared.  And, besides, a body _couldn’t_
+breathe and hear such talk.  They talked low and earnest.  Bill wanted
+to kill Turner.  He says:
+
+“He’s said he’ll tell, and he will.  If we was to give both our shares
+to him _now_ it wouldn’t make no difference after the row and the way
+we’ve served him.  Shore’s you’re born, he’ll turn State’s evidence; now
+you hear _me_.  I’m for putting him out of his troubles.”
+
+“So’m I,” says Packard, very quiet.
+
+“Blame it, I’d sorter begun to think you wasn’t.  Well, then, that’s all
+right.  Le’s go and do it.”
+
+“Hold on a minute; I hain’t had my say yit.  You listen to me.
+Shooting’s good, but there’s quieter ways if the thing’s _got_ to be
+done. But what I say is this:  it ain’t good sense to go court’n around
+after a halter if you can git at what you’re up to in some way that’s
+jist as good and at the same time don’t bring you into no resks.  Ain’t
+that so?”
+
+“You bet it is.  But how you goin’ to manage it this time?”
+
+“Well, my idea is this:  we’ll rustle around and gather up whatever
+pickins we’ve overlooked in the staterooms, and shove for shore and hide
+the truck. Then we’ll wait.  Now I say it ain’t a-goin’ to be more’n two
+hours befo’ this wrack breaks up and washes off down the river.  See?
+He’ll be drownded, and won’t have nobody to blame for it but his own
+self.  I reckon that’s a considerble sight better ‘n killin’ of him.
+ I’m unfavorable to killin’ a man as long as you can git aroun’ it; it
+ain’t good sense, it ain’t good morals.  Ain’t I right?”
+
+“Yes, I reck’n you are.  But s’pose she _don’t_ break up and wash off?”
+
+“Well, we can wait the two hours anyway and see, can’t we?”
+
+“All right, then; come along.”
+
+So they started, and I lit out, all in a cold sweat, and scrambled
+forward. It was dark as pitch there; but I said, in a kind of a coarse
+whisper, “Jim!” and he answered up, right at my elbow, with a sort of a
+moan, and I says:
+
+“Quick, Jim, it ain’t no time for fooling around and moaning; there’s a
+gang of murderers in yonder, and if we don’t hunt up their boat and set
+her drifting down the river so these fellows can’t get away from the
+wreck there’s one of ‘em going to be in a bad fix.  But if we find their
+boat we can put _all_ of ‘em in a bad fix--for the sheriff ‘ll get ‘em.
+Quick--hurry!  I’ll hunt the labboard side, you hunt the stabboard. You
+start at the raft, and--”
+
+“Oh, my lordy, lordy!  _raf’_?  Dey ain’ no raf’ no mo’; she done broke
+loose en gone I--en here we is!”
+
+
+
+
+CHAPTER XIII.
+
+WELL, I catched my breath and most fainted.  Shut up on a wreck with
+such a gang as that!  But it warn’t no time to be sentimentering.  We’d
+_got_ to find that boat now--had to have it for ourselves.  So we went
+a-quaking and shaking down the stabboard side, and slow work it was,
+too--seemed a week before we got to the stern.  No sign of a boat.  Jim
+said he didn’t believe he could go any further--so scared he hadn’t
+hardly any strength left, he said.  But I said, come on, if we get left
+on this wreck we are in a fix, sure.  So on we prowled again.  We struck
+for the stern of the texas, and found it, and then scrabbled along
+forwards on the skylight, hanging on from shutter to shutter, for the
+edge of the skylight was in the water.  When we got pretty close to the
+cross-hall door there was the skiff, sure enough!  I could just barely
+see her.  I felt ever so thankful.  In another second I would a been
+aboard of her, but just then the door opened.  One of the men stuck his
+head out only about a couple of foot from me, and I thought I was gone;
+but he jerked it in again, and says:
+
+“Heave that blame lantern out o’ sight, Bill!”
+
+He flung a bag of something into the boat, and then got in himself and
+set down.  It was Packard.  Then Bill _he_ come out and got in.  Packard
+says, in a low voice:
+
+“All ready--shove off!”
+
+I couldn’t hardly hang on to the shutters, I was so weak.  But Bill
+says:
+
+“Hold on--‘d you go through him?”
+
+“No.  Didn’t you?”
+
+“No.  So he’s got his share o’ the cash yet.”
+
+“Well, then, come along; no use to take truck and leave money.”
+
+“Say, won’t he suspicion what we’re up to?”
+
+“Maybe he won’t.  But we got to have it anyway. Come along.”
+
+So they got out and went in.
+
+The door slammed to because it was on the careened side; and in a half
+second I was in the boat, and Jim come tumbling after me.  I out with my
+knife and cut the rope, and away we went!
+
+We didn’t touch an oar, and we didn’t speak nor whisper, nor hardly even
+breathe.  We went gliding swift along, dead silent, past the tip of the
+paddle-box, and past the stern; then in a second or two more we was a
+hundred yards below the wreck, and the darkness soaked her up, every
+last sign of her, and we was safe, and knowed it.
+
+When we was three or four hundred yards down-stream we see the lantern
+show like a little spark at the texas door for a second, and we knowed
+by that that the rascals had missed their boat, and was beginning to
+understand that they was in just as much trouble now as Jim Turner was.
+
+Then Jim manned the oars, and we took out after our raft.  Now was the
+first time that I begun to worry about the men--I reckon I hadn’t
+had time to before.  I begun to think how dreadful it was, even for
+murderers, to be in such a fix.  I says to myself, there ain’t no
+telling but I might come to be a murderer myself yet, and then how would
+I like it?  So says I to Jim:
+
+“The first light we see we’ll land a hundred yards below it or above
+it, in a place where it’s a good hiding-place for you and the skiff, and
+then I’ll go and fix up some kind of a yarn, and get somebody to go for
+that gang and get them out of their scrape, so they can be hung when
+their time comes.”
+
+But that idea was a failure; for pretty soon it begun to storm again,
+and this time worse than ever.  The rain poured down, and never a light
+showed; everybody in bed, I reckon.  We boomed along down the river,
+watching for lights and watching for our raft.  After a long time the
+rain let up, but the clouds stayed, and the lightning kept whimpering,
+and by and by a flash showed us a black thing ahead, floating, and we
+made for it.
+
+It was the raft, and mighty glad was we to get aboard of it again.  We
+seen a light now away down to the right, on shore.  So I said I would
+go for it. The skiff was half full of plunder which that gang had stole
+there on the wreck.  We hustled it on to the raft in a pile, and I told
+Jim to float along down, and show a light when he judged he had gone
+about two mile, and keep it burning till I come; then I manned my oars
+and shoved for the light.  As I got down towards it three or four more
+showed--up on a hillside.  It was a village.  I closed in above the shore
+light, and laid on my oars and floated.  As I went by I see it was a
+lantern hanging on the jackstaff of a double-hull ferryboat.  I skimmed
+around for the watchman, a-wondering whereabouts he slept; and by and
+by I found him roosting on the bitts forward, with his head down between
+his knees.  I gave his shoulder two or three little shoves, and begun to
+cry.
+
+He stirred up in a kind of a startlish way; but when he see it was only
+me he took a good gap and stretch, and then he says:
+
+“Hello, what’s up?  Don’t cry, bub.  What’s the trouble?”
+
+I says:
+
+“Pap, and mam, and sis, and--”
+
+Then I broke down.  He says:
+
+“Oh, dang it now, _don’t_ take on so; we all has to have our troubles,
+and this ‘n ‘ll come out all right.  What’s the matter with ‘em?”
+
+“They’re--they’re--are you the watchman of the boat?”
+
+“Yes,” he says, kind of pretty-well-satisfied like.  “I’m the captain
+and the owner and the mate and the pilot and watchman and head
+deck-hand; and sometimes I’m the freight and passengers.  I ain’t as
+rich as old Jim Hornback, and I can’t be so blame’ generous and good
+to Tom, Dick, and Harry as what he is, and slam around money the way he
+does; but I’ve told him a many a time ‘t I wouldn’t trade places with
+him; for, says I, a sailor’s life’s the life for me, and I’m derned if
+_I’d_ live two mile out o’ town, where there ain’t nothing ever goin’
+on, not for all his spondulicks and as much more on top of it.  Says I--”
+
+I broke in and says:
+
+“They’re in an awful peck of trouble, and--”
+
+“_Who_ is?”
+
+“Why, pap and mam and sis and Miss Hooker; and if you’d take your
+ferryboat and go up there--”
+
+“Up where?  Where are they?”
+
+“On the wreck.”
+
+“What wreck?”
+
+“Why, there ain’t but one.”
+
+“What, you don’t mean the Walter Scott?”
+
+“Yes.”
+
+“Good land! what are they doin’ _there_, for gracious sakes?”
+
+“Well, they didn’t go there a-purpose.”
+
+“I bet they didn’t!  Why, great goodness, there ain’t no chance for ‘em
+if they don’t git off mighty quick!  Why, how in the nation did they
+ever git into such a scrape?”
+
+“Easy enough.  Miss Hooker was a-visiting up there to the town--”
+
+“Yes, Booth’s Landing--go on.”
+
+“She was a-visiting there at Booth’s Landing, and just in the edge of
+the evening she started over with her nigger woman in the horse-ferry
+to stay all night at her friend’s house, Miss What-you-may-call-her I
+disremember her name--and they lost their steering-oar, and swung
+around and went a-floating down, stern first, about two mile, and
+saddle-baggsed on the wreck, and the ferryman and the nigger woman and
+the horses was all lost, but Miss Hooker she made a grab and got aboard
+the wreck.  Well, about an hour after dark we come along down in our
+trading-scow, and it was so dark we didn’t notice the wreck till we was
+right on it; and so _we_ saddle-baggsed; but all of us was saved but
+Bill Whipple--and oh, he _was_ the best cretur!--I most wish ‘t it had
+been me, I do.”
+
+“My George!  It’s the beatenest thing I ever struck.  And _then_ what
+did you all do?”
+
+“Well, we hollered and took on, but it’s so wide there we couldn’t
+make nobody hear.  So pap said somebody got to get ashore and get help
+somehow. I was the only one that could swim, so I made a dash for it,
+and Miss Hooker she said if I didn’t strike help sooner, come here and
+hunt up her uncle, and he’d fix the thing.  I made the land about a mile
+below, and been fooling along ever since, trying to get people to do
+something, but they said, ‘What, in such a night and such a current?
+There ain’t no sense in it; go for the steam ferry.’  Now if you’ll go
+and--”
+
+“By Jackson, I’d _like_ to, and, blame it, I don’t know but I will; but
+who in the dingnation’s a-going’ to _pay_ for it?  Do you reckon your
+pap--”
+
+“Why _that’s_ all right.  Miss Hooker she tole me, _particular_, that
+her uncle Hornback--”
+
+“Great guns! is _he_ her uncle?  Looky here, you break for that light
+over yonder-way, and turn out west when you git there, and about a
+quarter of a mile out you’ll come to the tavern; tell ‘em to dart you
+out to Jim Hornback’s, and he’ll foot the bill.  And don’t you fool
+around any, because he’ll want to know the news.  Tell him I’ll have
+his niece all safe before he can get to town.  Hump yourself, now; I’m
+a-going up around the corner here to roust out my engineer.”
+
+I struck for the light, but as soon as he turned the corner I went back
+and got into my skiff and bailed her out, and then pulled up shore in
+the easy water about six hundred yards, and tucked myself in among
+some woodboats; for I couldn’t rest easy till I could see the ferryboat
+start. But take it all around, I was feeling ruther comfortable on
+accounts of taking all this trouble for that gang, for not many would
+a done it.  I wished the widow knowed about it.  I judged she would be
+proud of me for helping these rapscallions, because rapscallions and
+dead beats is the kind the widow and good people takes the most interest
+in.
+
+Well, before long here comes the wreck, dim and dusky, sliding along
+down! A kind of cold shiver went through me, and then I struck out for
+her.  She was very deep, and I see in a minute there warn’t much chance
+for anybody being alive in her.  I pulled all around her and hollered
+a little, but there wasn’t any answer; all dead still.  I felt a little
+bit heavy-hearted about the gang, but not much, for I reckoned if they
+could stand it I could.
+
+Then here comes the ferryboat; so I shoved for the middle of the river
+on a long down-stream slant; and when I judged I was out of eye-reach
+I laid on my oars, and looked back and see her go and smell around the
+wreck for Miss Hooker’s remainders, because the captain would know her
+uncle Hornback would want them; and then pretty soon the ferryboat give
+it up and went for the shore, and I laid into my work and went a-booming
+down the river.
+
+It did seem a powerful long time before Jim’s light showed up; and when
+it did show it looked like it was a thousand mile off.  By the time I
+got there the sky was beginning to get a little gray in the east; so we
+struck for an island, and hid the raft, and sunk the skiff, and turned
+in and slept like dead people.
+
+
+
+
+CHAPTER XIV.
+
+BY and by, when we got up, we turned over the truck the gang had stole
+off of the wreck, and found boots, and blankets, and clothes, and all
+sorts of other things, and a lot of books, and a spyglass, and three
+boxes of seegars.  We hadn’t ever been this rich before in neither of
+our lives.  The seegars was prime.  We laid off all the afternoon in the
+woods talking, and me reading the books, and having a general good
+time. I told Jim all about what happened inside the wreck and at the
+ferryboat, and I said these kinds of things was adventures; but he said
+he didn’t want no more adventures.  He said that when I went in the
+texas and he crawled back to get on the raft and found her gone he
+nearly died, because he judged it was all up with _him_ anyway it could
+be fixed; for if he didn’t get saved he would get drownded; and if he
+did get saved, whoever saved him would send him back home so as to get
+the reward, and then Miss Watson would sell him South, sure.  Well, he
+was right; he was most always right; he had an uncommon level head for a
+nigger.
+
+I read considerable to Jim about kings and dukes and earls and such, and
+how gaudy they dressed, and how much style they put on, and called each
+other your majesty, and your grace, and your lordship, and so on, ‘stead
+of mister; and Jim’s eyes bugged out, and he was interested.  He says:
+
+“I didn’ know dey was so many un um.  I hain’t hearn ‘bout none un um,
+skasely, but ole King Sollermun, onless you counts dem kings dat’s in a
+pack er k’yards.  How much do a king git?”
+
+“Get?”  I says; “why, they get a thousand dollars a month if they want
+it; they can have just as much as they want; everything belongs to
+them.”
+
+“_Ain’_ dat gay?  En what dey got to do, Huck?”
+
+“_They_ don’t do nothing!  Why, how you talk! They just set around.”
+
+“No; is dat so?”
+
+“Of course it is.  They just set around--except, maybe, when there’s a
+war; then they go to the war.  But other times they just lazy around; or
+go hawking--just hawking and sp--Sh!--d’ you hear a noise?”
+
+We skipped out and looked; but it warn’t nothing but the flutter of a
+steamboat’s wheel away down, coming around the point; so we come back.
+
+“Yes,” says I, “and other times, when things is dull, they fuss with the
+parlyment; and if everybody don’t go just so he whacks their heads off.
+But mostly they hang round the harem.”
+
+“Roun’ de which?”
+
+“Harem.”
+
+“What’s de harem?”
+
+“The place where he keeps his wives.  Don’t you know about the harem?
+Solomon had one; he had about a million wives.”
+
+“Why, yes, dat’s so; I--I’d done forgot it.  A harem’s a bo’d’n-house, I
+reck’n.  Mos’ likely dey has rackety times in de nussery.  En I reck’n
+de wives quarrels considable; en dat ‘crease de racket.  Yit dey say
+Sollermun de wises’ man dat ever live’.  I doan’ take no stock in
+dat. Bekase why: would a wise man want to live in de mids’ er sich a
+blim-blammin’ all de time?  No--‘deed he wouldn’t.  A wise man ‘ud take
+en buil’ a biler-factry; en den he could shet _down_ de biler-factry
+when he want to res’.”
+
+“Well, but he _was_ the wisest man, anyway; because the widow she told
+me so, her own self.”
+
+“I doan k’yer what de widder say, he _warn’t_ no wise man nuther.  He
+had some er de dad-fetchedes’ ways I ever see.  Does you know ‘bout dat
+chile dat he ‘uz gwyne to chop in two?”
+
+“Yes, the widow told me all about it.”
+
+“_Well_, den!  Warn’ dat de beatenes’ notion in de worl’?  You jes’
+take en look at it a minute.  Dah’s de stump, dah--dat’s one er de women;
+heah’s you--dat’s de yuther one; I’s Sollermun; en dish yer dollar bill’s
+de chile.  Bofe un you claims it.  What does I do?  Does I shin aroun’
+mongs’ de neighbors en fine out which un you de bill _do_ b’long to, en
+han’ it over to de right one, all safe en soun’, de way dat anybody dat
+had any gumption would?  No; I take en whack de bill in _two_, en give
+half un it to you, en de yuther half to de yuther woman.  Dat’s de way
+Sollermun was gwyne to do wid de chile.  Now I want to ast you:  what’s
+de use er dat half a bill?--can’t buy noth’n wid it.  En what use is a
+half a chile?  I wouldn’ give a dern for a million un um.”
+
+“But hang it, Jim, you’ve clean missed the point--blame it, you’ve missed
+it a thousand mile.”
+
+“Who?  Me?  Go ‘long.  Doan’ talk to me ‘bout yo’ pints.  I reck’n I
+knows sense when I sees it; en dey ain’ no sense in sich doin’s as
+dat. De ‘spute warn’t ‘bout a half a chile, de ‘spute was ‘bout a whole
+chile; en de man dat think he kin settle a ‘spute ‘bout a whole chile
+wid a half a chile doan’ know enough to come in out’n de rain.  Doan’
+talk to me ‘bout Sollermun, Huck, I knows him by de back.”
+
+“But I tell you you don’t get the point.”
+
+“Blame de point!  I reck’n I knows what I knows.  En mine you, de _real_
+pint is down furder--it’s down deeper.  It lays in de way Sollermun was
+raised.  You take a man dat’s got on’y one or two chillen; is dat man
+gwyne to be waseful o’ chillen?  No, he ain’t; he can’t ‘ford it.  _He_
+know how to value ‘em.  But you take a man dat’s got ‘bout five million
+chillen runnin’ roun’ de house, en it’s diffunt.  _He_ as soon chop a
+chile in two as a cat. Dey’s plenty mo’.  A chile er two, mo’ er less,
+warn’t no consekens to Sollermun, dad fatch him!”
+
+I never see such a nigger.  If he got a notion in his head once, there
+warn’t no getting it out again.  He was the most down on Solomon of
+any nigger I ever see.  So I went to talking about other kings, and let
+Solomon slide.  I told about Louis Sixteenth that got his head cut off
+in France long time ago; and about his little boy the dolphin, that
+would a been a king, but they took and shut him up in jail, and some say
+he died there.
+
+“Po’ little chap.”
+
+“But some says he got out and got away, and come to America.”
+
+“Dat’s good!  But he’ll be pooty lonesome--dey ain’ no kings here, is
+dey, Huck?”
+
+“No.”
+
+“Den he cain’t git no situation.  What he gwyne to do?”
+
+“Well, I don’t know.  Some of them gets on the police, and some of them
+learns people how to talk French.”
+
+“Why, Huck, doan’ de French people talk de same way we does?”
+
+“_No_, Jim; you couldn’t understand a word they said--not a single word.”
+
+“Well, now, I be ding-busted!  How do dat come?”
+
+“I don’t know; but it’s so.  I got some of their jabber out of a book.
+S’pose a man was to come to you and say Polly-voo-franzy--what would you
+think?”
+
+“I wouldn’ think nuff’n; I’d take en bust him over de head--dat is, if he
+warn’t white.  I wouldn’t ‘low no nigger to call me dat.”
+
+“Shucks, it ain’t calling you anything.  It’s only saying, do you know
+how to talk French?”
+
+“Well, den, why couldn’t he _say_ it?”
+
+“Why, he _is_ a-saying it.  That’s a Frenchman’s _way_ of saying it.”
+
+“Well, it’s a blame ridicklous way, en I doan’ want to hear no mo’ ‘bout
+it.  Dey ain’ no sense in it.”
+
+“Looky here, Jim; does a cat talk like we do?”
+
+“No, a cat don’t.”
+
+“Well, does a cow?”
+
+“No, a cow don’t, nuther.”
+
+“Does a cat talk like a cow, or a cow talk like a cat?”
+
+“No, dey don’t.”
+
+“It’s natural and right for ‘em to talk different from each other, ain’t
+it?”
+
+“Course.”
+
+“And ain’t it natural and right for a cat and a cow to talk different
+from _us_?”
+
+“Why, mos’ sholy it is.”
+
+“Well, then, why ain’t it natural and right for a _Frenchman_ to talk
+different from us?  You answer me that.”
+
+“Is a cat a man, Huck?”
+
+“No.”
+
+“Well, den, dey ain’t no sense in a cat talkin’ like a man.  Is a cow a
+man?--er is a cow a cat?”
+
+“No, she ain’t either of them.”
+
+“Well, den, she ain’t got no business to talk like either one er the
+yuther of ‘em.  Is a Frenchman a man?”
+
+“Yes.”
+
+“_Well_, den!  Dad blame it, why doan’ he _talk_ like a man?  You answer
+me _dat_!”
+
+I see it warn’t no use wasting words--you can’t learn a nigger to argue.
+So I quit.
+
+
+
+
+CHAPTER XV.
+
+WE judged that three nights more would fetch us to Cairo, at the bottom
+of Illinois, where the Ohio River comes in, and that was what we was
+after.  We would sell the raft and get on a steamboat and go way up the
+Ohio amongst the free States, and then be out of trouble.
+
+Well, the second night a fog begun to come on, and we made for a towhead
+to tie to, for it wouldn’t do to try to run in a fog; but when I paddled
+ahead in the canoe, with the line to make fast, there warn’t anything
+but little saplings to tie to.  I passed the line around one of them
+right on the edge of the cut bank, but there was a stiff current, and
+the raft come booming down so lively she tore it out by the roots and
+away she went.  I see the fog closing down, and it made me so sick and
+scared I couldn’t budge for most a half a minute it seemed to me--and
+then there warn’t no raft in sight; you couldn’t see twenty yards.  I
+jumped into the canoe and run back to the stern, and grabbed the paddle
+and set her back a stroke.  But she didn’t come.  I was in such a hurry
+I hadn’t untied her.  I got up and tried to untie her, but I was so
+excited my hands shook so I couldn’t hardly do anything with them.
+
+As soon as I got started I took out after the raft, hot and heavy, right
+down the towhead.  That was all right as far as it went, but the towhead
+warn’t sixty yards long, and the minute I flew by the foot of it I shot
+out into the solid white fog, and hadn’t no more idea which way I was
+going than a dead man.
+
+Thinks I, it won’t do to paddle; first I know I’ll run into the bank
+or a towhead or something; I got to set still and float, and yet it’s
+mighty fidgety business to have to hold your hands still at such a time.
+ I whooped and listened.  Away down there somewheres I hears a small
+whoop, and up comes my spirits.  I went tearing after it, listening
+sharp to hear it again.  The next time it come I see I warn’t heading
+for it, but heading away to the right of it.  And the next time I was
+heading away to the left of it--and not gaining on it much either, for
+I was flying around, this way and that and t’other, but it was going
+straight ahead all the time.
+
+I did wish the fool would think to beat a tin pan, and beat it all the
+time, but he never did, and it was the still places between the whoops
+that was making the trouble for me.  Well, I fought along, and directly
+I hears the whoop _behind_ me.  I was tangled good now.  That was
+somebody else’s whoop, or else I was turned around.
+
+I throwed the paddle down.  I heard the whoop again; it was behind me
+yet, but in a different place; it kept coming, and kept changing its
+place, and I kept answering, till by and by it was in front of me again,
+and I knowed the current had swung the canoe’s head down-stream, and I
+was all right if that was Jim and not some other raftsman hollering.
+ I couldn’t tell nothing about voices in a fog, for nothing don’t look
+natural nor sound natural in a fog.
+
+The whooping went on, and in about a minute I come a-booming down on a
+cut bank with smoky ghosts of big trees on it, and the current throwed
+me off to the left and shot by, amongst a lot of snags that fairly
+roared, the currrent was tearing by them so swift.
+
+In another second or two it was solid white and still again.  I set
+perfectly still then, listening to my heart thump, and I reckon I didn’t
+draw a breath while it thumped a hundred.
+
+I just give up then.  I knowed what the matter was.  That cut bank
+was an island, and Jim had gone down t’other side of it.  It warn’t no
+towhead that you could float by in ten minutes.  It had the big timber
+of a regular island; it might be five or six miles long and more than
+half a mile wide.
+
+I kept quiet, with my ears cocked, about fifteen minutes, I reckon.  I
+was floating along, of course, four or five miles an hour; but you don’t
+ever think of that.  No, you _feel_ like you are laying dead still on
+the water; and if a little glimpse of a snag slips by you don’t think to
+yourself how fast _you’re_ going, but you catch your breath and think,
+my! how that snag’s tearing along.  If you think it ain’t dismal and
+lonesome out in a fog that way by yourself in the night, you try it
+once--you’ll see.
+
+Next, for about a half an hour, I whoops now and then; at last I hears
+the answer a long ways off, and tries to follow it, but I couldn’t do
+it, and directly I judged I’d got into a nest of towheads, for I had
+little dim glimpses of them on both sides of me--sometimes just a narrow
+channel between, and some that I couldn’t see I knowed was there because
+I’d hear the wash of the current against the old dead brush and trash
+that hung over the banks.  Well, I warn’t long loosing the whoops down
+amongst the towheads; and I only tried to chase them a little while,
+anyway, because it was worse than chasing a Jack-o’-lantern.  You never
+knowed a sound dodge around so, and swap places so quick and so much.
+
+I had to claw away from the bank pretty lively four or five times, to
+keep from knocking the islands out of the river; and so I judged the
+raft must be butting into the bank every now and then, or else it would
+get further ahead and clear out of hearing--it was floating a little
+faster than what I was.
+
+Well, I seemed to be in the open river again by and by, but I couldn’t
+hear no sign of a whoop nowheres.  I reckoned Jim had fetched up on a
+snag, maybe, and it was all up with him.  I was good and tired, so I
+laid down in the canoe and said I wouldn’t bother no more.  I didn’t
+want to go to sleep, of course; but I was so sleepy I couldn’t help it;
+so I thought I would take jest one little cat-nap.
+
+But I reckon it was more than a cat-nap, for when I waked up the stars
+was shining bright, the fog was all gone, and I was spinning down a
+big bend stern first.  First I didn’t know where I was; I thought I was
+dreaming; and when things began to come back to me they seemed to come
+up dim out of last week.
+
+It was a monstrous big river here, with the tallest and the thickest
+kind of timber on both banks; just a solid wall, as well as I could see
+by the stars.  I looked away down-stream, and seen a black speck on the
+water. I took after it; but when I got to it it warn’t nothing but a
+couple of sawlogs made fast together.  Then I see another speck, and
+chased that; then another, and this time I was right.  It was the raft.
+
+When I got to it Jim was setting there with his head down between his
+knees, asleep, with his right arm hanging over the steering-oar.  The
+other oar was smashed off, and the raft was littered up with leaves and
+branches and dirt.  So she’d had a rough time.
+
+I made fast and laid down under Jim’s nose on the raft, and began to
+gap, and stretch my fists out against Jim, and says:
+
+“Hello, Jim, have I been asleep?  Why didn’t you stir me up?”
+
+“Goodness gracious, is dat you, Huck?  En you ain’ dead--you ain’
+drownded--you’s back agin?  It’s too good for true, honey, it’s too good
+for true. Lemme look at you chile, lemme feel o’ you.  No, you ain’
+dead! you’s back agin, ‘live en soun’, jis de same ole Huck--de same ole
+Huck, thanks to goodness!”
+
+“What’s the matter with you, Jim?  You been a-drinking?”
+
+“Drinkin’?  Has I ben a-drinkin’?  Has I had a chance to be a-drinkin’?”
+
+“Well, then, what makes you talk so wild?”
+
+“How does I talk wild?”
+
+“_How_?  Why, hain’t you been talking about my coming back, and all that
+stuff, as if I’d been gone away?”
+
+“Huck--Huck Finn, you look me in de eye; look me in de eye.  _Hain’t_ you
+ben gone away?”
+
+“Gone away?  Why, what in the nation do you mean?  I hain’t been gone
+anywheres.  Where would I go to?”
+
+“Well, looky here, boss, dey’s sumf’n wrong, dey is.  Is I _me_, or who
+_is_ I? Is I heah, or whah _is_ I?  Now dat’s what I wants to know.”
+
+“Well, I think you’re here, plain enough, but I think you’re a
+tangle-headed old fool, Jim.”
+
+“I is, is I?  Well, you answer me dis:  Didn’t you tote out de line in
+de canoe fer to make fas’ to de tow-head?”
+
+“No, I didn’t.  What tow-head?  I hain’t see no tow-head.”
+
+“You hain’t seen no towhead?  Looky here, didn’t de line pull loose en
+de raf’ go a-hummin’ down de river, en leave you en de canoe behine in
+de fog?”
+
+“What fog?”
+
+“Why, de fog!--de fog dat’s been aroun’ all night.  En didn’t you whoop,
+en didn’t I whoop, tell we got mix’ up in de islands en one un us got
+los’ en t’other one was jis’ as good as los’, ‘kase he didn’ know whah
+he wuz? En didn’t I bust up agin a lot er dem islands en have a turrible
+time en mos’ git drownded?  Now ain’ dat so, boss--ain’t it so?  You
+answer me dat.”
+
+“Well, this is too many for me, Jim.  I hain’t seen no fog, nor no
+islands, nor no troubles, nor nothing.  I been setting here talking with
+you all night till you went to sleep about ten minutes ago, and I reckon
+I done the same.  You couldn’t a got drunk in that time, so of course
+you’ve been dreaming.”
+
+“Dad fetch it, how is I gwyne to dream all dat in ten minutes?”
+
+“Well, hang it all, you did dream it, because there didn’t any of it
+happen.”
+
+“But, Huck, it’s all jis’ as plain to me as--”
+
+“It don’t make no difference how plain it is; there ain’t nothing in it.
+I know, because I’ve been here all the time.”
+
+Jim didn’t say nothing for about five minutes, but set there studying
+over it.  Then he says:
+
+“Well, den, I reck’n I did dream it, Huck; but dog my cats ef it ain’t
+de powerfullest dream I ever see.  En I hain’t ever had no dream b’fo’
+dat’s tired me like dis one.”
+
+“Oh, well, that’s all right, because a dream does tire a body like
+everything sometimes.  But this one was a staving dream; tell me all
+about it, Jim.”
+
+So Jim went to work and told me the whole thing right through, just as
+it happened, only he painted it up considerable.  Then he said he must
+start in and “‘terpret” it, because it was sent for a warning.  He said
+the first towhead stood for a man that would try to do us some good, but
+the current was another man that would get us away from him.  The whoops
+was warnings that would come to us every now and then, and if we didn’t
+try hard to make out to understand them they’d just take us into bad
+luck, ‘stead of keeping us out of it.  The lot of towheads was troubles
+we was going to get into with quarrelsome people and all kinds of mean
+folks, but if we minded our business and didn’t talk back and aggravate
+them, we would pull through and get out of the fog and into the big
+clear river, which was the free States, and wouldn’t have no more
+trouble.
+
+It had clouded up pretty dark just after I got on to the raft, but it
+was clearing up again now.
+
+“Oh, well, that’s all interpreted well enough as far as it goes, Jim,” I
+says; “but what does _these_ things stand for?”
+
+It was the leaves and rubbish on the raft and the smashed oar.  You
+could see them first-rate now.
+
+Jim looked at the trash, and then looked at me, and back at the trash
+again.  He had got the dream fixed so strong in his head that he
+couldn’t seem to shake it loose and get the facts back into its place
+again right away.  But when he did get the thing straightened around he
+looked at me steady without ever smiling, and says:
+
+“What do dey stan’ for?  I’se gwyne to tell you.  When I got all wore
+out wid work, en wid de callin’ for you, en went to sleep, my heart wuz
+mos’ broke bekase you wuz los’, en I didn’ k’yer no’ mo’ what become
+er me en de raf’.  En when I wake up en fine you back agin, all safe
+en soun’, de tears come, en I could a got down on my knees en kiss yo’
+foot, I’s so thankful. En all you wuz thinkin’ ‘bout wuz how you could
+make a fool uv ole Jim wid a lie.  Dat truck dah is _trash_; en trash
+is what people is dat puts dirt on de head er dey fren’s en makes ‘em
+ashamed.”
+
+Then he got up slow and walked to the wigwam, and went in there without
+saying anything but that.  But that was enough.  It made me feel so mean
+I could almost kissed _his_ foot to get him to take it back.
+
+It was fifteen minutes before I could work myself up to go and humble
+myself to a nigger; but I done it, and I warn’t ever sorry for it
+afterwards, neither.  I didn’t do him no more mean tricks, and I
+wouldn’t done that one if I’d a knowed it would make him feel that way.
+
+
+
+
+CHAPTER XVI.
+
+WE slept most all day, and started out at night, a little ways behind a
+monstrous long raft that was as long going by as a procession.  She had
+four long sweeps at each end, so we judged she carried as many as thirty
+men, likely.  She had five big wigwams aboard, wide apart, and an open
+camp fire in the middle, and a tall flag-pole at each end.  There was a
+power of style about her.  It _amounted_ to something being a raftsman
+on such a craft as that.
+
+We went drifting down into a big bend, and the night clouded up and got
+hot.  The river was very wide, and was walled with solid timber on
+both sides; you couldn’t see a break in it hardly ever, or a light.  We
+talked about Cairo, and wondered whether we would know it when we got to
+it.  I said likely we wouldn’t, because I had heard say there warn’t but
+about a dozen houses there, and if they didn’t happen to have them lit
+up, how was we going to know we was passing a town?  Jim said if the two
+big rivers joined together there, that would show.  But I said maybe
+we might think we was passing the foot of an island and coming into the
+same old river again. That disturbed Jim--and me too.  So the question
+was, what to do?  I said, paddle ashore the first time a light showed,
+and tell them pap was behind, coming along with a trading-scow, and
+was a green hand at the business, and wanted to know how far it was to
+Cairo.  Jim thought it was a good idea, so we took a smoke on it and
+waited.
+
+There warn’t nothing to do now but to look out sharp for the town, and
+not pass it without seeing it.  He said he’d be mighty sure to see it,
+because he’d be a free man the minute he seen it, but if he missed it
+he’d be in a slave country again and no more show for freedom.  Every
+little while he jumps up and says:
+
+“Dah she is?”
+
+But it warn’t.  It was Jack-o’-lanterns, or lightning bugs; so he set
+down again, and went to watching, same as before.  Jim said it made him
+all over trembly and feverish to be so close to freedom.  Well, I can
+tell you it made me all over trembly and feverish, too, to hear him,
+because I begun to get it through my head that he _was_ most free--and
+who was to blame for it?  Why, _me_.  I couldn’t get that out of my
+conscience, no how nor no way. It got to troubling me so I couldn’t
+rest; I couldn’t stay still in one place.  It hadn’t ever come home to
+me before, what this thing was that I was doing.  But now it did; and it
+stayed with me, and scorched me more and more.  I tried to make out to
+myself that I warn’t to blame, because I didn’t run Jim off from his
+rightful owner; but it warn’t no use, conscience up and says, every
+time, “But you knowed he was running for his freedom, and you could a
+paddled ashore and told somebody.”  That was so--I couldn’t get around
+that noway.  That was where it pinched.  Conscience says to me, “What
+had poor Miss Watson done to you that you could see her nigger go off
+right under your eyes and never say one single word?  What did that poor
+old woman do to you that you could treat her so mean?  Why, she tried to
+learn you your book, she tried to learn you your manners, she tried to
+be good to you every way she knowed how.  _That’s_ what she done.”
+
+I got to feeling so mean and so miserable I most wished I was dead.  I
+fidgeted up and down the raft, abusing myself to myself, and Jim was
+fidgeting up and down past me.  We neither of us could keep still.
+ Every time he danced around and says, “Dah’s Cairo!” it went through me
+like a shot, and I thought if it _was_ Cairo I reckoned I would die of
+miserableness.
+
+Jim talked out loud all the time while I was talking to myself.  He was
+saying how the first thing he would do when he got to a free State he
+would go to saving up money and never spend a single cent, and when he
+got enough he would buy his wife, which was owned on a farm close to
+where Miss Watson lived; and then they would both work to buy the
+two children, and if their master wouldn’t sell them, they’d get an
+Ab’litionist to go and steal them.
+
+It most froze me to hear such talk.  He wouldn’t ever dared to talk such
+talk in his life before.  Just see what a difference it made in him the
+minute he judged he was about free.  It was according to the old saying,
+“Give a nigger an inch and he’ll take an ell.”  Thinks I, this is what
+comes of my not thinking.  Here was this nigger, which I had as good
+as helped to run away, coming right out flat-footed and saying he would
+steal his children--children that belonged to a man I didn’t even know; a
+man that hadn’t ever done me no harm.
+
+I was sorry to hear Jim say that, it was such a lowering of him.  My
+conscience got to stirring me up hotter than ever, until at last I says
+to it, “Let up on me--it ain’t too late yet--I’ll paddle ashore at the
+first light and tell.”  I felt easy and happy and light as a feather
+right off.  All my troubles was gone.  I went to looking out sharp for a
+light, and sort of singing to myself.  By and by one showed.  Jim sings
+out:
+
+“We’s safe, Huck, we’s safe!  Jump up and crack yo’ heels!  Dat’s de
+good ole Cairo at las’, I jis knows it!”
+
+I says:
+
+“I’ll take the canoe and go and see, Jim.  It mightn’t be, you know.”
+
+He jumped and got the canoe ready, and put his old coat in the bottom
+for me to set on, and give me the paddle; and as I shoved off, he says:
+
+“Pooty soon I’ll be a-shout’n’ for joy, en I’ll say, it’s all on
+accounts o’ Huck; I’s a free man, en I couldn’t ever ben free ef it
+hadn’ ben for Huck; Huck done it.  Jim won’t ever forgit you, Huck;
+you’s de bes’ fren’ Jim’s ever had; en you’s de _only_ fren’ ole Jim’s
+got now.”
+
+I was paddling off, all in a sweat to tell on him; but when he says
+this, it seemed to kind of take the tuck all out of me.  I went along
+slow then, and I warn’t right down certain whether I was glad I started
+or whether I warn’t.  When I was fifty yards off, Jim says:
+
+“Dah you goes, de ole true Huck; de on’y white genlman dat ever kep’ his
+promise to ole Jim.”
+
+Well, I just felt sick.  But I says, I _got_ to do it--I can’t get _out_
+of it.  Right then along comes a skiff with two men in it with guns, and
+they stopped and I stopped.  One of them says:
+
+“What’s that yonder?”
+
+“A piece of a raft,” I says.
+
+“Do you belong on it?”
+
+“Yes, sir.”
+
+“Any men on it?”
+
+“Only one, sir.”
+
+“Well, there’s five niggers run off to-night up yonder, above the head
+of the bend.  Is your man white or black?”
+
+I didn’t answer up prompt.  I tried to, but the words wouldn’t come. I
+tried for a second or two to brace up and out with it, but I warn’t man
+enough--hadn’t the spunk of a rabbit.  I see I was weakening; so I just
+give up trying, and up and says:
+
+“He’s white.”
+
+“I reckon we’ll go and see for ourselves.”
+
+“I wish you would,” says I, “because it’s pap that’s there, and maybe
+you’d help me tow the raft ashore where the light is.  He’s sick--and so
+is mam and Mary Ann.”
+
+“Oh, the devil! we’re in a hurry, boy.  But I s’pose we’ve got to.
+ Come, buckle to your paddle, and let’s get along.”
+
+I buckled to my paddle and they laid to their oars.  When we had made a
+stroke or two, I says:
+
+“Pap’ll be mighty much obleeged to you, I can tell you.  Everybody goes
+away when I want them to help me tow the raft ashore, and I can’t do it
+by myself.”
+
+“Well, that’s infernal mean.  Odd, too.  Say, boy, what’s the matter
+with your father?”
+
+“It’s the--a--the--well, it ain’t anything much.”
+
+They stopped pulling.  It warn’t but a mighty little ways to the raft
+now. One says:
+
+“Boy, that’s a lie.  What _is_ the matter with your pap?  Answer up
+square now, and it’ll be the better for you.”
+
+“I will, sir, I will, honest--but don’t leave us, please.  It’s
+the--the--Gentlemen, if you’ll only pull ahead, and let me heave you the
+headline, you won’t have to come a-near the raft--please do.”
+
+“Set her back, John, set her back!” says one.  They backed water.  “Keep
+away, boy--keep to looard.  Confound it, I just expect the wind has
+blowed it to us.  Your pap’s got the small-pox, and you know it precious
+well.  Why didn’t you come out and say so?  Do you want to spread it all
+over?”
+
+“Well,” says I, a-blubbering, “I’ve told everybody before, and they just
+went away and left us.”
+
+“Poor devil, there’s something in that.  We are right down sorry for
+you, but we--well, hang it, we don’t want the small-pox, you see.  Look
+here, I’ll tell you what to do.  Don’t you try to land by yourself, or
+you’ll smash everything to pieces.  You float along down about twenty
+miles, and you’ll come to a town on the left-hand side of the river.  It
+will be long after sun-up then, and when you ask for help you tell them
+your folks are all down with chills and fever.  Don’t be a fool again,
+and let people guess what is the matter.  Now we’re trying to do you a
+kindness; so you just put twenty miles between us, that’s a good boy.
+ It wouldn’t do any good to land yonder where the light is--it’s only a
+wood-yard. Say, I reckon your father’s poor, and I’m bound to say he’s
+in pretty hard luck.  Here, I’ll put a twenty-dollar gold piece on this
+board, and you get it when it floats by.  I feel mighty mean to leave
+you; but my kingdom! it won’t do to fool with small-pox, don’t you see?”
+
+“Hold on, Parker,” says the other man, “here’s a twenty to put on the
+board for me.  Good-bye, boy; you do as Mr. Parker told you, and you’ll
+be all right.”
+
+“That’s so, my boy--good-bye, good-bye.  If you see any runaway niggers
+you get help and nab them, and you can make some money by it.”
+
+“Good-bye, sir,” says I; “I won’t let no runaway niggers get by me if I
+can help it.”
+
+They went off and I got aboard the raft, feeling bad and low, because I
+knowed very well I had done wrong, and I see it warn’t no use for me
+to try to learn to do right; a body that don’t get _started_ right when
+he’s little ain’t got no show--when the pinch comes there ain’t nothing
+to back him up and keep him to his work, and so he gets beat.  Then I
+thought a minute, and says to myself, hold on; s’pose you’d a done right
+and give Jim up, would you felt better than what you do now?  No, says
+I, I’d feel bad--I’d feel just the same way I do now.  Well, then, says
+I, what’s the use you learning to do right when it’s troublesome to do
+right and ain’t no trouble to do wrong, and the wages is just the same?
+ I was stuck.  I couldn’t answer that.  So I reckoned I wouldn’t bother
+no more about it, but after this always do whichever come handiest at
+the time.
+
+I went into the wigwam; Jim warn’t there.  I looked all around; he
+warn’t anywhere.  I says:
+
+“Jim!”
+
+“Here I is, Huck.  Is dey out o’ sight yit?  Don’t talk loud.”
+
+He was in the river under the stern oar, with just his nose out.  I told
+him they were out of sight, so he come aboard.  He says:
+
+“I was a-listenin’ to all de talk, en I slips into de river en was gwyne
+to shove for sho’ if dey come aboard.  Den I was gwyne to swim to de
+raf’ agin when dey was gone.  But lawsy, how you did fool ‘em, Huck!
+ Dat _wuz_ de smartes’ dodge!  I tell you, chile, I’spec it save’ ole
+Jim--ole Jim ain’t going to forgit you for dat, honey.”
+
+Then we talked about the money.  It was a pretty good raise--twenty
+dollars apiece.  Jim said we could take deck passage on a steamboat
+now, and the money would last us as far as we wanted to go in the free
+States. He said twenty mile more warn’t far for the raft to go, but he
+wished we was already there.
+
+Towards daybreak we tied up, and Jim was mighty particular about hiding
+the raft good.  Then he worked all day fixing things in bundles, and
+getting all ready to quit rafting.
+
+That night about ten we hove in sight of the lights of a town away down
+in a left-hand bend.
+
+I went off in the canoe to ask about it.  Pretty soon I found a man out
+in the river with a skiff, setting a trot-line.  I ranged up and says:
+
+“Mister, is that town Cairo?”
+
+“Cairo? no.  You must be a blame’ fool.”
+
+“What town is it, mister?”
+
+“If you want to know, go and find out.  If you stay here botherin’
+around me for about a half a minute longer you’ll get something you
+won’t want.”
+
+I paddled to the raft.  Jim was awful disappointed, but I said never
+mind, Cairo would be the next place, I reckoned.
+
+We passed another town before daylight, and I was going out again; but
+it was high ground, so I didn’t go.  No high ground about Cairo, Jim
+said. I had forgot it.  We laid up for the day on a towhead tolerable
+close to the left-hand bank.  I begun to suspicion something.  So did
+Jim.  I says:
+
+“Maybe we went by Cairo in the fog that night.”
+
+He says:
+
+“Doan’ le’s talk about it, Huck.  Po’ niggers can’t have no luck.  I
+awluz ‘spected dat rattlesnake-skin warn’t done wid its work.”
+
+“I wish I’d never seen that snake-skin, Jim--I do wish I’d never laid
+eyes on it.”
+
+“It ain’t yo’ fault, Huck; you didn’ know.  Don’t you blame yo’self
+‘bout it.”
+
+When it was daylight, here was the clear Ohio water inshore, sure
+enough, and outside was the old regular Muddy!  So it was all up with
+Cairo.
+
+We talked it all over.  It wouldn’t do to take to the shore; we couldn’t
+take the raft up the stream, of course.  There warn’t no way but to wait
+for dark, and start back in the canoe and take the chances.  So we slept
+all day amongst the cottonwood thicket, so as to be fresh for the work,
+and when we went back to the raft about dark the canoe was gone!
+
+We didn’t say a word for a good while.  There warn’t anything to
+say.  We both knowed well enough it was some more work of the
+rattlesnake-skin; so what was the use to talk about it?  It would only
+look like we was finding fault, and that would be bound to fetch more
+bad luck--and keep on fetching it, too, till we knowed enough to keep
+still.
+
+By and by we talked about what we better do, and found there warn’t no
+way but just to go along down with the raft till we got a chance to buy
+a canoe to go back in.  We warn’t going to borrow it when there warn’t
+anybody around, the way pap would do, for that might set people after
+us.
+
+So we shoved out after dark on the raft.
+
+Anybody that don’t believe yet that it’s foolishness to handle a
+snake-skin, after all that that snake-skin done for us, will believe it
+now if they read on and see what more it done for us.
+
+The place to buy canoes is off of rafts laying up at shore.  But we
+didn’t see no rafts laying up; so we went along during three hours and
+more.  Well, the night got gray and ruther thick, which is the next
+meanest thing to fog.  You can’t tell the shape of the river, and you
+can’t see no distance. It got to be very late and still, and then along
+comes a steamboat up the river.  We lit the lantern, and judged she
+would see it.  Up-stream boats didn’t generly come close to us; they
+go out and follow the bars and hunt for easy water under the reefs; but
+nights like this they bull right up the channel against the whole river.
+
+We could hear her pounding along, but we didn’t see her good till she
+was close.  She aimed right for us.  Often they do that and try to see
+how close they can come without touching; sometimes the wheel bites off
+a sweep, and then the pilot sticks his head out and laughs, and thinks
+he’s mighty smart.  Well, here she comes, and we said she was going to
+try and shave us; but she didn’t seem to be sheering off a bit.  She
+was a big one, and she was coming in a hurry, too, looking like a black
+cloud with rows of glow-worms around it; but all of a sudden she bulged
+out, big and scary, with a long row of wide-open furnace doors shining
+like red-hot teeth, and her monstrous bows and guards hanging right
+over us.  There was a yell at us, and a jingling of bells to stop the
+engines, a powwow of cussing, and whistling of steam--and as Jim went
+overboard on one side and I on the other, she come smashing straight
+through the raft.
+
+I dived--and I aimed to find the bottom, too, for a thirty-foot wheel
+had got to go over me, and I wanted it to have plenty of room.  I could
+always stay under water a minute; this time I reckon I stayed under a
+minute and a half.  Then I bounced for the top in a hurry, for I was
+nearly busting.  I popped out to my armpits and blowed the water out of
+my nose, and puffed a bit.  Of course there was a booming current; and
+of course that boat started her engines again ten seconds after she
+stopped them, for they never cared much for raftsmen; so now she was
+churning along up the river, out of sight in the thick weather, though I
+could hear her.
+
+I sung out for Jim about a dozen times, but I didn’t get any answer;
+so I grabbed a plank that touched me while I was “treading water,” and
+struck out for shore, shoving it ahead of me.  But I made out to see
+that the drift of the current was towards the left-hand shore, which
+meant that I was in a crossing; so I changed off and went that way.
+
+It was one of these long, slanting, two-mile crossings; so I was a good
+long time in getting over.  I made a safe landing, and clumb up the
+bank. I couldn’t see but a little ways, but I went poking along over
+rough ground for a quarter of a mile or more, and then I run across a
+big old-fashioned double log-house before I noticed it.  I was going to
+rush by and get away, but a lot of dogs jumped out and went to howling
+and barking at me, and I knowed better than to move another peg.
+
+
+
+
+CHAPTER XVII.
+
+IN about a minute somebody spoke out of a window without putting his
+head out, and says:
+
+“Be done, boys!  Who’s there?”
+
+I says:
+
+“It’s me.”
+
+“Who’s me?”
+
+“George Jackson, sir.”
+
+“What do you want?”
+
+“I don’t want nothing, sir.  I only want to go along by, but the dogs
+won’t let me.”
+
+“What are you prowling around here this time of night for--hey?”
+
+“I warn’t prowling around, sir, I fell overboard off of the steamboat.”
+
+“Oh, you did, did you?  Strike a light there, somebody.  What did you
+say your name was?”
+
+“George Jackson, sir.  I’m only a boy.”
+
+“Look here, if you’re telling the truth you needn’t be afraid--nobody’ll
+hurt you.  But don’t try to budge; stand right where you are.  Rouse out
+Bob and Tom, some of you, and fetch the guns.  George Jackson, is there
+anybody with you?”
+
+“No, sir, nobody.”
+
+I heard the people stirring around in the house now, and see a light.
+The man sung out:
+
+“Snatch that light away, Betsy, you old fool--ain’t you got any sense?
+Put it on the floor behind the front door.  Bob, if you and Tom are
+ready, take your places.”
+
+“All ready.”
+
+“Now, George Jackson, do you know the Shepherdsons?”
+
+“No, sir; I never heard of them.”
+
+“Well, that may be so, and it mayn’t.  Now, all ready.  Step forward,
+George Jackson.  And mind, don’t you hurry--come mighty slow.  If there’s
+anybody with you, let him keep back--if he shows himself he’ll be shot.
+Come along now.  Come slow; push the door open yourself--just enough to
+squeeze in, d’ you hear?”
+
+I didn’t hurry; I couldn’t if I’d a wanted to.  I took one slow step at
+a time and there warn’t a sound, only I thought I could hear my heart.
+ The dogs were as still as the humans, but they followed a little behind
+me. When I got to the three log doorsteps I heard them unlocking and
+unbarring and unbolting.  I put my hand on the door and pushed it a
+little and a little more till somebody said, “There, that’s enough--put
+your head in.” I done it, but I judged they would take it off.
+
+The candle was on the floor, and there they all was, looking at me, and
+me at them, for about a quarter of a minute:  Three big men with guns
+pointed at me, which made me wince, I tell you; the oldest, gray
+and about sixty, the other two thirty or more--all of them fine and
+handsome--and the sweetest old gray-headed lady, and back of her two
+young women which I couldn’t see right well.  The old gentleman says:
+
+“There; I reckon it’s all right.  Come in.”
+
+As soon as I was in the old gentleman he locked the door and barred it
+and bolted it, and told the young men to come in with their guns, and
+they all went in a big parlor that had a new rag carpet on the floor,
+and got together in a corner that was out of the range of the front
+windows--there warn’t none on the side.  They held the candle, and took a
+good look at me, and all said, “Why, _he_ ain’t a Shepherdson--no, there
+ain’t any Shepherdson about him.”  Then the old man said he hoped I
+wouldn’t mind being searched for arms, because he didn’t mean no harm by
+it--it was only to make sure.  So he didn’t pry into my pockets, but only
+felt outside with his hands, and said it was all right.  He told me to
+make myself easy and at home, and tell all about myself; but the old
+lady says:
+
+“Why, bless you, Saul, the poor thing’s as wet as he can be; and don’t
+you reckon it may be he’s hungry?”
+
+“True for you, Rachel--I forgot.”
+
+So the old lady says:
+
+“Betsy” (this was a nigger woman), “you fly around and get him something
+to eat as quick as you can, poor thing; and one of you girls go and wake
+up Buck and tell him--oh, here he is himself.  Buck, take this little
+stranger and get the wet clothes off from him and dress him up in some
+of yours that’s dry.”
+
+Buck looked about as old as me--thirteen or fourteen or along there,
+though he was a little bigger than me.  He hadn’t on anything but a
+shirt, and he was very frowzy-headed.  He came in gaping and digging one
+fist into his eyes, and he was dragging a gun along with the other one.
+He says:
+
+“Ain’t they no Shepherdsons around?”
+
+They said, no, ‘twas a false alarm.
+
+“Well,” he says, “if they’d a ben some, I reckon I’d a got one.”
+
+They all laughed, and Bob says:
+
+“Why, Buck, they might have scalped us all, you’ve been so slow in
+coming.”
+
+“Well, nobody come after me, and it ain’t right I’m always kept down; I
+don’t get no show.”
+
+“Never mind, Buck, my boy,” says the old man, “you’ll have show enough,
+all in good time, don’t you fret about that.  Go ‘long with you now, and
+do as your mother told you.”
+
+When we got up-stairs to his room he got me a coarse shirt and a
+roundabout and pants of his, and I put them on.  While I was at it he
+asked me what my name was, but before I could tell him he started to
+tell me about a bluejay and a young rabbit he had catched in the woods
+day before yesterday, and he asked me where Moses was when the candle
+went out.  I said I didn’t know; I hadn’t heard about it before, no way.
+
+“Well, guess,” he says.
+
+“How’m I going to guess,” says I, “when I never heard tell of it
+before?”
+
+“But you can guess, can’t you?  It’s just as easy.”
+
+“_Which_ candle?”  I says.
+
+“Why, any candle,” he says.
+
+“I don’t know where he was,” says I; “where was he?”
+
+“Why, he was in the _dark_!  That’s where he was!”
+
+“Well, if you knowed where he was, what did you ask me for?”
+
+“Why, blame it, it’s a riddle, don’t you see?  Say, how long are you
+going to stay here?  You got to stay always.  We can just have booming
+times--they don’t have no school now.  Do you own a dog?  I’ve got a
+dog--and he’ll go in the river and bring out chips that you throw in.  Do
+you like to comb up Sundays, and all that kind of foolishness?  You bet
+I don’t, but ma she makes me.  Confound these ole britches!  I reckon
+I’d better put ‘em on, but I’d ruther not, it’s so warm.  Are you all
+ready? All right.  Come along, old hoss.”
+
+Cold corn-pone, cold corn-beef, butter and buttermilk--that is what they
+had for me down there, and there ain’t nothing better that ever I’ve
+come across yet.  Buck and his ma and all of them smoked cob pipes,
+except the nigger woman, which was gone, and the two young women.  They
+all smoked and talked, and I eat and talked.  The young women had
+quilts around them, and their hair down their backs.  They all asked me
+questions, and I told them how pap and me and all the family was living
+on a little farm down at the bottom of Arkansaw, and my sister Mary Ann
+run off and got married and never was heard of no more, and Bill went
+to hunt them and he warn’t heard of no more, and Tom and Mort died,
+and then there warn’t nobody but just me and pap left, and he was just
+trimmed down to nothing, on account of his troubles; so when he died
+I took what there was left, because the farm didn’t belong to us, and
+started up the river, deck passage, and fell overboard; and that was how
+I come to be here.  So they said I could have a home there as long as I
+wanted it.  Then it was most daylight and everybody went to bed, and I
+went to bed with Buck, and when I waked up in the morning, drat it all,
+I had forgot what my name was. So I laid there about an hour trying to
+think, and when Buck waked up I says:
+
+“Can you spell, Buck?”
+
+“Yes,” he says.
+
+“I bet you can’t spell my name,” says I.
+
+“I bet you what you dare I can,” says he.
+
+“All right,” says I, “go ahead.”
+
+“G-e-o-r-g-e J-a-x-o-n--there now,” he says.
+
+“Well,” says I, “you done it, but I didn’t think you could.  It ain’t no
+slouch of a name to spell--right off without studying.”
+
+I set it down, private, because somebody might want _me_ to spell it
+next, and so I wanted to be handy with it and rattle it off like I was
+used to it.
+
+It was a mighty nice family, and a mighty nice house, too.  I hadn’t
+seen no house out in the country before that was so nice and had so much
+style.  It didn’t have an iron latch on the front door, nor a wooden one
+with a buckskin string, but a brass knob to turn, the same as houses in
+town. There warn’t no bed in the parlor, nor a sign of a bed; but heaps
+of parlors in towns has beds in them.  There was a big fireplace that
+was bricked on the bottom, and the bricks was kept clean and red by
+pouring water on them and scrubbing them with another brick; sometimes
+they wash them over with red water-paint that they call Spanish-brown,
+same as they do in town.  They had big brass dog-irons that could hold
+up a saw-log. There was a clock on the middle of the mantelpiece, with
+a picture of a town painted on the bottom half of the glass front, and
+a round place in the middle of it for the sun, and you could see the
+pendulum swinging behind it.  It was beautiful to hear that clock tick;
+and sometimes when one of these peddlers had been along and scoured her
+up and got her in good shape, she would start in and strike a hundred
+and fifty before she got tuckered out.  They wouldn’t took any money for
+her.
+
+Well, there was a big outlandish parrot on each side of the clock,
+made out of something like chalk, and painted up gaudy.  By one of the
+parrots was a cat made of crockery, and a crockery dog by the other;
+and when you pressed down on them they squeaked, but didn’t open
+their mouths nor look different nor interested.  They squeaked through
+underneath.  There was a couple of big wild-turkey-wing fans spread out
+behind those things.  On the table in the middle of the room was a kind
+of a lovely crockery basket that had apples and oranges and peaches and
+grapes piled up in it, which was much redder and yellower and prettier
+than real ones is, but they warn’t real because you could see where
+pieces had got chipped off and showed the white chalk, or whatever it
+was, underneath.
+
+This table had a cover made out of beautiful oilcloth, with a red and
+blue spread-eagle painted on it, and a painted border all around.  It
+come all the way from Philadelphia, they said.  There was some books,
+too, piled up perfectly exact, on each corner of the table.  One was a
+big family Bible full of pictures.  One was Pilgrim’s Progress, about a
+man that left his family, it didn’t say why.  I read considerable in it
+now and then.  The statements was interesting, but tough.  Another was
+Friendship’s Offering, full of beautiful stuff and poetry; but I didn’t
+read the poetry.  Another was Henry Clay’s Speeches, and another was Dr.
+Gunn’s Family Medicine, which told you all about what to do if a body
+was sick or dead.  There was a hymn book, and a lot of other books.  And
+there was nice split-bottom chairs, and perfectly sound, too--not bagged
+down in the middle and busted, like an old basket.
+
+They had pictures hung on the walls--mainly Washingtons and Lafayettes,
+and battles, and Highland Marys, and one called “Signing the
+Declaration.” There was some that they called crayons, which one of the
+daughters which was dead made her own self when she was only
+fifteen years old.  They was different from any pictures I ever see
+before--blacker, mostly, than is common.  One was a woman in a slim black
+dress, belted small under the armpits, with bulges like a cabbage in
+the middle of the sleeves, and a large black scoop-shovel bonnet with
+a black veil, and white slim ankles crossed about with black tape, and
+very wee black slippers, like a chisel, and she was leaning pensive on a
+tombstone on her right elbow, under a weeping willow, and her other hand
+hanging down her side holding a white handkerchief and a reticule,
+and underneath the picture it said “Shall I Never See Thee More Alas.”
+  Another one was a young lady with her hair all combed up straight
+to the top of her head, and knotted there in front of a comb like a
+chair-back, and she was crying into a handkerchief and had a dead bird
+laying on its back in her other hand with its heels up, and underneath
+the picture it said “I Shall Never Hear Thy Sweet Chirrup More Alas.”
+  There was one where a young lady was at a window looking up at the
+moon, and tears running down her cheeks; and she had an open letter in
+one hand with black sealing wax showing on one edge of it, and she was
+mashing a locket with a chain to it against her mouth, and underneath
+the picture it said “And Art Thou Gone Yes Thou Art Gone Alas.”  These
+was all nice pictures, I reckon, but I didn’t somehow seem to take
+to them, because if ever I was down a little they always give me the
+fan-tods.  Everybody was sorry she died, because she had laid out a lot
+more of these pictures to do, and a body could see by what she had done
+what they had lost.  But I reckoned that with her disposition she was
+having a better time in the graveyard.  She was at work on what they
+said was her greatest picture when she took sick, and every day and
+every night it was her prayer to be allowed to live till she got it
+done, but she never got the chance.  It was a picture of a young woman
+in a long white gown, standing on the rail of a bridge all ready to jump
+off, with her hair all down her back, and looking up to the moon, with
+the tears running down her face, and she had two arms folded across her
+breast, and two arms stretched out in front, and two more reaching up
+towards the moon--and the idea was to see which pair would look best,
+and then scratch out all the other arms; but, as I was saying, she died
+before she got her mind made up, and now they kept this picture over the
+head of the bed in her room, and every time her birthday come they hung
+flowers on it.  Other times it was hid with a little curtain.  The young
+woman in the picture had a kind of a nice sweet face, but there was so
+many arms it made her look too spidery, seemed to me.
+
+This young girl kept a scrap-book when she was alive, and used to paste
+obituaries and accidents and cases of patient suffering in it out of the
+Presbyterian Observer, and write poetry after them out of her own head.
+It was very good poetry. This is what she wrote about a boy by the name
+of Stephen Dowling Bots that fell down a well and was drownded:
+
+ODE TO STEPHEN DOWLING BOTS, DEC’D
+
+And did young Stephen sicken,    And did young Stephen die? And did the
+sad hearts thicken,    And did the mourners cry?
+
+No; such was not the fate of    Young Stephen Dowling Bots; Though sad
+hearts round him thickened,    ‘Twas not from sickness’ shots.
+
+No whooping-cough did rack his frame,    Nor measles drear with spots;
+Not these impaired the sacred name    Of Stephen Dowling Bots.
+
+Despised love struck not with woe    That head of curly knots, Nor
+stomach troubles laid him low,    Young Stephen Dowling Bots.
+
+O no. Then list with tearful eye,    Whilst I his fate do tell. His soul
+did from this cold world fly    By falling down a well.
+
+They got him out and emptied him;    Alas it was too late; His spirit
+was gone for to sport aloft    In the realms of the good and great.
+
+If Emmeline Grangerford could make poetry like that before she was
+fourteen, there ain’t no telling what she could a done by and by.  Buck
+said she could rattle off poetry like nothing.  She didn’t ever have to
+stop to think.  He said she would slap down a line, and if she couldn’t
+find anything to rhyme with it would just scratch it out and slap down
+another one, and go ahead. She warn’t particular; she could write about
+anything you choose to give her to write about just so it was sadful.
+Every time a man died, or a woman died, or a child died, she would be on
+hand with her “tribute” before he was cold.  She called them tributes.
+The neighbors said it was the doctor first, then Emmeline, then the
+undertaker--the undertaker never got in ahead of Emmeline but once, and
+then she hung fire on a rhyme for the dead person’s name, which was
+Whistler.  She warn’t ever the same after that; she never complained,
+but she kinder pined away and did not live long.  Poor thing, many’s the
+time I made myself go up to the little room that used to be hers and get
+out her poor old scrap-book and read in it when her pictures had been
+aggravating me and I had soured on her a little.  I liked all that
+family, dead ones and all, and warn’t going to let anything come between
+us.  Poor Emmeline made poetry about all the dead people when she was
+alive, and it didn’t seem right that there warn’t nobody to make some
+about her now she was gone; so I tried to sweat out a verse or two
+myself, but I couldn’t seem to make it go somehow.  They kept Emmeline’s
+room trim and nice, and all the things fixed in it just the way she
+liked to have them when she was alive, and nobody ever slept there.
+ The old lady took care of the room herself, though there was plenty
+of niggers, and she sewed there a good deal and read her Bible there
+mostly.
+
+Well, as I was saying about the parlor, there was beautiful curtains on
+the windows:  white, with pictures painted on them of castles with vines
+all down the walls, and cattle coming down to drink.  There was a little
+old piano, too, that had tin pans in it, I reckon, and nothing was ever
+so lovely as to hear the young ladies sing “The Last Link is Broken”
+ and play “The Battle of Prague” on it.  The walls of all the rooms was
+plastered, and most had carpets on the floors, and the whole house was
+whitewashed on the outside.
+
+It was a double house, and the big open place betwixt them was roofed
+and floored, and sometimes the table was set there in the middle of the
+day, and it was a cool, comfortable place.  Nothing couldn’t be better.
+ And warn’t the cooking good, and just bushels of it too!
+
+
+
+
+CHAPTER XVIII.
+
+COL.  Grangerford was a gentleman, you see.  He was a gentleman all
+over; and so was his family.  He was well born, as the saying is, and
+that’s worth as much in a man as it is in a horse, so the Widow Douglas
+said, and nobody ever denied that she was of the first aristocracy
+in our town; and pap he always said it, too, though he warn’t no more
+quality than a mudcat himself.  Col.  Grangerford was very tall and
+very slim, and had a darkish-paly complexion, not a sign of red in it
+anywheres; he was clean shaved every morning all over his thin face, and
+he had the thinnest kind of lips, and the thinnest kind of nostrils, and
+a high nose, and heavy eyebrows, and the blackest kind of eyes, sunk so
+deep back that they seemed like they was looking out of caverns at
+you, as you may say.  His forehead was high, and his hair was black and
+straight and hung to his shoulders. His hands was long and thin, and
+every day of his life he put on a clean shirt and a full suit from head
+to foot made out of linen so white it hurt your eyes to look at it;
+and on Sundays he wore a blue tail-coat with brass buttons on it.  He
+carried a mahogany cane with a silver head to it.  There warn’t no
+frivolishness about him, not a bit, and he warn’t ever loud.  He was
+as kind as he could be--you could feel that, you know, and so you had
+confidence.  Sometimes he smiled, and it was good to see; but when he
+straightened himself up like a liberty-pole, and the lightning begun to
+flicker out from under his eyebrows, you wanted to climb a tree first,
+and find out what the matter was afterwards.  He didn’t ever have to
+tell anybody to mind their manners--everybody was always good-mannered
+where he was.  Everybody loved to have him around, too; he was sunshine
+most always--I mean he made it seem like good weather.  When he turned
+into a cloudbank it was awful dark for half a minute, and that was
+enough; there wouldn’t nothing go wrong again for a week.
+
+When him and the old lady come down in the morning all the family got
+up out of their chairs and give them good-day, and didn’t set down again
+till they had set down.  Then Tom and Bob went to the sideboard where
+the decanter was, and mixed a glass of bitters and handed it to him, and
+he held it in his hand and waited till Tom’s and Bob’s was mixed, and
+then they bowed and said, “Our duty to you, sir, and madam;” and _they_
+bowed the least bit in the world and said thank you, and so they drank,
+all three, and Bob and Tom poured a spoonful of water on the sugar and
+the mite of whisky or apple brandy in the bottom of their tumblers, and
+give it to me and Buck, and we drank to the old people too.
+
+Bob was the oldest and Tom next--tall, beautiful men with very broad
+shoulders and brown faces, and long black hair and black eyes.  They
+dressed in white linen from head to foot, like the old gentleman, and
+wore broad Panama hats.
+
+Then there was Miss Charlotte; she was twenty-five, and tall and proud
+and grand, but as good as she could be when she warn’t stirred up; but
+when she was she had a look that would make you wilt in your tracks,
+like her father.  She was beautiful.
+
+So was her sister, Miss Sophia, but it was a different kind.  She was
+gentle and sweet like a dove, and she was only twenty.
+
+Each person had their own nigger to wait on them--Buck too.  My nigger
+had a monstrous easy time, because I warn’t used to having anybody do
+anything for me, but Buck’s was on the jump most of the time.
+
+This was all there was of the family now, but there used to be
+more--three sons; they got killed; and Emmeline that died.
+
+The old gentleman owned a lot of farms and over a hundred niggers.
+Sometimes a stack of people would come there, horseback, from ten or
+fifteen mile around, and stay five or six days, and have such junketings
+round about and on the river, and dances and picnics in the woods
+daytimes, and balls at the house nights.  These people was mostly
+kinfolks of the family.  The men brought their guns with them.  It was a
+handsome lot of quality, I tell you.
+
+There was another clan of aristocracy around there--five or six
+families--mostly of the name of Shepherdson.  They was as high-toned
+and well born and rich and grand as the tribe of Grangerfords.  The
+Shepherdsons and Grangerfords used the same steamboat landing, which was
+about two mile above our house; so sometimes when I went up there with a
+lot of our folks I used to see a lot of the Shepherdsons there on their
+fine horses.
+
+One day Buck and me was away out in the woods hunting, and heard a horse
+coming.  We was crossing the road.  Buck says:
+
+“Quick!  Jump for the woods!”
+
+We done it, and then peeped down the woods through the leaves.  Pretty
+soon a splendid young man come galloping down the road, setting his
+horse easy and looking like a soldier.  He had his gun across his
+pommel.  I had seen him before.  It was young Harney Shepherdson.  I
+heard Buck’s gun go off at my ear, and Harney’s hat tumbled off from his
+head.  He grabbed his gun and rode straight to the place where we was
+hid.  But we didn’t wait.  We started through the woods on a run.  The
+woods warn’t thick, so I looked over my shoulder to dodge the bullet,
+and twice I seen Harney cover Buck with his gun; and then he rode away
+the way he come--to get his hat, I reckon, but I couldn’t see.  We never
+stopped running till we got home.  The old gentleman’s eyes blazed a
+minute--‘twas pleasure, mainly, I judged--then his face sort of smoothed
+down, and he says, kind of gentle:
+
+“I don’t like that shooting from behind a bush.  Why didn’t you step
+into the road, my boy?”
+
+“The Shepherdsons don’t, father.  They always take advantage.”
+
+Miss Charlotte she held her head up like a queen while Buck was telling
+his tale, and her nostrils spread and her eyes snapped.  The two young
+men looked dark, but never said nothing.  Miss Sophia she turned pale,
+but the color come back when she found the man warn’t hurt.
+
+Soon as I could get Buck down by the corn-cribs under the trees by
+ourselves, I says:
+
+“Did you want to kill him, Buck?”
+
+“Well, I bet I did.”
+
+“What did he do to you?”
+
+“Him?  He never done nothing to me.”
+
+“Well, then, what did you want to kill him for?”
+
+“Why, nothing--only it’s on account of the feud.”
+
+“What’s a feud?”
+
+“Why, where was you raised?  Don’t you know what a feud is?”
+
+“Never heard of it before--tell me about it.”
+
+“Well,” says Buck, “a feud is this way:  A man has a quarrel with
+another man, and kills him; then that other man’s brother kills _him_;
+then the other brothers, on both sides, goes for one another; then the
+_cousins_ chip in--and by and by everybody’s killed off, and there ain’t
+no more feud.  But it’s kind of slow, and takes a long time.”
+
+“Has this one been going on long, Buck?”
+
+“Well, I should _reckon_!  It started thirty year ago, or som’ers along
+there.  There was trouble ‘bout something, and then a lawsuit to settle
+it; and the suit went agin one of the men, and so he up and shot the
+man that won the suit--which he would naturally do, of course.  Anybody
+would.”
+
+“What was the trouble about, Buck?--land?”
+
+“I reckon maybe--I don’t know.”
+
+“Well, who done the shooting?  Was it a Grangerford or a Shepherdson?”
+
+“Laws, how do I know?  It was so long ago.”
+
+“Don’t anybody know?”
+
+“Oh, yes, pa knows, I reckon, and some of the other old people; but they
+don’t know now what the row was about in the first place.”
+
+“Has there been many killed, Buck?”
+
+“Yes; right smart chance of funerals.  But they don’t always kill.  Pa’s
+got a few buckshot in him; but he don’t mind it ‘cuz he don’t weigh
+much, anyway.  Bob’s been carved up some with a bowie, and Tom’s been
+hurt once or twice.”
+
+“Has anybody been killed this year, Buck?”
+
+“Yes; we got one and they got one.  ‘Bout three months ago my cousin
+Bud, fourteen year old, was riding through the woods on t’other side
+of the river, and didn’t have no weapon with him, which was blame’
+foolishness, and in a lonesome place he hears a horse a-coming behind
+him, and sees old Baldy Shepherdson a-linkin’ after him with his gun in
+his hand and his white hair a-flying in the wind; and ‘stead of jumping
+off and taking to the brush, Bud ‘lowed he could out-run him; so they
+had it, nip and tuck, for five mile or more, the old man a-gaining all
+the time; so at last Bud seen it warn’t any use, so he stopped and faced
+around so as to have the bullet holes in front, you know, and the old
+man he rode up and shot him down.  But he didn’t git much chance to
+enjoy his luck, for inside of a week our folks laid _him_ out.”
+
+“I reckon that old man was a coward, Buck.”
+
+“I reckon he _warn’t_ a coward.  Not by a blame’ sight.  There ain’t a
+coward amongst them Shepherdsons--not a one.  And there ain’t no cowards
+amongst the Grangerfords either.  Why, that old man kep’ up his end in a
+fight one day for half an hour against three Grangerfords, and come
+out winner.  They was all a-horseback; he lit off of his horse and got
+behind a little woodpile, and kep’ his horse before him to stop the
+bullets; but the Grangerfords stayed on their horses and capered around
+the old man, and peppered away at him, and he peppered away at them.
+ Him and his horse both went home pretty leaky and crippled, but the
+Grangerfords had to be _fetched_ home--and one of ‘em was dead, and
+another died the next day.  No, sir; if a body’s out hunting for cowards
+he don’t want to fool away any time amongst them Shepherdsons, becuz
+they don’t breed any of that _kind_.”
+
+Next Sunday we all went to church, about three mile, everybody
+a-horseback. The men took their guns along, so did Buck, and kept
+them between their knees or stood them handy against the wall.  The
+Shepherdsons done the same.  It was pretty ornery preaching--all about
+brotherly love, and such-like tiresomeness; but everybody said it was
+a good sermon, and they all talked it over going home, and had such
+a powerful lot to say about faith and good works and free grace and
+preforeordestination, and I don’t know what all, that it did seem to me
+to be one of the roughest Sundays I had run across yet.
+
+About an hour after dinner everybody was dozing around, some in their
+chairs and some in their rooms, and it got to be pretty dull.  Buck and
+a dog was stretched out on the grass in the sun sound asleep.  I went up
+to our room, and judged I would take a nap myself.  I found that sweet
+Miss Sophia standing in her door, which was next to ours, and she took
+me in her room and shut the door very soft, and asked me if I liked her,
+and I said I did; and she asked me if I would do something for her and
+not tell anybody, and I said I would.  Then she said she’d forgot her
+Testament, and left it in the seat at church between two other books,
+and would I slip out quiet and go there and fetch it to her, and not say
+nothing to nobody.  I said I would. So I slid out and slipped off up the
+road, and there warn’t anybody at the church, except maybe a hog or two,
+for there warn’t any lock on the door, and hogs likes a puncheon floor
+in summer-time because it’s cool.  If you notice, most folks don’t go to
+church only when they’ve got to; but a hog is different.
+
+Says I to myself, something’s up; it ain’t natural for a girl to be in
+such a sweat about a Testament.  So I give it a shake, and out drops a
+little piece of paper with “HALF-PAST TWO” wrote on it with a pencil.  I
+ransacked it, but couldn’t find anything else.  I couldn’t make anything
+out of that, so I put the paper in the book again, and when I got home
+and upstairs there was Miss Sophia in her door waiting for me.  She
+pulled me in and shut the door; then she looked in the Testament till
+she found the paper, and as soon as she read it she looked glad; and
+before a body could think she grabbed me and give me a squeeze, and
+said I was the best boy in the world, and not to tell anybody.  She was
+mighty red in the face for a minute, and her eyes lighted up, and it
+made her powerful pretty.  I was a good deal astonished, but when I got
+my breath I asked her what the paper was about, and she asked me if I
+had read it, and I said no, and she asked me if I could read writing,
+and I told her “no, only coarse-hand,” and then she said the paper
+warn’t anything but a book-mark to keep her place, and I might go and
+play now.
+
+I went off down to the river, studying over this thing, and pretty soon
+I noticed that my nigger was following along behind.  When we was out
+of sight of the house he looked back and around a second, and then comes
+a-running, and says:
+
+“Mars Jawge, if you’ll come down into de swamp I’ll show you a whole
+stack o’ water-moccasins.”
+
+Thinks I, that’s mighty curious; he said that yesterday.  He oughter
+know a body don’t love water-moccasins enough to go around hunting for
+them. What is he up to, anyway?  So I says:
+
+“All right; trot ahead.”
+
+I followed a half a mile; then he struck out over the swamp, and waded
+ankle deep as much as another half-mile.  We come to a little flat piece
+of land which was dry and very thick with trees and bushes and vines,
+and he says:
+
+“You shove right in dah jist a few steps, Mars Jawge; dah’s whah dey is.
+I’s seed ‘m befo’; I don’t k’yer to see ‘em no mo’.”
+
+Then he slopped right along and went away, and pretty soon the trees hid
+him.  I poked into the place a-ways and come to a little open patch
+as big as a bedroom all hung around with vines, and found a man laying
+there asleep--and, by jings, it was my old Jim!
+
+I waked him up, and I reckoned it was going to be a grand surprise to
+him to see me again, but it warn’t.  He nearly cried he was so glad, but
+he warn’t surprised.  Said he swum along behind me that night, and heard
+me yell every time, but dasn’t answer, because he didn’t want nobody to
+pick _him_ up and take him into slavery again.  Says he:
+
+“I got hurt a little, en couldn’t swim fas’, so I wuz a considable ways
+behine you towards de las’; when you landed I reck’ned I could ketch
+up wid you on de lan’ ‘dout havin’ to shout at you, but when I see dat
+house I begin to go slow.  I ‘uz off too fur to hear what dey say to
+you--I wuz ‘fraid o’ de dogs; but when it ‘uz all quiet agin I knowed
+you’s in de house, so I struck out for de woods to wait for day.  Early
+in de mawnin’ some er de niggers come along, gwyne to de fields, en dey
+tuk me en showed me dis place, whah de dogs can’t track me on accounts
+o’ de water, en dey brings me truck to eat every night, en tells me how
+you’s a-gitt’n along.”
+
+“Why didn’t you tell my Jack to fetch me here sooner, Jim?”
+
+“Well, ‘twarn’t no use to ‘sturb you, Huck, tell we could do sumfn--but
+we’s all right now.  I ben a-buyin’ pots en pans en vittles, as I got a
+chanst, en a-patchin’ up de raf’ nights when--”
+
+“_What_ raft, Jim?”
+
+“Our ole raf’.”
+
+“You mean to say our old raft warn’t smashed all to flinders?”
+
+“No, she warn’t.  She was tore up a good deal--one en’ of her was; but
+dey warn’t no great harm done, on’y our traps was mos’ all los’.  Ef we
+hadn’ dive’ so deep en swum so fur under water, en de night hadn’ ben
+so dark, en we warn’t so sk’yerd, en ben sich punkin-heads, as de sayin’
+is, we’d a seed de raf’.  But it’s jis’ as well we didn’t, ‘kase now
+she’s all fixed up agin mos’ as good as new, en we’s got a new lot o’
+stuff, in de place o’ what ‘uz los’.”
+
+“Why, how did you get hold of the raft again, Jim--did you catch her?”
+
+“How I gwyne to ketch her en I out in de woods?  No; some er de niggers
+foun’ her ketched on a snag along heah in de ben’, en dey hid her in a
+crick ‘mongst de willows, en dey wuz so much jawin’ ‘bout which un ‘um
+she b’long to de mos’ dat I come to heah ‘bout it pooty soon, so I ups
+en settles de trouble by tellin’ ‘um she don’t b’long to none uv um, but
+to you en me; en I ast ‘m if dey gwyne to grab a young white genlman’s
+propaty, en git a hid’n for it?  Den I gin ‘m ten cents apiece, en dey
+‘uz mighty well satisfied, en wisht some mo’ raf’s ‘ud come along en
+make ‘m rich agin. Dey’s mighty good to me, dese niggers is, en whatever
+I wants ‘m to do fur me I doan’ have to ast ‘m twice, honey.  Dat Jack’s
+a good nigger, en pooty smart.”
+
+“Yes, he is.  He ain’t ever told me you was here; told me to come, and
+he’d show me a lot of water-moccasins.  If anything happens _he_ ain’t
+mixed up in it.  He can say he never seen us together, and it ‘ll be the
+truth.”
+
+I don’t want to talk much about the next day.  I reckon I’ll cut it
+pretty short.  I waked up about dawn, and was a-going to turn over and
+go to sleep again when I noticed how still it was--didn’t seem to be
+anybody stirring.  That warn’t usual.  Next I noticed that Buck was
+up and gone. Well, I gets up, a-wondering, and goes down stairs--nobody
+around; everything as still as a mouse.  Just the same outside.  Thinks
+I, what does it mean?  Down by the wood-pile I comes across my Jack, and
+says:
+
+“What’s it all about?”
+
+Says he:
+
+“Don’t you know, Mars Jawge?”
+
+“No,” says I, “I don’t.”
+
+“Well, den, Miss Sophia’s run off! ‘deed she has.  She run off in de
+night some time--nobody don’t know jis’ when; run off to get married
+to dat young Harney Shepherdson, you know--leastways, so dey ‘spec.  De
+fambly foun’ it out ‘bout half an hour ago--maybe a little mo’--en’ I
+_tell_ you dey warn’t no time los’.  Sich another hurryin’ up guns
+en hosses _you_ never see!  De women folks has gone for to stir up de
+relations, en ole Mars Saul en de boys tuck dey guns en rode up de
+river road for to try to ketch dat young man en kill him ‘fo’ he kin
+git acrost de river wid Miss Sophia.  I reck’n dey’s gwyne to be mighty
+rough times.”
+
+“Buck went off ‘thout waking me up.”
+
+“Well, I reck’n he _did_!  Dey warn’t gwyne to mix you up in it.
+ Mars Buck he loaded up his gun en ‘lowed he’s gwyne to fetch home a
+Shepherdson or bust. Well, dey’ll be plenty un ‘m dah, I reck’n, en you
+bet you he’ll fetch one ef he gits a chanst.”
+
+I took up the river road as hard as I could put.  By and by I begin to
+hear guns a good ways off.  When I come in sight of the log store and
+the woodpile where the steamboats lands I worked along under the trees
+and brush till I got to a good place, and then I clumb up into the
+forks of a cottonwood that was out of reach, and watched.  There was a
+wood-rank four foot high a little ways in front of the tree, and first I
+was going to hide behind that; but maybe it was luckier I didn’t.
+
+There was four or five men cavorting around on their horses in the open
+place before the log store, cussing and yelling, and trying to get at
+a couple of young chaps that was behind the wood-rank alongside of the
+steamboat landing; but they couldn’t come it.  Every time one of them
+showed himself on the river side of the woodpile he got shot at.  The
+two boys was squatting back to back behind the pile, so they could watch
+both ways.
+
+By and by the men stopped cavorting around and yelling.  They started
+riding towards the store; then up gets one of the boys, draws a steady
+bead over the wood-rank, and drops one of them out of his saddle.  All
+the men jumped off of their horses and grabbed the hurt one and started
+to carry him to the store; and that minute the two boys started on the
+run.  They got half way to the tree I was in before the men noticed.
+Then the men see them, and jumped on their horses and took out after
+them.  They gained on the boys, but it didn’t do no good, the boys had
+too good a start; they got to the woodpile that was in front of my tree,
+and slipped in behind it, and so they had the bulge on the men again.
+One of the boys was Buck, and the other was a slim young chap about
+nineteen years old.
+
+The men ripped around awhile, and then rode away.  As soon as they was
+out of sight I sung out to Buck and told him.  He didn’t know what
+to make of my voice coming out of the tree at first.  He was awful
+surprised.  He told me to watch out sharp and let him know when the
+men come in sight again; said they was up to some devilment or
+other--wouldn’t be gone long.  I wished I was out of that tree, but I
+dasn’t come down.  Buck begun to cry and rip, and ‘lowed that him and
+his cousin Joe (that was the other young chap) would make up for this
+day yet.  He said his father and his two brothers was killed, and two
+or three of the enemy.  Said the Shepherdsons laid for them in
+ambush.  Buck said his father and brothers ought to waited for their
+relations--the Shepherdsons was too strong for them.  I asked him what
+was become of young Harney and Miss Sophia.  He said they’d got across
+the river and was safe.  I was glad of that; but the way Buck did take
+on because he didn’t manage to kill Harney that day he shot at him--I
+hain’t ever heard anything like it.
+
+All of a sudden, bang! bang! bang! goes three or four guns--the men had
+slipped around through the woods and come in from behind without their
+horses!  The boys jumped for the river--both of them hurt--and as they
+swum down the current the men run along the bank shooting at them and
+singing out, “Kill them, kill them!”  It made me so sick I most fell out
+of the tree.  I ain’t a-going to tell _all_ that happened--it would make
+me sick again if I was to do that.  I wished I hadn’t ever come ashore
+that night to see such things.  I ain’t ever going to get shut of
+them--lots of times I dream about them.
+
+I stayed in the tree till it begun to get dark, afraid to come down.
+Sometimes I heard guns away off in the woods; and twice I seen little
+gangs of men gallop past the log store with guns; so I reckoned the
+trouble was still a-going on.  I was mighty downhearted; so I made up my
+mind I wouldn’t ever go anear that house again, because I reckoned I
+was to blame, somehow. I judged that that piece of paper meant that Miss
+Sophia was to meet Harney somewheres at half-past two and run off; and
+I judged I ought to told her father about that paper and the curious way
+she acted, and then maybe he would a locked her up, and this awful mess
+wouldn’t ever happened.
+
+When I got down out of the tree I crept along down the river bank a
+piece, and found the two bodies laying in the edge of the water, and
+tugged at them till I got them ashore; then I covered up their faces,
+and got away as quick as I could.  I cried a little when I was covering
+up Buck’s face, for he was mighty good to me.
+
+It was just dark now.  I never went near the house, but struck through
+the woods and made for the swamp.  Jim warn’t on his island, so I
+tramped off in a hurry for the crick, and crowded through the willows,
+red-hot to jump aboard and get out of that awful country.  The raft was
+gone!  My souls, but I was scared!  I couldn’t get my breath for most
+a minute. Then I raised a yell.  A voice not twenty-five foot from me
+says:
+
+“Good lan’! is dat you, honey?  Doan’ make no noise.”
+
+It was Jim’s voice--nothing ever sounded so good before.  I run along the
+bank a piece and got aboard, and Jim he grabbed me and hugged me, he was
+so glad to see me.  He says:
+
+“Laws bless you, chile, I ‘uz right down sho’ you’s dead agin.  Jack’s
+been heah; he say he reck’n you’s ben shot, kase you didn’ come home no
+mo’; so I’s jes’ dis minute a startin’ de raf’ down towards de mouf er
+de crick, so’s to be all ready for to shove out en leave soon as Jack
+comes agin en tells me for certain you _is_ dead.  Lawsy, I’s mighty
+glad to git you back again, honey.”
+
+I says:
+
+“All right--that’s mighty good; they won’t find me, and they’ll think
+I’ve been killed, and floated down the river--there’s something up there
+that ‘ll help them think so--so don’t you lose no time, Jim, but just
+shove off for the big water as fast as ever you can.”
+
+I never felt easy till the raft was two mile below there and out in
+the middle of the Mississippi.  Then we hung up our signal lantern, and
+judged that we was free and safe once more.  I hadn’t had a bite to eat
+since yesterday, so Jim he got out some corn-dodgers and buttermilk,
+and pork and cabbage and greens--there ain’t nothing in the world so good
+when it’s cooked right--and whilst I eat my supper we talked and had a
+good time.  I was powerful glad to get away from the feuds, and so was
+Jim to get away from the swamp.  We said there warn’t no home like a
+raft, after all.  Other places do seem so cramped up and smothery, but a
+raft don’t.  You feel mighty free and easy and comfortable on a raft.
+
+
+
+
+CHAPTER XIX.
+
+TWO or three days and nights went by; I reckon I might say they swum by,
+they slid along so quiet and smooth and lovely.  Here is the way we put
+in the time.  It was a monstrous big river down there--sometimes a mile
+and a half wide; we run nights, and laid up and hid daytimes; soon as
+night was most gone we stopped navigating and tied up--nearly always
+in the dead water under a towhead; and then cut young cottonwoods and
+willows, and hid the raft with them.  Then we set out the lines.  Next
+we slid into the river and had a swim, so as to freshen up and cool
+off; then we set down on the sandy bottom where the water was about knee
+deep, and watched the daylight come.  Not a sound anywheres--perfectly
+still--just like the whole world was asleep, only sometimes the bullfrogs
+a-cluttering, maybe.  The first thing to see, looking away over the
+water, was a kind of dull line--that was the woods on t’other side; you
+couldn’t make nothing else out; then a pale place in the sky; then more
+paleness spreading around; then the river softened up away off, and
+warn’t black any more, but gray; you could see little dark spots
+drifting along ever so far away--trading scows, and such things; and
+long black streaks--rafts; sometimes you could hear a sweep screaking; or
+jumbled up voices, it was so still, and sounds come so far; and by and
+by you could see a streak on the water which you know by the look of the
+streak that there’s a snag there in a swift current which breaks on it
+and makes that streak look that way; and you see the mist curl up off
+of the water, and the east reddens up, and the river, and you make out a
+log-cabin in the edge of the woods, away on the bank on t’other side of
+the river, being a woodyard, likely, and piled by them cheats so you can
+throw a dog through it anywheres; then the nice breeze springs up, and
+comes fanning you from over there, so cool and fresh and sweet to smell
+on account of the woods and the flowers; but sometimes not that way,
+because they’ve left dead fish laying around, gars and such, and they
+do get pretty rank; and next you’ve got the full day, and everything
+smiling in the sun, and the song-birds just going it!
+
+A little smoke couldn’t be noticed now, so we would take some fish off
+of the lines and cook up a hot breakfast.  And afterwards we would watch
+the lonesomeness of the river, and kind of lazy along, and by and by
+lazy off to sleep.  Wake up by and by, and look to see what done it, and
+maybe see a steamboat coughing along up-stream, so far off towards the
+other side you couldn’t tell nothing about her only whether she was
+a stern-wheel or side-wheel; then for about an hour there wouldn’t be
+nothing to hear nor nothing to see--just solid lonesomeness.  Next
+you’d see a raft sliding by, away off yonder, and maybe a galoot on it
+chopping, because they’re most always doing it on a raft; you’d see the
+axe flash and come down--you don’t hear nothing; you see that axe go
+up again, and by the time it’s above the man’s head then you hear the
+_k’chunk_!--it had took all that time to come over the water.  So we
+would put in the day, lazying around, listening to the stillness.  Once
+there was a thick fog, and the rafts and things that went by was beating
+tin pans so the steamboats wouldn’t run over them.  A scow or a
+raft went by so close we could hear them talking and cussing and
+laughing--heard them plain; but we couldn’t see no sign of them; it made
+you feel crawly; it was like spirits carrying on that way in the air.
+ Jim said he believed it was spirits; but I says:
+
+“No; spirits wouldn’t say, ‘Dern the dern fog.’”
+
+Soon as it was night out we shoved; when we got her out to about the
+middle we let her alone, and let her float wherever the current wanted
+her to; then we lit the pipes, and dangled our legs in the water, and
+talked about all kinds of things--we was always naked, day and night,
+whenever the mosquitoes would let us--the new clothes Buck’s folks made
+for me was too good to be comfortable, and besides I didn’t go much on
+clothes, nohow.
+
+Sometimes we’d have that whole river all to ourselves for the longest
+time. Yonder was the banks and the islands, across the water; and maybe
+a spark--which was a candle in a cabin window; and sometimes on the water
+you could see a spark or two--on a raft or a scow, you know; and maybe
+you could hear a fiddle or a song coming over from one of them crafts.
+It’s lovely to live on a raft.  We had the sky up there, all speckled
+with stars, and we used to lay on our backs and look up at them, and
+discuss about whether they was made or only just happened.  Jim he
+allowed they was made, but I allowed they happened; I judged it would
+have took too long to _make_ so many.  Jim said the moon could a _laid_
+them; well, that looked kind of reasonable, so I didn’t say nothing
+against it, because I’ve seen a frog lay most as many, so of course it
+could be done. We used to watch the stars that fell, too, and see them
+streak down.  Jim allowed they’d got spoiled and was hove out of the
+nest.
+
+Once or twice of a night we would see a steamboat slipping along in the
+dark, and now and then she would belch a whole world of sparks up out
+of her chimbleys, and they would rain down in the river and look awful
+pretty; then she would turn a corner and her lights would wink out and
+her powwow shut off and leave the river still again; and by and by her
+waves would get to us, a long time after she was gone, and joggle the
+raft a bit, and after that you wouldn’t hear nothing for you couldn’t
+tell how long, except maybe frogs or something.
+
+After midnight the people on shore went to bed, and then for two or
+three hours the shores was black--no more sparks in the cabin windows.
+ These sparks was our clock--the first one that showed again meant
+morning was coming, so we hunted a place to hide and tie up right away.
+
+One morning about daybreak I found a canoe and crossed over a chute to
+the main shore--it was only two hundred yards--and paddled about a mile
+up a crick amongst the cypress woods, to see if I couldn’t get some
+berries. Just as I was passing a place where a kind of a cowpath crossed
+the crick, here comes a couple of men tearing up the path as tight as
+they could foot it.  I thought I was a goner, for whenever anybody was
+after anybody I judged it was _me_--or maybe Jim.  I was about to dig out
+from there in a hurry, but they was pretty close to me then, and sung
+out and begged me to save their lives--said they hadn’t been doing
+nothing, and was being chased for it--said there was men and dogs
+a-coming.  They wanted to jump right in, but I says:
+
+“Don’t you do it.  I don’t hear the dogs and horses yet; you’ve got time
+to crowd through the brush and get up the crick a little ways; then you
+take to the water and wade down to me and get in--that’ll throw the dogs
+off the scent.”
+
+They done it, and soon as they was aboard I lit out for our towhead,
+and in about five or ten minutes we heard the dogs and the men away off,
+shouting. We heard them come along towards the crick, but couldn’t
+see them; they seemed to stop and fool around a while; then, as we got
+further and further away all the time, we couldn’t hardly hear them at
+all; by the time we had left a mile of woods behind us and struck the
+river, everything was quiet, and we paddled over to the towhead and hid
+in the cottonwoods and was safe.
+
+One of these fellows was about seventy or upwards, and had a bald head
+and very gray whiskers.  He had an old battered-up slouch hat on, and
+a greasy blue woollen shirt, and ragged old blue jeans britches stuffed
+into his boot-tops, and home-knit galluses--no, he only had one.  He had
+an old long-tailed blue jeans coat with slick brass buttons flung over
+his arm, and both of them had big, fat, ratty-looking carpet-bags.
+
+The other fellow was about thirty, and dressed about as ornery.  After
+breakfast we all laid off and talked, and the first thing that come out
+was that these chaps didn’t know one another.
+
+“What got you into trouble?” says the baldhead to t’other chap.
+
+“Well, I’d been selling an article to take the tartar off the teeth--and
+it does take it off, too, and generly the enamel along with it--but I
+stayed about one night longer than I ought to, and was just in the act
+of sliding out when I ran across you on the trail this side of town, and
+you told me they were coming, and begged me to help you to get off.  So
+I told you I was expecting trouble myself, and would scatter out _with_
+you. That’s the whole yarn--what’s yourn?
+
+“Well, I’d ben a-running’ a little temperance revival thar ‘bout a week,
+and was the pet of the women folks, big and little, for I was makin’ it
+mighty warm for the rummies, I _tell_ you, and takin’ as much as five
+or six dollars a night--ten cents a head, children and niggers free--and
+business a-growin’ all the time, when somehow or another a little report
+got around last night that I had a way of puttin’ in my time with a
+private jug on the sly.  A nigger rousted me out this mornin’, and told
+me the people was getherin’ on the quiet with their dogs and horses, and
+they’d be along pretty soon and give me ‘bout half an hour’s start,
+and then run me down if they could; and if they got me they’d tar
+and feather me and ride me on a rail, sure.  I didn’t wait for no
+breakfast--I warn’t hungry.”
+
+“Old man,” said the young one, “I reckon we might double-team it
+together; what do you think?”
+
+“I ain’t undisposed.  What’s your line--mainly?”
+
+“Jour printer by trade; do a little in patent medicines;
+theater-actor--tragedy, you know; take a turn to mesmerism and phrenology
+when there’s a chance; teach singing-geography school for a change;
+sling a lecture sometimes--oh, I do lots of things--most anything that
+comes handy, so it ain’t work.  What’s your lay?”
+
+“I’ve done considerble in the doctoring way in my time.  Layin’ on o’
+hands is my best holt--for cancer and paralysis, and sich things; and I
+k’n tell a fortune pretty good when I’ve got somebody along to find out
+the facts for me.  Preachin’s my line, too, and workin’ camp-meetin’s,
+and missionaryin’ around.”
+
+Nobody never said anything for a while; then the young man hove a sigh
+and says:
+
+“Alas!”
+
+“What ‘re you alassin’ about?” says the bald-head.
+
+“To think I should have lived to be leading such a life, and be degraded
+down into such company.”  And he begun to wipe the corner of his eye
+with a rag.
+
+“Dern your skin, ain’t the company good enough for you?” says the
+baldhead, pretty pert and uppish.
+
+“Yes, it _is_ good enough for me; it’s as good as I deserve; for who
+fetched me so low when I was so high?  I did myself.  I don’t blame
+_you_, gentlemen--far from it; I don’t blame anybody.  I deserve it
+all.  Let the cold world do its worst; one thing I know--there’s a grave
+somewhere for me. The world may go on just as it’s always done, and take
+everything from me--loved ones, property, everything; but it can’t take
+that. Some day I’ll lie down in it and forget it all, and my poor broken
+heart will be at rest.”  He went on a-wiping.
+
+“Drot your pore broken heart,” says the baldhead; “what are you heaving
+your pore broken heart at _us_ f’r?  _we_ hain’t done nothing.”
+
+“No, I know you haven’t.  I ain’t blaming you, gentlemen.  I brought
+myself down--yes, I did it myself.  It’s right I should suffer--perfectly
+right--I don’t make any moan.”
+
+“Brought you down from whar?  Whar was you brought down from?”
+
+“Ah, you would not believe me; the world never believes--let it pass--‘tis
+no matter.  The secret of my birth--”
+
+“The secret of your birth!  Do you mean to say--”
+
+“Gentlemen,” says the young man, very solemn, “I will reveal it to you,
+for I feel I may have confidence in you.  By rights I am a duke!”
+
+Jim’s eyes bugged out when he heard that; and I reckon mine did, too.
+Then the baldhead says:  “No! you can’t mean it?”
+
+“Yes.  My great-grandfather, eldest son of the Duke of Bridgewater, fled
+to this country about the end of the last century, to breathe the pure
+air of freedom; married here, and died, leaving a son, his own father
+dying about the same time.  The second son of the late duke seized the
+titles and estates--the infant real duke was ignored.  I am the lineal
+descendant of that infant--I am the rightful Duke of Bridgewater; and
+here am I, forlorn, torn from my high estate, hunted of men, despised
+by the cold world, ragged, worn, heart-broken, and degraded to the
+companionship of felons on a raft!”
+
+Jim pitied him ever so much, and so did I. We tried to comfort him, but
+he said it warn’t much use, he couldn’t be much comforted; said if we
+was a mind to acknowledge him, that would do him more good than most
+anything else; so we said we would, if he would tell us how.  He said we
+ought to bow when we spoke to him, and say “Your Grace,” or “My Lord,”
+ or “Your Lordship”--and he wouldn’t mind it if we called him plain
+“Bridgewater,” which, he said, was a title anyway, and not a name; and
+one of us ought to wait on him at dinner, and do any little thing for
+him he wanted done.
+
+Well, that was all easy, so we done it.  All through dinner Jim stood
+around and waited on him, and says, “Will yo’ Grace have some o’ dis or
+some o’ dat?” and so on, and a body could see it was mighty pleasing to
+him.
+
+But the old man got pretty silent by and by--didn’t have much to say, and
+didn’t look pretty comfortable over all that petting that was going on
+around that duke.  He seemed to have something on his mind.  So, along
+in the afternoon, he says:
+
+“Looky here, Bilgewater,” he says, “I’m nation sorry for you, but you
+ain’t the only person that’s had troubles like that.”
+
+“No?”
+
+“No you ain’t.  You ain’t the only person that’s ben snaked down
+wrongfully out’n a high place.”
+
+“Alas!”
+
+“No, you ain’t the only person that’s had a secret of his birth.”  And,
+by jings, _he_ begins to cry.
+
+“Hold!  What do you mean?”
+
+“Bilgewater, kin I trust you?” says the old man, still sort of sobbing.
+
+“To the bitter death!”  He took the old man by the hand and squeezed it,
+and says, “That secret of your being:  speak!”
+
+“Bilgewater, I am the late Dauphin!”
+
+You bet you, Jim and me stared this time.  Then the duke says:
+
+“You are what?”
+
+“Yes, my friend, it is too true--your eyes is lookin’ at this very moment
+on the pore disappeared Dauphin, Looy the Seventeen, son of Looy the
+Sixteen and Marry Antonette.”
+
+“You!  At your age!  No!  You mean you’re the late Charlemagne; you must
+be six or seven hundred years old, at the very least.”
+
+“Trouble has done it, Bilgewater, trouble has done it; trouble has brung
+these gray hairs and this premature balditude.  Yes, gentlemen, you
+see before you, in blue jeans and misery, the wanderin’, exiled,
+trampled-on, and sufferin’ rightful King of France.”
+
+Well, he cried and took on so that me and Jim didn’t know hardly what to
+do, we was so sorry--and so glad and proud we’d got him with us, too.
+ So we set in, like we done before with the duke, and tried to comfort
+_him_. But he said it warn’t no use, nothing but to be dead and done
+with it all could do him any good; though he said it often made him feel
+easier and better for a while if people treated him according to his
+rights, and got down on one knee to speak to him, and always called him
+“Your Majesty,” and waited on him first at meals, and didn’t set down
+in his presence till he asked them. So Jim and me set to majestying him,
+and doing this and that and t’other for him, and standing up till he
+told us we might set down.  This done him heaps of good, and so he
+got cheerful and comfortable.  But the duke kind of soured on him, and
+didn’t look a bit satisfied with the way things was going; still,
+the king acted real friendly towards him, and said the duke’s
+great-grandfather and all the other Dukes of Bilgewater was a good
+deal thought of by _his_ father, and was allowed to come to the palace
+considerable; but the duke stayed huffy a good while, till by and by the
+king says:
+
+“Like as not we got to be together a blamed long time on this h-yer
+raft, Bilgewater, and so what’s the use o’ your bein’ sour?  It ‘ll only
+make things oncomfortable.  It ain’t my fault I warn’t born a duke,
+it ain’t your fault you warn’t born a king--so what’s the use to worry?
+ Make the best o’ things the way you find ‘em, says I--that’s my motto.
+ This ain’t no bad thing that we’ve struck here--plenty grub and an easy
+life--come, give us your hand, duke, and le’s all be friends.”
+
+The duke done it, and Jim and me was pretty glad to see it.  It took
+away all the uncomfortableness and we felt mighty good over it, because
+it would a been a miserable business to have any unfriendliness on the
+raft; for what you want, above all things, on a raft, is for everybody
+to be satisfied, and feel right and kind towards the others.
+
+It didn’t take me long to make up my mind that these liars warn’t no
+kings nor dukes at all, but just low-down humbugs and frauds.  But I
+never said nothing, never let on; kept it to myself; it’s the best way;
+then you don’t have no quarrels, and don’t get into no trouble.  If they
+wanted us to call them kings and dukes, I hadn’t no objections, ‘long as
+it would keep peace in the family; and it warn’t no use to tell Jim, so
+I didn’t tell him.  If I never learnt nothing else out of pap, I learnt
+that the best way to get along with his kind of people is to let them
+have their own way.
+
+
+
+
+CHAPTER XX.
+
+THEY asked us considerable many questions; wanted to know what we
+covered up the raft that way for, and laid by in the daytime instead of
+running--was Jim a runaway nigger?  Says I:
+
+“Goodness sakes! would a runaway nigger run _south_?”
+
+No, they allowed he wouldn’t.  I had to account for things some way, so
+I says:
+
+“My folks was living in Pike County, in Missouri, where I was born, and
+they all died off but me and pa and my brother Ike.  Pa, he ‘lowed
+he’d break up and go down and live with Uncle Ben, who’s got a little
+one-horse place on the river, forty-four mile below Orleans.  Pa was
+pretty poor, and had some debts; so when he’d squared up there warn’t
+nothing left but sixteen dollars and our nigger, Jim.  That warn’t
+enough to take us fourteen hundred mile, deck passage nor no other way.
+ Well, when the river rose pa had a streak of luck one day; he ketched
+this piece of a raft; so we reckoned we’d go down to Orleans on it.
+ Pa’s luck didn’t hold out; a steamboat run over the forrard corner of
+the raft one night, and we all went overboard and dove under the wheel;
+Jim and me come up all right, but pa was drunk, and Ike was only four
+years old, so they never come up no more.  Well, for the next day or
+two we had considerable trouble, because people was always coming out in
+skiffs and trying to take Jim away from me, saying they believed he was
+a runaway nigger.  We don’t run daytimes no more now; nights they don’t
+bother us.”
+
+The duke says:
+
+“Leave me alone to cipher out a way so we can run in the daytime if we
+want to.  I’ll think the thing over--I’ll invent a plan that’ll fix it.
+We’ll let it alone for to-day, because of course we don’t want to go by
+that town yonder in daylight--it mightn’t be healthy.”
+
+Towards night it begun to darken up and look like rain; the heat
+lightning was squirting around low down in the sky, and the leaves was
+beginning to shiver--it was going to be pretty ugly, it was easy to see
+that.  So the duke and the king went to overhauling our wigwam, to see
+what the beds was like.  My bed was a straw tick better than Jim’s,
+which was a corn-shuck tick; there’s always cobs around about in a shuck
+tick, and they poke into you and hurt; and when you roll over the dry
+shucks sound like you was rolling over in a pile of dead leaves; it
+makes such a rustling that you wake up.  Well, the duke allowed he would
+take my bed; but the king allowed he wouldn’t.  He says:
+
+“I should a reckoned the difference in rank would a sejested to you that
+a corn-shuck bed warn’t just fitten for me to sleep on.  Your Grace ‘ll
+take the shuck bed yourself.”
+
+Jim and me was in a sweat again for a minute, being afraid there was
+going to be some more trouble amongst them; so we was pretty glad when
+the duke says:
+
+“‘Tis my fate to be always ground into the mire under the iron heel of
+oppression.  Misfortune has broken my once haughty spirit; I yield, I
+submit; ‘tis my fate.  I am alone in the world--let me suffer; can bear
+it.”
+
+We got away as soon as it was good and dark.  The king told us to stand
+well out towards the middle of the river, and not show a light till we
+got a long ways below the town.  We come in sight of the little bunch of
+lights by and by--that was the town, you know--and slid by, about a half
+a mile out, all right.  When we was three-quarters of a mile below we
+hoisted up our signal lantern; and about ten o’clock it come on to rain
+and blow and thunder and lighten like everything; so the king told us
+to both stay on watch till the weather got better; then him and the duke
+crawled into the wigwam and turned in for the night.  It was my watch
+below till twelve, but I wouldn’t a turned in anyway if I’d had a bed,
+because a body don’t see such a storm as that every day in the week, not
+by a long sight.  My souls, how the wind did scream along!  And every
+second or two there’d come a glare that lit up the white-caps for a half
+a mile around, and you’d see the islands looking dusty through the rain,
+and the trees thrashing around in the wind; then comes a H-WHACK!--bum!
+bum! bumble-umble-um-bum-bum-bum-bum--and the thunder would go rumbling
+and grumbling away, and quit--and then RIP comes another flash and
+another sockdolager.  The waves most washed me off the raft sometimes,
+but I hadn’t any clothes on, and didn’t mind.  We didn’t have no trouble
+about snags; the lightning was glaring and flittering around so constant
+that we could see them plenty soon enough to throw her head this way or
+that and miss them.
+
+I had the middle watch, you know, but I was pretty sleepy by that time,
+so Jim he said he would stand the first half of it for me; he was always
+mighty good that way, Jim was.  I crawled into the wigwam, but the king
+and the duke had their legs sprawled around so there warn’t no show for
+me; so I laid outside--I didn’t mind the rain, because it was warm, and
+the waves warn’t running so high now.  About two they come up again,
+though, and Jim was going to call me; but he changed his mind, because
+he reckoned they warn’t high enough yet to do any harm; but he was
+mistaken about that, for pretty soon all of a sudden along comes a
+regular ripper and washed me overboard.  It most killed Jim a-laughing.
+ He was the easiest nigger to laugh that ever was, anyway.
+
+I took the watch, and Jim he laid down and snored away; and by and by
+the storm let up for good and all; and the first cabin-light that showed
+I rousted him out, and we slid the raft into hiding quarters for the
+day.
+
+The king got out an old ratty deck of cards after breakfast, and him
+and the duke played seven-up a while, five cents a game.  Then they got
+tired of it, and allowed they would “lay out a campaign,” as they called
+it. The duke went down into his carpet-bag, and fetched up a lot of
+little printed bills and read them out loud.  One bill said, “The
+celebrated Dr. Armand de Montalban, of Paris,” would “lecture on the
+Science of Phrenology” at such and such a place, on the blank day of
+blank, at ten cents admission, and “furnish charts of character at
+twenty-five cents apiece.”  The duke said that was _him_.  In another
+bill he was the “world-renowned Shakespearian tragedian, Garrick the
+Younger, of Drury Lane, London.”  In other bills he had a lot of other
+names and done other wonderful things, like finding water and gold with
+a “divining-rod,” “dissipating witch spells,” and so on.  By and by he
+says:
+
+“But the histrionic muse is the darling.  Have you ever trod the boards,
+Royalty?”
+
+“No,” says the king.
+
+“You shall, then, before you’re three days older, Fallen Grandeur,” says
+the duke.  “The first good town we come to we’ll hire a hall and do the
+sword fight in Richard III. and the balcony scene in Romeo and Juliet.
+How does that strike you?”
+
+“I’m in, up to the hub, for anything that will pay, Bilgewater; but, you
+see, I don’t know nothing about play-actin’, and hain’t ever seen much
+of it.  I was too small when pap used to have ‘em at the palace.  Do you
+reckon you can learn me?”
+
+“Easy!”
+
+“All right.  I’m jist a-freezn’ for something fresh, anyway.  Le’s
+commence right away.”
+
+So the duke he told him all about who Romeo was and who Juliet was, and
+said he was used to being Romeo, so the king could be Juliet.
+
+“But if Juliet’s such a young gal, duke, my peeled head and my white
+whiskers is goin’ to look oncommon odd on her, maybe.”
+
+“No, don’t you worry; these country jakes won’t ever think of that.
+Besides, you know, you’ll be in costume, and that makes all the
+difference in the world; Juliet’s in a balcony, enjoying the moonlight
+before she goes to bed, and she’s got on her night-gown and her ruffled
+nightcap.  Here are the costumes for the parts.”
+
+He got out two or three curtain-calico suits, which he said was
+meedyevil armor for Richard III. and t’other chap, and a long white
+cotton nightshirt and a ruffled nightcap to match.  The king was
+satisfied; so the duke got out his book and read the parts over in the
+most splendid spread-eagle way, prancing around and acting at the same
+time, to show how it had got to be done; then he give the book to the
+king and told him to get his part by heart.
+
+There was a little one-horse town about three mile down the bend, and
+after dinner the duke said he had ciphered out his idea about how to run
+in daylight without it being dangersome for Jim; so he allowed he would
+go down to the town and fix that thing.  The king allowed he would go,
+too, and see if he couldn’t strike something.  We was out of coffee, so
+Jim said I better go along with them in the canoe and get some.
+
+When we got there there warn’t nobody stirring; streets empty, and
+perfectly dead and still, like Sunday.  We found a sick nigger sunning
+himself in a back yard, and he said everybody that warn’t too young or
+too sick or too old was gone to camp-meeting, about two mile back in the
+woods.  The king got the directions, and allowed he’d go and work that
+camp-meeting for all it was worth, and I might go, too.
+
+The duke said what he was after was a printing-office.  We found it;
+a little bit of a concern, up over a carpenter shop--carpenters and
+printers all gone to the meeting, and no doors locked.  It was a dirty,
+littered-up place, and had ink marks, and handbills with pictures of
+horses and runaway niggers on them, all over the walls.  The duke shed
+his coat and said he was all right now.  So me and the king lit out for
+the camp-meeting.
+
+We got there in about a half an hour fairly dripping, for it was a most
+awful hot day.  There was as much as a thousand people there from
+twenty mile around.  The woods was full of teams and wagons, hitched
+everywheres, feeding out of the wagon-troughs and stomping to keep
+off the flies.  There was sheds made out of poles and roofed over with
+branches, where they had lemonade and gingerbread to sell, and piles of
+watermelons and green corn and such-like truck.
+
+The preaching was going on under the same kinds of sheds, only they was
+bigger and held crowds of people.  The benches was made out of outside
+slabs of logs, with holes bored in the round side to drive sticks into
+for legs. They didn’t have no backs.  The preachers had high platforms
+to stand on at one end of the sheds.  The women had on sun-bonnets;
+and some had linsey-woolsey frocks, some gingham ones, and a few of the
+young ones had on calico.  Some of the young men was barefooted, and
+some of the children didn’t have on any clothes but just a tow-linen
+shirt.  Some of the old women was knitting, and some of the young folks
+was courting on the sly.
+
+The first shed we come to the preacher was lining out a hymn.  He lined
+out two lines, everybody sung it, and it was kind of grand to hear it,
+there was so many of them and they done it in such a rousing way; then
+he lined out two more for them to sing--and so on.  The people woke up
+more and more, and sung louder and louder; and towards the end some
+begun to groan, and some begun to shout.  Then the preacher begun to
+preach, and begun in earnest, too; and went weaving first to one side of
+the platform and then the other, and then a-leaning down over the front
+of it, with his arms and his body going all the time, and shouting his
+words out with all his might; and every now and then he would hold up
+his Bible and spread it open, and kind of pass it around this way and
+that, shouting, “It’s the brazen serpent in the wilderness!  Look upon
+it and live!”  And people would shout out, “Glory!--A-a-_men_!”  And so
+he went on, and the people groaning and crying and saying amen:
+
+“Oh, come to the mourners’ bench! come, black with sin! (_Amen_!) come,
+sick and sore! (_Amen_!) come, lame and halt and blind! (_Amen_!) come,
+pore and needy, sunk in shame! (_A-A-Men_!) come, all that’s worn and
+soiled and suffering!--come with a broken spirit! come with a contrite
+heart! come in your rags and sin and dirt! the waters that cleanse
+is free, the door of heaven stands open--oh, enter in and be at rest!”
+ (_A-A-Men_!  _Glory, Glory Hallelujah!_)
+
+And so on.  You couldn’t make out what the preacher said any more, on
+account of the shouting and crying.  Folks got up everywheres in the
+crowd, and worked their way just by main strength to the mourners’
+bench, with the tears running down their faces; and when all the
+mourners had got up there to the front benches in a crowd, they sung and
+shouted and flung themselves down on the straw, just crazy and wild.
+
+Well, the first I knowed the king got a-going, and you could hear him
+over everybody; and next he went a-charging up on to the platform, and
+the preacher he begged him to speak to the people, and he done it.  He
+told them he was a pirate--been a pirate for thirty years out in the
+Indian Ocean--and his crew was thinned out considerable last spring in
+a fight, and he was home now to take out some fresh men, and thanks to
+goodness he’d been robbed last night and put ashore off of a steamboat
+without a cent, and he was glad of it; it was the blessedest thing that
+ever happened to him, because he was a changed man now, and happy for
+the first time in his life; and, poor as he was, he was going to start
+right off and work his way back to the Indian Ocean, and put in the rest
+of his life trying to turn the pirates into the true path; for he could
+do it better than anybody else, being acquainted with all pirate crews
+in that ocean; and though it would take him a long time to get there
+without money, he would get there anyway, and every time he convinced
+a pirate he would say to him, “Don’t you thank me, don’t you give me no
+credit; it all belongs to them dear people in Pokeville camp-meeting,
+natural brothers and benefactors of the race, and that dear preacher
+there, the truest friend a pirate ever had!”
+
+And then he busted into tears, and so did everybody.  Then somebody
+sings out, “Take up a collection for him, take up a collection!”  Well,
+a half a dozen made a jump to do it, but somebody sings out, “Let _him_
+pass the hat around!”  Then everybody said it, the preacher too.
+
+So the king went all through the crowd with his hat swabbing his eyes,
+and blessing the people and praising them and thanking them for being
+so good to the poor pirates away off there; and every little while the
+prettiest kind of girls, with the tears running down their cheeks, would
+up and ask him would he let them kiss him for to remember him by; and he
+always done it; and some of them he hugged and kissed as many as five or
+six times--and he was invited to stay a week; and everybody wanted him to
+live in their houses, and said they’d think it was an honor; but he said
+as this was the last day of the camp-meeting he couldn’t do no good, and
+besides he was in a sweat to get to the Indian Ocean right off and go to
+work on the pirates.
+
+When we got back to the raft and he come to count up he found he had
+collected eighty-seven dollars and seventy-five cents.  And then he had
+fetched away a three-gallon jug of whisky, too, that he found under a
+wagon when he was starting home through the woods.  The king said,
+take it all around, it laid over any day he’d ever put in in the
+missionarying line.  He said it warn’t no use talking, heathens don’t
+amount to shucks alongside of pirates to work a camp-meeting with.
+
+The duke was thinking _he’d_ been doing pretty well till the king come
+to show up, but after that he didn’t think so so much.  He had set
+up and printed off two little jobs for farmers in that
+printing-office--horse bills--and took the money, four dollars.  And he
+had got in ten dollars’ worth of advertisements for the paper, which he
+said he would put in for four dollars if they would pay in advance--so
+they done it. The price of the paper was two dollars a year, but he took
+in three subscriptions for half a dollar apiece on condition of them
+paying him in advance; they were going to pay in cordwood and onions as
+usual, but he said he had just bought the concern and knocked down the
+price as low as he could afford it, and was going to run it for cash.
+ He set up a little piece of poetry, which he made, himself, out of
+his own head--three verses--kind of sweet and saddish--the name of it was,
+“Yes, crush, cold world, this breaking heart”--and he left that all set
+up and ready to print in the paper, and didn’t charge nothing for it.
+ Well, he took in nine dollars and a half, and said he’d done a pretty
+square day’s work for it.
+
+Then he showed us another little job he’d printed and hadn’t charged
+for, because it was for us.  It had a picture of a runaway nigger with
+a bundle on a stick over his shoulder, and “$200 reward” under it.  The
+reading was all about Jim, and just described him to a dot.  It said
+he run away from St. Jacques’ plantation, forty mile below New Orleans,
+last winter, and likely went north, and whoever would catch him and send
+him back he could have the reward and expenses.
+
+“Now,” says the duke, “after to-night we can run in the daytime if we
+want to.  Whenever we see anybody coming we can tie Jim hand and foot
+with a rope, and lay him in the wigwam and show this handbill and say we
+captured him up the river, and were too poor to travel on a steamboat,
+so we got this little raft on credit from our friends and are going down
+to get the reward.  Handcuffs and chains would look still better on Jim,
+but it wouldn’t go well with the story of us being so poor.  Too much
+like jewelry.  Ropes are the correct thing--we must preserve the unities,
+as we say on the boards.”
+
+We all said the duke was pretty smart, and there couldn’t be no trouble
+about running daytimes.  We judged we could make miles enough that night
+to get out of the reach of the powwow we reckoned the duke’s work in
+the printing office was going to make in that little town; then we could
+boom right along if we wanted to.
+
+We laid low and kept still, and never shoved out till nearly ten
+o’clock; then we slid by, pretty wide away from the town, and didn’t
+hoist our lantern till we was clear out of sight of it.
+
+When Jim called me to take the watch at four in the morning, he says:
+
+“Huck, does you reck’n we gwyne to run acrost any mo’ kings on dis
+trip?”
+
+“No,” I says, “I reckon not.”
+
+“Well,” says he, “dat’s all right, den.  I doan’ mine one er two kings,
+but dat’s enough.  Dis one’s powerful drunk, en de duke ain’ much
+better.”
+
+I found Jim had been trying to get him to talk French, so he could hear
+what it was like; but he said he had been in this country so long, and
+had so much trouble, he’d forgot it.
+
+
+
+
+CHAPTER XXI.
+
+IT was after sun-up now, but we went right on and didn’t tie up.  The
+king and the duke turned out by and by looking pretty rusty; but after
+they’d jumped overboard and took a swim it chippered them up a good
+deal. After breakfast the king he took a seat on the corner of the raft,
+and pulled off his boots and rolled up his britches, and let his legs
+dangle in the water, so as to be comfortable, and lit his pipe, and went
+to getting his Romeo and Juliet by heart.  When he had got it pretty
+good him and the duke begun to practice it together.  The duke had to
+learn him over and over again how to say every speech; and he made him
+sigh, and put his hand on his heart, and after a while he said he done
+it pretty well; “only,” he says, “you mustn’t bellow out _Romeo_!
+that way, like a bull--you must say it soft and sick and languishy,
+so--R-o-o-meo! that is the idea; for Juliet’s a dear sweet mere child of
+a girl, you know, and she doesn’t bray like a jackass.”
+
+Well, next they got out a couple of long swords that the duke made out
+of oak laths, and begun to practice the sword fight--the duke called
+himself Richard III.; and the way they laid on and pranced around
+the raft was grand to see.  But by and by the king tripped and fell
+overboard, and after that they took a rest, and had a talk about all
+kinds of adventures they’d had in other times along the river.
+
+After dinner the duke says:
+
+“Well, Capet, we’ll want to make this a first-class show, you know, so
+I guess we’ll add a little more to it.  We want a little something to
+answer encores with, anyway.”
+
+“What’s onkores, Bilgewater?”
+
+The duke told him, and then says:
+
+“I’ll answer by doing the Highland fling or the sailor’s hornpipe; and
+you--well, let me see--oh, I’ve got it--you can do Hamlet’s soliloquy.”
+
+“Hamlet’s which?”
+
+“Hamlet’s soliloquy, you know; the most celebrated thing in Shakespeare.
+Ah, it’s sublime, sublime!  Always fetches the house.  I haven’t got
+it in the book--I’ve only got one volume--but I reckon I can piece it out
+from memory.  I’ll just walk up and down a minute, and see if I can call
+it back from recollection’s vaults.”
+
+So he went to marching up and down, thinking, and frowning horrible
+every now and then; then he would hoist up his eyebrows; next he would
+squeeze his hand on his forehead and stagger back and kind of moan; next
+he would sigh, and next he’d let on to drop a tear.  It was beautiful
+to see him. By and by he got it.  He told us to give attention.  Then
+he strikes a most noble attitude, with one leg shoved forwards, and his
+arms stretched away up, and his head tilted back, looking up at the sky;
+and then he begins to rip and rave and grit his teeth; and after that,
+all through his speech, he howled, and spread around, and swelled up his
+chest, and just knocked the spots out of any acting ever I see before.
+ This is the speech--I learned it, easy enough, while he was learning it
+to the king:
+
+To be, or not to be; that is the bare bodkin That makes calamity of
+so long life; For who would fardels bear, till Birnam Wood do come
+to Dunsinane, But that the fear of something after death Murders the
+innocent sleep, Great nature’s second course, And makes us rather sling
+the arrows of outrageous fortune Than fly to others that we know not of.
+There’s the respect must give us pause: Wake Duncan with thy knocking! I
+would thou couldst; For who would bear the whips and scorns of time, The
+oppressor’s wrong, the proud man’s contumely, The law’s delay, and the
+quietus which his pangs might take. In the dead waste and middle of the
+night, when churchyards yawn In customary suits of solemn black, But
+that the undiscovered country from whose bourne no traveler returns,
+Breathes forth contagion on the world, And thus the native hue of
+resolution, like the poor cat i’ the adage, Is sicklied o’er with care.
+And all the clouds that lowered o’er our housetops, With this
+regard their currents turn awry, And lose the name of action. ‘Tis a
+consummation devoutly to be wished. But soft you, the fair Ophelia: Ope
+not thy ponderous and marble jaws. But get thee to a nunnery&mdash;go!
+
+Well, the old man he liked that speech, and he mighty soon got it so he
+could do it first rate. It seemed like he was just born for it; and when
+he had his hand in and was excited, it was perfectly lovely the way he
+would rip and tear and rair up behind when he was getting it off.
+
+The first chance we got, the duke he had some show bills printed; and
+after that, for two or three days as we floated along, the raft was a
+most uncommon lively place, for there warn’t nothing but sword-fighting
+and rehearsing--as the duke called it--going on all the time. One morning,
+when we was pretty well down the State of Arkansaw, we come in sight
+of a little one-horse town in a big bend; so we tied up about
+three-quarters of a mile above it, in the mouth of a crick which was
+shut in like a tunnel by the cypress trees, and all of us but Jim took
+the canoe and went down there to see if there was any chance in that
+place for our show.
+
+We struck it mighty lucky; there was going to be a circus there that
+afternoon, and the country people was already beginning to come in, in
+all kinds of old shackly wagons, and on horses. The circus would leave
+before night, so our show would have a pretty good chance. The duke he
+hired the court house, and we went around and stuck up our bills. They
+read like this:
+
+Shaksperean Revival!!!
+
+Wonderful Attraction!
+
+For One Night Only! The world renowned tragedians,
+
+David Garrick the younger, of Drury Lane Theatre, London,
+
+and
+
+Edmund Kean the elder, of the Royal Haymarket Theatre, Whitechapel,
+Pudding Lane, Piccadilly, London, and the Royal Continental Theatres, in
+their sublime Shaksperean Spectacle entitled The Balcony Scene in
+
+Romeo and Juliet!!!
+
+Romeo...................................... Mr. Garrick.
+
+Juliet..................................... Mr. Kean.
+
+Assisted by the whole strength of the company!
+
+New costumes, new scenery, new appointments!
+
+Also:
+
+The thrilling, masterly, and blood-curdling Broad-sword conflict In
+Richard III.!!!
+
+Richard III................................ Mr. Garrick.
+
+Richmond................................... Mr. Kean.
+
+also:
+
+(by special request,)
+
+Hamlet’s Immortal Soliloquy!!
+
+By the Illustrious Kean!
+
+Done by him 300 consecutive nights in Paris!
+
+For One Night Only,
+
+On account of imperative European engagements!
+
+Admission 25 cents; children and servants, 10 cents.
+
+Then we went loafing around the town. The stores and houses was most all
+old shackly dried-up frame concerns that hadn’t ever been painted; they
+was set up three or four foot above ground on stilts, so as to be out of
+reach of the water when the river was overflowed. The houses had little
+gardens around them, but they didn’t seem to raise hardly anything in
+them but jimpson weeds, and sunflowers, and ash-piles, and old curled-up
+boots and shoes, and pieces of bottles, and rags, and played-out
+tin-ware. The fences was made of different kinds of boards, nailed on
+at different times; and they leaned every which-way, and had gates that
+didn’t generly have but one hinge--a leather one. Some of the fences
+had been whitewashed, some time or another, but the duke said it was in
+Clumbus’s time, like enough. There was generly hogs in the garden, and
+people driving them out.
+
+All the stores was along one street.  They had white domestic awnings in
+front, and the country people hitched their horses to the awning-posts.
+There was empty drygoods boxes under the awnings, and loafers roosting
+on them all day long, whittling them with their Barlow knives; and
+chawing tobacco, and gaping and yawning and stretching--a mighty ornery
+lot. They generly had on yellow straw hats most as wide as an umbrella,
+but didn’t wear no coats nor waistcoats, they called one another Bill,
+and Buck, and Hank, and Joe, and Andy, and talked lazy and drawly, and
+used considerable many cuss words.  There was as many as one loafer
+leaning up against every awning-post, and he most always had his hands
+in his britches-pockets, except when he fetched them out to lend a chaw
+of tobacco or scratch.  What a body was hearing amongst them all the
+time was:
+
+“Gimme a chaw ‘v tobacker, Hank.”
+
+“Cain’t; I hain’t got but one chaw left.  Ask Bill.”
+
+Maybe Bill he gives him a chaw; maybe he lies and says he ain’t got
+none. Some of them kinds of loafers never has a cent in the world, nor a
+chaw of tobacco of their own.  They get all their chawing by borrowing;
+they say to a fellow, “I wisht you’d len’ me a chaw, Jack, I jist this
+minute give Ben Thompson the last chaw I had”--which is a lie pretty
+much everytime; it don’t fool nobody but a stranger; but Jack ain’t no
+stranger, so he says:
+
+“_You_ give him a chaw, did you?  So did your sister’s cat’s
+grandmother. You pay me back the chaws you’ve awready borry’d off’n me,
+Lafe Buckner, then I’ll loan you one or two ton of it, and won’t charge
+you no back intrust, nuther.”
+
+“Well, I _did_ pay you back some of it wunst.”
+
+“Yes, you did--‘bout six chaws.  You borry’d store tobacker and paid back
+nigger-head.”
+
+Store tobacco is flat black plug, but these fellows mostly chaws the
+natural leaf twisted.  When they borrow a chaw they don’t generly cut it
+off with a knife, but set the plug in between their teeth, and gnaw with
+their teeth and tug at the plug with their hands till they get it in
+two; then sometimes the one that owns the tobacco looks mournful at it
+when it’s handed back, and says, sarcastic:
+
+“Here, gimme the _chaw_, and you take the _plug_.”
+
+All the streets and lanes was just mud; they warn’t nothing else _but_
+mud--mud as black as tar and nigh about a foot deep in some places,
+and two or three inches deep in _all_ the places.  The hogs loafed and
+grunted around everywheres.  You’d see a muddy sow and a litter of pigs
+come lazying along the street and whollop herself right down in the way,
+where folks had to walk around her, and she’d stretch out and shut her
+eyes and wave her ears whilst the pigs was milking her, and look as
+happy as if she was on salary. And pretty soon you’d hear a loafer
+sing out, “Hi!  _so_ boy! sick him, Tige!” and away the sow would go,
+squealing most horrible, with a dog or two swinging to each ear, and
+three or four dozen more a-coming; and then you would see all the
+loafers get up and watch the thing out of sight, and laugh at the fun
+and look grateful for the noise.  Then they’d settle back again till
+there was a dog fight.  There couldn’t anything wake them up all over,
+and make them happy all over, like a dog fight--unless it might be
+putting turpentine on a stray dog and setting fire to him, or tying a
+tin pan to his tail and see him run himself to death.
+
+On the river front some of the houses was sticking out over the bank,
+and they was bowed and bent, and about ready to tumble in. The people
+had moved out of them.  The bank was caved away under one corner of some
+others, and that corner was hanging over.  People lived in them yet, but
+it was dangersome, because sometimes a strip of land as wide as a house
+caves in at a time.  Sometimes a belt of land a quarter of a mile deep
+will start in and cave along and cave along till it all caves into the
+river in one summer. Such a town as that has to be always moving back,
+and back, and back, because the river’s always gnawing at it.
+
+The nearer it got to noon that day the thicker and thicker was the
+wagons and horses in the streets, and more coming all the time.
+ Families fetched their dinners with them from the country, and eat them
+in the wagons.  There was considerable whisky drinking going on, and I
+seen three fights.  By and by somebody sings out:
+
+“Here comes old Boggs!--in from the country for his little old monthly
+drunk; here he comes, boys!”
+
+All the loafers looked glad; I reckoned they was used to having fun out
+of Boggs.  One of them says:
+
+“Wonder who he’s a-gwyne to chaw up this time.  If he’d a-chawed up all
+the men he’s ben a-gwyne to chaw up in the last twenty year he’d have
+considerable ruputation now.”
+
+Another one says, “I wisht old Boggs ‘d threaten me, ‘cuz then I’d know
+I warn’t gwyne to die for a thousan’ year.”
+
+Boggs comes a-tearing along on his horse, whooping and yelling like an
+Injun, and singing out:
+
+“Cler the track, thar.  I’m on the waw-path, and the price uv coffins is
+a-gwyne to raise.”
+
+He was drunk, and weaving about in his saddle; he was over fifty year
+old, and had a very red face.  Everybody yelled at him and laughed at
+him and sassed him, and he sassed back, and said he’d attend to them and
+lay them out in their regular turns, but he couldn’t wait now because
+he’d come to town to kill old Colonel Sherburn, and his motto was, “Meat
+first, and spoon vittles to top off on.”
+
+He see me, and rode up and says:
+
+“Whar’d you come f’m, boy?  You prepared to die?”
+
+Then he rode on.  I was scared, but a man says:
+
+“He don’t mean nothing; he’s always a-carryin’ on like that when he’s
+drunk.  He’s the best naturedest old fool in Arkansaw--never hurt nobody,
+drunk nor sober.”
+
+Boggs rode up before the biggest store in town, and bent his head down
+so he could see under the curtain of the awning and yells:
+
+“Come out here, Sherburn! Come out and meet the man you’ve swindled.
+You’re the houn’ I’m after, and I’m a-gwyne to have you, too!”
+
+And so he went on, calling Sherburn everything he could lay his tongue
+to, and the whole street packed with people listening and laughing and
+going on.  By and by a proud-looking man about fifty-five--and he was a
+heap the best dressed man in that town, too--steps out of the store, and
+the crowd drops back on each side to let him come.  He says to Boggs,
+mighty ca’m and slow--he says:
+
+“I’m tired of this, but I’ll endure it till one o’clock.  Till one
+o’clock, mind--no longer.  If you open your mouth against me only once
+after that time you can’t travel so far but I will find you.”
+
+Then he turns and goes in.  The crowd looked mighty sober; nobody
+stirred, and there warn’t no more laughing.  Boggs rode off
+blackguarding Sherburn as loud as he could yell, all down the street;
+and pretty soon back he comes and stops before the store, still keeping
+it up.  Some men crowded around him and tried to get him to shut up,
+but he wouldn’t; they told him it would be one o’clock in about fifteen
+minutes, and so he _must_ go home--he must go right away.  But it didn’t
+do no good.  He cussed away with all his might, and throwed his hat down
+in the mud and rode over it, and pretty soon away he went a-raging down
+the street again, with his gray hair a-flying. Everybody that could get
+a chance at him tried their best to coax him off of his horse so they
+could lock him up and get him sober; but it warn’t no use--up the street
+he would tear again, and give Sherburn another cussing.  By and by
+somebody says:
+
+“Go for his daughter!--quick, go for his daughter; sometimes he’ll listen
+to her.  If anybody can persuade him, she can.”
+
+So somebody started on a run.  I walked down street a ways and stopped.
+In about five or ten minutes here comes Boggs again, but not on his
+horse.  He was a-reeling across the street towards me, bare-headed, with
+a friend on both sides of him a-holt of his arms and hurrying him along.
+He was quiet, and looked uneasy; and he warn’t hanging back any, but was
+doing some of the hurrying himself.  Somebody sings out:
+
+“Boggs!”
+
+I looked over there to see who said it, and it was that Colonel
+Sherburn. He was standing perfectly still in the street, and had a
+pistol raised in his right hand--not aiming it, but holding it out with
+the barrel tilted up towards the sky.  The same second I see a young
+girl coming on the run, and two men with her.  Boggs and the men turned
+round to see who called him, and when they see the pistol the men
+jumped to one side, and the pistol-barrel come down slow and steady to
+a level--both barrels cocked. Boggs throws up both of his hands and says,
+“O Lord, don’t shoot!”  Bang! goes the first shot, and he staggers back,
+clawing at the air--bang! goes the second one, and he tumbles backwards
+on to the ground, heavy and solid, with his arms spread out.  That young
+girl screamed out and comes rushing, and down she throws herself on her
+father, crying, and saying, “Oh, he’s killed him, he’s killed him!”  The
+crowd closed up around them, and shouldered and jammed one another, with
+their necks stretched, trying to see, and people on the inside trying to
+shove them back and shouting, “Back, back! give him air, give him air!”
+
+Colonel Sherburn he tossed his pistol on to the ground, and turned
+around on his heels and walked off.
+
+They took Boggs to a little drug store, the crowd pressing around just
+the same, and the whole town following, and I rushed and got a good
+place at the window, where I was close to him and could see in.  They
+laid him on the floor and put one large Bible under his head, and opened
+another one and spread it on his breast; but they tore open his shirt
+first, and I seen where one of the bullets went in.  He made about a
+dozen long gasps, his breast lifting the Bible up when he drawed in his
+breath, and letting it down again when he breathed it out--and after that
+he laid still; he was dead.  Then they pulled his daughter away from
+him, screaming and crying, and took her off.  She was about sixteen, and
+very sweet and gentle looking, but awful pale and scared.
+
+Well, pretty soon the whole town was there, squirming and scrouging and
+pushing and shoving to get at the window and have a look, but people
+that had the places wouldn’t give them up, and folks behind them was
+saying all the time, “Say, now, you’ve looked enough, you fellows;
+‘tain’t right and ‘tain’t fair for you to stay thar all the time, and
+never give nobody a chance; other folks has their rights as well as
+you.”
+
+There was considerable jawing back, so I slid out, thinking maybe
+there was going to be trouble.  The streets was full, and everybody was
+excited. Everybody that seen the shooting was telling how it happened,
+and there was a big crowd packed around each one of these fellows,
+stretching their necks and listening.  One long, lanky man, with long
+hair and a big white fur stovepipe hat on the back of his head, and a
+crooked-handled cane, marked out the places on the ground where Boggs
+stood and where Sherburn stood, and the people following him around from
+one place to t’other and watching everything he done, and bobbing their
+heads to show they understood, and stooping a little and resting their
+hands on their thighs to watch him mark the places on the ground with
+his cane; and then he stood up straight and stiff where Sherburn had
+stood, frowning and having his hat-brim down over his eyes, and sung
+out, “Boggs!” and then fetched his cane down slow to a level, and says
+“Bang!” staggered backwards, says “Bang!” again, and fell down flat on
+his back. The people that had seen the thing said he done it perfect;
+said it was just exactly the way it all happened.  Then as much as a
+dozen people got out their bottles and treated him.
+
+Well, by and by somebody said Sherburn ought to be lynched.  In about a
+minute everybody was saying it; so away they went, mad and yelling, and
+snatching down every clothes-line they come to to do the hanging with.
+
+
+
+
+CHAPTER XXII.
+
+THEY swarmed up towards Sherburn’s house, a-whooping and raging like
+Injuns, and everything had to clear the way or get run over and tromped
+to mush, and it was awful to see.  Children was heeling it ahead of the
+mob, screaming and trying to get out of the way; and every window along
+the road was full of women’s heads, and there was nigger boys in every
+tree, and bucks and wenches looking over every fence; and as soon as the
+mob would get nearly to them they would break and skaddle back out of
+reach.  Lots of the women and girls was crying and taking on, scared
+most to death.
+
+They swarmed up in front of Sherburn’s palings as thick as they could
+jam together, and you couldn’t hear yourself think for the noise.  It
+was a little twenty-foot yard.  Some sung out “Tear down the fence! tear
+down the fence!”  Then there was a racket of ripping and tearing and
+smashing, and down she goes, and the front wall of the crowd begins to
+roll in like a wave.
+
+Just then Sherburn steps out on to the roof of his little front porch,
+with a double-barrel gun in his hand, and takes his stand, perfectly
+ca’m and deliberate, not saying a word.  The racket stopped, and the
+wave sucked back.
+
+Sherburn never said a word--just stood there, looking down.  The
+stillness was awful creepy and uncomfortable.  Sherburn run his eye slow
+along the crowd; and wherever it struck the people tried a little to
+out-gaze him, but they couldn’t; they dropped their eyes and looked
+sneaky. Then pretty soon Sherburn sort of laughed; not the pleasant
+kind, but the kind that makes you feel like when you are eating bread
+that’s got sand in it.
+
+Then he says, slow and scornful:
+
+“The idea of _you_ lynching anybody!  It’s amusing.  The idea of you
+thinking you had pluck enough to lynch a _man_!  Because you’re brave
+enough to tar and feather poor friendless cast-out women that come along
+here, did that make you think you had grit enough to lay your hands on a
+_man_?  Why, a _man’s_ safe in the hands of ten thousand of your kind--as
+long as it’s daytime and you’re not behind him.
+
+“Do I know you?  I know you clear through. I was born and raised in the
+South, and I’ve lived in the North; so I know the average all around.
+The average man’s a coward.  In the North he lets anybody walk over him
+that wants to, and goes home and prays for a humble spirit to bear it.
+In the South one man all by himself, has stopped a stage full of men
+in the daytime, and robbed the lot.  Your newspapers call you a
+brave people so much that you think you are braver than any other
+people--whereas you’re just _as_ brave, and no braver.  Why don’t your
+juries hang murderers?  Because they’re afraid the man’s friends will
+shoot them in the back, in the dark--and it’s just what they _would_ do.
+
+“So they always acquit; and then a _man_ goes in the night, with a
+hundred masked cowards at his back and lynches the rascal.  Your mistake
+is, that you didn’t bring a man with you; that’s one mistake, and the
+other is that you didn’t come in the dark and fetch your masks.  You
+brought _part_ of a man--Buck Harkness, there--and if you hadn’t had him
+to start you, you’d a taken it out in blowing.
+
+“You didn’t want to come.  The average man don’t like trouble and
+danger. _You_ don’t like trouble and danger.  But if only _half_ a
+man--like Buck Harkness, there--shouts ‘Lynch him! lynch him!’ you’re
+afraid to back down--afraid you’ll be found out to be what you
+are--_cowards_--and so you raise a yell, and hang yourselves on to that
+half-a-man’s coat-tail, and come raging up here, swearing what big
+things you’re going to do. The pitifulest thing out is a mob; that’s
+what an army is--a mob; they don’t fight with courage that’s born in
+them, but with courage that’s borrowed from their mass, and from their
+officers.  But a mob without any _man_ at the head of it is _beneath_
+pitifulness.  Now the thing for _you_ to do is to droop your tails and
+go home and crawl in a hole.  If any real lynching’s going to be done it
+will be done in the dark, Southern fashion; and when they come they’ll
+bring their masks, and fetch a _man_ along.  Now _leave_--and take your
+half-a-man with you”--tossing his gun up across his left arm and cocking
+it when he says this.
+
+The crowd washed back sudden, and then broke all apart, and went tearing
+off every which way, and Buck Harkness he heeled it after them, looking
+tolerable cheap.  I could a stayed if I wanted to, but I didn’t want to.
+
+I went to the circus and loafed around the back side till the watchman
+went by, and then dived in under the tent.  I had my twenty-dollar gold
+piece and some other money, but I reckoned I better save it, because
+there ain’t no telling how soon you are going to need it, away from
+home and amongst strangers that way.  You can’t be too careful.  I ain’t
+opposed to spending money on circuses when there ain’t no other way, but
+there ain’t no use in _wasting_ it on them.
+
+It was a real bully circus.  It was the splendidest sight that ever was
+when they all come riding in, two and two, a gentleman and lady, side
+by side, the men just in their drawers and undershirts, and no shoes
+nor stirrups, and resting their hands on their thighs easy and
+comfortable--there must a been twenty of them--and every lady with a
+lovely complexion, and perfectly beautiful, and looking just like a gang
+of real sure-enough queens, and dressed in clothes that cost millions of
+dollars, and just littered with diamonds.  It was a powerful fine sight;
+I never see anything so lovely.  And then one by one they got up
+and stood, and went a-weaving around the ring so gentle and wavy and
+graceful, the men looking ever so tall and airy and straight, with their
+heads bobbing and skimming along, away up there under the tent-roof, and
+every lady’s rose-leafy dress flapping soft and silky around her hips,
+and she looking like the most loveliest parasol.
+
+And then faster and faster they went, all of them dancing, first one
+foot out in the air and then the other, the horses leaning more and
+more, and the ringmaster going round and round the center-pole, cracking
+his whip and shouting “Hi!--hi!” and the clown cracking jokes behind
+him; and by and by all hands dropped the reins, and every lady put her
+knuckles on her hips and every gentleman folded his arms, and then how
+the horses did lean over and hump themselves!  And so one after the
+other they all skipped off into the ring, and made the sweetest bow I
+ever see, and then scampered out, and everybody clapped their hands and
+went just about wild.
+
+Well, all through the circus they done the most astonishing things; and
+all the time that clown carried on so it most killed the people.  The
+ringmaster couldn’t ever say a word to him but he was back at him quick
+as a wink with the funniest things a body ever said; and how he ever
+_could_ think of so many of them, and so sudden and so pat, was what I
+couldn’t noway understand. Why, I couldn’t a thought of them in a year.
+And by and by a drunk man tried to get into the ring--said he wanted to
+ride; said he could ride as well as anybody that ever was.  They argued
+and tried to keep him out, but he wouldn’t listen, and the whole show
+come to a standstill.  Then the people begun to holler at him and make
+fun of him, and that made him mad, and he begun to rip and tear; so that
+stirred up the people, and a lot of men begun to pile down off of the
+benches and swarm towards the ring, saying, “Knock him down! throw him
+out!” and one or two women begun to scream.  So, then, the ringmaster
+he made a little speech, and said he hoped there wouldn’t be no
+disturbance, and if the man would promise he wouldn’t make no more
+trouble he would let him ride if he thought he could stay on the horse.
+ So everybody laughed and said all right, and the man got on. The minute
+he was on, the horse begun to rip and tear and jump and cavort around,
+with two circus men hanging on to his bridle trying to hold him, and the
+drunk man hanging on to his neck, and his heels flying in the air every
+jump, and the whole crowd of people standing up shouting and laughing
+till tears rolled down.  And at last, sure enough, all the circus men
+could do, the horse broke loose, and away he went like the very nation,
+round and round the ring, with that sot laying down on him and hanging
+to his neck, with first one leg hanging most to the ground on one side,
+and then t’other one on t’other side, and the people just crazy.  It
+warn’t funny to me, though; I was all of a tremble to see his danger.
+ But pretty soon he struggled up astraddle and grabbed the bridle,
+a-reeling this way and that; and the next minute he sprung up and
+dropped the bridle and stood! and the horse a-going like a house afire
+too.  He just stood up there, a-sailing around as easy and comfortable
+as if he warn’t ever drunk in his life--and then he begun to pull off his
+clothes and sling them.  He shed them so thick they kind of clogged up
+the air, and altogether he shed seventeen suits. And, then, there he
+was, slim and handsome, and dressed the gaudiest and prettiest you
+ever saw, and he lit into that horse with his whip and made him fairly
+hum--and finally skipped off, and made his bow and danced off to
+the dressing-room, and everybody just a-howling with pleasure and
+astonishment.
+
+Then the ringmaster he see how he had been fooled, and he _was_ the
+sickest ringmaster you ever see, I reckon.  Why, it was one of his own
+men!  He had got up that joke all out of his own head, and never let on
+to nobody. Well, I felt sheepish enough to be took in so, but I wouldn’t
+a been in that ringmaster’s place, not for a thousand dollars.  I don’t
+know; there may be bullier circuses than what that one was, but I
+never struck them yet. Anyways, it was plenty good enough for _me_; and
+wherever I run across it, it can have all of _my_ custom every time.
+
+Well, that night we had _our_ show; but there warn’t only about twelve
+people there--just enough to pay expenses.  And they laughed all the
+time, and that made the duke mad; and everybody left, anyway, before
+the show was over, but one boy which was asleep.  So the duke said these
+Arkansaw lunkheads couldn’t come up to Shakespeare; what they wanted
+was low comedy--and maybe something ruther worse than low comedy, he
+reckoned.  He said he could size their style.  So next morning he got
+some big sheets of wrapping paper and some black paint, and drawed off
+some handbills, and stuck them up all over the village.  The bills said:
+
+
+
+
+CHAPTER XXIII.
+
+WELL, all day him and the king was hard at it, rigging up a stage and
+a curtain and a row of candles for footlights; and that night the house
+was jam full of men in no time.  When the place couldn’t hold no more,
+the duke he quit tending door and went around the back way and come on
+to the stage and stood up before the curtain and made a little speech,
+and praised up this tragedy, and said it was the most thrillingest one
+that ever was; and so he went on a-bragging about the tragedy, and about
+Edmund Kean the Elder, which was to play the main principal part in it;
+and at last when he’d got everybody’s expectations up high enough, he
+rolled up the curtain, and the next minute the king come a-prancing
+out on all fours, naked; and he was painted all over,
+ring-streaked-and-striped, all sorts of colors, as splendid as a
+rainbow.  And--but never mind the rest of his outfit; it was just wild,
+but it was awful funny. The people most killed themselves laughing; and
+when the king got done capering and capered off behind the scenes, they
+roared and clapped and stormed and haw-hawed till he come back and done
+it over again, and after that they made him do it another time. Well, it
+would make a cow laugh to see the shines that old idiot cut.
+
+Then the duke he lets the curtain down, and bows to the people, and says
+the great tragedy will be performed only two nights more, on accounts of
+pressing London engagements, where the seats is all sold already for it
+in Drury Lane; and then he makes them another bow, and says if he has
+succeeded in pleasing them and instructing them, he will be deeply
+obleeged if they will mention it to their friends and get them to come
+and see it.
+
+Twenty people sings out:
+
+“What, is it over?  Is that _all_?”
+
+The duke says yes.  Then there was a fine time.  Everybody sings
+out, “Sold!” and rose up mad, and was a-going for that stage and them
+tragedians.  But a big, fine looking man jumps up on a bench and shouts:
+
+“Hold on!  Just a word, gentlemen.”  They stopped to listen.  “We are
+sold--mighty badly sold.  But we don’t want to be the laughing stock of
+this whole town, I reckon, and never hear the last of this thing as long
+as we live.  _No_.  What we want is to go out of here quiet, and talk
+this show up, and sell the _rest_ of the town!  Then we’ll all be in the
+same boat.  Ain’t that sensible?” (“You bet it is!--the jedge is right!”
+ everybody sings out.) “All right, then--not a word about any sell.  Go
+along home, and advise everybody to come and see the tragedy.”
+
+Next day you couldn’t hear nothing around that town but how splendid
+that show was.  House was jammed again that night, and we sold this
+crowd the same way.  When me and the king and the duke got home to the
+raft we all had a supper; and by and by, about midnight, they made Jim
+and me back her out and float her down the middle of the river, and
+fetch her in and hide her about two mile below town.
+
+The third night the house was crammed again--and they warn’t new-comers
+this time, but people that was at the show the other two nights.  I
+stood by the duke at the door, and I see that every man that went in had
+his pockets bulging, or something muffled up under his coat--and I see it
+warn’t no perfumery, neither, not by a long sight.  I smelt sickly eggs
+by the barrel, and rotten cabbages, and such things; and if I know the
+signs of a dead cat being around, and I bet I do, there was sixty-four
+of them went in.  I shoved in there for a minute, but it was too various
+for me; I couldn’t stand it.  Well, when the place couldn’t hold no more
+people the duke he give a fellow a quarter and told him to tend door
+for him a minute, and then he started around for the stage door, I after
+him; but the minute we turned the corner and was in the dark he says:
+
+“Walk fast now till you get away from the houses, and then shin for the
+raft like the dickens was after you!”
+
+I done it, and he done the same.  We struck the raft at the same time,
+and in less than two seconds we was gliding down stream, all dark and
+still, and edging towards the middle of the river, nobody saying a
+word. I reckoned the poor king was in for a gaudy time of it with the
+audience, but nothing of the sort; pretty soon he crawls out from under
+the wigwam, and says:
+
+“Well, how’d the old thing pan out this time, duke?”  He hadn’t been
+up-town at all.
+
+We never showed a light till we was about ten mile below the village.
+Then we lit up and had a supper, and the king and the duke fairly
+laughed their bones loose over the way they’d served them people.  The
+duke says:
+
+“Greenhorns, flatheads!  I knew the first house would keep mum and let
+the rest of the town get roped in; and I knew they’d lay for us the
+third night, and consider it was _their_ turn now.  Well, it _is_ their
+turn, and I’d give something to know how much they’d take for it.  I
+_would_ just like to know how they’re putting in their opportunity.
+ They can turn it into a picnic if they want to--they brought plenty
+provisions.”
+
+Them rapscallions took in four hundred and sixty-five dollars in that
+three nights.  I never see money hauled in by the wagon-load like that
+before.  By and by, when they was asleep and snoring, Jim says:
+
+“Don’t it s’prise you de way dem kings carries on, Huck?”
+
+“No,” I says, “it don’t.”
+
+“Why don’t it, Huck?”
+
+“Well, it don’t, because it’s in the breed.  I reckon they’re all
+alike.”
+
+“But, Huck, dese kings o’ ourn is reglar rapscallions; dat’s jist what
+dey is; dey’s reglar rapscallions.”
+
+“Well, that’s what I’m a-saying; all kings is mostly rapscallions, as
+fur as I can make out.”
+
+“Is dat so?”
+
+“You read about them once--you’ll see.  Look at Henry the Eight; this ‘n
+‘s a Sunday-school Superintendent to _him_.  And look at Charles Second,
+and Louis Fourteen, and Louis Fifteen, and James Second, and Edward
+Second, and Richard Third, and forty more; besides all them Saxon
+heptarchies that used to rip around so in old times and raise Cain.  My,
+you ought to seen old Henry the Eight when he was in bloom.  He _was_ a
+blossom.  He used to marry a new wife every day, and chop off her head
+next morning.  And he would do it just as indifferent as if he was
+ordering up eggs.  ‘Fetch up Nell Gwynn,’ he says.  They fetch her up.
+Next morning, ‘Chop off her head!’  And they chop it off.  ‘Fetch up
+Jane Shore,’ he says; and up she comes, Next morning, ‘Chop off her
+head’--and they chop it off.  ‘Ring up Fair Rosamun.’  Fair Rosamun
+answers the bell.  Next morning, ‘Chop off her head.’  And he made every
+one of them tell him a tale every night; and he kept that up till he had
+hogged a thousand and one tales that way, and then he put them all in a
+book, and called it Domesday Book--which was a good name and stated the
+case.  You don’t know kings, Jim, but I know them; and this old rip
+of ourn is one of the cleanest I’ve struck in history.  Well, Henry he
+takes a notion he wants to get up some trouble with this country. How
+does he go at it--give notice?--give the country a show?  No.  All of a
+sudden he heaves all the tea in Boston Harbor overboard, and whacks
+out a declaration of independence, and dares them to come on.  That was
+_his_ style--he never give anybody a chance.  He had suspicions of his
+father, the Duke of Wellington.  Well, what did he do?  Ask him to show
+up?  No--drownded him in a butt of mamsey, like a cat.  S’pose people
+left money laying around where he was--what did he do?  He collared it.
+ S’pose he contracted to do a thing, and you paid him, and didn’t set
+down there and see that he done it--what did he do?  He always done the
+other thing. S’pose he opened his mouth--what then?  If he didn’t shut it
+up powerful quick he’d lose a lie every time.  That’s the kind of a bug
+Henry was; and if we’d a had him along ‘stead of our kings he’d a fooled
+that town a heap worse than ourn done.  I don’t say that ourn is lambs,
+because they ain’t, when you come right down to the cold facts; but they
+ain’t nothing to _that_ old ram, anyway.  All I say is, kings is kings,
+and you got to make allowances.  Take them all around, they’re a mighty
+ornery lot. It’s the way they’re raised.”
+
+“But dis one do _smell_ so like de nation, Huck.”
+
+“Well, they all do, Jim.  We can’t help the way a king smells; history
+don’t tell no way.”
+
+“Now de duke, he’s a tolerble likely man in some ways.”
+
+“Yes, a duke’s different.  But not very different.  This one’s
+a middling hard lot for a duke.  When he’s drunk there ain’t no
+near-sighted man could tell him from a king.”
+
+“Well, anyways, I doan’ hanker for no mo’ un um, Huck.  Dese is all I
+kin stan’.”
+
+“It’s the way I feel, too, Jim.  But we’ve got them on our hands, and we
+got to remember what they are, and make allowances.  Sometimes I wish we
+could hear of a country that’s out of kings.”
+
+What was the use to tell Jim these warn’t real kings and dukes?  It
+wouldn’t a done no good; and, besides, it was just as I said:  you
+couldn’t tell them from the real kind.
+
+I went to sleep, and Jim didn’t call me when it was my turn.  He often
+done that.  When I waked up just at daybreak he was sitting there with
+his head down betwixt his knees, moaning and mourning to himself.  I
+didn’t take notice nor let on.  I knowed what it was about.  He was
+thinking about his wife and his children, away up yonder, and he was low
+and homesick; because he hadn’t ever been away from home before in his
+life; and I do believe he cared just as much for his people as white
+folks does for their’n.  It don’t seem natural, but I reckon it’s so.
+ He was often moaning and mourning that way nights, when he judged I
+was asleep, and saying, “Po’ little ‘Lizabeth! po’ little Johnny! it’s
+mighty hard; I spec’ I ain’t ever gwyne to see you no mo’, no mo’!”  He
+was a mighty good nigger, Jim was.
+
+But this time I somehow got to talking to him about his wife and young
+ones; and by and by he says:
+
+“What makes me feel so bad dis time ‘uz bekase I hear sumpn over yonder
+on de bank like a whack, er a slam, while ago, en it mine me er de time
+I treat my little ‘Lizabeth so ornery.  She warn’t on’y ‘bout fo’ year
+ole, en she tuck de sk’yarlet fever, en had a powful rough spell; but
+she got well, en one day she was a-stannin’ aroun’, en I says to her, I
+says:
+
+“‘Shet de do’.’
+
+“She never done it; jis’ stood dah, kiner smilin’ up at me.  It make me
+mad; en I says agin, mighty loud, I says:
+
+“‘Doan’ you hear me?  Shet de do’!’
+
+“She jis stood de same way, kiner smilin’ up.  I was a-bilin’!  I says:
+
+“‘I lay I _make_ you mine!’
+
+“En wid dat I fetch’ her a slap side de head dat sont her a-sprawlin’.
+Den I went into de yuther room, en ‘uz gone ‘bout ten minutes; en when
+I come back dah was dat do’ a-stannin’ open _yit_, en dat chile stannin’
+mos’ right in it, a-lookin’ down and mournin’, en de tears runnin’ down.
+ My, but I _wuz_ mad!  I was a-gwyne for de chile, but jis’ den--it was a
+do’ dat open innerds--jis’ den, ‘long come de wind en slam it to, behine
+de chile, ker-BLAM!--en my lan’, de chile never move’!  My breff mos’
+hop outer me; en I feel so--so--I doan’ know HOW I feel.  I crope out,
+all a-tremblin’, en crope aroun’ en open de do’ easy en slow, en poke my
+head in behine de chile, sof’ en still, en all uv a sudden I says POW!
+jis’ as loud as I could yell.  _She never budge!_  Oh, Huck, I bust out
+a-cryin’ en grab her up in my arms, en say, ‘Oh, de po’ little thing!
+ De Lord God Amighty fogive po’ ole Jim, kaze he never gwyne to fogive
+hisself as long’s he live!’  Oh, she was plumb deef en dumb, Huck, plumb
+deef en dumb--en I’d ben a-treat’n her so!”
+
+
+
+
+CHAPTER XXIV.
+
+NEXT day, towards night, we laid up under a little willow towhead out in
+the middle, where there was a village on each side of the river, and the
+duke and the king begun to lay out a plan for working them towns.  Jim
+he spoke to the duke, and said he hoped it wouldn’t take but a few
+hours, because it got mighty heavy and tiresome to him when he had to
+lay all day in the wigwam tied with the rope.  You see, when we left him
+all alone we had to tie him, because if anybody happened on to him all
+by himself and not tied it wouldn’t look much like he was a runaway
+nigger, you know. So the duke said it _was_ kind of hard to have to lay
+roped all day, and he’d cipher out some way to get around it.
+
+He was uncommon bright, the duke was, and he soon struck it.  He dressed
+Jim up in King Lear’s outfit--it was a long curtain-calico gown, and a
+white horse-hair wig and whiskers; and then he took his theater paint
+and painted Jim’s face and hands and ears and neck all over a dead,
+dull, solid blue, like a man that’s been drownded nine days.  Blamed if
+he warn’t the horriblest looking outrage I ever see.  Then the duke took
+and wrote out a sign on a shingle so:
+
+Sick Arab--but harmless when not out of his head.
+
+And he nailed that shingle to a lath, and stood the lath up four or five
+foot in front of the wigwam.  Jim was satisfied.  He said it was a sight
+better than lying tied a couple of years every day, and trembling all
+over every time there was a sound.  The duke told him to make himself
+free and easy, and if anybody ever come meddling around, he must hop
+out of the wigwam, and carry on a little, and fetch a howl or two like
+a wild beast, and he reckoned they would light out and leave him alone.
+ Which was sound enough judgment; but you take the average man, and he
+wouldn’t wait for him to howl.  Why, he didn’t only look like he was
+dead, he looked considerable more than that.
+
+These rapscallions wanted to try the Nonesuch again, because there was
+so much money in it, but they judged it wouldn’t be safe, because maybe
+the news might a worked along down by this time.  They couldn’t hit no
+project that suited exactly; so at last the duke said he reckoned he’d
+lay off and work his brains an hour or two and see if he couldn’t put up
+something on the Arkansaw village; and the king he allowed he would drop
+over to t’other village without any plan, but just trust in Providence
+to lead him the profitable way--meaning the devil, I reckon.  We had all
+bought store clothes where we stopped last; and now the king put his’n
+on, and he told me to put mine on.  I done it, of course.  The king’s
+duds was all black, and he did look real swell and starchy.  I never
+knowed how clothes could change a body before.  Why, before, he looked
+like the orneriest old rip that ever was; but now, when he’d take off
+his new white beaver and make a bow and do a smile, he looked that grand
+and good and pious that you’d say he had walked right out of the ark,
+and maybe was old Leviticus himself.  Jim cleaned up the canoe, and I
+got my paddle ready.  There was a big steamboat laying at the shore away
+up under the point, about three mile above the town--been there a couple
+of hours, taking on freight.  Says the king:
+
+“Seein’ how I’m dressed, I reckon maybe I better arrive down from St.
+Louis or Cincinnati, or some other big place.  Go for the steamboat,
+Huckleberry; we’ll come down to the village on her.”
+
+I didn’t have to be ordered twice to go and take a steamboat ride.
+ I fetched the shore a half a mile above the village, and then went
+scooting along the bluff bank in the easy water.  Pretty soon we come to
+a nice innocent-looking young country jake setting on a log swabbing the
+sweat off of his face, for it was powerful warm weather; and he had a
+couple of big carpet-bags by him.
+
+“Run her nose in shore,” says the king.  I done it.  “Wher’ you bound
+for, young man?”
+
+“For the steamboat; going to Orleans.”
+
+“Git aboard,” says the king.  “Hold on a minute, my servant ‘ll he’p you
+with them bags.  Jump out and he’p the gentleman, Adolphus”--meaning me,
+I see.
+
+I done so, and then we all three started on again.  The young chap was
+mighty thankful; said it was tough work toting his baggage such weather.
+He asked the king where he was going, and the king told him he’d come
+down the river and landed at the other village this morning, and now he
+was going up a few mile to see an old friend on a farm up there.  The
+young fellow says:
+
+“When I first see you I says to myself, ‘It’s Mr. Wilks, sure, and he
+come mighty near getting here in time.’  But then I says again, ‘No, I
+reckon it ain’t him, or else he wouldn’t be paddling up the river.’  You
+_ain’t_ him, are you?”
+
+“No, my name’s Blodgett--Elexander Blodgett--_Reverend_ Elexander
+Blodgett, I s’pose I must say, as I’m one o’ the Lord’s poor servants.
+ But still I’m jist as able to be sorry for Mr. Wilks for not arriving
+in time, all the same, if he’s missed anything by it--which I hope he
+hasn’t.”
+
+“Well, he don’t miss any property by it, because he’ll get that all
+right; but he’s missed seeing his brother Peter die--which he mayn’t
+mind, nobody can tell as to that--but his brother would a give anything
+in this world to see _him_ before he died; never talked about nothing
+else all these three weeks; hadn’t seen him since they was boys
+together--and hadn’t ever seen his brother William at all--that’s the deef
+and dumb one--William ain’t more than thirty or thirty-five.  Peter and
+George were the only ones that come out here; George was the married
+brother; him and his wife both died last year.  Harvey and William’s the
+only ones that’s left now; and, as I was saying, they haven’t got here
+in time.”
+
+“Did anybody send ‘em word?”
+
+“Oh, yes; a month or two ago, when Peter was first took; because Peter
+said then that he sorter felt like he warn’t going to get well this
+time. You see, he was pretty old, and George’s g’yirls was too young to
+be much company for him, except Mary Jane, the red-headed one; and so he
+was kinder lonesome after George and his wife died, and didn’t seem
+to care much to live.  He most desperately wanted to see Harvey--and
+William, too, for that matter--because he was one of them kind that can’t
+bear to make a will.  He left a letter behind for Harvey, and said he’d
+told in it where his money was hid, and how he wanted the rest of the
+property divided up so George’s g’yirls would be all right--for George
+didn’t leave nothing.  And that letter was all they could get him to put
+a pen to.”
+
+“Why do you reckon Harvey don’t come?  Wher’ does he live?”
+
+“Oh, he lives in England--Sheffield--preaches there--hasn’t ever been in
+this country.  He hasn’t had any too much time--and besides he mightn’t a
+got the letter at all, you know.”
+
+“Too bad, too bad he couldn’t a lived to see his brothers, poor soul.
+You going to Orleans, you say?”
+
+“Yes, but that ain’t only a part of it.  I’m going in a ship, next
+Wednesday, for Ryo Janeero, where my uncle lives.”
+
+“It’s a pretty long journey.  But it’ll be lovely; wisht I was a-going.
+Is Mary Jane the oldest?  How old is the others?”
+
+“Mary Jane’s nineteen, Susan’s fifteen, and Joanna’s about
+fourteen--that’s the one that gives herself to good works and has a
+hare-lip.”
+
+“Poor things! to be left alone in the cold world so.”
+
+“Well, they could be worse off.  Old Peter had friends, and they
+ain’t going to let them come to no harm.  There’s Hobson, the Babtis’
+preacher; and Deacon Lot Hovey, and Ben Rucker, and Abner Shackleford,
+and Levi Bell, the lawyer; and Dr. Robinson, and their wives, and the
+widow Bartley, and--well, there’s a lot of them; but these are the ones
+that Peter was thickest with, and used to write about sometimes, when
+he wrote home; so Harvey ‘ll know where to look for friends when he gets
+here.”
+
+Well, the old man went on asking questions till he just fairly emptied
+that young fellow.  Blamed if he didn’t inquire about everybody and
+everything in that blessed town, and all about the Wilkses; and about
+Peter’s business--which was a tanner; and about George’s--which was a
+carpenter; and about Harvey’s--which was a dissentering minister; and so
+on, and so on.  Then he says:
+
+“What did you want to walk all the way up to the steamboat for?”
+
+“Because she’s a big Orleans boat, and I was afeard she mightn’t stop
+there.  When they’re deep they won’t stop for a hail.  A Cincinnati boat
+will, but this is a St. Louis one.”
+
+“Was Peter Wilks well off?”
+
+“Oh, yes, pretty well off.  He had houses and land, and it’s reckoned he
+left three or four thousand in cash hid up som’ers.”
+
+“When did you say he died?”
+
+“I didn’t say, but it was last night.”
+
+“Funeral to-morrow, likely?”
+
+“Yes, ‘bout the middle of the day.”
+
+“Well, it’s all terrible sad; but we’ve all got to go, one time or
+another. So what we want to do is to be prepared; then we’re all right.”
+
+“Yes, sir, it’s the best way.  Ma used to always say that.”
+
+When we struck the boat she was about done loading, and pretty soon she
+got off.  The king never said nothing about going aboard, so I lost
+my ride, after all.  When the boat was gone the king made me paddle up
+another mile to a lonesome place, and then he got ashore and says:
+
+“Now hustle back, right off, and fetch the duke up here, and the new
+carpet-bags.  And if he’s gone over to t’other side, go over there and
+git him.  And tell him to git himself up regardless.  Shove along, now.”
+
+I see what _he_ was up to; but I never said nothing, of course.  When
+I got back with the duke we hid the canoe, and then they set down on a
+log, and the king told him everything, just like the young fellow had
+said it--every last word of it.  And all the time he was a-doing it he
+tried to talk like an Englishman; and he done it pretty well, too, for
+a slouch. I can’t imitate him, and so I ain’t a-going to try to; but he
+really done it pretty good.  Then he says:
+
+“How are you on the deef and dumb, Bilgewater?”
+
+The duke said, leave him alone for that; said he had played a deef
+and dumb person on the histronic boards.  So then they waited for a
+steamboat.
+
+About the middle of the afternoon a couple of little boats come along,
+but they didn’t come from high enough up the river; but at last there
+was a big one, and they hailed her.  She sent out her yawl, and we went
+aboard, and she was from Cincinnati; and when they found we only wanted
+to go four or five mile they was booming mad, and gave us a cussing, and
+said they wouldn’t land us.  But the king was ca’m.  He says:
+
+“If gentlemen kin afford to pay a dollar a mile apiece to be took on and
+put off in a yawl, a steamboat kin afford to carry ‘em, can’t it?”
+
+So they softened down and said it was all right; and when we got to the
+village they yawled us ashore.  About two dozen men flocked down when
+they see the yawl a-coming, and when the king says:
+
+“Kin any of you gentlemen tell me wher’ Mr. Peter Wilks lives?” they
+give a glance at one another, and nodded their heads, as much as to say,
+“What d’ I tell you?”  Then one of them says, kind of soft and gentle:
+
+“I’m sorry sir, but the best we can do is to tell you where he _did_
+live yesterday evening.”
+
+Sudden as winking the ornery old cretur went an to smash, and fell up
+against the man, and put his chin on his shoulder, and cried down his
+back, and says:
+
+“Alas, alas, our poor brother--gone, and we never got to see him; oh,
+it’s too, too hard!”
+
+Then he turns around, blubbering, and makes a lot of idiotic signs to
+the duke on his hands, and blamed if he didn’t drop a carpet-bag and
+bust out a-crying.  If they warn’t the beatenest lot, them two frauds,
+that ever I struck.
+
+Well, the men gathered around and sympathized with them, and said all
+sorts of kind things to them, and carried their carpet-bags up the hill
+for them, and let them lean on them and cry, and told the king all about
+his brother’s last moments, and the king he told it all over again on
+his hands to the duke, and both of them took on about that dead tanner
+like they’d lost the twelve disciples.  Well, if ever I struck anything
+like it, I’m a nigger. It was enough to make a body ashamed of the human
+race.
+
+
+
+
+CHAPTER XXV.
+
+THE news was all over town in two minutes, and you could see the people
+tearing down on the run from every which way, some of them putting on
+their coats as they come.  Pretty soon we was in the middle of a crowd,
+and the noise of the tramping was like a soldier march.  The windows and
+dooryards was full; and every minute somebody would say, over a fence:
+
+“Is it _them_?”
+
+And somebody trotting along with the gang would answer back and say:
+
+“You bet it is.”
+
+When we got to the house the street in front of it was packed, and the
+three girls was standing in the door.  Mary Jane _was_ red-headed, but
+that don’t make no difference, she was most awful beautiful, and her
+face and her eyes was all lit up like glory, she was so glad her uncles
+was come. The king he spread his arms, and Mary Jane she jumped for
+them, and the hare-lip jumped for the duke, and there they had it!
+ Everybody most, leastways women, cried for joy to see them meet again
+at last and have such good times.
+
+Then the king he hunched the duke private--I see him do it--and then he
+looked around and see the coffin, over in the corner on two chairs; so
+then him and the duke, with a hand across each other’s shoulder, and
+t’other hand to their eyes, walked slow and solemn over there, everybody
+dropping back to give them room, and all the talk and noise stopping,
+people saying “Sh!” and all the men taking their hats off and drooping
+their heads, so you could a heard a pin fall.  And when they got there
+they bent over and looked in the coffin, and took one sight, and then
+they bust out a-crying so you could a heard them to Orleans, most; and
+then they put their arms around each other’s necks, and hung their chins
+over each other’s shoulders; and then for three minutes, or maybe four,
+I never see two men leak the way they done.  And, mind you, everybody
+was doing the same; and the place was that damp I never see anything
+like it. Then one of them got on one side of the coffin, and t’other on
+t’other side, and they kneeled down and rested their foreheads on the
+coffin, and let on to pray all to themselves.  Well, when it come
+to that it worked the crowd like you never see anything like it, and
+everybody broke down and went to sobbing right out loud--the poor girls,
+too; and every woman, nearly, went up to the girls, without saying a
+word, and kissed them, solemn, on the forehead, and then put their hand
+on their head, and looked up towards the sky, with the tears running
+down, and then busted out and went off sobbing and swabbing, and give
+the next woman a show.  I never see anything so disgusting.
+
+Well, by and by the king he gets up and comes forward a little, and
+works himself up and slobbers out a speech, all full of tears and
+flapdoodle about its being a sore trial for him and his poor brother
+to lose the diseased, and to miss seeing diseased alive after the long
+journey of four thousand mile, but it’s a trial that’s sweetened and
+sanctified to us by this dear sympathy and these holy tears, and so he
+thanks them out of his heart and out of his brother’s heart, because out
+of their mouths they can’t, words being too weak and cold, and all that
+kind of rot and slush, till it was just sickening; and then he blubbers
+out a pious goody-goody Amen, and turns himself loose and goes to crying
+fit to bust.
+
+And the minute the words were out of his mouth somebody over in the
+crowd struck up the doxolojer, and everybody joined in with all their
+might, and it just warmed you up and made you feel as good as church
+letting out. Music is a good thing; and after all that soul-butter and
+hogwash I never see it freshen up things so, and sound so honest and
+bully.
+
+Then the king begins to work his jaw again, and says how him and his
+nieces would be glad if a few of the main principal friends of the
+family would take supper here with them this evening, and help set up
+with the ashes of the diseased; and says if his poor brother laying
+yonder could speak he knows who he would name, for they was names that
+was very dear to him, and mentioned often in his letters; and so he will
+name the same, to wit, as follows, vizz.:--Rev. Mr. Hobson, and Deacon
+Lot Hovey, and Mr. Ben Rucker, and Abner Shackleford, and Levi Bell, and
+Dr. Robinson, and their wives, and the widow Bartley.
+
+Rev. Hobson and Dr. Robinson was down to the end of the town a-hunting
+together--that is, I mean the doctor was shipping a sick man to t’other
+world, and the preacher was pinting him right.  Lawyer Bell was away up
+to Louisville on business.  But the rest was on hand, and so they all
+come and shook hands with the king and thanked him and talked to him;
+and then they shook hands with the duke and didn’t say nothing, but just
+kept a-smiling and bobbing their heads like a passel of sapheads whilst
+he made all sorts of signs with his hands and said “Goo-goo--goo-goo-goo”
+ all the time, like a baby that can’t talk.
+
+So the king he blattered along, and managed to inquire about pretty
+much everybody and dog in town, by his name, and mentioned all sorts
+of little things that happened one time or another in the town, or to
+George’s family, or to Peter.  And he always let on that Peter wrote him
+the things; but that was a lie:  he got every blessed one of them out of
+that young flathead that we canoed up to the steamboat.
+
+Then Mary Jane she fetched the letter her father left behind, and the
+king he read it out loud and cried over it.  It give the dwelling-house
+and three thousand dollars, gold, to the girls; and it give the tanyard
+(which was doing a good business), along with some other houses and
+land (worth about seven thousand), and three thousand dollars in gold
+to Harvey and William, and told where the six thousand cash was hid down
+cellar.  So these two frauds said they’d go and fetch it up, and have
+everything square and above-board; and told me to come with a candle.
+ We shut the cellar door behind us, and when they found the bag
+they spilt it out on the floor, and it was a lovely sight, all them
+yaller-boys.  My, the way the king’s eyes did shine!  He slaps the duke
+on the shoulder and says:
+
+“Oh, _this_ ain’t bully nor noth’n!  Oh, no, I reckon not!  Why,
+_bully_, it beats the Nonesuch, _don’t_ it?”
+
+The duke allowed it did.  They pawed the yaller-boys, and sifted them
+through their fingers and let them jingle down on the floor; and the
+king says:
+
+“It ain’t no use talkin’; bein’ brothers to a rich dead man and
+representatives of furrin heirs that’s got left is the line for you and
+me, Bilge.  Thish yer comes of trust’n to Providence.  It’s the best
+way, in the long run.  I’ve tried ‘em all, and ther’ ain’t no better
+way.”
+
+Most everybody would a been satisfied with the pile, and took it on
+trust; but no, they must count it.  So they counts it, and it comes out
+four hundred and fifteen dollars short.  Says the king:
+
+“Dern him, I wonder what he done with that four hundred and fifteen
+dollars?”
+
+They worried over that awhile, and ransacked all around for it.  Then
+the duke says:
+
+“Well, he was a pretty sick man, and likely he made a mistake--I reckon
+that’s the way of it.  The best way’s to let it go, and keep still about
+it.  We can spare it.”
+
+“Oh, shucks, yes, we can _spare_ it.  I don’t k’yer noth’n ‘bout
+that--it’s the _count_ I’m thinkin’ about.  We want to be awful square
+and open and above-board here, you know.  We want to lug this h-yer
+money up stairs and count it before everybody--then ther’ ain’t noth’n
+suspicious.  But when the dead man says ther’s six thous’n dollars, you
+know, we don’t want to--”
+
+“Hold on,” says the duke.  “Le’s make up the deffisit,” and he begun to
+haul out yaller-boys out of his pocket.
+
+“It’s a most amaz’n’ good idea, duke--you _have_ got a rattlin’ clever
+head on you,” says the king.  “Blest if the old Nonesuch ain’t a heppin’
+us out agin,” and _he_ begun to haul out yaller-jackets and stack them
+up.
+
+It most busted them, but they made up the six thousand clean and clear.
+
+“Say,” says the duke, “I got another idea.  Le’s go up stairs and count
+this money, and then take and _give it to the girls_.”
+
+“Good land, duke, lemme hug you!  It’s the most dazzling idea ‘at ever a
+man struck.  You have cert’nly got the most astonishin’ head I ever see.
+Oh, this is the boss dodge, ther’ ain’t no mistake ‘bout it.  Let ‘em
+fetch along their suspicions now if they want to--this ‘ll lay ‘em out.”
+
+When we got up-stairs everybody gethered around the table, and the king
+he counted it and stacked it up, three hundred dollars in a pile--twenty
+elegant little piles.  Everybody looked hungry at it, and licked their
+chops.  Then they raked it into the bag again, and I see the king begin
+to swell himself up for another speech.  He says:
+
+“Friends all, my poor brother that lays yonder has done generous by
+them that’s left behind in the vale of sorrers.  He has done generous by
+these yer poor little lambs that he loved and sheltered, and that’s left
+fatherless and motherless.  Yes, and we that knowed him knows that he
+would a done _more_ generous by ‘em if he hadn’t ben afeard o’ woundin’
+his dear William and me.  Now, _wouldn’t_ he?  Ther’ ain’t no question
+‘bout it in _my_ mind.  Well, then, what kind o’ brothers would it be
+that ‘d stand in his way at sech a time?  And what kind o’ uncles would
+it be that ‘d rob--yes, _rob_--sech poor sweet lambs as these ‘at he loved
+so at sech a time?  If I know William--and I _think_ I do--he--well, I’ll
+jest ask him.” He turns around and begins to make a lot of signs to
+the duke with his hands, and the duke he looks at him stupid and
+leather-headed a while; then all of a sudden he seems to catch his
+meaning, and jumps for the king, goo-gooing with all his might for joy,
+and hugs him about fifteen times before he lets up.  Then the king says,
+“I knowed it; I reckon _that ‘ll_ convince anybody the way _he_ feels
+about it.  Here, Mary Jane, Susan, Joanner, take the money--take it
+_all_.  It’s the gift of him that lays yonder, cold but joyful.”
+
+Mary Jane she went for him, Susan and the hare-lip went for the
+duke, and then such another hugging and kissing I never see yet.  And
+everybody crowded up with the tears in their eyes, and most shook the
+hands off of them frauds, saying all the time:
+
+“You _dear_ good souls!--how _lovely_!--how _could_ you!”
+
+Well, then, pretty soon all hands got to talking about the diseased
+again, and how good he was, and what a loss he was, and all that; and
+before long a big iron-jawed man worked himself in there from outside,
+and stood a-listening and looking, and not saying anything; and nobody
+saying anything to him either, because the king was talking and they was
+all busy listening.  The king was saying--in the middle of something he’d
+started in on--
+
+“--they bein’ partickler friends o’ the diseased.  That’s why they’re
+invited here this evenin’; but tomorrow we want _all_ to come--everybody;
+for he respected everybody, he liked everybody, and so it’s fitten that
+his funeral orgies sh’d be public.”
+
+And so he went a-mooning on and on, liking to hear himself talk, and
+every little while he fetched in his funeral orgies again, till the duke
+he couldn’t stand it no more; so he writes on a little scrap of paper,
+“_Obsequies_, you old fool,” and folds it up, and goes to goo-gooing and
+reaching it over people’s heads to him.  The king he reads it and puts
+it in his pocket, and says:
+
+“Poor William, afflicted as he is, his _heart’s_ aluz right.  Asks me
+to invite everybody to come to the funeral--wants me to make ‘em all
+welcome.  But he needn’t a worried--it was jest what I was at.”
+
+Then he weaves along again, perfectly ca’m, and goes to dropping in his
+funeral orgies again every now and then, just like he done before.  And
+when he done it the third time he says:
+
+“I say orgies, not because it’s the common term, because it
+ain’t--obsequies bein’ the common term--but because orgies is the right
+term. Obsequies ain’t used in England no more now--it’s gone out.  We
+say orgies now in England.  Orgies is better, because it means the thing
+you’re after more exact.  It’s a word that’s made up out’n the Greek
+_orgo_, outside, open, abroad; and the Hebrew _jeesum_, to plant, cover
+up; hence in_ter._  So, you see, funeral orgies is an open er public
+funeral.”
+
+He was the _worst_ I ever struck.  Well, the iron-jawed man he laughed
+right in his face.  Everybody was shocked.  Everybody says, “Why,
+_doctor_!” and Abner Shackleford says:
+
+“Why, Robinson, hain’t you heard the news?  This is Harvey Wilks.”
+
+The king he smiled eager, and shoved out his flapper, and says:
+
+“Is it my poor brother’s dear good friend and physician?  I--”
+
+“Keep your hands off of me!” says the doctor.  “_You_ talk like an
+Englishman, _don’t_ you?  It’s the worst imitation I ever heard.  _You_
+Peter Wilks’s brother!  You’re a fraud, that’s what you are!”
+
+Well, how they all took on!  They crowded around the doctor and tried to
+quiet him down, and tried to explain to him and tell him how Harvey ‘d
+showed in forty ways that he _was_ Harvey, and knowed everybody by name,
+and the names of the very dogs, and begged and _begged_ him not to hurt
+Harvey’s feelings and the poor girl’s feelings, and all that.  But it
+warn’t no use; he stormed right along, and said any man that pretended
+to be an Englishman and couldn’t imitate the lingo no better than what
+he did was a fraud and a liar.  The poor girls was hanging to the king
+and crying; and all of a sudden the doctor ups and turns on _them_.  He
+says:
+
+“I was your father’s friend, and I’m your friend; and I warn you as a
+friend, and an honest one that wants to protect you and keep you out of
+harm and trouble, to turn your backs on that scoundrel and have nothing
+to do with him, the ignorant tramp, with his idiotic Greek and Hebrew,
+as he calls it.  He is the thinnest kind of an impostor--has come here
+with a lot of empty names and facts which he picked up somewheres, and
+you take them for _proofs_, and are helped to fool yourselves by these
+foolish friends here, who ought to know better.  Mary Jane Wilks, you
+know me for your friend, and for your unselfish friend, too.  Now listen
+to me; turn this pitiful rascal out--I _beg_ you to do it.  Will you?”
+
+Mary Jane straightened herself up, and my, but she was handsome!  She
+says:
+
+“_Here_ is my answer.”  She hove up the bag of money and put it in the
+king’s hands, and says, “Take this six thousand dollars, and invest for
+me and my sisters any way you want to, and don’t give us no receipt for
+it.”
+
+Then she put her arm around the king on one side, and Susan and the
+hare-lip done the same on the other.  Everybody clapped their hands and
+stomped on the floor like a perfect storm, whilst the king held up his
+head and smiled proud.  The doctor says:
+
+“All right; I wash _my_ hands of the matter.  But I warn you all that a
+time ‘s coming when you’re going to feel sick whenever you think of this
+day.” And away he went.
+
+“All right, doctor,” says the king, kinder mocking him; “we’ll try and
+get ‘em to send for you;” which made them all laugh, and they said it
+was a prime good hit.
+
+
+
+
+CHAPTER XXVI.
+
+WELL, when they was all gone the king he asks Mary Jane how they was off
+for spare rooms, and she said she had one spare room, which would do for
+Uncle William, and she’d give her own room to Uncle Harvey, which was
+a little bigger, and she would turn into the room with her sisters and
+sleep on a cot; and up garret was a little cubby, with a pallet in it.
+The king said the cubby would do for his valley--meaning me.
+
+So Mary Jane took us up, and she showed them their rooms, which was
+plain but nice.  She said she’d have her frocks and a lot of other traps
+took out of her room if they was in Uncle Harvey’s way, but he said
+they warn’t.  The frocks was hung along the wall, and before them was
+a curtain made out of calico that hung down to the floor.  There was an
+old hair trunk in one corner, and a guitar-box in another, and all sorts
+of little knickknacks and jimcracks around, like girls brisken up a room
+with.  The king said it was all the more homely and more pleasanter for
+these fixings, and so don’t disturb them.  The duke’s room was pretty
+small, but plenty good enough, and so was my cubby.
+
+That night they had a big supper, and all them men and women was there,
+and I stood behind the king and the duke’s chairs and waited on them,
+and the niggers waited on the rest.  Mary Jane she set at the head of
+the table, with Susan alongside of her, and said how bad the biscuits
+was, and how mean the preserves was, and how ornery and tough the fried
+chickens was--and all that kind of rot, the way women always do for to
+force out compliments; and the people all knowed everything was tiptop,
+and said so--said “How _do_ you get biscuits to brown so nice?” and
+“Where, for the land’s sake, _did_ you get these amaz’n pickles?” and
+all that kind of humbug talky-talk, just the way people always does at a
+supper, you know.
+
+And when it was all done me and the hare-lip had supper in the kitchen
+off of the leavings, whilst the others was helping the niggers clean up
+the things.  The hare-lip she got to pumping me about England, and blest
+if I didn’t think the ice was getting mighty thin sometimes.  She says:
+
+“Did you ever see the king?”
+
+“Who?  William Fourth?  Well, I bet I have--he goes to our church.”  I
+knowed he was dead years ago, but I never let on.  So when I says he
+goes to our church, she says:
+
+“What--regular?”
+
+“Yes--regular.  His pew’s right over opposite ourn--on t’other side the
+pulpit.”
+
+“I thought he lived in London?”
+
+“Well, he does.  Where _would_ he live?”
+
+“But I thought _you_ lived in Sheffield?”
+
+I see I was up a stump.  I had to let on to get choked with a chicken
+bone, so as to get time to think how to get down again.  Then I says:
+
+“I mean he goes to our church regular when he’s in Sheffield.  That’s
+only in the summer time, when he comes there to take the sea baths.”
+
+“Why, how you talk--Sheffield ain’t on the sea.”
+
+“Well, who said it was?”
+
+“Why, you did.”
+
+“I _didn’t_ nuther.”
+
+“You did!”
+
+“I didn’t.”
+
+“You did.”
+
+“I never said nothing of the kind.”
+
+“Well, what _did_ you say, then?”
+
+“Said he come to take the sea _baths_--that’s what I said.”
+
+“Well, then, how’s he going to take the sea baths if it ain’t on the
+sea?”
+
+“Looky here,” I says; “did you ever see any Congress-water?”
+
+“Yes.”
+
+“Well, did you have to go to Congress to get it?”
+
+“Why, no.”
+
+“Well, neither does William Fourth have to go to the sea to get a sea
+bath.”
+
+“How does he get it, then?”
+
+“Gets it the way people down here gets Congress-water--in barrels.  There
+in the palace at Sheffield they’ve got furnaces, and he wants his water
+hot.  They can’t bile that amount of water away off there at the sea.
+They haven’t got no conveniences for it.”
+
+“Oh, I see, now.  You might a said that in the first place and saved
+time.”
+
+When she said that I see I was out of the woods again, and so I was
+comfortable and glad.  Next, she says:
+
+“Do you go to church, too?”
+
+“Yes--regular.”
+
+“Where do you set?”
+
+“Why, in our pew.”
+
+“_Whose_ pew?”
+
+“Why, _ourn_--your Uncle Harvey’s.”
+
+“His’n?  What does _he_ want with a pew?”
+
+“Wants it to set in.  What did you _reckon_ he wanted with it?”
+
+“Why, I thought he’d be in the pulpit.”
+
+Rot him, I forgot he was a preacher.  I see I was up a stump again, so I
+played another chicken bone and got another think.  Then I says:
+
+“Blame it, do you suppose there ain’t but one preacher to a church?”
+
+“Why, what do they want with more?”
+
+“What!--to preach before a king?  I never did see such a girl as you.
+They don’t have no less than seventeen.”
+
+“Seventeen!  My land!  Why, I wouldn’t set out such a string as that,
+not if I _never_ got to glory.  It must take ‘em a week.”
+
+“Shucks, they don’t _all_ of ‘em preach the same day--only _one_ of ‘em.”
+
+“Well, then, what does the rest of ‘em do?”
+
+“Oh, nothing much.  Loll around, pass the plate--and one thing or
+another.  But mainly they don’t do nothing.”
+
+“Well, then, what are they _for_?”
+
+“Why, they’re for _style_.  Don’t you know nothing?”
+
+“Well, I don’t _want_ to know no such foolishness as that.  How is
+servants treated in England?  Do they treat ‘em better ‘n we treat our
+niggers?”
+
+“_No_!  A servant ain’t nobody there.  They treat them worse than dogs.”
+
+“Don’t they give ‘em holidays, the way we do, Christmas and New Year’s
+week, and Fourth of July?”
+
+“Oh, just listen!  A body could tell _you_ hain’t ever been to England
+by that.  Why, Hare-l--why, Joanna, they never see a holiday from year’s
+end to year’s end; never go to the circus, nor theater, nor nigger
+shows, nor nowheres.”
+
+“Nor church?”
+
+“Nor church.”
+
+“But _you_ always went to church.”
+
+Well, I was gone up again.  I forgot I was the old man’s servant.  But
+next minute I whirled in on a kind of an explanation how a valley was
+different from a common servant and _had_ to go to church whether he
+wanted to or not, and set with the family, on account of its being the
+law.  But I didn’t do it pretty good, and when I got done I see she
+warn’t satisfied.  She says:
+
+“Honest injun, now, hain’t you been telling me a lot of lies?”
+
+“Honest injun,” says I.
+
+“None of it at all?”
+
+“None of it at all.  Not a lie in it,” says I.
+
+“Lay your hand on this book and say it.”
+
+I see it warn’t nothing but a dictionary, so I laid my hand on it and
+said it.  So then she looked a little better satisfied, and says:
+
+“Well, then, I’ll believe some of it; but I hope to gracious if I’ll
+believe the rest.”
+
+“What is it you won’t believe, Joe?” says Mary Jane, stepping in with
+Susan behind her.  “It ain’t right nor kind for you to talk so to him,
+and him a stranger and so far from his people.  How would you like to be
+treated so?”
+
+“That’s always your way, Maim--always sailing in to help somebody before
+they’re hurt.  I hain’t done nothing to him.  He’s told some stretchers,
+I reckon, and I said I wouldn’t swallow it all; and that’s every bit
+and grain I _did_ say.  I reckon he can stand a little thing like that,
+can’t he?”
+
+“I don’t care whether ‘twas little or whether ‘twas big; he’s here in
+our house and a stranger, and it wasn’t good of you to say it.  If you
+was in his place it would make you feel ashamed; and so you oughtn’t to
+say a thing to another person that will make _them_ feel ashamed.”
+
+“Why, Mam, he said--”
+
+“It don’t make no difference what he _said_--that ain’t the thing.  The
+thing is for you to treat him _kind_, and not be saying things to make
+him remember he ain’t in his own country and amongst his own folks.”
+
+I says to myself, _this_ is a girl that I’m letting that old reptile rob
+her of her money!
+
+Then Susan _she_ waltzed in; and if you’ll believe me, she did give
+Hare-lip hark from the tomb!
+
+Says I to myself, and this is _another_ one that I’m letting him rob her
+of her money!
+
+Then Mary Jane she took another inning, and went in sweet and lovely
+again--which was her way; but when she got done there warn’t hardly
+anything left o’ poor Hare-lip.  So she hollered.
+
+“All right, then,” says the other girls; “you just ask his pardon.”
+
+She done it, too; and she done it beautiful.  She done it so beautiful
+it was good to hear; and I wished I could tell her a thousand lies, so
+she could do it again.
+
+I says to myself, this is _another_ one that I’m letting him rob her of
+her money.  And when she got through they all jest laid theirselves
+out to make me feel at home and know I was amongst friends.  I felt so
+ornery and low down and mean that I says to myself, my mind’s made up;
+I’ll hive that money for them or bust.
+
+So then I lit out--for bed, I said, meaning some time or another.  When
+I got by myself I went to thinking the thing over.  I says to myself,
+shall I go to that doctor, private, and blow on these frauds?  No--that
+won’t do. He might tell who told him; then the king and the duke would
+make it warm for me.  Shall I go, private, and tell Mary Jane?  No--I
+dasn’t do it. Her face would give them a hint, sure; they’ve got the
+money, and they’d slide right out and get away with it.  If she was to
+fetch in help I’d get mixed up in the business before it was done with,
+I judge.  No; there ain’t no good way but one.  I got to steal that
+money, somehow; and I got to steal it some way that they won’t suspicion
+that I done it. They’ve got a good thing here, and they ain’t a-going
+to leave till they’ve played this family and this town for all they’re
+worth, so I’ll find a chance time enough. I’ll steal it and hide it; and
+by and by, when I’m away down the river, I’ll write a letter and tell
+Mary Jane where it’s hid.  But I better hive it tonight if I can,
+because the doctor maybe hasn’t let up as much as he lets on he has; he
+might scare them out of here yet.
+
+So, thinks I, I’ll go and search them rooms.  Upstairs the hall was
+dark, but I found the duke’s room, and started to paw around it with
+my hands; but I recollected it wouldn’t be much like the king to let
+anybody else take care of that money but his own self; so then I went to
+his room and begun to paw around there.  But I see I couldn’t do nothing
+without a candle, and I dasn’t light one, of course.  So I judged I’d
+got to do the other thing--lay for them and eavesdrop.  About that time
+I hears their footsteps coming, and was going to skip under the bed; I
+reached for it, but it wasn’t where I thought it would be; but I touched
+the curtain that hid Mary Jane’s frocks, so I jumped in behind that and
+snuggled in amongst the gowns, and stood there perfectly still.
+
+They come in and shut the door; and the first thing the duke done was to
+get down and look under the bed.  Then I was glad I hadn’t found the bed
+when I wanted it.  And yet, you know, it’s kind of natural to hide under
+the bed when you are up to anything private.  They sets down then, and
+the king says:
+
+“Well, what is it?  And cut it middlin’ short, because it’s better for
+us to be down there a-whoopin’ up the mournin’ than up here givin’ ‘em a
+chance to talk us over.”
+
+“Well, this is it, Capet.  I ain’t easy; I ain’t comfortable.  That
+doctor lays on my mind.  I wanted to know your plans.  I’ve got a
+notion, and I think it’s a sound one.”
+
+“What is it, duke?”
+
+“That we better glide out of this before three in the morning, and clip
+it down the river with what we’ve got.  Specially, seeing we got it so
+easy--_given_ back to us, flung at our heads, as you may say, when of
+course we allowed to have to steal it back.  I’m for knocking off and
+lighting out.”
+
+That made me feel pretty bad.  About an hour or two ago it would a been
+a little different, but now it made me feel bad and disappointed, The
+king rips out and says:
+
+“What!  And not sell out the rest o’ the property?  March off like
+a passel of fools and leave eight or nine thous’n’ dollars’ worth o’
+property layin’ around jest sufferin’ to be scooped in?--and all good,
+salable stuff, too.”
+
+The duke he grumbled; said the bag of gold was enough, and he didn’t
+want to go no deeper--didn’t want to rob a lot of orphans of _everything_
+they had.
+
+“Why, how you talk!” says the king.  “We sha’n’t rob ‘em of nothing at
+all but jest this money.  The people that _buys_ the property is the
+suff’rers; because as soon ‘s it’s found out ‘at we didn’t own it--which
+won’t be long after we’ve slid--the sale won’t be valid, and it ‘ll all
+go back to the estate.  These yer orphans ‘ll git their house back agin,
+and that’s enough for _them_; they’re young and spry, and k’n easy
+earn a livin’.  _they_ ain’t a-goin to suffer.  Why, jest think--there’s
+thous’n’s and thous’n’s that ain’t nigh so well off.  Bless you, _they_
+ain’t got noth’n’ to complain of.”
+
+Well, the king he talked him blind; so at last he give in, and said all
+right, but said he believed it was blamed foolishness to stay, and that
+doctor hanging over them.  But the king says:
+
+“Cuss the doctor!  What do we k’yer for _him_?  Hain’t we got all the
+fools in town on our side?  And ain’t that a big enough majority in any
+town?”
+
+So they got ready to go down stairs again.  The duke says:
+
+“I don’t think we put that money in a good place.”
+
+That cheered me up.  I’d begun to think I warn’t going to get a hint of
+no kind to help me.  The king says:
+
+“Why?”
+
+“Because Mary Jane ‘ll be in mourning from this out; and first you know
+the nigger that does up the rooms will get an order to box these duds
+up and put ‘em away; and do you reckon a nigger can run across money and
+not borrow some of it?”
+
+“Your head’s level agin, duke,” says the king; and he comes a-fumbling
+under the curtain two or three foot from where I was.  I stuck tight to
+the wall and kept mighty still, though quivery; and I wondered what them
+fellows would say to me if they catched me; and I tried to think what
+I’d better do if they did catch me.  But the king he got the bag before
+I could think more than about a half a thought, and he never suspicioned
+I was around.  They took and shoved the bag through a rip in the straw
+tick that was under the feather-bed, and crammed it in a foot or two
+amongst the straw and said it was all right now, because a nigger only
+makes up the feather-bed, and don’t turn over the straw tick only about
+twice a year, and so it warn’t in no danger of getting stole now.
+
+But I knowed better.  I had it out of there before they was half-way
+down stairs.  I groped along up to my cubby, and hid it there till I
+could get a chance to do better.  I judged I better hide it outside
+of the house somewheres, because if they missed it they would give the
+house a good ransacking:  I knowed that very well.  Then I turned in,
+with my clothes all on; but I couldn’t a gone to sleep if I’d a wanted
+to, I was in such a sweat to get through with the business.  By and by I
+heard the king and the duke come up; so I rolled off my pallet and laid
+with my chin at the top of my ladder, and waited to see if anything was
+going to happen.  But nothing did.
+
+So I held on till all the late sounds had quit and the early ones hadn’t
+begun yet; and then I slipped down the ladder.
+
+
+
+
+CHAPTER XXVII.
+
+I crept to their doors and listened; they was snoring.  So I tiptoed
+along, and got down stairs all right.  There warn’t a sound anywheres.
+ I peeped through a crack of the dining-room door, and see the men that
+was watching the corpse all sound asleep on their chairs.  The door
+was open into the parlor, where the corpse was laying, and there was a
+candle in both rooms. I passed along, and the parlor door was open; but
+I see there warn’t nobody in there but the remainders of Peter; so I
+shoved on by; but the front door was locked, and the key wasn’t there.
+ Just then I heard somebody coming down the stairs, back behind me.  I
+run in the parlor and took a swift look around, and the only place I
+see to hide the bag was in the coffin.  The lid was shoved along about
+a foot, showing the dead man’s face down in there, with a wet cloth over
+it, and his shroud on.  I tucked the money-bag in under the lid, just
+down beyond where his hands was crossed, which made me creep, they was
+so cold, and then I run back across the room and in behind the door.
+
+The person coming was Mary Jane.  She went to the coffin, very soft, and
+kneeled down and looked in; then she put up her handkerchief, and I see
+she begun to cry, though I couldn’t hear her, and her back was to me.  I
+slid out, and as I passed the dining-room I thought I’d make sure them
+watchers hadn’t seen me; so I looked through the crack, and everything
+was all right.  They hadn’t stirred.
+
+I slipped up to bed, feeling ruther blue, on accounts of the thing
+playing out that way after I had took so much trouble and run so much
+resk about it.  Says I, if it could stay where it is, all right; because
+when we get down the river a hundred mile or two I could write back to
+Mary Jane, and she could dig him up again and get it; but that ain’t the
+thing that’s going to happen; the thing that’s going to happen is, the
+money ‘ll be found when they come to screw on the lid.  Then the king
+‘ll get it again, and it ‘ll be a long day before he gives anybody
+another chance to smouch it from him. Of course I _wanted_ to slide
+down and get it out of there, but I dasn’t try it.  Every minute it was
+getting earlier now, and pretty soon some of them watchers would begin
+to stir, and I might get catched--catched with six thousand dollars in my
+hands that nobody hadn’t hired me to take care of.  I don’t wish to be
+mixed up in no such business as that, I says to myself.
+
+When I got down stairs in the morning the parlor was shut up, and the
+watchers was gone.  There warn’t nobody around but the family and the
+widow Bartley and our tribe.  I watched their faces to see if anything
+had been happening, but I couldn’t tell.
+
+Towards the middle of the day the undertaker come with his man, and they
+set the coffin in the middle of the room on a couple of chairs, and then
+set all our chairs in rows, and borrowed more from the neighbors till
+the hall and the parlor and the dining-room was full.  I see the coffin
+lid was the way it was before, but I dasn’t go to look in under it, with
+folks around.
+
+Then the people begun to flock in, and the beats and the girls took
+seats in the front row at the head of the coffin, and for a half an hour
+the people filed around slow, in single rank, and looked down at the
+dead man’s face a minute, and some dropped in a tear, and it was
+all very still and solemn, only the girls and the beats holding
+handkerchiefs to their eyes and keeping their heads bent, and sobbing a
+little.  There warn’t no other sound but the scraping of the feet on
+the floor and blowing noses--because people always blows them more at a
+funeral than they do at other places except church.
+
+When the place was packed full the undertaker he slid around in his
+black gloves with his softy soothering ways, putting on the last
+touches, and getting people and things all ship-shape and comfortable,
+and making no more sound than a cat.  He never spoke; he moved people
+around, he squeezed in late ones, he opened up passageways, and done
+it with nods, and signs with his hands.  Then he took his place over
+against the wall. He was the softest, glidingest, stealthiest man I ever
+see; and there warn’t no more smile to him than there is to a ham.
+
+They had borrowed a melodeum--a sick one; and when everything was ready
+a young woman set down and worked it, and it was pretty skreeky and
+colicky, and everybody joined in and sung, and Peter was the only one
+that had a good thing, according to my notion.  Then the Reverend Hobson
+opened up, slow and solemn, and begun to talk; and straight off the most
+outrageous row busted out in the cellar a body ever heard; it was only
+one dog, but he made a most powerful racket, and he kept it up right
+along; the parson he had to stand there, over the coffin, and wait--you
+couldn’t hear yourself think.  It was right down awkward, and nobody
+didn’t seem to know what to do.  But pretty soon they see that
+long-legged undertaker make a sign to the preacher as much as to say,
+“Don’t you worry--just depend on me.”  Then he stooped down and begun
+to glide along the wall, just his shoulders showing over the people’s
+heads.  So he glided along, and the powwow and racket getting more and
+more outrageous all the time; and at last, when he had gone around two
+sides of the room, he disappears down cellar.  Then in about two seconds
+we heard a whack, and the dog he finished up with a most amazing howl or
+two, and then everything was dead still, and the parson begun his solemn
+talk where he left off.  In a minute or two here comes this undertaker’s
+back and shoulders gliding along the wall again; and so he glided and
+glided around three sides of the room, and then rose up, and shaded his
+mouth with his hands, and stretched his neck out towards the preacher,
+over the people’s heads, and says, in a kind of a coarse whisper, “_He
+had a rat_!”  Then he drooped down and glided along the wall again to
+his place.  You could see it was a great satisfaction to the people,
+because naturally they wanted to know.  A little thing like that don’t
+cost nothing, and it’s just the little things that makes a man to be
+looked up to and liked.  There warn’t no more popular man in town than
+what that undertaker was.
+
+Well, the funeral sermon was very good, but pison long and tiresome; and
+then the king he shoved in and got off some of his usual rubbage, and
+at last the job was through, and the undertaker begun to sneak up on the
+coffin with his screw-driver.  I was in a sweat then, and watched him
+pretty keen. But he never meddled at all; just slid the lid along as
+soft as mush, and screwed it down tight and fast.  So there I was!  I
+didn’t know whether the money was in there or not.  So, says I, s’pose
+somebody has hogged that bag on the sly?--now how do I know whether
+to write to Mary Jane or not? S’pose she dug him up and didn’t find
+nothing, what would she think of me? Blame it, I says, I might get
+hunted up and jailed; I’d better lay low and keep dark, and not write at
+all; the thing’s awful mixed now; trying to better it, I’ve worsened it
+a hundred times, and I wish to goodness I’d just let it alone, dad fetch
+the whole business!
+
+They buried him, and we come back home, and I went to watching faces
+again--I couldn’t help it, and I couldn’t rest easy.  But nothing come of
+it; the faces didn’t tell me nothing.
+
+The king he visited around in the evening, and sweetened everybody up,
+and made himself ever so friendly; and he give out the idea that his
+congregation over in England would be in a sweat about him, so he must
+hurry and settle up the estate right away and leave for home.  He was
+very sorry he was so pushed, and so was everybody; they wished he could
+stay longer, but they said they could see it couldn’t be done.  And he
+said of course him and William would take the girls home with them; and
+that pleased everybody too, because then the girls would be well fixed
+and amongst their own relations; and it pleased the girls, too--tickled
+them so they clean forgot they ever had a trouble in the world; and told
+him to sell out as quick as he wanted to, they would be ready.  Them
+poor things was that glad and happy it made my heart ache to see them
+getting fooled and lied to so, but I didn’t see no safe way for me to
+chip in and change the general tune.
+
+Well, blamed if the king didn’t bill the house and the niggers and all
+the property for auction straight off--sale two days after the funeral;
+but anybody could buy private beforehand if they wanted to.
+
+So the next day after the funeral, along about noon-time, the girls’ joy
+got the first jolt.  A couple of nigger traders come along, and the king
+sold them the niggers reasonable, for three-day drafts as they called
+it, and away they went, the two sons up the river to Memphis, and their
+mother down the river to Orleans.  I thought them poor girls and them
+niggers would break their hearts for grief; they cried around each
+other, and took on so it most made me down sick to see it.  The girls
+said they hadn’t ever dreamed of seeing the family separated or sold
+away from the town.  I can’t ever get it out of my memory, the sight of
+them poor miserable girls and niggers hanging around each other’s necks
+and crying; and I reckon I couldn’t a stood it all, but would a had
+to bust out and tell on our gang if I hadn’t knowed the sale warn’t no
+account and the niggers would be back home in a week or two.
+
+The thing made a big stir in the town, too, and a good many come out
+flatfooted and said it was scandalous to separate the mother and the
+children that way.  It injured the frauds some; but the old fool he
+bulled right along, spite of all the duke could say or do, and I tell
+you the duke was powerful uneasy.
+
+Next day was auction day.  About broad day in the morning the king and
+the duke come up in the garret and woke me up, and I see by their look
+that there was trouble.  The king says:
+
+“Was you in my room night before last?”
+
+“No, your majesty”--which was the way I always called him when nobody but
+our gang warn’t around.
+
+“Was you in there yisterday er last night?”
+
+“No, your majesty.”
+
+“Honor bright, now--no lies.”
+
+“Honor bright, your majesty, I’m telling you the truth.  I hain’t been
+a-near your room since Miss Mary Jane took you and the duke and showed
+it to you.”
+
+The duke says:
+
+“Have you seen anybody else go in there?”
+
+“No, your grace, not as I remember, I believe.”
+
+“Stop and think.”
+
+I studied awhile and see my chance; then I says:
+
+“Well, I see the niggers go in there several times.”
+
+Both of them gave a little jump, and looked like they hadn’t ever
+expected it, and then like they _had_.  Then the duke says:
+
+“What, all of them?”
+
+“No--leastways, not all at once--that is, I don’t think I ever see them
+all come _out_ at once but just one time.”
+
+“Hello!  When was that?”
+
+“It was the day we had the funeral.  In the morning.  It warn’t early,
+because I overslept.  I was just starting down the ladder, and I see
+them.”
+
+“Well, go on, _go_ on!  What did they do?  How’d they act?”
+
+“They didn’t do nothing.  And they didn’t act anyway much, as fur as I
+see. They tiptoed away; so I seen, easy enough, that they’d shoved in
+there to do up your majesty’s room, or something, s’posing you was up;
+and found you _warn’t_ up, and so they was hoping to slide out of the
+way of trouble without waking you up, if they hadn’t already waked you
+up.”
+
+“Great guns, _this_ is a go!” says the king; and both of them looked
+pretty sick and tolerable silly.  They stood there a-thinking and
+scratching their heads a minute, and the duke he bust into a kind of a
+little raspy chuckle, and says:
+
+“It does beat all how neat the niggers played their hand.  They let on
+to be _sorry_ they was going out of this region!  And I believed they
+_was_ sorry, and so did you, and so did everybody.  Don’t ever tell _me_
+any more that a nigger ain’t got any histrionic talent.  Why, the way
+they played that thing it would fool _anybody_.  In my opinion, there’s
+a fortune in ‘em.  If I had capital and a theater, I wouldn’t want a
+better lay-out than that--and here we’ve gone and sold ‘em for a song.
+ Yes, and ain’t privileged to sing the song yet.  Say, where _is_ that
+song--that draft?”
+
+“In the bank for to be collected.  Where _would_ it be?”
+
+“Well, _that’s_ all right then, thank goodness.”
+
+Says I, kind of timid-like:
+
+“Is something gone wrong?”
+
+The king whirls on me and rips out:
+
+“None o’ your business!  You keep your head shet, and mind y’r own
+affairs--if you got any.  Long as you’re in this town don’t you forgit
+_that_--you hear?”  Then he says to the duke, “We got to jest swaller it
+and say noth’n’:  mum’s the word for _us_.”
+
+As they was starting down the ladder the duke he chuckles again, and
+says:
+
+“Quick sales _and_ small profits!  It’s a good business--yes.”
+
+The king snarls around on him and says:
+
+“I was trying to do for the best in sellin’ ‘em out so quick.  If the
+profits has turned out to be none, lackin’ considable, and none to
+carry, is it my fault any more’n it’s yourn?”
+
+“Well, _they’d_ be in this house yet and we _wouldn’t_ if I could a got
+my advice listened to.”
+
+The king sassed back as much as was safe for him, and then swapped
+around and lit into _me_ again.  He give me down the banks for not
+coming and _telling_ him I see the niggers come out of his room acting
+that way--said any fool would a _knowed_ something was up.  And then
+waltzed in and cussed _himself_ awhile, and said it all come of him not
+laying late and taking his natural rest that morning, and he’d be
+blamed if he’d ever do it again.  So they went off a-jawing; and I felt
+dreadful glad I’d worked it all off on to the niggers, and yet hadn’t
+done the niggers no harm by it.
+
+
+
+
+CHAPTER XXVIII.
+
+BY and by it was getting-up time.  So I come down the ladder and started
+for down-stairs; but as I come to the girls’ room the door was open, and
+I see Mary Jane setting by her old hair trunk, which was open and she’d
+been packing things in it--getting ready to go to England.  But she
+had stopped now with a folded gown in her lap, and had her face in her
+hands, crying.  I felt awful bad to see it; of course anybody would.  I
+went in there and says:
+
+“Miss Mary Jane, you can’t a-bear to see people in trouble, and I
+can’t--most always.  Tell me about it.”
+
+So she done it.  And it was the niggers--I just expected it.  She said
+the beautiful trip to England was most about spoiled for her; she didn’t
+know _how_ she was ever going to be happy there, knowing the mother and
+the children warn’t ever going to see each other no more--and then busted
+out bitterer than ever, and flung up her hands, and says:
+
+“Oh, dear, dear, to think they ain’t _ever_ going to see each other any
+more!”
+
+“But they _will_--and inside of two weeks--and I _know_ it!” says I.
+
+Laws, it was out before I could think!  And before I could budge she
+throws her arms around my neck and told me to say it _again_, say it
+_again_, say it _again_!
+
+I see I had spoke too sudden and said too much, and was in a close
+place. I asked her to let me think a minute; and she set there, very
+impatient and excited and handsome, but looking kind of happy and
+eased-up, like a person that’s had a tooth pulled out.  So I went to
+studying it out.  I says to myself, I reckon a body that ups and tells
+the truth when he is in a tight place is taking considerable many resks,
+though I ain’t had no experience, and can’t say for certain; but it
+looks so to me, anyway; and yet here’s a case where I’m blest if it
+don’t look to me like the truth is better and actuly _safer_ than a lie.
+ I must lay it by in my mind, and think it over some time or other, it’s
+so kind of strange and unregular. I never see nothing like it.  Well, I
+says to myself at last, I’m a-going to chance it; I’ll up and tell the
+truth this time, though it does seem most like setting down on a kag of
+powder and touching it off just to see where you’ll go to. Then I says:
+
+“Miss Mary Jane, is there any place out of town a little ways where you
+could go and stay three or four days?”
+
+“Yes; Mr. Lothrop’s.  Why?”
+
+“Never mind why yet.  If I’ll tell you how I know the niggers will see
+each other again inside of two weeks--here in this house--and _prove_ how
+I know it--will you go to Mr. Lothrop’s and stay four days?”
+
+“Four days!” she says; “I’ll stay a year!”
+
+“All right,” I says, “I don’t want nothing more out of _you_ than just
+your word--I druther have it than another man’s kiss-the-Bible.”  She
+smiled and reddened up very sweet, and I says, “If you don’t mind it,
+I’ll shut the door--and bolt it.”
+
+Then I come back and set down again, and says:
+
+“Don’t you holler.  Just set still and take it like a man.  I got to
+tell the truth, and you want to brace up, Miss Mary, because it’s a
+bad kind, and going to be hard to take, but there ain’t no help for
+it.  These uncles of yourn ain’t no uncles at all; they’re a couple of
+frauds--regular dead-beats.  There, now we’re over the worst of it, you
+can stand the rest middling easy.”
+
+It jolted her up like everything, of course; but I was over the shoal
+water now, so I went right along, her eyes a-blazing higher and higher
+all the time, and told her every blame thing, from where we first struck
+that young fool going up to the steamboat, clear through to where she
+flung herself on to the king’s breast at the front door and he kissed
+her sixteen or seventeen times--and then up she jumps, with her face
+afire like sunset, and says:
+
+“The brute!  Come, don’t waste a minute--not a _second_--we’ll have them
+tarred and feathered, and flung in the river!”
+
+Says I:
+
+“Cert’nly.  But do you mean _before_ you go to Mr. Lothrop’s, or--”
+
+“Oh,” she says, “what am I _thinking_ about!” she says, and set right
+down again.  “Don’t mind what I said--please don’t--you _won’t,_ now,
+_will_ you?” Laying her silky hand on mine in that kind of a way that
+I said I would die first.  “I never thought, I was so stirred up,” she
+says; “now go on, and I won’t do so any more.  You tell me what to do,
+and whatever you say I’ll do it.”
+
+“Well,” I says, “it’s a rough gang, them two frauds, and I’m fixed so
+I got to travel with them a while longer, whether I want to or not--I
+druther not tell you why; and if you was to blow on them this town would
+get me out of their claws, and I’d be all right; but there’d be another
+person that you don’t know about who’d be in big trouble.  Well, we
+got to save _him_, hain’t we?  Of course.  Well, then, we won’t blow on
+them.”
+
+Saying them words put a good idea in my head.  I see how maybe I could
+get me and Jim rid of the frauds; get them jailed here, and then leave.
+But I didn’t want to run the raft in the daytime without anybody aboard
+to answer questions but me; so I didn’t want the plan to begin working
+till pretty late to-night.  I says:
+
+“Miss Mary Jane, I’ll tell you what we’ll do, and you won’t have to stay
+at Mr. Lothrop’s so long, nuther.  How fur is it?”
+
+“A little short of four miles--right out in the country, back here.”
+
+“Well, that ‘ll answer.  Now you go along out there, and lay low
+till nine or half-past to-night, and then get them to fetch you home
+again--tell them you’ve thought of something.  If you get here before
+eleven put a candle in this window, and if I don’t turn up wait _till_
+eleven, and _then_ if I don’t turn up it means I’m gone, and out of the
+way, and safe. Then you come out and spread the news around, and get
+these beats jailed.”
+
+“Good,” she says, “I’ll do it.”
+
+“And if it just happens so that I don’t get away, but get took up along
+with them, you must up and say I told you the whole thing beforehand,
+and you must stand by me all you can.”
+
+“Stand by you! indeed I will.  They sha’n’t touch a hair of your head!”
+ she says, and I see her nostrils spread and her eyes snap when she said
+it, too.
+
+“If I get away I sha’n’t be here,” I says, “to prove these rapscallions
+ain’t your uncles, and I couldn’t do it if I _was_ here.  I could swear
+they was beats and bummers, that’s all, though that’s worth something.
+Well, there’s others can do that better than what I can, and they’re
+people that ain’t going to be doubted as quick as I’d be.  I’ll tell you
+how to find them.  Gimme a pencil and a piece of paper.  There--‘Royal
+Nonesuch, Bricksville.’  Put it away, and don’t lose it.  When the
+court wants to find out something about these two, let them send up to
+Bricksville and say they’ve got the men that played the Royal Nonesuch,
+and ask for some witnesses--why, you’ll have that entire town down here
+before you can hardly wink, Miss Mary.  And they’ll come a-biling, too.”
+
+I judged we had got everything fixed about right now.  So I says:
+
+“Just let the auction go right along, and don’t worry.  Nobody don’t
+have to pay for the things they buy till a whole day after the auction
+on accounts of the short notice, and they ain’t going out of this till
+they get that money; and the way we’ve fixed it the sale ain’t going to
+count, and they ain’t going to get no money.  It’s just like the way
+it was with the niggers--it warn’t no sale, and the niggers will be
+back before long.  Why, they can’t collect the money for the _niggers_
+yet--they’re in the worst kind of a fix, Miss Mary.”
+
+“Well,” she says, “I’ll run down to breakfast now, and then I’ll start
+straight for Mr. Lothrop’s.”
+
+“‘Deed, _that_ ain’t the ticket, Miss Mary Jane,” I says, “by no manner
+of means; go _before_ breakfast.”
+
+“Why?”
+
+“What did you reckon I wanted you to go at all for, Miss Mary?”
+
+“Well, I never thought--and come to think, I don’t know.  What was it?”
+
+“Why, it’s because you ain’t one of these leather-face people.  I don’t
+want no better book than what your face is.  A body can set down and
+read it off like coarse print.  Do you reckon you can go and face your
+uncles when they come to kiss you good-morning, and never--”
+
+“There, there, don’t!  Yes, I’ll go before breakfast--I’ll be glad to.
+And leave my sisters with them?”
+
+“Yes; never mind about them.  They’ve got to stand it yet a while.  They
+might suspicion something if all of you was to go.  I don’t want you to
+see them, nor your sisters, nor nobody in this town; if a neighbor was
+to ask how is your uncles this morning your face would tell something.
+ No, you go right along, Miss Mary Jane, and I’ll fix it with all of
+them. I’ll tell Miss Susan to give your love to your uncles and say
+you’ve went away for a few hours for to get a little rest and change, or
+to see a friend, and you’ll be back to-night or early in the morning.”
+
+“Gone to see a friend is all right, but I won’t have my love given to
+them.”
+
+“Well, then, it sha’n’t be.”  It was well enough to tell _her_ so--no
+harm in it.  It was only a little thing to do, and no trouble; and it’s
+the little things that smooths people’s roads the most, down here below;
+it would make Mary Jane comfortable, and it wouldn’t cost nothing.  Then
+I says:  “There’s one more thing--that bag of money.”
+
+“Well, they’ve got that; and it makes me feel pretty silly to think
+_how_ they got it.”
+
+“No, you’re out, there.  They hain’t got it.”
+
+“Why, who’s got it?”
+
+“I wish I knowed, but I don’t.  I _had_ it, because I stole it from
+them; and I stole it to give to you; and I know where I hid it, but I’m
+afraid it ain’t there no more.  I’m awful sorry, Miss Mary Jane, I’m
+just as sorry as I can be; but I done the best I could; I did honest.  I
+come nigh getting caught, and I had to shove it into the first place I
+come to, and run--and it warn’t a good place.”
+
+“Oh, stop blaming yourself--it’s too bad to do it, and I won’t allow
+it--you couldn’t help it; it wasn’t your fault.  Where did you hide it?”
+
+I didn’t want to set her to thinking about her troubles again; and I
+couldn’t seem to get my mouth to tell her what would make her see that
+corpse laying in the coffin with that bag of money on his stomach.  So
+for a minute I didn’t say nothing; then I says:
+
+“I’d ruther not _tell_ you where I put it, Miss Mary Jane, if you don’t
+mind letting me off; but I’ll write it for you on a piece of paper, and
+you can read it along the road to Mr. Lothrop’s, if you want to.  Do you
+reckon that ‘ll do?”
+
+“Oh, yes.”
+
+So I wrote:  “I put it in the coffin.  It was in there when you was
+crying there, away in the night.  I was behind the door, and I was
+mighty sorry for you, Miss Mary Jane.”
+
+It made my eyes water a little to remember her crying there all by
+herself in the night, and them devils laying there right under her own
+roof, shaming her and robbing her; and when I folded it up and give it
+to her I see the water come into her eyes, too; and she shook me by the
+hand, hard, and says:
+
+“_Good_-bye.  I’m going to do everything just as you’ve told me; and if
+I don’t ever see you again, I sha’n’t ever forget you and I’ll think of
+you a many and a many a time, and I’ll _pray_ for you, too!”--and she was
+gone.
+
+Pray for me!  I reckoned if she knowed me she’d take a job that was more
+nearer her size.  But I bet she done it, just the same--she was just that
+kind.  She had the grit to pray for Judus if she took the notion--there
+warn’t no back-down to her, I judge.  You may say what you want to, but
+in my opinion she had more sand in her than any girl I ever see; in
+my opinion she was just full of sand.  It sounds like flattery, but it
+ain’t no flattery.  And when it comes to beauty--and goodness, too--she
+lays over them all.  I hain’t ever seen her since that time that I see
+her go out of that door; no, I hain’t ever seen her since, but I reckon
+I’ve thought of her a many and a many a million times, and of her saying
+she would pray for me; and if ever I’d a thought it would do any good
+for me to pray for _her_, blamed if I wouldn’t a done it or bust.
+
+Well, Mary Jane she lit out the back way, I reckon; because nobody see
+her go.  When I struck Susan and the hare-lip, I says:
+
+“What’s the name of them people over on t’other side of the river that
+you all goes to see sometimes?”
+
+They says:
+
+“There’s several; but it’s the Proctors, mainly.”
+
+“That’s the name,” I says; “I most forgot it.  Well, Miss Mary Jane she
+told me to tell you she’s gone over there in a dreadful hurry--one of
+them’s sick.”
+
+“Which one?”
+
+“I don’t know; leastways, I kinder forget; but I thinks it’s--”
+
+“Sakes alive, I hope it ain’t _Hanner_?”
+
+“I’m sorry to say it,” I says, “but Hanner’s the very one.”
+
+“My goodness, and she so well only last week!  Is she took bad?”
+
+“It ain’t no name for it.  They set up with her all night, Miss Mary
+Jane said, and they don’t think she’ll last many hours.”
+
+“Only think of that, now!  What’s the matter with her?”
+
+I couldn’t think of anything reasonable, right off that way, so I says:
+
+“Mumps.”
+
+“Mumps your granny!  They don’t set up with people that’s got the
+mumps.”
+
+“They don’t, don’t they?  You better bet they do with _these_ mumps.
+ These mumps is different.  It’s a new kind, Miss Mary Jane said.”
+
+“How’s it a new kind?”
+
+“Because it’s mixed up with other things.”
+
+“What other things?”
+
+“Well, measles, and whooping-cough, and erysiplas, and consumption, and
+yaller janders, and brain-fever, and I don’t know what all.”
+
+“My land!  And they call it the _mumps_?”
+
+“That’s what Miss Mary Jane said.”
+
+“Well, what in the nation do they call it the _mumps_ for?”
+
+“Why, because it _is_ the mumps.  That’s what it starts with.”
+
+“Well, ther’ ain’t no sense in it.  A body might stump his toe, and take
+pison, and fall down the well, and break his neck, and bust his brains
+out, and somebody come along and ask what killed him, and some numskull
+up and say, ‘Why, he stumped his _toe_.’  Would ther’ be any sense
+in that? _No_.  And ther’ ain’t no sense in _this_, nuther.  Is it
+ketching?”
+
+“Is it _ketching_?  Why, how you talk.  Is a _harrow_ catching--in the
+dark? If you don’t hitch on to one tooth, you’re bound to on another,
+ain’t you? And you can’t get away with that tooth without fetching the
+whole harrow along, can you?  Well, these kind of mumps is a kind of a
+harrow, as you may say--and it ain’t no slouch of a harrow, nuther, you
+come to get it hitched on good.”
+
+“Well, it’s awful, I think,” says the hare-lip.  “I’ll go to Uncle
+Harvey and--”
+
+“Oh, yes,” I says, “I _would_.  Of _course_ I would.  I wouldn’t lose no
+time.”
+
+“Well, why wouldn’t you?”
+
+“Just look at it a minute, and maybe you can see.  Hain’t your uncles
+obleegd to get along home to England as fast as they can?  And do you
+reckon they’d be mean enough to go off and leave you to go all that
+journey by yourselves?  _you_ know they’ll wait for you.  So fur, so
+good. Your uncle Harvey’s a preacher, ain’t he?  Very well, then; is a
+_preacher_ going to deceive a steamboat clerk? is he going to deceive
+a _ship clerk?_--so as to get them to let Miss Mary Jane go aboard?  Now
+_you_ know he ain’t.  What _will_ he do, then?  Why, he’ll say, ‘It’s a
+great pity, but my church matters has got to get along the best way they
+can; for my niece has been exposed to the dreadful pluribus-unum mumps,
+and so it’s my bounden duty to set down here and wait the three months
+it takes to show on her if she’s got it.’  But never mind, if you think
+it’s best to tell your uncle Harvey--”
+
+“Shucks, and stay fooling around here when we could all be having good
+times in England whilst we was waiting to find out whether Mary Jane’s
+got it or not?  Why, you talk like a muggins.”
+
+“Well, anyway, maybe you’d better tell some of the neighbors.”
+
+“Listen at that, now.  You do beat all for natural stupidness.  Can’t
+you _see_ that _they’d_ go and tell?  Ther’ ain’t no way but just to not
+tell anybody at _all_.”
+
+“Well, maybe you’re right--yes, I judge you _are_ right.”
+
+“But I reckon we ought to tell Uncle Harvey she’s gone out a while,
+anyway, so he won’t be uneasy about her?”
+
+“Yes, Miss Mary Jane she wanted you to do that.  She says, ‘Tell them to
+give Uncle Harvey and William my love and a kiss, and say I’ve run over
+the river to see Mr.’--Mr.--what _is_ the name of that rich family your
+uncle Peter used to think so much of?--I mean the one that--”
+
+“Why, you must mean the Apthorps, ain’t it?”
+
+“Of course; bother them kind of names, a body can’t ever seem to
+remember them, half the time, somehow.  Yes, she said, say she has run
+over for to ask the Apthorps to be sure and come to the auction and buy
+this house, because she allowed her uncle Peter would ruther they had
+it than anybody else; and she’s going to stick to them till they say
+they’ll come, and then, if she ain’t too tired, she’s coming home; and
+if she is, she’ll be home in the morning anyway.  She said, don’t say
+nothing about the Proctors, but only about the Apthorps--which ‘ll be
+perfectly true, because she is going there to speak about their buying
+the house; I know it, because she told me so herself.”
+
+“All right,” they said, and cleared out to lay for their uncles, and
+give them the love and the kisses, and tell them the message.
+
+Everything was all right now.  The girls wouldn’t say nothing because
+they wanted to go to England; and the king and the duke would ruther
+Mary Jane was off working for the auction than around in reach of
+Doctor Robinson.  I felt very good; I judged I had done it pretty neat--I
+reckoned Tom Sawyer couldn’t a done it no neater himself.  Of course he
+would a throwed more style into it, but I can’t do that very handy, not
+being brung up to it.
+
+Well, they held the auction in the public square, along towards the end
+of the afternoon, and it strung along, and strung along, and the old man
+he was on hand and looking his level pisonest, up there longside of the
+auctioneer, and chipping in a little Scripture now and then, or a little
+goody-goody saying of some kind, and the duke he was around goo-gooing
+for sympathy all he knowed how, and just spreading himself generly.
+
+But by and by the thing dragged through, and everything was
+sold--everything but a little old trifling lot in the graveyard.  So
+they’d got to work that off--I never see such a girafft as the king was
+for wanting to swallow _everything_.  Well, whilst they was at it a
+steamboat landed, and in about two minutes up comes a crowd a-whooping
+and yelling and laughing and carrying on, and singing out:
+
+“_Here’s_ your opposition line! here’s your two sets o’ heirs to old
+Peter Wilks--and you pays your money and you takes your choice!”
+
+
+
+
+CHAPTER XXIX.
+
+THEY was fetching a very nice-looking old gentleman along, and a
+nice-looking younger one, with his right arm in a sling.  And, my souls,
+how the people yelled and laughed, and kept it up.  But I didn’t see no
+joke about it, and I judged it would strain the duke and the king some
+to see any.  I reckoned they’d turn pale.  But no, nary a pale did
+_they_ turn. The duke he never let on he suspicioned what was up, but
+just went a goo-gooing around, happy and satisfied, like a jug that’s
+googling out buttermilk; and as for the king, he just gazed and gazed
+down sorrowful on them new-comers like it give him the stomach-ache in
+his very heart to think there could be such frauds and rascals in the
+world.  Oh, he done it admirable.  Lots of the principal people
+gethered around the king, to let him see they was on his side.  That old
+gentleman that had just come looked all puzzled to death.  Pretty
+soon he begun to speak, and I see straight off he pronounced _like_ an
+Englishman--not the king’s way, though the king’s _was_ pretty good for
+an imitation.  I can’t give the old gent’s words, nor I can’t imitate
+him; but he turned around to the crowd, and says, about like this:
+
+“This is a surprise to me which I wasn’t looking for; and I’ll
+acknowledge, candid and frank, I ain’t very well fixed to meet it and
+answer it; for my brother and me has had misfortunes; he’s broke his
+arm, and our baggage got put off at a town above here last night in the
+night by a mistake.  I am Peter Wilks’ brother Harvey, and this is his
+brother William, which can’t hear nor speak--and can’t even make signs to
+amount to much, now’t he’s only got one hand to work them with.  We are
+who we say we are; and in a day or two, when I get the baggage, I can
+prove it. But up till then I won’t say nothing more, but go to the hotel
+and wait.”
+
+So him and the new dummy started off; and the king he laughs, and
+blethers out:
+
+“Broke his arm--_very_ likely, _ain’t_ it?--and very convenient, too,
+for a fraud that’s got to make signs, and ain’t learnt how.  Lost
+their baggage! That’s _mighty_ good!--and mighty ingenious--under the
+_circumstances_!”
+
+So he laughed again; and so did everybody else, except three or four,
+or maybe half a dozen.  One of these was that doctor; another one was
+a sharp-looking gentleman, with a carpet-bag of the old-fashioned kind
+made out of carpet-stuff, that had just come off of the steamboat and
+was talking to him in a low voice, and glancing towards the king now and
+then and nodding their heads--it was Levi Bell, the lawyer that was gone
+up to Louisville; and another one was a big rough husky that come along
+and listened to all the old gentleman said, and was listening to the
+king now. And when the king got done this husky up and says:
+
+“Say, looky here; if you are Harvey Wilks, when’d you come to this
+town?”
+
+“The day before the funeral, friend,” says the king.
+
+“But what time o’ day?”
+
+“In the evenin’--‘bout an hour er two before sundown.”
+
+“_How’d_ you come?”
+
+“I come down on the Susan Powell from Cincinnati.”
+
+“Well, then, how’d you come to be up at the Pint in the _mornin_’--in a
+canoe?”
+
+“I warn’t up at the Pint in the mornin’.”
+
+“It’s a lie.”
+
+Several of them jumped for him and begged him not to talk that way to an
+old man and a preacher.
+
+“Preacher be hanged, he’s a fraud and a liar.  He was up at the Pint
+that mornin’.  I live up there, don’t I?  Well, I was up there, and
+he was up there.  I see him there.  He come in a canoe, along with Tim
+Collins and a boy.”
+
+The doctor he up and says:
+
+“Would you know the boy again if you was to see him, Hines?”
+
+“I reckon I would, but I don’t know.  Why, yonder he is, now.  I know
+him perfectly easy.”
+
+It was me he pointed at.  The doctor says:
+
+“Neighbors, I don’t know whether the new couple is frauds or not; but if
+_these_ two ain’t frauds, I am an idiot, that’s all.  I think it’s our
+duty to see that they don’t get away from here till we’ve looked into
+this thing. Come along, Hines; come along, the rest of you.  We’ll take
+these fellows to the tavern and affront them with t’other couple, and I
+reckon we’ll find out _something_ before we get through.”
+
+It was nuts for the crowd, though maybe not for the king’s friends; so
+we all started.  It was about sundown.  The doctor he led me along by
+the hand, and was plenty kind enough, but he never let go my hand.
+
+We all got in a big room in the hotel, and lit up some candles, and
+fetched in the new couple.  First, the doctor says:
+
+“I don’t wish to be too hard on these two men, but I think they’re
+frauds, and they may have complices that we don’t know nothing about.
+ If they have, won’t the complices get away with that bag of gold Peter
+Wilks left?  It ain’t unlikely.  If these men ain’t frauds, they won’t
+object to sending for that money and letting us keep it till they prove
+they’re all right--ain’t that so?”
+
+Everybody agreed to that.  So I judged they had our gang in a pretty
+tight place right at the outstart.  But the king he only looked
+sorrowful, and says:
+
+“Gentlemen, I wish the money was there, for I ain’t got no disposition
+to throw anything in the way of a fair, open, out-and-out investigation
+o’ this misable business; but, alas, the money ain’t there; you k’n send
+and see, if you want to.”
+
+“Where is it, then?”
+
+“Well, when my niece give it to me to keep for her I took and hid it
+inside o’ the straw tick o’ my bed, not wishin’ to bank it for the few
+days we’d be here, and considerin’ the bed a safe place, we not bein’
+used to niggers, and suppos’n’ ‘em honest, like servants in England.
+ The niggers stole it the very next mornin’ after I had went down
+stairs; and when I sold ‘em I hadn’t missed the money yit, so they got
+clean away with it.  My servant here k’n tell you ‘bout it, gentlemen.”
+
+The doctor and several said “Shucks!” and I see nobody didn’t altogether
+believe him.  One man asked me if I see the niggers steal it.  I said
+no, but I see them sneaking out of the room and hustling away, and I
+never thought nothing, only I reckoned they was afraid they had waked up
+my master and was trying to get away before he made trouble with them.
+ That was all they asked me.  Then the doctor whirls on me and says:
+
+“Are _you_ English, too?”
+
+I says yes; and him and some others laughed, and said, “Stuff!”
+
+Well, then they sailed in on the general investigation, and there we had
+it, up and down, hour in, hour out, and nobody never said a word about
+supper, nor ever seemed to think about it--and so they kept it up, and
+kept it up; and it _was_ the worst mixed-up thing you ever see.  They
+made the king tell his yarn, and they made the old gentleman tell his’n;
+and anybody but a lot of prejudiced chuckleheads would a _seen_ that the
+old gentleman was spinning truth and t’other one lies.  And by and by
+they had me up to tell what I knowed.  The king he give me a left-handed
+look out of the corner of his eye, and so I knowed enough to talk on the
+right side.  I begun to tell about Sheffield, and how we lived there,
+and all about the English Wilkses, and so on; but I didn’t get pretty
+fur till the doctor begun to laugh; and Levi Bell, the lawyer, says:
+
+“Set down, my boy; I wouldn’t strain myself if I was you.  I reckon
+you ain’t used to lying, it don’t seem to come handy; what you want is
+practice.  You do it pretty awkward.”
+
+I didn’t care nothing for the compliment, but I was glad to be let off,
+anyway.
+
+The doctor he started to say something, and turns and says:
+
+“If you’d been in town at first, Levi Bell--” The king broke in and
+reached out his hand, and says:
+
+“Why, is this my poor dead brother’s old friend that he’s wrote so often
+about?”
+
+The lawyer and him shook hands, and the lawyer smiled and looked
+pleased, and they talked right along awhile, and then got to one side
+and talked low; and at last the lawyer speaks up and says:
+
+“That ‘ll fix it.  I’ll take the order and send it, along with your
+brother’s, and then they’ll know it’s all right.”
+
+So they got some paper and a pen, and the king he set down and twisted
+his head to one side, and chawed his tongue, and scrawled off something;
+and then they give the pen to the duke--and then for the first time the
+duke looked sick.  But he took the pen and wrote.  So then the lawyer
+turns to the new old gentleman and says:
+
+“You and your brother please write a line or two and sign your names.”
+
+The old gentleman wrote, but nobody couldn’t read it.  The lawyer looked
+powerful astonished, and says:
+
+“Well, it beats _me_”--and snaked a lot of old letters out of his pocket,
+and examined them, and then examined the old man’s writing, and then
+_them_ again; and then says:  “These old letters is from Harvey Wilks;
+and here’s _these_ two handwritings, and anybody can see they didn’t
+write them” (the king and the duke looked sold and foolish, I tell
+you, to see how the lawyer had took them in), “and here’s _this_ old
+gentleman’s hand writing, and anybody can tell, easy enough, _he_ didn’t
+write them--fact is, the scratches he makes ain’t properly _writing_ at
+all.  Now, here’s some letters from--”
+
+The new old gentleman says:
+
+“If you please, let me explain.  Nobody can read my hand but my brother
+there--so he copies for me.  It’s _his_ hand you’ve got there, not mine.”
+
+“_Well_!” says the lawyer, “this _is_ a state of things.  I’ve got some
+of William’s letters, too; so if you’ll get him to write a line or so we
+can com--”
+
+“He _can’t_ write with his left hand,” says the old gentleman.  “If he
+could use his right hand, you would see that he wrote his own letters
+and mine too.  Look at both, please--they’re by the same hand.”
+
+The lawyer done it, and says:
+
+“I believe it’s so--and if it ain’t so, there’s a heap stronger
+resemblance than I’d noticed before, anyway.  Well, well, well!  I
+thought we was right on the track of a solution, but it’s gone to grass,
+partly.  But anyway, one thing is proved--_these_ two ain’t either of ‘em
+Wilkses”--and he wagged his head towards the king and the duke.
+
+Well, what do you think?  That muleheaded old fool wouldn’t give in
+_then_! Indeed he wouldn’t.  Said it warn’t no fair test.  Said his
+brother William was the cussedest joker in the world, and hadn’t tried
+to write--_he_ see William was going to play one of his jokes the minute
+he put the pen to paper.  And so he warmed up and went warbling and
+warbling right along till he was actuly beginning to believe what he was
+saying _himself_; but pretty soon the new gentleman broke in, and says:
+
+“I’ve thought of something.  Is there anybody here that helped to lay
+out my br--helped to lay out the late Peter Wilks for burying?”
+
+“Yes,” says somebody, “me and Ab Turner done it.  We’re both here.”
+
+Then the old man turns towards the king, and says:
+
+“Perhaps this gentleman can tell me what was tattooed on his breast?”
+
+Blamed if the king didn’t have to brace up mighty quick, or he’d a
+squshed down like a bluff bank that the river has cut under, it took
+him so sudden; and, mind you, it was a thing that was calculated to make
+most _anybody_ sqush to get fetched such a solid one as that without any
+notice, because how was _he_ going to know what was tattooed on the man?
+ He whitened a little; he couldn’t help it; and it was mighty still in
+there, and everybody bending a little forwards and gazing at him.  Says
+I to myself, _now_ he’ll throw up the sponge--there ain’t no more use.
+ Well, did he?  A body can’t hardly believe it, but he didn’t.  I reckon
+he thought he’d keep the thing up till he tired them people out, so
+they’d thin out, and him and the duke could break loose and get away.
+ Anyway, he set there, and pretty soon he begun to smile, and says:
+
+“Mf!  It’s a _very_ tough question, _ain’t_ it!  _yes_, sir, I k’n
+tell you what’s tattooed on his breast.  It’s jest a small, thin, blue
+arrow--that’s what it is; and if you don’t look clost, you can’t see it.
+ _now_ what do you say--hey?”
+
+Well, I never see anything like that old blister for clean out-and-out
+cheek.
+
+The new old gentleman turns brisk towards Ab Turner and his pard, and
+his eye lights up like he judged he’d got the king _this_ time, and
+says:
+
+“There--you’ve heard what he said!  Was there any such mark on Peter
+Wilks’ breast?”
+
+Both of them spoke up and says:
+
+“We didn’t see no such mark.”
+
+“Good!” says the old gentleman.  “Now, what you _did_ see on his breast
+was a small dim P, and a B (which is an initial he dropped when he was
+young), and a W, with dashes between them, so:  P--B--W”--and he marked
+them that way on a piece of paper.  “Come, ain’t that what you saw?”
+
+Both of them spoke up again, and says:
+
+“No, we _didn’t_.  We never seen any marks at all.”
+
+Well, everybody _was_ in a state of mind now, and they sings out:
+
+“The whole _bilin_’ of ‘m ‘s frauds!  Le’s duck ‘em! le’s drown ‘em!
+le’s ride ‘em on a rail!” and everybody was whooping at once, and there
+was a rattling powwow.  But the lawyer he jumps on the table and yells,
+and says:
+
+“Gentlemen--gentle_men!_  Hear me just a word--just a _single_ word--if you
+_please_!  There’s one way yet--let’s go and dig up the corpse and look.”
+
+That took them.
+
+“Hooray!” they all shouted, and was starting right off; but the lawyer
+and the doctor sung out:
+
+“Hold on, hold on!  Collar all these four men and the boy, and fetch
+_them_ along, too!”
+
+“We’ll do it!” they all shouted; “and if we don’t find them marks we’ll
+lynch the whole gang!”
+
+I _was_ scared, now, I tell you.  But there warn’t no getting away, you
+know. They gripped us all, and marched us right along, straight for the
+graveyard, which was a mile and a half down the river, and the whole
+town at our heels, for we made noise enough, and it was only nine in the
+evening.
+
+As we went by our house I wished I hadn’t sent Mary Jane out of town;
+because now if I could tip her the wink she’d light out and save me, and
+blow on our dead-beats.
+
+Well, we swarmed along down the river road, just carrying on like
+wildcats; and to make it more scary the sky was darking up, and the
+lightning beginning to wink and flitter, and the wind to shiver amongst
+the leaves. This was the most awful trouble and most dangersome I ever
+was in; and I was kinder stunned; everything was going so different from
+what I had allowed for; stead of being fixed so I could take my own time
+if I wanted to, and see all the fun, and have Mary Jane at my back to
+save me and set me free when the close-fit come, here was nothing in the
+world betwixt me and sudden death but just them tattoo-marks.  If they
+didn’t find them--
+
+I couldn’t bear to think about it; and yet, somehow, I couldn’t think
+about nothing else.  It got darker and darker, and it was a beautiful
+time to give the crowd the slip; but that big husky had me by the
+wrist--Hines--and a body might as well try to give Goliar the slip.  He
+dragged me right along, he was so excited, and I had to run to keep up.
+
+When they got there they swarmed into the graveyard and washed over it
+like an overflow.  And when they got to the grave they found they had
+about a hundred times as many shovels as they wanted, but nobody hadn’t
+thought to fetch a lantern.  But they sailed into digging anyway by the
+flicker of the lightning, and sent a man to the nearest house, a half a
+mile off, to borrow one.
+
+So they dug and dug like everything; and it got awful dark, and the rain
+started, and the wind swished and swushed along, and the lightning come
+brisker and brisker, and the thunder boomed; but them people never took
+no notice of it, they was so full of this business; and one minute
+you could see everything and every face in that big crowd, and the
+shovelfuls of dirt sailing up out of the grave, and the next second the
+dark wiped it all out, and you couldn’t see nothing at all.
+
+At last they got out the coffin and begun to unscrew the lid, and then
+such another crowding and shouldering and shoving as there was, to
+scrouge in and get a sight, you never see; and in the dark, that way, it
+was awful.  Hines he hurt my wrist dreadful pulling and tugging so,
+and I reckon he clean forgot I was in the world, he was so excited and
+panting.
+
+All of a sudden the lightning let go a perfect sluice of white glare,
+and somebody sings out:
+
+“By the living jingo, here’s the bag of gold on his breast!”
+
+Hines let out a whoop, like everybody else, and dropped my wrist and
+give a big surge to bust his way in and get a look, and the way I lit
+out and shinned for the road in the dark there ain’t nobody can tell.
+
+I had the road all to myself, and I fairly flew--leastways, I had it all
+to myself except the solid dark, and the now-and-then glares, and the
+buzzing of the rain, and the thrashing of the wind, and the splitting of
+the thunder; and sure as you are born I did clip it along!
+
+When I struck the town I see there warn’t nobody out in the storm, so
+I never hunted for no back streets, but humped it straight through the
+main one; and when I begun to get towards our house I aimed my eye and
+set it. No light there; the house all dark--which made me feel sorry and
+disappointed, I didn’t know why.  But at last, just as I was sailing by,
+_flash_ comes the light in Mary Jane’s window! and my heart swelled up
+sudden, like to bust; and the same second the house and all was behind
+me in the dark, and wasn’t ever going to be before me no more in this
+world. She _was_ the best girl I ever see, and had the most sand.
+
+The minute I was far enough above the town to see I could make the
+towhead, I begun to look sharp for a boat to borrow, and the first
+time the lightning showed me one that wasn’t chained I snatched it and
+shoved. It was a canoe, and warn’t fastened with nothing but a rope.
+ The towhead was a rattling big distance off, away out there in the
+middle of the river, but I didn’t lose no time; and when I struck the
+raft at last I was so fagged I would a just laid down to blow and gasp
+if I could afforded it.  But I didn’t.  As I sprung aboard I sung out:
+
+“Out with you, Jim, and set her loose!  Glory be to goodness, we’re shut
+of them!”
+
+Jim lit out, and was a-coming for me with both arms spread, he was so
+full of joy; but when I glimpsed him in the lightning my heart shot up
+in my mouth and I went overboard backwards; for I forgot he was old King
+Lear and a drownded A-rab all in one, and it most scared the livers and
+lights out of me.  But Jim fished me out, and was going to hug me and
+bless me, and so on, he was so glad I was back and we was shut of the
+king and the duke, but I says:
+
+“Not now; have it for breakfast, have it for breakfast!  Cut loose and
+let her slide!”
+
+So in two seconds away we went a-sliding down the river, and it _did_
+seem so good to be free again and all by ourselves on the big river, and
+nobody to bother us.  I had to skip around a bit, and jump up and crack
+my heels a few times--I couldn’t help it; but about the third crack
+I noticed a sound that I knowed mighty well, and held my breath and
+listened and waited; and sure enough, when the next flash busted out
+over the water, here they come!--and just a-laying to their oars and
+making their skiff hum!  It was the king and the duke.
+
+So I wilted right down on to the planks then, and give up; and it was
+all I could do to keep from crying.
+
+
+
+
+CHAPTER XXX.
+
+WHEN they got aboard the king went for me, and shook me by the collar,
+and says:
+
+“Tryin’ to give us the slip, was ye, you pup!  Tired of our company,
+hey?”
+
+I says:
+
+“No, your majesty, we warn’t--_please_ don’t, your majesty!”
+
+“Quick, then, and tell us what _was_ your idea, or I’ll shake the
+insides out o’ you!”
+
+“Honest, I’ll tell you everything just as it happened, your majesty.
+ The man that had a-holt of me was very good to me, and kept saying he
+had a boy about as big as me that died last year, and he was sorry
+to see a boy in such a dangerous fix; and when they was all took by
+surprise by finding the gold, and made a rush for the coffin, he lets go
+of me and whispers, ‘Heel it now, or they’ll hang ye, sure!’ and I lit
+out.  It didn’t seem no good for _me_ to stay--I couldn’t do nothing,
+and I didn’t want to be hung if I could get away.  So I never stopped
+running till I found the canoe; and when I got here I told Jim to hurry,
+or they’d catch me and hang me yet, and said I was afeard you and the
+duke wasn’t alive now, and I was awful sorry, and so was Jim, and was
+awful glad when we see you coming; you may ask Jim if I didn’t.”
+
+Jim said it was so; and the king told him to shut up, and said, “Oh,
+yes, it’s _mighty_ likely!” and shook me up again, and said he reckoned
+he’d drownd me.  But the duke says:
+
+“Leggo the boy, you old idiot!  Would _you_ a done any different?  Did
+you inquire around for _him_ when you got loose?  I don’t remember it.”
+
+So the king let go of me, and begun to cuss that town and everybody in
+it. But the duke says:
+
+“You better a blame’ sight give _yourself_ a good cussing, for you’re
+the one that’s entitled to it most.  You hain’t done a thing from the
+start that had any sense in it, except coming out so cool and cheeky
+with that imaginary blue-arrow mark.  That _was_ bright--it was right
+down bully; and it was the thing that saved us.  For if it hadn’t been
+for that they’d a jailed us till them Englishmen’s baggage come--and
+then--the penitentiary, you bet! But that trick took ‘em to the
+graveyard, and the gold done us a still bigger kindness; for if the
+excited fools hadn’t let go all holts and made that rush to get a
+look we’d a slept in our cravats to-night--cravats warranted to _wear_,
+too--longer than _we’d_ need ‘em.”
+
+They was still a minute--thinking; then the king says, kind of
+absent-minded like:
+
+“Mf!  And we reckoned the _niggers_ stole it!”
+
+That made me squirm!
+
+“Yes,” says the duke, kinder slow and deliberate and sarcastic, “_we_
+did.”
+
+After about a half a minute the king drawls out:
+
+“Leastways, I did.”
+
+The duke says, the same way:
+
+“On the contrary, I did.”
+
+The king kind of ruffles up, and says:
+
+“Looky here, Bilgewater, what’r you referrin’ to?”
+
+The duke says, pretty brisk:
+
+“When it comes to that, maybe you’ll let me ask, what was _you_
+referring to?”
+
+“Shucks!” says the king, very sarcastic; “but I don’t know--maybe you was
+asleep, and didn’t know what you was about.”
+
+The duke bristles up now, and says:
+
+“Oh, let _up_ on this cussed nonsense; do you take me for a blame’ fool?
+Don’t you reckon I know who hid that money in that coffin?”
+
+“_Yes_, sir!  I know you _do_ know, because you done it yourself!”
+
+“It’s a lie!”--and the duke went for him.  The king sings out:
+
+“Take y’r hands off!--leggo my throat!--I take it all back!”
+
+The duke says:
+
+“Well, you just own up, first, that you _did_ hide that money there,
+intending to give me the slip one of these days, and come back and dig
+it up, and have it all to yourself.”
+
+“Wait jest a minute, duke--answer me this one question, honest and fair;
+if you didn’t put the money there, say it, and I’ll b’lieve you, and
+take back everything I said.”
+
+“You old scoundrel, I didn’t, and you know I didn’t.  There, now!”
+
+“Well, then, I b’lieve you.  But answer me only jest this one more--now
+_don’t_ git mad; didn’t you have it in your mind to hook the money and
+hide it?”
+
+The duke never said nothing for a little bit; then he says:
+
+“Well, I don’t care if I _did_, I didn’t _do_ it, anyway.  But you not
+only had it in mind to do it, but you _done_ it.”
+
+“I wisht I never die if I done it, duke, and that’s honest.  I won’t say
+I warn’t goin’ to do it, because I _was_; but you--I mean somebody--got in
+ahead o’ me.”
+
+“It’s a lie!  You done it, and you got to _say_ you done it, or--”
+
+The king began to gurgle, and then he gasps out:
+
+“‘Nough!--I _own up!_”
+
+I was very glad to hear him say that; it made me feel much more easier
+than what I was feeling before.  So the duke took his hands off and
+says:
+
+“If you ever deny it again I’ll drown you.  It’s _well_ for you to set
+there and blubber like a baby--it’s fitten for you, after the way
+you’ve acted. I never see such an old ostrich for wanting to gobble
+everything--and I a-trusting you all the time, like you was my own
+father.  You ought to been ashamed of yourself to stand by and hear it
+saddled on to a lot of poor niggers, and you never say a word for ‘em.
+ It makes me feel ridiculous to think I was soft enough to _believe_
+that rubbage.  Cuss you, I can see now why you was so anxious to make
+up the deffisit--you wanted to get what money I’d got out of the Nonesuch
+and one thing or another, and scoop it _all_!”
+
+The king says, timid, and still a-snuffling:
+
+“Why, duke, it was you that said make up the deffisit; it warn’t me.”
+
+“Dry up!  I don’t want to hear no more out of you!” says the duke.  “And
+_now_ you see what you GOT by it.  They’ve got all their own money back,
+and all of _ourn_ but a shekel or two _besides_.  G’long to bed, and
+don’t you deffersit _me_ no more deffersits, long ‘s _you_ live!”
+
+So the king sneaked into the wigwam and took to his bottle for comfort,
+and before long the duke tackled HIS bottle; and so in about a half an
+hour they was as thick as thieves again, and the tighter they got the
+lovinger they got, and went off a-snoring in each other’s arms.  They
+both got powerful mellow, but I noticed the king didn’t get mellow
+enough to forget to remember to not deny about hiding the money-bag
+again.  That made me feel easy and satisfied.  Of course when they got
+to snoring we had a long gabble, and I told Jim everything.
+
+
+
+
+CHAPTER XXXI.
+
+WE dasn’t stop again at any town for days and days; kept right along
+down the river.  We was down south in the warm weather now, and a mighty
+long ways from home.  We begun to come to trees with Spanish moss on
+them, hanging down from the limbs like long, gray beards.  It was the
+first I ever see it growing, and it made the woods look solemn and
+dismal.  So now the frauds reckoned they was out of danger, and they
+begun to work the villages again.
+
+First they done a lecture on temperance; but they didn’t make enough
+for them both to get drunk on.  Then in another village they started
+a dancing-school; but they didn’t know no more how to dance than a
+kangaroo does; so the first prance they made the general public jumped
+in and pranced them out of town.  Another time they tried to go at
+yellocution; but they didn’t yellocute long till the audience got up and
+give them a solid good cussing, and made them skip out.  They tackled
+missionarying, and mesmerizing, and doctoring, and telling fortunes, and
+a little of everything; but they couldn’t seem to have no luck.  So at
+last they got just about dead broke, and laid around the raft as she
+floated along, thinking and thinking, and never saying nothing, by the
+half a day at a time, and dreadful blue and desperate.
+
+And at last they took a change and begun to lay their heads together in
+the wigwam and talk low and confidential two or three hours at a time.
+Jim and me got uneasy.  We didn’t like the look of it.  We judged they
+was studying up some kind of worse deviltry than ever.  We turned it
+over and over, and at last we made up our minds they was going to break
+into somebody’s house or store, or was going into the counterfeit-money
+business, or something. So then we was pretty scared, and made up an
+agreement that we wouldn’t have nothing in the world to do with such
+actions, and if we ever got the least show we would give them the cold
+shake and clear out and leave them behind. Well, early one morning we
+hid the raft in a good, safe place about two mile below a little bit of
+a shabby village named Pikesville, and the king he went ashore and told
+us all to stay hid whilst he went up to town and smelt around to see
+if anybody had got any wind of the Royal Nonesuch there yet. (“House to
+rob, you _mean_,” says I to myself; “and when you get through robbing it
+you’ll come back here and wonder what has become of me and Jim and the
+raft--and you’ll have to take it out in wondering.”) And he said if he
+warn’t back by midday the duke and me would know it was all right, and
+we was to come along.
+
+So we stayed where we was.  The duke he fretted and sweated around, and
+was in a mighty sour way.  He scolded us for everything, and we couldn’t
+seem to do nothing right; he found fault with every little thing.
+Something was a-brewing, sure.  I was good and glad when midday come
+and no king; we could have a change, anyway--and maybe a chance for _the_
+change on top of it.  So me and the duke went up to the village, and
+hunted around there for the king, and by and by we found him in the
+back room of a little low doggery, very tight, and a lot of loafers
+bullyragging him for sport, and he a-cussing and a-threatening with all
+his might, and so tight he couldn’t walk, and couldn’t do nothing to
+them.  The duke he begun to abuse him for an old fool, and the king
+begun to sass back, and the minute they was fairly at it I lit out and
+shook the reefs out of my hind legs, and spun down the river road like
+a deer, for I see our chance; and I made up my mind that it would be a
+long day before they ever see me and Jim again.  I got down there all
+out of breath but loaded up with joy, and sung out:
+
+“Set her loose, Jim! we’re all right now!”
+
+But there warn’t no answer, and nobody come out of the wigwam.  Jim was
+gone!  I set up a shout--and then another--and then another one; and run
+this way and that in the woods, whooping and screeching; but it warn’t
+no use--old Jim was gone.  Then I set down and cried; I couldn’t help
+it. But I couldn’t set still long.  Pretty soon I went out on the road,
+trying to think what I better do, and I run across a boy walking, and
+asked him if he’d seen a strange nigger dressed so and so, and he says:
+
+“Yes.”
+
+“Whereabouts?” says I.
+
+“Down to Silas Phelps’ place, two mile below here.  He’s a runaway
+nigger, and they’ve got him.  Was you looking for him?”
+
+“You bet I ain’t!  I run across him in the woods about an hour or two
+ago, and he said if I hollered he’d cut my livers out--and told me to lay
+down and stay where I was; and I done it.  Been there ever since; afeard
+to come out.”
+
+“Well,” he says, “you needn’t be afeard no more, becuz they’ve got him.
+He run off f’m down South, som’ers.”
+
+“It’s a good job they got him.”
+
+“Well, I _reckon_!  There’s two hunderd dollars reward on him.  It’s
+like picking up money out’n the road.”
+
+“Yes, it is--and I could a had it if I’d been big enough; I see him
+_first_. Who nailed him?”
+
+“It was an old fellow--a stranger--and he sold out his chance in him for
+forty dollars, becuz he’s got to go up the river and can’t wait.  Think
+o’ that, now!  You bet _I’d_ wait, if it was seven year.”
+
+“That’s me, every time,” says I.  “But maybe his chance ain’t worth
+no more than that, if he’ll sell it so cheap.  Maybe there’s something
+ain’t straight about it.”
+
+“But it _is_, though--straight as a string.  I see the handbill myself.
+ It tells all about him, to a dot--paints him like a picture, and tells
+the plantation he’s frum, below Newr_leans_.  No-sirree-_bob_, they
+ain’t no trouble ‘bout _that_ speculation, you bet you.  Say, gimme a
+chaw tobacker, won’t ye?”
+
+I didn’t have none, so he left.  I went to the raft, and set down in the
+wigwam to think.  But I couldn’t come to nothing.  I thought till I wore
+my head sore, but I couldn’t see no way out of the trouble.  After all
+this long journey, and after all we’d done for them scoundrels, here it
+was all come to nothing, everything all busted up and ruined, because
+they could have the heart to serve Jim such a trick as that, and make
+him a slave again all his life, and amongst strangers, too, for forty
+dirty dollars.
+
+Once I said to myself it would be a thousand times better for Jim to
+be a slave at home where his family was, as long as he’d _got_ to be a
+slave, and so I’d better write a letter to Tom Sawyer and tell him to
+tell Miss Watson where he was.  But I soon give up that notion for two
+things: she’d be mad and disgusted at his rascality and ungratefulness
+for leaving her, and so she’d sell him straight down the river again;
+and if she didn’t, everybody naturally despises an ungrateful nigger,
+and they’d make Jim feel it all the time, and so he’d feel ornery and
+disgraced. And then think of _me_!  It would get all around that Huck
+Finn helped a nigger to get his freedom; and if I was ever to see
+anybody from that town again I’d be ready to get down and lick his boots
+for shame.  That’s just the way:  a person does a low-down thing, and
+then he don’t want to take no consequences of it. Thinks as long as he
+can hide it, it ain’t no disgrace.  That was my fix exactly. The more I
+studied about this the more my conscience went to grinding me, and the
+more wicked and low-down and ornery I got to feeling. And at last, when
+it hit me all of a sudden that here was the plain hand of Providence
+slapping me in the face and letting me know my wickedness was being
+watched all the time from up there in heaven, whilst I was stealing a
+poor old woman’s nigger that hadn’t ever done me no harm, and now was
+showing me there’s One that’s always on the lookout, and ain’t a-going
+to allow no such miserable doings to go only just so fur and no further,
+I most dropped in my tracks I was so scared.  Well, I tried the best I
+could to kinder soften it up somehow for myself by saying I was brung
+up wicked, and so I warn’t so much to blame; but something inside of me
+kept saying, “There was the Sunday-school, you could a gone to it; and
+if you’d a done it they’d a learnt you there that people that acts as
+I’d been acting about that nigger goes to everlasting fire.”
+
+It made me shiver.  And I about made up my mind to pray, and see if I
+couldn’t try to quit being the kind of a boy I was and be better.  So
+I kneeled down.  But the words wouldn’t come.  Why wouldn’t they?  It
+warn’t no use to try and hide it from Him.  Nor from _me_, neither.  I
+knowed very well why they wouldn’t come.  It was because my heart warn’t
+right; it was because I warn’t square; it was because I was playing
+double.  I was letting _on_ to give up sin, but away inside of me I was
+holding on to the biggest one of all.  I was trying to make my mouth
+_say_ I would do the right thing and the clean thing, and go and write
+to that nigger’s owner and tell where he was; but deep down in me I
+knowed it was a lie, and He knowed it.  You can’t pray a lie--I found
+that out.
+
+So I was full of trouble, full as I could be; and didn’t know what to
+do. At last I had an idea; and I says, I’ll go and write the letter--and
+then see if I can pray.  Why, it was astonishing, the way I felt as
+light as a feather right straight off, and my troubles all gone.  So I
+got a piece of paper and a pencil, all glad and excited, and set down
+and wrote:
+
+Miss Watson, your runaway nigger Jim is down here two mile below
+Pikesville, and Mr. Phelps has got him and he will give him up for the
+reward if you send.
+
+_Huck Finn._
+
+I felt good and all washed clean of sin for the first time I had ever
+felt so in my life, and I knowed I could pray now.  But I didn’t do it
+straight off, but laid the paper down and set there thinking--thinking
+how good it was all this happened so, and how near I come to being lost
+and going to hell.  And went on thinking.  And got to thinking over our
+trip down the river; and I see Jim before me all the time:  in the day
+and in the night-time, sometimes moonlight, sometimes storms, and we
+a-floating along, talking and singing and laughing.  But somehow I
+couldn’t seem to strike no places to harden me against him, but only the
+other kind.  I’d see him standing my watch on top of his’n, ‘stead of
+calling me, so I could go on sleeping; and see him how glad he was when
+I come back out of the fog; and when I come to him again in the swamp,
+up there where the feud was; and such-like times; and would always call
+me honey, and pet me and do everything he could think of for me, and how
+good he always was; and at last I struck the time I saved him by telling
+the men we had small-pox aboard, and he was so grateful, and said I was
+the best friend old Jim ever had in the world, and the _only_ one he’s
+got now; and then I happened to look around and see that paper.
+
+It was a close place.  I took it up, and held it in my hand.  I was
+a-trembling, because I’d got to decide, forever, betwixt two things, and
+I knowed it.  I studied a minute, sort of holding my breath, and then
+says to myself:
+
+“All right, then, I’ll _go_ to hell”--and tore it up.
+
+It was awful thoughts and awful words, but they was said.  And I let
+them stay said; and never thought no more about reforming.  I shoved the
+whole thing out of my head, and said I would take up wickedness again,
+which was in my line, being brung up to it, and the other warn’t.  And
+for a starter I would go to work and steal Jim out of slavery again;
+and if I could think up anything worse, I would do that, too; because as
+long as I was in, and in for good, I might as well go the whole hog.
+
+Then I set to thinking over how to get at it, and turned over some
+considerable many ways in my mind; and at last fixed up a plan that
+suited me.  So then I took the bearings of a woody island that was down
+the river a piece, and as soon as it was fairly dark I crept out with my
+raft and went for it, and hid it there, and then turned in.  I slept the
+night through, and got up before it was light, and had my breakfast,
+and put on my store clothes, and tied up some others and one thing or
+another in a bundle, and took the canoe and cleared for shore.  I landed
+below where I judged was Phelps’s place, and hid my bundle in the woods,
+and then filled up the canoe with water, and loaded rocks into her and
+sunk her where I could find her again when I wanted her, about a quarter
+of a mile below a little steam sawmill that was on the bank.
+
+Then I struck up the road, and when I passed the mill I see a sign on
+it, “Phelps’s Sawmill,” and when I come to the farm-houses, two or
+three hundred yards further along, I kept my eyes peeled, but didn’t
+see nobody around, though it was good daylight now.  But I didn’t mind,
+because I didn’t want to see nobody just yet--I only wanted to get the
+lay of the land. According to my plan, I was going to turn up there from
+the village, not from below.  So I just took a look, and shoved along,
+straight for town. Well, the very first man I see when I got there was
+the duke.  He was sticking up a bill for the Royal Nonesuch--three-night
+performance--like that other time.  They had the cheek, them frauds!  I
+was right on him before I could shirk.  He looked astonished, and says:
+
+“Hel-_lo_!  Where’d _you_ come from?”  Then he says, kind of glad and
+eager, “Where’s the raft?--got her in a good place?”
+
+I says:
+
+“Why, that’s just what I was going to ask your grace.”
+
+Then he didn’t look so joyful, and says:
+
+“What was your idea for asking _me_?” he says.
+
+“Well,” I says, “when I see the king in that doggery yesterday I says
+to myself, we can’t get him home for hours, till he’s soberer; so I went
+a-loafing around town to put in the time and wait.  A man up and offered
+me ten cents to help him pull a skiff over the river and back to fetch
+a sheep, and so I went along; but when we was dragging him to the boat,
+and the man left me a-holt of the rope and went behind him to shove him
+along, he was too strong for me and jerked loose and run, and we after
+him.  We didn’t have no dog, and so we had to chase him all over the
+country till we tired him out.  We never got him till dark; then we
+fetched him over, and I started down for the raft.  When I got there and
+see it was gone, I says to myself, ‘They’ve got into trouble and had to
+leave; and they’ve took my nigger, which is the only nigger I’ve got in
+the world, and now I’m in a strange country, and ain’t got no property
+no more, nor nothing, and no way to make my living;’ so I set down and
+cried.  I slept in the woods all night.  But what _did_ become of the
+raft, then?--and Jim--poor Jim!”
+
+“Blamed if I know--that is, what’s become of the raft.  That old fool had
+made a trade and got forty dollars, and when we found him in the doggery
+the loafers had matched half-dollars with him and got every cent but
+what he’d spent for whisky; and when I got him home late last night and
+found the raft gone, we said, ‘That little rascal has stole our raft and
+shook us, and run off down the river.’”
+
+“I wouldn’t shake my _nigger_, would I?--the only nigger I had in the
+world, and the only property.”
+
+“We never thought of that.  Fact is, I reckon we’d come to consider him
+_our_ nigger; yes, we did consider him so--goodness knows we had trouble
+enough for him.  So when we see the raft was gone and we flat broke,
+there warn’t anything for it but to try the Royal Nonesuch another
+shake. And I’ve pegged along ever since, dry as a powder-horn.  Where’s
+that ten cents? Give it here.”
+
+I had considerable money, so I give him ten cents, but begged him to
+spend it for something to eat, and give me some, because it was all the
+money I had, and I hadn’t had nothing to eat since yesterday.  He never
+said nothing.  The next minute he whirls on me and says:
+
+“Do you reckon that nigger would blow on us?  We’d skin him if he done
+that!”
+
+“How can he blow?  Hain’t he run off?”
+
+“No!  That old fool sold him, and never divided with me, and the money’s
+gone.”
+
+“_Sold_ him?”  I says, and begun to cry; “why, he was _my_ nigger, and
+that was my money.  Where is he?--I want my nigger.”
+
+“Well, you can’t _get_ your nigger, that’s all--so dry up your
+blubbering. Looky here--do you think _you’d_ venture to blow on us?
+ Blamed if I think I’d trust you.  Why, if you _was_ to blow on us--”
+
+He stopped, but I never see the duke look so ugly out of his eyes
+before. I went on a-whimpering, and says:
+
+“I don’t want to blow on nobody; and I ain’t got no time to blow, nohow.
+I got to turn out and find my nigger.”
+
+He looked kinder bothered, and stood there with his bills fluttering on
+his arm, thinking, and wrinkling up his forehead.  At last he says:
+
+“I’ll tell you something.  We got to be here three days.  If you’ll
+promise you won’t blow, and won’t let the nigger blow, I’ll tell you
+where to find him.”
+
+So I promised, and he says:
+
+“A farmer by the name of Silas Ph--” and then he stopped.  You see, he
+started to tell me the truth; but when he stopped that way, and begun to
+study and think again, I reckoned he was changing his mind.  And so he
+was. He wouldn’t trust me; he wanted to make sure of having me out of
+the way the whole three days.  So pretty soon he says:
+
+“The man that bought him is named Abram Foster--Abram G. Foster--and he
+lives forty mile back here in the country, on the road to Lafayette.”
+
+“All right,” I says, “I can walk it in three days.  And I’ll start this
+very afternoon.”
+
+“No you wont, you’ll start _now_; and don’t you lose any time about it,
+neither, nor do any gabbling by the way.  Just keep a tight tongue in
+your head and move right along, and then you won’t get into trouble with
+_us_, d’ye hear?”
+
+That was the order I wanted, and that was the one I played for.  I
+wanted to be left free to work my plans.
+
+“So clear out,” he says; “and you can tell Mr. Foster whatever you want
+to. Maybe you can get him to believe that Jim _is_ your nigger--some
+idiots don’t require documents--leastways I’ve heard there’s such down
+South here.  And when you tell him the handbill and the reward’s bogus,
+maybe he’ll believe you when you explain to him what the idea was for
+getting ‘em out.  Go ‘long now, and tell him anything you want to; but
+mind you don’t work your jaw any _between_ here and there.”
+
+So I left, and struck for the back country.  I didn’t look around, but I
+kinder felt like he was watching me.  But I knowed I could tire him out
+at that.  I went straight out in the country as much as a mile before
+I stopped; then I doubled back through the woods towards Phelps’.  I
+reckoned I better start in on my plan straight off without fooling
+around, because I wanted to stop Jim’s mouth till these fellows could
+get away.  I didn’t want no trouble with their kind.  I’d seen all I
+wanted to of them, and wanted to get entirely shut of them.
+
+
+
+
+CHAPTER XXXII.
+
+WHEN I got there it was all still and Sunday-like, and hot and sunshiny;
+the hands was gone to the fields; and there was them kind of faint
+dronings of bugs and flies in the air that makes it seem so lonesome and
+like everybody’s dead and gone; and if a breeze fans along and quivers
+the leaves it makes you feel mournful, because you feel like it’s
+spirits whispering--spirits that’s been dead ever so many years--and you
+always think they’re talking about _you_.  As a general thing it makes a
+body wish _he_ was dead, too, and done with it all.
+
+Phelps’ was one of these little one-horse cotton plantations, and they
+all look alike.  A rail fence round a two-acre yard; a stile made out
+of logs sawed off and up-ended in steps, like barrels of a different
+length, to climb over the fence with, and for the women to stand on when
+they are going to jump on to a horse; some sickly grass-patches in the
+big yard, but mostly it was bare and smooth, like an old hat with the
+nap rubbed off; big double log-house for the white folks--hewed logs,
+with the chinks stopped up with mud or mortar, and these mud-stripes
+been whitewashed some time or another; round-log kitchen, with a big
+broad, open but roofed passage joining it to the house; log smoke-house
+back of the kitchen; three little log nigger-cabins in a row t’other
+side the smoke-house; one little hut all by itself away down against
+the back fence, and some outbuildings down a piece the other side;
+ash-hopper and big kettle to bile soap in by the little hut; bench by
+the kitchen door, with bucket of water and a gourd; hound asleep there
+in the sun; more hounds asleep round about; about three shade trees away
+off in a corner; some currant bushes and gooseberry bushes in one place
+by the fence; outside of the fence a garden and a watermelon patch; then
+the cotton fields begins, and after the fields the woods.
+
+I went around and clumb over the back stile by the ash-hopper, and
+started for the kitchen.  When I got a little ways I heard the dim hum
+of a spinning-wheel wailing along up and sinking along down again;
+and then I knowed for certain I wished I was dead--for that _is_ the
+lonesomest sound in the whole world.
+
+I went right along, not fixing up any particular plan, but just trusting
+to Providence to put the right words in my mouth when the time come; for
+I’d noticed that Providence always did put the right words in my mouth
+if I left it alone.
+
+When I got half-way, first one hound and then another got up and went
+for me, and of course I stopped and faced them, and kept still.  And
+such another powwow as they made!  In a quarter of a minute I was a kind
+of a hub of a wheel, as you may say--spokes made out of dogs--circle of
+fifteen of them packed together around me, with their necks and noses
+stretched up towards me, a-barking and howling; and more a-coming; you
+could see them sailing over fences and around corners from everywheres.
+
+A nigger woman come tearing out of the kitchen with a rolling-pin in her
+hand, singing out, “Begone _you_ Tige! you Spot! begone sah!” and she
+fetched first one and then another of them a clip and sent them howling,
+and then the rest followed; and the next second half of them come back,
+wagging their tails around me, and making friends with me.  There ain’t
+no harm in a hound, nohow.
+
+And behind the woman comes a little nigger girl and two little nigger
+boys without anything on but tow-linen shirts, and they hung on to their
+mother’s gown, and peeped out from behind her at me, bashful, the way
+they always do.  And here comes the white woman running from the house,
+about forty-five or fifty year old, bareheaded, and her spinning-stick
+in her hand; and behind her comes her little white children, acting the
+same way the little niggers was doing.  She was smiling all over so she
+could hardly stand--and says:
+
+“It’s _you_, at last!--_ain’t_ it?”
+
+I out with a “Yes’m” before I thought.
+
+She grabbed me and hugged me tight; and then gripped me by both hands
+and shook and shook; and the tears come in her eyes, and run down over;
+and she couldn’t seem to hug and shake enough, and kept saying, “You
+don’t look as much like your mother as I reckoned you would; but law
+sakes, I don’t care for that, I’m so glad to see you!  Dear, dear, it
+does seem like I could eat you up!  Children, it’s your cousin Tom!--tell
+him howdy.”
+
+But they ducked their heads, and put their fingers in their mouths, and
+hid behind her.  So she run on:
+
+“Lize, hurry up and get him a hot breakfast right away--or did you get
+your breakfast on the boat?”
+
+I said I had got it on the boat.  So then she started for the house,
+leading me by the hand, and the children tagging after.  When we got
+there she set me down in a split-bottomed chair, and set herself down on
+a little low stool in front of me, holding both of my hands, and says:
+
+“Now I can have a _good_ look at you; and, laws-a-me, I’ve been hungry
+for it a many and a many a time, all these long years, and it’s come
+at last! We been expecting you a couple of days and more.  What kep’
+you?--boat get aground?”
+
+“Yes’m--she--”
+
+“Don’t say yes’m--say Aunt Sally.  Where’d she get aground?”
+
+I didn’t rightly know what to say, because I didn’t know whether the
+boat would be coming up the river or down.  But I go a good deal on
+instinct; and my instinct said she would be coming up--from down towards
+Orleans. That didn’t help me much, though; for I didn’t know the names
+of bars down that way.  I see I’d got to invent a bar, or forget the
+name of the one we got aground on--or--Now I struck an idea, and fetched
+it out:
+
+“It warn’t the grounding--that didn’t keep us back but a little.  We
+blowed out a cylinder-head.”
+
+“Good gracious! anybody hurt?”
+
+“No’m.  Killed a nigger.”
+
+“Well, it’s lucky; because sometimes people do get hurt.  Two years ago
+last Christmas your uncle Silas was coming up from Newrleans on the old
+Lally Rook, and she blowed out a cylinder-head and crippled a man.  And
+I think he died afterwards.  He was a Baptist.  Your uncle Silas knowed
+a family in Baton Rouge that knowed his people very well.  Yes, I
+remember now, he _did_ die.  Mortification set in, and they had to
+amputate him. But it didn’t save him.  Yes, it was mortification--that
+was it.  He turned blue all over, and died in the hope of a glorious
+resurrection. They say he was a sight to look at.  Your uncle’s been up
+to the town every day to fetch you. And he’s gone again, not more’n an
+hour ago; he’ll be back any minute now. You must a met him on the road,
+didn’t you?--oldish man, with a--”
+
+“No, I didn’t see nobody, Aunt Sally.  The boat landed just at daylight,
+and I left my baggage on the wharf-boat and went looking around the town
+and out a piece in the country, to put in the time and not get here too
+soon; and so I come down the back way.”
+
+“Who’d you give the baggage to?”
+
+“Nobody.”
+
+“Why, child, it ‘ll be stole!”
+
+“Not where I hid it I reckon it won’t,” I says.
+
+“How’d you get your breakfast so early on the boat?”
+
+It was kinder thin ice, but I says:
+
+“The captain see me standing around, and told me I better have something
+to eat before I went ashore; so he took me in the texas to the officers’
+lunch, and give me all I wanted.”
+
+I was getting so uneasy I couldn’t listen good.  I had my mind on the
+children all the time; I wanted to get them out to one side and pump
+them a little, and find out who I was.  But I couldn’t get no show, Mrs.
+Phelps kept it up and run on so.  Pretty soon she made the cold chills
+streak all down my back, because she says:
+
+“But here we’re a-running on this way, and you hain’t told me a word
+about Sis, nor any of them.  Now I’ll rest my works a little, and you
+start up yourn; just tell me _everything_--tell me all about ‘m all every
+one of ‘m; and how they are, and what they’re doing, and what they told
+you to tell me; and every last thing you can think of.”
+
+Well, I see I was up a stump--and up it good.  Providence had stood by
+me this fur all right, but I was hard and tight aground now.  I see it
+warn’t a bit of use to try to go ahead--I’d got to throw up my hand.  So
+I says to myself, here’s another place where I got to resk the truth.
+ I opened my mouth to begin; but she grabbed me and hustled me in behind
+the bed, and says:
+
+“Here he comes!  Stick your head down lower--there, that’ll do; you can’t
+be seen now.  Don’t you let on you’re here.  I’ll play a joke on him.
+Children, don’t you say a word.”
+
+I see I was in a fix now.  But it warn’t no use to worry; there warn’t
+nothing to do but just hold still, and try and be ready to stand from
+under when the lightning struck.
+
+I had just one little glimpse of the old gentleman when he come in; then
+the bed hid him.  Mrs. Phelps she jumps for him, and says:
+
+“Has he come?”
+
+“No,” says her husband.
+
+“Good-_ness_ gracious!” she says, “what in the warld can have become of
+him?”
+
+“I can’t imagine,” says the old gentleman; “and I must say it makes me
+dreadful uneasy.”
+
+“Uneasy!” she says; “I’m ready to go distracted!  He _must_ a come; and
+you’ve missed him along the road.  I _know_ it’s so--something tells me
+so.”
+
+“Why, Sally, I _couldn’t_ miss him along the road--_you_ know that.”
+
+“But oh, dear, dear, what _will_ Sis say!  He must a come!  You must a
+missed him.  He--”
+
+“Oh, don’t distress me any more’n I’m already distressed.  I don’t know
+what in the world to make of it.  I’m at my wit’s end, and I don’t mind
+acknowledging ‘t I’m right down scared.  But there’s no hope that he’s
+come; for he _couldn’t_ come and me miss him.  Sally, it’s terrible--just
+terrible--something’s happened to the boat, sure!”
+
+“Why, Silas!  Look yonder!--up the road!--ain’t that somebody coming?”
+
+He sprung to the window at the head of the bed, and that give Mrs.
+Phelps the chance she wanted.  She stooped down quick at the foot of the
+bed and give me a pull, and out I come; and when he turned back from the
+window there she stood, a-beaming and a-smiling like a house afire, and
+I standing pretty meek and sweaty alongside.  The old gentleman stared,
+and says:
+
+“Why, who’s that?”
+
+“Who do you reckon ‘t is?”
+
+“I hain’t no idea.  Who _is_ it?”
+
+“It’s _Tom Sawyer!_”
+
+By jings, I most slumped through the floor!  But there warn’t no time to
+swap knives; the old man grabbed me by the hand and shook, and kept on
+shaking; and all the time how the woman did dance around and laugh and
+cry; and then how they both did fire off questions about Sid, and Mary,
+and the rest of the tribe.
+
+But if they was joyful, it warn’t nothing to what I was; for it was like
+being born again, I was so glad to find out who I was.  Well, they froze
+to me for two hours; and at last, when my chin was so tired it couldn’t
+hardly go any more, I had told them more about my family--I mean the
+Sawyer family--than ever happened to any six Sawyer families.  And I
+explained all about how we blowed out a cylinder-head at the mouth of
+White River, and it took us three days to fix it.  Which was all right,
+and worked first-rate; because _they_ didn’t know but what it would take
+three days to fix it.  If I’d a called it a bolthead it would a done
+just as well.
+
+Now I was feeling pretty comfortable all down one side, and pretty
+uncomfortable all up the other.  Being Tom Sawyer was easy and
+comfortable, and it stayed easy and comfortable till by and by I hear a
+steamboat coughing along down the river.  Then I says to myself, s’pose
+Tom Sawyer comes down on that boat?  And s’pose he steps in here any
+minute, and sings out my name before I can throw him a wink to keep
+quiet?
+
+Well, I couldn’t _have_ it that way; it wouldn’t do at all.  I must go
+up the road and waylay him.  So I told the folks I reckoned I would go
+up to the town and fetch down my baggage.  The old gentleman was for
+going along with me, but I said no, I could drive the horse myself, and
+I druther he wouldn’t take no trouble about me.
+
+
+
+
+CHAPTER XXXIII.
+
+SO I started for town in the wagon, and when I was half-way I see a
+wagon coming, and sure enough it was Tom Sawyer, and I stopped and
+waited till he come along.  I says “Hold on!” and it stopped alongside,
+and his mouth opened up like a trunk, and stayed so; and he swallowed
+two or three times like a person that’s got a dry throat, and then says:
+
+“I hain’t ever done you no harm.  You know that.  So, then, what you
+want to come back and ha’nt _me_ for?”
+
+I says:
+
+“I hain’t come back--I hain’t been _gone_.”
+
+When he heard my voice it righted him up some, but he warn’t quite
+satisfied yet.  He says:
+
+“Don’t you play nothing on me, because I wouldn’t on you.  Honest injun
+now, you ain’t a ghost?”
+
+“Honest injun, I ain’t,” I says.
+
+“Well--I--I--well, that ought to settle it, of course; but I can’t somehow
+seem to understand it no way.  Looky here, warn’t you ever murdered _at
+all?_”
+
+“No.  I warn’t ever murdered at all--I played it on them.  You come in
+here and feel of me if you don’t believe me.”
+
+So he done it; and it satisfied him; and he was that glad to see me
+again he didn’t know what to do.  And he wanted to know all about it
+right off, because it was a grand adventure, and mysterious, and so it
+hit him where he lived.  But I said, leave it alone till by and by; and
+told his driver to wait, and we drove off a little piece, and I told
+him the kind of a fix I was in, and what did he reckon we better do?  He
+said, let him alone a minute, and don’t disturb him.  So he thought and
+thought, and pretty soon he says:
+
+“It’s all right; I’ve got it.  Take my trunk in your wagon, and let on
+it’s your’n; and you turn back and fool along slow, so as to get to the
+house about the time you ought to; and I’ll go towards town a piece, and
+take a fresh start, and get there a quarter or a half an hour after you;
+and you needn’t let on to know me at first.”
+
+I says:
+
+“All right; but wait a minute.  There’s one more thing--a thing that
+_nobody_ don’t know but me.  And that is, there’s a nigger here that
+I’m a-trying to steal out of slavery, and his name is _Jim_--old Miss
+Watson’s Jim.”
+
+He says:
+
+“What!  Why, Jim is--”
+
+He stopped and went to studying.  I says:
+
+“I know what you’ll say.  You’ll say it’s dirty, low-down business; but
+what if it is?  I’m low down; and I’m a-going to steal him, and I want
+you keep mum and not let on.  Will you?”
+
+His eye lit up, and he says:
+
+“I’ll _help_ you steal him!”
+
+Well, I let go all holts then, like I was shot.  It was the most
+astonishing speech I ever heard--and I’m bound to say Tom Sawyer fell
+considerable in my estimation.  Only I couldn’t believe it.  Tom Sawyer
+a _nigger-stealer!_
+
+“Oh, shucks!”  I says; “you’re joking.”
+
+“I ain’t joking, either.”
+
+“Well, then,” I says, “joking or no joking, if you hear anything said
+about a runaway nigger, don’t forget to remember that _you_ don’t know
+nothing about him, and I don’t know nothing about him.”
+
+Then we took the trunk and put it in my wagon, and he drove off his
+way and I drove mine.  But of course I forgot all about driving slow on
+accounts of being glad and full of thinking; so I got home a heap too
+quick for that length of a trip.  The old gentleman was at the door, and
+he says:
+
+“Why, this is wonderful!  Whoever would a thought it was in that mare
+to do it?  I wish we’d a timed her.  And she hain’t sweated a hair--not
+a hair. It’s wonderful.  Why, I wouldn’t take a hundred dollars for that
+horse now--I wouldn’t, honest; and yet I’d a sold her for fifteen before,
+and thought ‘twas all she was worth.”
+
+That’s all he said.  He was the innocentest, best old soul I ever see.
+But it warn’t surprising; because he warn’t only just a farmer, he was
+a preacher, too, and had a little one-horse log church down back of the
+plantation, which he built it himself at his own expense, for a church
+and schoolhouse, and never charged nothing for his preaching, and it was
+worth it, too.  There was plenty other farmer-preachers like that, and
+done the same way, down South.
+
+In about half an hour Tom’s wagon drove up to the front stile, and Aunt
+Sally she see it through the window, because it was only about fifty
+yards, and says:
+
+“Why, there’s somebody come!  I wonder who ‘tis?  Why, I do believe it’s
+a stranger.  Jimmy” (that’s one of the children) “run and tell Lize to
+put on another plate for dinner.”
+
+Everybody made a rush for the front door, because, of course, a stranger
+don’t come _every_ year, and so he lays over the yaller-fever, for
+interest, when he does come.  Tom was over the stile and starting for
+the house; the wagon was spinning up the road for the village, and we
+was all bunched in the front door.  Tom had his store clothes on, and an
+audience--and that was always nuts for Tom Sawyer.  In them circumstances
+it warn’t no trouble to him to throw in an amount of style that was
+suitable.  He warn’t a boy to meeky along up that yard like a sheep; no,
+he come ca’m and important, like the ram.  When he got a-front of us he
+lifts his hat ever so gracious and dainty, like it was the lid of a box
+that had butterflies asleep in it and he didn’t want to disturb them,
+and says:
+
+“Mr. Archibald Nichols, I presume?”
+
+“No, my boy,” says the old gentleman, “I’m sorry to say ‘t your driver
+has deceived you; Nichols’s place is down a matter of three mile more.
+Come in, come in.”
+
+Tom he took a look back over his shoulder, and says, “Too late--he’s out
+of sight.”
+
+“Yes, he’s gone, my son, and you must come in and eat your dinner with
+us; and then we’ll hitch up and take you down to Nichols’s.”
+
+“Oh, I _can’t_ make you so much trouble; I couldn’t think of it.  I’ll
+walk--I don’t mind the distance.”
+
+“But we won’t _let_ you walk--it wouldn’t be Southern hospitality to do
+it. Come right in.”
+
+“Oh, _do_,” says Aunt Sally; “it ain’t a bit of trouble to us, not a
+bit in the world.  You must stay.  It’s a long, dusty three mile, and
+we can’t let you walk.  And, besides, I’ve already told ‘em to put on
+another plate when I see you coming; so you mustn’t disappoint us.  Come
+right in and make yourself at home.”
+
+So Tom he thanked them very hearty and handsome, and let himself be
+persuaded, and come in; and when he was in he said he was a stranger
+from Hicksville, Ohio, and his name was William Thompson--and he made
+another bow.
+
+Well, he run on, and on, and on, making up stuff about Hicksville and
+everybody in it he could invent, and I getting a little nervious, and
+wondering how this was going to help me out of my scrape; and at last,
+still talking along, he reached over and kissed Aunt Sally right on the
+mouth, and then settled back again in his chair comfortable, and was
+going on talking; but she jumped up and wiped it off with the back of
+her hand, and says:
+
+“You owdacious puppy!”
+
+He looked kind of hurt, and says:
+
+“I’m surprised at you, m’am.”
+
+“You’re s’rp--Why, what do you reckon I am?  I’ve a good notion to take
+and--Say, what do you mean by kissing me?”
+
+He looked kind of humble, and says:
+
+“I didn’t mean nothing, m’am.  I didn’t mean no harm.  I--I--thought you’d
+like it.”
+
+“Why, you born fool!”  She took up the spinning stick, and it looked
+like it was all she could do to keep from giving him a crack with it.
+ “What made you think I’d like it?”
+
+“Well, I don’t know.  Only, they--they--told me you would.”
+
+“_They_ told you I would.  Whoever told you’s _another_ lunatic.  I
+never heard the beat of it.  Who’s _they_?”
+
+“Why, everybody.  They all said so, m’am.”
+
+It was all she could do to hold in; and her eyes snapped, and her
+fingers worked like she wanted to scratch him; and she says:
+
+“Who’s ‘everybody’?  Out with their names, or ther’ll be an idiot
+short.”
+
+He got up and looked distressed, and fumbled his hat, and says:
+
+“I’m sorry, and I warn’t expecting it.  They told me to.  They all told
+me to.  They all said, kiss her; and said she’d like it.  They all said
+it--every one of them.  But I’m sorry, m’am, and I won’t do it no more--I
+won’t, honest.”
+
+“You won’t, won’t you?  Well, I sh’d _reckon_ you won’t!”
+
+“No’m, I’m honest about it; I won’t ever do it again--till you ask me.”
+
+“Till I _ask_ you!  Well, I never see the beat of it in my born days!
+ I lay you’ll be the Methusalem-numskull of creation before ever I ask
+you--or the likes of you.”
+
+“Well,” he says, “it does surprise me so.  I can’t make it out, somehow.
+They said you would, and I thought you would.  But--” He stopped and
+looked around slow, like he wished he could run across a friendly eye
+somewheres, and fetched up on the old gentleman’s, and says, “Didn’t
+_you_ think she’d like me to kiss her, sir?”
+
+“Why, no; I--I--well, no, I b’lieve I didn’t.”
+
+Then he looks on around the same way to me, and says:
+
+“Tom, didn’t _you_ think Aunt Sally ‘d open out her arms and say, ‘Sid
+Sawyer--’”
+
+“My land!” she says, breaking in and jumping for him, “you impudent
+young rascal, to fool a body so--” and was going to hug him, but he
+fended her off, and says:
+
+“No, not till you’ve asked me first.”
+
+So she didn’t lose no time, but asked him; and hugged him and kissed
+him over and over again, and then turned him over to the old man, and he
+took what was left.  And after they got a little quiet again she says:
+
+“Why, dear me, I never see such a surprise.  We warn’t looking for _you_
+at all, but only Tom.  Sis never wrote to me about anybody coming but
+him.”
+
+“It’s because it warn’t _intended_ for any of us to come but Tom,” he
+says; “but I begged and begged, and at the last minute she let me
+come, too; so, coming down the river, me and Tom thought it would be a
+first-rate surprise for him to come here to the house first, and for me
+to by and by tag along and drop in, and let on to be a stranger.  But it
+was a mistake, Aunt Sally.  This ain’t no healthy place for a stranger
+to come.”
+
+“No--not impudent whelps, Sid.  You ought to had your jaws boxed; I
+hain’t been so put out since I don’t know when.  But I don’t care, I
+don’t mind the terms--I’d be willing to stand a thousand such jokes to
+have you here. Well, to think of that performance!  I don’t deny it, I
+was most putrified with astonishment when you give me that smack.”
+
+We had dinner out in that broad open passage betwixt the house and
+the kitchen; and there was things enough on that table for seven
+families--and all hot, too; none of your flabby, tough meat that’s laid
+in a cupboard in a damp cellar all night and tastes like a hunk of
+old cold cannibal in the morning.  Uncle Silas he asked a pretty long
+blessing over it, but it was worth it; and it didn’t cool it a bit,
+neither, the way I’ve seen them kind of interruptions do lots of times.
+ There was a considerable good deal of talk all the afternoon, and me
+and Tom was on the lookout all the time; but it warn’t no use, they
+didn’t happen to say nothing about any runaway nigger, and we was afraid
+to try to work up to it.  But at supper, at night, one of the little
+boys says:
+
+“Pa, mayn’t Tom and Sid and me go to the show?”
+
+“No,” says the old man, “I reckon there ain’t going to be any; and you
+couldn’t go if there was; because the runaway nigger told Burton and
+me all about that scandalous show, and Burton said he would tell the
+people; so I reckon they’ve drove the owdacious loafers out of town
+before this time.”
+
+So there it was!--but I couldn’t help it.  Tom and me was to sleep in the
+same room and bed; so, being tired, we bid good-night and went up to
+bed right after supper, and clumb out of the window and down the
+lightning-rod, and shoved for the town; for I didn’t believe anybody was
+going to give the king and the duke a hint, and so if I didn’t hurry up
+and give them one they’d get into trouble sure.
+
+On the road Tom he told me all about how it was reckoned I was murdered,
+and how pap disappeared pretty soon, and didn’t come back no more, and
+what a stir there was when Jim run away; and I told Tom all about our
+Royal Nonesuch rapscallions, and as much of the raft voyage as I had
+time to; and as we struck into the town and up through the the middle of
+it--it was as much as half-after eight, then--here comes a raging rush of
+people with torches, and an awful whooping and yelling, and banging tin
+pans and blowing horns; and we jumped to one side to let them go by;
+and as they went by I see they had the king and the duke astraddle of a
+rail--that is, I knowed it _was_ the king and the duke, though they was
+all over tar and feathers, and didn’t look like nothing in the
+world that was human--just looked like a couple of monstrous big
+soldier-plumes.  Well, it made me sick to see it; and I was sorry for
+them poor pitiful rascals, it seemed like I couldn’t ever feel any
+hardness against them any more in the world.  It was a dreadful thing to
+see.  Human beings _can_ be awful cruel to one another.
+
+We see we was too late--couldn’t do no good.  We asked some stragglers
+about it, and they said everybody went to the show looking very
+innocent; and laid low and kept dark till the poor old king was in the
+middle of his cavortings on the stage; then somebody give a signal, and
+the house rose up and went for them.
+
+So we poked along back home, and I warn’t feeling so brash as I was
+before, but kind of ornery, and humble, and to blame, somehow--though
+I hadn’t done nothing.  But that’s always the way; it don’t make no
+difference whether you do right or wrong, a person’s conscience ain’t
+got no sense, and just goes for him anyway.  If I had a yaller dog that
+didn’t know no more than a person’s conscience does I would pison him.
+It takes up more room than all the rest of a person’s insides, and yet
+ain’t no good, nohow.  Tom Sawyer he says the same.
+
+
+
+
+CHAPTER XXXIV.
+
+WE stopped talking, and got to thinking.  By and by Tom says:
+
+“Looky here, Huck, what fools we are to not think of it before!  I bet I
+know where Jim is.”
+
+“No!  Where?”
+
+“In that hut down by the ash-hopper.  Why, looky here.  When we was at
+dinner, didn’t you see a nigger man go in there with some vittles?”
+
+“Yes.”
+
+“What did you think the vittles was for?”
+
+“For a dog.”
+
+“So ‘d I. Well, it wasn’t for a dog.”
+
+“Why?”
+
+“Because part of it was watermelon.”
+
+“So it was--I noticed it.  Well, it does beat all that I never thought
+about a dog not eating watermelon.  It shows how a body can see and
+don’t see at the same time.”
+
+“Well, the nigger unlocked the padlock when he went in, and he locked it
+again when he came out.  He fetched uncle a key about the time we got up
+from table--same key, I bet.  Watermelon shows man, lock shows prisoner;
+and it ain’t likely there’s two prisoners on such a little plantation,
+and where the people’s all so kind and good.  Jim’s the prisoner.  All
+right--I’m glad we found it out detective fashion; I wouldn’t give shucks
+for any other way.  Now you work your mind, and study out a plan to
+steal Jim, and I will study out one, too; and we’ll take the one we like
+the best.”
+
+What a head for just a boy to have!  If I had Tom Sawyer’s head I
+wouldn’t trade it off to be a duke, nor mate of a steamboat, nor clown
+in a circus, nor nothing I can think of.  I went to thinking out a plan,
+but only just to be doing something; I knowed very well where the right
+plan was going to come from.  Pretty soon Tom says:
+
+“Ready?”
+
+“Yes,” I says.
+
+“All right--bring it out.”
+
+“My plan is this,” I says.  “We can easy find out if it’s Jim in there.
+Then get up my canoe to-morrow night, and fetch my raft over from the
+island.  Then the first dark night that comes steal the key out of the
+old man’s britches after he goes to bed, and shove off down the river
+on the raft with Jim, hiding daytimes and running nights, the way me and
+Jim used to do before.  Wouldn’t that plan work?”
+
+“_Work_?  Why, cert’nly it would work, like rats a-fighting.  But it’s
+too blame’ simple; there ain’t nothing _to_ it.  What’s the good of a
+plan that ain’t no more trouble than that?  It’s as mild as goose-milk.
+ Why, Huck, it wouldn’t make no more talk than breaking into a soap
+factory.”
+
+I never said nothing, because I warn’t expecting nothing different; but
+I knowed mighty well that whenever he got _his_ plan ready it wouldn’t
+have none of them objections to it.
+
+And it didn’t.  He told me what it was, and I see in a minute it was
+worth fifteen of mine for style, and would make Jim just as free a man
+as mine would, and maybe get us all killed besides.  So I was satisfied,
+and said we would waltz in on it.  I needn’t tell what it was here,
+because I knowed it wouldn’t stay the way, it was.  I knowed he would be
+changing it around every which way as we went along, and heaving in new
+bullinesses wherever he got a chance.  And that is what he done.
+
+Well, one thing was dead sure, and that was that Tom Sawyer was in
+earnest, and was actuly going to help steal that nigger out of slavery.
+That was the thing that was too many for me.  Here was a boy that was
+respectable and well brung up; and had a character to lose; and folks at
+home that had characters; and he was bright and not leather-headed; and
+knowing and not ignorant; and not mean, but kind; and yet here he was,
+without any more pride, or rightness, or feeling, than to stoop to
+this business, and make himself a shame, and his family a shame,
+before everybody.  I _couldn’t_ understand it no way at all.  It was
+outrageous, and I knowed I ought to just up and tell him so; and so be
+his true friend, and let him quit the thing right where he was and save
+himself. And I _did_ start to tell him; but he shut me up, and says:
+
+“Don’t you reckon I know what I’m about?  Don’t I generly know what I’m
+about?”
+
+“Yes.”
+
+“Didn’t I _say_ I was going to help steal the nigger?”
+
+“Yes.”
+
+“_Well_, then.”
+
+That’s all he said, and that’s all I said.  It warn’t no use to say any
+more; because when he said he’d do a thing, he always done it.  But I
+couldn’t make out how he was willing to go into this thing; so I just
+let it go, and never bothered no more about it.  If he was bound to have
+it so, I couldn’t help it.
+
+When we got home the house was all dark and still; so we went on down to
+the hut by the ash-hopper for to examine it.  We went through the yard
+so as to see what the hounds would do.  They knowed us, and didn’t make
+no more noise than country dogs is always doing when anything comes by
+in the night.  When we got to the cabin we took a look at the front and
+the two sides; and on the side I warn’t acquainted with--which was the
+north side--we found a square window-hole, up tolerable high, with just
+one stout board nailed across it.  I says:
+
+“Here’s the ticket.  This hole’s big enough for Jim to get through if we
+wrench off the board.”
+
+Tom says:
+
+“It’s as simple as tit-tat-toe, three-in-a-row, and as easy as
+playing hooky.  I should _hope_ we can find a way that’s a little more
+complicated than _that_, Huck Finn.”
+
+“Well, then,” I says, “how ‘ll it do to saw him out, the way I done
+before I was murdered that time?”
+
+“That’s more _like_,” he says.  “It’s real mysterious, and troublesome,
+and good,” he says; “but I bet we can find a way that’s twice as long.
+ There ain’t no hurry; le’s keep on looking around.”
+
+Betwixt the hut and the fence, on the back side, was a lean-to that
+joined the hut at the eaves, and was made out of plank.  It was as long
+as the hut, but narrow--only about six foot wide.  The door to it was at
+the south end, and was padlocked.  Tom he went to the soap-kettle and
+searched around, and fetched back the iron thing they lift the lid with;
+so he took it and prized out one of the staples.  The chain fell down,
+and we opened the door and went in, and shut it, and struck a match,
+and see the shed was only built against a cabin and hadn’t no connection
+with it; and there warn’t no floor to the shed, nor nothing in it but
+some old rusty played-out hoes and spades and picks and a crippled plow.
+ The match went out, and so did we, and shoved in the staple again, and
+the door was locked as good as ever. Tom was joyful.  He says;
+
+“Now we’re all right.  We’ll _dig_ him out.  It ‘ll take about a week!”
+
+Then we started for the house, and I went in the back door--you only have
+to pull a buckskin latch-string, they don’t fasten the doors--but that
+warn’t romantical enough for Tom Sawyer; no way would do him but he must
+climb up the lightning-rod.  But after he got up half way about three
+times, and missed fire and fell every time, and the last time most
+busted his brains out, he thought he’d got to give it up; but after he
+was rested he allowed he would give her one more turn for luck, and this
+time he made the trip.
+
+In the morning we was up at break of day, and down to the nigger cabins
+to pet the dogs and make friends with the nigger that fed Jim--if it
+_was_ Jim that was being fed.  The niggers was just getting through
+breakfast and starting for the fields; and Jim’s nigger was piling up
+a tin pan with bread and meat and things; and whilst the others was
+leaving, the key come from the house.
+
+This nigger had a good-natured, chuckle-headed face, and his wool was
+all tied up in little bunches with thread.  That was to keep witches
+off.  He said the witches was pestering him awful these nights, and
+making him see all kinds of strange things, and hear all kinds of
+strange words and noises, and he didn’t believe he was ever witched so
+long before in his life.  He got so worked up, and got to running on so
+about his troubles, he forgot all about what he’d been a-going to do.
+ So Tom says:
+
+“What’s the vittles for?  Going to feed the dogs?”
+
+The nigger kind of smiled around gradually over his face, like when you
+heave a brickbat in a mud-puddle, and he says:
+
+“Yes, Mars Sid, A dog.  Cur’us dog, too.  Does you want to go en look at
+‘im?”
+
+“Yes.”
+
+I hunched Tom, and whispers:
+
+“You going, right here in the daybreak?  _that_ warn’t the plan.”
+
+“No, it warn’t; but it’s the plan _now_.”
+
+So, drat him, we went along, but I didn’t like it much.  When we got in
+we couldn’t hardly see anything, it was so dark; but Jim was there, sure
+enough, and could see us; and he sings out:
+
+“Why, _Huck_!  En good _lan_’! ain’ dat Misto Tom?”
+
+I just knowed how it would be; I just expected it.  I didn’t know
+nothing to do; and if I had I couldn’t a done it, because that nigger
+busted in and says:
+
+“Why, de gracious sakes! do he know you genlmen?”
+
+We could see pretty well now.  Tom he looked at the nigger, steady and
+kind of wondering, and says:
+
+“Does _who_ know us?”
+
+“Why, dis-yer runaway nigger.”
+
+“I don’t reckon he does; but what put that into your head?”
+
+“What _put_ it dar?  Didn’ he jis’ dis minute sing out like he knowed
+you?”
+
+Tom says, in a puzzled-up kind of way:
+
+“Well, that’s mighty curious.  _Who_ sung out? _when_ did he sing out?
+ _what_ did he sing out?” And turns to me, perfectly ca’m, and says,
+“Did _you_ hear anybody sing out?”
+
+Of course there warn’t nothing to be said but the one thing; so I says:
+
+“No; I ain’t heard nobody say nothing.”
+
+Then he turns to Jim, and looks him over like he never see him before,
+and says:
+
+“Did you sing out?”
+
+“No, sah,” says Jim; “I hain’t said nothing, sah.”
+
+“Not a word?”
+
+“No, sah, I hain’t said a word.”
+
+“Did you ever see us before?”
+
+“No, sah; not as I knows on.”
+
+So Tom turns to the nigger, which was looking wild and distressed, and
+says, kind of severe:
+
+“What do you reckon’s the matter with you, anyway?  What made you think
+somebody sung out?”
+
+“Oh, it’s de dad-blame’ witches, sah, en I wisht I was dead, I do.
+ Dey’s awluz at it, sah, en dey do mos’ kill me, dey sk’yers me so.
+ Please to don’t tell nobody ‘bout it sah, er ole Mars Silas he’ll scole
+me; ‘kase he say dey _ain’t_ no witches.  I jis’ wish to goodness he was
+heah now--_den_ what would he say!  I jis’ bet he couldn’ fine no way to
+git aroun’ it _dis_ time.  But it’s awluz jis’ so; people dat’s _sot_,
+stays sot; dey won’t look into noth’n’en fine it out f’r deyselves, en
+when _you_ fine it out en tell um ‘bout it, dey doan’ b’lieve you.”
+
+Tom give him a dime, and said we wouldn’t tell nobody; and told him to
+buy some more thread to tie up his wool with; and then looks at Jim, and
+says:
+
+“I wonder if Uncle Silas is going to hang this nigger.  If I was to
+catch a nigger that was ungrateful enough to run away, I wouldn’t give
+him up, I’d hang him.”  And whilst the nigger stepped to the door to
+look at the dime and bite it to see if it was good, he whispers to Jim
+and says:
+
+“Don’t ever let on to know us.  And if you hear any digging going on
+nights, it’s us; we’re going to set you free.”
+
+Jim only had time to grab us by the hand and squeeze it; then the nigger
+come back, and we said we’d come again some time if the nigger wanted
+us to; and he said he would, more particular if it was dark, because the
+witches went for him mostly in the dark, and it was good to have folks
+around then.
+
+
+
+
+CHAPTER XXXV.
+
+IT would be most an hour yet till breakfast, so we left and struck down
+into the woods; because Tom said we got to have _some_ light to see how
+to dig by, and a lantern makes too much, and might get us into trouble;
+what we must have was a lot of them rotten chunks that’s called
+fox-fire, and just makes a soft kind of a glow when you lay them in a
+dark place.  We fetched an armful and hid it in the weeds, and set down
+to rest, and Tom says, kind of dissatisfied:
+
+“Blame it, this whole thing is just as easy and awkward as it can be.
+And so it makes it so rotten difficult to get up a difficult plan.
+ There ain’t no watchman to be drugged--now there _ought_ to be a
+watchman.  There ain’t even a dog to give a sleeping-mixture to.  And
+there’s Jim chained by one leg, with a ten-foot chain, to the leg of his
+bed:  why, all you got to do is to lift up the bedstead and slip off
+the chain.  And Uncle Silas he trusts everybody; sends the key to the
+punkin-headed nigger, and don’t send nobody to watch the nigger.  Jim
+could a got out of that window-hole before this, only there wouldn’t be
+no use trying to travel with a ten-foot chain on his leg.  Why, drat it,
+Huck, it’s the stupidest arrangement I ever see. You got to invent _all_
+the difficulties.  Well, we can’t help it; we got to do the best we can
+with the materials we’ve got. Anyhow, there’s one thing--there’s more
+honor in getting him out through a lot of difficulties and dangers,
+where there warn’t one of them furnished to you by the people who it was
+their duty to furnish them, and you had to contrive them all out of your
+own head.  Now look at just that one thing of the lantern.  When you
+come down to the cold facts, we simply got to _let on_ that a lantern’s
+resky.  Why, we could work with a torchlight procession if we wanted to,
+I believe.  Now, whilst I think of it, we got to hunt up something to
+make a saw out of the first chance we get.”
+
+“What do we want of a saw?”
+
+“What do we _want_ of it?  Hain’t we got to saw the leg of Jim’s bed
+off, so as to get the chain loose?”
+
+“Why, you just said a body could lift up the bedstead and slip the chain
+off.”
+
+“Well, if that ain’t just like you, Huck Finn.  You _can_ get up the
+infant-schooliest ways of going at a thing.  Why, hain’t you ever read
+any books at all?--Baron Trenck, nor Casanova, nor Benvenuto Chelleeny,
+nor Henri IV., nor none of them heroes?  Who ever heard of getting a
+prisoner loose in such an old-maidy way as that?  No; the way all the
+best authorities does is to saw the bed-leg in two, and leave it just
+so, and swallow the sawdust, so it can’t be found, and put some dirt and
+grease around the sawed place so the very keenest seneskal can’t see
+no sign of it’s being sawed, and thinks the bed-leg is perfectly sound.
+Then, the night you’re ready, fetch the leg a kick, down she goes; slip
+off your chain, and there you are.  Nothing to do but hitch your
+rope ladder to the battlements, shin down it, break your leg in the
+moat--because a rope ladder is nineteen foot too short, you know--and
+there’s your horses and your trusty vassles, and they scoop you up and
+fling you across a saddle, and away you go to your native Langudoc, or
+Navarre, or wherever it is. It’s gaudy, Huck.  I wish there was a moat
+to this cabin. If we get time, the night of the escape, we’ll dig one.”
+
+I says:
+
+“What do we want of a moat when we’re going to snake him out from under
+the cabin?”
+
+But he never heard me.  He had forgot me and everything else.  He had
+his chin in his hand, thinking.  Pretty soon he sighs and shakes his
+head; then sighs again, and says:
+
+“No, it wouldn’t do--there ain’t necessity enough for it.”
+
+“For what?”  I says.
+
+“Why, to saw Jim’s leg off,” he says.
+
+“Good land!”  I says; “why, there ain’t _no_ necessity for it.  And what
+would you want to saw his leg off for, anyway?”
+
+“Well, some of the best authorities has done it.  They couldn’t get the
+chain off, so they just cut their hand off and shoved.  And a leg would
+be better still.  But we got to let that go.  There ain’t necessity
+enough in this case; and, besides, Jim’s a nigger, and wouldn’t
+understand the reasons for it, and how it’s the custom in Europe; so
+we’ll let it go.  But there’s one thing--he can have a rope ladder; we
+can tear up our sheets and make him a rope ladder easy enough.  And we
+can send it to him in a pie; it’s mostly done that way.  And I’ve et
+worse pies.”
+
+“Why, Tom Sawyer, how you talk,” I says; “Jim ain’t got no use for a
+rope ladder.”
+
+“He _has_ got use for it.  How _you_ talk, you better say; you don’t
+know nothing about it.  He’s _got_ to have a rope ladder; they all do.”
+
+“What in the nation can he _do_ with it?”
+
+“_Do_ with it?  He can hide it in his bed, can’t he?”  That’s what they
+all do; and _he’s_ got to, too.  Huck, you don’t ever seem to want to do
+anything that’s regular; you want to be starting something fresh all the
+time. S’pose he _don’t_ do nothing with it? ain’t it there in his bed,
+for a clew, after he’s gone? and don’t you reckon they’ll want clews?
+ Of course they will.  And you wouldn’t leave them any?  That would be a
+_pretty_ howdy-do, _wouldn’t_ it!  I never heard of such a thing.”
+
+“Well,” I says, “if it’s in the regulations, and he’s got to have
+it, all right, let him have it; because I don’t wish to go back on no
+regulations; but there’s one thing, Tom Sawyer--if we go to tearing up
+our sheets to make Jim a rope ladder, we’re going to get into trouble
+with Aunt Sally, just as sure as you’re born.  Now, the way I look at
+it, a hickry-bark ladder don’t cost nothing, and don’t waste nothing,
+and is just as good to load up a pie with, and hide in a straw tick,
+as any rag ladder you can start; and as for Jim, he ain’t had no
+experience, and so he don’t care what kind of a--”
+
+“Oh, shucks, Huck Finn, if I was as ignorant as you I’d keep
+still--that’s what I’D do.  Who ever heard of a state prisoner escaping
+by a hickry-bark ladder?  Why, it’s perfectly ridiculous.”
+
+“Well, all right, Tom, fix it your own way; but if you’ll take my
+advice, you’ll let me borrow a sheet off of the clothesline.”
+
+He said that would do.  And that gave him another idea, and he says:
+
+“Borrow a shirt, too.”
+
+“What do we want of a shirt, Tom?”
+
+“Want it for Jim to keep a journal on.”
+
+“Journal your granny--_Jim_ can’t write.”
+
+“S’pose he _can’t_ write--he can make marks on the shirt, can’t he, if
+we make him a pen out of an old pewter spoon or a piece of an old iron
+barrel-hoop?”
+
+“Why, Tom, we can pull a feather out of a goose and make him a better
+one; and quicker, too.”
+
+“_Prisoners_ don’t have geese running around the donjon-keep to pull
+pens out of, you muggins.  They _always_ make their pens out of the
+hardest, toughest, troublesomest piece of old brass candlestick or
+something like that they can get their hands on; and it takes them weeks
+and weeks and months and months to file it out, too, because they’ve got
+to do it by rubbing it on the wall.  _They_ wouldn’t use a goose-quill
+if they had it. It ain’t regular.”
+
+“Well, then, what’ll we make him the ink out of?”
+
+“Many makes it out of iron-rust and tears; but that’s the common sort
+and women; the best authorities uses their own blood.  Jim can do that;
+and when he wants to send any little common ordinary mysterious message
+to let the world know where he’s captivated, he can write it on the
+bottom of a tin plate with a fork and throw it out of the window.  The
+Iron Mask always done that, and it’s a blame’ good way, too.”
+
+“Jim ain’t got no tin plates.  They feed him in a pan.”
+
+“That ain’t nothing; we can get him some.”
+
+“Can’t nobody _read_ his plates.”
+
+“That ain’t got anything to _do_ with it, Huck Finn.  All _he’s_ got to
+do is to write on the plate and throw it out.  You don’t _have_ to be
+able to read it. Why, half the time you can’t read anything a prisoner
+writes on a tin plate, or anywhere else.”
+
+“Well, then, what’s the sense in wasting the plates?”
+
+“Why, blame it all, it ain’t the _prisoner’s_ plates.”
+
+“But it’s _somebody’s_ plates, ain’t it?”
+
+“Well, spos’n it is?  What does the _prisoner_ care whose--”
+
+He broke off there, because we heard the breakfast-horn blowing.  So we
+cleared out for the house.
+
+Along during the morning I borrowed a sheet and a white shirt off of the
+clothes-line; and I found an old sack and put them in it, and we went
+down and got the fox-fire, and put that in too.  I called it borrowing,
+because that was what pap always called it; but Tom said it warn’t
+borrowing, it was stealing.  He said we was representing prisoners; and
+prisoners don’t care how they get a thing so they get it, and nobody
+don’t blame them for it, either.  It ain’t no crime in a prisoner to
+steal the thing he needs to get away with, Tom said; it’s his right; and
+so, as long as we was representing a prisoner, we had a perfect right to
+steal anything on this place we had the least use for to get ourselves
+out of prison with.  He said if we warn’t prisoners it would be a very
+different thing, and nobody but a mean, ornery person would steal when
+he warn’t a prisoner.  So we allowed we would steal everything there was
+that come handy.  And yet he made a mighty fuss, one day, after that,
+when I stole a watermelon out of the nigger-patch and eat it; and he
+made me go and give the niggers a dime without telling them what it
+was for. Tom said that what he meant was, we could steal anything we
+_needed_. Well, I says, I needed the watermelon.  But he said I didn’t
+need it to get out of prison with; there’s where the difference was.
+ He said if I’d a wanted it to hide a knife in, and smuggle it to Jim
+to kill the seneskal with, it would a been all right.  So I let it go at
+that, though I couldn’t see no advantage in my representing a prisoner
+if I got to set down and chaw over a lot of gold-leaf distinctions like
+that every time I see a chance to hog a watermelon.
+
+Well, as I was saying, we waited that morning till everybody was settled
+down to business, and nobody in sight around the yard; then Tom he
+carried the sack into the lean-to whilst I stood off a piece to keep
+watch.  By and by he come out, and we went and set down on the woodpile
+to talk.  He says:
+
+“Everything’s all right now except tools; and that’s easy fixed.”
+
+“Tools?”  I says.
+
+“Yes.”
+
+“Tools for what?”
+
+“Why, to dig with.  We ain’t a-going to _gnaw_ him out, are we?”
+
+“Ain’t them old crippled picks and things in there good enough to dig a
+nigger out with?”  I says.
+
+He turns on me, looking pitying enough to make a body cry, and says:
+
+“Huck Finn, did you _ever_ hear of a prisoner having picks and shovels,
+and all the modern conveniences in his wardrobe to dig himself out with?
+ Now I want to ask you--if you got any reasonableness in you at all--what
+kind of a show would _that_ give him to be a hero?  Why, they might as
+well lend him the key and done with it.  Picks and shovels--why, they
+wouldn’t furnish ‘em to a king.”
+
+“Well, then,” I says, “if we don’t want the picks and shovels, what do
+we want?”
+
+“A couple of case-knives.”
+
+“To dig the foundations out from under that cabin with?”
+
+“Yes.”
+
+“Confound it, it’s foolish, Tom.”
+
+“It don’t make no difference how foolish it is, it’s the _right_ way--and
+it’s the regular way.  And there ain’t no _other_ way, that ever I heard
+of, and I’ve read all the books that gives any information about these
+things. They always dig out with a case-knife--and not through dirt, mind
+you; generly it’s through solid rock.  And it takes them weeks and weeks
+and weeks, and for ever and ever.  Why, look at one of them prisoners in
+the bottom dungeon of the Castle Deef, in the harbor of Marseilles, that
+dug himself out that way; how long was _he_ at it, you reckon?”
+
+“I don’t know.”
+
+“Well, guess.”
+
+“I don’t know.  A month and a half.”
+
+“_Thirty-seven year_--and he come out in China.  _That’s_ the kind.  I
+wish the bottom of _this_ fortress was solid rock.”
+
+“_Jim_ don’t know nobody in China.”
+
+“What’s _that_ got to do with it?  Neither did that other fellow.  But
+you’re always a-wandering off on a side issue.  Why can’t you stick to
+the main point?”
+
+“All right--I don’t care where he comes out, so he _comes_ out; and Jim
+don’t, either, I reckon.  But there’s one thing, anyway--Jim’s too old to
+be dug out with a case-knife.  He won’t last.”
+
+“Yes he will _last_, too.  You don’t reckon it’s going to take
+thirty-seven years to dig out through a _dirt_ foundation, do you?”
+
+“How long will it take, Tom?”
+
+“Well, we can’t resk being as long as we ought to, because it mayn’t
+take very long for Uncle Silas to hear from down there by New Orleans.
+ He’ll hear Jim ain’t from there.  Then his next move will be to
+advertise Jim, or something like that.  So we can’t resk being as long
+digging him out as we ought to.  By rights I reckon we ought to be
+a couple of years; but we can’t.  Things being so uncertain, what I
+recommend is this:  that we really dig right in, as quick as we can;
+and after that, we can _let on_, to ourselves, that we was at it
+thirty-seven years.  Then we can snatch him out and rush him away the
+first time there’s an alarm.  Yes, I reckon that ‘ll be the best way.”
+
+“Now, there’s _sense_ in that,” I says.  “Letting on don’t cost nothing;
+letting on ain’t no trouble; and if it’s any object, I don’t mind
+letting on we was at it a hundred and fifty year.  It wouldn’t strain
+me none, after I got my hand in.  So I’ll mosey along now, and smouch a
+couple of case-knives.”
+
+“Smouch three,” he says; “we want one to make a saw out of.”
+
+“Tom, if it ain’t unregular and irreligious to sejest it,” I says,
+“there’s an old rusty saw-blade around yonder sticking under the
+weather-boarding behind the smoke-house.”
+
+He looked kind of weary and discouraged-like, and says:
+
+“It ain’t no use to try to learn you nothing, Huck.  Run along and
+smouch the knives--three of them.”  So I done it.
+
+
+
+
+CHAPTER XXXVI.
+
+AS soon as we reckoned everybody was asleep that night we went down the
+lightning-rod, and shut ourselves up in the lean-to, and got out our
+pile of fox-fire, and went to work.  We cleared everything out of the
+way, about four or five foot along the middle of the bottom log.  Tom
+said he was right behind Jim’s bed now, and we’d dig in under it, and
+when we got through there couldn’t nobody in the cabin ever know there
+was any hole there, because Jim’s counter-pin hung down most to the
+ground, and you’d have to raise it up and look under to see the hole.
+ So we dug and dug with the case-knives till most midnight; and then
+we was dog-tired, and our hands was blistered, and yet you couldn’t see
+we’d done anything hardly.  At last I says:
+
+“This ain’t no thirty-seven year job; this is a thirty-eight year job,
+Tom Sawyer.”
+
+He never said nothing.  But he sighed, and pretty soon he stopped
+digging, and then for a good little while I knowed that he was thinking.
+Then he says:
+
+“It ain’t no use, Huck, it ain’t a-going to work.  If we was prisoners
+it would, because then we’d have as many years as we wanted, and no
+hurry; and we wouldn’t get but a few minutes to dig, every day, while
+they was changing watches, and so our hands wouldn’t get blistered, and
+we could keep it up right along, year in and year out, and do it right,
+and the way it ought to be done.  But _we_ can’t fool along; we got to
+rush; we ain’t got no time to spare.  If we was to put in another
+night this way we’d have to knock off for a week to let our hands get
+well--couldn’t touch a case-knife with them sooner.”
+
+“Well, then, what we going to do, Tom?”
+
+“I’ll tell you.  It ain’t right, and it ain’t moral, and I wouldn’t like
+it to get out; but there ain’t only just the one way:  we got to dig him
+out with the picks, and _let on_ it’s case-knives.”
+
+“_Now_ you’re _talking_!”  I says; “your head gets leveler and leveler
+all the time, Tom Sawyer,” I says.  “Picks is the thing, moral or no
+moral; and as for me, I don’t care shucks for the morality of it, nohow.
+ When I start in to steal a nigger, or a watermelon, or a Sunday-school
+book, I ain’t no ways particular how it’s done so it’s done.  What I
+want is my nigger; or what I want is my watermelon; or what I want is my
+Sunday-school book; and if a pick’s the handiest thing, that’s the thing
+I’m a-going to dig that nigger or that watermelon or that Sunday-school
+book out with; and I don’t give a dead rat what the authorities thinks
+about it nuther.”
+
+“Well,” he says, “there’s excuse for picks and letting-on in a case like
+this; if it warn’t so, I wouldn’t approve of it, nor I wouldn’t stand by
+and see the rules broke--because right is right, and wrong is wrong,
+and a body ain’t got no business doing wrong when he ain’t ignorant and
+knows better.  It might answer for _you_ to dig Jim out with a pick,
+_without_ any letting on, because you don’t know no better; but it
+wouldn’t for me, because I do know better.  Gimme a case-knife.”
+
+He had his own by him, but I handed him mine.  He flung it down, and
+says:
+
+“Gimme a _case-knife_.”
+
+I didn’t know just what to do--but then I thought.  I scratched around
+amongst the old tools, and got a pickaxe and give it to him, and he took
+it and went to work, and never said a word.
+
+He was always just that particular.  Full of principle.
+
+So then I got a shovel, and then we picked and shoveled, turn about,
+and made the fur fly.  We stuck to it about a half an hour, which was as
+long as we could stand up; but we had a good deal of a hole to show for
+it. When I got up stairs I looked out at the window and see Tom doing
+his level best with the lightning-rod, but he couldn’t come it, his
+hands was so sore.  At last he says:
+
+“It ain’t no use, it can’t be done.  What you reckon I better do?  Can’t
+you think of no way?”
+
+“Yes,” I says, “but I reckon it ain’t regular.  Come up the stairs, and
+let on it’s a lightning-rod.”
+
+So he done it.
+
+Next day Tom stole a pewter spoon and a brass candlestick in the house,
+for to make some pens for Jim out of, and six tallow candles; and I
+hung around the nigger cabins and laid for a chance, and stole three tin
+plates.  Tom says it wasn’t enough; but I said nobody wouldn’t ever see
+the plates that Jim throwed out, because they’d fall in the dog-fennel
+and jimpson weeds under the window-hole--then we could tote them back and
+he could use them over again.  So Tom was satisfied.  Then he says:
+
+“Now, the thing to study out is, how to get the things to Jim.”
+
+“Take them in through the hole,” I says, “when we get it done.”
+
+He only just looked scornful, and said something about nobody ever heard
+of such an idiotic idea, and then he went to studying.  By and by he
+said he had ciphered out two or three ways, but there warn’t no need to
+decide on any of them yet.  Said we’d got to post Jim first.
+
+That night we went down the lightning-rod a little after ten, and took
+one of the candles along, and listened under the window-hole, and heard
+Jim snoring; so we pitched it in, and it didn’t wake him.  Then we
+whirled in with the pick and shovel, and in about two hours and a half
+the job was done.  We crept in under Jim’s bed and into the cabin, and
+pawed around and found the candle and lit it, and stood over Jim awhile,
+and found him looking hearty and healthy, and then we woke him up gentle
+and gradual.  He was so glad to see us he most cried; and called us
+honey, and all the pet names he could think of; and was for having us
+hunt up a cold-chisel to cut the chain off of his leg with right away,
+and clearing out without losing any time.  But Tom he showed him how
+unregular it would be, and set down and told him all about our plans,
+and how we could alter them in a minute any time there was an alarm; and
+not to be the least afraid, because we would see he got away, _sure_.
+ So Jim he said it was all right, and we set there and talked over old
+times awhile, and then Tom asked a lot of questions, and when Jim told
+him Uncle Silas come in every day or two to pray with him, and Aunt
+Sally come in to see if he was comfortable and had plenty to eat, and
+both of them was kind as they could be, Tom says:
+
+“_Now_ I know how to fix it.  We’ll send you some things by them.”
+
+I said, “Don’t do nothing of the kind; it’s one of the most jackass
+ideas I ever struck;” but he never paid no attention to me; went right
+on.  It was his way when he’d got his plans set.
+
+So he told Jim how we’d have to smuggle in the rope-ladder pie and other
+large things by Nat, the nigger that fed him, and he must be on the
+lookout, and not be surprised, and not let Nat see him open them; and
+we would put small things in uncle’s coat-pockets and he must steal them
+out; and we would tie things to aunt’s apron-strings or put them in her
+apron-pocket, if we got a chance; and told him what they would be and
+what they was for.  And told him how to keep a journal on the shirt with
+his blood, and all that. He told him everything.  Jim he couldn’t see
+no sense in the most of it, but he allowed we was white folks and knowed
+better than him; so he was satisfied, and said he would do it all just
+as Tom said.
+
+Jim had plenty corn-cob pipes and tobacco; so we had a right down good
+sociable time; then we crawled out through the hole, and so home to
+bed, with hands that looked like they’d been chawed.  Tom was in high
+spirits. He said it was the best fun he ever had in his life, and the
+most intellectural; and said if he only could see his way to it we would
+keep it up all the rest of our lives and leave Jim to our children to
+get out; for he believed Jim would come to like it better and better the
+more he got used to it.  He said that in that way it could be strung out
+to as much as eighty year, and would be the best time on record.  And he
+said it would make us all celebrated that had a hand in it.
+
+In the morning we went out to the woodpile and chopped up the brass
+candlestick into handy sizes, and Tom put them and the pewter spoon in
+his pocket.  Then we went to the nigger cabins, and while I got Nat’s
+notice off, Tom shoved a piece of candlestick into the middle of a
+corn-pone that was in Jim’s pan, and we went along with Nat to see how
+it would work, and it just worked noble; when Jim bit into it it most
+mashed all his teeth out; and there warn’t ever anything could a worked
+better. Tom said so himself. Jim he never let on but what it was only
+just a piece of rock or something like that that’s always getting into
+bread, you know; but after that he never bit into nothing but what he
+jabbed his fork into it in three or four places first.
+
+And whilst we was a-standing there in the dimmish light, here comes a
+couple of the hounds bulging in from under Jim’s bed; and they kept on
+piling in till there was eleven of them, and there warn’t hardly room
+in there to get your breath.  By jings, we forgot to fasten that lean-to
+door!  The nigger Nat he only just hollered “Witches” once, and keeled
+over on to the floor amongst the dogs, and begun to groan like he was
+dying.  Tom jerked the door open and flung out a slab of Jim’s meat,
+and the dogs went for it, and in two seconds he was out himself and back
+again and shut the door, and I knowed he’d fixed the other door too.
+Then he went to work on the nigger, coaxing him and petting him, and
+asking him if he’d been imagining he saw something again.  He raised up,
+and blinked his eyes around, and says:
+
+“Mars Sid, you’ll say I’s a fool, but if I didn’t b’lieve I see most a
+million dogs, er devils, er some’n, I wisht I may die right heah in dese
+tracks.  I did, mos’ sholy.  Mars Sid, I _felt_ um--I _felt_ um, sah; dey
+was all over me.  Dad fetch it, I jis’ wisht I could git my han’s on one
+er dem witches jis’ wunst--on’y jis’ wunst--it’s all I’d ast.  But mos’ly
+I wisht dey’d lemme ‘lone, I does.”
+
+Tom says:
+
+“Well, I tell you what I think.  What makes them come here just at this
+runaway nigger’s breakfast-time?  It’s because they’re hungry; that’s
+the reason.  You make them a witch pie; that’s the thing for _you_ to
+do.”
+
+“But my lan’, Mars Sid, how’s I gwyne to make ‘m a witch pie?  I doan’
+know how to make it.  I hain’t ever hearn er sich a thing b’fo’.”
+
+“Well, then, I’ll have to make it myself.”
+
+“Will you do it, honey?--will you?  I’ll wusshup de groun’ und’ yo’ foot,
+I will!”
+
+“All right, I’ll do it, seeing it’s you, and you’ve been good to us and
+showed us the runaway nigger.  But you got to be mighty careful.  When
+we come around, you turn your back; and then whatever we’ve put in the
+pan, don’t you let on you see it at all.  And don’t you look when Jim
+unloads the pan--something might happen, I don’t know what.  And above
+all, don’t you _handle_ the witch-things.”
+
+“_Hannel ‘M_, Mars Sid?  What _is_ you a-talkin’ ‘bout?  I wouldn’
+lay de weight er my finger on um, not f’r ten hund’d thous’n billion
+dollars, I wouldn’t.”
+
+
+
+
+CHAPTER XXXVII.
+
+THAT was all fixed.  So then we went away and went to the rubbage-pile
+in the back yard, where they keep the old boots, and rags, and pieces
+of bottles, and wore-out tin things, and all such truck, and scratched
+around and found an old tin washpan, and stopped up the holes as well as
+we could, to bake the pie in, and took it down cellar and stole it full
+of flour and started for breakfast, and found a couple of shingle-nails
+that Tom said would be handy for a prisoner to scrabble his name and
+sorrows on the dungeon walls with, and dropped one of them in Aunt
+Sally’s apron-pocket which was hanging on a chair, and t’other we stuck
+in the band of Uncle Silas’s hat, which was on the bureau, because we
+heard the children say their pa and ma was going to the runaway nigger’s
+house this morning, and then went to breakfast, and Tom dropped the
+pewter spoon in Uncle Silas’s coat-pocket, and Aunt Sally wasn’t come
+yet, so we had to wait a little while.
+
+And when she come she was hot and red and cross, and couldn’t hardly
+wait for the blessing; and then she went to sluicing out coffee with one
+hand and cracking the handiest child’s head with her thimble with the
+other, and says:
+
+“I’ve hunted high and I’ve hunted low, and it does beat all what _has_
+become of your other shirt.”
+
+My heart fell down amongst my lungs and livers and things, and a hard
+piece of corn-crust started down my throat after it and got met on the
+road with a cough, and was shot across the table, and took one of the
+children in the eye and curled him up like a fishing-worm, and let a cry
+out of him the size of a warwhoop, and Tom he turned kinder blue around
+the gills, and it all amounted to a considerable state of things for
+about a quarter of a minute or as much as that, and I would a sold out
+for half price if there was a bidder.  But after that we was all right
+again--it was the sudden surprise of it that knocked us so kind of cold.
+Uncle Silas he says:
+
+“It’s most uncommon curious, I can’t understand it.  I know perfectly
+well I took it _off_, because--”
+
+“Because you hain’t got but one _on_.  Just _listen_ at the man!  I know
+you took it off, and know it by a better way than your wool-gethering
+memory, too, because it was on the clo’s-line yesterday--I see it there
+myself. But it’s gone, that’s the long and the short of it, and you’ll
+just have to change to a red flann’l one till I can get time to make a
+new one. And it ‘ll be the third I’ve made in two years.  It just keeps
+a body on the jump to keep you in shirts; and whatever you do manage to
+_do_ with ‘m all is more’n I can make out.  A body ‘d think you _would_
+learn to take some sort of care of ‘em at your time of life.”
+
+“I know it, Sally, and I do try all I can.  But it oughtn’t to be
+altogether my fault, because, you know, I don’t see them nor have
+nothing to do with them except when they’re on me; and I don’t believe
+I’ve ever lost one of them _off_ of me.”
+
+“Well, it ain’t _your_ fault if you haven’t, Silas; you’d a done it
+if you could, I reckon.  And the shirt ain’t all that’s gone, nuther.
+ Ther’s a spoon gone; and _that_ ain’t all.  There was ten, and now
+ther’s only nine. The calf got the shirt, I reckon, but the calf never
+took the spoon, _that’s_ certain.”
+
+“Why, what else is gone, Sally?”
+
+“Ther’s six _candles_ gone--that’s what.  The rats could a got the
+candles, and I reckon they did; I wonder they don’t walk off with the
+whole place, the way you’re always going to stop their holes and don’t
+do it; and if they warn’t fools they’d sleep in your hair, Silas--_you’d_
+never find it out; but you can’t lay the _spoon_ on the rats, and that I
+know.”
+
+“Well, Sally, I’m in fault, and I acknowledge it; I’ve been remiss; but
+I won’t let to-morrow go by without stopping up them holes.”
+
+“Oh, I wouldn’t hurry; next year ‘ll do.  Matilda Angelina Araminta
+_Phelps!_”
+
+Whack comes the thimble, and the child snatches her claws out of the
+sugar-bowl without fooling around any.  Just then the nigger woman steps
+on to the passage, and says:
+
+“Missus, dey’s a sheet gone.”
+
+“A _sheet_ gone!  Well, for the land’s sake!”
+
+“I’ll stop up them holes to-day,” says Uncle Silas, looking sorrowful.
+
+“Oh, _do_ shet up!--s’pose the rats took the _sheet_?  _where’s_ it gone,
+Lize?”
+
+“Clah to goodness I hain’t no notion, Miss’ Sally.  She wuz on de
+clo’sline yistiddy, but she done gone:  she ain’ dah no mo’ now.”
+
+“I reckon the world _is_ coming to an end.  I _never_ see the beat of it
+in all my born days.  A shirt, and a sheet, and a spoon, and six can--”
+
+“Missus,” comes a young yaller wench, “dey’s a brass cannelstick
+miss’n.”
+
+“Cler out from here, you hussy, er I’ll take a skillet to ye!”
+
+Well, she was just a-biling.  I begun to lay for a chance; I reckoned
+I would sneak out and go for the woods till the weather moderated.  She
+kept a-raging right along, running her insurrection all by herself, and
+everybody else mighty meek and quiet; and at last Uncle Silas, looking
+kind of foolish, fishes up that spoon out of his pocket.  She stopped,
+with her mouth open and her hands up; and as for me, I wished I was in
+Jeruslem or somewheres. But not long, because she says:
+
+“It’s _just_ as I expected.  So you had it in your pocket all the time;
+and like as not you’ve got the other things there, too.  How’d it get
+there?”
+
+“I reely don’t know, Sally,” he says, kind of apologizing, “or you know
+I would tell.  I was a-studying over my text in Acts Seventeen before
+breakfast, and I reckon I put it in there, not noticing, meaning to put
+my Testament in, and it must be so, because my Testament ain’t in; but
+I’ll go and see; and if the Testament is where I had it, I’ll know I
+didn’t put it in, and that will show that I laid the Testament down and
+took up the spoon, and--”
+
+“Oh, for the land’s sake!  Give a body a rest!  Go ‘long now, the whole
+kit and biling of ye; and don’t come nigh me again till I’ve got back my
+peace of mind.”
+
+I’D a heard her if she’d a said it to herself, let alone speaking it
+out; and I’d a got up and obeyed her if I’d a been dead.  As we was
+passing through the setting-room the old man he took up his hat, and the
+shingle-nail fell out on the floor, and he just merely picked it up and
+laid it on the mantel-shelf, and never said nothing, and went out.  Tom
+see him do it, and remembered about the spoon, and says:
+
+“Well, it ain’t no use to send things by _him_ no more, he ain’t
+reliable.” Then he says:  “But he done us a good turn with the spoon,
+anyway, without knowing it, and so we’ll go and do him one without _him_
+knowing it--stop up his rat-holes.”
+
+There was a noble good lot of them down cellar, and it took us a whole
+hour, but we done the job tight and good and shipshape.  Then we heard
+steps on the stairs, and blowed out our light and hid; and here comes
+the old man, with a candle in one hand and a bundle of stuff in t’other,
+looking as absent-minded as year before last.  He went a mooning around,
+first to one rat-hole and then another, till he’d been to them all.
+ Then he stood about five minutes, picking tallow-drip off of his candle
+and thinking.  Then he turns off slow and dreamy towards the stairs,
+saying:
+
+“Well, for the life of me I can’t remember when I done it.  I could
+show her now that I warn’t to blame on account of the rats.  But never
+mind--let it go.  I reckon it wouldn’t do no good.”
+
+And so he went on a-mumbling up stairs, and then we left.  He was a
+mighty nice old man.  And always is.
+
+Tom was a good deal bothered about what to do for a spoon, but he said
+we’d got to have it; so he took a think.  When he had ciphered it out
+he told me how we was to do; then we went and waited around the
+spoon-basket till we see Aunt Sally coming, and then Tom went to
+counting the spoons and laying them out to one side, and I slid one of
+them up my sleeve, and Tom says:
+
+“Why, Aunt Sally, there ain’t but nine spoons _yet_.”
+
+She says:
+
+“Go ‘long to your play, and don’t bother me.  I know better, I counted
+‘m myself.”
+
+“Well, I’ve counted them twice, Aunty, and I can’t make but nine.”
+
+She looked out of all patience, but of course she come to count--anybody
+would.
+
+“I declare to gracious ther’ _ain’t_ but nine!” she says.  “Why, what in
+the world--plague _take_ the things, I’ll count ‘m again.”
+
+So I slipped back the one I had, and when she got done counting, she
+says:
+
+“Hang the troublesome rubbage, ther’s _ten_ now!” and she looked huffy
+and bothered both.  But Tom says:
+
+“Why, Aunty, I don’t think there’s ten.”
+
+“You numskull, didn’t you see me _count ‘m?_”
+
+“I know, but--”
+
+“Well, I’ll count ‘m _again_.”
+
+So I smouched one, and they come out nine, same as the other time.
+ Well, she _was_ in a tearing way--just a-trembling all over, she was so
+mad.  But she counted and counted till she got that addled she’d start
+to count in the basket for a spoon sometimes; and so, three times they
+come out right, and three times they come out wrong.  Then she grabbed
+up the basket and slammed it across the house and knocked the cat
+galley-west; and she said cle’r out and let her have some peace, and if
+we come bothering around her again betwixt that and dinner she’d skin
+us.  So we had the odd spoon, and dropped it in her apron-pocket whilst
+she was a-giving us our sailing orders, and Jim got it all right, along
+with her shingle nail, before noon.  We was very well satisfied with
+this business, and Tom allowed it was worth twice the trouble it took,
+because he said _now_ she couldn’t ever count them spoons twice alike
+again to save her life; and wouldn’t believe she’d counted them right if
+she _did_; and said that after she’d about counted her head off for the
+next three days he judged she’d give it up and offer to kill anybody
+that wanted her to ever count them any more.
+
+So we put the sheet back on the line that night, and stole one out of
+her closet; and kept on putting it back and stealing it again for a
+couple of days till she didn’t know how many sheets she had any more,
+and she didn’t _care_, and warn’t a-going to bullyrag the rest of her
+soul out about it, and wouldn’t count them again not to save her life;
+she druther die first.
+
+So we was all right now, as to the shirt and the sheet and the spoon
+and the candles, by the help of the calf and the rats and the mixed-up
+counting; and as to the candlestick, it warn’t no consequence, it would
+blow over by and by.
+
+But that pie was a job; we had no end of trouble with that pie.  We
+fixed it up away down in the woods, and cooked it there; and we got it
+done at last, and very satisfactory, too; but not all in one day; and we
+had to use up three wash-pans full of flour before we got through, and
+we got burnt pretty much all over, in places, and eyes put out with
+the smoke; because, you see, we didn’t want nothing but a crust, and we
+couldn’t prop it up right, and she would always cave in.  But of course
+we thought of the right way at last--which was to cook the ladder, too,
+in the pie.  So then we laid in with Jim the second night, and tore
+up the sheet all in little strings and twisted them together, and long
+before daylight we had a lovely rope that you could a hung a person
+with.  We let on it took nine months to make it.
+
+And in the forenoon we took it down to the woods, but it wouldn’t go
+into the pie.  Being made of a whole sheet, that way, there was rope
+enough for forty pies if we’d a wanted them, and plenty left over
+for soup, or sausage, or anything you choose.  We could a had a whole
+dinner.
+
+But we didn’t need it.  All we needed was just enough for the pie, and
+so we throwed the rest away.  We didn’t cook none of the pies in the
+wash-pan--afraid the solder would melt; but Uncle Silas he had a noble
+brass warming-pan which he thought considerable of, because it belonged
+to one of his ancesters with a long wooden handle that come over from
+England with William the Conqueror in the Mayflower or one of them early
+ships and was hid away up garret with a lot of other old pots and things
+that was valuable, not on account of being any account, because they
+warn’t, but on account of them being relicts, you know, and we snaked
+her out, private, and took her down there, but she failed on the first
+pies, because we didn’t know how, but she come up smiling on the last
+one.  We took and lined her with dough, and set her in the coals, and
+loaded her up with rag rope, and put on a dough roof, and shut down the
+lid, and put hot embers on top, and stood off five foot, with the long
+handle, cool and comfortable, and in fifteen minutes she turned out a
+pie that was a satisfaction to look at. But the person that et it would
+want to fetch a couple of kags of toothpicks along, for if that rope
+ladder wouldn’t cramp him down to business I don’t know nothing what I’m
+talking about, and lay him in enough stomach-ache to last him till next
+time, too.
+
+Nat didn’t look when we put the witch pie in Jim’s pan; and we put the
+three tin plates in the bottom of the pan under the vittles; and so Jim
+got everything all right, and as soon as he was by himself he busted
+into the pie and hid the rope ladder inside of his straw tick,
+and scratched some marks on a tin plate and throwed it out of the
+window-hole.
+
+
+
+
+CHAPTER XXXVIII.
+
+MAKING them pens was a distressid tough job, and so was the saw; and Jim
+allowed the inscription was going to be the toughest of all.  That’s the
+one which the prisoner has to scrabble on the wall.  But he had to have
+it; Tom said he’d _got_ to; there warn’t no case of a state prisoner not
+scrabbling his inscription to leave behind, and his coat of arms.
+
+“Look at Lady Jane Grey,” he says; “look at Gilford Dudley; look at old
+Northumberland!  Why, Huck, s’pose it _is_ considerble trouble?--what
+you going to do?--how you going to get around it?  Jim’s _got_ to do his
+inscription and coat of arms.  They all do.”
+
+Jim says:
+
+“Why, Mars Tom, I hain’t got no coat o’ arm; I hain’t got nuffn but dish
+yer ole shirt, en you knows I got to keep de journal on dat.”
+
+“Oh, you don’t understand, Jim; a coat of arms is very different.”
+
+“Well,” I says, “Jim’s right, anyway, when he says he ain’t got no coat
+of arms, because he hain’t.”
+
+“I reckon I knowed that,” Tom says, “but you bet he’ll have one before
+he goes out of this--because he’s going out _right_, and there ain’t
+going to be no flaws in his record.”
+
+So whilst me and Jim filed away at the pens on a brickbat apiece, Jim
+a-making his’n out of the brass and I making mine out of the spoon,
+Tom set to work to think out the coat of arms.  By and by he said he’d
+struck so many good ones he didn’t hardly know which to take, but there
+was one which he reckoned he’d decide on.  He says:
+
+“On the scutcheon we’ll have a bend _or_ in the dexter base, a saltire
+_murrey_ in the fess, with a dog, couchant, for common charge, and under
+his foot a chain embattled, for slavery, with a chevron _vert_ in a
+chief engrailed, and three invected lines on a field _azure_, with the
+nombril points rampant on a dancette indented; crest, a runaway nigger,
+_sable_, with his bundle over his shoulder on a bar sinister; and a
+couple of gules for supporters, which is you and me; motto, _Maggiore
+Fretta, Minore Otto._  Got it out of a book--means the more haste the
+less speed.”
+
+“Geewhillikins,” I says, “but what does the rest of it mean?”
+
+“We ain’t got no time to bother over that,” he says; “we got to dig in
+like all git-out.”
+
+“Well, anyway,” I says, “what’s _some_ of it?  What’s a fess?”
+
+“A fess--a fess is--_you_ don’t need to know what a fess is.  I’ll show
+him how to make it when he gets to it.”
+
+“Shucks, Tom,” I says, “I think you might tell a person.  What’s a bar
+sinister?”
+
+“Oh, I don’t know.  But he’s got to have it.  All the nobility does.”
+
+That was just his way.  If it didn’t suit him to explain a thing to you,
+he wouldn’t do it.  You might pump at him a week, it wouldn’t make no
+difference.
+
+He’d got all that coat of arms business fixed, so now he started in to
+finish up the rest of that part of the work, which was to plan out a
+mournful inscription--said Jim got to have one, like they all done.  He
+made up a lot, and wrote them out on a paper, and read them off, so:
+
+1.  Here a captive heart busted. 2.  Here a poor prisoner, forsook by
+the world and friends, fretted his sorrowful life. 3.  Here a lonely
+heart broke, and a worn spirit went to its rest, after thirty-seven
+years of solitary captivity. 4.  Here, homeless and friendless, after
+thirty-seven years of bitter captivity, perished a noble stranger,
+natural son of Louis XIV.
+
+Tom’s voice trembled whilst he was reading them, and he most broke down.
+When he got done he couldn’t no way make up his mind which one for Jim
+to scrabble on to the wall, they was all so good; but at last he allowed
+he would let him scrabble them all on.  Jim said it would take him a
+year to scrabble such a lot of truck on to the logs with a nail, and he
+didn’t know how to make letters, besides; but Tom said he would block
+them out for him, and then he wouldn’t have nothing to do but just
+follow the lines.  Then pretty soon he says:
+
+“Come to think, the logs ain’t a-going to do; they don’t have log walls
+in a dungeon:  we got to dig the inscriptions into a rock.  We’ll fetch
+a rock.”
+
+Jim said the rock was worse than the logs; he said it would take him
+such a pison long time to dig them into a rock he wouldn’t ever get out.
+ But Tom said he would let me help him do it.  Then he took a look to
+see how me and Jim was getting along with the pens.  It was most pesky
+tedious hard work and slow, and didn’t give my hands no show to get
+well of the sores, and we didn’t seem to make no headway, hardly; so Tom
+says:
+
+“I know how to fix it.  We got to have a rock for the coat of arms and
+mournful inscriptions, and we can kill two birds with that same rock.
+There’s a gaudy big grindstone down at the mill, and we’ll smouch it,
+and carve the things on it, and file out the pens and the saw on it,
+too.”
+
+It warn’t no slouch of an idea; and it warn’t no slouch of a grindstone
+nuther; but we allowed we’d tackle it.  It warn’t quite midnight yet,
+so we cleared out for the mill, leaving Jim at work.  We smouched the
+grindstone, and set out to roll her home, but it was a most nation tough
+job. Sometimes, do what we could, we couldn’t keep her from falling
+over, and she come mighty near mashing us every time.  Tom said she was
+going to get one of us, sure, before we got through.  We got her half
+way; and then we was plumb played out, and most drownded with sweat.  We
+see it warn’t no use; we got to go and fetch Jim. So he raised up his
+bed and slid the chain off of the bed-leg, and wrapt it round and round
+his neck, and we crawled out through our hole and down there, and Jim
+and me laid into that grindstone and walked her along like nothing; and
+Tom superintended.  He could out-superintend any boy I ever see.  He
+knowed how to do everything.
+
+Our hole was pretty big, but it warn’t big enough to get the grindstone
+through; but Jim he took the pick and soon made it big enough.  Then Tom
+marked out them things on it with the nail, and set Jim to work on them,
+with the nail for a chisel and an iron bolt from the rubbage in the
+lean-to for a hammer, and told him to work till the rest of his candle
+quit on him, and then he could go to bed, and hide the grindstone under
+his straw tick and sleep on it.  Then we helped him fix his chain back
+on the bed-leg, and was ready for bed ourselves.  But Tom thought of
+something, and says:
+
+“You got any spiders in here, Jim?”
+
+“No, sah, thanks to goodness I hain’t, Mars Tom.”
+
+“All right, we’ll get you some.”
+
+“But bless you, honey, I doan’ _want_ none.  I’s afeard un um.  I jis’
+‘s soon have rattlesnakes aroun’.”
+
+Tom thought a minute or two, and says:
+
+“It’s a good idea.  And I reckon it’s been done.  It _must_ a been done;
+it stands to reason.  Yes, it’s a prime good idea.  Where could you keep
+it?”
+
+“Keep what, Mars Tom?”
+
+“Why, a rattlesnake.”
+
+“De goodness gracious alive, Mars Tom!  Why, if dey was a rattlesnake to
+come in heah I’d take en bust right out thoo dat log wall, I would, wid
+my head.”
+
+“Why, Jim, you wouldn’t be afraid of it after a little.  You could tame
+it.”
+
+“_Tame_ it!”
+
+“Yes--easy enough.  Every animal is grateful for kindness and petting,
+and they wouldn’t _think_ of hurting a person that pets them.  Any book
+will tell you that.  You try--that’s all I ask; just try for two or three
+days. Why, you can get him so, in a little while, that he’ll love you;
+and sleep with you; and won’t stay away from you a minute; and will let
+you wrap him round your neck and put his head in your mouth.”
+
+“_Please_, Mars Tom--_doan_’ talk so!  I can’t _stan_’ it!  He’d _let_
+me shove his head in my mouf--fer a favor, hain’t it?  I lay he’d wait a
+pow’ful long time ‘fo’ I _ast_ him.  En mo’ en dat, I doan’ _want_ him
+to sleep wid me.”
+
+“Jim, don’t act so foolish.  A prisoner’s _got_ to have some kind of a
+dumb pet, and if a rattlesnake hain’t ever been tried, why, there’s more
+glory to be gained in your being the first to ever try it than any other
+way you could ever think of to save your life.”
+
+“Why, Mars Tom, I doan’ _want_ no sich glory.  Snake take ‘n bite
+Jim’s chin off, den _whah_ is de glory?  No, sah, I doan’ want no sich
+doin’s.”
+
+“Blame it, can’t you _try_?  I only _want_ you to try--you needn’t keep
+it up if it don’t work.”
+
+“But de trouble all _done_ ef de snake bite me while I’s a tryin’ him.
+Mars Tom, I’s willin’ to tackle mos’ anything ‘at ain’t onreasonable,
+but ef you en Huck fetches a rattlesnake in heah for me to tame, I’s
+gwyne to _leave_, dat’s _shore_.”
+
+“Well, then, let it go, let it go, if you’re so bull-headed about it.
+ We can get you some garter-snakes, and you can tie some buttons on
+their tails, and let on they’re rattlesnakes, and I reckon that ‘ll have
+to do.”
+
+“I k’n stan’ _dem_, Mars Tom, but blame’ ‘f I couldn’ get along widout
+um, I tell you dat.  I never knowed b’fo’ ‘t was so much bother and
+trouble to be a prisoner.”
+
+“Well, it _always_ is when it’s done right.  You got any rats around
+here?”
+
+“No, sah, I hain’t seed none.”
+
+“Well, we’ll get you some rats.”
+
+“Why, Mars Tom, I doan’ _want_ no rats.  Dey’s de dadblamedest creturs
+to ‘sturb a body, en rustle roun’ over ‘im, en bite his feet, when he’s
+tryin’ to sleep, I ever see.  No, sah, gimme g’yarter-snakes, ‘f I’s
+got to have ‘m, but doan’ gimme no rats; I hain’ got no use f’r um,
+skasely.”
+
+“But, Jim, you _got_ to have ‘em--they all do.  So don’t make no more
+fuss about it.  Prisoners ain’t ever without rats.  There ain’t no
+instance of it.  And they train them, and pet them, and learn them
+tricks, and they get to be as sociable as flies.  But you got to play
+music to them.  You got anything to play music on?”
+
+“I ain’ got nuffn but a coase comb en a piece o’ paper, en a juice-harp;
+but I reck’n dey wouldn’ take no stock in a juice-harp.”
+
+“Yes they would _they_ don’t care what kind of music ‘tis.  A
+jews-harp’s plenty good enough for a rat.  All animals like music--in a
+prison they dote on it.  Specially, painful music; and you can’t get no
+other kind out of a jews-harp.  It always interests them; they come out
+to see what’s the matter with you.  Yes, you’re all right; you’re fixed
+very well.  You want to set on your bed nights before you go to sleep,
+and early in the mornings, and play your jews-harp; play ‘The Last Link
+is Broken’--that’s the thing that ‘ll scoop a rat quicker ‘n anything
+else; and when you’ve played about two minutes you’ll see all the rats,
+and the snakes, and spiders, and things begin to feel worried about you,
+and come.  And they’ll just fairly swarm over you, and have a noble good
+time.”
+
+“Yes, _dey_ will, I reck’n, Mars Tom, but what kine er time is _Jim_
+havin’? Blest if I kin see de pint.  But I’ll do it ef I got to.  I
+reck’n I better keep de animals satisfied, en not have no trouble in de
+house.”
+
+Tom waited to think it over, and see if there wasn’t nothing else; and
+pretty soon he says:
+
+“Oh, there’s one thing I forgot.  Could you raise a flower here, do you
+reckon?”
+
+“I doan know but maybe I could, Mars Tom; but it’s tolable dark in heah,
+en I ain’ got no use f’r no flower, nohow, en she’d be a pow’ful sight
+o’ trouble.”
+
+“Well, you try it, anyway.  Some other prisoners has done it.”
+
+“One er dem big cat-tail-lookin’ mullen-stalks would grow in heah, Mars
+Tom, I reck’n, but she wouldn’t be wuth half de trouble she’d coss.”
+
+“Don’t you believe it.  We’ll fetch you a little one and you plant it in
+the corner over there, and raise it.  And don’t call it mullen, call it
+Pitchiola--that’s its right name when it’s in a prison.  And you want to
+water it with your tears.”
+
+“Why, I got plenty spring water, Mars Tom.”
+
+“You don’t _want_ spring water; you want to water it with your tears.
+ It’s the way they always do.”
+
+“Why, Mars Tom, I lay I kin raise one er dem mullen-stalks twyste wid
+spring water whiles another man’s a _start’n_ one wid tears.”
+
+“That ain’t the idea.  You _got_ to do it with tears.”
+
+“She’ll die on my han’s, Mars Tom, she sholy will; kase I doan’ skasely
+ever cry.”
+
+So Tom was stumped.  But he studied it over, and then said Jim would
+have to worry along the best he could with an onion.  He promised
+he would go to the nigger cabins and drop one, private, in Jim’s
+coffee-pot, in the morning. Jim said he would “jis’ ‘s soon have
+tobacker in his coffee;” and found so much fault with it, and with the
+work and bother of raising the mullen, and jews-harping the rats, and
+petting and flattering up the snakes and spiders and things, on top of
+all the other work he had to do on pens, and inscriptions, and journals,
+and things, which made it more trouble and worry and responsibility to
+be a prisoner than anything he ever undertook, that Tom most lost all
+patience with him; and said he was just loadened down with more gaudier
+chances than a prisoner ever had in the world to make a name for
+himself, and yet he didn’t know enough to appreciate them, and they was
+just about wasted on him.  So Jim he was sorry, and said he wouldn’t
+behave so no more, and then me and Tom shoved for bed.
+
+
+
+
+CHAPTER XXXIX.
+
+IN the morning we went up to the village and bought a wire rat-trap and
+fetched it down, and unstopped the best rat-hole, and in about an hour
+we had fifteen of the bulliest kind of ones; and then we took it and put
+it in a safe place under Aunt Sally’s bed.  But while we was gone for
+spiders little Thomas Franklin Benjamin Jefferson Elexander Phelps found
+it there, and opened the door of it to see if the rats would come out,
+and they did; and Aunt Sally she come in, and when we got back she was
+a-standing on top of the bed raising Cain, and the rats was doing what
+they could to keep off the dull times for her.  So she took and dusted
+us both with the hickry, and we was as much as two hours catching
+another fifteen or sixteen, drat that meddlesome cub, and they warn’t
+the likeliest, nuther, because the first haul was the pick of the flock.
+ I never see a likelier lot of rats than what that first haul was.
+
+We got a splendid stock of sorted spiders, and bugs, and frogs, and
+caterpillars, and one thing or another; and we like to got a hornet’s
+nest, but we didn’t.  The family was at home.  We didn’t give it right
+up, but stayed with them as long as we could; because we allowed we’d
+tire them out or they’d got to tire us out, and they done it.  Then we
+got allycumpain and rubbed on the places, and was pretty near all right
+again, but couldn’t set down convenient.  And so we went for the snakes,
+and grabbed a couple of dozen garters and house-snakes, and put them in
+a bag, and put it in our room, and by that time it was supper-time, and
+a rattling good honest day’s work:  and hungry?--oh, no, I reckon not!
+ And there warn’t a blessed snake up there when we went back--we didn’t
+half tie the sack, and they worked out somehow, and left.  But it didn’t
+matter much, because they was still on the premises somewheres.  So
+we judged we could get some of them again.  No, there warn’t no real
+scarcity of snakes about the house for a considerable spell.  You’d see
+them dripping from the rafters and places every now and then; and they
+generly landed in your plate, or down the back of your neck, and most
+of the time where you didn’t want them.  Well, they was handsome and
+striped, and there warn’t no harm in a million of them; but that never
+made no difference to Aunt Sally; she despised snakes, be the breed what
+they might, and she couldn’t stand them no way you could fix it; and
+every time one of them flopped down on her, it didn’t make no difference
+what she was doing, she would just lay that work down and light out.  I
+never see such a woman.  And you could hear her whoop to Jericho.  You
+couldn’t get her to take a-holt of one of them with the tongs.  And if
+she turned over and found one in bed she would scramble out and lift a
+howl that you would think the house was afire.  She disturbed the old
+man so that he said he could most wish there hadn’t ever been no snakes
+created.  Why, after every last snake had been gone clear out of the
+house for as much as a week Aunt Sally warn’t over it yet; she warn’t
+near over it; when she was setting thinking about something you could
+touch her on the back of her neck with a feather and she would jump
+right out of her stockings.  It was very curious.  But Tom said all
+women was just so.  He said they was made that way for some reason or
+other.
+
+We got a licking every time one of our snakes come in her way, and she
+allowed these lickings warn’t nothing to what she would do if we ever
+loaded up the place again with them.  I didn’t mind the lickings,
+because they didn’t amount to nothing; but I minded the trouble we
+had to lay in another lot.  But we got them laid in, and all the other
+things; and you never see a cabin as blithesome as Jim’s was when they’d
+all swarm out for music and go for him.  Jim didn’t like the spiders,
+and the spiders didn’t like Jim; and so they’d lay for him, and make it
+mighty warm for him.  And he said that between the rats and the snakes
+and the grindstone there warn’t no room in bed for him, skasely; and
+when there was, a body couldn’t sleep, it was so lively, and it was
+always lively, he said, because _they_ never all slept at one time, but
+took turn about, so when the snakes was asleep the rats was on deck, and
+when the rats turned in the snakes come on watch, so he always had one
+gang under him, in his way, and t’other gang having a circus over him,
+and if he got up to hunt a new place the spiders would take a chance at
+him as he crossed over. He said if he ever got out this time he wouldn’t
+ever be a prisoner again, not for a salary.
+
+Well, by the end of three weeks everything was in pretty good shape.
+ The shirt was sent in early, in a pie, and every time a rat bit Jim he
+would get up and write a little in his journal whilst the ink was fresh;
+the pens was made, the inscriptions and so on was all carved on the
+grindstone; the bed-leg was sawed in two, and we had et up the sawdust,
+and it give us a most amazing stomach-ache.  We reckoned we was all
+going to die, but didn’t.  It was the most undigestible sawdust I ever
+see; and Tom said the same.
+
+But as I was saying, we’d got all the work done now, at last; and we was
+all pretty much fagged out, too, but mainly Jim.  The old man had wrote
+a couple of times to the plantation below Orleans to come and get their
+runaway nigger, but hadn’t got no answer, because there warn’t no such
+plantation; so he allowed he would advertise Jim in the St. Louis and
+New Orleans papers; and when he mentioned the St. Louis ones it give me
+the cold shivers, and I see we hadn’t no time to lose. So Tom said, now
+for the nonnamous letters.
+
+“What’s them?”  I says.
+
+“Warnings to the people that something is up.  Sometimes it’s done one
+way, sometimes another.  But there’s always somebody spying around that
+gives notice to the governor of the castle.  When Louis XVI. was going
+to light out of the Tooleries, a servant-girl done it.  It’s a very good
+way, and so is the nonnamous letters.  We’ll use them both.  And it’s
+usual for the prisoner’s mother to change clothes with him, and she
+stays in, and he slides out in her clothes.  We’ll do that, too.”
+
+“But looky here, Tom, what do we want to _warn_ anybody for that
+something’s up?  Let them find it out for themselves--it’s their
+lookout.”
+
+“Yes, I know; but you can’t depend on them.  It’s the way they’ve acted
+from the very start--left us to do _everything_.  They’re so confiding
+and mullet-headed they don’t take notice of nothing at all.  So if we
+don’t _give_ them notice there won’t be nobody nor nothing to interfere
+with us, and so after all our hard work and trouble this escape ‘ll go
+off perfectly flat; won’t amount to nothing--won’t be nothing _to_ it.”
+
+“Well, as for me, Tom, that’s the way I’d like.”
+
+“Shucks!” he says, and looked disgusted.  So I says:
+
+“But I ain’t going to make no complaint.  Any way that suits you suits
+me. What you going to do about the servant-girl?”
+
+“You’ll be her.  You slide in, in the middle of the night, and hook that
+yaller girl’s frock.”
+
+“Why, Tom, that ‘ll make trouble next morning; because, of course, she
+prob’bly hain’t got any but that one.”
+
+“I know; but you don’t want it but fifteen minutes, to carry the
+nonnamous letter and shove it under the front door.”
+
+“All right, then, I’ll do it; but I could carry it just as handy in my
+own togs.”
+
+“You wouldn’t look like a servant-girl _then_, would you?”
+
+“No, but there won’t be nobody to see what I look like, _anyway_.”
+
+“That ain’t got nothing to do with it.  The thing for us to do is just
+to do our _duty_, and not worry about whether anybody _sees_ us do it or
+not. Hain’t you got no principle at all?”
+
+“All right, I ain’t saying nothing; I’m the servant-girl.  Who’s Jim’s
+mother?”
+
+“I’m his mother.  I’ll hook a gown from Aunt Sally.”
+
+“Well, then, you’ll have to stay in the cabin when me and Jim leaves.”
+
+“Not much.  I’ll stuff Jim’s clothes full of straw and lay it on his bed
+to represent his mother in disguise, and Jim ‘ll take the nigger woman’s
+gown off of me and wear it, and we’ll all evade together.  When a
+prisoner of style escapes it’s called an evasion.  It’s always called
+so when a king escapes, f’rinstance.  And the same with a king’s son;
+it don’t make no difference whether he’s a natural one or an unnatural
+one.”
+
+So Tom he wrote the nonnamous letter, and I smouched the yaller wench’s
+frock that night, and put it on, and shoved it under the front door, the
+way Tom told me to.  It said:
+
+Beware.  Trouble is brewing.  Keep a sharp lookout. _Unknown_ _Friend_.
+
+Next night we stuck a picture, which Tom drawed in blood, of a skull and
+crossbones on the front door; and next night another one of a coffin on
+the back door.  I never see a family in such a sweat.  They couldn’t a
+been worse scared if the place had a been full of ghosts laying for them
+behind everything and under the beds and shivering through the air.  If
+a door banged, Aunt Sally she jumped and said “ouch!” if anything fell,
+she jumped and said “ouch!” if you happened to touch her, when she
+warn’t noticing, she done the same; she couldn’t face noway and be
+satisfied, because she allowed there was something behind her every
+time--so she was always a-whirling around sudden, and saying “ouch,” and
+before she’d got two-thirds around she’d whirl back again, and say it
+again; and she was afraid to go to bed, but she dasn’t set up.  So the
+thing was working very well, Tom said; he said he never see a thing work
+more satisfactory. He said it showed it was done right.
+
+So he said, now for the grand bulge!  So the very next morning at the
+streak of dawn we got another letter ready, and was wondering what we
+better do with it, because we heard them say at supper they was going
+to have a nigger on watch at both doors all night.  Tom he went down the
+lightning-rod to spy around; and the nigger at the back door was asleep,
+and he stuck it in the back of his neck and come back.  This letter
+said:
+
+Don’t betray me, I wish to be your friend.  There is a desprate gang of
+cutthroats from over in the Indian Territory going to steal your runaway
+nigger to-night, and they have been trying to scare you so as you will
+stay in the house and not bother them.  I am one of the gang, but have
+got religgion and wish to quit it and lead an honest life again, and
+will betray the helish design. They will sneak down from northards,
+along the fence, at midnight exact, with a false key, and go in the
+nigger’s cabin to get him. I am to be off a piece and blow a tin horn
+if I see any danger; but stead of that I will _baa_ like a sheep soon as
+they get in and not blow at all; then whilst they are getting his
+chains loose, you slip there and lock them in, and can kill them at your
+leasure.  Don’t do anything but just the way I am telling you, if you do
+they will suspicion something and raise whoop-jamboreehoo. I do not wish
+any reward but to know I have done the right thing. _Unknown Friend._
+
+
+
+
+CHAPTER XL.
+
+WE was feeling pretty good after breakfast, and took my canoe and went
+over the river a-fishing, with a lunch, and had a good time, and took a
+look at the raft and found her all right, and got home late to supper,
+and found them in such a sweat and worry they didn’t know which end they
+was standing on, and made us go right off to bed the minute we was done
+supper, and wouldn’t tell us what the trouble was, and never let on a
+word about the new letter, but didn’t need to, because we knowed as much
+about it as anybody did, and as soon as we was half up stairs and her
+back was turned we slid for the cellar cupboard and loaded up a good
+lunch and took it up to our room and went to bed, and got up about
+half-past eleven, and Tom put on Aunt Sally’s dress that he stole and
+was going to start with the lunch, but says:
+
+“Where’s the butter?”
+
+“I laid out a hunk of it,” I says, “on a piece of a corn-pone.”
+
+“Well, you _left_ it laid out, then--it ain’t here.”
+
+“We can get along without it,” I says.
+
+“We can get along _with_ it, too,” he says; “just you slide down cellar
+and fetch it.  And then mosey right down the lightning-rod and come
+along. I’ll go and stuff the straw into Jim’s clothes to represent his
+mother in disguise, and be ready to _baa_ like a sheep and shove soon as
+you get there.”
+
+So out he went, and down cellar went I. The hunk of butter, big as
+a person’s fist, was where I had left it, so I took up the slab of
+corn-pone with it on, and blowed out my light, and started up stairs
+very stealthy, and got up to the main floor all right, but here comes
+Aunt Sally with a candle, and I clapped the truck in my hat, and clapped
+my hat on my head, and the next second she see me; and she says:
+
+“You been down cellar?”
+
+“Yes’m.”
+
+“What you been doing down there?”
+
+“Noth’n.”
+
+“_Noth’n!_”
+
+“No’m.”
+
+“Well, then, what possessed you to go down there this time of night?”
+
+“I don’t know ‘m.”
+
+“You don’t _know_?  Don’t answer me that way. Tom, I want to know what
+you been _doing_ down there.”
+
+“I hain’t been doing a single thing, Aunt Sally, I hope to gracious if I
+have.”
+
+I reckoned she’d let me go now, and as a generl thing she would; but I
+s’pose there was so many strange things going on she was just in a sweat
+about every little thing that warn’t yard-stick straight; so she says,
+very decided:
+
+“You just march into that setting-room and stay there till I come.  You
+been up to something you no business to, and I lay I’ll find out what it
+is before I’M done with you.”
+
+So she went away as I opened the door and walked into the setting-room.
+My, but there was a crowd there!  Fifteen farmers, and every one of them
+had a gun.  I was most powerful sick, and slunk to a chair and set down.
+They was setting around, some of them talking a little, in a low voice,
+and all of them fidgety and uneasy, but trying to look like they warn’t;
+but I knowed they was, because they was always taking off their hats,
+and putting them on, and scratching their heads, and changing their
+seats, and fumbling with their buttons.  I warn’t easy myself, but I
+didn’t take my hat off, all the same.
+
+I did wish Aunt Sally would come, and get done with me, and lick me, if
+she wanted to, and let me get away and tell Tom how we’d overdone this
+thing, and what a thundering hornet’s-nest we’d got ourselves into, so
+we could stop fooling around straight off, and clear out with Jim before
+these rips got out of patience and come for us.
+
+At last she come and begun to ask me questions, but I _couldn’t_ answer
+them straight, I didn’t know which end of me was up; because these men
+was in such a fidget now that some was wanting to start right NOW and
+lay for them desperadoes, and saying it warn’t but a few minutes to
+midnight; and others was trying to get them to hold on and wait for the
+sheep-signal; and here was Aunty pegging away at the questions, and
+me a-shaking all over and ready to sink down in my tracks I was
+that scared; and the place getting hotter and hotter, and the butter
+beginning to melt and run down my neck and behind my ears; and pretty
+soon, when one of them says, “I’M for going and getting in the cabin
+_first_ and right _now_, and catching them when they come,” I most
+dropped; and a streak of butter come a-trickling down my forehead, and
+Aunt Sally she see it, and turns white as a sheet, and says:
+
+“For the land’s sake, what _is_ the matter with the child?  He’s got the
+brain-fever as shore as you’re born, and they’re oozing out!”
+
+And everybody runs to see, and she snatches off my hat, and out comes
+the bread and what was left of the butter, and she grabbed me, and
+hugged me, and says:
+
+“Oh, what a turn you did give me! and how glad and grateful I am it
+ain’t no worse; for luck’s against us, and it never rains but it pours,
+and when I see that truck I thought we’d lost you, for I knowed by
+the color and all it was just like your brains would be if--Dear,
+dear, whyd’nt you _tell_ me that was what you’d been down there for, I
+wouldn’t a cared.  Now cler out to bed, and don’t lemme see no more of
+you till morning!”
+
+I was up stairs in a second, and down the lightning-rod in another one,
+and shinning through the dark for the lean-to.  I couldn’t hardly get my
+words out, I was so anxious; but I told Tom as quick as I could we must
+jump for it now, and not a minute to lose--the house full of men, yonder,
+with guns!
+
+His eyes just blazed; and he says:
+
+“No!--is that so?  _ain’t_ it bully!  Why, Huck, if it was to do over
+again, I bet I could fetch two hundred!  If we could put it off till--”
+
+“Hurry!  _Hurry_!”  I says.  “Where’s Jim?”
+
+“Right at your elbow; if you reach out your arm you can touch him.
+ He’s dressed, and everything’s ready.  Now we’ll slide out and give the
+sheep-signal.”
+
+But then we heard the tramp of men coming to the door, and heard them
+begin to fumble with the pad-lock, and heard a man say:
+
+“I _told_ you we’d be too soon; they haven’t come--the door is locked.
+Here, I’ll lock some of you into the cabin, and you lay for ‘em in the
+dark and kill ‘em when they come; and the rest scatter around a piece,
+and listen if you can hear ‘em coming.”
+
+So in they come, but couldn’t see us in the dark, and most trod on
+us whilst we was hustling to get under the bed.  But we got under all
+right, and out through the hole, swift but soft--Jim first, me next,
+and Tom last, which was according to Tom’s orders.  Now we was in the
+lean-to, and heard trampings close by outside.  So we crept to the door,
+and Tom stopped us there and put his eye to the crack, but couldn’t make
+out nothing, it was so dark; and whispered and said he would listen
+for the steps to get further, and when he nudged us Jim must glide out
+first, and him last.  So he set his ear to the crack and listened, and
+listened, and listened, and the steps a-scraping around out there all
+the time; and at last he nudged us, and we slid out, and stooped down,
+not breathing, and not making the least noise, and slipped stealthy
+towards the fence in Injun file, and got to it all right, and me and Jim
+over it; but Tom’s britches catched fast on a splinter on the top
+rail, and then he hear the steps coming, so he had to pull loose, which
+snapped the splinter and made a noise; and as he dropped in our tracks
+and started somebody sings out:
+
+“Who’s that?  Answer, or I’ll shoot!”
+
+But we didn’t answer; we just unfurled our heels and shoved.  Then there
+was a rush, and a _Bang, Bang, Bang!_ and the bullets fairly whizzed
+around us! We heard them sing out:
+
+“Here they are!  They’ve broke for the river!  After ‘em, boys, and turn
+loose the dogs!”
+
+So here they come, full tilt.  We could hear them because they wore
+boots and yelled, but we didn’t wear no boots and didn’t yell.  We was
+in the path to the mill; and when they got pretty close on to us we
+dodged into the bush and let them go by, and then dropped in behind
+them.  They’d had all the dogs shut up, so they wouldn’t scare off the
+robbers; but by this time somebody had let them loose, and here they
+come, making powwow enough for a million; but they was our dogs; so we
+stopped in our tracks till they catched up; and when they see it warn’t
+nobody but us, and no excitement to offer them, they only just said
+howdy, and tore right ahead towards the shouting and clattering; and
+then we up-steam again, and whizzed along after them till we was nearly
+to the mill, and then struck up through the bush to where my canoe was
+tied, and hopped in and pulled for dear life towards the middle of the
+river, but didn’t make no more noise than we was obleeged to. Then we
+struck out, easy and comfortable, for the island where my raft was; and
+we could hear them yelling and barking at each other all up and down the
+bank, till we was so far away the sounds got dim and died out.  And when
+we stepped on to the raft I says:
+
+“_Now_, old Jim, you’re a free man again, and I bet you won’t ever be a
+slave no more.”
+
+“En a mighty good job it wuz, too, Huck.  It ‘uz planned beautiful, en
+it ‘uz done beautiful; en dey ain’t _nobody_ kin git up a plan dat’s mo’
+mixed-up en splendid den what dat one wuz.”
+
+We was all glad as we could be, but Tom was the gladdest of all because
+he had a bullet in the calf of his leg.
+
+When me and Jim heard that we didn’t feel so brash as what we did
+before. It was hurting him considerable, and bleeding; so we laid him in
+the wigwam and tore up one of the duke’s shirts for to bandage him, but
+he says:
+
+“Gimme the rags; I can do it myself.  Don’t stop now; don’t fool around
+here, and the evasion booming along so handsome; man the sweeps, and set
+her loose!  Boys, we done it elegant!--‘deed we did.  I wish _we’d_ a
+had the handling of Louis XVI., there wouldn’t a been no ‘Son of Saint
+Louis, ascend to heaven!’ wrote down in _his_ biography; no, sir, we’d
+a whooped him over the _border_--that’s what we’d a done with _him_--and
+done it just as slick as nothing at all, too.  Man the sweeps--man the
+sweeps!”
+
+But me and Jim was consulting--and thinking.  And after we’d thought a
+minute, I says:
+
+“Say it, Jim.”
+
+So he says:
+
+“Well, den, dis is de way it look to me, Huck.  Ef it wuz _him_ dat ‘uz
+bein’ sot free, en one er de boys wuz to git shot, would he say, ‘Go on
+en save me, nemmine ‘bout a doctor f’r to save dis one?’  Is dat like
+Mars Tom Sawyer?  Would he say dat?  You _bet_ he wouldn’t!  _well_,
+den, is _Jim_ gywne to say it?  No, sah--I doan’ budge a step out’n dis
+place ‘dout a _doctor_, not if it’s forty year!”
+
+I knowed he was white inside, and I reckoned he’d say what he did say--so
+it was all right now, and I told Tom I was a-going for a doctor.
+ He raised considerable row about it, but me and Jim stuck to it and
+wouldn’t budge; so he was for crawling out and setting the raft loose
+himself; but we wouldn’t let him.  Then he give us a piece of his mind,
+but it didn’t do no good.
+
+So when he sees me getting the canoe ready, he says:
+
+“Well, then, if you’re bound to go, I’ll tell you the way to do when you
+get to the village.  Shut the door and blindfold the doctor tight and
+fast, and make him swear to be silent as the grave, and put a purse
+full of gold in his hand, and then take and lead him all around the
+back alleys and everywheres in the dark, and then fetch him here in the
+canoe, in a roundabout way amongst the islands, and search him and take
+his chalk away from him, and don’t give it back to him till you get him
+back to the village, or else he will chalk this raft so he can find it
+again. It’s the way they all do.”
+
+So I said I would, and left, and Jim was to hide in the woods when he
+see the doctor coming till he was gone again.
+
+
+
+
+CHAPTER XLI.
+
+THE doctor was an old man; a very nice, kind-looking old man when I got
+him up.  I told him me and my brother was over on Spanish Island hunting
+yesterday afternoon, and camped on a piece of a raft we found, and about
+midnight he must a kicked his gun in his dreams, for it went off and
+shot him in the leg, and we wanted him to go over there and fix it and
+not say nothing about it, nor let anybody know, because we wanted to
+come home this evening and surprise the folks.
+
+“Who is your folks?” he says.
+
+“The Phelpses, down yonder.”
+
+“Oh,” he says.  And after a minute, he says:
+
+“How’d you say he got shot?”
+
+“He had a dream,” I says, “and it shot him.”
+
+“Singular dream,” he says.
+
+So he lit up his lantern, and got his saddle-bags, and we started.  But
+when he sees the canoe he didn’t like the look of her--said she was big
+enough for one, but didn’t look pretty safe for two.  I says:
+
+“Oh, you needn’t be afeard, sir, she carried the three of us easy
+enough.”
+
+“What three?”
+
+“Why, me and Sid, and--and--and _the guns_; that’s what I mean.”
+
+“Oh,” he says.
+
+But he put his foot on the gunnel and rocked her, and shook his head,
+and said he reckoned he’d look around for a bigger one.  But they was
+all locked and chained; so he took my canoe, and said for me to wait
+till he come back, or I could hunt around further, or maybe I better
+go down home and get them ready for the surprise if I wanted to.  But
+I said I didn’t; so I told him just how to find the raft, and then he
+started.
+
+I struck an idea pretty soon.  I says to myself, spos’n he can’t fix
+that leg just in three shakes of a sheep’s tail, as the saying is?
+spos’n it takes him three or four days?  What are we going to do?--lay
+around there till he lets the cat out of the bag?  No, sir; I know what
+_I’ll_ do.  I’ll wait, and when he comes back if he says he’s got to
+go any more I’ll get down there, too, if I swim; and we’ll take and tie
+him, and keep him, and shove out down the river; and when Tom’s done
+with him we’ll give him what it’s worth, or all we got, and then let him
+get ashore.
+
+So then I crept into a lumber-pile to get some sleep; and next time I
+waked up the sun was away up over my head!  I shot out and went for the
+doctor’s house, but they told me he’d gone away in the night some time
+or other, and warn’t back yet.  Well, thinks I, that looks powerful bad
+for Tom, and I’ll dig out for the island right off.  So away I shoved,
+and turned the corner, and nearly rammed my head into Uncle Silas’s
+stomach! He says:
+
+“Why, _Tom!_  Where you been all this time, you rascal?”
+
+“I hain’t been nowheres,” I says, “only just hunting for the runaway
+nigger--me and Sid.”
+
+“Why, where ever did you go?” he says.  “Your aunt’s been mighty
+uneasy.”
+
+“She needn’t,” I says, “because we was all right.  We followed the men
+and the dogs, but they outrun us, and we lost them; but we thought we
+heard them on the water, so we got a canoe and took out after them and
+crossed over, but couldn’t find nothing of them; so we cruised along
+up-shore till we got kind of tired and beat out; and tied up the canoe
+and went to sleep, and never waked up till about an hour ago; then we
+paddled over here to hear the news, and Sid’s at the post-office to see
+what he can hear, and I’m a-branching out to get something to eat for
+us, and then we’re going home.”
+
+So then we went to the post-office to get “Sid”; but just as I
+suspicioned, he warn’t there; so the old man he got a letter out of the
+office, and we waited awhile longer, but Sid didn’t come; so the old man
+said, come along, let Sid foot it home, or canoe it, when he got done
+fooling around--but we would ride.  I couldn’t get him to let me stay
+and wait for Sid; and he said there warn’t no use in it, and I must come
+along, and let Aunt Sally see we was all right.
+
+When we got home Aunt Sally was that glad to see me she laughed and
+cried both, and hugged me, and give me one of them lickings of hern that
+don’t amount to shucks, and said she’d serve Sid the same when he come.
+
+And the place was plum full of farmers and farmers’ wives, to dinner;
+and such another clack a body never heard.  Old Mrs. Hotchkiss was the
+worst; her tongue was a-going all the time.  She says:
+
+“Well, Sister Phelps, I’ve ransacked that-air cabin over, an’ I b’lieve
+the nigger was crazy.  I says to Sister Damrell--didn’t I, Sister
+Damrell?--s’I, he’s crazy, s’I--them’s the very words I said.  You all
+hearn me: he’s crazy, s’I; everything shows it, s’I.  Look at that-air
+grindstone, s’I; want to tell _me_’t any cretur ‘t’s in his right mind
+‘s a goin’ to scrabble all them crazy things onto a grindstone, s’I?
+ Here sich ‘n’ sich a person busted his heart; ‘n’ here so ‘n’ so
+pegged along for thirty-seven year, ‘n’ all that--natcherl son o’ Louis
+somebody, ‘n’ sich everlast’n rubbage.  He’s plumb crazy, s’I; it’s what
+I says in the fust place, it’s what I says in the middle, ‘n’ it’s what
+I says last ‘n’ all the time--the nigger’s crazy--crazy ‘s Nebokoodneezer,
+s’I.”
+
+“An’ look at that-air ladder made out’n rags, Sister Hotchkiss,” says
+old Mrs. Damrell; “what in the name o’ goodness _could_ he ever want
+of--”
+
+“The very words I was a-sayin’ no longer ago th’n this minute to Sister
+Utterback, ‘n’ she’ll tell you so herself.  Sh-she, look at that-air rag
+ladder, sh-she; ‘n’ s’I, yes, _look_ at it, s’I--what _could_ he a-wanted
+of it, s’I.  Sh-she, Sister Hotchkiss, sh-she--”
+
+“But how in the nation’d they ever _git_ that grindstone _in_ there,
+_anyway_? ‘n’ who dug that-air _hole_? ‘n’ who--”
+
+“My very _words_, Brer Penrod!  I was a-sayin’--pass that-air sasser o’
+m’lasses, won’t ye?--I was a-sayin’ to Sister Dunlap, jist this minute,
+how _did_ they git that grindstone in there, s’I.  Without _help_, mind
+you--‘thout _help_!  _that’s_ wher ‘tis.  Don’t tell _me_, s’I; there
+_wuz_ help, s’I; ‘n’ ther’ wuz a _plenty_ help, too, s’I; ther’s ben a
+_dozen_ a-helpin’ that nigger, ‘n’ I lay I’d skin every last nigger on
+this place but _I’d_ find out who done it, s’I; ‘n’ moreover, s’I--”
+
+“A _dozen_ says you!--_forty_ couldn’t a done every thing that’s been
+done. Look at them case-knife saws and things, how tedious they’ve been
+made; look at that bed-leg sawed off with ‘m, a week’s work for six men;
+look at that nigger made out’n straw on the bed; and look at--”
+
+“You may _well_ say it, Brer Hightower!  It’s jist as I was a-sayin’
+to Brer Phelps, his own self.  S’e, what do _you_ think of it, Sister
+Hotchkiss, s’e? Think o’ what, Brer Phelps, s’I?  Think o’ that bed-leg
+sawed off that a way, s’e?  _think_ of it, s’I?  I lay it never sawed
+_itself_ off, s’I--somebody _sawed_ it, s’I; that’s my opinion, take it
+or leave it, it mayn’t be no ‘count, s’I, but sich as ‘t is, it’s my
+opinion, s’I, ‘n’ if any body k’n start a better one, s’I, let him _do_
+it, s’I, that’s all.  I says to Sister Dunlap, s’I--”
+
+“Why, dog my cats, they must a ben a house-full o’ niggers in there
+every night for four weeks to a done all that work, Sister Phelps.  Look
+at that shirt--every last inch of it kivered over with secret African
+writ’n done with blood!  Must a ben a raft uv ‘m at it right along, all
+the time, amost.  Why, I’d give two dollars to have it read to me; ‘n’
+as for the niggers that wrote it, I ‘low I’d take ‘n’ lash ‘m t’ll--”
+
+“People to _help_ him, Brother Marples!  Well, I reckon you’d _think_
+so if you’d a been in this house for a while back.  Why, they’ve stole
+everything they could lay their hands on--and we a-watching all the time,
+mind you. They stole that shirt right off o’ the line! and as for that
+sheet they made the rag ladder out of, ther’ ain’t no telling how
+many times they _didn’t_ steal that; and flour, and candles, and
+candlesticks, and spoons, and the old warming-pan, and most a thousand
+things that I disremember now, and my new calico dress; and me and
+Silas and my Sid and Tom on the constant watch day _and_ night, as I was
+a-telling you, and not a one of us could catch hide nor hair nor sight
+nor sound of them; and here at the last minute, lo and behold you, they
+slides right in under our noses and fools us, and not only fools _us_
+but the Injun Territory robbers too, and actuly gets _away_ with that
+nigger safe and sound, and that with sixteen men and twenty-two dogs
+right on their very heels at that very time!  I tell you, it just bangs
+anything I ever _heard_ of. Why, _sperits_ couldn’t a done better and
+been no smarter. And I reckon they must a _been_ sperits--because, _you_
+know our dogs, and ther’ ain’t no better; well, them dogs never even got
+on the _track_ of ‘m once!  You explain _that_ to me if you can!--_any_
+of you!”
+
+“Well, it does beat--”
+
+“Laws alive, I never--”
+
+“So help me, I wouldn’t a be--”
+
+“_House_-thieves as well as--”
+
+“Goodnessgracioussakes, I’d a ben afeard to live in sich a--”
+
+“‘Fraid to _live_!--why, I was that scared I dasn’t hardly go to bed, or
+get up, or lay down, or _set_ down, Sister Ridgeway.  Why, they’d steal
+the very--why, goodness sakes, you can guess what kind of a fluster I was
+in by the time midnight come last night.  I hope to gracious if I warn’t
+afraid they’d steal some o’ the family!  I was just to that pass I
+didn’t have no reasoning faculties no more.  It looks foolish enough
+_now_, in the daytime; but I says to myself, there’s my two poor boys
+asleep, ‘way up stairs in that lonesome room, and I declare to goodness
+I was that uneasy ‘t I crep’ up there and locked ‘em in!  I _did_.  And
+anybody would. Because, you know, when you get scared that way, and it
+keeps running on, and getting worse and worse all the time, and your
+wits gets to addling, and you get to doing all sorts o’ wild things,
+and by and by you think to yourself, spos’n I was a boy, and was away up
+there, and the door ain’t locked, and you--” She stopped, looking kind
+of wondering, and then she turned her head around slow, and when her eye
+lit on me--I got up and took a walk.
+
+Says I to myself, I can explain better how we come to not be in that
+room this morning if I go out to one side and study over it a little.
+ So I done it.  But I dasn’t go fur, or she’d a sent for me.  And when
+it was late in the day the people all went, and then I come in and
+told her the noise and shooting waked up me and “Sid,” and the door was
+locked, and we wanted to see the fun, so we went down the lightning-rod,
+and both of us got hurt a little, and we didn’t never want to try _that_
+no more.  And then I went on and told her all what I told Uncle Silas
+before; and then she said she’d forgive us, and maybe it was all right
+enough anyway, and about what a body might expect of boys, for all boys
+was a pretty harum-scarum lot as fur as she could see; and so, as long
+as no harm hadn’t come of it, she judged she better put in her time
+being grateful we was alive and well and she had us still, stead of
+fretting over what was past and done.  So then she kissed me, and patted
+me on the head, and dropped into a kind of a brown study; and pretty
+soon jumps up, and says:
+
+“Why, lawsamercy, it’s most night, and Sid not come yet!  What _has_
+become of that boy?”
+
+I see my chance; so I skips up and says:
+
+“I’ll run right up to town and get him,” I says.
+
+“No you won’t,” she says.  “You’ll stay right wher’ you are; _one’s_
+enough to be lost at a time.  If he ain’t here to supper, your uncle ‘ll
+go.”
+
+Well, he warn’t there to supper; so right after supper uncle went.
+
+He come back about ten a little bit uneasy; hadn’t run across Tom’s
+track. Aunt Sally was a good _deal_ uneasy; but Uncle Silas he said
+there warn’t no occasion to be--boys will be boys, he said, and you’ll
+see this one turn up in the morning all sound and right.  So she had
+to be satisfied.  But she said she’d set up for him a while anyway, and
+keep a light burning so he could see it.
+
+And then when I went up to bed she come up with me and fetched her
+candle, and tucked me in, and mothered me so good I felt mean, and like
+I couldn’t look her in the face; and she set down on the bed and talked
+with me a long time, and said what a splendid boy Sid was, and didn’t
+seem to want to ever stop talking about him; and kept asking me every
+now and then if I reckoned he could a got lost, or hurt, or maybe
+drownded, and might be laying at this minute somewheres suffering or
+dead, and she not by him to help him, and so the tears would drip down
+silent, and I would tell her that Sid was all right, and would be home
+in the morning, sure; and she would squeeze my hand, or maybe kiss me,
+and tell me to say it again, and keep on saying it, because it done her
+good, and she was in so much trouble.  And when she was going away she
+looked down in my eyes so steady and gentle, and says:
+
+“The door ain’t going to be locked, Tom, and there’s the window and
+the rod; but you’ll be good, _won’t_ you?  And you won’t go?  For _my_
+sake.”
+
+Laws knows I _wanted_ to go bad enough to see about Tom, and was all
+intending to go; but after that I wouldn’t a went, not for kingdoms.
+
+But she was on my mind and Tom was on my mind, so I slept very restless.
+And twice I went down the rod away in the night, and slipped around
+front, and see her setting there by her candle in the window with her
+eyes towards the road and the tears in them; and I wished I could do
+something for her, but I couldn’t, only to swear that I wouldn’t never
+do nothing to grieve her any more.  And the third time I waked up at
+dawn, and slid down, and she was there yet, and her candle was most out,
+and her old gray head was resting on her hand, and she was asleep.
+
+
+
+
+CHAPTER XLII.
+
+THE old man was uptown again before breakfast, but couldn’t get no
+track of Tom; and both of them set at the table thinking, and not saying
+nothing, and looking mournful, and their coffee getting cold, and not
+eating anything. And by and by the old man says:
+
+“Did I give you the letter?”
+
+“What letter?”
+
+“The one I got yesterday out of the post-office.”
+
+“No, you didn’t give me no letter.”
+
+“Well, I must a forgot it.”
+
+So he rummaged his pockets, and then went off somewheres where he had
+laid it down, and fetched it, and give it to her.  She says:
+
+“Why, it’s from St. Petersburg--it’s from Sis.”
+
+I allowed another walk would do me good; but I couldn’t stir.  But
+before she could break it open she dropped it and run--for she see
+something. And so did I. It was Tom Sawyer on a mattress; and that old
+doctor; and Jim, in _her_ calico dress, with his hands tied behind him;
+and a lot of people.  I hid the letter behind the first thing that come
+handy, and rushed.  She flung herself at Tom, crying, and says:
+
+“Oh, he’s dead, he’s dead, I know he’s dead!”
+
+And Tom he turned his head a little, and muttered something or other,
+which showed he warn’t in his right mind; then she flung up her hands,
+and says:
+
+“He’s alive, thank God!  And that’s enough!” and she snatched a kiss of
+him, and flew for the house to get the bed ready, and scattering orders
+right and left at the niggers and everybody else, as fast as her tongue
+could go, every jump of the way.
+
+I followed the men to see what they was going to do with Jim; and the
+old doctor and Uncle Silas followed after Tom into the house.  The men
+was very huffy, and some of them wanted to hang Jim for an example to
+all the other niggers around there, so they wouldn’t be trying to run
+away like Jim done, and making such a raft of trouble, and keeping a
+whole family scared most to death for days and nights.  But the others
+said, don’t do it, it wouldn’t answer at all; he ain’t our nigger, and
+his owner would turn up and make us pay for him, sure.  So that cooled
+them down a little, because the people that’s always the most anxious
+for to hang a nigger that hain’t done just right is always the very
+ones that ain’t the most anxious to pay for him when they’ve got their
+satisfaction out of him.
+
+They cussed Jim considerble, though, and give him a cuff or two side the
+head once in a while, but Jim never said nothing, and he never let on to
+know me, and they took him to the same cabin, and put his own clothes
+on him, and chained him again, and not to no bed-leg this time, but to
+a big staple drove into the bottom log, and chained his hands, too, and
+both legs, and said he warn’t to have nothing but bread and water to
+eat after this till his owner come, or he was sold at auction because
+he didn’t come in a certain length of time, and filled up our hole, and
+said a couple of farmers with guns must stand watch around about the
+cabin every night, and a bulldog tied to the door in the daytime; and
+about this time they was through with the job and was tapering off with
+a kind of generl good-bye cussing, and then the old doctor comes and
+takes a look, and says:
+
+“Don’t be no rougher on him than you’re obleeged to, because he ain’t
+a bad nigger.  When I got to where I found the boy I see I couldn’t cut
+the bullet out without some help, and he warn’t in no condition for
+me to leave to go and get help; and he got a little worse and a little
+worse, and after a long time he went out of his head, and wouldn’t let
+me come a-nigh him any more, and said if I chalked his raft he’d kill
+me, and no end of wild foolishness like that, and I see I couldn’t do
+anything at all with him; so I says, I got to have _help_ somehow; and
+the minute I says it out crawls this nigger from somewheres and says
+he’ll help, and he done it, too, and done it very well.  Of course I
+judged he must be a runaway nigger, and there I _was_! and there I had
+to stick right straight along all the rest of the day and all night.  It
+was a fix, I tell you! I had a couple of patients with the chills, and
+of course I’d of liked to run up to town and see them, but I dasn’t,
+because the nigger might get away, and then I’d be to blame; and yet
+never a skiff come close enough for me to hail.  So there I had to stick
+plumb until daylight this morning; and I never see a nigger that was a
+better nuss or faithfuller, and yet he was risking his freedom to do it,
+and was all tired out, too, and I see plain enough he’d been worked
+main hard lately.  I liked the nigger for that; I tell you, gentlemen, a
+nigger like that is worth a thousand dollars--and kind treatment, too.  I
+had everything I needed, and the boy was doing as well there as he
+would a done at home--better, maybe, because it was so quiet; but there I
+_was_, with both of ‘m on my hands, and there I had to stick till about
+dawn this morning; then some men in a skiff come by, and as good luck
+would have it the nigger was setting by the pallet with his head propped
+on his knees sound asleep; so I motioned them in quiet, and they slipped
+up on him and grabbed him and tied him before he knowed what he was
+about, and we never had no trouble. And the boy being in a kind of a
+flighty sleep, too, we muffled the oars and hitched the raft on, and
+towed her over very nice and quiet, and the nigger never made the least
+row nor said a word from the start.  He ain’t no bad nigger, gentlemen;
+that’s what I think about him.”
+
+Somebody says:
+
+“Well, it sounds very good, doctor, I’m obleeged to say.”
+
+Then the others softened up a little, too, and I was mighty thankful
+to that old doctor for doing Jim that good turn; and I was glad it was
+according to my judgment of him, too; because I thought he had a good
+heart in him and was a good man the first time I see him.  Then they
+all agreed that Jim had acted very well, and was deserving to have some
+notice took of it, and reward.  So every one of them promised, right out
+and hearty, that they wouldn’t cuss him no more.
+
+Then they come out and locked him up.  I hoped they was going to say he
+could have one or two of the chains took off, because they was rotten
+heavy, or could have meat and greens with his bread and water; but they
+didn’t think of it, and I reckoned it warn’t best for me to mix in, but
+I judged I’d get the doctor’s yarn to Aunt Sally somehow or other as
+soon as I’d got through the breakers that was laying just ahead of
+me--explanations, I mean, of how I forgot to mention about Sid being shot
+when I was telling how him and me put in that dratted night paddling
+around hunting the runaway nigger.
+
+But I had plenty time.  Aunt Sally she stuck to the sick-room all day
+and all night, and every time I see Uncle Silas mooning around I dodged
+him.
+
+Next morning I heard Tom was a good deal better, and they said Aunt
+Sally was gone to get a nap.  So I slips to the sick-room, and if I
+found him awake I reckoned we could put up a yarn for the family that
+would wash. But he was sleeping, and sleeping very peaceful, too; and
+pale, not fire-faced the way he was when he come.  So I set down and
+laid for him to wake.  In about half an hour Aunt Sally comes gliding
+in, and there I was, up a stump again!  She motioned me to be still, and
+set down by me, and begun to whisper, and said we could all be joyful
+now, because all the symptoms was first-rate, and he’d been sleeping
+like that for ever so long, and looking better and peacefuller all the
+time, and ten to one he’d wake up in his right mind.
+
+So we set there watching, and by and by he stirs a bit, and opened his
+eyes very natural, and takes a look, and says:
+
+“Hello!--why, I’m at _home_!  How’s that?  Where’s the raft?”
+
+“It’s all right,” I says.
+
+“And _Jim_?”
+
+“The same,” I says, but couldn’t say it pretty brash.  But he never
+noticed, but says:
+
+“Good!  Splendid!  _Now_ we’re all right and safe! Did you tell Aunty?”
+
+I was going to say yes; but she chipped in and says:  “About what, Sid?”
+
+“Why, about the way the whole thing was done.”
+
+“What whole thing?”
+
+“Why, _the_ whole thing.  There ain’t but one; how we set the runaway
+nigger free--me and Tom.”
+
+“Good land!  Set the run--What _is_ the child talking about!  Dear, dear,
+out of his head again!”
+
+“_No_, I ain’t out of my _head_; I know all what I’m talking about.  We
+_did_ set him free--me and Tom.  We laid out to do it, and we _done_ it.
+ And we done it elegant, too.”  He’d got a start, and she never checked
+him up, just set and stared and stared, and let him clip along, and
+I see it warn’t no use for _me_ to put in.  “Why, Aunty, it cost us a
+power of work--weeks of it--hours and hours, every night, whilst you was
+all asleep. And we had to steal candles, and the sheet, and the shirt,
+and your dress, and spoons, and tin plates, and case-knives, and the
+warming-pan, and the grindstone, and flour, and just no end of things,
+and you can’t think what work it was to make the saws, and pens, and
+inscriptions, and one thing or another, and you can’t think _half_ the
+fun it was.  And we had to make up the pictures of coffins and things,
+and nonnamous letters from the robbers, and get up and down the
+lightning-rod, and dig the hole into the cabin, and made the rope ladder
+and send it in cooked up in a pie, and send in spoons and things to work
+with in your apron pocket--”
+
+“Mercy sakes!”
+
+“--and load up the cabin with rats and snakes and so on, for company for
+Jim; and then you kept Tom here so long with the butter in his hat that
+you come near spiling the whole business, because the men come before
+we was out of the cabin, and we had to rush, and they heard us and let
+drive at us, and I got my share, and we dodged out of the path and let
+them go by, and when the dogs come they warn’t interested in us, but
+went for the most noise, and we got our canoe, and made for the
+raft, and was all safe, and Jim was a free man, and we done it all by
+ourselves, and _wasn’t_ it bully, Aunty!”
+
+“Well, I never heard the likes of it in all my born days!  So it was
+_you_, you little rapscallions, that’s been making all this trouble,
+and turned everybody’s wits clean inside out and scared us all most to
+death.  I’ve as good a notion as ever I had in my life to take it out
+o’ you this very minute.  To think, here I’ve been, night after night,
+a--_you_ just get well once, you young scamp, and I lay I’ll tan the Old
+Harry out o’ both o’ ye!”
+
+But Tom, he _was_ so proud and joyful, he just _couldn’t_ hold in,
+and his tongue just _went_ it--she a-chipping in, and spitting fire all
+along, and both of them going it at once, like a cat convention; and she
+says:
+
+“_Well_, you get all the enjoyment you can out of it _now_, for mind I
+tell you if I catch you meddling with him again--”
+
+“Meddling with _who_?”  Tom says, dropping his smile and looking
+surprised.
+
+“With _who_?  Why, the runaway nigger, of course.  Who’d you reckon?”
+
+Tom looks at me very grave, and says:
+
+“Tom, didn’t you just tell me he was all right?  Hasn’t he got away?”
+
+“_Him_?” says Aunt Sally; “the runaway nigger?  ‘Deed he hasn’t.
+ They’ve got him back, safe and sound, and he’s in that cabin again,
+on bread and water, and loaded down with chains, till he’s claimed or
+sold!”
+
+Tom rose square up in bed, with his eye hot, and his nostrils opening
+and shutting like gills, and sings out to me:
+
+“They hain’t no _right_ to shut him up!  SHOVE!--and don’t you lose a
+minute.  Turn him loose! he ain’t no slave; he’s as free as any cretur
+that walks this earth!”
+
+“What _does_ the child mean?”
+
+“I mean every word I _say_, Aunt Sally, and if somebody don’t go, _I’ll_
+go. I’ve knowed him all his life, and so has Tom, there.  Old Miss
+Watson died two months ago, and she was ashamed she ever was going to
+sell him down the river, and _said_ so; and she set him free in her
+will.”
+
+“Then what on earth did _you_ want to set him free for, seeing he was
+already free?”
+
+“Well, that _is_ a question, I must say; and just like women!  Why,
+I wanted the _adventure_ of it; and I’d a waded neck-deep in blood
+to--goodness alive, _Aunt Polly!_”
+
+If she warn’t standing right there, just inside the door, looking as
+sweet and contented as an angel half full of pie, I wish I may never!
+
+Aunt Sally jumped for her, and most hugged the head off of her, and
+cried over her, and I found a good enough place for me under the bed,
+for it was getting pretty sultry for us, seemed to me.  And I peeped
+out, and in a little while Tom’s Aunt Polly shook herself loose and
+stood there looking across at Tom over her spectacles--kind of grinding
+him into the earth, you know.  And then she says:
+
+“Yes, you _better_ turn y’r head away--I would if I was you, Tom.”
+
+“Oh, deary me!” says Aunt Sally; “_Is_ he changed so?  Why, that ain’t
+_Tom_, it’s Sid; Tom’s--Tom’s--why, where is Tom?  He was here a minute
+ago.”
+
+“You mean where’s Huck _Finn_--that’s what you mean!  I reckon I hain’t
+raised such a scamp as my Tom all these years not to know him when I
+_see_ him.  That _would_ be a pretty howdy-do. Come out from under that
+bed, Huck Finn.”
+
+So I done it.  But not feeling brash.
+
+Aunt Sally she was one of the mixed-upest-looking persons I ever
+see--except one, and that was Uncle Silas, when he come in and they told
+it all to him.  It kind of made him drunk, as you may say, and he didn’t
+know nothing at all the rest of the day, and preached a prayer-meeting
+sermon that night that gave him a rattling ruputation, because the
+oldest man in the world couldn’t a understood it.  So Tom’s Aunt Polly,
+she told all about who I was, and what; and I had to up and tell how
+I was in such a tight place that when Mrs. Phelps took me for Tom
+Sawyer--she chipped in and says, “Oh, go on and call me Aunt Sally, I’m
+used to it now, and ‘tain’t no need to change”--that when Aunt Sally took
+me for Tom Sawyer I had to stand it--there warn’t no other way, and
+I knowed he wouldn’t mind, because it would be nuts for him, being
+a mystery, and he’d make an adventure out of it, and be perfectly
+satisfied.  And so it turned out, and he let on to be Sid, and made
+things as soft as he could for me.
+
+And his Aunt Polly she said Tom was right about old Miss Watson setting
+Jim free in her will; and so, sure enough, Tom Sawyer had gone and took
+all that trouble and bother to set a free nigger free! and I couldn’t
+ever understand before, until that minute and that talk, how he _could_
+help a body set a nigger free with his bringing-up.
+
+Well, Aunt Polly she said that when Aunt Sally wrote to her that Tom and
+_Sid_ had come all right and safe, she says to herself:
+
+“Look at that, now!  I might have expected it, letting him go off that
+way without anybody to watch him.  So now I got to go and trapse all
+the way down the river, eleven hundred mile, and find out what that
+creetur’s up to _this_ time, as long as I couldn’t seem to get any
+answer out of you about it.”
+
+“Why, I never heard nothing from you,” says Aunt Sally.
+
+“Well, I wonder!  Why, I wrote you twice to ask you what you could mean
+by Sid being here.”
+
+“Well, I never got ‘em, Sis.”
+
+Aunt Polly she turns around slow and severe, and says:
+
+“You, Tom!”
+
+“Well--_what_?” he says, kind of pettish.
+
+“Don’t you what _me_, you impudent thing--hand out them letters.”
+
+“What letters?”
+
+“_Them_ letters.  I be bound, if I have to take a-holt of you I’ll--”
+
+“They’re in the trunk.  There, now.  And they’re just the same as they
+was when I got them out of the office.  I hain’t looked into them, I
+hain’t touched them.  But I knowed they’d make trouble, and I thought if
+you warn’t in no hurry, I’d--”
+
+“Well, you _do_ need skinning, there ain’t no mistake about it.  And I
+wrote another one to tell you I was coming; and I s’pose he--”
+
+“No, it come yesterday; I hain’t read it yet, but _it’s_ all right, I’ve
+got that one.”
+
+I wanted to offer to bet two dollars she hadn’t, but I reckoned maybe it
+was just as safe to not to.  So I never said nothing.
+
+
+
+
+CHAPTER THE LAST
+
+THE first time I catched Tom private I asked him what was his idea, time
+of the evasion?--what it was he’d planned to do if the evasion worked all
+right and he managed to set a nigger free that was already free before?
+And he said, what he had planned in his head from the start, if we got
+Jim out all safe, was for us to run him down the river on the raft, and
+have adventures plumb to the mouth of the river, and then tell him about
+his being free, and take him back up home on a steamboat, in style,
+and pay him for his lost time, and write word ahead and get out all
+the niggers around, and have them waltz him into town with a torchlight
+procession and a brass-band, and then he would be a hero, and so would
+we.  But I reckoned it was about as well the way it was.
+
+We had Jim out of the chains in no time, and when Aunt Polly and Uncle
+Silas and Aunt Sally found out how good he helped the doctor nurse Tom,
+they made a heap of fuss over him, and fixed him up prime, and give him
+all he wanted to eat, and a good time, and nothing to do.  And we had
+him up to the sick-room, and had a high talk; and Tom give Jim forty
+dollars for being prisoner for us so patient, and doing it up so good,
+and Jim was pleased most to death, and busted out, and says:
+
+“Dah, now, Huck, what I tell you?--what I tell you up dah on Jackson
+islan’?  I _tole_ you I got a hairy breas’, en what’s de sign un it; en
+I _tole_ you I ben rich wunst, en gwineter to be rich _agin_; en it’s
+come true; en heah she is!  _dah_, now! doan’ talk to _me_--signs is
+_signs_, mine I tell you; en I knowed jis’ ‘s well ‘at I ‘uz gwineter be
+rich agin as I’s a-stannin’ heah dis minute!”
+
+And then Tom he talked along and talked along, and says, le’s all three
+slide out of here one of these nights and get an outfit, and go for
+howling adventures amongst the Injuns, over in the Territory, for a
+couple of weeks or two; and I says, all right, that suits me, but I
+ain’t got no money for to buy the outfit, and I reckon I couldn’t get
+none from home, because it’s likely pap’s been back before now, and got
+it all away from Judge Thatcher and drunk it up.
+
+“No, he hain’t,” Tom says; “it’s all there yet--six thousand dollars
+and more; and your pap hain’t ever been back since.  Hadn’t when I come
+away, anyhow.”
+
+Jim says, kind of solemn:
+
+“He ain’t a-comin’ back no mo’, Huck.”
+
+I says:
+
+“Why, Jim?”
+
+“Nemmine why, Huck--but he ain’t comin’ back no mo.”
+
+But I kept at him; so at last he says:
+
+“Doan’ you ‘member de house dat was float’n down de river, en dey wuz a
+man in dah, kivered up, en I went in en unkivered him and didn’ let you
+come in?  Well, den, you kin git yo’ money when you wants it, kase dat
+wuz him.”
+
+Tom’s most well now, and got his bullet around his neck on a watch-guard
+for a watch, and is always seeing what time it is, and so there ain’t
+nothing more to write about, and I am rotten glad of it, because if I’d
+a knowed what a trouble it was to make a book I wouldn’t a tackled it,
+and ain’t a-going to no more.  But I reckon I got to light out for the
+Territory ahead of the rest, because Aunt Sally she’s going to adopt me
+and sivilize me, and I can’t stand it.  I been there before.
+
+THE END. YOURS TRULY, _HUCK FINN_.
+
+
+
+
+
+End of the Project Gutenberg EBook of Adventures of Huckleberry Finn,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK HUCKLEBERRY FINN ***
+
+***** This file should be named 76-0.htm or 76-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/76/
+
+Produced by David Widger. Previous editions produced by Ron Burkey and
+Internet Wiretap
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/tf-idf/src/main/resources/books/land-of-oz.txt
+++ b/jet/tf-idf/src/main/resources/books/land-of-oz.txt
@@ -1,0 +1,6638 @@
+﻿The Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+This eBook is for the use of anyone anywhere in the United States and most
+other parts of the world at no cost and with almost no restrictions
+whatsoever.  You may copy it, give it away or re-use it under the terms of
+the Project Gutenberg License included with this eBook or online at
+www.gutenberg.org.  If you are not located in the United States, you'll have
+to check the laws of the country where you are located before using this ebook.
+
+Title: The Land of Oz
+
+Author: L. Frank Baum
+
+Illustrator: John Neill
+
+Release Date: December 30, 2016 [EBook #53844]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+
+
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+
+
+
+
+
+
+
+
+
+    The
+    Land of Oz
+
+    The Further Adventures of
+
+    A Sequel to
+    THE WIZARD OF OZ
+
+    by
+
+    L. Frank Baum
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration]
+
+The Famous Oz Books
+
+
+Since 1900 when L. Frank Baum introduced to the children of America
+THE WONDERFUL WIZARD OF OZ and all the other exciting characters who
+inhabit the land of Oz, these delightful fairy tales have stimulated
+the imagination of millions of young readers.
+
+These are stories which are genuine fantasy--creative, funny, tender,
+exciting and surprising. Filled with the rarest and most absurd
+creatures, each of the =14= volumes which now comprise the series, has
+been eagerly sought out by generation after generation until today they
+are known to all except the very young or those who were never young at
+all.
+
+When, in a recent survey, =The New York Times= polled a group of
+teenagers on the books they liked best when they were young, the Oz
+books topped the list.
+
+
+
+
+_THE FAMOUS OZ BOOKS_
+
+By L. Frank Baum:
+
+
+    THE WIZARD OF OZ
+    THE LAND OF OZ
+    OZMA OF OZ
+    DOROTHY AND THE WIZARD IN OZ
+    THE ROAD TO OZ
+    THE EMERALD CITY OF OZ
+    THE PATCHWORK GIRL OF OZ
+    TIK-TOK OF OZ
+    THE SCARECROW OF OZ
+    RINKITINK IN OZ
+    THE LOST PRINCESS OF OZ
+    THE TIN WOODMAN OF OZ
+    THE MAGIC OF OZ
+    GLINDA OF OZ
+
+
+    CHICAGO      THE REILLY & LEE CO.      _Publishers_
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration: TIP MANUFACTURES A PUMPKINHEAD]
+
+
+
+
+    The
+    Land of Oz
+
+    Being an account of the
+    further adventures of the
+
+    Scarecrow
+    and Tin Woodman
+
+    and also the strange experiences
+    of the Highly Magnified
+    Woggle-Bug, Jack Pumpkinhead,
+    the Animated Saw-Horse
+    and the Gump;
+    the story being
+
+    A Sequel _to_ The Wizard _of_ Oz
+
+    By
+
+    L. Frank Baum
+
+    Author of Father Goose--His Book; The Wizard of Oz; The Magical Monarch
+    of Mo; The Enchanted Isle of Yew, The Life and Adventures _of_
+    Santa Claus; Dot and Tot of Merryland etc., etc.
+
+    PICTURED BY
+
+    John R. Neill
+
+    CHICAGO
+
+    THE REILLY & LEE COMPANY
+
+
+
+
+[Illustration:
+
+    Copyright 1904
+
+    by
+
+    L. Frank Baum
+
+    All rights reserved
+]
+
+
+
+
+[Illustration:
+
+    Author's Note
+
+
+    After the publication of "The Wonderful Wizard of Oz" I began to
+    receive letters from children, telling me of their pleasure in
+    reading the story and asking me to "write something more" about the
+    Scarecrow and the Tin Woodman. At first I considered these little
+    letters, frank and earnest though they were, in the light of pretty
+    compliments; but the letters continued to come during succeeding
+    months, and even years.
+
+    Finally I promised one little girl, who made a long journey to
+    see me and prefer her request,--and she is a "Dorothy," by the
+    way--that when a thousand little girls had written me a thousand
+    little letters asking for another story of the Scarecrow and the
+    Tin Woodman, I would write the book. Either little Dorothy was a
+    fairy in disguise, and waved her magic wand, or the success of the
+    stage production of "The Wizard of Oz" made new friends for the
+    story. For the thousand letters reached their destination long
+    since--and many more followed them.
+
+    And now, although pleading guilty to a long delay, I have kept my
+    promise in this book.
+
+    L. FRANK BAUM.
+
+        Chicago, June, 1904.
+]
+
+
+
+
+[Illustration:
+
+    To those excellent good fellows and eminent comedians =David C.
+    Montgomery= and =Fred A. Stone= whose clever personations of the
+    Tin Woodman and the Scarecrow have delighted thousands of children
+    throughout the land, this book is gratefully dedicated
+                           by
+                       THE AUTHOR
+]
+
+
+
+
+[Illustration:
+
+    TIP.
+
+    JACK
+
+    MOMBI
+
+    SCARECROW
+
+    TIN WOODMAN
+
+    WOGGLE-BUG
+
+    GUMP
+]
+
+LIST OF CHAPTERS
+
+
+                                     PAGE
+
+    Tip Manufactures a Pumpkinhead            1
+    The Marvelous Powder of Life              9
+    The Flight of the Fugitives              23
+    Tip Makes an Experiment in Magic         33
+    The Awakening of the Saw-Horse           41
+    Jack Pumpkinhead's Ride                  53
+    His Majesty, the Scarecrow               65
+    General Jinjur's Army of Revolt          77
+    The Scarecrow Plans an Escape            91
+    The Journey to the Tin Woodman          103
+    A Nickel-Plated Emperor                 115
+    Mr. H. M. Woggle-Bug, T. E.             129
+    A Highly Magnified History              141
+    Old Mombi Indulges in Witchcraft        153
+    The Prisoners of the Queen              163
+    The Scarecrow Takes Time to Think       175
+    The Astonishing Flight of the Gump      185
+    In the Jackdaws' Nest                   195
+    Dr. Nikidik's Famous Wishing Pills      213
+    The Scarecrow Appeals to Glinda         225
+    The Tin Woodman Plucks a Rose           241
+    The Transformation of Old Mombi         251
+    Princess Ozma of Oz                     259
+    The Riches of Content                   273
+
+[Illustration]
+
+[Illustration:
+
+    The
+    Land _of_ Oz
+]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Manufactures
+    a Pumpkinhead
+]
+
+
+In the Country of the Gillikins, which is at the North of the Land of
+Oz, lived a youth called Tip. There was more to his name than that, for
+old Mombi often declared that his whole name was Tippetarius; but no
+one was expected to say such a long word when "Tip" would do just as
+well.
+
+This boy remembered nothing of his parents, for he had been brought
+when quite young to be reared by the old woman known as Mombi, whose
+reputation, I am sorry to say, was none of the best. For the Gillikin
+people had reason to suspect her of indulging in magical arts, and
+therefore hesitated to associate with her.
+
+Mombi was not exactly a Witch, because the Good Witch who ruled that
+part of the Land of Oz had forbidden any other Witch to exist in her
+dominions. So Tip's guardian, however much she might aspire to working
+magic, realized it was unlawful to be more than a Sorceress, or at most
+a Wizardess.
+
+[Illustration]
+
+Tip was made to carry wood from the forest, that the old woman might
+boil her pot. He also worked in the corn-fields, hoeing and husking;
+and he fed the pigs and milked the four-horned cow that was Mombi's
+especial pride.
+
+But you must not suppose he worked all the time, for he felt that
+would be bad for him. When sent to the forest Tip often climbed trees
+for birds' eggs or amused himself chasing the fleet white rabbits or
+fishing in the brooks with bent pins. Then he would hastily gather
+his armful of wood and carry it home. And when he was supposed to be
+working in the corn-fields, and the tall stalks hid him from Mombi's
+view, Tip would often dig in the gopher holes, or--if the mood seized
+him--lie upon his back between the rows of corn and take a nap. So, by
+taking care not to exhaust his strength, he grew as strong and rugged
+as a boy may be.
+
+Mombi's curious magic often frightened her neighbors, and they treated
+her shyly, yet respectfully, because of her weird powers. But Tip
+frankly hated her, and took no pains to hide his feelings. Indeed, he
+sometimes showed less respect for the old woman than he should have
+done, considering she was his guardian.
+
+[Illustration]
+
+There were pumpkins in Mombi's corn-fields, lying golden red among the
+rows of green stalks; and these had been planted and carefully tended
+that the four-horned cow might eat of them in the winter time. But one
+day, after the corn had all been cut and stacked, and Tip was carrying
+the pumpkins to the stable, he took a notion to make a "Jack Lantern"
+and try to give the old woman a fright with it.
+
+So he selected a fine, big pumpkin--one with a lustrous, orange-red
+color--and began carving it. With the point of his knife he made two
+round eyes, a three-cornered nose, and a mouth shaped like a new moon.
+The face, when completed, could not have been considered strictly
+beautiful; but it wore a smile so big and broad, and was so jolly in
+expression, that even Tip laughed as he looked admiringly at his work.
+
+The child had no playmates, so he did not know that boys often dig
+out the inside of a "pumpkin-jack," and in the space thus made put a
+lighted candle to render the face more startling; but he conceived an
+idea of his own that promised to be quite as effective. He decided to
+manufacture the form of a man, who would wear this pumpkin head, and to
+stand it in a place where old Mombi would meet it face to face.
+
+"And then," said Tip to himself, with a laugh, "she'll squeal louder
+than the brown pig does when I pull her tail, and shiver with fright
+worse than I did last year when I had the ague!"
+
+He had plenty of time to accomplish this task, for Mombi had gone to a
+village--to buy groceries, she said--and it was a journey of at least
+two days.
+
+So he took his axe to the forest, and selected some stout, straight
+saplings, which he cut down and trimmed of all their twigs and leaves.
+From these he would make the arms, and legs, and feet of his man. For
+the body he stripped a sheet of thick bark from around a big tree, and
+with much labor fashioned it into a cylinder of about the right size,
+pinning the edges together with wooden pegs. Then, whistling happily as
+he worked, he carefully jointed the limbs and fastened them to the body
+with pegs whittled into shape with his knife.
+
+By the time this feat had been accomplished it began to grow dark, and
+Tip remembered he must milk the cow and feed the pigs. So he picked up
+his wooden man and carried it back to the house with him.
+
+During the evening, by the light of the fire in the kitchen, Tip
+carefully rounded all the edges of the joints and smoothed the rough
+places in a neat and workmanlike manner. Then he stood the figure up
+against the wall and admired it. It seemed remarkably tall, even for a
+full-grown man; but that was a good point in a small boy's eyes, and
+Tip did not object at all to the size of his creation.
+
+Next morning, when he looked at his work again, Tip saw he had
+forgotten to give the dummy a neck, by means of which he might fasten
+the pumpkinhead to the body. So he went again to the forest, which was
+not far away, and chopped from a tree several pieces of wood with which
+to complete his work. When he returned he fastened a cross-piece to
+the upper end of the body, making a hole through the center to hold
+upright the neck. The bit of wood which formed this neck was also
+sharpened at the upper end, and when all was ready Tip put on the
+pumpkin head, pressing it well down onto the neck, and found that it
+fitted very well. The head could be turned to one side or the other, as
+he pleased, and the hinges of the arms and legs allowed him to place
+the dummy in any position he desired.
+
+"Now, that," declared Tip, proudly, "is really a very fine man, and it
+ought to frighten several screeches out of old Mombi! But it would be
+much more lifelike if it were properly dressed."
+
+To find clothing seemed no easy task; but Tip boldly ransacked the
+great chest in which Mombi kept all her keepsakes and treasures, and
+at the very bottom he discovered some purple trousers, a red shirt
+and a pink vest which was dotted with white spots. These he carried
+away to his man and succeeded, although the garments did not fit very
+well, in dressing the creature in a jaunty fashion. Some knit stockings
+belonging to Mombi and a much worn pair of his own shoes completed the
+man's apparel, and Tip was so delighted that he danced up and down and
+laughed aloud in boyish ecstasy.
+
+"I must give him a name!" he cried. "So good a man as this must surely
+have a name. I believe," he added, after a moment's thought, "I will
+name the fellow 'Jack Pumpkinhead!'"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Marvelous
+    Powder of Life
+]
+
+
+After considering the matter carefully, Tip decided that the best
+place to locate Jack would be at the bend in the road, a little way
+from the house. So he started to carry his man there, but found him
+heavy and rather awkward to handle. After dragging the creature a short
+distance Tip stood him on his feet, and by first bending the joints of
+one leg, and then those of the other,--at the same time pushing from
+behind,--the boy managed to induce Jack to walk to the bend in the
+road. It was not accomplished without a few tumbles, and Tip really
+worked harder than he ever had in the fields or forest; but a love of
+mischief urged him on, and it pleased him to test the cleverness of his
+workmanship.
+
+"Jack's all right, and works fine!" he said to himself, panting with
+the unusual exertion. But just then he discovered the man's left
+arm had fallen off in the journey; so he went back to find it, and
+afterward, by whittling a new and stouter pin for the shoulder-joint,
+he repaired the injury so successfully that the arm was stronger than
+before. Tip also noticed that Jack's pumpkin head had twisted around
+until it faced his back; but this was easily remedied. When, at last,
+the man was set up facing the turn in the path where old Mombi was to
+appear, he looked natural enough to be a fair imitation of a Gillikin
+farmer,--and unnatural enough to startle anyone that came on him
+unawares.
+
+As it was yet too early in the day to expect the old woman to return
+home, Tip went down into the valley below the farm-house and began to
+gather nuts from the trees that grew there.
+
+However, old Mombi returned earlier than usual. She had met a crooked
+wizard who resided in a lonely cave in the mountains, and had traded
+several important secrets of magic with him. Having in this way
+secured three new recipes, four magical powders and a selection of
+herbs of wonderful power and potency, she hobbled home as fast as she
+could, in order to test her new sorceries.
+
+So intent was Mombi on the treasures she had gained that when she
+turned the bend in the road and caught a glimpse of the man, she merely
+nodded and said:
+
+"Good evening, sir."
+
+But, a moment after, noting that the person did not move or reply,
+she cast a shrewd glance into his face and discovered his pumpkin
+head--elaborately carved by Tip's jack-knife.
+
+"Heh!" ejaculated Mombi, giving a sort of grunt; "that rascally boy
+has been playing tricks again! Very good! ve--ry _good_! I'll beat him
+black-and-blue for trying to scare me in this fashion!"
+
+Angrily she raised her stick to smash in the grinning pumpkin head of
+the dummy; but a sudden thought made her pause, the uplifted stick left
+motionless in the air.
+
+"Why, here is a good chance to try my new powder!" said she, eagerly.
+"And then I can tell whether that crooked wizard has fairly traded
+secrets, or whether he has fooled me as wickedly as I fooled him."
+
+So she set down her basket and began fumbling in it for one of the
+precious powders she had obtained.
+
+While Mombi was thus occupied Tip strolled back, with his pockets full
+of nuts, and discovered the old woman standing beside his man and
+apparently not the least bit frightened by it.
+
+At first he was greatly disappointed; but the next moment he became
+curious to know what Mombi was going to do. So he hid behind a hedge,
+where he could see without being seen, and prepared to watch.
+
+After some search the woman drew from her basket an old pepper-box,
+upon the faded label of which the wizard had written with a
+lead-pencil: "Powder of Life."
+
+"Ah--here it is!" she cried, joyfully. "And now let us see if it is
+potent. The stingy wizard didn't give me much of it, but I guess
+there's enough for two or three doses."
+
+[Illustration: "OLD MOMBI DANCED AROUND HIM"]
+
+Tip was much surprised when he overheard this speech. Then he saw old
+Mombi raise her arm and sprinkle the powder from the box over the
+pumpkin head of his man Jack. She did this in the same way one would
+pepper a baked potato, and the powder sifted down from Jack's head and
+scattered over the red shirt and pink waistcoat and purple trousers
+Tip had dressed him in, and a portion even fell upon the patched and
+worn shoes.
+
+Then, putting the pepper-box back into the basket, Mombi lifted her
+left hand, with its little finger pointed upward, and said:
+
+"Weaugh!"
+
+Then she lifted her right hand, with the thumb pointed upward, and said:
+
+"Teaugh!"
+
+Then she lifted both hands, with all the fingers and thumbs spread out,
+and cried:
+
+"Peaugh!"
+
+Jack Pumpkinhead stepped back a pace, at this, and said in a
+reproachful voice:
+
+"Don't yell like that! Do you think I'm deaf?"
+
+Old Mombi danced around him, frantic with delight.
+
+"He lives!" she screamed: "he lives! he lives!"
+
+Then she threw her stick into the air and caught it as it came down;
+and she hugged herself with both arms, and tried to do a step of a jig;
+and all the time she repeated, rapturously:
+
+"He lives!--he lives!--he lives!"
+
+Now you may well suppose that Tip observed all this with amazement.
+
+At first he was so frightened and horrified that he wanted to run
+away, but his legs trembled and shook so badly that he couldn't.
+Then it struck him as a very funny thing for Jack to come to life,
+especially as the expression on his pumpkin face was so droll and
+comical it excited laughter on the instant. So, recovering from his
+first fear, Tip began to laugh; and the merry peals reached old Mombi's
+ears and made her hobble quickly to the hedge, where she seized Tip's
+collar and dragged him back to where she had left her basket and the
+pumpkin-headed man.
+
+"You naughty, sneaking, wicked boy!" she exclaimed, furiously; "I'll
+teach you to spy out my secrets and to make fun of me!"
+
+"I wasn't making fun of you," protested Tip. "I was laughing at old
+Pumpkinhead! Look at him! Isn't he a picture, though?"
+
+"I hope you are not reflecting on my personal appearance," said Jack;
+and it was so funny to hear his grave voice, while his face continued
+to wear its jolly smile, that Tip again burst into a peal of laughter.
+
+Even Mombi was not without a curious interest in the man her magic had
+brought to life; for, after staring at him intently, she presently
+asked:
+
+[Illustration: OLD MOMBI PUTS JACK IN THE STABLE]
+
+"What do you know?"
+
+"Well, that is hard to tell," replied Jack. "For although I feel that
+I know a tremendous lot, I am not yet aware how much there is in the
+world to find out about. It will take me a little time to discover
+whether I am very wise or very foolish."
+
+"To be sure," said Mombi, thoughtfully.
+
+"But what are you going to do with him, now he is alive?" asked Tip,
+wondering.
+
+"I must think it over," answered Mombi. "But we must get home at once,
+for it is growing dark. Help the Pumpkinhead to walk."
+
+"Never mind me," said Jack; "I can walk as well as you can. Haven't I
+got legs and feet, and aren't they jointed?"
+
+"Are they?" asked the woman, turning to Tip.
+
+"Of course they are; I made 'em myself," returned the boy, with pride.
+
+So they started for the house; but when they reached the farm yard old
+Mombi led the pumpkin man to the cow stable and shut him up in an empty
+stall, fastening the door securely on the outside.
+
+"I've got to attend to you, first," she said, nodding her head at Tip.
+
+Hearing this, the boy became uneasy; for he knew Mombi had a bad and
+revengeful heart, and would not hesitate to do any evil thing.
+
+They entered the house. It was a round, dome-shaped structure, as are
+nearly all the farm houses in the Land of Oz.
+
+Mombi bade the boy light a candle, while she put her basket in a
+cupboard and hung her cloak on a peg. Tip obeyed quickly, for he was
+afraid of her.
+
+After the candle had been lighted Mombi ordered him to build a fire
+in the hearth, and while Tip was thus engaged the old woman ate her
+supper. When the flames began to crackle the boy came to her and asked
+a share of the bread and cheese; but Mombi refused him.
+
+"I'm hungry!" said Tip, in a sulky tone.
+
+"You won't be hungry long," replied Mombi, with a grim look.
+
+The boy didn't like this speech, for it sounded like a threat; but he
+happened to remember he had nuts in his pocket, so he cracked some of
+those and ate them while the woman rose, shook the crumbs from her
+apron, and hung above the fire a small black kettle.
+
+Then she measured out equal parts of milk and vinegar and poured them
+into the kettle. Next she produced several packets of herbs and
+powders and began adding a portion of each to the contents of the
+kettle. Occasionally she would draw near the candle and read from a
+yellow paper the recipe of the mess she was concocting.
+
+As Tip watched her his uneasiness increased.
+
+"What is that for?" he asked.
+
+"For you," returned Mombi, briefly.
+
+Tip wriggled around upon his stool and stared awhile at the kettle,
+which was beginning to bubble. Then he would glance at the stern and
+wrinkled features of the witch and wish he were any place but in that
+dim and smoky kitchen, where even the shadows cast by the candle upon
+the wall were enough to give one the horrors. So an hour passed away,
+during which the silence was only broken by the bubbling of the pot and
+the hissing of the flames.
+
+Finally, Tip spoke again.
+
+"Have I got to drink that stuff?" he asked, nodding toward the pot.
+
+"Yes," said Mombi.
+
+"What'll it do to me?" asked Tip.
+
+"If it's properly made," replied Mombi, "it will change or transform
+you into a marble statue."
+
+Tip groaned, and wiped the perspiration from his forehead with his
+sleeve.
+
+"I don't want to be a marble statue!" he protested.
+
+"That doesn't matter; I want you to be one," said the old woman,
+looking at him severely.
+
+"What use'll I be then?" asked Tip. "There won't be any one to work for
+you."
+
+"I'll make the Pumpkinhead work for me," said Mombi.
+
+Again Tip groaned.
+
+"Why don't you change me into a goat, or a chicken?" he asked,
+anxiously. "You can't do anything with a marble statue."
+
+"Oh, yes; I can," returned Mombi. "I'm going to plant a flower garden,
+next Spring, and I'll put you in the middle of it, for an ornament. I
+wonder I haven't thought of that before; you've been a bother to me for
+years."
+
+At this terrible speech Tip felt the beads of perspiration starting all
+over his body; but he sat still and shivered and looked anxiously at
+the kettle.
+
+"Perhaps it won't work," he muttered, in a voice that sounded weak and
+discouraged.
+
+"Oh, I think it will," answered Mombi, cheerfully. "I seldom make a
+mistake."
+
+Again there was a period of silence--a silence so long and gloomy that
+when Mombi finally lifted the kettle from the fire it was close to
+midnight.
+
+[Illustration: "I DON'T WANT TO BE A MARBLE STATUE."]
+
+"You cannot drink it until it has become quite cold," announced the
+old witch--for in spite of the law she had acknowledged practising
+witchcraft. "We must both go to bed now, and at daybreak I will call
+you and at once complete your transformation into a marble statue."
+
+With this she hobbled into her room, bearing the steaming kettle with
+her, and Tip heard her close and lock the door.
+
+The boy did not go to bed, as he had been commanded to do, but still
+sat glaring at the embers of the dying fire.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Flight of the
+    Fugitives
+]
+
+
+Tip reflected.
+
+"It's a hard thing, to be a marble statue," he thought, rebelliously,
+"and I'm not going to stand it. For years I've been a bother to her,
+she says; so she's going to get rid of me. Well, there's an easier way
+than to become a statue. No boy could have any fun forever standing in
+the middle of a flower garden! I'll run away, that's what I'll do--and
+I may as well go before she makes me drink that nasty stuff in the
+kettle."
+
+He waited until the snores of the old witch announced she was fast
+asleep, and then he arose softly and went to the cupboard to find
+something to eat.
+
+"No use starting on a journey without food," he decided, searching upon
+the narrow shelves.
+
+He found some crusts of bread; but he had to look into Mombi's basket
+to find the cheese she had brought from the village. While turning over
+the contents of the basket he came upon the pepper-box which contained
+the "Powder of Life."
+
+"I may as well take this with me," he thought, "or Mombi'll be using it
+to make more mischief with." So he put the box in his pocket, together
+with the bread and cheese.
+
+Then he cautiously left the house and latched the door behind him.
+Outside both moon and stars shone brightly, and the night seemed
+peaceful and inviting after the close and ill-smelling kitchen.
+
+"I'll be glad to get away," said Tip, softly; "for I never did like
+that old woman. I wonder how I ever came to live with her."
+
+He was walking slowly toward the road when a thought made him pause.
+
+"I don't like to leave Jack Pumpkinhead to the tender mercies of old
+Mombi," he muttered. "And Jack belongs to me, for I made him--even if
+the old witch did bring him to life."
+
+He retraced his steps to the cow-stable and opened the door of the
+stall where the pumpkin-headed man had been left.
+
+[Illustration: "TIP LED HIM ALONG THE PATH."]
+
+Jack was standing in the middle of the stall, and by the moonlight Tip
+could see he was smiling just as jovially as ever.
+
+"Come on!" said the boy, beckoning.
+
+"Where to?" asked Jack.
+
+"You'll know as soon as I do," answered Tip, smiling sympathetically
+into the pumpkin face. "All we've got to do now is to tramp."
+
+"Very well," returned Jack, and walked awkwardly out of the stable and
+into the moonlight.
+
+Tip turned toward the road and the man followed him. Jack walked with a
+sort of limp, and occasionally one of the joints of his legs would turn
+backward, instead of frontwise, almost causing him to tumble. But the
+Pumpkinhead was quick to notice this, and began to take more pains to
+step carefully; so that he met with few accidents.
+
+Tip led him along the path without stopping an instant. They could not
+go very fast, but they walked steadily; and by the time the moon sank
+away and the sun peeped over the hills they had travelled so great a
+distance that the boy had no reason to fear pursuit from the old witch.
+Moreover, he had turned first into one path, and then into another, so
+that should anyone follow them it would prove very difficult to guess
+which way they had gone, or where to seek them.
+
+[Illustration]
+
+Fairly satisfied that he had escaped--for a time, at least--being
+turned into a marble statue, the boy stopped his companion and seated
+himself upon a rock by the roadside.
+
+"Let's have some breakfast," he said.
+
+Jack Pumpkinhead watched Tip curiously, but refused to join in the
+repast.
+
+"I don't seem to be made the same way you are," he said.
+
+"I know you are not," returned Tip; "for I made you."
+
+"Oh! Did you?" asked Jack.
+
+"Certainly. And put you together. And carved your eyes and nose and
+ears and mouth," said Tip proudly. "And dressed you."
+
+Jack looked at his body and limbs critically.
+
+"It strikes me you made a very good job of it," he remarked.
+
+"Just so-so," replied Tip, modestly; for he began to see certain
+defects in the construction of his man. "If I'd known we were going to
+travel together I might have been a little more particular."
+
+"Why, then," said the Pumpkinhead, in a tone that expressed surprise,
+"you must be my creator--my parent--my father!"
+
+"Or your inventor," replied the boy with a laugh. "Yes, my son; I
+really believe I am!"
+
+"Then I owe you obedience," continued the man, "and you owe
+me--support."
+
+"That's it, exactly," declared Tip, jumping up. "So let us be off."
+
+"Where are we going?" asked Jack, when they had resumed their journey.
+
+"I'm not exactly sure," said the boy; "but I believe we are headed
+South, and that will bring us, sooner or later, to the Emerald City."
+
+"What city is that?" enquired the Pumpkinhead.
+
+"Why, it's the center of the Land of Oz, and the biggest town in all
+the country. I've never been there, myself, but I've heard all about
+its history. It was built by a mighty and wonderful Wizard named Oz,
+and everything there is of a green color--just as everything in this
+Country of the Gillikins is of a purple color."
+
+"Is everything here purple?" asked Jack.
+
+"Of course it is. Can't you see?" returned the boy.
+
+"I believe I must be color-blind," said the Pumpkinhead, after staring
+about him.
+
+"Well, the grass is purple, and the trees are purple, and the houses
+and fences are purple," explained Tip. "Even the mud in the roads is
+purple. But in the Emerald City everything is green that is purple
+here. And in the Country of the Munchkins, over at the East, everything
+is blue; and in the South country of the Quadlings everything is red;
+and in the West country of the Winkies, where the Tin Woodman rules,
+everything is yellow."
+
+"Oh!" said Jack. Then, after a pause, he asked: "Did you say a Tin
+Woodman rules the Winkies?"
+
+"Yes; he was one of those who helped Dorothy to destroy the Wicked
+Witch of the West, and the Winkies were so grateful that they invited
+him to become their ruler,--just as the people of the Emerald City
+invited the Scarecrow to rule them."
+
+"Dear me!" said Jack. "I'm getting confused with all this history. Who
+is the Scarecrow?"
+
+"Another friend of Dorothy's," replied Tip.
+
+"And who is Dorothy?"
+
+"She was a girl that came here from Kansas, a place in the big, outside
+World. She got blown to the Land of Oz by a cyclone, and while she was
+here the Scarecrow and the Tin Woodman accompanied her on her travels."
+
+"And where is she now?" inquired the Pumpkinhead.
+
+"Glinda the Good, who rules the Quadlings, sent her home again," said
+the boy.
+
+"Oh. And what became of the Scarecrow?"
+
+"I told you. He rules the Emerald City," answered Tip.
+
+"I thought you said it was ruled by a wonderful Wizard," objected Jack,
+seeming more and more confused.
+
+"Well, so I did. Now, pay attention, and I'll explain it," said Tip,
+speaking slowly and looking the smiling Pumpkinhead squarely in the
+eye. "Dorothy went to the Emerald City to ask the Wizard to send her
+back to Kansas; and the Scarecrow and the Tin Woodman went with her.
+But the Wizard couldn't send her back, because he wasn't so much of a
+Wizard as he might have been. And then they got angry at the Wizard,
+and threatened to expose him; so the Wizard made a big balloon and
+escaped in it, and no one has ever seen him since."
+
+"Now, that is very interesting history," said Jack, well pleased; "and
+I understand it perfectly--all but the explanation."
+
+"I'm glad you do," responded Tip. "After the Wizard was gone, the
+people of the Emerald City made His Majesty, the Scarecrow, their King;
+and I have heard that he became a very popular ruler."
+
+"Are we going to see this queer King?" asked Jack, with interest.
+
+"I think we may as well," replied the boy; "unless you have something
+better to do."
+
+"Oh, no, dear father," said the Pumpkinhead. "I am quite willing to go
+wherever you please."
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Tip Makes an
+    Experiment in Magic
+]
+
+
+The boy, small and rather delicate in appearance, seemed somewhat
+embarrassed at being called "father" by the tall, awkward,
+pumpkin-headed man; but to deny the relationship would involve another
+long and tedious explanation; so he changed the subject by asking,
+abruptly:
+
+"Are you tired?"
+
+"Of course not!" replied the other. "But," he continued, after a pause,
+"it is quite certain I shall wear out my wooden joints if I keep on
+walking."
+
+Tip reflected, as they journeyed on, that this was true. He began to
+regret that he had not constructed the wooden limbs more carefully and
+substantially. Yet how could he ever have guessed that the man he had
+made merely to scare old Mombi with would be brought to life by means
+of a magical powder contained in an old pepper-box?
+
+So he ceased to reproach himself, and began to think how he might yet
+remedy the deficiencies of Jack's weak joints.
+
+While thus engaged they came to the edge of a wood, and the boy sat
+down to rest upon an old saw-horse that some woodcutter had left there.
+
+[Illustration]
+
+"Why don't you sit down?" he asked the Pumpkinhead.
+
+"Won't it strain my joints?" inquired the other.
+
+"Of course not. It'll rest them," declared the boy.
+
+So Jack tried to sit down; but as soon as he bent his joints farther
+than usual they gave way altogether, and he came clattering to the
+ground with such a crash that Tip feared he was entirely ruined.
+
+He rushed to the man, lifted him to his feet, straightened his arms and
+legs, and felt of his head to see if by chance it had become cracked.
+But Jack seemed to be in pretty good shape, after all, and Tip said to
+him:
+
+"I guess you'd better remain standing, hereafter. It seems the safest
+way."
+
+"Very well, dear father; just as you say," replied the smiling Jack,
+who had been in no wise confused by his tumble.
+
+Tip sat down again. Presently the Pumpkinhead asked:
+
+"What is that thing you are sitting on?"
+
+"Oh, this is a horse," replied the boy, carelessly.
+
+"What is a horse?" demanded Jack.
+
+"A horse? Why, there are two kinds of horses," returned Tip, slightly
+puzzled how to explain. "One kind of horse is alive, and has four legs
+and a head and a tail. And people ride upon its back."
+
+"I understand," said Jack, cheerfully. "That's the kind of horse you
+are now sitting on."
+
+"No, it isn't," answered Tip, promptly.
+
+"Why not? That one has four legs, and a head, and a tail."
+
+Tip looked at the saw-horse more carefully, and found that the
+Pumpkinhead was right. The body had been formed from a tree-trunk, and
+a branch had been left sticking up at one end that looked very much
+like a tail. In the other end were two big knots that resembled eyes,
+and a place had been chopped away that might easily be mistaken for the
+horse's mouth. As for the legs, they were four straight limbs cut from
+trees and stuck fast into the body, being spread wide apart so that the
+saw-horse would stand firmly when a log was laid across it to be sawed.
+
+"This thing resembles a real horse more than I imagined," said Tip,
+trying to explain. "But a real horse is alive, and trots and prances
+and eats oats, while this is nothing more than a dead horse, made of
+wood, and used to saw logs upon."
+
+"If it were alive, wouldn't it trot, and prance, and eat oats?"
+inquired the Pumpkinhead.
+
+"It would trot and prance, perhaps; but it wouldn't eat oats," replied
+the boy, laughing at the idea. "And of course it can't ever be alive,
+because it is made of wood."
+
+"So am I," answered the man.
+
+Tip looked at him in surprise.
+
+"Why, so you are!" he exclaimed. "And the magic powder that brought you
+to life is here in my pocket."
+
+[Illustration: THE MAGICAL POWDER OF LIFE]
+
+He brought out the pepper box, and eyed it curiously.
+
+"I wonder," said he, musingly, "if it would bring the saw-horse to
+life."
+
+"If it would," returned Jack, calmly--for nothing seemed to surprise
+him--"I could ride on its back, and that would save my joints from
+wearing out."
+
+"I'll try it!" cried the boy, jumping up. "But I wonder if I can
+remember the words old Mombi said, and the way she held her hands up."
+
+He thought it over for a minute, and as he had watched carefully from
+the hedge every motion of the old witch, and listened to her words, he
+believed he could repeat exactly what she had said and done.
+
+So he began by sprinkling some of the magic Powder of Life from the
+pepper-box upon the body of the saw-horse. Then he lifted his left
+hand, with the little finger pointing upward, and said "Weaugh!"
+
+"What does that mean, dear father?" asked Jack, curiously.
+
+"I don't know," answered Tip. Then he lifted his right hand, with the
+thumb pointing upward, and said: "Teaugh!"
+
+"What's that, dear father?" inquired Jack.
+
+"It means you must keep quiet!" replied the boy, provoked at being
+interrupted at so important a moment.
+
+"How fast I am learning!" remarked the Pumpkinhead, with his eternal
+smile.
+
+Tip now lifted both hands above his head, with all the fingers and
+thumbs spread out, and cried in a loud voice: "Peaugh!"
+
+Immediately the saw-horse moved, stretched its legs, yawned with its
+chopped-out mouth, and shook a few grains of the powder off its back.
+The rest of the powder seemed to have vanished into the body of the
+horse.
+
+"Good!" called Jack, while the boy looked on in astonishment. "You are
+a very clever sorcerer, dear father!"
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Awakening
+    of the Saw-Horse
+]
+
+
+The Saw-Horse, finding himself alive, seemed even more astonished
+than Tip. He rolled his knotty eyes from side to side, taking a first
+wondering view of the world in which he had now so important an
+existence. Then he tried to look at himself; but he had, indeed, no
+neck to turn; so that in the endeavor to see his body he kept circling
+around and around, without catching even a glimpse of it. His legs
+were stiff and awkward, for there were no knee-joints in them; so that
+presently he bumped against Jack Pumpkinhead and sent that personage
+tumbling upon the moss that lined the roadside.
+
+Tip became alarmed at this accident, as well as at the persistence of
+the Saw-Horse in prancing around in a circle; so he called out:
+
+"Whoa! Whoa, there!"
+
+The Saw-Horse paid no attention whatever to this command, and the next
+instant brought one of his wooden legs down upon Tip's foot so forcibly
+that the boy danced away in pain to a safer distance, from where he
+again yelled:
+
+"Whoa! Whoa, I say!"
+
+Jack had now managed to raise himself to a sitting position, and he
+looked at the Saw-Horse with much interest.
+
+"I don't believe the animal can hear you," he remarked.
+
+"I shout loud enough, don't I?" answered Tip, angrily.
+
+"Yes; but the horse has no ears," said the smiling Pumpkinhead.
+
+"Sure enough!" exclaimed Tip, noting the fact for the first time. "How,
+then, am I going to stop him?"
+
+But at that instant the Saw-Horse stopped himself, having concluded it
+was impossible to see his own body. He saw Tip, however, and came close
+to the boy to observe him more fully.
+
+It was really comical to see the creature walk; for it moved the legs
+on its right side together, and those on its left side together, as a
+pacing horse does; and that made its body rock sidewise, like a cradle.
+
+Tip patted it upon the head, and said "Good boy! Good boy!" in a
+coaxing tone; and the Saw-Horse pranced away to examine with its
+bulging eyes the form of Jack Pumpkinhead.
+
+"I must find a halter for him," said Tip; and having made a search
+in his pocket he produced a roll of strong cord. Unwinding this,
+he approached the Saw-Horse and tied the cord around its neck,
+afterward fastening the other end to a large tree. The Saw-Horse, not
+understanding the action, stepped backward and snapped the string
+easily; but it made no attempt to run away.
+
+"He's stronger than I thought," said the boy, "and rather obstinate,
+too."
+
+"Why don't you make him some ears?" asked Jack. "Then you can tell him
+what to do."
+
+"That's a splendid idea!" said Tip. "How did you happen to think of it?"
+
+"Why, I didn't think of it," answered the Pumpkinhead; "I didn't need
+to, for it's the simplest and easiest thing to do."
+
+So Tip got out his knife and fashioned some ears out of the bark of a
+small tree.
+
+"I mustn't make them too big," he said, as he whittled, "or our horse
+would become a donkey."
+
+"How is that?" inquired Jack, from the roadside.
+
+"Why, a horse has bigger ears than a man; and a donkey has bigger ears
+than a horse," explained Tip.
+
+"Then, if my ears were longer, would I be a horse?" asked Jack.
+
+"My friend," said Tip, gravely, "you'll never be anything but a
+Pumpkinhead, no matter how big your ears are."
+
+"Oh," returned Jack, nodding; "I think I understand."
+
+"If you do, you're a wonder," remarked the boy; "but there's no harm in
+_thinking_ you understand. I guess these ears are ready now. Will you
+hold the horse while I stick them on?"
+
+"Certainly, if you'll help me up," said Jack.
+
+So Tip raised him to his feet, and the Pumpkinhead went to the horse
+and held its head while the boy bored two holes in it with his
+knife-blade and inserted the ears.
+
+"They make him look very handsome," said Jack, admiringly.
+
+But those words, spoken close to the Saw-Horse, and being the first
+sounds he had ever heard, so startled the animal that he made a bound
+forward and tumbled Tip on one side and Jack on the other. Then he
+continued to rush forward as if frightened by the clatter of his own
+footsteps.
+
+"Whoa!" shouted Tip, picking himself up; "whoa! you idiot--whoa!"
+
+The Saw-Horse would probably have paid no attention to this, but just
+then it stepped a leg into a gopher-hole and stumbled head-over-heels
+to the ground, where it lay upon its back, frantically waving its four
+legs in the air.
+
+Tip ran up to it.
+
+"You're a nice sort of a horse, I must say!" he exclaimed. "Why didn't
+you stop when I yelled 'whoa?'"
+
+"Does 'whoa' mean to stop?" asked the Saw-Horse, in a surprised voice,
+as it rolled its eyes upward to look at the boy.
+
+"Of course it does," answered Tip.
+
+"And a hole in the ground means to stop, also, doesn't it?" continued
+the horse.
+
+"To be sure; unless you step over it," said Tip.
+
+"What a strange place this is," the creature exclaimed, as if amazed.
+"What am I doing here, anyway?"
+
+[Illustration: "DO KEEP THOSE LEGS STILL."]
+
+"Why, I've brought you to life," answered the boy; "but it won't hurt
+you any, if you mind me and do as I tell you."
+
+"Then I will do as you tell me," replied the Saw-Horse, humbly. "But
+what happened to me, a moment ago? I don't seem to be just right,
+someway."
+
+"You're upside down," explained Tip. "But just keep those legs still a
+minute and I'll set you right side up again."
+
+"How many sides have I?" asked the creature, wonderingly.
+
+"Several," said Tip, briefly. "But do keep those legs still."
+
+The Saw-Horse now became quiet, and held its legs rigid; so that Tip,
+after several efforts, was able to roll him over and set him upright.
+
+"Ah, I seem all right now," said the queer animal, with a sigh.
+
+"One of your ears is broken," Tip announced, after a careful
+examination. "I'll have to make a new one."
+
+Then he led the Saw-Horse back to where Jack was vainly struggling to
+regain his feet, and after assisting the Pumpkinhead to stand upright
+Tip whittled out a new ear and fastened it to the horse's head.
+
+"Now," said he, addressing his steed, "pay attention to what I'm going
+to tell you. 'Whoa!' means to stop; 'Get-Up!' means to walk forward;
+'Trot!' means to go as fast as you can. Understand?"
+
+"I believe I do," returned the horse.
+
+"Very good. We are all going on a journey to the Emerald City, to see
+His Majesty, the Scarecrow; and Jack Pumpkinhead is going to ride on
+your back, so he won't wear out his joints."
+
+"I don't mind," said the Saw-Horse. "Anything that suits you suits me."
+
+Then Tip assisted Jack to get upon the horse.
+
+"Hold on tight," he cautioned, "or you may fall off and crack your
+pumpkin head."
+
+"That would be horrible!" said Jack, with a shudder. "What shall I hold
+on to?"
+
+"Why, hold on to his ears," replied Tip, after a moment's hesitation.
+
+"Don't do that!" remonstrated the Saw-Horse; "for then I can't hear."
+
+That seemed reasonable, so Tip tried to think of something else.
+
+"I'll fix it!" said he, at length. He went into the wood and cut a
+short length of limb from a young, stout tree. One end of this he
+sharpened to a point, and then he dug a hole in the back of the
+Saw-Horse, just behind its head. Next he brought a piece of rock from
+the road and hammered the post firmly into the animal's back.
+
+[Illustration: "DOES IT HURT?" ASKED THE BOY.]
+
+"Stop! Stop!" shouted the horse; "you're jarring me terribly."
+
+"Does it hurt?" asked the boy.
+
+"Not exactly hurt," answered the animal; "but it makes me quite nervous
+to be jarred."
+
+"Well, it's all over now," said Tip, encouragingly. "Now, Jack, be sure
+to hold fast to this post, and then you can't fall off and get smashed."
+
+So Jack held on tight, and Tip said to the horse:
+
+"Get-up."
+
+The obedient creature at once walked forward, rocking from side to side
+as he raised his feet from the ground.
+
+Tip walked beside the Saw-Horse, quite content with this addition to
+their party. Presently he began to whistle.
+
+"What does that sound mean?" asked the horse.
+
+"Don't pay any attention to it," said Tip. "I'm just whistling, and
+that only means I'm pretty well satisfied."
+
+"I'd whistle myself, if I could push my lips together," remarked Jack.
+"I fear, dear father, that in some respects I am sadly lacking."
+
+After journeying on for some distance the narrow path they were
+following turned into a broad road-way, paved with yellow brick. By the
+side of the road Tip noticed a sign-post that read:
+
+"NINE MILES TO THE EMERALD CITY."
+
+But it was now growing dark, so he decided to camp for the night by the
+roadside and to resume the journey next morning by daybreak. He led the
+Saw-Horse to a grassy mound upon which grew several bushy trees, and
+carefully assisted the Pumpkinhead to alight.
+
+"I think I'll lay you upon the ground, overnight," said the boy. "You
+will be safer that way."
+
+"How about me?" asked the Saw-Horse.
+
+"It won't hurt you to stand," replied Tip; "and, as you can't sleep,
+you may as well watch out and see that no one comes near to disturb us."
+
+Then the boy stretched himself upon the grass beside the Pumpkinhead,
+and being greatly wearied by the journey was soon fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Jack Pumpkinhead's Ride
+    to the Emerald City
+]
+
+
+At daybreak Tip was awakened by the Pumpkinhead. He rubbed the sleep
+from his eyes, bathed in a little brook, and then ate a portion of his
+bread and cheese. Having thus prepared for a new day the boy said:
+
+"Let us start at once. Nine miles is quite a distance, but we ought to
+reach the Emerald City by noon if no accidents happen."
+
+So the Pumpkinhead was again perched upon the back of the Saw-Horse and
+the journey was resumed.
+
+Tip noticed that the purple tint of the grass and trees had now faded
+to a dull lavender, and before long this lavender appeared to take on
+a greenish tinge that gradually brightened as they drew nearer to the
+great City where the Scarecrow ruled.
+
+The little party had traveled but a short two miles upon their way when
+the road of yellow brick was parted by a broad and swift river. Tip was
+puzzled how to cross over; but after a time he discovered a man in a
+ferry-boat approaching from the other side of the stream.
+
+When the man reached the bank Tip asked:
+
+"Will you row us to the other side?"
+
+"Yes, if you have money," returned the ferryman, whose face looked
+cross and disagreeable.
+
+"But I have no money," said Tip.
+
+"None at all?" inquired the man.
+
+"None at all," answered the boy.
+
+"Then I'll not break my back rowing you over," said the ferryman,
+decidedly.
+
+"What a nice man!" remarked the Pumpkinhead, smilingly.
+
+The ferryman stared at him, but made no reply. Tip was trying to
+think, for it was a great disappointment to him to find his journey so
+suddenly brought to an end.
+
+"I must certainly get to the Emerald City," he said to the boatman;
+"but how can I cross the river if you do not take me?"
+
+The man laughed, and it was not a nice laugh.
+
+"That wooden horse will float," said he; "and you can ride him across.
+As for the pumpkin-headed loon who accompanies you, let him sink or
+swim--it won't matter greatly which."
+
+[Illustration]
+
+"Don't worry about me," said Jack, smiling pleasantly upon the crabbed
+ferryman; "I'm sure I ought to float beautifully."
+
+Tip thought the experiment was worth making, and the Saw-Horse, who did
+not know what danger meant, offered no objections whatever. So the boy
+led it down into the water and climbed upon its back. Jack also waded
+in up to his knees and grasped the tail of the horse so that he might
+keep his pumpkin head above the water.
+
+"Now," said Tip, instructing the Saw-Horse, "if you wiggle your legs
+you will probably swim; and if you swim we shall probably reach the
+other side."
+
+The Saw-Horse at once began to wiggle its legs, which acted as oars and
+moved the adventurers slowly across the river to the opposite side.
+So successful was the trip that presently they were climbing, wet and
+dripping, up the grassy bank.
+
+Tip's trouser-legs and shoes were thoroughly soaked; but the Saw-Horse
+had floated so perfectly that from his knees up the boy was entirely
+dry. As for the Pumpkinhead, every stitch of his gorgeous clothing
+dripped water.
+
+"The sun will soon dry us," said Tip; "and, anyhow, we are now safely
+across, in spite of the ferryman, and can continue our journey."
+
+"I didn't mind swimming, at all," remarked the horse.
+
+"Nor did I," added Jack.
+
+They soon regained the road of yellow brick, which proved to be a
+continuation of the road they had left on the other side, and then Tip
+once more mounted the Pumpkinhead upon the back of the Saw-Horse.
+
+"If you ride fast," said he, "the wind will help to dry your clothing.
+I will hold on to the horse's tail and run after you. In this way we
+all will become dry in a very short time."
+
+"Then the horse must step lively," said Jack.
+
+"I'll do my best," returned the Saw-Horse, cheerfully.
+
+Tip grasped the end of the branch that served as tail to the Saw-Horse,
+and called loudly: "Get-up!"
+
+The horse started at a good pace, and Tip followed behind. Then he
+decided they could go faster, so he shouted: "Trot!"
+
+[Illustration]
+
+Now, the Saw-Horse remembered that this word was the command to go as
+fast as he could; so he began rocking along the road at a tremendous
+pace, and Tip had hard work--running faster than he ever had before in
+his life--to keep his feet.
+
+Soon he was out of breath, and although he wanted to call "Whoa!" to
+the horse, he found he could not get the word out of his throat. Then
+the end of the tail he was clutching, being nothing more than a dead
+branch, suddenly broke away, and the next minute the boy was rolling
+in the dust of the road, while the horse and its pumpkin-headed rider
+dashed on and quickly disappeared in the distance.
+
+By the time Tip had picked himself up and cleared the dust from his
+throat so he could say "Whoa!" there was no further need of saying it,
+for the horse was long since out of sight.
+
+So he did the only sensible thing he could do. He sat down and took a
+good rest, and afterward began walking along the road.
+
+"Some time I will surely overtake them," he reflected; "for the road
+will end at the gates of the Emerald City, and they can go no further
+than that."
+
+Meantime Jack was holding fast to the post and the Saw-Horse was
+tearing along the road like a racer. Neither of them knew Tip was left
+behind, for the Pumpkinhead did not look around and the Saw-Horse
+couldn't.
+
+As he rode, Jack noticed that the grass and trees had become a bright
+emerald-green in color, so he guessed they were nearing the Emerald
+City even before the tall spires and domes came into sight.
+
+At length a high wall of green stone, studded thick with emeralds,
+loomed up before them; and fearing the Saw-Horse would not know enough
+to stop and so might smash them both against this wall, Jack ventured
+to cry "Whoa!" as loud as he could.
+
+So suddenly did the horse obey that had it not been for his post Jack
+would have been pitched off head foremost, and his beautiful face
+ruined.
+
+"That was a fast ride, dear father!" he exclaimed; and then, hearing no
+reply, he turned around and discovered for the first time that Tip was
+not there.
+
+This apparent desertion puzzled the Pumpkinhead, and made him uneasy.
+And while he was wondering what had become of the boy, and what he
+ought to do next under such trying circumstances, the gateway in the
+green wall opened and a man came out.
+
+This man was short and round, with a fat face that seemed remarkably
+good-natured. He was clothed all in green and wore a high, peaked green
+hat upon his head and green spectacles over his eyes. Bowing before the
+Pumpkinhead he said:
+
+"I am the Guardian of the Gates of the Emerald City. May I inquire who
+you are, and what is your business?"
+
+"My name is Jack Pumpkinhead," returned the other, smilingly; "but as
+to my business, I haven't the least idea in the world what it is."
+
+The Guardian of the Gates looked surprised, and shook his head as if
+dissatisfied with the reply.
+
+"What are you, a man or a pumpkin?" he asked, politely.
+
+"Both, if you please," answered Jack.
+
+"And this wooden horse--is it alive?" questioned the Guardian.
+
+The horse rolled one knotty eye upward and winked at Jack. Then it gave
+a prance and brought one leg down on the Guardian's toes.
+
+"Ouch!" cried the man; "I'm sorry I asked that question. But the answer
+is most convincing. Have you any errand, sir, in the Emerald City?"
+
+"It seems to me that I have," replied the Pumpkinhead, seriously; "but
+I cannot think what it is. My father knows all about it, but he is not
+here."
+
+"This is a strange affair--very strange!" declared the Guardian. "But
+you seem harmless. Folks do not smile so delightfully when they mean
+mischief."
+
+"As for that," said Jack, "I cannot help my smile, for it is carved on
+my face with a jack-knife."
+
+"Well, come with me into my room," resumed the Guardian, "and I will
+see what can be done for you."
+
+So Jack rode the Saw-Horse through the gate-way into a little room
+built into the wall. The Guardian pulled a bell-cord, and presently
+a very tall soldier--clothed in a green uniform--entered from the
+opposite door. This soldier carried a long green gun over his shoulder
+and had lovely green whiskers that fell quite to his knees. The
+Guardian at once addressed him, saying:
+
+"Here is a strange gentleman who doesn't know why he has come to the
+Emerald City, or what he wants. Tell me, what shall we do with him?"
+
+The Soldier with the Green Whiskers looked at Jack with much care and
+curiosity. Finally he shook his head so positively that little waves
+rippled down his whiskers, and then he said:
+
+"I must take him to His Majesty, the Scarecrow."
+
+"But what will His Majesty, the Scarecrow, do with him?" asked the
+Guardian of the Gates.
+
+"That is His Majesty's business," returned the soldier. "I have
+troubles enough of my own. All outside troubles must be turned over to
+His Majesty. So put the spectacles on this fellow, and I'll take him to
+the royal palace."
+
+So the Guardian opened a big box of spectacles and tried to fit a pair
+to Jack's great round eyes.
+
+"I haven't a pair in stock that will really cover those eyes up," said
+the little man, with a sigh; "and your head is so big that I shall be
+obliged to tie the spectacles on."
+
+"But why need I wear spectacles?" asked Jack.
+
+"It's the fashion here," said the Soldier, "and they will keep you from
+being blinded by the glitter and glare of the gorgeous Emerald City."
+
+"Oh!" exclaimed Jack. "Tie them on, by all means. I don't wish to be
+blinded."
+
+"Nor I!" broke in the Saw-Horse; so a pair of green spectacles was
+quickly fastened over the bulging knots that served it for eyes.
+
+Then the Soldier with the Green Whiskers led them through the inner
+gate and they at once found themselves in the main street of the
+magnificent Emerald City.
+
+Sparkling green gems ornamented the fronts of the beautiful houses and
+the towers and turrets were all faced with emeralds. Even the green
+marble pavement glittered with precious stones, and it was indeed a
+grand and marvelous sight to one who beheld it for the first time.
+
+However, the Pumpkinhead and the Saw-Horse, knowing nothing of wealth
+and beauty, paid little attention to the wonderful sights they saw
+through their green spectacles. They calmly followed after the green
+soldier and scarcely noticed the crowds of green people who stared
+at them in surprise. When a green dog ran out and barked at them the
+Saw-Horse promptly kicked at it with its wooden leg and sent the little
+animal howling into one of the houses; but nothing more serious than
+this happened to interrupt their progress to the royal palace.
+
+The Pumpkinhead wanted to ride up the green marble steps and straight
+into the Scarecrow's presence; but the soldier would not permit that.
+So Jack dismounted, with much difficulty, and a servant led the
+Saw-Horse around to the rear while the Soldier with the Green Whiskers
+escorted the Pumpkinhead into the palace, by the front entrance.
+
+The stranger was left in a handsomely furnished waiting room while the
+soldier went to announce him. It so happened that at this hour His
+Majesty was at leisure and greatly bored for want of something to do,
+so he ordered his visitor to be shown at once into his throne room.
+
+Jack felt no fear or embarrassment at meeting the ruler of this
+magnificent city, for he was entirely ignorant of all worldly customs.
+But when he entered the room and saw for the first time His Majesty
+the Scarecrow seated upon his glittering throne, he stopped short in
+amazement.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    His majesty the Scarecrow
+]
+
+
+I suppose every reader of this book knows what a scarecrow is; but Jack
+Pumpkinhead, never having seen such a creation, was more surprised at
+meeting the remarkable King of the Emerald City than by any other one
+experience of his brief life.
+
+His Majesty the Scarecrow was dressed in a suit of faded blue clothes,
+and his head was merely a small sack stuffed with straw, upon which
+eyes, ears, a nose and a mouth had been rudely painted to represent a
+face. The clothes were also stuffed with straw, and that so unevenly
+or carelessly that his Majesty's legs and arms seemed more bumpy
+than was necessary. Upon his hands were gloves with long fingers,
+and these were padded with cotton. Wisps of straw stuck out from the
+monarch's coat and also from his neck and boot-tops. Upon his head
+he wore a heavy golden crown set thick with sparkling jewels, and
+the weight of this crown caused his brow to sag in wrinkles, giving
+a thoughtful expression to the painted face. Indeed, the crown alone
+betokened majesty; in all else the Scarecrow King was but a simple
+scarecrow--flimsy, awkward, and unsubstantial.
+
+But if the strange appearance of his Majesty the Scarecrow seemed
+startling to Jack, no less wonderful was the form of the Pumpkinhead
+to the Scarecrow. The purple trousers and pink waistcoat and red
+shirt hung loosely over the wooden joints Tip had manufactured, and
+the carved face on the pumpkin grinned perpetually, as if its wearer
+considered life the jolliest thing imaginable.
+
+At first, indeed, His Majesty thought his queer visitor was laughing at
+him, and was inclined to resent such a liberty; but it was not without
+reason that the Scarecrow had attained the reputation of being the
+wisest personage in the Land of Oz. He made a more careful examination
+of his visitor, and soon discovered that Jack's features were carved
+into a smile and that he could not look grave if he wished to.
+
+The King was the first to speak. After regarding
+
+[Illustration]
+
+Jack for some minutes he said, in a tone of wonder:
+
+"Where on earth did you come from, and how do you happen to be alive?"
+
+"I beg your Majesty's pardon," returned the Pumpkinhead; "but I do not
+understand you."
+
+"What don't you understand?" asked the Scarecrow.
+
+"Why, I don't understand your language. You see, I came from the
+Country of the Gillikins, so that I am a foreigner."
+
+"Ah, to be sure!" exclaimed the Scarecrow. "I myself speak the language
+of the Munchkins, which is also the language of the Emerald City. But
+you, I suppose, speak the language of the Pumpkinheads?"
+
+"Exactly so, your Majesty," replied the other, bowing; "so it will be
+impossible for us to understand one another."
+
+"That is unfortunate, certainly," said the Scarecrow, thoughtfully. "We
+must have an interpreter."
+
+"What is an interpreter?" asked Jack.
+
+"A person who understands both my language and your own. When I say
+anything, the interpreter can tell you what I mean; and when you
+say anything the interpreter can tell me what _you_ mean. For the
+interpreter can speak both languages as well as understand them."
+
+"That is certainly clever," said Jack, greatly pleased at finding so
+simple a way out of the difficulty.
+
+So the Scarecrow commanded the Soldier with the Green Whiskers to
+search among his people until he found one who understood the language
+of the Gillikins as well as the language of the Emerald City, and to
+bring that person to him at once.
+
+When the Soldier had departed the Scarecrow said:
+
+"Won't you take a chair while we are waiting?"
+
+"Your Majesty forgets that I cannot understand you," replied the
+Pumpkinhead. "If you wish me to sit down you must make a sign for me to
+do so."
+
+The Scarecrow came down from his throne and rolled an armchair to a
+position behind the Pumpkinhead. Then he gave Jack a sudden push that
+sent him sprawling upon the cushions in so awkward a fashion that he
+doubled up like a jack-knife, and had hard work to untangle himself.
+
+"Did you understand that sign?" asked His Majesty, politely.
+
+"Perfectly," declared Jack, reaching up his arms to turn his head
+to the front, the pumpkin having twisted around upon the stick that
+supported it.
+
+"You seem hastily made," remarked the Scarecrow, watching Jack's
+efforts to straighten himself.
+
+"Not more so than your Majesty," was the frank reply.
+
+"There is this difference between us," said the Scarecrow, "that
+whereas I will bend, but not break, you will break, but not bend."
+
+[Illustration: "HE GAVE JACK A SUDDEN PUSH."]
+
+At this moment the soldier returned leading a young girl by the hand.
+She seemed very sweet and modest, having a pretty face and beautiful
+green eyes and hair. A dainty green silk skirt reached to her knees,
+showing silk stockings embroidered with pea-pods, and green satin
+slippers with bunches of lettuce for decorations instead of bows or
+buckles. Upon her silken waist clover leaves were embroidered, and
+she wore a jaunty little jacket trimmed with sparkling emeralds of a
+uniform size.
+
+"Why, it's little Jellia Jamb!" exclaimed the Scarecrow, as the green
+maiden bowed her pretty head before him. "Do you understand the
+language of the Gillikins, my dear?"
+
+"Yes, your Majesty," she answered, "for I was born in the North
+Country."
+
+"Then you shall be our interpreter," said the Scarecrow, "and explain
+to this Pumpkinhead all that I say, and also explain to me all that
+_he_ says. Is this arrangement satisfactory?" he asked, turning toward
+his guest.
+
+"Very satisfactory indeed," was the reply.
+
+"Then ask him, to begin with," resumed the Scarecrow, turning to
+Jellia, "what brought him to the Emerald City."
+
+But instead of this the girl, who had been staring at Jack, said to
+him:
+
+"You are certainly a wonderful creature. Who made you?"
+
+"A boy named Tip," answered Jack.
+
+"What does he say?" inquired the Scarecrow. "My ears must have deceived
+me. What did he say?"
+
+"He says that your Majesty's brains seem to have come loose," replied
+the girl, demurely.
+
+The Scarecrow moved uneasily upon his throne, and felt of his head with
+his left hand.
+
+"What a fine thing it is to understand two different languages," he
+said, with a perplexed sigh. "Ask him, my dear, if he has any objection
+to being put in jail for insulting the ruler of the Emerald City.
+
+"I didn't insult you!" protested Jack, indignantly.
+
+"Tut--tut!" cautioned the Scarecrow; "wait until Jellia translates my
+speech. What have we got an interpreter for, if you break out in this
+rash way?"
+
+"All right, I'll wait," replied the Pumpkinhead, in a surly
+tone--although his face smiled as genially as ever. "Translate the
+speech, young woman."
+
+"His Majesty inquires if you are hungry," said Jellia.
+
+"Oh, not at all!" answered Jack, more pleasantly. "for it is impossible
+for me to eat."
+
+"It's the same way with me," remarked the Scarecrow. "What did he say,
+Jellia, my dear?"
+
+"He asked if you were aware that one of your eyes is painted larger
+than the other," said the girl, mischievously.
+
+"Don't you believe her, your Majesty," cried Jack.
+
+"Oh, I don't," answered the Scarecrow, calmly. Then, casting a sharp
+look at the girl, he asked:
+
+"Are you quite certain you understand the languages of both the
+Gillikins and the Munchkins?"
+
+"Quite certain, your Majesty," said Jellia Jamb, trying hard not to
+laugh in the face of royalty.
+
+"Then how is it that I seem to understand them myself?" inquired the
+Scarecrow.
+
+"Because they are one and the same!" declared the girl, now laughing
+merrily. "Does not your Majesty know that in all the land of Oz but one
+language is spoken?"
+
+"Is it indeed so?" cried the Scarecrow, much relieved to hear this;
+"then I might easily have been my own interpreter!"
+
+"It was all my fault, your Majesty," said Jack, looking rather foolish,
+"I thought we must surely speak different languages, since we came from
+different countries."
+
+"This should be a warning to you never to think," returned the
+Scarecrow, severely. "For unless one can think wisely it is better to
+remain a dummy--which you most certainly are."
+
+"I am!--I surely am!" agreed the Pumpkinhead.
+
+"It seems to me," continued the Scarecrow, more mildly, "that your
+manufacturer spoiled some good pies to create an indifferent man."
+
+"I assure your Majesty that I did not ask to be created," answered Jack.
+
+"Ah! It was the same in my case," said the King, pleasantly. "And so,
+as we differ from all ordinary people, let us become friends."
+
+"With all my heart!" exclaimed Jack.
+
+"What! Have you a heart?" asked the Scarecrow, surprised.
+
+"No; that was only imaginative--I might say, a figure of speech," said
+the other.
+
+"Well, your most prominent figure seems to be a figure of wood; so I
+must beg you to restrain an imagination which, having no brains, you
+have no right to exercise," suggested the Scarecrow, warningly.
+
+"To be sure!" said Jack, without in the least comprehending.
+
+His Majesty then dismissed Jellia Jamb and the Soldier with the Green
+Whiskers, and when they were gone he took his new friend by the arm and
+led him into the courtyard to play a game of quoits.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Gen. Jinjur's Army
+    of Revolt
+]
+
+
+Tip was so anxious to rejoin his man Jack and the Saw-Horse that he
+walked a full half the distance to the Emerald City without stopping to
+rest. Then he discovered that he was hungry and the crackers and cheese
+he had provided for the journey had all been eaten.
+
+While wondering what he should do in this emergency he came upon a
+girl sitting by the roadside. She wore a costume that struck the boy
+as being remarkably brilliant: her silken waist being of emerald green
+and her skirt of four distinct colors--blue in front, yellow at the
+left side, red at the back and purple at the right side. Fastening the
+waist in front were four buttons--the top one blue, the next yellow, a
+third red and the last purple.
+
+[Illustration]
+
+The splendor of this dress was almost barbaric; so Tip was fully
+justified in staring at the gown for some moments before his eyes
+were attracted by the pretty face above it. Yes, the face was pretty
+enough, he decided; but it wore an expression of discontent coupled to
+a shade of defiance or audacity.
+
+While the boy stared the girl looked upon him calmly. A lunch basket
+stood beside her, and she held a dainty sandwich in one hand and a
+hard-boiled egg in the other, eating with an evident appetite that
+aroused Tip's sympathy.
+
+He was just about to ask a share of the luncheon when the girl stood up
+and brushed the crumbs from her lap.
+
+"There!" said she; "it is time for me to go. Carry that basket for me
+and help yourself to its contents if you are hungry."
+
+Tip seized the basket eagerly and began to eat, following for a time
+the strange girl without bothering to ask questions. She walked along
+before him with swift strides, and there was about her an air of
+decision and importance that led him to suspect she was some great
+personage.
+
+Finally, when he had satisfied his hunger, he ran up beside her and
+tried to keep pace with her swift footsteps--a very difficult feat, for
+she was much taller than he, and evidently in a hurry.
+
+"Thank you very much for the sandwiches," said Tip, as he trotted
+along. "May I ask your name?"
+
+"I am General Jinjur," was the brief reply.
+
+"Oh!" said the boy, surprised. "What sort of a General?"
+
+"I command the Army of Revolt in this war," answered the General, with
+unnecessary sharpness.
+
+"Oh!" he again exclaimed. "I didn't know there was a war."
+
+"You were not supposed to know it," she returned, "for we have kept it
+a secret; and considering that our army is composed entirely of girls,"
+she added, with some pride, "it is surely a remarkable thing that our
+Revolt is not yet discovered."
+
+"It is, indeed," acknowledged Tip. "But where is your army?"
+
+"About a mile from here," said General Jinjur. "The forces have
+assembled from all parts of the Land of Oz, at my express command. For
+this is the day we are to conquer His Majesty the Scarecrow, and wrest
+from him the throne. The Army of Revolt only awaits my coming to march
+upon the Emerald City."
+
+"Well!" declared Tip, drawing a long breath, "this is certainly a
+surprising thing! May I ask why you wish to conquer His Majesty the
+Scarecrow?"
+
+"Because the Emerald City has been ruled by men long enough, for one
+reason," said the girl. "Moreover, the City glitters with beautiful
+gems, which might far better be used for rings, bracelets and
+necklaces; and there is enough money in the King's treasury to buy
+every girl in our Army a dozen new gowns. So we intend to conquer the
+City and run the government to suit ourselves."
+
+Jinjur spoke these words with an eagerness and decision that proved she
+was in earnest.
+
+"But war is a terrible thing," said Tip, thoughtfully.
+
+"This war will be pleasant," replied the girl, cheerfully.
+
+"Many of you will be slain!" continued the boy, in an awed voice.
+
+"Oh, no," said Jinjur. "What man would oppose a girl, or dare to harm
+her? And there is not an ugly face in my entire Army."
+
+Tip laughed.
+
+"Perhaps you are right," said he. "But the Guardian of the Gate is
+considered a faithful Guardian, and the King's Army will not let the
+City be conquered without a struggle."
+
+"The Army is old and feeble," replied General Jinjur, scornfully. "His
+strength has all been used to grow whiskers, and his wife has such a
+temper that she has already pulled more than half of them out by the
+roots. When the Wonderful Wizard reigned the Soldier with the Green
+Whiskers was a very good Royal Army, for people feared the Wizard. But
+no one is afraid of the Scarecrow, so his Royal Army don't count for
+much in time of war."
+
+After this conversation they proceeded some distance in silence, and
+before long reached a large clearing in the forest where fully four
+hundred young women were assembled. These were laughing and talking
+together as gaily as if they had gathered for a picnic instead of a war
+of conquest.
+
+They were divided into four companies, and Tip noticed that all were
+dressed in costumes similar to that worn by General Jinjur. The only
+real difference was that while those girls from the Munchkin country
+had the blue strip in front of their skirts, those from the country of
+the Quadlings had the red strip in front; and those from the country
+of the Winkies had the yellow strip in front, and the Gillikin girls
+wore the purple strip in front. All had green waists, representing the
+Emerald City they intended to conquer, and the top button on each waist
+indicated by its color which country the wearer came from. The uniforms
+were jaunty and becoming, and quite effective when massed together.
+
+Tip thought this strange Army bore no weapons whatever; but in this he
+was wrong. For each girl had stuck through the knot of her back hair
+two long, glittering knitting-needles.
+
+[Illustration]
+
+General Jinjur immediately mounted the stump of a tree and addressed
+her army.
+
+"Friends, fellow-citizens, and girls!" she said; "we are about to begin
+our great Revolt against the men of Oz! We march to conquer the Emerald
+City--to dethrone the Scarecrow King--to acquire thousands of gorgeous
+gems--to rifle the royal treasury--and to obtain power over our former
+oppressors!"
+
+"Hurrah!" said those who had listened; but Tip thought most of the Army
+was too much engaged in chattering to pay attention to the words of the
+General.
+
+The command to march was now given, and the girls formed themselves
+into four bands, or companies, and set off with eager strides toward
+the Emerald City.
+
+[Illustration]
+
+The boy followed after them, carrying several baskets and wraps and
+packages which various members of the Army of Revolt had placed in his
+care. It was not long before they came to the green granite walls of
+the City and halted before the gateway.
+
+The Guardian of the Gate at once came out and looked at them curiously,
+as if a circus had come to town. He carried a bunch of keys swung round
+his neck by a golden chain; his hands were thrust carelessly into
+his pockets, and he seemed to have no idea at all that the City was
+threatened by rebels. Speaking pleasantly to the girls, he said:
+
+"Good morning, my dears! What can I do for you?"
+
+[Illustration]
+
+"Surrender instantly!" answered General Jinjur, standing before him and
+frowning as terribly as her pretty face would allow her to.
+
+"Surrender!" echoed the man, astounded. "Why, it's impossible. It's
+against the law! I never heard of such a thing in my life."
+
+"Still, you must surrender!" exclaimed the General, fiercely. "We are
+revolting!"
+
+"You don't look it," said the Guardian, gazing from one to another,
+admiringly.
+
+"But we are!" cried Jinjur, stamping her foot, impatiently; "and we
+mean to conquer the Emerald City!"
+
+"Good gracious!" returned the surprised Guardian of the Gates; "what
+a nonsensical idea! Go home to your mothers, my good girls, and milk
+the cows and bake the bread. Don't you know it's a dangerous thing to
+conquer a city?"
+
+"We are not afraid!" responded the General; and she looked so
+determined that it made the Guardian uneasy.
+
+So he rang the bell for the Soldier with the Green Whiskers, and the
+next minute was sorry he had done so. For immediately he was surrounded
+by a crowd of girls who drew the knitting-needles from their hair and
+began jabbing them at the Guardian with the sharp points dangerously
+near his fat cheeks and blinking eyes.
+
+The poor man howled loudly for mercy and made no resistance when Jinjur
+drew the bunch of keys from around his neck.
+
+[Illustration: GENERAL JINJUR AND HER ARMY CAPTURE THE CITY.]
+
+Followed by her Army the General now rushed to the gateway, where she
+was confronted by the Royal Army of Oz--which was the other name for
+the Soldier with the Green Whiskers.
+
+"Halt!" he cried, and pointed his long gun full in the face of the
+leader.
+
+Some of the girls screamed and ran back, but General Jinjur bravely
+stood her ground and said, reproachfully:
+
+"Why, how now? Would you shoot a poor, defenceless girl?"
+
+"No," replied the soldier; "for my gun isn't loaded."
+
+"Not loaded?"
+
+"No; for fear of accidents. And I've forgotten where I hid the powder
+and shot to load it with. But if you'll wait a short time I'll try to
+hunt them up."
+
+"Don't trouble yourself," said Jinjur, cheerfully. Then she turned to
+her Army and cried:
+
+"Girls, the gun isn't loaded!"
+
+"Hooray," shrieked the rebels, delighted at this good news, and they
+proceeded to rush upon the Soldier with the Green Whiskers in such a
+crowd that it was a wonder they didn't stick the knitting-needles into
+one another.
+
+But the Royal Army of Oz was too much afraid of women to meet the
+onslaught. He simply turned about and ran with all his might through
+the gate and toward the royal palace, while General Jinjur and her mob
+flocked into the unprotected City.
+
+In this way was the Emerald City captured without a drop of blood being
+spilled. The Army of Revolt had become an Army of Conquerors!
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Plans an escape
+]
+
+
+Tip slipped away from the girls and followed swiftly after the
+Soldier with the Green Whiskers. The invading army entered the City
+more slowly, for they stopped to dig emeralds out of the walls and
+paving-stones with the points of their knitting-needles. So the Soldier
+and the boy reached the palace before the news had spread that the City
+was conquered.
+
+The Scarecrow and Jack Pumpkinhead were still playing at quoits in
+the courtyard when the game was interrupted by the abrupt entrance of
+the Royal Army of Oz, who came flying in without his hat or gun, his
+clothes in sad disarray and his long beard floating a yard behind him
+as he ran.
+
+"Tally one for me," said the Scarecrow, calmly. "What's wrong, my man?"
+he added, addressing the Soldier.
+
+"Oh! your Majesty--your Majesty! The City is conquered!" gasped the
+Royal Army, who was all out of breath.
+
+"This is quite sudden," said the Scarecrow. "But please go and bar all
+the doors and windows of the palace, while I show this Pumpkinhead how
+to throw a quoit."
+
+The Soldier hastened to do this, while Tip, who had arrived at his
+heels, remained in the courtyard to look at the Scarecrow with
+wondering eyes.
+
+His Majesty continued to throw the quoits as coolly as if no danger
+threatened his throne, but the Pumpkinhead, having caught sight of Tip,
+ambled toward the boy as fast as his wooden legs would go.
+
+"Good afternoon, noble parent!" he cried, delightedly. "I'm glad to see
+you are here. That terrible Saw-Horse ran away with me."
+
+"I suspected it," said Tip. "Did you get hurt? Are you cracked at all?"
+
+"No, I arrived safely," answered Jack, "and his Majesty has been very
+kind indeed to me."
+
+At this moment the Soldier with the Green Whiskers returned, and the
+Scarecrow asked:
+
+"By the way, who has conquered me?"
+
+"A regiment of girls, gathered from the four corners of the Land of
+Oz," replied the Soldier, still pale with fear.
+
+"But where was my Standing Army at the time?" inquired his Majesty,
+looking at the Soldier, gravely.
+
+"Your Standing Army was running," answered the fellow, honestly; "for
+no man could face the terrible weapons of the invaders."
+
+"Well," said the Scarecrow, after a moment's thought, "I don't mind
+much the loss of my throne, for it's a tiresome job to rule over the
+Emerald City. And this crown is so heavy that it makes my head ache.
+But I hope the Conquerors have no intention of injuring me, just
+because I happen to be the King."
+
+"I heard them say," remarked Tip, with some hesitation, "that
+they intend to make a rag carpet of your outside and stuff their
+sofa-cushions with your inside."
+
+"Then I am really in danger," declared his Majesty, positively, "and it
+will be wise for me to consider a means to escape."
+
+"Where can you go?" asked Jack Pumpkinhead.
+
+"Why, to my friend the Tin Woodman, who rules over the Winkies, and
+calls himself their Emperor," was the answer. "I am sure he will
+protect me."
+
+[Illustration]
+
+Tip was looking out of the window.
+
+"The palace is surrounded by the enemy," said he. "It is too late to
+escape. They would soon tear you to pieces."
+
+The Scarecrow sighed.
+
+"In an emergency," he announced, "it is always a good thing to pause
+and reflect. Please excuse me while I pause and reflect."
+
+"But we also are in danger," said the Pumpkinhead, anxiously. "If any
+of these girls understand cooking, my end is not far off!"
+
+"Nonsense!" exclaimed the Scarecrow; "they're too busy to cook, even if
+they know how!"
+
+"But should I remain here a prisoner for any length of time," protested
+Jack, "I'm liable to spoil."
+
+"Ah! then you would not be fit to associate with," returned the
+Scarecrow. "The matter is more serious than I suspected."
+
+"You," said the Pumpkinhead, gloomily, "are liable to live for many
+years. My life is necessarily short. So I must take advantage of the
+few days that remain to me."
+
+"There, there! Don't worry," answered the Scarecrow, soothingly; "if
+you'll keep quiet long enough for me to think, I'll try to find some
+way for us all to escape."
+
+So the others waited in patient silence while the Scarecrow walked to
+a corner and stood with his face to the wall for a good five minutes.
+At the end of that time he faced them with a more cheerful expression
+upon his painted face.
+
+"Where is the Saw-Horse you rode here?" he asked the Pumpkinhead.
+
+"Why, I said he was a jewel, and so your man locked him up in the royal
+treasury," said Jack.
+
+"It was the only place I could think of, your Majesty," added the
+Soldier, fearing he had made a blunder.
+
+"It pleases me very much," said the Scarecrow. "Has the animal been
+fed?"
+
+"Oh, yes; I gave him a heaping peck of sawdust."
+
+"Excellent!" cried the Scarecrow. "Bring the horse here at once."
+
+The Soldier hastened away, and presently they heard the clattering
+of the horse's wooden legs upon the pavement as he was led into the
+courtyard.
+
+His Majesty regarded the steed critically.
+
+"He doesn't seem especially graceful," he remarked, musingly; "but I
+suppose he can run?"
+
+"He can, indeed," said Tip, gazing upon the Saw-Horse admiringly.
+
+"Then, bearing us upon his back, he must make a dash through the ranks
+of the rebels and carry us to my friend the Tin Woodman," announced the
+Scarecrow.
+
+"He can't carry four!" objected Tip.
+
+"No, but he may be induced to carry three," said his Majesty. "I shall
+therefore leave my Royal Army behind. For, from the ease with which he
+was conquered, I have little confidence in his powers."
+
+"Still, he can run," declared Tip, laughing.
+
+"I expected this blow," said the Soldier, sulkily; "but I can bear it.
+I shall disguise myself by cutting off my lovely green whiskers. And,
+after all, it is no more dangerous to face those reckless girls than to
+ride this fiery, untamed wooden horse!"
+
+"Perhaps you are right," observed his Majesty. "But, for my part, not
+being a soldier, I am fond of danger. Now, my boy, you must mount
+first. And please sit as close to the horse's neck as possible."
+
+Tip climbed quickly to his place, and the Soldier and the Scarecrow
+managed to hoist the Pumpkinhead to a seat just behind him. There
+remained so little space for the King that he was liable to fall off as
+soon as the horse started.
+
+"Fetch a clothesline," said the King to his Army, "and tie us all
+together. Then if one falls off we will all fall off."
+
+And while the Soldier was gone for the clothesline his Majesty
+continued, "it is well for me to be careful, for my very existence is
+in danger."
+
+"I have to be as careful as you do," said Jack.
+
+"Not exactly," replied the Scarecrow; "for if anything happened to me,
+that would be the end of me. But if anything happened to you, they
+could use you for seed."
+
+The Soldier now returned with a long line and tied all three firmly
+together, also lashing them to the body of the Saw-Horse; so there
+seemed little danger of their tumbling off.
+
+"Now throw open the gates," commanded the Scarecrow, "and we will make
+a dash to liberty or to death."
+
+The courtyard in which they were standing was located in the center of
+the great palace, which surrounded it on all sides. But in one place a
+passage led to an outer gateway, which the Soldier had barred by order
+of his sovereign. It was through this gateway his Majesty proposed to
+escape, and the Royal Army now led the Saw-Horse along the passage and
+unbarred the gate, which swung backward with a loud crash.
+
+"Now," said Tip to the horse, "you must save us all. Run as fast as you
+can for the gate of the City, and don't let anything stop you."
+
+"All right!" answered the Saw-Horse, gruffly, and dashed away so
+suddenly that Tip had to gasp for breath and hold firmly to the post
+he had driven into the creature's neck.
+
+[Illustration: "WE WILL MAKE A DASH TO LIBERTY OR TO DEATH."]
+
+Several of the girls, who stood outside guarding the palace, were
+knocked over by the Saw-Horse's mad rush. Others ran screaming out of
+the way, and only one or two jabbed their knitting-needles frantically
+at the escaping prisoners. Tip got one small prick in his left arm,
+which smarted for an hour afterward; but the needles had no effect upon
+the Scarecrow or Jack Pumpkinhead, who never even suspected they were
+being prodded.
+
+As for the Saw-Horse, he made a wonderful record, upsetting a fruit
+cart, overturning several meek looking men, and finally bowling over
+the new Guardian of the Gate--a fussy little fat woman appointed by
+General Jinjur.
+
+Nor did the impetuous charger stop then. Once outside the walls of the
+Emerald City he dashed along the road to the West with fast and violent
+leaps that shook the breath out of the boy and filled the Scarecrow
+with wonder.
+
+Jack had ridden at this mad rate once before, so he devoted every
+effort to holding, with both hands, his pumpkin head upon its
+stick, enduring meantime the dreadful jolting with the courage of a
+philosopher.
+
+[Illustration: THE WOODEN STEED GAVE ONE FINAL LEAP.]
+
+"Slow him up! Slow him up!" shouted the Scarecrow. "My straw is all
+shaking down into my legs."
+
+But Tip had no breath to speak, so the Saw-Horse continued his wild
+career unchecked and with unabated speed.
+
+Presently they came to the banks of a wide river, and without a pause
+the wooden steed gave one final leap and launched them all in mid-air.
+
+A second later they were rolling, splashing and bobbing about in the
+water, the horse struggling frantically to find a rest for its feet
+and its riders being first plunged beneath the rapid current and then
+floating upon the surface like corks.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Journey to the
+    Tin Woodman
+]
+
+
+Tip was well soaked and dripping water from every angle of his body;
+but he managed to lean forward and shout in the ear of the Saw-Horse:
+
+"Keep still, you fool! Keep still!"
+
+The horse at once ceased struggling and floated calmly upon the
+surface, its wooden body being as buoyant as a raft.
+
+"What does that word 'fool' mean?" enquired the horse.
+
+"It is a term of reproach," answered Tip, somewhat ashamed of the
+expression. "I only use it when I am angry."
+
+"Then it pleases me to be able to call you a fool, in return," said the
+horse. "For I did not make the river, nor put it in our way; so only a
+term of reproach is fit for one who becomes angry with me for falling
+into the water."
+
+"That is quite evident," replied Tip; "so I will acknowledge myself in
+the wrong." Then he called out to the Pumpkinhead: "are you all right,
+Jack?"
+
+There was no reply. So the boy called to the King: "are you all right,
+your majesty?"
+
+The Scarecrow groaned.
+
+"I'm all wrong, somehow," he said, in a weak voice. "How very wet this
+water is!"
+
+Tip was bound so tightly by the cord that he could not turn his head to
+look at his companions; so he said to the Saw-Horse:
+
+"Paddle with your legs toward the shore."
+
+The horse obeyed, and although their progress was slow they finally
+reached the opposite river bank at a place where it was low enough to
+enable the creature to scramble upon dry land.
+
+With some difficulty the boy managed to get his knife out of his pocket
+and cut the cords that bound the riders to one another and to the
+wooden horse. He heard the Scarecrow fall to the ground with a mushy
+sound, and then he himself quickly dismounted and looked at his friend
+Jack.
+
+The wooden body, with its gorgeous clothing, still sat upright upon
+the horse's back; but the pumpkin head was gone, and only the sharpened
+stick that served for a neck was visible. As for the Scarecrow, the
+straw in his body had shaken down with the jolting and packed itself
+into his legs and the lower part of his body--which appeared very plump
+and round while his upper half seemed like an empty sack. Upon his head
+the Scarecrow still wore the heavy crown, which had been sewed on to
+prevent his losing it; but the head was now so damp and limp that the
+weight of the gold and jewels sagged forward and crushed the painted
+face into a mass of wrinkles that made him look exactly like a Japanese
+pug dog.
+
+Tip would have laughed--had he not been so anxious about his man Jack.
+But the Scarecrow, however damaged, was all there, while the pumpkin
+head that was so necessary to Jack's existence was missing; so the boy
+seized a long pole that fortunately lay near at hand and anxiously
+turned again toward the river.
+
+Far out upon the waters he sighted the golden hue of the pumpkin, which
+gently bobbed up and down with the motion of the waves. At that moment
+it was quite out of Tip's reach, but after a time it floated nearer
+and still nearer until the boy was able to reach it with his pole
+and draw it to the shore. Then he brought it to the top of the bank,
+carefully wiped the water from its pumpkin face with his handkerchief,
+and ran with it to Jack and replaced the head upon the man's neck.
+
+[Illustration: TIP RESCUES JACK'S PUMPKIN HEAD.]
+
+"Dear me!" were Jack's first words. "What a dreadful experience! I
+wonder if water is liable to spoil pumpkins?"
+
+Tip did not think a reply was necessary, for he knew that the Scarecrow
+also stood in need of his help. So he carefully removed the straw from
+the King's body and legs, and spread it out in the sun to dry. The wet
+clothing he hung over the body of the Saw-Horse.
+
+"If water spoils pumpkins," observed Jack, with a deep sigh, "then my
+days are numbered."
+
+"I've never noticed that water spoils pumpkins," returned Tip; "unless
+the water happens to be boiling. If your head isn't cracked, my friend,
+you must be in fairly good condition."
+
+"Oh, my head isn't cracked in the least," declared Jack, more
+cheerfully.
+
+"Then don't worry," retorted the boy. "Care once killed a cat."
+
+"Then," said Jack, seriously, "I am very glad indeed that I am not a
+cat."
+
+The sun was fast drying their clothing, and Tip stirred up his
+Majesty's straw so that the warm rays might absorb the moisture and
+make it as crisp and dry as ever. When this had been accomplished he
+stuffed the Scarecrow into symmetrical shape and smoothed out his face
+so that he wore his usual gay and charming expression.
+
+"Thank you very much," said the monarch, brightly, as he walked about
+and found himself to be well balanced. "There are several distinct
+advantages in being a Scarecrow. For if one has friends near at hand to
+repair damages, nothing very serious can happen to you."
+
+"I wonder if hot sunshine is liable to crack pumpkins," said Jack, with
+an anxious ring in his voice.
+
+"Not at all--not at all!" replied the Scarecrow, gaily. "All you
+need fear, my boy, is old age. When your golden youth has decayed we
+shall quickly part company--but you needn't look forward to it; we'll
+discover the fact ourselves, and notify you. But come! Let us resume
+our journey. I am anxious to greet my friend the Tin Woodman."
+
+So they remounted the Saw-Horse, Tip holding to the post, the
+Pumpkinhead clinging to Tip, and the Scarecrow with both arms around
+the wooden form of Jack.
+
+[Illustration: TIP STUFFS THE SCARECROW WITH DRY STRAW.]
+
+"Go slowly, for now there is no danger of pursuit," said Tip to his
+steed.
+
+"All right!" responded the creature, in a voice rather gruff.
+
+"Aren't you a little hoarse?" asked the Pumpkinhead, politely.
+
+The Saw-Horse gave an angry prance and rolled one knotty eye backward
+toward Tip.
+
+"See here," he growled, "can't you protect me from insult?"
+
+"To be sure!" answered Tip, soothingly. "I am sure Jack meant no harm.
+And it will not do for us to quarrel, you know; we must all remain good
+friends."
+
+"I'll have nothing more to do with that Pumpkinhead," declared the
+Saw-Horse, viciously; "he loses his head too easily to suit me."
+
+There seemed no fitting reply to this speech, so for a time they rode
+along in silence.
+
+After a while the Scarecrow remarked:
+
+"This reminds me of old times. It was upon this grassy knoll that I
+once saved Dorothy from the Stinging Bees of the Wicked Witch of the
+West."
+
+"Do Stinging Bees injure pumpkins?" asked Jack, glancing around
+fearfully.
+
+"They are all dead, so it doesn't matter," replied the Scarecrow. "And
+here is where Nick Chopper destroyed the Wicked Witch's Grey Wolves."
+
+"Who was Nick Chopper?" asked Tip.
+
+"That is the name of my friend the Tin Woodman," answered his Majesty.
+"And here is where the Winged Monkeys captured and bound us, and flew
+away with little Dorothy," he continued, after they had traveled a
+little way farther.
+
+"Do Winged Monkeys ever eat pumpkins?" asked Jack, with a shiver of
+fear.
+
+"I do not know; but you have little cause to worry, for the Winged
+Monkeys are now the slaves of Glinda the Good, who owns the Golden Cap
+that commands their services," said the Scarecrow, reflectively.
+
+Then the stuffed monarch became lost in thought, recalling the days
+of past adventures. And the Saw-Horse rocked and rolled over the
+flower-strewn fields and carried its riders swiftly upon their way.
+
+       *       *       *       *       *
+
+Twilight fell, bye and bye, and then the dark shadows of night. So Tip
+stopped the horse and they all proceeded to dismount.
+
+"I'm tired out," said the boy, yawning wearily; "and the grass is soft
+and cool. Let us lie down here and sleep until morning."
+
+"I can't sleep," said Jack.
+
+"I never do," said the Scarecrow.
+
+"I do not even know what sleep is," said the Saw-Horse.
+
+"Still, we must have consideration for this poor boy, who is made of
+flesh and blood and bone, and gets tired," suggested the Scarecrow,
+in his usual thoughtful manner. "I remember it was the same way with
+little Dorothy. We always had to sit through the night while she slept."
+
+"I'm sorry," said Tip, meekly, "but I can't help it. And I'm dreadfully
+hungry, too!"
+
+"Here is a new danger!" remarked Jack, gloomily. "I hope you are not
+fond of eating pumpkins."
+
+"Not unless they're stewed and made into pies," answered the boy,
+laughing. "So have no fears of me, friend Jack."
+
+"What a coward that Pumpkinhead is!" said the Saw-Horse, scornfully.
+
+"You might be a coward yourself, if you knew you were liable to spoil!"
+retorted Jack, angrily.
+
+"There!--there!" interrupted the Scarecrow; "don't let us quarrel.
+We all have our weaknesses, dear friends; so we must strive to be
+considerate of one another. And since this poor boy is hungry and has
+nothing whatever to eat, let us all remain quiet and allow him to
+sleep; for it is said that in sleep a mortal may forget even hunger."
+
+"Thank you!" exclaimed Tip, gratefully. "Your Majesty is fully as good
+as you are wise--and that is saying a good deal!"
+
+He then stretched himself upon the grass and, using the stuffed form of
+the Scarecrow for a pillow, was presently fast asleep.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Nickel-Plated Emperor
+]
+
+
+Tip awoke soon after dawn, but the Scarecrow had already risen and
+plucked, with his clumsy fingers, a double-handful of ripe berries from
+some bushes near by. These the boy ate greedily, finding them an ample
+breakfast, and afterward the little party resumed its journey.
+
+After an hour's ride they reached the summit of a hill from whence
+they espied the City of the Winkies and noted the tall domes of the
+Emperor's palace rising from the clusters of more modest dwellings.
+
+The Scarecrow became greatly animated at this sight, and exclaimed:
+
+"How delighted I shall be to see my old friend the Tin Woodman again! I
+hope that he rules his people more successfully than I have ruled mine!"
+
+"Is the Tin Woodman the Emperor of the Winkies?" asked the horse.
+
+"Yes, indeed. They invited him to rule over them soon after the Wicked
+Witch was destroyed; and as Nick Chopper has the best heart in all the
+world I am sure he has proved an excellent and able emperor."
+
+"I thought that 'Emperor' was the title of a person who rules an
+empire," said Tip, "and the Country of the Winkies is only a Kingdom."
+
+"Don't mention that to the Tin Woodman!" exclaimed the Scarecrow,
+earnestly. "You would hurt his feelings terribly. He is a proud man,
+as he has every reason to be, and it pleases him to be termed Emperor
+rather than King."
+
+"I'm sure it makes no difference to me," replied the boy.
+
+The Saw-Horse now ambled forward at a pace so fast that its riders
+had hard work to stick upon its back; so there was little further
+conversation until they drew up beside the palace steps.
+
+An aged Winkie, dressed in a uniform of silver cloth, came forward to
+assist them to alight. Said the Scarecrow to this personage:
+
+"Show us at once to your master, the Emperor."
+
+The man looked from one to another of the party in an embarrassed way,
+and finally answered:
+
+"I fear I must ask you to wait for a time. The Emperor is not receiving
+this morning."
+
+"How is that?" enquired the Scarecrow, anxiously. "I hope nothing has
+happened to him."
+
+"Oh, no; nothing serious," returned the man. "But this is his Majesty's
+day for being polished, and just now his august presence is thickly
+smeared with putz-pomade."
+
+"Oh, I see!" cried the Scarecrow, greatly reassured. "My friend was
+ever inclined to be a dandy, and I suppose he is now more proud than
+ever of his personal appearance."
+
+"He is, indeed," said the man, with a polite bow. "Our mighty Emperor
+has lately caused himself to be nickel-plated."
+
+"Good Gracious!" the Scarecrow exclaimed at hearing this. "If his wit
+bears the same polish, how sparkling it must be! But show us in--I'm
+sure the Emperor will receive us, even in his present state."
+
+"The Emperor's state is always magnificent," said the man. "But I will
+venture to tell him of your arrival, and will receive his commands
+concerning you."
+
+So the party followed the servant into a splendid ante-room, and the
+Saw-Horse ambled awkwardly after them, having no knowledge that a horse
+might be expected to remain outside.
+
+The travelers were at first somewhat awed by their surroundings, and
+even the Scarecrow seemed impressed as he examined the rich hangings
+of silver cloth caught up into knots and fastened with tiny silver
+axes. Upon a handsome center-table stood a large silver oil-can,
+richly engraved with scenes from the past adventures of the Tin
+Woodman, Dorothy, the Cowardly Lion and the Scarecrow: the lines of the
+engraving being traced upon the silver in yellow gold. On the walls
+hung several portraits, that of the Scarecrow seeming to be the most
+prominent and carefully executed, while a large painting of the famous
+Wizard of Oz, in the act of presenting the Tin Woodman with a heart,
+covered almost one entire end of the room.
+
+While the visitors gazed at these things in silent admiration they
+suddenly heard a loud voice in the next room exclaim:
+
+"Well! well! well! What a great surprise!"
+
+And then the door burst open and Nick Chopper rushed into their midst
+and caught the Scarecrow in a close and loving embrace that creased him
+into many folds and wrinkles.
+
+"My dear old friend! My noble comrade!" cried the Tin Woodman,
+joyfully; "how delighted I am to meet you once again!"
+
+[Illustration: CAUGHT THE SCARECROW IN A CLOSE AND LOVING EMBRACE.]
+
+And then he released the Scarecrow and held him at arms' length while
+he surveyed the beloved, painted features.
+
+But, alas! the face of the Scarecrow and many portions of his body bore
+great blotches of putz-pomade; for the Tin Woodman, in his eagerness to
+welcome his friend, had quite forgotten the condition of his toilet and
+had rubbed the thick coating of paste from his own body to that of his
+comrade.
+
+"Dear me!" said the Scarecrow, dolefully. "What a mess I'm in!"
+
+"Never mind, my friend," returned the Tin Woodman, "I'll send you to my
+Imperial Laundry, and you'll come out as good as new."
+
+"Won't I be mangled?" asked the Scarecrow.
+
+"No, indeed!" was the reply. "But tell me, how came your Majesty here?
+and who are your companions?"
+
+The Scarecrow, with great politeness, introduced Tip and Jack
+Pumpkinhead, and the latter personage seemed to interest the Tin
+Woodman greatly.
+
+"You are not very substantial, I must admit," said the Emperor; "but
+you are certainly unusual, and therefore worthy to become a member of
+our select society."
+
+"I thank your Majesty," said Jack, humbly.
+
+[Illustration]
+
+"I hope you are enjoying good health?" continued the Woodman.
+
+"At present, yes;" replied the Pumpkinhead, with a sigh; "but I am in
+constant terror of the day when I shall spoil."
+
+"Nonsense!" said the Emperor--but in a kindly, sympathetic tone. "Do
+not, I beg of you, dampen today's sun with the showers of tomorrow. For
+before your head has time to spoil you can have it canned, and in that
+way it may be preserved indefinitely."
+
+Tip, during this conversation, was looking at the Woodman with
+undisguised amazement, and noticed that the celebrated Emperor of
+the Winkies was composed entirely of pieces of tin, neatly soldered
+and riveted together into the form of a man. He rattled and clanked
+a little, as he moved, but in the main he seemed to be most cleverly
+constructed, and his appearance was only marred by the thick coating of
+polishing-paste that covered him from head to foot.
+
+The boy's intent gaze caused the Tin Woodman to remember that he was
+not in the most presentable condition, so he begged his friends to
+excuse him while he retired to his private apartment and allowed his
+servants to polish him. This was accomplished in a short time, and when
+the Emperor returned his nickel-plated body shone so magnificently that
+the Scarecrow heartily congratulated him on his improved appearance.
+
+"That nickel-plate was, I confess, a happy thought," said Nick; "and it
+was the more necessary because I had become somewhat scratched during
+my adventurous experiences. You will observe this engraved star upon
+my left breast. It not only indicates where my excellent heart lies,
+but covers very neatly the patch made by the Wonderful Wizard when he
+placed that valued organ in my breast with his own skillful hands."
+
+"Is your heart, then, a hand-organ?" asked the Pumpkinhead, curiously.
+
+"By no means," responded the Emperor, with dignity. "It is, I am
+convinced, a strictly orthodox heart, although somewhat larger and
+warmer than most people possess."
+
+Then he turned to the Scarecrow and asked:
+
+"Are your subjects happy and contented, my dear friend?"
+
+"I cannot say," was the reply; "for the girls of Oz have risen in
+revolt and driven me out of the Emerald City."
+
+"Great Goodness!" cried the Tin Woodman. "What a calamity! They surely
+do not complain of your wise and gracious rule?"
+
+"No; but they say it is a poor rule that don't work both ways,"
+answered the Scarecrow; "and these females are also of the opinion that
+men have ruled the land long enough. So they have captured my city,
+robbed the treasury of all its jewels, and are running things to suit
+themselves."
+
+"Dear me! What an extraordinary idea!" cried the Emperor, who was both
+shocked and surprised.
+
+"And I heard some of them say," said Tip, "that they intend to march
+here and capture the castle and city of the Tin Woodman."
+
+"Ah! we must not give them time to do that," said the Emperor, quickly;
+"we will go at once and recapture the Emerald City and place the
+Scarecrow again upon his throne."
+
+[Illustration: RENOVATING HIS MAJESTY, THE SCARECROW.]
+
+"I was sure you would help me," remarked the Scarecrow in a pleased
+voice. "How large an army can you assemble?"
+
+"We do not need an army," replied the Woodman. "We four, with the aid
+of my gleaming axe, are enough to strike terror into the hearts of the
+rebels."
+
+"We five," corrected the Pumpkinhead.
+
+"Five?" repeated the Tin Woodman.
+
+"Yes; the Saw-Horse is brave and fearless," answered Jack, forgetting
+his recent quarrel with the quadruped.
+
+The Tin Woodman looked around him in a puzzled way, for the Saw-Horse
+had until now remained quietly standing in a corner, where the Emperor
+had not noticed him. Tip immediately called the odd-looking creature to
+them, and it approached so awkwardly that it nearly upset the beautiful
+center-table and the engraved oil-can.
+
+"I begin to think," remarked the Tin Woodman as he looked earnestly at
+the Saw-Horse, "that wonders will never cease! How came this creature
+alive?"
+
+"I did it with a magic powder," modestly asserted the boy; "and the
+Saw-Horse has been very useful to us."
+
+"He enabled us to escape the rebels," added the Scarecrow.
+
+"Then we must surely accept him as a comrade," declared the Emperor. "A
+live Saw-Horse is a distinct novelty, and should prove an interesting
+study. Does he know anything?"
+
+"Well, I cannot claim any great experience in life," the Saw-Horse
+answered for himself; "but I seem to learn very quickly, and often it
+occurs to me that I know more than any of those around me."
+
+"Perhaps you do," said the Emperor; "for experience does not always
+mean wisdom. But time is precious just now, so let us quickly make
+preparations to start upon our journey."
+
+The Emperor called his Lord High Chancellor and instructed him how to
+run the kingdom during his absence. Meanwhile the Scarecrow was taken
+apart and the painted sack that served him for a head was carefully
+laundered and restuffed with the brains originally given him by the
+great Wizard. His clothes were also cleaned and pressed by the Imperial
+tailors, and his crown polished and again sewed upon his head, for the
+Tin Woodman insisted he should not renounce this badge of royalty. The
+Scarecrow now presented a very respectable appearance, and although
+in no way addicted to vanity he was quite pleased with himself and
+strutted a trifle as he walked. While this was being done Tip mended
+the wooden limbs of Jack Pumpkinhead and made them stronger than
+before, and the Saw-Horse was also inspected to see if he was in good
+working order.
+
+Then bright and early the next morning they set out upon the return
+journey to the Emerald City, the Tin Woodman bearing upon his shoulder
+a gleaming axe and leading the way, while the Pumpkinhead rode upon the
+Saw-Horse and Tip and the Scarecrow walked upon either side to make
+sure that he didn't fall off or become damaged.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Mr. H. M. Woggle-Bug, T. E.
+]
+
+
+Now, General Jinjur--who, you will remember, commanded the Army of
+Revolt--was rendered very uneasy by the escape of the Scarecrow from
+the Emerald City. She feared, and with good reason, that if his Majesty
+and the Tin Woodman joined forces, it would mean danger to her and
+her entire army; for the people of Oz had not yet forgotten the deeds
+of these famous heroes, who had passed successfully through so many
+startling adventures.
+
+So Jinjur sent post-haste for old Mombi, the witch, and promised her
+large rewards if she would come to the assistance of the rebel army.
+
+Mombi was furious at the trick Tip had played upon her, as well as at
+his escape and the theft of the precious Powder of Life; so she needed
+no urging to induce her to travel to the Emerald City to assist Jinjur
+in defeating the Scarecrow and the Tin Woodman, who had made Tip one of
+their friends.
+
+Mombi had no sooner arrived at the royal palace than she discovered,
+by means of her secret magic, that the adventurers were starting upon
+their journey to the Emerald City; so she retired to a small room high
+up in a tower and locked herself in while she practised such arts
+as she could command to prevent the return of the Scarecrow and his
+companions.
+
+That was why the Tin Woodman presently stopped and said:
+
+"Something very curious has happened. I ought to know by heart every
+step of this journey, and yet I fear we have already lost our way."
+
+"That is quite impossible!" protested the Scarecrow. "Why do you think,
+my dear friend, that we have gone astray?"
+
+"Why, here before us is a great field of sunflowers--and I never saw
+this field before in all my life."
+
+At these words they all looked around, only to find that they were
+indeed surrounded by a field of tall stalks, every stalk bearing at
+its top a gigantic sunflower. And not only were these flowers almost
+blinding in their vivid hues of red and gold, but each one whirled
+around upon its stalk like a miniature wind-mill, completely dazzling
+the vision of the beholders and so mystifying them that they knew not
+which way to turn.
+
+"It's witchcraft!" exclaimed Tip.
+
+While they paused, hesitating and wondering, the Tin Woodman uttered
+a cry of impatience and advanced with swinging axe to cut down the
+stalks before him. But now the sunflowers suddenly stopped their rapid
+whirling, and the travelers plainly saw a girl's face appear in the
+center of each flower. These lovely faces looked upon the astonished
+band with mocking smiles, and then burst into a chorus of merry
+laughter at the dismay their appearance caused.
+
+"Stop! stop!" cried Tip, seizing the Woodman's arm; "they're alive!
+they're girls!"
+
+At that moment the flowers began whirling again, and the faces faded
+away and were lost in the rapid revolutions.
+
+The Tin Woodman dropped his axe and sat down upon the ground.
+
+"It would be heartless to chop down those pretty creatures," said he,
+despondently; "and yet I do not know how else we can proceed upon our
+way."
+
+"They looked to me strangely like the faces of the Army of Revolt,"
+mused the Scarecrow. "But I cannot conceive how the girls could have
+followed us here so quickly."
+
+"I believe it's magic," said Tip, positively, "and that someone is
+playing a trick upon us. I've known old Mombi do things like that
+before. Probably it's nothing more than an illusion, and there are no
+sunflowers here at all."
+
+"Then let us shut our eyes and walk forward," suggested the Woodman.
+
+"Excuse me," replied the Scarecrow. "My eyes are not painted to shut.
+Because you happen to have tin eyelids, you must not imagine we are all
+built in the same way."
+
+"And the eyes of the Saw-Horse are knot eyes," said Jack, leaning
+forward to examine them.
+
+"Nevertheless, you must ride quickly forward," commanded Tip, "and we
+will follow after you and so try to escape. My eyes are already so
+dazzled that I can scarcely see."
+
+So the Pumpkinhead rode boldly forward, and Tip grasped the stub tail
+of the Saw-Horse and followed with closed eyes. The Scarecrow and the
+Tin Woodman brought up the rear, and before they had gone many yards a
+joyful shout from Jack announced that the way was clear before them.
+
+Then all paused to look backward, but not a trace of the field of
+sunflowers remained.
+
+More cheerfully, now, they proceeded upon their journey; but old Mombi
+had so changed the appearance of the landscape that they would surely
+have been lost had not the Scarecrow wisely concluded to take their
+direction from the sun. For no witchcraft could change the course of
+the sun, and it was therefore a safe guide.
+
+However, other difficulties lay before them. The Saw-Horse stepped into
+a rabbit hole and fell to the ground. The Pumpkinhead was pitched high
+into the air, and his history would probably have ended at that exact
+moment had not the Tin Woodman skillfully caught the pumpkin as it
+descended and saved it from injury.
+
+Tip soon had it fitted to the neck again and replaced Jack upon his
+feet. But the Saw-Horse did not escape so easily. For when his leg was
+pulled from the rabbit hole it was found to be broken short off, and
+must be replaced or repaired before he could go a step farther.
+
+"This is quite serious," said the Tin Woodman. "If there were trees
+near by I might soon manufacture another leg for this animal; but I
+cannot see even a shrub for miles around."
+
+[Illustration: THE TIN WOODMAN SKILLFULLY CAUGHT THE PUMPKIN]
+
+"And there are neither fences nor houses in this part of the land of
+Oz," added the Scarecrow, disconsolately.
+
+"Then what shall we do?" enquired the boy.
+
+"I suppose I must start my brains working," replied his Majesty the
+Scarecrow; "for experience has taught me that I can do anything if I
+but take time to think it out."
+
+"Let us all think," said Tip; "and perhaps we shall find a way to
+repair the Saw-Horse."
+
+So they sat in a row upon the grass and began to think, while the
+Saw-Horse occupied itself by gazing curiously upon its broken limb.
+
+"Does it hurt?" asked the Tin Woodman, in a soft, sympathetic voice.
+
+"Not in the least," returned the Saw-Horse; "but my pride is injured to
+find that my anatomy is so brittle."
+
+For a time the little group remained in silent thought. Presently the
+Tin Woodman raised his head and looked over the fields.
+
+"What sort of creature is that which approaches us?" he asked,
+wonderingly.
+
+The others followed his gaze, and discovered coming toward them the
+most extraordinary object they had ever beheld. It advanced quickly
+and noiselessly over the soft grass and in a few minutes stood before
+the adventurers and regarded them with an astonishment equal to their
+own.
+
+The Scarecrow was calm under all circumstances.
+
+"Good morning!" he said, politely.
+
+The stranger removed his hat with a flourish, bowed very low, and then
+responded:
+
+[Illustration]
+
+"Good morning, one and all. I hope you are, as an aggregation, enjoying
+excellent health. Permit me to present my card."
+
+With this courteous speech it extended a card toward the Scarecrow, who
+accepted it, turned it over and over, and then handed it with a shake
+of his head to Tip.
+
+The boy read aloud:
+
+"MR. H. M. WOGGLE-BUG, T. E."
+
+"Dear me!" ejaculated the Pumpkinhead, staring somewhat intently.
+
+"How very peculiar!" said the Tin Woodman.
+
+Tip's eyes were round and wondering, and the Saw-Horse uttered a sigh
+and turned away its head.
+
+"Are you really a Woggle-Bug?" enquired the Scarecrow.
+
+"Most certainly, my dear sir!" answered the stranger, briskly. "Is not
+my name upon the card?"
+
+"It is," said the Scarecrow. "But may I ask what 'H. M.' stands for?"
+
+"'H. M.' means Highly Magnified," returned the Woggle-Bug, proudly.
+
+"Oh, I see." The Scarecrow viewed the stranger critically. "And are
+you, in truth, highly magnified?"
+
+"Sir," said the Woggle-Bug, "I take you for a gentleman of judgment
+and discernment. Does it not occur to you that I am several thousand
+times greater than any Woggle-Bug you ever saw before? Therefore it is
+plainly evident that I am Highly Magnified, and there is no good reason
+why you should doubt the fact."
+
+"Pardon me," returned the Scarecrow. "My brains are slightly mixed
+since I was last laundered. Would it be improper for me to ask, also,
+what the 'T. E.' at the end of your name stands for?"
+
+"Those letters express my degree," answered the Woggle-Bug, with a
+condescending smile. "To be more explicit, the initials mean that I am
+Thoroughly Educated."
+
+"Oh!" said the Scarecrow, much relieved.
+
+Tip had not yet taken his eyes off this wonderful personage. What he
+saw was a great, round, bug-like body supported upon two slender legs
+which ended in delicate feet--the toes curling upward. The body of the
+Woggle-Bug was rather flat, and judging from what could be seen of it
+was of a glistening dark brown color upon the back, while the front
+was striped with alternate bands of light brown and white, blending
+together at the edges. Its arms were fully as slender as its legs, and
+upon a rather long neck was perched its head--not unlike the head of a
+man, except that its nose ended in a curling antenna, or "feeler," and
+its ears from the upper points bore antennæ that decorated the sides
+of its head like two miniature, curling pig tails. It must be admitted
+that the round, black eyes were rather bulging in appearance; but the
+expression upon the Woggle-Bug's face was by no means unpleasant.
+
+For dress the insect wore a dark-blue swallow-tail coat with a yellow
+silk lining and a flower in the button-hole; a vest of white duck that
+stretched tightly across the wide body; knickerbockers of fawn-colored
+plush, fastened at the knees with gilt buckles; and, perched upon its
+small head, was jauntily set a tall silk hat.
+
+Standing upright before our amazed friends the Woggle-Bug appeared to
+be fully as tall as the Tin Woodman; and surely no bug in all the Land
+of Oz had ever before attained so enormous a size.
+
+"I confess," said the Scarecrow, "that your abrupt appearance has
+caused me surprise, and no doubt has startled my companions. I hope,
+however, that this circumstance will not distress you. We shall
+probably get used to you in time."
+
+"Do not apologize, I beg of you!" returned the Woggle-Bug, earnestly.
+"It affords me great pleasure to surprise people; for surely I cannot
+be classed with ordinary insects and am entitled to both curiosity and
+admiration from those I meet."
+
+"You are, indeed," agreed his Majesty.
+
+"If you will permit me to seat myself in your august company,"
+continued the stranger, "I will gladly relate my history, so
+that you will be better able to comprehend my unusual--may I say
+remarkable?--appearance."
+
+"You may say what you please," answered the Tin Woodman, briefly.
+
+So the Woggle-Bug sat down upon the grass, facing the little group of
+wanderers, and told them the following story:
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    A Highly Magnified
+    History
+]
+
+
+"It is but honest that I should acknowledge at the beginning of my
+recital that I was born an ordinary Woggle-Bug," began the creature, in
+a frank and friendly tone. "Knowing no better, I used my arms as well
+as my legs for walking, and crawled under the edges of stones or hid
+among the roots of grasses with no thought beyond finding a few insects
+smaller than myself to feed upon.
+
+"The chill nights rendered me stiff and motionless, for I wore no
+clothing, but each morning the warm rays of the sun gave me new life
+and restored me to activity. A horrible existence is this, but you must
+remember it is the regularly ordained existence of Woggle-Bugs, as well
+as of many other tiny creatures that inhabit the earth.
+
+"But Destiny had singled me out, humble though I was, for a grander
+fate! One day I crawled near to a country school house, and my
+curiosity being excited by the monotonous hum of the students within,
+I made bold to enter and creep along a crack between two boards until
+I reached the far end, where, in front of a hearth of glowing embers,
+sat the master at his desk.
+
+"No one noticed so small a creature as a Woggle-Bug, and when I found
+that the hearth was even warmer and more comfortable than the sunshine,
+I resolved to establish my future home beside it. So I found a charming
+nest between two bricks and hid myself therein for many, many months.
+
+"Professor Nowitall is, doubtless, the most famous scholar in the land
+of Oz, and after a few days I began to listen to the lectures and
+discourses he gave his pupils. Not one of them was more attentive than
+the humble, unnoticed Woggle-Bug, and I acquired in this way a fund of
+knowledge that I will myself confess is simply marvelous. That is why
+I place 'T. E.'--Thoroughly Educated--upon my cards; for my greatest
+pride lies in the fact that the world cannot produce another Woggle-Bug
+with a tenth part of my own culture and erudition."
+
+"I do not blame you," said the Scarecrow. "Education is a thing to
+be proud of. I'm educated myself. The mess of brains given me by the
+Great Wizard is considered by my friends to be unexcelled."
+
+"Nevertheless," interrupted the Tin Woodman, "a good heart is, I
+believe, much more desirable than education or brains."
+
+"To me," said the Saw-Horse, "a good leg is more desirable than either."
+
+"Could seeds be considered in the light of brains?" enquired the
+Pumpkinhead, abruptly.
+
+"Keep quiet!" commanded Tip, sternly.
+
+"Very well, dear father," answered the obedient Jack.
+
+The Woggle-Bug listened patiently--even respectfully--to these remarks,
+and then resumed his story.
+
+"I must have lived fully three years in that secluded school-house
+hearth," said he, "drinking thirstily of the ever-flowing fount of
+limpid knowledge before me."
+
+"Quite poetical," commented the Scarecrow, nodding his head approvingly.
+
+[Illustration: "Caught me between his thumb and forefinger."]
+
+"But one day," continued the Bug, "a marvelous circumstance occurred
+that altered my very existence and brought me to my present pinnacle of
+greatness. The Professor discovered me in the act of crawling across
+the hearth, and before I could escape he had caught me between his
+thumb and forefinger.
+
+"'My dear children,' said he, 'I have captured a Woggle-Bug--a very
+rare and interesting specimen. Do any of you know what a Woggle-Bug is?'
+
+"'No!' yelled the scholars, in chorus.
+
+"'Then,' said the Professor, 'I will get out my famous magnifying-glass
+and throw the insect upon a screen in a highly-magnified condition,
+that you may all study carefully its peculiar construction and become
+acquainted with its habits and manner of life.'
+
+"He then brought from a cupboard a most curious instrument, and before
+I could realize what had happened I found myself thrown upon a screen
+in a highly-magnified state--even as you now behold me.
+
+"The students stood up on their stools and craned their heads forward
+to get a better view of me, and two little girls jumped upon the sill
+of an open window where they could see more plainly.
+
+"'Behold!' cried the Professor, in a loud voice, 'this highly-magnified
+Woggle-Bug; one of the most curious insects in existence!'
+
+"Being Thoroughly Educated, and knowing what is required of a cultured
+gentleman, at this juncture I stood upright and, placing my hand upon
+my bosom, made a very polite bow. My action, being unexpected, must
+have startled them, for one of the little girls perched upon the
+window-sill gave a scream and fell backward out the window, drawing her
+companion with her as she disappeared.
+
+[Illustration: "THE STUDENTS STOOD UP ON THEIR STOOLS."]
+
+"The Professor uttered a cry of horror and rushed away through the
+door to see if the poor children were injured by the fall. The
+scholars followed after him in a wild mob, and I was left alone in the
+school-room, still in a Highly-Magnified state and free to do as I
+pleased.
+
+"It immediately occurred to me that this was a good opportunity to
+escape. I was proud of my great size, and realized that now I could
+safely travel anywhere in the world, while my superior culture would
+make me a fit associate for the most learned person I might chance to
+meet.
+
+"So, while the Professor picked the little girls--who were more
+frightened than hurt--off the ground, and the pupils clustered around
+him closely grouped, I calmly walked out of the school-house, turned a
+corner, and escaped unnoticed to a grove of trees that stood near."
+
+"Wonderful!" exclaimed the Pumpkinhead, admiringly.
+
+"It was, indeed," agreed the Woggle-Bug. "I have never ceased to
+congratulate myself for escaping while I was Highly Magnified; for
+even my excessive knowledge would have proved of little use to me had
+I remained a tiny, insignificant insect."
+
+[Illustration]
+
+"I didn't know before," said Tip, looking at the Woggle-Bug with a
+puzzled expression, "that insects wore clothes."
+
+"Nor do they, in their natural state," returned the stranger. "But
+in the course of my wanderings I had the good fortune to save the
+ninth life of a tailor--tailors having, like cats, nine lives, as
+you probably know. The fellow was exceedingly grateful, for had he
+lost that ninth life it would have been the end of him; so he begged
+permission to furnish me with the stylish costume I now wear. It fits
+very nicely, does it not?" and the Woggle-Bug stood up and turned
+himself around slowly, that all might examine his person.
+
+"He must have been a good tailor," said the Scarecrow, somewhat
+enviously.
+
+"He was a good-hearted tailor, at any rate," observed Nick Chopper.
+
+"But where were you going, when you met us?" Tip asked the Woggle-Bug.
+
+"Nowhere in particular," was the reply, "although it is my intention
+soon to visit the Emerald City and arrange to give a course of lectures
+to select audiences on the 'Advantages of Magnification.'"
+
+"We are bound for the Emerald City now," said the Tin Woodman; "so, if
+it pleases you to do so, you are welcome to travel in our company."
+
+The Woggle-Bug bowed with profound grace.
+
+"It will give me great pleasure," said he, "to accept your kind
+invitation; for nowhere in the Land of Oz could I hope to meet with so
+congenial a company."
+
+"That is true," acknowledged the Pumpkinhead. "We are quite as
+congenial as flies and honey."
+
+"But--pardon me if I seem inquisitive--are you not all
+rather--ahem!--rather unusual?" asked the Woggle-Bug, looking from one
+to another with unconcealed interest.
+
+"Not more so than yourself," answered the Scarecrow. "Everything in
+life is unusual until you get accustomed to it."
+
+"What rare philosophy!" exclaimed the Woggle-Bug, admiringly.
+
+"Yes; my brains are working well today," admitted the Scarecrow, an
+accent of pride in his voice.
+
+"Then, if you are sufficiently rested and refreshed, let us bend our
+steps toward the Emerald City," suggested the magnified one.
+
+"We can't," said Tip. "The Saw-Horse has broken a leg, so he can't bend
+his steps. And there is no wood around to make him a new limb from. And
+we can't leave the horse behind because the Pumpkinhead is so stiff in
+his joints that he has to ride."
+
+"How very unfortunate!" cried the Woggle-Bug. Then he looked the party
+over carefully and said:
+
+"If the Pumpkinhead is to ride, why not use one of his legs to make a
+leg for the horse that carries him? I judge that both are made of wood."
+
+"Now, that is what I call real cleverness," said the Scarecrow,
+approvingly. "I wonder my brains did not think of that long ago! Get to
+work, my dear Nick, and fit the Pumpkinhead's leg to the Saw-Horse."
+
+Jack was not especially pleased with this idea; but he submitted to
+having his left leg amputated by the Tin Woodman and whittled down to
+fit the left leg of the Saw-Horse. Nor was the Saw-Horse especially
+pleased with the operation, either; for he growled a good deal about
+being "butchered," as he called it, and afterward declared that the new
+leg was a disgrace to a respectable Saw-Horse.
+
+"I beg you to be more careful in your speech," said the Pumpkinhead,
+sharply. "Remember, if you please, that it is my leg you are abusing."
+
+"I cannot forget it," retorted the Saw-Horse, "for it is quite as
+flimsy as the rest of your person."
+
+"Flimsy! me flimsy!" cried Jack, in a rage. "How dare you call me
+flimsy?"
+
+"Because you are built as absurdly as a jumping-jack," sneered the
+horse, rolling his knotty eyes in a vicious manner. "Even your head
+won't stay straight, and you never can tell whether you are looking
+backwards or forward!"
+
+"Friends, I entreat you not to quarrel!" pleaded the Tin Woodman,
+anxiously. "As a matter of fact, we are none of us above criticism; so
+let us bear with each others' faults."
+
+"An excellent suggestion," said the Woggle-Bug, approvingly. "You must
+have an excellent heart, my metallic friend."
+
+"I have," returned Nick, well pleased. "My heart is quite the best part
+of me. But now let us start upon our journey."
+
+They perched the one-legged Pumpkinhead upon the Saw-Horse, and tied
+him to his seat with cords, so that he could not possibly fall off.
+
+And then, following the lead of the Scarecrow, they all advanced in the
+direction of the Emerald City.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Old Mombi indulges
+    in Witchcraft
+]
+
+
+They soon discovered that the Saw-Horse limped, for his new leg was a
+trifle too long. So they were obliged to halt while the Tin Woodman
+chopped it down with his axe, after which the wooden steed paced along
+more comfortably. But the Saw-Horse was not entirely satisfied, even
+yet.
+
+"It was a shame that I broke my other leg!" it growled.
+
+"On the contrary," airily remarked the Woggle-Bug, who was walking
+alongside, "you should consider the accident most fortunate. For a
+horse is never of much use until he has been broken."
+
+"I beg your pardon," said Tip, rather provoked, for he felt a warm
+interest in both the Saw-Horse and his man Jack; "but permit me to say
+that your joke is a poor one, and as old as it is poor."
+
+"Still, it is a joke," declared the Woggle-Bug, firmly, "and a joke
+derived from a play upon words is considered among educated people to
+be eminently proper."
+
+"What does that mean?" enquired the Pumpkinhead, stupidly.
+
+"It means, my dear friend," explained the Woggle-Bug, "that our
+language contains many words having a double meaning; and that to
+pronounce a joke that allows both meanings of a certain word, proves
+the joker a person of culture and refinement, who has, moreover, a
+thorough command of the language."
+
+"I don't believe that," said Tip, plainly; "anybody can make a pun."
+
+"Not so," rejoined the Woggle-Bug, stiffly. "It requires education of
+a high order. Are you educated, young sir?"
+
+"Not especially," admitted Tip.
+
+"Then you cannot judge the matter. I myself am Thoroughly Educated, and
+I say that puns display genius. For instance, were I to ride upon this
+Saw-Horse, he would not only be an animal--he would become an equipage.
+For he would then be a horse-and-buggy."
+
+At this the Scarecrow gave a gasp and the Tin Woodman stopped short
+and looked reproachfully at the Woggle-Bug. At the same time the
+Saw-Horse loudly snorted his derision; and even the Pumpkinhead put up
+his hand to hide the smile which, because it was carved upon his face,
+he could not change to a frown.
+
+But the Woggle-Bug strutted along as if he had made some brilliant
+remark, and the Scarecrow was obliged to say:
+
+"I have heard, my dear friend, that a person can become over-educated;
+and although I have a high respect for brains, no matter how they may
+be arranged or classified, I begin to suspect that yours are slightly
+tangled. In any event, I must beg you to restrain your superior
+education while in our society."
+
+"We are not very particular," added the Tin Woodman; "and we are
+exceedingly kind hearted. But if your superior culture gets leaky
+again--" He did not complete the sentence, but he twirled his gleaming
+axe so carelessly that the Woggle-Bug looked frightened, and shrank
+away to a safe distance.
+
+The others marched on in silence, and the Highly-Magnified one, after
+a period of deep thought, said in an humble voice:
+
+"I will endeavor to restrain myself."
+
+"That is all we can expect," returned the Scarecrow, pleasantly; and
+good nature being thus happily restored to the party, they proceeded
+upon their way.
+
+When they again stopped to allow Tip to rest--the boy being the only
+one that seemed to tire--the Tin Woodman noticed many small, round
+holes in the grassy meadow.
+
+"This must be a village of the Field Mice," he said to the Scarecrow.
+"I wonder if my old friend, the Queen of the Mice, is in this
+neighborhood."
+
+"If she is, she may be of great service to us," answered the Scarecrow,
+who was impressed by a sudden thought. "See if you can call her, my
+dear Nick."
+
+So the Tin Woodman blew a shrill note upon a silver whistle that hung
+around his neck, and presently a tiny grey mouse popped from a near-by
+hole and advanced fearlessly toward them. For the Tin Woodman had once
+saved her life, and the Queen of the Field Mice knew he was to be
+trusted.
+
+"Good day, your Majesty," said Nick, politely addressing the mouse; "I
+trust you are enjoying good health?"
+
+"Thank you, I am quite well," answered the Queen, demurely, as she
+sat up and displayed the tiny golden crown upon her head. "Can I do
+anything to assist my old friends?"
+
+"You can, indeed," replied the Scarecrow, eagerly. "Let me, I intreat
+you, take a dozen of your subjects with me to the Emerald City."
+
+"Will they be injured in any way?" asked the Queen, doubtfully.
+
+"I think not," replied the Scarecrow. "I will carry them hidden in
+the straw which stuffs my body, and when I give them the signal by
+unbuttoning my jacket, they have only to rush out and scamper home
+again as fast as they can. By doing this they will assist me to regain
+my throne, which the Army of Revolt has taken from me."
+
+"In that case," said the Queen, "I will not refuse your request.
+Whenever you are ready, I will call twelve of my most intelligent
+subjects."
+
+"I am ready now," returned the Scarecrow. Then he lay flat upon the
+ground and unbuttoned his jacket, displaying the mass of straw with
+which he was stuffed.
+
+The Queen uttered a little piping call, and in an instant a dozen
+pretty field mice had emerged from their holes and stood before their
+ruler, awaiting her orders.
+
+What the Queen said to them none of our travelers could understand,
+for it was in the mouse language; but the field mice obeyed without
+hesitation, running one after the other to the Scarecrow and hiding
+themselves in the straw of his breast.
+
+When all of the twelve mice had thus concealed themselves, the
+Scarecrow buttoned his jacket securely and then arose and thanked the
+Queen for her kindness.
+
+"One thing more you might do to serve us," suggested the Tin Woodman;
+"and that is to run ahead and show us the way to the Emerald City. For
+some enemy is evidently trying to prevent us from reaching it."
+
+"I will do that gladly," returned the Queen. "Are you ready?"
+
+The Tin Woodman looked at Tip.
+
+"I'm rested," said the boy. "Let us start."
+
+Then they resumed their journey, the little grey Queen of the Field
+Mice running swiftly ahead and then pausing until the travelers drew
+near, when away she would dart again.
+
+Without this unerring guide the Scarecrow and his comrades might never
+have gained the Emerald City; for many were the obstacles thrown in
+their way by the arts of old Mombi. Yet not one of the obstacles really
+existed--all were cleverly contrived deceptions. For when they came
+to the banks of a rushing river that threatened to bar their way the
+little Queen kept steadily on, passing through the seeming flood in
+safety; and our travelers followed her without encountering a single
+drop of water.
+
+Again, a high wall of granite towered high above their heads and
+opposed their advance. But the grey Field Mouse walked straight through
+it, and the others did the same, the wall melting into mist as they
+passed it.
+
+Afterward, when they had stopped for a moment to allow Tip to rest,
+they saw forty roads branching off from their feet in forty different
+directions; and soon these forty roads began whirling around like a
+mighty wheel, first in one direction and then in the other, completely
+bewildering their vision.
+
+But the Queen called for them to follow her and darted off in a
+straight line; and when they had gone a few paces the whirling pathways
+vanished and were seen no more.
+
+Mombi's last trick was most fearful of all. She sent a sheet of
+crackling flame rushing over the meadow to consume them; and for the
+first time the Scarecrow became afraid and turned to fly.
+
+"If that fire reaches me I will be gone in no time!" said he, trembling
+until his straw rattled. "It's the most dangerous thing I ever
+encountered."
+
+"I'm off, too!" cried the Saw-Horse, turning and prancing with
+agitation; "for my wood is so dry it would burn like kindlings."
+
+"Is fire dangerous to pumpkins?" asked Jack, fearfully.
+
+[Illustration]
+
+"You'll be baked like a tart--and so will I!" answered the Woggle-Bug,
+getting down on all fours so he could run the faster.
+
+But the Tin Woodman, having no fear of fire, averted the stampede by a
+few sensible words.
+
+"Look at the Field Mouse!" he shouted. "The fire does not burn her in
+the least. In fact, it is no fire at all, but only a deception."
+
+Indeed, to watch the little Queen march calmly through the advancing
+flames restored courage to every member of the party, and they followed
+her without being even scorched.
+
+"This is surely a most extraordinary adventure," said the Woggle-Bug,
+who was greatly amazed; "for it upsets all the Natural Laws that I
+heard Professor Nowitall teach in the school-house."
+
+"Of course it does," said the Scarecrow, wisely. "All magic is
+unnatural, and for that reason is to be feared and avoided. But I see
+before us the gates of the Emerald City, so I imagine we have now
+overcome all the magical obstacles that seemed to oppose us."
+
+Indeed, the walls of the City were plainly visible, and the Queen of
+the Field Mice, who had guided them so faithfully, came near to bid
+them good-bye.
+
+"We are very grateful to your Majesty for your kind assistance," said
+the Tin Woodman, bowing before the pretty creature.
+
+"I am always pleased to be of service to my friends," answered the
+Queen, and in a flash she had darted away upon her journey home.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Prisoners of the Queen
+]
+
+
+Approaching the gateway of the Emerald City the travelers found it
+guarded by two girls of the Army of Revolt, who opposed their entrance
+by drawing the knitting-needles from their hair and threatening to prod
+the first that came near.
+
+But the Tin Woodman was not afraid.
+
+"At the worst they can but scratch my beautiful nickel-plate," he said.
+"But there will be no 'worst,' for I think I can manage to frighten
+these absurd soldiers very easily. Follow me closely, all of you!"
+
+Then, swinging his axe in a great circle to right and left before
+him, he advanced upon the gate, and the others followed him without
+hesitation.
+
+The girls, who had expected no resistance whatever, were terrified by
+the sweep of the glittering axe and fled screaming into the city; so
+that our travelers passed the gates in safety and marched down the
+green marble pavement of the wide street toward the royal palace.
+
+"At this rate we will soon have your Majesty upon the throne again,"
+said the Tin Woodman, laughing at his easy conquest of the guards.
+
+"Thank you, friend Nick," returned the Scarecrow, gratefully. "Nothing
+can resist your kind heart and your sharp axe."
+
+As they passed the rows of houses they saw through the open doors that
+men were sweeping and dusting and washing dishes, while the women sat
+around in groups, gossiping and laughing.
+
+"What has happened?" the Scarecrow asked a sad-looking man with a bushy
+beard, who wore an apron and was wheeling a baby-carriage along the
+sidewalk.
+
+"Why, we've had a revolution, your Majesty--as you ought to know very
+well," replied the man; "and since you went away the women have been
+running things to suit themselves. I'm glad you have decided to come
+back and restore order, for doing housework and minding the children is
+wearing out the strength of every man in the Emerald City."
+
+"Hm!" said the Scarecrow, thoughtfully. "If it is such hard work as
+you say, how did the women manage it so easily?"
+
+"I really do not know," replied the man, with a deep sigh. "Perhaps the
+women are made of cast-iron."
+
+No movement was made, as they passed along the street, to oppose their
+progress. Several of the women stopped their gossip long enough to cast
+curious looks upon our friends, but immediately they would turn away
+with a laugh or a sneer and resume their chatter. And when they met
+with several girls belonging to the Army of Revolt, those soldiers,
+instead of being alarmed or appearing surprised, merely stepped out of
+the way and allowed them to advance without protest.
+
+This action rendered the Scarecrow uneasy.
+
+"I'm afraid we are walking into a trap," said he.
+
+"Nonsense!" returned Nick Chopper, confidently; "the silly creatures
+are conquered already!"
+
+But the Scarecrow shook his head in a way that expressed doubt, and Tip
+said:
+
+"It's too easy, altogether. Look out for trouble ahead."
+
+"I will," returned his Majesty.
+
+[Illustration: "IT'S TOO EASY, ALTOGETHER."]
+
+Unopposed they reached the royal palace and marched up the marble
+steps, which had once been thickly encrusted with emeralds but were
+now filled with tiny holes where the jewels had been ruthlessly torn
+from their settings by the Army of Revolt. And so far not a rebel
+barred their way.
+
+Through the arched hallways and into the magnificent throne room
+marched the Tin Woodman and his followers, and here, when the green
+silken curtains fell behind them, they saw a curious sight.
+
+Seated within the glittering throne was General Jinjur, with the
+Scarecrow's second-best crown upon her head, and the royal sceptre in
+her right hand. A box of caramels, from which she was eating, rested in
+her lap, and the girl seemed entirely at ease in her royal surroundings.
+
+The Scarecrow stepped forward and confronted her, while the Tin Woodman
+leaned upon his axe and the others formed a half-circle back of his
+Majesty's person.
+
+"How dare you sit in my throne?" demanded the Scarecrow, sternly eyeing
+the intruder. "Don't you know you are guilty of treason, and that there
+is a law against treason?"
+
+"The throne belongs to whoever is able to take it," answered Jinjur, as
+she slowly ate another caramel. "I have taken it, as you see; so just
+now I am the Queen, and all who oppose me are guilty of treason, and
+must be punished by the law you have just mentioned."
+
+This view of the case puzzled the Scarecrow.
+
+"How is it, friend Nick?" he asked, turning to the Tin Woodman.
+
+"Why, when it comes to Law, I have nothing to say," answered that
+personage; "for laws were never meant to be understood, and it is
+foolish to make the attempt."
+
+"Then what shall we do?" asked the Scarecrow, in dismay.
+
+"Why don't you marry the Queen? And then you can both rule," suggested
+the Woggle-Bug.
+
+Jinjur glared at the insect fiercely.
+
+"Why don't you send her back to her mother, where she belongs?" asked
+Jack Pumpkinhead.
+
+Jinjur frowned.
+
+"Why don't you shut her up in a closet until she behaves herself, and
+promises to be good?" enquired Tip. Jinjur's lip curled scornfully.
+
+"Or give her a good shaking!" added the Saw-Horse.
+
+"No," said the Tin Woodman, "we must treat the poor girl with
+gentleness. Let us give her all the jewels she can carry, and send her
+away happy and contented."
+
+At this Queen Jinjur laughed aloud, and the next minute clapped her
+pretty hands together thrice, as if for a signal.
+
+"You are very absurd creatures," said she; "but I am tired of your
+nonsense and have no time to bother with you longer."
+
+While the monarch and his friends listened in amazement to this
+impudent speech, a startling thing happened. The Tin Woodman's axe was
+snatched from his grasp by some person behind him, and he found himself
+disarmed and helpless. At the same instant a shout of laughter rang in
+the ears of the devoted band, and turning to see whence this came they
+found themselves surrounded by the Army of Revolt, the girls bearing in
+either hand their glistening knitting-needles. The entire throne room
+seemed to be filled with the rebels, and the Scarecrow and his comrades
+realized that they were prisoners.
+
+"You see how foolish it is to oppose a woman's wit," said Jinjur,
+gaily; "and this event only proves that I am more fit to rule the
+Emerald City than a Scarecrow. I bear you no ill will, I assure you;
+but lest you should prove troublesome to me in the future I shall order
+you all to be destroyed. That is, all except the boy, who belongs
+to old Mombi and must be restored to her keeping. The rest of you
+are not human, and therefore it will not be wicked to demolish you.
+The Saw-Horse and the Pumpkinhead's body I will have chopped up for
+kindling-wood; and the pumpkin shall be made into tarts. The Scarecrow
+will do nicely to start a bonfire, and the tin man can be cut into
+small pieces and fed to the goats. As for this immense Woggle-Bug--"
+
+"Highly Magnified, if you please!" interrupted the insect.
+
+"I think I will ask the cook to make green-turtle soup of you,"
+continued the Queen, reflectively.
+
+The Woggle-Bug shuddered.
+
+"Or, if that won't do, we might use you for a Hungarian goulash, stewed
+and highly spiced," she added, cruelly.
+
+This programme of extermination was so terrible that the prisoners
+looked upon one another in a panic of fear. The Scarecrow alone did not
+give way to despair. He stood quietly before the Queen and his brow was
+wrinkled in deep thought as he strove to find some means to escape.
+
+While thus engaged he felt the straw within his breast move gently. At
+once his expression changed from sadness to joy, and raising his hand
+he quickly unbuttoned the front of his jacket.
+
+[Illustration]
+
+This action did not pass unnoticed by the crowd of girls clustering
+about him, but none of them suspected what he was doing until a tiny
+grey mouse leaped from his bosom to the floor and scampered away
+between the feet of the Army of Revolt. Another mouse quickly followed;
+then another and another, in rapid succession. And suddenly such a
+scream of terror went up from the Army that it might easily have filled
+the stoutest heart with consternation. The flight that ensued turned to
+a stampede, and the stampede to a panic.
+
+For while the startled mice rushed wildly about the room the Scarecrow
+had only time to note a whirl of skirts and a twinkling of feet as the
+girls disappeared from the palace--pushing and crowding one another in
+their mad efforts to escape.
+
+The Queen, at the first alarm, stood up on the cushions of the throne
+and began to dance frantically upon her tiptoes. Then a mouse ran up
+the cushions, and with a terrified leap poor Jinjur shot clear over the
+head of the Scarecrow and escaped through an archway--never pausing in
+her wild career until she had reached the city gates.
+
+So, in less time than I can explain, the throne room was deserted by
+all save the Scarecrow and his friends, and the Woggle-Bug heaved a
+deep sigh of relief as he exclaimed:
+
+"Thank goodness, we are saved!"
+
+"For a time, yes;" answered the Tin Woodman. "But the enemy will soon
+return, I fear."
+
+"Let us bar all the entrances to the palace!" said the Scarecrow. "Then
+we shall have time to think what is best to be done."
+
+So all except Jack Pumpkinhead, who was still tied fast to the
+Saw-Horse, ran to the various entrances of the royal palace and closed
+the heavy doors, bolting and locking them securely. Then, knowing that
+the Army of Revolt could not batter down the barriers in several days,
+the adventurers gathered once more in the throne room for a council of
+war.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow
+    Takes Time to Think
+]
+
+
+"It seems to me," began the Scarecrow, when all were again assembled in
+the throne room, "that the girl Jinjur is quite right in claiming to be
+Queen. And if she is right, then I am wrong, and we have no business to
+be occupying her palace."
+
+"But you were the King until she came," said the Woggle-Bug, strutting
+up and down with his hands in his pockets; "so it appears to me that
+she is the interloper instead of you."
+
+"Especially as we have just conquered her and put her to flight," added
+the Pumpkinhead, as he raised his hands to turn his face toward the
+Scarecrow.
+
+"Have we really conquered her?" asked the Scarecrow, quietly. "Look out
+of the window, and tell me what you see."
+
+Tip ran to the window and looked out.
+
+"The palace is surrounded by a double row of girl soldiers," he
+announced.
+
+"I thought so," returned the Scarecrow. "We are as truly their
+prisoners as we were before the mice frightened them from the palace."
+
+"My friend is right," said Nick Chopper, who had been polishing his
+breast with a bit of chamois-leather. "Jinjur is still the Queen, and
+we are her prisoners."
+
+"But I hope she cannot get at us," exclaimed the Pumpkinhead, with a
+shiver of fear. "She threatened to make tarts of me, you know."
+
+"Don't worry," said the Tin Woodman. "It cannot matter greatly. If you
+stay shut up here you will spoil in time, anyway. A good tart is far
+more admirable than a decayed intellect."
+
+"Very true," agreed the Scarecrow.
+
+"Oh, dear!" moaned Jack; "what an unhappy lot is mine! Why, dear
+father, did you not make me out of tin--or even out of straw--so that
+I would keep indefinitely."
+
+"Shucks!" returned Tip, indignantly. "You ought to be glad that I made
+you at all." Then he added, reflectively, "everything has to come to an
+end, some time."
+
+"But I beg to remind you," broke in the Woggle-Bug, who had a
+distressed look in his bulging, round eyes, "that this terrible Queen
+Jinjur suggested making a goulash of me--Me! the only Highly Magnified
+and Thoroughly Educated Woggle-Bug in the wide, wide world!"
+
+"I think it was a brilliant idea," remarked the Scarecrow, approvingly.
+
+"Don't you imagine he would make a better soup?" asked the Tin Woodman,
+turning toward his friend.
+
+"Well, perhaps," acknowledged the Scarecrow.
+
+The Woggle-Bug groaned.
+
+"I can see, in my mind's eye," said he, mournfully, "the goats eating
+small pieces of my dear comrade, the Tin Woodman, while my soup is
+being cooked on a bonfire built of the Saw-Horse and Jack Pumpkinhead's
+body, and Queen Jinjur watches me boil while she feeds the flames with
+my friend the Scarecrow!"
+
+This morbid picture cast a gloom over the entire party, making them
+restless and anxious.
+
+"It can't happen for some time," said the Tin Woodman, trying to speak
+cheerfully; "for we shall be able to keep Jinjur out of the palace
+until she manages to break down the doors."
+
+"And in the meantime I am liable to starve to death, and so is the
+Woggle-Bug," announced Tip.
+
+"As for me," said the Woggle-Bug, "I think that I could live for some
+time on Jack Pumpkinhead. Not that I prefer pumpkins for food; but I
+believe they are somewhat nutritious, and Jack's head is large and
+plump."
+
+"How heartless!" exclaimed the Tin Woodman, greatly shocked. "Are we
+cannibals, let me ask? Or are we faithful friends?"
+
+"I see very clearly that we cannot stay shut up in this palace," said
+the Scarecrow, with decision. "So let us end this mournful talk and try
+to discover a means to escape."
+
+At this suggestion they all gathered eagerly around the throne, wherein
+was seated the Scarecrow, and as Tip sat down upon a stool there fell
+from his pocket a pepper-box, which rolled upon the floor.
+
+"What is this?" asked Nick Chopper, picking up the box.
+
+"Be careful!" cried the boy. "That's my Powder of Life. Don't spill it,
+for it is nearly gone."
+
+"And what is the Powder of Life?" enquired the Scarecrow, as Tip
+replaced the box carefully in his pocket.
+
+"It's some magical stuff old Mombi got from a crooked sorcerer,"
+explained the boy. "She brought Jack to life with it, and afterward I
+used it to bring the Saw-Horse to life. I guess it will make anything
+live that is sprinkled with it; but there's only about one dose left."
+
+"Then it is very precious," said the Tin Woodman.
+
+"Indeed it is," agreed the Scarecrow. "It may prove our best means of
+escape from our difficulties. I believe I will think for a few minutes;
+so I will thank you, friend Tip, to get out your knife and rip this
+heavy crown from my forehead."
+
+Tip soon cut the stitches that had fastened the crown to the
+Scarecrow's head, and the former monarch of the Emerald City removed it
+with a sigh of relief and hung it on a peg beside the throne.
+
+[Illustration]
+
+"That is my last memento of royalty," said he; "and I'm glad to get rid
+of it. The former King of this City, who was named Pastoria, lost the
+crown to the Wonderful Wizard, who passed it on to me. Now the girl
+Jinjur claims it, and I sincerely hope it will not give her a headache."
+
+"A kindly thought, which I greatly admire," said the Tin Woodman,
+nodding approvingly.
+
+"And now I will indulge in a quiet think," continued the Scarecrow,
+lying back in the throne.
+
+The others remained as silent and still as possible, so as not to
+disturb him; for all had great confidence in the extraordinary brains
+of the Scarecrow.
+
+And, after what seemed a very long time indeed to the anxious watchers,
+the thinker sat up, looked upon his friends with his most whimsical
+expression, and said:
+
+"My brains work beautifully today. I'm quite proud of them. Now,
+listen! If we attempt to escape through the doors of the palace we
+shall surely be captured. And, as we can't escape through the ground,
+there is only one other thing to be done. We must escape through the
+air!"
+
+He paused to note the effect of these words; but all his hearers seemed
+puzzled and unconvinced.
+
+"The Wonderful Wizard escaped in a balloon," he continued. "We don't
+know how to make a balloon, of course; but any sort of thing that can
+fly through the air can carry us easily. So I suggest that my friend
+the Tin Woodman, who is a skillful mechanic, shall build some sort of
+a machine, with good strong wings, to carry us; and our friend Tip can
+then bring the Thing to life with his magical powder."
+
+"Bravo!" cried Nick Chopper.
+
+"What splendid brains!" murmured Jack.
+
+"Really quite clever!" said the Educated Woggle-Bug.
+
+[Illustration]
+
+"I believe it can be done," declared Tip; "that is, if the Tin Woodman
+is equal to making the Thing."
+
+"I'll do my best," said Nick, cheerily; "and, as a matter of fact, I do
+not often fail in what I attempt. But the Thing will have to be built
+on the roof of the palace, so it can rise comfortably into the air."
+
+"To be sure," said the Scarecrow.
+
+"Then let us search through the palace," continued the Tin Woodman,
+"and carry all the material we can find to the roof, where I will begin
+my work."
+
+"First, however," said the Pumpkinhead, "I beg you will release me from
+this horse, and make me another leg to walk with. For in my present
+condition I am of no use to myself or to anyone else."
+
+So the Tin Woodman knocked a mahogany center-table to pieces with his
+axe and fitted one of the legs, which was beautifully carved, on to the
+body of Jack Pumpkinhead, who was very proud of the acquisition.
+
+"It seems strange," said he, as he watched the Tin Woodman work, "that
+my left leg should be the most elegant and substantial part of me."
+
+"That proves you are unusual," returned the Scarecrow; "and I am
+convinced that the only people worthy of consideration in this world
+are the unusual ones. For the common folks are like the leaves of a
+tree, and live and die unnoticed."
+
+"Spoken like a philosopher!" cried the Woggle-Bug, as he assisted the
+Tin Woodman to set Jack upon his feet.
+
+"How do you feel now?" asked Tip, watching the Pumpkinhead stump
+around to try his new leg.
+
+"As good as new," answered Jack, joyfully, "and quite ready to assist
+you all to escape."
+
+"Then let us get to work," said the Scarecrow, in a business-like tone.
+
+So, glad to be doing anything that might lead to the end of their
+captivity, the friends separated to wander over the palace in search of
+fitting material to use in the construction of their aerial machine.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Astonishing Flight
+    of the Gump
+]
+
+
+When the adventurers reassembled upon the roof it was found that a
+remarkably queer assortment of articles had been selected by the
+various members of the party. No one seemed to have a very clear idea
+of what was required, but all had brought something.
+
+The Woggle-Bug had taken from its position over the mantle-piece in the
+great hallway the head of a Gump, which was adorned with wide-spreading
+antlers; and this, with great care and greater difficulty, the insect
+had carried up the stairs to the roof. This Gump resembled an Elk's
+head, only the nose turned upward in a saucy manner and there were
+whiskers upon its chin, like those of a billy-goat. Why the Woggle-Bug
+selected this article he could not have explained, except that it had
+aroused his curiosity.
+
+Tip, with the aid of the Saw-Horse, had brought a large, upholstered
+sofa to the roof. It was an old-fashioned piece of furniture, with high
+back and ends, and it was so heavy that even by resting the greatest
+weight upon the back of the Saw-Horse, the boy found himself out of
+breath when at last the clumsy sofa was dumped upon the roof.
+
+The Pumpkinhead had brought a broom, which was the first thing he saw.
+The Scarecrow arrived with a coil of clotheslines and ropes which he
+had taken from the courtyard, and in his trip up the stairs he had
+become so entangled in the loose ends of the ropes that both he and his
+burden tumbled in a heap upon the roof and might have rolled off if Tip
+had not rescued him.
+
+The Tin Woodman appeared last. He also had been to the courtyard, where
+he had cut four great, spreading leaves from a huge palm-tree that was
+the pride of all the inhabitants of the Emerald City.
+
+"My dear Nick!" exclaimed the Scarecrow, seeing what his friend had
+done; "you have been guilty of the greatest crime any person can
+commit in the Emerald City. If I remember rightly, the penalty for
+chopping leaves from the royal palm-tree is to be killed seven times
+and afterward imprisoned for life."
+
+[Illustration: ALL BROUGHT SOMETHING TO THE ROOF.]
+
+"It cannot be helped now," answered the Tin Woodman, throwing down the
+big leaves upon the roof. "But it may be one more reason why it is
+necessary for us to escape. And now let us see what you have found for
+me to work with."
+
+Many were the doubtful looks cast upon the heap of miscellaneous
+material that now cluttered the roof, and finally the Scarecrow shook
+his head and remarked:
+
+"Well, if friend Nick can manufacture, from this mess of rubbish, a
+Thing that will fly through the air and carry us to safety, then I will
+acknowledge him to be a better mechanic than I suspected."
+
+But the Tin Woodman seemed at first by no means sure of his powers, and
+only after polishing his forehead vigorously with the chamois-leather
+did he resolve to undertake the task.
+
+"The first thing required for the machine," said he, "is a body big
+enough to carry the entire party. This sofa is the biggest thing we
+have, and might be used for a body. But, should the machine ever tip
+sideways, we would all slide off and fall to the ground."
+
+"Why not use two sofas?" asked Tip. "There's another one just like this
+down stairs."
+
+"That is a very sensible suggestion," exclaimed the Tin Woodman. "You
+must fetch the other sofa at once."
+
+So Tip and the Saw-Horse managed, with much labor, to get the second
+sofa to the roof; and when the two were placed together, edge to edge,
+the backs and ends formed a protecting rampart all around the seats.
+
+"Excellent!" cried the Scarecrow. "We can ride within this snug nest
+quite at our ease."
+
+The two sofas were now bound firmly together with ropes and
+clotheslines, and then Nick Chopper fastened the Gump's head to one end.
+
+"That will show which is the front end of the Thing," said he, greatly
+pleased with the idea. "And, really, if you examine it critically, the
+Gump looks very well as a figure-head. These great palm-leaves, for
+which I have endangered my life seven times, must serve us as wings."
+
+"Are they strong enough?" asked the boy.
+
+"They are as strong as anything we can get," answered the Woodman; "and
+although they are not in proportion to the Thing's body, we are not in
+a position to be very particular."
+
+So he fastened the palm-leaves to the sofas, two on each side.
+
+Said the Woggle-Bug, with considerable admiration:
+
+"The Thing is now complete, and only needs to be brought to life."
+
+"Stop a moment!" exclaimed Jack. "Are you not going to use my broom?"
+
+"What for?" asked the Scarecrow.
+
+"Why, it can be fastened to the back end for a tail," answered the
+Pumpkinhead. "Surely you would not call the Thing complete without a
+tail."
+
+"Hm!" said the Tin Woodman; "I do not see the use of a tail. We are not
+trying to copy a beast, or a fish, or a bird. All we ask of the Thing
+is to carry us through the air."
+
+"Perhaps, after the Thing is brought to life, it can use a tail to
+steer with," suggested the Scarecrow. "For if it flies through the air
+it will not be unlike a bird, and I've noticed that all birds have
+tails, which they use for a rudder while flying."
+
+"Very well," answered Nick, "the broom shall be used for a tail," and
+he fastened it firmly to the back end of the sofa body.
+
+Tip took the pepper-box from his pocket.
+
+"The Thing looks very big," said he, anxiously; "and I am not sure
+there is enough powder left to bring all of it to life. But I'll make
+it go as far as possible."
+
+"Put most on the wings," said Nick Chopper; "for they must be made as
+strong as possible."
+
+"And don't forget the head!" exclaimed the Woggle-Bug.
+
+"Or the tail!" added Jack Pumpkinhead.
+
+"Do be quiet," said Tip, nervously; "you must give me a chance to work
+the magic charm in the proper manner."
+
+Very carefully he began sprinkling the Thing with the precious powder.
+Each of the four wings was first lightly covered with a layer; then the
+sofas were sprinkled, and the broom given a slight coating.
+
+"The head! The head! Don't, I beg of you, forget the head!" cried the
+Woggle-Bug, excitedly.
+
+"There's only a little of the powder left," announced Tip, looking
+within the box. "And it seems to me it is more important to bring the
+legs of the sofas to life than the head."
+
+"Not so," decided the Scarecrow. "Every thing must have a head to
+direct it; and since this creature is to fly, and not walk, it is
+really unimportant whether its legs are alive or not."
+
+So Tip abided by this decision and sprinkled the Gump's head with the
+remainder of the powder.
+
+"Now," said he, "keep silence while I work the charm!"
+
+Having heard old Mombi pronounce the magic words, and having also
+succeeded in bringing the Saw-Horse to life, Tip did not hesitate an
+instant in speaking the three cabalistic words, each accompanied by the
+peculiar gesture of the hands.
+
+It was a grave and impressive ceremony.
+
+As he finished the incantation the Thing shuddered throughout its
+huge bulk, the Gump gave the screeching cry that is familiar to those
+animals, and then the four wings began flopping furiously.
+
+[Illustration]
+
+Tip managed to grasp a chimney, else he would have been blown off the
+roof by the terrible breeze raised by the wings. The Scarecrow, being
+light in weight, was caught up bodily and borne through the air until
+Tip luckily seized him by one leg and held him fast. The Woggle-Bug
+lay flat upon the roof and so escaped harm, and the Tin Woodman,
+whose weight of tin anchored him firmly, threw both arms around Jack
+Pumpkinhead and managed to save him. The Saw-Horse toppled over upon
+his back and lay with his legs waving helplessly above him.
+
+And now, while all were struggling to recover themselves, the Thing
+rose slowly from the roof and mounted into the air.
+
+"Here! Come back!" cried Tip, in a frightened voice, as he clung to the
+chimney with one hand and the Scarecrow with the other. "Come back at
+once, I command you!"
+
+It was now that the wisdom of the Scarecrow, in bringing the head of
+the Thing to life instead of the legs, was proved beyond a doubt. For
+the Gump, already high in the air, turned its head at Tip's command and
+gradually circled around until it could view the roof of the palace.
+
+"Come back!" shouted the boy, again.
+
+And the Gump obeyed, slowly and gracefully waving its four wings in
+the air until the Thing had settled once more upon the roof and become
+still.
+
+[Illustration: "COME BACK!"]
+
+
+
+
+[Illustration:
+
+    In the Jackdaws' Nest
+]
+
+
+"This," said the Gump, in a squeaky voice not at all proportioned to
+the size of its great body, "is the most novel experience I ever heard
+of. The last thing I remember distinctly is walking through the forest
+and hearing a loud noise. Something probably killed me then, and it
+certainly ought to have been the end of me. Yet here I am, alive again,
+with four monstrous wings and a body which I venture to say would make
+any respectable animal or fowl weep with shame to own. What does it all
+mean? Am I a Gump, or am I a juggernaut?" The creature, as it spoke,
+wiggled its chin whiskers in a very comical manner.
+
+"You're just a Thing," answered Tip, "with a Gump's head on it. And we
+have made you and brought you to life so that you may carry us through
+the air wherever we wish to go."
+
+"Very good!" said the Thing. "As I am not a Gump, I cannot have a
+Gump's pride or independent spirit. So I may as well become your
+servant as anything else. My only satisfaction is that I do not seem
+to have a very strong constitution, and am not likely to live long in
+a state of slavery."
+
+"Don't say that, I beg of you!" cried the Tin Woodman, whose excellent
+heart was strongly affected by this sad speech. "Are you not feeling
+well today?"
+
+"Oh, as for that," returned the Gump, "it is my first day of existence;
+so I cannot judge whether I am feeling well or ill." And it waved its
+broom tail to and fro in a pensive manner.
+
+"Come, come!" said the Scarecrow, kindly; "do try to be more cheerful
+and take life as you find it. We shall be kind masters, and will strive
+to render your existence as pleasant as possible. Are you willing to
+carry us through the air wherever we wish to go?"
+
+"Certainly," answered the Gump. "I greatly prefer to navigate the air.
+For should I travel on the earth and meet with one of my own species,
+my embarrassment would be something awful!"
+
+"I can appreciate that," said the Tin Woodman, sympathetically.
+
+"And yet," continued the Thing, "when I carefully look you over, my
+masters, none of you seems to be constructed much more artistically
+than I am."
+
+"Appearances are deceitful," said the Woggle-Bug, earnestly. "I am both
+Highly Magnified and Thoroughly Educated."
+
+"Indeed!" murmured the Gump, indifferently.
+
+"And my brains are considered remarkably rare specimens," added the
+Scarecrow, proudly.
+
+"How strange!" remarked the Gump.
+
+"Although I am of tin," said the Woodman, "I own a heart altogether the
+warmest and most admirable in the whole world."
+
+"I'm delighted to hear it," replied the Gump, with a slight cough.
+
+"My smile," said Jack Pumpkinhead, "is worthy your best attention. It
+is always the same."
+
+"_Semper idem_," explained the Woggle-Bug, pompously; and the Gump
+turned to stare at him.
+
+"And I," declared the Saw-Horse, filling in an awkward pause, "am only
+remarkable because I can't help it."
+
+"I am proud, indeed, to meet with such exceptional masters," said
+the Gump, in a careless tone. "If I could but secure so complete an
+introduction to myself, I would be more than satisfied."
+
+"That will come in time," remarked the Scarecrow. "To 'Know Thyself'
+is considered quite an accomplishment, which it has taken us, who are
+your elders, months to perfect. But now," he added, turning to the
+others, "let us get aboard and start upon our journey."
+
+"Where shall we go?" asked Tip, as he clambered to a seat on the sofas
+and assisted the Pumpkinhead to follow him.
+
+"In the South Country rules a very delightful Queen called Glinda
+the Good, who I am sure will gladly receive us," said the Scarecrow,
+getting into the Thing clumsily. "Let us go to her and ask her advice."
+
+"That is cleverly thought of," declared Nick Chopper, giving the
+Woggle-Bug a boost and then toppling the Saw-Horse into the rear end
+of the cushioned seats. "I know Glinda the Good, and believe she will
+prove a friend indeed."
+
+"Are we all ready?" asked the boy.
+
+"Yes," announced the Tin Woodman, seating himself beside the Scarecrow.
+
+"Then," said Tip, addressing the Gump, "be kind enough to fly with us
+to the Southward; and do not go higher than to escape the houses and
+trees, for it makes me dizzy to be up so far."
+
+"All right," answered the Gump, briefly.
+
+It flopped its four huge wings and rose slowly into the air; and then,
+while our little band of adventurers clung to the backs and sides of
+the sofas for support, the Gump turned toward the South and soared
+swiftly and majestically away.
+
+"The scenic effect, from this altitude, is marvelous," commented the
+educated Woggle-Bug, as they rode along.
+
+"Never mind the scenery," said the Scarecrow. "Hold on tight, or you
+may get a tumble. The Thing seems to rock badly."
+
+"It will be dark soon," said Tip, observing that the sun was low on the
+horizon. "Perhaps we should have waited until morning. I wonder if the
+Gump can fly in the night."
+
+"I've been wondering that myself," returned the Gump, quietly. "You
+see, this is a new experience to me. I used to have legs that carried
+me swiftly over the ground. But now my legs feel as if they were
+asleep."
+
+"They are," said Tip. "We didn't bring 'em to life."
+
+"You're expected to fly," explained the Scarecrow; "not to walk."
+
+"We can walk ourselves," said the Woggle-Bug.
+
+"I begin to understand what is required of me," remarked the Gump; "so
+I will do my best to please you," and he flew on for a time in silence.
+
+Presently Jack Pumpkinhead became uneasy.
+
+"I wonder if riding through the air is liable to spoil pumpkins," he
+said.
+
+"Not unless you carelessly drop your head over the side," answered the
+Woggle-Bug. "In that event your head would no longer be a pumpkin, for
+it would become a squash."
+
+"Have I not asked you to restrain these unfeeling jokes?" demanded Tip,
+looking at the Woggle-Bug with a severe expression.
+
+"You have; and I've restrained a good many of them," replied the
+insect. "But there are opportunities for so many excellent puns in our
+language that, to an educated person like myself, the temptation to
+express them is almost irresistible."
+
+"People with more or less education discovered those puns centuries
+ago," said Tip.
+
+"Are you sure?" asked the Woggle-Bug, with a startled look.
+
+"Of course I am," answered the boy. "An educated Woggle-Bug may be a
+new thing; but a Woggle-Bug education is as old as the hills, judging
+from the display you make of it."
+
+The insect seemed much impressed by this remark, and for a time
+maintained a meek silence.
+
+The Scarecrow, in shifting his seat, saw upon the cushions the
+pepper-box which Tip had cast aside, and began to examine it.
+
+"Throw it overboard," said the boy; "it's quite empty now, and there's
+no use keeping it."
+
+"Is it really empty?" asked the Scarecrow, looking curiously into the
+box.
+
+"Of course it is," answered Tip. "I shook out every grain of the
+powder."
+
+"Then the box has two bottoms," announced the Scarecrow; "for the
+bottom on the inside is fully an inch away from the bottom on the
+outside."
+
+"Let me see," said the Tin Woodman, taking the box from his friend.
+"Yes," he declared, after looking it over, "the thing certainly has a
+false bottom. Now, I wonder what that is for?"
+
+"Can't you get it apart, and find out?" enquired Tip, now quite
+interested in the mystery.
+
+"Why, yes; the lower bottom unscrews," said the Tin Woodman. "My
+fingers are rather stiff; please see if you can open it."
+
+He handed the pepper-box to Tip, who had no difficulty in unscrewing
+the bottom. And in the cavity below were three silver pills, with a
+carefully folded paper lying underneath them.
+
+This paper the boy proceeded to unfold, taking care not to spill the
+pills, and found several lines clearly written in red ink.
+
+"Read it aloud," said the Scarecrow; so Tip read as follows:
+
+    "DR. NIKIDIK'S CELEBRATED WISHING PILLS.
+
+    "_Directions for Use_: Swallow one pill; count seventeen by twos;
+    then make a Wish.--The Wish will immediately be granted.
+
+    "CAUTION: Keep in a Dry and Dark Place."
+
+"Why, this is a very valuable discovery!" cried the Scarecrow.
+
+"It is, indeed," replied Tip, gravely. "These pills may be of great
+use to us. I wonder if old Mombi knew they were in the bottom of the
+pepper-box. I remember hearing her say that she got the Powder of Life
+from this same Nikidik."
+
+"He must be a powerful Sorcerer!" exclaimed the Tin Woodman; "and since
+the powder proved a success we ought to have confidence in the pills."
+
+"But how," asked the Scarecrow, "can anyone count seventeen by twos?
+Seventeen is an odd number.
+
+"That is true," replied Tip, greatly disappointed. "No one can possibly
+count seventeen by twos."
+
+"Then the pills are of no use to us," wailed the Pumpkinhead; "and this
+fact overwhelms me with grief. For I had intended wishing that my head
+would never spoil."
+
+"Nonsense!" said the Scarecrow, sharply. "If we could use the pills at
+all we would make far better wishes than that."
+
+"I do not see how anything could be better," protested poor Jack. "If
+you were liable to spoil at any time you could understand my anxiety."
+
+"For my part," said the Tin Woodman, "I sympathize with you in every
+respect. But since we cannot count seventeen by twos, sympathy is all
+you are liable to get."
+
+By this time it had become quite dark, and the voyagers found above
+them a cloudy sky, through which the rays of the moon could not
+penetrate.
+
+The Gump flew steadily on, and for some reason the huge sofa-body
+rocked more and more dizzily every hour.
+
+The Woggle-Bug declared he was sea-sick; and Tip was also pale and
+somewhat distressed. But the others clung to the backs of the sofas and
+did not seem to mind the motion as long as they were not tipped out.
+
+Darker and darker grew the night, and on and on sped the Gump through
+the black heavens. The travelers could not even see one another, and
+an oppressive silence settled down upon them.
+
+After a long time Tip, who had been thinking deeply, spoke.
+
+"How are we to know when we come to the palace of Glinda the Good?" he
+asked.
+
+"It's a long way to Glinda's palace," answered the Woodman; "I've
+traveled it."
+
+"But how are we to know how fast the Gump is flying?" persisted the
+boy. "We cannot see a single thing down on the earth, and before
+morning we may be far beyond the place we want to reach."
+
+"That is all true enough," the Scarecrow replied, a little uneasily.
+"But I do not see how we can stop just now; for we might alight in a
+river, or on the top of a steeple; and that would be a great disaster."
+
+So they permitted the Gump to fly on, with regular flops of its great
+wings, and waited patiently for morning.
+
+Then Tip's fears were proven to be well founded; for with the first
+streaks of gray dawn they looked over the sides of the sofas and
+discovered rolling plains dotted with queer villages, where the houses,
+instead of being dome-shaped--as they all are in the Land of Oz--had
+slanting roofs that rose to a peak in the center. Odd looking animals
+were also moving about upon the open plains, and the country was
+unfamiliar to both the Tin Woodman and the Scarecrow, who had formerly
+visited Glinda the Good's domain and knew it well.
+
+"We are lost!" said the Scarecrow, dolefully. "The Gump must have
+carried us entirely out of the Land of Oz and over the sandy deserts
+and into the terrible outside world that Dorothy told us about."
+
+"We must get back," exclaimed the Tin Woodman, earnestly; "we must get
+back as soon as possible!"
+
+"Turn around!" cried Tip to the Gump; "turn as quickly as you can!"
+
+"If I do I shall upset," answered the Gump. "I'm not at all used to
+flying, and the best plan would be for me to alight in some place, and
+then I can turn around and take a fresh start."
+
+Just then, however, there seemed to be no stopping-place that would
+answer their purpose. They flew over a village so big that the
+Woggle-Bug declared it was a city; and then they came to a range of
+high mountains with many deep gorges and steep cliffs showing plainly.
+
+"Now is our chance to stop," said the boy, finding they were very
+close to the mountain tops. Then he turned to the Gump and commanded:
+"Stop at the first level place you see!"
+
+"Very well," answered the Gump, and settled down upon a table of rock
+that stood between two cliffs.
+
+But not being experienced in such matters, the Gump did not judge his
+speed correctly; and instead of coming to a stop upon the flat rock he
+missed it by half the width of his body, breaking off both his right
+wings against the sharp edge of the rock and then tumbling over and
+over down the cliff.
+
+Our friends held on to the sofas as long as they could, but when the
+Gump caught on a projecting rock the Thing stopped suddenly--bottom
+side up--and all were immediately dumped out.
+
+By good fortune they fell only a few feet; for underneath them was a
+monster nest, built by a colony of Jackdaws in a hollow ledge of rock;
+so none of them--not even the Pumpkinhead--was injured by the fall.
+For Jack found his precious head resting on the soft breast of the
+Scarecrow, which made an excellent cushion; and Tip fell on a mass of
+leaves and papers, which saved him from injury. The Woggle-Bug had
+bumped his round head against the Saw-Horse, but without causing him
+more than a moment's inconvenience.
+
+[Illustration: ALL WERE IMMEDIATELY DUMPED OUT.]
+
+The Tin Woodman was at first much alarmed; but finding he had escaped
+without even a scratch upon his beautiful nickel-plate he at once
+regained his accustomed cheerfulness and turned to address his comrades.
+
+"Our journey has ended rather suddenly," said he, "and we cannot justly
+blame our friend the Gump for our accident, because he did the best he
+could under the circumstances. But how we are ever to escape from this
+nest I must leave to someone with better brains than I possess."
+
+Here he gazed at the Scarecrow; who crawled to the edge of the nest and
+looked over. Below them was a sheer precipice several hundred feet in
+depth. Above them was a smooth cliff unbroken save by the point of rock
+where the wrecked body of the Gump still hung suspended from the end of
+one of the sofas. There really seemed to be no means of escape, and as
+they realized their helpless plight the little band of adventurers gave
+way to their bewilderment.
+
+"This is a worse prison than the palace," sadly remarked the Woggle-Bug.
+
+"I wish we had stayed there," moaned Jack. "I'm afraid the mountain
+air isn't good for pumpkins."
+
+"It won't be when the Jackdaws come back," growled the Saw-Horse, which
+lay waving its legs in a vain endeavor to get upon its feet again.
+"Jackdaws are especially fond of pumpkins."
+
+"Do you think the birds will come here?" asked Jack, much distressed.
+
+"Of course they will," said Tip; "for this is their nest. And there
+must be hundreds of them," he continued, "for see what a lot of things
+they have brought here!"
+
+Indeed, the nest was half filled with a most curious collection of
+small articles for which the birds could have no use, but which the
+thieving Jackdaws had stolen during many years from the homes of men.
+And as the nest was safely hidden where no human being could reach it,
+this lost property would never be recovered.
+
+The Woggle-Bug, searching among the rubbish--for the Jackdaws stole
+useless things as well as valuable ones--turned up with his foot a
+beautiful diamond necklace. This was so greatly admired by the Tin
+Woodman that the Woggle-Bug presented it to him with a graceful speech,
+after which the Woodman hung it around his neck with much pride,
+rejoicing exceedingly when the big diamonds glittered in the sun's
+rays.
+
+[Illustration: TURNED UP A BEAUTIFUL DIAMOND NECKLACE.]
+
+But now they heard a great jabbering and flopping of wings, and as the
+sound grew nearer to them Tip exclaimed:
+
+"The Jackdaws are coming! And if they find us here they will surely
+kill us in their anger."
+
+"I was afraid of this!" moaned the Pumpkinhead. "My time has come!"
+
+"And mine, also!" said the Woggle-Bug; "for Jackdaws are the greatest
+enemies of my race."
+
+The others were not at all afraid; but the Scarecrow at once decided
+to save those of the party who were liable to be injured by the angry
+birds. So he commanded Tip to take off Jack's head and lie down with
+it in the bottom of the nest, and when this was done he ordered
+the Woggle-Bug to lie beside Tip. Nick Chopper, who knew from past
+experience just what to do, then took the Scarecrow to pieces--(all
+except his head)--and scattered the straw over Tip and the Woggle-Bug,
+completely covering their bodies.
+
+Hardly had this been accomplished when the flock of Jackdaws reached
+them. Perceiving the intruders in their nest the birds flew down upon
+them with screams of rage.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Dr. Nikidik's
+    Famous Wishing Pills
+]
+
+
+The Tin Woodman was usually a peaceful man, but when occasion required
+he could fight as fiercely as a Roman gladiator. So, when the Jackdaws
+nearly knocked him down in their rush of wings, and their sharp beaks
+and claws threatened to damage his brilliant plating, the Woodman
+picked up his axe and made it whirl swiftly around his head.
+
+But although many were beaten off in this way, the birds were so
+numerous and so brave that they continued the attack as furiously as
+before. Some of them pecked at the eyes of the Gump, which hung over
+the nest in a helpless condition; but the Gump's eyes were of glass and
+could not be injured. Others of the Jackdaws rushed at the Saw-Horse;
+but that animal, being still upon his back, kicked out so viciously
+with his wooden legs that he beat off as many assailants as did the
+Woodman's axe.
+
+Finding themselves thus opposed, the birds fell upon the Scarecrow's
+straw, which lay at the center of the nest, covering Tip and the
+Woggle-Bug and Jack's pumpkin head, and began tearing it away and
+flying off with it, only to let it drop, straw by straw into the great
+gulf beneath.
+
+The Scarecrow's head, noting with dismay this wanton destruction of
+his interior, cried to the Tin Woodman to save him; and that good
+friend responded with renewed energy. His axe fairly flashed among
+the Jackdaws, and fortunately the Gump began wildly waving the two
+wings remaining on the left side of its body. The flutter of these
+great wings filled the Jackdaws with terror, and when the Gump by its
+exertions freed itself from the peg of rock on which it hung, and sank
+flopping into the nest, the alarm of the birds knew no bounds and they
+fled screaming over the mountains.
+
+When the last foe had disappeared, Tip crawled from under the sofas and
+assisted the Woggle-Bug to follow him.
+
+"We are saved!" shouted the boy, delightedly.
+
+"We are, indeed!" responded the Educated Insect, fairly hugging the
+stiff head of the Gump in his joy; "and we owe it all to the flopping
+of the Thing and the good axe of the Woodman!"
+
+"If I am saved, get me out of here!" called Jack, whose head was still
+beneath the sofas; and Tip managed to roll the pumpkin out and place it
+upon its neck again. He also set the Saw-Horse upright, and said to it:
+
+"We owe you many thanks for the gallant fight you made."
+
+"I really think we have escaped very nicely," remarked the Tin Woodman,
+in a tone of pride.
+
+"Not so!" exclaimed a hollow voice.
+
+At this they all turned in surprise to look at the Scarecrow's head,
+which lay at the back of the nest.
+
+[Illustration]
+
+"I am completely ruined!" declared the Scarecrow, as he noted their
+astonishment. "For where is the straw that stuffs my body?"
+
+The awful question startled them all. They gazed around the nest with
+horror, for not a vestige of straw remained. The Jackdaws had stolen
+it to the last wisp and flung it all into the chasm that yawned for
+hundreds of feet beneath the nest.
+
+"My poor, poor friend!" said the Tin Woodman, taking up the Scarecrow's
+head and caressing it tenderly; "whoever could imagine you would come
+to this untimely end?"
+
+"I did it to save my friends," returned the head; "and I am glad that
+I perished in so noble and unselfish a manner."
+
+"But why are you all so despondent?" inquired the Woggle-Bug. "The
+Scarecrow's clothing is still safe."
+
+"Yes," answered the Tin Woodman; "but our friend's clothes are useless
+without stuffing."
+
+"Why not stuff him with money?" asked Tip.
+
+"Money!" they all cried, in an amazed chorus.
+
+"To be sure," said the boy. "In the bottom of the nest are thousands of
+dollar bills--and two-dollar bills--and five-dollar bills--and tens,
+and twenties, and fifties. There are enough of them to stuff a dozen
+Scarecrows. Why not use the money?"
+
+The Tin Woodman began to turn over the rubbish with the handle of his
+axe; and, sure enough, what they had first thought only worthless
+papers were found to be all bills of various denominations, which the
+mischievous Jackdaws had for years been engaged in stealing from the
+villages and cities they visited.
+
+[Illustration]
+
+There was an immense fortune lying in that inaccessible nest; and Tip's
+suggestion was, with the Scarecrow's consent, quickly acted upon.
+
+They selected all the newest and cleanest bills and assorted them
+into various piles. The Scarecrow's left leg boot were stuffed with
+five-dollar bills; his right leg was stuffed with ten-dollar bills, and
+his body so closely filled with fifties, one-hundreds and one-thousands
+that he could scarcely button his jacket with comfort.
+
+"You are now," said the Woggle-Bug, impressively, when the task had
+been completed, "the most valuable member of our party; and as you are
+among faithful friends there is little danger of your being spent."
+
+"Thank you," returned the Scarecrow, gratefully. "I feel like a new
+man; and although at first glance I might be mistaken for a Safety
+Deposit Vault, I beg you to remember that my Brains are still composed
+of the same old material. And these are the possessions that have
+always made me a person to be depended upon in an emergency."
+
+"Well, the emergency is here," observed Tip; "and unless your brains
+help us out of it we shall be compelled to pass the remainder of our
+lives in this nest."
+
+"How about these wishing pills?" enquired the Scarecrow, taking the box
+from his jacket pocket. "Can't we use them to escape?"
+
+"Not unless we can count seventeen by twos," answered the Tin Woodman.
+"But our friend the Woggle-Bug claims to be highly educated, so he
+ought easily to figure out how that can be done."
+
+"It isn't a question of education," returned the Insect; "it's merely a
+question of mathematics. I've seen the Professor work lots of sums on
+the black-board, and he claimed anything could be done with x's and y's
+and a's, and such things, by mixing them up with plenty of plusses and
+minuses and equals, and so forth. But he never said anything, so far
+as I can remember, about counting up to the odd number of seventeen by
+the even numbers of twos."
+
+"Stop! stop!" cried the Pumpkinhead. "You're making my head ache."
+
+"And mine," added the Scarecrow. "Your mathematics seem to me very like
+a bottle of mixed pickles--the more you fish for what you want the less
+chance you have of getting it. I am certain that if the thing can be
+accomplished at all, it is in a very simple manner."
+
+"Yes," said Tip; "old Mombi couldn't use x's and minuses, for she never
+went to school."
+
+"Why not start counting at a half of one?" asked the Saw-Horse,
+abruptly. "Then anyone can count up to seventeen by twos very easily."
+
+They looked at each other in surprise, for the Saw-Horse was considered
+the most stupid of the entire party.
+
+"You make me quite ashamed of myself," said the Scarecrow, bowing low
+to the Saw-Horse.
+
+"Nevertheless, the creature is right," declared the Woggle-Bug; "for
+twice one-half is one, and if you get to one it is easy to count from
+one up to seventeen by twos."
+
+"I wonder I didn't think of that myself," said the Pumpkinhead.
+
+"I don't," returned the Scarecrow. "You're no wiser than the rest of
+us, are you? But let us make a wish at once. Who will swallow the first
+pill?"
+
+"Suppose you do it," suggested Tip.
+
+"I can't," said the Scarecrow.
+
+"Why not? You've a mouth, haven't you?" asked the boy.
+
+"Yes; but my mouth is painted on, and there's no swallow connected with
+it," answered the Scarecrow. "In fact," he continued, looking from one
+to another critically, "I believe the boy and the Woggle-Bug are the
+only ones in our party that are able to swallow."
+
+Observing the truth of this remark, Tip said:
+
+"Then I will undertake to make the first wish. Give me one of the
+Silver Pills."
+
+This the Scarecrow tried to do; but his padded gloves were too clumsy
+to clutch so small an object, and he held the box toward the boy while
+Tip selected one of the pills and swallowed it.
+
+"Count!" cried the Scarecrow.
+
+"One-half, one, three, five, seven, nine, eleven, thirteen, fifteen,
+seventeen!" counted Tip.
+
+"Now wish!" said the Tin Woodman anxiously.
+
+But just then the boy began to suffer such fearful pains that he became
+alarmed.
+
+"The pill has poisoned me!" he gasped; "O--h! O-o-o-o-o! Ouch! Murder!
+Fire! O-o-h!" and here he rolled upon the bottom of the nest in such
+contortions that he frightened them all.
+
+"What can we do for you? Speak, I beg!" entreated the Tin Woodman,
+tears of sympathy running down his nickel cheeks.
+
+"I--I don't know!" answered Tip. "O--h! I wish I'd never swallowed that
+pill!"
+
+Then at once the pain stopped, and the boy rose to his feet again and
+found the Scarecrow looking with amazement at the end of the pepper-box.
+
+"What's happened?" asked the boy, a little ashamed of his recent
+exhibition.
+
+"Why, the three pills are in the box again!" said the Scarecrow.
+
+[Illustration]
+
+"Of course they are," the Woggle-Bug declared. "Didn't Tip wish that
+he'd never swallowed one of them? Well, the wish came true, and he
+_didn't_ swallow one of them. So of course they are all three in the
+box."
+
+"That may be; but the pill gave me a dreadful pain, just the same,"
+said the boy.
+
+"Impossible!" declared the Woggle-Bug. "If you have never swallowed
+it, the pill can not have given you a pain. And as your wish, being
+granted, proves you did not swallow the pill, it is also plain that you
+suffered no pain."
+
+"Then it was a splendid imitation of a pain," retorted Tip, angrily.
+"Suppose you try the next pill yourself. We've wasted one wish already."
+
+"Oh, no, we haven't!" protested the Scarecrow. "Here are still three
+pills in the box, and each pill is good for a wish."
+
+"Now you're making _my_ head ache," said Tip. "I can't understand the
+thing at all. But I won't take another pill, I promise you!" and with
+this remark he retired sulkily to the back of the nest.
+
+"Well," said the Woggle-Bug, "it remains for me to save us in my most
+Highly Magnified and Thoroughly Educated manner; for I seem to be the
+only one able and willing to make a wish. Let me have one of the pills."
+
+He swallowed it without hesitation, and they all stood admiring his
+courage while the Insect counted seventeen by twos in the same way
+that Tip had done. And for some reason--perhaps because Woggle-Bugs
+have stronger stomachs than boys--the silver pellet caused it no pain
+whatever.
+
+"I wish the Gump's broken wings mended, and as good as new!" said the
+Woggle-Bug, in a slow, impressive voice.
+
+All turned to look at the Thing, and so quickly had the wish been
+granted that the Gump lay before them in perfect repair, and as well
+able to fly through the air as when it had first been brought to life
+on the roof of the palace.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Scarecrow Appeals
+    to Glinda the Good
+]
+
+
+"Hooray!" shouted the Scarecrow, gaily. "We can now leave this
+miserable Jackdaws' nest whenever we please."
+
+"But it is nearly dark," said the Tin Woodman; "and unless we wait
+until morning to make our flight we may get into more trouble. I don't
+like these night trips, for one never knows what will happen."
+
+So it was decided to wait until daylight, and the adventurers amused
+themselves in the twilight by searching the Jackdaws' nest for
+treasures.
+
+The Woggle-Bug found two handsome bracelets of wrought gold, which
+fitted his slender arms very well. The Scarecrow took a fancy for
+rings, of which there were many in the nest. Before long he had fitted
+a ring to each finger of his padded gloves, and not being content
+with that display he added one more to each thumb. As he carefully
+chose those rings set with sparkling stones, such as rubies, amethysts
+and sapphires, the Scarecrow's hands now presented a most brilliant
+appearance.
+
+"This nest would be a picnic for Queen Jinjur," said he, musingly; "for
+as nearly as I can make out she and her girls conquered me merely to
+rob my city of its emeralds."
+
+The Tin Woodman was content with his diamond necklace and refused
+to accept any additional decorations; but Tip secured a fine gold
+watch, which was attached to a heavy fob, and placed it in his pocket
+with much pride. He also pinned several jeweled brooches to Jack
+Pumpkinhead's red waistcoat, and attached a lorgnette, by means of a
+fine chain, to the neck of the Saw-Horse.
+
+"It's very pretty," said the creature, regarding the lorgnette
+approvingly; "but what is it for?"
+
+None of them could answer that question, however; so the Saw-Horse
+decided it was some rare decoration and became very fond of it.
+
+That none of the party might be slighted, they ended by placing several
+large seal rings upon the points of the Gump's antlers, although that
+odd personage seemed by no means gratified by the attention.
+
+Darkness soon fell upon them, and Tip and the Woggle-Bug went to sleep
+while the others sat down to wait patiently for the day.
+
+Next morning they had cause to congratulate themselves upon the useful
+condition of the Gump; for with daylight a great flock of Jackdaws
+approached to engage in one more battle for the possession of the nest.
+
+But our adventurers did not wait for the assault. They tumbled into the
+cushioned seats of the sofas as quickly as possible, and Tip gave the
+word to the Gump to start.
+
+At once it rose into the air, the great wings flopping strongly and
+with regular motions, and in a few moments they were so far from the
+nest that the chattering Jackdaws took possession without any attempt
+at pursuit.
+
+The Thing flew due North, going in the same direction from whence
+it had come. At least, that was the Scarecrow's opinion, and the
+others agreed that the Scarecrow was the best judge of direction.
+After passing over several cities and villages the Gump carried them
+high above a broad plain where houses became more and more scattered
+until they disappeared altogether. Next came the wide, sandy desert
+separating the rest of the world from the Land of Oz, and before noon
+they saw the dome-shaped houses that proved they were once more within
+the borders of their native land.
+
+"But the houses and fences are blue," said the Tin Woodman, "and that
+indicates we are in the land of the Munchkins, and therefore a long
+distance from Glinda the Good."
+
+"What shall we do?" asked the boy, turning to their guide.
+
+"I don't know," replied the Scarecrow, frankly. "If we were at the
+Emerald City we could then move directly southward, and so reach our
+destination. But we dare not go to the Emerald City, and the Gump is
+probably carrying us further in the wrong direction with every flop of
+its wings."
+
+"Then the Woggle-Bug must swallow another pill," said Tip, decidedly,
+"and wish us headed in the right direction."
+
+"Very well," returned the Highly Magnified one; "I'm willing."
+
+But when the Scarecrow searched in his pocket for the pepper-box
+containing the two silver Wishing Pills, it was not to be found. Filled
+with anxiety, the voyagers hunted throughout every inch of the Thing
+for the precious box; but it had disappeared entirely.
+
+And still the Gump flew onward, carrying them they knew not where.
+
+"I must have left the pepper-box in the Jackdaws' nest," said the
+Scarecrow, at length.
+
+"It is a great misfortune," the Tin Woodman declared. "But we are no
+worse off than before we discovered the Wishing Pills."
+
+"We are better off," replied Tip; "for the one pill we used has enabled
+us to escape from that horrible nest."
+
+"Yet the loss of the other two is serious, and I deserve a good
+scolding for my carelessness," the Scarecrow rejoined, penitently. "For
+in such an unusual party as this accidents are liable to happen any
+moment, and even now we may be approaching a new danger."
+
+No one dared contradict this, and a dismal silence ensued.
+
+The Gump flew steadily on.
+
+Suddenly Tip uttered an exclamation of surprise.
+
+"We must have reached the South Country," he cried, "for below us
+everything is red!"
+
+[Illustration]
+
+Immediately they all leaned over the backs of the sofas to look--all
+except Jack, who was too careful of his pumpkin head to risk its
+slipping off his neck. Sure enough; the red houses and fences and
+trees indicated they were within the domain of Glinda the Good; and
+presently, as they glided rapidly on, the Tin Woodman recognized the
+roads and buildings they passed, and altered slightly the flight
+of the Gump so that they might reach the palace of the celebrated
+Sorceress.
+
+"Good!" cried the Scarecrow, delightedly. "We do not need the lost
+Wishing Pills now, for we have arrived at our destination."
+
+Gradually the Thing sank lower and nearer to the ground until at length
+it came to rest within the beautiful gardens of Glinda, settling upon
+a velvety green lawn close by a fountain which sent sprays of flashing
+gems, instead of water, high into the air, whence they fell with a
+soft, tinkling sound into the carved marble basin placed to receive
+them.
+
+Everything was very gorgeous in Glinda's gardens, and while our
+voyagers gazed about with admiring eyes a company of soldiers silently
+appeared and surrounded them. But these soldiers of the great Sorceress
+were entirely different from those of Jinjur's Army of Revolt, although
+they were likewise girls. For Glinda's soldiers wore neat uniforms and
+bore swords and spears; and they marched with a skill and precision
+that proved them well trained in the arts of war.
+
+The Captain commanding this troop--which was Glinda's private Body
+Guard--recognized the Scarecrow and the Tin Woodman at once, and
+greeted them with respectful salutations.
+
+"Good day!" said the Scarecrow, gallantly removing his hat, while the
+Woodman gave a soldierly salute; "we have come to request an audience
+with your fair Ruler."
+
+"Glinda is now within her palace, awaiting you," returned the Captain;
+"for she saw you coming long before you arrived."
+
+"That is strange!" said Tip, wondering.
+
+"Not at all," answered the Scarecrow; "for Glinda the Good is a mighty
+Sorceress, and nothing that goes on in the Land of Oz escapes her
+notice. I suppose she knows why we came as well as we do ourselves."
+
+"Then what was the use of our coming?" asked Jack, stupidly.
+
+[Illustration]
+
+"To prove you are a Pumpkinhead!" retorted the Scarecrow. "But, if the
+Sorceress expects us, we must not keep her waiting."
+
+So they all clambered out of the sofas and followed the Captain toward
+the palace--even the Saw-Horse taking his place in the queer procession.
+
+Upon her throne of finely wrought gold sat Glinda, and she could
+scarcely repress a smile as her peculiar visitors entered and bowed
+before her. Both the Scarecrow and the Tin Woodman she knew and
+liked; but the awkward Pumpkinhead and Highly Magnified Woggle-Bug
+were creatures she had never seen before, and they seemed even more
+curious than the others. As for the Saw-Horse, he looked to be nothing
+more than an animated chunk of wood; and he bowed so stiffly that his
+head bumped against the floor, causing a ripple of laughter among the
+soldiers, in which Glinda frankly joined.
+
+"I beg to announce to your glorious highness," began the Scarecrow, in
+a solemn voice, "that my Emerald City has been overrun by a crowd of
+impudent girls with knitting-needles, who have enslaved all the men,
+robbed the streets and public buildings of all their emerald jewels,
+and usurped my throne."
+
+"I know it," said Glinda.
+
+"They also threatened to destroy me, as well as all the good friends
+and allies you see before you," continued the Scarecrow; "and had we
+not managed to escape their clutches our days would long since have
+ended."
+
+"I know it," repeated Glinda.
+
+"Therefore I have come to beg your assistance," resumed the Scarecrow,
+"for I believe you are always glad to succor the unfortunate and
+oppressed."
+
+"That is true," replied the Sorceress, slowly. "But the Emerald City is
+now ruled by General Jinjur, who has caused herself to be proclaimed
+Queen. What right have I to oppose her?"
+
+"Why, she stole the throne from me," said the Scarecrow.
+
+"And how came you to possess the throne?" asked Glinda.
+
+"I got it from the Wizard of Oz, and by the choice of the people,"
+returned the Scarecrow, uneasy at such questioning.
+
+"And where did the Wizard get it?" she continued, gravely.
+
+"I am told he took it from Pastoria, the former King," said the
+Scarecrow, becoming confused under the intent look of the Sorceress.
+
+"Then," declared Glinda, "the throne of the Emerald City belongs
+neither to you nor to Jinjur, but to this Pastoria from whom the Wizard
+usurped it."
+
+"That is true," acknowledged the Scarecrow, humbly; "but Pastoria is
+now dead and gone, and some one must rule in his place."
+
+"Pastoria had a daughter, who is the rightful heir to the throne of the
+Emerald City. Did you know that?" questioned the Sorceress.
+
+"No," replied the Scarecrow. "But if the girl still lives I will not
+stand in her way. It will satisfy me as well to have Jinjur turned out,
+as an impostor, as to regain the throne myself. In fact, it isn't much
+fun to be King, especially if one has good brains. I have known for
+some time that I am fitted to occupy a far more exalted position. But
+where is this girl who owns the throne, and what is her name?"
+
+"Her name is Ozma," answered Glinda. "But where she is I have tried in
+vain to discover. For the Wizard of Oz, when he stole the throne from
+Ozma's father, hid the girl in some secret place; and by means of a
+magical trick with which I am not familiar he also managed to prevent
+her being discovered--even by so experienced a Sorceress as myself."
+
+"That is strange," interrupted the Woggle-Bug, pompously. "I have
+been informed that the Wonderful Wizard of Oz was nothing more than a
+humbug!"
+
+"Nonsense!" exclaimed the Scarecrow, much provoked by this speech.
+"Didn't he give me a wonderful set of brains?"
+
+"There's no humbug about my heart," announced the Tin Woodman, glaring
+indignantly at the Woggle-Bug.
+
+"Perhaps I was misinformed," stammered the Insect, shrinking back; "I
+never knew the Wizard personally."
+
+"Well, we did," retorted the Scarecrow, "and he was a very great
+Wizard, I assure you. It is true he was guilty of some slight
+impostures, but unless he was a great Wizard how--let me ask--could he
+have hidden this girl Ozma so securely that no one can find her?"
+
+"I--I give it up!" replied the Woggle-Bug, meekly.
+
+"That is the most sensible speech you've made," said the Tin Woodman.
+
+"I must really make another effort to discover where this girl is
+hidden," resumed the Sorceress, thoughtfully. "I have in my library a
+book in which is inscribed every action of the Wizard while he was in
+our land of Oz--or, at least, every action that could be observed by
+my spies. This book I will read carefully tonight, and try to single
+out the acts that may guide us in discovering the lost Ozma. In the
+meantime, pray amuse yourselves in my palace and command my servants as
+if they were your own. I will grant you another audience tomorrow."
+
+With this gracious speech Glinda dismissed the adventurers, and they
+wandered away through the beautiful gardens, where they passed several
+hours enjoying all the delightful things with which the Queen of the
+Southland had surrounded her royal palace.
+
+On the following morning they again appeared before Glinda, who said to
+them:
+
+"I have searched carefully through the records of the Wizard's
+actions, and among them I can find but three that appear to have been
+suspicious. He ate beans with a knife, made three secret visits to old
+Mombi, and limped slightly on his left foot."
+
+"Ah! that last is certainly suspicious!" exclaimed the Pumpkinhead.
+
+"Not necessarily," said the Scarecrow; "he may have had corns. Now, it
+seems to me his eating beans with a knife is more suspicious."
+
+"Perhaps it is a polite custom in Omaha, from which great country the
+Wizard originally came," suggested the Tin Woodman.
+
+"It may be," admitted the Scarecrow.
+
+"But why," asked Glinda, "did he make three secret visits to old Mombi?"
+
+"Ah! Why, indeed!" echoed the Woggle-Bug, impressively.
+
+"We know that the Wizard taught the old woman many of his tricks of
+magic," continued Glinda; "and this he would not have done had she not
+assisted him in some way. So we may suspect with good reason that Mombi
+aided him to hide the girl Ozma, who was the real heir to the throne
+of the Emerald City, and a constant danger to the usurper. For, if the
+people knew that she lived, they would quickly make her their Queen and
+restore her to her rightful position."
+
+"An able argument!" cried the Scarecrow. "I have no doubt that Mombi
+was mixed up in this wicked business. But how does that knowledge help
+us?"
+
+"We must find Mombi," replied Glinda, "and force her to tell where the
+girl is hidden."
+
+"Mombi is now with Queen Jinjur, in the Emerald City," said Tip. "It
+was she who threw so many obstacles in our pathway, and made Jinjur
+threaten to destroy my friends and give me back into the old witch's
+power."
+
+"Then," decided Glinda, "I will march with my army to the Emerald
+City, and take Mombi prisoner. After that we can, perhaps, force her to
+tell the truth about Ozma."
+
+"She is a terrible old woman!" remarked Tip, with a shudder at the
+thought of Mombi's black kettle; "and obstinate, too."
+
+"I am quite obstinate myself," returned the Sorceress, with a sweet
+smile; "so I do not fear Mombi in the least. Today I will make all
+necessary preparations, and we will march upon the Emerald City at
+daybreak tomorrow."
+
+[Illustration: "She is a terrible old woman."]
+
+[Illustration: Jinjur]
+
+
+
+
+[Illustration:
+
+    The Tin-Woodman
+    Plucks a Rose
+]
+
+[Illustration]
+
+The Army of Glinda the Good looked very grand and imposing when it
+assembled at daybreak before the palace gates. The uniforms of the
+girl soldiers were pretty and of gay colors, and their silver-tipped
+spears were bright and glistening, the long shafts being inlaid with
+mother-of-pearl. All the officers wore sharp, gleaming swords, and
+shields edged with peacock-feathers; and it really seemed that no foe
+could by any possibility defeat such a brilliant army.
+
+The Sorceress rode in a beautiful palanquin which was like the body of
+a coach, having doors and windows with silken curtains; but instead
+of wheels, which a coach has, the palanquin rested upon two long,
+horizontal bars, which were borne upon the shoulders of twelve servants.
+
+The Scarecrow and his comrades decided to ride in the Gump, in order
+to keep up with the swift march of the army; so, as soon as Glinda had
+started and her soldiers had marched away to the inspiring strains of
+music played by the royal band, our friends climbed into the sofas
+and followed. The Gump flew along slowly at a point directly over the
+palanquin in which rode the Sorceress.
+
+[Illustration]
+
+"Be careful," said the Tin Woodman to the Scarecrow, who was leaning
+far over the side to look at the army below. "You might fall."
+
+"It wouldn't matter," remarked the educated Woggle-Bug; "he can't get
+broke so long as he is stuffed with money."
+
+"Didn't I ask you--" began Tip, in a reproachful voice.
+
+"You did!" said the Woggle-Bug, promptly. "And I beg your pardon. I
+will really try to restrain myself."
+
+"You'd better," declared the boy. "That is, if you wish to travel in
+our company."
+
+"Ah! I couldn't bear to part with you now," murmured the Insect,
+feelingly; so Tip let the subject drop.
+
+The army moved steadily on, but night had fallen before they came
+to the walls of the Emerald City. By the dim light of the new moon,
+however, Glinda's forces silently surrounded the city and pitched their
+tents of scarlet silk upon the greensward. The tent of the Sorceress
+was larger than the others, and was composed of pure white silk, with
+scarlet banners flying above it. A tent was also pitched for the
+Scarecrow's party; and when these preparations had been made, with
+military precision and quickness, the army retired to rest.
+
+Great was the amazement of Queen Jinjur next morning when her soldiers
+came running to inform her of the vast army surrounding them. She at
+once climbed to a high tower of the royal palace and saw banners waving
+in every direction and the great white tent of Glinda standing directly
+before the gates.
+
+[Illustration]
+
+"We are surely lost!" cried Jinjur, in despair; "for how can our
+knitting-needles avail against the long spears and terrible swords of
+our foes?"
+
+"The best thing we can do," said one of the girls, "is to surrender as
+quickly as possible, before we get hurt."
+
+"Not so," returned Jinjur, more bravely. "The enemy is still outside
+the walls, so we must try to gain time by engaging them in parley. Go
+you with a flag of truce to Glinda and ask her why she has dared to
+invade my dominions, and what are her demands."
+
+So the girl passed through the gates, bearing a white flag to show she
+was on a mission of peace, and came to Glinda's tent.
+
+"Tell your Queen," said the Sorceress to the girl, "that she must
+deliver up to me old Mombi, to be my prisoner. If this is done I will
+not molest her farther."
+
+Now when this message was delivered to the Queen it filled her with
+dismay, for Mombi was her chief counsellor, and Jinjur was terribly
+afraid of the old hag. But she sent for Mombi, and told her what Glinda
+had said.
+
+"I see trouble ahead for all of us," muttered the old witch, after
+glancing into a magic mirror she carried in her pocket. "But we may
+even yet escape by deceiving this sorceress, clever as she thinks
+herself."
+
+"Don't you think it will be safer for me to deliver you into her
+hands?" asked Jinjur, nervously.
+
+"If you do, it will cost you the throne of the Emerald City!" answered
+the witch, positively. "But, if you will let me have my own way, I can
+save us both very easily."
+
+"Then do as you please," replied Jinjur, "for it is so aristocratic to
+be a Queen that I do not wish to be obliged to return home again, to
+make beds and wash dishes for my mother."
+
+So Mombi called Jellia Jamb to her, and performed a certain magical
+rite with which she was familiar. As a result of the enchantment Jellia
+took on the form and features of Mombi, while the old witch grew to
+resemble the girl so closely that it seemed impossible anyone could
+guess the deception.
+
+"Now," said old Mombi to the Queen, "let your soldiers deliver up this
+girl to Glinda. She will think she has the real Mombi in her power, and
+so will return immediately to her own country in the South."
+
+[Illustration]
+
+Therefore Jellia, hobbling along like an aged woman, was led from the
+city gates and taken before Glinda.
+
+"Here is the person you demanded," said one of the guards, "and our
+Queen now begs you will go away, as you promised, and leave us in
+peace."
+
+"That I will surely do," replied Glinda, much pleased; "if this is
+really the person she seems to be."
+
+"It is certainly old Mombi," said the guard, who believed she was
+speaking the truth; and then Jinjur's soldiers returned within the
+city's gates.
+
+The Sorceress quickly summoned the Scarecrow and his friends to her
+tent, and began to question the supposed Mombi about the lost girl
+Ozma. But Jellia knew nothing at all of this affair, and presently she
+grew so nervous under the questioning that she gave way and began to
+weep, to Glinda's great astonishment.
+
+"Here is some foolish trickery!" said the Sorceress, her eyes flashing
+with anger. "This is not Mombi at all, but some other person who has
+been made to resemble her! Tell me," she demanded, turning to the
+trembling girl, "what is your name?"
+
+This Jellia dared not tell, having been threatened with death by the
+witch if she confessed the fraud. But Glinda, sweet and fair though she
+was, understood magic better than any other person in the Land of Oz.
+So, by uttering a few potent words and making a peculiar gesture, she
+quickly transformed the girl into her proper shape, while at the same
+time old Mombi, far away in Jinjur's palace, suddenly resumed her own
+crooked form and evil features.
+
+"Why, it's Jellia Jamb!" cried the Scarecrow, recognizing in the girl
+one of his old friends.
+
+"It's our interpreter!" said the Pumpkinhead, smiling pleasantly.
+
+Then Jellia was forced to tell of the trick Mombi had played, and she
+also begged Glinda's protection, which the Sorceress readily granted.
+But Glinda was now really angry, and sent word to Jinjur that the
+fraud was discovered and she must deliver up the real Mombi or suffer
+terrible consequences. Jinjur was prepared for this message, for the
+witch well understood, when her natural form was thrust upon her, that
+Glinda had discovered her trickery. But the wicked old creature had
+already thought up a new deception, and had made Jinjur promise to
+carry it out. So the Queen said to Glinda's messenger:
+
+[Illustration]
+
+"Tell your mistress that I cannot find Mombi anywhere; but that Glinda
+is welcome to enter the city and search herself for the old woman. She
+may also bring her friends with her, if she likes; but if she does not
+find Mombi by sundown, the Sorceress must promise to go away peaceably
+and bother us no more."
+
+Glinda agreed to these terms, well knowing that Mombi was somewhere
+within the city walls. So Jinjur caused the gates to be thrown open,
+and Glinda marched in at the head of a company of soldiers, followed by
+the Scarecrow and the Tin Woodman, while Jack Pumpkinhead rode astride
+the Saw-Horse, and the Educated, Highly Magnified Woggle-Bug sauntered
+behind in a dignified manner. Tip walked by the side of the Sorceress,
+for Glinda had conceived a great liking for the boy.
+
+Of course old Mombi had no intention of being found by Glinda; so,
+while her enemies were marching up the street, the witch transformed
+herself into a red rose growing upon a bush in the garden of the
+palace. It was a clever idea, and a trick Glinda did not suspect; so
+several precious hours were spent in a vain search for Mombi.
+
+As sundown approached the Sorceress realized she had been defeated by
+the superior cunning of the aged witch; so she gave the command to her
+people to march out of the city and back to their tents.
+
+The Scarecrow and his comrades happened to be searching in the garden
+of the palace just then, and they turned with disappointment to obey
+Glinda's command. But before they left the garden the Tin Woodman,
+who was fond of flowers, chanced to espy a big red rose growing upon
+a bush; so he plucked the flower and fastened it securely in the tin
+button-hole of his tin bosom.
+
+As he did this he fancied he heard a low moan proceed from the rose;
+but he paid no attention to the sound, and Mombi was thus carried out
+of the city and into Glinda's camp without anyone having a suspicion
+that they had succeeded in their quest.
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Transformation
+    of Old Mombi
+]
+
+
+The Witch was at first frightened at finding herself captured by the
+enemy; but soon she decided that she was exactly as safe in the Tin
+Woodman's button-hole as growing upon the bush. For no one knew the
+rose and Mombi to be one, and now that she was without the gates of the
+City her chances of escaping altogether from Glinda were much improved.
+
+"But there is no hurry," thought Mombi. "I will wait awhile and enjoy
+the humiliation of this Sorceress when she finds I have outwitted her."
+
+So throughout the night the rose lay quietly on the Woodman's bosom,
+and in the morning, when Glinda summoned our friends to a consultation,
+Nick Chopper carried his pretty flower with him to the white silk tent.
+
+[Illustration]
+
+"For some reason," said Glinda, "we have failed to find this cunning
+old Mombi; so I fear our expedition will prove a failure. And for that
+I am sorry, because without our assistance little Ozma will never be
+rescued and restored to her rightful position as Queen of the Emerald
+City."
+
+"Do not let us give up so easily," said the Pumpkinhead. "Let us do
+something else."
+
+"Something else must really be done," replied Glinda, with a smile;
+"yet I cannot understand how I have been defeated so easily by an old
+Witch who knows far less of magic than I do myself."
+
+"While we are on the ground I believe it would be wise for us to
+conquer the Emerald City for Princess Ozma, and find the girl
+afterward," said the Scarecrow. "And while the girl remains hidden I
+will gladly rule in her place, for I understand the business of ruling
+much better than Jinjur does."
+
+"But I have promised not to molest Jinjur," objected Glinda.
+
+"Suppose you all return with me to my kingdom--or Empire, rather," said
+the Tin Woodman, politely including the entire party in a royal wave of
+his arm. "It will give me great pleasure to entertain you in my castle,
+where there is room enough and to spare. And if any of you wish to be
+nickel-plated, my valet will do it free of all expense."
+
+While the Woodman was speaking Glinda's eyes had been noting the rose
+in his button-hole, and now she imagined she saw the big red leaves of
+the flower tremble slightly. This quickly aroused her suspicions, and
+in a moment more the Sorceress had decided that the seeming rose was
+nothing else than a transformation of old Mombi. At the same instant
+Mombi knew she was discovered and must quickly plan an escape, and
+as transformations were easy to her she immediately took the form of
+a Shadow and glided along the wall of the tent toward the entrance,
+thinking thus to disappear.
+
+But Glinda had not only equal cunning, but far more experience than
+the Witch. So the Sorceress reached the opening of the tent before the
+Shadow, and with a wave of her hand closed the entrance so securely
+that Mombi could not find a crack big enough to creep through. The
+Scarecrow and his friends were greatly surprised at Glinda's actions;
+for none of them had noted the Shadow. But the Sorceress said to them:
+
+"Remain perfectly quiet, all of you! For the old Witch is even now with
+us in this tent, and I hope to capture her."
+
+These words so alarmed Mombi that she quickly transformed herself from
+a shadow to a Black Ant, in which shape she crawled along the ground,
+seeking a crack or crevice in which to hide her tiny body.
+
+Fortunately, the ground where the tent had been pitched, being just
+before the city gates, was hard and smooth; and while the Ant still
+crawled about, Glinda discovered it and ran quickly forward to effect
+its capture. But, just as her hand was descending, the Witch, now
+fairly frantic with fear, made her last transformation, and in the form
+of a huge Griffin sprang through the wall of the tent--tearing the silk
+asunder in her rush--and in a moment had darted away with the speed of
+a whirlwind.
+
+Glinda did not hesitate to follow. She sprang upon the back of the
+Saw-Horse and cried:
+
+"Now you shall prove that you have a right to be alive! Run--run--run!"
+
+The Saw-Horse ran. Like a flash he followed the Griffin, his wooden
+legs moving so fast that they twinkled like the rays of a star. Before
+our friends could recover from their surprise both the Griffin and the
+Saw-Horse had dashed out of sight.
+
+"Come! Let us follow!" cried the Scarecrow.
+
+They ran to the place where the Gump was lying and quickly tumbled
+aboard.
+
+"Fly!" commanded Tip, eagerly.
+
+"Where to?" asked the Gump, in its calm voice.
+
+"I don't know," returned Tip, who was very nervous at the delay; "but
+if you will mount into the air I think we can discover which way Glinda
+has gone."
+
+[Illustration]
+
+"Very well," returned the Gump, quietly; and it spread its great wings
+and mounted high into the air.
+
+Far away, across the meadows, they could now see two tiny specks,
+speeding one after the other; and they knew these specks must be the
+Griffin and the Saw-Horse. So Tip called the Gump's attention to them
+and bade the creature try to overtake the Witch and the Sorceress. But,
+swift as was the Gump's flight, the pursued and pursuer moved more
+swiftly yet, and within a few moments were blotted out against the dim
+horizon.
+
+"Let us continue to follow them, nevertheless," said the Scarecrow;
+"for the Land of Oz is of small extent, and sooner or later they must
+both come to a halt."
+
+Old Mombi had thought herself very wise to choose the form of a
+Griffin, for its legs were exceedingly fleet and its strength more
+enduring than that of other animals. But she had not reckoned on the
+untiring energy of the Saw-Horse, whose wooden limbs could run for days
+without slacking their speed. Therefore, after an hour's hard running,
+the Griffin's breath began to fail, and it panted and gasped painfully,
+and moved more slowly than before. Then it reached the edge of the
+desert and began racing across the deep sands. But its tired feet sank
+far into the sand, and in a few minutes the Griffin fell forward,
+completely exhausted, and lay still upon the desert waste.
+
+Glinda came up a moment later, riding the still vigorous Saw-Horse; and
+having unwound a slender golden thread from her girdle the Sorceress
+threw it over the head of the panting and helpless Griffin, and so
+destroyed the magical power of Mombi's transformation.
+
+For the animal, with one fierce shudder, disappeared from view, while
+in its place was discovered the form of the old Witch, glaring savagely
+at the serene and beautiful face of the Sorceress.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    Princess Ozma of Oz
+]
+
+
+"You are my prisoner, and it is useless for you to struggle any
+longer," said Glinda, in her soft, sweet voice. "Lie still a moment,
+and rest yourself, and then I will carry you back to my tent."
+
+"Why do you seek me?" asked Mombi, still scarce able to speak plainly
+for lack of breath. "What have I done to you, to be so persecuted?"
+
+"You have done nothing to me," answered the gentle Sorceress; "but I
+suspect you have been guilty of several wicked actions; and if I find
+it is true that you have so abused your knowledge of magic, I intend to
+punish you severely."
+
+"I defy you!" croaked the old hag. "You dare not harm me!"
+
+Just then the Gump flew up to them and alighted upon the desert sands
+beside Glinda. Our friends were delighted to find that Mombi had
+finally been captured, and after a hurried consultation it was decided
+they should all return to the camp in the Gump. So the Saw-Horse was
+tossed aboard, and then Glinda, still holding an end of the golden
+thread that was around Mombi's neck, forced her prisoner to climb into
+the sofas. The others now followed, and Tip gave the word to the Gump
+to return.
+
+The journey was made in safety, Mombi sitting in her place with a grim
+and sullen air; for the old hag was absolutely helpless so long as the
+magical thread encircled her throat. The army hailed Glinda's return
+with loud cheers, and the party of friends soon gathered again in the
+royal tent, which had been neatly repaired during their absence.
+
+"Now," said the Sorceress to Mombi, "I want you to tell us why the
+Wonderful Wizard of Oz paid you three visits, and what became of the
+child, Ozma, which so curiously disappeared."
+
+The Witch looked at Glinda defiantly, but said not a word.
+
+"Answer me!" cried the Sorceress.
+
+But still Mombi remained silent.
+
+"Perhaps she doesn't know," remarked Jack.
+
+"I beg you will keep quiet," said Tip. "You might spoil everything with
+your foolishness."
+
+"Very well, dear father!" returned the Pumpkinhead, meekly.
+
+"How glad I am to be a Woggle-Bug!" murmured the Highly Magnified
+Insect, softly. "No one can expect wisdom to flow from a pumpkin."
+
+"Well," said the Scarecrow, "what shall we do to make Mombi speak?
+Unless she tells us what we wish to know her capture will do us no good
+at all."
+
+"Suppose we try kindness," suggested the Tin Woodman. "I've heard that
+anyone can be conquered with kindness, no matter how ugly they may be."
+
+At this the Witch turned to glare upon him so horribly that the Tin
+Woodman shrank back abashed.
+
+Glinda had been carefully considering what to do, and now she turned to
+Mombi and said:
+
+"You will gain nothing, I assure you, by thus defying us. For I am
+determined to learn the truth about the girl Ozma, and unless you tell
+me all that you know, I will certainly put you to death."
+
+"Oh, no! Don't do that!" exclaimed the Tin Woodman. "It would be an
+awful thing to kill anyone--even old Mombi!"
+
+"But it is merely a threat," returned Glinda. "I shall not put Mombi to
+death, because she will prefer to tell me the truth."
+
+"Oh, I see!" said the tin man, much relieved.
+
+"Suppose I tell you all that you wish to know," said Mombi, speaking so
+suddenly that she startled them all. "What will you do with me then?"
+
+"In that case," replied Glinda, "I shall merely ask you to drink a
+powerful draught which will cause you to forget all the magic you have
+ever learned."
+
+"Then I would become a helpless old woman!"
+
+"But you would be alive," suggested the Pumpkinhead, consolingly.
+
+"Do try to keep silent!" said Tip, nervously.
+
+"I'll try," responded Jack; "but you will admit that it's a good thing
+to be alive."
+
+"Especially if one happens to be Thoroughly Educated," added the
+Woggle-Bug, nodding approval.
+
+"You may make your choice," Glinda said to old Mombi, "between death if
+you remain silent, and the loss of your magical powers if you tell me
+the truth. But I think you will prefer to live."
+
+Mombi cast an uneasy glance at the Sorceress, and saw that she was in
+earnest, and not to be trifled with. So she replied, slowly:
+
+"I will answer your questions."
+
+"That is what I expected," said Glinda, pleasantly. "You have chosen
+wisely, I assure you."
+
+She then motioned to one of her Captains, who brought her a beautiful
+golden casket. From this the Sorceress drew an immense white pearl,
+attached to a slender chain which she placed around her neck in such a
+way that the pearl rested upon her bosom, directly over her heart.
+
+"Now," said she, "I will ask my first question: Why did the Wizard pay
+you three visits?"
+
+"Because I would not come to him," answered Mombi.
+
+"That is no answer," said Glinda, sternly. "Tell me the truth."
+
+"Well," returned Mombi, with downcast eyes, "he visited me to learn the
+way I make tea-biscuits."
+
+"Look up!" commanded the Sorceress.
+
+Mombi obeyed.
+
+"What is the color of my pearl?" demanded Glinda.
+
+"Why--it is black!" replied the old Witch, in a tone of wonder.
+
+"Then you have told me a falsehood!" cried Glinda, angrily. "Only when
+the truth is spoken will my magic pearl remain a pure white in color."
+
+Mombi now saw how useless it was to try to deceive the Sorceress; so
+she said, meanwhile scowling at her defeat:
+
+"The Wizard brought to me the girl Ozma, who was then no more than a
+baby, and begged me to conceal the child."
+
+"That is what I thought," declared Glinda, calmly. "What did he give
+you for thus serving him?"
+
+"He taught me all the magical tricks he knew. Some were good tricks,
+and some were only frauds; but I have remained faithful to my promise."
+
+"What did you do with the girl?" asked Glinda; and at this question
+everyone bent forward and listened eagerly for the reply.
+
+"I enchanted her," answered Mombi.
+
+"In what way?"
+
+"I transformed her into--into--"
+
+"Into what?" demanded Glinda, as the Witch hesitated.
+
+"_Into a boy!_" said Mombi, in a low tone.
+
+"A boy!" echoed every voice; and then, because they knew that this old
+woman had reared Tip from childhood, all eyes were turned to where the
+boy stood.
+
+"Yes," said the old Witch, nodding her head; "that is the Princess
+Ozma--the child brought to me by the Wizard who stole her father's
+throne. That is the rightful ruler of the Emerald City!" and she
+pointed her long bony finger straight at the boy.
+
+"I!" cried Tip, in amazement. "Why, I'm no Princess Ozma--I'm not a
+girl!"
+
+Glinda smiled, and going to Tip she took his small brown hand within
+her dainty white one.
+
+[Illustration: MOMBI POINTED HER LONG, BONY FINGER AT THE BOY.]
+
+"You are not a girl just now," said she, gently, "because Mombi
+transformed you into a boy. But you were born a girl, and also a
+Princess; so you must resume your proper form, that you may become
+Queen of the Emerald City."
+
+"Oh, let Jinjur be the Queen!" exclaimed Tip, ready to cry. "I want to
+stay a boy, and travel with the Scarecrow and the Tin Woodman, and the
+Woggle-Bug, and Jack--yes! and my friend the Saw-Horse--and the Gump!
+I don't want to be a girl!"
+
+"Never mind, old chap," said the Tin Woodman, soothingly; "it don't
+hurt to be a girl, I'm told; and we will all remain your faithful
+friends just the same. And, to be honest with you, I've always
+considered girls nicer than boys."
+
+"They're just as nice, anyway," added the Scarecrow, patting Tip
+affectionately upon the head.
+
+"And they are equally good students," proclaimed the Woggle-Bug. "I
+should like to become your tutor, when you are transformed into a girl
+again."
+
+"But--see here!" said Jack Pumpkinhead, with a gasp: "if you become a
+girl, you can't be my dear father any more!"
+
+"No," answered Tip, laughing in spite of his anxiety; "and I shall not
+be sorry to escape the relationship." Then he added, hesitatingly, as
+he turned to Glinda: "I might try it for awhile,--just to see how it
+seems, you know. But if I don't like being a girl you must promise to
+change me into a boy again."
+
+[Illustration]
+
+"Really," said the Sorceress, "that is beyond my magic. I never deal in
+transformations, for they are not honest, and no respectable sorceress
+likes to make things appear to be what they are not. Only unscrupulous
+witches use the art, and therefore I must ask Mombi to effect your
+release from her charm, and restore you to your proper form. It will be
+the last opportunity she will have to practice magic."
+
+Now that the truth about Princess Ozma had been discovered, Mombi did
+not care what became of Tip; but she feared Glinda's anger, and the boy
+generously promised to provide for Mombi in her old age if he became
+the ruler of the Emerald City. So the Witch consented to effect the
+transformation, and preparations for the event were at once made.
+
+Glinda ordered her own royal couch to be placed in the center of the
+tent. It was piled high with cushions covered with rose-colored silk,
+and from a golden railing above hung many folds of pink gossamer,
+completely concealing the interior of the couch.
+
+The first act of the Witch was to make the boy drink a potion which
+quickly sent him into a deep and dreamless sleep. Then the Tin Woodman
+and the Woggle-Bug bore him gently to the couch, placed him upon the
+soft cushions, and drew the gossamer hangings to shut him from all
+earthly view.
+
+The Witch squatted upon the ground and kindled a tiny fire of dried
+herbs, which she drew from her bosom. When the blaze shot up and burned
+clearly old Mombi scattered a handful of magical powder over the fire,
+which straightway gave off a rich violet vapor, filling all the tent
+with its fragrance and forcing the Saw-Horse to sneeze--although he had
+been warned to keep quiet.
+
+[Illustration: MOMBI AT HER MAGICAL INCANTATIONS.]
+
+Then, while the others watched her curiously, the hag chanted a
+rhythmical verse in words which no one understood, and bent her lean
+body seven times back and forth over the fire. And now the incantation
+seemed complete, for the Witch stood upright and cried the one word
+"Yeowa!" in a loud voice.
+
+The vapor floated away; the atmosphere became clear again; a whiff of
+fresh air filled the tent, and the pink curtains of the couch trembled
+slightly, as if stirred from within.
+
+Glinda walked to the canopy and parted the silken hangings. Then she
+bent over the cushions, reached out her hand, and from the couch
+arose the form of a young girl, fresh and beautiful as a May morning.
+Her eyes sparkled as two diamonds, and her lips were tinted like a
+tourmaline. All adown her back floated tresses of ruddy gold, with a
+slender jeweled circlet confining them at the brow. Her robes of silken
+gauze floated around her like a cloud, and dainty satin slippers shod
+her feet.
+
+At this exquisite vision Tip's old comrades stared in wonder for
+the space of a full minute, and then every head bent low in honest
+admiration of the lovely Princess Ozma. The girl herself cast one look
+into Glinda's bright face, which glowed with pleasure and satisfaction,
+and then turned upon the others. Speaking the words with sweet
+diffidence, she said:
+
+"I hope none of you will care less for me than you did before. I'm just
+the same Tip, you know; only--only--"
+
+"Only you're different!" said the Pumpkinhead; and everyone thought it
+was the wisest speech he had ever made.
+
+[Illustration]
+
+[Illustration]
+
+
+
+
+[Illustration:
+
+    The Riches of
+    Content
+]
+
+
+When the wonderful tidings reached the ears of Queen Jinjur--how Mombi
+the Witch had been captured; how she had confessed her crime to Glinda;
+and how the long-lost Princess Ozma had been discovered in no less a
+personage than the boy Tip--she wept real tears of grief and despair.
+
+"To think," she moaned, "that after having ruled as Queen, and lived in
+a palace, I must go back to scrubbing floors and churning butter again!
+It is too horrible to think of! I will never consent!"
+
+So when her soldiers, who spent most of their time making fudge in the
+palace kitchens, counseled Jinjur to resist, she listened to their
+foolish prattle and sent a sharp defiance to Glinda the Good and the
+Princess Ozma. The result was a declaration of war, and the very next
+day Glinda marched upon the Emerald City with pennants flying and bands
+playing, and a forest of shining spears sparkling brightly beneath the
+sun's rays.
+
+But when it came to the walls this brave assembly made a sudden halt;
+for Jinjur had closed and barred every gateway, and the walls of the
+Emerald City were builded high and thick with many blocks of green
+marble. Finding her advance thus baffled, Glinda bent her brows in deep
+thought, while the Woggle-Bug said, in his most positive tone:
+
+"We must lay siege to the city, and starve it into submission. It is
+the only thing we can do."
+
+"Not so," answered the Scarecrow. "We still have the Gump, and the Gump
+can still fly."
+
+The Sorceress turned quickly at this speech, and her face now wore a
+bright smile.
+
+"You are right," she exclaimed, "and certainly have reason to be proud
+of your brains. Let us go to the Gump at once!"
+
+So they passed through the ranks of the army until they came to the
+place, near the Scarecrow's tent, where the Gump lay. Glinda and
+Princess Ozma mounted first, and sat upon the sofas. Then the Scarecrow
+and his friends climbed aboard, and still there was room for a Captain
+and three soldiers, which Glinda considered sufficient for a guard.
+
+[Illustration]
+
+Now, at a word from the Princess, the queer Thing they had called
+the Gump flopped its palm-leaf wings and rose into the air, carrying
+the party of adventurers high above the walls. They hovered over
+the palace, and soon perceived Jinjur reclining in a hammock in the
+courtyard, where she was comfortably reading a novel with a green cover
+and eating green chocolates, confident that the walls would protect her
+from her enemies. Obeying a quick command, the Gump alighted safely in
+this very courtyard, and before Jinjur had time to do more than scream,
+the Captain and three soldiers leaped out and made the former Queen a
+prisoner, locking strong chains upon both her wrists.
+
+That act really ended the war; for the Army of Revolt submitted as
+soon as they knew Jinjur to be a captive, and the Captain marched in
+safety through the streets and up to the gates of the city, which
+she threw wide open. Then the bands played their most stirring music
+while Glinda's army marched into the city, and heralds proclaimed the
+conquest of the audacious Jinjur and the accession of the beautiful
+Princess Ozma to the throne of her royal ancestors.
+
+[Illustration]
+
+At once the men of the Emerald City cast off their aprons. And it is
+said that the women were so tired eating of their husbands' cooking
+that they all hailed the conquest of Jinjur with joy. Certain it is
+that, rushing one and all to the kitchens of their houses, the good
+wives prepared so delicious a feast for the weary men that harmony was
+immediately restored in every family.
+
+Ozma's first act was to oblige the Army of Revolt to return to
+her every emerald or other gem stolen from the public streets and
+buildings; and so great was the number of precious stones picked
+from their settings by these vain girls, that every one of the royal
+jewelers worked steadily for more than a month to replace them in their
+settings.
+
+Meantime the Army of Revolt was disbanded and the girls sent home to
+their mothers. On promise of good behavior Jinjur was likewise released.
+
+Ozma made the loveliest Queen the Emerald City had ever known; and,
+although she was so young and inexperienced, she ruled her people with
+wisdom and justice. For Glinda gave her good advice on all occasions;
+and the Woggle-Bug, who was appointed to the important post of Public
+Educator, was quite helpful to Ozma when her royal duties grew
+perplexing.
+
+The girl, in her gratitude to the Gump for its services, offered the
+creature any reward it might name.
+
+"Then," replied the Gump, "please take me to pieces. I did not wish
+to be brought to life, and I am greatly ashamed of my conglomerate
+personality. Once I was a monarch of the forest, as my antlers fully
+prove; but now, in my present upholstered condition of servitude, I
+am compelled to fly through the air--my legs being of no use to me
+whatever. Therefore I beg to be dispersed."
+
+So Ozma ordered the Gump taken apart. The antlered head was again
+hung over the mantle-piece in the hall, and the sofas were untied and
+placed in the reception parlors. The broom tail resumed its accustomed
+duties in the kitchen, and finally, the Scarecrow replaced all the
+clotheslines and ropes on the pegs from which he had taken them on the
+eventful day when the Thing was constructed.
+
+You might think that was the end of the Gump; and so it was, as a
+flying-machine. But the head over the mantle-piece continued to talk
+whenever it took a notion to do so, and it frequently startled, with
+its abrupt questions, the people who waited in the hall for an audience
+with the Queen.
+
+The Saw-Horse, being Ozma's personal property, was tenderly cared for;
+and often she rode the queer creature along the streets of the Emerald
+City. She had its wooden legs shod with gold, to keep them from
+wearing out, and the tinkle of these golden shoes upon the pavement
+always filled the Queen's subjects with awe as they thought upon this
+evidence of her magical powers.
+
+"The Wonderful Wizard was never so wonderful as Queen Ozma," the people
+said to one another, in whispers; "for he claimed to do many things he
+could not do; whereas our new Queen does many things no one would ever
+expect her to accomplish."
+
+Jack Pumpkinhead remained with Ozma to the end of his days; and he
+did not spoil as soon as he had feared, although he always remained
+as stupid as ever. The Woggle-Bug tried to teach him several arts and
+sciences; but Jack was so poor a student that any attempt to educate
+him was soon abandoned.
+
+After Glinda's army had marched back home, and peace was restored to
+the Emerald City, the Tin Woodman announced his intention to return to
+his own Kingdom of the Winkies.
+
+"It isn't a very big Kingdom," said he to Ozma, "but for that very
+reason it is easier to rule; and I have called myself an Emperor
+because I am an Absolute Monarch, and no one interferes in any way
+with my conduct of public or personal affairs. When I get home I shall
+have a new coat of nickel plate; for I have become somewhat marred and
+scratched lately; and then I shall be glad to have you pay me a visit."
+
+"Thank you," replied Ozma. "Some day I may accept the invitation. But
+what is to become of the Scarecrow?"
+
+"I shall return with my friend the Tin Woodman," said the stuffed one,
+seriously. "We have decided never to be parted in the future."
+
+"And I have made the Scarecrow my Royal Treasurer," explained the Tin
+Woodman. "For it has occurred to me that it is a good thing to have a
+Royal Treasurer who is made of money. What do you think?"
+
+"I think," said the little Queen, smiling, "that your friend must be
+the richest man in all the world."
+
+"I am," returned the Scarecrow; "but not on account of my money. For
+I consider brains far superior to money, in every way. You may have
+noticed that if one has money without brains, he cannot use it to
+advantage; but if one has brains without money, they will enable him to
+live comfortably to the end of his days."
+
+"At the same time," declared the Tin Woodman, "you must acknowledge
+that a good heart is a thing that brains can not create, and that money
+can not buy. Perhaps, after all, it is I who am the richest man in all
+the world."
+
+"You are both rich, my friends," said Ozma, gently; "and your riches
+are the only riches worth having--the riches of content!"
+
+[Illustration:
+
+    The End
+]
+
+
+
+
+THE OZ BOOKS
+
+BY
+
+L. FRANK BAUM
+
+
+_The Wizard of Oz_
+
+[Originally published as _The Wonderful Wizard of Oz_]
+
+It is in this book that Oz is "discovered." A little Kansas
+girl--Dorothy Gale--is carried in her house to Oz when a cyclone whisks
+it through the sky. As the house lands in the Munchkin Country (one of
+the four great countries of Oz) it destroys a wicked witch and sends
+Dorothy off on her first adventure in Oz. She finds the Scarecrow,
+meets the Tin Woodman and the Cowardly Lion, melts a second wicked
+witch with a pail of water and finds her way home. Since this book
+appeared a half-century ago, we have learned many marvelous things
+about the Land of Oz.
+
+
+_The Land of Oz_
+
+[Originally published as _The Marvelous Land of Oz_]
+
+This sequel to _The Wizard of Oz_ deals entirely with the early history
+of Oz. No one from the United States or any other part of the "great
+outside world" appears in it. It takes its readers on a series of
+incredible adventures with Tip, a small boy who runs away from old
+Mombi, the witch, taking with him Jack Pumpkinhead and the wooden
+Saw-Horse. The Scarecrow is King of the Emerald City until he, Tip,
+Jack, and the Tin Woodman are forced to flee the royal palace when it
+is invaded by General Jinjur and her army of rebelling girls. The _Land
+of Oz_ ends with an amazing surprise, and from that moment on Ozma is
+princess of all Oz.
+
+
+_Ozma of Oz_
+
+Few of the Oz books are as crowded with exciting Oz happenings as this
+one. Not only does it bring Dorothy back to Oz on her second visit,
+but it introduces Dorothy to Ozma, relates Ozma's first important
+adventure, and introduces for the first time such famous Oz characters
+as Tik-Tok, the mechanical man, Billina the hen, the Hungry Tiger,
+and--_the Nome King_! Most of the adventures in this book take place
+outside Oz, in the Land of Ev and the Nome Kingdom. Scarcely a page
+fails to quiver with excitement, magic and adventure.
+
+
+_Dorothy and the Wizard in Oz_
+
+Of course, everyone always predicted it would happen! And in this book
+it does--the Wizard comes back to Oz to stay. Best of all, he comes
+with Dorothy, who is having adventure number three that leads her
+to Oz, this time via a California earthquake. In this book we meet
+Dorothy's pink kitten, Eureka, whose manners need adjusting badly,
+and two good friends who we are sorry did not remain in Oz--Jim the
+cabhorse, and Zeb, Dorothy's young cousin, who works on a ranch as a
+hired boy.
+
+
+_The Road to Oz_
+
+We like to think of this volume as "The Party Book of Oz." Almost
+everyone loves a party, and when Ozma has a birthday party with
+notables from every part of fairyland attending--well! It is just like
+attending Ozma's party in person. You meet the famous of Oz, and lots
+of others, such as Queen Zixi of Ix, John Dough, Chick the Cherub, the
+Queen of Merryland, Para Bruin the rubber bear and--best of all--Santa
+Claus himself! Of course there are lots of adventures on that famous
+road to Oz before the party, during which Dorothy, on her way to Oz for
+the fourth time, meets such heart-warming characters as the Shaggy Man,
+Button-Bright, and lovely Polychrome, daughter of the rainbow.
+
+
+_The Emerald City of Oz_
+
+Here is a "double" story of Oz. While Dorothy, her Aunt Em and Uncle
+Henry experience the events that lead to their going to Oz to make
+their home in the Emerald City, the wicked Nome King is plotting to
+conquer Oz and enslave its people. Later we go with Dorothy and her
+friends in the Red Wagon on a grand tour of Oz that is simply packed
+with excitement and events. While this transpires, we learn also of the
+Nome King's elaborate preparations to conquer Oz. As Dorothy and her
+friends return to the Emerald City, the Nome King and his hordes of
+warriors are about to invade it. How Oz is saved is an ending that will
+amaze and delight you.
+
+
+_The Patchwork Girl of Oz_
+
+Here, the Patchwork Girl is brought to life by Dr. Pipt's magic Powder
+of Life. From that moment on the action never slows down in this
+exciting book. It tells of Ojo's quest for the strange ingredients
+necessary to brew a magic liquid that will release his Unk Nunkie from
+a spell--the spell cast by the Liquid of Petrifaction, which has turned
+him into a marble statue. In addition to the Patchwork Girl, Ojo and
+Unk Nunkie, this book introduces those famous Oz creatures, the Woozy,
+and Bungle the glass cat. Oz certainly has become a merrier, happier
+land since the Patchwork Girl came to life, and this is the book that
+tells how Scraps came to be made, how she was brought to life, and all
+about her early adventures.
+
+
+_Tik-Tok of Oz_
+
+For the second time a little girl from the United States comes to Oz.
+Betsy Bobbin is shipwrecked in the Nonestic Ocean with her friend Hank
+the mule. The two drift to shore in the Rose Kingdom on a fragment of
+wreckage. Betsy meets the Shaggy Man and accompanies him to the Nome
+Kingdom, where Shaggy hopes to release his brother, a prisoner of the
+Nome King. On their way to the Nome Kingdom, one fascinating adventure
+follows another. They meet Queen Ann Soforth of Oogaboo and her army,
+and lovely Polychrome, who had lost her rainbow again; they rescue
+Tik-Tok from a well; and are dropped through a Hollow Tube to the other
+side of the world where they meet Quox, the dragon. You'll find it one
+of the most exciting of all the Oz books.
+
+
+_The Scarecrow of Oz_
+
+This is the Oz book which L. Frank Baum considered his best. It starts
+quietly enough with Trot and Cap'n Bill rowing along a shore of the
+Pacific Ocean to visit one of the many caves near their home on the
+California coast. Suddenly, a mighty whirlpool engulfs them. The
+old sailorman and the little girl are miraculously saved and regain
+consciousness to find themselves in a sea cavern. (To this day, Trot
+asserts she felt mermaid arms about her during those terrible moments
+under water.) From here on, one perilous adventure crowds in upon
+another. In Jinxland they meet the Scarecrow who takes charge of things
+once Cap'n Bill is transformed into a tiny grasshopper with a wooden
+leg. An exciting royal reception greets the adventurers upon their
+return to the Emerald City.
+
+
+_Rinkitink in Oz_
+
+Prince Inga of Pingaree is the boy hero of this fine story of
+peril-filled adventure in the islands of the Nonestic Ocean. King
+Rinkitink provides comic relief, and by the time you reach the final
+page you will love this fat, jolly little king. Bilbil the goat,
+with his surly disposition, provides a fine contrast to Rinkitink's
+merriment and Prince Inga's bravery and courage in the face of
+danger. Some may say that the three magic pearls are the real heroes
+of this story, but the pearls would have been of little use to King
+Kitticut and Queen Garee if Prince Inga hadn't used them wisely and
+courageously.
+
+
+_The Lost Princess of Oz_
+
+Talk about _Button-Bright_ getting lost--_Ozma_ is almost as bad! This
+is actually the second time Ozma has been lost. As you know, once
+she was "lost" for many years. But in this book she is lost for only
+a short time. As soon as it is discovered that the ruler of Oz is
+lost--and with her all the important magical instruments in Oz--search
+parties, one for each of the four countries of Oz, set out to find her.
+We follow the adventures of the party headed by Dorothy and the Wizard,
+who explore unknown parts of the Winkie Country in search of Ozma. How
+Ozma is found, and where she has been, will surprise you. Frogman, a
+new character, is introduced in this book.
+
+
+_The Tin Woodman of Oz_
+
+Woot the Wanderer causes this chapter of Oz history to transpire. When
+Woot wanders into the splendid tin castle of Nick Chopper, the Tin
+Woodman and Emperor of the Winkies, he meets the Scarecrow, who is
+visiting his old friend. The Tin Woodman tells Woot the story of how
+he had once been a flesh-and-blood woodman in love with a maiden named
+Nimmie Aimee. Woot suggests that since the Tin Woodman now has a kind
+and loving heart, it is his duty to find Nimmie Aimee and make her
+Empress of the Winkies. The Scarecrow agrees, so the three set off to
+search for the girl. No less surprising than the adventures encountered
+on the journey is Nimmie Aimee's reception of her former suitor.
+
+
+_The Magic of Oz_
+
+Old Ruggedo, the former Nome King, comes to Oz for the second time,
+and makes more trouble than he did on his first visit. Ruggedo never
+gives up the idea of conquering Oz, and this time he has the advantage
+of being in the country without Ozma's knowledge. Also, he has the
+magic and somewhat grudging help of Kiki Aru, the Munchkin boy who
+is illegally practicing the art. If you like magic, then this is a
+book for you. There's magic on every page, and everyone in the story
+eventually is transformed into something else, or bewitched in one way
+or another. Even the wild animals in the great Forest of Gugu do not
+escape.
+
+
+_Glinda of Oz_
+
+This is the last Oz book written by L. Frank Baum. It is one of the
+best in the series, with Dorothy, Ozma, and Glinda in an adventure that
+takes them to an amazing crystal-domed city on an enchanted island.
+This island is situated in a lake in the Gillikin Country. Ozma and
+Glinda are confronted by powerful magic and determined enemies. For a
+time Dorothy and Ozma are prisoners in the crystal-domed city which is
+able to submerge below the surface of the lake. Few of the Oz books
+equal this one in suspense and mystery--a story that is truly "out of
+this world."
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+[Illustration]
+
+       *       *       *       *       *
+  +---------------------------------------------------------------------+
+  |                                                                     |
+  |                       Transcriber notes:                            |
+  |                                                                     |
+  | P.6. 'ecstacy.' changed to 'ecstasy.'                               |
+  | P.208. 'nickle-plate' changed to 'nickel-plate'                     |
+  | P.285. 'Liquid of Petrefaction' changed to 'Liquid of Petrifaction'.|
+  | Taken hypen out of pumpkinhead or pumpkinheads.                     |
+  | Fixed various punctuation.                                          |
+  |                                                                     |
+  | Text surrounded by _this_ indicated italics, and text surrounded    |
+  |   by =this= indicates bold.                                         |
+  |                                                                     |
+  +---------------------------------------------------------------------+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Land of Oz, by L. Frank Baum
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE LAND OF OZ ***
+
+***** This file should be named 53844-8.txt or 53844-8.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/5/3/8/4/53844/
+
+Produced by Jane Robins and the Online Distributed
+Proofreading Team at http://www.pgdp.net (This file was
+produced from images generously made available by The
+Internet Archive)
+
+Updated editions will replace the previous one--the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg-tm electronic works to protect the PROJECT GUTENBERG-tm
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for the eBooks, unless you receive
+specific permission. If you do not charge anything for copies of this
+eBook, complying with the rules is very easy. You may use this eBook
+for nearly any purpose such as creation of derivative works, reports,
+performances and research. They may be modified and printed and given
+away--you may do practically ANYTHING in the United States with eBooks
+not protected by U.S. copyright law. Redistribution is subject to the
+trademark license, especially commercial redistribution.
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project
+Gutenberg-tm electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg-tm electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg-tm electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the
+person or entity to whom you paid the fee as set forth in paragraph
+1.E.8.
+
+1.B. "Project Gutenberg" is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg-tm
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation ("the
+Foundation" or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg-tm electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg-tm mission of promoting
+free access to electronic works by freely sharing Project Gutenberg-tm
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg-tm name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg-tm License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg-tm work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country outside the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg-tm License must appear
+prominently whenever any copy of a Project Gutenberg-tm work (any work
+on which the phrase "Project Gutenberg" appears, or with which the
+phrase "Project Gutenberg" is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+  This eBook is for the use of anyone anywhere in the United States and
+  most other parts of the world at no cost and with almost no
+  restrictions whatsoever. You may copy it, give it away or re-use it
+  under the terms of the Project Gutenberg License included with this
+  eBook or online at www.gutenberg.org. If you are not located in the
+  United States, you'll have to check the laws of the country where you
+  are located before using this ebook.
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase "Project
+Gutenberg" associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg-tm
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg-tm License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg-tm work in a format
+other than "Plain Vanilla ASCII" or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original "Plain
+Vanilla ASCII" or other form. Any alternate format must include the
+full Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works
+provided that
+
+* You pay a royalty fee of 20% of the gross profits you derive from
+  the use of Project Gutenberg-tm works calculated using the method
+  you already use to calculate your applicable taxes. The fee is owed
+  to the owner of the Project Gutenberg-tm trademark, but he has
+  agreed to donate royalties under this paragraph to the Project
+  Gutenberg Literary Archive Foundation. Royalty payments must be paid
+  within 60 days following each date on which you prepare (or are
+  legally required to prepare) your periodic tax returns. Royalty
+  payments should be clearly marked as such and sent to the Project
+  Gutenberg Literary Archive Foundation at the address specified in
+  Section 4, "Information about donations to the Project Gutenberg
+  Literary Archive Foundation."
+
+* You provide a full refund of any money paid by a user who notifies
+  you in writing (or by e-mail) within 30 days of receipt that s/he
+  does not agree to the terms of the full Project Gutenberg-tm
+  License. You must require such a user to return or destroy all
+  copies of the works possessed in a physical medium and discontinue
+  all use of and all access to other copies of Project Gutenberg-tm
+  works.
+
+* You provide, in accordance with paragraph 1.F.3, a full refund of
+  any money paid for a work or a replacement copy, if a defect in the
+  electronic work is discovered and reported to you within 90 days of
+  receipt of the work.
+
+* You comply with all other terms of this agreement for free
+  distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg-tm electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from both the Project Gutenberg Literary Archive Foundation and The
+Project Gutenberg Trademark LLC, the owner of the Project Gutenberg-tm
+trademark. Contact the Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg-tm collection. Despite these efforts, Project Gutenberg-tm
+electronic works, and the medium on which they may be stored, may
+contain "Defects," such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg-tm
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg-tm work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg-tm work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at
+www.gutenberg.org
+
+
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation's EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state's laws.
+
+The Foundation's principal office is in Fairbanks, Alaska, with the
+mailing address: PO Box 750175, Fairbanks, AK 99775, but its
+volunteers and employees are scattered throughout numerous
+locations. Its business office is located at 809 North 1500 West, Salt
+Lake City, UT 84116, (801) 596-1887. Email contact links and up to
+date contact information can be found at the Foundation's web site and
+official page at www.gutenberg.org/contact
+
+For additional contact information:
+
+    Dr. Gregory B. Newby
+    Chief Executive and Director
+    gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular
+state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic works.
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg-tm concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg-tm eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our Web site which has the main PG search
+facility: www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/madame-bovary.txt
+++ b/jet/tf-idf/src/main/resources/books/madame-bovary.txt
@@ -1,0 +1,13856 @@
+﻿The Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Madame Bovary
+
+Author: Gustave Flaubert
+
+Translator: Eleanor Marx-Aveling
+
+Release Date: February 25, 2006 [EBook #2413]
+Last Updated: September 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+
+
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+
+
+
+
+MADAME BOVARY
+
+By Gustave Flaubert
+
+Translated from the French by Eleanor Marx-Aveling
+
+
+To Marie-Antoine-Jules Senard Member of the Paris Bar, Ex-President
+of the National Assembly, and Former Minister of the Interior Dear and
+Illustrious Friend, Permit me to inscribe your name at the head of this
+book, and above its dedication; for it is to you, before all, that I
+owe its publication. Reading over your magnificent defence, my work has
+acquired for myself, as it were, an unexpected authority.
+
+Accept, then, here, the homage of my gratitude, which, how great soever
+it is, will never attain the height of your eloquence and your devotion.
+
+Gustave Flaubert Paris, 12 April 1857
+
+
+
+
+MADAME BOVARY
+
+
+
+
+Part I
+
+
+
+Chapter One
+
+We were in class when the head-master came in, followed by a “new
+fellow,” not wearing the school uniform, and a school servant carrying a
+large desk. Those who had been asleep woke up, and every one rose as if
+just surprised at his work.
+
+The head-master made a sign to us to sit down. Then, turning to the
+class-master, he said to him in a low voice--
+
+“Monsieur Roger, here is a pupil whom I recommend to your care; he’ll be
+in the second. If his work and conduct are satisfactory, he will go into
+one of the upper classes, as becomes his age.”
+
+The “new fellow,” standing in the corner behind the door so that he
+could hardly be seen, was a country lad of about fifteen, and taller
+than any of us. His hair was cut square on his forehead like a village
+chorister’s; he looked reliable, but very ill at ease. Although he was
+not broad-shouldered, his short school jacket of green cloth with black
+buttons must have been tight about the arm-holes, and showed at the
+opening of the cuffs red wrists accustomed to being bare. His legs, in
+blue stockings, looked out from beneath yellow trousers, drawn tight by
+braces, He wore stout, ill-cleaned, hob-nailed boots.
+
+We began repeating the lesson. He listened with all his ears, as
+attentive as if at a sermon, not daring even to cross his legs or lean
+on his elbow; and when at two o’clock the bell rang, the master was
+obliged to tell him to fall into line with the rest of us.
+
+When we came back to work, we were in the habit of throwing our caps on
+the ground so as to have our hands more free; we used from the door to
+toss them under the form, so that they hit against the wall and made a
+lot of dust: it was “the thing.”
+
+But, whether he had not noticed the trick, or did not dare to attempt
+it, the “new fellow,” was still holding his cap on his knees even after
+prayers were over. It was one of those head-gears of composite order, in
+which we can find traces of the bearskin, shako, billycock hat, sealskin
+cap, and cotton night-cap; one of those poor things, in fine, whose
+dumb ugliness has depths of expression, like an imbecile’s face. Oval,
+stiffened with whalebone, it began with three round knobs; then came in
+succession lozenges of velvet and rabbit-skin separated by a red band;
+after that a sort of bag that ended in a cardboard polygon covered with
+complicated braiding, from which hung, at the end of a long thin cord,
+small twisted gold threads in the manner of a tassel. The cap was new;
+its peak shone.
+
+“Rise,” said the master.
+
+He stood up; his cap fell. The whole class began to laugh. He stooped to
+pick it up. A neighbor knocked it down again with his elbow; he picked
+it up once more.
+
+“Get rid of your helmet,” said the master, who was a bit of a wag.
+
+There was a burst of laughter from the boys, which so thoroughly put the
+poor lad out of countenance that he did not know whether to keep his cap
+in his hand, leave it on the ground, or put it on his head. He sat down
+again and placed it on his knee.
+
+“Rise,” repeated the master, “and tell me your name.”
+
+The new boy articulated in a stammering voice an unintelligible name.
+
+“Again!”
+
+The same sputtering of syllables was heard, drowned by the tittering of
+the class.
+
+“Louder!” cried the master; “louder!”
+
+The “new fellow” then took a supreme resolution, opened an inordinately
+large mouth, and shouted at the top of his voice as if calling someone
+in the word “Charbovari.”
+
+A hubbub broke out, rose in crescendo with bursts of shrill voices (they
+yelled, barked, stamped, repeated “Charbovari! Charbovari”), then died
+away into single notes, growing quieter only with great difficulty, and
+now and again suddenly recommencing along the line of a form whence rose
+here and there, like a damp cracker going off, a stifled laugh.
+
+However, amid a rain of impositions, order was gradually re-established
+in the class; and the master having succeeded in catching the name of
+“Charles Bovary,” having had it dictated to him, spelt out, and re-read,
+at once ordered the poor devil to go and sit down on the punishment form
+at the foot of the master’s desk. He got up, but before going hesitated.
+
+“What are you looking for?” asked the master.
+
+“My c-a-p,” timidly said the “new fellow,” casting troubled looks round
+him.
+
+“Five hundred lines for all the class!” shouted in a furious voice
+stopped, like the Quos ego*, a fresh outburst. “Silence!” continued the
+master indignantly, wiping his brow with his handkerchief, which he
+had just taken from his cap. “As to you, ‘new boy,’ you will conjugate
+‘ridiculus sum’ ** twenty times.”
+
+Then, in a gentler tone, “Come, you’ll find your cap again; it hasn’t
+been stolen.”
+
+     *A quotation from the Aeneid signifying a threat.
+
+     **I am ridiculous.
+
+Quiet was restored. Heads bent over desks, and the “new fellow” remained
+for two hours in an exemplary attitude, although from time to time some
+paper pellet flipped from the tip of a pen came bang in his face. But he
+wiped his face with one hand and continued motionless, his eyes lowered.
+
+In the evening, at preparation, he pulled out his pens from his desk,
+arranged his small belongings, and carefully ruled his paper. We saw him
+working conscientiously, looking up every word in the dictionary, and
+taking the greatest pains. Thanks, no doubt, to the willingness he
+showed, he had not to go down to the class below. But though he knew his
+rules passably, he had little finish in composition. It was the cure
+of his village who had taught him his first Latin; his parents, from
+motives of economy, having sent him to school as late as possible.
+
+His father, Monsieur Charles Denis Bartolome Bovary, retired
+assistant-surgeon-major, compromised about 1812 in certain conscription
+scandals, and forced at this time to leave the service, had taken
+advantage of his fine figure to get hold of a dowry of sixty thousand
+francs that offered in the person of a hosier’s daughter who had fallen
+in love with his good looks. A fine man, a great talker, making his
+spurs ring as he walked, wearing whiskers that ran into his moustache,
+his fingers always garnished with rings and dressed in loud colours,
+he had the dash of a military man with the easy go of a commercial
+traveller.
+
+Once married, he lived for three or four years on his wife’s fortune,
+dining well, rising late, smoking long porcelain pipes, not coming in
+at night till after the theatre, and haunting cafes. The father-in-law
+died, leaving little; he was indignant at this, “went in for the
+business,” lost some money in it, then retired to the country, where he
+thought he would make money.
+
+But, as he knew no more about farming than calico, as he rode his horses
+instead of sending them to plough, drank his cider in bottle instead of
+selling it in cask, ate the finest poultry in his farmyard, and greased
+his hunting-boots with the fat of his pigs, he was not long in finding
+out that he would do better to give up all speculation.
+
+For two hundred francs a year he managed to live on the border of
+the provinces of Caux and Picardy, in a kind of place half farm, half
+private house; and here, soured, eaten up with regrets, cursing his
+luck, jealous of everyone, he shut himself up at the age of forty-five,
+sick of men, he said, and determined to live at peace.
+
+His wife had adored him once on a time; she had bored him with a
+thousand servilities that had only estranged him the more. Lively once,
+expansive and affectionate, in growing older she had become (after the
+fashion of wine that, exposed to air, turns to vinegar) ill-tempered,
+grumbling, irritable. She had suffered so much without complaint at
+first, until she had seem him going after all the village drabs, and
+until a score of bad houses sent him back to her at night, weary,
+stinking drunk. Then her pride revolted. After that she was silent,
+burying her anger in a dumb stoicism that she maintained till her death.
+She was constantly going about looking after business matters. She
+called on the lawyers, the president, remembered when bills fell due,
+got them renewed, and at home ironed, sewed, washed, looked after the
+workmen, paid the accounts, while he, troubling himself about nothing,
+eternally besotted in sleepy sulkiness, whence he only roused himself
+to say disagreeable things to her, sat smoking by the fire and spitting
+into the cinders.
+
+When she had a child, it had to be sent out to nurse. When he came home,
+the lad was spoilt as if he were a prince. His mother stuffed him
+with jam; his father let him run about barefoot, and, playing the
+philosopher, even said he might as well go about quite naked like the
+young of animals. As opposed to the maternal ideas, he had a certain
+virile idea of childhood on which he sought to mould his son, wishing
+him to be brought up hardily, like a Spartan, to give him a strong
+constitution. He sent him to bed without any fire, taught him to drink
+off large draughts of rum and to jeer at religious processions. But,
+peaceable by nature, the lad answered only poorly to his notions. His
+mother always kept him near her; she cut out cardboard for him, told him
+tales, entertained him with endless monologues full of melancholy gaiety
+and charming nonsense. In her life’s isolation she centered on the
+child’s head all her shattered, broken little vanities. She dreamed of
+high station; she already saw him, tall, handsome, clever, settled as
+an engineer or in the law. She taught him to read, and even, on an old
+piano, she had taught him two or three little songs. But to all this
+Monsieur Bovary, caring little for letters, said, “It was not worth
+while. Would they ever have the means to send him to a public school, to
+buy him a practice, or start him in business? Besides, with cheek a man
+always gets on in the world.” Madame Bovary bit her lips, and the child
+knocked about the village.
+
+He went after the labourers, drove away with clods of earth the ravens
+that were flying about. He ate blackberries along the hedges, minded the
+geese with a long switch, went haymaking during harvest, ran about in
+the woods, played hop-scotch under the church porch on rainy days, and
+at great fetes begged the beadle to let him toll the bells, that he
+might hang all his weight on the long rope and feel himself borne upward
+by it in its swing. Meanwhile he grew like an oak; he was strong on
+hand, fresh of colour.
+
+When he was twelve years old his mother had her own way; he began
+lessons. The cure took him in hand; but the lessons were so short and
+irregular that they could not be of much use. They were given at spare
+moments in the sacristy, standing up, hurriedly, between a baptism and
+a burial; or else the cure, if he had not to go out, sent for his pupil
+after the Angelus*. They went up to his room and settled down; the
+flies and moths fluttered round the candle. It was close, the child
+fell asleep, and the good man, beginning to doze with his hands on his
+stomach, was soon snoring with his mouth wide open. On other occasions,
+when Monsieur le Cure, on his way back after administering the viaticum
+to some sick person in the neighbourhood, caught sight of Charles
+playing about the fields, he called him, lectured him for a quarter of
+an hour and took advantage of the occasion to make him conjugate his
+verb at the foot of a tree. The rain interrupted them or an acquaintance
+passed. All the same he was always pleased with him, and even said the
+“young man” had a very good memory.
+
+     *A devotion said at morning, noon, and evening, at the sound
+     of a bell. Here, the evening prayer.
+
+Charles could not go on like this. Madame Bovary took strong steps.
+Ashamed, or rather tired out, Monsieur Bovary gave in without a
+struggle, and they waited one year longer, so that the lad should take
+his first communion.
+
+Six months more passed, and the year after Charles was finally sent to
+school at Rouen, where his father took him towards the end of October,
+at the time of the St. Romain fair.
+
+It would now be impossible for any of us to remember anything about him.
+He was a youth of even temperament, who played in playtime, worked in
+school-hours, was attentive in class, slept well in the dormitory,
+and ate well in the refectory. He had in loco parentis* a wholesale
+ironmonger in the Rue Ganterie, who took him out once a month on Sundays
+after his shop was shut, sent him for a walk on the quay to look at
+the boats, and then brought him back to college at seven o’clock before
+supper. Every Thursday evening he wrote a long letter to his mother with
+red ink and three wafers; then he went over his history note-books, or
+read an old volume of “Anarchasis” that was knocking about the study.
+When he went for walks he talked to the servant, who, like himself, came
+from the country.
+
+     *In place of a parent.
+
+By dint of hard work he kept always about the middle of the class; once
+even he got a certificate in natural history. But at the end of his
+third year his parents withdrew him from the school to make him study
+medicine, convinced that he could even take his degree by himself.
+
+His mother chose a room for him on the fourth floor of a dyer’s she
+knew, overlooking the Eau-de-Robec. She made arrangements for his
+board, got him furniture, table and two chairs, sent home for an old
+cherry-tree bedstead, and bought besides a small cast-iron stove with
+the supply of wood that was to warm the poor child.
+
+Then at the end of a week she departed, after a thousand injunctions to
+be good now that he was going to be left to himself.
+
+The syllabus that he read on the notice-board stunned him; lectures
+on anatomy, lectures on pathology, lectures on physiology, lectures on
+pharmacy, lectures on botany and clinical medicine, and therapeutics,
+without counting hygiene and materia medica--all names of whose
+etymologies he was ignorant, and that were to him as so many doors to
+sanctuaries filled with magnificent darkness.
+
+He understood nothing of it all; it was all very well to listen--he did
+not follow. Still he worked; he had bound note-books, he attended all
+the courses, never missed a single lecture. He did his little daily task
+like a mill-horse, who goes round and round with his eyes bandaged, not
+knowing what work he is doing.
+
+To spare him expense his mother sent him every week by the carrier a
+piece of veal baked in the oven, with which he lunched when he came back
+from the hospital, while he sat kicking his feet against the wall.
+After this he had to run off to lectures, to the operation-room, to the
+hospital, and return to his home at the other end of the town. In the
+evening, after the poor dinner of his landlord, he went back to his
+room and set to work again in his wet clothes, which smoked as he sat in
+front of the hot stove.
+
+On the fine summer evenings, at the time when the close streets are
+empty, when the servants are playing shuttle-cock at the doors, he
+opened his window and leaned out. The river, that makes of this quarter
+of Rouen a wretched little Venice, flowed beneath him, between the
+bridges and the railings, yellow, violet, or blue. Working men, kneeling
+on the banks, washed their bare arms in the water. On poles projecting
+from the attics, skeins of cotton were drying in the air. Opposite,
+beyond the roots spread the pure heaven with the red sun setting. How
+pleasant it must be at home! How fresh under the beech-tree! And he
+expanded his nostrils to breathe in the sweet odours of the country
+which did not reach him.
+
+He grew thin, his figure became taller, his face took a saddened look
+that made it nearly interesting. Naturally, through indifference, he
+abandoned all the resolutions he had made. Once he missed a lecture; the
+next day all the lectures; and, enjoying his idleness, little by little,
+he gave up work altogether. He got into the habit of going to the
+public-house, and had a passion for dominoes. To shut himself up every
+evening in the dirty public room, to push about on marble tables the
+small sheep bones with black dots, seemed to him a fine proof of his
+freedom, which raised him in his own esteem. It was beginning to see
+life, the sweetness of stolen pleasures; and when he entered, he put
+his hand on the door-handle with a joy almost sensual. Then many things
+hidden within him came out; he learnt couplets by heart and sang them to
+his boon companions, became enthusiastic about Beranger, learnt how to
+make punch, and, finally, how to make love.
+
+Thanks to these preparatory labours, he failed completely in his
+examination for an ordinary degree. He was expected home the same night
+to celebrate his success. He started on foot, stopped at the beginning
+of the village, sent for his mother, and told her all. She excused
+him, threw the blame of his failure on the injustice of the examiners,
+encouraged him a little, and took upon herself to set matters straight.
+It was only five years later that Monsieur Bovary knew the truth; it was
+old then, and he accepted it. Moreover, he could not believe that a man
+born of him could be a fool.
+
+So Charles set to work again and crammed for his examination,
+ceaselessly learning all the old questions by heart. He passed pretty
+well. What a happy day for his mother! They gave a grand dinner.
+
+Where should he go to practice? To Tostes, where there was only one old
+doctor. For a long time Madame Bovary had been on the look-out for his
+death, and the old fellow had barely been packed off when Charles was
+installed, opposite his place, as his successor.
+
+But it was not everything to have brought up a son, to have had him
+taught medicine, and discovered Tostes, where he could practice it;
+he must have a wife. She found him one--the widow of a bailiff at
+Dieppe--who was forty-five and had an income of twelve hundred francs.
+Though she was ugly, as dry as a bone, her face with as many pimples as
+the spring has buds, Madame Dubuc had no lack of suitors. To attain her
+ends Madame Bovary had to oust them all, and she even succeeded in
+very cleverly baffling the intrigues of a port-butcher backed up by the
+priests.
+
+Charles had seen in marriage the advent of an easier life, thinking he
+would be more free to do as he liked with himself and his money. But his
+wife was master; he had to say this and not say that in company, to fast
+every Friday, dress as she liked, harass at her bidding those patients
+who did not pay. She opened his letter, watched his comings and goings,
+and listened at the partition-wall when women came to consult him in his
+surgery.
+
+She must have her chocolate every morning, attentions without end. She
+constantly complained of her nerves, her chest, her liver. The noise of
+footsteps made her ill; when people left her, solitude became odious to
+her; if they came back, it was doubtless to see her die. When Charles
+returned in the evening, she stretched forth two long thin arms from
+beneath the sheets, put them round his neck, and having made him sit
+down on the edge of the bed, began to talk to him of her troubles: he
+was neglecting her, he loved another. She had been warned she would be
+unhappy; and she ended by asking him for a dose of medicine and a little
+more love.
+
+
+
+Chapter Two
+
+One night towards eleven o’clock they were awakened by the noise of
+a horse pulling up outside their door. The servant opened the
+garret-window and parleyed for some time with a man in the street below.
+He came for the doctor, had a letter for him. Natasie came downstairs
+shivering and undid the bars and bolts one after the other. The man left
+his horse, and, following the servant, suddenly came in behind her. He
+pulled out from his wool cap with grey top-knots a letter wrapped up in
+a rag and presented it gingerly to Charles, who rested on his elbow on
+the pillow to read it. Natasie, standing near the bed, held the light.
+Madame in modesty had turned to the wall and showed only her back.
+
+This letter, sealed with a small seal in blue wax, begged Monsieur
+Bovary to come immediately to the farm of the Bertaux to set a broken
+leg. Now from Tostes to the Bertaux was a good eighteen miles across
+country by way of Longueville and Saint-Victor. It was a dark night;
+Madame Bovary junior was afraid of accidents for her husband. So it was
+decided the stable-boy should go on first; Charles would start three
+hours later when the moon rose. A boy was to be sent to meet him, and
+show him the way to the farm, and open the gates for him.
+
+Towards four o’clock in the morning, Charles, well wrapped up in his
+cloak, set out for the Bertaux. Still sleepy from the warmth of his bed,
+he let himself be lulled by the quiet trot of his horse. When it stopped
+of its own accord in front of those holes surrounded with thorns that
+are dug on the margin of furrows, Charles awoke with a start, suddenly
+remembered the broken leg, and tried to call to mind all the fractures
+he knew. The rain had stopped, day was breaking, and on the branches
+of the leafless trees birds roosted motionless, their little feathers
+bristling in the cold morning wind. The flat country stretched as far as
+eye could see, and the tufts of trees round the farms at long intervals
+seemed like dark violet stains on the cast grey surface, that on the
+horizon faded into the gloom of the sky.
+
+Charles from time to time opened his eyes, his mind grew weary, and,
+sleep coming upon him, he soon fell into a doze wherein, his recent
+sensations blending with memories, he became conscious of a double
+self, at once student and married man, lying in his bed as but now, and
+crossing the operation theatre as of old. The warm smell of poultices
+mingled in his brain with the fresh odour of dew; he heard the iron
+rings rattling along the curtain-rods of the bed and saw his wife
+sleeping. As he passed Vassonville he came upon a boy sitting on the
+grass at the edge of a ditch.
+
+“Are you the doctor?” asked the child.
+
+And on Charles’s answer he took his wooden shoes in his hands and ran on
+in front of him.
+
+The general practitioner, riding along, gathered from his guide’s talk
+that Monsieur Rouault must be one of the well-to-do farmers.
+
+He had broken his leg the evening before on his way home from a
+Twelfth-night feast at a neighbour’s. His wife had been dead for two
+years. There was with him only his daughter, who helped him to keep
+house.
+
+The ruts were becoming deeper; they were approaching the Bertaux.
+
+The little lad, slipping through a hole in the hedge, disappeared;
+then he came back to the end of a courtyard to open the gate. The
+horse slipped on the wet grass; Charles had to stoop to pass under
+the branches. The watchdogs in their kennels barked, dragging at their
+chains. As he entered the Bertaux, the horse took fright and stumbled.
+
+It was a substantial-looking farm. In the stables, over the top of the
+open doors, one could see great cart-horses quietly feeding from new
+racks. Right along the outbuildings extended a large dunghill, from
+which manure liquid oozed, while amidst fowls and turkeys, five or six
+peacocks, a luxury in Chauchois farmyards, were foraging on the top of
+it. The sheepfold was long, the barn high, with walls smooth as your
+hand. Under the cart-shed were two large carts and four ploughs, with
+their whips, shafts and harnesses complete, whose fleeces of blue wool
+were getting soiled by the fine dust that fell from the granaries. The
+courtyard sloped upwards, planted with trees set out symmetrically, and
+the chattering noise of a flock of geese was heard near the pond.
+
+A young woman in a blue merino dress with three flounces came to the
+threshold of the door to receive Monsieur Bovary, whom she led to the
+kitchen, where a large fire was blazing. The servant’s breakfast was
+boiling beside it in small pots of all sizes. Some damp clothes were
+drying inside the chimney-corner. The shovel, tongs, and the nozzle
+of the bellows, all of colossal size, shone like polished steel, while
+along the walls hung many pots and pans in which the clear flame of the
+hearth, mingling with the first rays of the sun coming in through the
+window, was mirrored fitfully.
+
+Charles went up the first floor to see the patient. He found him in his
+bed, sweating under his bed-clothes, having thrown his cotton nightcap
+right away from him. He was a fat little man of fifty, with white skin
+and blue eyes, the forepart of his head bald, and he wore earrings. By
+his side on a chair stood a large decanter of brandy, whence he poured
+himself a little from time to time to keep up his spirits; but as soon
+as he caught sight of the doctor his elation subsided, and instead of
+swearing, as he had been doing for the last twelve hours, began to groan
+freely.
+
+The fracture was a simple one, without any kind of complication.
+
+Charles could not have hoped for an easier case. Then calling to mind
+the devices of his masters at the bedsides of patients, he comforted the
+sufferer with all sorts of kindly remarks, those caresses of the surgeon
+that are like the oil they put on bistouries. In order to make some
+splints a bundle of laths was brought up from the cart-house. Charles
+selected one, cut it into two pieces and planed it with a fragment
+of windowpane, while the servant tore up sheets to make bandages, and
+Mademoiselle Emma tried to sew some pads. As she was a long time before
+she found her work-case, her father grew impatient; she did not answer,
+but as she sewed she pricked her fingers, which she then put to her
+mouth to suck them. Charles was surprised at the whiteness of her nails.
+They were shiny, delicate at the tips, more polished than the ivory of
+Dieppe, and almond-shaped. Yet her hand was not beautiful, perhaps not
+white enough, and a little hard at the knuckles; besides, it was too
+long, with no soft inflections in the outlines. Her real beauty was in
+her eyes. Although brown, they seemed black because of the lashes, and
+her look came at you frankly, with a candid boldness.
+
+The bandaging over, the doctor was invited by Monsieur Rouault himself
+to “pick a bit” before he left.
+
+Charles went down into the room on the ground floor. Knives and forks
+and silver goblets were laid for two on a little table at the foot of a
+huge bed that had a canopy of printed cotton with figures representing
+Turks. There was an odour of iris-root and damp sheets that escaped
+from a large oak chest opposite the window. On the floor in corners were
+sacks of flour stuck upright in rows. These were the overflow from
+the neighbouring granary, to which three stone steps led. By way of
+decoration for the apartment, hanging to a nail in the middle of the
+wall, whose green paint scaled off from the effects of the saltpetre,
+was a crayon head of Minerva in gold frame, underneath which was written
+in Gothic letters “To dear Papa.”
+
+First they spoke of the patient, then of the weather, of the great cold,
+of the wolves that infested the fields at night.
+
+Mademoiselle Rouault did not at all like the country, especially now
+that she had to look after the farm almost alone. As the room was
+chilly, she shivered as she ate. This showed something of her full lips,
+that she had a habit of biting when silent.
+
+Her neck stood out from a white turned-down collar. Her hair, whose
+two black folds seemed each of a single piece, so smooth were they, was
+parted in the middle by a delicate line that curved slightly with the
+curve of the head; and, just showing the tip of the ear, it was joined
+behind in a thick chignon, with a wavy movement at the temples that the
+country doctor saw now for the first time in his life. The upper part of
+her cheek was rose-coloured. She had, like a man, thrust in between two
+buttons of her bodice a tortoise-shell eyeglass.
+
+When Charles, after bidding farewell to old Rouault, returned to the
+room before leaving, he found her standing, her forehead against the
+window, looking into the garden, where the bean props had been knocked
+down by the wind. She turned round. “Are you looking for anything?” she
+asked.
+
+“My whip, if you please,” he answered.
+
+He began rummaging on the bed, behind the doors, under the chairs. It
+had fallen to the floor, between the sacks and the wall. Mademoiselle
+Emma saw it, and bent over the flour sacks.
+
+Charles out of politeness made a dash also, and as he stretched out his
+arm, at the same moment felt his breast brush against the back of the
+young girl bending beneath him. She drew herself up, scarlet, and looked
+at him over her shoulder as she handed him his whip.
+
+Instead of returning to the Bertaux in three days as he had promised,
+he went back the very next day, then regularly twice a week, without
+counting the visits he paid now and then as if by accident.
+
+Everything, moreover, went well; the patient progressed favourably; and
+when, at the end of forty-six days, old Rouault was seen trying to walk
+alone in his “den,” Monsieur Bovary began to be looked upon as a man
+of great capacity. Old Rouault said that he could not have been cured
+better by the first doctor of Yvetot, or even of Rouen.
+
+As to Charles, he did not stop to ask himself why it was a pleasure
+to him to go to the Bertaux. Had he done so, he would, no doubt, have
+attributed his zeal to the importance of the case, or perhaps to the
+money he hoped to make by it. Was it for this, however, that his visits
+to the farm formed a delightful exception to the meagre occupations of
+his life? On these days he rose early, set off at a gallop, urging on
+his horse, then got down to wipe his boots in the grass and put on black
+gloves before entering. He liked going into the courtyard, and noticing
+the gate turn against his shoulder, the cock crow on the wall, the lads
+run to meet him. He liked the granary and the stables; he liked old
+Rouault, who pressed his hand and called him his saviour; he liked the
+small wooden shoes of Mademoiselle Emma on the scoured flags of the
+kitchen--her high heels made her a little taller; and when she walked in
+front of him, the wooden soles springing up quickly struck with a sharp
+sound against the leather of her boots.
+
+She always accompanied him to the first step of the stairs. When his
+horse had not yet been brought round she stayed there. They had said
+“Good-bye”; there was no more talking. The open air wrapped her round,
+playing with the soft down on the back of her neck, or blew to and fro
+on her hips the apron-strings, that fluttered like streamers. Once,
+during a thaw the bark of the trees in the yard was oozing, the snow on
+the roofs of the outbuildings was melting; she stood on the threshold,
+and went to fetch her sunshade and opened it. The sunshade of silk of
+the colour of pigeons’ breasts, through which the sun shone, lighted
+up with shifting hues the white skin of her face. She smiled under the
+tender warmth, and drops of water could be heard falling one by one on
+the stretched silk.
+
+During the first period of Charles’s visits to the Bertaux, Madame
+Bovary junior never failed to inquire after the invalid, and she had
+even chosen in the book that she kept on a system of double entry a
+clean blank page for Monsieur Rouault. But when she heard he had a
+daughter, she began to make inquiries, and she learnt the Mademoiselle
+Rouault, brought up at the Ursuline Convent, had received what is called
+“a good education”; and so knew dancing, geography, drawing, how to
+embroider and play the piano. That was the last straw.
+
+“So it is for this,” she said to herself, “that his face beams when he
+goes to see her, and that he puts on his new waistcoat at the risk of
+spoiling it with the rain. Ah! that woman! That woman!”
+
+And she detested her instinctively. At first she solaced herself by
+allusions that Charles did not understand, then by casual observations
+that he let pass for fear of a storm, finally by open apostrophes to
+which he knew not what to answer. “Why did he go back to the Bertaux now
+that Monsieur Rouault was cured and that these folks hadn’t paid yet?
+Ah! it was because a young lady was there, some one who know how to
+talk, to embroider, to be witty. That was what he cared about; he wanted
+town misses.” And she went on--
+
+“The daughter of old Rouault a town miss! Get out! Their grandfather was
+a shepherd, and they have a cousin who was almost had up at the assizes
+for a nasty blow in a quarrel. It is not worth while making such a fuss,
+or showing herself at church on Sundays in a silk gown like a countess.
+Besides, the poor old chap, if it hadn’t been for the colza last year,
+would have had much ado to pay up his arrears.”
+
+For very weariness Charles left off going to the Bertaux. Heloise made
+him swear, his hand on the prayer-book, that he would go there no more
+after much sobbing and many kisses, in a great outburst of love. He
+obeyed then, but the strength of his desire protested against the
+servility of his conduct; and he thought, with a kind of naive
+hypocrisy, that his interdict to see her gave him a sort of right to
+love her. And then the widow was thin; she had long teeth; wore in all
+weathers a little black shawl, the edge of which hung down between her
+shoulder-blades; her bony figure was sheathed in her clothes as if they
+were a scabbard; they were too short, and displayed her ankles with the
+laces of her large boots crossed over grey stockings.
+
+Charles’s mother came to see them from time to time, but after a few
+days the daughter-in-law seemed to put her own edge on her, and
+then, like two knives, they scarified him with their reflections and
+observations. It was wrong of him to eat so much.
+
+Why did he always offer a glass of something to everyone who came?
+What obstinacy not to wear flannels! In the spring it came about that a
+notary at Ingouville, the holder of the widow Dubuc’s property, one fine
+day went off, taking with him all the money in his office. Heloise,
+it is true, still possessed, besides a share in a boat valued at six
+thousand francs, her house in the Rue St. Francois; and yet, with all
+this fortune that had been so trumpeted abroad, nothing, excepting
+perhaps a little furniture and a few clothes, had appeared in the
+household. The matter had to be gone into. The house at Dieppe was found
+to be eaten up with mortgages to its foundations; what she had placed
+with the notary God only knew, and her share in the boat did not exceed
+one thousand crowns. She had lied, the good lady! In his exasperation,
+Monsieur Bovary the elder, smashing a chair on the flags, accused his
+wife of having caused misfortune to the son by harnessing him to such
+a harridan, whose harness wasn’t worth her hide. They came to Tostes.
+Explanations followed. There were scenes. Heloise in tears, throwing her
+arms about her husband, implored him to defend her from his parents.
+
+Charles tried to speak up for her. They grew angry and left the house.
+
+But “the blow had struck home.” A week after, as she was hanging up some
+washing in her yard, she was seized with a spitting of blood, and
+the next day, while Charles had his back turned to her drawing the
+window-curtain, she said, “O God!” gave a sigh and fainted. She was
+dead! What a surprise! When all was over at the cemetery Charles went
+home. He found no one downstairs; he went up to the first floor to
+their room; saw her dress still hanging at the foot of the alcove; then,
+leaning against the writing-table, he stayed until the evening, buried
+in a sorrowful reverie. She had loved him after all!
+
+
+
+Chapter Three
+
+One morning old Rouault brought Charles the money for setting his
+leg--seventy-five francs in forty-sou pieces, and a turkey. He had heard
+of his loss, and consoled him as well as he could.
+
+“I know what it is,” said he, clapping him on the shoulder; “I’ve been
+through it. When I lost my dear departed, I went into the fields to be
+quite alone. I fell at the foot of a tree; I cried; I called on God; I
+talked nonsense to Him. I wanted to be like the moles that I saw on the
+branches, their insides swarming with worms, dead, and an end of it.
+And when I thought that there were others at that very moment with their
+nice little wives holding them in their embrace, I struck great blows on
+the earth with my stick. I was pretty well mad with not eating; the very
+idea of going to a cafe disgusted me--you wouldn’t believe it. Well,
+quite softly, one day following another, a spring on a winter, and an
+autumn after a summer, this wore away, piece by piece, crumb by crumb;
+it passed away, it is gone, I should say it has sunk; for something
+always remains at the bottom as one would say--a weight here, at one’s
+heart. But since it is the lot of all of us, one must not give way
+altogether, and, because others have died, want to die too. You must
+pull yourself together, Monsieur Bovary. It will pass away. Come to see
+us; my daughter thinks of you now and again, d’ye know, and she says
+you are forgetting her. Spring will soon be here. We’ll have some
+rabbit-shooting in the warrens to amuse you a bit.”
+
+Charles followed his advice. He went back to the Bertaux. He found all
+as he had left it, that is to say, as it was five months ago. The pear
+trees were already in blossom, and Farmer Rouault, on his legs again,
+came and went, making the farm more full of life.
+
+Thinking it his duty to heap the greatest attention upon the doctor
+because of his sad position, he begged him not to take his hat off,
+spoke to him in an undertone as if he had been ill, and even pretended
+to be angry because nothing rather lighter had been prepared for him
+than for the others, such as a little clotted cream or stewed pears. He
+told stories. Charles found himself laughing, but the remembrance of his
+wife suddenly coming back to him depressed him. Coffee was brought in;
+he thought no more about her.
+
+He thought less of her as he grew accustomed to living alone. The new
+delight of independence soon made his loneliness bearable. He could now
+change his meal-times, go in or out without explanation, and when he was
+very tired stretch himself at full length on his bed. So he nursed and
+coddled himself and accepted the consolations that were offered him.
+On the other hand, the death of his wife had not served him ill in his
+business, since for a month people had been saying, “The poor young
+man! what a loss!” His name had been talked about, his practice had
+increased; and moreover, he could go to the Bertaux just as he liked.
+He had an aimless hope, and was vaguely happy; he thought himself better
+looking as he brushed his whiskers before the looking-glass.
+
+One day he got there about three o’clock. Everybody was in the fields.
+He went into the kitchen, but did not at once catch sight of Emma; the
+outside shutters were closed. Through the chinks of the wood the sun
+sent across the flooring long fine rays that were broken at the corners
+of the furniture and trembled along the ceiling. Some flies on the table
+were crawling up the glasses that had been used, and buzzing as they
+drowned themselves in the dregs of the cider. The daylight that came in
+by the chimney made velvet of the soot at the back of the fireplace, and
+touched with blue the cold cinders. Between the window and the hearth
+Emma was sewing; she wore no fichu; he could see small drops of
+perspiration on her bare shoulders.
+
+After the fashion of country folks she asked him to have something to
+drink. He said no; she insisted, and at last laughingly offered to have
+a glass of liqueur with him. So she went to fetch a bottle of curacao
+from the cupboard, reached down two small glasses, filled one to the
+brim, poured scarcely anything into the other, and, after having clinked
+glasses, carried hers to her mouth. As it was almost empty she bent
+back to drink, her head thrown back, her lips pouting, her neck on the
+strain. She laughed at getting none of it, while with the tip of her
+tongue passing between her small teeth she licked drop by drop the
+bottom of her glass.
+
+She sat down again and took up her work, a white cotton stocking she was
+darning. She worked with her head bent down; she did not speak, nor did
+Charles. The air coming in under the door blew a little dust over the
+flags; he watched it drift along, and heard nothing but the throbbing
+in his head and the faint clucking of a hen that had laid an egg in the
+yard. Emma from time to time cooled her cheeks with the palms of her
+hands, and cooled these again on the knobs of the huge fire-dogs.
+
+She complained of suffering since the beginning of the season from
+giddiness; she asked if sea-baths would do her any good; she began
+talking of her convent, Charles of his school; words came to them. They
+went up into her bedroom. She showed him her old music-books, the little
+prizes she had won, and the oak-leaf crowns, left at the bottom of a
+cupboard. She spoke to him, too, of her mother, of the country, and even
+showed him the bed in the garden where, on the first Friday of every
+month, she gathered flowers to put on her mother’s tomb. But the
+gardener they had never knew anything about it; servants are so stupid!
+She would have dearly liked, if only for the winter, to live in town,
+although the length of the fine days made the country perhaps even more
+wearisome in the summer. And, according to what she was saying, her
+voice was clear, sharp, or, on a sudden all languor, drawn out in
+modulations that ended almost in murmurs as she spoke to herself, now
+joyous, opening big naive eyes, then with her eyelids half closed, her
+look full of boredom, her thoughts wandering.
+
+Going home at night, Charles went over her words one by one, trying to
+recall them, to fill out their sense, that he might piece out the life
+she had lived before he knew her. But he never saw her in his thoughts
+other than he had seen her the first time, or as he had just left her.
+Then he asked himself what would become of her--if she would be married,
+and to whom! Alas! Old Rouault was rich, and she!--so beautiful! But
+Emma’s face always rose before his eyes, and a monotone, like the
+humming of a top, sounded in his ears, “If you should marry after
+all! If you should marry!” At night he could not sleep; his throat was
+parched; he was athirst. He got up to drink from the water-bottle and
+opened the window. The night was covered with stars, a warm wind blowing
+in the distance; the dogs were barking. He turned his head towards the
+Bertaux.
+
+Thinking that, after all, he should lose nothing, Charles promised
+himself to ask her in marriage as soon as occasion offered, but each
+time such occasion did offer the fear of not finding the right words
+sealed his lips.
+
+Old Rouault would not have been sorry to be rid of his daughter, who was
+of no use to him in the house. In his heart he excused her, thinking
+her too clever for farming, a calling under the ban of Heaven, since one
+never saw a millionaire in it. Far from having made a fortune by it,
+the good man was losing every year; for if he was good in bargaining, in
+which he enjoyed the dodges of the trade, on the other hand, agriculture
+properly so called, and the internal management of the farm, suited him
+less than most people. He did not willingly take his hands out of his
+pockets, and did not spare expense in all that concerned himself, liking
+to eat well, to have good fires, and to sleep well. He liked old cider,
+underdone legs of mutton, glorias* well beaten up. He took his meals in
+the kitchen alone, opposite the fire, on a little table brought to him
+all ready laid as on the stage.
+
+     *A mixture of coffee and spirits.
+
+When, therefore, he perceived that Charles’s cheeks grew red if near his
+daughter, which meant that he would propose for her one of these days,
+he chewed the cud of the matter beforehand. He certainly thought him a
+little meagre, and not quite the son-in-law he would have liked, but he
+was said to be well brought-up, economical, very learned, and no doubt
+would not make too many difficulties about the dowry. Now, as old
+Rouault would soon be forced to sell twenty-two acres of “his property,”
+ as he owed a good deal to the mason, to the harness-maker, and as the
+shaft of the cider-press wanted renewing, “If he asks for her,” he said
+to himself, “I’ll give her to him.”
+
+At Michaelmas Charles went to spend three days at the Bertaux.
+
+The last had passed like the others in procrastinating from hour to
+hour. Old Rouault was seeing him off; they were walking along the road
+full of ruts; they were about to part. This was the time. Charles gave
+himself as far as to the corner of the hedge, and at last, when past
+it--
+
+“Monsieur Rouault,” he murmured, “I should like to say something to
+you.”
+
+They stopped. Charles was silent.
+
+“Well, tell me your story. Don’t I know all about it?” said old Rouault,
+laughing softly.
+
+“Monsieur Rouault--Monsieur Rouault,” stammered Charles.
+
+“I ask nothing better”, the farmer went on. “Although, no doubt, the
+little one is of my mind, still we must ask her opinion. So you get
+off--I’ll go back home. If it is ‘yes’, you needn’t return because of
+all the people about, and besides it would upset her too much. But so
+that you mayn’t be eating your heart, I’ll open wide the outer shutter
+of the window against the wall; you can see it from the back by leaning
+over the hedge.”
+
+And he went off.
+
+Charles fastened his horse to a tree; he ran into the road and waited.
+Half an hour passed, then he counted nineteen minutes by his watch.
+Suddenly a noise was heard against the wall; the shutter had been thrown
+back; the hook was still swinging.
+
+The next day by nine o’clock he was at the farm. Emma blushed as
+he entered, and she gave a little forced laugh to keep herself in
+countenance. Old Rouault embraced his future son-in-law. The discussion
+of money matters was put off; moreover, there was plenty of time before
+them, as the marriage could not decently take place till Charles was out
+of mourning, that is to say, about the spring of the next year.
+
+The winter passed waiting for this. Mademoiselle Rouault was busy with
+her trousseau. Part of it was ordered at Rouen, and she made herself
+chemises and nightcaps after fashion-plates that she borrowed. When
+Charles visited the farmer, the preparations for the wedding were talked
+over; they wondered in what room they should have dinner; they dreamed
+of the number of dishes that would be wanted, and what should be
+entrees.
+
+Emma would, on the contrary, have preferred to have a midnight wedding
+with torches, but old Rouault could not understand such an idea. So
+there was a wedding at which forty-three persons were present, at which
+they remained sixteen hours at table, began again the next day, and to
+some extent on the days following.
+
+
+
+Chapter Four
+
+The guests arrived early in carriages, in one-horse chaises, two-wheeled
+cars, old open gigs, waggonettes with leather hoods, and the young
+people from the nearer villages in carts, in which they stood up in
+rows, holding on to the sides so as not to fall, going at a trot
+and well shaken up. Some came from a distance of thirty miles, from
+Goderville, from Normanville, and from Cany.
+
+All the relatives of both families had been invited, quarrels between
+friends arranged, acquaintances long since lost sight of written to.
+
+From time to time one heard the crack of a whip behind the hedge; then
+the gates opened, a chaise entered. Galloping up to the foot of the
+steps, it stopped short and emptied its load. They got down from all
+sides, rubbing knees and stretching arms. The ladies, wearing bonnets,
+had on dresses in the town fashion, gold watch chains, pelerines with
+the ends tucked into belts, or little coloured fichus fastened down
+behind with a pin, and that left the back of the neck bare. The lads,
+dressed like their papas, seemed uncomfortable in their new clothes
+(many that day hand-sewed their first pair of boots), and by their
+sides, speaking never a work, wearing the white dress of their first
+communion lengthened for the occasion were some big girls of fourteen or
+sixteen, cousins or elder sisters no doubt, rubicund, bewildered, their
+hair greasy with rose pomade, and very much afraid of dirtying their
+gloves. As there were not enough stable-boys to unharness all the
+carriages, the gentlemen turned up their sleeves and set about it
+themselves. According to their different social positions they wore
+tail-coats, overcoats, shooting jackets, cutaway-coats; fine tail-coats,
+redolent of family respectability, that only came out of the wardrobe
+on state occasions; overcoats with long tails flapping in the wind and
+round capes and pockets like sacks; shooting jackets of coarse
+cloth, generally worn with a cap with a brass-bound peak; very short
+cutaway-coats with two small buttons in the back, close together like
+a pair of eyes, and the tails of which seemed cut out of one piece by a
+carpenter’s hatchet. Some, too (but these, you may be sure, would sit at
+the bottom of the table), wore their best blouses--that is to say,
+with collars turned down to the shoulders, the back gathered into small
+plaits and the waist fastened very low down with a worked belt.
+
+And the shirts stood out from the chests like cuirasses! Everyone had
+just had his hair cut; ears stood out from the heads; they had been
+close-shaved; a few, even, who had had to get up before daybreak, and
+not been able to see to shave, had diagonal gashes under their noses or
+cuts the size of a three-franc piece along the jaws, which the fresh
+air en route had enflamed, so that the great white beaming faces were
+mottled here and there with red dabs.
+
+The mairie was a mile and a half from the farm, and they went thither
+on foot, returning in the same way after the ceremony in the church.
+The procession, first united like one long coloured scarf that undulated
+across the fields, along the narrow path winding amid the green corn,
+soon lengthened out, and broke up into different groups that loitered to
+talk. The fiddler walked in front with his violin, gay with ribbons at
+its pegs. Then came the married pair, the relations, the friends, all
+following pell-mell; the children stayed behind amusing themselves
+plucking the bell-flowers from oat-ears, or playing amongst themselves
+unseen. Emma’s dress, too long, trailed a little on the ground; from
+time to time she stopped to pull it up, and then delicately, with her
+gloved hands, she picked off the coarse grass and the thistledowns,
+while Charles, empty handed, waited till she had finished. Old Rouault,
+with a new silk hat and the cuffs of his black coat covering his hands
+up to the nails, gave his arm to Madame Bovary senior. As to Monsieur
+Bovary senior, who, heartily despising all these folk, had come simply
+in a frock-coat of military cut with one row of buttons--he was passing
+compliments of the bar to a fair young peasant. She bowed, blushed,
+and did not know what to say. The other wedding guests talked of their
+business or played tricks behind each other’s backs, egging one another
+on in advance to be jolly. Those who listened could always catch the
+squeaking of the fiddler, who went on playing across the fields. When
+he saw that the rest were far behind he stopped to take breath, slowly
+rosined his bow, so that the strings should sound more shrilly, then set
+off again, by turns lowering and raising his neck, the better to mark
+time for himself. The noise of the instrument drove away the little
+birds from afar.
+
+The table was laid under the cart-shed. On it were four sirloins, six
+chicken fricassees, stewed veal, three legs of mutton, and in the middle
+a fine roast suckling pig, flanked by four chitterlings with sorrel. At
+the corners were decanters of brandy. Sweet bottled-cider frothed round
+the corks, and all the glasses had been filled to the brim with wine
+beforehand. Large dishes of yellow cream, that trembled with the least
+shake of the table, had designed on their smooth surface the initials of
+the newly wedded pair in nonpareil arabesques. A confectioner of Yvetot
+had been intrusted with the tarts and sweets. As he had only just set up
+on the place, he had taken a lot of trouble, and at dessert he himself
+brought in a set dish that evoked loud cries of wonderment. To begin
+with, at its base there was a square of blue cardboard, representing a
+temple with porticoes, colonnades, and stucco statuettes all round, and
+in the niches constellations of gilt paper stars; then on the second
+stage was a dungeon of Savoy cake, surrounded by many fortifications
+in candied angelica, almonds, raisins, and quarters of oranges; and
+finally, on the upper platform a green field with rocks set in lakes of
+jam, nutshell boats, and a small Cupid balancing himself in a chocolate
+swing whose two uprights ended in real roses for balls at the top.
+
+Until night they ate. When any of them were too tired of sitting, they
+went out for a stroll in the yard, or for a game with corks in the
+granary, and then returned to table. Some towards the finish went to
+sleep and snored. But with the coffee everyone woke up. Then they began
+songs, showed off tricks, raised heavy weights, performed feats with
+their fingers, then tried lifting carts on their shoulders, made broad
+jokes, kissed the women. At night when they left, the horses, stuffed
+up to the nostrils with oats, could hardly be got into the shafts; they
+kicked, reared, the harness broke, their masters laughed or swore;
+and all night in the light of the moon along country roads there were
+runaway carts at full gallop plunging into the ditches, jumping over
+yard after yard of stones, clambering up the hills, with women leaning
+out from the tilt to catch hold of the reins.
+
+Those who stayed at the Bertaux spent the night drinking in the kitchen.
+The children had fallen asleep under the seats.
+
+The bride had begged her father to be spared the usual marriage
+pleasantries. However, a fishmonger, one of their cousins (who had even
+brought a pair of soles for his wedding present), began to squirt water
+from his mouth through the keyhole, when old Rouault came up just in
+time to stop him, and explain to him that the distinguished position
+of his son-in-law would not allow of such liberties. The cousin all the
+same did not give in to these reasons readily. In his heart he accused
+old Rouault of being proud, and he joined four or five other guests in
+a corner, who having, through mere chance, been several times running
+served with the worst helps of meat, also were of opinion they had been
+badly used, and were whispering about their host, and with covered hints
+hoping he would ruin himself.
+
+Madame Bovary, senior, had not opened her mouth all day. She had been
+consulted neither as to the dress of her daughter-in-law nor as to the
+arrangement of the feast; she went to bed early. Her husband, instead
+of following her, sent to Saint-Victor for some cigars, and smoked till
+daybreak, drinking kirsch-punch, a mixture unknown to the company. This
+added greatly to the consideration in which he was held.
+
+Charles, who was not of a facetious turn, did not shine at the wedding.
+He answered feebly to the puns, doubles entendres*, compliments, and
+chaff that it was felt a duty to let off at him as soon as the soup
+appeared.
+
+     *Double meanings.
+
+The next day, on the other hand, he seemed another man. It was he who
+might rather have been taken for the virgin of the evening before,
+whilst the bride gave no sign that revealed anything. The shrewdest did
+not know what to make of it, and they looked at her when she passed
+near them with an unbounded concentration of mind. But Charles concealed
+nothing. He called her “my wife”, tutoyed* her, asked for her of
+everyone, looked for her everywhere, and often he dragged her into the
+yards, where he could be seen from far between the trees, putting his
+arm around her waist, and walking half-bending over her, ruffling the
+chemisette of her bodice with his head.
+
+     *Used the familiar form of address.
+
+Two days after the wedding the married pair left. Charles, on account of
+his patients, could not be away longer. Old Rouault had them driven back
+in his cart, and himself accompanied them as far as Vassonville. Here
+he embraced his daughter for the last time, got down, and went his way.
+When he had gone about a hundred paces he stopped, and as he saw the
+cart disappearing, its wheels turning in the dust, he gave a deep sigh.
+Then he remembered his wedding, the old times, the first pregnancy of
+his wife; he, too, had been very happy the day when he had taken her
+from her father to his home, and had carried her off on a pillion,
+trotting through the snow, for it was near Christmas-time, and the
+country was all white. She held him by one arm, her basket hanging from
+the other; the wind blew the long lace of her Cauchois headdress so that
+it sometimes flapped across his mouth, and when he turned his head he
+saw near him, on his shoulder, her little rosy face, smiling silently
+under the gold bands of her cap. To warm her hands she put them from
+time to time in his breast. How long ago it all was! Their son would
+have been thirty by now. Then he looked back and saw nothing on the
+road. He felt dreary as an empty house; and tender memories mingling
+with the sad thoughts in his brain, addled by the fumes of the feast, he
+felt inclined for a moment to take a turn towards the church. As he was
+afraid, however, that this sight would make him yet more sad, he went
+right away home.
+
+Monsieur and Madame Charles arrived at Tostes about six o’clock.
+
+The neighbors came to the windows to see their doctor’s new wife.
+
+The old servant presented herself, curtsied to her, apologised for not
+having dinner ready, and suggested that madame, in the meantime, should
+look over her house.
+
+
+
+Chapter Five
+
+The brick front was just in a line with the street, or rather the road.
+Behind the door hung a cloak with a small collar, a bridle, and a black
+leather cap, and on the floor, in a corner, were a pair of leggings,
+still covered with dry mud. On the right was the one apartment, that was
+both dining and sitting room. A canary yellow paper, relieved at the
+top by a garland of pale flowers, was puckered everywhere over the badly
+stretched canvas; white calico curtains with a red border hung crossways
+at the length of the window; and on the narrow mantelpiece a clock with
+a head of Hippocrates shone resplendent between two plate candlesticks
+under oval shades. On the other side of the passage was Charles’s
+consulting room, a little room about six paces wide, with a table,
+three chairs, and an office chair. Volumes of the “Dictionary of Medical
+Science,” uncut, but the binding rather the worse for the successive
+sales through which they had gone, occupied almost along the six shelves
+of a deal bookcase.
+
+The smell of melted butter penetrated through the walls when he saw
+patients, just as in the kitchen one could hear the people coughing in
+the consulting room and recounting their histories.
+
+Then, opening on the yard, where the stable was, came a large
+dilapidated room with a stove, now used as a wood-house, cellar, and
+pantry, full of old rubbish, of empty casks, agricultural implements
+past service, and a mass of dusty things whose use it was impossible to
+guess.
+
+The garden, longer than wide, ran between two mud walls with espaliered
+apricots, to a hawthorn hedge that separated it from the field. In the
+middle was a slate sundial on a brick pedestal; four flower beds with
+eglantines surrounded symmetrically the more useful kitchen garden bed.
+Right at the bottom, under the spruce bushes, was a cure in plaster
+reading his breviary.
+
+Emma went upstairs. The first room was not furnished, but in the second,
+which was their bedroom, was a mahogany bedstead in an alcove with red
+drapery. A shell box adorned the chest of drawers, and on the secretary
+near the window a bouquet of orange blossoms tied with white satin
+ribbons stood in a bottle. It was a bride’s bouquet; it was the other
+one’s. She looked at it. Charles noticed it; he took it and carried it
+up to the attic, while Emma seated in an arm-chair (they were putting
+her things down around her) thought of her bridal flowers packed up in
+a bandbox, and wondered, dreaming, what would be done with them if she
+were to die.
+
+During the first days she occupied herself in thinking about changes in
+the house. She took the shades off the candlesticks, had new wallpaper
+put up, the staircase repainted, and seats made in the garden round the
+sundial; she even inquired how she could get a basin with a jet fountain
+and fishes. Finally her husband, knowing that she liked to drive out,
+picked up a second-hand dogcart, which, with new lamps and splashboard
+in striped leather, looked almost like a tilbury.
+
+He was happy then, and without a care in the world. A meal together,
+a walk in the evening on the highroad, a gesture of her hands over her
+hair, the sight of her straw hat hanging from the window-fastener, and
+many another thing in which Charles had never dreamed of pleasure, now
+made up the endless round of his happiness. In bed, in the morning, by
+her side, on the pillow, he watched the sunlight sinking into the down
+on her fair cheek, half hidden by the lappets of her night-cap. Seen
+thus closely, her eyes looked to him enlarged, especially when, on
+waking up, she opened and shut them rapidly many times. Black in the
+shade, dark blue in broad daylight, they had, as it were, depths of
+different colours, that, darker in the centre, grew paler towards the
+surface of the eye. His own eyes lost themselves in these depths; he saw
+himself in miniature down to the shoulders, with his handkerchief round
+his head and the top of his shirt open. He rose. She came to the window
+to see him off, and stayed leaning on the sill between two pots of
+geranium, clad in her dressing gown hanging loosely about her. Charles,
+in the street buckled his spurs, his foot on the mounting stone, while
+she talked to him from above, picking with her mouth some scrap of
+flower or leaf that she blew out at him. Then this, eddying, floating,
+described semicircles in the air like a bird, and was caught before
+it reached the ground in the ill-groomed mane of the old white mare
+standing motionless at the door. Charles from horseback threw her a
+kiss; she answered with a nod; she shut the window, and he set off. And
+then along the highroad, spreading out its long ribbon of dust, along
+the deep lanes that the trees bent over as in arbours, along paths where
+the corn reached to the knees, with the sun on his back and the morning
+air in his nostrils, his heart full of the joys of the past night, his
+mind at rest, his flesh at ease, he went on, re-chewing his happiness,
+like those who after dinner taste again the truffles which they are
+digesting.
+
+Until now what good had he had of his life? His time at school, when
+he remained shut up within the high walls, alone, in the midst of
+companions richer than he or cleverer at their work, who laughed at his
+accent, who jeered at his clothes, and whose mothers came to the school
+with cakes in their muffs? Later on, when he studied medicine, and never
+had his purse full enough to treat some little work-girl who would have
+become his mistress? Afterwards, he had lived fourteen months with the
+widow, whose feet in bed were cold as icicles. But now he had for life
+this beautiful woman whom he adored. For him the universe did not extend
+beyond the circumference of her petticoat, and he reproached himself
+with not loving her. He wanted to see her again; he turned back quickly,
+ran up the stairs with a beating heart. Emma, in her room, was dressing;
+he came up on tiptoe, kissed her back; she gave a cry.
+
+He could not keep from constantly touching her comb, her ring, her
+fichu; sometimes he gave her great sounding kisses with all his mouth on
+her cheeks, or else little kisses in a row all along her bare arm
+from the tip of her fingers up to her shoulder, and she put him away
+half-smiling, half-vexed, as you do a child who hangs about you.
+
+Before marriage she thought herself in love; but the happiness that
+should have followed this love not having come, she must, she thought,
+have been mistaken. And Emma tried to find out what one meant exactly in
+life by the words felicity, passion, rapture, that had seemed to her so
+beautiful in books.
+
+
+
+Chapter Six
+
+She had read “Paul and Virginia,” and she had dreamed of the little
+bamboo-house, the nigger Domingo, the dog Fidele, but above all of the
+sweet friendship of some dear little brother, who seeks red fruit for
+you on trees taller than steeples, or who runs barefoot over the sand,
+bringing you a bird’s nest.
+
+When she was thirteen, her father himself took her to town to place
+her in the convent. They stopped at an inn in the St. Gervais quarter,
+where, at their supper, they used painted plates that set forth the
+story of Mademoiselle de la Valliere. The explanatory legends, chipped
+here and there by the scratching of knives, all glorified religion, the
+tendernesses of the heart, and the pomps of court.
+
+Far from being bored at first at the convent, she took pleasure in the
+society of the good sisters, who, to amuse her, took her to the chapel,
+which one entered from the refectory by a long corridor. She played very
+little during recreation hours, knew her catechism well, and it was she
+who always answered Monsieur le Vicaire’s difficult questions. Living
+thus, without ever leaving the warm atmosphere of the classrooms, and
+amid these pale-faced women wearing rosaries with brass crosses, she
+was softly lulled by the mystic languor exhaled in the perfumes of the
+altar, the freshness of the holy water, and the lights of the tapers.
+Instead of attending to mass, she looked at the pious vignettes with
+their azure borders in her book, and she loved the sick lamb, the sacred
+heart pierced with sharp arrows, or the poor Jesus sinking beneath the
+cross he carries. She tried, by way of mortification, to eat nothing a
+whole day. She puzzled her head to find some vow to fulfil.
+
+When she went to confession, she invented little sins in order that she
+might stay there longer, kneeling in the shadow, her hands joined,
+her face against the grating beneath the whispering of the priest.
+The comparisons of betrothed, husband, celestial lover, and eternal
+marriage, that recur in sermons, stirred within her soul depths of
+unexpected sweetness.
+
+In the evening, before prayers, there was some religious reading in
+the study. On week-nights it was some abstract of sacred history or
+the Lectures of the Abbe Frayssinous, and on Sundays passages from the
+“Genie du Christianisme,” as a recreation. How she listened at first to
+the sonorous lamentations of its romantic melancholies reechoing
+through the world and eternity! If her childhood had been spent in the
+shop-parlour of some business quarter, she might perhaps have opened
+her heart to those lyrical invasions of Nature, which usually come to
+us only through translation in books. But she knew the country too well;
+she knew the lowing of cattle, the milking, the ploughs.
+
+Accustomed to calm aspects of life, she turned, on the contrary, to
+those of excitement. She loved the sea only for the sake of its storms,
+and the green fields only when broken up by ruins.
+
+She wanted to get some personal profit out of things, and she rejected
+as useless all that did not contribute to the immediate desires of her
+heart, being of a temperament more sentimental than artistic, looking
+for emotions, not landscapes.
+
+At the convent there was an old maid who came for a week each month to
+mend the linen. Patronized by the clergy, because she belonged to an
+ancient family of noblemen ruined by the Revolution, she dined in the
+refectory at the table of the good sisters, and after the meal had a bit
+of chat with them before going back to her work. The girls often slipped
+out from the study to go and see her. She knew by heart the love songs
+of the last century, and sang them in a low voice as she stitched away.
+
+She told stories, gave them news, went errands in the town, and on
+the sly lent the big girls some novel, that she always carried in the
+pockets of her apron, and of which the good lady herself swallowed
+long chapters in the intervals of her work. They were all love, lovers,
+sweethearts, persecuted ladies fainting in lonely pavilions, postilions
+killed at every stage, horses ridden to death on every page, sombre
+forests, heartaches, vows, sobs, tears and kisses, little skiffs by
+moonlight, nightingales in shady groves, “gentlemen” brave as lions,
+gentle as lambs, virtuous as no one ever was, always well dressed, and
+weeping like fountains. For six months, then, Emma, at fifteen years of
+age, made her hands dirty with books from old lending libraries.
+
+Through Walter Scott, later on, she fell in love with historical events,
+dreamed of old chests, guard-rooms and minstrels. She would have liked
+to live in some old manor-house, like those long-waisted chatelaines
+who, in the shade of pointed arches, spent their days leaning on the
+stone, chin in hand, watching a cavalier with white plume galloping on
+his black horse from the distant fields. At this time she had a cult
+for Mary Stuart and enthusiastic veneration for illustrious or unhappy
+women. Joan of Arc, Heloise, Agnes Sorel, the beautiful Ferroniere, and
+Clemence Isaure stood out to her like comets in the dark immensity of
+heaven, where also were seen, lost in shadow, and all unconnected, St.
+Louis with his oak, the dying Bayard, some cruelties of Louis XI, a
+little of St. Bartholomew’s Day, the plume of the Bearnais, and always
+the remembrance of the plates painted in honour of Louis XIV.
+
+In the music class, in the ballads she sang, there was nothing but
+little angels with golden wings, madonnas, lagunes, gondoliers;-mild
+compositions that allowed her to catch a glimpse athwart the obscurity
+of style and the weakness of the music of the attractive phantasmagoria
+of sentimental realities. Some of her companions brought “keepsakes”
+ given them as new year’s gifts to the convent. These had to be hidden;
+it was quite an undertaking; they were read in the dormitory. Delicately
+handling the beautiful satin bindings, Emma looked with dazzled eyes at
+the names of the unknown authors, who had signed their verses for the
+most part as counts or viscounts.
+
+She trembled as she blew back the tissue paper over the engraving and
+saw it folded in two and fall gently against the page. Here behind the
+balustrade of a balcony was a young man in a short cloak, holding in his
+arms a young girl in a white dress wearing an alms-bag at her belt; or
+there were nameless portraits of English ladies with fair curls, who
+looked at you from under their round straw hats with their large clear
+eyes. Some there were lounging in their carriages, gliding through
+parks, a greyhound bounding along in front of the equipage driven at
+a trot by two midget postilions in white breeches. Others, dreaming on
+sofas with an open letter, gazed at the moon through a slightly open
+window half draped by a black curtain. The naive ones, a tear on their
+cheeks, were kissing doves through the bars of a Gothic cage, or,
+smiling, their heads on one side, were plucking the leaves of a
+marguerite with their taper fingers, that curved at the tips like peaked
+shoes. And you, too, were there, Sultans with long pipes reclining
+beneath arbours in the arms of Bayaderes; Djiaours, Turkish sabres,
+Greek caps; and you especially, pale landscapes of dithyrambic lands,
+that often show us at once palm trees and firs, tigers on the right, a
+lion to the left, Tartar minarets on the horizon; the whole framed by
+a very neat virgin forest, and with a great perpendicular sunbeam
+trembling in the water, where, standing out in relief like white
+excoriations on a steel-grey ground, swans are swimming about.
+
+And the shade of the argand lamp fastened to the wall above Emma’s head
+lighted up all these pictures of the world, that passed before her one
+by one in the silence of the dormitory, and to the distant noise of some
+belated carriage rolling over the Boulevards.
+
+When her mother died she cried much the first few days. She had a
+funeral picture made with the hair of the deceased, and, in a letter
+sent to the Bertaux full of sad reflections on life, she asked to be
+buried later on in the same grave. The goodman thought she must be ill,
+and came to see her. Emma was secretly pleased that she had reached at
+a first attempt the rare ideal of pale lives, never attained by mediocre
+hearts. She let herself glide along with Lamartine meanderings, listened
+to harps on lakes, to all the songs of dying swans, to the falling of
+the leaves, the pure virgins ascending to heaven, and the voice of
+the Eternal discoursing down the valleys. She wearied of it, would not
+confess it, continued from habit, and at last was surprised to feel
+herself soothed, and with no more sadness at heart than wrinkles on her
+brow.
+
+The good nuns, who had been so sure of her vocation, perceived with
+great astonishment that Mademoiselle Rouault seemed to be slipping
+from them. They had indeed been so lavish to her of prayers, retreats,
+novenas, and sermons, they had so often preached the respect due to
+saints and martyrs, and given so much good advice as to the modesty of
+the body and the salvation of her soul, that she did as tightly reined
+horses; she pulled up short and the bit slipped from her teeth. This
+nature, positive in the midst of its enthusiasms, that had loved the
+church for the sake of the flowers, and music for the words of the
+songs, and literature for its passional stimulus, rebelled against
+the mysteries of faith as it grew irritated by discipline, a thing
+antipathetic to her constitution. When her father took her from school,
+no one was sorry to see her go. The Lady Superior even thought that she
+had latterly been somewhat irreverent to the community.
+
+Emma, at home once more, first took pleasure in looking after the
+servants, then grew disgusted with the country and missed her convent.
+When Charles came to the Bertaux for the first time, she thought herself
+quite disillusioned, with nothing more to learn, and nothing more to
+feel.
+
+But the uneasiness of her new position, or perhaps the disturbance
+caused by the presence of this man, had sufficed to make her believe
+that she at last felt that wondrous passion which, till then, like a
+great bird with rose-coloured wings, hung in the splendour of the skies
+of poesy; and now she could not think that the calm in which she lived
+was the happiness she had dreamed.
+
+
+
+Chapter Seven
+
+She thought, sometimes, that, after all, this was the happiest time
+of her life--the honeymoon, as people called it. To taste the full
+sweetness of it, it would have been necessary doubtless to fly to those
+lands with sonorous names where the days after marriage are full of
+laziness most suave. In post chaises behind blue silken curtains to ride
+slowly up steep road, listening to the song of the postilion re-echoed
+by the mountains, along with the bells of goats and the muffled sound of
+a waterfall; at sunset on the shores of gulfs to breathe in the perfume
+of lemon trees; then in the evening on the villa-terraces above, hand in
+hand to look at the stars, making plans for the future. It seemed to her
+that certain places on earth must bring happiness, as a plant peculiar
+to the soil, and that cannot thrive elsewhere. Why could not she lean
+over balconies in Swiss chalets, or enshrine her melancholy in a Scotch
+cottage, with a husband dressed in a black velvet coat with long tails,
+and thin shoes, a pointed hat and frills? Perhaps she would have liked
+to confide all these things to someone. But how tell an undefinable
+uneasiness, variable as the clouds, unstable as the winds? Words failed
+her--the opportunity, the courage.
+
+If Charles had but wished it, if he had guessed it, if his look had but
+once met her thought, it seemed to her that a sudden plenty would have
+gone out from her heart, as the fruit falls from a tree when shaken by
+a hand. But as the intimacy of their life became deeper, the greater
+became the gulf that separated her from him.
+
+Charles’s conversation was commonplace as a street pavement, and
+everyone’s ideas trooped through it in their everyday garb, without
+exciting emotion, laughter, or thought. He had never had the curiosity,
+he said, while he lived at Rouen, to go to the theatre to see the actors
+from Paris. He could neither swim, nor fence, nor shoot, and one day
+he could not explain some term of horsemanship to her that she had come
+across in a novel.
+
+A man, on the contrary, should he not know everything, excel in manifold
+activities, initiate you into the energies of passion, the refinements
+of life, all mysteries? But this one taught nothing, knew nothing,
+wished nothing. He thought her happy; and she resented this easy calm,
+this serene heaviness, the very happiness she gave him.
+
+Sometimes she would draw; and it was great amusement to Charles to stand
+there bolt upright and watch her bend over her cardboard, with eyes
+half-closed the better to see her work, or rolling, between her fingers,
+little bread-pellets. As to the piano, the more quickly her fingers
+glided over it the more he wondered. She struck the notes with aplomb,
+and ran from top to bottom of the keyboard without a break. Thus shaken
+up, the old instrument, whose strings buzzed, could be heard at the
+other end of the village when the window was open, and often the
+bailiff’s clerk, passing along the highroad bare-headed and in list
+slippers, stopped to listen, his sheet of paper in his hand.
+
+Emma, on the other hand, knew how to look after her house. She sent the
+patients’ accounts in well-phrased letters that had no suggestion of
+a bill. When they had a neighbour to dinner on Sundays, she managed to
+have some tasty dish--piled up pyramids of greengages on vine leaves,
+served up preserves turned out into plates--and even spoke of buying
+finger-glasses for dessert. From all this much consideration was
+extended to Bovary.
+
+Charles finished by rising in his own esteem for possessing such a wife.
+He showed with pride in the sitting room two small pencil sketches by
+her that he had had framed in very large frames, and hung up against the
+wallpaper by long green cords. People returning from mass saw him at his
+door in his wool-work slippers.
+
+He came home late--at ten o’clock, at midnight sometimes. Then he asked
+for something to eat, and as the servant had gone to bed, Emma waited
+on him. He took off his coat to dine more at his ease. He told her, one
+after the other, the people he had met, the villages where he had been,
+the prescriptions he had written, and, well pleased with himself, he
+finished the remainder of the boiled beef and onions, picked pieces off
+the cheese, munched an apple, emptied his water-bottle, and then went to
+bed, and lay on his back and snored.
+
+As he had been for a time accustomed to wear nightcaps, his handkerchief
+would not keep down over his ears, so that his hair in the morning was
+all tumbled pell-mell about his face and whitened with the feathers of
+the pillow, whose strings came untied during the night. He always wore
+thick boots that had two long creases over the instep running obliquely
+towards the ankle, while the rest of the upper continued in a straight
+line as if stretched on a wooden foot. He said that “was quite good
+enough for the country.”
+
+His mother approved of his economy, for she came to see him as formerly
+when there had been some violent row at her place; and yet Madame Bovary
+senior seemed prejudiced against her daughter-in-law. She thought “her
+ways too fine for their position”; the wood, the sugar, and the candles
+disappeared as “at a grand establishment,” and the amount of firing in
+the kitchen would have been enough for twenty-five courses. She put her
+linen in order for her in the presses, and taught her to keep an eye on
+the butcher when he brought the meat. Emma put up with these lessons.
+Madame Bovary was lavish of them; and the words “daughter” and “mother”
+ were exchanged all day long, accompanied by little quiverings of the
+lips, each one uttering gentle words in a voice trembling with anger.
+
+In Madame Dubuc’s time the old woman felt that she was still the
+favorite; but now the love of Charles for Emma seemed to her a desertion
+from her tenderness, an encroachment upon what was hers, and she watched
+her son’s happiness in sad silence, as a ruined man looks through
+the windows at people dining in his old house. She recalled to him as
+remembrances her troubles and her sacrifices, and, comparing these with
+Emma’s negligence, came to the conclusion that it was not reasonable to
+adore her so exclusively.
+
+Charles knew not what to answer: he respected his mother, and he loved
+his wife infinitely; he considered the judgment of the one infallible,
+and yet he thought the conduct of the other irreproachable. When Madam
+Bovary had gone, he tried timidly and in the same terms to hazard one or
+two of the more anodyne observations he had heard from his mamma. Emma
+proved to him with a word that he was mistaken, and sent him off to his
+patients.
+
+And yet, in accord with theories she believed right, she wanted to make
+herself in love with him. By moonlight in the garden she recited all
+the passionate rhymes she knew by heart, and, sighing, sang to him many
+melancholy adagios; but she found herself as calm after as before, and
+Charles seemed no more amorous and no more moved.
+
+When she had thus for a while struck the flint on her heart without
+getting a spark, incapable, moreover, of understanding what she did
+not experience as of believing anything that did not present itself
+in conventional forms, she persuaded herself without difficulty that
+Charles’s passion was nothing very exorbitant. His outbursts became
+regular; he embraced her at certain fixed times. It was one habit among
+other habits, and, like a dessert, looked forward to after the monotony
+of dinner.
+
+A gamekeeper, cured by the doctor of inflammation of the lungs, had
+given madame a little Italian greyhound; she took her out walking, for
+she went out sometimes in order to be alone for a moment, and not to see
+before her eyes the eternal garden and the dusty road. She went as far
+as the beeches of Banneville, near the deserted pavilion which forms an
+angle of the wall on the side of the country. Amidst the vegetation of
+the ditch there are long reeds with leaves that cut you.
+
+She began by looking round her to see if nothing had changed since last
+she had been there. She found again in the same places the foxgloves and
+wallflowers, the beds of nettles growing round the big stones, and
+the patches of lichen along the three windows, whose shutters, always
+closed, were rotting away on their rusty iron bars. Her thoughts,
+aimless at first, wandered at random, like her greyhound, who ran round
+and round in the fields, yelping after the yellow butterflies, chasing
+the shrew-mice, or nibbling the poppies on the edge of a cornfield.
+
+Then gradually her ideas took definite shape, and, sitting on the grass
+that she dug up with little prods of her sunshade, Emma repeated to
+herself, “Good heavens! Why did I marry?”
+
+She asked herself if by some other chance combination it would have not
+been possible to meet another man; and she tried to imagine what would
+have been these unrealised events, this different life, this unknown
+husband. All, surely, could not be like this one. He might have been
+handsome, witty, distinguished, attractive, such as, no doubt, her old
+companions of the convent had married. What were they doing now? In
+town, with the noise of the streets, the buzz of the theatres and the
+lights of the ballroom, they were living lives where the heart expands,
+the senses bourgeon out. But she--her life was cold as a garret whose
+dormer window looks on the north, and ennui, the silent spider, was
+weaving its web in the darkness in every corner of her heart.
+
+She recalled the prize days, when she mounted the platform to receive
+her little crowns, with her hair in long plaits. In her white frock and
+open prunella shoes she had a pretty way, and when she went back to her
+seat, the gentlemen bent over her to congratulate her; the courtyard was
+full of carriages; farewells were called to her through their windows;
+the music master with his violin case bowed in passing by. How far all
+of this! How far away! She called Djali, took her between her knees, and
+smoothed the long delicate head, saying, “Come, kiss mistress; you have
+no troubles.”
+
+Then noting the melancholy face of the graceful animal, who yawned
+slowly, she softened, and comparing her to herself, spoke to her aloud
+as to somebody in trouble whom one is consoling.
+
+Occasionally there came gusts of winds, breezes from the sea rolling in
+one sweep over the whole plateau of the Caux country, which brought
+even to these fields a salt freshness. The rushes, close to the ground,
+whistled; the branches trembled in a swift rustling, while their
+summits, ceaselessly swaying, kept up a deep murmur. Emma drew her shawl
+round her shoulders and rose.
+
+In the avenue a green light dimmed by the leaves lit up the short moss
+that crackled softly beneath her feet. The sun was setting; the sky
+showed red between the branches, and the trunks of the trees, uniform,
+and planted in a straight line, seemed a brown colonnade standing out
+against a background of gold. A fear took hold of her; she called Djali,
+and hurriedly returned to Tostes by the high road, threw herself into an
+armchair, and for the rest of the evening did not speak.
+
+But towards the end of September something extraordinary fell upon her
+life; she was invited by the Marquis d’Andervilliers to Vaubyessard.
+
+Secretary of State under the Restoration, the Marquis, anxious to
+re-enter political life, set about preparing for his candidature to
+the Chamber of Deputies long beforehand. In the winter he distributed a
+great deal of wood, and in the Conseil General always enthusiastically
+demanded new roads for his arrondissement. During the dog-days he had
+suffered from an abscess, which Charles had cured as if by miracle by
+giving a timely little touch with the lancet. The steward sent to Tostes
+to pay for the operation reported in the evening that he had seen some
+superb cherries in the doctor’s little garden. Now cherry trees did not
+thrive at Vaubyessard; the Marquis asked Bovary for some slips; made it
+his business to thank his personally; saw Emma; thought she had a pretty
+figure, and that she did not bow like a peasant; so that he did not
+think he was going beyond the bounds of condescension, nor, on the other
+hand, making a mistake, in inviting the young couple.
+
+On Wednesday at three o’clock, Monsieur and Madame Bovary, seated in
+their dog-cart, set out for Vaubyessard, with a great trunk strapped
+on behind and a bonnet-box in front of the apron. Besides these Charles
+held a bandbox between his knees.
+
+They arrived at nightfall, just as the lamps in the park were being lit
+to show the way for the carriages.
+
+
+
+Chapter Eight
+
+The chateau, a modern building in Italian style, with two projecting
+wings and three flights of steps, lay at the foot of an immense
+green-sward, on which some cows were grazing among groups of large trees
+set out at regular intervals, while large beds of arbutus, rhododendron,
+syringas, and guelder roses bulged out their irregular clusters of
+green along the curve of the gravel path. A river flowed under a bridge;
+through the mist one could distinguish buildings with thatched roofs
+scattered over the field bordered by two gently sloping, well timbered
+hillocks, and in the background amid the trees rose in two parallel
+lines the coach houses and stables, all that was left of the ruined old
+chateau.
+
+Charles’s dog-cart pulled up before the middle flight of steps; servants
+appeared; the Marquis came forward, and, offering his arm to the
+doctor’s wife, conducted her to the vestibule.
+
+It was paved with marble slabs, was very lofty, and the sound of
+footsteps and that of voices re-echoed through it as in a church.
+
+Opposite rose a straight staircase, and on the left a gallery
+overlooking the garden led to the billiard room, through whose door one
+could hear the click of the ivory balls. As she crossed it to go to the
+drawing room, Emma saw standing round the table men with grave faces,
+their chins resting on high cravats. They all wore orders, and smiled
+silently as they made their strokes.
+
+On the dark wainscoting of the walls large gold frames bore at
+the bottom names written in black letters. She read: “Jean-Antoine
+d’Andervilliers d’Yvervonbille, Count de la Vaubyessard and Baron de la
+Fresnay, killed at the battle of Coutras on the 20th of October,
+1587.” And on another: “Jean-Antoine-Henry-Guy d’Andervilliers de
+la Vaubyessard, Admiral of France and Chevalier of the Order of St.
+Michael, wounded at the battle of the Hougue-Saint-Vaast on the 29th of
+May, 1692; died at Vaubyessard on the 23rd of January 1693.” One could
+hardly make out those that followed, for the light of the lamps lowered
+over the green cloth threw a dim shadow round the room. Burnishing the
+horizontal pictures, it broke up against these in delicate lines where
+there were cracks in the varnish, and from all these great black squares
+framed in with gold stood out here and there some lighter portion of the
+painting--a pale brow, two eyes that looked at you, perukes flowing over
+and powdering red-coated shoulders, or the buckle of a garter above a
+well-rounded calf.
+
+The Marquis opened the drawing room door; one of the ladies (the
+Marchioness herself) came to meet Emma. She made her sit down by her on
+an ottoman, and began talking to her as amicably as if she had known her
+a long time. She was a woman of about forty, with fine shoulders, a hook
+nose, a drawling voice, and on this evening she wore over her brown hair
+a simple guipure fichu that fell in a point at the back. A fair young
+woman sat in a high-backed chair in a corner; and gentlemen with flowers
+in their buttonholes were talking to ladies round the fire.
+
+At seven dinner was served. The men, who were in the majority, sat down
+at the first table in the vestibule; the ladies at the second in the
+dining room with the Marquis and Marchioness.
+
+Emma, on entering, felt herself wrapped round by the warm air, a
+blending of the perfume of flowers and of the fine linen, of the fumes
+of the viands, and the odour of the truffles. The silver dish covers
+reflected the lighted wax candles in the candelabra, the cut crystal
+covered with light steam reflected from one to the other pale rays;
+bouquets were placed in a row the whole length of the table; and in
+the large-bordered plates each napkin, arranged after the fashion of a
+bishop’s mitre, held between its two gaping folds a small oval shaped
+roll. The red claws of lobsters hung over the dishes; rich fruit in open
+baskets was piled up on moss; there were quails in their plumage; smoke
+was rising; and in silk stockings, knee-breeches, white cravat, and
+frilled shirt, the steward, grave as a judge, offering ready carved
+dishes between the shoulders of the guests, with a touch of the spoon
+gave you the piece chosen. On the large stove of porcelain inlaid
+with copper baguettes the statue of a woman, draped to the chin, gazed
+motionless on the room full of life.
+
+Madame Bovary noticed that many ladies had not put their gloves in their
+glasses.
+
+But at the upper end of the table, alone amongst all these women, bent
+over his full plate, and his napkin tied round his neck like a child, an
+old man sat eating, letting drops of gravy drip from his mouth. His eyes
+were bloodshot, and he wore a little queue tied with black ribbon. He
+was the Marquis’s father-in-law, the old Duke de Laverdiere, once on
+a time favourite of the Count d’Artois, in the days of the Vaudreuil
+hunting-parties at the Marquis de Conflans’, and had been, it was said,
+the lover of Queen Marie Antoinette, between Monsieur de Coigny and
+Monsieur de Lauzun. He had lived a life of noisy debauch, full of duels,
+bets, elopements; he had squandered his fortune and frightened all his
+family. A servant behind his chair named aloud to him in his ear the
+dishes that he pointed to stammering, and constantly Emma’s eyes
+turned involuntarily to this old man with hanging lips, as to something
+extraordinary. He had lived at court and slept in the bed of queens!
+Iced champagne was poured out. Emma shivered all over as she felt
+it cold in her mouth. She had never seen pomegranates nor tasted
+pineapples. The powdered sugar even seemed to her whiter and finer than
+elsewhere.
+
+The ladies afterwards went to their rooms to prepare for the ball.
+
+Emma made her toilet with the fastidious care of an actress on her
+debut. She did her hair according to the directions of the hairdresser,
+and put on the barege dress spread out upon the bed.
+
+Charles’s trousers were tight across the belly.
+
+“My trouser-straps will be rather awkward for dancing,” he said.
+
+“Dancing?” repeated Emma.
+
+“Yes!”
+
+“Why, you must be mad! They would make fun of you; keep your place.
+Besides, it is more becoming for a doctor,” she added.
+
+Charles was silent. He walked up and down waiting for Emma to finish
+dressing.
+
+He saw her from behind in the glass between two lights. Her black eyes
+seemed blacker than ever. Her hair, undulating towards the ears, shone
+with a blue lustre; a rose in her chignon trembled on its mobile stalk,
+with artificial dewdrops on the tip of the leaves. She wore a gown of
+pale saffron trimmed with three bouquets of pompon roses mixed with
+green.
+
+Charles came and kissed her on her shoulder.
+
+“Let me alone!” she said; “you are tumbling me.”
+
+One could hear the flourish of the violin and the notes of a horn. She
+went downstairs restraining herself from running.
+
+Dancing had begun. Guests were arriving. There was some crushing.
+
+She sat down on a form near the door.
+
+The quadrille over, the floor was occupied by groups of men standing up
+and talking and servants in livery bearing large trays. Along the line
+of seated women painted fans were fluttering, bouquets half hid smiling
+faces, and gold stoppered scent-bottles were turned in partly-closed
+hands, whose white gloves outlined the nails and tightened on the flesh
+at the wrists. Lace trimmings, diamond brooches, medallion bracelets
+trembled on bodices, gleamed on breasts, clinked on bare arms.
+
+The hair, well-smoothed over the temples and knotted at the nape,
+bore crowns, or bunches, or sprays of mytosotis, jasmine, pomegranate
+blossoms, ears of corn, and corn-flowers. Calmly seated in their places,
+mothers with forbidding countenances were wearing red turbans.
+
+Emma’s heart beat rather faster when, her partner holding her by the
+tips of the fingers, she took her place in a line with the dancers, and
+waited for the first note to start. But her emotion soon vanished, and,
+swaying to the rhythm of the orchestra, she glided forward with slight
+movements of the neck. A smile rose to her lips at certain delicate
+phrases of the violin, that sometimes played alone while the other
+instruments were silent; one could hear the clear clink of the louis
+d’or that were being thrown down upon the card tables in the next room;
+then all struck again, the cornet-a-piston uttered its sonorous note,
+feet marked time, skirts swelled and rustled, hands touched and parted;
+the same eyes falling before you met yours again.
+
+A few men (some fifteen or so), of twenty-five to forty, scattered here
+and there among the dancers or talking at the doorways, distinguished
+themselves from the crowd by a certain air of breeding, whatever their
+differences in age, dress, or face.
+
+Their clothes, better made, seemed of finer cloth, and their hair,
+brought forward in curls towards the temples, glossy with more delicate
+pomades. They had the complexion of wealth--that clear complexion that
+is heightened by the pallor of porcelain, the shimmer of satin, the
+veneer of old furniture, and that an ordered regimen of exquisite
+nurture maintains at its best. Their necks moved easily in their low
+cravats, their long whiskers fell over their turned-down collars, they
+wiped their lips upon handkerchiefs with embroidered initials that gave
+forth a subtle perfume. Those who were beginning to grow old had an air
+of youth, while there was something mature in the faces of the young.
+In their unconcerned looks was the calm of passions daily satiated, and
+through all their gentleness of manner pierced that peculiar brutality,
+the result of a command of half-easy things, in which force is exercised
+and vanity amused--the management of thoroughbred horses and the society
+of loose women.
+
+A few steps from Emma a gentleman in a blue coat was talking of Italy
+with a pale young woman wearing a parure of pearls.
+
+They were praising the breadth of the columns of St. Peter’s, Tivoly,
+Vesuvius, Castellamare, and Cassines, the roses of Genoa, the Coliseum
+by moonlight. With her other ear Emma was listening to a conversation
+full of words she did not understand. A circle gathered round a very
+young man who the week before had beaten “Miss Arabella” and “Romolus,”
+ and won two thousand louis jumping a ditch in England. One complained
+that his racehorses were growing fat; another of the printers’ errors
+that had disfigured the name of his horse.
+
+The atmosphere of the ball was heavy; the lamps were growing dim.
+
+Guests were flocking to the billiard room. A servant got upon a chair
+and broke the window-panes. At the crash of the glass Madame Bovary
+turned her head and saw in the garden the faces of peasants pressed
+against the window looking in at them. Then the memory of the Bertaux
+came back to her. She saw the farm again, the muddy pond, her father in
+a blouse under the apple trees, and she saw herself again as formerly,
+skimming with her finger the cream off the milk-pans in the dairy. But
+in the refulgence of the present hour her past life, so distinct until
+then, faded away completely, and she almost doubted having lived it. She
+was there; beyond the ball was only shadow overspreading all the rest.
+She was just eating a maraschino ice that she held with her left hand
+in a silver-gilt cup, her eyes half-closed, and the spoon between her
+teeth.
+
+A lady near her dropped her fan. A gentlemen was passing.
+
+“Would you be so good,” said the lady, “as to pick up my fan that has
+fallen behind the sofa?”
+
+The gentleman bowed, and as he moved to stretch out his arm, Emma saw
+the hand of a young woman throw something white, folded in a triangle,
+into his hat. The gentleman, picking up the fan, offered it to the lady
+respectfully; she thanked him with an inclination of the head, and began
+smelling her bouquet.
+
+After supper, where were plenty of Spanish and Rhine wines, soups a la
+bisque and au lait d’amandes*, puddings a la Trafalgar, and all sorts of
+cold meats with jellies that trembled in the dishes, the carriages one
+after the other began to drive off. Raising the corners of the muslin
+curtain, one could see the light of their lanterns glimmering through
+the darkness. The seats began to empty, some card-players were still
+left; the musicians were cooling the tips of their fingers on their
+tongues. Charles was half asleep, his back propped against a door.
+
+     *With almond milk
+
+At three o’clock the cotillion began. Emma did not know how to waltz.
+Everyone was waltzing, Mademoiselle d’Andervilliers herself and the
+Marquis; only the guests staying at the castle were still there, about a
+dozen persons.
+
+One of the waltzers, however, who was familiarly called Viscount, and
+whose low cut waistcoat seemed moulded to his chest, came a second time
+to ask Madame Bovary to dance, assuring her that he would guide her, and
+that she would get through it very well.
+
+They began slowly, then went more rapidly. They turned; all around them
+was turning--the lamps, the furniture, the wainscoting, the floor, like
+a disc on a pivot. On passing near the doors the bottom of Emma’s dress
+caught against his trousers.
+
+Their legs commingled; he looked down at her; she raised her eyes to
+his. A torpor seized her; she stopped. They started again, and with a
+more rapid movement; the Viscount, dragging her along disappeared with
+her to the end of the gallery, where panting, she almost fell, and for
+a moment rested her head upon his breast. And then, still turning, but
+more slowly, he guided her back to her seat. She leaned back against the
+wall and covered her eyes with her hands.
+
+When she opened them again, in the middle of the drawing room three
+waltzers were kneeling before a lady sitting on a stool.
+
+She chose the Viscount, and the violin struck up once more.
+
+Everyone looked at them. They passed and re-passed, she with rigid body,
+her chin bent down, and he always in the same pose, his figure curved,
+his elbow rounded, his chin thrown forward. That woman knew how to
+waltz! They kept up a long time, and tired out all the others.
+
+Then they talked a few moments longer, and after the goodnights, or
+rather good mornings, the guests of the chateau retired to bed.
+
+Charles dragged himself up by the balusters. His “knees were going
+up into his body.” He had spent five consecutive hours standing
+bolt upright at the card tables, watching them play whist, without
+understanding anything about it, and it was with a deep sigh of relief
+that he pulled off his boots.
+
+Emma threw a shawl over her shoulders, opened the window, and leant out.
+
+The night was dark; some drops of rain were falling. She breathed in the
+damp wind that refreshed her eyelids. The music of the ball was still
+murmuring in her ears. And she tried to keep herself awake in order to
+prolong the illusion of this luxurious life that she would soon have to
+give up.
+
+Day began to break. She looked long at the windows of the chateau,
+trying to guess which were the rooms of all those she had noticed the
+evening before. She would fain have known their lives, have penetrated,
+blended with them. But she was shivering with cold. She undressed, and
+cowered down between the sheets against Charles, who was asleep.
+
+There were a great many people to luncheon. The repast lasted ten
+minutes; no liqueurs were served, which astonished the doctor.
+
+Next, Mademoiselle d’Andervilliers collected some pieces of roll in a
+small basket to take them to the swans on the ornamental waters, and
+they went to walk in the hot-houses, where strange plants, bristling
+with hairs, rose in pyramids under hanging vases, whence, as from
+over-filled nests of serpents, fell long green cords interlacing.
+The orangery, which was at the other end, led by a covered way to the
+outhouses of the chateau. The Marquis, to amuse the young woman, took
+her to see the stables.
+
+Above the basket-shaped racks porcelain slabs bore the names of the
+horses in black letters. Each animal in its stall whisked its tail when
+anyone went near and said “Tchk! tchk!” The boards of the harness room
+shone like the flooring of a drawing room. The carriage harness was
+piled up in the middle against two twisted columns, and the bits, the
+whips, the spurs, the curbs, were ranged in a line all along the wall.
+
+Charles, meanwhile, went to ask a groom to put his horse to. The
+dog-cart was brought to the foot of the steps, and, all the parcels
+being crammed in, the Bovarys paid their respects to the Marquis and
+Marchioness and set out again for Tostes.
+
+Emma watched the turning wheels in silence. Charles, on the extreme edge
+of the seat, held the reins with his two arms wide apart, and the little
+horse ambled along in the shafts that were too big for him. The loose
+reins hanging over his crupper were wet with foam, and the box fastened
+on behind the chaise gave great regular bumps against it.
+
+They were on the heights of Thibourville when suddenly some horsemen
+with cigars between their lips passed laughing. Emma thought she
+recognized the Viscount, turned back, and caught on the horizon only the
+movement of the heads rising or falling with the unequal cadence of the
+trot or gallop.
+
+A mile farther on they had to stop to mend with some string the traces
+that had broken.
+
+But Charles, giving a last look to the harness, saw something on the
+ground between his horse’s legs, and he picked up a cigar-case with
+a green silk border and beblazoned in the centre like the door of a
+carriage.
+
+“There are even two cigars in it,” said he; “they’ll do for this evening
+after dinner.”
+
+“Why, do you smoke?” she asked.
+
+“Sometimes, when I get a chance.”
+
+He put his find in his pocket and whipped up the nag.
+
+When they reached home the dinner was not ready. Madame lost her temper.
+Nastasie answered rudely.
+
+“Leave the room!” said Emma. “You are forgetting yourself. I give you
+warning.”
+
+For dinner there was onion soup and a piece of veal with sorrel.
+
+Charles, seated opposite Emma, rubbed his hands gleefully.
+
+“How good it is to be at home again!”
+
+Nastasie could be heard crying. He was rather fond of the poor girl.
+She had formerly, during the wearisome time of his widowhood, kept him
+company many an evening. She had been his first patient, his oldest
+acquaintance in the place.
+
+“Have you given her warning for good?” he asked at last.
+
+“Yes. Who is to prevent me?” she replied.
+
+Then they warmed themselves in the kitchen while their room was being
+made ready. Charles began to smoke. He smoked with lips protruding,
+spitting every moment, recoiling at every puff.
+
+“You’ll make yourself ill,” she said scornfully.
+
+He put down his cigar and ran to swallow a glass of cold water at the
+pump. Emma seizing hold of the cigar case threw it quickly to the back
+of the cupboard.
+
+The next day was a long one. She walked about her little garden, up
+and down the same walks, stopping before the beds, before the espalier,
+before the plaster curate, looking with amazement at all these things
+of once-on-a-time that she knew so well. How far off the ball seemed
+already! What was it that thus set so far asunder the morning of the day
+before yesterday and the evening of to-day? Her journey to Vaubyessard
+had made a hole in her life, like one of those great crevices that
+a storm will sometimes make in one night in mountains. Still she was
+resigned. She devoutly put away in her drawers her beautiful dress, down
+to the satin shoes whose soles were yellowed with the slippery wax of
+the dancing floor. Her heart was like these. In its friction against
+wealth something had come over it that could not be effaced.
+
+The memory of this ball, then, became an occupation for Emma.
+
+Whenever the Wednesday came round she said to herself as she awoke, “Ah!
+I was there a week--a fortnight--three weeks ago.”
+
+And little by little the faces grew confused in her remembrance.
+
+She forgot the tune of the quadrilles; she no longer saw the liveries
+and appointments so distinctly; some details escaped her, but the regret
+remained with her.
+
+
+
+Chapter Nine
+
+Often when Charles was out she took from the cupboard, between the
+folds of the linen where she had left it, the green silk cigar case.
+She looked at it, opened it, and even smelt the odour of the lining--a
+mixture of verbena and tobacco. Whose was it? The Viscount’s? Perhaps
+it was a present from his mistress. It had been embroidered on some
+rosewood frame, a pretty little thing, hidden from all eyes, that had
+occupied many hours, and over which had fallen the soft curls of the
+pensive worker. A breath of love had passed over the stitches on the
+canvas; each prick of the needle had fixed there a hope or a memory, and
+all those interwoven threads of silk were but the continuity of the same
+silent passion. And then one morning the Viscount had taken it away
+with him. Of what had they spoken when it lay upon the wide-mantelled
+chimneys between flower-vases and Pompadour clocks? She was at Tostes;
+he was at Paris now, far away! What was this Paris like? What a vague
+name! She repeated it in a low voice, for the mere pleasure of it; it
+rang in her ears like a great cathedral bell; it shone before her eyes,
+even on the labels of her pomade-pots.
+
+At night, when the carriers passed under her windows in their carts
+singing the “Marjolaine,” she awoke, and listened to the noise of the
+iron-bound wheels, which, as they gained the country road, was soon
+deadened by the soil. “They will be there to-morrow!” she said to
+herself.
+
+And she followed them in thought up and down the hills, traversing
+villages, gliding along the highroads by the light of the stars. At the
+end of some indefinite distance there was always a confused spot, into
+which her dream died.
+
+She bought a plan of Paris, and with the tip of her finger on the map
+she walked about the capital. She went up the boulevards, stopping at
+every turning, between the lines of the streets, in front of the white
+squares that represented the houses. At last she would close the lids of
+her weary eyes, and see in the darkness the gas jets flaring in the wind
+and the steps of carriages lowered with much noise before the peristyles
+of theatres.
+
+She took in “La Corbeille,” a lady’s journal, and the “Sylphe des
+Salons.” She devoured, without skipping a word, all the accounts of
+first nights, races, and soirees, took interest in the debut of a
+singer, in the opening of a new shop. She knew the latest fashions, the
+addresses of the best tailors, the days of the Bois and the Opera. In
+Eugene Sue she studied descriptions of furniture; she read Balzac and
+George Sand, seeking in them imaginary satisfaction for her own desires.
+Even at table she had her book by her, and turned over the pages
+while Charles ate and talked to her. The memory of the Viscount always
+returned as she read. Between him and the imaginary personages she made
+comparisons. But the circle of which he was the centre gradually widened
+round him, and the aureole that he bore, fading from his form, broadened
+out beyond, lighting up her other dreams.
+
+Paris, more vague than the ocean, glimmered before Emma’s eyes in an
+atmosphere of vermilion. The many lives that stirred amid this tumult
+were, however, divided into parts, classed as distinct pictures. Emma
+perceived only two or three that hid from her all the rest, and in
+themselves represented all humanity. The world of ambassadors moved over
+polished floors in drawing rooms lined with mirrors, round oval tables
+covered with velvet and gold-fringed cloths. There were dresses with
+trains, deep mysteries, anguish hidden beneath smiles. Then came the
+society of the duchesses; all were pale; all got up at four o’clock; the
+women, poor angels, wore English point on their petticoats; and the men,
+unappreciated geniuses under a frivolous outward seeming, rode horses to
+death at pleasure parties, spent the summer season at Baden, and towards
+the forties married heiresses. In the private rooms of restaurants,
+where one sups after midnight by the light of wax candles, laughed the
+motley crowd of men of letters and actresses. They were prodigal as
+kings, full of ideal, ambitious, fantastic frenzy. This was an existence
+outside that of all others, between heaven and earth, in the midst of
+storms, having something of the sublime. For the rest of the world it
+was lost, with no particular place and as if non-existent. The nearer
+things were, moreover, the more her thoughts turned away from them.
+All her immediate surroundings, the wearisome country, the middle-class
+imbeciles, the mediocrity of existence, seemed to her exceptional, a
+peculiar chance that had caught hold of her, while beyond stretched, as
+far as eye could see, an immense land of joys and passions. She confused
+in her desire the sensualities of luxury with the delights of the heart,
+elegance of manners with delicacy of sentiment. Did not love, like
+Indian plants, need a special soil, a particular temperature? Signs
+by moonlight, long embraces, tears flowing over yielded hands, all
+the fevers of the flesh and the languors of tenderness could not be
+separated from the balconies of great castles full of indolence,
+from boudoirs with silken curtains and thick carpets, well-filled
+flower-stands, a bed on a raised dias, nor from the flashing of precious
+stones and the shoulder-knots of liveries.
+
+The lad from the posting house who came to groom the mare every morning
+passed through the passage with his heavy wooden shoes; there were holes
+in his blouse; his feet were bare in list slippers. And this was the
+groom in knee-britches with whom she had to be content! His work done,
+he did not come back again all day, for Charles on his return put up
+his horse himself, unsaddled him and put on the halter, while the
+servant-girl brought a bundle of straw and threw it as best she could
+into the manger.
+
+To replace Nastasie (who left Tostes shedding torrents of tears) Emma
+took into her service a young girl of fourteen, an orphan with a sweet
+face. She forbade her wearing cotton caps, taught her to address her in
+the third person, to bring a glass of water on a plate, to knock before
+coming into a room, to iron, starch, and to dress her--wanted to make a
+lady’s-maid of her. The new servant obeyed without a murmur, so as not
+to be sent away; and as madame usually left the key in the sideboard,
+Felicite every evening took a small supply of sugar that she ate alone
+in her bed after she had said her prayers.
+
+Sometimes in the afternoon she went to chat with the postilions.
+
+Madame was in her room upstairs. She wore an open dressing gown that
+showed between the shawl facings of her bodice a pleated chamisette with
+three gold buttons. Her belt was a corded girdle with great tassels, and
+her small garnet coloured slippers had a large knot of ribbon that fell
+over her instep. She had bought herself a blotting book, writing case,
+pen-holder, and envelopes, although she had no one to write to; she
+dusted her what-not, looked at herself in the glass, picked up a book,
+and then, dreaming between the lines, let it drop on her knees. She
+longed to travel or to go back to her convent. She wished at the same
+time to die and to live in Paris.
+
+Charles in snow and rain trotted across country. He ate omelettes on
+farmhouse tables, poked his arm into damp beds, received the tepid
+spurt of blood-lettings in his face, listened to death-rattles, examined
+basins, turned over a good deal of dirty linen; but every evening he
+found a blazing fire, his dinner ready, easy-chairs, and a well-dressed
+woman, charming with an odour of freshness, though no one could say
+whence the perfume came, or if it were not her skin that made odorous
+her chemise.
+
+She charmed him by numerous attentions; now it was some new way of
+arranging paper sconces for the candles, a flounce that she altered on
+her gown, or an extraordinary name for some very simple dish that the
+servant had spoilt, but that Charles swallowed with pleasure to the last
+mouthful. At Rouen she saw some ladies who wore a bunch of charms on the
+watch-chains; she bought some charms. She wanted for her mantelpiece two
+large blue glass vases, and some time after an ivory necessaire with a
+silver-gilt thimble. The less Charles understood these refinements
+the more they seduced him. They added something to the pleasure of the
+senses and to the comfort of his fireside. It was like a golden dust
+sanding all along the narrow path of his life.
+
+He was well, looked well; his reputation was firmly established.
+
+The country-folk loved him because he was not proud. He petted the
+children, never went to the public house, and, moreover, his morals
+inspired confidence. He was specially successful with catarrhs and chest
+complaints. Being much afraid of killing his patients, Charles, in fact
+only prescribed sedatives, from time to time and emetic, a footbath,
+or leeches. It was not that he was afraid of surgery; he bled people
+copiously like horses, and for the taking out of teeth he had the
+“devil’s own wrist.”
+
+Finally, to keep up with the times, he took in “La Ruche Medicale,”
+ a new journal whose prospectus had been sent him. He read it a little
+after dinner, but in about five minutes the warmth of the room added to
+the effect of his dinner sent him to sleep; and he sat there, his chin
+on his two hands and his hair spreading like a mane to the foot of the
+lamp. Emma looked at him and shrugged her shoulders. Why, at least, was
+not her husband one of those men of taciturn passions who work at their
+books all night, and at last, when about sixty, the age of rheumatism
+sets in, wear a string of orders on their ill-fitting black coat?
+She could have wished this name of Bovary, which was hers, had been
+illustrious, to see it displayed at the booksellers’, repeated in the
+newspapers, known to all France. But Charles had no ambition.
+
+An Yvetot doctor whom he had lately met in consultation had somewhat
+humiliated him at the very bedside of the patient, before the assembled
+relatives. When, in the evening, Charles told her this anecdote, Emma
+inveighed loudly against his colleague. Charles was much touched. He
+kissed her forehead with a tear in his eyes. But she was angered with
+shame; she felt a wild desire to strike him; she went to open the window
+in the passage and breathed in the fresh air to calm herself.
+
+“What a man! What a man!” she said in a low voice, biting her lips.
+
+Besides, she was becoming more irritated with him. As he grew older his
+manner grew heavier; at dessert he cut the corks of the empty bottles;
+after eating he cleaned his teeth with his tongue; in taking soup
+he made a gurgling noise with every spoonful; and, as he was getting
+fatter, the puffed-out cheeks seemed to push the eyes, always small, up
+to the temples.
+
+Sometimes Emma tucked the red borders of his under-vest unto his
+waistcoat, rearranged his cravat, and threw away the dirty gloves he was
+going to put on; and this was not, as he fancied, for himself; it
+was for herself, by a diffusion of egotism, of nervous irritation.
+Sometimes, too, she told him of what she had read, such as a passage in
+a novel, of a new play, or an anecdote of the “upper ten” that she
+had seen in a feuilleton; for, after all, Charles was something, an
+ever-open ear, and ever-ready approbation. She confided many a thing to
+her greyhound. She would have done so to the logs in the fireplace or to
+the pendulum of the clock.
+
+At the bottom of her heart, however, she was waiting for something to
+happen. Like shipwrecked sailors, she turned despairing eyes upon the
+solitude of her life, seeking afar off some white sail in the mists of
+the horizon. She did not know what this chance would be, what wind would
+bring it her, towards what shore it would drive her, if it would be a
+shallop or a three-decker, laden with anguish or full of bliss to the
+portholes. But each morning, as she awoke, she hoped it would come that
+day; she listened to every sound, sprang up with a start, wondered that
+it did not come; then at sunset, always more saddened, she longed for
+the morrow.
+
+Spring came round. With the first warm weather, when the pear trees
+began to blossom, she suffered from dyspnoea.
+
+From the beginning of July she counted how many weeks there were to
+October, thinking that perhaps the Marquis d’Andervilliers would give
+another ball at Vaubyessard. But all September passed without letters or
+visits.
+
+After the ennui of this disappointment her heart once more remained
+empty, and then the same series of days recommenced. So now they would
+thus follow one another, always the same, immovable, and bringing
+nothing. Other lives, however flat, had at least the chance of some
+event. One adventure sometimes brought with it infinite consequences and
+the scene changed. But nothing happened to her; God had willed it so!
+The future was a dark corridor, with its door at the end shut fast.
+
+She gave up music. What was the good of playing? Who would hear her?
+Since she could never, in a velvet gown with short sleeves, striking
+with her light fingers the ivory keys of an Erard at a concert, feel
+the murmur of ecstasy envelop her like a breeze, it was not worth while
+boring herself with practicing. Her drawing cardboard and her embroidery
+she left in the cupboard. What was the good? What was the good? Sewing
+irritated her. “I have read everything,” she said to herself. And she
+sat there making the tongs red-hot, or looked at the rain falling.
+
+How sad she was on Sundays when vespers sounded! She listened with dull
+attention to each stroke of the cracked bell. A cat slowly walking over
+some roof put up his back in the pale rays of the sun. The wind on the
+highroad blew up clouds of dust. Afar off a dog sometimes howled; and
+the bell, keeping time, continued its monotonous ringing that died away
+over the fields.
+
+But the people came out from church. The women in waxed clogs, the
+peasants in new blouses, the little bare-headed children skipping along
+in front of them, all were going home. And till nightfall, five or six
+men, always the same, stayed playing at corks in front of the large door
+of the inn.
+
+The winter was severe. The windows every morning were covered with
+rime, and the light shining through them, dim as through ground-glass,
+sometimes did not change the whole day long. At four o’clock the lamp
+had to be lighted.
+
+On fine days she went down into the garden. The dew had left on the
+cabbages a silver lace with long transparent threads spreading from one
+to the other. No birds were to be heard; everything seemed asleep, the
+espalier covered with straw, and the vine, like a great sick serpent
+under the coping of the wall, along which, on drawing near, one saw the
+many-footed woodlice crawling. Under the spruce by the hedgerow, the
+curie in the three-cornered hat reading his breviary had lost his right
+foot, and the very plaster, scaling off with the frost, had left white
+scabs on his face.
+
+Then she went up again, shut her door, put on coals, and fainting with
+the heat of the hearth, felt her boredom weigh more heavily than ever.
+She would have liked to go down and talk to the servant, but a sense of
+shame restrained her.
+
+Every day at the same time the schoolmaster in a black skullcap opened
+the shutters of his house, and the rural policeman, wearing his sabre
+over his blouse, passed by. Night and morning the post-horses, three by
+three, crossed the street to water at the pond. From time to time the
+bell of a public house door rang, and when it was windy one could hear
+the little brass basins that served as signs for the hairdresser’s shop
+creaking on their two rods. This shop had as decoration an old engraving
+of a fashion-plate stuck against a windowpane and the wax bust of a
+woman with yellow hair. He, too, the hairdresser, lamented his wasted
+calling, his hopeless future, and dreaming of some shop in a big
+town--at Rouen, for example, overlooking the harbour, near the
+theatre--he walked up and down all day from the mairie to the church,
+sombre and waiting for customers. When Madame Bovary looked up, she
+always saw him there, like a sentinel on duty, with his skullcap over
+his ears and his vest of lasting.
+
+Sometimes in the afternoon outside the window of her room, the head of a
+man appeared, a swarthy head with black whiskers, smiling slowly, with
+a broad, gentle smile that showed his white teeth. A waltz immediately
+began and on the organ, in a little drawing room, dancers the size of
+a finger, women in pink turbans, Tyrolians in jackets, monkeys in frock
+coats, gentlemen in knee-breeches, turned and turned between the sofas,
+the consoles, multiplied in the bits of looking glass held together
+at their corners by a piece of gold paper. The man turned his handle,
+looking to the right and left, and up at the windows. Now and again,
+while he shot out a long squirt of brown saliva against the milestone,
+with his knee raised his instrument, whose hard straps tired his
+shoulder; and now, doleful and drawling, or gay and hurried, the music
+escaped from the box, droning through a curtain of pink taffeta under
+a brass claw in arabesque. They were airs played in other places at
+the theatres, sung in drawing rooms, danced to at night under lighted
+lustres, echoes of the world that reached even to Emma. Endless
+sarabands ran through her head, and, like an Indian dancing girl on the
+flowers of a carpet, her thoughts leapt with the notes, swung from dream
+to dream, from sadness to sadness. When the man had caught some coppers
+in his cap, he drew down an old cover of blue cloth, hitched his organ
+on to his back, and went off with a heavy tread. She watched him going.
+
+But it was above all the meal-times that were unbearable to her, in this
+small room on the ground floor, with its smoking stove, its creaking
+door, the walls that sweated, the damp flags; all the bitterness in life
+seemed served up on her plate, and with smoke of the boiled beef there
+rose from her secret soul whiffs of sickliness. Charles was a slow
+eater; she played with a few nuts, or, leaning on her elbow, amused
+herself with drawing lines along the oilcloth table cover with the point
+of her knife.
+
+She now let everything in her household take care of itself, and Madame
+Bovary senior, when she came to spend part of Lent at Tostes, was much
+surprised at the change. She who was formerly so careful, so dainty,
+now passed whole days without dressing, wore grey cotton stockings, and
+burnt tallow candles. She kept saying they must be economical since
+they were not rich, adding that she was very contented, very happy, that
+Tostes pleased her very much, with other speeches that closed the mouth
+of her mother-in-law. Besides, Emma no longer seemed inclined to follow
+her advice; once even, Madame Bovary having thought fit to maintain that
+mistresses ought to keep an eye on the religion of their servants, she
+had answered with so angry a look and so cold a smile that the good
+woman did not interfere again.
+
+Emma was growing difficult, capricious. She ordered dishes for herself,
+then she did not touch them; one day drank only pure milk, the next
+cups of tea by the dozen. Often she persisted in not going out, then,
+stifling, threw open the windows and put on light dresses. After she had
+well scolded her servant she gave her presents or sent her out to see
+neighbours, just as she sometimes threw beggars all the silver in her
+purse, although she was by no means tender-hearted or easily accessible
+to the feelings of others, like most country-bred people, who always
+retain in their souls something of the horny hardness of the paternal
+hands.
+
+Towards the end of February old Rouault, in memory of his cure, himself
+brought his son-in-law a superb turkey, and stayed three days at Tostes.
+Charles being with his patients, Emma kept him company. He smoked in the
+room, spat on the firedogs, talked farming, calves, cows, poultry, and
+municipal council, so that when he left she closed the door on him with
+a feeling of satisfaction that surprised even herself. Moreover she no
+longer concealed her contempt for anything or anybody, and at times she
+set herself to express singular opinions, finding fault with that which
+others approved, and approving things perverse and immoral, all of which
+made her husband open his eyes widely.
+
+Would this misery last for ever? Would she never issue from it? Yet
+she was as good as all the women who were living happily. She had seen
+duchesses at Vaubyessard with clumsier waists and commoner ways, and she
+execrated the injustice of God. She leant her head against the walls
+to weep; she envied lives of stir; longed for masked balls, for violent
+pleasures, with all the wildness that she did not know, but that these
+must surely yield.
+
+She grew pale and suffered from palpitations of the heart.
+
+Charles prescribed valerian and camphor baths. Everything that was tried
+only seemed to irritate her the more.
+
+On certain days she chatted with feverish rapidity, and this
+over-excitement was suddenly followed by a state of torpor, in which
+she remained without speaking, without moving. What then revived her was
+pouring a bottle of eau-de-cologne over her arms.
+
+As she was constantly complaining about Tostes, Charles fancied that her
+illness was no doubt due to some local cause, and fixing on this idea,
+began to think seriously of setting up elsewhere.
+
+From that moment she drank vinegar, contracted a sharp little cough, and
+completely lost her appetite.
+
+It cost Charles much to give up Tostes after living there four years and
+“when he was beginning to get on there.” Yet if it must be! He took her
+to Rouen to see his old master. It was a nervous complaint: change of
+air was needed.
+
+After looking about him on this side and on that, Charles learnt that
+in the Neufchatel arrondissement there was a considerable market town
+called Yonville-l’Abbaye, whose doctor, a Polish refugee, had decamped a
+week before. Then he wrote to the chemist of the place to ask the
+number of the population, the distance from the nearest doctor, what
+his predecessor had made a year, and so forth; and the answer being
+satisfactory, he made up his mind to move towards the spring, if Emma’s
+health did not improve.
+
+One day when, in view of her departure, she was tidying a drawer,
+something pricked her finger. It was a wire of her wedding bouquet.
+The orange blossoms were yellow with dust and the silver bordered satin
+ribbons frayed at the edges. She threw it into the fire. It flared
+up more quickly than dry straw. Then it was, like a red bush in the
+cinders, slowly devoured. She watched it burn.
+
+The little pasteboard berries burst, the wire twisted, the gold
+lace melted; and the shriveled paper corollas, fluttering like black
+butterflies at the back of the stove, at last flew up the chimney.
+
+When they left Tostes at the month of March, Madame Bovary was pregnant.
+
+
+
+
+
+Part II
+
+
+
+Chapter One
+
+Yonville-l’Abbaye (so called from an old Capuchin abbey of which not
+even the ruins remain) is a market-town twenty-four miles from Rouen,
+between the Abbeville and Beauvais roads, at the foot of a valley
+watered by the Rieule, a little river that runs into the Andelle after
+turning three water-mills near its mouth, where there are a few trout
+that the lads amuse themselves by fishing for on Sundays.
+
+We leave the highroad at La Boissiere and keep straight on to the top of
+the Leux hill, whence the valley is seen. The river that runs through it
+makes of it, as it were, two regions with distinct physiognomies--all on
+the left is pasture land, all of the right arable. The meadow stretches
+under a bulge of low hills to join at the back with the pasture land of
+the Bray country, while on the eastern side, the plain, gently rising,
+broadens out, showing as far as eye can follow its blond cornfields. The
+water, flowing by the grass, divides with a white line the colour of the
+roads and of the plains, and the country is like a great unfolded mantle
+with a green velvet cape bordered with a fringe of silver.
+
+Before us, on the verge of the horizon, lie the oaks of the forest of
+Argueil, with the steeps of the Saint-Jean hills scarred from top
+to bottom with red irregular lines; they are rain tracks, and these
+brick-tones standing out in narrow streaks against the grey colour of
+the mountain are due to the quantity of iron springs that flow beyond in
+the neighboring country.
+
+Here we are on the confines of Normandy, Picardy, and the Ile-de-France,
+a bastard land whose language is without accent and its landscape is
+without character. It is there that they make the worst Neufchatel
+cheeses of all the arrondissement; and, on the other hand, farming is
+costly because so much manure is needed to enrich this friable soil full
+of sand and flints.
+
+Up to 1835 there was no practicable road for getting to Yonville, but
+about this time a cross-road was made which joins that of Abbeville to
+that of Amiens, and is occasionally used by the Rouen wagoners on their
+way to Flanders. Yonville-l’Abbaye has remained stationary in spite of
+its “new outlet.” Instead of improving the soil, they persist in keeping
+up the pasture lands, however depreciated they may be in value, and
+the lazy borough, growing away from the plain, has naturally spread
+riverwards. It is seem from afar sprawling along the banks like a
+cowherd taking a siesta by the water-side.
+
+At the foot of the hill beyond the bridge begins a roadway, planted with
+young aspens, that leads in a straight line to the first houses in the
+place. These, fenced in by hedges, are in the middle of courtyards
+full of straggling buildings, wine-presses, cart-sheds and distilleries
+scattered under thick trees, with ladders, poles, or scythes hung on to
+the branches. The thatched roofs, like fur caps drawn over eyes, reach
+down over about a third of the low windows, whose coarse convex glasses
+have knots in the middle like the bottoms of bottles. Against the
+plaster wall diagonally crossed by black joists, a meagre pear-tree
+sometimes leans and the ground-floors have at their door a small
+swing-gate to keep out the chicks that come pilfering crumbs of bread
+steeped in cider on the threshold. But the courtyards grow narrower,
+the houses closer together, and the fences disappear; a bundle of
+ferns swings under a window from the end of a broomstick; there is a
+blacksmith’s forge and then a wheelwright’s, with two or three new carts
+outside that partly block the way. Then across an open space appears a
+white house beyond a grass mound ornamented by a Cupid, his finger
+on his lips; two brass vases are at each end of a flight of steps;
+scutcheons* blaze upon the door. It is the notary’s house, and the
+finest in the place.
+
+     *The panonceaux that have to be hung over the doors of
+     notaries.
+
+The Church is on the other side of the street, twenty paces farther
+down, at the entrance of the square. The little cemetery that surrounds
+it, closed in by a wall breast high, is so full of graves that the old
+stones, level with the ground, form a continuous pavement, on which the
+grass of itself has marked out regular green squares. The church was
+rebuilt during the last years of the reign of Charles X. The wooden roof
+is beginning to rot from the top, and here and there has black hollows
+in its blue colour. Over the door, where the organ should be, is a
+loft for the men, with a spiral staircase that reverberates under their
+wooden shoes.
+
+The daylight coming through the plain glass windows falls obliquely upon
+the pews ranged along the walls, which are adorned here and there with
+a straw mat bearing beneath it the words in large letters, “Mr.
+So-and-so’s pew.” Farther on, at a spot where the building narrows, the
+confessional forms a pendant to a statuette of the Virgin, clothed in
+a satin robe, coifed with a tulle veil sprinkled with silver stars, and
+with red cheeks, like an idol of the Sandwich Islands; and, finally, a
+copy of the “Holy Family, presented by the Minister of the Interior,”
+ overlooking the high altar, between four candlesticks, closes in the
+perspective. The choir stalls, of deal wood, have been left unpainted.
+
+The market, that is to say, a tiled roof supported by some twenty posts,
+occupies of itself about half the public square of Yonville. The town
+hall, constructed “from the designs of a Paris architect,” is a sort of
+Greek temple that forms the corner next to the chemist’s shop. On
+the ground-floor are three Ionic columns and on the first floor a
+semicircular gallery, while the dome that crowns it is occupied by a
+Gallic cock, resting one foot upon the “Charte” and holding in the other
+the scales of Justice.
+
+But that which most attracts the eye is opposite the Lion d’Or inn, the
+chemist’s shop of Monsieur Homais. In the evening especially its argand
+lamp is lit up and the red and green jars that embellish his shop-front
+throw far across the street their two streams of colour; then across
+them as if in Bengal lights is seen the shadow of the chemist
+leaning over his desk. His house from top to bottom is placarded with
+inscriptions written in large hand, round hand, printed hand: “Vichy,
+Seltzer, Barege waters, blood purifiers, Raspail patent medicine,
+Arabian racahout, Darcet lozenges, Regnault paste, trusses, baths,
+hygienic chocolate,” etc. And the signboard, which takes up all the
+breadth of the shop, bears in gold letters, “Homais, Chemist.” Then at
+the back of the shop, behind the great scales fixed to the counter, the
+word “Laboratory” appears on a scroll above a glass door, which about
+half-way up once more repeats “Homais” in gold letters on a black
+ground.
+
+Beyond this there is nothing to see at Yonville. The street (the only
+one) a gunshot in length and flanked by a few shops on either side stops
+short at the turn of the highroad. If it is left on the right hand and
+the foot of the Saint-Jean hills followed the cemetery is soon reached.
+
+At the time of the cholera, in order to enlarge this, a piece of wall
+was pulled down, and three acres of land by its side purchased; but all
+the new portion is almost tenantless; the tombs, as heretofore,
+continue to crowd together towards the gate. The keeper, who is at once
+gravedigger and church beadle (thus making a double profit out of the
+parish corpses), has taken advantage of the unused plot of ground to
+plant potatoes there. From year to year, however, his small field grows
+smaller, and when there is an epidemic, he does not know whether to
+rejoice at the deaths or regret the burials.
+
+“You live on the dead, Lestiboudois!” the curie at last said to him one
+day. This grim remark made him reflect; it checked him for some time;
+but to this day he carries on the cultivation of his little tubers, and
+even maintains stoutly that they grow naturally.
+
+Since the events about to be narrated, nothing in fact has changed
+at Yonville. The tin tricolour flag still swings at the top of the
+church-steeple; the two chintz streamers still flutter in the wind from
+the linen-draper’s; the chemist’s fetuses, like lumps of white amadou,
+rot more and more in their turbid alcohol, and above the big door of
+the inn the old golden lion, faded by rain, still shows passers-by its
+poodle mane.
+
+On the evening when the Bovarys were to arrive at Yonville, Widow
+Lefrancois, the landlady of this inn, was so very busy that she sweated
+great drops as she moved her saucepans. To-morrow was market-day. The
+meat had to be cut beforehand, the fowls drawn, the soup and coffee
+made. Moreover, she had the boarders’ meal to see to, and that of the
+doctor, his wife, and their servant; the billiard-room was echoing with
+bursts of laughter; three millers in a small parlour were calling for
+brandy; the wood was blazing, the brazen pan was hissing, and on the
+long kitchen table, amid the quarters of raw mutton, rose piles of
+plates that rattled with the shaking of the block on which spinach was
+being chopped.
+
+From the poultry-yard was heard the screaming of the fowls whom the
+servant was chasing in order to wring their necks.
+
+A man slightly marked with small-pox, in green leather slippers, and
+wearing a velvet cap with a gold tassel, was warming his back at the
+chimney. His face expressed nothing but self-satisfaction, and he
+appeared to take life as calmly as the goldfinch suspended over his head
+in its wicker cage: this was the chemist.
+
+“Artemise!” shouted the landlady, “chop some wood, fill the water
+bottles, bring some brandy, look sharp! If only I knew what dessert to
+offer the guests you are expecting! Good heavens! Those furniture-movers
+are beginning their racket in the billiard-room again; and their van has
+been left before the front door! The ‘Hirondelle’ might run into it when
+it draws up. Call Polyte and tell him to put it up. Only think, Monsieur
+Homais, that since morning they have had about fifteen games, and drunk
+eight jars of cider! Why, they’ll tear my cloth for me,” she went on,
+looking at them from a distance, her strainer in her hand.
+
+“That wouldn’t be much of a loss,” replied Monsieur Homais. “You would
+buy another.”
+
+“Another billiard-table!” exclaimed the widow.
+
+“Since that one is coming to pieces, Madame Lefrancois. I tell you again
+you are doing yourself harm, much harm! And besides, players now want
+narrow pockets and heavy cues. Hazards aren’t played now; everything is
+changed! One must keep pace with the times! Just look at Tellier!”
+
+The hostess reddened with vexation. The chemist went on--
+
+“You may say what you like; his table is better than yours; and if one
+were to think, for example, of getting up a patriotic pool for Poland or
+the sufferers from the Lyons floods--”
+
+“It isn’t beggars like him that’ll frighten us,” interrupted the
+landlady, shrugging her fat shoulders. “Come, come, Monsieur Homais; as
+long as the ‘Lion d’Or’ exists people will come to it. We’ve feathered
+our nest; while one of these days you’ll find the ‘Cafe Francais’ closed
+with a big placard on the shutters. Change my billiard-table!” she went
+on, speaking to herself, “the table that comes in so handy for folding
+the washing, and on which, in the hunting season, I have slept six
+visitors! But that dawdler, Hivert, doesn’t come!”
+
+“Are you waiting for him for your gentlemen’s dinner?”
+
+“Wait for him! And what about Monsieur Binet? As the clock strikes
+six you’ll see him come in, for he hasn’t his equal under the sun for
+punctuality. He must always have his seat in the small parlour. He’d
+rather die than dine anywhere else. And so squeamish as he is, and so
+particular about the cider! Not like Monsieur Leon; he sometimes comes
+at seven, or even half-past, and he doesn’t so much as look at what he
+eats. Such a nice young man! Never speaks a rough word!”
+
+“Well, you see, there’s a great difference between an educated man and
+an old carabineer who is now a tax-collector.”
+
+Six o’clock struck. Binet came in.
+
+He wore a blue frock-coat falling in a straight line round his thin
+body, and his leather cap, with its lappets knotted over the top of
+his head with string, showed under the turned-up peak a bald forehead,
+flattened by the constant wearing of a helmet. He wore a black cloth
+waistcoat, a hair collar, grey trousers, and, all the year round,
+well-blacked boots, that had two parallel swellings due to the sticking
+out of his big-toes. Not a hair stood out from the regular line of fair
+whiskers, which, encircling his jaws, framed, after the fashion of a
+garden border, his long, wan face, whose eyes were small and the nose
+hooked. Clever at all games of cards, a good hunter, and writing a
+fine hand, he had at home a lathe, and amused himself by turning napkin
+rings, with which he filled up his house, with the jealousy of an artist
+and the egotism of a bourgeois.
+
+He went to the small parlour, but the three millers had to be got out
+first, and during the whole time necessary for laying the cloth, Binet
+remained silent in his place near the stove. Then he shut the door and
+took off his cap in his usual way.
+
+“It isn’t with saying civil things that he’ll wear out his tongue,” said
+the chemist, as soon as he was along with the landlady.
+
+“He never talks more,” she replied. “Last week two travelers in the
+cloth line were here--such clever chaps who told such jokes in the
+evening, that I fairly cried with laughing; and he stood there like a
+dab fish and never said a word.”
+
+“Yes,” observed the chemist; “no imagination, no sallies, nothing that
+makes the society-man.”
+
+“Yet they say he has parts,” objected the landlady.
+
+“Parts!” replied Monsieur Homais; “he, parts! In his own line it is
+possible,” he added in a calmer tone. And he went on--
+
+“Ah! That a merchant, who has large connections, a jurisconsult, a
+doctor, a chemist, should be thus absent-minded, that they should become
+whimsical or even peevish, I can understand; such cases are cited in
+history. But at least it is because they are thinking of something.
+Myself, for example, how often has it happened to me to look on the
+bureau for my pen to write a label, and to find, after all, that I had
+put it behind my ear!”
+
+Madame Lefrancois just then went to the door to see if the “Hirondelle”
+ were not coming. She started. A man dressed in black suddenly came into
+the kitchen. By the last gleam of the twilight one could see that his
+face was rubicund and his form athletic.
+
+“What can I do for you, Monsieur le Curie?” asked the landlady, as she
+reached down from the chimney one of the copper candlesticks placed
+with their candles in a row. “Will you take something? A thimbleful of
+Cassis*? A glass of wine?”
+
+     *Black currant liqueur.
+
+The priest declined very politely. He had come for his umbrella, that
+he had forgotten the other day at the Ernemont convent, and after
+asking Madame Lefrancois to have it sent to him at the presbytery in the
+evening, he left for the church, from which the Angelus was ringing.
+
+When the chemist no longer heard the noise of his boots along the
+square, he thought the priest’s behaviour just now very unbecoming. This
+refusal to take any refreshment seemed to him the most odious hypocrisy;
+all priests tippled on the sly, and were trying to bring back the days
+of the tithe.
+
+The landlady took up the defence of her curie.
+
+“Besides, he could double up four men like you over his knee. Last year
+he helped our people to bring in the straw; he carried as many as six
+trusses at once, he is so strong.”
+
+“Bravo!” said the chemist. “Now just send your daughters to confess to
+fellows which such a temperament! I, if I were the Government, I’d have
+the priests bled once a month. Yes, Madame Lefrancois, every month--a
+good phlebotomy, in the interests of the police and morals.”
+
+“Be quiet, Monsieur Homais. You are an infidel; you’ve no religion.”
+
+The chemist answered: “I have a religion, my religion, and I even have
+more than all these others with their mummeries and their juggling.
+I adore God, on the contrary. I believe in the Supreme Being, in a
+Creator, whatever he may be. I care little who has placed us here below
+to fulfil our duties as citizens and fathers of families; but I don’t
+need to go to church to kiss silver plates, and fatten, out of my
+pocket, a lot of good-for-nothings who live better than we do. For one
+can know Him as well in a wood, in a field, or even contemplating the
+eternal vault like the ancients. My God! Mine is the God of Socrates, of
+Franklin, of Voltaire, and of Beranger! I am for the profession of faith
+of the ‘Savoyard Vicar,’ and the immortal principles of ‘89! And I can’t
+admit of an old boy of a God who takes walks in his garden with a
+cane in his hand, who lodges his friends in the belly of whales, dies
+uttering a cry, and rises again at the end of three days; things absurd
+in themselves, and completely opposed, moreover, to all physical laws,
+which prove to us, by the way, that priests have always wallowed in
+turpid ignorance, in which they would fain engulf the people with them.”
+
+He ceased, looking round for an audience, for in his bubbling over
+the chemist had for a moment fancied himself in the midst of the town
+council. But the landlady no longer heeded him; she was listening to a
+distant rolling. One could distinguish the noise of a carriage mingled
+with the clattering of loose horseshoes that beat against the ground,
+and at last the “Hirondelle” stopped at the door.
+
+It was a yellow box on two large wheels, that, reaching to the tilt,
+prevented travelers from seeing the road and dirtied their shoulders.
+The small panes of the narrow windows rattled in their sashes when the
+coach was closed, and retained here and there patches of mud amid the
+old layers of dust, that not even storms of rain had altogether washed
+away. It was drawn by three horses, the first a leader, and when it came
+down-hill its bottom jolted against the ground.
+
+Some of the inhabitants of Yonville came out into the square; they all
+spoke at once, asking for news, for explanations, for hampers. Hivert
+did not know whom to answer. It was he who did the errands of the place
+in town. He went to the shops and brought back rolls of leather for
+the shoemaker, old iron for the farrier, a barrel of herrings for his
+mistress, caps from the milliner’s, locks from the hair-dresser’s and
+all along the road on his return journey he distributed his parcels,
+which he threw, standing upright on his seat and shouting at the top of
+his voice, over the enclosures of the yards.
+
+An accident had delayed him. Madame Bovary’s greyhound had run across
+the field. They had whistled for him a quarter of an hour; Hivert had
+even gone back a mile and a half expecting every moment to catch sight
+of her; but it had been necessary to go on.
+
+Emma had wept, grown angry; she had accused Charles of this misfortune.
+Monsieur Lheureux, a draper, who happened to be in the coach with
+her, had tried to console her by a number of examples of lost dogs
+recognizing their masters at the end of long years. One, he said had
+been told of, who had come back to Paris from Constantinople. Another
+had gone one hundred and fifty miles in a straight line, and swum four
+rivers; and his own father had possessed a poodle, which, after twelve
+years of absence, had all of a sudden jumped on his back in the street
+as he was going to dine in town.
+
+
+
+Chapter Two
+
+Emma got out first, then Felicite, Monsieur Lheureux, and a nurse, and
+they had to wake up Charles in his corner, where he had slept soundly
+since night set in.
+
+Homais introduced himself; he offered his homages to madame and his
+respects to monsieur; said he was charmed to have been able to render
+them some slight service, and added with a cordial air that he had
+ventured to invite himself, his wife being away.
+
+When Madame Bovary was in the kitchen she went up to the chimney.
+
+With the tips of her fingers she caught her dress at the knee, and
+having thus pulled it up to her ankle, held out her foot in its black
+boot to the fire above the revolving leg of mutton. The flame lit up the
+whole of her, penetrating with a crude light the woof of her gowns, the
+fine pores of her fair skin, and even her eyelids, which she blinked now
+and again. A great red glow passed over her with the blowing of the wind
+through the half-open door.
+
+On the other side of the chimney a young man with fair hair watched her
+silently.
+
+As he was a good deal bored at Yonville, where he was a clerk at the
+notary’s, Monsieur Guillaumin, Monsieur Leon Dupuis (it was he who
+was the second habitue of the “Lion d’Or”) frequently put back his
+dinner-hour in hope that some traveler might come to the inn, with whom
+he could chat in the evening. On the days when his work was done early,
+he had, for want of something else to do, to come punctually, and endure
+from soup to cheese a tete-a-tete with Binet. It was therefore with
+delight that he accepted the landlady’s suggestion that he should dine
+in company with the newcomers, and they passed into the large parlour
+where Madame Lefrancois, for the purpose of showing off, had had the
+table laid for four.
+
+Homais asked to be allowed to keep on his skull-cap, for fear of coryza;
+then, turning to his neighbour--
+
+“Madame is no doubt a little fatigued; one gets jolted so abominably in
+our ‘Hirondelle.’”
+
+“That is true,” replied Emma; “but moving about always amuses me. I like
+change of place.”
+
+“It is so tedious,” sighed the clerk, “to be always riveted to the same
+places.”
+
+“If you were like me,” said Charles, “constantly obliged to be in the
+saddle”--
+
+“But,” Leon went on, addressing himself to Madame Bovary, “nothing, it
+seems to me, is more pleasant--when one can,” he added.
+
+“Moreover,” said the druggist, “the practice of medicine is not very
+hard work in our part of the world, for the state of our roads allows us
+the use of gigs, and generally, as the farmers are prosperous, they pay
+pretty well. We have, medically speaking, besides the ordinary cases
+of enteritis, bronchitis, bilious affections, etc., now and then a
+few intermittent fevers at harvest-time; but on the whole, little of a
+serious nature, nothing special to note, unless it be a great deal of
+scrofula, due, no doubt, to the deplorable hygienic conditions of our
+peasant dwellings. Ah! you will find many prejudices to combat, Monsieur
+Bovary, much obstinacy of routine, with which all the efforts of your
+science will daily come into collision; for people still have recourse
+to novenas, to relics, to the priest, rather than come straight to the
+doctor or the chemist. The climate, however, is not, truth to tell, bad,
+and we even have a few nonagenarians in our parish. The thermometer (I
+have made some observations) falls in winter to 4 degrees Centigrade
+at the outside, which gives us 24 degrees Reaumur as the maximum, or
+otherwise 54 degrees Fahrenheit (English scale), not more. And, as a
+matter of fact, we are sheltered from the north winds by the forest of
+Argueil on the one side, from the west winds by the St. Jean range on
+the other; and this heat, moreover, which, on account of the aqueous
+vapours given off by the river and the considerable number of cattle
+in the fields, which, as you know, exhale much ammonia, that is to say,
+nitrogen, hydrogen and oxygen (no, nitrogen and hydrogen alone), and
+which sucking up into itself the humus from the ground, mixing together
+all those different emanations, unites them into a stack, so to say,
+and combining with the electricity diffused through the atmosphere, when
+there is any, might in the long run, as in tropical countries, engender
+insalubrious miasmata--this heat, I say, finds itself perfectly tempered
+on the side whence it comes, or rather whence it should come--that is to
+say, the southern side--by the south-eastern winds, which, having cooled
+themselves passing over the Seine, reach us sometimes all at once like
+breezes from Russia.”
+
+“At any rate, you have some walks in the neighbourhood?” continued
+Madame Bovary, speaking to the young man.
+
+“Oh, very few,” he answered. “There is a place they call La Pature, on
+the top of the hill, on the edge of the forest. Sometimes, on Sundays, I
+go and stay there with a book, watching the sunset.”
+
+“I think there is nothing so admirable as sunsets,” she resumed; “but
+especially by the side of the sea.”
+
+“Oh, I adore the sea!” said Monsieur Leon.
+
+“And then, does it not seem to you,” continued Madame Bovary, “that the
+mind travels more freely on this limitless expanse, the contemplation of
+which elevates the soul, gives ideas of the infinite, the ideal?”
+
+“It is the same with mountainous landscapes,” continued Leon. “A cousin
+of mine who travelled in Switzerland last year told me that one could
+not picture to oneself the poetry of the lakes, the charm of the
+waterfalls, the gigantic effect of the glaciers. One sees pines of
+incredible size across torrents, cottages suspended over precipices,
+and, a thousand feet below one, whole valleys when the clouds open. Such
+spectacles must stir to enthusiasm, incline to prayer, to ecstasy; and I
+no longer marvel at that celebrated musician who, the better to inspire
+his imagination, was in the habit of playing the piano before some
+imposing site.”
+
+“You play?” she asked.
+
+“No, but I am very fond of music,” he replied.
+
+“Ah! don’t you listen to him, Madame Bovary,” interrupted Homais,
+bending over his plate. “That’s sheer modesty. Why, my dear fellow, the
+other day in your room you were singing ‘L’Ange Gardien’ ravishingly. I
+heard you from the laboratory. You gave it like an actor.”
+
+Leon, in fact, lodged at the chemist’s where he had a small room on the
+second floor, overlooking the Place. He blushed at the compliment of his
+landlord, who had already turned to the doctor, and was enumerating to
+him, one after the other, all the principal inhabitants of Yonville. He
+was telling anecdotes, giving information; the fortune of the notary
+was not known exactly, and “there was the Tuvache household,” who made a
+good deal of show.
+
+Emma continued, “And what music do you prefer?”
+
+“Oh, German music; that which makes you dream.”
+
+“Have you been to the opera?”
+
+“Not yet; but I shall go next year, when I am living at Paris to finish
+reading for the bar.”
+
+“As I had the honour of putting it to your husband,” said the chemist,
+“with regard to this poor Yanoda who has run away, you will find
+yourself, thanks to his extravagance, in the possession of one of the
+most comfortable houses of Yonville. Its greatest convenience for a
+doctor is a door giving on the Walk, where one can go in and out unseen.
+Moreover, it contains everything that is agreeable in a household--a
+laundry, kitchen with offices, sitting-room, fruit-room, and so on. He
+was a gay dog, who didn’t care what he spent. At the end of the garden,
+by the side of the water, he had an arbour built just for the purpose of
+drinking beer in summer; and if madame is fond of gardening she will be
+able--”
+
+“My wife doesn’t care about it,” said Charles; “although she has
+been advised to take exercise, she prefers always sitting in her room
+reading.”
+
+“Like me,” replied Leon. “And indeed, what is better than to sit by
+one’s fireside in the evening with a book, while the wind beats against
+the window and the lamp is burning?”
+
+“What, indeed?” she said, fixing her large black eyes wide open upon
+him.
+
+“One thinks of nothing,” he continued; “the hours slip by. Motionless we
+traverse countries we fancy we see, and your thought, blending with
+the fiction, playing with the details, follows the outline of the
+adventures. It mingles with the characters, and it seems as if it were
+yourself palpitating beneath their costumes.”
+
+“That is true! That is true?” she said.
+
+“Has it ever happened to you,” Leon went on, “to come across some vague
+idea of one’s own in a book, some dim image that comes back to you from
+afar, and as the completest expression of your own slightest sentiment?”
+
+“I have experienced it,” she replied.
+
+“That is why,” he said, “I especially love the poets. I think verse more
+tender than prose, and that it moves far more easily to tears.”
+
+“Still in the long run it is tiring,” continued Emma. “Now I, on the
+contrary, adore stories that rush breathlessly along, that frighten one.
+I detest commonplace heroes and moderate sentiments, such as there are
+in nature.”
+
+“In fact,” observed the clerk, “these works, not touching the heart,
+miss, it seems to me, the true end of art. It is so sweet, amid all
+the disenchantments of life, to be able to dwell in thought upon noble
+characters, pure affections, and pictures of happiness. For myself,
+living here far from the world, this is my one distraction; but Yonville
+affords so few resources.”
+
+“Like Tostes, no doubt,” replied Emma; “and so I always subscribed to a
+lending library.”
+
+“If madame will do me the honour of making use of it”, said the chemist,
+who had just caught the last words, “I have at her disposal a library
+composed of the best authors, Voltaire, Rousseau, Delille, Walter
+Scott, the ‘Echo des Feuilletons’; and in addition I receive various
+periodicals, among them the ‘Fanal de Rouen’ daily, having the advantage
+to be its correspondent for the districts of Buchy, Forges, Neufchatel,
+Yonville, and vicinity.”
+
+For two hours and a half they had been at table; for the servant
+Artemis, carelessly dragging her old list slippers over the flags,
+brought one plate after the other, forgot everything, and constantly
+left the door of the billiard-room half open, so that it beat against
+the wall with its hooks.
+
+Unconsciously, Leon, while talking, had placed his foot on one of the
+bars of the chair on which Madame Bovary was sitting. She wore a small
+blue silk necktie, that kept up like a ruff a gauffered cambric collar,
+and with the movements of her head the lower part of her face gently
+sunk into the linen or came out from it. Thus side by side, while
+Charles and the chemist chatted, they entered into one of those vague
+conversations where the hazard of all that is said brings you back to
+the fixed centre of a common sympathy. The Paris theatres, titles of
+novels, new quadrilles, and the world they did not know; Tostes, where
+she had lived, and Yonville, where they were; they examined all, talked
+of everything till to the end of dinner.
+
+When coffee was served Felicite went away to get ready the room in the
+new house, and the guests soon raised the siege. Madame Lefrancois was
+asleep near the cinders, while the stable-boy, lantern in hand, was
+waiting to show Monsieur and Madame Bovary the way home. Bits of straw
+stuck in his red hair, and he limped with his left leg. When he had
+taken in his other hand the cure’s umbrella, they started.
+
+The town was asleep; the pillars of the market threw great shadows; the
+earth was all grey as on a summer’s night. But as the doctor’s house was
+only some fifty paces from the inn, they had to say good-night almost
+immediately, and the company dispersed.
+
+As soon as she entered the passage, Emma felt the cold of the plaster
+fall about her shoulders like damp linen. The walls were new and the
+wooden stairs creaked. In their bedroom, on the first floor, a whitish
+light passed through the curtainless windows.
+
+She could catch glimpses of tree tops, and beyond, the fields,
+half-drowned in the fog that lay reeking in the moonlight along
+the course of the river. In the middle of the room, pell-mell, were
+scattered drawers, bottles, curtain-rods, gilt poles, with mattresses
+on the chairs and basins on the ground--the two men who had brought the
+furniture had left everything about carelessly.
+
+This was the fourth time that she had slept in a strange place.
+
+The first was the day of her going to the convent; the second, of her
+arrival at Tostes; the third, at Vaubyessard; and this was the fourth.
+And each one had marked, as it were, the inauguration of a new phase in
+her life. She did not believe that things could present themselves in
+the same way in different places, and since the portion of her life
+lived had been bad, no doubt that which remained to be lived would be
+better.
+
+
+
+Chapter Three
+
+The next day, as she was getting up, she saw the clerk on the Place. She
+had on a dressing-gown. He looked up and bowed. She nodded quickly and
+reclosed the window.
+
+Leon waited all day for six o’clock in the evening to come, but on going
+to the inn, he found no one but Monsieur Binet, already at table. The
+dinner of the evening before had been a considerable event for him; he
+had never till then talked for two hours consecutively to a “lady.” How
+then had he been able to explain, and in such language, the number of
+things that he could not have said so well before? He was usually
+shy, and maintained that reserve which partakes at once of modesty and
+dissimulation.
+
+At Yonville he was considered “well-bred.” He listened to the arguments
+of the older people, and did not seem hot about politics--a remarkable
+thing for a young man. Then he had some accomplishments; he painted in
+water-colours, could read the key of G, and readily talked literature
+after dinner when he did not play cards. Monsieur Homais respected him
+for his education; Madame Homais liked him for his good-nature, for
+he often took the little Homais into the garden--little brats who were
+always dirty, very much spoilt, and somewhat lymphatic, like their
+mother. Besides the servant to look after them, they had Justin, the
+chemist’s apprentice, a second cousin of Monsieur Homais, who had been
+taken into the house from charity, and who was useful at the same time
+as a servant.
+
+The druggist proved the best of neighbours. He gave Madame Bovary
+information as to the trades-people, sent expressly for his own cider
+merchant, tasted the drink himself, and saw that the casks were properly
+placed in the cellar; he explained how to set about getting in a
+supply of butter cheap, and made an arrangement with Lestiboudois, the
+sacristan, who, besides his sacerdotal and funeral functions, looked
+after the principal gardens at Yonville by the hour or the year,
+according to the taste of the customers.
+
+The need of looking after others was not the only thing that urged the
+chemist to such obsequious cordiality; there was a plan underneath it
+all.
+
+He had infringed the law of the 19th Ventose, year xi., article I, which
+forbade all persons not having a diploma to practise medicine; so that,
+after certain anonymous denunciations, Homais had been summoned to Rouen
+to see the procurer of the king in his own private room; the magistrate
+receiving him standing up, ermine on shoulder and cap on head. It was
+in the morning, before the court opened. In the corridors one heard
+the heavy boots of the gendarmes walking past, and like a far-off noise
+great locks that were shut. The druggist’s ears tingled as if he were
+about to have an apoplectic stroke; he saw the depths of dungeons,
+his family in tears, his shop sold, all the jars dispersed; and he was
+obliged to enter a cafe and take a glass of rum and seltzer to recover
+his spirits.
+
+Little by little the memory of this reprimand grew fainter, and
+he continued, as heretofore, to give anodyne consultations in his
+back-parlour. But the mayor resented it, his colleagues were jealous,
+everything was to be feared; gaining over Monsieur Bovary by his
+attentions was to earn his gratitude, and prevent his speaking out later
+on, should he notice anything. So every morning Homais brought him “the
+paper,” and often in the afternoon left his shop for a few moments to
+have a chat with the Doctor.
+
+Charles was dull: patients did not come. He remained seated for hours
+without speaking, went into his consulting room to sleep, or watched
+his wife sewing. Then for diversion he employed himself at home as a
+workman; he even tried to do up the attic with some paint which had been
+left behind by the painters. But money matters worried him. He had
+spent so much for repairs at Tostes, for madame’s toilette, and for the
+moving, that the whole dowry, over three thousand crowns, had slipped
+away in two years.
+
+Then how many things had been spoilt or lost during their carriage from
+Tostes to Yonville, without counting the plaster cure, who falling out
+of the coach at an over-severe jolt, had been dashed into a thousand
+fragments on the pavements of Quincampoix! A pleasanter trouble came
+to distract him, namely, the pregnancy of his wife. As the time of her
+confinement approached he cherished her the more. It was another bond of
+the flesh establishing itself, and, as it were, a continued sentiment
+of a more complex union. When from afar he saw her languid walk, and
+her figure without stays turning softly on her hips; when opposite one
+another he looked at her at his ease, while she took tired poses in her
+armchair, then his happiness knew no bounds; he got up, embraced her,
+passed his hands over her face, called her little mamma, wanted to
+make her dance, and half-laughing, half-crying, uttered all kinds of
+caressing pleasantries that came into his head. The idea of having
+begotten a child delighted him. Now he wanted nothing. He knew human
+life from end to end, and he sat down to it with serenity.
+
+Emma at first felt a great astonishment; then was anxious to be
+delivered that she might know what it was to be a mother. But not
+being able to spend as much as she would have liked, to have a
+swing-bassinette with rose silk curtains, and embroidered caps, in a fit
+of bitterness she gave up looking after the trousseau, and ordered the
+whole of it from a village needlewoman, without choosing or discussing
+anything. Thus she did not amuse herself with those preparations that
+stimulate the tenderness of mothers, and so her affection was from the
+very outset, perhaps, to some extent attenuated.
+
+As Charles, however, spoke of the boy at every meal, she soon began to
+think of him more consecutively.
+
+She hoped for a son; he would be strong and dark; she would call him
+George; and this idea of having a male child was like an expected
+revenge for all her impotence in the past. A man, at least, is free; he
+may travel over passions and over countries, overcome obstacles, taste
+of the most far-away pleasures. But a woman is always hampered. At once
+inert and flexible, she has against her the weakness of the flesh and
+legal dependence. Her will, like the veil of her bonnet, held by a
+string, flutters in every wind; there is always some desire that draws
+her, some conventionality that restrains.
+
+She was confined on a Sunday at about six o’clock, as the sun was
+rising.
+
+“It is a girl!” said Charles.
+
+She turned her head away and fainted.
+
+Madame Homais, as well as Madame Lefrancois of the Lion d’Or, almost
+immediately came running in to embrace her. The chemist, as man of
+discretion, only offered a few provincial felicitations through the
+half-opened door. He wished to see the child and thought it well made.
+
+Whilst she was getting well she occupied herself much in seeking a
+name for her daughter. First she went over all those that have Italian
+endings, such as Clara, Louisa, Amanda, Atala; she liked Galsuinde
+pretty well, and Yseult or Leocadie still better.
+
+Charles wanted the child to be called after her mother; Emma opposed
+this. They ran over the calendar from end to end, and then consulted
+outsiders.
+
+“Monsieur Leon,” said the chemist, “with whom I was talking about it
+the other day, wonders you do not chose Madeleine. It is very much in
+fashion just now.”
+
+But Madame Bovary, senior, cried out loudly against this name of a
+sinner. As to Monsieur Homais, he had a preference for all those that
+recalled some great man, an illustrious fact, or a generous idea, and it
+was on this system that he had baptized his four children. Thus Napoleon
+represented glory and Franklin liberty; Irma was perhaps a concession to
+romanticism, but Athalie was a homage to the greatest masterpiece of the
+French stage. For his philosophical convictions did not interfere
+with his artistic tastes; in him the thinker did not stifle the man of
+sentiment; he could make distinctions, make allowances for imagination
+and fanaticism. In this tragedy, for example, he found fault with the
+ideas, but admired the style; he detested the conception, but applauded
+all the details, and loathed the characters while he grew enthusiastic
+over their dialogue. When he read the fine passages he was transported,
+but when he thought that mummers would get something out of them for
+their show, he was disconsolate; and in this confusion of sentiments in
+which he was involved he would have liked at once to crown Racine with
+both his hands and discuss with him for a good quarter of an hour.
+
+At last Emma remembered that at the chateau of Vaubyessard she had heard
+the Marchioness call a young lady Berthe; from that moment this name was
+chosen; and as old Rouault could not come, Monsieur Homais was requested
+to stand godfather. His gifts were all products from his establishment,
+to wit: six boxes of jujubes, a whole jar of racahout, three cakes of
+marshmallow paste, and six sticks of sugar-candy into the bargain that
+he had come across in a cupboard. On the evening of the ceremony there
+was a grand dinner; the cure was present; there was much excitement.
+Monsieur Homais towards liqueur-time began singing “Le Dieu des bonnes
+gens.” Monsieur Leon sang a barcarolle, and Madame Bovary, senior, who
+was godmother, a romance of the time of the Empire; finally, M. Bovary,
+senior, insisted on having the child brought down, and began baptizing
+it with a glass of champagne that he poured over its head. This mockery
+of the first of the sacraments made the Abbe Bournisien angry; old
+Bovary replied by a quotation from “La Guerre des Dieux”; the cure
+wanted to leave; the ladies implored, Homais interfered; and they
+succeeded in making the priest sit down again, and he quietly went on
+with the half-finished coffee in his saucer.
+
+Monsieur Bovary, senior, stayed at Yonville a month, dazzling the
+natives by a superb policeman’s cap with silver tassels that he wore
+in the morning when he smoked his pipe in the square. Being also in the
+habit of drinking a good deal of brandy, he often sent the servant
+to the Lion d’Or to buy him a bottle, which was put down to his
+son’s account, and to perfume his handkerchiefs he used up his
+daughter-in-law’s whole supply of eau-de-cologne.
+
+The latter did not at all dislike his company. He had knocked about the
+world, he talked about Berlin, Vienna, and Strasbourg, of his soldier
+times, of the mistresses he had had, the grand luncheons of which he had
+partaken; then he was amiable, and sometimes even, either on the stairs,
+or in the garden, would seize hold of her waist, crying, “Charles, look
+out for yourself.”
+
+Then Madame Bovary, senior, became alarmed for her son’s happiness, and
+fearing that her husband might in the long-run have an immoral influence
+upon the ideas of the young woman, took care to hurry their departure.
+Perhaps she had more serious reasons for uneasiness. Monsieur Bovary was
+not the man to respect anything.
+
+One day Emma was suddenly seized with the desire to see her little
+girl, who had been put to nurse with the carpenter’s wife, and, without
+looking at the calendar to see whether the six weeks of the Virgin were
+yet passed, she set out for the Rollets’ house, situated at the extreme
+end of the village, between the highroad and the fields.
+
+It was mid-day, the shutters of the houses were closed and the slate
+roofs that glittered beneath the fierce light of the blue sky seemed to
+strike sparks from the crest of the gables. A heavy wind was blowing;
+Emma felt weak as she walked; the stones of the pavement hurt her; she
+was doubtful whether she would not go home again, or go in somewhere to
+rest.
+
+At this moment Monsieur Leon came out from a neighbouring door with a
+bundle of papers under his arm. He came to greet her, and stood in the
+shade in front of the Lheureux’s shop under the projecting grey awning.
+
+Madame Bovary said she was going to see her baby, but that she was
+beginning to grow tired.
+
+“If--” said Leon, not daring to go on.
+
+“Have you any business to attend to?” she asked.
+
+And on the clerk’s answer, she begged him to accompany her. That same
+evening this was known in Yonville, and Madame Tuvache, the mayor’s
+wife, declared in the presence of her servant that “Madame Bovary was
+compromising herself.”
+
+To get to the nurse’s it was necessary to turn to the left on leaving
+the street, as if making for the cemetery, and to follow between little
+houses and yards a small path bordered with privet hedges. They were
+in bloom, and so were the speedwells, eglantines, thistles, and the
+sweetbriar that sprang up from the thickets. Through openings in
+the hedges one could see into the huts, some pigs on a dung-heap, or
+tethered cows rubbing their horns against the trunk of trees. The two,
+side by side walked slowly, she leaning upon him, and he restraining
+his pace, which he regulated by hers; in front of them a swarm of midges
+fluttered, buzzing in the warm air.
+
+They recognized the house by an old walnut-tree which shaded it.
+
+Low and covered with brown tiles, there hung outside it, beneath the
+dormer-window of the garret, a string of onions. Faggots upright
+against a thorn fence surrounded a bed of lettuce, a few square feet of
+lavender, and sweet peas strung on sticks. Dirty water was running here
+and there on the grass, and all round were several indefinite rags,
+knitted stockings, a red calico jacket, and a large sheet of coarse
+linen spread over the hedge. At the noise of the gate the nurse appeared
+with a baby she was suckling on one arm. With her other hand she was
+pulling along a poor puny little fellow, his face covered with scrofula,
+the son of a Rouen hosier, whom his parents, too taken up with their
+business, left in the country.
+
+“Go in,” she said; “your little one is there asleep.”
+
+The room on the ground-floor, the only one in the dwelling, had at its
+farther end, against the wall, a large bed without curtains, while a
+kneading-trough took up the side by the window, one pane of which
+was mended with a piece of blue paper. In the corner behind the door,
+shining hob-nailed shoes stood in a row under the slab of the washstand,
+near a bottle of oil with a feather stuck in its mouth; a Matthieu
+Laensberg lay on the dusty mantelpiece amid gunflints, candle-ends, and
+bits of amadou.
+
+Finally, the last luxury in the apartment was a “Fame” blowing her
+trumpets, a picture cut out, no doubt, from some perfumer’s prospectus
+and nailed to the wall with six wooden shoe-pegs.
+
+Emma’s child was asleep in a wicker-cradle. She took it up in the
+wrapping that enveloped it and began singing softly as she rocked
+herself to and fro.
+
+Leon walked up and down the room; it seemed strange to him to see this
+beautiful woman in her nankeen dress in the midst of all this poverty.
+Madam Bovary reddened; he turned away, thinking perhaps there had been
+an impertinent look in his eyes. Then she put back the little girl, who
+had just been sick over her collar.
+
+The nurse at once came to dry her, protesting that it wouldn’t show.
+
+“She gives me other doses,” she said: “I am always a-washing of her. If
+you would have the goodness to order Camus, the grocer, to let me have
+a little soap, it would really be more convenient for you, as I needn’t
+trouble you then.”
+
+“Very well! very well!” said Emma. “Good morning, Madame Rollet,” and
+she went out, wiping her shoes at the door.
+
+The good woman accompanied her to the end of the garden, talking all the
+time of the trouble she had getting up of nights.
+
+“I’m that worn out sometimes as I drop asleep on my chair. I’m sure you
+might at least give me just a pound of ground coffee; that’d last me a
+month, and I’d take it of a morning with some milk.”
+
+After having submitted to her thanks, Madam Bovary left. She had gone a
+little way down the path when, at the sound of wooden shoes, she turned
+round. It was the nurse.
+
+“What is it?”
+
+Then the peasant woman, taking her aside behind an elm tree, began
+talking to her of her husband, who with his trade and six francs a year
+that the captain--
+
+“Oh, be quick!” said Emma.
+
+“Well,” the nurse went on, heaving sighs between each word, “I’m afraid
+he’ll be put out seeing me have coffee alone, you know men--”
+
+“But you are to have some,” Emma repeated; “I will give you some. You
+bother me!”
+
+“Oh, dear! my poor, dear lady! you see in consequence of his wounds he
+has terrible cramps in the chest. He even says that cider weakens him.”
+
+“Do make haste, Mere Rollet!”
+
+“Well,” the latter continued, making a curtsey, “if it weren’t asking
+too much,” and she curtsied once more, “if you would”--and her eyes
+begged--“a jar of brandy,” she said at last, “and I’d rub your little
+one’s feet with it; they’re as tender as one’s tongue.”
+
+Once rid of the nurse, Emma again took Monsieur Leon’s arm. She walked
+fast for some time, then more slowly, and looking straight in front of
+her, her eyes rested on the shoulder of the young man, whose frock-coat
+had a black-velvety collar. His brown hair fell over it, straight and
+carefully arranged. She noticed his nails which were longer than one
+wore them at Yonville. It was one of the clerk’s chief occupations to
+trim them, and for this purpose he kept a special knife in his writing
+desk.
+
+They returned to Yonville by the water-side. In the warm season the
+bank, wider than at other times, showed to their foot the garden walls
+whence a few steps led to the river. It flowed noiselessly, swift,
+and cold to the eye; long, thin grasses huddled together in it as the
+current drove them, and spread themselves upon the limpid water like
+streaming hair; sometimes at the tip of the reeds or on the leaf of a
+water-lily an insect with fine legs crawled or rested. The sun pierced
+with a ray the small blue bubbles of the waves that, breaking, followed
+each other; branchless old willows mirrored their grey backs in
+the water; beyond, all around, the meadows seemed empty. It was the
+dinner-hour at the farms, and the young woman and her companion heard
+nothing as they walked but the fall of their steps on the earth of the
+path, the words they spoke, and the sound of Emma’s dress rustling round
+her.
+
+The walls of the gardens with pieces of bottle on their coping were
+hot as the glass windows of a conservatory. Wallflowers had sprung up
+between the bricks, and with the tip of her open sunshade Madame Bovary,
+as she passed, made some of their faded flowers crumble into a yellow
+dust, or a spray of overhanging honeysuckle and clematis caught in its
+fringe and dangled for a moment over the silk.
+
+They were talking of a troupe of Spanish dancers who were expected
+shortly at the Rouen theatre.
+
+“Are you going?” she asked.
+
+“If I can,” he answered.
+
+Had they nothing else to say to one another? Yet their eyes were full
+of more serious speech, and while they forced themselves to find trivial
+phrases, they felt the same languor stealing over them both. It was the
+whisper of the soul, deep, continuous, dominating that of their voices.
+Surprised with wonder at this strange sweetness, they did not think of
+speaking of the sensation or of seeking its cause. Coming joys, like
+tropical shores, throw over the immensity before them their inborn
+softness, an odorous wind, and we are lulled by this intoxication
+without a thought of the horizon that we do not even know.
+
+In one place the ground had been trodden down by the cattle; they had to
+step on large green stones put here and there in the mud.
+
+She often stopped a moment to look where to place her foot, and
+tottering on a stone that shook, her arms outspread, her form bent
+forward with a look of indecision, she would laugh, afraid of falling
+into the puddles of water.
+
+When they arrived in front of her garden, Madame Bovary opened the
+little gate, ran up the steps and disappeared.
+
+Leon returned to his office. His chief was away; he just glanced at the
+briefs, then cut himself a pen, and at last took up his hat and went
+out.
+
+He went to La Pature at the top of the Argueil hills at the beginning of
+the forest; he threw himself upon the ground under the pines and watched
+the sky through his fingers.
+
+“How bored I am!” he said to himself, “how bored I am!”
+
+He thought he was to be pitied for living in this village, with Homais
+for a friend and Monsieru Guillaumin for master. The latter, entirely
+absorbed by his business, wearing gold-rimmed spectacles and red
+whiskers over a white cravat, understood nothing of mental refinements,
+although he affected a stiff English manner, which in the beginning had
+impressed the clerk.
+
+As to the chemist’s spouse, she was the best wife in Normandy, gentle
+as a sheep, loving her children, her father, her mother, her cousins,
+weeping for other’s woes, letting everything go in her household, and
+detesting corsets; but so slow of movement, such a bore to listen to, so
+common in appearance, and of such restricted conversation, that although
+she was thirty, he only twenty, although they slept in rooms next each
+other and he spoke to her daily, he never thought that she might be a
+woman for another, or that she possessed anything else of her sex than
+the gown.
+
+And what else was there? Binet, a few shopkeepers, two or three
+publicans, the cure, and finally, Monsieur Tuvache, the mayor, with his
+two sons, rich, crabbed, obtuse persons, who farmed their own lands
+and had feasts among themselves, bigoted to boot, and quite unbearable
+companions.
+
+But from the general background of all these human faces Emma’s stood
+out isolated and yet farthest off; for between her and him he seemed to
+see a vague abyss.
+
+In the beginning he had called on her several times along with the
+druggist. Charles had not appeared particularly anxious to see him
+again, and Leon did not know what to do between his fear of being
+indiscreet and the desire for an intimacy that seemed almost impossible.
+
+
+
+Chapter Four
+
+When the first cold days set in Emma left her bedroom for the
+sitting-room, a long apartment with a low ceiling, in which there was
+on the mantelpiece a large bunch of coral spread out against the
+looking-glass. Seated in her arm chair near the window, she could see
+the villagers pass along the pavement.
+
+Twice a day Leon went from his office to the Lion d’Or. Emma could hear
+him coming from afar; she leant forward listening, and the young man
+glided past the curtain, always dressed in the same way, and without
+turning his head. But in the twilight, when, her chin resting on her
+left hand, she let the embroidery she had begun fall on her knees, she
+often shuddered at the apparition of this shadow suddenly gliding past.
+She would get up and order the table to be laid.
+
+Monsieur Homais called at dinner-time. Skull-cap in hand, he came in on
+tiptoe, in order to disturb no one, always repeating the same phrase,
+“Good evening, everybody.” Then, when he had taken his seat at the table
+between the pair, he asked the doctor about his patients, and the latter
+consulted his as to the probability of their payment. Next they talked
+of “what was in the paper.”
+
+Homais by this hour knew it almost by heart, and he repeated it from end
+to end, with the reflections of the penny-a-liners, and all the stories
+of individual catastrophes that had occurred in France or abroad. But
+the subject becoming exhausted, he was not slow in throwing out some
+remarks on the dishes before him.
+
+Sometimes even, half-rising, he delicately pointed out to madame the
+tenderest morsel, or turning to the servant, gave her some advice on the
+manipulation of stews and the hygiene of seasoning.
+
+He talked aroma, osmazome, juices, and gelatine in a bewildering manner.
+Moreover, Homais, with his head fuller of recipes than his shop of jars,
+excelled in making all kinds of preserves, vinegars, and sweet liqueurs;
+he knew also all the latest inventions in economic stoves, together with
+the art of preserving cheese and of curing sick wines.
+
+At eight o’clock Justin came to fetch him to shut up the shop.
+
+Then Monsieur Homais gave him a sly look, especially if Felicite was
+there, for he half noticed that his apprentice was fond of the doctor’s
+house.
+
+“The young dog,” he said, “is beginning to have ideas, and the devil
+take me if I don’t believe he’s in love with your servant!”
+
+But a more serious fault with which he reproached Justin was his
+constantly listening to conversation. On Sunday, for example, one could
+not get him out of the drawing-room, whither Madame Homais had called
+him to fetch the children, who were falling asleep in the arm-chairs,
+and dragging down with their backs calico chair-covers that were too
+large.
+
+Not many people came to these soirees at the chemist’s, his
+scandal-mongering and political opinions having successfully alienated
+various respectable persons from him. The clerk never failed to be
+there. As soon as he heard the bell he ran to meet Madame Bovary, took
+her shawl, and put away under the shop-counter the thick list shoes that
+she wore over her boots when there was snow.
+
+First they played some hands at trente-et-un; next Monsieur Homais
+played ecarte with Emma; Leon behind her gave her advice.
+
+Standing up with his hands on the back of her chair he saw the teeth of
+her comb that bit into her chignon. With every movement that she made
+to throw her cards the right side of her dress was drawn up. From her
+turned-up hair a dark colour fell over her back, and growing gradually
+paler, lost itself little by little in the shade. Then her dress fell
+on both sides of her chair, puffing out full of folds, and reached the
+ground. When Leon occasionally felt the sole of his boot resting on it,
+he drew back as if he had trodden upon some one.
+
+When the game of cards was over, the druggist and the Doctor played
+dominoes, and Emma, changing her place, leant her elbow on the table,
+turning over the leaves of “L’Illustration”. She had brought her ladies’
+journal with her. Leon sat down near her; they looked at the engravings
+together, and waited for one another at the bottom of the pages. She
+often begged him to read her the verses; Leon declaimed them in a
+languid voice, to which he carefully gave a dying fall in the love
+passages. But the noise of the dominoes annoyed him. Monsieur Homais
+was strong at the game; he could beat Charles and give him a double-six.
+Then the three hundred finished, they both stretched themselves out in
+front of the fire, and were soon asleep. The fire was dying out in the
+cinders; the teapot was empty, Leon was still reading.
+
+Emma listened to him, mechanically turning around the lampshade, on the
+gauze of which were painted clowns in carriages, and tight-rope dances
+with their balancing-poles. Leon stopped, pointing with a gesture to his
+sleeping audience; then they talked in low tones, and their conversation
+seemed the more sweet to them because it was unheard.
+
+Thus a kind of bond was established between them, a constant commerce
+of books and of romances. Monsieur Bovary, little given to jealousy, did
+not trouble himself about it.
+
+On his birthday he received a beautiful phrenological head, all marked
+with figures to the thorax and painted blue. This was an attention of
+the clerk’s. He showed him many others, even to doing errands for him
+at Rouen; and the book of a novelist having made the mania for cactuses
+fashionable, Leon bought some for Madame Bovary, bringing them back on
+his knees in the “Hirondelle,” pricking his fingers on their hard hairs.
+
+She had a board with a balustrade fixed against her window to hold the
+pots. The clerk, too, had his small hanging garden; they saw each other
+tending their flowers at their windows.
+
+Of the windows of the village there was one yet more often occupied; for
+on Sundays from morning to night, and every morning when the weather was
+bright, one could see at the dormer-window of the garret the profile of
+Monsieur Binet bending over his lathe, whose monotonous humming could be
+heard at the Lion d’Or.
+
+One evening on coming home Leon found in his room a rug in velvet and
+wool with leaves on a pale ground. He called Madame Homais, Monsieur
+Homais, Justin, the children, the cook; he spoke of it to his chief;
+every one wanted to see this rug. Why did the doctor’s wife give the
+clerk presents? It looked queer. They decided that she must be his
+lover.
+
+He made this seem likely, so ceaselessly did he talk of her charms and
+of her wit; so much so, that Binet once roughly answered him--
+
+“What does it matter to me since I’m not in her set?”
+
+He tortured himself to find out how he could make his declaration to
+her, and always halting between the fear of displeasing her and the
+shame of being such a coward, he wept with discouragement and desire.
+Then he took energetic resolutions, wrote letters that he tore up, put
+it off to times that he again deferred.
+
+Often he set out with the determination to dare all; but this resolution
+soon deserted him in Emma’s presence, and when Charles, dropping in,
+invited him to jump into his chaise to go with him to see some patient
+in the neighbourhood, he at once accepted, bowed to madame, and went
+out. Her husband, was he not something belonging to her? As to Emma,
+she did not ask herself whether she loved. Love, she thought, must come
+suddenly, with great outbursts and lightnings--a hurricane of the skies,
+which falls upon life, revolutionises it, roots up the will like a leaf,
+and sweeps the whole heart into the abyss. She did not know that on
+the terrace of houses it makes lakes when the pipes are choked, and she
+would thus have remained in her security when she suddenly discovered a
+rent in the wall of it.
+
+
+
+Chapter Five
+
+It was a Sunday in February, an afternoon when the snow was falling.
+
+They had all, Monsieur and Madame Bovary, Homais, and Monsieur Leon,
+gone to see a yarn-mill that was being built in the valley a mile and a
+half from Yonville. The druggist had taken Napoleon and Athalie to give
+them some exercise, and Justin accompanied them, carrying the umbrellas
+on his shoulder.
+
+Nothing, however, could be less curious than this curiosity. A great
+piece of waste ground, on which pell-mell, amid a mass of sand and
+stones, were a few break-wheels, already rusty, surrounded by a
+quadrangular building pierced by a number of little windows. The
+building was unfinished; the sky could be seen through the joists of the
+roofing. Attached to the stop-plank of the gable a bunch of straw mixed
+with corn-ears fluttered its tricoloured ribbons in the wind.
+
+Homais was talking. He explained to the company the future importance
+of this establishment, computed the strength of the floorings, the
+thickness of the walls, and regretted extremely not having a yard-stick
+such as Monsieur Binet possessed for his own special use.
+
+Emma, who had taken his arm, bent lightly against his shoulder, and
+she looked at the sun’s disc shedding afar through the mist his pale
+splendour. She turned. Charles was there. His cap was drawn down over
+his eyebrows, and his two thick lips were trembling, which added a look
+of stupidity to his face; his very back, his calm back, was irritating
+to behold, and she saw written upon his coat all the platitude of the
+bearer.
+
+While she was considering him thus, tasting in her irritation a sort of
+depraved pleasure, Leon made a step forward. The cold that made him pale
+seemed to add a more gentle languor to his face; between his cravat and
+his neck the somewhat loose collar of his shirt showed the skin; the
+lobe of his ear looked out from beneath a lock of hair, and his large
+blue eyes, raised to the clouds, seemed to Emma more limpid and more
+beautiful than those mountain-lakes where the heavens are mirrored.
+
+“Wretched boy!” suddenly cried the chemist.
+
+And he ran to his son, who had just precipitated himself into a heap of
+lime in order to whiten his boots. At the reproaches with which he was
+being overwhelmed Napoleon began to roar, while Justin dried his shoes
+with a wisp of straw. But a knife was wanted; Charles offered his.
+
+“Ah!” she said to herself, “he carried a knife in his pocket like a
+peasant.”
+
+The hoar-frost was falling, and they turned back to Yonville.
+
+In the evening Madame Bovary did not go to her neighbour’s, and when
+Charles had left and she felt herself alone, the comparison re-began
+with the clearness of a sensation almost actual, and with that
+lengthening of perspective which memory gives to things. Looking from
+her bed at the clean fire that was burning, she still saw, as she had
+down there, Leon standing up with one hand behind his cane, and with
+the other holding Athalie, who was quietly sucking a piece of ice. She
+thought him charming; she could not tear herself away from him; she
+recalled his other attitudes on other days, the words he had spoken, the
+sound of his voice, his whole person; and she repeated, pouting out her
+lips as if for a kiss--
+
+“Yes, charming! charming! Is he not in love?” she asked herself; “but
+with whom? With me?”
+
+All the proofs arose before her at once; her heart leapt. The flame of
+the fire threw a joyous light upon the ceiling; she turned on her back,
+stretching out her arms.
+
+Then began the eternal lamentation: “Oh, if Heaven had not willed it!
+And why not? What prevented it?”
+
+When Charles came home at midnight, she seemed to have just awakened,
+and as he made a noise undressing, she complained of a headache, then
+asked carelessly what had happened that evening.
+
+“Monsieur Leon,” he said, “went to his room early.”
+
+She could not help smiling, and she fell asleep, her soul filled with a
+new delight.
+
+The next day, at dusk, she received a visit from Monsieur Lherueux, the
+draper. He was a man of ability, was this shopkeeper. Born a Gascon but
+bred a Norman, he grafted upon his southern volubility the cunning of
+the Cauchois. His fat, flabby, beardless face seemed dyed by a
+decoction of liquorice, and his white hair made even more vivid the
+keen brilliance of his small black eyes. No one knew what he had been
+formerly; a pedlar said some, a banker at Routot according to others.
+What was certain was that he made complex calculations in his head that
+would have frightened Binet himself. Polite to obsequiousness, he always
+held himself with his back bent in the position of one who bows or who
+invites.
+
+After leaving at the door his hat surrounded with crape, he put down
+a green bandbox on the table, and began by complaining to madame, with
+many civilities, that he should have remained till that day without
+gaining her confidence. A poor shop like his was not made to attract
+a “fashionable lady”; he emphasized the words; yet she had only to
+command, and he would undertake to provide her with anything she might
+wish, either in haberdashery or linen, millinery or fancy goods, for
+he went to town regularly four times a month. He was connected with the
+best houses. You could speak of him at the “Trois Freres,” at the “Barbe
+d’Or,” or at the “Grand Sauvage”; all these gentlemen knew him as
+well as the insides of their pockets. To-day, then he had come to show
+madame, in passing, various articles he happened to have, thanks to
+the most rare opportunity. And he pulled out half-a-dozen embroidered
+collars from the box.
+
+Madame Bovary examined them. “I do not require anything,” she said.
+
+Then Monsieur Lheureux delicately exhibited three Algerian scarves,
+several packets of English needles, a pair of straw slippers, and
+finally, four eggcups in cocoanut wood, carved in open work by convicts.
+Then, with both hands on the table, his neck stretched out, his figure
+bent forward, open-mouthed, he watched Emma’s look, who was walking up
+and down undecided amid these goods. From time to time, as if to remove
+some dust, he filliped with his nail the silk of the scarves spread
+out at full length, and they rustled with a little noise, making in the
+green twilight the gold spangles of their tissue scintillate like little
+stars.
+
+“How much are they?”
+
+“A mere nothing,” he replied, “a mere nothing. But there’s no hurry;
+whenever it’s convenient. We are not Jews.”
+
+She reflected for a few moments, and ended by again declining Monsieur
+Lheureux’s offer. He replied quite unconcernedly--
+
+“Very well. We shall understand one another by and by. I have always got
+on with ladies--if I didn’t with my own!”
+
+Emma smiled.
+
+“I wanted to tell you,” he went on good-naturedly, after his joke, “that
+it isn’t the money I should trouble about. Why, I could give you some,
+if need be.”
+
+She made a gesture of surprise.
+
+“Ah!” said he quickly and in a low voice, “I shouldn’t have to go far to
+find you some, rely on that.”
+
+And he began asking after Pere Tellier, the proprietor of the “Cafe
+Francais,” whom Monsieur Bovary was then attending.
+
+“What’s the matter with Pere Tellier? He coughs so that he shakes his
+whole house, and I’m afraid he’ll soon want a deal covering rather than
+a flannel vest. He was such a rake as a young man! Those sort of people,
+madame, have not the least regularity; he’s burnt up with brandy. Still
+it’s sad, all the same, to see an acquaintance go off.”
+
+And while he fastened up his box he discoursed about the doctor’s
+patients.
+
+“It’s the weather, no doubt,” he said, looking frowningly at the floor,
+“that causes these illnesses. I, too, don’t feel the thing. One of these
+days I shall even have to consult the doctor for a pain I have in my
+back. Well, good-bye, Madame Bovary. At your service; your very humble
+servant.” And he closed the door gently.
+
+Emma had her dinner served in her bedroom on a tray by the fireside; she
+was a long time over it; everything was well with her.
+
+“How good I was!” she said to herself, thinking of the scarves.
+
+She heard some steps on the stairs. It was Leon. She got up and took
+from the chest of drawers the first pile of dusters to be hemmed. When
+he came in she seemed very busy.
+
+The conversation languished; Madame Bovary gave it up every few minutes,
+whilst he himself seemed quite embarrassed. Seated on a low chair near
+the fire, he turned round in his fingers the ivory thimble-case. She
+stitched on, or from time to time turned down the hem of the cloth with
+her nail. She did not speak; he was silent, captivated by her silence,
+as he would have been by her speech.
+
+“Poor fellow!” she thought.
+
+“How have I displeased her?” he asked himself.
+
+At last, however, Leon said that he should have, one of these days, to
+go to Rouen on some office business.
+
+“Your music subscription is out; am I to renew it?”
+
+“No,” she replied.
+
+“Why?”
+
+“Because--”
+
+And pursing her lips she slowly drew a long stitch of grey thread.
+
+This work irritated Leon. It seemed to roughen the ends of her fingers.
+A gallant phrase came into his head, but he did not risk it.
+
+“Then you are giving it up?” he went on.
+
+“What?” she asked hurriedly. “Music? Ah! yes! Have I not my house to
+look after, my husband to attend to, a thousand things, in fact, many
+duties that must be considered first?”
+
+She looked at the clock. Charles was late. Then, she affected anxiety.
+Two or three times she even repeated, “He is so good!”
+
+The clerk was fond of Monsieur Bovary. But this tenderness on his behalf
+astonished him unpleasantly; nevertheless he took up on his praises,
+which he said everyone was singing, especially the chemist.
+
+“Ah! he is a good fellow,” continued Emma.
+
+“Certainly,” replied the clerk.
+
+And he began talking of Madame Homais, whose very untidy appearance
+generally made them laugh.
+
+“What does it matter?” interrupted Emma. “A good housewife does not
+trouble about her appearance.”
+
+Then she relapsed into silence.
+
+It was the same on the following days; her talks, her manners,
+everything changed. She took interest in the housework, went to church
+regularly, and looked after her servant with more severity.
+
+She took Berthe from nurse. When visitors called, Felicite brought her
+in, and Madame Bovary undressed her to show off her limbs. She declared
+she adored children; this was her consolation, her joy, her passion,
+and she accompanied her caresses with lyrical outburst which would have
+reminded anyone but the Yonville people of Sachette in “Notre Dame de
+Paris.”
+
+When Charles came home he found his slippers put to warm near the fire.
+His waistcoat now never wanted lining, nor his shirt buttons, and it was
+quite a pleasure to see in the cupboard the night-caps arranged in piles
+of the same height. She no longer grumbled as formerly at taking a turn
+in the garden; what he proposed was always done, although she did not
+understand the wishes to which she submitted without a murmur; and when
+Leon saw him by his fireside after dinner, his two hands on his stomach,
+his two feet on the fender, his two cheeks red with feeding, his eyes
+moist with happiness, the child crawling along the carpet, and this
+woman with the slender waist who came behind his arm-chair to kiss his
+forehead: “What madness!” he said to himself. “And how to reach her!”
+
+And thus she seemed so virtuous and inaccessible to him that he lost all
+hope, even the faintest. But by this renunciation he placed her on
+an extraordinary pinnacle. To him she stood outside those fleshly
+attributes from which he had nothing to obtain, and in his heart she
+rose ever, and became farther removed from him after the magnificent
+manner of an apotheosis that is taking wing. It was one of those pure
+feelings that do not interfere with life, that are cultivated because
+they are rare, and whose loss would afflict more than their passion
+rejoices.
+
+Emma grew thinner, her cheeks paler, her face longer. With her black
+hair, her large eyes, her aquiline nose, her birdlike walk, and always
+silent now, did she not seem to be passing through life scarcely
+touching it, and to bear on her brow the vague impress of some divine
+destiny? She was so sad and so calm, at once so gentle and so reserved,
+that near her one felt oneself seized by an icy charm, as we shudder
+in churches at the perfume of the flowers mingling with the cold of the
+marble. The others even did not escape from this seduction. The chemist
+said--
+
+“She is a woman of great parts, who wouldn’t be misplaced in a
+sub-prefecture.”
+
+The housewives admired her economy, the patients her politeness, the
+poor her charity.
+
+But she was eaten up with desires, with rage, with hate. That dress with
+the narrow folds hid a distracted fear, of whose torment those chaste
+lips said nothing. She was in love with Leon, and sought solitude that
+she might with the more ease delight in his image. The sight of his
+form troubled the voluptuousness of this mediation. Emma thrilled at
+the sound of his step; then in his presence the emotion subsided, and
+afterwards there remained to her only an immense astonishment that ended
+in sorrow.
+
+Leon did not know that when he left her in despair she rose after he had
+gone to see him in the street. She concerned herself about his comings
+and goings; she watched his face; she invented quite a history to find
+an excuse for going to his room. The chemist’s wife seemed happy to her
+to sleep under the same roof, and her thoughts constantly centered upon
+this house, like the “Lion d’Or” pigeons, who came there to dip their
+red feet and white wings in its gutters. But the more Emma recognised
+her love, the more she crushed it down, that it might not be evident,
+that she might make it less. She would have liked Leon to guess it, and
+she imagined chances, catastrophes that should facilitate this.
+
+What restrained her was, no doubt, idleness and fear, and a sense of
+shame also. She thought she had repulsed him too much, that the time was
+past, that all was lost. Then, pride, and joy of being able to say to
+herself, “I am virtuous,” and to look at herself in the glass taking
+resigned poses, consoled her a little for the sacrifice she believed she
+was making.
+
+Then the lusts of the flesh, the longing for money, and the melancholy
+of passion all blended themselves into one suffering, and instead of
+turning her thoughts from it, she clave to it the more, urging herself
+to pain, and seeking everywhere occasion for it. She was irritated by
+an ill-served dish or by a half-open door; bewailed the velvets she had
+not, the happiness she had missed, her too exalted dreams, her narrow
+home.
+
+What exasperated her was that Charles did not seem to notice her
+anguish. His conviction that he was making her happy seemed to her an
+imbecile insult, and his sureness on this point ingratitude. For whose
+sake, then was she virtuous? Was it not for him, the obstacle to all
+felicity, the cause of all misery, and, as it were, the sharp clasp of
+that complex strap that bucked her in on all sides.
+
+On him alone, then, she concentrated all the various hatreds that
+resulted from her boredom, and every effort to diminish only augmented
+it; for this useless trouble was added to the other reasons for despair,
+and contributed still more to the separation between them. Her own
+gentleness to herself made her rebel against him. Domestic mediocrity
+drove her to lewd fancies, marriage tenderness to adulterous desires.
+She would have liked Charles to beat her, that she might have a better
+right to hate him, to revenge herself upon him. She was surprised
+sometimes at the atrocious conjectures that came into her thoughts, and
+she had to go on smiling, to hear repeated to her at all hours that she
+was happy, to pretend to be happy, to let it be believed.
+
+Yet she had loathing of this hypocrisy. She was seized with the
+temptation to flee somewhere with Leon to try a new life; but at once a
+vague chasm full of darkness opened within her soul.
+
+“Besides, he no longer loves me,” she thought. “What is to become of me?
+What help is to be hoped for, what consolation, what solace?”
+
+She was left broken, breathless, inert, sobbing in a low voice, with
+flowing tears.
+
+“Why don’t you tell master?” the servant asked her when she came in
+during these crises.
+
+“It is the nerves,” said Emma. “Do not speak to him of it; it would
+worry him.”
+
+“Ah! yes,” Felicite went on, “you are just like La Guerine, Pere
+Guerin’s daughter, the fisherman at Pollet, that I used to know at
+Dieppe before I came to you. She was so sad, so sad, to see her
+standing upright on the threshold of her house, she seemed to you like a
+winding-sheet spread out before the door. Her illness, it appears, was
+a kind of fog that she had in her head, and the doctors could not do
+anything, nor the priest either. When she was taken too bad she went
+off quite alone to the sea-shore, so that the customs officer, going his
+rounds, often found her lying flat on her face, crying on the shingle.
+Then, after her marriage, it went off, they say.”
+
+“But with me,” replied Emma, “it was after marriage that it began.”
+
+
+
+Chapter Six
+
+One evening when the window was open, and she, sitting by it, had been
+watching Lestiboudois, the beadle, trimming the box, she suddenly heard
+the Angelus ringing.
+
+It was the beginning of April, when the primroses are in bloom, and a
+warm wind blows over the flower-beds newly turned, and the gardens, like
+women, seem to be getting ready for the summer fetes. Through the bars
+of the arbour and away beyond the river seen in the fields, meandering
+through the grass in wandering curves. The evening vapours rose between
+the leafless poplars, touching their outlines with a violet tint, paler
+and more transparent than a subtle gauze caught athwart their branches.
+In the distance cattle moved about; neither their steps nor their lowing
+could be heard; and the bell, still ringing through the air, kept up its
+peaceful lamentation.
+
+With this repeated tinkling the thoughts of the young woman lost
+themselves in old memories of her youth and school-days. She remembered
+the great candlesticks that rose above the vases full of flowers on the
+altar, and the tabernacle with its small columns. She would have liked
+to be once more lost in the long line of white veils, marked off here
+and there by the stuff black hoods of the good sisters bending over
+their prie-Dieu. At mass on Sundays, when she looked up, she saw the
+gentle face of the Virgin amid the blue smoke of the rising incense.
+Then she was moved; she felt herself weak and quite deserted, like the
+down of a bird whirled by the tempest, and it was unconsciously that she
+went towards the church, included to no matter what devotions, so that
+her soul was absorbed and all existence lost in it.
+
+On the Place she met Lestivoudois on his way back, for, in order not
+to shorten his day’s labour, he preferred interrupting his work,
+then beginning it again, so that he rang the Angelus to suit his own
+convenience. Besides, the ringing over a little earlier warned the lads
+of catechism hour.
+
+Already a few who had arrived were playing marbles on the stones of the
+cemetery. Others, astride the wall, swung their legs, kicking with their
+clogs the large nettles growing between the little enclosure and the
+newest graves. This was the only green spot. All the rest was but
+stones, always covered with a fine powder, despite the vestry-broom.
+
+The children in list shoes ran about there as if it were an enclosure
+made for them. The shouts of their voices could be heard through the
+humming of the bell. This grew less and less with the swinging of the
+great rope that, hanging from the top of the belfry, dragged its end on
+the ground. Swallows flitted to and fro uttering little cries, cut the
+air with the edge of their wings, and swiftly returned to their yellow
+nests under the tiles of the coping. At the end of the church a lamp was
+burning, the wick of a night-light in a glass hung up. Its light from a
+distance looked like a white stain trembling in the oil. A long ray of
+the sun fell across the nave and seemed to darken the lower sides and
+the corners.
+
+“Where is the cure?” asked Madame Bovary of one of the lads, who was
+amusing himself by shaking a swivel in a hole too large for it.
+
+“He is just coming,” he answered.
+
+And in fact the door of the presbytery grated; Abbe Bournisien appeared;
+the children, pell-mell, fled into the church.
+
+“These young scamps!” murmured the priest, “always the same!”
+
+Then, picking up a catechism all in rags that he had struck with is
+foot, “They respect nothing!” But as soon as he caught sight of Madame
+Bovary, “Excuse me,” he said; “I did not recognise you.”
+
+He thrust the catechism into his pocket, and stopped short, balancing
+the heavy vestry key between his two fingers.
+
+The light of the setting sun that fell full upon his face paled the
+lasting of his cassock, shiny at the elbows, unravelled at the hem.
+Grease and tobacco stains followed along his broad chest the lines
+of the buttons, and grew more numerous the farther they were from his
+neckcloth, in which the massive folds of his red chin rested; this was
+dotted with yellow spots, that disappeared beneath the coarse hair of
+his greyish beard. He had just dined and was breathing noisily.
+
+“How are you?” he added.
+
+“Not well,” replied Emma; “I am ill.”
+
+“Well, and so am I,” answered the priest. “These first warm days weaken
+one most remarkably, don’t they? But, after all, we are born to suffer,
+as St. Paul says. But what does Monsieur Bovary think of it?”
+
+“He!” she said with a gesture of contempt.
+
+“What!” replied the good fellow, quite astonished, “doesn’t he prescribe
+something for you?”
+
+“Ah!” said Emma, “it is no earthly remedy I need.”
+
+But the cure from time to time looked into the church, where the
+kneeling boys were shouldering one another, and tumbling over like packs
+of cards.
+
+“I should like to know--” she went on.
+
+“You look out, Riboudet,” cried the priest in an angry voice; “I’ll warm
+your ears, you imp!” Then turning to Emma, “He’s Boudet the carpenter’s
+son; his parents are well off, and let him do just as he pleases. Yet he
+could learn quickly if he would, for he is very sharp. And so sometimes
+for a joke I call him Riboudet (like the road one takes to go to
+Maromme) and I even say ‘Mon Riboudet.’ Ha! Ha! ‘Mont Riboudet.’ The
+other day I repeated that just to Monsignor, and he laughed at it; he
+condescended to laugh at it. And how is Monsieur Bovary?”
+
+She seemed not to hear him. And he went on--
+
+“Always very busy, no doubt; for he and I are certainly the busiest
+people in the parish. But he is doctor of the body,” he added with a
+thick laugh, “and I of the soul.”
+
+She fixed her pleading eyes upon the priest. “Yes,” she said, “you
+solace all sorrows.”
+
+“Ah! don’t talk to me of it, Madame Bovary. This morning I had to go to
+Bas-Diauville for a cow that was ill; they thought it was under a spell.
+All their cows, I don’t know how it is--But pardon me! Longuemarre and
+Boudet! Bless me! Will you leave off?”
+
+And with a bound he ran into the church.
+
+The boys were just then clustering round the large desk, climbing over
+the precentor’s footstool, opening the missal; and others on tiptoe were
+just about to venture into the confessional. But the priest suddenly
+distributed a shower of cuffs among them. Seizing them by the collars of
+their coats, he lifted them from the ground, and deposited them on their
+knees on the stones of the choir, firmly, as if he meant planting them
+there.
+
+“Yes,” said he, when he returned to Emma, unfolding his large cotton
+handkerchief, one corner of which he put between his teeth, “farmers are
+much to be pitied.”
+
+“Others, too,” she replied.
+
+“Assuredly. Town-labourers, for example.”
+
+“It is not they--”
+
+“Pardon! I’ve there known poor mothers of families, virtuous women, I
+assure you, real saints, who wanted even bread.”
+
+“But those,” replied Emma, and the corners of her mouth twitched as she
+spoke, “those, Monsieur le Cure, who have bread and have no--”
+
+“Fire in the winter,” said the priest.
+
+“Oh, what does that matter?”
+
+“What! What does it matter? It seems to me that when one has firing and
+food--for, after all--”
+
+“My God! my God!” she sighed.
+
+“It is indigestion, no doubt? You must get home, Madame Bovary; drink
+a little tea, that will strengthen you, or else a glass of fresh water
+with a little moist sugar.”
+
+“Why?” And she looked like one awaking from a dream.
+
+“Well, you see, you were putting your hand to your forehead. I thought
+you felt faint.” Then, bethinking himself, “But you were asking me
+something? What was it? I really don’t remember.”
+
+“I? Nothing! nothing!” repeated Emma.
+
+And the glance she cast round her slowly fell upon the old man in the
+cassock. They looked at one another face to face without speaking.
+
+“Then, Madame Bovary,” he said at last, “excuse me, but duty first, you
+know; I must look after my good-for-nothings. The first communion will
+soon be upon us, and I fear we shall be behind after all. So after
+Ascension Day I keep them recta* an extra hour every Wednesday. Poor
+children! One cannot lead them too soon into the path of the Lord, as,
+moreover, he has himself recommended us to do by the mouth of his Divine
+Son. Good health to you, madame; my respects to your husband.”
+
+     *On the straight and narrow path.
+
+And he went into the church making a genuflexion as soon as he reached
+the door.
+
+Emma saw him disappear between the double row of forms, walking with a
+heavy tread, his head a little bent over his shoulder, and with his two
+hands half-open behind him.
+
+Then she turned on her heel all of one piece, like a statue on a pivot,
+and went homewards. But the loud voice of the priest, the clear voices
+of the boys still reached her ears, and went on behind her.
+
+“Are you a Christian?”
+
+“Yes, I am a Christian.”
+
+“What is a Christian?”
+
+“He who, being baptized-baptized-baptized--”
+
+She went up the steps of the staircase holding on to the banisters, and
+when she was in her room threw herself into an arm-chair.
+
+The whitish light of the window-panes fell with soft undulations.
+
+The furniture in its place seemed to have become more immobile, and to
+lose itself in the shadow as in an ocean of darkness. The fire was out,
+the clock went on ticking, and Emma vaguely marvelled at this calm of
+all things while within herself was such tumult. But little Berthe was
+there, between the window and the work-table, tottering on her knitted
+shoes, and trying to come to her mother to catch hold of the ends of her
+apron-strings.
+
+“Leave me alone,” said the latter, putting her from her with her hand.
+
+The little girl soon came up closer against her knees, and leaning on
+them with her arms, she looked up with her large blue eyes, while a
+small thread of pure saliva dribbled from her lips on to the silk apron.
+
+“Leave me alone,” repeated the young woman quite irritably.
+
+Her face frightened the child, who began to scream.
+
+“Will you leave me alone?” she said, pushing her with her elbow.
+
+Berthe fell at the foot of the drawers against the brass handle, cutting
+her cheek, which began to bleed, against it. Madame Bovary sprang to
+lift her up, broke the bell-rope, called for the servant with all her
+might, and she was just going to curse herself when Charles appeared. It
+was the dinner-hour; he had come home.
+
+“Look, dear!” said Emma, in a calm voice, “the little one fell down
+while she was playing, and has hurt herself.”
+
+Charles reassured her; the case was not a serious one, and he went for
+some sticking plaster.
+
+Madame Bovary did not go downstairs to the dining-room; she wished
+to remain alone to look after the child. Then watching her sleep, the
+little anxiety she felt gradually wore off, and she seemed very stupid
+to herself, and very good to have been so worried just now at so little.
+Berthe, in fact, no longer sobbed.
+
+Her breathing now imperceptibly raised the cotton covering. Big tears
+lay in the corner of the half-closed eyelids, through whose lashes one
+could see two pale sunken pupils; the plaster stuck on her cheek drew
+the skin obliquely.
+
+“It is very strange,” thought Emma, “how ugly this child is!”
+
+When at eleven o’clock Charles came back from the chemist’s shop,
+whither he had gone after dinner to return the remainder of the
+sticking-plaster, he found his wife standing by the cradle.
+
+“I assure you it’s nothing.” he said, kissing her on the forehead.
+“Don’t worry, my poor darling; you will make yourself ill.”
+
+He had stayed a long time at the chemist’s. Although he had not seemed
+much moved, Homais, nevertheless, had exerted himself to buoy him up, to
+“keep up his spirits.” Then they had talked of the various dangers that
+threaten childhood, of the carelessness of servants. Madame Homais knew
+something of it, having still upon her chest the marks left by a basin
+full of soup that a cook had formerly dropped on her pinafore, and
+her good parents took no end of trouble for her. The knives were not
+sharpened, nor the floors waxed; there were iron gratings to the windows
+and strong bars across the fireplace; the little Homais, in spite of
+their spirit, could not stir without someone watching them; at the
+slightest cold their father stuffed them with pectorals; and until
+they were turned four they all, without pity, had to wear wadded
+head-protectors. This, it is true, was a fancy of Madame Homais’; her
+husband was inwardly afflicted at it. Fearing the possible consequences
+of such compression to the intellectual organs. He even went so far as
+to say to her, “Do you want to make Caribs or Botocudos of them?”
+
+Charles, however, had several times tried to interrupt the conversation.
+“I should like to speak to you,” he had whispered in the clerk’s ear,
+who went upstairs in front of him.
+
+“Can he suspect anything?” Leon asked himself. His heart beat, and he
+racked his brain with surmises.
+
+At last, Charles, having shut the door, asked him to see himself
+what would be the price at Rouen of a fine daguerreotypes. It was a
+sentimental surprise he intended for his wife, a delicate attention--his
+portrait in a frock-coat. But he wanted first to know “how much it would
+be.” The inquiries would not put Monsieur Leon out, since he went to
+town almost every week.
+
+Why? Monsieur Homais suspected some “young man’s affair” at the bottom
+of it, an intrigue. But he was mistaken. Leon was after no love-making.
+He was sadder than ever, as Madame Lefrancois saw from the amount of
+food he left on his plate. To find out more about it she questioned
+the tax-collector. Binet answered roughly that he “wasn’t paid by the
+police.”
+
+All the same, his companion seemed very strange to him, for Leon often
+threw himself back in his chair, and stretching out his arms, complained vaguely of life.
+
+“It’s because you don’t take enough recreation,” said the collector.
+
+“What recreation?”
+
+“If I were you I’d have a lathe.”
+
+“But I don’t know how to turn,” answered the clerk.
+
+“Ah! that’s true,” said the other, rubbing his chin with an air of
+mingled contempt and satisfaction.
+
+Leon was weary of loving without any result; moreover he was beginning
+to feel that depression caused by the repetition of the same kind of
+life, when no interest inspires and no hope sustains it. He was so bored
+with Yonville and its inhabitants, that the sight of certain persons,
+of certain houses, irritated him beyond endurance; and the chemist, good
+fellow though he was, was becoming absolutely unbearable to him. Yet
+the prospect of a new condition of life frightened as much as it seduced
+him.
+
+This apprehension soon changed into impatience, and then Paris from afar
+sounded its fanfare of masked balls with the laugh of grisettes. As he
+was to finish reading there, why not set out at once? What prevented
+him? And he began making home-preparations; he arranged his occupations
+beforehand. He furnished in his head an apartment. He would lead an
+artist’s life there! He would take lessons on the guitar! He would have
+a dressing-gown, a Basque cap, blue velvet slippers! He even already was
+admiring two crossed foils over his chimney-piece, with a death’s head
+on the guitar above them.
+
+The difficulty was the consent of his mother; nothing, however, seemed
+more reasonable. Even his employer advised him to go to some other
+chambers where he could advance more rapidly. Taking a middle course,
+then, Leon looked for some place as second clerk at Rouen; found none,
+and at last wrote his mother a long letter full of details, in which
+he set forth the reasons for going to live at Paris immediately. She
+consented.
+
+He did not hurry. Every day for a month Hivert carried boxes, valises,
+parcels for him from Yonville to Rouen and from Rouen to Yonville;
+and when Leon had packed up his wardrobe, had his three arm-chairs
+restuffed, bought a stock of neckties, in a word, had made more
+preparations than for a voyage around the world, he put it off from week
+to week, until he received a second letter from his mother urging him to
+leave, since he wanted to pass his examination before the vacation.
+
+When the moment for the farewells had come, Madame Homais wept, Justin
+sobbed; Homais, as a man of nerve, concealed his emotion; he wished to
+carry his friend’s overcoat himself as far as the gate of the notary,
+who was taking Leon to Rouen in his carriage.
+
+The latter had just time to bid farewell to Monsieur Bovary.
+
+When he reached the head of the stairs, he stopped, he was so out of
+breath. As he came in, Madame Bovary arose hurriedly.
+
+“It is I again!” said Leon.
+
+“I was sure of it!”
+
+She bit her lips, and a rush of blood flowing under her skin made her
+red from the roots of her hair to the top of her collar. She remained
+standing, leaning with her shoulder against the wainscot.
+
+“The doctor is not here?” he went on.
+
+“He is out.” She repeated, “He is out.”
+
+Then there was silence. They looked at one another and their thoughts,
+confounded in the same agony, clung close together like two throbbing
+breasts.
+
+“I should like to kiss Berthe,” said Leon.
+
+Emma went down a few steps and called Felicite.
+
+He threw one long look around him that took in the walls, the
+decorations, the fireplace, as if to penetrate everything, carry away
+everything. But she returned, and the servant brought Berthe, who was
+swinging a windmill roof downwards at the end of a string. Leon kissed
+her several times on the neck.
+
+“Good-bye, poor child! good-bye, dear little one! good-bye!” And he gave
+her back to her mother.
+
+“Take her away,” she said.
+
+They remained alone--Madame Bovary, her back turned, her face pressed
+against a window-pane; Leon held his cap in his hand, knocking it softly
+against his thigh.
+
+“It is going to rain,” said Emma.
+
+“I have a cloak,” he answered.
+
+“Ah!”
+
+She turned around, her chin lowered, her forehead bent forward.
+
+The light fell on it as on a piece of marble, to the curve of the
+eyebrows, without one’s being able to guess what Emma was seeing on the
+horizon or what she was thinking within herself.
+
+“Well, good-bye,” he sighed.
+
+She raised her head with a quick movement.
+
+“Yes, good-bye--go!”
+
+They advanced towards each other; he held out his hand; she hesitated.
+
+“In the English fashion, then,” she said, giving her own hand wholly to
+him, and forcing a laugh.
+
+Leon felt it between his fingers, and the very essence of all his being
+seemed to pass down into that moist palm. Then he opened his hand; their
+eyes met again, and he disappeared.
+
+When he reached the market-place, he stopped and hid behind a pillar to
+look for the last time at this white house with the four green blinds.
+He thought he saw a shadow behind the window in the room; but the
+curtain, sliding along the pole as though no one were touching it,
+slowly opened its long oblique folds that spread out with a single
+movement, and thus hung straight and motionless as a plaster wall. Leon
+set off running.
+
+From afar he saw his employer’s gig in the road, and by it a man in
+a coarse apron holding the horse. Homais and Monsieur Guillaumin were
+talking. They were waiting for him.
+
+“Embrace me,” said the druggist with tears in his eyes. “Here is your
+coat, my good friend. Mind the cold; take care of yourself; look after
+yourself.”
+
+“Come, Leon, jump in,” said the notary.
+
+Homais bent over the splash-board, and in a voice broken by sobs uttered
+these three sad words--
+
+“A pleasant journey!”
+
+“Good-night,” said Monsieur Guillaumin. “Give him his head.” They set
+out, and Homais went back.
+
+Madame Bovary had opened her window overlooking the garden and watched
+the clouds. They gathered around the sunset on the side of Rouen and
+then swiftly rolled back their black columns, behind which the great
+rays of the sun looked out like the golden arrows of a suspended trophy,
+while the rest of the empty heavens was white as porcelain. But a gust
+of wind bowed the poplars, and suddenly the rain fell; it pattered
+against the green leaves.
+
+Then the sun reappeared, the hens clucked, sparrows shook their wings in
+the damp thickets, and the pools of water on the gravel as they flowed
+away carried off the pink flowers of an acacia.
+
+“Ah! how far off he must be already!” she thought.
+
+Monsieur Homais, as usual, came at half-past six during dinner.
+
+“Well,” said he, “so we’ve sent off our young friend!”
+
+“So it seems,” replied the doctor. Then turning on his chair; “Any news
+at home?”
+
+“Nothing much. Only my wife was a little moved this afternoon. You know
+women--a nothing upsets them, especially my wife. And we should be
+wrong to object to that, since their nervous organization is much more
+malleable than ours.”
+
+“Poor Leon!” said Charles. “How will he live at Paris? Will he get used
+to it?”
+
+Madame Bovary sighed.
+
+“Get along!” said the chemist, smacking his lips. “The outings at
+restaurants, the masked balls, the champagne--all that’ll be jolly
+enough, I assure you.”
+
+“I don’t think he’ll go wrong,” objected Bovary.
+
+“Nor do I,” said Monsieur Homais quickly; “although he’ll have to do
+like the rest for fear of passing for a Jesuit. And you don’t know what
+a life those dogs lead in the Latin quarter with actresses. Besides,
+students are thought a great deal of in Paris. Provided they have a few
+accomplishments, they are received in the best society; there are even
+ladies of the Faubourg Saint-Germain who fall in love with them, which
+subsequently furnishes them opportunities for making very good matches.”
+
+“But,” said the doctor, “I fear for him that down there--”
+
+“You are right,” interrupted the chemist; “that is the reverse of the
+medal. And one is constantly obliged to keep one’s hand in one’s pocket
+there. Thus, we will suppose you are in a public garden. An individual
+presents himself, well dressed, even wearing an order, and whom one
+would take for a diplomatist. He approaches you, he insinuates himself;
+offers you a pinch of snuff, or picks up your hat. Then you become more
+intimate; he takes you to a cafe, invites you to his country-house,
+introduces you, between two drinks, to all sorts of people; and
+three-fourths of the time it’s only to plunder your watch or lead you
+into some pernicious step.
+
+“That is true,” said Charles; “but I was thinking especially of
+illnesses--of typhoid fever, for example, that attacks students from the
+provinces.”
+
+Emma shuddered.
+
+“Because of the change of regimen,” continued the chemist, “and of the
+perturbation that results therefrom in the whole system. And then the
+water at Paris, don’t you know! The dishes at restaurants, all the
+spiced food, end by heating the blood, and are not worth, whatever
+people may say of them, a good soup. For my own part, I have always
+preferred plain living; it is more healthy. So when I was studying
+pharmacy at Rouen, I boarded in a boarding house; I dined with the
+professors.”
+
+And thus he went on, expounding his opinions generally and his personal
+likings, until Justin came to fetch him for a mulled egg that was
+wanted.
+
+“Not a moment’s peace!” he cried; “always at it! I can’t go out for a
+minute! Like a plough-horse, I have always to be moiling and toiling.
+What drudgery!” Then, when he was at the door, “By the way, do you know
+the news?”
+
+“What news?”
+
+“That it is very likely,” Homais went on, raising his eyebrows and
+assuming one of his most serious expression, “that the agricultural
+meeting of the Seine-Inferieure will be held this year at
+Yonville-l’Abbaye. The rumour, at all events, is going the round. This
+morning the paper alluded to it. It would be of the utmost importance
+for our district. But we’ll talk it over later on. I can see, thank you;
+Justin has the lantern.”
+
+
+
+Chapter Seven
+
+The next day was a dreary one for Emma. Everything seemed to her
+enveloped in a black atmosphere floating confusedly over the exterior of
+things, and sorrow was engulfed within her soul with soft shrieks such
+as the winter wind makes in ruined castles. It was that reverie which we
+give to things that will not return, the lassitude that seizes you after
+everything was done; that pain, in fine, that the interruption of every
+wonted movement, the sudden cessation of any prolonged vibration, brings
+on.
+
+As on the return from Vaubyessard, when the quadrilles were running in
+her head, she was full of a gloomy melancholy, of a numb despair.
+Leon reappeared, taller, handsomer, more charming, more vague. Though
+separated from her, he had not left her; he was there, and the walls of
+the house seemed to hold his shadow.
+
+She could not detach her eyes from the carpet where he had walked, from
+those empty chairs where he had sat. The river still flowed on, and
+slowly drove its ripples along the slippery banks.
+
+They had often walked there to the murmur of the waves over the
+moss-covered pebbles. How bright the sun had been! What happy afternoons
+they had seen alone in the shade at the end of the garden! He read
+aloud, bareheaded, sitting on a footstool of dry sticks; the fresh wind
+of the meadow set trembling the leaves of the book and the nasturtiums
+of the arbour. Ah! he was gone, the only charm of her life, the only
+possible hope of joy. Why had she not seized this happiness when it came
+to her? Why not have kept hold of it with both hands, with both knees,
+when it was about to flee from her? And she cursed herself for not
+having loved Leon. She thirsted for his lips. The wish took possession
+of her to run after and rejoin him, throw herself into his arms and
+say to him, “It is I; I am yours.” But Emma recoiled beforehand at the
+difficulties of the enterprise, and her desires, increased by regret,
+became only the more acute.
+
+Henceforth the memory of Leon was the centre of her boredom; it burnt
+there more brightly than the fire travellers have left on the snow of
+a Russian steppe. She sprang towards him, she pressed against him, she
+stirred carefully the dying embers, sought all around her anything
+that could revive it; and the most distant reminiscences, like the most
+immediate occasions, what she experienced as well as what she imagined,
+her voluptuous desires that were unsatisfied, her projects of happiness
+that crackled in the wind like dead boughs, her sterile virtue, her
+lost hopes, the domestic tete-a-tete--she gathered it all up, took
+everything, and made it all serve as fuel for her melancholy.
+
+The flames, however, subsided, either because the supply had exhausted
+itself, or because it had been piled up too much. Love, little by
+little, was quelled by absence; regret stifled beneath habit; and this
+incendiary light that had empurpled her pale sky was overspread and
+faded by degrees. In the supineness of her conscience she even took her
+repugnance towards her husband for aspirations towards her lover, the
+burning of hate for the warmth of tenderness; but as the tempest still
+raged, and as passion burnt itself down to the very cinders, and no help
+came, no sun rose, there was night on all sides, and she was lost in the
+terrible cold that pierced her.
+
+Then the evil days of Tostes began again. She thought herself now far
+more unhappy; for she had the experience of grief, with the certainty
+that it would not end.
+
+A woman who had laid on herself such sacrifices could well allow herself
+certain whims. She bought a Gothic prie-dieu, and in a month spent
+fourteen francs on lemons for polishing her nails; she wrote to Rouen
+for a blue cashmere gown; she chose one of Lheureux’s finest scarves,
+and wore it knotted around her waist over her dressing-gown; and, with
+closed blinds and a book in her hand, she lay stretched out on a couch
+in this garb.
+
+She often changed her coiffure; she did her hair a la Chinoise, in
+flowing curls, in plaited coils; she parted in on one side and rolled it
+under like a man’s.
+
+She wanted to learn Italian; she bought dictionaries, a grammar, and
+a supply of white paper. She tried serious reading, history, and
+philosophy. Sometimes in the night Charles woke up with a start,
+thinking he was being called to a patient. “I’m coming,” he stammered;
+and it was the noise of a match Emma had struck to relight the lamp. But
+her reading fared like her piece of embroidery, all of which, only just
+begun, filled her cupboard; she took it up, left it, passed on to other
+books.
+
+She had attacks in which she could easily have been driven to commit any
+folly. She maintained one day, in opposition to her husband, that she
+could drink off a large glass of brandy, and, as Charles was stupid
+enough to dare her to, she swallowed the brandy to the last drop.
+
+In spite of her vapourish airs (as the housewives of Yonville called
+them), Emma, all the same, never seemed gay, and usually she had at the
+corners of her mouth that immobile contraction that puckers the faces of
+old maids, and those of men whose ambition has failed. She was pale all
+over, white as a sheet; the skin of her nose was drawn at the nostrils,
+her eyes looked at you vaguely. After discovering three grey hairs on
+her temples, she talked much of her old age.
+
+She often fainted. One day she even spat blood, and, as Charles fussed
+around her showing his anxiety--
+
+“Bah!” she answered, “what does it matter?”
+
+Charles fled to his study and wept there, both his elbows on the table,
+sitting in an arm-chair at his bureau under the phrenological head.
+
+Then he wrote to his mother begging her to come, and they had many long
+consultations together on the subject of Emma.
+
+What should they decide? What was to be done since she rejected all
+medical treatment? “Do you know what your wife wants?” replied Madame
+Bovary senior.
+
+“She wants to be forced to occupy herself with some manual work. If she
+were obliged, like so many others, to earn her living, she wouldn’t have
+these vapours, that come to her from a lot of ideas she stuffs into her
+head, and from the idleness in which she lives.”
+
+“Yet she is always busy,” said Charles.
+
+“Ah! always busy at what? Reading novels, bad books, works against
+religion, and in which they mock at priests in speeches taken from
+Voltaire. But all that leads you far astray, my poor child. Anyone who
+has no religion always ends by turning out badly.”
+
+So it was decided to stop Emma reading novels. The enterprise did not
+seem easy. The good lady undertook it. She was, when she passed through
+Rouen, to go herself to the lending-library and represent that Emma had
+discontinued her subscription. Would they not have a right to apply
+to the police if the librarian persisted all the same in his poisonous
+trade? The farewells of mother and daughter-in-law were cold. During
+the three weeks that they had been together they had not exchanged
+half-a-dozen words apart from the inquiries and phrases when they met at
+table and in the evening before going to bed.
+
+Madame Bovary left on a Wednesday, the market-day at Yonville.
+
+The Place since morning had been blocked by a row of carts, which, on
+end and their shafts in the air, spread all along the line of houses
+from the church to the inn. On the other side there were canvas booths,
+where cotton checks, blankets, and woollen stockings were sold,
+together with harness for horses, and packets of blue ribbon, whose ends
+fluttered in the wind. The coarse hardware was spread out on the ground
+between pyramids of eggs and hampers of cheeses, from which sticky straw
+stuck out.
+
+Near the corn-machines clucking hens passed their necks through the bars
+of flat cages. The people, crowding in the same place and unwilling
+to move thence, sometimes threatened to smash the shop front of the
+chemist. On Wednesdays his shop was never empty, and the people pushed
+in less to buy drugs than for consultations. So great was Homais’
+reputation in the neighbouring villages. His robust aplomb had
+fascinated the rustics. They considered him a greater doctor than all
+the doctors.
+
+Emma was leaning out at the window; she was often there. The window in
+the provinces replaces the theatre and the promenade, she was amusing
+herself with watching the crowd of boors when she saw a gentleman in
+a green velvet coat. He had on yellow gloves, although he wore heavy
+gaiters; he was coming towards the doctor’s house, followed by a peasant
+walking with a bent head and quite a thoughtful air.
+
+“Can I see the doctor?” he asked Justin, who was talking on the
+doorsteps with Felicite, and, taking him for a servant of the
+house--“Tell him that Monsieur Rodolphe Boulanger of La Huchette is
+here.”
+
+It was not from territorial vanity that the new arrival added “of La
+Huchette” to his name, but to make himself the better known.
+
+La Huchette, in fact, was an estate near Yonville, where he had just
+bought the chateau and two farms that he cultivated himself, without,
+however, troubling very much about them. He lived as a bachelor, and was
+supposed to have “at least fifteen thousand francs a year.”
+
+Charles came into the room. Monsieur Boulanger introduced his man, who
+wanted to be bled because he felt “a tingling all over.”
+
+“That’ll purge me,” he urged as an objection to all reasoning.
+
+So Bovary ordered a bandage and a basin, and asked Justin to hold it.
+Then addressing the peasant, who was already pale--
+
+“Don’t be afraid, my lad.”
+
+“No, no, sir,” said the other; “get on.”
+
+And with an air of bravado he held out his great arm. At the prick of
+the lancet the blood spurted out, splashing against the looking-glass.
+
+“Hold the basin nearer,” exclaimed Charles.
+
+“Lor!” said the peasant, “one would swear it was a little fountain
+flowing. How red my blood is! That’s a good sign, isn’t it?”
+
+“Sometimes,” answered the doctor, “one feels nothing at first, and then
+syncope sets in, and more especially with people of strong constitution
+like this man.”
+
+At these words the rustic let go the lancet-case he was twisting between
+his fingers. A shudder of his shoulders made the chair-back creak. His
+hat fell off.
+
+“I thought as much,” said Bovary, pressing his finger on the vein.
+
+The basin was beginning to tremble in Justin’s hands; his knees shook,
+he turned pale.
+
+“Emma! Emma!” called Charles.
+
+With one bound she came down the staircase.
+
+“Some vinegar,” he cried. “O dear! two at once!”
+
+And in his emotion he could hardly put on the compress.
+
+“It is nothing,” said Monsieur Boulanger quietly, taking Justin in his
+arms. He seated him on the table with his back resting against the wall.
+
+Madame Bovary began taking off his cravat. The strings of his shirt had
+got into a knot, and she was for some minutes moving her light fingers
+about the young fellow’s neck. Then she poured some vinegar on her
+cambric handkerchief; she moistened his temples with little dabs, and
+then blew upon them softly. The ploughman revived, but Justin’s syncope
+still lasted, and his eyeballs disappeared in the pale sclerotics like
+blue flowers in milk.
+
+“We must hide this from him,” said Charles.
+
+Madame Bovary took the basin to put it under the table. With the
+movement she made in bending down, her dress (it was a summer dress with
+four flounces, yellow, long in the waist and wide in the skirt) spread
+out around her on the flags of the room; and as Emma stooping, staggered
+a little as she stretched out her arms.
+
+The stuff here and there gave with the inflections of her bust.
+
+Then she went to fetch a bottle of water, and she was melting some
+pieces of sugar when the chemist arrived. The servant had been to
+fetch him in the tumult. Seeing his pupil’s eyes staring he drew a long
+breath; then going around him he looked at him from head to foot.
+
+“Fool!” he said, “really a little fool! A fool in four letters! A
+phlebotomy’s a big affair, isn’t it! And a fellow who isn’t afraid of
+anything; a kind of squirrel, just as he is who climbs to vertiginous
+heights to shake down nuts. Oh, yes! you just talk to me, boast about
+yourself! Here’s a fine fitness for practising pharmacy later on; for
+under serious circumstances you may be called before the tribunals in
+order to enlighten the minds of the magistrates, and you would have to
+keep your head then, to reason, show yourself a man, or else pass for an
+imbecile.”
+
+Justin did not answer. The chemist went on--
+
+“Who asked you to come? You are always pestering the doctor and madame.
+On Wednesday, moreover, your presence is indispensable to me. There are
+now twenty people in the shop. I left everything because of the interest
+I take in you. Come, get along! Sharp! Wait for me, and keep an eye on
+the jars.”
+
+When Justin, who was rearranging his dress, had gone, they talked for a
+little while about fainting-fits. Madame Bovary had never fainted.
+
+“That is extraordinary for a lady,” said Monsieur Boulanger; “but some
+people are very susceptible. Thus in a duel, I have seen a second lose
+consciousness at the mere sound of the loading of pistols.”
+
+“For my part,” said the chemist, “the sight of other people’s blood
+doesn’t affect me at all, but the mere thought of my own flowing would
+make me faint if I reflected upon it too much.”
+
+Monsieur Boulanger, however, dismissed his servant, advising him to calm
+himself, since his fancy was over.
+
+“It procured me the advantage of making your acquaintance,” he added,
+and he looked at Emma as he said this. Then he put three francs on the
+corner of the table, bowed negligently, and went out.
+
+He was soon on the other side of the river (this was his way back to La
+Huchette), and Emma saw him in the meadow, walking under the poplars,
+slackening his pace now and then as one who reflects.
+
+“She is very pretty,” he said to himself; “she is very pretty, this
+doctor’s wife. Fine teeth, black eyes, a dainty foot, a figure like a
+Parisienne’s. Where the devil does she come from? Wherever did that fat
+fellow pick her up?”
+
+Monsieur Rodolphe Boulanger was thirty-four; he was of brutal
+temperament and intelligent perspicacity, having, moreover, had much to
+do with women, and knowing them well. This one had seemed pretty to him;
+so he was thinking about her and her husband.
+
+“I think he is very stupid. She is tired of him, no doubt. He has dirty
+nails, and hasn’t shaved for three days. While he is trotting after his
+patients, she sits there botching socks. And she gets bored! She would
+like to live in town and dance polkas every evening. Poor little woman!
+She is gaping after love like a carp after water on a kitchen-table.
+With three words of gallantry she’d adore one, I’m sure of it. She’d be
+tender, charming. Yes; but how to get rid of her afterwards?”
+
+Then the difficulties of love-making seen in the distance made him by
+contrast think of his mistress. She was an actress at Rouen, whom he
+kept; and when he had pondered over this image, with which, even in
+remembrance, he was satiated--
+
+“Ah! Madame Bovary,” he thought, “is much prettier, especially fresher.
+Virginie is decidedly beginning to grow fat. She is so finiky about her
+pleasures; and, besides, she has a mania for prawns.”
+
+The fields were empty, and around him Rodolphe only heard the regular
+beating of the grass striking against his boots, with a cry of the
+grasshopper hidden at a distance among the oats. He again saw Emma in
+her room, dressed as he had seen her, and he undressed her.
+
+“Oh, I will have her,” he cried, striking a blow with his stick at a
+clod in front of him. And he at once began to consider the political
+part of the enterprise. He asked himself--
+
+“Where shall we meet? By what means? We shall always be having the brat
+on our hands, and the servant, the neighbours, and husband, all sorts of
+worries. Pshaw! one would lose too much time over it.”
+
+Then he resumed, “She really has eyes that pierce one’s heart like a
+gimlet. And that pale complexion! I adore pale women!”
+
+When he reached the top of the Arguiel hills he had made up his mind.
+“It’s only finding the opportunities. Well, I will call in now and then.
+I’ll send them venison, poultry; I’ll have myself bled, if need be. We
+shall become friends; I’ll invite them to my place. By Jove!” added he,
+“there’s the agricultural show coming on. She’ll be there. I shall see
+her. We’ll begin boldly, for that’s the surest way.”
+
+
+
+Chapter Eight
+
+At last it came, the famous agricultural show. On the morning of the
+solemnity all the inhabitants at their doors were chatting over the
+preparations. The pediment of the town hall had been hung with garlands
+of ivy; a tent had been erected in a meadow for the banquet; and in the
+middle of the Place, in front of the church, a kind of bombarde was
+to announce the arrival of the prefect and the names of the successful
+farmers who had obtained prizes. The National Guard of Buchy (there was
+none at Yonville) had come to join the corps of firemen, of whom Binet
+was captain. On that day he wore a collar even higher than usual; and,
+tightly buttoned in his tunic, his figure was so stiff and motionless
+that the whole vital portion of his person seemed to have descended into
+his legs, which rose in a cadence of set steps with a single movement.
+As there was some rivalry between the tax-collector and the colonel,
+both, to show off their talents, drilled their men separately. One
+saw the red epaulettes and the black breastplates pass and re-pass
+alternately; there was no end to it, and it constantly began again.
+There had never been such a display of pomp. Several citizens had
+scoured their houses the evening before; tri-coloured flags hung from
+half-open windows; all the public-houses were full; and in the lovely
+weather the starched caps, the golden crosses, and the coloured
+neckerchiefs seemed whiter than snow, shone in the sun, and relieved
+with the motley colours the sombre monotony of the frock-coats and blue
+smocks. The neighbouring farmers’ wives, when they got off their horses,
+pulled out the long pins that fastened around them their dresses, turned
+up for fear of mud; and the husbands, for their part, in order to save
+their hats, kept their handkerchiefs around them, holding one corner
+between their teeth.
+
+The crowd came into the main street from both ends of the village.
+People poured in from the lanes, the alleys, the houses; and from time
+to time one heard knockers banging against doors closing behind women
+with their gloves, who were going out to see the fete. What was most
+admired were two long lamp-stands covered with lanterns, that flanked a
+platform on which the authorities were to sit. Besides this there were
+against the four columns of the town hall four kinds of poles,
+each bearing a small standard of greenish cloth, embellished with
+inscriptions in gold letters.
+
+On one was written, “To Commerce”; on the other, “To Agriculture”; on
+the third, “To Industry”; and on the fourth, “To the Fine Arts.”
+
+But the jubilation that brightened all faces seemed to darken that of
+Madame Lefrancois, the innkeeper. Standing on her kitchen-steps she
+muttered to herself, “What rubbish! what rubbish! With their canvas
+booth! Do they think the prefect will be glad to dine down there under
+a tent like a gipsy? They call all this fussing doing good to the place!
+Then it wasn’t worth while sending to Neufchatel for the keeper of a
+cookshop! And for whom? For cowherds! tatterdemalions!”
+
+The druggist was passing. He had on a frock-coat, nankeen trousers,
+beaver shoes, and, for a wonder, a hat with a low crown.
+
+“Your servant! Excuse me, I am in a hurry.” And as the fat widow asked
+where he was going--
+
+“It seems odd to you, doesn’t it, I who am always more cooped up in my
+laboratory than the man’s rat in his cheese.”
+
+“What cheese?” asked the landlady.
+
+“Oh, nothing! nothing!” Homais continued. “I merely wished to convey
+to you, Madame Lefrancois, that I usually live at home like a recluse.
+To-day, however, considering the circumstances, it is necessary--”
+
+“Oh, you’re going down there!” she said contemptuously.
+
+“Yes, I am going,” replied the druggist, astonished. “Am I not a member
+of the consulting commission?”
+
+Mere Lefrancois looked at him for a few moments, and ended by saying
+with a smile--
+
+“That’s another pair of shoes! But what does agriculture matter to you?
+Do you understand anything about it?”
+
+“Certainly I understand it, since I am a druggist--that is to say,
+a chemist. And the object of chemistry, Madame Lefrancois, being the
+knowledge of the reciprocal and molecular action of all natural bodies,
+it follows that agriculture is comprised within its domain. And, in
+fact, the composition of the manure, the fermentation of liquids, the
+analyses of gases, and the influence of miasmata, what, I ask you, is
+all this, if it isn’t chemistry, pure and simple?”
+
+The landlady did not answer. Homais went on--
+
+“Do you think that to be an agriculturist it is necessary to have tilled
+the earth or fattened fowls oneself? It is necessary rather to know the
+composition of the substances in question--the geological strata, the
+atmospheric actions, the quality of the soil, the minerals, the waters,
+the density of the different bodies, their capillarity, and what not.
+And one must be master of all the principles of hygiene in order to
+direct, criticize the construction of buildings, the feeding of animals,
+the diet of domestics. And, moreover, Madame Lefrancois, one must know
+botany, be able to distinguish between plants, you understand, which are
+the wholesome and those that are deleterious, which are unproductive
+and which nutritive, if it is well to pull them up here and re-sow them
+there, to propagate some, destroy others; in brief, one must keep pace
+with science by means of pamphlets and public papers, be always on the
+alert to find out improvements.”
+
+The landlady never took her eyes off the “Cafe Francois” and the chemist
+went on--
+
+“Would to God our agriculturists were chemists, or that at least they
+would pay more attention to the counsels of science. Thus lately I
+myself wrote a considerable tract, a memoir of over seventy-two pages,
+entitled, ‘Cider, its Manufacture and its Effects, together with some
+New Reflections on the Subject,’ that I sent to the Agricultural Society
+of Rouen, and which even procured me the honour of being received among
+its members--Section, Agriculture; Class, Pomological. Well, if my
+work had been given to the public--” But the druggist stopped, Madame
+Lefrancois seemed so preoccupied.
+
+“Just look at them!” she said. “It’s past comprehension! Such a cookshop
+as that!” And with a shrug of the shoulders that stretched out over her
+breast the stitches of her knitted bodice, she pointed with both hands
+at her rival’s inn, whence songs were heard issuing. “Well, it won’t
+last long,” she added. “It’ll be over before a week.”
+
+Homais drew back with stupefaction. She came down three steps and
+whispered in his ear--
+
+“What! you didn’t know it? There is to be an execution in next week.
+It’s Lheureux who is selling him out; he has killed him with bills.”
+
+“What a terrible catastrophe!” cried the druggist, who always found
+expressions in harmony with all imaginable circumstances.
+
+Then the landlady began telling him the story that she had heard from
+Theodore, Monsieur Guillaumin’s servant, and although she detested
+Tellier, she blamed Lheureux. He was “a wheedler, a sneak.”
+
+“There!” she said. “Look at him! he is in the market; he is bowing to
+Madame Bovary, who’s got on a green bonnet. Why, she’s taking Monsieur
+Boulanger’s arm.”
+
+“Madame Bovary!” exclaimed Homais. “I must go at once and pay her my
+respects. Perhaps she’ll be very glad to have a seat in the enclosure
+under the peristyle.” And, without heeding Madame Lefrancois, who was
+calling him back to tell him more about it, the druggist walked off
+rapidly with a smile on his lips, with straight knees, bowing copiously
+to right and left, and taking up much room with the large tails of his
+frock-coat that fluttered behind him in the wind.
+
+Rodolphe, having caught sight of him from afar, hurried on, but Madame
+Bovary lost her breath; so he walked more slowly, and, smiling at her,
+said in a rough tone--
+
+“It’s only to get away from that fat fellow, you know, the druggist.”
+ She pressed his elbow.
+
+“What’s the meaning of that?” he asked himself. And he looked at her out
+of the corner of his eyes.
+
+Her profile was so calm that one could guess nothing from it. It stood
+out in the light from the oval of her bonnet, with pale ribbons on it
+like the leaves of weeds. Her eyes with their long curved lashes looked
+straight before her, and though wide open, they seemed slightly puckered
+by the cheek-bones, because of the blood pulsing gently under the
+delicate skin. A pink line ran along the partition between her nostrils.
+Her head was bent upon her shoulder, and the pearl tips of her white
+teeth were seen between her lips.
+
+“Is she making fun of me?” thought Rodolphe.
+
+Emma’s gesture, however, had only been meant for a warning; for Monsieur
+Lheureux was accompanying them, and spoke now and again as if to enter
+into the conversation.
+
+“What a superb day! Everybody is out! The wind is east!”
+
+And neither Madame Bovary nor Rodolphe answered him, whilst at the
+slightest movement made by them he drew near, saying, “I beg your
+pardon!” and raised his hat.
+
+When they reached the farrier’s house, instead of following the road
+up to the fence, Rodolphe suddenly turned down a path, drawing with him
+Madame Bovary. He called out--
+
+“Good evening, Monsieur Lheureux! See you again presently.”
+
+“How you got rid of him!” she said, laughing.
+
+“Why,” he went on, “allow oneself to be intruded upon by others? And as
+to-day I have the happiness of being with you--”
+
+Emma blushed. He did not finish his sentence. Then he talked of the fine
+weather and of the pleasure of walking on the grass. A few daisies had
+sprung up again.
+
+“Here are some pretty Easter daisies,” he said, “and enough of them to
+furnish oracles to all the amorous maids in the place.”
+
+He added, “Shall I pick some? What do you think?”
+
+“Are you in love?” she asked, coughing a little.
+
+“H’m, h’m! who knows?” answered Rodolphe.
+
+The meadow began to fill, and the housewives hustled you with their
+great umbrellas, their baskets, and their babies. One had often to get
+out of the way of a long file of country folk, servant-maids with blue
+stockings, flat shoes, silver rings, and who smelt of milk, when one
+passed close to them. They walked along holding one another by the hand,
+and thus they spread over the whole field from the row of open trees to
+the banquet tent.
+
+But this was the examination time, and the farmers one after the other
+entered a kind of enclosure formed by a long cord supported on sticks.
+
+The beasts were there, their noses towards the cord, and making a
+confused line with their unequal rumps. Drowsy pigs were burrowing in
+the earth with their snouts, calves were bleating, lambs baaing; the
+cows, on knees folded in, were stretching their bellies on the grass,
+slowly chewing the cud, and blinking their heavy eyelids at the gnats
+that buzzed round them. Plough-men with bare arms were holding by the
+halter prancing stallions that neighed with dilated nostrils looking
+towards the mares. These stood quietly, stretching out their heads and
+flowing manes, while their foals rested in their shadow, or now and then
+came and sucked them. And above the long undulation of these crowded
+animals one saw some white mane rising in the wind like a wave, or some
+sharp horns sticking out, and the heads of men running about. Apart,
+outside the enclosure, a hundred paces off, was a large black bull,
+muzzled, with an iron ring in its nostrils, and who moved no more than
+if he had been in bronze. A child in rags was holding him by a rope.
+
+Between the two lines the committee-men were walking with heavy steps,
+examining each animal, then consulting one another in a low voice. One
+who seemed of more importance now and then took notes in a book as he
+walked along. This was the president of the jury, Monsieur Derozerays de
+la Panville. As soon as he recognised Rodolphe he came forward quickly,
+and smiling amiably, said--
+
+“What! Monsieur Boulanger, you are deserting us?”
+
+Rodolphe protested that he was just coming. But when the president had
+disappeared--
+
+“Ma foi!*” said he, “I shall not go. Your company is better than his.”
+
+     *Upon my word!
+
+And while poking fun at the show, Rodolphe, to move about more easily,
+showed the gendarme his blue card, and even stopped now and then in
+front of some fine beast, which Madame Bovary did not at all admire.
+He noticed this, and began jeering at the Yonville ladies and their
+dresses; then he apologised for the negligence of his own. He had that
+incongruity of common and elegant in which the habitually vulgar think
+they see the revelation of an eccentric existence, of the perturbations
+of sentiment, the tyrannies of art, and always a certain contempt for
+social conventions, that seduces or exasperates them. Thus his cambric
+shirt with plaited cuffs was blown out by the wind in the opening of his
+waistcoat of grey ticking, and his broad-striped trousers disclosed at
+the ankle nankeen boots with patent leather gaiters.
+
+These were so polished that they reflected the grass. He trampled on
+horses’s dung with them, one hand in the pocket of his jacket and his
+straw hat on one side.
+
+“Besides,” added he, “when one lives in the country--”
+
+“It’s waste of time,” said Emma.
+
+“That is true,” replied Rodolphe. “To think that not one of these people
+is capable of understanding even the cut of a coat!”
+
+Then they talked about provincial mediocrity, of the lives it crushed,
+the illusions lost there.
+
+“And I too,” said Rodolphe, “am drifting into depression.”
+
+“You!” she said in astonishment; “I thought you very light-hearted.”
+
+“Ah! yes. I seem so, because in the midst of the world I know how to
+wear the mask of a scoffer upon my face; and yet, how many a time at the
+sight of a cemetery by moonlight have I not asked myself whether it were
+not better to join those sleeping there!”
+
+“Oh! and your friends?” she said. “You do not think of them.”
+
+“My friends! What friends? Have I any? Who cares for me?” And he
+accompanied the last words with a kind of whistling of the lips.
+
+But they were obliged to separate from each other because of a great
+pile of chairs that a man was carrying behind them. He was so overladen
+with them that one could only see the tips of his wooden shoes and the
+ends of his two outstretched arms. It was Lestiboudois, the gravedigger,
+who was carrying the church chairs about amongst the people. Alive to
+all that concerned his interests, he had hit upon this means of turning
+the show to account; and his idea was succeeding, for he no longer knew
+which way to turn. In fact, the villagers, who were hot, quarreled for
+these seats, whose straw smelt of incense, and they leant against the
+thick backs, stained with the wax of candles, with a certain veneration.
+
+Madame Bovary again took Rodolphe’s arm; he went on as if speaking to
+himself--
+
+“Yes, I have missed so many things. Always alone! Ah! if I had some aim
+in life, if I had met some love, if I had found someone! Oh, how I would
+have spent all the energy of which I am capable, surmounted everything,
+overcome everything!”
+
+“Yet it seems to me,” said Emma, “that you are not to be pitied.”
+
+“Ah! you think so?” said Rodolphe.
+
+“For, after all,” she went on, “you are free--” she hesitated, “rich--”
+
+“Do not mock me,” he replied.
+
+And she protested that she was not mocking him, when the report of a
+cannon resounded. Immediately all began hustling one another pell-mell
+towards the village.
+
+It was a false alarm. The prefect seemed not to be coming, and the
+members of the jury felt much embarrassed, not knowing if they ought to
+begin the meeting or still wait.
+
+At last at the end of the Place a large hired landau appeared, drawn by
+two thin horses, which a coachman in a white hat was whipping lustily.
+Binet had only just time to shout, “Present arms!” and the colonel to
+imitate him. All ran towards the enclosure; everyone pushed forward. A
+few even forgot their collars; but the equipage of the prefect seemed
+to anticipate the crowd, and the two yoked jades, trapesing in their
+harness, came up at a little trot in front of the peristyle of the town
+hall at the very moment when the National Guard and firemen deployed,
+beating drums and marking time.
+
+“Present!” shouted Binet.
+
+“Halt!” shouted the colonel. “Left about, march.”
+
+And after presenting arms, during which the clang of the band, letting
+loose, rang out like a brass kettle rolling downstairs, all the guns
+were lowered. Then was seen stepping down from the carriage a gentleman
+in a short coat with silver braiding, with bald brow, and wearing a tuft
+of hair at the back of his head, of a sallow complexion and the most
+benign appearance. His eyes, very large and covered by heavy lids, were
+half-closed to look at the crowd, while at the same time he raised his
+sharp nose, and forced a smile upon his sunken mouth. He recognised the
+mayor by his scarf, and explained to him that the prefect was not able
+to come. He himself was a councillor at the prefecture; then he added
+a few apologies. Monsieur Tuvache answered them with compliments; the
+other confessed himself nervous; and they remained thus, face to face,
+their foreheads almost touching, with the members of the jury all round,
+the municipal council, the notable personages, the National Guard and
+the crowd. The councillor pressing his little cocked hat to his
+breast repeated his bows, while Tuvache, bent like a bow, also smiled,
+stammered, tried to say something, protested his devotion to the
+monarchy and the honour that was being done to Yonville.
+
+Hippolyte, the groom from the inn, took the head of the horses from the
+coachman, and, limping along with his club-foot, led them to the door
+of the “Lion d’Or”, where a number of peasants collected to look at the
+carriage. The drum beat, the howitzer thundered, and the gentlemen one
+by one mounted the platform, where they sat down in red utrecht velvet
+arm-chairs that had been lent by Madame Tuvache.
+
+All these people looked alike. Their fair flabby faces, somewhat tanned
+by the sun, were the colour of sweet cider, and their puffy whiskers
+emerged from stiff collars, kept up by white cravats with broad bows.
+All the waist-coats were of velvet, double-breasted; all the watches
+had, at the end of a long ribbon, an oval cornelian seal; everyone
+rested his two hands on his thighs, carefully stretching the stride of
+their trousers, whose unsponged glossy cloth shone more brilliantly than
+the leather of their heavy boots.
+
+The ladies of the company stood at the back under the vestibule between
+the pillars while the common herd was opposite, standing up or sitting
+on chairs. As a matter of fact, Lestiboudois had brought thither all
+those that he had moved from the field, and he even kept running back
+every minute to fetch others from the church. He caused such confusion
+with this piece of business that one had great difficulty in getting to
+the small steps of the platform.
+
+“I think,” said Monsieur Lheureux to the chemist, who was passing to his
+place, “that they ought to have put up two Venetian masts with something
+rather severe and rich for ornaments; it would have been a very pretty
+effect.”
+
+“To be sure,” replied Homais; “but what can you expect? The mayor took
+everything on his own shoulders. He hasn’t much taste. Poor Tuvache! and
+he is even completely destitute of what is called the genius of art.”
+
+Rodolphe, meanwhile, with Madame Bovary, had gone up to the first
+floor of the town hall, to the “council-room,” and, as it was empty,
+he declared that they could enjoy the sight there more comfortably. He
+fetched three stools from the round table under the bust of the monarch,
+and having carried them to one of the windows, they sat down by each
+other.
+
+There was commotion on the platform, long whisperings, much parleying.
+At last the councillor got up. They knew now that his name was Lieuvain,
+and in the crowd the name was passed from one to the other. After he had
+collated a few pages, and bent over them to see better, he began--
+
+“Gentlemen! May I be permitted first of all (before addressing you on
+the object of our meeting to-day, and this sentiment will, I am sure, be
+shared by you all), may I be permitted, I say, to pay a tribute to the
+higher administration, to the government to the monarch, gentle men, our
+sovereign, to that beloved king, to whom no branch of public or private
+prosperity is a matter of indifference, and who directs with a hand at
+once so firm and wise the chariot of the state amid the incessant perils
+of a stormy sea, knowing, moreover, how to make peace respected as well
+as war, industry, commerce, agriculture, and the fine arts?”
+
+“I ought,” said Rodolphe, “to get back a little further.”
+
+“Why?” said Emma.
+
+But at this moment the voice of the councillor rose to an extraordinary
+pitch. He declaimed--
+
+“This is no longer the time, gentlemen, when civil discord ensanguined
+our public places, when the landlord, the business-man, the working-man
+himself, falling asleep at night, lying down to peaceful sleep, trembled
+lest he should be awakened suddenly by the noise of incendiary tocsins,
+when the most subversive doctrines audaciously sapped foundations.”
+
+“Well, someone down there might see me,” Rodolphe resumed, “then
+I should have to invent excuses for a fortnight; and with my bad
+reputation--”
+
+“Oh, you are slandering yourself,” said Emma.
+
+“No! It is dreadful, I assure you.”
+
+“But, gentlemen,” continued the councillor, “if, banishing from my
+memory the remembrance of these sad pictures, I carry my eyes back
+to the actual situation of our dear country, what do I see there?
+Everywhere commerce and the arts are flourishing; everywhere new means
+of communication, like so many new arteries in the body of the state,
+establish within it new relations. Our great industrial centres have
+recovered all their activity; religion, more consolidated, smiles in
+all hearts; our ports are full, confidence is born again, and France
+breathes once more!”
+
+“Besides,” added Rodolphe, “perhaps from the world’s point of view they
+are right.”
+
+“How so?” she asked.
+
+“What!” said he. “Do you not know that there are souls constantly
+tormented? They need by turns to dream and to act, the purest passions
+and the most turbulent joys, and thus they fling themselves into all
+sorts of fantasies, of follies.”
+
+Then she looked at him as one looks at a traveller who has voyaged over
+strange lands, and went on--
+
+“We have not even this distraction, we poor women!”
+
+“A sad distraction, for happiness isn’t found in it.”
+
+“But is it ever found?” she asked.
+
+“Yes; one day it comes,” he answered.
+
+“And this is what you have understood,” said the councillor.
+
+“You, farmers, agricultural labourers! you pacific pioneers of a work
+that belongs wholly to civilization! you, men of progress and morality,
+you have understood, I say, that political storms are even more
+redoubtable than atmospheric disturbances!”
+
+“It comes one day,” repeated Rodolphe, “one day suddenly, and when
+one is despairing of it. Then the horizon expands; it is as if a voice
+cried, ‘It is here!’ You feel the need of confiding the whole of your
+life, of giving everything, sacrificing everything to this being. There
+is no need for explanations; they understand one another. They have seen
+each other in dreams!”
+
+(And he looked at her.) “In fine, here it is, this treasure so sought
+after, here before you. It glitters, it flashes; yet one still doubts,
+one does not believe it; one remains dazzled, as if one went out from
+darkness into light.”
+
+And as he ended Rodolphe suited the action to the word. He passed his
+hand over his face, like a man seized with giddiness. Then he let it
+fall on Emma’s. She took hers away.
+
+“And who would be surprised at it, gentlemen? He only who is so blind,
+so plunged (I do not fear to say it), so plunged in the prejudices
+of another age as still to misunderstand the spirit of agricultural
+populations. Where, indeed, is to be found more patriotism than in the
+country, greater devotion to the public welfare, more intelligence, in a
+word? And, gentlemen, I do not mean that superficial intelligence,
+vain ornament of idle minds, but rather that profound and balanced
+intelligence that applies itself above all else to useful objects, thus
+contributing to the good of all, to the common amelioration and to
+the support of the state, born of respect for law and the practice of
+duty--”
+
+“Ah! again!” said Rodolphe. “Always ‘duty.’ I am sick of the word.
+They are a lot of old blockheads in flannel vests and of old women with
+foot-warmers and rosaries who constantly drone into our ears ‘Duty,
+duty!’ Ah! by Jove! one’s duty is to feel what is great, cherish the
+beautiful, and not accept all the conventions of society with the
+ignominy that it imposes upon us.”
+
+“Yet--yet--” objected Madame Bovary.
+
+“No, no! Why cry out against the passions? Are they not the one
+beautiful thing on the earth, the source of heroism, of enthusiasm, of
+poetry, music, the arts, of everything, in a word?”
+
+“But one must,” said Emma, “to some extent bow to the opinion of the
+world and accept its moral code.”
+
+“Ah! but there are two,” he replied. “The small, the conventional, that
+of men, that which constantly changes, that brays out so loudly, that
+makes such a commotion here below, of the earth earthly, like the mass
+of imbeciles you see down there. But the other, the eternal, that is
+about us and above, like the landscape that surrounds us, and the blue
+heavens that give us light.”
+
+Monsieur Lieuvain had just wiped his mouth with a pocket-handkerchief.
+He continued--
+
+“And what should I do here gentlemen, pointing out to you the uses
+of agriculture? Who supplies our wants? Who provides our means of
+subsistence? Is it not the agriculturist? The agriculturist, gentlemen,
+who, sowing with laborious hand the fertile furrows of the country,
+brings forth the corn, which, being ground, is made into a powder by
+means of ingenious machinery, comes out thence under the name of flour,
+and from there, transported to our cities, is soon delivered at the
+baker’s, who makes it into food for poor and rich alike. Again, is it
+not the agriculturist who fattens, for our clothes, his abundant
+flocks in the pastures? For how should we clothe ourselves, how nourish
+ourselves, without the agriculturist? And, gentlemen, is it even
+necessary to go so far for examples? Who has not frequently reflected
+on all the momentous things that we get out of that modest animal, the
+ornament of poultry-yards, that provides us at once with a soft pillow
+for our bed, with succulent flesh for our tables, and eggs? But I should
+never end if I were to enumerate one after the other all the different
+products which the earth, well cultivated, like a generous mother,
+lavishes upon her children. Here it is the vine, elsewhere the apple
+tree for cider, there colza, farther on cheeses and flax. Gentlemen, let
+us not forget flax, which has made such great strides of late years, and
+to which I will more particularly call your attention.”
+
+He had no need to call it, for all the mouths of the multitude were wide
+open, as if to drink in his words. Tuvache by his side listened to him
+with staring eyes. Monsieur Derozerays from time to time softly closed
+his eyelids, and farther on the chemist, with his son Napoleon between
+his knees, put his hand behind his ear in order not to lose a syllable.
+The chins of the other members of the jury went slowly up and down in
+their waistcoats in sign of approval. The firemen at the foot of the
+platform rested on their bayonets; and Binet, motionless, stood with
+out-turned elbows, the point of his sabre in the air. Perhaps he could
+hear, but certainly he could see nothing, because of the visor of his
+helmet, that fell down on his nose. His lieutenant, the youngest son of
+Monsieur Tuvache, had a bigger one, for his was enormous, and shook on
+his head, and from it an end of his cotton scarf peeped out. He smiled
+beneath it with a perfectly infantine sweetness, and his pale little
+face, whence drops were running, wore an expression of enjoyment and
+sleepiness.
+
+The square as far as the houses was crowded with people. One saw folk
+leaning on their elbows at all the windows, others standing at doors,
+and Justin, in front of the chemist’s shop, seemed quite transfixed by
+the sight of what he was looking at. In spite of the silence Monsieur
+Lieuvain’s voice was lost in the air. It reached you in fragments of
+phrases, and interrupted here and there by the creaking of chairs in the
+crowd; then you suddenly heard the long bellowing of an ox, or else the
+bleating of the lambs, who answered one another at street corners. In
+fact, the cowherds and shepherds had driven their beasts thus far, and
+these lowed from time to time, while with their tongues they tore down
+some scrap of foliage that hung above their mouths.
+
+Rodolphe had drawn nearer to Emma, and said to her in a low voice,
+speaking rapidly--
+
+“Does not this conspiracy of the world revolt you? Is there a single
+sentiment it does not condemn? The noblest instincts, the purest
+sympathies are persecuted, slandered; and if at length two poor souls do
+meet, all is so organised that they cannot blend together. Yet they will
+make the attempt; they will flutter their wings; they will call upon
+each other. Oh! no matter. Sooner or later, in six months, ten years,
+they will come together, will love; for fate has decreed it, and they
+are born one for the other.”
+
+His arms were folded across his knees, and thus lifting his face towards
+Emma, close by her, he looked fixedly at her. She noticed in his eyes
+small golden lines radiating from black pupils; she even smelt the
+perfume of the pomade that made his hair glossy.
+
+Then a faintness came over her; she recalled the Viscount who had
+waltzed with her at Vaubyessard, and his beard exhaled like this air an
+odour of vanilla and citron, and mechanically she half-closed her eyes
+the better to breathe it in. But in making this movement, as she leant
+back in her chair, she saw in the distance, right on the line of the
+horizon, the old diligence, the “Hirondelle,” that was slowly descending
+the hill of Leux, dragging after it a long trail of dust. It was in this
+yellow carriage that Leon had so often come back to her, and by this
+route down there that he had gone for ever. She fancied she saw him
+opposite at his windows; then all grew confused; clouds gathered; it
+seemed to her that she was again turning in the waltz under the light of
+the lustres on the arm of the Viscount, and that Leon was not far away,
+that he was coming; and yet all the time she was conscious of the scent
+of Rodolphe’s head by her side. This sweetness of sensation pierced
+through her old desires, and these, like grains of sand under a gust
+of wind, eddied to and fro in the subtle breath of the perfume which
+suffused her soul. She opened wide her nostrils several times to drink
+in the freshness of the ivy round the capitals. She took off her gloves,
+she wiped her hands, then fanned her face with her handkerchief, while
+athwart the throbbing of her temples she heard the murmur of the
+crowd and the voice of the councillor intoning his phrases. He
+said--“Continue, persevere; listen neither to the suggestions of
+routine, nor to the over-hasty councils of a rash empiricism.
+
+“Apply yourselves, above all, to the amelioration of the soil, to good
+manures, to the development of the equine, bovine, ovine, and porcine
+races. Let these shows be to you pacific arenas, where the victor in
+leaving it will hold forth a hand to the vanquished, and will fraternise
+with him in the hope of better success. And you, aged servants, humble
+domestics, whose hard labour no Government up to this day has taken into
+consideration, come hither to receive the reward of your silent virtues,
+and be assured that the state henceforward has its eye upon you; that it
+encourages you, protects you; that it will accede to your just
+demands, and alleviate as much as in it lies the burden of your painful
+sacrifices.”
+
+Monsieur Lieuvain then sat down; Monsieur Derozerays got up, beginning
+another speech. His was not perhaps so florid as that of the councillor,
+but it recommended itself by a more direct style, that is to say, by
+more special knowledge and more elevated considerations. Thus the praise
+of the Government took up less space in it; religion and agriculture
+more. He showed in it the relations of these two, and how they had
+always contributed to civilisation. Rodolphe with Madame Bovary was
+talking dreams, presentiments, magnetism. Going back to the cradle of
+society, the orator painted those fierce times when men lived on acorns
+in the heart of woods. Then they had left off the skins of beasts, had
+put on cloth, tilled the soil, planted the vine. Was this a good, and
+in this discovery was there not more of injury than of gain? Monsieur
+Derozerays set himself this problem. From magnetism little by little
+Rodolphe had come to affinities, and while the president was citing
+Cincinnatus and his plough, Diocletian, planting his cabbages, and the
+Emperors of China inaugurating the year by the sowing of seed, the
+young man was explaining to the young woman that these irresistible
+attractions find their cause in some previous state of existence.
+
+“Thus we,” he said, “why did we come to know one another? What chance
+willed it? It was because across the infinite, like two streams that
+flow but to unite; our special bents of mind had driven us towards each
+other.”
+
+And he seized her hand; she did not withdraw it.
+
+“For good farming generally!” cried the president.
+
+“Just now, for example, when I went to your house.”
+
+“To Monsieur Bizat of Quincampoix.”
+
+“Did I know I should accompany you?”
+
+“Seventy francs.”
+
+“A hundred times I wished to go; and I followed you--I remained.”
+
+“Manures!”
+
+“And I shall remain to-night, to-morrow, all other days, all my life!”
+
+“To Monsieur Caron of Argueil, a gold medal!”
+
+“For I have never in the society of any other person found so complete a
+charm.”
+
+“To Monsieur Bain of Givry-Saint-Martin.”
+
+“And I shall carry away with me the remembrance of you.”
+
+“For a merino ram!”
+
+“But you will forget me; I shall pass away like a shadow.”
+
+“To Monsieur Belot of Notre-Dame.”
+
+“Oh, no! I shall be something in your thought, in your life, shall I
+not?”
+
+“Porcine race; prizes--equal, to Messrs. Leherisse and Cullembourg,
+sixty francs!”
+
+Rodolphe was pressing her hand, and he felt it all warm and quivering
+like a captive dove that wants to fly away; but, whether she was trying
+to take it away or whether she was answering his pressure; she made a
+movement with her fingers. He exclaimed--
+
+“Oh, I thank you! You do not repulse me! You are good! You understand
+that I am yours! Let me look at you; let me contemplate you!”
+
+A gust of wind that blew in at the window ruffled the cloth on the
+table, and in the square below all the great caps of the peasant women
+were uplifted by it like the wings of white butterflies fluttering.
+
+“Use of oil-cakes,” continued the president. He was hurrying on:
+“Flemish manure-flax-growing-drainage-long leases-domestic service.”
+
+Rodolphe was no longer speaking. They looked at one another. A supreme
+desire made their dry lips tremble, and wearily, without an effort,
+their fingers intertwined.
+
+“Catherine Nicaise Elizabeth Leroux, of Sassetot-la-Guerriere, for
+fifty-four years of service at the same farm, a silver medal--value,
+twenty-five francs!”
+
+“Where is Catherine Leroux?” repeated the councillor.
+
+She did not present herself, and one could hear voices whispering--
+
+“Go up!”
+
+“Don’t be afraid!”
+
+“Oh, how stupid she is!”
+
+“Well, is she there?” cried Tuvache.
+
+“Yes; here she is.”
+
+“Then let her come up!”
+
+Then there came forward on the platform a little old woman with timid
+bearing, who seemed to shrink within her poor clothes. On her feet she
+wore heavy wooden clogs, and from her hips hung a large blue apron. Her
+pale face framed in a borderless cap was more wrinkled than a withered
+russet apple. And from the sleeves of her red jacket looked out two
+large hands with knotty joints, the dust of barns, the potash of washing
+the grease of wools had so encrusted, roughened, hardened these that
+they seemed dirty, although they had been rinsed in clear water; and
+by dint of long service they remained half open, as if to bear humble
+witness for themselves of so much suffering endured. Something of
+monastic rigidity dignified her face. Nothing of sadness or of emotion
+weakened that pale look. In her constant living with animals she had
+caught their dumbness and their calm. It was the first time that she
+found herself in the midst of so large a company, and inwardly scared by
+the flags, the drums, the gentlemen in frock-coats, and the order of the
+councillor, she stood motionless, not knowing whether to advance or run
+away, nor why the crowd was pushing her and the jury were smiling at
+her.
+
+Thus stood before these radiant bourgeois this half-century of
+servitude.
+
+“Approach, venerable Catherine Nicaise Elizabeth Leroux!” said the
+councillor, who had taken the list of prize-winners from the president;
+and, looking at the piece of paper and the old woman by turns, he
+repeated in a fatherly tone--“Approach! approach!”
+
+“Are you deaf?” said Tuvache, fidgeting in his armchair; and he began
+shouting in her ear, “Fifty-four years of service. A silver medal!
+Twenty-five francs! For you!”
+
+Then, when she had her medal, she looked at it, and a smile of beatitude
+spread over her face; and as she walked away they could hear her
+muttering “I’ll give it to our cure up home, to say some masses for me!”
+
+“What fanaticism!” exclaimed the chemist, leaning across to the notary.
+
+The meeting was over, the crowd dispersed, and now that the speeches had
+been read, each one fell back into his place again, and everything into
+the old grooves; the masters bullied the servants, and these struck the
+animals, indolent victors, going back to the stalls, a green-crown on
+their horns.
+
+The National Guards, however, had gone up to the first floor of the
+town hall with buns spitted on their bayonets, and the drummer of the
+battalion carried a basket with bottles. Madame Bovary took Rodolphe’s
+arm; he saw her home; they separated at her door; then he walked about
+alone in the meadow while he waited for the time of the banquet.
+
+The feast was long, noisy, ill served; the guests were so crowded that
+they could hardly move their elbows; and the narrow planks used for
+forms almost broke down under their weight. They ate hugely. Each one
+stuffed himself on his own account. Sweat stood on every brow, and a
+whitish steam, like the vapour of a stream on an autumn morning, floated
+above the table between the hanging lamps. Rodolphe, leaning against
+the calico of the tent was thinking so earnestly of Emma that he heard
+nothing. Behind him on the grass the servants were piling up the dirty
+plates, his neighbours were talking; he did not answer them; they filled
+his glass, and there was silence in his thoughts in spite of the growing
+noise. He was dreaming of what she had said, of the line of her lips;
+her face, as in a magic mirror, shone on the plates of the shakos, the
+folds of her gown fell along the walls, and days of love unrolled to all
+infinity before him in the vistas of the future.
+
+He saw her again in the evening during the fireworks, but she was with
+her husband, Madame Homais, and the druggist, who was worrying about the
+danger of stray rockets, and every moment he left the company to go and
+give some advice to Binet.
+
+The pyrotechnic pieces sent to Monsieur Tuvache had, through an excess
+of caution, been shut up in his cellar, and so the damp powder would
+not light, and the principal set piece, that was to represent a dragon
+biting his tail, failed completely. Now and then a meagre Roman-candle
+went off; then the gaping crowd sent up a shout that mingled with the
+cry of the women, whose waists were being squeezed in the darkness. Emma
+silently nestled against Charles’s shoulder; then, raising her chin, she
+watched the luminous rays of the rockets against the dark sky. Rodolphe
+gazed at her in the light of the burning lanterns.
+
+They went out one by one. The stars shone out. A few crops of rain began
+to fall. She knotted her fichu round her bare head.
+
+At this moment the councillor’s carriage came out from the inn.
+
+His coachman, who was drunk, suddenly dozed off, and one could see from
+the distance, above the hood, between the two lanterns, the mass of his
+body, that swayed from right to left with the giving of the traces.
+
+“Truly,” said the druggist, “one ought to proceed most rigorously
+against drunkenness! I should like to see written up weekly at the door
+of the town hall on a board ad hoc* the names of all those who during
+the week got intoxicated on alcohol. Besides, with regard to statistics,
+one would thus have, as it were, public records that one could refer to
+in case of need. But excuse me!”
+
+     *Specifically for that.
+
+And he once more ran off to the captain. The latter was going back to
+see his lathe again.
+
+“Perhaps you would not do ill,” Homais said to him, “to send one of your
+men, or to go yourself--”
+
+“Leave me alone!” answered the tax-collector. “It’s all right!”
+
+“Do not be uneasy,” said the druggist, when he returned to his friends.
+“Monsieur Binet has assured me that all precautions have been taken. No
+sparks have fallen; the pumps are full. Let us go to rest.”
+
+“Ma foi! I want it,” said Madame Homais, yawning at large. “But never
+mind; we’ve had a beautiful day for our fete.”
+
+Rodolphe repeated in a low voice, and with a tender look, “Oh, yes! very
+beautiful!”
+
+And having bowed to one another, they separated.
+
+Two days later, in the “Final de Rouen,” there was a long article on the
+show. Homais had composed it with verve the very next morning.
+
+“Why these festoons, these flowers, these garlands? Whither hurries this
+crowd like the waves of a furious sea under the torrents of a tropical
+sun pouring its heat upon our heads?”
+
+Then he spoke of the condition of the peasants. Certainly the Government
+was doing much, but not enough. “Courage!” he cried to it; “a thousand
+reforms are indispensable; let us accomplish them!” Then touching on
+the entry of the councillor, he did not forget “the martial air of our
+militia;” nor “our most merry village maidens;” nor the “bald-headed old
+men like patriarchs who were there, and of whom some, the remnants of
+our phalanxes, still felt their hearts beat at the manly sound of the
+drums.” He cited himself among the first of the members of the jury,
+and he even called attention in a note to the fact that Monsieur Homais,
+chemist, had sent a memoir on cider to the agricultural society.
+
+When he came to the distribution of the prizes, he painted the joy of
+the prize-winners in dithyrambic strophes. “The father embraced the son,
+the brother the brother, the husband his consort. More than one showed
+his humble medal with pride; and no doubt when he got home to his good
+housewife, he hung it up weeping on the modest walls of his cot.
+
+“About six o’clock a banquet prepared in the meadow of Monsieur Leigeard
+brought together the principal personages of the fete. The greatest
+cordiality reigned here. Divers toasts were proposed: Monsieur
+Lieuvain, the King; Monsieur Tuvache, the Prefect; Monsieur Derozerays,
+Agriculture; Monsieur Homais, Industry and the Fine Arts, those twin
+sisters; Monsieur Leplichey, Progress. In the evening some brilliant
+fireworks on a sudden illumined the air. One would have called it a
+veritable kaleidoscope, a real operatic scene; and for a moment our
+little locality might have thought itself transported into the midst of
+a dream of the ‘Thousand and One Nights.’ Let us state that no untoward
+event disturbed this family meeting.” And he added “Only the absence
+of the clergy was remarked. No doubt the priests understand progress in
+another fashion. Just as you please, messieurs the followers of Loyola!”
+
+
+
+Chapter Nine
+
+Six weeks passed. Rodolphe did not come again. At last one evening he
+appeared.
+
+The day after the show he had said to himself--“We mustn’t go back too
+soon; that would be a mistake.”
+
+And at the end of a week he had gone off hunting. After the hunting he
+had thought it was too late, and then he reasoned thus--
+
+“If from the first day she loved me, she must from impatience to see me
+again love me more. Let’s go on with it!”
+
+And he knew that his calculation had been right when, on entering the
+room, he saw Emma turn pale.
+
+She was alone. The day was drawing in. The small muslin curtain along
+the windows deepened the twilight, and the gilding of the barometer, on
+which the rays of the sun fell, shone in the looking-glass between the
+meshes of the coral.
+
+Rodolphe remained standing, and Emma hardly answered his first
+conventional phrases.
+
+“I,” he said, “have been busy. I have been ill.”
+
+“Seriously?” she cried.
+
+“Well,” said Rodolphe, sitting down at her side on a footstool, “no; it
+was because I did not want to come back.”
+
+“Why?”
+
+“Can you not guess?”
+
+He looked at her again, but so hard that she lowered her head, blushing.
+He went on--
+
+“Emma!”
+
+“Sir,” she said, drawing back a little.
+
+“Ah! you see,” replied he in a melancholy voice, “that I was right not
+to come back; for this name, this name that fills my whole soul, and
+that escaped me, you forbid me to use! Madame Bovary! why all the
+world calls you thus! Besides, it is not your name; it is the name of
+another!”
+
+He repeated, “of another!” And he hid his face in his hands.
+
+“Yes, I think of you constantly. The memory of you drives me to despair.
+Ah! forgive me! I will leave you! Farewell! I will go far away, so far
+that you will never hear of me again; and yet--to-day--I know not what
+force impelled me towards you. For one does not struggle against Heaven;
+one cannot resist the smile of angels; one is carried away by that which
+is beautiful, charming, adorable.”
+
+It was the first time that Emma had heard such words spoken to herself,
+and her pride, like one who reposes bathed in warmth, expanded softly
+and fully at this glowing language.
+
+“But if I did not come,” he continued, “if I could not see you, at least
+I have gazed long on all that surrounds you. At night-every night-I
+arose; I came hither; I watched your house, its glimmering in the moon,
+the trees in the garden swaying before your window, and the little lamp,
+a gleam shining through the window-panes in the darkness. Ah! you never
+knew that there, so near you, so far from you, was a poor wretch!”
+
+She turned towards him with a sob.
+
+“Oh, you are good!” she said.
+
+“No, I love you, that is all! You do not doubt that! Tell me--one
+word--only one word!”
+
+And Rodolphe imperceptibly glided from the footstool to the ground; but
+a sound of wooden shoes was heard in the kitchen, and he noticed the
+door of the room was not closed.
+
+“How kind it would be of you,” he went on, rising, “if you would humour
+a whim of mine.” It was to go over her house; he wanted to know it; and
+Madame Bovary seeing no objection to this, they both rose, when Charles
+came in.
+
+“Good morning, doctor,” Rodolphe said to him.
+
+The doctor, flattered at this unexpected title, launched out into
+obsequious phrases. Of this the other took advantage to pull himself
+together a little.
+
+“Madame was speaking to me,” he then said, “about her health.”
+
+Charles interrupted him; he had indeed a thousand anxieties; his wife’s
+palpitations of the heart were beginning again. Then Rodolphe asked if
+riding would not be good.
+
+“Certainly! excellent! just the thing! There’s an idea! You ought to
+follow it up.”
+
+And as she objected that she had no horse, Monsieur Rodolphe offered
+one. She refused his offer; he did not insist. Then to explain his visit
+he said that his ploughman, the man of the blood-letting, still suffered
+from giddiness.
+
+“I’ll call around,” said Bovary.
+
+“No, no! I’ll send him to you; we’ll come; that will be more convenient
+for you.”
+
+“Ah! very good! I thank you.”
+
+And as soon as they were alone, “Why don’t you accept Monsieur
+Boulanger’s kind offer?”
+
+She assumed a sulky air, invented a thousand excuses, and finally
+declared that perhaps it would look odd.
+
+“Well, what the deuce do I care for that?” said Charles, making a
+pirouette. “Health before everything! You are wrong.”
+
+“And how do you think I can ride when I haven’t got a habit?”
+
+“You must order one,” he answered.
+
+The riding-habit decided her.
+
+When the habit was ready, Charles wrote to Monsieur Boulanger that his
+wife was at his command, and that they counted on his good-nature.
+
+The next day at noon Rodolphe appeared at Charles’s door with two
+saddle-horses. One had pink rosettes at his ears and a deerskin
+side-saddle.
+
+Rodolphe had put on high soft boots, saying to himself that no doubt she
+had never seen anything like them. In fact, Emma was charmed with his
+appearance as he stood on the landing in his great velvet coat and white
+corduroy breeches. She was ready; she was waiting for him.
+
+Justin escaped from the chemist’s to see her start, and the chemist also
+came out. He was giving Monsieur Boulanger a little good advice.
+
+“An accident happens so easily. Be careful! Your horses perhaps are
+mettlesome.”
+
+She heard a noise above her; it was Felicite drumming on the windowpanes
+to amuse little Berthe. The child blew her a kiss; her mother answered
+with a wave of her whip.
+
+“A pleasant ride!” cried Monsieur Homais. “Prudence! above all,
+prudence!” And he flourished his newspaper as he saw them disappear.
+
+As soon as he felt the ground, Emma’s horse set off at a gallop.
+
+Rodolphe galloped by her side. Now and then they exchanged a word. Her
+figure slightly bent, her hand well up, and her right arm stretched out,
+she gave herself up to the cadence of the movement that rocked her in
+her saddle. At the bottom of the hill Rodolphe gave his horse its head;
+they started together at a bound, then at the top suddenly the horses
+stopped, and her large blue veil fell about her.
+
+It was early in October. There was fog over the land. Hazy clouds
+hovered on the horizon between the outlines of the hills; others, rent
+asunder, floated up and disappeared. Sometimes through a rift in the
+clouds, beneath a ray of sunshine, gleamed from afar the roots of
+Yonville, with the gardens at the water’s edge, the yards, the walls and
+the church steeple. Emma half closed her eyes to pick out her house, and
+never had this poor village where she lived appeared so small. From the
+height on which they were the whole valley seemed an immense pale lake
+sending off its vapour into the air. Clumps of trees here and there
+stood out like black rocks, and the tall lines of the poplars that rose
+above the mist were like a beach stirred by the wind.
+
+By the side, on the turf between the pines, a brown light shimmered
+in the warm atmosphere. The earth, ruddy like the powder of tobacco,
+deadened the noise of their steps, and with the edge of their shoes the
+horses as they walked kicked the fallen fir cones in front of them.
+
+Rodolphe and Emma thus went along the skirt of the wood. She turned
+away from time to time to avoid his look, and then she saw only the pine
+trunks in lines, whose monotonous succession made her a little giddy.
+The horses were panting; the leather of the saddles creaked.
+
+Just as they were entering the forest the sun shone out.
+
+“God protects us!” said Rodolphe.
+
+“Do you think so?” she said.
+
+“Forward! forward!” he continued.
+
+He “tchk’d” with his tongue. The two beasts set off at a trot.
+
+Long ferns by the roadside caught in Emma’s stirrup.
+
+Rodolphe leant forward and removed them as they rode along. At other
+times, to turn aside the branches, he passed close to her, and Emma felt
+his knee brushing against her leg. The sky was now blue, the leaves no
+longer stirred. There were spaces full of heather in flower, and plots
+of violets alternated with the confused patches of the trees that were
+grey, fawn, or golden coloured, according to the nature of their leaves.
+Often in the thicket was heard the fluttering of wings, or else the
+hoarse, soft cry of the ravens flying off amidst the oaks.
+
+They dismounted. Rodolphe fastened up the horses. She walked on in
+front on the moss between the paths. But her long habit got in her way,
+although she held it up by the skirt; and Rodolphe, walking behind her,
+saw between the black cloth and the black shoe the fineness of her white
+stocking, that seemed to him as if it were a part of her nakedness.
+
+She stopped. “I am tired,” she said.
+
+“Come, try again,” he went on. “Courage!”
+
+Then some hundred paces farther on she again stopped, and through her
+veil, that fell sideways from her man’s hat over her hips, her face
+appeared in a bluish transparency as if she were floating under azure
+waves.
+
+“But where are we going?”
+
+He did not answer. She was breathing irregularly. Rodolphe looked round
+him biting his moustache. They came to a larger space where the coppice
+had been cut. They sat down on the trunk of a fallen tree, and Rodolphe
+began speaking to her of his love. He did not begin by frightening her
+with compliments. He was calm, serious, melancholy.
+
+Emma listened to him with bowed head, and stirred the bits of wood on
+the ground with the tip of her foot. But at the words, “Are not our
+destinies now one?”
+
+“Oh, no!” she replied. “You know that well. It is impossible!” She rose
+to go. He seized her by the wrist. She stopped. Then, having gazed
+at him for a few moments with an amorous and humid look, she said
+hurriedly--
+
+“Ah! do not speak of it again! Where are the horses? Let us go back.”
+
+He made a gesture of anger and annoyance. She repeated:
+
+“Where are the horses? Where are the horses?”
+
+Then smiling a strange smile, his pupil fixed, his teeth set, he
+advanced with outstretched arms. She recoiled trembling. She stammered:
+
+“Oh, you frighten me! You hurt me! Let me go!”
+
+“If it must be,” he went on, his face changing; and he again became
+respectful, caressing, timid. She gave him her arm. They went back. He
+said--
+
+“What was the matter with you? Why? I do not understand. You were
+mistaken, no doubt. In my soul you are as a Madonna on a pedestal, in
+a place lofty, secure, immaculate. But I need you to live! I must have
+your eyes, your voice, your thought! Be my friend, my sister, my angel!”
+
+And he put out his arm round her waist. She feebly tried to disengage
+herself. He supported her thus as they walked along.
+
+But they heard the two horses browsing on the leaves.
+
+“Oh! one moment!” said Rodolphe. “Do not let us go! Stay!”
+
+He drew her farther on to a small pool where duckweeds made a greenness
+on the water. Faded water lilies lay motionless between the reeds.
+At the noise of their steps in the grass, frogs jumped away to hide
+themselves.
+
+“I am wrong! I am wrong!” she said. “I am mad to listen to you!”
+
+“Why? Emma! Emma!”
+
+“Oh, Rodolphe!” said the young woman slowly, leaning on his shoulder.
+
+The cloth of her habit caught against the velvet of his coat. She threw
+back her white neck, swelling with a sigh, and faltering, in tears, with
+a long shudder and hiding her face, she gave herself up to him--
+
+The shades of night were falling; the horizontal sun passing between the
+branches dazzled the eyes. Here and there around her, in the leaves
+or on the ground, trembled luminous patches, as it hummingbirds flying
+about had scattered their feathers. Silence was everywhere; something
+sweet seemed to come forth from the trees; she felt her heart, whose
+beating had begun again, and the blood coursing through her flesh like a
+stream of milk. Then far away, beyond the wood, on the other hills, she
+heard a vague prolonged cry, a voice which lingered, and in silence she
+heard it mingling like music with the last pulsations of her throbbing
+nerves. Rodolphe, a cigar between his lips, was mending with his
+penknife one of the two broken bridles.
+
+They returned to Yonville by the same road. On the mud they saw again
+the traces of their horses side by side, the same thickets, the same
+stones to the grass; nothing around them seemed changed; and yet for her
+something had happened more stupendous than if the mountains had moved
+in their places. Rodolphe now and again bent forward and took her hand
+to kiss it.
+
+She was charming on horseback--upright, with her slender waist, her knee
+bent on the mane of her horse, her face somewhat flushed by the fresh
+air in the red of the evening.
+
+On entering Yonville she made her horse prance in the road. People
+looked at her from the windows.
+
+At dinner her husband thought she looked well, but she pretended not to
+hear him when he inquired about her ride, and she remained sitting there
+with her elbow at the side of her plate between the two lighted candles.
+
+“Emma!” he said.
+
+“What?”
+
+“Well, I spent the afternoon at Monsieur Alexandre’s. He has an old cob,
+still very fine, only a little broken-kneed, and that could be bought; I
+am sure, for a hundred crowns.” He added, “And thinking it might please
+you, I have bespoken it--bought it. Have I done right? Do tell me?”
+
+She nodded her head in assent; then a quarter of an hour later--
+
+“Are you going out to-night?” she asked.
+
+“Yes. Why?”
+
+“Oh, nothing, nothing, my dear!”
+
+And as soon as she had got rid of Charles she went and shut herself up
+in her room.
+
+At first she felt stunned; she saw the trees, the paths, the ditches,
+Rodolphe, and she again felt the pressure of his arm, while the leaves
+rustled and the reeds whistled.
+
+But when she saw herself in the glass she wondered at her face. Never
+had her eyes been so large, so black, of so profound a depth. Something
+subtle about her being transfigured her. She repeated, “I have a lover!
+a lover!” delighting at the idea as if a second puberty had come to her.
+So at last she was to know those joys of love, that fever of happiness
+of which she had despaired! She was entering upon marvels where all
+would be passion, ecstasy, delirium. An azure infinity encompassed
+her, the heights of sentiment sparkled under her thought, and ordinary
+existence appeared only afar off, down below in the shade, through the
+interspaces of these heights.
+
+Then she recalled the heroines of the books that she had read, and the
+lyric legion of these adulterous women began to sing in her memory with
+the voice of sisters that charmed her. She became herself, as it were,
+an actual part of these imaginings, and realised the love-dream of her
+youth as she saw herself in this type of amorous women whom she had
+so envied. Besides, Emma felt a satisfaction of revenge. Had she not
+suffered enough? But now she triumphed, and the love so long pent up
+burst forth in full joyous bubblings. She tasted it without remorse,
+without anxiety, without trouble.
+
+The day following passed with a new sweetness. They made vows to one
+another She told him of her sorrows. Rodolphe interrupted her with
+kisses; and she looking at him through half-closed eyes, asked him to
+call her again by her name--to say that he loved her They were in the
+forest, as yesterday, in the shed of some woodenshoe maker. The walls
+were of straw, and the roof so low they had to stoop. They were seated
+side by side on a bed of dry leaves.
+
+From that day forth they wrote to one another regularly every evening.
+Emma placed her letter at the end of the garden, by the river, in a
+fissure of the wall. Rodolphe came to fetch it, and put another there,
+that she always found fault with as too short.
+
+One morning, when Charles had gone out before day break, she was seized
+with the fancy to see Rodolphe at once. She would go quickly to La
+Huchette, stay there an hour, and be back again at Yonville while
+everyone was still asleep. This idea made her pant with desire, and she
+soon found herself in the middle of the field, walking with rapid steps,
+without looking behind her.
+
+Day was just breaking. Emma from afar recognised her lover’s house. Its
+two dove-tailed weathercocks stood out black against the pale dawn.
+
+Beyond the farmyard there was a detached building that she thought must
+be the chateau She entered--it was if the doors at her approach had
+opened wide of their own accord. A large straight staircase led up to
+the corridor. Emma raised the latch of a door, and suddenly at the end
+of the room she saw a man sleeping. It was Rodolphe. She uttered a cry.
+
+“You here? You here?” he repeated. “How did you manage to come? Ah! your
+dress is damp.”
+
+“I love you,” she answered, throwing her arms about his neck.
+
+This first piece of daring successful, now every time Charles went out
+early Emma dressed quickly and slipped on tiptoe down the steps that led
+to the waterside.
+
+But when the plank for the cows was taken up, she had to go by the walls
+alongside of the river; the bank was slippery; in order not to fall
+she caught hold of the tufts of faded wallflowers. Then she went across
+ploughed fields, in which she sank, stumbling; and clogging her thin
+shoes. Her scarf, knotted round her head, fluttered to the wind in the
+meadows. She was afraid of the oxen; she began to run; she arrived out
+of breath, with rosy cheeks, and breathing out from her whole person a
+fresh perfume of sap, of verdure, of the open air. At this hour Rodolphe
+still slept. It was like a spring morning coming into his room.
+
+The yellow curtains along the windows let a heavy, whitish light enter
+softly. Emma felt about, opening and closing her eyes, while the drops
+of dew hanging from her hair formed, as it were, a topaz aureole around
+her face. Rodolphe, laughing, drew her to him, and pressed her to his
+breast.
+
+Then she examined the apartment, opened the drawers of the tables,
+combed her hair with his comb, and looked at herself in his
+shaving-glass. Often she even put between her teeth the big pipe that
+lay on the table by the bed, amongst lemons and pieces of sugar near a
+bottle of water.
+
+It took them a good quarter of an hour to say goodbye. Then Emma cried.
+She would have wished never to leave Rodolphe. Something stronger than
+herself forced her to him; so much so, that one day, seeing her come
+unexpectedly, he frowned as one put out.
+
+“What is the matter with you?” she said. “Are you ill? Tell me!”
+
+At last he declared with a serious air that her visits were becoming
+imprudent--that she was compromising herself.
+
+
+
+Chapter Ten
+
+Gradually Rodolphe’s fears took possession of her. At first, love had
+intoxicated her; and she had thought of nothing beyond. But now that he
+was indispensable to her life, she feared to lose anything of this, or
+even that it should be disturbed. When she came back from his house she
+looked all about her, anxiously watching every form that passed in the
+horizon, and every village window from which she could be seen. She
+listened for steps, cries, the noise of the ploughs, and she stopped
+short, white, and trembling more than the aspen leaves swaying overhead.
+
+One morning as she was thus returning, she suddenly thought she saw the
+long barrel of a carbine that seemed to be aimed at her. It stuck out
+sideways from the end of a small tub half-buried in the grass on the
+edge of a ditch. Emma, half-fainting with terror, nevertheless walked
+on, and a man stepped out of the tub like a Jack-in-the-box. He had
+gaiters buckled up to the knees, his cap pulled down over his eyes,
+trembling lips, and a red nose. It was Captain Binet lying in ambush for
+wild ducks.
+
+“You ought to have called out long ago!” he exclaimed; “When one sees a
+gun, one should always give warning.”
+
+The tax-collector was thus trying to hide the fright he had had, for
+a prefectorial order having prohibited duckhunting except in boats,
+Monsieur Binet, despite his respect for the laws, was infringing them,
+and so he every moment expected to see the rural guard turn up. But
+this anxiety whetted his pleasure, and, all alone in his tub, he
+congratulated himself on his luck and on his cuteness. At sight of
+Emma he seemed relieved from a great weight, and at once entered upon a
+conversation.
+
+“It isn’t warm; it’s nipping.”
+
+Emma answered nothing. He went on--
+
+“And you’re out so early?”
+
+“Yes,” she said stammering; “I am just coming from the nurse where my
+child is.”
+
+“Ah! very good! very good! For myself, I am here, just as you see me,
+since break of day; but the weather is so muggy, that unless one had the
+bird at the mouth of the gun--”
+
+“Good evening, Monsieur Binet,” she interrupted him, turning on her
+heel.
+
+“Your servant, madame,” he replied drily; and he went back into his tub.
+
+Emma regretted having left the tax-collector so abruptly. No doubt he
+would form unfavourable conjectures. The story about the nurse was the
+worst possible excuse, everyone at Yonville knowing that the little
+Bovary had been at home with her parents for a year. Besides, no one
+was living in this direction; this path led only to La Huchette. Binet,
+then, would guess whence she came, and he would not keep silence; he
+would talk, that was certain. She remained until evening racking her
+brain with every conceivable lying project, and had constantly before
+her eyes that imbecile with the game-bag.
+
+Charles after dinner, seeing her gloomy, proposed, by way of
+distraction, to take her to the chemist’s, and the first person she
+caught sight of in the shop was the taxcollector again. He was standing
+in front of the counter, lit up by the gleams of the red bottle, and was
+saying--
+
+“Please give me half an ounce of vitriol.”
+
+“Justin,” cried the druggist, “bring us the sulphuric acid.” Then to
+Emma, who was going up to Madame Homais’ room, “No, stay here; it isn’t
+worth while going up; she is just coming down. Warm yourself at the
+stove in the meantime. Excuse me. Good-day, doctor,” (for the chemist
+much enjoyed pronouncing the word “doctor,” as if addressing another by
+it reflected on himself some of the grandeur that he found in it). “Now,
+take care not to upset the mortars! You’d better fetch some chairs from
+the little room; you know very well that the arm-chairs are not to be
+taken out of the drawing-room.”
+
+And to put his arm-chair back in its place he was darting away from the
+counter, when Binet asked him for half an ounce of sugar acid.
+
+“Sugar acid!” said the chemist contemptuously, “don’t know it; I’m
+ignorant of it! But perhaps you want oxalic acid. It is oxalic acid,
+isn’t it?”
+
+Binet explained that he wanted a corrosive to make himself some
+copperwater with which to remove rust from his hunting things.
+
+Emma shuddered. The chemist began saying--
+
+“Indeed the weather is not propitious on account of the damp.”
+
+“Nevertheless,” replied the tax-collector, with a sly look, “there are
+people who like it.”
+
+She was stifling.
+
+“And give me--”
+
+“Will he never go?” thought she.
+
+“Half an ounce of resin and turpentine, four ounces of yellow wax,
+and three half ounces of animal charcoal, if you please, to clean the
+varnished leather of my togs.”
+
+The druggist was beginning to cut the wax when Madame Homais appeared,
+Irma in her arms, Napoleon by her side, and Athalie following. She sat
+down on the velvet seat by the window, and the lad squatted down on a
+footstool, while his eldest sister hovered round the jujube box near
+her papa. The latter was filling funnels and corking phials, sticking on
+labels, making up parcels. Around him all were silent; only from time
+to time, were heard the weights jingling in the balance, and a few low
+words from the chemist giving directions to his pupil.
+
+“And how’s the little woman?” suddenly asked Madame Homais.
+
+“Silence!” exclaimed her husband, who was writing down some figures in
+his waste-book.
+
+“Why didn’t you bring her?” she went on in a low voice.
+
+“Hush! hush!” said Emma, pointing with her finger to the druggist.
+
+But Binet, quite absorbed in looking over his bill, had probably heard
+nothing. At last he went out. Then Emma, relieved, uttered a deep sigh.
+
+“How hard you are breathing!” said Madame Homais.
+
+“Well, you see, it’s rather warm,” she replied.
+
+So the next day they talked over how to arrange their rendezvous. Emma
+wanted to bribe her servant with a present, but it would be better to
+find some safe house at Yonville. Rodolphe promised to look for one.
+
+All through the winter, three or four times a week, in the dead of night
+he came to the garden. Emma had on purpose taken away the key of the
+gate, which Charles thought lost.
+
+To call her, Rodolphe threw a sprinkle of sand at the shutters. She
+jumped up with a start; but sometimes he had to wait, for Charles had a
+mania for chatting by the fireside, and he would not stop. She was wild
+with impatience; if her eyes could have done it, she would have hurled
+him out at the window. At last she would begin to undress, then take up
+a book, and go on reading very quietly as if the book amused her. But
+Charles, who was in bed, called to her to come too.
+
+“Come, now, Emma,” he said, “it is time.”
+
+“Yes, I am coming,” she answered.
+
+Then, as the candles dazzled him; he turned to the wall and fell asleep.
+She escaped, smiling, palpitating, undressed. Rodolphe had a large
+cloak; he wrapped her in it, and putting his arm round her waist, he
+drew her without a word to the end of the garden.
+
+It was in the arbour, on the same seat of old sticks where formerly Leon
+had looked at her so amorously on the summer evenings. She never thought
+of him now.
+
+The stars shone through the leafless jasmine branches. Behind them they
+heard the river flowing, and now and again on the bank the rustling
+of the dry reeds. Masses of shadow here and there loomed out in the
+darkness, and sometimes, vibrating with one movement, they rose up and
+swayed like immense black waves pressing forward to engulf them. The
+cold of the nights made them clasp closer; the sighs of their lips
+seemed to them deeper; their eyes that they could hardly see, larger;
+and in the midst of the silence low words were spoken that fell on
+their souls sonorous, crystalline, and that reverberated in multiplied
+vibrations.
+
+When the night was rainy, they took refuge in the consulting-room
+between the cart-shed and the stable. She lighted one of the kitchen
+candles that she had hidden behind the books. Rodolphe settled down
+there as if at home. The sight of the library, of the bureau, of the
+whole apartment, in fine, excited his merriment, and he could not
+refrain from making jokes about Charles, which rather embarrassed Emma.
+She would have liked to see him more serious, and even on occasions
+more dramatic; as, for example, when she thought she heard a noise of
+approaching steps in the alley.
+
+“Someone is coming!” she said.
+
+He blew out the light.
+
+“Have you your pistols?”
+
+“Why?”
+
+“Why, to defend yourself,” replied Emma.
+
+“From your husband? Oh, poor devil!” And Rodolphe finished his sentence
+with a gesture that said, “I could crush him with a flip of my finger.”
+
+She was wonder-stricken at his bravery, although she felt in it a sort
+of indecency and a naive coarseness that scandalised her.
+
+Rodolphe reflected a good deal on the affair of the pistols. If she had
+spoken seriously, it was very ridiculous, he thought, even odious; for
+he had no reason to hate the good Charles, not being what is called
+devoured by jealousy; and on this subject Emma had taken a great vow
+that he did not think in the best of taste.
+
+Besides, she was growing very sentimental. She had insisted on
+exchanging miniatures; they had cut off handfuls of hair, and now she
+was asking for a ring--a real wedding-ring, in sign of an eternal union.
+She often spoke to him of the evening chimes, of the voices of nature.
+Then she talked to him of her mother--hers! and of his mother--his!
+Rodolphe had lost his twenty years ago. Emma none the less consoled
+him with caressing words as one would have done a lost child, and she
+sometimes even said to him, gazing at the moon--
+
+“I am sure that above there together they approve of our love.”
+
+But she was so pretty. He had possessed so few women of such
+ingenuousness. This love without debauchery was a new experience for
+him, and, drawing him out of his lazy habits, caressed at once his pride
+and his sensuality. Emma’s enthusiasm, which his bourgeois good sense
+disdained, seemed to him in his heart of hearts charming, since it
+was lavished on him. Then, sure of being loved, he no longer kept up
+appearances, and insensibly his ways changed.
+
+He had no longer, as formerly, words so gentle that they made her cry,
+nor passionate caresses that made her mad, so that their great love,
+which engrossed her life, seemed to lessen beneath her like the water of
+a stream absorbed into its channel, and she could see the bed of it.
+She would not believe it; she redoubled in tenderness, and Rodolphe
+concealed his indifference less and less.
+
+She did not know if she regretted having yielded to him, or whether she
+did not wish, on the contrary, to enjoy him the more. The humiliation
+of feeling herself weak was turning to rancour, tempered by their
+voluptuous pleasures. It was not affection; it was like a continual
+seduction. He subjugated her; she almost feared him.
+
+Appearances, nevertheless, were calmer than ever, Rodolphe having
+succeeded in carrying out the adultery after his own fancy; and at the
+end of six months, when the spring-time came, they were to one another
+like a married couple, tranquilly keeping up a domestic flame.
+
+It was the time of year when old Rouault sent his turkey in remembrance
+of the setting of his leg. The present always arrived with a letter.
+Emma cut the string that tied it to the basket, and read the following
+lines:--
+
+“My Dear Children--I hope this will find you well, and that this one
+will be as good as the others. For it seems to me a little more tender,
+if I may venture to say so, and heavier. But next time, for a change,
+I’ll give you a turkeycock, unless you have a preference for some dabs;
+and send me back the hamper, if you please, with the two old ones. I
+have had an accident with my cart-sheds, whose covering flew off one
+windy night among the trees. The harvest has not been overgood either.
+Finally, I don’t know when I shall come to see you. It is so difficult
+now to leave the house since I am alone, my poor Emma.”
+
+Here there was a break in the lines, as if the old fellow had dropped
+his pen to dream a little while.
+
+“For myself, I am very well, except for a cold I caught the other day at
+the fair at Yvetot, where I had gone to hire a shepherd, having turned
+away mine because he was too dainty. How we are to be pitied with such
+a lot of thieves! Besides, he was also rude. I heard from a pedlar, who,
+travelling through your part of the country this winter, had a tooth
+drawn, that Bovary was as usual working hard. That doesn’t surprise me;
+and he showed me his tooth; we had some coffee together. I asked him if
+he had seen you, and he said not, but that he had seen two horses in the
+stables, from which I conclude that business is looking up. So much
+the better, my dear children, and may God send you every imaginable
+happiness! It grieves me not yet to have seen my dear little
+grand-daughter, Berthe Bovary. I have planted an Orleans plum-tree for
+her in the garden under your room, and I won’t have it touched unless it
+is to have jam made for her by and bye, that I will keep in the cupboard
+for her when she comes.
+
+“Good-bye, my dear children. I kiss you, my girl, you too, my
+son-in-law, and the little one on both cheeks. I am, with best
+compliments, your loving father.
+
+“Theodore Rouault.”
+
+She held the coarse paper in her fingers for some minutes. The spelling
+mistakes were interwoven one with the other, and Emma followed the
+kindly thought that cackled right through it like a hen half hidden
+in the hedge of thorns. The writing had been dried with ashes from
+the hearth, for a little grey powder slipped from the letter on to her
+dress, and she almost thought she saw her father bending over the hearth
+to take up the tongs. How long since she had been with him, sitting on
+the footstool in the chimney-corner, where she used to burn the end of
+a bit of wood in the great flame of the sea-sedges! She remembered the
+summer evenings all full of sunshine. The colts neighed when anyone
+passed by, and galloped, galloped. Under her window there was a beehive,
+and sometimes the bees wheeling round in the light struck against her
+window like rebounding balls of gold. What happiness there had been
+at that time, what freedom, what hope! What an abundance of illusions!
+Nothing was left of them now. She had got rid of them all in her soul’s
+life, in all her successive conditions of life, maidenhood, her marriage,
+and her love--thus constantly losing them all her life through, like
+a traveller who leaves something of his wealth at every inn along his
+road.
+
+But what then, made her so unhappy? What was the extraordinary
+catastrophe that had transformed her? And she raised her head, looking
+round as if to seek the cause of that which made her suffer.
+
+An April ray was dancing on the china of the whatnot; the fire burned;
+beneath her slippers she felt the softness of the carpet; the day was
+bright, the air warm, and she heard her child shouting with laughter.
+
+In fact, the little girl was just then rolling on the lawn in the midst
+of the grass that was being turned. She was lying flat on her stomach
+at the top of a rick. The servant was holding her by her skirt.
+Lestiboudois was raking by her side, and every time he came near she
+lent forward, beating the air with both her arms.
+
+“Bring her to me,” said her mother, rushing to embrace her. “How I love
+you, my poor child! How I love you!”
+
+Then noticing that the tips of her ears were rather dirty, she rang at
+once for warm water, and washed her, changed her linen, her stockings,
+her shoes, asked a thousand questions about her health, as if on the
+return from a long journey, and finally, kissing her again and crying
+a little, she gave her back to the servant, who stood quite
+thunderstricken at this excess of tenderness.
+
+That evening Rodolphe found her more serious than usual.
+
+“That will pass over,” he concluded; “it’s a whim:”
+
+And he missed three rendezvous running. When he did come, she showed
+herself cold and almost contemptuous.
+
+“Ah! you’re losing your time, my lady!”
+
+And he pretended not to notice her melancholy sighs, nor the
+handkerchief she took out.
+
+Then Emma repented. She even asked herself why she detested Charles; if
+it had not been better to have been able to love him? But he gave her
+no opportunities for such a revival of sentiment, so that she was much
+embarrassed by her desire for sacrifice, when the druggist came just in
+time to provide her with an opportunity.
+
+
+
+Chapter Eleven
+
+He had recently read a eulogy on a new method for curing club-foot, and
+as he was a partisan of progress, he conceived the patriotic idea that
+Yonville, in order to keep to the fore, ought to have some operations
+for strephopody or club-foot.
+
+“For,” said he to Emma, “what risk is there? See--” (and he enumerated
+on his fingers the advantages of the attempt), “success, almost certain
+relief and beautifying of the patient, celebrity acquired by the
+operator. Why, for example, should not your husband relieve poor
+Hippolyte of the ‘Lion d’Or’? Note that he would not fail to tell about
+his cure to all the travellers, and then” (Homais lowered his voice and
+looked round him) “who is to prevent me from sending a short paragraph
+on the subject to the paper? Eh! goodness me! an article gets about; it
+is talked of; it ends by making a snowball! And who knows? who knows?”
+
+In fact, Bovary might succeed. Nothing proved to Emma that he was not
+clever; and what a satisfaction for her to have urged him to a step by
+which his reputation and fortune would be increased! She only wished to
+lean on something more solid than love.
+
+Charles, urged by the druggist and by her, allowed himself to be
+persuaded. He sent to Rouen for Dr. Duval’s volume, and every evening,
+holding his head between both hands, plunged into the reading of it.
+
+While he was studying equinus, varus, and valgus, that is to say,
+katastrephopody, endostrephopody, and exostrephopody (or better, the
+various turnings of the foot downwards, inwards, and outwards, with the
+hypostrephopody and anastrephopody), otherwise torsion downwards and
+upwards, Monsier Homais, with all sorts of arguments, was exhorting the
+lad at the inn to submit to the operation.
+
+“You will scarcely feel, probably, a slight pain; it is a simple prick,
+like a little blood-letting, less than the extraction of certain corns.”
+
+Hippolyte, reflecting, rolled his stupid eyes.
+
+“However,” continued the chemist, “it doesn’t concern me. It’s for your
+sake, for pure humanity! I should like to see you, my friend, rid of
+your hideous caudication, together with that waddling of the lumbar
+regions which, whatever you say, must considerably interfere with you in
+the exercise of your calling.”
+
+Then Homais represented to him how much jollier and brisker he would
+feel afterwards, and even gave him to understand that he would be more
+likely to please the women; and the stable-boy began to smile heavily.
+Then he attacked him through his vanity:
+
+“Aren’t you a man? Hang it! what would you have done if you had had to
+go into the army, to go and fight beneath the standard? Ah! Hippolyte!”
+
+And Homais retired, declaring that he could not understand this
+obstinacy, this blindness in refusing the benefactions of science.
+
+The poor fellow gave way, for it was like a conspiracy. Binet, who never
+interfered with other people’s business, Madame Lefrancois, Artemise,
+the neighbours, even the mayor, Monsieur Tuvache--everyone persuaded
+him, lectured him, shamed him; but what finally decided him was that it
+would cost him nothing. Bovary even undertook to provide the machine
+for the operation. This generosity was an idea of Emma’s, and Charles
+consented to it, thinking in his heart of hearts that his wife was an
+angel.
+
+So by the advice of the chemist, and after three fresh starts, he had a
+kind of box made by the carpenter, with the aid of the locksmith,
+that weighed about eight pounds, and in which iron, wood, sheer-iron,
+leather, screws, and nuts had not been spared.
+
+But to know which of Hippolyte’s tendons to cut, it was necessary first
+of all to find out what kind of club-foot he had.
+
+He had a foot forming almost a straight line with the leg, which,
+however, did not prevent it from being turned in, so that it was an
+equinus together with something of a varus, or else a slight varus with
+a strong tendency to equinus. But with this equinus, wide in foot like
+a horse’s hoof, with rugose skin, dry tendons, and large toes, on which
+the black nails looked as if made of iron, the clubfoot ran about like
+a deer from morn till night. He was constantly to be seen on the Place,
+jumping round the carts, thrusting his limping foot forwards. He seemed
+even stronger on that leg than the other. By dint of hard service it had
+acquired, as it were, moral qualities of patience and energy; and
+when he was given some heavy work, he stood on it in preference to its
+fellow.
+
+Now, as it was an equinus, it was necessary to cut the tendon of
+Achilles, and, if need were, the anterior tibial muscle could be seen to
+afterwards for getting rid of the varus; for the doctor did not dare to
+risk both operations at once; he was even trembling already for fear of
+injuring some important region that he did not know.
+
+Neither Ambrose Pare, applying for the first time since Celsus, after an
+interval of fifteen centuries, a ligature to an artery, nor Dupuytren,
+about to open an abscess in the brain, nor Gensoul when he first took
+away the superior maxilla, had hearts that trembled, hands that shook,
+minds so strained as Monsieur Bovary when he approached Hippolyte, his
+tenotome between his fingers. And as at hospitals, near by on a table
+lay a heap of lint, with waxed thread, many bandages--a pyramid of
+bandages--every bandage to be found at the druggist’s. It was Monsieur
+Homais who since morning had been organising all these preparations,
+as much to dazzle the multitude as to keep up his illusions. Charles
+pierced the skin; a dry crackling was heard. The tendon was cut, the
+operation over. Hippolyte could not get over his surprise, but bent over
+Bovary’s hands to cover them with kisses.
+
+“Come, be calm,” said the druggist; “later on you will show your
+gratitude to your benefactor.”
+
+And he went down to tell the result to five or six inquirers who were
+waiting in the yard, and who fancied that Hippolyte would reappear
+walking properly. Then Charles, having buckled his patient into the
+machine, went home, where Emma, all anxiety, awaited him at the door.
+She threw herself on his neck; they sat down to table; he ate much,
+and at dessert he even wanted to take a cup of coffee, a luxury he only
+permitted himself on Sundays when there was company.
+
+The evening was charming, full of prattle, of dreams together. They
+talked about their future fortune, of the improvements to be made in
+their house; he saw people’s estimation of him growing, his comforts
+increasing, his wife always loving him; and she was happy to refresh
+herself with a new sentiment, healthier, better, to feel at last some
+tenderness for this poor fellow who adored her. The thought of Rodolphe
+for one moment passed through her mind, but her eyes turned again to
+Charles; she even noticed with surprise that he had not bad teeth.
+
+They were in bed when Monsieur Homais, in spite of the servant, suddenly
+entered the room, holding in his hand a sheet of paper just written. It
+was the paragraph he intended for the “Fanal de Rouen.” He brought it
+for them to read.
+
+“Read it yourself,” said Bovary.
+
+He read--
+
+“‘Despite the prejudices that still invest a part of the face of Europe
+like a net, the light nevertheless begins to penetrate our country
+places. Thus on Tuesday our little town of Yonville found itself the
+scene of a surgical operation which is at the same time an act of
+loftiest philanthropy. Monsieur Bovary, one of our most distinguished
+practitioners--’”
+
+“Oh, that is too much! too much!” said Charles, choking with emotion.
+
+“No, no! not at all! What next!”
+
+“‘--Performed an operation on a club-footed man.’ I have not used the
+scientific term, because you know in a newspaper everyone would not
+perhaps understand. The masses must--’”
+
+“No doubt,” said Bovary; “go on!”
+
+“I proceed,” said the chemist. “‘Monsieur Bovary, one of our most
+distinguished practitioners, performed an operation on a club-footed man
+called Hippolyte Tautain, stableman for the last twenty-five years at
+the hotel of the “Lion d’Or,” kept by Widow Lefrancois, at the Place
+d’Armes. The novelty of the attempt, and the interest incident to the
+subject, had attracted such a concourse of persons that there was
+a veritable obstruction on the threshold of the establishment. The
+operation, moreover, was performed as if by magic, and barely a
+few drops of blood appeared on the skin, as though to say that the
+rebellious tendon had at last given way beneath the efforts of art. The
+patient, strangely enough--we affirm it as an eye-witness--complained
+of no pain. His condition up to the present time leaves nothing to be
+desired. Everything tends to show that his convelescence will be brief;
+and who knows even if at our next village festivity we shall not see our
+good Hippolyte figuring in the bacchic dance in the midst of a chorus
+of joyous boon-companions, and thus proving to all eyes by his verve
+and his capers his complete cure? Honour, then, to the generous savants!
+Honour to those indefatigable spirits who consecrate their vigils to the
+amelioration or to the alleviation of their kind! Honour, thrice honour!
+Is it not time to cry that the blind shall see, the deaf hear, the lame
+walk? But that which fanaticism formerly promised to its elect, science
+now accomplishes for all men. We shall keep our readers informed as to
+the successive phases of this remarkable cure.’”
+
+This did not prevent Mere Lefrancois, from coming five days after,
+scared, and crying out--
+
+“Help! he is dying! I am going crazy!”
+
+Charles rushed to the “Lion d’Or,” and the chemist, who caught sight
+of him passing along the Place hatless, abandoned his shop. He appeared
+himself breathless, red, anxious, and asking everyone who was going up
+the stairs--
+
+“Why, what’s the matter with our interesting strephopode?”
+
+The strephopode was writhing in hideous convulsions, so that the machine
+in which his leg was enclosed was knocked against the wall enough to
+break it.
+
+With many precautions, in order not to disturb the position of the limb,
+the box was removed, and an awful sight presented itself. The outlines
+of the foot disappeared in such a swelling that the entire skin seemed
+about to burst, and it was covered with ecchymosis, caused by the famous
+machine. Hippolyte had already complained of suffering from it. No
+attention had been paid to him; they had to acknowledge that he had not
+been altogether wrong, and he was freed for a few hours. But, hardly had
+the oedema gone down to some extent, than the two savants thought fit
+to put back the limb in the apparatus, strapping it tighter to hasten
+matters. At last, three days after, Hippolyte being unable to endure it
+any longer, they once more removed the machine, and were much surprised
+at the result they saw. The livid tumefaction spread over the leg, with
+blisters here and there, whence there oozed a black liquid. Matters
+were taking a serious turn. Hippolyte began to worry himself, and Mere
+Lefrancois, had him installed in the little room near the kitchen, so
+that he might at least have some distraction.
+
+But the tax-collector, who dined there every day, complained bitterly of
+such companionship. Then Hippolyte was removed to the billiard-room.
+He lay there moaning under his heavy coverings, pale with long beard,
+sunken eyes, and from time to time turning his perspiring head on the
+dirty pillow, where the flies alighted. Madame Bovary went to see him.
+She brought him linen for his poultices; she comforted, and encouraged
+him. Besides, he did not want for company, especially on market-days,
+when the peasants were knocking about the billiard-balls round him,
+fenced with the cues, smoked, drank, sang, and brawled.
+
+“How are you?” they said, clapping him on the shoulder. “Ah! you’re not
+up to much, it seems, but it’s your own fault. You should do this! do
+that!” And then they told him stories of people who had all been cured
+by other remedies than his. Then by way of consolation they added--
+
+“You give way too much! Get up! You coddle yourself like a king! All the
+same, old chap, you don’t smell nice!”
+
+Gangrene, in fact, was spreading more and more. Bovary himself turned
+sick at it. He came every hour, every moment. Hippolyte looked at him
+with eyes full of terror, sobbing--
+
+“When shall I get well? Oh, save me! How unfortunate I am! How
+unfortunate I am!”
+
+And the doctor left, always recommending him to diet himself.
+
+“Don’t listen to him, my lad,” said Mere Lefrancois, “Haven’t they
+tortured you enough already? You’ll grow still weaker. Here! swallow
+this.”
+
+And she gave him some good beef-tea, a slice of mutton, a piece of
+bacon, and sometimes small glasses of brandy, that he had not the
+strength to put to his lips.
+
+Abbe Bournisien, hearing that he was growing worse, asked to see him.
+He began by pitying his sufferings, declaring at the same time that he
+ought to rejoice at them since it was the will of the Lord, and take
+advantage of the occasion to reconcile himself to Heaven.
+
+“For,” said the ecclesiastic in a paternal tone, “you rather neglected
+your duties; you were rarely seen at divine worship. How many years is
+it since you approached the holy table? I understand that your work,
+that the whirl of the world may have kept you from care for your
+salvation. But now is the time to reflect. Yet don’t despair. I have
+known great sinners, who, about to appear before God (you are not yet
+at this point I know), had implored His mercy, and who certainly died in
+the best frame of mind. Let us hope that, like them, you will set us a
+good example. Thus, as a precaution, what is to prevent you from saying
+morning and evening a ‘Hail Mary, full of grace,’ and ‘Our Father which
+art in heaven’? Yes, do that, for my sake, to oblige me. That won’t cost
+you anything. Will you promise me?”
+
+The poor devil promised. The cure came back day after day. He chatted
+with the landlady; and even told anecdotes interspersed with jokes and
+puns that Hippolyte did not understand. Then, as soon as he could, he
+fell back upon matters of religion, putting on an appropriate expression
+of face.
+
+His zeal seemed successful, for the club-foot soon manifested a desire
+to go on a pilgrimage to Bon-Secours if he were cured; to which Monsieur
+Bournisien replied that he saw no objection; two precautions were better
+than one; it was no risk anyhow.
+
+The druggist was indignant at what he called the manoeuvres of the
+priest; they were prejudicial, he said, to Hippolyte’s convalescence,
+and he kept repeating to Madame Lefrancois, “Leave him alone! leave him
+alone! You perturb his morals with your mysticism.” But the good woman
+would no longer listen to him; he was the cause of it all. From a spirit
+of contradiction she hung up near the bedside of the patient a basin
+filled with holy-water and a branch of box.
+
+Religion, however, seemed no more able to succour him than surgery, and
+the invincible gangrene still spread from the extremities towards
+the stomach. It was all very well to vary the potions and change the
+poultices; the muscles each day rotted more and more; and at last
+Charles replied by an affirmative nod of the head when Mere Lefrancois,
+asked him if she could not, as a forlorn hope, send for Monsieur Canivet
+of Neufchatel, who was a celebrity.
+
+A doctor of medicine, fifty years of age, enjoying a good position
+and self-possessed, Charles’s colleague did not refrain from laughing
+disdainfully when he had uncovered the leg, mortified to the knee. Then
+having flatly declared that it must be amputated, he went off to the
+chemist’s to rail at the asses who could have reduced a poor man to such
+a state. Shaking Monsieur Homais by the button of his coat, he shouted
+out in the shop--
+
+“These are the inventions of Paris! These are the ideas of those gentry
+of the capital! It is like strabismus, chloroform, lithotrity, a heap of
+monstrosities that the Government ought to prohibit. But they want to do
+the clever, and they cram you with remedies without, troubling about
+the consequences. We are not so clever, not we! We are not savants,
+coxcombs, fops! We are practitioners; we cure people, and we should
+not dream of operating on anyone who is in perfect health. Straighten
+club-feet! As if one could straighten club-feet! It is as if one wished,
+for example, to make a hunchback straight!”
+
+Homais suffered as he listened to this discourse, and he concealed his
+discomfort beneath a courtier’s smile; for he needed to humour Monsier
+Canivet, whose prescriptions sometimes came as far as Yonville. So he
+did not take up the defence of Bovary; he did not even make a single
+remark, and, renouncing his principles, he sacrificed his dignity to the
+more serious interests of his business.
+
+This amputation of the thigh by Doctor Canivet was a great event in the
+village. On that day all the inhabitants got up earlier, and the Grande
+Rue, although full of people, had something lugubrious about it, as
+if an execution had been expected. At the grocer’s they discussed
+Hippolyte’s illness; the shops did no business, and Madame Tuvache, the
+mayor’s wife, did not stir from her window, such was her impatience to
+see the operator arrive.
+
+He came in his gig, which he drove himself. But the springs of the right
+side having at length given way beneath the weight of his corpulence, it
+happened that the carriage as it rolled along leaned over a little, and
+on the other cushion near him could be seen a large box covered in red
+sheep-leather, whose three brass clasps shone grandly.
+
+After he had entered like a whirlwind the porch of the “Lion d’Or,” the
+doctor, shouting very loud, ordered them to unharness his horse. Then he
+went into the stable to see that she was eating her oats all right; for
+on arriving at a patient’s he first of all looked after his mare and his
+gig. People even said about this--
+
+“Ah! Monsieur Canivet’s a character!”
+
+And he was the more esteemed for this imperturbable coolness. The
+universe to the last man might have died, and he would not have missed
+the smallest of his habits.
+
+Homais presented himself.
+
+“I count on you,” said the doctor. “Are we ready? Come along!”
+
+But the druggist, turning red, confessed that he was too sensitive to
+assist at such an operation.
+
+“When one is a simple spectator,” he said, “the imagination, you know,
+is impressed. And then I have such a nervous system!”
+
+“Pshaw!” interrupted Canivet; “on the contrary, you seem to me inclined
+to apoplexy. Besides, that doesn’t astonish me, for you chemist fellows
+are always poking about your kitchens, which must end by spoiling your
+constitutions. Now just look at me. I get up every day at four o’clock;
+I shave with cold water (and am never cold). I don’t wear flannels, and
+I never catch cold; my carcass is good enough! I live now in one way,
+now in another, like a philosopher, taking pot-luck; that is why I
+am not squeamish like you, and it is as indifferent to me to carve a
+Christian as the first fowl that turns up. Then, perhaps, you will say,
+habit! habit!”
+
+Then, without any consideration for Hippolyte, who was sweating with
+agony between his sheets, these gentlemen entered into a conversation,
+in which the druggist compared the coolness of a surgeon to that of a
+general; and this comparison was pleasing to Canivet, who launched out
+on the exigencies of his art. He looked upon, it as a sacred office,
+although the ordinary practitioners dishonoured it. At last, coming back
+to the patient, he examined the bandages brought by Homais, the same
+that had appeared for the club-foot, and asked for someone to hold the
+limb for him. Lestiboudois was sent for, and Monsieur Canivet having
+turned up his sleeves, passed into the billiard-room, while the druggist
+stayed with Artemise and the landlady, both whiter than their aprons,
+and with ears strained towards the door.
+
+Bovary during this time did not dare to stir from his house.
+
+He kept downstairs in the sitting-room by the side of the fireless
+chimney, his chin on his breast, his hands clasped, his eyes staring.
+“What a mishap!” he thought, “what a mishap!” Perhaps, after all, he had
+made some slip. He thought it over, but could hit upon nothing. But the
+most famous surgeons also made mistakes; and that is what no one would
+ever believe! People, on the contrary, would laugh, jeer! It would
+spread as far as Forges, as Neufchatel, as Rouen, everywhere! Who could
+say if his colleagues would not write against him. Polemics would ensue;
+he would have to answer in the papers. Hippolyte might even prosecute
+him. He saw himself dishonoured, ruined, lost; and his imagination,
+assailed by a world of hypotheses, tossed amongst them like an empty
+cask borne by the sea and floating upon the waves.
+
+Emma, opposite, watched him; she did not share his humiliation; she felt
+another--that of having supposed such a man was worth anything. As if
+twenty times already she had not sufficiently perceived his mediocrity.
+
+Charles was walking up and down the room; his boots creaked on the
+floor.
+
+“Sit down,” she said; “you fidget me.”
+
+He sat down again.
+
+How was it that she--she, who was so intelligent--could have allowed
+herself to be deceived again? and through what deplorable madness had
+she thus ruined her life by continual sacrifices? She recalled all her
+instincts of luxury, all the privations of her soul, the sordidness of
+marriage, of the household, her dream sinking into the mire like wounded
+swallows; all that she had longed for, all that she had denied herself,
+all that she might have had! And for what? for what?
+
+In the midst of the silence that hung over the village a heart-rending
+cry rose on the air. Bovary turned white to fainting. She knit her
+brows with a nervous gesture, then went on. And it was for him, for this
+creature, for this man, who understood nothing, who felt nothing! For he
+was there quite quiet, not even suspecting that the ridicule of his name
+would henceforth sully hers as well as his. She had made efforts to love
+him, and she had repented with tears for having yielded to another!
+
+“But it was perhaps a valgus!” suddenly exclaimed Bovary, who was
+meditating.
+
+At the unexpected shock of this phrase falling on her thought like a
+leaden bullet on a silver plate, Emma, shuddering, raised her head in
+order to find out what he meant to say; and they looked at the other in
+silence, almost amazed to see each other, so far sundered were they
+by their inner thoughts. Charles gazed at her with the dull look of
+a drunken man, while he listened motionless to the last cries of the
+sufferer, that followed each other in long-drawn modulations, broken by
+sharp spasms like the far-off howling of some beast being slaughtered.
+Emma bit her wan lips, and rolling between her fingers a piece of coral
+that she had broken, fixed on Charles the burning glance of her eyes
+like two arrows of fire about to dart forth. Everything in him irritated
+her now; his face, his dress, what he did not say, his whole person, his
+existence, in fine. She repented of her past virtue as of a crime, and
+what still remained of it rumbled away beneath the furious blows of her
+pride. She revelled in all the evil ironies of triumphant adultery.
+The memory of her lover came back to her with dazzling attractions; she
+threw her whole soul into it, borne away towards this image with a fresh
+enthusiasm; and Charles seemed to her as much removed from her life, as
+absent forever, as impossible and annihilated, as if he had been about
+to die and were passing under her eyes.
+
+There was a sound of steps on the pavement. Charles looked up, and
+through the lowered blinds he saw at the corner of the market in
+the broad sunshine Dr. Canivet, who was wiping his brow with his
+handkerchief. Homais, behind him, was carrying a large red box in his
+hand, and both were going towards the chemist’s.
+
+Then with a feeling of sudden tenderness and discouragement Charles
+turned to his wife saying to her--
+
+“Oh, kiss me, my own!”
+
+“Leave me!” she said, red with anger.
+
+“What is the matter?” he asked, stupefied. “Be calm; compose yourself.
+You know well enough that I love you. Come!”
+
+“Enough!” she cried with a terrible look.
+
+And escaping from the room, Emma closed the door so violently that the
+barometer fell from the wall and smashed on the floor.
+
+Charles sank back into his arm-chair overwhelmed, trying to discover
+what could be wrong with her, fancying some nervous illness, weeping,
+and vaguely feeling something fatal and incomprehensible whirling round
+him.
+
+When Rodolphe came to the garden that evening, he found his mistress
+waiting for him at the foot of the steps on the lowest stair. They threw
+their arms round one another, and all their rancour melted like snow
+beneath the warmth of that kiss.
+
+
+
+Chapter Twelve
+
+They began to love one another again. Often, even in the middle of the
+day, Emma suddenly wrote to him, then from the window made a sign to
+Justin, who, taking his apron off, quickly ran to La Huchette. Rodolphe
+would come; she had sent for him to tell him that she was bored, that
+her husband was odious, her life frightful.
+
+“But what can I do?” he cried one day impatiently.
+
+“Ah! if you would--”
+
+She was sitting on the floor between his knees, her hair loose, her look
+lost.
+
+“Why, what?” said Rodolphe.
+
+She sighed.
+
+“We would go and live elsewhere--somewhere!”
+
+“You are really mad!” he said laughing. “How could that be possible?”
+
+She returned to the subject; he pretended not to understand, and turned
+the conversation.
+
+What he did not understand was all this worry about so simple an affair
+as love. She had a motive, a reason, and, as it were, a pendant to her
+affection.
+
+Her tenderness, in fact, grew each day with her repulsion to her
+husband. The more she gave up herself to the one, the more she loathed
+the other. Never had Charles seemed to her so disagreeable, to have
+such stodgy fingers, such vulgar ways, to be so dull as when they found
+themselves together after her meeting with Rodolphe. Then, while playing
+the spouse and virtue, she was burning at the thought of that head whose
+black hair fell in a curl over the sunburnt brow, of that form at once
+so strong and elegant, of that man, in a word, who had such experience
+in his reasoning, such passion in his desires. It was for him that she
+filed her nails with the care of a chaser, and that there was never
+enough cold-cream for her skin, nor of patchouli for her handkerchiefs.
+She loaded herself with bracelets, rings, and necklaces. When he
+was coming she filled the two large blue glass vases with roses, and
+prepared her room and her person like a courtesan expecting a prince.
+The servant had to be constantly washing linen, and all day Felicite
+did not stir from the kitchen, where little Justin, who often kept her
+company, watched her at work.
+
+With his elbows on the long board on which she was ironing, he
+greedily watched all these women’s clothes spread about him, the dimity
+petticoats, the fichus, the collars, and the drawers with running
+strings, wide at the hips and growing narrower below.
+
+“What is that for?” asked the young fellow, passing his hand over the
+crinoline or the hooks and eyes.
+
+“Why, haven’t you ever seen anything?” Felicite answered laughing. “As
+if your mistress, Madame Homais, didn’t wear the same.”
+
+“Oh, I daresay! Madame Homais!” And he added with a meditative air, “As
+if she were a lady like madame!”
+
+But Felicite grew impatient of seeing him hanging round her. She was six
+years older than he, and Theodore, Monsieur Guillaumin’s servant, was
+beginning to pay court to her.
+
+“Let me alone,” she said, moving her pot of starch. “You’d better be
+off and pound almonds; you are always dangling about women. Before you
+meddle with such things, bad boy, wait till you’ve got a beard to your
+chin.”
+
+“Oh, don’t be cross! I’ll go and clean her boots.”
+
+And he at once took down from the shelf Emma’s boots, all coated with
+mud, the mud of the rendezvous, that crumbled into powder beneath his
+fingers, and that he watched as it gently rose in a ray of sunlight.
+
+“How afraid you are of spoiling them!” said the servant, who wasn’t so
+particular when she cleaned them herself, because as soon as the stuff
+of the boots was no longer fresh madame handed them over to her.
+
+Emma had a number in her cupboard that she squandered one after the
+other, without Charles allowing himself the slightest observation. So
+also he disbursed three hundred francs for a wooden leg that she thought
+proper to make a present of to Hippolyte. Its top was covered with cork,
+and it had spring joints, a complicated mechanism, covered over by black
+trousers ending in a patent-leather boot. But Hippolyte, not daring
+to use such a handsome leg every day, begged Madame Bovary to get him
+another more convenient one. The doctor, of course, had again to defray
+the expense of this purchase.
+
+So little by little the stable-man took up his work again. One saw him
+running about the village as before, and when Charles heard from afar
+the sharp noise of the wooden leg, he at once went in another direction.
+
+It was Monsieur Lheureux, the shopkeeper, who had undertaken the order;
+this provided him with an excuse for visiting Emma. He chatted with her
+about the new goods from Paris, about a thousand feminine trifles, made
+himself very obliging, and never asked for his money. Emma yielded to
+this lazy mode of satisfying all her caprices. Thus she wanted to have
+a very handsome ridding-whip that was at an umbrella-maker’s at Rouen
+to give to Rodolphe. The week after Monsieur Lheureux placed it on her
+table.
+
+But the next day he called on her with a bill for two hundred and
+seventy francs, not counting the centimes. Emma was much embarrassed;
+all the drawers of the writing-table were empty; they owed over a
+fortnight’s wages to Lestiboudois, two quarters to the servant, for any
+quantity of other things, and Bovary was impatiently expecting Monsieur
+Derozeray’s account, which he was in the habit of paying every year
+about Midsummer.
+
+She succeeded at first in putting off Lheureux. At last he lost
+patience; he was being sued; his capital was out, and unless he got some
+in he should be forced to take back all the goods she had received.
+
+“Oh, very well, take them!” said Emma.
+
+“I was only joking,” he replied; “the only thing I regret is the whip.
+My word! I’ll ask monsieur to return it to me.”
+
+“No, no!” she said.
+
+“Ah! I’ve got you!” thought Lheureux.
+
+And, certain of his discovery, he went out repeating to himself in an
+undertone, and with his usual low whistle--
+
+“Good! we shall see! we shall see!”
+
+She was thinking how to get out of this when the servant coming in
+put on the mantelpiece a small roll of blue paper “from Monsieur
+Derozeray’s.” Emma pounced upon and opened it. It contained fifteen
+napoleons; it was the account. She heard Charles on the stairs; threw
+the gold to the back of her drawer, and took out the key.
+
+Three days after Lheureux reappeared.
+
+“I have an arrangement to suggest to you,” he said. “If, instead of the
+sum agreed on, you would take--”
+
+“Here it is,” she said placing fourteen napoleons in his hand.
+
+The tradesman was dumfounded. Then, to conceal his disappointment, he
+was profuse in apologies and proffers of service, all of which Emma
+declined; then she remained a few moments fingering in the pocket of
+her apron the two five-franc pieces that he had given her in change.
+She promised herself she would economise in order to pay back later on.
+“Pshaw!” she thought, “he won’t think about it again.”
+
+Besides the riding-whip with its silver-gilt handle, Rodolphe had
+received a seal with the motto Amor nel cor* furthermore, a scarf for
+a muffler, and, finally, a cigar-case exactly like the Viscount’s, that
+Charles had formerly picked up in the road, and that Emma had kept.
+These presents, however, humiliated him; he refused several; she
+insisted, and he ended by obeying, thinking her tyrannical and
+overexacting.
+
+     *A loving heart.
+
+Then she had strange ideas.
+
+“When midnight strikes,” she said, “you must think of me.”
+
+And if he confessed that he had not thought of her, there were floods of
+reproaches that always ended with the eternal question--
+
+“Do you love me?”
+
+“Why, of course I love you,” he answered.
+
+“A great deal?”
+
+“Certainly!”
+
+“You haven’t loved any others?”
+
+“Did you think you’d got a virgin?” he exclaimed laughing.
+
+Emma cried, and he tried to console her, adorning his protestations with
+puns.
+
+“Oh,” she went on, “I love you! I love you so that I could not live
+without you, do you see? There are times when I long to see you again,
+when I am torn by all the anger of love. I ask myself, Where is
+he? Perhaps he is talking to other women. They smile upon him; he
+approaches. Oh no; no one else pleases you. There are some more
+beautiful, but I love you best. I know how to love best. I am your
+servant, your concubine! You are my king, my idol! You are good, you are
+beautiful, you are clever, you are strong!”
+
+He had so often heard these things said that they did not strike him as
+original. Emma was like all his mistresses; and the charm of novelty,
+gradually falling away like a garment, laid bare the eternal monotony
+of passion, that has always the same forms and the same language. He
+did not distinguish, this man of so much experience, the difference of
+sentiment beneath the sameness of expression. Because lips libertine
+and venal had murmured such words to him, he believed but little in the
+candour of hers; exaggerated speeches hiding mediocre affections must be
+discounted; as if the fullness of the soul did not sometimes overflow in
+the emptiest metaphors, since no one can ever give the exact measure of
+his needs, nor of his conceptions, nor of his sorrows; and since human
+speech is like a cracked tin kettle, on which we hammer out tunes to
+make bears dance when we long to move the stars.
+
+But with that superior critical judgment that belongs to him who, in no
+matter what circumstance, holds back, Rodolphe saw other delights to be
+got out of this love. He thought all modesty in the way. He treated her
+quite sans facon.* He made of her something supple and corrupt. Hers
+was an idiotic sort of attachment, full of admiration for him, of
+voluptuousness for her, a beatitude that benumbed her; her soul sank
+into this drunkenness, shrivelled up, drowned in it, like Clarence in
+his butt of Malmsey.
+
+     *Off-handedly.
+
+
+By the mere effect of her love Madame Bovary’s manners changed.
+Her looks grew bolder, her speech more free; she even committed the
+impropriety of walking out with Monsieur Rodolphe, a cigarette in her
+mouth, “as if to defy the people.” At last, those who still doubted
+doubted no longer when one day they saw her getting out of the
+“Hirondelle,” her waist squeezed into a waistcoat like a man; and Madame
+Bovary senior, who, after a fearful scene with her husband, had taken
+refuge at her son’s, was not the least scandalised of the women-folk.
+Many other things displeased her. First, Charles had not attended to
+her advice about the forbidding of novels; then the “ways of the house”
+ annoyed her; she allowed herself to make some remarks, and there were
+quarrels, especially one on account of Felicite.
+
+Madame Bovary senior, the evening before, passing along the passage,
+had surprised her in company of a man--a man with a brown collar, about
+forty years old, who, at the sound of her step, had quickly escaped
+through the kitchen. Then Emma began to laugh, but the good lady grew
+angry, declaring that unless morals were to be laughed at one ought to
+look after those of one’s servants.
+
+“Where were you brought up?” asked the daughter-in-law, with so
+impertinent a look that Madame Bovary asked her if she were not perhaps
+defending her own case.
+
+“Leave the room!” said the young woman, springing up with a bound.
+
+“Emma! Mamma!” cried Charles, trying to reconcile them.
+
+But both had fled in their exasperation. Emma was stamping her feet as
+she repeated--
+
+“Oh! what manners! What a peasant!”
+
+He ran to his mother; she was beside herself. She stammered
+
+“She is an insolent, giddy-headed thing, or perhaps worse!”
+
+And she was for leaving at once if the other did not apologise. So
+Charles went back again to his wife and implored her to give way; he
+knelt to her; she ended by saying--
+
+“Very well! I’ll go to her.”
+
+And in fact she held out her hand to her mother-in-law with the dignity
+of a marchioness as she said--
+
+“Excuse me, madame.”
+
+Then, having gone up again to her room, she threw herself flat on her
+bed and cried there like a child, her face buried in the pillow.
+
+She and Rodolphe had agreed that in the event of anything extraordinary
+occurring, she should fasten a small piece of white paper to the blind,
+so that if by chance he happened to be in Yonville, he could hurry to
+the lane behind the house. Emma made the signal; she had been waiting
+three-quarters of an hour when she suddenly caught sight of Rodolphe at
+the corner of the market. She felt tempted to open the window and call
+him, but he had already disappeared. She fell back in despair.
+
+Soon, however, it seemed to her that someone was walking on the
+pavement. It was he, no doubt. She went downstairs, crossed the yard. He
+was there outside. She threw herself into his arms.
+
+“Do take care!” he said.
+
+“Ah! if you knew!” she replied.
+
+And she began telling him everything, hurriedly, disjointedly,
+exaggerating the facts, inventing many, and so prodigal of parentheses
+that he understood nothing of it.
+
+“Come, my poor angel, courage! Be comforted! be patient!”
+
+“But I have been patient; I have suffered for four years. A love like
+ours ought to show itself in the face of heaven. They torture me! I can
+bear it no longer! Save me!”
+
+She clung to Rodolphe. Her eyes, full of tears, flashed like flames
+beneath a wave; her breast heaved; he had never loved her so much, so
+that he lost his head and said “What is, it? What do you wish?”
+
+“Take me away,” she cried, “carry me off! Oh, I pray you!”
+
+And she threw herself upon his mouth, as if to seize there the
+unexpected consent if breathed forth in a kiss.
+
+“But--” Rodolphe resumed.
+
+“What?”
+
+“Your little girl!”
+
+She reflected a few moments, then replied--
+
+“We will take her! It can’t be helped!”
+
+“What a woman!” he said to himself, watching her as she went. For she
+had run into the garden. Someone was calling her.
+
+On the following days Madame Bovary senior was much surprised at the
+change in her daughter-in-law. Emma, in fact, was showing herself more
+docile, and even carried her deference so far as to ask for a recipe for
+pickling gherkins.
+
+Was it the better to deceive them both? Or did she wish by a sort of
+voluptuous stoicism to feel the more profoundly the bitterness of the
+things she was about to leave?
+
+But she paid no heed to them; on the contrary, she lived as lost in the
+anticipated delight of her coming happiness.
+
+It was an eternal subject for conversation with Rodolphe. She leant on
+his shoulder murmuring--
+
+“Ah! when we are in the mail-coach! Do you think about it? Can it be? It
+seems to me that the moment I feel the carriage start, it will be as if
+we were rising in a balloon, as if we were setting out for the clouds.
+Do you know that I count the hours? And you?”
+
+Never had Madame Bovary been so beautiful as at this period; she had
+that indefinable beauty that results from joy, from enthusiasm, from
+success, and that is only the harmony of temperament with circumstances.
+Her desires, her sorrows, the experience of pleasure, and her ever-young
+illusions, that had, as soil and rain and winds and the sun make flowers
+grow, gradually developed her, and she at length blossomed forth in all
+the plenitude of her nature. Her eyelids seemed chiselled expressly for
+her long amorous looks in which the pupil disappeared, while a strong
+inspiration expanded her delicate nostrils and raised the fleshy corner
+of her lips, shaded in the light by a little black down. One would have
+thought that an artist apt in conception had arranged the curls of hair
+upon her neck; they fell in a thick mass, negligently, and with the
+changing chances of their adultery, that unbound them every day. Her
+voice now took more mellow infections, her figure also; something subtle
+and penetrating escaped even from the folds of her gown and from the
+line of her foot. Charles, as when they were first married, thought her
+delicious and quite irresistible.
+
+When he came home in the middle of the night, he did not dare to wake
+her. The porcelain night-light threw a round trembling gleam upon the
+ceiling, and the drawn curtains of the little cot formed as it were a
+white hut standing out in the shade, and by the bedside Charles looked
+at them. He seemed to hear the light breathing of his child. She would
+grow big now; every season would bring rapid progress. He already saw
+her coming from school as the day drew in, laughing, with ink-stains on
+her jacket, and carrying her basket on her arm. Then she would have to
+be sent to the boarding-school; that would cost much; how was it to
+be done? Then he reflected. He thought of hiring a small farm in the
+neighbourhood, that he would superintend every morning on his way to his
+patients. He would save up what he brought in; he would put it in the
+savings-bank. Then he would buy shares somewhere, no matter where;
+besides, his practice would increase; he counted upon that, for he
+wanted Berthe to be well-educated, to be accomplished, to learn to play
+the piano. Ah! how pretty she would be later on when she was fifteen,
+when, resembling her mother, she would, like her, wear large straw hats
+in the summer-time; from a distance they would be taken for two sisters.
+He pictured her to himself working in the evening by their side beneath
+the light of the lamp; she would embroider him slippers; she would look
+after the house; she would fill all the home with her charm and her
+gaiety. At last, they would think of her marriage; they would find her
+some good young fellow with a steady business; he would make her happy;
+this would last for ever.
+
+Emma was not asleep; she pretended to be; and while he dozed off by her
+side she awakened to other dreams.
+
+To the gallop of four horses she was carried away for a week towards a
+new land, whence they would return no more. They went on and on, their
+arms entwined, without a word. Often from the top of a mountain there
+suddenly glimpsed some splendid city with domes, and bridges, and
+ships, forests of citron trees, and cathedrals of white marble, on whose
+pointed steeples were storks’ nests. They went at a walking-pace because
+of the great flag-stones, and on the ground there were bouquets of
+flowers, offered you by women dressed in red bodices. They heard the
+chiming of bells, the neighing of mules, together with the murmur of
+guitars and the noise of fountains, whose rising spray refreshed heaps
+of fruit arranged like a pyramid at the foot of pale statues that smiled
+beneath playing waters. And then, one night they came to a fishing
+village, where brown nets were drying in the wind along the cliffs and
+in front of the huts. It was there that they would stay; they would live
+in a low, flat-roofed house, shaded by a palm-tree, in the heart of a
+gulf, by the sea. They would row in gondolas, swing in hammocks, and
+their existence would be easy and large as their silk gowns, warm and
+star-spangled as the nights they would contemplate. However, in the
+immensity of this future that she conjured up, nothing special stood
+forth; the days, all magnificent, resembled each other like waves; and
+it swayed in the horizon, infinite, harmonised, azure, and bathed in
+sunshine. But the child began to cough in her cot or Bovary snored
+more loudly, and Emma did not fall asleep till morning, when the dawn
+whitened the windows, and when little Justin was already in the square
+taking down the shutters of the chemist’s shop.
+
+She had sent for Monsieur Lheureux, and had said to him--
+
+“I want a cloak--a large lined cloak with a deep collar.”
+
+“You are going on a journey?” he asked.
+
+“No; but--never mind. I may count on you, may I not, and quickly?”
+
+He bowed.
+
+“Besides, I shall want,” she went on, “a trunk--not too heavy--handy.”
+
+“Yes, yes, I understand. About three feet by a foot and a half, as they
+are being made just now.”
+
+“And a travelling bag.”
+
+“Decidedly,” thought Lheureux, “there’s a row on here.”
+
+“And,” said Madame Bovary, taking her watch from her belt, “take this;
+you can pay yourself out of it.”
+
+But the tradesman cried out that she was wrong; they knew one another;
+did he doubt her? What childishness!
+
+She insisted, however, on his taking at least the chain, and Lheureux
+had already put it in his pocket and was going, when she called him
+back.
+
+“You will leave everything at your place. As to the cloak”--she seemed
+to be reflecting--“do not bring it either; you can give me the maker’s
+address, and tell him to have it ready for me.”
+
+It was the next month that they were to run away. She was to leave
+Yonville as if she was going on some business to Rouen. Rodolphe would
+have booked the seats, procured the passports, and even have written to
+Paris in order to have the whole mail-coach reserved for them as far as
+Marseilles, where they would buy a carriage, and go on thence without
+stopping to Genoa. She would take care to send her luggage to Lheureux
+whence it would be taken direct to the “Hirondelle,” so that no one
+would have any suspicion. And in all this there never was any allusion
+to the child. Rodolphe avoided speaking of her; perhaps he no longer
+thought about it.
+
+He wished to have two more weeks before him to arrange some affairs;
+then at the end of a week he wanted two more; then he said he was ill;
+next he went on a journey. The month of August passed, and, after all
+these delays, they decided that it was to be irrevocably fixed for the
+4th September--a Monday.
+
+At length the Saturday before arrived.
+
+Rodolphe came in the evening earlier than usual.
+
+“Everything is ready?” she asked him.
+
+“Yes.”
+
+Then they walked round a garden-bed, and went to sit down near the
+terrace on the kerb-stone of the wall.
+
+“You are sad,” said Emma.
+
+“No; why?”
+
+And yet he looked at her strangely in a tender fashion.
+
+“It is because you are going away?” she went on; “because you are
+leaving what is dear to you--your life? Ah! I understand. I have nothing
+in the world! you are all to me; so shall I be to you. I will be your
+people, your country; I will tend, I will love you!”
+
+“How sweet you are!” he said, seizing her in his arms.
+
+“Really!” she said with a voluptuous laugh. “Do you love me? Swear it
+then!”
+
+“Do I love you--love you? I adore you, my love.”
+
+The moon, full and purple-coloured, was rising right out of the earth
+at the end of the meadow. She rose quickly between the branches of the
+poplars, that hid her here and there like a black curtain pierced with
+holes. Then she appeared dazzling with whiteness in the empty heavens
+that she lit up, and now sailing more slowly along, let fall upon the
+river a great stain that broke up into an infinity of stars; and the
+silver sheen seemed to writhe through the very depths like a heedless
+serpent covered with luminous scales; it also resembled some monster
+candelabra all along which sparkled drops of diamonds running together.
+The soft night was about them; masses of shadow filled the branches.
+Emma, her eyes half closed, breathed in with deep sighs the fresh wind
+that was blowing. They did not speak, lost as they were in the rush of
+their reverie. The tenderness of the old days came back to their hearts,
+full and silent as the flowing river, with the softness of the perfume
+of the syringas, and threw across their memories shadows more immense
+and more sombre than those of the still willows that lengthened out over
+the grass. Often some night-animal, hedgehog or weasel, setting out on
+the hunt, disturbed the lovers, or sometimes they heard a ripe peach
+falling all alone from the espalier.
+
+“Ah! what a lovely night!” said Rodolphe.
+
+“We shall have others,” replied Emma; and, as if speaking to herself:
+“Yet, it will be good to travel. And yet, why should my heart be
+so heavy? Is it dread of the unknown? The effect of habits left? Or
+rather--? No; it is the excess of happiness. How weak I am, am I not?
+Forgive me!”
+
+“There is still time!” he cried. “Reflect! perhaps you may repent!”
+
+“Never!” she cried impetuously. And coming closer to him: “What ill
+could come to me? There is no desert, no precipice, no ocean I would not
+traverse with you. The longer we live together the more it will be like
+an embrace, every day closer, more heart to heart. There will be
+nothing to trouble us, no cares, no obstacle. We shall be alone, all to
+ourselves eternally. Oh, speak! Answer me!”
+
+At regular intervals he answered, “Yes--Yes--” She had passed her hands
+through his hair, and she repeated in a childlike voice, despite the big
+tears which were falling, “Rodolphe! Rodolphe! Ah! Rodolphe! dear little
+Rodolphe!”
+
+Midnight struck.
+
+“Midnight!” said she. “Come, it is to-morrow. One day more!”
+
+He rose to go; and as if the movement he made had been the signal for
+their flight, Emma said, suddenly assuming a gay air--
+
+“You have the passports?”
+
+“Yes.”
+
+“You are forgetting nothing?”
+
+“No.”
+
+“Are you sure?”
+
+“Certainly.”
+
+“It is at the Hotel de Provence, is it not, that you will wait for me at
+midday?”
+
+He nodded.
+
+“Till to-morrow then!” said Emma in a last caress; and she watched him
+go.
+
+He did not turn round. She ran after him, and, leaning over the water’s
+edge between the bulrushes--
+
+“To-morrow!” she cried.
+
+He was already on the other side of the river and walking fast across
+the meadow.
+
+After a few moments Rodolphe stopped; and when he saw her with her white
+gown gradually fade away in the shade like a ghost, he was seized with
+such a beating of the heart that he leant against a tree lest he should
+fall.
+
+“What an imbecile I am!” he said with a fearful oath. “No matter! She
+was a pretty mistress!”
+
+And immediately Emma’s beauty, with all the pleasures of their love,
+came back to him. For a moment he softened; then he rebelled against
+her.
+
+“For, after all,” he exclaimed, gesticulating, “I can’t exile
+myself--have a child on my hands.”
+
+He was saying these things to give himself firmness.
+
+“And besides, the worry, the expense! Ah! no, no, no, no! a thousand
+times no! That would be too stupid.”
+
+
+
+Chapter Thirteen
+
+No sooner was Rodolphe at home than he sat down quickly at his bureau
+under the stag’s head that hung as a trophy on the wall. But when he had
+the pen between his fingers, he could think of nothing, so that, resting
+on his elbows, he began to reflect. Emma seemed to him to have receded
+into a far-off past, as if the resolution he had taken had suddenly
+placed a distance between them.
+
+To get back something of her, he fetched from the cupboard at the
+bedside an old Rheims biscuit-box, in which he usually kept his letters
+from women, and from it came an odour of dry dust and withered
+roses. First he saw a handkerchief with pale little spots. It was a
+handkerchief of hers. Once when they were walking her nose had bled; he
+had forgotten it. Near it, chipped at all the corners, was a miniature
+given him by Emma: her toilette seemed to him pretentious, and her
+languishing look in the worst possible taste. Then, from looking at this
+image and recalling the memory of its original, Emma’s features little
+by little grew confused in his remembrance, as if the living and the
+painted face, rubbing one against the other, had effaced each other.
+Finally, he read some of her letters; they were full of explanations
+relating to their journey, short, technical, and urgent, like business
+notes. He wanted to see the long ones again, those of old times. In
+order to find them at the bottom of the box, Rodolphe disturbed all the
+others, and mechanically began rummaging amidst this mass of papers and
+things, finding pell-mell bouquets, garters, a black mask, pins, and
+hair--hair! dark and fair, some even, catching in the hinges of the box,
+broke when it was opened.
+
+Thus dallying with his souvenirs, he examined the writing and the style
+of the letters, as varied as their orthography. They were tender or
+jovial, facetious, melancholy; there were some that asked for love,
+others that asked for money. A word recalled faces to him, certain
+gestures, the sound of a voice; sometimes, however, he remembered
+nothing at all.
+
+In fact, these women, rushing at once into his thoughts, cramped each
+other and lessened, as reduced to a uniform level of love that equalised
+them all. So taking handfuls of the mixed-up letters, he amused himself
+for some moments with letting them fall in cascades from his right into
+his left hand. At last, bored and weary, Rodolphe took back the box to
+the cupboard, saying to himself, “What a lot of rubbish!” Which summed
+up his opinion; for pleasures, like schoolboys in a school courtyard,
+had so trampled upon his heart that no green thing grew there, and that
+which passed through it, more heedless than children, did not even, like
+them, leave a name carved upon the wall.
+
+“Come,” said he, “let’s begin.”
+
+He wrote--
+
+“Courage, Emma! courage! I would not bring misery into your life.”
+
+“After all, that’s true,” thought Rodolphe. “I am acting in her
+interest; I am honest.”
+
+“Have you carefully weighed your resolution? Do you know to what an
+abyss I was dragging you, poor angel? No, you do not, do you? You were
+coming confident and fearless, believing in happiness in the future. Ah!
+unhappy that we are--insensate!”
+
+Rodolphe stopped here to think of some good excuse.
+
+“If I told her all my fortune is lost? No! Besides, that would stop
+nothing. It would all have to be begun over again later on. As if one
+could make women like that listen to reason!” He reflected, then went
+on--
+
+“I shall not forget you, oh believe it; and I shall ever have a profound
+devotion for you; but some day, sooner or later, this ardour (such is
+the fate of human things) would have grown less, no doubt. Lassitude
+would have come to us, and who knows if I should not even have had the
+atrocious pain of witnessing your remorse, of sharing it myself, since
+I should have been its cause? The mere idea of the grief that would come
+to you tortures me, Emma. Forget me! Why did I ever know you? Why were
+you so beautiful? Is it my fault? O my God! No, no! Accuse only fate.”
+
+“That’s a word that always tells,” he said to himself.
+
+“Ah, if you had been one of those frivolous women that one sees,
+certainly I might, through egotism, have tried an experiment, in that
+case without danger for you. But that delicious exaltation, at once your
+charm and your torment, has prevented you from understanding, adorable
+woman that you are, the falseness of our future position. Nor had I
+reflected upon this at first, and I rested in the shade of that ideal
+happiness as beneath that of the manchineel tree, without foreseeing the
+consequences.”
+
+“Perhaps she’ll think I’m giving it up from avarice. Ah, well! so much
+the worse; it must be stopped!”
+
+“The world is cruel, Emma. Wherever we might have gone, it would have
+persecuted us. You would have had to put up with indiscreet questions,
+calumny, contempt, insult perhaps. Insult to you! Oh! And I, who would
+place you on a throne! I who bear with me your memory as a talisman! For
+I am going to punish myself by exile for all the ill I have done you.
+I am going away. Whither I know not. I am mad. Adieu! Be good always.
+Preserve the memory of the unfortunate who has lost you. Teach my name
+to your child; let her repeat it in her prayers.”
+
+The wicks of the candles flickered. Rodolphe got up to, shut the window,
+and when he had sat down again--
+
+“I think it’s all right. Ah! and this for fear she should come and hunt
+me up.”
+
+“I shall be far away when you read these sad lines, for I have wished to
+flee as quickly as possible to shun the temptation of seeing you again.
+No weakness! I shall return, and perhaps later on we shall talk together
+very coldly of our old love. Adieu!”
+
+And there was a last “adieu” divided into two words! “A Dieu!” which he
+thought in very excellent taste.
+
+“Now how am I to sign?” he said to himself. “‘Yours devotedly?’ No!
+‘Your friend?’ Yes, that’s it.”
+
+“Your friend.”
+
+He re-read his letter. He considered it very good.
+
+“Poor little woman!” he thought with emotion. “She’ll think me harder
+than a rock. There ought to have been some tears on this; but I can’t
+cry; it isn’t my fault.” Then, having emptied some water into a glass,
+Rodolphe dipped his finger into it, and let a big drop fall on the
+paper, that made a pale stain on the ink. Then looking for a seal, he
+came upon the one “Amor nel cor.”
+
+“That doesn’t at all fit in with the circumstances. Pshaw! never mind!”
+
+After which he smoked three pipes and went to bed.
+
+The next day when he was up (at about two o’clock--he had slept late),
+Rodolphe had a basket of apricots picked. He put his letter at
+the bottom under some vine leaves, and at once ordered Girard, his
+ploughman, to take it with care to Madame Bovary. He made use of this
+means for corresponding with her, sending according to the season fruits
+or game.
+
+“If she asks after me,” he said, “you will tell her that I have gone on
+a journey. You must give the basket to her herself, into her own hands.
+Get along and take care!”
+
+Girard put on his new blouse, knotted his handkerchief round the
+apricots, and walking with great heavy steps in his thick iron-bound
+galoshes, made his way to Yonville.
+
+Madame Bovary, when he got to her house, was arranging a bundle of linen
+on the kitchen-table with Felicite.
+
+“Here,” said the ploughboy, “is something for you--from the master.”
+
+She was seized with apprehension, and as she sought in her pocket for
+some coppers, she looked at the peasant with haggard eyes, while he
+himself looked at her with amazement, not understanding how such a
+present could so move anyone. At last he went out. Felicite remained.
+She could bear it no longer; she ran into the sitting room as if to take
+the apricots there, overturned the basket, tore away the leaves, found
+the letter, opened it, and, as if some fearful fire were behind her,
+Emma flew to her room terrified.
+
+Charles was there; she saw him; he spoke to her; she heard nothing, and
+she went on quickly up the stairs, breathless, distraught, dumb, and
+ever holding this horrible piece of paper, that crackled between her
+fingers like a plate of sheet-iron. On the second floor she stopped
+before the attic door, which was closed.
+
+Then she tried to calm herself; she recalled the letter; she must finish
+it; she did not dare to. And where? How? She would be seen! “Ah, no!
+here,” she thought, “I shall be all right.”
+
+Emma pushed open the door and went in.
+
+The slates threw straight down a heavy heat that gripped her temples,
+stifled her; she dragged herself to the closed garret-window. She drew
+back the bolt, and the dazzling light burst in with a leap.
+
+Opposite, beyond the roofs, stretched the open country till it was lost
+to sight. Down below, underneath her, the village square was empty; the
+stones of the pavement glittered, the weathercocks on the houses were
+motionless. At the corner of the street, from a lower storey, rose a
+kind of humming with strident modulations. It was Binet turning.
+
+She leant against the embrasure of the window, and reread the letter
+with angry sneers. But the more she fixed her attention upon it, the
+more confused were her ideas. She saw him again, heard him, encircled
+him with her arms, and throbs of her heart, that beat against her breast
+like blows of a sledge-hammer, grew faster and faster, with uneven
+intervals. She looked about her with the wish that the earth might
+crumble into pieces. Why not end it all? What restrained her? She was
+free. She advanced, looking at the paving-stones, saying to herself,
+“Come! come!”
+
+The luminous ray that came straight up from below drew the weight of
+her body towards the abyss. It seemed to her that the ground of the
+oscillating square went up the walls and that the floor dipped on
+end like a tossing boat. She was right at the edge, almost hanging,
+surrounded by vast space. The blue of the heavens suffused her, the air
+was whirling in her hollow head; she had but to yield, to let herself
+be taken; and the humming of the lathe never ceased, like an angry voice
+calling her.
+
+“Emma! Emma!” cried Charles.
+
+She stopped.
+
+“Wherever are you? Come!”
+
+The thought that she had just escaped from death almost made her faint
+with terror. She closed her eyes; then she shivered at the touch of a
+hand on her sleeve; it was Felicite.
+
+“Master is waiting for you, madame; the soup is on the table.”
+
+And she had to go down to sit at table.
+
+She tried to eat. The food choked her. Then she unfolded her napkin as
+if to examine the darns, and she really thought of applying herself to
+this work, counting the threads in the linen. Suddenly the remembrance
+of the letter returned to her. How had she lost it? Where could she find
+it? But she felt such weariness of spirit that she could not even invent
+a pretext for leaving the table. Then she became a coward; she was
+afraid of Charles; he knew all, that was certain! Indeed he pronounced
+these words in a strange manner:
+
+“We are not likely to see Monsieur Rodolphe soon again, it seems.”
+
+“Who told you?” she said, shuddering.
+
+“Who told me!” he replied, rather astonished at her abrupt tone. “Why,
+Girard, whom I met just now at the door of the Cafe Francais. He has
+gone on a journey, or is to go.”
+
+She gave a sob.
+
+“What surprises you in that? He absents himself like that from time
+to time for a change, and, ma foi, I think he’s right, when one has a
+fortune and is a bachelor. Besides, he has jolly times, has our friend.
+He’s a bit of a rake. Monsieur Langlois told me--”
+
+He stopped for propriety’s sake because the servant came in. She put
+back into the basket the apricots scattered on the sideboard. Charles,
+without noticing his wife’s colour, had them brought to him, took one,
+and bit into it.
+
+“Ah! perfect!” said he; “just taste!”
+
+And he handed her the basket, which she put away from her gently.
+
+“Do just smell! What an odour!” he remarked, passing it under her nose
+several times.
+
+“I am choking,” she cried, leaping up. But by an effort of will the
+spasm passed; then--
+
+“It is nothing,” she said, “it is nothing! It is nervousness. Sit down
+and go on eating.” For she dreaded lest he should begin questioning her,
+attending to her, that she should not be left alone.
+
+Charles, to obey her, sat down again, and he spat the stones of the
+apricots into his hands, afterwards putting them on his plate.
+
+Suddenly a blue tilbury passed across the square at a rapid trot. Emma
+uttered a cry and fell back rigid to the ground.
+
+In fact, Rodolphe, after many reflections, had decided to set out for
+Rouen. Now, as from La Huchette to Buchy there is no other way than by
+Yonville, he had to go through the village, and Emma had recognised him
+by the rays of the lanterns, which like lightning flashed through the
+twilight.
+
+The chemist, at the tumult which broke out in the house ran thither. The
+table with all the plates was upset; sauce, meat, knives, the salt, and
+cruet-stand were strewn over the room; Charles was calling for help;
+Berthe, scared, was crying; and Felicite, whose hands trembled, was
+unlacing her mistress, whose whole body shivered convulsively.
+
+“I’ll run to my laboratory for some aromatic vinegar,” said the
+druggist.
+
+Then as she opened her eyes on smelling the bottle--
+
+“I was sure of it,” he remarked; “that would wake any dead person for
+you!”
+
+“Speak to us,” said Charles; “collect yourself; it is your Charles, who
+loves you. Do you know me? See! here is your little girl! Oh, kiss her!”
+
+The child stretched out her arms to her mother to cling to her neck. But
+turning away her head, Emma said in a broken voice “No, no! no one!”
+
+She fainted again. They carried her to her bed. She lay there stretched
+at full length, her lips apart, her eyelids closed, her hands open,
+motionless, and white as a waxen image. Two streams of tears flowed from
+her eyes and fell slowly upon the pillow.
+
+Charles, standing up, was at the back of the alcove, and the chemist,
+near him, maintained that meditative silence that is becoming on the
+serious occasions of life.
+
+“Do not be uneasy,” he said, touching his elbow; “I think the paroxysm
+is past.”
+
+“Yes, she is resting a little now,” answered Charles, watching her
+sleep. “Poor girl! poor girl! She had gone off now!”
+
+Then Homais asked how the accident had come about. Charles answered that
+she had been taken ill suddenly while she was eating some apricots.
+
+“Extraordinary!” continued the chemist. “But it might be that the
+apricots had brought on the syncope. Some natures are so sensitive to
+certain smells; and it would even be a very fine question to study both
+in its pathological and physiological relation. The priests know the
+importance of it, they who have introduced aromatics into all their
+ceremonies. It is to stupefy the senses and to bring on ecstasies--a
+thing, moreover, very easy in persons of the weaker sex, who are more
+delicate than the other. Some are cited who faint at the smell of burnt
+hartshorn, of new bread--”
+
+“Take care; you’ll wake her!” said Bovary in a low voice.
+
+“And not only,” the druggist went on, “are human beings subject to such
+anomalies, but animals also. Thus you are not ignorant of the singularly
+aphrodisiac effect produced by the Nepeta cataria, vulgarly called
+catmint, on the feline race; and, on the other hand, to quote an example
+whose authenticity I can answer for. Bridaux (one of my old comrades, at
+present established in the Rue Malpalu) possesses a dog that falls into
+convulsions as soon as you hold out a snuff-box to him. He often even
+makes the experiment before his friends at his summer-house at Guillaume
+Wood. Would anyone believe that a simple sternutation could produce such
+ravages on a quadrupedal organism? It is extremely curious, is it not?”
+
+“Yes,” said Charles, who was not listening to him.
+
+“This shows us,” went on the other, smiling with benign
+self-sufficiency, “the innumerable irregularities of the nervous system.
+With regard to madame, she has always seemed to me, I confess, very
+susceptible. And so I should by no means recommend to you, my dear
+friend, any of those so-called remedies that, under the pretence
+of attacking the symptoms, attack the constitution. No; no useless
+physicking! Diet, that is all; sedatives, emollients, dulcification.
+Then, don’t you think that perhaps her imagination should be worked
+upon?”
+
+“In what way? How?” said Bovary.
+
+“Ah! that is it. Such is indeed the question. ‘That is the question,’ as
+I lately read in a newspaper.”
+
+But Emma, awaking, cried out--
+
+“The letter! the letter!”
+
+They thought she was delirious; and she was by midnight. Brain-fever had
+set in.
+
+For forty-three days Charles did not leave her. He gave up all his
+patients; he no longer went to bed; he was constantly feeling her pulse,
+putting on sinapisms and cold-water compresses. He sent Justin as far as
+Neufchatel for ice; the ice melted on the way; he sent him back again.
+He called Monsieur Canivet into consultation; he sent for Dr. Lariviere,
+his old master, from Rouen; he was in despair. What alarmed him most was
+Emma’s prostration, for she did not speak, did not listen, did not even
+seem to suffer, as if her body and soul were both resting together after
+all their troubles.
+
+About the middle of October she could sit up in bed supported by
+pillows. Charles wept when he saw her eat her first bread-and-jelly. Her
+strength returned to her; she got up for a few hours of an afternoon,
+and one day, when she felt better, he tried to take her, leaning on his
+arm, for a walk round the garden. The sand of the paths was disappearing
+beneath the dead leaves; she walked slowly, dragging along her slippers,
+and leaning against Charles’s shoulder. She smiled all the time.
+
+They went thus to the bottom of the garden near the terrace. She drew
+herself up slowly, shading her eyes with her hand to look. She looked
+far off, as far as she could, but on the horizon were only great
+bonfires of grass smoking on the hills.
+
+“You will tire yourself, my darling!” said Bovary. And, pushing her
+gently to make her go into the arbour, “Sit down on this seat; you’ll be
+comfortable.”
+
+“Oh! no; not there!” she said in a faltering voice.
+
+She was seized with giddiness, and from that evening her illness
+recommenced, with a more uncertain character, it is true, and more
+complex symptoms. Now she suffered in her heart, then in the chest, the
+head, the limbs; she had vomitings, in which Charles thought he saw the
+first signs of cancer.
+
+And besides this, the poor fellow was worried about money matters.
+
+
+
+Chapter Fourteen
+
+To begin with, he did not know how he could pay Monsieur Homais for all
+the physic supplied by him, and though, as a medical man, he was not
+obliged to pay for it, he nevertheless blushed a little at such an
+obligation. Then the expenses of the household, now that the servant was
+mistress, became terrible. Bills rained in upon the house; the tradesmen
+grumbled; Monsieur Lheureux especially harassed him. In fact, at
+the height of Emma’s illness, the latter, taking advantage of the
+circumstances to make his bill larger, had hurriedly brought the cloak,
+the travelling-bag, two trunks instead of one, and a number of other
+things. It was very well for Charles to say he did not want them. The
+tradesman answered arrogantly that these articles had been ordered, and
+that he would not take them back; besides, it would vex madame in her
+convalescence; the doctor had better think it over; in short, he was
+resolved to sue him rather than give up his rights and take back his
+goods. Charles subsequently ordered them to be sent back to the shop.
+Felicite forgot; he had other things to attend to; then thought no more
+about them. Monsieur Lheureux returned to the charge, and, by turns
+threatening and whining, so managed that Bovary ended by signing a
+bill at six months. But hardly had he signed this bill than a bold idea
+occurred to him: it was to borrow a thousand francs from Lheureux.
+So, with an embarrassed air, he asked if it were possible to get them,
+adding that it would be for a year, at any interest he wished. Lheureux
+ran off to his shop, brought back the money, and dictated another bill,
+by which Bovary undertook to pay to his order on the 1st of September
+next the sum of one thousand and seventy francs, which, with the hundred
+and eighty already agreed to, made just twelve hundred and fifty, thus
+lending at six per cent in addition to one-fourth for commission: and
+the things bringing him in a good third at the least, this ought in
+twelve months to give him a profit of a hundred and thirty francs. He
+hoped that the business would not stop there; that the bills would not
+be paid; that they would be renewed; and that his poor little money,
+having thriven at the doctor’s as at a hospital, would come back to him
+one day considerably more plump, and fat enough to burst his bag.
+
+Everything, moreover, succeeded with him. He was adjudicator for a
+supply of cider to the hospital at Neufchatel; Monsieur Guillaumin
+promised him some shares in the turf-pits of Gaumesnil, and he dreamt of
+establishing a new diligence service between Arcueil and Rouen, which
+no doubt would not be long in ruining the ramshackle van of the “Lion
+d’Or,” and that, travelling faster, at a cheaper rate, and carrying more
+luggage, would thus put into his hands the whole commerce of Yonville.
+
+Charles several times asked himself by what means he should next year be
+able to pay back so much money. He reflected, imagined expedients, such
+as applying to his father or selling something. But his father would be
+deaf, and he--he had nothing to sell. Then he foresaw such worries that
+he quickly dismissed so disagreeable a subject of meditation from
+his mind. He reproached himself with forgetting Emma, as if, all his
+thoughts belonging to this woman, it was robbing her of something not to
+be constantly thinking of her.
+
+The winter was severe, Madame Bovary’s convalescence slow. When it
+was fine they wheeled her arm-chair to the window that overlooked the
+square, for she now had an antipathy to the garden, and the blinds on
+that side were always down. She wished the horse to be sold; what she
+formerly liked now displeased her. All her ideas seemed to be limited to
+the care of herself. She stayed in bed taking little meals, rang for the
+servant to inquire about her gruel or to chat with her. The snow on
+the market-roof threw a white, still light into the room; then the rain
+began to fall; and Emma waited daily with a mind full of eagerness for
+the inevitable return of some trifling events which nevertheless had no
+relation to her. The most important was the arrival of the “Hirondelle”
+ in the evening. Then the landlady shouted out, and other voices
+answered, while Hippolyte’s lantern, as he fetched the boxes from the
+boot, was like a star in the darkness. At mid-day Charles came in;
+then he went out again; next she took some beef-tea, and towards five
+o’clock, as the day drew in, the children coming back from school,
+dragging their wooden shoes along the pavement, knocked the clapper of
+the shutters with their rulers one after the other.
+
+It was at this hour that Monsieur Bournisien came to see her. He
+inquired after her health, gave her news, exhorted her to religion, in a
+coaxing little prattle that was not without its charm. The mere thought
+of his cassock comforted her.
+
+One day, when at the height of her illness, she had thought herself
+dying, and had asked for the communion; and, while they were making the
+preparations in her room for the sacrament, while they were turning the
+night table covered with syrups into an altar, and while Felicite was
+strewing dahlia flowers on the floor, Emma felt some power passing
+over her that freed her from her pains, from all perception, from
+all feeling. Her body, relieved, no longer thought; another life was
+beginning; it seemed to her that her being, mounting toward God, would
+be annihilated in that love like a burning incense that melts into
+vapour. The bed-clothes were sprinkled with holy water, the priest drew
+from the holy pyx the white wafer; and it was fainting with a celestial
+joy that she put out her lips to accept the body of the Saviour
+presented to her. The curtains of the alcove floated gently round her
+like clouds, and the rays of the two tapers burning on the night-table
+seemed to shine like dazzling halos. Then she let her head fall back,
+fancying she heard in space the music of seraphic harps, and perceived
+in an azure sky, on a golden throne in the midst of saints holding green
+palms, God the Father, resplendent with majesty, who with a sign sent to
+earth angels with wings of fire to carry her away in their arms.
+
+This splendid vision dwelt in her memory as the most beautiful thing
+that it was possible to dream, so that now she strove to recall her
+sensation. That still lasted, however, but in a less exclusive fashion
+and with a deeper sweetness. Her soul, tortured by pride, at length
+found rest in Christian humility, and, tasting the joy of weakness, she
+saw within herself the destruction of her will, that must have left a
+wide entrance for the inroads of heavenly grace. There existed, then,
+in the place of happiness, still greater joys--another love beyond all
+loves, without pause and without end, one that would grow eternally! She
+saw amid the illusions of her hope a state of purity floating above the
+earth mingling with heaven, to which she aspired. She wanted to become
+a saint. She bought chaplets and wore amulets; she wished to have in her
+room, by the side of her bed, a reliquary set in emeralds that she might
+kiss it every evening.
+
+The cure marvelled at this humour, although Emma’s religion, he thought,
+might, from its fervour, end by touching on heresy, extravagance. But
+not being much versed in these matters, as soon as they went beyond a
+certain limit he wrote to Monsieur Boulard, bookseller to Monsignor,
+to send him “something good for a lady who was very clever.” The
+bookseller, with as much indifference as if he had been sending off
+hardware to niggers, packed up, pellmell, everything that was then the
+fashion in the pious book trade. There were little manuals in questions
+and answers, pamphlets of aggressive tone after the manner of Monsieur
+de Maistre, and certain novels in rose-coloured bindings and with
+a honied style, manufactured by troubadour seminarists or penitent
+blue-stockings. There were the “Think of it; the Man of the World at
+Mary’s Feet, by Monsieur de ***, decorated with many Orders”; “The
+Errors of Voltaire, for the Use of the Young,” etc.
+
+Madame Bovary’s mind was not yet sufficiently clear to apply herself
+seriously to anything; moreover, she began this reading in too much
+hurry. She grew provoked at the doctrines of religion; the arrogance
+of the polemic writings displeased her by their inveteracy in attacking
+people she did not know; and the secular stories, relieved with
+religion, seemed to her written in such ignorance of the world, that
+they insensibly estranged her from the truths for whose proof she was
+looking. Nevertheless, she persevered; and when the volume slipped
+from her hands, she fancied herself seized with the finest Catholic
+melancholy that an ethereal soul could conceive.
+
+As for the memory of Rodolphe, she had thrust it back to the bottom of
+her heart, and it remained there more solemn and more motionless than
+a king’s mummy in a catacomb. An exhalation escaped from this embalmed
+love, that, penetrating through everything, perfumed with tenderness the
+immaculate atmosphere in which she longed to live. When she knelt on her
+Gothic prie-Dieu, she addressed to the Lord the same suave words that
+she had murmured formerly to her lover in the outpourings of adultery.
+It was to make faith come; but no delights descended from the heavens,
+and she arose with tired limbs and with a vague feeling of a gigantic
+dupery.
+
+This searching after faith, she thought, was only one merit the more,
+and in the pride of her devoutness Emma compared herself to those grand
+ladies of long ago whose glory she had dreamed of over a portrait of La
+Valliere, and who, trailing with so much majesty the lace-trimmed trains
+of their long gowns, retired into solitudes to shed at the feet of
+Christ all the tears of hearts that life had wounded.
+
+Then she gave herself up to excessive charity. She sewed clothes for the
+poor, she sent wood to women in childbed; and Charles one day, on coming
+home, found three good-for-nothings in the kitchen seated at the table
+eating soup. She had her little girl, whom during her illness her
+husband had sent back to the nurse, brought home. She wanted to teach
+her to read; even when Berthe cried, she was not vexed. She had made
+up her mind to resignation, to universal indulgence. Her language about
+everything was full of ideal expressions. She said to her child, “Is
+your stomach-ache better, my angel?”
+
+Madame Bovary senior found nothing to censure except perhaps this mania
+of knitting jackets for orphans instead of mending her own house-linen;
+but, harassed with domestic quarrels, the good woman took pleasure in
+this quiet house, and she even stayed there till after Easter, to escape
+the sarcasms of old Bovary, who never failed on Good Friday to order
+chitterlings.
+
+Besides the companionship of her mother-in-law, who strengthened her a
+little by the rectitude of her judgment and her grave ways, Emma almost
+every day had other visitors. These were Madame Langlois, Madame Caron,
+Madame Dubreuil, Madame Tuvache, and regularly from two to five o’clock
+the excellent Madame Homais, who, for her part, had never believed any
+of the tittle-tattle about her neighbour. The little Homais also came to
+see her; Justin accompanied them. He went up with them to her bedroom,
+and remained standing near the door, motionless and mute. Often even
+Madame Bovary; taking no heed of him, began her toilette. She began by
+taking out her comb, shaking her head with a quick movement, and when
+he for the first time saw all this mass of hair that fell to her knees
+unrolling in black ringlets, it was to him, poor child! like a sudden
+entrance into something new and strange, whose splendour terrified him.
+
+Emma, no doubt, did not notice his silent attentions or his timidity.
+She had no suspicion that the love vanished from her life was there,
+palpitating by her side, beneath that coarse holland shirt, in that
+youthful heart open to the emanations of her beauty. Besides, she
+now enveloped all things with such indifference, she had words so
+affectionate with looks so haughty, such contradictory ways, that one
+could no longer distinguish egotism from charity, or corruption from
+virtue. One evening, for example, she was angry with the servant, who
+had asked to go out, and stammered as she tried to find some pretext.
+Then suddenly--
+
+“So you love him?” she said.
+
+And without waiting for any answer from Felicite, who was blushing, she
+added, “There! run along; enjoy yourself!”
+
+In the beginning of spring she had the garden turned up from end to end,
+despite Bovary’s remonstrances. However, he was glad to see her at last
+manifest a wish of any kind. As she grew stronger she displayed more
+wilfulness. First, she found occasion to expel Mere Rollet, the nurse,
+who during her convalescence had contracted the habit of coming too
+often to the kitchen with her two nurslings and her boarder, better
+off for teeth than a cannibal. Then she got rid of the Homais family,
+successively dismissed all the other visitors, and even frequented
+church less assiduously, to the great approval of the druggist, who said
+to her in a friendly way--
+
+“You were going in a bit for the cassock!”
+
+As formerly, Monsieur Bournisien dropped in every day when he came out
+after catechism class. He preferred staying out of doors to taking the
+air “in the grove,” as he called the arbour. This was the time when
+Charles came home. They were hot; some sweet cider was brought out, and
+they drank together to madame’s complete restoration.
+
+Binet was there; that is to say, a little lower down against the terrace
+wall, fishing for crayfish. Bovary invited him to have a drink, and he
+thoroughly understood the uncorking of the stone bottles.
+
+“You must,” he said, throwing a satisfied glance all round him, even to
+the very extremity of the landscape, “hold the bottle perpendicularly on
+the table, and after the strings are cut, press up the cork with
+little thrusts, gently, gently, as indeed they do seltzer-water at
+restaurants.”
+
+But during his demonstration the cider often spurted right into their
+faces, and then the ecclesiastic, with a thick laugh, never missed this
+joke--
+
+“Its goodness strikes the eye!”
+
+He was, in fact, a good fellow and one day he was not even scandalised
+at the chemist, who advised Charles to give madame some distraction
+by taking her to the theatre at Rouen to hear the illustrious tenor,
+Lagardy. Homais, surprised at this silence, wanted to know his opinion,
+and the priest declared that he considered music less dangerous for
+morals than literature.
+
+But the chemist took up the defence of letters. The theatre, he
+contended, served for railing at prejudices, and, beneath a mask of
+pleasure, taught virtue.
+
+“‘Castigat ridendo mores,’ * Monsieur Bournisien! Thus consider the
+greater part of Voltaire’s tragedies; they are cleverly strewn with
+philosophical reflections, that made them a vast school of morals and
+diplomacy for the people.”
+
+     *It corrects customs through laughter.
+
+
+“I,” said Binet, “once saw a piece called the ‘Gamin de Paris,’ in which
+there was the character of an old general that is really hit off to a
+T. He sets down a young swell who had seduced a working girl, who at the
+ending--”
+
+“Certainly,” continued Homais, “there is bad literature as there is bad
+pharmacy, but to condemn in a lump the most important of the fine arts
+seems to me a stupidity, a Gothic idea, worthy of the abominable times
+that imprisoned Galileo.”
+
+“I know very well,” objected the cure, “that there are good works,
+good authors. However, if it were only those persons of different sexes
+united in a bewitching apartment, decorated rouge, those lights, those
+effeminate voices, all this must, in the long-run, engender a
+certain mental libertinage, give rise to immodest thoughts and impure
+temptations. Such, at any rate, is the opinion of all the Fathers.
+Finally,” he added, suddenly assuming a mystic tone of voice while
+he rolled a pinch of snuff between his fingers, “if the Church has
+condemned the theatre, she must be right; we must submit to her
+decrees.”
+
+“Why,” asked the druggist, “should she excommunicate actors? For
+formerly they openly took part in religious ceremonies. Yes, in the
+middle of the chancel they acted; they performed a kind of farce called
+‘Mysteries,’ which often offended against the laws of decency.”
+
+The ecclesiastic contented himself with uttering a groan, and the
+chemist went on--
+
+“It’s like it is in the Bible; there there are, you know, more than one
+piquant detail, matters really libidinous!”
+
+And on a gesture of irritation from Monsieur Bournisien--
+
+“Ah! you’ll admit that it is not a book to place in the hands of a young
+girl, and I should be sorry if Athalie--”
+
+“But it is the Protestants, and not we,” cried the other impatiently,
+“who recommend the Bible.”
+
+“No matter,” said Homais. “I am surprised that in our days, in this
+century of enlightenment, anyone should still persist in proscribing an
+intellectual relaxation that is inoffensive, moralising, and sometimes
+even hygienic; is it not, doctor?”
+
+“No doubt,” replied the doctor carelessly, either because, sharing the
+same ideas, he wished to offend no one, or else because he had not any
+ideas.
+
+The conversation seemed at an end when the chemist thought fit to shoot
+a Parthian arrow.
+
+“I’ve known priests who put on ordinary clothes to go and see dancers
+kicking about.”
+
+“Come, come!” said the cure.
+
+“Ah! I’ve known some!” And separating the words of his sentence, Homais
+repeated, “I--have--known--some!”
+
+“Well, they were wrong,” said Bournisien, resigned to anything.
+
+“By Jove! they go in for more than that,” exclaimed the druggist.
+
+“Sir!” replied the ecclesiastic, with such angry eyes that the druggist
+was intimidated by them.
+
+“I only mean to say,” he replied in less brutal a tone, “that toleration
+is the surest way to draw people to religion.”
+
+“That is true! that is true!” agreed the good fellow, sitting down again
+on his chair. But he stayed only a few moments.
+
+Then, as soon as he had gone, Monsieur Homais said to the doctor--
+
+“That’s what I call a cock-fight. I beat him, did you see, in a
+way!--Now take my advice. Take madame to the theatre, if it were only
+for once in your life, to enrage one of these ravens, hang it! If anyone
+could take my place, I would accompany you myself. Be quick about it.
+Lagardy is only going to give one performance; he’s engaged to go to
+England at a high salary. From what I hear, he’s a regular dog; he’s
+rolling in money; he’s taking three mistresses and a cook along with
+him. All these great artists burn the candle at both ends; they require
+a dissolute life, that suits the imagination to some extent. But they
+die at the hospital, because they haven’t the sense when young to lay
+by. Well, a pleasant dinner! Goodbye till to-morrow.”
+
+The idea of the theatre quickly germinated in Bovary’s head, for he at
+once communicated it to his wife, who at first refused, alleging the
+fatigue, the worry, the expense; but, for a wonder, Charles did not give
+in, so sure was he that this recreation would be good for her. He saw
+nothing to prevent it: his mother had sent them three hundred francs
+which he had no longer expected; the current debts were not very large,
+and the falling in of Lheureux’s bills was still so far off that
+there was no need to think about them. Besides, imagining that she
+was refusing from delicacy, he insisted the more; so that by dint of
+worrying her she at last made up her mind, and the next day at eight
+o’clock they set out in the “Hirondelle.”
+
+The druggist, whom nothing whatever kept at Yonville, but who thought
+himself bound not to budge from it, sighed as he saw them go.
+
+“Well, a pleasant journey!” he said to them; “happy mortals that you
+are!”
+
+Then addressing himself to Emma, who was wearing a blue silk gown with
+four flounces--
+
+“You are as lovely as a Venus. You’ll cut a figure at Rouen.”
+
+The diligence stopped at the “Croix-Rouge” in the Place Beauvoisine. It
+was the inn that is in every provincial faubourg, with large stables
+and small bedrooms, where one sees in the middle of the court chickens
+pilfering the oats under the muddy gigs of the commercial travellers--a
+good old house, with worm-eaten balconies that creak in the wind on
+winter nights, always full of people, noise, and feeding, whose black
+tables are sticky with coffee and brandy, the thick windows made yellow
+by the flies, the damp napkins stained with cheap wine, and that always
+smells of the village, like ploughboys dressed in Sundayclothes, has
+a cafe on the street, and towards the countryside a kitchen-garden.
+Charles at once set out. He muddled up the stage-boxes with the gallery,
+the pit with the boxes; asked for explanations, did not understand them;
+was sent from the box-office to the acting-manager; came back to the
+inn, returned to the theatre, and thus several times traversed the whole
+length of the town from the theatre to the boulevard.
+
+Madame Bovary bought a bonnet, gloves, and a bouquet. The doctor was
+much afraid of missing the beginning, and, without having had time to
+swallow a plate of soup, they presented themselves at the doors of the
+theatre, which were still closed.
+
+
+
+
+Chapter Fifteen
+
+The crowd was waiting against the wall, symmetrically enclosed between
+the balustrades. At the corner of the neighbouring streets huge bills
+repeated in quaint letters “Lucie de Lammermoor-Lagardy-Opera-etc.” The
+weather was fine, the people were hot, perspiration trickled amid the
+curls, and handkerchiefs taken from pockets were mopping red foreheads;
+and now and then a warm wind that blew from the river gently stirred the
+border of the tick awnings hanging from the doors of the public-houses.
+A little lower down, however, one was refreshed by a current of icy air
+that smelt of tallow, leather, and oil. This was an exhalation from
+the Rue des Charrettes, full of large black warehouses where they made
+casks.
+
+For fear of seeming ridiculous, Emma before going in wished to have a
+little stroll in the harbour, and Bovary prudently kept his tickets in
+his hand, in the pocket of his trousers, which he pressed against his
+stomach.
+
+Her heart began to beat as soon as she reached the vestibule. She
+involuntarily smiled with vanity on seeing the crowd rushing to the
+right by the other corridor while she went up the staircase to the
+reserved seats. She was as pleased as a child to push with her finger
+the large tapestried door. She breathed in with all her might the
+dusty smell of the lobbies, and when she was seated in her box she bent
+forward with the air of a duchess.
+
+The theatre was beginning to fill; opera-glasses were taken from their
+cases, and the subscribers, catching sight of one another, were bowing.
+They came to seek relaxation in the fine arts after the anxieties of
+business; but “business” was not forgotten; they still talked cottons,
+spirits of wine, or indigo. The heads of old men were to be seen,
+inexpressive and peaceful, with their hair and complexions looking like
+silver medals tarnished by steam of lead. The young beaux were strutting
+about in the pit, showing in the opening of their waistcoats their pink
+or applegreen cravats, and Madame Bovary from above admired them leaning
+on their canes with golden knobs in the open palm of their yellow
+gloves.
+
+Now the lights of the orchestra were lit, the lustre, let down from the
+ceiling, throwing by the glimmering of its facets a sudden gaiety over
+the theatre; then the musicians came in one after the other; and
+first there was the protracted hubbub of the basses grumbling, violins
+squeaking, cornets trumpeting, flutes and flageolets fifing. But three
+knocks were heard on the stage, a rolling of drums began, the brass
+instruments played some chords, and the curtain rising, discovered a
+country-scene.
+
+It was the cross-roads of a wood, with a fountain shaded by an oak to
+the left. Peasants and lords with plaids on their shoulders were singing
+a hunting-song together; then a captain suddenly came on, who evoked
+the spirit of evil by lifting both his arms to heaven. Another appeared;
+they went away, and the hunters started afresh. She felt herself
+transported to the reading of her youth, into the midst of Walter Scott.
+She seemed to hear through the mist the sound of the Scotch bagpipes
+re-echoing over the heather. Then her remembrance of the novel helping
+her to understand the libretto, she followed the story phrase by phrase,
+while vague thoughts that came back to her dispersed at once again with
+the bursts of music. She gave herself up to the lullaby of the melodies,
+and felt all her being vibrate as if the violin bows were drawn over her
+nerves. She had not eyes enough to look at the costumes, the scenery,
+the actors, the painted trees that shook when anyone walked, and the
+velvet caps, cloaks, swords--all those imaginary things that floated
+amid the harmony as in the atmosphere of another world. But a young
+woman stepped forward, throwing a purse to a squire in green. She was
+left alone, and the flute was heard like the murmur of a fountain or the
+warbling of birds. Lucie attacked her cavatina in G major bravely. She
+plained of love; she longed for wings. Emma, too, fleeing from life,
+would have liked to fly away in an embrace. Suddenly Edgar-Lagardy
+appeared.
+
+He had that splendid pallor that gives something of the majesty of
+marble to the ardent races of the South. His vigorous form was tightly
+clad in a brown-coloured doublet; a small chiselled poniard hung against
+his left thigh, and he cast round laughing looks showing his white
+teeth. They said that a Polish princess having heard him sing one night
+on the beach at Biarritz, where he mended boats, had fallen in love
+with him. She had ruined herself for him. He had deserted her for
+other women, and this sentimental celebrity did not fail to enhance his
+artistic reputation. The diplomatic mummer took care always to slip into
+his advertisements some poetic phrase on the fascination of his
+person and the susceptibility of his soul. A fine organ, imperturbable
+coolness, more temperament than intelligence, more power of emphasis
+than of real singing, made up the charm of this admirable charlatan
+nature, in which there was something of the hairdresser and the
+toreador.
+
+From the first scene he evoked enthusiasm. He pressed Lucy in his arms,
+he left her, he came back, he seemed desperate; he had outbursts of
+rage, then elegiac gurglings of infinite sweetness, and the notes
+escaped from his bare neck full of sobs and kisses. Emma leant forward
+to see him, clutching the velvet of the box with her nails. She was
+filling her heart with these melodious lamentations that were drawn
+out to the accompaniment of the double-basses, like the cries of the
+drowning in the tumult of a tempest. She recognised all the intoxication
+and the anguish that had almost killed her. The voice of a prima donna
+seemed to her to be but echoes of her conscience, and this illusion that
+charmed her as some very thing of her own life. But no one on earth had
+loved her with such love. He had not wept like Edgar that last moonlit
+night when they said, “To-morrow! to-morrow!” The theatre rang with
+cheers; they recommenced the entire movement; the lovers spoke of
+the flowers on their tomb, of vows, exile, fate, hopes; and when they
+uttered the final adieu, Emma gave a sharp cry that mingled with the
+vibrations of the last chords.
+
+“But why,” asked Bovary, “does that gentleman persecute her?”
+
+“No, no!” she answered; “he is her lover!”
+
+“Yet he vows vengeance on her family, while the other one who came on
+before said, ‘I love Lucie and she loves me!’ Besides, he went off with
+her father arm in arm. For he certainly is her father, isn’t he--the
+ugly little man with a cock’s feather in his hat?”
+
+Despite Emma’s explanations, as soon as the recitative duet began
+in which Gilbert lays bare his abominable machinations to his master
+Ashton, Charles, seeing the false troth-ring that is to deceive Lucie,
+thought it was a love-gift sent by Edgar. He confessed, moreover, that
+he did not understand the story because of the music, which interfered
+very much with the words.
+
+“What does it matter?” said Emma. “Do be quiet!”
+
+“Yes, but you know,” he went on, leaning against her shoulder, “I like
+to understand things.”
+
+“Be quiet! be quiet!” she cried impatiently.
+
+Lucie advanced, half supported by her women, a wreath of orange blossoms
+in her hair, and paler than the white satin of her gown. Emma dreamed
+of her marriage day; she saw herself at home again amid the corn in the
+little path as they walked to the church. Oh, why had not she, like
+this woman, resisted, implored? She, on the contrary, had been joyous,
+without seeing the abyss into which she was throwing herself. Ah! if
+in the freshness of her beauty, before the soiling of marriage and the
+disillusions of adultery, she could have anchored her life upon some
+great, strong heart, then virtue, tenderness, voluptuousness, and duty
+blending, she would never have fallen from so high a happiness. But that
+happiness, no doubt, was a lie invented for the despair of all desire.
+She now knew the smallness of the passions that art exaggerated. So,
+striving to divert her thoughts, Emma determined now to see in this
+reproduction of her sorrows only a plastic fantasy, well enough to
+please the eye, and she even smiled internally with disdainful pity when
+at the back of the stage under the velvet hangings a man appeared in a
+black cloak.
+
+His large Spanish hat fell at a gesture he made, and immediately the
+instruments and the singers began the sextet. Edgar, flashing with fury,
+dominated all the others with his clearer voice; Ashton hurled homicidal
+provocations at him in deep notes; Lucie uttered her shrill plaint,
+Arthur at one side, his modulated tones in the middle register, and the
+bass of the minister pealed forth like an organ, while the voices of the
+women repeating his words took them up in chorus delightfully. They were
+all in a row gesticulating, and anger, vengeance, jealousy, terror, and
+stupefaction breathed forth at once from their half-opened mouths. The
+outraged lover brandished his naked sword; his guipure ruffle rose with
+jerks to the movements of his chest, and he walked from right to left
+with long strides, clanking against the boards the silver-gilt spurs of
+his soft boots, widening out at the ankles. He, she thought must have an
+inexhaustible love to lavish it upon the crowd with such effusion.
+All her small fault-findings faded before the poetry of the part
+that absorbed her; and, drawn towards this man by the illusion of the
+character, she tried to imagine to herself his life--that life resonant,
+extraordinary, splendid, and that might have been hers if fate had
+willed it. They would have known one another, loved one another. With
+him, through all the kingdoms of Europe she would have travelled from
+capital to capital, sharing his fatigues and his pride, picking up the
+flowers thrown to him, herself embroidering his costumes. Then each
+evening, at the back of a box, behind the golden trellis-work she would
+have drunk in eagerly the expansions of this soul that would have sung
+for her alone; from the stage, even as he acted, he would have looked
+at her. But the mad idea seized her that he was looking at her; it was
+certain. She longed to run to his arms, to take refuge in his strength,
+as in the incarnation of love itself, and to say to him, to cry out,
+“Take me away! carry me with you! let us go! Thine, thine! all my ardour
+and all my dreams!”
+
+The curtain fell.
+
+The smell of the gas mingled with that of the breaths, the waving of the
+fans, made the air more suffocating. Emma wanted to go out; the
+crowd filled the corridors, and she fell back in her arm-chair with
+palpitations that choked her. Charles, fearing that she would faint, ran
+to the refreshment-room to get a glass of barley-water.
+
+He had great difficulty in getting back to his seat, for his elbows were
+jerked at every step because of the glass he held in his hands, and
+he even spilt three-fourths on the shoulders of a Rouen lady in short
+sleeves, who feeling the cold liquid running down to her loins, uttered
+cries like a peacock, as if she were being assassinated. Her husband,
+who was a millowner, railed at the clumsy fellow, and while she was with
+her handkerchief wiping up the stains from her handsome cherry-coloured
+taffeta gown, he angrily muttered about indemnity, costs, reimbursement.
+At last Charles reached his wife, saying to her, quite out of breath--
+
+“Ma foi! I thought I should have had to stay there. There is such a
+crowd--SUCH a crowd!”
+
+He added--
+
+“Just guess whom I met up there! Monsieur Leon!”
+
+“Leon?”
+
+“Himself! He’s coming along to pay his respects.” And as he finished
+these words the ex-clerk of Yonville entered the box.
+
+He held out his hand with the ease of a gentleman; and Madame Bovary
+extended hers, without doubt obeying the attraction of a stronger will.
+She had not felt it since that spring evening when the rain fell upon
+the green leaves, and they had said good-bye standing at the window.
+But soon recalling herself to the necessities of the situation, with an
+effort she shook off the torpor of her memories, and began stammering a
+few hurried words.
+
+“Ah, good-day! What! you here?”
+
+“Silence!” cried a voice from the pit, for the third act was beginning.
+
+“So you are at Rouen?”
+
+“Yes.”
+
+“And since when?”
+
+“Turn them out! turn them out!” People were looking at them. They were
+silent.
+
+But from that moment she listened no more; and the chorus of the guests,
+the scene between Ashton and his servant, the grand duet in D major, all
+were for her as far off as if the instruments had grown less sonorous
+and the characters more remote. She remembered the games at cards at the
+druggist’s, and the walk to the nurse’s, the reading in the arbour,
+the tete-a-tete by the fireside--all that poor love, so calm and so
+protracted, so discreet, so tender, and that she had nevertheless
+forgotten. And why had he come back? What combination of circumstances
+had brought him back into her life? He was standing behind her, leaning
+with his shoulder against the wall of the box; now and again she felt
+herself shuddering beneath the hot breath from his nostrils falling upon
+her hair.
+
+“Does this amuse you?” said he, bending over her so closely that the end
+of his moustache brushed her cheek. She replied carelessly--
+
+“Oh, dear me, no, not much.”
+
+Then he proposed that they should leave the theatre and go and take an
+ice somewhere.
+
+“Oh, not yet; let us stay,” said Bovary. “Her hair’s undone; this is
+going to be tragic.”
+
+But the mad scene did not at all interest Emma, and the acting of the
+singer seemed to her exaggerated.
+
+“She screams too loud,” said she, turning to Charles, who was listening.
+
+“Yes--a little,” he replied, undecided between the frankness of his
+pleasure and his respect for his wife’s opinion.
+
+Then with a sigh Leon said--
+
+“The heat is--”
+
+“Unbearable! Yes!”
+
+“Do you feel unwell?” asked Bovary.
+
+“Yes, I am stifling; let us go.”
+
+Monsieur Leon put her long lace shawl carefully about her shoulders, and
+all three went off to sit down in the harbour, in the open air, outside
+the windows of a cafe.
+
+First they spoke of her illness, although Emma interrupted Charles
+from time to time, for fear, she said, of boring Monsieur Leon; and the
+latter told them that he had come to spend two years at Rouen in a large
+office, in order to get practice in his profession, which was different
+in Normandy and Paris. Then he inquired after Berthe, the Homais, Mere
+Lefrancois, and as they had, in the husband’s presence, nothing more to
+say to one another, the conversation soon came to an end.
+
+People coming out of the theatre passed along the pavement, humming or
+shouting at the top of their voices, “O bel ange, ma Lucie!*” Then Leon,
+playing the dilettante, began to talk music. He had seen Tambourini,
+Rubini, Persiani, Grisi, and, compared with them, Lagardy, despite his
+grand outbursts, was nowhere.
+
+     *Oh beautiful angel, my Lucie.
+
+
+“Yet,” interrupted Charles, who was slowly sipping his rum-sherbet,
+“they say that he is quite admirable in the last act. I regret leaving
+before the end, because it was beginning to amuse me.”
+
+“Why,” said the clerk, “he will soon give another performance.”
+
+But Charles replied that they were going back next day. “Unless,” he
+added, turning to his wife, “you would like to stay alone, kitten?”
+
+And changing his tactics at this unexpected opportunity that presented
+itself to his hopes, the young man sang the praises of Lagardy in the
+last number. It was really superb, sublime. Then Charles insisted--
+
+“You would get back on Sunday. Come, make up your mind. You are wrong if
+you feel that this is doing you the least good.”
+
+The tables round them, however, were emptying; a waiter came and stood
+discreetly near them. Charles, who understood, took out his purse; the
+clerk held back his arm, and did not forget to leave two more pieces of
+silver that he made chink on the marble.
+
+“I am really sorry,” said Bovary, “about the money which you are--”
+
+The other made a careless gesture full of cordiality, and taking his hat
+said--
+
+“It is settled, isn’t it? To-morrow at six o’clock?”
+
+Charles explained once more that he could not absent himself longer, but
+that nothing prevented Emma--
+
+“But,” she stammered, with a strange smile, “I am not sure--”
+
+“Well, you must think it over. We’ll see. Night brings counsel.” Then to
+Leon, who was walking along with them, “Now that you are in our part of
+the world, I hope you’ll come and ask us for some dinner now and then.”
+
+The clerk declared he would not fail to do so, being obliged, moreover,
+to go to Yonville on some business for his office. And they parted
+before the Saint-Herbland Passage just as the clock in the cathedral
+struck half-past eleven.
+
+
+
+
+Part III
+
+
+
+Chapter One
+
+Monsieur Leon, while studying law, had gone pretty often to the
+dancing-rooms, where he was even a great success amongst the grisettes,
+who thought he had a distinguished air. He was the best-mannered of the
+students; he wore his hair neither too long nor too short, didn’t spend
+all his quarter’s money on the first day of the month, and kept on good
+terms with his professors. As for excesses, he had always abstained from
+them, as much from cowardice as from refinement.
+
+Often when he stayed in his room to read, or else when sitting of an
+evening under the lime-trees of the Luxembourg, he let his Code fall to
+the ground, and the memory of Emma came back to him. But gradually this
+feeling grew weaker, and other desires gathered over it, although it
+still persisted through them all. For Leon did not lose all hope; there
+was for him, as it were, a vague promise floating in the future, like a
+golden fruit suspended from some fantastic tree.
+
+Then, seeing her again after three years of absence his passion
+reawakened. He must, he thought, at last make up his mind to possess
+her. Moreover, his timidity had worn off by contact with his gay
+companions, and he returned to the provinces despising everyone who had
+not with varnished shoes trodden the asphalt of the boulevards. By
+the side of a Parisienne in her laces, in the drawing-room of some
+illustrious physician, a person driving his carriage and wearing many
+orders, the poor clerk would no doubt have trembled like a child; but
+here, at Rouen, on the harbour, with the wife of this small doctor
+he felt at his ease, sure beforehand he would shine. Self-possession
+depends on its environment. We don’t speak on the first floor as on the
+fourth; and the wealthy woman seems to have, about her, to guard her
+virtue, all her banknotes, like a cuirass in the lining of her corset.
+
+On leaving the Bovarys the night before, Leon had followed them
+through the streets at a distance; then having seen them stop at the
+“Croix-Rouge,” he turned on his heel, and spent the night meditating a
+plan.
+
+So the next day about five o’clock he walked into the kitchen of the
+inn, with a choking sensation in his throat, pale cheeks, and that
+resolution of cowards that stops at nothing.
+
+“The gentleman isn’t in,” answered a servant.
+
+This seemed to him a good omen. He went upstairs.
+
+She was not disturbed at his approach; on the contrary, she apologised
+for having neglected to tell him where they were staying.
+
+“Oh, I divined it!” said Leon.
+
+He pretended he had been guided towards her by chance, by, instinct. She
+began to smile; and at once, to repair his folly, Leon told her that he
+had spent his morning in looking for her in all the hotels in the town
+one after the other.
+
+“So you have made up your mind to stay?” he added.
+
+“Yes,” she said, “and I am wrong. One ought not to accustom oneself to
+impossible pleasures when there are a thousand demands upon one.”
+
+“Oh, I can imagine!”
+
+“Ah! no; for you, you are a man!”
+
+But men too had had their trials, and the conversation went off into
+certain philosophical reflections. Emma expatiated much on the misery of
+earthly affections, and the eternal isolation in which the heart remains
+entombed.
+
+To show off, or from a naive imitation of this melancholy which called
+forth his, the young man declared that he had been awfully bored during
+the whole course of his studies. The law irritated him, other vocations
+attracted him, and his mother never ceased worrying him in every one
+of her letters. As they talked they explained more and more fully the
+motives of their sadness, working themselves up in their progressive
+confidence. But they sometimes stopped short of the complete exposition
+of their thought, and then sought to invent a phrase that might express
+it all the same. She did not confess her passion for another; he did not
+say that he had forgotten her.
+
+Perhaps he no longer remembered his suppers with girls after masked
+balls; and no doubt she did not recollect the rendezvous of old when she
+ran across the fields in the morning to her lover’s house. The noises
+of the town hardly reached them, and the room seemed small, as if
+on purpose to hem in their solitude more closely. Emma, in a dimity
+dressing-gown, leant her head against the back of the old arm-chair; the
+yellow wall-paper formed, as it were, a golden background behind her,
+and her bare head was mirrored in the glass with the white parting in
+the middle, and the tip of her ears peeping out from the folds of her
+hair.
+
+“But pardon me!” she said. “It is wrong of me. I weary you with my
+eternal complaints.”
+
+“No, never, never!”
+
+“If you knew,” she went on, raising to the ceiling her beautiful eyes,
+in which a tear was trembling, “all that I had dreamed!”
+
+“And I! Oh, I too have suffered! Often I went out; I went away. I
+dragged myself along the quays, seeking distraction amid the din of the
+crowd without being able to banish the heaviness that weighed upon me.
+In an engraver’s shop on the boulevard there is an Italian print of one
+of the Muses. She is draped in a tunic, and she is looking at the
+moon, with forget-me-nots in her flowing hair. Something drove me there
+continually; I stayed there hours together.” Then in a trembling voice,
+“She resembled you a little.”
+
+Madame Bovary turned away her head that he might not see the
+irrepressible smile she felt rising to her lips.
+
+“Often,” he went on, “I wrote you letters that I tore up.”
+
+She did not answer. He continued--
+
+“I sometimes fancied that some chance would bring you. I thought I
+recognised you at street-corners, and I ran after all the carriages
+through whose windows I saw a shawl fluttering, a veil like yours.”
+
+She seemed resolved to let him go on speaking without interruption.
+Crossing her arms and bending down her face, she looked at the rosettes
+on her slippers, and at intervals made little movements inside the satin
+of them with her toes.
+
+At last she sighed.
+
+“But the most wretched thing, is it not--is to drag out, as I do, a
+useless existence. If our pains were only of some use to someone, we
+should find consolation in the thought of the sacrifice.”
+
+He started off in praise of virtue, duty, and silent immolation, having
+himself an incredible longing for self-sacrifice that he could not
+satisfy.
+
+“I should much like,” she said, “to be a nurse at a hospital.”
+
+“Alas! men have none of these holy missions, and I see nowhere any
+calling--unless perhaps that of a doctor.”
+
+With a slight shrug of her shoulders, Emma interrupted him to speak of
+her illness, which had almost killed her. What a pity! She should not be
+suffering now! Leon at once envied the calm of the tomb, and one evening
+he had even made his will, asking to be buried in that beautiful rug
+with velvet stripes he had received from her. For this was how they
+would have wished to be, each setting up an ideal to which they were now
+adapting their past life. Besides, speech is a rolling-mill that always
+thins out the sentiment.
+
+But at this invention of the rug she asked, “But why?”
+
+“Why?” He hesitated. “Because I loved you so!” And congratulating
+himself at having surmounted the difficulty, Leon watched her face out
+of the corner of his eyes.
+
+It was like the sky when a gust of wind drives the clouds across. The
+mass of sad thoughts that darkened them seemed to be lifted from her
+blue eyes; her whole face shone. He waited. At last she replied--
+
+“I always suspected it.”
+
+Then they went over all the trifling events of that far-off existence,
+whose joys and sorrows they had just summed up in one word. They
+recalled the arbour with clematis, the dresses she had worn, the
+furniture of her room, the whole of her house.
+
+“And our poor cactuses, where are they?”
+
+“The cold killed them this winter.”
+
+“Ah! how I have thought of them, do you know? I often saw them again as
+of yore, when on the summer mornings the sun beat down upon your blinds,
+and I saw your two bare arms passing out amongst the flowers.”
+
+“Poor friend!” she said, holding out her hand to him.
+
+Leon swiftly pressed his lips to it. Then, when he had taken a deep
+breath--
+
+“At that time you were to me I know not what incomprehensible force that
+took captive my life. Once, for instance, I went to see you; but you, no
+doubt, do not remember it.”
+
+“I do,” she said; “go on.”
+
+“You were downstairs in the ante-room, ready to go out, standing on
+the last stair; you were wearing a bonnet with small blue flowers; and
+without any invitation from you, in spite of myself, I went with you.
+Every moment, however, I grew more and more conscious of my folly, and
+I went on walking by you, not daring to follow you completely, and
+unwilling to leave you. When you went into a shop, I waited in the
+street, and I watched you through the window taking off your gloves and
+counting the change on the counter. Then you rang at Madame Tuvache’s;
+you were let in, and I stood like an idiot in front of the great heavy
+door that had closed after you.”
+
+Madame Bovary, as she listened to him, wondered that she was so old. All
+these things reappearing before her seemed to widen out her life; it was
+like some sentimental immensity to which she returned; and from time to
+time she said in a low voice, her eyes half closed--
+
+“Yes, it is true--true--true!”
+
+They heard eight strike on the different clocks of the Beauvoisine
+quarter, which is full of schools, churches, and large empty hotels.
+They no longer spoke, but they felt as they looked upon each other a
+buzzing in their heads, as if something sonorous had escaped from the
+fixed eyes of each of them. They were hand in hand now, and the past,
+the future, reminiscences and dreams, all were confounded in the
+sweetness of this ecstasy. Night was darkening over the walls, on which
+still shone, half hidden in the shade, the coarse colours of four bills
+representing four scenes from the “Tour de Nesle,” with a motto in
+Spanish and French at the bottom. Through the sash-window a patch of
+dark sky was seen between the pointed roofs.
+
+She rose to light two wax-candles on the drawers, then she sat down
+again.
+
+“Well!” said Leon.
+
+“Well!” she replied.
+
+He was thinking how to resume the interrupted conversation, when she
+said to him--
+
+“How is it that no one until now has ever expressed such sentiments to
+me?”
+
+The clerk said that ideal natures were difficult to understand. He from
+the first moment had loved her, and he despaired when he thought of the
+happiness that would have been theirs, if thanks to fortune, meeting her
+earlier, they had been indissolubly bound to one another.
+
+“I have sometimes thought of it,” she went on.
+
+“What a dream!” murmured Leon. And fingering gently the blue binding of
+her long white sash, he added, “And who prevents us from beginning now?”
+
+“No, my friend,” she replied; “I am too old; you are too young. Forget
+me! Others will love you; you will love them.”
+
+“Not as you!” he cried.
+
+“What a child you are! Come, let us be sensible. I wish it.”
+
+She showed him the impossibility of their love, and that they must
+remain, as formerly, on the simple terms of a fraternal friendship.
+
+Was she speaking thus seriously? No doubt Emma did not herself know,
+quite absorbed as she was by the charm of the seduction, and the
+necessity of defending herself from it; and contemplating the young
+man with a moved look, she gently repulsed the timid caresses that his
+trembling hands attempted.
+
+“Ah! forgive me!” he cried, drawing back.
+
+Emma was seized with a vague fear at this shyness, more dangerous to her
+than the boldness of Rodolphe when he advanced to her open-armed. No man
+had ever seemed to her so beautiful. An exquisite candour emanated from
+his being. He lowered his long fine eyelashes, that curled upwards.
+His cheek, with the soft skin reddened, she thought, with desire of her
+person, and Emma felt an invincible longing to press her lips to it.
+Then, leaning towards the clock as if to see the time--
+
+“Ah! how late it is!” she said; “how we do chatter!”
+
+He understood the hint and took up his hat.
+
+“It has even made me forget the theatre. And poor Bovary has left me
+here especially for that. Monsieur Lormeaux, of the Rue Grand-Pont, was
+to take me and his wife.”
+
+And the opportunity was lost, as she was to leave the next day.
+
+“Really!” said Leon.
+
+“Yes.”
+
+“But I must see you again,” he went on. “I wanted to tell you--”
+
+“What?”
+
+“Something--important--serious. Oh, no! Besides, you will not go; it is
+impossible. If you should--listen to me. Then you have not understood
+me; you have not guessed--”
+
+“Yet you speak plainly,” said Emma.
+
+“Ah! you can jest. Enough! enough! Oh, for pity’s sake, let me see you
+once--only once!”
+
+“Well--” She stopped; then, as if thinking better of it, “Oh, not here!”
+
+“Where you will.”
+
+“Will you--” She seemed to reflect; then abruptly, “To-morrow at eleven
+o’clock in the cathedral.”
+
+“I shall be there,” he cried, seizing her hands, which she disengaged.
+
+And as they were both standing up, he behind her, and Emma with her head
+bent, he stooped over her and pressed long kisses on her neck.
+
+“You are mad! Ah! you are mad!” she said, with sounding little laughs,
+while the kisses multiplied.
+
+Then bending his head over her shoulder, he seemed to beg the consent of
+her eyes. They fell upon him full of an icy dignity.
+
+Leon stepped back to go out. He stopped on the threshold; then he
+whispered with a trembling voice, “Tomorrow!”
+
+She answered with a nod, and disappeared like a bird into the next room.
+
+In the evening Emma wrote the clerk an interminable letter, in which she
+cancelled the rendezvous; all was over; they must not, for the sake of
+their happiness, meet again. But when the letter was finished, as she
+did not know Leon’s address, she was puzzled.
+
+“I’ll give it to him myself,” she said; “he will come.”
+
+The next morning, at the open window, and humming on his balcony, Leon
+himself varnished his pumps with several coatings. He put on white
+trousers, fine socks, a green coat, emptied all the scent he had into
+his handkerchief, then having had his hair curled, he uncurled it again,
+in order to give it a more natural elegance.
+
+“It is still too early,” he thought, looking at the hairdresser’s
+cuckoo-clock, that pointed to the hour of nine. He read an old fashion
+journal, went out, smoked a cigar, walked up three streets, thought it
+was time, and went slowly towards the porch of Notre Dame.
+
+It was a beautiful summer morning. Silver plate sparkled in the
+jeweller’s windows, and the light falling obliquely on the cathedral
+made mirrors of the corners of the grey stones; a flock of birds
+fluttered in the grey sky round the trefoil bell-turrets; the square,
+resounding with cries, was fragrant with the flowers that bordered its
+pavement, roses, jasmines, pinks, narcissi, and tube-roses, unevenly
+spaced out between moist grasses, catmint, and chickweed for the birds;
+the fountains gurgled in the centre, and under large umbrellas, amidst
+melons, piled up in heaps, flower-women, bare-headed, were twisting
+paper round bunches of violets.
+
+The young man took one. It was the first time that he had bought flowers
+for a woman, and his breast, as he smelt them, swelled with pride, as if
+this homage that he meant for another had recoiled upon himself.
+
+But he was afraid of being seen; he resolutely entered the church. The
+beadle, who was just then standing on the threshold in the middle of the
+left doorway, under the “Dancing Marianne,” with feather cap, and rapier
+dangling against his calves, came in, more majestic than a cardinal, and
+as shining as a saint on a holy pyx.
+
+He came towards Leon, and, with that smile of wheedling benignity
+assumed by ecclesiastics when they question children--
+
+“The gentleman, no doubt, does not belong to these parts? The gentleman
+would like to see the curiosities of the church?”
+
+“No!” said the other.
+
+And he first went round the lower aisles. Then he went out to look at
+the Place. Emma was not coming yet. He went up again to the choir.
+
+The nave was reflected in the full fonts with the beginning of the
+arches and some portions of the glass windows. But the reflections of
+the paintings, broken by the marble rim, were continued farther on upon
+the flag-stones, like a many-coloured carpet. The broad daylight from
+without streamed into the church in three enormous rays from the three
+opened portals. From time to time at the upper end a sacristan passed,
+making the oblique genuflexion of devout persons in a hurry. The crystal
+lustres hung motionless. In the choir a silver lamp was burning, and
+from the side chapels and dark places of the church sometimes rose
+sounds like sighs, with the clang of a closing grating, its echo
+reverberating under the lofty vault.
+
+Leon with solemn steps walked along by the walls. Life had never seemed
+so good to him. She would come directly, charming, agitated, looking
+back at the glances that followed her, and with her flounced dress, her
+gold eyeglass, her thin shoes, with all sorts of elegant trifles that he
+had never enjoyed, and with the ineffable seduction of yielding virtue.
+The church like a huge boudoir spread around her; the arches bent down
+to gather in the shade the confession of her love; the windows shone
+resplendent to illumine her face, and the censers would burn that she
+might appear like an angel amid the fumes of the sweet-smelling odours.
+
+But she did not come. He sat down on a chair, and his eyes fell upon a
+blue stained window representing boatmen carrying baskets. He looked at
+it long, attentively, and he counted the scales of the fishes and the
+button-holes of the doublets, while his thoughts wandered off towards
+Emma.
+
+The beadle, standing aloof, was inwardly angry at this individual who
+took the liberty of admiring the cathedral by himself. He seemed to him
+to be conducting himself in a monstrous fashion, to be robbing him in a
+sort, and almost committing sacrilege.
+
+But a rustle of silk on the flags, the tip of a bonnet, a lined
+cloak--it was she! Leon rose and ran to meet her.
+
+Emma was pale. She walked fast.
+
+“Read!” she said, holding out a paper to him. “Oh, no!”
+
+And she abruptly withdrew her hand to enter the chapel of the Virgin,
+where, kneeling on a chair, she began to pray.
+
+The young man was irritated at this bigot fancy; then he nevertheless
+experienced a certain charm in seeing her, in the middle of a
+rendezvous, thus lost in her devotions, like an Andalusian marchioness;
+then he grew bored, for she seemed never coming to an end.
+
+Emma prayed, or rather strove to pray, hoping that some sudden
+resolution might descend to her from heaven; and to draw down divine
+aid she filled full her eyes with the splendours of the tabernacle. She
+breathed in the perfumes of the full-blown flowers in the large vases,
+and listened to the stillness of the church, that only heightened the
+tumult of her heart.
+
+She rose, and they were about to leave, when the beadle came forward,
+hurriedly saying--
+
+“Madame, no doubt, does not belong to these parts? Madame would like to
+see the curiosities of the church?”
+
+“Oh, no!” cried the clerk.
+
+“Why not?” said she. For she clung with her expiring virtue to the
+Virgin, the sculptures, the tombs--anything.
+
+Then, in order to proceed “by rule,” the beadle conducted them right to
+the entrance near the square, where, pointing out with his cane a large
+circle of block-stones without inscription or carving--
+
+“This,” he said majestically, “is the circumference of the beautiful
+bell of Ambroise. It weighed forty thousand pounds. There was not its
+equal in all Europe. The workman who cast it died of the joy--”
+
+“Let us go on,” said Leon.
+
+The old fellow started off again; then, having got back to the chapel of
+the Virgin, he stretched forth his arm with an all-embracing gesture
+of demonstration, and, prouder than a country squire showing you his
+espaliers, went on--
+
+“This simple stone covers Pierre de Breze, lord of Varenne and of
+Brissac, grand marshal of Poitou, and governor of Normandy, who died at
+the battle of Montlhery on the 16th of July, 1465.”
+
+Leon bit his lips, fuming.
+
+“And on the right, this gentleman all encased in iron, on the
+prancing horse, is his grandson, Louis de Breze, lord of Breval and of
+Montchauvet, Count de Maulevrier, Baron de Mauny, chamberlain to the
+king, Knight of the Order, and also governor of Normandy; died on the
+23rd of July, 1531--a Sunday, as the inscription specifies; and below,
+this figure, about to descend into the tomb, portrays the same person.
+It is not possible, is it, to see a more perfect representation of
+annihilation?”
+
+Madame Bovary put up her eyeglasses. Leon, motionless, looked at her,
+no longer even attempting to speak a single word, to make a gesture,
+so discouraged was he at this two-fold obstinacy of gossip and
+indifference.
+
+The everlasting guide went on--
+
+“Near him, this kneeling woman who weeps is his spouse, Diane de
+Poitiers, Countess de Breze, Duchess de Valentinois, born in 1499, died
+in 1566, and to the left, the one with the child is the Holy Virgin. Now
+turn to this side; here are the tombs of the Ambroise. They were both
+cardinals and archbishops of Rouen. That one was minister under Louis
+XII. He did a great deal for the cathedral. In his will he left thirty
+thousand gold crowns for the poor.”
+
+And without stopping, still talking, he pushed them into a chapel
+full of balustrades, some put away, and disclosed a kind of block that
+certainly might once have been an ill-made statue.
+
+“Truly,” he said with a groan, “it adorned the tomb of Richard Coeur de
+Lion, King of England and Duke of Normandy. It was the Calvinists, sir,
+who reduced it to this condition. They had buried it for spite in the
+earth, under the episcopal seat of Monsignor. See! this is the door by
+which Monsignor passes to his house. Let us pass on quickly to see the
+gargoyle windows.”
+
+But Leon hastily took some silver from his pocket and seized Emma’s
+arm. The beadle stood dumfounded, not able to understand this untimely
+munificence when there were still so many things for the stranger to
+see. So calling him back, he cried--
+
+“Sir! sir! The steeple! the steeple!”
+
+“No, thank you!” said Leon.
+
+“You are wrong, sir! It is four hundred and forty feet high, nine less
+than the great pyramid of Egypt. It is all cast; it--”
+
+Leon was fleeing, for it seemed to him that his love, that for nearly
+two hours now had become petrified in the church like the stones, would
+vanish like a vapour through that sort of truncated funnel, of oblong
+cage, of open chimney that rises so grotesquely from the cathedral like
+the extravagant attempt of some fantastic brazier.
+
+“But where are we going?” she said.
+
+Making no answer, he walked on with a rapid step; and Madame Bovary
+was already, dipping her finger in the holy water when behind them they
+heard a panting breath interrupted by the regular sound of a cane. Leon
+turned back.
+
+“Sir!”
+
+“What is it?”
+
+And he recognised the beadle, holding under his arms and balancing
+against his stomach some twenty large sewn volumes. They were works
+“which treated of the cathedral.”
+
+“Idiot!” growled Leon, rushing out of the church.
+
+A lad was playing about the close.
+
+“Go and get me a cab!”
+
+The child bounded off like a ball by the Rue Quatre-Vents; then they
+were alone a few minutes, face to face, and a little embarrassed.
+
+“Ah! Leon! Really--I don’t know--if I ought,” she whispered. Then with a
+more serious air, “Do you know, it is very improper--”
+
+“How so?” replied the clerk. “It is done at Paris.”
+
+And that, as an irresistible argument, decided her.
+
+Still the cab did not come. Leon was afraid she might go back into the
+church. At last the cab appeared.
+
+“At all events, go out by the north porch,” cried the beadle, who was
+left alone on the threshold, “so as to see the Resurrection, the Last
+Judgment, Paradise, King David, and the Condemned in Hell-flames.”
+
+“Where to, sir?” asked the coachman.
+
+“Where you like,” said Leon, forcing Emma into the cab.
+
+And the lumbering machine set out. It went down the Rue Grand-Pont,
+crossed the Place des Arts, the Quai Napoleon, the Pont Neuf, and
+stopped short before the statue of Pierre Corneille.
+
+“Go on,” cried a voice that came from within.
+
+The cab went on again, and as soon as it reached the Carrefour
+Lafayette, set off down-hill, and entered the station at a gallop.
+
+“No, straight on!” cried the same voice.
+
+The cab came out by the gate, and soon having reached the Cours, trotted
+quietly beneath the elm-trees. The coachman wiped his brow, put his
+leather hat between his knees, and drove his carriage beyond the side
+alley by the meadow to the margin of the waters.
+
+It went along by the river, along the towing-path paved with sharp
+pebbles, and for a long while in the direction of Oyssel, beyond the
+isles.
+
+But suddenly it turned with a dash across Quatremares, Sotteville, La
+Grande-Chaussee, the Rue d’Elbeuf, and made its third halt in front of
+the Jardin des Plantes.
+
+“Get on, will you?” cried the voice more furiously.
+
+And at once resuming its course, it passed by Saint-Sever, by the
+Quai’des Curandiers, the Quai aux Meules, once more over the bridge, by
+the Place du Champ de Mars, and behind the hospital gardens, where old
+men in black coats were walking in the sun along the terrace all green
+with ivy. It went up the Boulevard Bouvreuil, along the Boulevard
+Cauchoise, then the whole of Mont-Riboudet to the Deville hills.
+
+It came back; and then, without any fixed plan or direction, wandered
+about at hazard. The cab was seen at Saint-Pol, at Lescure, at Mont
+Gargan, at La Rougue-Marc and Place du Gaillardbois; in the Rue
+Maladrerie, Rue Dinanderie, before Saint-Romain, Saint-Vivien,
+Saint-Maclou, Saint-Nicaise--in front of the Customs, at the “Vieille
+Tour,” the “Trois Pipes,” and the Monumental Cemetery. From time to time
+the coachman, on his box cast despairing eyes at the public-houses.
+He could not understand what furious desire for locomotion urged these
+individuals never to wish to stop. He tried to now and then, and at
+once exclamations of anger burst forth behind him. Then he lashed his
+perspiring jades afresh, but indifferent to their jolting, running up
+against things here and there, not caring if he did, demoralised, and
+almost weeping with thirst, fatigue, and depression.
+
+And on the harbour, in the midst of the drays and casks, and in the
+streets, at the corners, the good folk opened large wonder-stricken
+eyes at this sight, so extraordinary in the provinces, a cab with blinds
+drawn, and which appeared thus constantly shut more closely than a tomb,
+and tossing about like a vessel.
+
+Once in the middle of the day, in the open country, just as the sun
+beat most fiercely against the old plated lanterns, a bared hand passed
+beneath the small blinds of yellow canvas, and threw out some scraps
+of paper that scattered in the wind, and farther off lighted like white
+butterflies on a field of red clover all in bloom.
+
+At about six o’clock the carriage stopped in a back street of the
+Beauvoisine Quarter, and a woman got out, who walked with her veil down,
+and without turning her head.
+
+
+
+Chapter Two
+
+On reaching the inn, Madame Bovary was surprised not to see the
+diligence. Hivert, who had waited for her fifty-three minutes, had at
+last started.
+
+Yet nothing forced her to go; but she had given her word that she would
+return that same evening. Moreover, Charles expected her, and in her
+heart she felt already that cowardly docility that is for some women at
+once the chastisement and atonement of adultery.
+
+She packed her box quickly, paid her bill, took a cab in the yard,
+hurrying on the driver, urging him on, every moment inquiring about
+the time and the miles traversed. He succeeded in catching up the
+“Hirondelle” as it neared the first houses of Quincampoix.
+
+Hardly was she seated in her corner than she closed her eyes, and opened
+them at the foot of the hill, when from afar she recognised Felicite,
+who was on the lookout in front of the farrier’s shop. Hivert pulled
+in his horses and, the servant, climbing up to the window, said
+mysteriously--
+
+“Madame, you must go at once to Monsieur Homais. It’s for something
+important.”
+
+The village was silent as usual. At the corner of the streets were small
+pink heaps that smoked in the air, for this was the time for jam-making,
+and everyone at Yonville prepared his supply on the same day. But in
+front of the chemist’s shop one might admire a far larger heap, and that
+surpassed the others with the superiority that a laboratory must have
+over ordinary stores, a general need over individual fancy.
+
+She went in. The large arm-chair was upset, and even the “Fanal de
+Rouen” lay on the ground, outspread between two pestles. She pushed open
+the lobby door, and in the middle of the kitchen, amid brown jars full
+of picked currants, of powdered sugar and lump sugar, of the scales on
+the table, and of the pans on the fire, she saw all the Homais, small
+and large, with aprons reaching to their chins, and with forks in their
+hands. Justin was standing up with bowed head, and the chemist was
+screaming--
+
+“Who told you to go and fetch it in the Capharnaum.”
+
+“What is it? What is the matter?”
+
+“What is it?” replied the druggist. “We are making preserves; they are
+simmering; but they were about to boil over, because there is too
+much juice, and I ordered another pan. Then he, from indolence, from
+laziness, went and took, hanging on its nail in my laboratory, the key
+of the Capharnaum.”
+
+It was thus the druggist called a small room under the leads, full of
+the utensils and the goods of his trade. He often spent long hours there
+alone, labelling, decanting, and doing up again; and he looked upon
+it not as a simple store, but as a veritable sanctuary, whence there
+afterwards issued, elaborated by his hands, all sorts of pills, boluses,
+infusions, lotions, and potions, that would bear far and wide his
+celebrity. No one in the world set foot there, and he respected it so,
+that he swept it himself. Finally, if the pharmacy, open to all comers,
+was the spot where he displayed his pride, the Capharnaum was the refuge
+where, egoistically concentrating himself, Homais delighted in the
+exercise of his predilections, so that Justin’s thoughtlessness seemed
+to him a monstrous piece of irreverence, and, redder than the currants,
+he repeated--
+
+“Yes, from the Capharnaum! The key that locks up the acids and caustic
+alkalies! To go and get a spare pan! a pan with a lid! and that I
+shall perhaps never use! Everything is of importance in the delicate
+operations of our art! But, devil take it! one must make distinctions,
+and not employ for almost domestic purposes that which is meant for
+pharmaceutical! It is as if one were to carve a fowl with a scalpel; as
+if a magistrate--”
+
+“Now be calm,” said Madame Homais.
+
+And Athalie, pulling at his coat, cried “Papa! papa!”
+
+“No, let me alone,” went on the druggist “let me alone, hang it! My
+word! One might as well set up for a grocer. That’s it! go it! respect
+nothing! break, smash, let loose the leeches, burn the mallow-paste,
+pickle the gherkins in the window jars, tear up the bandages!”
+
+“I thought you had--” said Emma.
+
+“Presently! Do you know to what you exposed yourself? Didn’t you see
+anything in the corner, on the left, on the third shelf? Speak, answer,
+articulate something.”
+
+“I--don’t--know,” stammered the young fellow.
+
+“Ah! you don’t know! Well, then, I do know! You saw a bottle of blue
+glass, sealed with yellow wax, that contains a white powder, on which I
+have even written ‘Dangerous!’ And do you know what is in it? Arsenic!
+And you go and touch it! You take a pan that was next to it!”
+
+“Next to it!” cried Madame Homais, clasping her hands. “Arsenic! You
+might have poisoned us all.”
+
+And the children began howling as if they already had frightful pains in
+their entrails.
+
+“Or poison a patient!” continued the druggist. “Do you want to see me
+in the prisoner’s dock with criminals, in a court of justice? To see
+me dragged to the scaffold? Don’t you know what care I take in managing
+things, although I am so thoroughly used to it? Often I am horrified
+myself when I think of my responsibility; for the Government persecutes
+us, and the absurd legislation that rules us is a veritable Damocles’
+sword over our heads.”
+
+Emma no longer dreamed of asking what they wanted her for, and the
+druggist went on in breathless phrases--
+
+“That is your return for all the kindness we have shown you! That is how
+you recompense me for the really paternal care that I lavish on you! For
+without me where would you be? What would you be doing? Who provides
+you with food, education, clothes, and all the means of figuring one day
+with honour in the ranks of society? But you must pull hard at the oar
+if you’re to do that, and get, as, people say, callosities upon your
+hands. Fabricando fit faber, age quod agis.*”
+
+     * The worker lives by working, do what he will.
+
+
+He was so exasperated he quoted Latin. He would have quoted Chinese
+or Greenlandish had he known those two languages, for he was in one
+of those crises in which the whole soul shows indistinctly what it
+contains, like the ocean, which, in the storm, opens itself from the
+seaweeds on its shores down to the sands of its abysses.
+
+And he went on--
+
+“I am beginning to repent terribly of having taken you up! I should
+certainly have done better to have left you to rot in your poverty and
+the dirt in which you were born. Oh, you’ll never be fit for anything
+but to herd animals with horns! You have no aptitude for science! You
+hardly know how to stick on a label! And there you are, dwelling with me
+snug as a parson, living in clover, taking your ease!”
+
+But Emma, turning to Madame Homais, “I was told to come here--”
+
+“Oh, dear me!” interrupted the good woman, with a sad air, “how am I to
+tell you? It is a misfortune!”
+
+She could not finish, the druggist was thundering--“Empty it! Clean it!
+Take it back! Be quick!”
+
+And seizing Justin by the collar of his blouse, he shook a book out of
+his pocket. The lad stooped, but Homais was the quicker, and, having
+picked up the volume, contemplated it with staring eyes and open mouth.
+
+“CONJUGAL--LOVE!” he said, slowly separating the two words. “Ah! very
+good! very good! very pretty! And illustrations! Oh, this is too much!”
+
+Madame Homais came forward.
+
+“No, do not touch it!”
+
+The children wanted to look at the pictures.
+
+“Leave the room,” he said imperiously; and they went out.
+
+First he walked up and down with the open volume in his hand, rolling
+his eyes, choking, tumid, apoplectic. Then he came straight to his
+pupil, and, planting himself in front of him with crossed arms--
+
+“Have you every vice, then, little wretch? Take care! you are on a
+downward path. Did not you reflect that this infamous book might fall
+in the hands of my children, kindle a spark in their minds, tarnish the
+purity of Athalie, corrupt Napoleon. He is already formed like a man.
+Are you quite sure, anyhow, that they have not read it? Can you certify
+to me--”
+
+“But really, sir,” said Emma, “you wished to tell me--”
+
+“Ah, yes! madame. Your father-in-law is dead.”
+
+In fact, Monsieur Bovary senior had expired the evening before suddenly
+from an attack of apoplexy as he got up from table, and by way of
+greater precaution, on account of Emma’s sensibility, Charles had begged
+Homais to break the horrible news to her gradually. Homais had thought
+over his speech; he had rounded, polished it, made it rhythmical; it was
+a masterpiece of prudence and transitions, of subtle turns and delicacy;
+but anger had got the better of rhetoric.
+
+Emma, giving up all chance of hearing any details, left the pharmacy;
+for Monsieur Homais had taken up the thread of his vituperations.
+However, he was growing calmer, and was now grumbling in a paternal tone
+whilst he fanned himself with his skull-cap.
+
+“It is not that I entirely disapprove of the work. Its author was a
+doctor! There are certain scientific points in it that it is not ill a
+man should know, and I would even venture to say that a man must know.
+But later--later! At any rate, not till you are man yourself and your
+temperament is formed.”
+
+When Emma knocked at the door. Charles, who was waiting for her, came
+forward with open arms and said to her with tears in his voice--
+
+“Ah! my dear!”
+
+And he bent over her gently to kiss her. But at the contact of his lips
+the memory of the other seized her, and she passed her hand over her
+face shuddering.
+
+But she made answer, “Yes, I know, I know!”
+
+He showed her the letter in which his mother told the event without any
+sentimental hypocrisy. She only regretted her husband had not received
+the consolations of religion, as he had died at Daudeville, in the
+street, at the door of a cafe after a patriotic dinner with some
+ex-officers.
+
+Emma gave him back the letter; then at dinner, for appearance’s sake,
+she affected a certain repugnance. But as he urged her to try, she
+resolutely began eating, while Charles opposite her sat motionless in a
+dejected attitude.
+
+Now and then he raised his head and gave her a long look full of
+distress. Once he sighed, “I should have liked to see him again!”
+
+She was silent. At last, understanding that she must say something, “How
+old was your father?” she asked.
+
+“Fifty-eight.”
+
+“Ah!”
+
+And that was all.
+
+A quarter of an hour after he added, “My poor mother! what will become
+of her now?”
+
+She made a gesture that signified she did not know. Seeing her so
+taciturn, Charles imagined her much affected, and forced himself to say
+nothing, not to reawaken this sorrow which moved him. And, shaking off
+his own--
+
+“Did you enjoy yourself yesterday?” he asked.
+
+“Yes.”
+
+When the cloth was removed, Bovary did not rise, nor did Emma; and as
+she looked at him, the monotony of the spectacle drove little by little
+all pity from her heart. He seemed to her paltry, weak, a cipher--in
+a word, a poor thing in every way. How to get rid of him? What an
+interminable evening! Something stupefying like the fumes of opium
+seized her.
+
+They heard in the passage the sharp noise of a wooden leg on the boards.
+It was Hippolyte bringing back Emma’s luggage. In order to put it down
+he described painfully a quarter of a circle with his stump.
+
+“He doesn’t even remember any more about it,” she thought, looking at
+the poor devil, whose coarse red hair was wet with perspiration.
+
+Bovary was searching at the bottom of his purse for a centime, and
+without appearing to understand all there was of humiliation for him
+in the mere presence of this man, who stood there like a personified
+reproach to his incurable incapacity.
+
+“Hallo! you’ve a pretty bouquet,” he said, noticing Leon’s violets on
+the chimney.
+
+“Yes,” she replied indifferently; “it’s a bouquet I bought just now from
+a beggar.”
+
+Charles picked up the flowers, and freshening his eyes, red with tears,
+against them, smelt them delicately.
+
+She took them quickly from his hand and put them in a glass of water.
+
+The next day Madame Bovary senior arrived. She and her son wept much.
+Emma, on the pretext of giving orders, disappeared. The following day
+they had a talk over the mourning. They went and sat down with their
+workboxes by the waterside under the arbour.
+
+Charles was thinking of his father, and was surprised to feel so much
+affection for this man, whom till then he had thought he cared little
+about. Madame Bovary senior was thinking of her husband. The worst
+days of the past seemed enviable to her. All was forgotten beneath the
+instinctive regret of such a long habit, and from time to time whilst
+she sewed, a big tear rolled along her nose and hung suspended there a
+moment. Emma was thinking that it was scarcely forty-eight hours since
+they had been together, far from the world, all in a frenzy of joy, and
+not having eyes enough to gaze upon each other. She tried to recall the
+slightest details of that past day. But the presence of her husband and
+mother-in-law worried her. She would have liked to hear nothing, to see
+nothing, so as not to disturb the meditation on her love, that, do what
+she would, became lost in external sensations.
+
+She was unpicking the lining of a dress, and the strips were scattered
+around her. Madame Bovary senior was plying her scissor without looking
+up, and Charles, in his list slippers and his old brown surtout that he
+used as a dressing-gown, sat with both hands in his pockets, and did not
+speak either; near them Berthe, in a little white pinafore, was raking
+sand in the walks with her spade. Suddenly she saw Monsieur Lheureux,
+the linendraper, come in through the gate.
+
+He came to offer his services “under the sad circumstances.” Emma
+answered that she thought she could do without. The shopkeeper was not
+to be beaten.
+
+“I beg your pardon,” he said, “but I should like to have a private talk
+with you.” Then in a low voice, “It’s about that affair--you know.”
+
+Charles crimsoned to his ears. “Oh, yes! certainly.” And in his
+confusion, turning to his wife, “Couldn’t you, my darling?”
+
+She seemed to understand him, for she rose; and Charles said to his
+mother, “It is nothing particular. No doubt, some household trifle.” He
+did not want her to know the story of the bill, fearing her reproaches.
+
+As soon as they were alone, Monsieur Lheureux in sufficiently clear
+terms began to congratulate Emma on the inheritance, then to talk of
+indifferent matters, of the espaliers, of the harvest, and of his own
+health, which was always so-so, always having ups and downs. In fact, he
+had to work devilish hard, although he didn’t make enough, in spite of
+all people said, to find butter for his bread.
+
+Emma let him talk on. She had bored herself so prodigiously the last two
+days.
+
+“And so you’re quite well again?” he went on. “Ma foi! I saw your
+husband in a sad state. He’s a good fellow, though we did have a little
+misunderstanding.”
+
+She asked what misunderstanding, for Charles had said nothing of the
+dispute about the goods supplied to her.
+
+“Why, you know well enough,” cried Lheureux. “It was about your little
+fancies--the travelling trunks.”
+
+He had drawn his hat over his eyes, and, with his hands behind his
+back, smiling and whistling, he looked straight at her in an unbearable
+manner. Did he suspect anything?
+
+She was lost in all kinds of apprehensions. At last, however, he went
+on--
+
+“We made it up, all the same, and I’ve come again to propose another
+arrangement.”
+
+This was to renew the bill Bovary had signed. The doctor, of course,
+would do as he pleased; he was not to trouble himself, especially just
+now, when he would have a lot of worry. “And he would do better to give
+it over to someone else--to you, for example. With a power of attorney
+it could be easily managed, and then we (you and I) would have our
+little business transactions together.”
+
+She did not understand. He was silent. Then, passing to his trade,
+Lheureux declared that madame must require something. He would send her
+a black barege, twelve yards, just enough to make a gown.
+
+“The one you’ve on is good enough for the house, but you want another
+for calls. I saw that the very moment that I came in. I’ve the eye of an
+American!”
+
+He did not send the stuff; he brought it. Then he came again to measure
+it; he came again on other pretexts, always trying to make himself
+agreeable, useful, “enfeoffing himself,” as Homais would have said, and
+always dropping some hint to Emma about the power of attorney. He never
+mentioned the bill; she did not think of it. Charles, at the beginning
+of her convalescence, had certainly said something about it to her,
+but so many emotions had passed through her head that she no longer
+remembered it. Besides, she took care not to talk of any money
+questions. Madame Bovary seemed surprised at this, and attributed the
+change in her ways to the religious sentiments she had contracted during
+her illness.
+
+But as soon as she was gone, Emma greatly astounded Bovary by her
+practical good sense. It would be necessary to make inquiries, to look
+into mortgages, and see if there were any occasion for a sale by auction
+or a liquidation. She quoted technical terms casually, pronounced the
+grand words of order, the future, foresight, and constantly exaggerated
+the difficulties of settling his father’s affairs so much, that at last
+one day she showed him the rough draft of a power of attorney to manage
+and administer his business, arrange all loans, sign and endorse all
+bills, pay all sums, etc. She had profited by Lheureux’s lessons.
+Charles naively asked her where this paper came from.
+
+“Monsieur Guillaumin”; and with the utmost coolness she added, “I don’t
+trust him overmuch. Notaries have such a bad reputation. Perhaps we
+ought to consult--we only know--no one.”
+
+“Unless Leon--” replied Charles, who was reflecting. But it was
+difficult to explain matters by letter. Then she offered to make the
+journey, but he thanked her. She insisted. It was quite a contest of
+mutual consideration. At last she cried with affected waywardness--
+
+“No, I will go!”
+
+“How good you are!” he said, kissing her forehead.
+
+The next morning she set out in the “Hirondelle” to go to Rouen to
+consult Monsieur Leon, and she stayed there three days.
+
+
+
+Chapter Three
+
+They were three full, exquisite days--a true honeymoon. They were at
+the Hotel-de-Boulogne, on the harbour; and they lived there, with drawn
+blinds and closed doors, with flowers on the floor, and iced syrups were
+brought them early in the morning.
+
+Towards evening they took a covered boat and went to dine on one of the
+islands. It was the time when one hears by the side of the dockyard the
+caulking-mallets sounding against the hull of vessels. The smoke of
+the tar rose up between the trees; there were large fatty drops on the
+water, undulating in the purple colour of the sun, like floating plaques
+of Florentine bronze.
+
+They rowed down in the midst of moored boats, whose long oblique cables
+grazed lightly against the bottom of the boat. The din of the town
+gradually grew distant; the rolling of carriages, the tumult of voices,
+the yelping of dogs on the decks of vessels. She took off her bonnet,
+and they landed on their island.
+
+They sat down in the low-ceilinged room of a tavern, at whose door hung
+black nets. They ate fried smelts, cream and cherries. They lay down
+upon the grass; they kissed behind the poplars; and they would fain,
+like two Robinsons, have lived for ever in this little place, which
+seemed to them in their beatitude the most magnificent on earth. It was
+not the first time that they had seen trees, a blue sky, meadows; that
+they had heard the water flowing and the wind blowing in the leaves;
+but, no doubt, they had never admired all this, as if Nature had
+not existed before, or had only begun to be beautiful since the
+gratification of their desires.
+
+At night they returned. The boat glided along the shores of the islands.
+They sat at the bottom, both hidden by the shade, in silence. The square
+oars rang in the iron thwarts, and, in the stillness, seemed to mark
+time, like the beating of a metronome, while at the stern the rudder
+that trailed behind never ceased its gentle splash against the water.
+
+Once the moon rose; they did not fail to make fine phrases, finding the
+orb melancholy and full of poetry. She even began to sing--
+
+“One night, do you remember, we were sailing,” etc.
+
+Her musical but weak voice died away along the waves, and the winds
+carried off the trills that Leon heard pass like the flapping of wings
+about him.
+
+She was opposite him, leaning against the partition of the shallop,
+through one of whose raised blinds the moon streamed in. Her black
+dress, whose drapery spread out like a fan, made her seem more slender,
+taller. Her head was raised, her hands clasped, her eyes turned towards
+heaven. At times the shadow of the willows hid her completely; then she
+reappeared suddenly, like a vision in the moonlight.
+
+Leon, on the floor by her side, found under his hand a ribbon of scarlet
+silk. The boatman looked at it, and at last said--
+
+“Perhaps it belongs to the party I took out the other day. A lot
+of jolly folk, gentlemen and ladies, with cakes, champagne,
+cornets--everything in style! There was one especially, a tall handsome
+man with small moustaches, who was that funny! And they all kept saying,
+‘Now tell us something, Adolphe--Dolpe,’ I think.”
+
+She shivered.
+
+“You are in pain?” asked Leon, coming closer to her.
+
+“Oh, it’s nothing! No doubt, it is only the night air.”
+
+“And who doesn’t want for women, either,” softly added the sailor,
+thinking he was paying the stranger a compliment.
+
+Then, spitting on his hands, he took the oars again.
+
+Yet they had to part. The adieux were sad. He was to send his letters to
+Mere Rollet, and she gave him such precise instructions about a double
+envelope that he admired greatly her amorous astuteness.
+
+“So you can assure me it is all right?” she said with her last kiss.
+
+“Yes, certainly.”
+
+“But why,” he thought afterwards as he came back through the streets
+alone, “is she so very anxious to get this power of attorney?”
+
+
+
+Chapter Four
+
+Leon soon put on an air of superiority before his comrades, avoided
+their company, and completely neglected his work.
+
+He waited for her letters; he re-read them; he wrote to her. He called
+her to mind with all the strength of his desires and of his memories.
+Instead of lessening with absence, this longing to see her again grew,
+so that at last on Saturday morning he escaped from his office.
+
+When, from the summit of the hill, he saw in the valley below the
+church-spire with its tin flag swinging in the wind, he felt that
+delight mingled with triumphant vanity and egoistic tenderness that
+millionaires must experience when they come back to their native
+village.
+
+He went rambling round her house. A light was burning in the kitchen. He
+watched for her shadow behind the curtains, but nothing appeared.
+
+Mere Lefrancois, when she saw him, uttered many exclamations. She
+thought he “had grown and was thinner,” while Artemise, on the contrary,
+thought him stouter and darker.
+
+He dined in the little room as of yore, but alone, without the
+tax-gatherer; for Binet, tired of waiting for the “Hirondelle,” had
+definitely put forward his meal one hour, and now he dined punctually at
+five, and yet he declared usually the rickety old concern “was late.”
+
+Leon, however, made up his mind, and knocked at the doctor’s door.
+Madame was in her room, and did not come down for a quarter of an hour.
+The doctor seemed delighted to see him, but he never stirred out that
+evening, nor all the next day.
+
+He saw her alone in the evening, very late, behind the garden in the
+lane; in the lane, as she had the other one! It was a stormy night, and
+they talked under an umbrella by lightning flashes.
+
+Their separation was becoming intolerable. “I would rather die!” said
+Emma. She was writhing in his arms, weeping. “Adieu! adieu! When shall I
+see you again?”
+
+They came back again to embrace once more, and it was then that
+she promised him to find soon, by no matter what means, a regular
+opportunity for seeing one another in freedom at least once a week. Emma
+never doubted she should be able to do this. Besides, she was full of
+hope. Some money was coming to her.
+
+On the strength of it she bought a pair of yellow curtains with large
+stripes for her room, whose cheapness Monsieur Lheureux had commended;
+she dreamed of getting a carpet, and Lheureux, declaring that it wasn’t
+“drinking the sea,” politely undertook to supply her with one. She could
+no longer do without his services. Twenty times a day she sent for him,
+and he at once put by his business without a murmur. People could not
+understand either why Mere Rollet breakfasted with her every day, and
+even paid her private visits.
+
+It was about this time, that is to say, the beginning of winter, that
+she seemed seized with great musical fervour.
+
+One evening when Charles was listening to her, she began the same piece
+four times over, each time with much vexation, while he, not noticing
+any difference, cried--
+
+“Bravo! very goodl You are wrong to stop. Go on!”
+
+“Oh, no; it is execrable! My fingers are quite rusty.”
+
+The next day he begged her to play him something again.
+
+“Very well; to please you!”
+
+And Charles confessed she had gone off a little. She played wrong notes
+and blundered; then, stopping short--
+
+“Ah! it is no use. I ought to take some lessons; but--” She bit her lips
+and added, “Twenty francs a lesson, that’s too dear!”
+
+“Yes, so it is--rather,” said Charles, giggling stupidly. “But it seems
+to me that one might be able to do it for less; for there are artists of
+no reputation, and who are often better than the celebrities.”
+
+“Find them!” said Emma.
+
+The next day when he came home he looked at her shyly, and at last could
+no longer keep back the words.
+
+“How obstinate you are sometimes! I went to Barfucheres to-day. Well,
+Madame Liegard assured me that her three young ladies who are at
+La Misericorde have lessons at fifty sous apiece, and that from an
+excellent mistress!”
+
+She shrugged her shoulders and did not open her piano again. But when
+she passed by it (if Bovary were there), she sighed--
+
+“Ah! my poor piano!”
+
+And when anyone came to see her, she did not fail to inform them she
+had given up music, and could not begin again now for important reasons.
+Then people commiserated her--
+
+“What a pity! she had so much talent!”
+
+They even spoke to Bovary about it. They put him to shame, and
+especially the chemist.
+
+“You are wrong. One should never let any of the faculties of nature lie
+fallow. Besides, just think, my good friend, that by inducing madame to
+study; you are economising on the subsequent musical education of
+your child. For my own part, I think that mothers ought themselves to
+instruct their children. That is an idea of Rousseau’s, still rather
+new perhaps, but that will end by triumphing, I am certain of it, like
+mothers nursing their own children and vaccination.”
+
+So Charles returned once more to this question of the piano. Emma
+replied bitterly that it would be better to sell it. This poor piano,
+that had given her vanity so much satisfaction--to see it go was to
+Bovary like the indefinable suicide of a part of herself.
+
+“If you liked,” he said, “a lesson from time to time, that wouldn’t
+after all be very ruinous.”
+
+“But lessons,” she replied, “are only of use when followed up.”
+
+And thus it was she set about obtaining her husband’s permission to go
+to town once a week to see her lover. At the end of a month she was even
+considered to have made considerable progress.
+
+
+
+Chapter Five
+
+She went on Thursdays. She got up and dressed silently, in order not to
+awaken Charles, who would have made remarks about her getting ready too
+early. Next she walked up and down, went to the windows, and looked out
+at the Place. The early dawn was broadening between the pillars of the
+market, and the chemist’s shop, with the shutters still up, showed in
+the pale light of the dawn the large letters of his signboard.
+
+When the clock pointed to a quarter past seven, she went off to the
+“Lion d’Or,” whose door Artemise opened yawning. The girl then made
+up the coals covered by the cinders, and Emma remained alone in the
+kitchen. Now and again she went out. Hivert was leisurely harnessing his
+horses, listening, moreover, to Mere Lefrancois, who, passing her head
+and nightcap through a grating, was charging him with commissions and
+giving him explanations that would have confused anyone else. Emma kept
+beating the soles of her boots against the pavement of the yard.
+
+At last, when he had eaten his soup, put on his cloak, lighted his pipe,
+and grasped his whip, he calmly installed himself on his seat.
+
+The “Hirondelle” started at a slow trot, and for about a mile stopped
+here and there to pick up passengers who waited for it, standing at the
+border of the road, in front of their yard gates.
+
+Those who had secured seats the evening before kept it waiting; some
+even were still in bed in their houses. Hivert called, shouted, swore;
+then he got down from his seat and went and knocked loudly at the doors.
+The wind blew through the cracked windows.
+
+The four seats, however, filled up. The carriage rolled off; rows of
+apple-trees followed one upon another, and the road between its two long
+ditches, full of yellow water, rose, constantly narrowing towards the
+horizon.
+
+Emma knew it from end to end; she knew that after a meadow there was
+a sign-post, next an elm, a barn, or the hut of a lime-kiln tender.
+Sometimes even, in the hope of getting some surprise, she shut her eyes,
+but she never lost the clear perception of the distance to be traversed.
+
+At last the brick houses began to follow one another more closely, the
+earth resounded beneath the wheels, the “Hirondelle” glided between the
+gardens, where through an opening one saw statues, a periwinkle plant,
+clipped yews, and a swing. Then on a sudden the town appeared. Sloping
+down like an amphitheatre, and drowned in the fog, it widened out
+beyond the bridges confusedly. Then the open country spread away with
+a monotonous movement till it touched in the distance the vague line of
+the pale sky. Seen thus from above, the whole landscape looked immovable
+as a picture; the anchored ships were massed in one corner, the river
+curved round the foot of the green hills, and the isles, oblique in
+shape, lay on the water, like large, motionless, black fishes. The
+factory chimneys belched forth immense brown fumes that were blown away
+at the top. One heard the rumbling of the foundries, together with the
+clear chimes of the churches that stood out in the mist. The leafless
+trees on the boulevards made violet thickets in the midst of the
+houses, and the roofs, all shining with the rain, threw back unequal
+reflections, according to the height of the quarters in which they were.
+Sometimes a gust of wind drove the clouds towards the Saint Catherine
+hills, like aerial waves that broke silently against a cliff.
+
+A giddiness seemed to her to detach itself from this mass of existence,
+and her heart swelled as if the hundred and twenty thousand souls that
+palpitated there had all at once sent into it the vapour of the passions
+she fancied theirs. Her love grew in the presence of this vastness, and
+expanded with tumult to the vague murmurings that rose towards her. She
+poured it out upon the square, on the walks, on the streets, and the
+old Norman city outspread before her eyes as an enormous capital, as a
+Babylon into which she was entering. She leant with both hands against
+the window, drinking in the breeze; the three horses galloped, the
+stones grated in the mud, the diligence rocked, and Hivert, from afar,
+hailed the carts on the road, while the bourgeois who had spent the
+night at the Guillaume woods came quietly down the hill in their little
+family carriages.
+
+They stopped at the barrier; Emma undid her overshoes, put on other
+gloves, rearranged her shawl, and some twenty paces farther she got down
+from the “Hirondelle.”
+
+The town was then awakening. Shop-boys in caps were cleaning up the
+shop-fronts, and women with baskets against their hips, at intervals
+uttered sonorous cries at the corners of streets. She walked with
+downcast eyes, close to the walls, and smiling with pleasure under her
+lowered black veil.
+
+For fear of being seen, she did not usually take the most direct road.
+She plunged into dark alleys, and, all perspiring, reached the bottom
+of the Rue Nationale, near the fountain that stands there. It is the
+quarter for theatres, public-houses, and whores. Often a cart would
+pass near her, bearing some shaking scenery. Waiters in aprons were
+sprinkling sand on the flagstones between green shrubs. It all smelt of
+absinthe, cigars, and oysters.
+
+She turned down a street; she recognised him by his curling hair that
+escaped from beneath his hat.
+
+Leon walked along the pavement. She followed him to the hotel. He went
+up, opened the door, entered--What an embrace!
+
+Then, after the kisses, the words gushed forth. They told each other the
+sorrows of the week, the presentiments, the anxiety for the letters; but
+now everything was forgotten; they gazed into each other’s faces with
+voluptuous laughs, and tender names.
+
+The bed was large, of mahogany, in the shape of a boat. The curtains
+were in red levantine, that hung from the ceiling and bulged out too
+much towards the bell-shaped bedside; and nothing in the world was so
+lovely as her brown head and white skin standing out against this purple
+colour, when, with a movement of shame, she crossed her bare arms,
+hiding her face in her hands.
+
+The warm room, with its discreet carpet, its gay ornaments, and its
+calm light, seemed made for the intimacies of passion. The curtain-rods,
+ending in arrows, their brass pegs, and the great balls of the fire-dogs
+shone suddenly when the sun came in. On the chimney between the
+candelabra there were two of those pink shells in which one hears the
+murmur of the sea if one holds them to the ear.
+
+How they loved that dear room, so full of gaiety, despite its rather
+faded splendour! They always found the furniture in the same place, and
+sometimes hairpins, that she had forgotten the Thursday before, under
+the pedestal of the clock. They lunched by the fireside on a little
+round table, inlaid with rosewood. Emma carved, put bits on his plate
+with all sorts of coquettish ways, and she laughed with a sonorous and
+libertine laugh when the froth of the champagne ran over from the
+glass to the rings on her fingers. They were so completely lost in
+the possession of each other that they thought themselves in their
+own house, and that they would live there till death, like two spouses
+eternally young. They said “our room,” “our carpet,” she even said “my
+slippers,” a gift of Leon’s, a whim she had had. They were pink satin,
+bordered with swansdown. When she sat on his knees, her leg, then too
+short, hung in the air, and the dainty shoe, that had no back to it, was
+held only by the toes to her bare foot.
+
+He for the first time enjoyed the inexpressible delicacy of feminine
+refinements. He had never met this grace of language, this reserve of
+clothing, these poses of the weary dove. He admired the exaltation of
+her soul and the lace on her petticoat. Besides, was she not “a lady”
+ and a married woman--a real mistress, in fine?
+
+By the diversity of her humour, in turn mystical or mirthful, talkative,
+taciturn, passionate, careless, she awakened in him a thousand desires,
+called up instincts or memories. She was the mistress of all the novels,
+the heroine of all the dramas, the vague “she” of all the volumes
+of verse. He found again on her shoulder the amber colouring of the
+“Odalisque Bathing”; she had the long waist of feudal chatelaines, and
+she resembled the “Pale Woman of Barcelona.” But above all she was the
+Angel!
+
+Often looking at her, it seemed to him that his soul, escaping towards
+her, spread like a wave about the outline of her head, and descended
+drawn down into the whiteness of her breast. He knelt on the ground
+before her, and with both elbows on her knees looked at her with a
+smile, his face upturned.
+
+She bent over him, and murmured, as if choking with intoxication--
+
+“Oh, do not move! do not speak! look at me! Something so sweet comes
+from your eyes that helps me so much!”
+
+She called him “child.” “Child, do you love me?”
+
+And she did not listen for his answer in the haste of her lips that
+fastened to his mouth.
+
+On the clock there was a bronze cupid, who smirked as he bent his arm
+beneath a golden garland. They had laughed at it many a time, but when
+they had to part everything seemed serious to them.
+
+Motionless in front of each other, they kept repeating, “Till Thursday,
+till Thursday.”
+
+Suddenly she seized his head between her hands, kissed him hurriedly on
+the forehead, crying, “Adieu!” and rushed down the stairs.
+
+She went to a hairdresser’s in the Rue de la Comedie to have her hair
+arranged. Night fell; the gas was lighted in the shop. She heard the
+bell at the theatre calling the mummers to the performance, and she saw,
+passing opposite, men with white faces and women in faded gowns going in
+at the stage-door.
+
+It was hot in the room, small, and too low where the stove was hissing
+in the midst of wigs and pomades. The smell of the tongs, together with
+the greasy hands that handled her head, soon stunned her, and she dozed
+a little in her wrapper. Often, as he did her hair, the man offered her
+tickets for a masked ball.
+
+Then she went away. She went up the streets; reached the Croix-Rouge,
+put on her overshoes, that she had hidden in the morning under the seat,
+and sank into her place among the impatient passengers. Some got out
+at the foot of the hill. She remained alone in the carriage. At every
+turning all the lights of the town were seen more and more completely,
+making a great luminous vapour about the dim houses. Emma knelt on the
+cushions and her eyes wandered over the dazzling light. She sobbed;
+called on Leon, sent him tender words and kisses lost in the wind.
+
+On the hillside a poor devil wandered about with his stick in the midst
+of the diligences. A mass of rags covered his shoulders, and an old
+staved-in beaver, turned out like a basin, hid his face; but when he
+took it off he discovered in the place of eyelids empty and bloody
+orbits. The flesh hung in red shreds, and there flowed from it liquids
+that congealed into green scale down to the nose, whose black nostrils
+sniffed convulsively. To speak to you he threw back his head with an
+idiotic laugh; then his bluish eyeballs, rolling constantly, at the
+temples beat against the edge of the open wound. He sang a little song
+as he followed the carriages--
+
+“Maids an the warmth of a summer day Dream of love, and of love always”
+
+And all the rest was about birds and sunshine and green leaves.
+
+Sometimes he appeared suddenly behind Emma, bareheaded, and she drew
+back with a cry. Hivert made fun of him. He would advise him to get a
+booth at the Saint Romain fair, or else ask him, laughing, how his young
+woman was.
+
+Often they had started when, with a sudden movement, his hat entered the
+diligence through the small window, while he clung with his other arm
+to the footboard, between the wheels splashing mud. His voice, feeble
+at first and quavering, grew sharp; it resounded in the night like the
+indistinct moan of a vague distress; and through the ringing of the
+bells, the murmur of the trees, and the rumbling of the empty vehicle,
+it had a far-off sound that disturbed Emma. It went to the bottom of
+her soul, like a whirlwind in an abyss, and carried her away into the
+distances of a boundless melancholy. But Hivert, noticing a weight
+behind, gave the blind man sharp cuts with his whip. The thong lashed
+his wounds, and he fell back into the mud with a yell. Then the
+passengers in the “Hirondelle” ended by falling asleep, some with open
+mouths, others with lowered chins, leaning against their neighbour’s
+shoulder, or with their arm passed through the strap, oscillating
+regularly with the jolting of the carriage; and the reflection of the
+lantern swinging without, on the crupper of the wheeler; penetrating
+into the interior through the chocolate calico curtains, threw
+sanguineous shadows over all these motionless people. Emma, drunk with
+grief, shivered in her clothes, feeling her feet grow colder and colder,
+and death in her soul.
+
+Charles at home was waiting for her; the “Hirondelle” was always late
+on Thursdays. Madame arrived at last, and scarcely kissed the child. The
+dinner was not ready. No matter! She excused the servant. This girl now
+seemed allowed to do just as she liked.
+
+Often her husband, noting her pallor, asked if she were unwell.
+
+“No,” said Emma.
+
+“But,” he replied, “you seem so strange this evening.”
+
+“Oh, it’s nothing! nothing!”
+
+There were even days when she had no sooner come in than she went up to
+her room; and Justin, happening to be there, moved about noiselessly,
+quicker at helping her than the best of maids. He put the matches
+ready, the candlestick, a book, arranged her nightgown, turned back the
+bedclothes.
+
+“Come!” said she, “that will do. Now you can go.”
+
+For he stood there, his hands hanging down and his eyes wide open, as if
+enmeshed in the innumerable threads of a sudden reverie.
+
+The following day was frightful, and those that came after still more
+unbearable, because of her impatience to once again seize her happiness;
+an ardent lust, inflamed by the images of past experience, and that
+burst forth freely on the seventh day beneath Leon’s caresses. His
+ardours were hidden beneath outbursts of wonder and gratitude. Emma
+tasted this love in a discreet, absorbed fashion, maintained it by all
+the artifices of her tenderness, and trembled a little lest it should be
+lost later on.
+
+She often said to him, with her sweet, melancholy voice--
+
+“Ah! you too, you will leave me! You will marry! You will be like all
+the others.”
+
+He asked, “What others?”
+
+“Why, like all men,” she replied. Then added, repulsing him with a
+languid movement--
+
+“You are all evil!”
+
+One day, as they were talking philosophically of earthly disillusions,
+to experiment on his jealousy, or yielding, perhaps, to an over-strong
+need to pour out her heart, she told him that formerly, before him, she
+had loved someone.
+
+“Not like you,” she went on quickly, protesting by the head of her child
+that “nothing had passed between them.”
+
+The young man believed her, but none the less questioned her to find out
+what he was.
+
+“He was a ship’s captain, my dear.”
+
+Was this not preventing any inquiry, and, at the same time, assuming a
+higher ground through this pretended fascination exercised over a man
+who must have been of warlike nature and accustomed to receive homage?
+
+The clerk then felt the lowliness of his position; he longed for
+epaulettes, crosses, titles. All that would please her--he gathered that
+from her spendthrift habits.
+
+Emma nevertheless concealed many of these extravagant fancies, such as
+her wish to have a blue tilbury to drive into Rouen, drawn by an English
+horse and driven by a groom in top-boots. It was Justin who had inspired
+her with this whim, by begging her to take him into her service as
+valet-de-chambre*, and if the privation of it did not lessen the
+pleasure of her arrival at each rendezvous, it certainly augmented the
+bitterness of the return.
+
+     * Manservant.
+
+
+Often, when they talked together of Paris, she ended by murmuring, “Ah!
+how happy we should be there!”
+
+“Are we not happy?” gently answered the young man passing his hands over
+her hair.
+
+“Yes, that is true,” she said. “I am mad. Kiss me!”
+
+To her husband she was more charming than ever. She made him
+pistachio-creams, and played him waltzes after dinner. So he thought
+himself the most fortunate of men and Emma was without uneasiness, when,
+one evening suddenly he said--
+
+“It is Mademoiselle Lempereur, isn’t it, who gives you lessons?”
+
+“Yes.”
+
+“Well, I saw her just now,” Charles went on, “at Madame Liegeard’s. I
+spoke to her about you, and she doesn’t know you.”
+
+This was like a thunderclap. However, she replied quite naturally--
+
+“Ah! no doubt she forgot my name.”
+
+“But perhaps,” said the doctor, “there are several Demoiselles Lempereur
+at Rouen who are music-mistresses.”
+
+“Possibly!” Then quickly--“But I have my receipts here. See!”
+
+And she went to the writing-table, ransacked all the drawers, rummaged
+the papers, and at last lost her head so completely that Charles
+earnestly begged her not to take so much trouble about those wretched
+receipts.
+
+“Oh, I will find them,” she said.
+
+And, in fact, on the following Friday, as Charles was putting on one
+of his boots in the dark cabinet where his clothes were kept, he felt
+a piece of paper between the leather and his sock. He took it out and
+read--
+
+“Received, for three months’ lessons and several pieces of music, the
+sum of sixty-three francs.--Felicie Lempereur, professor of music.”
+
+“How the devil did it get into my boots?”
+
+“It must,” she replied, “have fallen from the old box of bills that is
+on the edge of the shelf.”
+
+From that moment her existence was but one long tissue of lies, in which
+she enveloped her love as in veils to hide it. It was a want, a mania,
+a pleasure carried to such an extent that if she said she had the day
+before walked on the right side of a road, one might know she had taken
+the left.
+
+One morning, when she had gone, as usual, rather lightly clothed, it
+suddenly began to snow, and as Charles was watching the weather from the
+window, he caught sight of Monsieur Bournisien in the chaise of Monsieur
+Tuvache, who was driving him to Rouen. Then he went down to give the
+priest a thick shawl that he was to hand over to Emma as soon as he
+reached the “Croix-Rouge.” When he got to the inn, Monsieur Bournisien
+asked for the wife of the Yonville doctor. The landlady replied that
+she very rarely came to her establishment. So that evening, when he
+recognised Madame Bovary in the “Hirondelle,” the cure told her his
+dilemma, without, however, appearing to attach much importance to it,
+for he began praising a preacher who was doing wonders at the Cathedral,
+and whom all the ladies were rushing to hear.
+
+Still, if he did not ask for any explanation, others, later on, might
+prove less discreet. So she thought well to get down each time at the
+“Croix-Rouge,” so that the good folk of her village who saw her on the
+stairs should suspect nothing.
+
+One day, however, Monsieur Lheureux met her coming out of the Hotel
+de Boulogne on Leon’s arm; and she was frightened, thinking he would
+gossip. He was not such a fool. But three days after he came to her
+room, shut the door, and said, “I must have some money.”
+
+She declared she could not give him any. Lheureux burst into
+lamentations and reminded her of all the kindnesses he had shown her.
+
+In fact, of the two bills signed by Charles, Emma up to the present had
+paid only one. As to the second, the shopkeeper, at her request, had
+consented to replace it by another, which again had been renewed for a
+long date. Then he drew from his pocket a list of goods not paid for; to
+wit, the curtains, the carpet, the material for the armchairs, several
+dresses, and divers articles of dress, the bills for which amounted to
+about two thousand francs.
+
+She bowed her head. He went on--
+
+“But if you haven’t any ready money, you have an estate.” And he
+reminded her of a miserable little hovel situated at Barneville, near
+Aumale, that brought in almost nothing. It had formerly been part of a
+small farm sold by Monsieur Bovary senior; for Lheureux knew everything,
+even to the number of acres and the names of the neighbours.
+
+“If I were in your place,” he said, “I should clear myself of my debts,
+and have money left over.”
+
+She pointed out the difficulty of getting a purchaser. He held out the
+hope of finding one; but she asked him how she should manage to sell it.
+
+“Haven’t you your power of attorney?” he replied.
+
+The phrase came to her like a breath of fresh air. “Leave me the bill,”
+ said Emma.
+
+“Oh, it isn’t worth while,” answered Lheureux.
+
+He came back the following week and boasted of having, after much
+trouble, at last discovered a certain Langlois, who, for a long time,
+had had an eye on the property, but without mentioning his price.
+
+“Never mind the price!” she cried.
+
+But they would, on the contrary, have to wait, to sound the fellow.
+The thing was worth a journey, and, as she could not undertake it, he
+offered to go to the place to have an interview with Langlois. On his
+return he announced that the purchaser proposed four thousand francs.
+
+Emma was radiant at this news.
+
+“Frankly,” he added, “that’s a good price.”
+
+She drew half the sum at once, and when she was about to pay her account
+the shopkeeper said--
+
+“It really grieves me, on my word! to see you depriving yourself all at
+once of such a big sum as that.”
+
+Then she looked at the bank-notes, and dreaming of the unlimited number
+of rendezvous represented by those two thousand francs, she stammered--
+
+“What! what!”
+
+“Oh!” he went on, laughing good-naturedly, “one puts anything one likes
+on receipts. Don’t you think I know what household affairs are?” And he
+looked at her fixedly, while in his hand he held two long papers that he
+slid between his nails. At last, opening his pocket-book, he spread out
+on the table four bills to order, each for a thousand francs.
+
+“Sign these,” he said, “and keep it all!”
+
+She cried out, scandalised.
+
+“But if I give you the surplus,” replied Monsieur Lheureux impudently,
+“is that not helping you?”
+
+And taking a pen he wrote at the bottom of the account, “Received of
+Madame Bovary four thousand francs.”
+
+“Now who can trouble you, since in six months you’ll draw the arrears
+for your cottage, and I don’t make the last bill due till after you’ve
+been paid?”
+
+Emma grew rather confused in her calculations, and her ears tingled
+as if gold pieces, bursting from their bags, rang all round her on
+the floor. At last Lheureux explained that he had a very good friend,
+Vincart, a broker at Rouen, who would discount these four bills. Then
+he himself would hand over to madame the remainder after the actual debt
+was paid.
+
+But instead of two thousand francs he brought only eighteen hundred, for
+the friend Vincart (which was only fair) had deducted two hundred francs
+for commission and discount. Then he carelessly asked for a receipt.
+
+“You understand--in business--sometimes. And with the date, if you
+please, with the date.”
+
+A horizon of realisable whims opened out before Emma. She was prudent
+enough to lay by a thousand crowns, with which the first three bills
+were paid when they fell due; but the fourth, by chance, came to the
+house on a Thursday, and Charles, quite upset, patiently awaited his
+wife’s return for an explanation.
+
+If she had not told him about this bill, it was only to spare him such
+domestic worries; she sat on his knees, caressed him, cooed to him, gave
+him a long enumeration of all the indispensable things that had been got
+on credit.
+
+“Really, you must confess, considering the quantity, it isn’t too dear.”
+
+Charles, at his wit’s end, soon had recourse to the eternal Lheureux,
+who swore he would arrange matters if the doctor would sign him two
+bills, one of which was for seven hundred francs, payable in three
+months. In order to arrange for this he wrote his mother a pathetic
+letter. Instead of sending a reply she came herself; and when Emma
+wanted to know whether he had got anything out of her, “Yes,” he
+replied; “but she wants to see the account.” The next morning at
+daybreak Emma ran to Lheureux to beg him to make out another account for
+not more than a thousand francs, for to show the one for four thousand
+it would be necessary to say that she had paid two-thirds, and confess,
+consequently, the sale of the estate--a negotiation admirably carried
+out by the shopkeeper, and which, in fact, was only actually known later
+on.
+
+Despite the low price of each article, Madame Bovary senior, of course,
+thought the expenditure extravagant.
+
+“Couldn’t you do without a carpet? Why have recovered the arm-chairs? In
+my time there was a single arm-chair in a house, for elderly persons--at
+any rate it was so at my mother’s, who was a good woman, I can tell you.
+Everybody can’t be rich! No fortune can hold out against waste! I should
+be ashamed to coddle myself as you do! And yet I am old. I need looking
+after. And there! there! fitting up gowns! fallals! What! silk for
+lining at two francs, when you can get jaconet for ten sous, or even for
+eight, that would do well enough!”
+
+Emma, lying on a lounge, replied as quietly as possible--“Ah! Madame,
+enough! enough!”
+
+The other went on lecturing her, predicting they would end in the
+workhouse. But it was Bovary’s fault. Luckily he had promised to destroy
+that power of attorney.
+
+“What?”
+
+“Ah! he swore he would,” went on the good woman.
+
+Emma opened the window, called Charles, and the poor fellow was obliged
+to confess the promise torn from him by his mother.
+
+Emma disappeared, then came back quickly, and majestically handed her a
+thick piece of paper.
+
+“Thank you,” said the old woman. And she threw the power of attorney
+into the fire.
+
+Emma began to laugh, a strident, piercing, continuous laugh; she had an
+attack of hysterics.
+
+“Oh, my God!” cried Charles. “Ah! you really are wrong! You come here
+and make scenes with her!”
+
+His mother, shrugging her shoulders, declared it was “all put on.”
+
+But Charles, rebelling for the first time, took his wife’s part, so that
+Madame Bovary, senior, said she would leave. She went the very next day,
+and on the threshold, as he was trying to detain her, she replied--
+
+“No, no! You love her better than me, and you are right. It is natural.
+For the rest, so much the worse! You will see. Good day--for I am not
+likely to come soon again, as you say, to make scenes.”
+
+Charles nevertheless was very crestfallen before Emma, who did not hide
+the resentment she still felt at his want of confidence, and it needed
+many prayers before she would consent to have another power of attorney.
+He even accompanied her to Monsieur Guillaumin to have a second one,
+just like the other, drawn up.
+
+“I understand,” said the notary; “a man of science can’t be worried with
+the practical details of life.”
+
+And Charles felt relieved by this comfortable reflection, which gave his
+weakness the flattering appearance of higher pre-occupation.
+
+And what an outburst the next Thursday at the hotel in their room with
+Leon! She laughed, cried, sang, sent for sherbets, wanted to smoke
+cigarettes, seemed to him wild and extravagant, but adorable, superb.
+
+He did not know what recreation of her whole being drove her more and
+more to plunge into the pleasures of life. She was becoming irritable,
+greedy, voluptuous; and she walked about the streets with him carrying
+her head high, without fear, so she said, of compromising herself.
+At times, however, Emma shuddered at the sudden thought of meeting
+Rodolphe, for it seemed to her that, although they were separated
+forever, she was not completely free from her subjugation to him.
+
+One night she did not return to Yonville at all. Charles lost his head
+with anxiety, and little Berthe would not go to bed without her mamma,
+and sobbed enough to break her heart. Justin had gone out searching the
+road at random. Monsieur Homais even had left his pharmacy.
+
+At last, at eleven o’clock, able to bear it no longer, Charles
+harnessed his chaise, jumped in, whipped up his horse, and reached the
+“Croix-Rouge” about two o’clock in the morning. No one there! He thought
+that the clerk had perhaps seen her; but where did he live? Happily,
+Charles remembered his employer’s address, and rushed off there.
+
+Day was breaking, and he could distinguish the escutcheons over the
+door, and knocked. Someone, without opening the door, shouted out the
+required information, adding a few insults to those who disturb people
+in the middle of the night.
+
+The house inhabited by the clerk had neither bell, knocker, nor porter.
+Charles knocked loudly at the shutters with his hands. A policeman
+happened to pass by. Then he was frightened, and went away.
+
+“I am mad,” he said; “no doubt they kept her to dinner at Monsieur
+Lormeaux’.” But the Lormeaux no longer lived at Rouen.
+
+“She probably stayed to look after Madame Dubreuil. Why, Madame Dubreuil
+has been dead these ten months! Where can she be?”
+
+An idea occurred to him. At a cafe he asked for a Directory, and
+hurriedly looked for the name of Mademoiselle Lempereur, who lived at
+No. 74 Rue de la Renelle-des-Maroquiniers.
+
+As he was turning into the street, Emma herself appeared at the other
+end of it. He threw himself upon her rather than embraced her, crying--
+
+“What kept you yesterday?”
+
+“I was not well.”
+
+“What was it? Where? How?”
+
+She passed her hand over her forehead and answered, “At Mademoiselle
+Lempereur’s.”
+
+“I was sure of it! I was going there.”
+
+“Oh, it isn’t worth while,” said Emma. “She went out just now; but for
+the future don’t worry. I do not feel free, you see, if I know that the
+least delay upsets you like this.”
+
+This was a sort of permission that she gave herself, so as to get
+perfect freedom in her escapades. And she profited by it freely, fully.
+When she was seized with the desire to see Leon, she set out upon any
+pretext; and as he was not expecting her on that day, she went to fetch
+him at his office.
+
+It was a great delight at first, but soon he no longer concealed the
+truth, which was, that his master complained very much about these
+interruptions.
+
+“Pshaw! come along,” she said.
+
+And he slipped out.
+
+She wanted him to dress all in black, and grow a pointed beard, to
+look like the portraits of Louis XIII. She wanted to see his lodgings;
+thought them poor. He blushed at them, but she did not notice this, then
+advised him to buy some curtains like hers, and as he objected to the
+expense--
+
+“Ah! ah! you care for your money,” she said laughing.
+
+Each time Leon had to tell her everything that he had done since their
+last meeting. She asked him for some verses--some verses “for herself,”
+ a “love poem” in honour of her. But he never succeeded in getting a
+rhyme for the second verse; and at last ended by copying a sonnet in
+a “Keepsake.” This was less from vanity than from the one desire of
+pleasing her. He did not question her ideas; he accepted all her tastes;
+he was rather becoming her mistress than she his. She had tender words
+and kisses that thrilled his soul. Where could she have learnt this
+corruption almost incorporeal in the strength of its profanity and
+dissimulation?
+
+
+
+Chapter Six
+
+During the journeys he made to see her, Leon had often dined at the
+chemist’s, and he felt obliged from politeness to invite him in turn.
+
+“With pleasure!” Monsieur Homais replied; “besides, I must invigorate
+my mind, for I am getting rusty here. We’ll go to the theatre, to the
+restaurant; we’ll make a night of it.”
+
+“Oh, my dear!” tenderly murmured Madame Homais, alarmed at the vague
+perils he was preparing to brave.
+
+“Well, what? Do you think I’m not sufficiently ruining my health living
+here amid the continual emanations of the pharmacy? But there! that is
+the way with women! They are jealous of science, and then are opposed to
+our taking the most legitimate distractions. No matter! Count upon
+me. One of these days I shall turn up at Rouen, and we’ll go the pace
+together.”
+
+The druggist would formerly have taken good care not to use such an
+expression, but he was cultivating a gay Parisian style, which he
+thought in the best taste; and, like his neighbour, Madame Bovary, he
+questioned the clerk curiously about the customs of the capital; he
+even talked slang to dazzle the bourgeois, saying bender, crummy, dandy,
+macaroni, the cheese, cut my stick and “I’ll hook it,” for “I am going.”
+
+So one Thursday Emma was surprised to meet Monsieur Homais in the
+kitchen of the “Lion d’Or,” wearing a traveller’s costume, that is to
+say, wrapped in an old cloak which no one knew he had, while he carried
+a valise in one hand and the foot-warmer of his establishment in the
+other. He had confided his intentions to no one, for fear of causing the
+public anxiety by his absence.
+
+The idea of seeing again the place where his youth had been spent no
+doubt excited him, for during the whole journey he never ceased talking,
+and as soon as he had arrived, he jumped quickly out of the diligence
+to go in search of Leon. In vain the clerk tried to get rid of him.
+Monsieur Homais dragged him off to the large Cafe de la Normandie,
+which he entered majestically, not raising his hat, thinking it very
+provincial to uncover in any public place.
+
+Emma waited for Leon three quarters of an hour. At last she ran to
+his office; and, lost in all sorts of conjectures, accusing him of
+indifference, and reproaching herself for her weakness, she spent the
+afternoon, her face pressed against the window-panes.
+
+At two o’clock they were still at a table opposite each other. The large
+room was emptying; the stove-pipe, in the shape of a palm-tree, spread
+its gilt leaves over the white ceiling, and near them, outside the
+window, in the bright sunshine, a little fountain gurgled in a white
+basin, where; in the midst of watercress and asparagus, three torpid
+lobsters stretched across to some quails that lay heaped up in a pile on
+their sides.
+
+Homais was enjoying himself. Although he was even more intoxicated with
+the luxury than the rich fare, the Pommard wine all the same rather
+excited his faculties; and when the omelette au rhum* appeared, he began
+propounding immoral theories about women. What seduced him above all
+else was chic. He admired an elegant toilette in a well-furnished
+apartment, and as to bodily qualities, he didn’t dislike a young girl.
+
+     * In rum.
+
+
+Leon watched the clock in despair. The druggist went on drinking,
+eating, and talking.
+
+“You must be very lonely,” he said suddenly, “here at Rouen. To be sure
+your lady-love doesn’t live far away.”
+
+And the other blushed--
+
+“Come now, be frank. Can you deny that at Yonville--”
+
+The young man stammered something.
+
+“At Madame Bovary’s, you’re not making love to--”
+
+“To whom?”
+
+“The servant!”
+
+He was not joking; but vanity getting the better of all prudence, Leon,
+in spite of himself protested. Besides, he only liked dark women.
+
+“I approve of that,” said the chemist; “they have more passion.”
+
+And whispering into his friend’s ear, he pointed out the symptoms by
+which one could find out if a woman had passion. He even launched into
+an ethnographic digression: the German was vapourish, the French woman
+licentious, the Italian passionate.
+
+“And negresses?” asked the clerk.
+
+“They are an artistic taste!” said Homais. “Waiter! two cups of coffee!”
+
+“Are we going?” at last asked Leon impatiently.
+
+“Ja!”
+
+But before leaving he wanted to see the proprietor of the establishment
+and made him a few compliments. Then the young man, to be alone, alleged
+he had some business engagement.
+
+“Ah! I will escort you,” said Homais.
+
+And all the while he was walking through the streets with him he talked
+of his wife, his children; of their future, and of his business; told
+him in what a decayed condition it had formerly been, and to what a
+degree of perfection he had raised it.
+
+Arrived in front of the Hotel de Boulogne, Leon left him abruptly, ran
+up the stairs, and found his mistress in great excitement. At mention of
+the chemist she flew into a passion. He, however, piled up good reasons;
+it wasn’t his fault; didn’t she know Homais--did she believe that he
+would prefer his company? But she turned away; he drew her back, and,
+sinking on his knees, clasped her waist with his arms in a languorous
+pose, full of concupiscence and supplication.
+
+She was standing up, her large flashing eyes looked at him seriously,
+almost terribly. Then tears obscured them, her red eyelids were lowered,
+she gave him her hands, and Leon was pressing them to his lips when a
+servant appeared to tell the gentleman that he was wanted.
+
+“You will come back?” she said.
+
+“Yes.”
+
+“But when?”
+
+“Immediately.”
+
+“It’s a trick,” said the chemist, when he saw Leon. “I wanted to
+interrupt this visit, that seemed to me to annoy you. Let’s go and have
+a glass of garus at Bridoux’.”
+
+Leon vowed that he must get back to his office. Then the druggist joked
+him about quill-drivers and the law.
+
+“Leave Cujas and Barthole alone a bit. Who the devil prevents you? Be a
+man! Let’s go to Bridoux’. You’ll see his dog. It’s very interesting.”
+
+And as the clerk still insisted--
+
+“I’ll go with you. I’ll read a paper while I wait for you, or turn over
+the leaves of a ‘Code.’”
+
+Leon, bewildered by Emma’s anger, Monsieur Homais’ chatter, and,
+perhaps, by the heaviness of the luncheon, was undecided, and, as it
+were, fascinated by the chemist, who kept repeating--
+
+“Let’s go to Bridoux’. It’s just by here, in the Rue Malpalu.”
+
+Then, through cowardice, through stupidity, through that indefinable
+feeling that drags us into the most distasteful acts, he allowed
+himself to be led off to Bridoux’, whom they found in his small yard,
+superintending three workmen, who panted as they turned the large
+wheel of a machine for making seltzer-water. Homais gave them some good
+advice. He embraced Bridoux; they took some garus. Twenty times Leon
+tried to escape, but the other seized him by the arm saying--
+
+“Presently! I’m coming! We’ll go to the ‘Fanal de Rouen’ to see the
+fellows there. I’ll introduce you to Thornassin.”
+
+At last he managed to get rid of him, and rushed straight to the hotel.
+Emma was no longer there. She had just gone in a fit of anger. She
+detested him now. This failing to keep their rendezvous seemed to her an
+insult, and she tried to rake up other reasons to separate herself from
+him. He was incapable of heroism, weak, banal, more spiritless than a
+woman, avaricious too, and cowardly.
+
+Then, growing calmer, she at length discovered that she had, no doubt,
+calumniated him. But the disparaging of those we love always alienates
+us from them to some extent. We must not touch our idols; the gilt
+sticks to our fingers.
+
+They gradually came to talking more frequently of matters outside their
+love, and in the letters that Emma wrote him she spoke of flowers,
+verses, the moon and the stars, naive resources of a waning passion
+striving to keep itself alive by all external aids. She was constantly
+promising herself a profound felicity on her next journey. Then
+she confessed to herself that she felt nothing extraordinary. This
+disappointment quickly gave way to a new hope, and Emma returned to him
+more inflamed, more eager than ever. She undressed brutally, tearing off
+the thin laces of her corset that nestled around her hips like a gliding
+snake. She went on tiptoe, barefooted, to see once more that the
+door was closed, then, pale, serious, and, without speaking, with one
+movement, she threw herself upon his breast with a long shudder.
+
+Yet there was upon that brow covered with cold drops, on those quivering
+lips, in those wild eyes, in the strain of those arms, something vague
+and dreary that seemed to Leon to glide between them subtly as if to
+separate them.
+
+He did not dare to question her; but, seeing her so skilled, she must
+have passed, he thought, through every experience of suffering and of
+pleasure. What had once charmed now frightened him a little. Besides, he
+rebelled against his absorption, daily more marked, by her personality.
+He begrudged Emma this constant victory. He even strove not to love her;
+then, when he heard the creaking of her boots, he turned coward, like
+drunkards at the sight of strong drinks.
+
+She did not fail, in truth, to lavish all sorts of attentions upon him,
+from the delicacies of food to the coquettries of dress and languishing
+looks. She brought roses to her breast from Yonville, which she threw
+into his face; was anxious about his health, gave him advice as to his
+conduct; and, in order the more surely to keep her hold on him, hoping
+perhaps that heaven would take her part, she tied a medal of the
+Virgin round his neck. She inquired like a virtuous mother about his
+companions. She said to him--
+
+“Don’t see them; don’t go out; think only of ourselves; love me!”
+
+She would have liked to be able to watch over his life; and the idea
+occurred to her of having him followed in the streets. Near the hotel
+there was always a kind of loafer who accosted travellers, and who would
+not refuse. But her pride revolted at this.
+
+“Bah! so much the worse. Let him deceive me! What does it matter to me?
+As If I cared for him!”
+
+One day, when they had parted early and she was returning alone along
+the boulevard, she saw the walls of her convent; then she sat down on a
+form in the shade of the elm-trees. How calm that time had been! How she
+longed for the ineffable sentiments of love that she had tried to figure
+to herself out of books! The first month of her marriage, her rides in
+the wood, the viscount that waltzed, and Lagardy singing, all repassed
+before her eyes. And Leon suddenly appeared to her as far off as the
+others.
+
+“Yet I love him,” she said to herself.
+
+No matter! She was not happy--she never had been. Whence came this
+insufficiency in life--this instantaneous turning to decay of everything
+on which she leant? But if there were somewhere a being strong and
+beautiful, a valiant nature, full at once of exaltation and refinement,
+a poet’s heart in an angel’s form, a lyre with sounding chords ringing
+out elegiac epithalamia to heaven, why, perchance, should she not find
+him? Ah! how impossible! Besides, nothing was worth the trouble of
+seeking it; everything was a lie. Every smile hid a yawn of boredom,
+every joy a curse, all pleasure satiety, and the sweetest kisses left
+upon your lips only the unattainable desire for a greater delight.
+
+A metallic clang droned through the air, and four strokes were heard
+from the convent-clock. Four o’clock! And it seemed to her that she had
+been there on that form an eternity. But an infinity of passions may be
+contained in a minute, like a crowd in a small space.
+
+Emma lived all absorbed in hers, and troubled no more about money
+matters than an archduchess.
+
+Once, however, a wretched-looking man, rubicund and bald, came to her
+house, saying he had been sent by Monsieur Vincart of Rouen. He took out
+the pins that held together the side-pockets of his long green overcoat,
+stuck them into his sleeve, and politely handed her a paper.
+
+It was a bill for seven hundred francs, signed by her, and which
+Lheureux, in spite of all his professions, had paid away to Vincart. She
+sent her servant for him. He could not come. Then the stranger, who
+had remained standing, casting right and left curious glances, that his
+thick, fair eyebrows hid, asked with a naive air--
+
+“What answer am I to take Monsieur Vincart?”
+
+“Oh,” said Emma, “tell him that I haven’t it. I will send next week; he
+must wait; yes, till next week.”
+
+And the fellow went without another word.
+
+But the next day at twelve o’clock she received a summons, and the sight
+of the stamped paper, on which appeared several times in large letters,
+“Maitre Hareng, bailiff at Buchy,” so frightened her that she rushed in
+hot haste to the linendraper’s. She found him in his shop, doing up a
+parcel.
+
+“Your obedient!” he said; “I am at your service.”
+
+But Lheureux, all the same, went on with his work, helped by a young
+girl of about thirteen, somewhat hunch-backed, who was at once his clerk
+and his servant.
+
+Then, his clogs clattering on the shop-boards, he went up in front
+of Madame Bovary to the first door, and introduced her into a narrow
+closet, where, in a large bureau in sapon-wood, lay some ledgers,
+protected by a horizontal padlocked iron bar. Against the wall, under
+some remnants of calico, one glimpsed a safe, but of such dimensions
+that it must contain something besides bills and money. Monsieur
+Lheureux, in fact, went in for pawnbroking, and it was there that he had
+put Madame Bovary’s gold chain, together with the earrings of poor old
+Tellier, who, at last forced to sell out, had bought a meagre store
+of grocery at Quincampoix, where he was dying of catarrh amongst his
+candles, that were less yellow than his face.
+
+Lheureux sat down in a large cane arm-chair, saying: “What news?”
+
+“See!”
+
+And she showed him the paper.
+
+“Well how can I help it?”
+
+Then she grew angry, reminding him of the promise he had given not to
+pay away her bills. He acknowledged it.
+
+“But I was pressed myself; the knife was at my own throat.”
+
+“And what will happen now?” she went on.
+
+“Oh, it’s very simple; a judgment and then a distraint--that’s about
+it!”
+
+Emma kept down a desire to strike him, and asked gently if there was no
+way of quieting Monsieur Vincart.
+
+“I dare say! Quiet Vincart! You don’t know him; he’s more ferocious than
+an Arab!”
+
+Still Monsieur Lheureux must interfere.
+
+“Well, listen. It seems to me so far I’ve been very good to you.” And
+opening one of his ledgers, “See,” he said. Then running up the page
+with his finger, “Let’s see! let’s see! August 3d, two hundred francs;
+June 17th, a hundred and fifty; March 23d, forty-six. In April--”
+
+He stopped, as if afraid of making some mistake.
+
+“Not to speak of the bills signed by Monsieur Bovary, one for seven
+hundred francs, and another for three hundred. As to your little
+installments, with the interest, why, there’s no end to ‘em; one gets
+quite muddled over ‘em. I’ll have nothing more to do with it.”
+
+She wept; she even called him “her good Monsieur Lheureux.” But he
+always fell back upon “that rascal Vincart.” Besides, he hadn’t a brass
+farthing; no one was paying him now-a-days; they were eating his coat
+off his back; a poor shopkeeper like him couldn’t advance money.
+
+Emma was silent, and Monsieur Lheureux, who was biting the feathers of a
+quill, no doubt became uneasy at her silence, for he went on--
+
+“Unless one of these days I have something coming in, I might--”
+
+“Besides,” said she, “as soon as the balance of Barneville--”
+
+“What!”
+
+And on hearing that Langlois had not yet paid he seemed much surprised.
+Then in a honied voice--
+
+“And we agree, you say?”
+
+“Oh! to anything you like.”
+
+On this he closed his eyes to reflect, wrote down a few figures, and
+declaring it would be very difficult for him, that the affair was shady,
+and that he was being bled, he wrote out four bills for two hundred and
+fifty francs each, to fall due month by month.
+
+“Provided that Vincart will listen to me! However, it’s settled. I don’t
+play the fool; I’m straight enough.”
+
+Next he carelessly showed her several new goods, not one of which,
+however, was in his opinion worthy of madame.
+
+“When I think that there’s a dress at threepence-halfpenny a yard, and
+warranted fast colours! And yet they actually swallow it! Of course you
+understand one doesn’t tell them what it really is!” He hoped by this
+confession of dishonesty to others to quite convince her of his probity
+to her.
+
+Then he called her back to show her three yards of guipure that he had
+lately picked up “at a sale.”
+
+“Isn’t it lovely?” said Lheureux. “It is very much used now for the
+backs of arm-chairs. It’s quite the rage.”
+
+And, more ready than a juggler, he wrapped up the guipure in some blue
+paper and put it in Emma’s hands.
+
+“But at least let me know--”
+
+“Yes, another time,” he replied, turning on his heel.
+
+That same evening she urged Bovary to write to his mother, to ask her
+to send as quickly as possible the whole of the balance due from the
+father’s estate. The mother-in-law replied that she had nothing more,
+the winding up was over, and there was due to them besides Barneville an
+income of six hundred francs, that she would pay them punctually.
+
+Then Madame Bovary sent in accounts to two or three patients, and she
+made large use of this method, which was very successful. She was always
+careful to add a postscript: “Do not mention this to my husband; you
+know how proud he is. Excuse me. Yours obediently.” There were some
+complaints; she intercepted them.
+
+To get money she began selling her old gloves, her old hats, the old
+odds and ends, and she bargained rapaciously, her peasant blood standing
+her in good stead. Then on her journey to town she picked up nick-nacks
+secondhand, that, in default of anyone else, Monsieur Lheureux would
+certainly take off her hands. She bought ostrich feathers, Chinese
+porcelain, and trunks; she borrowed from Felicite, from Madame
+Lefrancois, from the landlady at the Croix-Rouge, from everybody, no
+matter where.
+
+With the money she at last received from Barneville she paid two bills;
+the other fifteen hundred francs fell due. She renewed the bills, and
+thus it was continually.
+
+Sometimes, it is true, she tried to make a calculation, but she
+discovered things so exorbitant that she could not believe them
+possible. Then she recommenced, soon got confused, gave it all up, and
+thought no more about it.
+
+The house was very dreary now. Tradesmen were seen leaving it with angry
+faces. Handkerchiefs were lying about on the stoves, and little Berthe,
+to the great scandal of Madame Homais, wore stockings with holes in
+them. If Charles timidly ventured a remark, she answered roughly that it
+wasn’t her fault.
+
+What was the meaning of all these fits of temper? He explained
+everything through her old nervous illness, and reproaching himself with
+having taken her infirmities for faults, accused himself of egotism, and
+longed to go and take her in his arms.
+
+“Ah, no!” he said to himself; “I should worry her.”
+
+And he did not stir.
+
+After dinner he walked about alone in the garden; he took little Berthe
+on his knees, and unfolding his medical journal, tried to teach her
+to read. But the child, who never had any lessons, soon looked up with
+large, sad eyes and began to cry. Then he comforted her; went to fetch
+water in her can to make rivers on the sand path, or broke off branches
+from the privet hedges to plant trees in the beds. This did not spoil
+the garden much, all choked now with long weeds. They owed Lestiboudois
+for so many days. Then the child grew cold and asked for her mother.
+
+“Call the servant,” said Charles. “You know, dearie, that mamma does not
+like to be disturbed.”
+
+Autumn was setting in, and the leaves were already falling, as they did
+two years ago when she was ill. Where would it all end? And he walked up
+and down, his hands behind his back.
+
+Madame was in her room, which no one entered. She stayed there all
+day long, torpid, half dressed, and from time to time burning Turkish
+pastilles which she had bought at Rouen in an Algerian’s shop. In order
+not to have at night this sleeping man stretched at her side, by dint of
+manoeuvring, she at last succeeded in banishing him to the second floor,
+while she read till morning extravagant books, full of pictures of
+orgies and thrilling situations. Often, seized with fear, she cried out,
+and Charles hurried to her.
+
+“Oh, go away!” she would say.
+
+Or at other times, consumed more ardently than ever by that inner flame
+to which adultery added fuel, panting, tremulous, all desire, she threw
+open her window, breathed in the cold air, shook loose in the wind her
+masses of hair, too heavy, and, gazing upon the stars, longed for some
+princely love. She thought of him, of Leon. She would then have given
+anything for a single one of those meetings that surfeited her.
+
+These were her gala days. She wanted them to be sumptuous, and when he
+alone could not pay the expenses, she made up the deficit liberally,
+which happened pretty well every time. He tried to make her understand
+that they would be quite as comfortable somewhere else, in a smaller
+hotel, but she always found some objection.
+
+One day she drew six small silver-gilt spoons from her bag (they were
+old Roualt’s wedding present), begging him to pawn them at once for her,
+and Leon obeyed, though the proceeding annoyed him. He was afraid of
+compromising himself.
+
+Then, on, reflection, he began to think his mistress’s ways were growing
+odd, and that they were perhaps not wrong in wishing to separate him
+from her.
+
+In fact someone had sent his mother a long anonymous letter to warn her
+that he was “ruining himself with a married woman,” and the good lady at
+once conjuring up the eternal bugbear of families, the vague pernicious
+creature, the siren, the monster, who dwells fantastically in depths of
+love, wrote to Lawyer Dubocage, his employer, who behaved perfectly in
+the affair. He kept him for three quarters of an hour trying to open
+his eyes, to warn him of the abyss into which he was falling. Such
+an intrigue would damage him later on, when he set up for himself. He
+implored him to break with her, and, if he would not make this sacrifice
+in his own interest, to do it at least for his, Dubocage’s sake.
+
+At last Leon swore he would not see Emma again, and he reproached
+himself with not having kept his word, considering all the worry and
+lectures this woman might still draw down upon him, without reckoning
+the jokes made by his companions as they sat round the stove in the
+morning. Besides, he was soon to be head clerk; it was time to settle
+down. So he gave up his flute, exalted sentiments, and poetry; for every
+bourgeois in the flush of his youth, were it but for a day, a moment,
+has believed himself capable of immense passions, of lofty enterprises.
+The most mediocre libertine has dreamed of sultanas; every notary bears
+within him the debris of a poet.
+
+He was bored now when Emma suddenly began to sob on his breast, and his
+heart, like the people who can only stand a certain amount of music,
+dozed to the sound of a love whose delicacies he no longer noted.
+
+They knew one another too well for any of those surprises of possession
+that increase its joys a hundred-fold. She was as sick of him as he
+was weary of her. Emma found again in adultery all the platitudes of
+marriage.
+
+But how to get rid of him? Then, though she might feel humiliated at
+the baseness of such enjoyment, she clung to it from habit or from
+corruption, and each day she hungered after them the more, exhausting
+all felicity in wishing for too much of it. She accused Leon of her
+baffled hopes, as if he had betrayed her; and she even longed for some
+catastrophe that would bring about their separation, since she had not
+the courage to make up her mind to it herself.
+
+She none the less went on writing him love letters, in virtue of the
+notion that a woman must write to her lover.
+
+But whilst she wrote it was another man she saw, a phantom fashioned out
+of her most ardent memories, of her finest reading, her strongest
+lusts, and at last he became so real, so tangible, that she palpitated
+wondering, without, however, the power to imagine him clearly, so lost
+was he, like a god, beneath the abundance of his attributes. He dwelt in
+that azure land where silk ladders hang from balconies under the breath
+of flowers, in the light of the moon. She felt him near her; he was
+coming, and would carry her right away in a kiss.
+
+Then she fell back exhausted, for these transports of vague love wearied
+her more than great debauchery.
+
+She now felt constant ache all over her. Often she even received
+summonses, stamped paper that she barely looked at. She would have liked
+not to be alive, or to be always asleep.
+
+On Mid-Lent she did not return to Yonville, but in the evening went to
+a masked ball. She wore velvet breeches, red stockings, a club wig, and
+three-cornered hat cocked on one side. She danced all night to the wild
+tones of the trombones; people gathered round her, and in the morning
+she found herself on the steps of the theatre together with five or six
+masks, debardeuses* and sailors, Leon’s comrades, who were talking about
+having supper.
+
+     * People dressed as longshoremen.
+
+
+The neighbouring cafes were full. They caught sight of one on the
+harbour, a very indifferent restaurant, whose proprietor showed them to
+a little room on the fourth floor.
+
+The men were whispering in a corner, no doubt consorting about expenses.
+There were a clerk, two medical students, and a shopman--what company
+for her! As to the women, Emma soon perceived from the tone of their
+voices that they must almost belong to the lowest class. Then she was
+frightened, pushed back her chair, and cast down her eyes.
+
+The others began to eat; she ate nothing. Her head was on fire, her eyes
+smarted, and her skin was ice-cold. In her head she seemed to feel the
+floor of the ball-room rebounding again beneath the rhythmical pulsation
+of the thousands of dancing feet. And now the smell of the punch, the
+smoke of the cigars, made her giddy. She fainted, and they carried her
+to the window.
+
+Day was breaking, and a great stain of purple colour broadened out
+in the pale horizon over the St. Catherine hills. The livid river was
+shivering in the wind; there was no one on the bridges; the street lamps
+were going out.
+
+She revived, and began thinking of Berthe asleep yonder in the servant’s
+room. Then a cart filled with long strips of iron passed by, and made a
+deafening metallic vibration against the walls of the houses.
+
+She slipped away suddenly, threw off her costume, told Leon she must get
+back, and at last was alone at the Hotel de Boulogne. Everything, even
+herself, was now unbearable to her. She wished that, taking wing like a
+bird, she could fly somewhere, far away to regions of purity, and there
+grow young again.
+
+She went out, crossed the Boulevard, the Place Cauchoise, and the
+Faubourg, as far as an open street that overlooked some gardens. She
+walked rapidly; the fresh air calming her; and, little by little, the
+faces of the crowd, the masks, the quadrilles, the lights, the supper,
+those women, all disappeared like mists fading away. Then, reaching the
+“Croix-Rouge,” she threw herself on the bed in her little room on the
+second floor, where there were pictures of the “Tour de Nesle.” At four
+o’clock Hivert awoke her.
+
+When she got home, Felicite showed her behind the clock a grey paper.
+She read--
+
+“In virtue of the seizure in execution of a judgment.”
+
+What judgment? As a matter of fact, the evening before another paper
+had been brought that she had not yet seen, and she was stunned by these
+words--
+
+“By order of the king, law, and justice, to Madame Bovary.” Then,
+skipping several lines, she read, “Within twenty-four hours, without
+fail--” But what? “To pay the sum of eight thousand francs.” And there
+was even at the bottom, “She will be constrained thereto by every
+form of law, and notably by a writ of distraint on her furniture and
+effects.”
+
+What was to be done? In twenty-four hours--tomorrow. Lheureux, she
+thought, wanted to frighten her again; for she saw through all his
+devices, the object of his kindnesses. What reassured her was the very
+magnitude of the sum.
+
+However, by dint of buying and not paying, of borrowing, signing bills,
+and renewing these bills that grew at each new falling-in, she had ended
+by preparing a capital for Monsieur Lheureux which he was impatiently
+awaiting for his speculations.
+
+She presented herself at his place with an offhand air.
+
+“You know what has happened to me? No doubt it’s a joke!”
+
+“How so?”
+
+He turned away slowly, and, folding his arms, said to her--
+
+“My good lady, did you think I should go on to all eternity being your
+purveyor and banker, for the love of God? Now be just. I must get back
+what I’ve laid out. Now be just.”
+
+She cried out against the debt.
+
+“Ah! so much the worse. The court has admitted it. There’s a judgment.
+It’s been notified to you. Besides, it isn’t my fault. It’s Vincart’s.”
+
+“Could you not--?”
+
+“Oh, nothing whatever.”
+
+“But still, now talk it over.”
+
+And she began beating about the bush; she had known nothing about it; it
+was a surprise.
+
+“Whose fault is that?” said Lheureux, bowing ironically. “While I’m
+slaving like a nigger, you go gallivanting about.”
+
+“Ah! no lecturing.”
+
+“It never does any harm,” he replied.
+
+She turned coward; she implored him; she even pressed her pretty white
+and slender hand against the shopkeeper’s knee.
+
+“There, that’ll do! Anyone’d think you wanted to seduce me!”
+
+“You are a wretch!” she cried.
+
+“Oh, oh! go it! go it!”
+
+“I will show you up. I shall tell my husband.”
+
+“All right! I too. I’ll show your husband something.”
+
+And Lheureux drew from his strong box the receipt for eighteen hundred
+francs that she had given him when Vincart had discounted the bills.
+
+“Do you think,” he added, “that he’ll not understand your little theft,
+the poor dear man?”
+
+She collapsed, more overcome than if felled by the blow of a pole-axe.
+He was walking up and down from the window to the bureau, repeating all
+the while--
+
+“Ah! I’ll show him! I’ll show him!” Then he approached her, and in a
+soft voice said--
+
+“It isn’t pleasant, I know; but, after all, no bones are broken, and,
+since that is the only way that is left for you paying back my money--”
+
+“But where am I to get any?” said Emma, wringing her hands.
+
+“Bah! when one has friends like you!”
+
+And he looked at her in so keen, so terrible a fashion, that she
+shuddered to her very heart.
+
+“I promise you,” she said, “to sign--”
+
+“I’ve enough of your signatures.”
+
+“I will sell something.”
+
+“Get along!” he said, shrugging his shoulders; “you’ve not got
+anything.”
+
+And he called through the peep-hole that looked down into the shop--
+
+“Annette, don’t forget the three coupons of No. 14.”
+
+The servant appeared. Emma understood, and asked how much money would be
+wanted to put a stop to the proceedings.
+
+“It is too late.”
+
+“But if I brought you several thousand francs--a quarter of the sum--a
+third--perhaps the whole?”
+
+“No; it’s no use!”
+
+And he pushed her gently towards the staircase.
+
+“I implore you, Monsieur Lheureux, just a few days more!” She was
+sobbing.
+
+“There! tears now!”
+
+“You are driving me to despair!”
+
+“What do I care?” said he, shutting the door.
+
+
+
+Chapter Seven
+
+She was stoical the next day when Maitre Hareng, the bailiff, with two
+assistants, presented himself at her house to draw up the inventory for
+the distraint.
+
+They began with Bovary’s consulting-room, and did not write down
+the phrenological head, which was considered an “instrument of his
+profession”; but in the kitchen they counted the plates; the saucepans,
+the chairs, the candlesticks, and in the bedroom all the nick-nacks on
+the whatnot. They examined her dresses, the linen, the dressing-room;
+and her whole existence to its most intimate details, was, like a corpse
+on whom a post-mortem is made, outspread before the eyes of these three
+men.
+
+Maitre Hareng, buttoned up in his thin black coat, wearing a white
+choker and very tight foot-straps, repeated from time to time--“Allow
+me, madame. You allow me?” Often he uttered exclamations. “Charming!
+very pretty.” Then he began writing again, dipping his pen into the horn
+inkstand in his left hand.
+
+When they had done with the rooms they went up to the attic. She kept a
+desk there in which Rodolphe’s letters were locked. It had to be opened.
+
+“Ah! a correspondence,” said Maitre Hareng, with a discreet smile. “But
+allow me, for I must make sure the box contains nothing else.” And he
+tipped up the papers lightly, as if to shake out napoleons. Then she
+grew angered to see this coarse hand, with fingers red and pulpy like
+slugs, touching these pages against which her heart had beaten.
+
+They went at last. Felicite came back. Emma had sent her out to watch
+for Bovary in order to keep him off, and they hurriedly installed the
+man in possession under the roof, where he swore he would remain.
+
+During the evening Charles seemed to her careworn. Emma watched him with
+a look of anguish, fancying she saw an accusation in every line of his
+face. Then, when her eyes wandered over the chimney-piece ornamented
+with Chinese screens, over the large curtains, the armchairs, all
+those things, in a word, that had, softened the bitterness of her life,
+remorse seized her or rather an immense regret, that, far from crushing,
+irritated her passion. Charles placidly poked the fire, both his feet on
+the fire-dogs.
+
+Once the man, no doubt bored in his hiding-place, made a slight noise.
+
+“Is anyone walking upstairs?” said Charles.
+
+“No,” she replied; “it is a window that has been left open, and is
+rattling in the wind.”
+
+The next day, Sunday, she went to Rouen to call on all the brokers whose
+names she knew. They were at their country-places or on journeys. She
+was not discouraged; and those whom she did manage to see she asked for
+money, declaring she must have some, and that she would pay it back.
+Some laughed in her face; all refused.
+
+At two o’clock she hurried to Leon, and knocked at the door. No one
+answered. At length he appeared.
+
+“What brings you here?”
+
+“Do I disturb you?”
+
+“No; but--” And he admitted that his landlord didn’t like his having
+“women” there.
+
+“I must speak to you,” she went on.
+
+Then he took down the key, but she stopped him.
+
+“No, no! Down there, in our home!”
+
+And they went to their room at the Hotel de Boulogne.
+
+On arriving she drank off a large glass of water. She was very pale. She
+said to him--
+
+“Leon, you will do me a service?”
+
+And, shaking him by both hands that she grasped tightly, she added--
+
+“Listen, I want eight thousand francs.”
+
+“But you are mad!”
+
+“Not yet.”
+
+And thereupon, telling him the story of the distraint, she explained
+her distress to him; for Charles knew nothing of it; her mother-in-law
+detested her; old Rouault could do nothing; but he, Leon, he would set
+about finding this indispensable sum.
+
+“How on earth can I?”
+
+“What a coward you are!” she cried.
+
+Then he said stupidly, “You are exaggerating the difficulty. Perhaps,
+with a thousand crowns or so the fellow could be stopped.”
+
+All the greater reason to try and do something; it was impossible that
+they could not find three thousand francs. Besides, Leon, could be
+security instead of her.
+
+“Go, try, try! I will love you so!”
+
+He went out, and came back at the end of an hour, saying, with solemn
+face--
+
+“I have been to three people with no success.”
+
+Then they remained sitting face to face at the two chimney corners,
+motionless, in silence. Emma shrugged her shoulders as she stamped her
+feet. He heard her murmuring--
+
+“If I were in your place _I_ should soon get some.”
+
+“But where?”
+
+“At your office.” And she looked at him.
+
+An infernal boldness looked out from her burning eyes, and their lids
+drew close together with a lascivious and encouraging look, so that the
+young man felt himself growing weak beneath the mute will of this woman
+who was urging him to a crime. Then he was afraid, and to avoid any
+explanation he smote his forehead, crying--
+
+“Morel is to come back to-night; he will not refuse me, I hope” (this
+was one of his friends, the son of a very rich merchant); “and I will
+bring it you to-morrow,” he added.
+
+Emma did not seem to welcome this hope with all the joy he had expected.
+Did she suspect the lie? He went on, blushing--
+
+“However, if you don’t see me by three o’clock do not wait for me, my
+darling. I must be off now; forgive me! Goodbye!”
+
+He pressed her hand, but it felt quite lifeless. Emma had no strength
+left for any sentiment.
+
+Four o’clock struck, and she rose to return to Yonville, mechanically
+obeying the force of old habits.
+
+The weather was fine. It was one of those March days, clear and sharp,
+when the sun shines in a perfectly white sky. The Rouen folk, in
+Sunday-clothes, were walking about with happy looks. She reached the
+Place du Parvis. People were coming out after vespers; the crowd flowed
+out through the three doors like a stream through the three arches of
+a bridge, and in the middle one, more motionless than a rock, stood the
+beadle.
+
+Then she remembered the day when, all anxious and full of hope, she had
+entered beneath this large nave, that had opened out before her, less
+profound than her love; and she walked on weeping beneath her veil,
+giddy, staggering, almost fainting.
+
+“Take care!” cried a voice issuing from the gate of a courtyard that was
+thrown open.
+
+She stopped to let pass a black horse, pawing the ground between the
+shafts of a tilbury, driven by a gentleman in sable furs. Who was it?
+She knew him. The carriage darted by and disappeared.
+
+Why, it was he--the Viscount. She turned away; the street was empty. She
+was so overwhelmed, so sad, that she had to lean against a wall to keep
+herself from falling.
+
+Then she thought she had been mistaken. Anyhow, she did not know. All
+within her and around her was abandoning her. She felt lost, sinking
+at random into indefinable abysses, and it was almost with joy that, on
+reaching the “Croix-Rouge,” she saw the good Homais, who was watching
+a large box full of pharmaceutical stores being hoisted on to the
+“Hirondelle.” In his hand he held tied in a silk handkerchief six
+cheminots for his wife.
+
+Madame Homais was very fond of these small, heavy turban-shaped loaves,
+that are eaten in Lent with salt butter; a last vestige of Gothic food
+that goes back, perhaps, to the time of the Crusades, and with which
+the robust Normans gorged themselves of yore, fancying they saw on the
+table, in the light of the yellow torches, between tankards of hippocras
+and huge boars’ heads, the heads of Saracens to be devoured. The
+druggist’s wife crunched them up as they had done--heroically, despite
+her wretched teeth. And so whenever Homais journeyed to town, he never
+failed to bring her home some that he bought at the great baker’s in the
+Rue Massacre.
+
+“Charmed to see you,” he said, offering Emma a hand to help her into the
+“Hirondelle.” Then he hung up his cheminots to the cords of the netting,
+and remained bare-headed in an attitude pensive and Napoleonic.
+
+But when the blind man appeared as usual at the foot of the hill he
+exclaimed--
+
+“I can’t understand why the authorities tolerate such culpable
+industries. Such unfortunates should be locked up and forced to work.
+Progress, my word! creeps at a snail’s pace. We are floundering about in
+mere barbarism.”
+
+The blind man held out his hat, that flapped about at the door, as if it
+were a bag in the lining that had come unnailed.
+
+“This,” said the chemist, “is a scrofulous affection.”
+
+And though he knew the poor devil, he pretended to see him for the first
+time, murmured something about “cornea,” “opaque cornea,” “sclerotic,”
+ “facies,” then asked him in a paternal tone--
+
+“My friend, have you long had this terrible infirmity? Instead of
+getting drunk at the public, you’d do better to die yourself.”
+
+He advised him to take good wine, good beer, and good joints. The blind
+man went on with his song; he seemed, moreover, almost idiotic. At last
+Monsieur Homais opened his purse--
+
+“Now there’s a sou; give me back two lairds, and don’t forget my advice:
+you’ll be the better for it.”
+
+Hivert openly cast some doubt on the efficacy of it. But the druggist
+said that he would cure himself with an antiphlogistic pomade of his own
+composition, and he gave his address--“Monsieur Homais, near the market,
+pretty well known.”
+
+“Now,” said Hivert, “for all this trouble you’ll give us your
+performance.”
+
+The blind man sank down on his haunches, with his head thrown back,
+whilst he rolled his greenish eyes, lolled out his tongue, and rubbed
+his stomach with both hands as he uttered a kind of hollow yell like a
+famished dog. Emma, filled with disgust, threw him over her shoulder
+a five-franc piece. It was all her fortune. It seemed to her very fine
+thus to throw it away.
+
+The coach had gone on again when suddenly Monsieur Homais leant out
+through the window, crying--
+
+“No farinaceous or milk food, wear wool next the skin, and expose the
+diseased parts to the smoke of juniper berries.”
+
+The sight of the well-known objects that defiled before her eyes
+gradually diverted Emma from her present trouble. An intolerable fatigue
+overwhelmed her, and she reached her home stupefied, discouraged, almost
+asleep.
+
+“Come what may come!” she said to herself. “And then, who knows? Why, at
+any moment could not some extraordinary event occur? Lheureux even might
+die!”
+
+At nine o’clock in the morning she was awakened by the sound of voices
+in the Place. There was a crowd round the market reading a large bill
+fixed to one of the posts, and she saw Justin, who was climbing on to
+a stone and tearing down the bill. But at this moment the rural guard
+seized him by the collar. Monsieur Homais came out of his shop, and Mere
+Lefrangois, in the midst of the crowd, seemed to be perorating.
+
+“Madame! madame!” cried Felicite, running in, “it’s abominable!”
+
+And the poor girl, deeply moved, handed her a yellow paper that she had
+just torn off the door. Emma read with a glance that all her furniture
+was for sale.
+
+Then they looked at one another silently. The servant and mistress had
+no secret one from the other. At last Felicite sighed--
+
+“If I were you, madame, I should go to Monsieur Guillaumin.”
+
+“Do you think--”
+
+And this question meant to say--
+
+“You who know the house through the servant, has the master spoken
+sometimes of me?”
+
+“Yes, you’d do well to go there.”
+
+She dressed, put on her black gown, and her hood with jet beads, and
+that she might not be seen (there was still a crowd on the Place), she
+took the path by the river, outside the village.
+
+She reached the notary’s gate quite breathless. The sky was sombre, and
+a little snow was falling. At the sound of the bell, Theodore in a
+red waistcoat appeared on the steps; he came to open the door almost
+familiarly, as to an acquaintance, and showed her into the dining-room.
+
+A large porcelain stove crackled beneath a cactus that filled up the
+niche in the wall, and in black wood frames against the oak-stained
+paper hung Steuben’s “Esmeralda” and Schopin’s “Potiphar.” The
+ready-laid table, the two silver chafing-dishes, the crystal door-knobs,
+the parquet and the furniture, all shone with a scrupulous, English
+cleanliness; the windows were ornamented at each corner with stained
+glass.
+
+“Now this,” thought Emma, “is the dining-room I ought to have.”
+
+The notary came in pressing his palm-leaf dressing-gown to his breast
+with his left arm, while with the other hand he raised and quickly put
+on again his brown velvet cap, pretentiously cocked on the right side,
+whence looked out the ends of three fair curls drawn from the back of
+the head, following the line of his bald skull.
+
+After he had offered her a seat he sat down to breakfast, apologising
+profusely for his rudeness.
+
+“I have come,” she said, “to beg you, sir--”
+
+“What, madame? I am listening.”
+
+And she began explaining her position to him. Monsieur Guillaumin knew
+it, being secretly associated with the linendraper, from whom he always
+got capital for the loans on mortgages that he was asked to make.
+
+So he knew (and better than she herself) the long story of the bills,
+small at first, bearing different names as endorsers, made out at long
+dates, and constantly renewed up to the day, when, gathering together
+all the protested bills, the shopkeeper had bidden his friend Vincart
+take in his own name all the necessary proceedings, not wishing to pass
+for a tiger with his fellow-citizens.
+
+She mingled her story with recriminations against Lheureux, to which the
+notary replied from time to time with some insignificant word. Eating
+his cutlet and drinking his tea, he buried his chin in his sky-blue
+cravat, into which were thrust two diamond pins, held together by a
+small gold chain; and he smiled a singular smile, in a sugary, ambiguous
+fashion. But noticing that her feet were damp, he said--
+
+“Do get closer to the stove; put your feet up against the porcelain.”
+
+She was afraid of dirtying it. The notary replied in a gallant tone--
+
+“Beautiful things spoil nothing.”
+
+Then she tried to move him, and, growing moved herself, she began
+telling him about the poorness of her home, her worries, her wants.
+He could understand that; an elegant woman! and, without leaving off
+eating, he had turned completely round towards her, so that his knee
+brushed against her boot, whose sole curled round as it smoked against
+the stove.
+
+But when she asked for a thousand sous, he closed his lips, and declared
+he was very sorry he had not had the management of her fortune before,
+for there were hundreds of ways very convenient, even for a lady, of
+turning her money to account. They might, either in the turf-peats
+of Grumesnil or building-ground at Havre, almost without risk, have
+ventured on some excellent speculations; and he let her consume herself
+with rage at the thought of the fabulous sums that she would certainly
+have made.
+
+“How was it,” he went on, “that you didn’t come to me?”
+
+“I hardly know,” she said.
+
+“Why, hey? Did I frighten you so much? It is I, on the contrary, who
+ought to complain. We hardly know one another; yet I am very devoted to
+you. You do not doubt that, I hope?”
+
+He held out his hand, took hers, covered it with a greedy kiss, then
+held it on his knee; and he played delicately with her fingers whilst
+he murmured a thousand blandishments. His insipid voice murmured like a
+running brook; a light shone in his eyes through the glimmering of his
+spectacles, and his hand was advancing up Emma’s sleeve to press her
+arm. She felt against her cheek his panting breath. This man oppressed
+her horribly.
+
+She sprang up and said to him--
+
+“Sir, I am waiting.”
+
+“For what?” said the notary, who suddenly became very pale.
+
+“This money.”
+
+“But--” Then, yielding to the outburst of too powerful a desire, “Well,
+yes!”
+
+He dragged himself towards her on his knees, regardless of his
+dressing-gown.
+
+“For pity’s sake, stay. I love you!”
+
+He seized her by her waist. Madame Bovary’s face flushed purple. She
+recoiled with a terrible look, crying--
+
+“You are taking a shameless advantage of my distress, sir! I am to be
+pitied--not to be sold.”
+
+And she went out.
+
+The notary remained quite stupefied, his eyes fixed on his fine
+embroidered slippers. They were a love gift, and the sight of them at
+last consoled him. Besides, he reflected that such an adventure might
+have carried him too far.
+
+“What a wretch! what a scoundrel! what an infamy!” she said to herself,
+as she fled with nervous steps beneath the aspens of the path. The
+disappointment of her failure increased the indignation of her outraged
+modesty; it seemed to her that Providence pursued her implacably, and,
+strengthening herself in her pride, she had never felt so much esteem
+for herself nor so much contempt for others. A spirit of warfare
+transformed her. She would have liked to strike all men, to spit in
+their faces, to crush them, and she walked rapidly straight on, pale,
+quivering, maddened, searching the empty horizon with tear-dimmed eyes,
+and as it were rejoicing in the hate that was choking her.
+
+When she saw her house a numbness came over her. She could not go on;
+and yet she must. Besides, whither could she flee?
+
+Felicite was waiting for her at the door. “Well?”
+
+“No!” said Emma.
+
+And for a quarter of an hour the two of them went over the various
+persons in Yonville who might perhaps be inclined to help her. But each
+time that Felicite named someone Emma replied--
+
+“Impossible! they will not!”
+
+“And the master’ll soon be in.”
+
+“I know that well enough. Leave me alone.”
+
+She had tried everything; there was nothing more to be done now; and
+when Charles came in she would have to say to him--
+
+“Go away! This carpet on which you are walking is no longer ours. In
+your own house you do not possess a chair, a pin, a straw, and it is I,
+poor man, who have ruined you.”
+
+Then there would be a great sob; next he would weep abundantly, and at
+last, the surprise past, he would forgive her.
+
+“Yes,” she murmured, grinding her teeth, “he will forgive me, he who
+would give a million if I would forgive him for having known me! Never!
+never!”
+
+This thought of Bovary’s superiority to her exasperated her. Then,
+whether she confessed or did not confess, presently, immediately,
+to-morrow, he would know the catastrophe all the same; so she must wait
+for this horrible scene, and bear the weight of his magnanimity. The
+desire to return to Lheureux’s seized her--what would be the use? To
+write to her father--it was too late; and perhaps, she began to repent
+now that she had not yielded to that other, when she heard the trot of
+a horse in the alley. It was he; he was opening the gate; he was whiter
+than the plaster wall. Rushing to the stairs, she ran out quickly to the
+square; and the wife of the mayor, who was talking to Lestiboudois in
+front of the church, saw her go in to the tax-collector’s.
+
+She hurried off to tell Madame Caron, and the two ladies went up to
+the attic, and, hidden by some linen spread across props, stationed
+themselves comfortably for overlooking the whole of Binet’s room.
+
+He was alone in his garret, busy imitating in wood one of those
+indescribable bits of ivory, composed of crescents, of spheres hollowed
+out one within the other, the whole as straight as an obelisk, and of no
+use whatever; and he was beginning on the last piece--he was nearing his
+goal. In the twilight of the workshop the white dust was flying from his
+tools like a shower of sparks under the hoofs of a galloping horse; the
+two wheels were turning, droning; Binet smiled, his chin lowered, his
+nostrils distended, and, in a word, seemed lost in one of those complete
+happinesses that, no doubt, belong only to commonplace occupations,
+which amuse the mind with facile difficulties, and satisfy by a
+realisation of that beyond which such minds have not a dream.
+
+“Ah! there she is!” exclaimed Madame Tuvache.
+
+But it was impossible because of the lathe to hear what she was saying.
+
+At last these ladies thought they made out the word “francs,” and Madame
+Tuvache whispered in a low voice--
+
+“She is begging him to give her time for paying her taxes.”
+
+“Apparently!” replied the other.
+
+They saw her walking up and down, examining the napkin-rings, the
+candlesticks, the banister rails against the walls, while Binet stroked
+his beard with satisfaction.
+
+“Do you think she wants to order something of him?” said Madame Tuvache.
+
+“Why, he doesn’t sell anything,” objected her neighbour.
+
+The tax-collector seemed to be listening with wide-open eyes, as if he
+did not understand. She went on in a tender, suppliant manner. She came
+nearer to him, her breast heaving; they no longer spoke.
+
+“Is she making him advances?” said Madame Tuvache. Binet was scarlet to
+his very ears. She took hold of his hands.
+
+“Oh, it’s too much!”
+
+And no doubt she was suggesting something abominable to him; for the
+tax-collector--yet he was brave, had fought at Bautzen and at Lutzen,
+had been through the French campaign, and had even been recommended for
+the cross--suddenly, as at the sight of a serpent, recoiled as far as he
+could from her, crying--
+
+“Madame! what do you mean?”
+
+“Women like that ought to be whipped,” said Madame Tuvache.
+
+“But where is she?” continued Madame Caron, for she had disappeared
+whilst they spoke; then catching sight of her going up the Grande Rue,
+and turning to the right as if making for the cemetery, they were lost
+in conjectures.
+
+“Nurse Rollet,” she said on reaching the nurse’s, “I am choking; unlace
+me!” She fell on the bed sobbing. Nurse Rollet covered her with a
+petticoat and remained standing by her side. Then, as she did not
+answer, the good woman withdrew, took her wheel and began spinning flax.
+
+“Oh, leave off!” she murmured, fancying she heard Binet’s lathe.
+
+“What’s bothering her?” said the nurse to herself. “Why has she come
+here?”
+
+She had rushed thither; impelled by a kind of horror that drove her from
+her home.
+
+Lying on her back, motionless, and with staring eyes, she saw things but
+vaguely, although she tried to with idiotic persistence. She looked
+at the scales on the walls, two brands smoking end to end, and a long
+spider crawling over her head in a rent in the beam. At last she began
+to collect her thoughts. She remembered--one day--Leon--Oh! how long
+ago that was--the sun was shining on the river, and the clematis were
+perfuming the air. Then, carried away as by a rushing torrent, she soon
+began to recall the day before.
+
+“What time is it?” she asked.
+
+Mere Rollet went out, raised the fingers of her right hand to that side
+of the sky that was brightest, and came back slowly, saying--
+
+“Nearly three.”
+
+“Ah! thanks, thanks!”
+
+For he would come; he would have found some money. But he would,
+perhaps, go down yonder, not guessing she was here, and she told the
+nurse to run to her house to fetch him.
+
+“Be quick!”
+
+“But, my dear lady, I’m going, I’m going!”
+
+She wondered now that she had not thought of him from the first.
+Yesterday he had given his word; he would not break it. And she already
+saw herself at Lheureux’s spreading out her three bank-notes on his
+bureau. Then she would have to invent some story to explain matters to
+Bovary. What should it be?
+
+The nurse, however, was a long while gone. But, as there was no clock
+in the cot, Emma feared she was perhaps exaggerating the length of time.
+She began walking round the garden, step by step; she went into the path
+by the hedge, and returned quickly, hoping that the woman would have
+come back by another road. At last, weary of waiting, assailed by fears
+that she thrust from her, no longer conscious whether she had been here
+a century or a moment, she sat down in a corner, closed her eyes, and
+stopped her ears. The gate grated; she sprang up. Before she had spoken
+Mere Rollet said to her--
+
+“There is no one at your house!”
+
+“What?”
+
+“Oh, no one! And the doctor is crying. He is calling for you; they’re
+looking for you.”
+
+Emma answered nothing. She gasped as she turned her eyes about
+her, while the peasant woman, frightened at her face, drew back
+instinctively, thinking her mad. Suddenly she struck her brow and
+uttered a cry; for the thought of Rodolphe, like a flash of lightning in
+a dark night, had passed into her soul. He was so good, so delicate, so
+generous! And besides, should he hesitate to do her this service, she
+would know well enough how to constrain him to it by re-waking, in a
+single moment, their lost love. So she set out towards La Huchette, not
+seeing that she was hastening to offer herself to that which but a while
+ago had so angered her, not in the least conscious of her prostitution.
+
+
+
+Chapter Eight
+
+She asked herself as she walked along, “What am I going to say? How
+shall I begin?” And as she went on she recognised the thickets,
+the trees, the sea-rushes on the hill, the chateau yonder. All the
+sensations of her first tenderness came back to her, and her poor aching
+heart opened out amorously. A warm wind blew in her face; the melting
+snow fell drop by drop from the buds to the grass.
+
+She entered, as she used to, through the small park-gate. She reached
+the avenue bordered by a double row of dense lime-trees. They were
+swaying their long whispering branches to and fro. The dogs in their
+kennels all barked, and the noise of their voices resounded, but brought
+out no one.
+
+She went up the large straight staircase with wooden balusters that led
+to the corridor paved with dusty flags, into which several doors in a
+row opened, as in a monastery or an inn. His was at the top, right
+at the end, on the left. When she placed her fingers on the lock her
+strength suddenly deserted her. She was afraid, almost wished he
+would not be there, though this was her only hope, her last chance of
+salvation. She collected her thoughts for one moment, and, strengthening
+herself by the feeling of present necessity, went in.
+
+He was in front of the fire, both his feet on the mantelpiece, smoking a
+pipe.
+
+“What! it is you!” he said, getting up hurriedly.
+
+“Yes, it is I, Rodolphe. I should like to ask your advice.”
+
+And, despite all her efforts, it was impossible for her to open her
+lips.
+
+“You have not changed; you are charming as ever!”
+
+“Oh,” she replied bitterly, “they are poor charms since you disdained
+them.”
+
+Then he began a long explanation of his conduct, excusing himself in
+vague terms, in default of being able to invent better.
+
+She yielded to his words, still more to his voice and the sight of him,
+so that, she pretended to believe, or perhaps believed; in the pretext
+he gave for their rupture; this was a secret on which depended the
+honour, the very life of a third person.
+
+“No matter!” she said, looking at him sadly. “I have suffered much.”
+
+He replied philosophically--
+
+“Such is life!”
+
+“Has life,” Emma went on, “been good to you at least, since our
+separation?”
+
+“Oh, neither good nor bad.”
+
+“Perhaps it would have been better never to have parted.”
+
+“Yes, perhaps.”
+
+“You think so?” she said, drawing nearer, and she sighed. “Oh, Rodolphe!
+if you but knew! I loved you so!”
+
+It was then that she took his hand, and they remained some time, their
+fingers intertwined, like that first day at the Show. With a gesture of
+pride he struggled against this emotion. But sinking upon his breast she
+said to him--
+
+“How did you think I could live without you? One cannot lose the habit
+of happiness. I was desolate. I thought I should die. I will tell you
+about all that and you will see. And you--you fled from me!”
+
+For, all the three years, he had carefully avoided her in consequence
+of that natural cowardice that characterises the stronger sex. Emma went
+on, with dainty little nods, more coaxing than an amorous kitten--
+
+“You love others, confess it! Oh, I understand them, dear! I excuse
+them. You probably seduced them as you seduced me. You are indeed a man;
+you have everything to make one love you. But we’ll begin again, won’t
+we? We will love one another. See! I am laughing; I am happy! Oh,
+speak!”
+
+And she was charming to see, with her eyes, in which trembled a tear,
+like the rain of a storm in a blue corolla.
+
+He had drawn her upon his knees, and with the back of his hand was
+caressing her smooth hair, where in the twilight was mirrored like a
+golden arrow one last ray of the sun. She bent down her brow; at last he
+kissed her on the eyelids quite gently with the tips of his lips.
+
+“Why, you have been crying! What for?”
+
+She burst into tears. Rodolphe thought this was an outburst of her
+love. As she did not speak, he took this silence for a last remnant of
+resistance, and then he cried out--
+
+“Oh, forgive me! You are the only one who pleases me. I was imbecile and
+cruel. I love you. I will love you always. What is it. Tell me!” He was
+kneeling by her.
+
+“Well, I am ruined, Rodolphe! You must lend me three thousand francs.”
+
+“But--but--” said he, getting up slowly, while his face assumed a grave
+expression.
+
+“You know,” she went on quickly, “that my husband had placed his whole
+fortune at a notary’s. He ran away. So we borrowed; the patients don’t
+pay us. Moreover, the settling of the estate is not yet done; we shall
+have the money later on. But to-day, for want of three thousand francs,
+we are to be sold up. It is to be at once, this very moment, and,
+counting upon your friendship, I have come to you.”
+
+“Ah!” thought Rodolphe, turning very pale, “that was what she came for.”
+ At last he said with a calm air--
+
+“Dear madame, I have not got them.”
+
+He did not lie. If he had had them, he would, no doubt, have given them,
+although it is generally disagreeable to do such fine things: a demand
+for money being, of all the winds that blow upon love, the coldest and
+most destructive.
+
+First she looked at him for some moments.
+
+“You have not got them!” she repeated several times. “You have not got
+them! I ought to have spared myself this last shame. You never loved me.
+You are no better than the others.”
+
+She was betraying, ruining herself.
+
+Rodolphe interrupted her, declaring he was “hard up” himself.
+
+“Ah! I pity you,” said Emma. “Yes--very much.”
+
+And fixing her eyes upon an embossed carabine, that shone against its
+panoply, “But when one is so poor one doesn’t have silver on the butt of
+one’s gun. One doesn’t buy a clock inlaid with tortoise shell,” she went
+on, pointing to a buhl timepiece, “nor silver-gilt whistles for one’s
+whips,” and she touched them, “nor charms for one’s watch. Oh, he wants
+for nothing! even to a liqueur-stand in his room! For you love yourself;
+you live well. You have a chateau, farms, woods; you go hunting; you
+travel to Paris. Why, if it were but that,” she cried, taking up two
+studs from the mantelpiece, “but the least of these trifles, one can get
+money for them. Oh, I do not want them, keep them!”
+
+And she threw the two links away from her, their gold chain breaking as
+it struck against the wall.
+
+“But I! I would have given you everything. I would have sold all, worked
+for you with my hands, I would have begged on the highroads for a smile,
+for a look, to hear you say ‘Thanks!’ And you sit there quietly in your
+arm-chair, as if you had not made me suffer enough already! But for you,
+and you know it, I might have lived happily. What made you do it? Was
+it a bet? Yet you loved me--you said so. And but a moment since--Ah!
+it would have been better to have driven me away. My hands are hot with
+your kisses, and there is the spot on the carpet where at my knees you
+swore an eternity of love! You made me believe you; for two years you
+held me in the most magnificent, the sweetest dream! Eh! Our plans for
+the journey, do you remember? Oh, your letter! your letter! it tore my
+heart! And then when I come back to him--to him, rich, happy, free--to
+implore the help the first stranger would give, a suppliant, and
+bringing back to him all my tenderness, he repulses me because it would
+cost him three thousand francs!”
+
+“I haven’t got them,” replied Rodolphe, with that perfect calm with
+which resigned rage covers itself as with a shield.
+
+She went out. The walls trembled, the ceiling was crushing her, and she
+passed back through the long alley, stumbling against the heaps of dead
+leaves scattered by the wind. At last she reached the ha-ha hedge in
+front of the gate; she broke her nails against the lock in her haste to
+open it. Then a hundred steps farther on, breathless, almost falling,
+she stopped. And now turning round, she once more saw the impassive
+chateau, with the park, the gardens, the three courts, and all the
+windows of the facade.
+
+She remained lost in stupor, and having no more consciousness of herself
+than through the beating of her arteries, that she seemed to hear
+bursting forth like a deafening music filling all the fields. The earth
+beneath her feet was more yielding than the sea, and the furrows seemed
+to her immense brown waves breaking into foam. Everything in her
+head, of memories, ideas, went off at once like a thousand pieces of
+fireworks. She saw her father, Lheureux’s closet, their room at home,
+another landscape. Madness was coming upon her; she grew afraid, and
+managed to recover herself, in a confused way, it is true, for she did
+not in the least remember the cause of the terrible condition she was
+in, that is to say, the question of money. She suffered only in her
+love, and felt her soul passing from her in this memory; as wounded men,
+dying, feel their life ebb from their bleeding wounds.
+
+Night was falling, crows were flying about.
+
+Suddenly it seemed to her that fiery spheres were exploding in the air
+like fulminating balls when they strike, and were whirling, whirling,
+to melt at last upon the snow between the branches of the trees. In the
+midst of each of them appeared the face of Rodolphe. They multiplied and
+drew near her, penetrating, her. It all disappeared; she recognised the
+lights of the houses that shone through the fog.
+
+Now her situation, like an abyss, rose up before her. She was panting as
+if her heart would burst. Then in an ecstasy of heroism, that made
+her almost joyous, she ran down the hill, crossed the cow-plank, the
+foot-path, the alley, the market, and reached the chemist’s shop. She
+was about to enter, but at the sound of the bell someone might come, and
+slipping in by the gate, holding her breath, feeling her way along the
+walls, she went as far as the door of the kitchen, where a candle stuck
+on the stove was burning. Justin in his shirt-sleeves was carrying out a
+dish.
+
+“Ah! they are dining; I will wait.”
+
+He returned; she tapped at the window. He went out.
+
+“The key! the one for upstairs where he keeps the--”
+
+“What?”
+
+And he looked at her, astonished at the pallor of her face, that stood
+out white against the black background of the night. She seemed to
+him extraordinarily beautiful and majestic as a phantom. Without
+understanding what she wanted, he had the presentiment of something
+terrible.
+
+But she went on quickly in a love voice; in a sweet, melting voice, “I
+want it; give it to me.”
+
+As the partition wall was thin, they could hear the clatter of the forks
+on the plates in the dining-room.
+
+She pretended that she wanted to kill the rats that kept her from
+sleeping.
+
+“I must tell master.”
+
+“No, stay!” Then with an indifferent air, “Oh, it’s not worth while;
+I’ll tell him presently. Come, light me upstairs.”
+
+She entered the corridor into which the laboratory door opened. Against
+the wall was a key labelled Capharnaum.
+
+“Justin!” called the druggist impatiently.
+
+“Let us go up.”
+
+And he followed her. The key turned in the lock, and she went straight
+to the third shelf, so well did her memory guide her, seized the blue
+jar, tore out the cork, plunged in her hand, and withdrawing it full of
+a white powder, she began eating it.
+
+“Stop!” he cried, rushing at her.
+
+“Hush! someone will come.”
+
+He was in despair, was calling out.
+
+“Say nothing, or all the blame will fall on your master.”
+
+Then she went home, suddenly calmed, and with something of the serenity
+of one that had performed a duty.
+
+When Charles, distracted by the news of the distraint, returned home,
+Emma had just gone out. He cried aloud, wept, fainted, but she did not
+return. Where could she be? He sent Felicite to Homais, to Monsieur
+Tuvache, to Lheureux, to the “Lion d’Or,” everywhere, and in the
+intervals of his agony he saw his reputation destroyed, their fortune
+lost, Berthe’s future ruined. By what?--Not a word! He waited till six
+in the evening. At last, unable to bear it any longer, and fancying she
+had gone to Rouen, he set out along the highroad, walked a mile, met no
+one, again waited, and returned home. She had come back.
+
+“What was the matter? Why? Explain to me.”
+
+She sat down at her writing-table and wrote a letter, which she sealed
+slowly, adding the date and the hour. Then she said in a solemn tone:
+
+“You are to read it to-morrow; till then, I pray you, do not ask me a
+single question. No, not one!”
+
+“But--”
+
+“Oh, leave me!”
+
+She lay down full length on her bed. A bitter taste that she felt in her
+mouth awakened her. She saw Charles, and again closed her eyes.
+
+She was studying herself curiously, to see if she were not suffering.
+But no! nothing as yet. She heard the ticking of the clock, the
+crackling of the fire, and Charles breathing as he stood upright by her
+bed.
+
+“Ah! it is but a little thing, death!” she thought. “I shall fall asleep
+and all will be over.”
+
+She drank a mouthful of water and turned to the wall. The frightful
+taste of ink continued.
+
+“I am thirsty; oh! so thirsty,” she sighed.
+
+“What is it?” said Charles, who was handing her a glass.
+
+“It is nothing! Open the window; I am choking.”
+
+She was seized with a sickness so sudden that she had hardly time to
+draw out her handkerchief from under the pillow.
+
+“Take it away,” she said quickly; “throw it away.”
+
+He spoke to her; she did not answer. She lay motionless, afraid that
+the slightest movement might make her vomit. But she felt an icy cold
+creeping from her feet to her heart.
+
+“Ah! it is beginning,” she murmured.
+
+“What did you say?”
+
+She turned her head from side to side with a gentle movement full of
+agony, while constantly opening her mouth as if something very heavy
+were weighing upon her tongue. At eight o’clock the vomiting began
+again.
+
+Charles noticed that at the bottom of the basin there was a sort of
+white sediment sticking to the sides of the porcelain.
+
+“This is extraordinary--very singular,” he repeated.
+
+But she said in a firm voice, “No, you are mistaken.”
+
+Then gently, and almost as caressing her, he passed his hand over her
+stomach. She uttered a sharp cry. He fell back terror-stricken.
+
+Then she began to groan, faintly at first. Her shoulders were shaken by
+a strong shuddering, and she was growing paler than the sheets in which
+her clenched fingers buried themselves. Her unequal pulse was now almost
+imperceptible.
+
+Drops of sweat oozed from her bluish face, that seemed as if rigid in
+the exhalations of a metallic vapour. Her teeth chattered, her dilated
+eyes looked vaguely about her, and to all questions she replied only
+with a shake of the head; she even smiled once or twice. Gradually, her
+moaning grew louder; a hollow shriek burst from her; she pretended she
+was better and that she would get up presently. But she was seized with
+convulsions and cried out--
+
+“Ah! my God! It is horrible!”
+
+He threw himself on his knees by her bed.
+
+“Tell me! what have you eaten? Answer, for heaven’s sake!”
+
+And he looked at her with a tenderness in his eyes such as she had never
+seen.
+
+“Well, there--there!” she said in a faint voice. He flew to the
+writing-table, tore open the seal, and read aloud: “Accuse no one.” He
+stopped, passed his hands across his eyes, and read it over again.
+
+“What! help--help!”
+
+He could only keep repeating the word: “Poisoned! poisoned!” Felicite
+ran to Homais, who proclaimed it in the market-place; Madame Lefrancois
+heard it at the “Lion d’Or”; some got up to go and tell their
+neighbours, and all night the village was on the alert.
+
+Distraught, faltering, reeling, Charles wandered about the room. He
+knocked against the furniture, tore his hair, and the chemist had never
+believed that there could be so terrible a sight.
+
+He went home to write to Monsieur Canivet and to Doctor Lariviere. He
+lost his head, and made more than fifteen rough copies. Hippolyte went
+to Neufchatel, and Justin so spurred Bovary’s horse that he left it
+foundered and three parts dead by the hill at Bois-Guillaume.
+
+Charles tried to look up his medical dictionary, but could not read it;
+the lines were dancing.
+
+“Be calm,” said the druggist; “we have only to administer a powerful
+antidote. What is the poison?”
+
+Charles showed him the letter. It was arsenic.
+
+“Very well,” said Homais, “we must make an analysis.”
+
+For he knew that in cases of poisoning an analysis must be made; and the
+other, who did not understand, answered--
+
+“Oh, do anything! save her!”
+
+Then going back to her, he sank upon the carpet, and lay there with his
+head leaning against the edge of her bed, sobbing.
+
+“Don’t cry,” she said to him. “Soon I shall not trouble you any more.”
+
+“Why was it? Who drove you to it?”
+
+She replied. “It had to be, my dear!”
+
+“Weren’t you happy? Is it my fault? I did all I could!”
+
+“Yes, that is true--you are good--you.”
+
+And she passed her hand slowly over his hair. The sweetness of this
+sensation deepened his sadness; he felt his whole being dissolving
+in despair at the thought that he must lose her, just when she was
+confessing more love for him than ever. And he could think of nothing;
+he did not know, he did not dare; the urgent need for some immediate
+resolution gave the finishing stroke to the turmoil of his mind.
+
+So she had done, she thought, with all the treachery; and meanness,
+and numberless desires that had tortured her. She hated no one now; a
+twilight dimness was settling upon her thoughts, and, of all earthly
+noises, Emma heard none but the intermittent lamentations of this poor
+heart, sweet and indistinct like the echo of a symphony dying away.
+
+“Bring me the child,” she said, raising herself on her elbow.
+
+“You are not worse, are you?” asked Charles.
+
+“No, no!”
+
+The child, serious, and still half-asleep, was carried in on the
+servant’s arm in her long white nightgown, from which her bare
+feet peeped out. She looked wonderingly at the disordered room, and
+half-closed her eyes, dazzled by the candles burning on the table. They
+reminded her, no doubt, of the morning of New Year’s day and Mid-Lent,
+when thus awakened early by candle-light she came to her mother’s bed to
+fetch her presents, for she began saying--
+
+“But where is it, mamma?” And as everybody was silent, “But I can’t see
+my little stocking.”
+
+Felicite held her over the bed while she still kept looking towards the
+mantelpiece.
+
+“Has nurse taken it?” she asked.
+
+And at this name, that carried her back to the memory of her adulteries
+and her calamities, Madame Bovary turned away her head, as at the
+loathing of another bitterer poison that rose to her mouth. But Berthe
+remained perched on the bed.
+
+“Oh, how big your eyes are, mamma! How pale you are! how hot you are!”
+
+Her mother looked at her. “I am frightened!” cried the child, recoiling.
+
+Emma took her hand to kiss it; the child struggled.
+
+“That will do. Take her away,” cried Charles, who was sobbing in the
+alcove.
+
+Then the symptoms ceased for a moment; she seemed less agitated; and at
+every insignificant word, at every respiration a little more easy, he
+regained hope. At last, when Canivet came in, he threw himself into his
+arms.
+
+“Ah! it is you. Thanks! You are good! But she is better. See! look at
+her.”
+
+His colleague was by no means of this opinion, and, as he said of
+himself, “never beating about the bush,” he prescribed, an emetic in
+order to empty the stomach completely.
+
+She soon began vomiting blood. Her lips became drawn. Her limbs were
+convulsed, her whole body covered with brown spots, and her pulse
+slipped beneath the fingers like a stretched thread, like a harp-string
+nearly breaking.
+
+After this she began to scream horribly. She cursed the poison, railed
+at it, and implored it to be quick, and thrust away with her stiffened
+arms everything that Charles, in more agony than herself, tried to make
+her drink. He stood up, his handkerchief to his lips, with a rattling
+sound in his throat, weeping, and choked by sobs that shook his whole
+body. Felicite was running hither and thither in the room. Homais,
+motionless, uttered great sighs; and Monsieur Canivet, always retaining
+his self-command, nevertheless began to feel uneasy.
+
+“The devil! yet she has been purged, and from the moment that the cause
+ceases--”
+
+“The effect must cease,” said Homais, “that is evident.”
+
+“Oh, save her!” cried Bovary.
+
+And, without listening to the chemist, who was still venturing the
+hypothesis, “It is perhaps a salutary paroxysm,” Canivet was about to
+administer some theriac, when they heard the cracking of a whip; all the
+windows rattled, and a post-chaise drawn by three horses abreast, up to
+their ears in mud, drove at a gallop round the corner of the market. It
+was Doctor Lariviere.
+
+The apparition of a god would not have caused more commotion. Bovary
+raised his hands; Canivet stopped short; and Homais pulled off his
+skull-cap long before the doctor had come in.
+
+He belonged to that great school of surgery begotten of Bichat, to that
+generation, now extinct, of philosophical practitioners, who, loving
+their art with a fanatical love, exercised it with enthusiasm and
+wisdom. Everyone in his hospital trembled when he was angry; and his
+students so revered him that they tried, as soon as they were themselves
+in practice, to imitate him as much as possible. So that in all the
+towns about they were found wearing his long wadded merino overcoat
+and black frock-coat, whose buttoned cuffs slightly covered his brawny
+hands--very beautiful hands, and that never knew gloves, as though to be
+more ready to plunge into suffering. Disdainful of honours, of titles,
+and of academies, like one of the old Knight-Hospitallers, generous,
+fatherly to the poor, and practising virtue without believing in it, he
+would almost have passed for a saint if the keenness of his intellect
+had not caused him to be feared as a demon. His glance, more penetrating
+than his bistouries, looked straight into your soul, and dissected every
+lie athwart all assertions and all reticences. And thus he went along,
+full of that debonair majesty that is given by the consciousness
+of great talent, of fortune, and of forty years of a labourious and
+irreproachable life.
+
+He frowned as soon as he had passed the door when he saw the cadaverous
+face of Emma stretched out on her back with her mouth open. Then, while
+apparently listening to Canivet, he rubbed his fingers up and down
+beneath his nostrils, and repeated--
+
+“Good! good!”
+
+But he made a slow gesture with his shoulders. Bovary watched him; they
+looked at one another; and this man, accustomed as he was to the sight
+of pain, could not keep back a tear that fell on his shirt-frill.
+
+He tried to take Canivet into the next room. Charles followed him.
+
+“She is very ill, isn’t she? If we put on sinapisms? Anything! Oh, think
+of something, you who have saved so many!”
+
+Charles caught him in both his arms, and gazed at him wildly,
+imploringly, half-fainting against his breast.
+
+“Come, my poor fellow, courage! There is nothing more to be done.”
+
+And Doctor Lariviere turned away.
+
+“You are going?”
+
+“I will come back.”
+
+He went out only to give an order to the coachman, with Monsieur
+Canivet, who did not care either to have Emma die under his hands.
+
+The chemist rejoined them on the Place. He could not by temperament keep
+away from celebrities, so he begged Monsieur Lariviere to do him the
+signal honour of accepting some breakfast.
+
+He sent quickly to the “Lion d’Or” for some pigeons; to the butcher’s
+for all the cutlets that were to be had; to Tuvache for cream; and
+to Lestiboudois for eggs; and the druggist himself aided in the
+preparations, while Madame Homais was saying as she pulled together the
+strings of her jacket--
+
+“You must excuse us, sir, for in this poor place, when one hasn’t been
+told the night before--”
+
+“Wine glasses!” whispered Homais.
+
+“If only we were in town, we could fall back upon stuffed trotters.”
+
+“Be quiet! Sit down, doctor!”
+
+He thought fit, after the first few mouthfuls, to give some details as
+to the catastrophe.
+
+“We first had a feeling of siccity in the pharynx, then intolerable
+pains at the epigastrium, super purgation, coma.”
+
+“But how did she poison herself?”
+
+“I don’t know, doctor, and I don’t even know where she can have procured
+the arsenious acid.”
+
+Justin, who was just bringing in a pile of plates, began to tremble.
+
+“What’s the matter?” said the chemist.
+
+At this question the young man dropped the whole lot on the ground with
+a crash.
+
+“Imbecile!” cried Homais, “awkward lout! block-head! confounded ass!”
+
+But suddenly controlling himself--
+
+“I wished, doctor, to make an analysis, and primo I delicately
+introduced a tube--”
+
+“You would have done better,” said the physician, “to introduce your
+fingers into her throat.”
+
+His colleague was silent, having just before privately received a severe
+lecture about his emetic, so that this good Canivet, so arrogant and so
+verbose at the time of the clubfoot, was to-day very modest. He smiled
+without ceasing in an approving manner.
+
+Homais dilated in Amphytrionic pride, and the affecting thought of
+Bovary vaguely contributed to his pleasure by a kind of egotistic
+reflex upon himself. Then the presence of the doctor transported him.
+He displayed his erudition, cited pell-mell cantharides, upas, the
+manchineel, vipers.
+
+“I have even read that various persons have found themselves
+under toxicological symptoms, and, as it were, thunderstricken by
+black-pudding that had been subjected to a too vehement fumigation.
+At least, this was stated in a very fine report drawn up by one of our
+pharmaceutical chiefs, one of our masters, the illustrious Cadet de
+Gassicourt!”
+
+Madame Homais reappeared, carrying one of those shaky machines that
+are heated with spirits of wine; for Homais liked to make his coffee
+at table, having, moreover, torrefied it, pulverised it, and mixed it
+himself.
+
+“Saccharum, doctor?” said he, offering the sugar.
+
+Then he had all his children brought down, anxious to have the
+physician’s opinion on their constitutions.
+
+At last Monsieur Lariviere was about to leave, when Madame Homais asked
+for a consultation about her husband. He was making his blood too thick
+by going to sleep every evening after dinner.
+
+“Oh, it isn’t his blood that’s too thick,” said the physician.
+
+And, smiling a little at his unnoticed joke, the doctor opened the
+door. But the chemist’s shop was full of people; he had the greatest
+difficulty in getting rid of Monsieur Tuvache, who feared his spouse
+would get inflammation of the lungs, because she was in the habit of
+spitting on the ashes; then of Monsieur Binet, who sometimes experienced
+sudden attacks of great hunger; and of Madame Caron, who suffered
+from tinglings; of Lheureux, who had vertigo; of Lestiboudois, who had
+rheumatism; and of Madame Lefrancois, who had heartburn. At last the
+three horses started; and it was the general opinion that he had not
+shown himself at all obliging.
+
+Public attention was distracted by the appearance of Monsieur
+Bournisien, who was going across the market with the holy oil.
+
+Homais, as was due to his principles, compared priests to ravens
+attracted by the odour of death. The sight of an ecclesiastic was
+personally disagreeable to him, for the cassock made him think of the
+shroud, and he detested the one from some fear of the other.
+
+Nevertheless, not shrinking from what he called his mission, he returned
+to Bovary’s in company with Canivet whom Monsieur Lariviere, before
+leaving, had strongly urged to make this visit; and he would, but for
+his wife’s objections, have taken his two sons with him, in order
+to accustom them to great occasions; that this might be a lesson, an
+example, a solemn picture, that should remain in their heads later on.
+
+The room when they went in was full of mournful solemnity. On the
+work-table, covered over with a white cloth, there were five or six
+small balls of cotton in a silver dish, near a large crucifix between
+two lighted candles.
+
+Emma, her chin sunken upon her breast, had her eyes inordinately wide
+open, and her poor hands wandered over the sheets with that hideous
+and soft movement of the dying, that seems as if they wanted already to
+cover themselves with the shroud. Pale as a statue and with eyes red as
+fire, Charles, not weeping, stood opposite her at the foot of the bed,
+while the priest, bending one knee, was muttering words in a low voice.
+
+She turned her face slowly, and seemed filled with joy on seeing
+suddenly the violet stole, no doubt finding again, in the midst of
+a temporary lull in her pain, the lost voluptuousness of her first
+mystical transports, with the visions of eternal beatitude that were
+beginning.
+
+The priest rose to take the crucifix; then she stretched forward her
+neck as one who is athirst, and glueing her lips to the body of the
+Man-God, she pressed upon it with all her expiring strength the fullest
+kiss of love that she had ever given. Then he recited the Misereatur and
+the Indulgentiam, dipped his right thumb in the oil, and began to give
+extreme unction. First upon the eyes, that had so coveted all worldly
+pomp; then upon the nostrils, that had been greedy of the warm breeze
+and amorous odours; then upon the mouth, that had uttered lies, that had
+curled with pride and cried out in lewdness; then upon the hands that
+had delighted in sensual touches; and finally upon the soles of the
+feet, so swift of yore, when she was running to satisfy her desires, and
+that would now walk no more.
+
+The cure wiped his fingers, threw the bit of cotton dipped in oil into
+the fire, and came and sat down by the dying woman, to tell her that
+she must now blend her sufferings with those of Jesus Christ and abandon
+herself to the divine mercy.
+
+Finishing his exhortations, he tried to place in her hand a blessed
+candle, symbol of the celestial glory with which she was soon to be
+surrounded. Emma, too weak, could not close her fingers, and the taper,
+but for Monsieur Bournisien would have fallen to the ground.
+
+However, she was not quite so pale, and her face had an expression of
+serenity as if the sacrament had cured her.
+
+The priest did not fail to point this out; he even explained to Bovary
+that the Lord sometimes prolonged the life of persons when he thought it
+meet for their salvation; and Charles remembered the day when, so near
+death, she had received the communion. Perhaps there was no need to
+despair, he thought.
+
+In fact, she looked around her slowly, as one awakening from a dream;
+then in a distinct voice she asked for her looking-glass, and remained
+some time bending over it, until the big tears fell from her eyes. Then
+she turned away her head with a sigh and fell back upon the pillows.
+
+Her chest soon began panting rapidly; the whole of her tongue protruded
+from her mouth; her eyes, as they rolled, grew paler, like the two
+globes of a lamp that is going out, so that one might have thought
+her already dead but for the fearful labouring of her ribs, shaken
+by violent breathing, as if the soul were struggling to free itself.
+Felicite knelt down before the crucifix, and the druggist himself
+slightly bent his knees, while Monsieur Canivet looked out vaguely at
+the Place. Bournisien had again begun to pray, his face bowed against
+the edge of the bed, his long black cassock trailing behind him in the
+room. Charles was on the other side, on his knees, his arms outstretched
+towards Emma. He had taken her hands and pressed them, shuddering at
+every beat of her heart, as at the shaking of a falling ruin. As the
+death-rattle became stronger the priest prayed faster; his prayers
+mingled with the stifled sobs of Bovary, and sometimes all seemed lost
+in the muffled murmur of the Latin syllables that tolled like a passing
+bell.
+
+Suddenly on the pavement was heard a loud noise of clogs and the
+clattering of a stick; and a voice rose--a raucous voice--that sang--
+
+“Maids in the warmth of a summer day Dream of love and of love always”
+
+Emma raised herself like a galvanised corpse, her hair undone, her eyes
+fixed, staring.
+
+“Where the sickle blades have been, Nannette, gathering ears of corn,
+Passes bending down, my queen, To the earth where they were born.”
+
+“The blind man!” she cried. And Emma began to laugh, an atrocious,
+frantic, despairing laugh, thinking she saw the hideous face of the poor
+wretch that stood out against the eternal night like a menace.
+
+“The wind is strong this summer day, Her petticoat has flown away.”
+
+She fell back upon the mattress in a convulsion. They all drew near. She
+was dead.
+
+
+
+Chapter Nine
+
+There is always after the death of anyone a kind of stupefaction;
+so difficult is it to grasp this advent of nothingness and to resign
+ourselves to believe in it. But still, when he saw that she did not
+move, Charles threw himself upon her, crying--
+
+“Farewell! farewell!”
+
+Homais and Canivet dragged him from the room.
+
+“Restrain yourself!”
+
+“Yes.” said he, struggling, “I’ll be quiet. I’ll not do anything. But
+leave me alone. I want to see her. She is my wife!”
+
+And he wept.
+
+“Cry,” said the chemist; “let nature take her course; that will solace
+you.”
+
+Weaker than a child, Charles let himself be led downstairs into the
+sitting-room, and Monsieur Homais soon went home. On the Place he
+was accosted by the blind man, who, having dragged himself as far as
+Yonville, in the hope of getting the antiphlogistic pomade, was asking
+every passer-by where the druggist lived.
+
+“There now! as if I hadn’t got other fish to fry. Well, so much the
+worse; you must come later on.”
+
+And he entered the shop hurriedly.
+
+He had to write two letters, to prepare a soothing potion for Bovary, to
+invent some lie that would conceal the poisoning, and work it up into an
+article for the “Fanal,” without counting the people who were waiting to
+get the news from him; and when the Yonvillers had all heard his story
+of the arsenic that she had mistaken for sugar in making a vanilla
+cream. Homais once more returned to Bovary’s.
+
+He found him alone (Monsieur Canivet had left), sitting in an arm-chair
+near the window, staring with an idiotic look at the flags of the floor.
+
+“Now,” said the chemist, “you ought yourself to fix the hour for the
+ceremony.”
+
+“Why? What ceremony?” Then, in a stammering, frightened voice, “Oh, no!
+not that. No! I want to see her here.”
+
+Homais, to keep himself in countenance, took up a water-bottle on the
+whatnot to water the geraniums.
+
+“Ah! thanks,” said Charles; “you are good.”
+
+But he did not finish, choking beneath the crowd of memories that this
+action of the druggist recalled to him.
+
+Then to distract him, Homais thought fit to talk a little horticulture:
+plants wanted humidity. Charles bowed his head in sign of approbation.
+
+“Besides, the fine days will soon be here again.”
+
+“Ah!” said Bovary.
+
+The druggist, at his wit’s end, began softly to draw aside the small
+window-curtain.
+
+“Hallo! there’s Monsieur Tuvache passing.”
+
+Charles repeated like a machine---
+
+“Monsieur Tuvache passing!”
+
+Homais did not dare to speak to him again about the funeral
+arrangements; it was the priest who succeeded in reconciling him to
+them.
+
+He shut himself up in his consulting-room, took a pen, and after sobbing
+for some time, wrote--
+
+“I wish her to be buried in her wedding-dress, with white shoes, and a
+wreath. Her hair is to be spread out over her shoulders. Three coffins,
+one of oak, one of mahogany, one of lead. Let no one say anything to me.
+I shall have strength. Over all there is to be placed a large piece of
+green velvet. This is my wish; see that it is done.”
+
+The two men were much surprised at Bovary’s romantic ideas. The chemist
+at once went to him and said--
+
+“This velvet seems to me a superfetation. Besides, the expense--”
+
+“What’s that to you?” cried Charles. “Leave me! You did not love her.
+Go!”
+
+The priest took him by the arm for a turn in the garden. He discoursed
+on the vanity of earthly things. God was very great, was very good: one
+must submit to his decrees without a murmur; nay, must even thank him.
+
+Charles burst out into blasphemies: “I hate your God!”
+
+“The spirit of rebellion is still upon you,” sighed the ecclesiastic.
+
+Bovary was far away. He was walking with great strides along by the
+wall, near the espalier, and he ground his teeth; he raised to heaven
+looks of malediction, but not so much as a leaf stirred.
+
+A fine rain was falling: Charles, whose chest was bare, at last began to
+shiver; he went in and sat down in the kitchen.
+
+At six o’clock a noise like a clatter of old iron was heard on the
+Place; it was the “Hirondelle” coming in, and he remained with his
+forehead against the windowpane, watching all the passengers get
+out, one after the other. Felicite put down a mattress for him in the
+drawing-room. He threw himself upon it and fell asleep.
+
+Although a philosopher, Monsieur Homais respected the dead. So bearing
+no grudge to poor Charles, he came back again in the evening to sit up
+with the body; bringing with him three volumes and a pocket-book for
+taking notes.
+
+Monsieur Bournisien was there, and two large candles were burning at the
+head of the bed, that had been taken out of the alcove. The druggist, on
+whom the silence weighed, was not long before he began formulating some
+regrets about this “unfortunate young woman.” and the priest replied
+that there was nothing to do now but pray for her.
+
+“Yet,” Homais went on, “one of two things; either she died in a state of
+grace (as the Church has it), and then she has no need of our prayers;
+or else she departed impertinent (that is, I believe, the ecclesiastical
+expression), and then--”
+
+Bournisien interrupted him, replying testily that it was none the less
+necessary to pray.
+
+“But,” objected the chemist, “since God knows all our needs, what can be
+the good of prayer?”
+
+“What!” cried the ecclesiastic, “prayer! Why, aren’t you a Christian?”
+
+“Excuse me,” said Homais; “I admire Christianity. To begin with, it
+enfranchised the slaves, introduced into the world a morality--”
+
+“That isn’t the question. All the texts-”
+
+“Oh! oh! As to texts, look at history; it, is known that all the texts
+have been falsified by the Jesuits.”
+
+Charles came in, and advancing towards the bed, slowly drew the
+curtains.
+
+Emma’s head was turned towards her right shoulder, the corner of her
+mouth, which was open, seemed like a black hole at the lower part of her
+face; her two thumbs were bent into the palms of her hands; a kind
+of white dust besprinkled her lashes, and her eyes were beginning to
+disappear in that viscous pallor that looks like a thin web, as if
+spiders had spun it over. The sheet sunk in from her breast to her
+knees, and then rose at the tips of her toes, and it seemed to Charles
+that infinite masses, an enormous load, were weighing upon her.
+
+The church clock struck two. They could hear the loud murmur of the
+river flowing in the darkness at the foot of the terrace. Monsieur
+Bournisien from time to time blew his nose noisily, and Homais’ pen was
+scratching over the paper.
+
+“Come, my good friend,” he said, “withdraw; this spectacle is tearing
+you to pieces.”
+
+Charles once gone, the chemist and the cure recommenced their
+discussions.
+
+“Read Voltaire,” said the one, “read D’Holbach, read the
+‘Encyclopaedia’!”
+
+“Read the ‘Letters of some Portuguese Jews,’” said the other; “read ‘The
+Meaning of Christianity,’ by Nicolas, formerly a magistrate.”
+
+They grew warm, they grew red, they both talked at once without
+listening to each other. Bournisien was scandalized at such audacity;
+Homais marvelled at such stupidity; and they were on the point of
+insulting one another when Charles suddenly reappeared. A fascination
+drew him. He was continually coming upstairs.
+
+He stood opposite her, the better to see her, and he lost himself in a
+contemplation so deep that it was no longer painful.
+
+He recalled stories of catalepsy, the marvels of magnetism, and he
+said to himself that by willing it with all his force he might perhaps
+succeed in reviving her. Once he even bent towards he, and cried in a
+low voice, “Emma! Emma!” His strong breathing made the flames of the
+candles tremble against the wall.
+
+At daybreak Madame Bovary senior arrived. Charles as he embraced her
+burst into another flood of tears. She tried, as the chemist had done,
+to make some remarks to him on the expenses of the funeral. He became so
+angry that she was silent, and he even commissioned her to go to town at
+once and buy what was necessary.
+
+Charles remained alone the whole afternoon; they had taken Berthe
+to Madame Homais’; Felicite was in the room upstairs with Madame
+Lefrancois.
+
+In the evening he had some visitors. He rose, pressed their hands,
+unable to speak. Then they sat down near one another, and formed a large
+semicircle in front of the fire. With lowered faces, and swinging one
+leg crossed over the other knee, they uttered deep sighs at intervals;
+each one was inordinately bored, and yet none would be the first to go.
+
+Homais, when he returned at nine o’clock (for the last two days only
+Homais seemed to have been on the Place), was laden with a stock of
+camphor, of benzine, and aromatic herbs. He also carried a large jar
+full of chlorine water, to keep off all miasmata. Just then the servant,
+Madame Lefrancois, and Madame Bovary senior were busy about Emma,
+finishing dressing her, and they were drawing down the long stiff veil
+that covered her to her satin shoes.
+
+Felicite was sobbing--“Ah! my poor mistress! my poor mistress!”
+
+“Look at her,” said the landlady, sighing; “how pretty she still is!
+Now, couldn’t you swear she was going to get up in a minute?”
+
+Then they bent over her to put on her wreath. They had to raise the head
+a little, and a rush of black liquid issued, as if she were vomiting,
+from her mouth.
+
+“Oh, goodness! The dress; take care!” cried Madame Lefrancois. “Now,
+just come and help,” she said to the chemist. “Perhaps you’re afraid?”
+
+“I afraid?” replied he, shrugging his shoulders. “I dare say! I’ve seen
+all sorts of things at the hospital when I was studying pharmacy. We
+used to make punch in the dissecting room! Nothingness does not terrify
+a philosopher; and, as I often say, I even intend to leave my body to
+the hospitals, in order, later on, to serve science.”
+
+The cure on his arrival inquired how Monsieur Bovary was, and, on
+the reply of the druggist, went on--“The blow, you see, is still too
+recent.”
+
+Then Homais congratulated him on not being exposed, like other people,
+to the loss of a beloved companion; whence there followed a discussion
+on the celibacy of priests.
+
+“For,” said the chemist, “it is unnatural that a man should do without
+women! There have been crimes--”
+
+“But, good heaven!” cried the ecclesiastic, “how do you expect an
+individual who is married to keep the secrets of the confessional, for
+example?”
+
+Homais fell foul of the confessional. Bournisien defended it; he
+enlarged on the acts of restitution that it brought about. He cited
+various anecdotes about thieves who had suddenly become honest. Military
+men on approaching the tribunal of penitence had felt the scales fall
+from their eyes. At Fribourg there was a minister--
+
+His companion was asleep. Then he felt somewhat stifled by the
+over-heavy atmosphere of the room; he opened the window; this awoke the
+chemist.
+
+“Come, take a pinch of snuff,” he said to him. “Take it; it’ll relieve
+you.”
+
+A continual barking was heard in the distance. “Do you hear that dog
+howling?” said the chemist.
+
+“They smell the dead,” replied the priest. “It’s like bees; they leave
+their hives on the decease of any person.”
+
+Homais made no remark upon these prejudices, for he had again dropped
+asleep. Monsieur Bournisien, stronger than he, went on moving his lips
+gently for some time, then insensibly his chin sank down, he let fall
+his big black boot, and began to snore.
+
+They sat opposite one another, with protruding stomachs, puffed-up
+faces, and frowning looks, after so much disagreement uniting at last in
+the same human weakness, and they moved no more than the corpse by their
+side, that seemed to be sleeping.
+
+Charles coming in did not wake them. It was the last time; he came to
+bid her farewell.
+
+The aromatic herbs were still smoking, and spirals of bluish vapour
+blended at the window-sash with the fog that was coming in. There were
+few stars, and the night was warm. The wax of the candles fell in great
+drops upon the sheets of the bed. Charles watched them burn, tiring his
+eyes against the glare of their yellow flame.
+
+The watering on the satin gown shimmered white as moonlight. Emma was
+lost beneath it; and it seemed to him that, spreading beyond her own
+self, she blended confusedly with everything around her--the silence,
+the night, the passing wind, the damp odours rising from the ground.
+
+Then suddenly he saw her in the garden at Tostes, on a bench against the
+thorn hedge, or else at Rouen in the streets, on the threshold of their
+house, in the yard at Bertaux. He again heard the laughter of the happy
+boys beneath the apple-trees: the room was filled with the perfume
+of her hair; and her dress rustled in his arms with a noise like
+electricity. The dress was still the same.
+
+For a long while he thus recalled all his lost joys, her attitudes,
+her movements, the sound of her voice. Upon one fit of despair followed
+another, and even others, inexhaustible as the waves of an overflowing
+sea.
+
+A terrible curiosity seized him. Slowly, with the tips of his fingers,
+palpitating, he lifted her veil. But he uttered a cry of horror that
+awoke the other two.
+
+They dragged him down into the sitting-room. Then Felicite came up to
+say that he wanted some of her hair.
+
+“Cut some off,” replied the druggist.
+
+And as she did not dare to, he himself stepped forward, scissors in
+hand. He trembled so that he pierced the skin of the temple in several
+places. At last, stiffening himself against emotion, Homais gave two
+or three great cuts at random that left white patches amongst that
+beautiful black hair.
+
+The chemist and the cure plunged anew into their occupations, not
+without sleeping from time to time, of which they accused each other
+reciprocally at each fresh awakening. Then Monsieur Bournisien sprinkled
+the room with holy water and Homais threw a little chlorine water on the
+floor.
+
+Felicite had taken care to put on the chest of drawers, for each
+of them, a bottle of brandy, some cheese, and a large roll. And the
+druggist, who could not hold out any longer, about four in the morning
+sighed--
+
+“My word! I should like to take some sustenance.”
+
+The priest did not need any persuading; he went out to go and say mass,
+came back, and then they ate and hobnobbed, giggling a little without
+knowing why, stimulated by that vague gaiety that comes upon us after
+times of sadness, and at the last glass the priest said to the druggist,
+as he clapped him on the shoulder--
+
+“We shall end by understanding one another.”
+
+In the passage downstairs they met the undertaker’s men, who were coming
+in. Then Charles for two hours had to suffer the torture of hearing the
+hammer resound against the wood. Next day they lowered her into her
+oak coffin, that was fitted into the other two; but as the bier was
+too large, they had to fill up the gaps with the wool of a mattress. At
+last, when the three lids had been planed down, nailed, soldered, it was
+placed outside in front of the door; the house was thrown open, and the
+people of Yonville began to flock round.
+
+Old Rouault arrived, and fainted on the Place when he saw the black
+cloth!
+
+
+
+Chapter Ten
+
+He had only received the chemist’s letter thirty-six hours after the
+event; and, from consideration for his feelings, Homais had so worded it
+that it was impossible to make out what it was all about.
+
+First, the old fellow had fallen as if struck by apoplexy. Next, he
+understood that she was not dead, but she might be. At last, he had put
+on his blouse, taken his hat, fastened his spurs to his boots, and set
+out at full speed; and the whole of the way old Rouault, panting, was
+torn by anguish. Once even he was obliged to dismount. He was dizzy; he
+heard voices round about him; he felt himself going mad.
+
+Day broke. He saw three black hens asleep in a tree. He shuddered,
+horrified at this omen. Then he promised the Holy Virgin three chasubles
+for the church, and that he would go barefooted from the cemetery at
+Bertaux to the chapel of Vassonville.
+
+He entered Maromme shouting for the people of the inn, burst open the
+door with a thrust of his shoulder, made for a sack of oats, emptied a
+bottle of sweet cider into the manger, and again mounted his nag, whose
+feet struck fire as it dashed along.
+
+He said to himself that no doubt they would save her; the doctors would
+discover some remedy surely. He remembered all the miraculous cures
+he had been told about. Then she appeared to him dead. She was there;
+before his eyes, lying on her back in the middle of the road. He reined
+up, and the hallucination disappeared.
+
+At Quincampoix, to give himself heart, he drank three cups of coffee
+one after the other. He fancied they had made a mistake in the name in
+writing. He looked for the letter in his pocket, felt it there, but did
+not dare to open it.
+
+At last he began to think it was all a joke; someone’s spite, the jest
+of some wag; and besides, if she were dead, one would have known it. But
+no! There was nothing extraordinary about the country; the sky was blue,
+the trees swayed; a flock of sheep passed. He saw the village; he was
+seen coming bending forward upon his horse, belabouring it with great
+blows, the girths dripping with blood.
+
+When he had recovered consciousness, he fell, weeping, into Bovary’s
+arms: “My girl! Emma! my child! tell me--”
+
+The other replied, sobbing, “I don’t know! I don’t know! It’s a curse!”
+
+The druggist separated them. “These horrible details are useless. I will
+tell this gentleman all about it. Here are the people coming. Dignity!
+Come now! Philosophy!”
+
+The poor fellow tried to show himself brave, and repeated several times.
+“Yes! courage!”
+
+“Oh,” cried the old man, “so I will have, by God! I’ll go along o’ her
+to the end!”
+
+The bell began tolling. All was ready; they had to start. And seated in
+a stall of the choir, side by side, they saw pass and repass in front of
+them continually the three chanting choristers.
+
+The serpent-player was blowing with all his might. Monsieur Bournisien,
+in full vestments, was singing in a shrill voice. He bowed before the
+tabernacle, raising his hands, stretched out his arms. Lestiboudois
+went about the church with his whalebone stick. The bier stood near the
+lectern, between four rows of candles. Charles felt inclined to get up
+and put them out.
+
+Yet he tried to stir himself to a feeling of devotion, to throw himself
+into the hope of a future life in which he should see her again. He
+imagined to himself she had gone on a long journey, far away, for a long
+time. But when he thought of her lying there, and that all was over,
+that they would lay her in the earth, he was seized with a fierce,
+gloomy, despairful rage. At times he thought he felt nothing more, and
+he enjoyed this lull in his pain, whilst at the same time he reproached
+himself for being a wretch.
+
+The sharp noise of an iron-ferruled stick was heard on the stones,
+striking them at irregular intervals. It came from the end of the
+church, and stopped short at the lower aisles. A man in a coarse brown
+jacket knelt down painfully. It was Hippolyte, the stable-boy at the
+“Lion d’Or.” He had put on his new leg.
+
+One of the choristers went round the nave making a collection, and the
+coppers chinked one after the other on the silver plate.
+
+“Oh, make haste! I am in pain!” cried Bovary, angrily throwing him a
+five-franc piece. The churchman thanked him with a deep bow.
+
+They sang, they knelt, they stood up; it was endless! He remembered that
+once, in the early times, they had been to mass together, and they had
+sat down on the other side, on the right, by the wall. The bell began
+again. There was a great moving of chairs; the bearers slipped their
+three staves under the coffin, and everyone left the church.
+
+Then Justin appeared at the door of the shop. He suddenly went in again,
+pale, staggering.
+
+People were at the windows to see the procession pass. Charles at the
+head walked erect. He affected a brave air, and saluted with a nod those
+who, coming out from the lanes or from their doors, stood amidst the
+crowd.
+
+The six men, three on either side, walked slowly, panting a little.
+The priests, the choristers, and the two choirboys recited the De
+profundis*, and their voices echoed over the fields, rising and falling
+with their undulations. Sometimes they disappeared in the windings of
+the path; but the great silver cross rose always before the trees.
+
+     *Psalm CXXX.
+
+
+The women followed in black cloaks with turned-down hoods; each of them
+carried in her hands a large lighted candle, and Charles felt himself
+growing weaker at this continual repetition of prayers and torches,
+beneath this oppressive odour of wax and of cassocks. A fresh breeze was
+blowing; the rye and colza were sprouting, little dewdrops trembled at
+the roadsides and on the hawthorn hedges. All sorts of joyous sounds
+filled the air; the jolting of a cart rolling afar off in the ruts, the
+crowing of a cock, repeated again and again, or the gambling of a foal
+running away under the apple-trees: The pure sky was fretted with rosy
+clouds; a bluish haze rested upon the cots covered with iris. Charles as
+he passed recognised each courtyard. He remembered mornings like this,
+when, after visiting some patient, he came out from one and returned to
+her.
+
+The black cloth bestrewn with white beads blew up from time to time,
+laying bare the coffin. The tired bearers walked more slowly, and it
+advanced with constant jerks, like a boat that pitches with every wave.
+
+They reached the cemetery. The men went right down to a place in the
+grass where a grave was dug. They ranged themselves all round; and while
+the priest spoke, the red soil thrown up at the sides kept noiselessly
+slipping down at the corners.
+
+Then when the four ropes were arranged the coffin was placed upon them.
+He watched it descend; it seemed descending for ever. At last a thud was
+heard; the ropes creaked as they were drawn up. Then Bournisien took
+the spade handed to him by Lestiboudois; with his left hand all the
+time sprinkling water, with the right he vigorously threw in a large
+spadeful; and the wood of the coffin, struck by the pebbles, gave forth
+that dread sound that seems to us the reverberation of eternity.
+
+The ecclesiastic passed the holy water sprinkler to his neighbour. This
+was Homais. He swung it gravely, then handed it to Charles, who sank to
+his knees in the earth and threw in handfuls of it, crying, “Adieu!” He
+sent her kisses; he dragged himself towards the grave, to engulf himself
+with her. They led him away, and he soon grew calmer, feeling perhaps,
+like the others, a vague satisfaction that it was all over.
+
+Old Rouault on his way back began quietly smoking a pipe, which Homais
+in his innermost conscience thought not quite the thing. He also noticed
+that Monsieur Binet had not been present, and that Tuvache had “made
+off” after mass, and that Theodore, the notary’s servant wore a blue
+coat, “as if one could not have got a black coat, since that is the
+custom, by Jove!” And to share his observations with others he went from
+group to group. They were deploring Emma’s death, especially Lheureux,
+who had not failed to come to the funeral.
+
+“Poor little woman! What a trouble for her husband!”
+
+The druggist continued, “Do you know that but for me he would have
+committed some fatal attempt upon himself?”
+
+“Such a good woman! To think that I saw her only last Saturday in my
+shop.”
+
+“I haven’t had leisure,” said Homais, “to prepare a few words that I
+would have cast upon her tomb.”
+
+Charles on getting home undressed, and old Rouault put on his blue
+blouse. It was a new one, and as he had often during the journey wiped
+his eyes on the sleeves, the dye had stained his face, and the traces of
+tears made lines in the layer of dust that covered it.
+
+Madame Bovary senior was with them. All three were silent. At last the
+old fellow sighed--
+
+“Do you remember, my friend, that I went to Tostes once when you had
+just lost your first deceased? I consoled you at that time. I thought of
+something to say then, but now--” Then, with a loud groan that shook his
+whole chest, “Ah! this is the end for me, do you see! I saw my wife go,
+then my son, and now to-day it’s my daughter.”
+
+He wanted to go back at once to Bertaux, saying that he could not sleep
+in this house. He even refused to see his granddaughter.
+
+“No, no! It would grieve me too much. Only you’ll kiss her many times
+for me. Good-bye! you’re a good fellow! And then I shall never forget
+that,” he said, slapping his thigh. “Never fear, you shall always have
+your turkey.”
+
+But when he reached the top of the hill he turned back, as he had turned
+once before on the road of Saint-Victor when he had parted from her. The
+windows of the village were all on fire beneath the slanting rays of the
+sun sinking behind the field. He put his hand over his eyes, and saw
+in the horizon an enclosure of walls, where trees here and there formed
+black clusters between white stones; then he went on his way at a gentle
+trot, for his nag had gone lame.
+
+Despite their fatigue, Charles and his mother stayed very long that
+evening talking together. They spoke of the days of the past and of the
+future. She would come to live at Yonville; she would keep house for
+him; they would never part again. She was ingenious and caressing,
+rejoicing in her heart at gaining once more an affection that had
+wandered from her for so many years. Midnight struck. The village as
+usual was silent, and Charles, awake, thought always of her.
+
+Rodolphe, who, to distract himself, had been rambling about the wood all
+day, was sleeping quietly in his chateau, and Leon, down yonder, always
+slept.
+
+There was another who at that hour was not asleep.
+
+On the grave between the pine-trees a child was on his knees weeping,
+and his heart, rent by sobs, was beating in the shadow beneath the load
+of an immense regret, sweeter than the moon and fathomless as the night.
+The gate suddenly grated. It was Lestiboudois; he came to fetch his
+spade, that he had forgotten. He recognised Justin climbing over the
+wall, and at last knew who was the culprit who stole his potatoes.
+
+
+
+Chapter Eleven
+
+The next day Charles had the child brought back. She asked for her
+mamma. They told her she was away; that she would bring her back some
+playthings. Berthe spoke of her again several times, then at last
+thought no more of her. The child’s gaiety broke Bovary’s heart, and he
+had to bear besides the intolerable consolations of the chemist.
+
+Money troubles soon began again, Monsieur Lheureux urging on anew his
+friend Vincart, and Charles pledged himself for exorbitant sums; for he
+would never consent to let the smallest of the things that had belonged
+to HER be sold. His mother was exasperated with him; he grew even more
+angry than she did. He had altogether changed. She left the house.
+
+Then everyone began “taking advantage” of him. Mademoiselle Lempereur
+presented a bill for six months’ teaching, although Emma had never taken
+a lesson (despite the receipted bill she had shown Bovary); it was an
+arrangement between the two women. The man at the circulating library
+demanded three years’ subscriptions; Mere Rollet claimed the postage due
+for some twenty letters, and when Charles asked for an explanation, she
+had the delicacy to reply--
+
+“Oh, I don’t know. It was for her business affairs.”
+
+With every debt he paid Charles thought he had come to the end of them.
+But others followed ceaselessly. He sent in accounts for professional
+attendance. He was shown the letters his wife had written. Then he had
+to apologise.
+
+Felicite now wore Madame Bovary’s gowns; not all, for he had kept some
+of them, and he went to look at them in her dressing-room, locking
+himself up there; she was about her height, and often Charles, seeing
+her from behind, was seized with an illusion, and cried out--
+
+“Oh, stay, stay!”
+
+But at Whitsuntide she ran away from Yonville, carried off by Theodore,
+stealing all that was left of the wardrobe.
+
+It was about this time that the widow Dupuis had the honour to inform
+him of the “marriage of Monsieur Leon Dupuis her son, notary at Yvetot,
+to Mademoiselle Leocadie Leboeuf of Bondeville.” Charles, among the
+other congratulations he sent him, wrote this sentence--
+
+“How glad my poor wife would have been!”
+
+One day when, wandering aimlessly about the house, he had gone up to the
+attic, he felt a pellet of fine paper under his slipper. He opened it
+and read: “Courage, Emma, courage. I would not bring misery into your
+life.” It was Rodolphe’s letter, fallen to the ground between the boxes,
+where it had remained, and that the wind from the dormer window had just
+blown towards the door. And Charles stood, motionless and staring, in
+the very same place where, long ago, Emma, in despair, and paler even
+than he, had thought of dying. At last he discovered a small R at the
+bottom of the second page. What did this mean? He remembered Rodolphe’s
+attentions, his sudden, disappearance, his constrained air when they
+had met two or three times since. But the respectful tone of the letter
+deceived him.
+
+“Perhaps they loved one another platonically,” he said to himself.
+
+Besides, Charles was not of those who go to the bottom of things; he
+shrank from the proofs, and his vague jealousy was lost in the immensity
+of his woe.
+
+Everyone, he thought, must have adored her; all men assuredly must have
+coveted her. She seemed but the more beautiful to him for this; he
+was seized with a lasting, furious desire for her, that inflamed his
+despair, and that was boundless, because it was now unrealisable.
+
+To please her, as if she were still living, he adopted her
+predilections, her ideas; he bought patent leather boots and took to
+wearing white cravats. He put cosmetics on his moustache, and, like her,
+signed notes of hand. She corrupted him from beyond the grave.
+
+He was obliged to sell his silver piece by piece; next he sold the
+drawing-room furniture. All the rooms were stripped; but the bedroom,
+her own room, remained as before. After his dinner Charles went up
+there. He pushed the round table in front of the fire, and drew up her
+armchair. He sat down opposite it. A candle burnt in one of the gilt
+candlesticks. Berthe by his side was painting prints.
+
+He suffered, poor man, at seeing her so badly dressed, with laceless
+boots, and the arm-holes of her pinafore torn down to the hips; for the
+charwoman took no care of her. But she was so sweet, so pretty, and her
+little head bent forward so gracefully, letting the dear fair hair fall
+over her rosy cheeks, that an infinite joy came upon him, a happiness
+mingled with bitterness, like those ill-made wines that taste of
+resin. He mended her toys, made her puppets from cardboard, or sewed up
+half-torn dolls. Then, if his eyes fell upon the workbox, a ribbon lying
+about, or even a pin left in a crack of the table, he began to dream,
+and looked so sad that she became as sad as he.
+
+No one now came to see them, for Justin had run away to Rouen, where he
+was a grocer’s assistant, and the druggist’s children saw less and less
+of the child, Monsieur Homais not caring, seeing the difference of their
+social position, to continue the intimacy.
+
+The blind man, whom he had not been able to cure with the pomade, had
+gone back to the hill of Bois-Guillaume, where he told the travellers of
+the vain attempt of the druggist, to such an extent, that Homais when
+he went to town hid himself behind the curtains of the “Hirondelle” to
+avoid meeting him. He detested him, and wishing, in the interests of his
+own reputation, to get rid of him at all costs, he directed against
+him a secret battery, that betrayed the depth of his intellect and the
+baseness of his vanity. Thus, for six consecutive months, one could read
+in the “Fanal de Rouen” editorials such as these--
+
+“All who bend their steps towards the fertile plains of Picardy have, no
+doubt, remarked, by the Bois-Guillaume hill, a wretch suffering from
+a horrible facial wound. He importunes, persecutes one, and levies a
+regular tax on all travellers. Are we still living in the monstrous
+times of the Middle Ages, when vagabonds were permitted to display in
+our public places leprosy and scrofulas they had brought back from the
+Crusades?”
+
+Or--
+
+“In spite of the laws against vagabondage, the approaches to our great
+towns continue to be infected by bands of beggars. Some are seen going
+about alone, and these are not, perhaps, the least dangerous. What are
+our ediles about?”
+
+Then Homais invented anecdotes--
+
+“Yesterday, by the Bois-Guillaume hill, a skittish horse--” And then
+followed the story of an accident caused by the presence of the blind
+man.
+
+He managed so well that the fellow was locked up. But he was released.
+He began again, and Homais began again. It was a struggle. Homais won
+it, for his foe was condemned to life-long confinement in an asylum.
+
+This success emboldened him, and henceforth there was no longer a dog
+run over, a barn burnt down, a woman beaten in the parish, of which
+he did not immediately inform the public, guided always by the love of
+progress and the hate of priests. He instituted comparisons between the
+elementary and clerical schools to the detriment of the latter; called
+to mind the massacre of St. Bartholomew a propos of a grant of one
+hundred francs to the church, and denounced abuses, aired new views.
+That was his phrase. Homais was digging and delving; he was becoming
+dangerous.
+
+However, he was stifling in the narrow limits of journalism, and soon a
+book, a work was necessary to him. Then he composed “General Statistics
+of the Canton of Yonville, followed by Climatological Remarks.” The
+statistics drove him to philosophy. He busied himself with great
+questions: the social problem, moralisation of the poorer classes,
+pisciculture, caoutchouc, railways, etc. He even began to blush at being
+a bourgeois. He affected the artistic style, he smoked. He bought two
+chic Pompadour statuettes to adorn his drawing-room.
+
+He by no means gave up his shop. On the contrary, he kept well abreast
+of new discoveries. He followed the great movement of chocolates; he
+was the first to introduce “cocoa” and “revalenta” into the
+Seine-Inferieure. He was enthusiastic about the hydro-electric
+Pulvermacher chains; he wore one himself, and when at night he took off
+his flannel vest, Madame Homais stood quite dazzled before the golden
+spiral beneath which he was hidden, and felt her ardour redouble for
+this man more bandaged than a Scythian, and splendid as one of the Magi.
+
+He had fine ideas about Emma’s tomb. First he proposed a broken column
+with some drapery, next a pyramid, then a Temple of Vesta, a sort of
+rotunda, or else a “mass of ruins.” And in all his plans Homais always
+stuck to the weeping willow, which he looked upon as the indispensable
+symbol of sorrow.
+
+Charles and he made a journey to Rouen together to look at some tombs
+at a funeral furnisher’s, accompanied by an artist, one Vaufrylard, a
+friend of Bridoux’s, who made puns all the time. At last, after having
+examined some hundred designs, having ordered an estimate and made
+another journey to Rouen, Charles decided in favour of a mausoleum,
+which on the two principal sides was to have a “spirit bearing an
+extinguished torch.”
+
+As to the inscription, Homais could think of nothing so fine as Sta
+viator*, and he got no further; he racked his brain, he constantly
+repeated Sta viator. At last he hit upon Amabilen conjugem calcas**,
+which was adopted.
+
+     * Rest traveler.
+
+     ** Tread upon a loving wife.
+
+A strange thing was that Bovary, while continually thinking of Emma, was
+forgetting her. He grew desperate as he felt this image fading from his
+memory in spite of all efforts to retain it. Yet every night he dreamt
+of her; it was always the same dream. He drew near her, but when he was
+about to clasp her she fell into decay in his arms.
+
+For a week he was seen going to church in the evening. Monsieur
+Bournisien even paid him two or three visits, then gave him up.
+Moreover, the old fellow was growing intolerant, fanatic, said Homais.
+He thundered against the spirit of the age, and never failed, every
+other week, in his sermon, to recount the death agony of Voltaire, who
+died devouring his excrements, as everyone knows.
+
+In spite of the economy with which Bovary lived, he was far from being
+able to pay off his old debts. Lheureux refused to renew any more
+bills. A distraint became imminent. Then he appealed to his mother, who
+consented to let him take a mortgage on her property, but with a great
+many recriminations against Emma; and in return for her sacrifice she
+asked for a shawl that had escaped the depredations of Felicite. Charles
+refused to give it her; they quarrelled.
+
+She made the first overtures of reconciliation by offering to have the
+little girl, who could help her in the house, to live with her. Charles
+consented to this, but when the time for parting came, all his courage
+failed him. Then there was a final, complete rupture.
+
+As his affections vanished, he clung more closely to the love of his
+child. She made him anxious, however, for she coughed sometimes, and had
+red spots on her cheeks.
+
+Opposite his house, flourishing and merry, was the family of the
+chemist, with whom everything was prospering. Napoleon helped him in the
+laboratory, Athalie embroidered him a skullcap, Irma cut out rounds of
+paper to cover the preserves, and Franklin recited Pythagoras’ table in
+a breath. He was the happiest of fathers, the most fortunate of men.
+
+Not so! A secret ambition devoured him. Homais hankered after the cross
+of the Legion of Honour. He had plenty of claims to it.
+
+“First, having at the time of the cholera distinguished myself by a
+boundless devotion; second, by having published, at my expense,
+various works of public utility, such as” (and he recalled his pamphlet
+entitled, “Cider, its manufacture and effects,” besides observation
+on the lanigerous plant-louse, sent to the Academy; his volume of
+statistics, and down to his pharmaceutical thesis); “without counting
+that I am a member of several learned societies” (he was member of a
+single one).
+
+“In short!” he cried, making a pirouette, “if it were only for
+distinguishing myself at fires!”
+
+Then Homais inclined towards the Government. He secretly did the
+prefect great service during the elections. He sold himself--in a word,
+prostituted himself. He even addressed a petition to the sovereign
+in which he implored him to “do him justice”; he called him “our good
+king,” and compared him to Henri IV.
+
+And every morning the druggist rushed for the paper to see if his
+nomination were in it. It was never there. At last, unable to bear it
+any longer, he had a grass plot in his garden designed to represent the
+Star of the Cross of Honour with two little strips of grass running from
+the top to imitate the ribband. He walked round it with folded arms,
+meditating on the folly of the Government and the ingratitude of men.
+
+From respect, or from a sort of sensuality that made him carry on his
+investigations slowly, Charles had not yet opened the secret drawer of
+a rosewood desk which Emma had generally used. One day, however, he
+sat down before it, turned the key, and pressed the spring. All Leon’s
+letters were there. There could be no doubt this time. He devoured them
+to the very last, ransacked every corner, all the furniture, all the
+drawers, behind the walls, sobbing, crying aloud, distraught, mad. He
+found a box and broke it open with a kick. Rodolphe’s portrait flew full
+in his face in the midst of the overturned love-letters.
+
+People wondered at his despondency. He never went out, saw no one,
+refused even to visit his patients. Then they said “he shut himself up
+to drink.”
+
+Sometimes, however, some curious person climbed on to the garden hedge,
+and saw with amazement this long-bearded, shabbily clothed, wild man,
+who wept aloud as he walked up and down.
+
+In the evening in summer he took his little girl with him and led her to
+the cemetery. They came back at nightfall, when the only light left in
+the Place was that in Binet’s window.
+
+The voluptuousness of his grief was, however, incomplete, for he had no
+one near him to share it, and he paid visits to Madame Lefrancois to be
+able to speak of her.
+
+But the landlady only listened with half an ear, having troubles
+like himself. For Lheureux had at last established the “Favorites du
+Commerce,” and Hivert, who enjoyed a great reputation for doing errands,
+insisted on a rise of wages, and was threatening to go over “to the
+opposition shop.”
+
+One day when he had gone to the market at Argueil to sell his horse--his
+last resource--he met Rodolphe.
+
+They both turned pale when they caught sight of one another. Rodolphe,
+who had only sent his card, first stammered some apologies, then grew
+bolder, and even pushed his assurance (it was in the month of August and
+very hot) to the length of inviting him to have a bottle of beer at the
+public-house.
+
+Leaning on the table opposite him, he chewed his cigar as he talked, and
+Charles was lost in reverie at this face that she had loved. He seemed
+to see again something of her in it. It was a marvel to him. He would
+have liked to have been this man.
+
+The other went on talking agriculture, cattle, pasturage, filling out
+with banal phrases all the gaps where an allusion might slip in. Charles
+was not listening to him; Rodolphe noticed it, and he followed the
+succession of memories that crossed his face. This gradually grew
+redder; the nostrils throbbed fast, the lips quivered. There was at
+last a moment when Charles, full of a sombre fury, fixed his eyes on
+Rodolphe, who, in something of fear, stopped talking. But soon the same
+look of weary lassitude came back to his face.
+
+“I don’t blame you,” he said.
+
+Rodolphe was dumb. And Charles, his head in his hands, went on in a
+broken voice, and with the resigned accent of infinite sorrow--
+
+“No, I don’t blame you now.”
+
+He even added a fine phrase, the only one he ever made--
+
+“It is the fault of fatality!”
+
+Rodolphe, who had managed the fatality, thought the remark very offhand
+from a man in his position, comic even, and a little mean.
+
+The next day Charles went to sit down on the seat in the arbour. Rays
+of light were straying through the trellis, the vine leaves threw their
+shadows on the sand, the jasmines perfumed the air, the heavens were
+blue, Spanish flies buzzed round the lilies in bloom, and Charles was
+suffocating like a youth beneath the vague love influences that filled
+his aching heart.
+
+At seven o’clock little Berthe, who had not seen him all the afternoon,
+went to fetch him to dinner.
+
+His head was thrown back against the wall, his eyes closed, his mouth
+open, and in his hand was a long tress of black hair.
+
+“Come along, papa,” she said.
+
+And thinking he wanted to play; she pushed him gently. He fell to the
+ground. He was dead.
+
+Thirty-six hours after, at the druggist’s request, Monsieur Canivet came
+thither. He made a post-mortem and found nothing.
+
+When everything had been sold, twelve francs seventy-five centimes
+remained, that served to pay for Mademoiselle Bovary’s going to
+her grandmother. The good woman died the same year; old Rouault was
+paralysed, and it was an aunt who took charge of her. She is poor, and
+sends her to a cotton-factory to earn a living.
+
+Since Bovary’s death three doctors have followed one another at Yonville
+without any success, so severely did Homais attack them. He has an
+enormous practice; the authorities treat him with consideration, and
+public opinion protects him.
+
+He has just received the cross of the Legion of Honour.
+
+
+
+
+
+End of the Project Gutenberg EBook of Madame Bovary, by Gustave Flaubert
+
+*** END OF THIS PROJECT GUTENBERG EBOOK MADAME BOVARY ***
+
+***** This file should be named 2413-0.txt or 2413-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/2/4/1/2413/
+
+Produced by An Anonymous Volunteer, Noah Adams and David Widger
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/odyssey.txt
+++ b/jet/tf-idf/src/main/resources/books/odyssey.txt
@@ -1,0 +1,11984 @@
+﻿The Project Gutenberg EBook of The Odyssey, by Homer
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: The Odyssey
+
+Author: Homer
+
+Translator: Samuel Butler
+
+
+Release Date: April, 1999 [EBook #1727]
+Last Updated: April 9, 2013
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+
+
+
+Produced by Jim Tinsley
+
+
+
+
+
+
+
+
+
+THE ODYSSEY
+
+
+  rendered into English
+  prose for the use of
+  those who cannot
+  read the original
+
+
+By Samuel Butler
+
+
+
+
+PREFACE TO FIRST EDITION
+
+This translation is intended to supplement a work entitled "The
+Authoress of the Odyssey", which I published in 1897. I could not give
+the whole "Odyssey" in that book without making it unwieldy, I therefore
+epitomised my translation, which was already completed and which I now
+publish in full.
+
+I shall not here argue the two main points dealt with in the work just
+mentioned; I have nothing either to add to, or to withdraw from, what I
+have there written. The points in question are:
+
+(1) that the "Odyssey" was written entirely at, and drawn entirely
+from, the place now called Trapani on the West Coast of Sicily, alike
+as regards the Phaeacian and the Ithaca scenes; while the voyages of
+Ulysses, when once he is within easy reach of Sicily, solve themselves
+into a periplus of the island, practically from Trapani back to Trapani,
+via the Lipari islands, the Straits of Messina, and the island of
+Pantellaria.
+
+(2) That the poem was entirely written by a very young woman, who lived
+at the place now called Trapani, and introduced herself into her work
+under the name of Nausicaa.
+
+The main arguments on which I base the first of these somewhat startling
+contentions, have been prominently and repeatedly before the English
+and Italian public ever since they appeared (without rejoinder) in the
+"Athenaeum" for January 30 and February 20, 1892. Both contentions were
+urged (also without rejoinder) in the Johnian "Eagle" for the Lent and
+October terms of the same year. Nothing to which I should reply
+has reached me from any quarter, and knowing how anxiously I have
+endeavoured to learn the existence of any flaws in my argument, I begin
+to feel some confidence that, did such flaws exist, I should have heard,
+at any rate about some of them, before now. Without, therefore, for
+a moment pretending to think that scholars generally acquiesce in my
+conclusions, I shall act as thinking them little likely so to gainsay me
+as that it will be incumbent upon me to reply, and shall confine myself
+to translating the "Odyssey" for English readers, with such notes as
+I think will be found useful. Among these I would especially call
+attention to one on xxii. 465-473 which Lord Grimthorpe has kindly
+allowed me to make public.
+
+I have repeated several of the illustrations used in "The Authoress of
+the Odyssey", and have added two which I hope may bring the outer court
+of Ulysses' house more vividly before the reader. I should like to
+explain that the presence of a man and a dog in one illustration is
+accidental, and was not observed by me till I developed the negative. In
+an appendix I have also reprinted the paragraphs explanatory of the
+plan of Ulysses' house, together with the plan itself. The reader is
+recommended to study this plan with some attention.
+
+In the preface to my translation of the "Iliad" I have given my views as
+to the main principles by which a translator should be guided, and need
+not repeat them here, beyond pointing out that the initial liberty of
+translating poetry into prose involves the continual taking of more
+or less liberty throughout the translation; for much that is right in
+poetry is wrong in prose, and the exigencies of readable prose are the
+first things to be considered in a prose translation. That the reader,
+however, may see how far I have departed from strict construe, I will
+print here Messrs. Butcher and Lang's translation of the sixty lines or
+so of the "Odyssey." Their translation runs:
+
+  Tell me, Muse, of that man, so ready at need, who wandered
+  far and wide, after he had sacked the sacred citadel of
+  Troy, and many were the men whose towns he saw and whose
+  mind he learnt, yea, and many the woes he suffered in his
+  heart on the deep, striving to win his own life and the
+  return of his company. Nay, but even so he saved not his
+  company, though he desired it sore. For through the
+  blindness of their own hearts they perished, fools, who
+  devoured the oxen of Helios Hyperion: but the god took from
+  them their day of returning. Of these things, goddess,
+  daughter of Zeus, whencesoever thou hast heard thereof,
+  declare thou even unto us.
+
+  Now all the rest, as many as fled from sheer destruction,
+  were at home, and had escaped both war and sea, but
+  Odysseus only, craving for his wife and for his homeward
+  path, the lady nymph Calypso held, that fair goddess, in her
+  hollow caves, longing to have him for her lord. But when
+  now the year had come in the courses of the seasons,
+  wherein the gods had ordained that he should return home to
+  Ithaca, not even there was he quit of labours, not even
+  among his own; but all the gods had pity on him save
+  Poseidon, who raged continually against godlike Odysseus,
+  till he came to his own country. Howbeit Poseidon had now
+  departed for the distant Ethiopians, the Ethiopians that are
+  sundered in twain, the uttermost of men, abiding some where
+  Hyperion sinks and some where he rises. There he looked to
+  receive his hecatomb of bulls and rams, there he made merry
+  sitting at the feast, but the other gods were gathered in
+  the halls of Olympian Zeus. Then among them the father of
+  men and gods began to speak, for he bethought him in his
+  heart of noble Aegisthus, whom the son of Agamemnon,
+  far-famed Orestes, slew. Thinking upon him he spake out among
+  the Immortals:
+
+  'Lo you now, how vainly mortal men do blame the gods! For of
+  us they say comes evil, whereas they even of themselves,
+  through the blindness of their own hearts, have sorrows
+  beyond that which is ordained. Even as of late Aegisthus,
+  beyond that which was ordained, took to him the wedded wife
+  of the son of Atreus, and killed her lord on his return,
+  and that with sheer doom before his eyes, since we had
+  warned him by the embassy of Hermes the keen-sighted, the
+  slayer of Argos, that he should neither kill the man, nor
+  woo his wife. For the son of Atreus shall be avenged at the
+  hand of Orestes, so soon as he shall come to man's estate
+  and long for his own country. So spake Hermes, yet he
+  prevailed not on the heart of Aegisthus, for all his good
+  will; but now hath he paid one price for all.'
+
+  And the goddess, grey-eyed Athene, answered him, saying: 'O
+  father, our father Cronides, throned in the highest; that
+  man assuredly lies in a death that is his due; so perish
+  likewise all who work such deeds! But my heart is rent for
+  wise Odysseus, the hapless one, who far from his friends
+  this long while suffereth affliction in a sea-girt isle,
+  where is the navel of the sea, a woodland isle, and
+  therein a goddess hath her habitation, the daughter of the
+  wizard Atlas, who knows the depths of every sea, and
+  himself upholds the tall pillars which keep earth and sky
+  asunder. His daughter it is that holds the hapless man in
+  sorrow: and ever with soft and guileful tales she is
+  wooing him to forgetfulness of Ithaca. But Odysseus
+  yearning to see if it were but the smoke leap upwards from
+  his own land, hath a desire to die. As for thee, thine
+  heart regardeth it not at all, Olympian! What! Did not
+  Odysseus by the ships of the Argives make thee free
+  offering of sacrifice in the wide Trojan land? Wherefore
+  wast thou then so wroth with him, O Zeus?'
+
+The "Odyssey" (as every one knows) abounds in passages borrowed from the
+"Iliad"; I had wished to print these in a slightly different type, with
+marginal references to the "Iliad," and had marked them to this end in
+my MS. I found, however, that the translation would be thus hopelessly
+scholasticised, and abandoned my intention. I would nevertheless urge on
+those who have the management of our University presses, that they would
+render a great service to students if they would publish a Greek text of
+the "Odyssey" with the Iliadic passages printed in a different type, and
+with marginal references. I have given the British Museum a copy of the
+"Odyssey" with the Iliadic passages underlined and referred to in MS.;
+I have also given an "Iliad" marked with all the Odyssean passages, and
+their references; but copies of both the "Iliad" and "Odyssey" so marked
+ought to be within easy reach of all students.
+
+Any one who at the present day discusses the questions that have arisen
+round the "Iliad" since Wolf's time, without keeping it well before
+his reader's mind that the "Odyssey" was demonstrably written from one
+single neighbourhood, and hence (even though nothing else pointed to
+this conclusion) presumably by one person only--that it was written
+certainly before 750, and in all probability before 1000 B.C.--that
+the writer of this very early poem was demonstrably familiar with the
+"Iliad" as we now have it, borrowing as freely from those books whose
+genuineness has been most impugned, as from those which are admitted to
+be by Homer--any one who fails to keep these points before his readers,
+is hardly dealing equitably by them. Any one on the other hand, who will
+mark his "Iliad" and his "Odyssey" from the copies in the British Museum
+above referred to, and who will draw the only inference that common
+sense can draw from the presence of so many identical passages in both
+poems, will, I believe, find no difficulty in assigning their proper
+value to a large number of books here and on the Continent that at
+present enjoy considerable reputations. Furthermore, and this perhaps
+is an advantage better worth securing, he will find that many puzzles of
+the "Odyssey" cease to puzzle him on the discovery that they arise from
+over-saturation with the "Iliad."
+
+Other difficulties will also disappear as soon as the development of the
+poem in the writer's mind is understood. I have dealt with this at some
+length in pp. 251-261 of "The Authoress of the Odyssey". Briefly, the
+"Odyssey" consists of two distinct poems: (1) The Return of Ulysses,
+which alone the Muse is asked to sing in the opening lines of the poem.
+This poem includes the Phaeacian episode, and the account of Ulysses'
+adventures as told by himself in Books ix.-xii. It consists of lines
+1-79 (roughly) of Book i., of line 28 of Book v., and thence without
+intermission to the middle of line 187 of Book xiii., at which point the
+original scheme was abandoned.
+
+(2) The story of Penelope and the suitors, with the episode of
+Telemachus' voyage to Pylos. This poem begins with line 80 (roughly)
+of Book i., is continued to the end of Book iv., and not resumed till
+Ulysses wakes in the middle of line 187, Book xiii., from whence it
+continues to the end of Book xxiv.
+
+In "The Authoress of the Odyssey", I wrote:
+
+   the introduction of lines xi., 115-137 and of line ix.,
+   535, with the writing a new council of the gods at the
+   beginning of Book v., to take the place of the one that was
+   removed to Book i., 1-79, were the only things that were
+   done to give even a semblance of unity to the old scheme
+   and the new, and to conceal the fact that the Muse, after
+   being asked to sing of one subject, spend two-thirds of her
+   time in singing a very different one, with a climax for
+   which no-one has asked her. For roughly the Return occupies
+   eight Books, and Penelope and the Suitors sixteen.
+
+I believe this to be substantially correct.
+
+Lastly, to deal with a very unimportant point, I observe that the
+Leipsic Teubner edition of 894 makes Books ii. and iii. end with a
+comma. Stops are things of such far more recent date than the "Odyssey,"
+that there does not seem much use in adhering to the text in so small a
+matter; still, from a spirit of mere conservatism, I have preferred
+to do so. Why [Greek] at the beginnings of Books ii. and viii., and
+[Greek], at the beginning of Book vii. should have initial capitals in
+an edition far too careful to admit a supposition of inadvertence, when
+[Greek] at the beginning of Books vi. and xiii., and [Greek] at the
+beginning of Book xvii. have no initial capitals, I cannot determine.
+No other Books of the "Odyssey" have initial capitals except the three
+mentioned unless the first word of the Book is a proper name.
+
+S. BUTLER.
+
+July 25, 1900.
+
+
+
+
+PREFACE TO SECOND EDITION
+
+Butler's Translation of the "Odyssey" appeared originally in 1900, and
+The Authoress of the Odyssey in 1897. In the preface to the new edition
+of "The Authoress", which is published simultaneously with this new
+edition of the Translation, I have given some account of the genesis of
+the two books.
+
+The size of the original page has been reduced so as to make both
+books uniform with Butler's other works; and, fortunately, it has been
+possible, by using a smaller type, to get the same number of words into
+each page, so that the references remain good, and, with the exception
+of a few minor alterations and rearrangements now to be enumerated
+so far as they affect the Translation, the new editions are faithful
+reprints of the original editions, with misprints and obvious errors
+corrected--no attempt having been made to edit them or to bring them up
+to date.
+
+(a) The Index has been revised.
+
+(b) Owing to the reduction in the size of the page it has been necessary
+to shorten some of the headlines, and here advantage has been taken of
+various corrections of and additions to the headlines and shoulder-notes
+made by Butler in his own copies of the two books.
+
+(c) For the most part each of the illustrations now occupies a page,
+whereas in the original editions they generally appeared two on the
+page. It has been necessary to reduce the plan of the House of Ulysses.
+
+On page 153 of "The Authoress" Butler says: "No great poet would compare
+his hero to a paunch full of blood and fat, cooking before the fire
+(xx, 24-28)." This passage is not given in the abridged Story of the
+"Odyssey" at the beginning of the book, but in the Translation it occurs
+in these words:
+
+"Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side then on the other, that he
+may get it cooked as soon as possible; even so did he turn himself about
+from side to side, thinking all the time how, single-handed as he
+was, he should contrive to kill so large a body of men as the wicked
+suitors."
+
+It looks as though in the interval between the publication of "The
+Authoress" (1897) and of the Translation (1900) Butler had changed his
+mind; for in the first case the comparison is between Ulysses and a
+paunch full, etc., and in the second it is between Ulysses and a man who
+turns a paunch full, etc. The second comparison is perhaps one which a
+great poet might make.
+
+In seeing the works through the press I have had the invaluable
+assistance of Mr. A. T. Bartholomew of the University Library,
+Cambridge, and of Mr. Donald S. Robertson, Fellow of Trinity College,
+Cambridge. To both these friends I give my most cordial thanks for the
+care and skill exercised by them. Mr. Robertson has found time for the
+labour of checking and correcting all the quotations from and references
+to the "Iliad" and "Odyssey," and I believe that it could not have been
+better performed. It was, I know, a pleasure for him; and it would have
+been a pleasure also for Butler if he could have known that his work was
+being shepherded by the son of his old friend, Mr. H. R. Robertson, who
+more than half a century ago was a fellow-student with him at Cary's
+School of Art in Streatham Street, Bloomsbury.
+
+HENRY FESTING JONES.
+
+120 MAIDA VALE, W.9.
+
+4th December, 1921.
+
+
+
+
+THE ODYSSEY
+
+
+Book I
+
+THE GODS IN COUNCIL--MINERVA'S VISIT TO ITHACA--THE CHALLENGE FROM
+TELEMACHUS TO THE SUITORS.
+
+Tell me, O Muse, of that ingenious hero who travelled far and wide after
+he had sacked the famous town of Troy. Many cities did he visit, and
+many were the nations with whose manners and customs he was acquainted;
+moreover he suffered much by sea while trying to save his own life and
+bring his men safely home; but do what he might he could not save his
+men, for they perished through their own sheer folly in eating the
+cattle of the Sun-god Hyperion; so the god prevented them from ever
+reaching home. Tell me, too, about all these things, oh daughter of
+Jove, from whatsoever source you may know them.
+
+So now all who escaped death in battle or by shipwreck had got safely
+home except Ulysses, and he, though he was longing to return to his wife
+and country, was detained by the goddess Calypso, who had got him into
+a large cave and wanted to marry him. But as years went by, there came a
+time when the gods settled that he should go back to Ithaca; even then,
+however, when he was among his own people, his troubles were not
+yet over; nevertheless all the gods had now begun to pity him except
+Neptune, who still persecuted him without ceasing and would not let him
+get home.
+
+Now Neptune had gone off to the Ethiopians, who are at the world's end,
+and lie in two halves, the one looking West and the other East. {1} He
+had gone there to accept a hecatomb of sheep and oxen, and was enjoying
+himself at his festival; but the other gods met in the house of Olympian
+Jove, and the sire of gods and men spoke first. At that moment he was
+thinking of Aegisthus, who had been killed by Agamemnon's son Orestes;
+so he said to the other gods:
+
+"See now, how men lay blame upon us gods for what is after all nothing
+but their own folly. Look at Aegisthus; he must needs make love to
+Agamemnon's wife unrighteously and then kill Agamemnon, though he knew
+it would be the death of him; for I sent Mercury to warn him not to do
+either of these things, inasmuch as Orestes would be sure to take his
+revenge when he grew up and wanted to return home. Mercury told him
+this in all good will but he would not listen, and now he has paid for
+everything in full."
+
+Then Minerva said, "Father, son of Saturn, King of kings, it served
+Aegisthus right, and so it would any one else who does as he did; but
+Aegisthus is neither here nor there; it is for Ulysses that my heart
+bleeds, when I think of his sufferings in that lonely sea-girt island,
+far away, poor man, from all his friends. It is an island covered
+with forest, in the very middle of the sea, and a goddess lives there,
+daughter of the magician Atlas, who looks after the bottom of the ocean,
+and carries the great columns that keep heaven and earth asunder. This
+daughter of Atlas has got hold of poor unhappy Ulysses, and keeps trying
+by every kind of blandishment to make him forget his home, so that he
+is tired of life, and thinks of nothing but how he may once more see the
+smoke of his own chimneys. You, sir, take no heed of this, and yet when
+Ulysses was before Troy did he not propitiate you with many a burnt
+sacrifice? Why then should you keep on being so angry with him?"
+
+And Jove said, "My child, what are you talking about? How can I forget
+Ulysses than whom there is no more capable man on earth, nor more
+liberal in his offerings to the immortal gods that live in heaven? Bear
+in mind, however, that Neptune is still furious with Ulysses for having
+blinded an eye of Polyphemus king of the Cyclopes. Polyphemus is son to
+Neptune by the nymph Thoosa, daughter to the sea-king Phorcys; therefore
+though he will not kill Ulysses outright, he torments him by preventing
+him from getting home. Still, let us lay our heads together and see how
+we can help him to return; Neptune will then be pacified, for if we are
+all of a mind he can hardly stand out against us."
+
+And Minerva said, "Father, son of Saturn, King of kings, if, then, the
+gods now mean that Ulysses should get home, we should first send Mercury
+to the Ogygian island to tell Calypso that we have made up our minds and
+that he is to return. In the meantime I will go to Ithaca, to put heart
+into Ulysses' son Telemachus; I will embolden him to call the Achaeans
+in assembly, and speak out to the suitors of his mother Penelope, who
+persist in eating up any number of his sheep and oxen; I will also
+conduct him to Sparta and to Pylos, to see if he can hear anything about
+the return of his dear father--for this will make people speak well of
+him."
+
+So saying she bound on her glittering golden sandals, imperishable,
+with which she can fly like the wind over land or sea; she grasped the
+redoubtable bronze-shod spear, so stout and sturdy and strong, wherewith
+she quells the ranks of heroes who have displeased her, and down she
+darted from the topmost summits of Olympus, whereon forthwith she was
+in Ithaca, at the gateway of Ulysses' house, disguised as a visitor,
+Mentes, chief of the Taphians, and she held a bronze spear in her hand.
+There she found the lordly suitors seated on hides of the oxen which
+they had killed and eaten, and playing draughts in front of the house.
+Men-servants and pages were bustling about to wait upon them, some
+mixing wine with water in the mixing-bowls, some cleaning down the
+tables with wet sponges and laying them out again, and some cutting up
+great quantities of meat.
+
+Telemachus saw her long before any one else did. He was sitting moodily
+among the suitors thinking about his brave father, and how he would send
+them flying out of the house, if he were to come to his own again and
+be honoured as in days gone by. Thus brooding as he sat among them, he
+caught sight of Minerva and went straight to the gate, for he was vexed
+that a stranger should be kept waiting for admittance. He took her right
+hand in his own, and bade her give him her spear. "Welcome," said he,
+"to our house, and when you have partaken of food you shall tell us what
+you have come for."
+
+He led the way as he spoke, and Minerva followed him. When they were
+within he took her spear and set it in the spear-stand against a strong
+bearing-post along with the many other spears of his unhappy father, and
+he conducted her to a richly decorated seat under which he threw a
+cloth of damask. There was a footstool also for her feet,{2} and he set
+another seat near her for himself, away from the suitors, that she might
+not be annoyed while eating by their noise and insolence, and that he
+might ask her more freely about his father.
+
+A maid servant then brought them water in a beautiful golden ewer and
+poured it into a silver basin for them to wash their hands, and she
+drew a clean table beside them. An upper servant brought them bread, and
+offered them many good things of what there was in the house, the carver
+fetched them plates of all manner of meats and set cups of gold by their
+side, and a manservant brought them wine and poured it out for them.
+
+Then the suitors came in and took their places on the benches and seats.
+{3} Forthwith men servants poured water over their hands, maids went
+round with the bread-baskets, pages filled the mixing-bowls with wine
+and water, and they laid their hands upon the good things that were
+before them. As soon as they had had enough to eat and drink they wanted
+music and dancing, which are the crowning embellishments of a banquet,
+so a servant brought a lyre to Phemius, whom they compelled perforce
+to sing to them. As soon as he touched his lyre and began to sing
+Telemachus spoke low to Minerva, with his head close to hers that no man
+might hear.
+
+"I hope, sir," said he, "that you will not be offended with what I am
+going to say. Singing comes cheap to those who do not pay for it, and
+all this is done at the cost of one whose bones lie rotting in some
+wilderness or grinding to powder in the surf. If these men were to see
+my father come back to Ithaca they would pray for longer legs rather
+than a longer purse, for money would not serve them; but he, alas, has
+fallen on an ill fate, and even when people do sometimes say that he is
+coming, we no longer heed them; we shall never see him again. And now,
+sir, tell me and tell me true, who you are and where you come from. Tell
+me of your town and parents, what manner of ship you came in, how your
+crew brought you to Ithaca, and of what nation they declared themselves
+to be--for you cannot have come by land. Tell me also truly, for I want
+to know, are you a stranger to this house, or have you been here in my
+father's time? In the old days we had many visitors for my father went
+about much himself."
+
+And Minerva answered, "I will tell you truly and particularly all about
+it. I am Mentes, son of Anchialus, and I am King of the Taphians. I have
+come here with my ship and crew, on a voyage to men of a foreign tongue
+being bound for Temesa {4} with a cargo of iron, and I shall bring back
+copper. As for my ship, it lies over yonder off the open country away
+from the town, in the harbour Rheithron {5} under the wooded mountain
+Neritum. {6} Our fathers were friends before us, as old Laertes will
+tell you, if you will go and ask him. They say, however, that he never
+comes to town now, and lives by himself in the country, faring hardly,
+with an old woman to look after him and get his dinner for him, when
+he comes in tired from pottering about his vineyard. They told me your
+father was at home again, and that was why I came, but it seems the gods
+are still keeping him back, for he is not dead yet not on the mainland.
+It is more likely he is on some sea-girt island in mid ocean, or a
+prisoner among savages who are detaining him against his will. I am no
+prophet, and know very little about omens, but I speak as it is borne
+in upon me from heaven, and assure you that he will not be away much
+longer; for he is a man of such resource that even though he were in
+chains of iron he would find some means of getting home again. But tell
+me, and tell me true, can Ulysses really have such a fine looking fellow
+for a son? You are indeed wonderfully like him about the head and eyes,
+for we were close friends before he set sail for Troy where the flower
+of all the Argives went also. Since that time we have never either of us
+seen the other."
+
+"My mother," answered Telemachus, "tells me I am son to Ulysses, but it
+is a wise child that knows his own father. Would that I were son to one
+who had grown old upon his own estates, for, since you ask me, there
+is no more ill-starred man under heaven than he who they tell me is my
+father."
+
+And Minerva said, "There is no fear of your race dying out yet, while
+Penelope has such a fine son as you are. But tell me, and tell me true,
+what is the meaning of all this feasting, and who are these people? What
+is it all about? Have you some banquet, or is there a wedding in the
+family--for no one seems to be bringing any provisions of his own? And
+the guests--how atrociously they are behaving; what riot they make over
+the whole house; it is enough to disgust any respectable person who
+comes near them."
+
+"Sir," said Telemachus, "as regards your question, so long as my father
+was here it was well with us and with the house, but the gods in their
+displeasure have willed it otherwise, and have hidden him away more
+closely than mortal man was ever yet hidden. I could have borne it
+better even though he were dead, if he had fallen with his men before
+Troy, or had died with friends around him when the days of his fighting
+were done; for then the Achaeans would have built a mound over his
+ashes, and I should myself have been heir to his renown; but now the
+storm-winds have spirited him away we know not whither; he is gone
+without leaving so much as a trace behind him, and I inherit nothing
+but dismay. Nor does the matter end simply with grief for the loss of
+my father; heaven has laid sorrows upon me of yet another kind; for the
+chiefs from all our islands, Dulichium, Same, and the woodland island of
+Zacynthus, as also all the principal men of Ithaca itself, are eating up
+my house under the pretext of paying their court to my mother, who
+will neither point blank say that she will not marry, {7} nor yet bring
+matters to an end; so they are making havoc of my estate, and before
+long will do so also with myself."
+
+"Is that so?" exclaimed Minerva, "then you do indeed want Ulysses home
+again. Give him his helmet, shield, and a couple of lances, and if he is
+the man he was when I first knew him in our house, drinking and making
+merry, he would soon lay his hands about these rascally suitors, were
+he to stand once more upon his own threshold. He was then coming from
+Ephyra, where he had been to beg poison for his arrows from Ilus, son of
+Mermerus. Ilus feared the ever-living gods and would not give him any,
+but my father let him have some, for he was very fond of him. If Ulysses
+is the man he then was these suitors will have a short shrift and a
+sorry wedding.
+
+"But there! It rests with heaven to determine whether he is to return,
+and take his revenge in his own house or no; I would, however, urge you
+to set about trying to get rid of these suitors at once. Take my advice,
+call the Achaean heroes in assembly to-morrow morning--lay your case
+before them, and call heaven to bear you witness. Bid the suitors take
+themselves off, each to his own place, and if your mother's mind is set
+on marrying again, let her go back to her father, who will find her
+a husband and provide her with all the marriage gifts that so dear a
+daughter may expect. As for yourself, let me prevail upon you to take
+the best ship you can get, with a crew of twenty men, and go in quest
+of your father who has so long been missing. Some one may tell
+you something, or (and people often hear things in this way) some
+heaven-sent message may direct you. First go to Pylos and ask Nestor;
+thence go on to Sparta and visit Menelaus, for he got home last of all
+the Achaeans; if you hear that your father is alive and on his way home,
+you can put up with the waste these suitors will make for yet another
+twelve months. If on the other hand you hear of his death, come home at
+once, celebrate his funeral rites with all due pomp, build a barrow
+to his memory, and make your mother marry again. Then, having done all
+this, think it well over in your mind how, by fair means or foul, you
+may kill these suitors in your own house. You are too old to plead
+infancy any longer; have you not heard how people are singing Orestes'
+praises for having killed his father's murderer Aegisthus? You are a
+fine, smart looking fellow; show your mettle, then, and make yourself a
+name in story. Now, however, I must go back to my ship and to my crew,
+who will be impatient if I keep them waiting longer; think the matter
+over for yourself, and remember what I have said to you."
+
+"Sir," answered Telemachus, "it has been very kind of you to talk to me
+in this way, as though I were your own son, and I will do all you tell
+me; I know you want to be getting on with your voyage, but stay a little
+longer till you have taken a bath and refreshed yourself. I will then
+give you a present, and you shall go on your way rejoicing; I will give
+you one of great beauty and value--a keepsake such as only dear friends
+give to one another."
+
+Minerva answered, "Do not try to keep me, for I would be on my way at
+once. As for any present you may be disposed to make me, keep it till
+I come again, and I will take it home with me. You shall give me a very
+good one, and I will give you one of no less value in return."
+
+With these words she flew away like a bird into the air, but she had
+given Telemachus courage, and had made him think more than ever about
+his father. He felt the change, wondered at it, and knew that the
+stranger had been a god, so he went straight to where the suitors were
+sitting.
+
+Phemius was still singing, and his hearers sat rapt in silence as he
+told the sad tale of the return from Troy, and the ills Minerva had laid
+upon the Achaeans. Penelope, daughter of Icarius, heard his song from
+her room upstairs, and came down by the great staircase, not alone, but
+attended by two of her handmaids. When she reached the suitors she stood
+by one of the bearing posts that supported the roof of the cloisters {8}
+with a staid maiden on either side of her. She held a veil, moreover,
+before her face, and was weeping bitterly.
+
+"Phemius," she cried, "you know many another feat of gods and heroes,
+such as poets love to celebrate. Sing the suitors some one of these, and
+let them drink their wine in silence, but cease this sad tale, for it
+breaks my sorrowful heart, and reminds me of my lost husband whom I
+mourn ever without ceasing, and whose name was great over all Hellas and
+middle Argos." {9}
+
+"Mother," answered Telemachus, "let the bard sing what he has a mind to;
+bards do not make the ills they sing of; it is Jove, not they, who makes
+them, and who sends weal or woe upon mankind according to his own good
+pleasure. This fellow means no harm by singing the ill-fated return of
+the Danaans, for people always applaud the latest songs most warmly.
+Make up your mind to it and bear it; Ulysses is not the only man who
+never came back from Troy, but many another went down as well as he. Go,
+then, within the house and busy yourself with your daily duties, your
+loom, your distaff, and the ordering of your servants; for speech is
+man's matter, and mine above all others {10}--for it is I who am master
+here."
+
+She went wondering back into the house, and laid her son's saying in
+her heart. Then, going upstairs with her handmaids into her room, she
+mourned her dear husband till Minerva shed sweet sleep over her eyes.
+But the suitors were clamorous throughout the covered cloisters {11},
+and prayed each one that he might be her bed fellow.
+
+Then Telemachus spoke, "Shameless," he cried, "and insolent suitors, let
+us feast at our pleasure now, and let there be no brawling, for it is a
+rare thing to hear a man with such a divine voice as Phemius has; but in
+the morning meet me in full assembly that I may give you formal notice
+to depart, and feast at one another's houses, turn and turn about, at
+your own cost. If on the other hand you choose to persist in spunging
+upon one man, heaven help me, but Jove shall reckon with you in full,
+and when you fall in my father's house there shall be no man to avenge
+you."
+
+The suitors bit their lips as they heard him, and marvelled at the
+boldness of his speech. Then, Antinous, son of Eupeithes, said, "The
+gods seem to have given you lessons in bluster and tall talking; may
+Jove never grant you to be chief in Ithaca as your father was before
+you."
+
+Telemachus answered, "Antinous, do not chide with me, but, god willing,
+I will be chief too if I can. Is this the worst fate you can think of
+for me? It is no bad thing to be a chief, for it brings both riches
+and honour. Still, now that Ulysses is dead there are many great men in
+Ithaca both old and young, and some other may take the lead among them;
+nevertheless I will be chief in my own house, and will rule those whom
+Ulysses has won for me."
+
+Then Eurymachus, son of Polybus, answered, "It rests with heaven to
+decide who shall be chief among us, but you shall be master in your
+own house and over your own possessions; no one while there is a man
+in Ithaca shall do you violence nor rob you. And now, my good fellow,
+I want to know about this stranger. What country does he come from?
+Of what family is he, and where is his estate? Has he brought you news
+about the return of your father, or was he on business of his own? He
+seemed a well to do man, but he hurried off so suddenly that he was gone
+in a moment before we could get to know him."
+
+"My father is dead and gone," answered Telemachus, "and even if some
+rumour reaches me I put no more faith in it now. My mother does indeed
+sometimes send for a soothsayer and question him, but I give his
+prophecyings no heed. As for the stranger, he was Mentes, son of
+Anchialus, chief of the Taphians, an old friend of my father's." But in
+his heart he knew that it had been the goddess.
+
+The suitors then returned to their singing and dancing until the
+evening; but when night fell upon their pleasuring they went home to
+bed each in his own abode. {12} Telemachus's room was high up in a tower
+{13} that looked on to the outer court; hither, then, he hied, brooding
+and full of thought. A good old woman, Euryclea, daughter of Ops,
+the son of Pisenor, went before him with a couple of blazing torches.
+Laertes had bought her with his own money when she was quite young; he
+gave the worth of twenty oxen for her, and shewed as much respect to her
+in his household as he did to his own wedded wife, but he did not take
+her to his bed for he feared his wife's resentment. {14} She it was who
+now lighted Telemachus to his room, and she loved him better than any of
+the other women in the house did, for she had nursed him when he was a
+baby. He opened the door of his bed room and sat down upon the bed; as
+he took off his shirt {15} he gave it to the good old woman, who folded
+it tidily up, and hung it for him over a peg by his bed side, after
+which she went out, pulled the door to by a silver catch, and drew the
+bolt home by means of the strap. {16} But Telemachus as he lay covered
+with a woollen fleece kept thinking all night through of his intended
+voyage and of the counsel that Minerva had given him.
+
+
+Book II
+
+ASSEMBLY OF THE PEOPLE OF ITHACA--SPEECHES OF TELEMACHUS AND OF THE
+SUITORS--TELEMACHUS MAKES HIS PREPARATIONS AND STARTS FOR PYLOS WITH
+MINERVA DISGUISED AS MENTOR.
+
+Now when the child of morning, rosy-fingered Dawn, appeared Telemachus
+rose and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulder, and left his room looking like an
+immortal god. He at once sent the criers round to call the people in
+assembly, so they called them and the people gathered thereon; then,
+when they were got together, he went to the place of assembly spear in
+hand--not alone, for his two hounds went with him. Minerva endowed him
+with a presence of such divine comeliness that all marvelled at him as
+he went by, and when he took his place in his father's seat even the
+oldest councillors made way for him.
+
+Aegyptius, a man bent double with age, and of infinite experience, was
+the first to speak. His son Antiphus had gone with Ulysses to Ilius,
+land of noble steeds, but the savage Cyclops had killed him when they
+were all shut up in the cave, and had cooked his last dinner for him.
+{17} He had three sons left, of whom two still worked on their father's
+land, while the third, Eurynomus, was one of the suitors; nevertheless
+their father could not get over the loss of Antiphus, and was still
+weeping for him when he began his speech.
+
+"Men of Ithaca," he said, "hear my words. From the day Ulysses left us
+there has been no meeting of our councillors until now; who then can it
+be, whether old or young, that finds it so necessary to convene us? Has
+he got wind of some host approaching, and does he wish to warn us, or
+would he speak upon some other matter of public moment? I am sure he is
+an excellent person, and I hope Jove will grant him his heart's desire."
+
+Telemachus took this speech as of good omen and rose at once, for he was
+bursting with what he had to say. He stood in the middle of the assembly
+and the good herald Pisenor brought him his staff. Then, turning to
+Aegyptius, "Sir," said he, "it is I, as you will shortly learn, who have
+convened you, for it is I who am the most aggrieved. I have not got wind
+of any host approaching about which I would warn you, nor is there any
+matter of public moment on which I would speak. My grievance is purely
+personal, and turns on two great misfortunes which have fallen upon my
+house. The first of these is the loss of my excellent father, who was
+chief among all you here present, and was like a father to every one
+of you; the second is much more serious, and ere long will be the utter
+ruin of my estate. The sons of all the chief men among you are pestering
+my mother to marry them against her will. They are afraid to go to
+her father Icarius, asking him to choose the one he likes best, and
+to provide marriage gifts for his daughter, but day by day they keep
+hanging about my father's house, sacrificing our oxen, sheep, and fat
+goats for their banquets, and never giving so much as a thought to the
+quantity of wine they drink. No estate can stand such recklessness; we
+have now no Ulysses to ward off harm from our doors, and I cannot hold
+my own against them. I shall never all my days be as good a man as he
+was, still I would indeed defend myself if I had power to do so, for I
+cannot stand such treatment any longer; my house is being disgraced and
+ruined. Have respect, therefore, to your own consciences and to public
+opinion. Fear, too, the wrath of heaven, lest the gods should be
+displeased and turn upon you. I pray you by Jove and Themis, who is the
+beginning and the end of councils, [do not] hold back, my friends, and
+leave me singlehanded {18}--unless it be that my brave father Ulysses
+did some wrong to the Achaeans which you would now avenge on me, by
+aiding and abetting these suitors. Moreover, if I am to be eaten out of
+house and home at all, I had rather you did the eating yourselves, for
+I could then take action against you to some purpose, and serve you with
+notices from house to house till I got paid in full, whereas now I have
+no remedy." {19}
+
+With this Telemachus dashed his staff to the ground and burst into
+tears. Every one was very sorry for him, but they all sat still and no
+one ventured to make him an angry answer, save only Antinous, who spoke
+thus:
+
+"Telemachus, insolent braggart that you are, how dare you try to throw
+the blame upon us suitors? It is your mother's fault not ours, for she
+is a very artful woman. This three years past, and close on four, she
+had been driving us out of our minds, by encouraging each one of us, and
+sending him messages without meaning one word of what she says. And then
+there was that other trick she played us. She set up a great tambour
+frame in her room, and began to work on an enormous piece of fine
+needlework. 'Sweet hearts,' said she, 'Ulysses is indeed dead, still
+do not press me to marry again immediately, wait--for I would not have
+skill in needlework perish unrecorded--till I have completed a pall for
+the hero Laertes, to be in readiness against the time when death shall
+take him. He is very rich, and the women of the place will talk if he is
+laid out without a pall.'
+
+"This was what she said, and we assented; whereon we could see her
+working on her great web all day long, but at night she would unpick the
+stitches again by torchlight. She fooled us in this way for three years
+and we never found her out, but as time wore on and she was now in her
+fourth year, one of her maids who knew what she was doing told us, and
+we caught her in the act of undoing her work, so she had to finish it
+whether she would or no. The suitors, therefore, make you this answer,
+that both you and the Achaeans may understand-'Send your mother away,
+and bid her marry the man of her own and of her father's choice'; for I
+do not know what will happen if she goes on plaguing us much longer with
+the airs she gives herself on the score of the accomplishments Minerva
+has taught her, and because she is so clever. We never yet heard of such
+a woman; we know all about Tyro, Alcmena, Mycene, and the famous women
+of old, but they were nothing to your mother any one of them. It was not
+fair of her to treat us in that way, and as long as she continues in
+the mind with which heaven has now endowed her, so long shall we go on
+eating up your estate; and I do not see why she should change, for she
+gets all the honour and glory, and it is you who pay for it, not she.
+Understand, then, that we will not go back to our lands, neither here
+nor elsewhere, till she has made her choice and married some one or
+other of us."
+
+Telemachus answered, "Antinous, how can I drive the mother who bore me
+from my father's house? My father is abroad and we do not know whether
+he is alive or dead. It will be hard on me if I have to pay Icarius the
+large sum which I must give him if I insist on sending his daughter back
+to him. Not only will he deal rigorously with me, but heaven will also
+punish me; for my mother when she leaves the house will call on the
+Erinyes to avenge her; besides, it would not be a creditable thing to
+do, and I will have nothing to say to it. If you choose to take offence
+at this, leave the house and feast elsewhere at one another's houses at
+your own cost turn and turn about. If, on the other hand, you elect to
+persist in spunging upon one man, heaven help me, but Jove shall reckon
+with you in full, and when you fall in my father's house there shall be
+no man to avenge you."
+
+As he spoke Jove sent two eagles from the top of the mountain, and they
+flew on and on with the wind, sailing side by side in their own lordly
+flight. When they were right over the middle of the assembly they
+wheeled and circled about, beating the air with their wings and glaring
+death into the eyes of them that were below; then, fighting fiercely and
+tearing at one another, they flew off towards the right over the town.
+The people wondered as they saw them, and asked each other what all this
+might be; whereon Halitherses, who was the best prophet and reader of
+omens among them, spoke to them plainly and in all honesty, saying:
+
+"Hear me, men of Ithaca, and I speak more particularly to the suitors,
+for I see mischief brewing for them. Ulysses is not going to be
+away much longer; indeed he is close at hand to deal out death and
+destruction, not on them alone, but on many another of us who live in
+Ithaca. Let us then be wise in time, and put a stop to this wickedness
+before he comes. Let the suitors do so of their own accord; it will
+be better for them, for I am not prophesying without due knowledge;
+everything has happened to Ulysses as I foretold when the Argives set
+out for Troy, and he with them. I said that after going through much
+hardship and losing all his men he should come home again in the
+twentieth year and that no one would know him; and now all this is
+coming true."
+
+Eurymachus son of Polybus then said, "Go home, old man, and prophesy to
+your own children, or it may be worse for them. I can read these omens
+myself much better than you can; birds are always flying about in the
+sunshine somewhere or other, but they seldom mean anything. Ulysses has
+died in a far country, and it is a pity you are not dead along with
+him, instead of prating here about omens and adding fuel to the anger of
+Telemachus which is fierce enough as it is. I suppose you think he will
+give you something for your family, but I tell you--and it shall surely
+be--when an old man like you, who should know better, talks a young one
+over till he becomes troublesome, in the first place his young friend
+will only fare so much the worse--he will take nothing by it, for the
+suitors will prevent this--and in the next, we will lay a heavier fine,
+sir, upon yourself than you will at all like paying, for it will bear
+hardly upon you. As for Telemachus, I warn him in the presence of you
+all to send his mother back to her father, who will find her a husband
+and provide her with all the marriage gifts so dear a daughter may
+expect. Till then we shall go on harassing him with our suit; for we
+fear no man, and care neither for him, with all his fine speeches, nor
+for any fortune-telling of yours. You may preach as much as you please,
+but we shall only hate you the more. We shall go back and continue to
+eat up Telemachus's estate without paying him, till such time as his
+mother leaves off tormenting us by keeping us day after day on the
+tiptoe of expectation, each vying with the other in his suit for a prize
+of such rare perfection. Besides we cannot go after the other women whom
+we should marry in due course, but for the way in which she treats us."
+
+Then Telemachus said, "Eurymachus, and you other suitors, I shall say no
+more, and entreat you no further, for the gods and the people of Ithaca
+now know my story. Give me, then, a ship and a crew of twenty men to
+take me hither and thither, and I will go to Sparta and to Pylos in
+quest of my father who has so long been missing. Some one may tell
+me something, or (and people often hear things in this way) some
+heaven-sent message may direct me. If I can hear of him as alive and on
+his way home I will put up with the waste you suitors will make for yet
+another twelve months. If on the other hand I hear of his death, I will
+return at once, celebrate his funeral rites with all due pomp, build a
+barrow to his memory, and make my mother marry again."
+
+With these words he sat down, and Mentor {20} who had been a friend of
+Ulysses, and had been left in charge of everything with full authority
+over the servants, rose to speak. He, then, plainly and in all honesty
+addressed them thus:
+
+"Hear me, men of Ithaca, I hope that you may never have a kind and
+well-disposed ruler any more, nor one who will govern you equitably;
+I hope that all your chiefs henceforward may be cruel and unjust, for
+there is not one of you but has forgotten Ulysses, who ruled you as
+though he were your father. I am not half so angry with the suitors, for
+if they choose to do violence in the naughtiness of their hearts, and
+wager their heads that Ulysses will not return, they can take the high
+hand and eat up his estate, but as for you others I am shocked at
+the way in which you all sit still without even trying to stop such
+scandalous goings on--which you could do if you chose, for you are many
+and they are few."
+
+Leiocritus, son of Evenor, answered him saying, "Mentor, what folly is
+all this, that you should set the people to stay us? It is a hard thing
+for one man to fight with many about his victuals. Even though Ulysses
+himself were to set upon us while we are feasting in his house, and do
+his best to oust us, his wife, who wants him back so very badly, would
+have small cause for rejoicing, and his blood would be upon his own head
+if he fought against such great odds. There is no sense in what you have
+been saying. Now, therefore, do you people go about your business, and
+let his father's old friends, Mentor and Halitherses, speed this boy on
+his journey, if he goes at all--which I do not think he will, for he
+is more likely to stay where he is till some one comes and tells him
+something."
+
+On this he broke up the assembly, and every man went back to his own
+abode, while the suitors returned to the house of Ulysses.
+
+Then Telemachus went all alone by the sea side, washed his hands in the
+grey waves, and prayed to Minerva.
+
+"Hear me," he cried, "you god who visited me yesterday, and bade me sail
+the seas in search of my father who has so long been missing. I would
+obey you, but the Achaeans, and more particularly the wicked suitors,
+are hindering me that I cannot do so."
+
+As he thus prayed, Minerva came close up to him in the likeness and with
+the voice of Mentor. "Telemachus," said she, "if you are made of
+the same stuff as your father you will be neither fool nor coward
+henceforward, for Ulysses never broke his word nor left his work half
+done. If, then, you take after him, your voyage will not be fruitless,
+but unless you have the blood of Ulysses and of Penelope in your veins
+I see no likelihood of your succeeding. Sons are seldom as good men as
+their fathers; they are generally worse, not better; still, as you are
+not going to be either fool or coward henceforward, and are not entirely
+without some share of your father's wise discernment, I look with hope
+upon your undertaking. But mind you never make common cause with any of
+those foolish suitors, for they have neither sense nor virtue, and give
+no thought to death and to the doom that will shortly fall on one and
+all of them, so that they shall perish on the same day. As for your
+voyage, it shall not be long delayed; your father was such an old friend
+of mine that I will find you a ship, and will come with you myself.
+Now, however, return home, and go about among the suitors; begin getting
+provisions ready for your voyage; see everything well stowed, the wine
+in jars, and the barley meal, which is the staff of life, in leathern
+bags, while I go round the town and beat up volunteers at once. There
+are many ships in Ithaca both old and new; I will run my eye over them
+for you and will choose the best; we will get her ready and will put out
+to sea without delay."
+
+Thus spoke Minerva daughter of Jove, and Telemachus lost no time in
+doing as the goddess told him. He went moodily home, and found the
+suitors flaying goats and singeing pigs in the outer court. Antinous
+came up to him at once and laughed as he took his hand in his own,
+saying, "Telemachus, my fine fire-eater, bear no more ill blood neither
+in word nor deed, but eat and drink with us as you used to do. The
+Achaeans will find you in everything--a ship and a picked crew to
+boot--so that you can set sail for Pylos at once and get news of your
+noble father."
+
+"Antinous," answered Telemachus, "I cannot eat in peace, nor take
+pleasure of any kind with such men as you are. Was it not enough that
+you should waste so much good property of mine while I was yet a boy?
+Now that I am older and know more about it, I am also stronger, and
+whether here among this people, or by going to Pylos, I will do you all
+the harm I can. I shall go, and my going will not be in vain--though,
+thanks to you suitors, I have neither ship nor crew of my own, and must
+be passenger not captain."
+
+As he spoke he snatched his hand from that of Antinous. Meanwhile the
+others went on getting dinner ready about the buildings, {21} jeering at
+him tauntingly as they did so.
+
+"Telemachus," said one youngster, "means to be the death of us; I
+suppose he thinks he can bring friends to help him from Pylos, or again
+from Sparta, where he seems bent on going. Or will he go to Ephyra as
+well, for poison to put in our wine and kill us?"
+
+Another said, "Perhaps if Telemachus goes on board ship, he will be like
+his father and perish far from his friends. In this case we should have
+plenty to do, for we could then divide up his property amongst us: as
+for the house we can let his mother and the man who marries her have
+that."
+
+This was how they talked. But Telemachus went down into the lofty and
+spacious store-room where his father's treasure of gold and bronze lay
+heaped up upon the floor, and where the linen and spare clothes were
+kept in open chests. Here, too, there was a store of fragrant olive oil,
+while casks of old, well-ripened wine, unblended and fit for a god to
+drink, were ranged against the wall in case Ulysses should come home
+again after all. The room was closed with well-made doors opening in the
+middle; moreover the faithful old house-keeper Euryclea, daughter of
+Ops the son of Pisenor, was in charge of everything both night and day.
+Telemachus called her to the store-room and said:
+
+"Nurse, draw me off some of the best wine you have, after what you
+are keeping for my father's own drinking, in case, poor man, he should
+escape death, and find his way home again after all. Let me have twelve
+jars, and see that they all have lids; also fill me some well-sewn
+leathern bags with barley meal--about twenty measures in all. Get these
+things put together at once, and say nothing about it. I will take
+everything away this evening as soon as my mother has gone upstairs
+for the night. I am going to Sparta and to Pylos to see if I can hear
+anything about the return of my dear father."
+
+When Euryclea heard this she began to cry, and spoke fondly to him,
+saying, "My dear child, what ever can have put such notion as that into
+your head? Where in the world do you want to go to--you, who are the
+one hope of the house? Your poor father is dead and gone in some foreign
+country nobody knows where, and as soon as your back is turned these
+wicked ones here will be scheming to get you put out of the way, and
+will share all your possessions among themselves; stay where you are
+among your own people, and do not go wandering and worrying your life
+out on the barren ocean."
+
+"Fear not, nurse," answered Telemachus, "my scheme is not without
+heaven's sanction; but swear that you will say nothing about all this
+to my mother, till I have been away some ten or twelve days, unless she
+hears of my having gone, and asks you; for I do not want her to spoil
+her beauty by crying."
+
+The old woman swore most solemnly that she would not, and when she
+had completed her oath, she began drawing off the wine into jars, and
+getting the barley meal into the bags, while Telemachus went back to the
+suitors.
+
+Then Minerva bethought her of another matter. She took his shape, and
+went round the town to each one of the crew, telling them to meet at the
+ship by sundown. She went also to Noemon son of Phronius, and asked him
+to let her have a ship--which he was very ready to do. When the sun had
+set and darkness was over all the land, she got the ship into the
+water, put all the tackle on board her that ships generally carry, and
+stationed her at the end of the harbour. Presently the crew came up, and
+the goddess spoke encouragingly to each of them.
+
+Furthermore she went to the house of Ulysses, and threw the suitors into
+a deep slumber. She caused their drink to fuddle them, and made them
+drop their cups from their hands, so that instead of sitting over their
+wine, they went back into the town to sleep, with their eyes heavy and
+full of drowsiness. Then she took the form and voice of Mentor, and
+called Telemachus to come outside.
+
+"Telemachus," said she, "the men are on board and at their oars, waiting
+for you to give your orders, so make haste and let us be off."
+
+On this she led the way, while Telemachus followed in her steps. When
+they got to the ship they found the crew waiting by the water side, and
+Telemachus said, "Now my men, help me to get the stores on board;
+they are all put together in the cloister, and my mother does not know
+anything about it, nor any of the maid servants except one."
+
+With these words he led the way and the others followed after. When
+they had brought the things as he told them, Telemachus went on board,
+Minerva going before him and taking her seat in the stern of the vessel,
+while Telemachus sat beside her. Then the men loosed the hawsers and
+took their places on the benches. Minerva sent them a fair wind from
+the West, {22} that whistled over the deep blue waves {23} whereon
+Telemachus told them to catch hold of the ropes and hoist sail, and they
+did as he told them. They set the mast in its socket in the cross plank,
+raised it, and made it fast with the forestays; then they hoisted their
+white sails aloft with ropes of twisted ox hide. As the sail bellied out
+with the wind, the ship flew through the deep blue water, and the foam
+hissed against her bows as she sped onward. Then they made all fast
+throughout the ship, filled the mixing bowls to the brim, and made
+drink offerings to the immortal gods that are from everlasting, but more
+particularly to the grey-eyed daughter of Jove.
+
+Thus, then, the ship sped on her way through the watches of the night
+from dark till dawn,
+
+
+Book III
+
+TELEMACHUS VISITS NESTOR AT PYLOS.
+
+but as the sun was rising from the fair sea {24} into the firmament of
+heaven to shed light on mortals and immortals, they reached Pylos the
+city of Neleus. Now the people of Pylos were gathered on the sea shore
+to offer sacrifice of black bulls to Neptune lord of the Earthquake.
+There were nine guilds with five hundred men in each, and there were
+nine bulls to each guild. As they were eating the inward meats {25}
+and burning the thigh bones [on the embers] in the name of Neptune,
+Telemachus and his crew arrived, furled their sails, brought their ship
+to anchor, and went ashore.
+
+Minerva led the way and Telemachus followed her. Presently she said,
+"Telemachus, you must not be in the least shy or nervous; you have taken
+this voyage to try and find out where your father is buried and how he
+came by his end; so go straight up to Nestor that we may see what he has
+got to tell us. Beg of him to speak the truth, and he will tell no lies,
+for he is an excellent person."
+
+"But how, Mentor," replied Telemachus, "dare I go up to Nestor, and
+how am I to address him? I have never yet been used to holding long
+conversations with people, and am ashamed to begin questioning one who
+is so much older than myself."
+
+"Some things, Telemachus," answered Minerva, "will be suggested to
+you by your own instinct, and heaven will prompt you further; for I am
+assured that the gods have been with you from the time of your birth
+until now."
+
+She then went quickly on, and Telemachus followed in her steps till they
+reached the place where the guilds of the Pylian people were assembled.
+There they found Nestor sitting with his sons, while his company round
+him were busy getting dinner ready, and putting pieces of meat on to the
+spits {26} while other pieces were cooking. When they saw the strangers
+they crowded round them, took them by the hand and bade them take their
+places. Nestor's son Pisistratus at once offered his hand to each of
+them, and seated them on some soft sheepskins that were lying on the
+sands near his father and his brother Thrasymedes. Then he gave them
+their portions of the inward meats and poured wine for them into a
+golden cup, handing it to Minerva first, and saluting her at the same
+time.
+
+"Offer a prayer, sir," said he, "to King Neptune, for it is his feast
+that you are joining; when you have duly prayed and made your drink
+offering, pass the cup to your friend that he may do so also. I doubt
+not that he too lifts his hands in prayer, for man cannot live without
+God in the world. Still he is younger than you are, and is much of an
+age with myself, so I will give you the precedence."
+
+As he spoke he handed her the cup. Minerva thought it very right and
+proper of him to have given it to herself first; {27} she accordingly
+began praying heartily to Neptune. "O thou," she cried, "that encirclest
+the earth, vouchsafe to grant the prayers of thy servants that call upon
+thee. More especially we pray thee send down thy grace on Nestor and
+on his sons; thereafter also make the rest of the Pylian people some
+handsome return for the goodly hecatomb they are offering you. Lastly,
+grant Telemachus and myself a happy issue, in respect of the matter that
+has brought us in our ship to Pylos."
+
+When she had thus made an end of praying, she handed the cup to
+Telemachus and he prayed likewise. By and by, when the outer meats were
+roasted and had been taken off the spits, the carvers gave every man his
+portion and they all made an excellent dinner. As soon as they had had
+enough to eat and drink, Nestor, knight of Gerene, began to speak.
+
+"Now," said he, "that our guests have done their dinner, it will be best
+to ask them who they are. Who, then, sir strangers, are you, and from
+what port have you sailed? Are you traders? or do you sail the seas as
+rovers with your hand against every man, and every man's hand against
+you?"
+
+Telemachus answered boldly, for Minerva had given him courage to ask
+about his father and get himself a good name.
+
+"Nestor," said he, "son of Neleus, honour to the Achaean name, you ask
+whence we come, and I will tell you. We come from Ithaca under Neritum,
+{28} and the matter about which I would speak is of private not public
+import. I seek news of my unhappy father Ulysses, who is said to have
+sacked the town of Troy in company with yourself. We know what fate
+befell each one of the other heroes who fought at Troy, but as regards
+Ulysses heaven has hidden from us the knowledge even that he is dead
+at all, for no one can certify us in what place he perished, nor say
+whether he fell in battle on the mainland, or was lost at sea amid the
+waves of Amphitrite. Therefore I am suppliant at your knees, if haply
+you may be pleased to tell me of his melancholy end, whether you saw it
+with your own eyes, or heard it from some other traveller, for he was
+a man born to trouble. Do not soften things out of any pity for me,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service, either by word or deed, when you
+Achaeans were harassed among the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+"My friend," answered Nestor, "you recall a time of much sorrow to
+my mind, for the brave Achaeans suffered much both at sea, while
+privateering under Achilles, and when fighting before the great city
+of king Priam. Our best men all of them fell there--Ajax, Achilles,
+Patroclus peer of gods in counsel, and my own dear son Antilochus, a man
+singularly fleet of foot and in fight valiant. But we suffered much more
+than this; what mortal tongue indeed could tell the whole story? Though
+you were to stay here and question me for five years, or even six, I
+could not tell you all that the Achaeans suffered, and you would turn
+homeward weary of my tale before it ended. Nine long years did we try
+every kind of stratagem, but the hand of heaven was against us; during
+all this time there was no one who could compare with your father in
+subtlety--if indeed you are his son--I can hardly believe my eyes--and
+you talk just like him too--no one would say that people of such
+different ages could speak so much alike. He and I never had any kind
+of difference from first to last neither in camp nor council, but in
+singleness of heart and purpose we advised the Argives how all might be
+ordered for the best.
+
+"When, however, we had sacked the city of Priam, and were setting sail
+in our ships as heaven had dispersed us, then Jove saw fit to vex the
+Argives on their homeward voyage; for they had not all been either
+wise or understanding, and hence many came to a bad end through the
+displeasure of Jove's daughter Minerva, who brought about a quarrel
+between the two sons of Atreus.
+
+"The sons of Atreus called a meeting which was not as it should be, for
+it was sunset and the Achaeans were heavy with wine. When they explained
+why they had called the people together, it seemed that Menelaus was
+for sailing homeward at once, and this displeased Agamemnon, who thought
+that we should wait till we had offered hecatombs to appease the anger
+of Minerva. Fool that he was, he might have known that he would not
+prevail with her, for when the gods have made up their minds they do not
+change them lightly. So the two stood bandying hard words, whereon the
+Achaeans sprang to their feet with a cry that rent the air, and were of
+two minds as to what they should do.
+
+"That night we rested and nursed our anger, for Jove was hatching
+mischief against us. But in the morning some of us drew our ships into
+the water and put our goods with our women on board, while the rest,
+about half in number, stayed behind with Agamemnon. We--the other
+half--embarked and sailed; and the ships went well, for heaven had
+smoothed the sea. When we reached Tenedos we offered sacrifices to the
+gods, for we were longing to get home; cruel Jove, however, did not yet
+mean that we should do so, and raised a second quarrel in the course of
+which some among us turned their ships back again, and sailed away under
+Ulysses to make their peace with Agamemnon; but I, and all the ships
+that were with me pressed forward, for I saw that mischief was brewing.
+The son of Tydeus went on also with me, and his crews with him. Later on
+Menelaus joined us at Lesbos, and found us making up our minds about our
+course--for we did not know whether to go outside Chios by the island
+of Psyra, keeping this to our left, or inside Chios, over against the
+stormy headland of Mimas. So we asked heaven for a sign, and were shown
+one to the effect that we should be soonest out of danger if we headed
+our ships across the open sea to Euboea. This we therefore did, and a
+fair wind sprang up which gave us a quick passage during the night to
+Geraestus, {29} where we offered many sacrifices to Neptune for
+having helped us so far on our way. Four days later Diomed and his men
+stationed their ships in Argos, but I held on for Pylos, and the wind
+never fell light from the day when heaven first made it fair for me.
+
+"Therefore, my dear young friend, I returned without hearing anything
+about the others. I know neither who got home safely nor who were lost
+but, as in duty bound, I will give you without reserve the reports that
+have reached me since I have been here in my own house. They say the
+Myrmidons returned home safely under Achilles' son Neoptolemus; so also
+did the valiant son of Poias, Philoctetes. Idomeneus, again, lost no men
+at sea, and all his followers who escaped death in the field got safe
+home with him to Crete. No matter how far out of the world you live, you
+will have heard of Agamemnon and the bad end he came to at the hands of
+Aegisthus--and a fearful reckoning did Aegisthus presently pay. See what
+a good thing it is for a man to leave a son behind him to do as Orestes
+did, who killed false Aegisthus the murderer of his noble father. You
+too, then--for you are a tall smart-looking fellow--show your mettle and
+make yourself a name in story."
+
+"Nestor son of Neleus," answered Telemachus, "honour to the Achaean
+name, the Achaeans applaud Orestes and his name will live through all
+time for he has avenged his father nobly. Would that heaven might grant
+me to do like vengeance on the insolence of the wicked suitors, who
+are ill treating me and plotting my ruin; but the gods have no such
+happiness in store for me and for my father, so we must bear it as best
+we may."
+
+"My friend," said Nestor, "now that you remind me, I remember to have
+heard that your mother has many suitors, who are ill disposed towards
+you and are making havoc of your estate. Do you submit to this tamely,
+or are public feeling and the voice of heaven against you? Who knows but
+what Ulysses may come back after all, and pay these scoundrels in full,
+either single-handed or with a force of Achaeans behind him? If Minerva
+were to take as great a liking to you as she did to Ulysses when we were
+fighting before Troy (for I never yet saw the gods so openly fond of any
+one as Minerva then was of your father), if she would take as good care
+of you as she did of him, these wooers would soon some of them forget
+their wooing."
+
+Telemachus answered, "I can expect nothing of the kind; it would be far
+too much to hope for. I dare not let myself think of it. Even though the
+gods themselves willed it no such good fortune could befall me."
+
+On this Minerva said, "Telemachus, what are you talking about? Heaven
+has a long arm if it is minded to save a man; and if it were me, I
+should not care how much I suffered before getting home, provided I
+could be safe when I was once there. I would rather this, than get home
+quickly, and then be killed in my own house as Agamemnon was by the
+treachery of Aegisthus and his wife. Still, death is certain, and when
+a man's hour is come, not even the gods can save him, no matter how fond
+they are of him."
+
+"Mentor," answered Telemachus, "do not let us talk about it any more.
+There is no chance of my father's ever coming back; the gods have long
+since counselled his destruction. There is something else, however,
+about which I should like to ask Nestor, for he knows much more than any
+one else does. They say he has reigned for three generations so that it
+is like talking to an immortal. Tell me, therefore, Nestor, and tell
+me true; how did Agamemnon come to die in that way? What was Menelaus
+doing? And how came false Aegisthus to kill so far better a man than
+himself? Was Menelaus away from Achaean Argos, voyaging elsewhither
+among mankind, that Aegisthus took heart and killed Agamemnon?"
+
+"I will tell you truly," answered Nestor, "and indeed you have yourself
+divined how it all happened. If Menelaus when he got back from Troy
+had found Aegisthus still alive in his house, there would have been no
+barrow heaped up for him, not even when he was dead, but he would have
+been thrown outside the city to dogs and vultures, and not a woman would
+have mourned him, for he had done a deed of great wickedness; but we
+were over there, fighting hard at Troy, and Aegisthus, who was taking
+his ease quietly in the heart of Argos, cajoled Agamemnon's wife
+Clytemnestra with incessant flattery.
+
+"At first she would have nothing to do with his wicked scheme, for she
+was of a good natural disposition; {30} moreover there was a bard with
+her, to whom Agamemnon had given strict orders on setting out for Troy,
+that he was to keep guard over his wife; but when heaven had counselled
+her destruction, Aegisthus carried this bard off to a desert island and
+left him there for crows and seagulls to batten upon--after which she
+went willingly enough to the house of Aegisthus. Then he offered many
+burnt sacrifices to the gods, and decorated many temples with tapestries
+and gilding, for he had succeeded far beyond his expectations.
+
+"Meanwhile Menelaus and I were on our way home from Troy, on good terms
+with one another. When we got to Sunium, which is the point of Athens,
+Apollo with his painless shafts killed Phrontis the steersman of
+Menelaus' ship (and never man knew better how to handle a vessel in
+rough weather) so that he died then and there with the helm in his hand,
+and Menelaus, though very anxious to press forward, had to wait in order
+to bury his comrade and give him his due funeral rites. Presently, when
+he too could put to sea again, and had sailed on as far as the Malean
+heads, Jove counselled evil against him and made it blow hard till the
+waves ran mountains high. Here he divided his fleet and took the one
+half towards Crete where the Cydonians dwell round about the waters of
+the river Iardanus. There is a high headland hereabouts stretching out
+into the sea from a place called Gortyn, and all along this part of the
+coast as far as Phaestus the sea runs high when there is a south wind
+blowing, but after Phaestus the coast is more protected, for a small
+headland can make a great shelter. Here this part of the fleet was
+driven on to the rocks and wrecked; but the crews just managed to save
+themselves. As for the other five ships, they were taken by winds and
+seas to Egypt, where Menelaus gathered much gold and substance among
+people of an alien speech. Meanwhile Aegisthus here at home plotted his
+evil deed. For seven years after he had killed Agamemnon he ruled in
+Mycene, and the people were obedient under him, but in the eighth year
+Orestes came back from Athens to be his bane, and killed the murderer
+of his father. Then he celebrated the funeral rites of his mother and
+of false Aegisthus by a banquet to the people of Argos, and on that very
+day Menelaus came home, {31} with as much treasure as his ships could
+carry.
+
+"Take my advice then, and do not go travelling about for long so far
+from home, nor leave your property with such dangerous people in your
+house; they will eat up everything you have among them, and you will
+have been on a fool's errand. Still, I should advise you by all means
+to go and visit Menelaus, who has lately come off a voyage among such
+distant peoples as no man could ever hope to get back from, when the
+winds had once carried him so far out of his reckoning; even birds
+cannot fly the distance in a twelve-month, so vast and terrible are the
+seas that they must cross. Go to him, therefore, by sea, and take your
+own men with you; or if you would rather travel by land you can have a
+chariot, you can have horses, and here are my sons who can escort you to
+Lacedaemon where Menelaus lives. Beg of him to speak the truth, and he
+will tell you no lies, for he is an excellent person."
+
+As he spoke the sun set and it came on dark, whereon Minerva said, "Sir,
+all that you have said is well; now, however, order the tongues of the
+victims to be cut, and mix wine that we may make drink-offerings to
+Neptune, and the other immortals, and then go to bed, for it is bed
+time. People should go away early and not keep late hours at a religious
+festival."
+
+Thus spoke the daughter of Jove, and they obeyed her saying. Men
+servants poured water over the hands of the guests, while pages filled
+the mixing-bowls with wine and water, and handed it round after giving
+every man his drink offering; then they threw the tongues of the victims
+into the fire, and stood up to make their drink offerings. When they
+had made their offerings and had drunk each as much as he was minded,
+Minerva and Telemachus were for going on board their ship, but Nestor
+caught them up at once and stayed them.
+
+"Heaven and the immortal gods," he exclaimed, "forbid that you should
+leave my house to go on board of a ship. Do you think I am so poor and
+short of clothes, or that I have so few cloaks and as to be unable to
+find comfortable beds both for myself and for my guests? Let me tell you
+I have store both of rugs and cloaks, and shall not permit the son of
+my old friend Ulysses to camp down on the deck of a ship--not while I
+live--nor yet will my sons after me, but they will keep open house as I
+have done."
+
+Then Minerva answered, "Sir, you have spoken well, and it will be much
+better that Telemachus should do as you have said; he, therefore, shall
+return with you and sleep at your house, but I must go back to give
+orders to my crew, and keep them in good heart. I am the only older
+person among them; the rest are all young men of Telemachus' own age,
+who have taken this voyage out of friendship; so I must return to the
+ship and sleep there. Moreover to-morrow I must go to the Cauconians
+where I have a large sum of money long owing to me. As for Telemachus,
+now that he is your guest, send him to Lacedaemon in a chariot, and let
+one of your sons go with him. Be pleased to also provide him with your
+best and fleetest horses."
+
+When she had thus spoken, she flew away in the form of an eagle, and all
+marvelled as they beheld it. Nestor was astonished, and took Telemachus
+by the hand. "My friend," said he, "I see that you are going to be a
+great hero some day, since the gods wait upon you thus while you are
+still so young. This can have been none other of those who dwell in
+heaven than Jove's redoubtable daughter, the Trito-born, who shewed
+such favour towards your brave father among the Argives. Holy queen," he
+continued, "vouchsafe to send down thy grace upon myself, my good wife,
+and my children. In return, I will offer you in sacrifice a broad-browed
+heifer of a year old, unbroken, and never yet brought by man under the
+yoke. I will gild her horns, and will offer her up to you in sacrifice."
+
+Thus did he pray, and Minerva heard his prayer. He then led the way to
+his own house, followed by his sons and sons in law. When they had got
+there and had taken their places on the benches and seats, he mixed them
+a bowl of sweet wine that was eleven years old when the housekeeper took
+the lid off the jar that held it. As he mixed the wine, he prayed much
+and made drink offerings to Minerva, daughter of Aegis-bearing Jove.
+Then, when they had made their drink offerings and had drunk each as
+much as he was minded, the others went home to bed each in his own
+abode; but Nestor put Telemachus to sleep in the room that was over the
+gateway along with Pisistratus, who was the only unmarried son now left
+him. As for himself, he slept in an inner room of the house, with the
+queen his wife by his side.
+
+Now when the child of morning rosy-fingered Dawn appeared, Nestor left
+his couch and took his seat on the benches of white and polished marble
+that stood in front of his house. Here aforetime sat Neleus, peer of
+gods in counsel, but he was now dead, and had gone to the house of
+Hades; so Nestor sat in his seat sceptre in hand, as guardian of the
+public weal. His sons as they left their rooms gathered round him,
+Echephron, Stratius, Perseus, Aretus, and Thrasymedes; the sixth son
+was Pisistratus, and when Telemachus joined them they made him sit with
+them. Nestor then addressed them.
+
+"My sons," said he, "make haste to do as I shall bid you. I wish first
+and foremost to propitiate the great goddess Minerva, who manifested
+herself visibly to me during yesterday's festivities. Go, then, one or
+other of you to the plain, tell the stockman to look me out a heifer,
+and come on here with it at once. Another must go to Telemachus' ship,
+and invite all the crew, leaving two men only in charge of the vessel.
+Some one else will run and fetch Laerceus the goldsmith to gild the
+horns of the heifer. The rest, stay all of you where you are; tell the
+maids in the house to prepare an excellent dinner, and to fetch seats,
+and logs of wood for a burnt offering. Tell them also to bring me some
+clear spring water."
+
+On this they hurried off on their several errands. The heifer was
+brought in from the plain, and Telemachus's crew came from the ship; the
+goldsmith brought the anvil, hammer, and tongs, with which he worked his
+gold, and Minerva herself came to accept the sacrifice. Nestor gave out
+the gold, and the smith gilded the horns of the heifer that the goddess
+might have pleasure in their beauty. Then Stratius and Echephron brought
+her in by the horns; Aretus fetched water from the house in a ewer that
+had a flower pattern on it, and in his other hand he held a basket of
+barley meal; sturdy Thrasymedes stood by with a sharp axe, ready to
+strike the heifer, while Perseus held a bucket. Then Nestor began with
+washing his hands and sprinkling the barley meal, and he offered many
+a prayer to Minerva as he threw a lock from the heifer's head upon the
+fire.
+
+When they had done praying and sprinkling the barley meal {32}
+Thrasymedes dealt his blow, and brought the heifer down with a stroke
+that cut through the tendons at the base of her neck, whereon the
+daughters and daughters in law of Nestor, and his venerable wife
+Eurydice (she was eldest daughter to Clymenus) screamed with delight.
+Then they lifted the heifer's head from off the ground, and Pisistratus
+cut her throat. When she had done bleeding and was quite dead, they cut
+her up. They cut out the thigh bones all in due course, wrapped them
+round in two layers of fat, and set some pieces of raw meat on the top
+of them; then Nestor laid them upon the wood fire and poured wine over
+them, while the young men stood near him with five-pronged spits in
+their hands. When the thighs were burned and they had tasted the inward
+meats, they cut the rest of the meat up small, put the pieces on the
+spits and toasted them over the fire.
+
+Meanwhile lovely Polycaste, Nestor's youngest daughter, washed
+Telemachus. When she had washed him and anointed him with oil, she
+brought him a fair mantle and shirt, {33} and he looked like a god as
+he came from the bath and took his seat by the side of Nestor. When
+the outer meats were done they drew them off the spits and sat down to
+dinner where they were waited upon by some worthy henchmen, who kept
+pouring them out their wine in cups of gold. As soon as they had had
+enough to eat and drink Nestor said, "Sons, put Telemachus's horses to
+the chariot that he may start at once."
+
+Thus did he speak, and they did even as he had said, and yoked the fleet
+horses to the chariot. The housekeeper packed them up a provision
+of bread, wine, and sweet meats fit for the sons of princes. Then
+Telemachus got into the chariot, while Pisistratus gathered up the reins
+and took his seat beside him. He lashed the horses on and they flew
+forward nothing loth into the open country, leaving the high citadel of
+Pylos behind them. All that day did they travel, swaying the yoke upon
+their necks till the sun went down and darkness was over all the land.
+Then they reached Pherae where Diocles lived, who was son to Ortilochus
+and grandson to Alpheus. Here they passed the night and Diocles
+entertained them hospitably. When the child of morning, rosy-fingered
+Dawn, appeared, they again yoked their horses and drove out through the
+gateway under the echoing gatehouse. {34} Pisistratus lashed the horses
+on and they flew forward nothing loth; presently they came to the corn
+lands of the open country, and in the course of time completed their
+journey, so well did their steeds take them. {35}
+
+Now when the sun had set and darkness was over the land,
+
+
+Book IV
+
+THE VISIT TO KING MENELAUS, WHO TELLS HIS STORY--MEANWHILE THE SUITORS
+IN ITHACA PLOT AGAINST TELEMACHUS.
+
+they reached the low lying city of Lacedaemon, where they drove straight
+to the abode of Menelaus {36} [and found him in his own house, feasting
+with his many clansmen in honour of the wedding of his son, and also of
+his daughter, whom he was marrying to the son of that valiant warrior
+Achilles. He had given his consent and promised her to him while he was
+still at Troy, and now the gods were bringing the marriage about; so he
+was sending her with chariots and horses to the city of the Myrmidons
+over whom Achilles' son was reigning. For his only son he had found a
+bride from Sparta, {37} the daughter of Alector. This son, Megapenthes,
+was born to him of a bondwoman, for heaven vouchsafed Helen no more
+children after she had borne Hermione, who was fair as golden Venus
+herself.
+
+So the neighbours and kinsmen of Menelaus were feasting and making merry
+in his house. There was a bard also to sing to them and play his lyre,
+while two tumblers went about performing in the midst of them when the
+man struck up with his tune.] {38}
+
+Telemachus and the son of Nestor stayed their horses at the gate,
+whereon Eteoneus servant to Menelaus came out, and as soon as he saw
+them ran hurrying back into the house to tell his Master. He went close
+up to him and said, "Menelaus, there are some strangers come here, two
+men, who look like sons of Jove. What are we to do? Shall we take their
+horses out, or tell them to find friends elsewhere as they best can?"
+
+Menelaus was very angry and said, "Eteoneus, son of Boethous, you never
+used to be a fool, but now you talk like a simpleton. Take their horses
+out, of course, and show the strangers in that they may have supper;
+you and I have staid often enough at other people's houses before we got
+back here, where heaven grant that we may rest in peace henceforward."
+
+So Eteoneus bustled back and bade the other servants come with him. They
+took their sweating steeds from under the yoke, made them fast to the
+mangers, and gave them a feed of oats and barley mixed. Then they leaned
+the chariot against the end wall of the courtyard, and led the way into
+the house. Telemachus and Pisistratus were astonished when they saw it,
+for its splendour was as that of the sun and moon; then, when they had
+admired everything to their heart's content, they went into the bath
+room and washed themselves.
+
+When the servants had washed them and anointed them with oil, they
+brought them woollen cloaks and shirts, and the two took their seats by
+the side of Menelaus. A maid-servant brought them water in a beautiful
+golden ewer, and poured it into a silver basin for them to wash their
+hands; and she drew a clean table beside them. An upper servant brought
+them bread, and offered them many good things of what there was in the
+house, while the carver fetched them plates of all manner of meats and
+set cups of gold by their side.
+
+Menelaus then greeted them saying, "Fall to, and welcome; when you have
+done supper I shall ask who you are, for the lineage of such men as
+you cannot have been lost. You must be descended from a line of
+sceptre-bearing kings, for poor people do not have such sons as you
+are."
+
+On this he handed them {39} a piece of fat roast loin, which had been
+set near him as being a prime part, and they laid their hands on the
+good things that were before them; as soon as they had had enough to eat
+and drink, Telemachus said to the son of Nestor, with his head so close
+that no one might hear, "Look, Pisistratus, man after my own heart,
+see the gleam of bronze and gold--of amber, {40} ivory, and silver.
+Everything is so splendid that it is like seeing the palace of Olympian
+Jove. I am lost in admiration."
+
+Menelaus overheard him and said, "No one, my sons, can hold his own
+with Jove, for his house and everything about him is immortal; but among
+mortal men--well, there may be another who has as much wealth as I
+have, or there may not; but at all events I have travelled much and have
+undergone much hardship, for it was nearly eight years before I could
+get home with my fleet. I went to Cyprus, Phoenicia and the Egyptians;
+I went also to the Ethiopians, the Sidonians, and the Erembians, and to
+Libya where the lambs have horns as soon as they are born, and the sheep
+lamb down three times a year. Every one in that country, whether master
+or man, has plenty of cheese, meat, and good milk, for the ewes yield
+all the year round. But while I was travelling and getting great riches
+among these people, my brother was secretly and shockingly murdered
+through the perfidy of his wicked wife, so that I have no pleasure in
+being lord of all this wealth. Whoever your parents may be they must
+have told you about all this, and of my heavy loss in the ruin {41} of a
+stately mansion fully and magnificently furnished. Would that I had only
+a third of what I now have so that I had stayed at home, and all those
+were living who perished on the plain of Troy, far from Argos. I often
+grieve, as I sit here in my house, for one and all of them. At times
+I cry aloud for sorrow, but presently I leave off again, for crying is
+cold comfort and one soon tires of it. Yet grieve for these as I may,
+I do so for one man more than for them all. I cannot even think of him
+without loathing both food and sleep, so miserable does he make me, for
+no one of all the Achaeans worked so hard or risked so much as he did.
+He took nothing by it, and has left a legacy of sorrow to myself, for he
+has been gone a long time, and we know not whether he is alive or
+dead. His old father, his long-suffering wife Penelope, and his son
+Telemachus, whom he left behind him an infant in arms, are plunged in
+grief on his account."
+
+Thus spoke Menelaus, and the heart of Telemachus yearned as he bethought
+him of his father. Tears fell from his eyes as he heard him thus
+mentioned, so that he held his cloak before his face with both hands.
+When Menelaus saw this he doubted whether to let him choose his own time
+for speaking, or to ask him at once and find what it was all about.
+
+While he was thus in two minds Helen came down from her high vaulted and
+perfumed room, looking as lovely as Diana herself. Adraste brought her
+a seat, Alcippe a soft woollen rug while Phylo fetched her the silver
+work-box which Alcandra wife of Polybus had given her. Polybus lived in
+Egyptian Thebes, which is the richest city in the whole world; he gave
+Menelaus two baths, both of pure silver, two tripods, and ten talents of
+gold; besides all this, his wife gave Helen some beautiful presents, to
+wit, a golden distaff, and a silver work box that ran on wheels, with a
+gold band round the top of it. Phylo now placed this by her side, full
+of fine spun yarn, and a distaff charged with violet coloured wool was
+laid upon the top of it. Then Helen took her seat, put her feet upon the
+footstool, and began to question her husband. {42}
+
+"Do we know, Menelaus," said she, "the names of these strangers who
+have come to visit us? Shall I guess right or wrong?--but I cannot help
+saying what I think. Never yet have I seen either man or woman so like
+somebody else (indeed when I look at him I hardly know what to think)
+as this young man is like Telemachus, whom Ulysses left as a baby behind
+him, when you Achaeans went to Troy with battle in your hearts, on
+account of my most shameless self."
+
+"My dear wife," replied Menelaus, "I see the likeness just as you do.
+His hands and feet are just like Ulysses; so is his hair, with the shape
+of his head and the expression of his eyes. Moreover, when I was talking
+about Ulysses, and saying how much he had suffered on my account, tears
+fell from his eyes, and he hid his face in his mantle."
+
+Then Pisistratus said, "Menelaus, son of Atreus, you are right in
+thinking that this young man is Telemachus, but he is very modest, and
+is ashamed to come here and begin opening up discourse with one whose
+conversation is so divinely interesting as your own. My father, Nestor,
+sent me to escort him hither, for he wanted to know whether you could
+give him any counsel or suggestion. A son has always trouble at home
+when his father has gone away leaving him without supporters; and this
+is how Telemachus is now placed, for his father is absent, and there is
+no one among his own people to stand by him."
+
+"Bless my heart," replied Menelaus, "then I am receiving a visit from
+the son of a very dear friend, who suffered much hardship for my sake.
+I had always hoped to entertain him with most marked distinction when
+heaven had granted us a safe return from beyond the seas. I should have
+founded a city for him in Argos, and built him a house. I should have
+made him leave Ithaca with his goods, his son, and all his people, and
+should have sacked for them some one of the neighbouring cities that
+are subject to me. We should thus have seen one another continually,
+and nothing but death could have interrupted so close and happy an
+intercourse. I suppose, however, that heaven grudged us such great good
+fortune, for it has prevented the poor fellow from ever getting home at
+all."
+
+Thus did he speak, and his words set them all a weeping. Helen wept,
+Telemachus wept, and so did Menelaus, nor could Pisistratus keep his
+eyes from filling, when he remembered his dear brother Antilochus whom
+the son of bright Dawn had killed. Thereon he said to Menelaus,
+
+"Sir, my father Nestor, when we used to talk about you at home, told me
+you were a person of rare and excellent understanding. If, then, it be
+possible, do as I would urge you. I am not fond of crying while I am
+getting my supper. Morning will come in due course, and in the forenoon
+I care not how much I cry for those that are dead and gone. This is all
+we can do for the poor things. We can only shave our heads for them and
+wring the tears from our cheeks. I had a brother who died at Troy; he
+was by no means the worst man there; you are sure to have known him--his
+name was Antilochus; I never set eyes upon him myself, but they say that
+he was singularly fleet of foot and in fight valiant."
+
+"Your discretion, my friend," answered Menelaus, "is beyond your years.
+It is plain you take after your father. One can soon see when a man
+is son to one whom heaven has blessed both as regards wife and
+offspring--and it has blessed Nestor from first to last all his days,
+giving him a green old age in his own house, with sons about him who are
+both well disposed and valiant. We will put an end therefore to all this
+weeping, and attend to our supper again. Let water be poured over our
+hands. Telemachus and I can talk with one another fully in the morning."
+
+On this Asphalion, one of the servants, poured water over their hands
+and they laid their hands on the good things that were before them.
+
+Then Jove's daughter Helen bethought her of another matter. She drugged
+the wine with an herb that banishes all care, sorrow, and ill humour.
+Whoever drinks wine thus drugged cannot shed a single tear all the rest
+of the day, not even though his father and mother both of them drop down
+dead, or he sees a brother or a son hewn in pieces before his very eyes.
+This drug, of such sovereign power and virtue, had been given to Helen
+by Polydamna wife of Thon, a woman of Egypt, where there grow all sorts
+of herbs, some good to put into the mixing bowl and others poisonous.
+Moreover, every one in the whole country is a skilled physician, for
+they are of the race of Paeeon. When Helen had put this drug in the
+bowl, and had told the servants to serve the wine round, she said:
+
+"Menelaus, son of Atreus, and you my good friends, sons of honourable
+men (which is as Jove wills, for he is the giver both of good and evil,
+and can do what he chooses), feast here as you will, and listen while I
+tell you a tale in season. I cannot indeed name every single one of the
+exploits of Ulysses, but I can say what he did when he was before Troy,
+and you Achaeans were in all sorts of difficulties. He covered himself
+with wounds and bruises, dressed himself all in rags, and entered the
+enemy's city looking like a menial or a beggar, and quite different
+from what he did when he was among his own people. In this disguise
+he entered the city of Troy, and no one said anything to him. I alone
+recognised him and began to question him, but he was too cunning for me.
+When, however, I had washed and anointed him and had given him clothes,
+and after I had sworn a solemn oath not to betray him to the Trojans
+till he had got safely back to his own camp and to the ships, he told me
+all that the Achaeans meant to do. He killed many Trojans and got much
+information before he reached the Argive camp, for all which things the
+Trojan women made lamentation, but for my own part I was glad, for my
+heart was beginning to yearn after my home, and I was unhappy about
+the wrong that Venus had done me in taking me over there, away from
+my country, my girl, and my lawful wedded husband, who is indeed by no
+means deficient either in person or understanding."
+
+Then Menelaus said, "All that you have been saying, my dear wife, is
+true. I have travelled much, and have had much to do with heroes, but
+I have never seen such another man as Ulysses. What endurance too,
+and what courage he displayed within the wooden horse, wherein all the
+bravest of the Argives were lying in wait to bring death and destruction
+upon the Trojans. {43} At that moment you came up to us; some god
+who wished well to the Trojans must have set you on to it and you had
+Deiphobus with you. Three times did you go all round our hiding place
+and pat it; you called our chiefs each by his own name, and mimicked
+all our wives--Diomed, Ulysses, and I from our seats inside heard what
+a noise you made. Diomed and I could not make up our minds whether to
+spring out then and there, or to answer you from inside, but Ulysses
+held us all in check, so we sat quite still, all except Anticlus, who
+was beginning to answer you, when Ulysses clapped his two brawny hands
+over his mouth, and kept them there. It was this that saved us all, for
+he muzzled Anticlus till Minerva took you away again."
+
+"How sad," exclaimed Telemachus, "that all this was of no avail to save
+him, nor yet his own iron courage. But now, sir, be pleased to send us
+all to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+On this Helen told the maid servants to set beds in the room that was in
+the gatehouse, and to make them with good red rugs, and spread coverlets
+on the top of them with woollen cloaks for the guests to wear. So
+the maids went out, carrying a torch, and made the beds, to which
+a man-servant presently conducted the strangers. Thus, then, did
+Telemachus and Pisistratus sleep there in the forecourt, while the son
+of Atreus lay in an inner room with lovely Helen by his side.
+
+When the child of morning, rosy-fingered Dawn appeared, Menelaus rose
+and dressed himself. He bound his sandals on to his comely feet,
+girded his sword about his shoulders, and left his room looking like an
+immortal god. Then, taking a seat near Telemachus he said:
+
+"And what, Telemachus, has led you to take this long sea voyage to
+Lacedaemon? Are you on public, or private business? Tell me all about
+it."
+
+"I have come, sir," replied Telemachus, "to see if you can tell me
+anything about my father. I am being eaten out of house and home; my
+fair estate is being wasted, and my house is full of miscreants who keep
+killing great numbers of my sheep and oxen, on the pretence of paying
+their addresses to my mother. Therefore, I am suppliant at your knees if
+haply you may tell me about my father's melancholy end, whether you saw
+it with your own eyes, or heard it from some other traveller; for he was
+a man born to trouble. Do not soften things out of any pity for myself,
+but tell me in all plainness exactly what you saw. If my brave father
+Ulysses ever did you loyal service either by word or deed, when you
+Achaeans were harassed by the Trojans, bear it in mind now as in my
+favour and tell me truly all."
+
+Menelaus on hearing this was very much shocked. "So," he exclaimed,
+"these cowards would usurp a brave man's bed? A hind might as well lay
+her new born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell: the lion when he comes back to his lair
+will make short work with the pair of them--and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Achaeans cheered him--if he is still
+such and were to come near these suitors, they would have a short shrift
+and a sorry wedding. As regards your questions, however, I will not
+prevaricate nor deceive you, but will tell you without concealment all
+that the old man of the sea told me.
+
+"I was trying to come on here, but the gods detained me in Egypt, for
+my hecatombs had not given them full satisfaction, and the gods are very
+strict about having their dues. Now off Egypt, about as far as a ship
+can sail in a day with a good stiff breeze behind her, there is an
+island called Pharos--it has a good harbour from which vessels can
+get out into open sea when they have taken in water--and here the gods
+becalmed me twenty days without so much as a breath of fair wind to help
+me forward. We should have run clean out of provisions and my men would
+have starved, if a goddess had not taken pity upon me and saved me in
+the person of Idothea, daughter to Proteus, the old man of the sea, for
+she had taken a great fancy to me.
+
+"She came to me one day when I was by myself, as I often was, for the
+men used to go with their barbed hooks, all over the island in the
+hope of catching a fish or two to save them from the pangs of hunger.
+'Stranger,' said she, 'it seems to me that you like starving in this
+way--at any rate it does not greatly trouble you, for you stick here day
+after day, without even trying to get away though your men are dying by
+inches.'
+
+"'Let me tell you,' said I, 'whichever of the goddesses you may happen
+to be, that I am not staying here of my own accord, but must have
+offended the gods that live in heaven. Tell me, therefore, for the gods
+know everything, which of the immortals it is that is hindering me in
+this way, and tell me also how I may sail the sea so as to reach my
+home.'
+
+"'Stranger,' replied she, 'I will make it all quite clear to you. There
+is an old immortal who lives under the sea hereabouts and whose name
+is Proteus. He is an Egyptian, and people say he is my father; he is
+Neptune's head man and knows every inch of ground all over the bottom of
+the sea. If you can snare him and hold him tight, he will tell you about
+your voyage, what courses you are to take, and how you are to sail the
+sea so as to reach your home. He will also tell you, if you so will, all
+that has been going on at your house both good and bad, while you have
+been away on your long and dangerous journey.'
+
+"'Can you show me,' said I, 'some stratagem by means of which I may
+catch this old god without his suspecting it and finding me out? For a
+god is not easily caught--not by a mortal man.'
+
+"'Stranger,' said she, 'I will make it all quite clear to you. About the
+time when the sun shall have reached mid heaven, the old man of the sea
+comes up from under the waves, heralded by the West wind that furs the
+water over his head. As soon as he has come up he lies down, and goes to
+sleep in a great sea cave, where the seals--Halosydne's chickens as they
+call them--come up also from the grey sea, and go to sleep in shoals
+all round him; and a very strong and fish-like smell do they bring with
+them. {44} Early to-morrow morning I will take you to this place and
+will lay you in ambush. Pick out, therefore, the three best men you have
+in your fleet, and I will tell you all the tricks that the old man will
+play you.
+
+"'First he will look over all his seals, and count them; then, when he
+has seen them and tallied them on his five fingers, he will go to sleep
+among them, as a shepherd among his sheep. The moment you see that he is
+asleep seize him; put forth all your strength and hold him fast, for he
+will do his very utmost to get away from you. He will turn himself into
+every kind of creature that goes upon the earth, and will become also
+both fire and water; but you must hold him fast and grip him tighter
+and tighter, till he begins to talk to you and comes back to what he was
+when you saw him go to sleep; then you may slacken your hold and let him
+go; and you can ask him which of the gods it is that is angry with you,
+and what you must do to reach your home over the seas.'
+
+"Having so said she dived under the waves, whereon I turned back to
+the place where my ships were ranged upon the shore; and my heart was
+clouded with care as I went along. When I reached my ship we got supper
+ready, for night was falling, and camped down upon the beach.
+
+"When the child of morning rosy-fingered Dawn appeared, I took the three
+men on whose prowess of all kinds I could most rely, and went along by
+the sea-side, praying heartily to heaven. Meanwhile the goddess fetched
+me up four seal skins from the bottom of the sea, all of them just
+skinned, for she meant playing a trick upon her father. Then she dug
+four pits for us to lie in, and sat down to wait till we should come up.
+When we were close to her, she made us lie down in the pits one after
+the other, and threw a seal skin over each of us. Our ambuscade would
+have been intolerable, for the stench of the fishy seals was most
+distressing {45}--who would go to bed with a sea monster if he could
+help it?--but here, too, the goddess helped us, and thought of something
+that gave us great relief, for she put some ambrosia under each man's
+nostrils, which was so fragrant that it killed the smell of the seals.
+{46}
+
+"We waited the whole morning and made the best of it, watching the seals
+come up in hundreds to bask upon the sea shore, till at noon the old man
+of the sea came up too, and when he had found his fat seals he went over
+them and counted them. We were among the first he counted, and he never
+suspected any guile, but laid himself down to sleep as soon as he had
+done counting. Then we rushed upon him with a shout and seized him; on
+which he began at once with his old tricks, and changed himself first
+into a lion with a great mane; then all of a sudden he became a dragon,
+a leopard, a wild boar; the next moment he was running water, and then
+again directly he was a tree, but we stuck to him and never lost hold,
+till at last the cunning old creature became distressed, and said,
+'Which of the gods was it, Son of Atreus, that hatched this plot with
+you for snaring me and seizing me against my will? What do you want?'
+
+"'You know that yourself, old man,' I answered, 'you will gain nothing
+by trying to put me off. It is because I have been kept so long in this
+island, and see no sign of my being able to get away. I am losing
+all heart; tell me, then, for you gods know everything, which of the
+immortals it is that is hindering me, and tell me also how I may sail
+the sea so as to reach my home?'
+
+"Then,' he said, 'if you would finish your voyage and get home quickly,
+you must offer sacrifices to Jove and to the rest of the gods before
+embarking; for it is decreed that you shall not get back to your
+friends, and to your own house, till you have returned to the heaven-fed
+stream of Egypt, and offered holy hecatombs to the immortal gods that
+reign in heaven. When you have done this they will let you finish your
+voyage.'
+
+"I was broken hearted when I heard that I must go back all that long and
+terrible voyage to Egypt; {47} nevertheless, I answered, 'I will do all,
+old man, that you have laid upon me; but now tell me, and tell me true,
+whether all the Achaeans whom Nestor and I left behind us when we set
+sail from Troy have got home safely, or whether any one of them came
+to a bad end either on board his own ship or among his friends when the
+days of his fighting were done.'
+
+"'Son of Atreus,' he answered, 'why ask me? You had better not know what
+I can tell you, for your eyes will surely fill when you have heard my
+story. Many of those about whom you ask are dead and gone, but many
+still remain, and only two of the chief men among the Achaeans
+perished during their return home. As for what happened on the field of
+battle--you were there yourself. A third Achaean leader is still at sea,
+alive, but hindered from returning. Ajax was wrecked, for Neptune drove
+him on to the great rocks of Gyrae; nevertheless, he let him get safe
+out of the water, and in spite of all Minerva's hatred he would have
+escaped death, if he had not ruined himself by boasting. He said the
+gods could not drown him even though they had tried to do so, and when
+Neptune heard this large talk, he seized his trident in his two brawny
+hands, and split the rock of Gyrae in two pieces. The base remained
+where it was, but the part on which Ajax was sitting fell headlong
+into the sea and carried Ajax with it; so he drank salt water and was
+drowned.
+
+"'Your brother and his ships escaped, for Juno protected him, but when
+he was just about to reach the high promontory of Malea, he was caught
+by a heavy gale which carried him out to sea again sorely against his
+will, and drove him to the foreland where Thyestes used to dwell, but
+where Aegisthus was then living. By and by, however, it seemed as though
+he was to return safely after all, for the gods backed the wind into its
+old quarter and they reached home; whereon Agamemnon kissed his native
+soil, and shed tears of joy at finding himself in his own country.
+
+"'Now there was a watchman whom Aegisthus kept always on the watch, and
+to whom he had promised two talents of gold. This man had been looking
+out for a whole year to make sure that Agamemnon did not give him the
+slip and prepare war; when, therefore, this man saw Agamemnon go by,
+he went and told Aegisthus, who at once began to lay a plot for him. He
+picked twenty of his bravest warriors and placed them in ambuscade on
+one side the cloister, while on the opposite side he prepared a banquet.
+Then he sent his chariots and horsemen to Agamemnon, and invited him to
+the feast, but he meant foul play. He got him there, all unsuspicious of
+the doom that was awaiting him, and killed him when the banquet was
+over as though he were butchering an ox in the shambles; not one of
+Agamemnon's followers was left alive, nor yet one of Aegisthus', but
+they were all killed there in the cloisters.'
+
+"Thus spoke Proteus, and I was broken hearted as I heard him. I sat down
+upon the sands and wept; I felt as though I could no longer bear to live
+nor look upon the light of the sun. Presently, when I had had my fill of
+weeping and writhing upon the ground, the old man of the sea said, 'Son
+of Atreus, do not waste any more time in crying so bitterly; it can
+do no manner of good; find your way home as fast as ever you can,
+for Aegisthus may be still alive, and even though Orestes has been
+beforehand with you in killing him, you may yet come in for his
+funeral.'
+
+"On this I took comfort in spite of all my sorrow, and said, 'I know,
+then, about these two; tell me, therefore, about the third man of whom
+you spoke; is he still alive, but at sea, and unable to get home? or is
+he dead? Tell me, no matter how much it may grieve me.'
+
+"'The third man,' he answered, 'is Ulysses who dwells in Ithaca. I
+can see him in an island sorrowing bitterly in the house of the nymph
+Calypso, who is keeping him prisoner, and he cannot reach his home for
+he has no ships nor sailors to take him over the sea. As for your own
+end, Menelaus, you shall not die in Argos, but the gods will take you to
+the Elysian plain, which is at the ends of the world. There fair-haired
+Rhadamanthus reigns, and men lead an easier life than any where else in
+the world, for in Elysium there falls not rain, nor hail, nor snow, but
+Oceanus breathes ever with a West wind that sings softly from the sea,
+and gives fresh life to all men. This will happen to you because you
+have married Helen, and are Jove's son-in-law.'
+
+"As he spoke he dived under the waves, whereon I turned back to the
+ships with my companions, and my heart was clouded with care as I went
+along. When we reached the ships we got supper ready, for night was
+falling, and camped down upon the beach. When the child of morning,
+rosy-fingered Dawn appeared, we drew our ships into the water, and put
+our masts and sails within them; then we went on board ourselves, took
+our seats on the benches, and smote the grey sea with our oars. I
+again stationed my ships in the heaven-fed stream of Egypt, and offered
+hecatombs that were full and sufficient. When I had thus appeased
+heaven's anger, I raised a barrow to the memory of Agamemnon that his
+name might live for ever, after which I had a quick passage home, for
+the gods sent me a fair wind.
+
+"And now for yourself--stay here some ten or twelve days longer, and I
+will then speed you on your way. I will make you a noble present of a
+chariot and three horses. I will also give you a beautiful chalice
+that so long as you live you may think of me whenever you make a
+drink-offering to the immortal gods."
+
+"Son of Atreus," replied Telemachus, "do not press me to stay longer; I
+should be contented to remain with you for another twelve months; I find
+your conversation so delightful that I should never once wish myself at
+home with my parents; but my crew whom I have left at Pylos are already
+impatient, and you are detaining me from them. As for any present you
+may be disposed to make me, I had rather that it should be a piece of
+plate. I will take no horses back with me to Ithaca, but will leave them
+to adorn your own stables, for you have much flat ground in your kingdom
+where lotus thrives, as also meadow-sweet and wheat and barley, and oats
+with their white and spreading ears; whereas in Ithaca we have neither
+open fields nor racecourses, and the country is more fit for goats than
+horses, and I like it the better for that. {48} None of our islands have
+much level ground, suitable for horses, and Ithaca least of all."
+
+Menelaus smiled and took Telemachus's hand within his own. "What you
+say," said he, "shows that you come of good family. I both can, and
+will, make this exchange for you, by giving you the finest and most
+precious piece of plate in all my house. It is a mixing bowl by Vulcan's
+own hand, of pure silver, except the rim, which is inlaid with gold.
+Phaedimus, king of the Sidonians, gave it me in the course of a visit
+which I paid him when I returned thither on my homeward journey. I will
+make you a present of it."
+
+Thus did they converse [and guests kept coming to the king's house. They
+brought sheep and wine, while their wives had put up bread for them to
+take with them; so they were busy cooking their dinners in the courts].
+{49}
+
+Meanwhile the suitors were throwing discs or aiming with spears at
+a mark on the levelled ground in front of Ulysses' house, and were
+behaving with all their old insolence. Antinous and Eurymachus, who were
+their ringleaders and much the foremost among them all, were sitting
+together when Noemon son of Phronius came up and said to Antinous,
+
+"Have we any idea, Antinous, on what day Telemachus returns from Pylos?
+He has a ship of mine, and I want it, to cross over to Elis: I have
+twelve brood mares there with yearling mule foals by their side not yet
+broken in, and I want to bring one of them over here and break him."
+
+They were astounded when they heard this, for they had made sure that
+Telemachus had not gone to the city of Neleus. They thought he was
+only away somewhere on the farms, and was with the sheep, or with the
+swineherd; so Antinous said, "When did he go? Tell me truly, and
+what young men did he take with him? Were they freemen or his own
+bondsmen--for he might manage that too? Tell me also, did you let him
+have the ship of your own free will because he asked you, or did he take
+it without your leave?"
+
+"I lent it him," answered Noemon, "what else could I do when a man of
+his position said he was in a difficulty, and asked me to oblige him? I
+could not possibly refuse. As for those who went with him they were the
+best young men we have, and I saw Mentor go on board as captain--or some
+god who was exactly like him. I cannot understand it, for I saw Mentor
+here myself yesterday morning, and yet he was then setting out for
+Pylos."
+
+Noemon then went back to his father's house, but Antinous and Eurymachus
+were very angry. They told the others to leave off playing, and to come
+and sit down along with themselves. When they came, Antinous son of
+Eupeithes spoke in anger. His heart was black with rage, and his eyes
+flashed fire as he said:
+
+"Good heavens, this voyage of Telemachus is a very serious matter; we
+had made sure that it would come to nothing, but the young fellow has
+got away in spite of us, and with a picked crew too. He will be giving
+us trouble presently; may Jove take him before he is full grown. Find me
+a ship, therefore, with a crew of twenty men, and I will lie in wait for
+him in the straits between Ithaca and Samos; he will then rue the day
+that he set out to try and get news of his father."
+
+Thus did he speak, and the others applauded his saying; they then all of
+them went inside the buildings.
+
+It was not long ere Penelope came to know what the suitors were
+plotting; for a man servant, Medon, overheard them from outside the
+outer court as they were laying their schemes within, and went to tell
+his mistress. As he crossed the threshold of her room Penelope said:
+"Medon, what have the suitors sent you here for? Is it to tell the maids
+to leave their master's business and cook dinner for them? I wish they
+may neither woo nor dine henceforward, neither here nor anywhere else,
+but let this be the very last time, for the waste you all make of my
+son's estate. Did not your fathers tell you when you were children, how
+good Ulysses had been to them--never doing anything high-handed, nor
+speaking harshly to anybody? Kings may say things sometimes, and they
+may take a fancy to one man and dislike another, but Ulysses never did
+an unjust thing by anybody--which shows what bad hearts you have, and
+that there is no such thing as gratitude left in this world."
+
+Then Medon said, "I wish, Madam, that this were all; but they are
+plotting something much more dreadful now--may heaven frustrate their
+design. They are going to try and murder Telemachus as he is coming home
+from Pylos and Lacedaemon, where he has been to get news of his father."
+
+Then Penelope's heart sank within her, and for a long time she was
+speechless; her eyes filled with tears, and she could find no utterance.
+At last, however, she said, "Why did my son leave me? What business had
+he to go sailing off in ships that make long voyages over the ocean like
+sea-horses? Does he want to die without leaving any one behind him to
+keep up his name?"
+
+"I do not know," answered Medon, "whether some god set him on to it, or
+whether he went on his own impulse to see if he could find out if his
+father was dead, or alive and on his way home."
+
+Then he went downstairs again, leaving Penelope in an agony of grief.
+There were plenty of seats in the house, but she had no heart for
+sitting on any one of them; she could only fling herself on the floor of
+her own room and cry; whereon all the maids in the house, both old
+and young, gathered round her and began to cry too, till at last in a
+transport of sorrow she exclaimed,
+
+"My dears, heaven has been pleased to try me with more affliction
+than any other woman of my age and country. First I lost my brave and
+lion-hearted husband, who had every good quality under heaven, and whose
+name was great over all Hellas and middle Argos, and now my darling son
+is at the mercy of the winds and waves, without my having heard one word
+about his leaving home. You hussies, there was not one of you would so
+much as think of giving me a call out of my bed, though you all of you
+very well knew when he was starting. If I had known he meant taking this
+voyage, he would have had to give it up, no matter how much he was bent
+upon it, or leave me a corpse behind him--one or other. Now, however,
+go some of you and call old Dolius, who was given me by my father on my
+marriage, and who is my gardener. Bid him go at once and tell everything
+to Laertes, who may be able to hit on some plan for enlisting public
+sympathy on our side, as against those who are trying to exterminate his
+own race and that of Ulysses."
+
+Then the dear old nurse Euryclea said, "You may kill me, Madam, or let
+me live on in your house, whichever you please, but I will tell you the
+real truth. I knew all about it, and gave him everything he wanted in
+the way of bread and wine, but he made me take my solemn oath that I
+would not tell you anything for some ten or twelve days, unless you
+asked or happened to hear of his having gone, for he did not want you to
+spoil your beauty by crying. And now, Madam, wash your face, change
+your dress, and go upstairs with your maids to offer prayers to Minerva,
+daughter of Aegis-bearing Jove, for she can save him even though he
+be in the jaws of death. Do not trouble Laertes: he has trouble enough
+already. Besides, I cannot think that the gods hate the race of the son
+of Arceisius so much, but there will be a son left to come up after him,
+and inherit both the house and the fair fields that lie far all round
+it."
+
+With these words she made her mistress leave off crying, and dried the
+tears from her eyes. Penelope washed her face, changed her dress, and
+went upstairs with her maids. She then put some bruised barley into a
+basket and began praying to Minerva.
+
+"Hear me," she cried, "Daughter of Aegis-bearing Jove, unweariable. If
+ever Ulysses while he was here burned you fat thigh bones of sheep or
+heifer, bear it in mind now as in my favour, and save my darling son
+from the villainy of the suitors."
+
+She cried aloud as she spoke, and the goddess heard her prayer;
+meanwhile the suitors were clamorous throughout the covered cloister,
+and one of them said:
+
+"The queen is preparing for her marriage with one or other of us. Little
+does she dream that her son has now been doomed to die."
+
+This was what they said, but they did not know what was going to happen.
+Then Antinous said, "Comrades, let there be no loud talking, lest some
+of it get carried inside. Let us be up and do that in silence, about
+which we are all of a mind."
+
+He then chose twenty men, and they went down to their ship and to the
+sea side; they drew the vessel into the water and got her mast and sails
+inside her; they bound the oars to the thole-pins with twisted thongs
+of leather, all in due course, and spread the white sails aloft, while
+their fine servants brought them their armour. Then they made the ship
+fast a little way out, came on shore again, got their suppers, and
+waited till night should fall.
+
+But Penelope lay in her own room upstairs unable to eat or drink, and
+wondering whether her brave son would escape, or be overpowered by the
+wicked suitors. Like a lioness caught in the toils with huntsmen hemming
+her in on every side she thought and thought till she sank into a
+slumber, and lay on her bed bereft of thought and motion.
+
+Then Minerva bethought her of another matter, and made a vision in
+the likeness of Penelope's sister Iphthime daughter of Icarius who had
+married Eumelus and lived in Pherae. She told the vision to go to the
+house of Ulysses, and to make Penelope leave off crying, so it came into
+her room by the hole through which the thong went for pulling the door
+to, and hovered over her head saying,
+
+"You are asleep, Penelope: the gods who live at ease will not suffer you
+to weep and be so sad. Your son has done them no wrong, so he will yet
+come back to you."
+
+Penelope, who was sleeping sweetly at the gates of dreamland, answered,
+"Sister, why have you come here? You do not come very often, but I
+suppose that is because you live such a long way off. Am I, then, to
+leave off crying and refrain from all the sad thoughts that torture me?
+I, who have lost my brave and lion-hearted husband, who had every good
+quality under heaven, and whose name was great over all Hellas and
+middle Argos; and now my darling son has gone off on board of a ship--a
+foolish fellow who has never been used to roughing it, nor to going
+about among gatherings of men. I am even more anxious about him than
+about my husband; I am all in a tremble when I think of him, lest
+something should happen to him, either from the people among whom he has
+gone, or by sea, for he has many enemies who are plotting against him,
+and are bent on killing him before he can return home."
+
+Then the vision said, "Take heart, and be not so much dismayed. There is
+one gone with him whom many a man would be glad enough to have stand by
+his side, I mean Minerva; it is she who has compassion upon you, and who
+has sent me to bear you this message."
+
+"Then," said Penelope, "if you are a god or have been sent here by
+divine commission, tell me also about that other unhappy one--is he
+still alive, or is he already dead and in the house of Hades?"
+
+And the vision said, "I shall not tell you for certain whether he is
+alive or dead, and there is no use in idle conversation."
+
+Then it vanished through the thong-hole of the door and was dissipated
+into thin air; but Penelope rose from her sleep refreshed and comforted,
+so vivid had been her dream.
+
+Meantime the suitors went on board and sailed their ways over the
+sea, intent on murdering Telemachus. Now there is a rocky islet called
+Asteris, of no great size, in mid channel between Ithaca and Samos, and
+there is a harbour on either side of it where a ship can lie. Here then
+the Achaeans placed themselves in ambush.
+
+
+Book V
+
+CALYPSO--ULYSSES REACHES SCHERIA ON A RAFT.
+
+And now, as Dawn rose from her couch beside Tithonus--harbinger of light
+alike to mortals and immortals--the gods met in council and with them,
+Jove the lord of thunder, who is their king. Thereon Minerva began to
+tell them of the many sufferings of Ulysses, for she pitied him away
+there in the house of the nymph Calypso.
+
+"Father Jove," said she, "and all you other gods that live in
+everlasting bliss, I hope there may never be such a thing as a kind and
+well-disposed ruler any more, nor one who will govern equitably. I hope
+they will be all henceforth cruel and unjust, for there is not one of
+his subjects but has forgotten Ulysses, who ruled them as though he were
+their father. There he is, lying in great pain in an island where dwells
+the nymph Calypso, who will not let him go; and he cannot get back to
+his own country, for he can find neither ships nor sailors to take him
+over the sea. Furthermore, wicked people are now trying to murder his
+only son Telemachus, who is coming home from Pylos and Lacedaemon, where
+he has been to see if he can get news of his father."
+
+"What, my dear, are you talking about?" replied her father, "did you not
+send him there yourself, because you thought it would help Ulysses to
+get home and punish the suitors? Besides, you are perfectly able to
+protect Telemachus, and to see him safely home again, while the suitors
+have to come hurry-skurrying back without having killed him."
+
+When he had thus spoken, he said to his son Mercury, "Mercury, you are
+our messenger, go therefore and tell Calypso we have decreed that poor
+Ulysses is to return home. He is to be convoyed neither by gods nor men,
+but after a perilous voyage of twenty days upon a raft he is to reach
+fertile Scheria, {50} the land of the Phaeacians, who are near of kin to
+the gods, and will honour him as though he were one of ourselves. They
+will send him in a ship to his own country, and will give him more
+bronze and gold and raiment than he would have brought back from Troy,
+if he had had all his prize money and had got home without disaster.
+This is how we have settled that he shall return to his country and his
+friends."
+
+Thus he spoke, and Mercury, guide and guardian, slayer of Argus, did as
+he was told. Forthwith he bound on his glittering golden sandals with
+which he could fly like the wind over land and sea. He took the wand
+with which he seals men's eyes in sleep or wakes them just as he
+pleases, and flew holding it in his hand over Pieria; then he swooped
+down through the firmament till he reached the level of the sea, whose
+waves he skimmed like a cormorant that flies fishing every hole and
+corner of the ocean, and drenching its thick plumage in the spray. He
+flew and flew over many a weary wave, but when at last he got to the
+island which was his journey's end, he left the sea and went on by land
+till he came to the cave where the nymph Calypso lived.
+
+He found her at home. There was a large fire burning on the hearth, and
+one could smell from far the fragrant reek of burning cedar and sandal
+wood. As for herself, she was busy at her loom, shooting her golden
+shuttle through the warp and singing beautifully. Round her cave there
+was a thick wood of alder, poplar, and sweet smelling cypress trees,
+wherein all kinds of great birds had built their nests--owls, hawks, and
+chattering sea-crows that occupy their business in the waters. A vine
+loaded with grapes was trained and grew luxuriantly about the mouth of
+the cave; there were also four running rills of water in channels cut
+pretty close together, and turned hither and thither so as to irrigate
+the beds of violets and luscious herbage over which they flowed. {51}
+Even a god could not help being charmed with such a lovely spot,
+so Mercury stood still and looked at it; but when he had admired it
+sufficiently he went inside the cave.
+
+Calypso knew him at once--for the gods all know each other, no matter
+how far they live from one another--but Ulysses was not within; he was
+on the sea-shore as usual, looking out upon the barren ocean with tears
+in his eyes, groaning and breaking his heart for sorrow. Calypso
+gave Mercury a seat and said: "Why have you come to see me,
+Mercury--honoured, and ever welcome--for you do not visit me often? Say
+what you want; I will do it for you at once if I can, and if it can be
+done at all; but come inside, and let me set refreshment before you."
+
+As she spoke she drew a table loaded with ambrosia beside him and mixed
+him some red nectar, so Mercury ate and drank till he had had enough,
+and then said:
+
+"We are speaking god and goddess to one another, and you ask me why I
+have come here, and I will tell you truly as you would have me do. Jove
+sent me; it was no doing of mine; who could possibly want to come all
+this way over the sea where there are no cities full of people to offer
+me sacrifices or choice hecatombs? Nevertheless I had to come, for none
+of us other gods can cross Jove, nor transgress his orders. He says that
+you have here the most ill-starred of all those who fought nine years
+before the city of King Priam and sailed home in the tenth year after
+having sacked it. On their way home they sinned against Minerva, {52}
+who raised both wind and waves against them, so that all his brave
+companions perished, and he alone was carried hither by wind and tide.
+Jove says that you are to let this man go at once, for it is decreed
+that he shall not perish here, far from his own people, but shall return
+to his house and country and see his friends again."
+
+Calypso trembled with rage when she heard this, "You gods," she
+exclaimed, "ought to be ashamed of yourselves. You are always jealous
+and hate seeing a goddess take a fancy to a mortal man, and live with
+him in open matrimony. So when rosy-fingered Dawn made love to Orion,
+you precious gods were all of you furious till Diana went and killed him
+in Ortygia. So again when Ceres fell in love with Iasion, and yielded to
+him in a thrice-ploughed fallow field, Jove came to hear of it before so
+very long and killed Iasion with his thunderbolts. And now you are angry
+with me too because I have a man here. I found the poor creature sitting
+all alone astride of a keel, for Jove had struck his ship with lightning
+and sunk it in mid ocean, so that all his crew were drowned, while he
+himself was driven by wind and waves on to my island. I got fond of him
+and cherished him, and had set my heart on making him immortal, so that
+he should never grow old all his days; still I cannot cross Jove, nor
+bring his counsels to nothing; therefore, if he insists upon it, let the
+man go beyond the seas again; but I cannot send him anywhere myself
+for I have neither ships nor men who can take him. Nevertheless I will
+readily give him such advice, in all good faith, as will be likely to
+bring him safely to his own country."
+
+"Then send him away," said Mercury, "or Jove will be angry with you and
+punish you".
+
+On this he took his leave, and Calypso went out to look for Ulysses, for
+she had heard Jove's message. She found him sitting upon the beach with
+his eyes ever filled with tears, and dying of sheer home sickness; for
+he had got tired of Calypso, and though he was forced to sleep with her
+in the cave by night, it was she, not he, that would have it so. As for
+the day time, he spent it on the rocks and on the sea shore, weeping,
+crying aloud for his despair, and always looking out upon the sea.
+Calypso then went close up to him said:
+
+"My poor fellow, you shall not stay here grieving and fretting your life
+out any longer. I am going to send you away of my own free will; so go,
+cut some beams of wood, and make yourself a large raft with an upper
+deck that it may carry you safely over the sea. I will put bread, wine,
+and water on board to save you from starving. I will also give you
+clothes, and will send you a fair wind to take you home, if the gods in
+heaven so will it--for they know more about these things, and can settle
+them better than I can."
+
+Ulysses shuddered as he heard her. "Now goddess," he answered, "there is
+something behind all this; you cannot be really meaning to help me home
+when you bid me do such a dreadful thing as put to sea on a raft. Not
+even a well found ship with a fair wind could venture on such a distant
+voyage: nothing that you can say or do shall make me go on board a raft
+unless you first solemnly swear that you mean me no mischief."
+
+Calypso smiled at this and caressed him with her hand: "You know a great
+deal," said she, "but you are quite wrong here. May heaven above and
+earth below be my witnesses, with the waters of the river Styx--and this
+is the most solemn oath which a blessed god can take--that I mean you
+no sort of harm, and am only advising you to do exactly what I should do
+myself in your place. I am dealing with you quite straightforwardly; my
+heart is not made of iron, and I am very sorry for you."
+
+When she had thus spoken she led the way rapidly before him, and Ulysses
+followed in her steps; so the pair, goddess and man, went on and on till
+they came to Calypso's cave, where Ulysses took the seat that Mercury
+had just left. Calypso set meat and drink before him of the food that
+mortals eat; but her maids brought ambrosia and nectar for herself, and
+they laid their hands on the good things that were before them. When
+they had satisfied themselves with meat and drink, Calypso spoke,
+saying:
+
+"Ulysses, noble son of Laertes, so you would start home to your own
+land at once? Good luck go with you, but if you could only know how much
+suffering is in store for you before you get back to your own country,
+you would stay where you are, keep house along with me, and let me
+make you immortal, no matter how anxious you may be to see this wife
+of yours, of whom you are thinking all the time day after day; yet I
+flatter myself that I am no whit less tall or well-looking than she
+is, for it is not to be expected that a mortal woman should compare in
+beauty with an immortal."
+
+"Goddess," replied Ulysses, "do not be angry with me about this. I
+am quite aware that my wife Penelope is nothing like so tall or so
+beautiful as yourself. She is only a woman, whereas you are an immortal.
+Nevertheless, I want to get home, and can think of nothing else. If some
+god wrecks me when I am on the sea, I will bear it and make the best
+of it. I have had infinite trouble both by land and sea already, so let
+this go with the rest."
+
+Presently the sun set and it became dark, whereon the pair retired into
+the inner part of the cave and went to bed.
+
+When the child of morning rosy-fingered Dawn appeared, Ulysses put on
+his shirt and cloak, while the goddess wore a dress of a light gossamer
+fabric, very fine and graceful, with a beautiful golden girdle about her
+waist and a veil to cover her head. She at once set herself to think how
+she could speed Ulysses on his way. So she gave him a great bronze
+axe that suited his hands; it was sharpened on both sides, and had a
+beautiful olive-wood handle fitted firmly on to it. She also gave him a
+sharp adze, and then led the way to the far end of the island where the
+largest trees grew--alder, poplar and pine, that reached the sky--very
+dry and well seasoned, so as to sail light for him in the water. {53}
+Then, when she had shown him where the best trees grew, Calypso went
+home, leaving him to cut them, which he soon finished doing. He cut down
+twenty trees in all and adzed them smooth, squaring them by rule in good
+workmanlike fashion. Meanwhile Calypso came back with some augers, so
+he bored holes with them and fitted the timbers together with bolts and
+rivets. He made the raft as broad as a skilled shipwright makes the beam
+of a large vessel, and he fixed a deck on top of the ribs, and ran a
+gunwale all round it. He also made a mast with a yard arm, and a rudder
+to steer with. He fenced the raft all round with wicker hurdles as a
+protection against the waves, and then he threw on a quantity of wood.
+By and by Calypso brought him some linen to make the sails, and he made
+these too, excellently, making them fast with braces and sheets. Last of
+all, with the help of levers, he drew the raft down into the water.
+
+In four days he had completed the whole work, and on the fifth Calypso
+sent him from the island after washing him and giving him some clean
+clothes. She gave him a goat skin full of black wine, and another larger
+one of water; she also gave him a wallet full of provisions, and found
+him in much good meat. Moreover, she made the wind fair and warm for
+him, and gladly did Ulysses spread his sail before it, while he sat and
+guided the raft skilfully by means of the rudder. He never closed his
+eyes, but kept them fixed on the Pleiads, on late-setting Bootes, and on
+the Bear--which men also call the wain, and which turns round and round
+where it is, facing Orion, and alone never dipping into the stream of
+Oceanus--for Calypso had told him to keep this to his left. Days seven
+and ten did he sail over the sea, and on the eighteenth the dim outlines
+of the mountains on the nearest part of the Phaeacian coast appeared,
+rising like a shield on the horizon.
+
+But King Neptune, who was returning from the Ethiopians, caught sight of
+Ulysses a long way off, from the mountains of the Solymi. He could see
+him sailing upon the sea, and it made him very angry, so he wagged his
+head and muttered to himself, saying, "Good heavens, so the gods have
+been changing their minds about Ulysses while I was away in Ethiopia,
+and now he is close to the land of the Phaeacians, where it is decreed
+that he shall escape from the calamities that have befallen him. Still,
+he shall have plenty of hardship yet before he has done with it."
+
+Thereon he gathered his clouds together, grasped his trident, stirred
+it round in the sea, and roused the rage of every wind that blows till
+earth, sea, and sky were hidden in cloud, and night sprang forth out of
+the heavens. Winds from East, South, North, and West fell upon him all
+at the same time, and a tremendous sea got up, so that Ulysses' heart
+began to fail him. "Alas," he said to himself in his dismay, "what ever
+will become of me? I am afraid Calypso was right when she said I should
+have trouble by sea before I got back home. It is all coming true. How
+black is Jove making heaven with his clouds, and what a sea the winds
+are raising from every quarter at once. I am now safe to perish. Blest
+and thrice blest were those Danaans who fell before Troy in the cause
+of the sons of Atreus. Would that I had been killed on the day when the
+Trojans were pressing me so sorely about the dead body of Achilles, for
+then I should have had due burial and the Achaeans would have honoured
+my name; but now it seems that I shall come to a most pitiable end."
+
+As he spoke a sea broke over him with such terrific fury that the raft
+reeled again, and he was carried overboard a long way off. He let go the
+helm, and the force of the hurricane was so great that it broke the mast
+half way up, and both sail and yard went over into the sea. For a long
+time Ulysses was under water, and it was all he could do to rise to the
+surface again, for the clothes Calypso had given him weighed him down;
+but at last he got his head above water and spat out the bitter brine
+that was running down his face in streams. In spite of all this,
+however, he did not lose sight of his raft, but swam as fast as he could
+towards it, got hold of it, and climbed on board again so as to escape
+drowning. The sea took the raft and tossed it about as Autumn winds
+whirl thistledown round and round upon a road. It was as though the
+South, North, East, and West winds were all playing battledore and
+shuttlecock with it at once.
+
+When he was in this plight, Ino daughter of Cadmus, also called
+Leucothea, saw him. She had formerly been a mere mortal, but had been
+since raised to the rank of a marine goddess. Seeing in what great
+distress Ulysses now was, she had compassion upon him, and, rising like
+a sea-gull from the waves, took her seat upon the raft.
+
+"My poor good man," said she, "why is Neptune so furiously angry with
+you? He is giving you a great deal of trouble, but for all his bluster
+he will not kill you. You seem to be a sensible person, do then as I bid
+you; strip, leave your raft to drive before the wind, and swim to the
+Phaeacian coast where better luck awaits you. And here, take my veil and
+put it round your chest; it is enchanted, and you can come to no harm
+so long as you wear it. As soon as you touch land take it off, throw it
+back as far as you can into the sea, and then go away again." With these
+words she took off her veil and gave it him. Then she dived down again
+like a sea-gull and vanished beneath the dark blue waters.
+
+But Ulysses did not know what to think. "Alas," he said to himself in
+his dismay, "this is only some one or other of the gods who is luring me
+to ruin by advising me to quit my raft. At any rate I will not do so at
+present, for the land where she said I should be quit of all troubles
+seemed to be still a good way off. I know what I will do--I am sure it
+will be best--no matter what happens I will stick to the raft as long
+as her timbers hold together, but when the sea breaks her up I will swim
+for it; I do not see how I can do any better than this."
+
+While he was thus in two minds, Neptune sent a terrible great wave that
+seemed to rear itself above his head till it broke right over the raft,
+which then went to pieces as though it were a heap of dry chaff tossed
+about by a whirlwind. Ulysses got astride of one plank and rode upon
+it as if he were on horseback; he then took off the clothes Calypso
+had given him, bound Ino's veil under his arms, and plunged into the
+sea--meaning to swim on shore. King Neptune watched him as he did so,
+and wagged his head, muttering to himself and saying, "There now, swim
+up and down as you best can till you fall in with well-to-do people.
+I do not think you will be able to say that I have let you off too
+lightly." On this he lashed his horses and drove to Aegae where his
+palace is.
+
+But Minerva resolved to help Ulysses, so she bound the ways of all the
+winds except one, and made them lie quite still; but she roused a good
+stiff breeze from the North that should lay the waters till Ulysses
+reached the land of the Phaeacians where he would be safe.
+
+Thereon he floated about for two nights and two days in the water, with
+a heavy swell on the sea and death staring him in the face; but when the
+third day broke, the wind fell and there was a dead calm without so much
+as a breath of air stirring. As he rose on the swell he looked eagerly
+ahead, and could see land quite near. Then, as children rejoice when
+their dear father begins to get better after having for a long time
+borne sore affliction sent him by some angry spirit, but the gods
+deliver him from evil, so was Ulysses thankful when he again saw land
+and trees, and swam on with all his strength that he might once more set
+foot upon dry ground. When, however, he got within earshot, he began to
+hear the surf thundering up against the rocks, for the swell still broke
+against them with a terrific roar. Everything was enveloped in spray;
+there were no harbours where a ship might ride, nor shelter of any kind,
+but only headlands, low-lying rocks, and mountain tops.
+
+Ulysses' heart now began to fail him, and he said despairingly to
+himself, "Alas, Jove has let me see land after swimming so far that I
+had given up all hope, but I can find no landing place, for the coast is
+rocky and surf-beaten, the rocks are smooth and rise sheer from the sea,
+with deep water close under them so that I cannot climb out for want of
+foot hold. I am afraid some great wave will lift me off my legs and dash
+me against the rocks as I leave the water--which would give me a
+sorry landing. If, on the other hand, I swim further in search of some
+shelving beach or harbour, a hurricane may carry me out to sea again
+sorely against my will, or heaven may send some great monster of the
+deep to attack me; for Amphitrite breeds many such, and I know that
+Neptune is very angry with me."
+
+While he was thus in two minds a wave caught him and took him with such
+force against the rocks that he would have been smashed and torn to
+pieces if Minerva had not shown him what to do. He caught hold of the
+rock with both hands and clung to it groaning with pain till the wave
+retired, so he was saved that time; but presently the wave came on again
+and carried him back with it far into the sea--tearing his hands as the
+suckers of a polypus are torn when some one plucks it from its bed, and
+the stones come up along with it--even so did the rocks tear the skin
+from his strong hands, and then the wave drew him deep down under the
+water.
+
+Here poor Ulysses would have certainly perished even in spite of his own
+destiny, if Minerva had not helped him to keep his wits about him. He
+swam seaward again, beyond reach of the surf that was beating against
+the land, and at the same time he kept looking towards the shore to
+see if he could find some haven, or a spit that should take the waves
+aslant. By and by, as he swam on, he came to the mouth of a river, and
+here he thought would be the best place, for there were no rocks, and it
+afforded shelter from the wind. He felt that there was a current, so he
+prayed inwardly and said:
+
+"Hear me, O King, whoever you may be, and save me from the anger of the
+sea-god Neptune, for I approach you prayerfully. Any one who has lost
+his way has at all times a claim even upon the gods, wherefore in my
+distress I draw near to your stream, and cling to the knees of your
+riverhood. Have mercy upon me, O king, for I declare myself your
+suppliant."
+
+Then the god staid his stream and stilled the waves, making all calm
+before him, and bringing him safely into the mouth of the river. Here
+at last Ulysses' knees and strong hands failed him, for the sea had
+completely broken him. His body was all swollen, and his mouth and
+nostrils ran down like a river with sea-water, so that he could neither
+breathe nor speak, and lay swooning from sheer exhaustion; presently,
+when he had got his breath and came to himself again, he took off the
+scarf that Ino had given him and threw it back into the salt {54} stream
+of the river, whereon Ino received it into her hands from the wave that
+bore it towards her. Then he left the river, laid himself down among the
+rushes, and kissed the bounteous earth.
+
+"Alas," he cried to himself in his dismay, "what ever will become of me,
+and how is it all to end? If I stay here upon the river bed through the
+long watches of the night, I am so exhausted that the bitter cold and
+damp may make an end of me--for towards sunrise there will be a keen
+wind blowing from off the river. If, on the other hand, I climb the hill
+side, find shelter in the woods, and sleep in some thicket, I may escape
+the cold and have a good night's rest, but some savage beast may take
+advantage of me and devour me."
+
+In the end he deemed it best to take to the woods, and he found one
+upon some high ground not far from the water. There he crept beneath
+two shoots of olive that grew from a single stock--the one an ungrafted
+sucker, while the other had been grafted. No wind, however squally,
+could break through the cover they afforded, nor could the sun's rays
+pierce them, nor the rain get through them, so closely did they grow
+into one another. Ulysses crept under these and began to make himself
+a bed to lie on, for there was a great litter of dead leaves lying
+about--enough to make a covering for two or three men even in hard
+winter weather. He was glad enough to see this, so he laid himself down
+and heaped the leaves all round him. Then, as one who lives alone in the
+country, far from any neighbor, hides a brand as fire-seed in the
+ashes to save himself from having to get a light elsewhere, even so did
+Ulysses cover himself up with leaves; and Minerva shed a sweet sleep
+upon his eyes, closed his eyelids, and made him lose all memories of his
+sorrows.
+
+
+Book VI
+
+THE MEETING BETWEEN NAUSICAA AND ULYSSES.
+
+So here Ulysses slept, overcome by sleep and toil; but Minerva went off
+to the country and city of the Phaeacians--a people who used to live in
+the fair town of Hypereia, near the lawless Cyclopes. Now the Cyclopes
+were stronger than they and plundered them, so their king Nausithous
+moved them thence and settled them in Scheria, far from all other
+people. He surrounded the city with a wall, built houses and temples,
+and divided the lands among his people; but he was dead and gone to
+the house of Hades, and King Alcinous, whose counsels were inspired
+of heaven, was now reigning. To his house, then, did Minerva hie in
+furtherance of the return of Ulysses.
+
+She went straight to the beautifully decorated bedroom in which there
+slept a girl who was as lovely as a goddess, Nausicaa, daughter to King
+Alcinous. Two maid servants were sleeping near her, both very pretty,
+one on either side of the doorway, which was closed with well made
+folding doors. Minerva took the form of the famous sea captain Dymas's
+daughter, who was a bosom friend of Nausicaa and just her own age; then,
+coming up to the girl's bedside like a breath of wind, she hovered over
+her head and said:
+
+"Nausicaa, what can your mother have been about, to have such a lazy
+daughter? Here are your clothes all lying in disorder, yet you are going
+to be married almost immediately, and should not only be well dressed
+yourself, but should find good clothes for those who attend you. This is
+the way to get yourself a good name, and to make your father and mother
+proud of you. Suppose, then, that we make tomorrow a washing day,
+and start at daybreak. I will come and help you so that you may have
+everything ready as soon as possible, for all the best young men among
+your own people are courting you, and you are not going to remain a
+maid much longer. Ask your father, therefore, to have a waggon and mules
+ready for us at daybreak, to take the rugs, robes, and girdles, and you
+can ride, too, which will be much pleasanter for you than walking, for
+the washing-cisterns are some way from the town."
+
+When she had said this Minerva went away to Olympus, which they say
+is the everlasting home of the gods. Here no wind beats roughly, and
+neither rain nor snow can fall; but it abides in everlasting sunshine
+and in a great peacefulness of light, wherein the blessed gods are
+illumined for ever and ever. This was the place to which the goddess
+went when she had given instructions to the girl.
+
+By and by morning came and woke Nausicaa, who began wondering about
+her dream; she therefore went to the other end of the house to tell her
+father and mother all about it, and found them in their own room. Her
+mother was sitting by the fireside spinning her purple yarn with her
+maids around her, and she happened to catch her father just as he was
+going out to attend a meeting of the town council, which the Phaeacian
+aldermen had convened. She stopped him and said:
+
+"Papa dear, could you manage to let me have a good big waggon? I want to
+take all our dirty clothes to the river and wash them. You are the chief
+man here, so it is only right that you should have a clean shirt when
+you attend meetings of the council. Moreover, you have five sons at
+home, two of them married, while the other three are good looking
+bachelors; you know they always like to have clean linen when they go to
+a dance, and I have been thinking about all this."
+
+She did not say a word about her own wedding, for she did not like to,
+but her father knew and said, "You shall have the mules, my love, and
+whatever else you have a mind for. Be off with you, and the men shall
+get you a good strong waggon with a body to it that will hold all your
+clothes."
+
+On this he gave his orders to the servants, who got the waggon out,
+harnessed the mules, and put them to, while the girl brought the clothes
+down from the linen room and placed them on the waggon. Her mother
+prepared her a basket of provisions with all sorts of good things, and a
+goat skin full of wine; the girl now got into the waggon, and her mother
+gave her also a golden cruse of oil, that she and her women might anoint
+themselves. Then she took the whip and reins and lashed the mules on,
+whereon they set off, and their hoofs clattered on the road. They pulled
+without flagging, and carried not only Nausicaa and her wash of clothes,
+but the maids also who were with her.
+
+When they reached the water side they went to the washing cisterns,
+through which there ran at all times enough pure water to wash any
+quantity of linen, no matter how dirty. Here they unharnessed the mules
+and turned them out to feed on the sweet juicy herbage that grew by the
+water side. They took the clothes out of the waggon, put them in the
+water, and vied with one another in treading them in the pits to get the
+dirt out. After they had washed them and got them quite clean, they laid
+them out by the sea side, where the waves had raised a high beach of
+shingle, and set about washing themselves and anointing themselves with
+olive oil. Then they got their dinner by the side of the stream, and
+waited for the sun to finish drying the clothes. When they had done
+dinner they threw off the veils that covered their heads and began to
+play at ball, while Nausicaa sang for them. As the huntress Diana goes
+forth upon the mountains of Taygetus or Erymanthus to hunt wild boars or
+deer, and the wood nymphs, daughters of Aegis-bearing Jove, take their
+sport along with her (then is Leto proud at seeing her daughter stand a
+full head taller than the others, and eclipse the loveliest amid a whole
+bevy of beauties), even so did the girl outshine her handmaids.
+
+When it was time for them to start home, and they were folding the
+clothes and putting them into the waggon, Minerva began to consider how
+Ulysses should wake up and see the handsome girl who was to conduct him
+to the city of the Phaeacians. The girl, therefore, threw a ball at one
+of the maids, which missed her and fell into deep water. On this they
+all shouted, and the noise they made woke Ulysses, who sat up in his bed
+of leaves and began to wonder what it might all be.
+
+"Alas," said he to himself, "what kind of people have I come amongst?
+Are they cruel, savage, and uncivilised, or hospitable and humane? I
+seem to hear the voices of young women, and they sound like those of
+the nymphs that haunt mountain tops, or springs of rivers and meadows of
+green grass. At any rate I am among a race of men and women. Let me try
+if I cannot manage to get a look at them."
+
+As he said this he crept from under his bush, and broke off a bough
+covered with thick leaves to hide his nakedness. He looked like some
+lion of the wilderness that stalks about exulting in his strength and
+defying both wind and rain; his eyes glare as he prowls in quest of
+oxen, sheep, or deer, for he is famished, and will dare break even
+into a well fenced homestead, trying to get at the sheep--even such did
+Ulysses seem to the young women, as he drew near to them all naked as he
+was, for he was in great want. On seeing one so unkempt and so begrimed
+with salt water, the others scampered off along the spits that jutted
+out into the sea, but the daughter of Alcinous stood firm, for Minerva
+put courage into her heart and took away all fear from her. She stood
+right in front of Ulysses, and he doubted whether he should go up to
+her, throw himself at her feet, and embrace her knees as a suppliant, or
+stay where he was and entreat her to give him some clothes and show him
+the way to the town. In the end he deemed it best to entreat her from a
+distance in case the girl should take offence at his coming near enough
+to clasp her knees, so he addressed her in honeyed and persuasive
+language.
+
+"O queen," he said, "I implore your aid--but tell me, are you a goddess
+or are you a mortal woman? If you are a goddess and dwell in heaven, I
+can only conjecture that you are Jove's daughter Diana, for your face
+and figure resemble none but hers; if on the other hand you are a mortal
+and live on earth, thrice happy are your father and mother--thrice
+happy, too, are your brothers and sisters; how proud and delighted
+they must feel when they see so fair a scion as yourself going out to a
+dance; most happy, however, of all will he be whose wedding gifts have
+been the richest, and who takes you to his own home. I never yet saw any
+one so beautiful, neither man nor woman, and am lost in admiration as I
+behold you. I can only compare you to a young palm tree which I saw when
+I was at Delos growing near the altar of Apollo--for I was there, too,
+with much people after me, when I was on that journey which has been the
+source of all my troubles. Never yet did such a young plant shoot out
+of the ground as that was, and I admired and wondered at it exactly as I
+now admire and wonder at yourself. I dare not clasp your knees, but I
+am in great distress; yesterday made the twentieth day that I had been
+tossing about upon the sea. The winds and waves have taken me all the
+way from the Ogygian island, {55} and now fate has flung me upon this
+coast that I may endure still further suffering; for I do not think that
+I have yet come to the end of it, but rather that heaven has still much
+evil in store for me.
+
+"And now, O queen, have pity upon me, for you are the first person I
+have met, and I know no one else in this country. Show me the way to
+your town, and let me have anything that you may have brought hither to
+wrap your clothes in. May heaven grant you in all things your heart's
+desire--husband, house, and a happy, peaceful home; for there is nothing
+better in this world than that man and wife should be of one mind in a
+house. It discomfits their enemies, makes the hearts of their friends
+glad, and they themselves know more about it than any one."
+
+To this Nausicaa answered, "Stranger, you appear to be a sensible,
+well-disposed person. There is no accounting for luck; Jove gives
+prosperity to rich and poor just as he chooses, so you must take what
+he has seen fit to send you, and make the best of it. Now, however, that
+you have come to this our country, you shall not want for clothes nor
+for anything else that a foreigner in distress may reasonably look for.
+I will show you the way to the town, and will tell you the name of our
+people; we are called Phaeacians, and I am daughter to Alcinous, in whom
+the whole power of the state is vested."
+
+Then she called her maids and said, "Stay where you are, you girls. Can
+you not see a man without running away from him? Do you take him for a
+robber or a murderer? Neither he nor any one else can come here to do
+us Phaeacians any harm, for we are dear to the gods, and live apart on a
+land's end that juts into the sounding sea, and have nothing to do with
+any other people. This is only some poor man who has lost his way, and
+we must be kind to him, for strangers and foreigners in distress
+are under Jove's protection, and will take what they can get and be
+thankful; so, girls, give the poor fellow something to eat and drink,
+and wash him in the stream at some place that is sheltered from the
+wind."
+
+On this the maids left off running away and began calling one another
+back. They made Ulysses sit down in the shelter as Nausicaa had told
+them, and brought him a shirt and cloak. They also brought him the
+little golden cruse of oil, and told him to go and wash in the stream.
+But Ulysses said, "Young women, please to stand a little on one side
+that I may wash the brine from my shoulders and anoint myself with oil,
+for it is long enough since my skin has had a drop of oil upon it. I
+cannot wash as long as you all keep standing there. I am ashamed to
+strip {56} before a number of good looking young women."
+
+Then they stood on one side and went to tell the girl, while Ulysses
+washed himself in the stream and scrubbed the brine from his back and
+from his broad shoulders. When he had thoroughly washed himself, and had
+got the brine out of his hair, he anointed himself with oil, and put
+on the clothes which the girl had given him; Minerva then made him look
+taller and stronger than before, she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders as a skilful workman who has
+studied art of all kinds under Vulcan and Minerva enriches a piece of
+silver plate by gilding it--and his work is full of beauty. Then he went
+and sat down a little way off upon the beach, looking quite young and
+handsome, and the girl gazed on him with admiration; then she said to
+her maids:
+
+"Hush, my dears, for I want to say something. I believe the gods who
+live in heaven have sent this man to the Phaeacians. When I first saw
+him I thought him plain, but now his appearance is like that of the gods
+who dwell in heaven. I should like my future husband to be just such
+another as he is, if he would only stay here and not want to go away.
+However, give him something to eat and drink."
+
+They did as they were told, and set food before Ulysses, who ate and
+drank ravenously, for it was long since he had had food of any kind.
+Meanwhile, Nausicaa bethought her of another matter. She got the linen
+folded and placed in the waggon, she then yoked the mules, and, as she
+took her seat, she called Ulysses:
+
+"Stranger," said she, "rise and let us be going back to the town; I will
+introduce you at the house of my excellent father, where I can tell you
+that you will meet all the best people among the Phaeacians. But be sure
+and do as I bid you, for you seem to be a sensible person. As long as
+we are going past the fields and farm lands, follow briskly behind the
+waggon along with the maids and I will lead the way myself. Presently,
+however, we shall come to the town, where you will find a high wall
+running all round it, and a good harbour on either side with a narrow
+entrance into the city, and the ships will be drawn up by the road side,
+for every one has a place where his own ship can lie. You will see the
+market place with a temple of Neptune in the middle of it, and paved
+with large stones bedded in the earth. Here people deal in ship's gear
+of all kinds, such as cables and sails, and here, too, are the places
+where oars are made, for the Phaeacians are not a nation of archers;
+they know nothing about bows and arrows, but are a sea-faring folk, and
+pride themselves on their masts, oars, and ships, with which they travel
+far over the sea.
+
+"I am afraid of the gossip and scandal that may be set on foot against
+me later on; for the people here are very ill-natured, and some low
+fellow, if he met us, might say, 'Who is this fine-looking stranger that
+is going about with Nausicaa? Where did she find him? I suppose she is
+going to marry him. Perhaps he is a vagabond sailor whom she has taken
+from some foreign vessel, for we have no neighbours; or some god has at
+last come down from heaven in answer to her prayers, and she is going to
+live with him all the rest of her life. It would be a good thing if she
+would take herself off and find a husband somewhere else, for she will
+not look at one of the many excellent young Phaeacians who are in love
+with her.' This is the kind of disparaging remark that would be made
+about me, and I could not complain, for I should myself be scandalised
+at seeing any other girl do the like, and go about with men in spite
+of everybody, while her father and mother were still alive, and without
+having been married in the face of all the world.
+
+"If, therefore, you want my father to give you an escort and to help you
+home, do as I bid you; you will see a beautiful grove of poplars by the
+road side dedicated to Minerva; it has a well in it and a meadow all
+round it. Here my father has a field of rich garden ground, about as far
+from the town as a man's voice will carry. Sit down there and wait for
+a while till the rest of us can get into the town and reach my father's
+house. Then, when you think we must have done this, come into the town
+and ask the way to the house of my father Alcinous. You will have no
+difficulty in finding it; any child will point it out to you, for no one
+else in the whole town has anything like such a fine house as he has.
+When you have got past the gates and through the outer court, go right
+across the inner court till you come to my mother. You will find her
+sitting by the fire and spinning her purple wool by firelight. It is a
+fine sight to see her as she leans back against one of the bearing-posts
+with her maids all ranged behind her. Close to her seat stands that of
+my father, on which he sits and topes like an immortal god. Never mind
+him, but go up to my mother, and lay your hands upon her knees if you
+would get home quickly. If you can gain her over, you may hope to see
+your own country again, no matter how distant it may be."
+
+So saying she lashed the mules with her whip and they left the river.
+The mules drew well, and their hoofs went up and down upon the road.
+She was careful not to go too fast for Ulysses and the maids who were
+following on foot along with the waggon, so she plied her whip with
+judgement. As the sun was going down they came to the sacred grove of
+Minerva, and there Ulysses sat down and prayed to the mighty daughter of
+Jove.
+
+"Hear me," he cried, "daughter of Aegis-bearing Jove, unweariable, hear
+me now, for you gave no heed to my prayers when Neptune was wrecking me.
+Now, therefore, have pity upon me and grant that I may find friends and
+be hospitably received by the Phaeacians."
+
+Thus did he pray, and Minerva heard his prayer, but she would not show
+herself to him openly, for she was afraid of her uncle Neptune, who was
+still furious in his endeavors to prevent Ulysses from getting home.
+
+
+Book VII
+
+RECEPTION OF ULYSSES AT THE PALACE OF KING ALCINOUS.
+
+Thus, then, did Ulysses wait and pray; but the girl drove on to the
+town. When she reached her father's house she drew up at the gateway,
+and her brothers--comely as the gods--gathered round her, took the mules
+out of the waggon, and carried the clothes into the house, while she
+went to her own room, where an old servant, Eurymedusa of Apeira, lit
+the fire for her. This old woman had been brought by sea from Apeira,
+and had been chosen as a prize for Alcinous because he was king over the
+Phaeacians, and the people obeyed him as though he were a god. {57}
+She had been nurse to Nausicaa, and had now lit the fire for her, and
+brought her supper for her into her own room.
+
+Presently Ulysses got up to go towards the town; and Minerva shed a
+thick mist all round him to hide him in case any of the proud Phaeacians
+who met him should be rude to him, or ask him who he was. Then, as he
+was just entering the town, she came towards him in the likeness of a
+little girl carrying a pitcher. She stood right in front of him, and
+Ulysses said:
+
+"My dear, will you be so kind as to show me the house of king Alcinous?
+I am an unfortunate foreigner in distress, and do not know one in your
+town and country."
+
+Then Minerva said, "Yes, father stranger, I will show you the house you
+want, for Alcinous lives quite close to my own father. I will go before
+you and show the way, but say not a word as you go, and do not look
+at any man, nor ask him questions; for the people here cannot abide
+strangers, and do not like men who come from some other place. They are
+a sea-faring folk, and sail the seas by the grace of Neptune in ships
+that glide along like thought, or as a bird in the air."
+
+On this she led the way, and Ulysses followed in her steps; but not one
+of the Phaeacians could see him as he passed through the city in the
+midst of them; for the great goddess Minerva in her good will towards
+him had hidden him in a thick cloud of darkness. He admired their
+harbours, ships, places of assembly, and the lofty walls of the city,
+which, with the palisade on top of them, were very striking, and when
+they reached the king's house Minerva said:
+
+"This is the house, father stranger, which you would have me show you.
+You will find a number of great people sitting at table, but do not be
+afraid; go straight in, for the bolder a man is the more likely he is to
+carry his point, even though he is a stranger. First find the queen. Her
+name is Arete, and she comes of the same family as her husband Alcinous.
+They both descend originally from Neptune, who was father to Nausithous
+by Periboea, a woman of great beauty. Periboea was the youngest daughter
+of Eurymedon, who at one time reigned over the giants, but he ruined his
+ill-fated people and lost his own life to boot.
+
+"Neptune, however, lay with his daughter, and she had a son by him, the
+great Nausithous, who reigned over the Phaeacians. Nausithous had two
+sons Rhexenor and Alcinous; {58} Apollo killed the first of them while
+he was still a bridegroom and without male issue; but he left a daughter
+Arete, whom Alcinous married, and honours as no other woman is honoured
+of all those that keep house along with their husbands.
+
+"Thus she both was, and still is, respected beyond measure by her
+children, by Alcinous himself, and by the whole people, who look upon
+her as a goddess, and greet her whenever she goes about the city, for
+she is a thoroughly good woman both in head and heart, and when any
+women are friends of hers, she will help their husbands also to settle
+their disputes. If you can gain her good will, you may have every hope
+of seeing your friends again, and getting safely back to your home and
+country."
+
+Then Minerva left Scheria and went away over the sea. She went to
+Marathon {59} and to the spacious streets of Athens, where she entered
+the abode of Erechtheus; but Ulysses went on to the house of Alcinous,
+and he pondered much as he paused a while before reaching the threshold
+of bronze, for the splendour of the palace was like that of the sun or
+moon. The walls on either side were of bronze from end to end, and the
+cornice was of blue enamel. The doors were gold, and hung on pillars of
+silver that rose from a floor of bronze, while the lintel was silver and
+the hook of the door was of gold.
+
+On either side there stood gold and silver mastiffs which Vulcan, with
+his consummate skill, had fashioned expressly to keep watch over the
+palace of king Alcinous; so they were immortal and could never grow old.
+Seats were ranged all along the wall, here and there from one end to the
+other, with coverings of fine woven work which the women of the house
+had made. Here the chief persons of the Phaeacians used to sit and eat
+and drink, for there was abundance at all seasons; and there were golden
+figures of young men with lighted torches in their hands, raised on
+pedestals, to give light by night to those who were at table. There are
+{60} fifty maid servants in the house, some of whom are always grinding
+rich yellow grain at the mill, while others work at the loom, or sit and
+spin, and their shuttles go backwards and forwards like the fluttering
+of aspen leaves, while the linen is so closely woven that it will turn
+oil. As the Phaeacians are the best sailors in the world, so their women
+excel all others in weaving, for Minerva has taught them all manner of
+useful arts, and they are very intelligent.
+
+Outside the gate of the outer court there is a large garden of
+about four acres with a wall all round it. It is full of beautiful
+trees--pears, pomegranates, and the most delicious apples. There are
+luscious figs also, and olives in full growth. The fruits never rot nor
+fail all the year round, neither winter nor summer, for the air is so
+soft that a new crop ripens before the old has dropped. Pear grows on
+pear, apple on apple, and fig on fig, and so also with the grapes, for
+there is an excellent vineyard: on the level ground of a part of this,
+the grapes are being made into raisins; in another part they are being
+gathered; some are being trodden in the wine tubs, others further on
+have shed their blossom and are beginning to show fruit, others again
+are just changing colour. In the furthest part of the ground there are
+beautifully arranged beds of flowers that are in bloom all the year
+round. Two streams go through it, the one turned in ducts throughout the
+whole garden, while the other is carried under the ground of the outer
+court to the house itself, and the town's people draw water from it.
+Such, then, were the splendours with which the gods had endowed the
+house of king Alcinous.
+
+So here Ulysses stood for a while and looked about him, but when he
+had looked long enough he crossed the threshold and went within the
+precincts of the house. There he found all the chief people among the
+Phaeacians making their drink offerings to Mercury, which they always
+did the last thing before going away for the night. {61} He went
+straight through the court, still hidden by the cloak of darkness
+in which Minerva had enveloped him, till he reached Arete and King
+Alcinous; then he laid his hands upon the knees of the queen, and at
+that moment the miraculous darkness fell away from him and he became
+visible. Every one was speechless with surprise at seeing a man there,
+but Ulysses began at once with his petition.
+
+"Queen Arete," he exclaimed, "daughter of great Rhexenor, in my distress
+I humbly pray you, as also your husband and these your guests (whom may
+heaven prosper with long life and happiness, and may they leave their
+possessions to their children, and all the honours conferred upon them
+by the state) to help me home to my own country as soon as possible; for
+I have been long in trouble and away from my friends."
+
+Then he sat down on the hearth among the ashes and they all held their
+peace, till presently the old hero Echeneus, who was an excellent
+speaker and an elder among the Phaeacians, plainly and in all honesty
+addressed them thus:
+
+"Alcinous," said he, "it is not creditable to you that a stranger should
+be seen sitting among the ashes of your hearth; every one is waiting to
+hear what you are about to say; tell him, then, to rise and take a seat
+on a stool inlaid with silver, and bid your servants mix some wine and
+water that we may make a drink offering to Jove the lord of thunder,
+who takes all well disposed suppliants under his protection; and let
+the housekeeper give him some supper, of whatever there may be in the
+house."
+
+When Alcinous heard this he took Ulysses by the hand, raised him from
+the hearth, and bade him take the seat of Laodamas, who had been sitting
+beside him, and was his favourite son. A maid servant then brought him
+water in a beautiful golden ewer and poured it into a silver basin for
+him to wash his hands, and she drew a clean table beside him; an upper
+servant brought him bread and offered him many good things of what there
+was in the house, and Ulysses ate and drank. Then Alcinous said to one
+of the servants, "Pontonous, mix a cup of wine and hand it round that
+we may make drink-offerings to Jove the lord of thunder, who is the
+protector of all well-disposed suppliants."
+
+Pontonous then mixed wine and water, and handed it round after giving
+every man his drink-offering. When they had made their offerings, and
+had drunk each as much as he was minded, Alcinous said:
+
+"Aldermen and town councillors of the Phaeacians, hear my words. You
+have had your supper, so now go home to bed. To-morrow morning I shall
+invite a still larger number of aldermen, and will give a sacrificial
+banquet in honour of our guest; we can then discuss the question of his
+escort, and consider how we may at once send him back rejoicing to his
+own country without trouble or inconvenience to himself, no matter how
+distant it may be. We must see that he comes to no harm while on his
+homeward journey, but when he is once at home he will have to take
+the luck he was born with for better or worse like other people. It is
+possible, however, that the stranger is one of the immortals who
+has come down from heaven to visit us; but in this case the gods
+are departing from their usual practice, for hitherto they have made
+themselves perfectly clear to us when we have been offering them
+hecatombs. They come and sit at our feasts just like one of our selves,
+and if any solitary wayfarer happens to stumble upon some one or other
+of them, they affect no concealment, for we are as near of kin to the
+gods as the Cyclopes and the savage giants are." {62}
+
+Then Ulysses said: "Pray, Alcinous, do not take any such notion into
+your head. I have nothing of the immortal about me, neither in body
+nor mind, and most resemble those among you who are the most afflicted.
+Indeed, were I to tell you all that heaven has seen fit to lay upon me,
+you would say that I was still worse off than they are. Nevertheless,
+let me sup in spite of sorrow, for an empty stomach is a very
+importunate thing, and thrusts itself on a man's notice no matter how
+dire is his distress. I am in great trouble, yet it insists that I shall
+eat and drink, bids me lay aside all memory of my sorrows and dwell only
+on the due replenishing of itself. As for yourselves, do as you propose,
+and at break of day set about helping me to get home. I shall be content
+to die if I may first once more behold my property, my bondsmen, and all
+the greatness of my house." {63}
+
+Thus did he speak. Every one approved his saying, and agreed that he
+should have his escort inasmuch as he had spoken reasonably. Then when
+they had made their drink offerings, and had drunk each as much as he
+was minded they went home to bed every man in his own abode, leaving
+Ulysses in the cloister with Arete and Alcinous while the servants were
+taking the things away after supper. Arete was the first to speak,
+for she recognised the shirt, cloak, and good clothes that Ulysses
+was wearing, as the work of herself and of her maids; so she said,
+"Stranger, before we go any further, there is a question I should like
+to ask you. Who, and whence are you, and who gave you those clothes? Did
+you not say you had come here from beyond the sea?"
+
+And Ulysses answered, "It would be a long story Madam, were I to relate
+in full the tale of my misfortunes, for the hand of heaven has been laid
+heavy upon me; but as regards your question, there is an island far away
+in the sea which is called 'the Ogygian.' Here dwells the cunning and
+powerful goddess Calypso, daughter of Atlas. She lives by herself far
+from all neighbours human or divine. Fortune, however, brought me to
+her hearth all desolate and alone, for Jove struck my ship with his
+thunderbolts, and broke it up in mid-ocean. My brave comrades were
+drowned every man of them, but I stuck to the keel and was carried
+hither and thither for the space of nine days, till at last during the
+darkness of the tenth night the gods brought me to the Ogygian island
+where the great goddess Calypso lives. She took me in and treated me
+with the utmost kindness; indeed she wanted to make me immortal that I
+might never grow old, but she could not persuade me to let her do so.
+
+"I stayed with Calypso seven years straight on end, and watered the good
+clothes she gave me with my tears during the whole time; but at last
+when the eighth year came round she bade me depart of her own free will,
+either because Jove had told her she must, or because she had changed
+her mind. She sent me from her island on a raft, which she provisioned
+with abundance of bread and wine. Moreover she gave me good stout
+clothing, and sent me a wind that blew both warm and fair. Days seven
+and ten did I sail over the sea, and on the eighteenth I caught sight of
+the first outlines of the mountains upon your coast--and glad indeed was
+I to set eyes upon them. Nevertheless there was still much trouble in
+store for me, for at this point Neptune would let me go no further, and
+raised a great storm against me; the sea was so terribly high that I
+could no longer keep to my raft, which went to pieces under the fury of
+the gale, and I had to swim for it, till wind and current brought me to
+your shores.
+
+"There I tried to land, but could not, for it was a bad place and the
+waves dashed me against the rocks, so I again took to the sea and swam
+on till I came to a river that seemed the most likely landing place, for
+there were no rocks and it was sheltered from the wind. Here, then, I
+got out of the water and gathered my senses together again. Night was
+coming on, so I left the river, and went into a thicket, where I covered
+myself all over with leaves, and presently heaven sent me off into a
+very deep sleep. Sick and sorry as I was I slept among the leaves all
+night, and through the next day till afternoon, when I woke as the sun
+was westering, and saw your daughter's maid servants playing upon the
+beach, and your daughter among them looking like a goddess. I besought
+her aid, and she proved to be of an excellent disposition, much more so
+than could be expected from so young a person--for young people are apt
+to be thoughtless. She gave me plenty of bread and wine, and when she
+had had me washed in the river she also gave me the clothes in which you
+see me. Now, therefore, though it has pained me to do so, I have told
+you the whole truth."
+
+Then Alcinous said, "Stranger, it was very wrong of my daughter not to
+bring you on at once to my house along with the maids, seeing that she
+was the first person whose aid you asked."
+
+"Pray do not scold her," replied Ulysses; "she is not to blame. She did
+tell me to follow along with the maids, but I was ashamed and afraid,
+for I thought you might perhaps be displeased if you saw me. Every human
+being is sometimes a little suspicious and irritable."
+
+"Stranger," replied Alcinous, "I am not the kind of man to get angry
+about nothing; it is always better to be reasonable; but by Father Jove,
+Minerva, and Apollo, now that I see what kind of person you are, and how
+much you think as I do, I wish you would stay here, marry my daughter,
+and become my son-in-law. If you will stay I will give you a house and
+an estate, but no one (heaven forbid) shall keep you here against your
+own wish, and that you may be sure of this I will attend tomorrow to the
+matter of your escort. You can sleep {64} during the whole voyage if you
+like, and the men shall sail you over smooth waters either to your own
+home, or wherever you please, even though it be a long way further
+off than Euboea, which those of my people who saw it when they took
+yellow-haired Rhadamanthus to see Tityus the son of Gaia, tell me is the
+furthest of any place--and yet they did the whole voyage in a single day
+without distressing themselves, and came back again afterwards. You
+will thus see how much my ships excel all others, and what magnificent
+oarsmen my sailors are."
+
+Then was Ulysses glad and prayed aloud saying, "Father Jove, grant that
+Alcinous may do all as he has said, for so he will win an imperishable
+name among mankind, and at the same time I shall return to my country."
+
+Thus did they converse. Then Arete told her maids to set a bed in the
+room that was in the gatehouse, and make it with good red rugs, and to
+spread coverlets on the top of them with woollen cloaks for Ulysses to
+wear. The maids thereon went out with torches in their hands, and when
+they had made the bed they came up to Ulysses and said, "Rise, sir
+stranger, and come with us for your bed is ready," and glad indeed was
+he to go to his rest.
+
+So Ulysses slept in a bed placed in a room over the echoing gateway; but
+Alcinous lay in the inner part of the house, with the queen his wife by
+his side.
+
+
+Book VIII
+
+BANQUET IN THE HOUSE OF ALCINOUS--THE GAMES.
+
+Now when the child of morning, rosy-fingered Dawn, appeared, Alcinous
+and Ulysses both rose, and Alcinous led the way to the Phaeacian place
+of assembly, which was near the ships. When they got there they sat down
+side by side on a seat of polished stone, while Minerva took the form
+of one of Alcinous' servants, and went round the town in order to help
+Ulysses to get home. She went up to the citizens, man by man, and said,
+"Aldermen and town councillors of the Phaeacians, come to the assembly
+all of you and listen to the stranger who has just come off a long
+voyage to the house of King Alcinous; he looks like an immortal god."
+
+With these words she made them all want to come, and they flocked to the
+assembly till seats and standing room were alike crowded. Every one was
+struck with the appearance of Ulysses, for Minerva had beautified him
+about the head and shoulders, making him look taller and stouter than he
+really was, that he might impress the Phaeacians favourably as being a
+very remarkable man, and might come off well in the many trials of skill
+to which they would challenge him. Then, when they were got together,
+Alcinous spoke:
+
+"Hear me," said he, "aldermen and town councillors of the Phaeacians,
+that I may speak even as I am minded. This stranger, whoever he may be,
+has found his way to my house from somewhere or other either East or
+West. He wants an escort and wishes to have the matter settled. Let
+us then get one ready for him, as we have done for others before him;
+indeed, no one who ever yet came to my house has been able to complain
+of me for not speeding on his way soon enough. Let us draw a ship into
+the sea--one that has never yet made a voyage--and man her with two and
+fifty of our smartest young sailors. Then when you have made fast
+your oars each by his own seat, leave the ship and come to my house to
+prepare a feast. {65} I will find you in everything. I am giving these
+instructions to the young men who will form the crew, for as regards
+you aldermen and town councillors, you will join me in entertaining
+our guest in the cloisters. I can take no excuses, and we will have
+Demodocus to sing to us; for there is no bard like him whatever he may
+choose to sing about."
+
+Alcinous then led the way, and the others followed after, while a
+servant went to fetch Demodocus. The fifty-two picked oarsmen went to
+the sea shore as they had been told, and when they got there they drew
+the ship into the water, got her mast and sails inside her, bound
+the oars to the thole-pins with twisted thongs of leather, all in due
+course, and spread the white sails aloft. They moored the vessel a
+little way out from land, and then came on shore and went to the house
+of King Alcinous. The out houses, {66} yards, and all the precincts were
+filled with crowds of men in great multitudes both old and young; and
+Alcinous killed them a dozen sheep, eight full grown pigs, and two oxen.
+These they skinned and dressed so as to provide a magnificent banquet.
+
+A servant presently led in the famous bard Demodocus, whom the muse had
+dearly loved, but to whom she had given both good and evil, for though
+she had endowed him with a divine gift of song, she had robbed him of
+his eyesight. Pontonous set a seat for him among the guests, leaning it
+up against a bearing-post. He hung the lyre for him on a peg over his
+head, and showed him where he was to feel for it with his hands. He also
+set a fair table with a basket of victuals by his side, and a cup of
+wine from which he might drink whenever he was so disposed.
+
+The company then laid their hands upon the good things that were before
+them, but as soon as they had had enough to eat and drink, the muse
+inspired Demodocus to sing the feats of heroes, and more especially
+a matter that was then in the mouths of all men, to wit, the quarrel
+between Ulysses and Achilles, and the fierce words that they heaped on
+one another as they sat together at a banquet. But Agamemnon was glad
+when he heard his chieftains quarrelling with one another, for Apollo
+had foretold him this at Pytho when he crossed the stone floor to
+consult the oracle. Here was the beginning of the evil that by the will
+of Jove fell both upon Danaans and Trojans.
+
+Thus sang the bard, but Ulysses drew his purple mantle over his head and
+covered his face, for he was ashamed to let the Phaeacians see that he
+was weeping. When the bard left off singing he wiped the tears from his
+eyes, uncovered his face, and, taking his cup, made a drink-offering to
+the gods; but when the Phaeacians pressed Demodocus to sing further, for
+they delighted in his lays, then Ulysses again drew his mantle over his
+head and wept bitterly. No one noticed his distress except Alcinous, who
+was sitting near him, and heard the heavy sighs that he was heaving. So
+he at once said, "Aldermen and town councillors of the Phaeacians, we
+have had enough now, both of the feast, and of the minstrelsy that is
+its due accompaniment; let us proceed therefore to the athletic sports,
+so that our guest on his return home may be able to tell his friends
+how much we surpass all other nations as boxers, wrestlers, jumpers, and
+runners."
+
+With these words he led the way, and the others followed after. A
+servant hung Demodocus's lyre on its peg for him, led him out of the
+cloister, and set him on the same way as that along which all the chief
+men of the Phaeacians were going to see the sports; a crowd of several
+thousands of people followed them, and there were many excellent
+competitors for all the prizes. Acroneos, Ocyalus, Elatreus, Nauteus,
+Prymneus, Anchialus, Eretmeus, Ponteus, Proreus, Thoon, Anabesineus, and
+Amphialus son of Polyneus son of Tecton. There was also Euryalus son of
+Naubolus, who was like Mars himself, and was the best looking man
+among the Phaeacians except Laodamas. Three sons of Alcinous, Laodamas,
+Halios, and Clytoneus, competed also.
+
+The foot races came first. The course was set out for them from the
+starting post, and they raised a dust upon the plain as they all flew
+forward at the same moment. Clytoneus came in first by a long way; he
+left every one else behind him by the length of the furrow that a couple
+of mules can plough in a fallow field. {67} They then turned to the
+painful art of wrestling, and here Euryalus proved to be the best man.
+Amphialus excelled all the others in jumping, while at throwing the disc
+there was no one who could approach Elatreus. Alcinous's son Laodamas
+was the best boxer, and he it was who presently said, when they had all
+been diverted with the games, "Let us ask the stranger whether he excels
+in any of these sports; he seems very powerfully built; his thighs,
+calves, hands, and neck are of prodigious strength, nor is he at all
+old, but he has suffered much lately, and there is nothing like the sea
+for making havoc with a man, no matter how strong he is."
+
+"You are quite right, Laodamas," replied Euryalus, "go up to your guest
+and speak to him about it yourself."
+
+When Laodamas heard this he made his way into the middle of the crowd
+and said to Ulysses, "I hope, Sir, that you will enter yourself for some
+one or other of our competitions if you are skilled in any of them--and
+you must have gone in for many a one before now. There is nothing that
+does any one so much credit all his life long as the showing himself a
+proper man with his hands and feet. Have a try therefore at something,
+and banish all sorrow from your mind. Your return home will not be long
+delayed, for the ship is already drawn into the water, and the crew is
+found."
+
+Ulysses answered, "Laodamas, why do you taunt me in this way? my mind is
+set rather on cares than contests; I have been through infinite trouble,
+and am come among you now as a suppliant, praying your king and people
+to further me on my return home."
+
+Then Euryalus reviled him outright and said, "I gather, then, that you
+are unskilled in any of the many sports that men generally delight in. I
+suppose you are one of those grasping traders that go about in ships
+as captains or merchants, and who think of nothing but of their outward
+freights and homeward cargoes. There does not seem to be much of the
+athlete about you."
+
+"For shame, Sir," answered Ulysses, fiercely, "you are an insolent
+fellow--so true is it that the gods do not grace all men alike in
+speech, person, and understanding. One man may be of weak presence, but
+heaven has adorned this with such a good conversation that he charms
+every one who sees him; his honeyed moderation carries his hearers with
+him so that he is leader in all assemblies of his fellows, and wherever
+he goes he is looked up to. Another may be as handsome as a god, but his
+good looks are not crowned with discretion. This is your case. No god
+could make a finer looking fellow than you are, but you are a fool. Your
+ill-judged remarks have made me exceedingly angry, and you are quite
+mistaken, for I excel in a great many athletic exercises; indeed, so
+long as I had youth and strength, I was among the first athletes of the
+age. Now, however, I am worn out by labour and sorrow, for I have gone
+through much both on the field of battle and by the waves of the weary
+sea; still, in spite of all this I will compete, for your taunts have
+stung me to the quick."
+
+So he hurried up without even taking his cloak off, and seized a disc,
+larger, more massive and much heavier than those used by the Phaeacians
+when disc-throwing among themselves. {68} Then, swinging it back, he
+threw it from his brawny hand, and it made a humming sound in the air as
+he did so. The Phaeacians quailed beneath the rushing of its flight as
+it sped gracefully from his hand, and flew beyond any mark that had been
+made yet. Minerva, in the form of a man, came and marked the place where
+it had fallen. "A blind man, Sir," said she, "could easily tell your
+mark by groping for it--it is so far ahead of any other. You may make
+your mind easy about this contest, for no Phaeacian can come near to
+such a throw as yours."
+
+Ulysses was glad when he found he had a friend among the lookers-on,
+so he began to speak more pleasantly. "Young men," said he, "come up to
+that throw if you can, and I will throw another disc as heavy or even
+heavier. If anyone wants to have a bout with me let him come on, for I
+am exceedingly angry; I will box, wrestle, or run, I do not care what it
+is, with any man of you all except Laodamas, but not with him because I
+am his guest, and one cannot compete with one's own personal friend.
+At least I do not think it a prudent or a sensible thing for a guest
+to challenge his host's family at any game, especially when he is in a
+foreign country. He will cut the ground from under his own feet if he
+does; but I make no exception as regards any one else, for I want to
+have the matter out and know which is the best man. I am a good hand
+at every kind of athletic sport known among mankind. I am an excellent
+archer. In battle I am always the first to bring a man down with my
+arrow, no matter how many more are taking aim at him alongside of me.
+Philoctetes was the only man who could shoot better than I could when we
+Achaeans were before Troy and in practice. I far excel every one else
+in the whole world, of those who still eat bread upon the face of the
+earth, but I should not like to shoot against the mighty dead, such as
+Hercules, or Eurytus the Oechalian--men who could shoot against the gods
+themselves. This in fact was how Eurytus came prematurely by his end,
+for Apollo was angry with him and killed him because he challenged him
+as an archer. I can throw a dart farther than any one else can shoot an
+arrow. Running is the only point in respect of which I am afraid some of
+the Phaeacians might beat me, for I have been brought down very low at
+sea; my provisions ran short, and therefore I am still weak."
+
+They all held their peace except King Alcinous, who began, "Sir, we have
+had much pleasure in hearing all that you have told us, from which I
+understand that you are willing to show your prowess, as having been
+displeased with some insolent remarks that have been made to you by one
+of our athletes, and which could never have been uttered by any one who
+knows how to talk with propriety. I hope you will apprehend my meaning,
+and will explain to any one of your chief men who may be dining with
+yourself and your family when you get home, that we have an hereditary
+aptitude for accomplishments of all kinds. We are not particularly
+remarkable for our boxing, nor yet as wrestlers, but we are singularly
+fleet of foot and are excellent sailors. We are extremely fond of good
+dinners, music, and dancing; we also like frequent changes of linen,
+warm baths, and good beds, so now, please, some of you who are the best
+dancers set about dancing, that our guest on his return home may be able
+to tell his friends how much we surpass all other nations as sailors,
+runners, dancers, and minstrels. Demodocus has left his lyre at my
+house, so run some one or other of you and fetch it for him."
+
+On this a servant hurried off to bring the lyre from the king's house,
+and the nine men who had been chosen as stewards stood forward. It was
+their business to manage everything connected with the sports, so
+they made the ground smooth and marked a wide space for the dancers.
+Presently the servant came back with Demodocus's lyre, and he took his
+place in the midst of them, whereon the best young dancers in the town
+began to foot and trip it so nimbly that Ulysses was delighted with the
+merry twinkling of their feet.
+
+Meanwhile the bard began to sing the loves of Mars and Venus, and how
+they first began their intrigue in the house of Vulcan. Mars made Venus
+many presents, and defiled King Vulcan's marriage bed, so the sun, who
+saw what they were about, told Vulcan. Vulcan was very angry when he
+heard such dreadful news, so he went to his smithy brooding mischief,
+got his great anvil into its place, and began to forge some chains which
+none could either unloose or break, so that they might stay there in
+that place. {69} When he had finished his snare he went into his bedroom
+and festooned the bed-posts all over with chains like cobwebs; he also
+let many hang down from the great beam of the ceiling. Not even a god
+could see them so fine and subtle were they. As soon as he had spread
+the chains all over the bed, he made as though he were setting out for
+the fair state of Lemnos, which of all places in the world was the one
+he was most fond of. But Mars kept no blind look out, and as soon as he
+saw him start, hurried off to his house, burning with love for Venus.
+
+Now Venus was just come in from a visit to her father Jove, and was
+about sitting down when Mars came inside the house, and said as he took
+her hand in his own, "Let us go to the couch of Vulcan: he is not at
+home, but is gone off to Lemnos among the Sintians, whose speech is
+barbarous."
+
+She was nothing loth, so they went to the couch to take their rest,
+whereon they were caught in the toils which cunning Vulcan had spread
+for them, and could neither get up nor stir hand or foot, but found too
+late that they were in a trap. Then Vulcan came up to them, for he had
+turned back before reaching Lemnos, when his scout the sun told him what
+was going on. He was in a furious passion, and stood in the vestibule
+making a dreadful noise as he shouted to all the gods.
+
+"Father Jove," he cried, "and all you other blessed gods who live for
+ever, come here and see the ridiculous and disgraceful sight that I will
+show you. Jove's daughter Venus is always dishonouring me because I am
+lame. She is in love with Mars, who is handsome and clean built, whereas
+I am a cripple--but my parents are to blame for that, not I; they ought
+never to have begotten me. Come and see the pair together asleep on
+my bed. It makes me furious to look at them. They are very fond of one
+another, but I do not think they will lie there longer than they can
+help, nor do I think that they will sleep much; there, however, they
+shall stay till her father has repaid me the sum I gave him for his
+baggage of a daughter, who is fair but not honest."
+
+On this the gods gathered to the house of Vulcan. Earth-encircling
+Neptune came, and Mercury the bringer of luck, and King Apollo, but the
+goddesses staid at home all of them for shame. Then the givers of all
+good things stood in the doorway, and the blessed gods roared with
+inextinguishable laughter, as they saw how cunning Vulcan had been,
+whereon one would turn towards his neighbour saying:
+
+"Ill deeds do not prosper, and the weak confound the strong. See how
+limping Vulcan, lame as he is, has caught Mars who is the fleetest god
+in heaven; and now Mars will be cast in heavy damages."
+
+Thus did they converse, but King Apollo said to Mercury, "Messenger
+Mercury, giver of good things, you would not care how strong the chains
+were, would you, if you could sleep with Venus?"
+
+"King Apollo," answered Mercury, "I only wish I might get the chance,
+though there were three times as many chains--and you might look on, all
+of you, gods and goddesses, but I would sleep with her if I could."
+
+The immortal gods burst out laughing as they heard him, but Neptune took
+it all seriously, and kept on imploring Vulcan to set Mars free again.
+"Let him go," he cried, "and I will undertake, as you require, that
+he shall pay you all the damages that are held reasonable among the
+immortal gods."
+
+"Do not," replied Vulcan, "ask me to do this; a bad man's bond is bad
+security; what remedy could I enforce against you if Mars should go away
+and leave his debts behind him along with his chains?"
+
+"Vulcan," said Neptune, "if Mars goes away without paying his damages,
+I will pay you myself." So Vulcan answered, "In this case I cannot and
+must not refuse you."
+
+Thereon he loosed the bonds that bound them, and as soon as they were
+free they scampered off, Mars to Thrace and laughter-loving Venus to
+Cyprus and to Paphos, where is her grove and her altar fragrant with
+burnt offerings. Here the Graces bathed her, and anointed her with oil
+of ambrosia such as the immortal gods make use of, and they clothed her
+in raiment of the most enchanting beauty.
+
+Thus sang the bard, and both Ulysses and the seafaring Phaeacians were
+charmed as they heard him.
+
+Then Alcinous told Laodamas and Halius to dance alone, for there was no
+one to compete with them. So they took a red ball which Polybus had made
+for them, and one of them bent himself backwards and threw it up towards
+the clouds, while the other jumped from off the ground and caught it
+with ease before it came down again. When they had done throwing the
+ball straight up into the air they began to dance, and at the same time
+kept on throwing it backwards and forwards to one another, while all
+the young men in the ring applauded and made a great stamping with their
+feet. Then Ulysses said:
+
+"King Alcinous, you said your people were the nimblest dancers in the
+world, and indeed they have proved themselves to be so. I was astonished
+as I saw them."
+
+The king was delighted at this, and exclaimed to the Phaeacians,
+"Aldermen and town councillors, our guest seems to be a person of
+singular judgement; let us give him such proof of our hospitality as
+he may reasonably expect. There are twelve chief men among you, and
+counting myself there are thirteen; contribute, each of you, a clean
+cloak, a shirt, and a talent of fine gold; let us give him all this in
+a lump down at once, so that when he gets his supper he may do so with a
+light heart. As for Euryalus he will have to make a formal apology and a
+present too, for he has been rude."
+
+Thus did he speak. The others all of them applauded his saying, and
+sent their servants to fetch the presents. Then Euryalus said, "King
+Alcinous, I will give the stranger all the satisfaction you require. He
+shall have my sword, which is of bronze, all but the hilt, which is of
+silver. I will also give him the scabbard of newly sawn ivory into which
+it fits. It will be worth a great deal to him."
+
+As he spoke he placed the sword in the hands of Ulysses and said, "Good
+luck to you, father stranger; if anything has been said amiss may the
+winds blow it away with them, and may heaven grant you a safe return,
+for I understand you have been long away from home, and have gone
+through much hardship."
+
+To which Ulysses answered, "Good luck to you too my friend, and may the
+gods grant you every happiness. I hope you will not miss the sword you
+have given me along with your apology."
+
+With these words he girded the sword about his shoulders and towards
+sundown the presents began to make their appearance, as the servants of
+the donors kept bringing them to the house of King Alcinous; here his
+sons received them, and placed them under their mother's charge. Then
+Alcinous led the way to the house and bade his guests take their seats.
+
+"Wife," said he, turning to Queen Arete, "Go, fetch the best chest we
+have, and put a clean cloak and shirt in it. Also, set a copper on the
+fire and heat some water; our guest will take a warm bath; see also to
+the careful packing of the presents that the noble Phaeacians have made
+him; he will thus better enjoy both his supper and the singing that
+will follow. I shall myself give him this golden goblet--which is of
+exquisite workmanship--that he may be reminded of me for the rest of his
+life whenever he makes a drink offering to Jove, or to any of the gods."
+{70}
+
+Then Arete told her maids to set a large tripod upon the fire as fast as
+they could, whereon they set a tripod full of bath water on to a clear
+fire; they threw on sticks to make it blaze, and the water became hot
+as the flame played about the belly of the tripod. {71} Meanwhile Arete
+brought a magnificent chest from her own room, and inside it she packed
+all the beautiful presents of gold and raiment which the Phaeacians had
+brought. Lastly she added a cloak and a good shirt from Alcinous, and
+said to Ulysses:
+
+"See to the lid yourself, and have the whole bound round at once, for
+fear any one should rob you by the way when you are asleep in your
+ship." {72}
+
+When Ulysses heard this he put the lid on the chest and made it fast
+with a bond that Circe had taught him. He had done so before an upper
+servant told him to come to the bath and wash himself. He was very glad
+of a warm bath, for he had had no one to wait upon him ever since he
+left the house of Calypso, who as long as he remained with her had taken
+as good care of him as though he had been a god. When the servants had
+done washing and anointing him with oil, and had given him a clean cloak
+and shirt, he left the bath room and joined the guests who were sitting
+over their wine. Lovely Nausicaa stood by one of the bearing-posts
+supporting the roof of the cloister, and admired him as she saw him
+pass. "Farewell stranger," said she, "do not forget me when you are safe
+at home again, for it is to me first that you owe a ransom for having
+saved your life."
+
+And Ulysses said, "Nausicaa, daughter of great Alcinous, may Jove the
+mighty husband of Juno, grant that I may reach my home; so shall I bless
+you as my guardian angel all my days, for it was you who saved me."
+
+When he had said this, he seated himself beside Alcinous. Supper was
+then served, and the wine was mixed for drinking. A servant led in the
+favourite bard Demodocus, and set him in the midst of the company, near
+one of the bearing-posts supporting the cloister, that he might lean
+against it. Then Ulysses cut off a piece of roast pork with plenty of
+fat (for there was abundance left on the joint) and said to a servant,
+"Take this piece of pork over to Demodocus and tell him to eat it; for
+all the pain his lays may cause me I will salute him none the less;
+bards are honoured and respected throughout the world, for the muse
+teaches them their songs and loves them."
+
+The servant carried the pork in his fingers over to Demodocus, who took
+it and was very much pleased. They then laid their hands on the good
+things that were before them, and as soon as they had had to eat and
+drink, Ulysses said to Demodocus, "Demodocus, there is no one in the
+world whom I admire more than I do you. You must have studied under the
+Muse, Jove's daughter, and under Apollo, so accurately do you sing the
+return of the Achaeans with all their sufferings and adventures. If you
+were not there yourself, you must have heard it all from some one who
+was. Now, however, change your song and tell us of the wooden horse
+which Epeus made with the assistance of Minerva, and which Ulysses got
+by stratagem into the fort of Troy after freighting it with the men who
+afterwards sacked the city. If you will sing this tale aright I will
+tell all the world how magnificently heaven has endowed you."
+
+The bard inspired of heaven took up the story at the point where some of
+the Argives set fire to their tents and sailed away while others, hidden
+within the horse, {73} were waiting with Ulysses in the Trojan place
+of assembly. For the Trojans themselves had drawn the horse into their
+fortress, and it stood there while they sat in council round it, and
+were in three minds as to what they should do. Some were for breaking it
+up then and there; others would have it dragged to the top of the rock
+on which the fortress stood, and then thrown down the precipice; while
+yet others were for letting it remain as an offering and propitiation
+for the gods. And this was how they settled it in the end, for the city
+was doomed when it took in that horse, within which were all the bravest
+of the Argives waiting to bring death and destruction on the Trojans.
+Anon he sang how the sons of the Achaeans issued from the horse, and
+sacked the town, breaking out from their ambuscade. He sang how they
+overran the city hither and thither and ravaged it, and how Ulysses went
+raging like Mars along with Menelaus to the house of Deiphobus. It was
+there that the fight raged most furiously, nevertheless by Minerva's
+help he was victorious.
+
+All this he told, but Ulysses was overcome as he heard him, and his
+cheeks were wet with tears. He wept as a woman weeps when she throws
+herself on the body of her husband who has fallen before his own city
+and people, fighting bravely in defence of his home and children. She
+screams aloud and flings her arms about him as he lies gasping for
+breath and dying, but her enemies beat her from behind about the back
+and shoulders, and carry her off into slavery, to a life of labour and
+sorrow, and the beauty fades from her cheeks--even so piteously did
+Ulysses weep, but none of those present perceived his tears except
+Alcinous, who was sitting near him, and could hear the sobs and sighs
+that he was heaving. The king, therefore, at once rose and said:
+
+"Aldermen and town councillors of the Phaeacians, let Demodocus cease
+his song, for there are those present who do not seem to like it. From
+the moment that we had done supper and Demodocus began to sing, our
+guest has been all the time groaning and lamenting. He is evidently
+in great trouble, so let the bard leave off, that we may all enjoy
+ourselves, hosts and guest alike. This will be much more as it should
+be, for all these festivities, with the escort and the presents that we
+are making with so much good will are wholly in his honour, and any
+one with even a moderate amount of right feeling knows that he ought to
+treat a guest and a suppliant as though he were his own brother.
+
+"Therefore, Sir, do you on your part affect no more concealment nor
+reserve in the matter about which I shall ask you; it will be more
+polite in you to give me a plain answer; tell me the name by which your
+father and mother over yonder used to call you, and by which you were
+known among your neighbours and fellow-citizens. There is no one,
+neither rich nor poor, who is absolutely without any name whatever, for
+people's fathers and mothers give them names as soon as they are born.
+Tell me also your country, nation, and city, that our ships may shape
+their purpose accordingly and take you there. For the Phaeacians have
+no pilots; their vessels have no rudders as those of other nations have,
+but the ships themselves understand what it is that we are thinking
+about and want; they know all the cities and countries in the whole
+world, and can traverse the sea just as well even when it is covered
+with mist and cloud, so that there is no danger of being wrecked or
+coming to any harm. Still I do remember hearing my father say that
+Neptune was angry with us for being too easy-going in the matter of
+giving people escorts. He said that one of these days he should wreck a
+ship of ours as it was returning from having escorted some one, {74} and
+bury our city under a high mountain. This is what my father used to say,
+but whether the god will carry out his threat or no is a matter which he
+will decide for himself.
+
+"And now, tell me and tell me true. Where have you been wandering, and
+in what countries have you travelled? Tell us of the peoples themselves,
+and of their cities--who were hostile, savage and uncivilised, and who,
+on the other hand, hospitable and humane. Tell us also why you are made
+so unhappy on hearing about the return of the Argive Danaans from Troy.
+The gods arranged all this, and sent them their misfortunes in order
+that future generations might have something to sing about. Did you
+lose some brave kinsman of your wife's when you were before Troy? a
+son-in-law or father-in-law--which are the nearest relations a man has
+outside his own flesh and blood? or was it some brave and kindly-natured
+comrade--for a good friend is as dear to a man as his own brother?"
+
+
+Book IX
+
+ULYSSES DECLARES HIMSELF AND BEGINS HIS STORY---THE CICONS, LOTOPHAGI,
+AND CYCLOPES.
+
+
+And Ulysses answered, "King Alcinous, it is a good thing to hear a bard
+with such a divine voice as this man has. There is nothing better or
+more delightful than when a whole people make merry together, with the
+guests sitting orderly to listen, while the table is loaded with bread
+and meats, and the cup-bearer draws wine and fills his cup for every
+man. This is indeed as fair a sight as a man can see. Now, however,
+since you are inclined to ask the story of my sorrows, and rekindle my
+own sad memories in respect of them, I do not know how to begin, nor yet
+how to continue and conclude my tale, for the hand of heaven has been
+laid heavily upon me.
+
+"Firstly, then, I will tell you my name that you too may know it, and
+one day, if I outlive this time of sorrow, may become my guests though I
+live so far away from all of you. I am Ulysses son of Laertes, renowned
+among mankind for all manner of subtlety, so that my fame ascends to
+heaven. I live in Ithaca, where there is a high mountain called Neritum,
+covered with forests; and not far from it there is a group of islands
+very near to one another--Dulichium, Same, and the wooded island of
+Zacynthus. It lies squat on the horizon, all highest up in the sea
+towards the sunset, while the others lie away from it towards dawn. {75}
+It is a rugged island, but it breeds brave men, and my eyes know none
+that they better love to look upon. The goddess Calypso kept me with her
+in her cave, and wanted me to marry her, as did also the cunning Aeaean
+goddess Circe; but they could neither of them persuade me, for there
+is nothing dearer to a man than his own country and his parents, and
+however splendid a home he may have in a foreign country, if it be far
+from father or mother, he does not care about it. Now, however, I will
+tell you of the many hazardous adventures which by Jove's will I met
+with on my return from Troy.
+
+"When I had set sail thence the wind took me first to Ismarus, which is
+the city of the Cicons. There I sacked the town and put the people to
+the sword. We took their wives and also much booty, which we divided
+equitably amongst us, so that none might have reason to complain. I
+then said that we had better make off at once, but my men very foolishly
+would not obey me, so they staid there drinking much wine and killing
+great numbers of sheep and oxen on the sea shore. Meanwhile the Cicons
+cried out for help to other Cicons who lived inland. These were more in
+number, and stronger, and they were more skilled in the art of war,
+for they could fight, either from chariots or on foot as the occasion
+served; in the morning, therefore, they came as thick as leaves and
+bloom in summer, and the hand of heaven was against us, so that we were
+hard pressed. They set the battle in array near the ships, and the hosts
+aimed their bronze-shod spears at one another. {76} So long as the day
+waxed and it was still morning, we held our own against them, though
+they were more in number than we; but as the sun went down, towards the
+time when men loose their oxen, the Cicons got the better of us, and we
+lost half a dozen men from every ship we had; so we got away with those
+that were left.
+
+"Thence we sailed onward with sorrow in our hearts, but glad to have
+escaped death though we had lost our comrades, nor did we leave till we
+had thrice invoked each one of the poor fellows who had perished by the
+hands of the Cicons. Then Jove raised the North wind against us till it
+blew a hurricane, so that land and sky were hidden in thick clouds, and
+night sprang forth out of the heavens. We let the ships run before the
+gale, but the force of the wind tore our sails to tatters, so we took
+them down for fear of shipwreck, and rowed our hardest towards the land.
+There we lay two days and two nights suffering much alike from toil and
+distress of mind, but on the morning of the third day we again raised
+our masts, set sail, and took our places, letting the wind and steersmen
+direct our ship. I should have got home at that time unharmed had not
+the North wind and the currents been against me as I was doubling Cape
+Malea, and set me off my course hard by the island of Cythera.
+
+"I was driven thence by foul winds for a space of nine days upon the
+sea, but on the tenth day we reached the land of the Lotus-eaters, who
+live on a food that comes from a kind of flower. Here we landed to take
+in fresh water, and our crews got their mid-day meal on the shore near
+the ships. When they had eaten and drunk I sent two of my company to
+see what manner of men the people of the place might be, and they had
+a third man under them. They started at once, and went about among the
+Lotus-eaters, who did them no hurt, but gave them to eat of the lotus,
+which was so delicious that those who ate of it left off caring about
+home, and did not even want to go back and say what had happened to
+them, but were for staying and munching lotus {77} with the Lotus-eaters
+without thinking further of their return; nevertheless, though they wept
+bitterly I forced them back to the ships and made them fast under the
+benches. Then I told the rest to go on board at once, lest any of them
+should taste of the lotus and leave off wanting to get home, so they
+took their places and smote the grey sea with their oars.
+
+"We sailed hence, always in much distress, till we came to the land of
+the lawless and inhuman Cyclopes. Now the Cyclopes neither plant nor
+plough, but trust in providence, and live on such wheat, barley, and
+grapes as grow wild without any kind of tillage, and their wild grapes
+yield them wine as the sun and the rain may grow them. They have no
+laws nor assemblies of the people, but live in caves on the tops of
+high mountains; each is lord and master in his family, and they take no
+account of their neighbours.
+
+"Now off their harbour there lies a wooded and fertile island not quite
+close to the land of the Cyclopes, but still not far. It is over-run
+with wild goats, that breed there in great numbers and are never
+disturbed by foot of man; for sportsmen--who as a rule will suffer so
+much hardship in forest or among mountain precipices--do not go there,
+nor yet again is it ever ploughed or fed down, but it lies a wilderness
+untilled and unsown from year to year, and has no living thing upon it
+but only goats. For the Cyclopes have no ships, nor yet shipwrights who
+could make ships for them; they cannot therefore go from city to city,
+or sail over the sea to one another's country as people who have ships
+can do; if they had had these they would have colonised the island, {78}
+for it is a very good one, and would yield everything in due season.
+There are meadows that in some places come right down to the sea
+shore, well watered and full of luscious grass; grapes would do there
+excellently; there is level land for ploughing, and it would always
+yield heavily at harvest time, for the soil is deep. There is a good
+harbour where no cables are wanted, nor yet anchors, nor need a ship be
+moored, but all one has to do is to beach one's vessel and stay there
+till the wind becomes fair for putting out to sea again. At the head of
+the harbour there is a spring of clear water coming out of a cave, and
+there are poplars growing all round it.
+
+"Here we entered, but so dark was the night that some god must have
+brought us in, for there was nothing whatever to be seen. A thick mist
+hung all round our ships; {79} the moon was hidden behind a mass of
+clouds so that no one could have seen the island if he had looked for
+it, nor were there any breakers to tell us we were close in shore before
+we found ourselves upon the land itself; when, however, we had beached
+the ships, we took down the sails, went ashore and camped upon the beach
+till daybreak.
+
+"When the child of morning, rosy-fingered Dawn appeared, we admired
+the island and wandered all over it, while the nymphs Jove's daughters
+roused the wild goats that we might get some meat for our dinner. On
+this we fetched our spears and bows and arrows from the ships, and
+dividing ourselves into three bands began to shoot the goats. Heaven
+sent us excellent sport; I had twelve ships with me, and each ship got
+nine goats, while my own ship had ten; thus through the livelong day to
+the going down of the sun we ate and drank our fill, and we had plenty
+of wine left, for each one of us had taken many jars full when we sacked
+the city of the Cicons, and this had not yet run out. While we were
+feasting we kept turning our eyes towards the land of the Cyclopes,
+which was hard by, and saw the smoke of their stubble fires. We could
+almost fancy we heard their voices and the bleating of their sheep and
+goats, but when the sun went down and it came on dark, we camped down
+upon the beach, and next morning I called a council.
+
+"'Stay here, my brave fellows,' said I, 'all the rest of you, while I go
+with my ship and exploit these people myself: I want to see if they are
+uncivilised savages, or a hospitable and humane race.'
+
+"I went on board, bidding my men to do so also and loose the hawsers; so
+they took their places and smote the grey sea with their oars. When we
+got to the land, which was not far, there, on the face of a cliff near
+the sea, we saw a great cave overhung with laurels. It was a station for
+a great many sheep and goats, and outside there was a large yard, with
+a high wall round it made of stones built into the ground and of trees
+both pine and oak. This was the abode of a huge monster who was then
+away from home shepherding his flocks. He would have nothing to do with
+other people, but led the life of an outlaw. He was a horrid creature,
+not like a human being at all, but resembling rather some crag that
+stands out boldly against the sky on the top of a high mountain.
+
+"I told my men to draw the ship ashore, and stay where they were, all
+but the twelve best among them, who were to go along with myself. I also
+took a goatskin of sweet black wine which had been given me by Maron,
+son of Euanthes, who was priest of Apollo the patron god of Ismarus, and
+lived within the wooded precincts of the temple. When we were sacking
+the city we respected him, and spared his life, as also his wife and
+child; so he made me some presents of great value--seven talents of fine
+gold, and a bowl of silver, with twelve jars of sweet wine, unblended,
+and of the most exquisite flavour. Not a man nor maid in the house knew
+about it, but only himself, his wife, and one housekeeper: when he drank
+it he mixed twenty parts of water to one of wine, and yet the fragrance
+from the mixing-bowl was so exquisite that it was impossible to refrain
+from drinking. I filled a large skin with this wine, and took a wallet
+full of provisions with me, for my mind misgave me that I might have to
+deal with some savage who would be of great strength, and would respect
+neither right nor law.
+
+"We soon reached his cave, but he was out shepherding, so we went inside
+and took stock of all that we could see. His cheese-racks were loaded
+with cheeses, and he had more lambs and kids than his pens could hold.
+They were kept in separate flocks; first there were the hoggets, then
+the oldest of the younger lambs and lastly the very young ones {80} all
+kept apart from one another; as for his dairy, all the vessels, bowls,
+and milk pails into which he milked, were swimming with whey. When they
+saw all this, my men begged me to let them first steal some cheeses, and
+make off with them to the ship; they would then return, drive down the
+lambs and kids, put them on board and sail away with them. It would have
+been indeed better if we had done so but I would not listen to them, for
+I wanted to see the owner himself, in the hope that he might give me
+a present. When, however, we saw him my poor men found him ill to deal
+with.
+
+"We lit a fire, offered some of the cheeses in sacrifice, ate others
+of them, and then sat waiting till the Cyclops should come in with his
+sheep. When he came, he brought in with him a huge load of dry firewood
+to light the fire for his supper, and this he flung with such a noise on
+to the floor of his cave that we hid ourselves for fear at the far end
+of the cavern. Meanwhile he drove all the ewes inside, as well as the
+she-goats that he was going to milk, leaving the males, both rams and
+he-goats, outside in the yards. Then he rolled a huge stone to the mouth
+of the cave--so huge that two and twenty strong four-wheeled waggons
+would not be enough to draw it from its place against the doorway. When
+he had so done he sat down and milked his ewes and goats, all in due
+course, and then let each of them have her own young. He curdled half
+the milk and set it aside in wicker strainers, but the other half he
+poured into bowls that he might drink it for his supper. When he had got
+through with all his work, he lit the fire, and then caught sight of us,
+whereon he said:
+
+"'Strangers, who are you? Where do sail from? Are you traders, or do
+you sail the sea as rovers, with your hands against every man, and every
+man's hand against you?'
+
+"We were frightened out of our senses by his loud voice and monstrous
+form, but I managed to say, 'We are Achaeans on our way home from Troy,
+but by the will of Jove, and stress of weather, we have been driven far
+out of our course. We are the people of Agamemnon, son of Atreus, who
+has won infinite renown throughout the whole world, by sacking so great
+a city and killing so many people. We therefore humbly pray you to show
+us some hospitality, and otherwise make us such presents as visitors may
+reasonably expect. May your excellency fear the wrath of heaven, for we
+are your suppliants, and Jove takes all respectable travellers under his
+protection, for he is the avenger of all suppliants and foreigners in
+distress.'
+
+"To this he gave me but a pitiless answer, 'Stranger,' said he, 'you are
+a fool, or else you know nothing of this country. Talk to me, indeed,
+about fearing the gods or shunning their anger? We Cyclopes do not care
+about Jove or any of your blessed gods, for we are ever so much stronger
+than they. I shall not spare either yourself or your companions out of
+any regard for Jove, unless I am in the humour for doing so. And now
+tell me where you made your ship fast when you came on shore. Was it
+round the point, or is she lying straight off the land?'
+
+"He said this to draw me out, but I was too cunning to be caught in that
+way, so I answered with a lie; 'Neptune,' said I, 'sent my ship on to
+the rocks at the far end of your country, and wrecked it. We were driven
+on to them from the open sea, but I and those who are with me escaped
+the jaws of death.'
+
+"The cruel wretch vouchsafed me not one word of answer, but with a
+sudden clutch he gripped up two of my men at once and dashed them down
+upon the ground as though they had been puppies. Their brains were shed
+upon the ground, and the earth was wet with their blood. Then he tore
+them limb from limb and supped upon them. He gobbled them up like a lion
+in the wilderness, flesh, bones, marrow, and entrails, without leaving
+anything uneaten. As for us, we wept and lifted up our hands to heaven
+on seeing such a horrid sight, for we did not know what else to do; but
+when the Cyclops had filled his huge paunch, and had washed down his
+meal of human flesh with a drink of neat milk, he stretched himself
+full length upon the ground among his sheep, and went to sleep. I was at
+first inclined to seize my sword, draw it, and drive it into his vitals,
+but I reflected that if I did we should all certainly be lost, for we
+should never be able to shift the stone which the monster had put in
+front of the door. So we stayed sobbing and sighing where we were till
+morning came.
+
+"When the child of morning, rosy-fingered dawn, appeared, he again lit
+his fire, milked his goats and ewes, all quite rightly, and then let
+each have her own young one; as soon as he had got through with all his
+work, he clutched up two more of my men, and began eating them for his
+morning's meal. Presently, with the utmost ease, he rolled the stone
+away from the door and drove out his sheep, but he at once put it back
+again--as easily as though he were merely clapping the lid on to a
+quiver full of arrows. As soon as he had done so he shouted, and cried
+'Shoo, shoo,' after his sheep to drive them on to the mountain; so I was
+left to scheme some way of taking my revenge and covering myself with
+glory.
+
+"In the end I deemed it would be the best plan to do as follows: The
+Cyclops had a great club which was lying near one of the sheep pens;
+it was of green olive wood, and he had cut it intending to use it for
+a staff as soon as it should be dry. It was so huge that we could
+only compare it to the mast of a twenty-oared merchant vessel of large
+burden, and able to venture out into open sea. I went up to this club
+and cut off about six feet of it; I then gave this piece to the men and
+told them to fine it evenly off at one end, which they proceeded to do,
+and lastly I brought it to a point myself, charring the end in the fire
+to make it harder. When I had done this I hid it under dung, which was
+lying about all over the cave, and told the men to cast lots which of
+them should venture along with myself to lift it and bore it into the
+monster's eye while he was asleep. The lot fell upon the very four whom
+I should have chosen, and I myself made five. In the evening the wretch
+came back from shepherding, and drove his flocks into the cave--this
+time driving them all inside, and not leaving any in the yards; I
+suppose some fancy must have taken him, or a god must have prompted him
+to do so. As soon as he had put the stone back to its place against the
+door, he sat down, milked his ewes and his goats all quite rightly, and
+then let each have her own young one; when he had got through with all
+this work, he gripped up two more of my men, and made his supper off
+them. So I went up to him with an ivy-wood bowl of black wine in my
+hands:
+
+"'Look here, Cyclops,' said I, you have been eating a great deal of
+man's flesh, so take this and drink some wine, that you may see what
+kind of liquor we had on board my ship. I was bringing it to you as a
+drink-offering, in the hope that you would take compassion upon me and
+further me on my way home, whereas all you do is to go on ramping and
+raving most intolerably. You ought to be ashamed of yourself; how can
+you expect people to come see you any more if you treat them in this
+way?'
+
+"He then took the cup and drank. He was so delighted with the taste of
+the wine that he begged me for another bowl full. 'Be so kind,' he said,
+'as to give me some more, and tell me your name at once. I want to make
+you a present that you will be glad to have. We have wine even in this
+country, for our soil grows grapes and the sun ripens them, but this
+drinks like Nectar and Ambrosia all in one.'
+
+"I then gave him some more; three times did I fill the bowl for him, and
+three times did he drain it without thought or heed; then, when I saw
+that the wine had got into his head, I said to him as plausibly as
+I could: 'Cyclops, you ask my name and I will tell it you; give me,
+therefore, the present you promised me; my name is Noman; this is what
+my father and mother and my friends have always called me.'
+
+"But the cruel wretch said, 'Then I will eat all Noman's comrades before
+Noman himself, and will keep Noman for the last. This is the present
+that I will make him.'
+
+"As he spoke he reeled, and fell sprawling face upwards on the ground.
+His great neck hung heavily backwards and a deep sleep took hold upon
+him. Presently he turned sick, and threw up both wine and the gobbets of
+human flesh on which he had been gorging, for he was very drunk. Then I
+thrust the beam of wood far into the embers to heat it, and encouraged
+my men lest any of them should turn faint-hearted. When the wood, green
+though it was, was about to blaze, I drew it out of the fire glowing
+with heat, and my men gathered round me, for heaven had filled their
+hearts with courage. We drove the sharp end of the beam into the
+monster's eye, and bearing upon it with all my weight I kept turning it
+round and round as though I were boring a hole in a ship's plank with an
+auger, which two men with a wheel and strap can keep on turning as long
+as they choose. Even thus did we bore the red hot beam into his eye,
+till the boiling blood bubbled all over it as we worked it round and
+round, so that the steam from the burning eyeball scalded his eyelids
+and eyebrows, and the roots of the eye sputtered in the fire. As a
+blacksmith plunges an axe or hatchet into cold water to temper it--for
+it is this that gives strength to the iron--and it makes a great hiss as
+he does so, even thus did the Cyclops' eye hiss round the beam of olive
+wood, and his hideous yells made the cave ring again. We ran away in a
+fright, but he plucked the beam all besmirched with gore from his eye,
+and hurled it from him in a frenzy of rage and pain, shouting as he did
+so to the other Cyclopes who lived on the bleak headlands near him;
+so they gathered from all quarters round his cave when they heard him
+crying, and asked what was the matter with him.
+
+"'What ails you, Polyphemus,' said they, 'that you make such a noise,
+breaking the stillness of the night, and preventing us from being able
+to sleep? Surely no man is carrying off your sheep? Surely no man is
+trying to kill you either by fraud or by force?'
+
+"But Polyphemus shouted to them from inside the cave, 'Noman is killing
+me by fraud; no man is killing me by force.'
+
+"'Then,' said they, 'if no man is attacking you, you must be ill; when
+Jove makes people ill, there is no help for it, and you had better pray
+to your father Neptune.'
+
+"Then they went away, and I laughed inwardly at the success of my clever
+stratagem, but the Cyclops, groaning and in an agony of pain, felt about
+with his hands till he found the stone and took it from the door; then
+he sat in the doorway and stretched his hands in front of it to catch
+anyone going out with the sheep, for he thought I might be foolish
+enough to attempt this.
+
+"As for myself I kept on puzzling to think how I could best save my own
+life and those of my companions; I schemed and schemed, as one who knows
+that his life depends upon it, for the danger was very great. In the
+end I deemed that this plan would be the best; the male sheep were well
+grown, and carried a heavy black fleece, so I bound them noiselessly in
+threes together, with some of the withies on which the wicked monster
+used to sleep. There was to be a man under the middle sheep, and the two
+on either side were to cover him, so that there were three sheep to each
+man. As for myself there was a ram finer than any of the others, so I
+caught hold of him by the back, esconced myself in the thick wool under
+his belly, and hung on patiently to his fleece, face upwards, keeping a
+firm hold on it all the time.
+
+"Thus, then, did we wait in great fear of mind till morning came, but
+when the child of morning, rosy-fingered Dawn, appeared, the male sheep
+hurried out to feed, while the ewes remained bleating about the pens
+waiting to be milked, for their udders were full to bursting; but their
+master in spite of all his pain felt the backs of all the sheep as they
+stood upright, without being sharp enough to find out that the men were
+underneath their bellies. As the ram was going out, last of all, heavy
+with its fleece and with the weight of my crafty self, Polyphemus laid
+hold of it and said:
+
+"'My good ram, what is it that makes you the last to leave my cave this
+morning? You are not wont to let the ewes go before you, but lead the
+mob with a run whether to flowery mead or bubbling fountain, and are the
+first to come home again at night; but now you lag last of all. Is it
+because you know your master has lost his eye, and are sorry because
+that wicked Noman and his horrid crew has got him down in his drink and
+blinded him? But I will have his life yet. If you could understand and
+talk, you would tell me where the wretch is hiding, and I would dash his
+brains upon the ground till they flew all over the cave. I should thus
+have some satisfaction for the harm this no-good Noman has done me.'
+
+"As he spoke he drove the ram outside, but when we were a little way
+out from the cave and yards, I first got from under the ram's belly,
+and then freed my comrades; as for the sheep, which were very fat, by
+constantly heading them in the right direction we managed to drive them
+down to the ship. The crew rejoiced greatly at seeing those of us who
+had escaped death, but wept for the others whom the Cyclops had killed.
+However, I made signs to them by nodding and frowning that they were to
+hush their crying, and told them to get all the sheep on board at once
+and put out to sea; so they went aboard, took their places, and smote
+the grey sea with their oars. Then, when I had got as far out as my
+voice would reach, I began to jeer at the Cyclops.
+
+"'Cyclops,' said I, 'you should have taken better measure of your man
+before eating up his comrades in your cave. You wretch, eat up your
+visitors in your own house? You might have known that your sin would
+find you out, and now Jove and the other gods have punished you.'
+
+"He got more and more furious as he heard me, so he tore the top from
+off a high mountain, and flung it just in front of my ship so that
+it was within a little of hitting the end of the rudder. {81} The sea
+quaked as the rock fell into it, and the wash of the wave it raised
+carried us back towards the mainland, and forced us towards the shore.
+But I snatched up a long pole and kept the ship off, making signs to my
+men by nodding my head, that they must row for their lives, whereon they
+laid out with a will. When we had got twice as far as we were before, I
+was for jeering at the Cyclops again, but the men begged and prayed of
+me to hold my tongue.
+
+"'Do not,' they exclaimed, 'be mad enough to provoke this savage
+creature further; he has thrown one rock at us already which drove us
+back again to the mainland, and we made sure it had been the death
+of us; if he had then heard any further sound of voices he would have
+pounded our heads and our ship's timbers into a jelly with the rugged
+rocks he would have heaved at us, for he can throw them a long way.'
+
+"But I would not listen to them, and shouted out to him in my rage,
+'Cyclops, if any one asks you who it was that put your eye out and
+spoiled your beauty, say it was the valiant warrior Ulysses, son of
+Laertes, who lives in Ithaca.'
+
+"On this he groaned, and cried out, 'Alas, alas, then the old prophecy
+about me is coming true. There was a prophet here, at one time, a man
+both brave and of great stature, Telemus son of Eurymus, who was an
+excellent seer, and did all the prophesying for the Cyclopes till he
+grew old; he told me that all this would happen to me some day, and said
+I should lose my sight by the hand of Ulysses. I have been all along
+expecting some one of imposing presence and superhuman strength, whereas
+he turns out to be a little insignificant weakling, who has managed to
+blind my eye by taking advantage of me in my drink; come here, then,
+Ulysses, that I may make you presents to show my hospitality, and urge
+Neptune to help you forward on your journey--for Neptune and I are
+father and son. He, if he so will, shall heal me, which no one else
+neither god nor man can do.'
+
+"Then I said, 'I wish I could be as sure of killing you outright and
+sending you down to the house of Hades, as I am that it will take more
+than Neptune to cure that eye of yours.'
+
+"On this he lifted up his hands to the firmament of heaven and prayed,
+saying, 'Hear me, great Neptune; if I am indeed your own true begotten
+son, grant that Ulysses may never reach his home alive; or if he must
+get back to his friends at last, let him do so late and in sore plight
+after losing all his men [let him reach his home in another man's ship
+and find trouble in his house.'] {82}
+
+"Thus did he pray, and Neptune heard his prayer. Then he picked up
+a rock much larger than the first, swung it aloft and hurled it with
+prodigious force. It fell just short of the ship, but was within a
+little of hitting the end of the rudder. The sea quaked as the rock fell
+into it, and the wash of the wave it raised drove us onwards on our way
+towards the shore of the island.
+
+"When at last we got to the island where we had left the rest of our
+ships, we found our comrades lamenting us, and anxiously awaiting our
+return. We ran our vessel upon the sands and got out of her on to the
+sea shore; we also landed the Cyclops' sheep, and divided them equitably
+amongst us so that none might have reason to complain. As for the ram,
+my companions agreed that I should have it as an extra share; so I
+sacrificed it on the sea shore, and burned its thigh bones to Jove, who
+is the lord of all. But he heeded not my sacrifice, and only thought how
+he might destroy both my ships and my comrades.
+
+"Thus through the livelong day to the going down of the sun we feasted
+our fill on meat and drink, but when the sun went down and it came on
+dark, we camped upon the beach. When the child of morning rosy-fingered
+Dawn appeared, I bade my men on board and loose the hawsers. Then they
+took their places and smote the grey sea with their oars; so we sailed
+on with sorrow in our hearts, but glad to have escaped death though we
+had lost our comrades.
+
+
+Book X
+
+AEOLUS, THE LAESTRYGONES, CIRCE.
+
+"Thence we went on to the Aeolian island where lives Aeolus son of
+Hippotas, dear to the immortal gods. It is an island that floats (as
+it were) upon the sea, {83} iron bound with a wall that girds it. Now,
+Aeolus has six daughters and six lusty sons, so he made the sons marry
+the daughters, and they all live with their dear father and mother,
+feasting and enjoying every conceivable kind of luxury. All day long the
+atmosphere of the house is loaded with the savour of roasting meats till
+it groans again, yard and all; but by night they sleep on their well
+made bedsteads, each with his own wife between the blankets. These were
+the people among whom we had now come.
+
+"Aeolus entertained me for a whole month asking me questions all the
+time about Troy, the Argive fleet, and the return of the Achaeans. I
+told him exactly how everything had happened, and when I said I must go,
+and asked him to further me on my way, he made no sort of difficulty,
+but set about doing so at once. Moreover, he flayed me a prime ox-hide
+to hold the ways of the roaring winds, which he shut up in the hide as
+in a sack--for Jove had made him captain over the winds, and he could
+stir or still each one of them according to his own pleasure. He put
+the sack in the ship and bound the mouth so tightly with a silver thread
+that not even a breath of a side-wind could blow from any quarter. The
+West wind which was fair for us did he alone let blow as it chose; but
+it all came to nothing, for we were lost through our own folly.
+
+"Nine days and nine nights did we sail, and on the tenth day our native
+land showed on the horizon. We got so close in that we could see the
+stubble fires burning, and I, being then dead beat, fell into a light
+sleep, for I had never let the rudder out of my own hands, that we might
+get home the faster. On this the men fell to talking among themselves,
+and said I was bringing back gold and silver in the sack that Aeolus
+had given me. 'Bless my heart,' would one turn to his neighbour, saying,
+'how this man gets honoured and makes friends to whatever city or
+country he may go. See what fine prizes he is taking home from Troy,
+while we, who have travelled just as far as he has, come back with hands
+as empty as we set out with--and now Aeolus has given him ever so much
+more. Quick--let us see what it all is, and how much gold and silver
+there is in the sack he gave him.'
+
+"Thus they talked and evil counsels prevailed. They loosed the sack,
+whereupon the wind flew howling forth and raised a storm that carried us
+weeping out to sea and away from our own country. Then I awoke, and knew
+not whether to throw myself into the sea or to live on and make the best
+of it; but I bore it, covered myself up, and lay down in the ship, while
+the men lamented bitterly as the fierce winds bore our fleet back to the
+Aeolian island.
+
+"When we reached it we went ashore to take in water, and dined hard by
+the ships. Immediately after dinner I took a herald and one of my men
+and went straight to the house of Aeolus, where I found him feasting
+with his wife and family; so we sat down as suppliants on the threshold.
+They were astounded when they saw us and said, 'Ulysses, what brings you
+here? What god has been ill-treating you? We took great pains to further
+you on your way home to Ithaca, or wherever it was that you wanted to go
+to.'
+
+"Thus did they speak, but I answered sorrowfully, 'My men have undone
+me; they, and cruel sleep, have ruined me. My friends, mend me this
+mischief, for you can if you will.'
+
+"I spoke as movingly as I could, but they said nothing, till their
+father answered, 'Vilest of mankind, get you gone at once out of the
+island; him whom heaven hates will I in no wise help. Be off, for you
+come here as one abhorred of heaven.' And with these words he sent me
+sorrowing from his door.
+
+"Thence we sailed sadly on till the men were worn out with long and
+fruitless rowing, for there was no longer any wind to help them. Six
+days, night and day did we toil, and on the seventh day we reached the
+rocky stronghold of Lamus--Telepylus, the city of the Laestrygonians,
+where the shepherd who is driving in his sheep and goats [to be milked]
+salutes him who is driving out his flock [to feed] and this last answers
+the salute. In that country a man who could do without sleep might earn
+double wages, one as a herdsman of cattle, and another as a shepherd,
+for they work much the same by night as they do by day. {84}
+
+"When we reached the harbour we found it land-locked under steep cliffs,
+with a narrow entrance between two headlands. My captains took all their
+ships inside, and made them fast close to one another, for there was
+never so much as a breath of wind inside, but it was always dead calm. I
+kept my own ship outside, and moored it to a rock at the very end of the
+point; then I climbed a high rock to reconnoitre, but could see no sign
+neither of man nor cattle, only some smoke rising from the ground. So I
+sent two of my company with an attendant to find out what sort of people
+the inhabitants were.
+
+"The men when they got on shore followed a level road by which the
+people draw their firewood from the mountains into the town, till
+presently they met a young woman who had come outside to fetch water,
+and who was daughter to a Laestrygonian named Antiphates. She was going
+to the fountain Artacia from which the people bring in their water, and
+when my men had come close up to her, they asked her who the king of
+that country might be, and over what kind of people he ruled; so she
+directed them to her father's house, but when they got there they found
+his wife to be a giantess as huge as a mountain, and they were horrified
+at the sight of her.
+
+"She at once called her husband Antiphates from the place of assembly,
+and forthwith he set about killing my men. He snatched up one of them,
+and began to make his dinner off him then and there, whereon the other
+two ran back to the ships as fast as ever they could. But Antiphates
+raised a hue-and-cry after them, and thousands of sturdy Laestrygonians
+sprang up from every quarter--ogres, not men. They threw vast rocks at
+us from the cliffs as though they had been mere stones, and I heard
+the horrid sound of the ships crunching up against one another, and the
+death cries of my men, as the Laestrygonians speared them like fishes
+and took them home to eat them. While they were thus killing my men
+within the harbour I drew my sword, cut the cable of my own ship, and
+told my men to row with all their might if they too would not fare like
+the rest; so they laid out for their lives, and we were thankful enough
+when we got into open water out of reach of the rocks they hurled at us.
+As for the others there was not one of them left.
+
+"Thence we sailed sadly on, glad to have escaped death, though we had
+lost our comrades, and came to the Aeaean island, where Circe lives--a
+great and cunning goddess who is own sister to the magician Aeetes--for
+they are both children of the sun by Perse, who is daughter to Oceanus.
+We brought our ship into a safe harbour without a word, for some god
+guided us thither, and having landed we lay there for two days and two
+nights, worn out in body and mind. When the morning of the third day
+came I took my spear and my sword, and went away from the ship to
+reconnoitre, and see if I could discover signs of human handiwork,
+or hear the sound of voices. Climbing to the top of a high look-out I
+espied the smoke of Circe's house rising upwards amid a dense forest of
+trees, and when I saw this I doubted whether, having seen the smoke, I
+would not go on at once and find out more, but in the end I deemed it
+best to go back to the ship, give the men their dinners, and send some
+of them instead of going myself.
+
+"When I had nearly got back to the ship some god took pity upon my
+solitude, and sent a fine antlered stag right into the middle of my
+path. He was coming down his pasture in the forest to drink of the
+river, for the heat of the sun drove him, and as he passed I struck
+him in the middle of the back; the bronze point of the spear went clean
+through him, and he lay groaning in the dust until the life went out of
+him. Then I set my foot upon him, drew my spear from the wound, and laid
+it down; I also gathered rough grass and rushes and twisted them into a
+fathom or so of good stout rope, with which I bound the four feet of
+the noble creature together; having so done I hung him round my neck and
+walked back to the ship leaning upon my spear, for the stag was much too
+big for me to be able to carry him on my shoulder, steadying him with
+one hand. As I threw him down in front of the ship, I called the men
+and spoke cheeringly man by man to each of them. 'Look here my friends,'
+said I, 'we are not going to die so much before our time after all, and
+at any rate we will not starve so long as we have got something to eat
+and drink on board.' On this they uncovered their heads upon the sea
+shore and admired the stag, for he was indeed a splendid fellow. Then,
+when they had feasted their eyes upon him sufficiently, they washed
+their hands and began to cook him for dinner.
+
+"Thus through the livelong day to the going down of the sun we stayed
+there eating and drinking our fill, but when the sun went down and it
+came on dark, we camped upon the sea shore. When the child of morning,
+rosy-fingered Dawn, appeared, I called a council and said, 'My friends,
+we are in very great difficulties; listen therefore to me. We have no
+idea where the sun either sets or rises, {85} so that we do not even
+know East from West. I see no way out of it; nevertheless, we must try
+and find one. We are certainly on an island, for I went as high as
+I could this morning, and saw the sea reaching all round it to the
+horizon; it lies low, but towards the middle I saw smoke rising from out
+of a thick forest of trees.'
+
+"Their hearts sank as they heard me, for they remembered how they had
+been treated by the Laestrygonian Antiphates, and by the savage ogre
+Polyphemus. They wept bitterly in their dismay, but there was nothing to
+be got by crying, so I divided them into two companies and set a captain
+over each; I gave one company to Eurylochus, while I took command of
+the other myself. Then we cast lots in a helmet, and the lot fell upon
+Eurylochus; so he set out with his twenty-two men, and they wept, as
+also did we who were left behind.
+
+"When they reached Circe's house they found it built of cut stones, on
+a site that could be seen from far, in the middle of the forest.
+There were wild mountain wolves and lions prowling all round it--poor
+bewitched creatures whom she had tamed by her enchantments and drugged
+into subjection. They did not attack my men, but wagged their great
+tails, fawned upon them, and rubbed their noses lovingly against them.
+{86} As hounds crowd round their master when they see him coming from
+dinner--for they know he will bring them something--even so did these
+wolves and lions with their great claws fawn upon my men, but the men
+were terribly frightened at seeing such strange creatures. Presently
+they reached the gates of the goddess's house, and as they stood there
+they could hear Circe within, singing most beautifully as she worked at
+her loom, making a web so fine, so soft, and of such dazzling colours
+as no one but a goddess could weave. On this Polites, whom I valued and
+trusted more than any other of my men, said, 'There is some one inside
+working at a loom and singing most beautifully; the whole place resounds
+with it, let us call her and see whether she is woman or goddess.'
+
+"They called her and she came down, unfastened the door, and bade them
+enter. They, thinking no evil, followed her, all except Eurylochus, who
+suspected mischief and staid outside. When she had got them into her
+house, she set them upon benches and seats and mixed them a mess with
+cheese, honey, meal, and Pramnian wine, but she drugged it with wicked
+poisons to make them forget their homes, and when they had drunk she
+turned them into pigs by a stroke of her wand, and shut them up in her
+pig-styes. They were like pigs--head, hair, and all, and they grunted
+just as pigs do; but their senses were the same as before, and they
+remembered everything.
+
+"Thus then were they shut up squealing, and Circe threw them some acorns
+and beech masts such as pigs eat, but Eurylochus hurried back to tell me
+about the sad fate of our comrades. He was so overcome with dismay
+that though he tried to speak he could find no words to do so; his eyes
+filled with tears and he could only sob and sigh, till at last we forced
+his story out of him, and he told us what had happened to the others.
+
+"'We went,' said he, 'as you told us, through the forest, and in the
+middle of it there was a fine house built with cut stones in a place
+that could be seen from far. There we found a woman, or else she was a
+goddess, working at her loom and singing sweetly; so the men shouted to
+her and called her, whereon she at once came down, opened the door, and
+invited us in. The others did not suspect any mischief so they followed
+her into the house, but I staid where I was, for I thought there might
+be some treachery. From that moment I saw them no more, for not one of
+them ever came out, though I sat a long time watching for them.'
+
+"Then I took my sword of bronze and slung it over my shoulders; I also
+took my bow, and told Eurylochus to come back with me and shew me the
+way. But he laid hold of me with both his hands and spoke piteously,
+saying, 'Sir, do not force me to go with you, but let me stay here, for
+I know you will not bring one of them back with you, nor even return
+alive yourself; let us rather see if we cannot escape at any rate with
+the few that are left us, for we may still save our lives.'
+
+"'Stay where you are, then,' answered I, 'eating and drinking at the
+ship, but I must go, for I am most urgently bound to do so.'
+
+"With this I left the ship and went up inland. When I got through the
+charmed grove, and was near the great house of the enchantress Circe,
+I met Mercury with his golden wand, disguised as a young man in the
+hey-day of his youth and beauty with the down just coming upon his
+face. He came up to me and took my hand within his own, saying, 'My poor
+unhappy man, whither are you going over this mountain top, alone and
+without knowing the way? Your men are shut up in Circe's pigstyes, like
+so many wild boars in their lairs. You surely do not fancy that you can
+set them free? I can tell you that you will never get back and will have
+to stay there with the rest of them. But never mind, I will protect
+you and get you out of your difficulty. Take this herb, which is one
+of great virtue, and keep it about you when you go to Circe's house, it
+will be a talisman to you against every kind of mischief.
+
+"'And I will tell you of all the wicked witchcraft that Circe will try
+to practice upon you. She will mix a mess for you to drink, and she will
+drug the meal with which she makes it, but she will not be able to charm
+you, for the virtue of the herb that I shall give you will prevent her
+spells from working. I will tell you all about it. When Circe strikes
+you with her wand, draw your sword and spring upon her as though you
+were going to kill her. She will then be frightened, and will desire you
+to go to bed with her; on this you must not point blank refuse her, for
+you want her to set your companions free, and to take good care also of
+yourself, but you must make her swear solemnly by all the blessed gods
+that she will plot no further mischief against you, or else when she has
+got you naked she will unman you and make you fit for nothing.'
+
+"As he spoke he pulled the herb out of the ground and shewed me what it
+was like. The root was black, while the flower was as white as milk; the
+gods call it Moly, and mortal men cannot uproot it, but the gods can do
+whatever they like.
+
+"Then Mercury went back to high Olympus passing over the wooded island;
+but I fared onward to the house of Circe, and my heart was clouded with
+care as I walked along. When I got to the gates I stood there and called
+the goddess, and as soon as she heard me she came down, opened the door,
+and asked me to come in; so I followed her--much troubled in my mind.
+She set me on a richly decorated seat inlaid with silver, there was a
+footstool also under my feet, and she mixed a mess in a golden goblet
+for me to drink; but she drugged it, for she meant me mischief. When she
+had given it me, and I had drunk it without its charming me, she struck
+me with her wand. 'There now,' she cried, 'be off to the pigstye, and
+make your lair with the rest of them.'
+
+"But I rushed at her with my sword drawn as though I would kill her,
+whereon she fell with a loud scream, clasped my knees, and spoke
+piteously, saying, 'Who and whence are you? from what place and people
+have you come? How can it be that my drugs have no power to charm you?
+Never yet was any man able to stand so much as a taste of the herb I
+gave you; you must be spell-proof; surely you can be none other than the
+bold hero Ulysses, who Mercury always said would come here some day with
+his ship while on his way home from Troy; so be it then; sheathe your
+sword and let us go to bed, that we may make friends and learn to trust
+each other.'
+
+"And I answered, 'Circe, how can you expect me to be friendly with you
+when you have just been turning all my men into pigs? And now that you
+have got me here myself, you mean me mischief when you ask me to go to
+bed with you, and will unman me and make me fit for nothing. I shall
+certainly not consent to go to bed with you unless you will first take
+your solemn oath to plot no further harm against me.'
+
+"So she swore at once as I had told her, and when she had completed her
+oath then I went to bed with her.
+
+"Meanwhile her four servants, who are her housemaids, set about their
+work. They are the children of the groves and fountains, and of the
+holy waters that run down into the sea. One of them spread a fair purple
+cloth over a seat, and laid a carpet underneath it. Another brought
+tables of silver up to the seats, and set them with baskets of gold. A
+third mixed some sweet wine with water in a silver bowl and put golden
+cups upon the tables, while the fourth brought in water and set it to
+boil in a large cauldron over a good fire which she had lighted. When
+the water in the cauldron was boiling, {87} she poured cold into it
+till it was just as I liked it, and then she set me in a bath and began
+washing me from the cauldron about the head and shoulders, to take the
+tire and stiffness out of my limbs. As soon as she had done washing me
+and anointing me with oil, she arrayed me in a good cloak and shirt
+and led me to a richly decorated seat inlaid with silver; there was a
+footstool also under my feet. A maid servant then brought me water in a
+beautiful golden ewer and poured it into a silver basin for me to wash
+my hands, and she drew a clean table beside me; an upper servant brought
+me bread and offered me many things of what there was in the house, and
+then Circe bade me eat, but I would not, and sat without heeding what
+was before me, still moody and suspicious.
+
+"When Circe saw me sitting there without eating, and in great grief, she
+came to me and said, 'Ulysses, why do you sit like that as though you
+were dumb, gnawing at your own heart, and refusing both meat and drink?
+Is it that you are still suspicious? You ought not to be, for I have
+already sworn solemnly that I will not hurt you.'
+
+"And I said, 'Circe, no man with any sense of what is right can think of
+either eating or drinking in your house until you have set his friends
+free and let him see them. If you want me to eat and drink, you must
+free my men and bring them to me that I may see them with my own eyes.'
+
+"When I had said this she went straight through the court with her wand
+in her hand and opened the pigstye doors. My men came out like so many
+prime hogs and stood looking at her, but she went about among them and
+anointed each with a second drug, whereon the bristles that the bad drug
+had given them fell off, and they became men again, younger than they
+were before, and much taller and better looking. They knew me at once,
+seized me each of them by the hand, and wept for joy till the whole
+house was filled with the sound of their halloa-ballooing, and Circe
+herself was so sorry for them that she came up to me and said, 'Ulysses,
+noble son of Laertes, go back at once to the sea where you have left
+your ship, and first draw it on to the land. Then, hide all your ship's
+gear and property in some cave, and come back here with your men.'
+
+"I agreed to this, so I went back to the sea shore, and found the men at
+the ship weeping and wailing most piteously. When they saw me the silly
+blubbering fellows began frisking round me as calves break out and
+gambol round their mothers, when they see them coming home to be milked
+after they have been feeding all day, and the homestead resounds with
+their lowing. They seemed as glad to see me as though they had got back
+to their own rugged Ithaca, where they had been born and bred. 'Sir,'
+said the affectionate creatures, 'we are as glad to see you back as
+though we had got safe home to Ithaca; but tell us all about the fate of
+our comrades.'
+
+"I spoke comfortingly to them and said, 'We must draw our ship on to the
+land, and hide the ship's gear with all our property in some cave; then
+come with me all of you as fast as you can to Circe's house, where
+you will find your comrades eating and drinking in the midst of great
+abundance.'
+
+"On this the men would have come with me at once, but Eurylochus tried
+to hold them back and said, 'Alas, poor wretches that we are, what will
+become of us? Rush not on your ruin by going to the house of Circe, who
+will turn us all into pigs or wolves or lions, and we shall have to
+keep guard over her house. Remember how the Cyclops treated us when our
+comrades went inside his cave, and Ulysses with them. It was all through
+his sheer folly that those men lost their lives.'
+
+"When I heard him I was in two minds whether or no to draw the keen
+blade that hung by my sturdy thigh and cut his head off in spite of
+his being a near relation of my own; but the men interceded for him
+and said, 'Sir, if it may so be, let this fellow stay here and mind the
+ship, but take the rest of us with you to Circe's house.'
+
+"On this we all went inland, and Eurylochus was not left behind after
+all, but came on too, for he was frightened by the severe reprimand that
+I had given him.
+
+"Meanwhile Circe had been seeing that the men who had been left behind
+were washed and anointed with olive oil; she had also given them woollen
+cloaks and shirts, and when we came we found them all comfortably at
+dinner in her house. As soon as the men saw each other face to face
+and knew one another, they wept for joy and cried aloud till the whole
+palace rang again. Thereon Circe came up to me and said, 'Ulysses, noble
+son of Laertes, tell your men to leave off crying; I know how much you
+have all of you suffered at sea, and how ill you have fared among cruel
+savages on the mainland, but that is over now, so stay here, and eat and
+drink till you are once more as strong and hearty as you were when you
+left Ithaca; for at present you are weakened both in body and mind; you
+keep all the time thinking of the hardships you have suffered during
+your travels, so that you have no more cheerfulness left in you.'
+
+"Thus did she speak and we assented. We stayed with Circe for a whole
+twelvemonth feasting upon an untold quantity both of meat and wine. But
+when the year had passed in the waning of moons and the long days had
+come round, my men called me apart and said, 'Sir, it is time you began
+to think about going home, if so be you are to be spared to see your
+house and native country at all.'
+
+"Thus did they speak and I assented. Thereon through the livelong day to
+the going down of the sun we feasted our fill on meat and wine, but when
+the sun went down and it came on dark the men laid themselves down to
+sleep in the covered cloisters. I, however, after I had got into bed
+with Circe, besought her by her knees, and the goddess listened to what
+I had got to say. 'Circe,' said I, 'please to keep the promise you made
+me about furthering me on my homeward voyage. I want to get back and so
+do my men, they are always pestering me with their complaints as soon as
+ever your back is turned.'
+
+"And the goddess answered, 'Ulysses, noble son of Laertes, you shall
+none of you stay here any longer if you do not want to, but there
+is another journey which you have got to take before you can sail
+homewards. You must go to the house of Hades and of dread Proserpine to
+consult the ghost of the blind Theban prophet Teiresias, whose reason is
+still unshaken. To him alone has Proserpine left his understanding even
+in death, but the other ghosts flit about aimlessly.'
+
+"I was dismayed when I heard this. I sat up in bed and wept, and would
+gladly have lived no longer to see the light of the sun, but presently
+when I was tired of weeping and tossing myself about, I said, 'And who
+shall guide me upon this voyage--for the house of Hades is a port that
+no ship can reach.'
+
+"'You will want no guide,' she answered; 'raise your mast, set your
+white sails, sit quite still, and the North Wind will blow you there
+of itself. When your ship has traversed the waters of Oceanus, you will
+reach the fertile shore of Proserpine's country with its groves of tall
+poplars and willows that shed their fruit untimely; here beach your
+ship upon the shore of Oceanus, and go straight on to the dark abode of
+Hades. You will find it near the place where the rivers Pyriphlegethon
+and Cocytus (which is a branch of the river Styx) flow into Acheron, and
+you will see a rock near it, just where the two roaring rivers run into
+one another.
+
+"'When you have reached this spot, as I now tell you, dig a trench
+a cubit or so in length, breadth, and depth, and pour into it as a
+drink-offering to all the dead, first, honey mixed with milk, then wine,
+and in the third place water--sprinkling white barley meal over the
+whole. Moreover you must offer many prayers to the poor feeble ghosts,
+and promise them that when you get back to Ithaca you will sacrifice a
+barren heifer to them, the best you have, and will load the pyre with
+good things. More particularly you must promise that Teiresias shall
+have a black sheep all to himself, the finest in all your flocks.
+
+"'When you shall have thus besought the ghosts with your prayers, offer
+them a ram and a black ewe, bending their heads towards Erebus; but
+yourself turn away from them as though you would make towards the river.
+On this, many dead men's ghosts will come to you, and you must tell your
+men to skin the two sheep that you have just killed, and offer them as a
+burnt sacrifice with prayers to Hades and to Proserpine. Then draw your
+sword and sit there, so as to prevent any other poor ghost from
+coming near the spilt blood before Teiresias shall have answered your
+questions. The seer will presently come to you, and will tell you about
+your voyage--what stages you are to make, and how you are to sail the
+sea so as to reach your home.'
+
+"It was day-break by the time she had done speaking, so she dressed
+me in my shirt and cloak. As for herself she threw a beautiful light
+gossamer fabric over her shoulders, fastening it with a golden girdle
+round her waist, and she covered her head with a mantle. Then I went
+about among the men everywhere all over the house, and spoke kindly to
+each of them man by man: 'You must not lie sleeping here any longer,'
+said I to them, 'we must be going, for Circe has told me all about it.'
+And on this they did as I bade them.
+
+"Even so, however, I did not get them away without misadventure. We had
+with us a certain youth named Elpenor, not very remarkable for sense or
+courage, who had got drunk and was lying on the house-top away from the
+rest of the men, to sleep off his liquor in the cool. When he heard the
+noise of the men bustling about, he jumped up on a sudden and forgot
+all about coming down by the main staircase, so he tumbled right off the
+roof and broke his neck, and his soul went down to the house of Hades.
+
+"When I had got the men together I said to them, 'You think you are
+about to start home again, but Circe has explained to me that instead of
+this, we have got to go to the house of Hades and Proserpine to consult
+the ghost of the Theban prophet Teiresias.'
+
+"The men were broken-hearted as they heard me, and threw themselves
+on the ground groaning and tearing their hair, but they did not mend
+matters by crying. When we reached the sea shore, weeping and lamenting
+our fate, Circe brought the ram and the ewe, and we made them fast hard
+by the ship. She passed through the midst of us without our knowing it,
+for who can see the comings and goings of a god, if the god does not
+wish to be seen?
+
+
+Book XI
+
+THE VISIT TO THE DEAD. {88}
+
+"Then, when we had got down to the sea shore we drew our ship into the
+water and got her mast and sails into her; we also put the sheep on
+board and took our places, weeping and in great distress of mind. Circe,
+that great and cunning goddess, sent us a fair wind that blew dead aft
+and staid steadily with us keeping our sails all the time well filled;
+so we did whatever wanted doing to the ship's gear and let her go as the
+wind and helmsman headed her. All day long her sails were full as she
+held her course over the sea, but when the sun went down and darkness
+was over all the earth, we got into the deep waters of the river
+Oceanus, where lie the land and city of the Cimmerians who live
+enshrouded in mist and darkness which the rays of the sun never pierce
+neither at his rising nor as he goes down again out of the heavens, but
+the poor wretches live in one long melancholy night. When we got there
+we beached the ship, took the sheep out of her, and went along by the
+waters of Oceanus till we came to the place of which Circe had told us.
+
+"Here Perimedes and Eurylochus held the victims, while I drew my sword
+and dug the trench a cubit each way. I made a drink-offering to all the
+dead, first with honey and milk, then with wine, and thirdly with water,
+and I sprinkled white barley meal over the whole, praying earnestly to
+the poor feckless ghosts, and promising them that when I got back to
+Ithaca I would sacrifice a barren heifer for them, the best I had, and
+would load the pyre with good things. I also particularly promised
+that Teiresias should have a black sheep to himself, the best in all my
+flocks. When I had prayed sufficiently to the dead, I cut the throats of
+the two sheep and let the blood run into the trench, whereon the ghosts
+came trooping up from Erebus--brides, {89} young bachelors, old men worn
+out with toil, maids who had been crossed in love, and brave men who had
+been killed in battle, with their armour still smirched with blood; they
+came from every quarter and flitted round the trench with a strange kind
+of screaming sound that made me turn pale with fear. When I saw them
+coming I told the men to be quick and flay the carcasses of the two dead
+sheep and make burnt offerings of them, and at the same time to repeat
+prayers to Hades and to Proserpine; but I sat where I was with my sword
+drawn and would not let the poor feckless ghosts come near the blood
+till Teiresias should have answered my questions.
+
+"The first ghost that came was that of my comrade Elpenor, for he had
+not yet been laid beneath the earth. We had left his body unwaked and
+unburied in Circe's house, for we had had too much else to do. I was
+very sorry for him, and cried when I saw him: 'Elpenor,' said I, 'how
+did you come down here into this gloom and darkness? You have got here
+on foot quicker than I have with my ship.'
+
+"'Sir,' he answered with a groan, 'it was all bad luck, and my own
+unspeakable drunkenness. I was lying asleep on the top of Circe's house,
+and never thought of coming down again by the great staircase but fell
+right off the roof and broke my neck, so my soul came down to the house
+of Hades. And now I beseech you by all those whom you have left behind
+you, though they are not here, by your wife, by the father who brought
+you up when you were a child, and by Telemachus who is the one hope of
+your house, do what I shall now ask you. I know that when you leave this
+limbo you will again hold your ship for the Aeaean island. Do not
+go thence leaving me unwaked and unburied behind you, or I may bring
+heaven's anger upon you; but burn me with whatever armour I have, build
+a barrow for me on the sea shore, that may tell people in days to come
+what a poor unlucky fellow I was, and plant over my grave the oar I used
+to row with when I was yet alive and with my messmates.' And I said, 'My
+poor fellow, I will do all that you have asked of me.'
+
+"Thus, then, did we sit and hold sad talk with one another, I on the one
+side of the trench with my sword held over the blood, and the ghost
+of my comrade saying all this to me from the other side. Then came the
+ghost of my dead mother Anticlea, daughter to Autolycus. I had left her
+alive when I set out for Troy and was moved to tears when I saw her, but
+even so, for all my sorrow I would not let her come near the blood till
+I had asked my questions of Teiresias.
+
+"Then came also the ghost of Theban Teiresias, with his golden sceptre
+in his hand. He knew me and said, 'Ulysses, noble son of Laertes, why,
+poor man, have you left the light of day and come down to visit the dead
+in this sad place? Stand back from the trench and withdraw your sword
+that I may drink of the blood and answer your questions truly.'
+
+"So I drew back, and sheathed my sword, whereon when he had drank of the
+blood he began with his prophecy.
+
+"'You want to know,' said he, 'about your return home, but heaven will
+make this hard for you. I do not think that you will escape the eye
+of Neptune, who still nurses his bitter grudge against you for having
+blinded his son. Still, after much suffering you may get home if you
+can restrain yourself and your companions when your ship reaches the
+Thrinacian island, where you will find the sheep and cattle belonging to
+the sun, who sees and gives ear to everything. If you leave these flocks
+unharmed and think of nothing but of getting home, you may yet after
+much hardship reach Ithaca; but if you harm them, then I forewarn you of
+the destruction both of your ship and of your men. Even though you may
+yourself escape, you will return in bad plight after losing all your
+men, [in another man's ship, and you will find trouble in your house,
+which will be overrun by high-handed people, who are devouring your
+substance under the pretext of paying court and making presents to your
+wife.
+
+"'When you get home you will take your revenge on these suitors; and
+after you have killed them by force or fraud in your own house, you must
+take a well made oar and carry it on and on, till you come to a country
+where the people have never heard of the sea and do not even mix salt
+with their food, nor do they know anything about ships, and oars that
+are as the wings of a ship. I will give you this certain token which
+cannot escape your notice. A wayfarer will meet you and will say it must
+be a winnowing shovel that you have got upon your shoulder; on this you
+must fix the oar in the ground and sacrifice a ram, a bull, and a boar
+to Neptune. {90} Then go home and offer hecatombs to all the gods in
+heaven one after the other. As for yourself, death shall come to you
+from the sea, and your life shall ebb away very gently when you are full
+of years and peace of mind, and your people shall bless you. All that I
+have said will come true].' {91}
+
+"'This,' I answered, 'must be as it may please heaven, but tell me and
+tell me and tell me true, I see my poor mother's ghost close by us; she
+is sitting by the blood without saying a word, and though I am her own
+son she does not remember me and speak to me; tell me, Sir, how I can
+make her know me.'
+
+"'That,' said he, 'I can soon do. Any ghost that you let taste of the
+blood will talk with you like a reasonable being, but if you do not let
+them have any blood they will go away again.'
+
+"On this the ghost of Teiresias went back to the house of Hades, for his
+prophecyings had now been spoken, but I sat still where I was until my
+mother came up and tasted the blood. Then she knew me at once and spoke
+fondly to me, saying, 'My son, how did you come down to this abode of
+darkness while you are still alive? It is a hard thing for the living to
+see these places, for between us and them there are great and terrible
+waters, and there is Oceanus, which no man can cross on foot, but he
+must have a good ship to take him. Are you all this time trying to find
+your way home from Troy, and have you never yet got back to Ithaca nor
+seen your wife in your own house?'
+
+"'Mother,' said I, 'I was forced to come here to consult the ghost of
+the Theban prophet Teiresias. I have never yet been near the Achaean
+land nor set foot on my native country, and I have had nothing but one
+long series of misfortunes from the very first day that I set out with
+Agamemnon for Ilius, the land of noble steeds, to fight the Trojans. But
+tell me, and tell me true, in what way did you die? Did you have a long
+illness, or did heaven vouchsafe you a gentle easy passage to eternity?
+Tell me also about my father, and the son whom I left behind me, is my
+property still in their hands, or has some one else got hold of it, who
+thinks that I shall not return to claim it? Tell me again what my wife
+intends doing, and in what mind she is; does she live with my son and
+guard my estate securely, or has she made the best match she could and
+married again?'
+
+"My mother answered, 'Your wife still remains in your house, but she is
+in great distress of mind and spends her whole time in tears both night
+and day. No one as yet has got possession of your fine property, and
+Telemachus still holds your lands undisturbed. He has to entertain
+largely, as of course he must, considering his position as a magistrate,
+{92} and how every one invites him; your father remains at his old place
+in the country and never goes near the town. He has no comfortable bed
+nor bedding; in the winter he sleeps on the floor in front of the fire
+with the men and goes about all in rags, but in summer, when the warm
+weather comes on again, he lies out in the vineyard on a bed of vine
+leaves thrown any how upon the ground. He grieves continually about your
+never having come home, and suffers more and more as he grows older. As
+for my own end it was in this wise: heaven did not take me swiftly and
+painlessly in my own house, nor was I attacked by any illness such as
+those that generally wear people out and kill them, but my longing to
+know what you were doing and the force of my affection for you--this it
+was that was the death of me.' {93}
+
+"Then I tried to find some way of embracing my poor mother's ghost.
+Thrice I sprang towards her and tried to clasp her in my arms, but each
+time she flitted from my embrace as it were a dream or phantom, and
+being touched to the quick I said to her, 'Mother, why do you not stay
+still when I would embrace you? If we could throw our arms around one
+another we might find sad comfort in the sharing of our sorrows even in
+the house of Hades; does Proserpine want to lay a still further load of
+grief upon me by mocking me with a phantom only?'
+
+"'My son,' she answered, 'most ill-fated of all mankind, it is not
+Proserpine that is beguiling you, but all people are like this when they
+are dead. The sinews no longer hold the flesh and bones together; these
+perish in the fierceness of consuming fire as soon as life has left the
+body, and the soul flits away as though it were a dream. Now, however,
+go back to the light of day as soon as you can, and note all these
+things that you may tell them to your wife hereafter.'
+
+"Thus did we converse, and anon Proserpine sent up the ghosts of the
+wives and daughters of all the most famous men. They gathered in crowds
+about the blood, and I considered how I might question them severally.
+In the end I deemed that it would be best to draw the keen blade that
+hung by my sturdy thigh, and keep them from all drinking the blood at
+once. So they came up one after the other, and each one as I questioned
+her told me her race and lineage.
+
+"The first I saw was Tyro. She was daughter of Salmoneus and wife of
+Cretheus the son of Aeolus. {94} She fell in love with the river Enipeus
+who is much the most beautiful river in the whole world. Once when she
+was taking a walk by his side as usual, Neptune, disguised as her lover,
+lay with her at the mouth of the river, and a huge blue wave arched
+itself like a mountain over them to hide both woman and god, whereon he
+loosed her virgin girdle and laid her in a deep slumber. When the god
+had accomplished the deed of love, he took her hand in his own and
+said, 'Tyro, rejoice in all good will; the embraces of the gods are not
+fruitless, and you will have fine twins about this time twelve months.
+Take great care of them. I am Neptune, so now go home, but hold your
+tongue and do not tell any one.'
+
+"Then he dived under the sea, and she in due course bore Pelias and
+Neleus, who both of them served Jove with all their might. Pelias was
+a great breeder of sheep and lived in Iolcus, but the other lived in
+Pylos. The rest of her children were by Cretheus, namely, Aeson, Pheres,
+and Amythaon, who was a mighty warrior and charioteer.
+
+"Next to her I saw Antiope, daughter to Asopus, who could boast of
+having slept in the arms of even Jove himself, and who bore him two sons
+Amphion and Zethus. These founded Thebes with its seven gates, and built
+a wall all round it; for strong though they were they could not hold
+Thebes till they had walled it.
+
+"Then I saw Alcmena, the wife of Amphitryon, who also bore to Jove
+indomitable Hercules; and Megara who was daughter to great King Creon,
+and married the redoubtable son of Amphitryon.
+
+"I also saw fair Epicaste mother of king Oedipodes whose awful lot it
+was to marry her own son without suspecting it. He married her after
+having killed his father, but the gods proclaimed the whole story to the
+world; whereon he remained king of Thebes, in great grief for the spite
+the gods had borne him; but Epicaste went to the house of the mighty
+jailor Hades, having hanged herself for grief, and the avenging spirits
+haunted him as for an outraged mother--to his ruing bitterly thereafter.
+
+"Then I saw Chloris, whom Neleus married for her beauty, having given
+priceless presents for her. She was youngest daughter to Amphion son of
+Iasus and king of Minyan Orchomenus, and was Queen in Pylos. She bore
+Nestor, Chromius, and Periclymenus, and she also bore that marvellously
+lovely woman Pero, who was wooed by all the country round; but Neleus
+would only give her to him who should raid the cattle of Iphicles from
+the grazing grounds of Phylace, and this was a hard task. The only man
+who would undertake to raid them was a certain excellent seer, {95} but
+the will of heaven was against him, for the rangers of the cattle caught
+him and put him in prison; nevertheless when a full year had passed and
+the same season came round again, Iphicles set him at liberty, after
+he had expounded all the oracles of heaven. Thus, then, was the will of
+Jove accomplished.
+
+"And I saw Leda the wife of Tyndarus, who bore him two famous sons,
+Castor breaker of horses, and Pollux the mighty boxer. Both these heroes
+are lying under the earth, though they are still alive, for by a special
+dispensation of Jove, they die and come to life again, each one of them
+every other day throughout all time, and they have the rank of gods.
+
+"After her I saw Iphimedeia wife of Aloeus who boasted the embrace
+of Neptune. She bore two sons Otus and Ephialtes, but both were short
+lived. They were the finest children that were ever born in this world,
+and the best looking, Orion only excepted; for at nine years old they
+were nine fathoms high, and measured nine cubits round the chest. They
+threatened to make war with the gods in Olympus, and tried to set Mount
+Ossa on the top of Mount Olympus, and Mount Pelion on the top of Ossa,
+that they might scale heaven itself, and they would have done it too if
+they had been grown up, but Apollo, son of Leto, killed both of them,
+before they had got so much as a sign of hair upon their cheeks or chin.
+
+"Then I saw Phaedra, and Procris, and fair Ariadne daughter of the
+magician Minos, whom Theseus was carrying off from Crete to Athens, but
+he did not enjoy her, for before he could do so Diana killed her in the
+island of Dia on account of what Bacchus had said against her.
+
+"I also saw Maera and Clymene and hateful Eriphyle, who sold her own
+husband for gold. But it would take me all night if I were to name every
+single one of the wives and daughters of heroes whom I saw, and it is
+time for me to go to bed, either on board ship with my crew, or here. As
+for my escort, heaven and yourselves will see to it."
+
+Here he ended, and the guests sat all of them enthralled and speechless
+throughout the covered cloister. Then Arete said to them:--
+
+"What do you think of this man, O Phaeacians? Is he not tall and good
+looking, and is he not clever? True, he is my own guest, but all of you
+share in the distinction. Do not be in a hurry to send him away, nor
+niggardly in the presents you make to one who is in such great need, for
+heaven has blessed all of you with great abundance."
+
+Then spoke the aged hero Echeneus who was one of the oldest men among
+them, "My friends," said he, "what our august queen has just said to us
+is both reasonable and to the purpose, therefore be persuaded by it;
+but the decision whether in word or deed rests ultimately with King
+Alcinous."
+
+"The thing shall be done," exclaimed Alcinous, "as surely as I still
+live and reign over the Phaeacians. Our guest is indeed very anxious to
+get home, still we must persuade him to remain with us until to-morrow,
+by which time I shall be able to get together the whole sum that I mean
+to give him. As regards his escort it will be a matter for you all, and
+mine above all others as the chief person among you."
+
+And Ulysses answered, "King Alcinous, if you were to bid me to stay here
+for a whole twelve months, and then speed me on my way, loaded with your
+noble gifts, I should obey you gladly and it would redound greatly to
+my advantage, for I should return fuller-handed to my own people, and
+should thus be more respected and beloved by all who see me when I get
+back to Ithaca."
+
+"Ulysses," replied Alcinous, "not one of us who sees you has any idea
+that you are a charlatan or a swindler. I know there are many people
+going about who tell such plausible stories that it is very hard to see
+through them, but there is a style about your language which assures me
+of your good disposition. Moreover you have told the story of your own
+misfortunes, and those of the Argives, as though you were a practiced
+bard; but tell me, and tell me true, whether you saw any of the mighty
+heroes who went to Troy at the same time with yourself, and perished
+there. The evenings are still at their longest, and it is not yet bed
+time--go on, therefore, with your divine story, for I could stay here
+listening till tomorrow morning, so long as you will continue to tell us
+of your adventures."
+
+"Alcinous," answered Ulysses, "there is a time for making speeches, and
+a time for going to bed; nevertheless, since you so desire, I will not
+refrain from telling you the still sadder tale of those of my comrades
+who did not fall fighting with the Trojans, but perished on their
+return, through the treachery of a wicked woman.
+
+"When Proserpine had dismissed the female ghosts in all directions,
+the ghost of Agamemnon son of Atreus came sadly up to me, surrounded by
+those who had perished with him in the house of Aegisthus. As soon as he
+had tasted the blood, he knew me, and weeping bitterly stretched out his
+arms towards me to embrace me; but he had no strength nor substance any
+more, and I too wept and pitied him as I beheld him. 'How did you come
+by your death,' said I, 'King Agamemnon? Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the main land when you were cattle-lifting or sheep-stealing,
+or while they were fighting in defence of their wives and city?'
+
+"'Ulysses,' he answered, 'noble son of Laertes, I was not lost at sea
+in any storm of Neptune's raising, nor did my foes despatch me upon the
+mainland, but Aegisthus and my wicked wife were the death of me between
+them. He asked me to his house, feasted me, and then butchered me most
+miserably as though I were a fat beast in a slaughter house, while all
+around me my comrades were slain like sheep or pigs for the wedding
+breakfast, or picnic, or gorgeous banquet of some great nobleman. You
+must have seen numbers of men killed either in a general engagement, or
+in single combat, but you never saw anything so truly pitiable as the
+way in which we fell in that cloister, with the mixing bowl and the
+loaded tables lying all about, and the ground reeking with our blood. I
+heard Priam's daughter Cassandra scream as Clytemnestra killed her close
+beside me. I lay dying upon the earth with the sword in my body, and
+raised my hands to kill the slut of a murderess, but she slipped away
+from me; she would not even close my lips nor my eyes when I was dying,
+for there is nothing in this world so cruel and so shameless as a woman
+when she has fallen into such guilt as hers was. Fancy murdering her own
+husband! I thought I was going to be welcomed home by my children and my
+servants, but her abominable crime has brought disgrace on herself and
+all women who shall come after--even on the good ones.'
+
+"And I said, 'In truth Jove has hated the house of Atreus from first to
+last in the matter of their women's counsels. See how many of us fell
+for Helen's sake, and now it seems that Clytemnestra hatched mischief
+against you too during your absence.'
+
+"'Be sure, therefore,' continued Agamemnon, 'and not be too friendly
+even with your own wife. Do not tell her all that you know perfectly
+well yourself. Tell her a part only, and keep your own counsel about the
+rest. Not that your wife, Ulysses, is likely to murder you, for Penelope
+is a very admirable woman, and has an excellent nature. We left her a
+young bride with an infant at her breast when we set out for Troy. This
+child no doubt is now grown up happily to man's estate, {96} and he and
+his father will have a joyful meeting and embrace one another as it is
+right they should do, whereas my wicked wife did not even allow me
+the happiness of looking upon my son, but killed me ere I could do so.
+Furthermore I say--and lay my saying to your heart--do not tell people
+when you are bringing your ship to Ithaca, but steal a march upon them,
+for after all this there is no trusting women. But now tell me, and
+tell me true, can you give me any news of my son Orestes? Is he in
+Orchomenus, or at Pylos, or is he at Sparta with Menelaus--for I presume
+that he is still living.'
+
+"And I said, 'Agamemnon, why do you ask me? I do not know whether your
+son is alive or dead, and it is not right to talk when one does not
+know.'
+
+"As we two sat weeping and talking thus sadly with one another the ghost
+of Achilles came up to us with Patroclus, Antilochus, and Ajax who was
+the finest and goodliest man of all the Danaans after the son of Peleus.
+The fleet descendant of Aeacus knew me and spoke piteously, saying,
+'Ulysses, noble son of Laertes, what deed of daring will you undertake
+next, that you venture down to the house of Hades among us silly dead,
+who are but the ghosts of them that can labour no more?'
+
+"And I said, 'Achilles, son of Peleus, foremost champion of the
+Achaeans, I came to consult Teiresias, and see if he could advise me
+about my return home to Ithaca, for I have never yet been able to get
+near the Achaean land, nor to set foot in my own country, but have been
+in trouble all the time. As for you, Achilles, no one was ever yet so
+fortunate as you have been, nor ever will be, for you were adored by all
+us Argives as long as you were alive, and now that you are here you are
+a great prince among the dead. Do not, therefore, take it so much to
+heart even if you are dead.'
+
+"'Say not a word,' he answered, 'in death's favour; I would rather be
+a paid servant in a poor man's house and be above ground than king of
+kings among the dead. But give me news about my son; is he gone to the
+wars and will he be a great soldier, or is this not so? Tell me also if
+you have heard anything about my father Peleus--does he still rule among
+the Myrmidons, or do they show him no respect throughout Hellas and
+Phthia now that he is old and his limbs fail him? Could I but stand by
+his side, in the light of day, with the same strength that I had when I
+killed the bravest of our foes upon the plain of Troy--could I but be
+as I then was and go even for a short time to my father's house, any one
+who tried to do him violence or supersede him would soon rue it.'
+
+"'I have heard nothing,' I answered, 'of Peleus, but I can tell you all
+about your son Neoptolemus, for I took him in my own ship from Scyros
+with the Achaeans. In our councils of war before Troy he was always
+first to speak, and his judgement was unerring. Nestor and I were the
+only two who could surpass him; and when it came to fighting on the
+plain of Troy, he would never remain with the body of his men, but would
+dash on far in front, foremost of them all in valour. Many a man did
+he kill in battle--I cannot name every single one of those whom he slew
+while fighting on the side of the Argives, but will only say how
+he killed that valiant hero Eurypylus son of Telephus, who was the
+handsomest man I ever saw except Memnon; many others also of the
+Ceteians fell around him by reason of a woman's bribes. Moreover, when
+all the bravest of the Argives went inside the horse that Epeus had
+made, and it was left to me to settle when we should either open the
+door of our ambuscade, or close it, though all the other leaders and
+chief men among the Danaans were drying their eyes and quaking in every
+limb, I never once saw him turn pale nor wipe a tear from his cheek;
+he was all the time urging me to break out from the horse--grasping
+the handle of his sword and his bronze-shod spear, and breathing fury
+against the foe. Yet when we had sacked the city of Priam he got his
+handsome share of the prize money and went on board (such is the fortune
+of war) without a wound upon him, neither from a thrown spear nor in
+close combat, for the rage of Mars is a matter of great chance.'
+
+"When I had told him this, the ghost of Achilles strode off across a
+meadow full of asphodel, exulting over what I had said concerning the
+prowess of his son.
+
+"The ghosts of other dead men stood near me and told me each his own
+melancholy tale; but that of Ajax son of Telamon alone held aloof--still
+angry with me for having won the cause in our dispute about the armour
+of Achilles. Thetis had offered it as a prize, but the Trojan prisoners
+and Minerva were the judges. Would that I had never gained the day in
+such a contest, for it cost the life of Ajax, who was foremost of all
+the Danaans after the son of Peleus, alike in stature and prowess.
+
+"When I saw him I tried to pacify him and said, 'Ajax, will you not
+forget and forgive even in death, but must the judgement about that
+hateful armour still rankle with you? It cost us Argives dear enough to
+lose such a tower of strength as you were to us. We mourned you as much
+as we mourned Achilles son of Peleus himself, nor can the blame be laid
+on anything but on the spite which Jove bore against the Danaans, for it
+was this that made him counsel your destruction--come hither, therefore,
+bring your proud spirit into subjection, and hear what I can tell you.'
+
+"He would not answer, but turned away to Erebus and to the other ghosts;
+nevertheless, I should have made him talk to me in spite of his being
+so angry, or I should have gone on talking to him, {97} only that there
+were still others among the dead whom I desired to see.
+
+"Then I saw Minos son of Jove with his golden sceptre in his hand
+sitting in judgement on the dead, and the ghosts were gathered sitting
+and standing round him in the spacious house of Hades, to learn his
+sentences upon them.
+
+"After him I saw huge Orion in a meadow full of asphodel driving the
+ghosts of the wild beasts that he had killed upon the mountains, and he
+had a great bronze club in his hand, unbreakable for ever and ever.
+
+"And I saw Tityus son of Gaia stretched upon the plain and covering some
+nine acres of ground. Two vultures on either side of him were digging
+their beaks into his liver, and he kept on trying to beat them off with
+his hands, but could not; for he had violated Jove's mistress Leto as
+she was going through Panopeus on her way to Pytho.
+
+"I saw also the dreadful fate of Tantalus, who stood in a lake that
+reached his chin; he was dying to quench his thirst, but could never
+reach the water, for whenever the poor creature stooped to drink, it
+dried up and vanished, so that there was nothing but dry ground--parched
+by the spite of heaven. There were tall trees, moreover, that shed their
+fruit over his head--pears, pomegranates, apples, sweet figs and juicy
+olives, but whenever the poor creature stretched out his hand to take
+some, the wind tossed the branches back again to the clouds.
+
+"And I saw Sisyphus at his endless task raising his prodigious stone
+with both his hands. With hands and feet he tried to roll it up to the
+top of the hill, but always, just before he could roll it over on to the
+other side, its weight would be too much for him, and the pitiless stone
+{98} would come thundering down again on to the plain. Then he would
+begin trying to push it up hill again, and the sweat ran off him and the
+steam rose after him.
+
+"After him I saw mighty Hercules, but it was his phantom only, for he is
+feasting ever with the immortal gods, and has lovely Hebe to wife, who
+is daughter of Jove and Juno. The ghosts were screaming round him like
+scared birds flying all whithers. He looked black as night with his bare
+bow in his hands and his arrow on the string, glaring around as though
+ever on the point of taking aim. About his breast there was a wondrous
+golden belt adorned in the most marvellous fashion with bears, wild
+boars, and lions with gleaming eyes; there was also war, battle, and
+death. The man who made that belt, do what he might, would never be able
+to make another like it. Hercules knew me at once when he saw me, and
+spoke piteously, saying, 'My poor Ulysses, noble son of Laertes, are
+you too leading the same sorry kind of life that I did when I was above
+ground? I was son of Jove, but I went through an infinity of suffering,
+for I became bondsman to one who was far beneath me--a low fellow
+who set me all manner of labours. He once sent me here to fetch the
+hell-hound--for he did not think he could find anything harder for me
+than this, but I got the hound out of Hades and brought him to him, for
+Mercury and Minerva helped me.'
+
+"On this Hercules went down again into the house of Hades, but I stayed
+where I was in case some other of the mighty dead should come to me.
+And I should have seen still other of them that are gone before, whom
+I would fain have seen--Theseus and Pirithous--glorious children of the
+gods, but so many thousands of ghosts came round me and uttered such
+appalling cries, that I was panic stricken lest Proserpine should send
+up from the house of Hades the head of that awful monster Gorgon. On
+this I hastened back to my ship and ordered my men to go on board at
+once and loose the hawsers; so they embarked and took their places,
+whereon the ship went down the stream of the river Oceanus. We had to
+row at first, but presently a fair wind sprang up.
+
+
+Book XII
+
+THE SIRENS, SCYLLA AND CHARYBDIS, THE CATTLE OF THE SUN.
+
+"After we were clear of the river Oceanus, and had got out into the open
+sea, we went on till we reached the Aeaean island where there is dawn
+and sun-rise as in other places. We then drew our ship on to the sands
+and got out of her on to the shore, where we went to sleep and waited
+till day should break.
+
+"Then, when the child of morning, rosy-fingered Dawn, appeared, I sent
+some men to Circe's house to fetch the body of Elpenor. We cut firewood
+from a wood where the headland jutted out into the sea, and after we had
+wept over him and lamented him we performed his funeral rites. When his
+body and armour had been burned to ashes, we raised a cairn, set a stone
+over it, and at the top of the cairn we fixed the oar that he had been
+used to row with.
+
+"While we were doing all this, Circe, who knew that we had got back from
+the house of Hades, dressed herself and came to us as fast as she could;
+and her maid servants came with her bringing us bread, meat, and wine.
+Then she stood in the midst of us and said, 'You have done a bold thing
+in going down alive to the house of Hades, and you will have died twice,
+to other people's once; now, then, stay here for the rest of the
+day, feast your fill, and go on with your voyage at daybreak tomorrow
+morning. In the meantime I will tell Ulysses about your course, and
+will explain everything to him so as to prevent your suffering from
+misadventure either by land or sea.'
+
+"We agreed to do as she had said, and feasted through the livelong day
+to the going down of the sun, but when the sun had set and it came on
+dark, the men laid themselves down to sleep by the stern cables of the
+ship. Then Circe took me by the hand and bade me be seated away from
+the others, while she reclined by my side and asked me all about our
+adventures.
+
+"'So far so good,' said she, when I had ended my story, 'and now pay
+attention to what I am about to tell you--heaven itself, indeed, will
+recall it to your recollection. First you will come to the Sirens who
+enchant all who come near them. If any one unwarily draws in too close
+and hears the singing of the Sirens, his wife and children will never
+welcome him home again, for they sit in a green field and warble him to
+death with the sweetness of their song. There is a great heap of dead
+men's bones lying all around, with the flesh still rotting off them.
+Therefore pass these Sirens by, and stop your men's ears with wax that
+none of them may hear; but if you like you can listen yourself, for you
+may get the men to bind you as you stand upright on a cross piece half
+way up the mast, {99} and they must lash the rope's ends to the mast
+itself, that you may have the pleasure of listening. If you beg and pray
+the men to unloose you, then they must bind you faster.
+
+"'When your crew have taken you past these Sirens, I cannot give you
+coherent directions {100} as to which of two courses you are to take; I
+will lay the two alternatives before you, and you must consider them for
+yourself. On the one hand there are some overhanging rocks against which
+the deep blue waves of Amphitrite beat with terrific fury; the blessed
+gods call these rocks the Wanderers. Here not even a bird may pass, no,
+not even the timid doves that bring ambrosia to Father Jove, but the
+sheer rock always carries off one of them, and Father Jove has to send
+another to make up their number; no ship that ever yet came to these
+rocks has got away again, but the waves and whirlwinds of fire are
+freighted with wreckage and with the bodies of dead men. The only vessel
+that ever sailed and got through, was the famous Argo on her way from
+the house of Aetes, and she too would have gone against these great
+rocks, only that Juno piloted her past them for the love she bore to
+Jason.
+
+"'Of these two rocks the one reaches heaven and its peak is lost in a
+dark cloud. This never leaves it, so that the top is never clear not
+even in summer and early autumn. No man though he had twenty hands and
+twenty feet could get a foothold on it and climb it, for it runs sheer
+up, as smooth as though it had been polished. In the middle of it there
+is a large cavern, looking West and turned towards Erebus; you must
+take your ship this way, but the cave is so high up that not even the
+stoutest archer could send an arrow into it. Inside it Scylla sits and
+yelps with a voice that you might take to be that of a young hound, but
+in truth she is a dreadful monster and no one--not even a god--could
+face her without being terror-struck. She has twelve mis-shapen feet,
+and six necks of the most prodigious length; and at the end of each neck
+she has a frightful head with three rows of teeth in each, all set very
+close together, so that they would crunch any one to death in a moment,
+and she sits deep within her shady cell thrusting out her heads and
+peering all round the rock, fishing for dolphins or dogfish or
+any larger monster that she can catch, of the thousands with which
+Amphitrite teems. No ship ever yet got past her without losing some men,
+for she shoots out all her heads at once, and carries off a man in each
+mouth.
+
+"'You will find the other rock lie lower, but they are so close together
+that there is not more than a bow-shot between them. [A large fig
+tree in full leaf {101} grows upon it], and under it lies the sucking
+whirlpool of Charybdis. Three times in the day does she vomit forth her
+waters, and three times she sucks them down again; see that you be not
+there when she is sucking, for if you are, Neptune himself could not
+save you; you must hug the Scylla side and drive ship by as fast as you
+can, for you had better lose six men than your whole crew.'
+
+"'Is there no way,' said I, 'of escaping Charybdis, and at the same time
+keeping Scylla off when she is trying to harm my men?'
+
+"'You dare devil,' replied the goddess, 'you are always wanting to fight
+somebody or something; you will not let yourself be beaten even by the
+immortals. For Scylla is not mortal; moreover she is savage, extreme,
+rude, cruel and invincible. There is no help for it; your best chance
+will be to get by her as fast as ever you can, for if you dawdle about
+her rock while you are putting on your armour, she may catch you with
+a second cast of her six heads, and snap up another half dozen of your
+men; so drive your ship past her at full speed, and roar out lustily to
+Crataiis who is Scylla's dam, bad luck to her; she will then stop her
+from making a second raid upon you.'
+
+"'You will now come to the Thrinacian island, and here you will see
+many herds of cattle and flocks of sheep belonging to the sun-god--seven
+herds of cattle and seven flocks of sheep, with fifty head in each
+flock. They do not breed, nor do they become fewer in number, and they
+are tended by the goddesses Phaethusa and Lampetie, who are children of
+the sun-god Hyperion by Neaera. Their mother when she had borne them and
+had done suckling them sent them to the Thrinacian island, which was
+a long way off, to live there and look after their father's flocks and
+herds. If you leave these flocks unharmed, and think of nothing but
+getting home, you may yet after much hardship reach Ithaca; but if you
+harm them, then I forewarn you of the destruction both of your ship
+and of your comrades; and even though you may yourself escape, you will
+return late, in bad plight, after losing all your men.'
+
+"Here she ended, and dawn enthroned in gold began to show in heaven,
+whereon she returned inland. I then went on board and told my men to
+loose the ship from her moorings; so they at once got into her, took
+their places, and began to smite the grey sea with their oars. Presently
+the great and cunning goddess Circe befriended us with a fair wind
+that blew dead aft, and staid steadily with us, keeping our sails well
+filled, so we did whatever wanted doing to the ship's gear, and let her
+go as wind and helmsman headed her.
+
+"Then, being much troubled in mind, I said to my men, 'My friends, it
+is not right that one or two of us alone should know the prophecies that
+Circe has made me, I will therefore tell you about them, so that whether
+we live or die we may do so with our eyes open. First she said we were
+to keep clear of the Sirens, who sit and sing most beautifully in a
+field of flowers; but she said I might hear them myself so long as no
+one else did. Therefore, take me and bind me to the crosspiece half
+way up the mast; bind me as I stand upright, with a bond so fast that I
+cannot possibly break away, and lash the rope's ends to the mast itself.
+If I beg and pray you to set me free, then bind me more tightly still.'
+
+"I had hardly finished telling everything to the men before we
+reached the island of the two Sirens, {102} for the wind had been very
+favourable. Then all of a sudden it fell dead calm; there was not a
+breath of wind nor a ripple upon the water, so the men furled the sails
+and stowed them; then taking to their oars they whitened the water with
+the foam they raised in rowing. Meanwhile I look a large wheel of wax
+and cut it up small with my sword. Then I kneaded the wax in my strong
+hands till it became soft, which it soon did between the kneading and
+the rays of the sun-god son of Hyperion. Then I stopped the ears of all
+my men, and they bound me hands and feet to the mast as I stood upright
+on the cross piece; but they went on rowing themselves. When we had got
+within earshot of the land, and the ship was going at a good rate, the
+Sirens saw that we were getting in shore and began with their singing.
+
+"'Come here,' they sang, 'renowned Ulysses, honour to the Achaean name,
+and listen to our two voices. No one ever sailed past us without staying
+to hear the enchanting sweetness of our song--and he who listens will
+go on his way not only charmed, but wiser, for we know all the ills that
+the gods laid upon the Argives and Trojans before Troy, and can tell you
+everything that is going to happen over the whole world.'
+
+"They sang these words most musically, and as I longed to hear them
+further I made signs by frowning to my men that they should set me free;
+but they quickened their stroke, and Eurylochus and Perimedes bound me
+with still stronger bonds till we had got out of hearing of the Sirens'
+voices. Then my men took the wax from their ears and unbound me.
+
+"Immediately after we had got past the island I saw a great wave from
+which spray was rising, and I heard a loud roaring sound. The men were
+so frightened that they loosed hold of their oars, for the whole sea
+resounded with the rushing of the waters, {103} but the ship stayed
+where it was, for the men had left off rowing. I went round, therefore,
+and exhorted them man by man not to lose heart.
+
+"'My friends,' said I, 'this is not the first time that we have been
+in danger, and we are in nothing like so bad a case as when the Cyclops
+shut us up in his cave; nevertheless, my courage and wise counsel
+saved us then, and we shall live to look back on all this as well. Now,
+therefore, let us all do as I say, trust in Jove and row on with might
+and main. As for you, coxswain, these are your orders; attend to them,
+for the ship is in your hands; turn her head away from these steaming
+rapids and hug the rock, or she will give you the slip and be over
+yonder before you know where you are, and you will be the death of us.'
+
+"So they did as I told them; but I said nothing about the awful monster
+Scylla, for I knew the men would not go on rowing if I did, but would
+huddle together in the hold. In one thing only did I disobey Circe's
+strict instructions--I put on my armour. Then seizing two strong spears
+I took my stand on the ship's bows, for it was there that I expected
+first to see the monster of the rock, who was to do my men so much harm;
+but I could not make her out anywhere, though I strained my eyes with
+looking the gloomy rock all over and over.
+
+"Then we entered the Straits in great fear of mind, for on the one hand
+was Scylla, and on the other dread Charybdis kept sucking up the salt
+water. As she vomited it up, it was like the water in a cauldron when it
+is boiling over upon a great fire, and the spray reached the top of the
+rocks on either side. When she began to suck again, we could see the
+water all inside whirling round and round, and it made a deafening sound
+as it broke against the rocks. We could see the bottom of the whirlpool
+all black with sand and mud, and the men were at their wits ends for
+fear. While we were taken up with this, and were expecting each moment
+to be our last, Scylla pounced down suddenly upon us and snatched up my
+six best men. I was looking at once after both ship and men, and in a
+moment I saw their hands and feet ever so high above me, struggling in
+the air as Scylla was carrying them off, and I heard them call out my
+name in one last despairing cry. As a fisherman, seated, spear in hand,
+upon some jutting rock {104} throws bait into the water to deceive the
+poor little fishes, and spears them with the ox's horn with which his
+spear is shod, throwing them gasping on to the land as he catches them
+one by one--even so did Scylla land these panting creatures on her
+rock and munch them up at the mouth of her den, while they screamed and
+stretched out their hands to me in their mortal agony. This was the most
+sickening sight that I saw throughout all my voyages.
+
+"When we had passed the [Wandering] rocks, with Scylla and terrible
+Charybdis, we reached the noble island of the sun-god, where were the
+goodly cattle and sheep belonging to the sun Hyperion. While still at
+sea in my ship I could bear the cattle lowing as they came home to the
+yards, and the sheep bleating. Then I remembered what the blind Theban
+prophet Teiresias had told me, and how carefully Aeaean Circe had warned
+me to shun the island of the blessed sun-god. So being much troubled I
+said to the men, 'My men, I know you are hard pressed, but listen while
+I tell you the prophecy that Teiresias made me, and how carefully Aeaean
+Circe warned me to shun the island of the blessed sun-god, for it
+was here, she said, that our worst danger would lie. Head the ship,
+therefore, away from the island.'
+
+"The men were in despair at this, and Eurylochus at once gave me an
+insolent answer. 'Ulysses,' said he, 'you are cruel; you are very strong
+yourself and never get worn out; you seem to be made of iron, and now,
+though your men are exhausted with toil and want of sleep, you will not
+let them land and cook themselves a good supper upon this island, but
+bid them put out to sea and go faring fruitlessly on through the watches
+of the flying night. It is by night that the winds blow hardest and do
+so much damage; how can we escape should one of those sudden squalls
+spring up from South West or West, which so often wreck a vessel when
+our lords the gods are unpropitious? Now, therefore, let us obey the
+behests of night and prepare our supper here hard by the ship; to-morrow
+morning we will go on board again and put out to sea.'
+
+"Thus spoke Eurylochus, and the men approved his words. I saw that
+heaven meant us a mischief and said, 'You force me to yield, for you are
+many against one, but at any rate each one of you must take his solemn
+oath that if he meet with a herd of cattle or a large flock of sheep,
+he will not be so mad as to kill a single head of either, but will be
+satisfied with the food that Circe has given us.'
+
+"They all swore as I bade them, and when they had completed their oath
+we made the ship fast in a harbour that was near a stream of fresh
+water, and the men went ashore and cooked their suppers. As soon as they
+had had enough to eat and drink, they began talking about their poor
+comrades whom Scylla had snatched up and eaten; this set them weeping
+and they went on crying till they fell off into a sound sleep.
+
+"In the third watch of the night when the stars had shifted their
+places, Jove raised a great gale of wind that flew a hurricane so that
+land and sea were covered with thick clouds, and night sprang forth out
+of the heavens. When the child of morning, rosy-fingered Dawn, appeared,
+we brought the ship to land and drew her into a cave wherein the
+sea-nymphs hold their courts and dances, and I called the men together
+in council.
+
+"'My friends,' said I, 'we have meat and drink in the ship, let us mind,
+therefore, and not touch the cattle, or we shall suffer for it; for
+these cattle and sheep belong to the mighty sun, who sees and gives ear
+to everything.' And again they promised that they would obey.
+
+"For a whole month the wind blew steadily from the South, and there was
+no other wind, but only South and East. {105} As long as corn and wine
+held out the men did not touch the cattle when they were hungry; when,
+however, they had eaten all there was in the ship, they were forced
+to go further afield, with hook and line, catching birds, and taking
+whatever they could lay their hands on; for they were starving. One day,
+therefore, I went up inland that I might pray heaven to show me some
+means of getting away. When I had gone far enough to be clear of all
+my men, and had found a place that was well sheltered from the wind,
+I washed my hands and prayed to all the gods in Olympus till by and by
+they sent me off into a sweet sleep.
+
+"Meanwhile Eurylochus had been giving evil counsel to the men, 'Listen
+to me,' said he, 'my poor comrades. All deaths are bad enough but there
+is none so bad as famine. Why should not we drive in the best of these
+cows and offer them in sacrifice to the immortal gods? If we ever get
+back to Ithaca, we can build a fine temple to the sun-god and enrich it
+with every kind of ornament; if, however, he is determined to sink our
+ship out of revenge for these homed cattle, and the other gods are of
+the same mind, I for one would rather drink salt water once for all and
+have done with it, than be starved to death by inches in such a desert
+island as this is.'
+
+"Thus spoke Eurylochus, and the men approved his words. Now the cattle,
+so fair and goodly, were feeding not far from the ship; the men,
+therefore, drove in the best of them, and they all stood round them
+saying their prayers, and using young oak-shoots instead of barley-meal,
+for there was no barley left. When they had done praying they killed the
+cows and dressed their carcasses; they cut out the thigh bones, wrapped
+them round in two layers of fat, and set some pieces of raw meat on top
+of them. They had no wine with which to make drink-offerings over the
+sacrifice while it was cooking, so they kept pouring on a little water
+from time to time while the inward meats were being grilled; then, when
+the thigh bones were burned and they had tasted the inward meats, they
+cut the rest up small and put the pieces upon the spits.
+
+"By this time my deep sleep had left me, and I turned back to the ship
+and to the sea shore. As I drew near I began to smell hot roast meat, so
+I groaned out a prayer to the immortal gods. 'Father Jove,' I exclaimed,
+'and all you other gods who live in everlasting bliss, you have done me
+a cruel mischief by the sleep into which you have sent me; see what fine
+work these men of mine have been making in my absence.'
+
+"Meanwhile Lampetie went straight off to the sun and told him we had
+been killing his cows, whereon he flew into a great rage, and said
+to the immortals, 'Father Jove, and all you other gods who live in
+everlasting bliss, I must have vengeance on the crew of Ulysses' ship:
+they have had the insolence to kill my cows, which were the one thing I
+loved to look upon, whether I was going up heaven or down again. If they
+do not square accounts with me about my cows, I will go down to Hades
+and shine there among the dead.'
+
+"'Sun,' said Jove, 'go on shining upon us gods and upon mankind over the
+fruitful earth. I will shiver their ship into little pieces with a bolt
+of white lightning as soon as they get out to sea.'
+
+"I was told all this by Calypso, who said she had heard it from the
+mouth of Mercury.
+
+"As soon as I got down to my ship and to the sea shore I rebuked each
+one of the men separately, but we could see no way out of it, for the
+cows were dead already. And indeed the gods began at once to show signs
+and wonders among us, for the hides of the cattle crawled about, and
+the joints upon the spits began to low like cows, and the meat, whether
+cooked or raw, kept on making a noise just as cows do.
+
+"For six days my men kept driving in the best cows and feasting upon
+them, but when Jove the son of Saturn had added a seventh day, the fury
+of the gale abated; we therefore went on board, raised our masts, spread
+sail, and put out to sea. As soon as we were well away from the island,
+and could see nothing but sky and sea, the son of Saturn raised a black
+cloud over our ship, and the sea grew dark beneath it. We did not get on
+much further, for in another moment we were caught by a terrific squall
+from the West that snapped the forestays of the mast so that it fell
+aft, while all the ship's gear tumbled about at the bottom of the
+vessel. The mast fell upon the head of the helmsman in the ship's
+stern, so that the bones of his head were crushed to pieces, and he fell
+overboard as though he were diving, with no more life left in him.
+
+"Then Jove let fly with his thunderbolts, and the ship went round and
+round, and was filled with fire and brimstone as the lightning struck
+it. The men all fell into the sea; they were carried about in the water
+round the ship, looking like so many sea-gulls, but the god presently
+deprived them of all chance of getting home again.
+
+"I stuck to the ship till the sea knocked her sides from her keel (which
+drifted about by itself) and struck the mast out of her in the direction
+of the keel; but there was a backstay of stout ox-thong still hanging
+about it, and with this I lashed the mast and keel together, and getting
+astride of them was carried wherever the winds chose to take me.
+
+"[The gale from the West had now spent its force, and the wind got into
+the South again, which frightened me lest I should be taken back to the
+terrible whirlpool of Charybdis. This indeed was what actually happened,
+for I was borne along by the waves all night, and by sunrise had reached
+the rock of Scylla, and the whirlpool. She was then sucking down the
+salt sea water, {106} but I was carried aloft toward the fig tree, which
+I caught hold of and clung on to like a bat. I could not plant my feet
+anywhere so as to stand securely, for the roots were a long way off and
+the boughs that overshadowed the whole pool were too high, too vast, and
+too far apart for me to reach them; so I hung patiently on, waiting till
+the pool should discharge my mast and raft again--and a very long while
+it seemed. A jury-man is not more glad to get home to supper, after
+having been long detained in court by troublesome cases, than I was to
+see my raft beginning to work its way out of the whirlpool again. At
+last I let go with my hands and feet, and fell heavily into the sea,
+hard by my raft on to which I then got, and began to row with my hands.
+As for Scylla, the father of gods and men would not let her get further
+sight of me--otherwise I should have certainly been lost.] {107}
+
+"Hence I was carried along for nine days till on the tenth night the
+gods stranded me on the Ogygian island, where dwells the great and
+powerful goddess Calypso. She took me in and was kind to me, but I need
+say no more about this, for I told you and your noble wife all about it
+yesterday, and I hate saying the same thing over and over again."
+
+
+Book XIII
+
+ULYSSES LEAVES SCHERIA AND RETURNS TO ITHACA.
+
+Thus did he speak, and they all held their peace throughout the covered
+cloister, enthralled by the charm of his story, till presently Alcinous
+began to speak.
+
+"Ulysses," said he, "now that you have reached my house I doubt not you
+will get home without further misadventure no matter how much you have
+suffered in the past. To you others, however, who come here night after
+night to drink my choicest wine and listen to my bard, I would insist
+as follows. Our guest has already packed up the clothes, wrought gold,
+{108} and other valuables which you have brought for his acceptance;
+let us now, therefore, present him further, each one of us, with a large
+tripod and a cauldron. We will recoup ourselves by the levy of a general
+rate; for private individuals cannot be expected to bear the burden of
+such a handsome present."
+
+Every one approved of this, and then they went home to bed each in his
+own abode. When the child of morning, rosy-fingered Dawn, appeared they
+hurried down to the ship and brought their cauldrons with them. Alcinous
+went on board and saw everything so securely stowed under the ship's
+benches that nothing could break adrift and injure the rowers. Then they
+went to the house of Alcinous to get dinner, and he sacrificed a bull
+for them in honour of Jove who is the lord of all. They set the steaks
+to grill and made an excellent dinner, after which the inspired bard,
+Demodocus, who was a favourite with every one, sang to them; but Ulysses
+kept on turning his eyes towards the sun, as though to hasten his
+setting, for he was longing to be on his way. As one who has been all
+day ploughing a fallow field with a couple of oxen keeps thinking about
+his supper and is glad when night comes that he may go and get it, for
+it is all his legs can do to carry him, even so did Ulysses rejoice when
+the sun went down, and he at once said to the Phaeacians, addressing
+himself more particularly to King Alcinous:
+
+"Sir, and all of you, farewell. Make your drink-offerings and send me on
+my way rejoicing, for you have fulfilled my heart's desire by giving me
+an escort, and making me presents, which heaven grant that I may turn
+to good account; may I find my admirable wife living in peace among
+friends, {109} and may you whom I leave behind me give satisfaction
+to your wives and children; {110} may heaven vouchsafe you every good
+grace, and may no evil thing come among your people."
+
+Thus did he speak. His hearers all of them approved his saying and
+agreed that he should have his escort inasmuch as he had spoken
+reasonably. Alcinous therefore said to his servant, "Pontonous, mix
+some wine and hand it round to everybody, that we may offer a prayer to
+father Jove, and speed our guest upon his way."
+
+Pontonous mixed the wine and handed it to every one in turn; the others
+each from his own seat made a drink-offering to the blessed gods that
+live in heaven, but Ulysses rose and placed the double cup in the hands
+of queen Arete.
+
+"Farewell, queen," said he, "henceforward and for ever, till age and
+death, the common lot of mankind, lay their hands upon you. I now take
+my leave; be happy in this house with your children, your people, and
+with king Alcinous."
+
+As he spoke he crossed the threshold, and Alcinous sent a man to conduct
+him to his ship and to the sea shore. Arete also sent some maidservants
+with him--one with a clean shirt and cloak, another to carry his strong
+box, and a third with corn and wine. When they got to the water side
+the crew took these things and put them on board, with all the meat and
+drink; but for Ulysses they spread a rug and a linen sheet on deck that
+he might sleep soundly in the stern of the ship. Then he too went on
+board and lay down without a word, but the crew took every man his place
+and loosed the hawser from the pierced stone to which it had been bound.
+Thereon, when they began rowing out to sea, Ulysses fell into a deep,
+sweet, and almost deathlike slumber. {111}
+
+The ship bounded forward on her way as a four in hand chariot flies over
+the course when the horses feel the whip. Her prow curvetted as it were
+the neck of a stallion, and a great wave of dark blue water seethed in
+her wake. She held steadily on her course, and even a falcon, swiftest
+of all birds, could not have kept pace with her. Thus, then, she cut her
+way through the water, carrying one who was as cunning as the gods, but
+who was now sleeping peacefully, forgetful of all that he had suffered
+both on the field of battle and by the waves of the weary sea.
+
+When the bright star that heralds the approach of dawn began to show,
+the ship drew near to land. {112} Now there is in Ithaca a haven of the
+old merman Phorcys, which lies between two points that break the line
+of the sea and shut the harbour in. These shelter it from the storms of
+wind and sea that rage outside, so that, when once within it, a ship may
+lie without being even moored. At the head of this harbour there is a
+large olive tree, and at no great distance a fine overarching cavern
+sacred to the nymphs who are called Naiads. {113} There are mixing bowls
+within it and wine-jars of stone, and the bees hive there. Moreover,
+there are great looms of stone on which the nymphs weave their robes of
+sea purple--very curious to see--and at all times there is water within
+it. It has two entrances, one facing North by which mortals can go
+down into the cave, while the other comes from the South and is more
+mysterious; mortals cannot possibly get in by it, it is the way taken by
+the gods.
+
+Into this harbour, then, they took their ship, for they knew the place.
+{114} She had so much way upon her that she ran half her own length on
+to the shore; {115} when, however, they had landed, the first thing they
+did was to lift Ulysses with his rug and linen sheet out of the ship,
+and lay him down upon the sand still fast asleep. Then they took out the
+presents which Minerva had persuaded the Phaeacians to give him when he
+was setting out on his voyage homewards. They put these all together by
+the root of the olive tree, away from the road, for fear some passer by
+{116} might come and steal them before Ulysses awoke; and then they made
+the best of their way home again.
+
+But Neptune did not forget the threats with which he had already
+threatened Ulysses, so he took counsel with Jove. "Father Jove," said
+he, "I shall no longer be held in any sort of respect among you gods, if
+mortals like the Phaeacians, who are my own flesh and blood, show such
+small regard for me. I said I would let Ulysses get home when he had
+suffered sufficiently. I did not say that he should never get home at
+all, for I knew you had already nodded your head about it, and promised
+that he should do so; but now they have brought him in a ship fast
+asleep and have landed him in Ithaca after loading him with more
+magnificent presents of bronze, gold, and raiment than he would ever
+have brought back from Troy, if he had had his share of the spoil and
+got home without misadventure."
+
+And Jove answered, "What, O Lord of the Earthquake, are you talking
+about? The gods are by no means wanting in respect for you. It would
+be monstrous were they to insult one so old and honoured as you are. As
+regards mortals, however, if any of them is indulging in insolence and
+treating you disrespectfully, it will always rest with yourself to deal
+with him as you may think proper, so do just as you please."
+
+"I should have done so at once," replied Neptune, "if I were not anxious
+to avoid anything that might displease you; now, therefore, I should
+like to wreck the Phaeacian ship as it is returning from its escort.
+This will stop them from escorting people in future; and I should also
+like to bury their city under a huge mountain."
+
+"My good friend," answered Jove, "I should recommend you at the very
+moment when the people from the city are watching the ship on her way,
+to turn it into a rock near the land and looking like a ship. This
+will astonish everybody, and you can then bury their city under the
+mountain."
+
+When earth-encircling Neptune heard this he went to Scheria where the
+Phaeacians live, and stayed there till the ship, which was making rapid
+way, had got close in. Then he went up to it, turned it into stone, and
+drove it down with the flat of his hand so as to root it in the ground.
+After this he went away.
+
+The Phaeacians then began talking among themselves, and one would turn
+towards his neighbour, saying, "Bless my heart, who is it that can have
+rooted the ship in the sea just as she was getting into port? We could
+see the whole of her only a moment ago."
+
+This was how they talked, but they knew nothing about it; and Alcinous
+said, "I remember now the old prophecy of my father. He said that
+Neptune would be angry with us for taking every one so safely over the
+sea, and would one day wreck a Phaeacian ship as it was returning from
+an escort, and bury our city under a high mountain. This was what my old
+father used to say, and now it is all coming true. {117} Now therefore
+let us all do as I say; in the first place we must leave off giving
+people escorts when they come here, and in the next let us sacrifice
+twelve picked bulls to Neptune that he may have mercy upon us, and not
+bury our city under the high mountain." When the people heard this they
+were afraid and got ready the bulls.
+
+Thus did the chiefs and rulers of the Phaeacians pray to king Neptune,
+standing round his altar; and at the same time {118} Ulysses woke up
+once more upon his own soil. He had been so long away that he did not
+know it again; moreover, Jove's daughter Minerva had made it a foggy
+day, so that people might not know of his having come, and that she
+might tell him everything without either his wife or his fellow citizens
+and friends recognising him {119} until he had taken his revenge upon
+the wicked suitors. Everything, therefore, seemed quite different to
+him--the long straight tracks, the harbours, the precipices, and the
+goodly trees, appeared all changed as he started up and looked upon his
+native land. So he smote his thighs with the flat of his hands and cried
+aloud despairingly.
+
+"Alas," he exclaimed, "among what manner of people am I fallen? Are they
+savage and uncivilised or hospitable and humane? Where shall I put all
+this treasure, and which way shall I go? I wish I had staid over there
+with the Phaeacians; or I could have gone to some other great chief who
+would have been good to me and given me an escort. As it is I do not
+know where to put my treasure, and I cannot leave it here for fear
+somebody else should get hold of it. In good truth the chiefs and rulers
+of the Phaeacians have not been dealing fairly by me, and have left me
+in the wrong country; they said they would take me back to Ithaca and
+they have not done so: may Jove the protector of suppliants chastise
+them, for he watches over everybody and punishes those who do wrong.
+Still, I suppose I must count my goods and see if the crew have gone off
+with any of them."
+
+He counted his goodly coppers and cauldrons, his gold and all his
+clothes, but there was nothing missing; still he kept grieving about not
+being in his own country, and wandered up and down by the shore of
+the sounding sea bewailing his hard fate. Then Minerva came up to him
+disguised as a young shepherd of delicate and princely mien, with a good
+cloak folded double about her shoulders; she had sandals on her comely
+feet and held a javelin in her hand. Ulysses was glad when he saw her,
+and went straight up to her.
+
+"My friend," said he, "you are the first person whom I have met with in
+this country; I salute you, therefore, and beg you to be well disposed
+towards me. Protect these my goods, and myself too, for I embrace your
+knees and pray to you as though you were a god. Tell me, then, and tell
+me truly, what land and country is this? Who are its inhabitants? Am I
+on an island, or is this the sea board of some continent?"
+
+Minerva answered, "Stranger, you must be very simple, or must have come
+from somewhere a long way off, not to know what country this is. It is
+a very celebrated place, and everybody knows it East and West. It is
+rugged and not a good driving country, but it is by no means a bad
+island for what there is of it. It grows any quantity of corn and also
+wine, for it is watered both by rain and dew; it breeds cattle also
+and goats; all kinds of timber grow here, and there are watering places
+where the water never runs dry; so, sir, the name of Ithaca is known
+even as far as Troy, which I understand to be a long way off from this
+Achaean country."
+
+Ulysses was glad at finding himself, as Minerva told him, in his own
+country, and he began to answer, but he did not speak the truth, and
+made up a lying story in the instinctive wiliness of his heart.
+
+"I heard of Ithaca," said he, "when I was in Crete beyond the seas, and
+now it seems I have reached it with all these treasures. I have left
+as much more behind me for my children, but am flying because I killed
+Orsilochus son of Idomeneus, the fleetest runner in Crete. I killed him
+because he wanted to rob me of the spoils I had got from Troy with so
+much trouble and danger both on the field of battle and by the waves of
+the weary sea; he said I had not served his father loyally at Troy as
+vassal, but had set myself up as an independent ruler, so I lay in wait
+for him with one of my followers by the road side, and speared him as
+he was coming into town from the country. It was a very dark night and
+nobody saw us; it was not known, therefore, that I had killed him, but
+as soon as I had done so I went to a ship and besought the owners, who
+were Phoenicians, to take me on board and set me in Pylos or in Elis
+where the Epeans rule, giving them as much spoil as satisfied them. They
+meant no guile, but the wind drove them off their course, and we sailed
+on till we came hither by night. It was all we could do to get inside
+the harbour, and none of us said a word about supper though we wanted it
+badly, but we all went on shore and lay down just as we were. I was very
+tired and fell asleep directly, so they took my goods out of the ship,
+and placed them beside me where I was lying upon the sand. Then they
+sailed away to Sidonia, and I was left here in great distress of mind."
+
+Such was his story, but Minerva smiled and caressed him with her hand.
+Then she took the form of a woman, fair, stately, and wise, "He must be
+indeed a shifty lying fellow," said she, "who could surpass you in all
+manner of craft even though you had a god for your antagonist. Dare
+devil that you are, full of guile, unwearying in deceit, can you not
+drop your tricks and your instinctive falsehood, even now that you are
+in your own country again? We will say no more, however, about this, for
+we can both of us deceive upon occasion--you are the most accomplished
+counsellor and orator among all mankind, while I for diplomacy and
+subtlety have no equal among the gods. Did you not know Jove's daughter
+Minerva--me, who have been ever with you, who kept watch over you in
+all your troubles, and who made the Phaeacians take so great a liking
+to you? And now, again, I am come here to talk things over with you, and
+help you to hide the treasure I made the Phaeacians give you; I want to
+tell you about the troubles that await you in your own house; you have
+got to face them, but tell no one, neither man nor woman, that you have
+come home again. Bear everything, and put up with every man's insolence,
+without a word."
+
+And Ulysses answered, "A man, goddess, may know a great deal, but you
+are so constantly changing your appearance that when he meets you it
+is a hard matter for him to know whether it is you or not. This much,
+however, I know exceedingly well; you were very kind to me as long as we
+Achaeans were fighting before Troy, but from the day on which we went on
+board ship after having sacked the city of Priam, and heaven dispersed
+us--from that day, Minerva, I saw no more of you, and cannot ever
+remember your coming to my ship to help me in a difficulty; I had to
+wander on sick and sorry till the gods delivered me from evil and I
+reached the city of the Phaeacians, where you encouraged me and took me
+into the town. {120} And now, I beseech you in your father's name, tell
+me the truth, for I do not believe I am really back in Ithaca. I am in
+some other country and you are mocking me and deceiving me in all you
+have been saying. Tell me then truly, have I really got back to my own
+country?"
+
+"You are always taking something of that sort in your head," replied
+Minerva, "and that is why I cannot desert you in your afflictions; you
+are so plausible, shrewd and shifty. Any one but yourself on returning
+from so long a voyage would at once have gone home to see his wife and
+children, but you do not seem to care about asking after them or hearing
+any news about them till you have exploited your wife, who remains at
+home vainly grieving for you, and having no peace night or day for the
+tears she sheds on your behalf. As for my not coming near you, I was
+never uneasy about you, for I was certain you would get back safely
+though you would lose all your men, and I did not wish to quarrel with
+my uncle Neptune, who never forgave you for having blinded his son.
+{121} I will now, however, point out to you the lie of the land, and
+you will then perhaps believe me. This is the haven of the old merman
+Phorcys, and here is the olive tree that grows at the head of it; [near
+it is the cave sacred to the Naiads;] {122} here too is the overarching
+cavern in which you have offered many an acceptable hecatomb to the
+nymphs, and this is the wooded mountain Neritum."
+
+As she spoke the goddess dispersed the mist and the land appeared. Then
+Ulysses rejoiced at finding himself again in his own land, and kissed
+the bounteous soil; he lifted up his hands and prayed to the nymphs,
+saying, "Naiad nymphs, daughters of Jove, I made sure that I was never
+again to see you, now therefore I greet you with all loving salutations,
+and I will bring you offerings as in the old days, if Jove's redoubtable
+daughter will grant me life, and bring my son to manhood."
+
+"Take heart, and do not trouble yourself about that," rejoined Minerva,
+"let us rather set about stowing your things at once in the cave, where
+they will be quite safe. Let us see how we can best manage it all."
+
+Therewith she went down into the cave to look for the safest hiding
+places, while Ulysses brought up all the treasure of gold, bronze, and
+good clothing which the Phaeacians had given him. They stowed everything
+carefully away, and Minerva set a stone against the door of the cave.
+Then the two sat down by the root of the great olive, and consulted how
+to compass the destruction of the wicked suitors.
+
+"Ulysses," said Minerva, "noble son of Laertes, think how you can lay
+hands on these disreputable people who have been lording it in your
+house these three years, courting your wife and making wedding presents
+to her, while she does nothing but lament your absence, giving hope and
+sending encouraging messages {123} to every one of them, but meaning the
+very opposite of all she says."
+
+And Ulysses answered, "In good truth, goddess, it seems I should have
+come to much the same bad end in my own house as Agamemnon did, if you
+had not given me such timely information. Advise me how I shall best
+avenge myself. Stand by my side and put your courage into my heart as on
+the day when we loosed Troy's fair diadem from her brow. Help me now as
+you did then, and I will fight three hundred men, if you, goddess, will
+be with me."
+
+"Trust me for that," said she, "I will not lose sight of you when once
+we set about it, and I imagine that some of those who are devouring your
+substance will then bespatter the pavement with their blood and brains.
+I will begin by disguising you so that no human being shall know you; I
+will cover your body with wrinkles; you shall lose all your yellow
+hair; I will clothe you in a garment that shall fill all who see it with
+loathing; I will blear your fine eyes for you, and make you an unseemly
+object in the sight of the suitors, of your wife, and of the son whom
+you left behind you. Then go at once to the swineherd who is in charge
+of your pigs; he has been always well affected towards you, and is
+devoted to Penelope and your son; you will find him feeding his pigs
+near the rock that is called Raven {124} by the fountain Arethusa, where
+they are fattening on beechmast and spring water after their manner.
+Stay with him and find out how things are going, while I proceed to
+Sparta and see your son, who is with Menelaus at Lacedaemon, where he
+has gone to try and find out whether you are still alive." {125}
+
+"But why," said Ulysses, "did you not tell him, for you knew all about
+it? Did you want him too to go sailing about amid all kinds of hardship
+while others are eating up his estate?"
+
+Minerva answered, "Never mind about him, I sent him that he might be
+well spoken of for having gone. He is in no sort of difficulty, but
+is staying quite comfortably with Menelaus, and is surrounded with
+abundance of every kind. The suitors have put out to sea and are lying
+in wait for him, for they mean to kill him before he can get home. I do
+not much think they will succeed, but rather that some of those who are
+now eating up your estate will first find a grave themselves."
+
+As she spoke Minerva touched him with her wand and covered him with
+wrinkles, took away all his yellow hair, and withered the flesh over his
+whole body; she bleared his eyes, which were naturally very fine ones;
+she changed his clothes and threw an old rag of a wrap about him, and a
+tunic, tattered, filthy, and begrimed with smoke; she also gave him an
+undressed deer skin as an outer garment, and furnished him with a staff
+and a wallet all in holes, with a twisted thong for him to sling it over
+his shoulder.
+
+When the pair had thus laid their plans they parted, and the goddess
+went straight to Lacedaemon to fetch Telemachus.
+
+
+Book XIV
+
+ULYSSES IN THE HUT WITH EUMAEUS.
+
+Ulysses now left the haven, and took the rough track up through the
+wooded country and over the crest of the mountain till he reached the
+place where Minerva had said that he would find the swineherd, who was
+the most thrifty servant he had. He found him sitting in front of his
+hut, which was by the yards that he had built on a site which could be
+seen from far. He had made them spacious {126} and fair to see, with
+a free run for the pigs all round them; he had built them during his
+master's absence, of stones which he had gathered out of the ground,
+without saying anything to Penelope or Laertes, and he had fenced them
+on top with thorn bushes. Outside the yard he had run a strong fence of
+oaken posts, split, and set pretty close together, while inside he had
+built twelve styes near one another for the sows to lie in. There were
+fifty pigs wallowing in each stye, all of them breeding sows; but the
+boars slept outside and were much fewer in number, for the suitors
+kept on eating them, and the swineherd had to send them the best he
+had continually. There were three hundred and sixty boar pigs, and the
+herdsman's four hounds, which were as fierce as wolves, slept always
+with them. The swineherd was at that moment cutting out a pair of
+sandals {127} from a good stout ox hide. Three of his men were out
+herding the pigs in one place or another, and he had sent the fourth to
+town with a boar that he had been forced to send the suitors that they
+might sacrifice it and have their fill of meat.
+
+When the hounds saw Ulysses they set up a furious barking and flew at
+him, but Ulysses was cunning enough to sit down and loose his hold of
+the stick that he had in his hand: still, he would have been torn by
+them in his own homestead had not the swineherd dropped his ox hide,
+rushed full speed through the gate of the yard and driven the dogs off
+by shouting and throwing stones at them. Then he said to Ulysses, "Old
+man, the dogs were likely to have made short work of you, and then you
+would have got me into trouble. The gods have given me quite enough
+worries without that, for I have lost the best of masters, and am in
+continual grief on his account. I have to attend swine for other people
+to eat, while he, if he yet lives to see the light of day, is starving
+in some distant land. But come inside, and when you have had your fill
+of bread and wine, tell me where you come from, and all about your
+misfortunes."
+
+On this the swineherd led the way into the hut and bade him sit down.
+He strewed a good thick bed of rushes upon the floor, and on the top of
+this he threw the shaggy chamois skin--a great thick one--on which he
+used to sleep by night. Ulysses was pleased at being made thus welcome,
+and said "May Jove, sir, and the rest of the gods grant you your heart's
+desire in return for the kind way in which you have received me."
+
+To this you answered, O swineherd Eumaeus, "Stranger, though a still
+poorer man should come here, it would not be right for me to insult him,
+for all strangers and beggars are from Jove. You must take what you
+can get and be thankful, for servants live in fear when they have young
+lords for their masters; and this is my misfortune now, for heaven has
+hindered the return of him who would have been always good to me and
+given me something of my own--a house, a piece of land, a good looking
+wife, and all else that a liberal master allows a servant who has worked
+hard for him, and whose labour the gods have prospered as they have mine
+in the situation which I hold. If my master had grown old here he would
+have done great things by me, but he is gone, and I wish that Helen's
+whole race were utterly destroyed, for she has been the death of many a
+good man. It was this matter that took my master to Ilius, the land of
+noble steeds, to fight the Trojans in the cause of king Agamemnon."
+
+As he spoke he bound his girdle round him and went to the styes where
+the young sucking pigs were penned. He picked out two which he brought
+back with him and sacrificed. He singed them, cut them up, and spitted
+them; when the meat was cooked he brought it all in and set it before
+Ulysses, hot and still on the spit, whereon Ulysses sprinkled it over
+with white barley meal. The swineherd then mixed wine in a bowl of
+ivy-wood, and taking a seat opposite Ulysses told him to begin.
+
+"Fall to, stranger," said he, "on a dish of servant's pork. The fat pigs
+have to go to the suitors, who eat them up without shame or scruple; but
+the blessed gods love not such shameful doings, and respect those who do
+what is lawful and right. Even the fierce freebooters who go raiding on
+other people's land, and Jove gives them their spoil--even they,
+when they have filled their ships and got home again live
+conscience-stricken, and look fearfully for judgement; but some god
+seems to have told these people that Ulysses is dead and gone; they
+will not, therefore, go back to their own homes and make their offers of
+marriage in the usual way, but waste his estate by force, without fear
+or stint. Not a day or night comes out of heaven, but they sacrifice not
+one victim nor two only, and they take the run of his wine, for he was
+exceedingly rich. No other great man either in Ithaca or on the mainland
+is as rich as he was; he had as much as twenty men put together. I will
+tell you what he had. There are twelve herds of cattle upon the main
+land, and as many flocks of sheep, there are also twelve droves of pigs,
+while his own men and hired strangers feed him twelve widely spreading
+herds of goats. Here in Ithaca he runs even large flocks of goats on
+the far end of the island, and they are in the charge of excellent goat
+herds. Each one of these sends the suitors the best goat in the flock
+every day. As for myself, I am in charge of the pigs that you see here,
+and I have to keep picking out the best I have and sending it to them."
+
+This was his story, but Ulysses went on eating and drinking ravenously
+without a word, brooding his revenge. When he had eaten enough and was
+satisfied, the swineherd took the bowl from which he usually drank,
+filled it with wine, and gave it to Ulysses, who was pleased, and said
+as he took it in his hands, "My friend, who was this master of yours
+that bought you and paid for you, so rich and so powerful as you tell
+me? You say he perished in the cause of King Agamemnon; tell me who he
+was, in case I may have met with such a person. Jove and the other gods
+know, but I may be able to give you news of him, for I have travelled
+much."
+
+Eumaeus answered, "Old man, no traveller who comes here with news will
+get Ulysses' wife and son to believe his story. Nevertheless, tramps in
+want of a lodging keep coming with their mouths full of lies, and not a
+word of truth; every one who finds his way to Ithaca goes to my mistress
+and tells her falsehoods, whereon she takes them in, makes much of them,
+and asks them all manner of questions, crying all the time as women will
+when they have lost their husbands. And you too, old man, for a shirt
+and a cloak would doubtless make up a very pretty story. But the wolves
+and birds of prey have long since torn Ulysses to pieces, or the fishes
+of the sea have eaten him, and his bones are lying buried deep in sand
+upon some foreign shore; he is dead and gone, and a bad business it is
+for all his friends--for me especially; go where I may I shall never
+find so good a master, not even if I were to go home to my mother and
+father where I was bred and born. I do not so much care, however, about
+my parents now, though I should dearly like to see them again in my own
+country; it is the loss of Ulysses that grieves me most; I cannot speak
+of him without reverence though he is here no longer, for he was very
+fond of me, and took such care of me that wherever he may be I shall
+always honour his memory."
+
+"My friend," replied Ulysses, "you are very positive, and very hard of
+belief about your master's coming home again, nevertheless I will not
+merely say, but will swear, that he is coming. Do not give me anything
+for my news till he has actually come, you may then give me a shirt and
+cloak of good wear if you will. I am in great want, but I will not take
+anything at all till then, for I hate a man, even as I hate hell fire,
+who lets his poverty tempt him into lying. I swear by king Jove, by the
+rites of hospitality, and by that hearth of Ulysses to which I have now
+come, that all will surely happen as I have said it will. Ulysses
+will return in this self same year; with the end of this moon and the
+beginning of the next he will be here to do vengeance on all those who
+are ill treating his wife and son."
+
+To this you answered, O swineherd Eumaeus, "Old man, you will neither
+get paid for bringing good news, nor will Ulysses ever come home; drink
+your wine in peace, and let us talk about something else. Do not keep on
+reminding me of all this; it always pains me when any one speaks about
+my honoured master. As for your oath we will let it alone, but I only
+wish he may come, as do Penelope, his old father Laertes, and his son
+Telemachus. I am terribly unhappy too about this same boy of his; he was
+running up fast into manhood, and bade fare to be no worse man, face
+and figure, than his father, but some one, either god or man, has been
+unsettling his mind, so he has gone off to Pylos to try and get news of
+his father, and the suitors are lying in wait for him as he is coming
+home, in the hope of leaving the house of Arceisius without a name in
+Ithaca. But let us say no more about him, and leave him to be taken, or
+else to escape if the son of Saturn holds his hand over him to protect
+him. And now, old man, tell me your own story; tell me also, for I want
+to know, who you are and where you come from. Tell me of your town
+and parents, what manner of ship you came in, how crew brought you to
+Ithaca, and from what country they professed to come--for you cannot
+have come by land."
+
+And Ulysses answered, "I will tell you all about it. If there were meat
+and wine enough, and we could stay here in the hut with nothing to do
+but to eat and drink while the others go to their work, I could easily
+talk on for a whole twelve months without ever finishing the story of
+the sorrows with which it has pleased heaven to visit me.
+
+"I am by birth a Cretan; my father was a well to do man, who had many
+sons born in marriage, whereas I was the son of a slave whom he had
+purchased for a concubine; nevertheless, my father Castor son of Hylax
+(whose lineage I claim, and who was held in the highest honour among the
+Cretans for his wealth, prosperity, and the valour of his sons) put me
+on the same level with my brothers who had been born in wedlock. When,
+however, death took him to the house of Hades, his sons divided his
+estate and cast lots for their shares, but to me they gave a holding
+and little else; nevertheless, my valour enabled me to marry into a rich
+family, for I was not given to bragging, or shirking on the field of
+battle. It is all over now; still, if you look at the straw you can see
+what the ear was, for I have had trouble enough and to spare. Mars and
+Minerva made me doughty in war; when I had picked my men to surprise the
+enemy with an ambuscade I never gave death so much as a thought, but was
+the first to leap forward and spear all whom I could overtake. Such was
+I in battle, but I did not care about farm work, nor the frugal home
+life of those who would bring up children. My delight was in ships,
+fighting, javelins, and arrows--things that most men shudder to think
+of; but one man likes one thing and another another, and this was what
+I was most naturally inclined to. Before the Achaeans went to Troy,
+nine times was I in command of men and ships on foreign service, and I
+amassed much wealth. I had my pick of the spoil in the first instance,
+and much more was allotted to me later on.
+
+"My house grew apace and I became a great man among the Cretans,
+but when Jove counselled that terrible expedition, in which so many
+perished, the people required me and Idomeneus to lead their ships to
+Troy, and there was no way out of it, for they insisted on our doing
+so. There we fought for nine whole years, but in the tenth we sacked the
+city of Priam and sailed home again as heaven dispersed us. Then it was
+that Jove devised evil against me. I spent but one month happily with my
+children, wife, and property, and then I conceived the idea of making a
+descent on Egypt, so I fitted out a fine fleet and manned it. I had nine
+ships, and the people flocked to fill them. For six days I and my men
+made feast, and I found them many victims both for sacrifice to the gods
+and for themselves, but on the seventh day we went on board and set sail
+from Crete with a fair North wind behind us though we were going down a
+river. Nothing went ill with any of our ships, and we had no sickness
+on board, but sat where we were and let the ships go as the wind and
+steersmen took them. On the fifth day we reached the river Aegyptus;
+there I stationed my ships in the river, bidding my men stay by them and
+keep guard over them while I sent out scouts to reconnoitre from every
+point of vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captive. The alarm was soon carried to the city, and when they
+heard the war cry, the people came out at daybreak till the plain was
+filled with horsemen and foot soldiers and with the gleam of armour.
+Then Jove spread panic among my men, and they would no longer face the
+enemy, for they found themselves surrounded. The Egyptians killed many
+of us, and took the rest alive to do forced labour for them. Jove,
+however, put it in my mind to do thus--and I wish I had died then and
+there in Egypt instead, for there was much sorrow in store for me--I
+took off my helmet and shield and dropped my spear from my hand; then
+I went straight up to the king's chariot, clasped his knees and kissed
+them, whereon he spared my life, bade me get into his chariot, and took
+me weeping to his own home. Many made at me with their ashen spears and
+tried to kill me in their fury, but the king protected me, for he feared
+the wrath of Jove the protector of strangers, who punishes those who do
+evil.
+
+"I stayed there for seven years and got together much money among the
+Egyptians, for they all gave me something; but when it was now going on
+for eight years there came a certain Phoenician, a cunning rascal, who
+had already committed all sorts of villainy, and this man talked me over
+into going with him to Phoenicia, where his house and his possessions
+lay. I stayed there for a whole twelve months, but at the end of that
+time when months and days had gone by till the same season had come
+round again, he set me on board a ship bound for Libya, on a pretence
+that I was to take a cargo along with him to that place, but really that
+he might sell me as a slave and take the money I fetched. I suspected
+his intention, but went on board with him, for I could not help it.
+
+"The ship ran before a fresh North wind till we had reached the sea
+that lies between Crete and Libya; there, however, Jove counselled their
+destruction, for as soon as we were well out from Crete and could see
+nothing but sea and sky, he raised a black cloud over our ship and the
+sea grew dark beneath it. Then Jove let fly with his thunderbolts and
+the ship went round and round and was filled with fire and brimstone
+as the lightning struck it. The men fell all into the sea; they
+were carried about in the water round the ship looking like so many
+sea-gulls, but the god presently deprived them of all chance of getting
+home again. I was all dismayed. Jove, however, sent the ship's mast
+within my reach, which saved my life, for I clung to it, and drifted
+before the fury of the gale. Nine days did I drift but in the darkness
+of the tenth night a great wave bore me on to the Thesprotian coast.
+There Pheidon king of the Thesprotians entertained me hospitably without
+charging me anything at all--for his son found me when I was nearly dead
+with cold and fatigue, whereon he raised me by the hand, took me to his
+father's house and gave me clothes to wear.
+
+"There it was that I heard news of Ulysses, for the king told me he
+had entertained him, and shown him much hospitality while he was on his
+homeward journey. He showed me also the treasure of gold, and wrought
+iron that Ulysses had got together. There was enough to keep his family
+for ten generations, so much had he left in the house of king Pheidon.
+But the king said Ulysses had gone to Dodona that he might learn Jove's
+mind from the god's high oak tree, and know whether after so long an
+absence he should return to Ithaca openly, or in secret. Moreover the
+king swore in my presence, making drink-offerings in his own house as
+he did so, that the ship was by the water side, and the crew found,
+that should take him to his own country. He sent me off however before
+Ulysses returned, for there happened to be a Thesprotian ship sailing
+for the wheat-growing island of Dulichium, and he told those in charge
+of her to be sure and take me safely to King Acastus.
+
+"These men hatched a plot against me that would have reduced me to the
+very extreme of misery, for when the ship had got some way out from land
+they resolved on selling me as a slave. They stripped me of the shirt
+and cloak that I was wearing, and gave me instead the tattered old
+clouts in which you now see me; then, towards nightfall, they reached
+the tilled lands of Ithaca, and there they bound me with a strong rope
+fast in the ship, while they went on shore to get supper by the sea
+side. But the gods soon undid my bonds for me, and having drawn my rags
+over my head I slid down the rudder into the sea, where I struck out and
+swam till I was well clear of them, and came ashore near a thick wood
+in which I lay concealed. They were very angry at my having escaped and
+went searching about for me, till at last they thought it was no further
+use and went back to their ship. The gods, having hidden me thus easily,
+then took me to a good man's door--for it seems that I am not to die yet
+awhile."
+
+To this you answered, O swineherd Eumaeus, "Poor unhappy stranger, I
+have found the story of your misfortunes extremely interesting, but that
+part about Ulysses is not right; and you will never get me to believe
+it. Why should a man like you go about telling lies in this way? I know
+all about the return of my master. The gods one and all of them detest
+him, or they would have taken him before Troy, or let him die with
+friends around him when the days of his fighting were done; for then the
+Achaeans would have built a mound over his ashes and his son would have
+been heir to his renown, but now the storm winds have spirited him away
+we know not whither.
+
+"As for me I live out of the way here with the pigs, and never go to the
+town unless when Penelope sends for me on the arrival of some news
+about Ulysses. Then they all sit round and ask questions, both those who
+grieve over the king's absence, and those who rejoice at it because they
+can eat up his property without paying for it. For my own part I have
+never cared about asking anyone else since the time when I was taken in
+by an Aetolian, who had killed a man and come a long way till at last
+he reached my station, and I was very kind to him. He said he had seen
+Ulysses with Idomeneus among the Cretans, refitting his ships which had
+been damaged in a gale. He said Ulysses would return in the following
+summer or autumn with his men, and that he would bring back much wealth.
+And now you, you unfortunate old man, since fate has brought you to my
+door, do not try to flatter me in this way with vain hopes. It is not
+for any such reason that I shall treat you kindly, but only out of
+respect for Jove the god of hospitality, as fearing him and pitying
+you."
+
+Ulysses answered, "I see that you are of an unbelieving mind; I have
+given you my oath, and yet you will not credit me; let us then make a
+bargain, and call all the gods in heaven to witness it. If your master
+comes home, give me a cloak and shirt of good wear, and send me to
+Dulichium where I want to go; but if he does not come as I say he will,
+set your men on to me, and tell them to throw me from yonder precipice,
+as a warning to tramps not to go about the country telling lies."
+
+"And a pretty figure I should cut then," replied Eumaeus, "both now and
+hereafter, if I were to kill you after receiving you into my hut and
+showing you hospitality. I should have to say my prayers in good earnest
+if I did; but it is just supper time and I hope my men will come in
+directly, that we may cook something savoury for supper."
+
+Thus did they converse, and presently the swineherds came up with
+the pigs, which were then shut up for the night in their styes, and a
+tremendous squealing they made as they were being driven into them. But
+Eumaeus called to his men and said, "Bring in the best pig you have,
+that I may sacrifice him for this stranger, and we will take toll of him
+ourselves. We have had trouble enough this long time feeding pigs, while
+others reap the fruit of our labour."
+
+On this he began chopping firewood, while the others brought in a fine
+fat five year old boar pig, and set it at the altar. Eumaeus did not
+forget the gods, for he was a man of good principles, so the first thing
+he did was to cut bristles from the pig's face and throw them into the
+fire, praying to all the gods as he did so that Ulysses might return
+home again. Then he clubbed the pig with a billet of oak which he had
+kept back when he was chopping the firewood, and stunned it, while the
+others slaughtered and singed it. Then they cut it up, and Eumaeus began
+by putting raw pieces from each joint on to some of the fat; these he
+sprinkled with barley meal, and laid upon the embers; they cut the rest
+of the meat up small, put the pieces upon the spits and roasted them
+till they were done; when they had taken them off the spits they
+threw them on to the dresser in a heap. The swineherd, who was a most
+equitable man, then stood up to give every one his share. He made seven
+portions; one of these he set apart for Mercury the son of Maia and the
+nymphs, praying to them as he did so; the others he dealt out to the men
+man by man. He gave Ulysses some slices cut lengthways down the loin
+as a mark of especial honour, and Ulysses was much pleased. "I hope,
+Eumaeus," said he, "that Jove will be as well disposed towards you as I
+am, for the respect you are showing to an outcast like myself."
+
+To this you answered, O swineherd Eumaeus, "Eat, my good fellow, and
+enjoy your supper, such as it is. God grants this, and withholds that,
+just as he thinks right, for he can do whatever he chooses."
+
+As he spoke he cut off the first piece and offered it as a burnt
+sacrifice to the immortal gods; then he made them a drink-offering,
+put the cup in the hands of Ulysses, and sat down to his own portion.
+Mesaulius brought them their bread; the swineherd had brought this man
+on his own account from among the Taphians during his master's absence,
+and had paid for him with his own money without saying anything either
+to his mistress or Laertes. They then laid their hands upon the good
+things that were before them, and when they had had enough to eat and
+drink, Mesaulius took away what was left of the bread, and they all went
+to bed after having made a hearty supper.
+
+Now the night came on stormy and very dark, for there was no moon. It
+poured without ceasing, and the wind blew strong from the West, which is
+a wet quarter, so Ulysses thought he would see whether Eumaeus, in the
+excellent care he took of him, would take off his own cloak and give
+it him, or make one of his men give him one. "Listen to me," said he,
+"Eumaeus and the rest of you; when I have said a prayer I will tell you
+something. It is the wine that makes me talk in this way; wine will make
+even a wise man fall to singing; it will make him chuckle and dance
+and say many a word that he had better leave unspoken; still, as I have
+begun, I will go on. Would that I were still young and strong as when we
+got up an ambuscade before Troy. Menelaus and Ulysses were the leaders,
+but I was in command also, for the other two would have it so. When we
+had come up to the wall of the city we crouched down beneath our armour
+and lay there under cover of the reeds and thick brushwood that grew
+about the swamp. It came on to freeze with a North wind blowing; the
+snow fell small and fine like hoar frost, and our shields were coated
+thick with rime. The others had all got cloaks and shirts, and slept
+comfortably enough with their shields about their shoulders, but I had
+carelessly left my cloak behind me, not thinking that I should be too
+cold, and had gone off in nothing but my shirt and shield. When the
+night was two-thirds through and the stars had shifted their places, I
+nudged Ulysses who was close to me with my elbow, and he at once gave me
+his ear.
+
+"'Ulysses,' said I, 'this cold will be the death of me, for I have no
+cloak; some god fooled me into setting off with nothing on but my shirt,
+and I do not know what to do.'
+
+"Ulysses, who was as crafty as he was valiant, hit upon the following
+plan:
+
+"'Keep still,' said he in a low voice, 'or the others will hear you.'
+Then he raised his head on his elbow.
+
+"'My friends,' said he, 'I have had a dream from heaven in my sleep. We
+are a long way from the ships; I wish some one would go down and tell
+Agamemnon to send us up more men at once.'
+
+"On this Thoas son of Andraemon threw off his cloak and set out running
+to the ships, whereon I took the cloak and lay in it comfortably enough
+till morning. Would that I were still young and strong as I was in those
+days, for then some one of you swineherds would give me a cloak both out
+of good will and for the respect due to a brave soldier; but now people
+look down upon me because my clothes are shabby."
+
+And Eumaeus answered, "Old man, you have told us an excellent story,
+and have said nothing so far but what is quite satisfactory; for the
+present, therefore, you shall want neither clothing nor anything else
+that a stranger in distress may reasonably expect, but to-morrow morning
+you have to shake your own old rags about your body again, for we have
+not many spare cloaks nor shirts up here, but every man has only one.
+When Ulysses' son comes home again he will give you both cloak and
+shirt, and send you wherever you may want to go."
+
+With this he got up and made a bed for Ulysses by throwing some
+goatskins and sheepskins on the ground in front of the fire. Here
+Ulysses lay down, and Eumaeus covered him over with a great heavy cloak
+that he kept for a change in case of extraordinarily bad weather.
+
+Thus did Ulysses sleep, and the young men slept beside him. But the
+swineherd did not like sleeping away from his pigs, so he got ready
+to go outside, and Ulysses was glad to see that he looked after his
+property during his master's absence. First he slung his sword over his
+brawny shoulders and put on a thick cloak to keep out the wind. He also
+took the skin of a large and well fed goat, and a javelin in case of
+attack from men or dogs. Thus equipped he went to his rest where the
+pigs were camping under an overhanging rock that gave them shelter from
+the North wind.
+
+
+Book XV
+
+MINERVA SUMMONS TELEMACHUS FROM LACEDAEMON--HE MEETS WITH THEOCLYMENUS
+AT PYLOS AND BRINGS HIM TO ITHACA--ON LANDING HE GOES TO THE HUT OF
+EUMAEUS.
+
+But Minerva went to the fair city of Lacedaemon to tell Ulysses' son
+that he was to return at once. She found him and Pisistratus sleeping
+in the forecourt of Menelaus's house; Pisistratus was fast asleep,
+but Telemachus could get no rest all night for thinking of his unhappy
+father, so Minerva went close up to him and said:
+
+"Telemachus, you should not remain so far away from home any longer, nor
+leave your property with such dangerous people in your house; they
+will eat up everything you have among them, and you will have been on a
+fool's errand. Ask Menelaus to send you home at once if you wish to
+find your excellent mother still there when you get back. Her father and
+brothers are already urging her to marry Eurymachus, who has given her
+more than any of the others, and has been greatly increasing his wedding
+presents. I hope nothing valuable may have been taken from the house in
+spite of you, but you know what women are--they always want to do the
+best they can for the man who marries them, and never give another
+thought to the children of their first husband, nor to their father
+either when he is dead and done with. Go home, therefore, and put
+everything in charge of the most respectable woman servant that you
+have, until it shall please heaven to send you a wife of your own. Let
+me tell you also of another matter which you had better attend to. The
+chief men among the suitors are lying in wait for you in the Strait
+{128} between Ithaca and Samos, and they mean to kill you before you
+can reach home. I do not much think they will succeed; it is more likely
+that some of those who are now eating up your property will find a grave
+themselves. Sail night and day, and keep your ship well away from the
+islands; the god who watches over you and protects you will send you a
+fair wind. As soon as you get to Ithaca send your ship and men on to the
+town, but yourself go straight to the swineherd who has charge of your
+pigs; he is well disposed towards you, stay with him, therefore, for the
+night, and then send him to Penelope to tell her that you have got back
+safe from Pylos."
+
+Then she went back to Olympus; but Telemachus stirred Pisistratus with
+his heel to rouse him, and said, "Wake up Pisistratus, and yoke the
+horses to the chariot, for we must set off home." {129}
+
+But Pisistratus said, "No matter what hurry we are in we cannot drive
+in the dark. It will be morning soon; wait till Menelaus has brought his
+presents and put them in the chariot for us; and let him say good bye to
+us in the usual way. So long as he lives a guest should never forget a
+host who has shown him kindness."
+
+As he spoke day began to break, and Menelaus, who had already risen,
+leaving Helen in bed, came towards them. When Telemachus saw him he
+put on his shirt as fast as he could, threw a great cloak over his
+shoulders, and went out to meet him. "Menelaus," said he, "let me go
+back now to my own country, for I want to get home."
+
+And Menelaus answered, "Telemachus, if you insist on going I will not
+detain you. I do not like to see a host either too fond of his guest or
+too rude to him. Moderation is best in all things, and not letting a
+man go when he wants to do so is as bad as telling him to go if he would
+like to stay. One should treat a guest well as long as he is in the
+house and speed him when he wants to leave it. Wait, then, till I
+can get your beautiful presents into your chariot, and till you have
+yourself seen them. I will tell the women to prepare a sufficient dinner
+for you of what there may be in the house; it will be at once more
+proper and cheaper for you to get your dinner before setting out on
+such a long journey. If, moreover, you have a fancy for making a tour
+in Hellas or in the Peloponnese, I will yoke my horses, and will conduct
+you myself through all our principal cities. No one will send us away
+empty handed; every one will give us something--a bronze tripod, a
+couple of mules, or a gold cup."
+
+"Menelaus," replied Telemachus, "I want to go home at once, for when
+I came away I left my property without protection, and fear that
+while looking for my father I shall come to ruin myself, or find that
+something valuable has been stolen during my absence."
+
+When Menelaus heard this he immediately told his wife and servants to
+prepare a sufficient dinner from what there might be in the house. At
+this moment Eteoneus joined him, for he lived close by and had just got
+up; so Menelaus told him to light the fire and cook some meat, which he
+at once did. Then Menelaus went down into his fragrant store room, {130}
+not alone, but Helen went too, with Megapenthes. When he reached the
+place where the treasures of his house were kept, he selected a double
+cup, and told his son Megapenthes to bring also a silver mixing bowl.
+Meanwhile Helen went to the chest where she kept the lovely dresses
+which she had made with her own hands, and took out one that was largest
+and most beautifully enriched with embroidery; it glittered like a star,
+and lay at the very bottom of the chest. {131} Then they all came back
+through the house again till they got to Telemachus, and Menelaus said,
+"Telemachus, may Jove, the mighty husband of Juno, bring you safely home
+according to your desire. I will now present you with the finest and
+most precious piece of plate in all my house. It is a mixing bowl of
+pure silver, except the rim, which is inlaid with gold, and it is the
+work of Vulcan. Phaedimus king of the Sidonians made me a present of it
+in the course of a visit that I paid him while I was on my return home.
+I should like to give it to you."
+
+With these words he placed the double cup in the hands of Telemachus,
+while Megapenthes brought the beautiful mixing bowl and set it before
+him. Hard by stood lovely Helen with the robe ready in her hand.
+
+"I too, my son," said she, "have something for you as a keepsake from
+the hand of Helen; it is for your bride to wear upon her wedding day.
+Till then, get your dear mother to keep it for you; thus may you go back
+rejoicing to your own country and to your home."
+
+So saying she gave the robe over to him and he received it gladly. Then
+Pisistratus put the presents into the chariot, and admired them all as
+he did so. Presently Menelaus took Telemachus and Pisistratus into the
+house, and they both of them sat down to table. A maid servant brought
+them water in a beautiful golden ewer, and poured it into a silver basin
+for them to wash their hands, and she drew a clean table beside them;
+an upper servant brought them bread and offered them many good things of
+what there was in the house. Eteoneus carved the meat and gave them each
+their portions, while Megapenthes poured out the wine. Then they laid
+their hands upon the good things that were before them, but as soon as
+they had had enough to eat and drink Telemachus and Pisistratus yoked
+the horses, and took their places in the chariot. They drove out through
+the inner gateway and under the echoing gatehouse of the outer court,
+and Menelaus came after them with a golden goblet of wine in his right
+hand that they might make a drink-offering before they set out. He stood
+in front of the horses and pledged them, saying, "Farewell to both of
+you; see that you tell Nestor how I have treated you, for he was as
+kind to me as any father could be while we Achaeans were fighting before
+Troy."
+
+"We will be sure, sir," answered Telemachus, "to tell him everything as
+soon as we see him. I wish I were as certain of finding Ulysses returned
+when I get back to Ithaca, that I might tell him of the very great
+kindness you have shown me and of the many beautiful presents I am
+taking with me."
+
+As he was thus speaking a bird flew on his right hand--an eagle with a
+great white goose in its talons which it had carried off from the farm
+yard--and all the men and women were running after it and shouting. It
+came quite close up to them and flew away on their right hands in front
+of the horses. When they saw it they were glad, and their hearts took
+comfort within them, whereon Pisistratus said, "Tell me, Menelaus, has
+heaven sent this omen for us or for you?"
+
+Menelaus was thinking what would be the most proper answer for him to
+make, but Helen was too quick for him and said, "I will read this matter
+as heaven has put it in my heart, and as I doubt not that it will come
+to pass. The eagle came from the mountain where it was bred and has
+its nest, and in like manner Ulysses, after having travelled far and
+suffered much, will return to take his revenge--if indeed he is not back
+already and hatching mischief for the suitors."
+
+"May Jove so grant it," replied Telemachus, "if it should prove to be
+so, I will make vows to you as though you were a god, even when I am at
+home."
+
+As he spoke he lashed his horses and they started off at full speed
+through the town towards the open country. They swayed the yoke upon
+their necks and travelled the whole day long till the sun set and
+darkness was over all the land. Then they reached Pherae, where Diocles
+lived who was son of Ortilochus, the son of Alpheus. There they passed
+the night and were treated hospitably. When the child of morning,
+rosy-fingered Dawn, appeared, they again yoked their horses and their
+places in the chariot. They drove out through the inner gateway and
+under the echoing gatehouse of the outer court. Then Pisistratus lashed
+his horses on and they flew forward nothing loath; ere long they came to
+Pylos, and then Telemachus said:
+
+"Pisistratus, I hope you will promise to do what I am going to ask you.
+You know our fathers were old friends before us; moreover, we are both
+of an age, and this journey has brought us together still more closely;
+do not, therefore, take me past my ship, but leave me there, for if I go
+to your father's house he will try to keep me in the warmth of his good
+will towards me, and I must go home at once."
+
+Pisistratus thought how he should do as he was asked, and in the end he
+deemed it best to turn his horses towards the ship, and put Menelaus's
+beautiful presents of gold and raiment in the stern of the vessel. Then
+he said, "Go on board at once and tell your men to do so also before
+I can reach home to tell my father. I know how obstinate he is, and am
+sure he will not let you go; he will come down here to fetch you, and he
+will not go back without you. But he will be very angry."
+
+With this he drove his goodly steeds back to the city of the Pylians and
+soon reached his home, but Telemachus called the men together and gave
+his orders. "Now, my men," said he, "get everything in order on board
+the ship, and let us set out home."
+
+Thus did he speak, and they went on board even as he had said. But as
+Telemachus was thus busied, praying also and sacrificing to Minerva
+in the ship's stern, there came to him a man from a distant country,
+a seer, who was flying from Argos because he had killed a man. He was
+descended from Melampus, who used to live in Pylos, the land of sheep;
+he was rich and owned a great house, but he was driven into exile by the
+great and powerful king Neleus. Neleus seized his goods and held them
+for a whole year, during which he was a close prisoner in the house
+of king Phylacus, and in much distress of mind both on account of the
+daughter of Neleus and because he was haunted by a great sorrow that
+dread Erinys had laid upon him. In the end, however, he escaped with his
+life, drove the cattle from Phylace to Pylos, avenged the wrong that had
+been done him, and gave the daughter of Neleus to his brother. Then he
+left the country and went to Argos, where it was ordained that he should
+reign over much people. There he married, established himself, and had
+two famous sons Antiphates and Mantius. Antiphates became father of
+Oicleus, and Oicleus of Amphiaraus, who was dearly loved both by Jove
+and by Apollo, but he did not live to old age, for he was killed
+in Thebes by reason of a woman's gifts. His sons were Alcmaeon
+and Amphilochus. Mantius, the other son of Melampus, was father to
+Polypheides and Cleitus. Aurora, throned in gold, carried off Cleitus
+for his beauty's sake, that he might dwell among the immortals, but
+Apollo made Polypheides the greatest seer in the whole world now that
+Amphiaraus was dead. He quarrelled with his father and went to live in
+Hyperesia, where he remained and prophesied for all men.
+
+His son, Theoclymenus, it was who now came up to Telemachus as he was
+making drink-offerings and praying in his ship. "Friend," said he,
+"now that I find you sacrificing in this place, I beseech you by your
+sacrifices themselves, and by the god to whom you make them, I pray you
+also by your own head and by those of your followers tell me the truth
+and nothing but the truth. Who and whence are you? Tell me also of your
+town and parents."
+
+Telemachus said, "I will answer you quite truly. I am from Ithaca, and
+my father is Ulysses, as surely as that he ever lived. But he has come
+to some miserable end. Therefore I have taken this ship and got my crew
+together to see if I can hear any news of him, for he has been away a
+long time."
+
+"I too," answered Theoclymenus, "am an exile, for I have killed a man
+of my own race. He has many brothers and kinsmen in Argos, and they
+have great power among the Argives. I am flying to escape death at their
+hands, and am thus doomed to be a wanderer on the face of the earth. I
+am your suppliant; take me, therefore, on board your ship that they may
+not kill me, for I know they are in pursuit."
+
+"I will not refuse you," replied Telemachus, "if you wish to join us.
+Come, therefore, and in Ithaca we will treat you hospitably according to
+what we have."
+
+On this he received Theoclymenus' spear and laid it down on the deck of
+the ship. He went on board and sat in the stern, bidding Theoclymenus
+sit beside him; then the men let go the hawsers. Telemachus told them to
+catch hold of the ropes, and they made all haste to do so. They set the
+mast in its socket in the cross plank, raised it and made it fast with
+the forestays, and they hoisted their white sails with sheets of twisted
+ox hide. Minerva sent them a fair wind that blew fresh and strong to
+take the ship on her course as fast as possible. Thus then they passed
+by Crouni and Chalcis.
+
+Presently the sun set and darkness was over all the land. The vessel
+made a quick passage to Pheae and thence on to Elis, where the Epeans
+rule. Telemachus then headed her for the flying islands, {132} wondering
+within himself whether he should escape death or should be taken
+prisoner.
+
+Meanwhile Ulysses and the swineherd were eating their supper in the hut,
+and the men supped with them. As soon as they had had to eat and drink,
+Ulysses began trying to prove the swineherd and see whether he would
+continue to treat him kindly, and ask him to stay on at the station or
+pack him off to the city; so he said:
+
+"Eumaeus, and all of you, to-morrow I want to go away and begin begging
+about the town, so as to be no more trouble to you or to your men. Give
+me your advice therefore, and let me have a good guide to go with me
+and show me the way. I will go the round of the city begging as I needs
+must, to see if any one will give me a drink and a piece of bread. I
+should like also to go to the house of Ulysses and bring news of her
+husband to Queen Penelope. I could then go about among the suitors and
+see if out of all their abundance they will give me a dinner. I should
+soon make them an excellent servant in all sorts of ways. Listen and
+believe when I tell you that by the blessing of Mercury who gives grace
+and good name to the works of all men, there is no one living who would
+make a more handy servant than I should--to put fresh wood on the fire,
+chop fuel, carve, cook, pour out wine, and do all those services that
+poor men have to do for their betters."
+
+The swineherd was very much disturbed when he heard this. "Heaven help
+me," he exclaimed, "what ever can have put such a notion as that into
+your head? If you go near the suitors you will be undone to a certainty,
+for their pride and insolence reach the very heavens. They would never
+think of taking a man like you for a servant. Their servants are all
+young men, well dressed, wearing good cloaks and shirts, with well
+looking faces and their hair always tidy, the tables are kept quite
+clean and are loaded with bread, meat, and wine. Stay where you are,
+then; you are not in anybody's way; I do not mind your being here, no
+more do any of the others, and when Telemachus comes home he will give
+you a shirt and cloak and will send you wherever you want to go."
+
+Ulysses answered, "I hope you may be as dear to the gods as you are to
+me, for having saved me from going about and getting into trouble; there
+is nothing worse than being always on the tramp; still, when men have
+once got low down in the world they will go through a great deal on
+behalf of their miserable bellies. Since, however, you press me to stay
+here and await the return of Telemachus, tell me about Ulysses' mother,
+and his father whom he left on the threshold of old age when he set
+out for Troy. Are they still living or are they already dead and in the
+house of Hades?"
+
+"I will tell you all about them," replied Eumaeus, "Laertes is still
+living and prays heaven to let him depart peacefully in his own house,
+for he is terribly distressed about the absence of his son, and also
+about the death of his wife, which grieved him greatly and aged him more
+than anything else did. She came to an unhappy end {133} through sorrow
+for her son: may no friend or neighbour who has dealt kindly by me come
+to such an end as she did. As long as she was still living, though she
+was always grieving, I used to like seeing her and asking her how she
+did, for she brought me up along with her daughter Ctimene, the youngest
+of her children; we were boy and girl together, and she made little
+difference between us. When, however, we both grew up, they sent Ctimene
+to Same and received a splendid dowry for her. As for me, my mistress
+gave me a good shirt and cloak with a pair of sandals for my feet, and
+sent me off into the country, but she was just as fond of me as ever.
+This is all over now. Still it has pleased heaven to prosper my work in
+the situation which I now hold. I have enough to eat and drink, and can
+find something for any respectable stranger who comes here; but there
+is no getting a kind word or deed out of my mistress, for the house has
+fallen into the hands of wicked people. Servants want sometimes to see
+their mistress and have a talk with her; they like to have something
+to eat and drink at the house, and something too to take back with them
+into the country. This is what will keep servants in a good humour."
+
+Ulysses answered, "Then you must have been a very little fellow,
+Eumaeus, when you were taken so far away from your home and parents.
+Tell me, and tell me true, was the city in which your father and mother
+lived sacked and pillaged, or did some enemies carry you off when you
+were alone tending sheep or cattle, ship you off here, and sell you for
+whatever your master gave them?"
+
+"Stranger," replied Eumaeus, "as regards your question: sit still, make
+yourself comfortable, drink your wine, and listen to me. The nights
+are now at their longest; there is plenty of time both for sleeping and
+sitting up talking together; you ought not to go to bed till bed time,
+too much sleep is as bad as too little; if any one of the others wishes
+to go to bed let him leave us and do so; he can then take my master's
+pigs out when he has done breakfast in the morning. We too will sit here
+eating and drinking in the hut, and telling one another stories about
+our misfortunes; for when a man has suffered much, and been buffeted
+about in the world, he takes pleasure in recalling the memory of sorrows
+that have long gone by. As regards your question, then, my tale is as
+follows:
+
+"You may have heard of an island called Syra that lies over above
+Ortygia, {134} where the land begins to turn round and look in another
+direction. {135} It is not very thickly peopled, but the soil is good,
+with much pasture fit for cattle and sheep, and it abounds with wine
+and wheat. Dearth never comes there, nor are the people plagued by any
+sickness, but when they grow old Apollo comes with Diana and kills them
+with his painless shafts. It contains two communities, and the whole
+country is divided between these two. My father Ctesius son of Ormenus,
+a man comparable to the gods, reigned over both.
+
+"Now to this place there came some cunning traders from Phoenicia (for
+the Phoenicians are great mariners) in a ship which they had freighted
+with gewgaws of all kinds. There happened to be a Phoenician woman in
+my father's house, very tall and comely, and an excellent servant; these
+scoundrels got hold of her one day when she was washing near their ship,
+seduced her, and cajoled her in ways that no woman can resist, no matter
+how good she may be by nature. The man who had seduced her asked her who
+she was and where she came from, and on this she told him her father's
+name. 'I come from Sidon,' said she, 'and am daughter to Arybas, a
+man rolling in wealth. One day as I was coming into the town from the
+country, some Taphian pirates seized me and took me here over the sea,
+where they sold me to the man who owns this house, and he gave them
+their price for me.'
+
+"The man who had seduced her then said, 'Would you like to come along
+with us to see the house of your parents and your parents themselves?
+They are both alive and are said to be well off.'
+
+"'I will do so gladly,' answered she, 'if you men will first swear me a
+solemn oath that you will do me no harm by the way.'
+
+"They all swore as she told them, and when they had completed their oath
+the woman said, 'Hush; and if any of your men meets me in the street or
+at the well, do not let him speak to me, for fear some one should go and
+tell my master, in which case he would suspect something. He would put
+me in prison, and would have all of you murdered; keep your own counsel
+therefore; buy your merchandise as fast as you can, and send me word
+when you have done loading. I will bring as much gold as I can lay my
+hands on, and there is something else also that I can do towards paying
+my fare. I am nurse to the son of the good man of the house, a funny
+little fellow just able to run about. I will carry him off in your ship,
+and you will get a great deal of money for him if you take him and sell
+him in foreign parts.'
+
+"On this she went back to the house. The Phoenicians stayed a whole
+year till they had loaded their ship with much precious merchandise,
+and then, when they had got freight enough, they sent to tell the
+woman. Their messenger, a very cunning fellow, came to my father's house
+bringing a necklace of gold with amber beads strung among it; and
+while my mother and the servants had it in their hands admiring it and
+bargaining about it, he made a sign quietly to the woman and then went
+back to the ship, whereon she took me by the hand and led me out of the
+house. In the fore part of the house she saw the tables set with
+the cups of guests who had been feasting with my father, as being in
+attendance on him; these were now all gone to a meeting of the public
+assembly, so she snatched up three cups and carried them off in the
+bosom of her dress, while I followed her, for I knew no better. The sun
+was now set, and darkness was over all the land, so we hurried on as
+fast as we could till we reached the harbour, where the Phoenician ship
+was lying. When they had got on board they sailed their ways over the
+sea, taking us with them, and Jove sent then a fair wind; six days did
+we sail both night and day, but on the seventh day Diana struck the
+woman and she fell heavily down into the ship's hold as though she were
+a sea gull alighting on the water; so they threw her overboard to the
+seals and fishes, and I was left all sorrowful and alone. Presently the
+winds and waves took the ship to Ithaca, where Laertes gave sundry of
+his chattels for me, and thus it was that ever I came to set eyes upon
+this country."
+
+Ulysses answered, "Eumaeus, I have heard the story of your misfortunes
+with the most lively interest and pity, but Jove has given you good as
+well as evil, for in spite of everything you have a good master, who
+sees that you always have enough to eat and drink; and you lead a good
+life, whereas I am still going about begging my way from city to city."
+
+Thus did they converse, and they had only a very little time left for
+sleep, for it was soon daybreak. In the mean time Telemachus and his
+crew were nearing land, so they loosed the sails, took down the mast,
+and rowed the ship into the harbour. {136} They cast out their mooring
+stones and made fast the hawsers; they then got out upon the sea shore,
+mixed their wine, and got dinner ready. As soon as they had had enough
+to eat and drink Telemachus said, "Take the ship on to the town, but
+leave me here, for I want to look after the herdsmen on one of my farms.
+In the evening, when I have seen all I want, I will come down to the
+city, and to-morrow morning in return for your trouble I will give you
+all a good dinner with meat and wine." {137}
+
+Then Theoclymenus said, "And what, my dear young friend, is to become of
+me? To whose house, among all your chief men, am I to repair? or shall I
+go straight to your own house and to your mother?"
+
+"At any other time," replied Telemachus, "I should have bidden you go to
+my own house, for you would find no want of hospitality; at the present
+moment, however, you would not be comfortable there, for I shall be
+away, and my mother will not see you; she does not often show herself
+even to the suitors, but sits at her loom weaving in an upper chamber,
+out of their way; but I can tell you a man whose house you can go
+to--I mean Eurymachus the son of Polybus, who is held in the highest
+estimation by every one in Ithaca. He is much the best man and the most
+persistent wooer, of all those who are paying court to my mother and
+trying to take Ulysses' place. Jove, however, in heaven alone knows
+whether or no they will come to a bad end before the marriage takes
+place."
+
+As he was speaking a bird flew by upon his right hand--a hawk, Apollo's
+messenger. It held a dove in its talons, and the feathers, as it tore
+them off, {138} fell to the ground midway between Telemachus and the
+ship. On this Theoclymenus called him apart and caught him by the hand.
+"Telemachus," said he, "that bird did not fly on your right hand without
+having been sent there by some god. As soon as I saw it I knew it was an
+omen; it means that you will remain powerful and that there will be no
+house in Ithaca more royal than your own."
+
+"I wish it may prove so," answered Telemachus. "If it does, I will show
+you so much good will and give you so many presents that all who meet
+you will congratulate you."
+
+Then he said to his friend Piraeus, "Piraeus, son of Clytius, you have
+throughout shown yourself the most willing to serve me of all those who
+have accompanied me to Pylos; I wish you would take this stranger to
+your own house and entertain him hospitably till I can come for him."
+
+And Piraeus answered, "Telemachus, you may stay away as long as you
+please, but I will look after him for you, and he shall find no lack of
+hospitality."
+
+As he spoke he went on board, and bade the others do so also and loose
+the hawsers, so they took their places in the ship. But Telemachus
+bound on his sandals, and took a long and doughty spear with a head
+of sharpened bronze from the deck of the ship. Then they loosed the
+hawsers, thrust the ship off from land, and made on towards the city
+as they had been told to do, while Telemachus strode on as fast as he
+could, till he reached the homestead where his countless herds of
+swine were feeding, and where dwelt the excellent swineherd, who was so
+devoted a servant to his master.
+
+
+Book XVI
+
+ULYSSES REVEALS HIMSELF TO TELEMACHUS.
+
+Meanwhile Ulysses and the swineherd had lit a fire in the hut and were
+were getting breakfast ready at daybreak, for they had sent the men out
+with the pigs. When Telemachus came up, the dogs did not bark but fawned
+upon him, so Ulysses, hearing the sound of feet and noticing that the
+dogs did not bark, said to Eumaeus:
+
+"Eumaeus, I hear footsteps; I suppose one of your men or some one of
+your acquaintance is coming here, for the dogs are fawning upon him and
+not barking."
+
+The words were hardly out of his mouth before his son stood at the door.
+Eumaeus sprang to his feet, and the bowls in which he was mixing wine
+fell from his hands, as he made towards his master. He kissed his head
+and both his beautiful eyes, and wept for joy. A father could not be
+more delighted at the return of an only son, the child of his old age,
+after ten years' absence in a foreign country and after having gone
+through much hardship. He embraced him, kissed him all over as though he
+had come back from the dead, and spoke fondly to him saying:
+
+"So you are come, Telemachus, light of my eyes that you are. When I
+heard you had gone to Pylos I made sure I was never going to see you any
+more. Come in, my dear child, and sit down, that I may have a good look
+at you now you are home again; it is not very often you come into
+the country to see us herdsmen; you stick pretty close to the town
+generally. I suppose you think it better to keep an eye on what the
+suitors are doing."
+
+"So be it, old friend," answered Telemachus, "but I am come now because
+I want to see you, and to learn whether my mother is still at her
+old home or whether some one else has married her, so that the bed of
+Ulysses is without bedding and covered with cobwebs."
+
+"She is still at the house," replied Eumaeus, "grieving and breaking her
+heart, and doing nothing but weep, both night and day continually."
+
+As he spoke he took Telemachus' spear, whereon he crossed the stone
+threshold and came inside. Ulysses rose from his seat to give him place
+as he entered, but Telemachus checked him; "Sit down, stranger," said
+he, "I can easily find another seat, and there is one here who will lay
+it for me."
+
+Ulysses went back to his own place, and Eumaeus strewed some green
+brushwood on the floor and threw a sheepskin on top of it for Telemachus
+to sit upon. Then the swineherd brought them platters of cold meat, the
+remains from what they had eaten the day before, and he filled the bread
+baskets with bread as fast as he could. He mixed wine also in bowls of
+ivy-wood, and took his seat facing Ulysses. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Telemachus said to Eumaeus, "Old friend, where
+does this stranger come from? How did his crew bring him to Ithaca, and
+who were they?--for assuredly he did not come here by land."
+
+To this you answered, O swineherd Eumaeus, "My son, I will tell you
+the real truth. He says he is a Cretan, and that he has been a great
+traveller. At this moment he is running away from a Thesprotian ship,
+and has taken refuge at my station, so I will put him into your hands.
+Do whatever you like with him, only remember that he is your suppliant."
+
+"I am very much distressed," said Telemachus, "by what you have just
+told me. How can I take this stranger into my house? I am as yet young,
+and am not strong enough to hold my own if any man attacks me. My mother
+cannot make up her mind whether to stay where she is and look after the
+house out of respect for public opinion and the memory of her husband,
+or whether the time is now come for her to take the best man of those
+who are wooing her, and the one who will make her the most advantageous
+offer; still, as the stranger has come to your station I will find him
+a cloak and shirt of good wear, with a sword and sandals, and will send
+him wherever he wants to go. Or if you like you can keep him here at the
+station, and I will send him clothes and food that he may be no burden
+on you and on your men; but I will not have him go near the suitors,
+for they are very insolent, and are sure to ill treat him in a way that
+would greatly grieve me; no matter how valiant a man may be he can do
+nothing against numbers, for they will be too strong for him."
+
+Then Ulysses said, "Sir, it is right that I should say something myself.
+I am much shocked about what you have said about the insolent way in
+which the suitors are behaving in despite of such a man as you are. Tell
+me, do you submit to such treatment tamely, or has some god set your
+people against you? May you not complain of your brothers--for it is to
+these that a man may look for support, however great his quarrel may be?
+I wish I were as young as you are and in my present mind; if I were son
+to Ulysses, or, indeed, Ulysses himself, I would rather some one came
+and cut my head off, but I would go to the house and be the bane of
+every one of these men. {139} If they were too many for me--I being
+single-handed--I would rather die fighting in my own house than see such
+disgraceful sights day after day, strangers grossly maltreated, and men
+dragging the women servants about the house in an unseemly way, wine
+drawn recklessly, and bread wasted all to no purpose for an end that
+shall never be accomplished."
+
+And Telemachus answered, "I will tell you truly everything. There is no
+enmity between me and my people, nor can I complain of brothers, to whom
+a man may look for support however great his quarrel may be. Jove has
+made us a race of only sons. Laertes was the only son of Arceisius, and
+Ulysses only son of Laertes. I am myself the only son of Ulysses who
+left me behind him when he went away, so that I have never been of any
+use to him. Hence it comes that my house is in the hands of numberless
+marauders; for the chiefs from all the neighbouring islands, Dulichium,
+Same, Zacynthus, as also all the principal men of Ithaca itself, are
+eating up my house under the pretext of paying court to my mother, who
+will neither say point blank that she will not marry, nor yet bring
+matters to an end, so they are making havoc of my estate, and before
+long will do so with myself into the bargain. The issue, however,
+rests with heaven. But do you, old friend Eumaeus, go at once and tell
+Penelope that I am safe and have returned from Pylos. Tell it to herself
+alone, and then come back here without letting any one else know, for
+there are many who are plotting mischief against me."
+
+"I understand and heed you," replied Eumaeus; "you need instruct me no
+further, only as I am going that way say whether I had not better let
+poor Laertes know that you are returned. He used to superintend the work
+on his farm in spite of his bitter sorrow about Ulysses, and he would
+eat and drink at will along with his servants; but they tell me that
+from the day on which you set out for Pylos he has neither eaten nor
+drunk as he ought to do, nor does he look after his farm, but sits
+weeping and wasting the flesh from off his bones."
+
+"More's the pity," answered Telemachus, "I am sorry for him, but we must
+leave him to himself just now. If people could have everything their own
+way, the first thing I should choose would be the return of my father;
+but go, and give your message; then make haste back again, and do not
+turn out of your way to tell Laertes. Tell my mother to send one of her
+women secretly with the news at once, and let him hear it from her."
+
+Thus did he urge the swineherd; Eumaeus, therefore, took his sandals,
+bound them to his feet, and started for the town. Minerva watched
+him well off the station, and then came up to it in the form of a
+woman--fair, stately, and wise. She stood against the side of the entry,
+and revealed herself to Ulysses, but Telemachus could not see her, and
+knew not that she was there, for the gods do not let themselves be seen
+by everybody. Ulysses saw her, and so did the dogs, for they did not
+bark, but went scared and whining off to the other side of the yards.
+She nodded her head and motioned to Ulysses with her eyebrows; whereon
+he left the hut and stood before her outside the main wall of the yards.
+Then she said to him:
+
+"Ulysses, noble son of Laertes, it is now time for you to tell your
+son: do not keep him in the dark any longer, but lay your plans for the
+destruction of the suitors, and then make for the town. I will not be
+long in joining you, for I too am eager for the fray."
+
+As she spoke she touched him with her golden wand. First she threw
+a fair clean shirt and cloak about his shoulders; then she made him
+younger and of more imposing presence; she gave him back his colour,
+filled out his cheeks, and let his beard become dark again. Then she
+went away and Ulysses came back inside the hut. His son was astounded
+when he saw him, and turned his eyes away for fear he might be looking
+upon a god.
+
+"Stranger," said he, "how suddenly you have changed from what you were
+a moment or two ago. You are dressed differently and your colour is not
+the same. Are you some one or other of the gods that live in heaven? If
+so, be propitious to me till I can make you due sacrifice and offerings
+of wrought gold. Have mercy upon me."
+
+And Ulysses said, "I am no god, why should you take me for one? I am
+your father, on whose account you grieve and suffer so much at the hands
+of lawless men."
+
+As he spoke he kissed his son, and a tear fell from his cheek on to the
+ground, for he had restrained all tears till now. But Telemachus could
+not yet believe that it was his father, and said:
+
+"You are not my father, but some god is flattering me with vain hopes
+that I may grieve the more hereafter; no mortal man could of himself
+contrive to do as you have been doing, and make yourself old and young
+at a moment's notice, unless a god were with him. A second ago you
+were old and all in rags, and now you are like some god come down from
+heaven."
+
+Ulysses answered, "Telemachus, you ought not to be so immeasurably
+astonished at my being really here. There is no other Ulysses who will
+come hereafter. Such as I am, it is I, who after long wandering and much
+hardship have got home in the twentieth year to my own country. What you
+wonder at is the work of the redoubtable goddess Minerva, who does with
+me whatever she will, for she can do what she pleases. At one moment she
+makes me like a beggar, and the next I am a young man with good clothes
+on my back; it is an easy matter for the gods who live in heaven to make
+any man look either rich or poor."
+
+As he spoke he sat down, and Telemachus threw his arms about his father
+and wept. They were both so much moved that they cried aloud like eagles
+or vultures with crooked talons that have been robbed of their half
+fledged young by peasants. Thus piteously did they weep, and the sun
+would have gone down upon their mourning if Telemachus had not suddenly
+said, "In what ship, my dear father, did your crew bring you to Ithaca?
+Of what nation did they declare themselves to be--for you cannot have
+come by land?"
+
+"I will tell you the truth, my son," replied Ulysses. "It was the
+Phaeacians who brought me here. They are great sailors, and are in the
+habit of giving escorts to any one who reaches their coasts. They took
+me over the sea while I was fast asleep, and landed me in Ithaca, after
+giving me many presents in bronze, gold, and raiment. These things by
+heaven's mercy are lying concealed in a cave, and I am now come here on
+the suggestion of Minerva that we may consult about killing our enemies.
+First, therefore, give me a list of the suitors, with their number, that
+I may learn who, and how many, they are. I can then turn the matter
+over in my mind, and see whether we two can fight the whole body of them
+ourselves, or whether we must find others to help us."
+
+To this Telemachus answered, "Father, I have always heard of your renown
+both in the field and in council, but the task you talk of is a very
+great one: I am awed at the mere thought of it; two men cannot stand
+against many and brave ones. There are not ten suitors only, nor twice
+ten, but ten many times over; you shall learn their number at once.
+There are fifty-two chosen youths from Dulichium, and they have six
+servants; from Same there are twenty-four; twenty young Achaeans from
+Zacynthus, and twelve from Ithaca itself, all of them well born. They
+have with them a servant Medon, a bard, and two men who can carve at
+table. If we face such numbers as this, you may have bitter cause to rue
+your coming, and your revenge. See whether you cannot think of some one
+who would be willing to come and help us."
+
+"Listen to me," replied Ulysses, "and think whether Minerva and her
+father Jove may seem sufficient, or whether I am to try and find some
+one else as well."
+
+"Those whom you have named," answered Telemachus, "are a couple of good
+allies, for though they dwell high up among the clouds they have power
+over both gods and men."
+
+"These two," continued Ulysses, "will not keep long out of the fray,
+when the suitors and we join fight in my house. Now, therefore, return
+home early to-morrow morning, and go about among the suitors as
+before. Later on the swineherd will bring me to the city disguised as a
+miserable old beggar. If you see them ill treating me, steel your heart
+against my sufferings; even though they drag me feet foremost out of
+the house, or throw things at me, look on and do nothing beyond gently
+trying to make them behave more reasonably; but they will not listen to
+you, for the day of their reckoning is at hand. Furthermore I say, and
+lay my saying to your heart; when Minerva shall put it in my mind, I
+will nod my head to you, and on seeing me do this you must collect all
+the armour that is in the house and hide it in the strong store room.
+Make some excuse when the suitors ask you why you are removing it; say
+that you have taken it to be out of the way of the smoke, inasmuch as it
+is no longer what it was when Ulysses went away, but has become soiled
+and begrimed with soot. Add to this more particularly that you are
+afraid Jove may set them on to quarrel over their wine, and that they
+may do each other some harm which may disgrace both banquet and wooing,
+for the sight of arms sometimes tempts people to use them. But leave
+a sword and a spear apiece for yourself and me, and a couple of oxhide
+shields so that we can snatch them up at any moment; Jove and Minerva
+will then soon quiet these people. There is also another matter; if you
+are indeed my son and my blood runs in your veins, let no one know that
+Ulysses is within the house--neither Laertes, nor yet the swineherd, nor
+any of the servants, nor even Penelope herself. Let you and me exploit
+the women alone, and let us also make trial of some other of the men
+servants, to see who is on our side and whose hand is against us."
+
+"Father," replied Telemachus, "you will come to know me by and by, and
+when you do you will find that I can keep your counsel. I do not think,
+however, the plan you propose will turn out well for either of us. Think
+it over. It will take us a long time to go the round of the farms and
+exploit the men, and all the time the suitors will be wasting your
+estate with impunity and without compunction. Prove the women by all
+means, to see who are disloyal and who guiltless, but I am not in favour
+of going round and trying the men. We can attend to that later on, if
+you really have some sign from Jove that he will support you."
+
+Thus did they converse, and meanwhile the ship which had brought
+Telemachus and his crew from Pylos had reached the town of Ithaca. When
+they had come inside the harbour they drew the ship on to the land;
+their servants came and took their armour from them, and they left all
+the presents at the house of Clytius. Then they sent a servant to tell
+Penelope that Telemachus had gone into the country, but had sent the
+ship to the town to prevent her from being alarmed and made unhappy.
+This servant and Eumaeus happened to meet when they were both on the
+same errand of going to tell Penelope. When they reached the House, the
+servant stood up and said to the queen in the presence of the waiting
+women, "Your son, Madam, is now returned from Pylos"; but Eumaeus went
+close up to Penelope, and said privately all that her son had bidden
+him tell her. When he had given his message he left the house with its
+outbuildings and went back to his pigs again.
+
+The suitors were surprised and angry at what had happened, so they
+went outside the great wall that ran round the outer court, and held
+a council near the main entrance. Eurymachus, son of Polybus, was the
+first to speak.
+
+"My friends," said he, "this voyage of Telemachus's is a very serious
+matter; we had made sure that it would come to nothing. Now, however,
+let us draw a ship into the water, and get a crew together to send after
+the others and tell them to come back as fast as they can."
+
+He had hardly done speaking when Amphinomus turned in his place and
+saw the ship inside the harbour, with the crew lowering her sails, and
+putting by their oars; so he laughed, and said to the others, "We need
+not send them any message, for they are here. Some god must have told
+them, or else they saw the ship go by, and could not overtake her."
+
+On this they rose and went to the water side. The crew then drew the
+ship on shore; their servants took their armour from them, and they went
+up in a body to the place of assembly, but they would not let any one
+old or young sit along with them, and Antinous, son of Eupeithes, spoke
+first.
+
+"Good heavens," said he, "see how the gods have saved this man from
+destruction. We kept a succession of scouts upon the headlands all day
+long, and when the sun was down we never went on shore to sleep, but
+waited in the ship all night till morning in the hope of capturing and
+killing him; but some god has conveyed him home in spite of us. Let
+us consider how we can make an end of him. He must not escape us; our
+affair is never likely to come off while he is alive, for he is very
+shrewd, and public feeling is by no means all on our side. We must make
+haste before he can call the Achaeans in assembly; he will lose no time
+in doing so, for he will be furious with us, and will tell all the world
+how we plotted to kill him, but failed to take him. The people will not
+like this when they come to know of it; we must see that they do us no
+hurt, nor drive us from our own country into exile. Let us try and
+lay hold of him either on his farm away from the town, or on the road
+hither. Then we can divide up his property amongst us, and let his
+mother and the man who marries her have the house. If this does not
+please you, and you wish Telemachus to live on and hold his father's
+property, then we must not gather here and eat up his goods in this way,
+but must make our offers to Penelope each from his own house, and she
+can marry the man who will give the most for her, and whose lot it is to
+win her."
+
+They all held their peace until Amphinomus rose to speak. He was the son
+of Nisus, who was son to king Aretias, and he was foremost among all the
+suitors from the wheat-growing and well grassed island of Dulichium; his
+conversation, moreover, was more agreeable to Penelope than that of any
+of the other suitors, for he was a man of good natural disposition. "My
+friends," said he, speaking to them plainly and in all honestly, "I am
+not in favour of killing Telemachus. It is a heinous thing to kill one
+who is of noble blood. Let us first take counsel of the gods, and if the
+oracles of Jove advise it, I will both help to kill him myself, and will
+urge everyone else to do so; but if they dissuade us, I would have you
+hold your hands."
+
+Thus did he speak, and his words pleased them well, so they rose
+forthwith and went to the house of Ulysses, where they took their
+accustomed seats.
+
+Then Penelope resolved that she would show herself to the suitors. She
+knew of the plot against Telemachus, for the servant Medon had overheard
+their counsels and had told her; she went down therefore to the court
+attended by her maidens, and when she reached the suitors she stood by
+one of the bearing-posts supporting the roof of the cloister holding a
+veil before her face, and rebuked Antinous saying:
+
+"Antinous, insolent and wicked schemer, they say you are the best
+speaker and counsellor of any man your own age in Ithaca, but you are
+nothing of the kind. Madman, why should you try to compass the death
+of Telemachus, and take no heed of suppliants, whose witness is Jove
+himself? It is not right for you to plot thus against one another.
+Do you not remember how your father fled to this house in fear of the
+people, who were enraged against him for having gone with some Taphian
+pirates and plundered the Thesprotians who were at peace with us? They
+wanted to tear him in pieces and eat up everything he had, but Ulysses
+stayed their hands although they were infuriated, and now you devour his
+property without paying for it, and break my heart by wooing his wife
+and trying to kill his son. Leave off doing so, and stop the others
+also."
+
+To this Eurymachus son of Polybus answered, "Take heart, Queen Penelope
+daughter of Icarius, and do not trouble yourself about these matters.
+The man is not yet born, nor never will be, who shall lay hands upon
+your son Telemachus, while I yet live to look upon the face of the
+earth. I say--and it shall surely be--that my spear shall be reddened
+with his blood; for many a time has Ulysses taken me on his knees,
+held wine up to my lips to drink, and put pieces of meat into my hands.
+Therefore Telemachus is much the dearest friend I have, and has nothing
+to fear from the hands of us suitors. Of course, if death comes to him
+from the gods, he cannot escape it." He said this to quiet her, but in
+reality he was plotting against Telemachus.
+
+Then Penelope went upstairs again and mourned her husband till Minerva
+shed sleep over her eyes. In the evening Eumaeus got back to Ulysses
+and his son, who had just sacrificed a young pig of a year old and were
+helping one another to get supper ready; Minerva therefore came up to
+Ulysses, turned him into an old man with a stroke of her wand, and
+clad him in his old clothes again, for fear that the swineherd might
+recognise him and not keep the secret, but go and tell Penelope.
+
+Telemachus was the first to speak. "So you have got back, Eumaeus," said
+he. "What is the news of the town? Have the suitors returned, or are
+they still waiting over yonder, to take me on my way home?"
+
+"I did not think of asking about that," replied Eumaeus, "when I was in
+the town. I thought I would give my message and come back as soon as I
+could. I met a man sent by those who had gone with you to Pylos, and he
+was the first to tell the news to your mother, but I can say what I saw
+with my own eyes; I had just got on to the crest of the hill of Mercury
+above the town when I saw a ship coming into harbour with a number of
+men in her. They had many shields and spears, and I thought it was the
+suitors, but I cannot be sure."
+
+On hearing this Telemachus smiled to his father, but so that Eumaeus
+could not see him.
+
+Then, when they had finished their work and the meal was ready, they ate
+it, and every man had his full share so that all were satisfied. As
+soon as they had had enough to eat and drink, they laid down to rest and
+enjoyed the boon of sleep.
+
+
+Book XVII
+
+TELEMACHUS AND HIS MOTHER MEET--ULYSSES AND EUMAEUS COME DOWN TO THE
+TOWN, AND ULYSSES IS INSULTED BY MELANTHIUS--HE IS RECOGNISED BY THE
+DOG ARGOS--HE IS INSULTED AND PRESENTLY STRUCK BY ANTINOUS WITH A
+STOOL--PENELOPE DESIRES THAT HE SHALL BE SENT TO HER.
+
+When the child of morning, rosy-fingered Dawn, appeared, Telemachus
+bound on his sandals and took a strong spear that suited his hands, for
+he wanted to go into the city. "Old friend," said he to the swineherd,
+"I will now go to the town and show myself to my mother, for she will
+never leave off grieving till she has seen me. As for this unfortunate
+stranger, take him to the town and let him beg there of any one who will
+give him a drink and a piece of bread. I have trouble enough of my own,
+and cannot be burdened with other people. If this makes him angry so
+much the worse for him, but I like to say what I mean."
+
+Then Ulysses said, "Sir, I do not want to stay here; a beggar can always
+do better in town than country, for any one who likes can give him
+something. I am too old to care about remaining here at the beck and
+call of a master. Therefore let this man do as you have just told him,
+and take me to the town as soon as I have had a warm by the fire, and
+the day has got a little heat in it. My clothes are wretchedly thin, and
+this frosty morning I shall be perished with cold, for you say the city
+is some way off."
+
+On this Telemachus strode off through the yards, brooding his revenge
+upon the suitors. When he reached home he stood his spear against a
+bearing-post of the cloister, crossed the stone floor of the cloister
+itself, and went inside.
+
+Nurse Euryclea saw him long before any one else did. She was putting the
+fleeces on to the seats, and she burst out crying as she ran up to him;
+all the other maids came up too, and covered his head and shoulders with
+their kisses. Penelope came out of her room looking like Diana or Venus,
+and wept as she flung her arms about her son. She kissed his forehead
+and both his beautiful eyes, "Light of my eyes," she cried as she spoke
+fondly to him, "so you are come home again; I made sure I was never
+going to see you any more. To think of your having gone off to Pylos
+without saying anything about it or obtaining my consent. But come, tell
+me what you saw."
+
+"Do not scold me, mother," answered Telemachus, "nor vex me, seeing what
+a narrow escape I have had, but wash your face, change your dress, go
+upstairs with your maids, and promise full and sufficient hecatombs to
+all the gods if Jove will only grant us our revenge upon the suitors. I
+must now go to the place of assembly to invite a stranger who has come
+back with me from Pylos. I sent him on with my crew, and told Piraeus to
+take him home and look after him till I could come for him myself."
+
+She heeded her son's words, washed her face, changed her dress, and
+vowed full and sufficient hecatombs to all the gods if they would only
+vouchsafe her revenge upon the suitors.
+
+Telemachus went through, and out of, the cloisters spear in hand--not
+alone, for his two fleet dogs went with him. Minerva endowed him with a
+presence of such divine comeliness that all marvelled at him as he went
+by, and the suitors gathered round him with fair words in their mouths
+and malice in their hearts; but he avoided them, and went to sit with
+Mentor, Antiphus, and Halitherses, old friends of his father's house,
+and they made him tell them all that had happened to him. Then Piraeus
+came up with Theoclymenus, whom he had escorted through the town to the
+place of assembly, whereon Telemachus at once joined them. Piraeus was
+first to speak: "Telemachus," said he, "I wish you would send some of
+your women to my house to take away the presents Menelaus gave you."
+
+"We do not know, Piraeus," answered Telemachus, "what may happen. If
+the suitors kill me in my own house and divide my property among them,
+I would rather you had the presents than that any of those people should
+get hold of them. If on the other hand I managed to kill them, I shall
+be much obliged if you will kindly bring me my presents."
+
+With these words he took Theoclymenus to his own house. When they got
+there they laid their cloaks on the benches and seats, went into the
+baths, and washed themselves. When the maids had washed and anointed
+them, and had given them cloaks and shirts, they took their seats at
+table. A maid servant then brought them water in a beautiful golden
+ewer, and poured it into a silver basin for them to wash their hands;
+and she drew a clean table beside them. An upper servant brought them
+bread and offered them many good things of what there was in the
+house. Opposite them sat Penelope, reclining on a couch by one of the
+bearing-posts of the cloister, and spinning. Then they laid their hands
+on the good things that were before them, and as soon as they had had
+enough to eat and drink Penelope said:
+
+"Telemachus, I shall go upstairs and lie down on that sad couch, which I
+have not ceased to water with my tears, from the day Ulysses set out for
+Troy with the sons of Atreus. You failed, however, to make it clear to
+me before the suitors came back to the house, whether or no you had been
+able to hear anything about the return of your father."
+
+"I will tell you then truth," replied her son. "We went to Pylos and saw
+Nestor, who took me to his house and treated me as hospitably as though
+I were a son of his own who had just returned after a long absence; so
+also did his sons; but he said he had not heard a word from any
+human being about Ulysses, whether he was alive or dead. He sent me,
+therefore, with a chariot and horses to Menelaus. There I saw Helen, for
+whose sake so many, both Argives and Trojans, were in heaven's wisdom
+doomed to suffer. Menelaus asked me what it was that had brought me to
+Lacedaemon, and I told him the whole truth, whereon he said, 'So, then,
+these cowards would usurp a brave man's bed? A hind might as well lay
+her new-born young in the lair of a lion, and then go off to feed in the
+forest or in some grassy dell. The lion, when he comes back to his lair,
+will make short work with the pair of them, and so will Ulysses with
+these suitors. By father Jove, Minerva, and Apollo, if Ulysses is still
+the man that he was when he wrestled with Philomeleides in Lesbos, and
+threw him so heavily that all the Greeks cheered him--if he is still
+such, and were to come near these suitors, they would have a short
+shrift and a sorry wedding. As regards your question, however, I will
+not prevaricate nor deceive you, but what the old man of the sea told
+me, so much will I tell you in full. He said he could see Ulysses on
+an island sorrowing bitterly in the house of the nymph Calypso, who was
+keeping him prisoner, and he could not reach his home, for he had no
+ships nor sailors to take him over the sea.' This was what Menelaus told
+me, and when I had heard his story I came away; the gods then gave me a
+fair wind and soon brought me safe home again."
+
+With these words he moved the heart of Penelope. Then Theoclymenus said
+to her:
+
+"Madam, wife of Ulysses, Telemachus does not understand these things;
+listen therefore to me, for I can divine them surely, and will hide
+nothing from you. May Jove the king of heaven be my witness, and the
+rites of hospitality, with that hearth of Ulysses to which I now come,
+that Ulysses himself is even now in Ithaca, and, either going about the
+country or staying in one place, is enquiring into all these evil deeds
+and preparing a day of reckoning for the suitors. I saw an omen when I
+was on the ship which meant this, and I told Telemachus about it."
+
+"May it be even so," answered Penelope; "if your words come true, you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you."
+
+Thus did they converse. Meanwhile the suitors were throwing discs, or
+aiming with spears at a mark on the levelled ground in front of the
+house, and behaving with all their old insolence. But when it was now
+time for dinner, and the flock of sheep and goats had come into the town
+from all the country round, {140} with their shepherds as usual, then
+Medon, who was their favourite servant, and who waited upon them at
+table, said, "Now then, my young masters, you have had enough sport, so
+come inside that we may get dinner ready. Dinner is not a bad thing, at
+dinner time."
+
+They left their sports as he told them, and when they were within the
+house, they laid their cloaks on the benches and seats inside, and then
+sacrificed some sheep, goats, pigs, and a heifer, all of them fat and
+well grown. {141} Thus they made ready for their meal. In the meantime
+Ulysses and the swineherd were about starting for the town, and the
+swineherd said, "Stranger, I suppose you still want to go to town
+to-day, as my master said you were to do; for my own part I should have
+liked you to stay here as a station hand, but I must do as my master
+tells me, or he will scold me later on, and a scolding from one's master
+is a very serious thing. Let us then be off, for it is now broad day; it
+will be night again directly and then you will find it colder." {142}
+
+"I know, and understand you," replied Ulysses; "you need say no more.
+Let us be going, but if you have a stick ready cut, let me have it to
+walk with, for you say the road is a very rough one."
+
+As he spoke he threw his shabby old tattered wallet over his shoulders,
+by the cord from which it hung, and Eumaeus gave him a stick to his
+liking. The two then started, leaving the station in charge of the dogs
+and herdsmen who remained behind; the swineherd led the way and his
+master followed after, looking like some broken down old tramp as he
+leaned upon his staff, and his clothes were all in rags. When they had
+got over the rough steep ground and were nearing the city, they reached
+the fountain from which the citizens drew their water. This had
+been made by Ithacus, Neritus, and Polyctor. There was a grove of
+water-loving poplars planted in a circle all round it, and the clear
+cold water came down to it from a rock high up, {143} while above the
+fountain there was an altar to the nymphs, at which all wayfarers used
+to sacrifice. Here Melanthius son of Dolius overtook them as he was
+driving down some goats, the best in his flock, for the suitors' dinner,
+and there were two shepherds with him. When he saw Eumaeus and Ulysses
+he reviled them with outrageous and unseemly language, which made
+Ulysses very angry.
+
+"There you go," cried he, "and a precious pair you are. See how heaven
+brings birds of the same feather to one another. Where, pray, master
+swineherd, are you taking this poor miserable object? It would make any
+one sick to see such a creature at table. A fellow like this never won a
+prize for anything in his life, but will go about rubbing his shoulders
+against every man's door post, and begging, not for swords and cauldrons
+{144} like a man, but only for a few scraps not worth begging for. If
+you would give him to me for a hand on my station, he might do to clean
+out the folds, or bring a bit of sweet feed to the kids, and he could
+fatten his thighs as much as he pleased on whey; but he has taken to bad
+ways and will not go about any kind of work; he will do nothing but
+beg victuals all the town over, to feed his insatiable belly. I say,
+therefore--and it shall surely be--if he goes near Ulysses' house he
+will get his head broken by the stools they will fling at him, till they
+turn him out."
+
+On this, as he passed, he gave Ulysses a kick on the hip out of pure
+wantonness, but Ulysses stood firm, and did not budge from the path. For
+a moment he doubted whether or no to fly at Melanthius and kill him
+with his staff, or fling him to the ground and beat his brains out;
+he resolved, however, to endure it and keep himself in check, but the
+swineherd looked straight at Melanthius and rebuked him, lifting up his
+hands and praying to heaven as he did so.
+
+"Fountain nymphs," he cried, "children of Jove, if ever Ulysses burned
+you thigh bones covered with fat whether of lambs or kids, grant my
+prayer that heaven may send him home. He would soon put an end to
+the swaggering threats with which such men as you go about insulting
+people--gadding all over the town while your flocks are going to ruin
+through bad shepherding."
+
+Then Melanthius the goatherd answered, "You ill conditioned cur, what
+are you talking about? Some day or other I will put you on board ship
+and take you to a foreign country, where I can sell you and pocket the
+money you will fetch. I wish I were as sure that Apollo would strike
+Telemachus dead this very day, or that the suitors would kill him, as I
+am that Ulysses will never come home again."
+
+With this he left them to come on at their leisure, while he went
+quickly forward and soon reached the house of his master. When he
+got there he went in and took his seat among the suitors opposite
+Eurymachus, who liked him better than any of the others. The servants
+brought him a portion of meat, and an upper woman servant set bread
+before him that he might eat. Presently Ulysses and the swineherd came
+up to the house and stood by it, amid a sound of music, for Phemius was
+just beginning to sing to the suitors. Then Ulysses took hold of the
+swineherd's hand, and said:
+
+"Eumaeus, this house of Ulysses is a very fine place. No matter how far
+you go, you will find few like it. One building keeps following on after
+another. The outer court has a wall with battlements all round it; the
+doors are double folding, and of good workmanship; it would be a hard
+matter to take it by force of arms. I perceive, too, that there are many
+people banqueting within it, for there is a smell of roast meat, and
+I hear a sound of music, which the gods have made to go along with
+feasting."
+
+Then Eumaeus said, "You have perceived aright, as indeed you generally
+do; but let us think what will be our best course. Will you go inside
+first and join the suitors, leaving me here behind you, or will you wait
+here and let me go in first? But do not wait long, or some one may see
+you loitering about outside, and throw something at you. Consider this
+matter I pray you."
+
+And Ulysses answered, "I understand and heed. Go in first and leave
+me here where I am. I am quite used to being beaten and having things
+thrown at me. I have been so much buffeted about in war and by sea that
+I am case-hardened, and this too may go with the rest. But a man cannot
+hide away the cravings of a hungry belly; this is an enemy which gives
+much trouble to all men; it is because of this that ships are fitted out
+to sail the seas, and to make war upon other people."
+
+As they were thus talking, a dog that had been lying asleep raised his
+head and pricked up his ears. This was Argos, whom Ulysses had bred
+before setting out for Troy, but he had never had any work out of him.
+In the old days he used to be taken out by the young men when they went
+hunting wild goats, or deer, or hares, but now that his master was gone
+he was lying neglected on the heaps of mule and cow dung that lay in
+front of the stable doors till the men should come and draw it away
+to manure the great close; and he was full of fleas. As soon as he saw
+Ulysses standing there, he dropped his ears and wagged his tail, but he
+could not get close up to his master. When Ulysses saw the dog on the
+other side of the yard, he dashed a tear from his eyes without Eumaeus
+seeing it, and said:
+
+"Eumaeus, what a noble hound that is over yonder on the manure heap: his
+build is splendid; is he as fine a fellow as he looks, or is he only one
+of those dogs that come begging about a table, and are kept merely for
+show?"
+
+"This hound," answered Eumaeus, "belonged to him who has died in a far
+country. If he were what he was when Ulysses left for Troy, he would
+soon show you what he could do. There was not a wild beast in the forest
+that could get away from him when he was once on its tracks. But now he
+has fallen on evil times, for his master is dead and gone, and the women
+take no care of him. Servants never do their work when their master's
+hand is no longer over them, for Jove takes half the goodness out of a
+man when he makes a slave of him."
+
+As he spoke he went inside the buildings to the cloister where the
+suitors were, but Argos died as soon as he had recognised his master.
+
+Telemachus saw Eumaeus long before any one else did, and beckoned him
+to come and sit beside him; so he looked about and saw a seat lying
+near where the carver sat serving out their portions to the suitors; he
+picked it up, brought it to Telemachus's table, and sat down opposite
+him. Then the servant brought him his portion, and gave him bread from
+the bread-basket.
+
+Immediately afterwards Ulysses came inside, looking like a poor
+miserable old beggar, leaning on his staff and with his clothes all in
+rags. He sat down upon the threshold of ash-wood just inside the doors
+leading from the outer to the inner court, and against a bearing-post of
+cypress-wood which the carpenter had skilfully planed, and had made to
+join truly with rule and line. Telemachus took a whole loaf from the
+bread-basket, with as much meat as he could hold in his two hands, and
+said to Eumaeus, "Take this to the stranger, and tell him to go
+the round of the suitors, and beg from them; a beggar must not be
+shamefaced."
+
+So Eumaeus went up to him and said, "Stranger, Telemachus sends you
+this, and says you are to go the round of the suitors begging, for
+beggars must not be shamefaced."
+
+Ulysses answered, "May King Jove grant all happiness to Telemachus, and
+fulfil the desire of his heart."
+
+Then with both hands he took what Telemachus had sent him, and laid it
+on the dirty old wallet at his feet. He went on eating it while the
+bard was singing, and had just finished his dinner as he left off.
+The suitors applauded the bard, whereon Minerva went up to Ulysses and
+prompted him to beg pieces of bread from each one of the suitors, that
+he might see what kind of people they were, and tell the good from the
+bad; but come what might she was not going to save a single one of them.
+Ulysses, therefore, went on his round, going from left to right, and
+stretched out his hands to beg as though he were a real beggar. Some of
+them pitied him, and were curious about him, asking one another who
+he was and where he came from; whereon the goatherd Melanthius said,
+"Suitors of my noble mistress, I can tell you something about him, for I
+have seen him before. The swineherd brought him here, but I know nothing
+about the man himself, nor where he comes from."
+
+On this Antinous began to abuse the swineherd. "You precious idiot," he
+cried, "what have you brought this man to town for? Have we not tramps
+and beggars enough already to pester us as we sit at meat? Do you think
+it a small thing that such people gather here to waste your master's
+property--and must you needs bring this man as well?"
+
+And Eumaeus answered, "Antinous, your birth is good but your words evil.
+It was no doing of mine that he came here. Who is likely to invite a
+stranger from a foreign country, unless it be one of those who can do
+public service as a seer, a healer of hurts, a carpenter, or a bard who
+can charm us with his singing? Such men are welcome all the world over,
+but no one is likely to ask a beggar who will only worry him. You are
+always harder on Ulysses' servants than any of the other suitors
+are, and above all on me, but I do not care so long as Telemachus and
+Penelope are alive and here."
+
+But Telemachus said, "Hush, do not answer him; Antinous has the
+bitterest tongue of all the suitors, and he makes the others worse."
+
+Then turning to Antinous he said, "Antinous, you take as much care of
+my interests as though I were your son. Why should you want to see this
+stranger turned out of the house? Heaven forbid; take something and give
+it him yourself; I do not grudge it; I bid you take it. Never mind my
+mother, nor any of the other servants in the house; but I know you will
+not do what I say, for you are more fond of eating things yourself than
+of giving them to other people."
+
+"What do you mean, Telemachus," replied Antinous, "by this swaggering
+talk? If all the suitors were to give him as much as I will, he would
+not come here again for another three months."
+
+As he spoke he drew the stool on which he rested his dainty feet from
+under the table, and made as though he would throw it at Ulysses, but
+the other suitors all gave him something, and filled his wallet with
+bread and meat; he was about, therefore, to go back to the threshold and
+eat what the suitors had given him, but he first went up to Antinous and
+said:
+
+"Sir, give me something; you are not, surely, the poorest man here; you
+seem to be a chief, foremost among them all; therefore you should be the
+better giver, and I will tell far and wide of your bounty. I too was a
+rich man once, and had a fine house of my own; in those days I gave to
+many a tramp such as I now am, no matter who he might be nor what he
+wanted. I had any number of servants, and all the other things which
+people have who live well and are accounted wealthy, but it pleased Jove
+to take all away from me. He sent me with a band of roving robbers to
+Egypt; it was a long voyage and I was undone by it. I stationed my ships
+in the river Aegyptus, and bade my men stay by them and keep guard
+over them, while I sent out scouts to reconnoitre from every point of
+vantage.
+
+"But the men disobeyed my orders, took to their own devices, and ravaged
+the land of the Egyptians, killing the men, and taking their wives and
+children captives. The alarm was soon carried to the city, and when they
+heard the war-cry, the people came out at daybreak till the plain was
+filled with soldiers horse and foot, and with the gleam of armour. Then
+Jove spread panic among my men, and they would no longer face the enemy,
+for they found themselves surrounded. The Egyptians killed many of us,
+and took the rest alive to do forced labour for them; as for myself,
+they gave me to a friend who met them, to take to Cyprus, Dmetor by
+name, son of Iasus, who was a great man in Cyprus. Thence I am come
+hither in a state of great misery."
+
+Then Antinous said, "What god can have sent such a pestilence to plague
+us during our dinner? Get out, into the open part of the court, {145}
+or I will give you Egypt and Cyprus over again for your insolence and
+importunity; you have begged of all the others, and they have given you
+lavishly, for they have abundance round them, and it is easy to be free
+with other people's property when there is plenty of it."
+
+On this Ulysses began to move off, and said, "Your looks, my fine sir,
+are better than your breeding; if you were in your own house you would
+not spare a poor man so much as a pinch of salt, for though you are in
+another man's, and surrounded with abundance, you cannot find it in you
+to give him even a piece of bread."
+
+This made Antinous very angry, and he scowled at him saying, "You shall
+pay for this before you get clear of the court." With these words he
+threw a footstool at him, and hit him on the right shoulder blade near
+the top of his back. Ulysses stood firm as a rock and the blow did not
+even stagger him, but he shook his head in silence as he brooded on his
+revenge. Then he went back to the threshold and sat down there, laying
+his well filled wallet at his feet.
+
+"Listen to me," he cried, "you suitors of Queen Penelope, that I may
+speak even as I am minded. A man knows neither ache nor pain if he gets
+hit while fighting for his money, or for his sheep or his cattle; and
+even so Antinous has hit me while in the service of my miserable belly,
+which is always getting people into trouble. Still, if the poor have
+gods and avenging deities at all, I pray them that Antinous may come to
+a bad end before his marriage."
+
+"Sit where you are, and eat your victuals in silence, or be off
+elsewhere," shouted Antinous. "If you say more I will have you dragged
+hand and foot through the courts, and the servants shall flay you
+alive."
+
+The other suitors were much displeased at this, and one of the young men
+said, "Antinous, you did ill in striking that poor wretch of a tramp: it
+will be worse for you if he should turn out to be some god--and we know
+the gods go about disguised in all sorts of ways as people from foreign
+countries, and travel about the world to see who do amiss and who
+righteously." {146}
+
+Thus said the suitors, but Antinous paid them no heed. Meanwhile
+Telemachus was furious about the blow that had been given to his father,
+and though no tear fell from him, he shook his head in silence and
+brooded on his revenge.
+
+Now when Penelope heard that the beggar had been struck in the
+banqueting-cloister, she said before her maids, "Would that Apollo would
+so strike you, Antinous," and her waiting woman Eurynome answered, "If
+our prayers were answered not one of the suitors would ever again see
+the sun rise." Then Penelope said, "Nurse, {147} I hate every single one
+of them, for they mean nothing but mischief, but I hate Antinous like
+the darkness of death itself. A poor unfortunate tramp has come begging
+about the house for sheer want. Every one else has given him
+something to put in his wallet, but Antinous has hit him on the right
+shoulder-blade with a footstool."
+
+Thus did she talk with her maids as she sat in her own room, and in
+the meantime Ulysses was getting his dinner. Then she called for the
+swineherd and said, "Eumaeus, go and tell the stranger to come here, I
+want to see him and ask him some questions. He seems to have travelled
+much, and he may have seen or heard something of my unhappy husband."
+
+To this you answered, O swineherd Eumaeus, "If these Achaeans, Madam,
+would only keep quiet, you would be charmed with the history of his
+adventures. I had him three days and three nights with me in my hut,
+which was the first place he reached after running away from his ship,
+and he has not yet completed the story of his misfortunes. If he had
+been the most heaven-taught minstrel in the whole world, on whose lips
+all hearers hang entranced, I could not have been more charmed as I
+sat in my hut and listened to him. He says there is an old friendship
+between his house and that of Ulysses, and that he comes from Crete
+where the descendants of Minos live, after having been driven hither and
+thither by every kind of misfortune; he also declares that he has heard
+of Ulysses as being alive and near at hand among the Thesprotians, and
+that he is bringing great wealth home with him."
+
+"Call him here, then," said Penelope, "that I too may hear his story.
+As for the suitors, let them take their pleasure indoors or out as they
+will, for they have nothing to fret about. Their corn and wine remain
+unwasted in their houses with none but servants to consume them, while
+they keep hanging about our house day after day sacrificing our oxen,
+sheep, and fat goats for their banquets, and never giving so much as
+a thought to the quantity of wine they drink. No estate can stand such
+recklessness, for we have now no Ulysses to protect us. If he were to
+come again, he and his son would soon have their revenge."
+
+As she spoke Telemachus sneezed so loudly that the whole house resounded
+with it. Penelope laughed when she heard this, and said to Eumaeus, "Go
+and call the stranger; did you not hear how my son sneezed just as I
+was speaking? This can only mean that all the suitors are going to be
+killed, and that not one of them shall escape. Furthermore I say, and
+lay my saying to your heart: if I am satisfied that the stranger is
+speaking the truth I shall give him a shirt and cloak of good wear."
+
+When Eumaeus heard this he went straight to Ulysses and said, "Father
+stranger, my mistress Penelope, mother of Telemachus, has sent for you;
+she is in great grief, but she wishes to hear anything you can tell her
+about her husband, and if she is satisfied that you are speaking the
+truth, she will give you a shirt and cloak, which are the very things
+that you are most in want of. As for bread, you can get enough of that
+to fill your belly, by begging about the town, and letting those give
+that will."
+
+"I will tell Penelope," answered Ulysses, "nothing but what is strictly
+true. I know all about her husband, and have been partner with him
+in affliction, but I am afraid of passing through this crowd of cruel
+suitors, for their pride and insolence reach heaven. Just now, moreover,
+as I was going about the house without doing any harm, a man gave me
+a blow that hurt me very much, but neither Telemachus nor any one else
+defended me. Tell Penelope, therefore, to be patient and wait till
+sundown. Let her give me a seat close up to the fire, for my clothes are
+worn very thin--you know they are, for you have seen them ever since I
+first asked you to help me--she can then ask me about the return of her
+husband."
+
+The swineherd went back when he heard this, and Penelope said as she saw
+him cross the threshold, "Why do you not bring him here, Eumaeus? Is he
+afraid that some one will ill-treat him, or is he shy of coming inside
+the house at all? Beggars should not be shamefaced."
+
+To this you answered, O swineherd Eumaeus, "The stranger is quite
+reasonable. He is avoiding the suitors, and is only doing what any one
+else would do. He asks you to wait till sundown, and it will be much
+better, madam, that you should have him all to yourself, when you can
+hear him and talk to him as you will."
+
+"The man is no fool," answered Penelope, "it would very likely be as
+he says, for there are no such abominable people in the whole world as
+these men are."
+
+When she had done speaking Eumaeus went back to the suitors, for he had
+explained everything. Then he went up to Telemachus and said in his ear
+so that none could overhear him, "My dear sir, I will now go back to the
+pigs, to see after your property and my own business. You will look to
+what is going on here, but above all be careful to keep out of danger,
+for there are many who bear you ill will. May Jove bring them to a bad
+end before they do us a mischief."
+
+"Very well," replied Telemachus, "go home when you have had your dinner,
+and in the morning come here with the victims we are to sacrifice for
+the day. Leave the rest to heaven and me."
+
+On this Eumaeus took his seat again, and when he had finished his dinner
+he left the courts and the cloister with the men at table, and went
+back to his pigs. As for the suitors, they presently began to amuse
+themselves with singing and dancing, for it was now getting on towards
+evening.
+
+
+Book XVIII
+
+THE FIGHT WITH IRUS--ULYSSES WARNS AMPHINOMUS--PENELOPE GETS PRESENTS
+FROM THE SUITORS--THE BRAZIERS--ULYSSES REBUKES EURYMACHUS.
+
+Now there came a certain common tramp who used to go begging all over
+the city of Ithaca, and was notorious as an incorrigible glutton and
+drunkard. This man had no strength nor stay in him, but he was a great
+hulking fellow to look at; his real name, the one his mother gave him,
+was Arnaeus, but the young men of the place called him Irus, {148}
+because he used to run errands for any one who would send him. As soon
+as he came he began to insult Ulysses, and to try and drive him out of
+his own house.
+
+"Be off, old man," he cried, "from the doorway, or you shall be dragged
+out neck and heels. Do you not see that they are all giving me the wink,
+and wanting me to turn you out by force, only I do not like to do so?
+Get up then, and go of yourself, or we shall come to blows."
+
+Ulysses frowned on him and said, "My friend, I do you no manner of harm;
+people give you a great deal, but I am not jealous. There is room enough
+in this doorway for the pair of us, and you need not grudge me things
+that are not yours to give. You seem to be just such another tramp as
+myself, but perhaps the gods will give us better luck by and by. Do not,
+however, talk too much about fighting or you will incense me, and old
+though I am, I shall cover your mouth and chest with blood. I shall
+have more peace tomorrow if I do, for you will not come to the house of
+Ulysses any more."
+
+Irus was very angry and answered, "You filthy glutton, you run on
+trippingly like an old fish-fag. I have a good mind to lay both hands
+about you, and knock your teeth out of your head like so many boar's
+tusks. Get ready, therefore, and let these people here stand by and
+look on. You will never be able to fight one who is so much younger than
+yourself."
+
+Thus roundly did they rate one another on the smooth pavement in front
+of the doorway, {149} and when Antinous saw what was going on he laughed
+heartily and said to the others, "This is the finest sport that you
+ever saw; heaven never yet sent anything like it into this house. The
+stranger and Irus have quarreled and are going to fight, let us set them
+on to do so at once."
+
+The suitors all came up laughing, and gathered round the two ragged
+tramps. "Listen to me," said Antinous, "there are some goats' paunches
+down at the fire, which we have filled with blood and fat, and set aside
+for supper; he who is victorious and proves himself to be the better
+man shall have his pick of the lot; he shall be free of our table and we
+will not allow any other beggar about the house at all."
+
+The others all agreed, but Ulysses, to throw them off the scent, said,
+"Sirs, an old man like myself, worn out with suffering, cannot hold his
+own against a young one; but my irrepressible belly urges me on, though
+I know it can only end in my getting a drubbing. You must swear, however
+that none of you will give me a foul blow to favour Irus and secure him
+the victory."
+
+They swore as he told them, and when they had completed their oath
+Telemachus put in a word and said, "Stranger, if you have a mind to
+settle with this fellow, you need not be afraid of any one here. Whoever
+strikes you will have to fight more than one. I am host, and the other
+chiefs, Antinous and Eurymachus, both of them men of understanding, are
+of the same mind as I am."
+
+Every one assented, and Ulysses girded his old rags about his loins,
+thus baring his stalwart thighs, his broad chest and shoulders, and his
+mighty arms; but Minerva came up to him and made his limbs even stronger
+still. The suitors were beyond measure astonished, and one would turn
+towards his neighbour saying, "The stranger has brought such a thigh out
+of his old rags that there will soon be nothing left of Irus."
+
+Irus began to be very uneasy as he heard them, but the servants girded
+him by force, and brought him [into the open part of the court] in such
+a fright that his limbs were all of a tremble. Antinous scolded him and
+said, "You swaggering bully, you ought never to have been born at all if
+you are afraid of such an old broken down creature as this tramp is.
+I say, therefore--and it shall surely be--if he beats you and proves
+himself the better man, I shall pack you off on board ship to the
+mainland and send you to king Echetus, who kills every one that comes
+near him. He will cut off your nose and ears, and draw out your entrails
+for the dogs to eat."
+
+This frightened Irus still more, but they brought him into the middle
+of the court, and the two men raised their hands to fight. Then Ulysses
+considered whether he should let drive so hard at him as to make an end
+of him then and there, or whether he should give him a lighter blow that
+should only knock him down; in the end he deemed it best to give the
+lighter blow for fear the Achaeans should begin to suspect who he was.
+Then they began to fight, and Irus hit Ulysses on the right shoulder;
+but Ulysses gave Irus a blow on the neck under the ear that broke in the
+bones of his skull, and the blood came gushing out of his mouth; he fell
+groaning in the dust, gnashing his teeth and kicking on the ground, but
+the suitors threw up their hands and nearly died of laughter, as Ulysses
+caught hold of him by the foot and dragged him into the outer court as
+far as the gate-house. There he propped him up against the wall and put
+his staff in his hands. "Sit here," said he, "and keep the dogs and pigs
+off; you are a pitiful creature, and if you try to make yourself king of
+the beggars any more you shall fare still worse."
+
+Then he threw his dirty old wallet, all tattered and torn over his
+shoulder with the cord by which it hung, and went back to sit down upon
+the threshold; but the suitors went within the cloisters, laughing and
+saluting him, "May Jove, and all the other gods," said they, "grant
+you whatever you want for having put an end to the importunity of this
+insatiable tramp. We will take him over to the mainland presently, to
+king Echetus, who kills every one that comes near him."
+
+Ulysses hailed this as of good omen, and Antinous set a great goat's
+paunch before him filled with blood and fat. Amphinomus took two loaves
+out of the bread-basket and brought them to him, pledging him as he
+did so in a golden goblet of wine. "Good luck to you," he said, "father
+stranger, you are very badly off at present, but I hope you will have
+better times by and by."
+
+To this Ulysses answered, "Amphinomus, you seem to be a man of good
+understanding, as indeed you may well be, seeing whose son you are. I
+have heard your father well spoken of; he is Nisus of Dulichium, a man
+both brave and wealthy. They tell me you are his son, and you appear to
+be a considerable person; listen, therefore, and take heed to what I am
+saying. Man is the vainest of all creatures that have their being upon
+earth. As long as heaven vouchsafes him health and strength, he thinks
+that he shall come to no harm hereafter, and even when the blessed gods
+bring sorrow upon him, he bears it as he needs must, and makes the best
+of it; for God almighty gives men their daily minds day by day. I know
+all about it, for I was a rich man once, and did much wrong in the
+stubbornness of my pride, and in the confidence that my father and my
+brothers would support me; therefore let a man fear God in all things
+always, and take the good that heaven may see fit to send him without
+vain glory. Consider the infamy of what these suitors are doing; see how
+they are wasting the estate, and doing dishonour to the wife, of one who
+is certain to return some day, and that, too, not long hence. Nay, he
+will be here soon; may heaven send you home quietly first that you may
+not meet with him in the day of his coming, for once he is here the
+suitors and he will not part bloodlessly."
+
+With these words he made a drink-offering, and when he had drunk he put
+the gold cup again into the hands of Amphinomus, who walked away serious
+and bowing his head, for he foreboded evil. But even so he did not
+escape destruction, for Minerva had doomed him to fall by the hand of
+Telemachus. So he took his seat again at the place from which he had
+come.
+
+Then Minerva put it into the mind of Penelope to show herself to the
+suitors, that she might make them still more enamoured of her, and win
+still further honour from her son and husband. So she feigned a mocking
+laugh and said, "Eurynome, I have changed my mind, and have a fancy to
+show myself to the suitors although I detest them. I should like also to
+give my son a hint that he had better not have anything more to do with
+them. They speak fairly enough but they mean mischief."
+
+"My dear child," answered Eurynome, "all that you have said is true,
+go and tell your son about it, but first wash yourself and anoint your
+face. Do not go about with your cheeks all covered with tears; it is not
+right that you should grieve so incessantly; for Telemachus, whom you
+always prayed that you might live to see with a beard, is already grown
+up."
+
+"I know, Eurynome," replied Penelope, "that you mean well, but do not
+try and persuade me to wash and to anoint myself, for heaven robbed
+me of all my beauty on the day my husband sailed; nevertheless, tell
+Autonoe and Hippodamia that I want them. They must be with me when I
+am in the cloister; I am not going among the men alone; it would not be
+proper for me to do so."
+
+On this the old woman {150} went out of the room to bid the maids go to
+their mistress. In the meantime Minerva bethought her of another matter,
+and sent Penelope off into a sweet slumber; so she lay down on her couch
+and her limbs became heavy with sleep. Then the goddess shed grace and
+beauty over her that all the Achaeans might admire her. She washed
+her face with the ambrosial loveliness that Venus wears when she goes
+dancing with the Graces; she made her taller and of a more commanding
+figure, while as for her complexion it was whiter than sawn ivory. When
+Minerva had done all this she went away, whereon the maids came in from
+the women's room and woke Penelope with the sound of their talking.
+
+"What an exquisitely delicious sleep I have been having," said she, as
+she passed her hands over her face, "in spite of all my misery. I wish
+Diana would let me die so sweetly now at this very moment, that I
+might no longer waste in despair for the loss of my dear husband, who
+possessed every kind of good quality and was the most distinguished man
+among the Achaeans."
+
+With these words she came down from her upper room, not alone but
+attended by two of her maidens, and when she reached the suitors she
+stood by one of the bearing-posts supporting the roof of the cloister,
+holding a veil before her face, and with a staid maid servant on either
+side of her. As they beheld her the suitors were so overpowered and
+became so desperately enamoured of her, that each one prayed he might
+win her for his own bed fellow.
+
+"Telemachus," said she, addressing her son, "I fear you are no longer so
+discreet and well conducted as you used to be. When you were younger you
+had a greater sense of propriety; now, however, that you are grown up,
+though a stranger to look at you would take you for the son of a well to
+do father as far as size and good looks go, your conduct is by no means
+what it should be. What is all this disturbance that has been going on,
+and how came you to allow a stranger to be so disgracefully ill-treated?
+What would have happened if he had suffered serious injury while a
+suppliant in our house? Surely this would have been very discreditable
+to you."
+
+"I am not surprised, my dear mother, at your displeasure," replied
+Telemachus, "I understand all about it and know when things are not
+as they should be, which I could not do when I was younger; I cannot,
+however, behave with perfect propriety at all times. First one and then
+another of these wicked people here keeps driving me out of my mind,
+and I have no one to stand by me. After all, however, this fight between
+Irus and the stranger did not turn out as the suitors meant it to do,
+for the stranger got the best of it. I wish Father Jove, Minerva, and
+Apollo would break the neck of every one of these wooers of yours, some
+inside the house and some out; and I wish they might all be as limp as
+Irus is over yonder in the gate of the outer court. See how he nods
+his head like a drunken man; he has had such a thrashing that he cannot
+stand on his feet nor get back to his home, wherever that may be, for he
+has no strength left in him."
+
+Thus did they converse. Eurymachus then came up and said, "Queen
+Penelope, daughter of Icarius, if all the Achaeans in Iasian Argos could
+see you at this moment, you would have still more suitors in your house
+by tomorrow morning, for you are the most admirable woman in the whole
+world both as regards personal beauty and strength of understanding."
+
+To this Penelope replied, "Eurymachus, heaven robbed me of all my beauty
+whether of face or figure when the Argives set sail for Troy and my dear
+husband with them. If he were to return and look after my affairs, I
+should both be more respected and show a better presence to the world.
+As it is, I am oppressed with care, and with the afflictions which
+heaven has seen fit to heap upon me. My husband foresaw it all, and when
+he was leaving home he took my right wrist in his hand--'Wife,' he said,
+'we shall not all of us come safe home from Troy, for the Trojans fight
+well both with bow and spear. They are excellent also at fighting from
+chariots, and nothing decides the issue of a fight sooner than this. I
+know not, therefore, whether heaven will send me back to you, or whether
+I may not fall over there at Troy. In the meantime do you look after
+things here. Take care of my father and mother as at present, and even
+more so during my absence, but when you see our son growing a beard,
+then marry whom you will, and leave this your present home.' This is
+what he said and now it is all coming true. A night will come when I
+shall have to yield myself to a marriage which I detest, for Jove has
+taken from me all hope of happiness. This further grief, moreover, cuts
+me to the very heart. You suitors are not wooing me after the custom of
+my country. When men are courting a woman who they think will be a good
+wife to them and who is of noble birth, and when they are each trying
+to win her for himself, they usually bring oxen and sheep to feast the
+friends of the lady, and they make her magnificent presents, instead of
+eating up other people's property without paying for it."
+
+This was what she said, and Ulysses was glad when he heard her trying
+to get presents out of the suitors, and flattering them with fair words
+which he knew she did not mean.
+
+Then Antinous said, "Queen Penelope, daughter of Icarius, take as many
+presents as you please from any one who will give them to you; it is not
+well to refuse a present; but we will not go about our business nor stir
+from where we are, till you have married the best man among us whoever
+he may be."
+
+The others applauded what Antinous had said, and each one sent his
+servant to bring his present. Antinous's man returned with a large and
+lovely dress most exquisitely embroidered. It had twelve beautifully
+made brooch pins of pure gold with which to fasten it. Eurymachus
+immediately brought her a magnificent chain of gold and amber beads that
+gleamed like sunlight. Eurydamas's two men returned with some
+earrings fashioned into three brilliant pendants which glistened most
+beautifully; while king Pisander son of Polyctor gave her a necklace
+of the rarest workmanship, and every one else brought her a beautiful
+present of some kind.
+
+Then the queen went back to her room upstairs, and her maids brought the
+presents after her. Meanwhile the suitors took to singing and dancing,
+and stayed till evening came. They danced and sang till it grew dark;
+they then brought in three braziers {151} to give light, and piled them
+up with chopped firewood very old and dry, and they lit torches from
+them, which the maids held up turn and turn about. Then Ulysses said:
+
+"Maids, servants of Ulysses who has so long been absent, go to the queen
+inside the house; sit with her and amuse her, or spin, and pick wool.
+I will hold the light for all these people. They may stay till morning,
+but shall not beat me, for I can stand a great deal."
+
+The maids looked at one another and laughed, while pretty Melantho began
+to gibe at him contemptuously. She was daughter to Dolius, but had been
+brought up by Penelope, who used to give her toys to play with, and
+looked after her when she was a child; but in spite of all this she
+showed no consideration for the sorrows of her mistress, and used to
+misconduct herself with Eurymachus, with whom she was in love.
+
+"Poor wretch," said she, "are you gone clean out of your mind? Go and
+sleep in some smithy, or place of public gossips, instead of chattering
+here. Are you not ashamed of opening your mouth before your betters--so
+many of them too? Has the wine been getting into your head, or do you
+always babble in this way? You seem to have lost your wits because you
+beat the tramp Irus; take care that a better man than he does not come
+and cudgel you about the head till he pack you bleeding out of the
+house."
+
+"Vixen," replied Ulysses, scowling at her, "I will go and tell
+Telemachus what you have been saying, and he will have you torn limb
+from limb."
+
+With these words he scared the women, and they went off into the body
+of the house. They trembled all over, for they thought he would do as he
+said. But Ulysses took his stand near the burning braziers, holding up
+torches and looking at the people--brooding the while on things that
+should surely come to pass.
+
+But Minerva would not let the suitors for one moment cease their
+insolence, for she wanted Ulysses to become even more bitter against
+them; she therefore set Eurymachus son of Polybus on to gibe at him,
+which made the others laugh. "Listen to me," said he, "you suitors of
+Queen Penelope, that I may speak even as I am minded. It is not for
+nothing that this man has come to the house of Ulysses; I believe the
+light has not been coming from the torches, but from his own head--for
+his hair is all gone, every bit of it."
+
+Then turning to Ulysses he said, "Stranger, will you work as a servant,
+if I send you to the wolds and see that you are well paid? Can you build
+a stone fence, or plant trees? I will have you fed all the year round,
+and will find you in shoes and clothing. Will you go, then? Not you; for
+you have got into bad ways, and do not want to work; you had rather fill
+your belly by going round the country begging."
+
+"Eurymachus," answered Ulysses, "if you and I were to work one against
+the other in early summer when the days are at their longest--give me a
+good scythe, and take another yourself, and let us see which will last
+the longer or mow the stronger, from dawn till dark when the mowing
+grass is about. Or if you will plough against me, let us each take a
+yoke of tawny oxen, well-mated and of great strength and endurance:
+turn me into a four acre field, and see whether you or I can drive the
+straighter furrow. If, again, war were to break out this day, give me
+a shield, a couple of spears and a helmet fitting well upon my
+temples--you would find me foremost in the fray, and would cease your
+gibes about my belly. You are insolent and cruel, and think yourself
+a great man because you live in a little world, and that a bad one. If
+Ulysses comes to his own again, the doors of his house are wide, but you
+will find them narrow when you try to fly through them."
+
+Eurymachus was furious at all this. He scowled at him and cried, "You
+wretch, I will soon pay you out for daring to say such things to me, and
+in public too. Has the wine been getting into your head or do you always
+babble in this way? You seem to have lost your wits because you beat the
+tramp Irus." With this he caught hold of a footstool, but Ulysses sought
+protection at the knees of Amphinomus of Dulichium, for he was afraid.
+The stool hit the cupbearer on his right hand and knocked him down: the
+man fell with a cry flat on his back, and his wine-jug fell ringing to
+the ground. The suitors in the covered cloister were now in an uproar,
+and one would turn towards his neighbour, saying, "I wish the stranger
+had gone somewhere else, bad luck to him, for all the trouble he gives
+us. We cannot permit such disturbance about a beggar; if such ill
+counsels are to prevail we shall have no more pleasure at our banquet."
+
+On this Telemachus came forward and said, "Sirs, are you mad? Can you
+not carry your meat and your liquor decently? Some evil spirit has
+possessed you. I do not wish to drive any of you away, but you have had
+your suppers, and the sooner you all go home to bed the better."
+
+The suitors bit their lips and marvelled at the boldness of his speech;
+but Amphinomus the son of Nisus, who was son to Aretias, said, "Do not
+let us take offence; it is reasonable, so let us make no answer. Neither
+let us do violence to the stranger nor to any of Ulysses' servants. Let
+the cupbearer go round with the drink-offerings, that we may make them
+and go home to our rest. As for the stranger, let us leave Telemachus to
+deal with him, for it is to his house that he has come."
+
+Thus did he speak, and his saying pleased them well, so Mulius of
+Dulichium, servant to Amphinomus, mixed them a bowl of wine and water
+and handed it round to each of them man by man, whereon they made their
+drink-offerings to the blessed gods: Then, when they had made their
+drink-offerings and had drunk each one as he was minded, they took their
+several ways each of them to his own abode.
+
+
+Book XIX
+
+TELEMACHUS AND ULYSSES REMOVE THE ARMOUR--ULYSSES INTERVIEWS
+PENELOPE--EURYCLEA WASHES HIS FEET AND RECOGNISES THE SCAR ON HIS
+LEG--PENELOPE TELLS HER DREAM TO ULYSSES.
+
+Ulysses was left in the cloister, pondering on the means whereby with
+Minerva's help he might be able to kill the suitors. Presently he said
+to Telemachus, "Telemachus, we must get the armour together and take
+it down inside. Make some excuse when the suitors ask you why you have
+removed it. Say that you have taken it to be out of the way of the
+smoke, inasmuch as it is no longer what it was when Ulysses went
+away, but has become soiled and begrimed with soot. Add to this more
+particularly that you are afraid Jove may set them on to quarrel over
+their wine, and that they may do each other some harm which may disgrace
+both banquet and wooing, for the sight of arms sometimes tempts people
+to use them."
+
+Telemachus approved of what his father had said, so he called nurse
+Euryclea and said, "Nurse, shut the women up in their room, while I take
+the armour that my father left behind him down into the store room. No
+one looks after it now my father is gone, and it has got all smirched
+with soot during my own boyhood. I want to take it down where the smoke
+cannot reach it."
+
+"I wish, child," answered Euryclea, "that you would take the management
+of the house into your own hands altogether, and look after all the
+property yourself. But who is to go with you and light you to the
+store-room? The maids would have done so, but you would not let them."
+
+"The stranger," said Telemachus, "shall show me a light; when people eat
+my bread they must earn it, no matter where they come from."
+
+Euryclea did as she was told, and bolted the women inside their room.
+Then Ulysses and his son made all haste to take the helmets, shields,
+and spears inside; and Minerva went before them with a gold lamp in her
+hand that shed a soft and brilliant radiance, whereon Telemachus said,
+"Father, my eyes behold a great marvel: the walls, with the rafters,
+crossbeams, and the supports on which they rest are all aglow as with
+a flaming fire. Surely there is some god here who has come down from
+heaven."
+
+"Hush," answered Ulysses, "hold your peace and ask no questions, for
+this is the manner of the gods. Get you to your bed, and leave me here
+to talk with your mother and the maids. Your mother in her grief will
+ask me all sorts of questions."
+
+On this Telemachus went by torch-light to the other side of the inner
+court, to the room in which he always slept. There he lay in his bed
+till morning, while Ulysses was left in the cloister pondering on the
+means whereby with Minerva's help he might be able to kill the suitors.
+
+Then Penelope came down from her room looking like Venus or Diana, and
+they set her a seat inlaid with scrolls of silver and ivory near the
+fire in her accustomed place. It had been made by Icmalius and had a
+footstool all in one piece with the seat itself; and it was covered with
+a thick fleece: on this she now sat, and the maids came from the women's
+room to join her. They set about removing the tables at which the wicked
+suitors had been dining, and took away the bread that was left, with
+the cups from which they had drunk. They emptied the embers out of the
+braziers, and heaped much wood upon them to give both light and heat;
+but Melantho began to rail at Ulysses a second time and said, "Stranger,
+do you mean to plague us by hanging about the house all night and spying
+upon the women? Be off, you wretch, outside, and eat your supper there,
+or you shall be driven out with a firebrand."
+
+Ulysses scowled at her and answered, "My good woman, why should you be
+so angry with me? Is it because I am not clean, and my clothes are all
+in rags, and because I am obliged to go begging about after the manner
+of tramps and beggars generally? I too was a rich man once, and had a
+fine house of my own; in those days I gave to many a tramp such as I now
+am, no matter who he might be nor what he wanted. I had any number of
+servants, and all the other things which people have who live well and
+are accounted wealthy, but it pleased Jove to take all away from me;
+therefore, woman, beware lest you too come to lose that pride and place
+in which you now wanton above your fellows; have a care lest you get
+out of favour with your mistress, and lest Ulysses should come home, for
+there is still a chance that he may do so. Moreover, though he be dead
+as you think he is, yet by Apollo's will he has left a son behind him,
+Telemachus, who will note anything done amiss by the maids in the house,
+for he is now no longer in his boyhood."
+
+Penelope heard what he was saying and scolded the maid, "Impudent
+baggage," said she, "I see how abominably you are behaving, and you
+shall smart for it. You knew perfectly well, for I told you myself, that
+I was going to see the stranger and ask him about my husband, for whose
+sake I am in such continual sorrow."
+
+Then she said to her head waiting woman Eurynome, "Bring a seat with a
+fleece upon it, for the stranger to sit upon while he tells his story,
+and listens to what I have to say. I wish to ask him some questions."
+
+Eurynome brought the seat at once and set a fleece upon it, and as soon
+as Ulysses had sat down Penelope began by saying, "Stranger, I shall
+first ask you who and whence are you? Tell me of your town and parents."
+
+"Madam," answered Ulysses, "who on the face of the whole earth can dare
+to chide with you? Your fame reaches the firmament of heaven itself; you
+are like some blameless king, who upholds righteousness, as the monarch
+over a great and valiant nation: the earth yields its wheat and barley,
+the trees are loaded with fruit, the ewes bring forth lambs, and the sea
+abounds with fish by reason of his virtues, and his people do good deeds
+under him. Nevertheless, as I sit here in your house, ask me some other
+question and do not seek to know my race and family, or you will recall
+memories that will yet more increase my sorrow. I am full of heaviness,
+but I ought not to sit weeping and wailing in another person's house,
+nor is it well to be thus grieving continually. I shall have one of the
+servants or even yourself complaining of me, and saying that my eyes
+swim with tears because I am heavy with wine."
+
+Then Penelope answered, "Stranger, heaven robbed me of all beauty,
+whether of face or figure, when the Argives set sail for Troy and my
+dear husband with them. If he were to return and look after my affairs
+I should be both more respected and should show a better presence to
+the world. As it is, I am oppressed with care, and with the afflictions
+which heaven has seen fit to heap upon me. The chiefs from all our
+islands--Dulichium, Same, and Zacynthus, as also from Ithaca itself,
+are wooing me against my will and are wasting my estate. I can therefore
+show no attention to strangers, nor suppliants, nor to people who say
+that they are skilled artisans, but am all the time broken-hearted
+about Ulysses. They want me to marry again at once, and I have to invent
+stratagems in order to deceive them. In the first place heaven put it in
+my mind to set up a great tambour-frame in my room, and to begin
+working upon an enormous piece of fine needlework. Then I said to them,
+'Sweethearts, Ulysses is indeed dead, still, do not press me to marry
+again immediately; wait--for I would not have my skill in needlework
+perish unrecorded--till I have finished making a pall for the hero
+Laertes, to be ready against the time when death shall take him. He
+is very rich, and the women of the place will talk if he is laid out
+without a pall.' This was what I said, and they assented; whereon I
+used to keep working at my great web all day long, but at night I would
+unpick the stitches again by torch light. I fooled them in this way for
+three years without their finding it out, but as time wore on and I was
+now in my fourth year, in the waning of moons, and many days had been
+accomplished, those good for nothing hussies my maids betrayed me to the
+suitors, who broke in upon me and caught me; they were very angry with
+me, so I was forced to finish my work whether I would or no. And now
+I do not see how I can find any further shift for getting out of this
+marriage. My parents are putting great pressure upon me, and my son
+chafes at the ravages the suitors are making upon his estate, for he is
+now old enough to understand all about it and is perfectly able to look
+after his own affairs, for heaven has blessed him with an excellent
+disposition. Still, notwithstanding all this, tell me who you are and
+where you come from--for you must have had father and mother of some
+sort; you cannot be the son of an oak or of a rock."
+
+Then Ulysses answered, "Madam, wife of Ulysses, since you persist in
+asking me about my family, I will answer, no matter what it costs me:
+people must expect to be pained when they have been exiles as long as
+I have, and suffered as much among as many peoples. Nevertheless, as
+regards your question I will tell you all you ask. There is a fair and
+fruitful island in mid-ocean called Crete; it is thickly peopled and
+there are ninety cities in it: the people speak many different languages
+which overlap one another, for there are Achaeans, brave Eteocretans,
+Dorians of three-fold race, and noble Pelasgi. There is a great
+town there, Cnossus, where Minos reigned who every nine years had a
+conference with Jove himself. {152} Minos was father to Deucalion, whose
+son I am, for Deucalion had two sons Idomeneus and myself. Idomeneus
+sailed for Troy, and I, who am the younger, am called Aethon; my
+brother, however, was at once the older and the more valiant of the two;
+hence it was in Crete that I saw Ulysses and showed him hospitality, for
+the winds took him there as he was on his way to Troy, carrying him out
+of his course from cape Malea and leaving him in Amnisus off the cave of
+Ilithuia, where the harbours are difficult to enter and he could hardly
+find shelter from the winds that were then raging. As soon as he got
+there he went into the town and asked for Idomeneus, claiming to be his
+old and valued friend, but Idomeneus had already set sail for Troy some
+ten or twelve days earlier, so I took him to my own house and showed him
+every kind of hospitality, for I had abundance of everything. Moreover,
+I fed the men who were with him with barley meal from the public store,
+and got subscriptions of wine and oxen for them to sacrifice to their
+heart's content. They stayed with me twelve days, for there was a gale
+blowing from the North so strong that one could hardly keep one's feet
+on land. I suppose some unfriendly god had raised it for them, but on
+the thirteenth day the wind dropped, and they got away."
+
+Many a plausible tale did Ulysses further tell her, and Penelope wept
+as she listened, for her heart was melted. As the snow wastes upon the
+mountain tops when the winds from South East and West have breathed upon
+it and thawed it till the rivers run bank full with water, even so did
+her cheeks overflow with tears for the husband who was all the time
+sitting by her side. Ulysses felt for her and was sorry for her, but he
+kept his eyes as hard as horn or iron without letting them so much
+as quiver, so cunningly did he restrain his tears. Then, when she had
+relieved herself by weeping, she turned to him again and said: "Now,
+stranger, I shall put you to the test and see whether or no you really
+did entertain my husband and his men, as you say you did. Tell me, then,
+how he was dressed, what kind of a man he was to look at, and so also
+with his companions."
+
+"Madam," answered Ulysses, "it is such a long time ago that I can hardly
+say. Twenty years are come and gone since he left my home, and went
+elsewhither; but I will tell you as well as I can recollect. Ulysses
+wore a mantle of purple wool, double lined, and it was fastened by a
+gold brooch with two catches for the pin. On the face of this there was
+a device that shewed a dog holding a spotted fawn between his fore paws,
+and watching it as it lay panting upon the ground. Every one marvelled
+at the way in which these things had been done in gold, the dog
+looking at the fawn, and strangling it, while the fawn was struggling
+convulsively to escape. {153} As for the shirt that he wore next his
+skin, it was so soft that it fitted him like the skin of an onion, and
+glistened in the sunlight to the admiration of all the women who beheld
+it. Furthermore I say, and lay my saying to your heart, that I do not
+know whether Ulysses wore these clothes when he left home, or whether
+one of his companions had given them to him while he was on his voyage;
+or possibly some one at whose house he was staying made him a present
+of them, for he was a man of many friends and had few equals among the
+Achaeans. I myself gave him a sword of bronze and a beautiful purple
+mantle, double lined, with a shirt that went down to his feet, and I
+sent him on board his ship with every mark of honour. He had a servant
+with him, a little older than himself, and I can tell you what he was
+like; his shoulders were hunched, {154} he was dark, and he had thick
+curly hair. His name was Eurybates, and Ulysses treated him with greater
+familiarity than he did any of the others, as being the most like-minded
+with himself."
+
+Penelope was moved still more deeply as she heard the indisputable
+proofs that Ulysses laid before her; and when she had again found relief
+in tears she said to him, "Stranger, I was already disposed to pity you,
+but henceforth you shall be honoured and made welcome in my house. It
+was I who gave Ulysses the clothes you speak of. I took them out of
+the store room and folded them up myself, and I gave him also the gold
+brooch to wear as an ornament. Alas! I shall never welcome him home
+again. It was by an ill fate that he ever set out for that detested city
+whose very name I cannot bring myself even to mention."
+
+Then Ulysses answered, "Madam, wife of Ulysses, do not disfigure
+yourself further by grieving thus bitterly for your loss, though I can
+hardly blame you for doing so. A woman who has loved her husband and
+borne him children, would naturally be grieved at losing him, even
+though he were a worse man than Ulysses, who they say was like a god.
+Still, cease your tears and listen to what I can tell you. I will hide
+nothing from you, and can say with perfect truth that I have lately
+heard of Ulysses as being alive and on his way home; he is among the
+Thesprotians, and is bringing back much valuable treasure that he has
+begged from one and another of them; but his ship and all his crew
+were lost as they were leaving the Thrinacian island, for Jove and
+the sun-god were angry with him because his men had slaughtered the
+sun-god's cattle, and they were all drowned to a man. But Ulysses
+stuck to the keel of the ship and was drifted on to the land of the
+Phaeacians, who are near of kin to the immortals, and who treated him
+as though he had been a god, giving him many presents, and wishing to
+escort him home safe and sound. In fact Ulysses would have been here
+long ago, had he not thought better to go from land to land gathering
+wealth; for there is no man living who is so wily as he is; there is no
+one can compare with him. Pheidon king of the Thesprotians told me all
+this, and he swore to me--making drink-offerings in his house as he did
+so--that the ship was by the water side and the crew found who would
+take Ulysses to his own country. He sent me off first, for there
+happened to be a Thesprotian ship sailing for the wheat-growing
+island of Dulichium, but he showed me all the treasure Ulysses had got
+together, and he had enough lying in the house of king Pheidon to keep
+his family for ten generations; but the king said Ulysses had gone to
+Dodona that he might learn Jove's mind from the high oak tree, and know
+whether after so long an absence he should return to Ithaca openly or in
+secret. So you may know he is safe and will be here shortly; he is close
+at hand and cannot remain away from home much longer; nevertheless I
+will confirm my words with an oath, and call Jove who is the first and
+mightiest of all gods to witness, as also that hearth of Ulysses to
+which I have now come, that all I have spoken shall surely come to pass.
+Ulysses will return in this self same year; with the end of this moon
+and the beginning of the next he will be here."
+
+"May it be even so," answered Penelope; "if your words come true you
+shall have such gifts and such good will from me that all who see you
+shall congratulate you; but I know very well how it will be. Ulysses
+will not return, neither will you get your escort hence, for so surely
+as that Ulysses ever was, there are now no longer any such masters in
+the house as he was, to receive honourable strangers or to further them
+on their way home. And now, you maids, wash his feet for him, and make
+him a bed on a couch with rugs and blankets, that he may be warm and
+quiet till morning. Then, at day break wash him and anoint him again,
+that he may sit in the cloister and take his meals with Telemachus. It
+shall be the worse for any one of these hateful people who is uncivil to
+him; like it or not, he shall have no more to do in this house. For how,
+sir, shall you be able to learn whether or no I am superior to others of
+my sex both in goodness of heart and understanding, if I let you dine in
+my cloisters squalid and ill clad? Men live but for a little season; if
+they are hard, and deal hardly, people wish them ill so long as they are
+alive, and speak contemptuously of them when they are dead, but he that
+is righteous and deals righteously, the people tell of his praise among
+all lands, and many shall call him blessed."
+
+Ulysses answered, "Madam, I have foresworn rugs and blankets from the
+day that I left the snowy ranges of Crete to go on shipboard. I will
+lie as I have lain on many a sleepless night hitherto. Night after night
+have I passed in any rough sleeping place, and waited for morning. Nor,
+again, do I like having my feet washed; I shall not let any of the young
+hussies about your house touch my feet; but, if you have any old and
+respectable woman who has gone through as much trouble as I have, I will
+allow her to wash them."
+
+To this Penelope said, "My dear sir, of all the guests who ever yet
+came to my house there never was one who spoke in all things with such
+admirable propriety as you do. There happens to be in the house a most
+respectable old woman--the same who received my poor dear husband in
+her arms the night he was born, and nursed him in infancy. She is
+very feeble now, but she shall wash your feet." "Come here," said she,
+"Euryclea, and wash your master's age-mate; I suppose Ulysses' hands and
+feet are very much the same now as his are, for trouble ages all of us
+dreadfully fast."
+
+On these words the old woman covered her face with her hands; she began
+to weep and made lamentation saying, "My dear child, I cannot think
+whatever I am to do with you. I am certain no one was ever more
+god-fearing than yourself, and yet Jove hates you. No one in the whole
+world ever burned him more thigh bones, nor gave him finer hecatombs
+when you prayed you might come to a green old age yourself and see your
+son grow up to take after you: yet see how he has prevented you alone
+from ever getting back to your own home. I have no doubt the women in
+some foreign palace which Ulysses has got to are gibing at him as all
+these sluts here have been gibing at you. I do not wonder at your
+not choosing to let them wash you after the manner in which they have
+insulted you; I will wash your feet myself gladly enough, as Penelope
+has said that I am to do so; I will wash them both for Penelope's
+sake and for your own, for you have raised the most lively feelings of
+compassion in my mind; and let me say this moreover, which pray attend
+to; we have had all kinds of strangers in distress come here before now,
+but I make bold to say that no one ever yet came who was so like Ulysses
+in figure, voice, and feet as you are."
+
+"Those who have seen us both," answered Ulysses, "have always said we
+were wonderfully like each other, and now you have noticed it too."
+
+Then the old woman took the cauldron in which she was going to wash his
+feet, and poured plenty of cold water into it, adding hot till the bath
+was warm enough. Ulysses sat by the fire, but ere long he turned away
+from the light, for it occurred to him that when the old woman had hold
+of his leg she would recognise a certain scar which it bore, whereon the
+whole truth would come out. And indeed as soon as she began washing her
+master, she at once knew the scar as one that had been given him by
+a wild boar when he was hunting on Mt. Parnassus with his excellent
+grandfather Autolycus--who was the most accomplished thief and perjurer
+in the whole world--and with the sons of Autolycus. Mercury himself had
+endowed him with this gift, for he used to burn the thigh bones of goats
+and kids to him, so he took pleasure in his companionship. It happened
+once that Autolycus had gone to Ithaca and had found the child of his
+daughter just born. As soon as he had done supper Euryclea set the
+infant upon his knees and said, "Autolycus, you must find a name for
+your grandson; you greatly wished that you might have one."
+
+"Son-in-law and daughter," replied Autolycus, "call the child thus: I
+am highly displeased with a large number of people in one place and
+another, both men and women; so name the child 'Ulysses,' or the child
+of anger. When he grows up and comes to visit his mother's family on Mt.
+Parnassus, where my possessions lie, I will make him a present and will
+send him on his way rejoicing."
+
+Ulysses, therefore, went to Parnassus to get the presents from
+Autolycus, who with his sons shook hands with him and gave him welcome.
+His grandmother Amphithea threw her arms about him, and kissed his head,
+and both his beautiful eyes, while Autolycus desired his sons to get
+dinner ready, and they did as he told them. They brought in a five year
+old bull, flayed it, made it ready and divided it into joints; these
+they then cut carefully up into smaller pieces and spitted them; they
+roasted them sufficiently and served the portions round. Thus through
+the livelong day to the going down of the sun they feasted, and every
+man had his full share so that all were satisfied; but when the sun set
+and it came on dark, they went to bed and enjoyed the boon of sleep.
+
+When the child of morning, rosy-fingered Dawn, appeared, the sons of
+Autolycus went out with their hounds hunting, and Ulysses went too.
+They climbed the wooded slopes of Parnassus and soon reached its breezy
+upland valleys; but as the sun was beginning to beat upon the fields,
+fresh-risen from the slow still currents of Oceanus, they came to a
+mountain dell. The dogs were in front searching for the tracks of the
+beast they were chasing, and after them came the sons of Autolycus,
+among whom was Ulysses, close behind the dogs, and he had a long
+spear in his hand. Here was the lair of a huge boar among some thick
+brushwood, so dense that the wind and rain could not get through it, nor
+could the sun's rays pierce it, and the ground underneath lay thick
+with fallen leaves. The boar heard the noise of the men's feet, and the
+hounds baying on every side as the huntsmen came up to him, so he rushed
+from his lair, raised the bristles on his neck, and stood at bay with
+fire flashing from his eyes. Ulysses was the first to raise his spear
+and try to drive it into the brute, but the boar was too quick for him,
+and charged him sideways, ripping him above the knee with a gash that
+tore deep though it did not reach the bone. As for the boar, Ulysses hit
+him on the right shoulder, and the point of the spear went right through
+him, so that he fell groaning in the dust until the life went out of
+him. The sons of Autolycus busied themselves with the carcass of the
+boar, and bound Ulysses' wound; then, after saying a spell to stop the
+bleeding, they went home as fast as they could. But when Autolycus and
+his sons had thoroughly healed Ulysses, they made him some splendid
+presents, and sent him back to Ithaca with much mutual good will. When
+he got back, his father and mother were rejoiced to see him, and asked
+him all about it, and how he had hurt himself to get the scar; so he
+told them how the boar had ripped him when he was out hunting with
+Autolycus and his sons on Mt. Parnassus.
+
+As soon as Euryclea had got the scarred limb in her hands and had well
+hold of it, she recognised it and dropped the foot at once. The leg fell
+into the bath, which rang out and was overturned, so that all the water
+was spilt on the ground; Euryclea's eyes between her joy and her grief
+filled with tears, and she could not speak, but she caught Ulysses
+by the beard and said, "My dear child, I am sure you must be Ulysses
+himself, only I did not know you till I had actually touched and handled
+you."
+
+As she spoke she looked towards Penelope, as though wanting to tell her
+that her dear husband was in the house, but Penelope was unable to
+look in that direction and observe what was going on, for Minerva had
+diverted her attention; so Ulysses caught Euryclea by the throat with
+his right hand and with his left drew her close to him, and said,
+"Nurse, do you wish to be the ruin of me, you who nursed me at your own
+breast, now that after twenty years of wandering I am at last come to
+my own home again? Since it has been borne in upon you by heaven to
+recognise me, hold your tongue, and do not say a word about it to any
+one else in the house, for if you do I tell you--and it shall surely
+be--that if heaven grants me to take the lives of these suitors, I will
+not spare you, though you are my own nurse, when I am killing the other
+women."
+
+"My child," answered Euryclea, "what are you talking about? You know
+very well that nothing can either bend or break me. I will hold my
+tongue like a stone or a piece of iron; furthermore let me say, and lay
+my saying to your heart, when heaven has delivered the suitors into your
+hand, I will give you a list of the women in the house who have been
+ill-behaved, and of those who are guiltless."
+
+And Ulysses answered, "Nurse, you ought not to speak in that way; I am
+well able to form my own opinion about one and all of them; hold your
+tongue and leave everything to heaven."
+
+As he said this Euryclea left the cloister to fetch some more water, for
+the first had been all spilt; and when she had washed him and anointed
+him with oil, Ulysses drew his seat nearer to the fire to warm himself,
+and hid the scar under his rags. Then Penelope began talking to him and
+said:
+
+"Stranger, I should like to speak with you briefly about another matter.
+It is indeed nearly bed time--for those, at least, who can sleep in
+spite of sorrow. As for myself, heaven has given me a life of such
+unmeasurable woe, that even by day when I am attending to my duties and
+looking after the servants, I am still weeping and lamenting during the
+whole time; then, when night comes, and we all of us go to bed, I lie
+awake thinking, and my heart becomes a prey to the most incessant and
+cruel tortures. As the dun nightingale, daughter of Pandareus, sings in
+the early spring from her seat in shadiest covert hid, and with many
+a plaintive trill pours out the tale how by mishap she killed her own
+child Itylus, son of king Zethus, even so does my mind toss and turn in
+its uncertainty whether I ought to stay with my son here, and safeguard
+my substance, my bondsmen, and the greatness of my house, out of regard
+to public opinion and the memory of my late husband, or whether it is
+not now time for me to go with the best of these suitors who are wooing
+me and making me such magnificent presents. As long as my son was still
+young, and unable to understand, he would not hear of my leaving my
+husband's house, but now that he is full grown he begs and prays me to
+do so, being incensed at the way in which the suitors are eating up his
+property. Listen, then, to a dream that I have had and interpret it for
+me if you can. I have twenty geese about the house that eat mash out
+of a trough, {155} and of which I am exceedingly fond. I dreamed that a
+great eagle came swooping down from a mountain, and dug his curved beak
+into the neck of each of them till he had killed them all. Presently
+he soared off into the sky, and left them lying dead about the yard;
+whereon I wept in my dream till all my maids gathered round me, so
+piteously was I grieving because the eagle had killed my geese. Then he
+came back again, and perching on a projecting rafter spoke to me with
+human voice, and told me to leave off crying. 'Be of good courage,' he
+said, 'daughter of Icarius; this is no dream, but a vision of good omen
+that shall surely come to pass. The geese are the suitors, and I am no
+longer an eagle, but your own husband, who am come back to you, and who
+will bring these suitors to a disgraceful end.' On this I woke, and when
+I looked out I saw my geese at the trough eating their mash as usual."
+
+"This dream, Madam," replied Ulysses, "can admit but of one
+interpretation, for had not Ulysses himself told you how it shall be
+fulfilled? The death of the suitors is portended, and not one single one
+of them will escape."
+
+And Penelope answered, "Stranger, dreams are very curious and
+unaccountable things, and they do not by any means invariably come true.
+There are two gates through which these unsubstantial fancies proceed;
+the one is of horn, and the other ivory. Those that come through
+the gate of ivory are fatuous, but those from the gate of horn mean
+something to those that see them. I do not think, however, that my own
+dream came through the gate of horn, though I and my son should be most
+thankful if it proves to have done so. Furthermore I say--and lay my
+saying to your heart--the coming dawn will usher in the ill-omened day
+that is to sever me from the house of Ulysses, for I am about to hold a
+tournament of axes. My husband used to set up twelve axes in the court,
+one in front of the other, like the stays upon which a ship is built;
+he would then go back from them and shoot an arrow through the whole
+twelve. I shall make the suitors try to do the same thing, and whichever
+of them can string the bow most easily, and send his arrow through all
+the twelve axes, him will I follow, and quit this house of my lawful
+husband, so goodly and so abounding in wealth. But even so, I doubt not
+that I shall remember it in my dreams."
+
+Then Ulysses answered, "Madam, wife of Ulysses, you need not defer your
+tournament, for Ulysses will return ere ever they can string the bow,
+handle it how they will, and send their arrows through the iron."
+
+To this Penelope said, "As long, sir, as you will sit here and talk
+to me, I can have no desire to go to bed. Still, people cannot do
+permanently without sleep, and heaven has appointed us dwellers on earth
+a time for all things. I will therefore go upstairs and recline upon
+that couch which I have never ceased to flood with my tears from the day
+Ulysses set out for the city with a hateful name."
+
+She then went upstairs to her own room, not alone, but attended by her
+maidens, and when there, she lamented her dear husband till Minerva shed
+sweet sleep over her eyelids.
+
+
+Book XX
+
+ULYSSES CANNOT SLEEP--PENELOPE'S PRAYER TO DIANA--THE TWO SIGNS FROM
+HEAVEN--EUMAEUS AND PHILOETIUS ARRIVE--THE SUITORS DINE--CTESIPPUS
+THROWS AN OX'S FOOT AT ULYSSES--THEOCLYMENUS FORETELLS DISASTER AND
+LEAVES THE HOUSE.
+
+Ulysses slept in the cloister upon an undressed bullock's hide, on the
+top of which he threw several skins of the sheep the suitors had eaten,
+and Eurynome {156} threw a cloak over him after he had laid himself
+down. There, then, Ulysses lay wakefully brooding upon the way in which
+he should kill the suitors; and by and by, the women who had been in the
+habit of misconducting themselves with them, left the house giggling and
+laughing with one another. This made Ulysses very angry, and he doubted
+whether to get up and kill every single one of them then and there, or
+to let them sleep one more and last time with the suitors. His heart
+growled within him, and as a bitch with puppies growls and shows her
+teeth when she sees a stranger, so did his heart growl with anger at
+the evil deeds that were being done: but he beat his breast and said,
+"Heart, be still, you had worse than this to bear on the day when the
+terrible Cyclops ate your brave companions; yet you bore it in silence
+till your cunning got you safe out of the cave, though you made sure of
+being killed."
+
+Thus he chided with his heart, and checked it into endurance, but he
+tossed about as one who turns a paunch full of blood and fat in front
+of a hot fire, doing it first on one side and then on the other, that he
+may get it cooked as soon as possible, even so did he turn himself about
+from side to side, thinking all the time how, single handed as he was,
+he should contrive to kill so large a body of men as the wicked suitors.
+But by and by Minerva came down from heaven in the likeness of a woman,
+and hovered over his head saying, "My poor unhappy man, why do you lie
+awake in this way? This is your house: your wife is safe inside it, and
+so is your son who is just such a young man as any father may be proud
+of."
+
+"Goddess," answered Ulysses, "all that you have said is true, but I am
+in some doubt as to how I shall be able to kill these wicked suitors
+single handed, seeing what a number of them there always are. And there
+is this further difficulty, which is still more considerable. Supposing
+that with Jove's and your assistance I succeed in killing them, I must
+ask you to consider where I am to escape to from their avengers when it
+is all over."
+
+"For shame," replied Minerva, "why, any one else would trust a worse
+ally than myself, even though that ally were only a mortal and less wise
+than I am. Am I not a goddess, and have I not protected you throughout
+in all your troubles? I tell you plainly that even though there were
+fifty bands of men surrounding us and eager to kill us, you should take
+all their sheep and cattle, and drive them away with you. But go to
+sleep; it is a very bad thing to lie awake all night, and you shall be
+out of your troubles before long."
+
+As she spoke she shed sleep over his eyes, and then went back to
+Olympus.
+
+While Ulysses was thus yielding himself to a very deep slumber that
+eased the burden of his sorrows, his admirable wife awoke, and sitting
+up in her bed began to cry. When she had relieved herself by weeping she
+prayed to Diana saying, "Great Goddess Diana, daughter of Jove, drive an
+arrow into my heart and slay me; or let some whirlwind snatch me up and
+bear me through paths of darkness till it drop me into the mouths
+of over-flowing Oceanus, as it did the daughters of Pandareus. The
+daughters of Pandareus lost their father and mother, for the gods killed
+them, so they were left orphans. But Venus took care of them, and fed
+them on cheese, honey, and sweet wine. Juno taught them to excel all
+women in beauty of form and understanding; Diana gave them an imposing
+presence, and Minerva endowed them with every kind of accomplishment;
+but one day when Venus had gone up to Olympus to see Jove about getting
+them married (for well does he know both what shall happen and what
+not happen to every one) the storm winds came and spirited them away to
+become handmaids to the dread Erinyes. Even so I wish that the gods who
+live in heaven would hide me from mortal sight, or that fair Diana might
+strike me, for I would fain go even beneath the sad earth if I might
+do so still looking towards Ulysses only, and without having to yield
+myself to a worse man than he was. Besides, no matter how much people
+may grieve by day, they can put up with it so long as they can sleep at
+night, for when the eyes are closed in slumber people forget good and
+ill alike; whereas my misery haunts me even in my dreams. This very
+night methought there was one lying by my side who was like Ulysses as
+he was when he went away with his host, and I rejoiced, for I believed
+that it was no dream, but the very truth itself."
+
+On this the day broke, but Ulysses heard the sound of her weeping, and
+it puzzled him, for it seemed as though she already knew him and was by
+his side. Then he gathered up the cloak and the fleeces on which he had
+lain, and set them on a seat in the cloister, but he took the bullock's
+hide out into the open. He lifted up his hands to heaven, and prayed,
+saying "Father Jove, since you have seen fit to bring me over land and
+sea to my own home after all the afflictions you have laid upon me, give
+me a sign out of the mouth of some one or other of those who are now
+waking within the house, and let me have another sign of some kind from
+outside."
+
+Thus did he pray. Jove heard his prayer and forthwith thundered high
+up among the clouds from the splendour of Olympus, and Ulysses was glad
+when he heard it. At the same time within the house, a miller-woman from
+hard by in the mill room lifted up her voice and gave him another sign.
+There were twelve miller-women whose business it was to grind wheat and
+barley which are the staff of life. The others had ground their task and
+had gone to take their rest, but this one had not yet finished, for
+she was not so strong as they were, and when she heard the thunder she
+stopped grinding and gave the sign to her master. "Father Jove," said
+she, "you, who rule over heaven and earth, you have thundered from a
+clear sky without so much as a cloud in it, and this means something for
+somebody; grant the prayer, then, of me your poor servant who calls
+upon you, and let this be the very last day that the suitors dine in the
+house of Ulysses. They have worn me out with labour of grinding meal for
+them, and I hope they may never have another dinner anywhere at all."
+
+Ulysses was glad when he heard the omens conveyed to him by the woman's
+speech, and by the thunder, for he knew they meant that he should avenge
+himself on the suitors.
+
+Then the other maids in the house rose and lit the fire on the hearth;
+Telemachus also rose and put on his clothes. He girded his sword about
+his shoulder, bound his sandals on to his comely feet, and took a
+doughty spear with a point of sharpened bronze; then he went to the
+threshold of the cloister and said to Euryclea, "Nurse, did you make the
+stranger comfortable both as regards bed and board, or did you let him
+shift for himself?--for my mother, good woman though she is, has a
+way of paying great attention to second-rate people, and of neglecting
+others who are in reality much better men."
+
+"Do not find fault child," said Euryclea, "when there is no one to find
+fault with. The stranger sat and drank his wine as long as he liked:
+your mother did ask him if he would take any more bread and he said he
+would not. When he wanted to go to bed she told the servants to make one
+for him, but he said he was such a wretched outcast that he would not
+sleep on a bed and under blankets; he insisted on having an undressed
+bullock's hide and some sheepskins put for him in the cloister and I
+threw a cloak over him myself." {157}
+
+Then Telemachus went out of the court to the place where the Achaeans
+were meeting in assembly; he had his spear in his hand, and he was not
+alone, for his two dogs went with him. But Euryclea called the maids and
+said, "Come, wake up; set about sweeping the cloisters and sprinkling
+them with water to lay the dust; put the covers on the seats; wipe down
+the tables, some of you, with a wet sponge; clean out the mixing-jugs
+and the cups, and go for water from the fountain at once; the suitors
+will be here directly; they will be here early, for it is a feast day."
+
+Thus did she speak, and they did even as she had said: twenty of them
+went to the fountain for water, and the others set themselves busily to
+work about the house. The men who were in attendance on the suitors also
+came up and began chopping firewood. By and by the women returned from
+the fountain, and the swineherd came after them with the three best pigs
+he could pick out. These he let feed about the premises, and then he
+said good-humouredly to Ulysses, "Stranger, are the suitors treating you
+any better now, or are they as insolent as ever?"
+
+"May heaven," answered Ulysses, "requite to them the wickedness with
+which they deal high-handedly in another man's house without any sense
+of shame."
+
+Thus did they converse; meanwhile Melanthius the goatherd came up, for
+he too was bringing in his best goats for the suitors' dinner; and he
+had two shepherds with him. They tied the goats up under the gatehouse,
+and then Melanthius began gibing at Ulysses. "Are you still here,
+stranger," said he, "to pester people by begging about the house? Why
+can you not go elsewhere? You and I shall not come to an understanding
+before we have given each other a taste of our fists. You beg without
+any sense of decency: are there not feasts elsewhere among the Achaeans,
+as well as here?"
+
+Ulysses made no answer, but bowed his head and brooded. Then a third
+man, Philoetius, joined them, who was bringing in a barren heifer and
+some goats. These were brought over by the boatmen who are there to take
+people over when any one comes to them. So Philoetius made his heifer
+and his goats secure under the gatehouse, and then went up to the
+swineherd. "Who, Swineherd," said he, "is this stranger that is lately
+come here? Is he one of your men? What is his family? Where does he come
+from? Poor fellow, he looks as if he had been some great man, but the
+gods give sorrow to whom they will--even to kings if it so pleases
+them."
+
+As he spoke he went up to Ulysses and saluted him with his right hand;
+"Good day to you, father stranger," said he, "you seem to be very poorly
+off now, but I hope you will have better times by and by. Father Jove,
+of all gods you are the most malicious. We are your own children, yet
+you show us no mercy in all our misery and afflictions. A sweat came
+over me when I saw this man, and my eyes filled with tears, for he
+reminds me of Ulysses, who I fear is going about in just such rags as
+this man's are, if indeed he is still among the living. If he is already
+dead and in the house of Hades, then, alas! for my good master, who made
+me his stockman when I was quite young among the Cephallenians, and now
+his cattle are countless; no one could have done better with them than I
+have, for they have bred like ears of corn; nevertheless I have to keep
+bringing them in for others to eat, who take no heed to his son though
+he is in the house, and fear not the wrath of heaven, but are already
+eager to divide Ulysses' property among them because he has been away so
+long. I have often thought--only it would not be right while his son
+is living--of going off with the cattle to some foreign country; bad as
+this would be, it is still harder to stay here and be ill-treated about
+other people's herds. My position is intolerable, and I should long
+since have run away and put myself under the protection of some other
+chief, only that I believe my poor master will yet return, and send all
+these suitors flying out of the house."
+
+"Stockman," answered Ulysses, "you seem to be a very well-disposed
+person, and I can see that you are a man of sense. Therefore I will tell
+you, and will confirm my words with an oath. By Jove, the chief of all
+gods, and by that hearth of Ulysses to which I am now come, Ulysses
+shall return before you leave this place, and if you are so minded you
+shall see him killing the suitors who are now masters here."
+
+"If Jove were to bring this to pass," replied the stockman, "you should
+see how I would do my very utmost to help him."
+
+And in like manner Eumaeus prayed that Ulysses might return home.
+
+Thus did they converse. Meanwhile the suitors were hatching a plot to
+murder Telemachus: but a bird flew near them on their left hand--an
+eagle with a dove in its talons. On this Amphinomus said, "My friends,
+this plot of ours to murder Telemachus will not succeed; let us go to
+dinner instead."
+
+The others assented, so they went inside and laid their cloaks on the
+benches and seats. They sacrificed the sheep, goats, pigs, and the
+heifer, and when the inward meats were cooked they served them round.
+They mixed the wine in the mixing-bowls, and the swineherd gave every
+man his cup, while Philoetius handed round the bread in the bread
+baskets, and Melanthius poured them out their wine. Then they laid their
+hands upon the good things that were before them.
+
+Telemachus purposely made Ulysses sit in the part of the cloister that
+was paved with stone; {158} he gave him a shabby looking seat at a
+little table to himself, and had his portion of the inward meats brought
+to him, with his wine in a gold cup. "Sit there," said he, "and drink
+your wine among the great people. I will put a stop to the gibes and
+blows of the suitors, for this is no public house, but belongs to
+Ulysses, and has passed from him to me. Therefore, suitors, keep your
+hands and your tongues to yourselves, or there will be mischief."
+
+The suitors bit their lips, and marvelled at the boldness of his speech;
+then Antinous said, "We do not like such language but we will put up
+with it, for Telemachus is threatening us in good earnest. If Jove had
+let us we should have put a stop to his brave talk ere now."
+
+Thus spoke Antinous, but Telemachus heeded him not. Meanwhile the
+heralds were bringing the holy hecatomb through the city, and the
+Achaeans gathered under the shady grove of Apollo.
+
+Then they roasted the outer meat, drew it off the spits, gave every man
+his portion, and feasted to their heart's content; those who waited
+at table gave Ulysses exactly the same portion as the others had, for
+Telemachus had told them to do so.
+
+But Minerva would not let the suitors for one moment drop their
+insolence, for she wanted Ulysses to become still more bitter against
+them. Now there happened to be among them a ribald fellow, whose name
+was Ctesippus, and who came from Same. This man, confident in his
+great wealth, was paying court to the wife of Ulysses, and said to the
+suitors, "Hear what I have to say. The stranger has already had as
+large a portion as any one else; this is well, for it is not right nor
+reasonable to ill-treat any guest of Telemachus who comes here. I
+will, however, make him a present on my own account, that he may have
+something to give to the bath-woman, or to some other of Ulysses'
+servants."
+
+As he spoke he picked up a heifer's foot from the meat-basket in which
+it lay, and threw it at Ulysses, but Ulysses turned his head a little
+aside, and avoided it, smiling grimly Sardinian fashion {159} as he did
+so, and it hit the wall, not him. On this Telemachus spoke fiercely to
+Ctesippus, "It is a good thing for you," said he, "that the stranger
+turned his head so that you missed him. If you had hit him I should have
+run you through with my spear, and your father would have had to see
+about getting you buried rather than married in this house. So let me
+have no more unseemly behaviour from any of you, for I am grown up
+now to the knowledge of good and evil and understand what is going on,
+instead of being the child that I have been heretofore. I have long seen
+you killing my sheep and making free with my corn and wine: I have put
+up with this, for one man is no match for many, but do me no further
+violence. Still, if you wish to kill me, kill me; I would far rather die
+than see such disgraceful scenes day after day--guests insulted, and men
+dragging the women servants about the house in an unseemly way."
+
+They all held their peace till at last Agelaus son of Damastor said, "No
+one should take offence at what has just been said, nor gainsay it, for
+it is quite reasonable. Leave off, therefore, ill-treating the stranger,
+or any one else of the servants who are about the house; I would say,
+however, a friendly word to Telemachus and his mother, which I trust may
+commend itself to both. 'As long,' I would say, 'as you had ground for
+hoping that Ulysses would one day come home, no one could complain of
+your waiting and suffering {160} the suitors to be in your house. It
+would have been better that he should have returned, but it is now
+sufficiently clear that he will never do so; therefore talk all this
+quietly over with your mother, and tell her to marry the best man,
+and the one who makes her the most advantageous offer. Thus you will
+yourself be able to manage your own inheritance, and to eat and drink
+in peace, while your mother will look after some other man's house, not
+yours.'"
+
+To this Telemachus answered, "By Jove, Agelaus, and by the sorrows of my
+unhappy father, who has either perished far from Ithaca, or is wandering
+in some distant land, I throw no obstacles in the way of my mother's
+marriage; on the contrary I urge her to choose whomsoever she will, and
+I will give her numberless gifts into the bargain, but I dare not insist
+point blank that she shall leave the house against her own wishes.
+Heaven forbid that I should do this."
+
+Minerva now made the suitors fall to laughing immoderately, and set
+their wits wandering; but they were laughing with a forced laughter.
+Their meat became smeared with blood; their eyes filled with tears,
+and their hearts were heavy with forebodings. Theoclymenus saw this
+and said, "Unhappy men, what is it that ails you? There is a shroud
+of darkness drawn over you from head to foot, your cheeks are wet with
+tears; the air is alive with wailing voices; the walls and roof-beams
+drip blood; the gate of the cloisters and the court beyond them are full
+of ghosts trooping down into the night of hell; the sun is blotted out
+of heaven, and a blighting gloom is over all the land."
+
+Thus did he speak, and they all of them laughed heartily. Eurymachus
+then said, "This stranger who has lately come here has lost his senses.
+Servants, turn him out into the streets, since he finds it so dark
+here."
+
+But Theoclymenus said, "Eurymachus, you need not send any one with me.
+I have eyes, ears, and a pair of feet of my own, to say nothing of an
+understanding mind. I will take these out of the house with me, for
+I see mischief overhanging you, from which not one of you men who are
+insulting people and plotting ill deeds in the house of Ulysses will be
+able to escape."
+
+He left the house as he spoke, and went back to Piraeus who gave him
+welcome, but the suitors kept looking at one another and provoking
+Telemachus by laughing at the strangers. One insolent fellow said to
+him, "Telemachus, you are not happy in your guests; first you have this
+importunate tramp, who comes begging bread and wine and has no skill
+for work or for hard fighting, but is perfectly useless, and now here is
+another fellow who is setting himself up as a prophet. Let me persuade
+you, for it will be much better to put them on board ship and send them
+off to the Sicels to sell for what they will bring."
+
+Telemachus gave him no heed, but sate silently watching his father,
+expecting every moment that he would begin his attack upon the suitors.
+
+Meanwhile the daughter of Icarius, wise Penelope, had had a rich seat
+placed for her facing the court and cloisters, so that she could hear
+what every one was saying. The dinner indeed had been prepared amid much
+merriment; it had been both good and abundant, for they had sacrificed
+many victims; but the supper was yet to come, and nothing can be
+conceived more gruesome than the meal which a goddess and a brave man
+were soon to lay before them--for they had brought their doom upon
+themselves.
+
+
+Book XXI
+
+THE TRIAL OF THE AXES, DURING WHICH ULYSSES REVEALS HIMSELF TO EUMAEUS
+AND PHILOETIUS
+
+Minerva now put it in Penelope's mind to make the suitors try their
+skill with the bow and with the iron axes, in contest among themselves,
+as a means of bringing about their destruction. She went upstairs and
+got the store-room key, which was made of bronze and had a handle of
+ivory; she then went with her maidens into the store-room at the end of
+the house, where her husband's treasures of gold, bronze, and wrought
+iron were kept, and where was also his bow, and the quiver full of
+deadly arrows that had been given him by a friend whom he had met in
+Lacedaemon--Iphitus the son of Eurytus. The two fell in with one another
+in Messene at the house of Ortilochus, where Ulysses was staying in
+order to recover a debt that was owing from the whole people; for the
+Messenians had carried off three hundred sheep from Ithaca, and had
+sailed away with them and with their shepherds. In quest of these
+Ulysses took a long journey while still quite young, for his father and
+the other chieftains sent him on a mission to recover them. Iphitus had
+gone there also to try and get back twelve brood mares that he had lost,
+and the mule foals that were running with them. These mares were the
+death of him in the end, for when he went to the house of Jove's son,
+mighty Hercules, who performed such prodigies of valour, Hercules to his
+shame killed him, though he was his guest, for he feared not heaven's
+vengeance, nor yet respected his own table which he had set before
+Iphitus, but killed him in spite of everything, and kept the mares
+himself. It was when claiming these that Iphitus met Ulysses, and gave
+him the bow which mighty Eurytus had been used to carry, and which on
+his death had been left by him to his son. Ulysses gave him in return
+a sword and a spear, and this was the beginning of a fast friendship,
+although they never visited at one another's houses, for Jove's son
+Hercules killed Iphitus ere they could do so. This bow, then, given him
+by Iphitus, had not been taken with him by Ulysses when he sailed for
+Troy; he had used it so long as he had been at home, but had left it
+behind as having been a keepsake from a valued friend.
+
+Penelope presently reached the oak threshold of the store-room; the
+carpenter had planed this duly, and had drawn a line on it so as to get
+it quite straight; he had then set the door posts into it and hung the
+doors. She loosed the strap from the handle of the door, put in the key,
+and drove it straight home to shoot back the bolts that held the doors;
+{161} these flew open with a noise like a bull bellowing in a meadow,
+and Penelope stepped upon the raised platform, where the chests stood in
+which the fair linen and clothes were laid by along with fragrant herbs:
+reaching thence, she took down the bow with its bow case from the peg
+on which it hung. She sat down with it on her knees, weeping bitterly as
+she took the bow out of its case, and when her tears had relieved her,
+she went to the cloister where the suitors were, carrying the bow and
+the quiver, with the many deadly arrows that were inside it. Along
+with her came her maidens, bearing a chest that contained much iron
+and bronze which her husband had won as prizes. When she reached the
+suitors, she stood by one of the bearing-posts supporting the roof of
+the cloister, holding a veil before her face, and with a maid on either
+side of her. Then she said:
+
+"Listen to me you suitors, who persist in abusing the hospitality of
+this house because its owner has been long absent, and without other
+pretext than that you want to marry me; this, then, being the prize that
+you are contending for, I will bring out the mighty bow of Ulysses, and
+whomsoever of you shall string it most easily and send his arrow through
+each one of twelve axes, him will I follow and quit this house of my
+lawful husband, so goodly, and so abounding in wealth. But even so I
+doubt not that I shall remember it in my dreams."
+
+As she spoke, she told Eumaeus to set the bow and the pieces of iron
+before the suitors, and Eumaeus wept as he took them to do as she had
+bidden him. Hard by, the stockman wept also when he saw his master's
+bow, but Antinous scolded them. "You country louts," said he, "silly
+simpletons; why should you add to the sorrows of your mistress by crying
+in this way? She has enough to grieve her in the loss of her husband;
+sit still, therefore, and eat your dinners in silence, or go outside if
+you want to cry, and leave the bow behind you. We suitors shall have to
+contend for it with might and main, for we shall find it no light matter
+to string such a bow as this is. There is not a man of us all who is
+such another as Ulysses; for I have seen him and remember him, though I
+was then only a child."
+
+This was what he said, but all the time he was expecting to be able to
+string the bow and shoot through the iron, whereas in fact he was to
+be the first that should taste of the arrows from the hands of Ulysses,
+whom he was dishonouring in his own house--egging the others on to do so
+also.
+
+Then Telemachus spoke. "Great heavens!" he exclaimed, "Jove must have
+robbed me of my senses. Here is my dear and excellent mother saying she
+will quit this house and marry again, yet I am laughing and enjoying
+myself as though there were nothing happening. But, suitors, as the
+contest has been agreed upon, let it go forward. It is for a woman whose
+peer is not to be found in Pylos, Argos, or Mycene, nor yet in Ithaca
+nor on the mainland. You know this as well as I do; what need have I to
+speak in praise of my mother? Come on, then, make no excuses for delay,
+but let us see whether you can string the bow or no. I too will make
+trial of it, for if I can string it and shoot through the iron, I shall
+not suffer my mother to quit this house with a stranger, not if I can
+win the prizes which my father won before me."
+
+As he spoke he sprang from his seat, threw his crimson cloak from him,
+and took his sword from his shoulder. First he set the axes in a row, in
+a long groove which he had dug for them, and had made straight by line.
+{162} Then he stamped the earth tight round them, and everyone was
+surprised when they saw him set them up so orderly, though he had never
+seen anything of the kind before. This done, he went on to the pavement
+to make trial of the bow; thrice did he tug at it, trying with all his
+might to draw the string, and thrice he had to leave off, though he had
+hoped to string the bow and shoot through the iron. He was trying for
+the fourth time, and would have strung it had not Ulysses made a sign to
+check him in spite of all his eagerness. So he said:
+
+"Alas! I shall either be always feeble and of no prowess, or I am too
+young, and have not yet reached my full strength so as to be able
+to hold my own if any one attacks me. You others, therefore, who are
+stronger than I, make trial of the bow and get this contest settled."
+
+On this he put the bow down, letting it lean against the door [that led
+into the house] with the arrow standing against the top of the bow. Then
+he sat down on the seat from which he had risen, and Antinous said:
+
+"Come on each of you in his turn, going towards the right from the place
+at which the cupbearer begins when he is handing round the wine."
+
+The rest agreed, and Leiodes son of Oenops was the first to rise. He
+was sacrificial priest to the suitors, and sat in the corner near the
+mixing-bowl. {163} He was the only man who hated their evil deeds and
+was indignant with the others. He was now the first to take the bow and
+arrow, so he went on to the pavement to make his trial, but he could not
+string the bow, for his hands were weak and unused to hard work, they
+therefore soon grew tired, and he said to the suitors, "My friends, I
+cannot string it; let another have it, this bow shall take the life and
+soul out of many a chief among us, for it is better to die than to live
+after having missed the prize that we have so long striven for, and
+which has brought us so long together. Some one of us is even now hoping
+and praying that he may marry Penelope, but when he has seen this bow
+and tried it, let him woo and make bridal offerings to some other woman,
+and let Penelope marry whoever makes her the best offer and whose lot it
+is to win her."
+
+On this he put the bow down, letting it lean against the door, {164}
+with the arrow standing against the tip of the bow. Then he took his
+seat again on the seat from which he had risen; and Antinous rebuked him
+saying:
+
+"Leiodes, what are you talking about? Your words are monstrous and
+intolerable; it makes me angry to listen to you. Shall, then, this bow
+take the life of many a chief among us, merely because you cannot bend
+it yourself? True, you were not born to be an archer, but there are
+others who will soon string it."
+
+Then he said to Melanthius the goatherd, "Look sharp, light a fire in
+the court, and set a seat hard by with a sheep skin on it; bring us also
+a large ball of lard, from what they have in the house. Let us warm the
+bow and grease it--we will then make trial of it again, and bring the
+contest to an end."
+
+Melanthius lit the fire, and set a seat covered with sheep skins beside
+it. He also brought a great ball of lard from what they had in the
+house, and the suitors warmed the bow and again made trial of it, but
+they were none of them nearly strong enough to string it. Nevertheless
+there still remained Antinous and Eurymachus, who were the ringleaders
+among the suitors and much the foremost among them all.
+
+Then the swineherd and the stockman left the cloisters together, and
+Ulysses followed them. When they had got outside the gates and the outer
+yard, Ulysses said to them quietly:
+
+"Stockman, and you swineherd, I have something in my mind which I am in
+doubt whether to say or no; but I think I will say it. What manner of
+men would you be to stand by Ulysses, if some god should bring him back
+here all of a sudden? Say which you are disposed to do--to side with the
+suitors, or with Ulysses?"
+
+"Father Jove," answered the stockman, "would indeed that you might so
+ordain it. If some god were but to bring Ulysses back, you should see
+with what might and main I would fight for him."
+
+In like words Eumaeus prayed to all the gods that Ulysses might return;
+when, therefore, he saw for certain what mind they were of, Ulysses
+said, "It is I, Ulysses, who am here. I have suffered much, but at last,
+in the twentieth year, I am come back to my own country. I find that you
+two alone of all my servants are glad that I should do so, for I
+have not heard any of the others praying for my return. To you two,
+therefore, will I unfold the truth as it shall be. If heaven shall
+deliver the suitors into my hands, I will find wives for both of you,
+will give you house and holding close to my own, and you shall be to me
+as though you were brothers and friends of Telemachus. I will now give
+you convincing proofs that you may know me and be assured. See, here is
+the scar from the boar's tooth that ripped me when I was out hunting on
+Mt. Parnassus with the sons of Autolycus."
+
+As he spoke he drew his rags aside from the great scar, and when they
+had examined it thoroughly, they both of them wept about Ulysses, threw
+their arms round him, and kissed his head and shoulders, while Ulysses
+kissed their hands and faces in return. The sun would have gone down
+upon their mourning if Ulysses had not checked them and said:
+
+"Cease your weeping, lest some one should come outside and see us, and
+tell those who are within. When you go in, do so separately, not both
+together; I will go first, and do you follow afterwards; let this
+moreover be the token between us; the suitors will all of them try to
+prevent me from getting hold of the bow and quiver; do you, therefore,
+Eumaeus, place it in my hands when you are carrying it about, and
+tell the women to close the doors of their apartment. If they hear any
+groaning or uproar as of men fighting about the house, they must not
+come out; they must keep quiet, and stay where they are at their work.
+And I charge you, Philoetius, to make fast the doors of the outer court,
+and to bind them securely at once."
+
+When he had thus spoken, he went back to the house and took the seat
+that he had left. Presently, his two servants followed him inside.
+
+At this moment the bow was in the hands of Eurymachus, who was warming
+it by the fire, but even so he could not string it, and he was greatly
+grieved. He heaved a deep sigh and said, "I grieve for myself and for us
+all; I grieve that I shall have to forgo the marriage, but I do not care
+nearly so much about this, for there are plenty of other women in Ithaca
+and elsewhere; what I feel most is the fact of our being so inferior to
+Ulysses in strength that we cannot string his bow. This will disgrace us
+in the eyes of those who are yet unborn."
+
+"It shall not be so, Eurymachus," said Antinous, "and you know it
+yourself. Today is the feast of Apollo throughout all the land; who can
+string a bow on such a day as this? Put it on one side--as for the axes
+they can stay where they are, for no one is likely to come to the house
+and take them away: let the cupbearer go round with his cups, that we
+may make our drink-offerings and drop this matter of the bow; we will
+tell Melanthius to bring us in some goats tomorrow--the best he has; we
+can then offer thigh bones to Apollo the mighty archer, and again make
+trial of the bow, so as to bring the contest to an end."
+
+The rest approved his words, and thereon men servants poured water over
+the hands of the guests, while pages filled the mixing-bowls with wine
+and water and handed it round after giving every man his drink-offering.
+Then, when they had made their offerings and had drunk each as much as
+he desired, Ulysses craftily said:--
+
+"Suitors of the illustrious queen, listen that I may speak even as I am
+minded. I appeal more especially to Eurymachus, and to Antinous who
+has just spoken with so much reason. Cease shooting for the present and
+leave the matter to the gods, but in the morning let heaven give victory
+to whom it will. For the moment, however, give me the bow that I may
+prove the power of my hands among you all, and see whether I still have
+as much strength as I used to have, or whether travel and neglect have
+made an end of it."
+
+This made them all very angry, for they feared he might string the bow,
+Antinous therefore rebuked him fiercely saying, "Wretched creature, you
+have not so much as a grain of sense in your whole body; you ought
+to think yourself lucky in being allowed to dine unharmed among your
+betters, without having any smaller portion served you than we others
+have had, and in being allowed to hear our conversation. No other beggar
+or stranger has been allowed to hear what we say among ourselves; the
+wine must have been doing you a mischief, as it does with all those who
+drink immoderately. It was wine that inflamed the Centaur Eurytion when
+he was staying with Peirithous among the Lapithae. When the wine had
+got into his head, he went mad and did ill deeds about the house of
+Peirithous; this angered the heroes who were there assembled, so they
+rushed at him and cut off his ears and nostrils; then they dragged him
+through the doorway out of the house, so he went away crazed, and bore
+the burden of his crime, bereft of understanding. Henceforth, therefore,
+there was war between mankind and the centaurs, but he brought it upon
+himself through his own drunkenness. In like manner I can tell you that
+it will go hardly with you if you string the bow: you will find no mercy
+from any one here, for we shall at once ship you off to king Echetus,
+who kills every one that comes near him: you will never get away alive,
+so drink and keep quiet without getting into a quarrel with men younger
+than yourself."
+
+Penelope then spoke to him. "Antinous," said she, "it is not right that
+you should ill-treat any guest of Telemachus who comes to this house.
+If the stranger should prove strong enough to string the mighty bow of
+Ulysses, can you suppose that he would take me home with him and make me
+his wife? Even the man himself can have no such idea in his mind:
+none of you need let that disturb his feasting; it would be out of all
+reason."
+
+"Queen Penelope," answered Eurymachus, "we do not suppose that this man
+will take you away with him; it is impossible; but we are afraid lest
+some of the baser sort, men or women among the Achaeans, should go
+gossiping about and say, 'These suitors are a feeble folk; they are
+paying court to the wife of a brave man whose bow not one of them was
+able to string, and yet a beggarly tramp who came to the house strung it
+at once and sent an arrow through the iron.' This is what will be said,
+and it will be a scandal against us."
+
+"Eurymachus," Penelope answered, "people who persist in eating up the
+estate of a great chieftain and dishonouring his house must not expect
+others to think well of them. Why then should you mind if men talk as
+you think they will? This stranger is strong and well-built, he says
+moreover that he is of noble birth. Give him the bow, and let us see
+whether he can string it or no. I say--and it shall surely be--that if
+Apollo vouchsafes him the glory of stringing it, I will give him a cloak
+and shirt of good wear, with a javelin to keep off dogs and robbers,
+and a sharp sword. I will also give him sandals, and will see him sent
+safely wherever he wants to go."
+
+Then Telemachus said, "Mother, I am the only man either in Ithaca or in
+the islands that are over against Elis who has the right to let any
+one have the bow or to refuse it. No one shall force me one way or the
+other, not even though I choose to make the stranger a present of the
+bow outright, and let him take it away with him. Go, then, within the
+house and busy yourself with your daily duties, your loom, your distaff,
+and the ordering of your servants. This bow is a man's matter, and mine
+above all others, for it is I who am master here."
+
+She went wondering back into the house, and laid her son's saying in her
+heart. Then going upstairs with her handmaids into her room, she mourned
+her dear husband till Minerva sent sweet sleep over her eyelids.
+
+The swineherd now took up the bow and was for taking it to Ulysses, but
+the suitors clamoured at him from all parts of the cloisters, and one of
+them said, "You idiot, where are you taking the bow to? Are you out of
+your wits? If Apollo and the other gods will grant our prayer, your own
+boarhounds shall get you into some quiet little place, and worry you to
+death."
+
+Eumaeus was frightened at the outcry they all raised, so he put the bow
+down then and there, but Telemachus shouted out at him from the other
+side of the cloisters, and threatened him saying, "Father Eumaeus,
+bring the bow on in spite of them, or young as I am I will pelt you with
+stones back to the country, for I am the better man of the two. I wish
+I was as much stronger than all the other suitors in the house as I am
+than you, I would soon send some of them off sick and sorry, for they
+mean mischief."
+
+Thus did he speak, and they all of them laughed heartily, which put them
+in a better humour with Telemachus; so Eumaeus brought the bow on and
+placed it in the hands of Ulysses. When he had done this, he called
+Euryclea apart and said to her, "Euryclea, Telemachus says you are to
+close the doors of the women's apartments. If they hear any groaning or
+uproar as of men fighting about the house, they are not to come out, but
+are to keep quiet and stay where they are at their work."
+
+Euryclea did as she was told and closed the doors of the women's
+apartments.
+
+Meanwhile Philoetius slipped quietly out and made fast the gates of
+the outer court. There was a ship's cable of byblus fibre lying in the
+gatehouse, so he made the gates fast with it and then came in again,
+resuming the seat that he had left, and keeping an eye on Ulysses, who
+had now got the bow in his hands, and was turning it every way about,
+and proving it all over to see whether the worms had been eating into
+its two horns during his absence. Then would one turn towards his
+neighbour saying, "This is some tricky old bow-fancier; either he has
+got one like it at home, or he wants to make one, in such workmanlike
+style does the old vagabond handle it."
+
+Another said, "I hope he may be no more successful in other things than
+he is likely to be in stringing this bow."
+
+But Ulysses, when he had taken it up and examined it all over, strung it
+as easily as a skilled bard strings a new peg of his lyre and makes
+the twisted gut fast at both ends. Then he took it in his right hand
+to prove the string, and it sang sweetly under his touch like the
+twittering of a swallow. The suitors were dismayed, and turned colour
+as they heard it; at that moment, moreover, Jove thundered loudly as a
+sign, and the heart of Ulysses rejoiced as he heard the omen that the
+son of scheming Saturn had sent him.
+
+He took an arrow that was lying upon the table {165}--for those
+which the Achaeans were so shortly about to taste were all inside the
+quiver--he laid it on the centre-piece of the bow, and drew the notch of
+the arrow and the string toward him, still seated on his seat. When
+he had taken aim he let fly, and his arrow pierced every one of the
+handle-holes of the axes from the first onwards till it had gone right
+through them, and into the outer courtyard. Then he said to Telemachus:
+
+"Your guest has not disgraced you, Telemachus. I did not miss what I
+aimed at, and I was not long in stringing my bow. I am still strong, and
+not as the suitors twit me with being. Now, however, it is time for
+the Achaeans to prepare supper while there is still daylight, and
+then otherwise to disport themselves with song and dance which are the
+crowning ornaments of a banquet."
+
+As he spoke he made a sign with his eyebrows, and Telemachus girded on
+his sword, grasped his spear, and stood armed beside his father's seat.
+
+
+Book XXII
+
+THE KILLING OF THE SUITORS--THE MAIDS WHO HAVE MISCONDUCTED THEMSELVES
+ARE MADE TO CLEANSE THE CLOISTERS AND ARE THEN HANGED.
+
+Then Ulysses tore off his rags, and sprang on to the broad pavement
+with his bow and his quiver full of arrows. He shed the arrows on to the
+ground at his feet and said, "The mighty contest is at an end. I will
+now see whether Apollo will vouchsafe it to me to hit another mark which
+no man has yet hit."
+
+On this he aimed a deadly arrow at Antinous, who was about to take up a
+two-handled gold cup to drink his wine and already had it in his hands.
+He had no thought of death--who amongst all the revellers would think
+that one man, however brave, would stand alone among so many and kill
+him? The arrow struck Antinous in the throat, and the point went clean
+through his neck, so that he fell over and the cup dropped from his
+hand, while a thick stream of blood gushed from his nostrils. He kicked
+the table from him and upset the things on it, so that the bread and
+roasted meats were all soiled as they fell over on to the ground. {166}
+The suitors were in an uproar when they saw that a man had been hit;
+they sprang in dismay one and all of them from their seats and looked
+everywhere towards the walls, but there was neither shield nor spear,
+and they rebuked Ulysses very angrily. "Stranger," said they, "you shall
+pay for shooting people in this way: you shall see no other contest;
+you are a doomed man; he whom you have slain was the foremost youth in
+Ithaca, and the vultures shall devour you for having killed him."
+
+Thus they spoke, for they thought that he had killed Antinous by
+mistake, and did not perceive that death was hanging over the head of
+every one of them. But Ulysses glared at them and said:
+
+"Dogs, did you think that I should not come back from Troy? You have
+wasted my substance, {167} have forced my women servants to lie with
+you, and have wooed my wife while I was still living. You have feared
+neither God nor man, and now you shall die."
+
+They turned pale with fear as he spoke, and every man looked round about
+to see whither he might fly for safety, but Eurymachus alone spoke.
+
+"If you are Ulysses," said he, "then what you have said is just. We have
+done much wrong on your lands and in your house. But Antinous who was
+the head and front of the offending lies low already. It was all his
+doing. It was not that he wanted to marry Penelope; he did not so much
+care about that; what he wanted was something quite different, and Jove
+has not vouchsafed it to him; he wanted to kill your son and to be chief
+man in Ithaca. Now, therefore, that he has met the death which was his
+due, spare the lives of your people. We will make everything good among
+ourselves, and pay you in full for all that we have eaten and drunk.
+Each one of us shall pay you a fine worth twenty oxen, and we will keep
+on giving you gold and bronze till your heart is softened. Until we have
+done this no one can complain of your being enraged against us."
+
+Ulysses again glared at him and said, "Though you should give me all
+that you have in the world both now and all that you ever shall have,
+I will not stay my hand till I have paid all of you in full. You must
+fight, or fly for your lives; and fly, not a man of you shall."
+
+Their hearts sank as they heard him, but Eurymachus again spoke saying:
+
+"My friends, this man will give us no quarter. He will stand where he
+is and shoot us down till he has killed every man among us. Let us then
+show fight; draw your swords, and hold up the tables to shield you
+from his arrows. Let us have at him with a rush, to drive him from the
+pavement and doorway: we can then get through into the town, and raise
+such an alarm as shall soon stay his shooting."
+
+As he spoke he drew his keen blade of bronze, sharpened on both sides,
+and with a loud cry sprang towards Ulysses, but Ulysses instantly shot
+an arrow into his breast that caught him by the nipple and fixed itself
+in his liver. He dropped his sword and fell doubled up over his table.
+The cup and all the meats went over on to the ground as he smote the
+earth with his forehead in the agonies of death, and he kicked the stool
+with his feet until his eyes were closed in darkness.
+
+Then Amphinomus drew his sword and made straight at Ulysses to try and
+get him away from the door; but Telemachus was too quick for him, and
+struck him from behind; the spear caught him between the shoulders and
+went right through his chest, so that he fell heavily to the ground and
+struck the earth with his forehead. Then Telemachus sprang away from
+him, leaving his spear still in the body, for he feared that if he
+stayed to draw it out, some one of the Achaeans might come up and hack
+at him with his sword, or knock him down, so he set off at a run, and
+immediately was at his father's side. Then he said:
+
+"Father, let me bring you a shield, two spears, and a brass helmet for
+your temples. I will arm myself as well, and will bring other armour for
+the swineherd and the stockman, for we had better be armed."
+
+"Run and fetch them," answered Ulysses, "while my arrows hold out, or
+when I am alone they may get me away from the door."
+
+Telemachus did as his father said, and went off to the store room where
+the armour was kept. He chose four shields, eight spears, and four brass
+helmets with horse-hair plumes. He brought them with all speed to his
+father, and armed himself first, while the stockman and the swineherd
+also put on their armour, and took their places near Ulysses. Meanwhile
+Ulysses, as long as his arrows lasted, had been shooting the suitors one
+by one, and they fell thick on one another: when his arrows gave out, he
+set the bow to stand against the end wall of the house by the door post,
+and hung a shield four hides thick about his shoulders; on his comely
+head he set his helmet, well wrought with a crest of horse-hair that
+nodded menacingly above it, {168} and he grasped two redoubtable
+bronze-shod spears.
+
+Now there was a trap door {169} on the wall, while at one end of the
+pavement {170} there was an exit leading to a narrow passage, and this
+exit was closed by a well-made door. Ulysses told Philoetius to stand by
+this door and guard it, for only one person could attack it at a time.
+But Agelaus shouted out, "Cannot some one go up to the trap door and
+tell the people what is going on? Help would come at once, and we should
+soon make an end of this man and his shooting."
+
+"This may not be, Agelaus," answered Melanthius, "the mouth of the
+narrow passage is dangerously near the entrance to the outer court. One
+brave man could prevent any number from getting in. But I know what I
+will do, I will bring you arms from the store-room, for I am sure it is
+there that Ulysses and his son have put them."
+
+On this the goatherd Melanthius went by back passages to the store-room
+of Ulysses' house. There he chose twelve shields, with as many helmets
+and spears, and brought them back as fast as he could to give them to
+the suitors. Ulysses' heart began to fail him when he saw the suitors
+{171} putting on their armour and brandishing their spears. He saw the
+greatness of the danger, and said to Telemachus, "Some one of the women
+inside is helping the suitors against us, or it may be Melanthius."
+
+Telemachus answered, "The fault, father, is mine, and mine only; I left
+the store room door open, and they have kept a sharper look out than
+I have. Go, Eumaeus, put the door to, and see whether it is one of the
+women who is doing this, or whether, as I suspect, it is Melanthius the
+son of Dolius."
+
+Thus did they converse. Meanwhile Melanthius was again going to the
+store room to fetch more armour, but the swineherd saw him and said to
+Ulysses who was beside him, "Ulysses, noble son of Laertes, it is that
+scoundrel Melanthius, just as we suspected, who is going to the store
+room. Say, shall I kill him, if I can get the better of him, or shall
+I bring him here that you may take your own revenge for all the many
+wrongs that he has done in your house?"
+
+Ulysses answered, "Telemachus and I will hold these suitors in check, no
+matter what they do; go back both of you and bind Melanthius' hands and
+feet behind him. Throw him into the store room and make the door fast
+behind you; then fasten a noose about his body, and string him close up
+to the rafters from a high bearing-post, {172} that he may linger on in
+an agony."
+
+Thus did he speak, and they did even as he had said; they went to the
+store room, which they entered before Melanthius saw them, for he was
+busy searching for arms in the innermost part of the room, so the
+two took their stand on either side of the door and waited. By and by
+Melanthius came out with a helmet in one hand, and an old dry-rotted
+shield in the other, which had been borne by Laertes when he was young,
+but which had been long since thrown aside, and the straps had become
+unsewn; on this the two seized him, dragged him back by the hair, and
+threw him struggling to the ground. They bent his hands and feet well
+behind his back, and bound them tight with a painful bond as Ulysses had
+told them; then they fastened a noose about his body and strung him up
+from a high pillar till he was close up to the rafters, and over him did
+you then vaunt, O swineherd Eumaeus saying, "Melanthius, you will pass
+the night on a soft bed as you deserve. You will know very well when
+morning comes from the streams of Oceanus, and it is time for you to be
+driving in your goats for the suitors to feast on."
+
+There, then, they left him in very cruel bondage, and having put on
+their armour they closed the door behind them and went back to take
+their places by the side of Ulysses; whereon the four men stood in the
+cloister, fierce and full of fury; nevertheless, those who were in the
+body of the court were still both brave and many. Then Jove's daughter
+Minerva came up to them, having assumed the voice and form of Mentor.
+Ulysses was glad when he saw her and said, "Mentor, lend me your help,
+and forget not your old comrade, nor the many good turns he has done
+you. Besides, you are my age-mate."
+
+But all the time he felt sure it was Minerva, and the suitors from the
+other side raised an uproar when they saw her. Agelaus was the first to
+reproach her. "Mentor," he cried, "do not let Ulysses beguile you into
+siding with him and fighting the suitors. This is what we will do: when
+we have killed these people, father and son, we will kill you too. You
+shall pay for it with your head, and when we have killed you, we will
+take all you have, in doors or out, and bring it into hotch-pot with
+Ulysses' property; we will not let your sons live in your house, nor
+your daughters, nor shall your widow continue to live in the city of
+Ithaca."
+
+This made Minerva still more furious, so she scolded Ulysses very
+angrily. {173} "Ulysses," said she, "your strength and prowess are no
+longer what they were when you fought for nine long years among the
+Trojans about the noble lady Helen. You killed many a man in those days,
+and it was through your stratagem that Priam's city was taken. How comes
+it that you are so lamentably less valiant now that you are on your own
+ground, face to face with the suitors in your own house? Come on, my
+good fellow, stand by my side and see how Mentor, son of Alcimus shall
+fight your foes and requite your kindnesses conferred upon him."
+
+But she would not give him full victory as yet, for she wished still
+further to prove his own prowess and that of his brave son, so she flew
+up to one of the rafters in the roof of the cloister and sat upon it in
+the form of a swallow.
+
+Meanwhile Agelaus son of Damastor, Eurynomus, Amphimedon, Demoptolemus,
+Pisander, and Polybus son of Polyctor bore the brunt of the fight upon
+the suitors' side; of all those who were still fighting for their lives
+they were by far the most valiant, for the others had already fallen
+under the arrows of Ulysses. Agelaus shouted to them and said, "My
+friends, he will soon have to leave off, for Mentor has gone away after
+having done nothing for him but brag. They are standing at the doors
+unsupported. Do not aim at him all at once, but six of you throw your
+spears first, and see if you cannot cover yourselves with glory by
+killing him. When he has fallen we need not be uneasy about the others."
+
+They threw their spears as he bade them, but Minerva made them all of
+no effect. One hit the door post; another went against the door; the
+pointed shaft of another struck the wall; and as soon as they had
+avoided all the spears of the suitors Ulysses said to his own men, "My
+friends, I should say we too had better let drive into the middle of
+them, or they will crown all the harm they have done us by killing us
+outright."
+
+They therefore aimed straight in front of them and threw their spears.
+Ulysses killed Demoptolemus, Telemachus Euryades, Eumaeus Elatus, while
+the stockman killed Pisander. These all bit the dust, and as the others
+drew back into a corner Ulysses and his men rushed forward and regained
+their spears by drawing them from the bodies of the dead.
+
+The suitors now aimed a second time, but again Minerva made their
+weapons for the most part without effect. One hit a bearing-post of
+the cloister; another went against the door; while the pointed shaft of
+another struck the wall. Still, Amphimedon just took a piece of the
+top skin from off Telemachus's wrist, and Ctesippus managed to graze
+Eumaeus's shoulder above his shield; but the spear went on and fell
+to the ground. Then Ulysses and his men let drive into the crowd of
+suitors. Ulysses hit Eurydamas, Telemachus Amphimedon, and Eumaeus
+Polybus. After this the stockman hit Ctesippus in the breast, and
+taunted him saying, "Foul-mouthed son of Polytherses, do not be so
+foolish as to talk wickedly another time, but let heaven direct your
+speech, for the gods are far stronger than men. I make you a present of
+this advice to repay you for the foot which you gave Ulysses when he was
+begging about in his own house."
+
+Thus spoke the stockman, and Ulysses struck the son of Damastor with a
+spear in close fight, while Telemachus hit Leocritus son of Evenor in
+the belly, and the dart went clean through him, so that he fell forward
+full on his face upon the ground. Then Minerva from her seat on the
+rafter held up her deadly aegis, and the hearts of the suitors quailed.
+They fled to the other end of the court like a herd of cattle maddened
+by the gadfly in early summer when the days are at their longest. As
+eagle-beaked, crook-taloned vultures from the mountains swoop down on
+the smaller birds that cower in flocks upon the ground, and kill
+them, for they cannot either fight or fly, and lookers on enjoy the
+sport--even so did Ulysses and his men fall upon the suitors and smite
+them on every side. They made a horrible groaning as their brains were
+being battered in, and the ground seethed with their blood.
+
+Leiodes then caught the knees of Ulysses and said, "Ulysses I beseech
+you have mercy upon me and spare me. I never wronged any of the women in
+your house either in word or deed, and I tried to stop the others. I
+saw them, but they would not listen, and now they are paying for their
+folly. I was their sacrificing priest; if you kill me, I shall die
+without having done anything to deserve it, and shall have got no thanks
+for all the good that I did."
+
+Ulysses looked sternly at him and answered, "If you were their
+sacrificing priest, you must have prayed many a time that it might be
+long before I got home again, and that you might marry my wife and have
+children by her. Therefore you shall die."
+
+With these words he picked up the sword that Agelaus had dropped when
+he was being killed, and which was lying upon the ground. Then he struck
+Leiodes on the back of his neck, so that his head fell rolling in the
+dust while he was yet speaking.
+
+The minstrel Phemius son of Terpes--he who had been forced by the
+suitors to sing to them--now tried to save his life. He was standing
+near towards the trap door, {174} and held his lyre in his hand. He did
+not know whether to fly out of the cloister and sit down by the altar of
+Jove that was in the outer court, and on which both Laertes and Ulysses
+had offered up the thigh bones of many an ox, or whether to go straight
+up to Ulysses and embrace his knees, but in the end he deemed it best
+to embrace Ulysses' knees. So he laid his lyre on the ground between the
+mixing bowl {175} and the silver-studded seat; then going up to Ulysses
+he caught hold of his knees and said, "Ulysses, I beseech you have mercy
+on me and spare me. You will be sorry for it afterwards if you kill a
+bard who can sing both for gods and men as I can. I make all my lays
+myself, and heaven visits me with every kind of inspiration. I would
+sing to you as though you were a god, do not therefore be in such a
+hurry to cut my head off. Your own son Telemachus will tell you that I
+did not want to frequent your house and sing to the suitors after their
+meals, but they were too many and too strong for me, so they made me."
+
+Telemachus heard him, and at once went up to his father. "Hold!" he
+cried, "the man is guiltless, do him no hurt; and we will spare Medon
+too, who was always good to me when I was a boy, unless Philoetius or
+Eumaeus has already killed him, or he has fallen in your way when you
+were raging about the court."
+
+Medon caught these words of Telemachus, for he was crouching under a
+seat beneath which he had hidden by covering himself up with a freshly
+flayed heifer's hide, so he threw off the hide, went up to Telemachus,
+and laid hold of his knees.
+
+"Here I am, my dear sir," said he, "stay your hand therefore, and tell
+your father, or he will kill me in his rage against the suitors for
+having wasted his substance and been so foolishly disrespectful to
+yourself."
+
+Ulysses smiled at him and answered, "Fear not; Telemachus has saved your
+life, that you may know in future, and tell other people, how greatly
+better good deeds prosper than evil ones. Go, therefore, outside
+the cloisters into the outer court, and be out of the way of the
+slaughter--you and the bard--while I finish my work here inside."
+
+The pair went into the outer court as fast as they could, and sat down
+by Jove's great altar, looking fearfully round, and still expecting that
+they would be killed. Then Ulysses searched the whole court carefully
+over, to see if anyone had managed to hide himself and was still living,
+but he found them all lying in the dust and weltering in their blood.
+They were like fishes which fishermen have netted out of the sea, and
+thrown upon the beach to lie gasping for water till the heat of the sun
+makes an end of them. Even so were the suitors lying all huddled up one
+against the other.
+
+Then Ulysses said to Telemachus, "Call nurse Euryclea; I have something
+to say to her."
+
+Telemachus went and knocked at the door of the women's room. "Make
+haste," said he, "you old woman who have been set over all the other
+women in the house. Come outside; my father wishes to speak to you."
+
+When Euryclea heard this she unfastened the door of the women's room
+and came out, following Telemachus. She found Ulysses among the
+corpses bespattered with blood and filth like a lion that has just been
+devouring an ox, and his breast and both his cheeks are all bloody, so
+that he is a fearful sight; even so was Ulysses besmirched from head
+to foot with gore. When she saw all the corpses and such a quantity of
+blood, she was beginning to cry out for joy, for she saw that a great
+deed had been done; but Ulysses checked her, "Old woman," said he,
+"rejoice in silence; restrain yourself, and do not make any noise about
+it; it is an unholy thing to vaunt over dead men. Heaven's doom and
+their own evil deeds have brought these men to destruction, for they
+respected no man in the whole world, neither rich nor poor, who came
+near them, and they have come to a bad end as a punishment for their
+wickedness and folly. Now, however, tell me which of the women in the
+house have misconducted themselves, and who are innocent." {176}
+
+"I will tell you the truth, my son," answered Euryclea. "There are fifty
+women in the house whom we teach to do things, such as carding wool,
+and all kinds of household work. Of these, twelve in all {177} have
+misbehaved, and have been wanting in respect to me, and also to
+Penelope. They showed no disrespect to Telemachus, for he has only
+lately grown and his mother never permitted him to give orders to the
+female servants; but let me go upstairs and tell your wife all that has
+happened, for some god has been sending her to sleep."
+
+"Do not wake her yet," answered Ulysses, "but tell the women who have
+misconducted themselves to come to me."
+
+Euryclea left the cloister to tell the women, and make them come to
+Ulysses; in the meantime he called Telemachus, the stockman, and the
+swineherd. "Begin," said he, "to remove the dead, and make the women
+help you. Then, get sponges and clean water to swill down the tables and
+seats. When you have thoroughly cleansed the whole cloisters, take the
+women into the space between the domed room and the wall of the outer
+court, and run them through with your swords till they are quite dead,
+and have forgotten all about love and the way in which they used to lie
+in secret with the suitors."
+
+On this the women came down in a body, weeping and wailing bitterly.
+First they carried the dead bodies out, and propped them up against one
+another in the gatehouse. Ulysses ordered them about and made them do
+their work quickly, so they had to carry the bodies out. When they had
+done this, they cleaned all the tables and seats with sponges and water,
+while Telemachus and the two others shovelled up the blood and dirt from
+the ground, and the women carried it all away and put it out of doors.
+Then when they had made the whole place quite clean and orderly, they
+took the women out and hemmed them in the narrow space between the wall
+of the domed room and that of the yard, so that they could not get away:
+and Telemachus said to the other two, "I shall not let these women die
+a clean death, for they were insolent to me and my mother, and used to
+sleep with the suitors."
+
+So saying he made a ship's cable fast to one of the bearing-posts that
+supported the roof of the domed room, and secured it all around the
+building, at a good height, lest any of the women's feet should touch
+the ground; and as thrushes or doves beat against a net that has been
+set for them in a thicket just as they were getting to their nest, and a
+terrible fate awaits them, even so did the women have to put their heads
+in nooses one after the other and die most miserably. {178} Their feet
+moved convulsively for a while, but not for very long.
+
+As for Melanthius, they took him through the cloister into the inner
+court. There they cut off his nose and his ears; they drew out his
+vitals and gave them to the dogs raw, and then in their fury they cut
+off his hands and his feet.
+
+When they had done this they washed their hands and feet and went back
+into the house, for all was now over; and Ulysses said to the dear old
+nurse Euryclea, "Bring me sulphur, which cleanses all pollution, and
+fetch fire also that I may burn it, and purify the cloisters. Go,
+moreover, and tell Penelope to come here with her attendants, and also
+all the maidservants that are in the house."
+
+"All that you have said is true," answered Euryclea, "but let me bring
+you some clean clothes--a shirt and cloak. Do not keep these rags on
+your back any longer. It is not right."
+
+"First light me a fire," replied Ulysses.
+
+She brought the fire and sulphur, as he had bidden her, and Ulysses
+thoroughly purified the cloisters and both the inner and outer courts.
+Then she went inside to call the women and tell them what had happened;
+whereon they came from their apartment with torches in their hands, and
+pressed round Ulysses to embrace him, kissing his head and shoulders and
+taking hold of his hands. It made him feel as if he should like to weep,
+for he remembered every one of them. {179}
+
+
+Book XXIII
+
+PENELOPE EVENTUALLY RECOGNISES HER HUSBAND--EARLY IN THE MORNING
+ULYSSES, TELEMACHUS, EUMAEUS, AND PHILOETIUS LEAVE THE TOWN.
+
+Euryclea now went upstairs laughing to tell her mistress that her dear
+husband had come home. Her aged knees became young again and her feet
+were nimble for joy as she went up to her mistress and bent over her
+head to speak to her. "Wake up Penelope, my dear child," she exclaimed,
+"and see with your own eyes something that you have been wanting this
+long time past. Ulysses has at last indeed come home again, and has
+killed the suitors who were giving so much trouble in his house, eating
+up his estate and ill treating his son."
+
+"My good nurse," answered Penelope, "you must be mad. The gods sometimes
+send some very sensible people out of their minds, and make foolish
+people become sensible. This is what they must have been doing to you;
+for you always used to be a reasonable person. Why should you thus mock
+me when I have trouble enough already--talking such nonsense, and waking
+me up out of a sweet sleep that had taken possession of my eyes and
+closed them? I have never slept so soundly from the day my poor husband
+went to that city with the ill-omened name. Go back again into the
+women's room; if it had been any one else who had woke me up to bring me
+such absurd news I should have sent her away with a severe scolding. As
+it is your age shall protect you."
+
+"My dear child," answered Euryclea, "I am not mocking you. It is quite
+true as I tell you that Ulysses is come home again. He was the stranger
+whom they all kept on treating so badly in the cloister. Telemachus knew
+all the time that he was come back, but kept his father's secret that he
+might have his revenge on all these wicked people."
+
+Then Penelope sprang up from her couch, threw her arms round Euryclea,
+and wept for joy. "But my dear nurse," said she, "explain this to me;
+if he has really come home as you say, how did he manage to overcome the
+wicked suitors single handed, seeing what a number of them there always
+were?"
+
+"I was not there," answered Euryclea, "and do not know; I only heard
+them groaning while they were being killed. We sat crouching and huddled
+up in a corner of the women's room with the doors closed, till your
+son came to fetch me because his father sent him. Then I found Ulysses
+standing over the corpses that were lying on the ground all round him,
+one on top of the other. You would have enjoyed it if you could have
+seen him standing there all bespattered with blood and filth, and
+looking just like a lion. But the corpses are now all piled up in the
+gatehouse that is in the outer court, and Ulysses has lit a great fire
+to purify the house with sulphur. He has sent me to call you, so come
+with me that you may both be happy together after all; for now at last
+the desire of your heart has been fulfilled; your husband is come home
+to find both wife and son alive and well, and to take his revenge in his
+own house on the suitors who behaved so badly to him."
+
+"My dear nurse," said Penelope, "do not exult too confidently over all
+this. You know how delighted every one would be to see Ulysses come
+home--more particularly myself, and the son who has been born to both
+of us; but what you tell me cannot be really true. It is some god who is
+angry with the suitors for their great wickedness, and has made an end
+of them; for they respected no man in the whole world, neither rich nor
+poor, who came near them, and they have come to a bad end in consequence
+of their iniquity; Ulysses is dead far away from the Achaean land; he
+will never return home again."
+
+Then nurse Euryclea said, "My child, what are you talking about? but you
+were all hard of belief and have made up your mind that your husband is
+never coming, although he is in the house and by his own fire side
+at this very moment. Besides I can give you another proof; when I was
+washing him I perceived the scar which the wild boar gave him, and I
+wanted to tell you about it, but in his wisdom he would not let me, and
+clapped his hands over my mouth; so come with me and I will make this
+bargain with you--if I am deceiving you, you may have me killed by the
+most cruel death you can think of."
+
+"My dear nurse," said Penelope, "however wise you may be you can hardly
+fathom the counsels of the gods. Nevertheless, we will go in search of
+my son, that I may see the corpses of the suitors, and the man who has
+killed them."
+
+On this she came down from her upper room, and while doing so she
+considered whether she should keep at a distance from her husband and
+question him, or whether she should at once go up to him and embrace
+him. When, however, she had crossed the stone floor of the cloister, she
+sat down opposite Ulysses by the fire, against the wall at right angles
+{180} [to that by which she had entered], while Ulysses sat near one of
+the bearing-posts, looking upon the ground, and waiting to see what his
+brave wife would say to him when she saw him. For a long time she sat
+silent and as one lost in amazement. At one moment she looked him full
+in the face, but then again directly, she was misled by his shabby
+clothes and failed to recognise him, {181} till Telemachus began to
+reproach her and said:
+
+"Mother--but you are so hard that I cannot call you by such a name--why
+do you keep away from my father in this way? Why do you not sit by his
+side and begin talking to him and asking him questions? No other woman
+could bear to keep away from her husband when he had come back to her
+after twenty years of absence, and after having gone through so much;
+but your heart always was as hard as a stone."
+
+Penelope answered, "My son, I am so lost in astonishment that I can find
+no words in which either to ask questions or to answer them. I cannot
+even look him straight in the face. Still, if he really is Ulysses
+come back to his own home again, we shall get to understand one another
+better by and by, for there are tokens with which we two are alone
+acquainted, and which are hidden from all others."
+
+Ulysses smiled at this, and said to Telemachus, "Let your mother put me
+to any proof she likes; she will make up her mind about it presently.
+She rejects me for the moment and believes me to be somebody else,
+because I am covered with dirt and have such bad clothes on; let us,
+however, consider what we had better do next. When one man has killed
+another--even though he was not one who would leave many friends to take
+up his quarrel--the man who has killed him must still say good bye to
+his friends and fly the country; whereas we have been killing the stay
+of a whole town, and all the picked youth of Ithaca. I would have you
+consider this matter."
+
+"Look to it yourself, father," answered Telemachus, "for they say you
+are the wisest counsellor in the world, and that there is no other
+mortal man who can compare with you. We will follow you with right good
+will, nor shall you find us fail you in so far as our strength holds
+out."
+
+"I will say what I think will be best," answered Ulysses. "First wash
+and put your shirts on; tell the maids also to go to their own room and
+dress; Phemius shall then strike up a dance tune on his lyre, so that if
+people outside hear, or any of the neighbours, or some one going along
+the street happens to notice it, they may think there is a wedding in
+the house, and no rumours about the death of the suitors will get about
+in the town, before we can escape to the woods upon my own land. Once
+there, we will settle which of the courses heaven vouchsafes us shall
+seem wisest."
+
+Thus did he speak, and they did even as he had said. First they washed
+and put their shirts on, while the women got ready. Then Phemius took
+his lyre and set them all longing for sweet song and stately dance. The
+house re-echoed with the sound of men and women dancing, and the people
+outside said, "I suppose the queen has been getting married at last.
+She ought to be ashamed of herself for not continuing to protect her
+husband's property until he comes home." {182}
+
+This was what they said, but they did not know what it was that had been
+happening. The upper servant Eurynome washed and anointed Ulysses in his
+own house and gave him a shirt and cloak, while Minerva made him look
+taller and stronger than before; she also made the hair grow thick on
+the top of his head, and flow down in curls like hyacinth blossoms; she
+glorified him about the head and shoulders just as a skilful workman who
+has studied art of all kinds under Vulcan or Minerva--and his work is
+full of beauty--enriches a piece of silver plate by gilding it. He came
+from the bath looking like one of the immortals, and sat down opposite
+his wife on the seat he had left. "My dear," said he, "heaven has
+endowed you with a heart more unyielding than woman ever yet had. No
+other woman could bear to keep away from her husband when he had come
+back to her after twenty years of absence, and after having gone through
+so much. But come, nurse, get a bed ready for me; I will sleep alone,
+for this woman has a heart as hard as iron."
+
+"My dear," answered Penelope, "I have no wish to set myself up, nor to
+depreciate you; but I am not struck by your appearance, for I very well
+remember what kind of a man you were when you set sail from Ithaca.
+Nevertheless, Euryclea, take his bed outside the bed chamber that he
+himself built. Bring the bed outside this room, and put bedding upon it
+with fleeces, good coverlets, and blankets."
+
+She said this to try him, but Ulysses was very angry and said, "Wife,
+I am much displeased at what you have just been saying. Who has been
+taking my bed from the place in which I left it? He must have found it a
+hard task, no matter how skilled a workman he was, unless some god came
+and helped him to shift it. There is no man living, however strong and
+in his prime, who could move it from its place, for it is a marvellous
+curiosity which I made with my very own hands. There was a young olive
+growing within the precincts of the house, in full vigour, and about as
+thick as a bearing-post. I built my room round this with strong walls
+of stone and a roof to cover them, and I made the doors strong and
+well-fitting. Then I cut off the top boughs of the olive tree and left
+the stump standing. This I dressed roughly from the root upwards and
+then worked with carpenter's tools well and skilfully, straightening
+my work by drawing a line on the wood, and making it into a bed-prop.
+I then bored a hole down the middle, and made it the centre-post of my
+bed, at which I worked till I had finished it, inlaying it with gold and
+silver; after this I stretched a hide of crimson leather from one side
+of it to the other. So you see I know all about it, and I desire to
+learn whether it is still there, or whether any one has been removing it
+by cutting down the olive tree at its roots."
+
+When she heard the sure proofs Ulysses now gave her, she fairly broke
+down. She flew weeping to his side, flung her arms about his neck, and
+kissed him. "Do not be angry with me Ulysses," she cried, "you, who are
+the wisest of mankind. We have suffered, both of us. Heaven has denied
+us the happiness of spending our youth, and of growing old, together; do
+not then be aggrieved or take it amiss that I did not embrace you thus
+as soon as I saw you. I have been shuddering all the time through fear
+that someone might come here and deceive me with a lying story; for
+there are many very wicked people going about. Jove's daughter Helen
+would never have yielded herself to a man from a foreign country, if she
+had known that the sons of Achaeans would come after her and bring her
+back. Heaven put it in her heart to do wrong, and she gave no thought
+to that sin, which has been the source of all our sorrows. Now, however,
+that you have convinced me by showing that you know all about our
+bed (which no human being has ever seen but you and I and a single
+maidservant, the daughter of Actor, who was given me by my father on my
+marriage, and who keeps the doors of our room) hard of belief though I
+have been I can mistrust no longer."
+
+Then Ulysses in his turn melted, and wept as he clasped his dear and
+faithful wife to his bosom. As the sight of land is welcome to men who
+are swimming towards the shore, when Neptune has wrecked their ship with
+the fury of his winds and waves; a few alone reach the land, and these,
+covered with brine, are thankful when they find themselves on firm
+ground and out of danger--even so was her husband welcome to her as she
+looked upon him, and she could not tear her two fair arms from about
+his neck. Indeed they would have gone on indulging their sorrow till
+rosy-fingered morn appeared, had not Minerva determined otherwise, and
+held night back in the far west, while she would not suffer Dawn to
+leave Oceanus, nor to yoke the two steeds Lampus and Phaethon that bear
+her onward to break the day upon mankind.
+
+At last, however, Ulysses said, "Wife, we have not yet reached the end
+of our troubles. I have an unknown amount of toil still to undergo. It
+is long and difficult, but I must go through with it, for thus the shade
+of Teiresias prophesied concerning me, on the day when I went down into
+Hades to ask about my return and that of my companions. But now let us
+go to bed, that we may lie down and enjoy the blessed boon of sleep."
+
+"You shall go to bed as soon as you please," replied Penelope, "now that
+the gods have sent you home to your own good house and to your country.
+But as heaven has put it in your mind to speak of it, tell me about the
+task that lies before you. I shall have to hear about it later, so it is
+better that I should be told at once."
+
+"My dear," answered Ulysses, "why should you press me to tell you?
+Still, I will not conceal it from you, though you will not like it. I do
+not like it myself, for Teiresias bade me travel far and wide, carrying
+an oar, till I came to a country where the people have never heard of
+the sea, and do not even mix salt with their food. They know nothing
+about ships, nor oars that are as the wings of a ship. He gave me this
+certain token which I will not hide from you. He said that a wayfarer
+should meet me and ask me whether it was a winnowing shovel that I had
+on my shoulder. On this, I was to fix my oar in the ground and sacrifice
+a ram, a bull, and a boar to Neptune; after which I was to go home and
+offer hecatombs to all the gods in heaven, one after the other. As for
+myself, he said that death should come to me from the sea, and that my
+life should ebb away very gently when I was full of years and peace of
+mind, and my people should bless me. All this, he said, should surely
+come to pass."
+
+And Penelope said, "If the gods are going to vouchsafe you a happier
+time in your old age, you may hope then to have some respite from
+misfortune."
+
+Thus did they converse. Meanwhile Eurynome and the nurse took torches
+and made the bed ready with soft coverlets; as soon as they had laid
+them, the nurse went back into the house to go to her rest, leaving the
+bed chamber woman Eurynome {183} to show Ulysses and Penelope to bed by
+torch light. When she had conducted them to their room she went
+back, and they then came joyfully to the rites of their own old bed.
+Telemachus, Philoetius, and the swineherd now left off dancing, and made
+the women leave off also. They then laid themselves down to sleep in the
+cloisters.
+
+When Ulysses and Penelope had had their fill of love they fell talking
+with one another. She told him how much she had had to bear in seeing
+the house filled with a crowd of wicked suitors who had killed so many
+sheep and oxen on her account, and had drunk so many casks of wine.
+Ulysses in his turn told her what he had suffered, and how much trouble
+he had himself given to other people. He told her everything, and she
+was so delighted to listen that she never went to sleep till he had
+ended his whole story.
+
+He began with his victory over the Cicons, and how he thence reached the
+fertile land of the Lotus-eaters. He told her all about the Cyclops
+and how he had punished him for having so ruthlessly eaten his brave
+comrades; how he then went on to Aeolus, who received him hospitably and
+furthered him on his way, but even so he was not to reach home, for to
+his great grief a hurricane carried him out to sea again; how he went on
+to the Laestrygonian city Telepylos, where the people destroyed all his
+ships with their crews, save himself and his own ship only. Then he told
+of cunning Circe and her craft, and how he sailed to the chill house of
+Hades, to consult the ghost of the Theban prophet Teiresias, and how he
+saw his old comrades in arms, and his mother who bore him and brought
+him up when he was a child; how he then heard the wondrous singing of
+the Sirens, and went on to the wandering rocks and terrible Charybdis
+and to Scylla, whom no man had ever yet passed in safety; how his men
+then ate the cattle of the sun-god, and how Jove therefore struck the
+ship with his thunderbolts, so that all his men perished together,
+himself alone being left alive; how at last he reached the Ogygian
+island and the nymph Calypso, who kept him there in a cave, and fed
+him, and wanted him to marry her, in which case she intended making him
+immortal so that he should never grow old, but she could not persuade
+him to let her do so; and how after much suffering he had found his way
+to the Phaeacians, who had treated him as though he had been a god, and
+sent him back in a ship to his own country after having given him gold,
+bronze, and raiment in great abundance. This was the last thing about
+which he told her, for here a deep sleep took hold upon him and eased
+the burden of his sorrows.
+
+Then Minerva bethought her of another matter. When she deemed that
+Ulysses had had both of his wife and of repose, she bade gold-enthroned
+Dawn rise out of Oceanus that she might shed light upon mankind. On
+this, Ulysses rose from his comfortable bed and said to Penelope,
+"Wife, we have both of us had our full share of troubles, you, here, in
+lamenting my absence, and I in being prevented from getting home though
+I was longing all the time to do so. Now, however, that we have at last
+come together, take care of the property that is in the house. As for
+the sheep and goats which the wicked suitors have eaten, I will take
+many myself by force from other people, and will compel the Achaeans to
+make good the rest till they shall have filled all my yards. I am now
+going to the wooded lands out in the country to see my father who has
+so long been grieved on my account, and to yourself I will give these
+instructions, though you have little need of them. At sunrise it will
+at once get abroad that I have been killing the suitors; go upstairs,
+therefore, {184} and stay there with your women. See nobody and ask no
+questions." {185}
+
+As he spoke he girded on his armour. Then he roused Telemachus,
+Philoetius, and Eumaeus, and told them all to put on their armour also.
+This they did, and armed themselves. When they had done so, they
+opened the gates and sallied forth, Ulysses leading the way. It was now
+daylight, but Minerva nevertheless concealed them in darkness and led
+them quickly out of the town.
+
+
+Book XXIV
+
+THE GHOSTS OF THE SUITORS IN HADES--ULYSSES AND HIS MEN GO TO THE HOUSE
+OF LAERTES--THE PEOPLE OF ITHACA COME OUT TO ATTACK ULYSSES, BUT MINERVA
+CONCLUDES A PEACE.
+
+Then Mercury of Cyllene summoned the ghosts of the suitors, and in his
+hand he held the fair golden wand with which he seals men's eyes in
+sleep or wakes them just as he pleases; with this he roused the ghosts
+and led them, while they followed whining and gibbering behind him. As
+bats fly squealing in the hollow of some great cave, when one of them
+has fallen out of the cluster in which they hang, even so did the ghosts
+whine and squeal as Mercury the healer of sorrow led them down into the
+dark abode of death. When they had passed the waters of Oceanus and the
+rock Leucas, they came to the gates of the sun and the land of dreams,
+whereon they reached the meadow of asphodel where dwell the souls and
+shadows of them that can labour no more.
+
+Here they found the ghost of Achilles son of Peleus, with those of
+Patroclus, Antilochus, and Ajax, who was the finest and handsomest man
+of all the Danaans after the son of Peleus himself.
+
+They gathered round the ghost of the son of Peleus, and the ghost of
+Agamemnon joined them, sorrowing bitterly. Round him were gathered also
+the ghosts of those who had perished with him in the house of Aegisthus;
+and the ghost of Achilles spoke first.
+
+"Son of Atreus," it said, "we used to say that Jove had loved you better
+from first to last than any other hero, for you were captain over many
+and brave men, when we were all fighting together before Troy; yet the
+hand of death, which no mortal can escape, was laid upon you all too
+early. Better for you had you fallen at Troy in the hey-day of your
+renown, for the Achaeans would have built a mound over your ashes, and
+your son would have been heir to your good name, whereas it has now been
+your lot to come to a most miserable end."
+
+"Happy son of Peleus," answered the ghost of Agamemnon, "for having
+died at Troy far from Argos, while the bravest of the Trojans and the
+Achaeans fell round you fighting for your body. There you lay in the
+whirling clouds of dust, all huge and hugely, heedless now of your
+chivalry. We fought the whole of the livelong day, nor should we ever
+have left off if Jove had not sent a hurricane to stay us. Then, when we
+had borne you to the ships out of the fray, we laid you on your bed and
+cleansed your fair skin with warm water and with ointments. The Danaans
+tore their hair and wept bitterly round about you. Your mother, when she
+heard, came with her immortal nymphs from out of the sea, and the sound
+of a great wailing went forth over the waters so that the Achaeans
+quaked for fear. They would have fled panic-stricken to their ships had
+not wise old Nestor whose counsel was ever truest checked them saying,
+'Hold, Argives, fly not sons of the Achaeans, this is his mother coming
+from the sea with her immortal nymphs to view the body of her son.'
+
+"Thus he spoke, and the Achaeans feared no more. The daughters of the
+old man of the sea stood round you weeping bitterly, and clothed you
+in immortal raiment. The nine muses also came and lifted up their sweet
+voices in lament--calling and answering one another; there was not an
+Argive but wept for pity of the dirge they chaunted. Days and nights
+seven and ten we mourned you, mortals and immortals, but on the
+eighteenth day we gave you to the flames, and many a fat sheep with many
+an ox did we slay in sacrifice around you. You were burnt in raiment of
+the gods, with rich resins and with honey, while heroes, horse and foot,
+clashed their armour round the pile as you were burning, with the tramp
+as of a great multitude. But when the flames of heaven had done
+their work, we gathered your white bones at daybreak and laid them in
+ointments and in pure wine. Your mother brought us a golden vase to hold
+them--gift of Bacchus, and work of Vulcan himself; in this we mingled
+your bleached bones with those of Patroclus who had gone before you, and
+separate we enclosed also those of Antilochus, who had been closer to
+you than any other of your comrades now that Patroclus was no more.
+
+"Over these the host of the Argives built a noble tomb, on a point
+jutting out over the open Hellespont, that it might be seen from far
+out upon the sea by those now living and by them that shall be born
+hereafter. Your mother begged prizes from the gods, and offered them
+to be contended for by the noblest of the Achaeans. You must have
+been present at the funeral of many a hero, when the young men gird
+themselves and make ready to contend for prizes on the death of some
+great chieftain, but you never saw such prizes as silver-footed Thetis
+offered in your honour; for the gods loved you well. Thus even in death
+your fame, Achilles, has not been lost, and your name lives evermore
+among all mankind. But as for me, what solace had I when the days of my
+fighting were done? For Jove willed my destruction on my return, by the
+hands of Aegisthus and those of my wicked wife."
+
+Thus did they converse, and presently Mercury came up to them with the
+ghosts of the suitors who had been killed by Ulysses. The ghosts of
+Agamemnon and Achilles were astonished at seeing them, and went up
+to them at once. The ghost of Agamemnon recognised Amphimedon son of
+Melaneus, who lived in Ithaca and had been his host, so it began to talk
+to him.
+
+"Amphimedon," it said, "what has happened to all you fine young men--all
+of an age too--that you are come down here under the ground? One could
+pick no finer body of men from any city. Did Neptune raise his winds and
+waves against you when you were at sea, or did your enemies make an end
+of you on the mainland when you were cattle-lifting or sheep-stealing,
+or while fighting in defence of their wives and city? Answer my
+question, for I have been your guest. Do you not remember how I came to
+your house with Menelaus, to persuade Ulysses to join us with his ships
+against Troy? It was a whole month ere we could resume our voyage, for
+we had hard work to persuade Ulysses to come with us."
+
+And the ghost of Amphimedon answered, "Agamemnon, son of Atreus, king of
+men, I remember everything that you have said, and will tell you fully
+and accurately about the way in which our end was brought about. Ulysses
+had been long gone, and we were courting his wife, who did not say point
+blank that she would not marry, nor yet bring matters to an end, for she
+meant to compass our destruction: this, then, was the trick she played
+us. She set up a great tambour frame in her room and began to work on an
+enormous piece of fine needlework. 'Sweethearts,' said she, 'Ulysses
+is indeed dead, still, do not press me to marry again immediately;
+wait--for I would not have my skill in needlework perish
+unrecorded--till I have completed a pall for the hero Laertes, against
+the time when death shall take him. He is very rich, and the women of
+the place will talk if he is laid out without a pall.' This is what she
+said, and we assented; whereupon we could see her working upon her great
+web all day long, but at night she would unpick the stitches again
+by torchlight. She fooled us in this way for three years without our
+finding it out, but as time wore on and she was now in her fourth year,
+in the waning of moons and many days had been accomplished, one of her
+maids who knew what she was doing told us, and we caught her in the act
+of undoing her work, so she had to finish it whether she would or no;
+and when she showed us the robe she had made, after she had had it
+washed, {186} its splendour was as that of the sun or moon.
+
+"Then some malicious god conveyed Ulysses to the upland farm where his
+swineherd lives. Thither presently came also his son, returning from
+a voyage to Pylos, and the two came to the town when they had hatched
+their plot for our destruction. Telemachus came first, and then after
+him, accompanied by the swineherd, came Ulysses, clad in rags and
+leaning on a staff as though he were some miserable old beggar. He came
+so unexpectedly that none of us knew him, not even the older ones among
+us, and we reviled him and threw things at him. He endured both being
+struck and insulted without a word, though he was in his own house; but
+when the will of Aegis-bearing Jove inspired him, he and Telemachus
+took the armour and hid it in an inner chamber, bolting the doors behind
+them. Then he cunningly made his wife offer his bow and a quantity
+of iron to be contended for by us ill-fated suitors; and this was the
+beginning of our end, for not one of us could string the bow--nor nearly
+do so. When it was about to reach the hands of Ulysses, we all of us
+shouted out that it should not be given him, no matter what he might
+say, but Telemachus insisted on his having it. When he had got it in his
+hands he strung it with ease and sent his arrow through the iron. Then
+he stood on the floor of the cloister and poured his arrows on the
+ground, glaring fiercely about him. First he killed Antinous, and then,
+aiming straight before him, he let fly his deadly darts and they fell
+thick on one another. It was plain that some one of the gods was
+helping them, for they fell upon us with might and main throughout the
+cloisters, and there was a hideous sound of groaning as our brains
+were being battered in, and the ground seethed with our blood. This,
+Agamemnon, is how we came by our end, and our bodies are lying still
+uncared for in the house of Ulysses, for our friends at home do not
+yet know what has happened, so that they cannot lay us out and wash
+the black blood from our wounds, making moan over us according to the
+offices due to the departed."
+
+"Happy Ulysses, son of Laertes," replied the ghost of Agamemnon, "you
+are indeed blessed in the possession of a wife endowed with such rare
+excellence of understanding, and so faithful to her wedded lord as
+Penelope the daughter of Icarius. The fame, therefore, of her virtue
+shall never die, and the immortals shall compose a song that shall be
+welcome to all mankind in honour of the constancy of Penelope. How far
+otherwise was the wickedness of the daughter of Tyndareus who killed her
+lawful husband; her song shall be hateful among men, for she has brought
+disgrace on all womankind even on the good ones."
+
+Thus did they converse in the house of Hades deep down within the bowels
+of the earth. Meanwhile Ulysses and the others passed out of the town
+and soon reached the fair and well-tilled farm of Laertes, which he
+had reclaimed with infinite labour. Here was his house, with a lean-to
+running all round it, where the slaves who worked for him slept and sat
+and ate, while inside the house there was an old Sicel woman, who looked
+after him in this his country-farm. When Ulysses got there, he said to
+his son and to the other two:
+
+"Go to the house, and kill the best pig that you can find for dinner.
+Meanwhile I want to see whether my father will know me, or fail to
+recognise me after so long an absence."
+
+He then took off his armour and gave it to Eumaeus and Philoetius, who
+went straight on to the house, while he turned off into the vineyard to
+make trial of his father. As he went down into the great orchard, he did
+not see Dolius, nor any of his sons nor of the other bondsmen, for they
+were all gathering thorns to make a fence for the vineyard, at the place
+where the old man had told them; he therefore found his father alone,
+hoeing a vine. He had on a dirty old shirt, patched and very shabby;
+his legs were bound round with thongs of oxhide to save him from the
+brambles, and he also wore sleeves of leather; he had a goat skin cap on
+his head, and was looking very woe-begone. When Ulysses saw him so worn,
+so old and full of sorrow, he stood still under a tall pear tree and
+began to weep. He doubted whether to embrace him, kiss him, and tell him
+all about his having come home, or whether he should first question him
+and see what he would say. In the end he deemed it best to be crafty
+with him, so in this mind he went up to his father, who was bending down
+and digging about a plant.
+
+"I see, sir," said Ulysses, "that you are an excellent gardener--what
+pains you take with it, to be sure. There is not a single plant, not a
+fig tree, vine, olive, pear, nor flower bed, but bears the trace of your
+attention. I trust, however, that you will not be offended if I say
+that you take better care of your garden than of yourself. You are old,
+unsavoury, and very meanly clad. It cannot be because you are idle that
+your master takes such poor care of you, indeed your face and figure
+have nothing of the slave about them, and proclaim you of noble birth.
+I should have said that you were one of those who should wash well, eat
+well, and lie soft at night as old men have a right to do; but tell me,
+and tell me true, whose bondman are you, and in whose garden are you
+working? Tell me also about another matter. Is this place that I have
+come to really Ithaca? I met a man just now who said so, but he was a
+dull fellow, and had not the patience to hear my story out when I was
+asking him about an old friend of mine, whether he was still living, or
+was already dead and in the house of Hades. Believe me when I tell you
+that this man came to my house once when I was in my own country and
+never yet did any stranger come to me whom I liked better. He said that
+his family came from Ithaca and that his father was Laertes, son of
+Arceisius. I received him hospitably, making him welcome to all the
+abundance of my house, and when he went away I gave him all customary
+presents. I gave him seven talents of fine gold, and a cup of solid
+silver with flowers chased upon it. I gave him twelve light cloaks,
+and as many pieces of tapestry; I also gave him twelve cloaks of single
+fold, twelve rugs, twelve fair mantles, and an equal number of shirts.
+To all this I added four good looking women skilled in all useful arts,
+and I let him take his choice."
+
+His father shed tears and answered, "Sir, you have indeed come to the
+country that you have named, but it is fallen into the hands of wicked
+people. All this wealth of presents has been given to no purpose. If
+you could have found your friend here alive in Ithaca, he would have
+entertained you hospitably and would have requited your presents amply
+when you left him--as would have been only right considering what you
+had already given him. But tell me, and tell me true, how many years is
+it since you entertained this guest--my unhappy son, as ever was? Alas!
+He has perished far from his own country; the fishes of the sea have
+eaten him, or he has fallen a prey to the birds and wild beasts of some
+continent. Neither his mother, nor I his father, who were his parents,
+could throw our arms about him and wrap him in his shroud, nor could
+his excellent and richly dowered wife Penelope bewail her husband as was
+natural upon his death bed, and close his eyes according to the offices
+due to the departed. But now, tell me truly for I want to know. Who
+and whence are you--tell me of your town and parents? Where is the
+ship lying that has brought you and your men to Ithaca? Or were you a
+passenger on some other man's ship, and those who brought you here have
+gone on their way and left you?"
+
+"I will tell you everything," answered Ulysses, "quite truly. I come
+from Alybas, where I have a fine house. I am son of king Apheidas, who
+is the son of Polypemon. My own name is Eperitus; heaven drove me off my
+course as I was leaving Sicania, and I have been carried here against
+my will. As for my ship it is lying over yonder, off the open country
+outside the town, and this is the fifth year since Ulysses left my
+country. Poor fellow, yet the omens were good for him when he left me.
+The birds all flew on our right hands, and both he and I rejoiced to
+see them as we parted, for we had every hope that we should have another
+friendly meeting and exchange presents."
+
+A dark cloud of sorrow fell upon Laertes as he listened. He filled both
+hands with the dust from off the ground and poured it over his grey
+head, groaning heavily as he did so. The heart of Ulysses was touched,
+and his nostrils quivered as he looked upon his father; then he sprang
+towards him, flung his arms about him and kissed him, saying, "I am he,
+father, about whom you are asking--I have returned after having been
+away for twenty years. But cease your sighing and lamentation--we have
+no time to lose, for I should tell you that I have been killing the
+suitors in my house, to punish them for their insolence and crimes."
+
+"If you really are my son Ulysses," replied Laertes, "and have come back
+again, you must give me such manifest proof of your identity as shall
+convince me."
+
+"First observe this scar," answered Ulysses, "which I got from a boar's
+tusk when I was hunting on Mt. Parnassus. You and my mother had sent me
+to Autolycus, my mother's father, to receive the presents which when he
+was over here he had promised to give me. Furthermore I will point out
+to you the trees in the vineyard which you gave me, and I asked you all
+about them as I followed you round the garden. We went over them all,
+and you told me their names and what they all were. You gave me thirteen
+pear trees, ten apple trees, and forty fig trees; you also said you
+would give me fifty rows of vines; there was corn planted between each
+row, and they yield grapes of every kind when the heat of heaven has
+been laid heavy upon them."
+
+Laertes' strength failed him when he heard the convincing proofs which
+his son had given him. He threw his arms about him, and Ulysses had to
+support him, or he would have gone off into a swoon; but as soon as he
+came to, and was beginning to recover his senses, he said, "O father
+Jove, then you gods are still in Olympus after all, if the suitors have
+really been punished for their insolence and folly. Nevertheless, I
+am much afraid that I shall have all the townspeople of Ithaca up here
+directly, and they will be sending messengers everywhere throughout the
+cities of the Cephallenians."
+
+Ulysses answered, "Take heart and do not trouble yourself about that,
+but let us go into the house hard by your garden. I have already told
+Telemachus, Philoetius, and Eumaeus to go on there and get dinner ready
+as soon as possible."
+
+Thus conversing the two made their way towards the house. When they got
+there they found Telemachus with the stockman and the swineherd cutting
+up meat and mixing wine with water. Then the old Sicel woman took
+Laertes inside and washed him and anointed him with oil. She put him on
+a good cloak, and Minerva came up to him and gave him a more imposing
+presence, making him taller and stouter than before. When he came back
+his son was surprised to see him looking so like an immortal, and said
+to him, "My dear father, some one of the gods has been making you much
+taller and better-looking."
+
+Laertes answered, "Would, by Father Jove, Minerva, and Apollo, that
+I were the man I was when I ruled among the Cephallenians, and took
+Nericum, that strong fortress on the foreland. If I were still what I
+then was and had been in our house yesterday with my armour on, I should
+have been able to stand by you and help you against the suitors. I
+should have killed a great many of them, and you would have rejoiced to
+see it."
+
+Thus did they converse; but the others, when they had finished their
+work and the feast was ready, left off working, and took each his proper
+place on the benches and seats. Then they began eating; by and by old
+Dolius and his sons left their work and came up, for their mother, the
+Sicel woman who looked after Laertes now that he was growing old, had
+been to fetch them. When they saw Ulysses and were certain it was he,
+they stood there lost in astonishment; but Ulysses scolded them good
+naturedly and said, "Sit down to your dinner, old man, and never mind
+about your surprise; we have been wanting to begin for some time and
+have been waiting for you."
+
+Then Dolius put out both his hands and went up to Ulysses. "Sir," said
+he, seizing his master's hand and kissing it at the wrist, "we have long
+been wishing you home: and now heaven has restored you to us after we
+had given up hoping. All hail, therefore, and may the gods prosper you.
+{187} But tell me, does Penelope already know of your return, or shall
+we send some one to tell her?"
+
+"Old man," answered Ulysses, "she knows already, so you need not trouble
+about that." On this he took his seat, and the sons of Dolius gathered
+round Ulysses to give him greeting and embrace him one after the other;
+then they took their seats in due order near Dolius their father.
+
+While they were thus busy getting their dinner ready, Rumour went round
+the town, and noised abroad the terrible fate that had befallen the
+suitors; as soon, therefore, as the people heard of it they gathered
+from every quarter, groaning and hooting before the house of Ulysses.
+They took the dead away, buried every man his own, and put the bodies
+of those who came from elsewhere on board the fishing vessels, for the
+fishermen to take each of them to his own place. They then met angrily
+in the place of assembly, and when they were got together Eupeithes
+rose to speak. He was overwhelmed with grief for the death of his son
+Antinous, who had been the first man killed by Ulysses, so he said,
+weeping bitterly, "My friends, this man has done the Achaeans great
+wrong. He took many of our best men away with him in his fleet, and he
+has lost both ships and men; now, moreover, on his return he has been
+killing all the foremost men among the Cephallenians. Let us be up and
+doing before he can get away to Pylos or to Elis where the Epeans rule,
+or we shall be ashamed of ourselves for ever afterwards. It will be an
+everlasting disgrace to us if we do not avenge the murder of our sons
+and brothers. For my own part I should have no more pleasure in life,
+but had rather die at once. Let us be up, then, and after them, before
+they can cross over to the main land."
+
+He wept as he spoke and every one pitied him. But Medon and the bard
+Phemius had now woke up, and came to them from the house of Ulysses.
+Every one was astonished at seeing them, but they stood in the middle of
+the assembly, and Medon said, "Hear me, men of Ithaca. Ulysses did not
+do these things against the will of heaven. I myself saw an immortal god
+take the form of Mentor and stand beside him. This god appeared, now in
+front of him encouraging him, and now going furiously about the court
+and attacking the suitors whereon they fell thick on one another."
+
+On this pale fear laid hold of them, and old Halitherses, son of Mastor,
+rose to speak, for he was the only man among them who knew both past and
+future; so he spoke to them plainly and in all honesty, saying,
+
+"Men of Ithaca, it is all your own fault that things have turned out as
+they have; you would not listen to me, nor yet to Mentor, when we
+bade you check the folly of your sons who were doing much wrong in the
+wantonness of their hearts--wasting the substance and dishonouring the
+wife of a chieftain who they thought would not return. Now, however, let
+it be as I say, and do as I tell you. Do not go out against Ulysses, or
+you may find that you have been drawing down evil on your own heads."
+
+This was what he said, and more than half raised a loud shout, and at
+once left the assembly. But the rest stayed where they were, for the
+speech of Halitherses displeased them, and they sided with Eupeithes;
+they therefore hurried off for their armour, and when they had armed
+themselves, they met together in front of the city, and Eupeithes led
+them on in their folly. He thought he was going to avenge the murder
+of his son, whereas in truth he was never to return, but was himself to
+perish in his attempt.
+
+Then Minerva said to Jove, "Father, son of Saturn, king of kings, answer
+me this question--What do you propose to do? Will you set them fighting
+still further, or will you make peace between them?"
+
+And Jove answered, "My child, why should you ask me? Was it not by your
+own arrangement that Ulysses came home and took his revenge upon the
+suitors? Do whatever you like, but I will tell you what I think will
+be most reasonable arrangement. Now that Ulysses is revenged, let them
+swear to a solemn covenant, in virtue of which he shall continue to
+rule, while we cause the others to forgive and forget the massacre of
+their sons and brothers. Let them then all become friends as heretofore,
+and let peace and plenty reign."
+
+This was what Minerva was already eager to bring about, so down she
+darted from off the topmost summits of Olympus.
+
+Now when Laertes and the others had done dinner, Ulysses began by
+saying, "Some of you go out and see if they are not getting close up
+to us." So one of Dolius's sons went as he was bid. Standing on the
+threshold he could see them all quite near, and said to Ulysses, "Here
+they are, let us put on our armour at once."
+
+They put on their armour as fast as they could--that is to say Ulysses,
+his three men, and the six sons of Dolius. Laertes also and Dolius did
+the same--warriors by necessity in spite of their grey hair. When they
+had all put on their armour, they opened the gate and sallied forth,
+Ulysses leading the way.
+
+Then Jove's daughter Minerva came up to them, having assumed the form
+and voice of Mentor. Ulysses was glad when he saw her, and said to
+his son Telemachus, "Telemachus, now that you are about to fight in an
+engagement, which will show every man's mettle, be sure not to disgrace
+your ancestors, who were eminent for their strength and courage all the
+world over."
+
+"You say truly, my dear father," answered Telemachus, "and you shall
+see, if you will, that I am in no mind to disgrace your family."
+
+Laertes was delighted when he heard this. "Good heavens," he exclaimed,
+"what a day I am enjoying: I do indeed rejoice at it. My son and
+grandson are vying with one another in the matter of valour."
+
+On this Minerva came close up to him and said, "Son of Arceisius---best
+friend I have in the world--pray to the blue-eyed damsel, and to Jove
+her father; then poise your spear and hurl it."
+
+As she spoke she infused fresh vigour into him, and when he had prayed
+to her he poised his spear and hurled it. He hit Eupeithes' helmet, and
+the spear went right through it, for the helmet stayed it not, and
+his armour rang rattling round him as he fell heavily to the ground.
+Meantime Ulysses and his son fell upon the front line of the foe and
+smote them with their swords and spears; indeed, they would have killed
+every one of them, and prevented them from ever getting home again,
+only Minerva raised her voice aloud, and made every one pause. "Men of
+Ithaca," she cried, "cease this dreadful war, and settle the matter at
+once without further bloodshed."
+
+On this pale fear seized every one; they were so frightened that their
+arms dropped from their hands and fell upon the ground at the sound of
+the goddess' voice, and they fled back to the city for their lives. But
+Ulysses gave a great cry, and gathering himself together swooped down
+like a soaring eagle. Then the son of Saturn sent a thunderbolt of fire
+that fell just in front of Minerva, so she said to Ulysses, "Ulysses,
+noble son of Laertes, stop this warful strife, or Jove will be angry
+with you."
+
+Thus spoke Minerva, and Ulysses obeyed her gladly. Then Minerva assumed
+the form and voice of Mentor, and presently made a covenant of peace
+between the two contending parties.
+
+
+
+                        FOOTNOTES
+
+{1} Black races are evidently known to the writer as stretching all
+across Africa, one half looking West on to the Atlantic, and the other
+East on to the Indian Ocean.
+
+{2} The original use of the footstool was probably less to rest the feet
+than to keep them (especially when bare) from a floor which was often
+wet and dirty.
+
+{3} The [Greek] or seat, is occasionally called "high," as being higher
+than the [Greek] or low footstool. It was probably no higher than an
+ordinary chair is now, and seems to have had no back.
+
+{4} Temesa was on the West Coast of the toe of Italy, in what is now the
+gulf of Sta Eufemia. It was famous in remote times for its copper mines,
+which, however, were worked out when Strabo wrote.
+
+{5} i.e. "with a current in it"--see illustrations and map near the end
+of bks. v. and vi. respectively.
+
+{6} Reading [Greek] for [Greek], cf. "Od." iii. 81 where the same
+mistake is made, and xiii. 351 where the mountain is called Neritum, the
+same place being intended both here and in book xiii.
+
+{7} It is never plausibly explained why Penelope cannot do this, and
+from bk. ii. it is clear that she kept on deliberately encouraging the
+suitors, though we are asked to believe that she was only fooling them.
+
+{8} See note on "Od." i. 365.
+
+{9} Middle Argos means the Peleponnese which, however, is never so
+called in the "Iliad". I presume "middle" means "middle between the two
+Greek-speaking countries of Asia Minor and Sicily, with South Italy";
+for that parts of Sicily and also large parts, though not the whole of
+South Italy, were inhabited by Greek-speaking races centuries before the
+Dorian colonisations can hardly be doubted. The Sicians, and also the
+Sicels, both of them probably spoke Greek.
+
+{10} cf. "Il." vi. 490-495. In the "Iliad" it is "war," not "speech,"
+that is a man's matter. It argues a certain hardness, or at any rate
+dislike of the "Iliad" on the part of the writer of the "Odyssey,"
+that she should have adopted Hector's farewell to Andromache here, as
+elsewhere in the poem, for a scene of such inferior pathos.
+
+{11} [Greek] The whole open court with the covered cloister running
+round it was called [Greek], or [Greek], but the covered part was
+distinguished by being called "shady" or "shadow-giving". It was in this
+part that the tables for the suitors were laid. The Fountain Court at
+Hampton Court may serve as an illustration (save as regards the use of
+arches instead of wooden supports and rafters) and the arrangement
+is still common in Sicily. The usual translation "shadowy" or "dusky"
+halls, gives a false idea of the scene.
+
+{12} The reader will note the extreme care which the writer takes to
+make it clear that none of the suitors were allowed to sleep in Ulysses'
+house.
+
+{13} See Appendix; g, in plan of Ulysses' house.
+
+{14} I imagine this passage to be a rejoinder to "Il." xxiii. 702-705 in
+which a tripod is valued at twelve oxen, and a good useful maid of
+all work at only four. The scrupulous regard of Laertes for his wife's
+feelings is of a piece with the extreme jealousy for the honour of
+woman, which is manifest throughout the "Odyssey".
+
+{15} [Greek] "The [Greek], or tunica, was a shirt or shift, and served
+as the chief under garment of the Greeks and Romans, whether men
+or women." Smith's Dictionary of Greek and Roman Antiquities, under
+"Tunica".
+
+{16} Doors fastened to all intents and purposes as here described may be
+seen in the older houses at Trapani. There is a slot on the outer side
+of the door by means of which a person who has left the room can shoot
+the bolt. My bedroom at the Albergo Centrale was fastened in this way.
+
+{17} [Greek] So we vulgarly say "had cooked his goose," or "had settled
+his hash." Aegyptus cannot of course know of the fate Antiphus had met
+with, for there had as yet been no news of or from Ulysses.
+
+{18} "Il." xxii. 416. [Greek] The authoress has bungled by borrowing
+these words verbatim from the "Iliad", without prefixing the necessary
+"do not," which I have supplied.
+
+{19} i.e. you have money, and could pay when I got judgment, whereas the
+suitors are men of straw.
+
+{20} cf. "Il." ii. 76. [Greek]. The Odyssean passage runs [Greek]. Is
+it possible not to suspect that the name Mentor was coined upon that of
+Nestor?
+
+{21} i.e. in the outer court, and in the uncovered part of the inner
+house.
+
+{22} This would be fair from Sicily, which was doing duty for Ithaca in
+the mind of the writer, but a North wind would have been preferable for
+a voyage from the real Ithaca to Pylos.
+
+{23} [Greek] The wind does not whistle over waves. It only whistles
+through rigging or some other obstacle that cuts it.
+
+{24} cf. "Il." v.20. [Greek] The Odyssean line is [Greek]. There can
+be no doubt that the Odyssean line was suggested by the Iliadic, but
+nothing can explain why Idaeus jumping from his chariot should suggest
+to the writer of the "Odyssey" the sun jumping from the sea. The
+probability is that she never gave the matter a thought, but took the
+line in question as an effect of saturation with the "Iliad," and of
+unconscious cerebration. The "Odyssey" contains many such examples.
+
+{25} The heart, liver, lights, kidneys, etc. were taken out from the
+inside and eaten first as being more readily cooked; the [Greek], or
+bone meat, was cooking while the [Greek] or inward parts were being
+eaten. I imagine that the thigh bones made a kind of gridiron, while at
+the same time the marrow inside them got cooked.
+
+{26} i.e. skewers, either single, double, or even five pronged. The meat
+would be pierced with the skewer, and laid over the ashes to grill--the
+two ends of the skewer being supported in whatever way convenient. Meat
+so cooking may be seen in any eating house in Smyrna, or any Eastern
+town. When I rode across the Troad from the Dardanelles to Hissarlik and
+Mount Ida, I noticed that my dragoman and his men did all our outdoor
+cooking exactly in the Odyssean and Iliadic fashion.
+
+{27} cf. "Il." xvii. 567. [Greek] The Odyssean lines are--[Greek]
+
+{28} Reading [Greek] for [Greek], cf. "Od." i.186.
+
+{29} The geography of the Aegean as above described is correct, but is
+probably taken from the lost poem, the Nosti, the existence of which is
+referred to "Od." i.326,327 and 350, etc. A glance at the map will show
+that heaven advised its supplicants quite correctly.
+
+{30} The writer--ever jealous for the honour of women--extenuates
+Clytemnestra's guilt as far as possible, and explains it as due to her
+having been left unprotected, and fallen into the hands of a wicked man.
+
+{31} The Greek is [Greek] cf. "Iliad" ii. 408 [Greek] Surely the [Greek]
+of the Odyssean passage was due to the [Greek] of the "Iliad." No other
+reason suggests itself for the making Menelaus return on the very day of
+the feast given by Orestes. The fact that in the "Iliad" Menelaus came
+to a banquet without waiting for an invitation, determines the writer
+of the "Odyssey" to make him come to a banquet, also uninvited, but
+as circumstances did not permit of his having been invited, his coming
+uninvited is shown to have been due to chance. I do not think the
+authoress thought all this out, but attribute the strangeness of the
+coincidence to unconscious cerebration and saturation.
+
+{32} cf. "Il." i.458, ii. 421. The writer here interrupts an Iliadic
+passage (to which she returns immediately) for the double purpose of
+dwelling upon the slaughter of the heifer, and of letting Nestor's wife
+and daughter enjoy it also. A male writer, if he was borrowing from the
+"Iliad," would have stuck to his borrowing.
+
+{33} cf. "Il." xxiv. 587,588 where the lines refer to the washing the
+dead body of Hector.
+
+{34} See illustration on opposite page. The yard is typical of many that
+may be seen in Sicily. The existing ground-plan is probably unmodified
+from Odyssean, and indeed long pre-Odyssean times, but the earlier
+buildings would have no arches, and would, one would suppose, be mainly
+timber. The Odyssean [Greek] were the sheds that ran round the yard
+as the arches do now. The [Greek] was the one through which the main
+entrance passed, and which was hence "noisy," or reverberating. It had
+an upper story in which visitors were often lodged.
+
+{35} This journey is an impossible one. Telemachus and Pisistratus would
+have been obliged to drive over the Taygetus range, over which there has
+never yet been a road for wheeled vehicles. It is plain therefore that
+the audience for whom the "Odyssey" was written was one that would be
+unlikely to know anything about the topography of the Peloponnese, so
+that the writer might take what liberties she chose.
+
+{36} The lines which I have enclosed in brackets are evidently an
+afterthought--added probably by the writer herself--for they evince
+the same instinctively greater interest in anything that may concern a
+woman, which is so noticeable throughout the poem. There is no further
+sign of any special festivities nor of any other guests than Telemachus
+and Pisistratus, until lines 621-624 (ordinarily enclosed in brackets)
+are abruptly introduced, probably with a view of trying to carry off the
+introduction of the lines now in question.
+
+The addition was, I imagine, suggested by a desire to excuse and explain
+the non-appearance of Hermione in bk. xv., as also of both Hermione and
+Megapenthes in the rest of bk. iv. Megapenthes in bk. xv. seems to be
+still a bachelor: the presumption therefore is that bk. xv. was written
+before the story of his marriage here given. I take it he is only
+married here because his sister is being married. She having been
+properly attended to, Megapenthes might as well be married at the same
+time. Hermione could not now be less than thirty.
+
+I have dealt with this passage somewhat more fully in my "Authoress of
+the Odyssey", p.136-138. See also p. 256 of the same book.
+
+{37} Sparta and Lacedaemon are here treated as two different places,
+though in other parts of the poem it is clear that the writer
+understands them as one. The catalogue in the "Iliad," which the writer
+is here presumably following, makes the same mistake ("Il." ii. 581,582)
+
+{38} These last three lines are identical with "Il." vxiii. 604-606.
+
+{39} From the Greek [Greek] it is plain that Menelaus took up the piece
+of meat with his fingers.
+
+{40} Amber is never mentioned in the "Iliad." Sicily, where I suppose
+the "Odyssey" to have been written, has always been, and still is, one
+of the principal amber producing countries. It was probably the only one
+known in the Odyssean age. See "The Authoress of the Odyssey", p260.
+
+{41} This no doubt refers to the story told in the last poem of the
+Cypria about Paris and Helen robbing Menelaus of the greater part of his
+treasures, when they sailed together for Troy.
+
+{42} It is inconceivable that Helen should enter thus, in the middle of
+supper, intending to work with her distaff, if great festivities were
+going on. Telemachus and Pisistratus are evidently dining en famille.
+
+{43} In the Italian insurrection of 1848, eight young men who were being
+hotly pursued by the Austrian police hid themselves inside Donatello's
+colossal wooden horse in the Salone at Padua, and remained there for
+a week being fed by their confederates. In 1898 the last survivor was
+carried round Padua in triumph.
+
+{44} The Greek is [Greek]. Is it unfair to argue that the writer is a
+person of somewhat delicate sensibility, to whom a strong smell of fish
+is distasteful?
+
+{45} The Greek is [Greek]. I believe this to be a hit at the writer's
+own countrymen who were of Phocaean descent, and the next following line
+to be a rejoinder to complaints made against her in bk. vi. 273-288, to
+the effect that she gave herself airs and would marry none of her own
+people. For that the writer of the "Odyssey" was the person who has
+been introduced into the poem under the name of Nausicaa, I cannot bring
+myself to question. I may remind English readers that [Greek] (i.e.
+phoca) means "seal." Seals almost always appear on Phocaean coins.
+
+{46} Surely here again we are in the hands of a writer of delicate
+sensibility. It is not as though the seals were stale; they had only
+just been killed. The writer, however is obviously laughing at her own
+countrymen, and insulting them as openly as she dares.
+
+{47} We were told above (lines 357,357) that it was only one day's sail.
+
+{48} I give the usual translation, but I do not believe the Greek will
+warrant it. The Greek reads [Greek].
+
+This is usually held to mean that Ithaca is an island fit for breeding
+goats, and on that account more delectable to the speaker than it would
+have been if it were fit for breeding horses. I find little authority
+for such a translation; the most equitable translation of the text as it
+stands is, "Ithaca is an island fit for breeding goats, and delectable
+rather than fit for breeding horses; for not one of the islands is good
+driving ground, nor well meadowed." Surely the writer does not mean that
+a pleasant or delectable island would not be fit for breeding horses?
+The most equitable translation, therefore, of the present text being
+thus halt and impotent, we may suspect corruption, and I hazard the
+following emendation, though I have not adopted it in my translation, as
+fearing that it would be deemed too fanciful. I would read:--[Greek].
+
+As far as scanning goes the [Greek] is not necessary; [Greek] iv. 72,
+[Greek] iv. 233, to go no further afield than earlier lines of the same
+book, give sufficient authority for [Greek], but the [Greek] would not
+be redundant; it would emphasise the surprise of the contrast, and I
+should prefer to have it, though it is not very important either way.
+This reading of course should be translated "Ithaca is an island fit for
+breeding goats, and (by your leave) itself a horseman rather than
+fit for breeding horses--for not one of the islands is good and well
+meadowed ground."
+
+This would be sure to baffle the Alexandrian editors. "How," they would
+ask themselves, "could an island be a horseman?" and they would cast
+about for an emendation. A visit to the top of Mt. Eryx might perhaps
+make the meaning intelligible, and suggest my proposed restoration of
+the text to the reader as readily as it did to myself.
+
+I have elsewhere stated my conviction that the writer of the "Odyssey"
+was familiar with the old Sican city at the top of Mt. Eryx, and that
+the Aegadean islands which are so striking when seen thence did duty
+with her for the Ionian islands--Marettimo, the highest and most
+westerly of the group, standing for Ithaca. When seen from the top of
+Mt. Eryx Marettimo shows as it should do according to "Od." ix. 25,26,
+"on the horizon, all highest up in the sea towards the West," while
+the other islands lie "some way off it to the East." As we descend
+to Trapani, Marettimo appears to sink on to the top of the island of
+Levanzo, behind which it disappears. My friend, the late Signor E.
+Biaggini, pointed to it once as it was just standing on the top of
+Levanzo, and said to me "Come cavalca bene" ("How well it rides"), and
+this immediately suggested my emendation to me. Later on I found in
+the hymn to the Pythian Apollo (which abounds with tags taken from the
+"Odyssey") a line ending [Greek] which strengthened my suspicion that
+this was the original ending of the second of the two lines above under
+consideration.
+
+{49} See note on line 3 of this book. The reader will observe that
+the writer has been unable to keep the women out of an interpolation
+consisting only of four lines.
+
+{50} Scheria means a piece of land jutting out into the sea. In my
+"Authoress of the Odyssey" I thought "Jutland" would be a suitable
+translation, but it has been pointed out to me that "Jutland" only means
+the land of the Jutes.
+
+{51} Irrigation as here described is common in gardens near Trapani. The
+water that supplies the ducts is drawn from wells by a mule who turns a
+wheel with buckets on it.
+
+{52} There is not a word here about the cattle of the sun-god.
+
+{53} The writer evidently thought that green, growing wood might also be
+well seasoned.
+
+{54} The reader will note that the river was flowing with salt water
+i.e. that it was tidal.
+
+{55} Then the Ogygian island was not so far off, but that Nausicaa might
+be assumed to know where it was.
+
+{56} Greek [Greek]
+
+{57} I suspect a family joke, or sly allusion to some thing of which
+we know nothing, in this story of Eurymedusa's having been brought from
+Apeira. The Greek word "apeiros" means "inexperienced," "ignorant." Is
+it possible that Eurymedusa was notoriously incompetent?
+
+{58} Polyphemus was also son to Neptune, see "Od." ix. 412,529. he was
+therefore half brother to Nausithous, half uncle to King Alcinous, and
+half great uncle to Nausicaa.
+
+{59} It would seem as though the writer thought that Marathon was close
+to Athens.
+
+{60} Here the writer, knowing that she is drawing (with embellishments)
+from things actually existing, becomes impatient of past tenses and
+slides into the present.
+
+{61} This is hidden malice, implying that the Phaeacian magnates were
+no better than they should be. The final drink-offering should have been
+made to Jove or Neptune, not to the god of thievishness and rascality
+of all kinds. In line 164 we do indeed find Echeneus proposing that
+a drink-offering should be made to Jove, but Mercury is evidently,
+according to our authoress, the god who was most likely to be of use to
+them.
+
+{62} The fact of Alcinous knowing anything about the Cyclopes suggests
+that in the writer's mind Scheria and the country of the Cyclopes were
+not very far from one another. I take the Cyclopes and the giants to be
+one and the same people.
+
+{63} "My property, etc." The authoress is here adopting an Iliadic line
+(xix. 333), and this must account for the absence of all reference
+to Penelope. If she had happened to remember "Il." v.213, she would
+doubtless have appropriated it by preference, for that line reads "my
+country, my wife, and all the greatness of my house."
+
+{64} The at first inexplicable sleep of Ulysses (bk. xiii. 79, etc.)
+is here, as also in viii. 445, being obviously prepared. The writer
+evidently attached the utmost importance to it. Those who know that the
+harbour which did duty with the writer of the "Odyssey" for the one in
+which Ulysses landed in Ithaca, was only about 2 miles from the place
+in which Ulysses is now talking with Alcinous, will understand why the
+sleep was so necessary.
+
+{65} There were two classes--the lower who were found in provisions
+which they had to cook for themselves in the yards and outer precincts,
+where they would also eat--and the upper who would eat in the cloisters
+of the inner court, and have their cooking done for them.
+
+{66} Translation very dubious. I suppose the [Greek] here to be the
+covered sheds that ran round the outer courtyard. See illustrations at
+the end of bk. iii.
+
+{67} The writer apparently deems that the words "as compared with what
+oxen can plough in the same time" go without saying. Not so the writer
+of the "Iliad" from which the Odyssean passage is probably taken. He
+explains that mules can plough quicker than oxen ("Il." x.351-353)
+
+{68} It was very fortunate that such a disc happened to be there, seeing
+that none like it were in common use.
+
+{69} "Il." xiii. 37. Here, as so often elsewhere in the "Odyssey," the
+appropriation of an Iliadic line which is not quite appropriate puzzles
+the reader. The "they" is not the chains, nor yet Mars and Venus. It is
+an overflow from the Iliadic passage in which Neptune hobbles his horses
+in bonds "which none could either unloose or break so that they might
+stay there in that place." If the line would have scanned without the
+addition of the words "so that they might stay there in that place,"
+they would have been omitted in the "Odyssey."
+
+{70} The reader will note that Alcinous never goes beyond saying that
+he is going to give the goblet; he never gives it. Elsewhere in both
+"Iliad" and "Odyssey" the offer of a present is immediately followed by
+the statement that it was given and received gladly--Alcinous actually
+does give a chest and a cloak and shirt--probably also some of the corn
+and wine for the long two-mile voyage was provided by him--but it is
+quite plain that he gave no talent and no cup.
+
+{71} "Il." xviii, 344-349. These lines in the "Iliad" tell of the
+preparation for washing the body of Patroclus, and I am not pleased that
+the writer of the "Odyssey" should have adopted them here.
+
+{72} see note {64}
+
+{73} see note {43}
+
+{74} The reader will find this threat fulfilled in bk. xiii
+
+{75} If the other islands lay some distance away from Ithaca (which
+the word [Greek] suggests), what becomes of the [Greek] or gut between
+Ithaca and Samos which we hear of in Bks. iv. and xv.? I suspect that
+the authoress in her mind makes Telemachus come back from Pylos to the
+Lilybaean promontory and thence to Trapani through the strait between
+the Isola Grande and the mainland--the island of Asteria being the one
+on which Motya afterwards stood.
+
+{76} "Il." xviii. 533-534. The sudden lapse into the third person here
+for a couple of lines is due to the fact that the two Iliadic lines
+taken are in the third person.
+
+{77} cf. "Il." ii. 776. The words in both "Iliad" and "Odyssey" are
+[Greek]. In the "Iliad" they are used of the horses of Achilles'
+followers as they stood idle, "champing lotus."
+
+{78} I take all this passage about the Cyclopes having no ships to
+be sarcastic--meaning, "You people of Drepanum have no excuse for not
+colonising the island of Favognana, which you could easily do, for you
+have plenty of ships, and the island is a very good one." For that
+the island so fully described here is the Aegadean or "goat" island of
+Favognana, and that the Cyclopes are the old Sican inhabitants of Mt.
+Eryx should not be doubted.
+
+{79} For the reasons why it was necessary that the night should be so
+exceptionally dark see "The Authoress of the Odyssey" pp. 188-189.
+
+{80} None but such lambs as would suck if they were with their mothers
+would be left in the yard. The older lambs should have been out feeding.
+The authoress has got it all wrong, but it does not matter. See "The
+Authoress of the Odyssey" p.148.
+
+{81} This line is enclosed in brackets in the received text, and is
+omitted (with note) by Messrs. Butcher & Lang. But lines enclosed in
+brackets are almost always genuine; all that brackets mean is that the
+bracketed passage puzzled some early editor, who nevertheless found
+it too well established in the text to venture on omitting it. In the
+present case the line bracketed is the very last which a full-grown male
+editor would be likely to interpolate. It is safer to infer that the
+writer, a young woman, not knowing or caring at which end of the ship
+the rudder should be, determined to make sure by placing it at both
+ends, which we shall find she presently does by repeating it (line 340)
+at the stern of the ship. As for the two rocks thrown, the first I take
+to be the Asinelli, see map facing p.80. The second I see as the two
+contiguous islands of the Formiche, which are treated as one, see map
+facing p.108. The Asinelli is an island shaped like a boat, and pointing
+to the island of Favognana. I think the authoress's compatriots, who
+probably did not like her much better that she did them, jeered at the
+absurdity of Ulysses' conduct, and saw the Asinelli or "donkeys," not as
+the rock thrown by Polyphemus, but as the boat itself containing Ulysses
+and his men.
+
+{82} This line exists in the text here but not in the corresponding
+passage xii. 141. I am inclined to think it is interpolated (probably
+by the poetess herself) from the first of lines xi. 115-137, which I can
+hardly doubt were added by the writer when the scheme of the work was
+enlarged and altered. See "The Authoress of the Odyssey" pp. 254-255.
+
+{83} "Floating" ([Greek]) is not to be taken literally. The island
+itself, as apart from its inhabitants, was quite normal. There is no
+indication of its moving during the month that Ulysses stayed with
+Aeolus, and on his return from his unfortunate voyage, he seems to
+have found it in the same place. The [Greek] in fact should no more be
+pressed than [Greek] as applied to islands, "Odyssey" xv. 299--where
+they are called "flying" because the ship would fly past them. So also
+the "Wanderers," as explained by Buttmann; see note on "Odyssey" xii.
+57.
+
+{84} Literally "for the ways of the night and of the day are near." I
+have seen what Mr. Andrew Lang says ("Homer and the Epic," p.236, and
+"Longman's Magazine" for January, 1898, p.277) about the "amber route"
+and the "Sacred Way" in this connection; but until he gives his grounds
+for holding that the Mediterranean peoples in the Odyssean age used to
+go far North for their amber instead of getting it in Sicily, where it
+is still found in considerable quantities, I do not know what weight I
+ought to attach to his opinion. I have been unable to find grounds
+for asserting that B.C. 1000 there was any commerce between the
+Mediterranean and the "Far North," but I shall be very ready to learn
+if Mr. Lang will enlighten me. See "The Authoress of the Odyssey" pp.
+185-186.
+
+{85} One would have thought that when the sun was driving the stag down
+to the water, Ulysses might have observed its whereabouts.
+
+{86} See Hobbes of Malmesbury's translation.
+
+{87} "Il." vxiii. 349. Again the writer draws from the washing the body
+of Patroclus--which offends.
+
+{88} This visit is wholly without topographical significance.
+
+{89} Brides presented themselves instinctively to the imagination of the
+writer, as the phase of humanity which she found most interesting.
+
+{90} Ulysses was, in fact, to become a missionary and preach Neptune to
+people who knew not his name. I was fortunate enough to meet in Sicily
+a woman carrying one of these winnowing shovels; it was not much shorter
+than an oar, and I was able at once to see what the writer of the
+"Odyssey" intended.
+
+{91} I suppose the lines I have enclosed in brackets to have been added
+by the author when she enlarged her original scheme by the addition of
+books i.-iv. and xiii. (from line 187)-xxiv. The reader will observe
+that in the corresponding passage (xii. 137-141) the prophecy ends with
+"after losing all your comrades," and that there is no allusion to the
+suitors. For fuller explanation see "The Authoress of the Odyssey" pp.
+254-255.
+
+{92} The reader will remember that we are in the first year of Ulysses'
+wanderings, Telemachus therefore was only eleven years old. The same
+anachronism is made later on in this book. See "The Authoress of the
+Odyssey" pp. 132-133.
+
+{93} Tradition says that she had hanged herself. Cf. "Odyssey" xv. 355,
+etc.
+
+{94} Not to be confounded with Aeolus king of the winds.
+
+{95} Melampus, vide book xv. 223, etc.
+
+{96} I have already said in a note on bk. xi. 186 that at this point of
+Ulysses' voyage Telemachus could only be between eleven and twelve years
+old.
+
+{97} Is the writer a man or a woman?
+
+{98} Cf. "Il." iv. 521, [Greek]. The Odyssean line reads, [Greek]. The
+famous dactylism, therefore, of the Odyssean line was probably suggested
+by that of the Ileadic rather than by a desire to accommodate sound to
+sense. At any rate the double coincidence of a dactylic line, and an
+ending [Greek], seems conclusive as to the familiarity of the writer of
+the "Odyssey" with the Iliadic line.
+
+{99} Off the coast of Sicily and South Italy, in the month of May, I
+have seen men fastened half way up a boat's mast with their feet resting
+on a crosspiece, just large enough to support them. From this point
+of vantage they spear sword-fish. When I saw men thus employed I could
+hardly doubt that the writer of the "Odyssey" had seen others like them,
+and had them in her mind when describing the binding of Ulysses. I have
+therefore with some diffidence ventured to depart from the received
+translation of [Greek] (cf. Alcaeus frag. 18, where, however, it is
+very hard to say what [Greek] means). In Sophocles' Lexicon I find a
+reference to Chrysostom (l, 242, A. Ed. Benedictine Paris 1834-1839)
+for the word [Greek], which is probably the same as [Greek], but I have
+looked for the passage in vain.
+
+{100} The writer is at fault here and tries to put it off on Circe. When
+Ulysses comes to take the route prescribed by Circe, he ought to pass
+either the Wanderers or some other difficulty of which we are not told,
+but he does not do so. The Planctae, or Wanderers, merge into Scylla and
+Charybdis, and the alternative between them and something untold
+merges into the alternative whether Ulysses had better choose Scylla or
+Charybdis. Yet from line 260, it seems we are to consider the Wanderers
+as having been passed by Ulysses; this appears even more plainly from
+xxiii. 327, in which Ulysses expressly mentions the Wandering rocks as
+having been between the Sirens and Scylla and Charybdis. The writer,
+however, is evidently unaware that she does not quite understand her own
+story; her difficulty was perhaps due to the fact that though Trapanese
+sailors had given her a fair idea as to where all her other localities
+really were, no one in those days more than in our own could localise
+the Planctae, which in fact, as Buttmann has argued, were derived not
+from any particular spot, but from sailors' tales about the difficulties
+of navigating the group of the Aeolian islands as a whole (see note on
+"Od." x. 3). Still the matter of the poor doves caught her fancy, so she
+would not forgo them. The whirlwinds of fire and the smoke that hangs on
+Scylla suggests allusion to Stromboli and perhaps even Etna. Scylla is
+on the Italian side, and therefore may be said to look West. It is about
+8 miles thence to the Sicilian coast, so Ulysses may be perfectly well
+told that after passing Scylla he will come to the Thrinacian island or
+Sicily. Charybdis is transposed to a site some few miles to the north of
+its actual position.
+
+{101} I suppose this line to have been intercalated by the author when
+lines 426-446 were added.
+
+{102} For the reasons which enable us to identify the island of the two
+Sirens with the Lipari island now Salinas--the ancient Didyme, or "twin"
+island--see The Authoress of the Odyssey, pp. 195, 196. The two
+Sirens doubtless were, as their name suggests, the whistling gusts, or
+avalanches of air that at times descend without a moment's warning from
+the two lofty mountains of Salinas--as also from all high points in the
+neighbourhood.
+
+{103} See Admiral Smyth on the currents in the Straits of Messina,
+quoted in "The Authoress of the Odyssey," p. 197.
+
+{104} In the islands of Favognana and Marettimo off Trapani I have seen
+men fish exactly as here described. They chew bread into a paste and
+throw it into the sea to attract the fish, which they then spear. No
+line is used.
+
+{105} The writer evidently regards Ulysses as on a coast that looked
+East at no great distance south of the Straits of Messina somewhere,
+say, near Tauromenium, now Taormina.
+
+{106} Surely there must be a line missing here to tell us that the keel
+and mast were carried down into Charybdis. Besides, the aorist [Greek]
+in its present surrounding is perplexing. I have translated it as though
+it were an imperfect; I see Messrs. Butcher and Lang translate it as
+a pluperfect, but surely Charybdis was in the act of sucking down the
+water when Ulysses arrived.
+
+{107} I suppose the passage within brackets to have been an afterthought
+but to have been written by the same hand as the rest of the poem. I
+suppose xii. 103 to have been also added by the writer when she decided
+on sending Ulysses back to Charybdis. The simile suggests the hand of
+the wife or daughter of a magistrate who had often seen her father come
+in cross and tired.
+
+{108} Gr. [Greek]. This puts coined money out of the question, but
+nevertheless implies that the gold had been worked into ornaments of
+some kind.
+
+{109} I suppose Teiresias' prophecy of bk. xi. 114-120 had made no
+impression on Ulysses. More probably the prophecy was an afterthought,
+intercalated, as I have already said, by the authoress when she changed
+her scheme.
+
+{110} A male writer would have made Ulysses say, not "may you give
+satisfaction to your wives," but "may your wives give satisfaction to
+you."
+
+{111} See note {64}.
+
+{112} The land was in reality the shallow inlet, now the salt works of
+S. Cusumano--the neighbourhood of Trapani and Mt. Eryx being made to do
+double duty, both as Scheria and Ithaca. Hence the necessity for making
+Ulysses set out after dark, fall instantly into a profound sleep, and
+wake up on a morning so foggy that he could not see anything till the
+interviews between Neptune and Jove and between Ulysses and Minerva
+should have given the audience time to accept the situation. See
+illustrations and map near the end of bks. v. and vi. respectively.
+
+{113} This cave, which is identifiable with singular completeness, is
+now called the "grotta del toro," probably a corruption of "tesoro," for
+it is held to contain a treasure. See The Authoress of the Odyssey, pp.
+167-170.
+
+{114} Probably they would.
+
+{115} Then it had a shallow shelving bottom.
+
+{116} Doubtless the road would pass the harbour in Odyssean times as it
+passes the salt works now; indeed, if there is to be a road at all there
+is no other level ground which it could take. See map above referred to.
+
+{117} The rock at the end of the Northern harbour of Trapani, to which
+I suppose the writer of the "Odyssey" to be here referring, still bears
+the name Malconsiglio--"the rock of evil counsel." There is a legend
+that it was a ship of Turkish pirates who were intending to attack
+Trapani, but the "Madonna di Trapani" crushed them under this rock just
+as they were coming into port. My friend Cavaliere Giannitrapani of
+Trapani told me that his father used to tell him when he was a boy that
+if he would drop exactly three drops of oil on to the water near the
+rock, he would see the ship still at the bottom. The legend is evidently
+a Christianised version of the Odyssean story, while the name supplies
+the additional detail that the disaster happened in consequence of an
+evil counsel.
+
+{118} It would seem then that the ship had got all the way back from
+Ithaca in about a quarter of an hour.
+
+{119} And may we not add "and also to prevent his recognising that he
+was only in the place where he had met Nausicaa two days earlier."
+
+{120} All this is to excuse the entire absence of Minerva from books
+ix.-xii., which I suppose had been written already, before the authoress
+had determined on making Minerva so prominent a character.
+
+{121} We have met with this somewhat lame attempt to cover the writer's
+change of scheme at the end of bk. vi.
+
+{122} I take the following from The Authoress of the Odyssey, p. 167.
+"It is clear from the text that there were two [caves] not one, but some
+one has enclosed in brackets the two lines in which the second cave is
+mentioned, I presume because he found himself puzzled by having a second
+cave sprung upon him when up to this point he had only been told of one.
+
+"I venture to think that if he had known the ground he would not have
+been puzzled, for there are two caves, distant about 80 or 100 yards
+from one another." The cave in which Ulysses hid his treasure is, as I
+have already said, identifiable with singular completeness. The other
+cave presents no special features, neither in the poem nor in nature.
+
+{123} There is no attempt to disguise the fact that Penelope had long
+given encouragement to the suitors. The only defence set up is that she
+did not really mean to encourage them. Would it not have been wiser to
+have tried a little discouragement?
+
+{124} See map near the end of bk. vi. Ruccazzu dei corvi of course means
+"the rock of the ravens." Both name and ravens still exist.
+
+{125} See The Authoress of the Odyssey, pp. 140, 141. The real reason
+for sending Telemachus to Pylos and Lacedaemon was that the authoress
+might get Helen of Troy into her poem. He was sent at the only point in
+the story at which he could be sent, so he must have gone then or not at
+all.
+
+{126} The site I assign to Eumaeus's hut, close to the Ruccazzu dei
+Corvi, is about 2,000 feet above the sea, and commands an extensive
+view.
+
+{127} Sandals such as Eumaeus was making are still worn in the Abruzzi
+and elsewhere. An oblong piece of leather forms the sole: holes are cut
+at the four corners, and through these holes leathern straps are passed,
+which are bound round the foot and cross-gartered up the calf.
+
+{128} See note {75}
+
+{129} Telemachus like many another good young man seems to expect every
+one to fetch and carry for him.
+
+{130} "Il." vi. 288. The store room was fragrant because it was made of
+cedar wood. See "Il." xxiv. 192.
+
+{131} cf. "Il." vi. 289 and 293-296. The dress was kept at the bottom
+of the chest as one that would only be wanted on the greatest occasions;
+but surely the marriage of Hermione and of Megapenthes (bk, iv. ad
+init.) might have induced Helen to wear it on the preceding evening,
+in which case it could hardly have got back. We find no hint here of
+Megapenthes' recent marriage.
+
+{132} See note {83}.
+
+{133} cf. "Od." xi. 196, etc.
+
+{134} The names Syra and Ortygia, on which island a great part of the
+Doric Syracuse was originally built, suggest that even in Odyssean times
+there was a prehistoric Syracuse, the existence of which was known to
+the writer of the poem.
+
+{135} Literally "where are the turnings of the sun." Assuming, as we may
+safely do, that the Syra and Ortygia of the "Odyssey" refer to Syracuse,
+it is the fact that not far to the South of these places the land turns
+sharply round, so that mariners following the coast would find the
+sun upon the other side of their ship to that on which they'd had it
+hitherto.
+
+Mr. A. S. Griffith has kindly called my attention to Herod iv. 42,
+where, speaking of the circumnavigation of Africa by Phoenician mariners
+under Necos, he writes:
+
+"On their return they declared--I for my part do not believe them, but
+perhaps others may--that in sailing round Libya [i.e. Africa] they had
+the sun upon their right hand. In this way was the extent of Libya first
+discovered.
+
+"I take it that Eumaeus was made to have come from Syracuse because
+the writer thought she rather ought to have made something happen at
+Syracuse during her account of the voyages of Ulysses. She could
+not, however, break his long drift from Charybdis to the island of
+Pantellaria; she therefore resolved to make it up to Syracuse in another
+way."
+
+{135} Modern excavations establish the existence of two and only two
+pre-Dorian communities at Syracuse; they were, so Dr. Orsi informed me,
+at Plemmirio and Cozzo Pantano. See The Authoress of the Odyssey, pp.
+211-213.
+
+{136} This harbour is again evidently the harbour in which Ulysses had
+landed, i.e. the harbour that is now the salt works of S. Cusumano.
+
+{137} This never can have been anything but very niggardly pay for some
+eight or nine days' service. I suppose the crew were to consider the
+pleasure of having had a trip to Pylos as a set off. There is no trace
+of the dinner as having been actually given, either on the following or
+any other morning.
+
+{138} No hawk can tear its prey while it is on the wing.
+
+{139} The text is here apparently corrupt, and will not make sense as it
+stands. I follow Messrs. Butcher and Lang in omitting line 101.
+
+{140} i.e. to be milked, as in South Italian and Sicilian towns at the
+present day.
+
+{141} The butchering and making ready the carcases took place partly in
+the outer yard and partly in the open part of the inner court.
+
+{142} These words cannot mean that it would be afternoon soon after they
+were spoken. Ulysses and Eumaeus reached the town which was "some way
+off" (xvii. 25) in time for the suitor's early meal (xvii. 170 and 176)
+say at ten or eleven o' clock. The context of the rest of the book shows
+this. Eumaeus and Ulysses, therefore, cannot have started later than
+eight or nine, and Eumaeus's words must be taken as an exaggeration for
+the purpose of making Ulysses bestir himself.
+
+{143} I imagine the fountain to have been somewhere about where the
+church of the Madonna di Trapani now stands, and to have been fed with
+water from what is now called the Fontana Diffali on Mt. Eryx.
+
+{144} From this and other passages in the "Odyssey" it appears that
+we are in an age anterior to the use of coined money--an age when
+cauldrons, tripods, swords, cattle, chattels of all kinds, measures
+of corn, wine, or oil, etc. etc., not to say pieces of gold, silver,
+bronze, or even iron, wrought more or less, but unstamped, were the
+nearest approach to a currency that had as yet been reached.
+
+{145} Gr. is [Greek]
+
+{146} I correct these proofs abroad and am not within reach of Hesiod,
+but surely this passage suggests acquaintance with the Works and Ways,
+though it by no means compels it.
+
+{147} It would seem as though Eurynome and Euryclea were the same
+person. See note {156}
+
+{148} It is plain, therefore, that Iris was commonly accepted as the
+messenger of the gods, though our authoress will never permit her to
+fetch or carry for any one.
+
+{149} i.e. the doorway leading from the inner to the outer court.
+
+{150} Surely in this scene, again, Eurynome is in reality Euryclea. See
+note {156}
+
+{151} These, I imagine, must have been in the open part of the inner
+courtyard, where the maids also stood, and threw the light of their
+torches into the covered cloister that ran all round it. The smoke would
+otherwise have been intolerable.
+
+{152} Translation very uncertain; vide Liddell and Scott, under [Greek]
+
+{153} See photo on opposite page.
+
+{154} cf. "Il." ii. 184, and 217, 218. An additional and well-marked
+feature being wanted to convince Penelope, the writer has taken the
+hunched shoulders of Thersites (who is mentioned immediately after
+Eurybates in the "Iliad") and put them on to Eurybates' back.
+
+{155} This is how geese are now fed in Sicily, at any rate in summer,
+when the grass is all burnt up. I have never seen them grazing.
+
+{156} Lower down (line 143) Euryclea says it was herself that had thrown
+the cloak over Ulysses--for the plural should not be taken as implying
+more than one person. The writer is evidently still fluctuating between
+Euryclea and Eurynome as the name for the old nurse. She probably
+originally meant to call her Euryclea, but finding it not immediately
+easy to make Euryclea scan in xvii. 495, she hastily called her
+Eurynome, intending either to alter this name later or to change the
+earlier Euryclea's into Eurynome. She then drifted in to Eurynome
+as convenience further directed, still nevertheless hankering after
+Euryclea, till at last she found that the path of least resistance
+would lie in the direction of making Eurynome and Euryclea two persons.
+Therefore in xxiii. 289-292 both Eurynome and "the nurse" (who can be
+none other than Euryclea) come on together. I do not say that this is
+feminine, but it is not unfeminine.
+
+{157} See note {156}
+
+{158} This, I take it, was immediately in front of the main entrance of
+the inner courtyard into the body of the house.
+
+{159} This is the only allusion to Sardinia in either "Iliad" or
+"Odyssey."
+
+{160} The normal translation of the Greek word would be "holding back,"
+"curbing," "restraining," but I cannot think that the writer meant
+this--she must have been using the word in its other sense of "having,"
+"holding," "keeping," "maintaining."
+
+{161} I have vainly tried to realise the construction of the fastening
+here described.
+
+{162} See plan of Ulysses' house in the appendix. It is evident that the
+open part of the court had no flooring but the natural soil.
+
+{163} See plan of Ulysses' house, and note {175}.
+
+{164} i.e. the door that led into the body of the house.
+
+{165} This was, no doubt, the little table that was set for Ulysses,
+"Od." xx. 259.
+
+Surely the difficulty of this passage has been overrated. I suppose
+the iron part of the axe to have been wedged into the handle, or bound
+securely to it--the handle being half buried in the ground. The axe
+would be placed edgeways towards the archer, and he would have to shoot
+his arrow through the hole into which the handle was fitted when the axe
+was in use. Twelve axes were placed in a row all at the same height,
+all exactly in front of one another, all edgeways to Ulysses whose arrow
+passed through all the holes from the first onward. I cannot see how the
+Greek can bear any other interpretation, the words being, [Greek]
+
+"He did not miss a single hole from the first onwards." [Greek]
+according to Liddell and Scott being "the hole for the handle of an
+axe, etc.," while [Greek] ("Od." v. 236) is, according to the same
+authorities, the handle itself. The feat is absurdly impossible, but our
+authoress sometimes has a soul above impossibilities.
+
+{166} The reader will note how the spoiling of good food distresses the
+writer even in such a supreme moment as this.
+
+{167} Here we have it again. Waste of substance comes first.
+
+{168} cf. "Il." iii. 337 and three other places. It is strange that
+the author of the "Iliad" should find a little horse-hair so alarming.
+Possibly enough she was merely borrowing a common form line from some
+earlier poet--or poetess--for this is a woman's line rather than a
+man's.
+
+{169} Or perhaps simply "window." See plan in the appendix.
+
+{170} i.e. the pavement on which Ulysses was standing.
+
+{171} The interpretation of lines 126-143 is most dubious, and at best
+we are in a region of melodrama: cf., however, i.425, etc. from which it
+appears that there was a tower in the outer court, and that Telemachus
+used to sleep in it. The [Greek] I take to be a door, or trap door,
+leading on to the roof above Telemachus's bed room, which we are told
+was in a place that could be seen from all round--or it might be simply
+a window in Telemachus's room looking out into the street. From the
+top of the tower the outer world was to be told what was going on, but
+people could not get in by the [Greek]: they would have to come in by
+the main entrance, and Melanthius explains that the mouth of the narrow
+passage (which was in the lands of Ulysses and his friends) commanded
+the only entrance by which help could come, so that there would be
+nothing gained by raising an alarm. As for the [Greek] of line 143,
+no commentator ancient or modern has been able to say what was
+intended--but whatever they were, Melanthius could never carry twelve
+shields, twelve helmets, and twelve spears. Moreover, where he could
+go the others could go also. If a dozen suitors had followed Melanthius
+into the house they could have attacked Ulysses in the rear, in which
+case, unless Minerva had intervened promptly, the "Odyssey" would have
+had a different ending. But throughout the scene we are in a region of
+extravagance rather than of true fiction--it cannot be taken seriously
+by any but the very serious, until we come to the episode of Phemius and
+Medon, where the writer begins to be at home again.
+
+{172} I presume it was intended that there should be a hook driven into
+the bearing-post.
+
+{173} What for?
+
+{174} Gr: [Greek]. This is not [Greek].
+
+{175} From lines 333 and 341 of this book, and lines 145 and 146 of bk.
+xxi we can locate the approach to the [Greek] with some certainty.
+
+{176} But in xix. 500-502 Ulysses scolded Euryclea for offering
+information on this very point, and declared himself quite able to
+settle it for himself.
+
+{177} There were a hundred and eight Suitors.
+
+{178} Lord Grimthorpe, whose understanding does not lend itself to easy
+imposition, has been good enough to write to me about my conviction that
+the "Odyssey" was written by a woman, and to send me remarks upon the
+gross absurdity of the incident here recorded. It is plain that all
+the authoress cared about was that the women should be hanged: as for
+attempting to realise, or to make her readers realise, how the hanging
+was done, this was of no consequence. The reader must take her word for
+it and ask no questions. Lord Grimthorpe wrote:
+
+"I had better send you my ideas about Nausicaa's hanging of the
+maids (not 'maidens,' of whom Froude wrote so well in his 'Science of
+History') before I forget it all. Luckily for me Liddell & Scott have
+specially translated most of the doubtful words, referring to this very
+place.
+
+"A ship's cable. I don't know how big a ship she meant, but it must have
+been a very small one indeed if its 'cable' could be used to tie tightly
+round a woman's neck, and still more round a dozen of them 'in a row,'
+besides being strong enough to hold them and pull them all up.
+
+"A dozen average women would need the weight and strength of more than
+a dozen strong heavy men even over the best pulley hung to the roof
+over them; and the idea of pulling them up by a rope hung anyhow round a
+pillar [Greek] is absurdly impossible; and how a dozen of them could be
+hung dangling round one post is a problem which a senior wrangler would
+be puzzled to answer... She had better have let Telemachus use his sword
+as he had intended till she changed his mind for him."
+
+{179} Then they had all been in Ulysses' service over twenty years;
+perhaps the twelve guilty ones had been engaged more recently.
+
+{180} Translation very doubtful--cf. "It." xxiv. 598.
+
+{181} But why could she not at once ask to see the scar, of which
+Euryclea had told her, or why could not Ulysses have shown it to her?
+
+{182} The people of Ithaca seem to have been as fond of carping as the
+Phaeacians were in vi. 273, etc.
+
+{183} See note {156}. Ulysses's bed room does not appear to have been
+upstairs, nor yet quite within the house. Is it possible that it was
+"the domed room" round the outside of which the erring maids were, for
+aught we have heard to the contrary, still hanging?
+
+{184} Ulysses bedroom in the mind of the writer is here too apparently
+down stairs.
+
+{185} Penelope having been now sufficiently whitewashed, disappears from
+the poem.
+
+{186} So practised a washerwoman as our authoress doubtless knew that by
+this time the web must have become such a wreck that it would have gone
+to pieces in the wash.
+
+A lady points out to me, just as these sheets are leaving my hands, that
+no really good needlewoman--no one, indeed, whose work or character was
+worth consideration--could have endured, no matter for what reason, the
+unpicking of her day's work, day after day for between three and four
+years.
+
+{187} We must suppose Dolius not yet to know that his son Melanthius
+had been tortured, mutilated, and left to die by Ulysses' orders on the
+preceding day, and that his daughter Melantho had been hanged. Dolius
+was probably exceptionally simple-minded, and his name was ironical.
+So on Mt. Eryx I was shown a man who was always called Sonza Malizia or
+"Guileless"--he being held exceptionally cunning.
+
+
+
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The Odyssey, by Homer
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE ODYSSEY ***
+
+***** This file should be named 1727.txt or 1727.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/7/2/1727/
+
+Produced by Jim Tinsley
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License available with this file or online at
+  www.gutenberg.org/license.
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation information page at www.gutenberg.org
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at 809
+North 1500 West, Salt Lake City, UT 84116, (801) 596-1887.  Email
+contact links and up to date contact information can be found at the
+Foundation's web site and official page at www.gutenberg.org/contact
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit www.gutenberg.org/donate
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit:  www.gutenberg.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart was the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For forty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/peter-pan.txt
+++ b/jet/tf-idf/src/main/resources/books/peter-pan.txt
@@ -1,0 +1,6649 @@
+﻿The Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+** This is a COPYRIGHTED Project Gutenberg eBook, Details Below **
+**     Please follow the copyright guidelines in this file.     **
+
+Title: Peter Pan
+       Peter Pan and Wendy
+
+Author: James M. Barrie
+
+Posting Date: June 25, 2008 [EBook #16]
+Release Date: July, 1991
+Last Updated: October 14, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+
+
+
+
+
+
+
+
+
+PETER PAN
+
+[PETER AND WENDY]
+
+By J. M. Barrie [James Matthew Barrie]
+
+A Millennium Fulcrum Edition (c)1991 by Duncan Research
+
+
+
+
+Contents:
+
+Chapter 1 PETER BREAKS THROUGH
+
+Chapter 2 THE SHADOW
+
+Chapter 3 COME AWAY, COME AWAY!
+
+Chapter 4 THE FLIGHT
+
+Chapter 5 THE ISLAND COME TRUE
+
+Chapter 6 THE LITTLE HOUSE
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+Chapter 8 THE MERMAID’S LAGOON
+
+Chapter 9 THE NEVER BIRD
+
+Chapter 10 THE HAPPY HOME
+
+Chapter 11 WENDY’S STORY
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+Chapter 14 THE PIRATE SHIP
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Chapter 16 THE RETURN HOME
+
+Chapter 17 WHEN WENDY GREW UP
+
+
+
+
+Chapter 1 PETER BREAKS THROUGH
+
+All children, except one, grow up. They soon know that they will grow
+up, and the way Wendy knew was this. One day when she was two years old
+she was playing in a garden, and she plucked another flower and ran with
+it to her mother. I suppose she must have looked rather delightful, for
+Mrs. Darling put her hand to her heart and cried, “Oh, why can’t you
+remain like this for ever!” This was all that passed between them on
+the subject, but henceforth Wendy knew that she must grow up. You always
+know after you are two. Two is the beginning of the end.
+
+Of course they lived at 14 [their house number on their street], and
+until Wendy came her mother was the chief one. She was a lovely lady,
+with a romantic mind and such a sweet mocking mouth. Her romantic
+mind was like the tiny boxes, one within the other, that come from the
+puzzling East, however many you discover there is always one more; and
+her sweet mocking mouth had one kiss on it that Wendy could never get,
+though there it was, perfectly conspicuous in the right-hand corner.
+
+The way Mr. Darling won her was this: the many gentlemen who had been
+boys when she was a girl discovered simultaneously that they loved her,
+and they all ran to her house to propose to her except Mr. Darling, who
+took a cab and nipped in first, and so he got her. He got all of her,
+except the innermost box and the kiss. He never knew about the box, and
+in time he gave up trying for the kiss. Wendy thought Napoleon could
+have got it, but I can picture him trying, and then going off in a
+passion, slamming the door.
+
+Mr. Darling used to boast to Wendy that her mother not only loved him
+but respected him. He was one of those deep ones who know about stocks
+and shares. Of course no one really knows, but he quite seemed to know,
+and he often said stocks were up and shares were down in a way that
+would have made any woman respect him.
+
+Mrs. Darling was married in white, and at first she kept the books
+perfectly, almost gleefully, as if it were a game, not so much as a
+Brussels sprout was missing; but by and by whole cauliflowers dropped
+out, and instead of them there were pictures of babies without faces.
+She drew them when she should have been totting up. They were Mrs.
+Darling’s guesses.
+
+Wendy came first, then John, then Michael.
+
+For a week or two after Wendy came it was doubtful whether they would
+be able to keep her, as she was another mouth to feed. Mr. Darling was
+frightfully proud of her, but he was very honourable, and he sat on the
+edge of Mrs. Darling’s bed, holding her hand and calculating expenses,
+while she looked at him imploringly. She wanted to risk it, come what
+might, but that was not his way; his way was with a pencil and a piece
+of paper, and if she confused him with suggestions he had to begin at
+the beginning again.
+
+“Now don’t interrupt,” he would beg of her.
+
+“I have one pound seventeen here, and two and six at the office; I can
+cut off my coffee at the office, say ten shillings, making two nine
+and six, with your eighteen and three makes three nine seven, with five
+naught naught in my cheque-book makes eight nine seven--who is that
+moving?--eight nine seven, dot and carry seven--don’t speak, my own--and
+the pound you lent to that man who came to the door--quiet, child--dot
+and carry child--there, you’ve done it!--did I say nine nine seven? yes,
+I said nine nine seven; the question is, can we try it for a year on
+nine nine seven?”
+
+“Of course we can, George,” she cried. But she was prejudiced in Wendy’s
+favour, and he was really the grander character of the two.
+
+“Remember mumps,” he warned her almost threateningly, and off he went
+again. “Mumps one pound, that is what I have put down, but I daresay
+it will be more like thirty shillings--don’t speak--measles one five,
+German measles half a guinea, makes two fifteen six--don’t waggle your
+finger--whooping-cough, say fifteen shillings”--and so on it went, and
+it added up differently each time; but at last Wendy just got through,
+with mumps reduced to twelve six, and the two kinds of measles treated
+as one.
+
+There was the same excitement over John, and Michael had even a narrower
+squeak; but both were kept, and soon, you might have seen the three of
+them going in a row to Miss Fulsom’s Kindergarten school, accompanied by
+their nurse.
+
+Mrs. Darling loved to have everything just so, and Mr. Darling had a
+passion for being exactly like his neighbours; so, of course, they had
+a nurse. As they were poor, owing to the amount of milk the children
+drank, this nurse was a prim Newfoundland dog, called Nana, who had
+belonged to no one in particular until the Darlings engaged her. She had
+always thought children important, however, and the Darlings had become
+acquainted with her in Kensington Gardens, where she spent most of her
+spare time peeping into perambulators, and was much hated by careless
+nursemaids, whom she followed to their homes and complained of to their
+mistresses. She proved to be quite a treasure of a nurse. How thorough
+she was at bath-time, and up at any moment of the night if one of her
+charges made the slightest cry. Of course her kennel was in the nursery.
+She had a genius for knowing when a cough is a thing to have no patience
+with and when it needs stocking around your throat. She believed to her
+last day in old-fashioned remedies like rhubarb leaf, and made sounds of
+contempt over all this new-fangled talk about germs, and so on. It was a
+lesson in propriety to see her escorting the children to school, walking
+sedately by their side when they were well behaved, and butting them
+back into line if they strayed. On John’s footer [in England soccer
+was called football, “footer” for short] days she never once forgot his
+sweater, and she usually carried an umbrella in her mouth in case of
+rain. There is a room in the basement of Miss Fulsom’s school where the
+nurses wait. They sat on forms, while Nana lay on the floor, but that
+was the only difference. They affected to ignore her as of an inferior
+social status to themselves, and she despised their light talk. She
+resented visits to the nursery from Mrs. Darling’s friends, but if they
+did come she first whipped off Michael’s pinafore and put him into the
+one with blue braiding, and smoothed out Wendy and made a dash at John’s
+hair.
+
+No nursery could possibly have been conducted more correctly, and
+Mr. Darling knew it, yet he sometimes wondered uneasily whether the
+neighbours talked.
+
+He had his position in the city to consider.
+
+Nana also troubled him in another way. He had sometimes a feeling that
+she did not admire him. “I know she admires you tremendously, George,”
+ Mrs. Darling would assure him, and then she would sign to the children
+to be specially nice to father. Lovely dances followed, in which the
+only other servant, Liza, was sometimes allowed to join. Such a midget
+she looked in her long skirt and maid’s cap, though she had sworn, when
+engaged, that she would never see ten again. The gaiety of those romps!
+And gayest of all was Mrs. Darling, who would pirouette so wildly that
+all you could see of her was the kiss, and then if you had dashed at her
+you might have got it. There never was a simpler happier family until
+the coming of Peter Pan.
+
+Mrs. Darling first heard of Peter when she was tidying up her children’s
+minds. It is the nightly custom of every good mother after her children
+are asleep to rummage in their minds and put things straight for next
+morning, repacking into their proper places the many articles that have
+wandered during the day. If you could keep awake (but of course you
+can’t) you would see your own mother doing this, and you would find it
+very interesting to watch her. It is quite like tidying up drawers. You
+would see her on her knees, I expect, lingering humorously over some of
+your contents, wondering where on earth you had picked this thing up,
+making discoveries sweet and not so sweet, pressing this to her cheek as
+if it were as nice as a kitten, and hurriedly stowing that out of sight.
+When you wake in the morning, the naughtiness and evil passions with
+which you went to bed have been folded up small and placed at the bottom
+of your mind and on the top, beautifully aired, are spread out your
+prettier thoughts, ready for you to put on.
+
+I don’t know whether you have ever seen a map of a person’s mind.
+Doctors sometimes draw maps of other parts of you, and your own map can
+become intensely interesting, but catch them trying to draw a map of a
+child’s mind, which is not only confused, but keeps going round all
+the time. There are zigzag lines on it, just like your temperature on a
+card, and these are probably roads in the island, for the Neverland is
+always more or less an island, with astonishing splashes of colour here
+and there, and coral reefs and rakish-looking craft in the offing, and
+savages and lonely lairs, and gnomes who are mostly tailors, and caves
+through which a river runs, and princes with six elder brothers, and a
+hut fast going to decay, and one very small old lady with a hooked nose.
+It would be an easy map if that were all, but there is also first day
+at school, religion, fathers, the round pond, needle-work, murders,
+hangings, verbs that take the dative, chocolate pudding day, getting
+into braces, say ninety-nine, three-pence for pulling out your tooth
+yourself, and so on, and either these are part of the island or they are
+another map showing through, and it is all rather confusing, especially
+as nothing will stand still.
+
+Of course the Neverlands vary a good deal. John’s, for instance, had a
+lagoon with flamingoes flying over it at which John was shooting, while
+Michael, who was very small, had a flamingo with lagoons flying over
+it. John lived in a boat turned upside down on the sands, Michael in
+a wigwam, Wendy in a house of leaves deftly sewn together. John had no
+friends, Michael had friends at night, Wendy had a pet wolf forsaken by
+its parents, but on the whole the Neverlands have a family resemblance,
+and if they stood still in a row you could say of them that they have
+each other’s nose, and so forth. On these magic shores children at play
+are for ever beaching their coracles [simple boat]. We too have been
+there; we can still hear the sound of the surf, though we shall land no
+more.
+
+Of all delectable islands the Neverland is the snuggest and most
+compact, not large and sprawly, you know, with tedious distances between
+one adventure and another, but nicely crammed. When you play at it by
+day with the chairs and table-cloth, it is not in the least alarming,
+but in the two minutes before you go to sleep it becomes very real. That
+is why there are night-lights.
+
+Occasionally in her travels through her children’s minds Mrs. Darling
+found things she could not understand, and of these quite the most
+perplexing was the word Peter. She knew of no Peter, and yet he was
+here and there in John and Michael’s minds, while Wendy’s began to be
+scrawled all over with him. The name stood out in bolder letters than
+any of the other words, and as Mrs. Darling gazed she felt that it had
+an oddly cocky appearance.
+
+“Yes, he is rather cocky,” Wendy admitted with regret. Her mother had
+been questioning her.
+
+“But who is he, my pet?”
+
+“He is Peter Pan, you know, mother.”
+
+At first Mrs. Darling did not know, but after thinking back into her
+childhood she just remembered a Peter Pan who was said to live with the
+fairies. There were odd stories about him, as that when children died he
+went part of the way with them, so that they should not be frightened.
+She had believed in him at the time, but now that she was married and
+full of sense she quite doubted whether there was any such person.
+
+“Besides,” she said to Wendy, “he would be grown up by this time.”
+
+“Oh no, he isn’t grown up,” Wendy assured her confidently, “and he is
+just my size.” She meant that he was her size in both mind and body; she
+didn’t know how she knew, she just knew it.
+
+Mrs. Darling consulted Mr. Darling, but he smiled pooh-pooh. “Mark my
+words,” he said, “it is some nonsense Nana has been putting into their
+heads; just the sort of idea a dog would have. Leave it alone, and it
+will blow over.”
+
+But it would not blow over and soon the troublesome boy gave Mrs.
+Darling quite a shock.
+
+Children have the strangest adventures without being troubled by them.
+For instance, they may remember to mention, a week after the event
+happened, that when they were in the wood they had met their dead
+father and had a game with him. It was in this casual way that Wendy one
+morning made a disquieting revelation. Some leaves of a tree had been
+found on the nursery floor, which certainly were not there when the
+children went to bed, and Mrs. Darling was puzzling over them when Wendy
+said with a tolerant smile:
+
+“I do believe it is that Peter again!”
+
+“Whatever do you mean, Wendy?”
+
+“It is so naughty of him not to wipe his feet,” Wendy said, sighing. She
+was a tidy child.
+
+She explained in quite a matter-of-fact way that she thought Peter
+sometimes came to the nursery in the night and sat on the foot of her
+bed and played on his pipes to her. Unfortunately she never woke, so she
+didn’t know how she knew, she just knew.
+
+“What nonsense you talk, precious. No one can get into the house without
+knocking.”
+
+“I think he comes in by the window,” she said.
+
+“My love, it is three floors up.”
+
+“Were not the leaves at the foot of the window, mother?”
+
+It was quite true; the leaves had been found very near the window.
+
+Mrs. Darling did not know what to think, for it all seemed so natural to
+Wendy that you could not dismiss it by saying she had been dreaming.
+
+“My child,” the mother cried, “why did you not tell me of this before?”
+
+“I forgot,” said Wendy lightly. She was in a hurry to get her breakfast.
+
+Oh, surely she must have been dreaming.
+
+But, on the other hand, there were the leaves. Mrs. Darling examined
+them very carefully; they were skeleton leaves, but she was sure they
+did not come from any tree that grew in England. She crawled about the
+floor, peering at it with a candle for marks of a strange foot. She
+rattled the poker up the chimney and tapped the walls. She let down a
+tape from the window to the pavement, and it was a sheer drop of thirty
+feet, without so much as a spout to climb up by.
+
+Certainly Wendy had been dreaming.
+
+But Wendy had not been dreaming, as the very next night showed, the
+night on which the extraordinary adventures of these children may be
+said to have begun.
+
+On the night we speak of all the children were once more in bed. It
+happened to be Nana’s evening off, and Mrs. Darling had bathed them and
+sung to them till one by one they had let go her hand and slid away into
+the land of sleep.
+
+All were looking so safe and cosy that she smiled at her fears now and
+sat down tranquilly by the fire to sew.
+
+It was something for Michael, who on his birthday was getting into
+shirts. The fire was warm, however, and the nursery dimly lit by three
+night-lights, and presently the sewing lay on Mrs. Darling’s lap. Then
+her head nodded, oh, so gracefully. She was asleep. Look at the four of
+them, Wendy and Michael over there, John here, and Mrs. Darling by the
+fire. There should have been a fourth night-light.
+
+While she slept she had a dream. She dreamt that the Neverland had come
+too near and that a strange boy had broken through from it. He did not
+alarm her, for she thought she had seen him before in the faces of many
+women who have no children. Perhaps he is to be found in the faces of
+some mothers also. But in her dream he had rent the film that obscures
+the Neverland, and she saw Wendy and John and Michael peeping through
+the gap.
+
+The dream by itself would have been a trifle, but while she was dreaming
+the window of the nursery blew open, and a boy did drop on the floor.
+He was accompanied by a strange light, no bigger than your fist, which
+darted about the room like a living thing and I think it must have been
+this light that wakened Mrs. Darling.
+
+She started up with a cry, and saw the boy, and somehow she knew at once
+that he was Peter Pan. If you or I or Wendy had been there we should
+have seen that he was very like Mrs. Darling’s kiss. He was a lovely
+boy, clad in skeleton leaves and the juices that ooze out of trees but
+the most entrancing thing about him was that he had all his first teeth.
+When he saw she was a grown-up, he gnashed the little pearls at her.
+
+
+
+
+Chapter 2 THE SHADOW
+
+Mrs. Darling screamed, and, as if in answer to a bell, the door opened,
+and Nana entered, returned from her evening out. She growled and sprang
+at the boy, who leapt lightly through the window. Again Mrs. Darling
+screamed, this time in distress for him, for she thought he was killed,
+and she ran down into the street to look for his little body, but it
+was not there; and she looked up, and in the black night she could see
+nothing but what she thought was a shooting star.
+
+She returned to the nursery, and found Nana with something in her mouth,
+which proved to be the boy’s shadow. As he leapt at the window Nana had
+closed it quickly, too late to catch him, but his shadow had not had
+time to get out; slam went the window and snapped it off.
+
+You may be sure Mrs. Darling examined the shadow carefully, but it was
+quite the ordinary kind.
+
+Nana had no doubt of what was the best thing to do with this shadow. She
+hung it out at the window, meaning “He is sure to come back for it; let
+us put it where he can get it easily without disturbing the children.”
+
+But unfortunately Mrs. Darling could not leave it hanging out at the
+window, it looked so like the washing and lowered the whole tone of the
+house. She thought of showing it to Mr. Darling, but he was totting up
+winter great-coats for John and Michael, with a wet towel around his
+head to keep his brain clear, and it seemed a shame to trouble him;
+besides, she knew exactly what he would say: “It all comes of having a
+dog for a nurse.”
+
+She decided to roll the shadow up and put it away carefully in a drawer,
+until a fitting opportunity came for telling her husband. Ah me!
+
+The opportunity came a week later, on that never-to-be-forgotten Friday.
+Of course it was a Friday.
+
+“I ought to have been specially careful on a Friday,” she used to say
+afterwards to her husband, while perhaps Nana was on the other side of
+her, holding her hand.
+
+“No, no,” Mr. Darling always said, “I am responsible for it all. I,
+George Darling, did it. MEA CULPA, MEA CULPA.” He had had a classical
+education.
+
+They sat thus night after night recalling that fatal Friday, till every
+detail of it was stamped on their brains and came through on the other
+side like the faces on a bad coinage.
+
+“If only I had not accepted that invitation to dine at 27,” Mrs. Darling
+said.
+
+“If only I had not poured my medicine into Nana’s bowl,” said Mr.
+Darling.
+
+“If only I had pretended to like the medicine,” was what Nana’s wet eyes
+said.
+
+“My liking for parties, George.”
+
+“My fatal gift of humour, dearest.”
+
+“My touchiness about trifles, dear master and mistress.”
+
+Then one or more of them would break down altogether; Nana at the
+thought, “It’s true, it’s true, they ought not to have had a dog for
+a nurse.” Many a time it was Mr. Darling who put the handkerchief to
+Nana’s eyes.
+
+“That fiend!” Mr. Darling would cry, and Nana’s bark was the echo of
+it, but Mrs. Darling never upbraided Peter; there was something in the
+right-hand corner of her mouth that wanted her not to call Peter names.
+
+They would sit there in the empty nursery, recalling fondly every
+smallest detail of that dreadful evening. It had begun so uneventfully,
+so precisely like a hundred other evenings, with Nana putting on the
+water for Michael’s bath and carrying him to it on her back.
+
+“I won’t go to bed,” he had shouted, like one who still believed that he
+had the last word on the subject, “I won’t, I won’t. Nana, it isn’t six
+o’clock yet. Oh dear, oh dear, I shan’t love you any more, Nana. I tell
+you I won’t be bathed, I won’t, I won’t!”
+
+Then Mrs. Darling had come in, wearing her white evening-gown. She had
+dressed early because Wendy so loved to see her in her evening-gown,
+with the necklace George had given her. She was wearing Wendy’s bracelet
+on her arm; she had asked for the loan of it. Wendy loved to lend her
+bracelet to her mother.
+
+She had found her two older children playing at being herself and father
+on the occasion of Wendy’s birth, and John was saying:
+
+“I am happy to inform you, Mrs. Darling, that you are now a mother,”
+ in just such a tone as Mr. Darling himself may have used on the real
+occasion.
+
+Wendy had danced with joy, just as the real Mrs. Darling must have done.
+
+Then John was born, with the extra pomp that he conceived due to the
+birth of a male, and Michael came from his bath to ask to be born also,
+but John said brutally that they did not want any more.
+
+Michael had nearly cried. “Nobody wants me,” he said, and of course the
+lady in the evening-dress could not stand that.
+
+“I do,” she said, “I so want a third child.”
+
+“Boy or girl?” asked Michael, not too hopefully.
+
+“Boy.”
+
+Then he had leapt into her arms. Such a little thing for Mr. and Mrs.
+Darling and Nana to recall now, but not so little if that was to be
+Michael’s last night in the nursery.
+
+They go on with their recollections.
+
+“It was then that I rushed in like a tornado, wasn’t it?” Mr. Darling
+would say, scorning himself; and indeed he had been like a tornado.
+
+Perhaps there was some excuse for him. He, too, had been dressing for
+the party, and all had gone well with him until he came to his tie. It
+is an astounding thing to have to tell, but this man, though he knew
+about stocks and shares, had no real mastery of his tie. Sometimes the
+thing yielded to him without a contest, but there were occasions when it
+would have been better for the house if he had swallowed his pride and
+used a made-up tie.
+
+This was such an occasion. He came rushing into the nursery with the
+crumpled little brute of a tie in his hand.
+
+“Why, what is the matter, father dear?”
+
+“Matter!” he yelled; he really yelled. “This tie, it will not tie.” He
+became dangerously sarcastic. “Not round my neck! Round the bed-post!
+Oh yes, twenty times have I made it up round the bed-post, but round my
+neck, no! Oh dear no! begs to be excused!”
+
+He thought Mrs. Darling was not sufficiently impressed, and he went on
+sternly, “I warn you of this, mother, that unless this tie is round my
+neck we don’t go out to dinner to-night, and if I don’t go out to dinner
+to-night, I never go to the office again, and if I don’t go to the
+office again, you and I starve, and our children will be flung into the
+streets.”
+
+Even then Mrs. Darling was placid. “Let me try, dear,” she said, and
+indeed that was what he had come to ask her to do, and with her nice
+cool hands she tied his tie for him, while the children stood around to
+see their fate decided. Some men would have resented her being able to
+do it so easily, but Mr. Darling had far too fine a nature for that; he
+thanked her carelessly, at once forgot his rage, and in another moment
+was dancing round the room with Michael on his back.
+
+“How wildly we romped!” says Mrs. Darling now, recalling it.
+
+“Our last romp!” Mr. Darling groaned.
+
+“O George, do you remember Michael suddenly said to me, ‘How did you get
+to know me, mother?’”
+
+“I remember!”
+
+“They were rather sweet, don’t you think, George?”
+
+“And they were ours, ours! and now they are gone.”
+
+The romp had ended with the appearance of Nana, and most unluckily Mr.
+Darling collided against her, covering his trousers with hairs. They
+were not only new trousers, but they were the first he had ever had
+with braid on them, and he had had to bite his lip to prevent the tears
+coming. Of course Mrs. Darling brushed him, but he began to talk again
+about its being a mistake to have a dog for a nurse.
+
+“George, Nana is a treasure.”
+
+“No doubt, but I have an uneasy feeling at times that she looks upon the
+children as puppies.”
+
+“Oh no, dear one, I feel sure she knows they have souls.”
+
+“I wonder,” Mr. Darling said thoughtfully, “I wonder.” It was an
+opportunity, his wife felt, for telling him about the boy. At first he
+pooh-poohed the story, but he became thoughtful when she showed him the
+shadow.
+
+“It is nobody I know,” he said, examining it carefully, “but it does
+look a scoundrel.”
+
+“We were still discussing it, you remember,” says Mr. Darling, “when
+Nana came in with Michael’s medicine. You will never carry the bottle in
+your mouth again, Nana, and it is all my fault.”
+
+Strong man though he was, there is no doubt that he had behaved rather
+foolishly over the medicine. If he had a weakness, it was for thinking
+that all his life he had taken medicine boldly, and so now, when Michael
+dodged the spoon in Nana’s mouth, he had said reprovingly, “Be a man,
+Michael.”
+
+“Won’t; won’t!” Michael cried naughtily. Mrs. Darling left the room to
+get a chocolate for him, and Mr. Darling thought this showed want of
+firmness.
+
+“Mother, don’t pamper him,” he called after her. “Michael, when I was
+your age I took medicine without a murmur. I said, ‘Thank you, kind
+parents, for giving me bottles to make me well.’”
+
+He really thought this was true, and Wendy, who was now in her
+night-gown, believed it also, and she said, to encourage Michael, “That
+medicine you sometimes take, father, is much nastier, isn’t it?”
+
+“Ever so much nastier,” Mr. Darling said bravely, “and I would take it
+now as an example to you, Michael, if I hadn’t lost the bottle.”
+
+He had not exactly lost it; he had climbed in the dead of night to the
+top of the wardrobe and hidden it there. What he did not know was that
+the faithful Liza had found it, and put it back on his wash-stand.
+
+“I know where it is, father,” Wendy cried, always glad to be of service.
+“I’ll bring it,” and she was off before he could stop her. Immediately
+his spirits sank in the strangest way.
+
+“John,” he said, shuddering, “it’s most beastly stuff. It’s that nasty,
+sticky, sweet kind.”
+
+“It will soon be over, father,” John said cheerily, and then in rushed
+Wendy with the medicine in a glass.
+
+“I have been as quick as I could,” she panted.
+
+“You have been wonderfully quick,” her father retorted, with a
+vindictive politeness that was quite thrown away upon her. “Michael
+first,” he said doggedly.
+
+“Father first,” said Michael, who was of a suspicious nature.
+
+“I shall be sick, you know,” Mr. Darling said threateningly.
+
+“Come on, father,” said John.
+
+“Hold your tongue, John,” his father rapped out.
+
+Wendy was quite puzzled. “I thought you took it quite easily, father.”
+
+“That is not the point,” he retorted. “The point is, that there is
+more in my glass than in Michael’s spoon.” His proud heart was nearly
+bursting. “And it isn’t fair: I would say it though it were with my last
+breath; it isn’t fair.”
+
+“Father, I am waiting,” said Michael coldly.
+
+“It’s all very well to say you are waiting; so am I waiting.”
+
+“Father’s a cowardly custard.”
+
+“So are you a cowardly custard.”
+
+“I’m not frightened.”
+
+“Neither am I frightened.”
+
+“Well, then, take it.”
+
+“Well, then, you take it.”
+
+Wendy had a splendid idea. “Why not both take it at the same time?”
+
+“Certainly,” said Mr. Darling. “Are you ready, Michael?”
+
+Wendy gave the words, one, two, three, and Michael took his medicine,
+but Mr. Darling slipped his behind his back.
+
+There was a yell of rage from Michael, and “O father!” Wendy exclaimed.
+
+“What do you mean by ‘O father’?” Mr. Darling demanded. “Stop that row,
+Michael. I meant to take mine, but I--I missed it.”
+
+It was dreadful the way all the three were looking at him, just as if
+they did not admire him. “Look here, all of you,” he said entreatingly,
+as soon as Nana had gone into the bathroom. “I have just thought of a
+splendid joke. I shall pour my medicine into Nana’s bowl, and she will
+drink it, thinking it is milk!”
+
+It was the colour of milk; but the children did not have their father’s
+sense of humour, and they looked at him reproachfully as he poured the
+medicine into Nana’s bowl. “What fun!” he said doubtfully, and they did
+not dare expose him when Mrs. Darling and Nana returned.
+
+“Nana, good dog,” he said, patting her, “I have put a little milk into
+your bowl, Nana.”
+
+Nana wagged her tail, ran to the medicine, and began lapping it. Then
+she gave Mr. Darling such a look, not an angry look: she showed him the
+great red tear that makes us so sorry for noble dogs, and crept into her
+kennel.
+
+Mr. Darling was frightfully ashamed of himself, but he would not give
+in. In a horrid silence Mrs. Darling smelt the bowl. “O George,” she
+said, “it’s your medicine!”
+
+“It was only a joke,” he roared, while she comforted her boys, and Wendy
+hugged Nana. “Much good,” he said bitterly, “my wearing myself to the
+bone trying to be funny in this house.”
+
+And still Wendy hugged Nana. “That’s right,” he shouted. “Coddle her!
+Nobody coddles me. Oh dear no! I am only the breadwinner, why should I
+be coddled--why, why, why!”
+
+“George,” Mrs. Darling entreated him, “not so loud; the servants
+will hear you.” Somehow they had got into the way of calling Liza the
+servants.
+
+“Let them!” he answered recklessly. “Bring in the whole world. But I
+refuse to allow that dog to lord it in my nursery for an hour longer.”
+
+The children wept, and Nana ran to him beseechingly, but he waved her
+back. He felt he was a strong man again. “In vain, in vain,” he cried;
+“the proper place for you is the yard, and there you go to be tied up
+this instant.”
+
+“George, George,” Mrs. Darling whispered, “remember what I told you
+about that boy.”
+
+Alas, he would not listen. He was determined to show who was master in
+that house, and when commands would not draw Nana from the kennel, he
+lured her out of it with honeyed words, and seizing her roughly, dragged
+her from the nursery. He was ashamed of himself, and yet he did it.
+It was all owing to his too affectionate nature, which craved for
+admiration. When he had tied her up in the back-yard, the wretched
+father went and sat in the passage, with his knuckles to his eyes.
+
+In the meantime Mrs. Darling had put the children to bed in unwonted
+silence and lit their night-lights. They could hear Nana barking, and
+John whimpered, “It is because he is chaining her up in the yard,” but
+Wendy was wiser.
+
+“That is not Nana’s unhappy bark,” she said, little guessing what was
+about to happen; “that is her bark when she smells danger.”
+
+Danger!
+
+“Are you sure, Wendy?”
+
+“Oh, yes.”
+
+Mrs. Darling quivered and went to the window. It was securely fastened.
+She looked out, and the night was peppered with stars. They were
+crowding round the house, as if curious to see what was to take place
+there, but she did not notice this, nor that one or two of the smaller
+ones winked at her. Yet a nameless fear clutched at her heart and made
+her cry, “Oh, how I wish that I wasn’t going to a party to-night!”
+
+Even Michael, already half asleep, knew that she was perturbed, and he
+asked, “Can anything harm us, mother, after the night-lights are lit?”
+
+“Nothing, precious,” she said; “they are the eyes a mother leaves behind
+her to guard her children.”
+
+She went from bed to bed singing enchantments over them, and little
+Michael flung his arms round her. “Mother,” he cried, “I’m glad of you.”
+ They were the last words she was to hear from him for a long time.
+
+No. 27 was only a few yards distant, but there had been a slight fall of
+snow, and Father and Mother Darling picked their way over it deftly not
+to soil their shoes. They were already the only persons in the street,
+and all the stars were watching them. Stars are beautiful, but they may
+not take an active part in anything, they must just look on for ever. It
+is a punishment put on them for something they did so long ago that no
+star now knows what it was. So the older ones have become glassy-eyed
+and seldom speak (winking is the star language), but the little
+ones still wonder. They are not really friendly to Peter, who had a
+mischievous way of stealing up behind them and trying to blow them out;
+but they are so fond of fun that they were on his side to-night, and
+anxious to get the grown-ups out of the way. So as soon as the door
+of 27 closed on Mr. and Mrs. Darling there was a commotion in the
+firmament, and the smallest of all the stars in the Milky Way screamed
+out:
+
+“Now, Peter!”
+
+
+
+
+Chapter 3 COME AWAY, COME AWAY!
+
+For a moment after Mr. and Mrs. Darling left the house the night-lights
+by the beds of the three children continued to burn clearly. They were
+awfully nice little night-lights, and one cannot help wishing that they
+could have kept awake to see Peter; but Wendy’s light blinked and gave
+such a yawn that the other two yawned also, and before they could close
+their mouths all the three went out.
+
+There was another light in the room now, a thousand times brighter than
+the night-lights, and in the time we have taken to say this, it had been
+in all the drawers in the nursery, looking for Peter’s shadow, rummaged
+the wardrobe and turned every pocket inside out. It was not really a
+light; it made this light by flashing about so quickly, but when it came
+to rest for a second you saw it was a fairy, no longer than your hand,
+but still growing. It was a girl called Tinker Bell exquisitely gowned
+in a skeleton leaf, cut low and square, through which her figure could
+be seen to the best advantage. She was slightly inclined to EMBONPOINT.
+[plump hourglass figure]
+
+A moment after the fairy’s entrance the window was blown open by the
+breathing of the little stars, and Peter dropped in. He had carried
+Tinker Bell part of the way, and his hand was still messy with the fairy
+dust.
+
+“Tinker Bell,” he called softly, after making sure that the children
+were asleep, “Tink, where are you?” She was in a jug for the moment, and
+liking it extremely; she had never been in a jug before.
+
+“Oh, do come out of that jug, and tell me, do you know where they put my
+shadow?”
+
+The loveliest tinkle as of golden bells answered him. It is the fairy
+language. You ordinary children can never hear it, but if you were to
+hear it you would know that you had heard it once before.
+
+Tink said that the shadow was in the big box. She meant the chest of
+drawers, and Peter jumped at the drawers, scattering their contents to
+the floor with both hands, as kings toss ha’pence to the crowd. In a
+moment he had recovered his shadow, and in his delight he forgot that he
+had shut Tinker Bell up in the drawer.
+
+If he thought at all, but I don’t believe he ever thought, it was that
+he and his shadow, when brought near each other, would join like drops
+of water, and when they did not he was appalled. He tried to stick it
+on with soap from the bathroom, but that also failed. A shudder passed
+through Peter, and he sat on the floor and cried.
+
+His sobs woke Wendy, and she sat up in bed. She was not alarmed to see
+a stranger crying on the nursery floor; she was only pleasantly
+interested.
+
+“Boy,” she said courteously, “why are you crying?”
+
+Peter could be exceeding polite also, having learned the grand manner at
+fairy ceremonies, and he rose and bowed to her beautifully. She was much
+pleased, and bowed beautifully to him from the bed.
+
+“What’s your name?” he asked.
+
+“Wendy Moira Angela Darling,” she replied with some satisfaction. “What
+is your name?”
+
+“Peter Pan.”
+
+She was already sure that he must be Peter, but it did seem a
+comparatively short name.
+
+“Is that all?”
+
+“Yes,” he said rather sharply. He felt for the first time that it was a
+shortish name.
+
+“I’m so sorry,” said Wendy Moira Angela.
+
+“It doesn’t matter,” Peter gulped.
+
+She asked where he lived.
+
+“Second to the right,” said Peter, “and then straight on till morning.”
+
+“What a funny address!”
+
+Peter had a sinking. For the first time he felt that perhaps it was a
+funny address.
+
+“No, it isn’t,” he said.
+
+“I mean,” Wendy said nicely, remembering that she was hostess, “is that
+what they put on the letters?”
+
+He wished she had not mentioned letters.
+
+“Don’t get any letters,” he said contemptuously.
+
+“But your mother gets letters?”
+
+“Don’t have a mother,” he said. Not only had he no mother, but he had
+not the slightest desire to have one. He thought them very over-rated
+persons. Wendy, however, felt at once that she was in the presence of a
+tragedy.
+
+“O Peter, no wonder you were crying,” she said, and got out of bed and
+ran to him.
+
+“I wasn’t crying about mothers,” he said rather indignantly. “I was
+crying because I can’t get my shadow to stick on. Besides, I wasn’t
+crying.”
+
+“It has come off?”
+
+“Yes.”
+
+Then Wendy saw the shadow on the floor, looking so draggled, and she was
+frightfully sorry for Peter. “How awful!” she said, but she could not
+help smiling when she saw that he had been trying to stick it on with
+soap. How exactly like a boy!
+
+Fortunately she knew at once what to do. “It must be sewn on,” she said,
+just a little patronisingly.
+
+“What’s sewn?” he asked.
+
+“You’re dreadfully ignorant.”
+
+“No, I’m not.”
+
+But she was exulting in his ignorance. “I shall sew it on for you, my
+little man,” she said, though he was tall as herself, and she got out
+her housewife [sewing bag], and sewed the shadow on to Peter’s foot.
+
+“I daresay it will hurt a little,” she warned him.
+
+“Oh, I shan’t cry,” said Peter, who was already of the opinion that he
+had never cried in his life. And he clenched his teeth and did not
+cry, and soon his shadow was behaving properly, though still a little
+creased.
+
+“Perhaps I should have ironed it,” Wendy said thoughtfully, but Peter,
+boylike, was indifferent to appearances, and he was now jumping about in
+the wildest glee. Alas, he had already forgotten that he owed his bliss
+to Wendy. He thought he had attached the shadow himself. “How clever I
+am!” he crowed rapturously, “oh, the cleverness of me!”
+
+It is humiliating to have to confess that this conceit of Peter was
+one of his most fascinating qualities. To put it with brutal frankness,
+there never was a cockier boy.
+
+But for the moment Wendy was shocked. “You conceit [braggart],” she
+exclaimed, with frightful sarcasm; “of course I did nothing!”
+
+“You did a little,” Peter said carelessly, and continued to dance.
+
+“A little!” she replied with hauteur [pride]; “if I am no use I can at
+least withdraw,” and she sprang in the most dignified way into bed and
+covered her face with the blankets.
+
+To induce her to look up he pretended to be going away, and when this
+failed he sat on the end of the bed and tapped her gently with his foot.
+“Wendy,” he said, “don’t withdraw. I can’t help crowing, Wendy, when
+I’m pleased with myself.” Still she would not look up, though she was
+listening eagerly. “Wendy,” he continued, in a voice that no woman has
+ever yet been able to resist, “Wendy, one girl is more use than twenty
+boys.”
+
+Now Wendy was every inch a woman, though there were not very many
+inches, and she peeped out of the bed-clothes.
+
+“Do you really think so, Peter?”
+
+“Yes, I do.”
+
+“I think it’s perfectly sweet of you,” she declared, “and I’ll get up
+again,” and she sat with him on the side of the bed. She also said
+she would give him a kiss if he liked, but Peter did not know what she
+meant, and he held out his hand expectantly.
+
+“Surely you know what a kiss is?” she asked, aghast.
+
+“I shall know when you give it to me,” he replied stiffly, and not to
+hurt his feeling she gave him a thimble.
+
+“Now,” said he, “shall I give you a kiss?” and she replied with a slight
+primness, “If you please.” She made herself rather cheap by inclining
+her face toward him, but he merely dropped an acorn button into her
+hand, so she slowly returned her face to where it had been before, and
+said nicely that she would wear his kiss on the chain around her neck.
+It was lucky that she did put it on that chain, for it was afterwards to
+save her life.
+
+When people in our set are introduced, it is customary for them to
+ask each other’s age, and so Wendy, who always liked to do the correct
+thing, asked Peter how old he was. It was not really a happy question to
+ask him; it was like an examination paper that asks grammar, when what
+you want to be asked is Kings of England.
+
+“I don’t know,” he replied uneasily, “but I am quite young.” He really
+knew nothing about it, he had merely suspicions, but he said at a
+venture, “Wendy, I ran away the day I was born.”
+
+Wendy was quite surprised, but interested; and she indicated in the
+charming drawing-room manner, by a touch on her night-gown, that he
+could sit nearer her.
+
+“It was because I heard father and mother,” he explained in a low
+voice, “talking about what I was to be when I became a man.” He was
+extraordinarily agitated now. “I don’t want ever to be a man,” he said
+with passion. “I want always to be a little boy and to have fun. So
+I ran away to Kensington Gardens and lived a long long time among the
+fairies.”
+
+She gave him a look of the most intense admiration, and he thought it
+was because he had run away, but it was really because he knew fairies.
+Wendy had lived such a home life that to know fairies struck her as
+quite delightful. She poured out questions about them, to his surprise,
+for they were rather a nuisance to him, getting in his way and so on,
+and indeed he sometimes had to give them a hiding [spanking]. Still, he
+liked them on the whole, and he told her about the beginning of fairies.
+
+“You see, Wendy, when the first baby laughed for the first time, its
+laugh broke into a thousand pieces, and they all went skipping about,
+and that was the beginning of fairies.”
+
+Tedious talk this, but being a stay-at-home she liked it.
+
+“And so,” he went on good-naturedly, “there ought to be one fairy for
+every boy and girl.”
+
+“Ought to be? Isn’t there?”
+
+“No. You see children know such a lot now, they soon don’t believe in
+fairies, and every time a child says, ‘I don’t believe in fairies,’
+there is a fairy somewhere that falls down dead.”
+
+Really, he thought they had now talked enough about fairies, and it
+struck him that Tinker Bell was keeping very quiet. “I can’t think where
+she has gone to,” he said, rising, and he called Tink by name. Wendy’s
+heart went flutter with a sudden thrill.
+
+“Peter,” she cried, clutching him, “you don’t mean to tell me that there
+is a fairy in this room!”
+
+“She was here just now,” he said a little impatiently. “You don’t hear
+her, do you?” and they both listened.
+
+“The only sound I hear,” said Wendy, “is like a tinkle of bells.”
+
+“Well, that’s Tink, that’s the fairy language. I think I hear her too.”
+
+The sound came from the chest of drawers, and Peter made a merry face.
+No one could ever look quite so merry as Peter, and the loveliest of
+gurgles was his laugh. He had his first laugh still.
+
+“Wendy,” he whispered gleefully, “I do believe I shut her up in the
+drawer!”
+
+He let poor Tink out of the drawer, and she flew about the nursery
+screaming with fury. “You shouldn’t say such things,” Peter retorted.
+“Of course I’m very sorry, but how could I know you were in the drawer?”
+
+Wendy was not listening to him. “O Peter,” she cried, “if she would only
+stand still and let me see her!”
+
+“They hardly ever stand still,” he said, but for one moment Wendy saw
+the romantic figure come to rest on the cuckoo clock. “O the lovely!”
+ she cried, though Tink’s face was still distorted with passion.
+
+“Tink,” said Peter amiably, “this lady says she wishes you were her
+fairy.”
+
+Tinker Bell answered insolently.
+
+“What does she say, Peter?”
+
+He had to translate. “She is not very polite. She says you are a great
+[huge] ugly girl, and that she is my fairy.”
+
+He tried to argue with Tink. “You know you can’t be my fairy, Tink,
+because I am an gentleman and you are a lady.”
+
+To this Tink replied in these words, “You silly ass,” and disappeared
+into the bathroom. “She is quite a common fairy,” Peter explained
+apologetically, “she is called Tinker Bell because she mends the pots
+and kettles [tinker = tin worker].” [Similar to “cinder” plus “elle” to
+get Cinderella]
+
+They were together in the armchair by this time, and Wendy plied him
+with more questions.
+
+“If you don’t live in Kensington Gardens now--”
+
+“Sometimes I do still.”
+
+“But where do you live mostly now?”
+
+“With the lost boys.”
+
+“Who are they?”
+
+“They are the children who fall out of their perambulators when the
+nurse is looking the other way. If they are not claimed in seven
+days they are sent far away to the Neverland to defray expenses. I’m
+captain.”
+
+“What fun it must be!”
+
+“Yes,” said cunning Peter, “but we are rather lonely. You see we have no
+female companionship.”
+
+“Are none of the others girls?”
+
+“Oh, no; girls, you know, are much too clever to fall out of their
+prams.”
+
+This flattered Wendy immensely. “I think,” she said, “it is perfectly
+lovely the way you talk about girls; John there just despises us.”
+
+For reply Peter rose and kicked John out of bed, blankets and all; one
+kick. This seemed to Wendy rather forward for a first meeting, and she
+told him with spirit that he was not captain in her house. However,
+John continued to sleep so placidly on the floor that she allowed him
+to remain there. “And I know you meant to be kind,” she said, relenting,
+“so you may give me a kiss.”
+
+For the moment she had forgotten his ignorance about kisses. “I thought
+you would want it back,” he said a little bitterly, and offered to
+return her the thimble.
+
+“Oh dear,” said the nice Wendy, “I don’t mean a kiss, I mean a thimble.”
+
+“What’s that?”
+
+“It’s like this.” She kissed him.
+
+“Funny!” said Peter gravely. “Now shall I give you a thimble?”
+
+“If you wish to,” said Wendy, keeping her head erect this time.
+
+Peter thimbled her, and almost immediately she screeched. “What is it,
+Wendy?”
+
+“It was exactly as if someone were pulling my hair.”
+
+“That must have been Tink. I never knew her so naughty before.”
+
+And indeed Tink was darting about again, using offensive language.
+
+“She says she will do that to you, Wendy, every time I give you a
+thimble.”
+
+“But why?”
+
+“Why, Tink?”
+
+Again Tink replied, “You silly ass.” Peter could not understand why,
+but Wendy understood, and she was just slightly disappointed when he
+admitted that he came to the nursery window not to see her but to listen
+to stories.
+
+“You see, I don’t know any stories. None of the lost boys knows any
+stories.”
+
+“How perfectly awful,” Wendy said.
+
+“Do you know,” Peter asked “why swallows build in the eaves of houses?
+It is to listen to the stories. O Wendy, your mother was telling you
+such a lovely story.”
+
+“Which story was it?”
+
+“About the prince who couldn’t find the lady who wore the glass
+slipper.”
+
+“Peter,” said Wendy excitedly, “that was Cinderella, and he found her,
+and they lived happily ever after.”
+
+Peter was so glad that he rose from the floor, where they had been
+sitting, and hurried to the window.
+
+“Where are you going?” she cried with misgiving.
+
+“To tell the other boys.”
+
+“Don’t go Peter,” she entreated, “I know such lots of stories.”
+
+Those were her precise words, so there can be no denying that it was she
+who first tempted him.
+
+He came back, and there was a greedy look in his eyes now which ought to
+have alarmed her, but did not.
+
+“Oh, the stories I could tell to the boys!” she cried, and then Peter
+gripped her and began to draw her toward the window.
+
+“Let me go!” she ordered him.
+
+“Wendy, do come with me and tell the other boys.”
+
+Of course she was very pleased to be asked, but she said, “Oh dear, I
+can’t. Think of mummy! Besides, I can’t fly.”
+
+“I’ll teach you.”
+
+“Oh, how lovely to fly.”
+
+“I’ll teach you how to jump on the wind’s back, and then away we go.”
+
+“Oo!” she exclaimed rapturously.
+
+“Wendy, Wendy, when you are sleeping in your silly bed you might be
+flying about with me saying funny things to the stars.”
+
+“Oo!”
+
+“And, Wendy, there are mermaids.”
+
+“Mermaids! With tails?”
+
+“Such long tails.”
+
+“Oh,” cried Wendy, “to see a mermaid!”
+
+He had become frightfully cunning. “Wendy,” he said, “how we should all
+respect you.”
+
+She was wriggling her body in distress. It was quite as if she were
+trying to remain on the nursery floor.
+
+But he had no pity for her.
+
+“Wendy,” he said, the sly one, “you could tuck us in at night.”
+
+“Oo!”
+
+“None of us has ever been tucked in at night.”
+
+“Oo,” and her arms went out to him.
+
+“And you could darn our clothes, and make pockets for us. None of us has
+any pockets.”
+
+How could she resist. “Of course it’s awfully fascinating!” she cried.
+“Peter, would you teach John and Michael to fly too?”
+
+“If you like,” he said indifferently, and she ran to John and Michael
+and shook them. “Wake up,” she cried, “Peter Pan has come and he is to
+teach us to fly.”
+
+John rubbed his eyes. “Then I shall get up,” he said. Of course he was
+on the floor already. “Hallo,” he said, “I am up!”
+
+Michael was up by this time also, looking as sharp as a knife with six
+blades and a saw, but Peter suddenly signed silence. Their faces assumed
+the awful craftiness of children listening for sounds from the grown-up
+world. All was as still as salt. Then everything was right. No, stop!
+Everything was wrong. Nana, who had been barking distressfully all the
+evening, was quiet now. It was her silence they had heard.
+
+“Out with the light! Hide! Quick!” cried John, taking command for the
+only time throughout the whole adventure. And thus when Liza entered,
+holding Nana, the nursery seemed quite its old self, very dark, and
+you would have sworn you heard its three wicked inmates breathing
+angelically as they slept. They were really doing it artfully from
+behind the window curtains.
+
+Liza was in a bad temper, for she was mixing the Christmas puddings in
+the kitchen, and had been drawn from them, with a raisin still on her
+cheek, by Nana’s absurd suspicions. She thought the best way of getting
+a little quiet was to take Nana to the nursery for a moment, but in
+custody of course.
+
+“There, you suspicious brute,” she said, not sorry that Nana was in
+disgrace. “They are perfectly safe, aren’t they? Every one of the little
+angels sound asleep in bed. Listen to their gentle breathing.”
+
+Here Michael, encouraged by his success, breathed so loudly that they
+were nearly detected. Nana knew that kind of breathing, and she tried to
+drag herself out of Liza’s clutches.
+
+But Liza was dense. “No more of it, Nana,” she said sternly, pulling
+her out of the room. “I warn you if you bark again I shall go straight
+for master and missus and bring them home from the party, and then, oh,
+won’t master whip you, just.”
+
+She tied the unhappy dog up again, but do you think Nana ceased to bark?
+Bring master and missus home from the party! Why, that was just what she
+wanted. Do you think she cared whether she was whipped so long as her
+charges were safe? Unfortunately Liza returned to her puddings, and
+Nana, seeing that no help would come from her, strained and strained at
+the chain until at last she broke it. In another moment she had burst
+into the dining-room of 27 and flung up her paws to heaven, her most
+expressive way of making a communication. Mr. and Mrs. Darling knew at
+once that something terrible was happening in their nursery, and without
+a good-bye to their hostess they rushed into the street.
+
+But it was now ten minutes since three scoundrels had been breathing
+behind the curtains, and Peter Pan can do a great deal in ten minutes.
+
+We now return to the nursery.
+
+“It’s all right,” John announced, emerging from his hiding-place. “I
+say, Peter, can you really fly?”
+
+Instead of troubling to answer him Peter flew around the room, taking
+the mantelpiece on the way.
+
+“How topping!” said John and Michael.
+
+“How sweet!” cried Wendy.
+
+“Yes, I’m sweet, oh, I am sweet!” said Peter, forgetting his manners
+again.
+
+It looked delightfully easy, and they tried it first from the floor and
+then from the beds, but they always went down instead of up.
+
+“I say, how do you do it?” asked John, rubbing his knee. He was quite a
+practical boy.
+
+“You just think lovely wonderful thoughts,” Peter explained, “and they
+lift you up in the air.”
+
+He showed them again.
+
+“You’re so nippy at it,” John said, “couldn’t you do it very slowly
+once?”
+
+Peter did it both slowly and quickly. “I’ve got it now, Wendy!” cried
+John, but soon he found he had not. Not one of them could fly an inch,
+though even Michael was in words of two syllables, and Peter did not
+know A from Z.
+
+Of course Peter had been trifling with them, for no one can fly unless
+the fairy dust has been blown on him. Fortunately, as we have mentioned,
+one of his hands was messy with it, and he blew some on each of them,
+with the most superb results.
+
+“Now just wiggle your shoulders this way,” he said, “and let go.”
+
+They were all on their beds, and gallant Michael let go first. He did
+not quite mean to let go, but he did it, and immediately he was borne
+across the room.
+
+“I flewed!” he screamed while still in mid-air.
+
+John let go and met Wendy near the bathroom.
+
+“Oh, lovely!”
+
+“Oh, ripping!”
+
+“Look at me!”
+
+“Look at me!”
+
+“Look at me!”
+
+They were not nearly so elegant as Peter, they could not help kicking a
+little, but their heads were bobbing against the ceiling, and there is
+almost nothing so delicious as that. Peter gave Wendy a hand at first,
+but had to desist, Tink was so indignant.
+
+Up and down they went, and round and round. Heavenly was Wendy’s word.
+
+“I say,” cried John, “why shouldn’t we all go out?”
+
+Of course it was to this that Peter had been luring them.
+
+Michael was ready: he wanted to see how long it took him to do a billion
+miles. But Wendy hesitated.
+
+“Mermaids!” said Peter again.
+
+“Oo!”
+
+“And there are pirates.”
+
+“Pirates,” cried John, seizing his Sunday hat, “let us go at once.”
+
+It was just at this moment that Mr. and Mrs. Darling hurried with Nana
+out of 27. They ran into the middle of the street to look up at the
+nursery window; and, yes, it was still shut, but the room was ablaze
+with light, and most heart-gripping sight of all, they could see in
+shadow on the curtain three little figures in night attire circling
+round and round, not on the floor but in the air.
+
+Not three figures, four!
+
+In a tremble they opened the street door. Mr. Darling would have rushed
+upstairs, but Mrs. Darling signed him to go softly. She even tried to
+make her heart go softly.
+
+Will they reach the nursery in time? If so, how delightful for them, and
+we shall all breathe a sigh of relief, but there will be no story. On
+the other hand, if they are not in time, I solemnly promise that it will
+all come right in the end.
+
+They would have reached the nursery in time had it not been that the
+little stars were watching them. Once again the stars blew the window
+open, and that smallest star of all called out:
+
+“Cave, Peter!”
+
+Then Peter knew that there was not a moment to lose. “Come,” he cried
+imperiously, and soared out at once into the night, followed by John and
+Michael and Wendy.
+
+Mr. and Mrs. Darling and Nana rushed into the nursery too late. The
+birds were flown.
+
+
+
+
+Chapter 4 THE FLIGHT
+
+“Second to the right, and straight on till morning.”
+
+That, Peter had told Wendy, was the way to the Neverland; but even
+birds, carrying maps and consulting them at windy corners, could not
+have sighted it with these instructions. Peter, you see, just said
+anything that came into his head.
+
+At first his companions trusted him implicitly, and so great were the
+delights of flying that they wasted time circling round church spires or
+any other tall objects on the way that took their fancy.
+
+John and Michael raced, Michael getting a start.
+
+They recalled with contempt that not so long ago they had thought
+themselves fine fellows for being able to fly round a room.
+
+Not long ago. But how long ago? They were flying over the sea before
+this thought began to disturb Wendy seriously. John thought it was their
+second sea and their third night.
+
+Sometimes it was dark and sometimes light, and now they were very cold
+and again too warm. Did they really feel hungry at times, or were they
+merely pretending, because Peter had such a jolly new way of feeding
+them? His way was to pursue birds who had food in their mouths suitable
+for humans and snatch it from them; then the birds would follow and
+snatch it back; and they would all go chasing each other gaily for
+miles, parting at last with mutual expressions of good-will. But Wendy
+noticed with gentle concern that Peter did not seem to know that this
+was rather an odd way of getting your bread and butter, nor even that
+there are other ways.
+
+Certainly they did not pretend to be sleepy, they were sleepy; and that
+was a danger, for the moment they popped off, down they fell. The awful
+thing was that Peter thought this funny.
+
+“There he goes again!” he would cry gleefully, as Michael suddenly
+dropped like a stone.
+
+“Save him, save him!” cried Wendy, looking with horror at the cruel
+sea far below. Eventually Peter would dive through the air, and catch
+Michael just before he could strike the sea, and it was lovely the way
+he did it; but he always waited till the last moment, and you felt it
+was his cleverness that interested him and not the saving of human life.
+Also he was fond of variety, and the sport that engrossed him one moment
+would suddenly cease to engage him, so there was always the possibility
+that the next time you fell he would let you go.
+
+He could sleep in the air without falling, by merely lying on his back
+and floating, but this was, partly at least, because he was so light
+that if you got behind him and blew he went faster.
+
+“Do be more polite to him,” Wendy whispered to John, when they were
+playing “Follow my Leader.”
+
+“Then tell him to stop showing off,” said John.
+
+When playing Follow my Leader, Peter would fly close to the water and
+touch each shark’s tail in passing, just as in the street you may run
+your finger along an iron railing. They could not follow him in this
+with much success, so perhaps it was rather like showing off, especially
+as he kept looking behind to see how many tails they missed.
+
+“You must be nice to him,” Wendy impressed on her brothers. “What could
+we do if he were to leave us!”
+
+“We could go back,” Michael said.
+
+“How could we ever find our way back without him?”
+
+“Well, then, we could go on,” said John.
+
+“That is the awful thing, John. We should have to go on, for we don’t
+know how to stop.”
+
+This was true, Peter had forgotten to show them how to stop.
+
+John said that if the worst came to the worst, all they had to do was to
+go straight on, for the world was round, and so in time they must come
+back to their own window.
+
+“And who is to get food for us, John?”
+
+“I nipped a bit out of that eagle’s mouth pretty neatly, Wendy.”
+
+“After the twentieth try,” Wendy reminded him. “And even though we
+became good at picking up food, see how we bump against clouds and things
+if he is not near to give us a hand.”
+
+Indeed they were constantly bumping. They could now fly strongly, though
+they still kicked far too much; but if they saw a cloud in front of
+them, the more they tried to avoid it, the more certainly did they bump
+into it. If Nana had been with them, she would have had a bandage round
+Michael’s forehead by this time.
+
+Peter was not with them for the moment, and they felt rather lonely up
+there by themselves. He could go so much faster than they that he would
+suddenly shoot out of sight, to have some adventure in which they had no
+share. He would come down laughing over something fearfully funny he had
+been saying to a star, but he had already forgotten what it was, or he
+would come up with mermaid scales still sticking to him, and yet not be
+able to say for certain what had been happening. It was really rather
+irritating to children who had never seen a mermaid.
+
+“And if he forgets them so quickly,” Wendy argued, “how can we expect
+that he will go on remembering us?”
+
+Indeed, sometimes when he returned he did not remember them, at least
+not well. Wendy was sure of it. She saw recognition come into his eyes
+as he was about to pass them the time of day and go on; once even she
+had to call him by name.
+
+“I’m Wendy,” she said agitatedly.
+
+He was very sorry. “I say, Wendy,” he whispered to her, “always if you
+see me forgetting you, just keep on saying ‘I’m Wendy,’ and then I’ll
+remember.”
+
+Of course this was rather unsatisfactory. However, to make amends he
+showed them how to lie out flat on a strong wind that was going their
+way, and this was such a pleasant change that they tried it several
+times and found that they could sleep thus with security. Indeed they
+would have slept longer, but Peter tired quickly of sleeping, and soon
+he would cry in his captain voice, “We get off here.” So with occasional
+tiffs, but on the whole rollicking, they drew near the Neverland; for
+after many moons they did reach it, and, what is more, they had been
+going pretty straight all the time, not perhaps so much owing to the
+guidance of Peter or Tink as because the island was looking for them. It
+is only thus that any one may sight those magic shores.
+
+“There it is,” said Peter calmly.
+
+“Where, where?”
+
+“Where all the arrows are pointing.”
+
+Indeed a million golden arrows were pointing it out to the children, all
+directed by their friend the sun, who wanted them to be sure of their
+way before leaving them for the night.
+
+Wendy and John and Michael stood on tip-toe in the air to get their
+first sight of the island. Strange to say, they all recognized it at
+once, and until fear fell upon them they hailed it, not as something
+long dreamt of and seen at last, but as a familiar friend to whom they
+were returning home for the holidays.
+
+“John, there’s the lagoon.”
+
+“Wendy, look at the turtles burying their eggs in the sand.”
+
+“I say, John, I see your flamingo with the broken leg!”
+
+“Look, Michael, there’s your cave!”
+
+“John, what’s that in the brushwood?”
+
+“It’s a wolf with her whelps. Wendy, I do believe that’s your little
+whelp!”
+
+“There’s my boat, John, with her sides stove in!”
+
+“No, it isn’t. Why, we burned your boat.”
+
+“That’s her, at any rate. I say, John, I see the smoke of the redskin
+camp!”
+
+“Where? Show me, and I’ll tell you by the way smoke curls whether they
+are on the war-path.”
+
+“There, just across the Mysterious River.”
+
+“I see now. Yes, they are on the war-path right enough.”
+
+Peter was a little annoyed with them for knowing so much, but if he
+wanted to lord it over them his triumph was at hand, for have I not told
+you that anon fear fell upon them?
+
+It came as the arrows went, leaving the island in gloom.
+
+In the old days at home the Neverland had always begun to look a little
+dark and threatening by bedtime. Then unexplored patches arose in it
+and spread, black shadows moved about in them, the roar of the beasts of
+prey was quite different now, and above all, you lost the certainty that
+you would win. You were quite glad that the night-lights were on. You
+even liked Nana to say that this was just the mantelpiece over here, and
+that the Neverland was all make-believe.
+
+Of course the Neverland had been make-believe in those days, but it
+was real now, and there were no night-lights, and it was getting darker
+every moment, and where was Nana?
+
+They had been flying apart, but they huddled close to Peter now. His
+careless manner had gone at last, his eyes were sparkling, and a tingle
+went through them every time they touched his body. They were now over
+the fearsome island, flying so low that sometimes a tree grazed their
+feet. Nothing horrid was visible in the air, yet their progress had
+become slow and laboured, exactly as if they were pushing their way
+through hostile forces. Sometimes they hung in the air until Peter had
+beaten on it with his fists.
+
+“They don’t want us to land,” he explained.
+
+“Who are they?” Wendy whispered, shuddering.
+
+But he could not or would not say. Tinker Bell had been asleep on his
+shoulder, but now he wakened her and sent her on in front.
+
+Sometimes he poised himself in the air, listening intently, with his
+hand to his ear, and again he would stare down with eyes so bright that
+they seemed to bore two holes to earth. Having done these things, he
+went on again.
+
+His courage was almost appalling. “Would you like an adventure now,” he
+said casually to John, “or would you like to have your tea first?”
+
+Wendy said “tea first” quickly, and Michael pressed her hand in
+gratitude, but the braver John hesitated.
+
+“What kind of adventure?” he asked cautiously.
+
+“There’s a pirate asleep in the pampas just beneath us,” Peter told him.
+“If you like, we’ll go down and kill him.”
+
+“I don’t see him,” John said after a long pause.
+
+“I do.”
+
+“Suppose,” John said, a little huskily, “he were to wake up.”
+
+Peter spoke indignantly. “You don’t think I would kill him while he was
+sleeping! I would wake him first, and then kill him. That’s the way I
+always do.”
+
+“I say! Do you kill many?”
+
+“Tons.”
+
+John said “How ripping,” but decided to have tea first. He asked if
+there were many pirates on the island just now, and Peter said he had
+never known so many.
+
+“Who is captain now?”
+
+“Hook,” answered Peter, and his face became very stern as he said that
+hated word.
+
+“Jas. Hook?”
+
+“Ay.”
+
+Then indeed Michael began to cry, and even John could speak in gulps
+only, for they knew Hook’s reputation.
+
+“He was Blackbeard’s bo’sun,” John whispered huskily. “He is the worst
+of them all. He is the only man of whom Barbecue was afraid.”
+
+“That’s him,” said Peter.
+
+“What is he like? Is he big?”
+
+“He is not so big as he was.”
+
+“How do you mean?”
+
+“I cut off a bit of him.”
+
+“You!”
+
+“Yes, me,” said Peter sharply.
+
+“I wasn’t meaning to be disrespectful.”
+
+“Oh, all right.”
+
+“But, I say, what bit?”
+
+“His right hand.”
+
+“Then he can’t fight now?”
+
+“Oh, can’t he just!”
+
+“Left-hander?”
+
+“He has an iron hook instead of a right hand, and he claws with it.”
+
+“Claws!”
+
+“I say, John,” said Peter.
+
+“Yes.”
+
+“Say, ‘Ay, ay, sir.’”
+
+“Ay, ay, sir.”
+
+“There is one thing,” Peter continued, “that every boy who serves under
+me has to promise, and so must you.”
+
+John paled.
+
+“It is this, if we meet Hook in open fight, you must leave him to me.”
+
+“I promise,” John said loyally.
+
+For the moment they were feeling less eerie, because Tink was flying
+with them, and in her light they could distinguish each other.
+Unfortunately she could not fly so slowly as they, and so she had to go
+round and round them in a circle in which they moved as in a halo. Wendy
+quite liked it, until Peter pointed out the drawbacks.
+
+“She tells me,” he said, “that the pirates sighted us before the
+darkness came, and got Long Tom out.”
+
+“The big gun?”
+
+“Yes. And of course they must see her light, and if they guess we are
+near it they are sure to let fly.”
+
+“Wendy!”
+
+“John!”
+
+“Michael!”
+
+“Tell her to go away at once, Peter,” the three cried simultaneously,
+but he refused.
+
+“She thinks we have lost the way,” he replied stiffly, “and she is
+rather frightened. You don’t think I would send her away all by herself
+when she is frightened!”
+
+For a moment the circle of light was broken, and something gave Peter a
+loving little pinch.
+
+“Then tell her,” Wendy begged, “to put out her light.”
+
+“She can’t put it out. That is about the only thing fairies can’t do. It
+just goes out of itself when she falls asleep, same as the stars.”
+
+“Then tell her to sleep at once,” John almost ordered.
+
+“She can’t sleep except when she’s sleepy. It is the only other thing
+fairies can’t do.”
+
+“Seems to me,” growled John, “these are the only two things worth
+doing.”
+
+Here he got a pinch, but not a loving one.
+
+“If only one of us had a pocket,” Peter said, “we could carry her in
+it.” However, they had set off in such a hurry that there was not a
+pocket between the four of them.
+
+He had a happy idea. John’s hat!
+
+Tink agreed to travel by hat if it was carried in the hand. John carried
+it, though she had hoped to be carried by Peter. Presently Wendy took
+the hat, because John said it struck against his knee as he flew; and
+this, as we shall see, led to mischief, for Tinker Bell hated to be
+under an obligation to Wendy.
+
+In the black topper the light was completely hidden, and they flew on in
+silence. It was the stillest silence they had ever known, broken once by
+a distant lapping, which Peter explained was the wild beasts drinking at
+the ford, and again by a rasping sound that might have been the branches
+of trees rubbing together, but he said it was the redskins sharpening
+their knives.
+
+Even these noises ceased. To Michael the loneliness was dreadful. “If
+only something would make a sound!” he cried.
+
+As if in answer to his request, the air was rent by the most tremendous
+crash he had ever heard. The pirates had fired Long Tom at them.
+
+The roar of it echoed through the mountains, and the echoes seemed to
+cry savagely, “Where are they, where are they, where are they?”
+
+Thus sharply did the terrified three learn the difference between an
+island of make-believe and the same island come true.
+
+When at last the heavens were steady again, John and Michael
+found themselves alone in the darkness. John was treading the air
+mechanically, and Michael without knowing how to float was floating.
+
+“Are you shot?” John whispered tremulously.
+
+“I haven’t tried [myself out] yet,” Michael whispered back.
+
+We know now that no one had been hit. Peter, however, had been carried
+by the wind of the shot far out to sea, while Wendy was blown upwards
+with no companion but Tinker Bell.
+
+It would have been well for Wendy if at that moment she had dropped the
+hat.
+
+I don’t know whether the idea came suddenly to Tink, or whether she had
+planned it on the way, but she at once popped out of the hat and began
+to lure Wendy to her destruction.
+
+Tink was not all bad; or, rather, she was all bad just now, but, on the
+other hand, sometimes she was all good. Fairies have to be one thing or
+the other, because being so small they unfortunately have room for one
+feeling only at a time. They are, however, allowed to change, only it
+must be a complete change. At present she was full of jealousy of Wendy.
+What she said in her lovely tinkle Wendy could not of course understand,
+and I believe some of it was bad words, but it sounded kind, and she
+flew back and forward, plainly meaning “Follow me, and all will be
+well.”
+
+What else could poor Wendy do? She called to Peter and John and Michael,
+and got only mocking echoes in reply. She did not yet know that Tink
+hated her with the fierce hatred of a very woman. And so, bewildered,
+and now staggering in her flight, she followed Tink to her doom.
+
+
+
+
+Chapter 5 THE ISLAND COME TRUE
+
+Feeling that Peter was on his way back, the Neverland had again woke
+into life. We ought to use the pluperfect and say wakened, but woke is
+better and was always used by Peter.
+
+In his absence things are usually quiet on the island. The fairies take
+an hour longer in the morning, the beasts attend to their young, the
+redskins feed heavily for six days and nights, and when pirates and
+lost boys meet they merely bite their thumbs at each other. But with the
+coming of Peter, who hates lethargy, they are under way again: if you
+put your ear to the ground now, you would hear the whole island seething
+with life.
+
+On this evening the chief forces of the island were disposed as follows.
+The lost boys were out looking for Peter, the pirates were out looking
+for the lost boys, the redskins were out looking for the pirates, and
+the beasts were out looking for the redskins. They were going round and
+round the island, but they did not meet because all were going at the
+same rate.
+
+All wanted blood except the boys, who liked it as a rule, but to-night
+were out to greet their captain. The boys on the island vary, of course,
+in numbers, according as they get killed and so on; and when they seem
+to be growing up, which is against the rules, Peter thins them out; but
+at this time there were six of them, counting the twins as two. Let us
+pretend to lie here among the sugar-cane and watch them as they steal by
+in single file, each with his hand on his dagger.
+
+They are forbidden by Peter to look in the least like him, and they wear
+the skins of the bears slain by themselves, in which they are so round
+and furry that when they fall they roll. They have therefore become very
+sure-footed.
+
+The first to pass is Tootles, not the least brave but the most
+unfortunate of all that gallant band. He had been in fewer adventures
+than any of them, because the big things constantly happened just when
+he had stepped round the corner; all would be quiet, he would take the
+opportunity of going off to gather a few sticks for firewood, and
+then when he returned the others would be sweeping up the blood. This
+ill-luck had given a gentle melancholy to his countenance, but instead
+of souring his nature had sweetened it, so that he was quite the
+humblest of the boys. Poor kind Tootles, there is danger in the air for
+you to-night. Take care lest an adventure is now offered you, which, if
+accepted, will plunge you in deepest woe. Tootles, the fairy Tink, who
+is bent on mischief this night is looking for a tool [for doing her
+mischief], and she thinks you are the most easily tricked of the boys.
+‘Ware Tinker Bell.
+
+Would that he could hear us, but we are not really on the island, and he
+passes by, biting his knuckles.
+
+Next comes Nibs, the gay and debonair, followed by Slightly, who cuts
+whistles out of the trees and dances ecstatically to his own tunes.
+Slightly is the most conceited of the boys. He thinks he remembers the
+days before he was lost, with their manners and customs, and this has
+given his nose an offensive tilt. Curly is fourth; he is a pickle, [a
+person who gets in pickles-predicaments] and so often has he had to
+deliver up his person when Peter said sternly, “Stand forth the one who
+did this thing,” that now at the command he stands forth automatically
+whether he has done it or not. Last come the Twins, who cannot be
+described because we should be sure to be describing the wrong one.
+Peter never quite knew what twins were, and his band were not allowed
+to know anything he did not know, so these two were always vague about
+themselves, and did their best to give satisfaction by keeping close
+together in an apologetic sort of way.
+
+The boys vanish in the gloom, and after a pause, but not a long pause,
+for things go briskly on the island, come the pirates on their track. We
+hear them before they are seen, and it is always the same dreadful song:
+
+     “Avast belay, yo ho, heave to,
+     A-pirating we go,
+     And if we’re parted by a shot
+     We’re sure to meet below!”
+
+A more villainous-looking lot never hung in a row on Execution dock.
+Here, a little in advance, ever and again with his head to the
+ground listening, his great arms bare, pieces of eight in his ears as
+ornaments, is the handsome Italian Cecco, who cut his name in letters
+of blood on the back of the governor of the prison at Gao. That gigantic
+black behind him has had many names since he dropped the one with
+which dusky mothers still terrify their children on the banks of the
+Guadjo-mo. Here is Bill Jukes, every inch of him tattooed, the same Bill
+Jukes who got six dozen on the WALRUS from Flint before he would drop
+the bag of moidores [Portuguese gold pieces]; and Cookson, said to
+be Black Murphy’s brother (but this was never proved), and Gentleman
+Starkey, once an usher in a public school and still dainty in his ways
+of killing; and Skylights (Morgan’s Skylights); and the Irish bo’sun
+Smee, an oddly genial man who stabbed, so to speak, without offence,
+and was the only Non-conformist in Hook’s crew; and Noodler, whose
+hands were fixed on backwards; and Robt. Mullins and Alf Mason and many
+another ruffian long known and feared on the Spanish Main.
+
+In the midst of them, the blackest and largest in that dark setting,
+reclined James Hook, or as he wrote himself, Jas. Hook, of whom it is
+said he was the only man that the Sea-Cook feared. He lay at his ease in
+a rough chariot drawn and propelled by his men, and instead of a right
+hand he had the iron hook with which ever and anon he encouraged them
+to increase their pace. As dogs this terrible man treated and addressed
+them, and as dogs they obeyed him. In person he was cadaverous [dead
+looking] and blackavized [dark faced], and his hair was dressed in long
+curls, which at a little distance looked like black candles, and gave a
+singularly threatening expression to his handsome countenance. His eyes
+were of the blue of the forget-me-not, and of a profound melancholy,
+save when he was plunging his hook into you, at which time two red spots
+appeared in them and lit them up horribly. In manner, something of the
+grand seigneur still clung to him, so that he even ripped you up with
+an air, and I have been told that he was a RACONTEUR [storyteller] of
+repute. He was never more sinister than when he was most polite,
+which is probably the truest test of breeding; and the elegance of his
+diction, even when he was swearing, no less than the distinction of his
+demeanour, showed him one of a different cast from his crew. A man of
+indomitable courage, it was said that the only thing he shied at was
+the sight of his own blood, which was thick and of an unusual colour.
+In dress he somewhat aped the attire associated with the name of Charles
+II, having heard it said in some earlier period of his career that he
+bore a strange resemblance to the ill-fated Stuarts; and in his mouth
+he had a holder of his own contrivance which enabled him to smoke two
+cigars at once. But undoubtedly the grimmest part of him was his iron
+claw.
+
+Let us now kill a pirate, to show Hook’s method. Skylights will do. As
+they pass, Skylights lurches clumsily against him, ruffling his lace
+collar; the hook shoots forth, there is a tearing sound and one screech,
+then the body is kicked aside, and the pirates pass on. He has not even
+taken the cigars from his mouth.
+
+Such is the terrible man against whom Peter Pan is pitted. Which will
+win?
+
+On the trail of the pirates, stealing noiselessly down the war-path,
+which is not visible to inexperienced eyes, come the redskins, every one
+of them with his eyes peeled. They carry tomahawks and knives, and their
+naked bodies gleam with paint and oil. Strung around them are scalps, of
+boys as well as of pirates, for these are the Piccaninny tribe, and not
+to be confused with the softer-hearted Delawares or the Hurons. In
+the van, on all fours, is Great Big Little Panther, a brave of so many
+scalps that in his present position they somewhat impede his progress.
+Bringing up the rear, the place of greatest danger, comes Tiger Lily,
+proudly erect, a princess in her own right. She is the most beautiful
+of dusky Dianas [Diana = goddess of the woods] and the belle of the
+Piccaninnies, coquettish [flirting], cold and amorous [loving] by turns;
+there is not a brave who would not have the wayward thing to wife, but
+she staves off the altar with a hatchet. Observe how they pass over
+fallen twigs without making the slightest noise. The only sound to be
+heard is their somewhat heavy breathing. The fact is that they are all a
+little fat just now after the heavy gorging, but in time they will work
+this off. For the moment, however, it constitutes their chief danger.
+
+The redskins disappear as they have come like shadows, and soon their
+place is taken by the beasts, a great and motley procession: lions,
+tigers, bears, and the innumerable smaller savage things that flee
+from them, for every kind of beast, and, more particularly, all the
+man-eaters, live cheek by jowl on the favoured island. Their tongues are
+hanging out, they are hungry to-night.
+
+When they have passed, comes the last figure of all, a gigantic
+crocodile. We shall see for whom she is looking presently.
+
+The crocodile passes, but soon the boys appear again, for the procession
+must continue indefinitely until one of the parties stops or changes its
+pace. Then quickly they will be on top of each other.
+
+All are keeping a sharp look-out in front, but none suspects that the
+danger may be creeping up from behind. This shows how real the island
+was.
+
+The first to fall out of the moving circle was the boys. They flung
+themselves down on the sward [turf], close to their underground home.
+
+“I do wish Peter would come back,” every one of them said nervously,
+though in height and still more in breadth they were all larger than
+their captain.
+
+“I am the only one who is not afraid of the pirates,” Slightly said, in
+the tone that prevented his being a general favourite; but perhaps some
+distant sound disturbed him, for he added hastily, “but I wish he
+would come back, and tell us whether he has heard anything more about
+Cinderella.”
+
+They talked of Cinderella, and Tootles was confident that his mother
+must have been very like her.
+
+It was only in Peter’s absence that they could speak of mothers, the
+subject being forbidden by him as silly.
+
+“All I remember about my mother,” Nibs told them, “is that she often
+said to my father, ‘Oh, how I wish I had a cheque-book of my own!’ I
+don’t know what a cheque-book is, but I should just love to give my
+mother one.”
+
+While they talked they heard a distant sound. You or I, not being wild
+things of the woods, would have heard nothing, but they heard it, and it
+was the grim song:
+
+     “Yo ho, yo ho, the pirate life,
+     The flag o’ skull and bones,
+     A merry hour, a hempen rope,
+     And hey for Davy Jones.”
+
+At once the lost boys--but where are they? They are no longer there.
+Rabbits could not have disappeared more quickly.
+
+I will tell you where they are. With the exception of Nibs, who has
+darted away to reconnoitre [look around], they are already in their home
+under the ground, a very delightful residence of which we shall see
+a good deal presently. But how have they reached it? for there is no
+entrance to be seen, not so much as a large stone, which if rolled away,
+would disclose the mouth of a cave. Look closely, however, and you may
+note that there are here seven large trees, each with a hole in its
+hollow trunk as large as a boy. These are the seven entrances to the
+home under the ground, for which Hook has been searching in vain these
+many moons. Will he find it tonight?
+
+As the pirates advanced, the quick eye of Starkey sighted Nibs
+disappearing through the wood, and at once his pistol flashed out. But
+an iron claw gripped his shoulder.
+
+“Captain, let go!” he cried, writhing.
+
+Now for the first time we hear the voice of Hook. It was a black voice.
+“Put back that pistol first,” it said threateningly.
+
+“It was one of those boys you hate. I could have shot him dead.”
+
+“Ay, and the sound would have brought Tiger Lily’s redskins upon us. Do
+you want to lose your scalp?”
+
+“Shall I after him, Captain,” asked pathetic Smee, “and tickle him
+with Johnny Corkscrew?” Smee had pleasant names for everything, and his
+cutlass was Johnny Corkscrew, because he wiggled it in the wound. One
+could mention many lovable traits in Smee. For instance, after killing,
+it was his spectacles he wiped instead of his weapon.
+
+“Johnny’s a silent fellow,” he reminded Hook.
+
+“Not now, Smee,” Hook said darkly. “He is only one, and I want to
+mischief all the seven. Scatter and look for them.”
+
+The pirates disappeared among the trees, and in a moment their Captain
+and Smee were alone. Hook heaved a heavy sigh, and I know not why it
+was, perhaps it was because of the soft beauty of the evening, but there
+came over him a desire to confide to his faithful bo’sun the story of
+his life. He spoke long and earnestly, but what it was all about Smee,
+who was rather stupid, did not know in the least.
+
+Anon [later] he caught the word Peter.
+
+“Most of all,” Hook was saying passionately, “I want their captain,
+Peter Pan. ‘Twas he cut off my arm.” He brandished the hook
+threateningly. “I’ve waited long to shake his hand with this. Oh, I’ll
+tear him!”
+
+“And yet,” said Smee, “I have often heard you say that hook was worth a
+score of hands, for combing the hair and other homely uses.”
+
+“Ay,” the captain answered, “if I was a mother I would pray to have my
+children born with this instead of that,” and he cast a look of pride
+upon his iron hand and one of scorn upon the other. Then again he
+frowned.
+
+“Peter flung my arm,” he said, wincing, “to a crocodile that happened to
+be passing by.”
+
+“I have often,” said Smee, “noticed your strange dread of crocodiles.”
+
+“Not of crocodiles,” Hook corrected him, “but of that one crocodile.” He
+lowered his voice. “It liked my arm so much, Smee, that it has followed
+me ever since, from sea to sea and from land to land, licking its lips
+for the rest of me.”
+
+“In a way,” said Smee, “it’s sort of a compliment.”
+
+“I want no such compliments,” Hook barked petulantly. “I want Peter Pan,
+who first gave the brute its taste for me.”
+
+He sat down on a large mushroom, and now there was a quiver in his
+voice. “Smee,” he said huskily, “that crocodile would have had me before
+this, but by a lucky chance it swallowed a clock which goes tick tick
+inside it, and so before it can reach me I hear the tick and bolt.” He
+laughed, but in a hollow way.
+
+“Some day,” said Smee, “the clock will run down, and then he’ll get
+you.”
+
+Hook wetted his dry lips. “Ay,” he said, “that’s the fear that haunts
+me.”
+
+Since sitting down he had felt curiously warm. “Smee,” he said, “this
+seat is hot.” He jumped up. “Odds bobs, hammer and tongs I’m burning.”
+
+They examined the mushroom, which was of a size and solidity unknown
+on the mainland; they tried to pull it up, and it came away at once in
+their hands, for it had no root. Stranger still, smoke began at once
+to ascend. The pirates looked at each other. “A chimney!” they both
+exclaimed.
+
+They had indeed discovered the chimney of the home under the ground. It
+was the custom of the boys to stop it with a mushroom when enemies were
+in the neighbourhood.
+
+Not only smoke came out of it. There came also children’s voices, for
+so safe did the boys feel in their hiding-place that they were gaily
+chattering. The pirates listened grimly, and then replaced the mushroom.
+They looked around them and noted the holes in the seven trees.
+
+“Did you hear them say Peter Pan’s from home?” Smee whispered, fidgeting
+with Johnny Corkscrew.
+
+Hook nodded. He stood for a long time lost in thought, and at last a
+curdling smile lit up his swarthy face. Smee had been waiting for it.
+“Unrip your plan, captain,” he cried eagerly.
+
+“To return to the ship,” Hook replied slowly through his teeth, “and
+cook a large rich cake of a jolly thickness with green sugar on it.
+There can be but one room below, for there is but one chimney. The silly
+moles had not the sense to see that they did not need a door apiece.
+That shows they have no mother. We will leave the cake on the shore
+of the Mermaids’ Lagoon. These boys are always swimming about there,
+playing with the mermaids. They will find the cake and they will gobble
+it up, because, having no mother, they don’t know how dangerous ‘tis to
+eat rich damp cake.” He burst into laughter, not hollow laughter now,
+but honest laughter. “Aha, they will die.”
+
+Smee had listened with growing admiration.
+
+“It’s the wickedest, prettiest policy ever I heard of!” he cried, and in
+their exultation they danced and sang:
+
+     “Avast, belay, when I appear,
+     By fear they’re overtook;
+     Nought’s left upon your bones when you
+     Have shaken claws with Hook.”
+
+They began the verse, but they never finished it, for another sound
+broke in and stilled them. There was at first such a tiny sound that a
+leaf might have fallen on it and smothered it, but as it came nearer it
+was more distinct.
+
+Tick tick tick tick!
+
+Hook stood shuddering, one foot in the air.
+
+“The crocodile!” he gasped, and bounded away, followed by his bo’sun.
+
+It was indeed the crocodile. It had passed the redskins, who were now on
+the trail of the other pirates. It oozed on after Hook.
+
+Once more the boys emerged into the open; but the dangers of the night
+were not yet over, for presently Nibs rushed breathless into their
+midst, pursued by a pack of wolves. The tongues of the pursuers were
+hanging out; the baying of them was horrible.
+
+“Save me, save me!” cried Nibs, falling on the ground.
+
+“But what can we do, what can we do?”
+
+It was a high compliment to Peter that at that dire moment their
+thoughts turned to him.
+
+“What would Peter do?” they cried simultaneously.
+
+Almost in the same breath they cried, “Peter would look at them through
+his legs.”
+
+And then, “Let us do what Peter would do.”
+
+It is quite the most successful way of defying wolves, and as one boy
+they bent and looked through their legs. The next moment is the long
+one, but victory came quickly, for as the boys advanced upon them in the
+terrible attitude, the wolves dropped their tails and fled.
+
+Now Nibs rose from the ground, and the others thought that his staring
+eyes still saw the wolves. But it was not wolves he saw.
+
+“I have seen a wonderfuller thing,” he cried, as they gathered round him
+eagerly. “A great white bird. It is flying this way.”
+
+“What kind of a bird, do you think?”
+
+“I don’t know,” Nibs said, awestruck, “but it looks so weary, and as it
+flies it moans, ‘Poor Wendy.’”
+
+“Poor Wendy?”
+
+“I remember,” said Slightly instantly, “there are birds called Wendies.”
+
+“See, it comes!” cried Curly, pointing to Wendy in the heavens.
+
+Wendy was now almost overhead, and they could hear her plaintive cry.
+But more distinct came the shrill voice of Tinker Bell. The jealous
+fairy had now cast off all disguise of friendship, and was darting
+at her victim from every direction, pinching savagely each time she
+touched.
+
+“Hullo, Tink,” cried the wondering boys.
+
+Tink’s reply rang out: “Peter wants you to shoot the Wendy.”
+
+It was not in their nature to question when Peter ordered. “Let us do
+what Peter wishes!” cried the simple boys. “Quick, bows and arrows!”
+
+All but Tootles popped down their trees. He had a bow and arrow with
+him, and Tink noted it, and rubbed her little hands.
+
+“Quick, Tootles, quick,” she screamed. “Peter will be so pleased.”
+
+Tootles excitedly fitted the arrow to his bow. “Out of the way, Tink,”
+ he shouted, and then he fired, and Wendy fluttered to the ground with an
+arrow in her breast.
+
+
+
+
+Chapter 6 THE LITTLE HOUSE
+
+Foolish Tootles was standing like a conqueror over Wendy’s body when the
+other boys sprang, armed, from their trees.
+
+“You are too late,” he cried proudly, “I have shot the Wendy. Peter will
+be so pleased with me.”
+
+Overhead Tinker Bell shouted “Silly ass!” and darted into hiding. The
+others did not hear her. They had crowded round Wendy, and as they
+looked a terrible silence fell upon the wood. If Wendy’s heart had been
+beating they would all have heard it.
+
+Slightly was the first to speak. “This is no bird,” he said in a scared
+voice. “I think this must be a lady.”
+
+“A lady?” said Tootles, and fell a-trembling.
+
+“And we have killed her,” Nibs said hoarsely.
+
+They all whipped off their caps.
+
+“Now I see,” Curly said: “Peter was bringing her to us.” He threw
+himself sorrowfully on the ground.
+
+“A lady to take care of us at last,” said one of the twins, “and you
+have killed her!”
+
+They were sorry for him, but sorrier for themselves, and when he took a
+step nearer them they turned from him.
+
+Tootles’ face was very white, but there was a dignity about him now that
+had never been there before.
+
+“I did it,” he said, reflecting. “When ladies used to come to me in
+dreams, I said, ‘Pretty mother, pretty mother.’ But when at last she
+really came, I shot her.”
+
+He moved slowly away.
+
+“Don’t go,” they called in pity.
+
+“I must,” he answered, shaking; “I am so afraid of Peter.”
+
+It was at this tragic moment that they heard a sound which made the
+heart of every one of them rise to his mouth. They heard Peter crow.
+
+“Peter!” they cried, for it was always thus that he signalled his
+return.
+
+“Hide her,” they whispered, and gathered hastily around Wendy. But
+Tootles stood aloof.
+
+Again came that ringing crow, and Peter dropped in front of them.
+“Greetings, boys,” he cried, and mechanically they saluted, and then
+again was silence.
+
+He frowned.
+
+“I am back,” he said hotly, “why do you not cheer?”
+
+They opened their mouths, but the cheers would not come. He overlooked
+it in his haste to tell the glorious tidings.
+
+“Great news, boys,” he cried, “I have brought at last a mother for you
+all.”
+
+Still no sound, except a little thud from Tootles as he dropped on his
+knees.
+
+“Have you not seen her?” asked Peter, becoming troubled. “She flew this
+way.”
+
+“Ah me!” one voice said, and another said, “Oh, mournful day.”
+
+Tootles rose. “Peter,” he said quietly, “I will show her to you,” and
+when the others would still have hidden her he said, “Back, twins, let
+Peter see.”
+
+So they all stood back, and let him see, and after he had looked for a
+little time he did not know what to do next.
+
+“She is dead,” he said uncomfortably. “Perhaps she is frightened at
+being dead.”
+
+He thought of hopping off in a comic sort of way till he was out of
+sight of her, and then never going near the spot any more. They would
+all have been glad to follow if he had done this.
+
+But there was the arrow. He took it from her heart and faced his band.
+
+“Whose arrow?” he demanded sternly.
+
+“Mine, Peter,” said Tootles on his knees.
+
+“Oh, dastard hand,” Peter said, and he raised the arrow to use it as a
+dagger.
+
+Tootles did not flinch. He bared his breast. “Strike, Peter,” he said
+firmly, “strike true.”
+
+Twice did Peter raise the arrow, and twice did his hand fall. “I cannot
+strike,” he said with awe, “there is something stays my hand.”
+
+All looked at him in wonder, save Nibs, who fortunately looked at Wendy.
+
+“It is she,” he cried, “the Wendy lady, see, her arm!”
+
+Wonderful to relate [tell], Wendy had raised her arm. Nibs bent over
+her and listened reverently. “I think she said, ‘Poor Tootles,’” he
+whispered.
+
+“She lives,” Peter said briefly.
+
+Slightly cried instantly, “The Wendy lady lives.”
+
+Then Peter knelt beside her and found his button. You remember she had
+put it on a chain that she wore round her neck.
+
+“See,” he said, “the arrow struck against this. It is the kiss I gave
+her. It has saved her life.”
+
+“I remember kisses,” Slightly interposed quickly, “let me see it. Ay,
+that’s a kiss.”
+
+Peter did not hear him. He was begging Wendy to get better quickly, so
+that he could show her the mermaids. Of course she could not answer yet,
+being still in a frightful faint; but from overhead came a wailing note.
+
+“Listen to Tink,” said Curly, “she is crying because the Wendy lives.”
+
+Then they had to tell Peter of Tink’s crime, and almost never had they
+seen him look so stern.
+
+“Listen, Tinker Bell,” he cried, “I am your friend no more. Begone from
+me for ever.”
+
+She flew on to his shoulder and pleaded, but he brushed her off. Not
+until Wendy again raised her arm did he relent sufficiently to say,
+“Well, not for ever, but for a whole week.”
+
+Do you think Tinker Bell was grateful to Wendy for raising her arm? Oh
+dear no, never wanted to pinch her so much. Fairies indeed are strange,
+and Peter, who understood them best, often cuffed [slapped] them.
+
+But what to do with Wendy in her present delicate state of health?
+
+“Let us carry her down into the house,” Curly suggested.
+
+“Ay,” said Slightly, “that is what one does with ladies.”
+
+“No, no,” Peter said, “you must not touch her. It would not be
+sufficiently respectful.”
+
+“That,” said Slightly, “is what I was thinking.”
+
+“But if she lies there,” Tootles said, “she will die.”
+
+“Ay, she will die,” Slightly admitted, “but there is no way out.”
+
+“Yes, there is,” cried Peter. “Let us build a little house round her.”
+
+They were all delighted. “Quick,” he ordered them, “bring me each of you
+the best of what we have. Gut our house. Be sharp.”
+
+In a moment they were as busy as tailors the night before a wedding.
+They skurried this way and that, down for bedding, up for firewood, and
+while they were at it, who should appear but John and Michael. As they
+dragged along the ground they fell asleep standing, stopped, woke up,
+moved another step and slept again.
+
+“John, John,” Michael would cry, “wake up! Where is Nana, John, and
+mother?”
+
+And then John would rub his eyes and mutter, “It is true, we did fly.”
+
+You may be sure they were very relieved to find Peter.
+
+“Hullo, Peter,” they said.
+
+“Hullo,” replied Peter amicably, though he had quite forgotten them.
+He was very busy at the moment measuring Wendy with his feet to see
+how large a house she would need. Of course he meant to leave room for
+chairs and a table. John and Michael watched him.
+
+“Is Wendy asleep?” they asked.
+
+“Yes.”
+
+“John,” Michael proposed, “let us wake her and get her to make supper
+for us,” but as he said it some of the other boys rushed on carrying
+branches for the building of the house. “Look at them!” he cried.
+
+“Curly,” said Peter in his most captainy voice, “see that these boys
+help in the building of the house.”
+
+“Ay, ay, sir.”
+
+“Build a house?” exclaimed John.
+
+“For the Wendy,” said Curly.
+
+“For Wendy?” John said, aghast. “Why, she is only a girl!”
+
+“That,” explained Curly, “is why we are her servants.”
+
+“You? Wendy’s servants!”
+
+“Yes,” said Peter, “and you also. Away with them.”
+
+The astounded brothers were dragged away to hack and hew and carry.
+“Chairs and a fender [fireplace] first,” Peter ordered. “Then we shall
+build a house round them.”
+
+“Ay,” said Slightly, “that is how a house is built; it all comes back to
+me.”
+
+Peter thought of everything. “Slightly,” he cried, “fetch a doctor.”
+
+“Ay, ay,” said Slightly at once, and disappeared, scratching his head.
+But he knew Peter must be obeyed, and he returned in a moment, wearing
+John’s hat and looking solemn.
+
+“Please, sir,” said Peter, going to him, “are you a doctor?”
+
+The difference between him and the other boys at such a time was that
+they knew it was make-believe, while to him make-believe and true were
+exactly the same thing. This sometimes troubled them, as when they had
+to make-believe that they had had their dinners.
+
+If they broke down in their make-believe he rapped them on the knuckles.
+
+“Yes, my little man,” Slightly anxiously replied, who had chapped
+knuckles.
+
+“Please, sir,” Peter explained, “a lady lies very ill.”
+
+She was lying at their feet, but Slightly had the sense not to see her.
+
+“Tut, tut, tut,” he said, “where does she lie?”
+
+“In yonder glade.”
+
+“I will put a glass thing in her mouth,” said Slightly, and he
+made-believe to do it, while Peter waited. It was an anxious moment when
+the glass thing was withdrawn.
+
+“How is she?” inquired Peter.
+
+“Tut, tut, tut,” said Slightly, “this has cured her.”
+
+“I am glad!” Peter cried.
+
+“I will call again in the evening,” Slightly said; “give her beef tea
+out of a cup with a spout to it;” but after he had returned the hat
+to John he blew big breaths, which was his habit on escaping from a
+difficulty.
+
+In the meantime the wood had been alive with the sound of axes; almost
+everything needed for a cosy dwelling already lay at Wendy’s feet.
+
+“If only we knew,” said one, “the kind of house she likes best.”
+
+“Peter,” shouted another, “she is moving in her sleep.”
+
+“Her mouth opens,” cried a third, looking respectfully into it. “Oh,
+lovely!”
+
+“Perhaps she is going to sing in her sleep,” said Peter. “Wendy, sing
+the kind of house you would like to have.”
+
+Immediately, without opening her eyes, Wendy began to sing:
+
+     “I wish I had a pretty house,
+     The littlest ever seen,
+     With funny little red walls
+     And roof of mossy green.”
+
+They gurgled with joy at this, for by the greatest good luck the
+branches they had brought were sticky with red sap, and all the ground
+was carpeted with moss. As they rattled up the little house they broke
+into song themselves:
+
+     “We’ve built the little walls and roof
+     And made a lovely door,
+     So tell us, mother Wendy,
+     What are you wanting more?”
+
+To this she answered greedily:
+
+     “Oh, really next I think I’ll have
+     Gay windows all about,
+     With roses peeping in, you know,
+     And babies peeping out.”
+
+With a blow of their fists they made windows, and large yellow leaves
+were the blinds. But roses--?
+
+“Roses,” cried Peter sternly.
+
+Quickly they made-believe to grow the loveliest roses up the walls.
+
+Babies?
+
+To prevent Peter ordering babies they hurried into song again:
+
+     “We’ve made the roses peeping out,
+     The babes are at the door,
+     We cannot make ourselves, you know,
+     ‘cos we’ve been made before.”
+
+Peter, seeing this to be a good idea, at once pretended that it was his
+own. The house was quite beautiful, and no doubt Wendy was very cosy
+within, though, of course, they could no longer see her. Peter strode
+up and down, ordering finishing touches. Nothing escaped his eagle eyes.
+Just when it seemed absolutely finished:
+
+“There’s no knocker on the door,” he said.
+
+They were very ashamed, but Tootles gave the sole of his shoe, and it
+made an excellent knocker.
+
+Absolutely finished now, they thought.
+
+Not of bit of it. “There’s no chimney,” Peter said; “we must have a
+chimney.”
+
+“It certainly does need a chimney,” said John importantly. This gave
+Peter an idea. He snatched the hat off John’s head, knocked out the
+bottom [top], and put the hat on the roof. The little house was so
+pleased to have such a capital chimney that, as if to say thank you,
+smoke immediately began to come out of the hat.
+
+Now really and truly it was finished. Nothing remained to do but to
+knock.
+
+“All look your best,” Peter warned them; “first impressions are awfully
+important.”
+
+He was glad no one asked him what first impressions are; they were all
+too busy looking their best.
+
+He knocked politely, and now the wood was as still as the children, not
+a sound to be heard except from Tinker Bell, who was watching from a
+branch and openly sneering.
+
+What the boys were wondering was, would any one answer the knock? If a
+lady, what would she be like?
+
+The door opened and a lady came out. It was Wendy. They all whipped off
+their hats.
+
+She looked properly surprised, and this was just how they had hoped she
+would look.
+
+“Where am I?” she said.
+
+Of course Slightly was the first to get his word in. “Wendy lady,” he
+said rapidly, “for you we built this house.”
+
+“Oh, say you’re pleased,” cried Nibs.
+
+“Lovely, darling house,” Wendy said, and they were the very words they
+had hoped she would say.
+
+“And we are your children,” cried the twins.
+
+Then all went on their knees, and holding out their arms cried, “O Wendy
+lady, be our mother.”
+
+“Ought I?” Wendy said, all shining. “Of course it’s frightfully
+fascinating, but you see I am only a little girl. I have no real
+experience.”
+
+“That doesn’t matter,” said Peter, as if he were the only person present
+who knew all about it, though he was really the one who knew least.
+“What we need is just a nice motherly person.”
+
+“Oh dear!” Wendy said, “you see, I feel that is exactly what I am.”
+
+“It is, it is,” they all cried; “we saw it at once.”
+
+“Very well,” she said, “I will do my best. Come inside at once, you
+naughty children; I am sure your feet are damp. And before I put you to
+bed I have just time to finish the story of Cinderella.”
+
+In they went; I don’t know how there was room for them, but you can
+squeeze very tight in the Neverland. And that was the first of the many
+joyous evenings they had with Wendy. By and by she tucked them up in the
+great bed in the home under the trees, but she herself slept that night
+in the little house, and Peter kept watch outside with drawn sword, for
+the pirates could be heard carousing far away and the wolves were on the
+prowl. The little house looked so cosy and safe in the darkness, with
+a bright light showing through its blinds, and the chimney smoking
+beautifully, and Peter standing on guard. After a time he fell asleep,
+and some unsteady fairies had to climb over him on their way home from
+an orgy. Any of the other boys obstructing the fairy path at night they
+would have mischiefed, but they just tweaked Peter’s nose and passed on.
+
+
+
+
+Chapter 7 THE HOME UNDER THE GROUND
+
+One of the first things Peter did next day was to measure Wendy and John
+and Michael for hollow trees. Hook, you remember, had sneered at the
+boys for thinking they needed a tree apiece, but this was ignorance, for
+unless your tree fitted you it was difficult to go up and down, and no
+two of the boys were quite the same size. Once you fitted, you drew in
+[let out] your breath at the top, and down you went at exactly the
+right speed, while to ascend you drew in and let out alternately, and so
+wriggled up. Of course, when you have mastered the action you are able
+to do these things without thinking of them, and nothing can be more
+graceful.
+
+But you simply must fit, and Peter measures you for your tree as
+carefully as for a suit of clothes: the only difference being that the
+clothes are made to fit you, while you have to be made to fit the tree.
+Usually it is done quite easily, as by your wearing too many garments
+or too few, but if you are bumpy in awkward places or the only available
+tree is an odd shape, Peter does some things to you, and after that you
+fit. Once you fit, great care must be taken to go on fitting, and this,
+as Wendy was to discover to her delight, keeps a whole family in perfect
+condition.
+
+Wendy and Michael fitted their trees at the first try, but John had to
+be altered a little.
+
+After a few days’ practice they could go up and down as gaily as buckets
+in a well. And how ardently they grew to love their home under the
+ground; especially Wendy. It consisted of one large room, as all houses
+should do, with a floor in which you could dig [for worms] if you wanted
+to go fishing, and in this floor grew stout mushrooms of a charming
+colour, which were used as stools. A Never tree tried hard to grow in
+the centre of the room, but every morning they sawed the trunk through,
+level with the floor. By tea-time it was always about two feet high, and
+then they put a door on top of it, the whole thus becoming a table;
+as soon as they cleared away, they sawed off the trunk again, and thus
+there was more room to play. There was an enormous fireplace which was
+in almost any part of the room where you cared to light it, and across
+this Wendy stretched strings, made of fibre, from which she suspended
+her washing. The bed was tilted against the wall by day, and let down at
+6:30, when it filled nearly half the room; and all the boys slept in it,
+except Michael, lying like sardines in a tin. There was a strict rule
+against turning round until one gave the signal, when all turned at
+once. Michael should have used it also, but Wendy would have [desired]
+a baby, and he was the littlest, and you know what women are, and the
+short and long of it is that he was hung up in a basket.
+
+It was rough and simple, and not unlike what baby bears would have made
+of an underground house in the same circumstances. But there was one
+recess in the wall, no larger than a bird-cage, which was the private
+apartment of Tinker Bell. It could be shut off from the rest of
+the house by a tiny curtain, which Tink, who was most fastidious
+[particular], always kept drawn when dressing or undressing. No woman,
+however large, could have had a more exquisite boudoir [dressing room]
+and bed-chamber combined. The couch, as she always called it, was
+a genuine Queen Mab, with club legs; and she varied the bedspreads
+according to what fruit-blossom was in season. Her mirror was a
+Puss-in-Boots, of which there are now only three, unchipped, known to
+fairy dealers; the washstand was Pie-crust and reversible, the chest
+of drawers an authentic Charming the Sixth, and the carpet and rugs the
+best (the early) period of Margery and Robin. There was a chandelier
+from Tiddlywinks for the look of the thing, but of course she lit the
+residence herself. Tink was very contemptuous of the rest of the house,
+as indeed was perhaps inevitable, and her chamber, though beautiful,
+looked rather conceited, having the appearance of a nose permanently
+turned up.
+
+I suppose it was all especially entrancing to Wendy, because those
+rampagious boys of hers gave her so much to do. Really there were whole
+weeks when, except perhaps with a stocking in the evening, she was never
+above ground. The cooking, I can tell you, kept her nose to the pot, and
+even if there was nothing in it, even if there was no pot, she had to
+keep watching that it came aboil just the same. You never exactly
+knew whether there would be a real meal or just a make-believe, it all
+depended upon Peter’s whim: he could eat, really eat, if it was part of
+a game, but he could not stodge [cram down the food] just to feel
+stodgy [stuffed with food], which is what most children like better than
+anything else; the next best thing being to talk about it. Make-believe
+was so real to him that during a meal of it you could see him getting
+rounder. Of course it was trying, but you simply had to follow his lead,
+and if you could prove to him that you were getting loose for your tree
+he let you stodge.
+
+Wendy’s favourite time for sewing and darning was after they had all
+gone to bed. Then, as she expressed it, she had a breathing time for
+herself; and she occupied it in making new things for them, and putting
+double pieces on the knees, for they were all most frightfully hard on
+their knees.
+
+When she sat down to a basketful of their stockings, every heel with a
+hole in it, she would fling up her arms and exclaim, “Oh dear, I am sure
+I sometimes think spinsters are to be envied!”
+
+Her face beamed when she exclaimed this.
+
+You remember about her pet wolf. Well, it very soon discovered that she
+had come to the island and it found her out, and they just ran into each
+other’s arms. After that it followed her about everywhere.
+
+As time wore on did she think much about the beloved parents she had
+left behind her? This is a difficult question, because it is quite
+impossible to say how time does wear on in the Neverland, where it is
+calculated by moons and suns, and there are ever so many more of them
+than on the mainland. But I am afraid that Wendy did not really worry
+about her father and mother; she was absolutely confident that they
+would always keep the window open for her to fly back by, and this gave
+her complete ease of mind. What did disturb her at times was that John
+remembered his parents vaguely only, as people he had once known, while
+Michael was quite willing to believe that she was really his mother.
+These things scared her a little, and nobly anxious to do her duty, she
+tried to fix the old life in their minds by setting them examination
+papers on it, as like as possible to the ones she used to do at school.
+The other boys thought this awfully interesting, and insisted on
+joining, and they made slates for themselves, and sat round the table,
+writing and thinking hard about the questions she had written on another
+slate and passed round. They were the most ordinary questions--“What
+was the colour of Mother’s eyes? Which was taller, Father or Mother? Was
+Mother blonde or brunette? Answer all three questions if possible.”
+ “(A) Write an essay of not less than 40 words on How I spent my last
+Holidays, or The Characters of Father and Mother compared. Only one of
+these to be attempted.” Or “(1) Describe Mother’s laugh; (2) Describe
+Father’s laugh; (3) Describe Mother’s Party Dress; (4) Describe the
+Kennel and its Inmate.”
+
+They were just everyday questions like these, and when you could not
+answer them you were told to make a cross; and it was really dreadful
+what a number of crosses even John made. Of course the only boy who
+replied to every question was Slightly, and no one could have been more
+hopeful of coming out first, but his answers were perfectly ridiculous,
+and he really came out last: a melancholy thing.
+
+Peter did not compete. For one thing he despised all mothers except
+Wendy, and for another he was the only boy on the island who could
+neither write nor spell; not the smallest word. He was above all that
+sort of thing.
+
+By the way, the questions were all written in the past tense. What
+was the colour of Mother’s eyes, and so on. Wendy, you see, had been
+forgetting, too.
+
+Adventures, of course, as we shall see, were of daily occurrence; but
+about this time Peter invented, with Wendy’s help, a new game that
+fascinated him enormously, until he suddenly had no more interest in it,
+which, as you have been told, was what always happened with his games.
+It consisted in pretending not to have adventures, in doing the sort of
+thing John and Michael had been doing all their lives, sitting on stools
+flinging balls in the air, pushing each other, going out for walks and
+coming back without having killed so much as a grizzly. To see Peter
+doing nothing on a stool was a great sight; he could not help looking
+solemn at such times, to sit still seemed to him such a comic thing to
+do. He boasted that he had gone walking for the good of his health. For
+several suns these were the most novel of all adventures to him; and
+John and Michael had to pretend to be delighted also; otherwise he would
+have treated them severely.
+
+He often went out alone, and when he came back you were never absolutely
+certain whether he had had an adventure or not. He might have forgotten
+it so completely that he said nothing about it; and then when you went
+out you found the body; and, on the other hand, he might say a great
+deal about it, and yet you could not find the body. Sometimes he came
+home with his head bandaged, and then Wendy cooed over him and bathed
+it in lukewarm water, while he told a dazzling tale. But she was never
+quite sure, you know. There were, however, many adventures which she
+knew to be true because she was in them herself, and there were still
+more that were at least partly true, for the other boys were in them and
+said they were wholly true. To describe them all would require a book as
+large as an English-Latin, Latin-English Dictionary, and the most we can
+do is to give one as a specimen of an average hour on the island. The
+difficulty is which one to choose. Should we take the brush with the
+redskins at Slightly Gulch? It was a sanguinary affair, and
+especially interesting as showing one of Peter’s peculiarities, which
+was that in the middle of a fight he would suddenly change sides. At the
+Gulch, when victory was still in the balance, sometimes leaning this way
+and sometimes that, he called out, “I’m redskin to-day; what are you,
+Tootles?” And Tootles answered, “Redskin; what are you, Nibs?” and
+Nibs said, “Redskin; what are you Twin?” and so on; and they were all
+redskins; and of course this would have ended the fight had not the real
+redskins fascinated by Peter’s methods, agreed to be lost boys for that
+once, and so at it they all went again, more fiercely than ever.
+
+The extraordinary upshot of this adventure was--but we have not decided
+yet that this is the adventure we are to narrate. Perhaps a better one
+would be the night attack by the redskins on the house under the ground,
+when several of them stuck in the hollow trees and had to be pulled out
+like corks. Or we might tell how Peter saved Tiger Lily’s life in the
+Mermaids’ Lagoon, and so made her his ally.
+
+Or we could tell of that cake the pirates cooked so that the boys might
+eat it and perish; and how they placed it in one cunning spot after
+another; but always Wendy snatched it from the hands of her children, so
+that in time it lost its succulence, and became as hard as a stone, and
+was used as a missile, and Hook fell over it in the dark.
+
+Or suppose we tell of the birds that were Peter’s friends, particularly
+of the Never bird that built in a tree overhanging the lagoon, and how
+the nest fell into the water, and still the bird sat on her eggs, and
+Peter gave orders that she was not to be disturbed. That is a pretty
+story, and the end shows how grateful a bird can be; but if we tell
+it we must also tell the whole adventure of the lagoon, which would
+of course be telling two adventures rather than just one. A shorter
+adventure, and quite as exciting, was Tinker Bell’s attempt, with the
+help of some street fairies, to have the sleeping Wendy conveyed on a
+great floating leaf to the mainland. Fortunately the leaf gave way and
+Wendy woke, thinking it was bath-time, and swam back. Or again, we might
+choose Peter’s defiance of the lions, when he drew a circle round him
+on the ground with an arrow and dared them to cross it; and though he
+waited for hours, with the other boys and Wendy looking on breathlessly
+from trees, not one of them dared to accept his challenge.
+
+Which of these adventures shall we choose? The best way will be to toss
+for it.
+
+I have tossed, and the lagoon has won. This almost makes one wish that
+the gulch or the cake or Tink’s leaf had won. Of course I could do it
+again, and make it best out of three; however, perhaps fairest to stick
+to the lagoon.
+
+
+
+
+Chapter 8 THE MERMAIDS’ LAGOON
+
+If you shut your eyes and are a lucky one, you may see at times a
+shapeless pool of lovely pale colours suspended in the darkness; then
+if you squeeze your eyes tighter, the pool begins to take shape, and the
+colours become so vivid that with another squeeze they must go on fire.
+But just before they go on fire you see the lagoon. This is the nearest
+you ever get to it on the mainland, just one heavenly moment; if there
+could be two moments you might see the surf and hear the mermaids
+singing.
+
+The children often spent long summer days on this lagoon, swimming or
+floating most of the time, playing the mermaid games in the water,
+and so forth. You must not think from this that the mermaids were on
+friendly terms with them: on the contrary, it was among Wendy’s lasting
+regrets that all the time she was on the island she never had a civil
+word from one of them. When she stole softly to the edge of the lagoon
+she might see them by the score, especially on Marooners’ Rock, where
+they loved to bask, combing out their hair in a lazy way that quite
+irritated her; or she might even swim, on tiptoe as it were, to within
+a yard of them, but then they saw her and dived, probably splashing her
+with their tails, not by accident, but intentionally.
+
+They treated all the boys in the same way, except of course Peter, who
+chatted with them on Marooners’ Rock by the hour, and sat on their tails
+when they got cheeky. He gave Wendy one of their combs.
+
+The most haunting time at which to see them is at the turn of the moon,
+when they utter strange wailing cries; but the lagoon is dangerous for
+mortals then, and until the evening of which we have now to tell, Wendy
+had never seen the lagoon by moonlight, less from fear, for of course
+Peter would have accompanied her, than because she had strict rules
+about every one being in bed by seven. She was often at the lagoon,
+however, on sunny days after rain, when the mermaids come up in
+extraordinary numbers to play with their bubbles. The bubbles of many
+colours made in rainbow water they treat as balls, hitting them gaily
+from one to another with their tails, and trying to keep them in the
+rainbow till they burst. The goals are at each end of the rainbow, and
+the keepers only are allowed to use their hands. Sometimes a dozen of
+these games will be going on in the lagoon at a time, and it is quite a
+pretty sight.
+
+But the moment the children tried to join in they had to play by
+themselves, for the mermaids immediately disappeared. Nevertheless we
+have proof that they secretly watched the interlopers, and were not
+above taking an idea from them; for John introduced a new way of hitting
+the bubble, with the head instead of the hand, and the mermaids adopted
+it. This is the one mark that John has left on the Neverland.
+
+It must also have been rather pretty to see the children resting on a
+rock for half an hour after their mid-day meal. Wendy insisted on
+their doing this, and it had to be a real rest even though the meal was
+make-believe. So they lay there in the sun, and their bodies glistened
+in it, while she sat beside them and looked important.
+
+It was one such day, and they were all on Marooners’ Rock. The rock was
+not much larger than their great bed, but of course they all knew how
+not to take up much room, and they were dozing, or at least lying with
+their eyes shut, and pinching occasionally when they thought Wendy was
+not looking. She was very busy, stitching.
+
+While she stitched a change came to the lagoon. Little shivers ran over
+it, and the sun went away and shadows stole across the water, turning
+it cold. Wendy could no longer see to thread her needle, and when she
+looked up, the lagoon that had always hitherto been such a laughing
+place seemed formidable and unfriendly.
+
+It was not, she knew, that night had come, but something as dark as
+night had come. No, worse than that. It had not come, but it had sent
+that shiver through the sea to say that it was coming. What was it?
+
+There crowded upon her all the stories she had been told of Marooners’
+Rock, so called because evil captains put sailors on it and leave
+them there to drown. They drown when the tide rises, for then it is
+submerged.
+
+Of course she should have roused the children at once; not merely
+because of the unknown that was stalking toward them, but because it was
+no longer good for them to sleep on a rock grown chilly. But she was
+a young mother and she did not know this; she thought you simply must
+stick to your rule about half an hour after the mid-day meal. So, though
+fear was upon her, and she longed to hear male voices, she would not
+waken them. Even when she heard the sound of muffled oars, though her
+heart was in her mouth, she did not waken them. She stood over them to
+let them have their sleep out. Was it not brave of Wendy?
+
+It was well for those boys then that there was one among them who could
+sniff danger even in his sleep. Peter sprang erect, as wide awake at
+once as a dog, and with one warning cry he roused the others.
+
+He stood motionless, one hand to his ear.
+
+“Pirates!” he cried. The others came closer to him. A strange smile was
+playing about his face, and Wendy saw it and shuddered. While that smile
+was on his face no one dared address him; all they could do was to stand
+ready to obey. The order came sharp and incisive.
+
+“Dive!”
+
+There was a gleam of legs, and instantly the lagoon seemed deserted.
+Marooners’ Rock stood alone in the forbidding waters as if it were
+itself marooned.
+
+The boat drew nearer. It was the pirate dinghy, with three figures in
+her, Smee and Starkey, and the third a captive, no other than Tiger
+Lily. Her hands and ankles were tied, and she knew what was to be her
+fate. She was to be left on the rock to perish, an end to one of her
+race more terrible than death by fire or torture, for is it not written
+in the book of the tribe that there is no path through water to the
+happy hunting-ground? Yet her face was impassive; she was the daughter
+of a chief, she must die as a chief’s daughter, it is enough.
+
+They had caught her boarding the pirate ship with a knife in her mouth.
+No watch was kept on the ship, it being Hook’s boast that the wind of
+his name guarded the ship for a mile around. Now her fate would help to
+guard it also. One more wail would go the round in that wind by night.
+
+In the gloom that they brought with them the two pirates did not see the
+rock till they crashed into it.
+
+“Luff, you lubber,” cried an Irish voice that was Smee’s; “here’s the
+rock. Now, then, what we have to do is to hoist the redskin on to it and
+leave her here to drown.”
+
+It was the work of one brutal moment to land the beautiful girl on the
+rock; she was too proud to offer a vain resistance.
+
+Quite near the rock, but out of sight, two heads were bobbing up and
+down, Peter’s and Wendy’s. Wendy was crying, for it was the first
+tragedy she had seen. Peter had seen many tragedies, but he had
+forgotten them all. He was less sorry than Wendy for Tiger Lily: it was
+two against one that angered him, and he meant to save her. An easy way
+would have been to wait until the pirates had gone, but he was never one
+to choose the easy way.
+
+There was almost nothing he could not do, and he now imitated the voice
+of Hook.
+
+“Ahoy there, you lubbers!” he called. It was a marvellous imitation.
+
+“The captain!” said the pirates, staring at each other in surprise.
+
+“He must be swimming out to us,” Starkey said, when they had looked for
+him in vain.
+
+“We are putting the redskin on the rock,” Smee called out.
+
+“Set her free,” came the astonishing answer.
+
+“Free!”
+
+“Yes, cut her bonds and let her go.”
+
+“But, captain--”
+
+“At once, d’ye hear,” cried Peter, “or I’ll plunge my hook in you.”
+
+“This is queer!” Smee gasped.
+
+“Better do what the captain orders,” said Starkey nervously.
+
+“Ay, ay,” Smee said, and he cut Tiger Lily’s cords. At once like an eel
+she slid between Starkey’s legs into the water.
+
+Of course Wendy was very elated over Peter’s cleverness; but she knew
+that he would be elated also and very likely crow and thus betray
+himself, so at once her hand went out to cover his mouth. But it was
+stayed even in the act, for “Boat ahoy!” rang over the lagoon in Hook’s
+voice, and this time it was not Peter who had spoken.
+
+Peter may have been about to crow, but his face puckered in a whistle of
+surprise instead.
+
+“Boat ahoy!” again came the voice.
+
+Now Wendy understood. The real Hook was also in the water.
+
+He was swimming to the boat, and as his men showed a light to guide him
+he had soon reached them. In the light of the lantern Wendy saw his hook
+grip the boat’s side; she saw his evil swarthy face as he rose dripping
+from the water, and, quaking, she would have liked to swim away, but
+Peter would not budge. He was tingling with life and also top-heavy with
+conceit. “Am I not a wonder, oh, I am a wonder!” he whispered to her,
+and though she thought so also, she was really glad for the sake of his
+reputation that no one heard him except herself.
+
+He signed to her to listen.
+
+The two pirates were very curious to know what had brought their captain
+to them, but he sat with his head on his hook in a position of profound
+melancholy.
+
+“Captain, is all well?” they asked timidly, but he answered with a
+hollow moan.
+
+“He sighs,” said Smee.
+
+“He sighs again,” said Starkey.
+
+“And yet a third time he sighs,” said Smee.
+
+Then at last he spoke passionately.
+
+“The game’s up,” he cried, “those boys have found a mother.”
+
+Affrighted though she was, Wendy swelled with pride.
+
+“O evil day!” cried Starkey.
+
+“What’s a mother?” asked the ignorant Smee.
+
+Wendy was so shocked that she exclaimed. “He doesn’t know!” and always
+after this she felt that if you could have a pet pirate Smee would be
+her one.
+
+Peter pulled her beneath the water, for Hook had started up, crying,
+“What was that?”
+
+“I heard nothing,” said Starkey, raising the lantern over the waters,
+and as the pirates looked they saw a strange sight. It was the nest I
+have told you of, floating on the lagoon, and the Never bird was sitting
+on it.
+
+“See,” said Hook in answer to Smee’s question, “that is a mother. What
+a lesson! The nest must have fallen into the water, but would the mother
+desert her eggs? No.”
+
+There was a break in his voice, as if for a moment he recalled innocent
+days when--but he brushed away this weakness with his hook.
+
+Smee, much impressed, gazed at the bird as the nest was borne past, but
+the more suspicious Starkey said, “If she is a mother, perhaps she is
+hanging about here to help Peter.”
+
+Hook winced. “Ay,” he said, “that is the fear that haunts me.”
+
+He was roused from this dejection by Smee’s eager voice.
+
+“Captain,” said Smee, “could we not kidnap these boys’ mother and make
+her our mother?”
+
+“It is a princely scheme,” cried Hook, and at once it took practical
+shape in his great brain. “We will seize the children and carry them to
+the boat: the boys we will make walk the plank, and Wendy shall be our
+mother.”
+
+Again Wendy forgot herself.
+
+“Never!” she cried, and bobbed.
+
+“What was that?”
+
+But they could see nothing. They thought it must have been a leaf in the
+wind. “Do you agree, my bullies?” asked Hook.
+
+“There is my hand on it,” they both said.
+
+“And there is my hook. Swear.”
+
+They all swore. By this time they were on the rock, and suddenly Hook
+remembered Tiger Lily.
+
+“Where is the redskin?” he demanded abruptly.
+
+He had a playful humour at moments, and they thought this was one of the
+moments.
+
+“That is all right, captain,” Smee answered complacently; “we let her
+go.”
+
+“Let her go!” cried Hook.
+
+“‘Twas your own orders,” the bo’sun faltered.
+
+“You called over the water to us to let her go,” said Starkey.
+
+“Brimstone and gall,” thundered Hook, “what cozening [cheating] is
+going on here!” His face had gone black with rage, but he saw that they
+believed their words, and he was startled. “Lads,” he said, shaking a
+little, “I gave no such order.”
+
+“It is passing queer,” Smee said, and they all fidgeted uncomfortably.
+Hook raised his voice, but there was a quiver in it.
+
+“Spirit that haunts this dark lagoon to-night,” he cried, “dost hear
+me?”
+
+Of course Peter should have kept quiet, but of course he did not. He
+immediately answered in Hook’s voice:
+
+“Odds, bobs, hammer and tongs, I hear you.”
+
+In that supreme moment Hook did not blanch, even at the gills, but Smee
+and Starkey clung to each other in terror.
+
+“Who are you, stranger? Speak!” Hook demanded.
+
+“I am James Hook,” replied the voice, “captain of the JOLLY ROGER.”
+
+“You are not; you are not,” Hook cried hoarsely.
+
+“Brimstone and gall,” the voice retorted, “say that again, and I’ll cast
+anchor in you.”
+
+Hook tried a more ingratiating manner. “If you are Hook,” he said almost
+humbly, “come tell me, who am I?”
+
+“A codfish,” replied the voice, “only a codfish.”
+
+“A codfish!” Hook echoed blankly, and it was then, but not till then,
+that his proud spirit broke. He saw his men draw back from him.
+
+“Have we been captained all this time by a codfish!” they muttered. “It
+is lowering to our pride.”
+
+They were his dogs snapping at him, but, tragic figure though he had
+become, he scarcely heeded them. Against such fearful evidence it was
+not their belief in him that he needed, it was his own. He felt his ego
+slipping from him. “Don’t desert me, bully,” he whispered hoarsely to
+it.
+
+In his dark nature there was a touch of the feminine, as in all the
+great pirates, and it sometimes gave him intuitions. Suddenly he tried
+the guessing game.
+
+“Hook,” he called, “have you another voice?”
+
+Now Peter could never resist a game, and he answered blithely in his own
+voice, “I have.”
+
+“And another name?”
+
+“Ay, ay.”
+
+“Vegetable?” asked Hook.
+
+“No.”
+
+“Mineral?”
+
+“No.”
+
+“Animal?”
+
+“Yes.”
+
+“Man?”
+
+“No!” This answer rang out scornfully.
+
+“Boy?”
+
+“Yes.”
+
+“Ordinary boy?”
+
+“No!”
+
+“Wonderful boy?”
+
+To Wendy’s pain the answer that rang out this time was “Yes.”
+
+“Are you in England?”
+
+“No.”
+
+“Are you here?”
+
+“Yes.”
+
+Hook was completely puzzled. “You ask him some questions,” he said to
+the others, wiping his damp brow.
+
+Smee reflected. “I can’t think of a thing,” he said regretfully.
+
+“Can’t guess, can’t guess!” crowed Peter. “Do you give it up?”
+
+Of course in his pride he was carrying the game too far, and the
+miscreants [villains] saw their chance.
+
+“Yes, yes,” they answered eagerly.
+
+“Well, then,” he cried, “I am Peter Pan.”
+
+Pan!
+
+In a moment Hook was himself again, and Smee and Starkey were his
+faithful henchmen.
+
+“Now we have him,” Hook shouted. “Into the water, Smee. Starkey, mind
+the boat. Take him dead or alive!”
+
+He leaped as he spoke, and simultaneously came the gay voice of Peter.
+
+“Are you ready, boys?”
+
+“Ay, ay,” from various parts of the lagoon.
+
+“Then lam into the pirates.”
+
+The fight was short and sharp. First to draw blood was John, who
+gallantly climbed into the boat and held Starkey. There was fierce
+struggle, in which the cutlass was torn from the pirate’s grasp. He
+wriggled overboard and John leapt after him. The dinghy drifted away.
+
+Here and there a head bobbed up in the water, and there was a flash
+of steel followed by a cry or a whoop. In the confusion some struck at
+their own side. The corkscrew of Smee got Tootles in the fourth rib, but
+he was himself pinked [nicked] in turn by Curly. Farther from the rock
+Starkey was pressing Slightly and the twins hard.
+
+Where all this time was Peter? He was seeking bigger game.
+
+The others were all brave boys, and they must not be blamed for backing
+from the pirate captain. His iron claw made a circle of dead water round
+him, from which they fled like affrighted fishes.
+
+But there was one who did not fear him: there was one prepared to enter
+that circle.
+
+Strangely, it was not in the water that they met. Hook rose to the rock
+to breathe, and at the same moment Peter scaled it on the opposite
+side. The rock was slippery as a ball, and they had to crawl rather than
+climb. Neither knew that the other was coming. Each feeling for a grip
+met the other’s arm: in surprise they raised their heads; their faces
+were almost touching; so they met.
+
+Some of the greatest heroes have confessed that just before they fell to
+[began combat] they had a sinking [feeling in the stomach]. Had it been
+so with Peter at that moment I would admit it. After all, he was the
+only man that the Sea-Cook had feared. But Peter had no sinking, he had
+one feeling only, gladness; and he gnashed his pretty teeth with joy.
+Quick as thought he snatched a knife from Hook’s belt and was about to
+drive it home, when he saw that he was higher up the rock than his foe.
+It would not have been fighting fair. He gave the pirate a hand to help
+him up.
+
+It was then that Hook bit him.
+
+Not the pain of this but its unfairness was what dazed Peter. It made
+him quite helpless. He could only stare, horrified. Every child is
+affected thus the first time he is treated unfairly. All he thinks he
+has a right to when he comes to you to be yours is fairness. After
+you have been unfair to him he will love you again, but will never
+afterwards be quite the same boy. No one ever gets over the first
+unfairness; no one except Peter. He often met it, but he always forgot
+it. I suppose that was the real difference between him and all the rest.
+
+So when he met it now it was like the first time; and he could just
+stare, helpless. Twice the iron hand clawed him.
+
+A few moments afterwards the other boys saw Hook in the water striking
+wildly for the ship; no elation on the pestilent face now, only white
+fear, for the crocodile was in dogged pursuit of him. On ordinary
+occasions the boys would have swum alongside cheering; but now they were
+uneasy, for they had lost both Peter and Wendy, and were scouring the
+lagoon for them, calling them by name. They found the dinghy and went
+home in it, shouting “Peter, Wendy” as they went, but no answer came
+save mocking laughter from the mermaids. “They must be swimming back or
+flying,” the boys concluded. They were not very anxious, because they
+had such faith in Peter. They chuckled, boylike, because they would be
+late for bed; and it was all mother Wendy’s fault!
+
+When their voices died away there came cold silence over the lagoon, and
+then a feeble cry.
+
+“Help, help!”
+
+Two small figures were beating against the rock; the girl had fainted
+and lay on the boy’s arm. With a last effort Peter pulled her up the
+rock and then lay down beside her. Even as he also fainted he saw that
+the water was rising. He knew that they would soon be drowned, but he
+could do no more.
+
+As they lay side by side a mermaid caught Wendy by the feet, and began
+pulling her softly into the water. Peter, feeling her slip from him,
+woke with a start, and was just in time to draw her back. But he had to
+tell her the truth.
+
+“We are on the rock, Wendy,” he said, “but it is growing smaller. Soon
+the water will be over it.”
+
+She did not understand even now.
+
+“We must go,” she said, almost brightly.
+
+“Yes,” he answered faintly.
+
+“Shall we swim or fly, Peter?”
+
+He had to tell her.
+
+“Do you think you could swim or fly as far as the island, Wendy, without
+my help?”
+
+She had to admit that she was too tired.
+
+He moaned.
+
+“What is it?” she asked, anxious about him at once.
+
+“I can’t help you, Wendy. Hook wounded me. I can neither fly nor swim.”
+
+“Do you mean we shall both be drowned?”
+
+“Look how the water is rising.”
+
+They put their hands over their eyes to shut out the sight. They thought
+they would soon be no more. As they sat thus something brushed against
+Peter as light as a kiss, and stayed there, as if saying timidly, “Can I
+be of any use?”
+
+It was the tail of a kite, which Michael had made some days before. It
+had torn itself out of his hand and floated away.
+
+“Michael’s kite,” Peter said without interest, but next moment he had
+seized the tail, and was pulling the kite toward him.
+
+“It lifted Michael off the ground,” he cried; “why should it not carry
+you?”
+
+“Both of us!”
+
+“It can’t lift two; Michael and Curly tried.”
+
+“Let us draw lots,” Wendy said bravely.
+
+“And you a lady; never.” Already he had tied the tail round her. She
+clung to him; she refused to go without him; but with a “Good-bye,
+Wendy,” he pushed her from the rock; and in a few minutes she was borne
+out of his sight. Peter was alone on the lagoon.
+
+The rock was very small now; soon it would be submerged. Pale rays of
+light tiptoed across the waters; and by and by there was to be heard a
+sound at once the most musical and the most melancholy in the world: the
+mermaids calling to the moon.
+
+Peter was not quite like other boys; but he was afraid at last. A
+tremour ran through him, like a shudder passing over the sea; but on
+the sea one shudder follows another till there are hundreds of them, and
+Peter felt just the one. Next moment he was standing erect on the rock
+again, with that smile on his face and a drum beating within him. It was
+saying, “To die will be an awfully big adventure.”
+
+
+
+
+Chapter 9 THE NEVER BIRD
+
+The last sound Peter heard before he was quite alone were the mermaids
+retiring one by one to their bedchambers under the sea. He was too far
+away to hear their doors shut; but every door in the coral caves where
+they live rings a tiny bell when it opens or closes (as in all the
+nicest houses on the mainland), and he heard the bells.
+
+Steadily the waters rose till they were nibbling at his feet; and to
+pass the time until they made their final gulp, he watched the only
+thing on the lagoon. He thought it was a piece of floating paper,
+perhaps part of the kite, and wondered idly how long it would take to
+drift ashore.
+
+Presently he noticed as an odd thing that it was undoubtedly out upon
+the lagoon with some definite purpose, for it was fighting the tide,
+and sometimes winning; and when it won, Peter, always sympathetic to
+the weaker side, could not help clapping; it was such a gallant piece of
+paper.
+
+It was not really a piece of paper; it was the Never bird, making
+desperate efforts to reach Peter on the nest. By working her wings, in a
+way she had learned since the nest fell into the water, she was able to
+some extent to guide her strange craft, but by the time Peter recognised
+her she was very exhausted. She had come to save him, to give him her
+nest, though there were eggs in it. I rather wonder at the bird, for
+though he had been nice to her, he had also sometimes tormented her. I
+can suppose only that, like Mrs. Darling and the rest of them, she was
+melted because he had all his first teeth.
+
+She called out to him what she had come for, and he called out to her
+what she was doing there; but of course neither of them understood
+the other’s language. In fanciful stories people can talk to the birds
+freely, and I wish for the moment I could pretend that this were such a
+story, and say that Peter replied intelligently to the Never bird; but
+truth is best, and I want to tell you only what really happened. Well,
+not only could they not understand each other, but they forgot their
+manners.
+
+“I--want--you--to--get--into--the--nest,” the bird called, speaking as
+slowly and distinctly as possible, “and--then--you--can--drift--ashore,
+but--I--am--too--tired--to--bring--it--any--nearer--so--you--must--try
+to--swim--to--it.”
+
+“What are you quacking about?” Peter answered. “Why don’t you let the
+nest drift as usual?”
+
+“I--want--you--” the bird said, and repeated it all over.
+
+Then Peter tried slow and distinct.
+
+“What--are--you--quacking--about?” and so on.
+
+The Never bird became irritated; they have very short tempers.
+
+“You dunderheaded little jay!” she screamed, “Why don’t you do as I tell
+you?”
+
+Peter felt that she was calling him names, and at a venture he retorted
+hotly:
+
+“So are you!”
+
+Then rather curiously they both snapped out the same remark:
+
+“Shut up!”
+
+“Shut up!”
+
+Nevertheless the bird was determined to save him if she could, and by
+one last mighty effort she propelled the nest against the rock. Then up
+she flew; deserting her eggs, so as to make her meaning clear.
+
+Then at last he understood, and clutched the nest and waved his thanks
+to the bird as she fluttered overhead. It was not to receive his thanks,
+however, that she hung there in the sky; it was not even to watch him
+get into the nest; it was to see what he did with her eggs.
+
+There were two large white eggs, and Peter lifted them up and reflected.
+The bird covered her face with her wings, so as not to see the last of
+them; but she could not help peeping between the feathers.
+
+I forget whether I have told you that there was a stave on the rock,
+driven into it by some buccaneers of long ago to mark the site of buried
+treasure. The children had discovered the glittering hoard, and when in
+a mischievous mood used to fling showers of moidores, diamonds, pearls
+and pieces of eight to the gulls, who pounced upon them for food, and
+then flew away, raging at the scurvy trick that had been played upon
+them. The stave was still there, and on it Starkey had hung his hat, a
+deep tarpaulin, watertight, with a broad brim. Peter put the eggs into
+this hat and set it on the lagoon. It floated beautifully.
+
+The Never bird saw at once what he was up to, and screamed her
+admiration of him; and, alas, Peter crowed his agreement with her. Then
+he got into the nest, reared the stave in it as a mast, and hung up his
+shirt for a sail. At the same moment the bird fluttered down upon the
+hat and once more sat snugly on her eggs. She drifted in one direction,
+and he was borne off in another, both cheering.
+
+Of course when Peter landed he beached his barque [small ship, actually
+the Never Bird’s nest in this particular case in point] in a place where
+the bird would easily find it; but the hat was such a great success that
+she abandoned the nest. It drifted about till it went to pieces, and
+often Starkey came to the shore of the lagoon, and with many bitter
+feelings watched the bird sitting on his hat. As we shall not see her
+again, it may be worth mentioning here that all Never birds now build
+in that shape of nest, with a broad brim on which the youngsters take an
+airing.
+
+Great were the rejoicings when Peter reached the home under the ground
+almost as soon as Wendy, who had been carried hither and thither by
+the kite. Every boy had adventures to tell; but perhaps the biggest
+adventure of all was that they were several hours late for bed. This so
+inflated them that they did various dodgy things to get staying up still
+longer, such as demanding bandages; but Wendy, though glorying in having
+them all home again safe and sound, was scandalised by the lateness of
+the hour, and cried, “To bed, to bed,” in a voice that had to be obeyed.
+Next day, however, she was awfully tender, and gave out bandages to
+every one, and they played till bed-time at limping about and carrying
+their arms in slings.
+
+
+
+
+Chapter 10 THE HAPPY HOME
+
+One important result of the brush [with the pirates] on the lagoon was
+that it made the redskins their friends. Peter had saved Tiger Lily from
+a dreadful fate, and now there was nothing she and her braves would not
+do for him. All night they sat above, keeping watch over the home under
+the ground and awaiting the big attack by the pirates which obviously
+could not be much longer delayed. Even by day they hung about, smoking
+the pipe of peace, and looking almost as if they wanted tit-bits to eat.
+
+They called Peter the Great White Father, prostrating themselves [lying
+down] before him; and he liked this tremendously, so that it was not
+really good for him.
+
+“The great white father,” he would say to them in a very lordly manner,
+as they grovelled at his feet, “is glad to see the Piccaninny warriors
+protecting his wigwam from the pirates.”
+
+“Me Tiger Lily,” that lovely creature would reply. “Peter Pan save me,
+me his velly nice friend. Me no let pirates hurt him.”
+
+She was far too pretty to cringe in this way, but Peter thought it his
+due, and he would answer condescendingly, “It is good. Peter Pan has
+spoken.”
+
+Always when he said, “Peter Pan has spoken,” it meant that they must now
+shut up, and they accepted it humbly in that spirit; but they were by
+no means so respectful to the other boys, whom they looked upon as just
+ordinary braves. They said “How-do?” to them, and things like that; and
+what annoyed the boys was that Peter seemed to think this all right.
+
+Secretly Wendy sympathised with them a little, but she was far too loyal
+a housewife to listen to any complaints against father. “Father knows
+best,” she always said, whatever her private opinion must be. Her
+private opinion was that the redskins should not call her a squaw.
+
+We have now reached the evening that was to be known among them as the
+Night of Nights, because of its adventures and their upshot. The day, as
+if quietly gathering its forces, had been almost uneventful, and now the
+redskins in their blankets were at their posts above, while, below, the
+children were having their evening meal; all except Peter, who had gone
+out to get the time. The way you got the time on the island was to find
+the crocodile, and then stay near him till the clock struck.
+
+The meal happened to be a make-believe tea, and they sat around the
+board, guzzling in their greed; and really, what with their chatter and
+recriminations, the noise, as Wendy said, was positively deafening.
+To be sure, she did not mind noise, but she simply would not have them
+grabbing things, and then excusing themselves by saying that Tootles had
+pushed their elbow. There was a fixed rule that they must never hit back
+at meals, but should refer the matter of dispute to Wendy by raising
+the right arm politely and saying, “I complain of so-and-so;” but what
+usually happened was that they forgot to do this or did it too much.
+
+“Silence,” cried Wendy when for the twentieth time she had told them
+that they were not all to speak at once. “Is your mug empty, Slightly
+darling?”
+
+“Not quite empty, mummy,” Slightly said, after looking into an imaginary
+mug.
+
+“He hasn’t even begun to drink his milk,” Nibs interposed.
+
+This was telling, and Slightly seized his chance.
+
+“I complain of Nibs,” he cried promptly.
+
+John, however, had held up his hand first.
+
+“Well, John?”
+
+“May I sit in Peter’s chair, as he is not here?”
+
+“Sit in father’s chair, John!” Wendy was scandalised. “Certainly not.”
+
+“He is not really our father,” John answered. “He didn’t even know how a
+father does till I showed him.”
+
+This was grumbling. “We complain of John,” cried the twins.
+
+Tootles held up his hand. He was so much the humblest of them, indeed he
+was the only humble one, that Wendy was specially gentle with him.
+
+“I don’t suppose,” Tootles said diffidently [bashfully or timidly],
+“that I could be father.”
+
+“No, Tootles.”
+
+Once Tootles began, which was not very often, he had a silly way of
+going on.
+
+“As I can’t be father,” he said heavily, “I don’t suppose, Michael, you
+would let me be baby?”
+
+“No, I won’t,” Michael rapped out. He was already in his basket.
+
+“As I can’t be baby,” Tootles said, getting heavier and heavier and
+heavier, “do you think I could be a twin?”
+
+“No, indeed,” replied the twins; “it’s awfully difficult to be a twin.”
+
+“As I can’t be anything important,” said Tootles, “would any of you like
+to see me do a trick?”
+
+“No,” they all replied.
+
+Then at last he stopped. “I hadn’t really any hope,” he said.
+
+The hateful telling broke out again.
+
+“Slightly is coughing on the table.”
+
+“The twins began with cheese-cakes.”
+
+“Curly is taking both butter and honey.”
+
+“Nibs is speaking with his mouth full.”
+
+“I complain of the twins.”
+
+“I complain of Curly.”
+
+“I complain of Nibs.”
+
+“Oh dear, oh dear,” cried Wendy, “I’m sure I sometimes think that
+spinsters are to be envied.”
+
+She told them to clear away, and sat down to her work-basket, a heavy
+load of stockings and every knee with a hole in it as usual.
+
+“Wendy,” remonstrated [scolded] Michael, “I’m too big for a cradle.”
+
+“I must have somebody in a cradle,” she said almost tartly, “and you
+are the littlest. A cradle is such a nice homely thing to have about a
+house.”
+
+While she sewed they played around her; such a group of happy faces
+and dancing limbs lit up by that romantic fire. It had become a very
+familiar scene, this, in the home under the ground, but we are looking
+on it for the last time.
+
+There was a step above, and Wendy, you may be sure, was the first to
+recognize it.
+
+“Children, I hear your father’s step. He likes you to meet him at the
+door.”
+
+Above, the redskins crouched before Peter.
+
+“Watch well, braves. I have spoken.”
+
+And then, as so often before, the gay children dragged him from his
+tree. As so often before, but never again.
+
+He had brought nuts for the boys as well as the correct time for Wendy.
+
+“Peter, you just spoil them, you know,” Wendy simpered [exaggerated a
+smile].
+
+“Ah, old lady,” said Peter, hanging up his gun.
+
+“It was me told him mothers are called old lady,” Michael whispered to
+Curly.
+
+“I complain of Michael,” said Curly instantly.
+
+The first twin came to Peter. “Father, we want to dance.”
+
+“Dance away, my little man,” said Peter, who was in high good humour.
+
+“But we want you to dance.”
+
+Peter was really the best dancer among them, but he pretended to be
+scandalised.
+
+“Me! My old bones would rattle!”
+
+“And mummy too.”
+
+“What,” cried Wendy, “the mother of such an armful, dance!”
+
+“But on a Saturday night,” Slightly insinuated.
+
+It was not really Saturday night, at least it may have been, for
+they had long lost count of the days; but always if they wanted to do
+anything special they said this was Saturday night, and then they did
+it.
+
+“Of course it is Saturday night, Peter,” Wendy said, relenting.
+
+“People of our figure, Wendy!”
+
+“But it is only among our own progeny [children].”
+
+“True, true.”
+
+So they were told they could dance, but they must put on their nighties
+first.
+
+“Ah, old lady,” Peter said aside to Wendy, warming himself by the fire
+and looking down at her as she sat turning a heel, “there is nothing
+more pleasant of an evening for you and me when the day’s toil is over
+than to rest by the fire with the little ones near by.”
+
+“It is sweet, Peter, isn’t it?” Wendy said, frightfully gratified.
+“Peter, I think Curly has your nose.”
+
+“Michael takes after you.”
+
+She went to him and put her hand on his shoulder.
+
+“Dear Peter,” she said, “with such a large family, of course, I have now
+passed my best, but you don’t want to [ex]change me, do you?”
+
+“No, Wendy.”
+
+Certainly he did not want a change, but he looked at her uncomfortably,
+blinking, you know, like one not sure whether he was awake or asleep.
+
+“Peter, what is it?”
+
+“I was just thinking,” he said, a little scared. “It is only
+make-believe, isn’t it, that I am their father?”
+
+“Oh yes,” Wendy said primly [formally and properly].
+
+“You see,” he continued apologetically, “it would make me seem so old to
+be their real father.”
+
+“But they are ours, Peter, yours and mine.”
+
+“But not really, Wendy?” he asked anxiously.
+
+“Not if you don’t wish it,” she replied; and she distinctly heard his
+sigh of relief. “Peter,” she asked, trying to speak firmly, “what are
+your exact feelings to [about] me?”
+
+“Those of a devoted son, Wendy.”
+
+“I thought so,” she said, and went and sat by herself at the extreme end
+of the room.
+
+“You are so queer,” he said, frankly puzzled, “and Tiger Lily is just
+the same. There is something she wants to be to me, but she says it is
+not my mother.”
+
+“No, indeed, it is not,” Wendy replied with frightful emphasis. Now we
+know why she was prejudiced against the redskins.
+
+“Then what is it?”
+
+“It isn’t for a lady to tell.”
+
+“Oh, very well,” Peter said, a little nettled. “Perhaps Tinker Bell will
+tell me.”
+
+“Oh yes, Tinker Bell will tell you,” Wendy retorted scornfully. “She is
+an abandoned little creature.”
+
+Here Tink, who was in her bedroom, eavesdropping, squeaked out something
+impudent.
+
+“She says she glories in being abandoned,” Peter interpreted.
+
+He had a sudden idea. “Perhaps Tink wants to be my mother?”
+
+“You silly ass!” cried Tinker Bell in a passion.
+
+She had said it so often that Wendy needed no translation.
+
+“I almost agree with her,” Wendy snapped. Fancy Wendy snapping! But she
+had been much tried, and she little knew what was to happen before the
+night was out. If she had known she would not have snapped.
+
+None of them knew. Perhaps it was best not to know. Their ignorance
+gave them one more glad hour; and as it was to be their last hour on the
+island, let us rejoice that there were sixty glad minutes in it. They
+sang and danced in their night-gowns. Such a deliciously creepy song
+it was, in which they pretended to be frightened at their own shadows,
+little witting that so soon shadows would close in upon them, from whom
+they would shrink in real fear. So uproariously gay was the dance, and
+how they buffeted each other on the bed and out of it! It was a pillow
+fight rather than a dance, and when it was finished, the pillows
+insisted on one bout more, like partners who know that they may never
+meet again. The stories they told, before it was time for Wendy’s
+good-night story! Even Slightly tried to tell a story that night, but
+the beginning was so fearfully dull that it appalled not only the others
+but himself, and he said happily:
+
+“Yes, it is a dull beginning. I say, let us pretend that it is the end.”
+
+And then at last they all got into bed for Wendy’s story, the story they
+loved best, the story Peter hated. Usually when she began to tell this
+story he left the room or put his hands over his ears; and possibly if
+he had done either of those things this time they might all still be on
+the island. But to-night he remained on his stool; and we shall see what
+happened.
+
+
+
+
+Chapter 11 WENDY’S STORY
+
+“Listen, then,” said Wendy, settling down to her story, with Michael at
+her feet and seven boys in the bed. “There was once a gentleman--”
+
+“I had rather he had been a lady,” Curly said.
+
+“I wish he had been a white rat,” said Nibs.
+
+“Quiet,” their mother admonished [cautioned] them. “There was a lady
+also, and--”
+
+“Oh, mummy,” cried the first twin, “you mean that there is a lady also,
+don’t you? She is not dead, is she?”
+
+“Oh, no.”
+
+“I am awfully glad she isn’t dead,” said Tootles. “Are you glad, John?”
+
+“Of course I am.”
+
+“Are you glad, Nibs?”
+
+“Rather.”
+
+“Are you glad, Twins?”
+
+“We are glad.”
+
+“Oh dear,” sighed Wendy.
+
+“Little less noise there,” Peter called out, determined that she should
+have fair play, however beastly a story it might be in his opinion.
+
+“The gentleman’s name,” Wendy continued, “was Mr. Darling, and her name
+was Mrs. Darling.”
+
+“I knew them,” John said, to annoy the others.
+
+“I think I knew them,” said Michael rather doubtfully.
+
+“They were married, you know,” explained Wendy, “and what do you think
+they had?”
+
+“White rats,” cried Nibs, inspired.
+
+“No.”
+
+“It’s awfully puzzling,” said Tootles, who knew the story by heart.
+
+“Quiet, Tootles. They had three descendants.”
+
+“What is descendants?”
+
+“Well, you are one, Twin.”
+
+“Did you hear that, John? I am a descendant.”
+
+“Descendants are only children,” said John.
+
+“Oh dear, oh dear,” sighed Wendy. “Now these three children had a
+faithful nurse called Nana; but Mr. Darling was angry with her and
+chained her up in the yard, and so all the children flew away.”
+
+“It’s an awfully good story,” said Nibs.
+
+“They flew away,” Wendy continued, “to the Neverland, where the lost
+children are.”
+
+“I just thought they did,” Curly broke in excitedly. “I don’t know how
+it is, but I just thought they did!”
+
+“O Wendy,” cried Tootles, “was one of the lost children called Tootles?”
+
+“Yes, he was.”
+
+“I am in a story. Hurrah, I am in a story, Nibs.”
+
+“Hush. Now I want you to consider the feelings of the unhappy parents
+with all their children flown away.”
+
+“Oo!” they all moaned, though they were not really considering the
+feelings of the unhappy parents one jot.
+
+“Think of the empty beds!”
+
+“Oo!”
+
+“It’s awfully sad,” the first twin said cheerfully.
+
+“I don’t see how it can have a happy ending,” said the second twin. “Do
+you, Nibs?”
+
+“I’m frightfully anxious.”
+
+“If you knew how great is a mother’s love,” Wendy told them
+triumphantly, “you would have no fear.” She had now come to the part
+that Peter hated.
+
+“I do like a mother’s love,” said Tootles, hitting Nibs with a pillow.
+“Do you like a mother’s love, Nibs?”
+
+“I do just,” said Nibs, hitting back.
+
+“You see,” Wendy said complacently, “our heroine knew that the mother
+would always leave the window open for her children to fly back by; so
+they stayed away for years and had a lovely time.”
+
+“Did they ever go back?”
+
+“Let us now,” said Wendy, bracing herself up for her finest effort,
+“take a peep into the future;” and they all gave themselves the twist
+that makes peeps into the future easier. “Years have rolled by, and who
+is this elegant lady of uncertain age alighting at London Station?”
+
+“O Wendy, who is she?” cried Nibs, every bit as excited as if he didn’t
+know.
+
+“Can it be--yes--no--it is--the fair Wendy!”
+
+“Oh!”
+
+“And who are the two noble portly figures accompanying her, now grown to
+man’s estate? Can they be John and Michael? They are!”
+
+“Oh!”
+
+“‘See, dear brothers,’ says Wendy pointing upwards, ‘there is the window
+still standing open. Ah, now we are rewarded for our sublime faith in a
+mother’s love.’ So up they flew to their mummy and daddy, and pen cannot
+describe the happy scene, over which we draw a veil.”
+
+That was the story, and they were as pleased with it as the fair
+narrator herself. Everything just as it should be, you see. Off we skip
+like the most heartless things in the world, which is what children are,
+but so attractive; and we have an entirely selfish time, and then when
+we have need of special attention we nobly return for it, confident that
+we shall be rewarded instead of smacked.
+
+So great indeed was their faith in a mother’s love that they felt they
+could afford to be callous for a bit longer.
+
+But there was one there who knew better, and when Wendy finished he
+uttered a hollow groan.
+
+“What is it, Peter?” she cried, running to him, thinking he was ill. She
+felt him solicitously, lower down than his chest. “Where is it, Peter?”
+
+“It isn’t that kind of pain,” Peter replied darkly.
+
+“Then what kind is it?”
+
+“Wendy, you are wrong about mothers.”
+
+They all gathered round him in affright, so alarming was his agitation;
+and with a fine candour he told them what he had hitherto concealed.
+
+“Long ago,” he said, “I thought like you that my mother would always
+keep the window open for me, so I stayed away for moons and moons and
+moons, and then flew back; but the window was barred, for mother had
+forgotten all about me, and there was another little boy sleeping in my
+bed.”
+
+I am not sure that this was true, but Peter thought it was true; and it
+scared them.
+
+“Are you sure mothers are like that?”
+
+“Yes.”
+
+So this was the truth about mothers. The toads!
+
+Still it is best to be careful; and no one knows so quickly as a child
+when he should give in. “Wendy, let us [let’s] go home,” cried John and
+Michael together.
+
+“Yes,” she said, clutching them.
+
+“Not to-night?” asked the lost boys bewildered. They knew in what they
+called their hearts that one can get on quite well without a mother, and
+that it is only the mothers who think you can’t.
+
+“At once,” Wendy replied resolutely, for the horrible thought had come
+to her: “Perhaps mother is in half mourning by this time.”
+
+This dread made her forgetful of what must be Peter’s feelings, and
+she said to him rather sharply, “Peter, will you make the necessary
+arrangements?”
+
+“If you wish it,” he replied, as coolly as if she had asked him to pass
+the nuts.
+
+Not so much as a sorry-to-lose-you between them! If she did not mind the
+parting, he was going to show her, was Peter, that neither did he.
+
+But of course he cared very much; and he was so full of wrath against
+grown-ups, who, as usual, were spoiling everything, that as soon as he
+got inside his tree he breathed intentionally quick short breaths at the
+rate of about five to a second. He did this because there is a saying in
+the Neverland that, every time you breathe, a grown-up dies; and Peter
+was killing them off vindictively as fast as possible.
+
+Then having given the necessary instructions to the redskins he returned
+to the home, where an unworthy scene had been enacted in his absence.
+Panic-stricken at the thought of losing Wendy the lost boys had advanced
+upon her threateningly.
+
+“It will be worse than before she came,” they cried.
+
+“We shan’t let her go.”
+
+“Let’s keep her prisoner.”
+
+“Ay, chain her up.”
+
+In her extremity an instinct told her to which of them to turn.
+
+“Tootles,” she cried, “I appeal to you.”
+
+Was it not strange? She appealed to Tootles, quite the silliest one.
+
+Grandly, however, did Tootles respond. For that one moment he dropped
+his silliness and spoke with dignity.
+
+“I am just Tootles,” he said, “and nobody minds me. But the first who
+does not behave to Wendy like an English gentleman I will blood him
+severely.”
+
+He drew back his hanger; and for that instant his sun was at noon. The
+others held back uneasily. Then Peter returned, and they saw at once
+that they would get no support from him. He would keep no girl in the
+Neverland against her will.
+
+“Wendy,” he said, striding up and down, “I have asked the redskins to
+guide you through the wood, as flying tires you so.”
+
+“Thank you, Peter.”
+
+“Then,” he continued, in the short sharp voice of one accustomed to be
+obeyed, “Tinker Bell will take you across the sea. Wake her, Nibs.”
+
+Nibs had to knock twice before he got an answer, though Tink had really
+been sitting up in bed listening for some time.
+
+“Who are you? How dare you? Go away,” she cried.
+
+“You are to get up, Tink,” Nibs called, “and take Wendy on a journey.”
+
+Of course Tink had been delighted to hear that Wendy was going; but
+she was jolly well determined not to be her courier, and she said so in
+still more offensive language. Then she pretended to be asleep again.
+
+“She says she won’t!” Nibs exclaimed, aghast at such insubordination,
+whereupon Peter went sternly toward the young lady’s chamber.
+
+“Tink,” he rapped out, “if you don’t get up and dress at once I will
+open the curtains, and then we shall all see you in your negligee
+[nightgown].”
+
+This made her leap to the floor. “Who said I wasn’t getting up?” she
+cried.
+
+In the meantime the boys were gazing very forlornly at Wendy, now
+equipped with John and Michael for the journey. By this time they were
+dejected, not merely because they were about to lose her, but also
+because they felt that she was going off to something nice to which they
+had not been invited. Novelty was beckoning to them as usual.
+
+Crediting them with a nobler feeling Wendy melted.
+
+“Dear ones,” she said, “if you will all come with me I feel almost sure
+I can get my father and mother to adopt you.”
+
+The invitation was meant specially for Peter, but each of the boys was
+thinking exclusively of himself, and at once they jumped with joy.
+
+“But won’t they think us rather a handful?” Nibs asked in the middle of
+his jump.
+
+“Oh no,” said Wendy, rapidly thinking it out, “it will only mean having
+a few beds in the drawing-room; they can be hidden behind the screens on
+first Thursdays.”
+
+“Peter, can we go?” they all cried imploringly. They took it for granted
+that if they went he would go also, but really they scarcely cared. Thus
+children are ever ready, when novelty knocks, to desert their dearest
+ones.
+
+“All right,” Peter replied with a bitter smile, and immediately they
+rushed to get their things.
+
+“And now, Peter,” Wendy said, thinking she had put everything right,
+“I am going to give you your medicine before you go.” She loved to give
+them medicine, and undoubtedly gave them too much. Of course it was only
+water, but it was out of a bottle, and she always shook the bottle and
+counted the drops, which gave it a certain medicinal quality. On this
+occasion, however, she did not give Peter his draught [portion], for
+just as she had prepared it, she saw a look on his face that made her
+heart sink.
+
+“Get your things, Peter,” she cried, shaking.
+
+“No,” he answered, pretending indifference, “I am not going with you,
+Wendy.”
+
+“Yes, Peter.”
+
+“No.”
+
+To show that her departure would leave him unmoved, he skipped up and
+down the room, playing gaily on his heartless pipes. She had to run
+about after him, though it was rather undignified.
+
+“To find your mother,” she coaxed.
+
+Now, if Peter had ever quite had a mother, he no longer missed her. He
+could do very well without one. He had thought them out, and remembered
+only their bad points.
+
+“No, no,” he told Wendy decisively; “perhaps she would say I was old,
+and I just want always to be a little boy and to have fun.”
+
+“But, Peter--”
+
+“No.”
+
+And so the others had to be told.
+
+“Peter isn’t coming.”
+
+Peter not coming! They gazed blankly at him, their sticks over their
+backs, and on each stick a bundle. Their first thought was that if Peter
+was not going he had probably changed his mind about letting them go.
+
+But he was far too proud for that. “If you find your mothers,” he said
+darkly, “I hope you will like them.”
+
+The awful cynicism of this made an uncomfortable impression, and most
+of them began to look rather doubtful. After all, their faces said, were
+they not noodles to want to go?
+
+“Now then,” cried Peter, “no fuss, no blubbering; good-bye, Wendy;” and
+he held out his hand cheerily, quite as if they must really go now, for
+he had something important to do.
+
+She had to take his hand, and there was no indication that he would
+prefer a thimble.
+
+“You will remember about changing your flannels, Peter?” she said,
+lingering over him. She was always so particular about their flannels.
+
+“Yes.”
+
+“And you will take your medicine?”
+
+“Yes.”
+
+That seemed to be everything, and an awkward pause followed. Peter,
+however, was not the kind that breaks down before other people. “Are you
+ready, Tinker Bell?” he called out.
+
+“Ay, ay.”
+
+“Then lead the way.”
+
+Tink darted up the nearest tree; but no one followed her, for it was
+at this moment that the pirates made their dreadful attack upon the
+redskins. Above, where all had been so still, the air was rent with
+shrieks and the clash of steel. Below, there was dead silence. Mouths
+opened and remained open. Wendy fell on her knees, but her arms were
+extended toward Peter. All arms were extended to him, as if suddenly
+blown in his direction; they were beseeching him mutely not to desert
+them. As for Peter, he seized his sword, the same he thought he had
+slain Barbecue with, and the lust of battle was in his eye.
+
+
+
+
+Chapter 12 THE CHILDREN ARE CARRIED OFF
+
+The pirate attack had been a complete surprise: a sure proof that the
+unscrupulous Hook had conducted it improperly, for to surprise redskins
+fairly is beyond the wit of the white man.
+
+By all the unwritten laws of savage warfare it is always the redskin who
+attacks, and with the wiliness of his race he does it just before the
+dawn, at which time he knows the courage of the whites to be at its
+lowest ebb. The white men have in the meantime made a rude stockade on
+the summit of yonder undulating ground, at the foot of which a stream
+runs, for it is destruction to be too far from water. There they await
+the onslaught, the inexperienced ones clutching their revolvers and
+treading on twigs, but the old hands sleeping tranquilly until just
+before the dawn. Through the long black night the savage scouts wriggle,
+snake-like, among the grass without stirring a blade. The brushwood
+closes behind them, as silently as sand into which a mole has dived.
+Not a sound is to be heard, save when they give vent to a wonderful
+imitation of the lonely call of the coyote. The cry is answered by other
+braves; and some of them do it even better than the coyotes, who are not
+very good at it. So the chill hours wear on, and the long suspense is
+horribly trying to the paleface who has to live through it for the first
+time; but to the trained hand those ghastly calls and still ghastlier
+silences are but an intimation of how the night is marching.
+
+That this was the usual procedure was so well known to Hook that in
+disregarding it he cannot be excused on the plea of ignorance.
+
+The Piccaninnies, on their part, trusted implicitly to his honour, and
+their whole action of the night stands out in marked contrast to his.
+They left nothing undone that was consistent with the reputation of
+their tribe. With that alertness of the senses which is at once the
+marvel and despair of civilised peoples, they knew that the pirates were
+on the island from the moment one of them trod on a dry stick; and in
+an incredibly short space of time the coyote cries began. Every foot of
+ground between the spot where Hook had landed his forces and the
+home under the trees was stealthily examined by braves wearing their
+mocassins with the heels in front. They found only one hillock with a
+stream at its base, so that Hook had no choice; here he must establish
+himself and wait for just before the dawn. Everything being thus mapped
+out with almost diabolical cunning, the main body of the redskins folded
+their blankets around them, and in the phlegmatic manner that is to
+them, the pearl of manhood squatted above the children’s home, awaiting
+the cold moment when they should deal pale death.
+
+Here dreaming, though wide-awake, of the exquisite tortures to which
+they were to put him at break of day, those confiding savages were found
+by the treacherous Hook. From the accounts afterwards supplied by such
+of the scouts as escaped the carnage, he does not seem even to have
+paused at the rising ground, though it is certain that in that grey
+light he must have seen it: no thought of waiting to be attacked appears
+from first to last to have visited his subtle mind; he would not even
+hold off till the night was nearly spent; on he pounded with no policy
+but to fall to [get into combat]. What could the bewildered scouts do,
+masters as they were of every war-like artifice save this one, but trot
+helplessly after him, exposing themselves fatally to view, while they
+gave pathetic utterance to the coyote cry.
+
+Around the brave Tiger Lily were a dozen of her stoutest warriors, and
+they suddenly saw the perfidious pirates bearing down upon them. Fell
+from their eyes then the film through which they had looked at
+victory. No more would they torture at the stake. For them the happy
+hunting-grounds was now. They knew it; but as their father’s sons they
+acquitted themselves. Even then they had time to gather in a phalanx
+[dense formation] that would have been hard to break had they risen
+quickly, but this they were forbidden to do by the traditions of their
+race. It is written that the noble savage must never express surprise in
+the presence of the white. Thus terrible as the sudden appearance of the
+pirates must have been to them, they remained stationary for a moment,
+not a muscle moving; as if the foe had come by invitation. Then, indeed,
+the tradition gallantly upheld, they seized their weapons, and the air
+was torn with the war-cry; but it was now too late.
+
+It is no part of ours to describe what was a massacre rather than a
+fight. Thus perished many of the flower of the Piccaninny tribe. Not all
+unavenged did they die, for with Lean Wolf fell Alf Mason, to disturb
+the Spanish Main no more, and among others who bit the dust were Geo.
+Scourie, Chas. Turley, and the Alsatian Foggerty. Turley fell to the
+tomahawk of the terrible Panther, who ultimately cut a way through the
+pirates with Tiger Lily and a small remnant of the tribe.
+
+To what extent Hook is to blame for his tactics on this occasion is for
+the historian to decide. Had he waited on the rising ground till the
+proper hour he and his men would probably have been butchered; and in
+judging him it is only fair to take this into account. What he should
+perhaps have done was to acquaint his opponents that he proposed to
+follow a new method. On the other hand, this, as destroying the element
+of surprise, would have made his strategy of no avail, so that the whole
+question is beset with difficulties. One cannot at least withhold a
+reluctant admiration for the wit that had conceived so bold a scheme,
+and the fell [deadly] genius with which it was carried out.
+
+What were his own feelings about himself at that triumphant moment?
+Fain [gladly] would his dogs have known, as breathing heavily and wiping
+their cutlasses, they gathered at a discreet distance from his hook, and
+squinted through their ferret eyes at this extraordinary man. Elation
+must have been in his heart, but his face did not reflect it: ever a
+dark and solitary enigma, he stood aloof from his followers in spirit as
+in substance.
+
+The night’s work was not yet over, for it was not the redskins he had
+come out to destroy; they were but the bees to be smoked, so that he
+should get at the honey. It was Pan he wanted, Pan and Wendy and their
+band, but chiefly Pan.
+
+Peter was such a small boy that one tends to wonder at the man’s hatred
+of him. True he had flung Hook’s arm to the crocodile, but even this
+and the increased insecurity of life to which it led, owing to
+the crocodile’s pertinacity [persistance], hardly account for a
+vindictiveness so relentless and malignant. The truth is that there was
+a something about Peter which goaded the pirate captain to frenzy. It
+was not his courage, it was not his engaging appearance, it was not--.
+There is no beating about the bush, for we know quite well what it was,
+and have got to tell. It was Peter’s cockiness.
+
+This had got on Hook’s nerves; it made his iron claw twitch, and at
+night it disturbed him like an insect. While Peter lived, the tortured
+man felt that he was a lion in a cage into which a sparrow had come.
+
+The question now was how to get down the trees, or how to get his dogs
+down? He ran his greedy eyes over them, searching for the thinnest
+ones. They wriggled uncomfortably, for they knew he would not scruple
+[hesitate] to ram them down with poles.
+
+In the meantime, what of the boys? We have seen them at the first clang
+of the weapons, turned as it were into stone figures, open-mouthed,
+all appealing with outstretched arms to Peter; and we return to them as
+their mouths close, and their arms fall to their sides. The pandemonium
+above has ceased almost as suddenly as it arose, passed like a fierce
+gust of wind; but they know that in the passing it has determined their
+fate.
+
+Which side had won?
+
+The pirates, listening avidly at the mouths of the trees, heard the
+question put by every boy, and alas, they also heard Peter’s answer.
+
+“If the redskins have won,” he said, “they will beat the tom-tom; it is
+always their sign of victory.”
+
+Now Smee had found the tom-tom, and was at that moment sitting on it.
+“You will never hear the tom-tom again,” he muttered, but inaudibly of
+course, for strict silence had been enjoined [urged]. To his amazement
+Hook signed him to beat the tom-tom, and slowly there came to Smee an
+understanding of the dreadful wickedness of the order. Never, probably,
+had this simple man admired Hook so much.
+
+Twice Smee beat upon the instrument, and then stopped to listen
+gleefully.
+
+“The tom-tom,” the miscreants heard Peter cry; “an Indian victory!”
+
+The doomed children answered with a cheer that was music to the black
+hearts above, and almost immediately they repeated their good-byes
+to Peter. This puzzled the pirates, but all their other feelings were
+swallowed by a base delight that the enemy were about to come up the
+trees. They smirked at each other and rubbed their hands. Rapidly and
+silently Hook gave his orders: one man to each tree, and the others to
+arrange themselves in a line two yards apart.
+
+
+
+
+Chapter 13 DO YOU BELIEVE IN FAIRIES?
+
+The more quickly this horror is disposed of the better. The first to
+emerge from his tree was Curly. He rose out of it into the arms of
+Cecco, who flung him to Smee, who flung him to Starkey, who flung him to
+Bill Jukes, who flung him to Noodler, and so he was tossed from one to
+another till he fell at the feet of the black pirate. All the boys were
+plucked from their trees in this ruthless manner; and several of them
+were in the air at a time, like bales of goods flung from hand to hand.
+
+A different treatment was accorded to Wendy, who came last. With
+ironical politeness Hook raised his hat to her, and, offering her his
+arm, escorted her to the spot where the others were being gagged. He
+did it with such an air, he was so frightfully DISTINGUE [imposingly
+distinguished], that she was too fascinated to cry out. She was only a
+little girl.
+
+Perhaps it is tell-tale to divulge that for a moment Hook entranced her,
+and we tell on her only because her slip led to strange results. Had she
+haughtily unhanded him (and we should have loved to write it of her),
+she would have been hurled through the air like the others, and then
+Hook would probably not have been present at the tying of the children;
+and had he not been at the tying he would not have discovered Slightly’s
+secret, and without the secret he could not presently have made his foul
+attempt on Peter’s life.
+
+They were tied to prevent their flying away, doubled up with their knees
+close to their ears; and for the trussing of them the black pirate had
+cut a rope into nine equal pieces. All went well until Slightly’s turn
+came, when he was found to be like those irritating parcels that use up
+all the string in going round and leave no tags [ends] with which to
+tie a knot. The pirates kicked him in their rage, just as you kick the
+parcel (though in fairness you should kick the string); and strange
+to say it was Hook who told them to belay their violence. His lip was
+curled with malicious triumph. While his dogs were merely sweating
+because every time they tried to pack the unhappy lad tight in one
+part he bulged out in another, Hook’s master mind had gone far beneath
+Slightly’s surface, probing not for effects but for causes; and his
+exultation showed that he had found them. Slightly, white to the gills,
+knew that Hook had surprised [discovered] his secret, which was this,
+that no boy so blown out could use a tree wherein an average man need
+stick. Poor Slightly, most wretched of all the children now, for he
+was in a panic about Peter, bitterly regretted what he had done. Madly
+addicted to the drinking of water when he was hot, he had swelled in
+consequence to his present girth, and instead of reducing himself to fit
+his tree he had, unknown to the others, whittled his tree to make it fit
+him.
+
+Sufficient of this Hook guessed to persuade him that Peter at last lay
+at his mercy, but no word of the dark design that now formed in the
+subterranean caverns of his mind crossed his lips; he merely signed
+that the captives were to be conveyed to the ship, and that he would be
+alone.
+
+How to convey them? Hunched up in their ropes they might indeed be
+rolled down hill like barrels, but most of the way lay through a morass.
+Again Hook’s genius surmounted difficulties. He indicated that the
+little house must be used as a conveyance. The children were flung into
+it, four stout pirates raised it on their shoulders, the others fell in
+behind, and singing the hateful pirate chorus the strange procession
+set off through the wood. I don’t know whether any of the children were
+crying; if so, the singing drowned the sound; but as the little house
+disappeared in the forest, a brave though tiny jet of smoke issued from
+its chimney as if defying Hook.
+
+Hook saw it, and it did Peter a bad service. It dried up any trickle of
+pity for him that may have remained in the pirate’s infuriated breast.
+
+The first thing he did on finding himself alone in the fast falling
+night was to tiptoe to Slightly’s tree, and make sure that it provided
+him with a passage. Then for long he remained brooding; his hat of ill
+omen on the sward, so that any gentle breeze which had arisen might play
+refreshingly through his hair. Dark as were his thoughts his blue eyes
+were as soft as the periwinkle. Intently he listened for any sound from
+the nether world, but all was as silent below as above; the house under
+the ground seemed to be but one more empty tenement in the void. Was
+that boy asleep, or did he stand waiting at the foot of Slightly’s tree,
+with his dagger in his hand?
+
+There was no way of knowing, save by going down. Hook let his cloak slip
+softly to the ground, and then biting his lips till a lewd blood stood
+on them, he stepped into the tree. He was a brave man, but for a moment
+he had to stop there and wipe his brow, which was dripping like a
+candle. Then, silently, he let himself go into the unknown.
+
+He arrived unmolested at the foot of the shaft, and stood still again,
+biting at his breath, which had almost left him. As his eyes became
+accustomed to the dim light various objects in the home under the trees
+took shape; but the only one on which his greedy gaze rested, long
+sought for and found at last, was the great bed. On the bed lay Peter
+fast asleep.
+
+Unaware of the tragedy being enacted above, Peter had continued, for
+a little time after the children left, to play gaily on his pipes: no
+doubt rather a forlorn attempt to prove to himself that he did not care.
+Then he decided not to take his medicine, so as to grieve Wendy. Then he
+lay down on the bed outside the coverlet, to vex her still more; for she
+had always tucked them inside it, because you never know that you may
+not grow chilly at the turn of the night. Then he nearly cried; but
+it struck him how indignant she would be if he laughed instead; so he
+laughed a haughty laugh and fell asleep in the middle of it.
+
+Sometimes, though not often, he had dreams, and they were more painful
+than the dreams of other boys. For hours he could not be separated from
+these dreams, though he wailed piteously in them. They had to do, I
+think, with the riddle of his existence. At such times it had been
+Wendy’s custom to take him out of bed and sit with him on her lap,
+soothing him in dear ways of her own invention, and when he grew calmer
+to put him back to bed before he quite woke up, so that he should
+not know of the indignity to which she had subjected him. But on this
+occasion he had fallen at once into a dreamless sleep. One arm dropped
+over the edge of the bed, one leg was arched, and the unfinished part of
+his laugh was stranded on his mouth, which was open, showing the little
+pearls.
+
+Thus defenceless Hook found him. He stood silent at the foot of the tree
+looking across the chamber at his enemy. Did no feeling of compassion
+disturb his sombre breast? The man was not wholly evil; he loved flowers
+(I have been told) and sweet music (he was himself no mean performer on
+the harpsichord); and, let it be frankly admitted, the idyllic nature of
+the scene stirred him profoundly. Mastered by his better self he would
+have returned reluctantly up the tree, but for one thing.
+
+What stayed him was Peter’s impertinent appearance as he slept. The
+open mouth, the drooping arm, the arched knee: they were such a
+personification of cockiness as, taken together, will never again, one
+may hope, be presented to eyes so sensitive to their offensiveness. They
+steeled Hook’s heart. If his rage had broken him into a hundred pieces
+every one of them would have disregarded the incident, and leapt at the
+sleeper.
+
+Though a light from the one lamp shone dimly on the bed, Hook stood in
+darkness himself, and at the first stealthy step forward he discovered
+an obstacle, the door of Slightly’s tree. It did not entirely fill the
+aperture, and he had been looking over it. Feeling for the catch,
+he found to his fury that it was low down, beyond his reach. To his
+disordered brain it seemed then that the irritating quality in Peter’s
+face and figure visibly increased, and he rattled the door and flung
+himself against it. Was his enemy to escape him after all?
+
+But what was that? The red in his eye had caught sight of Peter’s
+medicine standing on a ledge within easy reach. He fathomed what it was
+straightaway, and immediately knew that the sleeper was in his power.
+
+Lest he should be taken alive, Hook always carried about his person a
+dreadful drug, blended by himself of all the death-dealing rings that
+had come into his possession. These he had boiled down into a yellow
+liquid quite unknown to science, which was probably the most virulent
+poison in existence.
+
+Five drops of this he now added to Peter’s cup. His hand shook, but it
+was in exultation rather than in shame. As he did it he avoided glancing
+at the sleeper, but not lest pity should unnerve him; merely to avoid
+spilling. Then one long gloating look he cast upon his victim, and
+turning, wormed his way with difficulty up the tree. As he emerged
+at the top he looked the very spirit of evil breaking from its hole.
+Donning his hat at its most rakish angle, he wound his cloak around him,
+holding one end in front as if to conceal his person from the night,
+of which it was the blackest part, and muttering strangely to himself,
+stole away through the trees.
+
+Peter slept on. The light guttered [burned to edges] and went out,
+leaving the tenement in darkness; but still he slept. It must have been
+not less than ten o’clock by the crocodile, when he suddenly sat up in
+his bed, wakened by he knew not what. It was a soft cautious tapping on
+the door of his tree.
+
+Soft and cautious, but in that stillness it was sinister. Peter felt for
+his dagger till his hand gripped it. Then he spoke.
+
+“Who is that?”
+
+For long there was no answer: then again the knock.
+
+“Who are you?”
+
+No answer.
+
+He was thrilled, and he loved being thrilled. In two strides he reached
+the door. Unlike Slightly’s door, it filled the aperture [opening], so
+that he could not see beyond it, nor could the one knocking see him.
+
+“I won’t open unless you speak,” Peter cried.
+
+Then at last the visitor spoke, in a lovely bell-like voice.
+
+“Let me in, Peter.”
+
+It was Tink, and quickly he unbarred to her. She flew in excitedly, her
+face flushed and her dress stained with mud.
+
+“What is it?”
+
+“Oh, you could never guess!” she cried, and offered him three guesses.
+“Out with it!” he shouted, and in one ungrammatical sentence, as long as
+the ribbons that conjurers [magicians] pull from their mouths, she told
+of the capture of Wendy and the boys.
+
+Peter’s heart bobbed up and down as he listened. Wendy bound, and on the
+pirate ship; she who loved everything to be just so!
+
+“I’ll rescue her!” he cried, leaping at his weapons. As he leapt he
+thought of something he could do to please her. He could take his
+medicine.
+
+His hand closed on the fatal draught.
+
+“No!” shrieked Tinker Bell, who had heard Hook mutter about his deed as
+he sped through the forest.
+
+“Why not?”
+
+“It is poisoned.”
+
+“Poisoned? Who could have poisoned it?”
+
+“Hook.”
+
+“Don’t be silly. How could Hook have got down here?”
+
+Alas, Tinker Bell could not explain this, for even she did not know the
+dark secret of Slightly’s tree. Nevertheless Hook’s words had left no
+room for doubt. The cup was poisoned.
+
+“Besides,” said Peter, quite believing himself, “I never fell asleep.”
+
+He raised the cup. No time for words now; time for deeds; and with one
+of her lightning movements Tink got between his lips and the draught,
+and drained it to the dregs.
+
+“Why, Tink, how dare you drink my medicine?”
+
+But she did not answer. Already she was reeling in the air.
+
+“What is the matter with you?” cried Peter, suddenly afraid.
+
+“It was poisoned, Peter,” she told him softly; “and now I am going to be
+dead.”
+
+“O Tink, did you drink it to save me?”
+
+“Yes.”
+
+“But why, Tink?”
+
+Her wings would scarcely carry her now, but in reply she alighted on his
+shoulder and gave his nose a loving bite. She whispered in his ear “You
+silly ass,” and then, tottering to her chamber, lay down on the bed.
+
+His head almost filled the fourth wall of her little room as he knelt
+near her in distress. Every moment her light was growing fainter; and
+he knew that if it went out she would be no more. She liked his tears so
+much that she put out her beautiful finger and let them run over it.
+
+Her voice was so low that at first he could not make out what she said.
+Then he made it out. She was saying that she thought she could get well
+again if children believed in fairies.
+
+Peter flung out his arms. There were no children there, and it was night
+time; but he addressed all who might be dreaming of the Neverland, and
+who were therefore nearer to him than you think: boys and girls in their
+nighties, and naked papooses in their baskets hung from trees.
+
+“Do you believe?” he cried.
+
+Tink sat up in bed almost briskly to listen to her fate.
+
+She fancied she heard answers in the affirmative, and then again she
+wasn’t sure.
+
+“What do you think?” she asked Peter.
+
+“If you believe,” he shouted to them, “clap your hands; don’t let Tink
+die.”
+
+Many clapped.
+
+Some didn’t.
+
+A few beasts hissed.
+
+The clapping stopped suddenly; as if countless mothers had rushed to
+their nurseries to see what on earth was happening; but already Tink was
+saved. First her voice grew strong, then she popped out of bed, then
+she was flashing through the room more merry and impudent than ever. She
+never thought of thanking those who believed, but she would have liked to
+get at the ones who had hissed.
+
+“And now to rescue Wendy!”
+
+The moon was riding in a cloudy heaven when Peter rose from his tree,
+begirt [belted] with weapons and wearing little else, to set out upon
+his perilous quest. It was not such a night as he would have chosen.
+He had hoped to fly, keeping not far from the ground so that nothing
+unwonted should escape his eyes; but in that fitful light to have
+flown low would have meant trailing his shadow through the trees, thus
+disturbing birds and acquainting a watchful foe that he was astir.
+
+He regretted now that he had given the birds of the island such strange
+names that they are very wild and difficult of approach.
+
+There was no other course but to press forward in redskin fashion, at
+which happily he was an adept [expert]. But in what direction, for he
+could not be sure that the children had been taken to the ship? A
+light fall of snow had obliterated all footmarks; and a deathly silence
+pervaded the island, as if for a space Nature stood still in horror of
+the recent carnage. He had taught the children something of the forest
+lore that he had himself learned from Tiger Lily and Tinker Bell,
+and knew that in their dire hour they were not likely to forget it.
+Slightly, if he had an opportunity, would blaze [cut a mark in] the
+trees, for instance, Curly would drop seeds, and Wendy would leave her
+handkerchief at some important place. The morning was needed to search
+for such guidance, and he could not wait. The upper world had called
+him, but would give no help.
+
+The crocodile passed him, but not another living thing, not a sound, not
+a movement; and yet he knew well that sudden death might be at the next
+tree, or stalking him from behind.
+
+He swore this terrible oath: “Hook or me this time.”
+
+Now he crawled forward like a snake, and again erect, he darted across
+a space on which the moonlight played, one finger on his lip and his
+dagger at the ready. He was frightfully happy.
+
+
+
+
+Chapter 14 THE PIRATE SHIP
+
+One green light squinting over Kidd’s Creek, which is near the mouth of
+the pirate river, marked where the brig, the JOLLY ROGER, lay, low in
+the water; a rakish-looking [speedy-looking] craft foul to the hull,
+every beam in her detestable, like ground strewn with mangled feathers.
+She was the cannibal of the seas, and scarce needed that watchful eye,
+for she floated immune in the horror of her name.
+
+She was wrapped in the blanket of night, through which no sound from her
+could have reached the shore. There was little sound, and none agreeable
+save the whir of the ship’s sewing machine at which Smee sat, ever
+industrious and obliging, the essence of the commonplace, pathetic Smee.
+I know not why he was so infinitely pathetic, unless it were because
+he was so pathetically unaware of it; but even strong men had to turn
+hastily from looking at him, and more than once on summer evenings he
+had touched the fount of Hook’s tears and made it flow. Of this, as of
+almost everything else, Smee was quite unconscious.
+
+A few of the pirates leant over the bulwarks, drinking in the miasma
+[putrid mist] of the night; others sprawled by barrels over games of
+dice and cards; and the exhausted four who had carried the little house
+lay prone on the deck, where even in their sleep they rolled skillfully
+to this side or that out of Hook’s reach, lest he should claw them
+mechanically in passing.
+
+Hook trod the deck in thought. O man unfathomable. It was his hour of
+triumph. Peter had been removed for ever from his path, and all the
+other boys were in the brig, about to walk the plank. It was his
+grimmest deed since the days when he had brought Barbecue to heel; and
+knowing as we do how vain a tabernacle is man, could we be surprised
+had he now paced the deck unsteadily, bellied out by the winds of his
+success?
+
+But there was no elation in his gait, which kept pace with the action of
+his sombre mind. Hook was profoundly dejected.
+
+He was often thus when communing with himself on board ship in the
+quietude of the night. It was because he was so terribly alone. This
+inscrutable man never felt more alone than when surrounded by his dogs.
+They were socially inferior to him.
+
+Hook was not his true name. To reveal who he really was would even at
+this date set the country in a blaze; but as those who read between the
+lines must already have guessed, he had been at a famous public school;
+and its traditions still clung to him like garments, with which indeed
+they are largely concerned. Thus it was offensive to him even now to
+board a ship in the same dress in which he grappled [attacked] her, and
+he still adhered in his walk to the school’s distinguished slouch. But
+above all he retained the passion for good form.
+
+Good form! However much he may have degenerated, he still knew that this
+is all that really matters.
+
+From far within him he heard a creaking as of rusty portals, and through
+them came a stern tap-tap-tap, like hammering in the night when one
+cannot sleep. “Have you been good form to-day?” was their eternal
+question.
+
+“Fame, fame, that glittering bauble, it is mine,” he cried.
+
+“Is it quite good form to be distinguished at anything?” the tap-tap
+from his school replied.
+
+“I am the only man whom Barbecue feared,” he urged, “and Flint feared
+Barbecue.”
+
+“Barbecue, Flint--what house?” came the cutting retort.
+
+Most disquieting reflection of all, was it not bad form to think about
+good form?
+
+His vitals were tortured by this problem. It was a claw within him
+sharper than the iron one; and as it tore him, the perspiration dripped
+down his tallow [waxy] countenance and streaked his doublet. Ofttimes he
+drew his sleeve across his face, but there was no damming that trickle.
+
+Ah, envy not Hook.
+
+There came to him a presentiment of his early dissolution [death]. It
+was as if Peter’s terrible oath had boarded the ship. Hook felt a gloomy
+desire to make his dying speech, lest presently there should be no time
+for it.
+
+“Better for Hook,” he cried, “if he had had less ambition!” It was in
+his darkest hours only that he referred to himself in the third person.
+
+“No little children to love me!”
+
+Strange that he should think of this, which had never troubled him
+before; perhaps the sewing machine brought it to his mind. For long he
+muttered to himself, staring at Smee, who was hemming placidly, under
+the conviction that all children feared him.
+
+Feared him! Feared Smee! There was not a child on board the brig that
+night who did not already love him. He had said horrid things to them
+and hit them with the palm of his hand, because he could not hit with
+his fist, but they had only clung to him the more. Michael had tried on
+his spectacles.
+
+To tell poor Smee that they thought him lovable! Hook itched to do it,
+but it seemed too brutal. Instead, he revolved this mystery in his
+mind: why do they find Smee lovable? He pursued the problem like the
+sleuth-hound that he was. If Smee was lovable, what was it that made him
+so? A terrible answer suddenly presented itself--“Good form?”
+
+Had the bo’sun good form without knowing it, which is the best form of
+all?
+
+He remembered that you have to prove you don’t know you have it before
+you are eligible for Pop [an elite social club at Eton].
+
+With a cry of rage he raised his iron hand over Smee’s head; but he did
+not tear. What arrested him was this reflection:
+
+“To claw a man because he is good form, what would that be?”
+
+“Bad form!”
+
+The unhappy Hook was as impotent [powerless] as he was damp, and he fell
+forward like a cut flower.
+
+His dogs thinking him out of the way for a time, discipline instantly
+relaxed; and they broke into a bacchanalian [drunken] dance, which
+brought him to his feet at once, all traces of human weakness gone, as
+if a bucket of water had passed over him.
+
+“Quiet, you scugs,” he cried, “or I’ll cast anchor in you;” and at once
+the din was hushed. “Are all the children chained, so that they cannot
+fly away?”
+
+“Ay, ay.”
+
+“Then hoist them up.”
+
+The wretched prisoners were dragged from the hold, all except Wendy,
+and ranged in line in front of him. For a time he seemed unconscious
+of their presence. He lolled at his ease, humming, not unmelodiously,
+snatches of a rude song, and fingering a pack of cards. Ever and anon
+the light from his cigar gave a touch of colour to his face.
+
+“Now then, bullies,” he said briskly, “six of you walk the plank
+to-night, but I have room for two cabin boys. Which of you is it to be?”
+
+“Don’t irritate him unnecessarily,” had been Wendy’s instructions in
+the hold; so Tootles stepped forward politely. Tootles hated the idea
+of signing under such a man, but an instinct told him that it would
+be prudent to lay the responsibility on an absent person; and though a
+somewhat silly boy, he knew that mothers alone are always willing to be
+the buffer. All children know this about mothers, and despise them for
+it, but make constant use of it.
+
+So Tootles explained prudently, “You see, sir, I don’t think my mother
+would like me to be a pirate. Would your mother like you to be a pirate,
+Slightly?”
+
+He winked at Slightly, who said mournfully, “I don’t think so,” as if
+he wished things had been otherwise. “Would your mother like you to be a
+pirate, Twin?”
+
+“I don’t think so,” said the first twin, as clever as the others. “Nibs,
+would--”
+
+“Stow this gab,” roared Hook, and the spokesmen were dragged back. “You,
+boy,” he said, addressing John, “you look as if you had a little pluck
+in you. Didst never want to be a pirate, my hearty?”
+
+Now John had sometimes experienced this hankering at maths. prep.; and
+he was struck by Hook’s picking him out.
+
+“I once thought of calling myself Red-handed Jack,” he said diffidently.
+
+“And a good name too. We’ll call you that here, bully, if you join.”
+
+“What do you think, Michael?” asked John.
+
+“What would you call me if I join?” Michael demanded.
+
+“Blackbeard Joe.”
+
+Michael was naturally impressed. “What do you think, John?” He wanted
+John to decide, and John wanted him to decide.
+
+“Shall we still be respectful subjects of the King?” John inquired.
+
+Through Hook’s teeth came the answer: “You would have to swear, ‘Down
+with the King.’”
+
+Perhaps John had not behaved very well so far, but he shone out now.
+
+“Then I refuse,” he cried, banging the barrel in front of Hook.
+
+“And I refuse,” cried Michael.
+
+“Rule Britannia!” squeaked Curly.
+
+The infuriated pirates buffeted them in the mouth; and Hook roared out,
+“That seals your doom. Bring up their mother. Get the plank ready.”
+
+They were only boys, and they went white as they saw Jukes and Cecco
+preparing the fatal plank. But they tried to look brave when Wendy was
+brought up.
+
+No words of mine can tell you how Wendy despised those pirates. To the
+boys there was at least some glamour in the pirate calling; but all that
+she saw was that the ship had not been tidied for years. There was not
+a porthole on the grimy glass of which you might not have written with
+your finger “Dirty pig”; and she had already written it on several. But
+as the boys gathered round her she had no thought, of course, save for
+them.
+
+“So, my beauty,” said Hook, as if he spoke in syrup, “you are to see
+your children walk the plank.”
+
+Fine gentlemen though he was, the intensity of his communings had soiled
+his ruff, and suddenly he knew that she was gazing at it. With a hasty
+gesture he tried to hide it, but he was too late.
+
+“Are they to die?” asked Wendy, with a look of such frightful contempt
+that he nearly fainted.
+
+“They are,” he snarled. “Silence all,” he called gloatingly, “for a
+mother’s last words to her children.”
+
+At this moment Wendy was grand. “These are my last words, dear boys,”
+ she said firmly. “I feel that I have a message to you from your real
+mothers, and it is this: ‘We hope our sons will die like English
+gentlemen.’”
+
+Even the pirates were awed, and Tootles cried out hysterically, “I am
+going to do what my mother hopes. What are you to do, Nibs?”
+
+“What my mother hopes. What are you to do, Twin?”
+
+“What my mother hopes. John, what are--”
+
+But Hook had found his voice again.
+
+“Tie her up!” he shouted.
+
+It was Smee who tied her to the mast. “See here, honey,” he whispered,
+“I’ll save you if you promise to be my mother.”
+
+But not even for Smee would she make such a promise. “I would almost
+rather have no children at all,” she said disdainfully [scornfully].
+
+It is sad to know that not a boy was looking at her as Smee tied her to
+the mast; the eyes of all were on the plank: that last little walk they
+were about to take. They were no longer able to hope that they would
+walk it manfully, for the capacity to think had gone from them; they
+could stare and shiver only.
+
+Hook smiled on them with his teeth closed, and took a step toward Wendy.
+His intention was to turn her face so that she should see the boys
+walking the plank one by one. But he never reached her, he never heard
+the cry of anguish he hoped to wring from her. He heard something else
+instead.
+
+It was the terrible tick-tick of the crocodile.
+
+They all heard it--pirates, boys, Wendy; and immediately every head was
+blown in one direction; not to the water whence the sound proceeded, but
+toward Hook. All knew that what was about to happen concerned him alone,
+and that from being actors they were suddenly become spectators.
+
+Very frightful was it to see the change that came over him. It was as if
+he had been clipped at every joint. He fell in a little heap.
+
+The sound came steadily nearer; and in advance of it came this ghastly
+thought, “The crocodile is about to board the ship!”
+
+Even the iron claw hung inactive; as if knowing that it was no intrinsic
+part of what the attacking force wanted. Left so fearfully alone, any
+other man would have lain with his eyes shut where he fell: but the
+gigantic brain of Hook was still working, and under its guidance he
+crawled on the knees along the deck as far from the sound as he could
+go. The pirates respectfully cleared a passage for him, and it was only
+when he brought up against the bulwarks that he spoke.
+
+“Hide me!” he cried hoarsely.
+
+They gathered round him, all eyes averted from the thing that was coming
+aboard. They had no thought of fighting it. It was Fate.
+
+Only when Hook was hidden from them did curiosity loosen the limbs of
+the boys so that they could rush to the ship’s side to see the crocodile
+climbing it. Then they got the strangest surprise of the Night of
+Nights; for it was no crocodile that was coming to their aid. It was
+Peter.
+
+He signed to them not to give vent to any cry of admiration that might
+rouse suspicion. Then he went on ticking.
+
+
+
+
+Chapter 15 “HOOK OR ME THIS TIME”
+
+Odd things happen to all of us on our way through life without our
+noticing for a time that they have happened. Thus, to take an instance,
+we suddenly discover that we have been deaf in one ear for we don’t know
+how long, but, say, half an hour. Now such an experience had come that
+night to Peter. When last we saw him he was stealing across the island
+with one finger to his lips and his dagger at the ready. He had seen the
+crocodile pass by without noticing anything peculiar about it, but by
+and by he remembered that it had not been ticking. At first he thought
+this eerie, but soon concluded rightly that the clock had run down.
+
+Without giving a thought to what might be the feelings of a
+fellow-creature thus abruptly deprived of its closest companion, Peter
+began to consider how he could turn the catastrophe to his own use;
+and he decided to tick, so that wild beasts should believe he was the
+crocodile and let him pass unmolested. He ticked superbly, but with one
+unforeseen result. The crocodile was among those who heard the sound,
+and it followed him, though whether with the purpose of regaining what
+it had lost, or merely as a friend under the belief that it was again
+ticking itself, will never be certainly known, for, like slaves to a
+fixed idea, it was a stupid beast.
+
+Peter reached the shore without mishap, and went straight on, his legs
+encountering the water as if quite unaware that they had entered a new
+element. Thus many animals pass from land to water, but no other human
+of whom I know. As he swam he had but one thought: “Hook or me this
+time.” He had ticked so long that he now went on ticking without knowing
+that he was doing it. Had he known he would have stopped, for to board
+the brig by help of the tick, though an ingenious idea, had not occurred
+to him.
+
+On the contrary, he thought he had scaled her side as noiseless as a
+mouse; and he was amazed to see the pirates cowering from him, with Hook
+in their midst as abject as if he had heard the crocodile.
+
+The crocodile! No sooner did Peter remember it than he heard the
+ticking. At first he thought the sound did come from the crocodile,
+and he looked behind him swiftly. Then he realised that he was doing it
+himself, and in a flash he understood the situation. “How clever of me!”
+ he thought at once, and signed to the boys not to burst into applause.
+
+It was at this moment that Ed Teynte the quartermaster emerged from the
+forecastle and came along the deck. Now, reader, time what happened by
+your watch. Peter struck true and deep. John clapped his hands on the
+ill-fated pirate’s mouth to stifle the dying groan. He fell forward.
+Four boys caught him to prevent the thud. Peter gave the signal, and the
+carrion was cast overboard. There was a splash, and then silence. How
+long has it taken?
+
+“One!” (Slightly had begun to count.)
+
+None too soon, Peter, every inch of him on tiptoe, vanished into the
+cabin; for more than one pirate was screwing up his courage to look
+round. They could hear each other’s distressed breathing now, which
+showed them that the more terrible sound had passed.
+
+“It’s gone, captain,” Smee said, wiping off his spectacles. “All’s still
+again.”
+
+Slowly Hook let his head emerge from his ruff, and listened so intently
+that he could have caught the echo of the tick. There was not a sound,
+and he drew himself up firmly to his full height.
+
+“Then here’s to Johnny Plank!” he cried brazenly, hating the boys more
+than ever because they had seen him unbend. He broke into the villainous
+ditty:
+
+     “Yo ho, yo ho, the frisky plank,
+     You walks along it so,
+     Till it goes down and you goes down
+     To Davy Jones below!”
+
+To terrorize the prisoners the more, though with a certain loss of
+dignity, he danced along an imaginary plank, grimacing at them as he
+sang; and when he finished he cried, “Do you want a touch of the cat [o’
+nine tails] before you walk the plank?”
+
+At that they fell on their knees. “No, no!” they cried so piteously that
+every pirate smiled.
+
+“Fetch the cat, Jukes,” said Hook; “it’s in the cabin.”
+
+The cabin! Peter was in the cabin! The children gazed at each other.
+
+“Ay, ay,” said Jukes blithely, and he strode into the cabin. They
+followed him with their eyes; they scarce knew that Hook had resumed his
+song, his dogs joining in with him:
+
+     “Yo ho, yo ho, the scratching cat,
+     Its tails are nine, you know,
+     And when they’re writ upon your back--”
+
+What was the last line will never be known, for of a sudden the song was
+stayed by a dreadful screech from the cabin. It wailed through the ship,
+and died away. Then was heard a crowing sound which was well understood
+by the boys, but to the pirates was almost more eerie than the screech.
+
+“What was that?” cried Hook.
+
+“Two,” said Slightly solemnly.
+
+The Italian Cecco hesitated for a moment and then swung into the cabin.
+He tottered out, haggard.
+
+“What’s the matter with Bill Jukes, you dog?” hissed Hook, towering over
+him.
+
+“The matter wi’ him is he’s dead, stabbed,” replied Cecco in a hollow
+voice.
+
+“Bill Jukes dead!” cried the startled pirates.
+
+“The cabin’s as black as a pit,” Cecco said, almost gibbering, “but
+there is something terrible in there: the thing you heard crowing.”
+
+The exultation of the boys, the lowering looks of the pirates, both were
+seen by Hook.
+
+“Cecco,” he said in his most steely voice, “go back and fetch me out
+that doodle-doo.”
+
+Cecco, bravest of the brave, cowered before his captain, crying “No,
+no”; but Hook was purring to his claw.
+
+“Did you say you would go, Cecco?” he said musingly.
+
+Cecco went, first flinging his arms despairingly. There was no more
+singing, all listened now; and again came a death-screech and again a
+crow.
+
+No one spoke except Slightly. “Three,” he said.
+
+Hook rallied his dogs with a gesture. “‘S’death and odds fish,” he
+thundered, “who is to bring me that doodle-doo?”
+
+“Wait till Cecco comes out,” growled Starkey, and the others took up the
+cry.
+
+“I think I heard you volunteer, Starkey,” said Hook, purring again.
+
+“No, by thunder!” Starkey cried.
+
+“My hook thinks you did,” said Hook, crossing to him. “I wonder if it
+would not be advisable, Starkey, to humour the hook?”
+
+“I’ll swing before I go in there,” replied Starkey doggedly, and again
+he had the support of the crew.
+
+“Is this mutiny?” asked Hook more pleasantly than ever. “Starkey’s
+ringleader!”
+
+“Captain, mercy!” Starkey whimpered, all of a tremble now.
+
+“Shake hands, Starkey,” said Hook, proffering his claw.
+
+Starkey looked round for help, but all deserted him. As he backed up
+Hook advanced, and now the red spark was in his eye. With a despairing
+scream the pirate leapt upon Long Tom and precipitated himself into the
+sea.
+
+“Four,” said Slightly.
+
+“And now,” Hook said courteously, “did any other gentlemen say mutiny?”
+ Seizing a lantern and raising his claw with a menacing gesture, “I’ll
+bring out that doodle-doo myself,” he said, and sped into the cabin.
+
+“Five.” How Slightly longed to say it. He wetted his lips to be ready,
+but Hook came staggering out, without his lantern.
+
+“Something blew out the light,” he said a little unsteadily.
+
+“Something!” echoed Mullins.
+
+“What of Cecco?” demanded Noodler.
+
+“He’s as dead as Jukes,” said Hook shortly.
+
+His reluctance to return to the cabin impressed them all unfavourably,
+and the mutinous sounds again broke forth. All pirates are
+superstitious, and Cookson cried, “They do say the surest sign a ship’s
+accurst is when there’s one on board more than can be accounted for.”
+
+“I’ve heard,” muttered Mullins, “he always boards the pirate craft last.
+Had he a tail, captain?”
+
+“They say,” said another, looking viciously at Hook, “that when he comes
+it’s in the likeness of the wickedest man aboard.”
+
+“Had he a hook, captain?” asked Cookson insolently; and one after
+another took up the cry, “The ship’s doomed!” At this the children could
+not resist raising a cheer. Hook had well-nigh forgotten his prisoners,
+but as he swung round on them now his face lit up again.
+
+“Lads,” he cried to his crew, “now here’s a notion. Open the cabin door
+and drive them in. Let them fight the doodle-doo for their lives. If
+they kill him, we’re so much the better; if he kills them, we’re none
+the worse.”
+
+For the last time his dogs admired Hook, and devotedly they did his
+bidding. The boys, pretending to struggle, were pushed into the cabin
+and the door was closed on them.
+
+“Now, listen!” cried Hook, and all listened. But not one dared to face
+the door. Yes, one, Wendy, who all this time had been bound to the mast.
+It was for neither a scream nor a crow that she was watching, it was for
+the reappearance of Peter.
+
+She had not long to wait. In the cabin he had found the thing for which
+he had gone in search: the key that would free the children of their
+manacles, and now they all stole forth, armed with such weapons as they
+could find. First signing them to hide, Peter cut Wendy’s bonds,
+and then nothing could have been easier than for them all to fly off
+together; but one thing barred the way, an oath, “Hook or me this time.”
+ So when he had freed Wendy, he whispered for her to conceal herself with
+the others, and himself took her place by the mast, her cloak around him
+so that he should pass for her. Then he took a great breath and crowed.
+
+To the pirates it was a voice crying that all the boys lay slain in the
+cabin; and they were panic-stricken. Hook tried to hearten them; but
+like the dogs he had made them they showed him their fangs, and he knew
+that if he took his eyes off them now they would leap at him.
+
+“Lads,” he said, ready to cajole or strike as need be, but never
+quailing for an instant, “I’ve thought it out. There’s a Jonah aboard.”
+
+“Ay,” they snarled, “a man wi’ a hook.”
+
+“No, lads, no, it’s the girl. Never was luck on a pirate ship wi’ a
+woman on board. We’ll right the ship when she’s gone.”
+
+Some of them remembered that this had been a saying of Flint’s. “It’s
+worth trying,” they said doubtfully.
+
+“Fling the girl overboard,” cried Hook; and they made a rush at the
+figure in the cloak.
+
+“There’s none can save you now, missy,” Mullins hissed jeeringly.
+
+“There’s one,” replied the figure.
+
+“Who’s that?”
+
+“Peter Pan the avenger!” came the terrible answer; and as he spoke Peter
+flung off his cloak. Then they all knew who ‘twas that had been undoing
+them in the cabin, and twice Hook essayed to speak and twice he failed.
+In that frightful moment I think his fierce heart broke.
+
+At last he cried, “Cleave him to the brisket!” but without conviction.
+
+“Down, boys, and at them!” Peter’s voice rang out; and in another moment
+the clash of arms was resounding through the ship. Had the pirates kept
+together it is certain that they would have won; but the onset came
+when they were still unstrung, and they ran hither and thither, striking
+wildly, each thinking himself the last survivor of the crew. Man to man
+they were the stronger; but they fought on the defensive only, which
+enabled the boys to hunt in pairs and choose their quarry. Some of the
+miscreants leapt into the sea; others hid in dark recesses, where they
+were found by Slightly, who did not fight, but ran about with a lantern
+which he flashed in their faces, so that they were half blinded and
+fell as an easy prey to the reeking swords of the other boys. There was
+little sound to be heard but the clang of weapons, an occasional
+screech or splash, and Slightly monotonously counting--five--six--seven
+eight--nine--ten--eleven.
+
+I think all were gone when a group of savage boys surrounded Hook, who
+seemed to have a charmed life, as he kept them at bay in that circle
+of fire. They had done for his dogs, but this man alone seemed to be a
+match for them all. Again and again they closed upon him, and again and
+again he hewed a clear space. He had lifted up one boy with his hook,
+and was using him as a buckler [shield], when another, who had just
+passed his sword through Mullins, sprang into the fray.
+
+“Put up your swords, boys,” cried the newcomer, “this man is mine.”
+
+Thus suddenly Hook found himself face to face with Peter. The others
+drew back and formed a ring around them.
+
+For long the two enemies looked at one another, Hook shuddering
+slightly, and Peter with the strange smile upon his face.
+
+“So, Pan,” said Hook at last, “this is all your doing.”
+
+“Ay, James Hook,” came the stern answer, “it is all my doing.”
+
+“Proud and insolent youth,” said Hook, “prepare to meet thy doom.”
+
+“Dark and sinister man,” Peter answered, “have at thee.”
+
+Without more words they fell to, and for a space there was no advantage
+to either blade. Peter was a superb swordsman, and parried with dazzling
+rapidity; ever and anon he followed up a feint with a lunge that got
+past his foe’s defence, but his shorter reach stood him in ill stead,
+and he could not drive the steel home. Hook, scarcely his inferior in
+brilliancy, but not quite so nimble in wrist play, forced him back by
+the weight of his onset, hoping suddenly to end all with a favourite
+thrust, taught him long ago by Barbecue at Rio; but to his astonishment
+he found this thrust turned aside again and again. Then he sought to
+close and give the quietus with his iron hook, which all this time had
+been pawing the air; but Peter doubled under it and, lunging fiercely,
+pierced him in the ribs. At the sight of his own blood, whose peculiar
+colour, you remember, was offensive to him, the sword fell from Hook’s
+hand, and he was at Peter’s mercy.
+
+“Now!” cried all the boys, but with a magnificent gesture Peter invited
+his opponent to pick up his sword. Hook did so instantly, but with a
+tragic feeling that Peter was showing good form.
+
+Hitherto he had thought it was some fiend fighting him, but darker
+suspicions assailed him now.
+
+“Pan, who and what art thou?” he cried huskily.
+
+“I’m youth, I’m joy,” Peter answered at a venture, “I’m a little bird
+that has broken out of the egg.”
+
+This, of course, was nonsense; but it was proof to the unhappy Hook that
+Peter did not know in the least who or what he was, which is the very
+pinnacle of good form.
+
+“To’t again,” he cried despairingly.
+
+He fought now like a human flail, and every sweep of that terrible sword
+would have severed in twain any man or boy who obstructed it; but Peter
+fluttered round him as if the very wind it made blew him out of the
+danger zone. And again and again he darted in and pricked.
+
+Hook was fighting now without hope. That passionate breast no longer
+asked for life; but for one boon it craved: to see Peter show bad form
+before it was cold forever.
+
+Abandoning the fight he rushed into the powder magazine and fired it.
+
+“In two minutes,” he cried, “the ship will be blown to pieces.”
+
+Now, now, he thought, true form will show.
+
+But Peter issued from the powder magazine with the shell in his hands,
+and calmly flung it overboard.
+
+What sort of form was Hook himself showing? Misguided man though he was,
+we may be glad, without sympathising with him, that in the end he was
+true to the traditions of his race. The other boys were flying around
+him now, flouting, scornful; and he staggered about the deck striking up
+at them impotently, his mind was no longer with them; it was slouching
+in the playing fields of long ago, or being sent up [to the headmaster]
+for good, or watching the wall-game from a famous wall. And his shoes
+were right, and his waistcoat was right, and his tie was right, and his
+socks were right.
+
+James Hook, thou not wholly unheroic figure, farewell.
+
+For we have come to his last moment.
+
+Seeing Peter slowly advancing upon him through the air with dagger
+poised, he sprang upon the bulwarks to cast himself into the sea. He
+did not know that the crocodile was waiting for him; for we purposely
+stopped the clock that this knowledge might be spared him: a little mark
+of respect from us at the end.
+
+He had one last triumph, which I think we need not grudge him. As he
+stood on the bulwark looking over his shoulder at Peter gliding through
+the air, he invited him with a gesture to use his foot. It made Peter
+kick instead of stab.
+
+At last Hook had got the boon for which he craved.
+
+“Bad form,” he cried jeeringly, and went content to the crocodile.
+
+Thus perished James Hook.
+
+“Seventeen,” Slightly sang out; but he was not quite correct in his
+figures. Fifteen paid the penalty for their crimes that night; but two
+reached the shore: Starkey to be captured by the redskins, who made him
+nurse for all their papooses, a melancholy come-down for a pirate; and
+Smee, who henceforth wandered about the world in his spectacles, making
+a precarious living by saying he was the only man that Jas. Hook had
+feared.
+
+Wendy, of course, had stood by taking no part in the fight, though
+watching Peter with glistening eyes; but now that all was over she
+became prominent again. She praised them equally, and shuddered
+delightfully when Michael showed her the place where he had killed one;
+and then she took them into Hook’s cabin and pointed to his watch which
+was hanging on a nail. It said “half-past one!”
+
+The lateness of the hour was almost the biggest thing of all. She got
+them to bed in the pirates’ bunks pretty quickly, you may be sure; all
+but Peter, who strutted up and down on the deck, until at last he fell
+asleep by the side of Long Tom. He had one of his dreams that night, and
+cried in his sleep for a long time, and Wendy held him tightly.
+
+
+
+
+Chapter 16 THE RETURN HOME
+
+By three bells that morning they were all stirring their stumps [legs];
+for there was a big sea running; and Tootles, the bo’sun, was among
+them, with a rope’s end in his hand and chewing tobacco. They all donned
+pirate clothes cut off at the knee, shaved smartly, and tumbled up, with
+the true nautical roll and hitching their trousers.
+
+It need not be said who was the captain. Nibs and John were first and
+second mate. There was a woman aboard. The rest were tars [sailors]
+before the mast, and lived in the fo’c’sle. Peter had already lashed
+himself to the wheel; but he piped all hands and delivered a short
+address to them; said he hoped they would do their duty like gallant
+hearties, but that he knew they were the scum of Rio and the Gold Coast,
+and if they snapped at him he would tear them. The bluff strident words
+struck the note sailors understood, and they cheered him lustily. Then
+a few sharp orders were given, and they turned the ship round, and nosed
+her for the mainland.
+
+Captain Pan calculated, after consulting the ship’s chart, that if this
+weather lasted they should strike the Azores about the 21st of June,
+after which it would save time to fly.
+
+Some of them wanted it to be an honest ship and others were in favour
+of keeping it a pirate; but the captain treated them as dogs, and they
+dared not express their wishes to him even in a round robin [one person
+after another, as they had to Cpt. Hook]. Instant obedience was the only
+safe thing. Slightly got a dozen for looking perplexed when told to take
+soundings. The general feeling was that Peter was honest just now to
+lull Wendy’s suspicions, but that there might be a change when the new
+suit was ready, which, against her will, she was making for him out of
+some of Hook’s wickedest garments. It was afterwards whispered among
+them that on the first night he wore this suit he sat long in the cabin
+with Hook’s cigar-holder in his mouth and one hand clenched, all but for
+the forefinger, which he bent and held threateningly aloft like a hook.
+
+Instead of watching the ship, however, we must now return to that
+desolate home from which three of our characters had taken heartless
+flight so long ago. It seems a shame to have neglected No. 14 all this
+time; and yet we may be sure that Mrs. Darling does not blame us. If we
+had returned sooner to look with sorrowful sympathy at her, she would
+probably have cried, “Don’t be silly; what do I matter? Do go back and
+keep an eye on the children.” So long as mothers are like this their
+children will take advantage of them; and they may lay to [bet on] that.
+
+Even now we venture into that familiar nursery only because its lawful
+occupants are on their way home; we are merely hurrying on in advance
+of them to see that their beds are properly aired and that Mr. and Mrs.
+Darling do not go out for the evening. We are no more than servants. Why
+on earth should their beds be properly aired, seeing that they left them
+in such a thankless hurry? Would it not serve them jolly well right if
+they came back and found that their parents were spending the week-end
+in the country? It would be the moral lesson they have been in need
+of ever since we met them; but if we contrived things in this way Mrs.
+Darling would never forgive us.
+
+One thing I should like to do immensely, and that is to tell her, in the
+way authors have, that the children are coming back, that indeed they
+will be here on Thursday week. This would spoil so completely the
+surprise to which Wendy and John and Michael are looking forward. They
+have been planning it out on the ship: mother’s rapture, father’s shout
+of joy, Nana’s leap through the air to embrace them first, when what
+they ought to be prepared for is a good hiding. How delicious to spoil
+it all by breaking the news in advance; so that when they enter grandly
+Mrs. Darling may not even offer Wendy her mouth, and Mr. Darling may
+exclaim pettishly, “Dash it all, here are those boys again.” However,
+we should get no thanks even for this. We are beginning to know Mrs.
+Darling by this time, and may be sure that she would upbraid us for
+depriving the children of their little pleasure.
+
+“But, my dear madam, it is ten days till Thursday week; so that by
+telling you what’s what, we can save you ten days of unhappiness.”
+
+“Yes, but at what a cost! By depriving the children of ten minutes of
+delight.”
+
+“Oh, if you look at it in that way!”
+
+“What other way is there in which to look at it?”
+
+You see, the woman had no proper spirit. I had meant to say
+extraordinarily nice things about her; but I despise her, and not one of
+them will I say now. She does not really need to be told to have things
+ready, for they are ready. All the beds are aired, and she never leaves
+the house, and observe, the window is open. For all the use we are to
+her, we might well go back to the ship. However, as we are here we may
+as well stay and look on. That is all we are, lookers-on. Nobody really
+wants us. So let us watch and say jaggy things, in the hope that some of
+them will hurt.
+
+The only change to be seen in the night-nursery is that between nine
+and six the kennel is no longer there. When the children flew away, Mr.
+Darling felt in his bones that all the blame was his for having chained
+Nana up, and that from first to last she had been wiser than he. Of
+course, as we have seen, he was quite a simple man; indeed he might have
+passed for a boy again if he had been able to take his baldness off;
+but he had also a noble sense of justice and a lion’s courage to do what
+seemed right to him; and having thought the matter out with anxious care
+after the flight of the children, he went down on all fours and crawled
+into the kennel. To all Mrs. Darling’s dear invitations to him to come
+out he replied sadly but firmly:
+
+“No, my own one, this is the place for me.”
+
+In the bitterness of his remorse he swore that he would never leave
+the kennel until his children came back. Of course this was a pity; but
+whatever Mr. Darling did he had to do in excess, otherwise he soon gave
+up doing it. And there never was a more humble man than the once proud
+George Darling, as he sat in the kennel of an evening talking with his
+wife of their children and all their pretty ways.
+
+Very touching was his deference to Nana. He would not let her come into
+the kennel, but on all other matters he followed her wishes implicitly.
+
+Every morning the kennel was carried with Mr. Darling in it to a cab,
+which conveyed him to his office, and he returned home in the same way
+at six. Something of the strength of character of the man will be seen
+if we remember how sensitive he was to the opinion of neighbours: this
+man whose every movement now attracted surprised attention. Inwardly he
+must have suffered torture; but he preserved a calm exterior even when
+the young criticised his little home, and he always lifted his hat
+courteously to any lady who looked inside.
+
+It may have been Quixotic, but it was magnificent. Soon the inward
+meaning of it leaked out, and the great heart of the public was touched.
+Crowds followed the cab, cheering it lustily; charming girls scaled it
+to get his autograph; interviews appeared in the better class of papers,
+and society invited him to dinner and added, “Do come in the kennel.”
+
+On that eventful Thursday week, Mrs. Darling was in the night-nursery
+awaiting George’s return home; a very sad-eyed woman. Now that we look
+at her closely and remember the gaiety of her in the old days, all gone
+now just because she has lost her babes, I find I won’t be able to say
+nasty things about her after all. If she was too fond of her rubbishy
+children, she couldn’t help it. Look at her in her chair, where she has
+fallen asleep. The corner of her mouth, where one looks first, is almost
+withered up. Her hand moves restlessly on her breast as if she had a
+pain there. Some like Peter best, and some like Wendy best, but I like
+her best. Suppose, to make her happy, we whisper to her in her sleep
+that the brats are coming back. They are really within two miles of the
+window now, and flying strong, but all we need whisper is that they are
+on the way. Let’s.
+
+It is a pity we did it, for she has started up, calling their names; and
+there is no one in the room but Nana.
+
+“O Nana, I dreamt my dear ones had come back.”
+
+Nana had filmy eyes, but all she could do was put her paw gently on her
+mistress’s lap; and they were sitting together thus when the kennel was
+brought back. As Mr. Darling puts his head out to kiss his wife, we see
+that his face is more worn than of yore, but has a softer expression.
+
+He gave his hat to Liza, who took it scornfully; for she had no
+imagination, and was quite incapable of understanding the motives of
+such a man. Outside, the crowd who had accompanied the cab home were
+still cheering, and he was naturally not unmoved.
+
+“Listen to them,” he said; “it is very gratifying.”
+
+“Lots of little boys,” sneered Liza.
+
+“There were several adults to-day,” he assured her with a faint flush;
+but when she tossed her head he had not a word of reproof for her.
+Social success had not spoilt him; it had made him sweeter. For some
+time he sat with his head out of the kennel, talking with Mrs. Darling
+of this success, and pressing her hand reassuringly when she said she
+hoped his head would not be turned by it.
+
+“But if I had been a weak man,” he said. “Good heavens, if I had been a
+weak man!”
+
+“And, George,” she said timidly, “you are as full of remorse as ever,
+aren’t you?”
+
+“Full of remorse as ever, dearest! See my punishment: living in a
+kennel.”
+
+“But it is punishment, isn’t it, George? You are sure you are not
+enjoying it?”
+
+“My love!”
+
+You may be sure she begged his pardon; and then, feeling drowsy, he
+curled round in the kennel.
+
+“Won’t you play me to sleep,” he asked, “on the nursery piano?” and as
+she was crossing to the day-nursery he added thoughtlessly, “And shut
+that window. I feel a draught.”
+
+“O George, never ask me to do that. The window must always be left open
+for them, always, always.”
+
+Now it was his turn to beg her pardon; and she went into the day-nursery
+and played, and soon he was asleep; and while he slept, Wendy and John
+and Michael flew into the room.
+
+Oh no. We have written it so, because that was the charming arrangement
+planned by them before we left the ship; but something must have
+happened since then, for it is not they who have flown in, it is Peter
+and Tinker Bell.
+
+Peter’s first words tell all.
+
+“Quick Tink,” he whispered, “close the window; bar it! That’s right. Now
+you and I must get away by the door; and when Wendy comes she will think
+her mother has barred her out; and she will have to go back with me.”
+
+Now I understand what had hitherto puzzled me, why when Peter had
+exterminated the pirates he did not return to the island and leave Tink
+to escort the children to the mainland. This trick had been in his head
+all the time.
+
+Instead of feeling that he was behaving badly he danced with glee; then
+he peeped into the day-nursery to see who was playing. He whispered to
+Tink, “It’s Wendy’s mother! She is a pretty lady, but not so pretty as
+my mother. Her mouth is full of thimbles, but not so full as my mother’s
+was.”
+
+Of course he knew nothing whatever about his mother; but he sometimes
+bragged about her.
+
+He did not know the tune, which was “Home, Sweet Home,” but he knew it
+was saying, “Come back, Wendy, Wendy, Wendy”; and he cried exultantly,
+“You will never see Wendy again, lady, for the window is barred!”
+
+He peeped in again to see why the music had stopped, and now he saw
+that Mrs. Darling had laid her head on the box, and that two tears were
+sitting on her eyes.
+
+“She wants me to unbar the window,” thought Peter, “but I won’t, not I!”
+
+He peeped again, and the tears were still there, or another two had
+taken their place.
+
+“She’s awfully fond of Wendy,” he said to himself. He was angry with her
+now for not seeing why she could not have Wendy.
+
+The reason was so simple: “I’m fond of her too. We can’t both have her,
+lady.”
+
+But the lady would not make the best of it, and he was unhappy. He
+ceased to look at her, but even then she would not let go of him. He
+skipped about and made funny faces, but when he stopped it was just as
+if she were inside him, knocking.
+
+“Oh, all right,” he said at last, and gulped. Then he unbarred the
+window. “Come on, Tink,” he cried, with a frightful sneer at the laws of
+nature; “we don’t want any silly mothers;” and he flew away.
+
+Thus Wendy and John and Michael found the window open for them after
+all, which of course was more than they deserved. They alighted on the
+floor, quite unashamed of themselves, and the youngest one had already
+forgotten his home.
+
+“John,” he said, looking around him doubtfully, “I think I have been
+here before.”
+
+“Of course you have, you silly. There is your old bed.”
+
+“So it is,” Michael said, but not with much conviction.
+
+“I say,” cried John, “the kennel!” and he dashed across to look into it.
+
+“Perhaps Nana is inside it,” Wendy said.
+
+But John whistled. “Hullo,” he said, “there’s a man inside it.”
+
+“It’s father!” exclaimed Wendy.
+
+“Let me see father,” Michael begged eagerly, and he took a good look.
+“He is not so big as the pirate I killed,” he said with such frank
+disappointment that I am glad Mr. Darling was asleep; it would have been
+sad if those had been the first words he heard his little Michael say.
+
+Wendy and John had been taken aback somewhat at finding their father in
+the kennel.
+
+“Surely,” said John, like one who had lost faith in his memory, “he used
+not to sleep in the kennel?”
+
+“John,” Wendy said falteringly, “perhaps we don’t remember the old life
+as well as we thought we did.”
+
+A chill fell upon them; and serve them right.
+
+“It is very careless of mother,” said that young scoundrel John, “not to
+be here when we come back.”
+
+It was then that Mrs. Darling began playing again.
+
+“It’s mother!” cried Wendy, peeping.
+
+“So it is!” said John.
+
+“Then are you not really our mother, Wendy?” asked Michael, who was
+surely sleepy.
+
+“Oh dear!” exclaimed Wendy, with her first real twinge of remorse [for
+having gone], “it was quite time we came back.”
+
+“Let us creep in,” John suggested, “and put our hands over her eyes.”
+
+But Wendy, who saw that they must break the joyous news more gently, had
+a better plan.
+
+“Let us all slip into our beds, and be there when she comes in, just as
+if we had never been away.”
+
+And so when Mrs. Darling went back to the night-nursery to see if her
+husband was asleep, all the beds were occupied. The children waited
+for her cry of joy, but it did not come. She saw them, but she did not
+believe they were there. You see, she saw them in their beds so often in
+her dreams that she thought this was just the dream hanging around her
+still.
+
+She sat down in the chair by the fire, where in the old days she had
+nursed them.
+
+They could not understand this, and a cold fear fell upon all the three
+of them.
+
+“Mother!” Wendy cried.
+
+“That’s Wendy,” she said, but still she was sure it was the dream.
+
+“Mother!”
+
+“That’s John,” she said.
+
+“Mother!” cried Michael. He knew her now.
+
+“That’s Michael,” she said, and she stretched out her arms for the three
+little selfish children they would never envelop again. Yes, they did,
+they went round Wendy and John and Michael, who had slipped out of bed
+and run to her.
+
+“George, George!” she cried when she could speak; and Mr. Darling woke
+to share her bliss, and Nana came rushing in. There could not have been
+a lovelier sight; but there was none to see it except a little boy who
+was staring in at the window. He had had ecstasies innumerable that
+other children can never know; but he was looking through the window at
+the one joy from which he must be for ever barred.
+
+
+
+
+Chapter 17 WHEN WENDY GREW UP
+
+I hope you want to know what became of the other boys. They were waiting
+below to give Wendy time to explain about them; and when they had
+counted five hundred they went up. They went up by the stair, because
+they thought this would make a better impression. They stood in a row
+in front of Mrs. Darling, with their hats off, and wishing they were not
+wearing their pirate clothes. They said nothing, but their eyes asked
+her to have them. They ought to have looked at Mr. Darling also, but
+they forgot about him.
+
+Of course Mrs. Darling said at once that she would have them; but Mr.
+Darling was curiously depressed, and they saw that he considered six a
+rather large number.
+
+“I must say,” he said to Wendy, “that you don’t do things by halves,” a
+grudging remark which the twins thought was pointed at them.
+
+The first twin was the proud one, and he asked, flushing, “Do you think
+we should be too much of a handful, sir? Because, if so, we can go
+away.”
+
+“Father!” Wendy cried, shocked; but still the cloud was on him. He knew
+he was behaving unworthily, but he could not help it.
+
+“We could lie doubled up,” said Nibs.
+
+“I always cut their hair myself,” said Wendy.
+
+“George!” Mrs. Darling exclaimed, pained to see her dear one showing
+himself in such an unfavourable light.
+
+Then he burst into tears, and the truth came out. He was as glad to
+have them as she was, he said, but he thought they should have asked his
+consent as well as hers, instead of treating him as a cypher [zero] in
+his own house.
+
+“I don’t think he is a cypher,” Tootles cried instantly. “Do you think
+he is a cypher, Curly?”
+
+“No, I don’t. Do you think he is a cypher, Slightly?”
+
+“Rather not. Twin, what do you think?”
+
+It turned out that not one of them thought him a cypher; and he was
+absurdly gratified, and said he would find space for them all in the
+drawing-room if they fitted in.
+
+“We’ll fit in, sir,” they assured him.
+
+“Then follow the leader,” he cried gaily. “Mind you, I am not sure that
+we have a drawing-room, but we pretend we have, and it’s all the same.
+Hoop la!”
+
+He went off dancing through the house, and they all cried “Hoop la!” and
+danced after him, searching for the drawing-room; and I forget whether
+they found it, but at any rate they found corners, and they all fitted
+in.
+
+As for Peter, he saw Wendy once again before he flew away. He did not
+exactly come to the window, but he brushed against it in passing so that
+she could open it if she liked and call to him. That is what she did.
+
+“Hullo, Wendy, good-bye,” he said.
+
+“Oh dear, are you going away?”
+
+“Yes.”
+
+“You don’t feel, Peter,” she said falteringly, “that you would like to
+say anything to my parents about a very sweet subject?”
+
+“No.”
+
+“About me, Peter?”
+
+“No.”
+
+Mrs. Darling came to the window, for at present she was keeping a sharp
+eye on Wendy. She told Peter that she had adopted all the other boys,
+and would like to adopt him also.
+
+“Would you send me to school?” he inquired craftily.
+
+“Yes.”
+
+“And then to an office?”
+
+“I suppose so.”
+
+“Soon I would be a man?”
+
+“Very soon.”
+
+“I don’t want to go to school and learn solemn things,” he told her
+passionately. “I don’t want to be a man. O Wendy’s mother, if I was to
+wake up and feel there was a beard!”
+
+“Peter,” said Wendy the comforter, “I should love you in a beard;” and
+Mrs. Darling stretched out her arms to him, but he repulsed her.
+
+“Keep back, lady, no one is going to catch me and make me a man.”
+
+“But where are you going to live?”
+
+“With Tink in the house we built for Wendy. The fairies are to put it
+high up among the tree tops where they sleep at nights.”
+
+“How lovely,” cried Wendy so longingly that Mrs. Darling tightened her
+grip.
+
+“I thought all the fairies were dead,” Mrs. Darling said.
+
+“There are always a lot of young ones,” explained Wendy, who was now
+quite an authority, “because you see when a new baby laughs for the
+first time a new fairy is born, and as there are always new babies there
+are always new fairies. They live in nests on the tops of trees; and the
+mauve ones are boys and the white ones are girls, and the blue ones are
+just little sillies who are not sure what they are.”
+
+“I shall have such fun,” said Peter, with eye on Wendy.
+
+“It will be rather lonely in the evening,” she said, “sitting by the
+fire.”
+
+“I shall have Tink.”
+
+“Tink can’t go a twentieth part of the way round,” she reminded him a
+little tartly.
+
+“Sneaky tell-tale!” Tink called out from somewhere round the corner.
+
+“It doesn’t matter,” Peter said.
+
+“O Peter, you know it matters.”
+
+“Well, then, come with me to the little house.”
+
+“May I, mummy?”
+
+“Certainly not. I have got you home again, and I mean to keep you.”
+
+“But he does so need a mother.”
+
+“So do you, my love.”
+
+“Oh, all right,” Peter said, as if he had asked her from politeness
+merely; but Mrs. Darling saw his mouth twitch, and she made this
+handsome offer: to let Wendy go to him for a week every year to do
+his spring cleaning. Wendy would have preferred a more permanent
+arrangement; and it seemed to her that spring would be long in coming;
+but this promise sent Peter away quite gay again. He had no sense of
+time, and was so full of adventures that all I have told you about him
+is only a halfpenny-worth of them. I suppose it was because Wendy knew
+this that her last words to him were these rather plaintive ones:
+
+“You won’t forget me, Peter, will you, before spring cleaning time
+comes?”
+
+Of course Peter promised; and then he flew away. He took Mrs. Darling’s
+kiss with him. The kiss that had been for no one else, Peter took quite
+easily. Funny. But she seemed satisfied.
+
+Of course all the boys went to school; and most of them got into Class
+III, but Slightly was put first into Class IV and then into Class V.
+Class I is the top class. Before they had attended school a week they
+saw what goats they had been not to remain on the island; but it was too
+late now, and soon they settled down to being as ordinary as you or me
+or Jenkins minor [the younger Jenkins]. It is sad to have to say that
+the power to fly gradually left them. At first Nana tied their feet to
+the bed-posts so that they should not fly away in the night; and one of
+their diversions by day was to pretend to fall off buses [the English
+double-deckers]; but by and by they ceased to tug at their bonds in bed,
+and found that they hurt themselves when they let go of the bus. In time
+they could not even fly after their hats. Want of practice, they called
+it; but what it really meant was that they no longer believed.
+
+Michael believed longer than the other boys, though they jeered at him;
+so he was with Wendy when Peter came for her at the end of the first
+year. She flew away with Peter in the frock she had woven from leaves
+and berries in the Neverland, and her one fear was that he might notice
+how short it had become; but he never noticed, he had so much to say
+about himself.
+
+She had looked forward to thrilling talks with him about old times, but
+new adventures had crowded the old ones from his mind.
+
+“Who is Captain Hook?” he asked with interest when she spoke of the arch
+enemy.
+
+“Don’t you remember,” she asked, amazed, “how you killed him and saved
+all our lives?”
+
+“I forget them after I kill them,” he replied carelessly.
+
+When she expressed a doubtful hope that Tinker Bell would be glad to see
+her he said, “Who is Tinker Bell?”
+
+“O Peter,” she said, shocked; but even when she explained he could not
+remember.
+
+“There are such a lot of them,” he said. “I expect she is no more.”
+
+I expect he was right, for fairies don’t live long, but they are so
+little that a short time seems a good while to them.
+
+Wendy was pained too to find that the past year was but as yesterday
+to Peter; it had seemed such a long year of waiting to her. But he was
+exactly as fascinating as ever, and they had a lovely spring cleaning in
+the little house on the tree tops.
+
+Next year he did not come for her. She waited in a new frock because the
+old one simply would not meet; but he never came.
+
+“Perhaps he is ill,” Michael said.
+
+“You know he is never ill.”
+
+Michael came close to her and whispered, with a shiver, “Perhaps there
+is no such person, Wendy!” and then Wendy would have cried if Michael
+had not been crying.
+
+Peter came next spring cleaning; and the strange thing was that he never
+knew he had missed a year.
+
+That was the last time the girl Wendy ever saw him. For a little longer
+she tried for his sake not to have growing pains; and she felt she was
+untrue to him when she got a prize for general knowledge. But the years
+came and went without bringing the careless boy; and when they met again
+Wendy was a married woman, and Peter was no more to her than a little
+dust in the box in which she had kept her toys. Wendy was grown up. You
+need not be sorry for her. She was one of the kind that likes to grow
+up. In the end she grew up of her own free will a day quicker than other
+girls.
+
+All the boys were grown up and done for by this time; so it is scarcely
+worth while saying anything more about them. You may see the twins and
+Nibs and Curly any day going to an office, each carrying a little bag
+and an umbrella. Michael is an engine-driver [train engineer]. Slightly
+married a lady of title, and so he became a lord. You see that judge in
+a wig coming out at the iron door? That used to be Tootles. The bearded
+man who doesn’t know any story to tell his children was once John.
+
+Wendy was married in white with a pink sash. It is strange to think
+that Peter did not alight in the church and forbid the banns [formal
+announcement of a marriage].
+
+Years rolled on again, and Wendy had a daughter. This ought not to be
+written in ink but in a golden splash.
+
+She was called Jane, and always had an odd inquiring look, as if from
+the moment she arrived on the mainland she wanted to ask questions. When
+she was old enough to ask them they were mostly about Peter Pan. She
+loved to hear of Peter, and Wendy told her all she could remember in the
+very nursery from which the famous flight had taken place. It was
+Jane’s nursery now, for her father had bought it at the three per cents
+[mortgage rate] from Wendy’s father, who was no longer fond of stairs.
+Mrs. Darling was now dead and forgotten.
+
+There were only two beds in the nursery now, Jane’s and her nurse’s; and
+there was no kennel, for Nana also had passed away. She died of old age,
+and at the end she had been rather difficult to get on with; being very
+firmly convinced that no one knew how to look after children except
+herself.
+
+Once a week Jane’s nurse had her evening off; and then it was Wendy’s
+part to put Jane to bed. That was the time for stories. It was Jane’s
+invention to raise the sheet over her mother’s head and her own, thus
+making a tent, and in the awful darkness to whisper:
+
+“What do we see now?”
+
+“I don’t think I see anything to-night,” says Wendy, with a feeling that
+if Nana were here she would object to further conversation.
+
+“Yes, you do,” says Jane, “you see when you were a little girl.”
+
+“That is a long time ago, sweetheart,” says Wendy. “Ah me, how time
+flies!”
+
+“Does it fly,” asks the artful child, “the way you flew when you were a
+little girl?”
+
+“The way I flew? Do you know, Jane, I sometimes wonder whether I ever
+did really fly.”
+
+“Yes, you did.”
+
+“The dear old days when I could fly!”
+
+“Why can’t you fly now, mother?”
+
+“Because I am grown up, dearest. When people grow up they forget the
+way.”
+
+“Why do they forget the way?”
+
+“Because they are no longer gay and innocent and heartless. It is only
+the gay and innocent and heartless who can fly.”
+
+“What is gay and innocent and heartless? I do wish I were gay and
+innocent and heartless.”
+
+Or perhaps Wendy admits she does see something.
+
+“I do believe,” she says, “that it is this nursery.”
+
+“I do believe it is,” says Jane. “Go on.”
+
+They are now embarked on the great adventure of the night when Peter
+flew in looking for his shadow.
+
+“The foolish fellow,” says Wendy, “tried to stick it on with soap, and
+when he could not he cried, and that woke me, and I sewed it on for
+him.”
+
+“You have missed a bit,” interrupts Jane, who now knows the story better
+than her mother. “When you saw him sitting on the floor crying, what did
+you say?”
+
+“I sat up in bed and I said, ‘Boy, why are you crying?’”
+
+“Yes, that was it,” says Jane, with a big breath.
+
+“And then he flew us all away to the Neverland and the fairies and the
+pirates and the redskins and the mermaids’ lagoon, and the home under
+the ground, and the little house.”
+
+“Yes! which did you like best of all?”
+
+“I think I liked the home under the ground best of all.”
+
+“Yes, so do I. What was the last thing Peter ever said to you?”
+
+“The last thing he ever said to me was, ‘Just always be waiting for me,
+and then some night you will hear me crowing.’”
+
+“Yes.”
+
+“But, alas, he forgot all about me,” Wendy said it with a smile. She was
+as grown up as that.
+
+“What did his crow sound like?” Jane asked one evening.
+
+“It was like this,” Wendy said, trying to imitate Peter’s crow.
+
+“No, it wasn’t,” Jane said gravely, “it was like this;” and she did it
+ever so much better than her mother.
+
+Wendy was a little startled. “My darling, how can you know?”
+
+“I often hear it when I am sleeping,” Jane said.
+
+“Ah yes, many girls hear it when they are sleeping, but I was the only
+one who heard it awake.”
+
+“Lucky you,” said Jane.
+
+And then one night came the tragedy. It was the spring of the year, and
+the story had been told for the night, and Jane was now asleep in her
+bed. Wendy was sitting on the floor, very close to the fire, so as to
+see to darn, for there was no other light in the nursery; and while she
+sat darning she heard a crow. Then the window blew open as of old, and
+Peter dropped in on the floor.
+
+He was exactly the same as ever, and Wendy saw at once that he still had
+all his first teeth.
+
+He was a little boy, and she was grown up. She huddled by the fire not
+daring to move, helpless and guilty, a big woman.
+
+“Hullo, Wendy,” he said, not noticing any difference, for he was
+thinking chiefly of himself; and in the dim light her white dress might
+have been the nightgown in which he had seen her first.
+
+“Hullo, Peter,” she replied faintly, squeezing herself as small as
+possible. Something inside her was crying “Woman, Woman, let go of me.”
+
+“Hullo, where is John?” he asked, suddenly missing the third bed.
+
+“John is not here now,” she gasped.
+
+“Is Michael asleep?” he asked, with a careless glance at Jane.
+
+“Yes,” she answered; and now she felt that she was untrue to Jane as
+well as to Peter.
+
+“That is not Michael,” she said quickly, lest a judgment should fall on
+her.
+
+Peter looked. “Hullo, is it a new one?”
+
+“Yes.”
+
+“Boy or girl?”
+
+“Girl.”
+
+Now surely he would understand; but not a bit of it.
+
+“Peter,” she said, faltering, “are you expecting me to fly away with
+you?”
+
+“Of course; that is why I have come.” He added a little sternly, “Have
+you forgotten that this is spring cleaning time?”
+
+She knew it was useless to say that he had let many spring cleaning
+times pass.
+
+“I can’t come,” she said apologetically, “I have forgotten how to fly.”
+
+“I’ll soon teach you again.”
+
+“O Peter, don’t waste the fairy dust on me.”
+
+She had risen; and now at last a fear assailed him. “What is it?” he
+cried, shrinking.
+
+“I will turn up the light,” she said, “and then you can see for
+yourself.”
+
+For almost the only time in his life that I know of, Peter was afraid.
+“Don’t turn up the light,” he cried.
+
+She let her hands play in the hair of the tragic boy. She was not a
+little girl heart-broken about him; she was a grown woman smiling at it
+all, but they were wet-eyed smiles.
+
+Then she turned up the light, and Peter saw. He gave a cry of pain; and
+when the tall beautiful creature stooped to lift him in her arms he drew
+back sharply.
+
+“What is it?” he cried again.
+
+She had to tell him.
+
+“I am old, Peter. I am ever so much more than twenty. I grew up long
+ago.”
+
+“You promised not to!”
+
+“I couldn’t help it. I am a married woman, Peter.”
+
+“No, you’re not.”
+
+“Yes, and the little girl in the bed is my baby.”
+
+“No, she’s not.”
+
+But he supposed she was; and he took a step towards the sleeping child
+with his dagger upraised. Of course he did not strike. He sat down on
+the floor instead and sobbed; and Wendy did not know how to comfort him,
+though she could have done it so easily once. She was only a woman now,
+and she ran out of the room to try to think.
+
+Peter continued to cry, and soon his sobs woke Jane. She sat up in bed,
+and was interested at once.
+
+“Boy,” she said, “why are you crying?”
+
+Peter rose and bowed to her, and she bowed to him from the bed.
+
+“Hullo,” he said.
+
+“Hullo,” said Jane.
+
+“My name is Peter Pan,” he told her.
+
+“Yes, I know.”
+
+“I came back for my mother,” he explained, “to take her to the
+Neverland.”
+
+“Yes, I know,” Jane said, “I have been waiting for you.”
+
+When Wendy returned diffidently she found Peter sitting on the bed-post
+crowing gloriously, while Jane in her nighty was flying round the room
+in solemn ecstasy.
+
+“She is my mother,” Peter explained; and Jane descended and stood by his
+side, with the look in her face that he liked to see on ladies when they
+gazed at him.
+
+“He does so need a mother,” Jane said.
+
+“Yes, I know,” Wendy admitted rather forlornly; “no one knows it so well
+as I.”
+
+“Good-bye,” said Peter to Wendy; and he rose in the air, and the
+shameless Jane rose with him; it was already her easiest way of moving
+about.
+
+Wendy rushed to the window.
+
+“No, no,” she cried.
+
+“It is just for spring cleaning time,” Jane said, “he wants me always to
+do his spring cleaning.”
+
+“If only I could go with you,” Wendy sighed.
+
+“You see you can’t fly,” said Jane.
+
+Of course in the end Wendy let them fly away together. Our last glimpse
+of her shows her at the window, watching them receding into the sky
+until they were as small as stars.
+
+As you look at Wendy, you may see her hair becoming white, and her
+figure little again, for all this happened long ago. Jane is now a
+common grown-up, with a daughter called Margaret; and every spring
+cleaning time, except when he forgets, Peter comes for Margaret and
+takes her to the Neverland, where she tells him stories about himself,
+to which he listens eagerly. When Margaret grows up she will have a
+daughter, who is to be Peter’s mother in turn; and thus it will go on,
+so long as children are gay and innocent and heartless.
+
+
+THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Peter Pan, by James M. Barrie
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PETER PAN ***
+
+***** This file should be named 16-0.txt or 16-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/16/
+
+
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in the
+General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You may
+use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://www.gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+This particular work is one of the few copyrighted individual works
+included with the permission of the copyright holder.  Information on
+the copyright owner for this particular work and the terms of use
+imposed by the copyright holder on this work are set forth at the
+beginning of this work.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS,’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Each eBook is in a subdirectory of the same number as the eBook’s
+eBook number, often in several formats including plain vanilla ASCII,
+compressed (zipped), HTML and others.
+
+Corrected EDITIONS of our eBooks replace the old file and take over
+the old filename and etext number.  The replaced older file is renamed.
+VERSIONS based on separate sources are treated as new eBooks receiving
+new filenames and etext numbers.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+EBooks posted prior to November 2003, with eBook numbers BELOW #10000,
+are filed in directories based on their release date.  If you want to
+download any of these eBooks directly, rather than using the regular
+search system you may utilize the following addresses and just
+download by the etext year.
+
+http://www.ibiblio.org/gutenberg/etext06
+
+    (Or /etext 05, 04, 03, 02, 01, 00, 99,
+     98, 97, 96, 95, 94, 93, 92, 92, 91 or 90)
+
+EBooks posted since November 2003, with etext numbers OVER #10000, are
+filed in a different way.  The year of a release date is no longer part
+of the directory path.  The path is based on the etext number (which is
+identical to the filename).  The path to the file is made up of single
+digits corresponding to all but the last digit in the filename.  For
+example an eBook of filename 10234 would be found at:
+
+http://www.gutenberg.org/1/0/2/3/10234
+
+or filename 24689 would be found at:
+http://www.gutenberg.org/2/4/6/8/24689
+
+An alternative method of locating eBooks:
+http://www.gutenberg.org/GUTINDEX.ALL
+
+*** END: FULL LICENSE ***

--- a/jet/tf-idf/src/main/resources/books/pride-and-prejudice.txt
+++ b/jet/tf-idf/src/main/resources/books/pride-and-prejudice.txt
@@ -1,0 +1,13427 @@
+﻿The Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Pride and Prejudice
+
+Author: Jane Austen
+
+Posting Date: August 26, 2008 [EBook #1342]
+Release Date: June, 1998
+Last Updated: October 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+
+
+
+Produced by Anonymous Volunteers
+
+
+
+
+
+PRIDE AND PREJUDICE
+
+By Jane Austen
+
+
+
+Chapter 1
+
+
+It is a truth universally acknowledged, that a single man in possession
+of a good fortune, must be in want of a wife.
+
+However little known the feelings or views of such a man may be on his
+first entering a neighbourhood, this truth is so well fixed in the minds
+of the surrounding families, that he is considered the rightful property
+of some one or other of their daughters.
+
+“My dear Mr. Bennet,” said his lady to him one day, “have you heard that
+Netherfield Park is let at last?”
+
+Mr. Bennet replied that he had not.
+
+“But it is,” returned she; “for Mrs. Long has just been here, and she
+told me all about it.”
+
+Mr. Bennet made no answer.
+
+“Do you not want to know who has taken it?” cried his wife impatiently.
+
+“_You_ want to tell me, and I have no objection to hearing it.”
+
+This was invitation enough.
+
+“Why, my dear, you must know, Mrs. Long says that Netherfield is taken
+by a young man of large fortune from the north of England; that he came
+down on Monday in a chaise and four to see the place, and was so much
+delighted with it, that he agreed with Mr. Morris immediately; that he
+is to take possession before Michaelmas, and some of his servants are to
+be in the house by the end of next week.”
+
+“What is his name?”
+
+“Bingley.”
+
+“Is he married or single?”
+
+“Oh! Single, my dear, to be sure! A single man of large fortune; four or
+five thousand a year. What a fine thing for our girls!”
+
+“How so? How can it affect them?”
+
+“My dear Mr. Bennet,” replied his wife, “how can you be so tiresome! You
+must know that I am thinking of his marrying one of them.”
+
+“Is that his design in settling here?”
+
+“Design! Nonsense, how can you talk so! But it is very likely that he
+_may_ fall in love with one of them, and therefore you must visit him as
+soon as he comes.”
+
+“I see no occasion for that. You and the girls may go, or you may send
+them by themselves, which perhaps will be still better, for as you are
+as handsome as any of them, Mr. Bingley may like you the best of the
+party.”
+
+“My dear, you flatter me. I certainly _have_ had my share of beauty, but
+I do not pretend to be anything extraordinary now. When a woman has five
+grown-up daughters, she ought to give over thinking of her own beauty.”
+
+“In such cases, a woman has not often much beauty to think of.”
+
+“But, my dear, you must indeed go and see Mr. Bingley when he comes into
+the neighbourhood.”
+
+“It is more than I engage for, I assure you.”
+
+“But consider your daughters. Only think what an establishment it would
+be for one of them. Sir William and Lady Lucas are determined to
+go, merely on that account, for in general, you know, they visit no
+newcomers. Indeed you must go, for it will be impossible for _us_ to
+visit him if you do not.”
+
+“You are over-scrupulous, surely. I dare say Mr. Bingley will be very
+glad to see you; and I will send a few lines by you to assure him of my
+hearty consent to his marrying whichever he chooses of the girls; though
+I must throw in a good word for my little Lizzy.”
+
+“I desire you will do no such thing. Lizzy is not a bit better than the
+others; and I am sure she is not half so handsome as Jane, nor half so
+good-humoured as Lydia. But you are always giving _her_ the preference.”
+
+“They have none of them much to recommend them,” replied he; “they are
+all silly and ignorant like other girls; but Lizzy has something more of
+quickness than her sisters.”
+
+“Mr. Bennet, how _can_ you abuse your own children in such a way? You
+take delight in vexing me. You have no compassion for my poor nerves.”
+
+“You mistake me, my dear. I have a high respect for your nerves. They
+are my old friends. I have heard you mention them with consideration
+these last twenty years at least.”
+
+“Ah, you do not know what I suffer.”
+
+“But I hope you will get over it, and live to see many young men of four
+thousand a year come into the neighbourhood.”
+
+“It will be no use to us, if twenty such should come, since you will not
+visit them.”
+
+“Depend upon it, my dear, that when there are twenty, I will visit them
+all.”
+
+Mr. Bennet was so odd a mixture of quick parts, sarcastic humour,
+reserve, and caprice, that the experience of three-and-twenty years had
+been insufficient to make his wife understand his character. _Her_ mind
+was less difficult to develop. She was a woman of mean understanding,
+little information, and uncertain temper. When she was discontented,
+she fancied herself nervous. The business of her life was to get her
+daughters married; its solace was visiting and news.
+
+
+
+Chapter 2
+
+
+Mr. Bennet was among the earliest of those who waited on Mr. Bingley. He
+had always intended to visit him, though to the last always assuring
+his wife that he should not go; and till the evening after the visit was
+paid she had no knowledge of it. It was then disclosed in the following
+manner. Observing his second daughter employed in trimming a hat, he
+suddenly addressed her with:
+
+“I hope Mr. Bingley will like it, Lizzy.”
+
+“We are not in a way to know _what_ Mr. Bingley likes,” said her mother
+resentfully, “since we are not to visit.”
+
+“But you forget, mamma,” said Elizabeth, “that we shall meet him at the
+assemblies, and that Mrs. Long promised to introduce him.”
+
+“I do not believe Mrs. Long will do any such thing. She has two nieces
+of her own. She is a selfish, hypocritical woman, and I have no opinion
+of her.”
+
+“No more have I,” said Mr. Bennet; “and I am glad to find that you do
+not depend on her serving you.”
+
+Mrs. Bennet deigned not to make any reply, but, unable to contain
+herself, began scolding one of her daughters.
+
+“Don’t keep coughing so, Kitty, for Heaven’s sake! Have a little
+compassion on my nerves. You tear them to pieces.”
+
+“Kitty has no discretion in her coughs,” said her father; “she times
+them ill.”
+
+“I do not cough for my own amusement,” replied Kitty fretfully. “When is
+your next ball to be, Lizzy?”
+
+“To-morrow fortnight.”
+
+“Aye, so it is,” cried her mother, “and Mrs. Long does not come back
+till the day before; so it will be impossible for her to introduce him,
+for she will not know him herself.”
+
+“Then, my dear, you may have the advantage of your friend, and introduce
+Mr. Bingley to _her_.”
+
+“Impossible, Mr. Bennet, impossible, when I am not acquainted with him
+myself; how can you be so teasing?”
+
+“I honour your circumspection. A fortnight’s acquaintance is certainly
+very little. One cannot know what a man really is by the end of a
+fortnight. But if _we_ do not venture somebody else will; and after all,
+Mrs. Long and her neices must stand their chance; and, therefore, as
+she will think it an act of kindness, if you decline the office, I will
+take it on myself.”
+
+The girls stared at their father. Mrs. Bennet said only, “Nonsense,
+nonsense!”
+
+“What can be the meaning of that emphatic exclamation?” cried he. “Do
+you consider the forms of introduction, and the stress that is laid on
+them, as nonsense? I cannot quite agree with you _there_. What say you,
+Mary? For you are a young lady of deep reflection, I know, and read
+great books and make extracts.”
+
+Mary wished to say something sensible, but knew not how.
+
+“While Mary is adjusting her ideas,” he continued, “let us return to Mr.
+Bingley.”
+
+“I am sick of Mr. Bingley,” cried his wife.
+
+“I am sorry to hear _that_; but why did not you tell me that before? If
+I had known as much this morning I certainly would not have called
+on him. It is very unlucky; but as I have actually paid the visit, we
+cannot escape the acquaintance now.”
+
+The astonishment of the ladies was just what he wished; that of Mrs.
+Bennet perhaps surpassing the rest; though, when the first tumult of joy
+was over, she began to declare that it was what she had expected all the
+while.
+
+“How good it was in you, my dear Mr. Bennet! But I knew I should
+persuade you at last. I was sure you loved your girls too well to
+neglect such an acquaintance. Well, how pleased I am! and it is such a
+good joke, too, that you should have gone this morning and never said a
+word about it till now.”
+
+“Now, Kitty, you may cough as much as you choose,” said Mr. Bennet; and,
+as he spoke, he left the room, fatigued with the raptures of his wife.
+
+“What an excellent father you have, girls!” said she, when the door was
+shut. “I do not know how you will ever make him amends for his kindness;
+or me, either, for that matter. At our time of life it is not so
+pleasant, I can tell you, to be making new acquaintances every day; but
+for your sakes, we would do anything. Lydia, my love, though you _are_
+the youngest, I dare say Mr. Bingley will dance with you at the next
+ball.”
+
+“Oh!” said Lydia stoutly, “I am not afraid; for though I _am_ the
+youngest, I’m the tallest.”
+
+The rest of the evening was spent in conjecturing how soon he would
+return Mr. Bennet’s visit, and determining when they should ask him to
+dinner.
+
+
+
+Chapter 3
+
+
+Not all that Mrs. Bennet, however, with the assistance of her five
+daughters, could ask on the subject, was sufficient to draw from her
+husband any satisfactory description of Mr. Bingley. They attacked him
+in various ways--with barefaced questions, ingenious suppositions, and
+distant surmises; but he eluded the skill of them all, and they were at
+last obliged to accept the second-hand intelligence of their neighbour,
+Lady Lucas. Her report was highly favourable. Sir William had been
+delighted with him. He was quite young, wonderfully handsome, extremely
+agreeable, and, to crown the whole, he meant to be at the next assembly
+with a large party. Nothing could be more delightful! To be fond of
+dancing was a certain step towards falling in love; and very lively
+hopes of Mr. Bingley’s heart were entertained.
+
+“If I can but see one of my daughters happily settled at Netherfield,”
+ said Mrs. Bennet to her husband, “and all the others equally well
+married, I shall have nothing to wish for.”
+
+In a few days Mr. Bingley returned Mr. Bennet’s visit, and sat about
+ten minutes with him in his library. He had entertained hopes of being
+admitted to a sight of the young ladies, of whose beauty he had
+heard much; but he saw only the father. The ladies were somewhat more
+fortunate, for they had the advantage of ascertaining from an upper
+window that he wore a blue coat, and rode a black horse.
+
+An invitation to dinner was soon afterwards dispatched; and already
+had Mrs. Bennet planned the courses that were to do credit to her
+housekeeping, when an answer arrived which deferred it all. Mr. Bingley
+was obliged to be in town the following day, and, consequently, unable
+to accept the honour of their invitation, etc. Mrs. Bennet was quite
+disconcerted. She could not imagine what business he could have in town
+so soon after his arrival in Hertfordshire; and she began to fear that
+he might be always flying about from one place to another, and never
+settled at Netherfield as he ought to be. Lady Lucas quieted her fears
+a little by starting the idea of his being gone to London only to get
+a large party for the ball; and a report soon followed that Mr. Bingley
+was to bring twelve ladies and seven gentlemen with him to the assembly.
+The girls grieved over such a number of ladies, but were comforted the
+day before the ball by hearing, that instead of twelve he brought only
+six with him from London--his five sisters and a cousin. And when
+the party entered the assembly room it consisted of only five
+altogether--Mr. Bingley, his two sisters, the husband of the eldest, and
+another young man.
+
+Mr. Bingley was good-looking and gentlemanlike; he had a pleasant
+countenance, and easy, unaffected manners. His sisters were fine women,
+with an air of decided fashion. His brother-in-law, Mr. Hurst, merely
+looked the gentleman; but his friend Mr. Darcy soon drew the attention
+of the room by his fine, tall person, handsome features, noble mien, and
+the report which was in general circulation within five minutes
+after his entrance, of his having ten thousand a year. The gentlemen
+pronounced him to be a fine figure of a man, the ladies declared he
+was much handsomer than Mr. Bingley, and he was looked at with great
+admiration for about half the evening, till his manners gave a disgust
+which turned the tide of his popularity; for he was discovered to be
+proud; to be above his company, and above being pleased; and not all
+his large estate in Derbyshire could then save him from having a most
+forbidding, disagreeable countenance, and being unworthy to be compared
+with his friend.
+
+Mr. Bingley had soon made himself acquainted with all the principal
+people in the room; he was lively and unreserved, danced every dance,
+was angry that the ball closed so early, and talked of giving
+one himself at Netherfield. Such amiable qualities must speak for
+themselves. What a contrast between him and his friend! Mr. Darcy danced
+only once with Mrs. Hurst and once with Miss Bingley, declined being
+introduced to any other lady, and spent the rest of the evening in
+walking about the room, speaking occasionally to one of his own party.
+His character was decided. He was the proudest, most disagreeable man
+in the world, and everybody hoped that he would never come there again.
+Amongst the most violent against him was Mrs. Bennet, whose dislike of
+his general behaviour was sharpened into particular resentment by his
+having slighted one of her daughters.
+
+Elizabeth Bennet had been obliged, by the scarcity of gentlemen, to sit
+down for two dances; and during part of that time, Mr. Darcy had been
+standing near enough for her to hear a conversation between him and Mr.
+Bingley, who came from the dance for a few minutes, to press his friend
+to join it.
+
+“Come, Darcy,” said he, “I must have you dance. I hate to see you
+standing about by yourself in this stupid manner. You had much better
+dance.”
+
+“I certainly shall not. You know how I detest it, unless I am
+particularly acquainted with my partner. At such an assembly as this
+it would be insupportable. Your sisters are engaged, and there is not
+another woman in the room whom it would not be a punishment to me to
+stand up with.”
+
+“I would not be so fastidious as you are,” cried Mr. Bingley, “for a
+kingdom! Upon my honour, I never met with so many pleasant girls in
+my life as I have this evening; and there are several of them you see
+uncommonly pretty.”
+
+“_You_ are dancing with the only handsome girl in the room,” said Mr.
+Darcy, looking at the eldest Miss Bennet.
+
+“Oh! She is the most beautiful creature I ever beheld! But there is one
+of her sisters sitting down just behind you, who is very pretty, and I
+dare say very agreeable. Do let me ask my partner to introduce you.”
+
+“Which do you mean?” and turning round he looked for a moment at
+Elizabeth, till catching her eye, he withdrew his own and coldly said:
+“She is tolerable, but not handsome enough to tempt _me_; I am in no
+humour at present to give consequence to young ladies who are slighted
+by other men. You had better return to your partner and enjoy her
+smiles, for you are wasting your time with me.”
+
+Mr. Bingley followed his advice. Mr. Darcy walked off; and Elizabeth
+remained with no very cordial feelings toward him. She told the story,
+however, with great spirit among her friends; for she had a lively,
+playful disposition, which delighted in anything ridiculous.
+
+The evening altogether passed off pleasantly to the whole family. Mrs.
+Bennet had seen her eldest daughter much admired by the Netherfield
+party. Mr. Bingley had danced with her twice, and she had been
+distinguished by his sisters. Jane was as much gratified by this as
+her mother could be, though in a quieter way. Elizabeth felt Jane’s
+pleasure. Mary had heard herself mentioned to Miss Bingley as the most
+accomplished girl in the neighbourhood; and Catherine and Lydia had been
+fortunate enough never to be without partners, which was all that they
+had yet learnt to care for at a ball. They returned, therefore, in good
+spirits to Longbourn, the village where they lived, and of which they
+were the principal inhabitants. They found Mr. Bennet still up. With
+a book he was regardless of time; and on the present occasion he had a
+good deal of curiosity as to the event of an evening which had raised
+such splendid expectations. He had rather hoped that his wife’s views on
+the stranger would be disappointed; but he soon found out that he had a
+different story to hear.
+
+“Oh! my dear Mr. Bennet,” as she entered the room, “we have had a most
+delightful evening, a most excellent ball. I wish you had been there.
+Jane was so admired, nothing could be like it. Everybody said how well
+she looked; and Mr. Bingley thought her quite beautiful, and danced with
+her twice! Only think of _that_, my dear; he actually danced with her
+twice! and she was the only creature in the room that he asked a second
+time. First of all, he asked Miss Lucas. I was so vexed to see him stand
+up with her! But, however, he did not admire her at all; indeed, nobody
+can, you know; and he seemed quite struck with Jane as she was going
+down the dance. So he inquired who she was, and got introduced, and
+asked her for the two next. Then the two third he danced with Miss King,
+and the two fourth with Maria Lucas, and the two fifth with Jane again,
+and the two sixth with Lizzy, and the _Boulanger_--”
+
+“If he had had any compassion for _me_,” cried her husband impatiently,
+“he would not have danced half so much! For God’s sake, say no more of
+his partners. Oh that he had sprained his ankle in the first dance!”
+
+“Oh! my dear, I am quite delighted with him. He is so excessively
+handsome! And his sisters are charming women. I never in my life saw
+anything more elegant than their dresses. I dare say the lace upon Mrs.
+Hurst’s gown--”
+
+Here she was interrupted again. Mr. Bennet protested against any
+description of finery. She was therefore obliged to seek another branch
+of the subject, and related, with much bitterness of spirit and some
+exaggeration, the shocking rudeness of Mr. Darcy.
+
+“But I can assure you,” she added, “that Lizzy does not lose much by not
+suiting _his_ fancy; for he is a most disagreeable, horrid man, not at
+all worth pleasing. So high and so conceited that there was no enduring
+him! He walked here, and he walked there, fancying himself so very
+great! Not handsome enough to dance with! I wish you had been there, my
+dear, to have given him one of your set-downs. I quite detest the man.”
+
+
+
+Chapter 4
+
+
+When Jane and Elizabeth were alone, the former, who had been cautious in
+her praise of Mr. Bingley before, expressed to her sister just how very
+much she admired him.
+
+“He is just what a young man ought to be,” said she, “sensible,
+good-humoured, lively; and I never saw such happy manners!--so much
+ease, with such perfect good breeding!”
+
+“He is also handsome,” replied Elizabeth, “which a young man ought
+likewise to be, if he possibly can. His character is thereby complete.”
+
+“I was very much flattered by his asking me to dance a second time. I
+did not expect such a compliment.”
+
+“Did not you? I did for you. But that is one great difference between
+us. Compliments always take _you_ by surprise, and _me_ never. What
+could be more natural than his asking you again? He could not help
+seeing that you were about five times as pretty as every other woman
+in the room. No thanks to his gallantry for that. Well, he certainly is
+very agreeable, and I give you leave to like him. You have liked many a
+stupider person.”
+
+“Dear Lizzy!”
+
+“Oh! you are a great deal too apt, you know, to like people in general.
+You never see a fault in anybody. All the world are good and agreeable
+in your eyes. I never heard you speak ill of a human being in your
+life.”
+
+“I would not wish to be hasty in censuring anyone; but I always speak
+what I think.”
+
+“I know you do; and it is _that_ which makes the wonder. With _your_
+good sense, to be so honestly blind to the follies and nonsense of
+others! Affectation of candour is common enough--one meets with it
+everywhere. But to be candid without ostentation or design--to take the
+good of everybody’s character and make it still better, and say nothing
+of the bad--belongs to you alone. And so you like this man’s sisters,
+too, do you? Their manners are not equal to his.”
+
+“Certainly not--at first. But they are very pleasing women when you
+converse with them. Miss Bingley is to live with her brother, and keep
+his house; and I am much mistaken if we shall not find a very charming
+neighbour in her.”
+
+Elizabeth listened in silence, but was not convinced; their behaviour at
+the assembly had not been calculated to please in general; and with more
+quickness of observation and less pliancy of temper than her sister,
+and with a judgement too unassailed by any attention to herself, she
+was very little disposed to approve them. They were in fact very fine
+ladies; not deficient in good humour when they were pleased, nor in the
+power of making themselves agreeable when they chose it, but proud and
+conceited. They were rather handsome, had been educated in one of the
+first private seminaries in town, had a fortune of twenty thousand
+pounds, were in the habit of spending more than they ought, and of
+associating with people of rank, and were therefore in every respect
+entitled to think well of themselves, and meanly of others. They were of
+a respectable family in the north of England; a circumstance more deeply
+impressed on their memories than that their brother’s fortune and their
+own had been acquired by trade.
+
+Mr. Bingley inherited property to the amount of nearly a hundred
+thousand pounds from his father, who had intended to purchase an
+estate, but did not live to do it. Mr. Bingley intended it likewise, and
+sometimes made choice of his county; but as he was now provided with a
+good house and the liberty of a manor, it was doubtful to many of those
+who best knew the easiness of his temper, whether he might not spend the
+remainder of his days at Netherfield, and leave the next generation to
+purchase.
+
+His sisters were anxious for his having an estate of his own; but,
+though he was now only established as a tenant, Miss Bingley was by no
+means unwilling to preside at his table--nor was Mrs. Hurst, who had
+married a man of more fashion than fortune, less disposed to consider
+his house as her home when it suited her. Mr. Bingley had not been of
+age two years, when he was tempted by an accidental recommendation
+to look at Netherfield House. He did look at it, and into it for
+half-an-hour--was pleased with the situation and the principal
+rooms, satisfied with what the owner said in its praise, and took it
+immediately.
+
+Between him and Darcy there was a very steady friendship, in spite of
+great opposition of character. Bingley was endeared to Darcy by the
+easiness, openness, and ductility of his temper, though no disposition
+could offer a greater contrast to his own, and though with his own he
+never appeared dissatisfied. On the strength of Darcy’s regard, Bingley
+had the firmest reliance, and of his judgement the highest opinion.
+In understanding, Darcy was the superior. Bingley was by no means
+deficient, but Darcy was clever. He was at the same time haughty,
+reserved, and fastidious, and his manners, though well-bred, were not
+inviting. In that respect his friend had greatly the advantage. Bingley
+was sure of being liked wherever he appeared, Darcy was continually
+giving offense.
+
+The manner in which they spoke of the Meryton assembly was sufficiently
+characteristic. Bingley had never met with more pleasant people or
+prettier girls in his life; everybody had been most kind and attentive
+to him; there had been no formality, no stiffness; he had soon felt
+acquainted with all the room; and, as to Miss Bennet, he could not
+conceive an angel more beautiful. Darcy, on the contrary, had seen a
+collection of people in whom there was little beauty and no fashion, for
+none of whom he had felt the smallest interest, and from none received
+either attention or pleasure. Miss Bennet he acknowledged to be pretty,
+but she smiled too much.
+
+Mrs. Hurst and her sister allowed it to be so--but still they admired
+her and liked her, and pronounced her to be a sweet girl, and one
+whom they would not object to know more of. Miss Bennet was therefore
+established as a sweet girl, and their brother felt authorized by such
+commendation to think of her as he chose.
+
+
+
+Chapter 5
+
+
+Within a short walk of Longbourn lived a family with whom the Bennets
+were particularly intimate. Sir William Lucas had been formerly in trade
+in Meryton, where he had made a tolerable fortune, and risen to the
+honour of knighthood by an address to the king during his mayoralty.
+The distinction had perhaps been felt too strongly. It had given him a
+disgust to his business, and to his residence in a small market town;
+and, in quitting them both, he had removed with his family to a house
+about a mile from Meryton, denominated from that period Lucas Lodge,
+where he could think with pleasure of his own importance, and,
+unshackled by business, occupy himself solely in being civil to all
+the world. For, though elated by his rank, it did not render him
+supercilious; on the contrary, he was all attention to everybody. By
+nature inoffensive, friendly, and obliging, his presentation at St.
+James’s had made him courteous.
+
+Lady Lucas was a very good kind of woman, not too clever to be a
+valuable neighbour to Mrs. Bennet. They had several children. The eldest
+of them, a sensible, intelligent young woman, about twenty-seven, was
+Elizabeth’s intimate friend.
+
+That the Miss Lucases and the Miss Bennets should meet to talk over
+a ball was absolutely necessary; and the morning after the assembly
+brought the former to Longbourn to hear and to communicate.
+
+“_You_ began the evening well, Charlotte,” said Mrs. Bennet with civil
+self-command to Miss Lucas. “_You_ were Mr. Bingley’s first choice.”
+
+“Yes; but he seemed to like his second better.”
+
+“Oh! you mean Jane, I suppose, because he danced with her twice. To be
+sure that _did_ seem as if he admired her--indeed I rather believe he
+_did_--I heard something about it--but I hardly know what--something
+about Mr. Robinson.”
+
+“Perhaps you mean what I overheard between him and Mr. Robinson; did not
+I mention it to you? Mr. Robinson’s asking him how he liked our Meryton
+assemblies, and whether he did not think there were a great many
+pretty women in the room, and _which_ he thought the prettiest? and his
+answering immediately to the last question: ‘Oh! the eldest Miss Bennet,
+beyond a doubt; there cannot be two opinions on that point.’”
+
+“Upon my word! Well, that is very decided indeed--that does seem as
+if--but, however, it may all come to nothing, you know.”
+
+“_My_ overhearings were more to the purpose than _yours_, Eliza,” said
+Charlotte. “Mr. Darcy is not so well worth listening to as his friend,
+is he?--poor Eliza!--to be only just _tolerable_.”
+
+“I beg you would not put it into Lizzy’s head to be vexed by his
+ill-treatment, for he is such a disagreeable man, that it would be quite
+a misfortune to be liked by him. Mrs. Long told me last night that he
+sat close to her for half-an-hour without once opening his lips.”
+
+“Are you quite sure, ma’am?--is not there a little mistake?” said Jane.
+“I certainly saw Mr. Darcy speaking to her.”
+
+“Aye--because she asked him at last how he liked Netherfield, and he
+could not help answering her; but she said he seemed quite angry at
+being spoke to.”
+
+“Miss Bingley told me,” said Jane, “that he never speaks much,
+unless among his intimate acquaintances. With _them_ he is remarkably
+agreeable.”
+
+“I do not believe a word of it, my dear. If he had been so very
+agreeable, he would have talked to Mrs. Long. But I can guess how it
+was; everybody says that he is eat up with pride, and I dare say he had
+heard somehow that Mrs. Long does not keep a carriage, and had come to
+the ball in a hack chaise.”
+
+“I do not mind his not talking to Mrs. Long,” said Miss Lucas, “but I
+wish he had danced with Eliza.”
+
+“Another time, Lizzy,” said her mother, “I would not dance with _him_,
+if I were you.”
+
+“I believe, ma’am, I may safely promise you _never_ to dance with him.”
+
+“His pride,” said Miss Lucas, “does not offend _me_ so much as pride
+often does, because there is an excuse for it. One cannot wonder that so
+very fine a young man, with family, fortune, everything in his favour,
+should think highly of himself. If I may so express it, he has a _right_
+to be proud.”
+
+“That is very true,” replied Elizabeth, “and I could easily forgive
+_his_ pride, if he had not mortified _mine_.”
+
+“Pride,” observed Mary, who piqued herself upon the solidity of her
+reflections, “is a very common failing, I believe. By all that I have
+ever read, I am convinced that it is very common indeed; that human
+nature is particularly prone to it, and that there are very few of us
+who do not cherish a feeling of self-complacency on the score of some
+quality or other, real or imaginary. Vanity and pride are different
+things, though the words are often used synonymously. A person may
+be proud without being vain. Pride relates more to our opinion of
+ourselves, vanity to what we would have others think of us.”
+
+“If I were as rich as Mr. Darcy,” cried a young Lucas, who came with
+his sisters, “I should not care how proud I was. I would keep a pack of
+foxhounds, and drink a bottle of wine a day.”
+
+“Then you would drink a great deal more than you ought,” said Mrs.
+Bennet; “and if I were to see you at it, I should take away your bottle
+directly.”
+
+The boy protested that she should not; she continued to declare that she
+would, and the argument ended only with the visit.
+
+
+
+Chapter 6
+
+
+The ladies of Longbourn soon waited on those of Netherfield. The visit
+was soon returned in due form. Miss Bennet’s pleasing manners grew on
+the goodwill of Mrs. Hurst and Miss Bingley; and though the mother was
+found to be intolerable, and the younger sisters not worth speaking to,
+a wish of being better acquainted with _them_ was expressed towards
+the two eldest. By Jane, this attention was received with the greatest
+pleasure, but Elizabeth still saw superciliousness in their treatment
+of everybody, hardly excepting even her sister, and could not like them;
+though their kindness to Jane, such as it was, had a value as arising in
+all probability from the influence of their brother’s admiration. It
+was generally evident whenever they met, that he _did_ admire her and
+to _her_ it was equally evident that Jane was yielding to the preference
+which she had begun to entertain for him from the first, and was in a
+way to be very much in love; but she considered with pleasure that it
+was not likely to be discovered by the world in general, since Jane
+united, with great strength of feeling, a composure of temper and a
+uniform cheerfulness of manner which would guard her from the suspicions
+of the impertinent. She mentioned this to her friend Miss Lucas.
+
+“It may perhaps be pleasant,” replied Charlotte, “to be able to impose
+on the public in such a case; but it is sometimes a disadvantage to be
+so very guarded. If a woman conceals her affection with the same skill
+from the object of it, she may lose the opportunity of fixing him; and
+it will then be but poor consolation to believe the world equally in
+the dark. There is so much of gratitude or vanity in almost every
+attachment, that it is not safe to leave any to itself. We can all
+_begin_ freely--a slight preference is natural enough; but there are
+very few of us who have heart enough to be really in love without
+encouragement. In nine cases out of ten a women had better show _more_
+affection than she feels. Bingley likes your sister undoubtedly; but he
+may never do more than like her, if she does not help him on.”
+
+“But she does help him on, as much as her nature will allow. If I can
+perceive her regard for him, he must be a simpleton, indeed, not to
+discover it too.”
+
+“Remember, Eliza, that he does not know Jane’s disposition as you do.”
+
+“But if a woman is partial to a man, and does not endeavour to conceal
+it, he must find it out.”
+
+“Perhaps he must, if he sees enough of her. But, though Bingley and Jane
+meet tolerably often, it is never for many hours together; and, as they
+always see each other in large mixed parties, it is impossible that
+every moment should be employed in conversing together. Jane should
+therefore make the most of every half-hour in which she can command his
+attention. When she is secure of him, there will be more leisure for
+falling in love as much as she chooses.”
+
+“Your plan is a good one,” replied Elizabeth, “where nothing is in
+question but the desire of being well married, and if I were determined
+to get a rich husband, or any husband, I dare say I should adopt it. But
+these are not Jane’s feelings; she is not acting by design. As yet,
+she cannot even be certain of the degree of her own regard nor of its
+reasonableness. She has known him only a fortnight. She danced four
+dances with him at Meryton; she saw him one morning at his own house,
+and has since dined with him in company four times. This is not quite
+enough to make her understand his character.”
+
+“Not as you represent it. Had she merely _dined_ with him, she might
+only have discovered whether he had a good appetite; but you must
+remember that four evenings have also been spent together--and four
+evenings may do a great deal.”
+
+“Yes; these four evenings have enabled them to ascertain that they
+both like Vingt-un better than Commerce; but with respect to any other
+leading characteristic, I do not imagine that much has been unfolded.”
+
+“Well,” said Charlotte, “I wish Jane success with all my heart; and
+if she were married to him to-morrow, I should think she had as good a
+chance of happiness as if she were to be studying his character for a
+twelvemonth. Happiness in marriage is entirely a matter of chance. If
+the dispositions of the parties are ever so well known to each other or
+ever so similar beforehand, it does not advance their felicity in the
+least. They always continue to grow sufficiently unlike afterwards to
+have their share of vexation; and it is better to know as little as
+possible of the defects of the person with whom you are to pass your
+life.”
+
+“You make me laugh, Charlotte; but it is not sound. You know it is not
+sound, and that you would never act in this way yourself.”
+
+Occupied in observing Mr. Bingley’s attentions to her sister, Elizabeth
+was far from suspecting that she was herself becoming an object of some
+interest in the eyes of his friend. Mr. Darcy had at first scarcely
+allowed her to be pretty; he had looked at her without admiration at the
+ball; and when they next met, he looked at her only to criticise. But no
+sooner had he made it clear to himself and his friends that she hardly
+had a good feature in her face, than he began to find it was rendered
+uncommonly intelligent by the beautiful expression of her dark eyes. To
+this discovery succeeded some others equally mortifying. Though he had
+detected with a critical eye more than one failure of perfect symmetry
+in her form, he was forced to acknowledge her figure to be light and
+pleasing; and in spite of his asserting that her manners were not those
+of the fashionable world, he was caught by their easy playfulness. Of
+this she was perfectly unaware; to her he was only the man who made
+himself agreeable nowhere, and who had not thought her handsome enough
+to dance with.
+
+He began to wish to know more of her, and as a step towards conversing
+with her himself, attended to her conversation with others. His doing so
+drew her notice. It was at Sir William Lucas’s, where a large party were
+assembled.
+
+“What does Mr. Darcy mean,” said she to Charlotte, “by listening to my
+conversation with Colonel Forster?”
+
+“That is a question which Mr. Darcy only can answer.”
+
+“But if he does it any more I shall certainly let him know that I see
+what he is about. He has a very satirical eye, and if I do not begin by
+being impertinent myself, I shall soon grow afraid of him.”
+
+On his approaching them soon afterwards, though without seeming to have
+any intention of speaking, Miss Lucas defied her friend to mention such
+a subject to him; which immediately provoking Elizabeth to do it, she
+turned to him and said:
+
+“Did you not think, Mr. Darcy, that I expressed myself uncommonly
+well just now, when I was teasing Colonel Forster to give us a ball at
+Meryton?”
+
+“With great energy; but it is always a subject which makes a lady
+energetic.”
+
+“You are severe on us.”
+
+“It will be _her_ turn soon to be teased,” said Miss Lucas. “I am going
+to open the instrument, Eliza, and you know what follows.”
+
+“You are a very strange creature by way of a friend!--always wanting me
+to play and sing before anybody and everybody! If my vanity had taken
+a musical turn, you would have been invaluable; but as it is, I would
+really rather not sit down before those who must be in the habit of
+hearing the very best performers.” On Miss Lucas’s persevering, however,
+she added, “Very well, if it must be so, it must.” And gravely glancing
+at Mr. Darcy, “There is a fine old saying, which everybody here is of
+course familiar with: ‘Keep your breath to cool your porridge’; and I
+shall keep mine to swell my song.”
+
+Her performance was pleasing, though by no means capital. After a song
+or two, and before she could reply to the entreaties of several that
+she would sing again, she was eagerly succeeded at the instrument by her
+sister Mary, who having, in consequence of being the only plain one in
+the family, worked hard for knowledge and accomplishments, was always
+impatient for display.
+
+Mary had neither genius nor taste; and though vanity had given her
+application, it had given her likewise a pedantic air and conceited
+manner, which would have injured a higher degree of excellence than she
+had reached. Elizabeth, easy and unaffected, had been listened to with
+much more pleasure, though not playing half so well; and Mary, at the
+end of a long concerto, was glad to purchase praise and gratitude by
+Scotch and Irish airs, at the request of her younger sisters, who,
+with some of the Lucases, and two or three officers, joined eagerly in
+dancing at one end of the room.
+
+Mr. Darcy stood near them in silent indignation at such a mode of
+passing the evening, to the exclusion of all conversation, and was too
+much engrossed by his thoughts to perceive that Sir William Lucas was
+his neighbour, till Sir William thus began:
+
+“What a charming amusement for young people this is, Mr. Darcy! There
+is nothing like dancing after all. I consider it as one of the first
+refinements of polished society.”
+
+“Certainly, sir; and it has the advantage also of being in vogue amongst
+the less polished societies of the world. Every savage can dance.”
+
+Sir William only smiled. “Your friend performs delightfully,” he
+continued after a pause, on seeing Bingley join the group; “and I doubt
+not that you are an adept in the science yourself, Mr. Darcy.”
+
+“You saw me dance at Meryton, I believe, sir.”
+
+“Yes, indeed, and received no inconsiderable pleasure from the sight. Do
+you often dance at St. James’s?”
+
+“Never, sir.”
+
+“Do you not think it would be a proper compliment to the place?”
+
+“It is a compliment which I never pay to any place if I can avoid it.”
+
+“You have a house in town, I conclude?”
+
+Mr. Darcy bowed.
+
+“I had once had some thought of fixing in town myself--for I am fond
+of superior society; but I did not feel quite certain that the air of
+London would agree with Lady Lucas.”
+
+He paused in hopes of an answer; but his companion was not disposed
+to make any; and Elizabeth at that instant moving towards them, he was
+struck with the action of doing a very gallant thing, and called out to
+her:
+
+“My dear Miss Eliza, why are you not dancing? Mr. Darcy, you must allow
+me to present this young lady to you as a very desirable partner. You
+cannot refuse to dance, I am sure when so much beauty is before you.”
+ And, taking her hand, he would have given it to Mr. Darcy who, though
+extremely surprised, was not unwilling to receive it, when she instantly
+drew back, and said with some discomposure to Sir William:
+
+“Indeed, sir, I have not the least intention of dancing. I entreat you
+not to suppose that I moved this way in order to beg for a partner.”
+
+Mr. Darcy, with grave propriety, requested to be allowed the honour of
+her hand, but in vain. Elizabeth was determined; nor did Sir William at
+all shake her purpose by his attempt at persuasion.
+
+“You excel so much in the dance, Miss Eliza, that it is cruel to deny
+me the happiness of seeing you; and though this gentleman dislikes the
+amusement in general, he can have no objection, I am sure, to oblige us
+for one half-hour.”
+
+“Mr. Darcy is all politeness,” said Elizabeth, smiling.
+
+“He is, indeed; but, considering the inducement, my dear Miss Eliza,
+we cannot wonder at his complaisance--for who would object to such a
+partner?”
+
+Elizabeth looked archly, and turned away. Her resistance had not
+injured her with the gentleman, and he was thinking of her with some
+complacency, when thus accosted by Miss Bingley:
+
+“I can guess the subject of your reverie.”
+
+“I should imagine not.”
+
+“You are considering how insupportable it would be to pass many evenings
+in this manner--in such society; and indeed I am quite of your opinion.
+I was never more annoyed! The insipidity, and yet the noise--the
+nothingness, and yet the self-importance of all those people! What would
+I give to hear your strictures on them!”
+
+“Your conjecture is totally wrong, I assure you. My mind was more
+agreeably engaged. I have been meditating on the very great pleasure
+which a pair of fine eyes in the face of a pretty woman can bestow.”
+
+Miss Bingley immediately fixed her eyes on his face, and desired he
+would tell her what lady had the credit of inspiring such reflections.
+Mr. Darcy replied with great intrepidity:
+
+“Miss Elizabeth Bennet.”
+
+“Miss Elizabeth Bennet!” repeated Miss Bingley. “I am all astonishment.
+How long has she been such a favourite?--and pray, when am I to wish you
+joy?”
+
+“That is exactly the question which I expected you to ask. A lady’s
+imagination is very rapid; it jumps from admiration to love, from love
+to matrimony, in a moment. I knew you would be wishing me joy.”
+
+“Nay, if you are serious about it, I shall consider the matter is
+absolutely settled. You will be having a charming mother-in-law, indeed;
+and, of course, she will always be at Pemberley with you.”
+
+He listened to her with perfect indifference while she chose to
+entertain herself in this manner; and as his composure convinced her
+that all was safe, her wit flowed long.
+
+
+
+Chapter 7
+
+
+Mr. Bennet’s property consisted almost entirely in an estate of two
+thousand a year, which, unfortunately for his daughters, was entailed,
+in default of heirs male, on a distant relation; and their mother’s
+fortune, though ample for her situation in life, could but ill supply
+the deficiency of his. Her father had been an attorney in Meryton, and
+had left her four thousand pounds.
+
+She had a sister married to a Mr. Phillips, who had been a clerk to
+their father and succeeded him in the business, and a brother settled in
+London in a respectable line of trade.
+
+The village of Longbourn was only one mile from Meryton; a most
+convenient distance for the young ladies, who were usually tempted
+thither three or four times a week, to pay their duty to their aunt and
+to a milliner’s shop just over the way. The two youngest of the family,
+Catherine and Lydia, were particularly frequent in these attentions;
+their minds were more vacant than their sisters’, and when nothing
+better offered, a walk to Meryton was necessary to amuse their morning
+hours and furnish conversation for the evening; and however bare of news
+the country in general might be, they always contrived to learn some
+from their aunt. At present, indeed, they were well supplied both with
+news and happiness by the recent arrival of a militia regiment in the
+neighbourhood; it was to remain the whole winter, and Meryton was the
+headquarters.
+
+Their visits to Mrs. Phillips were now productive of the most
+interesting intelligence. Every day added something to their knowledge
+of the officers’ names and connections. Their lodgings were not long a
+secret, and at length they began to know the officers themselves. Mr.
+Phillips visited them all, and this opened to his nieces a store of
+felicity unknown before. They could talk of nothing but officers; and
+Mr. Bingley’s large fortune, the mention of which gave animation
+to their mother, was worthless in their eyes when opposed to the
+regimentals of an ensign.
+
+After listening one morning to their effusions on this subject, Mr.
+Bennet coolly observed:
+
+“From all that I can collect by your manner of talking, you must be two
+of the silliest girls in the country. I have suspected it some time, but
+I am now convinced.”
+
+Catherine was disconcerted, and made no answer; but Lydia, with perfect
+indifference, continued to express her admiration of Captain Carter,
+and her hope of seeing him in the course of the day, as he was going the
+next morning to London.
+
+“I am astonished, my dear,” said Mrs. Bennet, “that you should be so
+ready to think your own children silly. If I wished to think slightingly
+of anybody’s children, it should not be of my own, however.”
+
+“If my children are silly, I must hope to be always sensible of it.”
+
+“Yes--but as it happens, they are all of them very clever.”
+
+“This is the only point, I flatter myself, on which we do not agree. I
+had hoped that our sentiments coincided in every particular, but I must
+so far differ from you as to think our two youngest daughters uncommonly
+foolish.”
+
+“My dear Mr. Bennet, you must not expect such girls to have the sense of
+their father and mother. When they get to our age, I dare say they will
+not think about officers any more than we do. I remember the time when
+I liked a red coat myself very well--and, indeed, so I do still at my
+heart; and if a smart young colonel, with five or six thousand a year,
+should want one of my girls I shall not say nay to him; and I thought
+Colonel Forster looked very becoming the other night at Sir William’s in
+his regimentals.”
+
+“Mamma,” cried Lydia, “my aunt says that Colonel Forster and Captain
+Carter do not go so often to Miss Watson’s as they did when they first
+came; she sees them now very often standing in Clarke’s library.”
+
+Mrs. Bennet was prevented replying by the entrance of the footman with
+a note for Miss Bennet; it came from Netherfield, and the servant waited
+for an answer. Mrs. Bennet’s eyes sparkled with pleasure, and she was
+eagerly calling out, while her daughter read,
+
+“Well, Jane, who is it from? What is it about? What does he say? Well,
+Jane, make haste and tell us; make haste, my love.”
+
+“It is from Miss Bingley,” said Jane, and then read it aloud.
+
+“MY DEAR FRIEND,--
+
+“If you are not so compassionate as to dine to-day with Louisa and me,
+we shall be in danger of hating each other for the rest of our lives,
+for a whole day’s tete-a-tete between two women can never end without a
+quarrel. Come as soon as you can on receipt of this. My brother and the
+gentlemen are to dine with the officers.--Yours ever,
+
+“CAROLINE BINGLEY”
+
+“With the officers!” cried Lydia. “I wonder my aunt did not tell us of
+_that_.”
+
+“Dining out,” said Mrs. Bennet, “that is very unlucky.”
+
+“Can I have the carriage?” said Jane.
+
+“No, my dear, you had better go on horseback, because it seems likely to
+rain; and then you must stay all night.”
+
+“That would be a good scheme,” said Elizabeth, “if you were sure that
+they would not offer to send her home.”
+
+“Oh! but the gentlemen will have Mr. Bingley’s chaise to go to Meryton,
+and the Hursts have no horses to theirs.”
+
+“I had much rather go in the coach.”
+
+“But, my dear, your father cannot spare the horses, I am sure. They are
+wanted in the farm, Mr. Bennet, are they not?”
+
+“They are wanted in the farm much oftener than I can get them.”
+
+“But if you have got them to-day,” said Elizabeth, “my mother’s purpose
+will be answered.”
+
+She did at last extort from her father an acknowledgment that the horses
+were engaged. Jane was therefore obliged to go on horseback, and her
+mother attended her to the door with many cheerful prognostics of a
+bad day. Her hopes were answered; Jane had not been gone long before
+it rained hard. Her sisters were uneasy for her, but her mother was
+delighted. The rain continued the whole evening without intermission;
+Jane certainly could not come back.
+
+“This was a lucky idea of mine, indeed!” said Mrs. Bennet more than
+once, as if the credit of making it rain were all her own. Till the
+next morning, however, she was not aware of all the felicity of her
+contrivance. Breakfast was scarcely over when a servant from Netherfield
+brought the following note for Elizabeth:
+
+“MY DEAREST LIZZY,--
+
+“I find myself very unwell this morning, which, I suppose, is to be
+imputed to my getting wet through yesterday. My kind friends will not
+hear of my returning till I am better. They insist also on my seeing Mr.
+Jones--therefore do not be alarmed if you should hear of his having been
+to me--and, excepting a sore throat and headache, there is not much the
+matter with me.--Yours, etc.”
+
+“Well, my dear,” said Mr. Bennet, when Elizabeth had read the note
+aloud, “if your daughter should have a dangerous fit of illness--if she
+should die, it would be a comfort to know that it was all in pursuit of
+Mr. Bingley, and under your orders.”
+
+“Oh! I am not afraid of her dying. People do not die of little trifling
+colds. She will be taken good care of. As long as she stays there, it is
+all very well. I would go and see her if I could have the carriage.”
+
+Elizabeth, feeling really anxious, was determined to go to her, though
+the carriage was not to be had; and as she was no horsewoman, walking
+was her only alternative. She declared her resolution.
+
+“How can you be so silly,” cried her mother, “as to think of such a
+thing, in all this dirt! You will not be fit to be seen when you get
+there.”
+
+“I shall be very fit to see Jane--which is all I want.”
+
+“Is this a hint to me, Lizzy,” said her father, “to send for the
+horses?”
+
+“No, indeed, I do not wish to avoid the walk. The distance is nothing
+when one has a motive; only three miles. I shall be back by dinner.”
+
+“I admire the activity of your benevolence,” observed Mary, “but every
+impulse of feeling should be guided by reason; and, in my opinion,
+exertion should always be in proportion to what is required.”
+
+“We will go as far as Meryton with you,” said Catherine and Lydia.
+Elizabeth accepted their company, and the three young ladies set off
+together.
+
+“If we make haste,” said Lydia, as they walked along, “perhaps we may
+see something of Captain Carter before he goes.”
+
+In Meryton they parted; the two youngest repaired to the lodgings of one
+of the officers’ wives, and Elizabeth continued her walk alone, crossing
+field after field at a quick pace, jumping over stiles and springing
+over puddles with impatient activity, and finding herself at last
+within view of the house, with weary ankles, dirty stockings, and a face
+glowing with the warmth of exercise.
+
+She was shown into the breakfast-parlour, where all but Jane were
+assembled, and where her appearance created a great deal of surprise.
+That she should have walked three miles so early in the day, in such
+dirty weather, and by herself, was almost incredible to Mrs. Hurst and
+Miss Bingley; and Elizabeth was convinced that they held her in contempt
+for it. She was received, however, very politely by them; and in their
+brother’s manners there was something better than politeness; there
+was good humour and kindness. Mr. Darcy said very little, and Mr.
+Hurst nothing at all. The former was divided between admiration of the
+brilliancy which exercise had given to her complexion, and doubt as
+to the occasion’s justifying her coming so far alone. The latter was
+thinking only of his breakfast.
+
+Her inquiries after her sister were not very favourably answered. Miss
+Bennet had slept ill, and though up, was very feverish, and not
+well enough to leave her room. Elizabeth was glad to be taken to her
+immediately; and Jane, who had only been withheld by the fear of giving
+alarm or inconvenience from expressing in her note how much she longed
+for such a visit, was delighted at her entrance. She was not equal,
+however, to much conversation, and when Miss Bingley left them
+together, could attempt little besides expressions of gratitude for the
+extraordinary kindness she was treated with. Elizabeth silently attended
+her.
+
+When breakfast was over they were joined by the sisters; and Elizabeth
+began to like them herself, when she saw how much affection and
+solicitude they showed for Jane. The apothecary came, and having
+examined his patient, said, as might be supposed, that she had caught
+a violent cold, and that they must endeavour to get the better of it;
+advised her to return to bed, and promised her some draughts. The advice
+was followed readily, for the feverish symptoms increased, and her head
+ached acutely. Elizabeth did not quit her room for a moment; nor were
+the other ladies often absent; the gentlemen being out, they had, in
+fact, nothing to do elsewhere.
+
+When the clock struck three, Elizabeth felt that she must go, and very
+unwillingly said so. Miss Bingley offered her the carriage, and she only
+wanted a little pressing to accept it, when Jane testified such concern
+in parting with her, that Miss Bingley was obliged to convert the offer
+of the chaise to an invitation to remain at Netherfield for the present.
+Elizabeth most thankfully consented, and a servant was dispatched to
+Longbourn to acquaint the family with her stay and bring back a supply
+of clothes.
+
+
+
+Chapter 8
+
+
+At five o’clock the two ladies retired to dress, and at half-past six
+Elizabeth was summoned to dinner. To the civil inquiries which then
+poured in, and amongst which she had the pleasure of distinguishing the
+much superior solicitude of Mr. Bingley’s, she could not make a very
+favourable answer. Jane was by no means better. The sisters, on hearing
+this, repeated three or four times how much they were grieved, how
+shocking it was to have a bad cold, and how excessively they disliked
+being ill themselves; and then thought no more of the matter: and their
+indifference towards Jane when not immediately before them restored
+Elizabeth to the enjoyment of all her former dislike.
+
+Their brother, indeed, was the only one of the party whom she could
+regard with any complacency. His anxiety for Jane was evident, and his
+attentions to herself most pleasing, and they prevented her feeling
+herself so much an intruder as she believed she was considered by the
+others. She had very little notice from any but him. Miss Bingley was
+engrossed by Mr. Darcy, her sister scarcely less so; and as for Mr.
+Hurst, by whom Elizabeth sat, he was an indolent man, who lived only to
+eat, drink, and play at cards; who, when he found her to prefer a plain
+dish to a ragout, had nothing to say to her.
+
+When dinner was over, she returned directly to Jane, and Miss Bingley
+began abusing her as soon as she was out of the room. Her manners were
+pronounced to be very bad indeed, a mixture of pride and impertinence;
+she had no conversation, no style, no beauty. Mrs. Hurst thought the
+same, and added:
+
+“She has nothing, in short, to recommend her, but being an excellent
+walker. I shall never forget her appearance this morning. She really
+looked almost wild.”
+
+“She did, indeed, Louisa. I could hardly keep my countenance. Very
+nonsensical to come at all! Why must _she_ be scampering about the
+country, because her sister had a cold? Her hair, so untidy, so blowsy!”
+
+“Yes, and her petticoat; I hope you saw her petticoat, six inches deep
+in mud, I am absolutely certain; and the gown which had been let down to
+hide it not doing its office.”
+
+“Your picture may be very exact, Louisa,” said Bingley; “but this was
+all lost upon me. I thought Miss Elizabeth Bennet looked remarkably
+well when she came into the room this morning. Her dirty petticoat quite
+escaped my notice.”
+
+“_You_ observed it, Mr. Darcy, I am sure,” said Miss Bingley; “and I am
+inclined to think that you would not wish to see _your_ sister make such
+an exhibition.”
+
+“Certainly not.”
+
+“To walk three miles, or four miles, or five miles, or whatever it is,
+above her ankles in dirt, and alone, quite alone! What could she mean by
+it? It seems to me to show an abominable sort of conceited independence,
+a most country-town indifference to decorum.”
+
+“It shows an affection for her sister that is very pleasing,” said
+Bingley.
+
+“I am afraid, Mr. Darcy,” observed Miss Bingley in a half whisper, “that
+this adventure has rather affected your admiration of her fine eyes.”
+
+“Not at all,” he replied; “they were brightened by the exercise.” A
+short pause followed this speech, and Mrs. Hurst began again:
+
+“I have an excessive regard for Miss Jane Bennet, she is really a very
+sweet girl, and I wish with all my heart she were well settled. But with
+such a father and mother, and such low connections, I am afraid there is
+no chance of it.”
+
+“I think I have heard you say that their uncle is an attorney in
+Meryton.”
+
+“Yes; and they have another, who lives somewhere near Cheapside.”
+
+“That is capital,” added her sister, and they both laughed heartily.
+
+“If they had uncles enough to fill _all_ Cheapside,” cried Bingley, “it
+would not make them one jot less agreeable.”
+
+“But it must very materially lessen their chance of marrying men of any
+consideration in the world,” replied Darcy.
+
+To this speech Bingley made no answer; but his sisters gave it their
+hearty assent, and indulged their mirth for some time at the expense of
+their dear friend’s vulgar relations.
+
+With a renewal of tenderness, however, they returned to her room on
+leaving the dining-parlour, and sat with her till summoned to coffee.
+She was still very poorly, and Elizabeth would not quit her at all, till
+late in the evening, when she had the comfort of seeing her sleep, and
+when it seemed to her rather right than pleasant that she should go
+downstairs herself. On entering the drawing-room she found the whole
+party at loo, and was immediately invited to join them; but suspecting
+them to be playing high she declined it, and making her sister the
+excuse, said she would amuse herself for the short time she could stay
+below, with a book. Mr. Hurst looked at her with astonishment.
+
+“Do you prefer reading to cards?” said he; “that is rather singular.”
+
+“Miss Eliza Bennet,” said Miss Bingley, “despises cards. She is a great
+reader, and has no pleasure in anything else.”
+
+“I deserve neither such praise nor such censure,” cried Elizabeth; “I am
+_not_ a great reader, and I have pleasure in many things.”
+
+“In nursing your sister I am sure you have pleasure,” said Bingley; “and
+I hope it will be soon increased by seeing her quite well.”
+
+Elizabeth thanked him from her heart, and then walked towards the
+table where a few books were lying. He immediately offered to fetch her
+others--all that his library afforded.
+
+“And I wish my collection were larger for your benefit and my own
+credit; but I am an idle fellow, and though I have not many, I have more
+than I ever looked into.”
+
+Elizabeth assured him that she could suit herself perfectly with those
+in the room.
+
+“I am astonished,” said Miss Bingley, “that my father should have left
+so small a collection of books. What a delightful library you have at
+Pemberley, Mr. Darcy!”
+
+“It ought to be good,” he replied, “it has been the work of many
+generations.”
+
+“And then you have added so much to it yourself, you are always buying
+books.”
+
+“I cannot comprehend the neglect of a family library in such days as
+these.”
+
+“Neglect! I am sure you neglect nothing that can add to the beauties of
+that noble place. Charles, when you build _your_ house, I wish it may be
+half as delightful as Pemberley.”
+
+“I wish it may.”
+
+“But I would really advise you to make your purchase in that
+neighbourhood, and take Pemberley for a kind of model. There is not a
+finer county in England than Derbyshire.”
+
+“With all my heart; I will buy Pemberley itself if Darcy will sell it.”
+
+“I am talking of possibilities, Charles.”
+
+“Upon my word, Caroline, I should think it more possible to get
+Pemberley by purchase than by imitation.”
+
+Elizabeth was so much caught with what passed, as to leave her very
+little attention for her book; and soon laying it wholly aside, she drew
+near the card-table, and stationed herself between Mr. Bingley and his
+eldest sister, to observe the game.
+
+“Is Miss Darcy much grown since the spring?” said Miss Bingley; “will
+she be as tall as I am?”
+
+“I think she will. She is now about Miss Elizabeth Bennet’s height, or
+rather taller.”
+
+“How I long to see her again! I never met with anybody who delighted me
+so much. Such a countenance, such manners! And so extremely accomplished
+for her age! Her performance on the pianoforte is exquisite.”
+
+“It is amazing to me,” said Bingley, “how young ladies can have patience
+to be so very accomplished as they all are.”
+
+“All young ladies accomplished! My dear Charles, what do you mean?”
+
+“Yes, all of them, I think. They all paint tables, cover screens, and
+net purses. I scarcely know anyone who cannot do all this, and I am sure
+I never heard a young lady spoken of for the first time, without being
+informed that she was very accomplished.”
+
+“Your list of the common extent of accomplishments,” said Darcy, “has
+too much truth. The word is applied to many a woman who deserves it no
+otherwise than by netting a purse or covering a screen. But I am very
+far from agreeing with you in your estimation of ladies in general. I
+cannot boast of knowing more than half-a-dozen, in the whole range of my
+acquaintance, that are really accomplished.”
+
+“Nor I, I am sure,” said Miss Bingley.
+
+“Then,” observed Elizabeth, “you must comprehend a great deal in your
+idea of an accomplished woman.”
+
+“Yes, I do comprehend a great deal in it.”
+
+“Oh! certainly,” cried his faithful assistant, “no one can be really
+esteemed accomplished who does not greatly surpass what is usually met
+with. A woman must have a thorough knowledge of music, singing, drawing,
+dancing, and the modern languages, to deserve the word; and besides
+all this, she must possess a certain something in her air and manner of
+walking, the tone of her voice, her address and expressions, or the word
+will be but half-deserved.”
+
+“All this she must possess,” added Darcy, “and to all this she must
+yet add something more substantial, in the improvement of her mind by
+extensive reading.”
+
+“I am no longer surprised at your knowing _only_ six accomplished women.
+I rather wonder now at your knowing _any_.”
+
+“Are you so severe upon your own sex as to doubt the possibility of all
+this?”
+
+“I never saw such a woman. I never saw such capacity, and taste, and
+application, and elegance, as you describe united.”
+
+Mrs. Hurst and Miss Bingley both cried out against the injustice of her
+implied doubt, and were both protesting that they knew many women who
+answered this description, when Mr. Hurst called them to order, with
+bitter complaints of their inattention to what was going forward. As all
+conversation was thereby at an end, Elizabeth soon afterwards left the
+room.
+
+“Elizabeth Bennet,” said Miss Bingley, when the door was closed on her,
+“is one of those young ladies who seek to recommend themselves to the
+other sex by undervaluing their own; and with many men, I dare say, it
+succeeds. But, in my opinion, it is a paltry device, a very mean art.”
+
+“Undoubtedly,” replied Darcy, to whom this remark was chiefly addressed,
+“there is a meanness in _all_ the arts which ladies sometimes condescend
+to employ for captivation. Whatever bears affinity to cunning is
+despicable.”
+
+Miss Bingley was not so entirely satisfied with this reply as to
+continue the subject.
+
+Elizabeth joined them again only to say that her sister was worse, and
+that she could not leave her. Bingley urged Mr. Jones being sent for
+immediately; while his sisters, convinced that no country advice could
+be of any service, recommended an express to town for one of the most
+eminent physicians. This she would not hear of; but she was not so
+unwilling to comply with their brother’s proposal; and it was settled
+that Mr. Jones should be sent for early in the morning, if Miss Bennet
+were not decidedly better. Bingley was quite uncomfortable; his sisters
+declared that they were miserable. They solaced their wretchedness,
+however, by duets after supper, while he could find no better relief
+to his feelings than by giving his housekeeper directions that every
+attention might be paid to the sick lady and her sister.
+
+
+
+Chapter 9
+
+
+Elizabeth passed the chief of the night in her sister’s room, and in the
+morning had the pleasure of being able to send a tolerable answer to the
+inquiries which she very early received from Mr. Bingley by a housemaid,
+and some time afterwards from the two elegant ladies who waited on his
+sisters. In spite of this amendment, however, she requested to have a
+note sent to Longbourn, desiring her mother to visit Jane, and form her
+own judgement of her situation. The note was immediately dispatched, and
+its contents as quickly complied with. Mrs. Bennet, accompanied by her
+two youngest girls, reached Netherfield soon after the family breakfast.
+
+Had she found Jane in any apparent danger, Mrs. Bennet would have been
+very miserable; but being satisfied on seeing her that her illness was
+not alarming, she had no wish of her recovering immediately, as her
+restoration to health would probably remove her from Netherfield. She
+would not listen, therefore, to her daughter’s proposal of being carried
+home; neither did the apothecary, who arrived about the same time, think
+it at all advisable. After sitting a little while with Jane, on Miss
+Bingley’s appearance and invitation, the mother and three daughters all
+attended her into the breakfast parlour. Bingley met them with hopes
+that Mrs. Bennet had not found Miss Bennet worse than she expected.
+
+“Indeed I have, sir,” was her answer. “She is a great deal too ill to be
+moved. Mr. Jones says we must not think of moving her. We must trespass
+a little longer on your kindness.”
+
+“Removed!” cried Bingley. “It must not be thought of. My sister, I am
+sure, will not hear of her removal.”
+
+“You may depend upon it, Madam,” said Miss Bingley, with cold civility,
+“that Miss Bennet will receive every possible attention while she
+remains with us.”
+
+Mrs. Bennet was profuse in her acknowledgments.
+
+“I am sure,” she added, “if it was not for such good friends I do not
+know what would become of her, for she is very ill indeed, and suffers
+a vast deal, though with the greatest patience in the world, which is
+always the way with her, for she has, without exception, the sweetest
+temper I have ever met with. I often tell my other girls they are
+nothing to _her_. You have a sweet room here, Mr. Bingley, and a
+charming prospect over the gravel walk. I do not know a place in the
+country that is equal to Netherfield. You will not think of quitting it
+in a hurry, I hope, though you have but a short lease.”
+
+“Whatever I do is done in a hurry,” replied he; “and therefore if I
+should resolve to quit Netherfield, I should probably be off in five
+minutes. At present, however, I consider myself as quite fixed here.”
+
+“That is exactly what I should have supposed of you,” said Elizabeth.
+
+“You begin to comprehend me, do you?” cried he, turning towards her.
+
+“Oh! yes--I understand you perfectly.”
+
+“I wish I might take this for a compliment; but to be so easily seen
+through I am afraid is pitiful.”
+
+“That is as it happens. It does not follow that a deep, intricate
+character is more or less estimable than such a one as yours.”
+
+“Lizzy,” cried her mother, “remember where you are, and do not run on in
+the wild manner that you are suffered to do at home.”
+
+“I did not know before,” continued Bingley immediately, “that you were a
+studier of character. It must be an amusing study.”
+
+“Yes, but intricate characters are the _most_ amusing. They have at
+least that advantage.”
+
+“The country,” said Darcy, “can in general supply but a few subjects for
+such a study. In a country neighbourhood you move in a very confined and
+unvarying society.”
+
+“But people themselves alter so much, that there is something new to be
+observed in them for ever.”
+
+“Yes, indeed,” cried Mrs. Bennet, offended by his manner of mentioning
+a country neighbourhood. “I assure you there is quite as much of _that_
+going on in the country as in town.”
+
+Everybody was surprised, and Darcy, after looking at her for a moment,
+turned silently away. Mrs. Bennet, who fancied she had gained a complete
+victory over him, continued her triumph.
+
+“I cannot see that London has any great advantage over the country, for
+my part, except the shops and public places. The country is a vast deal
+pleasanter, is it not, Mr. Bingley?”
+
+“When I am in the country,” he replied, “I never wish to leave it;
+and when I am in town it is pretty much the same. They have each their
+advantages, and I can be equally happy in either.”
+
+“Aye--that is because you have the right disposition. But that
+gentleman,” looking at Darcy, “seemed to think the country was nothing
+at all.”
+
+“Indeed, Mamma, you are mistaken,” said Elizabeth, blushing for her
+mother. “You quite mistook Mr. Darcy. He only meant that there was not
+such a variety of people to be met with in the country as in the town,
+which you must acknowledge to be true.”
+
+“Certainly, my dear, nobody said there were; but as to not meeting
+with many people in this neighbourhood, I believe there are few
+neighbourhoods larger. I know we dine with four-and-twenty families.”
+
+Nothing but concern for Elizabeth could enable Bingley to keep his
+countenance. His sister was less delicate, and directed her eyes towards
+Mr. Darcy with a very expressive smile. Elizabeth, for the sake of
+saying something that might turn her mother’s thoughts, now asked her if
+Charlotte Lucas had been at Longbourn since _her_ coming away.
+
+“Yes, she called yesterday with her father. What an agreeable man Sir
+William is, Mr. Bingley, is not he? So much the man of fashion! So
+genteel and easy! He has always something to say to everybody. _That_
+is my idea of good breeding; and those persons who fancy themselves very
+important, and never open their mouths, quite mistake the matter.”
+
+“Did Charlotte dine with you?”
+
+“No, she would go home. I fancy she was wanted about the mince-pies. For
+my part, Mr. Bingley, I always keep servants that can do their own work;
+_my_ daughters are brought up very differently. But everybody is to
+judge for themselves, and the Lucases are a very good sort of girls,
+I assure you. It is a pity they are not handsome! Not that I think
+Charlotte so _very_ plain--but then she is our particular friend.”
+
+“She seems a very pleasant young woman.”
+
+“Oh! dear, yes; but you must own she is very plain. Lady Lucas herself
+has often said so, and envied me Jane’s beauty. I do not like to boast
+of my own child, but to be sure, Jane--one does not often see anybody
+better looking. It is what everybody says. I do not trust my own
+partiality. When she was only fifteen, there was a man at my brother
+Gardiner’s in town so much in love with her that my sister-in-law was
+sure he would make her an offer before we came away. But, however, he
+did not. Perhaps he thought her too young. However, he wrote some verses
+on her, and very pretty they were.”
+
+“And so ended his affection,” said Elizabeth impatiently. “There has
+been many a one, I fancy, overcome in the same way. I wonder who first
+discovered the efficacy of poetry in driving away love!”
+
+“I have been used to consider poetry as the _food_ of love,” said Darcy.
+
+“Of a fine, stout, healthy love it may. Everything nourishes what is
+strong already. But if it be only a slight, thin sort of inclination, I
+am convinced that one good sonnet will starve it entirely away.”
+
+Darcy only smiled; and the general pause which ensued made Elizabeth
+tremble lest her mother should be exposing herself again. She longed to
+speak, but could think of nothing to say; and after a short silence Mrs.
+Bennet began repeating her thanks to Mr. Bingley for his kindness to
+Jane, with an apology for troubling him also with Lizzy. Mr. Bingley was
+unaffectedly civil in his answer, and forced his younger sister to be
+civil also, and say what the occasion required. She performed her part
+indeed without much graciousness, but Mrs. Bennet was satisfied, and
+soon afterwards ordered her carriage. Upon this signal, the youngest of
+her daughters put herself forward. The two girls had been whispering to
+each other during the whole visit, and the result of it was, that the
+youngest should tax Mr. Bingley with having promised on his first coming
+into the country to give a ball at Netherfield.
+
+Lydia was a stout, well-grown girl of fifteen, with a fine complexion
+and good-humoured countenance; a favourite with her mother, whose
+affection had brought her into public at an early age. She had high
+animal spirits, and a sort of natural self-consequence, which the
+attention of the officers, to whom her uncle’s good dinners, and her own
+easy manners recommended her, had increased into assurance. She was very
+equal, therefore, to address Mr. Bingley on the subject of the ball, and
+abruptly reminded him of his promise; adding, that it would be the most
+shameful thing in the world if he did not keep it. His answer to this
+sudden attack was delightful to their mother’s ear:
+
+“I am perfectly ready, I assure you, to keep my engagement; and when
+your sister is recovered, you shall, if you please, name the very day of
+the ball. But you would not wish to be dancing when she is ill.”
+
+Lydia declared herself satisfied. “Oh! yes--it would be much better to
+wait till Jane was well, and by that time most likely Captain Carter
+would be at Meryton again. And when you have given _your_ ball,” she
+added, “I shall insist on their giving one also. I shall tell Colonel
+Forster it will be quite a shame if he does not.”
+
+Mrs. Bennet and her daughters then departed, and Elizabeth returned
+instantly to Jane, leaving her own and her relations’ behaviour to the
+remarks of the two ladies and Mr. Darcy; the latter of whom, however,
+could not be prevailed on to join in their censure of _her_, in spite of
+all Miss Bingley’s witticisms on _fine eyes_.
+
+
+
+Chapter 10
+
+
+The day passed much as the day before had done. Mrs. Hurst and Miss
+Bingley had spent some hours of the morning with the invalid, who
+continued, though slowly, to mend; and in the evening Elizabeth joined
+their party in the drawing-room. The loo-table, however, did not appear.
+Mr. Darcy was writing, and Miss Bingley, seated near him, was watching
+the progress of his letter and repeatedly calling off his attention by
+messages to his sister. Mr. Hurst and Mr. Bingley were at piquet, and
+Mrs. Hurst was observing their game.
+
+Elizabeth took up some needlework, and was sufficiently amused in
+attending to what passed between Darcy and his companion. The perpetual
+commendations of the lady, either on his handwriting, or on the evenness
+of his lines, or on the length of his letter, with the perfect unconcern
+with which her praises were received, formed a curious dialogue, and was
+exactly in union with her opinion of each.
+
+“How delighted Miss Darcy will be to receive such a letter!”
+
+He made no answer.
+
+“You write uncommonly fast.”
+
+“You are mistaken. I write rather slowly.”
+
+“How many letters you must have occasion to write in the course of a
+year! Letters of business, too! How odious I should think them!”
+
+“It is fortunate, then, that they fall to my lot instead of yours.”
+
+“Pray tell your sister that I long to see her.”
+
+“I have already told her so once, by your desire.”
+
+“I am afraid you do not like your pen. Let me mend it for you. I mend
+pens remarkably well.”
+
+“Thank you--but I always mend my own.”
+
+“How can you contrive to write so even?”
+
+He was silent.
+
+“Tell your sister I am delighted to hear of her improvement on the harp;
+and pray let her know that I am quite in raptures with her beautiful
+little design for a table, and I think it infinitely superior to Miss
+Grantley’s.”
+
+“Will you give me leave to defer your raptures till I write again? At
+present I have not room to do them justice.”
+
+“Oh! it is of no consequence. I shall see her in January. But do you
+always write such charming long letters to her, Mr. Darcy?”
+
+“They are generally long; but whether always charming it is not for me
+to determine.”
+
+“It is a rule with me, that a person who can write a long letter with
+ease, cannot write ill.”
+
+“That will not do for a compliment to Darcy, Caroline,” cried her
+brother, “because he does _not_ write with ease. He studies too much for
+words of four syllables. Do not you, Darcy?”
+
+“My style of writing is very different from yours.”
+
+“Oh!” cried Miss Bingley, “Charles writes in the most careless way
+imaginable. He leaves out half his words, and blots the rest.”
+
+“My ideas flow so rapidly that I have not time to express them--by which
+means my letters sometimes convey no ideas at all to my correspondents.”
+
+“Your humility, Mr. Bingley,” said Elizabeth, “must disarm reproof.”
+
+“Nothing is more deceitful,” said Darcy, “than the appearance of
+humility. It is often only carelessness of opinion, and sometimes an
+indirect boast.”
+
+“And which of the two do you call _my_ little recent piece of modesty?”
+
+“The indirect boast; for you are really proud of your defects in
+writing, because you consider them as proceeding from a rapidity of
+thought and carelessness of execution, which, if not estimable, you
+think at least highly interesting. The power of doing anything with
+quickness is always prized much by the possessor, and often without any
+attention to the imperfection of the performance. When you told Mrs.
+Bennet this morning that if you ever resolved upon quitting Netherfield
+you should be gone in five minutes, you meant it to be a sort of
+panegyric, of compliment to yourself--and yet what is there so very
+laudable in a precipitance which must leave very necessary business
+undone, and can be of no real advantage to yourself or anyone else?”
+
+“Nay,” cried Bingley, “this is too much, to remember at night all the
+foolish things that were said in the morning. And yet, upon my honour,
+I believe what I said of myself to be true, and I believe it at this
+moment. At least, therefore, I did not assume the character of needless
+precipitance merely to show off before the ladies.”
+
+“I dare say you believed it; but I am by no means convinced that
+you would be gone with such celerity. Your conduct would be quite as
+dependent on chance as that of any man I know; and if, as you were
+mounting your horse, a friend were to say, ‘Bingley, you had better
+stay till next week,’ you would probably do it, you would probably not
+go--and at another word, might stay a month.”
+
+“You have only proved by this,” cried Elizabeth, “that Mr. Bingley did
+not do justice to his own disposition. You have shown him off now much
+more than he did himself.”
+
+“I am exceedingly gratified,” said Bingley, “by your converting what my
+friend says into a compliment on the sweetness of my temper. But I am
+afraid you are giving it a turn which that gentleman did by no means
+intend; for he would certainly think better of me, if under such a
+circumstance I were to give a flat denial, and ride off as fast as I
+could.”
+
+“Would Mr. Darcy then consider the rashness of your original intentions
+as atoned for by your obstinacy in adhering to it?”
+
+“Upon my word, I cannot exactly explain the matter; Darcy must speak for
+himself.”
+
+“You expect me to account for opinions which you choose to call mine,
+but which I have never acknowledged. Allowing the case, however, to
+stand according to your representation, you must remember, Miss Bennet,
+that the friend who is supposed to desire his return to the house, and
+the delay of his plan, has merely desired it, asked it without offering
+one argument in favour of its propriety.”
+
+“To yield readily--easily--to the _persuasion_ of a friend is no merit
+with you.”
+
+“To yield without conviction is no compliment to the understanding of
+either.”
+
+“You appear to me, Mr. Darcy, to allow nothing for the influence of
+friendship and affection. A regard for the requester would often make
+one readily yield to a request, without waiting for arguments to reason
+one into it. I am not particularly speaking of such a case as you have
+supposed about Mr. Bingley. We may as well wait, perhaps, till the
+circumstance occurs before we discuss the discretion of his behaviour
+thereupon. But in general and ordinary cases between friend and friend,
+where one of them is desired by the other to change a resolution of no
+very great moment, should you think ill of that person for complying
+with the desire, without waiting to be argued into it?”
+
+“Will it not be advisable, before we proceed on this subject, to
+arrange with rather more precision the degree of importance which is to
+appertain to this request, as well as the degree of intimacy subsisting
+between the parties?”
+
+“By all means,” cried Bingley; “let us hear all the particulars, not
+forgetting their comparative height and size; for that will have more
+weight in the argument, Miss Bennet, than you may be aware of. I assure
+you, that if Darcy were not such a great tall fellow, in comparison with
+myself, I should not pay him half so much deference. I declare I do not
+know a more awful object than Darcy, on particular occasions, and in
+particular places; at his own house especially, and of a Sunday evening,
+when he has nothing to do.”
+
+Mr. Darcy smiled; but Elizabeth thought she could perceive that he was
+rather offended, and therefore checked her laugh. Miss Bingley warmly
+resented the indignity he had received, in an expostulation with her
+brother for talking such nonsense.
+
+“I see your design, Bingley,” said his friend. “You dislike an argument,
+and want to silence this.”
+
+“Perhaps I do. Arguments are too much like disputes. If you and Miss
+Bennet will defer yours till I am out of the room, I shall be very
+thankful; and then you may say whatever you like of me.”
+
+“What you ask,” said Elizabeth, “is no sacrifice on my side; and Mr.
+Darcy had much better finish his letter.”
+
+Mr. Darcy took her advice, and did finish his letter.
+
+When that business was over, he applied to Miss Bingley and Elizabeth
+for an indulgence of some music. Miss Bingley moved with some alacrity
+to the pianoforte; and, after a polite request that Elizabeth would lead
+the way which the other as politely and more earnestly negatived, she
+seated herself.
+
+Mrs. Hurst sang with her sister, and while they were thus employed,
+Elizabeth could not help observing, as she turned over some music-books
+that lay on the instrument, how frequently Mr. Darcy’s eyes were fixed
+on her. She hardly knew how to suppose that she could be an object of
+admiration to so great a man; and yet that he should look at her
+because he disliked her, was still more strange. She could only imagine,
+however, at last that she drew his notice because there was something
+more wrong and reprehensible, according to his ideas of right, than in
+any other person present. The supposition did not pain her. She liked
+him too little to care for his approbation.
+
+After playing some Italian songs, Miss Bingley varied the charm by
+a lively Scotch air; and soon afterwards Mr. Darcy, drawing near
+Elizabeth, said to her:
+
+“Do not you feel a great inclination, Miss Bennet, to seize such an
+opportunity of dancing a reel?”
+
+She smiled, but made no answer. He repeated the question, with some
+surprise at her silence.
+
+“Oh!” said she, “I heard you before, but I could not immediately
+determine what to say in reply. You wanted me, I know, to say ‘Yes,’
+that you might have the pleasure of despising my taste; but I always
+delight in overthrowing those kind of schemes, and cheating a person of
+their premeditated contempt. I have, therefore, made up my mind to tell
+you, that I do not want to dance a reel at all--and now despise me if
+you dare.”
+
+“Indeed I do not dare.”
+
+Elizabeth, having rather expected to affront him, was amazed at his
+gallantry; but there was a mixture of sweetness and archness in her
+manner which made it difficult for her to affront anybody; and Darcy
+had never been so bewitched by any woman as he was by her. He really
+believed, that were it not for the inferiority of her connections, he
+should be in some danger.
+
+Miss Bingley saw, or suspected enough to be jealous; and her great
+anxiety for the recovery of her dear friend Jane received some
+assistance from her desire of getting rid of Elizabeth.
+
+She often tried to provoke Darcy into disliking her guest, by talking of
+their supposed marriage, and planning his happiness in such an alliance.
+
+“I hope,” said she, as they were walking together in the shrubbery
+the next day, “you will give your mother-in-law a few hints, when this
+desirable event takes place, as to the advantage of holding her tongue;
+and if you can compass it, do cure the younger girls of running after
+officers. And, if I may mention so delicate a subject, endeavour to
+check that little something, bordering on conceit and impertinence,
+which your lady possesses.”
+
+“Have you anything else to propose for my domestic felicity?”
+
+“Oh! yes. Do let the portraits of your uncle and aunt Phillips be placed
+in the gallery at Pemberley. Put them next to your great-uncle the
+judge. They are in the same profession, you know, only in different
+lines. As for your Elizabeth’s picture, you must not have it taken, for
+what painter could do justice to those beautiful eyes?”
+
+“It would not be easy, indeed, to catch their expression, but their
+colour and shape, and the eyelashes, so remarkably fine, might be
+copied.”
+
+At that moment they were met from another walk by Mrs. Hurst and
+Elizabeth herself.
+
+“I did not know that you intended to walk,” said Miss Bingley, in some
+confusion, lest they had been overheard.
+
+“You used us abominably ill,” answered Mrs. Hurst, “running away without
+telling us that you were coming out.”
+
+Then taking the disengaged arm of Mr. Darcy, she left Elizabeth to walk
+by herself. The path just admitted three. Mr. Darcy felt their rudeness,
+and immediately said:
+
+“This walk is not wide enough for our party. We had better go into the
+avenue.”
+
+But Elizabeth, who had not the least inclination to remain with them,
+laughingly answered:
+
+“No, no; stay where you are. You are charmingly grouped, and appear
+to uncommon advantage. The picturesque would be spoilt by admitting a
+fourth. Good-bye.”
+
+She then ran gaily off, rejoicing as she rambled about, in the hope of
+being at home again in a day or two. Jane was already so much recovered
+as to intend leaving her room for a couple of hours that evening.
+
+
+
+Chapter 11
+
+
+When the ladies removed after dinner, Elizabeth ran up to her
+sister, and seeing her well guarded from cold, attended her into the
+drawing-room, where she was welcomed by her two friends with many
+professions of pleasure; and Elizabeth had never seen them so agreeable
+as they were during the hour which passed before the gentlemen appeared.
+Their powers of conversation were considerable. They could describe an
+entertainment with accuracy, relate an anecdote with humour, and laugh
+at their acquaintance with spirit.
+
+But when the gentlemen entered, Jane was no longer the first object;
+Miss Bingley’s eyes were instantly turned toward Darcy, and she had
+something to say to him before he had advanced many steps. He addressed
+himself to Miss Bennet, with a polite congratulation; Mr. Hurst also
+made her a slight bow, and said he was “very glad;” but diffuseness
+and warmth remained for Bingley’s salutation. He was full of joy and
+attention. The first half-hour was spent in piling up the fire, lest she
+should suffer from the change of room; and she removed at his desire
+to the other side of the fireplace, that she might be further from
+the door. He then sat down by her, and talked scarcely to anyone
+else. Elizabeth, at work in the opposite corner, saw it all with great
+delight.
+
+When tea was over, Mr. Hurst reminded his sister-in-law of the
+card-table--but in vain. She had obtained private intelligence that Mr.
+Darcy did not wish for cards; and Mr. Hurst soon found even his open
+petition rejected. She assured him that no one intended to play, and
+the silence of the whole party on the subject seemed to justify her. Mr.
+Hurst had therefore nothing to do, but to stretch himself on one of the
+sofas and go to sleep. Darcy took up a book; Miss Bingley did the same;
+and Mrs. Hurst, principally occupied in playing with her bracelets
+and rings, joined now and then in her brother’s conversation with Miss
+Bennet.
+
+Miss Bingley’s attention was quite as much engaged in watching Mr.
+Darcy’s progress through _his_ book, as in reading her own; and she
+was perpetually either making some inquiry, or looking at his page. She
+could not win him, however, to any conversation; he merely answered her
+question, and read on. At length, quite exhausted by the attempt to be
+amused with her own book, which she had only chosen because it was the
+second volume of his, she gave a great yawn and said, “How pleasant
+it is to spend an evening in this way! I declare after all there is no
+enjoyment like reading! How much sooner one tires of anything than of a
+book! When I have a house of my own, I shall be miserable if I have not
+an excellent library.”
+
+No one made any reply. She then yawned again, threw aside her book, and
+cast her eyes round the room in quest for some amusement; when hearing
+her brother mentioning a ball to Miss Bennet, she turned suddenly
+towards him and said:
+
+“By the bye, Charles, are you really serious in meditating a dance at
+Netherfield? I would advise you, before you determine on it, to consult
+the wishes of the present party; I am much mistaken if there are
+not some among us to whom a ball would be rather a punishment than a
+pleasure.”
+
+“If you mean Darcy,” cried her brother, “he may go to bed, if he
+chooses, before it begins--but as for the ball, it is quite a settled
+thing; and as soon as Nicholls has made white soup enough, I shall send
+round my cards.”
+
+“I should like balls infinitely better,” she replied, “if they were
+carried on in a different manner; but there is something insufferably
+tedious in the usual process of such a meeting. It would surely be much
+more rational if conversation instead of dancing were made the order of
+the day.”
+
+“Much more rational, my dear Caroline, I dare say, but it would not be
+near so much like a ball.”
+
+Miss Bingley made no answer, and soon afterwards she got up and walked
+about the room. Her figure was elegant, and she walked well; but
+Darcy, at whom it was all aimed, was still inflexibly studious. In
+the desperation of her feelings, she resolved on one effort more, and,
+turning to Elizabeth, said:
+
+“Miss Eliza Bennet, let me persuade you to follow my example, and take a
+turn about the room. I assure you it is very refreshing after sitting so
+long in one attitude.”
+
+Elizabeth was surprised, but agreed to it immediately. Miss Bingley
+succeeded no less in the real object of her civility; Mr. Darcy looked
+up. He was as much awake to the novelty of attention in that quarter as
+Elizabeth herself could be, and unconsciously closed his book. He was
+directly invited to join their party, but he declined it, observing that
+he could imagine but two motives for their choosing to walk up and down
+the room together, with either of which motives his joining them would
+interfere. “What could he mean? She was dying to know what could be his
+meaning?”--and asked Elizabeth whether she could at all understand him?
+
+“Not at all,” was her answer; “but depend upon it, he means to be severe
+on us, and our surest way of disappointing him will be to ask nothing
+about it.”
+
+Miss Bingley, however, was incapable of disappointing Mr. Darcy in
+anything, and persevered therefore in requiring an explanation of his
+two motives.
+
+“I have not the smallest objection to explaining them,” said he, as soon
+as she allowed him to speak. “You either choose this method of passing
+the evening because you are in each other’s confidence, and have secret
+affairs to discuss, or because you are conscious that your figures
+appear to the greatest advantage in walking; if the first, I would be
+completely in your way, and if the second, I can admire you much better
+as I sit by the fire.”
+
+“Oh! shocking!” cried Miss Bingley. “I never heard anything so
+abominable. How shall we punish him for such a speech?”
+
+“Nothing so easy, if you have but the inclination,” said Elizabeth. “We
+can all plague and punish one another. Tease him--laugh at him. Intimate
+as you are, you must know how it is to be done.”
+
+“But upon my honour, I do _not_. I do assure you that my intimacy has
+not yet taught me _that_. Tease calmness of manner and presence of
+mind! No, no; I feel he may defy us there. And as to laughter, we will
+not expose ourselves, if you please, by attempting to laugh without a
+subject. Mr. Darcy may hug himself.”
+
+“Mr. Darcy is not to be laughed at!” cried Elizabeth. “That is an
+uncommon advantage, and uncommon I hope it will continue, for it would
+be a great loss to _me_ to have many such acquaintances. I dearly love a
+laugh.”
+
+“Miss Bingley,” said he, “has given me more credit than can be.
+The wisest and the best of men--nay, the wisest and best of their
+actions--may be rendered ridiculous by a person whose first object in
+life is a joke.”
+
+“Certainly,” replied Elizabeth--“there are such people, but I hope I
+am not one of _them_. I hope I never ridicule what is wise and good.
+Follies and nonsense, whims and inconsistencies, _do_ divert me, I own,
+and I laugh at them whenever I can. But these, I suppose, are precisely
+what you are without.”
+
+“Perhaps that is not possible for anyone. But it has been the study
+of my life to avoid those weaknesses which often expose a strong
+understanding to ridicule.”
+
+“Such as vanity and pride.”
+
+“Yes, vanity is a weakness indeed. But pride--where there is a real
+superiority of mind, pride will be always under good regulation.”
+
+Elizabeth turned away to hide a smile.
+
+“Your examination of Mr. Darcy is over, I presume,” said Miss Bingley;
+“and pray what is the result?”
+
+“I am perfectly convinced by it that Mr. Darcy has no defect. He owns it
+himself without disguise.”
+
+“No,” said Darcy, “I have made no such pretension. I have faults enough,
+but they are not, I hope, of understanding. My temper I dare not vouch
+for. It is, I believe, too little yielding--certainly too little for the
+convenience of the world. I cannot forget the follies and vices of others
+so soon as I ought, nor their offenses against myself. My feelings
+are not puffed about with every attempt to move them. My temper
+would perhaps be called resentful. My good opinion once lost, is lost
+forever.”
+
+“_That_ is a failing indeed!” cried Elizabeth. “Implacable resentment
+_is_ a shade in a character. But you have chosen your fault well. I
+really cannot _laugh_ at it. You are safe from me.”
+
+“There is, I believe, in every disposition a tendency to some particular
+evil--a natural defect, which not even the best education can overcome.”
+
+“And _your_ defect is to hate everybody.”
+
+“And yours,” he replied with a smile, “is willfully to misunderstand
+them.”
+
+“Do let us have a little music,” cried Miss Bingley, tired of a
+conversation in which she had no share. “Louisa, you will not mind my
+waking Mr. Hurst?”
+
+Her sister had not the smallest objection, and the pianoforte was
+opened; and Darcy, after a few moments’ recollection, was not sorry for
+it. He began to feel the danger of paying Elizabeth too much attention.
+
+
+
+Chapter 12
+
+
+In consequence of an agreement between the sisters, Elizabeth wrote the
+next morning to their mother, to beg that the carriage might be sent for
+them in the course of the day. But Mrs. Bennet, who had calculated on
+her daughters remaining at Netherfield till the following Tuesday, which
+would exactly finish Jane’s week, could not bring herself to receive
+them with pleasure before. Her answer, therefore, was not propitious, at
+least not to Elizabeth’s wishes, for she was impatient to get home. Mrs.
+Bennet sent them word that they could not possibly have the carriage
+before Tuesday; and in her postscript it was added, that if Mr. Bingley
+and his sister pressed them to stay longer, she could spare them
+very well. Against staying longer, however, Elizabeth was positively
+resolved--nor did she much expect it would be asked; and fearful, on the
+contrary, as being considered as intruding themselves needlessly long,
+she urged Jane to borrow Mr. Bingley’s carriage immediately, and at
+length it was settled that their original design of leaving Netherfield
+that morning should be mentioned, and the request made.
+
+The communication excited many professions of concern; and enough was
+said of wishing them to stay at least till the following day to work
+on Jane; and till the morrow their going was deferred. Miss Bingley was
+then sorry that she had proposed the delay, for her jealousy and dislike
+of one sister much exceeded her affection for the other.
+
+The master of the house heard with real sorrow that they were to go so
+soon, and repeatedly tried to persuade Miss Bennet that it would not be
+safe for her--that she was not enough recovered; but Jane was firm where
+she felt herself to be right.
+
+To Mr. Darcy it was welcome intelligence--Elizabeth had been at
+Netherfield long enough. She attracted him more than he liked--and Miss
+Bingley was uncivil to _her_, and more teasing than usual to himself.
+He wisely resolved to be particularly careful that no sign of admiration
+should _now_ escape him, nothing that could elevate her with the hope
+of influencing his felicity; sensible that if such an idea had been
+suggested, his behaviour during the last day must have material weight
+in confirming or crushing it. Steady to his purpose, he scarcely spoke
+ten words to her through the whole of Saturday, and though they were
+at one time left by themselves for half-an-hour, he adhered most
+conscientiously to his book, and would not even look at her.
+
+On Sunday, after morning service, the separation, so agreeable to almost
+all, took place. Miss Bingley’s civility to Elizabeth increased at last
+very rapidly, as well as her affection for Jane; and when they parted,
+after assuring the latter of the pleasure it would always give her
+to see her either at Longbourn or Netherfield, and embracing her most
+tenderly, she even shook hands with the former. Elizabeth took leave of
+the whole party in the liveliest of spirits.
+
+They were not welcomed home very cordially by their mother. Mrs. Bennet
+wondered at their coming, and thought them very wrong to give so much
+trouble, and was sure Jane would have caught cold again. But their
+father, though very laconic in his expressions of pleasure, was really
+glad to see them; he had felt their importance in the family circle. The
+evening conversation, when they were all assembled, had lost much of
+its animation, and almost all its sense by the absence of Jane and
+Elizabeth.
+
+They found Mary, as usual, deep in the study of thorough-bass and human
+nature; and had some extracts to admire, and some new observations of
+threadbare morality to listen to. Catherine and Lydia had information
+for them of a different sort. Much had been done and much had been said
+in the regiment since the preceding Wednesday; several of the officers
+had dined lately with their uncle, a private had been flogged, and it
+had actually been hinted that Colonel Forster was going to be married.
+
+
+
+Chapter 13
+
+
+“I hope, my dear,” said Mr. Bennet to his wife, as they were at
+breakfast the next morning, “that you have ordered a good dinner to-day,
+because I have reason to expect an addition to our family party.”
+
+“Who do you mean, my dear? I know of nobody that is coming, I am sure,
+unless Charlotte Lucas should happen to call in--and I hope _my_ dinners
+are good enough for her. I do not believe she often sees such at home.”
+
+“The person of whom I speak is a gentleman, and a stranger.”
+
+Mrs. Bennet’s eyes sparkled. “A gentleman and a stranger! It is Mr.
+Bingley, I am sure! Well, I am sure I shall be extremely glad to see Mr.
+Bingley. But--good Lord! how unlucky! There is not a bit of fish to be
+got to-day. Lydia, my love, ring the bell--I must speak to Hill this
+moment.”
+
+“It is _not_ Mr. Bingley,” said her husband; “it is a person whom I
+never saw in the whole course of my life.”
+
+This roused a general astonishment; and he had the pleasure of being
+eagerly questioned by his wife and his five daughters at once.
+
+After amusing himself some time with their curiosity, he thus explained:
+
+“About a month ago I received this letter; and about a fortnight ago
+I answered it, for I thought it a case of some delicacy, and requiring
+early attention. It is from my cousin, Mr. Collins, who, when I am dead,
+may turn you all out of this house as soon as he pleases.”
+
+“Oh! my dear,” cried his wife, “I cannot bear to hear that mentioned.
+Pray do not talk of that odious man. I do think it is the hardest thing
+in the world, that your estate should be entailed away from your own
+children; and I am sure, if I had been you, I should have tried long ago
+to do something or other about it.”
+
+Jane and Elizabeth tried to explain to her the nature of an entail. They
+had often attempted to do it before, but it was a subject on which
+Mrs. Bennet was beyond the reach of reason, and she continued to rail
+bitterly against the cruelty of settling an estate away from a family of
+five daughters, in favour of a man whom nobody cared anything about.
+
+“It certainly is a most iniquitous affair,” said Mr. Bennet, “and
+nothing can clear Mr. Collins from the guilt of inheriting Longbourn.
+But if you will listen to his letter, you may perhaps be a little
+softened by his manner of expressing himself.”
+
+“No, that I am sure I shall not; and I think it is very impertinent of
+him to write to you at all, and very hypocritical. I hate such false
+friends. Why could he not keep on quarreling with you, as his father did
+before him?”
+
+“Why, indeed; he does seem to have had some filial scruples on that
+head, as you will hear.”
+
+“Hunsford, near Westerham, Kent, 15th October.
+
+“Dear Sir,--
+
+“The disagreement subsisting between yourself and my late honoured
+father always gave me much uneasiness, and since I have had the
+misfortune to lose him, I have frequently wished to heal the breach; but
+for some time I was kept back by my own doubts, fearing lest it might
+seem disrespectful to his memory for me to be on good terms with anyone
+with whom it had always pleased him to be at variance.--‘There, Mrs.
+Bennet.’--My mind, however, is now made up on the subject, for having
+received ordination at Easter, I have been so fortunate as to be
+distinguished by the patronage of the Right Honourable Lady Catherine de
+Bourgh, widow of Sir Lewis de Bourgh, whose bounty and beneficence has
+preferred me to the valuable rectory of this parish, where it shall be
+my earnest endeavour to demean myself with grateful respect towards her
+ladyship, and be ever ready to perform those rites and ceremonies which
+are instituted by the Church of England. As a clergyman, moreover, I
+feel it my duty to promote and establish the blessing of peace in
+all families within the reach of my influence; and on these grounds I
+flatter myself that my present overtures are highly commendable, and
+that the circumstance of my being next in the entail of Longbourn estate
+will be kindly overlooked on your side, and not lead you to reject the
+offered olive-branch. I cannot be otherwise than concerned at being the
+means of injuring your amiable daughters, and beg leave to apologise for
+it, as well as to assure you of my readiness to make them every possible
+amends--but of this hereafter. If you should have no objection to
+receive me into your house, I propose myself the satisfaction of waiting
+on you and your family, Monday, November 18th, by four o’clock, and
+shall probably trespass on your hospitality till the Saturday se’ennight
+following, which I can do without any inconvenience, as Lady Catherine
+is far from objecting to my occasional absence on a Sunday, provided
+that some other clergyman is engaged to do the duty of the day.--I
+remain, dear sir, with respectful compliments to your lady and
+daughters, your well-wisher and friend,
+
+“WILLIAM COLLINS”
+
+“At four o’clock, therefore, we may expect this peace-making gentleman,”
+ said Mr. Bennet, as he folded up the letter. “He seems to be a most
+conscientious and polite young man, upon my word, and I doubt not will
+prove a valuable acquaintance, especially if Lady Catherine should be so
+indulgent as to let him come to us again.”
+
+“There is some sense in what he says about the girls, however, and if
+he is disposed to make them any amends, I shall not be the person to
+discourage him.”
+
+“Though it is difficult,” said Jane, “to guess in what way he can mean
+to make us the atonement he thinks our due, the wish is certainly to his
+credit.”
+
+Elizabeth was chiefly struck by his extraordinary deference for Lady
+Catherine, and his kind intention of christening, marrying, and burying
+his parishioners whenever it were required.
+
+“He must be an oddity, I think,” said she. “I cannot make him
+out.--There is something very pompous in his style.--And what can he
+mean by apologising for being next in the entail?--We cannot suppose he
+would help it if he could.--Could he be a sensible man, sir?”
+
+“No, my dear, I think not. I have great hopes of finding him quite the
+reverse. There is a mixture of servility and self-importance in his
+letter, which promises well. I am impatient to see him.”
+
+“In point of composition,” said Mary, “the letter does not seem
+defective. The idea of the olive-branch perhaps is not wholly new, yet I
+think it is well expressed.”
+
+To Catherine and Lydia, neither the letter nor its writer were in any
+degree interesting. It was next to impossible that their cousin should
+come in a scarlet coat, and it was now some weeks since they had
+received pleasure from the society of a man in any other colour. As for
+their mother, Mr. Collins’s letter had done away much of her ill-will,
+and she was preparing to see him with a degree of composure which
+astonished her husband and daughters.
+
+Mr. Collins was punctual to his time, and was received with great
+politeness by the whole family. Mr. Bennet indeed said little; but the
+ladies were ready enough to talk, and Mr. Collins seemed neither in
+need of encouragement, nor inclined to be silent himself. He was a
+tall, heavy-looking young man of five-and-twenty. His air was grave and
+stately, and his manners were very formal. He had not been long seated
+before he complimented Mrs. Bennet on having so fine a family of
+daughters; said he had heard much of their beauty, but that in this
+instance fame had fallen short of the truth; and added, that he did
+not doubt her seeing them all in due time disposed of in marriage. This
+gallantry was not much to the taste of some of his hearers; but Mrs.
+Bennet, who quarreled with no compliments, answered most readily.
+
+“You are very kind, I am sure; and I wish with all my heart it may
+prove so, for else they will be destitute enough. Things are settled so
+oddly.”
+
+“You allude, perhaps, to the entail of this estate.”
+
+“Ah! sir, I do indeed. It is a grievous affair to my poor girls, you
+must confess. Not that I mean to find fault with _you_, for such things
+I know are all chance in this world. There is no knowing how estates
+will go when once they come to be entailed.”
+
+“I am very sensible, madam, of the hardship to my fair cousins, and
+could say much on the subject, but that I am cautious of appearing
+forward and precipitate. But I can assure the young ladies that I come
+prepared to admire them. At present I will not say more; but, perhaps,
+when we are better acquainted--”
+
+He was interrupted by a summons to dinner; and the girls smiled on each
+other. They were not the only objects of Mr. Collins’s admiration. The
+hall, the dining-room, and all its furniture, were examined and praised;
+and his commendation of everything would have touched Mrs. Bennet’s
+heart, but for the mortifying supposition of his viewing it all as his
+own future property. The dinner too in its turn was highly admired; and
+he begged to know to which of his fair cousins the excellency of its
+cooking was owing. But he was set right there by Mrs. Bennet, who
+assured him with some asperity that they were very well able to keep a
+good cook, and that her daughters had nothing to do in the kitchen. He
+begged pardon for having displeased her. In a softened tone she declared
+herself not at all offended; but he continued to apologise for about a
+quarter of an hour.
+
+
+
+Chapter 14
+
+
+During dinner, Mr. Bennet scarcely spoke at all; but when the servants
+were withdrawn, he thought it time to have some conversation with his
+guest, and therefore started a subject in which he expected him to
+shine, by observing that he seemed very fortunate in his patroness. Lady
+Catherine de Bourgh’s attention to his wishes, and consideration for
+his comfort, appeared very remarkable. Mr. Bennet could not have chosen
+better. Mr. Collins was eloquent in her praise. The subject elevated him
+to more than usual solemnity of manner, and with a most important aspect
+he protested that “he had never in his life witnessed such behaviour in
+a person of rank--such affability and condescension, as he had himself
+experienced from Lady Catherine. She had been graciously pleased to
+approve of both of the discourses which he had already had the honour of
+preaching before her. She had also asked him twice to dine at Rosings,
+and had sent for him only the Saturday before, to make up her pool of
+quadrille in the evening. Lady Catherine was reckoned proud by many
+people he knew, but _he_ had never seen anything but affability in her.
+She had always spoken to him as she would to any other gentleman; she
+made not the smallest objection to his joining in the society of the
+neighbourhood nor to his leaving the parish occasionally for a week or
+two, to visit his relations. She had even condescended to advise him to
+marry as soon as he could, provided he chose with discretion; and had
+once paid him a visit in his humble parsonage, where she had perfectly
+approved all the alterations he had been making, and had even vouchsafed
+to suggest some herself--some shelves in the closet up stairs.”
+
+“That is all very proper and civil, I am sure,” said Mrs. Bennet, “and
+I dare say she is a very agreeable woman. It is a pity that great ladies
+in general are not more like her. Does she live near you, sir?”
+
+“The garden in which stands my humble abode is separated only by a lane
+from Rosings Park, her ladyship’s residence.”
+
+“I think you said she was a widow, sir? Has she any family?”
+
+“She has only one daughter, the heiress of Rosings, and of very
+extensive property.”
+
+“Ah!” said Mrs. Bennet, shaking her head, “then she is better off than
+many girls. And what sort of young lady is she? Is she handsome?”
+
+“She is a most charming young lady indeed. Lady Catherine herself says
+that, in point of true beauty, Miss de Bourgh is far superior to the
+handsomest of her sex, because there is that in her features which marks
+the young lady of distinguished birth. She is unfortunately of a sickly
+constitution, which has prevented her from making that progress in many
+accomplishments which she could not have otherwise failed of, as I am
+informed by the lady who superintended her education, and who still
+resides with them. But she is perfectly amiable, and often condescends
+to drive by my humble abode in her little phaeton and ponies.”
+
+“Has she been presented? I do not remember her name among the ladies at
+court.”
+
+“Her indifferent state of health unhappily prevents her being in town;
+and by that means, as I told Lady Catherine one day, has deprived the
+British court of its brightest ornament. Her ladyship seemed pleased
+with the idea; and you may imagine that I am happy on every occasion to
+offer those little delicate compliments which are always acceptable
+to ladies. I have more than once observed to Lady Catherine, that
+her charming daughter seemed born to be a duchess, and that the most
+elevated rank, instead of giving her consequence, would be adorned by
+her. These are the kind of little things which please her ladyship, and
+it is a sort of attention which I conceive myself peculiarly bound to
+pay.”
+
+“You judge very properly,” said Mr. Bennet, “and it is happy for you
+that you possess the talent of flattering with delicacy. May I ask
+whether these pleasing attentions proceed from the impulse of the
+moment, or are the result of previous study?”
+
+“They arise chiefly from what is passing at the time, and though I
+sometimes amuse myself with suggesting and arranging such little elegant
+compliments as may be adapted to ordinary occasions, I always wish to
+give them as unstudied an air as possible.”
+
+Mr. Bennet’s expectations were fully answered. His cousin was as absurd
+as he had hoped, and he listened to him with the keenest enjoyment,
+maintaining at the same time the most resolute composure of countenance,
+and, except in an occasional glance at Elizabeth, requiring no partner
+in his pleasure.
+
+By tea-time, however, the dose had been enough, and Mr. Bennet was glad
+to take his guest into the drawing-room again, and, when tea was over,
+glad to invite him to read aloud to the ladies. Mr. Collins readily
+assented, and a book was produced; but, on beholding it (for everything
+announced it to be from a circulating library), he started back, and
+begging pardon, protested that he never read novels. Kitty stared at
+him, and Lydia exclaimed. Other books were produced, and after some
+deliberation he chose Fordyce’s Sermons. Lydia gaped as he opened the
+volume, and before he had, with very monotonous solemnity, read three
+pages, she interrupted him with:
+
+“Do you know, mamma, that my uncle Phillips talks of turning away
+Richard; and if he does, Colonel Forster will hire him. My aunt told me
+so herself on Saturday. I shall walk to Meryton to-morrow to hear more
+about it, and to ask when Mr. Denny comes back from town.”
+
+Lydia was bid by her two eldest sisters to hold her tongue; but Mr.
+Collins, much offended, laid aside his book, and said:
+
+“I have often observed how little young ladies are interested by books
+of a serious stamp, though written solely for their benefit. It amazes
+me, I confess; for, certainly, there can be nothing so advantageous to
+them as instruction. But I will no longer importune my young cousin.”
+
+Then turning to Mr. Bennet, he offered himself as his antagonist at
+backgammon. Mr. Bennet accepted the challenge, observing that he acted
+very wisely in leaving the girls to their own trifling amusements.
+Mrs. Bennet and her daughters apologised most civilly for Lydia’s
+interruption, and promised that it should not occur again, if he would
+resume his book; but Mr. Collins, after assuring them that he bore his
+young cousin no ill-will, and should never resent her behaviour as any
+affront, seated himself at another table with Mr. Bennet, and prepared
+for backgammon.
+
+
+
+Chapter 15
+
+
+Mr. Collins was not a sensible man, and the deficiency of nature had
+been but little assisted by education or society; the greatest part
+of his life having been spent under the guidance of an illiterate and
+miserly father; and though he belonged to one of the universities, he
+had merely kept the necessary terms, without forming at it any useful
+acquaintance. The subjection in which his father had brought him up had
+given him originally great humility of manner; but it was now a
+good deal counteracted by the self-conceit of a weak head, living in
+retirement, and the consequential feelings of early and unexpected
+prosperity. A fortunate chance had recommended him to Lady Catherine de
+Bourgh when the living of Hunsford was vacant; and the respect which
+he felt for her high rank, and his veneration for her as his patroness,
+mingling with a very good opinion of himself, of his authority as a
+clergyman, and his right as a rector, made him altogether a mixture of
+pride and obsequiousness, self-importance and humility.
+
+Having now a good house and a very sufficient income, he intended to
+marry; and in seeking a reconciliation with the Longbourn family he had
+a wife in view, as he meant to choose one of the daughters, if he found
+them as handsome and amiable as they were represented by common report.
+This was his plan of amends--of atonement--for inheriting their father’s
+estate; and he thought it an excellent one, full of eligibility and
+suitableness, and excessively generous and disinterested on his own
+part.
+
+His plan did not vary on seeing them. Miss Bennet’s lovely face
+confirmed his views, and established all his strictest notions of what
+was due to seniority; and for the first evening _she_ was his settled
+choice. The next morning, however, made an alteration; for in a
+quarter of an hour’s tete-a-tete with Mrs. Bennet before breakfast, a
+conversation beginning with his parsonage-house, and leading naturally
+to the avowal of his hopes, that a mistress might be found for it at
+Longbourn, produced from her, amid very complaisant smiles and general
+encouragement, a caution against the very Jane he had fixed on. “As to
+her _younger_ daughters, she could not take upon her to say--she could
+not positively answer--but she did not _know_ of any prepossession; her
+_eldest_ daughter, she must just mention--she felt it incumbent on her
+to hint, was likely to be very soon engaged.”
+
+Mr. Collins had only to change from Jane to Elizabeth--and it was soon
+done--done while Mrs. Bennet was stirring the fire. Elizabeth, equally
+next to Jane in birth and beauty, succeeded her of course.
+
+Mrs. Bennet treasured up the hint, and trusted that she might soon have
+two daughters married; and the man whom she could not bear to speak of
+the day before was now high in her good graces.
+
+Lydia’s intention of walking to Meryton was not forgotten; every sister
+except Mary agreed to go with her; and Mr. Collins was to attend them,
+at the request of Mr. Bennet, who was most anxious to get rid of him,
+and have his library to himself; for thither Mr. Collins had followed
+him after breakfast; and there he would continue, nominally engaged with
+one of the largest folios in the collection, but really talking to Mr.
+Bennet, with little cessation, of his house and garden at Hunsford. Such
+doings discomposed Mr. Bennet exceedingly. In his library he had been
+always sure of leisure and tranquillity; and though prepared, as he told
+Elizabeth, to meet with folly and conceit in every other room of the
+house, he was used to be free from them there; his civility, therefore,
+was most prompt in inviting Mr. Collins to join his daughters in their
+walk; and Mr. Collins, being in fact much better fitted for a walker
+than a reader, was extremely pleased to close his large book, and go.
+
+In pompous nothings on his side, and civil assents on that of his
+cousins, their time passed till they entered Meryton. The attention of
+the younger ones was then no longer to be gained by him. Their eyes were
+immediately wandering up in the street in quest of the officers, and
+nothing less than a very smart bonnet indeed, or a really new muslin in
+a shop window, could recall them.
+
+But the attention of every lady was soon caught by a young man, whom
+they had never seen before, of most gentlemanlike appearance, walking
+with another officer on the other side of the way. The officer was
+the very Mr. Denny concerning whose return from London Lydia came
+to inquire, and he bowed as they passed. All were struck with the
+stranger’s air, all wondered who he could be; and Kitty and Lydia,
+determined if possible to find out, led the way across the street, under
+pretense of wanting something in an opposite shop, and fortunately
+had just gained the pavement when the two gentlemen, turning back, had
+reached the same spot. Mr. Denny addressed them directly, and entreated
+permission to introduce his friend, Mr. Wickham, who had returned with
+him the day before from town, and he was happy to say had accepted a
+commission in their corps. This was exactly as it should be; for the
+young man wanted only regimentals to make him completely charming.
+His appearance was greatly in his favour; he had all the best part of
+beauty, a fine countenance, a good figure, and very pleasing address.
+The introduction was followed up on his side by a happy readiness
+of conversation--a readiness at the same time perfectly correct and
+unassuming; and the whole party were still standing and talking together
+very agreeably, when the sound of horses drew their notice, and Darcy
+and Bingley were seen riding down the street. On distinguishing the
+ladies of the group, the two gentlemen came directly towards them, and
+began the usual civilities. Bingley was the principal spokesman, and
+Miss Bennet the principal object. He was then, he said, on his way to
+Longbourn on purpose to inquire after her. Mr. Darcy corroborated
+it with a bow, and was beginning to determine not to fix his eyes
+on Elizabeth, when they were suddenly arrested by the sight of the
+stranger, and Elizabeth happening to see the countenance of both as they
+looked at each other, was all astonishment at the effect of the meeting.
+Both changed colour, one looked white, the other red. Mr. Wickham,
+after a few moments, touched his hat--a salutation which Mr. Darcy just
+deigned to return. What could be the meaning of it? It was impossible to
+imagine; it was impossible not to long to know.
+
+In another minute, Mr. Bingley, but without seeming to have noticed what
+passed, took leave and rode on with his friend.
+
+Mr. Denny and Mr. Wickham walked with the young ladies to the door of
+Mr. Phillip’s house, and then made their bows, in spite of Miss Lydia’s
+pressing entreaties that they should come in, and even in spite of
+Mrs. Phillips’s throwing up the parlour window and loudly seconding the
+invitation.
+
+Mrs. Phillips was always glad to see her nieces; and the two eldest,
+from their recent absence, were particularly welcome, and she was
+eagerly expressing her surprise at their sudden return home, which, as
+their own carriage had not fetched them, she should have known nothing
+about, if she had not happened to see Mr. Jones’s shop-boy in the
+street, who had told her that they were not to send any more draughts to
+Netherfield because the Miss Bennets were come away, when her civility
+was claimed towards Mr. Collins by Jane’s introduction of him. She
+received him with her very best politeness, which he returned with
+as much more, apologising for his intrusion, without any previous
+acquaintance with her, which he could not help flattering himself,
+however, might be justified by his relationship to the young ladies who
+introduced him to her notice. Mrs. Phillips was quite awed by such an
+excess of good breeding; but her contemplation of one stranger was soon
+put to an end by exclamations and inquiries about the other; of whom,
+however, she could only tell her nieces what they already knew, that
+Mr. Denny had brought him from London, and that he was to have a
+lieutenant’s commission in the ----shire. She had been watching him the
+last hour, she said, as he walked up and down the street, and had Mr.
+Wickham appeared, Kitty and Lydia would certainly have continued the
+occupation, but unluckily no one passed windows now except a few of the
+officers, who, in comparison with the stranger, were become “stupid,
+disagreeable fellows.” Some of them were to dine with the Phillipses
+the next day, and their aunt promised to make her husband call on Mr.
+Wickham, and give him an invitation also, if the family from Longbourn
+would come in the evening. This was agreed to, and Mrs. Phillips
+protested that they would have a nice comfortable noisy game of lottery
+tickets, and a little bit of hot supper afterwards. The prospect of such
+delights was very cheering, and they parted in mutual good spirits. Mr.
+Collins repeated his apologies in quitting the room, and was assured
+with unwearying civility that they were perfectly needless.
+
+As they walked home, Elizabeth related to Jane what she had seen pass
+between the two gentlemen; but though Jane would have defended either
+or both, had they appeared to be in the wrong, she could no more explain
+such behaviour than her sister.
+
+Mr. Collins on his return highly gratified Mrs. Bennet by admiring
+Mrs. Phillips’s manners and politeness. He protested that, except Lady
+Catherine and her daughter, he had never seen a more elegant woman;
+for she had not only received him with the utmost civility, but even
+pointedly included him in her invitation for the next evening, although
+utterly unknown to her before. Something, he supposed, might be
+attributed to his connection with them, but yet he had never met with so
+much attention in the whole course of his life.
+
+
+
+Chapter 16
+
+
+As no objection was made to the young people’s engagement with their
+aunt, and all Mr. Collins’s scruples of leaving Mr. and Mrs. Bennet for
+a single evening during his visit were most steadily resisted, the coach
+conveyed him and his five cousins at a suitable hour to Meryton; and
+the girls had the pleasure of hearing, as they entered the drawing-room,
+that Mr. Wickham had accepted their uncle’s invitation, and was then in
+the house.
+
+When this information was given, and they had all taken their seats, Mr.
+Collins was at leisure to look around him and admire, and he was so much
+struck with the size and furniture of the apartment, that he declared he
+might almost have supposed himself in the small summer breakfast
+parlour at Rosings; a comparison that did not at first convey much
+gratification; but when Mrs. Phillips understood from him what
+Rosings was, and who was its proprietor--when she had listened to the
+description of only one of Lady Catherine’s drawing-rooms, and found
+that the chimney-piece alone had cost eight hundred pounds, she felt all
+the force of the compliment, and would hardly have resented a comparison
+with the housekeeper’s room.
+
+In describing to her all the grandeur of Lady Catherine and her mansion,
+with occasional digressions in praise of his own humble abode, and
+the improvements it was receiving, he was happily employed until the
+gentlemen joined them; and he found in Mrs. Phillips a very attentive
+listener, whose opinion of his consequence increased with what she
+heard, and who was resolving to retail it all among her neighbours as
+soon as she could. To the girls, who could not listen to their cousin,
+and who had nothing to do but to wish for an instrument, and examine
+their own indifferent imitations of china on the mantelpiece, the
+interval of waiting appeared very long. It was over at last, however.
+The gentlemen did approach, and when Mr. Wickham walked into the room,
+Elizabeth felt that she had neither been seeing him before, nor thinking
+of him since, with the smallest degree of unreasonable admiration.
+The officers of the ----shire were in general a very creditable,
+gentlemanlike set, and the best of them were of the present party; but
+Mr. Wickham was as far beyond them all in person, countenance, air, and
+walk, as _they_ were superior to the broad-faced, stuffy uncle Phillips,
+breathing port wine, who followed them into the room.
+
+Mr. Wickham was the happy man towards whom almost every female eye was
+turned, and Elizabeth was the happy woman by whom he finally seated
+himself; and the agreeable manner in which he immediately fell into
+conversation, though it was only on its being a wet night, made her feel
+that the commonest, dullest, most threadbare topic might be rendered
+interesting by the skill of the speaker.
+
+With such rivals for the notice of the fair as Mr. Wickham and the
+officers, Mr. Collins seemed to sink into insignificance; to the young
+ladies he certainly was nothing; but he had still at intervals a kind
+listener in Mrs. Phillips, and was by her watchfulness, most abundantly
+supplied with coffee and muffin. When the card-tables were placed, he
+had the opportunity of obliging her in turn, by sitting down to whist.
+
+“I know little of the game at present,” said he, “but I shall be glad
+to improve myself, for in my situation in life--” Mrs. Phillips was very
+glad for his compliance, but could not wait for his reason.
+
+Mr. Wickham did not play at whist, and with ready delight was he
+received at the other table between Elizabeth and Lydia. At first there
+seemed danger of Lydia’s engrossing him entirely, for she was a most
+determined talker; but being likewise extremely fond of lottery tickets,
+she soon grew too much interested in the game, too eager in making bets
+and exclaiming after prizes to have attention for anyone in particular.
+Allowing for the common demands of the game, Mr. Wickham was therefore
+at leisure to talk to Elizabeth, and she was very willing to hear
+him, though what she chiefly wished to hear she could not hope to be
+told--the history of his acquaintance with Mr. Darcy. She dared not
+even mention that gentleman. Her curiosity, however, was unexpectedly
+relieved. Mr. Wickham began the subject himself. He inquired how far
+Netherfield was from Meryton; and, after receiving her answer, asked in
+a hesitating manner how long Mr. Darcy had been staying there.
+
+“About a month,” said Elizabeth; and then, unwilling to let the subject
+drop, added, “He is a man of very large property in Derbyshire, I
+understand.”
+
+“Yes,” replied Mr. Wickham; “his estate there is a noble one. A clear
+ten thousand per annum. You could not have met with a person more
+capable of giving you certain information on that head than myself, for
+I have been connected with his family in a particular manner from my
+infancy.”
+
+Elizabeth could not but look surprised.
+
+“You may well be surprised, Miss Bennet, at such an assertion, after
+seeing, as you probably might, the very cold manner of our meeting
+yesterday. Are you much acquainted with Mr. Darcy?”
+
+“As much as I ever wish to be,” cried Elizabeth very warmly. “I have
+spent four days in the same house with him, and I think him very
+disagreeable.”
+
+“I have no right to give _my_ opinion,” said Wickham, “as to his being
+agreeable or otherwise. I am not qualified to form one. I have known him
+too long and too well to be a fair judge. It is impossible for _me_
+to be impartial. But I believe your opinion of him would in general
+astonish--and perhaps you would not express it quite so strongly
+anywhere else. Here you are in your own family.”
+
+“Upon my word, I say no more _here_ than I might say in any house in
+the neighbourhood, except Netherfield. He is not at all liked in
+Hertfordshire. Everybody is disgusted with his pride. You will not find
+him more favourably spoken of by anyone.”
+
+“I cannot pretend to be sorry,” said Wickham, after a short
+interruption, “that he or that any man should not be estimated beyond
+their deserts; but with _him_ I believe it does not often happen. The
+world is blinded by his fortune and consequence, or frightened by his
+high and imposing manners, and sees him only as he chooses to be seen.”
+
+“I should take him, even on _my_ slight acquaintance, to be an
+ill-tempered man.” Wickham only shook his head.
+
+“I wonder,” said he, at the next opportunity of speaking, “whether he is
+likely to be in this country much longer.”
+
+“I do not at all know; but I _heard_ nothing of his going away when I
+was at Netherfield. I hope your plans in favour of the ----shire will
+not be affected by his being in the neighbourhood.”
+
+“Oh! no--it is not for _me_ to be driven away by Mr. Darcy. If _he_
+wishes to avoid seeing _me_, he must go. We are not on friendly terms,
+and it always gives me pain to meet him, but I have no reason for
+avoiding _him_ but what I might proclaim before all the world, a sense
+of very great ill-usage, and most painful regrets at his being what he
+is. His father, Miss Bennet, the late Mr. Darcy, was one of the best men
+that ever breathed, and the truest friend I ever had; and I can never
+be in company with this Mr. Darcy without being grieved to the soul by
+a thousand tender recollections. His behaviour to myself has been
+scandalous; but I verily believe I could forgive him anything and
+everything, rather than his disappointing the hopes and disgracing the
+memory of his father.”
+
+Elizabeth found the interest of the subject increase, and listened with
+all her heart; but the delicacy of it prevented further inquiry.
+
+Mr. Wickham began to speak on more general topics, Meryton, the
+neighbourhood, the society, appearing highly pleased with all that
+he had yet seen, and speaking of the latter with gentle but very
+intelligible gallantry.
+
+“It was the prospect of constant society, and good society,” he added,
+“which was my chief inducement to enter the ----shire. I knew it to be
+a most respectable, agreeable corps, and my friend Denny tempted me
+further by his account of their present quarters, and the very great
+attentions and excellent acquaintances Meryton had procured them.
+Society, I own, is necessary to me. I have been a disappointed man, and
+my spirits will not bear solitude. I _must_ have employment and society.
+A military life is not what I was intended for, but circumstances have
+now made it eligible. The church _ought_ to have been my profession--I
+was brought up for the church, and I should at this time have been in
+possession of a most valuable living, had it pleased the gentleman we
+were speaking of just now.”
+
+“Indeed!”
+
+“Yes--the late Mr. Darcy bequeathed me the next presentation of the best
+living in his gift. He was my godfather, and excessively attached to me.
+I cannot do justice to his kindness. He meant to provide for me amply,
+and thought he had done it; but when the living fell, it was given
+elsewhere.”
+
+“Good heavens!” cried Elizabeth; “but how could _that_ be? How could his
+will be disregarded? Why did you not seek legal redress?”
+
+“There was just such an informality in the terms of the bequest as to
+give me no hope from law. A man of honour could not have doubted the
+intention, but Mr. Darcy chose to doubt it--or to treat it as a merely
+conditional recommendation, and to assert that I had forfeited all claim
+to it by extravagance, imprudence--in short anything or nothing. Certain
+it is, that the living became vacant two years ago, exactly as I was
+of an age to hold it, and that it was given to another man; and no
+less certain is it, that I cannot accuse myself of having really done
+anything to deserve to lose it. I have a warm, unguarded temper, and
+I may have spoken my opinion _of_ him, and _to_ him, too freely. I can
+recall nothing worse. But the fact is, that we are very different sort
+of men, and that he hates me.”
+
+“This is quite shocking! He deserves to be publicly disgraced.”
+
+“Some time or other he _will_ be--but it shall not be by _me_. Till I
+can forget his father, I can never defy or expose _him_.”
+
+Elizabeth honoured him for such feelings, and thought him handsomer than
+ever as he expressed them.
+
+“But what,” said she, after a pause, “can have been his motive? What can
+have induced him to behave so cruelly?”
+
+“A thorough, determined dislike of me--a dislike which I cannot but
+attribute in some measure to jealousy. Had the late Mr. Darcy liked me
+less, his son might have borne with me better; but his father’s uncommon
+attachment to me irritated him, I believe, very early in life. He had
+not a temper to bear the sort of competition in which we stood--the sort
+of preference which was often given me.”
+
+“I had not thought Mr. Darcy so bad as this--though I have never liked
+him. I had not thought so very ill of him. I had supposed him to be
+despising his fellow-creatures in general, but did not suspect him of
+descending to such malicious revenge, such injustice, such inhumanity as
+this.”
+
+After a few minutes’ reflection, however, she continued, “I _do_
+remember his boasting one day, at Netherfield, of the implacability of
+his resentments, of his having an unforgiving temper. His disposition
+must be dreadful.”
+
+“I will not trust myself on the subject,” replied Wickham; “I can hardly
+be just to him.”
+
+Elizabeth was again deep in thought, and after a time exclaimed, “To
+treat in such a manner the godson, the friend, the favourite of his
+father!” She could have added, “A young man, too, like _you_, whose very
+countenance may vouch for your being amiable”--but she contented herself
+with, “and one, too, who had probably been his companion from childhood,
+connected together, as I think you said, in the closest manner!”
+
+“We were born in the same parish, within the same park; the greatest
+part of our youth was passed together; inmates of the same house,
+sharing the same amusements, objects of the same parental care. _My_
+father began life in the profession which your uncle, Mr. Phillips,
+appears to do so much credit to--but he gave up everything to be of
+use to the late Mr. Darcy and devoted all his time to the care of the
+Pemberley property. He was most highly esteemed by Mr. Darcy, a most
+intimate, confidential friend. Mr. Darcy often acknowledged himself to
+be under the greatest obligations to my father’s active superintendence,
+and when, immediately before my father’s death, Mr. Darcy gave him a
+voluntary promise of providing for me, I am convinced that he felt it to
+be as much a debt of gratitude to _him_, as of his affection to myself.”
+
+“How strange!” cried Elizabeth. “How abominable! I wonder that the very
+pride of this Mr. Darcy has not made him just to you! If from no better
+motive, that he should not have been too proud to be dishonest--for
+dishonesty I must call it.”
+
+“It _is_ wonderful,” replied Wickham, “for almost all his actions may
+be traced to pride; and pride had often been his best friend. It has
+connected him nearer with virtue than with any other feeling. But we are
+none of us consistent, and in his behaviour to me there were stronger
+impulses even than pride.”
+
+“Can such abominable pride as his have ever done him good?”
+
+“Yes. It has often led him to be liberal and generous, to give his money
+freely, to display hospitality, to assist his tenants, and relieve the
+poor. Family pride, and _filial_ pride--for he is very proud of what
+his father was--have done this. Not to appear to disgrace his family,
+to degenerate from the popular qualities, or lose the influence of the
+Pemberley House, is a powerful motive. He has also _brotherly_ pride,
+which, with _some_ brotherly affection, makes him a very kind and
+careful guardian of his sister, and you will hear him generally cried up
+as the most attentive and best of brothers.”
+
+“What sort of girl is Miss Darcy?”
+
+He shook his head. “I wish I could call her amiable. It gives me pain to
+speak ill of a Darcy. But she is too much like her brother--very, very
+proud. As a child, she was affectionate and pleasing, and extremely fond
+of me; and I have devoted hours and hours to her amusement. But she is
+nothing to me now. She is a handsome girl, about fifteen or sixteen,
+and, I understand, highly accomplished. Since her father’s death, her
+home has been London, where a lady lives with her, and superintends her
+education.”
+
+After many pauses and many trials of other subjects, Elizabeth could not
+help reverting once more to the first, and saying:
+
+“I am astonished at his intimacy with Mr. Bingley! How can Mr. Bingley,
+who seems good humour itself, and is, I really believe, truly amiable,
+be in friendship with such a man? How can they suit each other? Do you
+know Mr. Bingley?”
+
+“Not at all.”
+
+“He is a sweet-tempered, amiable, charming man. He cannot know what Mr.
+Darcy is.”
+
+“Probably not; but Mr. Darcy can please where he chooses. He does not
+want abilities. He can be a conversible companion if he thinks it worth
+his while. Among those who are at all his equals in consequence, he is
+a very different man from what he is to the less prosperous. His
+pride never deserts him; but with the rich he is liberal-minded, just,
+sincere, rational, honourable, and perhaps agreeable--allowing something
+for fortune and figure.”
+
+The whist party soon afterwards breaking up, the players gathered round
+the other table and Mr. Collins took his station between his cousin
+Elizabeth and Mrs. Phillips. The usual inquiries as to his success were
+made by the latter. It had not been very great; he had lost every
+point; but when Mrs. Phillips began to express her concern thereupon,
+he assured her with much earnest gravity that it was not of the least
+importance, that he considered the money as a mere trifle, and begged
+that she would not make herself uneasy.
+
+“I know very well, madam,” said he, “that when persons sit down to a
+card-table, they must take their chances of these things, and happily I
+am not in such circumstances as to make five shillings any object. There
+are undoubtedly many who could not say the same, but thanks to Lady
+Catherine de Bourgh, I am removed far beyond the necessity of regarding
+little matters.”
+
+Mr. Wickham’s attention was caught; and after observing Mr. Collins for
+a few moments, he asked Elizabeth in a low voice whether her relation
+was very intimately acquainted with the family of de Bourgh.
+
+“Lady Catherine de Bourgh,” she replied, “has very lately given him
+a living. I hardly know how Mr. Collins was first introduced to her
+notice, but he certainly has not known her long.”
+
+“You know of course that Lady Catherine de Bourgh and Lady Anne Darcy
+were sisters; consequently that she is aunt to the present Mr. Darcy.”
+
+“No, indeed, I did not. I knew nothing at all of Lady Catherine’s
+connections. I never heard of her existence till the day before
+yesterday.”
+
+“Her daughter, Miss de Bourgh, will have a very large fortune, and it is
+believed that she and her cousin will unite the two estates.”
+
+This information made Elizabeth smile, as she thought of poor Miss
+Bingley. Vain indeed must be all her attentions, vain and useless her
+affection for his sister and her praise of himself, if he were already
+self-destined for another.
+
+“Mr. Collins,” said she, “speaks highly both of Lady Catherine and her
+daughter; but from some particulars that he has related of her ladyship,
+I suspect his gratitude misleads him, and that in spite of her being his
+patroness, she is an arrogant, conceited woman.”
+
+“I believe her to be both in a great degree,” replied Wickham; “I have
+not seen her for many years, but I very well remember that I never liked
+her, and that her manners were dictatorial and insolent. She has the
+reputation of being remarkably sensible and clever; but I rather believe
+she derives part of her abilities from her rank and fortune, part from
+her authoritative manner, and the rest from the pride for her
+nephew, who chooses that everyone connected with him should have an
+understanding of the first class.”
+
+Elizabeth allowed that he had given a very rational account of it, and
+they continued talking together, with mutual satisfaction till supper
+put an end to cards, and gave the rest of the ladies their share of Mr.
+Wickham’s attentions. There could be no conversation in the noise
+of Mrs. Phillips’s supper party, but his manners recommended him to
+everybody. Whatever he said, was said well; and whatever he did, done
+gracefully. Elizabeth went away with her head full of him. She could
+think of nothing but of Mr. Wickham, and of what he had told her, all
+the way home; but there was not time for her even to mention his name
+as they went, for neither Lydia nor Mr. Collins were once silent. Lydia
+talked incessantly of lottery tickets, of the fish she had lost and the
+fish she had won; and Mr. Collins in describing the civility of Mr. and
+Mrs. Phillips, protesting that he did not in the least regard his losses
+at whist, enumerating all the dishes at supper, and repeatedly fearing
+that he crowded his cousins, had more to say than he could well manage
+before the carriage stopped at Longbourn House.
+
+
+
+Chapter 17
+
+
+Elizabeth related to Jane the next day what had passed between Mr.
+Wickham and herself. Jane listened with astonishment and concern; she
+knew not how to believe that Mr. Darcy could be so unworthy of Mr.
+Bingley’s regard; and yet, it was not in her nature to question the
+veracity of a young man of such amiable appearance as Wickham. The
+possibility of his having endured such unkindness, was enough to
+interest all her tender feelings; and nothing remained therefore to be
+done, but to think well of them both, to defend the conduct of each,
+and throw into the account of accident or mistake whatever could not be
+otherwise explained.
+
+“They have both,” said she, “been deceived, I dare say, in some way
+or other, of which we can form no idea. Interested people have perhaps
+misrepresented each to the other. It is, in short, impossible for us to
+conjecture the causes or circumstances which may have alienated them,
+without actual blame on either side.”
+
+“Very true, indeed; and now, my dear Jane, what have you got to say on
+behalf of the interested people who have probably been concerned in the
+business? Do clear _them_ too, or we shall be obliged to think ill of
+somebody.”
+
+“Laugh as much as you choose, but you will not laugh me out of my
+opinion. My dearest Lizzy, do but consider in what a disgraceful light
+it places Mr. Darcy, to be treating his father’s favourite in such
+a manner, one whom his father had promised to provide for. It is
+impossible. No man of common humanity, no man who had any value for his
+character, could be capable of it. Can his most intimate friends be so
+excessively deceived in him? Oh! no.”
+
+“I can much more easily believe Mr. Bingley’s being imposed on, than
+that Mr. Wickham should invent such a history of himself as he gave me
+last night; names, facts, everything mentioned without ceremony. If it
+be not so, let Mr. Darcy contradict it. Besides, there was truth in his
+looks.”
+
+“It is difficult indeed--it is distressing. One does not know what to
+think.”
+
+“I beg your pardon; one knows exactly what to think.”
+
+But Jane could think with certainty on only one point--that Mr. Bingley,
+if he _had_ been imposed on, would have much to suffer when the affair
+became public.
+
+The two young ladies were summoned from the shrubbery, where this
+conversation passed, by the arrival of the very persons of whom they had
+been speaking; Mr. Bingley and his sisters came to give their personal
+invitation for the long-expected ball at Netherfield, which was fixed
+for the following Tuesday. The two ladies were delighted to see their
+dear friend again, called it an age since they had met, and repeatedly
+asked what she had been doing with herself since their separation. To
+the rest of the family they paid little attention; avoiding Mrs. Bennet
+as much as possible, saying not much to Elizabeth, and nothing at all to
+the others. They were soon gone again, rising from their seats with an
+activity which took their brother by surprise, and hurrying off as if
+eager to escape from Mrs. Bennet’s civilities.
+
+The prospect of the Netherfield ball was extremely agreeable to every
+female of the family. Mrs. Bennet chose to consider it as given in
+compliment to her eldest daughter, and was particularly flattered
+by receiving the invitation from Mr. Bingley himself, instead of a
+ceremonious card. Jane pictured to herself a happy evening in the
+society of her two friends, and the attentions of their brother; and
+Elizabeth thought with pleasure of dancing a great deal with Mr.
+Wickham, and of seeing a confirmation of everything in Mr. Darcy’s look
+and behaviour. The happiness anticipated by Catherine and Lydia depended
+less on any single event, or any particular person, for though they
+each, like Elizabeth, meant to dance half the evening with Mr. Wickham,
+he was by no means the only partner who could satisfy them, and a ball
+was, at any rate, a ball. And even Mary could assure her family that she
+had no disinclination for it.
+
+“While I can have my mornings to myself,” said she, “it is enough--I
+think it is no sacrifice to join occasionally in evening engagements.
+Society has claims on us all; and I profess myself one of those
+who consider intervals of recreation and amusement as desirable for
+everybody.”
+
+Elizabeth’s spirits were so high on this occasion, that though she did
+not often speak unnecessarily to Mr. Collins, she could not help asking
+him whether he intended to accept Mr. Bingley’s invitation, and if
+he did, whether he would think it proper to join in the evening’s
+amusement; and she was rather surprised to find that he entertained no
+scruple whatever on that head, and was very far from dreading a rebuke
+either from the Archbishop, or Lady Catherine de Bourgh, by venturing to
+dance.
+
+“I am by no means of the opinion, I assure you,” said he, “that a ball
+of this kind, given by a young man of character, to respectable people,
+can have any evil tendency; and I am so far from objecting to dancing
+myself, that I shall hope to be honoured with the hands of all my fair
+cousins in the course of the evening; and I take this opportunity of
+soliciting yours, Miss Elizabeth, for the two first dances especially,
+a preference which I trust my cousin Jane will attribute to the right
+cause, and not to any disrespect for her.”
+
+Elizabeth felt herself completely taken in. She had fully proposed being
+engaged by Mr. Wickham for those very dances; and to have Mr. Collins
+instead! her liveliness had never been worse timed. There was no help
+for it, however. Mr. Wickham’s happiness and her own were perforce
+delayed a little longer, and Mr. Collins’s proposal accepted with as
+good a grace as she could. She was not the better pleased with his
+gallantry from the idea it suggested of something more. It now first
+struck her, that _she_ was selected from among her sisters as worthy
+of being mistress of Hunsford Parsonage, and of assisting to form a
+quadrille table at Rosings, in the absence of more eligible visitors.
+The idea soon reached to conviction, as she observed his increasing
+civilities toward herself, and heard his frequent attempt at a
+compliment on her wit and vivacity; and though more astonished than
+gratified herself by this effect of her charms, it was not long before
+her mother gave her to understand that the probability of their marriage
+was extremely agreeable to _her_. Elizabeth, however, did not choose
+to take the hint, being well aware that a serious dispute must be the
+consequence of any reply. Mr. Collins might never make the offer, and
+till he did, it was useless to quarrel about him.
+
+If there had not been a Netherfield ball to prepare for and talk of, the
+younger Miss Bennets would have been in a very pitiable state at this
+time, for from the day of the invitation, to the day of the ball, there
+was such a succession of rain as prevented their walking to Meryton
+once. No aunt, no officers, no news could be sought after--the very
+shoe-roses for Netherfield were got by proxy. Even Elizabeth might have
+found some trial of her patience in weather which totally suspended the
+improvement of her acquaintance with Mr. Wickham; and nothing less than
+a dance on Tuesday, could have made such a Friday, Saturday, Sunday, and
+Monday endurable to Kitty and Lydia.
+
+
+
+Chapter 18
+
+
+Till Elizabeth entered the drawing-room at Netherfield, and looked in
+vain for Mr. Wickham among the cluster of red coats there assembled, a
+doubt of his being present had never occurred to her. The certainty
+of meeting him had not been checked by any of those recollections that
+might not unreasonably have alarmed her. She had dressed with more than
+usual care, and prepared in the highest spirits for the conquest of all
+that remained unsubdued of his heart, trusting that it was not more than
+might be won in the course of the evening. But in an instant arose
+the dreadful suspicion of his being purposely omitted for Mr. Darcy’s
+pleasure in the Bingleys’ invitation to the officers; and though
+this was not exactly the case, the absolute fact of his absence was
+pronounced by his friend Denny, to whom Lydia eagerly applied, and who
+told them that Wickham had been obliged to go to town on business the
+day before, and was not yet returned; adding, with a significant smile,
+“I do not imagine his business would have called him away just now, if
+he had not wanted to avoid a certain gentleman here.”
+
+This part of his intelligence, though unheard by Lydia, was caught by
+Elizabeth, and, as it assured her that Darcy was not less answerable for
+Wickham’s absence than if her first surmise had been just, every
+feeling of displeasure against the former was so sharpened by immediate
+disappointment, that she could hardly reply with tolerable civility to
+the polite inquiries which he directly afterwards approached to make.
+Attendance, forbearance, patience with Darcy, was injury to Wickham. She
+was resolved against any sort of conversation with him, and turned away
+with a degree of ill-humour which she could not wholly surmount even in
+speaking to Mr. Bingley, whose blind partiality provoked her.
+
+But Elizabeth was not formed for ill-humour; and though every prospect
+of her own was destroyed for the evening, it could not dwell long on her
+spirits; and having told all her griefs to Charlotte Lucas, whom she had
+not seen for a week, she was soon able to make a voluntary transition
+to the oddities of her cousin, and to point him out to her particular
+notice. The first two dances, however, brought a return of distress;
+they were dances of mortification. Mr. Collins, awkward and solemn,
+apologising instead of attending, and often moving wrong without being
+aware of it, gave her all the shame and misery which a disagreeable
+partner for a couple of dances can give. The moment of her release from
+him was ecstasy.
+
+She danced next with an officer, and had the refreshment of talking of
+Wickham, and of hearing that he was universally liked. When those dances
+were over, she returned to Charlotte Lucas, and was in conversation with
+her, when she found herself suddenly addressed by Mr. Darcy who took
+her so much by surprise in his application for her hand, that,
+without knowing what she did, she accepted him. He walked away again
+immediately, and she was left to fret over her own want of presence of
+mind; Charlotte tried to console her:
+
+“I dare say you will find him very agreeable.”
+
+“Heaven forbid! _That_ would be the greatest misfortune of all! To find
+a man agreeable whom one is determined to hate! Do not wish me such an
+evil.”
+
+When the dancing recommenced, however, and Darcy approached to claim her
+hand, Charlotte could not help cautioning her in a whisper, not to be a
+simpleton, and allow her fancy for Wickham to make her appear unpleasant
+in the eyes of a man ten times his consequence. Elizabeth made no
+answer, and took her place in the set, amazed at the dignity to which
+she was arrived in being allowed to stand opposite to Mr. Darcy, and
+reading in her neighbours’ looks, their equal amazement in beholding
+it. They stood for some time without speaking a word; and she began to
+imagine that their silence was to last through the two dances, and at
+first was resolved not to break it; till suddenly fancying that it would
+be the greater punishment to her partner to oblige him to talk, she made
+some slight observation on the dance. He replied, and was again
+silent. After a pause of some minutes, she addressed him a second time
+with:--“It is _your_ turn to say something now, Mr. Darcy. I talked
+about the dance, and _you_ ought to make some sort of remark on the size
+of the room, or the number of couples.”
+
+He smiled, and assured her that whatever she wished him to say should be
+said.
+
+“Very well. That reply will do for the present. Perhaps by and by I may
+observe that private balls are much pleasanter than public ones. But
+_now_ we may be silent.”
+
+“Do you talk by rule, then, while you are dancing?”
+
+“Sometimes. One must speak a little, you know. It would look odd to be
+entirely silent for half an hour together; and yet for the advantage of
+_some_, conversation ought to be so arranged, as that they may have the
+trouble of saying as little as possible.”
+
+“Are you consulting your own feelings in the present case, or do you
+imagine that you are gratifying mine?”
+
+“Both,” replied Elizabeth archly; “for I have always seen a great
+similarity in the turn of our minds. We are each of an unsocial,
+taciturn disposition, unwilling to speak, unless we expect to say
+something that will amaze the whole room, and be handed down to
+posterity with all the eclat of a proverb.”
+
+“This is no very striking resemblance of your own character, I am sure,”
+ said he. “How near it may be to _mine_, I cannot pretend to say. _You_
+think it a faithful portrait undoubtedly.”
+
+“I must not decide on my own performance.”
+
+He made no answer, and they were again silent till they had gone down
+the dance, when he asked her if she and her sisters did not very often
+walk to Meryton. She answered in the affirmative, and, unable to resist
+the temptation, added, “When you met us there the other day, we had just
+been forming a new acquaintance.”
+
+The effect was immediate. A deeper shade of _hauteur_ overspread his
+features, but he said not a word, and Elizabeth, though blaming herself
+for her own weakness, could not go on. At length Darcy spoke, and in a
+constrained manner said, “Mr. Wickham is blessed with such happy manners
+as may ensure his _making_ friends--whether he may be equally capable of
+_retaining_ them, is less certain.”
+
+“He has been so unlucky as to lose _your_ friendship,” replied Elizabeth
+with emphasis, “and in a manner which he is likely to suffer from all
+his life.”
+
+Darcy made no answer, and seemed desirous of changing the subject. At
+that moment, Sir William Lucas appeared close to them, meaning to pass
+through the set to the other side of the room; but on perceiving Mr.
+Darcy, he stopped with a bow of superior courtesy to compliment him on
+his dancing and his partner.
+
+“I have been most highly gratified indeed, my dear sir. Such very
+superior dancing is not often seen. It is evident that you belong to the
+first circles. Allow me to say, however, that your fair partner does not
+disgrace you, and that I must hope to have this pleasure often repeated,
+especially when a certain desirable event, my dear Eliza (glancing at
+her sister and Bingley) shall take place. What congratulations will then
+flow in! I appeal to Mr. Darcy:--but let me not interrupt you, sir. You
+will not thank me for detaining you from the bewitching converse of that
+young lady, whose bright eyes are also upbraiding me.”
+
+The latter part of this address was scarcely heard by Darcy; but Sir
+William’s allusion to his friend seemed to strike him forcibly, and his
+eyes were directed with a very serious expression towards Bingley and
+Jane, who were dancing together. Recovering himself, however, shortly,
+he turned to his partner, and said, “Sir William’s interruption has made
+me forget what we were talking of.”
+
+“I do not think we were speaking at all. Sir William could not have
+interrupted two people in the room who had less to say for themselves.
+We have tried two or three subjects already without success, and what we
+are to talk of next I cannot imagine.”
+
+“What think you of books?” said he, smiling.
+
+“Books--oh! no. I am sure we never read the same, or not with the same
+feelings.”
+
+“I am sorry you think so; but if that be the case, there can at least be
+no want of subject. We may compare our different opinions.”
+
+“No--I cannot talk of books in a ball-room; my head is always full of
+something else.”
+
+“The _present_ always occupies you in such scenes--does it?” said he,
+with a look of doubt.
+
+“Yes, always,” she replied, without knowing what she said, for her
+thoughts had wandered far from the subject, as soon afterwards appeared
+by her suddenly exclaiming, “I remember hearing you once say, Mr. Darcy,
+that you hardly ever forgave, that your resentment once created was
+unappeasable. You are very cautious, I suppose, as to its _being
+created_.”
+
+“I am,” said he, with a firm voice.
+
+“And never allow yourself to be blinded by prejudice?”
+
+“I hope not.”
+
+“It is particularly incumbent on those who never change their opinion,
+to be secure of judging properly at first.”
+
+“May I ask to what these questions tend?”
+
+“Merely to the illustration of _your_ character,” said she, endeavouring
+to shake off her gravity. “I am trying to make it out.”
+
+“And what is your success?”
+
+She shook her head. “I do not get on at all. I hear such different
+accounts of you as puzzle me exceedingly.”
+
+“I can readily believe,” answered he gravely, “that reports may vary
+greatly with respect to me; and I could wish, Miss Bennet, that you were
+not to sketch my character at the present moment, as there is reason to
+fear that the performance would reflect no credit on either.”
+
+“But if I do not take your likeness now, I may never have another
+opportunity.”
+
+“I would by no means suspend any pleasure of yours,” he coldly replied.
+She said no more, and they went down the other dance and parted in
+silence; and on each side dissatisfied, though not to an equal degree,
+for in Darcy’s breast there was a tolerably powerful feeling towards
+her, which soon procured her pardon, and directed all his anger against
+another.
+
+They had not long separated, when Miss Bingley came towards her, and
+with an expression of civil disdain accosted her:
+
+“So, Miss Eliza, I hear you are quite delighted with George Wickham!
+Your sister has been talking to me about him, and asking me a thousand
+questions; and I find that the young man quite forgot to tell you, among
+his other communication, that he was the son of old Wickham, the late
+Mr. Darcy’s steward. Let me recommend you, however, as a friend, not to
+give implicit confidence to all his assertions; for as to Mr. Darcy’s
+using him ill, it is perfectly false; for, on the contrary, he has
+always been remarkably kind to him, though George Wickham has treated
+Mr. Darcy in a most infamous manner. I do not know the particulars, but
+I know very well that Mr. Darcy is not in the least to blame, that he
+cannot bear to hear George Wickham mentioned, and that though my brother
+thought that he could not well avoid including him in his invitation to
+the officers, he was excessively glad to find that he had taken himself
+out of the way. His coming into the country at all is a most insolent
+thing, indeed, and I wonder how he could presume to do it. I pity you,
+Miss Eliza, for this discovery of your favourite’s guilt; but really,
+considering his descent, one could not expect much better.”
+
+“His guilt and his descent appear by your account to be the same,” said
+Elizabeth angrily; “for I have heard you accuse him of nothing worse
+than of being the son of Mr. Darcy’s steward, and of _that_, I can
+assure you, he informed me himself.”
+
+“I beg your pardon,” replied Miss Bingley, turning away with a sneer.
+“Excuse my interference--it was kindly meant.”
+
+“Insolent girl!” said Elizabeth to herself. “You are much mistaken
+if you expect to influence me by such a paltry attack as this. I see
+nothing in it but your own wilful ignorance and the malice of Mr.
+Darcy.” She then sought her eldest sister, who had undertaken to make
+inquiries on the same subject of Bingley. Jane met her with a smile of
+such sweet complacency, a glow of such happy expression, as sufficiently
+marked how well she was satisfied with the occurrences of the evening.
+Elizabeth instantly read her feelings, and at that moment solicitude for
+Wickham, resentment against his enemies, and everything else, gave way
+before the hope of Jane’s being in the fairest way for happiness.
+
+“I want to know,” said she, with a countenance no less smiling than her
+sister’s, “what you have learnt about Mr. Wickham. But perhaps you have
+been too pleasantly engaged to think of any third person; in which case
+you may be sure of my pardon.”
+
+“No,” replied Jane, “I have not forgotten him; but I have nothing
+satisfactory to tell you. Mr. Bingley does not know the whole of
+his history, and is quite ignorant of the circumstances which have
+principally offended Mr. Darcy; but he will vouch for the good conduct,
+the probity, and honour of his friend, and is perfectly convinced that
+Mr. Wickham has deserved much less attention from Mr. Darcy than he has
+received; and I am sorry to say by his account as well as his sister’s,
+Mr. Wickham is by no means a respectable young man. I am afraid he has
+been very imprudent, and has deserved to lose Mr. Darcy’s regard.”
+
+“Mr. Bingley does not know Mr. Wickham himself?”
+
+“No; he never saw him till the other morning at Meryton.”
+
+“This account then is what he has received from Mr. Darcy. I am
+satisfied. But what does he say of the living?”
+
+“He does not exactly recollect the circumstances, though he has heard
+them from Mr. Darcy more than once, but he believes that it was left to
+him _conditionally_ only.”
+
+“I have not a doubt of Mr. Bingley’s sincerity,” said Elizabeth warmly;
+“but you must excuse my not being convinced by assurances only. Mr.
+Bingley’s defense of his friend was a very able one, I dare say; but
+since he is unacquainted with several parts of the story, and has learnt
+the rest from that friend himself, I shall venture to still think of
+both gentlemen as I did before.”
+
+She then changed the discourse to one more gratifying to each, and on
+which there could be no difference of sentiment. Elizabeth listened with
+delight to the happy, though modest hopes which Jane entertained of Mr.
+Bingley’s regard, and said all in her power to heighten her confidence
+in it. On their being joined by Mr. Bingley himself, Elizabeth withdrew
+to Miss Lucas; to whose inquiry after the pleasantness of her last
+partner she had scarcely replied, before Mr. Collins came up to them,
+and told her with great exultation that he had just been so fortunate as
+to make a most important discovery.
+
+“I have found out,” said he, “by a singular accident, that there is now
+in the room a near relation of my patroness. I happened to overhear the
+gentleman himself mentioning to the young lady who does the honours of
+the house the names of his cousin Miss de Bourgh, and of her mother Lady
+Catherine. How wonderfully these sort of things occur! Who would have
+thought of my meeting with, perhaps, a nephew of Lady Catherine de
+Bourgh in this assembly! I am most thankful that the discovery is made
+in time for me to pay my respects to him, which I am now going to
+do, and trust he will excuse my not having done it before. My total
+ignorance of the connection must plead my apology.”
+
+“You are not going to introduce yourself to Mr. Darcy!”
+
+“Indeed I am. I shall entreat his pardon for not having done it earlier.
+I believe him to be Lady Catherine’s _nephew_. It will be in my power to
+assure him that her ladyship was quite well yesterday se’nnight.”
+
+Elizabeth tried hard to dissuade him from such a scheme, assuring him
+that Mr. Darcy would consider his addressing him without introduction
+as an impertinent freedom, rather than a compliment to his aunt; that
+it was not in the least necessary there should be any notice on either
+side; and that if it were, it must belong to Mr. Darcy, the superior in
+consequence, to begin the acquaintance. Mr. Collins listened to her
+with the determined air of following his own inclination, and, when she
+ceased speaking, replied thus:
+
+“My dear Miss Elizabeth, I have the highest opinion in the world in
+your excellent judgement in all matters within the scope of your
+understanding; but permit me to say, that there must be a wide
+difference between the established forms of ceremony amongst the laity,
+and those which regulate the clergy; for, give me leave to observe that
+I consider the clerical office as equal in point of dignity with
+the highest rank in the kingdom--provided that a proper humility of
+behaviour is at the same time maintained. You must therefore allow me to
+follow the dictates of my conscience on this occasion, which leads me to
+perform what I look on as a point of duty. Pardon me for neglecting to
+profit by your advice, which on every other subject shall be my constant
+guide, though in the case before us I consider myself more fitted by
+education and habitual study to decide on what is right than a young
+lady like yourself.” And with a low bow he left her to attack Mr.
+Darcy, whose reception of his advances she eagerly watched, and whose
+astonishment at being so addressed was very evident. Her cousin prefaced
+his speech with a solemn bow and though she could not hear a word of
+it, she felt as if hearing it all, and saw in the motion of his lips the
+words “apology,” “Hunsford,” and “Lady Catherine de Bourgh.” It vexed
+her to see him expose himself to such a man. Mr. Darcy was eyeing him
+with unrestrained wonder, and when at last Mr. Collins allowed him time
+to speak, replied with an air of distant civility. Mr. Collins, however,
+was not discouraged from speaking again, and Mr. Darcy’s contempt seemed
+abundantly increasing with the length of his second speech, and at the
+end of it he only made him a slight bow, and moved another way. Mr.
+Collins then returned to Elizabeth.
+
+“I have no reason, I assure you,” said he, “to be dissatisfied with my
+reception. Mr. Darcy seemed much pleased with the attention. He answered
+me with the utmost civility, and even paid me the compliment of saying
+that he was so well convinced of Lady Catherine’s discernment as to be
+certain she could never bestow a favour unworthily. It was really a very
+handsome thought. Upon the whole, I am much pleased with him.”
+
+As Elizabeth had no longer any interest of her own to pursue, she turned
+her attention almost entirely on her sister and Mr. Bingley; and the
+train of agreeable reflections which her observations gave birth to,
+made her perhaps almost as happy as Jane. She saw her in idea settled in
+that very house, in all the felicity which a marriage of true affection
+could bestow; and she felt capable, under such circumstances, of
+endeavouring even to like Bingley’s two sisters. Her mother’s thoughts
+she plainly saw were bent the same way, and she determined not to
+venture near her, lest she might hear too much. When they sat down to
+supper, therefore, she considered it a most unlucky perverseness which
+placed them within one of each other; and deeply was she vexed to find
+that her mother was talking to that one person (Lady Lucas) freely,
+openly, and of nothing else but her expectation that Jane would soon
+be married to Mr. Bingley. It was an animating subject, and Mrs. Bennet
+seemed incapable of fatigue while enumerating the advantages of the
+match. His being such a charming young man, and so rich, and living but
+three miles from them, were the first points of self-gratulation; and
+then it was such a comfort to think how fond the two sisters were of
+Jane, and to be certain that they must desire the connection as much as
+she could do. It was, moreover, such a promising thing for her younger
+daughters, as Jane’s marrying so greatly must throw them in the way of
+other rich men; and lastly, it was so pleasant at her time of life to be
+able to consign her single daughters to the care of their sister, that
+she might not be obliged to go into company more than she liked. It was
+necessary to make this circumstance a matter of pleasure, because on
+such occasions it is the etiquette; but no one was less likely than Mrs.
+Bennet to find comfort in staying home at any period of her life. She
+concluded with many good wishes that Lady Lucas might soon be equally
+fortunate, though evidently and triumphantly believing there was no
+chance of it.
+
+In vain did Elizabeth endeavour to check the rapidity of her mother’s
+words, or persuade her to describe her felicity in a less audible
+whisper; for, to her inexpressible vexation, she could perceive that the
+chief of it was overheard by Mr. Darcy, who sat opposite to them. Her
+mother only scolded her for being nonsensical.
+
+“What is Mr. Darcy to me, pray, that I should be afraid of him? I am
+sure we owe him no such particular civility as to be obliged to say
+nothing _he_ may not like to hear.”
+
+“For heaven’s sake, madam, speak lower. What advantage can it be for you
+to offend Mr. Darcy? You will never recommend yourself to his friend by
+so doing!”
+
+Nothing that she could say, however, had any influence. Her mother would
+talk of her views in the same intelligible tone. Elizabeth blushed and
+blushed again with shame and vexation. She could not help frequently
+glancing her eye at Mr. Darcy, though every glance convinced her of what
+she dreaded; for though he was not always looking at her mother, she was
+convinced that his attention was invariably fixed by her. The expression
+of his face changed gradually from indignant contempt to a composed and
+steady gravity.
+
+At length, however, Mrs. Bennet had no more to say; and Lady Lucas, who
+had been long yawning at the repetition of delights which she saw no
+likelihood of sharing, was left to the comforts of cold ham and
+chicken. Elizabeth now began to revive. But not long was the interval of
+tranquillity; for, when supper was over, singing was talked of, and
+she had the mortification of seeing Mary, after very little entreaty,
+preparing to oblige the company. By many significant looks and silent
+entreaties, did she endeavour to prevent such a proof of complaisance,
+but in vain; Mary would not understand them; such an opportunity of
+exhibiting was delightful to her, and she began her song. Elizabeth’s
+eyes were fixed on her with most painful sensations, and she watched her
+progress through the several stanzas with an impatience which was very
+ill rewarded at their close; for Mary, on receiving, amongst the thanks
+of the table, the hint of a hope that she might be prevailed on to
+favour them again, after the pause of half a minute began another.
+Mary’s powers were by no means fitted for such a display; her voice was
+weak, and her manner affected. Elizabeth was in agonies. She looked at
+Jane, to see how she bore it; but Jane was very composedly talking to
+Bingley. She looked at his two sisters, and saw them making signs
+of derision at each other, and at Darcy, who continued, however,
+imperturbably grave. She looked at her father to entreat his
+interference, lest Mary should be singing all night. He took the hint,
+and when Mary had finished her second song, said aloud, “That will do
+extremely well, child. You have delighted us long enough. Let the other
+young ladies have time to exhibit.”
+
+Mary, though pretending not to hear, was somewhat disconcerted; and
+Elizabeth, sorry for her, and sorry for her father’s speech, was afraid
+her anxiety had done no good. Others of the party were now applied to.
+
+“If I,” said Mr. Collins, “were so fortunate as to be able to sing, I
+should have great pleasure, I am sure, in obliging the company with an
+air; for I consider music as a very innocent diversion, and perfectly
+compatible with the profession of a clergyman. I do not mean, however,
+to assert that we can be justified in devoting too much of our time
+to music, for there are certainly other things to be attended to. The
+rector of a parish has much to do. In the first place, he must make
+such an agreement for tithes as may be beneficial to himself and not
+offensive to his patron. He must write his own sermons; and the time
+that remains will not be too much for his parish duties, and the care
+and improvement of his dwelling, which he cannot be excused from making
+as comfortable as possible. And I do not think it of light importance
+that he should have attentive and conciliatory manners towards everybody,
+especially towards those to whom he owes his preferment. I cannot acquit
+him of that duty; nor could I think well of the man who should omit an
+occasion of testifying his respect towards anybody connected with the
+family.” And with a bow to Mr. Darcy, he concluded his speech, which had
+been spoken so loud as to be heard by half the room. Many stared--many
+smiled; but no one looked more amused than Mr. Bennet himself, while his
+wife seriously commended Mr. Collins for having spoken so sensibly,
+and observed in a half-whisper to Lady Lucas, that he was a remarkably
+clever, good kind of young man.
+
+To Elizabeth it appeared that, had her family made an agreement to
+expose themselves as much as they could during the evening, it would
+have been impossible for them to play their parts with more spirit or
+finer success; and happy did she think it for Bingley and her sister
+that some of the exhibition had escaped his notice, and that his
+feelings were not of a sort to be much distressed by the folly which he
+must have witnessed. That his two sisters and Mr. Darcy, however, should
+have such an opportunity of ridiculing her relations, was bad enough,
+and she could not determine whether the silent contempt of the
+gentleman, or the insolent smiles of the ladies, were more intolerable.
+
+The rest of the evening brought her little amusement. She was teased by
+Mr. Collins, who continued most perseveringly by her side, and though
+he could not prevail on her to dance with him again, put it out of her
+power to dance with others. In vain did she entreat him to stand up with
+somebody else, and offer to introduce him to any young lady in the room.
+He assured her, that as to dancing, he was perfectly indifferent to it;
+that his chief object was by delicate attentions to recommend himself to
+her and that he should therefore make a point of remaining close to her
+the whole evening. There was no arguing upon such a project. She owed
+her greatest relief to her friend Miss Lucas, who often joined them, and
+good-naturedly engaged Mr. Collins’s conversation to herself.
+
+She was at least free from the offense of Mr. Darcy’s further notice;
+though often standing within a very short distance of her, quite
+disengaged, he never came near enough to speak. She felt it to be the
+probable consequence of her allusions to Mr. Wickham, and rejoiced in
+it.
+
+The Longbourn party were the last of all the company to depart, and, by
+a manoeuvre of Mrs. Bennet, had to wait for their carriage a quarter of
+an hour after everybody else was gone, which gave them time to see how
+heartily they were wished away by some of the family. Mrs. Hurst and her
+sister scarcely opened their mouths, except to complain of fatigue, and
+were evidently impatient to have the house to themselves. They repulsed
+every attempt of Mrs. Bennet at conversation, and by so doing threw a
+languor over the whole party, which was very little relieved by the
+long speeches of Mr. Collins, who was complimenting Mr. Bingley and his
+sisters on the elegance of their entertainment, and the hospitality and
+politeness which had marked their behaviour to their guests. Darcy said
+nothing at all. Mr. Bennet, in equal silence, was enjoying the scene.
+Mr. Bingley and Jane were standing together, a little detached from the
+rest, and talked only to each other. Elizabeth preserved as steady a
+silence as either Mrs. Hurst or Miss Bingley; and even Lydia was too
+much fatigued to utter more than the occasional exclamation of “Lord,
+how tired I am!” accompanied by a violent yawn.
+
+When at length they arose to take leave, Mrs. Bennet was most pressingly
+civil in her hope of seeing the whole family soon at Longbourn, and
+addressed herself especially to Mr. Bingley, to assure him how happy he
+would make them by eating a family dinner with them at any time, without
+the ceremony of a formal invitation. Bingley was all grateful pleasure,
+and he readily engaged for taking the earliest opportunity of waiting on
+her, after his return from London, whither he was obliged to go the next
+day for a short time.
+
+Mrs. Bennet was perfectly satisfied, and quitted the house under the
+delightful persuasion that, allowing for the necessary preparations of
+settlements, new carriages, and wedding clothes, she should undoubtedly
+see her daughter settled at Netherfield in the course of three or four
+months. Of having another daughter married to Mr. Collins, she thought
+with equal certainty, and with considerable, though not equal, pleasure.
+Elizabeth was the least dear to her of all her children; and though the
+man and the match were quite good enough for _her_, the worth of each
+was eclipsed by Mr. Bingley and Netherfield.
+
+
+
+Chapter 19
+
+
+The next day opened a new scene at Longbourn. Mr. Collins made his
+declaration in form. Having resolved to do it without loss of time, as
+his leave of absence extended only to the following Saturday, and having
+no feelings of diffidence to make it distressing to himself even at
+the moment, he set about it in a very orderly manner, with all the
+observances, which he supposed a regular part of the business. On
+finding Mrs. Bennet, Elizabeth, and one of the younger girls together,
+soon after breakfast, he addressed the mother in these words:
+
+“May I hope, madam, for your interest with your fair daughter Elizabeth,
+when I solicit for the honour of a private audience with her in the
+course of this morning?”
+
+Before Elizabeth had time for anything but a blush of surprise, Mrs.
+Bennet answered instantly, “Oh dear!--yes--certainly. I am sure Lizzy
+will be very happy--I am sure she can have no objection. Come, Kitty, I
+want you up stairs.” And, gathering her work together, she was hastening
+away, when Elizabeth called out:
+
+“Dear madam, do not go. I beg you will not go. Mr. Collins must excuse
+me. He can have nothing to say to me that anybody need not hear. I am
+going away myself.”
+
+“No, no, nonsense, Lizzy. I desire you to stay where you are.” And upon
+Elizabeth’s seeming really, with vexed and embarrassed looks, about to
+escape, she added: “Lizzy, I _insist_ upon your staying and hearing Mr.
+Collins.”
+
+Elizabeth would not oppose such an injunction--and a moment’s
+consideration making her also sensible that it would be wisest to get it
+over as soon and as quietly as possible, she sat down again and tried to
+conceal, by incessant employment the feelings which were divided between
+distress and diversion. Mrs. Bennet and Kitty walked off, and as soon as
+they were gone, Mr. Collins began.
+
+“Believe me, my dear Miss Elizabeth, that your modesty, so far from
+doing you any disservice, rather adds to your other perfections. You
+would have been less amiable in my eyes had there _not_ been this little
+unwillingness; but allow me to assure you, that I have your respected
+mother’s permission for this address. You can hardly doubt the
+purport of my discourse, however your natural delicacy may lead you to
+dissemble; my attentions have been too marked to be mistaken. Almost as
+soon as I entered the house, I singled you out as the companion of
+my future life. But before I am run away with by my feelings on this
+subject, perhaps it would be advisable for me to state my reasons for
+marrying--and, moreover, for coming into Hertfordshire with the design
+of selecting a wife, as I certainly did.”
+
+The idea of Mr. Collins, with all his solemn composure, being run away
+with by his feelings, made Elizabeth so near laughing, that she could
+not use the short pause he allowed in any attempt to stop him further,
+and he continued:
+
+“My reasons for marrying are, first, that I think it a right thing for
+every clergyman in easy circumstances (like myself) to set the example
+of matrimony in his parish; secondly, that I am convinced that it will
+add very greatly to my happiness; and thirdly--which perhaps I ought
+to have mentioned earlier, that it is the particular advice and
+recommendation of the very noble lady whom I have the honour of calling
+patroness. Twice has she condescended to give me her opinion (unasked
+too!) on this subject; and it was but the very Saturday night before I
+left Hunsford--between our pools at quadrille, while Mrs. Jenkinson was
+arranging Miss de Bourgh’s footstool, that she said, ‘Mr. Collins, you
+must marry. A clergyman like you must marry. Choose properly, choose
+a gentlewoman for _my_ sake; and for your _own_, let her be an active,
+useful sort of person, not brought up high, but able to make a small
+income go a good way. This is my advice. Find such a woman as soon as
+you can, bring her to Hunsford, and I will visit her.’ Allow me, by the
+way, to observe, my fair cousin, that I do not reckon the notice
+and kindness of Lady Catherine de Bourgh as among the least of the
+advantages in my power to offer. You will find her manners beyond
+anything I can describe; and your wit and vivacity, I think, must be
+acceptable to her, especially when tempered with the silence and
+respect which her rank will inevitably excite. Thus much for my general
+intention in favour of matrimony; it remains to be told why my views
+were directed towards Longbourn instead of my own neighbourhood, where I
+can assure you there are many amiable young women. But the fact is, that
+being, as I am, to inherit this estate after the death of your honoured
+father (who, however, may live many years longer), I could not satisfy
+myself without resolving to choose a wife from among his daughters, that
+the loss to them might be as little as possible, when the melancholy
+event takes place--which, however, as I have already said, may not
+be for several years. This has been my motive, my fair cousin, and
+I flatter myself it will not sink me in your esteem. And now nothing
+remains for me but to assure you in the most animated language of the
+violence of my affection. To fortune I am perfectly indifferent, and
+shall make no demand of that nature on your father, since I am well
+aware that it could not be complied with; and that one thousand pounds
+in the four per cents, which will not be yours till after your mother’s
+decease, is all that you may ever be entitled to. On that head,
+therefore, I shall be uniformly silent; and you may assure yourself that
+no ungenerous reproach shall ever pass my lips when we are married.”
+
+It was absolutely necessary to interrupt him now.
+
+“You are too hasty, sir,” she cried. “You forget that I have made no
+answer. Let me do it without further loss of time. Accept my thanks for
+the compliment you are paying me. I am very sensible of the honour of
+your proposals, but it is impossible for me to do otherwise than to
+decline them.”
+
+“I am not now to learn,” replied Mr. Collins, with a formal wave of the
+hand, “that it is usual with young ladies to reject the addresses of the
+man whom they secretly mean to accept, when he first applies for their
+favour; and that sometimes the refusal is repeated a second, or even a
+third time. I am therefore by no means discouraged by what you have just
+said, and shall hope to lead you to the altar ere long.”
+
+“Upon my word, sir,” cried Elizabeth, “your hope is a rather
+extraordinary one after my declaration. I do assure you that I am not
+one of those young ladies (if such young ladies there are) who are so
+daring as to risk their happiness on the chance of being asked a second
+time. I am perfectly serious in my refusal. You could not make _me_
+happy, and I am convinced that I am the last woman in the world who
+could make you so. Nay, were your friend Lady Catherine to know me, I
+am persuaded she would find me in every respect ill qualified for the
+situation.”
+
+“Were it certain that Lady Catherine would think so,” said Mr. Collins
+very gravely--“but I cannot imagine that her ladyship would at all
+disapprove of you. And you may be certain when I have the honour of
+seeing her again, I shall speak in the very highest terms of your
+modesty, economy, and other amiable qualification.”
+
+“Indeed, Mr. Collins, all praise of me will be unnecessary. You
+must give me leave to judge for myself, and pay me the compliment
+of believing what I say. I wish you very happy and very rich, and by
+refusing your hand, do all in my power to prevent your being otherwise.
+In making me the offer, you must have satisfied the delicacy of your
+feelings with regard to my family, and may take possession of Longbourn
+estate whenever it falls, without any self-reproach. This matter may
+be considered, therefore, as finally settled.” And rising as she
+thus spoke, she would have quitted the room, had Mr. Collins not thus
+addressed her:
+
+“When I do myself the honour of speaking to you next on the subject, I
+shall hope to receive a more favourable answer than you have now given
+me; though I am far from accusing you of cruelty at present, because I
+know it to be the established custom of your sex to reject a man on
+the first application, and perhaps you have even now said as much to
+encourage my suit as would be consistent with the true delicacy of the
+female character.”
+
+“Really, Mr. Collins,” cried Elizabeth with some warmth, “you puzzle me
+exceedingly. If what I have hitherto said can appear to you in the form
+of encouragement, I know not how to express my refusal in such a way as
+to convince you of its being one.”
+
+“You must give me leave to flatter myself, my dear cousin, that your
+refusal of my addresses is merely words of course. My reasons for
+believing it are briefly these: It does not appear to me that my hand is
+unworthy of your acceptance, or that the establishment I can offer would
+be any other than highly desirable. My situation in life, my connections
+with the family of de Bourgh, and my relationship to your own, are
+circumstances highly in my favour; and you should take it into further
+consideration, that in spite of your manifold attractions, it is by no
+means certain that another offer of marriage may ever be made you. Your
+portion is unhappily so small that it will in all likelihood undo
+the effects of your loveliness and amiable qualifications. As I must
+therefore conclude that you are not serious in your rejection of me,
+I shall choose to attribute it to your wish of increasing my love by
+suspense, according to the usual practice of elegant females.”
+
+“I do assure you, sir, that I have no pretensions whatever to that kind
+of elegance which consists in tormenting a respectable man. I would
+rather be paid the compliment of being believed sincere. I thank you
+again and again for the honour you have done me in your proposals, but
+to accept them is absolutely impossible. My feelings in every respect
+forbid it. Can I speak plainer? Do not consider me now as an elegant
+female, intending to plague you, but as a rational creature, speaking
+the truth from her heart.”
+
+“You are uniformly charming!” cried he, with an air of awkward
+gallantry; “and I am persuaded that when sanctioned by the express
+authority of both your excellent parents, my proposals will not fail of
+being acceptable.”
+
+To such perseverance in wilful self-deception Elizabeth would make
+no reply, and immediately and in silence withdrew; determined, if
+he persisted in considering her repeated refusals as flattering
+encouragement, to apply to her father, whose negative might be uttered
+in such a manner as to be decisive, and whose behaviour at least could
+not be mistaken for the affectation and coquetry of an elegant female.
+
+
+
+Chapter 20
+
+
+Mr. Collins was not left long to the silent contemplation of his
+successful love; for Mrs. Bennet, having dawdled about in the vestibule
+to watch for the end of the conference, no sooner saw Elizabeth open
+the door and with quick step pass her towards the staircase, than she
+entered the breakfast-room, and congratulated both him and herself in
+warm terms on the happy prospect of their nearer connection. Mr. Collins
+received and returned these felicitations with equal pleasure, and then
+proceeded to relate the particulars of their interview, with the result
+of which he trusted he had every reason to be satisfied, since the
+refusal which his cousin had steadfastly given him would naturally flow
+from her bashful modesty and the genuine delicacy of her character.
+
+This information, however, startled Mrs. Bennet; she would have been
+glad to be equally satisfied that her daughter had meant to encourage
+him by protesting against his proposals, but she dared not believe it,
+and could not help saying so.
+
+“But, depend upon it, Mr. Collins,” she added, “that Lizzy shall be
+brought to reason. I will speak to her about it directly. She is a very
+headstrong, foolish girl, and does not know her own interest but I will
+_make_ her know it.”
+
+“Pardon me for interrupting you, madam,” cried Mr. Collins; “but if
+she is really headstrong and foolish, I know not whether she would
+altogether be a very desirable wife to a man in my situation, who
+naturally looks for happiness in the marriage state. If therefore she
+actually persists in rejecting my suit, perhaps it were better not
+to force her into accepting me, because if liable to such defects of
+temper, she could not contribute much to my felicity.”
+
+“Sir, you quite misunderstand me,” said Mrs. Bennet, alarmed. “Lizzy is
+only headstrong in such matters as these. In everything else she is as
+good-natured a girl as ever lived. I will go directly to Mr. Bennet, and
+we shall very soon settle it with her, I am sure.”
+
+She would not give him time to reply, but hurrying instantly to her
+husband, called out as she entered the library, “Oh! Mr. Bennet, you
+are wanted immediately; we are all in an uproar. You must come and make
+Lizzy marry Mr. Collins, for she vows she will not have him, and if you
+do not make haste he will change his mind and not have _her_.”
+
+Mr. Bennet raised his eyes from his book as she entered, and fixed them
+on her face with a calm unconcern which was not in the least altered by
+her communication.
+
+“I have not the pleasure of understanding you,” said he, when she had
+finished her speech. “Of what are you talking?”
+
+“Of Mr. Collins and Lizzy. Lizzy declares she will not have Mr. Collins,
+and Mr. Collins begins to say that he will not have Lizzy.”
+
+“And what am I to do on the occasion? It seems an hopeless business.”
+
+“Speak to Lizzy about it yourself. Tell her that you insist upon her
+marrying him.”
+
+“Let her be called down. She shall hear my opinion.”
+
+Mrs. Bennet rang the bell, and Miss Elizabeth was summoned to the
+library.
+
+“Come here, child,” cried her father as she appeared. “I have sent for
+you on an affair of importance. I understand that Mr. Collins has made
+you an offer of marriage. Is it true?” Elizabeth replied that it was.
+“Very well--and this offer of marriage you have refused?”
+
+“I have, sir.”
+
+“Very well. We now come to the point. Your mother insists upon your
+accepting it. Is it not so, Mrs. Bennet?”
+
+“Yes, or I will never see her again.”
+
+“An unhappy alternative is before you, Elizabeth. From this day you must
+be a stranger to one of your parents. Your mother will never see you
+again if you do _not_ marry Mr. Collins, and I will never see you again
+if you _do_.”
+
+Elizabeth could not but smile at such a conclusion of such a beginning,
+but Mrs. Bennet, who had persuaded herself that her husband regarded the
+affair as she wished, was excessively disappointed.
+
+“What do you mean, Mr. Bennet, in talking this way? You promised me to
+_insist_ upon her marrying him.”
+
+“My dear,” replied her husband, “I have two small favours to request.
+First, that you will allow me the free use of my understanding on the
+present occasion; and secondly, of my room. I shall be glad to have the
+library to myself as soon as may be.”
+
+Not yet, however, in spite of her disappointment in her husband, did
+Mrs. Bennet give up the point. She talked to Elizabeth again and again;
+coaxed and threatened her by turns. She endeavoured to secure Jane
+in her interest; but Jane, with all possible mildness, declined
+interfering; and Elizabeth, sometimes with real earnestness, and
+sometimes with playful gaiety, replied to her attacks. Though her manner
+varied, however, her determination never did.
+
+Mr. Collins, meanwhile, was meditating in solitude on what had passed.
+He thought too well of himself to comprehend on what motives his cousin
+could refuse him; and though his pride was hurt, he suffered in no other
+way. His regard for her was quite imaginary; and the possibility of her
+deserving her mother’s reproach prevented his feeling any regret.
+
+While the family were in this confusion, Charlotte Lucas came to spend
+the day with them. She was met in the vestibule by Lydia, who, flying to
+her, cried in a half whisper, “I am glad you are come, for there is such
+fun here! What do you think has happened this morning? Mr. Collins has
+made an offer to Lizzy, and she will not have him.”
+
+Charlotte hardly had time to answer, before they were joined by Kitty,
+who came to tell the same news; and no sooner had they entered the
+breakfast-room, where Mrs. Bennet was alone, than she likewise began on
+the subject, calling on Miss Lucas for her compassion, and entreating
+her to persuade her friend Lizzy to comply with the wishes of all her
+family. “Pray do, my dear Miss Lucas,” she added in a melancholy tone,
+“for nobody is on my side, nobody takes part with me. I am cruelly used,
+nobody feels for my poor nerves.”
+
+Charlotte’s reply was spared by the entrance of Jane and Elizabeth.
+
+“Aye, there she comes,” continued Mrs. Bennet, “looking as unconcerned
+as may be, and caring no more for us than if we were at York, provided
+she can have her own way. But I tell you, Miss Lizzy--if you take it
+into your head to go on refusing every offer of marriage in this way,
+you will never get a husband at all--and I am sure I do not know who is
+to maintain you when your father is dead. I shall not be able to keep
+you--and so I warn you. I have done with you from this very day. I told
+you in the library, you know, that I should never speak to you again,
+and you will find me as good as my word. I have no pleasure in talking
+to undutiful children. Not that I have much pleasure, indeed, in talking
+to anybody. People who suffer as I do from nervous complaints can have
+no great inclination for talking. Nobody can tell what I suffer! But it
+is always so. Those who do not complain are never pitied.”
+
+Her daughters listened in silence to this effusion, sensible that
+any attempt to reason with her or soothe her would only increase the
+irritation. She talked on, therefore, without interruption from any of
+them, till they were joined by Mr. Collins, who entered the room with
+an air more stately than usual, and on perceiving whom, she said to
+the girls, “Now, I do insist upon it, that you, all of you, hold
+your tongues, and let me and Mr. Collins have a little conversation
+together.”
+
+Elizabeth passed quietly out of the room, Jane and Kitty followed, but
+Lydia stood her ground, determined to hear all she could; and Charlotte,
+detained first by the civility of Mr. Collins, whose inquiries after
+herself and all her family were very minute, and then by a little
+curiosity, satisfied herself with walking to the window and pretending
+not to hear. In a doleful voice Mrs. Bennet began the projected
+conversation: “Oh! Mr. Collins!”
+
+“My dear madam,” replied he, “let us be for ever silent on this point.
+Far be it from me,” he presently continued, in a voice that marked his
+displeasure, “to resent the behaviour of your daughter. Resignation
+to inevitable evils is the duty of us all; the peculiar duty of a
+young man who has been so fortunate as I have been in early preferment;
+and I trust I am resigned. Perhaps not the less so from feeling a doubt
+of my positive happiness had my fair cousin honoured me with her hand;
+for I have often observed that resignation is never so perfect as
+when the blessing denied begins to lose somewhat of its value in our
+estimation. You will not, I hope, consider me as showing any disrespect
+to your family, my dear madam, by thus withdrawing my pretensions to
+your daughter’s favour, without having paid yourself and Mr. Bennet the
+compliment of requesting you to interpose your authority in my
+behalf. My conduct may, I fear, be objectionable in having accepted my
+dismission from your daughter’s lips instead of your own. But we are all
+liable to error. I have certainly meant well through the whole affair.
+My object has been to secure an amiable companion for myself, with due
+consideration for the advantage of all your family, and if my _manner_
+has been at all reprehensible, I here beg leave to apologise.”
+
+
+
+Chapter 21
+
+
+The discussion of Mr. Collins’s offer was now nearly at an end, and
+Elizabeth had only to suffer from the uncomfortable feelings necessarily
+attending it, and occasionally from some peevish allusions of her
+mother. As for the gentleman himself, _his_ feelings were chiefly
+expressed, not by embarrassment or dejection, or by trying to avoid her,
+but by stiffness of manner and resentful silence. He scarcely ever spoke
+to her, and the assiduous attentions which he had been so sensible of
+himself were transferred for the rest of the day to Miss Lucas, whose
+civility in listening to him was a seasonable relief to them all, and
+especially to her friend.
+
+The morrow produced no abatement of Mrs. Bennet’s ill-humour or ill
+health. Mr. Collins was also in the same state of angry pride. Elizabeth
+had hoped that his resentment might shorten his visit, but his plan did
+not appear in the least affected by it. He was always to have gone on
+Saturday, and to Saturday he meant to stay.
+
+After breakfast, the girls walked to Meryton to inquire if Mr. Wickham
+were returned, and to lament over his absence from the Netherfield ball.
+He joined them on their entering the town, and attended them to their
+aunt’s where his regret and vexation, and the concern of everybody, was
+well talked over. To Elizabeth, however, he voluntarily acknowledged
+that the necessity of his absence _had_ been self-imposed.
+
+“I found,” said he, “as the time drew near that I had better not meet
+Mr. Darcy; that to be in the same room, the same party with him for so
+many hours together, might be more than I could bear, and that scenes
+might arise unpleasant to more than myself.”
+
+She highly approved his forbearance, and they had leisure for a full
+discussion of it, and for all the commendation which they civilly
+bestowed on each other, as Wickham and another officer walked back with
+them to Longbourn, and during the walk he particularly attended to
+her. His accompanying them was a double advantage; she felt all the
+compliment it offered to herself, and it was most acceptable as an
+occasion of introducing him to her father and mother.
+
+Soon after their return, a letter was delivered to Miss Bennet; it came
+from Netherfield. The envelope contained a sheet of elegant, little,
+hot-pressed paper, well covered with a lady’s fair, flowing hand; and
+Elizabeth saw her sister’s countenance change as she read it, and saw
+her dwelling intently on some particular passages. Jane recollected
+herself soon, and putting the letter away, tried to join with her usual
+cheerfulness in the general conversation; but Elizabeth felt an anxiety
+on the subject which drew off her attention even from Wickham; and no
+sooner had he and his companion taken leave, than a glance from Jane
+invited her to follow her up stairs. When they had gained their own room,
+Jane, taking out the letter, said:
+
+“This is from Caroline Bingley; what it contains has surprised me a good
+deal. The whole party have left Netherfield by this time, and are on
+their way to town--and without any intention of coming back again. You
+shall hear what she says.”
+
+She then read the first sentence aloud, which comprised the information
+of their having just resolved to follow their brother to town directly,
+and of their meaning to dine in Grosvenor Street, where Mr. Hurst had a
+house. The next was in these words: “I do not pretend to regret anything
+I shall leave in Hertfordshire, except your society, my dearest friend;
+but we will hope, at some future period, to enjoy many returns of that
+delightful intercourse we have known, and in the meanwhile may
+lessen the pain of separation by a very frequent and most unreserved
+correspondence. I depend on you for that.” To these highflown
+expressions Elizabeth listened with all the insensibility of distrust;
+and though the suddenness of their removal surprised her, she saw
+nothing in it really to lament; it was not to be supposed that their
+absence from Netherfield would prevent Mr. Bingley’s being there; and as
+to the loss of their society, she was persuaded that Jane must cease to
+regard it, in the enjoyment of his.
+
+“It is unlucky,” said she, after a short pause, “that you should not be
+able to see your friends before they leave the country. But may we not
+hope that the period of future happiness to which Miss Bingley looks
+forward may arrive earlier than she is aware, and that the delightful
+intercourse you have known as friends will be renewed with yet greater
+satisfaction as sisters? Mr. Bingley will not be detained in London by
+them.”
+
+“Caroline decidedly says that none of the party will return into
+Hertfordshire this winter. I will read it to you:”
+
+“When my brother left us yesterday, he imagined that the business which
+took him to London might be concluded in three or four days; but as we
+are certain it cannot be so, and at the same time convinced that when
+Charles gets to town he will be in no hurry to leave it again, we have
+determined on following him thither, that he may not be obliged to spend
+his vacant hours in a comfortless hotel. Many of my acquaintances are
+already there for the winter; I wish that I could hear that you, my
+dearest friend, had any intention of making one of the crowd--but of
+that I despair. I sincerely hope your Christmas in Hertfordshire may
+abound in the gaieties which that season generally brings, and that your
+beaux will be so numerous as to prevent your feeling the loss of the
+three of whom we shall deprive you.”
+
+“It is evident by this,” added Jane, “that he comes back no more this
+winter.”
+
+“It is only evident that Miss Bingley does not mean that he _should_.”
+
+“Why will you think so? It must be his own doing. He is his own
+master. But you do not know _all_. I _will_ read you the passage which
+particularly hurts me. I will have no reserves from _you_.”
+
+“Mr. Darcy is impatient to see his sister; and, to confess the truth,
+_we_ are scarcely less eager to meet her again. I really do not think
+Georgiana Darcy has her equal for beauty, elegance, and accomplishments;
+and the affection she inspires in Louisa and myself is heightened into
+something still more interesting, from the hope we dare entertain of
+her being hereafter our sister. I do not know whether I ever before
+mentioned to you my feelings on this subject; but I will not leave the
+country without confiding them, and I trust you will not esteem them
+unreasonable. My brother admires her greatly already; he will have
+frequent opportunity now of seeing her on the most intimate footing;
+her relations all wish the connection as much as his own; and a sister’s
+partiality is not misleading me, I think, when I call Charles most
+capable of engaging any woman’s heart. With all these circumstances to
+favour an attachment, and nothing to prevent it, am I wrong, my dearest
+Jane, in indulging the hope of an event which will secure the happiness
+of so many?”
+
+“What do you think of _this_ sentence, my dear Lizzy?” said Jane as she
+finished it. “Is it not clear enough? Does it not expressly declare that
+Caroline neither expects nor wishes me to be her sister; that she is
+perfectly convinced of her brother’s indifference; and that if she
+suspects the nature of my feelings for him, she means (most kindly!) to
+put me on my guard? Can there be any other opinion on the subject?”
+
+“Yes, there can; for mine is totally different. Will you hear it?”
+
+“Most willingly.”
+
+“You shall have it in a few words. Miss Bingley sees that her brother is
+in love with you, and wants him to marry Miss Darcy. She follows him
+to town in hope of keeping him there, and tries to persuade you that he
+does not care about you.”
+
+Jane shook her head.
+
+“Indeed, Jane, you ought to believe me. No one who has ever seen you
+together can doubt his affection. Miss Bingley, I am sure, cannot. She
+is not such a simpleton. Could she have seen half as much love in Mr.
+Darcy for herself, she would have ordered her wedding clothes. But the
+case is this: We are not rich enough or grand enough for them; and she
+is the more anxious to get Miss Darcy for her brother, from the notion
+that when there has been _one_ intermarriage, she may have less trouble
+in achieving a second; in which there is certainly some ingenuity, and
+I dare say it would succeed, if Miss de Bourgh were out of the way. But,
+my dearest Jane, you cannot seriously imagine that because Miss Bingley
+tells you her brother greatly admires Miss Darcy, he is in the smallest
+degree less sensible of _your_ merit than when he took leave of you on
+Tuesday, or that it will be in her power to persuade him that, instead
+of being in love with you, he is very much in love with her friend.”
+
+“If we thought alike of Miss Bingley,” replied Jane, “your
+representation of all this might make me quite easy. But I know the
+foundation is unjust. Caroline is incapable of wilfully deceiving
+anyone; and all that I can hope in this case is that she is deceiving
+herself.”
+
+“That is right. You could not have started a more happy idea, since you
+will not take comfort in mine. Believe her to be deceived, by all means.
+You have now done your duty by her, and must fret no longer.”
+
+“But, my dear sister, can I be happy, even supposing the best, in
+accepting a man whose sisters and friends are all wishing him to marry
+elsewhere?”
+
+“You must decide for yourself,” said Elizabeth; “and if, upon mature
+deliberation, you find that the misery of disobliging his two sisters is
+more than equivalent to the happiness of being his wife, I advise you by
+all means to refuse him.”
+
+“How can you talk so?” said Jane, faintly smiling. “You must know that
+though I should be exceedingly grieved at their disapprobation, I could
+not hesitate.”
+
+“I did not think you would; and that being the case, I cannot consider
+your situation with much compassion.”
+
+“But if he returns no more this winter, my choice will never be
+required. A thousand things may arise in six months!”
+
+The idea of his returning no more Elizabeth treated with the utmost
+contempt. It appeared to her merely the suggestion of Caroline’s
+interested wishes, and she could not for a moment suppose that those
+wishes, however openly or artfully spoken, could influence a young man
+so totally independent of everyone.
+
+She represented to her sister as forcibly as possible what she felt
+on the subject, and had soon the pleasure of seeing its happy effect.
+Jane’s temper was not desponding, and she was gradually led to hope,
+though the diffidence of affection sometimes overcame the hope, that
+Bingley would return to Netherfield and answer every wish of her heart.
+
+They agreed that Mrs. Bennet should only hear of the departure of the
+family, without being alarmed on the score of the gentleman’s conduct;
+but even this partial communication gave her a great deal of concern,
+and she bewailed it as exceedingly unlucky that the ladies should happen
+to go away just as they were all getting so intimate together. After
+lamenting it, however, at some length, she had the consolation that Mr.
+Bingley would be soon down again and soon dining at Longbourn, and the
+conclusion of all was the comfortable declaration, that though he had
+been invited only to a family dinner, she would take care to have two
+full courses.
+
+
+
+Chapter 22
+
+
+The Bennets were engaged to dine with the Lucases and again during the
+chief of the day was Miss Lucas so kind as to listen to Mr. Collins.
+Elizabeth took an opportunity of thanking her. “It keeps him in good
+humour,” said she, “and I am more obliged to you than I can express.”
+ Charlotte assured her friend of her satisfaction in being useful, and
+that it amply repaid her for the little sacrifice of her time. This was
+very amiable, but Charlotte’s kindness extended farther than Elizabeth
+had any conception of; its object was nothing else than to secure her
+from any return of Mr. Collins’s addresses, by engaging them towards
+herself. Such was Miss Lucas’s scheme; and appearances were so
+favourable, that when they parted at night, she would have felt almost
+secure of success if he had not been to leave Hertfordshire so very
+soon. But here she did injustice to the fire and independence of his
+character, for it led him to escape out of Longbourn House the next
+morning with admirable slyness, and hasten to Lucas Lodge to throw
+himself at her feet. He was anxious to avoid the notice of his cousins,
+from a conviction that if they saw him depart, they could not fail to
+conjecture his design, and he was not willing to have the attempt known
+till its success might be known likewise; for though feeling almost
+secure, and with reason, for Charlotte had been tolerably encouraging,
+he was comparatively diffident since the adventure of Wednesday.
+His reception, however, was of the most flattering kind. Miss Lucas
+perceived him from an upper window as he walked towards the house, and
+instantly set out to meet him accidentally in the lane. But little had
+she dared to hope that so much love and eloquence awaited her there.
+
+In as short a time as Mr. Collins’s long speeches would allow,
+everything was settled between them to the satisfaction of both; and as
+they entered the house he earnestly entreated her to name the day that
+was to make him the happiest of men; and though such a solicitation must
+be waived for the present, the lady felt no inclination to trifle with
+his happiness. The stupidity with which he was favoured by nature must
+guard his courtship from any charm that could make a woman wish for its
+continuance; and Miss Lucas, who accepted him solely from the pure
+and disinterested desire of an establishment, cared not how soon that
+establishment were gained.
+
+Sir William and Lady Lucas were speedily applied to for their consent;
+and it was bestowed with a most joyful alacrity. Mr. Collins’s present
+circumstances made it a most eligible match for their daughter, to whom
+they could give little fortune; and his prospects of future wealth were
+exceedingly fair. Lady Lucas began directly to calculate, with more
+interest than the matter had ever excited before, how many years longer
+Mr. Bennet was likely to live; and Sir William gave it as his decided
+opinion, that whenever Mr. Collins should be in possession of the
+Longbourn estate, it would be highly expedient that both he and his wife
+should make their appearance at St. James’s. The whole family, in short,
+were properly overjoyed on the occasion. The younger girls formed hopes
+of _coming out_ a year or two sooner than they might otherwise have
+done; and the boys were relieved from their apprehension of Charlotte’s
+dying an old maid. Charlotte herself was tolerably composed. She had
+gained her point, and had time to consider of it. Her reflections were
+in general satisfactory. Mr. Collins, to be sure, was neither sensible
+nor agreeable; his society was irksome, and his attachment to her must
+be imaginary. But still he would be her husband. Without thinking highly
+either of men or matrimony, marriage had always been her object; it was
+the only provision for well-educated young women of small fortune,
+and however uncertain of giving happiness, must be their pleasantest
+preservative from want. This preservative she had now obtained; and at
+the age of twenty-seven, without having ever been handsome, she felt all
+the good luck of it. The least agreeable circumstance in the business
+was the surprise it must occasion to Elizabeth Bennet, whose friendship
+she valued beyond that of any other person. Elizabeth would wonder,
+and probably would blame her; and though her resolution was not to be
+shaken, her feelings must be hurt by such a disapprobation. She resolved
+to give her the information herself, and therefore charged Mr. Collins,
+when he returned to Longbourn to dinner, to drop no hint of what had
+passed before any of the family. A promise of secrecy was of course very
+dutifully given, but it could not be kept without difficulty; for the
+curiosity excited by his long absence burst forth in such very direct
+questions on his return as required some ingenuity to evade, and he was
+at the same time exercising great self-denial, for he was longing to
+publish his prosperous love.
+
+As he was to begin his journey too early on the morrow to see any of the
+family, the ceremony of leave-taking was performed when the ladies moved
+for the night; and Mrs. Bennet, with great politeness and cordiality,
+said how happy they should be to see him at Longbourn again, whenever
+his engagements might allow him to visit them.
+
+“My dear madam,” he replied, “this invitation is particularly
+gratifying, because it is what I have been hoping to receive; and
+you may be very certain that I shall avail myself of it as soon as
+possible.”
+
+They were all astonished; and Mr. Bennet, who could by no means wish for
+so speedy a return, immediately said:
+
+“But is there not danger of Lady Catherine’s disapprobation here, my
+good sir? You had better neglect your relations than run the risk of
+offending your patroness.”
+
+“My dear sir,” replied Mr. Collins, “I am particularly obliged to you
+for this friendly caution, and you may depend upon my not taking so
+material a step without her ladyship’s concurrence.”
+
+“You cannot be too much upon your guard. Risk anything rather than her
+displeasure; and if you find it likely to be raised by your coming to us
+again, which I should think exceedingly probable, stay quietly at home,
+and be satisfied that _we_ shall take no offence.”
+
+“Believe me, my dear sir, my gratitude is warmly excited by such
+affectionate attention; and depend upon it, you will speedily receive
+from me a letter of thanks for this, and for every other mark of your
+regard during my stay in Hertfordshire. As for my fair cousins, though
+my absence may not be long enough to render it necessary, I shall now
+take the liberty of wishing them health and happiness, not excepting my
+cousin Elizabeth.”
+
+With proper civilities the ladies then withdrew; all of them equally
+surprised that he meditated a quick return. Mrs. Bennet wished to
+understand by it that he thought of paying his addresses to one of her
+younger girls, and Mary might have been prevailed on to accept him.
+She rated his abilities much higher than any of the others; there was
+a solidity in his reflections which often struck her, and though by no
+means so clever as herself, she thought that if encouraged to read
+and improve himself by such an example as hers, he might become a very
+agreeable companion. But on the following morning, every hope of this
+kind was done away. Miss Lucas called soon after breakfast, and in a
+private conference with Elizabeth related the event of the day before.
+
+The possibility of Mr. Collins’s fancying himself in love with her
+friend had once occurred to Elizabeth within the last day or two; but
+that Charlotte could encourage him seemed almost as far from
+possibility as she could encourage him herself, and her astonishment was
+consequently so great as to overcome at first the bounds of decorum, and
+she could not help crying out:
+
+“Engaged to Mr. Collins! My dear Charlotte--impossible!”
+
+The steady countenance which Miss Lucas had commanded in telling her
+story, gave way to a momentary confusion here on receiving so direct a
+reproach; though, as it was no more than she expected, she soon regained
+her composure, and calmly replied:
+
+“Why should you be surprised, my dear Eliza? Do you think it incredible
+that Mr. Collins should be able to procure any woman’s good opinion,
+because he was not so happy as to succeed with you?”
+
+But Elizabeth had now recollected herself, and making a strong effort
+for it, was able to assure with tolerable firmness that the prospect of
+their relationship was highly grateful to her, and that she wished her
+all imaginable happiness.
+
+“I see what you are feeling,” replied Charlotte. “You must be surprised,
+very much surprised--so lately as Mr. Collins was wishing to marry
+you. But when you have had time to think it over, I hope you will be
+satisfied with what I have done. I am not romantic, you know; I never
+was. I ask only a comfortable home; and considering Mr. Collins’s
+character, connection, and situation in life, I am convinced that my
+chance of happiness with him is as fair as most people can boast on
+entering the marriage state.”
+
+Elizabeth quietly answered “Undoubtedly;” and after an awkward pause,
+they returned to the rest of the family. Charlotte did not stay much
+longer, and Elizabeth was then left to reflect on what she had heard.
+It was a long time before she became at all reconciled to the idea of so
+unsuitable a match. The strangeness of Mr. Collins’s making two offers
+of marriage within three days was nothing in comparison of his being now
+accepted. She had always felt that Charlotte’s opinion of matrimony was
+not exactly like her own, but she had not supposed it to be possible
+that, when called into action, she would have sacrificed every better
+feeling to worldly advantage. Charlotte the wife of Mr. Collins was a
+most humiliating picture! And to the pang of a friend disgracing herself
+and sunk in her esteem, was added the distressing conviction that it
+was impossible for that friend to be tolerably happy in the lot she had
+chosen.
+
+
+
+Chapter 23
+
+
+Elizabeth was sitting with her mother and sisters, reflecting on what
+she had heard, and doubting whether she was authorised to mention
+it, when Sir William Lucas himself appeared, sent by his daughter, to
+announce her engagement to the family. With many compliments to them,
+and much self-gratulation on the prospect of a connection between the
+houses, he unfolded the matter--to an audience not merely wondering, but
+incredulous; for Mrs. Bennet, with more perseverance than politeness,
+protested he must be entirely mistaken; and Lydia, always unguarded and
+often uncivil, boisterously exclaimed:
+
+“Good Lord! Sir William, how can you tell such a story? Do not you know
+that Mr. Collins wants to marry Lizzy?”
+
+Nothing less than the complaisance of a courtier could have borne
+without anger such treatment; but Sir William’s good breeding carried
+him through it all; and though he begged leave to be positive as to the
+truth of his information, he listened to all their impertinence with the
+most forbearing courtesy.
+
+Elizabeth, feeling it incumbent on her to relieve him from so unpleasant
+a situation, now put herself forward to confirm his account, by
+mentioning her prior knowledge of it from Charlotte herself; and
+endeavoured to put a stop to the exclamations of her mother and sisters
+by the earnestness of her congratulations to Sir William, in which she
+was readily joined by Jane, and by making a variety of remarks on the
+happiness that might be expected from the match, the excellent character
+of Mr. Collins, and the convenient distance of Hunsford from London.
+
+Mrs. Bennet was in fact too much overpowered to say a great deal while
+Sir William remained; but no sooner had he left them than her feelings
+found a rapid vent. In the first place, she persisted in disbelieving
+the whole of the matter; secondly, she was very sure that Mr. Collins
+had been taken in; thirdly, she trusted that they would never be
+happy together; and fourthly, that the match might be broken off. Two
+inferences, however, were plainly deduced from the whole: one, that
+Elizabeth was the real cause of the mischief; and the other that she
+herself had been barbarously misused by them all; and on these two
+points she principally dwelt during the rest of the day. Nothing could
+console and nothing could appease her. Nor did that day wear out her
+resentment. A week elapsed before she could see Elizabeth without
+scolding her, a month passed away before she could speak to Sir William
+or Lady Lucas without being rude, and many months were gone before she
+could at all forgive their daughter.
+
+Mr. Bennet’s emotions were much more tranquil on the occasion, and such
+as he did experience he pronounced to be of a most agreeable sort; for
+it gratified him, he said, to discover that Charlotte Lucas, whom he had
+been used to think tolerably sensible, was as foolish as his wife, and
+more foolish than his daughter!
+
+Jane confessed herself a little surprised at the match; but she said
+less of her astonishment than of her earnest desire for their happiness;
+nor could Elizabeth persuade her to consider it as improbable. Kitty
+and Lydia were far from envying Miss Lucas, for Mr. Collins was only a
+clergyman; and it affected them in no other way than as a piece of news
+to spread at Meryton.
+
+Lady Lucas could not be insensible of triumph on being able to retort
+on Mrs. Bennet the comfort of having a daughter well married; and she
+called at Longbourn rather oftener than usual to say how happy she was,
+though Mrs. Bennet’s sour looks and ill-natured remarks might have been
+enough to drive happiness away.
+
+Between Elizabeth and Charlotte there was a restraint which kept them
+mutually silent on the subject; and Elizabeth felt persuaded that
+no real confidence could ever subsist between them again. Her
+disappointment in Charlotte made her turn with fonder regard to her
+sister, of whose rectitude and delicacy she was sure her opinion could
+never be shaken, and for whose happiness she grew daily more anxious,
+as Bingley had now been gone a week and nothing more was heard of his
+return.
+
+Jane had sent Caroline an early answer to her letter, and was counting
+the days till she might reasonably hope to hear again. The promised
+letter of thanks from Mr. Collins arrived on Tuesday, addressed to
+their father, and written with all the solemnity of gratitude which a
+twelvemonth’s abode in the family might have prompted. After discharging
+his conscience on that head, he proceeded to inform them, with many
+rapturous expressions, of his happiness in having obtained the affection
+of their amiable neighbour, Miss Lucas, and then explained that it was
+merely with the view of enjoying her society that he had been so ready
+to close with their kind wish of seeing him again at Longbourn, whither
+he hoped to be able to return on Monday fortnight; for Lady Catherine,
+he added, so heartily approved his marriage, that she wished it to take
+place as soon as possible, which he trusted would be an unanswerable
+argument with his amiable Charlotte to name an early day for making him
+the happiest of men.
+
+Mr. Collins’s return into Hertfordshire was no longer a matter of
+pleasure to Mrs. Bennet. On the contrary, she was as much disposed to
+complain of it as her husband. It was very strange that he should come
+to Longbourn instead of to Lucas Lodge; it was also very inconvenient
+and exceedingly troublesome. She hated having visitors in the house
+while her health was so indifferent, and lovers were of all people the
+most disagreeable. Such were the gentle murmurs of Mrs. Bennet, and
+they gave way only to the greater distress of Mr. Bingley’s continued
+absence.
+
+Neither Jane nor Elizabeth were comfortable on this subject. Day after
+day passed away without bringing any other tidings of him than the
+report which shortly prevailed in Meryton of his coming no more to
+Netherfield the whole winter; a report which highly incensed Mrs.
+Bennet, and which she never failed to contradict as a most scandalous
+falsehood.
+
+Even Elizabeth began to fear--not that Bingley was indifferent--but that
+his sisters would be successful in keeping him away. Unwilling as
+she was to admit an idea so destructive of Jane’s happiness, and so
+dishonorable to the stability of her lover, she could not prevent its
+frequently occurring. The united efforts of his two unfeeling sisters
+and of his overpowering friend, assisted by the attractions of Miss
+Darcy and the amusements of London might be too much, she feared, for
+the strength of his attachment.
+
+As for Jane, _her_ anxiety under this suspense was, of course, more
+painful than Elizabeth’s, but whatever she felt she was desirous of
+concealing, and between herself and Elizabeth, therefore, the subject
+was never alluded to. But as no such delicacy restrained her mother,
+an hour seldom passed in which she did not talk of Bingley, express her
+impatience for his arrival, or even require Jane to confess that if he
+did not come back she would think herself very ill used. It needed
+all Jane’s steady mildness to bear these attacks with tolerable
+tranquillity.
+
+Mr. Collins returned most punctually on Monday fortnight, but his
+reception at Longbourn was not quite so gracious as it had been on his
+first introduction. He was too happy, however, to need much attention;
+and luckily for the others, the business of love-making relieved them
+from a great deal of his company. The chief of every day was spent by
+him at Lucas Lodge, and he sometimes returned to Longbourn only in time
+to make an apology for his absence before the family went to bed.
+
+Mrs. Bennet was really in a most pitiable state. The very mention of
+anything concerning the match threw her into an agony of ill-humour,
+and wherever she went she was sure of hearing it talked of. The sight
+of Miss Lucas was odious to her. As her successor in that house, she
+regarded her with jealous abhorrence. Whenever Charlotte came to see
+them, she concluded her to be anticipating the hour of possession; and
+whenever she spoke in a low voice to Mr. Collins, was convinced that
+they were talking of the Longbourn estate, and resolving to turn herself
+and her daughters out of the house, as soon as Mr. Bennet were dead. She
+complained bitterly of all this to her husband.
+
+“Indeed, Mr. Bennet,” said she, “it is very hard to think that Charlotte
+Lucas should ever be mistress of this house, that I should be forced to
+make way for _her_, and live to see her take her place in it!”
+
+“My dear, do not give way to such gloomy thoughts. Let us hope for
+better things. Let us flatter ourselves that I may be the survivor.”
+
+This was not very consoling to Mrs. Bennet, and therefore, instead of
+making any answer, she went on as before.
+
+“I cannot bear to think that they should have all this estate. If it was
+not for the entail, I should not mind it.”
+
+“What should not you mind?”
+
+“I should not mind anything at all.”
+
+“Let us be thankful that you are preserved from a state of such
+insensibility.”
+
+“I never can be thankful, Mr. Bennet, for anything about the entail. How
+anyone could have the conscience to entail away an estate from one’s own
+daughters, I cannot understand; and all for the sake of Mr. Collins too!
+Why should _he_ have it more than anybody else?”
+
+“I leave it to yourself to determine,” said Mr. Bennet.
+
+
+
+Chapter 24
+
+
+Miss Bingley’s letter arrived, and put an end to doubt. The very first
+sentence conveyed the assurance of their being all settled in London for
+the winter, and concluded with her brother’s regret at not having had
+time to pay his respects to his friends in Hertfordshire before he left
+the country.
+
+Hope was over, entirely over; and when Jane could attend to the rest
+of the letter, she found little, except the professed affection of the
+writer, that could give her any comfort. Miss Darcy’s praise occupied
+the chief of it. Her many attractions were again dwelt on, and Caroline
+boasted joyfully of their increasing intimacy, and ventured to predict
+the accomplishment of the wishes which had been unfolded in her former
+letter. She wrote also with great pleasure of her brother’s being an
+inmate of Mr. Darcy’s house, and mentioned with raptures some plans of
+the latter with regard to new furniture.
+
+Elizabeth, to whom Jane very soon communicated the chief of all this,
+heard it in silent indignation. Her heart was divided between concern
+for her sister, and resentment against all others. To Caroline’s
+assertion of her brother’s being partial to Miss Darcy she paid no
+credit. That he was really fond of Jane, she doubted no more than she
+had ever done; and much as she had always been disposed to like him, she
+could not think without anger, hardly without contempt, on that easiness
+of temper, that want of proper resolution, which now made him the slave
+of his designing friends, and led him to sacrifice of his own happiness
+to the caprice of their inclination. Had his own happiness, however,
+been the only sacrifice, he might have been allowed to sport with it in
+whatever manner he thought best, but her sister’s was involved in it, as
+she thought he must be sensible himself. It was a subject, in short,
+on which reflection would be long indulged, and must be unavailing. She
+could think of nothing else; and yet whether Bingley’s regard had really
+died away, or were suppressed by his friends’ interference; whether
+he had been aware of Jane’s attachment, or whether it had escaped his
+observation; whatever were the case, though her opinion of him must be
+materially affected by the difference, her sister’s situation remained
+the same, her peace equally wounded.
+
+A day or two passed before Jane had courage to speak of her feelings to
+Elizabeth; but at last, on Mrs. Bennet’s leaving them together, after a
+longer irritation than usual about Netherfield and its master, she could
+not help saying:
+
+“Oh, that my dear mother had more command over herself! She can have no
+idea of the pain she gives me by her continual reflections on him. But
+I will not repine. It cannot last long. He will be forgot, and we shall
+all be as we were before.”
+
+Elizabeth looked at her sister with incredulous solicitude, but said
+nothing.
+
+“You doubt me,” cried Jane, slightly colouring; “indeed, you have
+no reason. He may live in my memory as the most amiable man of my
+acquaintance, but that is all. I have nothing either to hope or fear,
+and nothing to reproach him with. Thank God! I have not _that_ pain. A
+little time, therefore--I shall certainly try to get the better.”
+
+With a stronger voice she soon added, “I have this comfort immediately,
+that it has not been more than an error of fancy on my side, and that it
+has done no harm to anyone but myself.”
+
+“My dear Jane!” exclaimed Elizabeth, “you are too good. Your sweetness
+and disinterestedness are really angelic; I do not know what to say
+to you. I feel as if I had never done you justice, or loved you as you
+deserve.”
+
+Miss Bennet eagerly disclaimed all extraordinary merit, and threw back
+the praise on her sister’s warm affection.
+
+“Nay,” said Elizabeth, “this is not fair. _You_ wish to think all the
+world respectable, and are hurt if I speak ill of anybody. I only want
+to think _you_ perfect, and you set yourself against it. Do not
+be afraid of my running into any excess, of my encroaching on your
+privilege of universal good-will. You need not. There are few people
+whom I really love, and still fewer of whom I think well. The more I see
+of the world, the more am I dissatisfied with it; and every day confirms
+my belief of the inconsistency of all human characters, and of the
+little dependence that can be placed on the appearance of merit or
+sense. I have met with two instances lately, one I will not mention; the
+other is Charlotte’s marriage. It is unaccountable! In every view it is
+unaccountable!”
+
+“My dear Lizzy, do not give way to such feelings as these. They will
+ruin your happiness. You do not make allowance enough for difference
+of situation and temper. Consider Mr. Collins’s respectability, and
+Charlotte’s steady, prudent character. Remember that she is one of a
+large family; that as to fortune, it is a most eligible match; and be
+ready to believe, for everybody’s sake, that she may feel something like
+regard and esteem for our cousin.”
+
+“To oblige you, I would try to believe almost anything, but no one else
+could be benefited by such a belief as this; for were I persuaded that
+Charlotte had any regard for him, I should only think worse of her
+understanding than I now do of her heart. My dear Jane, Mr. Collins is a
+conceited, pompous, narrow-minded, silly man; you know he is, as well as
+I do; and you must feel, as well as I do, that the woman who married him
+cannot have a proper way of thinking. You shall not defend her, though
+it is Charlotte Lucas. You shall not, for the sake of one individual,
+change the meaning of principle and integrity, nor endeavour to persuade
+yourself or me, that selfishness is prudence, and insensibility of
+danger security for happiness.”
+
+“I must think your language too strong in speaking of both,” replied
+Jane; “and I hope you will be convinced of it by seeing them happy
+together. But enough of this. You alluded to something else. You
+mentioned _two_ instances. I cannot misunderstand you, but I entreat
+you, dear Lizzy, not to pain me by thinking _that person_ to blame, and
+saying your opinion of him is sunk. We must not be so ready to fancy
+ourselves intentionally injured. We must not expect a lively young man
+to be always so guarded and circumspect. It is very often nothing but
+our own vanity that deceives us. Women fancy admiration means more than
+it does.”
+
+“And men take care that they should.”
+
+“If it is designedly done, they cannot be justified; but I have no idea
+of there being so much design in the world as some persons imagine.”
+
+“I am far from attributing any part of Mr. Bingley’s conduct to design,”
+ said Elizabeth; “but without scheming to do wrong, or to make others
+unhappy, there may be error, and there may be misery. Thoughtlessness,
+want of attention to other people’s feelings, and want of resolution,
+will do the business.”
+
+“And do you impute it to either of those?”
+
+“Yes; to the last. But if I go on, I shall displease you by saying what
+I think of persons you esteem. Stop me whilst you can.”
+
+“You persist, then, in supposing his sisters influence him?”
+
+“Yes, in conjunction with his friend.”
+
+“I cannot believe it. Why should they try to influence him? They can
+only wish his happiness; and if he is attached to me, no other woman can
+secure it.”
+
+“Your first position is false. They may wish many things besides his
+happiness; they may wish his increase of wealth and consequence; they
+may wish him to marry a girl who has all the importance of money, great
+connections, and pride.”
+
+“Beyond a doubt, they _do_ wish him to choose Miss Darcy,” replied Jane;
+“but this may be from better feelings than you are supposing. They have
+known her much longer than they have known me; no wonder if they love
+her better. But, whatever may be their own wishes, it is very unlikely
+they should have opposed their brother’s. What sister would think
+herself at liberty to do it, unless there were something very
+objectionable? If they believed him attached to me, they would not try
+to part us; if he were so, they could not succeed. By supposing such an
+affection, you make everybody acting unnaturally and wrong, and me most
+unhappy. Do not distress me by the idea. I am not ashamed of having been
+mistaken--or, at least, it is light, it is nothing in comparison of what
+I should feel in thinking ill of him or his sisters. Let me take it in
+the best light, in the light in which it may be understood.”
+
+Elizabeth could not oppose such a wish; and from this time Mr. Bingley’s
+name was scarcely ever mentioned between them.
+
+Mrs. Bennet still continued to wonder and repine at his returning no
+more, and though a day seldom passed in which Elizabeth did not account
+for it clearly, there was little chance of her ever considering it with
+less perplexity. Her daughter endeavoured to convince her of what she
+did not believe herself, that his attentions to Jane had been merely the
+effect of a common and transient liking, which ceased when he saw her
+no more; but though the probability of the statement was admitted at
+the time, she had the same story to repeat every day. Mrs. Bennet’s best
+comfort was that Mr. Bingley must be down again in the summer.
+
+Mr. Bennet treated the matter differently. “So, Lizzy,” said he one day,
+“your sister is crossed in love, I find. I congratulate her. Next to
+being married, a girl likes to be crossed a little in love now and then.
+It is something to think of, and it gives her a sort of distinction
+among her companions. When is your turn to come? You will hardly bear to
+be long outdone by Jane. Now is your time. Here are officers enough in
+Meryton to disappoint all the young ladies in the country. Let Wickham
+be _your_ man. He is a pleasant fellow, and would jilt you creditably.”
+
+“Thank you, sir, but a less agreeable man would satisfy me. We must not
+all expect Jane’s good fortune.”
+
+“True,” said Mr. Bennet, “but it is a comfort to think that whatever of
+that kind may befall you, you have an affectionate mother who will make
+the most of it.”
+
+Mr. Wickham’s society was of material service in dispelling the gloom
+which the late perverse occurrences had thrown on many of the Longbourn
+family. They saw him often, and to his other recommendations was now
+added that of general unreserve. The whole of what Elizabeth had already
+heard, his claims on Mr. Darcy, and all that he had suffered from him,
+was now openly acknowledged and publicly canvassed; and everybody was
+pleased to know how much they had always disliked Mr. Darcy before they
+had known anything of the matter.
+
+Miss Bennet was the only creature who could suppose there might be
+any extenuating circumstances in the case, unknown to the society
+of Hertfordshire; her mild and steady candour always pleaded for
+allowances, and urged the possibility of mistakes--but by everybody else
+Mr. Darcy was condemned as the worst of men.
+
+
+
+Chapter 25
+
+
+After a week spent in professions of love and schemes of felicity,
+Mr. Collins was called from his amiable Charlotte by the arrival of
+Saturday. The pain of separation, however, might be alleviated on his
+side, by preparations for the reception of his bride; as he had reason
+to hope, that shortly after his return into Hertfordshire, the day would
+be fixed that was to make him the happiest of men. He took leave of his
+relations at Longbourn with as much solemnity as before; wished his fair
+cousins health and happiness again, and promised their father another
+letter of thanks.
+
+On the following Monday, Mrs. Bennet had the pleasure of receiving
+her brother and his wife, who came as usual to spend the Christmas
+at Longbourn. Mr. Gardiner was a sensible, gentlemanlike man, greatly
+superior to his sister, as well by nature as education. The Netherfield
+ladies would have had difficulty in believing that a man who lived
+by trade, and within view of his own warehouses, could have been so
+well-bred and agreeable. Mrs. Gardiner, who was several years younger
+than Mrs. Bennet and Mrs. Phillips, was an amiable, intelligent, elegant
+woman, and a great favourite with all her Longbourn nieces. Between the
+two eldest and herself especially, there subsisted a particular regard.
+They had frequently been staying with her in town.
+
+The first part of Mrs. Gardiner’s business on her arrival was to
+distribute her presents and describe the newest fashions. When this was
+done she had a less active part to play. It became her turn to listen.
+Mrs. Bennet had many grievances to relate, and much to complain of. They
+had all been very ill-used since she last saw her sister. Two of her
+girls had been upon the point of marriage, and after all there was
+nothing in it.
+
+“I do not blame Jane,” she continued, “for Jane would have got Mr.
+Bingley if she could. But Lizzy! Oh, sister! It is very hard to think
+that she might have been Mr. Collins’s wife by this time, had it not
+been for her own perverseness. He made her an offer in this very room,
+and she refused him. The consequence of it is, that Lady Lucas will have
+a daughter married before I have, and that the Longbourn estate is just
+as much entailed as ever. The Lucases are very artful people indeed,
+sister. They are all for what they can get. I am sorry to say it of
+them, but so it is. It makes me very nervous and poorly, to be thwarted
+so in my own family, and to have neighbours who think of themselves
+before anybody else. However, your coming just at this time is the
+greatest of comforts, and I am very glad to hear what you tell us, of
+long sleeves.”
+
+Mrs. Gardiner, to whom the chief of this news had been given before,
+in the course of Jane and Elizabeth’s correspondence with her, made her
+sister a slight answer, and, in compassion to her nieces, turned the
+conversation.
+
+When alone with Elizabeth afterwards, she spoke more on the subject. “It
+seems likely to have been a desirable match for Jane,” said she. “I am
+sorry it went off. But these things happen so often! A young man, such
+as you describe Mr. Bingley, so easily falls in love with a pretty girl
+for a few weeks, and when accident separates them, so easily forgets
+her, that these sort of inconsistencies are very frequent.”
+
+“An excellent consolation in its way,” said Elizabeth, “but it will not
+do for _us_. We do not suffer by _accident_. It does not often
+happen that the interference of friends will persuade a young man of
+independent fortune to think no more of a girl whom he was violently in
+love with only a few days before.”
+
+“But that expression of ‘violently in love’ is so hackneyed, so
+doubtful, so indefinite, that it gives me very little idea. It is as
+often applied to feelings which arise from a half-hour’s acquaintance,
+as to a real, strong attachment. Pray, how _violent was_ Mr. Bingley’s
+love?”
+
+“I never saw a more promising inclination; he was growing quite
+inattentive to other people, and wholly engrossed by her. Every time
+they met, it was more decided and remarkable. At his own ball he
+offended two or three young ladies, by not asking them to dance; and I
+spoke to him twice myself, without receiving an answer. Could there be
+finer symptoms? Is not general incivility the very essence of love?”
+
+“Oh, yes!--of that kind of love which I suppose him to have felt. Poor
+Jane! I am sorry for her, because, with her disposition, she may not get
+over it immediately. It had better have happened to _you_, Lizzy; you
+would have laughed yourself out of it sooner. But do you think she
+would be prevailed upon to go back with us? Change of scene might be
+of service--and perhaps a little relief from home may be as useful as
+anything.”
+
+Elizabeth was exceedingly pleased with this proposal, and felt persuaded
+of her sister’s ready acquiescence.
+
+“I hope,” added Mrs. Gardiner, “that no consideration with regard to
+this young man will influence her. We live in so different a part of
+town, all our connections are so different, and, as you well know, we go
+out so little, that it is very improbable that they should meet at all,
+unless he really comes to see her.”
+
+“And _that_ is quite impossible; for he is now in the custody of his
+friend, and Mr. Darcy would no more suffer him to call on Jane in such
+a part of London! My dear aunt, how could you think of it? Mr. Darcy may
+perhaps have _heard_ of such a place as Gracechurch Street, but he
+would hardly think a month’s ablution enough to cleanse him from its
+impurities, were he once to enter it; and depend upon it, Mr. Bingley
+never stirs without him.”
+
+“So much the better. I hope they will not meet at all. But does not Jane
+correspond with his sister? _She_ will not be able to help calling.”
+
+“She will drop the acquaintance entirely.”
+
+But in spite of the certainty in which Elizabeth affected to place this
+point, as well as the still more interesting one of Bingley’s being
+withheld from seeing Jane, she felt a solicitude on the subject which
+convinced her, on examination, that she did not consider it entirely
+hopeless. It was possible, and sometimes she thought it probable, that
+his affection might be reanimated, and the influence of his friends
+successfully combated by the more natural influence of Jane’s
+attractions.
+
+Miss Bennet accepted her aunt’s invitation with pleasure; and the
+Bingleys were no otherwise in her thoughts at the same time, than as she
+hoped by Caroline’s not living in the same house with her brother,
+she might occasionally spend a morning with her, without any danger of
+seeing him.
+
+The Gardiners stayed a week at Longbourn; and what with the Phillipses,
+the Lucases, and the officers, there was not a day without its
+engagement. Mrs. Bennet had so carefully provided for the entertainment
+of her brother and sister, that they did not once sit down to a family
+dinner. When the engagement was for home, some of the officers always
+made part of it--of which officers Mr. Wickham was sure to be one; and
+on these occasions, Mrs. Gardiner, rendered suspicious by Elizabeth’s
+warm commendation, narrowly observed them both. Without supposing them,
+from what she saw, to be very seriously in love, their preference
+of each other was plain enough to make her a little uneasy; and
+she resolved to speak to Elizabeth on the subject before she left
+Hertfordshire, and represent to her the imprudence of encouraging such
+an attachment.
+
+To Mrs. Gardiner, Wickham had one means of affording pleasure,
+unconnected with his general powers. About ten or a dozen years ago,
+before her marriage, she had spent a considerable time in that very
+part of Derbyshire to which he belonged. They had, therefore, many
+acquaintances in common; and though Wickham had been little there since
+the death of Darcy’s father, it was yet in his power to give her fresher
+intelligence of her former friends than she had been in the way of
+procuring.
+
+Mrs. Gardiner had seen Pemberley, and known the late Mr. Darcy by
+character perfectly well. Here consequently was an inexhaustible subject
+of discourse. In comparing her recollection of Pemberley with the minute
+description which Wickham could give, and in bestowing her tribute of
+praise on the character of its late possessor, she was delighting both
+him and herself. On being made acquainted with the present Mr. Darcy’s
+treatment of him, she tried to remember some of that gentleman’s
+reputed disposition when quite a lad which might agree with it, and
+was confident at last that she recollected having heard Mr. Fitzwilliam
+Darcy formerly spoken of as a very proud, ill-natured boy.
+
+
+
+Chapter 26
+
+
+Mrs. Gardiner’s caution to Elizabeth was punctually and kindly given
+on the first favourable opportunity of speaking to her alone; after
+honestly telling her what she thought, she thus went on:
+
+“You are too sensible a girl, Lizzy, to fall in love merely because
+you are warned against it; and, therefore, I am not afraid of speaking
+openly. Seriously, I would have you be on your guard. Do not involve
+yourself or endeavour to involve him in an affection which the want
+of fortune would make so very imprudent. I have nothing to say against
+_him_; he is a most interesting young man; and if he had the fortune he
+ought to have, I should think you could not do better. But as it is, you
+must not let your fancy run away with you. You have sense, and we all
+expect you to use it. Your father would depend on _your_ resolution and
+good conduct, I am sure. You must not disappoint your father.”
+
+“My dear aunt, this is being serious indeed.”
+
+“Yes, and I hope to engage you to be serious likewise.”
+
+“Well, then, you need not be under any alarm. I will take care of
+myself, and of Mr. Wickham too. He shall not be in love with me, if I
+can prevent it.”
+
+“Elizabeth, you are not serious now.”
+
+“I beg your pardon, I will try again. At present I am not in love with
+Mr. Wickham; no, I certainly am not. But he is, beyond all comparison,
+the most agreeable man I ever saw--and if he becomes really attached to
+me--I believe it will be better that he should not. I see the imprudence
+of it. Oh! _that_ abominable Mr. Darcy! My father’s opinion of me does
+me the greatest honour, and I should be miserable to forfeit it. My
+father, however, is partial to Mr. Wickham. In short, my dear aunt, I
+should be very sorry to be the means of making any of you unhappy; but
+since we see every day that where there is affection, young people
+are seldom withheld by immediate want of fortune from entering into
+engagements with each other, how can I promise to be wiser than so many
+of my fellow-creatures if I am tempted, or how am I even to know that it
+would be wisdom to resist? All that I can promise you, therefore, is not
+to be in a hurry. I will not be in a hurry to believe myself his first
+object. When I am in company with him, I will not be wishing. In short,
+I will do my best.”
+
+“Perhaps it will be as well if you discourage his coming here so very
+often. At least, you should not _remind_ your mother of inviting him.”
+
+“As I did the other day,” said Elizabeth with a conscious smile: “very
+true, it will be wise in me to refrain from _that_. But do not imagine
+that he is always here so often. It is on your account that he has been
+so frequently invited this week. You know my mother’s ideas as to the
+necessity of constant company for her friends. But really, and upon my
+honour, I will try to do what I think to be the wisest; and now I hope
+you are satisfied.”
+
+Her aunt assured her that she was, and Elizabeth having thanked her for
+the kindness of her hints, they parted; a wonderful instance of advice
+being given on such a point, without being resented.
+
+Mr. Collins returned into Hertfordshire soon after it had been quitted
+by the Gardiners and Jane; but as he took up his abode with the Lucases,
+his arrival was no great inconvenience to Mrs. Bennet. His marriage was
+now fast approaching, and she was at length so far resigned as to think
+it inevitable, and even repeatedly to say, in an ill-natured tone, that
+she “_wished_ they might be happy.” Thursday was to be the wedding day,
+and on Wednesday Miss Lucas paid her farewell visit; and when she
+rose to take leave, Elizabeth, ashamed of her mother’s ungracious and
+reluctant good wishes, and sincerely affected herself, accompanied her
+out of the room. As they went downstairs together, Charlotte said:
+
+“I shall depend on hearing from you very often, Eliza.”
+
+“_That_ you certainly shall.”
+
+“And I have another favour to ask you. Will you come and see me?”
+
+“We shall often meet, I hope, in Hertfordshire.”
+
+“I am not likely to leave Kent for some time. Promise me, therefore, to
+come to Hunsford.”
+
+Elizabeth could not refuse, though she foresaw little pleasure in the
+visit.
+
+“My father and Maria are coming to me in March,” added Charlotte, “and I
+hope you will consent to be of the party. Indeed, Eliza, you will be as
+welcome as either of them.”
+
+The wedding took place; the bride and bridegroom set off for Kent from
+the church door, and everybody had as much to say, or to hear, on
+the subject as usual. Elizabeth soon heard from her friend; and their
+correspondence was as regular and frequent as it had ever been; that
+it should be equally unreserved was impossible. Elizabeth could never
+address her without feeling that all the comfort of intimacy was over,
+and though determined not to slacken as a correspondent, it was for the
+sake of what had been, rather than what was. Charlotte’s first letters
+were received with a good deal of eagerness; there could not but be
+curiosity to know how she would speak of her new home, how she would
+like Lady Catherine, and how happy she would dare pronounce herself to
+be; though, when the letters were read, Elizabeth felt that Charlotte
+expressed herself on every point exactly as she might have foreseen. She
+wrote cheerfully, seemed surrounded with comforts, and mentioned nothing
+which she could not praise. The house, furniture, neighbourhood, and
+roads, were all to her taste, and Lady Catherine’s behaviour was most
+friendly and obliging. It was Mr. Collins’s picture of Hunsford and
+Rosings rationally softened; and Elizabeth perceived that she must wait
+for her own visit there to know the rest.
+
+Jane had already written a few lines to her sister to announce their
+safe arrival in London; and when she wrote again, Elizabeth hoped it
+would be in her power to say something of the Bingleys.
+
+Her impatience for this second letter was as well rewarded as impatience
+generally is. Jane had been a week in town without either seeing or
+hearing from Caroline. She accounted for it, however, by supposing that
+her last letter to her friend from Longbourn had by some accident been
+lost.
+
+“My aunt,” she continued, “is going to-morrow into that part of the
+town, and I shall take the opportunity of calling in Grosvenor Street.”
+
+She wrote again when the visit was paid, and she had seen Miss Bingley.
+“I did not think Caroline in spirits,” were her words, “but she was very
+glad to see me, and reproached me for giving her no notice of my coming
+to London. I was right, therefore, my last letter had never reached
+her. I inquired after their brother, of course. He was well, but so much
+engaged with Mr. Darcy that they scarcely ever saw him. I found that
+Miss Darcy was expected to dinner. I wish I could see her. My visit was
+not long, as Caroline and Mrs. Hurst were going out. I dare say I shall
+see them soon here.”
+
+Elizabeth shook her head over this letter. It convinced her that
+accident only could discover to Mr. Bingley her sister’s being in town.
+
+Four weeks passed away, and Jane saw nothing of him. She endeavoured to
+persuade herself that she did not regret it; but she could no longer be
+blind to Miss Bingley’s inattention. After waiting at home every morning
+for a fortnight, and inventing every evening a fresh excuse for her, the
+visitor did at last appear; but the shortness of her stay, and yet more,
+the alteration of her manner would allow Jane to deceive herself no
+longer. The letter which she wrote on this occasion to her sister will
+prove what she felt.
+
+“My dearest Lizzy will, I am sure, be incapable of triumphing in her
+better judgement, at my expense, when I confess myself to have been
+entirely deceived in Miss Bingley’s regard for me. But, my dear sister,
+though the event has proved you right, do not think me obstinate if I
+still assert that, considering what her behaviour was, my confidence was
+as natural as your suspicion. I do not at all comprehend her reason for
+wishing to be intimate with me; but if the same circumstances were to
+happen again, I am sure I should be deceived again. Caroline did not
+return my visit till yesterday; and not a note, not a line, did I
+receive in the meantime. When she did come, it was very evident that
+she had no pleasure in it; she made a slight, formal apology, for not
+calling before, said not a word of wishing to see me again, and was
+in every respect so altered a creature, that when she went away I was
+perfectly resolved to continue the acquaintance no longer. I pity,
+though I cannot help blaming her. She was very wrong in singling me out
+as she did; I can safely say that every advance to intimacy began on
+her side. But I pity her, because she must feel that she has been acting
+wrong, and because I am very sure that anxiety for her brother is the
+cause of it. I need not explain myself farther; and though _we_ know
+this anxiety to be quite needless, yet if she feels it, it will easily
+account for her behaviour to me; and so deservedly dear as he is to
+his sister, whatever anxiety she must feel on his behalf is natural and
+amiable. I cannot but wonder, however, at her having any such fears now,
+because, if he had at all cared about me, we must have met, long ago.
+He knows of my being in town, I am certain, from something she said
+herself; and yet it would seem, by her manner of talking, as if she
+wanted to persuade herself that he is really partial to Miss Darcy. I
+cannot understand it. If I were not afraid of judging harshly, I should
+be almost tempted to say that there is a strong appearance of duplicity
+in all this. But I will endeavour to banish every painful thought,
+and think only of what will make me happy--your affection, and the
+invariable kindness of my dear uncle and aunt. Let me hear from you very
+soon. Miss Bingley said something of his never returning to Netherfield
+again, of giving up the house, but not with any certainty. We had better
+not mention it. I am extremely glad that you have such pleasant accounts
+from our friends at Hunsford. Pray go to see them, with Sir William and
+Maria. I am sure you will be very comfortable there.--Yours, etc.”
+
+This letter gave Elizabeth some pain; but her spirits returned as she
+considered that Jane would no longer be duped, by the sister at least.
+All expectation from the brother was now absolutely over. She would not
+even wish for a renewal of his attentions. His character sunk on
+every review of it; and as a punishment for him, as well as a possible
+advantage to Jane, she seriously hoped he might really soon marry Mr.
+Darcy’s sister, as by Wickham’s account, she would make him abundantly
+regret what he had thrown away.
+
+Mrs. Gardiner about this time reminded Elizabeth of her promise
+concerning that gentleman, and required information; and Elizabeth
+had such to send as might rather give contentment to her aunt than to
+herself. His apparent partiality had subsided, his attentions were over,
+he was the admirer of some one else. Elizabeth was watchful enough to
+see it all, but she could see it and write of it without material pain.
+Her heart had been but slightly touched, and her vanity was satisfied
+with believing that _she_ would have been his only choice, had fortune
+permitted it. The sudden acquisition of ten thousand pounds was the most
+remarkable charm of the young lady to whom he was now rendering himself
+agreeable; but Elizabeth, less clear-sighted perhaps in this case than
+in Charlotte’s, did not quarrel with him for his wish of independence.
+Nothing, on the contrary, could be more natural; and while able to
+suppose that it cost him a few struggles to relinquish her, she was
+ready to allow it a wise and desirable measure for both, and could very
+sincerely wish him happy.
+
+All this was acknowledged to Mrs. Gardiner; and after relating the
+circumstances, she thus went on: “I am now convinced, my dear aunt, that
+I have never been much in love; for had I really experienced that pure
+and elevating passion, I should at present detest his very name, and
+wish him all manner of evil. But my feelings are not only cordial
+towards _him_; they are even impartial towards Miss King. I cannot find
+out that I hate her at all, or that I am in the least unwilling to
+think her a very good sort of girl. There can be no love in all this. My
+watchfulness has been effectual; and though I certainly should be a more
+interesting object to all my acquaintances were I distractedly in love
+with him, I cannot say that I regret my comparative insignificance.
+Importance may sometimes be purchased too dearly. Kitty and Lydia take
+his defection much more to heart than I do. They are young in the
+ways of the world, and not yet open to the mortifying conviction that
+handsome young men must have something to live on as well as the plain.”
+
+
+
+Chapter 27
+
+
+With no greater events than these in the Longbourn family, and otherwise
+diversified by little beyond the walks to Meryton, sometimes dirty and
+sometimes cold, did January and February pass away. March was to take
+Elizabeth to Hunsford. She had not at first thought very seriously of
+going thither; but Charlotte, she soon found, was depending on the plan
+and she gradually learned to consider it herself with greater pleasure
+as well as greater certainty. Absence had increased her desire of seeing
+Charlotte again, and weakened her disgust of Mr. Collins. There
+was novelty in the scheme, and as, with such a mother and such
+uncompanionable sisters, home could not be faultless, a little change
+was not unwelcome for its own sake. The journey would moreover give her
+a peep at Jane; and, in short, as the time drew near, she would have
+been very sorry for any delay. Everything, however, went on smoothly,
+and was finally settled according to Charlotte’s first sketch. She was
+to accompany Sir William and his second daughter. The improvement
+of spending a night in London was added in time, and the plan became
+perfect as plan could be.
+
+The only pain was in leaving her father, who would certainly miss her,
+and who, when it came to the point, so little liked her going, that he
+told her to write to him, and almost promised to answer her letter.
+
+The farewell between herself and Mr. Wickham was perfectly friendly; on
+his side even more. His present pursuit could not make him forget that
+Elizabeth had been the first to excite and to deserve his attention, the
+first to listen and to pity, the first to be admired; and in his manner
+of bidding her adieu, wishing her every enjoyment, reminding her of
+what she was to expect in Lady Catherine de Bourgh, and trusting their
+opinion of her--their opinion of everybody--would always coincide, there
+was a solicitude, an interest which she felt must ever attach her to
+him with a most sincere regard; and she parted from him convinced that,
+whether married or single, he must always be her model of the amiable
+and pleasing.
+
+Her fellow-travellers the next day were not of a kind to make her
+think him less agreeable. Sir William Lucas, and his daughter Maria, a
+good-humoured girl, but as empty-headed as himself, had nothing to say
+that could be worth hearing, and were listened to with about as much
+delight as the rattle of the chaise. Elizabeth loved absurdities, but
+she had known Sir William’s too long. He could tell her nothing new of
+the wonders of his presentation and knighthood; and his civilities were
+worn out, like his information.
+
+It was a journey of only twenty-four miles, and they began it so early
+as to be in Gracechurch Street by noon. As they drove to Mr. Gardiner’s
+door, Jane was at a drawing-room window watching their arrival; when
+they entered the passage she was there to welcome them, and Elizabeth,
+looking earnestly in her face, was pleased to see it healthful and
+lovely as ever. On the stairs were a troop of little boys and girls,
+whose eagerness for their cousin’s appearance would not allow them to
+wait in the drawing-room, and whose shyness, as they had not seen
+her for a twelvemonth, prevented their coming lower. All was joy and
+kindness. The day passed most pleasantly away; the morning in bustle and
+shopping, and the evening at one of the theatres.
+
+Elizabeth then contrived to sit by her aunt. Their first object was her
+sister; and she was more grieved than astonished to hear, in reply to
+her minute inquiries, that though Jane always struggled to support her
+spirits, there were periods of dejection. It was reasonable, however,
+to hope that they would not continue long. Mrs. Gardiner gave her the
+particulars also of Miss Bingley’s visit in Gracechurch Street, and
+repeated conversations occurring at different times between Jane and
+herself, which proved that the former had, from her heart, given up the
+acquaintance.
+
+Mrs. Gardiner then rallied her niece on Wickham’s desertion, and
+complimented her on bearing it so well.
+
+“But my dear Elizabeth,” she added, “what sort of girl is Miss King? I
+should be sorry to think our friend mercenary.”
+
+“Pray, my dear aunt, what is the difference in matrimonial affairs,
+between the mercenary and the prudent motive? Where does discretion end,
+and avarice begin? Last Christmas you were afraid of his marrying me,
+because it would be imprudent; and now, because he is trying to get
+a girl with only ten thousand pounds, you want to find out that he is
+mercenary.”
+
+“If you will only tell me what sort of girl Miss King is, I shall know
+what to think.”
+
+“She is a very good kind of girl, I believe. I know no harm of her.”
+
+“But he paid her not the smallest attention till her grandfather’s death
+made her mistress of this fortune.”
+
+“No--why should he? If it were not allowable for him to gain _my_
+affections because I had no money, what occasion could there be for
+making love to a girl whom he did not care about, and who was equally
+poor?”
+
+“But there seems an indelicacy in directing his attentions towards her
+so soon after this event.”
+
+“A man in distressed circumstances has not time for all those elegant
+decorums which other people may observe. If _she_ does not object to it,
+why should _we_?”
+
+“_Her_ not objecting does not justify _him_. It only shows her being
+deficient in something herself--sense or feeling.”
+
+“Well,” cried Elizabeth, “have it as you choose. _He_ shall be
+mercenary, and _she_ shall be foolish.”
+
+“No, Lizzy, that is what I do _not_ choose. I should be sorry, you know,
+to think ill of a young man who has lived so long in Derbyshire.”
+
+“Oh! if that is all, I have a very poor opinion of young men who live in
+Derbyshire; and their intimate friends who live in Hertfordshire are not
+much better. I am sick of them all. Thank Heaven! I am going to-morrow
+where I shall find a man who has not one agreeable quality, who has
+neither manner nor sense to recommend him. Stupid men are the only ones
+worth knowing, after all.”
+
+“Take care, Lizzy; that speech savours strongly of disappointment.”
+
+Before they were separated by the conclusion of the play, she had the
+unexpected happiness of an invitation to accompany her uncle and aunt in
+a tour of pleasure which they proposed taking in the summer.
+
+“We have not determined how far it shall carry us,” said Mrs. Gardiner,
+“but, perhaps, to the Lakes.”
+
+No scheme could have been more agreeable to Elizabeth, and her
+acceptance of the invitation was most ready and grateful. “Oh, my dear,
+dear aunt,” she rapturously cried, “what delight! what felicity! You
+give me fresh life and vigour. Adieu to disappointment and spleen. What
+are young men to rocks and mountains? Oh! what hours of transport
+we shall spend! And when we _do_ return, it shall not be like other
+travellers, without being able to give one accurate idea of anything. We
+_will_ know where we have gone--we _will_ recollect what we have seen.
+Lakes, mountains, and rivers shall not be jumbled together in our
+imaginations; nor when we attempt to describe any particular scene,
+will we begin quarreling about its relative situation. Let _our_
+first effusions be less insupportable than those of the generality of
+travellers.”
+
+
+
+Chapter 28
+
+
+Every object in the next day’s journey was new and interesting to
+Elizabeth; and her spirits were in a state of enjoyment; for she had
+seen her sister looking so well as to banish all fear for her health,
+and the prospect of her northern tour was a constant source of delight.
+
+When they left the high road for the lane to Hunsford, every eye was in
+search of the Parsonage, and every turning expected to bring it in view.
+The palings of Rosings Park was their boundary on one side. Elizabeth
+smiled at the recollection of all that she had heard of its inhabitants.
+
+At length the Parsonage was discernible. The garden sloping to the
+road, the house standing in it, the green pales, and the laurel hedge,
+everything declared they were arriving. Mr. Collins and Charlotte
+appeared at the door, and the carriage stopped at the small gate which
+led by a short gravel walk to the house, amidst the nods and smiles of
+the whole party. In a moment they were all out of the chaise, rejoicing
+at the sight of each other. Mrs. Collins welcomed her friend with the
+liveliest pleasure, and Elizabeth was more and more satisfied with
+coming when she found herself so affectionately received. She saw
+instantly that her cousin’s manners were not altered by his marriage;
+his formal civility was just what it had been, and he detained her some
+minutes at the gate to hear and satisfy his inquiries after all her
+family. They were then, with no other delay than his pointing out the
+neatness of the entrance, taken into the house; and as soon as they
+were in the parlour, he welcomed them a second time, with ostentatious
+formality to his humble abode, and punctually repeated all his wife’s
+offers of refreshment.
+
+Elizabeth was prepared to see him in his glory; and she could not help
+in fancying that in displaying the good proportion of the room, its
+aspect and its furniture, he addressed himself particularly to her,
+as if wishing to make her feel what she had lost in refusing him. But
+though everything seemed neat and comfortable, she was not able to
+gratify him by any sigh of repentance, and rather looked with wonder at
+her friend that she could have so cheerful an air with such a companion.
+When Mr. Collins said anything of which his wife might reasonably be
+ashamed, which certainly was not unseldom, she involuntarily turned her
+eye on Charlotte. Once or twice she could discern a faint blush; but
+in general Charlotte wisely did not hear. After sitting long enough to
+admire every article of furniture in the room, from the sideboard to
+the fender, to give an account of their journey, and of all that had
+happened in London, Mr. Collins invited them to take a stroll in the
+garden, which was large and well laid out, and to the cultivation of
+which he attended himself. To work in this garden was one of his most
+respectable pleasures; and Elizabeth admired the command of countenance
+with which Charlotte talked of the healthfulness of the exercise, and
+owned she encouraged it as much as possible. Here, leading the way
+through every walk and cross walk, and scarcely allowing them an
+interval to utter the praises he asked for, every view was pointed out
+with a minuteness which left beauty entirely behind. He could number the
+fields in every direction, and could tell how many trees there were in
+the most distant clump. But of all the views which his garden, or which
+the country or kingdom could boast, none were to be compared with the
+prospect of Rosings, afforded by an opening in the trees that bordered
+the park nearly opposite the front of his house. It was a handsome
+modern building, well situated on rising ground.
+
+From his garden, Mr. Collins would have led them round his two meadows;
+but the ladies, not having shoes to encounter the remains of a white
+frost, turned back; and while Sir William accompanied him, Charlotte
+took her sister and friend over the house, extremely well pleased,
+probably, to have the opportunity of showing it without her husband’s
+help. It was rather small, but well built and convenient; and everything
+was fitted up and arranged with a neatness and consistency of which
+Elizabeth gave Charlotte all the credit. When Mr. Collins could be
+forgotten, there was really an air of great comfort throughout, and by
+Charlotte’s evident enjoyment of it, Elizabeth supposed he must be often
+forgotten.
+
+She had already learnt that Lady Catherine was still in the country. It
+was spoken of again while they were at dinner, when Mr. Collins joining
+in, observed:
+
+“Yes, Miss Elizabeth, you will have the honour of seeing Lady Catherine
+de Bourgh on the ensuing Sunday at church, and I need not say you will
+be delighted with her. She is all affability and condescension, and I
+doubt not but you will be honoured with some portion of her notice
+when service is over. I have scarcely any hesitation in saying she
+will include you and my sister Maria in every invitation with which she
+honours us during your stay here. Her behaviour to my dear Charlotte is
+charming. We dine at Rosings twice every week, and are never allowed
+to walk home. Her ladyship’s carriage is regularly ordered for us. I
+_should_ say, one of her ladyship’s carriages, for she has several.”
+
+“Lady Catherine is a very respectable, sensible woman indeed,” added
+Charlotte, “and a most attentive neighbour.”
+
+“Very true, my dear, that is exactly what I say. She is the sort of
+woman whom one cannot regard with too much deference.”
+
+The evening was spent chiefly in talking over Hertfordshire news,
+and telling again what had already been written; and when it closed,
+Elizabeth, in the solitude of her chamber, had to meditate upon
+Charlotte’s degree of contentment, to understand her address in guiding,
+and composure in bearing with, her husband, and to acknowledge that it
+was all done very well. She had also to anticipate how her visit
+would pass, the quiet tenor of their usual employments, the vexatious
+interruptions of Mr. Collins, and the gaieties of their intercourse with
+Rosings. A lively imagination soon settled it all.
+
+About the middle of the next day, as she was in her room getting ready
+for a walk, a sudden noise below seemed to speak the whole house in
+confusion; and, after listening a moment, she heard somebody running
+up stairs in a violent hurry, and calling loudly after her. She opened
+the door and met Maria in the landing place, who, breathless with
+agitation, cried out--
+
+“Oh, my dear Eliza! pray make haste and come into the dining-room, for
+there is such a sight to be seen! I will not tell you what it is. Make
+haste, and come down this moment.”
+
+Elizabeth asked questions in vain; Maria would tell her nothing more,
+and down they ran into the dining-room, which fronted the lane, in
+quest of this wonder; It was two ladies stopping in a low phaeton at the
+garden gate.
+
+“And is this all?” cried Elizabeth. “I expected at least that the pigs
+were got into the garden, and here is nothing but Lady Catherine and her
+daughter.”
+
+“La! my dear,” said Maria, quite shocked at the mistake, “it is not
+Lady Catherine. The old lady is Mrs. Jenkinson, who lives with them;
+the other is Miss de Bourgh. Only look at her. She is quite a little
+creature. Who would have thought that she could be so thin and small?”
+
+“She is abominably rude to keep Charlotte out of doors in all this wind.
+Why does she not come in?”
+
+“Oh, Charlotte says she hardly ever does. It is the greatest of favours
+when Miss de Bourgh comes in.”
+
+“I like her appearance,” said Elizabeth, struck with other ideas. “She
+looks sickly and cross. Yes, she will do for him very well. She will
+make him a very proper wife.”
+
+Mr. Collins and Charlotte were both standing at the gate in conversation
+with the ladies; and Sir William, to Elizabeth’s high diversion, was
+stationed in the doorway, in earnest contemplation of the greatness
+before him, and constantly bowing whenever Miss de Bourgh looked that
+way.
+
+At length there was nothing more to be said; the ladies drove on, and
+the others returned into the house. Mr. Collins no sooner saw the two
+girls than he began to congratulate them on their good fortune, which
+Charlotte explained by letting them know that the whole party was asked
+to dine at Rosings the next day.
+
+
+
+Chapter 29
+
+
+Mr. Collins’s triumph, in consequence of this invitation, was complete.
+The power of displaying the grandeur of his patroness to his wondering
+visitors, and of letting them see her civility towards himself and his
+wife, was exactly what he had wished for; and that an opportunity
+of doing it should be given so soon, was such an instance of Lady
+Catherine’s condescension, as he knew not how to admire enough.
+
+“I confess,” said he, “that I should not have been at all surprised by
+her ladyship’s asking us on Sunday to drink tea and spend the evening at
+Rosings. I rather expected, from my knowledge of her affability, that it
+would happen. But who could have foreseen such an attention as this? Who
+could have imagined that we should receive an invitation to dine there
+(an invitation, moreover, including the whole party) so immediately
+after your arrival!”
+
+“I am the less surprised at what has happened,” replied Sir William,
+“from that knowledge of what the manners of the great really are, which
+my situation in life has allowed me to acquire. About the court, such
+instances of elegant breeding are not uncommon.”
+
+Scarcely anything was talked of the whole day or next morning but their
+visit to Rosings. Mr. Collins was carefully instructing them in what
+they were to expect, that the sight of such rooms, so many servants, and
+so splendid a dinner, might not wholly overpower them.
+
+When the ladies were separating for the toilette, he said to Elizabeth--
+
+“Do not make yourself uneasy, my dear cousin, about your apparel. Lady
+Catherine is far from requiring that elegance of dress in us which
+becomes herself and her daughter. I would advise you merely to put on
+whatever of your clothes is superior to the rest--there is no occasion
+for anything more. Lady Catherine will not think the worse of you
+for being simply dressed. She likes to have the distinction of rank
+preserved.”
+
+While they were dressing, he came two or three times to their different
+doors, to recommend their being quick, as Lady Catherine very much
+objected to be kept waiting for her dinner. Such formidable accounts of
+her ladyship, and her manner of living, quite frightened Maria Lucas
+who had been little used to company, and she looked forward to her
+introduction at Rosings with as much apprehension as her father had done
+to his presentation at St. James’s.
+
+As the weather was fine, they had a pleasant walk of about half a
+mile across the park. Every park has its beauty and its prospects; and
+Elizabeth saw much to be pleased with, though she could not be in such
+raptures as Mr. Collins expected the scene to inspire, and was but
+slightly affected by his enumeration of the windows in front of the
+house, and his relation of what the glazing altogether had originally
+cost Sir Lewis de Bourgh.
+
+When they ascended the steps to the hall, Maria’s alarm was every
+moment increasing, and even Sir William did not look perfectly calm.
+Elizabeth’s courage did not fail her. She had heard nothing of Lady
+Catherine that spoke her awful from any extraordinary talents or
+miraculous virtue, and the mere stateliness of money or rank she thought
+she could witness without trepidation.
+
+From the entrance-hall, of which Mr. Collins pointed out, with a
+rapturous air, the fine proportion and the finished ornaments, they
+followed the servants through an ante-chamber, to the room where Lady
+Catherine, her daughter, and Mrs. Jenkinson were sitting. Her ladyship,
+with great condescension, arose to receive them; and as Mrs. Collins had
+settled it with her husband that the office of introduction should
+be hers, it was performed in a proper manner, without any of those
+apologies and thanks which he would have thought necessary.
+
+In spite of having been at St. James’s, Sir William was so completely
+awed by the grandeur surrounding him, that he had but just courage
+enough to make a very low bow, and take his seat without saying a word;
+and his daughter, frightened almost out of her senses, sat on the edge
+of her chair, not knowing which way to look. Elizabeth found herself
+quite equal to the scene, and could observe the three ladies before her
+composedly. Lady Catherine was a tall, large woman, with strongly-marked
+features, which might once have been handsome. Her air was not
+conciliating, nor was her manner of receiving them such as to make her
+visitors forget their inferior rank. She was not rendered formidable by
+silence; but whatever she said was spoken in so authoritative a tone,
+as marked her self-importance, and brought Mr. Wickham immediately to
+Elizabeth’s mind; and from the observation of the day altogether, she
+believed Lady Catherine to be exactly what he represented.
+
+When, after examining the mother, in whose countenance and deportment
+she soon found some resemblance of Mr. Darcy, she turned her eyes on the
+daughter, she could almost have joined in Maria’s astonishment at her
+being so thin and so small. There was neither in figure nor face any
+likeness between the ladies. Miss de Bourgh was pale and sickly; her
+features, though not plain, were insignificant; and she spoke very
+little, except in a low voice, to Mrs. Jenkinson, in whose appearance
+there was nothing remarkable, and who was entirely engaged in listening
+to what she said, and placing a screen in the proper direction before
+her eyes.
+
+After sitting a few minutes, they were all sent to one of the windows to
+admire the view, Mr. Collins attending them to point out its beauties,
+and Lady Catherine kindly informing them that it was much better worth
+looking at in the summer.
+
+The dinner was exceedingly handsome, and there were all the servants and
+all the articles of plate which Mr. Collins had promised; and, as he had
+likewise foretold, he took his seat at the bottom of the table, by her
+ladyship’s desire, and looked as if he felt that life could furnish
+nothing greater. He carved, and ate, and praised with delighted
+alacrity; and every dish was commended, first by him and then by Sir
+William, who was now enough recovered to echo whatever his son-in-law
+said, in a manner which Elizabeth wondered Lady Catherine could bear.
+But Lady Catherine seemed gratified by their excessive admiration, and
+gave most gracious smiles, especially when any dish on the table proved
+a novelty to them. The party did not supply much conversation. Elizabeth
+was ready to speak whenever there was an opening, but she was seated
+between Charlotte and Miss de Bourgh--the former of whom was engaged in
+listening to Lady Catherine, and the latter said not a word to her all
+dinner-time. Mrs. Jenkinson was chiefly employed in watching how little
+Miss de Bourgh ate, pressing her to try some other dish, and fearing
+she was indisposed. Maria thought speaking out of the question, and the
+gentlemen did nothing but eat and admire.
+
+When the ladies returned to the drawing-room, there was little to
+be done but to hear Lady Catherine talk, which she did without any
+intermission till coffee came in, delivering her opinion on every
+subject in so decisive a manner, as proved that she was not used to
+have her judgement controverted. She inquired into Charlotte’s domestic
+concerns familiarly and minutely, gave her a great deal of advice as
+to the management of them all; told her how everything ought to be
+regulated in so small a family as hers, and instructed her as to the
+care of her cows and her poultry. Elizabeth found that nothing was
+beneath this great lady’s attention, which could furnish her with an
+occasion of dictating to others. In the intervals of her discourse
+with Mrs. Collins, she addressed a variety of questions to Maria and
+Elizabeth, but especially to the latter, of whose connections she knew
+the least, and who she observed to Mrs. Collins was a very genteel,
+pretty kind of girl. She asked her, at different times, how many sisters
+she had, whether they were older or younger than herself, whether any of
+them were likely to be married, whether they were handsome, where they
+had been educated, what carriage her father kept, and what had been
+her mother’s maiden name? Elizabeth felt all the impertinence of
+her questions but answered them very composedly. Lady Catherine then
+observed,
+
+“Your father’s estate is entailed on Mr. Collins, I think. For your
+sake,” turning to Charlotte, “I am glad of it; but otherwise I see no
+occasion for entailing estates from the female line. It was not thought
+necessary in Sir Lewis de Bourgh’s family. Do you play and sing, Miss
+Bennet?”
+
+“A little.”
+
+“Oh! then--some time or other we shall be happy to hear you. Our
+instrument is a capital one, probably superior to----You shall try it
+some day. Do your sisters play and sing?”
+
+“One of them does.”
+
+“Why did not you all learn? You ought all to have learned. The Miss
+Webbs all play, and their father has not so good an income as yours. Do
+you draw?”
+
+“No, not at all.”
+
+“What, none of you?”
+
+“Not one.”
+
+“That is very strange. But I suppose you had no opportunity. Your mother
+should have taken you to town every spring for the benefit of masters.”
+
+“My mother would have had no objection, but my father hates London.”
+
+“Has your governess left you?”
+
+“We never had any governess.”
+
+“No governess! How was that possible? Five daughters brought up at home
+without a governess! I never heard of such a thing. Your mother must
+have been quite a slave to your education.”
+
+Elizabeth could hardly help smiling as she assured her that had not been
+the case.
+
+“Then, who taught you? who attended to you? Without a governess, you
+must have been neglected.”
+
+“Compared with some families, I believe we were; but such of us as
+wished to learn never wanted the means. We were always encouraged to
+read, and had all the masters that were necessary. Those who chose to be
+idle, certainly might.”
+
+“Aye, no doubt; but that is what a governess will prevent, and if I had
+known your mother, I should have advised her most strenuously to engage
+one. I always say that nothing is to be done in education without steady
+and regular instruction, and nobody but a governess can give it. It is
+wonderful how many families I have been the means of supplying in that
+way. I am always glad to get a young person well placed out. Four nieces
+of Mrs. Jenkinson are most delightfully situated through my means; and
+it was but the other day that I recommended another young person,
+who was merely accidentally mentioned to me, and the family are quite
+delighted with her. Mrs. Collins, did I tell you of Lady Metcalf’s
+calling yesterday to thank me? She finds Miss Pope a treasure. ‘Lady
+Catherine,’ said she, ‘you have given me a treasure.’ Are any of your
+younger sisters out, Miss Bennet?”
+
+“Yes, ma’am, all.”
+
+“All! What, all five out at once? Very odd! And you only the second. The
+younger ones out before the elder ones are married! Your younger sisters
+must be very young?”
+
+“Yes, my youngest is not sixteen. Perhaps _she_ is full young to be
+much in company. But really, ma’am, I think it would be very hard upon
+younger sisters, that they should not have their share of society and
+amusement, because the elder may not have the means or inclination to
+marry early. The last-born has as good a right to the pleasures of youth
+as the first. And to be kept back on _such_ a motive! I think it would
+not be very likely to promote sisterly affection or delicacy of mind.”
+
+“Upon my word,” said her ladyship, “you give your opinion very decidedly
+for so young a person. Pray, what is your age?”
+
+“With three younger sisters grown up,” replied Elizabeth, smiling, “your
+ladyship can hardly expect me to own it.”
+
+Lady Catherine seemed quite astonished at not receiving a direct answer;
+and Elizabeth suspected herself to be the first creature who had ever
+dared to trifle with so much dignified impertinence.
+
+“You cannot be more than twenty, I am sure, therefore you need not
+conceal your age.”
+
+“I am not one-and-twenty.”
+
+When the gentlemen had joined them, and tea was over, the card-tables
+were placed. Lady Catherine, Sir William, and Mr. and Mrs. Collins sat
+down to quadrille; and as Miss de Bourgh chose to play at cassino, the
+two girls had the honour of assisting Mrs. Jenkinson to make up her
+party. Their table was superlatively stupid. Scarcely a syllable was
+uttered that did not relate to the game, except when Mrs. Jenkinson
+expressed her fears of Miss de Bourgh’s being too hot or too cold, or
+having too much or too little light. A great deal more passed at the
+other table. Lady Catherine was generally speaking--stating the mistakes
+of the three others, or relating some anecdote of herself. Mr. Collins
+was employed in agreeing to everything her ladyship said, thanking her
+for every fish he won, and apologising if he thought he won too many.
+Sir William did not say much. He was storing his memory with anecdotes
+and noble names.
+
+When Lady Catherine and her daughter had played as long as they chose,
+the tables were broken up, the carriage was offered to Mrs. Collins,
+gratefully accepted and immediately ordered. The party then gathered
+round the fire to hear Lady Catherine determine what weather they were
+to have on the morrow. From these instructions they were summoned by
+the arrival of the coach; and with many speeches of thankfulness on Mr.
+Collins’s side and as many bows on Sir William’s they departed. As soon
+as they had driven from the door, Elizabeth was called on by her cousin
+to give her opinion of all that she had seen at Rosings, which, for
+Charlotte’s sake, she made more favourable than it really was. But her
+commendation, though costing her some trouble, could by no means satisfy
+Mr. Collins, and he was very soon obliged to take her ladyship’s praise
+into his own hands.
+
+
+
+Chapter 30
+
+
+Sir William stayed only a week at Hunsford, but his visit was long
+enough to convince him of his daughter’s being most comfortably settled,
+and of her possessing such a husband and such a neighbour as were not
+often met with. While Sir William was with them, Mr. Collins devoted his
+morning to driving him out in his gig, and showing him the country; but
+when he went away, the whole family returned to their usual employments,
+and Elizabeth was thankful to find that they did not see more of her
+cousin by the alteration, for the chief of the time between breakfast
+and dinner was now passed by him either at work in the garden or in
+reading and writing, and looking out of the window in his own book-room,
+which fronted the road. The room in which the ladies sat was backwards.
+Elizabeth had at first rather wondered that Charlotte should not prefer
+the dining-parlour for common use; it was a better sized room, and had a
+more pleasant aspect; but she soon saw that her friend had an excellent
+reason for what she did, for Mr. Collins would undoubtedly have been
+much less in his own apartment, had they sat in one equally lively; and
+she gave Charlotte credit for the arrangement.
+
+From the drawing-room they could distinguish nothing in the lane, and
+were indebted to Mr. Collins for the knowledge of what carriages went
+along, and how often especially Miss de Bourgh drove by in her phaeton,
+which he never failed coming to inform them of, though it happened
+almost every day. She not unfrequently stopped at the Parsonage, and
+had a few minutes’ conversation with Charlotte, but was scarcely ever
+prevailed upon to get out.
+
+Very few days passed in which Mr. Collins did not walk to Rosings, and
+not many in which his wife did not think it necessary to go likewise;
+and till Elizabeth recollected that there might be other family livings
+to be disposed of, she could not understand the sacrifice of so many
+hours. Now and then they were honoured with a call from her ladyship,
+and nothing escaped her observation that was passing in the room during
+these visits. She examined into their employments, looked at their work,
+and advised them to do it differently; found fault with the arrangement
+of the furniture; or detected the housemaid in negligence; and if she
+accepted any refreshment, seemed to do it only for the sake of finding
+out that Mrs. Collins’s joints of meat were too large for her family.
+
+Elizabeth soon perceived, that though this great lady was not in
+commission of the peace of the county, she was a most active magistrate
+in her own parish, the minutest concerns of which were carried to her
+by Mr. Collins; and whenever any of the cottagers were disposed to
+be quarrelsome, discontented, or too poor, she sallied forth into the
+village to settle their differences, silence their complaints, and scold
+them into harmony and plenty.
+
+The entertainment of dining at Rosings was repeated about twice a week;
+and, allowing for the loss of Sir William, and there being only one
+card-table in the evening, every such entertainment was the counterpart
+of the first. Their other engagements were few, as the style of living
+in the neighbourhood in general was beyond Mr. Collins’s reach. This,
+however, was no evil to Elizabeth, and upon the whole she spent her time
+comfortably enough; there were half-hours of pleasant conversation with
+Charlotte, and the weather was so fine for the time of year that she had
+often great enjoyment out of doors. Her favourite walk, and where she
+frequently went while the others were calling on Lady Catherine, was
+along the open grove which edged that side of the park, where there was
+a nice sheltered path, which no one seemed to value but herself, and
+where she felt beyond the reach of Lady Catherine’s curiosity.
+
+In this quiet way, the first fortnight of her visit soon passed away.
+Easter was approaching, and the week preceding it was to bring an
+addition to the family at Rosings, which in so small a circle must be
+important. Elizabeth had heard soon after her arrival that Mr. Darcy was
+expected there in the course of a few weeks, and though there were not
+many of her acquaintances whom she did not prefer, his coming would
+furnish one comparatively new to look at in their Rosings parties, and
+she might be amused in seeing how hopeless Miss Bingley’s designs on him
+were, by his behaviour to his cousin, for whom he was evidently
+destined by Lady Catherine, who talked of his coming with the greatest
+satisfaction, spoke of him in terms of the highest admiration, and
+seemed almost angry to find that he had already been frequently seen by
+Miss Lucas and herself.
+
+His arrival was soon known at the Parsonage; for Mr. Collins was walking
+the whole morning within view of the lodges opening into Hunsford Lane,
+in order to have the earliest assurance of it, and after making his
+bow as the carriage turned into the Park, hurried home with the great
+intelligence. On the following morning he hastened to Rosings to pay his
+respects. There were two nephews of Lady Catherine to require them, for
+Mr. Darcy had brought with him a Colonel Fitzwilliam, the younger son of
+his uncle Lord ----, and, to the great surprise of all the party, when
+Mr. Collins returned, the gentlemen accompanied him. Charlotte had seen
+them from her husband’s room, crossing the road, and immediately running
+into the other, told the girls what an honour they might expect, adding:
+
+“I may thank you, Eliza, for this piece of civility. Mr. Darcy would
+never have come so soon to wait upon me.”
+
+Elizabeth had scarcely time to disclaim all right to the compliment,
+before their approach was announced by the door-bell, and shortly
+afterwards the three gentlemen entered the room. Colonel Fitzwilliam,
+who led the way, was about thirty, not handsome, but in person and
+address most truly the gentleman. Mr. Darcy looked just as he had been
+used to look in Hertfordshire--paid his compliments, with his usual
+reserve, to Mrs. Collins, and whatever might be his feelings toward her
+friend, met her with every appearance of composure. Elizabeth merely
+curtseyed to him without saying a word.
+
+Colonel Fitzwilliam entered into conversation directly with the
+readiness and ease of a well-bred man, and talked very pleasantly; but
+his cousin, after having addressed a slight observation on the house and
+garden to Mrs. Collins, sat for some time without speaking to anybody.
+At length, however, his civility was so far awakened as to inquire of
+Elizabeth after the health of her family. She answered him in the usual
+way, and after a moment’s pause, added:
+
+“My eldest sister has been in town these three months. Have you never
+happened to see her there?”
+
+She was perfectly sensible that he never had; but she wished to see
+whether he would betray any consciousness of what had passed between
+the Bingleys and Jane, and she thought he looked a little confused as he
+answered that he had never been so fortunate as to meet Miss Bennet. The
+subject was pursued no farther, and the gentlemen soon afterwards went
+away.
+
+
+
+Chapter 31
+
+
+Colonel Fitzwilliam’s manners were very much admired at the Parsonage,
+and the ladies all felt that he must add considerably to the pleasures
+of their engagements at Rosings. It was some days, however, before they
+received any invitation thither--for while there were visitors in the
+house, they could not be necessary; and it was not till Easter-day,
+almost a week after the gentlemen’s arrival, that they were honoured by
+such an attention, and then they were merely asked on leaving church to
+come there in the evening. For the last week they had seen very little
+of Lady Catherine or her daughter. Colonel Fitzwilliam had called at the
+Parsonage more than once during the time, but Mr. Darcy they had seen
+only at church.
+
+The invitation was accepted of course, and at a proper hour they joined
+the party in Lady Catherine’s drawing-room. Her ladyship received
+them civilly, but it was plain that their company was by no means so
+acceptable as when she could get nobody else; and she was, in fact,
+almost engrossed by her nephews, speaking to them, especially to Darcy,
+much more than to any other person in the room.
+
+Colonel Fitzwilliam seemed really glad to see them; anything was a
+welcome relief to him at Rosings; and Mrs. Collins’s pretty friend had
+moreover caught his fancy very much. He now seated himself by her, and
+talked so agreeably of Kent and Hertfordshire, of travelling and staying
+at home, of new books and music, that Elizabeth had never been half so
+well entertained in that room before; and they conversed with so much
+spirit and flow, as to draw the attention of Lady Catherine herself,
+as well as of Mr. Darcy. _His_ eyes had been soon and repeatedly turned
+towards them with a look of curiosity; and that her ladyship, after a
+while, shared the feeling, was more openly acknowledged, for she did not
+scruple to call out:
+
+“What is that you are saying, Fitzwilliam? What is it you are talking
+of? What are you telling Miss Bennet? Let me hear what it is.”
+
+“We are speaking of music, madam,” said he, when no longer able to avoid
+a reply.
+
+“Of music! Then pray speak aloud. It is of all subjects my delight. I
+must have my share in the conversation if you are speaking of music.
+There are few people in England, I suppose, who have more true enjoyment
+of music than myself, or a better natural taste. If I had ever learnt,
+I should have been a great proficient. And so would Anne, if her health
+had allowed her to apply. I am confident that she would have performed
+delightfully. How does Georgiana get on, Darcy?”
+
+Mr. Darcy spoke with affectionate praise of his sister’s proficiency.
+
+“I am very glad to hear such a good account of her,” said Lady
+Catherine; “and pray tell her from me, that she cannot expect to excel
+if she does not practice a good deal.”
+
+“I assure you, madam,” he replied, “that she does not need such advice.
+She practises very constantly.”
+
+“So much the better. It cannot be done too much; and when I next write
+to her, I shall charge her not to neglect it on any account. I often
+tell young ladies that no excellence in music is to be acquired without
+constant practice. I have told Miss Bennet several times, that she
+will never play really well unless she practises more; and though Mrs.
+Collins has no instrument, she is very welcome, as I have often told
+her, to come to Rosings every day, and play on the pianoforte in Mrs.
+Jenkinson’s room. She would be in nobody’s way, you know, in that part
+of the house.”
+
+Mr. Darcy looked a little ashamed of his aunt’s ill-breeding, and made
+no answer.
+
+When coffee was over, Colonel Fitzwilliam reminded Elizabeth of having
+promised to play to him; and she sat down directly to the instrument. He
+drew a chair near her. Lady Catherine listened to half a song, and then
+talked, as before, to her other nephew; till the latter walked away
+from her, and making with his usual deliberation towards the pianoforte
+stationed himself so as to command a full view of the fair performer’s
+countenance. Elizabeth saw what he was doing, and at the first
+convenient pause, turned to him with an arch smile, and said:
+
+“You mean to frighten me, Mr. Darcy, by coming in all this state to hear
+me? I will not be alarmed though your sister _does_ play so well. There
+is a stubbornness about me that never can bear to be frightened at the
+will of others. My courage always rises at every attempt to intimidate
+me.”
+
+“I shall not say you are mistaken,” he replied, “because you could not
+really believe me to entertain any design of alarming you; and I have
+had the pleasure of your acquaintance long enough to know that you find
+great enjoyment in occasionally professing opinions which in fact are
+not your own.”
+
+Elizabeth laughed heartily at this picture of herself, and said to
+Colonel Fitzwilliam, “Your cousin will give you a very pretty notion of
+me, and teach you not to believe a word I say. I am particularly unlucky
+in meeting with a person so able to expose my real character, in a part
+of the world where I had hoped to pass myself off with some degree of
+credit. Indeed, Mr. Darcy, it is very ungenerous in you to mention all
+that you knew to my disadvantage in Hertfordshire--and, give me leave to
+say, very impolitic too--for it is provoking me to retaliate, and such
+things may come out as will shock your relations to hear.”
+
+“I am not afraid of you,” said he, smilingly.
+
+“Pray let me hear what you have to accuse him of,” cried Colonel
+Fitzwilliam. “I should like to know how he behaves among strangers.”
+
+“You shall hear then--but prepare yourself for something very dreadful.
+The first time of my ever seeing him in Hertfordshire, you must know,
+was at a ball--and at this ball, what do you think he did? He danced
+only four dances, though gentlemen were scarce; and, to my certain
+knowledge, more than one young lady was sitting down in want of a
+partner. Mr. Darcy, you cannot deny the fact.”
+
+“I had not at that time the honour of knowing any lady in the assembly
+beyond my own party.”
+
+“True; and nobody can ever be introduced in a ball-room. Well, Colonel
+Fitzwilliam, what do I play next? My fingers wait your orders.”
+
+“Perhaps,” said Darcy, “I should have judged better, had I sought an
+introduction; but I am ill-qualified to recommend myself to strangers.”
+
+“Shall we ask your cousin the reason of this?” said Elizabeth, still
+addressing Colonel Fitzwilliam. “Shall we ask him why a man of sense and
+education, and who has lived in the world, is ill qualified to recommend
+himself to strangers?”
+
+“I can answer your question,” said Fitzwilliam, “without applying to
+him. It is because he will not give himself the trouble.”
+
+“I certainly have not the talent which some people possess,” said Darcy,
+“of conversing easily with those I have never seen before. I cannot
+catch their tone of conversation, or appear interested in their
+concerns, as I often see done.”
+
+“My fingers,” said Elizabeth, “do not move over this instrument in the
+masterly manner which I see so many women’s do. They have not the same
+force or rapidity, and do not produce the same expression. But then I
+have always supposed it to be my own fault--because I will not take the
+trouble of practising. It is not that I do not believe _my_ fingers as
+capable as any other woman’s of superior execution.”
+
+Darcy smiled and said, “You are perfectly right. You have employed your
+time much better. No one admitted to the privilege of hearing you can
+think anything wanting. We neither of us perform to strangers.”
+
+Here they were interrupted by Lady Catherine, who called out to know
+what they were talking of. Elizabeth immediately began playing again.
+Lady Catherine approached, and, after listening for a few minutes, said
+to Darcy:
+
+“Miss Bennet would not play at all amiss if she practised more, and
+could have the advantage of a London master. She has a very good notion
+of fingering, though her taste is not equal to Anne’s. Anne would have
+been a delightful performer, had her health allowed her to learn.”
+
+Elizabeth looked at Darcy to see how cordially he assented to his
+cousin’s praise; but neither at that moment nor at any other could she
+discern any symptom of love; and from the whole of his behaviour to Miss
+de Bourgh she derived this comfort for Miss Bingley, that he might have
+been just as likely to marry _her_, had she been his relation.
+
+Lady Catherine continued her remarks on Elizabeth’s performance, mixing
+with them many instructions on execution and taste. Elizabeth received
+them with all the forbearance of civility, and, at the request of the
+gentlemen, remained at the instrument till her ladyship’s carriage was
+ready to take them all home.
+
+
+
+Chapter 32
+
+
+Elizabeth was sitting by herself the next morning, and writing to Jane
+while Mrs. Collins and Maria were gone on business into the village,
+when she was startled by a ring at the door, the certain signal of a
+visitor. As she had heard no carriage, she thought it not unlikely to
+be Lady Catherine, and under that apprehension was putting away her
+half-finished letter that she might escape all impertinent questions,
+when the door opened, and, to her very great surprise, Mr. Darcy, and
+Mr. Darcy only, entered the room.
+
+He seemed astonished too on finding her alone, and apologised for his
+intrusion by letting her know that he had understood all the ladies were
+to be within.
+
+They then sat down, and when her inquiries after Rosings were made,
+seemed in danger of sinking into total silence. It was absolutely
+necessary, therefore, to think of something, and in this emergence
+recollecting _when_ she had seen him last in Hertfordshire, and
+feeling curious to know what he would say on the subject of their hasty
+departure, she observed:
+
+“How very suddenly you all quitted Netherfield last November, Mr. Darcy!
+It must have been a most agreeable surprise to Mr. Bingley to see you
+all after him so soon; for, if I recollect right, he went but the day
+before. He and his sisters were well, I hope, when you left London?”
+
+“Perfectly so, I thank you.”
+
+She found that she was to receive no other answer, and, after a short
+pause added:
+
+“I think I have understood that Mr. Bingley has not much idea of ever
+returning to Netherfield again?”
+
+“I have never heard him say so; but it is probable that he may spend
+very little of his time there in the future. He has many friends, and
+is at a time of life when friends and engagements are continually
+increasing.”
+
+“If he means to be but little at Netherfield, it would be better for
+the neighbourhood that he should give up the place entirely, for then we
+might possibly get a settled family there. But, perhaps, Mr. Bingley did
+not take the house so much for the convenience of the neighbourhood as
+for his own, and we must expect him to keep it or quit it on the same
+principle.”
+
+“I should not be surprised,” said Darcy, “if he were to give it up as
+soon as any eligible purchase offers.”
+
+Elizabeth made no answer. She was afraid of talking longer of his
+friend; and, having nothing else to say, was now determined to leave the
+trouble of finding a subject to him.
+
+He took the hint, and soon began with, “This seems a very comfortable
+house. Lady Catherine, I believe, did a great deal to it when Mr.
+Collins first came to Hunsford.”
+
+“I believe she did--and I am sure she could not have bestowed her
+kindness on a more grateful object.”
+
+“Mr. Collins appears to be very fortunate in his choice of a wife.”
+
+“Yes, indeed, his friends may well rejoice in his having met with one
+of the very few sensible women who would have accepted him, or have made
+him happy if they had. My friend has an excellent understanding--though
+I am not certain that I consider her marrying Mr. Collins as the
+wisest thing she ever did. She seems perfectly happy, however, and in a
+prudential light it is certainly a very good match for her.”
+
+“It must be very agreeable for her to be settled within so easy a
+distance of her own family and friends.”
+
+“An easy distance, do you call it? It is nearly fifty miles.”
+
+“And what is fifty miles of good road? Little more than half a day’s
+journey. Yes, I call it a _very_ easy distance.”
+
+“I should never have considered the distance as one of the _advantages_
+of the match,” cried Elizabeth. “I should never have said Mrs. Collins
+was settled _near_ her family.”
+
+“It is a proof of your own attachment to Hertfordshire. Anything beyond
+the very neighbourhood of Longbourn, I suppose, would appear far.”
+
+As he spoke there was a sort of smile which Elizabeth fancied she
+understood; he must be supposing her to be thinking of Jane and
+Netherfield, and she blushed as she answered:
+
+“I do not mean to say that a woman may not be settled too near her
+family. The far and the near must be relative, and depend on many
+varying circumstances. Where there is fortune to make the expenses of
+travelling unimportant, distance becomes no evil. But that is not the
+case _here_. Mr. and Mrs. Collins have a comfortable income, but not
+such a one as will allow of frequent journeys--and I am persuaded my
+friend would not call herself _near_ her family under less than _half_
+the present distance.”
+
+Mr. Darcy drew his chair a little towards her, and said, “_You_ cannot
+have a right to such very strong local attachment. _You_ cannot have
+been always at Longbourn.”
+
+Elizabeth looked surprised. The gentleman experienced some change of
+feeling; he drew back his chair, took a newspaper from the table, and
+glancing over it, said, in a colder voice:
+
+“Are you pleased with Kent?”
+
+A short dialogue on the subject of the country ensued, on either side
+calm and concise--and soon put an end to by the entrance of Charlotte
+and her sister, just returned from her walk. The tete-a-tete surprised
+them. Mr. Darcy related the mistake which had occasioned his intruding
+on Miss Bennet, and after sitting a few minutes longer without saying
+much to anybody, went away.
+
+“What can be the meaning of this?” said Charlotte, as soon as he was
+gone. “My dear, Eliza, he must be in love with you, or he would never
+have called us in this familiar way.”
+
+But when Elizabeth told of his silence, it did not seem very likely,
+even to Charlotte’s wishes, to be the case; and after various
+conjectures, they could at last only suppose his visit to proceed from
+the difficulty of finding anything to do, which was the more probable
+from the time of year. All field sports were over. Within doors there
+was Lady Catherine, books, and a billiard-table, but gentlemen cannot
+always be within doors; and in the nearness of the Parsonage, or the
+pleasantness of the walk to it, or of the people who lived in it, the
+two cousins found a temptation from this period of walking thither
+almost every day. They called at various times of the morning, sometimes
+separately, sometimes together, and now and then accompanied by their
+aunt. It was plain to them all that Colonel Fitzwilliam came because he
+had pleasure in their society, a persuasion which of course recommended
+him still more; and Elizabeth was reminded by her own satisfaction in
+being with him, as well as by his evident admiration of her, of her
+former favourite George Wickham; and though, in comparing them, she saw
+there was less captivating softness in Colonel Fitzwilliam’s manners,
+she believed he might have the best informed mind.
+
+But why Mr. Darcy came so often to the Parsonage, it was more difficult
+to understand. It could not be for society, as he frequently sat there
+ten minutes together without opening his lips; and when he did speak,
+it seemed the effect of necessity rather than of choice--a sacrifice
+to propriety, not a pleasure to himself. He seldom appeared really
+animated. Mrs. Collins knew not what to make of him. Colonel
+Fitzwilliam’s occasionally laughing at his stupidity, proved that he was
+generally different, which her own knowledge of him could not have told
+her; and as she would liked to have believed this change the effect
+of love, and the object of that love her friend Eliza, she set herself
+seriously to work to find it out. She watched him whenever they were at
+Rosings, and whenever he came to Hunsford; but without much success. He
+certainly looked at her friend a great deal, but the expression of that
+look was disputable. It was an earnest, steadfast gaze, but she often
+doubted whether there were much admiration in it, and sometimes it
+seemed nothing but absence of mind.
+
+She had once or twice suggested to Elizabeth the possibility of his
+being partial to her, but Elizabeth always laughed at the idea; and Mrs.
+Collins did not think it right to press the subject, from the danger of
+raising expectations which might only end in disappointment; for in her
+opinion it admitted not of a doubt, that all her friend’s dislike would
+vanish, if she could suppose him to be in her power.
+
+
+In her kind schemes for Elizabeth, she sometimes planned her marrying
+Colonel Fitzwilliam. He was beyond comparison the most pleasant man; he
+certainly admired her, and his situation in life was most eligible; but,
+to counterbalance these advantages, Mr. Darcy had considerable patronage
+in the church, and his cousin could have none at all.
+
+
+
+Chapter 33
+
+
+More than once did Elizabeth, in her ramble within the park,
+unexpectedly meet Mr. Darcy. She felt all the perverseness of the
+mischance that should bring him where no one else was brought, and, to
+prevent its ever happening again, took care to inform him at first that
+it was a favourite haunt of hers. How it could occur a second time,
+therefore, was very odd! Yet it did, and even a third. It seemed like
+wilful ill-nature, or a voluntary penance, for on these occasions it was
+not merely a few formal inquiries and an awkward pause and then away,
+but he actually thought it necessary to turn back and walk with her. He
+never said a great deal, nor did she give herself the trouble of talking
+or of listening much; but it struck her in the course of their third
+rencontre that he was asking some odd unconnected questions--about
+her pleasure in being at Hunsford, her love of solitary walks, and her
+opinion of Mr. and Mrs. Collins’s happiness; and that in speaking of
+Rosings and her not perfectly understanding the house, he seemed to
+expect that whenever she came into Kent again she would be staying
+_there_ too. His words seemed to imply it. Could he have Colonel
+Fitzwilliam in his thoughts? She supposed, if he meant anything, he must
+mean an allusion to what might arise in that quarter. It distressed
+her a little, and she was quite glad to find herself at the gate in the
+pales opposite the Parsonage.
+
+She was engaged one day as she walked, in perusing Jane’s last letter,
+and dwelling on some passages which proved that Jane had not written in
+spirits, when, instead of being again surprised by Mr. Darcy, she saw
+on looking up that Colonel Fitzwilliam was meeting her. Putting away the
+letter immediately and forcing a smile, she said:
+
+“I did not know before that you ever walked this way.”
+
+“I have been making the tour of the park,” he replied, “as I generally
+do every year, and intend to close it with a call at the Parsonage. Are
+you going much farther?”
+
+“No, I should have turned in a moment.”
+
+And accordingly she did turn, and they walked towards the Parsonage
+together.
+
+“Do you certainly leave Kent on Saturday?” said she.
+
+“Yes--if Darcy does not put it off again. But I am at his disposal. He
+arranges the business just as he pleases.”
+
+“And if not able to please himself in the arrangement, he has at least
+pleasure in the great power of choice. I do not know anybody who seems
+more to enjoy the power of doing what he likes than Mr. Darcy.”
+
+“He likes to have his own way very well,” replied Colonel Fitzwilliam.
+“But so we all do. It is only that he has better means of having it
+than many others, because he is rich, and many others are poor. I speak
+feelingly. A younger son, you know, must be inured to self-denial and
+dependence.”
+
+“In my opinion, the younger son of an earl can know very little of
+either. Now seriously, what have you ever known of self-denial and
+dependence? When have you been prevented by want of money from going
+wherever you chose, or procuring anything you had a fancy for?”
+
+“These are home questions--and perhaps I cannot say that I have
+experienced many hardships of that nature. But in matters of greater
+weight, I may suffer from want of money. Younger sons cannot marry where
+they like.”
+
+“Unless where they like women of fortune, which I think they very often
+do.”
+
+“Our habits of expense make us too dependent, and there are not many
+in my rank of life who can afford to marry without some attention to
+money.”
+
+“Is this,” thought Elizabeth, “meant for me?” and she coloured at the
+idea; but, recovering herself, said in a lively tone, “And pray, what
+is the usual price of an earl’s younger son? Unless the elder brother is
+very sickly, I suppose you would not ask above fifty thousand pounds.”
+
+He answered her in the same style, and the subject dropped. To interrupt
+a silence which might make him fancy her affected with what had passed,
+she soon afterwards said:
+
+“I imagine your cousin brought you down with him chiefly for the sake of
+having someone at his disposal. I wonder he does not marry, to secure a
+lasting convenience of that kind. But, perhaps, his sister does as well
+for the present, and, as she is under his sole care, he may do what he
+likes with her.”
+
+“No,” said Colonel Fitzwilliam, “that is an advantage which he must
+divide with me. I am joined with him in the guardianship of Miss Darcy.”
+
+“Are you indeed? And pray what sort of guardians do you make? Does your
+charge give you much trouble? Young ladies of her age are sometimes a
+little difficult to manage, and if she has the true Darcy spirit, she
+may like to have her own way.”
+
+As she spoke she observed him looking at her earnestly; and the manner
+in which he immediately asked her why she supposed Miss Darcy likely to
+give them any uneasiness, convinced her that she had somehow or other
+got pretty near the truth. She directly replied:
+
+“You need not be frightened. I never heard any harm of her; and I dare
+say she is one of the most tractable creatures in the world. She is a
+very great favourite with some ladies of my acquaintance, Mrs. Hurst and
+Miss Bingley. I think I have heard you say that you know them.”
+
+“I know them a little. Their brother is a pleasant gentlemanlike man--he
+is a great friend of Darcy’s.”
+
+“Oh! yes,” said Elizabeth drily; “Mr. Darcy is uncommonly kind to Mr.
+Bingley, and takes a prodigious deal of care of him.”
+
+“Care of him! Yes, I really believe Darcy _does_ take care of him in
+those points where he most wants care. From something that he told me in
+our journey hither, I have reason to think Bingley very much indebted to
+him. But I ought to beg his pardon, for I have no right to suppose that
+Bingley was the person meant. It was all conjecture.”
+
+“What is it you mean?”
+
+“It is a circumstance which Darcy could not wish to be generally known,
+because if it were to get round to the lady’s family, it would be an
+unpleasant thing.”
+
+“You may depend upon my not mentioning it.”
+
+“And remember that I have not much reason for supposing it to be
+Bingley. What he told me was merely this: that he congratulated himself
+on having lately saved a friend from the inconveniences of a most
+imprudent marriage, but without mentioning names or any other
+particulars, and I only suspected it to be Bingley from believing
+him the kind of young man to get into a scrape of that sort, and from
+knowing them to have been together the whole of last summer.”
+
+“Did Mr. Darcy give you reasons for this interference?”
+
+“I understood that there were some very strong objections against the
+lady.”
+
+“And what arts did he use to separate them?”
+
+“He did not talk to me of his own arts,” said Fitzwilliam, smiling. “He
+only told me what I have now told you.”
+
+Elizabeth made no answer, and walked on, her heart swelling with
+indignation. After watching her a little, Fitzwilliam asked her why she
+was so thoughtful.
+
+“I am thinking of what you have been telling me,” said she. “Your
+cousin’s conduct does not suit my feelings. Why was he to be the judge?”
+
+“You are rather disposed to call his interference officious?”
+
+“I do not see what right Mr. Darcy had to decide on the propriety of his
+friend’s inclination, or why, upon his own judgement alone, he was to
+determine and direct in what manner his friend was to be happy.
+But,” she continued, recollecting herself, “as we know none of the
+particulars, it is not fair to condemn him. It is not to be supposed
+that there was much affection in the case.”
+
+“That is not an unnatural surmise,” said Fitzwilliam, “but it is a
+lessening of the honour of my cousin’s triumph very sadly.”
+
+This was spoken jestingly; but it appeared to her so just a picture
+of Mr. Darcy, that she would not trust herself with an answer, and
+therefore, abruptly changing the conversation talked on indifferent
+matters until they reached the Parsonage. There, shut into her own room,
+as soon as their visitor left them, she could think without interruption
+of all that she had heard. It was not to be supposed that any other
+people could be meant than those with whom she was connected. There
+could not exist in the world _two_ men over whom Mr. Darcy could have
+such boundless influence. That he had been concerned in the measures
+taken to separate Bingley and Jane she had never doubted; but she had
+always attributed to Miss Bingley the principal design and arrangement
+of them. If his own vanity, however, did not mislead him, _he_ was
+the cause, his pride and caprice were the cause, of all that Jane had
+suffered, and still continued to suffer. He had ruined for a while
+every hope of happiness for the most affectionate, generous heart in the
+world; and no one could say how lasting an evil he might have inflicted.
+
+“There were some very strong objections against the lady,” were Colonel
+Fitzwilliam’s words; and those strong objections probably were, her
+having one uncle who was a country attorney, and another who was in
+business in London.
+
+“To Jane herself,” she exclaimed, “there could be no possibility of
+objection; all loveliness and goodness as she is!--her understanding
+excellent, her mind improved, and her manners captivating. Neither
+could anything be urged against my father, who, though with some
+peculiarities, has abilities Mr. Darcy himself need not disdain, and
+respectability which he will probably never reach.” When she thought of
+her mother, her confidence gave way a little; but she would not allow
+that any objections _there_ had material weight with Mr. Darcy, whose
+pride, she was convinced, would receive a deeper wound from the want of
+importance in his friend’s connections, than from their want of sense;
+and she was quite decided, at last, that he had been partly governed
+by this worst kind of pride, and partly by the wish of retaining Mr.
+Bingley for his sister.
+
+The agitation and tears which the subject occasioned, brought on a
+headache; and it grew so much worse towards the evening, that, added to
+her unwillingness to see Mr. Darcy, it determined her not to attend her
+cousins to Rosings, where they were engaged to drink tea. Mrs. Collins,
+seeing that she was really unwell, did not press her to go and as much
+as possible prevented her husband from pressing her; but Mr. Collins
+could not conceal his apprehension of Lady Catherine’s being rather
+displeased by her staying at home.
+
+
+
+Chapter 34
+
+
+When they were gone, Elizabeth, as if intending to exasperate herself
+as much as possible against Mr. Darcy, chose for her employment the
+examination of all the letters which Jane had written to her since her
+being in Kent. They contained no actual complaint, nor was there any
+revival of past occurrences, or any communication of present suffering.
+But in all, and in almost every line of each, there was a want of that
+cheerfulness which had been used to characterise her style, and which,
+proceeding from the serenity of a mind at ease with itself and kindly
+disposed towards everyone, had been scarcely ever clouded. Elizabeth
+noticed every sentence conveying the idea of uneasiness, with an
+attention which it had hardly received on the first perusal. Mr. Darcy’s
+shameful boast of what misery he had been able to inflict, gave her
+a keener sense of her sister’s sufferings. It was some consolation
+to think that his visit to Rosings was to end on the day after the
+next--and, a still greater, that in less than a fortnight she should
+herself be with Jane again, and enabled to contribute to the recovery of
+her spirits, by all that affection could do.
+
+She could not think of Darcy’s leaving Kent without remembering that
+his cousin was to go with him; but Colonel Fitzwilliam had made it clear
+that he had no intentions at all, and agreeable as he was, she did not
+mean to be unhappy about him.
+
+While settling this point, she was suddenly roused by the sound of the
+door-bell, and her spirits were a little fluttered by the idea of its
+being Colonel Fitzwilliam himself, who had once before called late in
+the evening, and might now come to inquire particularly after her.
+But this idea was soon banished, and her spirits were very differently
+affected, when, to her utter amazement, she saw Mr. Darcy walk into the
+room. In an hurried manner he immediately began an inquiry after her
+health, imputing his visit to a wish of hearing that she were better.
+She answered him with cold civility. He sat down for a few moments, and
+then getting up, walked about the room. Elizabeth was surprised, but
+said not a word. After a silence of several minutes, he came towards her
+in an agitated manner, and thus began:
+
+“In vain I have struggled. It will not do. My feelings will not be
+repressed. You must allow me to tell you how ardently I admire and love
+you.”
+
+Elizabeth’s astonishment was beyond expression. She stared, coloured,
+doubted, and was silent. This he considered sufficient encouragement;
+and the avowal of all that he felt, and had long felt for her,
+immediately followed. He spoke well; but there were feelings besides
+those of the heart to be detailed; and he was not more eloquent on the
+subject of tenderness than of pride. His sense of her inferiority--of
+its being a degradation--of the family obstacles which had always
+opposed to inclination, were dwelt on with a warmth which seemed due to
+the consequence he was wounding, but was very unlikely to recommend his
+suit.
+
+In spite of her deeply-rooted dislike, she could not be insensible to
+the compliment of such a man’s affection, and though her intentions did
+not vary for an instant, she was at first sorry for the pain he was to
+receive; till, roused to resentment by his subsequent language, she
+lost all compassion in anger. She tried, however, to compose herself to
+answer him with patience, when he should have done. He concluded with
+representing to her the strength of that attachment which, in spite
+of all his endeavours, he had found impossible to conquer; and with
+expressing his hope that it would now be rewarded by her acceptance of
+his hand. As he said this, she could easily see that he had no doubt
+of a favourable answer. He _spoke_ of apprehension and anxiety, but
+his countenance expressed real security. Such a circumstance could
+only exasperate farther, and, when he ceased, the colour rose into her
+cheeks, and she said:
+
+“In such cases as this, it is, I believe, the established mode to
+express a sense of obligation for the sentiments avowed, however
+unequally they may be returned. It is natural that obligation should
+be felt, and if I could _feel_ gratitude, I would now thank you. But I
+cannot--I have never desired your good opinion, and you have certainly
+bestowed it most unwillingly. I am sorry to have occasioned pain to
+anyone. It has been most unconsciously done, however, and I hope will be
+of short duration. The feelings which, you tell me, have long prevented
+the acknowledgment of your regard, can have little difficulty in
+overcoming it after this explanation.”
+
+Mr. Darcy, who was leaning against the mantelpiece with his eyes fixed
+on her face, seemed to catch her words with no less resentment than
+surprise. His complexion became pale with anger, and the disturbance
+of his mind was visible in every feature. He was struggling for the
+appearance of composure, and would not open his lips till he believed
+himself to have attained it. The pause was to Elizabeth’s feelings
+dreadful. At length, with a voice of forced calmness, he said:
+
+“And this is all the reply which I am to have the honour of expecting!
+I might, perhaps, wish to be informed why, with so little _endeavour_ at
+civility, I am thus rejected. But it is of small importance.”
+
+“I might as well inquire,” replied she, “why with so evident a desire
+of offending and insulting me, you chose to tell me that you liked me
+against your will, against your reason, and even against your character?
+Was not this some excuse for incivility, if I _was_ uncivil? But I have
+other provocations. You know I have. Had not my feelings decided against
+you--had they been indifferent, or had they even been favourable, do you
+think that any consideration would tempt me to accept the man who has
+been the means of ruining, perhaps for ever, the happiness of a most
+beloved sister?”
+
+As she pronounced these words, Mr. Darcy changed colour; but the emotion
+was short, and he listened without attempting to interrupt her while she
+continued:
+
+“I have every reason in the world to think ill of you. No motive can
+excuse the unjust and ungenerous part you acted _there_. You dare not,
+you cannot deny, that you have been the principal, if not the only means
+of dividing them from each other--of exposing one to the censure of the
+world for caprice and instability, and the other to its derision for
+disappointed hopes, and involving them both in misery of the acutest
+kind.”
+
+She paused, and saw with no slight indignation that he was listening
+with an air which proved him wholly unmoved by any feeling of remorse.
+He even looked at her with a smile of affected incredulity.
+
+“Can you deny that you have done it?” she repeated.
+
+With assumed tranquillity he then replied: “I have no wish of denying
+that I did everything in my power to separate my friend from your
+sister, or that I rejoice in my success. Towards _him_ I have been
+kinder than towards myself.”
+
+Elizabeth disdained the appearance of noticing this civil reflection,
+but its meaning did not escape, nor was it likely to conciliate her.
+
+“But it is not merely this affair,” she continued, “on which my dislike
+is founded. Long before it had taken place my opinion of you was
+decided. Your character was unfolded in the recital which I received
+many months ago from Mr. Wickham. On this subject, what can you have to
+say? In what imaginary act of friendship can you here defend yourself?
+or under what misrepresentation can you here impose upon others?”
+
+“You take an eager interest in that gentleman’s concerns,” said Darcy,
+in a less tranquil tone, and with a heightened colour.
+
+“Who that knows what his misfortunes have been, can help feeling an
+interest in him?”
+
+“His misfortunes!” repeated Darcy contemptuously; “yes, his misfortunes
+have been great indeed.”
+
+“And of your infliction,” cried Elizabeth with energy. “You have reduced
+him to his present state of poverty--comparative poverty. You have
+withheld the advantages which you must know to have been designed for
+him. You have deprived the best years of his life of that independence
+which was no less his due than his desert. You have done all this!
+and yet you can treat the mention of his misfortune with contempt and
+ridicule.”
+
+“And this,” cried Darcy, as he walked with quick steps across the room,
+“is your opinion of me! This is the estimation in which you hold me!
+I thank you for explaining it so fully. My faults, according to this
+calculation, are heavy indeed! But perhaps,” added he, stopping in
+his walk, and turning towards her, “these offenses might have been
+overlooked, had not your pride been hurt by my honest confession of the
+scruples that had long prevented my forming any serious design. These
+bitter accusations might have been suppressed, had I, with greater
+policy, concealed my struggles, and flattered you into the belief of
+my being impelled by unqualified, unalloyed inclination; by reason, by
+reflection, by everything. But disguise of every sort is my abhorrence.
+Nor am I ashamed of the feelings I related. They were natural and
+just. Could you expect me to rejoice in the inferiority of your
+connections?--to congratulate myself on the hope of relations, whose
+condition in life is so decidedly beneath my own?”
+
+Elizabeth felt herself growing more angry every moment; yet she tried to
+the utmost to speak with composure when she said:
+
+“You are mistaken, Mr. Darcy, if you suppose that the mode of your
+declaration affected me in any other way, than as it spared me the concern
+which I might have felt in refusing you, had you behaved in a more
+gentlemanlike manner.”
+
+She saw him start at this, but he said nothing, and she continued:
+
+“You could not have made the offer of your hand in any possible way that
+would have tempted me to accept it.”
+
+Again his astonishment was obvious; and he looked at her with an
+expression of mingled incredulity and mortification. She went on:
+
+“From the very beginning--from the first moment, I may almost say--of
+my acquaintance with you, your manners, impressing me with the fullest
+belief of your arrogance, your conceit, and your selfish disdain of
+the feelings of others, were such as to form the groundwork of
+disapprobation on which succeeding events have built so immovable a
+dislike; and I had not known you a month before I felt that you were the
+last man in the world whom I could ever be prevailed on to marry.”
+
+“You have said quite enough, madam. I perfectly comprehend your
+feelings, and have now only to be ashamed of what my own have been.
+Forgive me for having taken up so much of your time, and accept my best
+wishes for your health and happiness.”
+
+And with these words he hastily left the room, and Elizabeth heard him
+the next moment open the front door and quit the house.
+
+The tumult of her mind, was now painfully great. She knew not how
+to support herself, and from actual weakness sat down and cried for
+half-an-hour. Her astonishment, as she reflected on what had passed,
+was increased by every review of it. That she should receive an offer of
+marriage from Mr. Darcy! That he should have been in love with her for
+so many months! So much in love as to wish to marry her in spite of
+all the objections which had made him prevent his friend’s marrying
+her sister, and which must appear at least with equal force in his
+own case--was almost incredible! It was gratifying to have inspired
+unconsciously so strong an affection. But his pride, his abominable
+pride--his shameless avowal of what he had done with respect to
+Jane--his unpardonable assurance in acknowledging, though he could
+not justify it, and the unfeeling manner in which he had mentioned Mr.
+Wickham, his cruelty towards whom he had not attempted to deny, soon
+overcame the pity which the consideration of his attachment had for
+a moment excited. She continued in very agitated reflections till the
+sound of Lady Catherine’s carriage made her feel how unequal she was to
+encounter Charlotte’s observation, and hurried her away to her room.
+
+
+
+Chapter 35
+
+
+Elizabeth awoke the next morning to the same thoughts and meditations
+which had at length closed her eyes. She could not yet recover from the
+surprise of what had happened; it was impossible to think of anything
+else; and, totally indisposed for employment, she resolved, soon after
+breakfast, to indulge herself in air and exercise. She was proceeding
+directly to her favourite walk, when the recollection of Mr. Darcy’s
+sometimes coming there stopped her, and instead of entering the park,
+she turned up the lane, which led farther from the turnpike-road. The
+park paling was still the boundary on one side, and she soon passed one
+of the gates into the ground.
+
+After walking two or three times along that part of the lane, she was
+tempted, by the pleasantness of the morning, to stop at the gates and
+look into the park. The five weeks which she had now passed in Kent had
+made a great difference in the country, and every day was adding to the
+verdure of the early trees. She was on the point of continuing her walk,
+when she caught a glimpse of a gentleman within the sort of grove which
+edged the park; he was moving that way; and, fearful of its being Mr.
+Darcy, she was directly retreating. But the person who advanced was now
+near enough to see her, and stepping forward with eagerness, pronounced
+her name. She had turned away; but on hearing herself called, though
+in a voice which proved it to be Mr. Darcy, she moved again towards the
+gate. He had by that time reached it also, and, holding out a letter,
+which she instinctively took, said, with a look of haughty composure,
+“I have been walking in the grove some time in the hope of meeting you.
+Will you do me the honour of reading that letter?” And then, with a
+slight bow, turned again into the plantation, and was soon out of sight.
+
+With no expectation of pleasure, but with the strongest curiosity,
+Elizabeth opened the letter, and, to her still increasing wonder,
+perceived an envelope containing two sheets of letter-paper, written
+quite through, in a very close hand. The envelope itself was likewise
+full. Pursuing her way along the lane, she then began it. It was dated
+from Rosings, at eight o’clock in the morning, and was as follows:--
+
+“Be not alarmed, madam, on receiving this letter, by the apprehension
+of its containing any repetition of those sentiments or renewal of those
+offers which were last night so disgusting to you. I write without any
+intention of paining you, or humbling myself, by dwelling on wishes
+which, for the happiness of both, cannot be too soon forgotten; and the
+effort which the formation and the perusal of this letter must occasion,
+should have been spared, had not my character required it to be written
+and read. You must, therefore, pardon the freedom with which I demand
+your attention; your feelings, I know, will bestow it unwillingly, but I
+demand it of your justice.
+
+“Two offenses of a very different nature, and by no means of equal
+magnitude, you last night laid to my charge. The first mentioned was,
+that, regardless of the sentiments of either, I had detached Mr. Bingley
+from your sister, and the other, that I had, in defiance of various
+claims, in defiance of honour and humanity, ruined the immediate
+prosperity and blasted the prospects of Mr. Wickham. Wilfully and
+wantonly to have thrown off the companion of my youth, the acknowledged
+favourite of my father, a young man who had scarcely any other
+dependence than on our patronage, and who had been brought up to expect
+its exertion, would be a depravity, to which the separation of two young
+persons, whose affection could be the growth of only a few weeks, could
+bear no comparison. But from the severity of that blame which was last
+night so liberally bestowed, respecting each circumstance, I shall hope
+to be in the future secured, when the following account of my actions
+and their motives has been read. If, in the explanation of them, which
+is due to myself, I am under the necessity of relating feelings which
+may be offensive to yours, I can only say that I am sorry. The necessity
+must be obeyed, and further apology would be absurd.
+
+“I had not been long in Hertfordshire, before I saw, in common with
+others, that Bingley preferred your elder sister to any other young
+woman in the country. But it was not till the evening of the dance
+at Netherfield that I had any apprehension of his feeling a serious
+attachment. I had often seen him in love before. At that ball, while I
+had the honour of dancing with you, I was first made acquainted, by Sir
+William Lucas’s accidental information, that Bingley’s attentions to
+your sister had given rise to a general expectation of their marriage.
+He spoke of it as a certain event, of which the time alone could
+be undecided. From that moment I observed my friend’s behaviour
+attentively; and I could then perceive that his partiality for Miss
+Bennet was beyond what I had ever witnessed in him. Your sister I also
+watched. Her look and manners were open, cheerful, and engaging as ever,
+but without any symptom of peculiar regard, and I remained convinced
+from the evening’s scrutiny, that though she received his attentions
+with pleasure, she did not invite them by any participation of
+sentiment. If _you_ have not been mistaken here, _I_ must have been
+in error. Your superior knowledge of your sister must make the latter
+probable. If it be so, if I have been misled by such error to inflict
+pain on her, your resentment has not been unreasonable. But I shall not
+scruple to assert, that the serenity of your sister’s countenance and
+air was such as might have given the most acute observer a conviction
+that, however amiable her temper, her heart was not likely to be
+easily touched. That I was desirous of believing her indifferent is
+certain--but I will venture to say that my investigation and decisions
+are not usually influenced by my hopes or fears. I did not believe
+her to be indifferent because I wished it; I believed it on impartial
+conviction, as truly as I wished it in reason. My objections to the
+marriage were not merely those which I last night acknowledged to have
+the utmost force of passion to put aside, in my own case; the want of
+connection could not be so great an evil to my friend as to me. But
+there were other causes of repugnance; causes which, though still
+existing, and existing to an equal degree in both instances, I had
+myself endeavoured to forget, because they were not immediately before
+me. These causes must be stated, though briefly. The situation of your
+mother’s family, though objectionable, was nothing in comparison to that
+total want of propriety so frequently, so almost uniformly betrayed by
+herself, by your three younger sisters, and occasionally even by your
+father. Pardon me. It pains me to offend you. But amidst your concern
+for the defects of your nearest relations, and your displeasure at this
+representation of them, let it give you consolation to consider that, to
+have conducted yourselves so as to avoid any share of the like censure,
+is praise no less generally bestowed on you and your elder sister, than
+it is honourable to the sense and disposition of both. I will only say
+farther that from what passed that evening, my opinion of all parties
+was confirmed, and every inducement heightened which could have led
+me before, to preserve my friend from what I esteemed a most unhappy
+connection. He left Netherfield for London, on the day following, as
+you, I am certain, remember, with the design of soon returning.
+
+“The part which I acted is now to be explained. His sisters’ uneasiness
+had been equally excited with my own; our coincidence of feeling was
+soon discovered, and, alike sensible that no time was to be lost in
+detaching their brother, we shortly resolved on joining him directly in
+London. We accordingly went--and there I readily engaged in the office
+of pointing out to my friend the certain evils of such a choice. I
+described, and enforced them earnestly. But, however this remonstrance
+might have staggered or delayed his determination, I do not suppose
+that it would ultimately have prevented the marriage, had it not been
+seconded by the assurance that I hesitated not in giving, of your
+sister’s indifference. He had before believed her to return his
+affection with sincere, if not with equal regard. But Bingley has great
+natural modesty, with a stronger dependence on my judgement than on his
+own. To convince him, therefore, that he had deceived himself, was
+no very difficult point. To persuade him against returning into
+Hertfordshire, when that conviction had been given, was scarcely the
+work of a moment. I cannot blame myself for having done thus much. There
+is but one part of my conduct in the whole affair on which I do not
+reflect with satisfaction; it is that I condescended to adopt the
+measures of art so far as to conceal from him your sister’s being in
+town. I knew it myself, as it was known to Miss Bingley; but her
+brother is even yet ignorant of it. That they might have met without
+ill consequence is perhaps probable; but his regard did not appear to me
+enough extinguished for him to see her without some danger. Perhaps this
+concealment, this disguise was beneath me; it is done, however, and it
+was done for the best. On this subject I have nothing more to say, no
+other apology to offer. If I have wounded your sister’s feelings, it
+was unknowingly done and though the motives which governed me may to
+you very naturally appear insufficient, I have not yet learnt to condemn
+them.
+
+“With respect to that other, more weighty accusation, of having injured
+Mr. Wickham, I can only refute it by laying before you the whole of his
+connection with my family. Of what he has _particularly_ accused me I
+am ignorant; but of the truth of what I shall relate, I can summon more
+than one witness of undoubted veracity.
+
+“Mr. Wickham is the son of a very respectable man, who had for many
+years the management of all the Pemberley estates, and whose good
+conduct in the discharge of his trust naturally inclined my father to
+be of service to him; and on George Wickham, who was his godson, his
+kindness was therefore liberally bestowed. My father supported him at
+school, and afterwards at Cambridge--most important assistance, as his
+own father, always poor from the extravagance of his wife, would have
+been unable to give him a gentleman’s education. My father was not only
+fond of this young man’s society, whose manners were always engaging; he
+had also the highest opinion of him, and hoping the church would be
+his profession, intended to provide for him in it. As for myself, it is
+many, many years since I first began to think of him in a very different
+manner. The vicious propensities--the want of principle, which he was
+careful to guard from the knowledge of his best friend, could not escape
+the observation of a young man of nearly the same age with himself,
+and who had opportunities of seeing him in unguarded moments, which Mr.
+Darcy could not have. Here again I shall give you pain--to what degree
+you only can tell. But whatever may be the sentiments which Mr. Wickham
+has created, a suspicion of their nature shall not prevent me from
+unfolding his real character--it adds even another motive.
+
+“My excellent father died about five years ago; and his attachment to
+Mr. Wickham was to the last so steady, that in his will he particularly
+recommended it to me, to promote his advancement in the best manner
+that his profession might allow--and if he took orders, desired that a
+valuable family living might be his as soon as it became vacant. There
+was also a legacy of one thousand pounds. His own father did not long
+survive mine, and within half a year from these events, Mr. Wickham
+wrote to inform me that, having finally resolved against taking orders,
+he hoped I should not think it unreasonable for him to expect some more
+immediate pecuniary advantage, in lieu of the preferment, by which he
+could not be benefited. He had some intention, he added, of studying
+law, and I must be aware that the interest of one thousand pounds would
+be a very insufficient support therein. I rather wished, than believed
+him to be sincere; but, at any rate, was perfectly ready to accede to
+his proposal. I knew that Mr. Wickham ought not to be a clergyman; the
+business was therefore soon settled--he resigned all claim to assistance
+in the church, were it possible that he could ever be in a situation to
+receive it, and accepted in return three thousand pounds. All connection
+between us seemed now dissolved. I thought too ill of him to invite him
+to Pemberley, or admit his society in town. In town I believe he chiefly
+lived, but his studying the law was a mere pretence, and being now free
+from all restraint, his life was a life of idleness and dissipation.
+For about three years I heard little of him; but on the decease of the
+incumbent of the living which had been designed for him, he applied to
+me again by letter for the presentation. His circumstances, he assured
+me, and I had no difficulty in believing it, were exceedingly bad. He
+had found the law a most unprofitable study, and was now absolutely
+resolved on being ordained, if I would present him to the living in
+question--of which he trusted there could be little doubt, as he was
+well assured that I had no other person to provide for, and I could not
+have forgotten my revered father’s intentions. You will hardly blame
+me for refusing to comply with this entreaty, or for resisting every
+repetition to it. His resentment was in proportion to the distress of
+his circumstances--and he was doubtless as violent in his abuse of me
+to others as in his reproaches to myself. After this period every
+appearance of acquaintance was dropped. How he lived I know not. But
+last summer he was again most painfully obtruded on my notice.
+
+“I must now mention a circumstance which I would wish to forget myself,
+and which no obligation less than the present should induce me to unfold
+to any human being. Having said thus much, I feel no doubt of your
+secrecy. My sister, who is more than ten years my junior, was left to
+the guardianship of my mother’s nephew, Colonel Fitzwilliam, and myself.
+About a year ago, she was taken from school, and an establishment formed
+for her in London; and last summer she went with the lady who presided
+over it, to Ramsgate; and thither also went Mr. Wickham, undoubtedly by
+design; for there proved to have been a prior acquaintance between him
+and Mrs. Younge, in whose character we were most unhappily deceived; and
+by her connivance and aid, he so far recommended himself to Georgiana,
+whose affectionate heart retained a strong impression of his kindness to
+her as a child, that she was persuaded to believe herself in love, and
+to consent to an elopement. She was then but fifteen, which must be her
+excuse; and after stating her imprudence, I am happy to add, that I owed
+the knowledge of it to herself. I joined them unexpectedly a day or two
+before the intended elopement, and then Georgiana, unable to support the
+idea of grieving and offending a brother whom she almost looked up to as
+a father, acknowledged the whole to me. You may imagine what I felt and
+how I acted. Regard for my sister’s credit and feelings prevented
+any public exposure; but I wrote to Mr. Wickham, who left the place
+immediately, and Mrs. Younge was of course removed from her charge. Mr.
+Wickham’s chief object was unquestionably my sister’s fortune, which
+is thirty thousand pounds; but I cannot help supposing that the hope of
+revenging himself on me was a strong inducement. His revenge would have
+been complete indeed.
+
+“This, madam, is a faithful narrative of every event in which we have
+been concerned together; and if you do not absolutely reject it as
+false, you will, I hope, acquit me henceforth of cruelty towards Mr.
+Wickham. I know not in what manner, under what form of falsehood he
+had imposed on you; but his success is not perhaps to be wondered
+at. Ignorant as you previously were of everything concerning either,
+detection could not be in your power, and suspicion certainly not in
+your inclination.
+
+“You may possibly wonder why all this was not told you last night; but
+I was not then master enough of myself to know what could or ought to
+be revealed. For the truth of everything here related, I can appeal more
+particularly to the testimony of Colonel Fitzwilliam, who, from our
+near relationship and constant intimacy, and, still more, as one of
+the executors of my father’s will, has been unavoidably acquainted
+with every particular of these transactions. If your abhorrence of _me_
+should make _my_ assertions valueless, you cannot be prevented by
+the same cause from confiding in my cousin; and that there may be
+the possibility of consulting him, I shall endeavour to find some
+opportunity of putting this letter in your hands in the course of the
+morning. I will only add, God bless you.
+
+“FITZWILLIAM DARCY”
+
+
+
+Chapter 36
+
+
+If Elizabeth, when Mr. Darcy gave her the letter, did not expect it to
+contain a renewal of his offers, she had formed no expectation at all of
+its contents. But such as they were, it may well be supposed how eagerly
+she went through them, and what a contrariety of emotion they excited.
+Her feelings as she read were scarcely to be defined. With amazement did
+she first understand that he believed any apology to be in his power;
+and steadfastly was she persuaded, that he could have no explanation
+to give, which a just sense of shame would not conceal. With a strong
+prejudice against everything he might say, she began his account of what
+had happened at Netherfield. She read with an eagerness which hardly
+left her power of comprehension, and from impatience of knowing what the
+next sentence might bring, was incapable of attending to the sense of
+the one before her eyes. His belief of her sister’s insensibility she
+instantly resolved to be false; and his account of the real, the worst
+objections to the match, made her too angry to have any wish of doing
+him justice. He expressed no regret for what he had done which satisfied
+her; his style was not penitent, but haughty. It was all pride and
+insolence.
+
+But when this subject was succeeded by his account of Mr. Wickham--when
+she read with somewhat clearer attention a relation of events which,
+if true, must overthrow every cherished opinion of his worth, and which
+bore so alarming an affinity to his own history of himself--her
+feelings were yet more acutely painful and more difficult of definition.
+Astonishment, apprehension, and even horror, oppressed her. She wished
+to discredit it entirely, repeatedly exclaiming, “This must be false!
+This cannot be! This must be the grossest falsehood!”--and when she had
+gone through the whole letter, though scarcely knowing anything of the
+last page or two, put it hastily away, protesting that she would not
+regard it, that she would never look in it again.
+
+In this perturbed state of mind, with thoughts that could rest on
+nothing, she walked on; but it would not do; in half a minute the letter
+was unfolded again, and collecting herself as well as she could, she
+again began the mortifying perusal of all that related to Wickham, and
+commanded herself so far as to examine the meaning of every sentence.
+The account of his connection with the Pemberley family was exactly what
+he had related himself; and the kindness of the late Mr. Darcy, though
+she had not before known its extent, agreed equally well with his own
+words. So far each recital confirmed the other; but when she came to the
+will, the difference was great. What Wickham had said of the living
+was fresh in her memory, and as she recalled his very words, it was
+impossible not to feel that there was gross duplicity on one side or the
+other; and, for a few moments, she flattered herself that her wishes did
+not err. But when she read and re-read with the closest attention, the
+particulars immediately following of Wickham’s resigning all pretensions
+to the living, of his receiving in lieu so considerable a sum as three
+thousand pounds, again was she forced to hesitate. She put down
+the letter, weighed every circumstance with what she meant to be
+impartiality--deliberated on the probability of each statement--but with
+little success. On both sides it was only assertion. Again she read
+on; but every line proved more clearly that the affair, which she had
+believed it impossible that any contrivance could so represent as to
+render Mr. Darcy’s conduct in it less than infamous, was capable of a
+turn which must make him entirely blameless throughout the whole.
+
+The extravagance and general profligacy which he scrupled not to lay at
+Mr. Wickham’s charge, exceedingly shocked her; the more so, as she could
+bring no proof of its injustice. She had never heard of him before his
+entrance into the ----shire Militia, in which he had engaged at the
+persuasion of the young man who, on meeting him accidentally in town,
+had there renewed a slight acquaintance. Of his former way of life
+nothing had been known in Hertfordshire but what he told himself. As
+to his real character, had information been in her power, she had
+never felt a wish of inquiring. His countenance, voice, and manner had
+established him at once in the possession of every virtue. She tried
+to recollect some instance of goodness, some distinguished trait of
+integrity or benevolence, that might rescue him from the attacks of
+Mr. Darcy; or at least, by the predominance of virtue, atone for those
+casual errors under which she would endeavour to class what Mr. Darcy
+had described as the idleness and vice of many years’ continuance. But
+no such recollection befriended her. She could see him instantly before
+her, in every charm of air and address; but she could remember no more
+substantial good than the general approbation of the neighbourhood, and
+the regard which his social powers had gained him in the mess. After
+pausing on this point a considerable while, she once more continued to
+read. But, alas! the story which followed, of his designs on Miss
+Darcy, received some confirmation from what had passed between Colonel
+Fitzwilliam and herself only the morning before; and at last she was
+referred for the truth of every particular to Colonel Fitzwilliam
+himself--from whom she had previously received the information of his
+near concern in all his cousin’s affairs, and whose character she had no
+reason to question. At one time she had almost resolved on applying to
+him, but the idea was checked by the awkwardness of the application, and
+at length wholly banished by the conviction that Mr. Darcy would never
+have hazarded such a proposal, if he had not been well assured of his
+cousin’s corroboration.
+
+She perfectly remembered everything that had passed in conversation
+between Wickham and herself, in their first evening at Mr. Phillips’s.
+Many of his expressions were still fresh in her memory. She was _now_
+struck with the impropriety of such communications to a stranger, and
+wondered it had escaped her before. She saw the indelicacy of putting
+himself forward as he had done, and the inconsistency of his professions
+with his conduct. She remembered that he had boasted of having no fear
+of seeing Mr. Darcy--that Mr. Darcy might leave the country, but that
+_he_ should stand his ground; yet he had avoided the Netherfield ball
+the very next week. She remembered also that, till the Netherfield
+family had quitted the country, he had told his story to no one but
+herself; but that after their removal it had been everywhere discussed;
+that he had then no reserves, no scruples in sinking Mr. Darcy’s
+character, though he had assured her that respect for the father would
+always prevent his exposing the son.
+
+How differently did everything now appear in which he was concerned!
+His attentions to Miss King were now the consequence of views solely and
+hatefully mercenary; and the mediocrity of her fortune proved no longer
+the moderation of his wishes, but his eagerness to grasp at anything.
+His behaviour to herself could now have had no tolerable motive; he had
+either been deceived with regard to her fortune, or had been gratifying
+his vanity by encouraging the preference which she believed she had most
+incautiously shown. Every lingering struggle in his favour grew fainter
+and fainter; and in farther justification of Mr. Darcy, she could not
+but allow that Mr. Bingley, when questioned by Jane, had long ago
+asserted his blamelessness in the affair; that proud and repulsive as
+were his manners, she had never, in the whole course of their
+acquaintance--an acquaintance which had latterly brought them much
+together, and given her a sort of intimacy with his ways--seen anything
+that betrayed him to be unprincipled or unjust--anything that spoke him
+of irreligious or immoral habits; that among his own connections he was
+esteemed and valued--that even Wickham had allowed him merit as a
+brother, and that she had often heard him speak so affectionately of his
+sister as to prove him capable of _some_ amiable feeling; that had his
+actions been what Mr. Wickham represented them, so gross a violation of
+everything right could hardly have been concealed from the world; and
+that friendship between a person capable of it, and such an amiable man
+as Mr. Bingley, was incomprehensible.
+
+She grew absolutely ashamed of herself. Of neither Darcy nor Wickham
+could she think without feeling she had been blind, partial, prejudiced,
+absurd.
+
+“How despicably I have acted!” she cried; “I, who have prided myself
+on my discernment! I, who have valued myself on my abilities! who have
+often disdained the generous candour of my sister, and gratified
+my vanity in useless or blameable mistrust! How humiliating is this
+discovery! Yet, how just a humiliation! Had I been in love, I could
+not have been more wretchedly blind! But vanity, not love, has been my
+folly. Pleased with the preference of one, and offended by the neglect
+of the other, on the very beginning of our acquaintance, I have courted
+prepossession and ignorance, and driven reason away, where either were
+concerned. Till this moment I never knew myself.”
+
+From herself to Jane--from Jane to Bingley, her thoughts were in a line
+which soon brought to her recollection that Mr. Darcy’s explanation
+_there_ had appeared very insufficient, and she read it again. Widely
+different was the effect of a second perusal. How could she deny that
+credit to his assertions in one instance, which she had been obliged to
+give in the other? He declared himself to be totally unsuspicious of her
+sister’s attachment; and she could not help remembering what Charlotte’s
+opinion had always been. Neither could she deny the justice of his
+description of Jane. She felt that Jane’s feelings, though fervent, were
+little displayed, and that there was a constant complacency in her air
+and manner not often united with great sensibility.
+
+When she came to that part of the letter in which her family were
+mentioned in terms of such mortifying, yet merited reproach, her sense
+of shame was severe. The justice of the charge struck her too forcibly
+for denial, and the circumstances to which he particularly alluded as
+having passed at the Netherfield ball, and as confirming all his first
+disapprobation, could not have made a stronger impression on his mind
+than on hers.
+
+The compliment to herself and her sister was not unfelt. It soothed,
+but it could not console her for the contempt which had thus been
+self-attracted by the rest of her family; and as she considered
+that Jane’s disappointment had in fact been the work of her nearest
+relations, and reflected how materially the credit of both must be hurt
+by such impropriety of conduct, she felt depressed beyond anything she
+had ever known before.
+
+After wandering along the lane for two hours, giving way to every
+variety of thought--re-considering events, determining probabilities,
+and reconciling herself, as well as she could, to a change so sudden and
+so important, fatigue, and a recollection of her long absence, made
+her at length return home; and she entered the house with the wish
+of appearing cheerful as usual, and the resolution of repressing such
+reflections as must make her unfit for conversation.
+
+She was immediately told that the two gentlemen from Rosings had each
+called during her absence; Mr. Darcy, only for a few minutes, to take
+leave--but that Colonel Fitzwilliam had been sitting with them at least
+an hour, hoping for her return, and almost resolving to walk after her
+till she could be found. Elizabeth could but just _affect_ concern
+in missing him; she really rejoiced at it. Colonel Fitzwilliam was no
+longer an object; she could think only of her letter.
+
+
+
+Chapter 37
+
+
+The two gentlemen left Rosings the next morning, and Mr. Collins having
+been in waiting near the lodges, to make them his parting obeisance, was
+able to bring home the pleasing intelligence, of their appearing in very
+good health, and in as tolerable spirits as could be expected, after the
+melancholy scene so lately gone through at Rosings. To Rosings he then
+hastened, to console Lady Catherine and her daughter; and on his return
+brought back, with great satisfaction, a message from her ladyship,
+importing that she felt herself so dull as to make her very desirous of
+having them all to dine with her.
+
+Elizabeth could not see Lady Catherine without recollecting that, had
+she chosen it, she might by this time have been presented to her as
+her future niece; nor could she think, without a smile, of what her
+ladyship’s indignation would have been. “What would she have said? how
+would she have behaved?” were questions with which she amused herself.
+
+Their first subject was the diminution of the Rosings party. “I assure
+you, I feel it exceedingly,” said Lady Catherine; “I believe no one
+feels the loss of friends so much as I do. But I am particularly
+attached to these young men, and know them to be so much attached to
+me! They were excessively sorry to go! But so they always are. The
+dear Colonel rallied his spirits tolerably till just at last; but Darcy
+seemed to feel it most acutely, more, I think, than last year. His
+attachment to Rosings certainly increases.”
+
+Mr. Collins had a compliment, and an allusion to throw in here, which
+were kindly smiled on by the mother and daughter.
+
+Lady Catherine observed, after dinner, that Miss Bennet seemed out of
+spirits, and immediately accounting for it by herself, by supposing that
+she did not like to go home again so soon, she added:
+
+“But if that is the case, you must write to your mother and beg that
+you may stay a little longer. Mrs. Collins will be very glad of your
+company, I am sure.”
+
+“I am much obliged to your ladyship for your kind invitation,” replied
+Elizabeth, “but it is not in my power to accept it. I must be in town
+next Saturday.”
+
+“Why, at that rate, you will have been here only six weeks. I expected
+you to stay two months. I told Mrs. Collins so before you came. There
+can be no occasion for your going so soon. Mrs. Bennet could certainly
+spare you for another fortnight.”
+
+“But my father cannot. He wrote last week to hurry my return.”
+
+“Oh! your father of course may spare you, if your mother can. Daughters
+are never of so much consequence to a father. And if you will stay
+another _month_ complete, it will be in my power to take one of you as
+far as London, for I am going there early in June, for a week; and as
+Dawson does not object to the barouche-box, there will be very good room
+for one of you--and indeed, if the weather should happen to be cool, I
+should not object to taking you both, as you are neither of you large.”
+
+“You are all kindness, madam; but I believe we must abide by our
+original plan.”
+
+Lady Catherine seemed resigned. “Mrs. Collins, you must send a servant
+with them. You know I always speak my mind, and I cannot bear the idea
+of two young women travelling post by themselves. It is highly improper.
+You must contrive to send somebody. I have the greatest dislike in
+the world to that sort of thing. Young women should always be properly
+guarded and attended, according to their situation in life. When my
+niece Georgiana went to Ramsgate last summer, I made a point of her
+having two men-servants go with her. Miss Darcy, the daughter of
+Mr. Darcy, of Pemberley, and Lady Anne, could not have appeared with
+propriety in a different manner. I am excessively attentive to all those
+things. You must send John with the young ladies, Mrs. Collins. I
+am glad it occurred to me to mention it; for it would really be
+discreditable to _you_ to let them go alone.”
+
+“My uncle is to send a servant for us.”
+
+“Oh! Your uncle! He keeps a man-servant, does he? I am very glad you
+have somebody who thinks of these things. Where shall you change horses?
+Oh! Bromley, of course. If you mention my name at the Bell, you will be
+attended to.”
+
+Lady Catherine had many other questions to ask respecting their journey,
+and as she did not answer them all herself, attention was necessary,
+which Elizabeth believed to be lucky for her; or, with a mind so
+occupied, she might have forgotten where she was. Reflection must be
+reserved for solitary hours; whenever she was alone, she gave way to it
+as the greatest relief; and not a day went by without a solitary
+walk, in which she might indulge in all the delight of unpleasant
+recollections.
+
+Mr. Darcy’s letter she was in a fair way of soon knowing by heart. She
+studied every sentence; and her feelings towards its writer were at
+times widely different. When she remembered the style of his address,
+she was still full of indignation; but when she considered how unjustly
+she had condemned and upbraided him, her anger was turned against
+herself; and his disappointed feelings became the object of compassion.
+His attachment excited gratitude, his general character respect; but she
+could not approve him; nor could she for a moment repent her refusal,
+or feel the slightest inclination ever to see him again. In her own past
+behaviour, there was a constant source of vexation and regret; and in
+the unhappy defects of her family, a subject of yet heavier chagrin.
+They were hopeless of remedy. Her father, contented with laughing at
+them, would never exert himself to restrain the wild giddiness of his
+youngest daughters; and her mother, with manners so far from right
+herself, was entirely insensible of the evil. Elizabeth had frequently
+united with Jane in an endeavour to check the imprudence of Catherine
+and Lydia; but while they were supported by their mother’s indulgence,
+what chance could there be of improvement? Catherine, weak-spirited,
+irritable, and completely under Lydia’s guidance, had been always
+affronted by their advice; and Lydia, self-willed and careless, would
+scarcely give them a hearing. They were ignorant, idle, and vain. While
+there was an officer in Meryton, they would flirt with him; and while
+Meryton was within a walk of Longbourn, they would be going there
+forever.
+
+Anxiety on Jane’s behalf was another prevailing concern; and Mr. Darcy’s
+explanation, by restoring Bingley to all her former good opinion,
+heightened the sense of what Jane had lost. His affection was proved
+to have been sincere, and his conduct cleared of all blame, unless any
+could attach to the implicitness of his confidence in his friend. How
+grievous then was the thought that, of a situation so desirable in every
+respect, so replete with advantage, so promising for happiness, Jane had
+been deprived, by the folly and indecorum of her own family!
+
+When to these recollections was added the development of Wickham’s
+character, it may be easily believed that the happy spirits which had
+seldom been depressed before, were now so much affected as to make it
+almost impossible for her to appear tolerably cheerful.
+
+Their engagements at Rosings were as frequent during the last week of
+her stay as they had been at first. The very last evening was spent
+there; and her ladyship again inquired minutely into the particulars of
+their journey, gave them directions as to the best method of packing,
+and was so urgent on the necessity of placing gowns in the only right
+way, that Maria thought herself obliged, on her return, to undo all the
+work of the morning, and pack her trunk afresh.
+
+When they parted, Lady Catherine, with great condescension, wished them
+a good journey, and invited them to come to Hunsford again next year;
+and Miss de Bourgh exerted herself so far as to curtsey and hold out her
+hand to both.
+
+
+
+Chapter 38
+
+
+On Saturday morning Elizabeth and Mr. Collins met for breakfast a few
+minutes before the others appeared; and he took the opportunity of
+paying the parting civilities which he deemed indispensably necessary.
+
+“I know not, Miss Elizabeth,” said he, “whether Mrs. Collins has yet
+expressed her sense of your kindness in coming to us; but I am very
+certain you will not leave the house without receiving her thanks for
+it. The favour of your company has been much felt, I assure you. We
+know how little there is to tempt anyone to our humble abode. Our plain
+manner of living, our small rooms and few domestics, and the little we
+see of the world, must make Hunsford extremely dull to a young lady like
+yourself; but I hope you will believe us grateful for the condescension,
+and that we have done everything in our power to prevent your spending
+your time unpleasantly.”
+
+Elizabeth was eager with her thanks and assurances of happiness. She
+had spent six weeks with great enjoyment; and the pleasure of being with
+Charlotte, and the kind attentions she had received, must make _her_
+feel the obliged. Mr. Collins was gratified, and with a more smiling
+solemnity replied:
+
+“It gives me great pleasure to hear that you have passed your time not
+disagreeably. We have certainly done our best; and most fortunately
+having it in our power to introduce you to very superior society, and,
+from our connection with Rosings, the frequent means of varying the
+humble home scene, I think we may flatter ourselves that your Hunsford
+visit cannot have been entirely irksome. Our situation with regard to
+Lady Catherine’s family is indeed the sort of extraordinary advantage
+and blessing which few can boast. You see on what a footing we are. You
+see how continually we are engaged there. In truth I must acknowledge
+that, with all the disadvantages of this humble parsonage, I should
+not think anyone abiding in it an object of compassion, while they are
+sharers of our intimacy at Rosings.”
+
+Words were insufficient for the elevation of his feelings; and he was
+obliged to walk about the room, while Elizabeth tried to unite civility
+and truth in a few short sentences.
+
+“You may, in fact, carry a very favourable report of us into
+Hertfordshire, my dear cousin. I flatter myself at least that you will
+be able to do so. Lady Catherine’s great attentions to Mrs. Collins you
+have been a daily witness of; and altogether I trust it does not appear
+that your friend has drawn an unfortunate--but on this point it will be
+as well to be silent. Only let me assure you, my dear Miss Elizabeth,
+that I can from my heart most cordially wish you equal felicity in
+marriage. My dear Charlotte and I have but one mind and one way of
+thinking. There is in everything a most remarkable resemblance of
+character and ideas between us. We seem to have been designed for each
+other.”
+
+Elizabeth could safely say that it was a great happiness where that was
+the case, and with equal sincerity could add, that she firmly believed
+and rejoiced in his domestic comforts. She was not sorry, however, to
+have the recital of them interrupted by the lady from whom they sprang.
+Poor Charlotte! it was melancholy to leave her to such society! But she
+had chosen it with her eyes open; and though evidently regretting that
+her visitors were to go, she did not seem to ask for compassion. Her
+home and her housekeeping, her parish and her poultry, and all their
+dependent concerns, had not yet lost their charms.
+
+At length the chaise arrived, the trunks were fastened on, the parcels
+placed within, and it was pronounced to be ready. After an affectionate
+parting between the friends, Elizabeth was attended to the carriage by
+Mr. Collins, and as they walked down the garden he was commissioning her
+with his best respects to all her family, not forgetting his thanks
+for the kindness he had received at Longbourn in the winter, and his
+compliments to Mr. and Mrs. Gardiner, though unknown. He then handed her
+in, Maria followed, and the door was on the point of being closed,
+when he suddenly reminded them, with some consternation, that they had
+hitherto forgotten to leave any message for the ladies at Rosings.
+
+“But,” he added, “you will of course wish to have your humble respects
+delivered to them, with your grateful thanks for their kindness to you
+while you have been here.”
+
+Elizabeth made no objection; the door was then allowed to be shut, and
+the carriage drove off.
+
+“Good gracious!” cried Maria, after a few minutes’ silence, “it seems
+but a day or two since we first came! and yet how many things have
+happened!”
+
+“A great many indeed,” said her companion with a sigh.
+
+“We have dined nine times at Rosings, besides drinking tea there twice!
+How much I shall have to tell!”
+
+Elizabeth added privately, “And how much I shall have to conceal!”
+
+Their journey was performed without much conversation, or any alarm; and
+within four hours of their leaving Hunsford they reached Mr. Gardiner’s
+house, where they were to remain a few days.
+
+Jane looked well, and Elizabeth had little opportunity of studying her
+spirits, amidst the various engagements which the kindness of her
+aunt had reserved for them. But Jane was to go home with her, and at
+Longbourn there would be leisure enough for observation.
+
+It was not without an effort, meanwhile, that she could wait even for
+Longbourn, before she told her sister of Mr. Darcy’s proposals. To know
+that she had the power of revealing what would so exceedingly astonish
+Jane, and must, at the same time, so highly gratify whatever of her own
+vanity she had not yet been able to reason away, was such a temptation
+to openness as nothing could have conquered but the state of indecision
+in which she remained as to the extent of what she should communicate;
+and her fear, if she once entered on the subject, of being hurried
+into repeating something of Bingley which might only grieve her sister
+further.
+
+
+
+Chapter 39
+
+
+It was the second week in May, in which the three young ladies set out
+together from Gracechurch Street for the town of ----, in Hertfordshire;
+and, as they drew near the appointed inn where Mr. Bennet’s carriage
+was to meet them, they quickly perceived, in token of the coachman’s
+punctuality, both Kitty and Lydia looking out of a dining-room up stairs.
+These two girls had been above an hour in the place, happily employed
+in visiting an opposite milliner, watching the sentinel on guard, and
+dressing a salad and cucumber.
+
+After welcoming their sisters, they triumphantly displayed a table set
+out with such cold meat as an inn larder usually affords, exclaiming,
+“Is not this nice? Is not this an agreeable surprise?”
+
+“And we mean to treat you all,” added Lydia, “but you must lend us the
+money, for we have just spent ours at the shop out there.” Then, showing
+her purchases--“Look here, I have bought this bonnet. I do not think
+it is very pretty; but I thought I might as well buy it as not. I shall
+pull it to pieces as soon as I get home, and see if I can make it up any
+better.”
+
+And when her sisters abused it as ugly, she added, with perfect
+unconcern, “Oh! but there were two or three much uglier in the shop; and
+when I have bought some prettier-coloured satin to trim it with fresh, I
+think it will be very tolerable. Besides, it will not much signify what
+one wears this summer, after the ----shire have left Meryton, and they
+are going in a fortnight.”
+
+“Are they indeed!” cried Elizabeth, with the greatest satisfaction.
+
+“They are going to be encamped near Brighton; and I do so want papa to
+take us all there for the summer! It would be such a delicious scheme;
+and I dare say would hardly cost anything at all. Mamma would like to
+go too of all things! Only think what a miserable summer else we shall
+have!”
+
+“Yes,” thought Elizabeth, “_that_ would be a delightful scheme indeed,
+and completely do for us at once. Good Heaven! Brighton, and a whole
+campful of soldiers, to us, who have been overset already by one poor
+regiment of militia, and the monthly balls of Meryton!”
+
+“Now I have got some news for you,” said Lydia, as they sat down at
+table. “What do you think? It is excellent news--capital news--and about
+a certain person we all like!”
+
+Jane and Elizabeth looked at each other, and the waiter was told he need
+not stay. Lydia laughed, and said:
+
+“Aye, that is just like your formality and discretion. You thought the
+waiter must not hear, as if he cared! I dare say he often hears worse
+things said than I am going to say. But he is an ugly fellow! I am glad
+he is gone. I never saw such a long chin in my life. Well, but now for
+my news; it is about dear Wickham; too good for the waiter, is it not?
+There is no danger of Wickham’s marrying Mary King. There’s for you! She
+is gone down to her uncle at Liverpool: gone to stay. Wickham is safe.”
+
+“And Mary King is safe!” added Elizabeth; “safe from a connection
+imprudent as to fortune.”
+
+“She is a great fool for going away, if she liked him.”
+
+“But I hope there is no strong attachment on either side,” said Jane.
+
+“I am sure there is not on _his_. I will answer for it, he never cared
+three straws about her--who could about such a nasty little freckled
+thing?”
+
+Elizabeth was shocked to think that, however incapable of such
+coarseness of _expression_ herself, the coarseness of the _sentiment_
+was little other than her own breast had harboured and fancied liberal!
+
+As soon as all had ate, and the elder ones paid, the carriage was
+ordered; and after some contrivance, the whole party, with all their
+boxes, work-bags, and parcels, and the unwelcome addition of Kitty’s and
+Lydia’s purchases, were seated in it.
+
+“How nicely we are all crammed in,” cried Lydia. “I am glad I bought my
+bonnet, if it is only for the fun of having another bandbox! Well, now
+let us be quite comfortable and snug, and talk and laugh all the way
+home. And in the first place, let us hear what has happened to you all
+since you went away. Have you seen any pleasant men? Have you had any
+flirting? I was in great hopes that one of you would have got a husband
+before you came back. Jane will be quite an old maid soon, I declare.
+She is almost three-and-twenty! Lord, how ashamed I should be of not
+being married before three-and-twenty! My aunt Phillips wants you so to
+get husbands, you can’t think. She says Lizzy had better have taken Mr.
+Collins; but _I_ do not think there would have been any fun in it. Lord!
+how I should like to be married before any of you; and then I would
+chaperon you about to all the balls. Dear me! we had such a good piece
+of fun the other day at Colonel Forster’s. Kitty and me were to spend
+the day there, and Mrs. Forster promised to have a little dance in the
+evening; (by the bye, Mrs. Forster and me are _such_ friends!) and so
+she asked the two Harringtons to come, but Harriet was ill, and so Pen
+was forced to come by herself; and then, what do you think we did? We
+dressed up Chamberlayne in woman’s clothes on purpose to pass for a
+lady, only think what fun! Not a soul knew of it, but Colonel and Mrs.
+Forster, and Kitty and me, except my aunt, for we were forced to borrow
+one of her gowns; and you cannot imagine how well he looked! When Denny,
+and Wickham, and Pratt, and two or three more of the men came in, they
+did not know him in the least. Lord! how I laughed! and so did Mrs.
+Forster. I thought I should have died. And _that_ made the men suspect
+something, and then they soon found out what was the matter.”
+
+With such kinds of histories of their parties and good jokes, did
+Lydia, assisted by Kitty’s hints and additions, endeavour to amuse her
+companions all the way to Longbourn. Elizabeth listened as little as she
+could, but there was no escaping the frequent mention of Wickham’s name.
+
+Their reception at home was most kind. Mrs. Bennet rejoiced to see Jane
+in undiminished beauty; and more than once during dinner did Mr. Bennet
+say voluntarily to Elizabeth:
+
+“I am glad you are come back, Lizzy.”
+
+Their party in the dining-room was large, for almost all the Lucases
+came to meet Maria and hear the news; and various were the subjects that
+occupied them: Lady Lucas was inquiring of Maria, after the welfare and
+poultry of her eldest daughter; Mrs. Bennet was doubly engaged, on one
+hand collecting an account of the present fashions from Jane, who sat
+some way below her, and, on the other, retailing them all to the younger
+Lucases; and Lydia, in a voice rather louder than any other person’s,
+was enumerating the various pleasures of the morning to anybody who
+would hear her.
+
+“Oh! Mary,” said she, “I wish you had gone with us, for we had such fun!
+As we went along, Kitty and I drew up the blinds, and pretended there
+was nobody in the coach; and I should have gone so all the way, if Kitty
+had not been sick; and when we got to the George, I do think we behaved
+very handsomely, for we treated the other three with the nicest cold
+luncheon in the world, and if you would have gone, we would have treated
+you too. And then when we came away it was such fun! I thought we never
+should have got into the coach. I was ready to die of laughter. And then
+we were so merry all the way home! we talked and laughed so loud, that
+anybody might have heard us ten miles off!”
+
+To this Mary very gravely replied, “Far be it from me, my dear sister,
+to depreciate such pleasures! They would doubtless be congenial with the
+generality of female minds. But I confess they would have no charms for
+_me_--I should infinitely prefer a book.”
+
+But of this answer Lydia heard not a word. She seldom listened to
+anybody for more than half a minute, and never attended to Mary at all.
+
+In the afternoon Lydia was urgent with the rest of the girls to walk
+to Meryton, and to see how everybody went on; but Elizabeth steadily
+opposed the scheme. It should not be said that the Miss Bennets could
+not be at home half a day before they were in pursuit of the officers.
+There was another reason too for her opposition. She dreaded seeing Mr.
+Wickham again, and was resolved to avoid it as long as possible. The
+comfort to _her_ of the regiment’s approaching removal was indeed beyond
+expression. In a fortnight they were to go--and once gone, she hoped
+there could be nothing more to plague her on his account.
+
+She had not been many hours at home before she found that the Brighton
+scheme, of which Lydia had given them a hint at the inn, was under
+frequent discussion between her parents. Elizabeth saw directly that her
+father had not the smallest intention of yielding; but his answers were
+at the same time so vague and equivocal, that her mother, though often
+disheartened, had never yet despaired of succeeding at last.
+
+
+
+Chapter 40
+
+
+Elizabeth’s impatience to acquaint Jane with what had happened could
+no longer be overcome; and at length, resolving to suppress every
+particular in which her sister was concerned, and preparing her to be
+surprised, she related to her the next morning the chief of the scene
+between Mr. Darcy and herself.
+
+Miss Bennet’s astonishment was soon lessened by the strong sisterly
+partiality which made any admiration of Elizabeth appear perfectly
+natural; and all surprise was shortly lost in other feelings. She was
+sorry that Mr. Darcy should have delivered his sentiments in a manner so
+little suited to recommend them; but still more was she grieved for the
+unhappiness which her sister’s refusal must have given him.
+
+“His being so sure of succeeding was wrong,” said she, “and certainly
+ought not to have appeared; but consider how much it must increase his
+disappointment!”
+
+“Indeed,” replied Elizabeth, “I am heartily sorry for him; but he has
+other feelings, which will probably soon drive away his regard for me.
+You do not blame me, however, for refusing him?”
+
+“Blame you! Oh, no.”
+
+“But you blame me for having spoken so warmly of Wickham?”
+
+“No--I do not know that you were wrong in saying what you did.”
+
+“But you _will_ know it, when I tell you what happened the very next
+day.”
+
+She then spoke of the letter, repeating the whole of its contents as far
+as they concerned George Wickham. What a stroke was this for poor Jane!
+who would willingly have gone through the world without believing that
+so much wickedness existed in the whole race of mankind, as was here
+collected in one individual. Nor was Darcy’s vindication, though
+grateful to her feelings, capable of consoling her for such discovery.
+Most earnestly did she labour to prove the probability of error, and
+seek to clear the one without involving the other.
+
+“This will not do,” said Elizabeth; “you never will be able to make both
+of them good for anything. Take your choice, but you must be satisfied
+with only one. There is but such a quantity of merit between them; just
+enough to make one good sort of man; and of late it has been shifting
+about pretty much. For my part, I am inclined to believe it all Darcy’s;
+but you shall do as you choose.”
+
+It was some time, however, before a smile could be extorted from Jane.
+
+“I do not know when I have been more shocked,” said she. “Wickham so
+very bad! It is almost past belief. And poor Mr. Darcy! Dear Lizzy, only
+consider what he must have suffered. Such a disappointment! and with the
+knowledge of your ill opinion, too! and having to relate such a thing
+of his sister! It is really too distressing. I am sure you must feel it
+so.”
+
+“Oh! no, my regret and compassion are all done away by seeing you so
+full of both. I know you will do him such ample justice, that I am
+growing every moment more unconcerned and indifferent. Your profusion
+makes me saving; and if you lament over him much longer, my heart will
+be as light as a feather.”
+
+“Poor Wickham! there is such an expression of goodness in his
+countenance! such an openness and gentleness in his manner!”
+
+“There certainly was some great mismanagement in the education of those
+two young men. One has got all the goodness, and the other all the
+appearance of it.”
+
+“I never thought Mr. Darcy so deficient in the _appearance_ of it as you
+used to do.”
+
+“And yet I meant to be uncommonly clever in taking so decided a dislike
+to him, without any reason. It is such a spur to one’s genius, such an
+opening for wit, to have a dislike of that kind. One may be continually
+abusive without saying anything just; but one cannot always be laughing
+at a man without now and then stumbling on something witty.”
+
+“Lizzy, when you first read that letter, I am sure you could not treat
+the matter as you do now.”
+
+“Indeed, I could not. I was uncomfortable enough, I may say unhappy. And
+with no one to speak to about what I felt, no Jane to comfort me and say
+that I had not been so very weak and vain and nonsensical as I knew I
+had! Oh! how I wanted you!”
+
+“How unfortunate that you should have used such very strong expressions
+in speaking of Wickham to Mr. Darcy, for now they _do_ appear wholly
+undeserved.”
+
+“Certainly. But the misfortune of speaking with bitterness is a most
+natural consequence of the prejudices I had been encouraging. There
+is one point on which I want your advice. I want to be told whether I
+ought, or ought not, to make our acquaintances in general understand
+Wickham’s character.”
+
+Miss Bennet paused a little, and then replied, “Surely there can be no
+occasion for exposing him so dreadfully. What is your opinion?”
+
+“That it ought not to be attempted. Mr. Darcy has not authorised me
+to make his communication public. On the contrary, every particular
+relative to his sister was meant to be kept as much as possible to
+myself; and if I endeavour to undeceive people as to the rest of his
+conduct, who will believe me? The general prejudice against Mr. Darcy
+is so violent, that it would be the death of half the good people in
+Meryton to attempt to place him in an amiable light. I am not equal
+to it. Wickham will soon be gone; and therefore it will not signify to
+anyone here what he really is. Some time hence it will be all found out,
+and then we may laugh at their stupidity in not knowing it before. At
+present I will say nothing about it.”
+
+“You are quite right. To have his errors made public might ruin him for
+ever. He is now, perhaps, sorry for what he has done, and anxious to
+re-establish a character. We must not make him desperate.”
+
+The tumult of Elizabeth’s mind was allayed by this conversation. She had
+got rid of two of the secrets which had weighed on her for a fortnight,
+and was certain of a willing listener in Jane, whenever she might wish
+to talk again of either. But there was still something lurking behind,
+of which prudence forbade the disclosure. She dared not relate the other
+half of Mr. Darcy’s letter, nor explain to her sister how sincerely she
+had been valued by her friend. Here was knowledge in which no one
+could partake; and she was sensible that nothing less than a perfect
+understanding between the parties could justify her in throwing off
+this last encumbrance of mystery. “And then,” said she, “if that very
+improbable event should ever take place, I shall merely be able to
+tell what Bingley may tell in a much more agreeable manner himself. The
+liberty of communication cannot be mine till it has lost all its value!”
+
+She was now, on being settled at home, at leisure to observe the real
+state of her sister’s spirits. Jane was not happy. She still cherished a
+very tender affection for Bingley. Having never even fancied herself
+in love before, her regard had all the warmth of first attachment,
+and, from her age and disposition, greater steadiness than most first
+attachments often boast; and so fervently did she value his remembrance,
+and prefer him to every other man, that all her good sense, and all her
+attention to the feelings of her friends, were requisite to check the
+indulgence of those regrets which must have been injurious to her own
+health and their tranquillity.
+
+“Well, Lizzy,” said Mrs. Bennet one day, “what is your opinion _now_ of
+this sad business of Jane’s? For my part, I am determined never to speak
+of it again to anybody. I told my sister Phillips so the other day. But
+I cannot find out that Jane saw anything of him in London. Well, he is
+a very undeserving young man--and I do not suppose there’s the least
+chance in the world of her ever getting him now. There is no talk of
+his coming to Netherfield again in the summer; and I have inquired of
+everybody, too, who is likely to know.”
+
+“I do not believe he will ever live at Netherfield any more.”
+
+“Oh well! it is just as he chooses. Nobody wants him to come. Though I
+shall always say he used my daughter extremely ill; and if I was her, I
+would not have put up with it. Well, my comfort is, I am sure Jane will
+die of a broken heart; and then he will be sorry for what he has done.”
+
+But as Elizabeth could not receive comfort from any such expectation,
+she made no answer.
+
+“Well, Lizzy,” continued her mother, soon afterwards, “and so the
+Collinses live very comfortable, do they? Well, well, I only hope
+it will last. And what sort of table do they keep? Charlotte is an
+excellent manager, I dare say. If she is half as sharp as her
+mother, she is saving enough. There is nothing extravagant in _their_
+housekeeping, I dare say.”
+
+“No, nothing at all.”
+
+“A great deal of good management, depend upon it. Yes, yes, _they_ will
+take care not to outrun their income. _They_ will never be distressed
+for money. Well, much good may it do them! And so, I suppose, they often
+talk of having Longbourn when your father is dead. They look upon it as
+quite their own, I dare say, whenever that happens.”
+
+“It was a subject which they could not mention before me.”
+
+“No; it would have been strange if they had; but I make no doubt they
+often talk of it between themselves. Well, if they can be easy with an
+estate that is not lawfully their own, so much the better. I should be
+ashamed of having one that was only entailed on me.”
+
+
+
+Chapter 41
+
+
+The first week of their return was soon gone. The second began. It was
+the last of the regiment’s stay in Meryton, and all the young ladies
+in the neighbourhood were drooping apace. The dejection was almost
+universal. The elder Miss Bennets alone were still able to eat, drink,
+and sleep, and pursue the usual course of their employments. Very
+frequently were they reproached for this insensibility by Kitty and
+Lydia, whose own misery was extreme, and who could not comprehend such
+hard-heartedness in any of the family.
+
+“Good Heaven! what is to become of us? What are we to do?” would they
+often exclaim in the bitterness of woe. “How can you be smiling so,
+Lizzy?”
+
+Their affectionate mother shared all their grief; she remembered what
+she had herself endured on a similar occasion, five-and-twenty years
+ago.
+
+“I am sure,” said she, “I cried for two days together when Colonel
+Miller’s regiment went away. I thought I should have broken my heart.”
+
+“I am sure I shall break _mine_,” said Lydia.
+
+“If one could but go to Brighton!” observed Mrs. Bennet.
+
+“Oh, yes!--if one could but go to Brighton! But papa is so
+disagreeable.”
+
+“A little sea-bathing would set me up forever.”
+
+“And my aunt Phillips is sure it would do _me_ a great deal of good,”
+ added Kitty.
+
+Such were the kind of lamentations resounding perpetually through
+Longbourn House. Elizabeth tried to be diverted by them; but all sense
+of pleasure was lost in shame. She felt anew the justice of Mr. Darcy’s
+objections; and never had she been so much disposed to pardon his
+interference in the views of his friend.
+
+But the gloom of Lydia’s prospect was shortly cleared away; for she
+received an invitation from Mrs. Forster, the wife of the colonel of
+the regiment, to accompany her to Brighton. This invaluable friend was a
+very young woman, and very lately married. A resemblance in good humour
+and good spirits had recommended her and Lydia to each other, and out of
+their _three_ months’ acquaintance they had been intimate _two_.
+
+The rapture of Lydia on this occasion, her adoration of Mrs. Forster,
+the delight of Mrs. Bennet, and the mortification of Kitty, are scarcely
+to be described. Wholly inattentive to her sister’s feelings, Lydia
+flew about the house in restless ecstasy, calling for everyone’s
+congratulations, and laughing and talking with more violence than ever;
+whilst the luckless Kitty continued in the parlour repined at her fate
+in terms as unreasonable as her accent was peevish.
+
+“I cannot see why Mrs. Forster should not ask _me_ as well as Lydia,”
+ said she, “Though I am _not_ her particular friend. I have just as much
+right to be asked as she has, and more too, for I am two years older.”
+
+In vain did Elizabeth attempt to make her reasonable, and Jane to make
+her resigned. As for Elizabeth herself, this invitation was so far from
+exciting in her the same feelings as in her mother and Lydia, that she
+considered it as the death warrant of all possibility of common sense
+for the latter; and detestable as such a step must make her were it
+known, she could not help secretly advising her father not to let her
+go. She represented to him all the improprieties of Lydia’s general
+behaviour, the little advantage she could derive from the friendship of
+such a woman as Mrs. Forster, and the probability of her being yet more
+imprudent with such a companion at Brighton, where the temptations must
+be greater than at home. He heard her attentively, and then said:
+
+“Lydia will never be easy until she has exposed herself in some public
+place or other, and we can never expect her to do it with so
+little expense or inconvenience to her family as under the present
+circumstances.”
+
+“If you were aware,” said Elizabeth, “of the very great disadvantage to
+us all which must arise from the public notice of Lydia’s unguarded and
+imprudent manner--nay, which has already arisen from it, I am sure you
+would judge differently in the affair.”
+
+“Already arisen?” repeated Mr. Bennet. “What, has she frightened away
+some of your lovers? Poor little Lizzy! But do not be cast down. Such
+squeamish youths as cannot bear to be connected with a little absurdity
+are not worth a regret. Come, let me see the list of pitiful fellows who
+have been kept aloof by Lydia’s folly.”
+
+“Indeed you are mistaken. I have no such injuries to resent. It is not
+of particular, but of general evils, which I am now complaining. Our
+importance, our respectability in the world must be affected by the
+wild volatility, the assurance and disdain of all restraint which mark
+Lydia’s character. Excuse me, for I must speak plainly. If you, my dear
+father, will not take the trouble of checking her exuberant spirits, and
+of teaching her that her present pursuits are not to be the business of
+her life, she will soon be beyond the reach of amendment. Her character
+will be fixed, and she will, at sixteen, be the most determined flirt
+that ever made herself or her family ridiculous; a flirt, too, in the
+worst and meanest degree of flirtation; without any attraction beyond
+youth and a tolerable person; and, from the ignorance and emptiness
+of her mind, wholly unable to ward off any portion of that universal
+contempt which her rage for admiration will excite. In this danger
+Kitty also is comprehended. She will follow wherever Lydia leads. Vain,
+ignorant, idle, and absolutely uncontrolled! Oh! my dear father, can you
+suppose it possible that they will not be censured and despised wherever
+they are known, and that their sisters will not be often involved in the
+disgrace?”
+
+Mr. Bennet saw that her whole heart was in the subject, and
+affectionately taking her hand said in reply:
+
+“Do not make yourself uneasy, my love. Wherever you and Jane are known
+you must be respected and valued; and you will not appear to less
+advantage for having a couple of--or I may say, three--very silly
+sisters. We shall have no peace at Longbourn if Lydia does not go to
+Brighton. Let her go, then. Colonel Forster is a sensible man, and will
+keep her out of any real mischief; and she is luckily too poor to be an
+object of prey to anybody. At Brighton she will be of less importance
+even as a common flirt than she has been here. The officers will find
+women better worth their notice. Let us hope, therefore, that her being
+there may teach her her own insignificance. At any rate, she cannot grow
+many degrees worse, without authorising us to lock her up for the rest
+of her life.”
+
+With this answer Elizabeth was forced to be content; but her own opinion
+continued the same, and she left him disappointed and sorry. It was not
+in her nature, however, to increase her vexations by dwelling on
+them. She was confident of having performed her duty, and to fret
+over unavoidable evils, or augment them by anxiety, was no part of her
+disposition.
+
+Had Lydia and her mother known the substance of her conference with her
+father, their indignation would hardly have found expression in their
+united volubility. In Lydia’s imagination, a visit to Brighton comprised
+every possibility of earthly happiness. She saw, with the creative eye
+of fancy, the streets of that gay bathing-place covered with officers.
+She saw herself the object of attention, to tens and to scores of them
+at present unknown. She saw all the glories of the camp--its tents
+stretched forth in beauteous uniformity of lines, crowded with the young
+and the gay, and dazzling with scarlet; and, to complete the view, she
+saw herself seated beneath a tent, tenderly flirting with at least six
+officers at once.
+
+Had she known her sister sought to tear her from such prospects and such
+realities as these, what would have been her sensations? They could have
+been understood only by her mother, who might have felt nearly the same.
+Lydia’s going to Brighton was all that consoled her for her melancholy
+conviction of her husband’s never intending to go there himself.
+
+But they were entirely ignorant of what had passed; and their raptures
+continued, with little intermission, to the very day of Lydia’s leaving
+home.
+
+Elizabeth was now to see Mr. Wickham for the last time. Having been
+frequently in company with him since her return, agitation was pretty
+well over; the agitations of former partiality entirely so. She had even
+learnt to detect, in the very gentleness which had first delighted
+her, an affectation and a sameness to disgust and weary. In his present
+behaviour to herself, moreover, she had a fresh source of displeasure,
+for the inclination he soon testified of renewing those intentions which
+had marked the early part of their acquaintance could only serve, after
+what had since passed, to provoke her. She lost all concern for him in
+finding herself thus selected as the object of such idle and frivolous
+gallantry; and while she steadily repressed it, could not but feel the
+reproof contained in his believing, that however long, and for whatever
+cause, his attentions had been withdrawn, her vanity would be gratified,
+and her preference secured at any time by their renewal.
+
+On the very last day of the regiment’s remaining at Meryton, he dined,
+with other of the officers, at Longbourn; and so little was Elizabeth
+disposed to part from him in good humour, that on his making some
+inquiry as to the manner in which her time had passed at Hunsford, she
+mentioned Colonel Fitzwilliam’s and Mr. Darcy’s having both spent three
+weeks at Rosings, and asked him, if he was acquainted with the former.
+
+He looked surprised, displeased, alarmed; but with a moment’s
+recollection and a returning smile, replied, that he had formerly seen
+him often; and, after observing that he was a very gentlemanlike man,
+asked her how she had liked him. Her answer was warmly in his favour.
+With an air of indifference he soon afterwards added:
+
+“How long did you say he was at Rosings?”
+
+“Nearly three weeks.”
+
+“And you saw him frequently?”
+
+“Yes, almost every day.”
+
+“His manners are very different from his cousin’s.”
+
+“Yes, very different. But I think Mr. Darcy improves upon acquaintance.”
+
+“Indeed!” cried Mr. Wickham with a look which did not escape her. “And
+pray, may I ask?--” But checking himself, he added, in a gayer tone, “Is
+it in address that he improves? Has he deigned to add aught of civility
+to his ordinary style?--for I dare not hope,” he continued in a lower
+and more serious tone, “that he is improved in essentials.”
+
+“Oh, no!” said Elizabeth. “In essentials, I believe, he is very much
+what he ever was.”
+
+While she spoke, Wickham looked as if scarcely knowing whether to
+rejoice over her words, or to distrust their meaning. There was a
+something in her countenance which made him listen with an apprehensive
+and anxious attention, while she added:
+
+“When I said that he improved on acquaintance, I did not mean that
+his mind or his manners were in a state of improvement, but that, from
+knowing him better, his disposition was better understood.”
+
+Wickham’s alarm now appeared in a heightened complexion and agitated
+look; for a few minutes he was silent, till, shaking off his
+embarrassment, he turned to her again, and said in the gentlest of
+accents:
+
+“You, who so well know my feeling towards Mr. Darcy, will readily
+comprehend how sincerely I must rejoice that he is wise enough to assume
+even the _appearance_ of what is right. His pride, in that direction,
+may be of service, if not to himself, to many others, for it must only
+deter him from such foul misconduct as I have suffered by. I only
+fear that the sort of cautiousness to which you, I imagine, have been
+alluding, is merely adopted on his visits to his aunt, of whose good
+opinion and judgement he stands much in awe. His fear of her has always
+operated, I know, when they were together; and a good deal is to be
+imputed to his wish of forwarding the match with Miss de Bourgh, which I
+am certain he has very much at heart.”
+
+Elizabeth could not repress a smile at this, but she answered only by a
+slight inclination of the head. She saw that he wanted to engage her on
+the old subject of his grievances, and she was in no humour to indulge
+him. The rest of the evening passed with the _appearance_, on his
+side, of usual cheerfulness, but with no further attempt to distinguish
+Elizabeth; and they parted at last with mutual civility, and possibly a
+mutual desire of never meeting again.
+
+When the party broke up, Lydia returned with Mrs. Forster to Meryton,
+from whence they were to set out early the next morning. The separation
+between her and her family was rather noisy than pathetic. Kitty was the
+only one who shed tears; but she did weep from vexation and envy. Mrs.
+Bennet was diffuse in her good wishes for the felicity of her daughter,
+and impressive in her injunctions that she should not miss the
+opportunity of enjoying herself as much as possible--advice which
+there was every reason to believe would be well attended to; and in
+the clamorous happiness of Lydia herself in bidding farewell, the more
+gentle adieus of her sisters were uttered without being heard.
+
+
+
+Chapter 42
+
+
+Had Elizabeth’s opinion been all drawn from her own family, she could
+not have formed a very pleasing opinion of conjugal felicity or domestic
+comfort. Her father, captivated by youth and beauty, and that appearance
+of good humour which youth and beauty generally give, had married a
+woman whose weak understanding and illiberal mind had very early in
+their marriage put an end to all real affection for her. Respect,
+esteem, and confidence had vanished for ever; and all his views
+of domestic happiness were overthrown. But Mr. Bennet was not of
+a disposition to seek comfort for the disappointment which his own
+imprudence had brought on, in any of those pleasures which too often
+console the unfortunate for their folly or their vice. He was fond of
+the country and of books; and from these tastes had arisen his principal
+enjoyments. To his wife he was very little otherwise indebted, than as
+her ignorance and folly had contributed to his amusement. This is not
+the sort of happiness which a man would in general wish to owe to his
+wife; but where other powers of entertainment are wanting, the true
+philosopher will derive benefit from such as are given.
+
+Elizabeth, however, had never been blind to the impropriety of her
+father’s behaviour as a husband. She had always seen it with pain; but
+respecting his abilities, and grateful for his affectionate treatment of
+herself, she endeavoured to forget what she could not overlook, and to
+banish from her thoughts that continual breach of conjugal obligation
+and decorum which, in exposing his wife to the contempt of her own
+children, was so highly reprehensible. But she had never felt so
+strongly as now the disadvantages which must attend the children of so
+unsuitable a marriage, nor ever been so fully aware of the evils arising
+from so ill-judged a direction of talents; talents, which, rightly used,
+might at least have preserved the respectability of his daughters, even
+if incapable of enlarging the mind of his wife.
+
+When Elizabeth had rejoiced over Wickham’s departure she found little
+other cause for satisfaction in the loss of the regiment. Their parties
+abroad were less varied than before, and at home she had a mother and
+sister whose constant repinings at the dullness of everything around
+them threw a real gloom over their domestic circle; and, though Kitty
+might in time regain her natural degree of sense, since the disturbers
+of her brain were removed, her other sister, from whose disposition
+greater evil might be apprehended, was likely to be hardened in all
+her folly and assurance by a situation of such double danger as a
+watering-place and a camp. Upon the whole, therefore, she found, what
+has been sometimes found before, that an event to which she had been
+looking with impatient desire did not, in taking place, bring all the
+satisfaction she had promised herself. It was consequently necessary to
+name some other period for the commencement of actual felicity--to have
+some other point on which her wishes and hopes might be fixed, and by
+again enjoying the pleasure of anticipation, console herself for the
+present, and prepare for another disappointment. Her tour to the Lakes
+was now the object of her happiest thoughts; it was her best consolation
+for all the uncomfortable hours which the discontentedness of her mother
+and Kitty made inevitable; and could she have included Jane in the
+scheme, every part of it would have been perfect.
+
+“But it is fortunate,” thought she, “that I have something to wish for.
+Were the whole arrangement complete, my disappointment would be certain.
+But here, by carrying with me one ceaseless source of regret in my
+sister’s absence, I may reasonably hope to have all my expectations of
+pleasure realised. A scheme of which every part promises delight can
+never be successful; and general disappointment is only warded off by
+the defence of some little peculiar vexation.”
+
+When Lydia went away she promised to write very often and very minutely
+to her mother and Kitty; but her letters were always long expected, and
+always very short. Those to her mother contained little else than that
+they were just returned from the library, where such and such officers
+had attended them, and where she had seen such beautiful ornaments as
+made her quite wild; that she had a new gown, or a new parasol, which
+she would have described more fully, but was obliged to leave off in a
+violent hurry, as Mrs. Forster called her, and they were going off to
+the camp; and from her correspondence with her sister, there was still
+less to be learnt--for her letters to Kitty, though rather longer, were
+much too full of lines under the words to be made public.
+
+After the first fortnight or three weeks of her absence, health, good
+humour, and cheerfulness began to reappear at Longbourn. Everything wore
+a happier aspect. The families who had been in town for the winter came
+back again, and summer finery and summer engagements arose. Mrs. Bennet
+was restored to her usual querulous serenity; and, by the middle of
+June, Kitty was so much recovered as to be able to enter Meryton without
+tears; an event of such happy promise as to make Elizabeth hope that by
+the following Christmas she might be so tolerably reasonable as not to
+mention an officer above once a day, unless, by some cruel and malicious
+arrangement at the War Office, another regiment should be quartered in
+Meryton.
+
+The time fixed for the beginning of their northern tour was now fast
+approaching, and a fortnight only was wanting of it, when a letter
+arrived from Mrs. Gardiner, which at once delayed its commencement and
+curtailed its extent. Mr. Gardiner would be prevented by business from
+setting out till a fortnight later in July, and must be in London again
+within a month, and as that left too short a period for them to go so
+far, and see so much as they had proposed, or at least to see it with
+the leisure and comfort they had built on, they were obliged to give up
+the Lakes, and substitute a more contracted tour, and, according to the
+present plan, were to go no farther northwards than Derbyshire. In that
+county there was enough to be seen to occupy the chief of their three
+weeks; and to Mrs. Gardiner it had a peculiarly strong attraction. The
+town where she had formerly passed some years of her life, and where
+they were now to spend a few days, was probably as great an object of
+her curiosity as all the celebrated beauties of Matlock, Chatsworth,
+Dovedale, or the Peak.
+
+Elizabeth was excessively disappointed; she had set her heart on seeing
+the Lakes, and still thought there might have been time enough. But it
+was her business to be satisfied--and certainly her temper to be happy;
+and all was soon right again.
+
+With the mention of Derbyshire there were many ideas connected. It was
+impossible for her to see the word without thinking of Pemberley and its
+owner. “But surely,” said she, “I may enter his county with impunity,
+and rob it of a few petrified spars without his perceiving me.”
+
+The period of expectation was now doubled. Four weeks were to pass away
+before her uncle and aunt’s arrival. But they did pass away, and Mr.
+and Mrs. Gardiner, with their four children, did at length appear at
+Longbourn. The children, two girls of six and eight years old, and two
+younger boys, were to be left under the particular care of their
+cousin Jane, who was the general favourite, and whose steady sense and
+sweetness of temper exactly adapted her for attending to them in every
+way--teaching them, playing with them, and loving them.
+
+The Gardiners stayed only one night at Longbourn, and set off the
+next morning with Elizabeth in pursuit of novelty and amusement.
+One enjoyment was certain--that of suitableness of companions;
+a suitableness which comprehended health and temper to bear
+inconveniences--cheerfulness to enhance every pleasure--and affection
+and intelligence, which might supply it among themselves if there were
+disappointments abroad.
+
+It is not the object of this work to give a description of Derbyshire,
+nor of any of the remarkable places through which their route thither
+lay; Oxford, Blenheim, Warwick, Kenilworth, Birmingham, etc. are
+sufficiently known. A small part of Derbyshire is all the present
+concern. To the little town of Lambton, the scene of Mrs. Gardiner’s
+former residence, and where she had lately learned some acquaintance
+still remained, they bent their steps, after having seen all the
+principal wonders of the country; and within five miles of Lambton,
+Elizabeth found from her aunt that Pemberley was situated. It was not
+in their direct road, nor more than a mile or two out of it. In
+talking over their route the evening before, Mrs. Gardiner expressed
+an inclination to see the place again. Mr. Gardiner declared his
+willingness, and Elizabeth was applied to for her approbation.
+
+“My love, should not you like to see a place of which you have heard
+so much?” said her aunt; “a place, too, with which so many of your
+acquaintances are connected. Wickham passed all his youth there, you
+know.”
+
+Elizabeth was distressed. She felt that she had no business at
+Pemberley, and was obliged to assume a disinclination for seeing it. She
+must own that she was tired of seeing great houses; after going over so
+many, she really had no pleasure in fine carpets or satin curtains.
+
+Mrs. Gardiner abused her stupidity. “If it were merely a fine house
+richly furnished,” said she, “I should not care about it myself; but
+the grounds are delightful. They have some of the finest woods in the
+country.”
+
+Elizabeth said no more--but her mind could not acquiesce. The
+possibility of meeting Mr. Darcy, while viewing the place, instantly
+occurred. It would be dreadful! She blushed at the very idea, and
+thought it would be better to speak openly to her aunt than to run such
+a risk. But against this there were objections; and she finally resolved
+that it could be the last resource, if her private inquiries to the
+absence of the family were unfavourably answered.
+
+Accordingly, when she retired at night, she asked the chambermaid
+whether Pemberley were not a very fine place? what was the name of its
+proprietor? and, with no little alarm, whether the family were down for
+the summer? A most welcome negative followed the last question--and her
+alarms now being removed, she was at leisure to feel a great deal of
+curiosity to see the house herself; and when the subject was revived the
+next morning, and she was again applied to, could readily answer, and
+with a proper air of indifference, that she had not really any dislike
+to the scheme. To Pemberley, therefore, they were to go.
+
+
+
+Chapter 43
+
+
+Elizabeth, as they drove along, watched for the first appearance of
+Pemberley Woods with some perturbation; and when at length they turned
+in at the lodge, her spirits were in a high flutter.
+
+The park was very large, and contained great variety of ground. They
+entered it in one of its lowest points, and drove for some time through
+a beautiful wood stretching over a wide extent.
+
+Elizabeth’s mind was too full for conversation, but she saw and admired
+every remarkable spot and point of view. They gradually ascended for
+half-a-mile, and then found themselves at the top of a considerable
+eminence, where the wood ceased, and the eye was instantly caught by
+Pemberley House, situated on the opposite side of a valley, into which
+the road with some abruptness wound. It was a large, handsome stone
+building, standing well on rising ground, and backed by a ridge of
+high woody hills; and in front, a stream of some natural importance was
+swelled into greater, but without any artificial appearance. Its banks
+were neither formal nor falsely adorned. Elizabeth was delighted. She
+had never seen a place for which nature had done more, or where natural
+beauty had been so little counteracted by an awkward taste. They were
+all of them warm in their admiration; and at that moment she felt that
+to be mistress of Pemberley might be something!
+
+They descended the hill, crossed the bridge, and drove to the door; and,
+while examining the nearer aspect of the house, all her apprehension of
+meeting its owner returned. She dreaded lest the chambermaid had been
+mistaken. On applying to see the place, they were admitted into the
+hall; and Elizabeth, as they waited for the housekeeper, had leisure to
+wonder at her being where she was.
+
+The housekeeper came; a respectable-looking elderly woman, much less
+fine, and more civil, than she had any notion of finding her. They
+followed her into the dining-parlour. It was a large, well proportioned
+room, handsomely fitted up. Elizabeth, after slightly surveying it, went
+to a window to enjoy its prospect. The hill, crowned with wood, which
+they had descended, receiving increased abruptness from the distance,
+was a beautiful object. Every disposition of the ground was good; and
+she looked on the whole scene, the river, the trees scattered on its
+banks and the winding of the valley, as far as she could trace it,
+with delight. As they passed into other rooms these objects were taking
+different positions; but from every window there were beauties to be
+seen. The rooms were lofty and handsome, and their furniture suitable to
+the fortune of its proprietor; but Elizabeth saw, with admiration of
+his taste, that it was neither gaudy nor uselessly fine; with less of
+splendour, and more real elegance, than the furniture of Rosings.
+
+“And of this place,” thought she, “I might have been mistress! With
+these rooms I might now have been familiarly acquainted! Instead of
+viewing them as a stranger, I might have rejoiced in them as my own, and
+welcomed to them as visitors my uncle and aunt. But no,”--recollecting
+herself--“that could never be; my uncle and aunt would have been lost to
+me; I should not have been allowed to invite them.”
+
+This was a lucky recollection--it saved her from something very like
+regret.
+
+She longed to inquire of the housekeeper whether her master was really
+absent, but had not the courage for it. At length however, the question
+was asked by her uncle; and she turned away with alarm, while Mrs.
+Reynolds replied that he was, adding, “But we expect him to-morrow, with
+a large party of friends.” How rejoiced was Elizabeth that their own
+journey had not by any circumstance been delayed a day!
+
+Her aunt now called her to look at a picture. She approached and saw the
+likeness of Mr. Wickham, suspended, amongst several other miniatures,
+over the mantelpiece. Her aunt asked her, smilingly, how she liked it.
+The housekeeper came forward, and told them it was a picture of a young
+gentleman, the son of her late master’s steward, who had been brought
+up by him at his own expense. “He is now gone into the army,” she added;
+“but I am afraid he has turned out very wild.”
+
+Mrs. Gardiner looked at her niece with a smile, but Elizabeth could not
+return it.
+
+“And that,” said Mrs. Reynolds, pointing to another of the miniatures,
+“is my master--and very like him. It was drawn at the same time as the
+other--about eight years ago.”
+
+“I have heard much of your master’s fine person,” said Mrs. Gardiner,
+looking at the picture; “it is a handsome face. But, Lizzy, you can tell
+us whether it is like or not.”
+
+Mrs. Reynolds respect for Elizabeth seemed to increase on this
+intimation of her knowing her master.
+
+“Does that young lady know Mr. Darcy?”
+
+Elizabeth coloured, and said: “A little.”
+
+“And do not you think him a very handsome gentleman, ma’am?”
+
+“Yes, very handsome.”
+
+“I am sure I know none so handsome; but in the gallery up stairs you
+will see a finer, larger picture of him than this. This room was my late
+master’s favourite room, and these miniatures are just as they used to
+be then. He was very fond of them.”
+
+This accounted to Elizabeth for Mr. Wickham’s being among them.
+
+Mrs. Reynolds then directed their attention to one of Miss Darcy, drawn
+when she was only eight years old.
+
+“And is Miss Darcy as handsome as her brother?” said Mrs. Gardiner.
+
+“Oh! yes--the handsomest young lady that ever was seen; and so
+accomplished!--She plays and sings all day long. In the next room is
+a new instrument just come down for her--a present from my master; she
+comes here to-morrow with him.”
+
+Mr. Gardiner, whose manners were very easy and pleasant, encouraged her
+communicativeness by his questions and remarks; Mrs. Reynolds, either
+by pride or attachment, had evidently great pleasure in talking of her
+master and his sister.
+
+“Is your master much at Pemberley in the course of the year?”
+
+“Not so much as I could wish, sir; but I dare say he may spend half his
+time here; and Miss Darcy is always down for the summer months.”
+
+“Except,” thought Elizabeth, “when she goes to Ramsgate.”
+
+“If your master would marry, you might see more of him.”
+
+“Yes, sir; but I do not know when _that_ will be. I do not know who is
+good enough for him.”
+
+Mr. and Mrs. Gardiner smiled. Elizabeth could not help saying, “It is
+very much to his credit, I am sure, that you should think so.”
+
+“I say no more than the truth, and everybody will say that knows him,”
+ replied the other. Elizabeth thought this was going pretty far; and she
+listened with increasing astonishment as the housekeeper added, “I have
+never known a cross word from him in my life, and I have known him ever
+since he was four years old.”
+
+This was praise, of all others most extraordinary, most opposite to her
+ideas. That he was not a good-tempered man had been her firmest opinion.
+Her keenest attention was awakened; she longed to hear more, and was
+grateful to her uncle for saying:
+
+“There are very few people of whom so much can be said. You are lucky in
+having such a master.”
+
+“Yes, sir, I know I am. If I were to go through the world, I could
+not meet with a better. But I have always observed, that they who are
+good-natured when children, are good-natured when they grow up; and
+he was always the sweetest-tempered, most generous-hearted boy in the
+world.”
+
+Elizabeth almost stared at her. “Can this be Mr. Darcy?” thought she.
+
+“His father was an excellent man,” said Mrs. Gardiner.
+
+“Yes, ma’am, that he was indeed; and his son will be just like him--just
+as affable to the poor.”
+
+Elizabeth listened, wondered, doubted, and was impatient for more. Mrs.
+Reynolds could interest her on no other point. She related the subjects
+of the pictures, the dimensions of the rooms, and the price of the
+furniture, in vain. Mr. Gardiner, highly amused by the kind of family
+prejudice to which he attributed her excessive commendation of her
+master, soon led again to the subject; and she dwelt with energy on his
+many merits as they proceeded together up the great staircase.
+
+“He is the best landlord, and the best master,” said she, “that ever
+lived; not like the wild young men nowadays, who think of nothing but
+themselves. There is not one of his tenants or servants but will give
+him a good name. Some people call him proud; but I am sure I never saw
+anything of it. To my fancy, it is only because he does not rattle away
+like other young men.”
+
+“In what an amiable light does this place him!” thought Elizabeth.
+
+“This fine account of him,” whispered her aunt as they walked, “is not
+quite consistent with his behaviour to our poor friend.”
+
+“Perhaps we might be deceived.”
+
+“That is not very likely; our authority was too good.”
+
+On reaching the spacious lobby above they were shown into a very pretty
+sitting-room, lately fitted up with greater elegance and lightness than
+the apartments below; and were informed that it was but just done to
+give pleasure to Miss Darcy, who had taken a liking to the room when
+last at Pemberley.
+
+“He is certainly a good brother,” said Elizabeth, as she walked towards
+one of the windows.
+
+Mrs. Reynolds anticipated Miss Darcy’s delight, when she should enter
+the room. “And this is always the way with him,” she added. “Whatever
+can give his sister any pleasure is sure to be done in a moment. There
+is nothing he would not do for her.”
+
+The picture-gallery, and two or three of the principal bedrooms, were
+all that remained to be shown. In the former were many good paintings;
+but Elizabeth knew nothing of the art; and from such as had been already
+visible below, she had willingly turned to look at some drawings of Miss
+Darcy’s, in crayons, whose subjects were usually more interesting, and
+also more intelligible.
+
+In the gallery there were many family portraits, but they could have
+little to fix the attention of a stranger. Elizabeth walked in quest of
+the only face whose features would be known to her. At last it arrested
+her--and she beheld a striking resemblance to Mr. Darcy, with such a
+smile over the face as she remembered to have sometimes seen when he
+looked at her. She stood several minutes before the picture, in earnest
+contemplation, and returned to it again before they quitted the gallery.
+Mrs. Reynolds informed them that it had been taken in his father’s
+lifetime.
+
+There was certainly at this moment, in Elizabeth’s mind, a more gentle
+sensation towards the original than she had ever felt at the height of
+their acquaintance. The commendation bestowed on him by Mrs. Reynolds
+was of no trifling nature. What praise is more valuable than the praise
+of an intelligent servant? As a brother, a landlord, a master, she
+considered how many people’s happiness were in his guardianship!--how
+much of pleasure or pain was it in his power to bestow!--how much of
+good or evil must be done by him! Every idea that had been brought
+forward by the housekeeper was favourable to his character, and as she
+stood before the canvas on which he was represented, and fixed his
+eyes upon herself, she thought of his regard with a deeper sentiment of
+gratitude than it had ever raised before; she remembered its warmth, and
+softened its impropriety of expression.
+
+When all of the house that was open to general inspection had been seen,
+they returned downstairs, and, taking leave of the housekeeper, were
+consigned over to the gardener, who met them at the hall-door.
+
+As they walked across the hall towards the river, Elizabeth turned back
+to look again; her uncle and aunt stopped also, and while the former
+was conjecturing as to the date of the building, the owner of it himself
+suddenly came forward from the road, which led behind it to the stables.
+
+They were within twenty yards of each other, and so abrupt was his
+appearance, that it was impossible to avoid his sight. Their eyes
+instantly met, and the cheeks of both were overspread with the deepest
+blush. He absolutely started, and for a moment seemed immovable from
+surprise; but shortly recovering himself, advanced towards the party,
+and spoke to Elizabeth, if not in terms of perfect composure, at least
+of perfect civility.
+
+She had instinctively turned away; but stopping on his approach,
+received his compliments with an embarrassment impossible to be
+overcome. Had his first appearance, or his resemblance to the picture
+they had just been examining, been insufficient to assure the other two
+that they now saw Mr. Darcy, the gardener’s expression of surprise, on
+beholding his master, must immediately have told it. They stood a little
+aloof while he was talking to their niece, who, astonished and confused,
+scarcely dared lift her eyes to his face, and knew not what answer
+she returned to his civil inquiries after her family. Amazed at the
+alteration of his manner since they last parted, every sentence that
+he uttered was increasing her embarrassment; and every idea of the
+impropriety of her being found there recurring to her mind, the few
+minutes in which they continued were some of the most uncomfortable in
+her life. Nor did he seem much more at ease; when he spoke, his accent
+had none of its usual sedateness; and he repeated his inquiries as
+to the time of her having left Longbourn, and of her having stayed in
+Derbyshire, so often, and in so hurried a way, as plainly spoke the
+distraction of his thoughts.
+
+At length every idea seemed to fail him; and, after standing a few
+moments without saying a word, he suddenly recollected himself, and took
+leave.
+
+The others then joined her, and expressed admiration of his figure; but
+Elizabeth heard not a word, and wholly engrossed by her own feelings,
+followed them in silence. She was overpowered by shame and vexation. Her
+coming there was the most unfortunate, the most ill-judged thing in the
+world! How strange it must appear to him! In what a disgraceful light
+might it not strike so vain a man! It might seem as if she had purposely
+thrown herself in his way again! Oh! why did she come? Or, why did he
+thus come a day before he was expected? Had they been only ten minutes
+sooner, they should have been beyond the reach of his discrimination;
+for it was plain that he was that moment arrived--that moment alighted
+from his horse or his carriage. She blushed again and again over
+the perverseness of the meeting. And his behaviour, so strikingly
+altered--what could it mean? That he should even speak to her was
+amazing!--but to speak with such civility, to inquire after her family!
+Never in her life had she seen his manners so little dignified, never
+had he spoken with such gentleness as on this unexpected meeting. What
+a contrast did it offer to his last address in Rosings Park, when he put
+his letter into her hand! She knew not what to think, or how to account
+for it.
+
+They had now entered a beautiful walk by the side of the water, and
+every step was bringing forward a nobler fall of ground, or a finer
+reach of the woods to which they were approaching; but it was some time
+before Elizabeth was sensible of any of it; and, though she answered
+mechanically to the repeated appeals of her uncle and aunt, and
+seemed to direct her eyes to such objects as they pointed out, she
+distinguished no part of the scene. Her thoughts were all fixed on that
+one spot of Pemberley House, whichever it might be, where Mr. Darcy then
+was. She longed to know what at the moment was passing in his mind--in
+what manner he thought of her, and whether, in defiance of everything,
+she was still dear to him. Perhaps he had been civil only because he
+felt himself at ease; yet there had been _that_ in his voice which was
+not like ease. Whether he had felt more of pain or of pleasure in
+seeing her she could not tell, but he certainly had not seen her with
+composure.
+
+At length, however, the remarks of her companions on her absence of mind
+aroused her, and she felt the necessity of appearing more like herself.
+
+They entered the woods, and bidding adieu to the river for a while,
+ascended some of the higher grounds; when, in spots where the opening of
+the trees gave the eye power to wander, were many charming views of the
+valley, the opposite hills, with the long range of woods overspreading
+many, and occasionally part of the stream. Mr. Gardiner expressed a wish
+of going round the whole park, but feared it might be beyond a walk.
+With a triumphant smile they were told that it was ten miles round.
+It settled the matter; and they pursued the accustomed circuit; which
+brought them again, after some time, in a descent among hanging woods,
+to the edge of the water, and one of its narrowest parts. They crossed
+it by a simple bridge, in character with the general air of the scene;
+it was a spot less adorned than any they had yet visited; and the
+valley, here contracted into a glen, allowed room only for the stream,
+and a narrow walk amidst the rough coppice-wood which bordered it.
+Elizabeth longed to explore its windings; but when they had crossed the
+bridge, and perceived their distance from the house, Mrs. Gardiner,
+who was not a great walker, could go no farther, and thought only
+of returning to the carriage as quickly as possible. Her niece was,
+therefore, obliged to submit, and they took their way towards the house
+on the opposite side of the river, in the nearest direction; but their
+progress was slow, for Mr. Gardiner, though seldom able to indulge the
+taste, was very fond of fishing, and was so much engaged in watching the
+occasional appearance of some trout in the water, and talking to the
+man about them, that he advanced but little. Whilst wandering on in this
+slow manner, they were again surprised, and Elizabeth’s astonishment
+was quite equal to what it had been at first, by the sight of Mr. Darcy
+approaching them, and at no great distance. The walk being here
+less sheltered than on the other side, allowed them to see him before
+they met. Elizabeth, however astonished, was at least more prepared
+for an interview than before, and resolved to appear and to speak with
+calmness, if he really intended to meet them. For a few moments, indeed,
+she felt that he would probably strike into some other path. The idea
+lasted while a turning in the walk concealed him from their view; the
+turning past, he was immediately before them. With a glance, she saw
+that he had lost none of his recent civility; and, to imitate his
+politeness, she began, as they met, to admire the beauty of the place;
+but she had not got beyond the words “delightful,” and “charming,” when
+some unlucky recollections obtruded, and she fancied that praise of
+Pemberley from her might be mischievously construed. Her colour changed,
+and she said no more.
+
+Mrs. Gardiner was standing a little behind; and on her pausing, he asked
+her if she would do him the honour of introducing him to her friends.
+This was a stroke of civility for which she was quite unprepared;
+and she could hardly suppress a smile at his being now seeking the
+acquaintance of some of those very people against whom his pride had
+revolted in his offer to herself. “What will be his surprise,” thought
+she, “when he knows who they are? He takes them now for people of
+fashion.”
+
+The introduction, however, was immediately made; and as she named their
+relationship to herself, she stole a sly look at him, to see how he bore
+it, and was not without the expectation of his decamping as fast as he
+could from such disgraceful companions. That he was _surprised_ by the
+connection was evident; he sustained it, however, with fortitude, and
+so far from going away, turned back with them, and entered into
+conversation with Mr. Gardiner. Elizabeth could not but be pleased,
+could not but triumph. It was consoling that he should know she had
+some relations for whom there was no need to blush. She listened most
+attentively to all that passed between them, and gloried in every
+expression, every sentence of her uncle, which marked his intelligence,
+his taste, or his good manners.
+
+The conversation soon turned upon fishing; and she heard Mr. Darcy
+invite him, with the greatest civility, to fish there as often as he
+chose while he continued in the neighbourhood, offering at the same time
+to supply him with fishing tackle, and pointing out those parts of
+the stream where there was usually most sport. Mrs. Gardiner, who was
+walking arm-in-arm with Elizabeth, gave her a look expressive of wonder.
+Elizabeth said nothing, but it gratified her exceedingly; the compliment
+must be all for herself. Her astonishment, however, was extreme, and
+continually was she repeating, “Why is he so altered? From what can
+it proceed? It cannot be for _me_--it cannot be for _my_ sake that his
+manners are thus softened. My reproofs at Hunsford could not work such a
+change as this. It is impossible that he should still love me.”
+
+After walking some time in this way, the two ladies in front, the two
+gentlemen behind, on resuming their places, after descending to
+the brink of the river for the better inspection of some curious
+water-plant, there chanced to be a little alteration. It originated
+in Mrs. Gardiner, who, fatigued by the exercise of the morning, found
+Elizabeth’s arm inadequate to her support, and consequently preferred
+her husband’s. Mr. Darcy took her place by her niece, and they walked on
+together. After a short silence, the lady first spoke. She wished him
+to know that she had been assured of his absence before she came to the
+place, and accordingly began by observing, that his arrival had been
+very unexpected--“for your housekeeper,” she added, “informed us that
+you would certainly not be here till to-morrow; and indeed, before we
+left Bakewell, we understood that you were not immediately expected
+in the country.” He acknowledged the truth of it all, and said that
+business with his steward had occasioned his coming forward a few hours
+before the rest of the party with whom he had been travelling. “They
+will join me early to-morrow,” he continued, “and among them are some
+who will claim an acquaintance with you--Mr. Bingley and his sisters.”
+
+Elizabeth answered only by a slight bow. Her thoughts were instantly
+driven back to the time when Mr. Bingley’s name had been the last
+mentioned between them; and, if she might judge by his complexion, _his_
+mind was not very differently engaged.
+
+“There is also one other person in the party,” he continued after a
+pause, “who more particularly wishes to be known to you. Will you allow
+me, or do I ask too much, to introduce my sister to your acquaintance
+during your stay at Lambton?”
+
+The surprise of such an application was great indeed; it was too great
+for her to know in what manner she acceded to it. She immediately felt
+that whatever desire Miss Darcy might have of being acquainted with her
+must be the work of her brother, and, without looking farther, it was
+satisfactory; it was gratifying to know that his resentment had not made
+him think really ill of her.
+
+They now walked on in silence, each of them deep in thought. Elizabeth
+was not comfortable; that was impossible; but she was flattered and
+pleased. His wish of introducing his sister to her was a compliment of
+the highest kind. They soon outstripped the others, and when they had
+reached the carriage, Mr. and Mrs. Gardiner were half a quarter of a
+mile behind.
+
+He then asked her to walk into the house--but she declared herself not
+tired, and they stood together on the lawn. At such a time much might
+have been said, and silence was very awkward. She wanted to talk, but
+there seemed to be an embargo on every subject. At last she recollected
+that she had been travelling, and they talked of Matlock and Dove Dale
+with great perseverance. Yet time and her aunt moved slowly--and her
+patience and her ideas were nearly worn out before the tete-a-tete was
+over. On Mr. and Mrs. Gardiner’s coming up they were all pressed to go
+into the house and take some refreshment; but this was declined, and
+they parted on each side with utmost politeness. Mr. Darcy handed the
+ladies into the carriage; and when it drove off, Elizabeth saw him
+walking slowly towards the house.
+
+The observations of her uncle and aunt now began; and each of them
+pronounced him to be infinitely superior to anything they had expected.
+“He is perfectly well behaved, polite, and unassuming,” said her uncle.
+
+“There _is_ something a little stately in him, to be sure,” replied her
+aunt, “but it is confined to his air, and is not unbecoming. I can now
+say with the housekeeper, that though some people may call him proud, I
+have seen nothing of it.”
+
+“I was never more surprised than by his behaviour to us. It was more
+than civil; it was really attentive; and there was no necessity for such
+attention. His acquaintance with Elizabeth was very trifling.”
+
+“To be sure, Lizzy,” said her aunt, “he is not so handsome as Wickham;
+or, rather, he has not Wickham’s countenance, for his features
+are perfectly good. But how came you to tell me that he was so
+disagreeable?”
+
+Elizabeth excused herself as well as she could; said that she had liked
+him better when they had met in Kent than before, and that she had never
+seen him so pleasant as this morning.
+
+“But perhaps he may be a little whimsical in his civilities,” replied
+her uncle. “Your great men often are; and therefore I shall not take him
+at his word, as he might change his mind another day, and warn me off
+his grounds.”
+
+Elizabeth felt that they had entirely misunderstood his character, but
+said nothing.
+
+“From what we have seen of him,” continued Mrs. Gardiner, “I really
+should not have thought that he could have behaved in so cruel a way by
+anybody as he has done by poor Wickham. He has not an ill-natured look.
+On the contrary, there is something pleasing about his mouth when he
+speaks. And there is something of dignity in his countenance that would
+not give one an unfavourable idea of his heart. But, to be sure, the
+good lady who showed us his house did give him a most flaming character!
+I could hardly help laughing aloud sometimes. But he is a liberal
+master, I suppose, and _that_ in the eye of a servant comprehends every
+virtue.”
+
+Elizabeth here felt herself called on to say something in vindication of
+his behaviour to Wickham; and therefore gave them to understand, in
+as guarded a manner as she could, that by what she had heard from
+his relations in Kent, his actions were capable of a very different
+construction; and that his character was by no means so faulty, nor
+Wickham’s so amiable, as they had been considered in Hertfordshire. In
+confirmation of this, she related the particulars of all the pecuniary
+transactions in which they had been connected, without actually naming
+her authority, but stating it to be such as might be relied on.
+
+Mrs. Gardiner was surprised and concerned; but as they were now
+approaching the scene of her former pleasures, every idea gave way to
+the charm of recollection; and she was too much engaged in pointing out
+to her husband all the interesting spots in its environs to think of
+anything else. Fatigued as she had been by the morning’s walk they
+had no sooner dined than she set off again in quest of her former
+acquaintance, and the evening was spent in the satisfactions of a
+intercourse renewed after many years’ discontinuance.
+
+The occurrences of the day were too full of interest to leave Elizabeth
+much attention for any of these new friends; and she could do nothing
+but think, and think with wonder, of Mr. Darcy’s civility, and, above
+all, of his wishing her to be acquainted with his sister.
+
+
+
+Chapter 44
+
+
+Elizabeth had settled it that Mr. Darcy would bring his sister to visit
+her the very day after her reaching Pemberley; and was consequently
+resolved not to be out of sight of the inn the whole of that morning.
+But her conclusion was false; for on the very morning after their
+arrival at Lambton, these visitors came. They had been walking about the
+place with some of their new friends, and were just returning to the inn
+to dress themselves for dining with the same family, when the sound of a
+carriage drew them to a window, and they saw a gentleman and a lady in
+a curricle driving up the street. Elizabeth immediately recognizing
+the livery, guessed what it meant, and imparted no small degree of her
+surprise to her relations by acquainting them with the honour which she
+expected. Her uncle and aunt were all amazement; and the embarrassment
+of her manner as she spoke, joined to the circumstance itself, and many
+of the circumstances of the preceding day, opened to them a new idea on
+the business. Nothing had ever suggested it before, but they felt that
+there was no other way of accounting for such attentions from such a
+quarter than by supposing a partiality for their niece. While these
+newly-born notions were passing in their heads, the perturbation of
+Elizabeth’s feelings was at every moment increasing. She was quite
+amazed at her own discomposure; but amongst other causes of disquiet,
+she dreaded lest the partiality of the brother should have said too much
+in her favour; and, more than commonly anxious to please, she naturally
+suspected that every power of pleasing would fail her.
+
+She retreated from the window, fearful of being seen; and as she walked
+up and down the room, endeavouring to compose herself, saw such looks of
+inquiring surprise in her uncle and aunt as made everything worse.
+
+Miss Darcy and her brother appeared, and this formidable introduction
+took place. With astonishment did Elizabeth see that her new
+acquaintance was at least as much embarrassed as herself. Since her
+being at Lambton, she had heard that Miss Darcy was exceedingly proud;
+but the observation of a very few minutes convinced her that she was
+only exceedingly shy. She found it difficult to obtain even a word from
+her beyond a monosyllable.
+
+Miss Darcy was tall, and on a larger scale than Elizabeth; and, though
+little more than sixteen, her figure was formed, and her appearance
+womanly and graceful. She was less handsome than her brother; but there
+was sense and good humour in her face, and her manners were perfectly
+unassuming and gentle. Elizabeth, who had expected to find in her as
+acute and unembarrassed an observer as ever Mr. Darcy had been, was much
+relieved by discerning such different feelings.
+
+They had not long been together before Mr. Darcy told her that Bingley
+was also coming to wait on her; and she had barely time to express her
+satisfaction, and prepare for such a visitor, when Bingley’s quick
+step was heard on the stairs, and in a moment he entered the room. All
+Elizabeth’s anger against him had been long done away; but had she still
+felt any, it could hardly have stood its ground against the unaffected
+cordiality with which he expressed himself on seeing her again. He
+inquired in a friendly, though general way, after her family, and looked
+and spoke with the same good-humoured ease that he had ever done.
+
+To Mr. and Mrs. Gardiner he was scarcely a less interesting personage
+than to herself. They had long wished to see him. The whole party before
+them, indeed, excited a lively attention. The suspicions which had just
+arisen of Mr. Darcy and their niece directed their observation towards
+each with an earnest though guarded inquiry; and they soon drew from
+those inquiries the full conviction that one of them at least knew
+what it was to love. Of the lady’s sensations they remained a little
+in doubt; but that the gentleman was overflowing with admiration was
+evident enough.
+
+Elizabeth, on her side, had much to do. She wanted to ascertain the
+feelings of each of her visitors; she wanted to compose her own, and
+to make herself agreeable to all; and in the latter object, where she
+feared most to fail, she was most sure of success, for those to whom she
+endeavoured to give pleasure were prepossessed in her favour. Bingley
+was ready, Georgiana was eager, and Darcy determined, to be pleased.
+
+In seeing Bingley, her thoughts naturally flew to her sister; and, oh!
+how ardently did she long to know whether any of his were directed in
+a like manner. Sometimes she could fancy that he talked less than on
+former occasions, and once or twice pleased herself with the notion
+that, as he looked at her, he was trying to trace a resemblance. But,
+though this might be imaginary, she could not be deceived as to his
+behaviour to Miss Darcy, who had been set up as a rival to Jane. No look
+appeared on either side that spoke particular regard. Nothing occurred
+between them that could justify the hopes of his sister. On this point
+she was soon satisfied; and two or three little circumstances occurred
+ere they parted, which, in her anxious interpretation, denoted a
+recollection of Jane not untinctured by tenderness, and a wish of saying
+more that might lead to the mention of her, had he dared. He observed
+to her, at a moment when the others were talking together, and in a tone
+which had something of real regret, that it “was a very long time since
+he had had the pleasure of seeing her;” and, before she could reply,
+he added, “It is above eight months. We have not met since the 26th of
+November, when we were all dancing together at Netherfield.”
+
+Elizabeth was pleased to find his memory so exact; and he afterwards
+took occasion to ask her, when unattended to by any of the rest, whether
+_all_ her sisters were at Longbourn. There was not much in the question,
+nor in the preceding remark; but there was a look and a manner which
+gave them meaning.
+
+It was not often that she could turn her eyes on Mr. Darcy himself;
+but, whenever she did catch a glimpse, she saw an expression of general
+complaisance, and in all that he said she heard an accent so removed
+from _hauteur_ or disdain of his companions, as convinced her that
+the improvement of manners which she had yesterday witnessed however
+temporary its existence might prove, had at least outlived one day. When
+she saw him thus seeking the acquaintance and courting the good opinion
+of people with whom any intercourse a few months ago would have been a
+disgrace--when she saw him thus civil, not only to herself, but to the
+very relations whom he had openly disdained, and recollected their last
+lively scene in Hunsford Parsonage--the difference, the change was
+so great, and struck so forcibly on her mind, that she could hardly
+restrain her astonishment from being visible. Never, even in the company
+of his dear friends at Netherfield, or his dignified relations
+at Rosings, had she seen him so desirous to please, so free from
+self-consequence or unbending reserve, as now, when no importance
+could result from the success of his endeavours, and when even the
+acquaintance of those to whom his attentions were addressed would draw
+down the ridicule and censure of the ladies both of Netherfield and
+Rosings.
+
+Their visitors stayed with them above half-an-hour; and when they arose
+to depart, Mr. Darcy called on his sister to join him in expressing
+their wish of seeing Mr. and Mrs. Gardiner, and Miss Bennet, to dinner
+at Pemberley, before they left the country. Miss Darcy, though with a
+diffidence which marked her little in the habit of giving invitations,
+readily obeyed. Mrs. Gardiner looked at her niece, desirous of knowing
+how _she_, whom the invitation most concerned, felt disposed as to its
+acceptance, but Elizabeth had turned away her head. Presuming however,
+that this studied avoidance spoke rather a momentary embarrassment than
+any dislike of the proposal, and seeing in her husband, who was fond of
+society, a perfect willingness to accept it, she ventured to engage for
+her attendance, and the day after the next was fixed on.
+
+Bingley expressed great pleasure in the certainty of seeing Elizabeth
+again, having still a great deal to say to her, and many inquiries to
+make after all their Hertfordshire friends. Elizabeth, construing all
+this into a wish of hearing her speak of her sister, was pleased, and on
+this account, as well as some others, found herself, when their
+visitors left them, capable of considering the last half-hour with some
+satisfaction, though while it was passing, the enjoyment of it had been
+little. Eager to be alone, and fearful of inquiries or hints from her
+uncle and aunt, she stayed with them only long enough to hear their
+favourable opinion of Bingley, and then hurried away to dress.
+
+But she had no reason to fear Mr. and Mrs. Gardiner’s curiosity; it was
+not their wish to force her communication. It was evident that she was
+much better acquainted with Mr. Darcy than they had before any idea of;
+it was evident that he was very much in love with her. They saw much to
+interest, but nothing to justify inquiry.
+
+Of Mr. Darcy it was now a matter of anxiety to think well; and, as far
+as their acquaintance reached, there was no fault to find. They could
+not be untouched by his politeness; and had they drawn his character
+from their own feelings and his servant’s report, without any reference
+to any other account, the circle in Hertfordshire to which he was known
+would not have recognized it for Mr. Darcy. There was now an interest,
+however, in believing the housekeeper; and they soon became sensible
+that the authority of a servant who had known him since he was four
+years old, and whose own manners indicated respectability, was not to be
+hastily rejected. Neither had anything occurred in the intelligence of
+their Lambton friends that could materially lessen its weight. They had
+nothing to accuse him of but pride; pride he probably had, and if not,
+it would certainly be imputed by the inhabitants of a small market-town
+where the family did not visit. It was acknowledged, however, that he
+was a liberal man, and did much good among the poor.
+
+With respect to Wickham, the travellers soon found that he was not held
+there in much estimation; for though the chief of his concerns with the
+son of his patron were imperfectly understood, it was yet a well-known
+fact that, on his quitting Derbyshire, he had left many debts behind
+him, which Mr. Darcy afterwards discharged.
+
+As for Elizabeth, her thoughts were at Pemberley this evening more than
+the last; and the evening, though as it passed it seemed long, was not
+long enough to determine her feelings towards _one_ in that mansion;
+and she lay awake two whole hours endeavouring to make them out. She
+certainly did not hate him. No; hatred had vanished long ago, and she
+had almost as long been ashamed of ever feeling a dislike against him,
+that could be so called. The respect created by the conviction of his
+valuable qualities, though at first unwillingly admitted, had for some
+time ceased to be repugnant to her feeling; and it was now heightened
+into somewhat of a friendlier nature, by the testimony so highly in
+his favour, and bringing forward his disposition in so amiable a light,
+which yesterday had produced. But above all, above respect and esteem,
+there was a motive within her of goodwill which could not be overlooked.
+It was gratitude; gratitude, not merely for having once loved her,
+but for loving her still well enough to forgive all the petulance and
+acrimony of her manner in rejecting him, and all the unjust accusations
+accompanying her rejection. He who, she had been persuaded, would avoid
+her as his greatest enemy, seemed, on this accidental meeting, most
+eager to preserve the acquaintance, and without any indelicate display
+of regard, or any peculiarity of manner, where their two selves only
+were concerned, was soliciting the good opinion of her friends, and bent
+on making her known to his sister. Such a change in a man of so much
+pride exciting not only astonishment but gratitude--for to love, ardent
+love, it must be attributed; and as such its impression on her was of a
+sort to be encouraged, as by no means unpleasing, though it could not be
+exactly defined. She respected, she esteemed, she was grateful to him,
+she felt a real interest in his welfare; and she only wanted to know how
+far she wished that welfare to depend upon herself, and how far it would
+be for the happiness of both that she should employ the power, which her
+fancy told her she still possessed, of bringing on her the renewal of
+his addresses.
+
+It had been settled in the evening between the aunt and the niece, that
+such a striking civility as Miss Darcy’s in coming to see them on the
+very day of her arrival at Pemberley, for she had reached it only to a
+late breakfast, ought to be imitated, though it could not be equalled,
+by some exertion of politeness on their side; and, consequently, that
+it would be highly expedient to wait on her at Pemberley the following
+morning. They were, therefore, to go. Elizabeth was pleased; though when
+she asked herself the reason, she had very little to say in reply.
+
+Mr. Gardiner left them soon after breakfast. The fishing scheme had been
+renewed the day before, and a positive engagement made of his meeting
+some of the gentlemen at Pemberley before noon.
+
+
+
+Chapter 45
+
+
+Convinced as Elizabeth now was that Miss Bingley’s dislike of her had
+originated in jealousy, she could not help feeling how unwelcome her
+appearance at Pemberley must be to her, and was curious to know with how
+much civility on that lady’s side the acquaintance would now be renewed.
+
+On reaching the house, they were shown through the hall into the saloon,
+whose northern aspect rendered it delightful for summer. Its windows
+opening to the ground, admitted a most refreshing view of the high woody
+hills behind the house, and of the beautiful oaks and Spanish chestnuts
+which were scattered over the intermediate lawn.
+
+In this house they were received by Miss Darcy, who was sitting there
+with Mrs. Hurst and Miss Bingley, and the lady with whom she lived in
+London. Georgiana’s reception of them was very civil, but attended with
+all the embarrassment which, though proceeding from shyness and the fear
+of doing wrong, would easily give to those who felt themselves inferior
+the belief of her being proud and reserved. Mrs. Gardiner and her niece,
+however, did her justice, and pitied her.
+
+By Mrs. Hurst and Miss Bingley they were noticed only by a curtsey; and,
+on their being seated, a pause, awkward as such pauses must always be,
+succeeded for a few moments. It was first broken by Mrs. Annesley, a
+genteel, agreeable-looking woman, whose endeavour to introduce some kind
+of discourse proved her to be more truly well-bred than either of the
+others; and between her and Mrs. Gardiner, with occasional help from
+Elizabeth, the conversation was carried on. Miss Darcy looked as if she
+wished for courage enough to join in it; and sometimes did venture a
+short sentence when there was least danger of its being heard.
+
+Elizabeth soon saw that she was herself closely watched by Miss Bingley,
+and that she could not speak a word, especially to Miss Darcy, without
+calling her attention. This observation would not have prevented her
+from trying to talk to the latter, had they not been seated at an
+inconvenient distance; but she was not sorry to be spared the necessity
+of saying much. Her own thoughts were employing her. She expected every
+moment that some of the gentlemen would enter the room. She wished, she
+feared that the master of the house might be amongst them; and whether
+she wished or feared it most, she could scarcely determine. After
+sitting in this manner a quarter of an hour without hearing Miss
+Bingley’s voice, Elizabeth was roused by receiving from her a cold
+inquiry after the health of her family. She answered with equal
+indifference and brevity, and the other said no more.
+
+The next variation which their visit afforded was produced by the
+entrance of servants with cold meat, cake, and a variety of all the
+finest fruits in season; but this did not take place till after many
+a significant look and smile from Mrs. Annesley to Miss Darcy had been
+given, to remind her of her post. There was now employment for the whole
+party--for though they could not all talk, they could all eat; and the
+beautiful pyramids of grapes, nectarines, and peaches soon collected
+them round the table.
+
+While thus engaged, Elizabeth had a fair opportunity of deciding whether
+she most feared or wished for the appearance of Mr. Darcy, by the
+feelings which prevailed on his entering the room; and then, though but
+a moment before she had believed her wishes to predominate, she began to
+regret that he came.
+
+He had been some time with Mr. Gardiner, who, with two or three other
+gentlemen from the house, was engaged by the river, and had left him
+only on learning that the ladies of the family intended a visit to
+Georgiana that morning. No sooner did he appear than Elizabeth wisely
+resolved to be perfectly easy and unembarrassed; a resolution the more
+necessary to be made, but perhaps not the more easily kept, because she
+saw that the suspicions of the whole party were awakened against them,
+and that there was scarcely an eye which did not watch his behaviour
+when he first came into the room. In no countenance was attentive
+curiosity so strongly marked as in Miss Bingley’s, in spite of the
+smiles which overspread her face whenever she spoke to one of its
+objects; for jealousy had not yet made her desperate, and her attentions
+to Mr. Darcy were by no means over. Miss Darcy, on her brother’s
+entrance, exerted herself much more to talk, and Elizabeth saw that he
+was anxious for his sister and herself to get acquainted, and forwarded
+as much as possible, every attempt at conversation on either side. Miss
+Bingley saw all this likewise; and, in the imprudence of anger, took the
+first opportunity of saying, with sneering civility:
+
+“Pray, Miss Eliza, are not the ----shire Militia removed from Meryton?
+They must be a great loss to _your_ family.”
+
+In Darcy’s presence she dared not mention Wickham’s name; but Elizabeth
+instantly comprehended that he was uppermost in her thoughts; and the
+various recollections connected with him gave her a moment’s distress;
+but exerting herself vigorously to repel the ill-natured attack, she
+presently answered the question in a tolerably detached tone. While
+she spoke, an involuntary glance showed her Darcy, with a heightened
+complexion, earnestly looking at her, and his sister overcome with
+confusion, and unable to lift up her eyes. Had Miss Bingley known what
+pain she was then giving her beloved friend, she undoubtedly would
+have refrained from the hint; but she had merely intended to discompose
+Elizabeth by bringing forward the idea of a man to whom she believed
+her partial, to make her betray a sensibility which might injure her in
+Darcy’s opinion, and, perhaps, to remind the latter of all the follies
+and absurdities by which some part of her family were connected
+with that corps. Not a syllable had ever reached her of Miss Darcy’s
+meditated elopement. To no creature had it been revealed, where secrecy
+was possible, except to Elizabeth; and from all Bingley’s connections
+her brother was particularly anxious to conceal it, from the very
+wish which Elizabeth had long ago attributed to him, of their becoming
+hereafter her own. He had certainly formed such a plan, and without
+meaning that it should affect his endeavour to separate him from Miss
+Bennet, it is probable that it might add something to his lively concern
+for the welfare of his friend.
+
+Elizabeth’s collected behaviour, however, soon quieted his emotion; and
+as Miss Bingley, vexed and disappointed, dared not approach nearer to
+Wickham, Georgiana also recovered in time, though not enough to be able
+to speak any more. Her brother, whose eye she feared to meet, scarcely
+recollected her interest in the affair, and the very circumstance which
+had been designed to turn his thoughts from Elizabeth seemed to have
+fixed them on her more and more cheerfully.
+
+Their visit did not continue long after the question and answer above
+mentioned; and while Mr. Darcy was attending them to their carriage Miss
+Bingley was venting her feelings in criticisms on Elizabeth’s person,
+behaviour, and dress. But Georgiana would not join her. Her brother’s
+recommendation was enough to ensure her favour; his judgement could not
+err. And he had spoken in such terms of Elizabeth as to leave Georgiana
+without the power of finding her otherwise than lovely and amiable. When
+Darcy returned to the saloon, Miss Bingley could not help repeating to
+him some part of what she had been saying to his sister.
+
+“How very ill Miss Eliza Bennet looks this morning, Mr. Darcy,” she
+cried; “I never in my life saw anyone so much altered as she is since
+the winter. She is grown so brown and coarse! Louisa and I were agreeing
+that we should not have known her again.”
+
+However little Mr. Darcy might have liked such an address, he contented
+himself with coolly replying that he perceived no other alteration than
+her being rather tanned, no miraculous consequence of travelling in the
+summer.
+
+“For my own part,” she rejoined, “I must confess that I never could
+see any beauty in her. Her face is too thin; her complexion has no
+brilliancy; and her features are not at all handsome. Her nose
+wants character--there is nothing marked in its lines. Her teeth are
+tolerable, but not out of the common way; and as for her eyes,
+which have sometimes been called so fine, I could never see anything
+extraordinary in them. They have a sharp, shrewish look, which I do
+not like at all; and in her air altogether there is a self-sufficiency
+without fashion, which is intolerable.”
+
+Persuaded as Miss Bingley was that Darcy admired Elizabeth, this was not
+the best method of recommending herself; but angry people are not always
+wise; and in seeing him at last look somewhat nettled, she had all the
+success she expected. He was resolutely silent, however, and, from a
+determination of making him speak, she continued:
+
+“I remember, when we first knew her in Hertfordshire, how amazed we all
+were to find that she was a reputed beauty; and I particularly recollect
+your saying one night, after they had been dining at Netherfield, ‘_She_
+a beauty!--I should as soon call her mother a wit.’ But afterwards she
+seemed to improve on you, and I believe you thought her rather pretty at
+one time.”
+
+“Yes,” replied Darcy, who could contain himself no longer, “but _that_
+was only when I first saw her, for it is many months since I have
+considered her as one of the handsomest women of my acquaintance.”
+
+He then went away, and Miss Bingley was left to all the satisfaction of
+having forced him to say what gave no one any pain but herself.
+
+Mrs. Gardiner and Elizabeth talked of all that had occurred during their
+visit, as they returned, except what had particularly interested them
+both. The look and behaviour of everybody they had seen were discussed,
+except of the person who had mostly engaged their attention. They talked
+of his sister, his friends, his house, his fruit--of everything but
+himself; yet Elizabeth was longing to know what Mrs. Gardiner thought of
+him, and Mrs. Gardiner would have been highly gratified by her niece’s
+beginning the subject.
+
+
+
+Chapter 46
+
+
+Elizabeth had been a good deal disappointed in not finding a letter from
+Jane on their first arrival at Lambton; and this disappointment had been
+renewed on each of the mornings that had now been spent there; but
+on the third her repining was over, and her sister justified, by the
+receipt of two letters from her at once, on one of which was marked that
+it had been missent elsewhere. Elizabeth was not surprised at it, as
+Jane had written the direction remarkably ill.
+
+They had just been preparing to walk as the letters came in; and
+her uncle and aunt, leaving her to enjoy them in quiet, set off by
+themselves. The one missent must first be attended to; it had been
+written five days ago. The beginning contained an account of all their
+little parties and engagements, with such news as the country afforded;
+but the latter half, which was dated a day later, and written in evident
+agitation, gave more important intelligence. It was to this effect:
+
+“Since writing the above, dearest Lizzy, something has occurred of a
+most unexpected and serious nature; but I am afraid of alarming you--be
+assured that we are all well. What I have to say relates to poor Lydia.
+An express came at twelve last night, just as we were all gone to bed,
+from Colonel Forster, to inform us that she was gone off to Scotland
+with one of his officers; to own the truth, with Wickham! Imagine our
+surprise. To Kitty, however, it does not seem so wholly unexpected. I am
+very, very sorry. So imprudent a match on both sides! But I am willing
+to hope the best, and that his character has been misunderstood.
+Thoughtless and indiscreet I can easily believe him, but this step
+(and let us rejoice over it) marks nothing bad at heart. His choice is
+disinterested at least, for he must know my father can give her nothing.
+Our poor mother is sadly grieved. My father bears it better. How
+thankful am I that we never let them know what has been said against
+him; we must forget it ourselves. They were off Saturday night about
+twelve, as is conjectured, but were not missed till yesterday morning at
+eight. The express was sent off directly. My dear Lizzy, they must have
+passed within ten miles of us. Colonel Forster gives us reason to expect
+him here soon. Lydia left a few lines for his wife, informing her of
+their intention. I must conclude, for I cannot be long from my poor
+mother. I am afraid you will not be able to make it out, but I hardly
+know what I have written.”
+
+Without allowing herself time for consideration, and scarcely knowing
+what she felt, Elizabeth on finishing this letter instantly seized the
+other, and opening it with the utmost impatience, read as follows: it
+had been written a day later than the conclusion of the first.
+
+“By this time, my dearest sister, you have received my hurried letter; I
+wish this may be more intelligible, but though not confined for time, my
+head is so bewildered that I cannot answer for being coherent. Dearest
+Lizzy, I hardly know what I would write, but I have bad news for you,
+and it cannot be delayed. Imprudent as the marriage between Mr. Wickham
+and our poor Lydia would be, we are now anxious to be assured it has
+taken place, for there is but too much reason to fear they are not gone
+to Scotland. Colonel Forster came yesterday, having left Brighton the
+day before, not many hours after the express. Though Lydia’s short
+letter to Mrs. F. gave them to understand that they were going to Gretna
+Green, something was dropped by Denny expressing his belief that W.
+never intended to go there, or to marry Lydia at all, which was
+repeated to Colonel F., who, instantly taking the alarm, set off from B.
+intending to trace their route. He did trace them easily to Clapham,
+but no further; for on entering that place, they removed into a hackney
+coach, and dismissed the chaise that brought them from Epsom. All that
+is known after this is, that they were seen to continue the London road.
+I know not what to think. After making every possible inquiry on that
+side London, Colonel F. came on into Hertfordshire, anxiously renewing
+them at all the turnpikes, and at the inns in Barnet and Hatfield, but
+without any success--no such people had been seen to pass through. With
+the kindest concern he came on to Longbourn, and broke his apprehensions
+to us in a manner most creditable to his heart. I am sincerely grieved
+for him and Mrs. F., but no one can throw any blame on them. Our
+distress, my dear Lizzy, is very great. My father and mother believe the
+worst, but I cannot think so ill of him. Many circumstances might make
+it more eligible for them to be married privately in town than to pursue
+their first plan; and even if _he_ could form such a design against a
+young woman of Lydia’s connections, which is not likely, can I suppose
+her so lost to everything? Impossible! I grieve to find, however, that
+Colonel F. is not disposed to depend upon their marriage; he shook his
+head when I expressed my hopes, and said he feared W. was not a man to
+be trusted. My poor mother is really ill, and keeps her room. Could she
+exert herself, it would be better; but this is not to be expected. And
+as to my father, I never in my life saw him so affected. Poor Kitty has
+anger for having concealed their attachment; but as it was a matter of
+confidence, one cannot wonder. I am truly glad, dearest Lizzy, that you
+have been spared something of these distressing scenes; but now, as the
+first shock is over, shall I own that I long for your return? I am not
+so selfish, however, as to press for it, if inconvenient. Adieu! I
+take up my pen again to do what I have just told you I would not; but
+circumstances are such that I cannot help earnestly begging you all to
+come here as soon as possible. I know my dear uncle and aunt so well,
+that I am not afraid of requesting it, though I have still something
+more to ask of the former. My father is going to London with Colonel
+Forster instantly, to try to discover her. What he means to do I am sure
+I know not; but his excessive distress will not allow him to pursue any
+measure in the best and safest way, and Colonel Forster is obliged to
+be at Brighton again to-morrow evening. In such an exigence, my
+uncle’s advice and assistance would be everything in the world; he will
+immediately comprehend what I must feel, and I rely upon his goodness.”
+
+“Oh! where, where is my uncle?” cried Elizabeth, darting from her seat
+as she finished the letter, in eagerness to follow him, without losing
+a moment of the time so precious; but as she reached the door it was
+opened by a servant, and Mr. Darcy appeared. Her pale face and impetuous
+manner made him start, and before he could recover himself to speak,
+she, in whose mind every idea was superseded by Lydia’s situation,
+hastily exclaimed, “I beg your pardon, but I must leave you. I must find
+Mr. Gardiner this moment, on business that cannot be delayed; I have not
+an instant to lose.”
+
+“Good God! what is the matter?” cried he, with more feeling than
+politeness; then recollecting himself, “I will not detain you a minute;
+but let me, or let the servant go after Mr. and Mrs. Gardiner. You are
+not well enough; you cannot go yourself.”
+
+Elizabeth hesitated, but her knees trembled under her and she felt how
+little would be gained by her attempting to pursue them. Calling back
+the servant, therefore, she commissioned him, though in so breathless
+an accent as made her almost unintelligible, to fetch his master and
+mistress home instantly.
+
+On his quitting the room she sat down, unable to support herself, and
+looking so miserably ill, that it was impossible for Darcy to leave her,
+or to refrain from saying, in a tone of gentleness and commiseration,
+“Let me call your maid. Is there nothing you could take to give you
+present relief? A glass of wine; shall I get you one? You are very ill.”
+
+“No, I thank you,” she replied, endeavouring to recover herself. “There
+is nothing the matter with me. I am quite well; I am only distressed by
+some dreadful news which I have just received from Longbourn.”
+
+She burst into tears as she alluded to it, and for a few minutes could
+not speak another word. Darcy, in wretched suspense, could only say
+something indistinctly of his concern, and observe her in compassionate
+silence. At length she spoke again. “I have just had a letter from Jane,
+with such dreadful news. It cannot be concealed from anyone. My younger
+sister has left all her friends--has eloped; has thrown herself into
+the power of--of Mr. Wickham. They are gone off together from Brighton.
+_You_ know him too well to doubt the rest. She has no money, no
+connections, nothing that can tempt him to--she is lost for ever.”
+
+Darcy was fixed in astonishment. “When I consider,” she added in a yet
+more agitated voice, “that I might have prevented it! I, who knew what
+he was. Had I but explained some part of it only--some part of what I
+learnt, to my own family! Had his character been known, this could not
+have happened. But it is all--all too late now.”
+
+“I am grieved indeed,” cried Darcy; “grieved--shocked. But is it
+certain--absolutely certain?”
+
+“Oh, yes! They left Brighton together on Sunday night, and were traced
+almost to London, but not beyond; they are certainly not gone to
+Scotland.”
+
+“And what has been done, what has been attempted, to recover her?”
+
+“My father is gone to London, and Jane has written to beg my uncle’s
+immediate assistance; and we shall be off, I hope, in half-an-hour. But
+nothing can be done--I know very well that nothing can be done. How is
+such a man to be worked on? How are they even to be discovered? I have
+not the smallest hope. It is every way horrible!”
+
+Darcy shook his head in silent acquiescence.
+
+“When _my_ eyes were opened to his real character--Oh! had I known what
+I ought, what I dared to do! But I knew not--I was afraid of doing too
+much. Wretched, wretched mistake!”
+
+Darcy made no answer. He seemed scarcely to hear her, and was walking
+up and down the room in earnest meditation, his brow contracted, his air
+gloomy. Elizabeth soon observed, and instantly understood it. Her
+power was sinking; everything _must_ sink under such a proof of family
+weakness, such an assurance of the deepest disgrace. She could neither
+wonder nor condemn, but the belief of his self-conquest brought nothing
+consolatory to her bosom, afforded no palliation of her distress. It
+was, on the contrary, exactly calculated to make her understand her own
+wishes; and never had she so honestly felt that she could have loved
+him, as now, when all love must be vain.
+
+But self, though it would intrude, could not engross her. Lydia--the
+humiliation, the misery she was bringing on them all, soon swallowed
+up every private care; and covering her face with her handkerchief,
+Elizabeth was soon lost to everything else; and, after a pause of
+several minutes, was only recalled to a sense of her situation by
+the voice of her companion, who, in a manner which, though it spoke
+compassion, spoke likewise restraint, said, “I am afraid you have been
+long desiring my absence, nor have I anything to plead in excuse of my
+stay, but real, though unavailing concern. Would to Heaven that anything
+could be either said or done on my part that might offer consolation to
+such distress! But I will not torment you with vain wishes, which may
+seem purposely to ask for your thanks. This unfortunate affair will, I
+fear, prevent my sister’s having the pleasure of seeing you at Pemberley
+to-day.”
+
+“Oh, yes. Be so kind as to apologise for us to Miss Darcy. Say that
+urgent business calls us home immediately. Conceal the unhappy truth as
+long as it is possible, I know it cannot be long.”
+
+He readily assured her of his secrecy; again expressed his sorrow for
+her distress, wished it a happier conclusion than there was at present
+reason to hope, and leaving his compliments for her relations, with only
+one serious, parting look, went away.
+
+As he quitted the room, Elizabeth felt how improbable it was that they
+should ever see each other again on such terms of cordiality as
+had marked their several meetings in Derbyshire; and as she threw a
+retrospective glance over the whole of their acquaintance, so full
+of contradictions and varieties, sighed at the perverseness of those
+feelings which would now have promoted its continuance, and would
+formerly have rejoiced in its termination.
+
+If gratitude and esteem are good foundations of affection, Elizabeth’s
+change of sentiment will be neither improbable nor faulty. But if
+otherwise--if regard springing from such sources is unreasonable or
+unnatural, in comparison of what is so often described as arising on
+a first interview with its object, and even before two words have been
+exchanged, nothing can be said in her defence, except that she had given
+somewhat of a trial to the latter method in her partiality for Wickham,
+and that its ill success might, perhaps, authorise her to seek the other
+less interesting mode of attachment. Be that as it may, she saw him
+go with regret; and in this early example of what Lydia’s infamy must
+produce, found additional anguish as she reflected on that wretched
+business. Never, since reading Jane’s second letter, had she entertained
+a hope of Wickham’s meaning to marry her. No one but Jane, she thought,
+could flatter herself with such an expectation. Surprise was the least
+of her feelings on this development. While the contents of the first
+letter remained in her mind, she was all surprise--all astonishment that
+Wickham should marry a girl whom it was impossible he could marry
+for money; and how Lydia could ever have attached him had appeared
+incomprehensible. But now it was all too natural. For such an attachment
+as this she might have sufficient charms; and though she did not suppose
+Lydia to be deliberately engaging in an elopement without the intention
+of marriage, she had no difficulty in believing that neither her virtue
+nor her understanding would preserve her from falling an easy prey.
+
+She had never perceived, while the regiment was in Hertfordshire, that
+Lydia had any partiality for him; but she was convinced that Lydia
+wanted only encouragement to attach herself to anybody. Sometimes one
+officer, sometimes another, had been her favourite, as their attentions
+raised them in her opinion. Her affections had continually been
+fluctuating but never without an object. The mischief of neglect and
+mistaken indulgence towards such a girl--oh! how acutely did she now
+feel it!
+
+She was wild to be at home--to hear, to see, to be upon the spot to
+share with Jane in the cares that must now fall wholly upon her, in a
+family so deranged, a father absent, a mother incapable of exertion, and
+requiring constant attendance; and though almost persuaded that nothing
+could be done for Lydia, her uncle’s interference seemed of the utmost
+importance, and till he entered the room her impatience was severe. Mr.
+and Mrs. Gardiner had hurried back in alarm, supposing by the servant’s
+account that their niece was taken suddenly ill; but satisfying them
+instantly on that head, she eagerly communicated the cause of their
+summons, reading the two letters aloud, and dwelling on the postscript
+of the last with trembling energy.--Though Lydia had never been a
+favourite with them, Mr. and Mrs. Gardiner could not but be deeply
+afflicted. Not Lydia only, but all were concerned in it; and after the
+first exclamations of surprise and horror, Mr. Gardiner promised every
+assistance in his power. Elizabeth, though expecting no less, thanked
+him with tears of gratitude; and all three being actuated by one spirit,
+everything relating to their journey was speedily settled. They were to
+be off as soon as possible. “But what is to be done about Pemberley?”
+ cried Mrs. Gardiner. “John told us Mr. Darcy was here when you sent for
+us; was it so?”
+
+“Yes; and I told him we should not be able to keep our engagement.
+_That_ is all settled.”
+
+“What is all settled?” repeated the other, as she ran into her room to
+prepare. “And are they upon such terms as for her to disclose the real
+truth? Oh, that I knew how it was!”
+
+But wishes were vain, or at least could only serve to amuse her in the
+hurry and confusion of the following hour. Had Elizabeth been at leisure
+to be idle, she would have remained certain that all employment was
+impossible to one so wretched as herself; but she had her share of
+business as well as her aunt, and amongst the rest there were notes to
+be written to all their friends at Lambton, with false excuses for their
+sudden departure. An hour, however, saw the whole completed; and Mr.
+Gardiner meanwhile having settled his account at the inn, nothing
+remained to be done but to go; and Elizabeth, after all the misery of
+the morning, found herself, in a shorter space of time than she could
+have supposed, seated in the carriage, and on the road to Longbourn.
+
+
+
+Chapter 47
+
+
+“I have been thinking it over again, Elizabeth,” said her uncle, as they
+drove from the town; “and really, upon serious consideration, I am much
+more inclined than I was to judge as your eldest sister does on the
+matter. It appears to me so very unlikely that any young man should
+form such a design against a girl who is by no means unprotected or
+friendless, and who was actually staying in his colonel’s family, that I
+am strongly inclined to hope the best. Could he expect that her friends
+would not step forward? Could he expect to be noticed again by the
+regiment, after such an affront to Colonel Forster? His temptation is
+not adequate to the risk!”
+
+“Do you really think so?” cried Elizabeth, brightening up for a moment.
+
+“Upon my word,” said Mrs. Gardiner, “I begin to be of your uncle’s
+opinion. It is really too great a violation of decency, honour, and
+interest, for him to be guilty of. I cannot think so very ill of
+Wickham. Can you yourself, Lizzy, so wholly give him up, as to believe
+him capable of it?”
+
+“Not, perhaps, of neglecting his own interest; but of every other
+neglect I can believe him capable. If, indeed, it should be so! But I
+dare not hope it. Why should they not go on to Scotland if that had been
+the case?”
+
+“In the first place,” replied Mr. Gardiner, “there is no absolute proof
+that they are not gone to Scotland.”
+
+“Oh! but their removing from the chaise into a hackney coach is such
+a presumption! And, besides, no traces of them were to be found on the
+Barnet road.”
+
+“Well, then--supposing them to be in London. They may be there, though
+for the purpose of concealment, for no more exceptional purpose. It is
+not likely that money should be very abundant on either side; and it
+might strike them that they could be more economically, though less
+expeditiously, married in London than in Scotland.”
+
+“But why all this secrecy? Why any fear of detection? Why must their
+marriage be private? Oh, no, no--this is not likely. His most particular
+friend, you see by Jane’s account, was persuaded of his never intending
+to marry her. Wickham will never marry a woman without some money. He
+cannot afford it. And what claims has Lydia--what attraction has she
+beyond youth, health, and good humour that could make him, for her sake,
+forego every chance of benefiting himself by marrying well? As to what
+restraint the apprehensions of disgrace in the corps might throw on a
+dishonourable elopement with her, I am not able to judge; for I know
+nothing of the effects that such a step might produce. But as to your
+other objection, I am afraid it will hardly hold good. Lydia has
+no brothers to step forward; and he might imagine, from my father’s
+behaviour, from his indolence and the little attention he has ever
+seemed to give to what was going forward in his family, that _he_ would
+do as little, and think as little about it, as any father could do, in
+such a matter.”
+
+“But can you think that Lydia is so lost to everything but love of him
+as to consent to live with him on any terms other than marriage?”
+
+“It does seem, and it is most shocking indeed,” replied Elizabeth, with
+tears in her eyes, “that a sister’s sense of decency and virtue in such
+a point should admit of doubt. But, really, I know not what to say.
+Perhaps I am not doing her justice. But she is very young; she has never
+been taught to think on serious subjects; and for the last half-year,
+nay, for a twelvemonth--she has been given up to nothing but amusement
+and vanity. She has been allowed to dispose of her time in the most idle
+and frivolous manner, and to adopt any opinions that came in her way.
+Since the ----shire were first quartered in Meryton, nothing but love,
+flirtation, and officers have been in her head. She has been doing
+everything in her power by thinking and talking on the subject, to give
+greater--what shall I call it? susceptibility to her feelings; which are
+naturally lively enough. And we all know that Wickham has every charm of
+person and address that can captivate a woman.”
+
+“But you see that Jane,” said her aunt, “does not think so very ill of
+Wickham as to believe him capable of the attempt.”
+
+“Of whom does Jane ever think ill? And who is there, whatever might be
+their former conduct, that she would think capable of such an attempt,
+till it were proved against them? But Jane knows, as well as I do, what
+Wickham really is. We both know that he has been profligate in every
+sense of the word; that he has neither integrity nor honour; that he is
+as false and deceitful as he is insinuating.”
+
+“And do you really know all this?” cried Mrs. Gardiner, whose curiosity
+as to the mode of her intelligence was all alive.
+
+“I do indeed,” replied Elizabeth, colouring. “I told you, the other day,
+of his infamous behaviour to Mr. Darcy; and you yourself, when last at
+Longbourn, heard in what manner he spoke of the man who had behaved
+with such forbearance and liberality towards him. And there are other
+circumstances which I am not at liberty--which it is not worth while to
+relate; but his lies about the whole Pemberley family are endless. From
+what he said of Miss Darcy I was thoroughly prepared to see a proud,
+reserved, disagreeable girl. Yet he knew to the contrary himself. He
+must know that she was as amiable and unpretending as we have found
+her.”
+
+“But does Lydia know nothing of this? can she be ignorant of what you
+and Jane seem so well to understand?”
+
+“Oh, yes!--that, that is the worst of all. Till I was in Kent, and saw
+so much both of Mr. Darcy and his relation Colonel Fitzwilliam, I was
+ignorant of the truth myself. And when I returned home, the ----shire
+was to leave Meryton in a week or fortnight’s time. As that was the
+case, neither Jane, to whom I related the whole, nor I, thought it
+necessary to make our knowledge public; for of what use could
+it apparently be to any one, that the good opinion which all the
+neighbourhood had of him should then be overthrown? And even when it was
+settled that Lydia should go with Mrs. Forster, the necessity of opening
+her eyes to his character never occurred to me. That _she_ could be
+in any danger from the deception never entered my head. That such a
+consequence as _this_ could ensue, you may easily believe, was far
+enough from my thoughts.”
+
+“When they all removed to Brighton, therefore, you had no reason, I
+suppose, to believe them fond of each other?”
+
+“Not the slightest. I can remember no symptom of affection on either
+side; and had anything of the kind been perceptible, you must be aware
+that ours is not a family on which it could be thrown away. When first
+he entered the corps, she was ready enough to admire him; but so we all
+were. Every girl in or near Meryton was out of her senses about him for
+the first two months; but he never distinguished _her_ by any particular
+attention; and, consequently, after a moderate period of extravagant and
+wild admiration, her fancy for him gave way, and others of the regiment,
+who treated her with more distinction, again became her favourites.”
+
+                          * * * * *
+
+It may be easily believed, that however little of novelty could be added
+to their fears, hopes, and conjectures, on this interesting subject, by
+its repeated discussion, no other could detain them from it long, during
+the whole of the journey. From Elizabeth’s thoughts it was never absent.
+Fixed there by the keenest of all anguish, self-reproach, she could find
+no interval of ease or forgetfulness.
+
+They travelled as expeditiously as possible, and, sleeping one night
+on the road, reached Longbourn by dinner time the next day. It was a
+comfort to Elizabeth to consider that Jane could not have been wearied
+by long expectations.
+
+The little Gardiners, attracted by the sight of a chaise, were standing
+on the steps of the house as they entered the paddock; and, when the
+carriage drove up to the door, the joyful surprise that lighted up their
+faces, and displayed itself over their whole bodies, in a variety of
+capers and frisks, was the first pleasing earnest of their welcome.
+
+Elizabeth jumped out; and, after giving each of them a hasty kiss,
+hurried into the vestibule, where Jane, who came running down from her
+mother’s apartment, immediately met her.
+
+Elizabeth, as she affectionately embraced her, whilst tears filled the
+eyes of both, lost not a moment in asking whether anything had been
+heard of the fugitives.
+
+“Not yet,” replied Jane. “But now that my dear uncle is come, I hope
+everything will be well.”
+
+“Is my father in town?”
+
+“Yes, he went on Tuesday, as I wrote you word.”
+
+“And have you heard from him often?”
+
+“We have heard only twice. He wrote me a few lines on Wednesday to say
+that he had arrived in safety, and to give me his directions, which I
+particularly begged him to do. He merely added that he should not write
+again till he had something of importance to mention.”
+
+“And my mother--how is she? How are you all?”
+
+“My mother is tolerably well, I trust; though her spirits are greatly
+shaken. She is up stairs and will have great satisfaction in seeing you
+all. She does not yet leave her dressing-room. Mary and Kitty, thank
+Heaven, are quite well.”
+
+“But you--how are you?” cried Elizabeth. “You look pale. How much you
+must have gone through!”
+
+Her sister, however, assured her of her being perfectly well; and their
+conversation, which had been passing while Mr. and Mrs. Gardiner were
+engaged with their children, was now put an end to by the approach
+of the whole party. Jane ran to her uncle and aunt, and welcomed and
+thanked them both, with alternate smiles and tears.
+
+When they were all in the drawing-room, the questions which Elizabeth
+had already asked were of course repeated by the others, and they soon
+found that Jane had no intelligence to give. The sanguine hope of
+good, however, which the benevolence of her heart suggested had not yet
+deserted her; she still expected that it would all end well, and that
+every morning would bring some letter, either from Lydia or her father,
+to explain their proceedings, and, perhaps, announce their marriage.
+
+Mrs. Bennet, to whose apartment they all repaired, after a few minutes’
+conversation together, received them exactly as might be expected; with
+tears and lamentations of regret, invectives against the villainous
+conduct of Wickham, and complaints of her own sufferings and ill-usage;
+blaming everybody but the person to whose ill-judging indulgence the
+errors of her daughter must principally be owing.
+
+“If I had been able,” said she, “to carry my point in going to Brighton,
+with all my family, _this_ would not have happened; but poor dear Lydia
+had nobody to take care of her. Why did the Forsters ever let her go out
+of their sight? I am sure there was some great neglect or other on their
+side, for she is not the kind of girl to do such a thing if she had been
+well looked after. I always thought they were very unfit to have the
+charge of her; but I was overruled, as I always am. Poor dear child!
+And now here’s Mr. Bennet gone away, and I know he will fight Wickham,
+wherever he meets him and then he will be killed, and what is to become
+of us all? The Collinses will turn us out before he is cold in his
+grave, and if you are not kind to us, brother, I do not know what we
+shall do.”
+
+They all exclaimed against such terrific ideas; and Mr. Gardiner, after
+general assurances of his affection for her and all her family, told her
+that he meant to be in London the very next day, and would assist Mr.
+Bennet in every endeavour for recovering Lydia.
+
+“Do not give way to useless alarm,” added he; “though it is right to be
+prepared for the worst, there is no occasion to look on it as certain.
+It is not quite a week since they left Brighton. In a few days more we
+may gain some news of them; and till we know that they are not married,
+and have no design of marrying, do not let us give the matter over as
+lost. As soon as I get to town I shall go to my brother, and make
+him come home with me to Gracechurch Street; and then we may consult
+together as to what is to be done.”
+
+“Oh! my dear brother,” replied Mrs. Bennet, “that is exactly what I
+could most wish for. And now do, when you get to town, find them out,
+wherever they may be; and if they are not married already, _make_ them
+marry. And as for wedding clothes, do not let them wait for that, but
+tell Lydia she shall have as much money as she chooses to buy them,
+after they are married. And, above all, keep Mr. Bennet from fighting.
+Tell him what a dreadful state I am in, that I am frighted out of my
+wits--and have such tremblings, such flutterings, all over me--such
+spasms in my side and pains in my head, and such beatings at heart, that
+I can get no rest by night nor by day. And tell my dear Lydia not to
+give any directions about her clothes till she has seen me, for she does
+not know which are the best warehouses. Oh, brother, how kind you are! I
+know you will contrive it all.”
+
+But Mr. Gardiner, though he assured her again of his earnest endeavours
+in the cause, could not avoid recommending moderation to her, as well
+in her hopes as her fear; and after talking with her in this manner till
+dinner was on the table, they all left her to vent all her feelings on
+the housekeeper, who attended in the absence of her daughters.
+
+Though her brother and sister were persuaded that there was no real
+occasion for such a seclusion from the family, they did not attempt to
+oppose it, for they knew that she had not prudence enough to hold her
+tongue before the servants, while they waited at table, and judged it
+better that _one_ only of the household, and the one whom they could
+most trust should comprehend all her fears and solicitude on the
+subject.
+
+In the dining-room they were soon joined by Mary and Kitty, who had been
+too busily engaged in their separate apartments to make their appearance
+before. One came from her books, and the other from her toilette. The
+faces of both, however, were tolerably calm; and no change was visible
+in either, except that the loss of her favourite sister, or the anger
+which she had herself incurred in this business, had given more of
+fretfulness than usual to the accents of Kitty. As for Mary, she was
+mistress enough of herself to whisper to Elizabeth, with a countenance
+of grave reflection, soon after they were seated at table:
+
+“This is a most unfortunate affair, and will probably be much talked of.
+But we must stem the tide of malice, and pour into the wounded bosoms of
+each other the balm of sisterly consolation.”
+
+Then, perceiving in Elizabeth no inclination of replying, she added,
+“Unhappy as the event must be for Lydia, we may draw from it this useful
+lesson: that loss of virtue in a female is irretrievable; that one
+false step involves her in endless ruin; that her reputation is no less
+brittle than it is beautiful; and that she cannot be too much guarded in
+her behaviour towards the undeserving of the other sex.”
+
+Elizabeth lifted up her eyes in amazement, but was too much oppressed
+to make any reply. Mary, however, continued to console herself with such
+kind of moral extractions from the evil before them.
+
+In the afternoon, the two elder Miss Bennets were able to be for
+half-an-hour by themselves; and Elizabeth instantly availed herself of
+the opportunity of making any inquiries, which Jane was equally eager to
+satisfy. After joining in general lamentations over the dreadful sequel
+of this event, which Elizabeth considered as all but certain, and Miss
+Bennet could not assert to be wholly impossible, the former continued
+the subject, by saying, “But tell me all and everything about it which
+I have not already heard. Give me further particulars. What did Colonel
+Forster say? Had they no apprehension of anything before the elopement
+took place? They must have seen them together for ever.”
+
+“Colonel Forster did own that he had often suspected some partiality,
+especially on Lydia’s side, but nothing to give him any alarm. I am so
+grieved for him! His behaviour was attentive and kind to the utmost. He
+_was_ coming to us, in order to assure us of his concern, before he had
+any idea of their not being gone to Scotland: when that apprehension
+first got abroad, it hastened his journey.”
+
+“And was Denny convinced that Wickham would not marry? Did he know of
+their intending to go off? Had Colonel Forster seen Denny himself?”
+
+“Yes; but, when questioned by _him_, Denny denied knowing anything of
+their plans, and would not give his real opinion about it. He did not
+repeat his persuasion of their not marrying--and from _that_, I am
+inclined to hope, he might have been misunderstood before.”
+
+“And till Colonel Forster came himself, not one of you entertained a
+doubt, I suppose, of their being really married?”
+
+“How was it possible that such an idea should enter our brains? I felt
+a little uneasy--a little fearful of my sister’s happiness with him
+in marriage, because I knew that his conduct had not been always quite
+right. My father and mother knew nothing of that; they only felt how
+imprudent a match it must be. Kitty then owned, with a very natural
+triumph on knowing more than the rest of us, that in Lydia’s last letter
+she had prepared her for such a step. She had known, it seems, of their
+being in love with each other, many weeks.”
+
+“But not before they went to Brighton?”
+
+“No, I believe not.”
+
+“And did Colonel Forster appear to think well of Wickham himself? Does
+he know his real character?”
+
+“I must confess that he did not speak so well of Wickham as he formerly
+did. He believed him to be imprudent and extravagant. And since this sad
+affair has taken place, it is said that he left Meryton greatly in debt;
+but I hope this may be false.”
+
+“Oh, Jane, had we been less secret, had we told what we knew of him,
+this could not have happened!”
+
+“Perhaps it would have been better,” replied her sister. “But to expose
+the former faults of any person without knowing what their present
+feelings were, seemed unjustifiable. We acted with the best intentions.”
+
+“Could Colonel Forster repeat the particulars of Lydia’s note to his
+wife?”
+
+“He brought it with him for us to see.”
+
+Jane then took it from her pocket-book, and gave it to Elizabeth. These
+were the contents:
+
+“MY DEAR HARRIET,
+
+“You will laugh when you know where I am gone, and I cannot help
+laughing myself at your surprise to-morrow morning, as soon as I am
+missed. I am going to Gretna Green, and if you cannot guess with who,
+I shall think you a simpleton, for there is but one man in the world I
+love, and he is an angel. I should never be happy without him, so think
+it no harm to be off. You need not send them word at Longbourn of my
+going, if you do not like it, for it will make the surprise the greater,
+when I write to them and sign my name ‘Lydia Wickham.’ What a good joke
+it will be! I can hardly write for laughing. Pray make my excuses to
+Pratt for not keeping my engagement, and dancing with him to-night.
+Tell him I hope he will excuse me when he knows all; and tell him I will
+dance with him at the next ball we meet, with great pleasure. I shall
+send for my clothes when I get to Longbourn; but I wish you would tell
+Sally to mend a great slit in my worked muslin gown before they are
+packed up. Good-bye. Give my love to Colonel Forster. I hope you will
+drink to our good journey.
+
+“Your affectionate friend,
+
+“LYDIA BENNET.”
+
+“Oh! thoughtless, thoughtless Lydia!” cried Elizabeth when she had
+finished it. “What a letter is this, to be written at such a moment!
+But at least it shows that _she_ was serious on the subject of their
+journey. Whatever he might afterwards persuade her to, it was not on her
+side a _scheme_ of infamy. My poor father! how he must have felt it!”
+
+“I never saw anyone so shocked. He could not speak a word for full ten
+minutes. My mother was taken ill immediately, and the whole house in
+such confusion!”
+
+“Oh! Jane,” cried Elizabeth, “was there a servant belonging to it who
+did not know the whole story before the end of the day?”
+
+“I do not know. I hope there was. But to be guarded at such a time is
+very difficult. My mother was in hysterics, and though I endeavoured to
+give her every assistance in my power, I am afraid I did not do so
+much as I might have done! But the horror of what might possibly happen
+almost took from me my faculties.”
+
+“Your attendance upon her has been too much for you. You do not look
+well. Oh that I had been with you! you have had every care and anxiety
+upon yourself alone.”
+
+“Mary and Kitty have been very kind, and would have shared in every
+fatigue, I am sure; but I did not think it right for either of them.
+Kitty is slight and delicate; and Mary studies so much, that her hours
+of repose should not be broken in on. My aunt Phillips came to Longbourn
+on Tuesday, after my father went away; and was so good as to stay till
+Thursday with me. She was of great use and comfort to us all. And
+Lady Lucas has been very kind; she walked here on Wednesday morning to
+condole with us, and offered her services, or any of her daughters’, if
+they should be of use to us.”
+
+“She had better have stayed at home,” cried Elizabeth; “perhaps she
+_meant_ well, but, under such a misfortune as this, one cannot see
+too little of one’s neighbours. Assistance is impossible; condolence
+insufferable. Let them triumph over us at a distance, and be satisfied.”
+
+She then proceeded to inquire into the measures which her father had
+intended to pursue, while in town, for the recovery of his daughter.
+
+“He meant I believe,” replied Jane, “to go to Epsom, the place where
+they last changed horses, see the postilions and try if anything could
+be made out from them. His principal object must be to discover the
+number of the hackney coach which took them from Clapham. It had come
+with a fare from London; and as he thought that the circumstance of a
+gentleman and lady’s removing from one carriage into another might
+be remarked he meant to make inquiries at Clapham. If he could anyhow
+discover at what house the coachman had before set down his fare, he
+determined to make inquiries there, and hoped it might not be impossible
+to find out the stand and number of the coach. I do not know of any
+other designs that he had formed; but he was in such a hurry to be gone,
+and his spirits so greatly discomposed, that I had difficulty in finding
+out even so much as this.”
+
+
+
+Chapter 48
+
+
+The whole party were in hopes of a letter from Mr. Bennet the next
+morning, but the post came in without bringing a single line from him.
+His family knew him to be, on all common occasions, a most negligent and
+dilatory correspondent; but at such a time they had hoped for exertion.
+They were forced to conclude that he had no pleasing intelligence to
+send; but even of _that_ they would have been glad to be certain. Mr.
+Gardiner had waited only for the letters before he set off.
+
+When he was gone, they were certain at least of receiving constant
+information of what was going on, and their uncle promised, at parting,
+to prevail on Mr. Bennet to return to Longbourn, as soon as he could,
+to the great consolation of his sister, who considered it as the only
+security for her husband’s not being killed in a duel.
+
+Mrs. Gardiner and the children were to remain in Hertfordshire a few
+days longer, as the former thought her presence might be serviceable
+to her nieces. She shared in their attendance on Mrs. Bennet, and was a
+great comfort to them in their hours of freedom. Their other aunt also
+visited them frequently, and always, as she said, with the design of
+cheering and heartening them up--though, as she never came without
+reporting some fresh instance of Wickham’s extravagance or irregularity,
+she seldom went away without leaving them more dispirited than she found
+them.
+
+All Meryton seemed striving to blacken the man who, but three months
+before, had been almost an angel of light. He was declared to be in debt
+to every tradesman in the place, and his intrigues, all honoured with
+the title of seduction, had been extended into every tradesman’s family.
+Everybody declared that he was the wickedest young man in the world;
+and everybody began to find out that they had always distrusted the
+appearance of his goodness. Elizabeth, though she did not credit above
+half of what was said, believed enough to make her former assurance of
+her sister’s ruin more certain; and even Jane, who believed still less
+of it, became almost hopeless, more especially as the time was now come
+when, if they had gone to Scotland, which she had never before entirely
+despaired of, they must in all probability have gained some news of
+them.
+
+Mr. Gardiner left Longbourn on Sunday; on Tuesday his wife received a
+letter from him; it told them that, on his arrival, he had immediately
+found out his brother, and persuaded him to come to Gracechurch Street;
+that Mr. Bennet had been to Epsom and Clapham, before his arrival,
+but without gaining any satisfactory information; and that he was now
+determined to inquire at all the principal hotels in town, as Mr. Bennet
+thought it possible they might have gone to one of them, on their first
+coming to London, before they procured lodgings. Mr. Gardiner himself
+did not expect any success from this measure, but as his brother was
+eager in it, he meant to assist him in pursuing it. He added that Mr.
+Bennet seemed wholly disinclined at present to leave London and promised
+to write again very soon. There was also a postscript to this effect:
+
+“I have written to Colonel Forster to desire him to find out, if
+possible, from some of the young man’s intimates in the regiment,
+whether Wickham has any relations or connections who would be likely to
+know in what part of town he has now concealed himself. If there were
+anyone that one could apply to with a probability of gaining such a
+clue as that, it might be of essential consequence. At present we have
+nothing to guide us. Colonel Forster will, I dare say, do everything in
+his power to satisfy us on this head. But, on second thoughts, perhaps,
+Lizzy could tell us what relations he has now living, better than any
+other person.”
+
+Elizabeth was at no loss to understand from whence this deference to her
+authority proceeded; but it was not in her power to give any information
+of so satisfactory a nature as the compliment deserved. She had never
+heard of his having had any relations, except a father and mother, both
+of whom had been dead many years. It was possible, however, that some of
+his companions in the ----shire might be able to give more information;
+and though she was not very sanguine in expecting it, the application
+was a something to look forward to.
+
+Every day at Longbourn was now a day of anxiety; but the most anxious
+part of each was when the post was expected. The arrival of letters
+was the grand object of every morning’s impatience. Through letters,
+whatever of good or bad was to be told would be communicated, and every
+succeeding day was expected to bring some news of importance.
+
+But before they heard again from Mr. Gardiner, a letter arrived for
+their father, from a different quarter, from Mr. Collins; which, as Jane
+had received directions to open all that came for him in his absence,
+she accordingly read; and Elizabeth, who knew what curiosities his
+letters always were, looked over her, and read it likewise. It was as
+follows:
+
+“MY DEAR SIR,
+
+“I feel myself called upon, by our relationship, and my situation
+in life, to condole with you on the grievous affliction you are now
+suffering under, of which we were yesterday informed by a letter from
+Hertfordshire. Be assured, my dear sir, that Mrs. Collins and myself
+sincerely sympathise with you and all your respectable family, in
+your present distress, which must be of the bitterest kind, because
+proceeding from a cause which no time can remove. No arguments shall be
+wanting on my part that can alleviate so severe a misfortune--or that
+may comfort you, under a circumstance that must be of all others the
+most afflicting to a parent’s mind. The death of your daughter would
+have been a blessing in comparison of this. And it is the more to
+be lamented, because there is reason to suppose as my dear Charlotte
+informs me, that this licentiousness of behaviour in your daughter has
+proceeded from a faulty degree of indulgence; though, at the same time,
+for the consolation of yourself and Mrs. Bennet, I am inclined to think
+that her own disposition must be naturally bad, or she could not be
+guilty of such an enormity, at so early an age. Howsoever that may be,
+you are grievously to be pitied; in which opinion I am not only joined
+by Mrs. Collins, but likewise by Lady Catherine and her daughter, to
+whom I have related the affair. They agree with me in apprehending that
+this false step in one daughter will be injurious to the fortunes of
+all the others; for who, as Lady Catherine herself condescendingly says,
+will connect themselves with such a family? And this consideration leads
+me moreover to reflect, with augmented satisfaction, on a certain event
+of last November; for had it been otherwise, I must have been involved
+in all your sorrow and disgrace. Let me then advise you, dear sir, to
+console yourself as much as possible, to throw off your unworthy child
+from your affection for ever, and leave her to reap the fruits of her
+own heinous offense.
+
+“I am, dear sir, etc., etc.”
+
+Mr. Gardiner did not write again till he had received an answer from
+Colonel Forster; and then he had nothing of a pleasant nature to send.
+It was not known that Wickham had a single relationship with whom he
+kept up any connection, and it was certain that he had no near one
+living. His former acquaintances had been numerous; but since he
+had been in the militia, it did not appear that he was on terms of
+particular friendship with any of them. There was no one, therefore,
+who could be pointed out as likely to give any news of him. And in the
+wretched state of his own finances, there was a very powerful motive for
+secrecy, in addition to his fear of discovery by Lydia’s relations, for
+it had just transpired that he had left gaming debts behind him to a
+very considerable amount. Colonel Forster believed that more than a
+thousand pounds would be necessary to clear his expenses at Brighton.
+He owed a good deal in town, but his debts of honour were still more
+formidable. Mr. Gardiner did not attempt to conceal these particulars
+from the Longbourn family. Jane heard them with horror. “A gamester!”
+ she cried. “This is wholly unexpected. I had not an idea of it.”
+
+Mr. Gardiner added in his letter, that they might expect to see their
+father at home on the following day, which was Saturday. Rendered
+spiritless by the ill-success of all their endeavours, he had yielded
+to his brother-in-law’s entreaty that he would return to his family, and
+leave it to him to do whatever occasion might suggest to be advisable
+for continuing their pursuit. When Mrs. Bennet was told of this, she did
+not express so much satisfaction as her children expected, considering
+what her anxiety for his life had been before.
+
+“What, is he coming home, and without poor Lydia?” she cried. “Sure he
+will not leave London before he has found them. Who is to fight Wickham,
+and make him marry her, if he comes away?”
+
+As Mrs. Gardiner began to wish to be at home, it was settled that she
+and the children should go to London, at the same time that Mr. Bennet
+came from it. The coach, therefore, took them the first stage of their
+journey, and brought its master back to Longbourn.
+
+Mrs. Gardiner went away in all the perplexity about Elizabeth and her
+Derbyshire friend that had attended her from that part of the world. His
+name had never been voluntarily mentioned before them by her niece; and
+the kind of half-expectation which Mrs. Gardiner had formed, of their
+being followed by a letter from him, had ended in nothing. Elizabeth had
+received none since her return that could come from Pemberley.
+
+The present unhappy state of the family rendered any other excuse for
+the lowness of her spirits unnecessary; nothing, therefore, could be
+fairly conjectured from _that_, though Elizabeth, who was by this time
+tolerably well acquainted with her own feelings, was perfectly aware
+that, had she known nothing of Darcy, she could have borne the dread of
+Lydia’s infamy somewhat better. It would have spared her, she thought,
+one sleepless night out of two.
+
+When Mr. Bennet arrived, he had all the appearance of his usual
+philosophic composure. He said as little as he had ever been in the
+habit of saying; made no mention of the business that had taken him
+away, and it was some time before his daughters had courage to speak of
+it.
+
+It was not till the afternoon, when he had joined them at tea, that
+Elizabeth ventured to introduce the subject; and then, on her briefly
+expressing her sorrow for what he must have endured, he replied, “Say
+nothing of that. Who should suffer but myself? It has been my own doing,
+and I ought to feel it.”
+
+“You must not be too severe upon yourself,” replied Elizabeth.
+
+“You may well warn me against such an evil. Human nature is so prone
+to fall into it! No, Lizzy, let me once in my life feel how much I have
+been to blame. I am not afraid of being overpowered by the impression.
+It will pass away soon enough.”
+
+“Do you suppose them to be in London?”
+
+“Yes; where else can they be so well concealed?”
+
+“And Lydia used to want to go to London,” added Kitty.
+
+“She is happy then,” said her father drily; “and her residence there
+will probably be of some duration.”
+
+Then after a short silence he continued:
+
+“Lizzy, I bear you no ill-will for being justified in your advice to me
+last May, which, considering the event, shows some greatness of mind.”
+
+They were interrupted by Miss Bennet, who came to fetch her mother’s
+tea.
+
+“This is a parade,” he cried, “which does one good; it gives such an
+elegance to misfortune! Another day I will do the same; I will sit in my
+library, in my nightcap and powdering gown, and give as much trouble as
+I can; or, perhaps, I may defer it till Kitty runs away.”
+
+“I am not going to run away, papa,” said Kitty fretfully. “If I should
+ever go to Brighton, I would behave better than Lydia.”
+
+“_You_ go to Brighton. I would not trust you so near it as Eastbourne
+for fifty pounds! No, Kitty, I have at last learnt to be cautious, and
+you will feel the effects of it. No officer is ever to enter into
+my house again, nor even to pass through the village. Balls will be
+absolutely prohibited, unless you stand up with one of your sisters.
+And you are never to stir out of doors till you can prove that you have
+spent ten minutes of every day in a rational manner.”
+
+Kitty, who took all these threats in a serious light, began to cry.
+
+“Well, well,” said he, “do not make yourself unhappy. If you are a good
+girl for the next ten years, I will take you to a review at the end of
+them.”
+
+
+
+Chapter 49
+
+
+Two days after Mr. Bennet’s return, as Jane and Elizabeth were walking
+together in the shrubbery behind the house, they saw the housekeeper
+coming towards them, and, concluding that she came to call them to their
+mother, went forward to meet her; but, instead of the expected summons,
+when they approached her, she said to Miss Bennet, “I beg your pardon,
+madam, for interrupting you, but I was in hopes you might have got some
+good news from town, so I took the liberty of coming to ask.”
+
+“What do you mean, Hill? We have heard nothing from town.”
+
+“Dear madam,” cried Mrs. Hill, in great astonishment, “don’t you know
+there is an express come for master from Mr. Gardiner? He has been here
+this half-hour, and master has had a letter.”
+
+Away ran the girls, too eager to get in to have time for speech. They
+ran through the vestibule into the breakfast-room; from thence to the
+library; their father was in neither; and they were on the point of
+seeking him up stairs with their mother, when they were met by the
+butler, who said:
+
+“If you are looking for my master, ma’am, he is walking towards the
+little copse.”
+
+Upon this information, they instantly passed through the hall once
+more, and ran across the lawn after their father, who was deliberately
+pursuing his way towards a small wood on one side of the paddock.
+
+Jane, who was not so light nor so much in the habit of running as
+Elizabeth, soon lagged behind, while her sister, panting for breath,
+came up with him, and eagerly cried out:
+
+“Oh, papa, what news--what news? Have you heard from my uncle?”
+
+“Yes I have had a letter from him by express.”
+
+“Well, and what news does it bring--good or bad?”
+
+“What is there of good to be expected?” said he, taking the letter from
+his pocket. “But perhaps you would like to read it.”
+
+Elizabeth impatiently caught it from his hand. Jane now came up.
+
+“Read it aloud,” said their father, “for I hardly know myself what it is
+about.”
+
+“Gracechurch Street, Monday, August 2.
+
+“MY DEAR BROTHER,
+
+“At last I am able to send you some tidings of my niece, and such as,
+upon the whole, I hope it will give you satisfaction. Soon after you
+left me on Saturday, I was fortunate enough to find out in what part of
+London they were. The particulars I reserve till we meet; it is enough
+to know they are discovered. I have seen them both--”
+
+“Then it is as I always hoped,” cried Jane; “they are married!”
+
+Elizabeth read on:
+
+“I have seen them both. They are not married, nor can I find there
+was any intention of being so; but if you are willing to perform the
+engagements which I have ventured to make on your side, I hope it will
+not be long before they are. All that is required of you is, to assure
+to your daughter, by settlement, her equal share of the five thousand
+pounds secured among your children after the decease of yourself and
+my sister; and, moreover, to enter into an engagement of allowing her,
+during your life, one hundred pounds per annum. These are conditions
+which, considering everything, I had no hesitation in complying with,
+as far as I thought myself privileged, for you. I shall send this by
+express, that no time may be lost in bringing me your answer. You
+will easily comprehend, from these particulars, that Mr. Wickham’s
+circumstances are not so hopeless as they are generally believed to be.
+The world has been deceived in that respect; and I am happy to say there
+will be some little money, even when all his debts are discharged, to
+settle on my niece, in addition to her own fortune. If, as I conclude
+will be the case, you send me full powers to act in your name throughout
+the whole of this business, I will immediately give directions to
+Haggerston for preparing a proper settlement. There will not be the
+smallest occasion for your coming to town again; therefore stay quiet at
+Longbourn, and depend on my diligence and care. Send back your answer as
+fast as you can, and be careful to write explicitly. We have judged it
+best that my niece should be married from this house, of which I hope
+you will approve. She comes to us to-day. I shall write again as soon as
+anything more is determined on. Yours, etc.,
+
+“EDW. GARDINER.”
+
+“Is it possible?” cried Elizabeth, when she had finished. “Can it be
+possible that he will marry her?”
+
+“Wickham is not so undeserving, then, as we thought him,” said her
+sister. “My dear father, I congratulate you.”
+
+“And have you answered the letter?” cried Elizabeth.
+
+“No; but it must be done soon.”
+
+Most earnestly did she then entreat him to lose no more time before he
+wrote.
+
+“Oh! my dear father,” she cried, “come back and write immediately.
+Consider how important every moment is in such a case.”
+
+“Let me write for you,” said Jane, “if you dislike the trouble
+yourself.”
+
+“I dislike it very much,” he replied; “but it must be done.”
+
+And so saying, he turned back with them, and walked towards the house.
+
+“And may I ask--” said Elizabeth; “but the terms, I suppose, must be
+complied with.”
+
+“Complied with! I am only ashamed of his asking so little.”
+
+“And they _must_ marry! Yet he is _such_ a man!”
+
+“Yes, yes, they must marry. There is nothing else to be done. But there
+are two things that I want very much to know; one is, how much money
+your uncle has laid down to bring it about; and the other, how am I ever
+to pay him.”
+
+“Money! My uncle!” cried Jane, “what do you mean, sir?”
+
+“I mean, that no man in his senses would marry Lydia on so slight a
+temptation as one hundred a year during my life, and fifty after I am
+gone.”
+
+“That is very true,” said Elizabeth; “though it had not occurred to me
+before. His debts to be discharged, and something still to remain! Oh!
+it must be my uncle’s doings! Generous, good man, I am afraid he has
+distressed himself. A small sum could not do all this.”
+
+“No,” said her father; “Wickham’s a fool if he takes her with a farthing
+less than ten thousand pounds. I should be sorry to think so ill of him,
+in the very beginning of our relationship.”
+
+“Ten thousand pounds! Heaven forbid! How is half such a sum to be
+repaid?”
+
+Mr. Bennet made no answer, and each of them, deep in thought, continued
+silent till they reached the house. Their father then went on to the
+library to write, and the girls walked into the breakfast-room.
+
+“And they are really to be married!” cried Elizabeth, as soon as they
+were by themselves. “How strange this is! And for _this_ we are to be
+thankful. That they should marry, small as is their chance of happiness,
+and wretched as is his character, we are forced to rejoice. Oh, Lydia!”
+
+“I comfort myself with thinking,” replied Jane, “that he certainly would
+not marry Lydia if he had not a real regard for her. Though our kind
+uncle has done something towards clearing him, I cannot believe that ten
+thousand pounds, or anything like it, has been advanced. He has children
+of his own, and may have more. How could he spare half ten thousand
+pounds?”
+
+“If he were ever able to learn what Wickham’s debts have been,” said
+Elizabeth, “and how much is settled on his side on our sister, we shall
+exactly know what Mr. Gardiner has done for them, because Wickham has
+not sixpence of his own. The kindness of my uncle and aunt can never
+be requited. Their taking her home, and affording her their personal
+protection and countenance, is such a sacrifice to her advantage as
+years of gratitude cannot enough acknowledge. By this time she is
+actually with them! If such goodness does not make her miserable now,
+she will never deserve to be happy! What a meeting for her, when she
+first sees my aunt!”
+
+“We must endeavour to forget all that has passed on either side,” said
+Jane: “I hope and trust they will yet be happy. His consenting to
+marry her is a proof, I will believe, that he is come to a right way of
+thinking. Their mutual affection will steady them; and I flatter myself
+they will settle so quietly, and live in so rational a manner, as may in
+time make their past imprudence forgotten.”
+
+“Their conduct has been such,” replied Elizabeth, “as neither you, nor
+I, nor anybody can ever forget. It is useless to talk of it.”
+
+It now occurred to the girls that their mother was in all likelihood
+perfectly ignorant of what had happened. They went to the library,
+therefore, and asked their father whether he would not wish them to make
+it known to her. He was writing and, without raising his head, coolly
+replied:
+
+“Just as you please.”
+
+“May we take my uncle’s letter to read to her?”
+
+“Take whatever you like, and get away.”
+
+Elizabeth took the letter from his writing-table, and they went up stairs
+together. Mary and Kitty were both with Mrs. Bennet: one communication
+would, therefore, do for all. After a slight preparation for good news,
+the letter was read aloud. Mrs. Bennet could hardly contain herself. As
+soon as Jane had read Mr. Gardiner’s hope of Lydia’s being soon
+married, her joy burst forth, and every following sentence added to its
+exuberance. She was now in an irritation as violent from delight, as she
+had ever been fidgety from alarm and vexation. To know that her daughter
+would be married was enough. She was disturbed by no fear for her
+felicity, nor humbled by any remembrance of her misconduct.
+
+“My dear, dear Lydia!” she cried. “This is delightful indeed! She will
+be married! I shall see her again! She will be married at sixteen!
+My good, kind brother! I knew how it would be. I knew he would manage
+everything! How I long to see her! and to see dear Wickham too! But the
+clothes, the wedding clothes! I will write to my sister Gardiner about
+them directly. Lizzy, my dear, run down to your father, and ask him
+how much he will give her. Stay, stay, I will go myself. Ring the bell,
+Kitty, for Hill. I will put on my things in a moment. My dear, dear
+Lydia! How merry we shall be together when we meet!”
+
+Her eldest daughter endeavoured to give some relief to the violence of
+these transports, by leading her thoughts to the obligations which Mr.
+Gardiner’s behaviour laid them all under.
+
+“For we must attribute this happy conclusion,” she added, “in a great
+measure to his kindness. We are persuaded that he has pledged himself to
+assist Mr. Wickham with money.”
+
+“Well,” cried her mother, “it is all very right; who should do it but
+her own uncle? If he had not had a family of his own, I and my children
+must have had all his money, you know; and it is the first time we have
+ever had anything from him, except a few presents. Well! I am so happy!
+In a short time I shall have a daughter married. Mrs. Wickham! How well
+it sounds! And she was only sixteen last June. My dear Jane, I am in
+such a flutter, that I am sure I can’t write; so I will dictate, and
+you write for me. We will settle with your father about the money
+afterwards; but the things should be ordered immediately.”
+
+She was then proceeding to all the particulars of calico, muslin, and
+cambric, and would shortly have dictated some very plentiful orders, had
+not Jane, though with some difficulty, persuaded her to wait till her
+father was at leisure to be consulted. One day’s delay, she observed,
+would be of small importance; and her mother was too happy to be quite
+so obstinate as usual. Other schemes, too, came into her head.
+
+“I will go to Meryton,” said she, “as soon as I am dressed, and tell the
+good, good news to my sister Philips. And as I come back, I can call
+on Lady Lucas and Mrs. Long. Kitty, run down and order the carriage.
+An airing would do me a great deal of good, I am sure. Girls, can I do
+anything for you in Meryton? Oh! Here comes Hill! My dear Hill, have you
+heard the good news? Miss Lydia is going to be married; and you shall
+all have a bowl of punch to make merry at her wedding.”
+
+Mrs. Hill began instantly to express her joy. Elizabeth received her
+congratulations amongst the rest, and then, sick of this folly, took
+refuge in her own room, that she might think with freedom.
+
+Poor Lydia’s situation must, at best, be bad enough; but that it was
+no worse, she had need to be thankful. She felt it so; and though, in
+looking forward, neither rational happiness nor worldly prosperity could
+be justly expected for her sister, in looking back to what they had
+feared, only two hours ago, she felt all the advantages of what they had
+gained.
+
+
+
+Chapter 50
+
+
+Mr. Bennet had very often wished before this period of his life that,
+instead of spending his whole income, he had laid by an annual sum for
+the better provision of his children, and of his wife, if she survived
+him. He now wished it more than ever. Had he done his duty in that
+respect, Lydia need not have been indebted to her uncle for whatever
+of honour or credit could now be purchased for her. The satisfaction of
+prevailing on one of the most worthless young men in Great Britain to be
+her husband might then have rested in its proper place.
+
+He was seriously concerned that a cause of so little advantage to anyone
+should be forwarded at the sole expense of his brother-in-law, and he
+was determined, if possible, to find out the extent of his assistance,
+and to discharge the obligation as soon as he could.
+
+When first Mr. Bennet had married, economy was held to be perfectly
+useless, for, of course, they were to have a son. The son was to join
+in cutting off the entail, as soon as he should be of age, and the widow
+and younger children would by that means be provided for. Five daughters
+successively entered the world, but yet the son was to come; and Mrs.
+Bennet, for many years after Lydia’s birth, had been certain that he
+would. This event had at last been despaired of, but it was then
+too late to be saving. Mrs. Bennet had no turn for economy, and her
+husband’s love of independence had alone prevented their exceeding their
+income.
+
+Five thousand pounds was settled by marriage articles on Mrs. Bennet and
+the children. But in what proportions it should be divided amongst the
+latter depended on the will of the parents. This was one point, with
+regard to Lydia, at least, which was now to be settled, and Mr. Bennet
+could have no hesitation in acceding to the proposal before him. In
+terms of grateful acknowledgment for the kindness of his brother,
+though expressed most concisely, he then delivered on paper his perfect
+approbation of all that was done, and his willingness to fulfil the
+engagements that had been made for him. He had never before supposed
+that, could Wickham be prevailed on to marry his daughter, it would
+be done with so little inconvenience to himself as by the present
+arrangement. He would scarcely be ten pounds a year the loser by the
+hundred that was to be paid them; for, what with her board and pocket
+allowance, and the continual presents in money which passed to her
+through her mother’s hands, Lydia’s expenses had been very little within
+that sum.
+
+That it would be done with such trifling exertion on his side, too, was
+another very welcome surprise; for his wish at present was to have as
+little trouble in the business as possible. When the first transports
+of rage which had produced his activity in seeking her were over, he
+naturally returned to all his former indolence. His letter was soon
+dispatched; for, though dilatory in undertaking business, he was quick
+in its execution. He begged to know further particulars of what he
+was indebted to his brother, but was too angry with Lydia to send any
+message to her.
+
+The good news spread quickly through the house, and with proportionate
+speed through the neighbourhood. It was borne in the latter with decent
+philosophy. To be sure, it would have been more for the advantage
+of conversation had Miss Lydia Bennet come upon the town; or, as the
+happiest alternative, been secluded from the world, in some distant
+farmhouse. But there was much to be talked of in marrying her; and the
+good-natured wishes for her well-doing which had proceeded before from
+all the spiteful old ladies in Meryton lost but a little of their spirit
+in this change of circumstances, because with such an husband her misery
+was considered certain.
+
+It was a fortnight since Mrs. Bennet had been downstairs; but on this
+happy day she again took her seat at the head of her table, and in
+spirits oppressively high. No sentiment of shame gave a damp to her
+triumph. The marriage of a daughter, which had been the first object
+of her wishes since Jane was sixteen, was now on the point of
+accomplishment, and her thoughts and her words ran wholly on those
+attendants of elegant nuptials, fine muslins, new carriages, and
+servants. She was busily searching through the neighbourhood for a
+proper situation for her daughter, and, without knowing or considering
+what their income might be, rejected many as deficient in size and
+importance.
+
+“Haye Park might do,” said she, “if the Gouldings could quit it--or the
+great house at Stoke, if the drawing-room were larger; but Ashworth is
+too far off! I could not bear to have her ten miles from me; and as for
+Pulvis Lodge, the attics are dreadful.”
+
+Her husband allowed her to talk on without interruption while the
+servants remained. But when they had withdrawn, he said to her: “Mrs.
+Bennet, before you take any or all of these houses for your son and
+daughter, let us come to a right understanding. Into _one_ house in this
+neighbourhood they shall never have admittance. I will not encourage the
+impudence of either, by receiving them at Longbourn.”
+
+A long dispute followed this declaration; but Mr. Bennet was firm. It
+soon led to another; and Mrs. Bennet found, with amazement and horror,
+that her husband would not advance a guinea to buy clothes for his
+daughter. He protested that she should receive from him no mark of
+affection whatever on the occasion. Mrs. Bennet could hardly comprehend
+it. That his anger could be carried to such a point of inconceivable
+resentment as to refuse his daughter a privilege without which her
+marriage would scarcely seem valid, exceeded all she could believe
+possible. She was more alive to the disgrace which her want of new
+clothes must reflect on her daughter’s nuptials, than to any sense of
+shame at her eloping and living with Wickham a fortnight before they
+took place.
+
+Elizabeth was now most heartily sorry that she had, from the distress of
+the moment, been led to make Mr. Darcy acquainted with their fears for
+her sister; for since her marriage would so shortly give the
+proper termination to the elopement, they might hope to conceal its
+unfavourable beginning from all those who were not immediately on the
+spot.
+
+She had no fear of its spreading farther through his means. There were
+few people on whose secrecy she would have more confidently depended;
+but, at the same time, there was no one whose knowledge of a sister’s
+frailty would have mortified her so much--not, however, from any fear
+of disadvantage from it individually to herself, for, at any rate,
+there seemed a gulf impassable between them. Had Lydia’s marriage been
+concluded on the most honourable terms, it was not to be supposed that
+Mr. Darcy would connect himself with a family where, to every other
+objection, would now be added an alliance and relationship of the
+nearest kind with a man whom he so justly scorned.
+
+From such a connection she could not wonder that he would shrink. The
+wish of procuring her regard, which she had assured herself of his
+feeling in Derbyshire, could not in rational expectation survive such a
+blow as this. She was humbled, she was grieved; she repented, though she
+hardly knew of what. She became jealous of his esteem, when she could no
+longer hope to be benefited by it. She wanted to hear of him, when there
+seemed the least chance of gaining intelligence. She was convinced that
+she could have been happy with him, when it was no longer likely they
+should meet.
+
+What a triumph for him, as she often thought, could he know that the
+proposals which she had proudly spurned only four months ago, would now
+have been most gladly and gratefully received! He was as generous, she
+doubted not, as the most generous of his sex; but while he was mortal,
+there must be a triumph.
+
+She began now to comprehend that he was exactly the man who, in
+disposition and talents, would most suit her. His understanding and
+temper, though unlike her own, would have answered all her wishes. It
+was an union that must have been to the advantage of both; by her ease
+and liveliness, his mind might have been softened, his manners improved;
+and from his judgement, information, and knowledge of the world, she
+must have received benefit of greater importance.
+
+But no such happy marriage could now teach the admiring multitude what
+connubial felicity really was. An union of a different tendency, and
+precluding the possibility of the other, was soon to be formed in their
+family.
+
+How Wickham and Lydia were to be supported in tolerable independence,
+she could not imagine. But how little of permanent happiness could
+belong to a couple who were only brought together because their passions
+were stronger than their virtue, she could easily conjecture.
+
+                          * * * * *
+
+Mr. Gardiner soon wrote again to his brother. To Mr. Bennet’s
+acknowledgments he briefly replied, with assurance of his eagerness to
+promote the welfare of any of his family; and concluded with entreaties
+that the subject might never be mentioned to him again. The principal
+purport of his letter was to inform them that Mr. Wickham had resolved
+on quitting the militia.
+
+“It was greatly my wish that he should do so,” he added, “as soon as
+his marriage was fixed on. And I think you will agree with me, in
+considering the removal from that corps as highly advisable, both on
+his account and my niece’s. It is Mr. Wickham’s intention to go into
+the regulars; and among his former friends, there are still some who
+are able and willing to assist him in the army. He has the promise of an
+ensigncy in General ----‘s regiment, now quartered in the North. It
+is an advantage to have it so far from this part of the kingdom. He
+promises fairly; and I hope among different people, where they may each
+have a character to preserve, they will both be more prudent. I have
+written to Colonel Forster, to inform him of our present arrangements,
+and to request that he will satisfy the various creditors of Mr. Wickham
+in and near Brighton, with assurances of speedy payment, for which I
+have pledged myself. And will you give yourself the trouble of carrying
+similar assurances to his creditors in Meryton, of whom I shall subjoin
+a list according to his information? He has given in all his debts; I
+hope at least he has not deceived us. Haggerston has our directions,
+and all will be completed in a week. They will then join his regiment,
+unless they are first invited to Longbourn; and I understand from Mrs.
+Gardiner, that my niece is very desirous of seeing you all before she
+leaves the South. She is well, and begs to be dutifully remembered to
+you and her mother.--Yours, etc.,
+
+“E. GARDINER.”
+
+Mr. Bennet and his daughters saw all the advantages of Wickham’s removal
+from the ----shire as clearly as Mr. Gardiner could do. But Mrs. Bennet
+was not so well pleased with it. Lydia’s being settled in the North,
+just when she had expected most pleasure and pride in her company,
+for she had by no means given up her plan of their residing in
+Hertfordshire, was a severe disappointment; and, besides, it was such a
+pity that Lydia should be taken from a regiment where she was acquainted
+with everybody, and had so many favourites.
+
+“She is so fond of Mrs. Forster,” said she, “it will be quite shocking
+to send her away! And there are several of the young men, too, that she
+likes very much. The officers may not be so pleasant in General ----‘s
+regiment.”
+
+His daughter’s request, for such it might be considered, of being
+admitted into her family again before she set off for the North,
+received at first an absolute negative. But Jane and Elizabeth,
+who agreed in wishing, for the sake of their sister’s feelings and
+consequence, that she should be noticed on her marriage by her parents,
+urged him so earnestly yet so rationally and so mildly, to receive her
+and her husband at Longbourn, as soon as they were married, that he was
+prevailed on to think as they thought, and act as they wished. And their
+mother had the satisfaction of knowing that she would be able to show
+her married daughter in the neighbourhood before she was banished to the
+North. When Mr. Bennet wrote again to his brother, therefore, he sent
+his permission for them to come; and it was settled, that as soon as
+the ceremony was over, they should proceed to Longbourn. Elizabeth was
+surprised, however, that Wickham should consent to such a scheme, and
+had she consulted only her own inclination, any meeting with him would
+have been the last object of her wishes.
+
+
+
+Chapter 51
+
+
+Their sister’s wedding day arrived; and Jane and Elizabeth felt for her
+probably more than she felt for herself. The carriage was sent to
+meet them at ----, and they were to return in it by dinner-time. Their
+arrival was dreaded by the elder Miss Bennets, and Jane more especially,
+who gave Lydia the feelings which would have attended herself, had she
+been the culprit, and was wretched in the thought of what her sister
+must endure.
+
+They came. The family were assembled in the breakfast room to receive
+them. Smiles decked the face of Mrs. Bennet as the carriage drove up to
+the door; her husband looked impenetrably grave; her daughters, alarmed,
+anxious, uneasy.
+
+Lydia’s voice was heard in the vestibule; the door was thrown open, and
+she ran into the room. Her mother stepped forwards, embraced her, and
+welcomed her with rapture; gave her hand, with an affectionate smile,
+to Wickham, who followed his lady; and wished them both joy with an
+alacrity which shewed no doubt of their happiness.
+
+Their reception from Mr. Bennet, to whom they then turned, was not quite
+so cordial. His countenance rather gained in austerity; and he scarcely
+opened his lips. The easy assurance of the young couple, indeed, was
+enough to provoke him. Elizabeth was disgusted, and even Miss Bennet
+was shocked. Lydia was Lydia still; untamed, unabashed, wild, noisy,
+and fearless. She turned from sister to sister, demanding their
+congratulations; and when at length they all sat down, looked eagerly
+round the room, took notice of some little alteration in it, and
+observed, with a laugh, that it was a great while since she had been
+there.
+
+Wickham was not at all more distressed than herself, but his manners
+were always so pleasing, that had his character and his marriage been
+exactly what they ought, his smiles and his easy address, while he
+claimed their relationship, would have delighted them all. Elizabeth had
+not before believed him quite equal to such assurance; but she sat down,
+resolving within herself to draw no limits in future to the impudence
+of an impudent man. She blushed, and Jane blushed; but the cheeks of the
+two who caused their confusion suffered no variation of colour.
+
+There was no want of discourse. The bride and her mother could neither
+of them talk fast enough; and Wickham, who happened to sit near
+Elizabeth, began inquiring after his acquaintance in that neighbourhood,
+with a good humoured ease which she felt very unable to equal in her
+replies. They seemed each of them to have the happiest memories in the
+world. Nothing of the past was recollected with pain; and Lydia led
+voluntarily to subjects which her sisters would not have alluded to for
+the world.
+
+“Only think of its being three months,” she cried, “since I went away;
+it seems but a fortnight I declare; and yet there have been things
+enough happened in the time. Good gracious! when I went away, I am sure
+I had no more idea of being married till I came back again! though I
+thought it would be very good fun if I was.”
+
+Her father lifted up his eyes. Jane was distressed. Elizabeth looked
+expressively at Lydia; but she, who never heard nor saw anything of
+which she chose to be insensible, gaily continued, “Oh! mamma, do the
+people hereabouts know I am married to-day? I was afraid they might not;
+and we overtook William Goulding in his curricle, so I was determined he
+should know it, and so I let down the side-glass next to him, and took
+off my glove, and let my hand just rest upon the window frame, so that
+he might see the ring, and then I bowed and smiled like anything.”
+
+Elizabeth could bear it no longer. She got up, and ran out of the room;
+and returned no more, till she heard them passing through the hall to
+the dining parlour. She then joined them soon enough to see Lydia, with
+anxious parade, walk up to her mother’s right hand, and hear her say
+to her eldest sister, “Ah! Jane, I take your place now, and you must go
+lower, because I am a married woman.”
+
+It was not to be supposed that time would give Lydia that embarrassment
+from which she had been so wholly free at first. Her ease and good
+spirits increased. She longed to see Mrs. Phillips, the Lucases, and
+all their other neighbours, and to hear herself called “Mrs. Wickham”
+ by each of them; and in the mean time, she went after dinner to show her
+ring, and boast of being married, to Mrs. Hill and the two housemaids.
+
+“Well, mamma,” said she, when they were all returned to the breakfast
+room, “and what do you think of my husband? Is not he a charming man? I
+am sure my sisters must all envy me. I only hope they may have half
+my good luck. They must all go to Brighton. That is the place to get
+husbands. What a pity it is, mamma, we did not all go.”
+
+“Very true; and if I had my will, we should. But my dear Lydia, I don’t
+at all like your going such a way off. Must it be so?”
+
+“Oh, lord! yes;--there is nothing in that. I shall like it of all
+things. You and papa, and my sisters, must come down and see us. We
+shall be at Newcastle all the winter, and I dare say there will be some
+balls, and I will take care to get good partners for them all.”
+
+“I should like it beyond anything!” said her mother.
+
+“And then when you go away, you may leave one or two of my sisters
+behind you; and I dare say I shall get husbands for them before the
+winter is over.”
+
+“I thank you for my share of the favour,” said Elizabeth; “but I do not
+particularly like your way of getting husbands.”
+
+Their visitors were not to remain above ten days with them. Mr. Wickham
+had received his commission before he left London, and he was to join
+his regiment at the end of a fortnight.
+
+No one but Mrs. Bennet regretted that their stay would be so short; and
+she made the most of the time by visiting about with her daughter, and
+having very frequent parties at home. These parties were acceptable to
+all; to avoid a family circle was even more desirable to such as did
+think, than such as did not.
+
+Wickham’s affection for Lydia was just what Elizabeth had expected
+to find it; not equal to Lydia’s for him. She had scarcely needed her
+present observation to be satisfied, from the reason of things, that
+their elopement had been brought on by the strength of her love, rather
+than by his; and she would have wondered why, without violently caring
+for her, he chose to elope with her at all, had she not felt certain
+that his flight was rendered necessary by distress of circumstances; and
+if that were the case, he was not the young man to resist an opportunity
+of having a companion.
+
+Lydia was exceedingly fond of him. He was her dear Wickham on every
+occasion; no one was to be put in competition with him. He did every
+thing best in the world; and she was sure he would kill more birds on
+the first of September, than any body else in the country.
+
+One morning, soon after their arrival, as she was sitting with her two
+elder sisters, she said to Elizabeth:
+
+“Lizzy, I never gave _you_ an account of my wedding, I believe. You
+were not by, when I told mamma and the others all about it. Are not you
+curious to hear how it was managed?”
+
+“No really,” replied Elizabeth; “I think there cannot be too little said
+on the subject.”
+
+“La! You are so strange! But I must tell you how it went off. We were
+married, you know, at St. Clement’s, because Wickham’s lodgings were in
+that parish. And it was settled that we should all be there by eleven
+o’clock. My uncle and aunt and I were to go together; and the others
+were to meet us at the church. Well, Monday morning came, and I was in
+such a fuss! I was so afraid, you know, that something would happen to
+put it off, and then I should have gone quite distracted. And there was
+my aunt, all the time I was dressing, preaching and talking away just as
+if she was reading a sermon. However, I did not hear above one word in
+ten, for I was thinking, you may suppose, of my dear Wickham. I longed
+to know whether he would be married in his blue coat.”
+
+“Well, and so we breakfasted at ten as usual; I thought it would never
+be over; for, by the bye, you are to understand, that my uncle and aunt
+were horrid unpleasant all the time I was with them. If you’ll believe
+me, I did not once put my foot out of doors, though I was there a
+fortnight. Not one party, or scheme, or anything. To be sure London was
+rather thin, but, however, the Little Theatre was open. Well, and so
+just as the carriage came to the door, my uncle was called away upon
+business to that horrid man Mr. Stone. And then, you know, when once
+they get together, there is no end of it. Well, I was so frightened I
+did not know what to do, for my uncle was to give me away; and if we
+were beyond the hour, we could not be married all day. But, luckily, he
+came back again in ten minutes’ time, and then we all set out. However,
+I recollected afterwards that if he had been prevented going, the
+wedding need not be put off, for Mr. Darcy might have done as well.”
+
+“Mr. Darcy!” repeated Elizabeth, in utter amazement.
+
+“Oh, yes!--he was to come there with Wickham, you know. But gracious
+me! I quite forgot! I ought not to have said a word about it. I promised
+them so faithfully! What will Wickham say? It was to be such a secret!”
+
+“If it was to be secret,” said Jane, “say not another word on the
+subject. You may depend upon my seeking no further.”
+
+“Oh! certainly,” said Elizabeth, though burning with curiosity; “we will
+ask you no questions.”
+
+“Thank you,” said Lydia, “for if you did, I should certainly tell you
+all, and then Wickham would be angry.”
+
+On such encouragement to ask, Elizabeth was forced to put it out of her
+power, by running away.
+
+But to live in ignorance on such a point was impossible; or at least
+it was impossible not to try for information. Mr. Darcy had been at
+her sister’s wedding. It was exactly a scene, and exactly among people,
+where he had apparently least to do, and least temptation to go.
+Conjectures as to the meaning of it, rapid and wild, hurried into her
+brain; but she was satisfied with none. Those that best pleased her, as
+placing his conduct in the noblest light, seemed most improbable. She
+could not bear such suspense; and hastily seizing a sheet of paper,
+wrote a short letter to her aunt, to request an explanation of what
+Lydia had dropt, if it were compatible with the secrecy which had been
+intended.
+
+“You may readily comprehend,” she added, “what my curiosity must be
+to know how a person unconnected with any of us, and (comparatively
+speaking) a stranger to our family, should have been amongst you at such
+a time. Pray write instantly, and let me understand it--unless it is,
+for very cogent reasons, to remain in the secrecy which Lydia seems
+to think necessary; and then I must endeavour to be satisfied with
+ignorance.”
+
+“Not that I _shall_, though,” she added to herself, as she finished
+the letter; “and my dear aunt, if you do not tell me in an honourable
+manner, I shall certainly be reduced to tricks and stratagems to find it
+out.”
+
+Jane’s delicate sense of honour would not allow her to speak to
+Elizabeth privately of what Lydia had let fall; Elizabeth was glad
+of it;--till it appeared whether her inquiries would receive any
+satisfaction, she had rather be without a confidante.
+
+
+
+Chapter 52
+
+
+Elizabeth had the satisfaction of receiving an answer to her letter as
+soon as she possibly could. She was no sooner in possession of it
+than, hurrying into the little copse, where she was least likely to
+be interrupted, she sat down on one of the benches and prepared to
+be happy; for the length of the letter convinced her that it did not
+contain a denial.
+
+“Gracechurch street, Sept. 6.
+
+“MY DEAR NIECE,
+
+“I have just received your letter, and shall devote this whole morning
+to answering it, as I foresee that a _little_ writing will not comprise
+what I have to tell you. I must confess myself surprised by your
+application; I did not expect it from _you_. Don’t think me angry,
+however, for I only mean to let you know that I had not imagined such
+inquiries to be necessary on _your_ side. If you do not choose to
+understand me, forgive my impertinence. Your uncle is as much surprised
+as I am--and nothing but the belief of your being a party concerned
+would have allowed him to act as he has done. But if you are really
+innocent and ignorant, I must be more explicit.
+
+“On the very day of my coming home from Longbourn, your uncle had a most
+unexpected visitor. Mr. Darcy called, and was shut up with him several
+hours. It was all over before I arrived; so my curiosity was not so
+dreadfully racked as _yours_ seems to have been. He came to tell Mr.
+Gardiner that he had found out where your sister and Mr. Wickham were,
+and that he had seen and talked with them both; Wickham repeatedly,
+Lydia once. From what I can collect, he left Derbyshire only one day
+after ourselves, and came to town with the resolution of hunting for
+them. The motive professed was his conviction of its being owing to
+himself that Wickham’s worthlessness had not been so well known as to
+make it impossible for any young woman of character to love or confide
+in him. He generously imputed the whole to his mistaken pride, and
+confessed that he had before thought it beneath him to lay his private
+actions open to the world. His character was to speak for itself. He
+called it, therefore, his duty to step forward, and endeavour to remedy
+an evil which had been brought on by himself. If he _had another_
+motive, I am sure it would never disgrace him. He had been some days
+in town, before he was able to discover them; but he had something to
+direct his search, which was more than _we_ had; and the consciousness
+of this was another reason for his resolving to follow us.
+
+“There is a lady, it seems, a Mrs. Younge, who was some time ago
+governess to Miss Darcy, and was dismissed from her charge on some cause
+of disapprobation, though he did not say what. She then took a large
+house in Edward-street, and has since maintained herself by letting
+lodgings. This Mrs. Younge was, he knew, intimately acquainted with
+Wickham; and he went to her for intelligence of him as soon as he got to
+town. But it was two or three days before he could get from her what he
+wanted. She would not betray her trust, I suppose, without bribery and
+corruption, for she really did know where her friend was to be found.
+Wickham indeed had gone to her on their first arrival in London, and had
+she been able to receive them into her house, they would have taken up
+their abode with her. At length, however, our kind friend procured the
+wished-for direction. They were in ---- street. He saw Wickham, and
+afterwards insisted on seeing Lydia. His first object with her, he
+acknowledged, had been to persuade her to quit her present disgraceful
+situation, and return to her friends as soon as they could be prevailed
+on to receive her, offering his assistance, as far as it would go. But
+he found Lydia absolutely resolved on remaining where she was. She cared
+for none of her friends; she wanted no help of his; she would not hear
+of leaving Wickham. She was sure they should be married some time or
+other, and it did not much signify when. Since such were her feelings,
+it only remained, he thought, to secure and expedite a marriage, which,
+in his very first conversation with Wickham, he easily learnt had never
+been _his_ design. He confessed himself obliged to leave the regiment,
+on account of some debts of honour, which were very pressing; and
+scrupled not to lay all the ill-consequences of Lydia’s flight on her
+own folly alone. He meant to resign his commission immediately; and as
+to his future situation, he could conjecture very little about it. He
+must go somewhere, but he did not know where, and he knew he should have
+nothing to live on.
+
+“Mr. Darcy asked him why he had not married your sister at once. Though
+Mr. Bennet was not imagined to be very rich, he would have been able
+to do something for him, and his situation must have been benefited by
+marriage. But he found, in reply to this question, that Wickham still
+cherished the hope of more effectually making his fortune by marriage in
+some other country. Under such circumstances, however, he was not likely
+to be proof against the temptation of immediate relief.
+
+“They met several times, for there was much to be discussed. Wickham of
+course wanted more than he could get; but at length was reduced to be
+reasonable.
+
+“Every thing being settled between _them_, Mr. Darcy’s next step was to
+make your uncle acquainted with it, and he first called in Gracechurch
+street the evening before I came home. But Mr. Gardiner could not be
+seen, and Mr. Darcy found, on further inquiry, that your father was
+still with him, but would quit town the next morning. He did not judge
+your father to be a person whom he could so properly consult as your
+uncle, and therefore readily postponed seeing him till after the
+departure of the former. He did not leave his name, and till the next
+day it was only known that a gentleman had called on business.
+
+“On Saturday he came again. Your father was gone, your uncle at home,
+and, as I said before, they had a great deal of talk together.
+
+“They met again on Sunday, and then _I_ saw him too. It was not all
+settled before Monday: as soon as it was, the express was sent off to
+Longbourn. But our visitor was very obstinate. I fancy, Lizzy, that
+obstinacy is the real defect of his character, after all. He has been
+accused of many faults at different times, but _this_ is the true one.
+Nothing was to be done that he did not do himself; though I am sure (and
+I do not speak it to be thanked, therefore say nothing about it), your
+uncle would most readily have settled the whole.
+
+“They battled it together for a long time, which was more than either
+the gentleman or lady concerned in it deserved. But at last your uncle
+was forced to yield, and instead of being allowed to be of use to his
+niece, was forced to put up with only having the probable credit of it,
+which went sorely against the grain; and I really believe your letter
+this morning gave him great pleasure, because it required an explanation
+that would rob him of his borrowed feathers, and give the praise where
+it was due. But, Lizzy, this must go no farther than yourself, or Jane
+at most.
+
+“You know pretty well, I suppose, what has been done for the young
+people. His debts are to be paid, amounting, I believe, to considerably
+more than a thousand pounds, another thousand in addition to her own
+settled upon _her_, and his commission purchased. The reason why all
+this was to be done by him alone, was such as I have given above. It
+was owing to him, to his reserve and want of proper consideration, that
+Wickham’s character had been so misunderstood, and consequently that he
+had been received and noticed as he was. Perhaps there was some truth
+in _this_; though I doubt whether _his_ reserve, or _anybody’s_ reserve,
+can be answerable for the event. But in spite of all this fine talking,
+my dear Lizzy, you may rest perfectly assured that your uncle would
+never have yielded, if we had not given him credit for _another
+interest_ in the affair.
+
+“When all this was resolved on, he returned again to his friends, who
+were still staying at Pemberley; but it was agreed that he should be in
+London once more when the wedding took place, and all money matters were
+then to receive the last finish.
+
+“I believe I have now told you every thing. It is a relation which
+you tell me is to give you great surprise; I hope at least it will not
+afford you any displeasure. Lydia came to us; and Wickham had constant
+admission to the house. _He_ was exactly what he had been, when I
+knew him in Hertfordshire; but I would not tell you how little I was
+satisfied with her behaviour while she staid with us, if I had not
+perceived, by Jane’s letter last Wednesday, that her conduct on coming
+home was exactly of a piece with it, and therefore what I now tell
+you can give you no fresh pain. I talked to her repeatedly in the most
+serious manner, representing to her all the wickedness of what she had
+done, and all the unhappiness she had brought on her family. If she
+heard me, it was by good luck, for I am sure she did not listen. I was
+sometimes quite provoked, but then I recollected my dear Elizabeth and
+Jane, and for their sakes had patience with her.
+
+“Mr. Darcy was punctual in his return, and as Lydia informed you,
+attended the wedding. He dined with us the next day, and was to leave
+town again on Wednesday or Thursday. Will you be very angry with me, my
+dear Lizzy, if I take this opportunity of saying (what I was never bold
+enough to say before) how much I like him. His behaviour to us has,
+in every respect, been as pleasing as when we were in Derbyshire. His
+understanding and opinions all please me; he wants nothing but a little
+more liveliness, and _that_, if he marry _prudently_, his wife may teach
+him. I thought him very sly;--he hardly ever mentioned your name. But
+slyness seems the fashion.
+
+“Pray forgive me if I have been very presuming, or at least do not
+punish me so far as to exclude me from P. I shall never be quite happy
+till I have been all round the park. A low phaeton, with a nice little
+pair of ponies, would be the very thing.
+
+“But I must write no more. The children have been wanting me this half
+hour.
+
+“Yours, very sincerely,
+
+“M. GARDINER.”
+
+The contents of this letter threw Elizabeth into a flutter of spirits,
+in which it was difficult to determine whether pleasure or pain bore the
+greatest share. The vague and unsettled suspicions which uncertainty had
+produced of what Mr. Darcy might have been doing to forward her sister’s
+match, which she had feared to encourage as an exertion of goodness too
+great to be probable, and at the same time dreaded to be just, from the
+pain of obligation, were proved beyond their greatest extent to be true!
+He had followed them purposely to town, he had taken on himself all
+the trouble and mortification attendant on such a research; in which
+supplication had been necessary to a woman whom he must abominate and
+despise, and where he was reduced to meet, frequently meet, reason
+with, persuade, and finally bribe, the man whom he always most wished to
+avoid, and whose very name it was punishment to him to pronounce. He had
+done all this for a girl whom he could neither regard nor esteem. Her
+heart did whisper that he had done it for her. But it was a hope shortly
+checked by other considerations, and she soon felt that even her vanity
+was insufficient, when required to depend on his affection for her--for
+a woman who had already refused him--as able to overcome a sentiment so
+natural as abhorrence against relationship with Wickham. Brother-in-law
+of Wickham! Every kind of pride must revolt from the connection. He had,
+to be sure, done much. She was ashamed to think how much. But he had
+given a reason for his interference, which asked no extraordinary
+stretch of belief. It was reasonable that he should feel he had been
+wrong; he had liberality, and he had the means of exercising it; and
+though she would not place herself as his principal inducement, she
+could, perhaps, believe that remaining partiality for her might assist
+his endeavours in a cause where her peace of mind must be materially
+concerned. It was painful, exceedingly painful, to know that they were
+under obligations to a person who could never receive a return. They
+owed the restoration of Lydia, her character, every thing, to him. Oh!
+how heartily did she grieve over every ungracious sensation she had ever
+encouraged, every saucy speech she had ever directed towards him. For
+herself she was humbled; but she was proud of him. Proud that in a cause
+of compassion and honour, he had been able to get the better of himself.
+She read over her aunt’s commendation of him again and again. It
+was hardly enough; but it pleased her. She was even sensible of some
+pleasure, though mixed with regret, on finding how steadfastly both she
+and her uncle had been persuaded that affection and confidence subsisted
+between Mr. Darcy and herself.
+
+She was roused from her seat, and her reflections, by some one’s
+approach; and before she could strike into another path, she was
+overtaken by Wickham.
+
+“I am afraid I interrupt your solitary ramble, my dear sister?” said he,
+as he joined her.
+
+“You certainly do,” she replied with a smile; “but it does not follow
+that the interruption must be unwelcome.”
+
+“I should be sorry indeed, if it were. We were always good friends; and
+now we are better.”
+
+“True. Are the others coming out?”
+
+“I do not know. Mrs. Bennet and Lydia are going in the carriage to
+Meryton. And so, my dear sister, I find, from our uncle and aunt, that
+you have actually seen Pemberley.”
+
+She replied in the affirmative.
+
+“I almost envy you the pleasure, and yet I believe it would be too much
+for me, or else I could take it in my way to Newcastle. And you saw the
+old housekeeper, I suppose? Poor Reynolds, she was always very fond of
+me. But of course she did not mention my name to you.”
+
+“Yes, she did.”
+
+“And what did she say?”
+
+“That you were gone into the army, and she was afraid had--not turned
+out well. At such a distance as _that_, you know, things are strangely
+misrepresented.”
+
+“Certainly,” he replied, biting his lips. Elizabeth hoped she had
+silenced him; but he soon afterwards said:
+
+“I was surprised to see Darcy in town last month. We passed each other
+several times. I wonder what he can be doing there.”
+
+“Perhaps preparing for his marriage with Miss de Bourgh,” said
+Elizabeth. “It must be something particular, to take him there at this
+time of year.”
+
+“Undoubtedly. Did you see him while you were at Lambton? I thought I
+understood from the Gardiners that you had.”
+
+“Yes; he introduced us to his sister.”
+
+“And do you like her?”
+
+“Very much.”
+
+“I have heard, indeed, that she is uncommonly improved within this year
+or two. When I last saw her, she was not very promising. I am very glad
+you liked her. I hope she will turn out well.”
+
+“I dare say she will; she has got over the most trying age.”
+
+“Did you go by the village of Kympton?”
+
+“I do not recollect that we did.”
+
+“I mention it, because it is the living which I ought to have had. A
+most delightful place!--Excellent Parsonage House! It would have suited
+me in every respect.”
+
+“How should you have liked making sermons?”
+
+“Exceedingly well. I should have considered it as part of my duty,
+and the exertion would soon have been nothing. One ought not to
+repine;--but, to be sure, it would have been such a thing for me! The
+quiet, the retirement of such a life would have answered all my ideas
+of happiness! But it was not to be. Did you ever hear Darcy mention the
+circumstance, when you were in Kent?”
+
+“I have heard from authority, which I thought _as good_, that it was
+left you conditionally only, and at the will of the present patron.”
+
+“You have. Yes, there was something in _that_; I told you so from the
+first, you may remember.”
+
+“I _did_ hear, too, that there was a time, when sermon-making was not
+so palatable to you as it seems to be at present; that you actually
+declared your resolution of never taking orders, and that the business
+had been compromised accordingly.”
+
+“You did! and it was not wholly without foundation. You may remember
+what I told you on that point, when first we talked of it.”
+
+They were now almost at the door of the house, for she had walked fast
+to get rid of him; and unwilling, for her sister’s sake, to provoke him,
+she only said in reply, with a good-humoured smile:
+
+“Come, Mr. Wickham, we are brother and sister, you know. Do not let
+us quarrel about the past. In future, I hope we shall be always of one
+mind.”
+
+She held out her hand; he kissed it with affectionate gallantry, though
+he hardly knew how to look, and they entered the house.
+
+
+
+Chapter 53
+
+
+Mr. Wickham was so perfectly satisfied with this conversation that he
+never again distressed himself, or provoked his dear sister Elizabeth,
+by introducing the subject of it; and she was pleased to find that she
+had said enough to keep him quiet.
+
+The day of his and Lydia’s departure soon came, and Mrs. Bennet was
+forced to submit to a separation, which, as her husband by no means
+entered into her scheme of their all going to Newcastle, was likely to
+continue at least a twelvemonth.
+
+“Oh! my dear Lydia,” she cried, “when shall we meet again?”
+
+“Oh, lord! I don’t know. Not these two or three years, perhaps.”
+
+“Write to me very often, my dear.”
+
+“As often as I can. But you know married women have never much time for
+writing. My sisters may write to _me_. They will have nothing else to
+do.”
+
+Mr. Wickham’s adieus were much more affectionate than his wife’s. He
+smiled, looked handsome, and said many pretty things.
+
+“He is as fine a fellow,” said Mr. Bennet, as soon as they were out of
+the house, “as ever I saw. He simpers, and smirks, and makes love to
+us all. I am prodigiously proud of him. I defy even Sir William Lucas
+himself to produce a more valuable son-in-law.”
+
+The loss of her daughter made Mrs. Bennet very dull for several days.
+
+“I often think,” said she, “that there is nothing so bad as parting with
+one’s friends. One seems so forlorn without them.”
+
+“This is the consequence, you see, Madam, of marrying a daughter,” said
+Elizabeth. “It must make you better satisfied that your other four are
+single.”
+
+“It is no such thing. Lydia does not leave me because she is married,
+but only because her husband’s regiment happens to be so far off. If
+that had been nearer, she would not have gone so soon.”
+
+But the spiritless condition which this event threw her into was shortly
+relieved, and her mind opened again to the agitation of hope, by an
+article of news which then began to be in circulation. The housekeeper
+at Netherfield had received orders to prepare for the arrival of her
+master, who was coming down in a day or two, to shoot there for several
+weeks. Mrs. Bennet was quite in the fidgets. She looked at Jane, and
+smiled and shook her head by turns.
+
+“Well, well, and so Mr. Bingley is coming down, sister,” (for Mrs.
+Phillips first brought her the news). “Well, so much the better. Not
+that I care about it, though. He is nothing to us, you know, and I am
+sure _I_ never want to see him again. But, however, he is very welcome
+to come to Netherfield, if he likes it. And who knows what _may_ happen?
+But that is nothing to us. You know, sister, we agreed long ago never to
+mention a word about it. And so, is it quite certain he is coming?”
+
+“You may depend on it,” replied the other, “for Mrs. Nicholls was in
+Meryton last night; I saw her passing by, and went out myself on purpose
+to know the truth of it; and she told me that it was certain true. He
+comes down on Thursday at the latest, very likely on Wednesday. She was
+going to the butcher’s, she told me, on purpose to order in some meat on
+Wednesday, and she has got three couple of ducks just fit to be killed.”
+
+Miss Bennet had not been able to hear of his coming without changing
+colour. It was many months since she had mentioned his name to
+Elizabeth; but now, as soon as they were alone together, she said:
+
+“I saw you look at me to-day, Lizzy, when my aunt told us of the present
+report; and I know I appeared distressed. But don’t imagine it was from
+any silly cause. I was only confused for the moment, because I felt that
+I _should_ be looked at. I do assure you that the news does not affect
+me either with pleasure or pain. I am glad of one thing, that he comes
+alone; because we shall see the less of him. Not that I am afraid of
+_myself_, but I dread other people’s remarks.”
+
+Elizabeth did not know what to make of it. Had she not seen him in
+Derbyshire, she might have supposed him capable of coming there with no
+other view than what was acknowledged; but she still thought him partial
+to Jane, and she wavered as to the greater probability of his coming
+there _with_ his friend’s permission, or being bold enough to come
+without it.
+
+“Yet it is hard,” she sometimes thought, “that this poor man cannot
+come to a house which he has legally hired, without raising all this
+speculation! I _will_ leave him to himself.”
+
+In spite of what her sister declared, and really believed to be her
+feelings in the expectation of his arrival, Elizabeth could easily
+perceive that her spirits were affected by it. They were more disturbed,
+more unequal, than she had often seen them.
+
+The subject which had been so warmly canvassed between their parents,
+about a twelvemonth ago, was now brought forward again.
+
+“As soon as ever Mr. Bingley comes, my dear,” said Mrs. Bennet, “you
+will wait on him of course.”
+
+“No, no. You forced me into visiting him last year, and promised, if I
+went to see him, he should marry one of my daughters. But it ended in
+nothing, and I will not be sent on a fool’s errand again.”
+
+His wife represented to him how absolutely necessary such an attention
+would be from all the neighbouring gentlemen, on his returning to
+Netherfield.
+
+“‘Tis an etiquette I despise,” said he. “If he wants our society,
+let him seek it. He knows where we live. I will not spend my hours
+in running after my neighbours every time they go away and come back
+again.”
+
+“Well, all I know is, that it will be abominably rude if you do not wait
+on him. But, however, that shan’t prevent my asking him to dine here, I
+am determined. We must have Mrs. Long and the Gouldings soon. That will
+make thirteen with ourselves, so there will be just room at table for
+him.”
+
+Consoled by this resolution, she was the better able to bear her
+husband’s incivility; though it was very mortifying to know that her
+neighbours might all see Mr. Bingley, in consequence of it, before
+_they_ did. As the day of his arrival drew near,--
+
+“I begin to be sorry that he comes at all,” said Jane to her sister. “It
+would be nothing; I could see him with perfect indifference, but I can
+hardly bear to hear it thus perpetually talked of. My mother means well;
+but she does not know, no one can know, how much I suffer from what she
+says. Happy shall I be, when his stay at Netherfield is over!”
+
+“I wish I could say anything to comfort you,” replied Elizabeth; “but it
+is wholly out of my power. You must feel it; and the usual satisfaction
+of preaching patience to a sufferer is denied me, because you have
+always so much.”
+
+Mr. Bingley arrived. Mrs. Bennet, through the assistance of servants,
+contrived to have the earliest tidings of it, that the period of anxiety
+and fretfulness on her side might be as long as it could. She counted
+the days that must intervene before their invitation could be sent;
+hopeless of seeing him before. But on the third morning after his
+arrival in Hertfordshire, she saw him, from her dressing-room window,
+enter the paddock and ride towards the house.
+
+Her daughters were eagerly called to partake of her joy. Jane resolutely
+kept her place at the table; but Elizabeth, to satisfy her mother, went
+to the window--she looked,--she saw Mr. Darcy with him, and sat down
+again by her sister.
+
+“There is a gentleman with him, mamma,” said Kitty; “who can it be?”
+
+“Some acquaintance or other, my dear, I suppose; I am sure I do not
+know.”
+
+“La!” replied Kitty, “it looks just like that man that used to be with
+him before. Mr. what’s-his-name. That tall, proud man.”
+
+“Good gracious! Mr. Darcy!--and so it does, I vow. Well, any friend of
+Mr. Bingley’s will always be welcome here, to be sure; but else I must
+say that I hate the very sight of him.”
+
+Jane looked at Elizabeth with surprise and concern. She knew but little
+of their meeting in Derbyshire, and therefore felt for the awkwardness
+which must attend her sister, in seeing him almost for the first time
+after receiving his explanatory letter. Both sisters were uncomfortable
+enough. Each felt for the other, and of course for themselves; and their
+mother talked on, of her dislike of Mr. Darcy, and her resolution to be
+civil to him only as Mr. Bingley’s friend, without being heard by either
+of them. But Elizabeth had sources of uneasiness which could not be
+suspected by Jane, to whom she had never yet had courage to shew Mrs.
+Gardiner’s letter, or to relate her own change of sentiment towards him.
+To Jane, he could be only a man whose proposals she had refused,
+and whose merit she had undervalued; but to her own more extensive
+information, he was the person to whom the whole family were indebted
+for the first of benefits, and whom she regarded herself with an
+interest, if not quite so tender, at least as reasonable and just as
+what Jane felt for Bingley. Her astonishment at his coming--at his
+coming to Netherfield, to Longbourn, and voluntarily seeking her again,
+was almost equal to what she had known on first witnessing his altered
+behaviour in Derbyshire.
+
+The colour which had been driven from her face, returned for half a
+minute with an additional glow, and a smile of delight added lustre to
+her eyes, as she thought for that space of time that his affection and
+wishes must still be unshaken. But she would not be secure.
+
+“Let me first see how he behaves,” said she; “it will then be early
+enough for expectation.”
+
+She sat intently at work, striving to be composed, and without daring to
+lift up her eyes, till anxious curiosity carried them to the face of
+her sister as the servant was approaching the door. Jane looked a little
+paler than usual, but more sedate than Elizabeth had expected. On the
+gentlemen’s appearing, her colour increased; yet she received them with
+tolerable ease, and with a propriety of behaviour equally free from any
+symptom of resentment or any unnecessary complaisance.
+
+Elizabeth said as little to either as civility would allow, and sat down
+again to her work, with an eagerness which it did not often command. She
+had ventured only one glance at Darcy. He looked serious, as usual; and,
+she thought, more as he had been used to look in Hertfordshire, than as
+she had seen him at Pemberley. But, perhaps he could not in her mother’s
+presence be what he was before her uncle and aunt. It was a painful, but
+not an improbable, conjecture.
+
+Bingley, she had likewise seen for an instant, and in that short period
+saw him looking both pleased and embarrassed. He was received by Mrs.
+Bennet with a degree of civility which made her two daughters ashamed,
+especially when contrasted with the cold and ceremonious politeness of
+her curtsey and address to his friend.
+
+Elizabeth, particularly, who knew that her mother owed to the latter
+the preservation of her favourite daughter from irremediable infamy,
+was hurt and distressed to a most painful degree by a distinction so ill
+applied.
+
+Darcy, after inquiring of her how Mr. and Mrs. Gardiner did, a question
+which she could not answer without confusion, said scarcely anything. He
+was not seated by her; perhaps that was the reason of his silence; but
+it had not been so in Derbyshire. There he had talked to her friends,
+when he could not to herself. But now several minutes elapsed without
+bringing the sound of his voice; and when occasionally, unable to resist
+the impulse of curiosity, she raised her eyes to his face, she as often
+found him looking at Jane as at herself, and frequently on no object but
+the ground. More thoughtfulness and less anxiety to please, than when
+they last met, were plainly expressed. She was disappointed, and angry
+with herself for being so.
+
+“Could I expect it to be otherwise!” said she. “Yet why did he come?”
+
+She was in no humour for conversation with anyone but himself; and to
+him she had hardly courage to speak.
+
+She inquired after his sister, but could do no more.
+
+“It is a long time, Mr. Bingley, since you went away,” said Mrs. Bennet.
+
+He readily agreed to it.
+
+“I began to be afraid you would never come back again. People _did_ say
+you meant to quit the place entirely at Michaelmas; but, however, I hope
+it is not true. A great many changes have happened in the neighbourhood,
+since you went away. Miss Lucas is married and settled. And one of my
+own daughters. I suppose you have heard of it; indeed, you must have
+seen it in the papers. It was in The Times and The Courier, I know;
+though it was not put in as it ought to be. It was only said, ‘Lately,
+George Wickham, Esq. to Miss Lydia Bennet,’ without there being a
+syllable said of her father, or the place where she lived, or anything.
+It was my brother Gardiner’s drawing up too, and I wonder how he came to
+make such an awkward business of it. Did you see it?”
+
+Bingley replied that he did, and made his congratulations. Elizabeth
+dared not lift up her eyes. How Mr. Darcy looked, therefore, she could
+not tell.
+
+“It is a delightful thing, to be sure, to have a daughter well married,”
+ continued her mother, “but at the same time, Mr. Bingley, it is very
+hard to have her taken such a way from me. They are gone down to
+Newcastle, a place quite northward, it seems, and there they are to stay
+I do not know how long. His regiment is there; for I suppose you have
+heard of his leaving the ----shire, and of his being gone into the
+regulars. Thank Heaven! he has _some_ friends, though perhaps not so
+many as he deserves.”
+
+Elizabeth, who knew this to be levelled at Mr. Darcy, was in such
+misery of shame, that she could hardly keep her seat. It drew from her,
+however, the exertion of speaking, which nothing else had so effectually
+done before; and she asked Bingley whether he meant to make any stay in
+the country at present. A few weeks, he believed.
+
+“When you have killed all your own birds, Mr. Bingley,” said her mother,
+“I beg you will come here, and shoot as many as you please on Mr.
+Bennet’s manor. I am sure he will be vastly happy to oblige you, and
+will save all the best of the covies for you.”
+
+Elizabeth’s misery increased, at such unnecessary, such officious
+attention! Were the same fair prospect to arise at present as had
+flattered them a year ago, every thing, she was persuaded, would be
+hastening to the same vexatious conclusion. At that instant, she felt
+that years of happiness could not make Jane or herself amends for
+moments of such painful confusion.
+
+“The first wish of my heart,” said she to herself, “is never more to
+be in company with either of them. Their society can afford no pleasure
+that will atone for such wretchedness as this! Let me never see either
+one or the other again!”
+
+Yet the misery, for which years of happiness were to offer no
+compensation, received soon afterwards material relief, from observing
+how much the beauty of her sister re-kindled the admiration of her
+former lover. When first he came in, he had spoken to her but little;
+but every five minutes seemed to be giving her more of his attention. He
+found her as handsome as she had been last year; as good natured, and
+as unaffected, though not quite so chatty. Jane was anxious that no
+difference should be perceived in her at all, and was really persuaded
+that she talked as much as ever. But her mind was so busily engaged,
+that she did not always know when she was silent.
+
+When the gentlemen rose to go away, Mrs. Bennet was mindful of her
+intended civility, and they were invited and engaged to dine at
+Longbourn in a few days time.
+
+“You are quite a visit in my debt, Mr. Bingley,” she added, “for when
+you went to town last winter, you promised to take a family dinner with
+us, as soon as you returned. I have not forgot, you see; and I assure
+you, I was very much disappointed that you did not come back and keep
+your engagement.”
+
+Bingley looked a little silly at this reflection, and said something of
+his concern at having been prevented by business. They then went away.
+
+Mrs. Bennet had been strongly inclined to ask them to stay and dine
+there that day; but, though she always kept a very good table, she did
+not think anything less than two courses could be good enough for a man
+on whom she had such anxious designs, or satisfy the appetite and pride
+of one who had ten thousand a year.
+
+
+
+Chapter 54
+
+
+As soon as they were gone, Elizabeth walked out to recover her spirits;
+or in other words, to dwell without interruption on those subjects that
+must deaden them more. Mr. Darcy’s behaviour astonished and vexed her.
+
+“Why, if he came only to be silent, grave, and indifferent,” said she,
+“did he come at all?”
+
+She could settle it in no way that gave her pleasure.
+
+“He could be still amiable, still pleasing, to my uncle and aunt, when
+he was in town; and why not to me? If he fears me, why come hither? If
+he no longer cares for me, why silent? Teasing, teasing, man! I will
+think no more about him.”
+
+Her resolution was for a short time involuntarily kept by the approach
+of her sister, who joined her with a cheerful look, which showed her
+better satisfied with their visitors, than Elizabeth.
+
+“Now,” said she, “that this first meeting is over, I feel perfectly
+easy. I know my own strength, and I shall never be embarrassed again by
+his coming. I am glad he dines here on Tuesday. It will then be publicly
+seen that, on both sides, we meet only as common and indifferent
+acquaintance.”
+
+“Yes, very indifferent indeed,” said Elizabeth, laughingly. “Oh, Jane,
+take care.”
+
+“My dear Lizzy, you cannot think me so weak, as to be in danger now?”
+
+“I think you are in very great danger of making him as much in love with
+you as ever.”
+
+                          * * * * *
+
+They did not see the gentlemen again till Tuesday; and Mrs. Bennet, in
+the meanwhile, was giving way to all the happy schemes, which the good
+humour and common politeness of Bingley, in half an hour’s visit, had
+revived.
+
+On Tuesday there was a large party assembled at Longbourn; and the two
+who were most anxiously expected, to the credit of their punctuality
+as sportsmen, were in very good time. When they repaired to the
+dining-room, Elizabeth eagerly watched to see whether Bingley would take
+the place, which, in all their former parties, had belonged to him, by
+her sister. Her prudent mother, occupied by the same ideas, forbore
+to invite him to sit by herself. On entering the room, he seemed to
+hesitate; but Jane happened to look round, and happened to smile: it was
+decided. He placed himself by her.
+
+Elizabeth, with a triumphant sensation, looked towards his friend.
+He bore it with noble indifference, and she would have imagined that
+Bingley had received his sanction to be happy, had she not seen his eyes
+likewise turned towards Mr. Darcy, with an expression of half-laughing
+alarm.
+
+His behaviour to her sister was such, during dinner time, as showed an
+admiration of her, which, though more guarded than formerly, persuaded
+Elizabeth, that if left wholly to himself, Jane’s happiness, and his
+own, would be speedily secured. Though she dared not depend upon the
+consequence, she yet received pleasure from observing his behaviour. It
+gave her all the animation that her spirits could boast; for she was in
+no cheerful humour. Mr. Darcy was almost as far from her as the table
+could divide them. He was on one side of her mother. She knew how little
+such a situation would give pleasure to either, or make either appear to
+advantage. She was not near enough to hear any of their discourse, but
+she could see how seldom they spoke to each other, and how formal and
+cold was their manner whenever they did. Her mother’s ungraciousness,
+made the sense of what they owed him more painful to Elizabeth’s mind;
+and she would, at times, have given anything to be privileged to tell
+him that his kindness was neither unknown nor unfelt by the whole of the
+family.
+
+She was in hopes that the evening would afford some opportunity of
+bringing them together; that the whole of the visit would not pass away
+without enabling them to enter into something more of conversation than
+the mere ceremonious salutation attending his entrance. Anxious
+and uneasy, the period which passed in the drawing-room, before the
+gentlemen came, was wearisome and dull to a degree that almost made her
+uncivil. She looked forward to their entrance as the point on which all
+her chance of pleasure for the evening must depend.
+
+“If he does not come to me, _then_,” said she, “I shall give him up for
+ever.”
+
+The gentlemen came; and she thought he looked as if he would have
+answered her hopes; but, alas! the ladies had crowded round the table,
+where Miss Bennet was making tea, and Elizabeth pouring out the coffee,
+in so close a confederacy that there was not a single vacancy near her
+which would admit of a chair. And on the gentlemen’s approaching, one of
+the girls moved closer to her than ever, and said, in a whisper:
+
+“The men shan’t come and part us, I am determined. We want none of them;
+do we?”
+
+Darcy had walked away to another part of the room. She followed him with
+her eyes, envied everyone to whom he spoke, had scarcely patience enough
+to help anybody to coffee; and then was enraged against herself for
+being so silly!
+
+“A man who has once been refused! How could I ever be foolish enough to
+expect a renewal of his love? Is there one among the sex, who would not
+protest against such a weakness as a second proposal to the same woman?
+There is no indignity so abhorrent to their feelings!”
+
+She was a little revived, however, by his bringing back his coffee cup
+himself; and she seized the opportunity of saying:
+
+“Is your sister at Pemberley still?”
+
+“Yes, she will remain there till Christmas.”
+
+“And quite alone? Have all her friends left her?”
+
+“Mrs. Annesley is with her. The others have been gone on to Scarborough,
+these three weeks.”
+
+She could think of nothing more to say; but if he wished to converse
+with her, he might have better success. He stood by her, however, for
+some minutes, in silence; and, at last, on the young lady’s whispering
+to Elizabeth again, he walked away.
+
+When the tea-things were removed, and the card-tables placed, the ladies
+all rose, and Elizabeth was then hoping to be soon joined by him,
+when all her views were overthrown by seeing him fall a victim to her
+mother’s rapacity for whist players, and in a few moments after seated
+with the rest of the party. She now lost every expectation of pleasure.
+They were confined for the evening at different tables, and she had
+nothing to hope, but that his eyes were so often turned towards her side
+of the room, as to make him play as unsuccessfully as herself.
+
+Mrs. Bennet had designed to keep the two Netherfield gentlemen to
+supper; but their carriage was unluckily ordered before any of the
+others, and she had no opportunity of detaining them.
+
+“Well girls,” said she, as soon as they were left to themselves, “What
+say you to the day? I think every thing has passed off uncommonly well,
+I assure you. The dinner was as well dressed as any I ever saw. The
+venison was roasted to a turn--and everybody said they never saw so
+fat a haunch. The soup was fifty times better than what we had at the
+Lucases’ last week; and even Mr. Darcy acknowledged, that the partridges
+were remarkably well done; and I suppose he has two or three French
+cooks at least. And, my dear Jane, I never saw you look in greater
+beauty. Mrs. Long said so too, for I asked her whether you did not. And
+what do you think she said besides? ‘Ah! Mrs. Bennet, we shall have her
+at Netherfield at last.’ She did indeed. I do think Mrs. Long is as good
+a creature as ever lived--and her nieces are very pretty behaved girls,
+and not at all handsome: I like them prodigiously.”
+
+Mrs. Bennet, in short, was in very great spirits; she had seen enough of
+Bingley’s behaviour to Jane, to be convinced that she would get him at
+last; and her expectations of advantage to her family, when in a happy
+humour, were so far beyond reason, that she was quite disappointed at
+not seeing him there again the next day, to make his proposals.
+
+“It has been a very agreeable day,” said Miss Bennet to Elizabeth. “The
+party seemed so well selected, so suitable one with the other. I hope we
+may often meet again.”
+
+Elizabeth smiled.
+
+“Lizzy, you must not do so. You must not suspect me. It mortifies me.
+I assure you that I have now learnt to enjoy his conversation as an
+agreeable and sensible young man, without having a wish beyond it. I am
+perfectly satisfied, from what his manners now are, that he never had
+any design of engaging my affection. It is only that he is blessed
+with greater sweetness of address, and a stronger desire of generally
+pleasing, than any other man.”
+
+“You are very cruel,” said her sister, “you will not let me smile, and
+are provoking me to it every moment.”
+
+“How hard it is in some cases to be believed!”
+
+“And how impossible in others!”
+
+“But why should you wish to persuade me that I feel more than I
+acknowledge?”
+
+“That is a question which I hardly know how to answer. We all love to
+instruct, though we can teach only what is not worth knowing. Forgive
+me; and if you persist in indifference, do not make me your confidante.”
+
+
+
+Chapter 55
+
+
+A few days after this visit, Mr. Bingley called again, and alone. His
+friend had left him that morning for London, but was to return home in
+ten days time. He sat with them above an hour, and was in remarkably
+good spirits. Mrs. Bennet invited him to dine with them; but, with many
+expressions of concern, he confessed himself engaged elsewhere.
+
+“Next time you call,” said she, “I hope we shall be more lucky.”
+
+He should be particularly happy at any time, etc. etc.; and if she would
+give him leave, would take an early opportunity of waiting on them.
+
+“Can you come to-morrow?”
+
+Yes, he had no engagement at all for to-morrow; and her invitation was
+accepted with alacrity.
+
+He came, and in such very good time that the ladies were none of them
+dressed. In ran Mrs. Bennet to her daughter’s room, in her dressing
+gown, and with her hair half finished, crying out:
+
+“My dear Jane, make haste and hurry down. He is come--Mr. Bingley is
+come. He is, indeed. Make haste, make haste. Here, Sarah, come to Miss
+Bennet this moment, and help her on with her gown. Never mind Miss
+Lizzy’s hair.”
+
+“We will be down as soon as we can,” said Jane; “but I dare say Kitty is
+forwarder than either of us, for she went up stairs half an hour ago.”
+
+“Oh! hang Kitty! what has she to do with it? Come be quick, be quick!
+Where is your sash, my dear?”
+
+But when her mother was gone, Jane would not be prevailed on to go down
+without one of her sisters.
+
+The same anxiety to get them by themselves was visible again in the
+evening. After tea, Mr. Bennet retired to the library, as was his
+custom, and Mary went up stairs to her instrument. Two obstacles of
+the five being thus removed, Mrs. Bennet sat looking and winking at
+Elizabeth and Catherine for a considerable time, without making any
+impression on them. Elizabeth would not observe her; and when at last
+Kitty did, she very innocently said, “What is the matter mamma? What do
+you keep winking at me for? What am I to do?”
+
+“Nothing child, nothing. I did not wink at you.” She then sat still
+five minutes longer; but unable to waste such a precious occasion, she
+suddenly got up, and saying to Kitty, “Come here, my love, I want to
+speak to you,” took her out of the room. Jane instantly gave a look
+at Elizabeth which spoke her distress at such premeditation, and her
+entreaty that _she_ would not give in to it. In a few minutes, Mrs.
+Bennet half-opened the door and called out:
+
+“Lizzy, my dear, I want to speak with you.”
+
+Elizabeth was forced to go.
+
+“We may as well leave them by themselves you know;” said her mother, as
+soon as she was in the hall. “Kitty and I are going up stairs to sit in
+my dressing-room.”
+
+Elizabeth made no attempt to reason with her mother, but remained
+quietly in the hall, till she and Kitty were out of sight, then returned
+into the drawing-room.
+
+Mrs. Bennet’s schemes for this day were ineffectual. Bingley was every
+thing that was charming, except the professed lover of her daughter. His
+ease and cheerfulness rendered him a most agreeable addition to their
+evening party; and he bore with the ill-judged officiousness of the
+mother, and heard all her silly remarks with a forbearance and command
+of countenance particularly grateful to the daughter.
+
+He scarcely needed an invitation to stay supper; and before he went
+away, an engagement was formed, chiefly through his own and Mrs.
+Bennet’s means, for his coming next morning to shoot with her husband.
+
+After this day, Jane said no more of her indifference. Not a word passed
+between the sisters concerning Bingley; but Elizabeth went to bed in
+the happy belief that all must speedily be concluded, unless Mr. Darcy
+returned within the stated time. Seriously, however, she felt tolerably
+persuaded that all this must have taken place with that gentleman’s
+concurrence.
+
+Bingley was punctual to his appointment; and he and Mr. Bennet spent
+the morning together, as had been agreed on. The latter was much more
+agreeable than his companion expected. There was nothing of presumption
+or folly in Bingley that could provoke his ridicule, or disgust him into
+silence; and he was more communicative, and less eccentric, than the
+other had ever seen him. Bingley of course returned with him to dinner;
+and in the evening Mrs. Bennet’s invention was again at work to get
+every body away from him and her daughter. Elizabeth, who had a letter
+to write, went into the breakfast room for that purpose soon after tea;
+for as the others were all going to sit down to cards, she could not be
+wanted to counteract her mother’s schemes.
+
+But on returning to the drawing-room, when her letter was finished, she
+saw, to her infinite surprise, there was reason to fear that her mother
+had been too ingenious for her. On opening the door, she perceived her
+sister and Bingley standing together over the hearth, as if engaged in
+earnest conversation; and had this led to no suspicion, the faces of
+both, as they hastily turned round and moved away from each other, would
+have told it all. Their situation was awkward enough; but _hers_ she
+thought was still worse. Not a syllable was uttered by either; and
+Elizabeth was on the point of going away again, when Bingley, who as
+well as the other had sat down, suddenly rose, and whispering a few
+words to her sister, ran out of the room.
+
+Jane could have no reserves from Elizabeth, where confidence would give
+pleasure; and instantly embracing her, acknowledged, with the liveliest
+emotion, that she was the happiest creature in the world.
+
+“‘Tis too much!” she added, “by far too much. I do not deserve it. Oh!
+why is not everybody as happy?”
+
+Elizabeth’s congratulations were given with a sincerity, a warmth,
+a delight, which words could but poorly express. Every sentence of
+kindness was a fresh source of happiness to Jane. But she would not
+allow herself to stay with her sister, or say half that remained to be
+said for the present.
+
+“I must go instantly to my mother;” she cried. “I would not on any
+account trifle with her affectionate solicitude; or allow her to hear it
+from anyone but myself. He is gone to my father already. Oh! Lizzy, to
+know that what I have to relate will give such pleasure to all my dear
+family! how shall I bear so much happiness!”
+
+She then hastened away to her mother, who had purposely broken up the
+card party, and was sitting up stairs with Kitty.
+
+Elizabeth, who was left by herself, now smiled at the rapidity and ease
+with which an affair was finally settled, that had given them so many
+previous months of suspense and vexation.
+
+“And this,” said she, “is the end of all his friend’s anxious
+circumspection! of all his sister’s falsehood and contrivance! the
+happiest, wisest, most reasonable end!”
+
+In a few minutes she was joined by Bingley, whose conference with her
+father had been short and to the purpose.
+
+“Where is your sister?” said he hastily, as he opened the door.
+
+“With my mother up stairs. She will be down in a moment, I dare say.”
+
+He then shut the door, and, coming up to her, claimed the good wishes
+and affection of a sister. Elizabeth honestly and heartily expressed
+her delight in the prospect of their relationship. They shook hands with
+great cordiality; and then, till her sister came down, she had to listen
+to all he had to say of his own happiness, and of Jane’s perfections;
+and in spite of his being a lover, Elizabeth really believed all his
+expectations of felicity to be rationally founded, because they had for
+basis the excellent understanding, and super-excellent disposition of
+Jane, and a general similarity of feeling and taste between her and
+himself.
+
+It was an evening of no common delight to them all; the satisfaction of
+Miss Bennet’s mind gave a glow of such sweet animation to her face, as
+made her look handsomer than ever. Kitty simpered and smiled, and hoped
+her turn was coming soon. Mrs. Bennet could not give her consent or
+speak her approbation in terms warm enough to satisfy her feelings,
+though she talked to Bingley of nothing else for half an hour; and when
+Mr. Bennet joined them at supper, his voice and manner plainly showed
+how really happy he was.
+
+Not a word, however, passed his lips in allusion to it, till their
+visitor took his leave for the night; but as soon as he was gone, he
+turned to his daughter, and said:
+
+“Jane, I congratulate you. You will be a very happy woman.”
+
+Jane went to him instantly, kissed him, and thanked him for his
+goodness.
+
+“You are a good girl;” he replied, “and I have great pleasure in
+thinking you will be so happily settled. I have not a doubt of your
+doing very well together. Your tempers are by no means unlike. You are
+each of you so complying, that nothing will ever be resolved on; so
+easy, that every servant will cheat you; and so generous, that you will
+always exceed your income.”
+
+“I hope not so. Imprudence or thoughtlessness in money matters would be
+unpardonable in me.”
+
+“Exceed their income! My dear Mr. Bennet,” cried his wife, “what are you
+talking of? Why, he has four or five thousand a year, and very likely
+more.” Then addressing her daughter, “Oh! my dear, dear Jane, I am so
+happy! I am sure I shan’t get a wink of sleep all night. I knew how it
+would be. I always said it must be so, at last. I was sure you could not
+be so beautiful for nothing! I remember, as soon as ever I saw him, when
+he first came into Hertfordshire last year, I thought how likely it was
+that you should come together. Oh! he is the handsomest young man that
+ever was seen!”
+
+Wickham, Lydia, were all forgotten. Jane was beyond competition her
+favourite child. At that moment, she cared for no other. Her younger
+sisters soon began to make interest with her for objects of happiness
+which she might in future be able to dispense.
+
+Mary petitioned for the use of the library at Netherfield; and Kitty
+begged very hard for a few balls there every winter.
+
+Bingley, from this time, was of course a daily visitor at Longbourn;
+coming frequently before breakfast, and always remaining till after
+supper; unless when some barbarous neighbour, who could not be enough
+detested, had given him an invitation to dinner which he thought himself
+obliged to accept.
+
+Elizabeth had now but little time for conversation with her sister; for
+while he was present, Jane had no attention to bestow on anyone else;
+but she found herself considerably useful to both of them in those hours
+of separation that must sometimes occur. In the absence of Jane, he
+always attached himself to Elizabeth, for the pleasure of talking of
+her; and when Bingley was gone, Jane constantly sought the same means of
+relief.
+
+“He has made me so happy,” said she, one evening, “by telling me that he
+was totally ignorant of my being in town last spring! I had not believed
+it possible.”
+
+“I suspected as much,” replied Elizabeth. “But how did he account for
+it?”
+
+“It must have been his sister’s doing. They were certainly no friends to
+his acquaintance with me, which I cannot wonder at, since he might have
+chosen so much more advantageously in many respects. But when they see,
+as I trust they will, that their brother is happy with me, they will
+learn to be contented, and we shall be on good terms again; though we
+can never be what we once were to each other.”
+
+“That is the most unforgiving speech,” said Elizabeth, “that I ever
+heard you utter. Good girl! It would vex me, indeed, to see you again
+the dupe of Miss Bingley’s pretended regard.”
+
+“Would you believe it, Lizzy, that when he went to town last November,
+he really loved me, and nothing but a persuasion of _my_ being
+indifferent would have prevented his coming down again!”
+
+“He made a little mistake to be sure; but it is to the credit of his
+modesty.”
+
+This naturally introduced a panegyric from Jane on his diffidence, and
+the little value he put on his own good qualities. Elizabeth was pleased
+to find that he had not betrayed the interference of his friend; for,
+though Jane had the most generous and forgiving heart in the world, she
+knew it was a circumstance which must prejudice her against him.
+
+“I am certainly the most fortunate creature that ever existed!” cried
+Jane. “Oh! Lizzy, why am I thus singled from my family, and blessed
+above them all! If I could but see _you_ as happy! If there _were_ but
+such another man for you!”
+
+“If you were to give me forty such men, I never could be so happy as
+you. Till I have your disposition, your goodness, I never can have your
+happiness. No, no, let me shift for myself; and, perhaps, if I have very
+good luck, I may meet with another Mr. Collins in time.”
+
+The situation of affairs in the Longbourn family could not be long a
+secret. Mrs. Bennet was privileged to whisper it to Mrs. Phillips,
+and she ventured, without any permission, to do the same by all her
+neighbours in Meryton.
+
+The Bennets were speedily pronounced to be the luckiest family in the
+world, though only a few weeks before, when Lydia had first run away,
+they had been generally proved to be marked out for misfortune.
+
+
+
+Chapter 56
+
+
+One morning, about a week after Bingley’s engagement with Jane had been
+formed, as he and the females of the family were sitting together in the
+dining-room, their attention was suddenly drawn to the window, by the
+sound of a carriage; and they perceived a chaise and four driving up
+the lawn. It was too early in the morning for visitors, and besides, the
+equipage did not answer to that of any of their neighbours. The horses
+were post; and neither the carriage, nor the livery of the servant who
+preceded it, were familiar to them. As it was certain, however, that
+somebody was coming, Bingley instantly prevailed on Miss Bennet to avoid
+the confinement of such an intrusion, and walk away with him into the
+shrubbery. They both set off, and the conjectures of the remaining three
+continued, though with little satisfaction, till the door was thrown
+open and their visitor entered. It was Lady Catherine de Bourgh.
+
+They were of course all intending to be surprised; but their
+astonishment was beyond their expectation; and on the part of Mrs.
+Bennet and Kitty, though she was perfectly unknown to them, even
+inferior to what Elizabeth felt.
+
+She entered the room with an air more than usually ungracious, made no
+other reply to Elizabeth’s salutation than a slight inclination of the
+head, and sat down without saying a word. Elizabeth had mentioned her
+name to her mother on her ladyship’s entrance, though no request of
+introduction had been made.
+
+Mrs. Bennet, all amazement, though flattered by having a guest of such
+high importance, received her with the utmost politeness. After sitting
+for a moment in silence, she said very stiffly to Elizabeth,
+
+“I hope you are well, Miss Bennet. That lady, I suppose, is your
+mother.”
+
+Elizabeth replied very concisely that she was.
+
+“And _that_ I suppose is one of your sisters.”
+
+“Yes, madam,” said Mrs. Bennet, delighted to speak to Lady Catherine.
+“She is my youngest girl but one. My youngest of all is lately married,
+and my eldest is somewhere about the grounds, walking with a young man
+who, I believe, will soon become a part of the family.”
+
+“You have a very small park here,” returned Lady Catherine after a short
+silence.
+
+“It is nothing in comparison of Rosings, my lady, I dare say; but I
+assure you it is much larger than Sir William Lucas’s.”
+
+“This must be a most inconvenient sitting room for the evening, in
+summer; the windows are full west.”
+
+Mrs. Bennet assured her that they never sat there after dinner, and then
+added:
+
+“May I take the liberty of asking your ladyship whether you left Mr. and
+Mrs. Collins well.”
+
+“Yes, very well. I saw them the night before last.”
+
+Elizabeth now expected that she would produce a letter for her from
+Charlotte, as it seemed the only probable motive for her calling. But no
+letter appeared, and she was completely puzzled.
+
+Mrs. Bennet, with great civility, begged her ladyship to take some
+refreshment; but Lady Catherine very resolutely, and not very politely,
+declined eating anything; and then, rising up, said to Elizabeth,
+
+“Miss Bennet, there seemed to be a prettyish kind of a little wilderness
+on one side of your lawn. I should be glad to take a turn in it, if you
+will favour me with your company.”
+
+“Go, my dear,” cried her mother, “and show her ladyship about the
+different walks. I think she will be pleased with the hermitage.”
+
+Elizabeth obeyed, and running into her own room for her parasol,
+attended her noble guest downstairs. As they passed through the
+hall, Lady Catherine opened the doors into the dining-parlour and
+drawing-room, and pronouncing them, after a short survey, to be decent
+looking rooms, walked on.
+
+Her carriage remained at the door, and Elizabeth saw that her
+waiting-woman was in it. They proceeded in silence along the gravel walk
+that led to the copse; Elizabeth was determined to make no effort for
+conversation with a woman who was now more than usually insolent and
+disagreeable.
+
+“How could I ever think her like her nephew?” said she, as she looked in
+her face.
+
+As soon as they entered the copse, Lady Catherine began in the following
+manner:--
+
+“You can be at no loss, Miss Bennet, to understand the reason of my
+journey hither. Your own heart, your own conscience, must tell you why I
+come.”
+
+Elizabeth looked with unaffected astonishment.
+
+“Indeed, you are mistaken, Madam. I have not been at all able to account
+for the honour of seeing you here.”
+
+“Miss Bennet,” replied her ladyship, in an angry tone, “you ought to
+know, that I am not to be trifled with. But however insincere _you_ may
+choose to be, you shall not find _me_ so. My character has ever been
+celebrated for its sincerity and frankness, and in a cause of such
+moment as this, I shall certainly not depart from it. A report of a most
+alarming nature reached me two days ago. I was told that not only your
+sister was on the point of being most advantageously married, but that
+you, that Miss Elizabeth Bennet, would, in all likelihood, be soon
+afterwards united to my nephew, my own nephew, Mr. Darcy. Though I
+_know_ it must be a scandalous falsehood, though I would not injure him
+so much as to suppose the truth of it possible, I instantly resolved
+on setting off for this place, that I might make my sentiments known to
+you.”
+
+“If you believed it impossible to be true,” said Elizabeth, colouring
+with astonishment and disdain, “I wonder you took the trouble of coming
+so far. What could your ladyship propose by it?”
+
+“At once to insist upon having such a report universally contradicted.”
+
+“Your coming to Longbourn, to see me and my family,” said Elizabeth
+coolly, “will be rather a confirmation of it; if, indeed, such a report
+is in existence.”
+
+“If! Do you then pretend to be ignorant of it? Has it not been
+industriously circulated by yourselves? Do you not know that such a
+report is spread abroad?”
+
+“I never heard that it was.”
+
+“And can you likewise declare, that there is no foundation for it?”
+
+“I do not pretend to possess equal frankness with your ladyship. You may
+ask questions which I shall not choose to answer.”
+
+“This is not to be borne. Miss Bennet, I insist on being satisfied. Has
+he, has my nephew, made you an offer of marriage?”
+
+“Your ladyship has declared it to be impossible.”
+
+“It ought to be so; it must be so, while he retains the use of his
+reason. But your arts and allurements may, in a moment of infatuation,
+have made him forget what he owes to himself and to all his family. You
+may have drawn him in.”
+
+“If I have, I shall be the last person to confess it.”
+
+“Miss Bennet, do you know who I am? I have not been accustomed to such
+language as this. I am almost the nearest relation he has in the world,
+and am entitled to know all his dearest concerns.”
+
+“But you are not entitled to know mine; nor will such behaviour as this,
+ever induce me to be explicit.”
+
+“Let me be rightly understood. This match, to which you have the
+presumption to aspire, can never take place. No, never. Mr. Darcy is
+engaged to my daughter. Now what have you to say?”
+
+“Only this; that if he is so, you can have no reason to suppose he will
+make an offer to me.”
+
+Lady Catherine hesitated for a moment, and then replied:
+
+“The engagement between them is of a peculiar kind. From their infancy,
+they have been intended for each other. It was the favourite wish of
+_his_ mother, as well as of hers. While in their cradles, we planned
+the union: and now, at the moment when the wishes of both sisters would
+be accomplished in their marriage, to be prevented by a young woman of
+inferior birth, of no importance in the world, and wholly unallied to
+the family! Do you pay no regard to the wishes of his friends? To his
+tacit engagement with Miss de Bourgh? Are you lost to every feeling of
+propriety and delicacy? Have you not heard me say that from his earliest
+hours he was destined for his cousin?”
+
+“Yes, and I had heard it before. But what is that to me? If there is
+no other objection to my marrying your nephew, I shall certainly not
+be kept from it by knowing that his mother and aunt wished him to
+marry Miss de Bourgh. You both did as much as you could in planning the
+marriage. Its completion depended on others. If Mr. Darcy is neither
+by honour nor inclination confined to his cousin, why is not he to make
+another choice? And if I am that choice, why may not I accept him?”
+
+“Because honour, decorum, prudence, nay, interest, forbid it. Yes,
+Miss Bennet, interest; for do not expect to be noticed by his family or
+friends, if you wilfully act against the inclinations of all. You will
+be censured, slighted, and despised, by everyone connected with him.
+Your alliance will be a disgrace; your name will never even be mentioned
+by any of us.”
+
+“These are heavy misfortunes,” replied Elizabeth. “But the wife of Mr.
+Darcy must have such extraordinary sources of happiness necessarily
+attached to her situation, that she could, upon the whole, have no cause
+to repine.”
+
+“Obstinate, headstrong girl! I am ashamed of you! Is this your gratitude
+for my attentions to you last spring? Is nothing due to me on that
+score? Let us sit down. You are to understand, Miss Bennet, that I came
+here with the determined resolution of carrying my purpose; nor will
+I be dissuaded from it. I have not been used to submit to any person’s
+whims. I have not been in the habit of brooking disappointment.”
+
+“_That_ will make your ladyship’s situation at present more pitiable;
+but it will have no effect on me.”
+
+“I will not be interrupted. Hear me in silence. My daughter and my
+nephew are formed for each other. They are descended, on the maternal
+side, from the same noble line; and, on the father’s, from respectable,
+honourable, and ancient--though untitled--families. Their fortune on
+both sides is splendid. They are destined for each other by the voice of
+every member of their respective houses; and what is to divide them?
+The upstart pretensions of a young woman without family, connections,
+or fortune. Is this to be endured! But it must not, shall not be. If you
+were sensible of your own good, you would not wish to quit the sphere in
+which you have been brought up.”
+
+“In marrying your nephew, I should not consider myself as quitting that
+sphere. He is a gentleman; I am a gentleman’s daughter; so far we are
+equal.”
+
+“True. You _are_ a gentleman’s daughter. But who was your mother?
+Who are your uncles and aunts? Do not imagine me ignorant of their
+condition.”
+
+“Whatever my connections may be,” said Elizabeth, “if your nephew does
+not object to them, they can be nothing to _you_.”
+
+“Tell me once for all, are you engaged to him?”
+
+Though Elizabeth would not, for the mere purpose of obliging Lady
+Catherine, have answered this question, she could not but say, after a
+moment’s deliberation:
+
+“I am not.”
+
+Lady Catherine seemed pleased.
+
+“And will you promise me, never to enter into such an engagement?”
+
+“I will make no promise of the kind.”
+
+“Miss Bennet I am shocked and astonished. I expected to find a more
+reasonable young woman. But do not deceive yourself into a belief that
+I will ever recede. I shall not go away till you have given me the
+assurance I require.”
+
+“And I certainly _never_ shall give it. I am not to be intimidated into
+anything so wholly unreasonable. Your ladyship wants Mr. Darcy to marry
+your daughter; but would my giving you the wished-for promise make their
+marriage at all more probable? Supposing him to be attached to me, would
+my refusing to accept his hand make him wish to bestow it on his cousin?
+Allow me to say, Lady Catherine, that the arguments with which you have
+supported this extraordinary application have been as frivolous as the
+application was ill-judged. You have widely mistaken my character, if
+you think I can be worked on by such persuasions as these. How far your
+nephew might approve of your interference in his affairs, I cannot tell;
+but you have certainly no right to concern yourself in mine. I must beg,
+therefore, to be importuned no farther on the subject.”
+
+“Not so hasty, if you please. I have by no means done. To all the
+objections I have already urged, I have still another to add. I am
+no stranger to the particulars of your youngest sister’s infamous
+elopement. I know it all; that the young man’s marrying her was a
+patched-up business, at the expence of your father and uncles. And is
+such a girl to be my nephew’s sister? Is her husband, is the son of his
+late father’s steward, to be his brother? Heaven and earth!--of what are
+you thinking? Are the shades of Pemberley to be thus polluted?”
+
+“You can now have nothing further to say,” she resentfully answered.
+“You have insulted me in every possible method. I must beg to return to
+the house.”
+
+And she rose as she spoke. Lady Catherine rose also, and they turned
+back. Her ladyship was highly incensed.
+
+“You have no regard, then, for the honour and credit of my nephew!
+Unfeeling, selfish girl! Do you not consider that a connection with you
+must disgrace him in the eyes of everybody?”
+
+“Lady Catherine, I have nothing further to say. You know my sentiments.”
+
+“You are then resolved to have him?”
+
+“I have said no such thing. I am only resolved to act in that manner,
+which will, in my own opinion, constitute my happiness, without
+reference to _you_, or to any person so wholly unconnected with me.”
+
+“It is well. You refuse, then, to oblige me. You refuse to obey the
+claims of duty, honour, and gratitude. You are determined to ruin him in
+the opinion of all his friends, and make him the contempt of the world.”
+
+“Neither duty, nor honour, nor gratitude,” replied Elizabeth, “have any
+possible claim on me, in the present instance. No principle of either
+would be violated by my marriage with Mr. Darcy. And with regard to the
+resentment of his family, or the indignation of the world, if the former
+_were_ excited by his marrying me, it would not give me one moment’s
+concern--and the world in general would have too much sense to join in
+the scorn.”
+
+“And this is your real opinion! This is your final resolve! Very well.
+I shall now know how to act. Do not imagine, Miss Bennet, that your
+ambition will ever be gratified. I came to try you. I hoped to find you
+reasonable; but, depend upon it, I will carry my point.”
+
+In this manner Lady Catherine talked on, till they were at the door of
+the carriage, when, turning hastily round, she added, “I take no leave
+of you, Miss Bennet. I send no compliments to your mother. You deserve
+no such attention. I am most seriously displeased.”
+
+Elizabeth made no answer; and without attempting to persuade her
+ladyship to return into the house, walked quietly into it herself. She
+heard the carriage drive away as she proceeded up stairs. Her mother
+impatiently met her at the door of the dressing-room, to ask why Lady
+Catherine would not come in again and rest herself.
+
+“She did not choose it,” said her daughter, “she would go.”
+
+“She is a very fine-looking woman! and her calling here was prodigiously
+civil! for she only came, I suppose, to tell us the Collinses were
+well. She is on her road somewhere, I dare say, and so, passing through
+Meryton, thought she might as well call on you. I suppose she had
+nothing particular to say to you, Lizzy?”
+
+Elizabeth was forced to give into a little falsehood here; for to
+acknowledge the substance of their conversation was impossible.
+
+
+
+Chapter 57
+
+
+The discomposure of spirits which this extraordinary visit threw
+Elizabeth into, could not be easily overcome; nor could she, for many
+hours, learn to think of it less than incessantly. Lady Catherine, it
+appeared, had actually taken the trouble of this journey from Rosings,
+for the sole purpose of breaking off her supposed engagement with Mr.
+Darcy. It was a rational scheme, to be sure! but from what the report
+of their engagement could originate, Elizabeth was at a loss to imagine;
+till she recollected that _his_ being the intimate friend of Bingley,
+and _her_ being the sister of Jane, was enough, at a time when the
+expectation of one wedding made everybody eager for another, to supply
+the idea. She had not herself forgotten to feel that the marriage of her
+sister must bring them more frequently together. And her neighbours
+at Lucas Lodge, therefore (for through their communication with the
+Collinses, the report, she concluded, had reached Lady Catherine), had
+only set that down as almost certain and immediate, which she had looked
+forward to as possible at some future time.
+
+In revolving Lady Catherine’s expressions, however, she could not help
+feeling some uneasiness as to the possible consequence of her persisting
+in this interference. From what she had said of her resolution to
+prevent their marriage, it occurred to Elizabeth that she must meditate
+an application to her nephew; and how _he_ might take a similar
+representation of the evils attached to a connection with her, she dared
+not pronounce. She knew not the exact degree of his affection for his
+aunt, or his dependence on her judgment, but it was natural to suppose
+that he thought much higher of her ladyship than _she_ could do; and it
+was certain that, in enumerating the miseries of a marriage with _one_,
+whose immediate connections were so unequal to his own, his aunt would
+address him on his weakest side. With his notions of dignity, he would
+probably feel that the arguments, which to Elizabeth had appeared weak
+and ridiculous, contained much good sense and solid reasoning.
+
+If he had been wavering before as to what he should do, which had often
+seemed likely, the advice and entreaty of so near a relation might
+settle every doubt, and determine him at once to be as happy as dignity
+unblemished could make him. In that case he would return no more. Lady
+Catherine might see him in her way through town; and his engagement to
+Bingley of coming again to Netherfield must give way.
+
+“If, therefore, an excuse for not keeping his promise should come to his
+friend within a few days,” she added, “I shall know how to understand
+it. I shall then give over every expectation, every wish of his
+constancy. If he is satisfied with only regretting me, when he might
+have obtained my affections and hand, I shall soon cease to regret him
+at all.”
+
+                          * * * * *
+
+The surprise of the rest of the family, on hearing who their visitor had
+been, was very great; but they obligingly satisfied it, with the same
+kind of supposition which had appeased Mrs. Bennet’s curiosity; and
+Elizabeth was spared from much teasing on the subject.
+
+The next morning, as she was going downstairs, she was met by her
+father, who came out of his library with a letter in his hand.
+
+“Lizzy,” said he, “I was going to look for you; come into my room.”
+
+She followed him thither; and her curiosity to know what he had to
+tell her was heightened by the supposition of its being in some manner
+connected with the letter he held. It suddenly struck her that it
+might be from Lady Catherine; and she anticipated with dismay all the
+consequent explanations.
+
+She followed her father to the fire place, and they both sat down. He
+then said,
+
+“I have received a letter this morning that has astonished me
+exceedingly. As it principally concerns yourself, you ought to know its
+contents. I did not know before, that I had two daughters on the brink
+of matrimony. Let me congratulate you on a very important conquest.”
+
+The colour now rushed into Elizabeth’s cheeks in the instantaneous
+conviction of its being a letter from the nephew, instead of the aunt;
+and she was undetermined whether most to be pleased that he explained
+himself at all, or offended that his letter was not rather addressed to
+herself; when her father continued:
+
+“You look conscious. Young ladies have great penetration in such matters
+as these; but I think I may defy even _your_ sagacity, to discover the
+name of your admirer. This letter is from Mr. Collins.”
+
+“From Mr. Collins! and what can _he_ have to say?”
+
+“Something very much to the purpose of course. He begins with
+congratulations on the approaching nuptials of my eldest daughter, of
+which, it seems, he has been told by some of the good-natured, gossiping
+Lucases. I shall not sport with your impatience, by reading what he says
+on that point. What relates to yourself, is as follows: ‘Having thus
+offered you the sincere congratulations of Mrs. Collins and myself on
+this happy event, let me now add a short hint on the subject of another;
+of which we have been advertised by the same authority. Your daughter
+Elizabeth, it is presumed, will not long bear the name of Bennet, after
+her elder sister has resigned it, and the chosen partner of her fate may
+be reasonably looked up to as one of the most illustrious personages in
+this land.’
+
+“Can you possibly guess, Lizzy, who is meant by this? ‘This young
+gentleman is blessed, in a peculiar way, with every thing the heart of
+mortal can most desire,--splendid property, noble kindred, and extensive
+patronage. Yet in spite of all these temptations, let me warn my cousin
+Elizabeth, and yourself, of what evils you may incur by a precipitate
+closure with this gentleman’s proposals, which, of course, you will be
+inclined to take immediate advantage of.’
+
+“Have you any idea, Lizzy, who this gentleman is? But now it comes out:
+
+“‘My motive for cautioning you is as follows. We have reason to imagine
+that his aunt, Lady Catherine de Bourgh, does not look on the match with
+a friendly eye.’
+
+“_Mr. Darcy_, you see, is the man! Now, Lizzy, I think I _have_
+surprised you. Could he, or the Lucases, have pitched on any man within
+the circle of our acquaintance, whose name would have given the lie
+more effectually to what they related? Mr. Darcy, who never looks at any
+woman but to see a blemish, and who probably never looked at you in his
+life! It is admirable!”
+
+Elizabeth tried to join in her father’s pleasantry, but could only force
+one most reluctant smile. Never had his wit been directed in a manner so
+little agreeable to her.
+
+“Are you not diverted?”
+
+“Oh! yes. Pray read on.”
+
+“‘After mentioning the likelihood of this marriage to her ladyship last
+night, she immediately, with her usual condescension, expressed what she
+felt on the occasion; when it became apparent, that on the score of some
+family objections on the part of my cousin, she would never give her
+consent to what she termed so disgraceful a match. I thought it my duty
+to give the speediest intelligence of this to my cousin, that she and
+her noble admirer may be aware of what they are about, and not run
+hastily into a marriage which has not been properly sanctioned.’ Mr.
+Collins moreover adds, ‘I am truly rejoiced that my cousin Lydia’s sad
+business has been so well hushed up, and am only concerned that their
+living together before the marriage took place should be so generally
+known. I must not, however, neglect the duties of my station, or refrain
+from declaring my amazement at hearing that you received the young
+couple into your house as soon as they were married. It was an
+encouragement of vice; and had I been the rector of Longbourn, I should
+very strenuously have opposed it. You ought certainly to forgive them,
+as a Christian, but never to admit them in your sight, or allow their
+names to be mentioned in your hearing.’ That is his notion of Christian
+forgiveness! The rest of his letter is only about his dear Charlotte’s
+situation, and his expectation of a young olive-branch. But, Lizzy, you
+look as if you did not enjoy it. You are not going to be _missish_,
+I hope, and pretend to be affronted at an idle report. For what do we
+live, but to make sport for our neighbours, and laugh at them in our
+turn?”
+
+“Oh!” cried Elizabeth, “I am excessively diverted. But it is so
+strange!”
+
+“Yes--_that_ is what makes it amusing. Had they fixed on any other man
+it would have been nothing; but _his_ perfect indifference, and _your_
+pointed dislike, make it so delightfully absurd! Much as I abominate
+writing, I would not give up Mr. Collins’s correspondence for any
+consideration. Nay, when I read a letter of his, I cannot help giving
+him the preference even over Wickham, much as I value the impudence and
+hypocrisy of my son-in-law. And pray, Lizzy, what said Lady Catherine
+about this report? Did she call to refuse her consent?”
+
+To this question his daughter replied only with a laugh; and as it had
+been asked without the least suspicion, she was not distressed by
+his repeating it. Elizabeth had never been more at a loss to make her
+feelings appear what they were not. It was necessary to laugh, when she
+would rather have cried. Her father had most cruelly mortified her, by
+what he said of Mr. Darcy’s indifference, and she could do nothing but
+wonder at such a want of penetration, or fear that perhaps, instead of
+his seeing too little, she might have fancied too much.
+
+
+
+Chapter 58
+
+
+Instead of receiving any such letter of excuse from his friend, as
+Elizabeth half expected Mr. Bingley to do, he was able to bring Darcy
+with him to Longbourn before many days had passed after Lady Catherine’s
+visit. The gentlemen arrived early; and, before Mrs. Bennet had time
+to tell him of their having seen his aunt, of which her daughter sat
+in momentary dread, Bingley, who wanted to be alone with Jane, proposed
+their all walking out. It was agreed to. Mrs. Bennet was not in the
+habit of walking; Mary could never spare time; but the remaining five
+set off together. Bingley and Jane, however, soon allowed the others
+to outstrip them. They lagged behind, while Elizabeth, Kitty, and Darcy
+were to entertain each other. Very little was said by either; Kitty
+was too much afraid of him to talk; Elizabeth was secretly forming a
+desperate resolution; and perhaps he might be doing the same.
+
+They walked towards the Lucases, because Kitty wished to call upon
+Maria; and as Elizabeth saw no occasion for making it a general concern,
+when Kitty left them she went boldly on with him alone. Now was the
+moment for her resolution to be executed, and, while her courage was
+high, she immediately said:
+
+“Mr. Darcy, I am a very selfish creature; and, for the sake of giving
+relief to my own feelings, care not how much I may be wounding yours. I
+can no longer help thanking you for your unexampled kindness to my
+poor sister. Ever since I have known it, I have been most anxious to
+acknowledge to you how gratefully I feel it. Were it known to the rest
+of my family, I should not have merely my own gratitude to express.”
+
+“I am sorry, exceedingly sorry,” replied Darcy, in a tone of surprise
+and emotion, “that you have ever been informed of what may, in a
+mistaken light, have given you uneasiness. I did not think Mrs. Gardiner
+was so little to be trusted.”
+
+“You must not blame my aunt. Lydia’s thoughtlessness first betrayed to
+me that you had been concerned in the matter; and, of course, I could
+not rest till I knew the particulars. Let me thank you again and again,
+in the name of all my family, for that generous compassion which induced
+you to take so much trouble, and bear so many mortifications, for the
+sake of discovering them.”
+
+“If you _will_ thank me,” he replied, “let it be for yourself alone.
+That the wish of giving happiness to you might add force to the other
+inducements which led me on, I shall not attempt to deny. But your
+_family_ owe me nothing. Much as I respect them, I believe I thought
+only of _you_.”
+
+Elizabeth was too much embarrassed to say a word. After a short pause,
+her companion added, “You are too generous to trifle with me. If your
+feelings are still what they were last April, tell me so at once. _My_
+affections and wishes are unchanged, but one word from you will silence
+me on this subject for ever.”
+
+Elizabeth, feeling all the more than common awkwardness and anxiety of
+his situation, now forced herself to speak; and immediately, though not
+very fluently, gave him to understand that her sentiments had undergone
+so material a change, since the period to which he alluded, as to make
+her receive with gratitude and pleasure his present assurances. The
+happiness which this reply produced, was such as he had probably never
+felt before; and he expressed himself on the occasion as sensibly and as
+warmly as a man violently in love can be supposed to do. Had Elizabeth
+been able to encounter his eye, she might have seen how well the
+expression of heartfelt delight, diffused over his face, became him;
+but, though she could not look, she could listen, and he told her of
+feelings, which, in proving of what importance she was to him, made his
+affection every moment more valuable.
+
+They walked on, without knowing in what direction. There was too much to
+be thought, and felt, and said, for attention to any other objects. She
+soon learnt that they were indebted for their present good understanding
+to the efforts of his aunt, who did call on him in her return through
+London, and there relate her journey to Longbourn, its motive, and the
+substance of her conversation with Elizabeth; dwelling emphatically on
+every expression of the latter which, in her ladyship’s apprehension,
+peculiarly denoted her perverseness and assurance; in the belief that
+such a relation must assist her endeavours to obtain that promise
+from her nephew which she had refused to give. But, unluckily for her
+ladyship, its effect had been exactly contrariwise.
+
+“It taught me to hope,” said he, “as I had scarcely ever allowed myself
+to hope before. I knew enough of your disposition to be certain that,
+had you been absolutely, irrevocably decided against me, you would have
+acknowledged it to Lady Catherine, frankly and openly.”
+
+Elizabeth coloured and laughed as she replied, “Yes, you know enough
+of my frankness to believe me capable of _that_. After abusing you so
+abominably to your face, I could have no scruple in abusing you to all
+your relations.”
+
+“What did you say of me, that I did not deserve? For, though your
+accusations were ill-founded, formed on mistaken premises, my
+behaviour to you at the time had merited the severest reproof. It was
+unpardonable. I cannot think of it without abhorrence.”
+
+“We will not quarrel for the greater share of blame annexed to that
+evening,” said Elizabeth. “The conduct of neither, if strictly examined,
+will be irreproachable; but since then, we have both, I hope, improved
+in civility.”
+
+“I cannot be so easily reconciled to myself. The recollection of what I
+then said, of my conduct, my manners, my expressions during the whole of
+it, is now, and has been many months, inexpressibly painful to me. Your
+reproof, so well applied, I shall never forget: ‘had you behaved in a
+more gentlemanlike manner.’ Those were your words. You know not, you can
+scarcely conceive, how they have tortured me;--though it was some time,
+I confess, before I was reasonable enough to allow their justice.”
+
+“I was certainly very far from expecting them to make so strong an
+impression. I had not the smallest idea of their being ever felt in such
+a way.”
+
+“I can easily believe it. You thought me then devoid of every proper
+feeling, I am sure you did. The turn of your countenance I shall never
+forget, as you said that I could not have addressed you in any possible
+way that would induce you to accept me.”
+
+“Oh! do not repeat what I then said. These recollections will not do at
+all. I assure you that I have long been most heartily ashamed of it.”
+
+Darcy mentioned his letter. “Did it,” said he, “did it soon make you
+think better of me? Did you, on reading it, give any credit to its
+contents?”
+
+She explained what its effect on her had been, and how gradually all her
+former prejudices had been removed.
+
+“I knew,” said he, “that what I wrote must give you pain, but it was
+necessary. I hope you have destroyed the letter. There was one part
+especially, the opening of it, which I should dread your having the
+power of reading again. I can remember some expressions which might
+justly make you hate me.”
+
+“The letter shall certainly be burnt, if you believe it essential to the
+preservation of my regard; but, though we have both reason to think my
+opinions not entirely unalterable, they are not, I hope, quite so easily
+changed as that implies.”
+
+“When I wrote that letter,” replied Darcy, “I believed myself perfectly
+calm and cool, but I am since convinced that it was written in a
+dreadful bitterness of spirit.”
+
+“The letter, perhaps, began in bitterness, but it did not end so. The
+adieu is charity itself. But think no more of the letter. The feelings
+of the person who wrote, and the person who received it, are now
+so widely different from what they were then, that every unpleasant
+circumstance attending it ought to be forgotten. You must learn some
+of my philosophy. Think only of the past as its remembrance gives you
+pleasure.”
+
+“I cannot give you credit for any philosophy of the kind. Your
+retrospections must be so totally void of reproach, that the contentment
+arising from them is not of philosophy, but, what is much better, of
+innocence. But with me, it is not so. Painful recollections will intrude
+which cannot, which ought not, to be repelled. I have been a selfish
+being all my life, in practice, though not in principle. As a child I
+was taught what was right, but I was not taught to correct my temper. I
+was given good principles, but left to follow them in pride and conceit.
+Unfortunately an only son (for many years an only child), I was spoilt
+by my parents, who, though good themselves (my father, particularly, all
+that was benevolent and amiable), allowed, encouraged, almost taught
+me to be selfish and overbearing; to care for none beyond my own family
+circle; to think meanly of all the rest of the world; to wish at least
+to think meanly of their sense and worth compared with my own. Such I
+was, from eight to eight and twenty; and such I might still have been
+but for you, dearest, loveliest Elizabeth! What do I not owe you! You
+taught me a lesson, hard indeed at first, but most advantageous. By you,
+I was properly humbled. I came to you without a doubt of my reception.
+You showed me how insufficient were all my pretensions to please a woman
+worthy of being pleased.”
+
+“Had you then persuaded yourself that I should?”
+
+“Indeed I had. What will you think of my vanity? I believed you to be
+wishing, expecting my addresses.”
+
+“My manners must have been in fault, but not intentionally, I assure
+you. I never meant to deceive you, but my spirits might often lead me
+wrong. How you must have hated me after _that_ evening?”
+
+“Hate you! I was angry perhaps at first, but my anger soon began to take
+a proper direction.”
+
+“I am almost afraid of asking what you thought of me, when we met at
+Pemberley. You blamed me for coming?”
+
+“No indeed; I felt nothing but surprise.”
+
+“Your surprise could not be greater than _mine_ in being noticed by you.
+My conscience told me that I deserved no extraordinary politeness, and I
+confess that I did not expect to receive _more_ than my due.”
+
+“My object then,” replied Darcy, “was to show you, by every civility in
+my power, that I was not so mean as to resent the past; and I hoped to
+obtain your forgiveness, to lessen your ill opinion, by letting you
+see that your reproofs had been attended to. How soon any other wishes
+introduced themselves I can hardly tell, but I believe in about half an
+hour after I had seen you.”
+
+He then told her of Georgiana’s delight in her acquaintance, and of her
+disappointment at its sudden interruption; which naturally leading to
+the cause of that interruption, she soon learnt that his resolution of
+following her from Derbyshire in quest of her sister had been formed
+before he quitted the inn, and that his gravity and thoughtfulness
+there had arisen from no other struggles than what such a purpose must
+comprehend.
+
+She expressed her gratitude again, but it was too painful a subject to
+each, to be dwelt on farther.
+
+After walking several miles in a leisurely manner, and too busy to know
+anything about it, they found at last, on examining their watches, that
+it was time to be at home.
+
+“What could become of Mr. Bingley and Jane!” was a wonder which
+introduced the discussion of their affairs. Darcy was delighted with
+their engagement; his friend had given him the earliest information of
+it.
+
+“I must ask whether you were surprised?” said Elizabeth.
+
+“Not at all. When I went away, I felt that it would soon happen.”
+
+“That is to say, you had given your permission. I guessed as much.” And
+though he exclaimed at the term, she found that it had been pretty much
+the case.
+
+“On the evening before my going to London,” said he, “I made a
+confession to him, which I believe I ought to have made long ago. I
+told him of all that had occurred to make my former interference in his
+affairs absurd and impertinent. His surprise was great. He had never had
+the slightest suspicion. I told him, moreover, that I believed myself
+mistaken in supposing, as I had done, that your sister was indifferent
+to him; and as I could easily perceive that his attachment to her was
+unabated, I felt no doubt of their happiness together.”
+
+Elizabeth could not help smiling at his easy manner of directing his
+friend.
+
+“Did you speak from your own observation,” said she, “when you told him
+that my sister loved him, or merely from my information last spring?”
+
+“From the former. I had narrowly observed her during the two visits
+which I had lately made here; and I was convinced of her affection.”
+
+“And your assurance of it, I suppose, carried immediate conviction to
+him.”
+
+“It did. Bingley is most unaffectedly modest. His diffidence had
+prevented his depending on his own judgment in so anxious a case, but
+his reliance on mine made every thing easy. I was obliged to confess
+one thing, which for a time, and not unjustly, offended him. I could not
+allow myself to conceal that your sister had been in town three months
+last winter, that I had known it, and purposely kept it from him. He was
+angry. But his anger, I am persuaded, lasted no longer than he remained
+in any doubt of your sister’s sentiments. He has heartily forgiven me
+now.”
+
+Elizabeth longed to observe that Mr. Bingley had been a most delightful
+friend; so easily guided that his worth was invaluable; but she checked
+herself. She remembered that he had yet to learn to be laughed at,
+and it was rather too early to begin. In anticipating the happiness
+of Bingley, which of course was to be inferior only to his own, he
+continued the conversation till they reached the house. In the hall they
+parted.
+
+
+
+Chapter 59
+
+
+“My dear Lizzy, where can you have been walking to?” was a question
+which Elizabeth received from Jane as soon as she entered their room,
+and from all the others when they sat down to table. She had only to
+say in reply, that they had wandered about, till she was beyond her own
+knowledge. She coloured as she spoke; but neither that, nor anything
+else, awakened a suspicion of the truth.
+
+The evening passed quietly, unmarked by anything extraordinary. The
+acknowledged lovers talked and laughed, the unacknowledged were silent.
+Darcy was not of a disposition in which happiness overflows in mirth;
+and Elizabeth, agitated and confused, rather _knew_ that she was happy
+than _felt_ herself to be so; for, besides the immediate embarrassment,
+there were other evils before her. She anticipated what would be felt
+in the family when her situation became known; she was aware that no
+one liked him but Jane; and even feared that with the others it was a
+dislike which not all his fortune and consequence might do away.
+
+At night she opened her heart to Jane. Though suspicion was very far
+from Miss Bennet’s general habits, she was absolutely incredulous here.
+
+“You are joking, Lizzy. This cannot be!--engaged to Mr. Darcy! No, no,
+you shall not deceive me. I know it to be impossible.”
+
+“This is a wretched beginning indeed! My sole dependence was on you; and
+I am sure nobody else will believe me, if you do not. Yet, indeed, I am
+in earnest. I speak nothing but the truth. He still loves me, and we are
+engaged.”
+
+Jane looked at her doubtingly. “Oh, Lizzy! it cannot be. I know how much
+you dislike him.”
+
+“You know nothing of the matter. _That_ is all to be forgot. Perhaps I
+did not always love him so well as I do now. But in such cases as
+these, a good memory is unpardonable. This is the last time I shall ever
+remember it myself.”
+
+Miss Bennet still looked all amazement. Elizabeth again, and more
+seriously assured her of its truth.
+
+“Good Heaven! can it be really so! Yet now I must believe you,” cried
+Jane. “My dear, dear Lizzy, I would--I do congratulate you--but are you
+certain? forgive the question--are you quite certain that you can be
+happy with him?”
+
+“There can be no doubt of that. It is settled between us already, that
+we are to be the happiest couple in the world. But are you pleased,
+Jane? Shall you like to have such a brother?”
+
+“Very, very much. Nothing could give either Bingley or myself more
+delight. But we considered it, we talked of it as impossible. And do you
+really love him quite well enough? Oh, Lizzy! do anything rather than
+marry without affection. Are you quite sure that you feel what you ought
+to do?”
+
+“Oh, yes! You will only think I feel _more_ than I ought to do, when I
+tell you all.”
+
+“What do you mean?”
+
+“Why, I must confess that I love him better than I do Bingley. I am
+afraid you will be angry.”
+
+“My dearest sister, now _be_ serious. I want to talk very seriously. Let
+me know every thing that I am to know, without delay. Will you tell me
+how long you have loved him?”
+
+“It has been coming on so gradually, that I hardly know when it began.
+But I believe I must date it from my first seeing his beautiful grounds
+at Pemberley.”
+
+Another entreaty that she would be serious, however, produced the
+desired effect; and she soon satisfied Jane by her solemn assurances
+of attachment. When convinced on that article, Miss Bennet had nothing
+further to wish.
+
+“Now I am quite happy,” said she, “for you will be as happy as myself.
+I always had a value for him. Were it for nothing but his love of you,
+I must always have esteemed him; but now, as Bingley’s friend and your
+husband, there can be only Bingley and yourself more dear to me. But
+Lizzy, you have been very sly, very reserved with me. How little did you
+tell me of what passed at Pemberley and Lambton! I owe all that I know
+of it to another, not to you.”
+
+Elizabeth told her the motives of her secrecy. She had been unwilling
+to mention Bingley; and the unsettled state of her own feelings had made
+her equally avoid the name of his friend. But now she would no longer
+conceal from her his share in Lydia’s marriage. All was acknowledged,
+and half the night spent in conversation.
+
+                          * * * * *
+
+“Good gracious!” cried Mrs. Bennet, as she stood at a window the next
+morning, “if that disagreeable Mr. Darcy is not coming here again with
+our dear Bingley! What can he mean by being so tiresome as to be always
+coming here? I had no notion but he would go a-shooting, or something or
+other, and not disturb us with his company. What shall we do with him?
+Lizzy, you must walk out with him again, that he may not be in Bingley’s
+way.”
+
+Elizabeth could hardly help laughing at so convenient a proposal; yet
+was really vexed that her mother should be always giving him such an
+epithet.
+
+As soon as they entered, Bingley looked at her so expressively, and
+shook hands with such warmth, as left no doubt of his good information;
+and he soon afterwards said aloud, “Mrs. Bennet, have you no more lanes
+hereabouts in which Lizzy may lose her way again to-day?”
+
+“I advise Mr. Darcy, and Lizzy, and Kitty,” said Mrs. Bennet, “to walk
+to Oakham Mount this morning. It is a nice long walk, and Mr. Darcy has
+never seen the view.”
+
+“It may do very well for the others,” replied Mr. Bingley; “but I am
+sure it will be too much for Kitty. Won’t it, Kitty?” Kitty owned that
+she had rather stay at home. Darcy professed a great curiosity to see
+the view from the Mount, and Elizabeth silently consented. As she went
+up stairs to get ready, Mrs. Bennet followed her, saying:
+
+“I am quite sorry, Lizzy, that you should be forced to have that
+disagreeable man all to yourself. But I hope you will not mind it: it is
+all for Jane’s sake, you know; and there is no occasion for talking
+to him, except just now and then. So, do not put yourself to
+inconvenience.”
+
+During their walk, it was resolved that Mr. Bennet’s consent should be
+asked in the course of the evening. Elizabeth reserved to herself the
+application for her mother’s. She could not determine how her mother
+would take it; sometimes doubting whether all his wealth and grandeur
+would be enough to overcome her abhorrence of the man. But whether she
+were violently set against the match, or violently delighted with it, it
+was certain that her manner would be equally ill adapted to do credit
+to her sense; and she could no more bear that Mr. Darcy should hear
+the first raptures of her joy, than the first vehemence of her
+disapprobation.
+
+                          * * * * *
+
+In the evening, soon after Mr. Bennet withdrew to the library, she saw
+Mr. Darcy rise also and follow him, and her agitation on seeing it was
+extreme. She did not fear her father’s opposition, but he was going to
+be made unhappy; and that it should be through her means--that _she_,
+his favourite child, should be distressing him by her choice, should be
+filling him with fears and regrets in disposing of her--was a wretched
+reflection, and she sat in misery till Mr. Darcy appeared again, when,
+looking at him, she was a little relieved by his smile. In a few minutes
+he approached the table where she was sitting with Kitty; and, while
+pretending to admire her work said in a whisper, “Go to your father, he
+wants you in the library.” She was gone directly.
+
+Her father was walking about the room, looking grave and anxious.
+“Lizzy,” said he, “what are you doing? Are you out of your senses, to be
+accepting this man? Have not you always hated him?”
+
+How earnestly did she then wish that her former opinions had been more
+reasonable, her expressions more moderate! It would have spared her from
+explanations and professions which it was exceedingly awkward to give;
+but they were now necessary, and she assured him, with some confusion,
+of her attachment to Mr. Darcy.
+
+“Or, in other words, you are determined to have him. He is rich, to be
+sure, and you may have more fine clothes and fine carriages than Jane.
+But will they make you happy?”
+
+“Have you any other objection,” said Elizabeth, “than your belief of my
+indifference?”
+
+“None at all. We all know him to be a proud, unpleasant sort of man; but
+this would be nothing if you really liked him.”
+
+“I do, I do like him,” she replied, with tears in her eyes, “I love him.
+Indeed he has no improper pride. He is perfectly amiable. You do not
+know what he really is; then pray do not pain me by speaking of him in
+such terms.”
+
+“Lizzy,” said her father, “I have given him my consent. He is the kind
+of man, indeed, to whom I should never dare refuse anything, which he
+condescended to ask. I now give it to _you_, if you are resolved on
+having him. But let me advise you to think better of it. I know
+your disposition, Lizzy. I know that you could be neither happy nor
+respectable, unless you truly esteemed your husband; unless you looked
+up to him as a superior. Your lively talents would place you in the
+greatest danger in an unequal marriage. You could scarcely escape
+discredit and misery. My child, let me not have the grief of seeing
+_you_ unable to respect your partner in life. You know not what you are
+about.”
+
+Elizabeth, still more affected, was earnest and solemn in her reply; and
+at length, by repeated assurances that Mr. Darcy was really the object
+of her choice, by explaining the gradual change which her estimation of
+him had undergone, relating her absolute certainty that his affection
+was not the work of a day, but had stood the test of many months’
+suspense, and enumerating with energy all his good qualities, she did
+conquer her father’s incredulity, and reconcile him to the match.
+
+“Well, my dear,” said he, when she ceased speaking, “I have no more to
+say. If this be the case, he deserves you. I could not have parted with
+you, my Lizzy, to anyone less worthy.”
+
+To complete the favourable impression, she then told him what Mr. Darcy
+had voluntarily done for Lydia. He heard her with astonishment.
+
+“This is an evening of wonders, indeed! And so, Darcy did every thing;
+made up the match, gave the money, paid the fellow’s debts, and got him
+his commission! So much the better. It will save me a world of trouble
+and economy. Had it been your uncle’s doing, I must and _would_ have
+paid him; but these violent young lovers carry every thing their own
+way. I shall offer to pay him to-morrow; he will rant and storm about
+his love for you, and there will be an end of the matter.”
+
+He then recollected her embarrassment a few days before, on his reading
+Mr. Collins’s letter; and after laughing at her some time, allowed her
+at last to go--saying, as she quitted the room, “If any young men come
+for Mary or Kitty, send them in, for I am quite at leisure.”
+
+Elizabeth’s mind was now relieved from a very heavy weight; and, after
+half an hour’s quiet reflection in her own room, she was able to join
+the others with tolerable composure. Every thing was too recent for
+gaiety, but the evening passed tranquilly away; there was no longer
+anything material to be dreaded, and the comfort of ease and familiarity
+would come in time.
+
+When her mother went up to her dressing-room at night, she followed her,
+and made the important communication. Its effect was most extraordinary;
+for on first hearing it, Mrs. Bennet sat quite still, and unable to
+utter a syllable. Nor was it under many, many minutes that she could
+comprehend what she heard; though not in general backward to credit
+what was for the advantage of her family, or that came in the shape of a
+lover to any of them. She began at length to recover, to fidget about in
+her chair, get up, sit down again, wonder, and bless herself.
+
+“Good gracious! Lord bless me! only think! dear me! Mr. Darcy! Who would
+have thought it! And is it really true? Oh! my sweetest Lizzy! how rich
+and how great you will be! What pin-money, what jewels, what carriages
+you will have! Jane’s is nothing to it--nothing at all. I am so
+pleased--so happy. Such a charming man!--so handsome! so tall!--Oh, my
+dear Lizzy! pray apologise for my having disliked him so much before. I
+hope he will overlook it. Dear, dear Lizzy. A house in town! Every thing
+that is charming! Three daughters married! Ten thousand a year! Oh,
+Lord! What will become of me. I shall go distracted.”
+
+This was enough to prove that her approbation need not be doubted: and
+Elizabeth, rejoicing that such an effusion was heard only by herself,
+soon went away. But before she had been three minutes in her own room,
+her mother followed her.
+
+“My dearest child,” she cried, “I can think of nothing else! Ten
+thousand a year, and very likely more! ‘Tis as good as a Lord! And a
+special licence. You must and shall be married by a special licence. But
+my dearest love, tell me what dish Mr. Darcy is particularly fond of,
+that I may have it to-morrow.”
+
+This was a sad omen of what her mother’s behaviour to the gentleman
+himself might be; and Elizabeth found that, though in the certain
+possession of his warmest affection, and secure of her relations’
+consent, there was still something to be wished for. But the morrow
+passed off much better than she expected; for Mrs. Bennet luckily stood
+in such awe of her intended son-in-law that she ventured not to speak to
+him, unless it was in her power to offer him any attention, or mark her
+deference for his opinion.
+
+Elizabeth had the satisfaction of seeing her father taking pains to get
+acquainted with him; and Mr. Bennet soon assured her that he was rising
+every hour in his esteem.
+
+“I admire all my three sons-in-law highly,” said he. “Wickham, perhaps,
+is my favourite; but I think I shall like _your_ husband quite as well
+as Jane’s.”
+
+
+
+Chapter 60
+
+
+Elizabeth’s spirits soon rising to playfulness again, she wanted Mr.
+Darcy to account for his having ever fallen in love with her. “How could
+you begin?” said she. “I can comprehend your going on charmingly, when
+you had once made a beginning; but what could set you off in the first
+place?”
+
+“I cannot fix on the hour, or the spot, or the look, or the words, which
+laid the foundation. It is too long ago. I was in the middle before I
+knew that I _had_ begun.”
+
+“My beauty you had early withstood, and as for my manners--my behaviour
+to _you_ was at least always bordering on the uncivil, and I never spoke
+to you without rather wishing to give you pain than not. Now be sincere;
+did you admire me for my impertinence?”
+
+“For the liveliness of your mind, I did.”
+
+“You may as well call it impertinence at once. It was very little less.
+The fact is, that you were sick of civility, of deference, of officious
+attention. You were disgusted with the women who were always speaking,
+and looking, and thinking for _your_ approbation alone. I roused, and
+interested you, because I was so unlike _them_. Had you not been really
+amiable, you would have hated me for it; but in spite of the pains you
+took to disguise yourself, your feelings were always noble and just; and
+in your heart, you thoroughly despised the persons who so assiduously
+courted you. There--I have saved you the trouble of accounting for
+it; and really, all things considered, I begin to think it perfectly
+reasonable. To be sure, you knew no actual good of me--but nobody thinks
+of _that_ when they fall in love.”
+
+“Was there no good in your affectionate behaviour to Jane while she was
+ill at Netherfield?”
+
+“Dearest Jane! who could have done less for her? But make a virtue of it
+by all means. My good qualities are under your protection, and you are
+to exaggerate them as much as possible; and, in return, it belongs to me
+to find occasions for teasing and quarrelling with you as often as may
+be; and I shall begin directly by asking you what made you so unwilling
+to come to the point at last. What made you so shy of me, when you first
+called, and afterwards dined here? Why, especially, when you called, did
+you look as if you did not care about me?”
+
+“Because you were grave and silent, and gave me no encouragement.”
+
+“But I was embarrassed.”
+
+“And so was I.”
+
+“You might have talked to me more when you came to dinner.”
+
+“A man who had felt less, might.”
+
+“How unlucky that you should have a reasonable answer to give, and that
+I should be so reasonable as to admit it! But I wonder how long you
+_would_ have gone on, if you had been left to yourself. I wonder when
+you _would_ have spoken, if I had not asked you! My resolution of
+thanking you for your kindness to Lydia had certainly great effect.
+_Too much_, I am afraid; for what becomes of the moral, if our comfort
+springs from a breach of promise? for I ought not to have mentioned the
+subject. This will never do.”
+
+“You need not distress yourself. The moral will be perfectly fair. Lady
+Catherine’s unjustifiable endeavours to separate us were the means of
+removing all my doubts. I am not indebted for my present happiness to
+your eager desire of expressing your gratitude. I was not in a humour
+to wait for any opening of yours. My aunt’s intelligence had given me
+hope, and I was determined at once to know every thing.”
+
+“Lady Catherine has been of infinite use, which ought to make her happy,
+for she loves to be of use. But tell me, what did you come down to
+Netherfield for? Was it merely to ride to Longbourn and be embarrassed?
+or had you intended any more serious consequence?”
+
+“My real purpose was to see _you_, and to judge, if I could, whether I
+might ever hope to make you love me. My avowed one, or what I avowed to
+myself, was to see whether your sister were still partial to Bingley,
+and if she were, to make the confession to him which I have since made.”
+
+“Shall you ever have courage to announce to Lady Catherine what is to
+befall her?”
+
+“I am more likely to want more time than courage, Elizabeth. But it
+ought to be done, and if you will give me a sheet of paper, it shall be
+done directly.”
+
+“And if I had not a letter to write myself, I might sit by you and
+admire the evenness of your writing, as another young lady once did. But
+I have an aunt, too, who must not be longer neglected.”
+
+From an unwillingness to confess how much her intimacy with Mr. Darcy
+had been over-rated, Elizabeth had never yet answered Mrs. Gardiner’s
+long letter; but now, having _that_ to communicate which she knew would
+be most welcome, she was almost ashamed to find that her uncle and
+aunt had already lost three days of happiness, and immediately wrote as
+follows:
+
+“I would have thanked you before, my dear aunt, as I ought to have done,
+for your long, kind, satisfactory, detail of particulars; but to say the
+truth, I was too cross to write. You supposed more than really existed.
+But _now_ suppose as much as you choose; give a loose rein to your
+fancy, indulge your imagination in every possible flight which the
+subject will afford, and unless you believe me actually married, you
+cannot greatly err. You must write again very soon, and praise him a
+great deal more than you did in your last. I thank you, again and again,
+for not going to the Lakes. How could I be so silly as to wish it! Your
+idea of the ponies is delightful. We will go round the Park every day. I
+am the happiest creature in the world. Perhaps other people have said so
+before, but not one with such justice. I am happier even than Jane; she
+only smiles, I laugh. Mr. Darcy sends you all the love in the world that
+he can spare from me. You are all to come to Pemberley at Christmas.
+Yours, etc.”
+
+Mr. Darcy’s letter to Lady Catherine was in a different style; and still
+different from either was what Mr. Bennet sent to Mr. Collins, in reply
+to his last.
+
+“DEAR SIR,
+
+“I must trouble you once more for congratulations. Elizabeth will soon
+be the wife of Mr. Darcy. Console Lady Catherine as well as you can.
+But, if I were you, I would stand by the nephew. He has more to give.
+
+“Yours sincerely, etc.”
+
+Miss Bingley’s congratulations to her brother, on his approaching
+marriage, were all that was affectionate and insincere. She wrote even
+to Jane on the occasion, to express her delight, and repeat all her
+former professions of regard. Jane was not deceived, but she was
+affected; and though feeling no reliance on her, could not help writing
+her a much kinder answer than she knew was deserved.
+
+The joy which Miss Darcy expressed on receiving similar information,
+was as sincere as her brother’s in sending it. Four sides of paper were
+insufficient to contain all her delight, and all her earnest desire of
+being loved by her sister.
+
+Before any answer could arrive from Mr. Collins, or any congratulations
+to Elizabeth from his wife, the Longbourn family heard that the
+Collinses were come themselves to Lucas Lodge. The reason of this
+sudden removal was soon evident. Lady Catherine had been rendered
+so exceedingly angry by the contents of her nephew’s letter, that
+Charlotte, really rejoicing in the match, was anxious to get away till
+the storm was blown over. At such a moment, the arrival of her friend
+was a sincere pleasure to Elizabeth, though in the course of their
+meetings she must sometimes think the pleasure dearly bought, when she
+saw Mr. Darcy exposed to all the parading and obsequious civility of
+her husband. He bore it, however, with admirable calmness. He could even
+listen to Sir William Lucas, when he complimented him on carrying away
+the brightest jewel of the country, and expressed his hopes of their all
+meeting frequently at St. James’s, with very decent composure. If he did
+shrug his shoulders, it was not till Sir William was out of sight.
+
+Mrs. Phillips’s vulgarity was another, and perhaps a greater, tax on his
+forbearance; and though Mrs. Phillips, as well as her sister, stood in
+too much awe of him to speak with the familiarity which Bingley’s good
+humour encouraged, yet, whenever she _did_ speak, she must be vulgar.
+Nor was her respect for him, though it made her more quiet, at all
+likely to make her more elegant. Elizabeth did all she could to shield
+him from the frequent notice of either, and was ever anxious to keep
+him to herself, and to those of her family with whom he might converse
+without mortification; and though the uncomfortable feelings arising
+from all this took from the season of courtship much of its pleasure, it
+added to the hope of the future; and she looked forward with delight to
+the time when they should be removed from society so little pleasing
+to either, to all the comfort and elegance of their family party at
+Pemberley.
+
+
+
+Chapter 61
+
+
+Happy for all her maternal feelings was the day on which Mrs. Bennet got
+rid of her two most deserving daughters. With what delighted pride
+she afterwards visited Mrs. Bingley, and talked of Mrs. Darcy, may
+be guessed. I wish I could say, for the sake of her family, that the
+accomplishment of her earnest desire in the establishment of so many
+of her children produced so happy an effect as to make her a sensible,
+amiable, well-informed woman for the rest of her life; though perhaps it
+was lucky for her husband, who might not have relished domestic felicity
+in so unusual a form, that she still was occasionally nervous and
+invariably silly.
+
+Mr. Bennet missed his second daughter exceedingly; his affection for her
+drew him oftener from home than anything else could do. He delighted in
+going to Pemberley, especially when he was least expected.
+
+Mr. Bingley and Jane remained at Netherfield only a twelvemonth. So near
+a vicinity to her mother and Meryton relations was not desirable even to
+_his_ easy temper, or _her_ affectionate heart. The darling wish of his
+sisters was then gratified; he bought an estate in a neighbouring county
+to Derbyshire, and Jane and Elizabeth, in addition to every other source
+of happiness, were within thirty miles of each other.
+
+Kitty, to her very material advantage, spent the chief of her time with
+her two elder sisters. In society so superior to what she had generally
+known, her improvement was great. She was not of so ungovernable a
+temper as Lydia; and, removed from the influence of Lydia’s example,
+she became, by proper attention and management, less irritable, less
+ignorant, and less insipid. From the further disadvantage of Lydia’s
+society she was of course carefully kept, and though Mrs. Wickham
+frequently invited her to come and stay with her, with the promise of
+balls and young men, her father would never consent to her going.
+
+Mary was the only daughter who remained at home; and she was necessarily
+drawn from the pursuit of accomplishments by Mrs. Bennet’s being quite
+unable to sit alone. Mary was obliged to mix more with the world, but
+she could still moralize over every morning visit; and as she was no
+longer mortified by comparisons between her sisters’ beauty and her own,
+it was suspected by her father that she submitted to the change without
+much reluctance.
+
+As for Wickham and Lydia, their characters suffered no revolution from
+the marriage of her sisters. He bore with philosophy the conviction that
+Elizabeth must now become acquainted with whatever of his ingratitude
+and falsehood had before been unknown to her; and in spite of every
+thing, was not wholly without hope that Darcy might yet be prevailed on
+to make his fortune. The congratulatory letter which Elizabeth received
+from Lydia on her marriage, explained to her that, by his wife at least,
+if not by himself, such a hope was cherished. The letter was to this
+effect:
+
+“MY DEAR LIZZY,
+
+“I wish you joy. If you love Mr. Darcy half as well as I do my dear
+Wickham, you must be very happy. It is a great comfort to have you so
+rich, and when you have nothing else to do, I hope you will think of us.
+I am sure Wickham would like a place at court very much, and I do not
+think we shall have quite money enough to live upon without some help.
+Any place would do, of about three or four hundred a year; but however,
+do not speak to Mr. Darcy about it, if you had rather not.
+
+“Yours, etc.”
+
+As it happened that Elizabeth had _much_ rather not, she endeavoured in
+her answer to put an end to every entreaty and expectation of the kind.
+Such relief, however, as it was in her power to afford, by the practice
+of what might be called economy in her own private expences, she
+frequently sent them. It had always been evident to her that such an
+income as theirs, under the direction of two persons so extravagant in
+their wants, and heedless of the future, must be very insufficient to
+their support; and whenever they changed their quarters, either Jane or
+herself were sure of being applied to for some little assistance
+towards discharging their bills. Their manner of living, even when the
+restoration of peace dismissed them to a home, was unsettled in the
+extreme. They were always moving from place to place in quest of a cheap
+situation, and always spending more than they ought. His affection for
+her soon sunk into indifference; hers lasted a little longer; and
+in spite of her youth and her manners, she retained all the claims to
+reputation which her marriage had given her.
+
+Though Darcy could never receive _him_ at Pemberley, yet, for
+Elizabeth’s sake, he assisted him further in his profession. Lydia was
+occasionally a visitor there, when her husband was gone to enjoy himself
+in London or Bath; and with the Bingleys they both of them frequently
+staid so long, that even Bingley’s good humour was overcome, and he
+proceeded so far as to talk of giving them a hint to be gone.
+
+Miss Bingley was very deeply mortified by Darcy’s marriage; but as she
+thought it advisable to retain the right of visiting at Pemberley, she
+dropt all her resentment; was fonder than ever of Georgiana, almost as
+attentive to Darcy as heretofore, and paid off every arrear of civility
+to Elizabeth.
+
+Pemberley was now Georgiana’s home; and the attachment of the sisters
+was exactly what Darcy had hoped to see. They were able to love each
+other even as well as they intended. Georgiana had the highest opinion
+in the world of Elizabeth; though at first she often listened with
+an astonishment bordering on alarm at her lively, sportive, manner of
+talking to her brother. He, who had always inspired in herself a respect
+which almost overcame her affection, she now saw the object of open
+pleasantry. Her mind received knowledge which had never before fallen
+in her way. By Elizabeth’s instructions, she began to comprehend that
+a woman may take liberties with her husband which a brother will not
+always allow in a sister more than ten years younger than himself.
+
+Lady Catherine was extremely indignant on the marriage of her nephew;
+and as she gave way to all the genuine frankness of her character in
+her reply to the letter which announced its arrangement, she sent him
+language so very abusive, especially of Elizabeth, that for some time
+all intercourse was at an end. But at length, by Elizabeth’s persuasion,
+he was prevailed on to overlook the offence, and seek a reconciliation;
+and, after a little further resistance on the part of his aunt, her
+resentment gave way, either to her affection for him, or her curiosity
+to see how his wife conducted herself; and she condescended to wait
+on them at Pemberley, in spite of that pollution which its woods had
+received, not merely from the presence of such a mistress, but the
+visits of her uncle and aunt from the city.
+
+With the Gardiners, they were always on the most intimate terms.
+Darcy, as well as Elizabeth, really loved them; and they were both ever
+sensible of the warmest gratitude towards the persons who, by bringing
+her into Derbyshire, had been the means of uniting them.
+
+
+
+
+
+End of the Project Gutenberg EBook of Pride and Prejudice, by Jane Austen
+
+*** END OF THIS PROJECT GUTENBERG EBOOK PRIDE AND PREJUDICE ***
+
+***** This file should be named 1342-0.txt or 1342-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/3/4/1342/
+
+Produced by Anonymous Volunteers
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, are critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/relativity-special-and-general-theory.txt
+++ b/jet/tf-idf/src/main/resources/books/relativity-special-and-general-theory.txt
@@ -1,0 +1,4063 @@
+﻿The Project Gutenberg EBook of Relativity: The Special and General Theory
+by Albert Einstein
+(#1 in our series by Albert Einstein)
+
+Note: 58 image files are part of this eBook.  They include tables,
+equations and figures that could not be represented well as plain text.
+
+Copyright laws are changing all over the world. Be sure to check the
+copyright laws for your country before downloading or redistributing
+this or any other Project Gutenberg eBook.
+
+This header should be the first thing seen when viewing this Project
+Gutenberg file.  Please do not remove it.  Do not change or edit the
+header without written permission.
+
+Please read the "legal small print," and other information about the
+eBook and Project Gutenberg at the bottom of this file.  Included is
+important information about your specific rights and restrictions in
+how the file may be used.  You can also find out about how to make a
+donation to Project Gutenberg, and how to get involved.
+
+
+**Welcome To The World of Free Plain Vanilla Electronic Texts**
+
+**eBooks Readable By Both Humans and By Computers, Since 1971**
+
+*****These eBooks Were Prepared By Thousands of Volunteers!*****
+
+
+Title: Relativity: The Special and General Theory
+
+Author: Albert Einstein
+
+Release Date: February, 2004  [EBook #5001]
+[Yes, we are more than one year ahead of schedule]
+[This file was first posted on April 1, 2002]
+
+Edition: 10
+
+Language: English
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+
+
+
+ALBERT EINSTEIN REFERENCE ARCHIVE
+
+RELATIVITY: THE SPECIAL AND GENERAL THEORY
+
+BY ALBERT EINSTEIN
+
+
+Written: 1916 (this revised edition: 1924)
+Source: Relativity: The Special and General Theory (1920)
+Publisher: Methuen & Co Ltd
+First Published: December, 1916
+Translated: Robert W. Lawson (Authorised translation)
+Transcription/Markup: Brian Basgen <brian@marxists.org>
+Transcription to text: Gregory B. Newby <gbnewby@petascale.org>
+Thanks to: Einstein Reference Archive (marxists.org)
+The Einstein Reference Archive is online at:
+http://www.marxists.org/reference/archive/einstein/index.htm
+
+Transcriber note: This file is a plain text rendition of HTML.
+Because many equations cannot be presented effectively in plain text,
+images are supplied for many equations and for all figures and tables.
+
+
+CONTENTS
+
+Preface
+
+Part I: The Special Theory of Relativity
+
+01. Physical Meaning of Geometrical Propositions
+02. The System of Co-ordinates
+03. Space and Time in Classical Mechanics
+04. The Galileian System of Co-ordinates
+05. The Principle of Relativity (in the Restricted Sense)
+06. The Theorem of the Addition of Velocities employed in
+Classical Mechanics
+07. The Apparent Incompatability of the Law of Propagation of
+Light with the Principle of Relativity
+08. On the Idea of Time in Physics
+09. The Relativity of Simultaneity
+10. On the Relativity of the Conception of Distance
+11. The Lorentz Transformation
+12. The Behaviour of Measuring-Rods and Clocks in Motion
+13. Theorem of the Addition of Velocities. The Experiment of Fizeau
+14. The Hueristic Value of the Theory of Relativity
+15. General Results of the Theory
+16. Expereince and the Special Theory of Relativity
+17. Minkowski's Four-dimensial Space
+
+
+Part II: The General Theory of Relativity
+
+18. Special and General Principle of Relativity
+19. The Gravitational Field
+20. The Equality of Inertial and Gravitational Mass as an Argument
+for the General Postulate of Relativity
+21. In What Respects are the Foundations of Classical Mechanics
+and of the Special Theory of Relativity Unsatisfactory?
+22. A Few Inferences from the General Principle of Relativity
+23. Behaviour of Clocks and Measuring-Rods on a Rotating Body of
+Reference
+24. Euclidean and non-Euclidean Continuum
+25. Gaussian Co-ordinates
+26. The Space-Time Continuum of the Speical Theory of Relativity
+Considered as a Euclidean Continuum
+27. The Space-Time Continuum of the General Theory of Relativity
+is Not a Eculidean Continuum
+28. Exact Formulation of the General Principle of Relativity
+29. The Solution of the Problem of Gravitation on the Basis of the
+General Principle of Relativity
+
+
+Part III: Considerations on the Universe as a Whole
+
+30. Cosmological Difficulties of Netwon's Theory
+31. The Possibility of a "Finite" and yet "Unbounded" Universe
+32. The Structure of Space According to the General Theory of
+Relativity
+
+
+Appendices:
+
+01. Simple Derivation of the Lorentz Transformation (sup. ch. 11)
+02. Minkowski's Four-Dimensional Space ("World") (sup. ch 17)
+03. The Experimental Confirmation of the General Theory of Relativity
+04. The Structure of Space According to the General Theory of
+Relativity (sup. ch 32)
+05. Relativity and the Problem of Space
+
+Note: The fifth Appendix was added by Einstein at the time of the
+fifteenth re-printing of this book; and as a result is still under
+copyright restrictions so cannot be added without the permission of
+the publisher.
+
+
+
+PREFACE
+
+ (December, 1916)
+
+The present book is intended, as far as possible, to give an exact
+insight into the theory of Relativity to those readers who, from a
+general scientific and philosophical point of view, are interested in
+the theory, but who are not conversant with the mathematical apparatus
+of theoretical physics. The work presumes a standard of education
+corresponding to that of a university matriculation examination, and,
+despite the shortness of the book, a fair amount of patience and force
+of will on the part of the reader. The author has spared himself no
+pains in his endeavour to present the main ideas in the simplest and
+most intelligible form, and on the whole, in the sequence and
+connection in which they actually originated. In the interest of
+clearness, it appeared to me inevitable that I should repeat myself
+frequently, without paying the slightest attention to the elegance of
+the presentation. I adhered scrupulously to the precept of that
+brilliant theoretical physicist L. Boltzmann, according to whom
+matters of elegance ought to be left to the tailor and to the cobbler.
+I make no pretence of having withheld from the reader difficulties
+which are inherent to the subject. On the other hand, I have purposely
+treated the empirical physical foundations of the theory in a
+"step-motherly" fashion, so that readers unfamiliar with physics may
+not feel like the wanderer who was unable to see the forest for the
+trees. May the book bring some one a few happy hours of suggestive
+thought!
+
+December, 1916
+A. EINSTEIN
+
+
+
+PART I
+
+THE SPECIAL THEORY OF RELATIVITY
+
+PHYSICAL MEANING OF GEOMETRICAL PROPOSITIONS
+
+
+In your schooldays most of you who read this book made acquaintance
+with the noble building of Euclid's geometry, and you remember --
+perhaps with more respect than love -- the magnificent structure, on
+the lofty staircase of which you were chased about for uncounted hours
+by conscientious teachers. By reason of our past experience, you would
+certainly regard everyone with disdain who should pronounce even the
+most out-of-the-way proposition of this science to be untrue. But
+perhaps this feeling of proud certainty would leave you immediately if
+some one were to ask you: "What, then, do you mean by the assertion
+that these propositions are true?" Let us proceed to give this
+question a little consideration.
+
+Geometry sets out form certain conceptions such as "plane," "point,"
+and "straight line," with which we are able to associate more or less
+definite ideas, and from certain simple propositions (axioms) which,
+in virtue of these ideas, we are inclined to accept as "true." Then,
+on the basis of a logical process, the justification of which we feel
+ourselves compelled to admit, all remaining propositions are shown to
+follow from those axioms, i.e. they are proven. A proposition is then
+correct ("true") when it has been derived in the recognised manner
+from the axioms. The question of "truth" of the individual geometrical
+propositions is thus reduced to one of the "truth" of the axioms. Now
+it has long been known that the last question is not only unanswerable
+by the methods of geometry, but that it is in itself entirely without
+meaning. We cannot ask whether it is true that only one straight line
+goes through two points. We can only say that Euclidean geometry deals
+with things called "straight lines," to each of which is ascribed the
+property of being uniquely determined by two points situated on it.
+The concept "true" does not tally with the assertions of pure
+geometry, because by the word "true" we are eventually in the habit of
+designating always the correspondence with a "real" object; geometry,
+however, is not concerned with the relation of the ideas involved in
+it to objects of experience, but only with the logical connection of
+these ideas among themselves.
+
+It is not difficult to understand why, in spite of this, we feel
+constrained to call the propositions of geometry "true." Geometrical
+ideas correspond to more or less exact objects in nature, and these
+last are undoubtedly the exclusive cause of the genesis of those
+ideas. Geometry ought to refrain from such a course, in order to give
+to its structure the largest possible logical unity. The practice, for
+example, of seeing in a "distance" two marked positions on a
+practically rigid body is something which is lodged deeply in our
+habit of thought. We are accustomed further to regard three points as
+being situated on a straight line, if their apparent positions can be
+made to coincide for observation with one eye, under suitable choice
+of our place of observation.
+
+If, in pursuance of our habit of thought, we now supplement the
+propositions of Euclidean geometry by the single proposition that two
+points on a practically rigid body always correspond to the same
+distance (line-interval), independently of any changes in position to
+which we may subject the body, the propositions of Euclidean geometry
+then resolve themselves into propositions on the possible relative
+position of practically rigid bodies.* Geometry which has been
+supplemented in this way is then to be treated as a branch of physics.
+We can now legitimately ask as to the "truth" of geometrical
+propositions interpreted in this way, since we are justified in asking
+whether these propositions are satisfied for those real things we have
+associated with the geometrical ideas. In less exact terms we can
+express this by saying that by the "truth" of a geometrical
+proposition in this sense we understand its validity for a
+construction with rule and compasses.
+
+Of course the conviction of the "truth" of geometrical propositions in
+this sense is founded exclusively on rather incomplete experience. For
+the present we shall assume the "truth" of the geometrical
+propositions, then at a later stage (in the general theory of
+relativity) we shall see that this "truth" is limited, and we shall
+consider the extent of its limitation.
+
+
+  Notes
+
+*) It follows that a natural object is associated also with a
+straight line. Three points A, B and C on a rigid body thus lie in a
+straight line when the points A and C being given, B is chosen such
+that the sum of the distances AB and BC is as short as possible. This
+incomplete suggestion will suffice for the present purpose.
+
+
+
+THE SYSTEM OF CO-ORDINATES
+
+
+On the basis of the physical interpretation of distance which has been
+indicated, we are also in a position to establish the distance between
+two points on a rigid body by means of measurements. For this purpose
+we require a " distance " (rod S) which is to be used once and for
+all, and which we employ as a standard measure. If, now, A and B are
+two points on a rigid body, we can construct the line joining them
+according to the rules of geometry ; then, starting from A, we can
+mark off the distance S time after time until we reach B. The number
+of these operations required is the numerical measure of the distance
+AB. This is the basis of all measurement of length. *
+
+Every description of the scene of an event or of the position of an
+object in space is based on the specification of the point on a rigid
+body (body of reference) with which that event or object coincides.
+This applies not only to scientific description, but also to everyday
+life. If I analyse the place specification " Times Square, New York,"
+**A I arrive at the following result. The earth is the rigid body
+to which the specification of place refers; " Times Square, New York,"
+is a well-defined point, to which a name has been assigned, and with
+which the event coincides in space.**B
+
+This primitive method of place specification deals only with places on
+the surface of rigid bodies, and is dependent on the existence of
+points on this surface which are distinguishable from each other. But
+we can free ourselves from both of these limitations without altering
+the nature of our specification of position. If, for instance, a cloud
+is hovering over Times Square, then we can determine its position
+relative to the surface of the earth by erecting a pole
+perpendicularly on the Square, so that it reaches the cloud. The
+length of the pole measured with the standard measuring-rod, combined
+with the specification of the position of the foot of the pole,
+supplies us with a complete place specification. On the basis of this
+illustration, we are able to see the manner in which a refinement of
+the conception of position has been developed.
+
+(a) We imagine the rigid body, to which the place specification is
+referred, supplemented in such a manner that the object whose position
+we require is reached by. the completed rigid body.
+
+(b) In locating the position of the object, we make use of a number
+(here the length of the pole measured with the measuring-rod) instead
+of designated points of reference.
+
+(c) We speak of the height of the cloud even when the pole which
+reaches the cloud has not been erected. By means of optical
+observations of the cloud from different positions on the ground, and
+taking into account the properties of the propagation of light, we
+determine the length of the pole we should have required in order to
+reach the cloud.
+
+From this consideration we see that it will be advantageous if, in the
+description of position, it should be possible by means of numerical
+measures to make ourselves independent of the existence of marked
+positions (possessing names) on the rigid body of reference. In the
+physics of measurement this is attained by the application of the
+Cartesian system of co-ordinates.
+
+This consists of three plane surfaces perpendicular to each other and
+rigidly attached to a rigid body. Referred to a system of
+co-ordinates, the scene of any event will be determined (for the main
+part) by the specification of the lengths of the three perpendiculars
+or co-ordinates (x, y, z) which can be dropped from the scene of the
+event to those three plane surfaces. The lengths of these three
+perpendiculars can be determined by a series of manipulations with
+rigid measuring-rods performed according to the rules and methods laid
+down by Euclidean geometry.
+
+In practice, the rigid surfaces which constitute the system of
+co-ordinates are generally not available ; furthermore, the magnitudes
+of the co-ordinates are not actually determined by constructions with
+rigid rods, but by indirect means. If the results of physics and
+astronomy are to maintain their clearness, the physical meaning of
+specifications of position must always be sought in accordance with
+the above considerations. ***
+
+We thus obtain the following result: Every description of events in
+space involves the use of a rigid body to which such events have to be
+referred. The resulting relationship takes for granted that the laws
+of Euclidean geometry hold for "distances;" the "distance" being
+represented physically by means of the convention of two marks on a
+rigid body.
+
+
+  Notes
+
+* Here we have assumed that there is nothing left over i.e. that
+the measurement gives a whole number. This difficulty is got over by
+the use of divided measuring-rods, the introduction of which does not
+demand any fundamentally new method.
+
+**A Einstein used "Potsdamer Platz, Berlin" in the original text.
+In the authorised translation this was supplemented with "Tranfalgar
+Square, London". We have changed this to "Times Square, New York", as
+this is the most well known/identifiable location to English speakers
+in the present day. [Note by the janitor.]
+
+**B It is not necessary here to investigate further the significance
+of the expression "coincidence in space." This conception is
+sufficiently obvious to ensure that differences of opinion are
+scarcely likely to arise as to its applicability in practice.
+
+*** A refinement and modification of these views does not become
+necessary until we come to deal with the general theory of relativity,
+treated in the second part of this book.
+
+
+
+SPACE AND TIME IN CLASSICAL MECHANICS
+
+
+The purpose of mechanics is to describe how bodies change their
+position in space with "time." I should load my conscience with grave
+sins against the sacred spirit of lucidity were I to formulate the
+aims of mechanics in this way, without serious reflection and detailed
+explanations. Let us proceed to disclose these sins.
+
+It is not clear what is to be understood here by "position" and
+"space." I stand at the window of a railway carriage which is
+travelling uniformly, and drop a stone on the embankment, without
+throwing it. Then, disregarding the influence of the air resistance, I
+see the stone descend in a straight line. A pedestrian who observes
+the misdeed from the footpath notices that the stone falls to earth in
+a parabolic curve. I now ask: Do the "positions" traversed by the
+stone lie "in reality" on a straight line or on a parabola? Moreover,
+what is meant here by motion "in space" ? From the considerations of
+the previous section the answer is self-evident. In the first place we
+entirely shun the vague word "space," of which, we must honestly
+acknowledge, we cannot form the slightest conception, and we replace
+it by "motion relative to a practically rigid body of reference." The
+positions relative to the body of reference (railway carriage or
+embankment) have already been defined in detail in the preceding
+section. If instead of " body of reference " we insert " system of
+co-ordinates," which is a useful idea for mathematical description, we
+are in a position to say : The stone traverses a straight line
+relative to a system of co-ordinates rigidly attached to the carriage,
+but relative to a system of co-ordinates rigidly attached to the
+ground (embankment) it describes a parabola. With the aid of this
+example it is clearly seen that there is no such thing as an
+independently existing trajectory (lit. "path-curve"*), but only
+a trajectory relative to a particular body of reference.
+
+In order to have a complete description of the motion, we must specify
+how the body alters its position with time ; i.e. for every point on
+the trajectory it must be stated at what time the body is situated
+there. These data must be supplemented by such a definition of time
+that, in virtue of this definition, these time-values can be regarded
+essentially as magnitudes (results of measurements) capable of
+observation. If we take our stand on the ground of classical
+mechanics, we can satisfy this requirement for our illustration in the
+following manner. We imagine two clocks of identical construction ;
+the man at the railway-carriage window is holding one of them, and the
+man on the footpath the other. Each of the observers determines the
+position on his own reference-body occupied by the stone at each tick
+of the clock he is holding in his hand. In this connection we have not
+taken account of the inaccuracy involved by the finiteness of the
+velocity of propagation of light. With this and with a second
+difficulty prevailing here we shall have to deal in detail later.
+
+
+  Notes
+
+*) That is, a curve along which the body moves.
+
+
+
+THE GALILEIAN SYSTEM OF CO-ORDINATES
+
+
+As is well known, the fundamental law of the mechanics of
+Galilei-Newton, which is known as the law of inertia, can be stated
+thus: A body removed sufficiently far from other bodies continues in a
+state of rest or of uniform motion in a straight line. This law not
+only says something about the motion of the bodies, but it also
+indicates the reference-bodies or systems of coordinates, permissible
+in mechanics, which can be used in mechanical description. The visible
+fixed stars are bodies for which the law of inertia certainly holds to
+a high degree of approximation. Now if we use a system of co-ordinates
+which is rigidly attached to the earth, then, relative to this system,
+every fixed star describes a circle of immense radius in the course of
+an astronomical day, a result which is opposed to the statement of the
+law of inertia. So that if we adhere to this law we must refer these
+motions only to systems of coordinates relative to which the fixed
+stars do not move in a circle. A system of co-ordinates of which the
+state of motion is such that the law of inertia holds relative to it
+is called a " Galileian system of co-ordinates." The laws of the
+mechanics of Galflei-Newton can be regarded as valid only for a
+Galileian system of co-ordinates.
+
+
+
+THE PRINCIPLE OF RELATIVITY
+(IN THE RESTRICTED SENSE)
+
+
+In order to attain the greatest possible clearness, let us return to
+our example of the railway carriage supposed to be travelling
+uniformly. We call its motion a uniform translation ("uniform" because
+it is of constant velocity and direction, " translation " because
+although the carriage changes its position relative to the embankment
+yet it does not rotate in so doing). Let us imagine a raven flying
+through the air in such a manner that its motion, as observed from the
+embankment, is uniform and in a straight line. If we were to observe
+the flying raven from the moving railway carriage. we should find that
+the motion of the raven would be one of different velocity and
+direction, but that it would still be uniform and in a straight line.
+Expressed in an abstract manner we may say : If a mass m is moving
+uniformly in a straight line with respect to a co-ordinate system K,
+then it will also be moving uniformly and in a straight line relative
+to a second co-ordinate system K1 provided that the latter is
+executing a uniform translatory motion with respect to K. In
+accordance with the discussion contained in the preceding section, it
+follows that:
+
+If K is a Galileian co-ordinate system. then every other co-ordinate
+system K' is a Galileian one, when, in relation to K, it is in a
+condition of uniform motion of translation. Relative to K1 the
+mechanical laws of Galilei-Newton hold good exactly as they do with
+respect to K.
+
+We advance a step farther in our generalisation when we express the
+tenet thus: If, relative to K, K1 is a uniformly moving co-ordinate
+system devoid of rotation, then natural phenomena run their course
+with respect to K1 according to exactly the same general laws as with
+respect to K. This statement is called the principle of relativity (in
+the restricted sense).
+
+As long as one was convinced that all natural phenomena were capable
+of representation with the help of classical mechanics, there was no
+need to doubt the validity of this principle of relativity. But in
+view of the more recent development of electrodynamics and optics it
+became more and more evident that classical mechanics affords an
+insufficient foundation for the physical description of all natural
+phenomena. At this juncture the question of the validity of the
+principle of relativity became ripe for discussion, and it did not
+appear impossible that the answer to this question might be in the
+negative.
+
+Nevertheless, there are two general facts which at the outset speak
+very much in favour of the validity of the principle of relativity.
+Even though classical mechanics does not supply us with a sufficiently
+broad basis for the theoretical presentation of all physical
+phenomena, still we must grant it a considerable measure of " truth,"
+since it supplies us with the actual motions of the heavenly bodies
+with a delicacy of detail little short of wonderful. The principle of
+relativity must therefore apply with great accuracy in the domain of
+mechanics. But that a principle of such broad generality should hold
+with such exactness in one domain of phenomena, and yet should be
+invalid for another, is a priori not very probable.
+
+We now proceed to the second argument, to which, moreover, we shall
+return later. If the principle of relativity (in the restricted sense)
+does not hold, then the Galileian co-ordinate systems K, K1, K2, etc.,
+which are moving uniformly relative to each other, will not be
+equivalent for the description of natural phenomena. In this case we
+should be constrained to believe that natural laws are capable of
+being formulated in a particularly simple manner, and of course only
+on condition that, from amongst all possible Galileian co-ordinate
+systems, we should have chosen one (K[0]) of a particular state of
+motion as our body of reference. We should then be justified (because
+of its merits for the description of natural phenomena) in calling
+this system " absolutely at rest," and all other Galileian systems K "
+in motion." If, for instance, our embankment were the system K[0] then
+our railway carriage would be a system K, relative to which less
+simple laws would hold than with respect to K[0]. This diminished
+simplicity would be due to the fact that the carriage K would be in
+motion (i.e."really")with respect to K[0]. In the general laws of
+nature which have been formulated with reference to K, the magnitude
+and direction of the velocity of the carriage would necessarily play a
+part. We should expect, for instance, that the note emitted by an
+organpipe placed with its axis parallel to the direction of travel
+would be different from that emitted if the axis of the pipe were
+placed perpendicular to this direction.
+
+Now in virtue of its motion in an orbit round the sun, our earth is
+comparable with a railway carriage travelling with a velocity of about
+30 kilometres per second. If the principle of relativity were not
+valid we should therefore expect that the direction of motion of the
+earth at any moment would enter into the laws of nature, and also that
+physical systems in their behaviour would be dependent on the
+orientation in space with respect to the earth. For owing to the
+alteration in direction of the velocity of revolution of the earth in
+the course of a year, the earth cannot be at rest relative to the
+hypothetical system K[0] throughout the whole year. However, the most
+careful observations have never revealed such anisotropic properties
+in terrestrial physical space, i.e. a physical non-equivalence of
+different directions. This is very powerful argument in favour of the
+principle of relativity.
+
+
+
+THE THEOREM OF THE
+ADDITION OF VELOCITIES
+EMPLOYED IN CLASSICAL MECHANICS
+
+
+Let us suppose our old friend the railway carriage to be travelling
+along the rails with a constant velocity v, and that a man traverses
+the length of the carriage in the direction of travel with a velocity
+w. How quickly or, in other words, with what velocity W does the man
+advance relative to the embankment during the process ? The only
+possible answer seems to result from the following consideration: If
+the man were to stand still for a second, he would advance relative to
+the embankment through a distance v equal numerically to the velocity
+of the carriage. As a consequence of his walking, however, he
+traverses an additional distance w relative to the carriage, and hence
+also relative to the embankment, in this second, the distance w being
+numerically equal to the velocity with which he is walking. Thus in
+total be covers the distance W=v+w relative to the embankment in the
+second considered. We shall see later that this result, which
+expresses the theorem of the addition of velocities employed in
+classical mechanics, cannot be maintained ; in other words, the law
+that we have just written down does not hold in reality. For the time
+being, however, we shall assume its correctness.
+
+
+
+THE APPARENT INCOMPATIBILITY OF THE
+LAW OF PROPAGATION OF LIGHT WITH THE
+PRINCIPLE OF RELATIVITY
+
+
+There is hardly a simpler law in physics than that according to which
+light is propagated in empty space. Every child at school knows, or
+believes he knows, that this propagation takes place in straight lines
+with a velocity c= 300,000 km./sec. At all events we know with great
+exactness that this velocity is the same for all colours, because if
+this were not the case, the minimum of emission would not be observed
+simultaneously for different colours during the eclipse of a fixed
+star by its dark neighbour. By means of similar considerations based
+on observa- tions of double stars, the Dutch astronomer De Sitter was
+also able to show that the velocity of propagation of light cannot
+depend on the velocity of motion of the body emitting the light. The
+assumption that this velocity of propagation is dependent on the
+direction "in space" is in itself improbable.
+
+In short, let us assume that the simple law of the constancy of the
+velocity of light c (in vacuum) is justifiably believed by the child
+at school. Who would imagine that this simple law has plunged the
+conscientiously thoughtful physicist into the greatest intellectual
+difficulties? Let us consider how these difficulties arise.
+
+Of course we must refer the process of the propagation of light (and
+indeed every other process) to a rigid reference-body (co-ordinate
+system). As such a system let us again choose our embankment. We shall
+imagine the air above it to have been removed. If a ray of light be
+sent along the embankment, we see from the above that the tip of the
+ray will be transmitted with the velocity c relative to the
+embankment. Now let us suppose that our railway carriage is again
+travelling along the railway lines with the velocity v, and that its
+direction is the same as that of the ray of light, but its velocity of
+course much less. Let us inquire about the velocity of propagation of
+the ray of light relative to the carriage. It is obvious that we can
+here apply the consideration of the previous section, since the ray of
+light plays the part of the man walking along relatively to the
+carriage. The velocity w of the man relative to the embankment is here
+replaced by the velocity of light relative to the embankment. w is the
+required velocity of light with respect to the carriage, and we have
+
+                               w = c-v.
+
+The velocity of propagation ot a ray of light relative to the carriage
+thus comes cut smaller than c.
+
+But this result comes into conflict with the principle of relativity
+set forth in Section V. For, like every other general law of
+nature, the law of the transmission of light in vacuo [in vacuum]
+must, according to the principle of relativity, be the same for the
+railway carriage as reference-body as when the rails are the body of
+reference. But, from our above consideration, this would appear to be
+impossible. If every ray of light is propagated relative to the
+embankment with the velocity c, then for this reason it would appear
+that another law of propagation of light must necessarily hold with
+respect to the carriage -- a result contradictory to the principle of
+relativity.
+
+In view of this dilemma there appears to be nothing else for it than
+to abandon either the principle of relativity or the simple law of the
+propagation of light in vacuo. Those of you who have carefully
+followed the preceding discussion are almost sure to expect that we
+should retain the principle of relativity, which appeals so
+convincingly to the intellect because it is so natural and simple. The
+law of the propagation of light in vacuo would then have to be
+replaced by a more complicated law conformable to the principle of
+relativity. The development of theoretical physics shows, however,
+that we cannot pursue this course. The epoch-making theoretical
+investigations of H. A. Lorentz on the electrodynamical and optical
+phenomena connected with moving bodies show that experience in this
+domain leads conclusively to a theory of electromagnetic phenomena, of
+which the law of the constancy of the velocity of light in vacuo is a
+necessary consequence. Prominent theoretical physicists were theref
+ore more inclined to reject the principle of relativity, in spite of
+the fact that no empirical data had been found which were
+contradictory to this principle.
+
+At this juncture the theory of relativity entered the arena. As a
+result of an analysis of the physical conceptions of time and space,
+it became evident that in realily there is not the least
+incompatibilitiy between the principle of relativity and the law of
+propagation of light, and that by systematically holding fast to both
+these laws a logically rigid theory could be arrived at. This theory
+has been called the special theory of relativity to distinguish it
+from the extended theory, with which we shall deal later. In the
+following pages we shall present the fundamental ideas of the special
+theory of relativity.
+
+
+
+ON THE IDEA OF TIME IN PHYSICS
+
+
+Lightning has struck the rails on our railway embankment at two places
+A and B far distant from each other. I make the additional assertion
+that these two lightning flashes occurred simultaneously. If I ask you
+whether there is sense in this statement, you will answer my question
+with a decided "Yes." But if I now approach you with the request to
+explain to me the sense of the statement more precisely, you find
+after some consideration that the answer to this question is not so
+easy as it appears at first sight.
+
+After some time perhaps the following answer would occur to you: "The
+significance of the statement is clear in itself and needs no further
+explanation; of course it would require some consideration if I were
+to be commissioned to determine by observations whether in the actual
+case the two events took place simultaneously or not." I cannot be
+satisfied with this answer for the following reason. Supposing that as
+a result of ingenious considerations an able meteorologist were to
+discover that the lightning must always strike the places A and B
+simultaneously, then we should be faced with the task of testing
+whether or not this theoretical result is in accordance with the
+reality. We encounter the same difficulty with all physical statements
+in which the conception " simultaneous " plays a part. The concept
+does not exist for the physicist until he has the possibility of
+discovering whether or not it is fulfilled in an actual case. We thus
+require a definition of simultaneity such that this definition
+supplies us with the method by means of which, in the present case, he
+can decide by experiment whether or not both the lightning strokes
+occurred simultaneously. As long as this requirement is not satisfied,
+I allow myself to be deceived as a physicist (and of course the same
+applies if I am not a physicist), when I imagine that I am able to
+attach a meaning to the statement of simultaneity. (I would ask the
+reader not to proceed farther until he is fully convinced on this
+point.)
+
+After thinking the matter over for some time you then offer the
+following suggestion with which to test simultaneity. By measuring
+along the rails, the connecting line AB should be measured up and an
+observer placed at the mid-point M of the distance AB. This observer
+should be supplied with an arrangement (e.g. two mirrors inclined at
+90^0) which allows him visually to observe both places A and B at the
+same time. If the observer perceives the two flashes of lightning at
+the same time, then they are simultaneous.
+
+I am very pleased with this suggestion, but for all that I cannot
+regard the matter as quite settled, because I feel constrained to
+raise the following objection:
+
+"Your definition would certainly be right, if only I knew that the
+light by means of which the observer at M perceives the lightning
+flashes travels along the length A arrow M with the same velocity as
+along the length B arrow M. But an examination of this supposition
+would only be possible if we already had at our disposal the means of
+measuring time. It would thus appear as though we were moving here in
+a logical circle."
+
+After further consideration you cast a somewhat disdainful glance at
+me -- and rightly so -- and you declare:
+
+"I maintain my previous definition nevertheless, because in reality it
+assumes absolutely nothing about light. There is only one demand to be
+made of the definition of simultaneity, namely, that in every real
+case it must supply us with an empirical decision as to whether or not
+the conception that has to be defined is fulfilled. That my definition
+satisfies this demand is indisputable. That light requires the same
+time to traverse the path A arrow M as for the path B arrow M is in
+reality neither a supposition nor a hypothesis about the physical
+nature of light, but a stipulation which I can make of my own freewill
+in order to arrive at a definition of simultaneity."
+
+It is clear that this definition can be used to give an exact meaning
+not only to two events, but to as many events as we care to choose,
+and independently of the positions of the scenes of the events with
+respect to the body of reference * (here the railway embankment).
+We are thus led also to a definition of " time " in physics. For this
+purpose we suppose that clocks of identical construction are placed at
+the points A, B and C of the railway line (co-ordinate system) and
+that they are set in such a manner that the positions of their
+pointers are simultaneously (in the above sense) the same. Under these
+conditions we understand by the " time " of an event the reading
+(position of the hands) of that one of these clocks which is in the
+immediate vicinity (in space) of the event. In this manner a
+time-value is associated with every event which is essentially capable
+of observation.
+
+This stipulation contains a further physical hypothesis, the validity
+of which will hardly be doubted without empirical evidence to the
+contrary. It has been assumed that all these clocks go at the same
+rate if they are of identical construction. Stated more exactly: When
+two clocks arranged at rest in different places of a reference-body
+are set in such a manner that a particular position of the pointers of
+the one clock is simultaneous (in the above sense) with the same
+position, of the pointers of the other clock, then identical "
+settings " are always simultaneous (in the sense of the above
+definition).
+
+
+  Notes
+
+*) We suppose further, that, when three events A, B and C occur in
+different places in such a manner that A is simultaneous with B and B
+is simultaneous with C (simultaneous in the sense of the above
+definition), then the criterion for the simultaneity of the pair of
+events A, C is also satisfied. This assumption is a physical
+hypothesis about the the of propagation of light: it must certainly be
+fulfilled if we are to maintain the law of the constancy of the
+velocity of light in vacuo.
+
+
+
+THE RELATIVITY OF SIMULATNEITY
+
+
+Up to now our considerations have been referred to a particular body
+of reference, which we have styled a " railway embankment." We suppose
+a very long train travelling along the rails with the constant
+velocity v and in the direction indicated in Fig 1. People travelling
+in this train will with a vantage view the train as a rigid
+reference-body (co-ordinate system); they regard all events in
+
+                       Fig. 01: file fig01.gif
+
+
+reference to the train. Then every event which takes place along the
+line also takes place at a particular point of the train. Also the
+definition of simultaneity can be given relative to the train in
+exactly the same way as with respect to the embankment. As a natural
+consequence, however, the following question arises :
+
+Are two events (e.g. the two strokes of lightning A and B) which are
+simultaneous with reference to the railway embankment also
+simultaneous relatively to the train? We shall show directly that the
+answer must be in the negative.
+
+When we say that the lightning strokes A and B are simultaneous with
+respect to be embankment, we mean: the rays of light emitted at the
+places A and B, where the lightning occurs, meet each other at the
+mid-point M of the length A arrow B of the embankment. But the events
+A and B also correspond to positions A and B on the train. Let M1 be
+the mid-point of the distance A arrow B on the travelling train. Just
+when the flashes (as judged from the embankment) of lightning occur,
+this point M1 naturally coincides with the point M but it moves
+towards the right in the diagram with the velocity v of the train. If
+an observer sitting in the position M1 in the train did not possess
+this velocity, then he would remain permanently at M, and the light
+rays emitted by the flashes of lightning A and B would reach him
+simultaneously, i.e. they would meet just where he is situated. Now in
+reality (considered with reference to the railway embankment) he is
+hastening towards the beam of light coming from B, whilst he is riding
+on ahead of the beam of light coming from A. Hence the observer will
+see the beam of light emitted from B earlier than he will see that
+emitted from A. Observers who take the railway train as their
+reference-body must therefore come to the conclusion that the
+lightning flash B took place earlier than the lightning flash A. We
+thus arrive at the important result:
+
+Events which are simultaneous with reference to the embankment are not
+simultaneous with respect to the train, and vice versa (relativity of
+simultaneity). Every reference-body (co-ordinate system) has its own
+particular time ; unless we are told the reference-body to which the
+statement of time refers, there is no meaning in a statement of the
+time of an event.
+
+Now before the advent of the theory of relativity it had always
+tacitly been assumed in physics that the statement of time had an
+absolute significance, i.e. that it is independent of the state of
+motion of the body of reference. But we have just seen that this
+assumption is incompatible with the most natural definition of
+simultaneity; if we discard this assumption, then the conflict between
+the law of the propagation of light in vacuo and the principle of
+relativity (developed in Section 7) disappears.
+
+We were led to that conflict by the considerations of Section 6,
+which are now no longer tenable. In that section we concluded that the
+man in the carriage, who traverses the distance w per second relative
+to the carriage, traverses the same distance also with respect to the
+embankment in each second of time. But, according to the foregoing
+considerations, the time required by a particular occurrence with
+respect to the carriage must not be considered equal to the duration
+of the same occurrence as judged from the embankment (as
+reference-body). Hence it cannot be contended that the man in walking
+travels the distance w relative to the railway line in a time which is
+equal to one second as judged from the embankment.
+
+Moreover, the considerations of Section 6 are based on yet a second
+assumption, which, in the light of a strict consideration, appears to
+be arbitrary, although it was always tacitly made even before the
+introduction of the theory of relativity.
+
+
+
+ON THE RELATIVITY OF THE CONCEPTION OF DISTANCE
+
+
+Let us consider two particular points on the train * travelling
+along the embankment with the velocity v, and inquire as to their
+distance apart. We already know that it is necessary to have a body of
+reference for the measurement of a distance, with respect to which
+body the distance can be measured up. It is the simplest plan to use
+the train itself as reference-body (co-ordinate system). An observer
+in the train measures the interval by marking off his measuring-rod in
+a straight line (e.g. along the floor of the carriage) as many times
+as is necessary to take him from the one marked point to the other.
+Then the number which tells us how often the rod has to be laid down
+is the required distance.
+
+It is a different matter when the distance has to be judged from the
+railway line. Here the following method suggests itself. If we call
+A^1 and B^1 the two points on the train whose distance apart is
+required, then both of these points are moving with the velocity v
+along the embankment. In the first place we require to determine the
+points A and B of the embankment which are just being passed by the
+two points A^1 and B^1 at a particular time t -- judged from the
+embankment. These points A and B of the embankment can be determined
+by applying the definition of time given in Section 8. The distance
+between these points A and B is then measured by repeated application
+of thee measuring-rod along the embankment.
+
+A priori it is by no means certain that this last measurement will
+supply us with the same result as the first. Thus the length of the
+train as measured from the embankment may be different from that
+obtained by measuring in the train itself. This circumstance leads us
+to a second objection which must be raised against the apparently
+obvious consideration of Section 6. Namely, if the man in the
+carriage covers the distance w in a unit of time -- measured from the
+train, -- then this distance -- as measured from the embankment -- is
+not necessarily also equal to w.
+
+
+  Notes
+
+*) e.g. the middle of the first and of the hundredth carriage.
+
+
+
+THE LORENTZ TRANSFORMATION
+
+
+The results of the last three sections show that the apparent
+incompatibility of the law of propagation of light with the principle
+of relativity (Section 7) has been derived by means of a
+consideration which borrowed two unjustifiable hypotheses from
+classical mechanics; these are as follows:
+
+(1) The time-interval (time) between two events is independent of the
+condition of motion of the body of reference.
+
+(2) The space-interval (distance) between two points of a rigid body
+is independent of the condition of motion of the body of reference.
+
+If we drop these hypotheses, then the dilemma of Section 7
+disappears, because the theorem of the addition of velocities derived
+in Section 6 becomes invalid. The possibility presents itself that
+the law of the propagation of light in vacuo may be compatible with
+the principle of relativity, and the question arises: How have we to
+modify the considerations of Section 6 in order to remove the
+apparent disagreement between these two fundamental results of
+experience? This question leads to a general one. In the discussion of
+Section 6 we have to do with places and times relative both to the
+train and to the embankment. How are we to find the place and time of
+an event in relation to the train, when we know the place and time of
+the event with respect to the railway embankment ? Is there a
+thinkable answer to this question of such a nature that the law of
+transmission of light in vacuo does not contradict the principle of
+relativity ? In other words : Can we conceive of a relation between
+place and time of the individual events relative to both
+reference-bodies, such that every ray of light possesses the velocity
+of transmission c relative to the embankment and relative to the train
+? This question leads to a quite definite positive answer, and to a
+perfectly definite transformation law for the space-time magnitudes of
+an event when changing over from one body of reference to another.
+
+Before we deal with this, we shall introduce the following incidental
+consideration. Up to the present we have only considered events taking
+place along the embankment, which had mathematically to assume the
+function of a straight line. In the manner indicated in Section 2
+we can imagine this reference-body supplemented laterally and in a
+vertical direction by means of a framework of rods, so that an event
+which takes place anywhere can be localised with reference to this
+framework. Fig. 2 Similarly, we can imagine the train travelling with
+the velocity v to be continued across the whole of space, so that
+every event, no matter how far off it may be, could also be localised
+with respect to the second framework. Without committing any
+fundamental error, we can disregard the fact that in reality these
+frameworks would continually interfere with each other, owing to the
+impenetrability of solid bodies. In every such framework we imagine
+three surfaces perpendicular to each other marked out, and designated
+as " co-ordinate planes " (" co-ordinate system "). A co-ordinate
+system K then corresponds to the embankment, and a co-ordinate system
+K' to the train. An event, wherever it may have taken place, would be
+fixed in space with respect to K by the three perpendiculars x, y, z
+on the co-ordinate planes, and with regard to time by a time value t.
+Relative to K1, the same event would be fixed in respect of space and
+time by corresponding values x1, y1, z1, t1, which of course are not
+identical with x, y, z, t. It has already been set forth in detail how
+these magnitudes are to be regarded as results of physical
+measurements.
+
+Obviously our problem can be exactly formulated in the following
+manner. What are the values x1, y1, z1, t1, of an event with respect
+to K1, when the magnitudes x, y, z, t, of the same event with respect
+to K are given ? The relations must be so chosen that the law of the
+transmission of light in vacuo is satisfied for one and the same ray
+of light (and of course for every ray) with respect to K and K1. For
+the relative orientation in space of the co-ordinate systems indicated
+in the diagram ([7]Fig. 2), this problem is solved by means of the
+equations :
+
+                         eq. 1: file eq01.gif
+
+                                y1 = y
+                                z1 = z
+
+                         eq. 2: file eq02.gif
+
+This system of equations is known as the " Lorentz transformation." *
+
+If in place of the law of transmission of light we had taken as our
+basis the tacit assumptions of the older mechanics as to the absolute
+character of times and lengths, then instead of the above we should
+have obtained the following equations:
+
+                             x1 = x - vt
+                                y1 = y
+                                z1 = z
+                                t1 = t
+
+This system of equations is often termed the " Galilei
+transformation." The Galilei transformation can be obtained from the
+Lorentz transformation by substituting an infinitely large value for
+the velocity of light c in the latter transformation.
+
+Aided by the following illustration, we can readily see that, in
+accordance with the Lorentz transformation, the law of the
+transmission of light in vacuo is satisfied both for the
+reference-body K and for the reference-body K1. A light-signal is sent
+along the positive x-axis, and this light-stimulus advances in
+accordance with the equation
+
+                               x = ct,
+
+i.e. with the velocity c. According to the equations of the Lorentz
+transformation, this simple relation between x and t involves a
+relation between x1 and t1. In point of fact, if we substitute for x
+the value ct in the first and fourth equations of the Lorentz
+transformation, we obtain:
+
+                         eq. 3: file eq03.gif
+
+
+                         eq. 4: file eq04.gif
+
+from which, by division, the expression
+
+                               x1 = ct1
+
+immediately follows. If referred to the system K1, the propagation of
+light takes place according to this equation. We thus see that the
+velocity of transmission relative to the reference-body K1 is also
+equal to c. The same result is obtained for rays of light advancing in
+any other direction whatsoever. Of cause this is not surprising, since
+the equations of the Lorentz transformation were derived conformably
+to this point of view.
+
+
+  Notes
+
+*) A simple derivation of the Lorentz transformation is given in
+Appendix I.
+
+
+
+THE BEHAVIOUR OF MEASURING-RODS AND CLOCKS IN MOTION
+
+
+Place a metre-rod in the x1-axis of K1 in such a manner that one end
+(the beginning) coincides with the point x1=0 whilst the other end
+(the end of the rod) coincides with the point x1=I. What is the length
+of the metre-rod relatively to the system K? In order to learn this,
+we need only ask where the beginning of the rod and the end of the rod
+lie with respect to K at a particular time t of the system K. By means
+of the first equation of the Lorentz transformation the values of
+these two points at the time t = 0 can be shown to be
+
+                       eq. 05a: file eq05a.gif
+
+
+                       eq. 05b: file eq05b.gif
+
+
+the distance between the points being eq. 06 .
+
+But the metre-rod is moving with the velocity v relative to K. It
+therefore follows that the length of a rigid metre-rod moving in the
+direction of its length with a velocity v is eq. 06 of a metre.
+
+The rigid rod is thus shorter when in motion than when at rest, and
+the more quickly it is moving, the shorter is the rod. For the
+velocity v=c we should have eq. 06a ,
+
+and for stiII greater velocities the square-root becomes imaginary.
+From this we conclude that in the theory of relativity the velocity c
+plays the part of a limiting velocity, which can neither be reached
+nor exceeded by any real body.
+
+Of course this feature of the velocity c as a limiting velocity also
+clearly follows from the equations of the Lorentz transformation, for
+these became meaningless if we choose values of v greater than c.
+
+If, on the contrary, we had considered a metre-rod at rest in the
+x-axis with respect to K, then we should have found that the length of
+the rod as judged from K1 would have been eq. 06 ;
+
+this is quite in accordance with the principle of relativity which
+forms the basis of our considerations.
+
+A Priori it is quite clear that we must be able to learn something
+about the physical behaviour of measuring-rods and clocks from the
+equations of transformation, for the magnitudes z, y, x, t, are
+nothing more nor less than the results of measurements obtainable by
+means of measuring-rods and clocks. If we had based our considerations
+on the Galileian transformation we should not have obtained a
+contraction of the rod as a consequence of its motion.
+
+Let us now consider a seconds-clock which is permanently situated at
+the origin (x1=0) of K1. t1=0 and t1=I are two successive ticks of
+this clock. The first and fourth equations of the Lorentz
+transformation give for these two ticks :
+
+                                t = 0
+
+and
+
+                        eq. 07: file eq07.gif
+
+As judged from K, the clock is moving with the velocity v; as judged
+from this reference-body, the time which elapses between two strokes
+of the clock is not one second, but
+
+                        eq. 08: file eq08.gif
+
+seconds, i.e. a somewhat larger time. As a consequence of its motion
+the clock goes more slowly than when at rest. Here also the velocity c
+plays the part of an unattainable limiting velocity.
+
+
+
+THEOREM OF THE ADDITION OF VELOCITIES.
+THE EXPERIMENT OF FIZEAU
+
+
+Now in practice we can move clocks and measuring-rods only with
+velocities that are small compared with the velocity of light; hence
+we shall hardly be able to compare the results of the previous section
+directly with the reality. But, on the other hand, these results must
+strike you as being very singular, and for that reason I shall now
+draw another conclusion from the theory, one which can easily be
+derived from the foregoing considerations, and which has been most
+elegantly confirmed by experiment.
+
+In Section 6 we derived the theorem of the addition of velocities
+in one direction in the form which also results from the hypotheses of
+classical mechanics- This theorem can also be deduced readily horn the
+Galilei transformation (Section 11). In place of the man walking
+inside the carriage, we introduce a point moving relatively to the
+co-ordinate system K1 in accordance with the equation
+
+                               x1 = wt1
+
+By means of the first and fourth equations of the Galilei
+transformation we can express x1 and t1 in terms of x and t, and we
+then obtain
+
+                             x = (v + w)t
+
+This equation expresses nothing else than the law of motion of the
+point with reference to the system K (of the man with reference to the
+embankment). We denote this velocity by the symbol W, and we then
+obtain, as in Section 6,
+
+                           W=v+w         A)
+
+But we can carry out this consideration just as well on the basis of
+the theory of relativity. In the equation
+
+                         x1 = wt1         B)
+
+we must then express x1and t1 in terms of x and t, making use of the
+first and fourth equations of the Lorentz transformation. Instead of
+the equation (A) we then obtain the equation
+
+                        eq. 09: file eq09.gif
+
+
+which corresponds to the theorem of addition for velocities in one
+direction according to the theory of relativity. The question now
+arises as to which of these two theorems is the better in accord with
+experience. On this point we axe enlightened by a most important
+experiment which the brilliant physicist Fizeau performed more than
+half a century ago, and which has been repeated since then by some of
+the best experimental physicists, so that there can be no doubt about
+its result. The experiment is concerned with the following question.
+Light travels in a motionless liquid with a particular velocity w. How
+quickly does it travel in the direction of the arrow in the tube T
+(see the accompanying diagram, Fig. 3) when the liquid above
+mentioned is flowing through the tube with a velocity v ?
+
+In accordance with the principle of relativity we shall certainly have
+to take for granted that the propagation of light always takes place
+with the same velocity w with respect to the liquid, whether the
+latter is in motion with reference to other bodies or not. The
+velocity of light relative to the liquid and the velocity of the
+latter relative to the tube are thus known, and we require the
+velocity of light relative to the tube.
+
+It is clear that we have the problem of Section 6 again before us. The
+tube plays the part of the railway embankment or of the co-ordinate
+system K, the liquid plays the part of the carriage or of the
+co-ordinate system K1, and finally, the light plays the part of the
+
+                      Figure 03: file fig03.gif
+
+
+man walking along the carriage, or of the moving point in the present
+section. If we denote the velocity of the light relative to the tube
+by W, then this is given by the equation (A) or (B), according as the
+Galilei transformation or the Lorentz transformation corresponds to
+the facts. Experiment * decides in favour of equation (B) derived
+from the theory of relativity, and the agreement is, indeed, very
+exact. According to recent and most excellent measurements by Zeeman,
+the influence of the velocity of flow v on the propagation of light is
+represented by formula (B) to within one per cent.
+
+Nevertheless we must now draw attention to the fact that a theory of
+this phenomenon was given by H. A. Lorentz long before the statement
+of the theory of relativity. This theory was of a purely
+electrodynamical nature, and was obtained by the use of particular
+hypotheses as to the electromagnetic structure of matter. This
+circumstance, however, does not in the least diminish the
+conclusiveness of the experiment as a crucial test in favour of the
+theory of relativity, for the electrodynamics of Maxwell-Lorentz, on
+which the original theory was based, in no way opposes the theory of
+relativity. Rather has the latter been developed trom electrodynamics
+as an astoundingly simple combination and generalisation of the
+hypotheses, formerly independent of each other, on which
+electrodynamics was built.
+
+
+  Notes
+
+*) Fizeau found eq. 10 , where eq. 11
+
+is the index of refraction of the liquid. On the other hand, owing to
+the smallness of eq. 12 as compared with I,
+
+we can replace (B) in the first place by eq. 13 , or to the same order
+of approximation by
+
+eq. 14 , which agrees with Fizeau's result.
+
+
+
+THE HEURISTIC VALUE OF THE THEORY OF RELATIVITY
+
+
+Our train of thought in the foregoing pages can be epitomised in the
+following manner. Experience has led to the conviction that, on the
+one hand, the principle of relativity holds true and that on the other
+hand the velocity of transmission of light in vacuo has to be
+considered equal to a constant c. By uniting these two postulates we
+obtained the law of transformation for the rectangular co-ordinates x,
+y, z and the time t of the events which constitute the processes of
+nature. In this connection we did not obtain the Galilei
+transformation, but, differing from classical mechanics, the Lorentz
+transformation.
+
+The law of transmission of light, the acceptance of which is justified
+by our actual knowledge, played an important part in this process of
+thought. Once in possession of the Lorentz transformation, however, we
+can combine this with the principle of relativity, and sum up the
+theory thus:
+
+Every general law of nature must be so constituted that it is
+transformed into a law of exactly the same form when, instead of the
+space-time variables x, y, z, t of the original coordinate system K,
+we introduce new space-time variables x1, y1, z1, t1 of a co-ordinate
+system K1. In this connection the relation between the ordinary and
+the accented magnitudes is given by the Lorentz transformation. Or in
+brief : General laws of nature are co-variant with respect to Lorentz
+transformations.
+
+This is a definite mathematical condition that the theory of
+relativity demands of a natural law, and in virtue of this, the theory
+becomes a valuable heuristic aid in the search for general laws of
+nature. If a general law of nature were to be found which did not
+satisfy this condition, then at least one of the two fundamental
+assumptions of the theory would have been disproved. Let us now
+examine what general results the latter theory has hitherto evinced.
+
+
+
+GENERAL RESULTS OF THE THEORY
+
+
+It is clear from our previous considerations that the (special) theory
+of relativity has grown out of electrodynamics and optics. In these
+fields it has not appreciably altered the predictions of theory, but
+it has considerably simplified the theoretical structure, i.e. the
+derivation of laws, and -- what is incomparably more important -- it
+has considerably reduced the number of independent hypothese forming
+the basis of theory. The special theory of relativity has rendered the
+Maxwell-Lorentz theory so plausible, that the latter would have been
+generally accepted by physicists even if experiment had decided less
+unequivocally in its favour.
+
+Classical mechanics required to be modified before it could come into
+line with the demands of the special theory of relativity. For the
+main part, however, this modification affects only the laws for rapid
+motions, in which the velocities of matter v are not very small as
+compared with the velocity of light. We have experience of such rapid
+motions only in the case of electrons and ions; for other motions the
+variations from the laws of classical mechanics are too small to make
+themselves evident in practice. We shall not consider the motion of
+stars until we come to speak of the general theory of relativity. In
+accordance with the theory of relativity the kinetic energy of a
+material point of mass m is no longer given by the well-known
+expression
+
+                        eq. 15: file eq15.gif
+
+but by the expression
+
+                        eq. 16: file eq16.gif
+
+
+This expression approaches infinity as the velocity v approaches the
+velocity of light c. The velocity must therefore always remain less
+than c, however great may be the energies used to produce the
+acceleration. If we develop the expression for the kinetic energy in
+the form of a series, we obtain
+
+                        eq. 17: file eq17.gif
+
+
+When eq. 18 is small compared with unity, the third of these terms is
+always small in comparison with the second,
+
+which last is alone considered in classical mechanics. The first term
+mc^2 does not contain the velocity, and requires no consideration if
+we are only dealing with the question as to how the energy of a
+point-mass; depends on the velocity. We shall speak of its essential
+significance later.
+
+The most important result of a general character to which the special
+theory of relativity has led is concerned with the conception of mass.
+Before the advent of relativity, physics recognised two conservation
+laws of fundamental importance, namely, the law of the canservation of
+energy and the law of the conservation of mass these two fundamental
+laws appeared to be quite independent of each other. By means of the
+theory of relativity they have been united into one law. We shall now
+briefly consider how this unification came about, and what meaning is
+to be attached to it.
+
+The principle of relativity requires that the law of the concervation
+of energy should hold not only with reference to a co-ordinate system
+K, but also with respect to every co-ordinate system K1 which is in a
+state of uniform motion of translation relative to K, or, briefly,
+relative to every " Galileian " system of co-ordinates. In contrast to
+classical mechanics; the Lorentz transformation is the deciding factor
+in the transition from one such system to another.
+
+By means of comparatively simple considerations we are led to draw the
+following conclusion from these premises, in conjunction with the
+fundamental equations of the electrodynamics of Maxwell: A body moving
+with the velocity v, which absorbs * an amount of energy E[0] in
+the form of radiation without suffering an alteration in velocity in
+the process, has, as a consequence, its energy increased by an amount
+
+                        eq. 19: file eq19.gif
+
+In consideration of the expression given above for the kinetic energy
+of the body, the required energy of the body comes out to be
+
+                        eq. 20: file eq20.gif
+
+
+Thus the body has the same energy as a body of mass
+
+                         eq.21: file eq21.gif
+
+moving with the velocity v. Hence we can say: If a body takes up an
+amount of energy E[0], then its inertial mass increases by an amount
+
+                        eq. 22: file eq22.gif
+
+
+the inertial mass of a body is not a constant but varies according to
+the change in the energy of the body. The inertial mass of a system of
+bodies can even be regarded as a measure of its energy. The law of the
+conservation of the mass of a system becomes identical with the law of
+the conservation of energy, and is only valid provided that the system
+neither takes up nor sends out energy. Writing the expression for the
+energy in the form
+
+                        eq. 23: file eq23.gif
+
+we see that the term mc^2, which has hitherto attracted our attention,
+is nothing else than the energy possessed by the body ** before it
+absorbed the energy E[0].
+
+A direct comparison of this relation with experiment is not possible
+at the present time (1920; see *** Note, p. 48), owing to the fact that
+the changes in energy E[0] to which we can Subject a system are not
+large enough to make themselves perceptible as a change in the
+inertial mass of the system.
+
+                                eq. 22: file eq22.gif
+
+
+is too small in comparison with the mass m, which was present before
+the alteration of the energy. It is owing to this circumstance that
+classical mechanics was able to establish successfully the
+conservation of mass as a law of independent validity.
+
+Let me add a final remark of a fundamental nature. The success of the
+Faraday-Maxwell interpretation of electromagnetic action at a distance
+resulted in physicists becoming convinced that there are no such
+things as instantaneous actions at a distance (not involving an
+intermediary medium) of the type of Newton's law of gravitation.
+According to the theory of relativity, action at a distance with the
+velocity of light always takes the place of instantaneous action at a
+distance or of action at a distance with an infinite velocity of
+transmission. This is connected with the fact that the velocity c
+plays a fundamental role in this theory. In Part II we shall see in
+what way this result becomes modified in the general theory of
+relativity.
+
+
+  Notes
+
+*) E[0] is the energy taken up, as judged from a co-ordinate system
+moving with the body.
+
+**) As judged from a co-ordinate system moving with the body.
+
+***[Note] The equation E = mc^2 has been thoroughly proved time and
+again since this time.
+
+
+
+EXPERIENCE AND THE SPECIAL THEORY OF RELATIVITY
+
+
+To what extent is the special theory of relativity supported by
+experience?  This question is not easily answered for the reason
+already mentioned in connection with the fundamental experiment of
+Fizeau. The special theory of relativity has crystallised out from the
+Maxwell-Lorentz theory of electromagnetic phenomena. Thus all facts of
+experience which support the electromagnetic theory also support the
+theory of relativity. As being of particular importance, I mention
+here the fact that the theory of relativity enables us to predict the
+effects produced on the light reaching us from the fixed stars. These
+results are obtained in an exceedingly simple manner, and the effects
+indicated, which are due to the relative motion of the earth with
+reference to those fixed stars are found to be in accord with
+experience. We refer to the yearly movement of the apparent position
+of the fixed stars resulting from the motion of the earth round the
+sun (aberration), and to the influence of the radial components of the
+relative motions of the fixed stars with respect to the earth on the
+colour of the light reaching us from them. The latter effect manifests
+itself in a slight displacement of the spectral lines of the light
+transmitted to us from a fixed star, as compared with the position of
+the same spectral lines when they are produced by a terrestrial source
+of light (Doppler principle). The experimental arguments in favour of
+the Maxwell-Lorentz theory, which are at the same time arguments in
+favour of the theory of relativity, are too numerous to be set forth
+here. In reality they limit the theoretical possibilities to such an
+extent, that no other theory than that of Maxwell and Lorentz has been
+able to hold its own when tested by experience.
+
+But there are two classes of experimental facts hitherto obtained
+which can be represented in the Maxwell-Lorentz theory only by the
+introduction of an auxiliary hypothesis, which in itself -- i.e.
+without making use of the theory of relativity -- appears extraneous.
+
+It is known that cathode rays and the so-called b-rays emitted by
+radioactive substances consist of negatively electrified particles
+(electrons) of very small inertia and large velocity. By examining the
+deflection of these rays under the influence of electric and magnetic
+fields, we can study the law of motion of these particles very
+exactly.
+
+In the theoretical treatment of these electrons, we are faced with the
+difficulty that electrodynamic theory of itself is unable to give an
+account of their nature. For since electrical masses of one sign repel
+each other, the negative electrical masses constituting the electron
+would necessarily be scattered under the influence of their mutual
+repulsions, unless there are forces of another kind operating between
+them, the nature of which has hitherto remained obscure to us.*   If
+we now assume that the relative distances between the electrical
+masses constituting the electron remain unchanged during the motion of
+the electron (rigid connection in the sense of classical mechanics),
+we arrive at a law of motion of the electron which does not agree with
+experience. Guided by purely formal points of view, H. A. Lorentz was
+the first to introduce the hypothesis that the form of the electron
+experiences a contraction in the direction of motion in consequence of
+that motion. the contracted length being proportional to the
+expression
+
+                        eq. 05: file eq05.gif
+
+This, hypothesis, which is not justifiable by any electrodynamical
+facts, supplies us then with that particular law of motion which has
+been confirmed with great precision in recent years.
+
+The theory of relativity leads to the same law of motion, without
+requiring any special hypothesis whatsoever as to the structure and
+the behaviour of the electron. We arrived at a similar conclusion in
+Section 13 in connection with the experiment of Fizeau, the result
+of which is foretold by the theory of relativity without the necessity
+of drawing on hypotheses as to the physical nature of the liquid.
+
+The second class of facts to which we have alluded has reference to
+the question whether or not the motion of the earth in space can be
+made perceptible in terrestrial experiments. We have already remarked
+in Section 5 that all attempts of this nature led to a negative
+result. Before the theory of relativity was put forward, it was
+difficult to become reconciled to this negative result, for reasons
+now to be discussed. The inherited prejudices about time and space did
+not allow any doubt to arise as to the prime importance of the
+Galileian transformation for changing over from one body of reference
+to another. Now assuming that the Maxwell-Lorentz equations hold for a
+reference-body K, we then find that they do not hold for a
+reference-body K1 moving uniformly with respect to K, if we assume
+that the relations of the Galileian transformstion exist between the
+co-ordinates of K and K1. It thus appears that, of all Galileian
+co-ordinate systems, one (K) corresponding to a particular state of
+motion is physically unique. This result was interpreted physically by
+regarding K as at rest with respect to a hypothetical ćther of space.
+On the other hand, all coordinate systems K1 moving relatively to K
+were to be regarded as in motion with respect to the ćther. To this
+motion of K1 against the ćther ("ćther-drift " relative to K1) were
+attributed the more complicated laws which were supposed to hold
+relative to K1. Strictly speaking, such an ćther-drift ought also to
+be assumed relative to the earth, and for a long time the efforts of
+physicists were devoted to attempts to detect the existence of an
+ćther-drift at the earth's surface.
+
+In one of the most notable of these attempts Michelson devised a
+method which appears as though it must be decisive. Imagine two
+mirrors so arranged on a rigid body that the reflecting surfaces face
+each other. A ray of light requires a perfectly definite time T to
+pass from one mirror to the other and back again, if the whole system
+be at rest with respect to the ćther. It is found by calculation,
+however, that a slightly different time T1 is required for this
+process, if the body, together with the mirrors, be moving relatively
+to the ćther. And yet another point: it is shown by calculation that
+for a given velocity v with reference to the ćther, this time T1 is
+different when the body is moving perpendicularly to the planes of the
+mirrors from that resulting when the motion is parallel to these
+planes. Although the estimated difference between these two times is
+exceedingly small, Michelson and Morley performed an experiment
+involving interference in which this difference should have been
+clearly detectable. But the experiment gave a negative result -- a
+fact very perplexing to physicists. Lorentz and FitzGerald rescued the
+theory from this difficulty by assuming that the motion of the body
+relative to the ćther produces a contraction of the body in the
+direction of motion, the amount of contraction being just sufficient
+to compensate for the differeace in time mentioned above. Comparison
+with the discussion in Section 11 shows that also from the
+standpoint of the theory of relativity this solution of the difficulty
+was the right one. But on the basis of the theory of relativity the
+method of interpretation is incomparably more satisfactory. According
+to this theory there is no such thing as a " specially favoured "
+(unique) co-ordinate system to occasion the introduction of the
+ćther-idea, and hence there can be no ćther-drift, nor any experiment
+with which to demonstrate it. Here the contraction of moving bodies
+follows from the two fundamental principles of the theory, without the
+introduction of particular hypotheses ; and as the prime factor
+involved in this contraction we find, not the motion in itself, to
+which we cannot attach any meaning, but the motion with respect to the
+body of reference chosen in the particular case in point. Thus for a
+co-ordinate system moving with the earth the mirror system of
+Michelson and Morley is not shortened, but it is shortened for a
+co-ordinate system which is at rest relatively to the sun.
+
+
+  Notes
+
+*) The general theory of relativity renders it likely that the
+electrical masses of an electron are held together by gravitational
+forces.
+
+
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE
+
+
+The non-mathematician is seized by a mysterious shuddering when he
+hears of "four-dimensional" things, by a feeling not unlike that
+awakened by thoughts of the occult. And yet there is no more
+common-place statement than that the world in which we live is a
+four-dimensional space-time continuum.
+
+Space is a three-dimensional continuum. By this we mean that it is
+possible to describe the position of a point (at rest) by means of
+three numbers (co-ordinales) x, y, z, and that there is an indefinite
+number of points in the neighbourhood of this one, the position of
+which can be described by co-ordinates such as x[1], y[1], z[1], which
+may be as near as we choose to the respective values of the
+co-ordinates x, y, z, of the first point. In virtue of the latter
+property we speak of a " continuum," and owing to the fact that there
+are three co-ordinates we speak of it as being " three-dimensional."
+
+Similarly, the world of physical phenomena which was briefly called "
+world " by Minkowski is naturally four dimensional in the space-time
+sense. For it is composed of individual events, each of which is
+described by four numbers, namely, three space co-ordinates x, y, z,
+and a time co-ordinate, the time value t. The" world" is in this sense
+also a continuum; for to every event there are as many "neighbouring"
+events (realised or at least thinkable) as we care to choose, the
+co-ordinates x[1], y[1], z[1], t[1] of which differ by an indefinitely
+small amount from those of the event x, y, z, t originally considered.
+That we have not been accustomed to regard the world in this sense as
+a four-dimensional continuum is due to the fact that in physics,
+before the advent of the theory of relativity, time played a different
+and more independent role, as compared with the space coordinates. It
+is for this reason that we have been in the habit of treating time as
+an independent continuum. As a matter of fact, according to classical
+mechanics, time is absolute, i.e. it is independent of the position
+and the condition of motion of the system of co-ordinates. We see this
+expressed in the last equation of the Galileian transformation (t1 =
+t)
+
+The four-dimensional mode of consideration of the "world" is natural
+on the theory of relativity, since according to this theory time is
+robbed of its independence. This is shown by the fourth equation of
+the Lorentz transformation:
+
+                        eq. 24: file eq24.gif
+
+
+Moreover, according to this equation the time difference Dt1 of two
+events with respect to K1 does not in general vanish, even when the
+time difference Dt1 of the same events with reference to K vanishes.
+Pure " space-distance " of two events with respect to K results in "
+time-distance " of the same events with respect to K. But the
+discovery of Minkowski, which was of importance for the formal
+development of the theory of relativity, does not lie here. It is to
+be found rather in the fact of his recognition that the
+four-dimensional space-time continuum of the theory of relativity, in
+its most essential formal properties, shows a pronounced relationship
+to the three-dimensional continuum of Euclidean geometrical
+space.*  In order to give due prominence to this relationship,
+however, we must replace the usual time co-ordinate t by an imaginary
+magnitude eq. 25 proportional to it. Under these conditions, the
+natural laws satisfying the demands of the (special) theory of
+relativity assume mathematical forms, in which the time co-ordinate
+plays exactly the same role as the three space co-ordinates. Formally,
+these four co-ordinates correspond exactly to the three space
+co-ordinates in Euclidean geometry. It must be clear even to the
+non-mathematician that, as a consequence of this purely formal
+addition to our knowledge, the theory perforce gained clearness in no
+mean measure.
+
+These inadequate remarks can give the reader only a vague notion of
+the important idea contributed by Minkowski. Without it the general
+theory of relativity, of which the fundamental ideas are developed in
+the following pages, would perhaps have got no farther than its long
+clothes. Minkowski's work is doubtless difficult of access to anyone
+inexperienced in mathematics, but since it is not necessary to have a
+very exact grasp of this work in order to understand the fundamental
+ideas of either the special or the general theory of relativity, I
+shall leave it here at present, and revert to it only towards the end
+of Part 2.
+
+
+  Notes
+
+*) Cf. the somewhat more detailed discussion in Appendix II.
+
+
+
+
+PART II
+
+THE GENERAL THEORY OF RELATIVITY
+
+
+SPECIAL AND GENERAL PRINCIPLE OF RELATIVITY
+
+
+The basal principle, which was the pivot of all our previous
+considerations, was the special principle of relativity, i.e. the
+principle of the physical relativity of all uniform motion. Let as
+once more analyse its meaning carefully.
+
+It was at all times clear that, from the point of view of the idea it
+conveys to us, every motion must be considered only as a relative
+motion. Returning to the illustration we have frequently used of the
+embankment and the railway carriage, we can express the fact of the
+motion here taking place in the following two forms, both of which are
+equally justifiable :
+
+(a) The carriage is in motion relative to the embankment,
+(b) The embankment is in motion relative to the carriage.
+
+In (a) the embankment, in (b) the carriage, serves as the body of
+reference in our statement of the motion taking place. If it is simply
+a question of detecting or of describing the motion involved, it is in
+principle immaterial to what reference-body we refer the motion. As
+already mentioned, this is self-evident, but it must not be confused
+with the much more comprehensive statement called "the principle of
+relativity," which we have taken as the basis of our investigations.
+
+The principle we have made use of not only maintains that we may
+equally well choose the carriage or the embankment as our
+reference-body for the description of any event (for this, too, is
+self-evident). Our principle rather asserts what follows : If we
+formulate the general laws of nature as they are obtained from
+experience, by making use of
+
+(a) the embankment as reference-body,
+(b) the railway carriage as reference-body,
+
+then these general laws of nature (e.g. the laws of mechanics or the
+law of the propagation of light in vacuo) have exactly the same form
+in both cases. This can also be expressed as follows : For the
+physical description of natural processes, neither of the reference
+bodies K, K1 is unique (lit. " specially marked out ") as compared
+with the other. Unlike the first, this latter statement need not of
+necessity hold a priori; it is not contained in the conceptions of "
+motion" and " reference-body " and derivable from them; only
+experience can decide as to its correctness or incorrectness.
+
+Up to the present, however, we have by no means maintained the
+equivalence of all bodies of reference K in connection with the
+formulation of natural laws. Our course was more on the following
+Iines. In the first place, we started out from the assumption that
+there exists a reference-body K, whose condition of motion is such
+that the Galileian law holds with respect to it : A particle left to
+itself and sufficiently far removed from all other particles moves
+uniformly in a straight line. With reference to K (Galileian
+reference-body) the laws of nature were to be as simple as possible.
+But in addition to K, all bodies of reference K1 should be given
+preference in this sense, and they should be exactly equivalent to K
+for the formulation of natural laws, provided that they are in a state
+of uniform rectilinear and non-rotary motion with respect to K ; all
+these bodies of reference are to be regarded as Galileian
+reference-bodies. The validity of the principle of relativity was
+assumed only for these reference-bodies, but not for others (e.g.
+those possessing motion of a different kind). In this sense we speak
+of the special principle of relativity, or special theory of
+relativity.
+
+In contrast to this we wish to understand by the "general principle of
+relativity" the following statement : All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion. But before proceeding farther, it ought to be pointed
+out that this formulation must be replaced later by a more abstract
+one, for reasons which will become evident at a later stage.
+
+Since the introduction of the special principle of relativity has been
+justified, every intellect which strives after generalisation must
+feel the temptation to venture the step towards the general principle
+of relativity. But a simple and apparently quite reliable
+consideration seems to suggest that, for the present at any rate,
+there is little hope of success in such an attempt; Let us imagine
+ourselves transferred to our old friend the railway carriage, which is
+travelling at a uniform rate. As long as it is moving unifromly, the
+occupant of the carriage is not sensible of its motion, and it is for
+this reason that he can without reluctance interpret the facts of the
+case as indicating that the carriage is at rest, but the embankment in
+motion. Moreover, according to the special principle of relativity,
+this interpretation is quite justified also from a physical point of
+view.
+
+If the motion of the carriage is now changed into a non-uniform
+motion, as for instance by a powerful application of the brakes, then
+the occupant of the carriage experiences a correspondingly powerful
+jerk forwards. The retarded motion is manifested in the mechanical
+behaviour of bodies relative to the person in the railway carriage.
+The mechanical behaviour is different from that of the case previously
+considered, and for this reason it would appear to be impossible that
+the same mechanical laws hold relatively to the non-uniformly moving
+carriage, as hold with reference to the carriage when at rest or in
+uniform motion. At all events it is clear that the Galileian law does
+not hold with respect to the non-uniformly moving carriage. Because of
+this, we feel compelled at the present juncture to grant a kind of
+absolute physical reality to non-uniform motion, in opposition to the
+general principle of relatvity. But in what follows we shall soon see
+that this conclusion cannot be maintained.
+
+
+
+THE GRAVITATIONAL FIELD
+
+
+"If we pick up a stone and then let it go, why does it fall to the
+ground ?" The usual answer to this question is: "Because it is
+attracted by the earth." Modern physics formulates the answer rather
+differently for the following reason. As a result of the more careful
+study of electromagnetic phenomena, we have come to regard action at a
+distance as a process impossible without the intervention of some
+intermediary medium. If, for instance, a magnet attracts a piece of
+iron, we cannot be content to regard this as meaning that the magnet
+acts directly on the iron through the intermediate empty space, but we
+are constrained to imagine -- after the manner of Faraday -- that the
+magnet always calls into being something physically real in the space
+around it, that something being what we call a "magnetic field." In
+its turn this magnetic field operates on the piece of iron, so that
+the latter strives to move towards the magnet. We shall not discuss
+here the justification for this incidental conception, which is indeed
+a somewhat arbitrary one. We shall only mention that with its aid
+electromagnetic phenomena can be theoretically represented much more
+satisfactorily than without it, and this applies particularly to the
+transmission of electromagnetic waves. The effects of gravitation also
+are regarded in an analogous manner.
+
+The action of the earth on the stone takes place indirectly. The earth
+produces in its surrounding a gravitational field, which acts on the
+stone and produces its motion of fall. As we know from experience, the
+intensity of the action on a body dimishes according to a quite
+definite law, as we proceed farther and farther away from the earth.
+From our point of view this means : The law governing the properties
+of the gravitational field in space must be a perfectly definite one,
+in order correctly to represent the diminution of gravitational action
+with the distance from operative bodies. It is something like this:
+The body (e.g. the earth) produces a field in its immediate
+neighbourhood directly; the intensity and direction of the field at
+points farther removed from the body are thence determined by the law
+which governs the properties in space of the gravitational fields
+themselves.
+
+In contrast to electric and magnetic fields, the gravitational field
+exhibits a most remarkable property, which is of fundamental
+importance for what follows. Bodies which are moving under the sole
+influence of a gravitational field receive an acceleration, which does
+not in the least depend either on the material or on the physical
+state of the body. For instance, a piece of lead and a piece of wood
+fall in exactly the same manner in a gravitational field (in vacuo),
+when they start off from rest or with the same initial velocity. This
+law, which holds most accurately, can be expressed in a different form
+in the light of the following consideration.
+
+According to Newton's law of motion, we have
+
+(Force) = (inertial mass) x (acceleration),
+
+where the "inertial mass" is a characteristic constant of the
+accelerated body. If now gravitation is the cause of the acceleration,
+we then have
+
+(Force) = (gravitational mass) x (intensity of the gravitational
+field),
+
+where the "gravitational mass" is likewise a characteristic constant
+for the body. From these two relations follows:
+
+                                eq. 26: file eq26.gif
+
+
+If now, as we find from experience, the acceleration is to be
+independent of the nature and the condition of the body and always the
+same for a given gravitational field, then the ratio of the
+gravitational to the inertial mass must likewise be the same for all
+bodies. By a suitable choice of units we can thus make this ratio
+equal to unity. We then have the following law: The gravitational mass
+of a body is equal to its inertial law.
+
+It is true that this important law had hitherto been recorded in
+mechanics, but it had not been interpreted. A satisfactory
+interpretation can be obtained only if we recognise the following fact
+: The same quality of a body manifests itself according to
+circumstances as " inertia " or as " weight " (lit. " heaviness '). In
+the following section we shall show to what extent this is actually
+the case, and how this question is connected with the general
+postulate of relativity.
+
+
+
+
+THE EQUALITY OF INERTIAL AND GRAVITATIONAL MASS
+AS AN ARGUMENT FOR THE GENERAL POSTULE OF RELATIVITY
+
+
+We imagine a large portion of empty space, so far removed from stars
+and other appreciable masses, that we have before us approximately the
+conditions required by the fundamental law of Galilei. It is then
+possible to choose a Galileian reference-body for this part of space
+(world), relative to which points at rest remain at rest and points in
+motion continue permanently in uniform rectilinear motion. As
+reference-body let us imagine a spacious chest resembling a room with
+an observer inside who is equipped with apparatus. Gravitation
+naturally does not exist for this observer. He must fasten himself
+with strings to the floor, otherwise the slightest impact against the
+floor will cause him to rise slowly towards the ceiling of the room.
+
+To the middle of the lid of the chest is fixed externally a hook with
+rope attached, and now a " being " (what kind of a being is immaterial
+to us) begins pulling at this with a constant force. The chest
+together with the observer then begin to move "upwards" with a
+uniformly accelerated motion. In course of time their velocity will
+reach unheard-of values -- provided that we are viewing all this from
+another reference-body which is not being pulled with a rope.
+
+But how does the man in the chest regard the Process ? The
+acceleration of the chest will be transmitted to him by the reaction
+of the floor of the chest. He must therefore take up this pressure by
+means of his legs if he does not wish to be laid out full length on
+the floor. He is then standing in the chest in exactly the same way as
+anyone stands in a room of a home on our earth. If he releases a body
+which he previously had in his land, the accelertion of the chest will
+no longer be transmitted to this body, and for this reason the body
+will approach the floor of the chest with an accelerated relative
+motion. The observer will further convince himself that the
+acceleration of the body towards the floor of the chest is always of
+the same magnitude, whatever kind of body he may happen to use for the
+experiment.
+
+Relying on his knowledge of the gravitational field (as it was
+discussed in the preceding section), the man in the chest will thus
+come to the conclusion that he and the chest are in a gravitational
+field which is constant with regard to time. Of course he will be
+puzzled for a moment as to why the chest does not fall in this
+gravitational field. just then, however, he discovers the hook in the
+middle of the lid of the chest and the rope which is attached to it,
+and he consequently comes to the conclusion that the chest is
+suspended at rest in the gravitational field.
+
+Ought we to smile at the man and say that he errs in his conclusion ?
+I do not believe we ought to if we wish to remain consistent ; we must
+rather admit that his mode of grasping the situation violates neither
+reason nor known mechanical laws. Even though it is being accelerated
+with respect to the "Galileian space" first considered, we can
+nevertheless regard the chest as being at rest. We have thus good
+grounds for extending the principle of relativity to include bodies of
+reference which are accelerated with respect to each other, and as a
+result we have gained a powerful argument for a generalised postulate
+of relativity.
+
+We must note carefully that the possibility of this mode of
+interpretation rests on the fundamental property of the gravitational
+field of giving all bodies the same acceleration, or, what comes to
+the same thing, on the law of the equality of inertial and
+gravitational mass. If this natural law did not exist, the man in the
+accelerated chest would not be able to interpret the behaviour of the
+bodies around him on the supposition of a gravitational field, and he
+would not be justified on the grounds of experience in supposing his
+reference-body to be " at rest."
+
+Suppose that the man in the chest fixes a rope to the inner side of
+the lid, and that he attaches a body to the free end of the rope. The
+result of this will be to strech the rope so that it will hang "
+vertically " downwards. If we ask for an opinion of the cause of
+tension in the rope, the man in the chest will say: "The suspended
+body experiences a downward force in the gravitational field, and this
+is neutralised by the tension of the rope ; what determines the
+magnitude of the tension of the rope is the gravitational mass of the
+suspended body." On the other hand, an observer who is poised freely
+in space will interpret the condition of things thus : " The rope must
+perforce take part in the accelerated motion of the chest, and it
+transmits this motion to the body attached to it. The tension of the
+rope is just large enough to effect the acceleration of the body. That
+which determines the magnitude of the tension of the rope is the
+inertial mass of the body." Guided by this example, we see that our
+extension of the principle of relativity implies the necessity of the
+law of the equality of inertial and gravitational mass. Thus we have
+obtained a physical interpretation of this law.
+
+From our consideration of the accelerated chest we see that a general
+theory of relativity must yield important results on the laws of
+gravitation. In point of fact, the systematic pursuit of the general
+idea of relativity has supplied the laws satisfied by the
+gravitational field. Before proceeding farther, however, I must warn
+the reader against a misconception suggested by these considerations.
+A gravitational field exists for the man in the chest, despite the
+fact that there was no such field for the co-ordinate system first
+chosen. Now we might easily suppose that the existence of a
+gravitational field is always only an apparent one. We might also
+think that, regardless of the kind of gravitational field which may be
+present, we could always choose another reference-body such that no
+gravitational field exists with reference to it. This is by no means
+true for all gravitational fields, but only for those of quite special
+form. It is, for instance, impossible to choose a body of reference
+such that, as judged from it, the gravitational field of the earth (in
+its entirety) vanishes.
+
+We can now appreciate why that argument is not convincing, which we
+brought forward against the general principle of relativity at theend
+of Section 18. It is certainly true that the observer in the
+railway carriage experiences a jerk forwards as a result of the
+application of the brake, and that he recognises, in this the
+non-uniformity of motion (retardation) of the carriage. But he is
+compelled by nobody to refer this jerk to a " real " acceleration
+(retardation) of the carriage. He might also interpret his experience
+thus: " My body of reference (the carriage) remains permanently at
+rest. With reference to it, however, there exists (during the period
+of application of the brakes) a gravitational field which is directed
+forwards and which is variable with respect to time. Under the
+influence of this field, the embankment together with the earth moves
+non-uniformly in such a manner that their original velocity in the
+backwards direction is continuously reduced."
+
+
+
+IN WHAT RESPECTS ARE THE FOUNDATIONS OF CLASSICAL MECHANICS AND OF THE
+SPECIAL THEORY OF RELATIVITY UNSATISFACTORY?
+
+
+We have already stated several times that classical mechanics starts
+out from the following law: Material particles sufficiently far
+removed from other material particles continue to move uniformly in a
+straight line or continue in a state of rest. We have also repeatedly
+emphasised that this fundamental law can only be valid for bodies of
+reference K which possess certain unique states of motion, and which
+are in uniform translational motion relative to each other. Relative
+to other reference-bodies K the law is not valid. Both in classical
+mechanics and in the special theory of relativity we therefore
+differentiate between reference-bodies K relative to which the
+recognised " laws of nature " can be said to hold, and
+reference-bodies K relative to which these laws do not hold.
+
+But no person whose mode of thought is logical can rest satisfied with
+this condition of things. He asks : " How does it come that certain
+reference-bodies (or their states of motion) are given priority over
+other reference-bodies (or their states of motion) ? What is the
+reason for this Preference? In order to show clearly what I mean by
+this question, I shall make use of a comparison.
+
+I am standing in front of a gas range. Standing alongside of each
+other on the range are two pans so much alike that one may be mistaken
+for the other. Both are half full of water. I notice that steam is
+being emitted continuously from the one pan, but not from the other. I
+am surprised at this, even if I have never seen either a gas range or
+a pan before. But if I now notice a luminous something of bluish
+colour under the first pan but not under the other, I cease to be
+astonished, even if I have never before seen a gas flame. For I can
+only say that this bluish something will cause the emission of the
+steam, or at least possibly it may do so. If, however, I notice the
+bluish something in neither case, and if I observe that the one
+continuously emits steam whilst the other does not, then I shall
+remain astonished and dissatisfied until I have discovered some
+circumstance to which I can attribute the different behaviour of the
+two pans.
+
+Analogously, I seek in vain for a real something in classical
+mechanics (or in the special theory of relativity) to which I can
+attribute the different behaviour of bodies considered with respect to
+the reference systems K and K1.*  Newton saw this objection and
+attempted to invalidate it, but without success. But E. Mach recognsed
+it most clearly of all, and because of this objection he claimed that
+mechanics must be placed on a new basis. It can only be got rid of by
+means of a physics which is conformable to the general principle of
+relativity, since the equations of such a theory hold for every body
+of reference, whatever may be its state of motion.
+
+
+  Notes
+
+*) The objection is of importance more especially when the state of
+motion of the reference-body is of such a nature that it does not
+require any external agency for its maintenance, e.g. in the case when
+the reference-body is rotating uniformly.
+
+
+
+A FEW INFERENCES FROM THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+The considerations of Section 20 show that the general principle of
+relativity puts us in a position to derive properties of the
+gravitational field in a purely theoretical manner. Let us suppose,
+for instance, that we know the space-time " course " for any natural
+process whatsoever, as regards the manner in which it takes place in
+the Galileian domain relative to a Galileian body of reference K. By
+means of purely theoretical operations (i.e. simply by calculation) we
+are then able to find how this known natural process appears, as seen
+from a reference-body K1 which is accelerated relatively to K. But
+since a gravitational field exists with respect to this new body of
+reference K1, our consideration also teaches us how the gravitational
+field influences the process studied.
+
+For example, we learn that a body which is in a state of uniform
+rectilinear motion with respect to K (in accordance with the law of
+Galilei) is executing an accelerated and in general curvilinear motion
+with respect to the accelerated reference-body K1 (chest). This
+acceleration or curvature corresponds to the influence on the moving
+body of the gravitational field prevailing relatively to K. It is
+known that a gravitational field influences the movement of bodies in
+this way, so that our consideration supplies us with nothing
+essentially new.
+
+However, we obtain a new result of fundamental importance when we
+carry out the analogous consideration for a ray of light. With respect
+to the Galileian reference-body K, such a ray of light is transmitted
+rectilinearly with the velocity c. It can easily be shown that the
+path of the same ray of light is no longer a straight line when we
+consider it with reference to the accelerated chest (reference-body
+K1). From this we conclude, that, in general, rays of light are
+propagated curvilinearly in gravitational fields. In two respects this
+result is of great importance.
+
+In the first place, it can be compared with the reality. Although a
+detailed examination of the question shows that the curvature of light
+rays required by the general theory of relativity is only exceedingly
+small for the gravitational fields at our disposal in practice, its
+estimated magnitude for light rays passing the sun at grazing
+incidence is nevertheless 1.7 seconds of arc. This ought to manifest
+itself in the following way. As seen from the earth, certain fixed
+stars appear to be in the neighbourhood of the sun, and are thus
+capable of observation during a total eclipse of the sun. At such
+times, these stars ought to appear to be displaced outwards from the
+sun by an amount indicated above, as compared with their apparent
+position in the sky when the sun is situated at another part of the
+heavens. The examination of the correctness or otherwise of this
+deduction is a problem of the greatest importance, the early solution
+of which is to be expected of astronomers.[2]*
+
+In the second place our result shows that, according to the general
+theory of relativity, the law of the constancy of the velocity of
+light in vacuo, which constitutes one of the two fundamental
+assumptions in the special theory of relativity and to which we have
+already frequently referred, cannot claim any unlimited validity. A
+curvature of rays of light can only take place when the velocity of
+propagation of light varies with position. Now we might think that as
+a consequence of this, the special theory of relativity and with it
+the whole theory of relativity would be laid in the dust. But in
+reality this is not the case. We can only conclude that the special
+theory of relativity cannot claim an unlinlited domain of validity ;
+its results hold only so long as we are able to disregard the
+influences of gravitational fields on the phenomena (e.g. of light).
+
+Since it has often been contended by opponents of the theory of
+relativity that the special theory of relativity is overthrown by the
+general theory of relativity, it is perhaps advisable to make the
+facts of the case clearer by means of an appropriate comparison.
+Before the development of electrodynamics the laws of electrostatics
+were looked upon as the laws of electricity. At the present time we
+know that electric fields can be derived correctly from electrostatic
+considerations only for the case, which is never strictly realised, in
+which the electrical masses are quite at rest relatively to each
+other, and to the co-ordinate system. Should we be justified in saying
+that for this reason electrostatics is overthrown by the
+field-equations of Maxwell in electrodynamics ? Not in the least.
+Electrostatics is contained in electrodynamics as a limiting case ;
+the laws of the latter lead directly to those of the former for the
+case in which the fields are invariable with regard to time. No fairer
+destiny could be allotted to any physical theory, than that it should
+of itself point out the way to the introduction of a more
+comprehensive theory, in which it lives on as a limiting case.
+
+In the example of the transmission of light just dealt with, we have
+seen that the general theory of relativity enables us to derive
+theoretically the influence of a gravitational field on the course of
+natural processes, the Iaws of which are already known when a
+gravitational field is absent. But the most attractive problem, to the
+solution of which the general theory of relativity supplies the key,
+concerns the investigation of the laws satisfied by the gravitational
+field itself. Let us consider this for a moment.
+
+We are acquainted with space-time domains which behave (approximately)
+in a " Galileian " fashion under suitable choice of reference-body,
+i.e. domains in which gravitational fields are absent. If we now refer
+such a domain to a reference-body K1 possessing any kind of motion,
+then relative to K1 there exists a gravitational field which is
+variable with respect to space and time.[3]**  The character of this
+field will of course depend on the motion chosen for K1. According to
+the general theory of relativity, the general law of the gravitational
+field must be satisfied for all gravitational fields obtainable in
+this way. Even though by no means all gravitationial fields can be
+produced in this way, yet we may entertain the hope that the general
+law of gravitation will be derivable from such gravitational fields of
+a special kind. This hope has been realised in the most beautiful
+manner. But between the clear vision of this goal and its actual
+realisation it was necessary to surmount a serious difficulty, and as
+this lies deep at the root of things, I dare not withhold it from the
+reader. We require to extend our ideas of the space-time continuum
+still farther.
+
+
+  Notes
+
+*) By means of the star photographs of two expeditions equipped by
+a Joint Committee of the Royal and Royal Astronomical Societies, the
+existence of the deflection of light demanded by theory was first
+confirmed during the solar eclipse of 29th May, 1919. (Cf. Appendix
+III.)
+
+**) This follows from a generalisation of the discussion in
+Section 20
+
+
+
+BEHAVIOUR OF CLOCKS AND MEASURING-RODS ON A ROTATING BODY OF REFERENCE
+
+
+Hitherto I have purposely refrained from speaking about the physical
+interpretation of space- and time-data in the case of the general
+theory of relativity. As a consequence, I am guilty of a certain
+slovenliness of treatment, which, as we know from the special theory
+of relativity, is far from being unimportant and pardonable. It is now
+high time that we remedy this defect; but I would mention at the
+outset, that this matter lays no small claims on the patience and on
+the power of abstraction of the reader.
+
+We start off again from quite special cases, which we have frequently
+used before. Let us consider a space time domain in which no
+gravitational field exists relative to a reference-body K whose state
+of motion has been suitably chosen. K is then a Galileian
+reference-body as regards the domain considered, and the results of
+the special theory of relativity hold relative to K. Let us supposse
+the same domain referred to a second body of reference K1, which is
+rotating uniformly with respect to K. In order to fix our ideas, we
+shall imagine K1 to be in the form of a plane circular disc, which
+rotates uniformly in its own plane about its centre. An observer who
+is sitting eccentrically on the disc K1 is sensible of a force which
+acts outwards in a radial direction, and which would be interpreted as
+an effect of inertia (centrifugal force) by an observer who was at
+rest with respect to the original reference-body K. But the observer
+on the disc may regard his disc as a reference-body which is " at rest
+" ; on the basis of the general principle of relativity he is
+justified in doing this. The force acting on himself, and in fact on
+all other bodies which are at rest relative to the disc, he regards as
+the effect of a gravitational field. Nevertheless, the
+space-distribution of this gravitational field is of a kind that would
+not be possible on Newton's theory of gravitation.* But since the
+observer believes in the general theory of relativity, this does not
+disturb him; he is quite in the right when he believes that a general
+law of gravitation can be formulated- a law which not only explains
+the motion of the stars correctly, but also the field of force
+experienced by himself.
+
+The observer performs experiments on his circular disc with clocks and
+measuring-rods. In doing so, it is his intention to arrive at exact
+definitions for the signification of time- and space-data with
+reference to the circular disc K1, these definitions being based on
+his observations. What will be his experience in this enterprise ?
+
+To start with, he places one of two identically constructed clocks at
+the centre of the circular disc, and the other on the edge of the
+disc, so that they are at rest relative to it. We now ask ourselves
+whether both clocks go at the same rate from the standpoint of the
+non-rotating Galileian reference-body K. As judged from this body, the
+clock at the centre of the disc has no velocity, whereas the clock at
+the edge of the disc is in motion relative to K in consequence of the
+rotation. According to a result obtained in Section 12, it follows
+that the latter clock goes at a rate permanently slower than that of
+the clock at the centre of the circular disc, i.e. as observed from K.
+It is obvious that the same effect would be noted by an observer whom
+we will imagine sitting alongside his clock at the centre of the
+circular disc. Thus on our circular disc, or, to make the case more
+general, in every gravitational field, a clock will go more quickly or
+less quickly, according to the position in which the clock is situated
+(at rest). For this reason it is not possible to obtain a reasonable
+definition of time with the aid of clocks which are arranged at rest
+with respect to the body of reference. A similar difficulty presents
+itself when we attempt to apply our earlier definition of simultaneity
+in such a case, but I do not wish to go any farther into this
+question.
+
+Moreover, at this stage the definition of the space co-ordinates also
+presents insurmountable difficulties. If the observer applies his
+standard measuring-rod (a rod which is short as compared with the
+radius of the disc) tangentially to the edge of the disc, then, as
+judged from the Galileian system, the length of this rod will be less
+than I, since, according to Section 12, moving bodies suffer a
+shortening in the direction of the motion. On the other hand, the
+measaring-rod will not experience a shortening in length, as judged
+from K, if it is applied to the disc in the direction of the radius.
+If, then, the observer first measures the circumference of the disc
+with his measuring-rod and then the diameter of the disc, on dividing
+the one by the other, he will not obtain as quotient the familiar
+number p = 3.14 . . ., but a larger number,[4]** whereas of course,
+for a disc which is at rest with respect to K, this operation would
+yield p exactly. This proves that the propositions of Euclidean
+geometry cannot hold exactly on the rotating disc, nor in general in a
+gravitational field, at least if we attribute the length I to the rod
+in all positions and in every orientation. Hence the idea of a
+straight line also loses its meaning. We are therefore not in a
+position to define exactly the co-ordinates x, y, z relative to the
+disc by means of the method used in discussing the special theory, and
+as long as the co- ordinates and times of events have not been
+defined, we cannot assign an exact meaning to the natural laws in
+which these occur.
+
+Thus all our previous conclusions based on general relativity would
+appear to be called in question. In reality we must make a subtle
+detour in order to be able to apply the postulate of general
+relativity exactly. I shall prepare the reader for this in the
+following paragraphs.
+
+
+  Notes
+
+*) The field disappears at the centre of the disc and increases
+proportionally to the distance from the centre as we proceed outwards.
+
+**) Throughout this consideration we have to use the Galileian
+(non-rotating) system K as reference-body, since we may only assume
+the validity of the results of the special theory of relativity
+relative to K (relative to K1 a gravitational field prevails).
+
+
+
+EUCLIDEAN AND NON-EUCLIDEAN CONTINUUM
+
+
+The surface of a marble table is spread out in front of me. I can get
+from any one point on this table to any other point by passing
+continuously from one point to a " neighbouring " one, and repeating
+this process a (large) number of times, or, in other words, by going
+from point to point without executing "jumps." I am sure the reader
+will appreciate with sufficient clearness what I mean here by "
+neighbouring " and by " jumps " (if he is not too pedantic). We
+express this property of the surface by describing the latter as a
+continuum.
+
+Let us now imagine that a large number of little rods of equal length
+have been made, their lengths being small compared with the dimensions
+of the marble slab. When I say they are of equal length, I mean that
+one can be laid on any other without the ends overlapping. We next lay
+four of these little rods on the marble slab so that they constitute a
+quadrilateral figure (a square), the diagonals of which are equally
+long. To ensure the equality of the diagonals, we make use of a little
+testing-rod. To this square we add similar ones, each of which has one
+rod in common with the first. We proceed in like manner with each of
+these squares until finally the whole marble slab is laid out with
+squares. The arrangement is such, that each side of a square belongs
+to two squares and each corner to four squares.
+
+It is a veritable wonder that we can carry out this business without
+getting into the greatest difficulties. We only need to think of the
+following. If at any moment three squares meet at a corner, then two
+sides of the fourth square are already laid, and, as a consequence,
+the arrangement of the remaining two sides of the square is already
+completely determined. But I am now no longer able to adjust the
+quadrilateral so that its diagonals may be equal. If they are equal of
+their own accord, then this is an especial favour of the marble slab
+and of the little rods, about which I can only be thankfully
+surprised. We must experience many such surprises if the construction
+is to be successful.
+
+If everything has really gone smoothly, then I say that the points of
+the marble slab constitute a Euclidean continuum with respect to the
+little rod, which has been used as a " distance " (line-interval). By
+choosing one corner of a square as " origin" I can characterise every
+other corner of a square with reference to this origin by means of two
+numbers. I only need state how many rods I must pass over when,
+starting from the origin, I proceed towards the " right " and then "
+upwards," in order to arrive at the corner of the square under
+consideration. These two numbers are then the " Cartesian co-ordinates
+" of this corner with reference to the " Cartesian co-ordinate system"
+which is determined by the arrangement of little rods.
+
+By making use of the following modification of this abstract
+experiment, we recognise that there must also be cases in which the
+experiment would be unsuccessful. We shall suppose that the rods "
+expand " by in amount proportional to the increase of temperature. We
+heat the central part of the marble slab, but not the periphery, in
+which case two of our little rods can still be brought into
+coincidence at every position on the table. But our construction of
+squares must necessarily come into disorder during the heating,
+because the little rods on the central region of the table expand,
+whereas those on the outer part do not.
+
+With reference to our little rods -- defined as unit lengths -- the
+marble slab is no longer a Euclidean continuum, and we are also no
+longer in the position of defining Cartesian co-ordinates directly
+with their aid, since the above construction can no longer be carried
+out. But since there are other things which are not influenced in a
+similar manner to the little rods (or perhaps not at all) by the
+temperature of the table, it is possible quite naturally to maintain
+the point of view that the marble slab is a " Euclidean continuum."
+This can be done in a satisfactory manner by making a more subtle
+stipulation about the measurement or the comparison of lengths.
+
+But if rods of every kind (i.e. of every material) were to behave in
+the same way as regards the influence of temperature when they are on
+the variably heated marble slab, and if we had no other means of
+detecting the effect of temperature than the geometrical behaviour of
+our rods in experiments analogous to the one described above, then our
+best plan would be to assign the distance one to two points on the
+slab, provided that the ends of one of our rods could be made to
+coincide with these two points ; for how else should we define the
+distance without our proceeding being in the highest measure grossly
+arbitrary ? The method of Cartesian coordinates must then be
+discarded, and replaced by another which does not assume the validity
+of Euclidean geometry for rigid bodies.*  The reader will notice
+that the situation depicted here corresponds to the one brought about
+by the general postitlate of relativity (Section 23).
+
+
+  Notes
+
+*) Mathematicians have been confronted with our problem in the
+following form. If we are given a surface (e.g. an ellipsoid) in
+Euclidean three-dimensional space, then there exists for this surface
+a two-dimensional geometry, just as much as for a plane surface. Gauss
+undertook the task of treating this two-dimensional geometry from
+first principles, without making use of the fact that the surface
+belongs to a Euclidean continuum of three dimensions. If we imagine
+constructions to be made with rigid rods in the surface (similar to
+that above with the marble slab), we should find that different laws
+hold for these from those resulting on the basis of Euclidean plane
+geometry. The surface is not a Euclidean continuum with respect to the
+rods, and we cannot define Cartesian co-ordinates in the surface.
+Gauss indicated the principles according to which we can treat the
+geometrical relationships in the surface, and thus pointed out the way
+to the method of Riemman of treating multi-dimensional, non-Euclidean
+continuum. Thus it is that mathematicians long ago solved the formal
+problems to which we are led by the general postulate of relativity.
+
+
+
+GAUSSIAN CO-ORDINATES
+
+
+According to Gauss, this combined analytical and geometrical mode of
+handling the problem can be arrived at in the following way. We
+imagine a system of arbitrary curves (see Fig. 4) drawn on the surface
+of the table. These we designate as u-curves, and we indicate each of
+them by means of a number. The Curves u= 1, u= 2 and u= 3 are drawn in
+the diagram. Between the curves u= 1 and u= 2 we must imagine an
+infinitely large number to be drawn, all of which correspond to real
+numbers lying between 1 and 2. fig. 04 We have then a system of
+u-curves, and this "infinitely dense" system covers the whole surface
+of the table. These u-curves must not intersect each other, and
+through each point of the surface one and only one curve must pass.
+Thus a perfectly definite value of u belongs to every point on the
+surface of the marble slab. In like manner we imagine a system of
+v-curves drawn on the surface. These satisfy the same conditions as
+the u-curves, they are provided with numbers in a corresponding
+manner, and they may likewise be of arbitrary shape. It follows that a
+value of u and a value of v belong to every point on the surface of
+the table. We call these two numbers the co-ordinates of the surface
+of the table (Gaussian co-ordinates). For example, the point P in the
+diagram has the Gaussian co-ordinates u= 3, v= 1. Two neighbouring
+points P and P1 on the surface then correspond to the co-ordinates
+
+                       P:       u,v
+
+                       P1:     u + du, v + dv,
+
+where du and dv signify very small numbers. In a similar manner we may
+indicate the distance (line-interval) between P and P1, as measured
+with a little rod, by means of the very small number ds. Then
+according to Gauss we have
+
+                ds2 = g[11]du2 + 2g[12]dudv = g[22]dv2
+
+where g[11], g[12], g[22], are magnitudes which depend in a perfectly
+definite way on u and v. The magnitudes g[11], g[12] and g[22],
+determine the behaviour of the rods relative to the u-curves and
+v-curves, and thus also relative to the surface of the table. For the
+case in which the points of the surface considered form a Euclidean
+continuum with reference to the measuring-rods, but only in this case,
+it is possible to draw the u-curves and v-curves and to attach numbers
+to them, in such a manner, that we simply have :
+
+                           ds2 = du2 + dv2
+
+Under these conditions, the u-curves and v-curves are straight lines
+in the sense of Euclidean geometry, and they are perpendicular to each
+other. Here the Gaussian coordinates are samply Cartesian ones. It is
+clear that Gauss co-ordinates are nothing more than an association of
+two sets of numbers with the points of the surface considered, of such
+a nature that numerical values differing very slightly from each other
+are associated with neighbouring points " in space."
+
+So far, these considerations hold for a continuum of two dimensions.
+But the Gaussian method can be applied also to a continuum of three,
+four or more dimensions. If, for instance, a continuum of four
+dimensions be supposed available, we may represent it in the following
+way. With every point of the continuum, we associate arbitrarily four
+numbers, x[1], x[2], x[3], x[4], which are known as " co-ordinates."
+Adjacent points correspond to adjacent values of the coordinates. If a
+distance ds is associated with the adjacent points P and P1, this
+distance being measurable and well defined from a physical point of
+view, then the following formula holds:
+
+ds2 = g[11]dx[1]^2 + 2g[12]dx[1]dx[2] . . . . g[44]dx[4]^2,
+
+where the magnitudes g[11], etc., have values which vary with the
+position in the continuum. Only when the continuum is a Euclidean one
+is it possible to associate the co-ordinates x[1] . . x[4]. with the
+points of the continuum so that we have simply
+
+ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+In this case relations hold in the four-dimensional continuum which
+are analogous to those holding in our three-dimensional measurements.
+
+However, the Gauss treatment for ds2 which we have given above is not
+always possible. It is only possible when sufficiently small regions
+of the continuum under consideration may be regarded as Euclidean
+continua. For example, this obviously holds in the case of the marble
+slab of the table and local variation of temperature. The temperature
+is practically constant for a small part of the slab, and thus the
+geometrical behaviour of the rods is almost as it ought to be
+according to the rules of Euclidean geometry. Hence the imperfections
+of the construction of squares in the previous section do not show
+themselves clearly until this construction is extended over a
+considerable portion of the surface of the table.
+
+We can sum this up as follows: Gauss invented a method for the
+mathematical treatment of continua in general, in which "
+size-relations " (" distances " between neighbouring points) are
+defined. To every point of a continuum are assigned as many numbers
+(Gaussian coordinates) as the continuum has dimensions. This is done
+in such a way, that only one meaning can be attached to the
+assignment, and that numbers (Gaussian coordinates) which differ by an
+indefinitely small amount are assigned to adjacent points. The
+Gaussian coordinate system is a logical generalisation of the
+Cartesian co-ordinate system. It is also applicable to non-Euclidean
+continua, but only when, with respect to the defined "size" or
+"distance," small parts of the continuum under consideration behave
+more nearly like a Euclidean system, the smaller the part of the
+continuum under our notice.
+
+
+
+THE SPACE-TIME CONTINUUM OF THE SPEICAL THEORY OF RELATIVITY CONSIDERED AS A
+EUCLIDEAN CONTINUUM
+
+
+We are now in a position to formulate more exactly the idea of
+Minkowski, which was only vaguely indicated in Section 17. In
+accordance with the special theory of relativity, certain co-ordinate
+systems are given preference for the description of the
+four-dimensional, space-time continuum. We called these " Galileian
+co-ordinate systems." For these systems, the four co-ordinates x, y,
+z, t, which determine an event or -- in other words, a point of the
+four-dimensional continuum -- are defined physically in a simple
+manner, as set forth in detail in the first part of this book. For the
+transition from one Galileian system to another, which is moving
+uniformly with reference to the first, the equations of the Lorentz
+transformation are valid. These last form the basis for the derivation
+of deductions from the special theory of relativity, and in themselves
+they are nothing more than the expression of the universal validity of
+the law of transmission of light for all Galileian systems of
+reference.
+
+Minkowski found that the Lorentz transformations satisfy the following
+simple conditions. Let us consider two neighbouring events, the
+relative position of which in the four-dimensional continuum is given
+with respect to a Galileian reference-body K by the space co-ordinate
+differences dx, dy, dz and the time-difference dt. With reference to a
+second Galileian system we shall suppose that the corresponding
+differences for these two events are dx1, dy1, dz1, dt1. Then these
+magnitudes always fulfil the condition*
+
+     dx2 + dy2 + dz2 - c^2dt2 = dx1 2 + dy1 2 + dz1 2 - c^2dt1 2.
+
+The validity of the Lorentz transformation follows from this
+condition. We can express this as follows: The magnitude
+
+                   ds2 = dx2 + dy2 + dz2 - c^2dt2,
+
+which belongs to two adjacent points of the four-dimensional
+space-time continuum, has the same value for all selected (Galileian)
+reference-bodies. If we replace x, y, z, sq. rt. -I . ct , by x[1],
+x[2], x[3], x[4], we also obtaill the result that
+
+             ds2 = dx[1]^2 + dx[2]^2 + dx[3]^2 + dx[4]^2.
+
+is independent of the choice of the body of reference. We call the
+magnitude ds the " distance " apart of the two events or
+four-dimensional points.
+
+Thus, if we choose as time-variable the imaginary variable sq. rt. -I
+. ct instead of the real quantity t, we can regard the space-time
+contintium -- accordance with the special theory of relativity -- as a
+", Euclidean " four-dimensional continuum, a result which follows from
+the considerations of the preceding section.
+
+
+  Notes
+
+*) Cf. Appendixes I and 2. The relations which are derived
+there for the co-ordlnates themselves are valid also for co-ordinate
+differences, and thus also for co-ordinate differentials (indefinitely
+small differences).
+
+
+
+THE SPACE-TIME CONTINUUM OF THE GENERAL THEORY OF REALTIIVTY IS NOT A
+ECULIDEAN CONTINUUM
+
+
+In the first part of this book we were able to make use of space-time
+co-ordinates which allowed of a simple and direct physical
+interpretation, and which, according to Section 26, can be regarded
+as four-dimensional Cartesian co-ordinates. This was possible on the
+basis of the law of the constancy of the velocity of tight. But
+according to Section 21 the general theory of relativity cannot
+retain this law. On the contrary, we arrived at the result that
+according to this latter theory the velocity of light must always
+depend on the co-ordinates when a gravitational field is present. In
+connection with a specific illustration in Section 23, we found
+that the presence of a gravitational field invalidates the definition
+of the coordinates and the ifine, which led us to our objective in the
+special theory of relativity.
+
+In view of the resuIts of these considerations we are led to the
+conviction that, according to the general principle of relativity, the
+space-time continuum cannot be regarded as a Euclidean one, but that
+here we have the general case, corresponding to the marble slab with
+local variations of temperature, and with which we made acquaintance
+as an example of a two-dimensional continuum. Just as it was there
+impossible to construct a Cartesian co-ordinate system from equal
+rods, so here it is impossible to build up a system (reference-body)
+from rigid bodies and clocks, which shall be of such a nature that
+measuring-rods and clocks, arranged rigidly with respect to one
+another, shaIll indicate position and time directly. Such was the
+essence of the difficulty with which we were confronted in Section
+23.
+
+But the considerations of Sections 25 and 26 show us the way to
+surmount this difficulty. We refer the fourdimensional space-time
+continuum in an arbitrary manner to Gauss co-ordinates. We assign to
+every point of the continuum (event) four numbers, x[1], x[2], x[3],
+x[4] (co-ordinates), which have not the least direct physical
+significance, but only serve the purpose of numbering the points of
+the continuum in a definite but arbitrary manner. This arrangement
+does not even need to be of such a kind that we must regard x[1],
+x[2], x[3], as "space" co-ordinates and x[4], as a " time "
+co-ordinate.
+
+The reader may think that such a description of the world would be
+quite inadequate. What does it mean to assign to an event the
+particular co-ordinates x[1], x[2], x[3], x[4], if in themselves these
+co-ordinates have no significance ? More careful consideration shows,
+however, that this anxiety is unfounded. Let us consider, for
+instance, a material point with any kind of motion. If this point had
+only a momentary existence without duration, then it would to
+described in space-time by a single system of values x[1], x[2], x[3],
+x[4]. Thus its permanent existence must be characterised by an
+infinitely large number of such systems of values, the co-ordinate
+values of which are so close together as to give continuity;
+corresponding to the material point, we thus have a (uni-dimensional)
+line in the four-dimensional continuum. In the same way, any such
+lines in our continuum correspond to many points in motion. The only
+statements having regard to these points which can claim a physical
+existence are in reality the statements about their encounters. In our
+mathematical treatment, such an encounter is expressed in the fact
+that the two lines which represent the motions of the points in
+question have a particular system of co-ordinate values, x[1], x[2],
+x[3], x[4], in common. After mature consideration the reader will
+doubtless admit that in reality such encounters constitute the only
+actual evidence of a time-space nature with which we meet in physical
+statements.
+
+When we were describing the motion of a material point relative to a
+body of reference, we stated nothing more than the encounters of this
+point with particular points of the reference-body. We can also
+determine the corresponding values of the time by the observation of
+encounters of the body with clocks, in conjunction with the
+observation of the encounter of the hands of clocks with particular
+points on the dials. It is just the same in the case of
+space-measurements by means of measuring-rods, as a litttle
+consideration will show.
+
+The following statements hold generally : Every physical description
+resolves itself into a number of statements, each of which refers to
+the space-time coincidence of two events A and B. In terms of Gaussian
+co-ordinates, every such statement is expressed by the agreement of
+their four co-ordinates x[1], x[2], x[3], x[4]. Thus in reality, the
+description of the time-space continuum by means of Gauss co-ordinates
+completely replaces the description with the aid of a body of
+reference, without suffering from the defects of the latter mode of
+description; it is not tied down to the Euclidean character of the
+continuum which has to be represented.
+
+
+
+EXACT FORMULATION OF THE GENERAL PRINCIPLE OF RELATIVITY
+
+
+We are now in a position to replace the pro. visional formulation of
+the general principle of relativity given in Section 18 by an exact
+formulation. The form there used, "All bodies of reference K, K1,
+etc., are equivalent for the description of natural phenomena
+(formulation of the general laws of nature), whatever may be their
+state of motion," cannot be maintained, because the use of rigid
+reference-bodies, in the sense of the method followed in the special
+theory of relativity, is in general not possible in space-time
+description. The Gauss co-ordinate system has to take the place of the
+body of reference. The following statement corresponds to the
+fundamental idea of the general principle of relativity: "All Gaussian
+co-ordinate systems are essentially equivalent for the formulation of
+the general laws of nature."
+
+We can state this general principle of relativity in still another
+form, which renders it yet more clearly intelligible than it is when
+in the form of the natural extension of the special principle of
+relativity. According to the special theory of relativity, the
+equations which express the general laws of nature pass over into
+equations of the same form when, by making use of the Lorentz
+transformation, we replace the space-time variables x, y, z, t, of a
+(Galileian) reference-body K by the space-time variables x1, y1, z1,
+t1, of a new reference-body K1. According to the general theory of
+relativity, on the other hand, by application of arbitrary
+substitutions of the Gauss variables x[1], x[2], x[3], x[4], the
+equations must pass over into equations of the same form; for every
+transformation (not only the Lorentz transformation) corresponds to
+the transition of one Gauss co-ordinate system into another.
+
+If we desire to adhere to our "old-time" three-dimensional view of
+things, then we can characterise the development which is being
+undergone by the fundamental idea of the general theory of relativity
+as follows : The special theory of relativity has reference to
+Galileian domains, i.e. to those in which no gravitational field
+exists. In this connection a Galileian reference-body serves as body
+of reference, i.e. a rigid body the state of motion of which is so
+chosen that the Galileian law of the uniform rectilinear motion of
+"isolated" material points holds relatively to it.
+
+Certain considerations suggest that we should refer the same Galileian
+domains to non-Galileian reference-bodies also. A gravitational field
+of a special kind is then present with respect to these bodies (cf.
+Sections 20 and 23).
+
+In gravitational fields there are no such things as rigid bodies with
+Euclidean properties; thus the fictitious rigid body of reference is
+of no avail in the general theory of relativity. The motion of clocks
+is also influenced by gravitational fields, and in such a way that a
+physical definition of time which is made directly with the aid of
+clocks has by no means the same degree of plausibility as in the
+special theory of relativity.
+
+For this reason non-rigid reference-bodies are used, which are as a
+whole not only moving in any way whatsoever, but which also suffer
+alterations in form ad lib. during their motion. Clocks, for which the
+law of motion is of any kind, however irregular, serve for the
+definition of time. We have to imagine each of these clocks fixed at a
+point on the non-rigid reference-body. These clocks satisfy only the
+one condition, that the "readings" which are observed simultaneously
+on adjacent clocks (in space) differ from each other by an
+indefinitely small amount. This non-rigid reference-body, which might
+appropriately be termed a "reference-mollusc", is in the main
+equivalent to a Gaussian four-dimensional co-ordinate system chosen
+arbitrarily. That which gives the "mollusc" a certain
+comprehensibility as compared with the Gauss co-ordinate system is the
+(really unjustified) formal retention of the separate existence of the
+space co-ordinates as opposed to the time co-ordinate. Every point on
+the mollusc is treated as a space-point, and every material point
+which is at rest relatively to it as at rest, so long as the mollusc
+is considered as reference-body. The general principle of relativity
+requires that all these molluscs can be used as reference-bodies with
+equal right and equal success in the formulation of the general laws
+of nature; the laws themselves must be quite independent of the choice
+of mollusc.
+
+The great power possessed by the general principle of relativity lies
+in the comprehensive limitation which is imposed on the laws of nature
+in consequence of what we have seen above.
+
+
+
+THE SOLUTION OF THE PROBLEM OF GRAVITATION ON THE BASIS OF THE GENERAL
+PRINCIPLE OF RELATIVITY
+
+
+If the reader has followed all our previous considerations, he will
+have no further difficulty in understanding the methods leading to the
+solution of the problem of gravitation.
+
+We start off on a consideration of a Galileian domain, i.e. a domain
+in which there is no gravitational field relative to the Galileian
+reference-body K. The behaviour of measuring-rods and clocks with
+reference to K is known from the special theory of relativity,
+likewise the behaviour of "isolated" material points; the latter move
+uniformly and in straight lines.
+
+Now let us refer this domain to a random Gauss coordinate system or to
+a "mollusc" as reference-body K1. Then with respect to K1 there is a
+gravitational field G (of a particular kind). We learn the behaviour
+of measuring-rods and clocks and also of freely-moving material points
+with reference to K1 simply by mathematical transformation. We
+interpret this behaviour as the behaviour of measuring-rods, docks and
+material points tinder the influence of the gravitational field G.
+Hereupon we introduce a hypothesis: that the influence of the
+gravitational field on measuringrods, clocks and freely-moving
+material points continues to take place according to the same laws,
+even in the case where the prevailing gravitational field is not
+derivable from the Galfleian special care, simply by means of a
+transformation of co-ordinates.
+
+The next step is to investigate the space-time behaviour of the
+gravitational field G, which was derived from the Galileian special
+case simply by transformation of the coordinates. This behaviour is
+formulated in a law, which is always valid, no matter how the
+reference-body (mollusc) used in the description may be chosen.
+
+This law is not yet the general law of the gravitational field, since
+the gravitational field under consideration is of a special kind. In
+order to find out the general law-of-field of gravitation we still
+require to obtain a generalisation of the law as found above. This can
+be obtained without caprice, however, by taking into consideration the
+following demands:
+
+(a) The required generalisation must likewise satisfy the general
+postulate of relativity.
+
+(b) If there is any matter in the domain under consideration, only its
+inertial mass, and thus according to Section 15 only its energy is
+of importance for its etfect in exciting a field.
+
+(c) Gravitational field and matter together must satisfy the law of
+the conservation of energy (and of impulse).
+
+Finally, the general principle of relativity permits us to determine
+the influence of the gravitational field on the course of all those
+processes which take place according to known laws when a
+gravitational field is absent i.e. which have already been fitted into
+the frame of the special theory of relativity. In this connection we
+proceed in principle according to the method which has already been
+explained for measuring-rods, clocks and freely moving material
+points.
+
+The theory of gravitation derived in this way from the general
+postulate of relativity excels not only in its beauty ; nor in
+removing the defect attaching to classical mechanics which was brought
+to light in Section 21; nor in interpreting the empirical law of
+the equality of inertial and gravitational mass ; but it has also
+already explained a result of observation in astronomy, against which
+classical mechanics is powerless.
+
+If we confine the application of the theory to the case where the
+gravitational fields can be regarded as being weak, and in which all
+masses move with respect to the coordinate system with velocities
+which are small compared with the velocity of light, we then obtain as
+a first approximation the Newtonian theory. Thus the latter theory is
+obtained here without any particular assumption, whereas Newton had to
+introduce the hypothesis that the force of attraction between mutually
+attracting material points is inversely proportional to the square of
+the distance between them. If we increase the accuracy of the
+calculation, deviations from the theory of Newton make their
+appearance, practically all of which must nevertheless escape the test
+of observation owing to their smallness.
+
+We must draw attention here to one of these deviations. According to
+Newton's theory, a planet moves round the sun in an ellipse, which
+would permanently maintain its position with respect to the fixed
+stars, if we could disregard the motion of the fixed stars themselves
+and the action of the other planets under consideration. Thus, if we
+correct the observed motion of the planets for these two influences,
+and if Newton's theory be strictly correct, we ought to obtain for the
+orbit of the planet an ellipse, which is fixed with reference to the
+fixed stars. This deduction, which can be tested with great accuracy,
+has been confirmed for all the planets save one, with the precision
+that is capable of being obtained by the delicacy of observation
+attainable at the present time. The sole exception is Mercury, the
+planet which lies nearest the sun. Since the time of Leverrier, it has
+been known that the ellipse corresponding to the orbit of Mercury,
+after it has been corrected for the influences mentioned above, is not
+stationary with respect to the fixed stars, but that it rotates
+exceedingly slowly in the plane of the orbit and in the sense of the
+orbital motion. The value obtained for this rotary movement of the
+orbital ellipse was 43 seconds of arc per century, an amount ensured
+to be correct to within a few seconds of arc. This effect can be
+explained by means of classical mechanics only on the assumption of
+hypotheses which have little probability, and which were devised
+solely for this purponse.
+
+On the basis of the general theory of relativity, it is found that the
+ellipse of every planet round the sun must necessarily rotate in the
+manner indicated above ; that for all the planets, with the exception
+of Mercury, this rotation is too small to be detected with the
+delicacy of observation possible at the present time ; but that in the
+case of Mercury it must amount to 43 seconds of arc per century, a
+result which is strictly in agreement with observation.
+
+Apart from this one, it has hitherto been possible to make only two
+deductions from the theory which admit of being tested by observation,
+to wit, the curvature of light rays by the gravitational field of the
+sun,*x and a displacement of the spectral lines of light reaching
+us from large stars, as compared with the corresponding lines for
+light produced in an analogous manner terrestrially (i.e. by the same
+kind of atom).**  These two deductions from the theory have both
+been confirmed.
+
+
+  Notes
+
+*) First observed by Eddington and others in 1919. (Cf. Appendix
+III, pp. 126-129).
+
+**) Established by Adams in 1924. (Cf. p. 132)
+
+
+
+
+PART III
+
+CONSIDERATIONS ON THE UNIVERSE AS A WHOLE
+
+
+COSMOLOGICAL DIFFICULTIES OF NEWTON'S THEORY
+
+
+Part from the difficulty discussed in Section 21, there is a second
+fundamental difficulty attending classical celestial mechanics, which,
+to the best of my knowledge, was first discussed in detail by the
+astronomer Seeliger. If we ponder over the question as to how the
+universe, considered as a whole, is to be regarded, the first answer
+that suggests itself to us is surely this: As regards space (and time)
+the universe is infinite. There are stars everywhere, so that the
+density of matter, although very variable in detail, is nevertheless
+on the average everywhere the same. In other words: However far we
+might travel through space, we should find everywhere an attenuated
+swarm of fixed stars of approrimately the same kind and density.
+
+This view is not in harmony with the theory of Newton. The latter
+theory rather requires that the universe should have a kind of centre
+in which the density of the stars is a maximum, and that as we proceed
+outwards from this centre the group-density of the stars should
+diminish, until finally, at great distances, it is succeeded by an
+infinite region of emptiness. The stellar universe ought to be a
+finite island in the infinite ocean of space.*
+
+This conception is in itself not very satisfactory. It is still less
+satisfactory because it leads to the result that the light emitted by
+the stars and also individual stars of the stellar system are
+perpetually passing out into infinite space, never to return, and
+without ever again coming into interaction with other objects of
+nature. Such a finite material universe would be destined to become
+gradually but systematically impoverished.
+
+In order to escape this dilemma, Seeliger suggested a modification of
+Newton's law, in which he assumes that for great distances the force
+of attraction between two masses diminishes more rapidly than would
+result from the inverse square law. In this way it is possible for the
+mean density of matter to be constant everywhere, even to infinity,
+without infinitely large gravitational fields being produced. We thus
+free ourselves from the distasteful conception that the material
+universe ought to possess something of the nature of a centre. Of
+course we purchase our emancipation from the fundamental difficulties
+mentioned, at the cost of a modification and complication of Newton's
+law which has neither empirical nor theoretical foundation. We can
+imagine innumerable laws which would serve the same purpose, without
+our being able to state a reason why one of them is to be preferred to
+the others ; for any one of these laws would be founded just as little
+on more general theoretical principles as is the law of Newton.
+
+
+  Notes
+
+*) Proof -- According to the theory of Newton, the number of "lines
+of force" which come from infinity and terminate in a mass m is
+proportional to the mass m. If, on the average, the Mass density p[0]
+is constant throughout tithe universe, then a sphere of volume V will
+enclose the average man p[0]V. Thus the number of lines of force
+passing through the surface F of the sphere into its interior is
+proportional to p[0] V. For unit area of the surface of the sphere the
+number of lines of force which enters the sphere is thus proportional
+to p[0] V/F or to p[0]R. Hence the intensity of the field at the
+surface would ultimately become infinite with increasing radius R of
+the sphere, which is impossible.
+
+
+
+THE POSSIBILITY OF A "FINITE" AND YET "UNBOUNDED" UNIVERSE
+
+
+But speculations on the structure of the universe also move in quite
+another direction. The development of non-Euclidean geometry led to
+the recognition of the fact, that we can cast doubt on the
+infiniteness of our space without coming into conflict with the laws
+of thought or with experience (Riemann, Helmholtz). These questions
+have already been treated in detail and with unsurpassable lucidity by
+Helmholtz and Poincaré, whereas I can only touch on them briefly here.
+
+In the first place, we imagine an existence in two dimensional space.
+Flat beings with flat implements, and in particular flat rigid
+measuring-rods, are free to move in a plane. For them nothing exists
+outside of this plane: that which they observe to happen to themselves
+and to their flat " things " is the all-inclusive reality of their
+plane. In particular, the constructions of plane Euclidean geometry
+can be carried out by means of the rods e.g. the lattice construction,
+considered in Section 24. In contrast to ours, the universe of
+these beings is two-dimensional; but, like ours, it extends to
+infinity. In their universe there is room for an infinite number of
+identical squares made up of rods, i.e. its volume (surface) is
+infinite. If these beings say their universe is " plane," there is
+sense in the statement, because they mean that they can perform the
+constructions of plane Euclidean geometry with their rods. In this
+connection the individual rods always represent the same distance,
+independently of their position.
+
+Let us consider now a second two-dimensional existence, but this time
+on a spherical surface instead of on a plane. The flat beings with
+their measuring-rods and other objects fit exactly on this surface and
+they are unable to leave it. Their whole universe of observation
+extends exclusively over the surface of the sphere. Are these beings
+able to regard the geometry of their universe as being plane geometry
+and their rods withal as the realisation of " distance " ? They cannot
+do this. For if they attempt to realise a straight line, they will
+obtain a curve, which we " three-dimensional beings " designate as a
+great circle, i.e. a self-contained line of definite finite length,
+which can be measured up by means of a measuring-rod. Similarly, this
+universe has a finite area that can be compared with the area, of a
+square constructed with rods. The great charm resulting from this
+consideration lies in the recognition of the fact that the universe of
+these beings is finite and yet has no limits.
+
+But the spherical-surface beings do not need to go on a world-tour in
+order to perceive that they are not living in a Euclidean universe.
+They can convince themselves of this on every part of their " world,"
+provided they do not use too small a piece of it. Starting from a
+point, they draw " straight lines " (arcs of circles as judged in
+three dimensional space) of equal length in all directions. They will
+call the line joining the free ends of these lines a " circle." For a
+plane surface, the ratio of the circumference of a circle to its
+diameter, both lengths being measured with the same rod, is, according
+to Euclidean geometry of the plane, equal to a constant value p, which
+is independent of the diameter of the circle. On their spherical
+surface our flat beings would find for this ratio the value
+
+                        eq. 27: file eq27.gif
+
+i.e. a smaller value than p, the difference being the more
+considerable, the greater is the radius of the circle in comparison
+with the radius R of the " world-sphere." By means of this relation
+the spherical beings can determine the radius of their universe ("
+world "), even when only a relatively small part of their worldsphere
+is available for their measurements. But if this part is very small
+indeed, they will no longer be able to demonstrate that they are on a
+spherical " world " and not on a Euclidean plane, for a small part of
+a spherical surface differs only slightly from a piece of a plane of
+the same size.
+
+Thus if the spherical surface beings are living on a planet of which
+the solar system occupies only a negligibly small part of the
+spherical universe, they have no means of determining whether they are
+living in a finite or in an infinite universe, because the " piece of
+universe " to which they have access is in both cases practically
+plane, or Euclidean. It follows directly from this discussion, that
+for our sphere-beings the circumference of a circle first increases
+with the radius until the " circumference of the universe " is
+reached, and that it thenceforward gradually decreases to zero for
+still further increasing values of the radius. During this process the
+area of the circle continues to increase more and more, until finally
+it becomes equal to the total area of the whole " world-sphere."
+
+Perhaps the reader will wonder why we have placed our " beings " on a
+sphere rather than on another closed surface. But this choice has its
+justification in the fact that, of all closed surfaces, the sphere is
+unique in possessing the property that all points on it are
+equivalent. I admit that the ratio of the circumference c of a circle
+to its radius r depends on r, but for a given value of r it is the
+same for all points of the " worldsphere "; in other words, the "
+world-sphere " is a " surface of constant curvature."
+
+To this two-dimensional sphere-universe there is a three-dimensional
+analogy, namely, the three-dimensional spherical space which was
+discovered by Riemann. its points are likewise all equivalent. It
+possesses a finite volume, which is determined by its "radius"
+(2p2R3). Is it possible to imagine a spherical space? To imagine a
+space means nothing else than that we imagine an epitome of our "
+space " experience, i.e. of experience that we can have in the
+movement of " rigid " bodies. In this sense we can imagine a spherical
+space.
+
+Suppose we draw lines or stretch strings in all directions from a
+point, and mark off from each of these the distance r with a
+measuring-rod. All the free end-points of these lengths lie on a
+spherical surface. We can specially measure up the area (F) of this
+surface by means of a square made up of measuring-rods. If the
+universe is Euclidean, then F = 4pR2 ; if it is spherical, then F is
+always less than 4pR2. With increasing values of r, F increases from
+zero up to a maximum value which is determined by the " world-radius,"
+but for still further increasing values of r, the area gradually
+diminishes to zero. At first, the straight lines which radiate from
+the starting point diverge farther and farther from one another, but
+later they approach each other, and finally they run together again at
+a "counter-point" to the starting point. Under such conditions they
+have traversed the whole spherical space. It is easily seen that the
+three-dimensional spherical space is quite analogous to the
+two-dimensional spherical surface. It is finite (i.e. of finite
+volume), and has no bounds.
+
+It may be mentioned that there is yet another kind of curved space: "
+elliptical space." It can be regarded as a curved space in which the
+two " counter-points " are identical (indistinguishable from each
+other). An elliptical universe can thus be considered to some extent
+as a curved universe possessing central symmetry.
+
+It follows from what has been said, that closed spaces without limits
+are conceivable. From amongst these, the spherical space (and the
+elliptical) excels in its simplicity, since all points on it are
+equivalent. As a result of this discussion, a most interesting
+question arises for astronomers and physicists, and that is whether
+the universe in which we live is infinite, or whether it is finite in
+the manner of the spherical universe. Our experience is far from being
+sufficient to enable us to answer this question. But the general
+theory of relativity permits of our answering it with a moduate degree
+of certainty, and in this connection the difficulty mentioned in
+Section 30 finds its solution.
+
+
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+
+
+According to the general theory of relativity, the geometrical
+properties of space are not independent, but they are determined by
+matter. Thus we can draw conclusions about the geometrical structure
+of the universe only if we base our considerations on the state of the
+matter as being something that is known. We know from experience that,
+for a suitably chosen co-ordinate system, the velocities of the stars
+are small as compared with the velocity of transmission of light. We
+can thus as a rough approximation arrive at a conclusion as to the
+nature of the universe as a whole, if we treat the matter as being at
+rest.
+
+We already know from our previous discussion that the behaviour of
+measuring-rods and clocks is influenced by gravitational fields, i.e.
+by the distribution of matter. This in itself is sufficient to exclude
+the possibility of the exact validity of Euclidean geometry in our
+universe. But it is conceivable that our universe differs only
+slightly from a Euclidean one, and this notion seems all the more
+probable, since calculations show that the metrics of surrounding
+space is influenced only to an exceedingly small extent by masses even
+of the magnitude of our sun. We might imagine that, as regards
+geometry, our universe behaves analogously to a surface which is
+irregularly curved in its individual parts, but which nowhere departs
+appreciably from a plane: something like the rippled surface of a
+lake. Such a universe might fittingly be called a quasi-Euclidean
+universe. As regards its space it would be infinite. But calculation
+shows that in a quasi-Euclidean universe the average density of matter
+would necessarily be nil. Thus such a universe could not be inhabited
+by matter everywhere ; it would present to us that unsatisfactory
+picture which we portrayed in Section 30.
+
+If we are to have in the universe an average density of matter which
+differs from zero, however small may be that difference, then the
+universe cannot be quasi-Euclidean. On the contrary, the results of
+calculation indicate that if matter be distributed uniformly, the
+universe would necessarily be spherical (or elliptical). Since in
+reality the detailed distribution of matter is not uniform, the real
+universe will deviate in individual parts from the spherical, i.e. the
+universe will be quasi-spherical. But it will be necessarily finite.
+In fact, the theory supplies us with a simple connection *  between
+the space-expanse of the universe and the average density of matter in
+it.
+
+
+  Notes
+
+*) For the radius R of the universe we obtain the equation
+
+                        eq. 28: file eq28.gif
+
+The use of the C.G.S. system in this equation gives 2/k = 1^.08.10^27;
+p is the average density of the matter and k is a constant connected
+with the Newtonian constant of gravitation.
+
+
+
+APPENDIX I
+
+SIMPLE DERIVATION OF THE LORENTZ TRANSFORMATION
+(SUPPLEMENTARY TO SECTION 11)
+
+
+For the relative orientation of the co-ordinate systems indicated in
+Fig. 2, the x-axes of both systems pernumently coincide. In the
+present case we can divide the problem into parts by considering first
+only events which are localised on the x-axis. Any such event is
+represented with respect to the co-ordinate system K by the abscissa x
+and the time t, and with respect to the system K1 by the abscissa x'
+and the time t'. We require to find x' and t' when x and t are given.
+
+A light-signal, which is proceeding along the positive axis of x, is
+transmitted according to the equation
+
+                                x = ct
+
+or
+
+                 x - ct = 0     .     .     .    (1).
+
+Since the same light-signal has to be transmitted relative to K1 with
+the velocity c, the propagation relative to the system K1 will be
+represented by the analogous formula
+
+                x' - ct' = O     .     .     .    (2)
+
+Those space-time points (events) which satisfy (x) must also satisfy
+(2). Obviously this will be the case when the relation
+
+          (x' - ct') = l (x - ct)     .     .     .    (3).
+
+is fulfilled in general, where l indicates a constant ; for, according
+to (3), the disappearance of (x - ct) involves the disappearance of
+(x' - ct').
+
+If we apply quite similar considerations to light rays which are being
+transmitted along the negative x-axis, we obtain the condition
+
+           (x' + ct') = ľ(x + ct)    .     .     .    (4).
+
+By adding (or subtracting) equations (3) and (4), and introducing for
+convenience the constants a and b in place of the constants l and ľ,
+where
+
+                        eq. 29: file eq29.gif
+
+and
+
+                        eq. 30: file eq30.gif
+
+we obtain the equations
+
+                        eq. 31: file eq31.gif
+
+We should thus have the solution of our problem, if the constants a
+and b were known. These result from the following discussion.
+
+For the origin of K1 we have permanently x' = 0, and hence according
+to the first of the equations (5)
+
+                        eq. 32: file eq32.gif
+
+If we call v the velocity with which the origin of K1 is moving
+relative to K, we then have
+
+                        eq. 33: file eq33.gif
+
+The same value v can be obtained from equations (5), if we calculate
+the velocity of another point of K1 relative to K, or the velocity
+(directed towards the negative x-axis) of a point of K with respect to
+K'. In short, we can designate v as the relative velocity of the two
+systems.
+
+Furthermore, the principle of relativity teaches us that, as judged
+from K, the length of a unit measuring-rod which is at rest with
+reference to K1 must be exactly the same as the length, as judged from
+K', of a unit measuring-rod which is at rest relative to K. In order
+to see how the points of the x-axis appear as viewed from K, we only
+require to take a " snapshot " of K1 from K; this means that we have
+to insert a particular value of t (time of K), e.g. t = 0. For this
+value of t we then obtain from the first of the equations (5)
+
+                               x' = ax
+
+Two points of the x'-axis which are separated by the distance Dx' = I
+when measured in the K1 system are thus separated in our instantaneous
+photograph by the distance
+
+                        eq. 34: file eq34.gif
+
+But if the snapshot be taken from K'(t' = 0), and if we eliminate t
+from the equations (5), taking into account the expression (6), we
+obtain
+
+                        eq. 35: file eq35.gif
+
+From this we conclude that two points on the x-axis separated by the
+distance I (relative to K) will be represented on our snapshot by the
+distance
+
+                        eq. 36: file eq36.gif
+
+But from what has been said, the two snapshots must be identical;
+hence Dx in (7) must be equal to Dx' in (7a), so that we obtain
+
+                        eq. 37: file eq37.gif
+
+The equations (6) and (7b) determine the constants a and b. By
+inserting the values of these constants in (5), we obtain the first
+and the fourth of the equations given in Section 11.
+
+                        eq. 38: file eq38.gif
+
+Thus we have obtained the Lorentz transformation for events on the
+x-axis. It satisfies the condition
+
+         x'2 - c^2t'2 = x2 - c^2t2    .     .     .    (8a).
+
+The extension of this result, to include events which take place
+outside the x-axis, is obtained by retaining equations (8) and
+supplementing them by the relations
+
+                        eq. 39: file eq39.gif
+
+In this way we satisfy the postulate of the constancy of the velocity
+of light in vacuo for rays of light of arbitrary direction, both for
+the system K and for the system K'. This may be shown in the following
+manner.
+
+We suppose a light-signal sent out from the origin of K at the time t
+= 0. It will be propagated according to the equation
+
+                        eq. 40: file eq40.gif
+
+or, if we square this equation, according to the equation
+
+          x2 + y2 + z2 = c^2t2 = 0    .     .     .    (10).
+
+It is required by the law of propagation of light, in conjunction with
+the postulate of relativity, that the transmission of the signal in
+question should take place -- as judged from K1 -- in accordance with
+the corresponding formula
+
+                               r' = ct'
+
+or,
+
+       x'2 + y'2 + z'2 - c^2t'2 = 0    .     .     .    (10a).
+
+In order that equation (10a) may be a consequence of equation (10), we
+must have
+
+   x'2 + y'2 + z'2 - c^2t'2 = s (x2 + y2 + z2 - c^2t2)       (11).
+
+Since equation (8a) must hold for points on the x-axis, we thus have s
+= I. It is easily seen that the Lorentz transformation really
+satisfies equation (11) for s = I; for (11) is a consequence of (8a)
+and (9), and hence also of (8) and (9). We have thus derived the
+Lorentz transformation.
+
+The Lorentz transformation represented by (8) and (9) still requires
+to be generalised. Obviously it is immaterial whether the axes of K1
+be chosen so that they are spatially parallel to those of K. It is
+also not essential that the velocity of translation of K1 with respect
+to K should be in the direction of the x-axis. A simple consideration
+shows that we are able to construct the Lorentz transformation in this
+general sense from two kinds of transformations, viz. from Lorentz
+transformations in the special sense and from purely spatial
+transformations. which corresponds to the replacement of the
+rectangular co-ordinate system by a new system with its axes pointing
+in other directions.
+
+Mathematically, we can characterise the generalised Lorentz
+transformation thus :
+
+It expresses x', y', x', t', in terms of linear homogeneous functions
+of x, y, x, t, of such a kind that the relation
+
+     x'2 + y'2 + z'2 - c^2t'2 = x2 + y2 + z2 - c^2t2       (11a).
+
+is satisficd identically. That is to say: If we substitute their
+expressions in x, y, x, t, in place of x', y', x', t', on the
+left-hand side, then the left-hand side of (11a) agrees with the
+right-hand side.
+
+
+
+APPENDIX II
+
+MINKOWSKI'S FOUR-DIMENSIONAL SPACE ("WORLD")
+(SUPPLEMENTARY TO SECTION 17)
+
+
+We can characterise the Lorentz transformation still more simply if we
+introduce the imaginary eq. 25 in place of t, as time-variable. If, in
+accordance with this, we insert
+
+                              x[1] = x
+                              x[2] = y
+                              x[3] = z
+                              x[4] = eq. 25
+
+and similarly for the accented system K1, then the condition which is
+identically satisfied by the transformation can be expressed thus :
+
+x[1]'2 + x[2]'2 + x[3]'2 + x[4]'2 = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    (12).
+
+That is, by the afore-mentioned choice of " coordinates," (11a) [see
+the end of Appendix II] is transformed into this equation.
+
+We see from (12) that the imaginary time co-ordinate x[4], enters into
+the condition of transformation in exactly the same way as the space
+co-ordinates x[1], x[2], x[3]. It is due to this fact that, according
+to the theory of relativity, the " time "x[4], enters into natural
+laws in the same form as the space co ordinates x[1], x[2], x[3].
+
+A four-dimensional continuum described by the "co-ordinates" x[1],
+x[2], x[3], x[4], was called "world" by Minkowski, who also termed a
+point-event a " world-point." From a "happening" in three-dimensional
+space, physics becomes, as it were, an " existence " in the
+four-dimensional " world."
+
+This four-dimensional " world " bears a close similarity to the
+three-dimensional " space " of (Euclidean) analytical geometry. If we
+introduce into the latter a new Cartesian co-ordinate system (x'[1],
+x'[2], x'[3]) with the same origin, then x'[1], x'[2], x'[3], are
+linear homogeneous functions of x[1], x[2], x[3] which identically
+satisfy the equation
+
+        x'[1]^2 + x'[2]^2 + x'[3]^2 = x[1]^2 + x[2]^2 + x[3]^2
+
+The analogy with (12) is a complete one. We can regard Minkowski's "
+world " in a formal manner as a four-dimensional Euclidean space (with
+an imaginary time coordinate) ; the Lorentz transformation corresponds
+to a " rotation " of the co-ordinate system in the fourdimensional "
+world."
+
+
+
+APPENDIX III
+
+THE EXPERIMENTAL CONFIRMATION OF THE GENERAL THEORY OF RELATIVITY
+
+
+From a systematic theoretical point of view, we may imagine the
+process of evolution of an empirical science to be a continuous
+process of induction. Theories are evolved and are expressed in short
+compass as statements of a large number of individual observations in
+the form of empirical laws, from which the general laws can be
+ascertained by comparison. Regarded in this way, the development of a
+science bears some resemblance to the compilation of a classified
+catalogue. It is, as it were, a purely empirical enterprise.
+
+But this point of view by no means embraces the whole of the actual
+process ; for it slurs over the important part played by intuition and
+deductive thought in the development of an exact science. As soon as a
+science has emerged from its initial stages, theoretical advances are
+no longer achieved merely by a process of arrangement. Guided by
+empirical data, the investigator rather develops a system of thought
+which, in general, is built up logically from a small number of
+fundamental assumptions, the so-called axioms. We call such a system
+of thought a theory. The theory finds the justification for its
+existence in the fact that it correlates a large number of single
+observations, and it is just here that the " truth " of the theory
+lies.
+
+Corresponding to the same complex of empirical data, there may be
+several theories, which differ from one another to a considerable
+extent. But as regards the deductions from the theories which are
+capable of being tested, the agreement between the theories may be so
+complete that it becomes difficult to find any deductions in which the
+two theories differ from each other. As an example, a case of general
+interest is available in the province of biology, in the Darwinian
+theory of the development of species by selection in the struggle for
+existence, and in the theory of development which is based on the
+hypothesis of the hereditary transmission of acquired characters.
+
+We have another instance of far-reaching agreement between the
+deductions from two theories in Newtonian mechanics on the one hand,
+and the general theory of relativity on the other. This agreement goes
+so far, that up to the preseat we have been able to find only a few
+deductions from the general theory of relativity which are capable of
+investigation, and to which the physics of pre-relativity days does
+not also lead, and this despite the profound difference in the
+fundamental assumptions of the two theories. In what follows, we shall
+again consider these important deductions, and we shall also discuss
+the empirical evidence appertaining to them which has hitherto been
+obtained.
+
+ (a) Motion of the Perihelion of Mercury
+
+According to Newtonian mechanics and Newton's law of gravitation, a
+planet which is revolving round the sun would describe an ellipse
+round the latter, or, more correctly, round the common centre of
+gravity of the sun and the planet. In such a system, the sun, or the
+common centre of gravity, lies in one of the foci of the orbital
+ellipse in such a manner that, in the course of a planet-year, the
+distance sun-planet grows from a minimum to a maximum, and then
+decreases again to a minimum. If instead of Newton's law we insert a
+somewhat different law of attraction into the calculation, we find
+that, according to this new law, the motion would still take place in
+such a manner that the distance sun-planet exhibits periodic
+variations; but in this case the angle described by the line joining
+sun and planet during such a period (from perihelion--closest
+proximity to the sun--to perihelion) would differ from 360^0. The line
+of the orbit would not then be a closed one but in the course of time
+it would fill up an annular part of the orbital plane, viz. between
+the circle of least and the circle of greatest distance of the planet
+from the sun.
+
+According also to the general theory of relativity, which differs of
+course from the theory of Newton, a small variation from the
+Newton-Kepler motion of a planet in its orbit should take place, and
+in such away, that the angle described by the radius sun-planet
+between one perhelion and the next should exceed that corresponding to
+one complete revolution by an amount given by
+
+                        eq. 41: file eq41.gif
+
+(N.B. -- One complete revolution corresponds to the angle 2p in the
+absolute angular measure customary in physics, and the above
+expression giver the amount by which the radius sun-planet exceeds
+this angle during the interval between one perihelion and the next.)
+In this expression a represents the major semi-axis of the ellipse, e
+its eccentricity, c the velocity of light, and T the period of
+revolution of the planet. Our result may also be stated as follows :
+According to the general theory of relativity, the major axis of the
+ellipse rotates round the sun in the same sense as the orbital motion
+of the planet. Theory requires that this rotation should amount to 43
+seconds of arc per century for the planet Mercury, but for the other
+Planets of our solar system its magnitude should be so small that it
+would necessarily escape detection. *
+
+In point of fact, astronomers have found that the theory of Newton
+does not suffice to calculate the observed motion of Mercury with an
+exactness corresponding to that of the delicacy of observation
+attainable at the present time. After taking account of all the
+disturbing influences exerted on Mercury by the remaining planets, it
+was found (Leverrier: 1859; and Newcomb: 1895) that an unexplained
+perihelial movement of the orbit of Mercury remained over, the amount
+of which does not differ sensibly from the above mentioned +43 seconds
+of arc per century. The uncertainty of the empirical result amounts to
+a few seconds only.
+
+ (b) Deflection of Light by a Gravitational Field
+
+In Section 22 it has been already mentioned that according to the
+general theory of relativity, a ray of light will experience a
+curvature of its path when passing through a gravitational field, this
+curvature being similar to that experienced by the path of a body
+which is projected through a gravitational field. As a result of this
+theory, we should expect that a ray of light which is passing close to
+a heavenly body would be deviated towards the latter. For a ray of
+light which passes the sun at a distance of D sun-radii from its
+centre, the angle of deflection (a) should amount to
+
+                        eq. 42: file eq42.gif
+
+It may be added that, according to the theory, half of Figure 05 this
+deflection is produced by the Newtonian field of attraction of the
+sun, and the other half by the geometrical modification (" curvature
+") of space caused by the sun.
+
+This result admits of an experimental test by means of the
+photographic registration of stars during a total eclipse of the sun.
+The only reason why we must wait for a total eclipse is because at
+every other time the atmosphere is so strongly illuminated by the
+light from the sun that the stars situated near the sun's disc are
+invisible. The predicted effect can be seen clearly from the
+accompanying diagram. If the sun (S) were not present, a star which is
+practically infinitely distant would be seen in the direction D[1], as
+observed front the earth. But as a consequence of the deflection of
+light from the star by the sun, the star will be seen in the direction
+D[2], i.e. at a somewhat greater distance from the centre of the sun
+than corresponds to its real position.
+
+In practice, the question is tested in the following way. The stars in
+the neighbourhood of the sun are photographed during a solar eclipse.
+In addition, a second photograph of the same stars is taken when the
+sun is situated at another position in the sky, i.e. a few months
+earlier or later. As compared whh the standard photograph, the
+positions of the stars on the eclipse-photograph ought to appear
+displaced radially outwards (away from the centre of the sun) by an
+amount corresponding to the angle a.
+
+We are indebted to the [British] Royal Society and to the Royal
+Astronomical Society for the investigation of this important
+deduction. Undaunted by the [first world] war and by difficulties of
+both a material and a psychological nature aroused by the war, these
+societies equipped two expeditions -- to Sobral (Brazil), and to the
+island of Principe (West Africa) -- and sent several of Britain's most
+celebrated astronomers (Eddington, Cottingham, Crommelin, Davidson),
+in order to obtain photographs of the solar eclipse of 29th May, 1919.
+The relative discrepancies to be expected between the stellar
+photographs obtained during the eclipse and the comparison photographs
+amounted to a few hundredths of a millimetre only. Thus great accuracy
+was necessary in making the adjustments required for the taking of the
+photographs, and in their subsequent measurement.
+
+The results of the measurements confirmed the theory in a thoroughly
+satisfactory manner. The rectangular components of the observed and of
+the calculated deviations of the stars (in seconds of arc) are set
+forth in the following table of results :
+
+                      Table 01: file table01.gif
+
+ (c) Displacement of Spectral Lines Towards the Red
+
+In Section 23 it has been shown that in a system K1 which is in
+rotation with regard to a Galileian system K, clocks of identical
+construction, and which are considered at rest with respect to the
+rotating reference-body, go at rates which are dependent on the
+positions of the clocks. We shall now examine this dependence
+quantitatively. A clock, which is situated at a distance r from the
+centre of the disc, has a velocity relative to K which is given by
+
+                                V = wr
+
+where w represents the angular velocity of rotation of the disc K1
+with respect to K. If v[0], represents the number of ticks of the
+clock per unit time (" rate " of the clock) relative to K when the
+clock is at rest, then the " rate " of the clock (v) when it is moving
+relative to K with a velocity V, but at rest with respect to the disc,
+will, in accordance with Section 12, be given by
+
+                        eq. 43: file eq43.gif
+
+or with sufficient accuracy by
+
+                        eq. 44: file eq44.gif
+
+This expression may also be stated in the following form:
+
+                        eq. 45: file eq45.gif
+
+If we represent the difference of potential of the centrifugal force
+between the position of the clock and the centre of the disc by f,
+i.e. the work, considered negatively, which must be performed on the
+unit of mass against the centrifugal force in order to transport it
+from the position of the clock on the rotating disc to the centre of
+the disc, then we have
+
+                        eq. 46: file eq46.gif
+
+From this it follows that
+
+                        eq. 47: file eq47.gif
+
+In the first place, we see from this expression that two clocks of
+identical construction will go at different rates when situated at
+different distances from the centre of the disc. This result is aiso
+valid from the standpoint of an observer who is rotating with the
+disc.
+
+Now, as judged from the disc, the latter is in a gravititional field
+of potential f, hence the result we have obtained will hold quite
+generally for gravitational fields. Furthermore, we can regard an atom
+which is emitting spectral lines as a clock, so that the following
+statement will hold:
+
+An atom absorbs or emits light of a frequency which is dependent on
+the potential of the gravitational field in which it is situated.
+
+The frequency of an atom situated on the surface of a heavenly body
+will be somewhat less than the frequency of an atom of the same
+element which is situated in free space (or on the surface of a
+smaller celestial body).
+
+Now f = - K (M/r), where K is Newton's constant of gravitation, and M
+is the mass of the heavenly body. Thus a displacement towards the red
+ought to take place for spectral lines produced at the surface of
+stars as compared with the spectral lines of the same element produced
+at the surface of the earth, the amount of this displacement being
+
+                        eq. 48: file eq48.gif
+
+For the sun, the displacement towards the red predicted by theory
+amounts to about two millionths of the wave-length. A trustworthy
+calculation is not possible in the case of the stars, because in
+general neither the mass M nor the radius r are known.
+
+It is an open question whether or not this effect exists, and at the
+present time (1920) astronomers are working with great zeal towards
+the solution. Owing to the smallness of the effect in the case of the
+sun, it is difficult to form an opinion as to its existence. Whereas
+Grebe and Bachem (Bonn), as a result of their own measurements and
+those of Evershed and Schwarzschild on the cyanogen bands, have placed
+the existence of the effect almost beyond doubt, while other
+investigators, particularly St. John, have been led to the opposite
+opinion in consequence of their measurements.
+
+Mean displacements of lines towards the less refrangible end of the
+spectrum are certainly revealed by statistical investigations of the
+fixed stars ; but up to the present the examination of the available
+data does not allow of any definite decision being arrived at, as to
+whether or not these displacements are to be referred in reality to
+the effect of gravitation. The results of observation have been
+collected together, and discussed in detail from the standpoint of the
+question which has been engaging our attention here, in a paper by E.
+Freundlich entitled "Zur Prüfung der allgemeinen
+Relativit&umlaut;ts-Theorie" (Die Naturwissenschaften, 1919, No. 35,
+p. 520: Julius Springer, Berlin).
+
+At all events, a definite decision will be reached during the next few
+years. If the displacement of spectral lines towards the red by the
+gravitational potential does not exist, then the general theory of
+relativity will be untenable. On the other hand, if the cause of the
+displacement of spectral lines be definitely traced to the
+gravitational potential, then the study of this displacement will
+furnish us with important information as to the mass of the heavenly
+bodies. [5][A]
+
+
+  Notes
+
+*) Especially since the next planet Venus has an orbit that is
+almost an exact circle, which makes it more difficult to locate the
+perihelion with precision.
+
+The displacentent of spectral lines towards the red end of the
+spectrum was definitely established by Adams in 1924, by observations
+on the dense companion of Sirius, for which the effect is about thirty
+times greater than for the Sun. R.W.L. -- translator
+
+
+
+APPENDIX IV
+
+THE STRUCTURE OF SPACE ACCORDING TO THE GENERAL THEORY OF RELATIVITY
+(SUPPLEMENTARY TO SECTION 32)
+
+
+Since the publication of the first edition of this little book, our
+knowledge about the structure of space in the large (" cosmological
+problem ") has had an important development, which ought to be
+mentioned even in a popular presentation of the subject.
+
+My original considerations on the subject were based on two
+hypotheses:
+
+(1) There exists an average density of matter in the whole of space
+which is everywhere the same and different from zero.
+
+(2) The magnitude (" radius ") of space is independent of time.
+
+Both these hypotheses proved to be consistent, according to the
+general theory of relativity, but only after a hypothetical term was
+added to the field equations, a term which was not required by the
+theory as such nor did it seem natural from a theoretical point of
+view (" cosmological term of the field equations ").
+
+Hypothesis (2) appeared unavoidable to me at the time, since I thought
+that one would get into bottomless speculations if one departed from
+it.
+
+However, already in the 'twenties, the Russian mathematician Friedman
+showed that a different hypothesis was natural from a purely
+theoretical point of view. He realized that it was possible to
+preserve hypothesis (1) without introducing the less natural
+cosmological term into the field equations of gravitation, if one was
+ready to drop hypothesis (2). Namely, the original field equations
+admit a solution in which the " world radius " depends on time
+(expanding space). In that sense one can say, according to Friedman,
+that the theory demands an expansion of space.
+
+A few years later Hubble showed, by a special investigation of the
+extra-galactic nebulae (" milky ways "), that the spectral lines
+emitted showed a red shift which increased regularly with the distance
+of the nebulae. This can be interpreted in regard to our present
+knowledge only in the sense of Doppler's principle, as an expansive
+motion of the system of stars in the large -- as required, according
+to Friedman, by the field equations of gravitation. Hubble's discovery
+can, therefore, be considered to some extent as a confirmation of the
+theory.
+
+There does arise, however, a strange difficulty. The interpretation of
+the galactic line-shift discovered by Hubble as an expansion (which
+can hardly be doubted from a theoretical point of view), leads to an
+origin of this expansion which lies " only " about 10^9 years ago,
+while physical astronomy makes it appear likely that the development
+of individual stars and systems of stars takes considerably longer. It
+is in no way known how this incongruity is to be overcome.
+
+I further want to rernark that the theory of expanding space, together
+with the empirical data of astronomy, permit no decision to be reached
+about the finite or infinite character of (three-dimensional) space,
+while the original " static " hypothesis of space yielded the closure
+(finiteness) of space.
+
+
+K = co-ordinate system
+x, y = two-dimensional co-ordinates
+x, y, z = three-dimensional co-ordinates
+x, y, z, t = four-dimensional co-ordinates
+
+t = time
+I = distance
+v = velocity
+
+F = force
+G = gravitational field
+
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK, RELATIVITY ***
+
+This file should be named 5001.zip and contains numerous
+image files for equations.
+
+Project Gutenberg eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the US
+unless a copyright notice is included.  Thus, we usually do not
+keep eBooks in compliance with any particular paper edition.
+
+We are now trying to release all our eBooks one year in advance
+of the official release dates, leaving time for better editing.
+Please be encouraged to tell us about any error or corrections,
+even years after the official publication date.
+
+Please note neither this listing nor its contents are final til
+midnight of the last day of the month of any such announcement.
+The official release date of all Project Gutenberg eBooks is at
+Midnight, Central Time, of the last day of the stated month.  A
+preliminary version may often be posted for suggestion, comment
+and editing by those who wish to do so.
+
+Most people start at our Web sites at:
+http://gutenberg.net or
+http://promo.net/pg
+
+These Web sites include award-winning information about Project
+Gutenberg, including how to donate, how to help produce our new
+eBooks, and how to subscribe to our email newsletter (free!).
+
+
+Those of you who want to download any eBook before announcement
+can get to them as follows, and just download by date.  This is
+also a good way to get them instantly upon announcement, as the
+indexes our cataloguers produce obviously take a while after an
+announcement goes out in the Project Gutenberg Newsletter.
+
+http://www.ibiblio.org/gutenberg/etext03 or
+ftp://ftp.ibiblio.org/pub/docs/books/gutenberg/etext03
+
+Or /etext02, 01, 00, 99, 98, 97, 96, 95, 94, 93, 92, 92, 91 or 90
+
+Just search by the first five letters of the filename you want,
+as it appears in our Newsletters.
+
+
+Information about Project Gutenberg (one page)
+
+We produce about two million dollars for each hour we work.  The
+time it takes us, a rather conservative estimate, is fifty hours
+to get any eBook selected, entered, proofread, edited, copyright
+searched and analyzed, the copyright letters written, etc.   Our
+projected audience is one hundred million readers.  If the value
+per text is nominally estimated at one dollar then we produce $2
+million dollars per hour in 2002 as we release over 100 new text
+files per month:  1240 more eBooks in 2001 for a total of 4000+
+We are already on our way to trying for 2000 more eBooks in 2002
+If they reach just 1-2% of the world's population then the total
+will reach over half a trillion eBooks given away by year's end.
+
+The Goal of Project Gutenberg is to Give Away 1 Trillion eBooks!
+This is ten thousand titles each to one hundred million readers,
+which is only about 4% of the present number of computer users.
+
+Here is the briefest record of our progress (* means estimated):
+
+eBooks Year Month
+
+    1  1971 July
+   10  1991 January
+  100  1994 January
+ 1000  1997 August
+ 1500  1998 October
+ 2000  1999 December
+ 2500  2000 December
+ 3000  2001 November
+ 4000  2001 October/November
+ 6000  2002 December*
+ 9000  2003 November*
+10000  2004 January*
+
+
+The Project Gutenberg Literary Archive Foundation has been created
+to secure a future for Project Gutenberg into the next millennium.
+
+We need your donations more than ever!
+
+As of February, 2002, contributions are being solicited from people
+and organizations in: Alabama, Alaska, Arkansas, Connecticut,
+Delaware, District of Columbia, Florida, Georgia, Hawaii, Illinois,
+Indiana, Iowa, Kansas, Kentucky, Louisiana, Maine, Massachusetts,
+Michigan, Mississippi, Missouri, Montana, Nebraska, Nevada, New
+Hampshire, New Jersey, New Mexico, New York, North Carolina, Ohio,
+Oklahoma, Oregon, Pennsylvania, Rhode Island, South Carolina, South
+Dakota, Tennessee, Texas, Utah, Vermont, Virginia, Washington, West
+Virginia, Wisconsin, and Wyoming.
+
+We have filed in all 50 states now, but these are the only ones
+that have responded.
+
+As the requirements for other states are met, additions to this list
+will be made and fund raising will begin in the additional states.
+Please feel free to ask to check the status of your state.
+
+In answer to various questions we have received on this:
+
+We are constantly working on finishing the paperwork to legally
+request donations in all 50 states.  If your state is not listed and
+you would like to know if we have added it since the list you have,
+just ask.
+
+While we cannot solicit donations from people in states where we are
+not yet registered, we know of no prohibition against accepting
+donations from donors in these states who approach us with an offer to
+donate.
+
+International donations are accepted, but we don't know ANYTHING about
+how to make them tax-deductible, or even if they CAN be made
+deductible, and don't have the staff to handle it even if there are
+ways.
+
+Donations by check or money order may be sent to:
+
+Project Gutenberg Literary Archive Foundation
+PMB 113
+1739 University Ave.
+Oxford, MS 38655-4109
+
+Contact us if you want to arrange for a wire transfer or payment
+method other than by check or money order.
+
+The Project Gutenberg Literary Archive Foundation has been approved by
+the US Internal Revenue Service as a 501(c)(3) organization with EIN
+[Employee Identification Number] 64-622154.  Donations are
+tax-deductible to the maximum extent permitted by law.  As fund-raising
+requirements for other states are met, additions to this list will be
+made and fund-raising will begin in the additional states.
+
+We need your donations more than ever!
+
+You can get up to date donation information online at:
+
+http://www.gutenberg.net/donation.html
+
+
+***
+
+If you can't reach Project Gutenberg,
+you can always email directly to:
+
+Michael S. Hart <hart@pobox.com>
+
+Prof. Hart will answer or forward your message.
+
+We would prefer to send you information by email.
+
+
+**The Legal Small Print**
+
+
+(Three Pages)
+
+***START**THE SMALL PRINT!**FOR PUBLIC DOMAIN EBOOKS**START***
+Why is this "Small Print!" statement here? You know: lawyers.
+They tell us you might sue us if there is something wrong with
+your copy of this eBook, even if you got it for free from
+someone other than us, and even if what's wrong is not our
+fault. So, among other things, this "Small Print!" statement
+disclaims most of our liability to you. It also tells you how
+you may distribute copies of this eBook if you want to.
+
+*BEFORE!* YOU USE OR READ THIS EBOOK
+By using or reading any part of this PROJECT GUTENBERG-tm
+eBook, you indicate that you understand, agree to and accept
+this "Small Print!" statement. If you do not, you can receive
+a refund of the money (if any) you paid for this eBook by
+sending a request within 30 days of receiving it to the person
+you got it from. If you received this eBook on a physical
+medium (such as a disk), you must return it with your request.
+
+ABOUT PROJECT GUTENBERG-TM EBOOKS
+This PROJECT GUTENBERG-tm eBook, like most PROJECT GUTENBERG-tm eBooks,
+is a "public domain" work distributed by Professor Michael S. Hart
+through the Project Gutenberg Association (the "Project").
+Among other things, this means that no one owns a United States copyright
+on or for this work, so the Project (and you!) can copy and
+distribute it in the United States without permission and
+without paying copyright royalties. Special rules, set forth
+below, apply if you wish to copy and distribute this eBook
+under the "PROJECT GUTENBERG" trademark.
+
+Please do not use the "PROJECT GUTENBERG" trademark to market
+any commercial products without permission.
+
+To create these eBooks, the Project expends considerable
+efforts to identify, transcribe and proofread public domain
+works. Despite these efforts, the Project's eBooks and any
+medium they may be on may contain "Defects". Among other
+things, Defects may take the form of incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged
+disk or other eBook medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+LIMITED WARRANTY; DISCLAIMER OF DAMAGES
+But for the "Right of Replacement or Refund" described below,
+[1] Michael Hart and the Foundation (and any other party you may
+receive this eBook from as a PROJECT GUTENBERG-tm eBook) disclaims
+all liability to you for damages, costs and expenses, including
+legal fees, and [2] YOU HAVE NO REMEDIES FOR NEGLIGENCE OR
+UNDER STRICT LIABILITY, OR FOR BREACH OF WARRANTY OR CONTRACT,
+INCLUDING BUT NOT LIMITED TO INDIRECT, CONSEQUENTIAL, PUNITIVE
+OR INCIDENTAL DAMAGES, EVEN IF YOU GIVE NOTICE OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+If you discover a Defect in this eBook within 90 days of
+receiving it, you can receive a refund of the money (if any)
+you paid for it by sending an explanatory note within that
+time to the person you received it from. If you received it
+on a physical medium, you must return it with your note, and
+such person may choose to alternatively give you a replacement
+copy. If you received it electronically, such person may
+choose to alternatively give you a second opportunity to
+receive it electronically.
+
+THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS". NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, ARE MADE TO YOU AS
+TO THE EBOOK OR ANY MEDIUM IT MAY BE ON, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+Some states do not allow disclaimers of implied warranties or
+the exclusion or limitation of consequential damages, so the
+above disclaimers and exclusions may not apply to you, and you
+may have other legal rights.
+
+INDEMNITY
+You will indemnify and hold Michael Hart, the Foundation,
+and its trustees and agents, and any volunteers associated
+with the production and distribution of Project Gutenberg-tm
+texts harmless, from all liability, cost and expense, including
+legal fees, that arise directly or indirectly from any of the
+following that you do or cause:  [1] distribution of this eBook,
+[2] alteration, modification, or addition to the eBook,
+or [3] any Defect.
+
+DISTRIBUTION UNDER "PROJECT GUTENBERG-tm"
+You may distribute copies of this eBook electronically, or by
+disk, book or any other medium if you either delete this
+"Small Print!" and all other references to Project Gutenberg,
+or:
+
+[1]  Only give exact copies of it.  Among other things, this
+     requires that you do not remove, alter or modify the
+     eBook or this "small print!" statement.  You may however,
+     if you wish, distribute this eBook in machine readable
+     binary, compressed, mark-up, or proprietary form,
+     including any form resulting from conversion by word
+     processing or hypertext software, but only so long as
+     *EITHER*:
+
+     [*]  The eBook, when displayed, is clearly readable, and
+          does *not* contain characters other than those
+          intended by the author of the work, although tilde
+          (~), asterisk (*) and underline (_) characters may
+          be used to convey punctuation intended by the
+          author, and additional characters may be used to
+          indicate hypertext links; OR
+
+     [*]  The eBook may be readily converted by the reader at
+          no expense into plain ASCII, EBCDIC or equivalent
+          form by the program that displays the eBook (as is
+          the case, for instance, with most word processors);
+          OR
+
+     [*]  You provide, or agree to also provide on request at
+          no additional cost, fee or expense, a copy of the
+          eBook in its original plain ASCII form (or in EBCDIC
+          or other equivalent proprietary form).
+
+[2]  Honor the eBook refund and replacement provisions of this
+     "Small Print!" statement.
+
+[3]  Pay a trademark license fee to the Foundation of 20% of the
+     gross profits you derive calculated using the method you
+     already use to calculate your applicable taxes.  If you
+     don't derive profits, no royalty is due.  Royalties are
+     payable to "Project Gutenberg Literary Archive Foundation"
+     the 60 days following each date you prepare (or were
+     legally required to prepare) your annual (or equivalent
+     periodic) tax return.  Please contact us beforehand to
+     let us know your plans and to work out the details.
+
+WHAT IF YOU *WANT* TO SEND MONEY EVEN IF YOU DON'T HAVE TO?
+Project Gutenberg is dedicated to increasing the number of
+public domain and licensed works that can be freely distributed
+in machine readable form.
+
+The Project gratefully accepts contributions of money, time,
+public domain materials, or royalty free copyright licenses.
+Money should be paid to the:
+"Project Gutenberg Literary Archive Foundation."
+
+If you are interested in contributing scanning equipment or
+software or other items, please contact Michael Hart at:
+hart@pobox.com
+
+[Portions of this eBook's header and trailer may be reprinted only
+when distributed free of all fees.  Copyright (C) 2001, 2002 by
+Michael S. Hart.  Project Gutenberg is a TradeMark and may not be
+used in any sales of Project Gutenberg eBooks or other materials be
+they hardware or software or any other related product without
+express permission.]
+
+*END THE SMALL PRINT! FOR PUBLIC DOMAIN EBOOKS*Ver.02/11/02*END*

--- a/jet/tf-idf/src/main/resources/books/through-the-looking-glass.txt
+++ b/jet/tf-idf/src/main/resources/books/through-the-looking-glass.txt
@@ -1,0 +1,4306 @@
+﻿The Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson                         AKA Lewis Carroll
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+
+Title: Through the Looking-Glass
+
+Author: Charles Dodgson, AKA Lewis Carroll
+
+Posting Date: June 25, 2008 [EBook #12]
+Release Date: February, 1991
+Last Updated: October 6, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+
+
+
+
+
+
+
+
+
+THROUGH THE LOOKING-GLASS
+
+By Lewis Carroll
+
+
+The Millennium Fulcrum Edition 1.7
+
+
+
+
+CHAPTER I. Looking-Glass house
+
+One thing was certain, that the WHITE kitten had had nothing to do with
+it:--it was the black kitten’s fault entirely. For the white kitten had
+been having its face washed by the old cat for the last quarter of
+an hour (and bearing it pretty well, considering); so you see that it
+COULDN’T have had any hand in the mischief.
+
+The way Dinah washed her children’s faces was this: first she held the
+poor thing down by its ear with one paw, and then with the other paw she
+rubbed its face all over, the wrong way, beginning at the nose: and
+just now, as I said, she was hard at work on the white kitten, which was
+lying quite still and trying to purr--no doubt feeling that it was all
+meant for its good.
+
+But the black kitten had been finished with earlier in the afternoon,
+and so, while Alice was sitting curled up in a corner of the great
+arm-chair, half talking to herself and half asleep, the kitten had been
+having a grand game of romps with the ball of worsted Alice had been
+trying to wind up, and had been rolling it up and down till it had all
+come undone again; and there it was, spread over the hearth-rug, all
+knots and tangles, with the kitten running after its own tail in the
+middle.
+
+‘Oh, you wicked little thing!’ cried Alice, catching up the kitten, and
+giving it a little kiss to make it understand that it was in disgrace.
+‘Really, Dinah ought to have taught you better manners! You OUGHT,
+Dinah, you know you ought!’ she added, looking reproachfully at the old
+cat, and speaking in as cross a voice as she could manage--and then she
+scrambled back into the arm-chair, taking the kitten and the worsted
+with her, and began winding up the ball again. But she didn’t get on
+very fast, as she was talking all the time, sometimes to the kitten, and
+sometimes to herself. Kitty sat very demurely on her knee, pretending to
+watch the progress of the winding, and now and then putting out one
+paw and gently touching the ball, as if it would be glad to help, if it
+might.
+
+‘Do you know what to-morrow is, Kitty?’ Alice began. ‘You’d have guessed
+if you’d been up in the window with me--only Dinah was making you tidy,
+so you couldn’t. I was watching the boys getting in sticks for the
+bonfire--and it wants plenty of sticks, Kitty! Only it got so cold, and
+it snowed so, they had to leave off. Never mind, Kitty, we’ll go and
+see the bonfire to-morrow.’ Here Alice wound two or three turns of the
+worsted round the kitten’s neck, just to see how it would look: this led
+to a scramble, in which the ball rolled down upon the floor, and yards
+and yards of it got unwound again.
+
+‘Do you know, I was so angry, Kitty,’ Alice went on as soon as they were
+comfortably settled again, ‘when I saw all the mischief you had been
+doing, I was very nearly opening the window, and putting you out into
+the snow! And you’d have deserved it, you little mischievous darling!
+What have you got to say for yourself? Now don’t interrupt me!’ she
+went on, holding up one finger. ‘I’m going to tell you all your faults.
+Number one: you squeaked twice while Dinah was washing your face this
+morning. Now you can’t deny it, Kitty: I heard you! What’s that you
+say?’ (pretending that the kitten was speaking.) ‘Her paw went into your
+eye? Well, that’s YOUR fault, for keeping your eyes open--if you’d
+shut them tight up, it wouldn’t have happened. Now don’t make any more
+excuses, but listen! Number two: you pulled Snowdrop away by the tail
+just as I had put down the saucer of milk before her! What, you were
+thirsty, were you? How do you know she wasn’t thirsty too? Now for
+number three: you unwound every bit of the worsted while I wasn’t
+looking!
+
+‘That’s three faults, Kitty, and you’ve not been punished for any of
+them yet. You know I’m saving up all your punishments for Wednesday
+week--Suppose they had saved up all MY punishments!’ she went on,
+talking more to herself than the kitten. ‘What WOULD they do at the end
+of a year? I should be sent to prison, I suppose, when the day came.
+Or--let me see--suppose each punishment was to be going without a
+dinner: then, when the miserable day came, I should have to go without
+fifty dinners at once! Well, I shouldn’t mind THAT much! I’d far rather
+go without them than eat them!
+
+‘Do you hear the snow against the window-panes, Kitty? How nice and soft
+it sounds! Just as if some one was kissing the window all over outside.
+I wonder if the snow LOVES the trees and fields, that it kisses them so
+gently? And then it covers them up snug, you know, with a white quilt;
+and perhaps it says, “Go to sleep, darlings, till the summer comes
+again.” And when they wake up in the summer, Kitty, they dress
+themselves all in green, and dance about--whenever the wind blows--oh,
+that’s very pretty!’ cried Alice, dropping the ball of worsted to clap
+her hands. ‘And I do so WISH it was true! I’m sure the woods look sleepy
+in the autumn, when the leaves are getting brown.
+
+‘Kitty, can you play chess? Now, don’t smile, my dear, I’m asking it
+seriously. Because, when we were playing just now, you watched just as
+if you understood it: and when I said “Check!” you purred! Well, it WAS
+a nice check, Kitty, and really I might have won, if it hadn’t been for
+that nasty Knight, that came wiggling down among my pieces. Kitty, dear,
+let’s pretend--’ And here I wish I could tell you half the things Alice
+used to say, beginning with her favourite phrase ‘Let’s pretend.’ She
+had had quite a long argument with her sister only the day before--all
+because Alice had begun with ‘Let’s pretend we’re kings and queens;’ and
+her sister, who liked being very exact, had argued that they couldn’t,
+because there were only two of them, and Alice had been reduced at last
+to say, ‘Well, YOU can be one of them then, and I’LL be all the rest.’
+And once she had really frightened her old nurse by shouting suddenly in
+her ear, ‘Nurse! Do let’s pretend that I’m a hungry hyaena, and you’re a
+bone.’
+
+But this is taking us away from Alice’s speech to the kitten. ‘Let’s
+pretend that you’re the Red Queen, Kitty! Do you know, I think if you
+sat up and folded your arms, you’d look exactly like her. Now do try,
+there’s a dear!’ And Alice got the Red Queen off the table, and set it
+up before the kitten as a model for it to imitate: however, the thing
+didn’t succeed, principally, Alice said, because the kitten wouldn’t
+fold its arms properly. So, to punish it, she held it up to the
+Looking-glass, that it might see how sulky it was--‘and if you’re not
+good directly,’ she added, ‘I’ll put you through into Looking-glass
+House. How would you like THAT?’
+
+‘Now, if you’ll only attend, Kitty, and not talk so much, I’ll tell you
+all my ideas about Looking-glass House. First, there’s the room you can
+see through the glass--that’s just the same as our drawing room, only
+the things go the other way. I can see all of it when I get upon a
+chair--all but the bit behind the fireplace. Oh! I do so wish I could
+see THAT bit! I want so much to know whether they’ve a fire in the
+winter: you never CAN tell, you know, unless our fire smokes, and then
+smoke comes up in that room too--but that may be only pretence, just to
+make it look as if they had a fire. Well then, the books are something
+like our books, only the words go the wrong way; I know that, because
+I’ve held up one of our books to the glass, and then they hold up one in
+the other room.
+
+‘How would you like to live in Looking-glass House, Kitty? I wonder if
+they’d give you milk in there? Perhaps Looking-glass milk isn’t good
+to drink--But oh, Kitty! now we come to the passage. You can just see a
+little PEEP of the passage in Looking-glass House, if you leave the door
+of our drawing-room wide open: and it’s very like our passage as far
+as you can see, only you know it may be quite different on beyond.
+Oh, Kitty! how nice it would be if we could only get through into
+Looking-glass House! I’m sure it’s got, oh! such beautiful things in it!
+Let’s pretend there’s a way of getting through into it, somehow, Kitty.
+Let’s pretend the glass has got all soft like gauze, so that we can get
+through. Why, it’s turning into a sort of mist now, I declare! It’ll be
+easy enough to get through--’ She was up on the chimney-piece while she
+said this, though she hardly knew how she had got there. And certainly
+the glass WAS beginning to melt away, just like a bright silvery mist.
+
+In another moment Alice was through the glass, and had jumped lightly
+down into the Looking-glass room. The very first thing she did was
+to look whether there was a fire in the fireplace, and she was quite
+pleased to find that there was a real one, blazing away as brightly as
+the one she had left behind. ‘So I shall be as warm here as I was in the
+old room,’ thought Alice: ‘warmer, in fact, because there’ll be no one
+here to scold me away from the fire. Oh, what fun it’ll be, when they
+see me through the glass in here, and can’t get at me!’
+
+Then she began looking about, and noticed that what could be seen from
+the old room was quite common and uninteresting, but that all the rest
+was as different as possible. For instance, the pictures on the
+wall next the fire seemed to be all alive, and the very clock on
+the chimney-piece (you know you can only see the back of it in the
+Looking-glass) had got the face of a little old man, and grinned at her.
+
+‘They don’t keep this room so tidy as the other,’ Alice thought to
+herself, as she noticed several of the chessmen down in the hearth among
+the cinders: but in another moment, with a little ‘Oh!’ of surprise, she
+was down on her hands and knees watching them. The chessmen were walking
+about, two and two!
+
+‘Here are the Red King and the Red Queen,’ Alice said (in a whisper, for
+fear of frightening them), ‘and there are the White King and the White
+Queen sitting on the edge of the shovel--and here are two castles
+walking arm in arm--I don’t think they can hear me,’ she went on, as she
+put her head closer down, ‘and I’m nearly sure they can’t see me. I feel
+somehow as if I were invisible--’
+
+Here something began squeaking on the table behind Alice, and made her
+turn her head just in time to see one of the White Pawns roll over and
+begin kicking: she watched it with great curiosity to see what would
+happen next.
+
+‘It is the voice of my child!’ the White Queen cried out as she rushed
+past the King, so violently that she knocked him over among the cinders.
+‘My precious Lily! My imperial kitten!’ and she began scrambling wildly
+up the side of the fender.
+
+‘Imperial fiddlestick!’ said the King, rubbing his nose, which had been
+hurt by the fall. He had a right to be a LITTLE annoyed with the Queen,
+for he was covered with ashes from head to foot.
+
+Alice was very anxious to be of use, and, as the poor little Lily was
+nearly screaming herself into a fit, she hastily picked up the Queen and
+set her on the table by the side of her noisy little daughter.
+
+The Queen gasped, and sat down: the rapid journey through the air had
+quite taken away her breath and for a minute or two she could do nothing
+but hug the little Lily in silence. As soon as she had recovered her
+breath a little, she called out to the White King, who was sitting
+sulkily among the ashes, ‘Mind the volcano!’
+
+‘What volcano?’ said the King, looking up anxiously into the fire, as if
+he thought that was the most likely place to find one.
+
+‘Blew--me--up,’ panted the Queen, who was still a little out of breath.
+‘Mind you come up--the regular way--don’t get blown up!’
+
+Alice watched the White King as he slowly struggled up from bar to bar,
+till at last she said, ‘Why, you’ll be hours and hours getting to the
+table, at that rate. I’d far better help you, hadn’t I?’ But the King
+took no notice of the question: it was quite clear that he could neither
+hear her nor see her.
+
+So Alice picked him up very gently, and lifted him across more slowly
+than she had lifted the Queen, that she mightn’t take his breath away:
+but, before she put him on the table, she thought she might as well dust
+him a little, he was so covered with ashes.
+
+She said afterwards that she had never seen in all her life such a face
+as the King made, when he found himself held in the air by an invisible
+hand, and being dusted: he was far too much astonished to cry out, but
+his eyes and his mouth went on getting larger and larger, and rounder
+and rounder, till her hand shook so with laughing that she nearly let
+him drop upon the floor.
+
+‘Oh! PLEASE don’t make such faces, my dear!’ she cried out, quite
+forgetting that the King couldn’t hear her. ‘You make me laugh so that
+I can hardly hold you! And don’t keep your mouth so wide open! All the
+ashes will get into it--there, now I think you’re tidy enough!’ she
+added, as she smoothed his hair, and set him upon the table near the
+Queen.
+
+The King immediately fell flat on his back, and lay perfectly still: and
+Alice was a little alarmed at what she had done, and went round the room
+to see if she could find any water to throw over him. However, she could
+find nothing but a bottle of ink, and when she got back with it she
+found he had recovered, and he and the Queen were talking together in a
+frightened whisper--so low, that Alice could hardly hear what they said.
+
+The King was saying, ‘I assure, you my dear, I turned cold to the very
+ends of my whiskers!’
+
+To which the Queen replied, ‘You haven’t got any whiskers.’
+
+‘The horror of that moment,’ the King went on, ‘I shall never, NEVER
+forget!’
+
+‘You will, though,’ the Queen said, ‘if you don’t make a memorandum of
+it.’
+
+Alice looked on with great interest as the King took an enormous
+memorandum-book out of his pocket, and began writing. A sudden thought
+struck her, and she took hold of the end of the pencil, which came some
+way over his shoulder, and began writing for him.
+
+The poor King looked puzzled and unhappy, and struggled with the pencil
+for some time without saying anything; but Alice was too strong for him,
+and at last he panted out, ‘My dear! I really MUST get a thinner pencil.
+I can’t manage this one a bit; it writes all manner of things that I
+don’t intend--’
+
+‘What manner of things?’ said the Queen, looking over the book (in which
+Alice had put ‘THE WHITE KNIGHT IS SLIDING DOWN THE POKER. HE BALANCES
+VERY BADLY’) ‘That’s not a memorandum of YOUR feelings!’
+
+There was a book lying near Alice on the table, and while she sat
+watching the White King (for she was still a little anxious about him,
+and had the ink all ready to throw over him, in case he fainted again),
+she turned over the leaves, to find some part that she could read,
+‘--for it’s all in some language I don’t know,’ she said to herself.
+
+It was like this.
+
+
+             YKCOWREBBAJ
+
+     sevot yhtils eht dna,gillirb sawT’
+      ebaw eht ni elbmig dna eryg diD
+        ,sevogorob eht erew ysmim llA
+       .ebargtuo shtar emom eht dnA
+
+
+She puzzled over this for some time, but at last a bright thought struck
+her. ‘Why, it’s a Looking-glass book, of course! And if I hold it up to
+a glass, the words will all go the right way again.’
+
+This was the poem that Alice read.
+
+
+             JABBERWOCKY
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+     ‘Beware the Jabberwock, my son!
+      The jaws that bite, the claws that catch!
+     Beware the Jubjub bird, and shun
+      The frumious Bandersnatch!’
+
+     He took his vorpal sword in hand:
+      Long time the manxome foe he sought--
+     So rested he by the Tumtum tree,
+      And stood awhile in thought.
+
+     And as in uffish thought he stood,
+      The Jabberwock, with eyes of flame,
+     Came whiffling through the tulgey wood,
+      And burbled as it came!
+
+     One, two! One, two! And through and through
+      The vorpal blade went snicker-snack!
+     He left it dead, and with its head
+      He went galumphing back.
+
+     ‘And hast thou slain the Jabberwock?
+      Come to my arms, my beamish boy!
+     O frabjous day! Callooh! Callay!’
+      He chortled in his joy.
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+
+‘It seems very pretty,’ she said when she had finished it, ‘but it’s
+RATHER hard to understand!’ (You see she didn’t like to confess, even
+to herself, that she couldn’t make it out at all.) ‘Somehow it seems
+to fill my head with ideas--only I don’t exactly know what they are!
+However, SOMEBODY killed SOMETHING: that’s clear, at any rate--’
+
+‘But oh!’ thought Alice, suddenly jumping up, ‘if I don’t make haste I
+shall have to go back through the Looking-glass, before I’ve seen what
+the rest of the house is like! Let’s have a look at the garden first!’
+She was out of the room in a moment, and ran down stairs--or, at least,
+it wasn’t exactly running, but a new invention of hers for getting down
+stairs quickly and easily, as Alice said to herself. She just kept the
+tips of her fingers on the hand-rail, and floated gently down without
+even touching the stairs with her feet; then she floated on through the
+hall, and would have gone straight out at the door in the same way, if
+she hadn’t caught hold of the door-post. She was getting a little giddy
+with so much floating in the air, and was rather glad to find herself
+walking again in the natural way.
+
+
+
+
+CHAPTER II. The Garden of Live Flowers
+
+‘I should see the garden far better,’ said Alice to herself, ‘if I could
+get to the top of that hill: and here’s a path that leads straight to
+it--at least, no, it doesn’t do that--’ (after going a few yards along
+the path, and turning several sharp corners), ‘but I suppose it will
+at last. But how curiously it twists! It’s more like a corkscrew than a
+path! Well, THIS turn goes to the hill, I suppose--no, it doesn’t! This
+goes straight back to the house! Well then, I’ll try it the other way.’
+
+And so she did: wandering up and down, and trying turn after turn, but
+always coming back to the house, do what she would. Indeed, once, when
+she turned a corner rather more quickly than usual, she ran against it
+before she could stop herself.
+
+‘It’s no use talking about it,’ Alice said, looking up at the house and
+pretending it was arguing with her. ‘I’m NOT going in again yet. I know
+I should have to get through the Looking-glass again--back into the old
+room--and there’d be an end of all my adventures!’
+
+So, resolutely turning her back upon the house, she set out once more
+down the path, determined to keep straight on till she got to the hill.
+For a few minutes all went on well, and she was just saying, ‘I really
+SHALL do it this time--’ when the path gave a sudden twist and shook
+itself (as she described it afterwards), and the next moment she found
+herself actually walking in at the door.
+
+‘Oh, it’s too bad!’ she cried. ‘I never saw such a house for getting in
+the way! Never!’
+
+However, there was the hill full in sight, so there was nothing to be
+done but start again. This time she came upon a large flower-bed, with a
+border of daisies, and a willow-tree growing in the middle.
+
+‘O Tiger-lily,’ said Alice, addressing herself to one that was waving
+gracefully about in the wind, ‘I WISH you could talk!’
+
+‘We CAN talk,’ said the Tiger-lily: ‘when there’s anybody worth talking
+to.’
+
+Alice was so astonished that she could not speak for a minute: it quite
+seemed to take her breath away. At length, as the Tiger-lily only went
+on waving about, she spoke again, in a timid voice--almost in a whisper.
+‘And can ALL the flowers talk?’
+
+‘As well as YOU can,’ said the Tiger-lily. ‘And a great deal louder.’
+
+‘It isn’t manners for us to begin, you know,’ said the Rose, ‘and I
+really was wondering when you’d speak! Said I to myself, “Her face has
+got SOME sense in it, though it’s not a clever one!” Still, you’re the
+right colour, and that goes a long way.’
+
+‘I don’t care about the colour,’ the Tiger-lily remarked. ‘If only her
+petals curled up a little more, she’d be all right.’
+
+Alice didn’t like being criticised, so she began asking questions.
+‘Aren’t you sometimes frightened at being planted out here, with nobody
+to take care of you?’
+
+‘There’s the tree in the middle,’ said the Rose: ‘what else is it good
+for?’
+
+‘But what could it do, if any danger came?’ Alice asked.
+
+‘It says “Bough-wough!”’ cried a Daisy: ‘that’s why its branches are
+called boughs!’
+
+‘Didn’t you know THAT?’ cried another Daisy, and here they all began
+shouting together, till the air seemed quite full of little shrill
+voices. ‘Silence, every one of you!’ cried the Tiger-lily, waving itself
+passionately from side to side, and trembling with excitement. ‘They
+know I can’t get at them!’ it panted, bending its quivering head towards
+Alice, ‘or they wouldn’t dare to do it!’
+
+‘Never mind!’ Alice said in a soothing tone, and stooping down to the
+daisies, who were just beginning again, she whispered, ‘If you don’t
+hold your tongues, I’ll pick you!’
+
+There was silence in a moment, and several of the pink daisies turned
+white.
+
+‘That’s right!’ said the Tiger-lily. ‘The daisies are worst of all. When
+one speaks, they all begin together, and it’s enough to make one wither
+to hear the way they go on!’
+
+‘How is it you can all talk so nicely?’ Alice said, hoping to get it
+into a better temper by a compliment. ‘I’ve been in many gardens before,
+but none of the flowers could talk.’
+
+‘Put your hand down, and feel the ground,’ said the Tiger-lily. ‘Then
+you’ll know why.’
+
+Alice did so. ‘It’s very hard,’ she said, ‘but I don’t see what that has
+to do with it.’
+
+‘In most gardens,’ the Tiger-lily said, ‘they make the beds too soft--so
+that the flowers are always asleep.’
+
+This sounded a very good reason, and Alice was quite pleased to know it.
+‘I never thought of that before!’ she said.
+
+‘It’s MY opinion that you never think AT ALL,’ the Rose said in a rather
+severe tone.
+
+‘I never saw anybody that looked stupider,’ a Violet said, so suddenly,
+that Alice quite jumped; for it hadn’t spoken before.
+
+‘Hold YOUR tongue!’ cried the Tiger-lily. ‘As if YOU ever saw anybody!
+You keep your head under the leaves, and snore away there, till you know
+no more what’s going on in the world, than if you were a bud!’
+
+‘Are there any more people in the garden besides me?’ Alice said, not
+choosing to notice the Rose’s last remark.
+
+‘There’s one other flower in the garden that can move about like you,’
+said the Rose. ‘I wonder how you do it--’ (‘You’re always wondering,’
+said the Tiger-lily), ‘but she’s more bushy than you are.’
+
+‘Is she like me?’ Alice asked eagerly, for the thought crossed her mind,
+‘There’s another little girl in the garden, somewhere!’
+
+‘Well, she has the same awkward shape as you,’ the Rose said, ‘but she’s
+redder--and her petals are shorter, I think.’
+
+‘Her petals are done up close, almost like a dahlia,’ the Tiger-lily
+interrupted: ‘not tumbled about anyhow, like yours.’
+
+‘But that’s not YOUR fault,’ the Rose added kindly: ‘you’re beginning
+to fade, you know--and then one can’t help one’s petals getting a little
+untidy.’
+
+Alice didn’t like this idea at all: so, to change the subject, she asked
+‘Does she ever come out here?’
+
+‘I daresay you’ll see her soon,’ said the Rose. ‘She’s one of the thorny
+kind.’
+
+‘Where does she wear the thorns?’ Alice asked with some curiosity.
+
+‘Why all round her head, of course,’ the Rose replied. ‘I was wondering
+YOU hadn’t got some too. I thought it was the regular rule.’
+
+‘She’s coming!’ cried the Larkspur. ‘I hear her footstep, thump, thump,
+thump, along the gravel-walk!’
+
+Alice looked round eagerly, and found that it was the Red Queen. ‘She’s
+grown a good deal!’ was her first remark. She had indeed: when Alice
+first found her in the ashes, she had been only three inches high--and
+here she was, half a head taller than Alice herself!
+
+‘It’s the fresh air that does it,’ said the Rose: ‘wonderfully fine air
+it is, out here.’
+
+‘I think I’ll go and meet her,’ said Alice, for, though the flowers were
+interesting enough, she felt that it would be far grander to have a talk
+with a real Queen.
+
+‘You can’t possibly do that,’ said the Rose: ‘_I_ should advise you to
+walk the other way.’
+
+This sounded nonsense to Alice, so she said nothing, but set off at
+once towards the Red Queen. To her surprise, she lost sight of her in a
+moment, and found herself walking in at the front-door again.
+
+A little provoked, she drew back, and after looking everywhere for the
+queen (whom she spied out at last, a long way off), she thought she
+would try the plan, this time, of walking in the opposite direction.
+
+It succeeded beautifully. She had not been walking a minute before she
+found herself face to face with the Red Queen, and full in sight of the
+hill she had been so long aiming at.
+
+‘Where do you come from?’ said the Red Queen. ‘And where are you going?
+Look up, speak nicely, and don’t twiddle your fingers all the time.’
+
+Alice attended to all these directions, and explained, as well as she
+could, that she had lost her way.
+
+‘I don’t know what you mean by YOUR way,’ said the Queen: ‘all the ways
+about here belong to ME--but why did you come out here at all?’ she
+added in a kinder tone. ‘Curtsey while you’re thinking what to say, it
+saves time.’
+
+Alice wondered a little at this, but she was too much in awe of the
+Queen to disbelieve it. ‘I’ll try it when I go home,’ she thought to
+herself, ‘the next time I’m a little late for dinner.’
+
+‘It’s time for you to answer now,’ the Queen said, looking at her watch:
+‘open your mouth a LITTLE wider when you speak, and always say “your
+Majesty.”’
+
+‘I only wanted to see what the garden was like, your Majesty--’
+
+‘That’s right,’ said the Queen, patting her on the head, which Alice
+didn’t like at all, ‘though, when you say “garden,”--I’VE seen gardens,
+compared with which this would be a wilderness.’
+
+Alice didn’t dare to argue the point, but went on: ‘--and I thought I’d
+try and find my way to the top of that hill--’
+
+‘When you say “hill,”’ the Queen interrupted, ‘_I_ could show you hills,
+in comparison with which you’d call that a valley.’
+
+‘No, I shouldn’t,’ said Alice, surprised into contradicting her at last:
+‘a hill CAN’T be a valley, you know. That would be nonsense--’
+
+The Red Queen shook her head, ‘You may call it “nonsense” if you like,’
+she said, ‘but I’VE heard nonsense, compared with which that would be as
+sensible as a dictionary!’
+
+Alice curtseyed again, as she was afraid from the Queen’s tone that she
+was a LITTLE offended: and they walked on in silence till they got to
+the top of the little hill.
+
+For some minutes Alice stood without speaking, looking out in all
+directions over the country--and a most curious country it was. There
+were a number of tiny little brooks running straight across it from side
+to side, and the ground between was divided up into squares by a number
+of little green hedges, that reached from brook to brook.
+
+‘I declare it’s marked out just like a large chessboard!’ Alice said at
+last. ‘There ought to be some men moving about somewhere--and so there
+are!’ She added in a tone of delight, and her heart began to beat quick
+with excitement as she went on. ‘It’s a great huge game of chess that’s
+being played--all over the world--if this IS the world at all, you know.
+Oh, what fun it is! How I WISH I was one of them! I wouldn’t mind being
+a Pawn, if only I might join--though of course I should LIKE to be a
+Queen, best.’
+
+She glanced rather shyly at the real Queen as she said this, but her
+companion only smiled pleasantly, and said, ‘That’s easily managed. You
+can be the White Queen’s Pawn, if you like, as Lily’s too young to
+play; and you’re in the Second Square to begin with: when you get to
+the Eighth Square you’ll be a Queen--’ Just at this moment, somehow or
+other, they began to run.
+
+Alice never could quite make out, in thinking it over afterwards, how it
+was that they began: all she remembers is, that they were running hand
+in hand, and the Queen went so fast that it was all she could do to keep
+up with her: and still the Queen kept crying ‘Faster! Faster!’ but Alice
+felt she COULD NOT go faster, though she had not breath left to say so.
+
+The most curious part of the thing was, that the trees and the other
+things round them never changed their places at all: however fast they
+went, they never seemed to pass anything. ‘I wonder if all the things
+move along with us?’ thought poor puzzled Alice. And the Queen seemed to
+guess her thoughts, for she cried, ‘Faster! Don’t try to talk!’
+
+Not that Alice had any idea of doing THAT. She felt as if she would
+never be able to talk again, she was getting so much out of breath: and
+still the Queen cried ‘Faster! Faster!’ and dragged her along. ‘Are we
+nearly there?’ Alice managed to pant out at last.
+
+‘Nearly there!’ the Queen repeated. ‘Why, we passed it ten minutes ago!
+Faster!’ And they ran on for a time in silence, with the wind whistling
+in Alice’s ears, and almost blowing her hair off her head, she fancied.
+
+‘Now! Now!’ cried the Queen. ‘Faster! Faster!’ And they went so fast
+that at last they seemed to skim through the air, hardly touching the
+ground with their feet, till suddenly, just as Alice was getting quite
+exhausted, they stopped, and she found herself sitting on the ground,
+breathless and giddy.
+
+The Queen propped her up against a tree, and said kindly, ‘You may rest
+a little now.’
+
+Alice looked round her in great surprise. ‘Why, I do believe we’ve been
+under this tree the whole time! Everything’s just as it was!’
+
+‘Of course it is,’ said the Queen, ‘what would you have it?’
+
+‘Well, in OUR country,’ said Alice, still panting a little, ‘you’d
+generally get to somewhere else--if you ran very fast for a long time,
+as we’ve been doing.’
+
+‘A slow sort of country!’ said the Queen. ‘Now, HERE, you see, it takes
+all the running YOU can do, to keep in the same place. If you want to
+get somewhere else, you must run at least twice as fast as that!’
+
+‘I’d rather not try, please!’ said Alice. ‘I’m quite content to stay
+here--only I AM so hot and thirsty!’
+
+‘I know what YOU’D like!’ the Queen said good-naturedly, taking a little
+box out of her pocket. ‘Have a biscuit?’
+
+Alice thought it would not be civil to say ‘No,’ though it wasn’t at all
+what she wanted. So she took it, and ate it as well as she could: and it
+was VERY dry; and she thought she had never been so nearly choked in all
+her life.
+
+‘While you’re refreshing yourself,’ said the Queen, ‘I’ll just take
+the measurements.’ And she took a ribbon out of her pocket, marked in
+inches, and began measuring the ground, and sticking little pegs in here
+and there.
+
+‘At the end of two yards,’ she said, putting in a peg to mark the
+distance, ‘I shall give you your directions--have another biscuit?’
+
+‘No, thank you,’ said Alice: ‘one’s QUITE enough!’
+
+‘Thirst quenched, I hope?’ said the Queen.
+
+Alice did not know what to say to this, but luckily the Queen did not
+wait for an answer, but went on. ‘At the end of THREE yards I shall
+repeat them--for fear of your forgetting them. At the end of FOUR, I
+shall say good-bye. And at the end of FIVE, I shall go!’
+
+She had got all the pegs put in by this time, and Alice looked on
+with great interest as she returned to the tree, and then began slowly
+walking down the row.
+
+At the two-yard peg she faced round, and said, ‘A pawn goes two squares
+in its first move, you know. So you’ll go VERY quickly through the Third
+Square--by railway, I should think--and you’ll find yourself in the
+Fourth Square in no time. Well, THAT square belongs to Tweedledum and
+Tweedledee--the Fifth is mostly water--the Sixth belongs to Humpty
+Dumpty--But you make no remark?’
+
+‘I--I didn’t know I had to make one--just then,’ Alice faltered out.
+
+‘You SHOULD have said, “It’s extremely kind of you to tell me all
+this”--however, we’ll suppose it said--the Seventh Square is all
+forest--however, one of the Knights will show you the way--and in the
+Eighth Square we shall be Queens together, and it’s all feasting and
+fun!’ Alice got up and curtseyed, and sat down again.
+
+At the next peg the Queen turned again, and this time she said, ‘Speak
+in French when you can’t think of the English for a thing--turn out your
+toes as you walk--and remember who you are!’ She did not wait for Alice
+to curtsey this time, but walked on quickly to the next peg, where she
+turned for a moment to say ‘good-bye,’ and then hurried on to the last.
+
+How it happened, Alice never knew, but exactly as she came to the last
+peg, she was gone. Whether she vanished into the air, or whether she
+ran quickly into the wood (‘and she CAN run very fast!’ thought Alice),
+there was no way of guessing, but she was gone, and Alice began to
+remember that she was a Pawn, and that it would soon be time for her to
+move.
+
+
+
+
+CHAPTER III. Looking-Glass Insects
+
+Of course the first thing to do was to make a grand survey of the
+country she was going to travel through. ‘It’s something very like
+learning geography,’ thought Alice, as she stood on tiptoe in hopes of
+being able to see a little further. ‘Principal rivers--there ARE none.
+Principal mountains--I’m on the only one, but I don’t think it’s got any
+name. Principal towns--why, what ARE those creatures, making honey down
+there? They can’t be bees--nobody ever saw bees a mile off, you know--’
+and for some time she stood silent, watching one of them that was
+bustling about among the flowers, poking its proboscis into them, ‘just
+as if it was a regular bee,’ thought Alice.
+
+However, this was anything but a regular bee: in fact it was an
+elephant--as Alice soon found out, though the idea quite took her breath
+away at first. ‘And what enormous flowers they must be!’ was her next
+idea. ‘Something like cottages with the roofs taken off, and stalks put
+to them--and what quantities of honey they must make! I think I’ll go
+down and--no, I won’t JUST yet,’ she went on, checking herself just as
+she was beginning to run down the hill, and trying to find some excuse
+for turning shy so suddenly. ‘It’ll never do to go down among them
+without a good long branch to brush them away--and what fun it’ll be
+when they ask me how I like my walk. I shall say--“Oh, I like it well
+enough--“’ (here came the favourite little toss of the head), ‘“only it
+was so dusty and hot, and the elephants did tease so!”’
+
+‘I think I’ll go down the other way,’ she said after a pause: ‘and
+perhaps I may visit the elephants later on. Besides, I do so want to get
+into the Third Square!’
+
+So with this excuse she ran down the hill and jumped over the first of
+the six little brooks.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Tickets, please!’ said the Guard, putting his head in at the window.
+In a moment everybody was holding out a ticket: they were about the same
+size as the people, and quite seemed to fill the carriage.
+
+‘Now then! Show your ticket, child!’ the Guard went on, looking angrily
+at Alice. And a great many voices all said together (‘like the chorus of
+a song,’ thought Alice), ‘Don’t keep him waiting, child! Why, his time
+is worth a thousand pounds a minute!’
+
+‘I’m afraid I haven’t got one,’ Alice said in a frightened tone: ‘there
+wasn’t a ticket-office where I came from.’ And again the chorus of
+voices went on. ‘There wasn’t room for one where she came from. The land
+there is worth a thousand pounds an inch!’
+
+‘Don’t make excuses,’ said the Guard: ‘you should have bought one from
+the engine-driver.’ And once more the chorus of voices went on with ‘The
+man that drives the engine. Why, the smoke alone is worth a thousand
+pounds a puff!’
+
+Alice thought to herself, ‘Then there’s no use in speaking.’ The
+voices didn’t join in this time, as she hadn’t spoken, but to her
+great surprise, they all THOUGHT in chorus (I hope you understand what
+THINKING IN CHORUS means--for I must confess that _I_ don’t), ‘Better
+say nothing at all. Language is worth a thousand pounds a word!’
+
+‘I shall dream about a thousand pounds tonight, I know I shall!’ thought
+Alice.
+
+All this time the Guard was looking at her, first through a telescope,
+then through a microscope, and then through an opera-glass. At last he
+said, ‘You’re travelling the wrong way,’ and shut up the window and went
+away.
+
+‘So young a child,’ said the gentleman sitting opposite to her (he was
+dressed in white paper), ‘ought to know which way she’s going, even if
+she doesn’t know her own name!’
+
+A Goat, that was sitting next to the gentleman in white, shut his
+eyes and said in a loud voice, ‘She ought to know her way to the
+ticket-office, even if she doesn’t know her alphabet!’
+
+There was a Beetle sitting next to the Goat (it was a very queer
+carriage-full of passengers altogether), and, as the rule seemed to be
+that they should all speak in turn, HE went on with ‘She’ll have to go
+back from here as luggage!’
+
+Alice couldn’t see who was sitting beyond the Beetle, but a hoarse voice
+spoke next. ‘Change engines--’ it said, and was obliged to leave off.
+
+‘It sounds like a horse,’ Alice thought to herself. And an extremely
+small voice, close to her ear, said, ‘You might make a joke on
+that--something about “horse” and “hoarse,” you know.’
+
+Then a very gentle voice in the distance said, ‘She must be labelled
+“Lass, with care,” you know--’
+
+And after that other voices went on (‘What a number of people there are
+in the carriage!’ thought Alice), saying, ‘She must go by post, as she’s
+got a head on her--’ ‘She must be sent as a message by the telegraph--’
+‘She must draw the train herself the rest of the way--’ and so on.
+
+But the gentleman dressed in white paper leaned forwards and whispered
+in her ear, ‘Never mind what they all say, my dear, but take a
+return-ticket every time the train stops.’
+
+‘Indeed I shan’t!’ Alice said rather impatiently. ‘I don’t belong to
+this railway journey at all--I was in a wood just now--and I wish I
+could get back there.’
+
+‘You might make a joke on THAT,’ said the little voice close to her ear:
+‘something about “you WOULD if you could,” you know.’
+
+‘Don’t tease so,’ said Alice, looking about in vain to see where the
+voice came from; ‘if you’re so anxious to have a joke made, why don’t
+you make one yourself?’
+
+The little voice sighed deeply: it was VERY unhappy, evidently, and
+Alice would have said something pitying to comfort it, ‘If it would only
+sigh like other people!’ she thought. But this was such a wonderfully
+small sigh, that she wouldn’t have heard it at all, if it hadn’t come
+QUITE close to her ear. The consequence of this was that it tickled her
+ear very much, and quite took off her thoughts from the unhappiness of
+the poor little creature.
+
+‘I know you are a friend,’ the little voice went on; ‘a dear friend, and
+an old friend. And you won’t hurt me, though I AM an insect.’
+
+‘What kind of insect?’ Alice inquired a little anxiously. What she
+really wanted to know was, whether it could sting or not, but she
+thought this wouldn’t be quite a civil question to ask.
+
+‘What, then you don’t--’ the little voice began, when it was drowned by
+a shrill scream from the engine, and everybody jumped up in alarm, Alice
+among the rest.
+
+The Horse, who had put his head out of the window, quietly drew it in
+and said, ‘It’s only a brook we have to jump over.’ Everybody seemed
+satisfied with this, though Alice felt a little nervous at the idea of
+trains jumping at all. ‘However, it’ll take us into the Fourth Square,
+that’s some comfort!’ she said to herself. In another moment she felt
+the carriage rise straight up into the air, and in her fright she caught
+at the thing nearest to her hand, which happened to be the Goat’s beard.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+But the beard seemed to melt away as she touched it, and she found
+herself sitting quietly under a tree--while the Gnat (for that was the
+insect she had been talking to) was balancing itself on a twig just over
+her head, and fanning her with its wings.
+
+It certainly was a VERY large Gnat: ‘about the size of a chicken,’ Alice
+thought. Still, she couldn’t feel nervous with it, after they had been
+talking together so long.
+
+‘--then you don’t like all insects?’ the Gnat went on, as quietly as if
+nothing had happened.
+
+‘I like them when they can talk,’ Alice said. ‘None of them ever talk,
+where _I_ come from.’
+
+‘What sort of insects do you rejoice in, where YOU come from?’ the Gnat
+inquired.
+
+‘I don’t REJOICE in insects at all,’ Alice explained, ‘because I’m
+rather afraid of them--at least the large kinds. But I can tell you the
+names of some of them.’
+
+‘Of course they answer to their names?’ the Gnat remarked carelessly.
+
+‘I never knew them to do it.’
+
+‘What’s the use of their having names,’ the Gnat said, ‘if they won’t
+answer to them?’
+
+‘No use to THEM,’ said Alice; ‘but it’s useful to the people who name
+them, I suppose. If not, why do things have names at all?’
+
+‘I can’t say,’ the Gnat replied. ‘Further on, in the wood down there,
+they’ve got no names--however, go on with your list of insects: you’re
+wasting time.’
+
+‘Well, there’s the Horse-fly,’ Alice began, counting off the names on
+her fingers.
+
+‘All right,’ said the Gnat: ‘half way up that bush, you’ll see a
+Rocking-horse-fly, if you look. It’s made entirely of wood, and gets
+about by swinging itself from branch to branch.’
+
+‘What does it live on?’ Alice asked, with great curiosity.
+
+‘Sap and sawdust,’ said the Gnat. ‘Go on with the list.’
+
+Alice looked up at the Rocking-horse-fly with great interest, and made
+up her mind that it must have been just repainted, it looked so bright
+and sticky; and then she went on.
+
+‘And there’s the Dragon-fly.’
+
+‘Look on the branch above your head,’ said the Gnat, ‘and there you’ll
+find a snap-dragon-fly. Its body is made of plum-pudding, its wings of
+holly-leaves, and its head is a raisin burning in brandy.’
+
+‘And what does it live on?’
+
+‘Frumenty and mince pie,’ the Gnat replied; ‘and it makes its nest in a
+Christmas box.’
+
+‘And then there’s the Butterfly,’ Alice went on, after she had taken
+a good look at the insect with its head on fire, and had thought to
+herself, ‘I wonder if that’s the reason insects are so fond of flying
+into candles--because they want to turn into Snap-dragon-flies!’
+
+‘Crawling at your feet,’ said the Gnat (Alice drew her feet back in
+some alarm), ‘you may observe a Bread-and-Butterfly. Its wings are thin
+slices of Bread-and-butter, its body is a crust, and its head is a lump
+of sugar.’
+
+‘And what does IT live on?’
+
+‘Weak tea with cream in it.’
+
+A new difficulty came into Alice’s head. ‘Supposing it couldn’t find
+any?’ she suggested.
+
+‘Then it would die, of course.’
+
+‘But that must happen very often,’ Alice remarked thoughtfully.
+
+‘It always happens,’ said the Gnat.
+
+After this, Alice was silent for a minute or two, pondering. The Gnat
+amused itself meanwhile by humming round and round her head: at last
+it settled again and remarked, ‘I suppose you don’t want to lose your
+name?’
+
+‘No, indeed,’ Alice said, a little anxiously.
+
+‘And yet I don’t know,’ the Gnat went on in a careless tone: ‘only think
+how convenient it would be if you could manage to go home without it!
+For instance, if the governess wanted to call you to your lessons, she
+would call out “come here--,” and there she would have to leave off,
+because there wouldn’t be any name for her to call, and of course you
+wouldn’t have to go, you know.’
+
+‘That would never do, I’m sure,’ said Alice: ‘the governess would never
+think of excusing me lessons for that. If she couldn’t remember my name,
+she’d call me “Miss!” as the servants do.’
+
+‘Well, if she said “Miss,” and didn’t say anything more,’ the Gnat
+remarked, ‘of course you’d miss your lessons. That’s a joke. I wish YOU
+had made it.’
+
+‘Why do you wish _I_ had made it?’ Alice asked. ‘It’s a very bad one.’
+
+But the Gnat only sighed deeply, while two large tears came rolling down
+its cheeks.
+
+‘You shouldn’t make jokes,’ Alice said, ‘if it makes you so unhappy.’
+
+Then came another of those melancholy little sighs, and this time the
+poor Gnat really seemed to have sighed itself away, for, when Alice
+looked up, there was nothing whatever to be seen on the twig, and, as
+she was getting quite chilly with sitting still so long, she got up and
+walked on.
+
+She very soon came to an open field, with a wood on the other side of
+it: it looked much darker than the last wood, and Alice felt a LITTLE
+timid about going into it. However, on second thoughts, she made up her
+mind to go on: ‘for I certainly won’t go BACK,’ she thought to herself,
+and this was the only way to the Eighth Square.
+
+‘This must be the wood,’ she said thoughtfully to herself, ‘where
+things have no names. I wonder what’ll become of MY name when I go in?
+I shouldn’t like to lose it at all--because they’d have to give me
+another, and it would be almost certain to be an ugly one. But then
+the fun would be trying to find the creature that had got my old
+name! That’s just like the advertisements, you know, when people lose
+dogs--“ANSWERS TO THE NAME OF ‘DASH:’ HAD ON A BRASS COLLAR”--just fancy
+calling everything you met “Alice,” till one of them answered! Only they
+wouldn’t answer at all, if they were wise.’
+
+She was rambling on in this way when she reached the wood: it looked
+very cool and shady. ‘Well, at any rate it’s a great comfort,’ she
+said as she stepped under the trees, ‘after being so hot, to get into
+the--into WHAT?’ she went on, rather surprised at not being able to
+think of the word. ‘I mean to get under the--under the--under THIS, you
+know!’ putting her hand on the trunk of the tree. ‘What DOES it call
+itself, I wonder? I do believe it’s got no name--why, to be sure it
+hasn’t!’
+
+She stood silent for a minute, thinking: then she suddenly began again.
+‘Then it really HAS happened, after all! And now, who am I? I WILL
+remember, if I can! I’m determined to do it!’ But being determined
+didn’t help much, and all she could say, after a great deal of puzzling,
+was, ‘L, I KNOW it begins with L!’
+
+Just then a Fawn came wandering by: it looked at Alice with its large
+gentle eyes, but didn’t seem at all frightened. ‘Here then! Here then!’
+Alice said, as she held out her hand and tried to stroke it; but it only
+started back a little, and then stood looking at her again.
+
+‘What do you call yourself?’ the Fawn said at last. Such a soft sweet
+voice it had!
+
+‘I wish I knew!’ thought poor Alice. She answered, rather sadly,
+‘Nothing, just now.’
+
+‘Think again,’ it said: ‘that won’t do.’
+
+Alice thought, but nothing came of it. ‘Please, would you tell me
+what YOU call yourself?’ she said timidly. ‘I think that might help a
+little.’
+
+‘I’ll tell you, if you’ll move a little further on,’ the Fawn said. ‘I
+can’t remember here.’
+
+So they walked on together though the wood, Alice with her arms clasped
+lovingly round the soft neck of the Fawn, till they came out into
+another open field, and here the Fawn gave a sudden bound into the air,
+and shook itself free from Alice’s arms. ‘I’m a Fawn!’ it cried out in a
+voice of delight, ‘and, dear me! you’re a human child!’ A sudden look of
+alarm came into its beautiful brown eyes, and in another moment it had
+darted away at full speed.
+
+Alice stood looking after it, almost ready to cry with vexation at
+having lost her dear little fellow-traveller so suddenly. ‘However, I
+know my name now.’ she said, ‘that’s SOME comfort. Alice--Alice--I won’t
+forget it again. And now, which of these finger-posts ought I to follow,
+I wonder?’
+
+It was not a very difficult question to answer, as there was only one
+road through the wood, and the two finger-posts both pointed along it.
+‘I’ll settle it,’ Alice said to herself, ‘when the road divides and they
+point different ways.’
+
+But this did not seem likely to happen. She went on and on, a long way,
+but wherever the road divided there were sure to be two finger-posts
+pointing the same way, one marked ‘TO TWEEDLEDUM’S HOUSE’ and the other
+‘TO THE HOUSE OF TWEEDLEDEE.’
+
+‘I do believe,’ said Alice at last, ‘that they live in the same house! I
+wonder I never thought of that before--But I can’t stay there long. I’ll
+just call and say “how d’you do?” and ask them the way out of the wood.
+If I could only get to the Eighth Square before it gets dark!’ So she
+wandered on, talking to herself as she went, till, on turning a sharp
+corner, she came upon two fat little men, so suddenly that she could not
+help starting back, but in another moment she recovered herself, feeling
+sure that they must be.
+
+
+
+
+CHAPTER IV. Tweedledum And Tweedledee
+
+They were standing under a tree, each with an arm round the other’s
+neck, and Alice knew which was which in a moment, because one of them
+had ‘DUM’ embroidered on his collar, and the other ‘DEE.’ ‘I suppose
+they’ve each got “TWEEDLE” round at the back of the collar,’ she said to
+herself.
+
+They stood so still that she quite forgot they were alive, and she was
+just looking round to see if the word “TWEEDLE” was written at the back
+of each collar, when she was startled by a voice coming from the one
+marked ‘DUM.’
+
+‘If you think we’re wax-works,’ he said, ‘you ought to pay, you know.
+Wax-works weren’t made to be looked at for nothing, nohow!’
+
+‘Contrariwise,’ added the one marked ‘DEE,’ ‘if you think we’re alive,
+you ought to speak.’
+
+‘I’m sure I’m very sorry,’ was all Alice could say; for the words of the
+old song kept ringing through her head like the ticking of a clock, and
+she could hardly help saying them out loud:--
+
+
+     ‘Tweedledum and Tweedledee
+      Agreed to have a battle;
+     For Tweedledum said Tweedledee
+      Had spoiled his nice new rattle.
+
+     Just then flew down a monstrous crow,
+      As black as a tar-barrel;
+     Which frightened both the heroes so,
+      They quite forgot their quarrel.’
+
+‘I know what you’re thinking about,’ said Tweedledum: ‘but it isn’t so,
+nohow.’
+
+‘Contrariwise,’ continued Tweedledee, ‘if it was so, it might be; and if
+it were so, it would be; but as it isn’t, it ain’t. That’s logic.’
+
+‘I was thinking,’ Alice said very politely, ‘which is the best way out
+of this wood: it’s getting so dark. Would you tell me, please?’
+
+But the little men only looked at each other and grinned.
+
+They looked so exactly like a couple of great schoolboys, that Alice
+couldn’t help pointing her finger at Tweedledum, and saying ‘First Boy!’
+
+‘Nohow!’ Tweedledum cried out briskly, and shut his mouth up again with
+a snap.
+
+‘Next Boy!’ said Alice, passing on to Tweedledee, though she felt quite
+certain he would only shout out ‘Contrariwise!’ and so he did.
+
+‘You’ve been wrong!’ cried Tweedledum. ‘The first thing in a visit is to
+say “How d’ye do?” and shake hands!’ And here the two brothers gave each
+other a hug, and then they held out the two hands that were free, to
+shake hands with her.
+
+Alice did not like shaking hands with either of them first, for fear
+of hurting the other one’s feelings; so, as the best way out of the
+difficulty, she took hold of both hands at once: the next moment they
+were dancing round in a ring. This seemed quite natural (she remembered
+afterwards), and she was not even surprised to hear music playing: it
+seemed to come from the tree under which they were dancing, and it was
+done (as well as she could make it out) by the branches rubbing one
+across the other, like fiddles and fiddle-sticks.
+
+‘But it certainly WAS funny,’ (Alice said afterwards, when she was
+telling her sister the history of all this,) ‘to find myself singing
+“HERE WE GO ROUND THE MULBERRY BUSH.” I don’t know when I began it, but
+somehow I felt as if I’d been singing it a long long time!’
+
+The other two dancers were fat, and very soon out of breath. ‘Four times
+round is enough for one dance,’ Tweedledum panted out, and they left
+off dancing as suddenly as they had begun: the music stopped at the same
+moment.
+
+Then they let go of Alice’s hands, and stood looking at her for a
+minute: there was a rather awkward pause, as Alice didn’t know how to
+begin a conversation with people she had just been dancing with. ‘It
+would never do to say “How d’ye do?” NOW,’ she said to herself: ‘we seem
+to have got beyond that, somehow!’
+
+‘I hope you’re not much tired?’ she said at last.
+
+‘Nohow. And thank you VERY much for asking,’ said Tweedledum.
+
+‘So much obliged!’ added Tweedledee. ‘You like poetry?’
+
+‘Ye-es, pretty well--SOME poetry,’ Alice said doubtfully. ‘Would you
+tell me which road leads out of the wood?’
+
+‘What shall I repeat to her?’ said Tweedledee, looking round at
+Tweedledum with great solemn eyes, and not noticing Alice’s question.
+
+‘“THE WALRUS AND THE CARPENTER” is the longest,’ Tweedledum replied,
+giving his brother an affectionate hug.
+
+Tweedledee began instantly:
+
+       ‘The sun was shining--’
+
+Here Alice ventured to interrupt him. ‘If it’s VERY long,’ she said, as
+politely as she could, ‘would you please tell me first which road--’
+
+Tweedledee smiled gently, and began again:
+
+     ‘The sun was shining on the sea,
+      Shining with all his might:
+     He did his very best to make
+      The billows smooth and bright--
+     And this was odd, because it was
+      The middle of the night.
+
+     The moon was shining sulkily,
+      Because she thought the sun
+     Had got no business to be there
+      After the day was done--
+     “It’s very rude of him,” she said,
+      “To come and spoil the fun!”
+
+     The sea was wet as wet could be,
+      The sands were dry as dry.
+     You could not see a cloud, because
+      No cloud was in the sky:
+     No birds were flying over head--
+      There were no birds to fly.
+
+     The Walrus and the Carpenter
+      Were walking close at hand;
+     They wept like anything to see
+      Such quantities of sand:
+     “If this were only cleared away,”
+       They said, “it WOULD be grand!”
+
+     “If seven maids with seven mops
+      Swept it for half a year,
+     Do you suppose,” the Walrus said,
+      “That they could get it clear?”
+      “I doubt it,” said the Carpenter,
+      And shed a bitter tear.
+
+     “O Oysters, come and walk with us!”
+       The Walrus did beseech.
+     “A pleasant walk, a pleasant talk,
+      Along the briny beach:
+     We cannot do with more than four,
+      To give a hand to each.”
+
+     The eldest Oyster looked at him.
+      But never a word he said:
+     The eldest Oyster winked his eye,
+      And shook his heavy head--
+     Meaning to say he did not choose
+      To leave the oyster-bed.
+
+     But four young oysters hurried up,
+      All eager for the treat:
+     Their coats were brushed, their faces washed,
+      Their shoes were clean and neat--
+     And this was odd, because, you know,
+      They hadn’t any feet.
+
+     Four other Oysters followed them,
+      And yet another four;
+     And thick and fast they came at last,
+      And more, and more, and more--
+     All hopping through the frothy waves,
+      And scrambling to the shore.
+
+     The Walrus and the Carpenter
+      Walked on a mile or so,
+     And then they rested on a rock
+      Conveniently low:
+     And all the little Oysters stood
+      And waited in a row.
+
+     “The time has come,” the Walrus said,
+      “To talk of many things:
+     Of shoes--and ships--and sealing-wax--
+      Of cabbages--and kings--
+     And why the sea is boiling hot--
+      And whether pigs have wings.”
+
+     “But wait a bit,” the Oysters cried,
+      “Before we have our chat;
+     For some of us are out of breath,
+      And all of us are fat!”
+      “No hurry!” said the Carpenter.
+      They thanked him much for that.
+
+     “A loaf of bread,” the Walrus said,
+      “Is what we chiefly need:
+     Pepper and vinegar besides
+      Are very good indeed--
+     Now if you’re ready Oysters dear,
+      We can begin to feed.”
+
+     “But not on us!” the Oysters cried,
+      Turning a little blue,
+     “After such kindness, that would be
+      A dismal thing to do!”
+      “The night is fine,” the Walrus said
+      “Do you admire the view?
+
+     “It was so kind of you to come!
+      And you are very nice!”
+      The Carpenter said nothing but
+      “Cut us another slice:
+     I wish you were not quite so deaf--
+      I’ve had to ask you twice!”
+
+     “It seems a shame,” the Walrus said,
+      “To play them such a trick,
+     After we’ve brought them out so far,
+      And made them trot so quick!”
+      The Carpenter said nothing but
+      “The butter’s spread too thick!”
+
+     “I weep for you,” the Walrus said.
+      “I deeply sympathize.”
+      With sobs and tears he sorted out
+      Those of the largest size.
+     Holding his pocket handkerchief
+      Before his streaming eyes.
+
+     “O Oysters,” said the Carpenter.
+      “You’ve had a pleasant run!
+     Shall we be trotting home again?”
+       But answer came there none--
+     And that was scarcely odd, because
+      They’d eaten every one.’
+
+‘I like the Walrus best,’ said Alice: ‘because you see he was a LITTLE
+sorry for the poor oysters.’
+
+‘He ate more than the Carpenter, though,’ said Tweedledee. ‘You see he
+held his handkerchief in front, so that the Carpenter couldn’t count how
+many he took: contrariwise.’
+
+‘That was mean!’ Alice said indignantly. ‘Then I like the Carpenter
+best--if he didn’t eat so many as the Walrus.’
+
+‘But he ate as many as he could get,’ said Tweedledum.
+
+This was a puzzler. After a pause, Alice began, ‘Well! They were BOTH
+very unpleasant characters--’ Here she checked herself in some alarm,
+at hearing something that sounded to her like the puffing of a large
+steam-engine in the wood near them, though she feared it was more likely
+to be a wild beast. ‘Are there any lions or tigers about here?’ she
+asked timidly.
+
+‘It’s only the Red King snoring,’ said Tweedledee.
+
+‘Come and look at him!’ the brothers cried, and they each took one of
+Alice’s hands, and led her up to where the King was sleeping.
+
+‘Isn’t he a LOVELY sight?’ said Tweedledum.
+
+Alice couldn’t say honestly that he was. He had a tall red night-cap on,
+with a tassel, and he was lying crumpled up into a sort of untidy heap,
+and snoring loud--‘fit to snore his head off!’ as Tweedledum remarked.
+
+‘I’m afraid he’ll catch cold with lying on the damp grass,’ said Alice,
+who was a very thoughtful little girl.
+
+‘He’s dreaming now,’ said Tweedledee: ‘and what do you think he’s
+dreaming about?’
+
+Alice said ‘Nobody can guess that.’
+
+‘Why, about YOU!’ Tweedledee exclaimed, clapping his hands triumphantly.
+‘And if he left off dreaming about you, where do you suppose you’d be?’
+
+‘Where I am now, of course,’ said Alice.
+
+‘Not you!’ Tweedledee retorted contemptuously. ‘You’d be nowhere. Why,
+you’re only a sort of thing in his dream!’
+
+‘If that there King was to wake,’ added Tweedledum, ‘you’d go
+out--bang!--just like a candle!’
+
+‘I shouldn’t!’ Alice exclaimed indignantly. ‘Besides, if I’M only a sort
+of thing in his dream, what are YOU, I should like to know?’
+
+‘Ditto’ said Tweedledum.
+
+‘Ditto, ditto’ cried Tweedledee.
+
+He shouted this so loud that Alice couldn’t help saying, ‘Hush! You’ll
+be waking him, I’m afraid, if you make so much noise.’
+
+‘Well, it no use YOUR talking about waking him,’ said Tweedledum, ‘when
+you’re only one of the things in his dream. You know very well you’re
+not real.’
+
+‘I AM real!’ said Alice and began to cry.
+
+‘You won’t make yourself a bit realler by crying,’ Tweedledee remarked:
+‘there’s nothing to cry about.’
+
+‘If I wasn’t real,’ Alice said--half-laughing through her tears, it all
+seemed so ridiculous--‘I shouldn’t be able to cry.’
+
+‘I hope you don’t suppose those are real tears?’ Tweedledum interrupted
+in a tone of great contempt.
+
+‘I know they’re talking nonsense,’ Alice thought to herself: ‘and it’s
+foolish to cry about it.’ So she brushed away her tears, and went on as
+cheerfully as she could. ‘At any rate I’d better be getting out of the
+wood, for really it’s coming on very dark. Do you think it’s going to
+rain?’
+
+Tweedledum spread a large umbrella over himself and his brother, and
+looked up into it. ‘No, I don’t think it is,’ he said: ‘at least--not
+under HERE. Nohow.’
+
+‘But it may rain OUTSIDE?’
+
+‘It may--if it chooses,’ said Tweedledee: ‘we’ve no objection.
+Contrariwise.’
+
+‘Selfish things!’ thought Alice, and she was just going to say
+‘Good-night’ and leave them, when Tweedledum sprang out from under the
+umbrella and seized her by the wrist.
+
+‘Do you see THAT?’ he said, in a voice choking with passion, and
+his eyes grew large and yellow all in a moment, as he pointed with a
+trembling finger at a small white thing lying under the tree.
+
+‘It’s only a rattle,’ Alice said, after a careful examination of the
+little white thing. ‘Not a rattleSNAKE, you know,’ she added hastily,
+thinking that he was frightened: ‘only an old rattle--quite old and
+broken.’
+
+‘I knew it was!’ cried Tweedledum, beginning to stamp about wildly and
+tear his hair. ‘It’s spoilt, of course!’ Here he looked at Tweedledee,
+who immediately sat down on the ground, and tried to hide himself under
+the umbrella.
+
+Alice laid her hand upon his arm, and said in a soothing tone, ‘You
+needn’t be so angry about an old rattle.’
+
+‘But it isn’t old!’ Tweedledum cried, in a greater fury than ever. ‘It’s
+new, I tell you--I bought it yesterday--my nice new RATTLE!’ and his
+voice rose to a perfect scream.
+
+All this time Tweedledee was trying his best to fold up the umbrella,
+with himself in it: which was such an extraordinary thing to do, that it
+quite took off Alice’s attention from the angry brother. But he couldn’t
+quite succeed, and it ended in his rolling over, bundled up in the
+umbrella, with only his head out: and there he lay, opening and shutting
+his mouth and his large eyes--‘looking more like a fish than anything
+else,’ Alice thought.
+
+‘Of course you agree to have a battle?’ Tweedledum said in a calmer
+tone.
+
+‘I suppose so,’ the other sulkily replied, as he crawled out of the
+umbrella: ‘only SHE must help us to dress up, you know.’
+
+So the two brothers went off hand-in-hand into the wood, and returned
+in a minute with their arms full of things--such as bolsters, blankets,
+hearth-rugs, table-cloths, dish-covers and coal-scuttles. ‘I hope you’re
+a good hand at pinning and tying strings?’ Tweedledum remarked. ‘Every
+one of these things has got to go on, somehow or other.’
+
+Alice said afterwards she had never seen such a fuss made about anything
+in all her life--the way those two bustled about--and the quantity of
+things they put on--and the trouble they gave her in tying strings and
+fastening buttons--‘Really they’ll be more like bundles of old clothes
+than anything else, by the time they’re ready!’ she said to herself, as
+she arranged a bolster round the neck of Tweedledee, ‘to keep his head
+from being cut off,’ as he said.
+
+‘You know,’ he added very gravely, ‘it’s one of the most serious things
+that can possibly happen to one in a battle--to get one’s head cut off.’
+
+Alice laughed aloud: but she managed to turn it into a cough, for fear
+of hurting his feelings.
+
+‘Do I look very pale?’ said Tweedledum, coming up to have his helmet
+tied on. (He CALLED it a helmet, though it certainly looked much more
+like a saucepan.)
+
+‘Well--yes--a LITTLE,’ Alice replied gently.
+
+‘I’m very brave generally,’ he went on in a low voice: ‘only to-day I
+happen to have a headache.’
+
+‘And I’VE got a toothache!’ said Tweedledee, who had overheard the
+remark. ‘I’m far worse off than you!’
+
+‘Then you’d better not fight to-day,’ said Alice, thinking it a good
+opportunity to make peace.
+
+‘We MUST have a bit of a fight, but I don’t care about going on long,’
+said Tweedledum. ‘What’s the time now?’
+
+Tweedledee looked at his watch, and said ‘Half-past four.’
+
+‘Let’s fight till six, and then have dinner,’ said Tweedledum.
+
+‘Very well,’ the other said, rather sadly: ‘and SHE can watch us--only
+you’d better not come VERY close,’ he added: ‘I generally hit everything
+I can see--when I get really excited.’
+
+‘And _I_ hit everything within reach,’ cried Tweedledum, ‘whether I can
+see it or not!’
+
+Alice laughed. ‘You must hit the TREES pretty often, I should think,’
+she said.
+
+Tweedledum looked round him with a satisfied smile. ‘I don’t suppose,’
+he said, ‘there’ll be a tree left standing, for ever so far round, by
+the time we’ve finished!’
+
+‘And all about a rattle!’ said Alice, still hoping to make them a LITTLE
+ashamed of fighting for such a trifle.
+
+‘I shouldn’t have minded it so much,’ said Tweedledum, ‘if it hadn’t
+been a new one.’
+
+‘I wish the monstrous crow would come!’ thought Alice.
+
+‘There’s only one sword, you know,’ Tweedledum said to his brother:
+‘but you can have the umbrella--it’s quite as sharp. Only we must begin
+quick. It’s getting as dark as it can.’
+
+‘And darker,’ said Tweedledee.
+
+It was getting dark so suddenly that Alice thought there must be a
+thunderstorm coming on. ‘What a thick black cloud that is!’ she said.
+‘And how fast it comes! Why, I do believe it’s got wings!’
+
+‘It’s the crow!’ Tweedledum cried out in a shrill voice of alarm: and
+the two brothers took to their heels and were out of sight in a moment.
+
+Alice ran a little way into the wood, and stopped under a large tree.
+‘It can never get at me HERE,’ she thought: ‘it’s far too large to
+squeeze itself in among the trees. But I wish it wouldn’t flap its wings
+so--it makes quite a hurricane in the wood--here’s somebody’s shawl
+being blown away!’
+
+
+
+
+CHAPTER V. Wool and Water
+
+She caught the shawl as she spoke, and looked about for the owner: in
+another moment the White Queen came running wildly through the wood,
+with both arms stretched out wide, as if she were flying, and Alice very
+civilly went to meet her with the shawl.
+
+‘I’m very glad I happened to be in the way,’ Alice said, as she helped
+her to put on her shawl again.
+
+The White Queen only looked at her in a helpless frightened sort of way,
+and kept repeating something in a whisper to herself that sounded like
+‘bread-and-butter, bread-and-butter,’ and Alice felt that if there was
+to be any conversation at all, she must manage it herself. So she began
+rather timidly: ‘Am I addressing the White Queen?’
+
+‘Well, yes, if you call that a-dressing,’ The Queen said. ‘It isn’t MY
+notion of the thing, at all.’
+
+Alice thought it would never do to have an argument at the very
+beginning of their conversation, so she smiled and said, ‘If your
+Majesty will only tell me the right way to begin, I’ll do it as well as
+I can.’
+
+‘But I don’t want it done at all!’ groaned the poor Queen. ‘I’ve been
+a-dressing myself for the last two hours.’
+
+It would have been all the better, as it seemed to Alice, if she had got
+some one else to dress her, she was so dreadfully untidy. ‘Every
+single thing’s crooked,’ Alice thought to herself, ‘and she’s all over
+pins!--may I put your shawl straight for you?’ she added aloud.
+
+‘I don’t know what’s the matter with it!’ the Queen said, in a
+melancholy voice. ‘It’s out of temper, I think. I’ve pinned it here, and
+I’ve pinned it there, but there’s no pleasing it!’
+
+‘It CAN’T go straight, you know, if you pin it all on one side,’ Alice
+said, as she gently put it right for her; ‘and, dear me, what a state
+your hair is in!’
+
+‘The brush has got entangled in it!’ the Queen said with a sigh. ‘And I
+lost the comb yesterday.’
+
+Alice carefully released the brush, and did her best to get the hair
+into order. ‘Come, you look rather better now!’ she said, after altering
+most of the pins. ‘But really you should have a lady’s maid!’
+
+‘I’m sure I’ll take you with pleasure!’ the Queen said. ‘Twopence a
+week, and jam every other day.’
+
+Alice couldn’t help laughing, as she said, ‘I don’t want you to hire
+ME--and I don’t care for jam.’
+
+‘It’s very good jam,’ said the Queen.
+
+‘Well, I don’t want any TO-DAY, at any rate.’
+
+‘You couldn’t have it if you DID want it,’ the Queen said. ‘The rule is,
+jam to-morrow and jam yesterday--but never jam to-day.’
+
+‘It MUST come sometimes to “jam to-day,”’ Alice objected.
+
+‘No, it can’t,’ said the Queen. ‘It’s jam every OTHER day: to-day isn’t
+any OTHER day, you know.’
+
+‘I don’t understand you,’ said Alice. ‘It’s dreadfully confusing!’
+
+‘That’s the effect of living backwards,’ the Queen said kindly: ‘it
+always makes one a little giddy at first--’
+
+‘Living backwards!’ Alice repeated in great astonishment. ‘I never heard
+of such a thing!’
+
+‘--but there’s one great advantage in it, that one’s memory works both
+ways.’
+
+‘I’m sure MINE only works one way,’ Alice remarked. ‘I can’t remember
+things before they happen.’
+
+‘It’s a poor sort of memory that only works backwards,’ the Queen
+remarked.
+
+‘What sort of things do YOU remember best?’ Alice ventured to ask.
+
+‘Oh, things that happened the week after next,’ the Queen replied in a
+careless tone. ‘For instance, now,’ she went on, sticking a large piece
+of plaster on her finger as she spoke, ‘there’s the King’s
+Messenger. He’s in prison now, being punished: and the trial doesn’t
+even begin till next Wednesday: and of course the crime comes last of
+all.’
+
+‘Suppose he never commits the crime?’ said Alice.
+
+‘That would be all the better, wouldn’t it?’ the Queen said, as she
+bound the plaster round her finger with a bit of ribbon.
+
+Alice felt there was no denying THAT. ‘Of course it would be all
+the better,’ she said: ‘but it wouldn’t be all the better his being
+punished.’
+
+‘You’re wrong THERE, at any rate,’ said the Queen: ‘were YOU ever
+punished?’
+
+‘Only for faults,’ said Alice.
+
+‘And you were all the better for it, I know!’ the Queen said
+triumphantly.
+
+‘Yes, but then I HAD done the things I was punished for,’ said Alice:
+‘that makes all the difference.’
+
+‘But if you HADN’T done them,’ the Queen said, ‘that would have been
+better still; better, and better, and better!’ Her voice went higher
+with each ‘better,’ till it got quite to a squeak at last.
+
+Alice was just beginning to say ‘There’s a mistake somewhere--,’ when
+the Queen began screaming so loud that she had to leave the sentence
+unfinished. ‘Oh, oh, oh!’ shouted the Queen, shaking her hand about as
+if she wanted to shake it off. ‘My finger’s bleeding! Oh, oh, oh, oh!’
+
+Her screams were so exactly like the whistle of a steam-engine, that
+Alice had to hold both her hands over her ears.
+
+‘What IS the matter?’ she said, as soon as there was a chance of making
+herself heard. ‘Have you pricked your finger?’
+
+‘I haven’t pricked it YET,’ the Queen said, ‘but I soon shall--oh, oh,
+oh!’
+
+‘When do you expect to do it?’ Alice asked, feeling very much inclined
+to laugh.
+
+‘When I fasten my shawl again,’ the poor Queen groaned out: ‘the brooch
+will come undone directly. Oh, oh!’ As she said the words the brooch
+flew open, and the Queen clutched wildly at it, and tried to clasp it
+again.
+
+‘Take care!’ cried Alice. ‘You’re holding it all crooked!’ And she
+caught at the brooch; but it was too late: the pin had slipped, and the
+Queen had pricked her finger.
+
+‘That accounts for the bleeding, you see,’ she said to Alice with a
+smile. ‘Now you understand the way things happen here.’
+
+‘But why don’t you scream now?’ Alice asked, holding her hands ready to
+put over her ears again.
+
+‘Why, I’ve done all the screaming already,’ said the Queen. ‘What would
+be the good of having it all over again?’
+
+By this time it was getting light. ‘The crow must have flown away, I
+think,’ said Alice: ‘I’m so glad it’s gone. I thought it was the night
+coming on.’
+
+‘I wish _I_ could manage to be glad!’ the Queen said. ‘Only I never
+can remember the rule. You must be very happy, living in this wood, and
+being glad whenever you like!’
+
+‘Only it is so VERY lonely here!’ Alice said in a melancholy voice; and
+at the thought of her loneliness two large tears came rolling down her
+cheeks.
+
+‘Oh, don’t go on like that!’ cried the poor Queen, wringing her hands in
+despair. ‘Consider what a great girl you are. Consider what a long way
+you’ve come to-day. Consider what o’clock it is. Consider anything, only
+don’t cry!’
+
+Alice could not help laughing at this, even in the midst of her tears.
+‘Can YOU keep from crying by considering things?’ she asked.
+
+‘That’s the way it’s done,’ the Queen said with great decision: ‘nobody
+can do two things at once, you know. Let’s consider your age to begin
+with--how old are you?’
+
+‘I’m seven and a half exactly.’
+
+‘You needn’t say “exactually,”’ the Queen remarked: ‘I can believe
+it without that. Now I’ll give YOU something to believe. I’m just one
+hundred and one, five months and a day.’
+
+‘I can’t believe THAT!’ said Alice.
+
+‘Can’t you?’ the Queen said in a pitying tone. ‘Try again: draw a long
+breath, and shut your eyes.’
+
+Alice laughed. ‘There’s no use trying,’ she said: ‘one CAN’T believe
+impossible things.’
+
+‘I daresay you haven’t had much practice,’ said the Queen. ‘When I was
+your age, I always did it for half-an-hour a day. Why, sometimes I’ve
+believed as many as six impossible things before breakfast. There goes
+the shawl again!’
+
+The brooch had come undone as she spoke, and a sudden gust of wind blew
+the Queen’s shawl across a little brook. The Queen spread out her arms
+again, and went flying after it, and this time she succeeded in catching
+it for herself. ‘I’ve got it!’ she cried in a triumphant tone. ‘Now you
+shall see me pin it on again, all by myself!’
+
+‘Then I hope your finger is better now?’ Alice said very politely, as
+she crossed the little brook after the Queen.
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+‘Oh, much better!’ cried the Queen, her voice rising to a squeak as she
+went on. ‘Much be-etter! Be-etter! Be-e-e-etter! Be-e-ehh!’ The last
+word ended in a long bleat, so like a sheep that Alice quite started.
+
+She looked at the Queen, who seemed to have suddenly wrapped herself up
+in wool. Alice rubbed her eyes, and looked again. She couldn’t make out
+what had happened at all. Was she in a shop? And was that really--was it
+really a SHEEP that was sitting on the other side of the counter? Rub as
+she could, she could make nothing more of it: she was in a little dark
+shop, leaning with her elbows on the counter, and opposite to her was
+an old Sheep, sitting in an arm-chair knitting, and every now and then
+leaving off to look at her through a great pair of spectacles.
+
+‘What is it you want to buy?’ the Sheep said at last, looking up for a
+moment from her knitting.
+
+‘I don’t QUITE know yet,’ Alice said, very gently. ‘I should like to
+look all round me first, if I might.’
+
+‘You may look in front of you, and on both sides, if you like,’ said the
+Sheep: ‘but you can’t look ALL round you--unless you’ve got eyes at the
+back of your head.’
+
+But these, as it happened, Alice had NOT got: so she contented herself
+with turning round, looking at the shelves as she came to them.
+
+The shop seemed to be full of all manner of curious things--but the
+oddest part of it all was, that whenever she looked hard at any shelf,
+to make out exactly what it had on it, that particular shelf was always
+quite empty: though the others round it were crowded as full as they
+could hold.
+
+‘Things flow about so here!’ she said at last in a plaintive tone, after
+she had spent a minute or so in vainly pursuing a large bright thing,
+that looked sometimes like a doll and sometimes like a work-box, and was
+always in the shelf next above the one she was looking at. ‘And this one
+is the most provoking of all--but I’ll tell you what--’ she added, as a
+sudden thought struck her, ‘I’ll follow it up to the very top shelf of
+all. It’ll puzzle it to go through the ceiling, I expect!’
+
+But even this plan failed: the ‘thing’ went through the ceiling as
+quietly as possible, as if it were quite used to it.
+
+‘Are you a child or a teetotum?’ the Sheep said, as she took up another
+pair of needles. ‘You’ll make me giddy soon, if you go on turning round
+like that.’ She was now working with fourteen pairs at once, and Alice
+couldn’t help looking at her in great astonishment.
+
+‘How CAN she knit with so many?’ the puzzled child thought to herself.
+‘She gets more and more like a porcupine every minute!’
+
+‘Can you row?’ the Sheep asked, handing her a pair of knitting-needles
+as she spoke.
+
+‘Yes, a little--but not on land--and not with needles--’ Alice was
+beginning to say, when suddenly the needles turned into oars in her
+hands, and she found they were in a little boat, gliding along between
+banks: so there was nothing for it but to do her best.
+
+‘Feather!’ cried the Sheep, as she took up another pair of needles.
+
+This didn’t sound like a remark that needed any answer, so Alice said
+nothing, but pulled away. There was something very queer about the
+water, she thought, as every now and then the oars got fast in it, and
+would hardly come out again.
+
+‘Feather! Feather!’ the Sheep cried again, taking more needles. ‘You’ll
+be catching a crab directly.’
+
+‘A dear little crab!’ thought Alice. ‘I should like that.’
+
+‘Didn’t you hear me say “Feather”?’ the Sheep cried angrily, taking up
+quite a bunch of needles.
+
+‘Indeed I did,’ said Alice: ‘you’ve said it very often--and very loud.
+Please, where ARE the crabs?’
+
+‘In the water, of course!’ said the Sheep, sticking some of the needles
+into her hair, as her hands were full. ‘Feather, I say!’
+
+‘WHY do you say “feather” so often?’ Alice asked at last, rather vexed.
+‘I’m not a bird!’
+
+‘You are,’ said the Sheep: ‘you’re a little goose.’
+
+This offended Alice a little, so there was no more conversation for a
+minute or two, while the boat glided gently on, sometimes among beds of
+weeds (which made the oars stick fast in the water, worse then ever),
+and sometimes under trees, but always with the same tall river-banks
+frowning over their heads.
+
+‘Oh, please! There are some scented rushes!’ Alice cried in a sudden
+transport of delight. ‘There really are--and SUCH beauties!’
+
+‘You needn’t say “please” to ME about ‘em,’ the Sheep said, without
+looking up from her knitting: ‘I didn’t put ‘em there, and I’m not going
+to take ‘em away.’
+
+‘No, but I meant--please, may we wait and pick some?’ Alice pleaded. ‘If
+you don’t mind stopping the boat for a minute.’
+
+‘How am _I_ to stop it?’ said the Sheep. ‘If you leave off rowing, it’ll
+stop of itself.’
+
+So the boat was left to drift down the stream as it would, till it
+glided gently in among the waving rushes. And then the little sleeves
+were carefully rolled up, and the little arms were plunged in elbow-deep
+to get the rushes a good long way down before breaking them off--and for
+a while Alice forgot all about the Sheep and the knitting, as she
+bent over the side of the boat, with just the ends of her tangled hair
+dipping into the water--while with bright eager eyes she caught at one
+bunch after another of the darling scented rushes.
+
+‘I only hope the boat won’t tipple over!’ she said to herself. ‘Oh, WHAT
+a lovely one! Only I couldn’t quite reach it.’ ‘And it certainly DID
+seem a little provoking (‘almost as if it happened on purpose,’ she
+thought) that, though she managed to pick plenty of beautiful rushes as
+the boat glided by, there was always a more lovely one that she couldn’t
+reach.
+
+‘The prettiest are always further!’ she said at last, with a sigh at the
+obstinacy of the rushes in growing so far off, as, with flushed cheeks
+and dripping hair and hands, she scrambled back into her place, and
+began to arrange her new-found treasures.
+
+What mattered it to her just then that the rushes had begun to fade, and
+to lose all their scent and beauty, from the very moment that she
+picked them? Even real scented rushes, you know, last only a very little
+while--and these, being dream-rushes, melted away almost like snow, as
+they lay in heaps at her feet--but Alice hardly noticed this, there were
+so many other curious things to think about.
+
+They hadn’t gone much farther before the blade of one of the oars got
+fast in the water and WOULDN’T come out again (so Alice explained it
+afterwards), and the consequence was that the handle of it caught her
+under the chin, and, in spite of a series of little shrieks of ‘Oh, oh,
+oh!’ from poor Alice, it swept her straight off the seat, and down among
+the heap of rushes.
+
+However, she wasn’t hurt, and was soon up again: the Sheep went on with
+her knitting all the while, just as if nothing had happened. ‘That was
+a nice crab you caught!’ she remarked, as Alice got back into her place,
+very much relieved to find herself still in the boat.
+
+‘Was it? I didn’t see it,’ Said Alice, peeping cautiously over the side
+of the boat into the dark water. ‘I wish it hadn’t let go--I should
+so like to see a little crab to take home with me!’ But the Sheep only
+laughed scornfully, and went on with her knitting.
+
+‘Are there many crabs here?’ said Alice.
+
+‘Crabs, and all sorts of things,’ said the Sheep: ‘plenty of choice,
+only make up your mind. Now, what DO you want to buy?’
+
+‘To buy!’ Alice echoed in a tone that was half astonished and half
+frightened--for the oars, and the boat, and the river, had vanished all
+in a moment, and she was back again in the little dark shop.
+
+‘I should like to buy an egg, please,’ she said timidly. ‘How do you
+sell them?’
+
+‘Fivepence farthing for one--Twopence for two,’ the Sheep replied.
+
+‘Then two are cheaper than one?’ Alice said in a surprised tone, taking
+out her purse.
+
+‘Only you MUST eat them both, if you buy two,’ said the Sheep.
+
+‘Then I’ll have ONE, please,’ said Alice, as she put the money down on
+the counter. For she thought to herself, ‘They mightn’t be at all nice,
+you know.’
+
+The Sheep took the money, and put it away in a box: then she said ‘I
+never put things into people’s hands--that would never do--you must get
+it for yourself.’ And so saying, she went off to the other end of the
+shop, and set the egg upright on a shelf.
+
+‘I wonder WHY it wouldn’t do?’ thought Alice, as she groped her way
+among the tables and chairs, for the shop was very dark towards the end.
+‘The egg seems to get further away the more I walk towards it. Let me
+see, is this a chair? Why, it’s got branches, I declare! How very odd to
+find trees growing here! And actually here’s a little brook! Well, this
+is the very queerest shop I ever saw!’
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+
+So she went on, wondering more and more at every step, as everything
+turned into a tree the moment she came up to it, and she quite expected
+the egg to do the same.
+
+
+
+
+CHAPTER VI. Humpty Dumpty
+
+However, the egg only got larger and larger, and more and more human:
+when she had come within a few yards of it, she saw that it had eyes
+and a nose and mouth; and when she had come close to it, she saw clearly
+that it was HUMPTY DUMPTY himself. ‘It can’t be anybody else!’ she said
+to herself. ‘I’m as certain of it, as if his name were written all over
+his face.’
+
+It might have been written a hundred times, easily, on that enormous
+face. Humpty Dumpty was sitting with his legs crossed, like a Turk, on
+the top of a high wall--such a narrow one that Alice quite wondered how
+he could keep his balance--and, as his eyes were steadily fixed in the
+opposite direction, and he didn’t take the least notice of her, she
+thought he must be a stuffed figure after all.
+
+‘And how exactly like an egg he is!’ she said aloud, standing with her
+hands ready to catch him, for she was every moment expecting him to
+fall.
+
+‘It’s VERY provoking,’ Humpty Dumpty said after a long silence, looking
+away from Alice as he spoke, ‘to be called an egg--VERY!’
+
+‘I said you LOOKED like an egg, Sir,’ Alice gently explained. ‘And some
+eggs are very pretty, you know’ she added, hoping to turn her remark
+into a sort of a compliment.
+
+‘Some people,’ said Humpty Dumpty, looking away from her as usual, ‘have
+no more sense than a baby!’
+
+Alice didn’t know what to say to this: it wasn’t at all like
+conversation, she thought, as he never said anything to HER; in fact,
+his last remark was evidently addressed to a tree--so she stood and
+softly repeated to herself:--
+
+
+     ‘Humpty Dumpty sat on a wall:
+     Humpty Dumpty had a great fall.
+     All the King’s horses and all the King’s men
+     Couldn’t put Humpty Dumpty in his place again.’
+
+
+‘That last line is much too long for the poetry,’ she added, almost out
+loud, forgetting that Humpty Dumpty would hear her.
+
+‘Don’t stand there chattering to yourself like that,’ Humpty Dumpty
+said, looking at her for the first time, ‘but tell me your name and your
+business.’
+
+‘My NAME is Alice, but--’
+
+‘It’s a stupid enough name!’ Humpty Dumpty interrupted impatiently.
+‘What does it mean?’
+
+‘MUST a name mean something?’ Alice asked doubtfully.
+
+‘Of course it must,’ Humpty Dumpty said with a short laugh: ‘MY name
+means the shape I am--and a good handsome shape it is, too. With a name
+like yours, you might be any shape, almost.’
+
+‘Why do you sit out here all alone?’ said Alice, not wishing to begin an
+argument.
+
+‘Why, because there’s nobody with me!’ cried Humpty Dumpty. ‘Did you
+think I didn’t know the answer to THAT? Ask another.’
+
+‘Don’t you think you’d be safer down on the ground?’ Alice went on, not
+with any idea of making another riddle, but simply in her good-natured
+anxiety for the queer creature. ‘That wall is so VERY narrow!’
+
+‘What tremendously easy riddles you ask!’ Humpty Dumpty growled out. ‘Of
+course I don’t think so! Why, if ever I DID fall off--which there’s no
+chance of--but IF I did--’ Here he pursed up his lips and looked so solemn
+and grand that Alice could hardly help laughing. ‘IF I did fall,’ he
+went on, ‘THE KING HAS PROMISED ME--ah, you may turn pale, if you like!
+You didn’t think I was going to say that, did you? THE KING HAS PROMISED ME--
+WITH HIS VERY OWN MOUTH--to--to--’
+
+‘To send all his horses and all his men,’ Alice interrupted, rather
+unwisely.
+
+‘Now I declare that’s too bad!’ Humpty Dumpty cried, breaking into a
+sudden passion. ‘You’ve been listening at doors--and behind trees--and
+down chimneys--or you couldn’t have known it!’
+
+‘I haven’t, indeed!’ Alice said very gently. ‘It’s in a book.’
+
+‘Ah, well! They may write such things in a BOOK,’ Humpty Dumpty said in
+a calmer tone. ‘That’s what you call a History of England, that is.
+Now, take a good look at me! I’m one that has spoken to a King, _I_ am:
+mayhap you’ll never see such another: and to show you I’m not proud, you
+may shake hands with me!’ And he grinned almost from ear to ear, as he
+leant forwards (and as nearly as possible fell off the wall in doing so)
+and offered Alice his hand. She watched him a little anxiously as she
+took it. ‘If he smiled much more, the ends of his mouth might meet
+behind,’ she thought: ‘and then I don’t know what would happen to his
+head! I’m afraid it would come off!’
+
+‘Yes, all his horses and all his men,’ Humpty Dumpty went on. ‘They’d
+pick me up again in a minute, THEY would! However, this conversation is
+going on a little too fast: let’s go back to the last remark but one.’
+
+‘I’m afraid I can’t quite remember it,’ Alice said very politely.
+
+‘In that case we start fresh,’ said Humpty Dumpty, ‘and it’s my turn
+to choose a subject--’ (‘He talks about it just as if it was a game!’
+thought Alice.) ‘So here’s a question for you. How old did you say you
+were?’
+
+Alice made a short calculation, and said ‘Seven years and six months.’
+
+‘Wrong!’ Humpty Dumpty exclaimed triumphantly. ‘You never said a word
+like it!’
+
+‘I though you meant “How old ARE you?”’ Alice explained.
+
+‘If I’d meant that, I’d have said it,’ said Humpty Dumpty.
+
+Alice didn’t want to begin another argument, so she said nothing.
+
+‘Seven years and six months!’ Humpty Dumpty repeated thoughtfully. ‘An
+uncomfortable sort of age. Now if you’d asked MY advice, I’d have said
+“Leave off at seven”--but it’s too late now.’
+
+‘I never ask advice about growing,’ Alice said indignantly.
+
+‘Too proud?’ the other inquired.
+
+Alice felt even more indignant at this suggestion. ‘I mean,’ she said,
+‘that one can’t help growing older.’
+
+‘ONE can’t, perhaps,’ said Humpty Dumpty, ‘but TWO can. With proper
+assistance, you might have left off at seven.’
+
+‘What a beautiful belt you’ve got on!’ Alice suddenly remarked.
+
+(They had had quite enough of the subject of age, she thought: and if
+they really were to take turns in choosing subjects, it was her turn
+now.) ‘At least,’ she corrected herself on second thoughts, ‘a beautiful
+cravat, I should have said--no, a belt, I mean--I beg your pardon!’ she
+added in dismay, for Humpty Dumpty looked thoroughly offended, and she
+began to wish she hadn’t chosen that subject. ‘If I only knew,’ she
+thought to herself, ‘which was neck and which was waist!’
+
+Evidently Humpty Dumpty was very angry, though he said nothing for a
+minute or two. When he DID speak again, it was in a deep growl.
+
+‘It is a--MOST--PROVOKING--thing,’ he said at last, ‘when a person
+doesn’t know a cravat from a belt!’
+
+‘I know it’s very ignorant of me,’ Alice said, in so humble a tone that
+Humpty Dumpty relented.
+
+‘It’s a cravat, child, and a beautiful one, as you say. It’s a present
+from the White King and Queen. There now!’
+
+‘Is it really?’ said Alice, quite pleased to find that she HAD chosen a
+good subject, after all.
+
+‘They gave it me,’ Humpty Dumpty continued thoughtfully, as he crossed
+one knee over the other and clasped his hands round it, ‘they gave it
+me--for an un-birthday present.’
+
+‘I beg your pardon?’ Alice said with a puzzled air.
+
+‘I’m not offended,’ said Humpty Dumpty.
+
+‘I mean, what IS an un-birthday present?’
+
+‘A present given when it isn’t your birthday, of course.’
+
+Alice considered a little. ‘I like birthday presents best,’ she said at
+last.
+
+‘You don’t know what you’re talking about!’ cried Humpty Dumpty. ‘How
+many days are there in a year?’
+
+‘Three hundred and sixty-five,’ said Alice.
+
+‘And how many birthdays have you?’
+
+‘One.’
+
+‘And if you take one from three hundred and sixty-five, what remains?’
+
+‘Three hundred and sixty-four, of course.’
+
+Humpty Dumpty looked doubtful. ‘I’d rather see that done on paper,’ he
+said.
+
+Alice couldn’t help smiling as she took out her memorandum-book, and
+worked the sum for him:
+
+
+               365
+                1
+               ____
+
+               364
+               ___
+
+Humpty Dumpty took the book, and looked at it carefully. ‘That seems to
+be done right--’ he began.
+
+‘You’re holding it upside down!’ Alice interrupted.
+
+‘To be sure I was!’ Humpty Dumpty said gaily, as she turned it round for
+him. ‘I thought it looked a little queer. As I was saying, that SEEMS
+to be done right--though I haven’t time to look it over thoroughly just
+now--and that shows that there are three hundred and sixty-four days
+when you might get un-birthday presents--’
+
+‘Certainly,’ said Alice.
+
+‘And only ONE for birthday presents, you know. There’s glory for you!’
+
+‘I don’t know what you mean by “glory,”’ Alice said.
+
+Humpty Dumpty smiled contemptuously. ‘Of course you don’t--till I tell
+you. I meant “there’s a nice knock-down argument for you!”’
+
+‘But “glory” doesn’t mean “a nice knock-down argument,”’ Alice objected.
+
+‘When _I_ use a word,’ Humpty Dumpty said in rather a scornful tone, ‘it
+means just what I choose it to mean--neither more nor less.’
+
+‘The question is,’ said Alice, ‘whether you CAN make words mean so many
+different things.’
+
+‘The question is,’ said Humpty Dumpty, ‘which is to be master--that’s
+all.’
+
+Alice was too much puzzled to say anything, so after a minute Humpty
+Dumpty began again. ‘They’ve a temper, some of them--particularly verbs,
+they’re the proudest--adjectives you can do anything with, but not
+verbs--however, _I_ can manage the whole lot of them! Impenetrability!
+That’s what _I_ say!’
+
+‘Would you tell me, please,’ said Alice ‘what that means?’
+
+‘Now you talk like a reasonable child,’ said Humpty Dumpty, looking very
+much pleased. ‘I meant by “impenetrability” that we’ve had enough of
+that subject, and it would be just as well if you’d mention what you
+mean to do next, as I suppose you don’t mean to stop here all the rest
+of your life.’
+
+‘That’s a great deal to make one word mean,’ Alice said in a thoughtful
+tone.
+
+‘When I make a word do a lot of work like that,’ said Humpty Dumpty, ‘I
+always pay it extra.’
+
+‘Oh!’ said Alice. She was too much puzzled to make any other remark.
+
+‘Ah, you should see ‘em come round me of a Saturday night,’ Humpty
+Dumpty went on, wagging his head gravely from side to side: ‘for to get
+their wages, you know.’
+
+(Alice didn’t venture to ask what he paid them with; and so you see I
+can’t tell YOU.)
+
+‘You seem very clever at explaining words, Sir,’ said Alice. ‘Would you
+kindly tell me the meaning of the poem called “Jabberwocky”?’
+
+‘Let’s hear it,’ said Humpty Dumpty. ‘I can explain all the poems that
+were ever invented--and a good many that haven’t been invented just
+yet.’
+
+This sounded very hopeful, so Alice repeated the first verse:
+
+     ‘Twas brillig, and the slithy toves
+      Did gyre and gimble in the wabe;
+     All mimsy were the borogoves,
+      And the mome raths outgrabe.
+
+‘That’s enough to begin with,’ Humpty Dumpty interrupted: ‘there
+are plenty of hard words there. “BRILLIG” means four o’clock in the
+afternoon--the time when you begin BROILING things for dinner.’
+
+‘That’ll do very well,’ said Alice: ‘and “SLITHY”?’
+
+‘Well, “SLITHY” means “lithe and slimy.” “Lithe” is the same as
+“active.” You see it’s like a portmanteau--there are two meanings packed
+up into one word.’
+
+‘I see it now,’ Alice remarked thoughtfully: ‘and what are “TOVES”?’
+
+‘Well, “TOVES” are something like badgers--they’re something like
+lizards--and they’re something like corkscrews.’
+
+‘They must be very curious looking creatures.’
+
+‘They are that,’ said Humpty Dumpty: ‘also they make their nests under
+sun-dials--also they live on cheese.’
+
+‘And what’s the “GYRE” and to “GIMBLE”?’
+
+‘To “GYRE” is to go round and round like a gyroscope. To “GIMBLE” is to
+make holes like a gimlet.’
+
+‘And “THE WABE” is the grass-plot round a sun-dial, I suppose?’ said
+Alice, surprised at her own ingenuity.
+
+‘Of course it is. It’s called “WABE,” you know, because it goes a long
+way before it, and a long way behind it--’
+
+‘And a long way beyond it on each side,’ Alice added.
+
+‘Exactly so. Well, then, “MIMSY” is “flimsy and miserable” (there’s
+another portmanteau for you). And a “BOROGOVE” is a thin shabby-looking
+bird with its feathers sticking out all round--something like a live
+mop.’
+
+‘And then “MOME RATHS”?’ said Alice. ‘I’m afraid I’m giving you a great
+deal of trouble.’
+
+‘Well, a “RATH” is a sort of green pig: but “MOME” I’m not certain
+about. I think it’s short for “from home”--meaning that they’d lost
+their way, you know.’
+
+‘And what does “OUTGRABE” mean?’
+
+‘Well, “OUTGRABING” is something between bellowing and whistling, with a
+kind of sneeze in the middle: however, you’ll hear it done, maybe--down
+in the wood yonder--and when you’ve once heard it you’ll be QUITE
+content. Who’s been repeating all that hard stuff to you?’
+
+‘I read it in a book,’ said Alice. ‘But I had some poetry repeated to
+me, much easier than that, by--Tweedledee, I think it was.’
+
+‘As to poetry, you know,’ said Humpty Dumpty, stretching out one of his
+great hands, ‘_I_ can repeat poetry as well as other folk, if it comes
+to that--’
+
+‘Oh, it needn’t come to that!’ Alice hastily said, hoping to keep him
+from beginning.
+
+‘The piece I’m going to repeat,’ he went on without noticing her remark,
+‘was written entirely for your amusement.’
+
+Alice felt that in that case she really OUGHT to listen to it, so she
+sat down, and said ‘Thank you’ rather sadly.
+
+
+     ‘In winter, when the fields are white,
+     I sing this song for your delight--
+
+
+only I don’t sing it,’ he added, as an explanation.
+
+‘I see you don’t,’ said Alice.
+
+‘If you can SEE whether I’m singing or not, you’ve sharper eyes than
+most.’ Humpty Dumpty remarked severely. Alice was silent.
+
+
+     ‘In spring, when woods are getting green,
+     I’ll try and tell you what I mean.’
+
+
+‘Thank you very much,’ said Alice.
+
+
+     ‘In summer, when the days are long,
+     Perhaps you’ll understand the song:
+     In autumn, when the leaves are brown,
+     Take pen and ink, and write it down.’
+
+
+‘I will, if I can remember it so long,’ said Alice.
+
+‘You needn’t go on making remarks like that,’ Humpty Dumpty said:
+‘they’re not sensible, and they put me out.’
+
+     ‘I sent a message to the fish:
+     I told them “This is what I wish.”
+
+     The little fishes of the sea,
+     They sent an answer back to me.
+
+     The little fishes’ answer was
+     “We cannot do it, Sir, because--“’
+
+
+‘I’m afraid I don’t quite understand,’ said Alice.
+
+‘It gets easier further on,’ Humpty Dumpty replied.
+
+
+     ‘I sent to them again to say
+     “It will be better to obey.”
+
+     The fishes answered with a grin,
+     “Why, what a temper you are in!”
+
+     I told them once, I told them twice:
+     They would not listen to advice.
+
+     I took a kettle large and new,
+     Fit for the deed I had to do.
+
+     My heart went hop, my heart went thump;
+     I filled the kettle at the pump.
+
+     Then some one came to me and said,
+     “The little fishes are in bed.”
+
+     I said to him, I said it plain,
+     “Then you must wake them up again.”
+
+     I said it very loud and clear;
+     I went and shouted in his ear.’
+
+
+Humpty Dumpty raised his voice almost to a scream as he repeated this
+verse, and Alice thought with a shudder, ‘I wouldn’t have been the
+messenger for ANYTHING!’
+
+
+     ‘But he was very stiff and proud;
+     He said “You needn’t shout so loud!”
+
+     And he was very proud and stiff;
+     He said “I’d go and wake them, if--”
+
+     I took a corkscrew from the shelf:
+     I went to wake them up myself.
+
+     And when I found the door was locked,
+     I pulled and pushed and kicked and knocked.
+
+     And when I found the door was shut,
+     I tried to turn the handle, but--’
+
+
+There was a long pause.
+
+‘Is that all?’ Alice timidly asked.
+
+‘That’s all,’ said Humpty Dumpty. ‘Good-bye.’
+
+This was rather sudden, Alice thought: but, after such a VERY strong
+hint that she ought to be going, she felt that it would hardly be civil
+to stay. So she got up, and held out her hand. ‘Good-bye, till we meet
+again!’ she said as cheerfully as she could.
+
+‘I shouldn’t know you again if we DID meet,’ Humpty Dumpty replied in
+a discontented tone, giving her one of his fingers to shake; ‘you’re so
+exactly like other people.’
+
+‘The face is what one goes by, generally,’ Alice remarked in a
+thoughtful tone.
+
+‘That’s just what I complain of,’ said Humpty Dumpty. ‘Your face is the
+same as everybody has--the two eyes, so--’ (marking their places in the
+air with this thumb) ‘nose in the middle, mouth under. It’s always the
+same. Now if you had the two eyes on the same side of the nose, for
+instance--or the mouth at the top--that would be SOME help.’
+
+‘It wouldn’t look nice,’ Alice objected. But Humpty Dumpty only shut his
+eyes and said ‘Wait till you’ve tried.’
+
+Alice waited a minute to see if he would speak again, but as he never
+opened his eyes or took any further notice of her, she said ‘Good-bye!’
+once more, and, getting no answer to this, she quietly walked away:
+but she couldn’t help saying to herself as she went, ‘Of all the
+unsatisfactory--’ (she repeated this aloud, as it was a great comfort to
+have such a long word to say) ‘of all the unsatisfactory people I EVER
+met--’ She never finished the sentence, for at this moment a heavy crash
+shook the forest from end to end.
+
+
+
+
+CHAPTER VII. The Lion and the Unicorn
+
+The next moment soldiers came running through the wood, at first in twos
+and threes, then ten or twenty together, and at last in such crowds that
+they seemed to fill the whole forest. Alice got behind a tree, for fear
+of being run over, and watched them go by.
+
+She thought that in all her life she had never seen soldiers so
+uncertain on their feet: they were always tripping over something or
+other, and whenever one went down, several more always fell over him, so
+that the ground was soon covered with little heaps of men.
+
+Then came the horses. Having four feet, these managed rather better than
+the foot-soldiers: but even THEY stumbled now and then; and it seemed
+to be a regular rule that, whenever a horse stumbled the rider fell off
+instantly. The confusion got worse every moment, and Alice was very glad
+to get out of the wood into an open place, where she found the White
+King seated on the ground, busily writing in his memorandum-book.
+
+‘I’ve sent them all!’ the King cried in a tone of delight, on seeing
+Alice. ‘Did you happen to meet any soldiers, my dear, as you came
+through the wood?’
+
+‘Yes, I did,’ said Alice: ‘several thousand, I should think.’
+
+‘Four thousand two hundred and seven, that’s the exact number,’ the King
+said, referring to his book. ‘I couldn’t send all the horses, you know,
+because two of them are wanted in the game. And I haven’t sent the two
+Messengers, either. They’re both gone to the town. Just look along the
+road, and tell me if you can see either of them.’
+
+‘I see nobody on the road,’ said Alice.
+
+‘I only wish _I_ had such eyes,’ the King remarked in a fretful tone.
+‘To be able to see Nobody! And at that distance, too! Why, it’s as much
+as _I_ can do to see real people, by this light!’
+
+All this was lost on Alice, who was still looking intently along
+the road, shading her eyes with one hand. ‘I see somebody now!’ she
+exclaimed at last. ‘But he’s coming very slowly--and what curious
+attitudes he goes into!’ (For the messenger kept skipping up and down,
+and wriggling like an eel, as he came along, with his great hands spread
+out like fans on each side.)
+
+‘Not at all,’ said the King. ‘He’s an Anglo-Saxon Messenger--and those
+are Anglo-Saxon attitudes. He only does them when he’s happy. His name
+is Haigha.’ (He pronounced it so as to rhyme with ‘mayor.’)
+
+‘I love my love with an H,’ Alice couldn’t help beginning, ‘because
+he is Happy. I hate him with an H, because he is Hideous. I fed him
+with--with--with Ham-sandwiches and Hay. His name is Haigha, and he
+lives--’
+
+‘He lives on the Hill,’ the King remarked simply, without the least idea
+that he was joining in the game, while Alice was still hesitating for
+the name of a town beginning with H. ‘The other Messenger’s called
+Hatta. I must have TWO, you know--to come and go. One to come, and one
+to go.’
+
+‘I beg your pardon?’ said Alice.
+
+‘It isn’t respectable to beg,’ said the King.
+
+‘I only meant that I didn’t understand,’ said Alice. ‘Why one to come
+and one to go?’
+
+‘Didn’t I tell you?’ the King repeated impatiently. ‘I must have Two--to
+fetch and carry. One to fetch, and one to carry.’
+
+At this moment the Messenger arrived: he was far too much out of breath
+to say a word, and could only wave his hands about, and make the most
+fearful faces at the poor King.
+
+‘This young lady loves you with an H,’ the King said, introducing Alice
+in the hope of turning off the Messenger’s attention from himself--but
+it was no use--the Anglo-Saxon attitudes only got more extraordinary
+every moment, while the great eyes rolled wildly from side to side.
+
+‘You alarm me!’ said the King. ‘I feel faint--Give me a ham sandwich!’
+
+On which the Messenger, to Alice’s great amusement, opened a bag that
+hung round his neck, and handed a sandwich to the King, who devoured it
+greedily.
+
+‘Another sandwich!’ said the King.
+
+‘There’s nothing but hay left now,’ the Messenger said, peeping into the
+bag.
+
+‘Hay, then,’ the King murmured in a faint whisper.
+
+Alice was glad to see that it revived him a good deal. ‘There’s nothing
+like eating hay when you’re faint,’ he remarked to her, as he munched
+away.
+
+‘I should think throwing cold water over you would be better,’ Alice
+suggested: ‘or some sal-volatile.’
+
+‘I didn’t say there was nothing BETTER,’ the King replied. ‘I said there
+was nothing LIKE it.’ Which Alice did not venture to deny.
+
+‘Who did you pass on the road?’ the King went on, holding out his hand
+to the Messenger for some more hay.
+
+‘Nobody,’ said the Messenger.
+
+‘Quite right,’ said the King: ‘this young lady saw him too. So of course
+Nobody walks slower than you.’
+
+‘I do my best,’ the Messenger said in a sulky tone. ‘I’m sure nobody
+walks much faster than I do!’
+
+‘He can’t do that,’ said the King, ‘or else he’d have been here first.
+However, now you’ve got your breath, you may tell us what’s happened in
+the town.’
+
+‘I’ll whisper it,’ said the Messenger, putting his hands to his mouth
+in the shape of a trumpet, and stooping so as to get close to the King’s
+ear. Alice was sorry for this, as she wanted to hear the news too.
+However, instead of whispering, he simply shouted at the top of his
+voice ‘They’re at it again!’
+
+‘Do you call THAT a whisper?’ cried the poor King, jumping up and
+shaking himself. ‘If you do such a thing again, I’ll have you buttered!
+It went through and through my head like an earthquake!’
+
+‘It would have to be a very tiny earthquake!’ thought Alice. ‘Who are at
+it again?’ she ventured to ask.
+
+‘Why the Lion and the Unicorn, of course,’ said the King.
+
+‘Fighting for the crown?’
+
+‘Yes, to be sure,’ said the King: ‘and the best of the joke is, that
+it’s MY crown all the while! Let’s run and see them.’ And they trotted
+off, Alice repeating to herself, as she ran, the words of the old
+song:--
+
+
+   ‘The Lion and the Unicorn were fighting for the crown:
+   The Lion beat the Unicorn all round the town.
+   Some gave them white bread, some gave them brown;
+   Some gave them plum-cake and drummed them out of town.’
+
+
+‘Does--the one--that wins--get the crown?’ she asked, as well as she
+could, for the run was putting her quite out of breath.
+
+‘Dear me, no!’ said the King. ‘What an idea!’
+
+‘Would you--be good enough,’ Alice panted out, after running a little
+further, ‘to stop a minute--just to get--one’s breath again?’
+
+‘I’m GOOD enough,’ the King said, ‘only I’m not strong enough. You see,
+a minute goes by so fearfully quick. You might as well try to stop a
+Bandersnatch!’
+
+Alice had no more breath for talking, so they trotted on in silence,
+till they came in sight of a great crowd, in the middle of which the
+Lion and Unicorn were fighting. They were in such a cloud of dust, that
+at first Alice could not make out which was which: but she soon managed
+to distinguish the Unicorn by his horn.
+
+They placed themselves close to where Hatta, the other messenger, was
+standing watching the fight, with a cup of tea in one hand and a piece
+of bread-and-butter in the other.
+
+‘He’s only just out of prison, and he hadn’t finished his tea when
+he was sent in,’ Haigha whispered to Alice: ‘and they only give them
+oyster-shells in there--so you see he’s very hungry and thirsty. How
+are you, dear child?’ he went on, putting his arm affectionately round
+Hatta’s neck.
+
+Hatta looked round and nodded, and went on with his bread and butter.
+
+‘Were you happy in prison, dear child?’ said Haigha.
+
+Hatta looked round once more, and this time a tear or two trickled down
+his cheek: but not a word would he say.
+
+‘Speak, can’t you!’ Haigha cried impatiently. But Hatta only munched
+away, and drank some more tea.
+
+‘Speak, won’t you!’ cried the King. ‘How are they getting on with the
+fight?’
+
+Hatta made a desperate effort, and swallowed a large piece of
+bread-and-butter. ‘They’re getting on very well,’ he said in a choking
+voice: ‘each of them has been down about eighty-seven times.’
+
+‘Then I suppose they’ll soon bring the white bread and the brown?’ Alice
+ventured to remark.
+
+‘It’s waiting for ‘em now,’ said Hatta: ‘this is a bit of it as I’m
+eating.’
+
+There was a pause in the fight just then, and the Lion and the Unicorn
+sat down, panting, while the King called out ‘Ten minutes allowed for
+refreshments!’ Haigha and Hatta set to work at once, carrying rough
+trays of white and brown bread. Alice took a piece to taste, but it was
+VERY dry.
+
+‘I don’t think they’ll fight any more to-day,’ the King said to Hatta:
+‘go and order the drums to begin.’ And Hatta went bounding away like a
+grasshopper.
+
+For a minute or two Alice stood silent, watching him. Suddenly she
+brightened up. ‘Look, look!’ she cried, pointing eagerly. ‘There’s the
+White Queen running across the country! She came flying out of the wood
+over yonder--How fast those Queens CAN run!’
+
+‘There’s some enemy after her, no doubt,’ the King said, without even
+looking round. ‘That wood’s full of them.’
+
+‘But aren’t you going to run and help her?’ Alice asked, very much
+surprised at his taking it so quietly.
+
+‘No use, no use!’ said the King. ‘She runs so fearfully quick. You might
+as well try to catch a Bandersnatch! But I’ll make a memorandum about
+her, if you like--She’s a dear good creature,’ he repeated softly to
+himself, as he opened his memorandum-book. ‘Do you spell “creature” with
+a double “e”?’
+
+At this moment the Unicorn sauntered by them, with his hands in his
+pockets. ‘I had the best of it this time?’ he said to the King, just
+glancing at him as he passed.
+
+‘A little--a little,’ the King replied, rather nervously. ‘You shouldn’t
+have run him through with your horn, you know.’
+
+‘It didn’t hurt him,’ the Unicorn said carelessly, and he was going
+on, when his eye happened to fall upon Alice: he turned round rather
+instantly, and stood for some time looking at her with an air of the
+deepest disgust.
+
+‘What--is--this?’ he said at last.
+
+‘This is a child!’ Haigha replied eagerly, coming in front of Alice
+to introduce her, and spreading out both his hands towards her in an
+Anglo-Saxon attitude. ‘We only found it to-day. It’s as large as life,
+and twice as natural!’
+
+‘I always thought they were fabulous monsters!’ said the Unicorn. ‘Is it
+alive?’
+
+‘It can talk,’ said Haigha, solemnly.
+
+The Unicorn looked dreamily at Alice, and said ‘Talk, child.’
+
+Alice could not help her lips curling up into a smile as she began: ‘Do
+you know, I always thought Unicorns were fabulous monsters, too! I never
+saw one alive before!’
+
+‘Well, now that we HAVE seen each other,’ said the Unicorn, ‘if you’ll
+believe in me, I’ll believe in you. Is that a bargain?’
+
+‘Yes, if you like,’ said Alice.
+
+‘Come, fetch out the plum-cake, old man!’ the Unicorn went on, turning
+from her to the King. ‘None of your brown bread for me!’
+
+‘Certainly--certainly!’ the King muttered, and beckoned to Haigha. ‘Open
+the bag!’ he whispered. ‘Quick! Not that one--that’s full of hay!’
+
+Haigha took a large cake out of the bag, and gave it to Alice to hold,
+while he got out a dish and carving-knife. How they all came out of it
+Alice couldn’t guess. It was just like a conjuring-trick, she thought.
+
+The Lion had joined them while this was going on: he looked very
+tired and sleepy, and his eyes were half shut. ‘What’s this!’ he said,
+blinking lazily at Alice, and speaking in a deep hollow tone that
+sounded like the tolling of a great bell.
+
+‘Ah, what IS it, now?’ the Unicorn cried eagerly. ‘You’ll never guess!
+_I_ couldn’t.’
+
+The Lion looked at Alice wearily. ‘Are you animal--vegetable--or
+mineral?’ he said, yawning at every other word.
+
+‘It’s a fabulous monster!’ the Unicorn cried out, before Alice could
+reply.
+
+‘Then hand round the plum-cake, Monster,’ the Lion said, lying down and
+putting his chin on his paws. ‘And sit down, both of you,’ (to the King
+and the Unicorn): ‘fair play with the cake, you know!’
+
+The King was evidently very uncomfortable at having to sit down between
+the two great creatures; but there was no other place for him.
+
+‘What a fight we might have for the crown, NOW!’ the Unicorn said,
+looking slyly up at the crown, which the poor King was nearly shaking
+off his head, he trembled so much.
+
+‘I should win easy,’ said the Lion.
+
+‘I’m not so sure of that,’ said the Unicorn.
+
+‘Why, I beat you all round the town, you chicken!’ the Lion replied
+angrily, half getting up as he spoke.
+
+Here the King interrupted, to prevent the quarrel going on: he was very
+nervous, and his voice quite quivered. ‘All round the town?’ he
+said. ‘That’s a good long way. Did you go by the old bridge, or the
+market-place? You get the best view by the old bridge.’
+
+‘I’m sure I don’t know,’ the Lion growled out as he lay down again.
+‘There was too much dust to see anything. What a time the Monster is,
+cutting up that cake!’
+
+Alice had seated herself on the bank of a little brook, with the great
+dish on her knees, and was sawing away diligently with the knife. ‘It’s
+very provoking!’ she said, in reply to the Lion (she was getting quite
+used to being called ‘the Monster’). ‘I’ve cut several slices already,
+but they always join on again!’
+
+‘You don’t know how to manage Looking-glass cakes,’ the Unicorn
+remarked. ‘Hand it round first, and cut it afterwards.’
+
+This sounded nonsense, but Alice very obediently got up, and carried the
+dish round, and the cake divided itself into three pieces as she did so.
+‘NOW cut it up,’ said the Lion, as she returned to her place with the
+empty dish.
+
+‘I say, this isn’t fair!’ cried the Unicorn, as Alice sat with the knife
+in her hand, very much puzzled how to begin. ‘The Monster has given the
+Lion twice as much as me!’
+
+‘She’s kept none for herself, anyhow,’ said the Lion. ‘Do you like
+plum-cake, Monster?’
+
+But before Alice could answer him, the drums began.
+
+Where the noise came from, she couldn’t make out: the air seemed full
+of it, and it rang through and through her head till she felt quite
+deafened. She started to her feet and sprang across the little brook in
+her terror,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and had just time to see the Lion and the Unicorn rise to their feet,
+with angry looks at being interrupted in their feast, before she dropped
+to her knees, and put her hands over her ears, vainly trying to shut out
+the dreadful uproar.
+
+‘If THAT doesn’t “drum them out of town,”’ she thought to herself,
+‘nothing ever will!’
+
+
+
+
+CHAPTER VIII. ‘It’s my own Invention’
+
+After a while the noise seemed gradually to die away, till all was dead
+silence, and Alice lifted up her head in some alarm. There was no one
+to be seen, and her first thought was that she must have been dreaming
+about the Lion and the Unicorn and those queer Anglo-Saxon Messengers.
+However, there was the great dish still lying at her feet, on which she
+had tried to cut the plum-cake, ‘So I wasn’t dreaming, after all,’ she
+said to herself, ‘unless--unless we’re all part of the same dream. Only
+I do hope it’s MY dream, and not the Red King’s! I don’t like belonging
+to another person’s dream,’ she went on in a rather complaining tone:
+‘I’ve a great mind to go and wake him, and see what happens!’
+
+At this moment her thoughts were interrupted by a loud shouting of
+‘Ahoy! Ahoy! Check!’ and a Knight dressed in crimson armour came
+galloping down upon her, brandishing a great club. Just as he reached
+her, the horse stopped suddenly: ‘You’re my prisoner!’ the Knight cried,
+as he tumbled off his horse.
+
+Startled as she was, Alice was more frightened for him than for herself
+at the moment, and watched him with some anxiety as he mounted again.
+As soon as he was comfortably in the saddle, he began once more ‘You’re
+my--’ but here another voice broke in ‘Ahoy! Ahoy! Check!’ and Alice
+looked round in some surprise for the new enemy.
+
+This time it was a White Knight. He drew up at Alice’s side, and tumbled
+off his horse just as the Red Knight had done: then he got on again,
+and the two Knights sat and looked at each other for some time without
+speaking. Alice looked from one to the other in some bewilderment.
+
+‘She’s MY prisoner, you know!’ the Red Knight said at last.
+
+‘Yes, but then _I_ came and rescued her!’ the White Knight replied.
+
+‘Well, we must fight for her, then,’ said the Red Knight, as he took up
+his helmet (which hung from the saddle, and was something the shape of a
+horse’s head), and put it on.
+
+‘You will observe the Rules of Battle, of course?’ the White Knight
+remarked, putting on his helmet too.
+
+‘I always do,’ said the Red Knight, and they began banging away at each
+other with such fury that Alice got behind a tree to be out of the way
+of the blows.
+
+‘I wonder, now, what the Rules of Battle are,’ she said to herself, as
+she watched the fight, timidly peeping out from her hiding-place: ‘one
+Rule seems to be, that if one Knight hits the other, he knocks him off
+his horse, and if he misses, he tumbles off himself--and another Rule
+seems to be that they hold their clubs with their arms, as if they were
+Punch and Judy--What a noise they make when they tumble! Just like
+a whole set of fire-irons falling into the fender! And how quiet the
+horses are! They let them get on and off them just as if they were
+tables!’
+
+Another Rule of Battle, that Alice had not noticed, seemed to be that
+they always fell on their heads, and the battle ended with their both
+falling off in this way, side by side: when they got up again, they
+shook hands, and then the Red Knight mounted and galloped off.
+
+‘It was a glorious victory, wasn’t it?’ said the White Knight, as he
+came up panting.
+
+‘I don’t know,’ Alice said doubtfully. ‘I don’t want to be anybody’s
+prisoner. I want to be a Queen.’
+
+‘So you will, when you’ve crossed the next brook,’ said the White
+Knight. ‘I’ll see you safe to the end of the wood--and then I must go
+back, you know. That’s the end of my move.’
+
+‘Thank you very much,’ said Alice. ‘May I help you off with your
+helmet?’ It was evidently more than he could manage by himself; however,
+she managed to shake him out of it at last.
+
+‘Now one can breathe more easily,’ said the Knight, putting back his
+shaggy hair with both hands, and turning his gentle face and large mild
+eyes to Alice. She thought she had never seen such a strange-looking
+soldier in all her life.
+
+He was dressed in tin armour, which seemed to fit him very badly, and
+he had a queer-shaped little deal box fastened across his shoulder,
+upside-down, and with the lid hanging open. Alice looked at it with
+great curiosity.
+
+‘I see you’re admiring my little box.’ the Knight said in a friendly
+tone. ‘It’s my own invention--to keep clothes and sandwiches in. You see
+I carry it upside-down, so that the rain can’t get in.’
+
+‘But the things can get OUT,’ Alice gently remarked. ‘Do you know the
+lid’s open?’
+
+‘I didn’t know it,’ the Knight said, a shade of vexation passing over
+his face. ‘Then all the things must have fallen out! And the box is no
+use without them.’ He unfastened it as he spoke, and was just going to
+throw it into the bushes, when a sudden thought seemed to strike him,
+and he hung it carefully on a tree. ‘Can you guess why I did that?’ he
+said to Alice.
+
+Alice shook her head.
+
+‘In hopes some bees may make a nest in it--then I should get the honey.’
+
+‘But you’ve got a bee-hive--or something like one--fastened to the
+saddle,’ said Alice.
+
+‘Yes, it’s a very good bee-hive,’ the Knight said in a discontented
+tone, ‘one of the best kind. But not a single bee has come near it yet.
+And the other thing is a mouse-trap. I suppose the mice keep the bees
+out--or the bees keep the mice out, I don’t know which.’
+
+‘I was wondering what the mouse-trap was for,’ said Alice. ‘It isn’t
+very likely there would be any mice on the horse’s back.’
+
+‘Not very likely, perhaps,’ said the Knight: ‘but if they DO come, I
+don’t choose to have them running all about.’
+
+‘You see,’ he went on after a pause, ‘it’s as well to be provided for
+EVERYTHING. That’s the reason the horse has all those anklets round his
+feet.’
+
+‘But what are they for?’ Alice asked in a tone of great curiosity.
+
+‘To guard against the bites of sharks,’ the Knight replied. ‘It’s an
+invention of my own. And now help me on. I’ll go with you to the end of
+the wood--What’s the dish for?’
+
+‘It’s meant for plum-cake,’ said Alice.
+
+‘We’d better take it with us,’ the Knight said. ‘It’ll come in handy if
+we find any plum-cake. Help me to get it into this bag.’
+
+This took a very long time to manage, though Alice held the bag open
+very carefully, because the Knight was so VERY awkward in putting in
+the dish: the first two or three times that he tried he fell in himself
+instead. ‘It’s rather a tight fit, you see,’ he said, as they got it in
+a last; ‘There are so many candlesticks in the bag.’ And he hung it
+to the saddle, which was already loaded with bunches of carrots, and
+fire-irons, and many other things.
+
+‘I hope you’ve got your hair well fastened on?’ he continued, as they
+set off.
+
+‘Only in the usual way,’ Alice said, smiling.
+
+‘That’s hardly enough,’ he said, anxiously. ‘You see the wind is so VERY
+strong here. It’s as strong as soup.’
+
+‘Have you invented a plan for keeping the hair from being blown off?’
+Alice enquired.
+
+‘Not yet,’ said the Knight. ‘But I’ve got a plan for keeping it from
+FALLING off.’
+
+‘I should like to hear it, very much.’
+
+‘First you take an upright stick,’ said the Knight. ‘Then you make your
+hair creep up it, like a fruit-tree. Now the reason hair falls off is
+because it hangs DOWN--things never fall UPWARDS, you know. It’s a plan
+of my own invention. You may try it if you like.’
+
+It didn’t sound a comfortable plan, Alice thought, and for a few minutes
+she walked on in silence, puzzling over the idea, and every now and then
+stopping to help the poor Knight, who certainly was NOT a good rider.
+
+Whenever the horse stopped (which it did very often), he fell off in
+front; and whenever it went on again (which it generally did rather
+suddenly), he fell off behind. Otherwise he kept on pretty well, except
+that he had a habit of now and then falling off sideways; and as he
+generally did this on the side on which Alice was walking, she soon
+found that it was the best plan not to walk QUITE close to the horse.
+
+‘I’m afraid you’ve not had much practice in riding,’ she ventured to
+say, as she was helping him up from his fifth tumble.
+
+The Knight looked very much surprised, and a little offended at the
+remark. ‘What makes you say that?’ he asked, as he scrambled back into
+the saddle, keeping hold of Alice’s hair with one hand, to save himself
+from falling over on the other side.
+
+‘Because people don’t fall off quite so often, when they’ve had much
+practice.’
+
+‘I’ve had plenty of practice,’ the Knight said very gravely: ‘plenty of
+practice!’
+
+Alice could think of nothing better to say than ‘Indeed?’ but she said
+it as heartily as she could. They went on a little way in silence after
+this, the Knight with his eyes shut, muttering to himself, and Alice
+watching anxiously for the next tumble.
+
+‘The great art of riding,’ the Knight suddenly began in a loud voice,
+waving his right arm as he spoke, ‘is to keep--’ Here the sentence ended
+as suddenly as it had begun, as the Knight fell heavily on the top of
+his head exactly in the path where Alice was walking. She was quite
+frightened this time, and said in an anxious tone, as she picked him up,
+‘I hope no bones are broken?’
+
+‘None to speak of,’ the Knight said, as if he didn’t mind breaking two
+or three of them. ‘The great art of riding, as I was saying, is--to keep
+your balance properly. Like this, you know--’
+
+He let go the bridle, and stretched out both his arms to show Alice
+what he meant, and this time he fell flat on his back, right under the
+horse’s feet.
+
+‘Plenty of practice!’ he went on repeating, all the time that Alice was
+getting him on his feet again. ‘Plenty of practice!’
+
+‘It’s too ridiculous!’ cried Alice, losing all her patience this time.
+‘You ought to have a wooden horse on wheels, that you ought!’
+
+‘Does that kind go smoothly?’ the Knight asked in a tone of great
+interest, clasping his arms round the horse’s neck as he spoke, just in
+time to save himself from tumbling off again.
+
+‘Much more smoothly than a live horse,’ Alice said, with a little scream
+of laughter, in spite of all she could do to prevent it.
+
+‘I’ll get one,’ the Knight said thoughtfully to himself. ‘One or
+two--several.’
+
+There was a short silence after this, and then the Knight went on again.
+‘I’m a great hand at inventing things. Now, I daresay you noticed, that
+last time you picked me up, that I was looking rather thoughtful?’
+
+‘You WERE a little grave,’ said Alice.
+
+‘Well, just then I was inventing a new way of getting over a gate--would
+you like to hear it?’
+
+‘Very much indeed,’ Alice said politely.
+
+‘I’ll tell you how I came to think of it,’ said the Knight. ‘You see, I
+said to myself, “The only difficulty is with the feet: the HEAD is high
+enough already.” Now, first I put my head on the top of the gate--then I
+stand on my head--then the feet are high enough, you see--then I’m over,
+you see.’
+
+‘Yes, I suppose you’d be over when that was done,’ Alice said
+thoughtfully: ‘but don’t you think it would be rather hard?’
+
+‘I haven’t tried it yet,’ the Knight said, gravely: ‘so I can’t tell for
+certain--but I’m afraid it WOULD be a little hard.’
+
+He looked so vexed at the idea, that Alice changed the subject hastily.
+‘What a curious helmet you’ve got!’ she said cheerfully. ‘Is that your
+invention too?’
+
+The Knight looked down proudly at his helmet, which hung from the
+saddle. ‘Yes,’ he said, ‘but I’ve invented a better one than that--like
+a sugar loaf. When I used to wear it, if I fell off the horse, it always
+touched the ground directly. So I had a VERY little way to fall, you
+see--But there WAS the danger of falling INTO it, to be sure. That
+happened to me once--and the worst of it was, before I could get out
+again, the other White Knight came and put it on. He thought it was his
+own helmet.’
+
+The knight looked so solemn about it that Alice did not dare to laugh.
+‘I’m afraid you must have hurt him,’ she said in a trembling voice,
+‘being on the top of his head.’
+
+‘I had to kick him, of course,’ the Knight said, very seriously. ‘And
+then he took the helmet off again--but it took hours and hours to get me
+out. I was as fast as--as lightning, you know.’
+
+‘But that’s a different kind of fastness,’ Alice objected.
+
+The Knight shook his head. ‘It was all kinds of fastness with me, I can
+assure you!’ he said. He raised his hands in some excitement as he said
+this, and instantly rolled out of the saddle, and fell headlong into a
+deep ditch.
+
+Alice ran to the side of the ditch to look for him. She was rather
+startled by the fall, as for some time he had kept on very well, and she
+was afraid that he really WAS hurt this time. However, though she could
+see nothing but the soles of his feet, she was much relieved to hear
+that he was talking on in his usual tone. ‘All kinds of fastness,’
+he repeated: ‘but it was careless of him to put another man’s helmet
+on--with the man in it, too.’
+
+‘How CAN you go on talking so quietly, head downwards?’ Alice asked, as
+she dragged him out by the feet, and laid him in a heap on the bank.
+
+The Knight looked surprised at the question. ‘What does it matter where
+my body happens to be?’ he said. ‘My mind goes on working all the same.
+In fact, the more head downwards I am, the more I keep inventing new
+things.’
+
+‘Now the cleverest thing of the sort that I ever did,’ he went on after
+a pause, ‘was inventing a new pudding during the meat-course.’
+
+‘In time to have it cooked for the next course?’ said Alice. ‘Well,
+not the NEXT course,’ the Knight said in a slow thoughtful tone: ‘no,
+certainly not the next COURSE.’
+
+‘Then it would have to be the next day. I suppose you wouldn’t have two
+pudding-courses in one dinner?’
+
+‘Well, not the NEXT day,’ the Knight repeated as before: ‘not the next
+DAY. In fact,’ he went on, holding his head down, and his voice getting
+lower and lower, ‘I don’t believe that pudding ever WAS cooked! In fact,
+I don’t believe that pudding ever WILL be cooked! And yet it was a very
+clever pudding to invent.’
+
+‘What did you mean it to be made of?’ Alice asked, hoping to cheer him
+up, for the poor Knight seemed quite low-spirited about it.
+
+‘It began with blotting paper,’ the Knight answered with a groan.
+
+‘That wouldn’t be very nice, I’m afraid--’
+
+‘Not very nice ALONE,’ he interrupted, quite eagerly: ‘but you’ve no
+idea what a difference it makes mixing it with other things--such as
+gunpowder and sealing-wax. And here I must leave you.’ They had just
+come to the end of the wood.
+
+Alice could only look puzzled: she was thinking of the pudding.
+
+‘You are sad,’ the Knight said in an anxious tone: ‘let me sing you a
+song to comfort you.’
+
+‘Is it very long?’ Alice asked, for she had heard a good deal of poetry
+that day.
+
+‘It’s long,’ said the Knight, ‘but very, VERY beautiful. Everybody that
+hears me sing it--either it brings the TEARS into their eyes, or else--’
+
+‘Or else what?’ said Alice, for the Knight had made a sudden pause.
+
+‘Or else it doesn’t, you know. The name of the song is called “HADDOCKS’
+EYES.”’
+
+‘Oh, that’s the name of the song, is it?’ Alice said, trying to feel
+interested.
+
+‘No, you don’t understand,’ the Knight said, looking a little vexed.
+‘That’s what the name is CALLED. The name really IS “THE AGED AGED
+MAN.”’
+
+‘Then I ought to have said “That’s what the SONG is called”?’ Alice
+corrected herself.
+
+‘No, you oughtn’t: that’s quite another thing! The SONG is called “WAYS
+AND MEANS”: but that’s only what it’s CALLED, you know!’
+
+‘Well, what IS the song, then?’ said Alice, who was by this time
+completely bewildered.
+
+‘I was coming to that,’ the Knight said. ‘The song really IS “A-SITTING
+ON A GATE”: and the tune’s my own invention.’
+
+So saying, he stopped his horse and let the reins fall on its neck:
+then, slowly beating time with one hand, and with a faint smile lighting
+up his gentle foolish face, as if he enjoyed the music of his song, he
+began.
+
+Of all the strange things that Alice saw in her journey Through The
+Looking-Glass, this was the one that she always remembered most clearly.
+Years afterwards she could bring the whole scene back again, as if it
+had been only yesterday--the mild blue eyes and kindly smile of the
+Knight--the setting sun gleaming through his hair, and shining on his
+armour in a blaze of light that quite dazzled her--the horse quietly
+moving about, with the reins hanging loose on his neck, cropping the
+grass at her feet--and the black shadows of the forest behind--all this
+she took in like a picture, as, with one hand shading her eyes, she
+leant against a tree, watching the strange pair, and listening, in a
+half dream, to the melancholy music of the song.
+
+‘But the tune ISN’T his own invention,’ she said to herself: ‘it’s “I
+GIVE THEE ALL, I CAN NO MORE.”’ She stood and listened very attentively,
+but no tears came into her eyes.
+
+
+     ‘I’ll tell thee everything I can;
+      There’s little to relate.
+     I saw an aged aged man,
+      A-sitting on a gate.
+     “Who are you, aged man?” I said,
+      “and how is it you live?”
+      And his answer trickled through my head
+      Like water through a sieve.
+
+     He said “I look for butterflies
+      That sleep among the wheat:
+     I make them into mutton-pies,
+      And sell them in the street.
+     I sell them unto men,” he said,
+      “Who sail on stormy seas;
+     And that’s the way I get my bread--
+      A trifle, if you please.”
+
+     But I was thinking of a plan
+      To dye one’s whiskers green,
+     And always use so large a fan
+      That they could not be seen.
+     So, having no reply to give
+      To what the old man said,
+     I cried, “Come, tell me how you live!”
+       And thumped him on the head.
+
+     His accents mild took up the tale:
+      He said “I go my ways,
+     And when I find a mountain-rill,
+      I set it in a blaze;
+     And thence they make a stuff they call
+      Rolands’ Macassar Oil--
+     Yet twopence-halfpenny is all
+      They give me for my toil.”
+
+     But I was thinking of a way
+      To feed oneself on batter,
+     And so go on from day to day
+      Getting a little fatter.
+     I shook him well from side to side,
+      Until his face was blue:
+     “Come, tell me how you live,” I cried,
+      “And what it is you do!”
+
+     He said “I hunt for haddocks’ eyes
+      Among the heather bright,
+     And work them into waistcoat-buttons
+      In the silent night.
+     And these I do not sell for gold
+      Or coin of silvery shine
+     But for a copper halfpenny,
+      And that will purchase nine.
+
+     “I sometimes dig for buttered rolls,
+      Or set limed twigs for crabs;
+     I sometimes search the grassy knolls
+      For wheels of Hansom-cabs.
+     And that’s the way” (he gave a wink)
+      “By which I get my wealth--
+     And very gladly will I drink
+      Your Honour’s noble health.”
+
+     I heard him then, for I had just
+      Completed my design
+     To keep the Menai bridge from rust
+      By boiling it in wine.
+     I thanked him much for telling me
+      The way he got his wealth,
+     But chiefly for his wish that he
+      Might drink my noble health.
+
+     And now, if e’er by chance I put
+      My fingers into glue
+     Or madly squeeze a right-hand foot
+      Into a left-hand shoe,
+     Or if I drop upon my toe
+      A very heavy weight,
+     I weep, for it reminds me so,
+      Of that old man I used to know--
+
+     Whose look was mild, whose speech was slow,
+     Whose hair was whiter than the snow,
+     Whose face was very like a crow,
+     With eyes, like cinders, all aglow,
+     Who seemed distracted with his woe,
+     Who rocked his body to and fro,
+     And muttered mumblingly and low,
+     As if his mouth were full of dough,
+     Who snorted like a buffalo--
+     That summer evening, long ago,
+      A-sitting on a gate.’
+
+
+As the Knight sang the last words of the ballad, he gathered up the
+reins, and turned his horse’s head along the road by which they had
+come. ‘You’ve only a few yards to go,’ he said, ‘down the hill and over
+that little brook, and then you’ll be a Queen--But you’ll stay and
+see me off first?’ he added as Alice turned with an eager look in the
+direction to which he pointed. ‘I shan’t be long. You’ll wait and wave
+your handkerchief when I get to that turn in the road? I think it’ll
+encourage me, you see.’
+
+‘Of course I’ll wait,’ said Alice: ‘and thank you very much for coming
+so far--and for the song--I liked it very much.’
+
+‘I hope so,’ the Knight said doubtfully: ‘but you didn’t cry so much as
+I thought you would.’
+
+So they shook hands, and then the Knight rode slowly away into the
+forest. ‘It won’t take long to see him OFF, I expect,’ Alice said to
+herself, as she stood watching him. ‘There he goes! Right on his head as
+usual! However, he gets on again pretty easily--that comes of having so
+many things hung round the horse--’ So she went on talking to herself,
+as she watched the horse walking leisurely along the road, and the
+Knight tumbling off, first on one side and then on the other. After
+the fourth or fifth tumble he reached the turn, and then she waved her
+handkerchief to him, and waited till he was out of sight.
+
+‘I hope it encouraged him,’ she said, as she turned to run down the
+hill: ‘and now for the last brook, and to be a Queen! How grand it
+sounds!’ A very few steps brought her to the edge of the brook. ‘The
+Eighth Square at last!’ she cried as she bounded across,
+
+  *    *    *    *    *    *    *
+
+    *    *    *    *    *    *
+
+  *    *    *    *    *    *    *
+
+and threw herself down to rest on a lawn as soft as moss, with little
+flower-beds dotted about it here and there. ‘Oh, how glad I am to get
+here! And what IS this on my head?’ she exclaimed in a tone of dismay,
+as she put her hands up to something very heavy, and fitted tight all
+round her head.
+
+‘But how CAN it have got there without my knowing it?’ she said to
+herself, as she lifted it off, and set it on her lap to make out what it
+could possibly be.
+
+It was a golden crown.
+
+
+
+
+CHAPTER IX. Queen Alice
+
+‘Well, this IS grand!’ said Alice. ‘I never expected I should be a Queen
+so soon--and I’ll tell you what it is, your majesty,’ she went on in
+a severe tone (she was always rather fond of scolding herself), ‘it’ll
+never do for you to be lolling about on the grass like that! Queens have
+to be dignified, you know!’
+
+So she got up and walked about--rather stiffly just at first, as she was
+afraid that the crown might come off: but she comforted herself with the
+thought that there was nobody to see her, ‘and if I really am a Queen,’
+she said as she sat down again, ‘I shall be able to manage it quite well
+in time.’
+
+Everything was happening so oddly that she didn’t feel a bit surprised
+at finding the Red Queen and the White Queen sitting close to her, one
+on each side: she would have liked very much to ask them how they came
+there, but she feared it would not be quite civil. However, there would
+be no harm, she thought, in asking if the game was over. ‘Please, would
+you tell me--’ she began, looking timidly at the Red Queen.
+
+‘Speak when you’re spoken to!’ The Queen sharply interrupted her.
+
+‘But if everybody obeyed that rule,’ said Alice, who was always ready
+for a little argument, ‘and if you only spoke when you were spoken to,
+and the other person always waited for YOU to begin, you see nobody
+would ever say anything, so that--’
+
+‘Ridiculous!’ cried the Queen. ‘Why, don’t you see, child--’ here she
+broke off with a frown, and, after thinking for a minute, suddenly
+changed the subject of the conversation. ‘What do you mean by “If you
+really are a Queen”? What right have you to call yourself so? You can’t
+be a Queen, you know, till you’ve passed the proper examination. And the
+sooner we begin it, the better.’
+
+‘I only said “if”!’ poor Alice pleaded in a piteous tone.
+
+The two Queens looked at each other, and the Red Queen remarked, with a
+little shudder, ‘She SAYS she only said “if”--’
+
+‘But she said a great deal more than that!’ the White Queen moaned,
+wringing her hands. ‘Oh, ever so much more than that!’
+
+‘So you did, you know,’ the Red Queen said to Alice. ‘Always speak the
+truth--think before you speak--and write it down afterwards.’
+
+‘I’m sure I didn’t mean--’ Alice was beginning, but the Red Queen
+interrupted her impatiently.
+
+‘That’s just what I complain of! You SHOULD have meant! What do you
+suppose is the use of child without any meaning? Even a joke should
+have some meaning--and a child’s more important than a joke, I hope. You
+couldn’t deny that, even if you tried with both hands.’
+
+‘I don’t deny things with my HANDS,’ Alice objected.
+
+‘Nobody said you did,’ said the Red Queen. ‘I said you couldn’t if you
+tried.’
+
+‘She’s in that state of mind,’ said the White Queen, ‘that she wants to
+deny SOMETHING--only she doesn’t know what to deny!’
+
+‘A nasty, vicious temper,’ the Red Queen remarked; and then there was an
+uncomfortable silence for a minute or two.
+
+The Red Queen broke the silence by saying to the White Queen, ‘I invite
+you to Alice’s dinner-party this afternoon.’
+
+The White Queen smiled feebly, and said ‘And I invite YOU.’
+
+‘I didn’t know I was to have a party at all,’ said Alice; ‘but if there
+is to be one, I think _I_ ought to invite the guests.’
+
+‘We gave you the opportunity of doing it,’ the Red Queen remarked: ‘but
+I daresay you’ve not had many lessons in manners yet?’
+
+‘Manners are not taught in lessons,’ said Alice. ‘Lessons teach you to
+do sums, and things of that sort.’
+
+‘And you do Addition?’ the White Queen asked. ‘What’s one and one and
+one and one and one and one and one and one and one and one?’
+
+‘I don’t know,’ said Alice. ‘I lost count.’
+
+‘She can’t do Addition,’ the Red Queen interrupted. ‘Can you do
+Subtraction? Take nine from eight.’
+
+‘Nine from eight I can’t, you know,’ Alice replied very readily: ‘but--’
+
+‘She can’t do Subtraction,’ said the White Queen. ‘Can you do Division?
+Divide a loaf by a knife--what’s the answer to that?’
+
+‘I suppose--’ Alice was beginning, but the Red Queen answered for her.
+‘Bread-and-butter, of course. Try another Subtraction sum. Take a bone
+from a dog: what remains?’
+
+Alice considered. ‘The bone wouldn’t remain, of course, if I took
+it--and the dog wouldn’t remain; it would come to bite me--and I’m sure
+I shouldn’t remain!’
+
+‘Then you think nothing would remain?’ said the Red Queen.
+
+‘I think that’s the answer.’
+
+‘Wrong, as usual,’ said the Red Queen: ‘the dog’s temper would remain.’
+
+‘But I don’t see how--’
+
+‘Why, look here!’ the Red Queen cried. ‘The dog would lose its temper,
+wouldn’t it?’
+
+‘Perhaps it would,’ Alice replied cautiously.
+
+‘Then if the dog went away, its temper would remain!’ the Queen
+exclaimed triumphantly.
+
+Alice said, as gravely as she could, ‘They might go different ways.’ But
+she couldn’t help thinking to herself, ‘What dreadful nonsense we ARE
+talking!’
+
+‘She can’t do sums a BIT!’ the Queens said together, with great
+emphasis.
+
+‘Can YOU do sums?’ Alice said, turning suddenly on the White Queen, for
+she didn’t like being found fault with so much.
+
+The Queen gasped and shut her eyes. ‘I can do Addition, if you give me
+time--but I can’t do Subtraction, under ANY circumstances!’
+
+‘Of course you know your A B C?’ said the Red Queen.
+
+‘To be sure I do.’ said Alice.
+
+‘So do I,’ the White Queen whispered: ‘we’ll often say it over together,
+dear. And I’ll tell you a secret--I can read words of one letter! Isn’t
+THAT grand! However, don’t be discouraged. You’ll come to it in time.’
+
+Here the Red Queen began again. ‘Can you answer useful questions?’ she
+said. ‘How is bread made?’
+
+‘I know THAT!’ Alice cried eagerly. ‘You take some flour--’
+
+‘Where do you pick the flower?’ the White Queen asked. ‘In a garden, or
+in the hedges?’
+
+‘Well, it isn’t PICKED at all,’ Alice explained: ‘it’s GROUND--’
+
+‘How many acres of ground?’ said the White Queen. ‘You mustn’t leave out
+so many things.’
+
+‘Fan her head!’ the Red Queen anxiously interrupted. ‘She’ll be feverish
+after so much thinking.’ So they set to work and fanned her with bunches
+of leaves, till she had to beg them to leave off, it blew her hair about
+so.
+
+‘She’s all right again now,’ said the Red Queen. ‘Do you know Languages?
+What’s the French for fiddle-de-dee?’
+
+‘Fiddle-de-dee’s not English,’ Alice replied gravely.
+
+‘Who ever said it was?’ said the Red Queen.
+
+Alice thought she saw a way out of the difficulty this time. ‘If you’ll
+tell me what language “fiddle-de-dee” is, I’ll tell you the French for
+it!’ she exclaimed triumphantly.
+
+But the Red Queen drew herself up rather stiffly, and said ‘Queens never
+make bargains.’
+
+‘I wish Queens never asked questions,’ Alice thought to herself.
+
+‘Don’t let us quarrel,’ the White Queen said in an anxious tone. ‘What
+is the cause of lightning?’
+
+‘The cause of lightning,’ Alice said very decidedly, for she felt quite
+certain about this, ‘is the thunder--no, no!’ she hastily corrected
+herself. ‘I meant the other way.’
+
+‘It’s too late to correct it,’ said the Red Queen: ‘when you’ve once
+said a thing, that fixes it, and you must take the consequences.’
+
+‘Which reminds me--’ the White Queen said, looking down and nervously
+clasping and unclasping her hands, ‘we had SUCH a thunderstorm last
+Tuesday--I mean one of the last set of Tuesdays, you know.’
+
+Alice was puzzled. ‘In OUR country,’ she remarked, ‘there’s only one day
+at a time.’
+
+The Red Queen said, ‘That’s a poor thin way of doing things. Now HERE,
+we mostly have days and nights two or three at a time, and sometimes
+in the winter we take as many as five nights together--for warmth, you
+know.’
+
+‘Are five nights warmer than one night, then?’ Alice ventured to ask.
+
+‘Five times as warm, of course.’
+
+‘But they should be five times as COLD, by the same rule--’
+
+‘Just so!’ cried the Red Queen. ‘Five times as warm, AND five times
+as cold--just as I’m five times as rich as you are, AND five times as
+clever!’
+
+Alice sighed and gave it up. ‘It’s exactly like a riddle with no
+answer!’ she thought.
+
+‘Humpty Dumpty saw it too,’ the White Queen went on in a low voice, more
+as if she were talking to herself. ‘He came to the door with a corkscrew
+in his hand--’
+
+‘What did he want?’ said the Red Queen.
+
+‘He said he WOULD come in,’ the White Queen went on, ‘because he was
+looking for a hippopotamus. Now, as it happened, there wasn’t such a
+thing in the house, that morning.’
+
+‘Is there generally?’ Alice asked in an astonished tone.
+
+‘Well, only on Thursdays,’ said the Queen.
+
+‘I know what he came for,’ said Alice: ‘he wanted to punish the fish,
+because--’
+
+Here the White Queen began again. ‘It was SUCH a thunderstorm, you can’t
+think!’ (‘She NEVER could, you know,’ said the Red Queen.) ‘And part of
+the roof came off, and ever so much thunder got in--and it went
+rolling round the room in great lumps--and knocking over the tables and
+things--till I was so frightened, I couldn’t remember my own name!’
+
+Alice thought to herself, ‘I never should TRY to remember my name in the
+middle of an accident! Where would be the use of it?’ but she did not
+say this aloud, for fear of hurting the poor Queen’s feeling.
+
+‘Your Majesty must excuse her,’ the Red Queen said to Alice, taking
+one of the White Queen’s hands in her own, and gently stroking it:
+‘she means well, but she can’t help saying foolish things, as a general
+rule.’
+
+The White Queen looked timidly at Alice, who felt she OUGHT to say
+something kind, but really couldn’t think of anything at the moment.
+
+‘She never was really well brought up,’ the Red Queen went on: ‘but
+it’s amazing how good-tempered she is! Pat her on the head, and see how
+pleased she’ll be!’ But this was more than Alice had courage to do.
+
+‘A little kindness--and putting her hair in papers--would do wonders
+with her--’
+
+The White Queen gave a deep sigh, and laid her head on Alice’s shoulder.
+‘I AM so sleepy?’ she moaned.
+
+‘She’s tired, poor thing!’ said the Red Queen. ‘Smooth her hair--lend
+her your nightcap--and sing her a soothing lullaby.’
+
+‘I haven’t got a nightcap with me,’ said Alice, as she tried to obey the
+first direction: ‘and I don’t know any soothing lullabies.’
+
+‘I must do it myself, then,’ said the Red Queen, and she began:
+
+
+   ‘Hush-a-by lady, in Alice’s lap!
+   Till the feast’s ready, we’ve time for a nap:
+   When the feast’s over, we’ll go to the ball--
+   Red Queen, and White Queen, and Alice, and all!
+
+
+‘And now you know the words,’ she added, as she put her head down on
+Alice’s other shoulder, ‘just sing it through to ME. I’m getting sleepy,
+too.’ In another moment both Queens were fast asleep, and snoring loud.
+
+‘What AM I to do?’ exclaimed Alice, looking about in great perplexity,
+as first one round head, and then the other, rolled down from her
+shoulder, and lay like a heavy lump in her lap. ‘I don’t think it EVER
+happened before, that any one had to take care of two Queens asleep
+at once! No, not in all the History of England--it couldn’t, you know,
+because there never was more than one Queen at a time. Do wake up, you
+heavy things!’ she went on in an impatient tone; but there was no answer
+but a gentle snoring.
+
+The snoring got more distinct every minute, and sounded more like a
+tune: at last she could even make out the words, and she listened so
+eagerly that, when the two great heads vanished from her lap, she hardly
+missed them.
+
+She was standing before an arched doorway over which were the words
+QUEEN ALICE in large letters, and on each side of the arch there was a
+bell-handle; one was marked ‘Visitors’ Bell,’ and the other ‘Servants’
+Bell.’
+
+‘I’ll wait till the song’s over,’ thought Alice, ‘and then I’ll
+ring--the--WHICH bell must I ring?’ she went on, very much puzzled by
+the names. ‘I’m not a visitor, and I’m not a servant. There OUGHT to be
+one marked “Queen,” you know--’
+
+Just then the door opened a little way, and a creature with a long beak
+put its head out for a moment and said ‘No admittance till the week
+after next!’ and shut the door again with a bang.
+
+Alice knocked and rang in vain for a long time, but at last, a very old
+Frog, who was sitting under a tree, got up and hobbled slowly towards
+her: he was dressed in bright yellow, and had enormous boots on.
+
+‘What is it, now?’ the Frog said in a deep hoarse whisper.
+
+Alice turned round, ready to find fault with anybody. ‘Where’s the
+servant whose business it is to answer the door?’ she began angrily.
+
+‘Which door?’ said the Frog.
+
+Alice almost stamped with irritation at the slow drawl in which he
+spoke. ‘THIS door, of course!’
+
+The Frog looked at the door with his large dull eyes for a minute:
+then he went nearer and rubbed it with his thumb, as if he were trying
+whether the paint would come off; then he looked at Alice.
+
+‘To answer the door?’ he said. ‘What’s it been asking of?’ He was so
+hoarse that Alice could scarcely hear him.
+
+‘I don’t know what you mean,’ she said.
+
+‘I talks English, doesn’t I?’ the Frog went on. ‘Or are you deaf? What
+did it ask you?’
+
+‘Nothing!’ Alice said impatiently. ‘I’ve been knocking at it!’
+
+‘Shouldn’t do that--shouldn’t do that--’ the Frog muttered. ‘Vexes it,
+you know.’ Then he went up and gave the door a kick with one of his
+great feet. ‘You let IT alone,’ he panted out, as he hobbled back to his
+tree, ‘and it’ll let YOU alone, you know.’
+
+At this moment the door was flung open, and a shrill voice was heard
+singing:
+
+
+   ‘To the Looking-Glass world it was Alice that said,
+   “I’ve a sceptre in hand, I’ve a crown on my head;
+   Let the Looking-Glass creatures, whatever they be,
+   Come and dine with the Red Queen, the White Queen, and me.”’
+
+
+And hundreds of voices joined in the chorus:
+
+
+  ‘Then fill up the glasses as quick as you can,
+  And sprinkle the table with buttons and bran:
+  Put cats in the coffee, and mice in the tea--
+  And welcome Queen Alice with thirty-times-three!’
+
+
+Then followed a confused noise of cheering, and Alice thought to
+herself, ‘Thirty times three makes ninety. I wonder if any one’s
+counting?’ In a minute there was silence again, and the same shrill
+voice sang another verse;
+
+
+  ‘“O Looking-Glass creatures,” quoth Alice, “draw near!
+  ‘Tis an honour to see me, a favour to hear:
+  ‘Tis a privilege high to have dinner and tea
+  Along with the Red Queen, the White Queen, and me!”’
+
+
+Then came the chorus again:--
+
+
+  ‘Then fill up the glasses with treacle and ink,
+  Or anything else that is pleasant to drink:
+  Mix sand with the cider, and wool with the wine--
+  And welcome Queen Alice with ninety-times-nine!’
+
+
+‘Ninety times nine!’ Alice repeated in despair, ‘Oh, that’ll never
+be done! I’d better go in at once--’ and there was a dead silence the
+moment she appeared.
+
+Alice glanced nervously along the table, as she walked up the large
+hall, and noticed that there were about fifty guests, of all kinds: some
+were animals, some birds, and there were even a few flowers among them.
+‘I’m glad they’ve come without waiting to be asked,’ she thought: ‘I
+should never have known who were the right people to invite!’
+
+There were three chairs at the head of the table; the Red and White
+Queens had already taken two of them, but the middle one was empty.
+Alice sat down in it, rather uncomfortable in the silence, and longing
+for some one to speak.
+
+At last the Red Queen began. ‘You’ve missed the soup and fish,’ she
+said. ‘Put on the joint!’ And the waiters set a leg of mutton before
+Alice, who looked at it rather anxiously, as she had never had to carve
+a joint before.
+
+‘You look a little shy; let me introduce you to that leg of mutton,’
+said the Red Queen. ‘Alice--Mutton; Mutton--Alice.’ The leg of mutton
+got up in the dish and made a little bow to Alice; and Alice returned
+the bow, not knowing whether to be frightened or amused.
+
+‘May I give you a slice?’ she said, taking up the knife and fork, and
+looking from one Queen to the other.
+
+‘Certainly not,’ the Red Queen said, very decidedly: ‘it isn’t etiquette
+to cut any one you’ve been introduced to. Remove the joint!’ And the
+waiters carried it off, and brought a large plum-pudding in its place.
+
+‘I won’t be introduced to the pudding, please,’ Alice said rather
+hastily, ‘or we shall get no dinner at all. May I give you some?’
+
+But the Red Queen looked sulky, and growled ‘Pudding--Alice;
+Alice--Pudding. Remove the pudding!’ and the waiters took it away so
+quickly that Alice couldn’t return its bow.
+
+However, she didn’t see why the Red Queen should be the only one to give
+orders, so, as an experiment, she called out ‘Waiter! Bring back the
+pudding!’ and there it was again in a moment like a conjuring-trick. It
+was so large that she couldn’t help feeling a LITTLE shy with it, as she
+had been with the mutton; however, she conquered her shyness by a great
+effort and cut a slice and handed it to the Red Queen.
+
+‘What impertinence!’ said the Pudding. ‘I wonder how you’d like it, if I
+were to cut a slice out of YOU, you creature!’
+
+It spoke in a thick, suety sort of voice, and Alice hadn’t a word to say
+in reply: she could only sit and look at it and gasp.
+
+‘Make a remark,’ said the Red Queen: ‘it’s ridiculous to leave all the
+conversation to the pudding!’
+
+‘Do you know, I’ve had such a quantity of poetry repeated to me to-day,’
+Alice began, a little frightened at finding that, the moment she opened
+her lips, there was dead silence, and all eyes were fixed upon her; ‘and
+it’s a very curious thing, I think--every poem was about fishes in some
+way. Do you know why they’re so fond of fishes, all about here?’
+
+She spoke to the Red Queen, whose answer was a little wide of the mark.
+‘As to fishes,’ she said, very slowly and solemnly, putting her mouth
+close to Alice’s ear, ‘her White Majesty knows a lovely riddle--all in
+poetry--all about fishes. Shall she repeat it?’
+
+‘Her Red Majesty’s very kind to mention it,’ the White Queen murmured
+into Alice’s other ear, in a voice like the cooing of a pigeon. ‘It
+would be SUCH a treat! May I?’
+
+‘Please do,’ Alice said very politely.
+
+The White Queen laughed with delight, and stroked Alice’s cheek. Then
+she began:
+
+
+    ‘“First, the fish must be caught.”
+   That is easy: a baby, I think, could have caught it.
+    “Next, the fish must be bought.”
+   That is easy: a penny, I think, would have bought it.
+
+    “Now cook me the fish!”
+   That is easy, and will not take more than a minute.
+    “Let it lie in a dish!”
+   That is easy, because it already is in it.
+
+    “Bring it here! Let me sup!”
+   It is easy to set such a dish on the table.
+    “Take the dish-cover up!”
+   Ah, THAT is so hard that I fear I’m unable!
+
+    For it holds it like glue--
+  Holds the lid to the dish, while it lies in the middle:
+    Which is easiest to do,
+  Un-dish-cover the fish, or dishcover the riddle?’
+
+
+‘Take a minute to think about it, and then guess,’ said the Red Queen.
+‘Meanwhile, we’ll drink your health--Queen Alice’s health!’ she screamed
+at the top of her voice, and all the guests began drinking it directly,
+and very queerly they managed it: some of them put their glasses upon
+their heads like extinguishers, and drank all that trickled down their
+faces--others upset the decanters, and drank the wine as it ran off
+the edges of the table--and three of them (who looked like kangaroos)
+scrambled into the dish of roast mutton, and began eagerly lapping up
+the gravy, ‘just like pigs in a trough!’ thought Alice.
+
+‘You ought to return thanks in a neat speech,’ the Red Queen said,
+frowning at Alice as she spoke.
+
+‘We must support you, you know,’ the White Queen whispered, as Alice got
+up to do it, very obediently, but a little frightened.
+
+‘Thank you very much,’ she whispered in reply, ‘but I can do quite well
+without.’
+
+‘That wouldn’t be at all the thing,’ the Red Queen said very decidedly:
+so Alice tried to submit to it with a good grace.
+
+(‘And they DID push so!’ she said afterwards, when she was telling her
+sister the history of the feast. ‘You would have thought they wanted to
+squeeze me flat!’)
+
+In fact it was rather difficult for her to keep in her place while she
+made her speech: the two Queens pushed her so, one on each side, that
+they nearly lifted her up into the air: ‘I rise to return thanks--’
+Alice began: and she really DID rise as she spoke, several inches; but
+she got hold of the edge of the table, and managed to pull herself down
+again.
+
+‘Take care of yourself!’ screamed the White Queen, seizing Alice’s hair
+with both her hands. ‘Something’s going to happen!’
+
+And then (as Alice afterwards described it) all sorts of things happened
+in a moment. The candles all grew up to the ceiling, looking something
+like a bed of rushes with fireworks at the top. As to the bottles, they
+each took a pair of plates, which they hastily fitted on as wings, and
+so, with forks for legs, went fluttering about in all directions: ‘and
+very like birds they look,’ Alice thought to herself, as well as she
+could in the dreadful confusion that was beginning.
+
+At this moment she heard a hoarse laugh at her side, and turned to see
+what was the matter with the White Queen; but, instead of the Queen,
+there was the leg of mutton sitting in the chair. ‘Here I am!’ cried a
+voice from the soup tureen, and Alice turned again, just in time to see
+the Queen’s broad good-natured face grinning at her for a moment over
+the edge of the tureen, before she disappeared into the soup.
+
+There was not a moment to be lost. Already several of the guests were
+lying down in the dishes, and the soup ladle was walking up the table
+towards Alice’s chair, and beckoning to her impatiently to get out of
+its way.
+
+‘I can’t stand this any longer!’ she cried as she jumped up and seized
+the table-cloth with both hands: one good pull, and plates, dishes,
+guests, and candles came crashing down together in a heap on the floor.
+
+‘And as for YOU,’ she went on, turning fiercely upon the Red Queen, whom
+she considered as the cause of all the mischief--but the Queen was no
+longer at her side--she had suddenly dwindled down to the size of a
+little doll, and was now on the table, merrily running round and round
+after her own shawl, which was trailing behind her.
+
+At any other time, Alice would have felt surprised at this, but she was
+far too much excited to be surprised at anything NOW. ‘As for YOU,’
+she repeated, catching hold of the little creature in the very act of
+jumping over a bottle which had just lighted upon the table, ‘I’ll shake
+you into a kitten, that I will!’
+
+
+
+
+CHAPTER X. Shaking
+
+She took her off the table as she spoke, and shook her backwards and
+forwards with all her might.
+
+The Red Queen made no resistance whatever; only her face grew very
+small, and her eyes got large and green: and still, as Alice went on
+shaking her, she kept on growing shorter--and fatter--and softer--and
+rounder--and--
+
+
+
+
+CHAPTER XI. Waking
+
+--and it really WAS a kitten, after all.
+
+
+
+
+CHAPTER XII. Which Dreamed it?
+
+‘Your majesty shouldn’t purr so loud,’ Alice said, rubbing her eyes, and
+addressing the kitten, respectfully, yet with some severity. ‘You
+woke me out of oh! such a nice dream! And you’ve been along with me,
+Kitty--all through the Looking-Glass world. Did you know it, dear?’
+
+It is a very inconvenient habit of kittens (Alice had once made the
+remark) that, whatever you say to them, they ALWAYS purr. ‘If they would
+only purr for “yes” and mew for “no,” or any rule of that sort,’ she had
+said, ‘so that one could keep up a conversation! But how CAN you talk
+with a person if they always say the same thing?’
+
+On this occasion the kitten only purred: and it was impossible to guess
+whether it meant ‘yes’ or ‘no.’
+
+So Alice hunted among the chessmen on the table till she had found the
+Red Queen: then she went down on her knees on the hearth-rug, and put
+the kitten and the Queen to look at each other. ‘Now, Kitty!’ she cried,
+clapping her hands triumphantly. ‘Confess that was what you turned
+into!’
+
+(‘But it wouldn’t look at it,’ she said, when she was explaining the
+thing afterwards to her sister: ‘it turned away its head, and pretended
+not to see it: but it looked a LITTLE ashamed of itself, so I think it
+MUST have been the Red Queen.’)
+
+‘Sit up a little more stiffly, dear!’ Alice cried with a merry laugh.
+‘And curtsey while you’re thinking what to--what to purr. It saves time,
+remember!’ And she caught it up and gave it one little kiss, ‘just in
+honour of having been a Red Queen.’
+
+‘Snowdrop, my pet!’ she went on, looking over her shoulder at the White
+Kitten, which was still patiently undergoing its toilet, ‘when WILL
+Dinah have finished with your White Majesty, I wonder? That must be the
+reason you were so untidy in my dream--Dinah! do you know that you’re
+scrubbing a White Queen? Really, it’s most disrespectful of you!
+
+‘And what did DINAH turn to, I wonder?’ she prattled on, as she settled
+comfortably down, with one elbow in the rug, and her chin in her hand,
+to watch the kittens. ‘Tell me, Dinah, did you turn to Humpty Dumpty? I
+THINK you did--however, you’d better not mention it to your friends just
+yet, for I’m not sure.
+
+‘By the way, Kitty, if only you’d been really with me in my dream, there
+was one thing you WOULD have enjoyed--I had such a quantity of poetry
+said to me, all about fishes! To-morrow morning you shall have a real
+treat. All the time you’re eating your breakfast, I’ll repeat “The
+Walrus and the Carpenter” to you; and then you can make believe it’s
+oysters, dear!
+
+‘Now, Kitty, let’s consider who it was that dreamed it all. This is a
+serious question, my dear, and you should NOT go on licking your paw
+like that--as if Dinah hadn’t washed you this morning! You see, Kitty,
+it MUST have been either me or the Red King. He was part of my dream,
+of course--but then I was part of his dream, too! WAS it the Red King,
+Kitty? You were his wife, my dear, so you ought to know--Oh, Kitty, DO
+help to settle it! I’m sure your paw can wait!’ But the provoking kitten
+only began on the other paw, and pretended it hadn’t heard the question.
+
+Which do YOU think it was?
+
+
+              ----
+
+
+         A boat beneath a sunny sky,
+         Lingering onward dreamily
+         In an evening of July--
+
+         Children three that nestle near,
+         Eager eye and willing ear,
+         Pleased a simple tale to hear--
+
+         Long has paled that sunny sky:
+         Echoes fade and memories die.
+         Autumn frosts have slain July.
+
+         Still she haunts me, phantomwise,
+         Alice moving under skies
+         Never seen by waking eyes.
+
+         Children yet, the tale to hear,
+         Eager eye and willing ear,
+         Lovingly shall nestle near.
+
+         In a Wonderland they lie,
+         Dreaming as the days go by,
+         Dreaming as the summers die:
+
+         Ever drifting down the stream--
+         Lingering in the golden gleam--
+         Life, what is it but a dream?
+
+
+              THE END
+
+
+
+
+
+End of the Project Gutenberg EBook of Through the Looking-Glass, by
+Charles Dodgson, AKA Lewis Carroll
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THROUGH THE LOOKING-GLASS ***
+
+***** This file should be named 12-0.txt or 12-0.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.org/1/12/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.org/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  “Project Gutenberg” is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.org
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase “Project Gutenberg” associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+“Plain Vanilla ASCII” or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.org),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original “Plain Vanilla ASCII” or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, “Information about donations to
+     the Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+“Defects,” such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation’s EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation’s web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.org
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/time-machine.txt
+++ b/jet/tf-idf/src/main/resources/books/time-machine.txt
@@ -1,0 +1,3617 @@
+﻿Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The Time Machine
+
+Author: H. G. (Herbert George) Wells
+
+Release Date: October 2, 2004 [EBook #35]
+[Last updated: October 3, 2014]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+
+
+
+
+
+
+
+
+
+
+
+The Time Machine, by H. G. Wells [1898]
+
+
+
+
+I
+
+
+The Time Traveller (for so it will be convenient to speak of him)
+was expounding a recondite matter to us. His grey eyes shone and
+twinkled, and his usually pale face was flushed and animated. The
+fire burned brightly, and the soft radiance of the incandescent
+lights in the lilies of silver caught the bubbles that flashed and
+passed in our glasses. Our chairs, being his patents, embraced and
+caressed us rather than submitted to be sat upon, and there was that
+luxurious after-dinner atmosphere when thought roams gracefully
+free of the trammels of precision. And he put it to us in this
+way--marking the points with a lean forefinger--as we sat and lazily
+admired his earnestness over this new paradox (as we thought it)
+and his fecundity.
+
+'You must follow me carefully. I shall have to controvert one or two
+ideas that are almost universally accepted. The geometry, for
+instance, they taught you at school is founded on a misconception.'
+
+'Is not that rather a large thing to expect us to begin upon?'
+said Filby, an argumentative person with red hair.
+
+'I do not mean to ask you to accept anything without reasonable
+ground for it. You will soon admit as much as I need from you. You
+know of course that a mathematical line, a line of thickness _nil_,
+has no real existence. They taught you that? Neither has a
+mathematical plane. These things are mere abstractions.'
+
+'That is all right,' said the Psychologist.
+
+'Nor, having only length, breadth, and thickness, can a cube have a
+real existence.'
+
+'There I object,' said Filby. 'Of course a solid body may exist. All
+real things--'
+
+'So most people think. But wait a moment. Can an _instantaneous_
+cube exist?'
+
+'Don't follow you,' said Filby.
+
+'Can a cube that does not last for any time at all, have a real
+existence?'
+
+Filby became pensive. 'Clearly,' the Time Traveller proceeded, 'any
+real body must have extension in _four_ directions: it must have
+Length, Breadth, Thickness, and--Duration. But through a natural
+infirmity of the flesh, which I will explain to you in a moment, we
+incline to overlook this fact. There are really four dimensions,
+three which we call the three planes of Space, and a fourth, Time.
+There is, however, a tendency to draw an unreal distinction between
+the former three dimensions and the latter, because it happens that
+our consciousness moves intermittently in one direction along the
+latter from the beginning to the end of our lives.'
+
+'That,' said a very young man, making spasmodic efforts to relight
+his cigar over the lamp; 'that ... very clear indeed.'
+
+'Now, it is very remarkable that this is so extensively overlooked,'
+continued the Time Traveller, with a slight accession of
+cheerfulness. 'Really this is what is meant by the Fourth Dimension,
+though some people who talk about the Fourth Dimension do not know
+they mean it. It is only another way of looking at Time. _There is
+no difference between Time and any of the three dimensions of Space
+except that our consciousness moves along it_. But some foolish
+people have got hold of the wrong side of that idea. You have all
+heard what they have to say about this Fourth Dimension?'
+
+'_I_ have not,' said the Provincial Mayor.
+
+'It is simply this. That Space, as our mathematicians have it, is
+spoken of as having three dimensions, which one may call Length,
+Breadth, and Thickness, and is always definable by reference to
+three planes, each at right angles to the others. But some
+philosophical people have been asking why _three_ dimensions
+particularly--why not another direction at right angles to the other
+three?--and have even tried to construct a Four-Dimension geometry.
+Professor Simon Newcomb was expounding this to the New York
+Mathematical Society only a month or so ago. You know how on a flat
+surface, which has only two dimensions, we can represent a figure of
+a three-dimensional solid, and similarly they think that by models
+of three dimensions they could represent one of four--if they could
+master the perspective of the thing. See?'
+
+'I think so,' murmured the Provincial Mayor; and, knitting his
+brows, he lapsed into an introspective state, his lips moving as one
+who repeats mystic words. 'Yes, I think I see it now,' he said after
+some time, brightening in a quite transitory manner.
+
+'Well, I do not mind telling you I have been at work upon this
+geometry of Four Dimensions for some time. Some of my results
+are curious. For instance, here is a portrait of a man at eight
+years old, another at fifteen, another at seventeen, another at
+twenty-three, and so on. All these are evidently sections, as it
+were, Three-Dimensional representations of his Four-Dimensioned
+being, which is a fixed and unalterable thing.
+
+'Scientific people,' proceeded the Time Traveller, after the pause
+required for the proper assimilation of this, 'know very well that
+Time is only a kind of Space. Here is a popular scientific diagram,
+a weather record. This line I trace with my finger shows the
+movement of the barometer. Yesterday it was so high, yesterday night
+it fell, then this morning it rose again, and so gently upward to
+here. Surely the mercury did not trace this line in any of the
+dimensions of Space generally recognized? But certainly it traced
+such a line, and that line, therefore, we must conclude was along
+the Time-Dimension.'
+
+'But,' said the Medical Man, staring hard at a coal in the fire, 'if
+Time is really only a fourth dimension of Space, why is it, and why
+has it always been, regarded as something different? And why cannot
+we move in Time as we move about in the other dimensions of Space?'
+
+The Time Traveller smiled. 'Are you sure we can move freely in
+Space? Right and left we can go, backward and forward freely enough,
+and men always have done so. I admit we move freely in two
+dimensions. But how about up and down? Gravitation limits us there.'
+
+'Not exactly,' said the Medical Man. 'There are balloons.'
+
+'But before the balloons, save for spasmodic jumping and the
+inequalities of the surface, man had no freedom of vertical
+movement.'
+
+'Still they could move a little up and down,' said the Medical Man.
+
+'Easier, far easier down than up.'
+
+'And you cannot move at all in Time, you cannot get away from the
+present moment.'
+
+'My dear sir, that is just where you are wrong. That is just where
+the whole world has gone wrong. We are always getting away from the
+present moment. Our mental existences, which are immaterial and have
+no dimensions, are passing along the Time-Dimension with a uniform
+velocity from the cradle to the grave. Just as we should travel _down_
+if we began our existence fifty miles above the earth's surface.'
+
+'But the great difficulty is this,' interrupted the Psychologist.
+'You _can_ move about in all directions of Space, but you cannot
+move about in Time.'
+
+'That is the germ of my great discovery. But you are wrong to say
+that we cannot move about in Time. For instance, if I am recalling
+an incident very vividly I go back to the instant of its occurrence:
+I become absent-minded, as you say. I jump back for a moment. Of
+course we have no means of staying back for any length of Time, any
+more than a savage or an animal has of staying six feet above the
+ground. But a civilized man is better off than the savage in this
+respect. He can go up against gravitation in a balloon, and why
+should he not hope that ultimately he may be able to stop or
+accelerate his drift along the Time-Dimension, or even turn about
+and travel the other way?'
+
+'Oh, _this_,' began Filby, 'is all--'
+
+'Why not?' said the Time Traveller.
+
+'It's against reason,' said Filby.
+
+'What reason?' said the Time Traveller.
+
+'You can show black is white by argument,' said Filby, 'but you will
+never convince me.'
+
+'Possibly not,' said the Time Traveller. 'But now you begin to see
+the object of my investigations into the geometry of Four
+Dimensions. Long ago I had a vague inkling of a machine--'
+
+'To travel through Time!' exclaimed the Very Young Man.
+
+'That shall travel indifferently in any direction of Space and Time,
+as the driver determines.'
+
+Filby contented himself with laughter.
+
+'But I have experimental verification,' said the Time Traveller.
+
+'It would be remarkably convenient for the historian,' the
+Psychologist suggested. 'One might travel back and verify the
+accepted account of the Battle of Hastings, for instance!'
+
+'Don't you think you would attract attention?' said the Medical Man.
+'Our ancestors had no great tolerance for anachronisms.'
+
+'One might get one's Greek from the very lips of Homer and Plato,'
+the Very Young Man thought.
+
+'In which case they would certainly plough you for the Little-go.
+The German scholars have improved Greek so much.'
+
+'Then there is the future,' said the Very Young Man. 'Just think!
+One might invest all one's money, leave it to accumulate at
+interest, and hurry on ahead!'
+
+'To discover a society,' said I, 'erected on a strictly communistic
+basis.'
+
+'Of all the wild extravagant theories!' began the Psychologist.
+
+'Yes, so it seemed to me, and so I never talked of it until--'
+
+'Experimental verification!' cried I. 'You are going to verify
+_that_?'
+
+'The experiment!' cried Filby, who was getting brain-weary.
+
+'Let's see your experiment anyhow,' said the Psychologist, 'though
+it's all humbug, you know.'
+
+The Time Traveller smiled round at us. Then, still smiling faintly,
+and with his hands deep in his trousers pockets, he walked slowly
+out of the room, and we heard his slippers shuffling down the long
+passage to his laboratory.
+
+The Psychologist looked at us. 'I wonder what he's got?'
+
+'Some sleight-of-hand trick or other,' said the Medical Man, and
+Filby tried to tell us about a conjurer he had seen at Burslem; but
+before he had finished his preface the Time Traveller came back, and
+Filby's anecdote collapsed.
+
+The thing the Time Traveller held in his hand was a glittering
+metallic framework, scarcely larger than a small clock, and very
+delicately made. There was ivory in it, and some transparent
+crystalline substance. And now I must be explicit, for this that
+follows--unless his explanation is to be accepted--is an absolutely
+unaccountable thing. He took one of the small octagonal tables that
+were scattered about the room, and set it in front of the fire, with
+two legs on the hearthrug. On this table he placed the mechanism.
+Then he drew up a chair, and sat down. The only other object on the
+table was a small shaded lamp, the bright light of which fell upon
+the model. There were also perhaps a dozen candles about, two in
+brass candlesticks upon the mantel and several in sconces, so that
+the room was brilliantly illuminated. I sat in a low arm-chair
+nearest the fire, and I drew this forward so as to be almost between
+the Time Traveller and the fireplace. Filby sat behind him, looking
+over his shoulder. The Medical Man and the Provincial Mayor watched
+him in profile from the right, the Psychologist from the left. The
+Very Young Man stood behind the Psychologist. We were all on the
+alert. It appears incredible to me that any kind of trick, however
+subtly conceived and however adroitly done, could have been played
+upon us under these conditions.
+
+The Time Traveller looked at us, and then at the mechanism. 'Well?'
+said the Psychologist.
+
+'This little affair,' said the Time Traveller, resting his elbows
+upon the table and pressing his hands together above the apparatus,
+'is only a model. It is my plan for a machine to travel through
+time. You will notice that it looks singularly askew, and that there
+is an odd twinkling appearance about this bar, as though it was in
+some way unreal.' He pointed to the part with his finger. 'Also,
+here is one little white lever, and here is another.'
+
+The Medical Man got up out of his chair and peered into the thing.
+'It's beautifully made,' he said.
+
+'It took two years to make,' retorted the Time Traveller. Then, when
+we had all imitated the action of the Medical Man, he said: 'Now I
+want you clearly to understand that this lever, being pressed over,
+sends the machine gliding into the future, and this other reverses
+the motion. This saddle represents the seat of a time traveller.
+Presently I am going to press the lever, and off the machine will
+go. It will vanish, pass into future Time, and disappear. Have a
+good look at the thing. Look at the table too, and satisfy
+yourselves there is no trickery. I don't want to waste this model,
+and then be told I'm a quack.'
+
+There was a minute's pause perhaps. The Psychologist seemed about to
+speak to me, but changed his mind. Then the Time Traveller put forth
+his finger towards the lever. 'No,' he said suddenly. 'Lend me your
+hand.' And turning to the Psychologist, he took that individual's
+hand in his own and told him to put out his forefinger. So that it
+was the Psychologist himself who sent forth the model Time Machine
+on its interminable voyage. We all saw the lever turn. I am
+absolutely certain there was no trickery. There was a breath of
+wind, and the lamp flame jumped. One of the candles on the mantel
+was blown out, and the little machine suddenly swung round, became
+indistinct, was seen as a ghost for a second perhaps, as an eddy of
+faintly glittering brass and ivory; and it was gone--vanished! Save
+for the lamp the table was bare.
+
+Everyone was silent for a minute. Then Filby said he was damned.
+
+The Psychologist recovered from his stupor, and suddenly looked
+under the table. At that the Time Traveller laughed cheerfully.
+'Well?' he said, with a reminiscence of the Psychologist. Then,
+getting up, he went to the tobacco jar on the mantel, and with his
+back to us began to fill his pipe.
+
+We stared at each other. 'Look here,' said the Medical Man, 'are you
+in earnest about this? Do you seriously believe that that machine
+has travelled into time?'
+
+'Certainly,' said the Time Traveller, stooping to light a spill at
+the fire. Then he turned, lighting his pipe, to look at the
+Psychologist's face. (The Psychologist, to show that he was not
+unhinged, helped himself to a cigar and tried to light it uncut.)
+'What is more, I have a big machine nearly finished in there'--he
+indicated the laboratory--'and when that is put together I mean to
+have a journey on my own account.'
+
+'You mean to say that that machine has travelled into the future?'
+said Filby.
+
+'Into the future or the past--I don't, for certain, know which.'
+
+After an interval the Psychologist had an inspiration. 'It must have
+gone into the past if it has gone anywhere,' he said.
+
+'Why?' said the Time Traveller.
+
+'Because I presume that it has not moved in space, and if it
+travelled into the future it would still be here all this time,
+since it must have travelled through this time.'
+
+'But,' I said, 'If it travelled into the past it would have been
+visible when we came first into this room; and last Thursday when we
+were here; and the Thursday before that; and so forth!'
+
+'Serious objections,' remarked the Provincial Mayor, with an air of
+impartiality, turning towards the Time Traveller.
+
+'Not a bit,' said the Time Traveller, and, to the Psychologist: 'You
+think. You can explain that. It's presentation below the threshold,
+you know, diluted presentation.'
+
+'Of course,' said the Psychologist, and reassured us. 'That's a
+simple point of psychology. I should have thought of it. It's plain
+enough, and helps the paradox delightfully. We cannot see it, nor
+can we appreciate this machine, any more than we can the spoke of
+a wheel spinning, or a bullet flying through the air. If it is
+travelling through time fifty times or a hundred times faster than
+we are, if it gets through a minute while we get through a second,
+the impression it creates will of course be only one-fiftieth or
+one-hundredth of what it would make if it were not travelling in
+time. That's plain enough.' He passed his hand through the space in
+which the machine had been. 'You see?' he said, laughing.
+
+We sat and stared at the vacant table for a minute or so. Then the
+Time Traveller asked us what we thought of it all.
+
+'It sounds plausible enough to-night,' said the Medical Man; 'but
+wait until to-morrow. Wait for the common sense of the morning.'
+
+'Would you like to see the Time Machine itself?' asked the Time
+Traveller. And therewith, taking the lamp in his hand, he led the
+way down the long, draughty corridor to his laboratory. I remember
+vividly the flickering light, his queer, broad head in silhouette,
+the dance of the shadows, how we all followed him, puzzled but
+incredulous, and how there in the laboratory we beheld a larger
+edition of the little mechanism which we had seen vanish from before
+our eyes. Parts were of nickel, parts of ivory, parts had certainly
+been filed or sawn out of rock crystal. The thing was generally
+complete, but the twisted crystalline bars lay unfinished upon the
+bench beside some sheets of drawings, and I took one up for a better
+look at it. Quartz it seemed to be.
+
+'Look here,' said the Medical Man, 'are you perfectly serious?
+Or is this a trick--like that ghost you showed us last Christmas?'
+
+'Upon that machine,' said the Time Traveller, holding the lamp
+aloft, 'I intend to explore time. Is that plain? I was never more
+serious in my life.'
+
+None of us quite knew how to take it.
+
+I caught Filby's eye over the shoulder of the Medical Man, and he
+winked at me solemnly.
+
+
+
+
+II
+
+
+I think that at that time none of us quite believed in the Time
+Machine. The fact is, the Time Traveller was one of those men who
+are too clever to be believed: you never felt that you saw all round
+him; you always suspected some subtle reserve, some ingenuity in
+ambush, behind his lucid frankness. Had Filby shown the model and
+explained the matter in the Time Traveller's words, we should have
+shown _him_ far less scepticism. For we should have perceived his
+motives; a pork butcher could understand Filby. But the Time
+Traveller had more than a touch of whim among his elements, and we
+distrusted him. Things that would have made the frame of a less
+clever man seemed tricks in his hands. It is a mistake to do things
+too easily. The serious people who took him seriously never felt
+quite sure of his deportment; they were somehow aware that trusting
+their reputations for judgment with him was like furnishing a
+nursery with egg-shell china. So I don't think any of us said very
+much about time travelling in the interval between that Thursday and
+the next, though its odd potentialities ran, no doubt, in most of
+our minds: its plausibility, that is, its practical incredibleness,
+the curious possibilities of anachronism and of utter confusion it
+suggested. For my own part, I was particularly preoccupied with the
+trick of the model. That I remember discussing with the Medical Man,
+whom I met on Friday at the Linnaean. He said he had seen a similar
+thing at Tubingen, and laid considerable stress on the blowing out
+of the candle. But how the trick was done he could not explain.
+
+The next Thursday I went again to Richmond--I suppose I was one of
+the Time Traveller's most constant guests--and, arriving late, found
+four or five men already assembled in his drawing-room. The Medical
+Man was standing before the fire with a sheet of paper in one hand
+and his watch in the other. I looked round for the Time Traveller,
+and--'It's half-past seven now,' said the Medical Man. 'I suppose
+we'd better have dinner?'
+
+'Where's----?' said I, naming our host.
+
+'You've just come? It's rather odd. He's unavoidably detained. He
+asks me in this note to lead off with dinner at seven if he's not
+back. Says he'll explain when he comes.'
+
+'It seems a pity to let the dinner spoil,' said the Editor of a
+well-known daily paper; and thereupon the Doctor rang the bell.
+
+The Psychologist was the only person besides the Doctor and myself
+who had attended the previous dinner. The other men were Blank, the
+Editor aforementioned, a certain journalist, and another--a quiet,
+shy man with a beard--whom I didn't know, and who, as far as my
+observation went, never opened his mouth all the evening. There was
+some speculation at the dinner-table about the Time Traveller's
+absence, and I suggested time travelling, in a half-jocular spirit.
+The Editor wanted that explained to him, and the Psychologist
+volunteered a wooden account of the 'ingenious paradox and trick' we
+had witnessed that day week. He was in the midst of his exposition
+when the door from the corridor opened slowly and without noise. I
+was facing the door, and saw it first. 'Hallo!' I said. 'At last!'
+And the door opened wider, and the Time Traveller stood before us.
+I gave a cry of surprise. 'Good heavens! man, what's the matter?'
+cried the Medical Man, who saw him next. And the whole tableful
+turned towards the door.
+
+He was in an amazing plight. His coat was dusty and dirty, and
+smeared with green down the sleeves; his hair disordered, and as it
+seemed to me greyer--either with dust and dirt or because its colour
+had actually faded. His face was ghastly pale; his chin had a brown
+cut on it--a cut half healed; his expression was haggard and drawn,
+as by intense suffering. For a moment he hesitated in the doorway,
+as if he had been dazzled by the light. Then he came into the room.
+He walked with just such a limp as I have seen in footsore tramps.
+We stared at him in silence, expecting him to speak.
+
+He said not a word, but came painfully to the table, and made a
+motion towards the wine. The Editor filled a glass of champagne, and
+pushed it towards him. He drained it, and it seemed to do him good:
+for he looked round the table, and the ghost of his old smile
+flickered across his face. 'What on earth have you been up to, man?'
+said the Doctor. The Time Traveller did not seem to hear. 'Don't let
+me disturb you,' he said, with a certain faltering articulation.
+'I'm all right.' He stopped, held out his glass for more, and took
+it off at a draught. 'That's good,' he said. His eyes grew brighter,
+and a faint colour came into his cheeks. His glance flickered over
+our faces with a certain dull approval, and then went round the warm
+and comfortable room. Then he spoke again, still as it were feeling
+his way among his words. 'I'm going to wash and dress, and then I'll
+come down and explain things ... Save me some of that mutton. I'm
+starving for a bit of meat.'
+
+He looked across at the Editor, who was a rare visitor, and hoped he
+was all right. The Editor began a question. 'Tell you presently,'
+said the Time Traveller. 'I'm--funny! Be all right in a minute.'
+
+He put down his glass, and walked towards the staircase door. Again
+I remarked his lameness and the soft padding sound of his footfall,
+and standing up in my place, I saw his feet as he went out. He had
+nothing on them but a pair of tattered, blood-stained socks. Then the
+door closed upon him. I had half a mind to follow, till I remembered
+how he detested any fuss about himself. For a minute, perhaps, my
+mind was wool-gathering. Then, 'Remarkable Behaviour of an Eminent
+Scientist,' I heard the Editor say, thinking (after his wont) in
+headlines. And this brought my attention back to the bright
+dinner-table.
+
+'What's the game?' said the Journalist. 'Has he been doing the
+Amateur Cadger? I don't follow.' I met the eye of the Psychologist,
+and read my own interpretation in his face. I thought of the Time
+Traveller limping painfully upstairs. I don't think any one else had
+noticed his lameness.
+
+The first to recover completely from this surprise was the Medical
+Man, who rang the bell--the Time Traveller hated to have servants
+waiting at dinner--for a hot plate. At that the Editor turned to his
+knife and fork with a grunt, and the Silent Man followed suit. The
+dinner was resumed. Conversation was exclamatory for a little while,
+with gaps of wonderment; and then the Editor got fervent in his
+curiosity. 'Does our friend eke out his modest income with a
+crossing? or has he his Nebuchadnezzar phases?' he inquired. 'I feel
+assured it's this business of the Time Machine,' I said, and took up
+the Psychologist's account of our previous meeting. The new guests
+were frankly incredulous. The Editor raised objections. 'What _was_
+this time travelling? A man couldn't cover himself with dust by
+rolling in a paradox, could he?' And then, as the idea came home to
+him, he resorted to caricature. Hadn't they any clothes-brushes in
+the Future? The Journalist too, would not believe at any price, and
+joined the Editor in the easy work of heaping ridicule on the whole
+thing. They were both the new kind of journalist--very joyous,
+irreverent young men. 'Our Special Correspondent in the Day
+after To-morrow reports,' the Journalist was saying--or rather
+shouting--when the Time Traveller came back. He was dressed in
+ordinary evening clothes, and nothing save his haggard look remained
+of the change that had startled me.
+
+'I say,' said the Editor hilariously, 'these chaps here say you have
+been travelling into the middle of next week! Tell us all about
+little Rosebery, will you? What will you take for the lot?'
+
+The Time Traveller came to the place reserved for him without a
+word. He smiled quietly, in his old way. 'Where's my mutton?' he
+said. 'What a treat it is to stick a fork into meat again!'
+
+'Story!' cried the Editor.
+
+'Story be damned!' said the Time Traveller. 'I want something to
+eat. I won't say a word until I get some peptone into my arteries.
+Thanks. And the salt.'
+
+'One word,' said I. 'Have you been time travelling?'
+
+'Yes,' said the Time Traveller, with his mouth full, nodding his
+head.
+
+'I'd give a shilling a line for a verbatim note,' said the Editor.
+The Time Traveller pushed his glass towards the Silent Man and rang
+it with his fingernail; at which the Silent Man, who had been
+staring at his face, started convulsively, and poured him wine.
+The rest of the dinner was uncomfortable. For my own part, sudden
+questions kept on rising to my lips, and I dare say it was the same
+with the others. The Journalist tried to relieve the tension by
+telling anecdotes of Hettie Potter. The Time Traveller devoted his
+attention to his dinner, and displayed the appetite of a tramp.
+The Medical Man smoked a cigarette, and watched the Time Traveller
+through his eyelashes. The Silent Man seemed even more clumsy than
+usual, and drank champagne with regularity and determination out of
+sheer nervousness. At last the Time Traveller pushed his plate away,
+and looked round us. 'I suppose I must apologize,' he said. 'I was
+simply starving. I've had a most amazing time.' He reached out his
+hand for a cigar, and cut the end. 'But come into the smoking-room.
+It's too long a story to tell over greasy plates.' And ringing the
+bell in passing, he led the way into the adjoining room.
+
+'You have told Blank, and Dash, and Chose about the machine?' he
+said to me, leaning back in his easy-chair and naming the three new
+guests.
+
+'But the thing's a mere paradox,' said the Editor.
+
+'I can't argue to-night. I don't mind telling you the story, but
+I can't argue. I will,' he went on, 'tell you the story of what
+has happened to me, if you like, but you must refrain from
+interruptions. I want to tell it. Badly. Most of it will sound like
+lying. So be it! It's true--every word of it, all the same. I was in
+my laboratory at four o'clock, and since then ... I've lived eight
+days ... such days as no human being ever lived before! I'm nearly
+worn out, but I shan't sleep till I've told this thing over to you.
+Then I shall go to bed. But no interruptions! Is it agreed?'
+
+'Agreed,' said the Editor, and the rest of us echoed 'Agreed.' And
+with that the Time Traveller began his story as I have set it forth.
+He sat back in his chair at first, and spoke like a weary man.
+Afterwards he got more animated. In writing it down I feel with only
+too much keenness the inadequacy of pen and ink--and, above all, my
+own inadequacy--to express its quality. You read, I will suppose,
+attentively enough; but you cannot see the speaker's white,
+sincere face in the bright circle of the little lamp, nor hear the
+intonation of his voice. You cannot know how his expression followed
+the turns of his story! Most of us hearers were in shadow, for the
+candles in the smoking-room had not been lighted, and only the face
+of the Journalist and the legs of the Silent Man from the knees
+downward were illuminated. At first we glanced now and again at each
+other. After a time we ceased to do that, and looked only at the
+Time Traveller's face.
+
+
+
+
+III
+
+
+'I told some of you last Thursday of the principles of the Time
+Machine, and showed you the actual thing itself, incomplete in the
+workshop. There it is now, a little travel-worn, truly; and one of
+the ivory bars is cracked, and a brass rail bent; but the rest of
+it's sound enough. I expected to finish it on Friday, but on Friday,
+when the putting together was nearly done, I found that one of the
+nickel bars was exactly one inch too short, and this I had to get
+remade; so that the thing was not complete until this morning. It
+was at ten o'clock to-day that the first of all Time Machines began
+its career. I gave it a last tap, tried all the screws again, put
+one more drop of oil on the quartz rod, and sat myself in the
+saddle. I suppose a suicide who holds a pistol to his skull feels
+much the same wonder at what will come next as I felt then. I took
+the starting lever in one hand and the stopping one in the other,
+pressed the first, and almost immediately the second. I seemed to
+reel; I felt a nightmare sensation of falling; and, looking round,
+I saw the laboratory exactly as before. Had anything happened? For
+a moment I suspected that my intellect had tricked me. Then I noted
+the clock. A moment before, as it seemed, it had stood at a minute
+or so past ten; now it was nearly half-past three!
+
+'I drew a breath, set my teeth, gripped the starting lever with both
+hands, and went off with a thud. The laboratory got hazy and went
+dark. Mrs. Watchett came in and walked, apparently without seeing
+me, towards the garden door. I suppose it took her a minute or so to
+traverse the place, but to me she seemed to shoot across the room
+like a rocket. I pressed the lever over to its extreme position. The
+night came like the turning out of a lamp, and in another moment
+came to-morrow. The laboratory grew faint and hazy, then fainter
+and ever fainter. To-morrow night came black, then day again, night
+again, day again, faster and faster still. An eddying murmur filled
+my ears, and a strange, dumb confusedness descended on my mind.
+
+'I am afraid I cannot convey the peculiar sensations of time
+travelling. They are excessively unpleasant. There is a feeling
+exactly like that one has upon a switchback--of a helpless headlong
+motion! I felt the same horrible anticipation, too, of an imminent
+smash. As I put on pace, night followed day like the flapping of a
+black wing. The dim suggestion of the laboratory seemed presently to
+fall away from me, and I saw the sun hopping swiftly across the sky,
+leaping it every minute, and every minute marking a day. I supposed
+the laboratory had been destroyed and I had come into the open air.
+I had a dim impression of scaffolding, but I was already going too
+fast to be conscious of any moving things. The slowest snail that
+ever crawled dashed by too fast for me. The twinkling succession of
+darkness and light was excessively painful to the eye. Then, in the
+intermittent darknesses, I saw the moon spinning swiftly through her
+quarters from new to full, and had a faint glimpse of the circling
+stars. Presently, as I went on, still gaining velocity, the
+palpitation of night and day merged into one continuous greyness;
+the sky took on a wonderful deepness of blue, a splendid luminous
+color like that of early twilight; the jerking sun became a streak
+of fire, a brilliant arch, in space; the moon a fainter fluctuating
+band; and I could see nothing of the stars, save now and then a
+brighter circle flickering in the blue.
+
+'The landscape was misty and vague. I was still on the hill-side
+upon which this house now stands, and the shoulder rose above me
+grey and dim. I saw trees growing and changing like puffs of vapour,
+now brown, now green; they grew, spread, shivered, and passed away.
+I saw huge buildings rise up faint and fair, and pass like dreams.
+The whole surface of the earth seemed changed--melting and flowing
+under my eyes. The little hands upon the dials that registered my
+speed raced round faster and faster. Presently I noted that the sun
+belt swayed up and down, from solstice to solstice, in a minute or
+less, and that consequently my pace was over a year a minute; and
+minute by minute the white snow flashed across the world, and
+vanished, and was followed by the bright, brief green of spring.
+
+'The unpleasant sensations of the start were less poignant now. They
+merged at last into a kind of hysterical exhilaration. I remarked
+indeed a clumsy swaying of the machine, for which I was unable to
+account. But my mind was too confused to attend to it, so with a
+kind of madness growing upon me, I flung myself into futurity. At
+first I scarce thought of stopping, scarce thought of anything but
+these new sensations. But presently a fresh series of impressions
+grew up in my mind--a certain curiosity and therewith a certain
+dread--until at last they took complete possession of me. What
+strange developments of humanity, what wonderful advances upon our
+rudimentary civilization, I thought, might not appear when I came to
+look nearly into the dim elusive world that raced and fluctuated
+before my eyes! I saw great and splendid architecture rising about
+me, more massive than any buildings of our own time, and yet, as it
+seemed, built of glimmer and mist. I saw a richer green flow up the
+hill-side, and remain there, without any wintry intermission. Even
+through the veil of my confusion the earth seemed very fair. And so
+my mind came round to the business of stopping.
+
+'The peculiar risk lay in the possibility of my finding some
+substance in the space which I, or the machine, occupied. So long
+as I travelled at a high velocity through time, this scarcely
+mattered; I was, so to speak, attenuated--was slipping like a vapour
+through the interstices of intervening substances! But to come to
+a stop involved the jamming of myself, molecule by molecule, into
+whatever lay in my way; meant bringing my atoms into such intimate
+contact with those of the obstacle that a profound chemical
+reaction--possibly a far-reaching explosion--would result, and blow
+myself and my apparatus out of all possible dimensions--into the
+Unknown. This possibility had occurred to me again and again while I
+was making the machine; but then I had cheerfully accepted it as an
+unavoidable risk--one of the risks a man has got to take! Now the
+risk was inevitable, I no longer saw it in the same cheerful light.
+The fact is that, insensibly, the absolute strangeness of everything,
+the sickly jarring and swaying of the machine, above all, the
+feeling of prolonged falling, had absolutely upset my nerve. I told
+myself that I could never stop, and with a gust of petulance I
+resolved to stop forthwith. Like an impatient fool, I lugged over
+the lever, and incontinently the thing went reeling over, and I was
+flung headlong through the air.
+
+'There was the sound of a clap of thunder in my ears. I may have
+been stunned for a moment. A pitiless hail was hissing round me,
+and I was sitting on soft turf in front of the overset machine.
+Everything still seemed grey, but presently I remarked that the
+confusion in my ears was gone. I looked round me. I was on what
+seemed to be a little lawn in a garden, surrounded by rhododendron
+bushes, and I noticed that their mauve and purple blossoms were
+dropping in a shower under the beating of the hail-stones. The
+rebounding, dancing hail hung in a cloud over the machine, and drove
+along the ground like smoke. In a moment I was wet to the skin.
+"Fine hospitality," said I, "to a man who has travelled innumerable
+years to see you."
+
+'Presently I thought what a fool I was to get wet. I stood up and
+looked round me. A colossal figure, carved apparently in some white
+stone, loomed indistinctly beyond the rhododendrons through the hazy
+downpour. But all else of the world was invisible.
+
+'My sensations would be hard to describe. As the columns of hail
+grew thinner, I saw the white figure more distinctly. It was very
+large, for a silver birch-tree touched its shoulder. It was of white
+marble, in shape something like a winged sphinx, but the wings,
+instead of being carried vertically at the sides, were spread so
+that it seemed to hover. The pedestal, it appeared to me, was of
+bronze, and was thick with verdigris. It chanced that the face was
+towards me; the sightless eyes seemed to watch me; there was the
+faint shadow of a smile on the lips. It was greatly weather-worn,
+and that imparted an unpleasant suggestion of disease. I stood
+looking at it for a little space--half a minute, perhaps, or half an
+hour. It seemed to advance and to recede as the hail drove before it
+denser or thinner. At last I tore my eyes from it for a moment and
+saw that the hail curtain had worn threadbare, and that the sky was
+lightening with the promise of the sun.
+
+'I looked up again at the crouching white shape, and the full
+temerity of my voyage came suddenly upon me. What might appear when
+that hazy curtain was altogether withdrawn? What might not have
+happened to men? What if cruelty had grown into a common passion?
+What if in this interval the race had lost its manliness and had
+developed into something inhuman, unsympathetic, and overwhelmingly
+powerful? I might seem some old-world savage animal, only the more
+dreadful and disgusting for our common likeness--a foul creature to
+be incontinently slain.
+
+'Already I saw other vast shapes--huge buildings with intricate
+parapets and tall columns, with a wooded hill-side dimly creeping
+in upon me through the lessening storm. I was seized with a panic
+fear. I turned frantically to the Time Machine, and strove hard to
+readjust it. As I did so the shafts of the sun smote through the
+thunderstorm. The grey downpour was swept aside and vanished like
+the trailing garments of a ghost. Above me, in the intense blue
+of the summer sky, some faint brown shreds of cloud whirled into
+nothingness. The great buildings about me stood out clear and
+distinct, shining with the wet of the thunderstorm, and picked out
+in white by the unmelted hailstones piled along their courses. I
+felt naked in a strange world. I felt as perhaps a bird may feel in
+the clear air, knowing the hawk wings above and will swoop. My fear
+grew to frenzy. I took a breathing space, set my teeth, and again
+grappled fiercely, wrist and knee, with the machine. It gave under
+my desperate onset and turned over. It struck my chin violently. One
+hand on the saddle, the other on the lever, I stood panting heavily
+in attitude to mount again.
+
+'But with this recovery of a prompt retreat my courage recovered. I
+looked more curiously and less fearfully at this world of the remote
+future. In a circular opening, high up in the wall of the nearer
+house, I saw a group of figures clad in rich soft robes. They had
+seen me, and their faces were directed towards me.
+
+'Then I heard voices approaching me. Coming through the bushes by
+the White Sphinx were the heads and shoulders of men running. One of
+these emerged in a pathway leading straight to the little lawn upon
+which I stood with my machine. He was a slight creature--perhaps
+four feet high--clad in a purple tunic, girdled at the waist with a
+leather belt. Sandals or buskins--I could not clearly distinguish
+which--were on his feet; his legs were bare to the knees, and his
+head was bare. Noticing that, I noticed for the first time how warm
+the air was.
+
+'He struck me as being a very beautiful and graceful creature, but
+indescribably frail. His flushed face reminded me of the more
+beautiful kind of consumptive--that hectic beauty of which we used
+to hear so much. At the sight of him I suddenly regained confidence.
+I took my hands from the machine.
+
+
+
+
+IV
+
+
+'In another moment we were standing face to face, I and this fragile
+thing out of futurity. He came straight up to me and laughed into my
+eyes. The absence from his bearing of any sign of fear struck me at
+once. Then he turned to the two others who were following him and
+spoke to them in a strange and very sweet and liquid tongue.
+
+'There were others coming, and presently a little group of perhaps
+eight or ten of these exquisite creatures were about me. One of them
+addressed me. It came into my head, oddly enough, that my voice was
+too harsh and deep for them. So I shook my head, and, pointing to my
+ears, shook it again. He came a step forward, hesitated, and then
+touched my hand. Then I felt other soft little tentacles upon my
+back and shoulders. They wanted to make sure I was real. There was
+nothing in this at all alarming. Indeed, there was something in
+these pretty little people that inspired confidence--a graceful
+gentleness, a certain childlike ease. And besides, they looked so
+frail that I could fancy myself flinging the whole dozen of them
+about like nine-pins. But I made a sudden motion to warn them when I
+saw their little pink hands feeling at the Time Machine. Happily
+then, when it was not too late, I thought of a danger I had hitherto
+forgotten, and reaching over the bars of the machine I unscrewed the
+little levers that would set it in motion, and put these in my
+pocket. Then I turned again to see what I could do in the way of
+communication.
+
+'And then, looking more nearly into their features, I saw some
+further peculiarities in their Dresden-china type of prettiness.
+Their hair, which was uniformly curly, came to a sharp end at the
+neck and cheek; there was not the faintest suggestion of it on the
+face, and their ears were singularly minute. The mouths were small,
+with bright red, rather thin lips, and the little chins ran to a
+point. The eyes were large and mild; and--this may seem egotism on
+my part--I fancied even that there was a certain lack of the
+interest I might have expected in them.
+
+'As they made no effort to communicate with me, but simply stood
+round me smiling and speaking in soft cooing notes to each other, I
+began the conversation. I pointed to the Time Machine and to myself.
+Then hesitating for a moment how to express time, I pointed to the
+sun. At once a quaintly pretty little figure in chequered purple and
+white followed my gesture, and then astonished me by imitating the
+sound of thunder.
+
+'For a moment I was staggered, though the import of his gesture was
+plain enough. The question had come into my mind abruptly: were
+these creatures fools? You may hardly understand how it took me.
+You see I had always anticipated that the people of the year Eight
+Hundred and Two Thousand odd would be incredibly in front of us in
+knowledge, art, everything. Then one of them suddenly asked me a
+question that showed him to be on the intellectual level of one of
+our five-year-old children--asked me, in fact, if I had come from
+the sun in a thunderstorm! It let loose the judgment I had suspended
+upon their clothes, their frail light limbs, and fragile features.
+A flow of disappointment rushed across my mind. For a moment I felt
+that I had built the Time Machine in vain.
+
+'I nodded, pointed to the sun, and gave them such a vivid rendering
+of a thunderclap as startled them. They all withdrew a pace or so
+and bowed. Then came one laughing towards me, carrying a chain of
+beautiful flowers altogether new to me, and put it about my neck.
+The idea was received with melodious applause; and presently they
+were all running to and fro for flowers, and laughingly flinging
+them upon me until I was almost smothered with blossom. You who
+have never seen the like can scarcely imagine what delicate and
+wonderful flowers countless years of culture had created. Then
+someone suggested that their plaything should be exhibited in the
+nearest building, and so I was led past the sphinx of white marble,
+which had seemed to watch me all the while with a smile at my
+astonishment, towards a vast grey edifice of fretted stone. As I
+went with them the memory of my confident anticipations of a
+profoundly grave and intellectual posterity came, with irresistible
+merriment, to my mind.
+
+'The building had a huge entry, and was altogether of colossal
+dimensions. I was naturally most occupied with the growing crowd of
+little people, and with the big open portals that yawned before me
+shadowy and mysterious. My general impression of the world I saw
+over their heads was a tangled waste of beautiful bushes and
+flowers, a long neglected and yet weedless garden. I saw a number
+of tall spikes of strange white flowers, measuring a foot perhaps
+across the spread of the waxen petals. They grew scattered, as if
+wild, among the variegated shrubs, but, as I say, I did not examine
+them closely at this time. The Time Machine was left deserted on the
+turf among the rhododendrons.
+
+'The arch of the doorway was richly carved, but naturally I did
+not observe the carving very narrowly, though I fancied I saw
+suggestions of old Phoenician decorations as I passed through, and
+it struck me that they were very badly broken and weather-worn.
+Several more brightly clad people met me in the doorway, and so we
+entered, I, dressed in dingy nineteenth-century garments, looking
+grotesque enough, garlanded with flowers, and surrounded by an
+eddying mass of bright, soft-colored robes and shining white limbs,
+in a melodious whirl of laughter and laughing speech.
+
+'The big doorway opened into a proportionately great hall hung with
+brown. The roof was in shadow, and the windows, partially glazed
+with coloured glass and partially unglazed, admitted a tempered
+light. The floor was made up of huge blocks of some very hard white
+metal, not plates nor slabs--blocks, and it was so much worn, as I
+judged by the going to and fro of past generations, as to be deeply
+channelled along the more frequented ways. Transverse to the length
+were innumerable tables made of slabs of polished stone, raised
+perhaps a foot from the floor, and upon these were heaps of fruits.
+Some I recognized as a kind of hypertrophied raspberry and orange,
+but for the most part they were strange.
+
+'Between the tables was scattered a great number of cushions.
+Upon these my conductors seated themselves, signing for me to do
+likewise. With a pretty absence of ceremony they began to eat the
+fruit with their hands, flinging peel and stalks, and so forth, into
+the round openings in the sides of the tables. I was not loath to
+follow their example, for I felt thirsty and hungry. As I did so I
+surveyed the hall at my leisure.
+
+'And perhaps the thing that struck me most was its dilapidated look.
+The stained-glass windows, which displayed only a geometrical
+pattern, were broken in many places, and the curtains that hung
+across the lower end were thick with dust. And it caught my eye that
+the corner of the marble table near me was fractured. Nevertheless,
+the general effect was extremely rich and picturesque. There were,
+perhaps, a couple of hundred people dining in the hall, and most of
+them, seated as near to me as they could come, were watching me with
+interest, their little eyes shining over the fruit they were eating.
+All were clad in the same soft and yet strong, silky material.
+
+'Fruit, by the by, was all their diet. These people of the remote
+future were strict vegetarians, and while I was with them, in spite
+of some carnal cravings, I had to be frugivorous also. Indeed, I
+found afterwards that horses, cattle, sheep, dogs, had followed the
+Ichthyosaurus into extinction. But the fruits were very delightful;
+one, in particular, that seemed to be in season all the time I was
+there--a floury thing in a three-sided husk--was especially good,
+and I made it my staple. At first I was puzzled by all these strange
+fruits, and by the strange flowers I saw, but later I began to
+perceive their import.
+
+'However, I am telling you of my fruit dinner in the distant future
+now. So soon as my appetite was a little checked, I determined to
+make a resolute attempt to learn the speech of these new men of
+mine. Clearly that was the next thing to do. The fruits seemed a
+convenient thing to begin upon, and holding one of these up I began
+a series of interrogative sounds and gestures. I had some
+considerable difficulty in conveying my meaning. At first my efforts
+met with a stare of surprise or inextinguishable laughter, but
+presently a fair-haired little creature seemed to grasp my intention
+and repeated a name. They had to chatter and explain the business
+at great length to each other, and my first attempts to make the
+exquisite little sounds of their language caused an immense amount
+of amusement. However, I felt like a schoolmaster amidst children,
+and persisted, and presently I had a score of noun substantives at
+least at my command; and then I got to demonstrative pronouns, and
+even the verb "to eat." But it was slow work, and the little people
+soon tired and wanted to get away from my interrogations, so I
+determined, rather of necessity, to let them give their lessons in
+little doses when they felt inclined. And very little doses I found
+they were before long, for I never met people more indolent or more
+easily fatigued.
+
+'A queer thing I soon discovered about my little hosts, and that was
+their lack of interest. They would come to me with eager cries of
+astonishment, like children, but like children they would soon stop
+examining me and wander away after some other toy. The dinner and my
+conversational beginnings ended, I noted for the first time that
+almost all those who had surrounded me at first were gone. It is
+odd, too, how speedily I came to disregard these little people. I
+went out through the portal into the sunlit world again as soon as
+my hunger was satisfied. I was continually meeting more of these men
+of the future, who would follow me a little distance, chatter and
+laugh about me, and, having smiled and gesticulated in a friendly
+way, leave me again to my own devices.
+
+'The calm of evening was upon the world as I emerged from the great
+hall, and the scene was lit by the warm glow of the setting sun.
+At first things were very confusing. Everything was so entirely
+different from the world I had known--even the flowers. The big
+building I had left was situated on the slope of a broad river
+valley, but the Thames had shifted perhaps a mile from its present
+position. I resolved to mount to the summit of a crest, perhaps a
+mile and a half away, from which I could get a wider view of this
+our planet in the year Eight Hundred and Two Thousand Seven Hundred
+and One A.D. For that, I should explain, was the date the little
+dials of my machine recorded.
+
+'As I walked I was watching for every impression that could possibly
+help to explain the condition of ruinous splendour in which I
+found the world--for ruinous it was. A little way up the hill, for
+instance, was a great heap of granite, bound together by masses of
+aluminium, a vast labyrinth of precipitous walls and crumpled
+heaps, amidst which were thick heaps of very beautiful pagoda-like
+plants--nettles possibly--but wonderfully tinted with brown about
+the leaves, and incapable of stinging. It was evidently the derelict
+remains of some vast structure, to what end built I could not
+determine. It was here that I was destined, at a later date, to have
+a very strange experience--the first intimation of a still stranger
+discovery--but of that I will speak in its proper place.
+
+'Looking round with a sudden thought, from a terrace on which I
+rested for a while, I realized that there were no small houses to be
+seen. Apparently the single house, and possibly even the household,
+had vanished. Here and there among the greenery were palace-like
+buildings, but the house and the cottage, which form such
+characteristic features of our own English landscape, had
+disappeared.
+
+'"Communism," said I to myself.
+
+'And on the heels of that came another thought. I looked at the
+half-dozen little figures that were following me. Then, in a flash,
+I perceived that all had the same form of costume, the same soft
+hairless visage, and the same girlish rotundity of limb. It may seem
+strange, perhaps, that I had not noticed this before. But everything
+was so strange. Now, I saw the fact plainly enough. In costume, and
+in all the differences of texture and bearing that now mark off the
+sexes from each other, these people of the future were alike. And
+the children seemed to my eyes to be but the miniatures of their
+parents. I judged, then, that the children of that time were
+extremely precocious, physically at least, and I found afterwards
+abundant verification of my opinion.
+
+'Seeing the ease and security in which these people were living, I
+felt that this close resemblance of the sexes was after all what
+one would expect; for the strength of a man and the softness of a
+woman, the institution of the family, and the differentiation of
+occupations are mere militant necessities of an age of physical
+force; where population is balanced and abundant, much childbearing
+becomes an evil rather than a blessing to the State; where
+violence comes but rarely and off-spring are secure, there is less
+necessity--indeed there is no necessity--for an efficient family,
+and the specialization of the sexes with reference to their
+children's needs disappears. We see some beginnings of this even
+in our own time, and in this future age it was complete. This, I
+must remind you, was my speculation at the time. Later, I was to
+appreciate how far it fell short of the reality.
+
+'While I was musing upon these things, my attention was attracted by
+a pretty little structure, like a well under a cupola. I thought in
+a transitory way of the oddness of wells still existing, and then
+resumed the thread of my speculations. There were no large buildings
+towards the top of the hill, and as my walking powers were evidently
+miraculous, I was presently left alone for the first time. With a
+strange sense of freedom and adventure I pushed on up to the crest.
+
+'There I found a seat of some yellow metal that I did not recognize,
+corroded in places with a kind of pinkish rust and half smothered
+in soft moss, the arm-rests cast and filed into the resemblance of
+griffins' heads. I sat down on it, and I surveyed the broad view of
+our old world under the sunset of that long day. It was as sweet and
+fair a view as I have ever seen. The sun had already gone below the
+horizon and the west was flaming gold, touched with some horizontal
+bars of purple and crimson. Below was the valley of the Thames, in
+which the river lay like a band of burnished steel. I have already
+spoken of the great palaces dotted about among the variegated
+greenery, some in ruins and some still occupied. Here and there rose
+a white or silvery figure in the waste garden of the earth, here and
+there came the sharp vertical line of some cupola or obelisk. There
+were no hedges, no signs of proprietary rights, no evidences of
+agriculture; the whole earth had become a garden.
+
+'So watching, I began to put my interpretation upon the things I had
+seen, and as it shaped itself to me that evening, my interpretation
+was something in this way. (Afterwards I found I had got only a
+half-truth--or only a glimpse of one facet of the truth.)
+
+'It seemed to me that I had happened upon humanity upon the wane.
+The ruddy sunset set me thinking of the sunset of mankind. For the
+first time I began to realize an odd consequence of the social
+effort in which we are at present engaged. And yet, come to think,
+it is a logical consequence enough. Strength is the outcome of need;
+security sets a premium on feebleness. The work of ameliorating the
+conditions of life--the true civilizing process that makes life more
+and more secure--had gone steadily on to a climax. One triumph of a
+united humanity over Nature had followed another. Things that are
+now mere dreams had become projects deliberately put in hand and
+carried forward. And the harvest was what I saw!
+
+'After all, the sanitation and the agriculture of to-day are still
+in the rudimentary stage. The science of our time has attacked but
+a little department of the field of human disease, but even so,
+it spreads its operations very steadily and persistently. Our
+agriculture and horticulture destroy a weed just here and there and
+cultivate perhaps a score or so of wholesome plants, leaving the
+greater number to fight out a balance as they can. We improve our
+favourite plants and animals--and how few they are--gradually by
+selective breeding; now a new and better peach, now a seedless
+grape, now a sweeter and larger flower, now a more convenient breed
+of cattle. We improve them gradually, because our ideals are vague
+and tentative, and our knowledge is very limited; because Nature,
+too, is shy and slow in our clumsy hands. Some day all this will
+be better organized, and still better. That is the drift of the
+current in spite of the eddies. The whole world will be intelligent,
+educated, and co-operating; things will move faster and faster
+towards the subjugation of Nature. In the end, wisely and carefully
+we shall readjust the balance of animal and vegetable life to suit
+our human needs.
+
+'This adjustment, I say, must have been done, and done well; done
+indeed for all Time, in the space of Time across which my machine
+had leaped. The air was free from gnats, the earth from weeds or
+fungi; everywhere were fruits and sweet and delightful flowers;
+brilliant butterflies flew hither and thither. The ideal of
+preventive medicine was attained. Diseases had been stamped out. I
+saw no evidence of any contagious diseases during all my stay. And I
+shall have to tell you later that even the processes of putrefaction
+and decay had been profoundly affected by these changes.
+
+'Social triumphs, too, had been effected. I saw mankind housed in
+splendid shelters, gloriously clothed, and as yet I had found them
+engaged in no toil. There were no signs of struggle, neither social
+nor economical struggle. The shop, the advertisement, traffic, all
+that commerce which constitutes the body of our world, was gone. It
+was natural on that golden evening that I should jump at the idea of
+a social paradise. The difficulty of increasing population had been
+met, I guessed, and population had ceased to increase.
+
+'But with this change in condition comes inevitably adaptations to
+the change. What, unless biological science is a mass of errors, is
+the cause of human intelligence and vigour? Hardship and freedom:
+conditions under which the active, strong, and subtle survive and
+the weaker go to the wall; conditions that put a premium upon the
+loyal alliance of capable men, upon self-restraint, patience, and
+decision. And the institution of the family, and the emotions that
+arise therein, the fierce jealousy, the tenderness for offspring,
+parental self-devotion, all found their justification and support in
+the imminent dangers of the young. _Now_, where are these imminent
+dangers? There is a sentiment arising, and it will grow, against
+connubial jealousy, against fierce maternity, against passion
+of all sorts; unnecessary things now, and things that make us
+uncomfortable, savage survivals, discords in a refined and pleasant
+life.
+
+'I thought of the physical slightness of the people, their lack of
+intelligence, and those big abundant ruins, and it strengthened my
+belief in a perfect conquest of Nature. For after the battle comes
+Quiet. Humanity had been strong, energetic, and intelligent, and had
+used all its abundant vitality to alter the conditions under which
+it lived. And now came the reaction of the altered conditions.
+
+'Under the new conditions of perfect comfort and security, that
+restless energy, that with us is strength, would become weakness.
+Even in our own time certain tendencies and desires, once necessary
+to survival, are a constant source of failure. Physical courage and
+the love of battle, for instance, are no great help--may even be
+hindrances--to a civilized man. And in a state of physical balance
+and security, power, intellectual as well as physical, would be out
+of place. For countless years I judged there had been no danger of
+war or solitary violence, no danger from wild beasts, no wasting
+disease to require strength of constitution, no need of toil. For
+such a life, what we should call the weak are as well equipped as
+the strong, are indeed no longer weak. Better equipped indeed they
+are, for the strong would be fretted by an energy for which there
+was no outlet. No doubt the exquisite beauty of the buildings I saw
+was the outcome of the last surgings of the now purposeless energy
+of mankind before it settled down into perfect harmony with the
+conditions under which it lived--the flourish of that triumph which
+began the last great peace. This has ever been the fate of energy in
+security; it takes to art and to eroticism, and then come languor
+and decay.
+
+'Even this artistic impetus would at last die away--had almost died
+in the Time I saw. To adorn themselves with flowers, to dance, to
+sing in the sunlight: so much was left of the artistic spirit, and
+no more. Even that would fade in the end into a contented
+inactivity. We are kept keen on the grindstone of pain and
+necessity, and, it seemed to me, that here was that hateful
+grindstone broken at last!
+
+'As I stood there in the gathering dark I thought that in this
+simple explanation I had mastered the problem of the world--mastered
+the whole secret of these delicious people. Possibly the checks they
+had devised for the increase of population had succeeded too well,
+and their numbers had rather diminished than kept stationary.
+That would account for the abandoned ruins. Very simple was my
+explanation, and plausible enough--as most wrong theories are!
+
+
+
+
+V
+
+
+'As I stood there musing over this too perfect triumph of man, the
+full moon, yellow and gibbous, came up out of an overflow of silver
+light in the north-east. The bright little figures ceased to move
+about below, a noiseless owl flitted by, and I shivered with the
+chill of the night. I determined to descend and find where I could
+sleep.
+
+'I looked for the building I knew. Then my eye travelled along to
+the figure of the White Sphinx upon the pedestal of bronze, growing
+distinct as the light of the rising moon grew brighter. I could see
+the silver birch against it. There was the tangle of rhododendron
+bushes, black in the pale light, and there was the little lawn.
+I looked at the lawn again. A queer doubt chilled my complacency.
+"No," said I stoutly to myself, "that was not the lawn."
+
+'But it _was_ the lawn. For the white leprous face of the sphinx was
+towards it. Can you imagine what I felt as this conviction came
+home to me? But you cannot. The Time Machine was gone!
+
+'At once, like a lash across the face, came the possibility of
+losing my own age, of being left helpless in this strange new world.
+The bare thought of it was an actual physical sensation. I could
+feel it grip me at the throat and stop my breathing. In another
+moment I was in a passion of fear and running with great leaping
+strides down the slope. Once I fell headlong and cut my face; I lost
+no time in stanching the blood, but jumped up and ran on, with a
+warm trickle down my cheek and chin. All the time I ran I was saying
+to myself: "They have moved it a little, pushed it under the bushes
+out of the way." Nevertheless, I ran with all my might. All the
+time, with the certainty that sometimes comes with excessive dread,
+I knew that such assurance was folly, knew instinctively that the
+machine was removed out of my reach. My breath came with pain. I
+suppose I covered the whole distance from the hill crest to the
+little lawn, two miles perhaps, in ten minutes. And I am not a young
+man. I cursed aloud, as I ran, at my confident folly in leaving the
+machine, wasting good breath thereby. I cried aloud, and none
+answered. Not a creature seemed to be stirring in that moonlit
+world.
+
+'When I reached the lawn my worst fears were realized. Not a trace
+of the thing was to be seen. I felt faint and cold when I faced the
+empty space among the black tangle of bushes. I ran round it
+furiously, as if the thing might be hidden in a corner, and then
+stopped abruptly, with my hands clutching my hair. Above me towered
+the sphinx, upon the bronze pedestal, white, shining, leprous, in
+the light of the rising moon. It seemed to smile in mockery of my
+dismay.
+
+'I might have consoled myself by imagining the little people had put
+the mechanism in some shelter for me, had I not felt assured of
+their physical and intellectual inadequacy. That is what dismayed
+me: the sense of some hitherto unsuspected power, through whose
+intervention my invention had vanished. Yet, for one thing I felt
+assured: unless some other age had produced its exact duplicate,
+the machine could not have moved in time. The attachment of the
+levers--I will show you the method later--prevented any one from
+tampering with it in that way when they were removed. It had moved,
+and was hid, only in space. But then, where could it be?
+
+'I think I must have had a kind of frenzy. I remember running
+violently in and out among the moonlit bushes all round the sphinx,
+and startling some white animal that, in the dim light, I took for a
+small deer. I remember, too, late that night, beating the bushes
+with my clenched fist until my knuckles were gashed and bleeding
+from the broken twigs. Then, sobbing and raving in my anguish of
+mind, I went down to the great building of stone. The big hall was
+dark, silent, and deserted. I slipped on the uneven floor, and fell
+over one of the malachite tables, almost breaking my shin. I lit a
+match and went on past the dusty curtains, of which I have told you.
+
+'There I found a second great hall covered with cushions, upon
+which, perhaps, a score or so of the little people were sleeping. I
+have no doubt they found my second appearance strange enough, coming
+suddenly out of the quiet darkness with inarticulate noises and the
+splutter and flare of a match. For they had forgotten about matches.
+"Where is my Time Machine?" I began, bawling like an angry child,
+laying hands upon them and shaking them up together. It must have
+been very queer to them. Some laughed, most of them looked sorely
+frightened. When I saw them standing round me, it came into my head
+that I was doing as foolish a thing as it was possible for me to do
+under the circumstances, in trying to revive the sensation of fear.
+For, reasoning from their daylight behaviour, I thought that fear
+must be forgotten.
+
+'Abruptly, I dashed down the match, and, knocking one of the people
+over in my course, went blundering across the big dining-hall again,
+out under the moonlight. I heard cries of terror and their little
+feet running and stumbling this way and that. I do not remember all
+I did as the moon crept up the sky. I suppose it was the unexpected
+nature of my loss that maddened me. I felt hopelessly cut off from
+my own kind--a strange animal in an unknown world. I must have raved
+to and fro, screaming and crying upon God and Fate. I have a memory
+of horrible fatigue, as the long night of despair wore away; of
+looking in this impossible place and that; of groping among moon-lit
+ruins and touching strange creatures in the black shadows; at last,
+of lying on the ground near the sphinx and weeping with absolute
+wretchedness. I had nothing left but misery. Then I slept, and when
+I woke again it was full day, and a couple of sparrows were hopping
+round me on the turf within reach of my arm.
+
+'I sat up in the freshness of the morning, trying to remember how
+I had got there, and why I had such a profound sense of desertion
+and despair. Then things came clear in my mind. With the plain,
+reasonable daylight, I could look my circumstances fairly in the
+face. I saw the wild folly of my frenzy overnight, and I could
+reason with myself. "Suppose the worst?" I said. "Suppose the
+machine altogether lost--perhaps destroyed? It behoves me to be
+calm and patient, to learn the way of the people, to get a clear
+idea of the method of my loss, and the means of getting materials
+and tools; so that in the end, perhaps, I may make another." That
+would be my only hope, perhaps, but better than despair. And, after
+all, it was a beautiful and curious world.
+
+'But probably, the machine had only been taken away. Still, I must
+be calm and patient, find its hiding-place, and recover it by force
+or cunning. And with that I scrambled to my feet and looked about
+me, wondering where I could bathe. I felt weary, stiff, and
+travel-soiled. The freshness of the morning made me desire an equal
+freshness. I had exhausted my emotion. Indeed, as I went about
+my business, I found myself wondering at my intense excitement
+overnight. I made a careful examination of the ground about the
+little lawn. I wasted some time in futile questionings, conveyed, as
+well as I was able, to such of the little people as came by. They
+all failed to understand my gestures; some were simply stolid, some
+thought it was a jest and laughed at me. I had the hardest task in
+the world to keep my hands off their pretty laughing faces. It was
+a foolish impulse, but the devil begotten of fear and blind anger
+was ill curbed and still eager to take advantage of my perplexity.
+The turf gave better counsel. I found a groove ripped in it, about
+midway between the pedestal of the sphinx and the marks of my feet
+where, on arrival, I had struggled with the overturned machine.
+There were other signs of removal about, with queer narrow
+footprints like those I could imagine made by a sloth. This directed
+my closer attention to the pedestal. It was, as I think I have said,
+of bronze. It was not a mere block, but highly decorated with deep
+framed panels on either side. I went and rapped at these. The
+pedestal was hollow. Examining the panels with care I found them
+discontinuous with the frames. There were no handles or keyholes,
+but possibly the panels, if they were doors, as I supposed, opened
+from within. One thing was clear enough to my mind. It took no very
+great mental effort to infer that my Time Machine was inside that
+pedestal. But how it got there was a different problem.
+
+'I saw the heads of two orange-clad people coming through the bushes
+and under some blossom-covered apple-trees towards me. I turned
+smiling to them and beckoned them to me. They came, and then,
+pointing to the bronze pedestal, I tried to intimate my wish to open
+it. But at my first gesture towards this they behaved very oddly. I
+don't know how to convey their expression to you. Suppose you were
+to use a grossly improper gesture to a delicate-minded woman--it is
+how she would look. They went off as if they had received the last
+possible insult. I tried a sweet-looking little chap in white next,
+with exactly the same result. Somehow, his manner made me feel
+ashamed of myself. But, as you know, I wanted the Time Machine, and
+I tried him once more. As he turned off, like the others, my temper
+got the better of me. In three strides I was after him, had him by
+the loose part of his robe round the neck, and began dragging him
+towards the sphinx. Then I saw the horror and repugnance of his
+face, and all of a sudden I let him go.
+
+'But I was not beaten yet. I banged with my fist at the bronze
+panels. I thought I heard something stir inside--to be explicit,
+I thought I heard a sound like a chuckle--but I must have been
+mistaken. Then I got a big pebble from the river, and came and
+hammered till I had flattened a coil in the decorations, and the
+verdigris came off in powdery flakes. The delicate little people
+must have heard me hammering in gusty outbreaks a mile away on
+either hand, but nothing came of it. I saw a crowd of them upon the
+slopes, looking furtively at me. At last, hot and tired, I sat down
+to watch the place. But I was too restless to watch long; I am too
+Occidental for a long vigil. I could work at a problem for years,
+but to wait inactive for twenty-four hours--that is another matter.
+
+'I got up after a time, and began walking aimlessly through the
+bushes towards the hill again. "Patience," said I to myself. "If you
+want your machine again you must leave that sphinx alone. If they
+mean to take your machine away, it's little good your wrecking their
+bronze panels, and if they don't, you will get it back as soon as
+you can ask for it. To sit among all those unknown things before a
+puzzle like that is hopeless. That way lies monomania. Face this
+world. Learn its ways, watch it, be careful of too hasty guesses
+at its meaning. In the end you will find clues to it all." Then
+suddenly the humour of the situation came into my mind: the thought
+of the years I had spent in study and toil to get into the future
+age, and now my passion of anxiety to get out of it. I had made
+myself the most complicated and the most hopeless trap that ever a
+man devised. Although it was at my own expense, I could not help
+myself. I laughed aloud.
+
+'Going through the big palace, it seemed to me that the little
+people avoided me. It may have been my fancy, or it may have had
+something to do with my hammering at the gates of bronze. Yet I felt
+tolerably sure of the avoidance. I was careful, however, to show no
+concern and to abstain from any pursuit of them, and in the course
+of a day or two things got back to the old footing. I made what
+progress I could in the language, and in addition I pushed my
+explorations here and there. Either I missed some subtle point or
+their language was excessively simple--almost exclusively composed
+of concrete substantives and verbs. There seemed to be few, if any,
+abstract terms, or little use of figurative language. Their
+sentences were usually simple and of two words, and I failed to
+convey or understand any but the simplest propositions. I determined
+to put the thought of my Time Machine and the mystery of the bronze
+doors under the sphinx as much as possible in a corner of memory,
+until my growing knowledge would lead me back to them in a natural
+way. Yet a certain feeling, you may understand, tethered me in a
+circle of a few miles round the point of my arrival.
+
+'So far as I could see, all the world displayed the same exuberant
+richness as the Thames valley. From every hill I climbed I saw the
+same abundance of splendid buildings, endlessly varied in material
+and style, the same clustering thickets of evergreens, the same
+blossom-laden trees and tree-ferns. Here and there water shone like
+silver, and beyond, the land rose into blue undulating hills, and
+so faded into the serenity of the sky. A peculiar feature, which
+presently attracted my attention, was the presence of certain
+circular wells, several, as it seemed to me, of a very great depth.
+One lay by the path up the hill, which I had followed during my
+first walk. Like the others, it was rimmed with bronze, curiously
+wrought, and protected by a little cupola from the rain. Sitting by
+the side of these wells, and peering down into the shafted darkness,
+I could see no gleam of water, nor could I start any reflection
+with a lighted match. But in all of them I heard a certain sound:
+a thud--thud--thud, like the beating of some big engine; and I
+discovered, from the flaring of my matches, that a steady current of
+air set down the shafts. Further, I threw a scrap of paper into the
+throat of one, and, instead of fluttering slowly down, it was at
+once sucked swiftly out of sight.
+
+'After a time, too, I came to connect these wells with tall towers
+standing here and there upon the slopes; for above them there was
+often just such a flicker in the air as one sees on a hot day above
+a sun-scorched beach. Putting things together, I reached a strong
+suggestion of an extensive system of subterranean ventilation, whose
+true import it was difficult to imagine. I was at first inclined to
+associate it with the sanitary apparatus of these people. It was an
+obvious conclusion, but it was absolutely wrong.
+
+'And here I must admit that I learned very little of drains and
+bells and modes of conveyance, and the like conveniences, during my
+time in this real future. In some of these visions of Utopias and
+coming times which I have read, there is a vast amount of detail
+about building, and social arrangements, and so forth. But while
+such details are easy enough to obtain when the whole world is
+contained in one's imagination, they are altogether inaccessible to
+a real traveller amid such realities as I found here. Conceive the
+tale of London which a negro, fresh from Central Africa, would take
+back to his tribe! What would he know of railway companies, of
+social movements, of telephone and telegraph wires, of the Parcels
+Delivery Company, and postal orders and the like? Yet we, at least,
+should be willing enough to explain these things to him! And even of
+what he knew, how much could he make his untravelled friend either
+apprehend or believe? Then, think how narrow the gap between a negro
+and a white man of our own times, and how wide the interval between
+myself and these of the Golden Age! I was sensible of much which was
+unseen, and which contributed to my comfort; but save for a general
+impression of automatic organization, I fear I can convey very
+little of the difference to your mind.
+
+'In the matter of sepulture, for instance, I could see no signs of
+crematoria nor anything suggestive of tombs. But it occurred to me
+that, possibly, there might be cemeteries (or crematoria) somewhere
+beyond the range of my explorings. This, again, was a question I
+deliberately put to myself, and my curiosity was at first entirely
+defeated upon the point. The thing puzzled me, and I was led to make
+a further remark, which puzzled me still more: that aged and infirm
+among this people there were none.
+
+'I must confess that my satisfaction with my first theories of an
+automatic civilization and a decadent humanity did not long endure.
+Yet I could think of no other. Let me put my difficulties. The
+several big palaces I had explored were mere living places, great
+dining-halls and sleeping apartments. I could find no machinery, no
+appliances of any kind. Yet these people were clothed in pleasant
+fabrics that must at times need renewal, and their sandals, though
+undecorated, were fairly complex specimens of metalwork. Somehow
+such things must be made. And the little people displayed no vestige
+of a creative tendency. There were no shops, no workshops, no sign
+of importations among them. They spent all their time in playing
+gently, in bathing in the river, in making love in a half-playful
+fashion, in eating fruit and sleeping. I could not see how things
+were kept going.
+
+'Then, again, about the Time Machine: something, I knew not what,
+had taken it into the hollow pedestal of the White Sphinx. Why? For
+the life of me I could not imagine. Those waterless wells, too,
+those flickering pillars. I felt I lacked a clue. I felt--how shall
+I put it? Suppose you found an inscription, with sentences here and
+there in excellent plain English, and interpolated therewith, others
+made up of words, of letters even, absolutely unknown to you? Well,
+on the third day of my visit, that was how the world of Eight
+Hundred and Two Thousand Seven Hundred and One presented itself to
+me!
+
+'That day, too, I made a friend--of a sort. It happened that, as I
+was watching some of the little people bathing in a shallow, one of
+them was seized with cramp and began drifting downstream. The main
+current ran rather swiftly, but not too strongly for even a moderate
+swimmer. It will give you an idea, therefore, of the strange
+deficiency in these creatures, when I tell you that none made the
+slightest attempt to rescue the weakly crying little thing which
+was drowning before their eyes. When I realized this, I hurriedly
+slipped off my clothes, and, wading in at a point lower down, I
+caught the poor mite and drew her safe to land. A little rubbing of
+the limbs soon brought her round, and I had the satisfaction of
+seeing she was all right before I left her. I had got to such a low
+estimate of her kind that I did not expect any gratitude from her.
+In that, however, I was wrong.
+
+'This happened in the morning. In the afternoon I met my little
+woman, as I believe it was, as I was returning towards my centre
+from an exploration, and she received me with cries of delight and
+presented me with a big garland of flowers--evidently made for me
+and me alone. The thing took my imagination. Very possibly I had
+been feeling desolate. At any rate I did my best to display my
+appreciation of the gift. We were soon seated together in a little
+stone arbour, engaged in conversation, chiefly of smiles. The
+creature's friendliness affected me exactly as a child's might have
+done. We passed each other flowers, and she kissed my hands. I did
+the same to hers. Then I tried talk, and found that her name was
+Weena, which, though I don't know what it meant, somehow seemed
+appropriate enough. That was the beginning of a queer friendship
+which lasted a week, and ended--as I will tell you!
+
+'She was exactly like a child. She wanted to be with me always. She
+tried to follow me everywhere, and on my next journey out and about
+it went to my heart to tire her down, and leave her at last,
+exhausted and calling after me rather plaintively. But the problems
+of the world had to be mastered. I had not, I said to myself, come
+into the future to carry on a miniature flirtation. Yet her distress
+when I left her was very great, her expostulations at the parting
+were sometimes frantic, and I think, altogether, I had as much
+trouble as comfort from her devotion. Nevertheless she was, somehow,
+a very great comfort. I thought it was mere childish affection that
+made her cling to me. Until it was too late, I did not clearly know
+what I had inflicted upon her when I left her. Nor until it was too
+late did I clearly understand what she was to me. For, by merely
+seeming fond of me, and showing in her weak, futile way that she
+cared for me, the little doll of a creature presently gave my return
+to the neighbourhood of the White Sphinx almost the feeling of
+coming home; and I would watch for her tiny figure of white and gold
+so soon as I came over the hill.
+
+'It was from her, too, that I learned that fear had not yet left the
+world. She was fearless enough in the daylight, and she had the
+oddest confidence in me; for once, in a foolish moment, I made
+threatening grimaces at her, and she simply laughed at them. But she
+dreaded the dark, dreaded shadows, dreaded black things. Darkness
+to her was the one thing dreadful. It was a singularly passionate
+emotion, and it set me thinking and observing. I discovered then,
+among other things, that these little people gathered into the great
+houses after dark, and slept in droves. To enter upon them without a
+light was to put them into a tumult of apprehension. I never found
+one out of doors, or one sleeping alone within doors, after dark.
+Yet I was still such a blockhead that I missed the lesson of that
+fear, and in spite of Weena's distress I insisted upon sleeping away
+from these slumbering multitudes.
+
+'It troubled her greatly, but in the end her odd affection for me
+triumphed, and for five of the nights of our acquaintance, including
+the last night of all, she slept with her head pillowed on my arm.
+But my story slips away from me as I speak of her. It must have been
+the night before her rescue that I was awakened about dawn. I had
+been restless, dreaming most disagreeably that I was drowned, and
+that sea anemones were feeling over my face with their soft palps.
+I woke with a start, and with an odd fancy that some greyish animal
+had just rushed out of the chamber. I tried to get to sleep again,
+but I felt restless and uncomfortable. It was that dim grey hour
+when things are just creeping out of darkness, when everything is
+colourless and clear cut, and yet unreal. I got up, and went down
+into the great hall, and so out upon the flagstones in front of the
+palace. I thought I would make a virtue of necessity, and see the
+sunrise.
+
+'The moon was setting, and the dying moonlight and the first pallor
+of dawn were mingled in a ghastly half-light. The bushes were inky
+black, the ground a sombre grey, the sky colourless and cheerless.
+And up the hill I thought I could see ghosts. There several times,
+as I scanned the slope, I saw white figures. Twice I fancied I saw
+a solitary white, ape-like creature running rather quickly up the
+hill, and once near the ruins I saw a leash of them carrying some
+dark body. They moved hastily. I did not see what became of them.
+It seemed that they vanished among the bushes. The dawn was still
+indistinct, you must understand. I was feeling that chill,
+uncertain, early-morning feeling you may have known. I doubted
+my eyes.
+
+'As the eastern sky grew brighter, and the light of the day came on
+and its vivid colouring returned upon the world once more, I scanned
+the view keenly. But I saw no vestige of my white figures. They were
+mere creatures of the half light. "They must have been ghosts," I
+said; "I wonder whence they dated." For a queer notion of Grant
+Allen's came into my head, and amused me. If each generation die and
+leave ghosts, he argued, the world at last will get overcrowded with
+them. On that theory they would have grown innumerable some Eight
+Hundred Thousand Years hence, and it was no great wonder to see four
+at once. But the jest was unsatisfying, and I was thinking of these
+figures all the morning, until Weena's rescue drove them out of my
+head. I associated them in some indefinite way with the white animal
+I had startled in my first passionate search for the Time Machine.
+But Weena was a pleasant substitute. Yet all the same, they were
+soon destined to take far deadlier possession of my mind.
+
+'I think I have said how much hotter than our own was the weather
+of this Golden Age. I cannot account for it. It may be that the sun
+was hotter, or the earth nearer the sun. It is usual to assume that
+the sun will go on cooling steadily in the future. But people,
+unfamiliar with such speculations as those of the younger Darwin,
+forget that the planets must ultimately fall back one by one into
+the parent body. As these catastrophes occur, the sun will blaze
+with renewed energy; and it may be that some inner planet had
+suffered this fate. Whatever the reason, the fact remains that the
+sun was very much hotter than we know it.
+
+'Well, one very hot morning--my fourth, I think--as I was seeking
+shelter from the heat and glare in a colossal ruin near the great
+house where I slept and fed, there happened this strange thing:
+Clambering among these heaps of masonry, I found a narrow gallery,
+whose end and side windows were blocked by fallen masses of stone.
+By contrast with the brilliancy outside, it seemed at first
+impenetrably dark to me. I entered it groping, for the change from
+light to blackness made spots of colour swim before me. Suddenly I
+halted spellbound. A pair of eyes, luminous by reflection against
+the daylight without, was watching me out of the darkness.
+
+'The old instinctive dread of wild beasts came upon me. I clenched
+my hands and steadfastly looked into the glaring eyeballs. I was
+afraid to turn. Then the thought of the absolute security in which
+humanity appeared to be living came to my mind. And then I
+remembered that strange terror of the dark. Overcoming my fear to
+some extent, I advanced a step and spoke. I will admit that my
+voice was harsh and ill-controlled. I put out my hand and touched
+something soft. At once the eyes darted sideways, and something
+white ran past me. I turned with my heart in my mouth, and saw a
+queer little ape-like figure, its head held down in a peculiar
+manner, running across the sunlit space behind me. It blundered
+against a block of granite, staggered aside, and in a moment was
+hidden in a black shadow beneath another pile of ruined masonry.
+
+'My impression of it is, of course, imperfect; but I know it was a
+dull white, and had strange large greyish-red eyes; also that there
+was flaxen hair on its head and down its back. But, as I say, it
+went too fast for me to see distinctly. I cannot even say whether it
+ran on all-fours, or only with its forearms held very low. After an
+instant's pause I followed it into the second heap of ruins. I could
+not find it at first; but, after a time in the profound obscurity, I
+came upon one of those round well-like openings of which I have told
+you, half closed by a fallen pillar. A sudden thought came to me.
+Could this Thing have vanished down the shaft? I lit a match, and,
+looking down, I saw a small, white, moving creature, with large
+bright eyes which regarded me steadfastly as it retreated. It made
+me shudder. It was so like a human spider! It was clambering down
+the wall, and now I saw for the first time a number of metal foot
+and hand rests forming a kind of ladder down the shaft. Then the
+light burned my fingers and fell out of my hand, going out as it
+dropped, and when I had lit another the little monster had
+disappeared.
+
+'I do not know how long I sat peering down that well. It was not for
+some time that I could succeed in persuading myself that the thing I
+had seen was human. But, gradually, the truth dawned on me: that
+Man had not remained one species, but had differentiated into two
+distinct animals: that my graceful children of the Upper-world were
+not the sole descendants of our generation, but that this bleached,
+obscene, nocturnal Thing, which had flashed before me, was also heir
+to all the ages.
+
+'I thought of the flickering pillars and of my theory of an
+underground ventilation. I began to suspect their true import. And
+what, I wondered, was this Lemur doing in my scheme of a perfectly
+balanced organization? How was it related to the indolent serenity
+of the beautiful Upper-worlders? And what was hidden down there,
+at the foot of that shaft? I sat upon the edge of the well telling
+myself that, at any rate, there was nothing to fear, and that there
+I must descend for the solution of my difficulties. And withal I
+was absolutely afraid to go! As I hesitated, two of the beautiful
+Upper-world people came running in their amorous sport across the
+daylight in the shadow. The male pursued the female, flinging
+flowers at her as he ran.
+
+'They seemed distressed to find me, my arm against the overturned
+pillar, peering down the well. Apparently it was considered bad form
+to remark these apertures; for when I pointed to this one, and tried
+to frame a question about it in their tongue, they were still more
+visibly distressed and turned away. But they were interested by my
+matches, and I struck some to amuse them. I tried them again about
+the well, and again I failed. So presently I left them, meaning to
+go back to Weena, and see what I could get from her. But my mind was
+already in revolution; my guesses and impressions were slipping and
+sliding to a new adjustment. I had now a clue to the import of these
+wells, to the ventilating towers, to the mystery of the ghosts; to
+say nothing of a hint at the meaning of the bronze gates and the
+fate of the Time Machine! And very vaguely there came a suggestion
+towards the solution of the economic problem that had puzzled me.
+
+'Here was the new view. Plainly, this second species of Man was
+subterranean. There were three circumstances in particular which
+made me think that its rare emergence above ground was the outcome
+of a long-continued underground habit. In the first place, there was
+the bleached look common in most animals that live largely in the
+dark--the white fish of the Kentucky caves, for instance. Then,
+those large eyes, with that capacity for reflecting light, are
+common features of nocturnal things--witness the owl and the cat.
+And last of all, that evident confusion in the sunshine, that hasty
+yet fumbling awkward flight towards dark shadow, and that peculiar
+carriage of the head while in the light--all reinforced the theory
+of an extreme sensitiveness of the retina.
+
+'Beneath my feet, then, the earth must be tunnelled enormously, and
+these tunnellings were the habitat of the new race. The presence of
+ventilating shafts and wells along the hill slopes--everywhere, in
+fact, except along the river valley--showed how universal were its
+ramifications. What so natural, then, as to assume that it was in
+this artificial Underworld that such work as was necessary to the
+comfort of the daylight race was done? The notion was so plausible
+that I at once accepted it, and went on to assume the _how_ of this
+splitting of the human species. I dare say you will anticipate the
+shape of my theory; though, for myself, I very soon felt that it
+fell far short of the truth.
+
+'At first, proceeding from the problems of our own age, it seemed
+clear as daylight to me that the gradual widening of the present
+merely temporary and social difference between the Capitalist and
+the Labourer, was the key to the whole position. No doubt it will
+seem grotesque enough to you--and wildly incredible!--and yet even
+now there are existing circumstances to point that way. There is
+a tendency to utilize underground space for the less ornamental
+purposes of civilization; there is the Metropolitan Railway in
+London, for instance, there are new electric railways, there are
+subways, there are underground workrooms and restaurants, and they
+increase and multiply. Evidently, I thought, this tendency had
+increased till Industry had gradually lost its birthright in the
+sky. I mean that it had gone deeper and deeper into larger and ever
+larger underground factories, spending a still-increasing amount of
+its time therein, till, in the end--! Even now, does not an East-end
+worker live in such artificial conditions as practically to be cut
+off from the natural surface of the earth?
+
+'Again, the exclusive tendency of richer people--due, no doubt, to
+the increasing refinement of their education, and the widening gulf
+between them and the rude violence of the poor--is already leading
+to the closing, in their interest, of considerable portions of the
+surface of the land. About London, for instance, perhaps half the
+prettier country is shut in against intrusion. And this same
+widening gulf--which is due to the length and expense of the higher
+educational process and the increased facilities for and temptations
+towards refined habits on the part of the rich--will make that
+exchange between class and class, that promotion by intermarriage
+which at present retards the splitting of our species along lines
+of social stratification, less and less frequent. So, in the end,
+above ground you must have the Haves, pursuing pleasure and comfort
+and beauty, and below ground the Have-nots, the Workers getting
+continually adapted to the conditions of their labour. Once they
+were there, they would no doubt have to pay rent, and not a little
+of it, for the ventilation of their caverns; and if they refused,
+they would starve or be suffocated for arrears. Such of them as were
+so constituted as to be miserable and rebellious would die; and, in
+the end, the balance being permanent, the survivors would become as
+well adapted to the conditions of underground life, and as happy in
+their way, as the Upper-world people were to theirs. As it seemed to
+me, the refined beauty and the etiolated pallor followed naturally
+enough.
+
+'The great triumph of Humanity I had dreamed of took a different
+shape in my mind. It had been no such triumph of moral education and
+general co-operation as I had imagined. Instead, I saw a real
+aristocracy, armed with a perfected science and working to a logical
+conclusion the industrial system of to-day. Its triumph had not been
+simply a triumph over Nature, but a triumph over Nature and the
+fellow-man. This, I must warn you, was my theory at the time. I had
+no convenient cicerone in the pattern of the Utopian books. My
+explanation may be absolutely wrong. I still think it is the
+most plausible one. But even on this supposition the balanced
+civilization that was at last attained must have long since passed
+its zenith, and was now far fallen into decay. The too-perfect
+security of the Upper-worlders had led them to a slow movement of
+degeneration, to a general dwindling in size, strength, and
+intelligence. That I could see clearly enough already. What had
+happened to the Under-grounders I did not yet suspect; but from what
+I had seen of the Morlocks--that, by the by, was the name by which
+these creatures were called--I could imagine that the modification
+of the human type was even far more profound than among the "Eloi,"
+the beautiful race that I already knew.
+
+'Then came troublesome doubts. Why had the Morlocks taken my Time
+Machine? For I felt sure it was they who had taken it. Why, too, if
+the Eloi were masters, could they not restore the machine to me? And
+why were they so terribly afraid of the dark? I proceeded, as I have
+said, to question Weena about this Under-world, but here again I was
+disappointed. At first she would not understand my questions, and
+presently she refused to answer them. She shivered as though the
+topic was unendurable. And when I pressed her, perhaps a little
+harshly, she burst into tears. They were the only tears, except my
+own, I ever saw in that Golden Age. When I saw them I ceased
+abruptly to trouble about the Morlocks, and was only concerned in
+banishing these signs of the human inheritance from Weena's eyes.
+And very soon she was smiling and clapping her hands, while I
+solemnly burned a match.
+
+
+
+
+VI
+
+
+'It may seem odd to you, but it was two days before I could follow
+up the new-found clue in what was manifestly the proper way. I felt
+a peculiar shrinking from those pallid bodies. They were just the
+half-bleached colour of the worms and things one sees preserved in
+spirit in a zoological museum. And they were filthily cold to the
+touch. Probably my shrinking was largely due to the sympathetic
+influence of the Eloi, whose disgust of the Morlocks I now began
+to appreciate.
+
+'The next night I did not sleep well. Probably my health was a
+little disordered. I was oppressed with perplexity and doubt. Once
+or twice I had a feeling of intense fear for which I could perceive
+no definite reason. I remember creeping noiselessly into the great
+hall where the little people were sleeping in the moonlight--that
+night Weena was among them--and feeling reassured by their presence.
+It occurred to me even then, that in the course of a few days the
+moon must pass through its last quarter, and the nights grow dark,
+when the appearances of these unpleasant creatures from below, these
+whitened Lemurs, this new vermin that had replaced the old, might be
+more abundant. And on both these days I had the restless feeling of
+one who shirks an inevitable duty. I felt assured that the Time
+Machine was only to be recovered by boldly penetrating these
+underground mysteries. Yet I could not face the mystery. If only I
+had had a companion it would have been different. But I was so
+horribly alone, and even to clamber down into the darkness of the
+well appalled me. I don't know if you will understand my feeling,
+but I never felt quite safe at my back.
+
+'It was this restlessness, this insecurity, perhaps, that drove me
+further and further afield in my exploring expeditions. Going to the
+south-westward towards the rising country that is now called Combe
+Wood, I observed far off, in the direction of nineteenth-century
+Banstead, a vast green structure, different in character from any
+I had hitherto seen. It was larger than the largest of the palaces
+or ruins I knew, and the facade had an Oriental look: the face
+of it having the lustre, as well as the pale-green tint, a kind
+of bluish-green, of a certain type of Chinese porcelain. This
+difference in aspect suggested a difference in use, and I was minded
+to push on and explore. But the day was growing late, and I had come
+upon the sight of the place after a long and tiring circuit; so I
+resolved to hold over the adventure for the following day, and I
+returned to the welcome and the caresses of little Weena. But next
+morning I perceived clearly enough that my curiosity regarding the
+Palace of Green Porcelain was a piece of self-deception, to enable
+me to shirk, by another day, an experience I dreaded. I resolved I
+would make the descent without further waste of time, and started
+out in the early morning towards a well near the ruins of granite
+and aluminium.
+
+'Little Weena ran with me. She danced beside me to the well, but
+when she saw me lean over the mouth and look downward, she seemed
+strangely disconcerted. "Good-bye, little Weena," I said, kissing
+her; and then putting her down, I began to feel over the parapet
+for the climbing hooks. Rather hastily, I may as well confess, for
+I feared my courage might leak away! At first she watched me in
+amazement. Then she gave a most piteous cry, and running to me, she
+began to pull at me with her little hands. I think her opposition
+nerved me rather to proceed. I shook her off, perhaps a little
+roughly, and in another moment I was in the throat of the well. I
+saw her agonized face over the parapet, and smiled to reassure her.
+Then I had to look down at the unstable hooks to which I clung.
+
+'I had to clamber down a shaft of perhaps two hundred yards. The
+descent was effected by means of metallic bars projecting from
+the sides of the well, and these being adapted to the needs of
+a creature much smaller and lighter than myself, I was speedily
+cramped and fatigued by the descent. And not simply fatigued! One of
+the bars bent suddenly under my weight, and almost swung me off into
+the blackness beneath. For a moment I hung by one hand, and after
+that experience I did not dare to rest again. Though my arms and
+back were presently acutely painful, I went on clambering down the
+sheer descent with as quick a motion as possible. Glancing upward,
+I saw the aperture, a small blue disk, in which a star was visible,
+while little Weena's head showed as a round black projection. The
+thudding sound of a machine below grew louder and more oppressive.
+Everything save that little disk above was profoundly dark, and when
+I looked up again Weena had disappeared.
+
+'I was in an agony of discomfort. I had some thought of trying to go
+up the shaft again, and leave the Under-world alone. But even while
+I turned this over in my mind I continued to descend. At last, with
+intense relief, I saw dimly coming up, a foot to the right of me, a
+slender loophole in the wall. Swinging myself in, I found it was the
+aperture of a narrow horizontal tunnel in which I could lie down and
+rest. It was not too soon. My arms ached, my back was cramped, and I
+was trembling with the prolonged terror of a fall. Besides this, the
+unbroken darkness had had a distressing effect upon my eyes. The air
+was full of the throb and hum of machinery pumping air down the
+shaft.
+
+'I do not know how long I lay. I was roused by a soft hand touching
+my face. Starting up in the darkness I snatched at my matches and,
+hastily striking one, I saw three stooping white creatures similar
+to the one I had seen above ground in the ruin, hastily retreating
+before the light. Living, as they did, in what appeared to me
+impenetrable darkness, their eyes were abnormally large and
+sensitive, just as are the pupils of the abysmal fishes, and they
+reflected the light in the same way. I have no doubt they could see
+me in that rayless obscurity, and they did not seem to have any fear
+of me apart from the light. But, so soon as I struck a match in
+order to see them, they fled incontinently, vanishing into dark
+gutters and tunnels, from which their eyes glared at me in the
+strangest fashion.
+
+'I tried to call to them, but the language they had was apparently
+different from that of the Over-world people; so that I was needs
+left to my own unaided efforts, and the thought of flight before
+exploration was even then in my mind. But I said to myself, "You are
+in for it now," and, feeling my way along the tunnel, I found the
+noise of machinery grow louder. Presently the walls fell away from
+me, and I came to a large open space, and striking another match,
+saw that I had entered a vast arched cavern, which stretched into
+utter darkness beyond the range of my light. The view I had of it
+was as much as one could see in the burning of a match.
+
+'Necessarily my memory is vague. Great shapes like big machines rose
+out of the dimness, and cast grotesque black shadows, in which dim
+spectral Morlocks sheltered from the glare. The place, by the by,
+was very stuffy and oppressive, and the faint halitus of freshly
+shed blood was in the air. Some way down the central vista was a
+little table of white metal, laid with what seemed a meal. The
+Morlocks at any rate were carnivorous! Even at the time, I remember
+wondering what large animal could have survived to furnish the red
+joint I saw. It was all very indistinct: the heavy smell, the big
+unmeaning shapes, the obscene figures lurking in the shadows, and
+only waiting for the darkness to come at me again! Then the match
+burned down, and stung my fingers, and fell, a wriggling red spot
+in the blackness.
+
+'I have thought since how particularly ill-equipped I was for such
+an experience. When I had started with the Time Machine, I had
+started with the absurd assumption that the men of the Future would
+certainly be infinitely ahead of ourselves in all their appliances.
+I had come without arms, without medicine, without anything to
+smoke--at times I missed tobacco frightfully--even without enough
+matches. If only I had thought of a Kodak! I could have flashed that
+glimpse of the Underworld in a second, and examined it at leisure.
+But, as it was, I stood there with only the weapons and the powers
+that Nature had endowed me with--hands, feet, and teeth; these, and
+four safety-matches that still remained to me.
+
+'I was afraid to push my way in among all this machinery in the
+dark, and it was only with my last glimpse of light I discovered
+that my store of matches had run low. It had never occurred to me
+until that moment that there was any need to economize them, and I
+had wasted almost half the box in astonishing the Upper-worlders, to
+whom fire was a novelty. Now, as I say, I had four left, and while I
+stood in the dark, a hand touched mine, lank fingers came feeling
+over my face, and I was sensible of a peculiar unpleasant odour. I
+fancied I heard the breathing of a crowd of those dreadful little
+beings about me. I felt the box of matches in my hand being gently
+disengaged, and other hands behind me plucking at my clothing. The
+sense of these unseen creatures examining me was indescribably
+unpleasant. The sudden realization of my ignorance of their ways of
+thinking and doing came home to me very vividly in the darkness. I
+shouted at them as loudly as I could. They started away, and then
+I could feel them approaching me again. They clutched at me more
+boldly, whispering odd sounds to each other. I shivered violently,
+and shouted again--rather discordantly. This time they were not so
+seriously alarmed, and they made a queer laughing noise as they came
+back at me. I will confess I was horribly frightened. I determined
+to strike another match and escape under the protection of its
+glare. I did so, and eking out the flicker with a scrap of paper
+from my pocket, I made good my retreat to the narrow tunnel. But I
+had scarce entered this when my light was blown out and in the
+blackness I could hear the Morlocks rustling like wind among leaves,
+and pattering like the rain, as they hurried after me.
+
+'In a moment I was clutched by several hands, and there was no
+mistaking that they were trying to haul me back. I struck another
+light, and waved it in their dazzled faces. You can scarce imagine
+how nauseatingly inhuman they looked--those pale, chinless faces
+and great, lidless, pinkish-grey eyes!--as they stared in their
+blindness and bewilderment. But I did not stay to look, I promise
+you: I retreated again, and when my second match had ended, I struck
+my third. It had almost burned through when I reached the opening
+into the shaft. I lay down on the edge, for the throb of the great
+pump below made me giddy. Then I felt sideways for the projecting
+hooks, and, as I did so, my feet were grasped from behind, and I
+was violently tugged backward. I lit my last match ... and it
+incontinently went out. But I had my hand on the climbing bars now,
+and, kicking violently, I disengaged myself from the clutches of the
+Morlocks and was speedily clambering up the shaft, while they stayed
+peering and blinking up at me: all but one little wretch who
+followed me for some way, and well-nigh secured my boot as a trophy.
+
+'That climb seemed interminable to me. With the last twenty or
+thirty feet of it a deadly nausea came upon me. I had the greatest
+difficulty in keeping my hold. The last few yards was a frightful
+struggle against this faintness. Several times my head swam, and I
+felt all the sensations of falling. At last, however, I got over the
+well-mouth somehow, and staggered out of the ruin into the blinding
+sunlight. I fell upon my face. Even the soil smelt sweet and clean.
+Then I remember Weena kissing my hands and ears, and the voices of
+others among the Eloi. Then, for a time, I was insensible.
+
+
+
+
+VII
+
+
+'Now, indeed, I seemed in a worse case than before. Hitherto,
+except during my night's anguish at the loss of the Time Machine,
+I had felt a sustaining hope of ultimate escape, but that hope was
+staggered by these new discoveries. Hitherto I had merely thought
+myself impeded by the childish simplicity of the little people, and
+by some unknown forces which I had only to understand to overcome;
+but there was an altogether new element in the sickening quality of
+the Morlocks--a something inhuman and malign. Instinctively I
+loathed them. Before, I had felt as a man might feel who had fallen
+into a pit: my concern was with the pit and how to get out of it.
+Now I felt like a beast in a trap, whose enemy would come upon him
+soon.
+
+'The enemy I dreaded may surprise you. It was the darkness of the
+new moon. Weena had put this into my head by some at first
+incomprehensible remarks about the Dark Nights. It was not now
+such a very difficult problem to guess what the coming Dark Nights
+might mean. The moon was on the wane: each night there was a longer
+interval of darkness. And I now understood to some slight degree at
+least the reason of the fear of the little Upper-world people for
+the dark. I wondered vaguely what foul villainy it might be that
+the Morlocks did under the new moon. I felt pretty sure now that
+my second hypothesis was all wrong. The Upper-world people might
+once have been the favoured aristocracy, and the Morlocks their
+mechanical servants: but that had long since passed away. The two
+species that had resulted from the evolution of man were sliding
+down towards, or had already arrived at, an altogether new
+relationship. The Eloi, like the Carolingian kings, had decayed
+to a mere beautiful futility. They still possessed the earth on
+sufferance: since the Morlocks, subterranean for innumerable
+generations, had come at last to find the daylit surface
+intolerable. And the Morlocks made their garments, I inferred, and
+maintained them in their habitual needs, perhaps through the
+survival of an old habit of service. They did it as a standing horse
+paws with his foot, or as a man enjoys killing animals in sport:
+because ancient and departed necessities had impressed it on the
+organism. But, clearly, the old order was already in part reversed.
+The Nemesis of the delicate ones was creeping on apace. Ages ago,
+thousands of generations ago, man had thrust his brother man out of
+the ease and the sunshine. And now that brother was coming back
+changed! Already the Eloi had begun to learn one old lesson anew.
+They were becoming reacquainted with Fear. And suddenly there came
+into my head the memory of the meat I had seen in the Under-world.
+It seemed odd how it floated into my mind: not stirred up as it
+were by the current of my meditations, but coming in almost like a
+question from outside. I tried to recall the form of it. I had a
+vague sense of something familiar, but I could not tell what it was
+at the time.
+
+'Still, however helpless the little people in the presence of their
+mysterious Fear, I was differently constituted. I came out of this
+age of ours, this ripe prime of the human race, when Fear does not
+paralyse and mystery has lost its terrors. I at least would defend
+myself. Without further delay I determined to make myself arms and a
+fastness where I might sleep. With that refuge as a base, I could
+face this strange world with some of that confidence I had lost in
+realizing to what creatures night by night I lay exposed. I felt
+I could never sleep again until my bed was secure from them. I
+shuddered with horror to think how they must already have examined
+me.
+
+'I wandered during the afternoon along the valley of the Thames, but
+found nothing that commended itself to my mind as inaccessible. All
+the buildings and trees seemed easily practicable to such dexterous
+climbers as the Morlocks, to judge by their wells, must be. Then the
+tall pinnacles of the Palace of Green Porcelain and the polished
+gleam of its walls came back to my memory; and in the evening,
+taking Weena like a child upon my shoulder, I went up the hills
+towards the south-west. The distance, I had reckoned, was seven or
+eight miles, but it must have been nearer eighteen. I had first seen
+the place on a moist afternoon when distances are deceptively
+diminished. In addition, the heel of one of my shoes was loose, and
+a nail was working through the sole--they were comfortable old shoes
+I wore about indoors--so that I was lame. And it was already long
+past sunset when I came in sight of the palace, silhouetted black
+against the pale yellow of the sky.
+
+'Weena had been hugely delighted when I began to carry her, but
+after a while she desired me to let her down, and ran along by the
+side of me, occasionally darting off on either hand to pick flowers
+to stick in my pockets. My pockets had always puzzled Weena, but at
+the last she had concluded that they were an eccentric kind of vase
+for floral decoration. At least she utilized them for that purpose.
+And that reminds me! In changing my jacket I found...'
+
+The Time Traveller paused, put his hand into his pocket, and
+silently placed two withered flowers, not unlike very large white
+mallows, upon the little table. Then he resumed his narrative.
+
+'As the hush of evening crept over the world and we proceeded over
+the hill crest towards Wimbledon, Weena grew tired and wanted to
+return to the house of grey stone. But I pointed out the distant
+pinnacles of the Palace of Green Porcelain to her, and contrived to
+make her understand that we were seeking a refuge there from her
+Fear. You know that great pause that comes upon things before the
+dusk? Even the breeze stops in the trees. To me there is always an
+air of expectation about that evening stillness. The sky was clear,
+remote, and empty save for a few horizontal bars far down in the
+sunset. Well, that night the expectation took the colour of my
+fears. In that darkling calm my senses seemed preternaturally
+sharpened. I fancied I could even feel the hollowness of the ground
+beneath my feet: could, indeed, almost see through it the Morlocks
+on their ant-hill going hither and thither and waiting for the dark.
+In my excitement I fancied that they would receive my invasion of
+their burrows as a declaration of war. And why had they taken my
+Time Machine?
+
+'So we went on in the quiet, and the twilight deepened into night.
+The clear blue of the distance faded, and one star after another
+came out. The ground grew dim and the trees black. Weena's fears and
+her fatigue grew upon her. I took her in my arms and talked to her
+and caressed her. Then, as the darkness grew deeper, she put her
+arms round my neck, and, closing her eyes, tightly pressed her face
+against my shoulder. So we went down a long slope into a valley, and
+there in the dimness I almost walked into a little river. This I
+waded, and went up the opposite side of the valley, past a number
+of sleeping houses, and by a statue--a Faun, or some such figure,
+_minus_ the head. Here too were acacias. So far I had seen nothing of
+the Morlocks, but it was yet early in the night, and the darker hours
+before the old moon rose were still to come.
+
+'From the brow of the next hill I saw a thick wood spreading wide
+and black before me. I hesitated at this. I could see no end to
+it, either to the right or the left. Feeling tired--my feet, in
+particular, were very sore--I carefully lowered Weena from my
+shoulder as I halted, and sat down upon the turf. I could no
+longer see the Palace of Green Porcelain, and I was in doubt of my
+direction. I looked into the thickness of the wood and thought of
+what it might hide. Under that dense tangle of branches one would
+be out of sight of the stars. Even were there no other lurking
+danger--a danger I did not care to let my imagination loose
+upon--there would still be all the roots to stumble over and the
+tree-boles to strike against.
+
+'I was very tired, too, after the excitements of the day; so I
+decided that I would not face it, but would pass the night upon the
+open hill.
+
+'Weena, I was glad to find, was fast asleep. I carefully wrapped her
+in my jacket, and sat down beside her to wait for the moonrise. The
+hill-side was quiet and deserted, but from the black of the wood
+there came now and then a stir of living things. Above me shone the
+stars, for the night was very clear. I felt a certain sense of
+friendly comfort in their twinkling. All the old constellations
+had gone from the sky, however: that slow movement which is
+imperceptible in a hundred human lifetimes, had long since
+rearranged them in unfamiliar groupings. But the Milky Way, it
+seemed to me, was still the same tattered streamer of star-dust as
+of yore. Southward (as I judged it) was a very bright red star that
+was new to me; it was even more splendid than our own green Sirius.
+And amid all these scintillating points of light one bright planet
+shone kindly and steadily like the face of an old friend.
+
+'Looking at these stars suddenly dwarfed my own troubles and all
+the gravities of terrestrial life. I thought of their unfathomable
+distance, and the slow inevitable drift of their movements out of
+the unknown past into the unknown future. I thought of the great
+precessional cycle that the pole of the earth describes. Only forty
+times had that silent revolution occurred during all the years that
+I had traversed. And during these few revolutions all the activity,
+all the traditions, the complex organizations, the nations,
+languages, literatures, aspirations, even the mere memory of Man as
+I knew him, had been swept out of existence. Instead were these
+frail creatures who had forgotten their high ancestry, and the white
+Things of which I went in terror. Then I thought of the Great Fear
+that was between the two species, and for the first time, with a
+sudden shiver, came the clear knowledge of what the meat I had seen
+might be. Yet it was too horrible! I looked at little Weena sleeping
+beside me, her face white and starlike under the stars, and
+forthwith dismissed the thought.
+
+'Through that long night I held my mind off the Morlocks as well as
+I could, and whiled away the time by trying to fancy I could find
+signs of the old constellations in the new confusion. The sky kept
+very clear, except for a hazy cloud or so. No doubt I dozed at
+times. Then, as my vigil wore on, came a faintness in the eastward
+sky, like the reflection of some colourless fire, and the old moon
+rose, thin and peaked and white. And close behind, and overtaking
+it, and overflowing it, the dawn came, pale at first, and then
+growing pink and warm. No Morlocks had approached us. Indeed, I had
+seen none upon the hill that night. And in the confidence of renewed
+day it almost seemed to me that my fear had been unreasonable. I
+stood up and found my foot with the loose heel swollen at the ankle
+and painful under the heel; so I sat down again, took off my shoes,
+and flung them away.
+
+'I awakened Weena, and we went down into the wood, now green and
+pleasant instead of black and forbidding. We found some fruit
+wherewith to break our fast. We soon met others of the dainty ones,
+laughing and dancing in the sunlight as though there was no such
+thing in nature as the night. And then I thought once more of the
+meat that I had seen. I felt assured now of what it was, and from
+the bottom of my heart I pitied this last feeble rill from the great
+flood of humanity. Clearly, at some time in the Long-Ago of human
+decay the Morlocks' food had run short. Possibly they had lived on
+rats and such-like vermin. Even now man is far less discriminating
+and exclusive in his food than he was--far less than any monkey. His
+prejudice against human flesh is no deep-seated instinct. And so
+these inhuman sons of men----! I tried to look at the thing in a
+scientific spirit. After all, they were less human and more remote
+than our cannibal ancestors of three or four thousand years ago.
+And the intelligence that would have made this state of things a
+torment had gone. Why should I trouble myself? These Eloi were mere
+fatted cattle, which the ant-like Morlocks preserved and preyed
+upon--probably saw to the breeding of. And there was Weena dancing
+at my side!
+
+'Then I tried to preserve myself from the horror that was coming
+upon me, by regarding it as a rigorous punishment of human
+selfishness. Man had been content to live in ease and delight upon
+the labours of his fellow-man, had taken Necessity as his watchword
+and excuse, and in the fullness of time Necessity had come home to
+him. I even tried a Carlyle-like scorn of this wretched aristocracy
+in decay. But this attitude of mind was impossible. However great
+their intellectual degradation, the Eloi had kept too much of the
+human form not to claim my sympathy, and to make me perforce a
+sharer in their degradation and their Fear.
+
+'I had at that time very vague ideas as to the course I should
+pursue. My first was to secure some safe place of refuge, and to
+make myself such arms of metal or stone as I could contrive. That
+necessity was immediate. In the next place, I hoped to procure some
+means of fire, so that I should have the weapon of a torch at hand,
+for nothing, I knew, would be more efficient against these Morlocks.
+Then I wanted to arrange some contrivance to break open the doors of
+bronze under the White Sphinx. I had in mind a battering ram. I had
+a persuasion that if I could enter those doors and carry a blaze of
+light before me I should discover the Time Machine and escape. I
+could not imagine the Morlocks were strong enough to move it far
+away. Weena I had resolved to bring with me to our own time. And
+turning such schemes over in my mind I pursued our way towards the
+building which my fancy had chosen as our dwelling.
+
+
+
+
+VIII
+
+
+'I found the Palace of Green Porcelain, when we approached it about
+noon, deserted and falling into ruin. Only ragged vestiges of glass
+remained in its windows, and great sheets of the green facing had
+fallen away from the corroded metallic framework. It lay very high
+upon a turfy down, and looking north-eastward before I entered it, I
+was surprised to see a large estuary, or even creek, where I judged
+Wandsworth and Battersea must once have been. I thought then--though
+I never followed up the thought--of what might have happened, or
+might be happening, to the living things in the sea.
+
+'The material of the Palace proved on examination to be indeed
+porcelain, and along the face of it I saw an inscription in some
+unknown character. I thought, rather foolishly, that Weena might
+help me to interpret this, but I only learned that the bare idea of
+writing had never entered her head. She always seemed to me, I
+fancy, more human than she was, perhaps because her affection was so
+human.
+
+'Within the big valves of the door--which were open and broken--we
+found, instead of the customary hall, a long gallery lit by many
+side windows. At the first glance I was reminded of a museum.
+The tiled floor was thick with dust, and a remarkable array of
+miscellaneous objects was shrouded in the same grey covering. Then
+I perceived, standing strange and gaunt in the centre of the hall,
+what was clearly the lower part of a huge skeleton. I recognized
+by the oblique feet that it was some extinct creature after the
+fashion of the Megatherium. The skull and the upper bones lay
+beside it in the thick dust, and in one place, where rain-water had
+dropped through a leak in the roof, the thing itself had been worn
+away. Further in the gallery was the huge skeleton barrel of a
+Brontosaurus. My museum hypothesis was confirmed. Going towards the
+side I found what appeared to be sloping shelves, and clearing away
+the thick dust, I found the old familiar glass cases of our own
+time. But they must have been air-tight to judge from the fair
+preservation of some of their contents.
+
+'Clearly we stood among the ruins of some latter-day South
+Kensington! Here, apparently, was the Palaeontological Section,
+and a very splendid array of fossils it must have been, though the
+inevitable process of decay that had been staved off for a time, and
+had, through the extinction of bacteria and fungi, lost ninety-nine
+hundredths of its force, was nevertheless, with extreme sureness if
+with extreme slowness at work again upon all its treasures. Here and
+there I found traces of the little people in the shape of rare
+fossils broken to pieces or threaded in strings upon reeds. And the
+cases had in some instances been bodily removed--by the Morlocks as
+I judged. The place was very silent. The thick dust deadened our
+footsteps. Weena, who had been rolling a sea urchin down the sloping
+glass of a case, presently came, as I stared about me, and very
+quietly took my hand and stood beside me.
+
+'And at first I was so much surprised by this ancient monument of an
+intellectual age, that I gave no thought to the possibilities it
+presented. Even my preoccupation about the Time Machine receded a
+little from my mind.
+
+'To judge from the size of the place, this Palace of Green Porcelain
+had a great deal more in it than a Gallery of Palaeontology;
+possibly historical galleries; it might be, even a library! To me,
+at least in my present circumstances, these would be vastly more
+interesting than this spectacle of oldtime geology in decay.
+Exploring, I found another short gallery running transversely to the
+first. This appeared to be devoted to minerals, and the sight of a
+block of sulphur set my mind running on gunpowder. But I could find
+no saltpeter; indeed, no nitrates of any kind. Doubtless they had
+deliquesced ages ago. Yet the sulphur hung in my mind, and set up a
+train of thinking. As for the rest of the contents of that gallery,
+though on the whole they were the best preserved of all I saw, I had
+little interest. I am no specialist in mineralogy, and I went on
+down a very ruinous aisle running parallel to the first hall I had
+entered. Apparently this section had been devoted to natural
+history, but everything had long since passed out of recognition. A
+few shrivelled and blackened vestiges of what had once been stuffed
+animals, desiccated mummies in jars that had once held spirit, a
+brown dust of departed plants: that was all! I was sorry for that,
+because I should have been glad to trace the patent readjustments by
+which the conquest of animated nature had been attained. Then we
+came to a gallery of simply colossal proportions, but singularly
+ill-lit, the floor of it running downward at a slight angle from the
+end at which I entered. At intervals white globes hung from the
+ceiling--many of them cracked and smashed--which suggested that
+originally the place had been artificially lit. Here I was more in
+my element, for rising on either side of me were the huge bulks of
+big machines, all greatly corroded and many broken down, but some
+still fairly complete. You know I have a certain weakness for
+mechanism, and I was inclined to linger among these; the more so as
+for the most part they had the interest of puzzles, and I could make
+only the vaguest guesses at what they were for. I fancied that if
+I could solve their puzzles I should find myself in possession of
+powers that might be of use against the Morlocks.
+
+'Suddenly Weena came very close to my side. So suddenly that she
+startled me. Had it not been for her I do not think I should have
+noticed that the floor of the gallery sloped at all. [Footnote: It
+may be, of course, that the floor did not slope, but that the museum
+was built into the side of a hill.--ED.] The end I had come in at
+was quite above ground, and was lit by rare slit-like windows. As
+you went down the length, the ground came up against these windows,
+until at last there was a pit like the "area" of a London house
+before each, and only a narrow line of daylight at the top. I went
+slowly along, puzzling about the machines, and had been too intent
+upon them to notice the gradual diminution of the light, until
+Weena's increasing apprehensions drew my attention. Then I saw that
+the gallery ran down at last into a thick darkness. I hesitated, and
+then, as I looked round me, I saw that the dust was less abundant
+and its surface less even. Further away towards the dimness, it
+appeared to be broken by a number of small narrow footprints. My
+sense of the immediate presence of the Morlocks revived at that.
+I felt that I was wasting my time in the academic examination of
+machinery. I called to mind that it was already far advanced in the
+afternoon, and that I had still no weapon, no refuge, and no means
+of making a fire. And then down in the remote blackness of the
+gallery I heard a peculiar pattering, and the same odd noises I had
+heard down the well.
+
+'I took Weena's hand. Then, struck with a sudden idea, I left her
+and turned to a machine from which projected a lever not unlike
+those in a signal-box. Clambering upon the stand, and grasping this
+lever in my hands, I put all my weight upon it sideways. Suddenly
+Weena, deserted in the central aisle, began to whimper. I had judged
+the strength of the lever pretty correctly, for it snapped after a
+minute's strain, and I rejoined her with a mace in my hand more than
+sufficient, I judged, for any Morlock skull I might encounter. And I
+longed very much to kill a Morlock or so. Very inhuman, you may
+think, to want to go killing one's own descendants! But it was
+impossible, somehow, to feel any humanity in the things. Only my
+disinclination to leave Weena, and a persuasion that if I began to
+slake my thirst for murder my Time Machine might suffer, restrained
+me from going straight down the gallery and killing the brutes I
+heard.
+
+'Well, mace in one hand and Weena in the other, I went out of that
+gallery and into another and still larger one, which at the first
+glance reminded me of a military chapel hung with tattered flags.
+The brown and charred rags that hung from the sides of it, I
+presently recognized as the decaying vestiges of books. They had
+long since dropped to pieces, and every semblance of print had left
+them. But here and there were warped boards and cracked metallic
+clasps that told the tale well enough. Had I been a literary man I
+might, perhaps, have moralized upon the futility of all ambition.
+But as it was, the thing that struck me with keenest force was the
+enormous waste of labour to which this sombre wilderness of rotting
+paper testified. At the time I will confess that I thought chiefly
+of the _Philosophical Transactions_ and my own seventeen papers upon
+physical optics.
+
+'Then, going up a broad staircase, we came to what may once have
+been a gallery of technical chemistry. And here I had not a little
+hope of useful discoveries. Except at one end where the roof had
+collapsed, this gallery was well preserved. I went eagerly to every
+unbroken case. And at last, in one of the really air-tight cases,
+I found a box of matches. Very eagerly I tried them. They were
+perfectly good. They were not even damp. I turned to Weena. "Dance,"
+I cried to her in her own tongue. For now I had a weapon indeed
+against the horrible creatures we feared. And so, in that derelict
+museum, upon the thick soft carpeting of dust, to Weena's huge
+delight, I solemnly performed a kind of composite dance, whistling
+_The Land of the Leal_ as cheerfully as I could. In part it was a
+modest _cancan_, in part a step dance, in part a skirt-dance (so far
+as my tail-coat permitted), and in part original. For I am naturally
+inventive, as you know.
+
+'Now, I still think that for this box of matches to have escaped
+the wear of time for immemorial years was a most strange, as for
+me it was a most fortunate thing. Yet, oddly enough, I found a far
+unlikelier substance, and that was camphor. I found it in a sealed
+jar, that by chance, I suppose, had been really hermetically sealed.
+I fancied at first that it was paraffin wax, and smashed the glass
+accordingly. But the odour of camphor was unmistakable. In the
+universal decay this volatile substance had chanced to survive,
+perhaps through many thousands of centuries. It reminded me of a
+sepia painting I had once seen done from the ink of a fossil
+Belemnite that must have perished and become fossilized millions
+of years ago. I was about to throw it away, but I remembered that
+it was inflammable and burned with a good bright flame--was, in
+fact, an excellent candle--and I put it in my pocket. I found no
+explosives, however, nor any means of breaking down the bronze
+doors. As yet my iron crowbar was the most helpful thing I had
+chanced upon. Nevertheless I left that gallery greatly elated.
+
+'I cannot tell you all the story of that long afternoon. It would
+require a great effort of memory to recall my explorations in at all
+the proper order. I remember a long gallery of rusting stands of
+arms, and how I hesitated between my crowbar and a hatchet or a
+sword. I could not carry both, however, and my bar of iron promised
+best against the bronze gates. There were numbers of guns, pistols,
+and rifles. The most were masses of rust, but many were of some
+new metal, and still fairly sound. But any cartridges or powder
+there may once have been had rotted into dust. One corner I saw was
+charred and shattered; perhaps, I thought, by an explosion among the
+specimens. In another place was a vast array of idols--Polynesian,
+Mexican, Grecian, Phoenician, every country on earth I should think.
+And here, yielding to an irresistible impulse, I wrote my name upon
+the nose of a steatite monster from South America that particularly
+took my fancy.
+
+'As the evening drew on, my interest waned. I went through gallery
+after gallery, dusty, silent, often ruinous, the exhibits sometimes
+mere heaps of rust and lignite, sometimes fresher. In one place I
+suddenly found myself near the model of a tin-mine, and then by the
+merest accident I discovered, in an air-tight case, two dynamite
+cartridges! I shouted "Eureka!" and smashed the case with joy. Then
+came a doubt. I hesitated. Then, selecting a little side gallery,
+I made my essay. I never felt such a disappointment as I did in
+waiting five, ten, fifteen minutes for an explosion that never came.
+Of course the things were dummies, as I might have guessed from
+their presence. I really believe that had they not been so, I should
+have rushed off incontinently and blown Sphinx, bronze doors, and
+(as it proved) my chances of finding the Time Machine, all together
+into non-existence.
+
+'It was after that, I think, that we came to a little open court
+within the palace. It was turfed, and had three fruit-trees. So we
+rested and refreshed ourselves. Towards sunset I began to consider
+our position. Night was creeping upon us, and my inaccessible
+hiding-place had still to be found. But that troubled me very little
+now. I had in my possession a thing that was, perhaps, the best of
+all defences against the Morlocks--I had matches! I had the camphor
+in my pocket, too, if a blaze were needed. It seemed to me that
+the best thing we could do would be to pass the night in the open,
+protected by a fire. In the morning there was the getting of the
+Time Machine. Towards that, as yet, I had only my iron mace. But
+now, with my growing knowledge, I felt very differently towards
+those bronze doors. Up to this, I had refrained from forcing them,
+largely because of the mystery on the other side. They had never
+impressed me as being very strong, and I hoped to find my bar of
+iron not altogether inadequate for the work.
+
+
+
+
+IX
+
+
+'We emerged from the palace while the sun was still in part above
+the horizon. I was determined to reach the White Sphinx early the
+next morning, and ere the dusk I purposed pushing through the woods
+that had stopped me on the previous journey. My plan was to go as
+far as possible that night, and then, building a fire, to sleep
+in the protection of its glare. Accordingly, as we went along I
+gathered any sticks or dried grass I saw, and presently had my arms
+full of such litter. Thus loaded, our progress was slower than I had
+anticipated, and besides Weena was tired. And I began to suffer from
+sleepiness too; so that it was full night before we reached the
+wood. Upon the shrubby hill of its edge Weena would have stopped,
+fearing the darkness before us; but a singular sense of impending
+calamity, that should indeed have served me as a warning, drove me
+onward. I had been without sleep for a night and two days, and I was
+feverish and irritable. I felt sleep coming upon me, and the
+Morlocks with it.
+
+'While we hesitated, among the black bushes behind us, and dim
+against their blackness, I saw three crouching figures. There was
+scrub and long grass all about us, and I did not feel safe from
+their insidious approach. The forest, I calculated, was rather
+less than a mile across. If we could get through it to the bare
+hill-side, there, as it seemed to me, was an altogether safer
+resting-place; I thought that with my matches and my camphor I could
+contrive to keep my path illuminated through the woods. Yet it was
+evident that if I was to flourish matches with my hands I should
+have to abandon my firewood; so, rather reluctantly, I put it down.
+And then it came into my head that I would amaze our friends behind
+by lighting it. I was to discover the atrocious folly of this
+proceeding, but it came to my mind as an ingenious move for covering
+our retreat.
+
+'I don't know if you have ever thought what a rare thing flame must
+be in the absence of man and in a temperate climate. The sun's
+heat is rarely strong enough to burn, even when it is focused by
+dewdrops, as is sometimes the case in more tropical districts.
+Lightning may blast and blacken, but it rarely gives rise to
+widespread fire. Decaying vegetation may occasionally smoulder with
+the heat of its fermentation, but this rarely results in flame. In
+this decadence, too, the art of fire-making had been forgotten on
+the earth. The red tongues that went licking up my heap of wood were
+an altogether new and strange thing to Weena.
+
+'She wanted to run to it and play with it. I believe she would have
+cast herself into it had I not restrained her. But I caught her up,
+and in spite of her struggles, plunged boldly before me into the
+wood. For a little way the glare of my fire lit the path. Looking
+back presently, I could see, through the crowded stems, that from my
+heap of sticks the blaze had spread to some bushes adjacent, and a
+curved line of fire was creeping up the grass of the hill. I laughed
+at that, and turned again to the dark trees before me. It was very
+black, and Weena clung to me convulsively, but there was still, as
+my eyes grew accustomed to the darkness, sufficient light for me to
+avoid the stems. Overhead it was simply black, except where a gap of
+remote blue sky shone down upon us here and there. I struck none of
+my matches because I had no hand free. Upon my left arm I carried my
+little one, in my right hand I had my iron bar.
+
+'For some way I heard nothing but the crackling twigs under my feet,
+the faint rustle of the breeze above, and my own breathing and the
+throb of the blood-vessels in my ears. Then I seemed to know of a
+pattering about me. I pushed on grimly. The pattering grew more
+distinct, and then I caught the same queer sound and voices I had
+heard in the Under-world. There were evidently several of the
+Morlocks, and they were closing in upon me. Indeed, in another
+minute I felt a tug at my coat, then something at my arm. And Weena
+shivered violently, and became quite still.
+
+'It was time for a match. But to get one I must put her down. I did
+so, and, as I fumbled with my pocket, a struggle began in the
+darkness about my knees, perfectly silent on her part and with the
+same peculiar cooing sounds from the Morlocks. Soft little hands,
+too, were creeping over my coat and back, touching even my neck.
+Then the match scratched and fizzed. I held it flaring, and saw the
+white backs of the Morlocks in flight amid the trees. I hastily took
+a lump of camphor from my pocket, and prepared to light it as soon
+as the match should wane. Then I looked at Weena. She was lying
+clutching my feet and quite motionless, with her face to the ground.
+With a sudden fright I stooped to her. She seemed scarcely to
+breathe. I lit the block of camphor and flung it to the ground,
+and as it split and flared up and drove back the Morlocks and the
+shadows, I knelt down and lifted her. The wood behind seemed full of
+the stir and murmur of a great company!
+
+'She seemed to have fainted. I put her carefully upon my shoulder
+and rose to push on, and then there came a horrible realization. In
+manoeuvring with my matches and Weena, I had turned myself about
+several times, and now I had not the faintest idea in what direction
+lay my path. For all I knew, I might be facing back towards the
+Palace of Green Porcelain. I found myself in a cold sweat. I had to
+think rapidly what to do. I determined to build a fire and encamp
+where we were. I put Weena, still motionless, down upon a turfy
+bole, and very hastily, as my first lump of camphor waned, I began
+collecting sticks and leaves. Here and there out of the darkness
+round me the Morlocks' eyes shone like carbuncles.
+
+'The camphor flickered and went out. I lit a match, and as I did so,
+two white forms that had been approaching Weena dashed hastily away.
+One was so blinded by the light that he came straight for me, and I
+felt his bones grind under the blow of my fist. He gave a whoop of
+dismay, staggered a little way, and fell down. I lit another piece
+of camphor, and went on gathering my bonfire. Presently I noticed
+how dry was some of the foliage above me, for since my arrival
+on the Time Machine, a matter of a week, no rain had fallen. So,
+instead of casting about among the trees for fallen twigs, I began
+leaping up and dragging down branches. Very soon I had a choking
+smoky fire of green wood and dry sticks, and could economize my
+camphor. Then I turned to where Weena lay beside my iron mace. I
+tried what I could to revive her, but she lay like one dead. I could
+not even satisfy myself whether or not she breathed.
+
+'Now, the smoke of the fire beat over towards me, and it must have
+made me heavy of a sudden. Moreover, the vapour of camphor was in
+the air. My fire would not need replenishing for an hour or so. I
+felt very weary after my exertion, and sat down. The wood, too, was
+full of a slumbrous murmur that I did not understand. I seemed just
+to nod and open my eyes. But all was dark, and the Morlocks had
+their hands upon me. Flinging off their clinging fingers I hastily
+felt in my pocket for the match-box, and--it had gone! Then they
+gripped and closed with me again. In a moment I knew what had
+happened. I had slept, and my fire had gone out, and the bitterness
+of death came over my soul. The forest seemed full of the smell of
+burning wood. I was caught by the neck, by the hair, by the arms,
+and pulled down. It was indescribably horrible in the darkness to
+feel all these soft creatures heaped upon me. I felt as if I was in
+a monstrous spider's web. I was overpowered, and went down. I felt
+little teeth nipping at my neck. I rolled over, and as I did so my
+hand came against my iron lever. It gave me strength. I struggled
+up, shaking the human rats from me, and, holding the bar short,
+I thrust where I judged their faces might be. I could feel the
+succulent giving of flesh and bone under my blows, and for a moment
+I was free.
+
+'The strange exultation that so often seems to accompany hard
+fighting came upon me. I knew that both I and Weena were lost, but I
+determined to make the Morlocks pay for their meat. I stood with my
+back to a tree, swinging the iron bar before me. The whole wood was
+full of the stir and cries of them. A minute passed. Their voices
+seemed to rise to a higher pitch of excitement, and their movements
+grew faster. Yet none came within reach. I stood glaring at the
+blackness. Then suddenly came hope. What if the Morlocks were
+afraid? And close on the heels of that came a strange thing. The
+darkness seemed to grow luminous. Very dimly I began to see the
+Morlocks about me--three battered at my feet--and then I recognized,
+with incredulous surprise, that the others were running, in an
+incessant stream, as it seemed, from behind me, and away through the
+wood in front. And their backs seemed no longer white, but reddish.
+As I stood agape, I saw a little red spark go drifting across a gap
+of starlight between the branches, and vanish. And at that I
+understood the smell of burning wood, the slumbrous murmur that was
+growing now into a gusty roar, the red glow, and the Morlocks'
+flight.
+
+'Stepping out from behind my tree and looking back, I saw, through
+the black pillars of the nearer trees, the flames of the burning
+forest. It was my first fire coming after me. With that I looked for
+Weena, but she was gone. The hissing and crackling behind me, the
+explosive thud as each fresh tree burst into flame, left little
+time for reflection. My iron bar still gripped, I followed in the
+Morlocks' path. It was a close race. Once the flames crept forward
+so swiftly on my right as I ran that I was outflanked and had to
+strike off to the left. But at last I emerged upon a small open
+space, and as I did so, a Morlock came blundering towards me, and
+past me, and went on straight into the fire!
+
+'And now I was to see the most weird and horrible thing, I think, of
+all that I beheld in that future age. This whole space was as bright
+as day with the reflection of the fire. In the centre was a hillock
+or tumulus, surmounted by a scorched hawthorn. Beyond this was
+another arm of the burning forest, with yellow tongues already
+writhing from it, completely encircling the space with a fence of
+fire. Upon the hill-side were some thirty or forty Morlocks, dazzled
+by the light and heat, and blundering hither and thither against
+each other in their bewilderment. At first I did not realize their
+blindness, and struck furiously at them with my bar, in a frenzy of
+fear, as they approached me, killing one and crippling several more.
+But when I had watched the gestures of one of them groping under the
+hawthorn against the red sky, and heard their moans, I was assured
+of their absolute helplessness and misery in the glare, and I struck
+no more of them.
+
+'Yet every now and then one would come straight towards me, setting
+loose a quivering horror that made me quick to elude him. At one
+time the flames died down somewhat, and I feared the foul creatures
+would presently be able to see me. I was thinking of beginning the
+fight by killing some of them before this should happen; but the
+fire burst out again brightly, and I stayed my hand. I walked about
+the hill among them and avoided them, looking for some trace of
+Weena. But Weena was gone.
+
+'At last I sat down on the summit of the hillock, and watched this
+strange incredible company of blind things groping to and fro, and
+making uncanny noises to each other, as the glare of the fire beat
+on them. The coiling uprush of smoke streamed across the sky, and
+through the rare tatters of that red canopy, remote as though they
+belonged to another universe, shone the little stars. Two or three
+Morlocks came blundering into me, and I drove them off with blows
+of my fists, trembling as I did so.
+
+'For the most part of that night I was persuaded it was a nightmare.
+I bit myself and screamed in a passionate desire to awake. I beat
+the ground with my hands, and got up and sat down again, and
+wandered here and there, and again sat down. Then I would fall to
+rubbing my eyes and calling upon God to let me awake. Thrice I saw
+Morlocks put their heads down in a kind of agony and rush into the
+flames. But, at last, above the subsiding red of the fire, above the
+streaming masses of black smoke and the whitening and blackening
+tree stumps, and the diminishing numbers of these dim creatures,
+came the white light of the day.
+
+'I searched again for traces of Weena, but there were none. It was
+plain that they had left her poor little body in the forest. I
+cannot describe how it relieved me to think that it had escaped the
+awful fate to which it seemed destined. As I thought of that, I was
+almost moved to begin a massacre of the helpless abominations about
+me, but I contained myself. The hillock, as I have said, was a kind
+of island in the forest. From its summit I could now make out
+through a haze of smoke the Palace of Green Porcelain, and from that
+I could get my bearings for the White Sphinx. And so, leaving the
+remnant of these damned souls still going hither and thither and
+moaning, as the day grew clearer, I tied some grass about my feet
+and limped on across smoking ashes and among black stems, that still
+pulsated internally with fire, towards the hiding-place of the Time
+Machine. I walked slowly, for I was almost exhausted, as well as
+lame, and I felt the intensest wretchedness for the horrible death
+of little Weena. It seemed an overwhelming calamity. Now, in this
+old familiar room, it is more like the sorrow of a dream than an
+actual loss. But that morning it left me absolutely lonely
+again--terribly alone. I began to think of this house of mine, of
+this fireside, of some of you, and with such thoughts came a longing
+that was pain.
+
+'But as I walked over the smoking ashes under the bright morning
+sky, I made a discovery. In my trouser pocket were still some loose
+matches. The box must have leaked before it was lost.
+
+
+
+
+X
+
+
+'About eight or nine in the morning I came to the same seat of
+yellow metal from which I had viewed the world upon the evening of
+my arrival. I thought of my hasty conclusions upon that evening and
+could not refrain from laughing bitterly at my confidence. Here
+was the same beautiful scene, the same abundant foliage, the same
+splendid palaces and magnificent ruins, the same silver river
+running between its fertile banks. The gay robes of the beautiful
+people moved hither and thither among the trees. Some were bathing
+in exactly the place where I had saved Weena, and that suddenly gave
+me a keen stab of pain. And like blots upon the landscape rose the
+cupolas above the ways to the Under-world. I understood now what all
+the beauty of the Over-world people covered. Very pleasant was their
+day, as pleasant as the day of the cattle in the field. Like the
+cattle, they knew of no enemies and provided against no needs. And
+their end was the same.
+
+'I grieved to think how brief the dream of the human intellect had
+been. It had committed suicide. It had set itself steadfastly
+towards comfort and ease, a balanced society with security and
+permanency as its watchword, it had attained its hopes--to come
+to this at last. Once, life and property must have reached almost
+absolute safety. The rich had been assured of his wealth and
+comfort, the toiler assured of his life and work. No doubt in that
+perfect world there had been no unemployed problem, no social
+question left unsolved. And a great quiet had followed.
+
+'It is a law of nature we overlook, that intellectual versatility
+is the compensation for change, danger, and trouble. An animal
+perfectly in harmony with its environment is a perfect mechanism.
+Nature never appeals to intelligence until habit and instinct are
+useless. There is no intelligence where there is no change and no
+need of change. Only those animals partake of intelligence that have
+to meet a huge variety of needs and dangers.
+
+'So, as I see it, the Upper-world man had drifted towards his
+feeble prettiness, and the Under-world to mere mechanical industry.
+But that perfect state had lacked one thing even for mechanical
+perfection--absolute permanency. Apparently as time went on, the
+feeding of the Under-world, however it was effected, had become
+disjointed. Mother Necessity, who had been staved off for a
+few thousand years, came back again, and she began below. The
+Under-world being in contact with machinery, which, however perfect,
+still needs some little thought outside habit, had probably retained
+perforce rather more initiative, if less of every other human
+character, than the Upper. And when other meat failed them, they
+turned to what old habit had hitherto forbidden. So I say I saw it
+in my last view of the world of Eight Hundred and Two Thousand Seven
+Hundred and One. It may be as wrong an explanation as mortal wit
+could invent. It is how the thing shaped itself to me, and as that I
+give it to you.
+
+'After the fatigues, excitements, and terrors of the past days, and
+in spite of my grief, this seat and the tranquil view and the warm
+sunlight were very pleasant. I was very tired and sleepy, and soon
+my theorizing passed into dozing. Catching myself at that, I took my
+own hint, and spreading myself out upon the turf I had a long and
+refreshing sleep.
+
+'I awoke a little before sunsetting. I now felt safe against being
+caught napping by the Morlocks, and, stretching myself, I came on
+down the hill towards the White Sphinx. I had my crowbar in one
+hand, and the other hand played with the matches in my pocket.
+
+'And now came a most unexpected thing. As I approached the pedestal
+of the sphinx I found the bronze valves were open. They had slid
+down into grooves.
+
+'At that I stopped short before them, hesitating to enter.
+
+'Within was a small apartment, and on a raised place in the corner
+of this was the Time Machine. I had the small levers in my pocket.
+So here, after all my elaborate preparations for the siege of the
+White Sphinx, was a meek surrender. I threw my iron bar away, almost
+sorry not to use it.
+
+'A sudden thought came into my head as I stooped towards the portal.
+For once, at least, I grasped the mental operations of the Morlocks.
+Suppressing a strong inclination to laugh, I stepped through the
+bronze frame and up to the Time Machine. I was surprised to find it
+had been carefully oiled and cleaned. I have suspected since that
+the Morlocks had even partially taken it to pieces while trying in
+their dim way to grasp its purpose.
+
+'Now as I stood and examined it, finding a pleasure in the mere
+touch of the contrivance, the thing I had expected happened. The
+bronze panels suddenly slid up and struck the frame with a clang.
+I was in the dark--trapped. So the Morlocks thought. At that I
+chuckled gleefully.
+
+'I could already hear their murmuring laughter as they came towards
+me. Very calmly I tried to strike the match. I had only to fix on
+the levers and depart then like a ghost. But I had overlooked one
+little thing. The matches were of that abominable kind that light
+only on the box.
+
+'You may imagine how all my calm vanished. The little brutes were
+close upon me. One touched me. I made a sweeping blow in the dark at
+them with the levers, and began to scramble into the saddle of the
+machine. Then came one hand upon me and then another. Then I had
+simply to fight against their persistent fingers for my levers, and
+at the same time feel for the studs over which these fitted. One,
+indeed, they almost got away from me. As it slipped from my hand,
+I had to butt in the dark with my head--I could hear the Morlock's
+skull ring--to recover it. It was a nearer thing than the fight in
+the forest, I think, this last scramble.
+
+'But at last the lever was fitted and pulled over. The clinging
+hands slipped from me. The darkness presently fell from my eyes.
+I found myself in the same grey light and tumult I have already
+described.
+
+
+
+
+XI
+
+
+'I have already told you of the sickness and confusion that comes
+with time travelling. And this time I was not seated properly in the
+saddle, but sideways and in an unstable fashion. For an indefinite
+time I clung to the machine as it swayed and vibrated, quite
+unheeding how I went, and when I brought myself to look at the dials
+again I was amazed to find where I had arrived. One dial records
+days, and another thousands of days, another millions of days, and
+another thousands of millions. Now, instead of reversing the levers,
+I had pulled them over so as to go forward with them, and when I
+came to look at these indicators I found that the thousands hand was
+sweeping round as fast as the seconds hand of a watch--into
+futurity.
+
+'As I drove on, a peculiar change crept over the appearance of
+things. The palpitating greyness grew darker; then--though I was
+still travelling with prodigious velocity--the blinking succession
+of day and night, which was usually indicative of a slower pace,
+returned, and grew more and more marked. This puzzled me very much
+at first. The alternations of night and day grew slower and slower,
+and so did the passage of the sun across the sky, until they seemed
+to stretch through centuries. At last a steady twilight brooded over
+the earth, a twilight only broken now and then when a comet glared
+across the darkling sky. The band of light that had indicated the
+sun had long since disappeared; for the sun had ceased to set--it
+simply rose and fell in the west, and grew ever broader and more
+red. All trace of the moon had vanished. The circling of the stars,
+growing slower and slower, had given place to creeping points of
+light. At last, some time before I stopped, the sun, red and very
+large, halted motionless upon the horizon, a vast dome glowing with
+a dull heat, and now and then suffering a momentary extinction. At
+one time it had for a little while glowed more brilliantly again,
+but it speedily reverted to its sullen red heat. I perceived by this
+slowing down of its rising and setting that the work of the tidal
+drag was done. The earth had come to rest with one face to the sun,
+even as in our own time the moon faces the earth. Very cautiously,
+for I remembered my former headlong fall, I began to reverse
+my motion. Slower and slower went the circling hands until the
+thousands one seemed motionless and the daily one was no longer a
+mere mist upon its scale. Still slower, until the dim outlines of a
+desolate beach grew visible.
+
+'I stopped very gently and sat upon the Time Machine, looking round.
+The sky was no longer blue. North-eastward it was inky black,
+and out of the blackness shone brightly and steadily the pale
+white stars. Overhead it was a deep Indian red and starless, and
+south-eastward it grew brighter to a glowing scarlet where, cut by
+the horizon, lay the huge hull of the sun, red and motionless. The
+rocks about me were of a harsh reddish colour, and all the trace of
+life that I could see at first was the intensely green vegetation
+that covered every projecting point on their south-eastern face. It
+was the same rich green that one sees on forest moss or on the
+lichen in caves: plants which like these grow in a perpetual
+twilight.
+
+'The machine was standing on a sloping beach. The sea stretched away
+to the south-west, to rise into a sharp bright horizon against the
+wan sky. There were no breakers and no waves, for not a breath of
+wind was stirring. Only a slight oily swell rose and fell like a
+gentle breathing, and showed that the eternal sea was still moving
+and living. And along the margin where the water sometimes broke was
+a thick incrustation of salt--pink under the lurid sky. There was a
+sense of oppression in my head, and I noticed that I was breathing
+very fast. The sensation reminded me of my only experience of
+mountaineering, and from that I judged the air to be more rarefied
+than it is now.
+
+'Far away up the desolate slope I heard a harsh scream, and saw a
+thing like a huge white butterfly go slanting and fluttering up into
+the sky and, circling, disappear over some low hillocks beyond. The
+sound of its voice was so dismal that I shivered and seated myself
+more firmly upon the machine. Looking round me again, I saw that,
+quite near, what I had taken to be a reddish mass of rock was moving
+slowly towards me. Then I saw the thing was really a monstrous
+crab-like creature. Can you imagine a crab as large as yonder table,
+with its many legs moving slowly and uncertainly, its big claws
+swaying, its long antennae, like carters' whips, waving and feeling,
+and its stalked eyes gleaming at you on either side of its metallic
+front? Its back was corrugated and ornamented with ungainly bosses,
+and a greenish incrustation blotched it here and there. I could see
+the many palps of its complicated mouth flickering and feeling as it
+moved.
+
+'As I stared at this sinister apparition crawling towards me, I felt
+a tickling on my cheek as though a fly had lighted there. I tried to
+brush it away with my hand, but in a moment it returned, and almost
+immediately came another by my ear. I struck at this, and caught
+something threadlike. It was drawn swiftly out of my hand. With a
+frightful qualm, I turned, and I saw that I had grasped the antenna
+of another monster crab that stood just behind me. Its evil eyes
+were wriggling on their stalks, its mouth was all alive with
+appetite, and its vast ungainly claws, smeared with an algal slime,
+were descending upon me. In a moment my hand was on the lever, and
+I had placed a month between myself and these monsters. But I was
+still on the same beach, and I saw them distinctly now as soon as I
+stopped. Dozens of them seemed to be crawling here and there, in the
+sombre light, among the foliated sheets of intense green.
+
+'I cannot convey the sense of abominable desolation that hung over
+the world. The red eastern sky, the northward blackness, the salt
+Dead Sea, the stony beach crawling with these foul, slow-stirring
+monsters, the uniform poisonous-looking green of the lichenous
+plants, the thin air that hurts one's lungs: all contributed to an
+appalling effect. I moved on a hundred years, and there was the same
+red sun--a little larger, a little duller--the same dying sea, the
+same chill air, and the same crowd of earthy crustacea creeping in
+and out among the green weed and the red rocks. And in the westward
+sky, I saw a curved pale line like a vast new moon.
+
+'So I travelled, stopping ever and again, in great strides of a
+thousand years or more, drawn on by the mystery of the earth's fate,
+watching with a strange fascination the sun grow larger and duller
+in the westward sky, and the life of the old earth ebb away. At
+last, more than thirty million years hence, the huge red-hot dome of
+the sun had come to obscure nearly a tenth part of the darkling
+heavens. Then I stopped once more, for the crawling multitude of
+crabs had disappeared, and the red beach, save for its livid green
+liverworts and lichens, seemed lifeless. And now it was flecked with
+white. A bitter cold assailed me. Rare white flakes ever and again
+came eddying down. To the north-eastward, the glare of snow lay
+under the starlight of the sable sky and I could see an undulating
+crest of hillocks pinkish white. There were fringes of ice along the
+sea margin, with drifting masses further out; but the main expanse
+of that salt ocean, all bloody under the eternal sunset, was still
+unfrozen.
+
+'I looked about me to see if any traces of animal life remained. A
+certain indefinable apprehension still kept me in the saddle of the
+machine. But I saw nothing moving, in earth or sky or sea. The green
+slime on the rocks alone testified that life was not extinct. A
+shallow sandbank had appeared in the sea and the water had receded
+from the beach. I fancied I saw some black object flopping about
+upon this bank, but it became motionless as I looked at it, and I
+judged that my eye had been deceived, and that the black object was
+merely a rock. The stars in the sky were intensely bright and seemed
+to me to twinkle very little.
+
+'Suddenly I noticed that the circular westward outline of the sun
+had changed; that a concavity, a bay, had appeared in the curve. I
+saw this grow larger. For a minute perhaps I stared aghast at this
+blackness that was creeping over the day, and then I realized that
+an eclipse was beginning. Either the moon or the planet Mercury was
+passing across the sun's disk. Naturally, at first I took it to be
+the moon, but there is much to incline me to believe that what I
+really saw was the transit of an inner planet passing very near to
+the earth.
+
+'The darkness grew apace; a cold wind began to blow in freshening
+gusts from the east, and the showering white flakes in the air
+increased in number. From the edge of the sea came a ripple and
+whisper. Beyond these lifeless sounds the world was silent. Silent?
+It would be hard to convey the stillness of it. All the sounds of
+man, the bleating of sheep, the cries of birds, the hum of insects,
+the stir that makes the background of our lives--all that was over.
+As the darkness thickened, the eddying flakes grew more abundant,
+dancing before my eyes; and the cold of the air more intense. At
+last, one by one, swiftly, one after the other, the white peaks of
+the distant hills vanished into blackness. The breeze rose to a
+moaning wind. I saw the black central shadow of the eclipse sweeping
+towards me. In another moment the pale stars alone were visible. All
+else was rayless obscurity. The sky was absolutely black.
+
+'A horror of this great darkness came on me. The cold, that smote
+to my marrow, and the pain I felt in breathing, overcame me. I
+shivered, and a deadly nausea seized me. Then like a red-hot bow
+in the sky appeared the edge of the sun. I got off the machine to
+recover myself. I felt giddy and incapable of facing the return
+journey. As I stood sick and confused I saw again the moving thing
+upon the shoal--there was no mistake now that it was a moving
+thing--against the red water of the sea. It was a round thing, the
+size of a football perhaps, or, it may be, bigger, and tentacles
+trailed down from it; it seemed black against the weltering
+blood-red water, and it was hopping fitfully about. Then I felt I
+was fainting. But a terrible dread of lying helpless in that remote
+and awful twilight sustained me while I clambered upon the saddle.
+
+
+
+
+XII
+
+
+'So I came back. For a long time I must have been insensible upon
+the machine. The blinking succession of the days and nights was
+resumed, the sun got golden again, the sky blue. I breathed with
+greater freedom. The fluctuating contours of the land ebbed and
+flowed. The hands spun backward upon the dials. At last I saw again
+the dim shadows of houses, the evidences of decadent humanity.
+These, too, changed and passed, and others came. Presently, when the
+million dial was at zero, I slackened speed. I began to recognize
+our own pretty and familiar architecture, the thousands hand ran back
+to the starting-point, the night and day flapped slower and slower.
+Then the old walls of the laboratory came round me. Very gently,
+now, I slowed the mechanism down.
+
+'I saw one little thing that seemed odd to me. I think I have told
+you that when I set out, before my velocity became very high, Mrs.
+Watchett had walked across the room, travelling, as it seemed to me,
+like a rocket. As I returned, I passed again across that minute when
+she traversed the laboratory. But now her every motion appeared to
+be the exact inversion of her previous ones. The door at the lower
+end opened, and she glided quietly up the laboratory, back foremost,
+and disappeared behind the door by which she had previously entered.
+Just before that I seemed to see Hillyer for a moment; but he passed
+like a flash.
+
+'Then I stopped the machine, and saw about me again the old familiar
+laboratory, my tools, my appliances just as I had left them. I got
+off the thing very shakily, and sat down upon my bench. For several
+minutes I trembled violently. Then I became calmer. Around me was
+my old workshop again, exactly as it had been. I might have slept
+there, and the whole thing have been a dream.
+
+'And yet, not exactly! The thing had started from the south-east
+corner of the laboratory. It had come to rest again in the
+north-west, against the wall where you saw it. That gives you the
+exact distance from my little lawn to the pedestal of the White
+Sphinx, into which the Morlocks had carried my machine.
+
+'For a time my brain went stagnant. Presently I got up and came
+through the passage here, limping, because my heel was still
+painful, and feeling sorely begrimed. I saw the _Pall Mall Gazette_
+on the table by the door. I found the date was indeed to-day, and
+looking at the timepiece, saw the hour was almost eight o'clock. I
+heard your voices and the clatter of plates. I hesitated--I felt so
+sick and weak. Then I sniffed good wholesome meat, and opened the
+door on you. You know the rest. I washed, and dined, and now I am
+telling you the story.
+
+'I know,' he said, after a pause, 'that all this will be absolutely
+incredible to you. To me the one incredible thing is that I am here
+to-night in this old familiar room looking into your friendly faces
+and telling you these strange adventures.'
+
+He looked at the Medical Man. 'No. I cannot expect you to believe
+it. Take it as a lie--or a prophecy. Say I dreamed it in the
+workshop. Consider I have been speculating upon the destinies of our
+race until I have hatched this fiction. Treat my assertion of its
+truth as a mere stroke of art to enhance its interest. And taking
+it as a story, what do you think of it?'
+
+He took up his pipe, and began, in his old accustomed manner, to tap
+with it nervously upon the bars of the grate. There was a momentary
+stillness. Then chairs began to creak and shoes to scrape upon the
+carpet. I took my eyes off the Time Traveller's face, and looked
+round at his audience. They were in the dark, and little spots of
+colour swam before them. The Medical Man seemed absorbed in the
+contemplation of our host. The Editor was looking hard at the end
+of his cigar--the sixth. The Journalist fumbled for his watch. The
+others, as far as I remember, were motionless.
+
+The Editor stood up with a sigh. 'What a pity it is you're not
+a writer of stories!' he said, putting his hand on the Time
+Traveller's shoulder.
+
+'You don't believe it?'
+
+'Well----'
+
+'I thought not.'
+
+The Time Traveller turned to us. 'Where are the matches?' he said.
+He lit one and spoke over his pipe, puffing. 'To tell you the truth
+... I hardly believe it myself.... And yet...'
+
+His eye fell with a mute inquiry upon the withered white flowers
+upon the little table. Then he turned over the hand holding his
+pipe, and I saw he was looking at some half-healed scars on his
+knuckles.
+
+The Medical Man rose, came to the lamp, and examined the flowers.
+'The gynaeceum's odd,' he said. The Psychologist leant forward to
+see, holding out his hand for a specimen.
+
+'I'm hanged if it isn't a quarter to one,' said the Journalist.
+'How shall we get home?'
+
+'Plenty of cabs at the station,' said the Psychologist.
+
+'It's a curious thing,' said the Medical Man; 'but I certainly don't
+know the natural order of these flowers. May I have them?'
+
+The Time Traveller hesitated. Then suddenly: 'Certainly not.'
+
+'Where did you really get them?' said the Medical Man.
+
+The Time Traveller put his hand to his head. He spoke like one who
+was trying to keep hold of an idea that eluded him. 'They were put
+into my pocket by Weena, when I travelled into Time.' He stared
+round the room. 'I'm damned if it isn't all going. This room and you
+and the atmosphere of every day is too much for my memory. Did I
+ever make a Time Machine, or a model of a Time Machine? Or is it all
+only a dream? They say life is a dream, a precious poor dream at
+times--but I can't stand another that won't fit. It's madness. And
+where did the dream come from? ... I must look at that machine. If
+there is one!'
+
+He caught up the lamp swiftly, and carried it, flaring red, through
+the door into the corridor. We followed him. There in the flickering
+light of the lamp was the machine sure enough, squat, ugly, and
+askew; a thing of brass, ebony, ivory, and translucent glimmering
+quartz. Solid to the touch--for I put out my hand and felt the rail
+of it--and with brown spots and smears upon the ivory, and bits of
+grass and moss upon the lower parts, and one rail bent awry.
+
+The Time Traveller put the lamp down on the bench, and ran his hand
+along the damaged rail. 'It's all right now,' he said. 'The story I
+told you was true. I'm sorry to have brought you out here in the
+cold.' He took up the lamp, and, in an absolute silence, we
+returned to the smoking-room.
+
+He came into the hall with us and helped the Editor on with his
+coat. The Medical Man looked into his face and, with a certain
+hesitation, told him he was suffering from overwork, at which he
+laughed hugely. I remember him standing in the open doorway, bawling
+good night.
+
+I shared a cab with the Editor. He thought the tale a 'gaudy lie.'
+For my own part I was unable to come to a conclusion. The story was
+so fantastic and incredible, the telling so credible and sober. I
+lay awake most of the night thinking about it. I determined to go
+next day and see the Time Traveller again. I was told he was in the
+laboratory, and being on easy terms in the house, I went up to him.
+The laboratory, however, was empty. I stared for a minute at the
+Time Machine and put out my hand and touched the lever. At that the
+squat substantial-looking mass swayed like a bough shaken by the
+wind. Its instability startled me extremely, and I had a queer
+reminiscence of the childish days when I used to be forbidden to
+meddle. I came back through the corridor. The Time Traveller met me
+in the smoking-room. He was coming from the house. He had a small
+camera under one arm and a knapsack under the other. He laughed when
+he saw me, and gave me an elbow to shake. 'I'm frightfully busy,'
+said he, 'with that thing in there.'
+
+'But is it not some hoax?' I said. 'Do you really travel through
+time?'
+
+'Really and truly I do.' And he looked frankly into my eyes. He
+hesitated. His eye wandered about the room. 'I only want half an
+hour,' he said. 'I know why you came, and it's awfully good of you.
+There's some magazines here. If you'll stop to lunch I'll prove you
+this time travelling up to the hilt, specimen and all. If you'll
+forgive my leaving you now?'
+
+I consented, hardly comprehending then the full import of his words,
+and he nodded and went on down the corridor. I heard the door of
+the laboratory slam, seated myself in a chair, and took up a daily
+paper. What was he going to do before lunch-time? Then suddenly
+I was reminded by an advertisement that I had promised to meet
+Richardson, the publisher, at two. I looked at my watch, and saw
+that I could barely save that engagement. I got up and went down the
+passage to tell the Time Traveller.
+
+As I took hold of the handle of the door I heard an exclamation,
+oddly truncated at the end, and a click and a thud. A gust of air
+whirled round me as I opened the door, and from within came the
+sound of broken glass falling on the floor. The Time Traveller was
+not there. I seemed to see a ghostly, indistinct figure sitting in
+a whirling mass of black and brass for a moment--a figure so
+transparent that the bench behind with its sheets of drawings was
+absolutely distinct; but this phantasm vanished as I rubbed my eyes.
+The Time Machine had gone. Save for a subsiding stir of dust, the
+further end of the laboratory was empty. A pane of the skylight had,
+apparently, just been blown in.
+
+I felt an unreasonable amazement. I knew that something strange had
+happened, and for the moment could not distinguish what the strange
+thing might be. As I stood staring, the door into the garden opened,
+and the man-servant appeared.
+
+We looked at each other. Then ideas began to come. 'Has Mr. ----
+gone out that way?' said I.
+
+'No, sir. No one has come out this way. I was expecting to find him
+here.'
+
+At that I understood. At the risk of disappointing Richardson I
+stayed on, waiting for the Time Traveller; waiting for the second,
+perhaps still stranger story, and the specimens and photographs he
+would bring with him. But I am beginning now to fear that I must
+wait a lifetime. The Time Traveller vanished three years ago. And,
+as everybody knows now, he has never returned.
+
+
+
+
+EPILOGUE
+
+
+One cannot choose but wonder. Will he ever return? It may be that he
+swept back into the past, and fell among the blood-drinking, hairy
+savages of the Age of Unpolished Stone; into the abysses of the
+Cretaceous Sea; or among the grotesque saurians, the huge reptilian
+brutes of the Jurassic times. He may even now--if I may use the
+phrase--be wandering on some plesiosaurus-haunted Oolitic coral
+reef, or beside the lonely saline lakes of the Triassic Age. Or did
+he go forward, into one of the nearer ages, in which men are still
+men, but with the riddles of our own time answered and its wearisome
+problems solved? Into the manhood of the race: for I, for my own
+part, cannot think that these latter days of weak experiment,
+fragmentary theory, and mutual discord are indeed man's culminating
+time! I say, for my own part. He, I know--for the question had been
+discussed among us long before the Time Machine was made--thought
+but cheerlessly of the Advancement of Mankind, and saw in the
+growing pile of civilization only a foolish heaping that must
+inevitably fall back upon and destroy its makers in the end. If that
+is so, it remains for us to live as though it were not so. But to me
+the future is still black and blank--is a vast ignorance, lit at a
+few casual places by the memory of his story. And I have by me, for
+my comfort, two strange white flowers--shrivelled now, and brown and
+flat and brittle--to witness that even when mind and strength had
+gone, gratitude and a mutual tenderness still lived on in the heart
+of man.
+
+
+
+
+
+
+
+End of Project Gutenberg's The Time Machine, by H. G. (Herbert George) Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE TIME MACHINE ***
+
+***** This file should be named 35.txt or 35.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/35/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.

--- a/jet/tf-idf/src/main/resources/books/tom-sawyer.txt
+++ b/jet/tf-idf/src/main/resources/books/tom-sawyer.txt
@@ -1,0 +1,9209 @@
+
+The Project Gutenberg EBook of The Adventures of Tom Sawyer, Complete by
+Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+Title: The Adventures of Tom Sawyer, Complete
+
+Author: Mark Twain (Samuel Clemens)
+
+Release Date: August 20, 2006 [EBook #74]
+Last updated: August 17, 2016
+
+Language: English
+
+Character set encoding: UTF-8
+
+*** START OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+Produced by David Widger
+
+
+
+
+
+THE ADVENTURES OF TOM SAWYER
+
+By Mark Twain
+
+(Samuel Langhorne Clemens)
+
+
+
+
+CONTENTS
+
+CHAPTER I. Y-o-u-u Tom-Aunt Polly Decides Upon her Duty--Tom Practices
+Music--The Challenge--A Private Entrance
+
+CHAPTER II. Strong Temptations--Strategic Movements--The Innocents
+Beguiled
+
+CHAPTER III. Tom as a General--Triumph and Reward--Dismal
+Felicity--Commission and Omission
+
+CHAPTER IV. Mental Acrobatics--Attending Sunday--School--The
+Superintendent--“Showing off”--Tom Lionized
+
+CHAPTER V. A Useful Minister--In Church--The Climax
+
+CHAPTER VI. Self-Examination--Dentistry--The Midnight Charm--Witches and
+Devils--Cautious Approaches--Happy Hours
+
+CHAPTER VII. A Treaty Entered Into--Early Lessons--A Mistake Made
+
+CHAPTER VIII. Tom Decides on his Course--Old Scenes Re-enacted
+
+CHAPTER IX. A Solemn Situation--Grave Subjects Introduced--Injun Joe
+Explains
+
+CHAPTER X. The Solemn Oath--Terror Brings Repentance--Mental Punishment
+
+CHAPTER XI. Muff Potter Comes Himself--Tom’s Conscience at Work
+
+CHAPTER XII. Tom Shows his Generosity--Aunt Polly Weakens
+
+CHAPTER XIII. The Young Pirates--Going to the Rendezvous--The Camp--Fire
+Talk
+
+CHAPTER XIV. Camp-Life--A Sensation--Tom Steals Away from Camp
+
+CHAPTER XV. Tom Reconnoiters--Learns the Situation--Reports at Camp
+
+CHAPTER XVI. A Day’s Amusements--Tom Reveals a Secret--The Pirates take a
+Lesson--A Night Surprise--An Indian War
+
+CHAPTER XVII. Memories of the Lost Heroes--The Point in Tom’s Secret
+
+CHAPTER XVIII. Tom’s Feelings Investigated--Wonderful Dream--Becky
+Thatcher Overshadowed--Tom Becomes Jealous--Black Revenge
+
+CHAPTER XIX. Tom Tells the Truth
+
+CHAPTER XX. Becky in a Dilemma--Tom’s Nobility Asserts Itself
+
+CHAPTER XXI. Youthful Eloquence--Compositions by the Young Ladies--A
+Lengthy Vision--The Boy’s Vengeance Satisfied
+
+CHAPTER XXII. Tom’s Confidence Betrayed--Expects Signal Punishment
+
+CHAPTER XXIII. Old Muff’s Friends--Muff Potter in Court--Muff Potter
+Saved
+
+CHAPTER XXIV. Tom as the Village Hero--Days of Splendor and Nights of
+Horror--Pursuit of Injun Joe
+
+CHAPTER XXV. About Kings and Diamonds--Search for the Treasure--Dead
+People and Ghosts
+
+CHAPTER XXVI. The Haunted House--Sleepy Ghosts--A Box of Gold--Bitter Luck
+
+CHAPTER XXVII. Doubts to be Settled--The Young Detectives
+
+CHAPTER XXVIII. An Attempt at No. Two--Huck Mounts Guard
+
+CHAPTER XXIX. The Pic-nic--Huck on Injun Joe’s Track--The “Revenge”
+ Job--Aid for the Widow
+
+CHAPTER XXX. The Welchman Reports--Huck Under Fire--The Story Circulated
+--A New Sensation--Hope Giving Way to Despair
+
+CHAPTER XXXI. An Exploring Expedition--Trouble Commences--Lost in the
+Cave--Total Darkness--Found but not Saved
+
+CHAPTER XXXII. Tom tells the Story of their Escape--Tom’s Enemy in Safe
+Quarters
+
+CHAPTER XXXIII. The Fate of Injun Joe--Huck and Tom Compare Notes
+--An Expedition to the Cave--Protection Against Ghosts--“An Awful Snug
+Place”--A Reception at the Widow Douglas’s
+
+CHAPTER XXXIV. Springing a Secret--Mr. Jones’ Surprise a Failure
+
+CHAPTER XXXV. A New Order of Things--Poor Huck--New Adventures Planned
+
+
+
+
+ILLUSTRATIONS
+
+Tom Sawyer
+
+Tom at Home
+
+Aunt Polly Beguiled
+
+A Good Opportunity
+
+Who’s Afraid
+
+Late Home
+
+Jim
+
+‘Tendin’ to Business
+
+Ain’t that Work?
+
+Cat and Toys
+
+Amusement
+
+Becky Thatcher
+
+Paying Off
+
+After the Battle
+
+“Showing Off”
+
+Not Amiss
+
+Mary
+
+Tom Contemplating
+
+Dampened Ardor
+
+Youth
+
+Boyhood
+
+Using the “Barlow”
+
+The Church
+
+Necessities
+
+Tom as a Sunday-School Hero    
+
+The Prize
+
+At Church
+
+The Model Boy
+
+The Church Choir
+
+A Side Show
+
+Result of Playing in Church
+
+The Pinch-Bug
+
+Sid
+
+Dentistry
+
+Huckleberry Finn
+
+Mother Hopkins
+
+Result of Tom’s Truthfulness
+
+Tom as an Artist
+
+Interrupted Courtship
+
+The Master
+
+Vain Pleading
+
+Tail Piece
+
+The Grave in the Woods
+
+Tom Meditates
+
+Robin Hood and his Foe
+
+Death of Robin Hood
+
+Midnight
+
+Tom’s Mode of Egress
+
+Tom’s Effort at Prayer
+
+Muff Potter Outwitted
+
+The Graveyard
+
+Forewarnings
+
+Disturbing Muff’s Sleep
+
+Tom’s Talk with his Aunt
+
+Muff Potter
+
+A Suspicious Incident
+
+Injun Joe’s two Victims
+
+In the Coils
+
+Peter
+
+Aunt Polly seeks Information
+
+A General Good Time
+
+Demoralized
+
+Joe Harper
+
+On Board Their First Prize
+
+The Pirates Ashore
+
+Wild Life
+
+The Pirate’s Bath
+
+The Pleasant Stroll
+
+The Search for the Drowned
+
+The Mysterious Writing
+
+River View
+
+What Tom Saw
+
+Tom Swims the River
+
+Taking Lessons
+
+The Pirates’ Egg Market
+
+Tom Looking for Joe’s Knife    
+
+The Thunder Storm
+
+Terrible Slaughter
+
+The Mourner
+
+Tom’s Proudest Moment
+
+Amy Lawrence
+
+Tom tries to Remember
+
+The Hero
+
+A Flirtation
+
+Becky Retaliates
+
+A Sudden Frost
+
+Counter-irritation
+
+Aunt Polly
+
+Tom justified
+
+The Discovery
+
+Caught in the Act
+
+Tom Astonishes the School
+
+Literature
+
+Tom Declaims
+
+Examination Evening
+
+On Exhibition
+
+Prize Authors
+
+The Master’s Dilemma
+
+The School House
+
+The Cadet
+
+Happy for Two Days
+
+Enjoying the Vacation
+
+The Stolen Melons
+
+The Judge
+
+Visiting the Prisoner
+
+Tom Swears
+
+The Court Room
+
+The Detective
+
+Tom Dreams
+
+The Treasure
+
+The Private Conference
+
+A King; Poor Fellow!
+
+Business
+
+The Ha’nted House
+
+Injun Joe
+
+The Greatest and Best
+
+Hidden Treasures Unearthed
+
+The Boy’s Salvation
+
+Room No. 2
+
+The Next Day’s Conference
+
+Treasures
+
+Uncle Jake
+
+Buck at Home
+
+The Haunted Room
+
+“Run for Your Life”
+
+McDougal’s Cave
+
+Inside the Cave
+
+Huck on Duty
+
+A Rousing Act
+
+Tail Piece
+
+The Welchman
+
+Result of a Sneeze
+
+Cornered
+
+Alarming Discoveries
+
+Tom and Becky stir up the Town
+
+Tom’s Marks
+
+Huck Questions the Widow
+
+Vampires
+
+Wonders of the Cave
+
+Attacked by Natives
+
+Despair
+
+The Wedding Cake
+
+A New Terror
+
+Daylight
+
+“Turn Out” to Receive Tom and Becky
+
+The Escape from the Cave
+
+Fate of the Ragged Man
+
+The Treasures Found
+
+Caught at Last
+
+Drop after Drop
+
+Having a Good Time
+
+A Business Trip
+
+“Got it at Last!”
+
+Tail Piece
+
+Widow Douglas
+
+Tom Backs his Statement
+
+Tail Piece
+
+Huck Transformed
+
+Comfortable Once More
+
+High up in Society
+
+Contentment
+
+
+
+
+PREFACE
+
+Most of the adventures recorded in this book really occurred; one or two
+were experiences of my own, the rest those of boys who were schoolmates
+of mine. Huck Finn is drawn from life; Tom Sawyer also, but not from an
+individual--he is a combination of the characteristics of three boys whom
+I knew, and therefore belongs to the composite order of architecture.
+
+The odd superstitions touched upon were all prevalent among children and
+slaves in the West at the period of this story--that is to say, thirty or
+forty years ago.
+
+Although my book is intended mainly for the entertainment of boys and
+girls, I hope it will not be shunned by men and women on that account,
+for part of my plan has been to try to pleasantly remind adults of what
+they once were themselves, and of how they felt and thought and talked,
+and what queer enterprises they sometimes engaged in.
+
+THE AUTHOR.
+
+HARTFORD, 1876.
+
+
+
+
+CHAPTER I
+
+“TOM!”
+
+No answer.
+
+“TOM!”
+
+No answer.
+
+“What’s gone with that boy,  I wonder? You TOM!”
+
+No answer.
+
+The old lady pulled her spectacles down and looked over them about the
+room; then she put them up and looked out under them. She seldom or
+never looked _through_ them for so small a thing as a boy; they were
+her state pair, the pride of her heart, and were built for “style,” not
+service--she could have seen through a pair of stove-lids just as well.
+She looked perplexed for a moment, and then said, not fiercely, but
+still loud enough for the furniture to hear:
+
+“Well, I lay if I get hold of you I’ll--”
+
+She did not finish, for by this time she was bending down and punching
+under the bed with the broom, and so she needed breath to punctuate the
+punches with. She resurrected nothing but the cat.
+
+“I never did see the beat of that boy!”
+
+She went to the open door and stood in it and looked out among the
+tomato vines and “jimpson” weeds that constituted the garden. No Tom. So
+she lifted up her voice at an angle calculated for distance and shouted:
+
+“Y-o-u-u TOM!”
+
+There was a slight noise behind her and she turned just in time to seize
+a small boy by the slack of his roundabout and arrest his flight.
+
+“There! I might ‘a’ thought of that closet. What you been doing in
+there?”
+
+“Nothing.”
+
+“Nothing! Look at your hands. And look at your mouth. What _is_ that
+truck?”
+
+“I don’t know, aunt.”
+
+“Well, I know. It’s jam--that’s what it is. Forty times I’ve said if you
+didn’t let that jam alone I’d skin you. Hand me that switch.”
+
+The switch hovered in the air--the peril was desperate--
+
+“My! Look behind you, aunt!”
+
+The old lady whirled round, and snatched her skirts out of danger.
+The lad fled on the instant, scrambled up the high board-fence, and
+disappeared over it.
+
+His aunt Polly stood surprised a moment, and then broke into a gentle
+laugh.
+
+“Hang the boy, can’t I never learn anything? Ain’t he played me tricks
+enough like that for me to be looking out for him by this time? But old
+fools is the biggest fools there is. Can’t learn an old dog new tricks,
+as the saying is. But my goodness, he never plays them alike, two days,
+and how is a body to know what’s coming? He ‘pears to know just how long
+he can torment me before I get my dander up, and he knows if he can make
+out to put me off for a minute or make me laugh, it’s all down again and
+I can’t hit him a lick. I ain’t doing my duty by that boy, and that’s
+the Lord’s truth, goodness knows. Spare the rod and spile the child,
+as the Good Book says. I’m a laying up sin and suffering for us both,
+I know. He’s full of the Old Scratch, but laws-a-me! he’s my own
+dead sister’s boy, poor thing, and I ain’t got the heart to lash him,
+somehow. Every time I let him off, my conscience does hurt me so, and
+every time I hit him my old heart most breaks. Well-a-well, man that is
+born of woman is of few days and full of trouble, as the Scripture
+says, and I reckon it’s so. He’ll play hookey this evening, * and [*
+Southwestern for “afternoon”] I’ll just be obleeged to make him work,
+tomorrow, to punish him. It’s mighty hard to make him work Saturdays,
+when all the boys is having holiday, but he hates work more than he
+hates anything else, and I’ve _got_ to do some of my duty by him, or
+I’ll be the ruination of the child.”
+
+Tom did play hookey, and he had a very good time. He got back home
+barely in season to help Jim, the small colored boy, saw next-day’s wood
+and split the kindlings before supper--at least he was there in time
+to tell his adventures to Jim while Jim did three-fourths of the work.
+Tom’s younger brother (or rather half-brother) Sid was already through
+with his part of the work (picking up chips), for he was a quiet boy,
+and had no adventurous, trouble-some ways.
+
+While Tom was eating his supper, and stealing sugar as opportunity
+offered, Aunt Polly asked him questions that were full of guile, and
+very deep--for she wanted to trap him into damaging revealments. Like
+many other simple-hearted souls, it was her pet vanity to believe she
+was endowed with a talent for dark and mysterious diplomacy, and she
+loved to contemplate her most transparent devices as marvels of low
+cunning. Said she:
+
+“Tom, it was middling warm in school, warn’t it?”
+
+“Yes’m.”
+
+“Powerful warm, warn’t it?”
+
+“Yes’m.”
+
+“Didn’t you want to go in a-swimming, Tom?”
+
+A bit of a scare shot through Tom--a touch of uncomfortable suspicion. He
+searched Aunt Polly’s face, but it told him nothing. So he said:
+
+“No’m--well, not very much.”
+
+The old lady reached out her hand and felt Tom’s shirt, and said:
+
+“But you ain’t too warm now, though.” And it flattered her to reflect
+that she had discovered that the shirt was dry without anybody knowing
+that that was what she had in her mind. But in spite of her, Tom knew
+where the wind lay, now. So he forestalled what might be the next move:
+
+“Some of us pumped on our heads--mine’s damp yet. See?”
+
+Aunt Polly was vexed to think she had overlooked that bit of
+circumstantial evidence, and missed a trick. Then she had a new
+inspiration:
+
+“Tom, you didn’t have to undo your shirt collar where I sewed it, to
+pump on your head, did you? Unbutton your jacket!”
+
+The trouble vanished out of Tom’s face. He opened his jacket. His shirt
+collar was securely sewed.
+
+“Bother! Well, go ‘long with you. I’d made sure you’d played hookey
+and been a-swimming. But I forgive ye, Tom. I reckon you’re a kind of a
+singed cat, as the saying is--better’n you look. _This_ time.”
+
+She was half sorry her sagacity had miscarried, and half glad that Tom
+had stumbled into obedient conduct for once.
+
+But Sidney said:
+
+“Well, now, if I didn’t think you sewed his collar with white thread,
+but it’s black.”
+
+“Why, I did sew it with white! Tom!”
+
+But Tom did not wait for the rest. As he went out at the door he said:
+
+“Siddy, I’ll lick you for that.”
+
+In a safe place Tom examined two large needles which were thrust into
+the lapels of his jacket, and had thread bound about them--one needle
+carried white thread and the other black. He said:
+
+“She’d never noticed if it hadn’t been for Sid. Confound it! sometimes
+she sews it with white, and sometimes she sews it with black. I wish to
+gee-miny she’d stick to one or t’other--I can’t keep the run of ‘em. But
+I bet you I’ll lam Sid for that. I’ll learn him!”
+
+He was not the Model Boy of the village. He knew the model boy very well
+though--and loathed him.
+
+Within two minutes, or even less, he had forgotten all his troubles. Not
+because his troubles were one whit less heavy and bitter to him than a
+man’s are to a man, but because a new and powerful interest bore
+them down and drove them out of his mind for the time--just as men’s
+misfortunes are forgotten in the excitement of new enterprises. This new
+interest was a valued novelty in whistling, which he had just acquired
+from a negro, and he was suffering to practise it un-disturbed. It
+consisted in a peculiar bird-like turn, a sort of liquid warble,
+produced by touching the tongue to the roof of the mouth at short
+intervals in the midst of the music--the reader probably remembers how to
+do it, if he has ever been a boy. Diligence and attention soon gave him
+the knack of it, and he strode down the street with his mouth full of
+harmony and his soul full of gratitude. He felt much as an astronomer
+feels who has discovered a new planet--no doubt, as far as strong, deep,
+unalloyed pleasure is concerned, the advantage was with the boy, not the
+astronomer.
+
+The summer evenings were long. It was not dark, yet. Presently Tom
+checked his whistle. A stranger was before him--a boy a shade larger
+than himself. A new-comer of any age or either sex was an im-pressive
+curiosity in the poor little shabby village of St. Petersburg. This boy
+was well dressed, too--well dressed on a week-day. This was simply as
+astounding. His cap was a dainty thing, his close-buttoned blue cloth
+roundabout was new and natty, and so were his pantaloons. He had shoes
+on--and it was only Friday. He even wore a necktie, a bright bit of
+ribbon. He had a citified air about him that ate into Tom’s vitals. The
+more Tom stared at the splendid marvel, the higher he turned up his nose
+at his finery and the shabbier and shabbier his own outfit seemed to
+him to grow. Neither boy spoke. If one moved, the other moved--but only
+sidewise, in a circle; they kept face to face and eye to eye all the
+time. Finally Tom said:
+
+“I can lick you!”
+
+“I’d like to see you try it.”
+
+“Well, I can do it.”
+
+“No you can’t, either.”
+
+“Yes I can.”
+
+“No you can’t.”
+
+“I can.”
+
+“You can’t.”
+
+“Can!”
+
+“Can’t!”
+
+An uncomfortable pause. Then Tom said:
+
+“What’s your name?”
+
+“‘Tisn’t any of your business, maybe.”
+
+“Well I ‘low I’ll _make_ it my business.”
+
+“Well why don’t you?”
+
+“If you say much, I will.”
+
+“Much--much--_much_. There now.”
+
+“Oh, you think you’re mighty smart, _don’t_ you? I could lick you with
+one hand tied behind me, if I wanted to.”
+
+“Well why don’t you _do_ it? You _say_ you can do it.”
+
+“Well I _will_, if you fool with me.”
+
+“Oh yes--I’ve seen whole families in the same fix.”
+
+“Smarty! You think you’re _some_, now, _don’t_ you? Oh, what a hat!”
+
+“You can lump that hat if you don’t like it. I dare you to knock it
+off--and anybody that’ll take a dare will suck eggs.”
+
+“You’re a liar!”
+
+“You’re another.”
+
+“You’re a fighting liar and dasn’t take it up.”
+
+“Aw--take a walk!”
+
+“Say--if you give me much more of your sass I’ll take and bounce a rock
+off’n your head.”
+
+“Oh, of _course_ you will.”
+
+“Well I _will_.”
+
+“Well why don’t you _do_ it then? What do you keep _saying_ you will
+for? Why don’t you _do_ it? It’s because you’re afraid.”
+
+“I _ain’t_ afraid.”
+
+“You are.”
+
+“I ain’t.”
+
+“You are.”
+
+Another pause, and more eying and sidling around each other. Presently
+they were shoulder to shoulder. Tom said:
+
+“Get away from here!”
+
+“Go away yourself!”
+
+“I won’t.”
+
+“I won’t either.”
+
+So they stood, each with a foot placed at an angle as a brace, and both
+shoving with might and main, and glowering at each other with hate. But
+neither could get an advantage. After struggling till both were hot and
+flushed, each relaxed his strain with watchful caution, and Tom said:
+
+“You’re a coward and a pup. I’ll tell my big brother on you, and he can
+thrash you with his little finger, and I’ll make him do it, too.”
+
+“What do I care for your big brother? I’ve got a brother that’s bigger
+than he is--and what’s more, he can throw him over that fence, too.”
+ [Both brothers were imaginary.]
+
+“That’s a lie.”
+
+“_Your_ saying so don’t make it so.”
+
+Tom drew a line in the dust with his big toe, and said:
+
+“I dare you to step over that, and I’ll lick you till you can’t stand
+up. Anybody that’ll take a dare will steal sheep.”
+
+The new boy stepped over promptly, and said:
+
+“Now you said you’d do it, now let’s see you do it.”
+
+“Don’t you crowd me now; you better look out.”
+
+“Well, you _said_ you’d do it--why don’t you do it?”
+
+“By jingo! for two cents I _will_ do it.”
+
+The new boy took two broad coppers out of his pocket and held them out
+with derision. Tom struck them to the ground. In an instant both boys
+were rolling and tumbling in the dirt, gripped together like cats; and
+for the space of a minute they tugged and tore at each other’s hair and
+clothes, punched and scratched each other’s nose, and covered themselves
+with dust and glory. Presently the confusion took form, and through the
+fog of battle Tom appeared, seated astride the new boy, and pounding him
+with his fists. “Holler ‘nuff!” said he.
+
+The boy only struggled to free himself. He was crying--mainly from rage.
+
+“Holler ‘nuff!”--and the pounding went on.
+
+At last the stranger got out a smothered “‘Nuff!” and Tom let him up and
+said:
+
+“Now that’ll learn you. Better look out who you’re fooling with next
+time.”
+
+The new boy went off brushing the dust from his clothes, sobbing,
+snuffling, and occasionally looking back and shaking his head and
+threatening what he would do to Tom the “next time he caught him out.”
+ To which Tom responded with jeers, and started off in high feather, and
+as soon as his back was turned the new boy snatched up a stone, threw it
+and hit him between the shoulders and then turned tail and ran like
+an antelope. Tom chased the traitor home, and thus found out where he
+lived. He then held a position at the gate for some time, daring the
+enemy to come outside, but the enemy only made faces at him through the
+window and declined. At last the enemy’s mother appeared, and called Tom
+a bad, vicious, vulgar child, and ordered him away. So he went away; but
+he said he “‘lowed” to “lay” for that boy.
+
+He got home pretty late that night, and when he climbed cautiously in
+at the window, he uncovered an ambuscade, in the person of his aunt; and
+when she saw the state his clothes were in her resolution to turn his
+Saturday holiday into captivity at hard labor became adamantine in its
+firmness.
+
+
+
+
+CHAPTER II
+
+SATURDAY morning was come, and all the summer world was bright and
+fresh, and brimming with life. There was a song in every heart; and if
+the heart was young the music issued at the lips. There was cheer in
+every face and a spring in every step. The locust-trees were in bloom
+and the fragrance of the blossoms filled the air. Cardiff Hill, beyond
+the village and above it, was green with vegetation and it lay just far
+enough away to seem a Delectable Land, dreamy, reposeful, and inviting.
+
+Tom appeared on the sidewalk with a bucket of whitewash and a
+long-handled brush. He surveyed the fence, and all gladness left him and
+a deep melancholy settled down upon his spirit. Thirty yards of board
+fence nine feet high. Life to him seemed hollow, and existence but a
+burden. Sighing, he dipped his brush and passed it along the topmost
+plank; repeated the operation; did it again; compared the insignificant
+whitewashed streak with the far-reaching continent of unwhitewashed
+fence, and sat down on a tree-box discouraged. Jim came skipping out at
+the gate with a tin pail, and singing Buffalo Gals. Bringing water from
+the town pump had always been hateful work in Tom’s eyes, before, but
+now it did not strike him so. He remembered that there was company at
+the pump. White, mulatto, and negro boys and girls were always there
+waiting their turns, resting, trading playthings, quarrelling, fighting,
+skylarking. And he remembered that although the pump was only a hundred
+and fifty yards off, Jim never got back with a bucket of water under an
+hour--and even then somebody generally had to go after him. Tom said:
+
+“Say, Jim, I’ll fetch the water if you’ll whitewash some.”
+
+Jim shook his head and said:
+
+“Can’t, Mars Tom. Ole missis, she tole me I got to go an’ git dis water
+an’ not stop foolin’ roun’ wid anybody. She say she spec’ Mars Tom gwine
+to ax me to whitewash, an’ so she tole me go ‘long an’ ‘tend to my own
+business--she ‘lowed _she’d_ ‘tend to de whitewashin’.”
+
+“Oh, never you mind what she said, Jim. That’s the way she always talks.
+Gimme the bucket--I won’t be gone only a a minute. _She_ won’t ever
+know.”
+
+“Oh, I dasn’t, Mars Tom. Ole missis she’d take an’ tar de head off’n me.
+‘Deed she would.”
+
+“_She_! She never licks anybody--whacks ‘em over the head with her
+thimble--and who cares for that, I’d like to know. She talks awful, but
+talk don’t hurt--anyways it don’t if she don’t cry. Jim, I’ll give you a
+marvel. I’ll give you a white alley!”
+
+Jim began to waver.
+
+“White alley, Jim! And it’s a bully taw.”
+
+“My! Dat’s a mighty gay marvel, I tell you! But Mars Tom I’s powerful
+‘fraid ole missis--”
+
+“And besides, if you will I’ll show you my sore toe.”
+
+Jim was only human--this attraction was too much for him. He put down
+his pail, took the white alley, and bent over the toe with absorbing
+interest while the bandage was being unwound. In another moment he
+was flying down the street with his pail and a tingling rear, Tom was
+whitewashing with vigor, and Aunt Polly was retiring from the field with
+a slipper in her hand and triumph in her eye.
+
+But Tom’s energy did not last. He began to think of the fun he had
+planned for this day, and his sorrows multiplied. Soon the free boys
+would come tripping along on all sorts of delicious expeditions, and
+they would make a world of fun of him for having to work--the very
+thought of it burnt him like fire. He got out his worldly wealth and
+examined it--bits of toys, marbles, and trash; enough to buy an exchange
+of _work_, maybe, but not half enough to buy so much as half an hour
+of pure freedom. So he returned his straitened means to his pocket, and
+gave up the idea of trying to buy the boys. At this dark and hopeless
+moment an inspiration burst upon him! Nothing less than a great,
+magnificent inspiration.
+
+He took up his brush and went tranquilly to work. Ben Rogers hove in
+sight presently--the very boy, of all boys, whose ridicule he had been
+dreading. Ben’s gait was the hop-skip-and-jump--proof enough that his
+heart was light and his anticipations high. He was eating an apple, and
+giving a long, melodious whoop, at intervals, followed by a deep-toned
+ding-dong-dong, ding-dong-dong, for he was personating a steamboat. As
+he drew near, he slackened speed, took the middle of the street, leaned
+far over to starboard and rounded to ponderously and with laborious pomp
+and circumstance--for he was personating the Big Missouri, and considered
+himself to be drawing nine feet of water. He was boat and captain and
+engine-bells combined, so he had to imagine himself standing on his own
+hurricane-deck giving the orders and executing them:
+
+“Stop her, sir! Ting-a-ling-ling!” The headway ran almost out, and he
+drew up slowly toward the sidewalk.
+
+“Ship up to back! Ting-a-ling-ling!” His arms straightened and stiffened
+down his sides.
+
+“Set her back on the stabboard! Ting-a-ling-ling! Chow! ch-chow-wow!
+Chow!” His right hand, mean-time, describing stately circles--for it was
+representing a forty-foot wheel.
+
+“Let her go back on the labboard! Ting-a-ling-ling! Chow-ch-chow-chow!”
+ The left hand began to describe circles.
+
+“Stop the stabboard! Ting-a-ling-ling! Stop the labboard! Come ahead on
+the stabboard! Stop her! Let your outside turn over slow! Ting-a-ling-ling!
+Chow-ow-ow! Get out that head-line! _lively_ now! Come--out with
+your spring-line--what’re you about there! Take a turn round that stump
+with the bight of it! Stand by that stage, now--let her go! Done with
+the engines, sir! Ting-a-ling-ling! SH’T! S’H’T! SH’T!” (trying the
+gauge-cocks).
+
+Tom went on whitewashing--paid no attention to the steamboat. Ben stared
+a moment and then said: “_Hi-Yi! You’re_ up a stump, ain’t you!”
+
+No answer. Tom surveyed his last touch with the eye of an artist, then
+he gave his brush another gentle sweep and surveyed the result, as
+before. Ben ranged up alongside of him. Tom’s mouth watered for the
+apple, but he stuck to his work. Ben said:
+
+“Hello, old chap, you got to work, hey?”
+
+Tom wheeled suddenly and said:
+
+“Why, it’s you, Ben! I warn’t noticing.”
+
+“Say--I’m going in a-swimming, I am. Don’t you wish you could? But of
+course you’d druther _work_--wouldn’t you? Course you would!”
+
+Tom contemplated the boy a bit, and said:
+
+“What do you call work?”
+
+“Why, ain’t _that_ work?”
+
+Tom resumed his whitewashing, and answered carelessly:
+
+“Well, maybe it is, and maybe it ain’t. All I know, is, it suits Tom
+Sawyer.”
+
+“Oh come, now, you don’t mean to let on that you _like_ it?”
+
+The brush continued to move.
+
+“Like it? Well, I don’t see why I oughtn’t to like it. Does a boy get a
+chance to whitewash a fence every day?”
+
+That put the thing in a new light. Ben stopped nibbling his apple.
+Tom swept his brush daintily back and forth--stepped back to note the
+effect--added a touch here and there--criticised the effect again--Ben
+watching every move and getting more and more interested, more and more
+absorbed. Presently he said:
+
+“Say, Tom, let _me_ whitewash a little.”
+
+Tom considered, was about to consent; but he altered his mind:
+
+“No--no--I reckon it wouldn’t hardly do, Ben. You see, Aunt Polly’s awful
+particular about this fence--right here on the street, you know--but if it
+was the back fence I wouldn’t mind and _she_ wouldn’t. Yes, she’s awful
+particular about this fence; it’s got to be done very careful; I reckon
+there ain’t one boy in a thousand, maybe two thousand, that can do it
+the way it’s got to be done.”
+
+“No--is that so? Oh come, now--lemme just try. Only just a little--I’d let
+_you_, if you was me, Tom.”
+
+“Ben, I’d like to, honest injun; but Aunt Polly--well, Jim wanted to do
+it, but she wouldn’t let him; Sid wanted to do it, and she wouldn’t let
+Sid. Now don’t you see how I’m fixed? If you was to tackle this fence
+and anything was to happen to it--”
+
+“Oh, shucks, I’ll be just as careful. Now lemme try. Say--I’ll give you
+the core of my apple.”
+
+“Well, here--No, Ben, now don’t. I’m afeard--”
+
+“I’ll give you _all_ of it!”
+
+Tom gave up the brush with reluctance in his face, but alacrity in his
+heart. And while the late steamer Big Missouri worked and sweated in the
+sun, the retired artist sat on a barrel in the shade close by,
+dangled his legs, munched his apple, and planned the slaughter of more
+innocents. There was no lack of material; boys happened along every
+little while; they came to jeer, but remained to whitewash. By the time
+Ben was fagged out, Tom had traded the next chance to Billy Fisher for
+a kite, in good repair; and when he played out, Johnny Miller bought in
+for a dead rat and a string to swing it with--and so on, and so on, hour
+after hour. And when the middle of the afternoon came, from being a
+poor poverty-stricken boy in the morning, Tom was literally rolling in
+wealth. He had besides the things before mentioned, twelve marbles, part
+of a jews-harp, a piece of blue bottle-glass to look through, a spool
+cannon, a key that wouldn’t unlock anything, a fragment of chalk, a
+glass stopper of a decanter, a tin soldier, a couple of tadpoles,
+six fire-crackers, a kitten with only one eye, a brass door-knob, a
+dog-collar--but no dog--the handle of a knife, four pieces of orange-peel,
+and a dilapidated old window sash.
+
+He had had a nice, good, idle time all the while--plenty of company--and
+the fence had three coats of whitewash on it! If he hadn’t run out of
+whitewash he would have bankrupted every boy in the village.
+
+Tom said to himself that it was not such a hollow world, after all. He
+had discovered a great law of human action, without knowing it--namely,
+that in order to make a man or a boy covet a thing, it is only necessary
+to make the thing difficult to attain. If he had been a great and
+wise philosopher, like the writer of this book, he would now have
+comprehended that Work consists of whatever a body is _obliged_ to do,
+and that Play consists of whatever a body is not obliged to do. And
+this would help him to understand why constructing artificial flowers or
+performing on a tread-mill is work, while rolling ten-pins or climbing
+Mont Blanc is only amusement. There are wealthy gentlemen in England
+who drive four-horse passenger-coaches twenty or thirty miles on a
+daily line, in the summer, because the privilege costs them considerable
+money; but if they were offered wages for the service, that would turn
+it into work and then they would resign.
+
+The boy mused awhile over the substantial change which had taken place
+in his worldly circumstances, and then wended toward headquarters to
+report.
+
+
+
+
+CHAPTER III
+
+TOM presented himself before Aunt Polly, who was sitting by an
+open window in a pleasant rearward apartment, which was bedroom,
+breakfast-room, dining-room, and library, combined. The balmy summer
+air, the restful quiet, the odor of the flowers, and the drowsing
+murmur of the bees had had their effect, and she was nodding over her
+knitting--for she had no company but the cat, and it was asleep in her
+lap. Her spectacles were propped up on her gray head for safety. She had
+thought that of course Tom had deserted long ago, and she wondered at
+seeing him place himself in her power again in this intrepid way. He
+said: “Mayn’t I go and play now, aunt?”
+
+“What, a’ready? How much have you done?”
+
+“It’s all done, aunt.”
+
+“Tom, don’t lie to me--I can’t bear it.”
+
+“I ain’t, aunt; it _is_ all done.”
+
+Aunt Polly placed small trust in such evidence. She went out to see for
+herself; and she would have been content to find twenty per cent. of
+Tom’s statement true. When she found the entire fence white-washed, and
+not only whitewashed but elaborately coated and recoated, and even a
+streak added to the ground, her astonishment was almost unspeakable. She
+said:
+
+“Well, I never! There’s no getting round it, you can work when you’re a
+mind to, Tom.” And then she diluted the compliment by adding, “But it’s
+powerful seldom you’re a mind to, I’m bound to say. Well, go ‘long and
+play; but mind you get back some time in a week, or I’ll tan you.”
+
+She was so overcome by the splendor of his achievement that she took
+him into the closet and selected a choice apple and delivered it to him,
+along with an improving lecture upon the added value and flavor a treat
+took to itself when it came without sin through virtuous effort.
+And while she closed with a happy Scriptural flourish, he “hooked” a
+doughnut.
+
+Then he skipped out, and saw Sid just starting up the outside stairway
+that led to the back rooms on the second floor. Clods were handy and
+the air was full of them in a twinkling. They raged around Sid like a
+hail-storm; and before Aunt Polly could collect her surprised faculties
+and sally to the rescue, six or seven clods had taken personal effect,
+and Tom was over the fence and gone. There was a gate, but as a general
+thing he was too crowded for time to make use of it. His soul was at
+peace, now that he had settled with Sid for calling attention to his
+black thread and getting him into trouble.
+
+Tom skirted the block, and came round into a muddy alley that led by the
+back of his aunt’s cow-stable. He presently got safely beyond the reach
+of capture and punishment, and hastened toward the public square of the
+village, where two “military” companies of boys had met for conflict,
+according to previous appointment. Tom was General of one of these
+armies, Joe Harper (a bosom friend) General of the other. These two
+great commanders did not condescend to fight in person--that being better
+suited to the still smaller fry--but sat together on an eminence
+and conducted the field operations by orders delivered through
+aides-de-camp. Tom’s army won a great victory, after a long and
+hard-fought battle. Then the dead were counted, prisoners exchanged,
+the terms of the next disagreement agreed upon, and the day for the
+necessary battle appointed; after which the armies fell into line and
+marched away, and Tom turned homeward alone.
+
+As he was passing by the house where Jeff Thatcher lived, he saw a new
+girl in the garden--a lovely little blue-eyed creature with yellow
+hair plaited into two long-tails, white summer frock and embroidered
+pan-talettes. The fresh-crowned hero fell without firing a shot. A
+certain Amy Lawrence vanished out of his heart and left not even a
+memory of herself behind. He had thought he loved her to distraction;
+he had regarded his passion as adoration; and behold it was only a poor
+little evanescent partiality. He had been months winning her; she had
+confessed hardly a week ago; he had been the happiest and the proudest
+boy in the world only seven short days, and here in one instant of time
+she had gone out of his heart like a casual stranger whose visit is
+done.
+
+He worshipped this new angel with furtive eye, till he saw that she had
+discovered him; then he pretended he did not know she was present, and
+began to “show off” in all sorts of absurd boyish ways, in order to win
+her admiration. He kept up this grotesque foolishness for some time;
+but by-and-by, while he was in the midst of some dangerous gymnastic
+performances, he glanced aside and saw that the little girl was wending
+her way toward the house. Tom came up to the fence and leaned on it,
+grieving, and hoping she would tarry yet awhile longer. She halted a
+moment on the steps and then moved toward the door. Tom heaved a great
+sigh as she put her foot on the threshold. But his face lit up,
+right away, for she tossed a pansy over the fence a moment before she
+disappeared.
+
+The boy ran around and stopped within a foot or two of the flower, and
+then shaded his eyes with his hand and began to look down street as
+if he had discovered something of interest going on in that direction.
+Presently he picked up a straw and began trying to balance it on his
+nose, with his head tilted far back; and as he moved from side to side,
+in his efforts, he edged nearer and nearer toward the pansy; finally his
+bare foot rested upon it, his pliant toes closed upon it, and he hopped
+away with the treasure and disappeared round the corner. But only for a
+minute--only while he could button the flower inside his jacket, next
+his heart--or next his stomach, possibly, for he was not much posted in
+anatomy, and not hypercritical, anyway.
+
+He returned, now, and hung about the fence till nightfall, “showing
+off,” as before; but the girl never exhibited herself again, though Tom
+comforted himself a little with the hope that she had been near some
+window, meantime, and been aware of his attentions. Finally he strode
+home reluctantly, with his poor head full of visions.
+
+All through supper his spirits were so high that his aunt wondered “what
+had got into the child.” He took a good scolding about clodding Sid, and
+did not seem to mind it in the least. He tried to steal sugar under his
+aunt’s very nose, and got his knuckles rapped for it. He said:
+
+“Aunt, you don’t whack Sid when he takes it.”
+
+“Well, Sid don’t torment a body the way you do. You’d be always into
+that sugar if I warn’t watching you.”
+
+Presently she stepped into the kitchen, and Sid, happy in his immunity,
+reached for the sugar-bowl--a sort of glorying over Tom which was
+wellnigh unbearable. But Sid’s fingers slipped and the bowl dropped and
+broke. Tom was in ecstasies. In such ecstasies that he even controlled
+his tongue and was silent. He said to himself that he would not speak a
+word, even when his aunt came in, but would sit perfectly still till she
+asked who did the mischief; and then he would tell, and there would be
+nothing so good in the world as to see that pet model “catch it.” He was
+so brimful of exultation that he could hardly hold himself when the old
+lady came back and stood above the wreck discharging lightnings of wrath
+from over her spectacles. He said to himself, “Now it’s coming!” And the
+next instant he was sprawling on the floor! The potent palm was uplifted
+to strike again when Tom cried out:
+
+“Hold on, now, what ‘er you belting _me_ for?--Sid broke it!”
+
+Aunt Polly paused, perplexed, and Tom looked for healing pity. But when
+she got her tongue again, she only said:
+
+“Umf! Well, you didn’t get a lick amiss, I reckon. You been into some
+other audacious mischief when I wasn’t around, like enough.”
+
+Then her conscience reproached her, and she yearned to say something
+kind and loving; but she judged that this would be construed into a
+confession that she had been in the wrong, and discipline forbade that.
+So she kept silence, and went about her affairs with a troubled heart.
+Tom sulked in a corner and exalted his woes. He knew that in her heart
+his aunt was on her knees to him, and he was morosely gratified by the
+consciousness of it. He would hang out no signals, he would take notice
+of none. He knew that a yearning glance fell upon him, now and then,
+through a film of tears, but he refused recognition of it. He pictured
+himself lying sick unto death and his aunt bending over him beseeching
+one little forgiving word, but he would turn his face to the wall, and
+die with that word unsaid. Ah, how would she feel then? And he pictured
+himself brought home from the river, dead, with his curls all wet, and
+his sore heart at rest. How she would throw herself upon him, and how
+her tears would fall like rain, and her lips pray God to give her back
+her boy and she would never, never abuse him any more! But he would
+lie there cold and white and make no sign--a poor little sufferer, whose
+griefs were at an end. He so worked upon his feelings with the pathos of
+these dreams, that he had to keep swallowing, he was so like to choke;
+and his eyes swam in a blur of water, which overflowed when he winked,
+and ran down and trickled from the end of his nose. And such a luxury to
+him was this petting of his sorrows, that he could not bear to have any
+worldly cheeriness or any grating delight intrude upon it; it was too
+sacred for such contact; and so, presently, when his cousin Mary danced
+in, all alive with the joy of seeing home again after an age-long visit
+of one week to the country, he got up and moved in clouds and darkness
+out at one door as she brought song and sunshine in at the other.
+
+He wandered far from the accustomed haunts of boys, and sought desolate
+places that were in harmony with his spirit. A log raft in the river
+invited him, and he seated himself on its outer edge and contemplated
+the dreary vastness of the stream, wishing, the while, that he could
+only be drowned, all at once and unconsciously, without undergoing the
+uncomfortable routine devised by nature. Then he thought of his flower.
+He got it out, rumpled and wilted, and it mightily increased his dismal
+felicity. He wondered if she would pity him if she knew? Would she
+cry, and wish that she had a right to put her arms around his neck and
+comfort him? Or would she turn coldly away like all the hollow world?
+This picture brought such an agony of pleasurable suffering that he
+worked it over and over again in his mind and set it up in new and
+varied lights, till he wore it threadbare. At last he rose up sighing
+and departed in the darkness.
+
+About half-past nine or ten o’clock he came along the deserted street to
+where the Adored Unknown lived; he paused a moment; no sound fell upon
+his listening ear; a candle was casting a dull glow upon the curtain
+of a second-story window. Was the sacred presence there? He climbed the
+fence, threaded his stealthy way through the plants, till he stood under
+that window; he looked up at it long, and with emotion; then he laid him
+down on the ground under it, disposing himself upon his back, with his
+hands clasped upon his breast and holding his poor wilted flower.
+And thus he would die--out in the cold world, with no shelter over his
+homeless head, no friendly hand to wipe the death-damps from his brow,
+no loving face to bend pityingly over him when the great agony came. And
+thus _she_ would see him when she looked out upon the glad morning, and
+oh! would she drop one little tear upon his poor, lifeless form, would
+she heave one little sigh to see a bright young life so rudely blighted,
+so untimely cut down?
+
+The window went up, a maid-servant’s discordant voice profaned the holy
+calm, and a deluge of water drenched the prone martyr’s remains!
+
+The strangling hero sprang up with a relieving snort. There was a whiz
+as of a missile in the air, mingled with the murmur of a curse, a sound
+as of shivering glass followed, and a small, vague form went over the
+fence and shot away in the gloom.
+
+Not long after, as Tom, all undressed for bed, was surveying his
+drenched garments by the light of a tallow dip, Sid woke up; but if he
+had any dim idea of making any “references to allusions,” he thought
+better of it and held his peace, for there was danger in Tom’s eye.
+
+Tom turned in without the added vexation of prayers, and Sid made mental
+note of the omission.
+
+
+
+
+CHAPTER IV
+
+THE sun rose upon a tranquil world, and beamed down upon the peaceful
+village like a benediction. Breakfast over, Aunt Polly had family
+worship: it began with a prayer built from the ground up of solid
+courses of Scriptural quotations, welded together with a thin mortar of
+originality; and from the summit of this she delivered a grim chapter of
+the Mosaic Law, as from Sinai.
+
+Then Tom girded up his loins, so to speak, and went to work to “get
+his verses.” Sid had learned his lesson days before. Tom bent all his
+energies to the memorizing of five verses, and he chose part of the
+Sermon on the Mount, because he could find no verses that were shorter.
+At the end of half an hour Tom had a vague general idea of his lesson,
+but no more, for his mind was traversing the whole field of human
+thought, and his hands were busy with distracting recreations. Mary took
+his book to hear him recite, and he tried to find his way through the
+fog:
+
+“Blessed are the--a--a--”
+
+“Poor”--
+
+“Yes--poor; blessed are the poor--a--a--”
+
+“In spirit--”
+
+“In spirit; blessed are the poor in spirit, for they--they--”
+
+“_Theirs_--”
+
+“For _theirs_. Blessed are the poor in spirit, for theirs is the kingdom
+of heaven. Blessed are they that mourn, for they--they--”
+
+“Sh--”
+
+“For they--a--”
+
+“S, H, A--”
+
+“For they S, H--Oh, I don’t know what it is!”
+
+“_Shall_!”
+
+“Oh, _shall_! for they shall--for they shall--a--a--shall mourn--a--a--blessed
+are they that shall--they that--a--they that shall mourn, for they
+shall--a--shall _what_? Why don’t you tell me, Mary?--what do you want to
+be so mean for?”
+
+“Oh, Tom, you poor thick-headed thing, I’m not teasing you. I wouldn’t
+do that. You must go and learn it again. Don’t you be discouraged, Tom,
+you’ll manage it--and if you do, I’ll give you something ever so nice.
+There, now, that’s a good boy.”
+
+“All right! What is it, Mary, tell me what it is.”
+
+“Never you mind, Tom. You know if I say it’s nice, it is nice.”
+
+“You bet you that’s so, Mary. All right, I’ll tackle it again.”
+
+And he did “tackle it again”--and under the double pressure of curiosity
+and prospective gain he did it with such spirit that he accomplished a
+shining success. Mary gave him a brand-new “Barlow” knife worth twelve
+and a half cents; and the convulsion of delight that swept his system
+shook him to his foundations. True, the knife would not cut anything,
+but it was a “sure-enough” Barlow, and there was inconceivable grandeur
+in that--though where the Western boys ever got the idea that such a
+weapon could possibly be counterfeited to its injury is an imposing
+mystery and will always remain so, perhaps. Tom contrived to scarify the
+cupboard with it, and was arranging to begin on the bureau, when he was
+called off to dress for Sunday-school.
+
+Mary gave him a tin basin of water and a piece of soap, and he went
+outside the door and set the basin on a little bench there; then he
+dipped the soap in the water and laid it down; turned up his sleeves;
+poured out the water on the ground, gently, and then entered the kitchen
+and began to wipe his face diligently on the towel behind the door. But
+Mary removed the towel and said:
+
+“Now ain’t you ashamed, Tom. You mustn’t be so bad. Water won’t hurt
+you.”
+
+Tom was a trifle disconcerted. The basin was refilled, and this time he
+stood over it a little while, gathering resolution; took in a big breath
+and began. When he entered the kitchen presently, with both eyes shut
+and groping for the towel with his hands, an honorable testimony of
+suds and water was dripping from his face. But when he emerged from
+the towel, he was not yet satisfactory, for the clean territory stopped
+short at his chin and his jaws, like a mask; below and beyond this line
+there was a dark expanse of unirrigated soil that spread downward in
+front and backward around his neck. Mary took him in hand, and when she
+was done with him he was a man and a brother, without distinction of
+color, and his saturated hair was neatly brushed, and its short curls
+wrought into a dainty and symmetrical general effect. [He privately
+smoothed out the curls, with labor and difficulty, and plastered his
+hair close down to his head; for he held curls to be effeminate, and his
+own filled his life with bitterness.] Then Mary got out a suit of his
+clothing that had been used only on Sundays during two years--they were
+simply called his “other clothes”--and so by that we know the size of his
+wardrobe. The girl “put him to rights” after he had dressed himself;
+she buttoned his neat roundabout up to his chin, turned his vast shirt
+collar down over his shoulders, brushed him off and crowned him with
+his speckled straw hat. He now looked exceedingly improved and
+uncomfortable. He was fully as uncomfortable as he looked; for there
+was a restraint about whole clothes and cleanliness that galled him. He
+hoped that Mary would forget his shoes, but the hope was blighted; she
+coated them thoroughly with tallow, as was the custom, and brought
+them out. He lost his temper and said he was always being made to do
+everything he didn’t want to do. But Mary said, persuasively:
+
+“Please, Tom--that’s a good boy.”
+
+So he got into the shoes snarling. Mary was soon ready, and the three
+children set out for Sunday-school--a place that Tom hated with his whole
+heart; but Sid and Mary were fond of it.
+
+Sabbath-school hours were from nine to half-past ten; and then church
+service. Two of the children always remained for the sermon voluntarily,
+and the other always remained too--for stronger reasons. The church’s
+high-backed, uncushioned pews would seat about three hundred persons;
+the edifice was but a small, plain affair, with a sort of pine board
+tree-box on top of it for a steeple. At the door Tom dropped back a step
+and accosted a Sunday-dressed comrade:
+
+“Say, Billy, got a yaller ticket?”
+
+“Yes.”
+
+“What’ll you take for her?”
+
+“What’ll you give?”
+
+“Piece of lickrish and a fish-hook.”
+
+“Less see ‘em.”
+
+Tom exhibited. They were satisfactory, and the property changed hands.
+Then Tom traded a couple of white alleys for three red tickets, and some
+small trifle or other for a couple of blue ones. He waylaid other
+boys as they came, and went on buying tickets of various colors ten
+or fifteen minutes longer. He entered the church, now, with a swarm
+of clean and noisy boys and girls, proceeded to his seat and started
+a quarrel with the first boy that came handy. The teacher, a grave,
+elderly man, interfered; then turned his back a moment and Tom pulled a
+boy’s hair in the next bench, and was absorbed in his book when the boy
+turned around; stuck a pin in another boy, presently, in order to hear
+him say “Ouch!” and got a new reprimand from his teacher. Tom’s whole
+class were of a pattern--restless, noisy, and troublesome. When they came
+to recite their lessons, not one of them knew his verses perfectly, but
+had to be prompted all along. However, they worried through, and each
+got his reward--in small blue tickets, each with a passage of Scripture
+on it; each blue ticket was pay for two verses of the recitation. Ten
+blue tickets equalled a red one, and could be exchanged for it; ten red
+tickets equalled a yellow one; for ten yellow tickets the superintendent
+gave a very plainly bound Bible (worth forty cents in those easy
+times) to the pupil. How many of my readers would have the industry and
+application to memorize two thousand verses, even for a Dore Bible? And
+yet Mary had acquired two Bibles in this way--it was the patient work of
+two years--and a boy of German parentage had won four or five. He once
+recited three thousand verses without stopping; but the strain upon his
+mental faculties was too great, and he was little better than an idiot
+from that day forth--a grievous misfortune for the school, for on great
+occasions, before company, the superintendent (as Tom expressed it)
+had always made this boy come out and “spread himself.” Only the older
+pupils managed to keep their tickets and stick to their tedious work
+long enough to get a Bible, and so the delivery of one of these prizes
+was a rare and noteworthy circumstance; the successful pupil was so
+great and conspicuous for that day that on the spot every scholar’s
+heart was fired with a fresh ambition that often lasted a couple
+of weeks. It is possible that Tom’s mental stomach had never really
+hungered for one of those prizes, but unquestionably his entire being
+had for many a day longed for the glory and the eclat that came with it.
+
+In due course the superintendent stood up in front of the pulpit, with
+a closed hymn-book in his hand and his forefinger inserted between its
+leaves, and commanded attention. When a Sunday-school superintendent
+makes his customary little speech, a hymn-book in the hand is as
+necessary as is the inevitable sheet of music in the hand of a singer
+who stands forward on the platform and sings a solo at a concert--though
+why, is a mystery: for neither the hymn-book nor the sheet of music
+is ever referred to by the sufferer. This superintendent was a slim
+creature of thirty-five, with a sandy goatee and short sandy hair; he
+wore a stiff standing-collar whose upper edge almost reached his ears
+and whose sharp points curved forward abreast the corners of his mouth--a
+fence that compelled a straight lookout ahead, and a turning of the
+whole body when a side view was required; his chin was propped on a
+spreading cravat which was as broad and as long as a bank-note, and had
+fringed ends; his boot toes were turned sharply up, in the fashion
+of the day, like sleigh-runners--an effect patiently and laboriously
+produced by the young men by sitting with their toes pressed against a
+wall for hours together. Mr. Walters was very earnest of mien, and very
+sincere and honest at heart; and he held sacred things and places
+in such reverence, and so separated them from worldly matters, that
+unconsciously to himself his Sunday-school voice had acquired a peculiar
+intonation which was wholly absent on week-days. He began after this
+fashion:
+
+“Now, children, I want you all to sit up just as straight and pretty as
+you can and give me all your attention for a minute or two. There--that
+is it. That is the way good little boys and girls should do. I see one
+little girl who is looking out of the window--I am afraid she thinks I
+am out there somewhere--perhaps up in one of the trees making a speech
+to the little birds. [Applausive titter.] I want to tell you how good it
+makes me feel to see so many bright, clean little faces assembled in a
+place like this, learning to do right and be good.” And so forth and so
+on. It is not necessary to set down the rest of the oration. It was of a
+pattern which does not vary, and so it is familiar to us all.
+
+The latter third of the speech was marred by the resumption of fights
+and other recreations among certain of the bad boys, and by fidgetings
+and whisperings that extended far and wide, washing even to the bases of
+isolated and incorruptible rocks like Sid and Mary. But now every sound
+ceased suddenly, with the subsidence of Mr. Walters’ voice, and the
+conclusion of the speech was received with a burst of silent gratitude.
+
+A good part of the whispering had been occasioned by an event which was
+more or less rare--the entrance of visitors: lawyer Thatcher, accompanied
+by a very feeble and aged man; a fine, portly, middle-aged gentleman
+with iron-gray hair; and a dignified lady who was doubtless the latter’s
+wife. The lady was leading a child. Tom had been restless and full of
+chafings and repinings; conscience-smitten, too--he could not meet Amy
+Lawrence’s eye, he could not brook her loving gaze. But when he saw this
+small newcomer his soul was all ablaze with bliss in a moment. The next
+moment he was “showing off” with all his might--cuffing boys, pulling
+hair, making faces--in a word, using every art that seemed likely to
+fascinate a girl and win her applause. His exaltation had but one
+alloy--the memory of his humiliation in this angel’s garden--and that
+record in sand was fast washing out, under the waves of happiness that
+were sweeping over it now.
+
+The visitors were given the highest seat of honor, and as soon as Mr.
+Walters’ speech was finished, he introduced them to the school. The
+middle-aged man turned out to be a prodigious personage--no less a one
+than the county judge--altogether the most august creation these children
+had ever looked upon--and they wondered what kind of material he was made
+of--and they half wanted to hear him roar, and were half afraid he might,
+too. He was from Constantinople, twelve miles away--so he had travelled,
+and seen the world--these very eyes had looked upon the county
+court-house--which was said to have a tin roof. The awe which these
+reflections inspired was attested by the impressive silence and the
+ranks of staring eyes. This was the great Judge Thatcher, brother of
+their own lawyer. Jeff Thatcher immediately went forward, to be familiar
+with the great man and be envied by the school. It would have been music
+to his soul to hear the whisperings:
+
+“Look at him, Jim! He’s a going up there. Say--look! he’s a going to
+shake hands with him--he _is_ shaking hands with him! By jings, don’t you
+wish you was Jeff?”
+
+Mr. Walters fell to “showing off,” with all sorts of official bustlings
+and activities, giving orders, delivering judgments, discharging
+directions here, there, everywhere that he could find a target. The
+librarian “showed off”--running hither and thither with his arms full of
+books and making a deal of the splutter and fuss that insect authority
+delights in. The young lady teachers “showed off”--bending sweetly over
+pupils that were lately being boxed, lifting pretty warning fingers
+at bad little boys and patting good ones lovingly. The young gentlemen
+teachers “showed off” with small scoldings and other little displays of
+authority and fine attention to discipline--and most of the teachers, of
+both sexes, found business up at the library, by the pulpit; and it was
+business that frequently had to be done over again two or three times
+(with much seeming vexation). The little girls “showed off” in various
+ways, and the little boys “showed off” with such diligence that the air
+was thick with paper wads and the murmur of scufflings. And above it
+all the great man sat and beamed a majestic judicial smile upon all
+the house, and warmed himself in the sun of his own grandeur--for he was
+“showing off,” too.
+
+There was only one thing wanting to make Mr. Walters’ ecstasy complete,
+and that was a chance to deliver a Bible-prize and exhibit a prodigy.
+Several pupils had a few yellow tickets, but none had enough--he had been
+around among the star pupils inquiring. He would have given worlds, now,
+to have that German lad back again with a sound mind.
+
+And now at this moment, when hope was dead, Tom Sawyer came forward with
+nine yellow tickets, nine red tickets, and ten blue ones, and demanded
+a Bible. This was a thunderbolt out of a clear sky. Walters was not
+expecting an application from this source for the next ten years. But
+there was no getting around it--here were the certified checks, and they
+were good for their face. Tom was therefore elevated to a place with
+the Judge and the other elect, and the great news was announced from
+headquarters. It was the most stunning surprise of the decade, and
+so profound was the sensation that it lifted the new hero up to the
+judicial one’s altitude, and the school had two marvels to gaze upon
+in place of one. The boys were all eaten up with envy--but those that
+suffered the bitterest pangs were those who perceived too late that they
+themselves had contributed to this hated splendor by trading tickets to
+Tom for the wealth he had amassed in selling whitewashing privileges.
+These despised themselves, as being the dupes of a wily fraud, a
+guileful snake in the grass.
+
+The prize was delivered to Tom with as much effusion as the
+superintendent could pump up under the circumstances; but it lacked
+somewhat of the true gush, for the poor fellow’s instinct taught him
+that there was a mystery here that could not well bear the light,
+perhaps; it was simply preposterous that this boy had warehoused two
+thousand sheaves of Scriptural wisdom on his premises--a dozen would
+strain his capacity, without a doubt.
+
+Amy Lawrence was proud and glad, and she tried to make Tom see it in
+her face--but he wouldn’t look. She wondered; then she was just a grain
+troubled; next a dim suspicion came and went--came again; she watched;
+a furtive glance told her worlds--and then her heart broke, and she was
+jealous, and angry, and the tears came and she hated everybody. Tom most
+of all (she thought).
+
+Tom was introduced to the Judge; but his tongue was tied, his breath
+would hardly come, his heart quaked--partly because of the awful
+greatness of the man, but mainly because he was her parent. He would
+have liked to fall down and worship him, if it were in the dark. The
+Judge put his hand on Tom’s head and called him a fine little man, and
+asked him what his name was. The boy stammered, gasped, and got it out:
+
+“Tom.”
+
+“Oh, no, not Tom--it is--”
+
+“Thomas.”
+
+“Ah, that’s it. I thought there was more to it, maybe. That’s very well.
+But you’ve another one I daresay, and you’ll tell it to me, won’t you?”
+
+“Tell the gentleman your other name, Thomas,” said Walters, “and say
+sir. You mustn’t forget your manners.”
+
+“Thomas Sawyer--sir.”
+
+“That’s it! That’s a good boy. Fine boy. Fine, manly little fellow. Two
+thousand verses is a great many--very, very great many. And you never can
+be sorry for the trouble you took to learn them; for knowledge is worth
+more than anything there is in the world; it’s what makes great men
+and good men; you’ll be a great man and a good man yourself, some
+day, Thomas, and then you’ll look back and say, It’s all owing to the
+precious Sunday-school privileges of my boyhood--it’s all owing to
+my dear teachers that taught me to learn--it’s all owing to the good
+superintendent, who encouraged me, and watched over me, and gave me a
+beautiful Bible--a splendid elegant Bible--to keep and have it all for my
+own, always--it’s all owing to right bringing up! That is what you will
+say, Thomas--and you wouldn’t take any money for those two thousand
+verses--no indeed you wouldn’t. And now you wouldn’t mind telling me and
+this lady some of the things you’ve learned--no, I know you wouldn’t--for
+we are proud of little boys that learn. Now, no doubt you know the names
+of all the twelve disciples. Won’t you tell us the names of the first
+two that were appointed?”
+
+Tom was tugging at a button-hole and looking sheepish. He blushed,
+now, and his eyes fell. Mr. Walters’ heart sank within him. He said
+to himself, it is not possible that the boy can answer the simplest
+question--why _did_ the Judge ask him? Yet he felt obliged to speak up
+and say:
+
+“Answer the gentleman, Thomas--don’t be afraid.”
+
+Tom still hung fire.
+
+“Now I know you’ll tell me,” said the lady. “The names of the first two
+disciples were--”
+
+“_David And Goliah!_”
+
+Let us draw the curtain of charity over the rest of the scene.
+
+
+
+
+CHAPTER V
+
+ABOUT half-past ten the cracked bell of the small church began to ring,
+and presently the people began to gather for the morning sermon. The
+Sunday-school children distributed themselves about the house and
+occupied pews with their parents, so as to be under supervision. Aunt
+Polly came, and Tom and Sid and Mary sat with her--Tom being placed next
+the aisle, in order that he might be as far away from the open window
+and the seductive outside summer scenes as possible. The crowd filed up
+the aisles: the aged and needy postmaster, who had seen better days;
+the mayor and his wife--for they had a mayor there, among other
+unnecessaries; the justice of the peace; the widow Douglass, fair,
+smart, and forty, a generous, good-hearted soul and well-to-do, her hill
+mansion the only palace in the town, and the most hospitable and much
+the most lavish in the matter of festivities that St. Petersburg could
+boast; the bent and venerable Major and Mrs. Ward; lawyer Riverson, the
+new notable from a distance; next the belle of the village, followed by
+a troop of lawn-clad and ribbon-decked young heart-breakers; then all
+the young clerks in town in a body--for they had stood in the vestibule
+sucking their cane-heads, a circling wall of oiled and simpering
+admirers, till the last girl had run their gantlet; and last of all came
+the Model Boy, Willie Mufferson, taking as heedful care of his mother as
+if she were cut glass. He always brought his mother to church, and was
+the pride of all the matrons. The boys all hated him, he was so
+good. And besides, he had been “thrown up to them” so much. His
+white handkerchief was hanging out of his pocket behind, as usual on
+Sundays--accidentally. Tom had no handkerchief, and he looked upon boys
+who had as snobs.
+
+The congregation being fully assembled, now, the bell rang once more,
+to warn laggards and stragglers, and then a solemn hush fell upon the
+church which was only broken by the tittering and whispering of the
+choir in the gallery. The choir always tittered and whispered all
+through service. There was once a church choir that was not ill-bred,
+but I have forgotten where it was, now. It was a great many years ago,
+and I can scarcely remember anything about it, but I think it was in
+some foreign country.
+
+The minister gave out the hymn, and read it through with a relish, in a
+peculiar style which was much admired in that part of the country. His
+voice began on a medium key and climbed steadily up till it reached a
+certain point, where it bore with strong emphasis upon the topmost word
+and then plunged down as if from a spring-board:
+
+Shall I be car-ri-ed toe the skies, on flow’ry _beds_ of ease,
+
+Whilst others fight to win the prize, and sail thro’ _blood_-y seas?
+
+He was regarded as a wonderful reader. At church “sociables” he was
+always called upon to read poetry; and when he was through, the ladies
+would lift up their hands and let them fall helplessly in their laps,
+and “wall” their eyes, and shake their heads, as much as to say, “Words
+cannot express it; it is too beautiful, TOO beautiful for this mortal
+earth.”
+
+After the hymn had been sung, the Rev. Mr. Sprague turned himself into
+a bulletin-board, and read off “notices” of meetings and societies and
+things till it seemed that the list would stretch out to the crack of
+doom--a queer custom which is still kept up in America, even in cities,
+away here in this age of abundant newspapers. Often, the less there is
+to justify a traditional custom, the harder it is to get rid of it.
+
+And now the minister prayed. A good, generous prayer it was, and went
+into details: it pleaded for the church, and the little children of the
+church; for the other churches of the village; for the village itself;
+for the county; for the State; for the State officers; for the United
+States; for the churches of the United States; for Congress; for the
+President; for the officers of the Government; for poor sailors, tossed
+by stormy seas; for the oppressed millions groaning under the heel of
+European monarchies and Oriental despotisms; for such as have the light
+and the good tidings, and yet have not eyes to see nor ears to hear
+withal; for the heathen in the far islands of the sea; and closed with
+a supplication that the words he was about to speak might find grace
+and favor, and be as seed sown in fertile ground, yielding in time a
+grateful harvest of good. Amen.
+
+There was a rustling of dresses, and the standing congregation sat down.
+The boy whose history this book relates did not enjoy the prayer, he
+only endured it--if he even did that much. He was restive all through it;
+he kept tally of the details of the prayer, unconsciously--for he was not
+listening, but he knew the ground of old, and the clergyman’s regular
+route over it--and when a little trifle of new matter was interlarded,
+his ear detected it and his whole nature resented it; he considered
+additions unfair, and scoundrelly. In the midst of the prayer a fly had
+lit on the back of the pew in front of him and tortured his spirit by
+calmly rubbing its hands together, embracing its head with its arms, and
+polishing it so vigorously that it seemed to almost part company with
+the body, and the slender thread of a neck was exposed to view; scraping
+its wings with its hind legs and smoothing them to its body as if they
+had been coat-tails; going through its whole toilet as tranquilly as if
+it knew it was perfectly safe. As indeed it was; for as sorely as Tom’s
+hands itched to grab for it they did not dare--he believed his soul would
+be instantly destroyed if he did such a thing while the prayer was going
+on. But with the closing sentence his hand began to curve and steal
+forward; and the instant the “Amen” was out the fly was a prisoner of
+war. His aunt detected the act and made him let it go.
+
+The minister gave out his text and droned along monotonously through an
+argument that was so prosy that many a head by and by began to nod--and
+yet it was an argument that dealt in limitless fire and brimstone and
+thinned the predestined elect down to a company so small as to be hardly
+worth the saving. Tom counted the pages of the sermon; after church he
+always knew how many pages there had been, but he seldom knew anything
+else about the discourse. However, this time he was really interested
+for a little while. The minister made a grand and moving picture of the
+assembling together of the world’s hosts at the millennium when the lion
+and the lamb should lie down together and a little child should lead
+them. But the pathos, the lesson, the moral of the great spectacle
+were lost upon the boy; he only thought of the conspicuousness of the
+principal character before the on-looking nations; his face lit with the
+thought, and he said to himself that he wished he could be that child,
+if it was a tame lion.
+
+Now he lapsed into suffering again, as the dry argument was resumed.
+Presently he bethought him of a treasure he had and got it out. It was
+a large black beetle with formidable jaws--a “pinchbug,” he called it. It
+was in a percussion-cap box. The first thing the beetle did was to
+take him by the finger. A natural fillip followed, the beetle went
+floundering into the aisle and lit on its back, and the hurt finger went
+into the boy’s mouth. The beetle lay there working its helpless legs,
+unable to turn over. Tom eyed it, and longed for it; but it was safe out
+of his reach. Other people uninterested in the sermon found relief in
+the beetle, and they eyed it too. Presently a vagrant poodle dog came
+idling along, sad at heart, lazy with the summer softness and the
+quiet, weary of captivity, sighing for change. He spied the beetle; the
+drooping tail lifted and wagged. He surveyed the prize; walked around
+it; smelt at it from a safe distance; walked around it again; grew
+bolder, and took a closer smell; then lifted his lip and made a gingerly
+snatch at it, just missing it; made another, and another; began to enjoy
+the diversion; subsided to his stomach with the beetle between his paws,
+and continued his experiments; grew weary at last, and then indifferent
+and absent-minded. His head nodded, and little by little his chin
+descended and touched the enemy, who seized it. There was a sharp yelp,
+a flirt of the poodle’s head, and the beetle fell a couple of yards
+away, and lit on its back once more. The neighboring spectators
+shook with a gentle inward joy, several faces went behind fans and
+hand-kerchiefs, and Tom was entirely happy. The dog looked foolish,
+and probably felt so; but there was resentment in his heart, too, and a
+craving for revenge. So he went to the beetle and began a wary attack on
+it again; jumping at it from every point of a circle, lighting with his
+fore-paws within an inch of the creature, making even closer snatches at
+it with his teeth, and jerking his head till his ears flapped again. But
+he grew tired once more, after a while; tried to amuse himself with a
+fly but found no relief; followed an ant around, with his nose close
+to the floor, and quickly wearied of that; yawned, sighed, forgot the
+beetle entirely, and sat down on it. Then there was a wild yelp of agony
+and the poodle went sailing up the aisle; the yelps continued, and so
+did the dog; he crossed the house in front of the altar; he flew
+down the other aisle; he crossed before the doors; he clamored up the
+home-stretch; his anguish grew with his progress, till presently he was
+but a woolly comet moving in its orbit with the gleam and the speed of
+light. At last the frantic sufferer sheered from its course, and sprang
+into its master’s lap; he flung it out of the window, and the voice of
+distress quickly thinned away and died in the distance.
+
+By this time the whole church was red-faced and suffocating with
+suppressed laughter, and the sermon had come to a dead standstill.
+The discourse was resumed presently, but it went lame and halting, all
+possibility of impressiveness being at an end; for even the gravest
+sentiments were constantly being received with a smothered burst of
+unholy mirth, under cover of some remote pew-back, as if the poor parson
+had said a rarely facetious thing. It was a genuine relief to the whole
+congregation when the ordeal was over and the benediction pronounced.
+
+Tom Sawyer went home quite cheerful, thinking to himself that there was
+some satisfaction about divine service when there was a bit of variety
+in it. He had but one marring thought; he was willing that the dog
+should play with his pinchbug, but he did not think it was upright in
+him to carry it off.
+
+
+
+
+CHAPTER VI
+
+MONDAY morning found Tom Sawyer miserable. Monday morning always found
+him so--because it began another week’s slow suffering in school. He
+generally began that day with wishing he had had no intervening holiday,
+it made the going into captivity and fetters again so much more odious.
+
+Tom lay thinking. Presently it occurred to him that he wished he was
+sick; then he could stay home from school. Here was a vague possibility.
+He canvassed his system. No ailment was found, and he investigated
+again. This time he thought he could detect colicky symptoms, and he
+began to encourage them with considerable hope. But they soon grew
+feeble, and presently died wholly away. He reflected further. Suddenly
+he discovered something. One of his upper front teeth was loose. This
+was lucky; he was about to begin to groan, as a “starter,” as he
+called it, when it occurred to him that if he came into court with that
+argument, his aunt would pull it out, and that would hurt. So he thought
+he would hold the tooth in reserve for the present, and seek further.
+Nothing offered for some little time, and then he remembered hearing
+the doctor tell about a certain thing that laid up a patient for two or
+three weeks and threatened to make him lose a finger. So the boy eagerly
+drew his sore toe from under the sheet and held it up for inspection.
+But now he did not know the necessary symptoms. However, it seemed
+well worth while to chance it, so he fell to groaning with considerable
+spirit.
+
+But Sid slept on unconscious.
+
+Tom groaned louder, and fancied that he began to feel pain in the toe.
+
+No result from Sid.
+
+Tom was panting with his exertions by this time. He took a rest and then
+swelled himself up and fetched a succession of admirable groans.
+
+Sid snored on.
+
+Tom was aggravated. He said, “Sid, Sid!” and shook him. This course
+worked well, and Tom began to groan again. Sid yawned, stretched, then
+brought himself up on his elbow with a snort, and began to stare at Tom.
+Tom went on groaning. Sid said:
+
+“Tom! Say, Tom!” [No response.] “Here, Tom! TOM! What is the matter,
+Tom?” And he shook him and looked in his face anxiously.
+
+Tom moaned out:
+
+“Oh, don’t, Sid. Don’t joggle me.”
+
+“Why, what’s the matter, Tom? I must call auntie.”
+
+“No--never mind. It’ll be over by and by, maybe. Don’t call anybody.”
+
+“But I must! _Don’t_ groan so, Tom, it’s awful. How long you been this
+way?”
+
+“Hours. Ouch! Oh, don’t stir so, Sid, you’ll kill me.”
+
+“Tom, why didn’t you wake me sooner? Oh, Tom, _don’t!_ It makes my flesh
+crawl to hear you. Tom, what is the matter?”
+
+“I forgive you everything, Sid. [Groan.] Everything you’ve ever done to
+me. When I’m gone--”
+
+“Oh, Tom, you ain’t dying, are you? Don’t, Tom--oh, don’t. Maybe--”
+
+“I forgive everybody, Sid. [Groan.] Tell ‘em so, Sid. And Sid, you give
+my window-sash and my cat with one eye to that new girl that’s come to
+town, and tell her--”
+
+But Sid had snatched his clothes and gone. Tom was suffering in reality,
+now, so handsomely was his imagination working, and so his groans had
+gathered quite a genuine tone.
+
+Sid flew downstairs and said:
+
+“Oh, Aunt Polly, come! Tom’s dying!”
+
+“Dying!”
+
+“Yes’m. Don’t wait--come quick!”
+
+“Rubbage! I don’t believe it!”
+
+But she fled upstairs, nevertheless, with Sid and Mary at her heels.
+And her face grew white, too, and her lip trembled. When she reached the
+bedside she gasped out:
+
+“You, Tom! Tom, what’s the matter with you?”
+
+“Oh, auntie, I’m--”
+
+“What’s the matter with you--what is the matter with you, child?”
+
+“Oh, auntie, my sore toe’s mortified!”
+
+The old lady sank down into a chair and laughed a little, then cried a
+little, then did both together. This restored her and she said:
+
+“Tom, what a turn you did give me. Now you shut up that nonsense and
+climb out of this.”
+
+The groans ceased and the pain vanished from the toe. The boy felt a
+little foolish, and he said:
+
+“Aunt Polly, it _seemed_ mortified, and it hurt so I never minded my
+tooth at all.”
+
+“Your tooth, indeed! What’s the matter with your tooth?”
+
+“One of them’s loose, and it aches perfectly awful.”
+
+“There, there, now, don’t begin that groaning again. Open your mouth.
+Well--your tooth _is_ loose, but you’re not going to die about that.
+Mary, get me a silk thread, and a chunk of fire out of the kitchen.”
+
+Tom said:
+
+“Oh, please, auntie, don’t pull it out. It don’t hurt any more. I wish
+I may never stir if it does. Please don’t, auntie. I don’t want to stay
+home from school.”
+
+“Oh, you don’t, don’t you? So all this row was because you thought you’d
+get to stay home from school and go a-fishing? Tom, Tom, I love you so,
+and you seem to try every way you can to break my old heart with your
+outrageousness.” By this time the dental instruments were ready. The old
+lady made one end of the silk thread fast to Tom’s tooth with a loop
+and tied the other to the bedpost. Then she seized the chunk of fire and
+suddenly thrust it almost into the boy’s face. The tooth hung dangling
+by the bedpost, now.
+
+But all trials bring their compensations. As Tom wended to school after
+breakfast, he was the envy of every boy he met because the gap in his
+upper row of teeth enabled him to expectorate in a new and admirable
+way. He gathered quite a following of lads interested in the exhibition;
+and one that had cut his finger and had been a centre of fascination and
+homage up to this time, now found himself suddenly without an adherent,
+and shorn of his glory. His heart was heavy, and he said with a disdain
+which he did not feel that it wasn’t anything to spit like Tom Sawyer;
+but another boy said, “Sour grapes!” and he wandered away a dismantled
+hero.
+
+Shortly Tom came upon the juvenile pariah of the village, Huckleberry
+Finn, son of the town drunkard. Huckleberry was cordially hated and
+dreaded by all the mothers of the town, because he was idle and lawless
+and vulgar and bad--and because all their children admired him so, and
+delighted in his forbidden society, and wished they dared to be like
+him. Tom was like the rest of the respectable boys, in that he envied
+Huckleberry his gaudy outcast condition, and was under strict orders
+not to play with him. So he played with him every time he got a chance.
+Huckleberry was always dressed in the cast-off clothes of full-grown
+men, and they were in perennial bloom and fluttering with rags. His hat
+was a vast ruin with a wide crescent lopped out of its brim; his coat,
+when he wore one, hung nearly to his heels and had the rearward buttons
+far down the back; but one suspender supported his trousers; the seat of
+the trousers bagged low and contained nothing, the fringed legs dragged
+in the dirt when not rolled up.
+
+Huckleberry came and went, at his own free will. He slept on doorsteps
+in fine weather and in empty hogsheads in wet; he did not have to go to
+school or to church, or call any being master or obey anybody; he could
+go fishing or swimming when and where he chose, and stay as long as it
+suited him; nobody forbade him to fight; he could sit up as late as he
+pleased; he was always the first boy that went barefoot in the spring
+and the last to resume leather in the fall; he never had to wash, nor
+put on clean clothes; he could swear wonderfully. In a word, everything
+that goes to make life precious that boy had. So thought every harassed,
+hampered, respectable boy in St. Petersburg.
+
+Tom hailed the romantic outcast:
+
+“Hello, Huckleberry!”
+
+“Hello yourself, and see how you like it.”
+
+“What’s that you got?”
+
+“Dead cat.”
+
+“Lemme see him, Huck. My, he’s pretty stiff. Where’d you get him?”
+
+“Bought him off’n a boy.”
+
+“What did you give?”
+
+“I give a blue ticket and a bladder that I got at the slaughter-house.”
+
+“Where’d you get the blue ticket?”
+
+“Bought it off’n Ben Rogers two weeks ago for a hoop-stick.”
+
+“Say--what is dead cats good for, Huck?”
+
+“Good for? Cure warts with.”
+
+“No! Is that so? I know something that’s better.”
+
+“I bet you don’t. What is it?”
+
+“Why, spunk-water.”
+
+“Spunk-water! I wouldn’t give a dern for spunk-water.”
+
+“You wouldn’t, wouldn’t you? D’you ever try it?”
+
+“No, I hain’t. But Bob Tanner did.”
+
+“Who told you so!”
+
+“Why, he told Jeff Thatcher, and Jeff told Johnny Baker, and Johnny
+told Jim Hollis, and Jim told Ben Rogers, and Ben told a nigger, and the
+nigger told me. There now!”
+
+“Well, what of it? They’ll all lie. Leastways all but the nigger. I
+don’t know _him_. But I never see a nigger that _wouldn’t_ lie. Shucks!
+Now you tell me how Bob Tanner done it, Huck.”
+
+“Why, he took and dipped his hand in a rotten stump where the rain-water
+was.”
+
+“In the daytime?”
+
+“Certainly.”
+
+“With his face to the stump?”
+
+“Yes. Least I reckon so.”
+
+“Did he say anything?”
+
+“I don’t reckon he did. I don’t know.”
+
+“Aha! Talk about trying to cure warts with spunk-water such a blame fool
+way as that! Why, that ain’t a-going to do any good. You got to go all
+by yourself, to the middle of the woods, where you know there’s a
+spunk-water stump, and just as it’s midnight you back up against the stump
+and jam your hand in and say:
+
+‘Barley-corn, barley-corn, injun-meal shorts, Spunk-water, spunk-water,
+swaller these warts,’
+
+and then walk away quick, eleven steps, with your eyes shut, and then
+turn around three times and walk home without speaking to anybody.
+Because if you speak the charm’s busted.”
+
+“Well, that sounds like a good way; but that ain’t the way Bob Tanner
+done.”
+
+“No, sir, you can bet he didn’t, becuz he’s the wartiest boy in this
+town; and he wouldn’t have a wart on him if he’d knowed how to work
+spunk-water. I’ve took off thousands of warts off of my hands that way,
+Huck. I play with frogs so much that I’ve always got considerable many
+warts. Sometimes I take ‘em off with a bean.”
+
+“Yes, bean’s good. I’ve done that.”
+
+“Have you? What’s your way?”
+
+“You take and split the bean, and cut the wart so as to get some blood,
+and then you put the blood on one piece of the bean and take and dig
+a hole and bury it ‘bout midnight at the crossroads in the dark of the
+moon, and then you burn up the rest of the bean. You see that piece
+that’s got the blood on it will keep drawing and drawing, trying to
+fetch the other piece to it, and so that helps the blood to draw the
+wart, and pretty soon off she comes.”
+
+“Yes, that’s it, Huck--that’s it; though when you’re burying it if you
+say ‘Down bean; off wart; come no more to bother me!’ it’s better.
+That’s the way Joe Harper does, and he’s been nearly to Coonville and
+most everywheres. But say--how do you cure ‘em with dead cats?”
+
+“Why, you take your cat and go and get in the grave-yard ‘long about
+midnight when somebody that was wicked has been buried; and when it’s
+midnight a devil will come, or maybe two or three, but you can’t see
+‘em, you can only hear something like the wind, or maybe hear ‘em talk;
+and when they’re taking that feller away, you heave your cat after ‘em
+and say, ‘Devil follow corpse, cat follow devil, warts follow cat, I’m
+done with ye!’ That’ll fetch _any_ wart.”
+
+“Sounds right. D’you ever try it, Huck?”
+
+“No, but old Mother Hopkins told me.”
+
+“Well, I reckon it’s so, then. Becuz they say she’s a witch.”
+
+“Say! Why, Tom, I _know_ she is. She witched pap. Pap says so his own
+self. He come along one day, and he see she was a-witching him, so he
+took up a rock, and if she hadn’t dodged, he’d a got her. Well, that
+very night he rolled off’n a shed wher’ he was a layin drunk, and broke
+his arm.”
+
+“Why, that’s awful. How did he know she was a-witching him?”
+
+“Lord, pap can tell, easy. Pap says when they keep looking at you right
+stiddy, they’re a-witching you. Specially if they mumble. Becuz when
+they mumble they’re saying the Lord’s Prayer backards.”
+
+“Say, Hucky, when you going to try the cat?”
+
+“To-night. I reckon they’ll come after old Hoss Williams to-night.”
+
+“But they buried him Saturday. Didn’t they get him Saturday night?”
+
+“Why, how you talk! How could their charms work till midnight?--and
+_then_ it’s Sunday. Devils don’t slosh around much of a Sunday, I don’t
+reckon.”
+
+“I never thought of that. That’s so. Lemme go with you?”
+
+“Of course--if you ain’t afeard.”
+
+“Afeard! ‘Tain’t likely. Will you meow?”
+
+“Yes--and you meow back, if you get a chance. Last time, you kep’ me
+a-meowing around till old Hays went to throwing rocks at me and says
+‘Dern that cat!’ and so I hove a brick through his window--but don’t you
+tell.”
+
+“I won’t. I couldn’t meow that night, becuz auntie was watching me, but
+I’ll meow this time. Say--what’s that?”
+
+“Nothing but a tick.”
+
+“Where’d you get him?”
+
+“Out in the woods.”
+
+“What’ll you take for him?”
+
+“I don’t know. I don’t want to sell him.”
+
+“All right. It’s a mighty small tick, anyway.”
+
+“Oh, anybody can run a tick down that don’t belong to them. I’m
+satisfied with it. It’s a good enough tick for me.”
+
+“Sho, there’s ticks a plenty. I could have a thousand of ‘em if I wanted
+to.”
+
+“Well, why don’t you? Becuz you know mighty well you can’t. This is a
+pretty early tick, I reckon. It’s the first one I’ve seen this year.”
+
+“Say, Huck--I’ll give you my tooth for him.”
+
+“Less see it.”
+
+Tom got out a bit of paper and carefully unrolled it. Huckleberry viewed
+it wistfully. The temptation was very strong. At last he said:
+
+“Is it genuwyne?”
+
+Tom lifted his lip and showed the vacancy.
+
+“Well, all right,” said Huckleberry, “it’s a trade.”
+
+Tom enclosed the tick in the percussion-cap box that had lately been the
+pinchbug’s prison, and the boys separated, each feeling wealthier than
+before.
+
+When Tom reached the little isolated frame school-house, he strode in
+briskly, with the manner of one who had come with all honest speed. He
+hung his hat on a peg and flung himself into his seat with business-like
+alacrity. The master, throned on high in his great splint-bottom
+arm-chair, was dozing, lulled by the drowsy hum of study. The
+interruption roused him.
+
+“Thomas Sawyer!”
+
+Tom knew that when his name was pronounced in full, it meant trouble.
+
+“Sir!”
+
+“Come up here. Now, sir, why are you late again, as usual?”
+
+Tom was about to take refuge in a lie, when he saw two long tails of
+yellow hair hanging down a back that he recognized by the electric
+sympathy of love; and by that form was _the only vacant place_ on the
+girls’ side of the school-house. He instantly said:
+
+“_I stopped to talk with Huckleberry Finn!_”
+
+The master’s pulse stood still, and he stared helplessly. The buzz of
+study ceased. The pupils wondered if this foolhardy boy had lost his
+mind. The master said:
+
+“You--you did what?”
+
+“Stopped to talk with Huckleberry Finn.”
+
+There was no mistaking the words.
+
+“Thomas Sawyer, this is the most astounding confession I have ever
+listened to. No mere ferule will answer for this offence. Take off your
+jacket.”
+
+The master’s arm performed until it was tired and the stock of switches
+notably diminished. Then the order followed:
+
+“Now, sir, go and sit with the girls! And let this be a warning to you.”
+
+The titter that rippled around the room appeared to abash the boy, but
+in reality that result was caused rather more by his worshipful awe
+of his unknown idol and the dread pleasure that lay in his high good
+fortune. He sat down upon the end of the pine bench and the girl hitched
+herself away from him with a toss of her head. Nudges and winks and
+whispers traversed the room, but Tom sat still, with his arms upon the
+long, low desk before him, and seemed to study his book.
+
+By and by attention ceased from him, and the accustomed school murmur
+rose upon the dull air once more. Presently the boy began to steal
+furtive glances at the girl. She observed it, “made a mouth” at him
+and gave him the back of her head for the space of a minute. When she
+cautiously faced around again, a peach lay before her. She thrust it
+away. Tom gently put it back. She thrust it away again, but with less
+animosity. Tom patiently returned it to its place. Then she let it
+remain. Tom scrawled on his slate, “Please take it--I got more.” The
+girl glanced at the words, but made no sign. Now the boy began to draw
+something on the slate, hiding his work with his left hand. For a time
+the girl refused to notice; but her human curiosity presently began
+to manifest itself by hardly perceptible signs. The boy worked on,
+apparently unconscious. The girl made a sort of non-committal attempt
+to see, but the boy did not betray that he was aware of it. At last she
+gave in and hesitatingly whispered:
+
+“Let me see it.”
+
+Tom partly uncovered a dismal caricature of a house with two gable ends
+to it and a corkscrew of smoke issuing from the chimney. Then the girl’s
+interest began to fasten itself upon the work and she forgot everything
+else. When it was finished, she gazed a moment, then whispered:
+
+“It’s nice--make a man.”
+
+The artist erected a man in the front yard, that resembled a derrick. He
+could have stepped over the house; but the girl was not hypercritical;
+she was satisfied with the monster, and whispered:
+
+“It’s a beautiful man--now make me coming along.”
+
+Tom drew an hour-glass with a full moon and straw limbs to it and armed
+the spreading fingers with a portentous fan. The girl said:
+
+“It’s ever so nice--I wish I could draw.”
+
+“It’s easy,” whispered Tom, “I’ll learn you.”
+
+“Oh, will you? When?”
+
+“At noon. Do you go home to dinner?”
+
+“I’ll stay if you will.”
+
+“Good--that’s a whack. What’s your name?”
+
+“Becky Thatcher. What’s yours? Oh, I know. It’s Thomas Sawyer.”
+
+“That’s the name they lick me by. I’m Tom when I’m good. You call me
+Tom, will you?”
+
+“Yes.”
+
+Now Tom began to scrawl something on the slate, hiding the words from
+the girl. But she was not backward this time. She begged to see. Tom
+said:
+
+“Oh, it ain’t anything.”
+
+“Yes it is.”
+
+“No it ain’t. You don’t want to see.”
+
+“Yes I do, indeed I do. Please let me.”
+
+“You’ll tell.”
+
+“No I won’t--deed and deed and double deed won’t.”
+
+“You won’t tell anybody at all? Ever, as long as you live?”
+
+“No, I won’t ever tell _any_body. Now let me.”
+
+“Oh, _you_ don’t want to see!”
+
+“Now that you treat me so, I _will_ see.” And she put her small hand
+upon his and a little scuffle ensued, Tom pretending to resist in
+earnest but letting his hand slip by degrees till these words were
+revealed: “_I love you_.”
+
+“Oh, you bad thing!” And she hit his hand a smart rap, but reddened and
+looked pleased, nevertheless.
+
+Just at this juncture the boy felt a slow, fateful grip closing on his
+ear, and a steady lifting impulse. In that wise he was borne across the
+house and deposited in his own seat, under a peppering fire of giggles
+from the whole school. Then the master stood over him during a few awful
+moments, and finally moved away to his throne without saying a word. But
+although Tom’s ear tingled, his heart was jubilant.
+
+As the school quieted down Tom made an honest effort to study, but
+the turmoil within him was too great. In turn he took his place in the
+reading class and made a botch of it; then in the geography class and
+turned lakes into mountains, mountains into rivers, and rivers into
+continents, till chaos was come again; then in the spelling class, and
+got “turned down,” by a succession of mere baby words, till he brought
+up at the foot and yielded up the pewter medal which he had worn with
+ostentation for months.
+
+
+
+
+CHAPTER VII
+
+THE harder Tom tried to fasten his mind on his book, the more his ideas
+wandered. So at last, with a sigh and a yawn, he gave it up. It seemed
+to him that the noon recess would never come. The air was utterly dead.
+There was not a breath stirring. It was the sleepiest of sleepy days.
+The drowsing murmur of the five and twenty studying scholars soothed
+the soul like the spell that is in the murmur of bees. Away off in the
+flaming sunshine, Cardiff Hill lifted its soft green sides through a
+shimmering veil of heat, tinted with the purple of distance; a few birds
+floated on lazy wing high in the air; no other living thing was visible
+but some cows, and they were asleep. Tom’s heart ached to be free, or
+else to have something of interest to do to pass the dreary time.
+His hand wandered into his pocket and his face lit up with a glow of
+gratitude that was prayer, though he did not know it. Then furtively
+the percussion-cap box came out. He released the tick and put him on
+the long flat desk. The creature probably glowed with a gratitude that
+amounted to prayer, too, at this moment, but it was premature: for when
+he started thankfully to travel off, Tom turned him aside with a pin and
+made him take a new direction.
+
+Tom’s bosom friend sat next him, suffering just as Tom had been, and
+now he was deeply and gratefully interested in this entertainment in
+an instant. This bosom friend was Joe Harper. The two boys were sworn
+friends all the week, and embattled enemies on Saturdays. Joe took a
+pin out of his lapel and began to assist in exercising the prisoner.
+The sport grew in interest momently. Soon Tom said that they were
+interfering with each other, and neither getting the fullest benefit
+of the tick. So he put Joe’s slate on the desk and drew a line down the
+middle of it from top to bottom.
+
+“Now,” said he, “as long as he is on your side you can stir him up and
+I’ll let him alone; but if you let him get away and get on my side,
+you’re to leave him alone as long as I can keep him from crossing over.”
+
+“All right, go ahead; start him up.”
+
+The tick escaped from Tom, presently, and crossed the equator. Joe
+harassed him awhile, and then he got away and crossed back again. This
+change of base occurred often. While one boy was worrying the tick with
+absorbing interest, the other would look on with interest as strong, the
+two heads bowed together over the slate, and the two souls dead to all
+things else. At last luck seemed to settle and abide with Joe. The
+tick tried this, that, and the other course, and got as excited and as
+anxious as the boys themselves, but time and again just as he would
+have victory in his very grasp, so to speak, and Tom’s fingers would
+be twitching to begin, Joe’s pin would deftly head him off, and keep
+possession. At last Tom could stand it no longer. The temptation was too
+strong. So he reached out and lent a hand with his pin. Joe was angry in
+a moment. Said he:
+
+“Tom, you let him alone.”
+
+“I only just want to stir him up a little, Joe.”
+
+“No, sir, it ain’t fair; you just let him alone.”
+
+“Blame it, I ain’t going to stir him much.”
+
+“Let him alone, I tell you.”
+
+“I won’t!”
+
+“You shall--he’s on my side of the line.”
+
+“Look here, Joe Harper, whose is that tick?”
+
+“I don’t care whose tick he is--he’s on my side of the line, and you
+sha’n’t touch him.”
+
+“Well, I’ll just bet I will, though. He’s my tick and I’ll do what I
+blame please with him, or die!”
+
+A tremendous whack came down on Tom’s shoulders, and its duplicate on
+Joe’s; and for the space of two minutes the dust continued to fly from
+the two jackets and the whole school to enjoy it. The boys had been
+too absorbed to notice the hush that had stolen upon the school awhile
+before when the master came tiptoeing down the room and stood over them.
+He had contemplated a good part of the performance before he contributed
+his bit of variety to it.
+
+When school broke up at noon, Tom flew to Becky Thatcher, and whispered
+in her ear:
+
+“Put on your bonnet and let on you’re going home; and when you get to
+the corner, give the rest of ‘em the slip, and turn down through the
+lane and come back. I’ll go the other way and come it over ‘em the same
+way.”
+
+So the one went off with one group of scholars, and the other with
+another. In a little while the two met at the bottom of the lane, and
+when they reached the school they had it all to themselves. Then they
+sat together, with a slate before them, and Tom gave Becky the pencil
+and held her hand in his, guiding it, and so created another surprising
+house. When the interest in art began to wane, the two fell to talking.
+Tom was swimming in bliss. He said:
+
+“Do you love rats?”
+
+“No! I hate them!”
+
+“Well, I do, too--_live_ ones. But I mean dead ones, to swing round your
+head with a string.”
+
+“No, I don’t care for rats much, anyway. What I like is chewing-gum.”
+
+“Oh, I should say so! I wish I had some now.”
+
+“Do you? I’ve got some. I’ll let you chew it awhile, but you must give
+it back to me.”
+
+That was agreeable, so they chewed it turn about, and dangled their legs
+against the bench in excess of contentment.
+
+“Was you ever at a circus?” said Tom.
+
+“Yes, and my pa’s going to take me again some time, if I’m good.”
+
+“I been to the circus three or four times--lots of times. Church ain’t
+shucks to a circus. There’s things going on at a circus all the time.
+I’m going to be a clown in a circus when I grow up.”
+
+“Oh, are you! That will be nice. They’re so lovely, all spotted up.”
+
+“Yes, that’s so. And they get slathers of money--most a dollar a day, Ben
+Rogers says. Say, Becky, was you ever engaged?”
+
+“What’s that?”
+
+“Why, engaged to be married.”
+
+“No.”
+
+“Would you like to?”
+
+“I reckon so. I don’t know. What is it like?”
+
+“Like? Why it ain’t like anything. You only just tell a boy you won’t
+ever have anybody but him, ever ever ever, and then you kiss and that’s
+all. Anybody can do it.”
+
+“Kiss? What do you kiss for?”
+
+“Why, that, you know, is to--well, they always do that.”
+
+“Everybody?”
+
+“Why, yes, everybody that’s in love with each other. Do you remember
+what I wrote on the slate?”
+
+“Ye--yes.”
+
+“What was it?”
+
+“I sha’n’t tell you.”
+
+“Shall I tell _you_?”
+
+“Ye--yes--but some other time.”
+
+“No, now.”
+
+“No, not now--to-morrow.”
+
+“Oh, no, _now_. Please, Becky--I’ll whisper it, I’ll whisper it ever so
+easy.”
+
+Becky hesitating, Tom took silence for consent, and passed his arm about
+her waist and whispered the tale ever so softly, with his mouth close to
+her ear. And then he added:
+
+“Now you whisper it to me--just the same.”
+
+She resisted, for a while, and then said:
+
+“You turn your face away so you can’t see, and then I will. But you
+mustn’t ever tell anybody--_will_ you, Tom? Now you won’t, _will_ you?”
+
+“No, indeed, indeed I won’t. Now, Becky.”
+
+He turned his face away. She bent timidly around till her breath stirred
+his curls and whispered, “I--love--you!”
+
+Then she sprang away and ran around and around the desks and benches,
+with Tom after her, and took refuge in a corner at last, with her little
+white apron to her face. Tom clasped her about her neck and pleaded:
+
+“Now, Becky, it’s all done--all over but the kiss. Don’t you be afraid
+of that--it ain’t anything at all. Please, Becky.” And he tugged at her
+apron and the hands.
+
+By and by she gave up, and let her hands drop; her face, all glowing
+with the struggle, came up and submitted. Tom kissed the red lips and
+said:
+
+“Now it’s all done, Becky. And always after this, you know, you ain’t
+ever to love anybody but me, and you ain’t ever to marry anybody but me,
+ever never and forever. Will you?”
+
+“No, I’ll never love anybody but you, Tom, and I’ll never marry anybody
+but you--and you ain’t to ever marry anybody but me, either.”
+
+“Certainly. Of course. That’s _part_ of it. And always coming to school
+or when we’re going home, you’re to walk with me, when there ain’t
+anybody looking--and you choose me and I choose you at parties, because
+that’s the way you do when you’re engaged.”
+
+“It’s so nice. I never heard of it before.”
+
+“Oh, it’s ever so gay! Why, me and Amy Lawrence--”
+
+The big eyes told Tom his blunder and he stopped, confused.
+
+“Oh, Tom! Then I ain’t the first you’ve ever been engaged to!”
+
+The child began to cry. Tom said:
+
+“Oh, don’t cry, Becky, I don’t care for her any more.”
+
+“Yes, you do, Tom--you know you do.”
+
+Tom tried to put his arm about her neck, but she pushed him away and
+turned her face to the wall, and went on crying. Tom tried again, with
+soothing words in his mouth, and was repulsed again. Then his pride was
+up, and he strode away and went outside. He stood about, restless and
+uneasy, for a while, glancing at the door, every now and then, hoping
+she would repent and come to find him. But she did not. Then he began
+to feel badly and fear that he was in the wrong. It was a hard struggle
+with him to make new advances, now, but he nerved himself to it and
+entered. She was still standing back there in the corner, sobbing, with
+her face to the wall. Tom’s heart smote him. He went to her and stood a
+moment, not knowing exactly how to proceed. Then he said hesitatingly:
+
+“Becky, I--I don’t care for anybody but you.”
+
+No reply--but sobs.
+
+“Becky”--pleadingly. “Becky, won’t you say something?”
+
+More sobs.
+
+Tom got out his chiefest jewel, a brass knob from the top of an andiron,
+and passed it around her so that she could see it, and said:
+
+“Please, Becky, won’t you take it?”
+
+She struck it to the floor. Then Tom marched out of the house and over
+the hills and far away, to return to school no more that day. Presently
+Becky began to suspect. She ran to the door; he was not in sight; she
+flew around to the play-yard; he was not there. Then she called:
+
+“Tom! Come back, Tom!”
+
+She listened intently, but there was no answer. She had no companions
+but silence and loneliness. So she sat down to cry again and upbraid
+herself; and by this time the scholars began to gather again, and she
+had to hide her griefs and still her broken heart and take up the cross
+of a long, dreary, aching afternoon, with none among the strangers about
+her to exchange sorrows with.
+
+
+
+
+CHAPTER VIII
+
+TOM dodged hither and thither through lanes until he was well out of the
+track of returning scholars, and then fell into a moody jog. He crossed
+a small “branch” two or three times, because of a prevailing juvenile
+superstition that to cross water baffled pursuit. Half an hour later
+he was disappearing behind the Douglas mansion on the summit of Cardiff
+Hill, and the school-house was hardly distinguishable away off in the
+valley behind him. He entered a dense wood, picked his pathless way to
+the centre of it, and sat down on a mossy spot under a spreading oak.
+There was not even a zephyr stirring; the dead noonday heat had even
+stilled the songs of the birds; nature lay in a trance that was broken
+by no sound but the occasional far-off hammering of a wood-pecker, and
+this seemed to render the pervading silence and sense of loneliness the
+more profound. The boy’s soul was steeped in melancholy; his feelings
+were in happy accord with his surroundings. He sat long with his elbows
+on his knees and his chin in his hands, meditating. It seemed to him
+that life was but a trouble, at best, and he more than half envied Jimmy
+Hodges, so lately released; it must be very peaceful, he thought, to lie
+and slumber and dream forever and ever, with the wind whispering through
+the trees and caressing the grass and the flowers over the grave, and
+nothing to bother and grieve about, ever any more. If he only had a
+clean Sunday-school record he could be willing to go, and be done with
+it all. Now as to this girl. What had he done? Nothing. He had meant
+the best in the world, and been treated like a dog--like a very dog. She
+would be sorry some day--maybe when it was too late. Ah, if he could only
+die _temporarily_!
+
+But the elastic heart of youth cannot be compressed into one constrained
+shape long at a time. Tom presently began to drift insensibly back into
+the concerns of this life again. What if he turned his back, now, and
+disappeared mysteriously? What if he went away--ever so far away, into
+unknown countries beyond the seas--and never came back any more! How
+would she feel then! The idea of being a clown recurred to him now, only
+to fill him with disgust. For frivolity and jokes and spotted tights
+were an offense, when they intruded themselves upon a spirit that was
+exalted into the vague august realm of the romantic. No, he would be
+a soldier, and return after long years, all war-worn and illustrious.
+No--better still, he would join the Indians, and hunt buffaloes and go on
+the warpath in the mountain ranges and the trackless great plains of the
+Far West, and away in the future come back a great chief, bristling with
+feathers, hideous with paint, and prance into Sunday-school, some drowsy
+summer morning, with a blood-curdling war-whoop, and sear the eyeballs
+of all his companions with unappeasable envy. But no, there was
+something gaudier even than this. He would be a pirate! That was it!
+_now_ his future lay plain before him, and glowing with unimaginable
+splendor. How his name would fill the world, and make people shudder!
+How gloriously he would go plowing the dancing seas, in his long, low,
+black-hulled racer, the Spirit of the Storm, with his grisly flag flying
+at the fore! And at the zenith of his fame, how he would suddenly appear
+at the old village and stalk into church, brown and weather-beaten, in
+his black velvet doublet and trunks, his great jack-boots, his crimson
+sash, his belt bristling with horse-pistols, his crime-rusted cutlass
+at his side, his slouch hat with waving plumes, his black flag unfurled,
+with the skull and crossbones on it, and hear with swelling ecstasy
+the whisperings, “It’s Tom Sawyer the Pirate!--the Black Avenger of the
+Spanish Main!”
+
+Yes, it was settled; his career was determined. He would run away from
+home and enter upon it. He would start the very next morning. Therefore
+he must now begin to get ready. He would collect his resources together.
+He went to a rotten log near at hand and began to dig under one end of
+it with his Barlow knife. He soon struck wood that sounded hollow. He
+put his hand there and uttered this incantation impressively:
+
+“What hasn’t come here, come! What’s here, stay here!”
+
+Then he scraped away the dirt, and exposed a pine shingle. He took it
+up and disclosed a shapely little treasure-house whose bottom and sides
+were of shingles. In it lay a marble. Tom’s astonishment was bound-less!
+He scratched his head with a perplexed air, and said:
+
+“Well, that beats anything!”
+
+Then he tossed the marble away pettishly, and stood cogitating. The
+truth was, that a superstition of his had failed, here, which he and
+all his comrades had always looked upon as infallible. If you buried
+a marble with certain necessary incantations, and left it alone a
+fortnight, and then opened the place with the incantation he had just
+used, you would find that all the marbles you had ever lost had gathered
+themselves together there, meantime, no matter how widely they had been
+separated. But now, this thing had actually and unquestionably failed.
+Tom’s whole structure of faith was shaken to its foundations. He had
+many a time heard of this thing succeeding but never of its failing
+before. It did not occur to him that he had tried it several times
+before, himself, but could never find the hiding-places afterward. He
+puzzled over the matter some time, and finally decided that some witch
+had interfered and broken the charm. He thought he would satisfy himself
+on that point; so he searched around till he found a small sandy spot
+with a little funnel-shaped depression in it. He laid himself down and
+put his mouth close to this depression and called--
+
+“Doodle-bug, doodle-bug, tell me what I want to know! Doodle-bug,
+doodle-bug, tell me what I want to know!”
+
+The sand began to work, and presently a small black bug appeared for a
+second and then darted under again in a fright.
+
+“He dasn’t tell! So it _was_ a witch that done it. I just knowed it.”
+
+He well knew the futility of trying to contend against witches, so he
+gave up discouraged. But it occurred to him that he might as well have
+the marble he had just thrown away, and therefore he went and made a
+patient search for it. But he could not find it. Now he went back to his
+treasure-house and carefully placed himself just as he had been standing
+when he tossed the marble away; then he took another marble from his
+pocket and tossed it in the same way, saying:
+
+“Brother, go find your brother!”
+
+He watched where it stopped, and went there and looked. But it must
+have fallen short or gone too far; so he tried twice more. The last
+repetition was successful. The two marbles lay within a foot of each
+other.
+
+Just here the blast of a toy tin trumpet came faintly down the green
+aisles of the forest. Tom flung off his jacket and trousers, turned
+a suspender into a belt, raked away some brush behind the rotten log,
+disclosing a rude bow and arrow, a lath sword and a tin trumpet, and
+in a moment had seized these things and bounded away, barelegged,
+with fluttering shirt. He presently halted under a great elm, blew an
+answering blast, and then began to tiptoe and look warily out, this way
+and that. He said cautiously--to an imaginary company:
+
+“Hold, my merry men! Keep hid till I blow.”
+
+Now appeared Joe Harper, as airily clad and elaborately armed as Tom.
+Tom called:
+
+“Hold! Who comes here into Sherwood Forest without my pass?”
+
+“Guy of Guisborne wants no man’s pass. Who art thou that--that--”
+
+“Dares to hold such language,” said Tom, prompting--for they talked “by
+the book,” from memory.
+
+“Who art thou that dares to hold such language?”
+
+“I, indeed! I am Robin Hood, as thy caitiff carcase soon shall know.”
+
+“Then art thou indeed that famous outlaw? Right gladly will I dispute
+with thee the passes of the merry wood. Have at thee!”
+
+They took their lath swords, dumped their other traps on the ground,
+struck a fencing attitude, foot to foot, and began a grave, careful
+combat, “two up and two down.” Presently Tom said:
+
+“Now, if you’ve got the hang, go it lively!”
+
+So they “went it lively,” panting and perspiring with the work. By and
+by Tom shouted:
+
+“Fall! fall! Why don’t you fall?”
+
+“I sha’n’t! Why don’t you fall yourself? You’re getting the worst of
+it.”
+
+“Why, that ain’t anything. I can’t fall; that ain’t the way it is in the
+book. The book says, ‘Then with one back-handed stroke he slew poor Guy
+of Guisborne.’ You’re to turn around and let me hit you in the back.”
+
+There was no getting around the authorities, so Joe turned, received the
+whack and fell.
+
+“Now,” said Joe, getting up, “you got to let me kill _you_. That’s
+fair.”
+
+“Why, I can’t do that, it ain’t in the book.”
+
+“Well, it’s blamed mean--that’s all.”
+
+“Well, say, Joe, you can be Friar Tuck or Much the miller’s son, and lam
+me with a quarter-staff; or I’ll be the Sheriff of Nottingham and you be
+Robin Hood a little while and kill me.”
+
+This was satisfactory, and so these adventures were carried out. Then
+Tom became Robin Hood again, and was allowed by the treacherous nun to
+bleed his strength away through his neglected wound. And at last Joe,
+representing a whole tribe of weeping outlaws, dragged him sadly forth,
+gave his bow into his feeble hands, and Tom said, “Where this arrow
+falls, there bury poor Robin Hood under the greenwood tree.” Then he
+shot the arrow and fell back and would have died, but he lit on a nettle
+and sprang up too gaily for a corpse.
+
+The boys dressed themselves, hid their accoutrements, and went off
+grieving that there were no outlaws any more, and wondering what modern
+civilization could claim to have done to compensate for their loss.
+They said they would rather be outlaws a year in Sherwood Forest than
+President of the United States forever.
+
+
+
+
+CHAPTER IX
+
+AT half-past nine, that night, Tom and Sid were sent to bed, as usual.
+They said their prayers, and Sid was soon asleep. Tom lay awake and
+waited, in restless impatience. When it seemed to him that it must be
+nearly daylight, he heard the clock strike ten! This was despair. He
+would have tossed and fidgeted, as his nerves demanded, but he was
+afraid he might wake Sid. So he lay still, and stared up into the dark.
+Everything was dismally still. By and by, out of the stillness, little,
+scarcely perceptible noises began to emphasize themselves. The ticking
+of the clock began to bring itself into notice. Old beams began to crack
+mysteriously. The stairs creaked faintly. Evidently spirits were abroad.
+A measured, muffled snore issued from Aunt Polly’s chamber. And now the
+tiresome chirping of a cricket that no human ingenuity could locate,
+began. Next the ghastly ticking of a death-watch in the wall at the
+bed’s head made Tom shudder--it meant that somebody’s days were numbered.
+Then the howl of a far-off dog rose on the night air, and was answered
+by a fainter howl from a remoter distance. Tom was in an agony. At last
+he was satisfied that time had ceased and eternity begun; he began to
+doze, in spite of himself; the clock chimed eleven, but he did not hear
+it. And then there came, mingling with his half-formed dreams, a most
+melancholy caterwauling. The raising of a neighboring window disturbed
+him. A cry of “Scat! you devil!” and the crash of an empty bottle
+against the back of his aunt’s woodshed brought him wide awake, and a
+single minute later he was dressed and out of the window and creeping
+along the roof of the “ell” on all fours. He “meow’d” with caution once
+or twice, as he went; then jumped to the roof of the woodshed and thence
+to the ground. Huckleberry Finn was there, with his dead cat. The boys
+moved off and disappeared in the gloom. At the end of half an hour they
+were wading through the tall grass of the graveyard.
+
+It was a graveyard of the old-fashioned Western kind. It was on a hill,
+about a mile and a half from the village. It had a crazy board fence
+around it, which leaned inward in places, and outward the rest of the
+time, but stood upright nowhere. Grass and weeds grew rank over the
+whole cemetery. All the old graves were sunken in, there was not a
+tombstone on the place; round-topped, worm-eaten boards staggered over
+the graves, leaning for support and finding none. “Sacred to the memory
+of” So-and-So had been painted on them once, but it could no longer have
+been read, on the most of them, now, even if there had been light.
+
+A faint wind moaned through the trees, and Tom feared it might be the
+spirits of the dead, complaining at being disturbed. The boys talked
+little, and only under their breath, for the time and the place and the
+pervading solemnity and silence oppressed their spirits. They found the
+sharp new heap they were seeking, and ensconced themselves within the
+protection of three great elms that grew in a bunch within a few feet of
+the grave.
+
+Then they waited in silence for what seemed a long time. The hooting of
+a distant owl was all the sound that troubled the dead stillness. Tom’s
+reflections grew oppressive. He must force some talk. So he said in a
+whisper:
+
+“Hucky, do you believe the dead people like it for us to be here?”
+
+Huckleberry whispered:
+
+“I wisht I knowed. It’s awful solemn like, _ain’t_ it?”
+
+“I bet it is.”
+
+There was a considerable pause, while the boys canvassed this matter
+inwardly. Then Tom whispered:
+
+“Say, Hucky--do you reckon Hoss Williams hears us talking?”
+
+“O’ course he does. Least his sperrit does.”
+
+Tom, after a pause:
+
+“I wish I’d said Mister Williams. But I never meant any harm. Everybody
+calls him Hoss.”
+
+“A body can’t be too partic’lar how they talk ‘bout these-yer dead
+people, Tom.”
+
+This was a damper, and conversation died again.
+
+Presently Tom seized his comrade’s arm and said:
+
+“Sh!”
+
+“What is it, Tom?” And the two clung together with beating hearts.
+
+“Sh! There ‘tis again! Didn’t you hear it?”
+
+“I--”
+
+“There! Now you hear it.”
+
+“Lord, Tom, they’re coming! They’re coming, sure. What’ll we do?”
+
+“I dono. Think they’ll see us?”
+
+“Oh, Tom, they can see in the dark, same as cats. I wisht I hadn’t
+come.”
+
+“Oh, don’t be afeard. I don’t believe they’ll bother us. We ain’t doing
+any harm. If we keep perfectly still, maybe they won’t notice us at
+all.”
+
+“I’ll try to, Tom, but, Lord, I’m all of a shiver.”
+
+“Listen!”
+
+The boys bent their heads together and scarcely breathed. A muffled
+sound of voices floated up from the far end of the graveyard.
+
+“Look! See there!” whispered Tom. “What is it?”
+
+“It’s devil-fire. Oh, Tom, this is awful.”
+
+Some vague figures approached through the gloom, swinging an
+old-fashioned tin lantern that freckled the ground with innumerable
+little spangles of light. Presently Huckleberry whispered with a
+shudder:
+
+“It’s the devils sure enough. Three of ‘em! Lordy, Tom, we’re goners!
+Can you pray?”
+
+“I’ll try, but don’t you be afeard. They ain’t going to hurt us. ‘Now I
+lay me down to sleep, I--’”
+
+“Sh!”
+
+“What is it, Huck?”
+
+“They’re _humans_! One of ‘em is, anyway. One of ‘em’s old Muff Potter’s
+voice.”
+
+“No--‘tain’t so, is it?”
+
+“I bet I know it. Don’t you stir nor budge. He ain’t sharp enough to
+notice us. Drunk, the same as usual, likely--blamed old rip!”
+
+“All right, I’ll keep still. Now they’re stuck. Can’t find it. Here they
+come again. Now they’re hot. Cold again. Hot again. Red hot! They’re
+p’inted right, this time. Say, Huck, I know another o’ them voices; it’s
+Injun Joe.”
+
+“That’s so--that murderin’ half-breed! I’d druther they was devils a dern
+sight. What kin they be up to?”
+
+The whisper died wholly out, now, for the three men had reached the
+grave and stood within a few feet of the boys’ hiding-place.
+
+“Here it is,” said the third voice; and the owner of it held the lantern
+up and revealed the face of young Doctor Robinson.
+
+Potter and Injun Joe were carrying a handbarrow with a rope and a couple
+of shovels on it. They cast down their load and began to open the grave.
+The doctor put the lantern at the head of the grave and came and sat
+down with his back against one of the elm trees. He was so close the
+boys could have touched him.
+
+“Hurry, men!” he said, in a low voice; “the moon might come out at any
+moment.”
+
+They growled a response and went on digging. For some time there was no
+noise but the grating sound of the spades discharging their freight of
+mould and gravel. It was very monotonous. Finally a spade struck upon
+the coffin with a dull woody accent, and within another minute or two
+the men had hoisted it out on the ground. They pried off the lid with
+their shovels, got out the body and dumped it rudely on the ground. The
+moon drifted from behind the clouds and exposed the pallid face.
+The barrow was got ready and the corpse placed on it, covered with a
+blanket, and bound to its place with the rope. Potter took out a large
+spring-knife and cut off the dangling end of the rope and then said:
+
+“Now the cussed thing’s ready, Sawbones, and you’ll just out with
+another five, or here she stays.”
+
+“That’s the talk!” said Injun Joe.
+
+“Look here, what does this mean?” said the doctor. “You required your
+pay in advance, and I’ve paid you.”
+
+“Yes, and you done more than that,” said Injun Joe, approaching the
+doctor, who was now standing. “Five years ago you drove me away from
+your father’s kitchen one night, when I come to ask for something to
+eat, and you said I warn’t there for any good; and when I swore I’d get
+even with you if it took a hundred years, your father had me jailed for
+a vagrant. Did you think I’d forget? The Injun blood ain’t in me for
+nothing. And now I’ve _got_ you, and you got to _settle_, you know!”
+
+He was threatening the doctor, with his fist in his face, by this time.
+The doctor struck out suddenly and stretched the ruffian on the ground.
+Potter dropped his knife, and exclaimed:
+
+“Here, now, don’t you hit my pard!” and the next moment he had grappled
+with the doctor and the two were struggling with might and main,
+trampling the grass and tearing the ground with their heels. Injun Joe
+sprang to his feet, his eyes flaming with passion, snatched up Potter’s
+knife, and went creeping, catlike and stooping, round and round about
+the combatants, seeking an opportunity. All at once the doctor flung
+himself free, seized the heavy headboard of Williams’ grave and felled
+Potter to the earth with it--and in the same instant the half-breed saw
+his chance and drove the knife to the hilt in the young man’s breast. He
+reeled and fell partly upon Potter, flooding him with his blood, and in
+the same moment the clouds blotted out the dreadful spectacle and the
+two frightened boys went speeding away in the dark.
+
+Presently, when the moon emerged again, Injun Joe was standing over the
+two forms, contemplating them. The doctor murmured inarticulately, gave
+a long gasp or two and was still. The half-breed muttered:
+
+“_That_ score is settled--damn you.”
+
+Then he robbed the body. After which he put the fatal knife in Potter’s
+open right hand, and sat down on the dismantled coffin. Three--four--five
+minutes passed, and then Potter began to stir and moan. His hand closed
+upon the knife; he raised it, glanced at it, and let it fall, with a
+shudder. Then he sat up, pushing the body from him, and gazed at it, and
+then around him, confusedly. His eyes met Joe’s.
+
+“Lord, how is this, Joe?” he said.
+
+“It’s a dirty business,” said Joe, without moving.
+
+“What did you do it for?”
+
+“I! I never done it!”
+
+“Look here! That kind of talk won’t wash.”
+
+Potter trembled and grew white.
+
+“I thought I’d got sober. I’d no business to drink to-night. But it’s
+in my head yet--worse’n when we started here. I’m all in a muddle;
+can’t recollect anything of it, hardly. Tell me, Joe--_honest_, now,
+old feller--did I do it? Joe, I never meant to--‘pon my soul and honor, I
+never meant to, Joe. Tell me how it was, Joe. Oh, it’s awful--and him so
+young and promising.”
+
+“Why, you two was scuffling, and he fetched you one with the headboard
+and you fell flat; and then up you come, all reeling and staggering
+like, and snatched the knife and jammed it into him, just as he fetched
+you another awful clip--and here you’ve laid, as dead as a wedge til
+now.”
+
+“Oh, I didn’t know what I was a-doing. I wish I may die this minute if I
+did. It was all on account of the whiskey and the excitement, I reckon.
+I never used a weepon in my life before, Joe. I’ve fought, but never
+with weepons. They’ll all say that. Joe, don’t tell! Say you won’t tell,
+Joe--that’s a good feller. I always liked you, Joe, and stood up for you,
+too. Don’t you remember? You _won’t_ tell, _will_ you, Joe?” And the
+poor creature dropped on his knees before the stolid murderer, and
+clasped his appealing hands.
+
+“No, you’ve always been fair and square with me, Muff Potter, and I
+won’t go back on you. There, now, that’s as fair as a man can say.”
+
+“Oh, Joe, you’re an angel. I’ll bless you for this the longest day I
+live.” And Potter began to cry.
+
+“Come, now, that’s enough of that. This ain’t any time for blubbering.
+You be off yonder way and I’ll go this. Move, now, and don’t leave any
+tracks behind you.”
+
+Potter started on a trot that quickly increased to a run. The half-breed
+stood looking after him. He muttered:
+
+“If he’s as much stunned with the lick and fuddled with the rum as he
+had the look of being, he won’t think of the knife till he’s gone so
+far he’ll be afraid to come back after it to such a place by
+himself--chicken-heart!”
+
+Two or three minutes later the murdered man, the blanketed corpse, the
+lidless coffin, and the open grave were under no inspection but the
+moon’s. The stillness was complete again, too.
+
+
+
+
+CHAPTER X
+
+THE two boys flew on and on, toward the village, speechless with
+horror. They glanced backward over their shoulders from time to time,
+apprehensively, as if they feared they might be followed. Every stump
+that started up in their path seemed a man and an enemy, and made them
+catch their breath; and as they sped by some outlying cottages that lay
+near the village, the barking of the aroused watch-dogs seemed to give
+wings to their feet.
+
+“If we can only get to the old tannery before we break down!” whispered
+Tom, in short catches between breaths. “I can’t stand it much longer.”
+
+Huckleberry’s hard pantings were his only reply, and the boys fixed
+their eyes on the goal of their hopes and bent to their work to win it.
+They gained steadily on it, and at last, breast to breast, they burst
+through the open door and fell grateful and exhausted in the sheltering
+shadows beyond. By and by their pulses slowed down, and Tom whispered:
+
+“Huckleberry, what do you reckon’ll come of this?”
+
+“If Doctor Robinson dies, I reckon hanging’ll come of it.”
+
+“Do you though?”
+
+“Why, I _know_ it, Tom.”
+
+Tom thought a while, then he said:
+
+“Who’ll tell? We?”
+
+“What are you talking about? S’pose something happened and Injun Joe
+_didn’t_ hang? Why, he’d kill us some time or other, just as dead sure
+as we’re a laying here.”
+
+“That’s just what I was thinking to myself, Huck.”
+
+“If anybody tells, let Muff Potter do it, if he’s fool enough. He’s
+generally drunk enough.”
+
+Tom said nothing--went on thinking. Presently he whispered:
+
+“Huck, Muff Potter don’t know it. How can he tell?”
+
+“What’s the reason he don’t know it?”
+
+“Because he’d just got that whack when Injun Joe done it. D’you reckon
+he could see anything? D’you reckon he knowed anything?”
+
+“By hokey, that’s so, Tom!”
+
+“And besides, look-a-here--maybe that whack done for _him_!”
+
+“No, ‘taint likely, Tom. He had liquor in him; I could see that; and
+besides, he always has. Well, when pap’s full, you might take and belt
+him over the head with a church and you couldn’t phase him. He says so,
+his own self. So it’s the same with Muff Potter, of course. But if a man
+was dead sober, I reckon maybe that whack might fetch him; I dono.”
+
+After another reflective silence, Tom said:
+
+“Hucky, you sure you can keep mum?”
+
+“Tom, we _got_ to keep mum. You know that. That Injun devil wouldn’t
+make any more of drownding us than a couple of cats, if we was to squeak
+‘bout this and they didn’t hang him. Now, look-a-here, Tom, less take
+and swear to one another--that’s what we got to do--swear to keep mum.”
+
+“I’m agreed. It’s the best thing. Would you just hold hands and swear
+that we--”
+
+“Oh no, that wouldn’t do for this. That’s good enough for little
+rubbishy common things--specially with gals, cuz _they_ go back on you
+anyway, and blab if they get in a huff--but there orter be writing ‘bout
+a big thing like this. And blood.”
+
+Tom’s whole being applauded this idea. It was deep, and dark, and awful;
+the hour, the circumstances, the surroundings, were in keeping with it.
+He picked up a clean pine shingle that lay in the moon-light, took a
+little fragment of “red keel” out of his pocket, got the moon on
+his work, and painfully scrawled these lines, emphasizing each slow
+down-stroke by clamping his tongue between his teeth, and letting up the
+pressure on the up-strokes. [See next page.]
+
+“Huck Finn and Tom Sawyer swears they will keep mum about This and They
+wish They may Drop down dead in Their Tracks if They ever Tell and Rot.”
+
+Huckleberry was filled with admiration of Tom’s facility in writing, and
+the sublimity of his language. He at once took a pin from his lapel and
+was going to prick his flesh, but Tom said:
+
+“Hold on! Don’t do that. A pin’s brass. It might have verdigrease on
+it.”
+
+“What’s verdigrease?”
+
+“It’s p’ison. That’s what it is. You just swaller some of it once--you’ll
+see.”
+
+So Tom unwound the thread from one of his needles, and each boy pricked
+the ball of his thumb and squeezed out a drop of blood. In time, after
+many squeezes, Tom managed to sign his initials, using the ball of his
+little finger for a pen. Then he showed Huckleberry how to make an H and
+an F, and the oath was complete. They buried the shingle close to the
+wall, with some dismal ceremonies and incantations, and the fetters
+that bound their tongues were considered to be locked and the key thrown
+away.
+
+A figure crept stealthily through a break in the other end of the ruined
+building, now, but they did not notice it.
+
+“Tom,” whispered Huckleberry, “does this keep us from _ever_
+telling--_always_?”
+
+“Of course it does. It don’t make any difference _what_ happens, we got
+to keep mum. We’d drop down dead--don’t _you_ know that?”
+
+“Yes, I reckon that’s so.”
+
+They continued to whisper for some little time. Presently a dog set up
+a long, lugubrious howl just outside--within ten feet of them. The boys
+clasped each other suddenly, in an agony of fright.
+
+“Which of us does he mean?” gasped Huckleberry.
+
+“I dono--peep through the crack. Quick!”
+
+“No, _you_, Tom!”
+
+“I can’t--I can’t _do_ it, Huck!”
+
+“Please, Tom. There ‘tis again!”
+
+“Oh, lordy, I’m thankful!” whispered Tom. “I know his voice. It’s Bull
+Harbison.” *
+
+[* If Mr. Harbison owned a slave named Bull, Tom would have spoken of
+him as “Harbison’s Bull,” but a son or a dog of that name was “Bull
+Harbison.”]
+
+“Oh, that’s good--I tell you, Tom, I was most scared to death; I’d a bet
+anything it was a _stray_ dog.”
+
+The dog howled again. The boys’ hearts sank once more.
+
+“Oh, my! that ain’t no Bull Harbison!” whispered Huckleberry. “_Do_,
+Tom!”
+
+Tom, quaking with fear, yielded, and put his eye to the crack. His
+whisper was hardly audible when he said:
+
+“Oh, Huck, _its a stray dog_!”
+
+“Quick, Tom, quick! Who does he mean?”
+
+“Huck, he must mean us both--we’re right together.”
+
+“Oh, Tom, I reckon we’re goners. I reckon there ain’t no mistake ‘bout
+where _I’ll_ go to. I been so wicked.”
+
+“Dad fetch it! This comes of playing hookey and doing everything a
+feller’s told _not_ to do. I might a been good, like Sid, if I’d a
+tried--but no, I wouldn’t, of course. But if ever I get off this time,
+I lay I’ll just _waller_ in Sunday-schools!” And Tom began to snuffle a
+little.
+
+“_You_ bad!” and Huckleberry began to snuffle too. “Consound it, Tom
+Sawyer, you’re just old pie, ‘long-side o’ what I am. Oh, _lordy_,
+lordy, lordy, I wisht I only had half your chance.”
+
+Tom choked off and whispered:
+
+“Look, Hucky, look! He’s got his _back_ to us!”
+
+Hucky looked, with joy in his heart.
+
+“Well, he has, by jingoes! Did he before?”
+
+“Yes, he did. But I, like a fool, never thought. Oh, this is bully, you
+know. _Now_ who can he mean?”
+
+The howling stopped. Tom pricked up his ears.
+
+“Sh! What’s that?” he whispered.
+
+“Sounds like--like hogs grunting. No--it’s somebody snoring, Tom.”
+
+“That _is_ it! Where ‘bouts is it, Huck?”
+
+“I bleeve it’s down at ‘tother end. Sounds so, anyway. Pap used to sleep
+there, sometimes, ‘long with the hogs, but laws bless you, he just lifts
+things when _he_ snores. Besides, I reckon he ain’t ever coming back to
+this town any more.”
+
+The spirit of adventure rose in the boys’ souls once more.
+
+“Hucky, do you das’t to go if I lead?”
+
+“I don’t like to, much. Tom, s’pose it’s Injun Joe!”
+
+Tom quailed. But presently the temptation rose up strong again and the
+boys agreed to try, with the understanding that they would take to their
+heels if the snoring stopped. So they went tiptoeing stealthily down,
+the one behind the other. When they had got to within five steps of the
+snorer, Tom stepped on a stick, and it broke with a sharp snap. The man
+moaned, writhed a little, and his face came into the moonlight. It was
+Muff Potter. The boys’ hearts had stood still, and their hopes too,
+when the man moved, but their fears passed away now. They tip-toed out,
+through the broken weather-boarding, and stopped at a little distance
+to exchange a parting word. That long, lugubrious howl rose on the night
+air again! They turned and saw the strange dog standing within a few
+feet of where Potter was lying, and _facing_ Potter, with his nose
+pointing heavenward.
+
+“Oh, geeminy, it’s _him_!” exclaimed both boys, in a breath.
+
+“Say, Tom--they say a stray dog come howling around Johnny Miller’s
+house, ‘bout midnight, as much as two weeks ago; and a whippoorwill come
+in and lit on the banisters and sung, the very same evening; and there
+ain’t anybody dead there yet.”
+
+“Well, I know that. And suppose there ain’t. Didn’t Gracie Miller fall
+in the kitchen fire and burn herself terrible the very next Saturday?”
+
+“Yes, but she ain’t _dead_. And what’s more, she’s getting better, too.”
+
+“All right, you wait and see. She’s a goner, just as dead sure as Muff
+Potter’s a goner. That’s what the niggers say, and they know all about
+these kind of things, Huck.”
+
+Then they separated, cogitating. When Tom crept in at his bedroom window
+the night was almost spent. He undressed with excessive caution, and
+fell asleep congratulating himself that nobody knew of his escapade. He
+was not aware that the gently-snoring Sid was awake, and had been so for
+an hour.
+
+When Tom awoke, Sid was dressed and gone. There was a late look in the
+light, a late sense in the atmosphere. He was startled. Why had he not
+been called--persecuted till he was up, as usual? The thought filled
+him with bodings. Within five minutes he was dressed and down-stairs,
+feeling sore and drowsy. The family were still at table, but they had
+finished breakfast. There was no voice of rebuke; but there were averted
+eyes; there was a silence and an air of solemnity that struck a chill
+to the culprit’s heart. He sat down and tried to seem gay, but it
+was up-hill work; it roused no smile, no response, and he lapsed into
+silence and let his heart sink down to the depths.
+
+After breakfast his aunt took him aside, and Tom almost brightened in
+the hope that he was going to be flogged; but it was not so. His aunt
+wept over him and asked him how he could go and break her old heart so;
+and finally told him to go on, and ruin himself and bring her gray hairs
+with sorrow to the grave, for it was no use for her to try any more.
+This was worse than a thousand whippings, and Tom’s heart was sorer now
+than his body. He cried, he pleaded for forgiveness, promised to reform
+over and over again, and then received his dismissal, feeling that
+he had won but an imperfect forgiveness and established but a feeble
+confidence.
+
+He left the presence too miserable to even feel revengeful toward
+Sid; and so the latter’s prompt retreat through the back gate was
+unnecessary. He moped to school gloomy and sad, and took his flogging,
+along with Joe Harper, for playing hookey the day before, with the
+air of one whose heart was busy with heavier woes and wholly dead to
+trifles. Then he betook himself to his seat, rested his elbows on his
+desk and his jaws in his hands, and stared at the wall with the stony
+stare of suffering that has reached the limit and can no further go.
+His elbow was pressing against some hard substance. After a long time
+he slowly and sadly changed his position, and took up this object with
+a sigh. It was in a paper. He unrolled it. A long, lingering, colossal
+sigh followed, and his heart broke. It was his brass andiron knob!
+
+This final feather broke the camel’s back.
+
+
+
+
+CHAPTER XI
+
+CLOSE upon the hour of noon the whole village was suddenly electrified
+with the ghastly news. No need of the as yet un-dreamed-of telegraph;
+the tale flew from man to man, from group to group, from house to house,
+with little less than telegraphic speed. Of course the schoolmaster gave
+holi-day for that afternoon; the town would have thought strangely of
+him if he had not.
+
+A gory knife had been found close to the murdered man, and it had been
+recognized by somebody as belonging to Muff Potter--so the story ran. And
+it was said that a belated citizen had come upon Potter washing himself
+in the “branch” about one or two o’clock in the morning, and that Potter
+had at once sneaked off--suspicious circumstances, especially the washing
+which was not a habit with Potter. It was also said that the town had
+been ransacked for this “murderer” (the public are not slow in the
+matter of sifting evidence and arriving at a verdict), but that he
+could not be found. Horsemen had departed down all the roads in every
+direction, and the Sheriff “was confident” that he would be captured
+before night.
+
+All the town was drifting toward the graveyard. Tom’s heartbreak
+vanished and he joined the procession, not because he would not
+a thousand times rather go anywhere else, but because an awful,
+unaccountable fascination drew him on. Arrived at the dreadful place, he
+wormed his small body through the crowd and saw the dismal spectacle.
+It seemed to him an age since he was there before. Somebody pinched
+his arm. He turned, and his eyes met Huckleberry’s. Then both looked
+elsewhere at once, and wondered if anybody had noticed anything in their
+mutual glance. But everybody was talking, and intent upon the grisly
+spectacle before them.
+
+“Poor fellow!” “Poor young fellow!” “This ought to be a lesson to grave
+robbers!” “Muff Potter’ll hang for this if they catch him!” This was the
+drift of remark; and the minister said, “It was a judgment; His hand is
+here.”
+
+Now Tom shivered from head to heel; for his eye fell upon the stolid
+face of Injun Joe. At this moment the crowd began to sway and struggle,
+and voices shouted, “It’s him! it’s him! he’s coming himself!”
+
+“Who? Who?” from twenty voices.
+
+“Muff Potter!”
+
+“Hallo, he’s stopped!--Look out, he’s turning! Don’t let him get away!”
+
+People in the branches of the trees over Tom’s head said he wasn’t
+trying to get away--he only looked doubtful and perplexed.
+
+“Infernal impudence!” said a bystander; “wanted to come and take a quiet
+look at his work, I reckon--didn’t expect any company.”
+
+The crowd fell apart, now, and the Sheriff came through, ostentatiously
+leading Potter by the arm. The poor fellow’s face was haggard, and
+his eyes showed the fear that was upon him. When he stood before the
+murdered man, he shook as with a palsy, and he put his face in his hands
+and burst into tears.
+
+“I didn’t do it, friends,” he sobbed; “‘pon my word and honor I never
+done it.”
+
+“Who’s accused you?” shouted a voice.
+
+This shot seemed to carry home. Potter lifted his face and looked around
+him with a pathetic hopelessness in his eyes. He saw Injun Joe, and
+exclaimed:
+
+“Oh, Injun Joe, you promised me you’d never--”
+
+“Is that your knife?” and it was thrust before him by the Sheriff.
+
+Potter would have fallen if they had not caught him and eased him to the
+ground. Then he said:
+
+“Something told me ‘t if I didn’t come back and get--” He shuddered; then
+waved his nerveless hand with a vanquished gesture and said, “Tell ‘em,
+Joe, tell ‘em--it ain’t any use any more.”
+
+Then Huckleberry and Tom stood dumb and staring, and heard the
+stony-hearted liar reel off his serene statement, they expecting every
+moment that the clear sky would deliver God’s lightnings upon his head,
+and wondering to see how long the stroke was delayed. And when he had
+finished and still stood alive and whole, their wavering impulse to
+break their oath and save the poor betrayed prisoner’s life faded and
+vanished away, for plainly this miscreant had sold himself to Satan and
+it would be fatal to meddle with the property of such a power as that.
+
+“Why didn’t you leave? What did you want to come here for?” somebody
+said.
+
+“I couldn’t help it--I couldn’t help it,” Potter moaned. “I wanted to
+run away, but I couldn’t seem to come anywhere but here.” And he fell to
+sobbing again.
+
+Injun Joe repeated his statement, just as calmly, a few minutes
+afterward on the inquest, under oath; and the boys, seeing that the
+lightnings were still withheld, were confirmed in their belief that
+Joe had sold himself to the devil. He was now become, to them, the most
+balefully interesting object they had ever looked upon, and they could
+not take their fascinated eyes from his face.
+
+They inwardly resolved to watch him nights, when opportunity should
+offer, in the hope of getting a glimpse of his dread master.
+
+Injun Joe helped to raise the body of the murdered man and put it in
+a wagon for removal; and it was whispered through the shuddering
+crowd that the wound bled a little! The boys thought that this happy
+circumstance would turn suspicion in the right direction; but they were
+disappointed, for more than one villager remarked:
+
+“It was within three feet of Muff Potter when it done it.”
+
+Tom’s fearful secret and gnawing conscience disturbed his sleep for as
+much as a week after this; and at breakfast one morning Sid said:
+
+“Tom, you pitch around and talk in your sleep so much that you keep me
+awake half the time.”
+
+Tom blanched and dropped his eyes.
+
+“It’s a bad sign,” said Aunt Polly, gravely. “What you got on your mind,
+Tom?”
+
+“Nothing. Nothing ‘t I know of.” But the boy’s hand shook so that he
+spilled his coffee.
+
+“And you do talk such stuff,” Sid said. “Last night you said, ‘It’s
+blood, it’s blood, that’s what it is!’ You said that over and over.
+And you said, ‘Don’t torment me so--I’ll tell!’ Tell _what_? What is it
+you’ll tell?”
+
+Everything was swimming before Tom. There is no telling what might have
+happened, now, but luckily the concern passed out of Aunt Polly’s face
+and she came to Tom’s relief without knowing it. She said:
+
+“Sho! It’s that dreadful murder. I dream about it most every night
+myself. Sometimes I dream it’s me that done it.”
+
+Mary said she had been affected much the same way. Sid seemed satisfied.
+Tom got out of the presence as quick as he plausibly could, and after
+that he complained of toothache for a week, and tied up his jaws every
+night. He never knew that Sid lay nightly watching, and frequently
+slipped the bandage free and then leaned on his elbow listening a good
+while at a time, and afterward slipped the bandage back to its place
+again. Tom’s distress of mind wore off gradually and the toothache grew
+irksome and was discarded. If Sid really managed to make anything out of
+Tom’s disjointed mutterings, he kept it to himself.
+
+It seemed to Tom that his schoolmates never would get done holding
+inquests on dead cats, and thus keeping his trouble present to his mind.
+Sid noticed that Tom never was coroner at one of these inquiries,
+though it had been his habit to take the lead in all new enterprises;
+he noticed, too, that Tom never acted as a witness--and that was strange;
+and Sid did not overlook the fact that Tom even showed a marked aversion
+to these inquests, and always avoided them when he could. Sid marvelled,
+but said nothing. However, even inquests went out of vogue at last, and
+ceased to torture Tom’s conscience.
+
+Every day or two, during this time of sorrow, Tom watched his
+opportunity and went to the little grated jail-window and smuggled such
+small comforts through to the “murderer” as he could get hold of. The
+jail was a trifling little brick den that stood in a marsh at the edge
+of the village, and no guards were afforded for it; indeed, it
+was seldom occupied. These offerings greatly helped to ease Tom’s
+conscience.
+
+The villagers had a strong desire to tar-and-feather Injun Joe and ride
+him on a rail, for body-snatching, but so formidable was his character
+that nobody could be found who was willing to take the lead in the
+matter, so it was dropped. He had been careful to begin both of his
+inquest-statements with the fight, without confessing the grave-robbery
+that preceded it; therefore it was deemed wisest not to try the case in
+the courts at present.
+
+
+
+
+CHAPTER XII
+
+ONE of the reasons why Tom’s mind had drifted away from its secret
+troubles was, that it had found a new and weighty matter to interest
+itself about. Becky Thatcher had stopped coming to school. Tom had
+struggled with his pride a few days, and tried to “whistle her down the
+wind,” but failed. He began to find himself hanging around her father’s
+house, nights, and feeling very miserable. She was ill. What if she
+should die! There was distraction in the thought. He no longer took an
+interest in war, nor even in piracy. The charm of life was gone; there
+was nothing but dreariness left. He put his hoop away, and his bat;
+there was no joy in them any more. His aunt was concerned. She began to
+try all manner of remedies on him. She was one of those people who
+are infatuated with patent medicines and all new-fangled methods of
+producing health or mending it. She was an inveterate experimenter in
+these things. When something fresh in this line came out she was in a
+fever, right away, to try it; not on herself, for she was never ailing,
+but on anybody else that came handy. She was a subscriber for all the
+“Health” periodicals and phrenological frauds; and the solemn ignorance
+they were inflated with was breath to her nostrils. All the “rot” they
+contained about ventilation, and how to go to bed, and how to get up,
+and what to eat, and what to drink, and how much exercise to take, and
+what frame of mind to keep one’s self in, and what sort of clothing
+to wear, was all gospel to her, and she never observed that her
+health-journals of the current month customarily upset everything they
+had recommended the month before. She was as simple-hearted and honest
+as the day was long, and so she was an easy victim. She gathered
+together her quack periodicals and her quack medicines, and thus armed
+with death, went about on her pale horse, metaphorically speaking, with
+“hell following after.” But she never suspected that she was not an
+angel of healing and the balm of Gilead in disguise, to the suffering
+neighbors.
+
+The water treatment was new, now, and Tom’s low condition was a windfall
+to her. She had him out at daylight every morning, stood him up in the
+wood-shed and drowned him with a deluge of cold water; then she scrubbed
+him down with a towel like a file, and so brought him to; then she
+rolled him up in a wet sheet and put him away under blankets till she
+sweated his soul clean and “the yellow stains of it came through his
+pores”--as Tom said.
+
+Yet notwithstanding all this, the boy grew more and more melancholy and
+pale and dejected. She added hot baths, sitz baths, shower baths, and
+plunges. The boy remained as dismal as a hearse. She began to assist the
+water with a slim oatmeal diet and blister-plasters. She calculated his
+capacity as she would a jug’s, and filled him up every day with quack
+cure-alls.
+
+Tom had become indifferent to persecution by this time. This phase
+filled the old lady’s heart with consternation. This indifference must
+be broken up at any cost. Now she heard of Pain-killer for the first
+time. She ordered a lot at once. She tasted it and was filled with
+gratitude. It was simply fire in a liquid form. She dropped the water
+treatment and everything else, and pinned her faith to Pain-killer.
+She gave Tom a teaspoonful and watched with the deepest anxiety for the
+result. Her troubles were instantly at rest, her soul at peace again;
+for the “indifference” was broken up. The boy could not have shown a
+wilder, heartier interest, if she had built a fire under him.
+
+Tom felt that it was time to wake up; this sort of life might be
+romantic enough, in his blighted condition, but it was getting to have
+too little sentiment and too much distracting variety about it. So he
+thought over various plans for relief, and finally hit upon that of
+professing to be fond of Pain-killer. He asked for it so often that he
+became a nuisance, and his aunt ended by telling him to help himself and
+quit bothering her. If it had been Sid, she would have had no misgivings
+to alloy her delight; but since it was Tom, she watched the bottle
+clandestinely. She found that the medicine did really diminish, but it
+did not occur to her that the boy was mending the health of a crack in
+the sitting-room floor with it.
+
+One day Tom was in the act of dosing the crack when his aunt’s yellow
+cat came along, purring, eyeing the teaspoon avariciously, and begging
+for a taste. Tom said:
+
+“Don’t ask for it unless you want it, Peter.”
+
+But Peter signified that he did want it.
+
+“You better make sure.”
+
+Peter was sure.
+
+“Now you’ve asked for it, and I’ll give it to you, because there ain’t
+anything mean about me; but if you find you don’t like it, you mustn’t
+blame anybody but your own self.”
+
+Peter was agreeable. So Tom pried his mouth open and poured down
+the Pain-killer. Peter sprang a couple of yards in the air, and then
+delivered a war-whoop and set off round and round the room, banging
+against furniture, upsetting flower-pots, and making general havoc. Next
+he rose on his hind feet and pranced around, in a frenzy of enjoyment,
+with his head over his shoulder and his voice proclaiming his
+unappeasable happiness. Then he went tearing around the house again
+spreading chaos and destruction in his path. Aunt Polly entered in time
+to see him throw a few double summersets, deliver a final mighty hurrah,
+and sail through the open window, carrying the rest of the flower-pots
+with him. The old lady stood petrified with astonishment, peering over
+her glasses; Tom lay on the floor expiring with laughter.
+
+“Tom, what on earth ails that cat?”
+
+“I don’t know, aunt,” gasped the boy.
+
+“Why, I never see anything like it. What did make him act so?”
+
+“Deed I don’t know, Aunt Polly; cats always act so when they’re having a
+good time.”
+
+“They do, do they?” There was something in the tone that made Tom
+apprehensive.
+
+“Yes’m. That is, I believe they do.”
+
+“You _do_?”
+
+“Yes’m.”
+
+The old lady was bending down, Tom watching, with interest emphasized
+by anxiety. Too late he divined her “drift.” The handle of the telltale
+tea-spoon was visible under the bed-valance. Aunt Polly took it, held it
+up. Tom winced, and dropped his eyes. Aunt Polly raised him by the usual
+handle--his ear--and cracked his head soundly with her thimble.
+
+“Now, sir, what did you want to treat that poor dumb beast so, for?”
+
+“I done it out of pity for him--because he hadn’t any aunt.”
+
+“Hadn’t any aunt!--you numskull. What has that got to do with it?”
+
+“Heaps. Because if he’d had one she’d a burnt him out herself! She’d a
+roasted his bowels out of him ‘thout any more feeling than if he was a
+human!”
+
+Aunt Polly felt a sudden pang of remorse. This was putting the thing in
+a new light; what was cruelty to a cat _might_ be cruelty to a boy, too.
+She began to soften; she felt sorry. Her eyes watered a little, and she
+put her hand on Tom’s head and said gently:
+
+“I was meaning for the best, Tom. And, Tom, it _did_ do you good.”
+
+Tom looked up in her face with just a perceptible twinkle peeping
+through his gravity.
+
+“I know you was meaning for the best, aunty, and so was I with Peter. It
+done _him_ good, too. I never see him get around so since--”
+
+“Oh, go ‘long with you, Tom, before you aggravate me again. And you try
+and see if you can’t be a good boy, for once, and you needn’t take any
+more medicine.”
+
+Tom reached school ahead of time. It was noticed that this strange thing
+had been occurring every day latterly. And now, as usual of late,
+he hung about the gate of the schoolyard instead of playing with his
+comrades. He was sick, he said, and he looked it. He tried to seem to
+be looking everywhere but whither he really was looking--down the road.
+Presently Jeff Thatcher hove in sight, and Tom’s face lighted; he gazed
+a moment, and then turned sorrowfully away. When Jeff arrived, Tom
+accosted him; and “led up” warily to opportunities for remark about
+Becky, but the giddy lad never could see the bait. Tom watched and
+watched, hoping whenever a frisking frock came in sight, and hating the
+owner of it as soon as he saw she was not the right one. At last frocks
+ceased to appear, and he dropped hopelessly into the dumps; he entered
+the empty schoolhouse and sat down to suffer. Then one more frock passed
+in at the gate, and Tom’s heart gave a great bound. The next instant he
+was out, and “going on” like an Indian; yelling, laughing, chasing boys,
+jumping over the fence at risk of life and limb, throwing handsprings,
+standing on his head--doing all the heroic things he could conceive of,
+and keeping a furtive eye out, all the while, to see if Becky Thatcher
+was noticing. But she seemed to be unconscious of it all; she never
+looked. Could it be possible that she was not aware that he was there?
+He carried his exploits to her immediate vicinity; came war-whooping
+around, snatched a boy’s cap, hurled it to the roof of the schoolhouse,
+broke through a group of boys, tumbling them in every direction, and
+fell sprawling, himself, under Becky’s nose, almost upsetting her--and
+she turned, with her nose in the air, and he heard her say: “Mf! some
+people think they’re mighty smart--always showing off!”
+
+Tom’s cheeks burned. He gathered himself up and sneaked off, crushed and
+crestfallen.
+
+
+
+
+CHAPTER XIII
+
+TOM’S mind was made up now. He was gloomy and desperate. He was a
+forsaken, friendless boy, he said; nobody loved him; when they found out
+what they had driven him to, perhaps they would be sorry; he had tried
+to do right and get along, but they would not let him; since nothing
+would do them but to be rid of him, let it be so; and let them blame
+_him_ for the consequences--why shouldn’t they? What right had the
+friendless to complain? Yes, they had forced him to it at last: he would
+lead a life of crime. There was no choice.
+
+By this time he was far down Meadow Lane, and the bell for school to
+“take up” tinkled faintly upon his ear. He sobbed, now, to think he
+should never, never hear that old familiar sound any more--it was very
+hard, but it was forced on him; since he was driven out into the cold
+world, he must submit--but he forgave them. Then the sobs came thick and
+fast.
+
+Just at this point he met his soul’s sworn comrade, Joe
+Harper--hard-eyed, and with evidently a great and dismal purpose in his
+heart. Plainly here were “two souls with but a single thought.” Tom,
+wiping his eyes with his sleeve, began to blubber out something about
+a resolution to escape from hard usage and lack of sympathy at home by
+roaming abroad into the great world never to return; and ended by hoping
+that Joe would not forget him.
+
+But it transpired that this was a request which Joe had just been going
+to make of Tom, and had come to hunt him up for that purpose. His mother
+had whipped him for drinking some cream which he had never tasted and
+knew nothing about; it was plain that she was tired of him and wished
+him to go; if she felt that way, there was nothing for him to do but
+succumb; he hoped she would be happy, and never regret having driven her
+poor boy out into the unfeeling world to suffer and die.
+
+As the two boys walked sorrowing along, they made a new compact to stand
+by each other and be brothers and never separate till death relieved
+them of their troubles. Then they began to lay their plans. Joe was for
+being a hermit, and living on crusts in a remote cave, and dying,
+some time, of cold and want and grief; but after listening to Tom, he
+conceded that there were some conspicuous advantages about a life of
+crime, and so he consented to be a pirate.
+
+Three miles below St. Petersburg, at a point where the Mississippi River
+was a trifle over a mile wide, there was a long, narrow, wooded island,
+with a shallow bar at the head of it, and this offered well as a
+rendezvous. It was not inhabited; it lay far over toward the further
+shore, abreast a dense and almost wholly unpeopled forest. So Jackson’s
+Island was chosen. Who were to be the subjects of their piracies was a
+matter that did not occur to them. Then they hunted up Huckleberry Finn,
+and he joined them promptly, for all careers were one to him; he was
+indifferent. They presently separated to meet at a lonely spot on the
+river-bank two miles above the village at the favorite hour--which was
+midnight. There was a small log raft there which they meant to capture.
+Each would bring hooks and lines, and such provision as he could steal
+in the most dark and mysterious way--as became outlaws. And before the
+afternoon was done, they had all managed to enjoy the sweet glory of
+spreading the fact that pretty soon the town would “hear something.” All
+who got this vague hint were cautioned to “be mum and wait.”
+
+About midnight Tom arrived with a boiled ham and a few trifles,
+and stopped in a dense undergrowth on a small bluff overlooking the
+meeting-place. It was starlight, and very still. The mighty river lay
+like an ocean at rest. Tom listened a moment, but no sound disturbed the
+quiet. Then he gave a low, distinct whistle. It was answered from under
+the bluff. Tom whistled twice more; these signals were answered in the
+same way. Then a guarded voice said:
+
+“Who goes there?”
+
+“Tom Sawyer, the Black Avenger of the Spanish Main. Name your names.”
+
+“Huck Finn the Red-Handed, and Joe Harper the Terror of the Seas.” Tom
+had furnished these titles, from his favorite literature.
+
+“‘Tis well. Give the countersign.”
+
+Two hoarse whispers delivered the same awful word simultaneously to the
+brooding night:
+
+“_Blood_!”
+
+Then Tom tumbled his ham over the bluff and let himself down after it,
+tearing both skin and clothes to some extent in the effort. There was
+an easy, comfortable path along the shore under the bluff, but it lacked
+the advantages of difficulty and danger so valued by a pirate.
+
+The Terror of the Seas had brought a side of bacon, and had about worn
+himself out with getting it there. Finn the Red-Handed had stolen a
+skillet and a quantity of half-cured leaf tobacco, and had also brought
+a few corn-cobs to make pipes with. But none of the pirates smoked or
+“chewed” but himself. The Black Avenger of the Spanish Main said it
+would never do to start without some fire. That was a wise thought;
+matches were hardly known there in that day. They saw a fire smouldering
+upon a great raft a hundred yards above, and they went stealthily
+thither and helped themselves to a chunk. They made an imposing
+adventure of it, saying, “Hist!” every now and then, and suddenly
+halting with finger on lip; moving with hands on imaginary dagger-hilts;
+and giving orders in dismal whispers that if “the foe” stirred, to “let
+him have it to the hilt,” because “dead men tell no tales.” They knew
+well enough that the raftsmen were all down at the village laying
+in stores or having a spree, but still that was no excuse for their
+conducting this thing in an unpiratical way.
+
+They shoved off, presently, Tom in command, Huck at the after oar and
+Joe at the forward. Tom stood amidships, gloomy-browed, and with folded
+arms, and gave his orders in a low, stern whisper:
+
+“Luff, and bring her to the wind!”
+
+“Aye-aye, sir!”
+
+“Steady, steady-y-y-y!”
+
+“Steady it is, sir!”
+
+“Let her go off a point!”
+
+“Point it is, sir!”
+
+As the boys steadily and monotonously drove the raft toward mid-stream
+it was no doubt understood that these orders were given only for
+“style,” and were not intended to mean anything in particular.
+
+“What sail’s she carrying?”
+
+“Courses, tops’ls, and flying-jib, sir.”
+
+“Send the r’yals up! Lay out aloft, there, half a dozen of
+ye--foretopmaststuns’l! Lively, now!”
+
+“Aye-aye, sir!”
+
+“Shake out that maintogalans’l! Sheets and braces! _now_ my hearties!”
+
+“Aye-aye, sir!”
+
+“Hellum-a-lee--hard a port! Stand by to meet her when she comes! Port,
+port! _Now_, men! With a will! Stead-y-y-y!”
+
+“Steady it is, sir!”
+
+The raft drew beyond the middle of the river; the boys pointed her head
+right, and then lay on their oars. The river was not high, so there was
+not more than a two or three mile current. Hardly a word was said during
+the next three-quarters of an hour. Now the raft was passing before
+the distant town. Two or three glimmering lights showed where it lay,
+peacefully sleeping, beyond the vague vast sweep of star-gemmed water,
+unconscious of the tremendous event that was happening. The Black
+Avenger stood still with folded arms, “looking his last” upon the scene
+of his former joys and his later sufferings, and wishing “she” could see
+him now, abroad on the wild sea, facing peril and death with dauntless
+heart, going to his doom with a grim smile on his lips. It was but
+a small strain on his imagination to remove Jackson’s Island beyond
+eye-shot of the village, and so he “looked his last” with a broken and
+satisfied heart. The other pirates were looking their last, too; and
+they all looked so long that they came near letting the current drift
+them out of the range of the island. But they discovered the danger in
+time, and made shift to avert it. About two o’clock in the morning the
+raft grounded on the bar two hundred yards above the head of the island,
+and they waded back and forth until they had landed their freight. Part
+of the little raft’s belongings consisted of an old sail, and this they
+spread over a nook in the bushes for a tent to shelter their provisions;
+but they themselves would sleep in the open air in good weather, as
+became outlaws.
+
+They built a fire against the side of a great log twenty or thirty steps
+within the sombre depths of the forest, and then cooked some bacon in
+the frying-pan for supper, and used up half of the corn “pone” stock
+they had brought. It seemed glorious sport to be feasting in that wild,
+free way in the virgin forest of an unexplored and uninhabited island,
+far from the haunts of men, and they said they never would return to
+civilization. The climbing fire lit up their faces and threw its ruddy
+glare upon the pillared tree-trunks of their forest temple, and upon the
+varnished foliage and festooning vines.
+
+When the last crisp slice of bacon was gone, and the last allowance
+of corn pone devoured, the boys stretched themselves out on the grass,
+filled with contentment. They could have found a cooler place, but
+they would not deny themselves such a romantic feature as the roasting
+campfire.
+
+“_Ain’t_ it gay?” said Joe.
+
+“It’s _nuts_!” said Tom. “What would the boys say if they could see us?”
+
+“Say? Well, they’d just die to be here--hey, Hucky!”
+
+“I reckon so,” said Huckleberry; “anyways, I’m suited. I don’t want
+nothing better’n this. I don’t ever get enough to eat, gen’ally--and here
+they can’t come and pick at a feller and bullyrag him so.”
+
+“It’s just the life for me,” said Tom. “You don’t have to get up,
+mornings, and you don’t have to go to school, and wash, and all that
+blame foolishness. You see a pirate don’t have to do _anything_, Joe,
+when he’s ashore, but a hermit _he_ has to be praying considerable, and
+then he don’t have any fun, anyway, all by himself that way.”
+
+“Oh yes, that’s so,” said Joe, “but I hadn’t thought much about it, you
+know. I’d a good deal rather be a pirate, now that I’ve tried it.”
+
+“You see,” said Tom, “people don’t go much on hermits, nowadays, like
+they used to in old times, but a pirate’s always respected. And
+a hermit’s got to sleep on the hardest place he can find, and put
+sackcloth and ashes on his head, and stand out in the rain, and--”
+
+“What does he put sackcloth and ashes on his head for?” inquired Huck.
+
+“I dono. But they’ve _got_ to do it. Hermits always do. You’d have to do
+that if you was a hermit.”
+
+“Dern’d if I would,” said Huck.
+
+“Well, what would you do?”
+
+“I dono. But I wouldn’t do that.”
+
+“Why, Huck, you’d _have_ to. How’d you get around it?”
+
+“Why, I just wouldn’t stand it. I’d run away.”
+
+“Run away! Well, you _would_ be a nice old slouch of a hermit. You’d be
+a disgrace.”
+
+The Red-Handed made no response, being better employed. He had finished
+gouging out a cob, and now he fitted a weed stem to it, loaded it with
+tobacco, and was pressing a coal to the charge and blowing a cloud of
+fragrant smoke--he was in the full bloom of luxurious contentment. The
+other pirates envied him this majestic vice, and secretly resolved to
+acquire it shortly. Presently Huck said:
+
+“What does pirates have to do?”
+
+Tom said:
+
+“Oh, they have just a bully time--take ships and burn them, and get the
+money and bury it in awful places in their island where there’s ghosts
+and things to watch it, and kill everybody in the ships--make ‘em walk a
+plank.”
+
+“And they carry the women to the island,” said Joe; “they don’t kill the
+women.”
+
+“No,” assented Tom, “they don’t kill the women--they’re too noble. And
+the women’s always beautiful, too.
+
+“And don’t they wear the bulliest clothes! Oh no! All gold and silver
+and di’monds,” said Joe, with enthusiasm.
+
+“Who?” said Huck.
+
+“Why, the pirates.”
+
+Huck scanned his own clothing forlornly.
+
+“I reckon I ain’t dressed fitten for a pirate,” said he, with a
+regretful pathos in his voice; “but I ain’t got none but these.”
+
+But the other boys told him the fine clothes would come fast enough,
+after they should have begun their adventures. They made him understand
+that his poor rags would do to begin with, though it was customary for
+wealthy pirates to start with a proper wardrobe.
+
+Gradually their talk died out and drowsiness began to steal upon the
+eyelids of the little waifs. The pipe dropped from the fingers of the
+Red-Handed, and he slept the sleep of the conscience-free and the weary.
+The Terror of the Seas and the Black Avenger of the Spanish Main had
+more difficulty in getting to sleep. They said their prayers inwardly,
+and lying down, since there was nobody there with authority to make them
+kneel and recite aloud; in truth, they had a mind not to say them at
+all, but they were afraid to proceed to such lengths as that, lest they
+might call down a sudden and special thunderbolt from heaven. Then at
+once they reached and hovered upon the imminent verge of sleep--but an
+intruder came, now, that would not “down.” It was conscience. They began
+to feel a vague fear that they had been doing wrong to run away; and
+next they thought of the stolen meat, and then the real torture came.
+They tried to argue it away by reminding conscience that they had
+purloined sweetmeats and apples scores of times; but conscience was not
+to be appeased by such thin plausibilities; it seemed to them, in the
+end, that there was no getting around the stubborn fact that taking
+sweetmeats was only “hooking,” while taking bacon and hams and such
+valuables was plain simple stealing--and there was a command against that
+in the Bible. So they inwardly resolved that so long as they remained in
+the business, their piracies should not again be sullied with the
+crime of stealing. Then conscience granted a truce, and these curiously
+inconsistent pirates fell peacefully to sleep.
+
+
+
+
+CHAPTER XIV
+
+WHEN Tom awoke in the morning, he wondered where he was. He sat up and
+rubbed his eyes and looked around. Then he comprehended. It was the cool
+gray dawn, and there was a delicious sense of repose and peace in the
+deep pervading calm and silence of the woods. Not a leaf stirred; not
+a sound obtruded upon great Nature’s meditation. Beaded dewdrops stood
+upon the leaves and grasses. A white layer of ashes covered the fire,
+and a thin blue breath of smoke rose straight into the air. Joe and Huck
+still slept.
+
+Now, far away in the woods a bird called; another answered; presently
+the hammering of a woodpecker was heard. Gradually the cool dim gray
+of the morning whitened, and as gradually sounds multiplied and life
+manifested itself. The marvel of Nature shaking off sleep and going
+to work unfolded itself to the musing boy. A little green worm came
+crawling over a dewy leaf, lifting two-thirds of his body into the air
+from time to time and “sniffing around,” then proceeding again--for he
+was measuring, Tom said; and when the worm approached him, of its own
+accord, he sat as still as a stone, with his hopes rising and falling,
+by turns, as the creature still came toward him or seemed inclined to
+go elsewhere; and when at last it considered a painful moment with its
+curved body in the air and then came decisively down upon Tom’s leg and
+began a journey over him, his whole heart was glad--for that meant that
+he was going to have a new suit of clothes--without the shadow of a
+doubt a gaudy piratical uniform. Now a procession of ants appeared,
+from nowhere in particular, and went about their labors; one struggled
+manfully by with a dead spider five times as big as itself in its arms,
+and lugged it straight up a tree-trunk. A brown spotted lady-bug climbed
+the dizzy height of a grass blade, and Tom bent down close to it and
+said, “Lady-bug, lady-bug, fly away home, your house is on fire, your
+children’s alone,” and she took wing and went off to see about it--which
+did not surprise the boy, for he knew of old that this insect was
+credulous about conflagrations, and he had practised upon its simplicity
+more than once. A tumblebug came next, heaving sturdily at its ball, and
+Tom touched the creature, to see it shut its legs against its body
+and pretend to be dead. The birds were fairly rioting by this time. A
+catbird, the Northern mocker, lit in a tree over Tom’s head, and trilled
+out her imitations of her neighbors in a rapture of enjoyment; then
+a shrill jay swept down, a flash of blue flame, and stopped on a twig
+almost within the boy’s reach, cocked his head to one side and eyed the
+strangers with a consuming curiosity; a gray squirrel and a big fellow
+of the “fox” kind came skurrying along, sitting up at intervals to
+inspect and chatter at the boys, for the wild things had probably never
+seen a human being before and scarcely knew whether to be afraid or not.
+All Nature was wide awake and stirring, now; long lances of sunlight
+pierced down through the dense foliage far and near, and a few
+butterflies came fluttering upon the scene.
+
+Tom stirred up the other pirates and they all clattered away with
+a shout, and in a minute or two were stripped and chasing after and
+tumbling over each other in the shallow limpid water of the white
+sandbar. They felt no longing for the little village sleeping in the
+distance beyond the majestic waste of water. A vagrant current or a
+slight rise in the river had carried off their raft, but this only
+gratified them, since its going was something like burning the bridge
+between them and civilization.
+
+They came back to camp wonderfully refreshed, glad-hearted, and
+ravenous; and they soon had the camp-fire blazing up again. Huck found a
+spring of clear cold water close by, and the boys made cups of broad oak
+or hickory leaves, and felt that water, sweetened with such a wildwood
+charm as that, would be a good enough substitute for coffee. While Joe
+was slicing bacon for breakfast, Tom and Huck asked him to hold on a
+minute; they stepped to a promising nook in the river-bank and threw in
+their lines; almost immediately they had reward. Joe had not had time
+to get impatient before they were back again with some handsome bass,
+a couple of sun-perch and a small catfish--provisions enough for quite a
+family. They fried the fish with the bacon, and were astonished; for
+no fish had ever seemed so delicious before. They did not know that the
+quicker a fresh-water fish is on the fire after he is caught the better
+he is; and they reflected little upon what a sauce open-air sleeping,
+open-air exercise, bathing, and a large ingredient of hunger make, too.
+
+They lay around in the shade, after breakfast, while Huck had a smoke,
+and then went off through the woods on an exploring expedition. They
+tramped gayly along, over decaying logs, through tangled underbrush,
+among solemn monarchs of the forest, hung from their crowns to the
+ground with a drooping regalia of grape-vines. Now and then they came
+upon snug nooks carpeted with grass and jeweled with flowers.
+
+They found plenty of things to be delighted with, but nothing to be
+astonished at. They discovered that the island was about three miles
+long and a quarter of a mile wide, and that the shore it lay closest to
+was only separated from it by a narrow channel hardly two hundred yards
+wide. They took a swim about every hour, so it was close upon the middle
+of the afternoon when they got back to camp. They were too hungry to
+stop to fish, but they fared sumptuously upon cold ham, and then threw
+themselves down in the shade to talk. But the talk soon began to drag,
+and then died. The stillness, the solemnity that brooded in the woods,
+and the sense of loneliness, began to tell upon the spirits of the boys.
+They fell to thinking. A sort of undefined longing crept upon them. This
+took dim shape, presently--it was budding homesickness. Even Finn the
+Red-Handed was dreaming of his doorsteps and empty hogsheads. But they
+were all ashamed of their weakness, and none was brave enough to speak
+his thought.
+
+For some time, now, the boys had been dully conscious of a peculiar
+sound in the distance, just as one sometimes is of the ticking of a
+clock which he takes no distinct note of. But now this mysterious sound
+became more pronounced, and forced a recognition. The boys started,
+glanced at each other, and then each assumed a listening attitude. There
+was a long silence, profound and unbroken; then a deep, sullen boom came
+floating down out of the distance.
+
+“What is it!” exclaimed Joe, under his breath.
+
+“I wonder,” said Tom in a whisper.
+
+“‘Tain’t thunder,” said Huckleberry, in an awed tone, “becuz thunder--”
+
+“Hark!” said Tom. “Listen--don’t talk.”
+
+They waited a time that seemed an age, and then the same muffled boom
+troubled the solemn hush.
+
+“Let’s go and see.”
+
+They sprang to their feet and hurried to the shore toward the town. They
+parted the bushes on the bank and peered out over the water. The little
+steam ferry-boat was about a mile below the village, drifting with the
+current. Her broad deck seemed crowded with people. There were a great
+many skiffs rowing about or floating with the stream in the neighborhood
+of the ferryboat, but the boys could not determine what the men in
+them were doing. Presently a great jet of white smoke burst from the
+ferryboat’s side, and as it expanded and rose in a lazy cloud, that same
+dull throb of sound was borne to the listeners again.
+
+“I know now!” exclaimed Tom; “somebody’s drownded!”
+
+“That’s it!” said Huck; “they done that last summer, when Bill Turner
+got drownded; they shoot a cannon over the water, and that makes
+him come up to the top. Yes, and they take loaves of bread and put
+quicksilver in ‘em and set ‘em afloat, and wherever there’s anybody
+that’s drownded, they’ll float right there and stop.”
+
+“Yes, I’ve heard about that,” said Joe. “I wonder what makes the bread
+do that.”
+
+“Oh, it ain’t the bread, so much,” said Tom; “I reckon it’s mostly what
+they _say_ over it before they start it out.”
+
+“But they don’t say anything over it,” said Huck. “I’ve seen ‘em and
+they don’t.”
+
+“Well, that’s funny,” said Tom. “But maybe they say it to themselves. Of
+_course_ they do. Anybody might know that.”
+
+The other boys agreed that there was reason in what Tom said, because
+an ignorant lump of bread, uninstructed by an incantation, could not
+be expected to act very intelligently when set upon an errand of such
+gravity.
+
+“By jings, I wish I was over there, now,” said Joe.
+
+“I do too” said Huck “I’d give heaps to know who it is.”
+
+The boys still listened and watched. Presently a revealing thought
+flashed through Tom’s mind, and he exclaimed:
+
+“Boys, I know who’s drownded--it’s us!”
+
+They felt like heroes in an instant. Here was a gorgeous triumph; they
+were missed; they were mourned; hearts were breaking on their account;
+tears were being shed; accusing memories of unkindness to these poor
+lost lads were rising up, and unavailing regrets and remorse were being
+indulged; and best of all, the departed were the talk of the whole town,
+and the envy of all the boys, as far as this dazzling notoriety was
+concerned. This was fine. It was worth while to be a pirate, after all.
+
+As twilight drew on, the ferryboat went back to her accustomed business
+and the skiffs disappeared. The pirates returned to camp. They were
+jubilant with vanity over their new grandeur and the illustrious trouble
+they were making. They caught fish, cooked supper and ate it, and then
+fell to guessing at what the village was thinking and saying about them;
+and the pictures they drew of the public distress on their account were
+gratifying to look upon--from their point of view. But when the shadows
+of night closed them in, they gradually ceased to talk, and sat gazing
+into the fire, with their minds evidently wandering elsewhere. The
+excitement was gone, now, and Tom and Joe could not keep back thoughts
+of certain persons at home who were not enjoying this fine frolic as
+much as they were. Misgivings came; they grew troubled and unhappy; a
+sigh or two escaped, unawares. By and by Joe timidly ventured upon a
+roundabout “feeler” as to how the others might look upon a return to
+civilization--not right now, but--
+
+Tom withered him with derision! Huck, being uncommitted as yet, joined
+in with Tom, and the waverer quickly “explained,” and was glad to get
+out of the scrape with as little taint of chicken-hearted home-sickness
+clinging to his garments as he could. Mutiny was effectually laid to
+rest for the moment.
+
+As the night deepened, Huck began to nod, and presently to snore.
+Joe followed next. Tom lay upon his elbow motionless, for some time,
+watching the two intently. At last he got up cautiously, on his knees,
+and went searching among the grass and the flickering reflections flung
+by the campfire. He picked up and inspected several large semi-cylinders
+of the thin white bark of a sycamore, and finally chose two which seemed
+to suit him. Then he knelt by the fire and painfully wrote something
+upon each of these with his “red keel”; one he rolled up and put in his
+jacket pocket, and the other he put in Joe’s hat and removed it to a
+little distance from the owner. And he also put into the hat certain
+schoolboy treasures of almost inestimable value--among them a lump of
+chalk, an India-rubber ball, three fishhooks, and one of that kind
+of marbles known as a “sure ‘nough crystal.” Then he tiptoed his way
+cautiously among the trees till he felt that he was out of hearing, and
+straightway broke into a keen run in the direction of the sandbar.
+
+
+
+
+CHAPTER XV
+
+A few minutes later Tom was in the shoal water of the bar, wading toward
+the Illinois shore. Before the depth reached his middle he was halfway
+over; the current would permit no more wading, now, so he struck out
+confidently to swim the remaining hundred yards. He swam quartering
+upstream, but still was swept downward rather faster than he had
+expected. However, he reached the shore finally, and drifted along till
+he found a low place and drew himself out. He put his hand on his jacket
+pocket, found his piece of bark safe, and then struck through the woods,
+following the shore, with streaming garments. Shortly before ten
+o’clock he came out into an open place opposite the village, and saw the
+ferryboat lying in the shadow of the trees and the high bank. Everything
+was quiet under the blinking stars. He crept down the bank, watching
+with all his eyes, slipped into the water, swam three or four strokes
+and climbed into the skiff that did “yawl” duty at the boat’s stern. He
+laid himself down under the thwarts and waited, panting.
+
+Presently the cracked bell tapped and a voice gave the order to “cast
+off.” A minute or two later the skiff’s head was standing high up,
+against the boat’s swell, and the voyage was begun. Tom felt happy in
+his success, for he knew it was the boat’s last trip for the night. At
+the end of a long twelve or fifteen minutes the wheels stopped, and
+Tom slipped overboard and swam ashore in the dusk, landing fifty yards
+downstream, out of danger of possible stragglers.
+
+He flew along unfrequented alleys, and shortly found himself at his
+aunt’s back fence. He climbed over, approached the “ell,” and looked
+in at the sitting-room window, for a light was burning there. There
+sat Aunt Polly, Sid, Mary, and Joe Harper’s mother, grouped together,
+talking. They were by the bed, and the bed was between them and the
+door. Tom went to the door and began to softly lift the latch; then
+he pressed gently and the door yielded a crack; he continued pushing
+cautiously, and quaking every time it creaked, till he judged he might
+squeeze through on his knees; so he put his head through and began,
+warily.
+
+“What makes the candle blow so?” said Aunt Polly. Tom hurried up. “Why,
+that door’s open, I believe. Why, of course it is. No end of strange
+things now. Go ‘long and shut it, Sid.”
+
+Tom disappeared under the bed just in time. He lay and “breathed”
+ himself for a time, and then crept to where he could almost touch his
+aunt’s foot.
+
+“But as I was saying,” said Aunt Polly, “he warn’t _bad_, so to say--only
+misch_ee_vous. Only just giddy, and harum-scarum, you know. He warn’t
+any more responsible than a colt. _He_ never meant any harm, and he was
+the best-hearted boy that ever was”--and she began to cry.
+
+“It was just so with my Joe--always full of his devilment, and up to
+every kind of mischief, but he was just as unselfish and kind as he
+could be--and laws bless me, to think I went and whipped him for taking
+that cream, never once recollecting that I throwed it out myself because
+it was sour, and I never to see him again in this world, never, never,
+never, poor abused boy!” And Mrs. Harper sobbed as if her heart would
+break.
+
+“I hope Tom’s better off where he is,” said Sid, “but if he’d been
+better in some ways--”
+
+“_Sid!_” Tom felt the glare of the old lady’s eye, though he could not
+see it. “Not a word against my Tom, now that he’s gone! God’ll take care
+of _him_--never you trouble _your_self, sir! Oh, Mrs. Harper, I don’t
+know how to give him up! I don’t know how to give him up! He was such a
+comfort to me, although he tormented my old heart out of me, ‘most.”
+
+“The Lord giveth and the Lord hath taken away--Blessed be the name of
+the Lord! But it’s so hard--Oh, it’s so hard! Only last Saturday my Joe
+busted a firecracker right under my nose and I knocked him sprawling.
+Little did I know then, how soon--Oh, if it was to do over again I’d hug
+him and bless him for it.”
+
+“Yes, yes, yes, I know just how you feel, Mrs. Harper, I know just
+exactly how you feel. No longer ago than yesterday noon, my Tom took
+and filled the cat full of Pain-killer, and I did think the cretur would
+tear the house down. And God forgive me, I cracked Tom’s head with my
+thimble, poor boy, poor dead boy. But he’s out of all his troubles now.
+And the last words I ever heard him say was to reproach--”
+
+But this memory was too much for the old lady, and she broke entirely
+down. Tom was snuffling, now, himself--and more in pity of himself than
+anybody else. He could hear Mary crying, and putting in a kindly word
+for him from time to time. He began to have a nobler opinion of himself
+than ever before. Still, he was sufficiently touched by his aunt’s grief
+to long to rush out from under the bed and overwhelm her with joy--and
+the theatrical gorgeousness of the thing appealed strongly to his
+nature, too, but he resisted and lay still.
+
+He went on listening, and gathered by odds and ends that it was
+conjectured at first that the boys had got drowned while taking a swim;
+then the small raft had been missed; next, certain boys said the missing
+lads had promised that the village should “hear something” soon; the
+wise-heads had “put this and that together” and decided that the lads
+had gone off on that raft and would turn up at the next town below,
+presently; but toward noon the raft had been found, lodged against the
+Missouri shore some five or six miles below the village--and then hope
+perished; they must be drowned, else hunger would have driven them home
+by nightfall if not sooner. It was believed that the search for the
+bodies had been a fruitless effort merely because the drowning must
+have occurred in mid-channel, since the boys, being good swimmers, would
+otherwise have escaped to shore. This was Wednesday night. If the bodies
+continued missing until Sunday, all hope would be given over, and the
+funerals would be preached on that morning. Tom shuddered.
+
+Mrs. Harper gave a sobbing goodnight and turned to go. Then with a
+mutual impulse the two bereaved women flung themselves into each other’s
+arms and had a good, consoling cry, and then parted. Aunt Polly was
+tender far beyond her wont, in her goodnight to Sid and Mary. Sid
+snuffled a bit and Mary went off crying with all her heart.
+
+Aunt Polly knelt down and prayed for Tom so touchingly, so appealingly,
+and with such measureless love in her words and her old trembling voice,
+that he was weltering in tears again, long before she was through.
+
+He had to keep still long after she went to bed, for she kept making
+broken-hearted ejaculations from time to time, tossing unrestfully, and
+turning over. But at last she was still, only moaning a little in her
+sleep. Now the boy stole out, rose gradually by the bedside, shaded the
+candle-light with his hand, and stood regarding her. His heart was full
+of pity for her. He took out his sycamore scroll and placed it by the
+candle. But something occurred to him, and he lingered considering.
+His face lighted with a happy solution of his thought; he put the bark
+hastily in his pocket. Then he bent over and kissed the faded lips, and
+straightway made his stealthy exit, latching the door behind him.
+
+He threaded his way back to the ferry landing, found nobody at large
+there, and walked boldly on board the boat, for he knew she was
+tenantless except that there was a watchman, who always turned in and
+slept like a graven image. He untied the skiff at the stern, slipped
+into it, and was soon rowing cautiously upstream. When he had pulled a
+mile above the village, he started quartering across and bent himself
+stoutly to his work. He hit the landing on the other side neatly, for
+this was a familiar bit of work to him. He was moved to capture
+the skiff, arguing that it might be considered a ship and therefore
+legitimate prey for a pirate, but he knew a thorough search would be
+made for it and that might end in revelations. So he stepped ashore and
+entered the woods.
+
+He sat down and took a long rest, torturing himself meanwhile to keep
+awake, and then started warily down the home-stretch. The night was far
+spent. It was broad daylight before he found himself fairly abreast the
+island bar. He rested again until the sun was well up and gilding the
+great river with its splendor, and then he plunged into the stream. A
+little later he paused, dripping, upon the threshold of the camp, and
+heard Joe say:
+
+“No, Tom’s true-blue, Huck, and he’ll come back. He won’t desert. He
+knows that would be a disgrace to a pirate, and Tom’s too proud for that
+sort of thing. He’s up to something or other. Now I wonder what?”
+
+“Well, the things is ours, anyway, ain’t they?”
+
+“Pretty near, but not yet, Huck. The writing says they are if he ain’t
+back here to breakfast.”
+
+“Which he is!” exclaimed Tom, with fine dramatic effect, stepping
+grandly into camp.
+
+A sumptuous breakfast of bacon and fish was shortly provided, and as the
+boys set to work upon it, Tom recounted (and adorned) his adventures.
+They were a vain and boastful company of heroes when the tale was done.
+Then Tom hid himself away in a shady nook to sleep till noon, and the
+other pirates got ready to fish and explore.
+
+
+
+
+CHAPTER XVI
+
+AFTER dinner all the gang turned out to hunt for turtle eggs on the bar.
+They went about poking sticks into the sand, and when they found a soft
+place they went down on their knees and dug with their hands. Sometimes
+they would take fifty or sixty eggs out of one hole. They were perfectly
+round white things a trifle smaller than an English walnut. They had a
+famous fried-egg feast that night, and another on Friday morning.
+
+After breakfast they went whooping and prancing out on the bar, and
+chased each other round and round, shedding clothes as they went, until
+they were naked, and then continued the frolic far away up the shoal
+water of the bar, against the stiff current, which latter tripped their
+legs from under them from time to time and greatly increased the fun.
+And now and then they stooped in a group and splashed water in each
+other’s faces with their palms, gradually approaching each other, with
+averted faces to avoid the strangling sprays, and finally gripping and
+struggling till the best man ducked his neighbor, and then they all
+went under in a tangle of white legs and arms and came up blowing,
+sputtering, laughing, and gasping for breath at one and the same time.
+
+When they were well exhausted, they would run out and sprawl on the dry,
+hot sand, and lie there and cover themselves up with it, and by and by
+break for the water again and go through the original performance once
+more. Finally it occurred to them that their naked skin represented
+flesh-colored “tights” very fairly; so they drew a ring in the sand and
+had a circus--with three clowns in it, for none would yield this proudest
+post to his neighbor.
+
+Next they got their marbles and played “knucks” and “ringtaw” and
+“keeps” till that amusement grew stale. Then Joe and Huck had another
+swim, but Tom would not venture, because he found that in kicking off
+his trousers he had kicked his string of rattlesnake rattles off his
+ankle, and he wondered how he had escaped cramp so long without the
+protection of this mysterious charm. He did not venture again until he
+had found it, and by that time the other boys were tired and ready to
+rest. They gradually wandered apart, dropped into the “dumps,” and
+fell to gazing longingly across the wide river to where the village lay
+drowsing in the sun. Tom found himself writing “BECKY” in the sand with
+his big toe; he scratched it out, and was angry with himself for his
+weakness. But he wrote it again, nevertheless; he could not help it. He
+erased it once more and then took himself out of temptation by driving
+the other boys together and joining them.
+
+But Joe’s spirits had gone down almost beyond resurrection. He was so
+homesick that he could hardly endure the misery of it. The tears lay
+very near the surface. Huck was melancholy, too. Tom was downhearted,
+but tried hard not to show it. He had a secret which he was not ready
+to tell, yet, but if this mutinous depression was not broken up soon, he
+would have to bring it out. He said, with a great show of cheerfulness:
+
+“I bet there’s been pirates on this island before, boys. We’ll explore
+it again. They’ve hid treasures here somewhere. How’d you feel to light
+on a rotten chest full of gold and silver--hey?”
+
+But it roused only faint enthusiasm, which faded out, with no reply.
+Tom tried one or two other seductions; but they failed, too. It was
+discouraging work. Joe sat poking up the sand with a stick and looking
+very gloomy. Finally he said:
+
+“Oh, boys, let’s give it up. I want to go home. It’s so lonesome.”
+
+“Oh no, Joe, you’ll feel better by and by,” said Tom. “Just think of the
+fishing that’s here.”
+
+“I don’t care for fishing. I want to go home.”
+
+“But, Joe, there ain’t such another swimming-place anywhere.”
+
+“Swimming’s no good. I don’t seem to care for it, somehow, when there
+ain’t anybody to say I sha’n’t go in. I mean to go home.”
+
+“Oh, shucks! Baby! You want to see your mother, I reckon.”
+
+“Yes, I _do_ want to see my mother--and you would, too, if you had one. I
+ain’t any more baby than you are.” And Joe snuffled a little.
+
+“Well, we’ll let the crybaby go home to his mother, won’t we, Huck? Poor
+thing--does it want to see its mother? And so it shall. You like it here,
+don’t you, Huck? We’ll stay, won’t we?”
+
+Huck said, “Y-e-s”--without any heart in it.
+
+“I’ll never speak to you again as long as I live,” said Joe, rising.
+“There now!” And he moved moodily away and began to dress himself.
+
+“Who cares!” said Tom. “Nobody wants you to. Go ‘long home and get
+laughed at. Oh, you’re a nice pirate. Huck and me ain’t crybabies. We’ll
+stay, won’t we, Huck? Let him go if he wants to. I reckon we can get
+along without him, per’aps.”
+
+But Tom was uneasy, nevertheless, and was alarmed to see Joe go sullenly
+on with his dressing. And then it was discomforting to see Huck eying
+Joe’s preparations so wistfully, and keeping up such an ominous silence.
+Presently, without a parting word, Joe began to wade off toward the
+Illinois shore. Tom’s heart began to sink. He glanced at Huck. Huck
+could not bear the look, and dropped his eyes. Then he said:
+
+“I want to go, too, Tom. It was getting so lonesome anyway, and now
+it’ll be worse. Let’s us go, too, Tom.”
+
+“I won’t! You can all go, if you want to. I mean to stay.”
+
+“Tom, I better go.”
+
+“Well, go ‘long--who’s hendering you.”
+
+Huck began to pick up his scattered clothes. He said:
+
+“Tom, I wisht you’d come, too. Now you think it over. We’ll wait for you
+when we get to shore.”
+
+“Well, you’ll wait a blame long time, that’s all.”
+
+Huck started sorrowfully away, and Tom stood looking after him, with a
+strong desire tugging at his heart to yield his pride and go along
+too. He hoped the boys would stop, but they still waded slowly on. It
+suddenly dawned on Tom that it was become very lonely and still. He made
+one final struggle with his pride, and then darted after his comrades,
+yelling:
+
+“Wait! Wait! I want to tell you something!”
+
+They presently stopped and turned around. When he got to where they
+were, he began unfolding his secret, and they listened moodily till
+at last they saw the “point” he was driving at, and then they set up a
+warwhoop of applause and said it was “splendid!” and said if he had
+told them at first, they wouldn’t have started away. He made a plausible
+excuse; but his real reason had been the fear that not even the secret
+would keep them with him any very great length of time, and so he had
+meant to hold it in reserve as a last seduction.
+
+The lads came gayly back and went at their sports again with a will,
+chattering all the time about Tom’s stupendous plan and admiring the
+genius of it. After a dainty egg and fish dinner, Tom said he wanted to
+learn to smoke, now. Joe caught at the idea and said he would like to
+try, too. So Huck made pipes and filled them. These novices had never
+smoked anything before but cigars made of grapevine, and they “bit” the
+tongue, and were not considered manly anyway.
+
+Now they stretched themselves out on their elbows and began to puff,
+charily, and with slender confidence. The smoke had an unpleasant taste,
+and they gagged a little, but Tom said:
+
+“Why, it’s just as easy! If I’d a knowed this was all, I’d a learnt long
+ago.”
+
+“So would I,” said Joe. “It’s just nothing.”
+
+“Why, many a time I’ve looked at people smoking, and thought well I wish
+I could do that; but I never thought I could,” said Tom.
+
+“That’s just the way with me, hain’t it, Huck? You’ve heard me talk just
+that way--haven’t you, Huck? I’ll leave it to Huck if I haven’t.”
+
+“Yes--heaps of times,” said Huck.
+
+“Well, I have too,” said Tom; “oh, hundreds of times. Once down by the
+slaughter-house. Don’t you remember, Huck? Bob Tanner was there, and
+Johnny Miller, and Jeff Thatcher, when I said it. Don’t you remember,
+Huck, ‘bout me saying that?”
+
+“Yes, that’s so,” said Huck. “That was the day after I lost a white
+alley. No, ‘twas the day before.”
+
+“There--I told you so,” said Tom. “Huck recollects it.”
+
+“I bleeve I could smoke this pipe all day,” said Joe. “I don’t feel
+sick.”
+
+“Neither do I,” said Tom. “I could smoke it all day. But I bet you Jeff
+Thatcher couldn’t.”
+
+“Jeff Thatcher! Why, he’d keel over just with two draws. Just let him
+try it once. _He’d_ see!”
+
+“I bet he would. And Johnny Miller--I wish could see Johnny Miller tackle
+it once.”
+
+“Oh, don’t I!” said Joe. “Why, I bet you Johnny Miller couldn’t any more
+do this than nothing. Just one little snifter would fetch _him_.”
+
+“‘Deed it would, Joe. Say--I wish the boys could see us now.”
+
+“So do I.”
+
+“Say--boys, don’t say anything about it, and some time when they’re
+around, I’ll come up to you and say, ‘Joe, got a pipe? I want a smoke.’
+And you’ll say, kind of careless like, as if it warn’t anything, you’ll
+say, ‘Yes, I got my _old_ pipe, and another one, but my tobacker ain’t
+very good.’ And I’ll say, ‘Oh, that’s all right, if it’s _strong_
+enough.’ And then you’ll out with the pipes, and we’ll light up just as
+ca’m, and then just see ‘em look!”
+
+“By jings, that’ll be gay, Tom! I wish it was _now_!”
+
+“So do I! And when we tell ‘em we learned when we was off pirating,
+won’t they wish they’d been along?”
+
+“Oh, I reckon not! I’ll just _bet_ they will!”
+
+So the talk ran on. But presently it began to flag a trifle, and
+grow disjointed. The silences widened; the expectoration marvellously
+increased. Every pore inside the boys’ cheeks became a spouting
+fountain; they could scarcely bail out the cellars under their tongues
+fast enough to prevent an inundation; little overflowings down their
+throats occurred in spite of all they could do, and sudden retchings
+followed every time. Both boys were looking very pale and miserable,
+now. Joe’s pipe dropped from his nerveless fingers. Tom’s followed. Both
+fountains were going furiously and both pumps bailing with might and
+main. Joe said feebly:
+
+“I’ve lost my knife. I reckon I better go and find it.”
+
+Tom said, with quivering lips and halting utterance:
+
+“I’ll help you. You go over that way and I’ll hunt around by the spring.
+No, you needn’t come, Huck--we can find it.”
+
+So Huck sat down again, and waited an hour. Then he found it lonesome,
+and went to find his comrades. They were wide apart in the woods, both
+very pale, both fast asleep. But something informed him that if they had
+had any trouble they had got rid of it.
+
+They were not talkative at supper that night. They had a humble look,
+and when Huck prepared his pipe after the meal and was going to prepare
+theirs, they said no, they were not feeling very well--something they ate
+at dinner had disagreed with them.
+
+About midnight Joe awoke, and called the boys. There was a brooding
+oppressiveness in the air that seemed to bode something. The boys
+huddled themselves together and sought the friendly companionship of
+the fire, though the dull dead heat of the breathless atmosphere was
+stifling. They sat still, intent and waiting. The solemn hush continued.
+Beyond the light of the fire everything was swallowed up in the
+blackness of darkness. Presently there came a quivering glow that
+vaguely revealed the foliage for a moment and then vanished. By and by
+another came, a little stronger. Then another. Then a faint moan came
+sighing through the branches of the forest and the boys felt a fleeting
+breath upon their cheeks, and shuddered with the fancy that the Spirit
+of the Night had gone by. There was a pause. Now a weird flash turned
+night into day and showed every little grassblade, separate and
+distinct, that grew about their feet. And it showed three white,
+startled faces, too. A deep peal of thunder went rolling and tumbling
+down the heavens and lost itself in sullen rumblings in the distance. A
+sweep of chilly air passed by, rustling all the leaves and snowing the
+flaky ashes broadcast about the fire. Another fierce glare lit up the
+forest and an instant crash followed that seemed to rend the treetops
+right over the boys’ heads. They clung together in terror, in the thick
+gloom that followed. A few big raindrops fell pattering upon the leaves.
+
+“Quick! boys, go for the tent!” exclaimed Tom.
+
+They sprang away, stumbling over roots and among vines in the dark, no
+two plunging in the same direction. A furious blast roared through
+the trees, making everything sing as it went. One blinding flash after
+another came, and peal on peal of deafening thunder. And now a drenching
+rain poured down and the rising hurricane drove it in sheets along the
+ground. The boys cried out to each other, but the roaring wind and the
+booming thunderblasts drowned their voices utterly. However, one by one
+they straggled in at last and took shelter under the tent, cold, scared,
+and streaming with water; but to have company in misery seemed something
+to be grateful for. They could not talk, the old sail flapped so
+furiously, even if the other noises would have allowed them. The tempest
+rose higher and higher, and presently the sail tore loose from its
+fastenings and went winging away on the blast. The boys seized each
+others’ hands and fled, with many tumblings and bruises, to the shelter
+of a great oak that stood upon the riverbank. Now the battle was at its
+highest. Under the ceaseless conflagration of lightning that flamed
+in the skies, everything below stood out in cleancut and shadowless
+distinctness: the bending trees, the billowy river, white with foam, the
+driving spray of spumeflakes, the dim outlines of the high bluffs on
+the other side, glimpsed through the drifting cloudrack and the slanting
+veil of rain. Every little while some giant tree yielded the fight
+and fell crashing through the younger growth; and the unflagging
+thunderpeals came now in ear-splitting explosive bursts, keen and sharp,
+and unspeakably appalling. The storm culminated in one matchless effort
+that seemed likely to tear the island to pieces, burn it up, drown it to
+the treetops, blow it away, and deafen every creature in it, all at one
+and the same moment. It was a wild night for homeless young heads to be
+out in.
+
+But at last the battle was done, and the forces retired with weaker and
+weaker threatenings and grumblings, and peace resumed her sway. The
+boys went back to camp, a good deal awed; but they found there was still
+something to be thankful for, because the great sycamore, the shelter
+of their beds, was a ruin, now, blasted by the lightnings, and they were
+not under it when the catastrophe happened.
+
+Everything in camp was drenched, the campfire as well; for they were but
+heedless lads, like their generation, and had made no provision against
+rain. Here was matter for dismay, for they were soaked through and
+chilled. They were eloquent in their distress; but they presently
+discovered that the fire had eaten so far up under the great log it had
+been built against (where it curved upward and separated itself from
+the ground), that a handbreadth or so of it had escaped wetting; so they
+patiently wrought until, with shreds and bark gathered from the under
+sides of sheltered logs, they coaxed the fire to burn again. Then they
+piled on great dead boughs till they had a roaring furnace, and were
+gladhearted once more. They dried their boiled ham and had a feast,
+and after that they sat by the fire and expanded and glorified their
+midnight adventure until morning, for there was not a dry spot to sleep
+on, anywhere around.
+
+As the sun began to steal in upon the boys, drowsiness came over
+them, and they went out on the sandbar and lay down to sleep. They got
+scorched out by and by, and drearily set about getting breakfast. After
+the meal they felt rusty, and stiff-jointed, and a little homesick once
+more. Tom saw the signs, and fell to cheering up the pirates as well as
+he could. But they cared nothing for marbles, or circus, or swimming, or
+anything. He reminded them of the imposing secret, and raised a ray of
+cheer. While it lasted, he got them interested in a new device. This was
+to knock off being pirates, for a while, and be Indians for a change.
+They were attracted by this idea; so it was not long before they were
+stripped, and striped from head to heel with black mud, like so many
+zebras--all of them chiefs, of course--and then they went tearing through
+the woods to attack an English settlement.
+
+By and by they separated into three hostile tribes, and darted upon each
+other from ambush with dreadful warwhoops, and killed and scalped each
+other by thousands. It was a gory day. Consequently it was an extremely
+satisfactory one.
+
+They assembled in camp toward suppertime, hungry and happy; but now
+a difficulty arose--hostile Indians could not break the bread of
+hospitality together without first making peace, and this was a simple
+impossibility without smoking a pipe of peace. There was no other
+process that ever they had heard of. Two of the savages almost wished
+they had remained pirates. However, there was no other way; so with such
+show of cheerfulness as they could muster they called for the pipe and
+took their whiff as it passed, in due form.
+
+And behold, they were glad they had gone into savagery, for they had
+gained something; they found that they could now smoke a little without
+having to go and hunt for a lost knife; they did not get sick enough to
+be seriously uncomfortable. They were not likely to fool away this high
+promise for lack of effort. No, they practised cautiously, after supper,
+with right fair success, and so they spent a jubilant evening. They were
+prouder and happier in their new acquirement than they would have been
+in the scalping and skinning of the Six Nations. We will leave them to
+smoke and chatter and brag, since we have no further use for them at
+present.
+
+
+
+
+CHAPTER XVII
+
+BUT there was no hilarity in the little town that same tranquil Saturday
+afternoon. The Harpers, and Aunt Polly’s family, were being put into
+mourning, with great grief and many tears. An unusual quiet possessed
+the village, although it was ordinarily quiet enough, in all conscience.
+The villagers conducted their concerns with an absent air, and talked
+little; but they sighed often. The Saturday holiday seemed a burden to
+the children. They had no heart in their sports, and gradually gave them
+up.
+
+In the afternoon Becky Thatcher found herself moping about the deserted
+schoolhouse yard, and feeling very melancholy. But she found nothing
+there to comfort her. She soliloquized:
+
+“Oh, if I only had a brass andiron-knob again! But I haven’t got
+anything now to remember him by.” And she choked back a little sob.
+
+Presently she stopped, and said to herself:
+
+“It was right here. Oh, if it was to do over again, I wouldn’t say
+that--I wouldn’t say it for the whole world. But he’s gone now; I’ll
+never, never, never see him any more.”
+
+This thought broke her down, and she wandered away, with tears rolling
+down her cheeks. Then quite a group of boys and girls--playmates of Tom’s
+and Joe’s--came by, and stood looking over the paling fence and talking
+in reverent tones of how Tom did so-and-so the last time they saw
+him, and how Joe said this and that small trifle (pregnant with awful
+prophecy, as they could easily see now!)--and each speaker pointed out
+the exact spot where the lost lads stood at the time, and then added
+something like “and I was a-standing just so--just as I am now, and as if
+you was him--I was as close as that--and he smiled, just this way--and then
+something seemed to go all over me, like--awful, you know--and I never
+thought what it meant, of course, but I can see now!”
+
+Then there was a dispute about who saw the dead boys last in life, and
+many claimed that dismal distinction, and offered evidences, more or
+less tampered with by the witness; and when it was ultimately decided
+who _did_ see the departed last, and exchanged the last words with them,
+the lucky parties took upon themselves a sort of sacred importance,
+and were gaped at and envied by all the rest. One poor chap, who had
+no other grandeur to offer, said with tolerably manifest pride in the
+remembrance:
+
+“Well, Tom Sawyer he licked me once.”
+
+But that bid for glory was a failure. Most of the boys could say that,
+and so that cheapened the distinction too much. The group loitered away,
+still recalling memories of the lost heroes, in awed voices.
+
+When the Sunday-school hour was finished, the next morning, the bell
+began to toll, instead of ringing in the usual way. It was a very still
+Sabbath, and the mournful sound seemed in keeping with the musing hush
+that lay upon nature. The villagers began to gather, loitering a moment
+in the vestibule to converse in whispers about the sad event. But there
+was no whispering in the house; only the funereal rustling of dresses
+as the women gathered to their seats disturbed the silence there. None
+could remember when the little church had been so full before. There
+was finally a waiting pause, an expectant dumbness, and then Aunt Polly
+entered, followed by Sid and Mary, and they by the Harper family, all in
+deep black, and the whole congregation, the old minister as well, rose
+reverently and stood until the mourners were seated in the front pew.
+There was another communing silence, broken at intervals by muffled
+sobs, and then the minister spread his hands abroad and prayed. A moving
+hymn was sung, and the text followed: “I am the Resurrection and the
+Life.”
+
+As the service proceeded, the clergyman drew such pictures of the
+graces, the winning ways, and the rare promise of the lost lads that
+every soul there, thinking he recognized these pictures, felt a pang
+in remembering that he had persistently blinded himself to them always
+before, and had as persistently seen only faults and flaws in the poor
+boys. The minister related many a touching incident in the lives of the
+departed, too, which illustrated their sweet, generous natures, and the
+people could easily see, now, how noble and beautiful those episodes
+were, and remembered with grief that at the time they occurred they had
+seemed rank rascalities, well deserving of the cowhide. The congregation
+became more and more moved, as the pathetic tale went on, till at last
+the whole company broke down and joined the weeping mourners in a chorus
+of anguished sobs, the preacher himself giving way to his feelings, and
+crying in the pulpit.
+
+There was a rustle in the gallery, which nobody noticed; a moment later
+the church door creaked; the minister raised his streaming eyes above
+his handkerchief, and stood transfixed! First one and then another pair
+of eyes followed the minister’s, and then almost with one impulse the
+congregation rose and stared while the three dead boys came marching up
+the aisle, Tom in the lead, Joe next, and Huck, a ruin of drooping rags,
+sneaking sheepishly in the rear! They had been hid in the unused gallery
+listening to their own funeral sermon!
+
+Aunt Polly, Mary, and the Harpers threw themselves upon their restored
+ones, smothered them with kisses and poured out thanksgivings, while
+poor Huck stood abashed and uncomfortable, not knowing exactly what
+to do or where to hide from so many unwelcoming eyes. He wavered, and
+started to slink away, but Tom seized him and said:
+
+“Aunt Polly, it ain’t fair. Somebody’s got to be glad to see Huck.”
+
+“And so they shall. I’m glad to see him, poor motherless thing!” And
+the loving attentions Aunt Polly lavished upon him were the one thing
+capable of making him more uncomfortable than he was before.
+
+Suddenly the minister shouted at the top of his voice: “Praise God from
+whom all blessings flow--_sing_!--and put your hearts in it!”
+
+And they did. Old Hundred swelled up with a triumphant burst, and
+while it shook the rafters Tom Sawyer the Pirate looked around upon the
+envying juveniles about him and confessed in his heart that this was the
+proudest moment of his life.
+
+As the “sold” congregation trooped out they said they would almost be
+willing to be made ridiculous again to hear Old Hundred sung like that
+once more.
+
+Tom got more cuffs and kisses that day--according to Aunt Polly’s varying
+moods--than he had earned before in a year; and he hardly knew which
+expressed the most gratefulness to God and affection for himself.
+
+
+
+
+CHAPTER XVIII
+
+THAT was Tom’s great secret--the scheme to return home with his brother
+pirates and attend their own funerals. They had paddled over to the
+Missouri shore on a log, at dusk on Saturday, landing five or six miles
+below the village; they had slept in the woods at the edge of the town
+till nearly daylight, and had then crept through back lanes and alleys
+and finished their sleep in the gallery of the church among a chaos of
+invalided benches.
+
+At breakfast, Monday morning, Aunt Polly and Mary were very loving to
+Tom, and very attentive to his wants. There was an unusual amount of
+talk. In the course of it Aunt Polly said:
+
+“Well, I don’t say it wasn’t a fine joke, Tom, to keep everybody
+suffering ‘most a week so you boys had a good time, but it is a pity you
+could be so hard-hearted as to let me suffer so. If you could come over
+on a log to go to your funeral, you could have come over and give me a
+hint some way that you warn’t dead, but only run off.”
+
+“Yes, you could have done that, Tom,” said Mary; “and I believe you
+would if you had thought of it.”
+
+“Would you, Tom?” said Aunt Polly, her face lighting wistfully. “Say,
+now, would you, if you’d thought of it?”
+
+“I--well, I don’t know. ‘Twould ‘a’ spoiled everything.”
+
+“Tom, I hoped you loved me that much,” said Aunt Polly, with a grieved
+tone that discomforted the boy. “It would have been something if you’d
+cared enough to _think_ of it, even if you didn’t _do_ it.”
+
+“Now, auntie, that ain’t any harm,” pleaded Mary; “it’s only Tom’s giddy
+way--he is always in such a rush that he never thinks of anything.”
+
+“More’s the pity. Sid would have thought. And Sid would have come and
+_done_ it, too. Tom, you’ll look back, some day, when it’s too late,
+and wish you’d cared a little more for me when it would have cost you so
+little.”
+
+“Now, auntie, you know I do care for you,” said Tom.
+
+“I’d know it better if you acted more like it.”
+
+“I wish now I’d thought,” said Tom, with a repentant tone; “but I dreamt
+about you, anyway. That’s something, ain’t it?”
+
+“It ain’t much--a cat does that much--but it’s better than nothing. What
+did you dream?”
+
+“Why, Wednesday night I dreamt that you was sitting over there by the
+bed, and Sid was sitting by the woodbox, and Mary next to him.”
+
+“Well, so we did. So we always do. I’m glad your dreams could take even
+that much trouble about us.”
+
+“And I dreamt that Joe Harper’s mother was here.”
+
+“Why, she was here! Did you dream any more?”
+
+“Oh, lots. But it’s so dim, now.”
+
+“Well, try to recollect--can’t you?”
+
+“Somehow it seems to me that the wind--the wind blowed the--the--”
+
+“Try harder, Tom! The wind did blow something. Come!”
+
+Tom pressed his fingers on his forehead an anxious minute, and then
+said:
+
+“I’ve got it now! I’ve got it now! It blowed the candle!”
+
+“Mercy on us! Go on, Tom--go on!”
+
+“And it seems to me that you said, ‘Why, I believe that that door--’”
+
+“Go _on_, Tom!”
+
+“Just let me study a moment--just a moment. Oh, yes--you said you believed
+the door was open.”
+
+“As I’m sitting here, I did! Didn’t I, Mary! Go on!”
+
+“And then--and then--well I won’t be certain, but it seems like as if you
+made Sid go and--and--”
+
+“Well? Well? What did I make him do, Tom? What did I make him do?”
+
+“You made him--you--Oh, you made him shut it.”
+
+“Well, for the land’s sake! I never heard the beat of that in all my
+days! Don’t tell _me_ there ain’t anything in dreams, any more. Sereny
+Harper shall know of this before I’m an hour older. I’d like to see her
+get around _this_ with her rubbage ‘bout superstition. Go on, Tom!”
+
+“Oh, it’s all getting just as bright as day, now. Next you said I warn’t
+_bad_, only mischeevous and harum-scarum, and not any more responsible
+than--than--I think it was a colt, or something.”
+
+“And so it was! Well, goodness gracious! Go on, Tom!”
+
+“And then you began to cry.”
+
+“So I did. So I did. Not the first time, neither. And then--”
+
+“Then Mrs. Harper she began to cry, and said Joe was just the same, and
+she wished she hadn’t whipped him for taking cream when she’d throwed it
+out her own self--”
+
+“Tom! The sperrit was upon you! You was a prophesying--that’s what you
+was doing! Land alive, go on, Tom!”
+
+“Then Sid he said--he said--”
+
+“I don’t think I said anything,” said Sid.
+
+“Yes you did, Sid,” said Mary.
+
+“Shut your heads and let Tom go on! What did he say, Tom?”
+
+“He said--I _think_ he said he hoped I was better off where I was gone
+to, but if I’d been better sometimes--”
+
+“_There_, d’you hear that! It was his very words!”
+
+“And you shut him up sharp.”
+
+“I lay I did! There must ‘a’ been an angel there. There _was_ an angel
+there, somewheres!”
+
+“And Mrs. Harper told about Joe scaring her with a firecracker, and you
+told about Peter and the Pain-killer--”
+
+“Just as true as I live!”
+
+“And then there was a whole lot of talk ‘bout dragging the river for us,
+and ‘bout having the funeral Sunday, and then you and old Miss Harper
+hugged and cried, and she went.”
+
+“It happened just so! It happened just so, as sure as I’m a-sitting in
+these very tracks. Tom, you couldn’t told it more like if you’d ‘a’ seen
+it! And then what? Go on, Tom!”
+
+“Then I thought you prayed for me--and I could see you and hear every
+word you said. And you went to bed, and I was so sorry that I took and
+wrote on a piece of sycamore bark, ‘We ain’t dead--we are only off being
+pirates,’ and put it on the table by the candle; and then you looked
+so good, laying there asleep, that I thought I went and leaned over and
+kissed you on the lips.”
+
+“Did you, Tom, _did_ you! I just forgive you everything for that!” And
+she seized the boy in a crushing embrace that made him feel like the
+guiltiest of villains.
+
+“It was very kind, even though it was only a--dream,” Sid soliloquized
+just audibly.
+
+“Shut up, Sid! A body does just the same in a dream as he’d do if he was
+awake. Here’s a big Milum apple I’ve been saving for you, Tom, if you
+was ever found again--now go ‘long to school. I’m thankful to the good
+God and Father of us all I’ve got you back, that’s long-suffering and
+merciful to them that believe on Him and keep His word, though goodness
+knows I’m unworthy of it, but if only the worthy ones got His blessings
+and had His hand to help them over the rough places, there’s few enough
+would smile here or ever enter into His rest when the long night comes.
+Go ‘long Sid, Mary, Tom--take yourselves off--you’ve hendered me long
+enough.”
+
+The children left for school, and the old lady to call on Mrs. Harper
+and vanquish her realism with Tom’s marvellous dream. Sid had better
+judgment than to utter the thought that was in his mind as he left the
+house. It was this: “Pretty thin--as long a dream as that, without any
+mistakes in it!”
+
+What a hero Tom was become, now! He did not go skipping and prancing,
+but moved with a dignified swagger as became a pirate who felt that the
+public eye was on him. And indeed it was; he tried not to seem to see
+the looks or hear the remarks as he passed along, but they were food and
+drink to him. Smaller boys than himself flocked at his heels, as proud
+to be seen with him, and tolerated by him, as if he had been the drummer
+at the head of a procession or the elephant leading a menagerie into
+town. Boys of his own size pretended not to know he had been away at
+all; but they were consuming with envy, nevertheless. They would have
+given anything to have that swarthy sun-tanned skin of his, and his
+glittering notoriety; and Tom would not have parted with either for a
+circus.
+
+At school the children made so much of him and of Joe, and delivered
+such eloquent admiration from their eyes, that the two heroes were
+not long in becoming insufferably “stuck-up.” They began to tell their
+adventures to hungry listeners--but they only began; it was not a
+thing likely to have an end, with imaginations like theirs to furnish
+material. And finally, when they got out their pipes and went serenely
+puffing around, the very summit of glory was reached.
+
+Tom decided that he could be independent of Becky Thatcher now. Glory
+was sufficient. He would live for glory. Now that he was distinguished,
+maybe she would be wanting to “make up.” Well, let her--she should see
+that he could be as indifferent as some other people. Presently she
+arrived. Tom pretended not to see her. He moved away and joined a group
+of boys and girls and began to talk. Soon he observed that she was
+tripping gayly back and forth with flushed face and dancing eyes,
+pretending to be busy chasing schoolmates, and screaming with laughter
+when she made a capture; but he noticed that she always made her
+captures in his vicinity, and that she seemed to cast a conscious eye
+in his direction at such times, too. It gratified all the vicious vanity
+that was in him; and so, instead of winning him, it only “set him up”
+ the more and made him the more diligent to avoid betraying that he
+knew she was about. Presently she gave over skylarking, and moved
+irresolutely about, sighing once or twice and glancing furtively and
+wistfully toward Tom. Then she observed that now Tom was talking more
+particularly to Amy Lawrence than to any one else. She felt a sharp pang
+and grew disturbed and uneasy at once. She tried to go away, but her
+feet were treacherous, and carried her to the group instead. She said to
+a girl almost at Tom’s elbow--with sham vivacity:
+
+“Why, Mary Austin! you bad girl, why didn’t you come to Sunday-school?”
+
+“I did come--didn’t you see me?”
+
+“Why, no! Did you? Where did you sit?”
+
+“I was in Miss Peters’ class, where I always go. I saw _you_.”
+
+“Did you? Why, it’s funny I didn’t see you. I wanted to tell you about
+the picnic.”
+
+“Oh, that’s jolly. Who’s going to give it?”
+
+“My ma’s going to let me have one.”
+
+“Oh, goody; I hope she’ll let _me_ come.”
+
+“Well, she will. The picnic’s for me. She’ll let anybody come that I
+want, and I want you.”
+
+“That’s ever so nice. When is it going to be?”
+
+“By and by. Maybe about vacation.”
+
+“Oh, won’t it be fun! You going to have all the girls and boys?”
+
+“Yes, every one that’s friends to me--or wants to be”; and she glanced
+ever so furtively at Tom, but he talked right along to Amy Lawrence
+about the terrible storm on the island, and how the lightning tore the
+great sycamore tree “all to flinders” while he was “standing within
+three feet of it.”
+
+“Oh, may I come?” said Grace Miller.
+
+“Yes.”
+
+“And me?” said Sally Rogers.
+
+“Yes.”
+
+“And me, too?” said Susy Harper. “And Joe?”
+
+“Yes.”
+
+And so on, with clapping of joyful hands till all the group had begged
+for invitations but Tom and Amy. Then Tom turned coolly away, still
+talking, and took Amy with him. Becky’s lips trembled and the tears
+came to her eyes; she hid these signs with a forced gayety and went on
+chattering, but the life had gone out of the picnic, now, and out of
+everything else; she got away as soon as she could and hid herself and
+had what her sex call “a good cry.” Then she sat moody, with wounded
+pride, till the bell rang. She roused up, now, with a vindictive cast
+in her eye, and gave her plaited tails a shake and said she knew what
+_she’d_ do.
+
+At recess Tom continued his flirtation with Amy with jubilant
+self-satisfaction. And he kept drifting about to find Becky and lacerate
+her with the performance. At last he spied her, but there was a sudden
+falling of his mercury. She was sitting cosily on a little bench behind
+the schoolhouse looking at a picture-book with Alfred Temple--and so
+absorbed were they, and their heads so close together over the book,
+that they did not seem to be conscious of anything in the world besides.
+Jealousy ran red-hot through Tom’s veins. He began to hate himself for
+throwing away the chance Becky had offered for a reconciliation. He
+called himself a fool, and all the hard names he could think of. He
+wanted to cry with vexation. Amy chatted happily along, as they walked,
+for her heart was singing, but Tom’s tongue had lost its function. He
+did not hear what Amy was saying, and whenever she paused expectantly
+he could only stammer an awkward assent, which was as often misplaced
+as otherwise. He kept drifting to the rear of the schoolhouse, again and
+again, to sear his eyeballs with the hateful spectacle there. He could
+not help it. And it maddened him to see, as he thought he saw, that
+Becky Thatcher never once suspected that he was even in the land of the
+living. But she did see, nevertheless; and she knew she was winning her
+fight, too, and was glad to see him suffer as she had suffered.
+
+Amy’s happy prattle became intolerable. Tom hinted at things he had
+to attend to; things that must be done; and time was fleeting. But in
+vain--the girl chirped on. Tom thought, “Oh, hang her, ain’t I ever going
+to get rid of her?” At last he must be attending to those things--and she
+said artlessly that she would be “around” when school let out. And he
+hastened away, hating her for it.
+
+“Any other boy!” Tom thought, grating his teeth. “Any boy in the whole
+town but that Saint Louis smarty that thinks he dresses so fine and is
+aristocracy! Oh, all right, I licked you the first day you ever saw this
+town, mister, and I’ll lick you again! You just wait till I catch you
+out! I’ll just take and--”
+
+And he went through the motions of thrashing an imaginary boy--pummelling
+the air, and kicking and gouging. “Oh, you do, do you? You holler
+‘nough, do you? Now, then, let that learn you!” And so the imaginary
+flogging was finished to his satisfaction.
+
+Tom fled home at noon. His conscience could not endure any more of Amy’s
+grateful happiness, and his jealousy could bear no more of the other
+distress. Becky resumed her picture inspections with Alfred, but as the
+minutes dragged along and no Tom came to suffer, her triumph began to
+cloud and she lost interest; gravity and absentmindedness followed,
+and then melancholy; two or three times she pricked up her ear at
+a footstep, but it was a false hope; no Tom came. At last she grew
+entirely miserable and wished she hadn’t carried it so far. When
+poor Alfred, seeing that he was losing her, he did not know how, kept
+exclaiming: “Oh, here’s a jolly one! look at this!” she lost patience at
+last, and said, “Oh, don’t bother me! I don’t care for them!” and burst
+into tears, and got up and walked away.
+
+Alfred dropped alongside and was going to try to comfort her, but she
+said:
+
+“Go away and leave me alone, can’t you! I hate you!”
+
+So the boy halted, wondering what he could have done--for she had said
+she would look at pictures all through the nooning--and she walked on,
+crying. Then Alfred went musing into the deserted schoolhouse. He was
+humiliated and angry. He easily guessed his way to the truth--the girl
+had simply made a convenience of him to vent her spite upon Tom Sawyer.
+He was far from hating Tom the less when this thought occurred to him.
+He wished there was some way to get that boy into trouble without much
+risk to himself. Tom’s spelling-book fell under his eye. Here was his
+opportunity. He gratefully opened to the lesson for the afternoon and
+poured ink upon the page.
+
+Becky, glancing in at a window behind him at the moment, saw the act,
+and moved on, without discovering herself. She started homeward, now,
+intending to find Tom and tell him; Tom would be thankful and their
+troubles would be healed. Before she was half way home, however, she
+had changed her mind. The thought of Tom’s treatment of her when she was
+talking about her picnic came scorching back and filled her with shame.
+She resolved to let him get whipped on the damaged spelling-book’s
+account, and to hate him forever, into the bargain.
+
+
+
+
+CHAPTER XIX
+
+TOM arrived at home in a dreary mood, and the first thing his aunt said
+to him showed him that he had brought his sorrows to an unpromising
+market:
+
+“Tom, I’ve a notion to skin you alive!”
+
+“Auntie, what have I done?”
+
+“Well, you’ve done enough. Here I go over to Sereny Harper, like an old
+softy, expecting I’m going to make her believe all that rubbage about
+that dream, when lo and behold you she’d found out from Joe that you was
+over here and heard all the talk we had that night. Tom, I don’t know
+what is to become of a boy that will act like that. It makes me feel so
+bad to think you could let me go to Sereny Harper and make such a fool
+of myself and never say a word.”
+
+This was a new aspect of the thing. His smartness of the morning had
+seemed to Tom a good joke before, and very ingenious. It merely looked
+mean and shabby now. He hung his head and could not think of anything to
+say for a moment. Then he said:
+
+“Auntie, I wish I hadn’t done it--but I didn’t think.”
+
+“Oh, child, you never think. You never think of anything but your
+own selfishness. You could think to come all the way over here from
+Jackson’s Island in the night to laugh at our troubles, and you could
+think to fool me with a lie about a dream; but you couldn’t ever think
+to pity us and save us from sorrow.”
+
+“Auntie, I know now it was mean, but I didn’t mean to be mean. I didn’t,
+honest. And besides, I didn’t come over here to laugh at you that
+night.”
+
+“What did you come for, then?”
+
+“It was to tell you not to be uneasy about us, because we hadn’t got
+drownded.”
+
+“Tom, Tom, I would be the thankfullest soul in this world if I could
+believe you ever had as good a thought as that, but you know you never
+did--and I know it, Tom.”
+
+“Indeed and ‘deed I did, auntie--I wish I may never stir if I didn’t.”
+
+“Oh, Tom, don’t lie--don’t do it. It only makes things a hundred times
+worse.”
+
+“It ain’t a lie, auntie; it’s the truth. I wanted to keep you from
+grieving--that was all that made me come.”
+
+“I’d give the whole world to believe that--it would cover up a power
+of sins, Tom. I’d ‘most be glad you’d run off and acted so bad. But it
+ain’t reasonable; because, why didn’t you tell me, child?”
+
+“Why, you see, when you got to talking about the funeral, I just got all
+full of the idea of our coming and hiding in the church, and I couldn’t
+somehow bear to spoil it. So I just put the bark back in my pocket and
+kept mum.”
+
+“What bark?”
+
+“The bark I had wrote on to tell you we’d gone pirating. I wish, now,
+you’d waked up when I kissed you--I do, honest.”
+
+The hard lines in his aunt’s face relaxed and a sudden tenderness dawned
+in her eyes.
+
+“_Did_ you kiss me, Tom?”
+
+“Why, yes, I did.”
+
+“Are you sure you did, Tom?”
+
+“Why, yes, I did, auntie--certain sure.”
+
+“What did you kiss me for, Tom?”
+
+“Because I loved you so, and you laid there moaning and I was so sorry.”
+
+The words sounded like truth. The old lady could not hide a tremor in
+her voice when she said:
+
+“Kiss me again, Tom!--and be off with you to school, now, and don’t
+bother me any more.”
+
+The moment he was gone, she ran to a closet and got out the ruin of a
+jacket which Tom had gone pirating in. Then she stopped, with it in her
+hand, and said to herself:
+
+“No, I don’t dare. Poor boy, I reckon he’s lied about it--but it’s a
+blessed, blessed lie, there’s such a comfort come from it. I hope
+the Lord--I _know_ the Lord will forgive him, because it was such
+good-heartedness in him to tell it. But I don’t want to find out it’s a
+lie. I won’t look.”
+
+She put the jacket away, and stood by musing a minute. Twice she put out
+her hand to take the garment again, and twice she refrained. Once more
+she ventured, and this time she fortified herself with the thought:
+“It’s a good lie--it’s a good lie--I won’t let it grieve me.” So she
+sought the jacket pocket. A moment later she was reading Tom’s piece of
+bark through flowing tears and saying: “I could forgive the boy, now, if
+he’d committed a million sins!”
+
+
+
+
+CHAPTER XX
+
+THERE was something about Aunt Polly’s manner, when she kissed Tom, that
+swept away his low spirits and made him lighthearted and happy again. He
+started to school and had the luck of coming upon Becky Thatcher at the
+head of Meadow Lane. His mood always determined his manner. Without a
+moment’s hesitation he ran to her and said:
+
+“I acted mighty mean today, Becky, and I’m so sorry. I won’t ever, ever
+do that way again, as long as ever I live--please make up, won’t you?”
+
+The girl stopped and looked him scornfully in the face:
+
+“I’ll thank you to keep yourself _to_ yourself, Mr. Thomas Sawyer. I’ll
+never speak to you again.”
+
+She tossed her head and passed on. Tom was so stunned that he had not
+even presence of mind enough to say “Who cares, Miss Smarty?” until the
+right time to say it had gone by. So he said nothing. But he was in a
+fine rage, nevertheless. He moped into the schoolyard wishing she were
+a boy, and imagining how he would trounce her if she were. He presently
+encountered her and delivered a stinging remark as he passed. She hurled
+one in return, and the angry breach was complete. It seemed to Becky, in
+her hot resentment, that she could hardly wait for school to “take in,”
+ she was so impatient to see Tom flogged for the injured spelling-book.
+If she had had any lingering notion of exposing Alfred Temple, Tom’s
+offensive fling had driven it entirely away.
+
+Poor girl, she did not know how fast she was nearing trouble herself.
+The master, Mr. Dobbins, had reached middle age with an unsatisfied
+ambition. The darling of his desires was, to be a doctor, but
+poverty had decreed that he should be nothing higher than a village
+schoolmaster. Every day he took a mysterious book out of his desk and
+absorbed himself in it at times when no classes were reciting. He kept
+that book under lock and key. There was not an urchin in school but was
+perishing to have a glimpse of it, but the chance never came. Every boy
+and girl had a theory about the nature of that book; but no two theories
+were alike, and there was no way of getting at the facts in the case.
+Now, as Becky was passing by the desk, which stood near the door, she
+noticed that the key was in the lock! It was a precious moment. She
+glanced around; found herself alone, and the next instant she had the
+book in her hands. The titlepage--Professor Somebody’s _Anatomy_--carried
+no information to her mind; so she began to turn the leaves. She came at
+once upon a handsomely engraved and colored frontispiece--a human figure,
+stark naked. At that moment a shadow fell on the page and Tom Sawyer
+stepped in at the door and caught a glimpse of the picture. Becky
+snatched at the book to close it, and had the hard luck to tear the
+pictured page half down the middle. She thrust the volume into the desk,
+turned the key, and burst out crying with shame and vexation.
+
+“Tom Sawyer, you are just as mean as you can be, to sneak up on a person
+and look at what they’re looking at.”
+
+“How could I know you was looking at anything?”
+
+“You ought to be ashamed of yourself, Tom Sawyer; you know you’re
+going to tell on me, and oh, what shall I do, what shall I do! I’ll be
+whipped, and I never was whipped in school.”
+
+Then she stamped her little foot and said:
+
+“_Be_ so mean if you want to! I know something that’s going to happen.
+You just wait and you’ll see! Hateful, hateful, hateful!”--and she flung
+out of the house with a new explosion of crying.
+
+Tom stood still, rather flustered by this onslaught. Presently he said
+to himself:
+
+“What a curious kind of a fool a girl is! Never been licked in
+school! Shucks! What’s a licking! That’s just like a girl--they’re so
+thin-skinned and chicken-hearted. Well, of course I ain’t going to tell
+old Dobbins on this little fool, because there’s other ways of getting
+even on her, that ain’t so mean; but what of it? Old Dobbins will ask
+who it was tore his book. Nobody’ll answer. Then he’ll do just the way
+he always does--ask first one and then t’other, and when he comes to the
+right girl he’ll know it, without any telling. Girls’ faces always tell
+on them. They ain’t got any backbone. She’ll get licked. Well, it’s a
+kind of a tight place for Becky Thatcher, because there ain’t any way
+out of it.” Tom conned the thing a moment longer, and then added: “All
+right, though; she’d like to see me in just such a fix--let her sweat it
+out!”
+
+Tom joined the mob of skylarking scholars outside. In a few moments the
+master arrived and school “took in.” Tom did not feel a strong interest
+in his studies. Every time he stole a glance at the girls’ side of the
+room Becky’s face troubled him. Considering all things, he did not want
+to pity her, and yet it was all he could do to help it. He could get
+up no exultation that was really worthy the name. Presently the
+spelling-book discovery was made, and Tom’s mind was entirely full
+of his own matters for a while after that. Becky roused up from her
+lethargy of distress and showed good interest in the proceedings. She
+did not expect that Tom could get out of his trouble by denying that he
+spilt the ink on the book himself; and she was right. The denial only
+seemed to make the thing worse for Tom. Becky supposed she would be glad
+of that, and she tried to believe she was glad of it, but she found she
+was not certain. When the worst came to the worst, she had an impulse
+to get up and tell on Alfred Temple, but she made an effort and forced
+herself to keep still--because, said she to herself, “he’ll tell about me
+tearing the picture sure. I wouldn’t say a word, not to save his life!”
+
+Tom took his whipping and went back to his seat not at all
+broken-hearted, for he thought it was possible that he had unknowingly
+upset the ink on the spelling-book himself, in some skylarking bout--he
+had denied it for form’s sake and because it was custom, and had stuck
+to the denial from principle.
+
+A whole hour drifted by, the master sat nodding in his throne, the air
+was drowsy with the hum of study. By and by, Mr. Dobbins straightened
+himself up, yawned, then unlocked his desk, and reached for his book,
+but seemed undecided whether to take it out or leave it. Most of the
+pupils glanced up languidly, but there were two among them that watched
+his movements with intent eyes. Mr. Dobbins fingered his book absently
+for a while, then took it out and settled himself in his chair to read!
+Tom shot a glance at Becky. He had seen a hunted and helpless rabbit
+look as she did, with a gun levelled at its head. Instantly he forgot
+his quarrel with her. Quick--something must be done! done in a flash,
+too! But the very imminence of the emergency paralyzed his invention.
+Good!--he had an inspiration! He would run and snatch the book, spring
+through the door and fly. But his resolution shook for one little
+instant, and the chance was lost--the master opened the volume. If Tom
+only had the wasted opportunity back again! Too late. There was no help
+for Becky now, he said. The next moment the master faced the school.
+Every eye sank under his gaze. There was that in it which smote even
+the innocent with fear. There was silence while one might count ten--the
+master was gathering his wrath. Then he spoke: “Who tore this book?”
+
+There was not a sound. One could have heard a pin drop. The stillness
+continued; the master searched face after face for signs of guilt.
+
+“Benjamin Rogers, did you tear this book?”
+
+A denial. Another pause.
+
+“Joseph Harper, did you?”
+
+Another denial. Tom’s uneasiness grew more and more intense under the
+slow torture of these proceedings. The master scanned the ranks of
+boys--considered a while, then turned to the girls:
+
+“Amy Lawrence?”
+
+A shake of the head.
+
+“Gracie Miller?”
+
+The same sign.
+
+“Susan Harper, did you do this?”
+
+Another negative. The next girl was Becky Thatcher. Tom was trembling
+from head to foot with excitement and a sense of the hopelessness of the
+situation.
+
+“Rebecca Thatcher” [Tom glanced at her face--it was white with
+terror]--“did you tear--no, look me in the face” [her hands rose in
+appeal]--“did you tear this book?”
+
+A thought shot like lightning through Tom’s brain. He sprang to his feet
+and shouted--“I done it!”
+
+The school stared in perplexity at this incredible folly. Tom stood a
+moment, to gather his dismembered faculties; and when he stepped forward
+to go to his punishment the surprise, the gratitude, the adoration that
+shone upon him out of poor Becky’s eyes seemed pay enough for a hundred
+floggings. Inspired by the splendor of his own act, he took without
+an outcry the most merciless flaying that even Mr. Dobbins had ever
+administered; and also received with indifference the added cruelty of a
+command to remain two hours after school should be dismissed--for he
+knew who would wait for him outside till his captivity was done, and not
+count the tedious time as loss, either.
+
+Tom went to bed that night planning vengeance against Alfred Temple; for
+with shame and repentance Becky had told him all, not forgetting her own
+treachery; but even the longing for vengeance had to give way, soon, to
+pleasanter musings, and he fell asleep at last with Becky’s latest words
+lingering dreamily in his ear--
+
+“Tom, how _could_ you be so noble!”
+
+
+
+
+CHAPTER XXI
+
+VACATION was approaching. The schoolmaster, always severe, grew severer
+and more exacting than ever, for he wanted the school to make a good
+showing on “Examination” day. His rod and his ferule were seldom idle
+now--at least among the smaller pupils. Only the biggest boys, and young
+ladies of eighteen and twenty, escaped lashing. Mr. Dobbins’ lashings
+were very vigorous ones, too; for although he carried, under his wig, a
+perfectly bald and shiny head, he had only reached middle age, and there
+was no sign of feebleness in his muscle. As the great day approached,
+all the tyranny that was in him came to the surface; he seemed to take a
+vindictive pleasure in punishing the least shortcomings. The consequence
+was, that the smaller boys spent their days in terror and suffering and
+their nights in plotting revenge. They threw away no opportunity to do
+the master a mischief. But he kept ahead all the time. The retribution
+that followed every vengeful success was so sweeping and majestic that
+the boys always retired from the field badly worsted. At last they
+conspired together and hit upon a plan that promised a dazzling victory.
+They swore in the signpainter’s boy, told him the scheme, and asked his
+help. He had his own reasons for being delighted, for the master boarded
+in his father’s family and had given the boy ample cause to hate him.
+The master’s wife would go on a visit to the country in a few days, and
+there would be nothing to interfere with the plan; the master always
+prepared himself for great occasions by getting pretty well fuddled, and
+the signpainter’s boy said that when the dominie had reached the proper
+condition on Examination Evening he would “manage the thing” while he
+napped in his chair; then he would have him awakened at the right time
+and hurried away to school.
+
+In the fulness of time the interesting occasion arrived. At eight in
+the evening the schoolhouse was brilliantly lighted, and adorned with
+wreaths and festoons of foliage and flowers. The master sat throned in
+his great chair upon a raised platform, with his blackboard behind him.
+He was looking tolerably mellow. Three rows of benches on each side and
+six rows in front of him were occupied by the dignitaries of the town
+and by the parents of the pupils. To his left, back of the rows of
+citizens, was a spacious temporary platform upon which were seated the
+scholars who were to take part in the exercises of the evening; rows of
+small boys, washed and dressed to an intolerable state of discomfort;
+rows of gawky big boys; snowbanks of girls and young ladies clad in
+lawn and muslin and conspicuously conscious of their bare arms, their
+grandmothers’ ancient trinkets, their bits of pink and blue ribbon and
+the flowers in their hair. All the rest of the house was filled with
+non-participating scholars.
+
+The exercises began. A very little boy stood up and sheepishly recited,
+“You’d scarce expect one of my age to speak in public on the stage,”
+ etc.--accompanying himself with the painfully exact and spasmodic
+gestures which a machine might have used--supposing the machine to be a
+trifle out of order. But he got through safely, though cruelly scared,
+and got a fine round of applause when he made his manufactured bow and
+retired.
+
+A little shamefaced girl lisped, “Mary had a little lamb,” etc.,
+performed a compassion-inspiring curtsy, got her meed of applause, and
+sat down flushed and happy.
+
+Tom Sawyer stepped forward with conceited confidence and soared into
+the unquenchable and indestructible “Give me liberty or give me death”
+ speech, with fine fury and frantic gesticulation, and broke down in the
+middle of it. A ghastly stage-fright seized him, his legs quaked under
+him and he was like to choke. True, he had the manifest sympathy of the
+house but he had the house’s silence, too, which was even worse than
+its sympathy. The master frowned, and this completed the disaster. Tom
+struggled awhile and then retired, utterly defeated. There was a weak
+attempt at applause, but it died early.
+
+“The Boy Stood on the Burning Deck” followed; also “The Assyrian Came
+Down,” and other declamatory gems. Then there were reading exercises,
+and a spelling fight. The meagre Latin class recited with honor. The
+prime feature of the evening was in order, now--original “compositions”
+ by the young ladies. Each in her turn stepped forward to the edge of the
+platform, cleared her throat, held up her manuscript (tied with dainty
+ribbon), and proceeded to read, with labored attention to “expression”
+ and punctuation. The themes were the same that had been illuminated upon
+similar occasions by their mothers before them, their grandmothers,
+and doubtless all their ancestors in the female line clear back to the
+Crusades. “Friendship” was one; “Memories of Other Days”; “Religion in
+History”; “Dream Land”; “The Advantages of Culture”; “Forms of Political
+Government Compared and Contrasted”; “Melancholy”; “Filial Love”; “Heart
+Longings,” etc., etc.
+
+A prevalent feature in these compositions was a nursed and petted
+melancholy; another was a wasteful and opulent gush of “fine language”;
+another was a tendency to lug in by the ears particularly prized words
+and phrases until they were worn entirely out; and a peculiarity that
+conspicuously marked and marred them was the inveterate and intolerable
+sermon that wagged its crippled tail at the end of each and every one
+of them. No matter what the subject might be, a brainracking effort was
+made to squirm it into some aspect or other that the moral and religious
+mind could contemplate with edification. The glaring insincerity of
+these sermons was not sufficient to compass the banishment of the
+fashion from the schools, and it is not sufficient today; it never will
+be sufficient while the world stands, perhaps. There is no school in
+all our land where the young ladies do not feel obliged to close their
+compositions with a sermon; and you will find that the sermon of the
+most frivolous and the least religious girl in the school is always
+the longest and the most relentlessly pious. But enough of this. Homely
+truth is unpalatable.
+
+Let us return to the “Examination.” The first composition that was read
+was one entitled “Is this, then, Life?” Perhaps the reader can endure an
+extract from it:
+
+“In the common walks of life, with what delightful emotions does the
+youthful mind look forward to some anticipated scene of festivity!
+Imagination is busy sketching rose-tinted pictures of joy. In fancy, the
+voluptuous votary of fashion sees herself amid the festive throng, ‘the
+observed of all observers.’ Her graceful form, arrayed in snowy robes,
+is whirling through the mazes of the joyous dance; her eye is brightest,
+her step is lightest in the gay assembly.
+
+“In such delicious fancies time quickly glides by, and the welcome hour
+arrives for her entrance into the Elysian world, of which she has
+had such bright dreams. How fairy-like does everything appear to her
+enchanted vision! Each new scene is more charming than the last. But
+after a while she finds that beneath this goodly exterior, all is
+vanity, the flattery which once charmed her soul, now grates harshly
+upon her ear; the ballroom has lost its charms; and with wasted health
+and imbittered heart, she turns away with the conviction that earthly
+pleasures cannot satisfy the longings of the soul!”
+
+And so forth and so on. There was a buzz of gratification from time to
+time during the reading, accompanied by whispered ejaculations of “How
+sweet!” “How eloquent!” “So true!” etc., and after the thing had closed
+with a peculiarly afflicting sermon the applause was enthusiastic.
+
+Then arose a slim, melancholy girl, whose face had the “interesting”
+ paleness that comes of pills and indigestion, and read a “poem.” Two
+stanzas of it will do:
+
+“A MISSOURI MAIDEN’S FAREWELL TO ALABAMA
+
+“Alabama, goodbye! I love thee well! But yet for a while do I leave thee
+now! Sad, yes, sad thoughts of thee my heart doth swell, And burning
+recollections throng my brow! For I have wandered through thy flowery
+woods; Have roamed and read near Tallapoosa’s stream; Have listened to
+Tallassee’s warring floods, And wooed on Coosa’s side Aurora’s beam.
+
+“Yet shame I not to bear an o’erfull heart, Nor blush to turn behind
+my tearful eyes; ‘Tis from no stranger land I now must part, ‘Tis to no
+strangers left I yield these sighs. Welcome and home were mine within
+this State, Whose vales I leave--whose spires fade fast from me And cold
+must be mine eyes, and heart, and tete, When, dear Alabama! they turn
+cold on thee!” There were very few there who knew what “tete” meant, but
+the poem was very satisfactory, nevertheless.
+
+Next appeared a dark-complexioned, black-eyed, black-haired young lady,
+who paused an impressive moment, assumed a tragic expression, and began
+to read in a measured, solemn tone:
+
+“A VISION
+
+“Dark and tempestuous was night. Around the throne on high not a single
+star quivered; but the deep intonations of the heavy thunder constantly
+vibrated upon the ear; whilst the terrific lightning revelled in angry
+mood through the cloudy chambers of heaven, seeming to scorn the power
+exerted over its terror by the illustrious Franklin! Even the boisterous
+winds unanimously came forth from their mystic homes, and blustered
+about as if to enhance by their aid the wildness of the scene.
+
+“At such a time, so dark, so dreary, for human sympathy my very spirit
+sighed; but instead thereof,
+
+“‘My dearest friend, my counsellor, my comforter and guide--My joy in
+grief, my second bliss in joy,’ came to my side. She moved like one of
+those bright beings pictured in the sunny walks of fancy’s Eden by
+the romantic and young, a queen of beauty unadorned save by her own
+transcendent loveliness. So soft was her step, it failed to make even a
+sound, and but for the magical thrill imparted by her genial touch,
+as other unobtrusive beauties, she would have glided away
+unperceived--unsought. A strange sadness rested upon her features, like
+icy tears upon the robe of December, as she pointed to the contending
+elements without, and bade me contemplate the two beings presented.”
+
+This nightmare occupied some ten pages of manuscript and wound up with a
+sermon so destructive of all hope to non-Presbyterians that it took
+the first prize. This composition was considered to be the very finest
+effort of the evening. The mayor of the village, in delivering the prize
+to the author of it, made a warm speech in which he said that it was by
+far the most “eloquent” thing he had ever listened to, and that Daniel
+Webster himself might well be proud of it.
+
+It may be remarked, in passing, that the number of compositions in which
+the word “beauteous” was over-fondled, and human experience referred to
+as “life’s page,” was up to the usual average.
+
+Now the master, mellow almost to the verge of geniality, put his chair
+aside, turned his back to the audience, and began to draw a map of
+America on the blackboard, to exercise the geography class upon. But he
+made a sad business of it with his unsteady hand, and a smothered titter
+rippled over the house. He knew what the matter was, and set himself to
+right it. He sponged out lines and remade them; but he only distorted
+them more than ever, and the tittering was more pronounced. He threw his
+entire attention upon his work, now, as if determined not to be put down
+by the mirth. He felt that all eyes were fastened upon him; he imagined
+he was succeeding, and yet the tittering continued; it even manifestly
+increased. And well it might. There was a garret above, pierced with
+a scuttle over his head; and down through this scuttle came a cat,
+suspended around the haunches by a string; she had a rag tied about
+her head and jaws to keep her from mewing; as she slowly descended she
+curved upward and clawed at the string, she swung downward and clawed
+at the intangible air. The tittering rose higher and higher--the cat was
+within six inches of the absorbed teacher’s head--down, down, a little
+lower, and she grabbed his wig with her desperate claws, clung to it,
+and was snatched up into the garret in an instant with her trophy still
+in her possession! And how the light did blaze abroad from the master’s
+bald pate--for the signpainter’s boy had _gilded_ it!
+
+That broke up the meeting. The boys were avenged. Vacation had come.
+
+NOTE:--The pretended “compositions” quoted in this chapter are taken
+without alteration from a volume entitled “Prose and Poetry, by a
+Western Lady”--but they are exactly and precisely after the schoolgirl
+pattern, and hence are much happier than any mere imitations could be.
+
+
+
+
+CHAPTER XXII
+
+TOM joined the new order of Cadets of Temperance, being attracted by the
+showy character of their “regalia.” He promised to abstain from smoking,
+chewing, and profanity as long as he remained a member. Now he found out
+a new thing--namely, that to promise not to do a thing is the surest way
+in the world to make a body want to go and do that very thing. Tom soon
+found himself tormented with a desire to drink and swear; the desire
+grew to be so intense that nothing but the hope of a chance to display
+himself in his red sash kept him from withdrawing from the order. Fourth
+of July was coming; but he soon gave that up--gave it up before he had
+worn his shackles over forty-eight hours--and fixed his hopes upon old
+Judge Frazer, justice of the peace, who was apparently on his deathbed
+and would have a big public funeral, since he was so high an official.
+During three days Tom was deeply concerned about the Judge’s condition
+and hungry for news of it. Sometimes his hopes ran high--so high that
+he would venture to get out his regalia and practise before the
+looking-glass. But the Judge had a most discouraging way of fluctuating.
+At last he was pronounced upon the mend--and then convalescent. Tom was
+disgusted; and felt a sense of injury, too. He handed in his resignation
+at once--and that night the Judge suffered a relapse and died. Tom
+resolved that he would never trust a man like that again.
+
+The funeral was a fine thing. The Cadets paraded in a style calculated
+to kill the late member with envy. Tom was a free boy again,
+however--there was something in that. He could drink and swear, now--but
+found to his surprise that he did not want to. The simple fact that he
+could, took the desire away, and the charm of it.
+
+Tom presently wondered to find that his coveted vacation was beginning
+to hang a little heavily on his hands.
+
+He attempted a diary--but nothing happened during three days, and so he
+abandoned it.
+
+The first of all the negro minstrel shows came to town, and made a
+sensation. Tom and Joe Harper got up a band of performers and were happy
+for two days.
+
+Even the Glorious Fourth was in some sense a failure, for it rained
+hard, there was no procession in consequence, and the greatest man
+in the world (as Tom supposed), Mr. Benton, an actual United States
+Senator, proved an overwhelming disappointment--for he was not
+twenty-five feet high, nor even anywhere in the neighborhood of it.
+
+A circus came. The boys played circus for three days afterward in tents
+made of rag carpeting--admission, three pins for boys, two for girls--and
+then circusing was abandoned.
+
+A phrenologist and a mesmerizer came--and went again and left the village
+duller and drearier than ever.
+
+There were some boys-and-girls’ parties, but they were so few and so
+delightful that they only made the aching voids between ache the harder.
+
+Becky Thatcher was gone to her Constantinople home to stay with her
+parents during vacation--so there was no bright side to life anywhere.
+
+The dreadful secret of the murder was a chronic misery. It was a very
+cancer for permanency and pain.
+
+Then came the measles.
+
+During two long weeks Tom lay a prisoner, dead to the world and its
+happenings. He was very ill, he was interested in nothing. When he got
+upon his feet at last and moved feebly downtown, a melancholy change had
+come over everything and every creature. There had been a “revival,” and
+everybody had “got religion,” not only the adults, but even the boys and
+girls. Tom went about, hoping against hope for the sight of one blessed
+sinful face, but disappointment crossed him everywhere. He found Joe
+Harper studying a Testament, and turned sadly away from the depressing
+spectacle. He sought Ben Rogers, and found him visiting the poor with a
+basket of tracts. He hunted up Jim Hollis, who called his attention to
+the precious blessing of his late measles as a warning. Every boy
+he encountered added another ton to his depression; and when, in
+desperation, he flew for refuge at last to the bosom of Huckleberry Finn
+and was received with a Scriptural quotation, his heart broke and he
+crept home and to bed realizing that he alone of all the town was lost,
+forever and forever.
+
+And that night there came on a terrific storm, with driving rain, awful
+claps of thunder and blinding sheets of lightning. He covered his head
+with the bedclothes and waited in a horror of suspense for his doom; for
+he had not the shadow of a doubt that all this hubbub was about him.
+He believed he had taxed the forbearance of the powers above to the
+extremity of endurance and that this was the result. It might have
+seemed to him a waste of pomp and ammunition to kill a bug with a
+battery of artillery, but there seemed nothing incongruous about the
+getting up such an expensive thunderstorm as this to knock the turf from
+under an insect like himself.
+
+By and by the tempest spent itself and died without accomplishing its
+object. The boy’s first impulse was to be grateful, and reform. His
+second was to wait--for there might not be any more storms.
+
+The next day the doctors were back; Tom had relapsed. The three weeks he
+spent on his back this time seemed an entire age. When he got abroad
+at last he was hardly grateful that he had been spared, remembering how
+lonely was his estate, how companionless and forlorn he was. He drifted
+listlessly down the street and found Jim Hollis acting as judge in a
+juvenile court that was trying a cat for murder, in the presence of her
+victim, a bird. He found Joe Harper and Huck Finn up an alley eating a
+stolen melon. Poor lads! they--like Tom--had suffered a relapse.
+
+
+
+
+CHAPTER XXIII
+
+AT last the sleepy atmosphere was stirred--and vigorously: the murder
+trial came on in the court. It became the absorbing topic of village
+talk immediately. Tom could not get away from it. Every reference to
+the murder sent a shudder to his heart, for his troubled conscience
+and fears almost persuaded him that these remarks were put forth in
+his hearing as “feelers”; he did not see how he could be suspected of
+knowing anything about the murder, but still he could not be comfortable
+in the midst of this gossip. It kept him in a cold shiver all the time.
+He took Huck to a lonely place to have a talk with him. It would be some
+relief to unseal his tongue for a little while; to divide his burden of
+distress with another sufferer. Moreover, he wanted to assure himself
+that Huck had remained discreet.
+
+“Huck, have you ever told anybody about--that?”
+
+“‘Bout what?”
+
+“You know what.”
+
+“Oh--‘course I haven’t.”
+
+“Never a word?”
+
+“Never a solitary word, so help me. What makes you ask?”
+
+“Well, I was afeard.”
+
+“Why, Tom Sawyer, we wouldn’t be alive two days if that got found out.
+_You_ know that.”
+
+Tom felt more comfortable. After a pause:
+
+“Huck, they couldn’t anybody get you to tell, could they?”
+
+“Get me to tell? Why, if I wanted that halfbreed devil to drownd me they
+could get me to tell. They ain’t no different way.”
+
+“Well, that’s all right, then. I reckon we’re safe as long as we keep
+mum. But let’s swear again, anyway. It’s more surer.”
+
+“I’m agreed.”
+
+So they swore again with dread solemnities.
+
+“What is the talk around, Huck? I’ve heard a power of it.”
+
+“Talk? Well, it’s just Muff Potter, Muff Potter, Muff Potter all the
+time. It keeps me in a sweat, constant, so’s I want to hide som’ers.”
+
+“That’s just the same way they go on round me. I reckon he’s a goner.
+Don’t you feel sorry for him, sometimes?”
+
+“Most always--most always. He ain’t no account; but then he hain’t ever
+done anything to hurt anybody. Just fishes a little, to get money to
+get drunk on--and loafs around considerable; but lord, we all do
+that--leastways most of us--preachers and such like. But he’s kind of
+good--he give me half a fish, once, when there warn’t enough for two; and
+lots of times he’s kind of stood by me when I was out of luck.”
+
+“Well, he’s mended kites for me, Huck, and knitted hooks on to my line.
+I wish we could get him out of there.”
+
+“My! we couldn’t get him out, Tom. And besides, ‘twouldn’t do any good;
+they’d ketch him again.”
+
+“Yes--so they would. But I hate to hear ‘em abuse him so like the dickens
+when he never done--that.”
+
+“I do too, Tom. Lord, I hear ‘em say he’s the bloodiest looking villain
+in this country, and they wonder he wasn’t ever hung before.”
+
+“Yes, they talk like that, all the time. I’ve heard ‘em say that if he
+was to get free they’d lynch him.”
+
+“And they’d do it, too.”
+
+The boys had a long talk, but it brought them little comfort. As the
+twilight drew on, they found themselves hanging about the neighborhood
+of the little isolated jail, perhaps with an undefined hope that
+something would happen that might clear away their difficulties. But
+nothing happened; there seemed to be no angels or fairies interested in
+this luckless captive.
+
+The boys did as they had often done before--went to the cell grating and
+gave Potter some tobacco and matches. He was on the ground floor and
+there were no guards.
+
+His gratitude for their gifts had always smote their consciences
+before--it cut deeper than ever, this time. They felt cowardly and
+treacherous to the last degree when Potter said:
+
+“You’ve been mighty good to me, boys--better’n anybody else in this town.
+And I don’t forget it, I don’t. Often I says to myself, says I, ‘I used
+to mend all the boys’ kites and things, and show ‘em where the good
+fishin’ places was, and befriend ‘em what I could, and now they’ve
+all forgot old Muff when he’s in trouble; but Tom don’t, and Huck
+don’t--_they_ don’t forget him, says I, ‘and I don’t forget them.’ Well,
+boys, I done an awful thing--drunk and crazy at the time--that’s the only
+way I account for it--and now I got to swing for it, and it’s right.
+Right, and _best_, too, I reckon--hope so, anyway. Well, we won’t talk
+about that. I don’t want to make _you_ feel bad; you’ve befriended me.
+But what I want to say, is, don’t _you_ ever get drunk--then you won’t
+ever get here. Stand a litter furder west--so--that’s it; it’s a prime
+comfort to see faces that’s friendly when a body’s in such a muck
+of trouble, and there don’t none come here but yourn. Good friendly
+faces--good friendly faces. Git up on one another’s backs and let me
+touch ‘em. That’s it. Shake hands--yourn’ll come through the bars, but
+mine’s too big. Little hands, and weak--but they’ve helped Muff Potter a
+power, and they’d help him more if they could.”
+
+Tom went home miserable, and his dreams that night were full of horrors.
+The next day and the day after, he hung about the courtroom, drawn by an
+almost irresistible impulse to go in, but forcing himself to stay out.
+Huck was having the same experience. They studiously avoided each other.
+Each wandered away, from time to time, but the same dismal fascination
+always brought them back presently. Tom kept his ears open when idlers
+sauntered out of the courtroom, but invariably heard distressing
+news--the toils were closing more and more relentlessly around poor
+Potter. At the end of the second day the village talk was to the effect
+that Injun Joe’s evidence stood firm and unshaken, and that there was
+not the slightest question as to what the jury’s verdict would be.
+
+Tom was out late, that night, and came to bed through the window. He
+was in a tremendous state of excitement. It was hours before he got to
+sleep. All the village flocked to the courthouse the next morning, for
+this was to be the great day. Both sexes were about equally represented
+in the packed audience. After a long wait the jury filed in and took
+their places; shortly afterward, Potter, pale and haggard, timid and
+hopeless, was brought in, with chains upon him, and seated where all
+the curious eyes could stare at him; no less conspicuous was Injun Joe,
+stolid as ever. There was another pause, and then the judge arrived and
+the sheriff proclaimed the opening of the court. The usual whisperings
+among the lawyers and gathering together of papers followed. These
+details and accompanying delays worked up an atmosphere of preparation
+that was as impressive as it was fascinating.
+
+Now a witness was called who testified that he found Muff Potter washing
+in the brook, at an early hour of the morning that the murder was
+discovered, and that he immediately sneaked away. After some further
+questioning, counsel for the prosecution said:
+
+“Take the witness.”
+
+The prisoner raised his eyes for a moment, but dropped them again when
+his own counsel said:
+
+“I have no questions to ask him.”
+
+The next witness proved the finding of the knife near the corpse.
+Counsel for the prosecution said:
+
+“Take the witness.”
+
+“I have no questions to ask him,” Potter’s lawyer replied.
+
+A third witness swore he had often seen the knife in Potter’s
+possession.
+
+“Take the witness.”
+
+Counsel for Potter declined to question him. The faces of the audience
+began to betray annoyance. Did this attorney mean to throw away his
+client’s life without an effort?
+
+Several witnesses deposed concerning Potter’s guilty behavior when
+brought to the scene of the murder. They were allowed to leave the stand
+without being cross-questioned.
+
+Every detail of the damaging circumstances that occurred in the
+graveyard upon that morning which all present remembered so well was
+brought out by credible witnesses, but none of them were cross-examined
+by Potter’s lawyer. The perplexity and dissatisfaction of the house
+expressed itself in murmurs and provoked a reproof from the bench.
+Counsel for the prosecution now said:
+
+“By the oaths of citizens whose simple word is above suspicion, we have
+fastened this awful crime, beyond all possibility of question, upon the
+unhappy prisoner at the bar. We rest our case here.”
+
+A groan escaped from poor Potter, and he put his face in his hands and
+rocked his body softly to and fro, while a painful silence reigned
+in the courtroom. Many men were moved, and many women’s compassion
+testified itself in tears. Counsel for the defence rose and said:
+
+“Your honor, in our remarks at the opening of this trial, we
+foreshadowed our purpose to prove that our client did this fearful deed
+while under the influence of a blind and irresponsible delirium produced
+by drink. We have changed our mind. We shall not offer that plea.” [Then
+to the clerk:] “Call Thomas Sawyer!”
+
+A puzzled amazement awoke in every face in the house, not even excepting
+Potter’s. Every eye fastened itself with wondering interest upon Tom as
+he rose and took his place upon the stand. The boy looked wild enough,
+for he was badly scared. The oath was administered.
+
+“Thomas Sawyer, where were you on the seventeenth of June, about the
+hour of midnight?”
+
+Tom glanced at Injun Joe’s iron face and his tongue failed him. The
+audience listened breathless, but the words refused to come. After a few
+moments, however, the boy got a little of his strength back, and managed
+to put enough of it into his voice to make part of the house hear:
+
+“In the graveyard!”
+
+“A little bit louder, please. Don’t be afraid. You were--”
+
+“In the graveyard.”
+
+A contemptuous smile flitted across Injun Joe’s face.
+
+“Were you anywhere near Horse Williams’ grave?”
+
+“Yes, sir.”
+
+“Speak up--just a trifle louder. How near were you?”
+
+“Near as I am to you.”
+
+“Were you hidden, or not?”
+
+“I was hid.”
+
+“Where?”
+
+“Behind the elms that’s on the edge of the grave.”
+
+Injun Joe gave a barely perceptible start.
+
+“Any one with you?”
+
+“Yes, sir. I went there with--”
+
+“Wait--wait a moment. Never mind mentioning your companion’s name. We
+will produce him at the proper time. Did you carry anything there with
+you.”
+
+Tom hesitated and looked confused.
+
+“Speak out, my boy--don’t be diffident. The truth is always respectable.
+What did you take there?”
+
+“Only a--a--dead cat.”
+
+There was a ripple of mirth, which the court checked.
+
+“We will produce the skeleton of that cat. Now, my boy, tell us
+everything that occurred--tell it in your own way--don’t skip anything,
+and don’t be afraid.”
+
+Tom began--hesitatingly at first, but as he warmed to his subject his
+words flowed more and more easily; in a little while every sound ceased
+but his own voice; every eye fixed itself upon him; with parted lips and
+bated breath the audience hung upon his words, taking no note of time,
+rapt in the ghastly fascinations of the tale. The strain upon pent
+emotion reached its climax when the boy said:
+
+“--and as the doctor fetched the board around and Muff Potter fell, Injun
+Joe jumped with the knife and--”
+
+Crash! Quick as lightning the halfbreed sprang for a window, tore his
+way through all opposers, and was gone!
+
+
+
+
+CHAPTER XXIV
+
+TOM was a glittering hero once more--the pet of the old, the envy of the
+young. His name even went into immortal print, for the village paper
+magnified him. There were some that believed he would be President, yet,
+if he escaped hanging.
+
+As usual, the fickle, unreasoning world took Muff Potter to its bosom
+and fondled him as lavishly as it had abused him before. But that sort
+of conduct is to the world’s credit; therefore it is not well to find
+fault with it.
+
+Tom’s days were days of splendor and exultation to him, but his nights
+were seasons of horror. Injun Joe infested all his dreams, and always
+with doom in his eye. Hardly any temptation could persuade the boy
+to stir abroad after nightfall. Poor Huck was in the same state of
+wretchedness and terror, for Tom had told the whole story to the lawyer
+the night before the great day of the trial, and Huck was sore afraid
+that his share in the business might leak out, yet, notwithstanding
+Injun Joe’s flight had saved him the suffering of testifying in court.
+The poor fellow had got the attorney to promise secrecy, but what of
+that? Since Tom’s harassed conscience had managed to drive him to the
+lawyer’s house by night and wring a dread tale from lips that had
+been sealed with the dismalest and most formidable of oaths, Huck’s
+confidence in the human race was wellnigh obliterated.
+
+Daily Muff Potter’s gratitude made Tom glad he had spoken; but nightly
+he wished he had sealed up his tongue.
+
+Half the time Tom was afraid Injun Joe would never be captured; the
+other half he was afraid he would be. He felt sure he never could draw a
+safe breath again until that man was dead and he had seen the corpse.
+
+Rewards had been offered, the country had been scoured, but no Injun
+Joe was found. One of those omniscient and aweinspiring marvels, a
+detective, came up from St. Louis, moused around, shook his head, looked
+wise, and made that sort of astounding success which members of that
+craft usually achieve. That is to say, he “found a clew.” But you can’t
+hang a “clew” for murder, and so after that detective had got through
+and gone home, Tom felt just as insecure as he was before.
+
+The slow days drifted on, and each left behind it a slightly lightened
+weight of apprehension.
+
+
+
+
+CHAPTER XXV
+
+THERE comes a time in every rightly-constructed boy’s life when he has
+a raging desire to go somewhere and dig for hidden treasure. This desire
+suddenly came upon Tom one day. He sallied out to find Joe Harper,
+but failed of success. Next he sought Ben Rogers; he had gone fishing.
+Presently he stumbled upon Huck Finn the Red-Handed. Huck would
+answer. Tom took him to a private place and opened the matter to him
+confidentially. Huck was willing. Huck was always willing to take a hand
+in any enterprise that offered entertainment and required no capital,
+for he had a troublesome superabundance of that sort of time which is
+not money. “Where’ll we dig?” said Huck.
+
+“Oh, most anywhere.”
+
+“Why, is it hid all around?”
+
+“No, indeed it ain’t. It’s hid in mighty particular places,
+Huck--sometimes on islands, sometimes in rotten chests under the end of
+a limb of an old dead tree, just where the shadow falls at midnight; but
+mostly under the floor in ha’nted houses.”
+
+“Who hides it?”
+
+“Why, robbers, of course--who’d you reckon? Sunday-school
+sup’rintendents?”
+
+“I don’t know. If ‘twas mine I wouldn’t hide it; I’d spend it and have a
+good time.”
+
+“So would I. But robbers don’t do that way. They always hide it and
+leave it there.”
+
+“Don’t they come after it any more?”
+
+“No, they think they will, but they generally forget the marks, or else
+they die. Anyway, it lays there a long time and gets rusty; and by and
+by somebody finds an old yellow paper that tells how to find the marks--a
+paper that’s got to be ciphered over about a week because it’s mostly
+signs and hy’roglyphics.”
+
+“Hyro--which?”
+
+“Hy’roglyphics--pictures and things, you know, that don’t seem to mean
+anything.”
+
+“Have you got one of them papers, Tom?”
+
+“No.”
+
+“Well then, how you going to find the marks?”
+
+“I don’t want any marks. They always bury it under a ha’nted house or on
+an island, or under a dead tree that’s got one limb sticking out. Well,
+we’ve tried Jackson’s Island a little, and we can try it again some
+time; and there’s the old ha’nted house up the Still-House branch, and
+there’s lots of dead-limb trees--dead loads of ‘em.”
+
+“Is it under all of them?”
+
+“How you talk! No!”
+
+“Then how you going to know which one to go for?”
+
+“Go for all of ‘em!”
+
+“Why, Tom, it’ll take all summer.”
+
+“Well, what of that? Suppose you find a brass pot with a hundred dollars
+in it, all rusty and gray, or rotten chest full of di’monds. How’s
+that?”
+
+Huck’s eyes glowed.
+
+“That’s bully. Plenty bully enough for me. Just you gimme the hundred
+dollars and I don’t want no di’monds.”
+
+“All right. But I bet you I ain’t going to throw off on di’monds. Some
+of ‘em’s worth twenty dollars apiece--there ain’t any, hardly, but’s
+worth six bits or a dollar.”
+
+“No! Is that so?”
+
+“Cert’nly--anybody’ll tell you so. Hain’t you ever seen one, Huck?”
+
+“Not as I remember.”
+
+“Oh, kings have slathers of them.”
+
+“Well, I don’ know no kings, Tom.”
+
+“I reckon you don’t. But if you was to go to Europe you’d see a raft of
+‘em hopping around.”
+
+“Do they hop?”
+
+“Hop?--your granny! No!”
+
+“Well, what did you say they did, for?”
+
+“Shucks, I only meant you’d _see_ ‘em--not hopping, of course--what do
+they want to hop for?--but I mean you’d just see ‘em--scattered around,
+you know, in a kind of a general way. Like that old humpbacked Richard.”
+
+“Richard? What’s his other name?”
+
+“He didn’t have any other name. Kings don’t have any but a given name.”
+
+“No?”
+
+“But they don’t.”
+
+“Well, if they like it, Tom, all right; but I don’t want to be a king
+and have only just a given name, like a nigger. But say--where you going
+to dig first?”
+
+“Well, I don’t know. S’pose we tackle that old dead-limb tree on the
+hill t’other side of Still-House branch?”
+
+“I’m agreed.”
+
+So they got a crippled pick and a shovel, and set out on their
+three-mile tramp. They arrived hot and panting, and threw themselves
+down in the shade of a neighboring elm to rest and have a smoke.
+
+“I like this,” said Tom.
+
+“So do I.”
+
+“Say, Huck, if we find a treasure here, what you going to do with your
+share?”
+
+“Well, I’ll have pie and a glass of soda every day, and I’ll go to every
+circus that comes along. I bet I’ll have a gay time.”
+
+“Well, ain’t you going to save any of it?”
+
+“Save it? What for?”
+
+“Why, so as to have something to live on, by and by.”
+
+“Oh, that ain’t any use. Pap would come back to thish-yer town some day
+and get his claws on it if I didn’t hurry up, and I tell you he’d clean
+it out pretty quick. What you going to do with yourn, Tom?”
+
+“I’m going to buy a new drum, and a sure’nough sword, and a red necktie
+and a bull pup, and get married.”
+
+“Married!”
+
+“That’s it.”
+
+“Tom, you--why, you ain’t in your right mind.”
+
+“Wait--you’ll see.”
+
+“Well, that’s the foolishest thing you could do. Look at pap and my
+mother. Fight! Why, they used to fight all the time. I remember, mighty
+well.”
+
+“That ain’t anything. The girl I’m going to marry won’t fight.”
+
+“Tom, I reckon they’re all alike. They’ll all comb a body. Now you
+better think ‘bout this awhile. I tell you you better. What’s the name
+of the gal?”
+
+“It ain’t a gal at all--it’s a girl.”
+
+“It’s all the same, I reckon; some says gal, some says girl--both’s
+right, like enough. Anyway, what’s her name, Tom?”
+
+“I’ll tell you some time--not now.”
+
+“All right--that’ll do. Only if you get married I’ll be more lonesomer
+than ever.”
+
+“No you won’t. You’ll come and live with me. Now stir out of this and
+we’ll go to digging.”
+
+They worked and sweated for half an hour. No result. They toiled another
+halfhour. Still no result. Huck said:
+
+“Do they always bury it as deep as this?”
+
+“Sometimes--not always. Not generally. I reckon we haven’t got the right
+place.”
+
+So they chose a new spot and began again. The labor dragged a little,
+but still they made progress. They pegged away in silence for some time.
+Finally Huck leaned on his shovel, swabbed the beaded drops from his
+brow with his sleeve, and said:
+
+“Where you going to dig next, after we get this one?”
+
+“I reckon maybe we’ll tackle the old tree that’s over yonder on Cardiff
+Hill back of the widow’s.”
+
+“I reckon that’ll be a good one. But won’t the widow take it away from
+us, Tom? It’s on her land.”
+
+“_She_ take it away! Maybe she’d like to try it once. Whoever finds one
+of these hid treasures, it belongs to him. It don’t make any difference
+whose land it’s on.”
+
+That was satisfactory. The work went on. By and by Huck said:
+
+“Blame it, we must be in the wrong place again. What do you think?”
+
+“It is mighty curious, Huck. I don’t understand it. Sometimes witches
+interfere. I reckon maybe that’s what’s the trouble now.”
+
+“Shucks! Witches ain’t got no power in the daytime.”
+
+“Well, that’s so. I didn’t think of that. Oh, I know what the matter is!
+What a blamed lot of fools we are! You got to find out where the shadow
+of the limb falls at midnight, and that’s where you dig!”
+
+“Then consound it, we’ve fooled away all this work for nothing. Now hang
+it all, we got to come back in the night. It’s an awful long way. Can
+you get out?”
+
+“I bet I will. We’ve got to do it tonight, too, because if somebody sees
+these holes they’ll know in a minute what’s here and they’ll go for it.”
+
+“Well, I’ll come around and maow tonight.”
+
+“All right. Let’s hide the tools in the bushes.”
+
+The boys were there that night, about the appointed time. They sat in
+the shadow waiting. It was a lonely place, and an hour made solemn by
+old traditions. Spirits whispered in the rustling leaves, ghosts lurked
+in the murky nooks, the deep baying of a hound floated up out of the
+distance, an owl answered with his sepulchral note. The boys were
+subdued by these solemnities, and talked little. By and by they judged
+that twelve had come; they marked where the shadow fell, and began to
+dig. Their hopes commenced to rise. Their interest grew stronger, and
+their industry kept pace with it. The hole deepened and still deepened,
+but every time their hearts jumped to hear the pick strike upon
+something, they only suffered a new disappointment. It was only a stone
+or a chunk. At last Tom said:
+
+“It ain’t any use, Huck, we’re wrong again.”
+
+“Well, but we _can’t_ be wrong. We spotted the shadder to a dot.”
+
+“I know it, but then there’s another thing.”
+
+“What’s that?”.
+
+“Why, we only guessed at the time. Like enough it was too late or too
+early.”
+
+Huck dropped his shovel.
+
+“That’s it,” said he. “That’s the very trouble. We got to give this one
+up. We can’t ever tell the right time, and besides this kind of thing’s
+too awful, here this time of night with witches and ghosts a-fluttering
+around so. I feel as if something’s behind me all the time;  and I’m
+afeard to turn around, becuz maybe there’s others in front a-waiting for
+a chance. I been creeping all over, ever since I got here.”
+
+“Well, I’ve been pretty much so, too, Huck. They most always put in a
+dead man when they bury a treasure under a tree, to look out for it.”
+
+“Lordy!”
+
+“Yes, they do. I’ve always heard that.”
+
+“Tom, I don’t like to fool around much where there’s dead people. A
+body’s bound to get into trouble with ‘em, sure.”
+
+“I don’t like to stir ‘em up, either. S’pose this one here was to stick
+his skull out and say something!”
+
+“Don’t Tom! It’s awful.”
+
+“Well, it just is. Huck, I don’t feel comfortable a bit.”
+
+“Say, Tom, let’s give this place up, and try somewheres else.”
+
+“All right, I reckon we better.”
+
+“What’ll it be?”
+
+Tom considered awhile; and then said:
+
+“The ha’nted house. That’s it!”
+
+“Blame it, I don’t like ha’nted houses, Tom. Why, they’re a dern sight
+worse’n dead people. Dead people might talk, maybe, but they don’t come
+sliding around in a shroud, when you ain’t noticing, and peep over your
+shoulder all of a sudden and grit their teeth, the way a ghost does. I
+couldn’t stand such a thing as that, Tom--nobody could.”
+
+“Yes, but, Huck, ghosts don’t travel around only at night. They won’t
+hender us from digging there in the daytime.”
+
+“Well, that’s so. But you know mighty well people don’t go about that
+ha’nted house in the day nor the night.”
+
+“Well, that’s mostly because they don’t like to go where a man’s been
+murdered, anyway--but nothing’s ever been seen around that house except
+in the night--just some blue lights slipping by the windows--no regular
+ghosts.”
+
+“Well, where you see one of them blue lights flickering around, Tom,
+you can bet there’s a ghost mighty close behind it. It stands to reason.
+Becuz you know that they don’t anybody but ghosts use ‘em.”
+
+“Yes, that’s so. But anyway they don’t come around in the daytime, so
+what’s the use of our being afeard?”
+
+“Well, all right. We’ll tackle the ha’nted house if you say so--but I
+reckon it’s taking chances.”
+
+They had started down the hill by this time. There in the middle of the
+moonlit valley below them stood the “ha’nted” house, utterly isolated,
+its fences gone long ago, rank weeds smothering the very doorsteps, the
+chimney crumbled to ruin, the window-sashes vacant, a corner of the roof
+caved in. The boys gazed awhile, half expecting to see a blue light flit
+past a window; then talking in a low tone, as befitted the time and the
+circumstances, they struck far off to the right, to give the haunted
+house a wide berth, and took their way homeward through the woods that
+adorned the rearward side of Cardiff Hill.
+
+
+
+
+CHAPTER XVI
+
+ABOUT noon the next day the boys arrived at the dead tree; they had come
+for their tools. Tom was impatient to go to the haunted house; Huck was
+measurably so, also--but suddenly said:
+
+“Lookyhere, Tom, do you know what day it is?”
+
+Tom mentally ran over the days of the week, and then quickly lifted his
+eyes with a startled look in them--
+
+“My! I never once thought of it, Huck!”
+
+“Well, I didn’t neither, but all at once it popped onto me that it was
+Friday.”
+
+“Blame it, a body can’t be too careful, Huck. We might ‘a’ got into an
+awful scrape, tackling such a thing on a Friday.”
+
+“_Might_! Better say we _would_! There’s some lucky days, maybe, but
+Friday ain’t.”
+
+“Any fool knows that. I don’t reckon _you_ was the first that found it
+out, Huck.”
+
+“Well, I never said I was, did I? And Friday ain’t all, neither. I had a
+rotten bad dream last night--dreampt about rats.”
+
+“No! Sure sign of trouble. Did they fight?”
+
+“No.”
+
+“Well, that’s good, Huck. When they don’t fight it’s only a sign that
+there’s trouble around, you know. All we got to do is to look mighty
+sharp and keep out of it. We’ll drop this thing for today, and play. Do
+you know Robin Hood, Huck?”
+
+“No. Who’s Robin Hood?”
+
+“Why, he was one of the greatest men that was ever in England--and the
+best. He was a robber.”
+
+“Cracky, I wisht I was. Who did he rob?”
+
+“Only sheriffs and bishops and rich people and kings, and such like. But
+he never bothered the poor. He loved ‘em. He always divided up with ‘em
+perfectly square.”
+
+“Well, he must ‘a’ been a brick.”
+
+“I bet you he was, Huck. Oh, he was the noblest man that ever was.
+They ain’t any such men now, I can tell you. He could lick any man in
+England, with one hand tied behind him; and he could take his yew bow
+and plug a ten-cent piece every time, a mile and a half.”
+
+“What’s a _yew_ bow?”
+
+“I don’t know. It’s some kind of a bow, of course. And if he hit that
+dime only on the edge he would set down and cry--and curse. But we’ll
+play Robin Hood--it’s nobby fun. I’ll learn you.”
+
+“I’m agreed.”
+
+So they played Robin Hood all the afternoon, now and then casting a
+yearning eye down upon the haunted house and passing a remark about the
+morrow’s prospects and possibilities there. As the sun began to sink
+into the west they took their way homeward athwart the long shadows
+of the trees and soon were buried from sight in the forests of Cardiff
+Hill.
+
+On Saturday, shortly after noon, the boys were at the dead tree again.
+They had a smoke and a chat in the shade, and then dug a little in their
+last hole, not with great hope, but merely because Tom said there were
+so many cases where people had given up a treasure after getting down
+within six inches of it, and then somebody else had come along and
+turned it up with a single thrust of a shovel. The thing failed this
+time, however, so the boys shouldered their tools and went away feeling
+that they had not trifled with fortune, but had fulfilled all the
+requirements that belong to the business of treasure-hunting.
+
+When they reached the haunted house there was something so weird and
+grisly about the dead silence that reigned there under the baking sun,
+and something so depressing about the loneliness and desolation of the
+place, that they were afraid, for a moment, to venture in. Then they
+crept to the door and took a trembling peep. They saw a weedgrown,
+floorless room, unplastered, an ancient fireplace, vacant windows,
+a ruinous staircase; and here, there, and everywhere hung ragged and
+abandoned cobwebs. They presently entered, softly, with quickened
+pulses, talking in whispers, ears alert to catch the slightest sound,
+and muscles tense and ready for instant retreat.
+
+In a little while familiarity modified their fears and they gave the
+place a critical and interested examination, rather admiring their own
+boldness, and wondering at it, too. Next they wanted to look upstairs.
+This was something like cutting off retreat, but they got to daring
+each other, and of course there could be but one result--they threw their
+tools into a corner and made the ascent. Up there were the same signs of
+decay. In one corner they found a closet that promised mystery, but the
+promise was a fraud--there was nothing in it. Their courage was up now
+and well in hand. They were about to go down and begin work when--
+
+“Sh!” said Tom.
+
+“What is it?” whispered Huck, blanching with fright.
+
+“Sh!... There!... Hear it?”
+
+“Yes!... Oh, my! Let’s run!”
+
+“Keep still! Don’t you budge! They’re coming right toward the door.”
+
+The boys stretched themselves upon the floor with their eyes to
+knotholes in the planking, and lay waiting, in a misery of fear.
+
+“They’ve stopped.... No--coming.... Here they are. Don’t whisper another
+word, Huck. My goodness, I wish I was out of this!”
+
+Two men entered. Each boy said to himself: “There’s the old deaf and
+dumb Spaniard that’s been about town once or twice lately--never saw
+t’other man before.”
+
+“T’other” was a ragged, unkempt creature, with nothing very pleasant
+in his face. The Spaniard was wrapped in a serape; he had bushy white
+whiskers; long white hair flowed from under his sombrero, and he wore
+green goggles. When they came in, “t’other” was talking in a low voice;
+they sat down on the ground, facing the door, with their backs to the
+wall, and the speaker continued his remarks. His manner became less
+guarded and his words more distinct as he proceeded:
+
+“No,” said he, “I’ve thought it all over, and I don’t like it. It’s
+dangerous.”
+
+“Dangerous!” grunted the “deaf and dumb” Spaniard--to the vast surprise
+of the boys. “Milksop!”
+
+This voice made the boys gasp and quake. It was Injun Joe’s! There was
+silence for some time. Then Joe said:
+
+“What’s any more dangerous than that job up yonder--but nothing’s come of
+it.”
+
+“That’s different. Away up the river so, and not another house about.
+‘Twon’t ever be known that we tried, anyway, long as we didn’t succeed.”
+
+“Well, what’s more dangerous than coming here in the daytime!--anybody
+would suspicion us that saw us.”
+
+“I know that. But there warn’t any other place as handy after that fool
+of a job. I want to quit this shanty. I wanted to yesterday, only it
+warn’t any use trying to stir out of here, with those infernal boys
+playing over there on the hill right in full view.”
+
+“Those infernal boys” quaked again under the inspiration of this remark,
+and thought how lucky it was that they had remembered it was Friday and
+concluded to wait a day. They wished in their hearts they had waited a
+year.
+
+The two men got out some food and made a luncheon. After a long and
+thoughtful silence, Injun Joe said:
+
+“Look here, lad--you go back up the river where you belong. Wait there
+till you hear from me. I’ll take the chances on dropping into this town
+just once more, for a look. We’ll do that ‘dangerous’ job after I’ve
+spied around a little and think things look well for it. Then for Texas!
+We’ll leg it together!”
+
+This was satisfactory. Both men presently fell to yawning, and Injun Joe
+said:
+
+“I’m dead for sleep! It’s your turn to watch.”
+
+He curled down in the weeds and soon began to snore. His comrade stirred
+him once or twice and he became quiet. Presently the watcher began to
+nod; his head drooped lower and lower, both men began to snore now.
+
+The boys drew a long, grateful breath. Tom whispered:
+
+“Now’s our chance--come!”
+
+Huck said:
+
+“I can’t--I’d die if they was to wake.”
+
+Tom urged--Huck held back. At last Tom rose slowly and softly, and
+started alone. But the first step he made wrung such a hideous creak
+from the crazy floor that he sank down almost dead with fright. He never
+made a second attempt. The boys lay there counting the dragging moments
+till it seemed to them that time must be done and eternity growing gray;
+and then they were grateful to note that at last the sun was setting.
+
+Now one snore ceased. Injun Joe sat up, stared around--smiled grimly upon
+his comrade, whose head was drooping upon his knees--stirred him up with
+his foot and said:
+
+“Here! _You’re_ a watchman, ain’t you! All right, though--nothing’s
+happened.”
+
+“My! have I been asleep?”
+
+“Oh, partly, partly. Nearly time for us to be moving, pard. What’ll we
+do with what little swag we’ve got left?”
+
+“I don’t know--leave it here as we’ve always done, I reckon. No use to
+take it away till we start south. Six hundred and fifty in silver’s
+something to carry.”
+
+“Well--all right--it won’t matter to come here once more.”
+
+“No--but I’d say come in the night as we used to do--it’s better.”
+
+“Yes: but look here; it may be a good while before I get the right
+chance at that job; accidents might happen; ‘tain’t in such a very good
+place; we’ll just regularly bury it--and bury it deep.”
+
+“Good idea,” said the comrade, who walked across the room, knelt down,
+raised one of the rearward hearth-stones and took out a bag that jingled
+pleasantly. He subtracted from it twenty or thirty dollars for himself
+and as much for Injun Joe, and passed the bag to the latter, who was on
+his knees in the corner, now, digging with his bowie-knife.
+
+The boys forgot all their fears, all their miseries in an instant. With
+gloating eyes they watched every movement. Luck!--the splendor of it was
+beyond all imagination! Six hundred dollars was money enough to make
+half a dozen boys rich! Here was treasure-hunting under the happiest
+auspices--there would not be any bothersome uncertainty as to where to
+dig. They nudged each other every moment--eloquent nudges and easily
+understood, for they simply meant--“Oh, but ain’t you glad _now_ we’re
+here!”
+
+Joe’s knife struck upon something.
+
+“Hello!” said he.
+
+“What is it?” said his comrade.
+
+“Half-rotten plank--no, it’s a box, I believe. Here--bear a hand and we’ll
+see what it’s here for. Never mind, I’ve broke a hole.”
+
+He reached his hand in and drew it out--
+
+“Man, it’s money!”
+
+The two men examined the handful of coins. They were gold. The boys
+above were as excited as themselves, and as delighted.
+
+Joe’s comrade said:
+
+“We’ll make quick work of this. There’s an old rusty pick over amongst
+the weeds in the corner the other side of the fireplace--I saw it a
+minute ago.”
+
+He ran and brought the boys’ pick and shovel. Injun Joe took the
+pick, looked it over critically, shook his head, muttered something to
+himself, and then began to use it. The box was soon unearthed. It was
+not very large; it was iron bound and had been very strong before the
+slow years had injured it. The men contemplated the treasure awhile in
+blissful silence.
+
+“Pard, there’s thousands of dollars here,” said Injun Joe.
+
+“‘Twas always said that Murrel’s gang used to be around here one
+summer,” the stranger observed.
+
+“I know it,” said Injun Joe; “and this looks like it, I should say.”
+
+“Now you won’t need to do that job.”
+
+The halfbreed frowned. Said he:
+
+“You don’t know me. Least you don’t know all about that thing. ‘Tain’t
+robbery altogether--it’s _revenge_!” and a wicked light flamed in his
+eyes. “I’ll need your help in it. When it’s finished--then Texas. Go home
+to your Nance and your kids, and stand by till you hear from me.”
+
+“Well--if you say so; what’ll we do with this--bury it again?”
+
+“Yes. [Ravishing delight overhead.] _No_! by the great Sachem, no!
+[Profound distress overhead.] I’d nearly forgot. That pick had fresh
+earth on it! [The boys were sick with terror in a moment.] What business
+has a pick and a shovel here? What business with fresh earth on
+them? Who brought them here--and where are they gone? Have you heard
+anybody?--seen anybody? What! bury it again and leave them to come and
+see the ground disturbed? Not exactly--not exactly. We’ll take it to my
+den.”
+
+“Why, of course! Might have thought of that before. You mean Number
+One?”
+
+“No--Number Two--under the cross. The other place is bad--too common.”
+
+“All right. It’s nearly dark enough to start.”
+
+Injun Joe got up and went about from window to window cautiously peeping
+out. Presently he said:
+
+“Who could have brought those tools here? Do you reckon they can be
+upstairs?”
+
+The boys’ breath forsook them. Injun Joe put his hand on his knife,
+halted a moment, undecided, and then turned toward the stairway. The
+boys thought of the closet, but their strength was gone. The steps came
+creaking up the stairs--the intolerable distress of the situation woke
+the stricken resolution of the lads--they were about to spring for the
+closet, when there was a crash of rotten timbers and Injun Joe landed on
+the ground amid the debris of the ruined stairway. He gathered himself
+up cursing, and his comrade said:
+
+“Now what’s the use of all that? If it’s anybody, and they’re up there,
+let them _stay_ there--who cares? If they want to jump down, now, and get
+into trouble, who objects? It will be dark in fifteen minutes--and then
+let them follow us if they want to. I’m willing. In my opinion, whoever
+hove those things in here caught a sight of us and took us for ghosts or
+devils or something. I’ll bet they’re running yet.”
+
+Joe grumbled awhile; then he agreed with his friend that what daylight
+was left ought to be economized in getting things ready for leaving.
+Shortly afterward they slipped out of the house in the deepening
+twilight, and moved toward the river with their precious box.
+
+Tom and Huck rose up, weak but vastly relieved, and stared after them
+through the chinks between the logs of the house. Follow? Not they. They
+were content to reach ground again without broken necks, and take the
+townward track over the hill. They did not talk much. They were too much
+absorbed in hating themselves--hating the ill luck that made them take
+the spade and the pick there. But for that, Injun Joe never would have
+suspected. He would have hidden the silver with the gold to wait
+there till his “revenge” was satisfied, and then he would have had the
+misfortune to find that money turn up missing. Bitter, bitter luck that
+the tools were ever brought there!
+
+They resolved to keep a lookout for that Spaniard when he should come to
+town spying out for chances to do his revengeful job, and follow him to
+“Number Two,” wherever that might be. Then a ghastly thought occurred to
+Tom.
+
+“Revenge? What if he means _us_, Huck!”
+
+“Oh, don’t!” said Huck, nearly fainting.
+
+They talked it all over, and as they entered town they agreed to believe
+that he might possibly mean somebody else--at least that he might at
+least mean nobody but Tom, since only Tom had testified.
+
+Very, very small comfort it was to Tom to be alone in danger! Company
+would be a palpable improvement, he thought.
+
+
+
+
+CHAPTER XXVII
+
+THE adventure of the day mightily tormented Tom’s dreams that night.
+Four times he had his hands on that rich treasure and four times
+it wasted to nothingness in his fingers as sleep forsook him and
+wakefulness brought back the hard reality of his misfortune. As he lay
+in the early morning recalling the incidents of his great adventure, he
+noticed that they seemed curiously subdued and far away--somewhat as if
+they had happened in another world, or in a time long gone by. Then it
+occurred to him that the great adventure itself must be a dream! There
+was one very strong argument in favor of this idea--namely, that the
+quantity of coin he had seen was too vast to be real. He had never seen
+as much as fifty dollars in one mass before, and he was like all boys of
+his age and station in life, in that he imagined that all references to
+“hundreds” and “thousands” were mere fanciful forms of speech, and that
+no such sums really existed in the world. He never had supposed for
+a moment that so large a sum as a hundred dollars was to be found in
+actual money in any one’s possession. If his notions of hidden treasure
+had been analyzed, they would have been found to consist of a handful of
+real dimes and a bushel of vague, splendid, ungraspable dollars.
+
+But the incidents of his adventure grew sensibly sharper and clearer
+under the attrition of thinking them over, and so he presently found
+himself leaning to the impression that the thing might not have been a
+dream, after all. This uncertainty must be swept away. He would snatch a
+hurried breakfast and go and find Huck. Huck was sitting on the gunwale
+of a flatboat, listlessly dangling his feet in the water and looking
+very melancholy. Tom concluded to let Huck lead up to the subject. If
+he did not do it, then the adventure would be proved to have been only a
+dream.
+
+“Hello, Huck!”
+
+“Hello, yourself.”
+
+Silence, for a minute.
+
+“Tom, if we’d ‘a’ left the blame tools at the dead tree, we’d ‘a’ got
+the money. Oh, ain’t it awful!”
+
+“‘Tain’t a dream, then, ‘tain’t a dream! Somehow I most wish it was.
+Dog’d if I don’t, Huck.”
+
+“What ain’t a dream?”
+
+“Oh, that thing yesterday. I been half thinking it was.”
+
+“Dream! If them stairs hadn’t broke down you’d ‘a’ seen how much dream
+it was! I’ve had dreams enough all night--with that patch-eyed Spanish
+devil going for me all through ‘em--rot him!”
+
+“No, not rot him. _Find_ him! Track the money!”
+
+“Tom, we’ll never find him. A feller don’t have only one chance for such
+a pile--and that one’s lost. I’d feel mighty shaky if I was to see him,
+anyway.”
+
+“Well, so’d I; but I’d like to see him, anyway--and track him out--to his
+Number Two.”
+
+“Number Two--yes, that’s it. I been thinking ‘bout that. But I can’t make
+nothing out of it. What do you reckon it is?”
+
+“I dono. It’s too deep. Say, Huck--maybe it’s the number of a house!”
+
+“Goody!... No, Tom, that ain’t it. If it is, it ain’t in this one-horse
+town. They ain’t no numbers here.”
+
+“Well, that’s so. Lemme think a minute. Here--it’s the number of a
+room--in a tavern, you know!”
+
+“Oh, that’s the trick! They ain’t only two taverns. We can find out
+quick.”
+
+“You stay here, Huck, till I come.”
+
+Tom was off at once. He did not care to have Huck’s company in public
+places. He was gone half an hour. He found that in the best tavern, No.
+2 had long been occupied by a young lawyer, and was still so occupied.
+In the less ostentatious house, No. 2 was a mystery. The tavern-keeper’s
+young son said it was kept locked all the time, and he never saw anybody
+go into it or come out of it except at night; he did not know any
+particular reason for this state of things; had had some little
+curiosity, but it was rather feeble; had made the most of the mystery
+by entertaining himself with the idea that that room was “ha’nted”; had
+noticed that there was a light in there the night before.
+
+“That’s what I’ve found out, Huck. I reckon that’s the very No. 2 we’re
+after.”
+
+“I reckon it is, Tom. Now what you going to do?”
+
+“Lemme think.”
+
+Tom thought a long time. Then he said:
+
+“I’ll tell you. The back door of that No. 2 is the door that comes out
+into that little close alley between the tavern and the old rattle trap
+of a brick store. Now you get hold of all the doorkeys you can find, and
+I’ll nip all of auntie’s, and the first dark night we’ll go there and
+try ‘em. And mind you, keep a lookout for Injun Joe, because he said he
+was going to drop into town and spy around once more for a chance to get
+his revenge. If you see him, you just follow him; and if he don’t go to
+that No. 2, that ain’t the place.”
+
+“Lordy, I don’t want to foller him by myself!”
+
+“Why, it’ll be night, sure. He mightn’t ever see you--and if he did,
+maybe he’d never think anything.”
+
+“Well, if it’s pretty dark I reckon I’ll track him. I dono--I dono. I’ll
+try.”
+
+“You bet I’ll follow him, if it’s dark, Huck. Why, he might ‘a’ found
+out he couldn’t get his revenge, and be going right after that money.”
+
+“It’s so, Tom, it’s so. I’ll foller him; I will, by jingoes!”
+
+“Now you’re _talking_! Don’t you ever weaken, Huck, and I won’t.”
+
+
+
+
+CHAPTER XXVIII
+
+THAT night Tom and Huck were ready for their adventure. They hung about
+the neighborhood of the tavern until after nine, one watching the alley
+at a distance and the other the tavern door. Nobody entered the alley or
+left it; nobody resembling the Spaniard entered or left the tavern
+door. The night promised to be a fair one; so Tom went home with the
+understanding that if a considerable degree of darkness came on, Huck
+was to come and “maow,” whereupon he would slip out and try the keys.
+But the night remained clear, and Huck closed his watch and retired to
+bed in an empty sugar hogshead about twelve.
+
+Tuesday the boys had the same ill luck. Also Wednesday. But Thursday
+night promised better. Tom slipped out in good season with his aunt’s
+old tin lantern, and a large towel to blindfold it with. He hid the
+lantern in Huck’s sugar hogshead and the watch began. An hour before
+midnight the tavern closed up and its lights (the only ones thereabouts)
+were put out. No Spaniard had been seen. Nobody had entered or left the
+alley. Everything was auspicious. The blackness of darkness reigned,
+the perfect stillness was interrupted only by occasional mutterings of
+distant thunder.
+
+Tom got his lantern, lit it in the hogshead, wrapped it closely in the
+towel, and the two adventurers crept in the gloom toward the tavern.
+Huck stood sentry and Tom felt his way into the alley. Then there was
+a season of waiting anxiety that weighed upon Huck’s spirits like a
+mountain. He began to wish he could see a flash from the lantern--it
+would frighten him, but it would at least tell him that Tom was alive
+yet. It seemed hours since Tom had disappeared. Surely he must have
+fainted; maybe he was dead; maybe his heart had burst under terror and
+excitement. In his uneasiness Huck found himself drawing closer
+and closer to the alley; fearing all sorts of dreadful things, and
+momentarily expecting some catastrophe to happen that would take away
+his breath. There was not much to take away, for he seemed only able to
+inhale it by thimblefuls, and his heart would soon wear itself out, the
+way it was beating. Suddenly there was a flash of light and Tom came
+tearing by him: “Run!” said he; “run, for your life!”
+
+He needn’t have repeated it; once was enough; Huck was making thirty or
+forty miles an hour before the repetition was uttered. The boys never
+stopped till they reached the shed of a deserted slaughter-house at the
+lower end of the village. Just as they got within its shelter the storm
+burst and the rain poured down. As soon as Tom got his breath he said:
+
+“Huck, it was awful! I tried two of the keys, just as soft as I could;
+but they seemed to make such a power of racket that I couldn’t hardly
+get my breath I was so scared. They wouldn’t turn in the lock, either.
+Well, without noticing what I was doing, I took hold of the knob, and
+open comes the door! It warn’t locked! I hopped in, and shook off the
+towel, and, _Great Caesar’s Ghost!_”
+
+“What!--what’d you see, Tom?”
+
+“Huck, I most stepped onto Injun Joe’s hand!”
+
+“No!”
+
+“Yes! He was lying there, sound asleep on the floor, with his old patch
+on his eye and his arms spread out.”
+
+“Lordy, what did you do? Did he wake up?”
+
+“No, never budged. Drunk, I reckon. I just grabbed that towel and
+started!”
+
+“I’d never ‘a’ thought of the towel, I bet!”
+
+“Well, I would. My aunt would make me mighty sick if I lost it.”
+
+“Say, Tom, did you see that box?”
+
+“Huck, I didn’t wait to look around. I didn’t see the box, I didn’t see
+the cross. I didn’t see anything but a bottle and a tin cup on the floor
+by Injun Joe; yes, I saw two barrels and lots more bottles in the room.
+Don’t you see, now, what’s the matter with that ha’nted room?”
+
+“How?”
+
+“Why, it’s ha’nted with whiskey! Maybe _all_ the Temperance Taverns have
+got a ha’nted room, hey, Huck?”
+
+“Well, I reckon maybe that’s so. Who’d ‘a’ thought such a thing? But
+say, Tom, now’s a mighty good time to get that box, if Injun Joe’s
+drunk.”
+
+“It is, that! You try it!”
+
+Huck shuddered.
+
+“Well, no--I reckon not.”
+
+“And I reckon not, Huck. Only one bottle alongside of Injun Joe ain’t
+enough. If there’d been three, he’d be drunk enough and I’d do it.”
+
+There was a long pause for reflection, and then Tom said:
+
+“Lookyhere, Huck, less not try that thing any more till we know Injun
+Joe’s not in there. It’s too scary. Now, if we watch every night, we’ll
+be dead sure to see him go out, some time or other, and then we’ll
+snatch that box quicker’n lightning.”
+
+“Well, I’m agreed. I’ll watch the whole night long, and I’ll do it every
+night, too, if you’ll do the other part of the job.”
+
+“All right, I will. All you got to do is to trot up Hooper Street a
+block and maow--and if I’m asleep, you throw some gravel at the window
+and that’ll fetch me.”
+
+“Agreed, and good as wheat!”
+
+“Now, Huck, the storm’s over, and I’ll go home. It’ll begin to be
+daylight in a couple of hours. You go back and watch that long, will
+you?”
+
+“I said I would, Tom, and I will. I’ll ha’nt that tavern every night for
+a year! I’ll sleep all day and I’ll stand watch all night.”
+
+“That’s all right. Now, where you going to sleep?”
+
+“In Ben Rogers’ hayloft. He lets me, and so does his pap’s nigger man,
+Uncle Jake. I tote water for Uncle Jake whenever he wants me to, and any
+time I ask him he gives me a little something to eat if he can spare it.
+That’s a mighty good nigger, Tom. He likes me, becuz I don’t ever act as
+if I was above him. Sometime I’ve set right down and eat _with_ him. But
+you needn’t tell that. A body’s got to do things when he’s awful hungry
+he wouldn’t want to do as a steady thing.”
+
+“Well, if I don’t want you in the daytime, I’ll let you sleep. I won’t
+come bothering around. Any time you see something’s up, in the night,
+just skip right around and maow.”
+
+
+
+
+CHAPTER XXIX
+
+THE first thing Tom heard on Friday morning was a glad piece of
+news--Judge Thatcher’s family had come back to town the night before.
+Both Injun Joe and the treasure sunk into secondary importance for a
+moment, and Becky took the chief place in the boy’s interest. He saw her
+and they had an exhausting good time playing “hispy” and “gully-keeper”
+ with a crowd of their schoolmates. The day was completed and crowned in
+a peculiarly satisfactory way: Becky teased her mother to appoint
+the next day for the long-promised and long-delayed picnic, and she
+consented. The child’s delight was boundless; and Tom’s not more
+moderate. The invitations were sent out before sunset, and straightway
+the young folks of the village were thrown into a fever of preparation
+and pleasurable anticipation. Tom’s excitement enabled him to keep
+awake until a pretty late hour, and he had good hopes of hearing Huck’s
+“maow,” and of having his treasure to astonish Becky and the picnickers
+with, next day; but he was disappointed. No signal came that night.
+
+Morning came, eventually, and by ten or eleven o’clock a giddy and
+rollicking company were gathered at Judge Thatcher’s, and everything was
+ready for a start. It was not the custom for elderly people to mar the
+picnics with their presence. The children were considered safe enough
+under the wings of a few young ladies of eighteen and a few young
+gentlemen of twenty-three or thereabouts. The old steam ferry-boat was
+chartered for the occasion; presently the gay throng filed up the main
+street laden with provision-baskets. Sid was sick and had to miss
+the fun; Mary remained at home to entertain him. The last thing Mrs.
+Thatcher said to Becky, was:
+
+“You’ll not get back till late. Perhaps you’d better stay all night with
+some of the girls that live near the ferry-landing, child.”
+
+“Then I’ll stay with Susy Harper, mamma.”
+
+“Very well. And mind and behave yourself and don’t be any trouble.”
+
+Presently, as they tripped along, Tom said to Becky:
+
+“Say--I’ll tell you what we’ll do. ‘Stead of going to Joe Harper’s we’ll
+climb right up the hill and stop at the Widow Douglas’. She’ll have
+ice-cream! She has it most every day--dead loads of it. And she’ll be
+awful glad to have us.”
+
+“Oh, that will be fun!”
+
+Then Becky reflected a moment and said:
+
+“But what will mamma say?”
+
+“How’ll she ever know?”
+
+The girl turned the idea over in her mind, and said reluctantly:
+
+“I reckon it’s wrong--but--”
+
+“But shucks! Your mother won’t know, and so what’s the harm? All she
+wants is that you’ll be safe; and I bet you she’d ‘a’ said go there if
+she’d ‘a’ thought of it. I know she would!”
+
+The Widow Douglas’ splendid hospitality was a tempting bait. It and
+Tom’s persuasions presently carried the day. So it was decided to say
+nothing to anybody about the night’s programme. Presently it occurred to
+Tom that maybe Huck might come this very night and give the signal. The
+thought took a deal of the spirit out of his anticipations. Still he
+could not bear to give up the fun at Widow Douglas’. And why should he
+give it up, he reasoned--the signal did not come the night before, so
+why should it be any more likely to come tonight? The sure fun of the
+evening outweighed the uncertain treasure; and, boy-like, he determined
+to yield to the stronger inclination and not allow himself to think of
+the box of money another time that day.
+
+Three miles below town the ferryboat stopped at the mouth of a woody
+hollow and tied up. The crowd swarmed ashore and soon the forest
+distances and craggy heights echoed far and near with shoutings and
+laughter. All the different ways of getting hot and tired were gone
+through with, and by-and-by the rovers straggled back to camp fortified
+with responsible appetites, and then the destruction of the good things
+began. After the feast there was a refreshing season of rest and chat in
+the shade of spreading oaks. By-and-by somebody shouted:
+
+“Who’s ready for the cave?”
+
+Everybody was. Bundles of candles were procured, and straightway there
+was a general scamper up the hill. The mouth of the cave was up the
+hillside--an opening shaped like a letter A. Its massive oaken door stood
+unbarred. Within was a small chamber, chilly as an icehouse, and walled
+by Nature with solid limestone that was dewy with a cold sweat. It was
+romantic and mysterious to stand here in the deep gloom and look out
+upon the green valley shining in the sun. But the impressiveness of the
+situation quickly wore off, and the romping began again. The moment
+a candle was lighted there was a general rush upon the owner of it; a
+struggle and a gallant defence followed, but the candle was soon knocked
+down or blown out, and then there was a glad clamor of laughter and a
+new chase. But all things have an end. By-and-by the procession went
+filing down the steep descent of the main avenue, the flickering rank of
+lights dimly revealing the lofty walls of rock almost to their point of
+junction sixty feet overhead. This main avenue was not more than
+eight or ten feet wide. Every few steps other lofty and still narrower
+crevices branched from it on either hand--for McDougal’s cave was but a
+vast labyrinth of crooked aisles that ran into each other and out again
+and led nowhere. It was said that one might wander days and nights
+together through its intricate tangle of rifts and chasms, and never
+find the end of the cave; and that he might go down, and down, and
+still down, into the earth, and it was just the same--labyrinth under
+labyrinth, and no end to any of them. No man “knew” the cave. That was
+an impossible thing. Most of the young men knew a portion of it, and it
+was not customary to venture much beyond this known portion. Tom Sawyer
+knew as much of the cave as any one.
+
+The procession moved along the main avenue some three-quarters of
+a mile, and then groups and couples began to slip aside into branch
+avenues, fly along the dismal corridors, and take each other by surprise
+at points where the corridors joined again. Parties were able to elude
+each other for the space of half an hour without going beyond the
+“known” ground.
+
+By-and-by, one group after another came straggling back to the mouth
+of the cave, panting, hilarious, smeared from head to foot with tallow
+drippings, daubed with clay, and entirely delighted with the success of
+the day. Then they were astonished to find that they had been taking
+no note of time and that night was about at hand. The clanging bell had
+been calling for half an hour. However, this sort of close to the day’s
+adventures was romantic and therefore satisfactory. When the ferryboat
+with her wild freight pushed into the stream, nobody cared sixpence for
+the wasted time but the captain of the craft.
+
+Huck was already upon his watch when the ferryboat’s lights went
+glinting past the wharf. He heard no noise on board, for the young
+people were as subdued and still as people usually are who are nearly
+tired to death. He wondered what boat it was, and why she did not
+stop at the wharf--and then he dropped her out of his mind and put his
+attention upon his business. The night was growing cloudy and dark. Ten
+o’clock came, and the noise of vehicles ceased, scattered lights began
+to wink out, all straggling foot-passengers disappeared, the village
+betook itself to its slumbers and left the small watcher alone with the
+silence and the ghosts. Eleven o’clock came, and the tavern lights were
+put out; darkness everywhere, now. Huck waited what seemed a weary long
+time, but nothing happened. His faith was weakening. Was there any use?
+Was there really any use? Why not give it up and turn in?
+
+A noise fell upon his ear. He was all attention in an instant. The alley
+door closed softly. He sprang to the corner of the brick store. The next
+moment two men brushed by him, and one seemed to have something under
+his arm. It must be that box! So they were going to remove the treasure.
+Why call Tom now? It would be absurd--the men would get away with the box
+and never be found again. No, he would stick to their wake and follow
+them; he would trust to the darkness for security from discovery. So
+communing with himself, Huck stepped out and glided along behind the
+men, cat-like, with bare feet, allowing them to keep just far enough
+ahead not to be invisible.
+
+They moved up the river street three blocks, then turned to the left up
+a crossstreet. They went straight ahead, then, until they came to the
+path that led up Cardiff Hill; this they took. They passed by the old
+Welshman’s house, halfway up the hill, without hesitating, and still
+climbed upward. Good, thought Huck, they will bury it in the old quarry.
+But they never stopped at the quarry. They passed on, up the summit.
+They plunged into the narrow path between the tall sumach bushes, and
+were at once hidden in the gloom. Huck closed up and shortened his
+distance, now, for they would never be able to see him. He trotted along
+awhile; then slackened his pace, fearing he was gaining too fast; moved
+on a piece, then stopped altogether; listened; no sound; none, save that
+he seemed to hear the beating of his own heart. The hooting of an
+owl came over the hill--ominous sound! But no footsteps. Heavens, was
+everything lost! He was about to spring with winged feet, when a man
+cleared his throat not four feet from him! Huck’s heart shot into his
+throat, but he swallowed it again; and then he stood there shaking as
+if a dozen agues had taken charge of him at once, and so weak that he
+thought he must surely fall to the ground. He knew where he was. He
+knew he was within five steps of the stile leading into Widow Douglas’
+grounds. Very well, he thought, let them bury it there; it won’t be hard
+to find.
+
+Now there was a voice--a very low voice--Injun Joe’s:
+
+“Damn her, maybe she’s got company--there’s lights, late as it is.”
+
+“I can’t see any.”
+
+This was that stranger’s voice--the stranger of the haunted house. A
+deadly chill went to Huck’s heart--this, then, was the “revenge” job! His
+thought was, to fly. Then he remembered that the Widow Douglas had been
+kind to him more than once, and maybe these men were going to murder
+her. He wished he dared venture to warn her; but he knew he didn’t
+dare--they might come and catch him. He thought all this and more in
+the moment that elapsed between the stranger’s remark and Injun Joe’s
+next--which was--
+
+“Because the bush is in your way. Now--this way--now you see, don’t you?”
+
+“Yes. Well, there _is_ company there, I reckon. Better give it up.”
+
+“Give it up, and I just leaving this country forever! Give it up and
+maybe never have another chance. I tell you again, as I’ve told you
+before, I don’t care for her swag--you may have it. But her husband was
+rough on me--many times he was rough on me--and mainly he was the justice
+of the peace that jugged me for a vagrant. And that ain’t all. It ain’t
+a millionth part of it! He had me _horsewhipped_!--horsewhipped in
+front of the jail, like a nigger!--with all the town looking on!
+_Horsewhipped_!--do you understand? He took advantage of me and died. But
+I’ll take it out of _her_.”
+
+“Oh, don’t kill her! Don’t do that!”
+
+“Kill? Who said anything about killing? I would kill _him_ if he was
+here; but not her. When you want to get revenge on a woman you don’t
+kill her--bosh! you go for her looks. You slit her nostrils--you notch her
+ears like a sow!”
+
+“By God, that’s--”
+
+“Keep your opinion to yourself! It will be safest for you. I’ll tie her
+to the bed. If she bleeds to death, is that my fault? I’ll not cry, if
+she does. My friend, you’ll help me in this thing--for _my_ sake--that’s
+why you’re here--I mightn’t be able alone. If you flinch, I’ll kill you.
+Do you understand that? And if I have to kill you, I’ll kill her--and
+then I reckon nobody’ll ever know much about who done this business.”
+
+“Well, if it’s got to be done, let’s get at it. The quicker the
+better--I’m all in a shiver.”
+
+“Do it _now_? And company there? Look here--I’ll get suspicious of you,
+first thing you know. No--we’ll wait till the lights are out--there’s no
+hurry.”
+
+Huck felt that a silence was going to ensue--a thing still more awful
+than any amount of murderous talk; so he held his breath and stepped
+gingerly back; planted his foot carefully and firmly, after balancing,
+one-legged, in a precarious way and almost toppling over, first on one
+side and then on the other. He took another step back, with the same
+elaboration and the same risks; then another and another, and--a twig
+snapped under his foot! His breath stopped and he listened. There was no
+sound--the stillness was perfect. His gratitude was measureless. Now he
+turned in his tracks, between the walls of sumach bushes--turned
+himself as carefully as if he were a ship--and then stepped quickly but
+cautiously along. When he emerged at the quarry he felt secure, and
+so he picked up his nimble heels and flew. Down, down he sped, till he
+reached the Welshman’s. He banged at the door, and presently the heads
+of the old man and his two stalwart sons were thrust from windows.
+
+“What’s the row there? Who’s banging? What do you want?”
+
+“Let me in--quick! I’ll tell everything.”
+
+“Why, who are you?”
+
+“Huckleberry Finn--quick, let me in!”
+
+“Huckleberry Finn, indeed! It ain’t a name to open many doors, I judge!
+But let him in, lads, and let’s see what’s the trouble.”
+
+“Please don’t ever tell I told you,” were Huck’s first words when he got
+in. “Please don’t--I’d be killed, sure--but the widow’s been good friends
+to me sometimes, and I want to tell--I _will_ tell if you’ll promise you
+won’t ever say it was me.”
+
+“By George, he _has_ got something to tell, or he wouldn’t act so!”
+ exclaimed the old man; “out with it and nobody here’ll ever tell, lad.”
+
+Three minutes later the old man and his sons, well armed, were up the
+hill, and just entering the sumach path on tiptoe, their weapons in
+their hands. Huck accompanied them no further. He hid behind a great
+bowlder and fell to listening. There was a lagging, anxious silence, and
+then all of a sudden there was an explosion of firearms and a cry.
+
+Huck waited for no particulars. He sprang away and sped down the hill as
+fast as his legs could carry him.
+
+
+
+
+CHAPTER XXX
+
+AS the earliest suspicion of dawn appeared on Sunday morning, Huck came
+groping up the hill and rapped gently at the old Welshman’s door. The
+inmates were asleep, but it was a sleep that was set on a hair-trigger,
+on account of the exciting episode of the night. A call came from a
+window:
+
+“Who’s there!”
+
+Huck’s scared voice answered in a low tone:
+
+“Please let me in! It’s only Huck Finn!”
+
+“It’s a name that can open this door night or day, lad!--and welcome!”
+
+These were strange words to the vagabond boy’s ears, and the pleasantest
+he had ever heard. He could not recollect that the closing word had ever
+been applied in his case before. The door was quickly unlocked, and he
+entered. Huck was given a seat and the old man and his brace of tall
+sons speedily dressed themselves.
+
+“Now, my boy, I hope you’re good and hungry, because breakfast will be
+ready as soon as the sun’s up, and we’ll have a piping hot one, too--make
+yourself easy about that! I and the boys hoped you’d turn up and stop
+here last night.”
+
+“I was awful scared,” said Huck, “and I run. I took out when the pistols
+went off, and I didn’t stop for three mile. I’ve come now becuz I wanted
+to know about it, you know; and I come before daylight becuz I didn’t
+want to run across them devils, even if they was dead.”
+
+“Well, poor chap, you do look as if you’d had a hard night of it--but
+there’s a bed here for you when you’ve had your breakfast. No, they
+ain’t dead, lad--we are sorry enough for that. You see we knew right
+where to put our hands on them, by your description; so we crept along
+on tiptoe till we got within fifteen feet of them--dark as a cellar that
+sumach path was--and just then I found I was going to sneeze. It was the
+meanest kind of luck! I tried to keep it back, but no use--‘twas bound to
+come, and it did come! I was in the lead with my pistol raised, and when
+the sneeze started those scoundrels a-rustling to get out of the path,
+I sung out, ‘Fire boys!’ and blazed away at the place where the rustling
+was. So did the boys. But they were off in a jiffy, those villains, and
+we after them, down through the woods. I judge we never touched them.
+They fired a shot apiece as they started, but their bullets whizzed by
+and didn’t do us any harm. As soon as we lost the sound of their feet
+we quit chasing, and went down and stirred up the constables. They got a
+posse together, and went off to guard the river bank, and as soon as it
+is light the sheriff and a gang are going to beat up the woods. My boys
+will be with them presently. I wish we had some sort of description of
+those rascals--‘twould help a good deal. But you couldn’t see what they
+were like, in the dark, lad, I suppose?”
+
+“Oh yes; I saw them downtown and follered them.”
+
+“Splendid! Describe them--describe them, my boy!”
+
+“One’s the old deaf and dumb Spaniard that’s ben around here once or
+twice, and t’other’s a mean-looking, ragged--”
+
+“That’s enough, lad, we know the men! Happened on them in the woods back
+of the widow’s one day, and they slunk away. Off with you, boys, and
+tell the sheriff--get your breakfast tomorrow morning!”
+
+The Welshman’s sons departed at once. As they were leaving the room Huck
+sprang up and exclaimed:
+
+“Oh, please don’t tell _any_body it was me that blowed on them! Oh,
+please!”
+
+“All right if you say it, Huck, but you ought to have the credit of what
+you did.”
+
+“Oh no, no! Please don’t tell!”
+
+When the young men were gone, the old Welshman said:
+
+“They won’t tell--and I won’t. But why don’t you want it known?”
+
+Huck would not explain, further than to say that he already knew too
+much about one of those men and would not have the man know that he knew
+anything against him for the whole world--he would be killed for knowing
+it, sure.
+
+The old man promised secrecy once more, and said:
+
+“How did you come to follow these fellows, lad? Were they looking
+suspicious?”
+
+Huck was silent while he framed a duly cautious reply. Then he said:
+
+“Well, you see, I’m a kind of a hard lot,--least everybody says so, and
+I don’t see nothing agin it--and sometimes I can’t sleep much, on account
+of thinking about it and sort of trying to strike out a new way of
+doing. That was the way of it last night. I couldn’t sleep, and so I
+come along upstreet ‘bout midnight, a-turning it all over, and when I
+got to that old shackly brick store by the Temperance Tavern, I backed
+up agin the wall to have another think. Well, just then along comes
+these two chaps slipping along close by me, with something under their
+arm, and I reckoned they’d stole it. One was a-smoking, and t’other one
+wanted a light; so they stopped right before me and the cigars lit up
+their faces and I see that the big one was the deaf and dumb Spaniard,
+by his white whiskers and the patch on his eye, and t’other one was a
+rusty, ragged-looking devil.”
+
+“Could you see the rags by the light of the cigars?”
+
+This staggered Huck for a moment. Then he said:
+
+“Well, I don’t know--but somehow it seems as if I did.”
+
+“Then they went on, and you--”
+
+“Follered ‘em--yes. That was it. I wanted to see what was up--they sneaked
+along so. I dogged ‘em to the widder’s stile, and stood in the dark and
+heard the ragged one beg for the widder, and the Spaniard swear he’d
+spile her looks just as I told you and your two--”
+
+“What! The _deaf and dumb_ man said all that!”
+
+Huck had made another terrible mistake! He was trying his best to keep
+the old man from getting the faintest hint of who the Spaniard might be,
+and yet his tongue seemed determined to get him into trouble in spite of
+all he could do. He made several efforts to creep out of his scrape,
+but the old man’s eye was upon him and he made blunder after blunder.
+Presently the Welshman said:
+
+“My boy, don’t be afraid of me. I wouldn’t hurt a hair of your head for
+all the world. No--I’d protect you--I’d protect you. This Spaniard is
+not deaf and dumb; you’ve let that slip without intending it; you can’t
+cover that up now. You know something about that Spaniard that you want
+to keep dark. Now trust me--tell me what it is, and trust me--I won’t
+betray you.”
+
+Huck looked into the old man’s honest eyes a moment, then bent over and
+whispered in his ear:
+
+“‘Tain’t a Spaniard--it’s Injun Joe!”
+
+The Welshman almost jumped out of his chair. In a moment he said:
+
+“It’s all plain enough, now. When you talked about notching ears and
+slitting noses I judged that that was your own embellishment, because
+white men don’t take that sort of revenge. But an Injun! That’s a
+different matter altogether.”
+
+During breakfast the talk went on, and in the course of it the old man
+said that the last thing which he and his sons had done, before going
+to bed, was to get a lantern and examine the stile and its vicinity for
+marks of blood. They found none, but captured a bulky bundle of--
+
+“Of _what_?”
+
+If the words had been lightning they could not have leaped with a more
+stunning suddenness from Huck’s blanched lips. His eyes were staring
+wide, now, and his breath suspended--waiting for the answer. The Welshman
+started--stared in return--three seconds--five seconds--ten--then replied:
+
+“Of burglar’s tools. Why, what’s the _matter_ with you?”
+
+Huck sank back, panting gently, but deeply, unutterably grateful. The
+Welshman eyed him gravely, curiously--and presently said:
+
+“Yes, burglar’s tools. That appears to relieve you a good deal. But what
+did give you that turn? What were _you_ expecting we’d found?”
+
+Huck was in a close place--the inquiring eye was upon him--he would have
+given anything for material for a plausible answer--nothing suggested
+itself--the inquiring eye was boring deeper and deeper--a senseless
+reply offered--there was no time to weigh it, so at a venture he uttered
+it--feebly:
+
+“Sunday-school books, maybe.”
+
+Poor Huck was too distressed to smile, but the old man laughed loud and
+joyously, shook up the details of his anatomy from head to foot, and
+ended by saying that such a laugh was money in a-man’s pocket, because
+it cut down the doctor’s bill like everything. Then he added:
+
+“Poor old chap, you’re white and jaded--you ain’t well a bit--no wonder
+you’re a little flighty and off your balance. But you’ll come out of it.
+Rest and sleep will fetch you out all right, I hope.”
+
+Huck was irritated to think he had been such a goose and betrayed such
+a suspicious excitement, for he had dropped the idea that the parcel
+brought from the tavern was the treasure, as soon as he had heard the
+talk at the widow’s stile. He had only thought it was not the treasure,
+however--he had not known that it wasn’t--and so the suggestion of a
+captured bundle was too much for his self-possession. But on the whole
+he felt glad the little episode had happened, for now he knew beyond all
+question that that bundle was not _the_ bundle, and so his mind was
+at rest and exceedingly comfortable. In fact, everything seemed to be
+drifting just in the right direction, now; the treasure must be still
+in No. 2, the men would be captured and jailed that day, and he and
+Tom could seize the gold that night without any trouble or any fear of
+interruption.
+
+Just as breakfast was completed there was a knock at the door. Huck
+jumped for a hiding-place, for he had no mind to be connected even
+remotely with the late event. The Welshman admitted several ladies and
+gentlemen, among them the Widow Douglas, and noticed that groups of
+citizens were climbing up the hill--to stare at the stile. So the news
+had spread. The Welshman had to tell the story of the night to the
+visitors. The widow’s gratitude for her preservation was outspoken.
+
+“Don’t say a word about it, madam. There’s another that you’re more
+beholden to than you are to me and my boys, maybe, but he don’t allow me
+to tell his name. We wouldn’t have been there but for him.”
+
+Of course this excited a curiosity so vast that it almost belittled the
+main matter--but the Welshman allowed it to eat into the vitals of his
+visitors, and through them be transmitted to the whole town, for he
+refused to part with his secret. When all else had been learned, the
+widow said:
+
+“I went to sleep reading in bed and slept straight through all that
+noise. Why didn’t you come and wake me?”
+
+“We judged it warn’t worth while. Those fellows warn’t likely to come
+again--they hadn’t any tools left to work with, and what was the use of
+waking you up and scaring you to death? My three negro men stood guard
+at your house all the rest of the night. They’ve just come back.”
+
+More visitors came, and the story had to be told and retold for a couple
+of hours more.
+
+There was no Sabbath-school during day-school vacation, but everybody
+was early at church. The stirring event was well canvassed. News came
+that not a sign of the two villains had been yet discovered. When the
+sermon was finished, Judge Thatcher’s wife dropped alongside of Mrs.
+Harper as she moved down the aisle with the crowd and said:
+
+“Is my Becky going to sleep all day? I just expected she would be tired
+to death.”
+
+“Your Becky?”
+
+“Yes,” with a startled look--“didn’t she stay with you last night?”
+
+“Why, no.”
+
+Mrs. Thatcher turned pale, and sank into a pew, just as Aunt Polly,
+talking briskly with a friend, passed by. Aunt Polly said:
+
+“Goodmorning, Mrs. Thatcher. Goodmorning, Mrs. Harper. I’ve got a boy
+that’s turned up missing. I reckon my Tom stayed at your house last
+night--one of you. And now he’s afraid to come to church. I’ve got to
+settle with him.”
+
+Mrs. Thatcher shook her head feebly and turned paler than ever.
+
+“He didn’t stay with us,” said Mrs. Harper, beginning to look uneasy. A
+marked anxiety came into Aunt Polly’s face.
+
+“Joe Harper, have you seen my Tom this morning?”
+
+“No’m.”
+
+“When did you see him last?”
+
+Joe tried to remember, but was not sure he could say. The people had
+stopped moving out of church. Whispers passed along, and a boding
+uneasiness took possession of every countenance. Children were anxiously
+questioned, and young teachers. They all said they had not noticed
+whether Tom and Becky were on board the ferryboat on the homeward trip;
+it was dark; no one thought of inquiring if any one was missing. One
+young man finally blurted out his fear that they were still in the cave!
+Mrs. Thatcher swooned away. Aunt Polly fell to crying and wringing her
+hands.
+
+The alarm swept from lip to lip, from group to group, from street to
+street, and within five minutes the bells were wildly clanging and
+the whole town was up! The Cardiff Hill episode sank into instant
+insignificance, the burglars were forgotten, horses were saddled, skiffs
+were manned, the ferryboat ordered out, and before the horror was half
+an hour old, two hundred men were pouring down highroad and river toward
+the cave.
+
+All the long afternoon the village seemed empty and dead. Many women
+visited Aunt Polly and Mrs. Thatcher and tried to comfort them. They
+cried with them, too, and that was still better than words. All the
+tedious night the town waited for news; but when the morning dawned at
+last, all the word that came was, “Send more candles--and send food.”
+ Mrs. Thatcher was almost crazed; and Aunt Polly, also. Judge Thatcher
+sent messages of hope and encouragement from the cave, but they conveyed
+no real cheer.
+
+The old Welshman came home toward daylight, spattered with
+candle-grease, smeared with clay, and almost worn out. He found Huck
+still in the bed that had been provided for him, and delirious with
+fever. The physicians were all at the cave, so the Widow Douglas came
+and took charge of the patient. She said she would do her best by him,
+because, whether he was good, bad, or indifferent, he was the Lord’s,
+and nothing that was the Lord’s was a thing to be neglected. The
+Welshman said Huck had good spots in him, and the widow said:
+
+“You can depend on it. That’s the Lord’s mark. He don’t leave it off.
+He never does. Puts it somewhere on every creature that comes from his
+hands.”
+
+Early in the forenoon parties of jaded men began to straggle into the
+village, but the strongest of the citizens continued searching. All the
+news that could be gained was that remotenesses of the cavern were being
+ransacked that had never been visited before; that every corner and
+crevice was going to be thoroughly searched; that wherever one wandered
+through the maze of passages, lights were to be seen flitting hither
+and thither in the distance, and shoutings and pistol-shots sent their
+hollow reverberations to the ear down the sombre aisles. In one place,
+far from the section usually traversed by tourists, the names “BECKY &
+TOM” had been found traced upon the rocky wall with candle-smoke, and
+near at hand a grease-soiled bit of ribbon. Mrs. Thatcher recognized the
+ribbon and cried over it. She said it was the last relic she should ever
+have of her child; and that no other memorial of her could ever be so
+precious, because this one parted latest from the living body before the
+awful death came. Some said that now and then, in the cave, a far-away
+speck of light would glimmer, and then a glorious shout would burst
+forth and a score of men go trooping down the echoing aisle--and then a
+sickening disappointment always followed; the children were not there;
+it was only a searcher’s light.
+
+Three dreadful days and nights dragged their tedious hours along, and
+the village sank into a hopeless stupor. No one had heart for anything.
+The accidental discovery, just made, that the proprietor of the
+Temperance Tavern kept liquor on his premises, scarcely fluttered the
+public pulse, tremendous as the fact was. In a lucid interval, Huck
+feebly led up to the subject of taverns, and finally asked--dimly
+dreading the worst--if anything had been discovered at the Temperance
+Tavern since he had been ill.
+
+“Yes,” said the widow.
+
+Huck started up in bed, wildeyed:
+
+“What? What was it?”
+
+“Liquor!--and the place has been shut up. Lie down, child--what a turn you
+did give me!”
+
+“Only tell me just one thing--only just one--please! Was it Tom Sawyer
+that found it?”
+
+The widow burst into tears. “Hush, hush, child, hush! I’ve told you
+before, you must _not_ talk. You are very, very sick!”
+
+Then nothing but liquor had been found; there would have been a great
+powwow if it had been the gold. So the treasure was gone forever--gone
+forever! But what could she be crying about? Curious that she should
+cry.
+
+These thoughts worked their dim way through Huck’s mind, and under the
+weariness they gave him he fell asleep. The widow said to herself:
+
+“There--he’s asleep, poor wreck. Tom Sawyer find it! Pity but somebody
+could find Tom Sawyer! Ah, there ain’t many left, now, that’s got hope
+enough, or strength enough, either, to go on searching.”
+
+
+
+
+CHAPTER XXXI
+
+NOW to return to Tom and Becky’s share in the picnic. They tripped along
+the murky aisles with the rest of the company, visiting the familiar
+wonders of the cave--wonders dubbed with rather over-descriptive names,
+such as “The Drawing-Room,” “The Cathedral,” “Aladdin’s Palace,” and
+so on. Presently the hide-and-seek frolicking began, and Tom and Becky
+engaged in it with zeal until the exertion began to grow a trifle
+wearisome; then they wandered down a sinuous avenue holding their
+candles aloft and reading the tangled webwork of names, dates,
+postoffice addresses, and mottoes with which the rocky walls had been
+frescoed (in candle-smoke). Still drifting along and talking, they
+scarcely noticed that they were now in a part of the cave whose walls
+were not frescoed. They smoked their own names under an overhanging
+shelf and moved on. Presently they came to a place where a little stream
+of water, trickling over a ledge and carrying a limestone sediment with
+it, had, in the slow-dragging ages, formed a laced and ruffled Niagara
+in gleaming and imperishable stone. Tom squeezed his small body behind
+it in order to illuminate it for Becky’s gratification. He found that
+it curtained a sort of steep natural stairway which was enclosed between
+narrow walls, and at once the ambition to be a discoverer seized him.
+
+Becky responded to his call, and they made a smoke-mark for future
+guidance, and started upon their quest. They wound this way and that,
+far down into the secret depths of the cave, made another mark, and
+branched off in search of novelties to tell the upper world about. In
+one place they found a spacious cavern, from whose ceiling depended a
+multitude of shining stalactites of the length and circumference of
+a man’s leg; they walked all about it, wondering and admiring, and
+presently left it by one of the numerous passages that opened into
+it. This shortly brought them to a bewitching spring, whose basin was
+incrusted with a frostwork of glittering crystals; it was in the midst
+of a cavern whose walls were supported by many fantastic pillars which
+had been formed by the joining of great stalactites and stalagmites
+together, the result of the ceaseless water-drip of centuries. Under the
+roof vast knots of bats had packed themselves together, thousands in a
+bunch; the lights disturbed the creatures and they came flocking down by
+hundreds, squeaking and darting furiously at the candles. Tom knew their
+ways and the danger of this sort of conduct. He seized Becky’s hand and
+hurried her into the first corridor that offered; and none too soon, for
+a bat struck Becky’s light out with its wing while she was passing out
+of the cavern. The bats chased the children a good distance; but the
+fugitives plunged into every new passage that offered, and at last got
+rid of the perilous things. Tom found a subterranean lake, shortly,
+which stretched its dim length away until its shape was lost in the
+shadows. He wanted to explore its borders, but concluded that it would
+be best to sit down and rest awhile, first. Now, for the first time, the
+deep stillness of the place laid a clammy hand upon the spirits of the
+children. Becky said:
+
+“Why, I didn’t notice, but it seems ever so long since I heard any of
+the others.”
+
+“Come to think, Becky, we are away down below them--and I don’t know how
+far away north, or south, or east, or whichever it is. We couldn’t hear
+them here.”
+
+Becky grew apprehensive.
+
+“I wonder how long we’ve been down here, Tom? We better start back.”
+
+“Yes, I reckon we better. P’raps we better.”
+
+“Can you find the way, Tom? It’s all a mixed-up crookedness to me.”
+
+“I reckon I could find it--but then the bats. If they put our candles
+out it will be an awful fix. Let’s try some other way, so as not to go
+through there.”
+
+“Well. But I hope we won’t get lost. It would be so awful!” and the girl
+shuddered at the thought of the dreadful possibilities.
+
+They started through a corridor, and traversed it in silence a long
+way, glancing at each new opening, to see if there was anything familiar
+about the look of it; but they were all strange. Every time Tom made an
+examination, Becky would watch his face for an encouraging sign, and he
+would say cheerily:
+
+“Oh, it’s all right. This ain’t the one, but we’ll come to it right
+away!”
+
+But he felt less and less hopeful with each failure, and presently began
+to turn off into diverging avenues at sheer random, in desperate hope of
+finding the one that was wanted. He still said it was “all right,” but
+there was such a leaden dread at his heart that the words had lost their
+ring and sounded just as if he had said, “All is lost!” Becky clung to
+his side in an anguish of fear, and tried hard to keep back the tears,
+but they would come. At last she said:
+
+“Oh, Tom, never mind the bats, let’s go back that way! We seem to get
+worse and worse off all the time.”
+
+“Listen!” said he.
+
+Profound silence; silence so deep that even their breathings were
+conspicuous in the hush. Tom shouted. The call went echoing down
+the empty aisles and died out in the distance in a faint sound that
+resembled a ripple of mocking laughter.
+
+“Oh, don’t do it again, Tom, it is too horrid,” said Becky.
+
+“It is horrid, but I better, Becky; they might hear us, you know,” and
+he shouted again.
+
+The “might” was even a chillier horror than the ghostly laughter, it so
+confessed a perishing hope. The children stood still and listened; but
+there was no result. Tom turned upon the back track at once, and hurried
+his steps. It was but a little while before a certain indecision in his
+manner revealed another fearful fact to Becky--he could not find his way
+back!
+
+“Oh, Tom, you didn’t make any marks!”
+
+“Becky, I was such a fool! Such a fool! I never thought we might want to
+come back! No--I can’t find the way. It’s all mixed up.”
+
+“Tom, Tom, we’re lost! we’re lost! We never can get out of this awful
+place! Oh, why _did_ we ever leave the others!”
+
+She sank to the ground and burst into such a frenzy of crying that Tom
+was appalled with the idea that she might die, or lose her reason. He
+sat down by her and put his arms around her; she buried her face in
+his bosom, she clung to him, she poured out her terrors, her unavailing
+regrets, and the far echoes turned them all to jeering laughter. Tom
+begged her to pluck up hope again, and she said she could not. He fell
+to blaming and abusing himself for getting her into this miserable
+situation; this had a better effect. She said she would try to hope
+again, she would get up and follow wherever he might lead if only he
+would not talk like that any more. For he was no more to blame than she,
+she said.
+
+So they moved on again--aimlessly--simply at random--all they could do
+was to move, keep moving. For a little while, hope made a show of
+reviving--not with any reason to back it, but only because it is its
+nature to revive when the spring has not been taken out of it by age and
+familiarity with failure.
+
+By-and-by Tom took Becky’s candle and blew it out. This economy meant so
+much! Words were not needed. Becky understood, and her hope died again.
+She knew that Tom had a whole candle and three or four pieces in his
+pockets--yet he must economize.
+
+By-and-by, fatigue began to assert its claims; the children tried to pay
+attention, for it was dreadful to think of sitting down when time was
+grown to be so precious, moving, in some direction, in any direction,
+was at least progress and might bear fruit; but to sit down was to
+invite death and shorten its pursuit.
+
+At last Becky’s frail limbs refused to carry her farther. She sat down.
+Tom rested with her, and they talked of home, and the friends there,
+and the comfortable beds and, above all, the light! Becky cried, and Tom
+tried to think of some way of comforting her, but all his encouragements
+were grown thread-bare with use, and sounded like sarcasms. Fatigue bore
+so heavily upon Becky that she drowsed off to sleep. Tom was grateful.
+He sat looking into her drawn face and saw it grow smooth and natural
+under the influence of pleasant dreams; and by-and-by a smile dawned and
+rested there. The peaceful face reflected somewhat of peace and healing
+into his own spirit, and his thoughts wandered away to bygone times and
+dreamy memories. While he was deep in his musings, Becky woke up with a
+breezy little laugh--but it was stricken dead upon her lips, and a groan
+followed it.
+
+“Oh, how _could_ I sleep! I wish I never, never had waked! No! No, I
+don’t, Tom! Don’t look so! I won’t say it again.”
+
+“I’m glad you’ve slept, Becky; you’ll feel rested, now, and we’ll find
+the way out.”
+
+“We can try, Tom; but I’ve seen such a beautiful country in my dream. I
+reckon we are going there.”
+
+“Maybe not, maybe not. Cheer up, Becky, and let’s go on trying.”
+
+They rose up and wandered along, hand in hand and hopeless. They tried
+to estimate how long they had been in the cave, but all they knew was
+that it seemed days and weeks, and yet it was plain that this could not
+be, for their candles were not gone yet. A long time after this--they
+could not tell how long--Tom said they must go softly and listen for
+dripping water--they must find a spring. They found one presently, and
+Tom said it was time to rest again. Both were cruelly tired, yet Becky
+said she thought she could go a little farther. She was surprised to
+hear Tom dissent. She could not understand it. They sat down, and Tom
+fastened his candle to the wall in front of them with some clay. Thought
+was soon busy; nothing was said for some time. Then Becky broke the
+silence:
+
+“Tom, I am so hungry!”
+
+Tom took something out of his pocket.
+
+“Do you remember this?” said he.
+
+Becky almost smiled.
+
+“It’s our wedding-cake, Tom.”
+
+“Yes--I wish it was as big as a barrel, for it’s all we’ve got.”
+
+“I saved it from the picnic for us to dream on, Tom, the way grownup
+people do with wedding-cake--but it’ll be our--”
+
+She dropped the sentence where it was. Tom divided the cake and Becky
+ate with good appetite, while Tom nibbled at his moiety. There was
+abundance of cold water to finish the feast with. By-and-by Becky
+suggested that they move on again. Tom was silent a moment. Then he
+said:
+
+“Becky, can you bear it if I tell you something?”
+
+Becky’s face paled, but she thought she could.
+
+“Well, then, Becky, we must stay here, where there’s water to drink.
+That little piece is our last candle!”
+
+Becky gave loose to tears and wailings. Tom did what he could to comfort
+her, but with little effect. At length Becky said:
+
+“Tom!”
+
+“Well, Becky?”
+
+“They’ll miss us and hunt for us!”
+
+“Yes, they will! Certainly they will!”
+
+“Maybe they’re hunting for us now, Tom.”
+
+“Why, I reckon maybe they are. I hope they are.”
+
+“When would they miss us, Tom?”
+
+“When they get back to the boat, I reckon.”
+
+“Tom, it might be dark then--would they notice we hadn’t come?”
+
+“I don’t know. But anyway, your mother would miss you as soon as they
+got home.”
+
+A frightened look in Becky’s face brought Tom to his senses and he saw
+that he had made a blunder. Becky was not to have gone home that night!
+The children became silent and thoughtful. In a moment a new burst of
+grief from Becky showed Tom that the thing in his mind had struck hers
+also--that the Sabbath morning might be half spent before Mrs. Thatcher
+discovered that Becky was not at Mrs. Harper’s.
+
+The children fastened their eyes upon their bit of candle and watched it
+melt slowly and pitilessly away; saw the half inch of wick stand alone
+at last; saw the feeble flame rise and fall, climb the thin column of
+smoke, linger at its top a moment, and then--the horror of utter darkness
+reigned!
+
+How long afterward it was that Becky came to a slow consciousness that
+she was crying in Tom’s arms, neither could tell. All that they knew
+was, that after what seemed a mighty stretch of time, both awoke out of
+a dead stupor of sleep and resumed their miseries once more. Tom said
+it might be Sunday, now--maybe Monday. He tried to get Becky to talk, but
+her sorrows were too oppressive, all her hopes were gone. Tom said that
+they must have been missed long ago, and no doubt the search was going
+on. He would shout and maybe some one would come. He tried it; but in
+the darkness the distant echoes sounded so hideously that he tried it no
+more.
+
+The hours wasted away, and hunger came to torment the captives again. A
+portion of Tom’s half of the cake was left; they divided and ate it. But
+they seemed hungrier than before. The poor morsel of food only whetted
+desire.
+
+By-and-by Tom said:
+
+“SH! Did you hear that?”
+
+Both held their breath and listened. There was a sound like the
+faintest, far-off shout. Instantly Tom answered it, and leading Becky by
+the hand, started groping down the corridor in its direction. Presently
+he listened again; again the sound was heard, and apparently a little
+nearer.
+
+“It’s them!” said Tom; “they’re coming! Come along, Becky--we’re all
+right now!”
+
+The joy of the prisoners was almost overwhelming. Their speed was slow,
+however, because pitfalls were somewhat common, and had to be guarded
+against. They shortly came to one and had to stop. It might be three
+feet deep, it might be a hundred--there was no passing it at any rate.
+Tom got down on his breast and reached as far down as he could. No
+bottom. They must stay there and wait until the searchers came. They
+listened; evidently the distant shoutings were growing more distant!
+a moment or two more and they had gone altogether. The heart-sinking
+misery of it! Tom whooped until he was hoarse, but it was of no use. He
+talked hopefully to Becky; but an age of anxious waiting passed and no
+sounds came again.
+
+The children groped their way back to the spring. The weary time dragged
+on; they slept again, and awoke famished and woe-stricken. Tom believed
+it must be Tuesday by this time.
+
+Now an idea struck him. There were some side passages near at hand. It
+would be better to explore some of these than bear the weight of the
+heavy time in idleness. He took a kite-line from his pocket, tied it to
+a projection, and he and Becky started, Tom in the lead, unwinding the
+line as he groped along. At the end of twenty steps the corridor ended
+in a “jumping-off place.” Tom got down on his knees and felt below,
+and then as far around the corner as he could reach with his hands
+conveniently; he made an effort to stretch yet a little farther to the
+right, and at that moment, not twenty yards away, a human hand, holding
+a candle, appeared from behind a rock! Tom lifted up a glorious shout,
+and instantly that hand was followed by the body it belonged to--Injun
+Joe’s! Tom was paralyzed; he could not move. He was vastly gratified the
+next moment, to see the “Spaniard” take to his heels and get himself out
+of sight. Tom wondered that Joe had not recognized his voice and come
+over and killed him for testifying in court. But the echoes must have
+disguised the voice. Without doubt, that was it, he reasoned. Tom’s
+fright weakened every muscle in his body. He said to himself that if he
+had strength enough to get back to the spring he would stay there, and
+nothing should tempt him to run the risk of meeting Injun Joe again. He
+was careful to keep from Becky what it was he had seen. He told her he
+had only shouted “for luck.”
+
+But hunger and wretchedness rise superior to fears in the long run.
+Another tedious wait at the spring and another long sleep brought
+changes. The children awoke tortured with a raging hunger. Tom believed
+that it must be Wednesday or Thursday or even Friday or Saturday, now,
+and that the search had been given over. He proposed to explore another
+passage. He felt willing to risk Injun Joe and all other terrors. But
+Becky was very weak. She had sunk into a dreary apathy and would not be
+roused. She said she would wait, now, where she was, and die--it would
+not be long. She told Tom to go with the kite-line and explore if he
+chose; but she implored him to come back every little while and speak
+to her; and she made him promise that when the awful time came, he would
+stay by her and hold her hand until all was over.
+
+Tom kissed her, with a choking sensation in his throat, and made a show
+of being confident of finding the searchers or an escape from the cave;
+then he took the kite-line in his hand and went groping down one of the
+passages on his hands and knees, distressed with hunger and sick with
+bodings of coming doom.
+
+
+
+
+CHAPTER XXXII
+
+TUESDAY afternoon came, and waned to the twilight. The village of St.
+Petersburg still mourned. The lost children had not been found. Public
+prayers had been offered up for them, and many and many a private prayer
+that had the petitioner’s whole heart in it; but still no good news came
+from the cave. The majority of the searchers had given up the quest
+and gone back to their daily avocations, saying that it was plain the
+children could never be found. Mrs. Thatcher was very ill, and a great
+part of the time delirious. People said it was heartbreaking to hear her
+call her child, and raise her head and listen a whole minute at a time,
+then lay it wearily down again with a moan. Aunt Polly had drooped into
+a settled melancholy, and her gray hair had grown almost white. The
+village went to its rest on Tuesday night, sad and forlorn.
+
+Away in the middle of the night a wild peal burst from the village
+bells, and in a moment the streets were swarming with frantic half-clad
+people, who shouted, “Turn out! turn out! they’re found! they’re found!”
+ Tin pans and horns were added to the din, the population massed itself
+and moved toward the river, met the children coming in an open carriage
+drawn by shouting citizens, thronged around it, joined its homeward
+march, and swept magnificently up the main street roaring huzzah after
+huzzah!
+
+The village was illuminated; nobody went to bed again; it was the
+greatest night the little town had ever seen. During the first half-hour
+a procession of villagers filed through Judge Thatcher’s house, seized
+the saved ones and kissed them, squeezed Mrs. Thatcher’s hand, tried to
+speak but couldn’t--and drifted out raining tears all over the place.
+
+Aunt Polly’s happiness was complete, and Mrs. Thatcher’s nearly so. It
+would be complete, however, as soon as the messenger dispatched with the
+great news to the cave should get the word to her husband. Tom lay upon
+a sofa with an eager auditory about him and told the history of the
+wonderful adventure, putting in many striking additions to adorn it
+withal; and closed with a description of how he left Becky and went
+on an exploring expedition; how he followed two avenues as far as his
+kite-line would reach; how he followed a third to the fullest stretch
+of the kite-line, and was about to turn back when he glimpsed a far-off
+speck that looked like daylight; dropped the line and groped toward it,
+pushed his head and shoulders through a small hole, and saw the broad
+Mississippi rolling by!
+
+And if it had only happened to be night he would not have seen that
+speck of daylight and would not have explored that passage any more! He
+told how he went back for Becky and broke the good news and she told
+him not to fret her with such stuff, for she was tired, and knew she was
+going to die, and wanted to. He described how he labored with her and
+convinced her; and how she almost died for joy when she had groped to
+where she actually saw the blue speck of daylight; how he pushed his way
+out at the hole and then helped her out; how they sat there and cried
+for gladness; how some men came along in a skiff and Tom hailed them
+and told them their situation and their famished condition; how the men
+didn’t believe the wild tale at first, “because,” said they, “you are
+five miles down the river below the valley the cave is in”--then took
+them aboard, rowed to a house, gave them supper, made them rest till two
+or three hours after dark and then brought them home.
+
+Before day-dawn, Judge Thatcher and the handful of searchers with him
+were tracked out, in the cave, by the twine clews they had strung behind
+them, and informed of the great news.
+
+Three days and nights of toil and hunger in the cave were not to
+be shaken off at once, as Tom and Becky soon discovered. They were
+bedridden all of Wednesday and Thursday, and seemed to grow more and
+more tired and worn, all the time. Tom got about, a little, on Thursday,
+was downtown Friday, and nearly as whole as ever Saturday; but Becky
+did not leave her room until Sunday, and then she looked as if she had
+passed through a wasting illness.
+
+Tom learned of Huck’s sickness and went to see him on Friday, but could
+not be admitted to the bedroom; neither could he on Saturday or Sunday.
+He was admitted daily after that, but was warned to keep still about his
+adventure and introduce no exciting topic. The Widow Douglas stayed by
+to see that he obeyed. At home Tom learned of the Cardiff Hill event;
+also that the “ragged man’s” body had eventually been found in the river
+near the ferry-landing; he had been drowned while trying to escape,
+perhaps.
+
+About a fortnight after Tom’s rescue from the cave, he started off to
+visit Huck, who had grown plenty strong enough, now, to hear exciting
+talk, and Tom had some that would interest him, he thought. Judge
+Thatcher’s house was on Tom’s way, and he stopped to see Becky. The
+Judge and some friends set Tom to talking, and some one asked him
+ironically if he wouldn’t like to go to the cave again. Tom said he
+thought he wouldn’t mind it. The Judge said:
+
+“Well, there are others just like you, Tom, I’ve not the least doubt.
+But we have taken care of that. Nobody will get lost in that cave any
+more.”
+
+“Why?”
+
+“Because I had its big door sheathed with boiler iron two weeks ago, and
+triple-locked--and I’ve got the keys.”
+
+Tom turned as white as a sheet.
+
+“What’s the matter, boy! Here, run, somebody! Fetch a glass of water!”
+
+The water was brought and thrown into Tom’s face.
+
+“Ah, now you’re all right. What was the matter with you, Tom?”
+
+“Oh, Judge, Injun Joe’s in the cave!”
+
+
+
+
+CHAPTER XXXIII
+
+WITHIN a few minutes the news had spread, and a dozen skiff-loads of
+men were on their way to McDougal’s cave, and the ferryboat, well filled
+with passengers, soon followed. Tom Sawyer was in the skiff that bore
+Judge Thatcher.
+
+When the cave door was unlocked, a sorrowful sight presented itself in
+the dim twilight of the place. Injun Joe lay stretched upon the ground,
+dead, with his face close to the crack of the door, as if his longing
+eyes had been fixed, to the latest moment, upon the light and the cheer
+of the free world outside. Tom was touched, for he knew by his own
+experience how this wretch had suffered. His pity was moved, but
+nevertheless he felt an abounding sense of relief and security, now,
+which revealed to him in a degree which he had not fully appreciated
+before how vast a weight of dread had been lying upon him since the day
+he lifted his voice against this bloody-minded outcast.
+
+Injun Joe’s bowie-knife lay close by, its blade broken in two. The great
+foundation-beam of the door had been chipped and hacked through, with
+tedious labor; useless labor, too, it was, for the native rock formed a
+sill outside it, and upon that stubborn material the knife had wrought
+no effect; the only damage done was to the knife itself. But if there
+had been no stony obstruction there the labor would have been useless
+still, for if the beam had been wholly cut away Injun Joe could not have
+squeezed his body under the door, and he knew it. So he had only hacked
+that place in order to be doing something--in order to pass the weary
+time--in order to employ his tortured faculties. Ordinarily one could
+find half a dozen bits of candle stuck around in the crevices of this
+vestibule, left there by tourists; but there were none now. The prisoner
+had searched them out and eaten them. He had also contrived to catch a
+few bats, and these, also, he had eaten, leaving only their claws. The
+poor unfortunate had starved to death. In one place, near at hand, a
+stalagmite had been slowly growing up from the ground for ages, builded
+by the water-drip from a stalactite overhead. The captive had broken off
+the stalagmite, and upon the stump had placed a stone, wherein he had
+scooped a shallow hollow to catch the precious drop that fell once
+in every three minutes with the dreary regularity of a clock-tick--a
+dessertspoonful once in four and twenty hours. That drop was falling
+when the Pyramids were new; when Troy fell; when the foundations of Rome
+were laid; when Christ was crucified; when the Conqueror created the
+British empire; when Columbus sailed; when the massacre at Lexington was
+“news.”
+
+It is falling now; it will still be falling when all these things shall
+have sunk down the afternoon of history, and the twilight of tradition,
+and been swallowed up in the thick night of oblivion. Has everything a
+purpose and a mission? Did this drop fall patiently during five thousand
+years to be ready for this flitting human insect’s need? and has it
+another important object to accomplish ten thousand years to come? No
+matter. It is many and many a year since the hapless half-breed scooped
+out the stone to catch the priceless drops, but to this day the tourist
+stares longest at that pathetic stone and that slow-dropping water when
+he comes to see the wonders of McDougal’s cave. Injun Joe’s cup stands
+first in the list of the cavern’s marvels; even “Aladdin’s Palace”
+ cannot rival it.
+
+Injun Joe was buried near the mouth of the cave; and people flocked
+there in boats and wagons from the towns and from all the farms and
+hamlets for seven miles around; they brought their children, and
+all sorts of provisions, and confessed that they had had almost as
+satisfactory a time at the funeral as they could have had at the
+hanging.
+
+This funeral stopped the further growth of one thing--the petition to the
+governor for Injun Joe’s pardon. The petition had been largely signed;
+many tearful and eloquent meetings had been held, and a committee of
+sappy women been appointed to go in deep mourning and wail around the
+governor, and implore him to be a merciful ass and trample his duty
+under foot. Injun Joe was believed to have killed five citizens of the
+village, but what of that? If he had been Satan himself there would
+have been plenty of weaklings ready to scribble their names to a
+pardon-petition, and drip a tear on it from their permanently impaired
+and leaky water-works.
+
+The morning after the funeral Tom took Huck to a private place to have
+an important talk. Huck had learned all about Tom’s adventure from the
+Welshman and the Widow Douglas, by this time, but Tom said he reckoned
+there was one thing they had not told him; that thing was what he wanted
+to talk about now. Huck’s face saddened. He said:
+
+“I know what it is. You got into No. 2 and never found anything but
+whiskey. Nobody told me it was you; but I just knowed it must ‘a’ ben
+you, soon as I heard ‘bout that whiskey business; and I knowed you
+hadn’t got the money becuz you’d ‘a’ got at me some way or other and
+told me even if you was mum to everybody else. Tom, something’s always
+told me we’d never get holt of that swag.”
+
+“Why, Huck, I never told on that tavern-keeper. _You_ know his tavern
+was all right the Saturday I went to the picnic. Don’t you remember you
+was to watch there that night?”
+
+“Oh yes! Why, it seems ‘bout a year ago. It was that very night that I
+follered Injun Joe to the widder’s.”
+
+“_You_ followed him?”
+
+“Yes--but you keep mum. I reckon Injun Joe’s left friends behind him, and
+I don’t want ‘em souring on me and doing me mean tricks. If it hadn’t
+ben for me he’d be down in Texas now, all right.”
+
+Then Huck told his entire adventure in confidence to Tom, who had only
+heard of the Welshman’s part of it before.
+
+“Well,” said Huck, presently, coming back to the main question, “whoever
+nipped the whiskey in No. 2, nipped the money, too, I reckon--anyways
+it’s a goner for us, Tom.”
+
+“Huck, that money wasn’t ever in No. 2!”
+
+“What!” Huck searched his comrade’s face keenly. “Tom, have you got on
+the track of that money again?”
+
+“Huck, it’s in the cave!”
+
+Huck’s eyes blazed.
+
+“Say it again, Tom.”
+
+“The money’s in the cave!”
+
+“Tom--honest injun, now--is it fun, or earnest?”
+
+“Earnest, Huck--just as earnest as ever I was in my life. Will you go in
+there with me and help get it out?”
+
+“I bet I will! I will if it’s where we can blaze our way to it and not
+get lost.”
+
+“Huck, we can do that without the least little bit of trouble in the
+world.”
+
+“Good as wheat! What makes you think the money’s--”
+
+“Huck, you just wait till we get in there. If we don’t find it I’ll
+agree to give you my drum and every thing I’ve got in the world. I will,
+by jings.”
+
+“All right--it’s a whiz. When do you say?”
+
+“Right now, if you say it. Are you strong enough?”
+
+“Is it far in the cave? I ben on my pins a little, three or four days,
+now, but I can’t walk more’n a mile, Tom--least I don’t think I could.”
+
+“It’s about five mile into there the way anybody but me would go, Huck,
+but there’s a mighty short cut that they don’t anybody but me know
+about. Huck, I’ll take you right to it in a skiff. I’ll float the skiff
+down there, and I’ll pull it back again all by myself. You needn’t ever
+turn your hand over.”
+
+“Less start right off, Tom.”
+
+“All right. We want some bread and meat, and our pipes, and a little
+bag or two, and two or three kite-strings, and some of these new-fangled
+things they call lucifer matches. I tell you, many’s the time I wished I
+had some when I was in there before.”
+
+A trifle after noon the boys borrowed a small skiff from a citizen who
+was absent, and got under way at once. When they were several miles
+below “Cave Hollow,” Tom said:
+
+“Now you see this bluff here looks all alike all the way down from the
+cave hollow--no houses, no wood-yards, bushes all alike. But do you see
+that white place up yonder where there’s been a landslide? Well, that’s
+one of my marks. We’ll get ashore, now.”
+
+They landed.
+
+“Now, Huck, where we’re a-standing you could touch that hole I got out
+of with a fishing-pole. See if you can find it.”
+
+Huck searched all the place about, and found nothing. Tom proudly
+marched into a thick clump of sumach bushes and said:
+
+“Here you are! Look at it, Huck; it’s the snuggest hole in this country.
+You just keep mum about it. All along I’ve been wanting to be a robber,
+but I knew I’d got to have a thing like this, and where to run across
+it was the bother. We’ve got it now, and we’ll keep it quiet, only we’ll
+let Joe Harper and Ben Rogers in--because of course there’s got to be a
+Gang, or else there wouldn’t be any style about it. Tom Sawyer’s Gang--it
+sounds splendid, don’t it, Huck?”
+
+“Well, it just does, Tom. And who’ll we rob?”
+
+“Oh, most anybody. Waylay people--that’s mostly the way.”
+
+“And kill them?”
+
+“No, not always. Hive them in the cave till they raise a ransom.”
+
+“What’s a ransom?”
+
+“Money. You make them raise all they can, off’n their friends; and after
+you’ve kept them a year, if it ain’t raised then you kill them. That’s
+the general way. Only you don’t kill the women. You shut up the women,
+but you don’t kill them. They’re always beautiful and rich, and awfully
+scared. You take their watches and things, but you always take your hat
+off and talk polite. They ain’t anybody as polite as robbers--you’ll see
+that in any book. Well, the women get to loving you, and after they’ve
+been in the cave a week or two weeks they stop crying and after that
+you couldn’t get them to leave. If you drove them out they’d turn right
+around and come back. It’s so in all the books.”
+
+“Why, it’s real bully, Tom. I believe it’s better’n to be a pirate.”
+
+“Yes, it’s better in some ways, because it’s close to home and circuses
+and all that.”
+
+By this time everything was ready and the boys entered the hole, Tom in
+the lead. They toiled their way to the farther end of the tunnel, then
+made their spliced kite-strings fast and moved on. A few steps brought
+them to the spring, and Tom felt a shudder quiver all through him.
+He showed Huck the fragment of candle-wick perched on a lump of clay
+against the wall, and described how he and Becky had watched the flame
+struggle and expire.
+
+The boys began to quiet down to whispers, now, for the stillness and
+gloom of the place oppressed their spirits. They went on, and presently
+entered and followed Tom’s other corridor until they reached the
+“jumping-off place.” The candles revealed the fact that it was not
+really a precipice, but only a steep clay hill twenty or thirty feet
+high. Tom whispered:
+
+“Now I’ll show you something, Huck.”
+
+He held his candle aloft and said:
+
+“Look as far around the corner as you can. Do you see that? There--on the
+big rock over yonder--done with candle-smoke.”
+
+“Tom, it’s a _cross_!”
+
+“_Now_ where’s your Number Two? ‘_under the cross_,’ hey? Right yonder’s
+where I saw Injun Joe poke up his candle, Huck!”
+
+Huck stared at the mystic sign awhile, and then said with a shaky voice:
+
+“Tom, less git out of here!”
+
+“What! and leave the treasure?”
+
+“Yes--leave it. Injun Joe’s ghost is round about there, certain.”
+
+“No it ain’t, Huck, no it ain’t. It would ha’nt the place where he
+died--away out at the mouth of the cave--five mile from here.”
+
+“No, Tom, it wouldn’t. It would hang round the money. I know the ways of
+ghosts, and so do you.”
+
+Tom began to fear that Huck was right. Mis-givings gathered in his mind.
+But presently an idea occurred to him--
+
+“Lookyhere, Huck, what fools we’re making of ourselves! Injun Joe’s
+ghost ain’t a going to come around where there’s a cross!”
+
+The point was well taken. It had its effect.
+
+“Tom, I didn’t think of that. But that’s so. It’s luck for us, that
+cross is. I reckon we’ll climb down there and have a hunt for that box.”
+
+Tom went first, cutting rude steps in the clay hill as he descended.
+Huck followed. Four avenues opened out of the small cavern which the
+great rock stood in. The boys examined three of them with no result.
+They found a small recess in the one nearest the base of the rock, with
+a pallet of blankets spread down in it; also an old suspender, some
+bacon rind, and the well-gnawed bones of two or three fowls. But there
+was no moneybox. The lads searched and researched this place, but in
+vain. Tom said:
+
+“He said _under_ the cross. Well, this comes nearest to being under the
+cross. It can’t be under the rock itself, because that sets solid on the
+ground.”
+
+They searched everywhere once more, and then sat down discouraged. Huck
+could suggest nothing. By-and-by Tom said:
+
+“Lookyhere, Huck, there’s footprints and some candle-grease on the clay
+about one side of this rock, but not on the other sides. Now, what’s
+that for? I bet you the money _is_ under the rock. I’m going to dig in
+the clay.”
+
+“That ain’t no bad notion, Tom!” said Huck with animation.
+
+Tom’s “real Barlow” was out at once, and he had not dug four inches
+before he struck wood.
+
+“Hey, Huck!--you hear that?”
+
+Huck began to dig and scratch now. Some boards were soon uncovered and
+removed. They had concealed a natural chasm which led under the rock.
+Tom got into this and held his candle as far under the rock as he
+could, but said he could not see to the end of the rift. He proposed
+to explore. He stooped and passed under; the narrow way descended
+gradually. He followed its winding course, first to the right, then to
+the left, Huck at his heels. Tom turned a short curve, by-and-by, and
+exclaimed:
+
+“My goodness, Huck, lookyhere!”
+
+It was the treasure-box, sure enough, occupying a snug little cavern,
+along with an empty powder-keg, a couple of guns in leather cases, two
+or three pairs of old moccasins, a leather belt, and some other rubbish
+well soaked with the water-drip.
+
+“Got it at last!” said Huck, ploughing among the tarnished coins with
+his hand. “My, but we’re rich, Tom!”
+
+“Huck, I always reckoned we’d get it. It’s just too good to believe, but
+we _have_ got it, sure! Say--let’s not fool around here. Let’s snake it
+out. Lemme see if I can lift the box.”
+
+It weighed about fifty pounds. Tom could lift it, after an awkward
+fashion, but could not carry it conveniently.
+
+“I thought so,” he said; “_They_ carried it like it was heavy, that day
+at the ha’nted house. I noticed that. I reckon I was right to think of
+fetching the little bags along.”
+
+The money was soon in the bags and the boys took it up to the cross
+rock.
+
+“Now less fetch the guns and things,” said Huck.
+
+“No, Huck--leave them there. They’re just the tricks to have when we
+go to robbing. We’ll keep them there all the time, and we’ll hold our
+orgies there, too. It’s an awful snug place for orgies.”
+
+“What orgies?”
+
+“I dono. But robbers always have orgies, and of course we’ve got to
+have them, too. Come along, Huck, we’ve been in here a long time. It’s
+getting late, I reckon. I’m hungry, too. We’ll eat and smoke when we get
+to the skiff.”
+
+They presently emerged into the clump of sumach bushes, looked warily
+out, found the coast clear, and were soon lunching and smoking in the
+skiff. As the sun dipped toward the horizon they pushed out and got
+under way. Tom skimmed up the shore through the long twilight, chatting
+cheerily with Huck, and landed shortly after dark.
+
+“Now, Huck,” said Tom, “we’ll hide the money in the loft of the widow’s
+woodshed, and I’ll come up in the morning and we’ll count it and divide,
+and then we’ll hunt up a place out in the woods for it where it will be
+safe. Just you lay quiet here and watch the stuff till I run and hook
+Benny Taylor’s little wagon; I won’t be gone a minute.”
+
+He disappeared, and presently returned with the wagon, put the two small
+sacks into it, threw some old rags on top of them, and started off,
+dragging his cargo behind him. When the boys reached the Welshman’s
+house, they stopped to rest. Just as they were about to move on, the
+Welshman stepped out and said:
+
+“Hallo, who’s that?”
+
+“Huck and Tom Sawyer.”
+
+“Good! Come along with me, boys, you are keeping everybody waiting.
+Here--hurry up, trot ahead--I’ll haul the wagon for you. Why, it’s not as
+light as it might be. Got bricks in it?--or old metal?”
+
+“Old metal,” said Tom.
+
+“I judged so; the boys in this town will take more trouble and fool away
+more time hunting up six bits’ worth of old iron to sell to the foundry
+than they would to make twice the money at regular work. But that’s
+human nature--hurry along, hurry along!”
+
+The boys wanted to know what the hurry was about.
+
+“Never mind; you’ll see, when we get to the Widow Douglas’.”
+
+Huck said with some apprehension--for he was long used to being falsely
+accused:
+
+“Mr. Jones, we haven’t been doing nothing.”
+
+The Welshman laughed.
+
+“Well, I don’t know, Huck, my boy. I don’t know about that. Ain’t you
+and the widow good friends?”
+
+“Yes. Well, she’s ben good friends to me, anyway.”
+
+“All right, then. What do you want to be afraid for?”
+
+This question was not entirely answered in Huck’s slow mind before he
+found himself pushed, along with Tom, into Mrs. Douglas’ drawing-room.
+Mr. Jones left the wagon near the door and followed.
+
+The place was grandly lighted, and everybody that was of any consequence
+in the village was there. The Thatchers were there, the Harpers, the
+Rogerses, Aunt Polly, Sid, Mary, the minister, the editor, and a great
+many more, and all dressed in their best. The widow received the boys
+as heartily as any one could well receive two such looking beings. They
+were covered with clay and candle-grease. Aunt Polly blushed crimson
+with humiliation, and frowned and shook her head at Tom. Nobody suffered
+half as much as the two boys did, however. Mr. Jones said:
+
+“Tom wasn’t at home, yet, so I gave him up; but I stumbled on him and
+Huck right at my door, and so I just brought them along in a hurry.”
+
+“And you did just right,” said the widow. “Come with me, boys.”
+
+She took them to a bedchamber and said:
+
+“Now wash and dress yourselves. Here are two new suits of
+clothes--shirts, socks, everything complete. They’re Huck’s--no, no
+thanks, Huck--Mr. Jones bought one and I the other. But they’ll fit both
+of you. Get into them. We’ll wait--come down when you are slicked up
+enough.”
+
+Then she left.
+
+
+
+
+CHAPTER XXXIV
+
+HUCK said: “Tom, we can slope, if we can find a rope. The window ain’t
+high from the ground.”
+
+“Shucks! what do you want to slope for?”
+
+“Well, I ain’t used to that kind of a crowd. I can’t stand it. I ain’t
+going down there, Tom.”
+
+“Oh, bother! It ain’t anything. I don’t mind it a bit. I’ll take care of
+you.”
+
+Sid appeared.
+
+“Tom,” said he, “auntie has been waiting for you all the afternoon. Mary
+got your Sunday clothes ready, and everybody’s been fretting about you.
+Say--ain’t this grease and clay, on your clothes?”
+
+“Now, Mr. Siddy, you jist ‘tend to your own business. What’s all this
+blowout about, anyway?”
+
+“It’s one of the widow’s parties that she’s always having. This time
+it’s for the Welshman and his sons, on account of that scrape they
+helped her out of the other night. And say--I can tell you something, if
+you want to know.”
+
+“Well, what?”
+
+“Why, old Mr. Jones is going to try to spring something on the people
+here tonight, but I overheard him tell auntie today about it, as a
+secret, but I reckon it’s not much of a secret now. Everybody knows--the
+widow, too, for all she tries to let on she don’t. Mr. Jones was bound
+Huck should be here--couldn’t get along with his grand secret without
+Huck, you know!”
+
+“Secret about what, Sid?”
+
+“About Huck tracking the robbers to the widow’s. I reckon Mr. Jones was
+going to make a grand time over his surprise, but I bet you it will drop
+pretty flat.”
+
+Sid chuckled in a very contented and satisfied way.
+
+“Sid, was it you that told?”
+
+“Oh, never mind who it was. _Somebody_ told--that’s enough.”
+
+“Sid, there’s only one person in this town mean enough to do that, and
+that’s you. If you had been in Huck’s place you’d ‘a’ sneaked down the
+hill and never told anybody on the robbers. You can’t do any but mean
+things, and you can’t bear to see anybody praised for doing good ones.
+There--no thanks, as the widow says”--and Tom cuffed Sid’s ears and helped
+him to the door with several kicks. “Now go and tell auntie if you
+dare--and tomorrow you’ll catch it!”
+
+Some minutes later the widow’s guests were at the supper-table, and a
+dozen children were propped up at little side-tables in the same room,
+after the fashion of that country and that day. At the proper time Mr.
+Jones made his little speech, in which he thanked the widow for the
+honor she was doing himself and his sons, but said that there was
+another person whose modesty--
+
+And so forth and so on. He sprung his secret about Huck’s share in
+the adventure in the finest dramatic manner he was master of, but the
+surprise it occasioned was largely counterfeit and not as clamorous and
+effusive as it might have been under happier circumstances. However,
+the widow made a pretty fair show of astonishment, and heaped so many
+compliments and so much gratitude upon Huck that he almost forgot
+the nearly intolerable discomfort of his new clothes in the entirely
+intolerable discomfort of being set up as a target for everybody’s gaze
+and everybody’s laudations.
+
+The widow said she meant to give Huck a home under her roof and have him
+educated; and that when she could spare the money she would start him in
+business in a modest way. Tom’s chance was come. He said:
+
+“Huck don’t need it. Huck’s rich.”
+
+Nothing but a heavy strain upon the good manners of the company kept
+back the due and proper complimentary laugh at this pleasant joke. But
+the silence was a little awkward. Tom broke it:
+
+“Huck’s got money. Maybe you don’t believe it, but he’s got lots of it.
+Oh, you needn’t smile--I reckon I can show you. You just wait a minute.”
+
+Tom ran out of doors. The company looked at each other with a perplexed
+interest--and inquiringly at Huck, who was tongue-tied.
+
+“Sid, what ails Tom?” said Aunt Polly. “He--well, there ain’t ever any
+making of that boy out. I never--”
+
+Tom entered, struggling with the weight of his sacks, and Aunt Polly
+did not finish her sentence. Tom poured the mass of yellow coin upon the
+table and said:
+
+“There--what did I tell you? Half of it’s Huck’s and half of it’s mine!”
+
+The spectacle took the general breath away. All gazed, nobody spoke for
+a moment. Then there was a unanimous call for an explanation. Tom said
+he could furnish it, and he did. The tale was long, but brimful of
+interest. There was scarcely an interruption from any one to break the
+charm of its flow. When he had finished, Mr. Jones said:
+
+“I thought I had fixed up a little surprise for this occasion, but it
+don’t amount to anything now. This one makes it sing mighty small, I’m
+willing to allow.”
+
+The money was counted. The sum amounted to a little over twelve thousand
+dollars. It was more than any one present had ever seen at one time
+before, though several persons were there who were worth considerably
+more than that in property.
+
+
+
+
+CHAPTER XXXV
+
+THE reader may rest satisfied that Tom’s and Huck’s windfall made a
+mighty stir in the poor little village of St. Petersburg. So vast a
+sum, all in actual cash, seemed next to incredible. It was talked
+about, gloated over, glorified, until the reason of many of the citizens
+tottered under the strain of the unhealthy excitement. Every “haunted”
+ house in St. Petersburg and the neighboring villages was dissected,
+plank by plank, and its foundations dug up and ransacked for hidden
+treasure--and not by boys, but men--pretty grave, unromantic men, too,
+some of them. Wherever Tom and Huck appeared they were courted, admired,
+stared at. The boys were not able to remember that their remarks had
+possessed weight before; but now their sayings were treasured and
+repeated; everything they did seemed somehow to be regarded as
+remarkable; they had evidently lost the power of doing and saying
+commonplace things; moreover, their past history was raked up and
+discovered to bear marks of conspicuous originality. The village paper
+published biographical sketches of the boys.
+
+The Widow Douglas put Huck’s money out at six per cent., and Judge
+Thatcher did the same with Tom’s at Aunt Polly’s request. Each lad had
+an income, now, that was simply prodigious--a dollar for every weekday in
+the year and half of the Sundays. It was just what the minister got--no,
+it was what he was promised--he generally couldn’t collect it. A dollar
+and a quarter a week would board, lodge, and school a boy in those old
+simple days--and clothe him and wash him, too, for that matter.
+
+Judge Thatcher had conceived a great opinion of Tom. He said that no
+commonplace boy would ever have got his daughter out of the cave. When
+Becky told her father, in strict confidence, how Tom had taken her
+whipping at school, the Judge was visibly moved; and when she pleaded
+grace for the mighty lie which Tom had told in order to shift that
+whipping from her shoulders to his own, the Judge said with a fine
+outburst that it was a noble, a generous, a magnanimous lie--a lie that
+was worthy to hold up its head and march down through history breast to
+breast with George Washington’s lauded Truth about the hatchet! Becky
+thought her father had never looked so tall and so superb as when he
+walked the floor and stamped his foot and said that. She went straight
+off and told Tom about it.
+
+Judge Thatcher hoped to see Tom a great lawyer or a great soldier some
+day. He said he meant to look to it that Tom should be admitted to the
+National Military Academy and afterward trained in the best law school
+in the country, in order that he might be ready for either career or
+both.
+
+Huck Finn’s wealth and the fact that he was now under the Widow Douglas’
+protection introduced him into society--no, dragged him into it, hurled
+him into it--and his sufferings were almost more than he could bear. The
+widow’s servants kept him clean and neat, combed and brushed, and they
+bedded him nightly in unsympathetic sheets that had not one little spot
+or stain which he could press to his heart and know for a friend. He had
+to eat with a knife and fork; he had to use napkin, cup, and plate;
+he had to learn his book, he had to go to church; he had to talk so
+properly that speech was become insipid in his mouth; whithersoever he
+turned, the bars and shackles of civilization shut him in and bound him
+hand and foot.
+
+He bravely bore his miseries three weeks, and then one day turned up
+missing. For forty-eight hours the widow hunted for him everywhere in
+great distress. The public were profoundly concerned; they searched high
+and low, they dragged the river for his body. Early the third morning
+Tom Sawyer wisely went poking among some old empty hogsheads down behind
+the abandoned slaughter-house, and in one of them he found the refugee.
+Huck had slept there; he had just breakfasted upon some stolen odds and
+ends of food, and was lying off, now, in comfort, with his pipe. He was
+unkempt, uncombed, and clad in the same old ruin of rags that had made
+him picturesque in the days when he was free and happy. Tom routed him
+out, told him the trouble he had been causing, and urged him to go home.
+Huck’s face lost its tranquil content, and took a melancholy cast. He
+said:
+
+“Don’t talk about it, Tom. I’ve tried it, and it don’t work; it don’t
+work, Tom. It ain’t for me; I ain’t used to it. The widder’s good to me,
+and friendly; but I can’t stand them ways. She makes me get up just
+at the same time every morning; she makes me wash, they comb me all
+to thunder; she won’t let me sleep in the woodshed; I got to wear them
+blamed clothes that just smothers me, Tom; they don’t seem to any air
+git through ‘em, somehow; and they’re so rotten nice that I can’t
+set down, nor lay down, nor roll around anywher’s; I hain’t slid on a
+cellar-door for--well, it ‘pears to be years; I got to go to church
+and sweat and sweat--I hate them ornery sermons! I can’t ketch a fly in
+there, I can’t chaw. I got to wear shoes all Sunday. The widder eats by
+a bell; she goes to bed by a bell; she gits up by a bell--everything’s so
+awful reg’lar a body can’t stand it.”
+
+“Well, everybody does that way, Huck.”
+
+“Tom, it don’t make no difference. I ain’t everybody, and I can’t
+_stand_ it. It’s awful to be tied up so. And grub comes too easy--I don’t
+take no interest in vittles, that way. I got to ask to go a-fishing;
+I got to ask to go in a-swimming--dern’d if I hain’t got to ask to do
+everything. Well, I’d got to talk so nice it wasn’t no comfort--I’d got
+to go up in the attic and rip out awhile, every day, to git a taste
+in my mouth, or I’d a died, Tom. The widder wouldn’t let me smoke;
+she wouldn’t let me yell, she wouldn’t let me gape, nor stretch, nor
+scratch, before folks--” [Then with a spasm of special irritation and
+injury]--“And dad fetch it, she prayed all the time! I never see such a
+woman! I _had_ to shove, Tom--I just had to. And besides, that school’s
+going to open, and I’d a had to go to it--well, I wouldn’t stand _that_,
+Tom. Looky-here, Tom, being rich ain’t what it’s cracked up to be. It’s
+just worry and worry, and sweat and sweat, and a-wishing you was dead
+all the time. Now these clothes suits me, and this bar’l suits me, and
+I ain’t ever going to shake ‘em any more. Tom, I wouldn’t ever got into
+all this trouble if it hadn’t ‘a’ ben for that money; now you just take
+my sheer of it along with your’n, and gimme a ten-center sometimes--not
+many times, becuz I don’t give a dern for a thing ‘thout it’s tollable
+hard to git--and you go and beg off for me with the widder.”
+
+“Oh, Huck, you know I can’t do that. ‘Tain’t fair; and besides if you’ll
+try this thing just a while longer you’ll come to like it.”
+
+“Like it! Yes--the way I’d like a hot stove if I was to set on it long
+enough. No, Tom, I won’t be rich, and I won’t live in them cussed
+smothery houses. I like the woods, and the river, and hogsheads, and
+I’ll stick to ‘em, too. Blame it all! just as we’d got guns, and a cave,
+and all just fixed to rob, here this dern foolishness has got to come up
+and spile it all!”
+
+Tom saw his opportunity--
+
+“Lookyhere, Huck, being rich ain’t going to keep me back from turning
+robber.”
+
+“No! Oh, good-licks; are you in real dead-wood earnest, Tom?”
+
+“Just as dead earnest as I’m sitting here. But Huck, we can’t let you
+into the gang if you ain’t respectable, you know.”
+
+Huck’s joy was quenched.
+
+“Can’t let me in, Tom? Didn’t you let me go for a pirate?”
+
+“Yes, but that’s different. A robber is more high-toned than what a
+pirate is--as a general thing. In most countries they’re awful high up in
+the nobility--dukes and such.”
+
+“Now, Tom, hain’t you always ben friendly to me? You wouldn’t shet me
+out, would you, Tom? You wouldn’t do that, now, _would_ you, Tom?”
+
+“Huck, I wouldn’t want to, and I _don’t_ want to--but what would people
+say? Why, they’d say, ‘Mph! Tom Sawyer’s Gang! pretty low characters in
+it!’ They’d mean you, Huck. You wouldn’t like that, and I wouldn’t.”
+
+Huck was silent for some time, engaged in a mental struggle. Finally he
+said:
+
+“Well, I’ll go back to the widder for a month and tackle it and see if I
+can come to stand it, if you’ll let me b’long to the gang, Tom.”
+
+“All right, Huck, it’s a whiz! Come along, old chap, and I’ll ask the
+widow to let up on you a little, Huck.”
+
+“Will you, Tom--now will you? That’s good. If she’ll let up on some of
+the roughest things, I’ll smoke private and cuss private, and crowd
+through or bust. When you going to start the gang and turn robbers?”
+
+“Oh, right off. We’ll get the boys together and have the initiation
+tonight, maybe.”
+
+“Have the which?”
+
+“Have the initiation.”
+
+“What’s that?”
+
+“It’s to swear to stand by one another, and never tell the gang’s
+secrets, even if you’re chopped all to flinders, and kill anybody and
+all his family that hurts one of the gang.”
+
+“That’s gay--that’s mighty gay, Tom, I tell you.”
+
+“Well, I bet it is. And all that swearing’s got to be done at midnight,
+in the lonesomest, awfulest place you can find--a ha’nted house is the
+best, but they’re all ripped up now.”
+
+“Well, midnight’s good, anyway, Tom.”
+
+“Yes, so it is. And you’ve got to swear on a coffin, and sign it with
+blood.”
+
+“Now, that’s something _like_! Why, it’s a million times bullier than
+pirating. I’ll stick to the widder till I rot, Tom; and if I git to be
+a reg’lar ripper of a robber, and everybody talking ‘bout it, I reckon
+she’ll be proud she snaked me in out of the wet.”
+
+CONCLUSION
+
+SO endeth this chronicle. It being strictly a history of a _boy_, it
+must stop here; the story could not go much further without becoming the
+history of a _man_. When one writes a novel about grown people, he knows
+exactly where to stop--that is, with a marriage; but when he writes of
+juveniles, he must stop where he best can.
+
+Most of the characters that perform in this book still live, and are
+prosperous and happy. Some day it may seem worth while to take up the
+story of the younger ones again and see what sort of men and women they
+turned out to be; therefore it will be wisest not to reveal any of that
+part of their lives at present.
+
+End of the Project Gutenberg Ebook of Adventures of Tom Sawyer,
+Complete, by Mark Twain (Samuel Clemens)
+
+*** END OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
+
+***** This file should be named 74-0.txt or 74-0.zip ***** This and
+all associated files of various formats will be found in:
+http://www.gutenberg.net/7/74/
+
+Produced by David Widger. The previous edition was updated by Jose
+Menendez.
+
+Updated editions will replace the previous one--the old editions will be
+renamed.
+
+Creating the works from public domain print editions means that no one
+owns a United States copyright in these works, so the Foundation (and
+you!) can copy and distribute it in the United States without permission
+and without paying copyright royalties. Special rules, set forth in
+the General Terms of Use part of this license, apply to copying and
+distributing Project Gutenberg-tm electronic works to protect the
+PROJECT GUTENBERG-tm concept and trademark. Project Gutenberg is a
+registered trademark, and may not be used if you charge for the eBooks,
+unless you receive specific permission. If you do not charge anything
+for copies of this eBook, complying with the rules is very easy. You
+may use this eBook for nearly any purpose such as creation of derivative
+works, reports, performances and research. They may be modified and
+printed and given away--you may do practically ANYTHING with public
+domain eBooks. Redistribution is subject to the trademark license,
+especially commercial redistribution.
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE PLEASE READ THIS BEFORE YOU
+DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree
+to and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all the
+terms of this agreement, you must cease using and return or destroy all
+copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be used
+on or associated in any way with an electronic work by people who agree
+to be bound by the terms of this agreement. There are a few things that
+you can do with most Project Gutenberg-tm electronic works even without
+complying with the full terms of this agreement. See paragraph 1.C
+below. There are a lot of things you can do with Project Gutenberg-tm
+electronic works if you follow the terms of this agreement and help
+preserve free future access to Project Gutenberg-tm electronic works.
+See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the Foundation”
+ or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works. Nearly all the individual works in
+the collection are in the public domain in the United States. If an
+individual work is in the public domain in the United States and you
+are located in the United States, we do not claim a right to prevent
+you from copying, distributing, performing, displaying or creating
+derivative works based on the work as long as all references to Project
+Gutenberg are removed. Of course, we hope that you will support the
+Project Gutenberg-tm mission of promoting free access to electronic
+works by freely sharing Project Gutenberg-tm works in compliance with
+the terms of this agreement for keeping the Project Gutenberg-tm name
+associated with the work. You can easily comply with the terms of this
+agreement by keeping this work in the same format with its attached
+full Project Gutenberg-tm License when you share it without charge with
+others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are in
+a constant state of change. If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing
+or creating derivative works based on this work or any other Project
+Gutenberg-tm work. The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase “Project Gutenberg” appears, or with which the phrase “Project
+Gutenberg” is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with almost
+no restrictions whatsoever. You may copy it, give it away or re-use
+it under the terms of the Project Gutenberg License included with this
+eBook or online at www.gutenberg.net
+
+1.E.2. If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges. If you are redistributing or providing access to a work with
+the phrase “Project Gutenberg” associated with or appearing on the work,
+you must comply either with the requirements of paragraphs 1.E.1 through
+1.E.7 or obtain permission for the use of the work and the Project
+Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder. Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute
+this electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form. However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other
+than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg-tm web site
+(www.gutenberg.net), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the full
+Project Gutenberg-tm License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing access
+to or distributing Project Gutenberg-tm electronic works provided that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+the use of Project Gutenberg-tm works calculated using the method you
+already use to calculate your applicable taxes. The fee is owed to the
+owner of the Project Gutenberg-tm trademark, but he has agreed to donate
+royalties under this paragraph to the Project Gutenberg Literary Archive
+Foundation. Royalty payments must be paid within 60 days following each
+date on which you prepare (or are legally required to prepare) your
+periodic tax returns. Royalty payments should be clearly marked as such
+and sent to the Project Gutenberg Literary Archive Foundation at the
+address specified in Section 4, “Information about donations to the
+Project Gutenberg Literary Archive Foundation.”
+
+- You provide a full refund of any money paid by a user who notifies you
+in writing (or by e-mail) within 30 days of receipt that s/he does not
+agree to the terms of the full Project Gutenberg-tm License. You
+must require such a user to return or destroy all copies of the works
+possessed in a physical medium and discontinue all use of and all access
+to other copies of Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of
+any money paid for a work or a replacement copy, if a defect in the
+electronic work is discovered and reported to you within 90 days of
+receipt of the work.
+
+- You comply with all other terms of this agreement for free
+distribution of Project Gutenberg-tm works.
+
+1.E.9. If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set forth
+in this agreement, you must obtain permission in writing from both the
+Project Gutenberg Literary Archive Foundation and Michael Hart, the
+owner of the Project Gutenberg-tm trademark. Contact the Foundation as
+set forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm collection.
+Despite these efforts, Project Gutenberg-tm electronic works, and the
+medium on which they may be stored, may contain “Defects,” such as, but
+not limited to, incomplete, inaccurate or corrupt data, transcription
+errors, a copyright or other intellectual property infringement, a
+defective or damaged disk or other medium, a computer virus, or computer
+codes that damage or cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES- Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal fees.
+YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT LIABILITY,
+BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE PROVIDED IN
+PARAGRAPH F3. YOU AGREE THAT THE FOUNDATION, THE TRADEMARK OWNER, AND
+ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE LIABLE TO YOU FOR
+ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR INCIDENTAL DAMAGES
+EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND- If you discover a defect
+in this electronic work within 90 days of receiving it, you can receive
+a refund of the money (if any) you paid for it by sending a written
+explanation to the person you received the work from. If you received
+the work on a physical medium, you must return the medium with your
+written explanation. The person or entity that provided you with the
+defective work may elect to provide a replacement copy in lieu of a
+refund. If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund. If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’ WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law. The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6. INDEMNITY- You agree to indemnify and hold the Foundation,
+the trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers. It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm’s
+goals and ensuring that the Project Gutenberg-tm collection will remain
+freely available for generations to come. In 2001, the Project Gutenberg
+Literary Archive Foundation was created to provide a secure and
+permanent future for Project Gutenberg-tm and future generations. To
+learn more about the Project Gutenberg Literary Archive Foundation and
+how your efforts and donations can help, see Sections 3 and 4 and the
+Foundation web page at http://www.pglaf.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the state
+of Mississippi and granted tax exempt status by the Internal Revenue
+Service. The Foundation’s EIN or federal tax identification number
+is 64-6221541. Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising. Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state’s laws.
+
+The Foundation’s principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations. Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887,
+email business@pglaf.org. Email contact links and up to date contact
+information can be found at the Foundation’s web site and official page
+at http://pglaf.org
+
+For additional contact information: Dr. Gregory B. Newby Chief Executive
+and Director gbnewby@pglaf.org
+
+Section 4. Information about Donations to the Project Gutenberg Literary
+Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide spread
+public support and donations to carry out its mission of increasing
+the number of public domain and licensed works that can be freely
+distributed in machine readable form accessible by the widest array
+of equipment including outdated equipment. Many small donations ($1 to
+$5,000) are particularly important to maintaining tax exempt status with
+the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make any
+statements concerning tax treatment of donations received from outside
+the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses. Donations are accepted in a number of other ways
+including including checks, online payments and credit card donations.
+To donate, please visit: http://pglaf.org/donate
+
+Section 5. General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone. For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S. unless
+a copyright notice is included. Thus, we do not necessarily keep eBooks
+in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm, including
+how to make donations to the Project Gutenberg Literary Archive
+Foundation, how to help produce our new eBooks, and how to subscribe to
+our email newsletter to hear about new eBooks.
+
+

--- a/jet/tf-idf/src/main/resources/books/war-of-the-worlds.txt
+++ b/jet/tf-idf/src/main/resources/books/war-of-the-worlds.txt
@@ -1,0 +1,6869 @@
+﻿The Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+
+Title: The War of the Worlds
+
+Author: H. G. Wells
+
+Release Date: July, 1992 [EBook #36]
+[Most recently updated October 1, 2004]
+
+Language: English
+
+
+*** START OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+
+
+
+
+
+
+
+
+
+
+The War of the Worlds
+
+by H. G. Wells [1898]
+
+
+     But who shall dwell in these worlds if they be
+     inhabited? .  .  .  Are we or they Lords of the
+     World? .  .  .  And how are all things made for man?--
+          KEPLER (quoted in The Anatomy of Melancholy)
+
+
+
+BOOK ONE
+
+THE COMING OF THE MARTIANS
+
+
+
+CHAPTER ONE
+
+THE EVE OF THE WAR
+
+
+No one would have believed in the last years of the nineteenth
+century that this world was being watched keenly and closely by
+intelligences greater than man's and yet as mortal as his own; that as
+men busied themselves about their various concerns they were
+scrutinised and studied, perhaps almost as narrowly as a man with a
+microscope might scrutinise the transient creatures that swarm and
+multiply in a drop of water.  With infinite complacency men went to
+and fro over this globe about their little affairs, serene in their
+assurance of their empire over matter.  It is possible that the
+infusoria under the microscope do the same.  No one gave a thought to
+the older worlds of space as sources of human danger, or thought of
+them only to dismiss the idea of life upon them as impossible or
+improbable.  It is curious to recall some of the mental habits of
+those departed days.  At most terrestrial men fancied there might be
+other men upon Mars, perhaps inferior to themselves and ready to
+welcome a missionary enterprise.  Yet across the gulf of space, minds
+that are to our minds as ours are to those of the beasts that perish,
+intellects vast and cool and unsympathetic, regarded this earth with
+envious eyes, and slowly and surely drew their plans against us.  And
+early in the twentieth century came the great disillusionment.
+
+The planet Mars, I scarcely need remind the reader, revolves about the
+sun at a mean distance of 140,000,000 miles, and the light and heat it
+receives from the sun is barely half of that received by this world.
+It must be, if the nebular hypothesis has any truth, older than our
+world; and long before this earth ceased to be molten, life upon its
+surface must have begun its course.  The fact that it is scarcely one
+seventh of the volume of the earth must have accelerated its cooling
+to the temperature at which life could begin.  It has air and water
+and all that is necessary for the support of animated existence.
+
+Yet so vain is man, and so blinded by his vanity, that no writer,
+up to the very end of the nineteenth century, expressed any idea that
+intelligent life might have developed there far, or indeed at all,
+beyond its earthly level.  Nor was it generally understood that since
+Mars is older than our earth, with scarcely a quarter of the
+superficial area and remoter from the sun, it necessarily follows that
+it is not only more distant from time's beginning but nearer its end.
+
+The secular cooling that must someday overtake our planet has
+already gone far indeed with our neighbour.  Its physical condition is
+still largely a mystery, but we know now that even in its equatorial
+region the midday temperature barely approaches that of our coldest
+winter.  Its air is much more attenuated than ours, its oceans have
+shrunk until they cover but a third of its surface, and as its slow
+seasons change huge snowcaps gather and melt about either pole and
+periodically inundate its temperate zones.  That last stage of
+exhaustion, which to us is still incredibly remote, has become a
+present-day problem for the inhabitants of Mars.  The immediate
+pressure of necessity has brightened their intellects, enlarged their
+powers, and hardened their hearts.  And looking across space with
+instruments, and intelligences such as we have scarcely dreamed of,
+they see, at its nearest distance only 35,000,000 of miles sunward of
+them, a morning star of hope, our own warmer planet, green with
+vegetation and grey with water, with a cloudy atmosphere eloquent of
+fertility, with glimpses through its drifting cloud wisps of broad
+stretches of populous country and narrow, navy-crowded seas.
+
+And we men, the creatures who inhabit this earth, must be to them
+at least as alien and lowly as are the monkeys and lemurs to us.  The
+intellectual side of man already admits that life is an incessant
+struggle for existence, and it would seem that this too is the belief
+of the minds upon Mars.  Their world is far gone in its cooling and
+this world is still crowded with life, but crowded only with what they
+regard as inferior animals.  To carry warfare sunward is, indeed,
+their only escape from the destruction that, generation after
+generation, creeps upon them.
+
+And before we judge of them too harshly we must remember what
+ruthless and utter destruction our own species has wrought, not only
+upon animals, such as the vanished bison and the dodo, but upon its
+inferior races.  The Tasmanians, in spite of their human likeness,
+were entirely swept out of existence in a war of extermination waged
+by European immigrants, in the space of fifty years.  Are we such
+apostles of mercy as to complain if the Martians warred in the same
+spirit?
+
+The Martians seem to have calculated their descent with amazing
+subtlety--their mathematical learning is evidently far in excess of
+ours--and to have carried out their preparations with a well-nigh
+perfect unanimity.  Had our instruments permitted it, we might have
+seen the gathering trouble far back in the nineteenth century.  Men
+like Schiaparelli watched the red planet--it is odd, by-the-bye, that
+for countless centuries Mars has been the star of war--but failed to
+interpret the fluctuating appearances of the markings they mapped so
+well.  All that time the Martians must have been getting ready.
+
+During the opposition of 1894 a great light was seen on the
+illuminated part of the disk, first at the Lick Observatory, then by
+Perrotin of Nice, and then by other observers.  English readers heard
+of it first in the issue of _Nature_ dated August 2.  I am inclined to
+think that this blaze may have been the casting of the huge gun, in
+the vast pit sunk into their planet, from which their shots were fired
+at us.  Peculiar markings, as yet unexplained, were seen near the site
+of that outbreak during the next two oppositions.
+
+The storm burst upon us six years ago now.  As Mars approached
+opposition, Lavelle of Java set the wires of the astronomical exchange
+palpitating with the amazing intelligence of a huge outbreak of
+incandescent gas upon the planet.  It had occurred towards midnight of
+the twelfth; and the spectroscope, to which he had at once resorted,
+indicated a mass of flaming gas, chiefly hydrogen, moving with an
+enormous velocity towards this earth.  This jet of fire had become
+invisible about a quarter past twelve.  He compared it to a colossal
+puff of flame suddenly and violently squirted out of the planet, "as
+flaming gases rushed out of a gun."
+
+A singularly appropriate phrase it proved.  Yet the next day there
+was nothing of this in the papers except a little note in the _Daily
+Telegraph_, and the world went in ignorance of one of the gravest
+dangers that ever threatened the human race. I might not have heard of
+the eruption at all had I not met Ogilvy, the well-known astronomer,
+at Ottershaw.  He was immensely excited at the news, and in the excess
+of his feelings invited me up to take a turn with him that night in a
+scrutiny of the red planet.
+
+In spite of all that has happened since, I still remember that
+vigil very distinctly: the black and silent observatory, the shadowed
+lantern throwing a feeble glow upon the floor in the corner, the
+steady ticking of the clockwork of the telescope, the little slit in
+the roof--an oblong profundity with the stardust streaked across it.
+Ogilvy moved about, invisible but audible.  Looking through the
+telescope, one saw a circle of deep blue and the little round planet
+swimming in the field.  It seemed such a little thing, so bright and
+small and still, faintly marked with transverse stripes, and slightly
+flattened from the perfect round.  But so little it was, so silvery
+warm--a pin's-head of light! It was as if it quivered, but really this
+was the telescope vibrating with the activity of the clockwork that
+kept the planet in view.
+
+As I watched, the planet seemed to grow larger and smaller and to
+advance and recede, but that was simply that my eye was tired.  Forty
+millions of miles it was from us--more than forty millions of miles of
+void.  Few people realise the immensity of vacancy in which the dust
+of the material universe swims.
+
+Near it in the field, I remember, were three faint points of light,
+three telescopic stars infinitely remote, and all around it was the
+unfathomable darkness of empty space.  You know how that blackness
+looks on a frosty starlight night.  In a telescope it seems far
+profounder.  And invisible to me because it was so remote and small,
+flying swiftly and steadily towards me across that incredible
+distance, drawing nearer every minute by so many thousands of miles,
+came the Thing they were sending us, the Thing that was to bring so
+much struggle and calamity and death to the earth.  I never dreamed of
+it then as I watched; no one on earth dreamed of that unerring
+missile.
+
+That night, too, there was another jetting out of gas from the
+distant planet.  I saw it.  A reddish flash at the edge, the slightest
+projection of the outline just as the chronometer struck midnight; and
+at that I told Ogilvy and he took my place.  The night was warm and I
+was thirsty, and I went stretching my legs clumsily and feeling my way
+in the darkness, to the little table where the siphon stood, while
+Ogilvy exclaimed at the streamer of gas that came out towards us.
+
+That night another invisible missile started on its way to the
+earth from Mars, just a second or so under twenty-four hours after the
+first one.  I remember how I sat on the table there in the blackness,
+with patches of green and crimson swimming before my eyes.  I wished I
+had a light to smoke by, little suspecting the meaning of the minute
+gleam I had seen and all that it would presently bring me.  Ogilvy
+watched till one, and then gave it up; and we lit the lantern and
+walked over to his house.  Down below in the darkness were Ottershaw
+and Chertsey and all their hundreds of people, sleeping in peace.
+
+He was full of speculation that night about the condition of Mars,
+and scoffed at the vulgar idea of its having inhabitants who were
+signalling us.  His idea was that meteorites might be falling in a
+heavy shower upon the planet, or that a huge volcanic explosion was in
+progress.  He pointed out to me how unlikely it was that organic
+evolution had taken the same direction in the two adjacent planets.
+
+"The chances against anything manlike on Mars are a million to
+one," he said.
+
+Hundreds of observers saw the flame that night and the night after
+about midnight, and again the night after; and so for ten nights, a
+flame each night.  Why the shots ceased after the tenth no one on
+earth has attempted to explain.  It may be the gases of the firing
+caused the Martians inconvenience.  Dense clouds of smoke or dust,
+visible through a powerful telescope on earth as little grey,
+fluctuating patches, spread through the clearness of the planet's
+atmosphere and obscured its more familiar features.
+
+Even the daily papers woke up to the disturbances at last, and
+popular notes appeared here, there, and everywhere concerning the
+volcanoes upon Mars.  The seriocomic periodical _Punch_, I remember,
+made a happy use of it in the political cartoon.  And, all
+unsuspected, those missiles the Martians had fired at us drew
+earthward, rushing now at a pace of many miles a second through the
+empty gulf of space, hour by hour and day by day, nearer and nearer.
+It seems to me now almost incredibly wonderful that, with that swift
+fate hanging over us, men could go about their petty concerns as they
+did.  I remember how jubilant Markham was at securing a new photograph
+of the planet for the illustrated paper he edited in those days.
+People in these latter times scarcely realise the abundance and
+enterprise of our nineteenth-century papers.  For my own part, I was
+much occupied in learning to ride the bicycle, and busy upon a series
+of papers discussing the probable developments of moral ideas as
+civilisation progressed.
+
+One night (the first missile then could scarcely have been
+10,000,000 miles away) I went for a walk with my wife.  It was
+starlight and I explained the Signs of the Zodiac to her, and pointed
+out Mars, a bright dot of light creeping zenithward, towards which so
+many telescopes were pointed.  It was a warm night.  Coming home, a
+party of excursionists from Chertsey or Isleworth passed us singing
+and playing music.  There were lights in the upper windows of the
+houses as the people went to bed.  From the railway station in the
+distance came the sound of shunting trains, ringing and rumbling,
+softened almost into melody by the distance.  My wife pointed out to
+me the brightness of the red, green, and yellow signal lights hanging
+in a framework against the sky.  It seemed so safe and tranquil.
+
+
+
+CHAPTER TWO
+
+THE FALLING STAR
+
+
+Then came the night of the first falling star.  It was seen early
+in the morning, rushing over Winchester eastward, a line of flame high
+in the atmosphere.  Hundreds must have seen it, and taken it for an
+ordinary falling star.  Albin described it as leaving a greenish
+streak behind it that glowed for some seconds.  Denning, our greatest
+authority on meteorites, stated that the height of its first
+appearance was about ninety or one hundred miles.  It seemed to him
+that it fell to earth about one hundred miles east of him.
+
+I was at home at that hour and writing in my study; and although my
+French windows face towards Ottershaw and the blind was up (for I
+loved in those days to look up at the night sky), I saw nothing of it.
+Yet this strangest of all things that ever came to earth from outer
+space must have fallen while I was sitting there, visible to me had I
+only looked up as it passed.  Some of those who saw its flight say it
+travelled with a hissing sound.  I myself heard nothing of that.  Many
+people in Berkshire, Surrey, and Middlesex must have seen the fall of
+it, and, at most, have thought that another meteorite had descended.
+No one seems to have troubled to look for the fallen mass that night.
+
+But very early in the morning poor Ogilvy, who had seen the
+shooting star and who was persuaded that a meteorite lay somewhere on
+the common between Horsell, Ottershaw, and Woking, rose early with the
+idea of finding it.  Find it he did, soon after dawn, and not far from
+the sand pits.  An enormous hole had been made by the impact of the
+projectile, and the sand and gravel had been flung violently in every
+direction over the heath, forming heaps visible a mile and a half
+away.  The heather was on fire eastward, and a thin blue smoke rose
+against the dawn.
+
+The Thing itself lay almost entirely buried in sand, amidst the
+scattered splinters of a fir tree it had shivered to fragments in its
+descent.  The uncovered part had the appearance of a huge cylinder,
+caked over and its outline softened by a thick scaly dun-coloured
+incrustation.  It had a diameter of about thirty yards.  He approached
+the mass, surprised at the size and more so at the shape, since most
+meteorites are rounded more or less completely.  It was, however,
+still so hot from its flight through the air as to forbid his near
+approach.  A stirring noise within its cylinder he ascribed to the
+unequal cooling of its surface; for at that time it had not occurred
+to him that it might be hollow.
+
+He remained standing at the edge of the pit that the Thing had made
+for itself, staring at its strange appearance, astonished chiefly at
+its unusual shape and colour, and dimly perceiving even then some
+evidence of design in its arrival.  The early morning was wonderfully
+still, and the sun, just clearing the pine trees towards Weybridge,
+was already warm.  He did not remember hearing any birds that morning,
+there was certainly no breeze stirring, and the only sounds were the
+faint movements from within the cindery cylinder.  He was all alone on
+the common.
+
+Then suddenly he noticed with a start that some of the grey
+clinker, the ashy incrustation that covered the meteorite, was falling
+off the circular edge of the end.  It was dropping off in flakes and
+raining down upon the sand.  A large piece suddenly came off and fell
+with a sharp noise that brought his heart into his mouth.
+
+For a minute he scarcely realised what this meant, and, although
+the heat was excessive, he clambered down into the pit close to the
+bulk to see the Thing more clearly.  He fancied even then that the
+cooling of the body might account for this, but what disturbed that
+idea was the fact that the ash was falling only from the end of the
+cylinder.
+
+And then he perceived that, very slowly, the circular top of the
+cylinder was rotating on its body.  It was such a gradual movement
+that he discovered it only through noticing that a black mark that had
+been near him five minutes ago was now at the other side of the
+circumference.  Even then he scarcely understood what this indicated,
+until he heard a muffled grating sound and saw the black mark jerk
+forward an inch or so.  Then the thing came upon him in a flash.  The
+cylinder was artificial--hollow--with an end that screwed out!
+Something within the cylinder was unscrewing the top!
+
+"Good heavens!" said Ogilvy.  "There's a man in it--men in it! Half
+roasted to death!  Trying to escape!"
+
+At once, with a quick mental leap, he linked the Thing with the
+flash upon Mars.
+
+The thought of the confined creature was so dreadful to him that he
+forgot the heat and went forward to the cylinder to help turn.  But
+luckily the dull radiation arrested him before he could burn his hands
+on the still-glowing metal.  At that he stood irresolute for a moment,
+then turned, scrambled out of the pit, and set off running wildly into
+Woking.  The time then must have been somewhere about six o'clock.
+He met a waggoner and tried to make him understand, but the tale he
+told and his appearance were so wild--his hat had fallen off in the
+pit--that the man simply drove on.  He was equally unsuccessful with the
+potman who was just unlocking the doors of the public-house by Horsell
+Bridge.  The fellow thought he was a lunatic at large and made an
+unsuccessful attempt to shut him into the taproom.  That sobered him a
+little; and when he saw Henderson, the London journalist, in his
+garden, he called over the palings and made himself understood.
+
+"Henderson," he called, "you saw that shooting star last night?"
+
+"Well?" said Henderson.
+
+"It's out on Horsell Common now."
+
+"Good Lord!" said Henderson.  "Fallen meteorite!  That's good."
+
+"But it's something more than a meteorite.  It's a cylinder--an
+artificial cylinder, man!  And there's something inside."
+
+Henderson stood up with his spade in his hand.
+
+"What's that?" he said.  He was deaf in one ear.
+
+Ogilvy told him all that he had seen.  Henderson was a minute or so
+taking it in.  Then he dropped his spade, snatched up his jacket, and
+came out into the road.  The two men hurried back at once to the
+common, and found the cylinder still lying in the same position.  But
+now the sounds inside had ceased, and a thin circle of bright metal
+showed between the top and the body of the cylinder.  Air was either
+entering or escaping at the rim with a thin, sizzling sound.
+
+They listened, rapped on the scaly burnt metal with a stick, and,
+meeting with no response, they both concluded the man or men inside
+must be insensible or dead.
+
+Of course the two were quite unable to do anything.  They shouted
+consolation and promises, and went off back to the town again to get
+help.  One can imagine them, covered with sand, excited and
+disordered, running up the little street in the bright sunlight just
+as the shop folks were taking down their shutters and people were
+opening their bedroom windows.  Henderson went into the railway
+station at once, in order to telegraph the news to London.  The
+newspaper articles had prepared men's minds for the reception of the
+idea.
+
+By eight o'clock a number of boys and unemployed men had already
+started for the common to see the "dead men from Mars."  That was the
+form the story took.  I heard of it first from my newspaper boy about
+a quarter to nine when I went out to get my _Daily Chronicle_.  I was
+naturally startled, and lost no time in going out and across the
+Ottershaw bridge to the sand pits.
+
+
+
+CHAPTER THREE
+
+ON HORSELL COMMON
+
+
+I found a little crowd of perhaps twenty people surrounding the
+huge hole in which the cylinder lay.  I have already described the
+appearance of that colossal bulk, embedded in the ground.  The turf
+and gravel about it seemed charred as if by a sudden explosion.  No
+doubt its impact had caused a flash of fire.  Henderson and Ogilvy
+were not there.  I think they perceived that nothing was to be done
+for the present, and had gone away to breakfast at Henderson's house.
+
+There were four or five boys sitting on the edge of the Pit, with
+their feet dangling, and amusing themselves--until I stopped them--by
+throwing stones at the giant mass.  After I had spoken to them about
+it, they began playing at "touch" in and out of the group of
+bystanders.
+
+Among these were a couple of cyclists, a jobbing gardener I
+employed sometimes, a girl carrying a baby, Gregg the butcher and his
+little boy, and two or three loafers and golf caddies who were
+accustomed to hang about the railway station.  There was very little
+talking.  Few of the common people in England had anything but the
+vaguest astronomical ideas in those days.  Most of them were staring
+quietly at the big table like end of the cylinder, which was still as
+Ogilvy and Henderson had left it.  I fancy the popular expectation of
+a heap of charred corpses was disappointed at this inanimate bulk.
+Some went away while I was there, and other people came.  I clambered
+into the pit and fancied I heard a faint movement under my feet.  The
+top had certainly ceased to rotate.
+
+It was only when I got thus close to it that the strangeness of
+this object was at all evident to me.  At the first glance it was
+really no more exciting than an overturned carriage or a tree blown
+across the road.  Not so much so, indeed.  It looked like a rusty gas
+float.  It required a certain amount of scientific education to
+perceive that the grey scale of the Thing was no common oxide, that
+the yellowish-white metal that gleamed in the crack between the lid
+and the cylinder had an unfamiliar hue.  "Extra-terrestrial" had no
+meaning for most of the onlookers.
+
+At that time it was quite clear in my own mind that the Thing had
+come from the planet Mars, but I judged it improbable that it
+contained any living creature.  I thought the unscrewing might be
+automatic.  In spite of Ogilvy, I still believed that there were men
+in Mars.  My mind ran fancifully on the possibilities of its
+containing manuscript, on the difficulties in translation that might
+arise, whether we should find coins and models in it, and so forth.
+Yet it was a little too large for assurance on this idea.  I felt an
+impatience to see it opened.  About eleven, as nothing seemed
+happening, I walked back, full of such thought, to my home in Maybury.
+But I found it difficult to get to work upon my abstract
+investigations.
+
+In the afternoon the appearance of the common had altered very
+much.  The early editions of the evening papers had startled London
+with enormous headlines:
+
+  "A MESSAGE RECEIVED FROM MARS."
+
+  "REMARKABLE STORY FROM WOKING,"
+
+and so forth.  In addition, Ogilvy's wire to the Astronomical Exchange
+had roused every observatory in the three kingdoms.
+
+There were half a dozen flies or more from the Woking station
+standing in the road by the sand pits, a basket-chaise from Chobham,
+and a rather lordly carriage.  Besides that, there was quite a heap of
+bicycles.  In addition, a large number of people must have walked, in
+spite of the heat of the day, from Woking and Chertsey, so that there
+was altogether quite a considerable crowd--one or two gaily dressed
+ladies among the others.
+
+It was glaringly hot, not a cloud in the sky nor a breath of wind,
+and the only shadow was that of the few scattered pine trees.  The
+burning heather had been extinguished, but the level ground towards
+Ottershaw was blackened as far as one could see, and still giving off
+vertical streamers of smoke.  An enterprising sweet-stuff dealer in
+the Chobham Road had sent up his son with a barrow-load of green
+apples and ginger beer.
+
+Going to the edge of the pit, I found it occupied by a group of
+about half a dozen men--Henderson, Ogilvy, and a tall, fair-haired man
+that I afterwards learned was Stent, the Astronomer Royal, with
+several workmen wielding spades and pickaxes.  Stent was giving
+directions in a clear, high-pitched voice.  He was standing on the
+cylinder, which was now evidently much cooler; his face was crimson
+and streaming with perspiration, and something seemed to have
+irritated him.
+
+A large portion of the cylinder had been uncovered, though its
+lower end was still embedded.  As soon as Ogilvy saw me among the
+staring crowd on the edge of the pit he called to me to come down, and
+asked me if I would mind going over to see Lord Hilton, the lord of
+the manor.
+
+The growing crowd, he said, was becoming a serious impediment to
+their excavations, especially the boys.  They wanted a light railing
+put up, and help to keep the people back.  He told me that a faint
+stirring was occasionally still audible within the case, but that the
+workmen had failed to unscrew the top, as it afforded no grip to them.
+The case appeared to be enormously thick, and it was possible that the
+faint sounds we heard represented a noisy tumult in the interior.
+
+I was very glad to do as he asked, and so become one of the
+privileged spectators within the contemplated enclosure.  I failed to
+find Lord Hilton at his house, but I was told he was expected from
+London by the six o'clock train from Waterloo; and as it was then
+about a quarter past five, I went home, had some tea, and walked up to
+the station to waylay him.
+
+
+
+CHAPTER FOUR
+
+THE CYLINDER OPENS
+
+
+When I returned to the common the sun was setting.  Scattered groups
+were hurrying from the direction of Woking, and one or two persons
+were returning.  The crowd about the pit had increased, and stood out
+black against the lemon yellow of the sky--a couple of hundred people,
+perhaps.  There were raised voices, and some sort of struggle appeared
+to be going on about the pit.  Strange imaginings passed through my
+mind.  As I drew nearer I heard Stent's voice:
+
+"Keep back!  Keep back!"
+
+A boy came running towards me.
+
+"It's a-movin'," he said to me as he passed; "a-screwin' and
+a-screwin' out.  I don't like it.  I'm a-goin' 'ome, I am."
+
+I went on to the crowd.  There were really, I should think, two or
+three hundred people elbowing and jostling one another, the one or two
+ladies there being by no means the least active.
+
+"He's fallen in the pit!" cried some one.
+
+"Keep back!" said several.
+
+The crowd swayed a little, and I elbowed my way through.  Every one
+seemed greatly excited.  I heard a peculiar humming sound from the
+pit.
+
+"I say!" said Ogilvy; "help keep these idiots back.  We don't know
+what's in the confounded thing, you know!"
+
+I saw a young man, a shop assistant in Woking I believe he was,
+standing on the cylinder and trying to scramble out of the hole again.
+The crowd had pushed him in.
+
+The end of the cylinder was being screwed out from within.  Nearly
+two feet of shining screw projected.  Somebody blundered against me,
+and I narrowly missed being pitched onto the top of the screw.  I
+turned, and as I did so the screw must have come out, for the lid of
+the cylinder fell upon the gravel with a ringing concussion.  I stuck
+my elbow into the person behind me, and turned my head towards the
+Thing again.  For a moment that circular cavity seemed perfectly black.
+I had the sunset in my eyes.
+
+I think everyone expected to see a man emerge--possibly something a
+little unlike us terrestrial men, but in all essentials a man.  I know
+I did.  But, looking, I presently saw something stirring within the
+shadow: greyish billowy movements, one above another, and then two
+luminous disks--like eyes.  Then something resembling a little grey
+snake, about the thickness of a walking stick, coiled up out of the
+writhing middle, and wriggled in the air towards me--and then another.
+
+A sudden chill came over me.  There was a loud shriek from a woman
+behind.  I half turned, keeping my eyes fixed upon the cylinder still,
+from which other tentacles were now projecting, and began pushing my
+way back from the edge of the pit.  I saw astonishment giving place to
+horror on the faces of the people about me.  I heard inarticulate
+exclamations on all sides.  There was a general movement backwards.
+I saw the shopman struggling still on the edge of the pit.  I found
+myself alone, and saw the people on the other side of the pit running
+off, Stent among them.  I looked again at the cylinder, and
+ungovernable terror gripped me.  I stood petrified and staring.
+
+A big greyish rounded bulk, the size, perhaps, of a bear, was
+rising slowly and painfully out of the cylinder.  As it bulged up and
+caught the light, it glistened like wet leather.
+
+Two large dark-coloured eyes were regarding me steadfastly.  The
+mass that framed them, the head of the thing, was rounded, and had,
+one might say, a face.  There was a mouth under the eyes, the lipless
+brim of which quivered and panted, and dropped saliva.  The whole
+creature heaved and pulsated convulsively.  A lank tentacular
+appendage gripped the edge of the cylinder, another swayed in the air.
+
+Those who have never seen a living Martian can scarcely imagine the
+strange horror of its appearance.  The peculiar V-shaped mouth with
+its pointed upper lip, the absence of brow ridges, the absence of a
+chin beneath the wedgelike lower lip, the incessant quivering of this
+mouth, the Gorgon groups of tentacles, the tumultuous breathing of the
+lungs in a strange atmosphere, the evident heaviness and painfulness
+of movement due to the greater gravitational energy of the earth--above
+all, the extraordinary intensity of the immense eyes--were at
+once vital, intense, inhuman, crippled and monstrous.  There was
+something fungoid in the oily brown skin, something in the clumsy
+deliberation of the tedious movements unspeakably nasty.  Even at this
+first encounter, this first glimpse, I was overcome with disgust and
+dread.
+
+Suddenly the monster vanished.  It had toppled over the brim of the
+cylinder and fallen into the pit, with a thud like the fall of a great
+mass of leather.  I heard it give a peculiar thick cry, and forthwith
+another of these creatures appeared darkly in the deep shadow of the
+aperture.
+
+I turned and, running madly, made for the first group of trees,
+perhaps a hundred yards away; but I ran slantingly and stumbling, for
+I could not avert my face from these things.
+
+There, among some young pine trees and furze bushes, I stopped,
+panting, and waited further developments.  The common round the sand
+pits was dotted with people, standing like myself in a half-fascinated
+terror, staring at these creatures, or rather at the heaped gravel at
+the edge of the pit in which they lay.  And then, with a renewed
+horror, I saw a round, black object bobbing up and down on the edge of
+the pit.  It was the head of the shopman who had fallen in, but
+showing as a little black object against the hot western sun.  Now he
+got his shoulder and knee up, and again he seemed to slip back until
+only his head was visible.  Suddenly he vanished, and I could have
+fancied a faint shriek had reached me.  I had a momentary impulse to
+go back and help him that my fears overruled.
+
+Everything was then quite invisible, hidden by the deep pit and the
+heap of sand that the fall of the cylinder had made.  Anyone coming
+along the road from Chobham or Woking would have been amazed at the
+sight--a dwindling multitude of perhaps a hundred people or more
+standing in a great irregular circle, in ditches, behind bushes,
+behind gates and hedges, saying little to one another and that in
+short, excited shouts, and staring, staring hard at a few heaps of
+sand.  The barrow of ginger beer stood, a queer derelict, black
+against the burning sky, and in the sand pits was a row of deserted
+vehicles with their horses feeding out of nosebags or pawing the
+ground.
+
+
+
+CHAPTER FIVE
+
+THE HEAT-RAY
+
+
+After the glimpse I had had of the Martians emerging from the
+cylinder in which they had come to the earth from their planet, a kind
+of fascination paralysed my actions.  I remained standing knee-deep in
+the heather, staring at the mound that hid them.  I was a battleground
+of fear and curiosity.
+
+I did not dare to go back towards the pit, but I felt a passionate
+longing to peer into it.  I began walking, therefore, in a big curve,
+seeking some point of vantage and continually looking at the sand
+heaps that hid these new-comers to our earth.  Once a leash of thin
+black whips, like the arms of an octopus, flashed across the sunset
+and was immediately withdrawn, and afterwards a thin rod rose up,
+joint by joint, bearing at its apex a circular disk that spun with a
+wobbling motion.  What could be going on there?
+
+Most of the spectators had gathered in one or two groups--one a
+little crowd towards Woking, the other a knot of people in the
+direction of Chobham.  Evidently they shared my mental conflict.
+There were few near me.  One man I approached--he was, I perceived,
+a neighbour of mine, though I did not know his name--and accosted.
+But it was scarcely a time for articulate conversation.
+
+"What ugly _brutes_!" he said.  "Good God!  What ugly brutes!"  He
+repeated this over and over again.
+
+"Did you see a man in the pit?" I said; but he made no answer to
+that.  We became silent, and stood watching for a time side by side,
+deriving, I fancy, a certain comfort in one another's company.  Then I
+shifted my position to a little knoll that gave me the advantage of a
+yard or more of elevation and when I looked for him presently he was
+walking towards Woking.
+
+The sunset faded to twilight before anything further happened.  The
+crowd far away on the left, towards Woking, seemed to grow, and I
+heard now a faint murmur from it.  The little knot of people towards
+Chobham dispersed.  There was scarcely an intimation of movement from
+the pit.
+
+It was this, as much as anything, that gave people courage, and I
+suppose the new arrivals from Woking also helped to restore
+confidence.  At any rate, as the dusk came on a slow, intermittent
+movement upon the sand pits began, a movement that seemed to gather
+force as the stillness of the evening about the cylinder remained
+unbroken.  Vertical black figures in twos and threes would advance,
+stop, watch, and advance again, spreading out as they did so in a thin
+irregular crescent that promised to enclose the pit in its attenuated
+horns.  I, too, on my side began to move towards the pit.
+
+Then I saw some cabmen and others had walked boldly into the sand
+pits, and heard the clatter of hoofs and the gride of wheels.  I saw a
+lad trundling off the barrow of apples.  And then, within thirty yards
+of the pit, advancing from the direction of Horsell, I noted a little
+black knot of men, the foremost of whom was waving a white flag.
+
+This was the Deputation.  There had been a hasty consultation, and
+since the Martians were evidently, in spite of their repulsive forms,
+intelligent creatures, it had been resolved to show them, by
+approaching them with signals, that we too were intelligent.
+
+Flutter, flutter, went the flag, first to the right, then to the
+left.  It was too far for me to recognise anyone there, but afterwards
+I learned that Ogilvy, Stent, and Henderson were with others in this
+attempt at communication.  This little group had in its advance
+dragged inward, so to speak, the circumference of the now almost
+complete circle of people, and a number of dim black figures followed
+it at discreet distances.
+
+Suddenly there was a flash of light, and a quantity of luminous
+greenish smoke came out of the pit in three distinct puffs, which
+drove up, one after the other, straight into the still air.
+
+This smoke (or flame, perhaps, would be the better word for it) was
+so bright that the deep blue sky overhead and the hazy stretches of
+brown common towards Chertsey, set with black pine trees, seemed to
+darken abruptly as these puffs arose, and to remain the darker after
+their dispersal.  At the same time a faint hissing sound became
+audible.
+
+Beyond the pit stood the little wedge of people with the white flag
+at its apex, arrested by these phenomena, a little knot of small
+vertical black shapes upon the black ground.  As the green smoke arose,
+their faces flashed out pallid green, and faded again as it vanished.
+Then slowly the hissing passed into a humming, into a long, loud,
+droning noise.  Slowly a humped shape rose out of the pit, and the
+ghost of a beam of light seemed to flicker out from it.
+
+Forthwith flashes of actual flame, a bright glare leaping from one
+to another, sprang from the scattered group of men.  It was as if some
+invisible jet impinged upon them and flashed into white flame.  It was
+as if each man were suddenly and momentarily turned to fire.
+
+Then, by the light of their own destruction, I saw them staggering
+and falling, and their supporters turning to run.
+
+I stood staring, not as yet realising that this was death leaping
+from man to man in that little distant crowd.  All I felt was that it
+was something very strange.  An almost noiseless and blinding flash of
+light, and a man fell headlong and lay still; and as the unseen shaft
+of heat passed over them, pine trees burst into fire, and every dry
+furze bush became with one dull thud a mass of flames.  And far away
+towards Knaphill I saw the flashes of trees and hedges and wooden
+buildings suddenly set alight.
+
+It was sweeping round swiftly and steadily, this flaming death,
+this invisible, inevitable sword of heat.  I perceived it coming
+towards me by the flashing bushes it touched, and was too astounded
+and stupefied to stir.  I heard the crackle of fire in the sand pits
+and the sudden squeal of a horse that was as suddenly stilled.  Then
+it was as if an invisible yet intensely heated finger were drawn
+through the heather between me and the Martians, and all along a
+curving line beyond the sand pits the dark ground smoked and crackled.
+Something fell with a crash far away to the left where the road from
+Woking station opens out on the common.  Forth-with the hissing and
+humming ceased, and the black, dome-like object sank slowly out of
+sight into the pit.
+
+All this had happened with such swiftness that I had stood
+motionless, dumbfounded and dazzled by the flashes of light.  Had that
+death swept through a full circle, it must inevitably have slain me in
+my surprise.  But it passed and spared me, and left the night about me
+suddenly dark and unfamiliar.
+
+The undulating common seemed now dark almost to blackness, except
+where its roadways lay grey and pale under the deep blue sky of the
+early night.  It was dark, and suddenly void of men.  Overhead the
+stars were mustering, and in the west the sky was still a pale,
+bright, almost greenish blue.  The tops of the pine trees and the
+roofs of Horsell came out sharp and black against the western
+afterglow.  The Martians and their appliances were altogether
+invisible, save for that thin mast upon which their restless mirror
+wobbled.  Patches of bush and isolated trees here and there smoked and
+glowed still, and the houses towards Woking station were sending up
+spires of flame into the stillness of the evening air.
+
+Nothing was changed save for that and a terrible astonishment.  The
+little group of black specks with the flag of white had been swept out
+of existence, and the stillness of the evening, so it seemed to me,
+had scarcely been broken.
+
+It came to me that I was upon this dark common, helpless,
+unprotected, and alone.  Suddenly, like a thing falling upon me from
+without, came--fear.
+
+With an effort I turned and began a stumbling run through the
+heather.
+
+The fear I felt was no rational fear, but a panic terror not only
+of the Martians, but of the dusk and stillness all about me.  Such an
+extraordinary effect in unmanning me it had that I ran weeping
+silently as a child might do.  Once I had turned, I did not dare to
+look back.
+
+I remember I felt an extraordinary persuasion that I was being
+played with, that presently, when I was upon the very verge of safety,
+this mysterious death--as swift as the passage of light--would leap
+after me from the pit about the cylinder and strike me down.
+
+
+
+CHAPTER SIX
+
+THE HEAT-RAY IN THE CHOBHAM ROAD
+
+
+It is still a matter of wonder how the Martians are able to slay
+men so swiftly and so silently.  Many think that in some way they are
+able to generate an intense heat in a chamber of practically absolute
+non-conductivity.  This intense heat they project in a parallel beam
+against any object they choose, by means of a polished parabolic
+mirror of unknown composition, much as the parabolic mirror of a
+lighthouse projects a beam of light.  But no one has absolutely proved
+these details.  However it is done, it is certain that a beam of heat
+is the essence of the matter.  Heat, and invisible, instead of
+visible, light.  Whatever is combustible flashes into flame at its
+touch, lead runs like water, it softens iron, cracks and melts glass,
+and when it falls upon water, incontinently that explodes into steam.
+
+That night nearly forty people lay under the starlight about the
+pit, charred and distorted beyond recognition, and all night long the
+common from Horsell to Maybury was deserted and brightly ablaze.
+
+The news of the massacre probably reached Chobham, Woking, and
+Ottershaw about the same time.  In Woking the shops had closed when
+the tragedy happened, and a number of people, shop people and so
+forth, attracted by the stories they had heard, were walking over the
+Horsell Bridge and along the road between the hedges that runs out at
+last upon the common.  You may imagine the young people brushed up
+after the labours of the day, and making this novelty, as they would
+make any novelty, the excuse for walking together and enjoying a
+trivial flirtation.  You may figure to yourself the hum of voices
+along the road in the gloaming. . . .
+
+As yet, of course, few people in Woking even knew that the cylinder
+had opened, though poor Henderson had sent a messenger on a bicycle to
+the post office with a special wire to an evening paper.
+
+As these folks came out by twos and threes upon the open, they
+found little knots of people talking excitedly and peering at the
+spinning mirror over the sand pits, and the newcomers were, no doubt,
+soon infected by the excitement of the occasion.
+
+By half past eight, when the Deputation was destroyed, there may
+have been a crowd of three hundred people or more at this place,
+besides those who had left the road to approach the Martians nearer.
+There were three policemen too, one of whom was mounted, doing their
+best, under instructions from Stent, to keep the people back and deter
+them from approaching the cylinder.  There was some booing from those
+more thoughtless and excitable souls to whom a crowd is always an
+occasion for noise and horse-play.
+
+Stent and Ogilvy, anticipating some possibilities of a collision,
+had telegraphed from Horsell to the barracks as soon as the Martians
+emerged, for the help of a company of soldiers to protect these
+strange creatures from violence.  After that they returned to lead that
+ill-fated advance.  The description of their death, as it was seen by
+the crowd, tallies very closely with my own impressions: the three
+puffs of green smoke, the deep humming note, and the flashes of flame.
+
+But that crowd of people had a far narrower escape than mine.  Only
+the fact that a hummock of heathery sand intercepted the lower part of
+the Heat-Ray saved them.  Had the elevation of the parabolic mirror
+been a few yards higher, none could have lived to tell the tale.  They
+saw the flashes and the men falling and an invisible hand, as it were,
+lit the bushes as it hurried towards them through the twilight.  Then,
+with a whistling note that rose above the droning of the pit, the beam
+swung close over their heads, lighting the tops of the beech trees
+that line the road, and splitting the bricks, smashing the windows,
+firing the window frames, and bringing down in crumbling ruin a
+portion of the gable of the house nearest the corner.
+
+In the sudden thud, hiss, and glare of the igniting trees, the
+panic-stricken crowd seems to have swayed hesitatingly for some
+moments.  Sparks and burning twigs began to fall into the road, and
+single leaves like puffs of flame.  Hats and dresses caught fire.  Then
+came a crying from the common.  There were shrieks and shouts, and
+suddenly a mounted policeman came galloping through the confusion with
+his hands clasped over his head, screaming.
+
+"They're coming!" a woman shrieked, and incontinently everyone was
+turning and pushing at those behind, in order to clear their way to
+Woking again.  They must have bolted as blindly as a flock of sheep.
+Where the road grows narrow and black between the high banks the crowd
+jammed, and a desperate struggle occurred.  All that crowd did not
+escape; three persons at least, two women and a little boy, were
+crushed and trampled there, and left to die amid the terror and the
+darkness.
+
+
+
+CHAPTER SEVEN
+
+HOW I REACHED HOME
+
+
+For my own part, I remember nothing of my flight except the stress
+of blundering against trees and stumbling through the heather.  All
+about me gathered the invisible terrors of the Martians; that pitiless
+sword of heat seemed whirling to and fro, flourishing overhead before
+it descended and smote me out of life.  I came into the road between
+the crossroads and Horsell, and ran along this to the crossroads.
+
+At last I could go no further; I was exhausted with the violence of
+my emotion and of my flight, and I staggered and fell by the wayside.
+That was near the bridge that crosses the canal by the gasworks.  I
+fell and lay still.
+
+I must have remained there some time.
+
+I sat up, strangely perplexed.  For a moment, perhaps, I could not
+clearly understand how I came there.  My terror had fallen from me
+like a garment.  My hat had gone, and my collar had burst away from
+its fastener.  A few minutes before, there had only been three real
+things before me--the immensity of the night and space and nature, my
+own feebleness and anguish, and the near approach of death.  Now it
+was as if something turned over, and the point of view altered
+abruptly.  There was no sensible transition from one state of mind to
+the other.  I was immediately the self of every day again--a decent,
+ordinary citizen.  The silent common, the impulse of my flight, the
+starting flames, were as if they had been in a dream.  I asked myself
+had these latter things indeed happened?  I could not credit it.
+
+I rose and walked unsteadily up the steep incline of the bridge.  My
+mind was blank wonder.  My muscles and nerves seemed drained of their
+strength.  I dare say I staggered drunkenly.  A head rose over the
+arch, and the figure of a workman carrying a basket appeared.  Beside
+him ran a little boy.  He passed me, wishing me good night.  I was
+minded to speak to him, but did not.  I answered his greeting with a
+meaningless mumble and went on over the bridge.
+
+Over the Maybury arch a train, a billowing tumult of white, firelit
+smoke, and a long caterpillar of lighted windows, went flying
+south--clatter, clatter, clap, rap, and it had gone.  A dim group of
+people talked in the gate of one of the houses in the pretty little
+row of gables that was called Oriental Terrace.  It was all so real
+and so familiar.  And that behind me!  It was frantic, fantastic!
+Such things, I told myself, could not be.
+
+Perhaps I am a man of exceptional moods.  I do not know how far my
+experience is common.  At times I suffer from the strangest sense of
+detachment from myself and the world about me; I seem to watch it all
+from the outside, from somewhere inconceivably remote, out of time,
+out of space, out of the stress and tragedy of it all.  This feeling
+was very strong upon me that night.  Here was another side to my
+dream.
+
+But the trouble was the blank incongruity of this serenity and the
+swift death flying yonder, not two miles away.  There was a noise of
+business from the gasworks, and the electric lamps were all alight.  I
+stopped at the group of people.
+
+"What news from the common?" said I.
+
+There were two men and a woman at the gate.
+
+"Eh?" said one of the men, turning.
+
+"What news from the common?" I said.
+
+"'Ain't yer just _been_ there?" asked the men.
+
+"People seem fair silly about the common," said the woman over the
+gate.  "What's it all abart?"
+
+"Haven't you heard of the men from Mars?" said I; "the creatures
+from Mars?"
+
+"Quite enough," said the woman over the gate.  "Thenks"; and all
+three of them laughed.
+
+I felt foolish and angry.  I tried and found I could not tell them
+what I had seen.  They laughed again at my broken sentences.
+
+"You'll hear more yet," I said, and went on to my home.
+
+I startled my wife at the doorway, so haggard was I.  I went into
+the dining room, sat down, drank some wine, and so soon as I could
+collect myself sufficiently I told her the things I had seen.  The
+dinner, which was a cold one, had already been served, and remained
+neglected on the table while I told my story.
+
+"There is one thing," I said, to allay the fears I had aroused;
+"they are the most sluggish things I ever saw crawl.  They may keep
+the pit and kill people who come near them, but they cannot get out
+of it. . . .  But the horror of them!"
+
+"Don't, dear!" said my wife, knitting her brows and putting her
+hand on mine.
+
+"Poor Ogilvy!" I said.  "To think he may be lying dead there!"
+
+My wife at least did not find my experience incredible.  When I saw
+how deadly white her face was, I ceased abruptly.
+
+"They may come here," she said again and again.
+
+I pressed her to take wine, and tried to reassure her.
+
+"They can scarcely move," I said.
+
+I began to comfort her and myself by repeating all that Ogilvy had
+told me of the impossibility of the Martians establishing themselves
+on the earth.  In particular I laid stress on the gravitational
+difficulty.  On the surface of the earth the force of gravity is three
+times what it is on the surface of Mars.  A Martian, therefore, would
+weigh three times more than on Mars, albeit his muscular strength
+would be the same.  His own body would be a cope of lead to him.  That,
+indeed, was the general opinion.  Both _The Times_ and the _Daily
+Telegraph_, for instance, insisted on it the next morning, and both
+overlooked, just as I did, two obvious modifying influences.
+
+The atmosphere of the earth, we now know, contains far more oxygen
+or far less argon (whichever way one likes to put it) than does Mars.
+The invigorating influences of this excess of oxygen upon the Martians
+indisputably did much to counterbalance the increased weight of their
+bodies.  And, in the second place, we all overlooked the fact that
+such mechanical intelligence as the Martian possessed was quite able
+to dispense with muscular exertion at a pinch.
+
+But I did not consider these points at the time, and so my
+reasoning was dead against the chances of the invaders.  With wine and
+food, the confidence of my own table, and the necessity of reassuring
+my wife, I grew by insensible degrees courageous and secure.
+
+"They have done a foolish thing," said I, fingering my wineglass.
+"They are dangerous because, no doubt, they are mad with terror.
+Perhaps they expected to find no living things--certainly no
+intelligent living things."
+
+"A shell in the pit" said I, "if the worst comes to the worst will
+kill them all."
+
+The intense excitement of the events had no doubt left my
+perceptive powers in a state of erethism.  I remember that dinner
+table with extraordinary vividness even now.  My dear wife's sweet
+anxious face peering at me from under the pink lamp shade, the white
+cloth with its silver and glass table furniture--for in those days
+even philosophical writers had many little luxuries--the crimson-purple
+wine in my glass, are photographically distinct.  At the end of
+it I sat, tempering nuts with a cigarette, regretting Ogilvy's
+rashness, and denouncing the shortsighted timidity of the Martians.
+
+So some respectable dodo in the Mauritius might have lorded it in
+his nest, and discussed the arrival of that shipful of pitiless
+sailors in want of animal food.  "We will peck them to death tomorrow,
+my dear."
+
+I did not know it, but that was the last civilised dinner I was to
+eat for very many strange and terrible days.
+
+
+
+CHAPTER EIGHT
+
+FRIDAY NIGHT
+
+
+The most extraordinary thing to my mind, of all the strange and
+wonderful things that happened upon that Friday, was the dovetailing
+of the commonplace habits of our social order with the first
+beginnings of the series of events that was to topple that social
+order headlong.  If on Friday night you had taken a pair of compasses
+and drawn a circle with a radius of five miles round the Woking sand
+pits, I doubt if you would have had one human being outside it, unless
+it were some relation of Stent or of the three or four cyclists or
+London people lying dead on the common, whose emotions or habits were
+at all affected by the new-comers.  Many people had heard of the
+cylinder, of course, and talked about it in their leisure, but it
+certainly did not make the sensation that an ultimatum to Germany
+would have done.
+
+In London that night poor Henderson's telegram describing the
+gradual unscrewing of the shot was judged to be a canard, and his
+evening paper, after wiring for authentication from him and receiving
+no reply--the man was killed--decided not to print a special edition.
+
+Even within the five-mile circle the great majority of people were
+inert.  I have already described the behaviour of the men and women to
+whom I spoke.  All over the district people were dining and supping;
+working men were gardening after the labours of the day, children
+were being put to bed, young people were wandering through the lanes
+love-making, students sat over their books.
+
+Maybe there was a murmur in the village streets, a novel and
+dominant topic in the public-houses, and here and there a messenger,
+or even an eye-witness of the later occurrences, caused a whirl of
+excitement, a shouting, and a running to and fro; but for the most
+part the daily routine of working, eating, drinking, sleeping, went on
+as it had done for countless years--as though no planet Mars existed
+in the sky.  Even at Woking station and Horsell and Chobham that was
+the case.
+
+In Woking junction, until a late hour, trains were stopping and
+going on, others were shunting on the sidings, passengers were
+alighting and waiting, and everything was proceeding in the most
+ordinary way.  A boy from the town, trenching on Smith's monopoly, was
+selling papers with the afternoon's news.  The ringing impact of
+trucks, the sharp whistle of the engines from the junction, mingled
+with their shouts of "Men from Mars!"  Excited men came into the
+station about nine o'clock with incredible tidings, and caused no more
+disturbance than drunkards might have done.  People rattling
+Londonwards peered into the darkness outside the carriage windows, and
+saw only a rare, flickering, vanishing spark dance up from the
+direction of Horsell, a red glow and a thin veil of smoke driving
+across the stars, and thought that nothing more serious than a heath
+fire was happening.  It was only round the edge of the common that any
+disturbance was perceptible.  There were half a dozen villas burning
+on the Woking border.  There were lights in all the houses on the
+common side of the three villages, and the people there kept awake
+till dawn.
+
+A curious crowd lingered restlessly, people coming and going but
+the crowd remaining, both on the Chobham and Horsell bridges.  One or
+two adventurous souls, it was afterwards found, went into the darkness
+and crawled quite near the Martians; but they never returned, for now
+and again a light-ray, like the beam of a warship's searchlight swept
+the common, and the Heat-Ray was ready to follow.  Save for such, that
+big area of common was silent and desolate, and the charred bodies lay
+about on it all night under the stars, and all the next day.  A noise
+of hammering from the pit was heard by many people.
+
+So you have the state of things on Friday night.  In the centre,
+sticking into the skin of our old planet Earth like a poisoned dart,
+was this cylinder.  But the poison was scarcely working yet.  Around
+it was a patch of silent common, smouldering in places, and with a few
+dark, dimly seen objects lying in contorted attitudes here and there.
+Here and there was a burning bush or tree.  Beyond was a fringe of
+excitement, and farther than that fringe the inflammation had not
+crept as yet.  In the rest of the world the stream of life still
+flowed as it had flowed for immemorial years.  The fever of war that
+would presently clog vein and artery, deaden nerve and destroy brain,
+had still to develop.
+
+All night long the Martians were hammering and stirring, sleepless,
+indefatigable, at work upon the machines they were making ready, and
+ever and again a puff of greenish-white smoke whirled up to the
+starlit sky.
+
+About eleven a company of soldiers came through Horsell, and
+deployed along the edge of the common to form a cordon.  Later a
+second company marched through Chobham to deploy on the north side of
+the common.  Several officers from the Inkerman barracks had been on
+the common earlier in the day, and one, Major Eden, was reported to be
+missing.  The colonel of the regiment came to the Chobham bridge and
+was busy questioning the crowd at midnight.  The military authorities
+were certainly alive to the seriousness of the business.  About
+eleven, the next morning's papers were able to say, a squadron of
+hussars, two Maxims, and about four hundred men of the Cardigan
+regiment started from Aldershot.
+
+A few seconds after midnight the crowd in the Chertsey road,
+Woking, saw a star fall from heaven into the pine woods to the
+northwest.  It had a greenish colour, and caused a silent brightness
+like summer lightning.  This was the second cylinder.
+
+
+
+CHAPTER NINE
+
+THE FIGHTING BEGINS
+
+
+Saturday lives in my memory as a day of suspense.  It was a day of
+lassitude too, hot and close, with, I am told, a rapidly fluctuating
+barometer.  I had slept but little, though my wife had succeeded in
+sleeping, and I rose early.  I went into my garden before breakfast
+and stood listening, but towards the common there was nothing stirring
+but a lark.
+
+The milkman came as usual.  I heard the rattle of his chariot and I
+went round to the side gate to ask the latest news.  He told me that
+during the night the Martians had been surrounded by troops, and that
+guns were expected.  Then--a familiar, reassuring note--I heard a train
+running towards Woking.
+
+"They aren't to be killed," said the milkman, "if that can possibly
+be avoided."
+
+I saw my neighbour gardening, chatted with him for a time, and then
+strolled in to breakfast.  It was a most unexceptional morning.  My
+neighbour was of opinion that the troops would be able to capture or
+to destroy the Martians during the day.
+
+"It's a pity they make themselves so unapproachable," he said.  "It
+would be curious to know how they live on another planet; we might
+learn a thing or two."
+
+He came up to the fence and extended a handful of strawberries, for
+his gardening was as generous as it was enthusiastic.  At the same
+time he told me of the burning of the pine woods about the Byfleet
+Golf Links.
+
+"They say," said he, "that there's another of those blessed things
+fallen there--number two.  But one's enough, surely.  This lot'll cost
+the insurance people a pretty penny before everything's settled."  He
+laughed with an air of the greatest good humour as he said this.  The
+woods, he said, were still burning, and pointed out a haze of smoke to
+me.  "They will be hot under foot for days, on account of the thick
+soil of pine needles and turf," he said, and then grew serious over
+"poor Ogilvy."
+
+After breakfast, instead of working, I decided to walk down
+towards the common.  Under the railway bridge I found a group of
+soldiers--sappers, I think, men in small round caps, dirty red jackets
+unbuttoned, and showing their blue shirts, dark trousers, and boots
+coming to the calf.  They told me no one was allowed over the canal,
+and, looking along the road towards the bridge, I saw one of the
+Cardigan men standing sentinel there.  I talked with these soldiers
+for a time; I told them of my sight of the Martians on the previous
+evening.  None of them had seen the Martians, and they had but the
+vaguest ideas of them, so that they plied me with questions.  They
+said that they did not know who had authorised the movements of the
+troops; their idea was that a dispute had arisen at the Horse Guards.
+The ordinary sapper is a great deal better educated than the common
+soldier, and they discussed the peculiar conditions of the possible
+fight with some acuteness.  I described the Heat-Ray to them, and they
+began to argue among themselves.
+
+"Crawl up under cover and rush 'em, say I," said one.
+
+"Get aht!" said another.  "What's cover against this 'ere 'eat?
+Sticks to cook yer!  What we got to do is to go as near as the
+ground'll let us, and then drive a trench."
+
+"Blow yer trenches!  You always want trenches; you ought to ha'
+been born a rabbit Snippy."
+
+"Ain't they got any necks, then?" said a third, abruptly--a little,
+contemplative, dark man, smoking a pipe.
+
+I repeated my description.
+
+"Octopuses," said he, "that's what I calls 'em.  Talk about fishers
+of men--fighters of fish it is this time!"
+
+"It ain't no murder killing beasts like that," said the first
+speaker.
+
+"Why not shell the darned things strite off and finish 'em?" said
+the little dark man.  "You carn tell what they might do."
+
+"Where's your shells?" said the first speaker.  "There ain't no
+time.  Do it in a rush, that's my tip, and do it at once."
+
+So they discussed it.  After a while I left them, and went on to
+the railway station to get as many morning papers as I could.
+
+But I will not weary the reader with a description of that long
+morning and of the longer afternoon.  I did not succeed in getting a
+glimpse of the common, for even Horsell and Chobham church towers were
+in the hands of the military authorities.  The soldiers I addressed
+didn't know anything; the officers were mysterious as well as busy.  I
+found people in the town quite secure again in the presence of the
+military, and I heard for the first time from Marshall, the
+tobacconist, that his son was among the dead on the common.  The
+soldiers had made the people on the outskirts of Horsell lock up and
+leave their houses.
+
+I got back to lunch about two, very tired for, as I have said, the
+day was extremely hot and dull; and in order to refresh myself I took
+a cold bath in the afternoon.  About half past four I went up to the
+railway station to get an evening paper, for the morning papers had
+contained only a very inaccurate description of the killing of Stent,
+Henderson, Ogilvy, and the others.  But there was little I didn't
+know.  The Martians did not show an inch of themselves.  They seemed
+busy in their pit, and there was a sound of hammering and an almost
+continuous streamer of smoke.  Apparently they were busy getting ready
+for a struggle.  "Fresh attempts have been made to signal, but without
+success," was the stereotyped formula of the papers.  A sapper told me
+it was done by a man in a ditch with a flag on a long pole.  The
+Martians took as much notice of such advances as we should of the
+lowing of a cow.
+
+I must confess the sight of all this armament, all this
+preparation, greatly excited me.  My imagination became belligerent,
+and defeated the invaders in a dozen striking ways; something of my
+schoolboy dreams of battle and heroism came back.  It hardly seemed a
+fair fight to me at that time.  They seemed very helpless in that pit
+of theirs.
+
+About three o'clock there began the thud of a gun at measured
+intervals from Chertsey or Addlestone.  I learned that the smouldering
+pine wood into which the second cylinder had fallen was being shelled,
+in the hope of destroying that object before it opened.  It was only
+about five, however, that a field gun reached Chobham for use against
+the first body of Martians.
+
+About six in the evening, as I sat at tea with my wife in the
+summerhouse talking vigorously about the battle that was lowering upon
+us, I heard a muffled detonation from the common, and immediately
+after a gust of firing.  Close on the heels of that came a violent
+rattling crash, quite close to us, that shook the ground; and,
+starting out upon the lawn, I saw the tops of the trees about the
+Oriental College burst into smoky red flame, and the tower of the
+little church beside it slide down into ruin.  The pinnacle of the
+mosque had vanished, and the roof line of the college itself looked as
+if a hundred-ton gun had been at work upon it.  One of our chimneys
+cracked as if a shot had hit it, flew, and a piece of it came
+clattering down the tiles and made a heap of broken red fragments upon
+the flower bed by my study window.
+
+I and my wife stood amazed.  Then I realised that the crest of
+Maybury Hill must be within range of the Martians' Heat-Ray now that
+the college was cleared out of the way.
+
+At that I gripped my wife's arm, and without ceremony ran her out
+into the road.  Then I fetched out the servant, telling her I would go
+upstairs myself for the box she was clamouring for.
+
+"We can't possibly stay here," I said; and as I spoke the firing
+reopened for a moment upon the common.
+
+"But where are we to go?" said my wife in terror.
+
+I thought perplexed.  Then I remembered her cousins at Leatherhead.
+
+"Leatherhead!" I shouted above the sudden noise.
+
+She looked away from me downhill.  The people were coming out of
+their houses, astonished.
+
+"How are we to get to Leatherhead?" she said.
+
+Down the hill I saw a bevy of hussars ride under the railway
+bridge; three galloped through the open gates of the Oriental College;
+two others dismounted, and began running from house to house.  The
+sun, shining through the smoke that drove up from the tops of the
+trees, seemed blood red, and threw an unfamiliar lurid light upon
+everything.
+
+"Stop here," said I; "you are safe here"; and I started off at once
+for the Spotted Dog, for I knew the landlord had a horse and dog cart.
+I ran, for I perceived that in a moment everyone upon this side of the
+hill would be moving.  I found him in his bar, quite unaware of what
+was going on behind his house.  A man stood with his back to me,
+talking to him.
+
+"I must have a pound," said the landlord, "and I've no one to drive
+it."
+
+"I'll give you two," said I, over the stranger's shoulder.
+
+"What for?"
+
+"And I'll bring it back by midnight," I said.
+
+"Lord!" said the landlord; "what's the hurry?  I'm selling my bit
+of a pig.  Two pounds, and you bring it back?  What's going on now?"
+
+I explained hastily that I had to leave my home, and so secured the
+dog cart.  At the time it did not seem to me nearly so urgent that the
+landlord should leave his.  I took care to have the cart there and
+then, drove it off down the road, and, leaving it in charge of my wife
+and servant, rushed into my house and packed a few valuables, such
+plate as we had, and so forth.  The beech trees below the house were
+burning while I did this, and the palings up the road glowed red.
+While I was occupied in this way, one of the dismounted hussars came
+running up.  He was going from house to house, warning people to
+leave.  He was going on as I came out of my front door, lugging my
+treasures, done up in a tablecloth.  I shouted after him:
+
+"What news?"
+
+He turned, stared, bawled something about "crawling out in a thing
+like a dish cover," and ran on to the gate of the house at the crest.
+A sudden whirl of black smoke driving across the road hid him for a
+moment.  I ran to my neighbour's door and rapped to satisfy myself of
+what I already knew, that his wife had gone to London with him and had
+locked up their house.  I went in again, according to my promise, to
+get my servant's box, lugged it out, clapped it beside her on the tail
+of the dog cart, and then caught the reins and jumped up into the
+driver's seat beside my wife.  In another moment we were clear of the
+smoke and noise, and spanking down the opposite slope of Maybury Hill
+towards Old Woking.
+
+In front was a quiet sunny landscape, a wheat field ahead on either
+side of the road, and the Maybury Inn with its swinging sign.  I saw
+the doctor's cart ahead of me.  At the bottom of the hill I turned my
+head to look at the hillside I was leaving.  Thick streamers of black
+smoke shot with threads of red fire were driving up into the still
+air, and throwing dark shadows upon the green treetops eastward.  The
+smoke already extended far away to the east and west--to the Byfleet
+pine woods eastward, and to Woking on the west.  The road was dotted
+with people running towards us.  And very faint now, but very distinct
+through the hot, quiet air, one heard the whirr of a machine-gun that
+was presently stilled, and an intermittent cracking of rifles.
+Apparently the Martians were setting fire to everything within range
+of their Heat-Ray.
+
+I am not an expert driver, and I had immediately to turn my
+attention to the horse.  When I looked back again the second hill had
+hidden the black smoke.  I slashed the horse with the whip, and gave
+him a loose rein until Woking and Send lay between us and that
+quivering tumult.  I overtook and passed the doctor between Woking and
+Send.
+
+
+
+CHAPTER TEN
+
+IN THE STORM
+
+
+Leatherhead is about twelve miles from Maybury Hill.  The scent of
+hay was in the air through the lush meadows beyond Pyrford, and the
+hedges on either side were sweet and gay with multitudes of dog-roses.
+The heavy firing that had broken out while we were driving down
+Maybury Hill ceased as abruptly as it began, leaving the evening very
+peaceful and still.  We got to Leatherhead without misadventure about
+nine o'clock, and the horse had an hour's rest while I took supper
+with my cousins and commended my wife to their care.
+
+My wife was curiously silent throughout the drive, and seemed
+oppressed with forebodings of evil.  I talked to her reassuringly,
+pointing out that the Martians were tied to the Pit by sheer
+heaviness, and at the utmost could but crawl a little out of it; but
+she answered only in monosyllables.  Had it not been for my promise to
+the innkeeper, she would, I think, have urged me to stay in
+Leatherhead that night.  Would that I had!  Her face, I remember, was
+very white as we parted.
+
+For my own part, I had been feverishly excited all day.  Something
+very like the war fever that occasionally runs through a civilised
+community had got into my blood, and in my heart I was not so very
+sorry that I had to return to Maybury that night.  I was even afraid
+that that last fusillade I had heard might mean the extermination of
+our invaders from Mars.  I can best express my state of mind by saying
+that I wanted to be in at the death.
+
+It was nearly eleven when I started to return.  The night was
+unexpectedly dark; to me, walking out of the lighted passage of my
+cousins' house, it seemed indeed black, and it was as hot and close as
+the day.  Overhead the clouds were driving fast, albeit not a breath
+stirred the shrubs about us.  My cousins' man lit both lamps.  Happily,
+I knew the road intimately.  My wife stood in the light of the
+doorway, and watched me until I jumped up into the dog cart.  Then
+abruptly she turned and went in, leaving my cousins side by side
+wishing me good hap.
+
+I was a little depressed at first with the contagion of my wife's
+fears, but very soon my thoughts reverted to the Martians.  At that
+time I was absolutely in the dark as to the course of the evening's
+fighting.  I did not know even the circumstances that had precipitated
+the conflict.  As I came through Ockham (for that was the way I
+returned, and not through Send and Old Woking) I saw along the western
+horizon a blood-red glow, which as I drew nearer, crept slowly up the
+sky.  The driving clouds of the gathering thunderstorm mingled there
+with masses of black and red smoke.
+
+Ripley Street was deserted, and except for a lighted window or so
+the village showed not a sign of life; but I narrowly escaped an
+accident at the corner of the road to Pyrford, where a knot of people
+stood with their backs to me.  They said nothing to me as I passed.  I
+do not know what they knew of the things happening beyond the hill,
+nor do I know if the silent houses I passed on my way were sleeping
+securely, or deserted and empty, or harassed and watching against the
+terror of the night.
+
+From Ripley until I came through Pyrford I was in the valley of the
+Wey, and the red glare was hidden from me.  As I ascended the little
+hill beyond Pyrford Church the glare came into view again, and the
+trees about me shivered with the first intimation of the storm that
+was upon me.  Then I heard midnight pealing out from Pyrford Church
+behind me, and then came the silhouette of Maybury Hill, with its
+tree-tops and roofs black and sharp against the red.
+
+Even as I beheld this a lurid green glare lit the road about me and
+showed the distant woods towards Addlestone.  I felt a tug at the
+reins.  I saw that the driving clouds had been pierced as it were by a
+thread of green fire, suddenly lighting their confusion and falling
+into the field to my left.  It was the third falling star!
+
+Close on its apparition, and blindingly violet by contrast, danced
+out the first lightning of the gathering storm, and the thunder burst
+like a rocket overhead.  The horse took the bit between his teeth and
+bolted.
+
+A moderate incline runs towards the foot of Maybury Hill, and down
+this we clattered.  Once the lightning had begun, it went on in as
+rapid a succession of flashes as I have ever seen.  The thunderclaps,
+treading one on the heels of another and with a strange crackling
+accompaniment, sounded more like the working of a gigantic electric
+machine than the usual detonating reverberations.  The flickering
+light was blinding and confusing, and a thin hail smote gustily at my
+face as I drove down the slope.
+
+At first I regarded little but the road before me, and then
+abruptly my attention was arrested by something that was moving
+rapidly down the opposite slope of Maybury Hill.  At first I took it
+for the wet roof of a house, but one flash following another showed it
+to be in swift rolling movement.  It was an elusive vision--a moment
+of bewildering darkness, and then, in a flash like daylight, the red
+masses of the Orphanage near the crest of the hill, the green tops of
+the pine trees, and this problematical object came out clear and sharp
+and bright.
+
+And this Thing I saw!  How can I describe it?  A monstrous tripod,
+higher than many houses, striding over the young pine trees, and
+smashing them aside in its career; a walking engine of glittering
+metal, striding now across the heather; articulate ropes of steel
+dangling from it, and the clattering tumult of its passage mingling
+with the riot of the thunder.  A flash, and it came out vividly,
+heeling over one way with two feet in the air, to vanish and reappear
+almost instantly as it seemed, with the next flash, a hundred yards
+nearer.  Can you imagine a milking stool tilted and bowled violently
+along the ground?  That was the impression those instant flashes gave.
+But instead of a milking stool imagine it a great body of machinery on
+a tripod stand.
+
+Then suddenly the trees in the pine wood ahead of me were parted,
+as brittle reeds are parted by a man thrusting through them; they were
+snapped off and driven headlong, and a second huge tripod appeared,
+rushing, as it seemed, headlong towards me.  And I was galloping hard
+to meet it! At the sight of the second monster my nerve went
+altogether.  Not stopping to look again, I wrenched the horse's head
+hard round to the right and in another moment the dog cart had heeled
+over upon the horse; the shafts smashed noisily, and I was flung
+sideways and fell heavily into a shallow pool of water.
+
+I crawled out almost immediately, and crouched, my feet still in
+the water, under a clump of furze.  The horse lay motionless (his neck
+was broken, poor brute!) and by the lightning flashes I saw the black
+bulk of the overturned dog cart and the silhouette of the wheel still
+spinning slowly.  In another moment the colossal mechanism went
+striding by me, and passed uphill towards Pyrford.
+
+Seen nearer, the Thing was incredibly strange, for it was no mere
+insensate machine driving on its way.  Machine it was, with a ringing
+metallic pace, and long, flexible, glittering tentacles (one of which
+gripped a young pine tree) swinging and rattling about its strange
+body.  It picked its road as it went striding along, and the brazen
+hood that surmounted it moved to and fro with the inevitable
+suggestion of a head looking about.  Behind the main body was a huge
+mass of white metal like a gigantic fisherman's basket, and puffs of
+green smoke squirted out from the joints of the limbs as the monster
+swept by me.  And in an instant it was gone.
+
+So much I saw then, all vaguely for the flickering of the
+lightning, in blinding highlights and dense black shadows.
+
+As it passed it set up an exultant deafening howl that drowned the
+thunder--"Aloo!  Aloo!"--and in another minute it was with its
+companion, half a mile away, stooping over something in the field.  I
+have no doubt this Thing in the field was the third of the ten
+cylinders they had fired at us from Mars.
+
+For some minutes I lay there in the rain and darkness watching, by
+the intermittent light, these monstrous beings of metal moving about
+in the distance over the hedge tops.  A thin hail was now beginning,
+and as it came and went their figures grew misty and then flashed into
+clearness again.  Now and then came a gap in the lightning, and the
+night swallowed them up.
+
+I was soaked with hail above and puddle water below.  It was some
+time before my blank astonishment would let me struggle up the bank to
+a drier position, or think at all of my imminent peril.
+
+Not far from me was a little one-roomed squatter's hut of wood,
+surrounded by a patch of potato garden.  I struggled to my feet at
+last, and, crouching and making use of every chance of cover, I made a
+run for this.  I hammered at the door, but I could not make the people
+hear (if there were any people inside), and after a time I desisted,
+and, availing myself of a ditch for the greater part of the way,
+succeeded in crawling, unobserved by these monstrous machines, into
+the pine woods towards Maybury.
+
+Under cover of this I pushed on, wet and shivering now, towards my
+own house.  I walked among the trees trying to find the footpath.  It
+was very dark indeed in the wood, for the lightning was now becoming
+infrequent, and the hail, which was pouring down in a torrent, fell in
+columns through the gaps in the heavy foliage.
+
+If I had fully realised the meaning of all the things I had seen I
+should have immediately worked my way round through Byfleet to Street
+Cobham, and so gone back to rejoin my wife at Leatherhead.  But that
+night the strangeness of things about me, and my physical
+wretchedness, prevented me, for I was bruised, weary, wet to the skin,
+deafened and blinded by the storm.
+
+I had a vague idea of going on to my own house, and that was as
+much motive as I had.  I staggered through the trees, fell into a
+ditch and bruised my knees against a plank, and finally splashed out
+into the lane that ran down from the College Arms.  I say splashed,
+for the storm water was sweeping the sand down the hill in a muddy
+torrent.  There in the darkness a man blundered into me and sent me
+reeling back.
+
+He gave a cry of terror, sprang sideways, and rushed on before I
+could gather my wits sufficiently to speak to him.  So heavy was the
+stress of the storm just at this place that I had the hardest task to
+win my way up the hill.  I went close up to the fence on the left and
+worked my way along its palings.
+
+Near the top I stumbled upon something soft, and, by a flash of
+lightning, saw between my feet a heap of black broadcloth and a pair
+of boots.  Before I could distinguish clearly how the man lay, the
+flicker of light had passed.  I stood over him waiting for the next
+flash.  When it came, I saw that he was a sturdy man, cheaply but not
+shabbily dressed; his head was bent under his body, and he lay
+crumpled up close to the fence, as though he had been flung violently
+against it.
+
+Overcoming the repugnance natural to one who had never before
+touched a dead body, I stooped and turned him over to feel for his
+heart.  He was quite dead.  Apparently his neck had been broken.  The
+lightning flashed for a third time, and his face leaped upon me.  I
+sprang to my feet.  It was the landlord of the Spotted Dog, whose
+conveyance I had taken.
+
+I stepped over him gingerly and pushed on up the hill.  I made my
+way by the police station and the College Arms towards my own house.
+Nothing was burning on the hillside, though from the common there
+still came a red glare and a rolling tumult of ruddy smoke beating up
+against the drenching hail.  So far as I could see by the flashes, the
+houses about me were mostly uninjured.  By the College Arms a dark
+heap lay in the road.
+
+Down the road towards Maybury Bridge there were voices and the
+sound of feet, but I had not the courage to shout or to go to them.  I
+let myself in with my latchkey, closed, locked and bolted the door,
+staggered to the foot of the staircase, and sat down.  My imagination
+was full of those striding metallic monsters, and of the dead body
+smashed against the fence.
+
+I crouched at the foot of the staircase with my back to the wall,
+shivering violently.
+
+
+
+CHAPTER ELEVEN
+
+AT THE WINDOW
+
+
+I have already said that my storms of emotion have a trick of
+exhausting themselves.  After a time I discovered that I was cold and
+wet, and with little pools of water about me on the stair carpet.  I
+got up almost mechanically, went into the dining room and drank some
+whiskey, and then I was moved to change my clothes.
+
+After I had done that I went upstairs to my study, but why I did so
+I do not know.  The window of my study looks over the trees and the
+railway towards Horsell Common.  In the hurry of our departure this
+window had been left open.  The passage was dark, and, by contrast with
+the picture the window frame enclosed, the side of the room seemed
+impenetrably dark.  I stopped short in the doorway.
+
+The thunderstorm had passed.  The towers of the Oriental College
+and the pine trees about it had gone, and very far away, lit by a
+vivid red glare, the common about the sand pits was visible.  Across
+the light huge black shapes, grotesque and strange, moved busily to
+and fro.
+
+It seemed indeed as if the whole country in that direction was on
+fire--a broad hillside set with minute tongues of flame, swaying and
+writhing with the gusts of the dying storm, and throwing a red
+reflection upon the cloud-scud above.  Every now and then a haze of
+smoke from some nearer conflagration drove across the window and hid
+the Martian shapes.  I could not see what they were doing, nor the
+clear form of them, nor recognise the black objects they were busied
+upon.  Neither could I see the nearer fire, though the reflections of
+it danced on the wall and ceiling of the study.  A sharp, resinous
+tang of burning was in the air.
+
+I closed the door noiselessly and crept towards the window.  As I
+did so, the view opened out until, on the one hand, it reached to the
+houses about Woking station, and on the other to the charred and
+blackened pine woods of Byfleet.  There was a light down below the
+hill, on the railway, near the arch, and several of the houses along
+the Maybury road and the streets near the station were glowing ruins.
+The light upon the railway puzzled me at first; there were a black
+heap and a vivid glare, and to the right of that a row of yellow
+oblongs.  Then I perceived this was a wrecked train, the fore part
+smashed and on fire, the hinder carriages still upon the rails.
+
+Between these three main centres of light--the houses, the train,
+and the burning county towards Chobham--stretched irregular patches of
+dark country, broken here and there by intervals of dimly glowing and
+smoking ground.  It was the strangest spectacle, that black expanse set
+with fire.  It reminded me, more than anything else, of the Potteries
+at night.  At first I could distinguish no people at all, though I
+peered intently for them.  Later I saw against the light of Woking
+station a number of black figures hurrying one after the other across
+the line.
+
+And this was the little world in which I had been living securely
+for years, this fiery chaos!  What had happened in the last seven
+hours I still did not know; nor did I know, though I was beginning to
+guess, the relation between these mechanical colossi and the sluggish
+lumps I had seen disgorged from the cylinder.  With a queer feeling of
+impersonal interest I turned my desk chair to the window, sat down,
+and stared at the blackened country, and particularly at the three
+gigantic black things that were going to and fro in the glare about
+the sand pits.
+
+They seemed amazingly busy.  I began to ask myself what they could
+be.  Were they intelligent mechanisms?  Such a thing I felt was
+impossible.  Or did a Martian sit within each, ruling, directing,
+using, much as a man's brain sits and rules in his body?  I began to
+compare the things to human machines, to ask myself for the first time
+in my life how an ironclad or a steam engine would seem to an
+intelligent lower animal.
+
+The storm had left the sky clear, and over the smoke of the burning
+land the little fading pinpoint of Mars was dropping into the west,
+when a soldier came into my garden.  I heard a slight scraping at the
+fence, and rousing myself from the lethargy that had fallen upon me, I
+looked down and saw him dimly, clambering over the palings.  At the
+sight of another human being my torpor passed, and I leaned out of the
+window eagerly.
+
+"Hist!" said I, in a whisper.
+
+He stopped astride of the fence in doubt.  Then he came over and
+across the lawn to the corner of the house.  He bent down and stepped
+softly.
+
+"Who's there?" he said, also whispering, standing under the window
+and peering up.
+
+"Where are you going?" I asked.
+
+"God knows."
+
+"Are you trying to hide?"
+
+"That's it."
+
+"Come into the house," I said.
+
+I went down, unfastened the door, and let him in, and locked the
+door again.  I could not see his face.  He was hatless, and his coat
+was unbuttoned.
+
+"My God!" he said, as I drew him in.
+
+"What has happened?" I asked.
+
+"What hasn't?"  In the obscurity I could see he made a gesture of
+despair.  "They wiped us out--simply wiped us out," he repeated again
+and again.
+
+He followed me, almost mechanically, into the dining room.
+
+"Take some whiskey," I said, pouring out a stiff dose.
+
+He drank it.  Then abruptly he sat down before the table, put his
+head on his arms, and began to sob and weep like a little boy, in a
+perfect passion of emotion, while I, with a curious forgetfulness of
+my own recent despair, stood beside him, wondering.
+
+It was a long time before he could steady his nerves to answer my
+questions, and then he answered perplexingly and brokenly.  He was a
+driver in the artillery, and had only come into action about seven.  At
+that time firing was going on across the common, and it was said the
+first party of Martians were crawling slowly towards their second
+cylinder under cover of a metal shield.
+
+Later this shield staggered up on tripod legs and became the first
+of the fighting-machines I had seen.  The gun he drove had been
+unlimbered near Horsell, in order to command the sand pits, and its
+arrival it was that had precipitated the action.  As the limber
+gunners went to the rear, his horse trod in a rabbit hole and came
+down, throwing him into a depression of the ground.  At the same
+moment the gun exploded behind him, the ammunition blew up, there was
+fire all about him, and he found himself lying under a heap of charred
+dead men and dead horses.
+
+"I lay still," he said, "scared out of my wits, with the fore quarter
+of a horse atop of me.  We'd been wiped out.  And the smell--good
+God!  Like burnt meat!  I was hurt across the back by the fall of
+the horse, and there I had to lie until I felt better.  Just like
+parade it had been a minute before--then stumble, bang, swish!"
+
+"Wiped out!" he said.
+
+He had hid under the dead horse for a long time, peeping out
+furtively across the common.  The Cardigan men had tried a rush, in
+skirmishing order, at the pit, simply to be swept out of existence.
+Then the monster had risen to its feet and had begun to walk leisurely
+to and fro across the common among the few fugitives, with its
+headlike hood turning about exactly like the head of a cowled human
+being.  A kind of arm carried a complicated metallic case, about which
+green flashes scintillated, and out of the funnel of this there smoked
+the Heat-Ray.
+
+In a few minutes there was, so far as the soldier could see, not a
+living thing left upon the common, and every bush and tree upon it
+that was not already a blackened skeleton was burning.  The hussars
+had been on the road beyond the curvature of the ground, and he saw
+nothing of them.  He heard the Martians rattle for a time and then
+become still.  The giant saved Woking station and its cluster of houses
+until the last; then in a moment the Heat-Ray was brought to bear, and
+the town became a heap of fiery ruins.  Then the Thing shut off the
+Heat-Ray, and turning its back upon the artilleryman, began to waddle
+away towards the smouldering pine woods that sheltered the second
+cylinder.  As it did so a second glittering Titan built itself up out
+of the pit.
+
+The second monster followed the first, and at that the artilleryman
+began to crawl very cautiously across the hot heather ash towards
+Horsell.  He managed to get alive into the ditch by the side of the
+road, and so escaped to Woking.  There his story became ejaculatory.
+The place was impassable.  It seems there were a few people alive
+there, frantic for the most part and many burned and scalded.  He was
+turned aside by the fire, and hid among some almost scorching heaps of
+broken wall as one of the Martian giants returned.  He saw this one
+pursue a man, catch him up in one of its steely tentacles, and knock
+his head against the trunk of a pine tree.  At last, after nightfall,
+the artilleryman made a rush for it and got over the railway
+embankment.
+
+Since then he had been skulking along towards Maybury, in the hope
+of getting out of danger Londonward.  People were hiding in trenches
+and cellars, and many of the survivors had made off towards Woking
+village and Send.  He had been consumed with thirst until he found one
+of the water mains near the railway arch smashed, and the water
+bubbling out like a spring upon the road.
+
+That was the story I got from him, bit by bit.  He grew calmer
+telling me and trying to make me see the things he had seen.  He had
+eaten no food since midday, he told me early in his narrative, and I
+found some mutton and bread in the pantry and brought it into the
+room.  We lit no lamp for fear of attracting the Martians, and ever
+and again our hands would touch upon bread or meat.  As he talked,
+things about us came darkly out of the darkness, and the trampled
+bushes and broken rose trees outside the window grew distinct.  It
+would seem that a number of men or animals had rushed across the lawn.
+I began to see his face, blackened and haggard, as no doubt mine was
+also.
+
+When we had finished eating we went softly upstairs to my study,
+and I looked again out of the open window.  In one night the valley
+had become a valley of ashes.  The fires had dwindled now.  Where
+flames had been there were now streamers of smoke; but the countless
+ruins of shattered and gutted houses and blasted and blackened trees
+that the night had hidden stood out now gaunt and terrible in the
+pitiless light of dawn.  Yet here and there some object had had the
+luck to escape--a white railway signal here, the end of a greenhouse
+there, white and fresh amid the wreckage.  Never before in the history
+of warfare had destruction been so indiscriminate and so universal.
+And shining with the growing light of the east, three of the metallic
+giants stood about the pit, their cowls rotating as though they were
+surveying the desolation they had made.
+
+It seemed to me that the pit had been enlarged, and ever and again
+puffs of vivid green vapour streamed up and out of it towards the
+brightening dawn--streamed up, whirled, broke, and vanished.
+
+Beyond were the pillars of fire about Chobham.  They became pillars
+of bloodshot smoke at the first touch of day.
+
+
+
+CHAPTER TWELVE
+
+WHAT I SAW OF THE DESTRUCTION OF WEYBRIDGE AND SHEPPERTON
+
+
+As the dawn grew brighter we withdrew from the window from which we
+had watched the Martians, and went very quietly downstairs.
+
+The artilleryman agreed with me that the house was no place to stay
+in.  He proposed, he said, to make his way Londonward, and thence
+rejoin his battery--No. 12, of the Horse Artillery.  My plan was to
+return at once to Leatherhead; and so greatly had the strength of the
+Martians impressed me that I had determined to take my wife to
+Newhaven, and go with her out of the country forthwith.  For I already
+perceived clearly that the country about London must inevitably be the
+scene of a disastrous struggle before such creatures as these could be
+destroyed.
+
+Between us and Leatherhead, however, lay the third cylinder, with
+its guarding giants.  Had I been alone, I think I should have taken my
+chance and struck across country.  But the artilleryman dissuaded me:
+"It's no kindness to the right sort of wife," he said, "to make her a
+widow"; and in the end I agreed to go with him, under cover of the
+woods, northward as far as Street Cobham before I parted with him.
+Thence I would make a big detour by Epsom to reach Leatherhead.
+
+I should have started at once, but my companion had been in active
+service and he knew better than that.  He made me ransack the house
+for a flask, which he filled with whiskey; and we lined every
+available pocket with packets of biscuits and slices of meat.  Then
+we crept out of the house, and ran as quickly as we could down the
+ill-made road by which I had come overnight.  The houses seemed
+deserted. In the road lay a group of three charred bodies close
+together, struck dead by the Heat-Ray; and here and there were things
+that people had dropped--a clock, a slipper, a silver spoon, and the
+like poor valuables.  At the corner turning up towards the post
+office a little cart, filled with boxes and furniture, and horseless,
+heeled over on a broken wheel.  A cash box had been hastily smashed
+open and thrown under the debris.
+
+Except the lodge at the Orphanage, which was still on fire, none of
+the houses had suffered very greatly here.  The Heat-Ray had shaved
+the chimney tops and passed.  Yet, save ourselves, there did not seem
+to be a living soul on Maybury Hill.  The majority of the inhabitants
+had escaped, I suppose, by way of the Old Woking road--the road I had
+taken when I drove to Leatherhead--or they had hidden.
+
+We went down the lane, by the body of the man in black, sodden now
+from the overnight hail, and broke into the woods at the foot of the
+hill.  We pushed through these towards the railway without meeting a
+soul.  The woods across the line were but the scarred and blackened
+ruins of woods; for the most part the trees had fallen, but a certain
+proportion still stood, dismal grey stems, with dark brown foliage
+instead of green.
+
+On our side the fire had done no more than scorch the nearer trees;
+it had failed to secure its footing.  In one place the woodmen had
+been at work on Saturday; trees, felled and freshly trimmed, lay in a
+clearing, with heaps of sawdust by the sawing-machine and its engine.
+Hard by was a temporary hut, deserted.  There was not a breath of wind
+this morning, and everything was strangely still.  Even the birds were
+hushed, and as we hurried along I and the artilleryman talked in
+whispers and looked now and again over our shoulders.  Once or twice
+we stopped to listen.
+
+After a time we drew near the road, and as we did so we heard the
+clatter of hoofs and saw through the tree stems three cavalry soldiers
+riding slowly towards Woking.  We hailed them, and they halted while
+we hurried towards them.  It was a lieutenant and a couple of privates
+of the 8th Hussars, with a stand like a theodolite, which the
+artilleryman told me was a heliograph.
+
+"You are the first men I've seen coming this way this morning,"
+said the lieutenant.  "What's brewing?"
+
+His voice and face were eager.  The men behind him stared
+curiously.  The artilleryman jumped down the bank into the road and
+saluted.
+
+"Gun destroyed last night, sir.  Have been hiding.  Trying to
+rejoin battery, sir.  You'll come in sight of the Martians, I expect,
+about half a mile along this road."
+
+"What the dickens are they like?" asked the lieutenant.
+
+"Giants in armour, sir.  Hundred feet high.  Three legs and a body
+like 'luminium, with a mighty great head in a hood, sir."
+
+"Get out!" said the lieutenant.  "What confounded nonsense!"
+
+"You'll see, sir.  They carry a kind of box, sir, that shoots fire
+and strikes you dead."
+
+"What d'ye mean--a gun?"
+
+"No, sir," and the artilleryman began a vivid account of the Heat-Ray.
+Halfway through, the lieutenant interrupted him and looked up at
+me.  I was still standing on the bank by the side of the road.
+
+"It's perfectly true," I said.
+
+"Well," said the lieutenant, "I suppose it's my business to see it
+too.  Look here"--to the artilleryman--"we're detailed here clearing
+people out of their houses.  You'd better go along and report yourself
+to Brigadier-General Marvin, and tell him all you know.  He's at
+Weybridge.  Know the way?"
+
+"I do," I said; and he turned his horse southward again.
+
+"Half a mile, you say?" said he.
+
+"At most," I answered, and pointed over the treetops southward.  He
+thanked me and rode on, and we saw them no more.
+
+Farther along we came upon a group of three women and two children
+in the road, busy clearing out a labourer's cottage.  They had
+got hold of a little hand truck, and were piling it up with
+unclean-looking bundles and shabby furniture.  They were all too
+assiduously engaged to talk to us as we passed.
+
+By Byfleet station we emerged from the pine trees, and found the
+country calm and peaceful under the morning sunlight.  We were far
+beyond the range of the Heat-Ray there, and had it not been for the
+silent desertion of some of the houses, the stirring movement of
+packing in others, and the knot of soldiers standing on the bridge
+over the railway and staring down the line towards Woking, the day
+would have seemed very like any other Sunday.
+
+Several farm waggons and carts were moving creakily along the road
+to Addlestone, and suddenly through the gate of a field we saw, across
+a stretch of flat meadow, six twelve-pounders standing neatly at equal
+distances pointing towards Woking.  The gunners stood by the guns
+waiting, and the ammunition waggons were at a business-like distance.
+The men stood almost as if under inspection.
+
+"That's good!" said I.  "They will get one fair shot, at any rate."
+
+The artilleryman hesitated at the gate.
+
+"I shall go on," he said.
+
+Farther on towards Weybridge, just over the bridge, there were a
+number of men in white fatigue jackets throwing up a long rampart, and
+more guns behind.
+
+"It's bows and arrows against the lightning, anyhow," said the
+artilleryman.  "They 'aven't seen that fire-beam yet."
+
+The officers who were not actively engaged stood and stared over
+the treetops southwestward, and the men digging would stop every now
+and again to stare in the same direction.
+
+Byfleet was in a tumult; people packing, and a score of hussars,
+some of them dismounted, some on horseback, were hunting them about.
+Three or four black government waggons, with crosses in white circles,
+and an old omnibus, among other vehicles, were being loaded in the
+village street.  There were scores of people, most of them
+sufficiently sabbatical to have assumed their best clothes.  The
+soldiers were having the greatest difficulty in making them realise
+the gravity of their position.  We saw one shrivelled old fellow with
+a huge box and a score or more of flower pots containing orchids,
+angrily expostulating with the corporal who would leave them behind.
+I stopped and gripped his arm.
+
+"Do you know what's over there?" I said, pointing at the pine tops
+that hid the Martians.
+
+"Eh?" said he, turning.  "I was explainin' these is vallyble."
+
+"Death!" I shouted.  "Death is coming!  Death!" and leaving him to
+digest that if he could, I hurried on after the artillery-man.  At the
+corner I looked back.  The soldier had left him, and he was still
+standing by his box, with the pots of orchids on the lid of it, and
+staring vaguely over the trees.
+
+No one in Weybridge could tell us where the headquarters were
+established; the whole place was in such confusion as I had never seen
+in any town before.  Carts, carriages everywhere, the most astonishing
+miscellany of conveyances and horseflesh.  The respectable inhabitants
+of the place, men in golf and boating costumes, wives prettily
+dressed, were packing, river-side loafers energetically helping,
+children excited, and, for the most part, highly delighted at this
+astonishing variation of their Sunday experiences.  In the midst of it
+all the worthy vicar was very pluckily holding an early celebration,
+and his bell was jangling out above the excitement.
+
+I and the artilleryman, seated on the step of the drinking
+fountain, made a very passable meal upon what we had brought with
+us. Patrols of soldiers--here no longer hussars, but grenadiers in
+white--were warning people to move now or to take refuge in their
+cellars as soon as the firing began.  We saw as we crossed the
+railway bridge that a growing crowd of people had assembled in and
+about the railway station, and the swarming platform was piled with
+boxes and packages. The ordinary traffic had been stopped, I believe,
+in order to allow of the passage of troops and guns to Chertsey, and
+I have heard since that a savage struggle occurred for places in the
+special trains that were put on at a later hour.
+
+We remained at Weybridge until midday, and at that hour we found
+ourselves at the place near Shepperton Lock where the Wey and Thames
+join.  Part of the time we spent helping two old women to pack a
+little cart.  The Wey has a treble mouth, and at this point boats are
+to be hired, and there was a ferry across the river.  On the
+Shepperton side was an inn with a lawn, and beyond that the tower of
+Shepperton Church--it has been replaced by a spire--rose above the
+trees.
+
+Here we found an excited and noisy crowd of fugitives.  As yet the
+flight had not grown to a panic, but there were already far more
+people than all the boats going to and fro could enable to cross.
+People came panting along under heavy burdens; one husband and wife
+were even carrying a small outhouse door between them, with some of
+their household goods piled thereon.  One man told us he meant to try
+to get away from Shepperton station.
+
+There was a lot of shouting, and one man was even jesting.  The idea
+people seemed to have here was that the Martians were simply
+formidable human beings, who might attack and sack the town, to be
+certainly destroyed in the end.  Every now and then people would
+glance nervously across the Wey, at the meadows towards Chertsey, but
+everything over there was still.
+
+Across the Thames, except just where the boats landed, everything
+was quiet, in vivid contrast with the Surrey side.  The people who
+landed there from the boats went tramping off down the lane.  The big
+ferryboat had just made a journey.  Three or four soldiers stood on
+the lawn of the inn, staring and jesting at the fugitives, without
+offering to help.  The inn was closed, as it was now within prohibited
+hours.
+
+"What's that?" cried a boatman, and "Shut up, you fool!" said a man
+near me to a yelping dog.  Then the sound came again, this time from
+the direction of Chertsey, a muffled thud--the sound of a gun.
+
+The fighting was beginning.  Almost immediately unseen batteries
+across the river to our right, unseen because of the trees, took up
+the chorus, firing heavily one after the other.  A woman screamed.
+Everyone stood arrested by the sudden stir of battle, near us and yet
+invisible to us.  Nothing was to be seen save flat meadows, cows
+feeding unconcernedly for the most part, and silvery pollard willows
+motionless in the warm sunlight.
+
+"The sojers'll stop 'em," said a woman beside me, doubtfully.  A
+haziness rose over the treetops.
+
+Then suddenly we saw a rush of smoke far away up the river, a puff
+of smoke that jerked up into the air and hung; and forthwith the
+ground heaved under foot and a heavy explosion shook the air, smashing
+two or three windows in the houses near, and leaving us astonished.
+
+"Here they are!" shouted a man in a blue jersey.  "Yonder! D'yer
+see them?  Yonder!"
+
+Quickly, one after the other, one, two, three, four of the armoured
+Martians appeared, far away over the little trees, across the flat
+meadows that stretched towards Chertsey, and striding hurriedly
+towards the river.  Little cowled figures they seemed at first, going
+with a rolling motion and as fast as flying birds.
+
+Then, advancing obliquely towards us, came a fifth.  Their armoured
+bodies glittered in the sun as they swept swiftly forward upon the
+guns, growing rapidly larger as they drew nearer.  One on the extreme
+left, the remotest that is, flourished a huge case high in the air,
+and the ghostly, terrible Heat-Ray I had already seen on Friday night
+smote towards Chertsey, and struck the town.
+
+At sight of these strange, swift, and terrible creatures the crowd
+near the water's edge seemed to me to be for a moment horror-struck.
+There was no screaming or shouting, but a silence.  Then a hoarse
+murmur and a movement of feet--a splashing from the water.  A man, too
+frightened to drop the portmanteau he carried on his shoulder, swung
+round and sent me staggering with a blow from the corner of his
+burden.  A woman thrust at me with her hand and rushed past me.  I
+turned with the rush of the people, but I was not too terrified for
+thought.  The terrible Heat-Ray was in my mind.  To get under water!
+That was it!
+
+"Get under water!" I shouted, unheeded.
+
+I faced about again, and rushed towards the approaching Martian,
+rushed right down the gravelly beach and headlong into the water.
+Others did the same.  A boatload of people putting back came leaping
+out as I rushed past.  The stones under my feet were muddy and
+slippery, and the river was so low that I ran perhaps twenty feet
+scarcely waist-deep.  Then, as the Martian towered overhead scarcely
+a couple of hundred yards away, I flung myself forward under the
+surface.  The splashes of the people in the boats leaping into the
+river sounded like thunderclaps in my ears.  People were landing
+hastily on both sides of the river.  But the Martian machine took no
+more notice for the moment of the people running this way and that
+than a man would of the confusion of ants in a nest against which his
+foot has kicked.  When, half suffocated, I raised my head above water,
+the Martian's hood pointed at the batteries that were still firing
+across the river, and as it advanced it swung loose what must have
+been the generator of the Heat-Ray.
+
+In another moment it was on the bank, and in a stride wading
+halfway across.  The knees of its foremost legs bent at the farther
+bank, and in another moment it had raised itself to its full height
+again, close to the village of Shepperton.  Forthwith the six guns
+which, unknown to anyone on the right bank, had been hidden behind the
+outskirts of that village, fired simultaneously.  The sudden near
+concussion, the last close upon the first, made my heart jump.  The
+monster was already raising the case generating the Heat-Ray as the
+first shell burst six yards above the hood.
+
+I gave a cry of astonishment.  I saw and thought nothing of the
+other four Martian monsters; my attention was riveted upon the nearer
+incident.  Simultaneously two other shells burst in the air near the
+body as the hood twisted round in time to receive, but not in time to
+dodge, the fourth shell.
+
+The shell burst clean in the face of the Thing.  The hood bulged,
+flashed, was whirled off in a dozen tattered fragments of red flesh
+and glittering metal.
+
+"Hit!" shouted I, with something between a scream and a cheer.
+
+I heard answering shouts from the people in the water about me.  I
+could have leaped out of the water with that momentary exultation.
+
+The decapitated colossus reeled like a drunken giant; but it did
+not fall over.  It recovered its balance by a miracle, and, no longer
+heeding its steps and with the camera that fired the Heat-Ray now
+rigidly upheld, it reeled swiftly upon Shepperton.  The living
+intelligence, the Martian within the hood, was slain and splashed to
+the four winds of heaven, and the Thing was now but a mere intricate
+device of metal whirling to destruction.  It drove along in a straight
+line, incapable of guidance.  It struck the tower of Shepperton
+Church, smashing it down as the impact of a battering ram might have
+done, swerved aside, blundered on and collapsed with tremendous force
+into the river out of my sight.
+
+A violent explosion shook the air, and a spout of water, steam,
+mud, and shattered metal shot far up into the sky.  As the camera of
+the Heat-Ray hit the water, the latter had immediately flashed into
+steam.  In another moment a huge wave, like a muddy tidal bore but
+almost scaldingly hot, came sweeping round the bend upstream.  I saw
+people struggling shorewards, and heard their screaming and shouting
+faintly above the seething and roar of the Martian's collapse.
+
+For a moment I heeded nothing of the heat, forgot the patent need
+of self-preservation.  I splashed through the tumultuous water,
+pushing aside a man in black to do so, until I could see round the
+bend.  Half a dozen deserted boats pitched aimlessly upon the
+confusion of the waves.  The fallen Martian came into sight
+downstream, lying across the river, and for the most part submerged.
+
+Thick clouds of steam were pouring off the wreckage, and through
+the tumultuously whirling wisps I could see, intermittently and
+vaguely, the gigantic limbs churning the water and flinging a splash
+and spray of mud and froth into the air.  The tentacles swayed and
+struck like living arms, and, save for the helpless purposelessness of
+these movements, it was as if some wounded thing were struggling for
+its life amid the waves.  Enormous quantities of a ruddy-brown fluid
+were spurting up in noisy jets out of the machine.
+
+My attention was diverted from this death flurry by a furious
+yelling, like that of the thing called a siren in our manufacturing
+towns.  A man, knee-deep near the towing path, shouted inaudibly to me
+and pointed.  Looking back, I saw the other Martians advancing with
+gigantic strides down the riverbank from the direction of Chertsey.
+The Shepperton guns spoke this time unavailingly.
+
+At that I ducked at once under water, and, holding my breath until
+movement was an agony, blundered painfully ahead under the surface as
+long as I could.  The water was in a tumult about me, and rapidly
+growing hotter.
+
+When for a moment I raised my head to take breath and throw the
+hair and water from my eyes, the steam was rising in a whirling white
+fog that at first hid the Martians altogether.  The noise was
+deafening.  Then I saw them dimly, colossal figures of grey, magnified
+by the mist.  They had passed by me, and two were stooping over the
+frothing, tumultuous ruins of their comrade.
+
+The third and fourth stood beside him in the water, one perhaps two
+hundred yards from me, the other towards Laleham.  The generators of
+the Heat-Rays waved high, and the hissing beams smote down this way
+and that.
+
+The air was full of sound, a deafening and confusing conflict of
+noises--the clangorous din of the Martians, the crash of falling
+houses, the thud of trees, fences, sheds flashing into flame, and the
+crackling and roaring of fire.  Dense black smoke was leaping up to
+mingle with the steam from the river, and as the Heat-Ray went to and
+fro over Weybridge its impact was marked by flashes of incandescent
+white, that gave place at once to a smoky dance of lurid flames.  The
+nearer houses still stood intact, awaiting their fate, shadowy, faint
+and pallid in the steam, with the fire behind them going to and fro.
+
+For a moment perhaps I stood there, breast-high in the almost
+boiling water, dumbfounded at my position, hopeless of escape.  Through
+the reek I could see the people who had been with me in the river
+scrambling out of the water through the reeds, like little frogs
+hurrying through grass from the advance of a man, or running to and
+fro in utter dismay on the towing path.
+
+Then suddenly the white flashes of the Heat-Ray came leaping
+towards me.  The houses caved in as they dissolved at its touch, and
+darted out flames; the trees changed to fire with a roar.  The Ray
+flickered up and down the towing path, licking off the people who ran
+this way and that, and came down to the water's edge not fifty yards
+from where I stood.  It swept across the river to Shepperton, and the
+water in its track rose in a boiling weal crested with steam.  I
+turned shoreward.
+
+In another moment the huge wave, well-nigh at the boiling-point had
+rushed upon me.  I screamed aloud, and scalded, half blinded,
+agonised, I staggered through the leaping, hissing water towards the
+shore.  Had my foot stumbled, it would have been the end.  I fell
+helplessly, in full sight of the Martians, upon the broad, bare
+gravelly spit that runs down to mark the angle of the Wey and Thames.
+I expected nothing but death.
+
+I have a dim memory of the foot of a Martian coming down within a
+score of yards of my head, driving straight into the loose gravel,
+whirling it this way and that and lifting again; of a long suspense,
+and then of the four carrying the debris of their comrade between
+them, now clear and then presently faint through a veil of smoke,
+receding interminably, as it seemed to me, across a vast space of
+river and meadow.  And then, very slowly, I realised that by a miracle
+I had escaped.
+
+
+
+CHAPTER THIRTEEN
+
+HOW I FELL IN WITH THE CURATE
+
+
+After getting this sudden lesson in the power of terrestrial
+weapons, the Martians retreated to their original position upon
+Horsell Common; and in their haste, and encumbered with the debris of
+their smashed companion, they no doubt overlooked many such a stray
+and negligible victim as myself.  Had they left their comrade and
+pushed on forthwith, there was nothing at that time between them and
+London but batteries of twelve-pounder guns, and they would certainly
+have reached the capital in advance of the tidings of their approach;
+as sudden, dreadful, and destructive their advent would have been as
+the earthquake that destroyed Lisbon a century ago.
+
+But they were in no hurry.  Cylinder followed cylinder on its
+interplanetary flight; every twenty-four hours brought them
+reinforcement.  And meanwhile the military and naval authorities, now
+fully alive to the tremendous power of their antagonists, worked with
+furious energy.  Every minute a fresh gun came into position until,
+before twilight, every copse, every row of suburban villas on the
+hilly slopes about Kingston and Richmond, masked an expectant black
+muzzle.  And through the charred and desolated area--perhaps twenty
+square miles altogether--that encircled the Martian encampment on
+Horsell Common, through charred and ruined villages among the green
+trees, through the blackened and smoking arcades that had been but a
+day ago pine spinneys, crawled the devoted scouts with the heliographs
+that were presently to warn the gunners of the Martian approach.  But
+the Martians now understood our command of artillery and the danger of
+human proximity, and not a man ventured within a mile of either
+cylinder, save at the price of his life.
+
+It would seem that these giants spent the earlier part of the
+afternoon in going to and fro, transferring everything from the second
+and third cylinders--the second in Addlestone Golf Links and the third
+at Pyrford--to their original pit on Horsell Common.  Over that, above
+the blackened heather and ruined buildings that stretched far and
+wide, stood one as sentinel, while the rest abandoned their vast
+fighting-machines and descended into the pit.  They were hard at work
+there far into the night, and the towering pillar of dense green smoke
+that rose therefrom could be seen from the hills about Merrow, and
+even, it is said, from Banstead and Epsom Downs.
+
+And while the Martians behind me were thus preparing for their next
+sally, and in front of me Humanity gathered for the battle, I made my
+way with infinite pains and labour from the fire and smoke of burning
+Weybridge towards London.
+
+I saw an abandoned boat, very small and remote, drifting down-stream;
+and throwing off the most of my sodden clothes, I went after it,
+gained it, and so escaped out of that destruction.  There were no
+oars in the boat, but I contrived to paddle, as well as my parboiled
+hands would allow, down the river towards Halliford and Walton, going
+very tediously and continually looking behind me, as you may well
+understand.  I followed the river, because I considered that the water
+gave me my best chance of escape should these giants return.
+
+The hot water from the Martian's overthrow drifted downstream with
+me, so that for the best part of a mile I could see little of either
+bank.  Once, however, I made out a string of black figures hurrying
+across the meadows from the direction of Weybridge.  Halliford, it
+seemed, was deserted, and several of the houses facing the river were
+on fire.  It was strange to see the place quite tranquil, quite
+desolate under the hot blue sky, with the smoke and little threads of
+flame going straight up into the heat of the afternoon.  Never before
+had I seen houses burning without the accompaniment of an obstructive
+crowd.  A little farther on the dry reeds up the bank were smoking and
+glowing, and a line of fire inland was marching steadily across a late
+field of hay.
+
+For a long time I drifted, so painful and weary was I after the
+violence I had been through, and so intense the heat upon the water.
+Then my fears got the better of me again, and I resumed my paddling.
+The sun scorched my bare back.  At last, as the bridge at Walton was
+coming into sight round the bend, my fever and faintness overcame my
+fears, and I landed on the Middlesex bank and lay down, deadly sick,
+amid the long grass.  I suppose the time was then about four or five
+o'clock.  I got up presently, walked perhaps half a mile without
+meeting a soul, and then lay down again in the shadow of a hedge.  I
+seem to remember talking, wanderingly, to myself during that last
+spurt.  I was also very thirsty, and bitterly regretful I had drunk no
+more water.  It is a curious thing that I felt angry with my wife; I
+cannot account for it, but my impotent desire to reach Leatherhead
+worried me excessively.
+
+I do not clearly remember the arrival of the curate, so that probably
+I dozed.  I became aware of him as a seated figure in soot-smudged
+shirt sleeves, and with his upturned, clean-shaven face staring at
+a faint flickering that danced over the sky.  The sky was what is
+called a mackerel sky--rows and rows of faint down-plumes of
+cloud, just tinted with the midsummer sunset.
+
+I sat up, and at the rustle of my motion he looked at me quickly.
+
+"Have you any water?" I asked abruptly.
+
+He shook his head.
+
+"You have been asking for water for the last hour," he said.
+
+For a moment we were silent, taking stock of each other.  I
+dare say he found me a strange enough figure, naked, save for my
+water-soaked trousers and socks, scalded, and my face and shoulders
+blackened by the smoke.  His face was a fair weakness, his chin
+retreated, and his hair lay in crisp, almost flaxen curls on his low
+forehead; his eyes were rather large, pale blue, and blankly staring.
+He spoke abruptly, looking vacantly away from me.
+
+"What does it mean?" he said.  "What do these things mean?"
+
+I stared at him and made no answer.
+
+He extended a thin white hand and spoke in almost a complaining
+tone.
+
+"Why are these things permitted?  What sins have we done?  The
+morning service was over, I was walking through the roads to clear my
+brain for the afternoon, and then--fire, earthquake, death!  As if it
+were Sodom and Gomorrah!  All our work undone, all the work---- What
+are these Martians?"
+
+"What are we?" I answered, clearing my throat.
+
+He gripped his knees and turned to look at me again.  For half a
+minute, perhaps, he stared silently.
+
+"I was walking through the roads to clear my brain," he said.  "And
+suddenly--fire, earthquake, death!"
+
+He relapsed into silence, with his chin now sunken almost to his
+knees.
+
+Presently he began waving his hand.
+
+"All the work--all the Sunday schools--What have we done--what has
+Weybridge done?  Everything gone--everything destroyed.  The church!
+We rebuilt it only three years ago.  Gone!  Swept out of existence!
+Why?"
+
+Another pause, and he broke out again like one demented.
+
+"The smoke of her burning goeth up for ever and ever!" he shouted.
+
+His eyes flamed, and he pointed a lean finger in the direction of
+Weybridge.
+
+By this time I was beginning to take his measure.  The tremendous
+tragedy in which he had been involved--it was evident he was a
+fugitive from Weybridge--had driven him to the very verge of his
+reason.
+
+"Are we far from Sunbury?" I said, in a matter-of-fact tone.
+
+"What are we to do?" he asked.  "Are these creatures everywhere?
+Has the earth been given over to them?"
+
+"Are we far from Sunbury?"
+
+"Only this morning I officiated at early celebration----"
+
+"Things have changed," I said, quietly.  "You must keep your head.
+There is still hope."
+
+"Hope!"
+
+"Yes.  Plentiful hope--for all this destruction!"
+
+I began to explain my view of our position.  He listened at first,
+but as I went on the interest dawning in his eyes gave place to their
+former stare, and his regard wandered from me.
+
+"This must be the beginning of the end," he said, interrupting me.
+"The end!  The great and terrible day of the Lord!  When men shall
+call upon the mountains and the rocks to fall upon them and hide
+them--hide them from the face of Him that sitteth upon the throne!"
+
+I began to understand the position.  I ceased my laboured
+reasoning, struggled to my feet, and, standing over him, laid my hand
+on his shoulder.
+
+"Be a man!" said I.  "You are scared out of your wits!  What good
+is religion if it collapses under calamity?  Think of what earthquakes
+and floods, wars and volcanoes, have done before to men!  Did you
+think God had exempted Weybridge?  He is not an insurance agent."
+
+For a time he sat in blank silence.
+
+"But how can we escape?" he asked, suddenly.  "They are
+invulnerable, they are pitiless."
+
+"Neither the one nor, perhaps, the other," I answered. "And the
+mightier they are the more sane and wary should we be.  One of them
+was killed yonder not three hours ago."
+
+"Killed!" he said, staring about him.  "How can God's ministers be
+killed?"
+
+"I saw it happen." I proceeded to tell him.  "We have chanced to
+come in for the thick of it," said I, "and that is all."
+
+"What is that flicker in the sky?" he asked abruptly.
+
+I told him it was the heliograph signalling--that it was the sign
+of human help and effort in the sky.
+
+"We are in the midst of it," I said, "quiet as it is.  That flicker
+in the sky tells of the gathering storm.  Yonder, I take it are the
+Martians, and Londonward, where those hills rise about Richmond and
+Kingston and the trees give cover, earthworks are being thrown up and
+guns are being placed.  Presently the Martians will be coming this way
+again."
+
+And even as I spoke he sprang to his feet and stopped me by a
+gesture.
+
+"Listen!" he said.
+
+From beyond the low hills across the water came the dull resonance
+of distant guns and a remote weird crying.  Then everything was still.
+A cockchafer came droning over the hedge and past us.  High in the
+west the crescent moon hung faint and pale above the smoke of
+Weybridge and Shepperton and the hot, still splendour of the sunset.
+
+"We had better follow this path," I said, "northward."
+
+
+
+CHAPTER FOURTEEN
+
+IN LONDON
+
+
+My younger brother was in London when the Martians fell at Woking.
+He was a medical student working for an imminent examination, and he
+heard nothing of the arrival until Saturday morning.  The morning
+papers on Saturday contained, in addition to lengthy special articles
+on the planet Mars, on life in the planets, and so forth, a brief and
+vaguely worded telegram, all the more striking for its brevity.
+
+The Martians, alarmed by the approach of a crowd, had killed a
+number of people with a quick-firing gun, so the story ran.  The
+telegram concluded with the words: "Formidable as they seem to be, the
+Martians have not moved from the pit into which they have fallen, and,
+indeed, seem incapable of doing so.  Probably this is due to the
+relative strength of the earth's gravitational energy."  On that last
+text their leader-writer expanded very comfortingly.
+
+Of course all the students in the crammer's biology class, to which
+my brother went that day, were intensely interested, but there were no
+signs of any unusual excitement in the streets.  The afternoon papers
+puffed scraps of news under big headlines.  They had nothing to tell
+beyond the movements of troops about the common, and the burning of
+the pine woods between Woking and Weybridge, until eight.  Then the
+_St. James's Gazette_, in an extra-special edition, announced the bare
+fact of the interruption of telegraphic communication.  This was
+thought to be due to the falling of burning pine trees across the
+line.  Nothing more of the fighting was known that night, the night of
+my drive to Leatherhead and back.
+
+My brother felt no anxiety about us, as he knew from the
+description in the papers that the cylinder was a good two miles from
+my house.  He made up his mind to run down that night to me, in order,
+as he says, to see the Things before they were killed.  He dispatched
+a telegram, which never reached me, about four o'clock, and spent the
+evening at a music hall.
+
+In London, also, on Saturday night there was a thunderstorm, and my
+brother reached Waterloo in a cab.  On the platform from which the
+midnight train usually starts he learned, after some waiting, that an
+accident prevented trains from reaching Woking that night.  The nature
+of the accident he could not ascertain; indeed, the railway
+authorities did not clearly know at that time.  There was very little
+excitement in the station, as the officials, failing to realise that
+anything further than a breakdown between Byfleet and Woking junction
+had occurred, were running the theatre trains which usually passed
+through Woking round by Virginia Water or Guildford.  They were busy
+making the necessary arrangements to alter the route of the
+Southampton and Portsmouth Sunday League excursions.  A nocturnal
+newspaper reporter, mistaking my brother for the traffic manager, to
+whom he bears a slight resemblance, waylaid and tried to interview
+him.  Few people, excepting the railway officials, connected the
+breakdown with the Martians.
+
+I have read, in another account of these events, that on Sunday
+morning "all London was electrified by the news from Woking."  As a
+matter of fact, there was nothing to justify that very extravagant
+phrase.  Plenty of Londoners did not hear of the Martians until the
+panic of Monday morning.  Those who did took some time to realise all
+that the hastily worded telegrams in the Sunday papers conveyed.  The
+majority of people in London do not read Sunday papers.
+
+The habit of personal security, moreover, is so deeply fixed in the
+Londoner's mind, and startling intelligence so much a matter of course
+in the papers, that they could read without any personal tremors:
+"About seven o'clock last night the Martians came out of the cylinder,
+and, moving about under an armour of metallic shields, have completely
+wrecked Woking station with the adjacent houses, and massacred an
+entire battalion of the Cardigan Regiment.  No details are known.
+Maxims have been absolutely useless against their armour; the field
+guns have been disabled by them.  Flying hussars have been galloping
+into Chertsey.  The Martians appear to be moving slowly towards
+Chertsey or Windsor.  Great anxiety prevails in West Surrey, and
+earthworks are being thrown up to check the advance Londonward."  That
+was how the Sunday _Sun_ put it, and a clever and remarkably prompt
+"handbook" article in the _Referee_ compared the affair to a menagerie
+suddenly let loose in a village.
+
+No one in London knew positively of the nature of the armoured
+Martians, and there was still a fixed idea that these monsters must be
+sluggish: "crawling," "creeping painfully"--such expressions occurred
+in almost all the earlier reports.  None of the telegrams could have
+been written by an eyewitness of their advance.  The Sunday papers
+printed separate editions as further news came to hand, some even in
+default of it.  But there was practically nothing more to tell people
+until late in the afternoon, when the authorities gave the press
+agencies the news in their possession.  It was stated that the people
+of Walton and Weybridge, and all the district were pouring along the
+roads Londonward, and that was all.
+
+My brother went to church at the Foundling Hospital in the morning,
+still in ignorance of what had happened on the previous night.  There
+he heard allusions made to the invasion, and a special prayer for
+peace.  Coming out, he bought a _Referee_.  He became alarmed at the
+news in this, and went again to Waterloo station to find out if
+communication were restored.  The omnibuses, carriages, cyclists, and
+innumerable people walking in their best clothes seemed scarcely
+affected by the strange intelligence that the news venders were
+disseminating.  People were interested, or, if alarmed, alarmed only
+on account of the local residents.  At the station he heard for the
+first time that the Windsor and Chertsey lines were now interrupted.
+The porters told him that several remarkable telegrams had been
+received in the morning from Byfleet and Chertsey stations, but that
+these had abruptly ceased.  My brother could get very little precise
+detail out of them.
+
+"There's fighting going on about Weybridge" was the extent of their
+information.
+
+The train service was now very much disorganised.  Quite a number
+of people who had been expecting friends from places on the
+South-Western network were standing about the station.  One
+grey-headed old gentleman came and abused the South-Western Company
+bitterly to my brother.  "It wants showing up," he said.
+
+One or two trains came in from Richmond, Putney, and Kingston,
+containing people who had gone out for a day's boating and found the
+locks closed and a feeling of panic in the air.  A man in a blue and
+white blazer addressed my brother, full of strange tidings.
+
+"There's hosts of people driving into Kingston in traps and carts
+and things, with boxes of valuables and all that," he said.  "They
+come from Molesey and Weybridge and Walton, and they say there's been
+guns heard at Chertsey, heavy firing, and that mounted soldiers have
+told them to get off at once because the Martians are coming.  We
+heard guns firing at Hampton Court station, but we thought it was
+thunder.  What the dickens does it all mean?  The Martians can't get
+out of their pit, can they?"
+
+My brother could not tell him.
+
+Afterwards he found that the vague feeling of alarm had spread to
+the clients of the underground railway, and that the Sunday
+excursionists began to return from all over the South-Western
+"lung"--Barnes, Wimbledon, Richmond Park, Kew, and so forth--at
+unnaturally early hours; but not a soul had anything more than vague
+hearsay to tell of.  Everyone connected with the terminus seemed
+ill-tempered.
+
+About five o'clock the gathering crowd in the station was immensely
+excited by the opening of the line of communication, which is almost
+invariably closed, between the South-Eastern and the South-Western
+stations, and the passage of carriage trucks bearing huge guns and
+carriages crammed with soldiers.  These were the guns that were
+brought up from Woolwich and Chatham to cover Kingston.  There was
+an exchange of pleasantries: "You'll get eaten!"  "We're the
+beast-tamers!" and so forth.  A little while after that a squad of
+police came into the station and began to clear the public off the
+platforms, and my brother went out into the street again.
+
+The church bells were ringing for evensong, and a squad of
+Salvation Army lassies came singing down Waterloo Road.  On the bridge
+a number of loafers were watching a curious brown scum that came
+drifting down the stream in patches.  The sun was just setting, and the
+Clock Tower and the Houses of Parliament rose against one of the most
+peaceful skies it is possible to imagine, a sky of gold, barred with
+long transverse stripes of reddish-purple cloud.  There was talk of a
+floating body.  One of the men there, a reservist he said he was, told
+my brother he had seen the heliograph flickering in the west.
+
+In Wellington Street my brother met a couple of sturdy roughs who
+had just been rushed out of Fleet Street with still-wet newspapers and
+staring placards.  "Dreadful catastrophe!" they bawled one to the
+other down Wellington Street.  "Fighting at Weybridge!  Full
+description!  Repulse of the Martians! London in Danger!"  He had to
+give threepence for a copy of that paper.
+
+Then it was, and then only, that he realised something of the full
+power and terror of these monsters.  He learned that they were not
+merely a handful of small sluggish creatures, but that they were minds
+swaying vast mechanical bodies; and that they could move swiftly and
+smite with such power that even the mightiest guns could not stand
+against them.
+
+They were described as "vast spiderlike machines, nearly a hundred
+feet high, capable of the speed of an express train, and able to shoot
+out a beam of intense heat."  Masked batteries, chiefly of field guns,
+had been planted in the country about Horsell Common, and especially
+between the Woking district and London.  Five of the machines had been
+seen moving towards the Thames, and one, by a happy chance, had been
+destroyed.  In the other cases the shells had missed, and the
+batteries had been at once annihilated by the Heat-Rays.  Heavy
+losses of soldiers were mentioned, but the tone of the dispatch was
+optimistic.
+
+The Martians had been repulsed; they were not invulnerable.  They
+had retreated to their triangle of cylinders again, in the circle
+about Woking.  Signallers with heliographs were pushing forward upon
+them from all sides.  Guns were in rapid transit from Windsor,
+Portsmouth, Aldershot, Woolwich--even from the north; among others,
+long wire-guns of ninety-five tons from Woolwich.  Altogether one
+hundred and sixteen were in position or being hastily placed, chiefly
+covering London.  Never before in England had there been such a vast
+or rapid concentration of military material.
+
+Any further cylinders that fell, it was hoped, could be destroyed
+at once by high explosives, which were being rapidly manufactured and
+distributed.  No doubt, ran the report, the situation was of the
+strangest and gravest description, but the public was exhorted to
+avoid and discourage panic.  No doubt the Martians were strange and
+terrible in the extreme, but at the outside there could not be more
+than twenty of them against our millions.
+
+The authorities had reason to suppose, from the size of the
+cylinders, that at the outside there could not be more than five in
+each cylinder--fifteen altogether.  And one at least was disposed
+of--perhaps more.  The public would be fairly warned of the approach
+of danger, and elaborate measures were being taken for the protection
+of the people in the threatened southwestern suburbs.  And so, with
+reiterated assurances of the safety of London and the ability of the
+authorities to cope with the difficulty, this quasi-proclamation
+closed.
+
+This was printed in enormous type on paper so fresh that it was
+still wet, and there had been no time to add a word of comment.  It
+was curious, my brother said, to see how ruthlessly the usual contents
+of the paper had been hacked and taken out to give this place.
+
+All down Wellington Street people could be seen fluttering out the
+pink sheets and reading, and the Strand was suddenly noisy with the
+voices of an army of hawkers following these pioneers.  Men came
+scrambling off buses to secure copies.  Certainly this news excited
+people intensely, whatever their previous apathy.  The shutters of a
+map shop in the Strand were being taken down, my brother said, and a
+man in his Sunday raiment, lemon-yellow gloves even, was visible
+inside the window hastily fastening maps of Surrey to the glass.
+
+Going on along the Strand to Trafalgar Square, the paper in his
+hand, my brother saw some of the fugitives from West Surrey.  There
+was a man with his wife and two boys and some articles of furniture in
+a cart such as greengrocers use.  He was driving from the direction of
+Westminster Bridge; and close behind him came a hay waggon with five
+or six respectable-looking people in it, and some boxes and bundles.
+The faces of these people were haggard, and their entire appearance
+contrasted conspicuously with the Sabbath-best appearance of the
+people on the omnibuses.  People in fashionable clothing peeped at
+them out of cabs.  They stopped at the Square as if undecided which
+way to take, and finally turned eastward along the Strand.  Some way
+behind these came a man in workday clothes, riding one of those
+old-fashioned tricycles with a small front wheel.  He was dirty and
+white in the face.
+
+My brother turned down towards Victoria, and met a number of such
+people.  He had a vague idea that he might see something of me.  He
+noticed an unusual number of police regulating the traffic.  Some of
+the refugees were exchanging news with the people on the omnibuses.
+One was professing to have seen the Martians.  "Boilers on stilts, I
+tell you, striding along like men."  Most of them were excited and
+animated by their strange experience.
+
+Beyond Victoria the public-houses were doing a lively trade with
+these arrivals.  At all the street corners groups of people were
+reading papers, talking excitedly, or staring at these unusual Sunday
+visitors.  They seemed to increase as night drew on, until at last the
+roads, my brother said, were like Epsom High Street on a Derby Day.  My
+brother addressed several of these fugitives and got unsatisfactory
+answers from most.
+
+None of them could tell him any news of Woking except one man, who
+assured him that Woking had been entirely destroyed on the previous
+night.
+
+"I come from Byfleet," he said; "man on a bicycle came through the
+place in the early morning, and ran from door to door warning us to
+come away.  Then came soldiers.  We went out to look, and there were
+clouds of smoke to the south--nothing but smoke, and not a soul coming
+that way.  Then we heard the guns at Chertsey, and folks coming from
+Weybridge.  So I've locked up my house and come on."
+
+At the time there was a strong feeling in the streets that the
+authorities were to blame for their incapacity to dispose of the
+invaders without all this inconvenience.
+
+About eight o'clock a noise of heavy firing was distinctly audible
+all over the south of London.  My brother could not hear it for the
+traffic in the main thoroughfares, but by striking through the quiet
+back streets to the river he was able to distinguish it quite plainly.
+
+He walked from Westminster to his apartments near Regent's Park,
+about two.  He was now very anxious on my account, and disturbed at
+the evident magnitude of the trouble.  His mind was inclined to run,
+even as mine had run on Saturday, on military details.  He thought of
+all those silent, expectant guns, of the suddenly nomadic countryside;
+he tried to imagine "boilers on stilts" a hundred feet high.
+
+There were one or two cartloads of refugees passing along Oxford
+Street, and several in the Marylebone Road, but so slowly was the news
+spreading that Regent Street and Portland Place were full of their
+usual Sunday-night promenaders, albeit they talked in groups, and
+along the edge of Regent's Park there were as many silent couples
+"walking out" together under the scattered gas lamps as ever there had
+been.  The night was warm and still, and a little oppressive; the
+sound of guns continued intermittently, and after midnight there
+seemed to be sheet lightning in the south.
+
+He read and re-read the paper, fearing the worst had happened to me.
+He was restless, and after supper prowled out again aimlessly.  He
+returned and tried in vain to divert his attention to his examination
+notes.  He went to bed a little after midnight, and was awakened from
+lurid dreams in the small hours of Monday by the sound of door
+knockers, feet running in the street, distant drumming, and a clamour
+of bells.  Red reflections danced on the ceiling.  For a moment he lay
+astonished, wondering whether day had come or the world gone mad.
+Then he jumped out of bed and ran to the window.
+
+His room was an attic and as he thrust his head out, up and down
+the street there were a dozen echoes to the noise of his window sash,
+and heads in every kind of night disarray appeared.  Enquiries were
+being shouted.  "They are coming!" bawled a policeman, hammering at
+the door; "the Martians are coming!" and hurried to the next door.
+
+The sound of drumming and trumpeting came from the Albany Street
+Barracks, and every church within earshot was hard at work killing
+sleep with a vehement disorderly tocsin.  There was a noise of doors
+opening, and window after window in the houses opposite flashed from
+darkness into yellow illumination.
+
+Up the street came galloping a closed carriage, bursting abruptly
+into noise at the corner, rising to a clattering climax under the
+window, and dying away slowly in the distance.  Close on the rear of
+this came a couple of cabs, the forerunners of a long procession of
+flying vehicles, going for the most part to Chalk Farm station, where
+the North-Western special trains were loading up, instead of coming
+down the gradient into Euston.
+
+For a long time my brother stared out of the window in blank
+astonishment, watching the policemen hammering at door after door, and
+delivering their incomprehensible message.  Then the door behind him
+opened, and the man who lodged across the landing came in, dressed
+only in shirt, trousers, and slippers, his braces loose about his
+waist, his hair disordered from his pillow.
+
+"What the devil is it?" he asked.  "A fire?  What a devil of a
+row!"
+
+They both craned their heads out of the window, straining to hear
+what the policemen were shouting.  People were coming out of the side
+streets, and standing in groups at the corners talking.
+
+"What the devil is it all about?" said my brother's fellow lodger.
+
+My brother answered him vaguely and began to dress, running with
+each garment to the window in order to miss nothing of the growing
+excitement.  And presently men selling unnaturally early newspapers
+came bawling into the street:
+
+"London in danger of suffocation!  The Kingston and Richmond
+defences forced!  Fearful massacres in the Thames Valley!"
+
+And all about him--in the rooms below, in the houses on each side
+and across the road, and behind in the Park Terraces and in the
+hundred other streets of that part of Marylebone, and the Westbourne
+Park district and St. Pancras, and westward and northward in Kilburn
+and St. John's Wood and Hampstead, and eastward in Shoreditch and
+Highbury and Haggerston and Hoxton, and, indeed, through all the
+vastness of London from Ealing to East Ham--people were rubbing their
+eyes, and opening windows to stare out and ask aimless questions,
+dressing hastily as the first breath of the coming storm of Fear blew
+through the streets.  It was the dawn of the great panic.  London,
+which had gone to bed on Sunday night oblivious and inert, was
+awakened, in the small hours of Monday morning, to a vivid sense of
+danger.
+
+Unable from his window to learn what was happening, my brother went
+down and out into the street, just as the sky between the parapets of
+the houses grew pink with the early dawn.  The flying people on foot
+and in vehicles grew more numerous every moment.  "Black Smoke!" he
+heard people crying, and again "Black Smoke!"  The contagion of such
+a unanimous fear was inevitable.  As my brother hesitated on the
+door-step, he saw another news vender approaching, and got a paper
+forthwith.  The man was running away with the rest, and selling his
+papers for a shilling each as he ran--a grotesque mingling of profit
+and panic.
+
+And from this paper my brother read that catastrophic dispatch of
+the Commander-in-Chief:
+
+"The Martians are able to discharge enormous clouds of a black and
+poisonous vapour by means of rockets.  They have smothered our
+batteries, destroyed Richmond, Kingston, and Wimbledon, and are
+advancing slowly towards London, destroying everything on the way.  It
+is impossible to stop them.  There is no safety from the Black Smoke
+but in instant flight."
+
+That was all, but it was enough.  The whole population of the great
+six-million city was stirring, slipping, running; presently it would
+be pouring _en masse_ northward.
+
+"Black Smoke!" the voices cried.  "Fire!"
+
+The bells of the neighbouring church made a jangling tumult, a cart
+carelessly driven smashed, amid shrieks and curses, against the water
+trough up the street.  Sickly yellow lights went to and fro in the
+houses, and some of the passing cabs flaunted unextinguished lamps.
+And overhead the dawn was growing brighter, clear and steady and calm.
+
+He heard footsteps running to and fro in the rooms, and up and down
+stairs behind him.  His landlady came to the door, loosely wrapped in
+dressing gown and shawl; her husband followed ejaculating.
+
+As my brother began to realise the import of all these things, he
+turned hastily to his own room, put all his available money--some ten
+pounds altogether--into his pockets, and went out again into the
+streets.
+
+
+
+CHAPTER FIFTEEN
+
+WHAT HAD HAPPENED IN SURREY
+
+
+It was while the curate had sat and talked so wildly to me under
+the hedge in the flat meadows near Halliford, and while my brother was
+watching the fugitives stream over Westminster Bridge, that the
+Martians had resumed the offensive.  So far as one can ascertain from
+the conflicting accounts that have been put forth, the majority of
+them remained busied with preparations in the Horsell pit until nine
+that night, hurrying on some operation that disengaged huge volumes of
+green smoke.
+
+But three certainly came out about eight o'clock and, advancing
+slowly and cautiously, made their way through Byfleet and Pyrford
+towards Ripley and Weybridge, and so came in sight of the expectant
+batteries against the setting sun.  These Martians did not advance in
+a body, but in a line, each perhaps a mile and a half from his nearest
+fellow.  They communicated with one another by means of sirenlike
+howls, running up and down the scale from one note to another.
+
+It was this howling and firing of the guns at Ripley and St.
+George's Hill that we had heard at Upper Halliford.  The Ripley
+gunners, unseasoned artillery volunteers who ought never to have been
+placed in such a position, fired one wild, premature, ineffectual
+volley, and bolted on horse and foot through the deserted village,
+while the Martian, without using his Heat-Ray, walked serenely over
+their guns, stepped gingerly among them, passed in front of them, and
+so came unexpectedly upon the guns in Painshill Park, which he
+destroyed.
+
+The St. George's Hill men, however, were better led or of a better
+mettle.  Hidden by a pine wood as they were, they seem to have been
+quite unsuspected by the Martian nearest to them.  They laid their
+guns as deliberately as if they had been on parade, and fired at about
+a thousand yards' range.
+
+The shells flashed all round him, and he was seen to advance a few
+paces, stagger, and go down.  Everybody yelled together, and the guns
+were reloaded in frantic haste.  The overthrown Martian set up a
+prolonged ululation, and immediately a second glittering giant,
+answering him, appeared over the trees to the south.  It would seem
+that a leg of the tripod had been smashed by one of the shells.  The
+whole of the second volley flew wide of the Martian on the ground,
+and, simultaneously, both his companions brought their Heat-Rays to
+bear on the battery.  The ammunition blew up, the pine trees all about
+the guns flashed into fire, and only one or two of the men who were
+already running over the crest of the hill escaped.
+
+After this it would seem that the three took counsel together and
+halted, and the scouts who were watching them report that they
+remained absolutely stationary for the next half hour.  The Martian
+who had been overthrown crawled tediously out of his hood, a small
+brown figure, oddly suggestive from that distance of a speck of
+blight, and apparently engaged in the repair of his support.  About
+nine he had finished, for his cowl was then seen above the trees
+again.
+
+It was a few minutes past nine that night when these three
+sentinels were joined by four other Martians, each carrying a thick
+black tube.  A similar tube was handed to each of the three, and the
+seven proceeded to distribute themselves at equal distances along a
+curved line between St. George's Hill, Weybridge, and the village of
+Send, southwest of Ripley.
+
+A dozen rockets sprang out of the hills before them so soon as they
+began to move, and warned the waiting batteries about Ditton and
+Esher.  At the same time four of their fighting machines, similarly
+armed with tubes, crossed the river, and two of them, black against
+the western sky, came into sight of myself and the curate as we
+hurried wearily and painfully along the road that runs northward out
+of Halliford.  They moved, as it seemed to us, upon a cloud, for a
+milky mist covered the fields and rose to a third of their height.
+
+At this sight the curate cried faintly in his throat, and began
+running; but I knew it was no good running from a Martian, and I
+turned aside and crawled through dewy nettles and brambles into the
+broad ditch by the side of the road.  He looked back, saw what I was
+doing, and turned to join me.
+
+The two halted, the nearer to us standing and facing Sunbury, the
+remoter being a grey indistinctness towards the evening star, away
+towards Staines.
+
+The occasional howling of the Martians had ceased; they took up
+their positions in the huge crescent about their cylinders in absolute
+silence.  It was a crescent with twelve miles between its horns.  Never
+since the devising of gunpowder was the beginning of a battle so
+still.  To us and to an observer about Ripley it would have had
+precisely the same effect--the Martians seemed in solitary possession
+of the darkling night, lit only as it was by the slender moon, the
+stars, the afterglow of the daylight, and the ruddy glare from St.
+George's Hill and the woods of Painshill.
+
+But facing that crescent everywhere--at Staines, Hounslow, Ditton,
+Esher, Ockham, behind hills and woods south of the river, and across
+the flat grass meadows to the north of it, wherever a cluster of trees
+or village houses gave sufficient cover--the guns were waiting.  The
+signal rockets burst and rained their sparks through the night and
+vanished, and the spirit of all those watching batteries rose to a
+tense expectation.  The Martians had but to advance into the line of
+fire, and instantly those motionless black forms of men, those guns
+glittering so darkly in the early night, would explode into a
+thunderous fury of battle.
+
+No doubt the thought that was uppermost in a thousand of those
+vigilant minds, even as it was uppermost in mine, was the riddle--how
+much they understood of us.  Did they grasp that we in our millions
+were organized, disciplined, working together?  Or did they interpret
+our spurts of fire, the sudden stinging of our shells, our steady
+investment of their encampment, as we should the furious unanimity of
+onslaught in a disturbed hive of bees?  Did they dream they might
+exterminate us?  (At that time no one knew what food they needed.)  A
+hundred such questions struggled together in my mind as I watched that
+vast sentinel shape.  And in the back of my mind was the sense of all
+the huge unknown and hidden forces Londonward.  Had they prepared
+pitfalls? Were the powder mills at Hounslow ready as a snare?  Would
+the Londoners have the heart and courage to make a greater Moscow of
+their mighty province of houses?
+
+Then, after an interminable time, as it seemed to us, crouching and
+peering through the hedge, came a sound like the distant concussion of
+a gun.  Another nearer, and then another.  And then the Martian beside
+us raised his tube on high and discharged it, gunwise, with a heavy
+report that made the ground heave.  The one towards Staines answered
+him.  There was no flash, no smoke, simply that loaded detonation.
+
+I was so excited by these heavy minute-guns following one another
+that I so far forgot my personal safety and my scalded hands as to
+clamber up into the hedge and stare towards Sunbury.  As I did so a
+second report followed, and a big projectile hurtled overhead towards
+Hounslow.  I expected at least to see smoke or fire, or some such
+evidence of its work.  But all I saw was the deep blue sky above, with
+one solitary star, and the white mist spreading wide and low beneath.
+And there had been no crash, no answering explosion.  The silence was
+restored; the minute lengthened to three.
+
+"What has happened?" said the curate, standing up beside me.
+
+"Heaven knows!" said I.
+
+A bat flickered by and vanished.  A distant tumult of shouting
+began and ceased.  I looked again at the Martian, and saw he was now
+moving eastward along the riverbank, with a swift, rolling motion.
+
+Every moment I expected the fire of some hidden battery to spring
+upon him; but the evening calm was unbroken.  The figure of the Martian
+grew smaller as he receded, and presently the mist and the gathering
+night had swallowed him up.  By a common impulse we clambered higher.
+Towards Sunbury was a dark appearance, as though a conical hill had
+suddenly come into being there, hiding our view of the farther
+country; and then, remoter across the river, over Walton, we saw
+another such summit.  These hill-like forms grew lower and broader
+even as we stared.
+
+Moved by a sudden thought, I looked northward, and there I
+perceived a third of these cloudy black kopjes had risen.
+
+Everything had suddenly become very still.  Far away to the
+southeast, marking the quiet, we heard the Martians hooting to one
+another, and then the air quivered again with the distant thud of
+their guns.  But the earthly artillery made no reply.
+
+Now at the time we could not understand these things, but later I
+was to learn the meaning of these ominous kopjes that gathered in the
+twilight.  Each of the Martians, standing in the great crescent I have
+described, had discharged, by means of the gunlike tube he carried, a
+huge canister over whatever hill, copse, cluster of houses, or other
+possible cover for guns, chanced to be in front of him.  Some fired
+only one of these, some two--as in the case of the one we had seen;
+the one at Ripley is said to have discharged no fewer than five at
+that time.  These canisters smashed on striking the ground--they did
+not explode--and incontinently disengaged an enormous volume of heavy,
+inky vapour, coiling and pouring upward in a huge and ebony cumulus
+cloud, a gaseous hill that sank and spread itself slowly over the
+surrounding country.  And the touch of that vapour, the inhaling of
+its pungent wisps, was death to all that breathes.
+
+It was heavy, this vapour, heavier than the densest smoke, so that,
+after the first tumultuous uprush and outflow of its impact, it sank
+down through the air and poured over the ground in a manner rather
+liquid than gaseous, abandoning the hills, and streaming into the
+valleys and ditches and watercourses even as I have heard the
+carbonic-acid gas that pours from volcanic clefts is wont to do.  And
+where it came upon water some chemical action occurred, and the
+surface would be instantly covered with a powdery scum that sank
+slowly and made way for more.  The scum was absolutely insoluble, and
+it is a strange thing, seeing the instant effect of the gas, that one
+could drink without hurt the water from which it had been strained.
+The vapour did not diffuse as a true gas would do.  It hung together
+in banks, flowing sluggishly down the slope of the land and driving
+reluctantly before the wind, and very slowly it combined with the mist
+and moisture of the air, and sank to the earth in the form of dust.
+Save that an unknown element giving a group of four lines in the blue
+of the spectrum is concerned, we are still entirely ignorant of the
+nature of this substance.
+
+Once the tumultuous upheaval of its dispersion was over, the black
+smoke clung so closely to the ground, even before its precipitation,
+that fifty feet up in the air, on the roofs and upper stories of high
+houses and on great trees, there was a chance of escaping its poison
+altogether, as was proved even that night at Street Cobham and Ditton.
+
+The man who escaped at the former place tells a wonderful story of
+the strangeness of its coiling flow, and how he looked down from the
+church spire and saw the houses of the village rising like ghosts out
+of its inky nothingness.  For a day and a half he remained there,
+weary, starving and sun-scorched, the earth under the blue sky and
+against the prospect of the distant hills a velvet-black expanse, with
+red roofs, green trees, and, later, black-veiled shrubs and gates,
+barns, outhouses, and walls, rising here and there into the sunlight.
+
+But that was at Street Cobham, where the black vapour was allowed
+to remain until it sank of its own accord into the ground.  As a rule
+the Martians, when it had served its purpose, cleared the air of it
+again by wading into it and directing a jet of steam upon it.
+
+This they did with the vapour banks near us, as we saw in the
+starlight from the window of a deserted house at Upper Halliford,
+whither we had returned.  From there we could see the searchlights on
+Richmond Hill and Kingston Hill going to and fro, and about eleven the
+windows rattled, and we heard the sound of the huge siege guns that
+had been put in position there.  These continued intermittently for
+the space of a quarter of an hour, sending chance shots at the
+invisible Martians at Hampton and Ditton, and then the pale beams of
+the electric light vanished, and were replaced by a bright red glow.
+
+Then the fourth cylinder fell--a brilliant green meteor--as I
+learned afterwards, in Bushey Park.  Before the guns on the Richmond
+and Kingston line of hills began, there was a fitful cannonade far
+away in the southwest, due, I believe, to guns being fired haphazard
+before the black vapour could overwhelm the gunners.
+
+So, setting about it as methodically as men might smoke out a
+wasps' nest, the Martians spread this strange stifling vapour over the
+Londonward country.  The horns of the crescent slowly moved apart,
+until at last they formed a line from Hanwell to Coombe and Malden.
+All night through their destructive tubes advanced.  Never once, after
+the Martian at St. George's Hill was brought down, did they give the
+artillery the ghost of a chance against them.  Wherever there was a
+possibility of guns being laid for them unseen, a fresh canister of
+the black vapour was discharged, and where the guns were openly
+displayed the Heat-Ray was brought to bear.
+
+By midnight the blazing trees along the slopes of Richmond Park and
+the glare of Kingston Hill threw their light upon a network of black
+smoke, blotting out the whole valley of the Thames and extending as
+far as the eye could reach.  And through this two Martians slowly
+waded, and turned their hissing steam jets this way and that.
+
+They were sparing of the Heat-Ray that night, either because they
+had but a limited supply of material for its production or because
+they did not wish to destroy the country but only to crush and overawe
+the opposition they had aroused.  In the latter aim they certainly
+succeeded.  Sunday night was the end of the organised opposition to
+their movements.  After that no body of men would stand against them,
+so hopeless was the enterprise.  Even the crews of the torpedo-boats
+and destroyers that had brought their quick-firers up the Thames
+refused to stop, mutinied, and went down again.  The only offensive
+operation men ventured upon after that night was the preparation of
+mines and pitfalls, and even in that their energies were frantic and
+spasmodic.
+
+One has to imagine, as well as one may, the fate of those batteries
+towards Esher, waiting so tensely in the twilight.  Survivors there
+were none.  One may picture the orderly expectation, the officers
+alert and watchful, the gunners ready, the ammunition piled to hand,
+the limber gunners with their horses and waggons, the groups of
+civilian spectators standing as near as they were permitted, the
+evening stillness, the ambulances and hospital tents with the burned
+and wounded from Weybridge; then the dull resonance of the shots the
+Martians fired, and the clumsy projectile whirling over the trees and
+houses and smashing amid the neighbouring fields.
+
+One may picture, too, the sudden shifting of the attention, the
+swiftly spreading coils and bellyings of that blackness advancing
+headlong, towering heavenward, turning the twilight to a palpable
+darkness, a strange and horrible antagonist of vapour striding upon
+its victims, men and horses near it seen dimly, running, shrieking,
+falling headlong, shouts of dismay, the guns suddenly abandoned, men
+choking and writhing on the ground, and the swift broadening-out of
+the opaque cone of smoke.  And then night and extinction--nothing but
+a silent mass of impenetrable vapour hiding its dead.
+
+Before dawn the black vapour was pouring through the streets of
+Richmond, and the disintegrating organism of government was, with a
+last expiring effort, rousing the population of London to the
+necessity of flight.
+
+
+
+CHAPTER SIXTEEN
+
+THE EXODUS FROM LONDON
+
+
+So you understand the roaring wave of fear that swept through the
+greatest city in the world just as Monday was dawning--the stream of
+flight rising swiftly to a torrent, lashing in a foaming tumult round
+the railway stations, banked up into a horrible struggle about the
+shipping in the Thames, and hurrying by every available channel
+northward and eastward.  By ten o'clock the police organisation, and
+by midday even the railway organisations, were losing coherency,
+losing shape and efficiency, guttering, softening, running at last in
+that swift liquefaction of the social body.
+
+All the railway lines north of the Thames and the South-Eastern
+people at Cannon Street had been warned by midnight on Sunday, and
+trains were being filled.  People were fighting savagely for
+standing-room in the carriages even at two o'clock.  By three, people
+were being trampled and crushed even in Bishopsgate Street, a couple
+of hundred yards or more from Liverpool Street station; revolvers were
+fired, people stabbed, and the policemen who had been sent to direct
+the traffic, exhausted and infuriated, were breaking the heads of the
+people they were called out to protect.
+
+And as the day advanced and the engine drivers and stokers refused
+to return to London, the pressure of the flight drove the people in an
+ever-thickening multitude away from the stations and along the
+northward-running roads.  By midday a Martian had been seen at Barnes,
+and a cloud of slowly sinking black vapour drove along the Thames and
+across the flats of Lambeth, cutting off all escape over the bridges
+in its sluggish advance.  Another bank drove over Ealing, and
+surrounded a little island of survivors on Castle Hill, alive, but
+unable to escape.
+
+After a fruitless struggle to get aboard a North-Western train at
+Chalk Farm--the engines of the trains that had loaded in the goods
+yard there _ploughed_ through shrieking people, and a dozen stalwart men
+fought to keep the crowd from crushing the driver against his
+furnace--my brother emerged upon the Chalk Farm road, dodged across
+through a hurrying swarm of vehicles, and had the luck to be foremost
+in the sack of a cycle shop.  The front tire of the machine he got was
+punctured in dragging it through the window, but he got up and off,
+notwithstanding, with no further injury than a cut wrist.  The steep
+foot of Haverstock Hill was impassable owing to several overturned
+horses, and my brother struck into Belsize Road.
+
+So he got out of the fury of the panic, and, skirting the Edgware
+Road, reached Edgware about seven, fasting and wearied, but well ahead
+of the crowd.  Along the road people were standing in the roadway,
+curious, wondering.  He was passed by a number of cyclists, some
+horsemen, and two motor cars.  A mile from Edgware the rim of the
+wheel broke, and the machine became unridable.  He left it by the
+roadside and trudged through the village.  There were shops half
+opened in the main street of the place, and people crowded on the
+pavement and in the doorways and windows, staring astonished at this
+extraordinary procession of fugitives that was beginning.  He
+succeeded in getting some food at an inn.
+
+For a time he remained in Edgware not knowing what next to do.  The
+flying people increased in number.  Many of them, like my brother,
+seemed inclined to loiter in the place.  There was no fresh news of
+the invaders from Mars.
+
+At that time the road was crowded, but as yet far from congested.
+Most of the fugitives at that hour were mounted on cycles, but there
+were soon motor cars, hansom cabs, and carriages hurrying along, and
+the dust hung in heavy clouds along the road to St. Albans.
+
+It was perhaps a vague idea of making his way to Chelmsford, where
+some friends of his lived, that at last induced my brother to strike
+into a quiet lane running eastward.  Presently he came upon a stile,
+and, crossing it, followed a footpath northeastward.  He passed near
+several farmhouses and some little places whose names he did not
+learn.  He saw few fugitives until, in a grass lane towards High
+Barnet, he happened upon two ladies who became his fellow travellers.
+He came upon them just in time to save them.
+
+He heard their screams, and, hurrying round the corner, saw a
+couple of men struggling to drag them out of the little pony-chaise in
+which they had been driving, while a third with difficulty held the
+frightened pony's head.  One of the ladies, a short woman dressed in
+white, was simply screaming; the other, a dark, slender figure,
+slashed at the man who gripped her arm with a whip she held in her
+disengaged hand.
+
+My brother immediately grasped the situation, shouted, and hurried
+towards the struggle.  One of the men desisted and turned towards him,
+and my brother, realising from his antagonist's face that a fight was
+unavoidable, and being an expert boxer, went into him forthwith and
+sent him down against the wheel of the chaise.
+
+It was no time for pugilistic chivalry and my brother laid him
+quiet with a kick, and gripped the collar of the man who pulled at the
+slender lady's arm.  He heard the clatter of hoofs, the whip stung
+across his face, a third antagonist struck him between the eyes, and
+the man he held wrenched himself free and made off down the lane in
+the direction from which he had come.
+
+Partly stunned, he found himself facing the man who had held the
+horse's head, and became aware of the chaise receding from him down
+the lane, swaying from side to side, and with the women in it looking
+back.  The man before him, a burly rough, tried to close, and he
+stopped him with a blow in the face.  Then, realising that he was
+deserted, he dodged round and made off down the lane after the chaise,
+with the sturdy man close behind him, and the fugitive, who had turned
+now, following remotely.
+
+Suddenly he stumbled and fell; his immediate pursuer went headlong,
+and he rose to his feet to find himself with a couple of antagonists
+again.  He would have had little chance against them had not the
+slender lady very pluckily pulled up and returned to his help.  It
+seems she had had a revolver all this time, but it had been under the
+seat when she and her companion were attacked.  She fired at six
+yards' distance, narrowly missing my brother.  The less courageous of
+the robbers made off, and his companion followed him, cursing his
+cowardice.  They both stopped in sight down the lane, where the third
+man lay insensible.
+
+"Take this!" said the slender lady, and she gave my brother her
+revolver.
+
+"Go back to the chaise," said my brother, wiping the blood from his
+split lip.
+
+She turned without a word--they were both panting--and they went
+back to where the lady in white struggled to hold back the frightened
+pony.
+
+The robbers had evidently had enough of it.  When my brother looked
+again they were retreating.
+
+"I'll sit here," said my brother, "if I may"; and he got upon the
+empty front seat.  The lady looked over her shoulder.
+
+"Give me the reins," she said, and laid the whip along the pony's
+side.  In another moment a bend in the road hid the three men from my
+brother's eyes.
+
+So, quite unexpectedly, my brother found himself, panting, with a
+cut mouth, a bruised jaw, and bloodstained knuckles, driving along an
+unknown lane with these two women.
+
+He learned they were the wife and the younger sister of a surgeon
+living at Stanmore, who had come in the small hours from a dangerous
+case at Pinner, and heard at some railway station on his way of the
+Martian advance.  He had hurried home, roused the women--their servant
+had left them two days before--packed some provisions, put his
+revolver under the seat--luckily for my brother--and told them to
+drive on to Edgware, with the idea of getting a train there.  He
+stopped behind to tell the neighbours.  He would overtake them, he
+said, at about half past four in the morning, and now it was nearly
+nine and they had seen nothing of him.  They could not stop in Edgware
+because of the growing traffic through the place, and so they had come
+into this side lane.
+
+That was the story they told my brother in fragments when presently
+they stopped again, nearer to New Barnet.  He promised to stay with
+them, at least until they could determine what to do, or until the
+missing man arrived, and professed to be an expert shot with the
+revolver--a weapon strange to him--in order to give them confidence.
+
+They made a sort of encampment by the wayside, and the pony became
+happy in the hedge.  He told them of his own escape out of London, and
+all that he knew of these Martians and their ways.  The sun crept
+higher in the sky, and after a time their talk died out and gave place
+to an uneasy state of anticipation.  Several wayfarers came along the
+lane, and of these my brother gathered such news as he could.  Every
+broken answer he had deepened his impression of the great disaster
+that had come on humanity, deepened his persuasion of the immediate
+necessity for prosecuting this flight.  He urged the matter upon them.
+
+"We have money," said the slender woman, and hesitated.
+
+Her eyes met my brother's, and her hesitation ended.
+
+"So have I," said my brother.
+
+She explained that they had as much as thirty pounds in gold,
+besides a five-pound note, and suggested that with that they might get
+upon a train at St. Albans or New Barnet.  My brother thought that was
+hopeless, seeing the fury of the Londoners to crowd upon the trains,
+and broached his own idea of striking across Essex towards Harwich and
+thence escaping from the country altogether.
+
+Mrs. Elphinstone--that was the name of the woman in white--would
+listen to no reasoning, and kept calling upon "George"; but her
+sister-in-law was astonishingly quiet and deliberate, and at last
+agreed to my brother's suggestion.  So, designing to cross the Great
+North Road, they went on towards Barnet, my brother leading the pony
+to save it as much as possible.  As the sun crept up the sky the day
+became excessively hot, and under foot a thick, whitish sand grew
+burning and blinding, so that they travelled only very slowly.  The
+hedges were grey with dust.  And as they advanced towards Barnet a
+tumultuous murmuring grew stronger.
+
+They began to meet more people.  For the most part these were
+staring before them, murmuring indistinct questions, jaded, haggard,
+unclean.  One man in evening dress passed them on foot, his eyes on
+the ground.  They heard his voice, and, looking back at him, saw one
+hand clutched in his hair and the other beating invisible things.  His
+paroxysm of rage over, he went on his way without once looking back.
+
+As my brother's party went on towards the crossroads to the south
+of Barnet they saw a woman approaching the road across some fields on
+their left, carrying a child and with two other children; and then
+passed a man in dirty black, with a thick stick in one hand and a
+small portmanteau in the other.  Then round the corner of the lane,
+from between the villas that guarded it at its confluence with the
+high road, came a little cart drawn by a sweating black pony and
+driven by a sallow youth in a bowler hat, grey with dust.  There were
+three girls, East End factory girls, and a couple of little children
+crowded in the cart.
+
+"This'll tike us rahnd Edgware?" asked the driver, wild-eyed,
+white-faced; and when my brother told him it would if he turned to the
+left, he whipped up at once without the formality of thanks.
+
+My brother noticed a pale grey smoke or haze rising among the
+houses in front of them, and veiling the white facade of a terrace
+beyond the road that appeared between the backs of the villas.  Mrs.
+Elphinstone suddenly cried out at a number of tongues of smoky red
+flame leaping up above the houses in front of them against the hot,
+blue sky.  The tumultuous noise resolved itself now into the
+disorderly mingling of many voices, the gride of many wheels, the
+creaking of waggons, and the staccato of hoofs.  The lane came round
+sharply not fifty yards from the crossroads.
+
+"Good heavens!" cried Mrs. Elphinstone.  "What is this you are
+driving us into?"
+
+My brother stopped.
+
+For the main road was a boiling stream of people, a torrent of
+human beings rushing northward, one pressing on another.  A great bank
+of dust, white and luminous in the blaze of the sun, made everything
+within twenty feet of the ground grey and indistinct and was
+perpetually renewed by the hurrying feet of a dense crowd of horses
+and of men and women on foot, and by the wheels of vehicles of every
+description.
+
+"Way!" my brother heard voices crying.  "Make way!"
+
+It was like riding into the smoke of a fire to approach the meeting
+point of the lane and road; the crowd roared like a fire, and the dust
+was hot and pungent.  And, indeed, a little way up the road a villa
+was burning and sending rolling masses of black smoke across the road
+to add to the confusion.
+
+Two men came past them.  Then a dirty woman, carrying a heavy
+bundle and weeping.  A lost retriever dog, with hanging tongue,
+circled dubiously round them, scared and wretched, and fled at my
+brother's threat.
+
+So much as they could see of the road Londonward between the houses
+to the right was a tumultuous stream of dirty, hurrying people, pent
+in between the villas on either side; the black heads, the crowded
+forms, grew into distinctness as they rushed towards the corner,
+hurried past, and merged their individuality again in a receding
+multitude that was swallowed up at last in a cloud of dust.
+
+"Go on!  Go on!" cried the voices.  "Way!  Way!"
+
+One man's hands pressed on the back of another.  My brother stood
+at the pony's head.  Irresistibly attracted, he advanced slowly, pace
+by pace, down the lane.
+
+Edgware had been a scene of confusion, Chalk Farm a riotous tumult,
+but this was a whole population in movement.  It is hard to imagine
+that host.  It had no character of its own.  The figures poured out
+past the corner, and receded with their backs to the group in the
+lane.  Along the margin came those who were on foot threatened by the
+wheels, stumbling in the ditches, blundering into one another.
+
+The carts and carriages crowded close upon one another, making
+little way for those swifter and more impatient vehicles that darted
+forward every now and then when an opportunity showed itself of doing
+so, sending the people scattering against the fences and gates of the
+villas.
+
+"Push on!" was the cry.  "Push on!  They are coming!"
+
+In one cart stood a blind man in the uniform of the Salvation Army,
+gesticulating with his crooked fingers and bawling, "Eternity!
+Eternity!"  His voice was hoarse and very loud so that my brother
+could hear him long after he was lost to sight in the dust.  Some of
+the people who crowded in the carts whipped stupidly at their horses
+and quarrelled with other drivers; some sat motionless, staring at
+nothing with miserable eyes; some gnawed their hands with thirst, or
+lay prostrate in the bottoms of their conveyances.  The horses' bits
+were covered with foam, their eyes bloodshot.
+
+There were cabs, carriages, shop cars, waggons, beyond counting; a
+mail cart, a road-cleaner's cart marked "Vestry of St. Pancras," a
+huge timber waggon crowded with roughs.  A brewer's dray rumbled by
+with its two near wheels splashed with fresh blood.
+
+"Clear the way!" cried the voices.  "Clear the way!"
+
+"Eter-nity!  Eter-nity!" came echoing down the road.
+
+There were sad, haggard women tramping by, well dressed, with
+children that cried and stumbled, their dainty clothes smothered in
+dust, their weary faces smeared with tears.  With many of these came
+men, sometimes helpful, sometimes lowering and savage.  Fighting side
+by side with them pushed some weary street outcast in faded black
+rags, wide-eyed, loud-voiced, and foul-mouthed.  There were sturdy
+workmen thrusting their way along, wretched, unkempt men, clothed like
+clerks or shopmen, struggling spasmodically; a wounded soldier my
+brother noticed, men dressed in the clothes of railway porters, one
+wretched creature in a nightshirt with a coat thrown over it.
+
+But varied as its composition was, certain things all that host had
+in common.  There were fear and pain on their faces, and fear behind
+them.  A tumult up the road, a quarrel for a place in a waggon, sent
+the whole host of them quickening their pace; even a man so scared and
+broken that his knees bent under him was galvanised for a moment into
+renewed activity.  The heat and dust had already been at work upon
+this multitude.  Their skins were dry, their lips black and cracked.
+They were all thirsty, weary, and footsore.  And amid the various
+cries one heard disputes, reproaches, groans of weariness and fatigue;
+the voices of most of them were hoarse and weak.  Through it all ran a
+refrain:
+
+"Way!  Way!  The Martians are coming!"
+
+Few stopped and came aside from that flood.  The lane opened
+slantingly into the main road with a narrow opening, and had a
+delusive appearance of coming from the direction of London.  Yet a
+kind of eddy of people drove into its mouth; weaklings elbowed out of
+the stream, who for the most part rested but a moment before plunging
+into it again.  A little way down the lane, with two friends bending
+over him, lay a man with a bare leg, wrapped about with bloody rags.
+He was a lucky man to have friends.
+
+A little old man, with a grey military moustache and a filthy black
+frock coat, limped out and sat down beside the trap, removed his
+boot--his sock was blood-stained--shook out a pebble, and hobbled on
+again; and then a little girl of eight or nine, all alone, threw
+herself under the hedge close by my brother, weeping.
+
+"I can't go on!  I can't go on!"
+
+My brother woke from his torpor of astonishment and lifted her up,
+speaking gently to her, and carried her to Miss Elphinstone.  So soon
+as my brother touched her she became quite still, as if frightened.
+
+"Ellen!" shrieked a woman in the crowd, with tears in her
+voice--"Ellen!"  And the child suddenly darted away from my brother,
+crying "Mother!"
+
+"They are coming," said a man on horseback, riding past along the
+lane.
+
+"Out of the way, there!" bawled a coachman, towering high; and my
+brother saw a closed carriage turning into the lane.
+
+The people crushed back on one another to avoid the horse.  My
+brother pushed the pony and chaise back into the hedge, and the man
+drove by and stopped at the turn of the way.  It was a carriage, with
+a pole for a pair of horses, but only one was in the traces.  My
+brother saw dimly through the dust that two men lifted out something
+on a white stretcher and put it gently on the grass beneath the privet
+hedge.
+
+One of the men came running to my brother.
+
+"Where is there any water?" he said.  "He is dying fast, and very
+thirsty.  It is Lord Garrick."
+
+"Lord Garrick!" said my brother; "the Chief Justice?"
+
+"The water?" he said.
+
+"There may be a tap," said my brother, "in some of the houses.  We
+have no water.  I dare not leave my people."
+
+The man pushed against the crowd towards the gate of the corner
+house.
+
+"Go on!" said the people, thrusting at him.  "They are coming!  Go
+on!"
+
+Then my brother's attention was distracted by a bearded, eagle-faced
+man lugging a small handbag, which split even as my brother's
+eyes rested on it and disgorged a mass of sovereigns that seemed to
+break up into separate coins as it struck the ground.  They rolled
+hither and thither among the struggling feet of men and horses.  The
+man stopped and looked stupidly at the heap, and the shaft of a cab
+struck his shoulder and sent him reeling.  He gave a shriek and dodged
+back, and a cartwheel shaved him narrowly.
+
+"Way!" cried the men all about him.  "Make way!"
+
+So soon as the cab had passed, he flung himself, with both hands
+open, upon the heap of coins, and began thrusting handfuls in his
+pocket.  A horse rose close upon him, and in another moment, half
+rising, he had been borne down under the horse's hoofs.
+
+"Stop!" screamed my brother, and pushing a woman out of his way,
+tried to clutch the bit of the horse.
+
+Before he could get to it, he heard a scream under the wheels, and
+saw through the dust the rim passing over the poor wretch's back.  The
+driver of the cart slashed his whip at my brother, who ran round
+behind the cart.  The multitudinous shouting confused his ears.  The
+man was writhing in the dust among his scattered money, unable to
+rise, for the wheel had broken his back, and his lower limbs lay limp
+and dead.  My brother stood up and yelled at the next driver, and a
+man on a black horse came to his assistance.
+
+"Get him out of the road," said he; and, clutching the man's collar
+with his free hand, my brother lugged him sideways.  But he still
+clutched after his money, and regarded my brother fiercely, hammering
+at his arm with a handful of gold.  "Go on!  Go on!" shouted angry
+voices behind.
+
+"Way!  Way!"
+
+There was a smash as the pole of a carriage crashed into the cart
+that the man on horseback stopped.  My brother looked up, and the man
+with the gold twisted his head round and bit the wrist that held his
+collar.  There was a concussion, and the black horse came staggering
+sideways, and the carthorse pushed beside it.  A hoof missed my
+brother's foot by a hair's breadth.  He released his grip on the
+fallen man and jumped back.  He saw anger change to terror on the face
+of the poor wretch on the ground, and in a moment he was hidden and my
+brother was borne backward and carried past the entrance of the lane,
+and had to fight hard in the torrent to recover it.
+
+He saw Miss Elphinstone covering her eyes, and a little child, with
+all a child's want of sympathetic imagination, staring with dilated
+eyes at a dusty something that lay black and still, ground and crushed
+under the rolling wheels.  "Let us go back!" he shouted, and began
+turning the pony round. "We cannot cross this--hell," he said and they
+went back a hundred yards the way they had come, until the fighting
+crowd was hidden.  As they passed the bend in the lane my brother saw
+the face of the dying man in the ditch under the privet, deadly white
+and drawn, and shining with perspiration.  The two women sat silent,
+crouching in their seat and shivering.
+
+Then beyond the bend my brother stopped again.  Miss Elphinstone
+was white and pale, and her sister-in-law sat weeping, too wretched
+even to call upon "George."  My brother was horrified and perplexed.
+So soon as they had retreated he realised how urgent and unavoidable
+it was to attempt this crossing.  He turned to Miss Elphinstone,
+suddenly resolute.
+
+"We must go that way," he said, and led the pony round again.
+
+For the second time that day this girl proved her quality.  To force
+their way into the torrent of people, my brother plunged into the
+traffic and held back a cab horse, while she drove the pony across its
+head.  A waggon locked wheels for a moment and ripped a long splinter
+from the chaise.  In another moment they were caught and swept forward
+by the stream.  My brother, with the cabman's whip marks red across
+his face and hands, scrambled into the chaise and took the reins from
+her.
+
+"Point the revolver at the man behind," he said, giving it to her,
+"if he presses us too hard.  No!--point it at his horse."
+
+Then he began to look out for a chance of edging to the right
+across the road.  But once in the stream he seemed to lose volition,
+to become a part of that dusty rout.  They swept through Chipping
+Barnet with the torrent; they were nearly a mile beyond the centre of
+the town before they had fought across to the opposite side of the
+way.  It was din and confusion indescribable; but in and beyond the
+town the road forks repeatedly, and this to some extent relieved the
+stress.
+
+They struck eastward through Hadley, and there on either side of
+the road, and at another place farther on they came upon a great
+multitude of people drinking at the stream, some fighting to come at
+the water.  And farther on, from a lull near East Barnet, they saw
+two trains running slowly one after the other without signal or
+order--trains swarming with people, with men even among the coals
+behind the engines--going northward along the Great Northern Railway.
+My brother supposes they must have filled outside London, for at that
+time the furious terror of the people had rendered the central
+termini impossible.
+
+Near this place they halted for the rest of the afternoon, for the
+violence of the day had already utterly exhausted all three of them.
+They began to suffer the beginnings of hunger; the night was cold, and
+none of them dared to sleep.  And in the evening many people came
+hurrying along the road nearby their stopping place, fleeing from
+unknown dangers before them, and going in the direction from which my
+brother had come.
+
+
+
+CHAPTER SEVENTEEN
+
+THE "THUNDER CHILD"
+
+
+Had the Martians aimed only at destruction, they might on Monday
+have annihilated the entire population of London, as it spread itself
+slowly through the home counties.  Not only along the road through
+Barnet, but also through Edgware and Waltham Abbey, and along the
+roads eastward to Southend and Shoeburyness, and south of the Thames
+to Deal and Broadstairs, poured the same frantic rout.  If one could
+have hung that June morning in a balloon in the blazing blue above
+London every northward and eastward road running out of the tangled
+maze of streets would have seemed stippled black with the streaming
+fugitives, each dot a human agony of terror and physical distress.  I
+have set forth at length in the last chapter my brother's account of
+the road through Chipping Barnet, in order that my readers may realise
+how that swarming of black dots appeared to one of those concerned.
+Never before in the history of the world had such a mass of human
+beings moved and suffered together.  The legendary hosts of Goths and
+Huns, the hugest armies Asia has ever seen, would have been but a drop
+in that current.  And this was no disciplined march; it was a
+stampede--a stampede gigantic and terrible--without order and without
+a goal, six million people unarmed and unprovisioned, driving
+headlong.  It was the beginning of the rout of civilisation, of the
+massacre of mankind.
+
+Directly below him the balloonist would have seen the network of
+streets far and wide, houses, churches, squares, crescents,
+gardens--already derelict--spread out like a huge map, and in the
+southward _blotted_.  Over Ealing, Richmond, Wimbledon, it would
+have seemed as if some monstrous pen had flung ink upon the chart.
+Steadily, incessantly, each black splash grew and spread, shooting out
+ramifications this way and that, now banking itself against rising
+ground, now pouring swiftly over a crest into a new-found valley,
+exactly as a gout of ink would spread itself upon blotting paper.
+
+And beyond, over the blue hills that rise southward of the river,
+the glittering Martians went to and fro, calmly and methodically
+spreading their poison cloud over this patch of country and then over
+that, laying it again with their steam jets when it had served its
+purpose, and taking possession of the conquered country.  They do not
+seem to have aimed at extermination so much as at complete
+demoralisation and the destruction of any opposition.  They exploded
+any stores of powder they came upon, cut every telegraph, and wrecked
+the railways here and there.  They were hamstringing mankind.  They
+seemed in no hurry to extend the field of their operations, and did
+not come beyond the central part of London all that day.  It is
+possible that a very considerable number of people in London stuck to
+their houses through Monday morning.  Certain it is that many died at
+home suffocated by the Black Smoke.
+
+Until about midday the Pool of London was an astonishing scene.
+Steamboats and shipping of all sorts lay there, tempted by the
+enormous sums of money offered by fugitives, and it is said that many
+who swam out to these vessels were thrust off with boathooks and
+drowned.  About one o'clock in the afternoon the thinning remnant of a
+cloud of the black vapour appeared between the arches of Blackfriars
+Bridge.  At that the Pool became a scene of mad confusion, fighting,
+and collision, and for some time a multitude of boats and barges
+jammed in the northern arch of the Tower Bridge, and the sailors and
+lightermen had to fight savagely against the people who swarmed upon
+them from the riverfront.  People were actually clambering down the
+piers of the bridge from above.
+
+When, an hour later, a Martian appeared beyond the Clock Tower and
+waded down the river, nothing but wreckage floated above Limehouse.
+
+Of the falling of the fifth cylinder I have presently to tell.  The
+sixth star fell at Wimbledon.  My brother, keeping watch beside the
+women in the chaise in a meadow, saw the green flash of it far beyond
+the hills.  On Tuesday the little party, still set upon getting across
+the sea, made its way through the swarming country towards Colchester.
+The news that the Martians were now in possession of the whole of
+London was confirmed.  They had been seen at Highgate, and even, it
+was said, at Neasden.  But they did not come into my brother's view
+until the morrow.
+
+That day the scattered multitudes began to realise the urgent need
+of provisions.  As they grew hungry the rights of property ceased to
+be regarded.  Farmers were out to defend their cattle-sheds,
+granaries, and ripening root crops with arms in their hands.  A number
+of people now, like my brother, had their faces eastward, and there
+were some desperate souls even going back towards London to get food.
+These were chiefly people from the northern suburbs, whose knowledge
+of the Black Smoke came by hearsay.  He heard that about half the
+members of the government had gathered at Birmingham, and that
+enormous quantities of high explosives were being prepared to be used
+in automatic mines across the Midland counties.
+
+He was also told that the Midland Railway Company had replaced the
+desertions of the first day's panic, had resumed traffic, and was
+running northward trains from St. Albans to relieve the congestion of
+the home counties.  There was also a placard in Chipping Ongar
+announcing that large stores of flour were available in the northern
+towns and that within twenty-four hours bread would be distributed
+among the starving people in the neighbourhood.  But this intelligence
+did not deter him from the plan of escape he had formed, and the three
+pressed eastward all day, and heard no more of the bread distribution
+than this promise.  Nor, as a matter of fact, did anyone else hear
+more of it.  That night fell the seventh star, falling upon Primrose
+Hill.  It fell while Miss Elphinstone was watching, for she took that
+duty alternately with my brother.  She saw it.
+
+On Wednesday the three fugitives--they had passed the night in a
+field of unripe wheat--reached Chelmsford, and there a body of the
+inhabitants, calling itself the Committee of Public Supply, seized the
+pony as provisions, and would give nothing in exchange for it but the
+promise of a share in it the next day.  Here there were rumours of
+Martians at Epping, and news of the destruction of Waltham Abbey
+Powder Mills in a vain attempt to blow up one of the invaders.
+
+People were watching for Martians here from the church towers.  My
+brother, very luckily for him as it chanced, preferred to push on at
+once to the coast rather than wait for food, although all three of
+them were very hungry.  By midday they passed through Tillingham,
+which, strangely enough, seemed to be quite silent and deserted, save
+for a few furtive plunderers hunting for food.  Near Tillingham they
+suddenly came in sight of the sea, and the most amazing crowd of
+shipping of all sorts that it is possible to imagine.
+
+For after the sailors could no longer come up the Thames, they came
+on to the Essex coast, to Harwich and Walton and Clacton, and
+afterwards to Foulness and Shoebury, to bring off the people.  They
+lay in a huge sickle-shaped curve that vanished into mist at last
+towards the Naze.  Close inshore was a multitude of fishing
+smacks--English, Scotch, French, Dutch, and Swedish; steam launches
+from the Thames, yachts, electric boats; and beyond were ships of large
+burden, a multitude of filthy colliers, trim merchantmen, cattle ships,
+passenger boats, petroleum tanks, ocean tramps, an old white transport
+even, neat white and grey liners from Southampton and Hamburg; and
+along the blue coast across the Blackwater my brother could make out
+dimly a dense swarm of boats chaffering with the people on the beach,
+a swarm which also extended up the Blackwater almost to Maldon.
+
+About a couple of miles out lay an ironclad, very low in the water,
+almost, to my brother's perception, like a water-logged ship.  This
+was the ram _Thunder Child_.  It was the only warship in sight, but far
+away to the right over the smooth surface of the sea--for that day
+there was a dead calm--lay a serpent of black smoke to mark the next
+ironclads of the Channel Fleet, which hovered in an extended line,
+steam up and ready for action, across the Thames estuary during the
+course of the Martian conquest, vigilant and yet powerless to prevent
+it.
+
+At the sight of the sea, Mrs. Elphinstone, in spite of the
+assurances of her sister-in-law, gave way to panic.  She had never
+been out of England before, she would rather die than trust herself
+friendless in a foreign country, and so forth.  She seemed, poor woman,
+to imagine that the French and the Martians might prove very similar.
+She had been growing increasingly hysterical, fearful, and depressed
+during the two days' journeyings.  Her great idea was to return to
+Stanmore.  Things had been always well and safe at Stanmore.  They
+would find George at Stanmore.
+
+It was with the greatest difficulty they could get her down to the
+beach, where presently my brother succeeded in attracting the
+attention of some men on a paddle steamer from the Thames.  They sent
+a boat and drove a bargain for thirty-six pounds for the three.  The
+steamer was going, these men said, to Ostend.
+
+It was about two o'clock when my brother, having paid their fares
+at the gangway, found himself safely aboard the steamboat with his
+charges.  There was food aboard, albeit at exorbitant prices, and the
+three of them contrived to eat a meal on one of the seats forward.
+
+There were already a couple of score of passengers aboard, some of
+whom had expended their last money in securing a passage, but the
+captain lay off the Blackwater until five in the afternoon, picking up
+passengers until the seated decks were even dangerously crowded.  He
+would probably have remained longer had it not been for the sound of
+guns that began about that hour in the south.  As if in answer, the
+ironclad seaward fired a small gun and hoisted a string of flags.  A
+jet of smoke sprang out of her funnels.
+
+Some of the passengers were of opinion that this firing came from
+Shoeburyness, until it was noticed that it was growing louder.  At the
+same time, far away in the southeast the masts and upperworks of three
+ironclads rose one after the other out of the sea, beneath clouds of
+black smoke.  But my brother's attention speedily reverted to the
+distant firing in the south.  He fancied he saw a column of smoke
+rising out of the distant grey haze.
+
+The little steamer was already flapping her way eastward of the big
+crescent of shipping, and the low Essex coast was growing blue and
+hazy, when a Martian appeared, small and faint in the remote distance,
+advancing along the muddy coast from the direction of Foulness.  At
+that the captain on the bridge swore at the top of his voice with fear
+and anger at his own delay, and the paddles seemed infected with his
+terror.  Every soul aboard stood at the bulwarks or on the seats of
+the steamer and stared at that distant shape, higher than the trees or
+church towers inland, and advancing with a leisurely parody of a human
+stride.
+
+It was the first Martian my brother had seen, and he stood, more
+amazed than terrified, watching this Titan advancing deliberately
+towards the shipping, wading farther and farther into the water as the
+coast fell away.  Then, far away beyond the Crouch, came another,
+striding over some stunted trees, and then yet another, still farther
+off, wading deeply through a shiny mudflat that seemed to hang halfway
+up between sea and sky.  They were all stalking seaward, as if to
+intercept the escape of the multitudinous vessels that were crowded
+between Foulness and the Naze.  In spite of the throbbing exertions of
+the engines of the little paddle-boat, and the pouring foam that her
+wheels flung behind her, she receded with terrifying slowness from
+this ominous advance.
+
+Glancing northwestward, my brother saw the large crescent of
+shipping already writhing with the approaching terror; one ship
+passing behind another, another coming round from broadside to end on,
+steamships whistling and giving off volumes of steam, sails being let
+out, launches rushing hither and thither.  He was so fascinated by
+this and by the creeping danger away to the left that he had no eyes
+for anything seaward.  And then a swift movement of the steamboat (she
+had suddenly come round to avoid being run down) flung him headlong
+from the seat upon which he was standing.  There was a shouting all
+about him, a trampling of feet, and a cheer that seemed to be answered
+faintly.  The steamboat lurched and rolled him over upon his hands.
+
+He sprang to his feet and saw to starboard, and not a hundred yards
+from their heeling, pitching boat, a vast iron bulk like the blade of
+a plough tearing through the water, tossing it on either side in huge
+waves of foam that leaped towards the steamer, flinging her paddles
+helplessly in the air, and then sucking her deck down almost to the
+waterline.
+
+A douche of spray blinded my brother for a moment.  When his eyes
+were clear again he saw the monster had passed and was rushing
+landward.  Big iron upperworks rose out of this headlong structure,
+and from that twin funnels projected and spat a smoking blast shot
+with fire.  It was the torpedo ram, _Thunder Child_, steaming headlong,
+coming to the rescue of the threatened shipping.
+
+Keeping his footing on the heaving deck by clutching the bulwarks,
+my brother looked past this charging leviathan at the Martians again,
+and he saw the three of them now close together, and standing so far
+out to sea that their tripod supports were almost entirely submerged.
+Thus sunken, and seen in remote perspective, they appeared far less
+formidable than the huge iron bulk in whose wake the steamer was
+pitching so helplessly.  It would seem they were regarding this new
+antagonist with astonishment.  To their intelligence, it may be, the
+giant was even such another as themselves.  The _Thunder Child_ fired no
+gun, but simply drove full speed towards them.  It was probably her
+not firing that enabled her to get so near the enemy as she did.  They
+did not know what to make of her.  One shell, and they would have sent
+her to the bottom forthwith with the Heat-Ray.
+
+She was steaming at such a pace that in a minute she seemed halfway
+between the steamboat and the Martians--a diminishing black bulk
+against the receding horizontal expanse of the Essex coast.
+
+Suddenly the foremost Martian lowered his tube and discharged a
+canister of the black gas at the ironclad.  It hit her larboard side
+and glanced off in an inky jet that rolled away to seaward, an
+unfolding torrent of Black Smoke, from which the ironclad drove clear.
+To the watchers from the steamer, low in the water and with the sun in
+their eyes, it seemed as though she were already among the Martians.
+
+They saw the gaunt figures separating and rising out of the water
+as they retreated shoreward, and one of them raised the camera-like
+generator of the Heat-Ray.  He held it pointing obliquely downward,
+and a bank of steam sprang from the water at its touch.  It must have
+driven through the iron of the ship's side like a white-hot iron rod
+through paper.
+
+A flicker of flame went up through the rising steam, and then the
+Martian reeled and staggered.  In another moment he was cut down, and
+a great body of water and steam shot high in the air.  The guns of the
+_Thunder Child_ sounded through the reek, going off one after the other,
+and one shot splashed the water high close by the steamer, ricocheted
+towards the other flying ships to the north, and smashed a smack to
+matchwood.
+
+But no one heeded that very much.  At the sight of the Martian's
+collapse the captain on the bridge yelled inarticulately, and all the
+crowding passengers on the steamer's stern shouted together.  And then
+they yelled again.  For, surging out beyond the white tumult, drove
+something long and black, the flames streaming from its middle parts,
+its ventilators and funnels spouting fire.
+
+She was alive still; the steering gear, it seems, was intact and
+her engines working.  She headed straight for a second Martian, and
+was within a hundred yards of him when the Heat-Ray came to bear.  Then
+with a violent thud, a blinding flash, her decks, her funnels, leaped
+upward.  The Martian staggered with the violence of her explosion, and
+in another moment the flaming wreckage, still driving forward with the
+impetus of its pace, had struck him and crumpled him up like a thing
+of cardboard.  My brother shouted involuntarily.  A boiling tumult of
+steam hid everything again.
+
+"Two!" yelled the captain.
+
+Everyone was shouting.  The whole steamer from end to end rang with
+frantic cheering that was taken up first by one and then by all in the
+crowding multitude of ships and boats that was driving out to sea.
+
+The steam hung upon the water for many minutes, hiding the third
+Martian and the coast altogether.  And all this time the boat was
+paddling steadily out to sea and away from the fight; and when at last
+the confusion cleared, the drifting bank of black vapour intervened,
+and nothing of the _Thunder Child_ could be made out, nor could the
+third Martian be seen.  But the ironclads to seaward were now quite
+close and standing in towards shore past the steamboat.
+
+The little vessel continued to beat its way seaward, and the
+ironclads receded slowly towards the coast, which was hidden still by
+a marbled bank of vapour, part steam, part black gas, eddying and
+combining in the strangest way.  The fleet of refugees was scattering
+to the northeast; several smacks were sailing between the ironclads
+and the steamboat.  After a time, and before they reached the sinking
+cloud bank, the warships turned northward, and then abruptly went
+about and passed into the thickening haze of evening southward.  The
+coast grew faint, and at last indistinguishable amid the low banks of
+clouds that were gathering about the sinking sun.
+
+Then suddenly out of the golden haze of the sunset came the
+vibration of guns, and a form of black shadows moving.  Everyone
+struggled to the rail of the steamer and peered into the blinding
+furnace of the west, but nothing was to be distinguished clearly.  A
+mass of smoke rose slanting and barred the face of the sun.  The
+steamboat throbbed on its way through an interminable suspense.
+
+The sun sank into grey clouds, the sky flushed and darkened, the
+evening star trembled into sight.  It was deep twilight when the
+captain cried out and pointed.  My brother strained his eyes.
+Something rushed up into the sky out of the greyness--rushed
+slantingly upward and very swiftly into the luminous clearness above
+the clouds in the western sky; something flat and broad, and very
+large, that swept round in a vast curve, grew smaller, sank slowly,
+and vanished again into the grey mystery of the night.  And as it flew
+it rained down darkness upon the land.
+
+
+
+BOOK TWO
+
+THE EARTH UNDER THE MARTIANS
+
+
+
+CHAPTER ONE
+
+UNDER FOOT
+
+
+In the first book I have wandered so much from my own adventures to
+tell of the experiences of my brother that all through the last two
+chapters I and the curate have been lurking in the empty house at
+Halliford whither we fled to escape the Black Smoke.  There I will
+resume.  We stopped there all Sunday night and all the next day--the
+day of the panic--in a little island of daylight, cut off by the Black
+Smoke from the rest of the world.  We could do nothing but wait in
+aching inactivity during those two weary days.
+
+My mind was occupied by anxiety for my wife.  I figured her at
+Leatherhead, terrified, in danger, mourning me already as a dead man.
+I paced the rooms and cried aloud when I thought of how I was cut off
+from her, of all that might happen to her in my absence.  My cousin I
+knew was brave enough for any emergency, but he was not the sort of
+man to realise danger quickly, to rise promptly.  What was needed now
+was not bravery, but circumspection.  My only consolation was to
+believe that the Martians were moving London-ward and away from her.
+Such vague anxieties keep the mind sensitive and painful.  I grew very
+weary and irritable with the curate's perpetual ejaculations; I tired
+of the sight of his selfish despair.  After some ineffectual
+remonstrance I kept away from him, staying in a room--evidently a
+children's schoolroom--containing globes, forms, and copybooks.  When
+he followed me thither, I went to a box room at the top of the house
+and, in order to be alone with my aching miseries, locked myself in.
+
+We were hopelessly hemmed in by the Black Smoke all that day and
+the morning of the next.  There were signs of people in the next house
+on Sunday evening--a face at a window and moving lights, and later the
+slamming of a door.  But I do not know who these people were, nor what
+became of them.  We saw nothing of them next day.  The Black Smoke
+drifted slowly riverward all through Monday morning, creeping nearer
+and nearer to us, driving at last along the roadway outside the house
+that hid us.
+
+A Martian came across the fields about midday, laying the stuff
+with a jet of superheated steam that hissed against the walls, smashed
+all the windows it touched, and scalded the curate's hand as he fled
+out of the front room.  When at last we crept across the sodden rooms
+and looked out again, the country northward was as though a black
+snowstorm had passed over it.  Looking towards the river, we were
+astonished to see an unaccountable redness mingling with the black of
+the scorched meadows.
+
+For a time we did not see how this change affected our position,
+save that we were relieved of our fear of the Black Smoke.  But later
+I perceived that we were no longer hemmed in, that now we might get
+away.  So soon as I realised that the way of escape was open, my dream
+of action returned.  But the curate was lethargic, unreasonable.
+
+"We are safe here," he repeated; "safe here."
+
+I resolved to leave him--would that I had!  Wiser now for the
+artilleryman's teaching, I sought out food and drink.  I had found oil
+and rags for my burns, and I also took a hat and a flannel shirt that
+I found in one of the bedrooms.  When it was clear to him that I meant
+to go alone--had reconciled myself to going alone--he suddenly roused
+himself to come.  And all being quiet throughout the afternoon, we
+started about five o'clock, as I should judge, along the blackened
+road to Sunbury.
+
+In Sunbury, and at intervals along the road, were dead bodies lying
+in contorted attitudes, horses as well as men, overturned carts and
+luggage, all covered thickly with black dust.  That pall of cindery
+powder made me think of what I had read of the destruction of Pompeii.
+We got to Hampton Court without misadventure, our minds full of
+strange and unfamiliar appearances, and at Hampton Court our eyes were
+relieved to find a patch of green that had escaped the suffocating
+drift.  We went through Bushey Park, with its deer going to and fro
+under the chestnuts, and some men and women hurrying in the distance
+towards Hampton, and so we came to Twickenham.  These were the first
+people we saw.
+
+Away across the road the woods beyond Ham and Petersham were still
+afire.  Twickenham was uninjured by either Heat-Ray or Black Smoke,
+and there were more people about here, though none could give us news.
+For the most part they were like ourselves, taking advantage of a lull
+to shift their quarters.  I have an impression that many of the houses
+here were still occupied by scared inhabitants, too frightened even
+for flight.  Here too the evidence of a hasty rout was abundant along
+the road.  I remember most vividly three smashed bicycles in a heap,
+pounded into the road by the wheels of subsequent carts.  We crossed
+Richmond Bridge about half past eight.  We hurried across the exposed
+bridge, of course, but I noticed floating down the stream a number
+of red masses, some many feet across.  I did not know what these
+were--there was no time for scrutiny--and I put a more horrible
+interpretation on them than they deserved.  Here again on the Surrey
+side were black dust that had once been smoke, and dead bodies--a heap
+near the approach to the station; but we had no glimpse of the
+Martians until we were some way towards Barnes.
+
+We saw in the blackened distance a group of three people running
+down a side street towards the river, but otherwise it seemed
+deserted.  Up the hill Richmond town was burning briskly; outside the
+town of Richmond there was no trace of the Black Smoke.
+
+Then suddenly, as we approached Kew, came a number of people
+running, and the upperworks of a Martian fighting-machine loomed in
+sight over the housetops, not a hundred yards away from us.  We stood
+aghast at our danger, and had the Martian looked down we must
+immediately have perished.  We were so terrified that we dared not go
+on, but turned aside and hid in a shed in a garden.  There the curate
+crouched, weeping silently, and refusing to stir again.
+
+But my fixed idea of reaching Leatherhead would not let me rest,
+and in the twilight I ventured out again.  I went through a shrubbery,
+and along a passage beside a big house standing in its own grounds,
+and so emerged upon the road towards Kew.  The curate I left in the
+shed, but he came hurrying after me.
+
+That second start was the most foolhardy thing I ever did.  For it
+was manifest the Martians were about us.  No sooner had the curate
+overtaken me than we saw either the fighting-machine we had seen
+before or another, far away across the meadows in the direction of Kew
+Lodge.  Four or five little black figures hurried before it across the
+green-grey of the field, and in a moment it was evident this Martian
+pursued them.  In three strides he was among them, and they ran
+radiating from his feet in all directions.  He used no Heat-Ray to
+destroy them, but picked them up one by one.  Apparently he tossed
+them into the great metallic carrier which projected behind him, much
+as a workman's basket hangs over his shoulder.
+
+It was the first time I realised that the Martians might have any
+other purpose than destruction with defeated humanity.  We stood for a
+moment petrified, then turned and fled through a gate behind us into a
+walled garden, fell into, rather than found, a fortunate ditch, and
+lay there, scarce daring to whisper to each other until the stars were
+out.
+
+I suppose it was nearly eleven o'clock before we gathered courage
+to start again, no longer venturing into the road, but sneaking along
+hedgerows and through plantations, and watching keenly through the
+darkness, he on the right and I on the left, for the Martians, who
+seemed to be all about us.  In one place we blundered upon a scorched
+and blackened area, now cooling and ashen, and a number of scattered
+dead bodies of men, burned horribly about the heads and trunks but
+with their legs and boots mostly intact; and of dead horses, fifty
+feet, perhaps, behind a line of four ripped guns and smashed gun
+carriages.
+
+Sheen, it seemed, had escaped destruction, but the place was silent
+and deserted.  Here we happened on no dead, though the night was too
+dark for us to see into the side roads of the place.  In Sheen my
+companion suddenly complained of faintness and thirst, and we decided
+to try one of the houses.
+
+The first house we entered, after a little difficulty with the
+window, was a small semi-detached villa, and I found nothing eatable
+left in the place but some mouldy cheese.  There was, however, water
+to drink; and I took a hatchet, which promised to be useful in our
+next house-breaking.
+
+We then crossed to a place where the road turns towards Mortlake.
+Here there stood a white house within a walled garden, and in the
+pantry of this domicile we found a store of food--two loaves of bread
+in a pan, an uncooked steak, and the half of a ham.  I give this
+catalogue so precisely because, as it happened, we were destined to
+subsist upon this store for the next fortnight.  Bottled beer stood
+under a shelf, and there were two bags of haricot beans and some limp
+lettuces.  This pantry opened into a kind of wash-up kitchen, and in
+this was firewood; there was also a cupboard, in which we found nearly
+a dozen of burgundy, tinned soups and salmon, and two tins of
+biscuits.
+
+We sat in the adjacent kitchen in the dark--for we dared not strike
+a light--and ate bread and ham, and drank beer out of the same bottle.
+The curate, who was still timorous and restless, was now, oddly
+enough, for pushing on, and I was urging him to keep up his strength
+by eating when the thing happened that was to imprison us.
+
+"It can't be midnight yet," I said, and then came a blinding glare
+of vivid green light.  Everything in the kitchen leaped out, clearly
+visible in green and black, and vanished again.  And then followed such
+a concussion as I have never heard before or since.  So close on the
+heels of this as to seem instantaneous came a thud behind me, a clash
+of glass, a crash and rattle of falling masonry all about us, and the
+plaster of the ceiling came down upon us, smashing into a multitude of
+fragments upon our heads.  I was knocked headlong across the floor
+against the oven handle and stunned.  I was insensible for a long
+time, the curate told me, and when I came to we were in darkness
+again, and he, with a face wet, as I found afterwards, with blood from
+a cut forehead, was dabbing water over me.
+
+For some time I could not recollect what had happened.  Then things
+came to me slowly.  A bruise on my temple asserted itself.
+
+"Are you better?" asked the curate in a whisper.
+
+At last I answered him.  I sat up.
+
+"Don't move," he said.  "The floor is covered with smashed crockery
+from the dresser.  You can't possibly move without making a noise, and
+I fancy _they_ are outside."
+
+We both sat quite silent, so that we could scarcely hear each other
+breathing.  Everything seemed deadly still, but once something near
+us, some plaster or broken brickwork, slid down with a rumbling sound.
+Outside and very near was an intermittent, metallic rattle.
+
+"That!" said the curate, when presently it happened again.
+
+"Yes," I said.  "But what is it?"
+
+"A Martian!" said the curate.
+
+I listened again.
+
+"It was not like the Heat-Ray," I said, and for a time I was
+inclined to think one of the great fighting-machines had stumbled
+against the house, as I had seen one stumble against the tower of
+Shepperton Church.
+
+Our situation was so strange and incomprehensible that for three or
+four hours, until the dawn came, we scarcely moved.  And then the light
+filtered in, not through the window, which remained black, but through
+a triangular aperture between a beam and a heap of broken bricks in
+the wall behind us.  The interior of the kitchen we now saw greyly for
+the first time.
+
+The window had been burst in by a mass of garden mould, which
+flowed over the table upon which we had been sitting and lay about our
+feet.  Outside, the soil was banked high against the house.  At the
+top of the window frame we could see an uprooted drainpipe.  The floor
+was littered with smashed hardware; the end of the kitchen towards the
+house was broken into, and since the daylight shone in there, it was
+evident the greater part of the house had collapsed.  Contrasting
+vividly with this ruin was the neat dresser, stained in the fashion,
+pale green, and with a number of copper and tin vessels below it, the
+wallpaper imitating blue and white tiles, and a couple of coloured
+supplements fluttering from the walls above the kitchen range.
+
+As the dawn grew clearer, we saw through the gap in the wall the
+body of a Martian, standing sentinel, I suppose, over the still
+glowing cylinder.  At the sight of that we crawled as circumspectly as
+possible out of the twilight of the kitchen into the darkness of the
+scullery.
+
+Abruptly the right interpretation dawned upon my mind.
+
+"The fifth cylinder," I whispered, "the fifth shot from Mars, has
+struck this house and buried us under the ruins!"
+
+For a time the curate was silent, and then he whispered:
+
+"God have mercy upon us!"
+
+I heard him presently whimpering to himself.
+
+Save for that sound we lay quite still in the scullery; I for my
+part scarce dared breathe, and sat with my eyes fixed on the faint
+light of the kitchen door.  I could just see the curate's face, a dim,
+oval shape, and his collar and cuffs.  Outside there began a metallic
+hammering, then a violent hooting, and then again, after a quiet
+interval, a hissing like the hissing of an engine.  These noises, for
+the most part problematical, continued intermittently, and seemed if
+anything to increase in number as time wore on.  Presently a measured
+thudding and a vibration that made everything about us quiver and the
+vessels in the pantry ring and shift, began and continued.  Once the
+light was eclipsed, and the ghostly kitchen doorway became absolutely
+dark.  For many hours we must have crouched there, silent and
+shivering, until our tired attention failed. . . .
+
+At last I found myself awake and very hungry.  I am inclined to
+believe we must have spent the greater portion of a day before that
+awakening.  My hunger was at a stride so insistent that it moved me to
+action.  I told the curate I was going to seek food, and felt my way
+towards the pantry.  He made me no answer, but so soon as I began
+eating the faint noise I made stirred him up and I heard him crawling
+after me.
+
+
+
+CHAPTER TWO
+
+WHAT WE SAW FROM THE RUINED HOUSE
+
+
+After eating we crept back to the scullery, and there I must have
+dozed again, for when presently I looked round I was alone.  The
+thudding vibration continued with wearisome persistence.  I whispered
+for the curate several times, and at last felt my way to the door of
+the kitchen.  It was still daylight, and I perceived him across the
+room, lying against the triangular hole that looked out upon the
+Martians.  His shoulders were hunched, so that his head was hidden
+from me.
+
+I could hear a number of noises almost like those in an engine
+shed; and the place rocked with that beating thud.  Through the
+aperture in the wall I could see the top of a tree touched with gold
+and the warm blue of a tranquil evening sky.  For a minute or so I
+remained watching the curate, and then I advanced, crouching and
+stepping with extreme care amid the broken crockery that littered the
+floor.
+
+I touched the curate's leg, and he started so violently that a mass
+of plaster went sliding down outside and fell with a loud impact.  I
+gripped his arm, fearing he might cry out, and for a long time we
+crouched motionless.  Then I turned to see how much of our rampart
+remained.  The detachment of the plaster had left a vertical slit open
+in the debris, and by raising myself cautiously across a beam I was
+able to see out of this gap into what had been overnight a quiet
+suburban roadway.  Vast, indeed, was the change that we beheld.
+
+The fifth cylinder must have fallen right into the midst of the
+house we had first visited.  The building had vanished, completely
+smashed, pulverised, and dispersed by the blow.  The cylinder lay now
+far beneath the original foundations--deep in a hole, already vastly
+larger than the pit I had looked into at Woking.  The earth all round
+it had splashed under that tremendous impact--"splashed" is the only
+word--and lay in heaped piles that hid the masses of the adjacent
+houses.  It had behaved exactly like mud under the violent blow of a
+hammer.  Our house had collapsed backward; the front portion, even on
+the ground floor, had been destroyed completely; by a chance the
+kitchen and scullery had escaped, and stood buried now under soil and
+ruins, closed in by tons of earth on every side save towards the
+cylinder.  Over that aspect we hung now on the very edge of the great
+circular pit the Martians were engaged in making.  The heavy beating
+sound was evidently just behind us, and ever and again a bright green
+vapour drove up like a veil across our peephole.
+
+The cylinder was already opened in the centre of the pit, and on
+the farther edge of the pit, amid the smashed and gravel-heaped
+shrubbery, one of the great fighting-machines, deserted by its
+occupant, stood stiff and tall against the evening sky.  At first I
+scarcely noticed the pit and the cylinder, although it has been
+convenient to describe them first, on account of the extraordinary
+glittering mechanism I saw busy in the excavation, and on account of
+the strange creatures that were crawling slowly and painfully across
+the heaped mould near it.
+
+The mechanism it certainly was that held my attention first.  It
+was one of those complicated fabrics that have since been called
+handling-machines, and the study of which has already given such an
+enormous impetus to terrestrial invention.  As it dawned upon me
+first, it presented a sort of metallic spider with five jointed,
+agile legs, and with an extraordinary number of jointed levers, bars,
+and reaching and clutching tentacles about its body.  Most of its
+arms were retracted, but with three long tentacles it was fishing
+out a number of rods, plates, and bars which lined the covering and
+apparently strengthened the walls of the cylinder.  These, as it
+extracted them, were lifted out and deposited upon a level surface
+of earth behind it.
+
+Its motion was so swift, complex, and perfect that at first I did
+not see it as a machine, in spite of its metallic glitter.  The
+fighting-machines were coordinated and animated to an extraordinary
+pitch, but nothing to compare with this.  People who have never seen
+these structures, and have only the ill-imagined efforts of artists or
+the imperfect descriptions of such eye-witnesses as myself to go upon,
+scarcely realise that living quality.
+
+I recall particularly the illustration of one of the first
+pamphlets to give a consecutive account of the war.  The artist had
+evidently made a hasty study of one of the fighting-machines, and
+there his knowledge ended.  He presented them as tilted, stiff
+tripods, without either flexibility or subtlety, and with an
+altogether misleading monotony of effect.  The pamphlet containing
+these renderings had a considerable vogue, and I mention them here
+simply to warn the reader against the impression they may have
+created.  They were no more like the Martians I saw in action than a
+Dutch doll is like a human being.  To my mind, the pamphlet would have
+been much better without them.
+
+At first, I say, the handling-machine did not impress me as a
+machine, but as a crablike creature with a glittering integument, the
+controlling Martian whose delicate tentacles actuated its movements
+seeming to be simply the equivalent of the crab's cerebral portion.
+But then I perceived the resemblance of its grey-brown, shiny,
+leathery integument to that of the other sprawling bodies beyond, and
+the true nature of this dexterous workman dawned upon me.  With that
+realisation my interest shifted to those other creatures, the real
+Martians.  Already I had had a transient impression of these, and the
+first nausea no longer obscured my observation.  Moreover, I was
+concealed and motionless, and under no urgency of action.
+
+They were, I now saw, the most unearthly creatures it is possible
+to conceive.  They were huge round bodies--or, rather, heads--about
+four feet in diameter, each body having in front of it a face.  This
+face had no nostrils--indeed, the Martians do not seem to have had any
+sense of smell, but it had a pair of very large dark-coloured eyes,
+and just beneath this a kind of fleshy beak.  In the back of this head
+or body--I scarcely know how to speak of it--was the single tight
+tympanic surface, since known to be anatomically an ear, though it
+must have been almost useless in our dense air.  In a group round the
+mouth were sixteen slender, almost whiplike tentacles, arranged in two
+bunches of eight each.  These bunches have since been named rather
+aptly, by that distinguished anatomist, Professor Howes, the _hands_.
+Even as I saw these Martians for the first time they seemed to be
+endeavouring to raise themselves on these hands, but of course, with
+the increased weight of terrestrial conditions, this was impossible.
+There is reason to suppose that on Mars they may have progressed upon
+them with some facility.
+
+The internal anatomy, I may remark here, as dissection has since
+shown, was almost equally simple.  The greater part of the structure
+was the brain, sending enormous nerves to the eyes, ear, and tactile
+tentacles.  Besides this were the bulky lungs, into which the mouth
+opened, and the heart and its vessels.  The pulmonary distress caused
+by the denser atmosphere and greater gravitational attraction was only
+too evident in the convulsive movements of the outer skin.
+
+And this was the sum of the Martian organs.  Strange as it may seem
+to a human being, all the complex apparatus of digestion, which makes
+up the bulk of our bodies, did not exist in the Martians.  They were
+heads--merely heads.  Entrails they had none.  They did not eat, much
+less digest.  Instead, they took the fresh, living blood of other
+creatures, and _injected_ it into their own veins.  I have myself seen
+this being done, as I shall mention in its place.  But, squeamish as I
+may seem, I cannot bring myself to describe what I could not endure
+even to continue watching.  Let it suffice to say, blood obtained from
+a still living animal, in most cases from a human being, was run
+directly by means of a little pipette into the recipient canal. . . .
+
+The bare idea of this is no doubt horribly repulsive to us, but at
+the same time I think that we should remember how repulsive our
+carnivorous habits would seem to an intelligent rabbit.
+
+The physiological advantages of the practice of injection are
+undeniable, if one thinks of the tremendous waste of human time and
+energy occasioned by eating and the digestive process.  Our bodies are
+half made up of glands and tubes and organs, occupied in turning
+heterogeneous food into blood.  The digestive processes and their
+reaction upon the nervous system sap our strength and colour our
+minds.  Men go happy or miserable as they have healthy or unhealthy
+livers, or sound gastric glands.  But the Martians were lifted above
+all these organic fluctuations of mood and emotion.
+
+Their undeniable preference for men as their source of nourishment
+is partly explained by the nature of the remains of the victims they
+had brought with them as provisions from Mars.  These creatures, to
+judge from the shrivelled remains that have fallen into human hands,
+were bipeds with flimsy, silicious skeletons (almost like those of the
+silicious sponges) and feeble musculature, standing about six feet
+high and having round, erect heads, and large eyes in flinty sockets.
+Two or three of these seem to have been brought in each cylinder, and
+all were killed before earth was reached.  It was just as well for
+them, for the mere attempt to stand upright upon our planet would have
+broken every bone in their bodies.
+
+And while I am engaged in this description, I may add in this place
+certain further details which, although they were not all evident to
+us at the time, will enable the reader who is unacquainted with them
+to form a clearer picture of these offensive creatures.
+
+In three other points their physiology differed strangely from
+ours.  Their organisms did not sleep, any more than the heart of man
+sleeps.  Since they had no extensive muscular mechanism to recuperate,
+that periodical extinction was unknown to them.  They had little or
+no sense of fatigue, it would seem.  On earth they could never have
+moved without effort, yet even to the last they kept in action.  In
+twenty-four hours they did twenty-four hours of work, as even on earth
+is perhaps the case with the ants.
+
+In the next place, wonderful as it seems in a sexual world, the
+Martians were absolutely without sex, and therefore without any of the
+tumultuous emotions that arise from that difference among men.  A
+young Martian, there can now be no dispute, was really born upon earth
+during the war, and it was found attached to its parent, partially
+_budded_ off, just as young lilybulbs bud off, or like the young animals
+in the fresh-water polyp.
+
+In man, in all the higher terrestrial animals, such a method of
+increase has disappeared; but even on this earth it was certainly the
+primitive method.  Among the lower animals, up even to those first
+cousins of the vertebrated animals, the Tunicates, the two processes
+occur side by side, but finally the sexual method superseded its
+competitor altogether.  On Mars, however, just the reverse has
+apparently been the case.
+
+It is worthy of remark that a certain speculative writer of
+quasi-scientific repute, writing long before the Martian invasion, did
+forecast for man a final structure not unlike the actual Martian
+condition.  His prophecy, I remember, appeared in November or
+December, 1893, in a long-defunct publication, the _Pall Mall Budget_,
+and I recall a caricature of it in a pre-Martian periodical called
+_Punch_.  He pointed out--writing in a foolish, facetious tone--that the
+perfection of mechanical appliances must ultimately supersede limbs;
+the perfection of chemical devices, digestion; that such organs as
+hair, external nose, teeth, ears, and chin were no longer essential
+parts of the human being, and that the tendency of natural selection
+would lie in the direction of their steady diminution through the
+coming ages.  The brain alone remained a cardinal necessity.  Only one
+other part of the body had a strong case for survival, and that was
+the hand, "teacher and agent of the brain."  While the rest of the
+body dwindled, the hands would grow larger.
+
+There is many a true word written in jest, and here in the Martians
+we have beyond dispute the actual accomplishment of such a suppression
+of the animal side of the organism by the intelligence.  To me it is
+quite credible that the Martians may be descended from beings not
+unlike ourselves, by a gradual development of brain and hands (the
+latter giving rise to the two bunches of delicate tentacles at last)
+at the expense of the rest of the body.  Without the body the brain
+would, of course, become a mere selfish intelligence, without any of
+the emotional substratum of the human being.
+
+The last salient point in which the systems of these creatures
+differed from ours was in what one might have thought a very trivial
+particular.  Micro-organisms, which cause so much disease and pain on
+earth, have either never appeared upon Mars or Martian sanitary
+science eliminated them ages ago.  A hundred diseases, all the fevers
+and contagions of human life, consumption, cancers, tumours and such
+morbidities, never enter the scheme of their life.  And speaking of
+the differences between the life on Mars and terrestrial life, I may
+allude here to the curious suggestions of the red weed.
+
+Apparently the vegetable kingdom in Mars, instead of having green
+for a dominant colour, is of a vivid blood-red tint.  At any rate, the
+seeds which the Martians (intentionally or accidentally) brought with
+them gave rise in all cases to red-coloured growths.  Only that known
+popularly as the red weed, however, gained any footing in competition
+with terrestrial forms.  The red creeper was quite a transitory
+growth, and few people have seen it growing.  For a time, however, the
+red weed grew with astonishing vigour and luxuriance.  It spread up
+the sides of the pit by the third or fourth day of our imprisonment,
+and its cactus-like branches formed a carmine fringe to the edges of
+our triangular window.  And afterwards I found it broadcast throughout
+the country, and especially wherever there was a stream of water.
+
+The Martians had what appears to have been an auditory organ, a
+single round drum at the back of the head-body, and eyes with a visual
+range not very different from ours except that, according to Philips,
+blue and violet were as black to them.  It is commonly supposed that
+they communicated by sounds and tentacular gesticulations; this is
+asserted, for instance, in the able but hastily compiled pamphlet
+(written evidently by someone not an eye-witness of Martian actions)
+to which I have already alluded, and which, so far, has been the chief
+source of information concerning them.  Now no surviving human being
+saw so much of the Martians in action as I did.  I take no credit to
+myself for an accident, but the fact is so.  And I assert that I
+watched them closely time after time, and that I have seen four, five,
+and (once) six of them sluggishly performing the most elaborately
+complicated operations together without either sound or gesture.  Their
+peculiar hooting invariably preceded feeding; it had no modulation,
+and was, I believe, in no sense a signal, but merely the expiration of
+air preparatory to the suctional operation.  I have a certain claim to
+at least an elementary knowledge of psychology, and in this matter I
+am convinced--as firmly as I am convinced of anything--that the
+Martians interchanged thoughts without any physical intermediation.
+And I have been convinced of this in spite of strong preconceptions.
+Before the Martian invasion, as an occasional reader here or there may
+remember, I had written with some little vehemence against the
+telepathic theory.
+
+The Martians wore no clothing.  Their conceptions of ornament and
+decorum were necessarily different from ours; and not only were they
+evidently much less sensible of changes of temperature than we are,
+but changes of pressure do not seem to have affected their health at
+all seriously.  Yet though they wore no clothing, it was in the other
+artificial additions to their bodily resources that their great
+superiority over man lay.  We men, with our bicycles and road-skates,
+our Lilienthal soaring-machines, our guns and sticks and so forth, are
+just in the beginning of the evolution that the Martians have worked
+out.  They have become practically mere brains, wearing different
+bodies according to their needs just as men wear suits of clothes and
+take a bicycle in a hurry or an umbrella in the wet.  And of their
+appliances, perhaps nothing is more wonderful to a man than the
+curious fact that what is the dominant feature of almost all human
+devices in mechanism is absent--the _wheel_ is absent; among all the
+things they brought to earth there is no trace or suggestion of their
+use of wheels.  One would have at least expected it in locomotion.  And
+in this connection it is curious to remark that even on this earth
+Nature has never hit upon the wheel, or has preferred other expedients
+to its development.  And not only did the Martians either not know of
+(which is incredible), or abstain from, the wheel, but in their
+apparatus singularly little use is made of the fixed pivot or
+relatively fixed pivot, with circular motions thereabout confined
+to one plane.  Almost all the joints of the machinery present a
+complicated system of sliding parts moving over small but beautifully
+curved friction bearings.  And while upon this matter of detail, it is
+remarkable that the long leverages of their machines are in most cases
+actuated by a sort of sham musculature of the disks in an elastic
+sheath; these disks become polarised and drawn closely and powerfully
+together when traversed by a current of electricity.  In this way the
+curious parallelism to animal motions, which was so striking and
+disturbing to the human beholder, was attained.  Such quasi-muscles
+abounded in the crablike handling-machine which, on my first peeping
+out of the slit, I watched unpacking the cylinder.  It seemed
+infinitely more alive than the actual Martians lying beyond it in the
+sunset light, panting, stirring ineffectual tentacles, and moving
+feebly after their vast journey across space.
+
+While I was still watching their sluggish motions in the sunlight,
+and noting each strange detail of their form, the curate reminded me
+of his presence by pulling violently at my arm.  I turned to a
+scowling face, and silent, eloquent lips.  He wanted the slit, which
+permitted only one of us to peep through; and so I had to forego
+watching them for a time while he enjoyed that privilege.
+
+When I looked again, the busy handling-machine had already put
+together several of the pieces of apparatus it had taken out of the
+cylinder into a shape having an unmistakable likeness to its own; and
+down on the left a busy little digging mechanism had come into view,
+emitting jets of green vapour and working its way round the pit,
+excavating and embanking in a methodical and discriminating manner.
+This it was which had caused the regular beating noise, and the
+rhythmic shocks that had kept our ruinous refuge quivering.  It piped
+and whistled as it worked.  So far as I could see, the thing was
+without a directing Martian at all.
+
+
+
+CHAPTER THREE
+
+THE DAYS OF IMPRISONMENT
+
+
+The arrival of a second fighting-machine drove us from our peephole
+into the scullery, for we feared that from his elevation the Martian
+might see down upon us behind our barrier.  At a later date we began
+to feel less in danger of their eyes, for to an eye in the dazzle of
+the sunlight outside our refuge must have been blank blackness, but at
+first the slightest suggestion of approach drove us into the scullery
+in heart-throbbing retreat.  Yet terrible as was the danger we
+incurred, the attraction of peeping was for both of us irresistible.
+And I recall now with a sort of wonder that, in spite of the infinite
+danger in which we were between starvation and a still more terrible
+death, we could yet struggle bitterly for that horrible privilege of
+sight.  We would race across the kitchen in a grotesque way between
+eagerness and the dread of making a noise, and strike each other, and
+thrust and kick, within a few inches of exposure.
+
+The fact is that we had absolutely incompatible dispositions and
+habits of thought and action, and our danger and isolation only
+accentuated the incompatibility.  At Halliford I had already come to
+hate the curate's trick of helpless exclamation, his stupid rigidity
+of mind.  His endless muttering monologue vitiated every effort I made
+to think out a line of action, and drove me at times, thus pent up and
+intensified, almost to the verge of craziness.  He was as lacking in
+restraint as a silly woman.  He would weep for hours together, and I
+verily believe that to the very end this spoiled child of life thought
+his weak tears in some way efficacious.  And I would sit in the
+darkness unable to keep my mind off him by reason of his
+importunities.  He ate more than I did, and it was in vain I pointed
+out that our only chance of life was to stop in the house until the
+Martians had done with their pit, that in that long patience a time
+might presently come when we should need food.  He ate and drank
+impulsively in heavy meals at long intervals.  He slept little.
+
+As the days wore on, his utter carelessness of any consideration so
+intensified our distress and danger that I had, much as I loathed
+doing it, to resort to threats, and at last to blows.  That brought him
+to reason for a time.  But he was one of those weak creatures, void of
+pride, timorous, anaemic, hateful souls, full of shifty cunning, who
+face neither God nor man, who face not even themselves.
+
+It is disagreeable for me to recall and write these things, but I
+set them down that my story may lack nothing.  Those who have escaped
+the dark and terrible aspects of life will find my brutality, my flash
+of rage in our final tragedy, easy enough to blame; for they know what
+is wrong as well as any, but not what is possible to tortured men.  But
+those who have been under the shadow, who have gone down at last to
+elemental things, will have a wider charity.
+
+And while within we fought out our dark, dim contest of whispers,
+snatched food and drink, and gripping hands and blows, without, in the
+pitiless sunlight of that terrible June, was the strange wonder, the
+unfamiliar routine of the Martians in the pit.  Let me return to those
+first new experiences of mine.  After a long time I ventured back to
+the peephole, to find that the new-comers had been reinforced by the
+occupants of no fewer than three of the fighting-machines.  These last
+had brought with them certain fresh appliances that stood in an
+orderly manner about the cylinder.  The second handling-machine was now
+completed, and was busied in serving one of the novel contrivances the
+big machine had brought.  This was a body resembling a milk can in its
+general form, above which oscillated a pear-shaped receptacle, and
+from which a stream of white powder flowed into a circular basin
+below.
+
+The oscillatory motion was imparted to this by one tentacle of the
+handling-machine.  With two spatulate hands the handling-machine was
+digging out and flinging masses of clay into the pear-shaped
+receptacle above, while with another arm it periodically opened a door
+and removed rusty and blackened clinkers from the middle part of the
+machine.  Another steely tentacle directed the powder from the basin
+along a ribbed channel towards some receiver that was hidden from me
+by the mound of bluish dust.  From this unseen receiver a little
+thread of green smoke rose vertically into the quiet air.  As I looked,
+the handling-machine, with a faint and musical clinking, extended,
+telescopic fashion, a tentacle that had been a moment before a mere
+blunt projection, until its end was hidden behind the mound of clay.
+In another second it had lifted a bar of white aluminium into sight,
+untarnished as yet, and shining dazzlingly, and deposited it in a
+growing stack of bars that stood at the side of the pit.  Between
+sunset and starlight this dexterous machine must have made more than a
+hundred such bars out of the crude clay, and the mound of bluish dust
+rose steadily until it topped the side of the pit.
+
+The contrast between the swift and complex movements of these
+contrivances and the inert panting clumsiness of their masters was
+acute, and for days I had to tell myself repeatedly that these latter
+were indeed the living of the two things.
+
+The curate had possession of the slit when the first men were
+brought to the pit.  I was sitting below, huddled up, listening with
+all my ears.  He made a sudden movement backward, and I, fearful that
+we were observed, crouched in a spasm of terror.  He came sliding down
+the rubbish and crept beside me in the darkness, inarticulate,
+gesticulating, and for a moment I shared his panic.  His gesture
+suggested a resignation of the slit, and after a little while my
+curiosity gave me courage, and I rose up, stepped across him, and
+clambered up to it.  At first I could see no reason for his frantic
+behaviour.  The twilight had now come, the stars were little and
+faint, but the pit was illuminated by the flickering green fire that
+came from the aluminium-making.  The whole picture was a flickering
+scheme of green gleams and shifting rusty black shadows, strangely
+trying to the eyes.  Over and through it all went the bats, heeding it
+not at all.  The sprawling Martians were no longer to be seen, the
+mound of blue-green powder had risen to cover them from sight, and a
+fighting-machine, with its legs contracted, crumpled, and abbreviated,
+stood across the corner of the pit.  And then, amid the clangour of
+the machinery, came a drifting suspicion of human voices, that I
+entertained at first only to dismiss.
+
+I crouched, watching this fighting-machine closely, satisfying
+myself now for the first time that the hood did indeed contain a
+Martian.  As the green flames lifted I could see the oily gleam of
+his integument and the brightness of his eyes.  And suddenly I heard
+a yell, and saw a long tentacle reaching over the shoulder of the
+machine to the little cage that hunched upon its back.  Then
+something--something struggling violently--was lifted high against the
+sky, a black, vague enigma against the starlight; and as this black
+object came down again, I saw by the green brightness that it was a
+man.  For an instant he was clearly visible.  He was a stout, ruddy,
+middle-aged man, well dressed; three days before, he must have been
+walking the world, a man of considerable consequence.  I could see his
+staring eyes and gleams of light on his studs and watch chain.  He
+vanished behind the mound, and for a moment there was silence.  And
+then began a shrieking and a sustained and cheerful hooting from the
+Martians.
+
+I slid down the rubbish, struggled to my feet, clapped my hands
+over my ears, and bolted into the scullery.  The curate, who had been
+crouching silently with his arms over his head, looked up as I passed,
+cried out quite loudly at my desertion of him, and came running after
+me.
+
+That night, as we lurked in the scullery, balanced between our
+horror and the terrible fascination this peeping had, although I felt
+an urgent need of action I tried in vain to conceive some plan of
+escape; but afterwards, during the second day, I was able to consider
+our position with great clearness.  The curate, I found, was quite
+incapable of discussion; this new and culminating atrocity had robbed
+him of all vestiges of reason or forethought.  Practically he had
+already sunk to the level of an animal.  But as the saying goes, I
+gripped myself with both hands.  It grew upon my mind, once I could
+face the facts, that terrible as our position was, there was as yet
+no justification for absolute despair.  Our chief chance lay in the
+possibility of the Martians making the pit nothing more than a
+temporary encampment.  Or even if they kept it permanently, they might
+not consider it necessary to guard it, and a chance of escape might be
+afforded us.  I also weighed very carefully the possibility of our
+digging a way out in a direction away from the pit, but the chances of
+our emerging within sight of some sentinel fighting-machine seemed at
+first too great.  And I should have had to do all the digging myself.
+The curate would certainly have failed me.
+
+It was on the third day, if my memory serves me right, that I saw
+the lad killed.  It was the only occasion on which I actually saw the
+Martians feed.  After that experience I avoided the hole in the wall
+for the better part of a day.  I went into the scullery, removed the
+door, and spent some hours digging with my hatchet as silently as
+possible; but when I had made a hole about a couple of feet deep the
+loose earth collapsed noisily, and I did not dare continue.  I lost
+heart, and lay down on the scullery floor for a long time, having no
+spirit even to move.  And after that I abandoned altogether the idea
+of escaping by excavation.
+
+It says much for the impression the Martians had made upon me that
+at first I entertained little or no hope of our escape being brought
+about by their overthrow through any human effort.  But on the fourth
+or fifth night I heard a sound like heavy guns.
+
+It was very late in the night, and the moon was shining brightly.
+The Martians had taken away the excavating-machine, and, save for a
+fighting-machine that stood in the remoter bank of the pit and a
+handling-machine that was buried out of my sight in a corner of the
+pit immediately beneath my peephole, the place was deserted by them.
+Except for the pale glow from the handling-machine and the bars and
+patches of white moonlight the pit was in darkness, and, except for
+the clinking of the handling-machine, quite still.  That night was a
+beautiful serenity; save for one planet, the moon seemed to have the
+sky to herself.  I heard a dog howling, and that familiar sound it was
+that made me listen.  Then I heard quite distinctly a booming exactly
+like the sound of great guns.  Six distinct reports I counted, and
+after a long interval six again.  And that was all.
+
+
+
+CHAPTER FOUR
+
+THE DEATH OF THE CURATE
+
+
+It was on the sixth day of our imprisonment that I peeped for the
+last time, and presently found myself alone.  Instead of keeping close
+to me and trying to oust me from the slit, the curate had gone back
+into the scullery.  I was struck by a sudden thought.  I went back
+quickly and quietly into the scullery.  In the darkness I heard the
+curate drinking.  I snatched in the darkness, and my fingers caught a
+bottle of burgundy.
+
+For a few minutes there was a tussle.  The bottle struck the floor
+and broke, and I desisted and rose.  We stood panting and threatening
+each other.  In the end I planted myself between him and the food, and
+told him of my determination to begin a discipline.  I divided the
+food in the pantry, into rations to last us ten days.  I would not let
+him eat any more that day.  In the afternoon he made a feeble effort
+to get at the food.  I had been dozing, but in an instant I was awake.
+All day and all night we sat face to face, I weary but resolute, and
+he weeping and complaining of his immediate hunger.  It was, I know, a
+night and a day, but to me it seemed--it seems now--an interminable
+length of time.
+
+And so our widened incompatibility ended at last in open conflict.
+For two vast days we struggled in undertones and wrestling contests.
+There were times when I beat and kicked him madly, times when I
+cajoled and persuaded him, and once I tried to bribe him with the last
+bottle of burgundy, for there was a rain-water pump from which I could
+get water.  But neither force nor kindness availed; he was indeed
+beyond reason.  He would neither desist from his attacks on the food
+nor from his noisy babbling to himself.  The rudimentary precautions
+to keep our imprisonment endurable he would not observe.  Slowly I
+began to realise the complete overthrow of his intelligence, to
+perceive that my sole companion in this close and sickly darkness was
+a man insane.
+
+From certain vague memories I am inclined to think my own mind
+wandered at times.  I had strange and hideous dreams whenever I slept.
+It sounds paradoxical, but I am inclined to think that the weakness
+and insanity of the curate warned me, braced me, and kept me a sane
+man.
+
+On the eighth day he began to talk aloud instead of whispering, and
+nothing I could do would moderate his speech.
+
+"It is just, O God!" he would say, over and over again. "It is
+just.  On me and mine be the punishment laid.  We have sinned, we have
+fallen short.  There was poverty, sorrow; the poor were trodden in
+the dust, and I held my peace.  I preached acceptable folly--my God,
+what folly!--when I should have stood up, though I died for it, and
+called upon them to repent--repent! . . .  Oppressors of the poor and
+needy . . . !  The wine press of God!"
+
+Then he would suddenly revert to the matter of the food I withheld
+from him, praying, begging, weeping, at last threatening.  He began to
+raise his voice--I prayed him not to.  He perceived a hold on me--he
+threatened he would shout and bring the Martians upon us.  For a time
+that scared me; but any concession would have shortened our chance of
+escape beyond estimating.  I defied him, although I felt no assurance
+that he might not do this thing.  But that day, at any rate, he did
+not.  He talked with his voice rising slowly, through the greater part
+of the eighth and ninth days--threats, entreaties, mingled with a
+torrent of half-sane and always frothy repentance for his vacant sham
+of God's service, such as made me pity him.  Then he slept awhile, and
+began again with renewed strength, so loudly that I must needs make
+him desist.
+
+"Be still!" I implored.
+
+He rose to his knees, for he had been sitting in the darkness near
+the copper.
+
+"I have been still too long," he said, in a tone that must have
+reached the pit, "and now I must bear my witness.  Woe unto this
+unfaithful city!  Woe!  Woe!  Woe!  Woe!  Woe! To the inhabitants of
+the earth by reason of the other voices of the trumpet----"
+
+"Shut up!" I said, rising to my feet, and in a terror lest the
+Martians should hear us.  "For God's sake----"
+
+"Nay," shouted the curate, at the top of his voice, standing
+likewise and extending his arms.  "Speak!  The word of the Lord is
+upon me!"
+
+In three strides he was at the door leading into the kitchen.
+
+"I must bear my witness!  I go!  It has already been too long
+delayed."
+
+I put out my hand and felt the meat chopper hanging to the wall.
+In a flash I was after him.  I was fierce with fear.  Before he was
+halfway across the kitchen I had overtaken him.  With one last touch
+of humanity I turned the blade back and struck him with the butt.  He
+went headlong forward and lay stretched on the ground.  I stumbled
+over him and stood panting.  He lay still.
+
+Suddenly I heard a noise without, the run and smash of slipping
+plaster, and the triangular aperture in the wall was darkened.  I
+looked up and saw the lower surface of a handling-machine coming
+slowly across the hole.  One of its gripping limbs curled amid the
+debris; another limb appeared, feeling its way over the fallen beams.
+I stood petrified, staring.  Then I saw through a sort of glass plate
+near the edge of the body the face, as we may call it, and the large
+dark eyes of a Martian, peering, and then a long metallic snake of
+tentacle came feeling slowly through the hole.
+
+I turned by an effort, stumbled over the curate, and stopped at the
+scullery door.  The tentacle was now some way, two yards or more, in
+the room, and twisting and turning, with queer sudden movements, this
+way and that.  For a while I stood fascinated by that slow, fitful
+advance.  Then, with a faint, hoarse cry, I forced myself across the
+scullery.  I trembled violently; I could scarcely stand upright.  I
+opened the door of the coal cellar, and stood there in the darkness
+staring at the faintly lit doorway into the kitchen, and listening.
+Had the Martian seen me?  What was it doing now?
+
+Something was moving to and fro there, very quietly; every now and
+then it tapped against the wall, or started on its movements with a
+faint metallic ringing, like the movements of keys on a split-ring.
+Then a heavy body--I knew too well what--was dragged across the floor
+of the kitchen towards the opening.  Irresistibly attracted, I crept
+to the door and peeped into the kitchen.  In the triangle of bright
+outer sunlight I saw the Martian, in its Briareus of a handling-machine,
+scrutinizing the curate's head.  I thought at once that it would infer
+my presence from the mark of the blow I had given him.
+
+I crept back to the coal cellar, shut the door, and began to cover
+myself up as much as I could, and as noiselessly as possible in the
+darkness, among the firewood and coal therein.  Every now and then I
+paused, rigid, to hear if the Martian had thrust its tentacles through
+the opening again.
+
+Then the faint metallic jingle returned.  I traced it slowly
+feeling over the kitchen.  Presently I heard it nearer--in the
+scullery, as I judged.  I thought that its length might be
+insufficient to reach me.  I prayed copiously.  It passed, scraping
+faintly across the cellar door.  An age of almost intolerable suspense
+intervened; then I heard it fumbling at the latch! It had found the
+door!  The Martians understood doors!
+
+It worried at the catch for a minute, perhaps, and then the door
+opened.
+
+In the darkness I could just see the thing--like an elephant's
+trunk more than anything else--waving towards me and touching and
+examining the wall, coals, wood and ceiling.  It was like a black worm
+swaying its blind head to and fro.
+
+Once, even, it touched the heel of my boot.  I was on the verge of
+screaming; I bit my hand.  For a time the tentacle was silent.  I
+could have fancied it had been withdrawn.  Presently, with an abrupt
+click, it gripped something--I thought it had me!--and seemed to go
+out of the cellar again.  For a minute I was not sure.  Apparently it
+had taken a lump of coal to examine.
+
+I seized the opportunity of slightly shifting my position, which
+had become cramped, and then listened.  I whispered passionate prayers
+for safety.
+
+Then I heard the slow, deliberate sound creeping towards me again.
+Slowly, slowly it drew near, scratching against the walls and tapping
+the furniture.
+
+While I was still doubtful, it rapped smartly against the cellar
+door and closed it.  I heard it go into the pantry, and the biscuit-tins
+rattled and a bottle smashed, and then came a heavy bump against
+the cellar door.  Then silence that passed into an infinity of
+suspense.
+
+Had it gone?
+
+At last I decided that it had.
+
+It came into the scullery no more; but I lay all the tenth day in
+the close darkness, buried among coals and firewood, not daring even
+to crawl out for the drink for which I craved.  It was the eleventh day
+before I ventured so far from my security.
+
+
+
+CHAPTER FIVE
+
+THE STILLNESS
+
+
+My first act before I went into the pantry was to fasten the door
+between the kitchen and the scullery.  But the pantry was empty; every
+scrap of food had gone.  Apparently, the Martian had taken it all on
+the previous day.  At that discovery I despaired for the first time.  I
+took no food, or no drink either, on the eleventh or the twelfth day.
+
+At first my mouth and throat were parched, and my strength ebbed
+sensibly.  I sat about in the darkness of the scullery, in a state of
+despondent wretchedness.  My mind ran on eating.  I thought I had
+become deaf, for the noises of movement I had been accustomed to hear
+from the pit had ceased absolutely.  I did not feel strong enough to
+crawl noiselessly to the peephole, or I would have gone there.
+
+On the twelfth day my throat was so painful that, taking the chance
+of alarming the Martians, I attacked the creaking rain-water pump that
+stood by the sink, and got a couple of glassfuls of blackened and
+tainted rain water.  I was greatly refreshed by this, and emboldened
+by the fact that no enquiring tentacle followed the noise of my
+pumping.
+
+During these days, in a rambling, inconclusive way, I thought much
+of the curate and of the manner of his death.
+
+On the thirteenth day I drank some more water, and dozed and
+thought disjointedly of eating and of vague impossible plans of
+escape.  Whenever I dozed I dreamt of horrible phantasms, of the death
+of the curate, or of sumptuous dinners; but, asleep or awake, I felt a
+keen pain that urged me to drink again and again.  The light that came
+into the scullery was no longer grey, but red.  To my disordered
+imagination it seemed the colour of blood.
+
+On the fourteenth day I went into the kitchen, and I was surprised
+to find that the fronds of the red weed had grown right across
+the hole in the wall, turning the half-light of the place into a
+crimson-coloured obscurity.
+
+It was early on the fifteenth day that I heard a curious, familiar
+sequence of sounds in the kitchen, and, listening, identified it as
+the snuffing and scratching of a dog.  Going into the kitchen, I saw a
+dog's nose peering in through a break among the ruddy fronds.  This
+greatly surprised me.  At the scent of me he barked shortly.
+
+I thought if I could induce him to come into the place quietly I
+should be able, perhaps, to kill and eat him; and in any case, it
+would be advisable to kill him, lest his actions attracted the
+attention of the Martians.
+
+I crept forward, saying "Good dog!" very softly; but he suddenly
+withdrew his head and disappeared.
+
+I listened--I was not deaf--but certainly the pit was still.  I
+heard a sound like the flutter of a bird's wings, and a hoarse
+croaking, but that was all.
+
+For a long while I lay close to the peephole, but not daring to
+move aside the red plants that obscured it.  Once or twice I heard a
+faint pitter-patter like the feet of the dog going hither and thither
+on the sand far below me, and there were more birdlike sounds, but
+that was all.  At length, encouraged by the silence, I looked out.
+
+Except in the corner, where a multitude of crows hopped and fought
+over the skeletons of the dead the Martians had consumed, there was
+not a living thing in the pit.
+
+I stared about me, scarcely believing my eyes.  All the machinery
+had gone.  Save for the big mound of greyish-blue powder in one
+corner, certain bars of aluminium in another, the black birds, and the
+skeletons of the killed, the place was merely an empty circular pit in
+the sand.
+
+Slowly I thrust myself out through the red weed, and stood upon the
+mound of rubble.  I could see in any direction save behind me, to the
+north, and neither Martians nor sign of Martians were to be seen.  The
+pit dropped sheerly from my feet, but a little way along the rubbish
+afforded a practicable slope to the summit of the ruins.  My chance of
+escape had come.  I began to tremble.
+
+I hesitated for some time, and then, in a gust of desperate
+resolution, and with a heart that throbbed violently, I scrambled to
+the top of the mound in which I had been buried so long.
+
+I looked about again.  To the northward, too, no Martian was
+visible.
+
+When I had last seen this part of Sheen in the daylight it had been
+a straggling street of comfortable white and red houses, interspersed
+with abundant shady trees.  Now I stood on a mound of smashed
+brickwork, clay, and gravel, over which spread a multitude of red
+cactus-shaped plants, knee-high, without a solitary terrestrial growth
+to dispute their footing.  The trees near me were dead and brown, but
+further a network of red thread scaled the still living stems.
+
+The neighbouring houses had all been wrecked, but none had been
+burned; their walls stood, sometimes to the second story, with smashed
+windows and shattered doors.  The red weed grew tumultuously in their
+roofless rooms.  Below me was the great pit, with the crows struggling
+for its refuse.  A number of other birds hopped about among the ruins.
+Far away I saw a gaunt cat slink crouchingly along a wall, but traces
+of men there were none.
+
+The day seemed, by contrast with my recent confinement, dazzlingly
+bright, the sky a glowing blue.  A gentle breeze kept the red weed
+that covered every scrap of unoccupied ground gently swaying.  And oh!
+the sweetness of the air!
+
+
+
+CHAPTER SIX
+
+THE WORK OF FIFTEEN DAYS
+
+
+For some time I stood tottering on the mound regardless of my
+safety.  Within that noisome den from which I had emerged I had
+thought with a narrow intensity only of our immediate security.  I had
+not realised what had been happening to the world, had not anticipated
+this startling vision of unfamiliar things.  I had expected to see
+Sheen in ruins--I found about me the landscape, weird and lurid, of
+another planet.
+
+For that moment I touched an emotion beyond the common range of
+men, yet one that the poor brutes we dominate know only too well.  I
+felt as a rabbit might feel returning to his burrow and suddenly
+confronted by the work of a dozen busy navvies digging the foundations
+of a house.  I felt the first inkling of a thing that presently grew
+quite clear in my mind, that oppressed me for many days, a sense of
+dethronement, a persuasion that I was no longer a master, but an
+animal among the animals, under the Martian heel.  With us it would be
+as with them, to lurk and watch, to run and hide; the fear and empire
+of man had passed away.
+
+But so soon as this strangeness had been realised it passed, and my
+dominant motive became the hunger of my long and dismal fast.  In the
+direction away from the pit I saw, beyond a red-covered wall, a patch
+of garden ground unburied.  This gave me a hint, and I went knee-deep,
+and sometimes neck-deep, in the red weed.  The density of the
+weed gave me a reassuring sense of hiding.  The wall was some six feet
+high, and when I attempted to clamber it I found I could not lift my
+feet to the crest.  So I went along by the side of it, and came to a
+corner and a rockwork that enabled me to get to the top, and tumble
+into the garden I coveted.  Here I found some young onions, a couple
+of gladiolus bulbs, and a quantity of immature carrots, all of which I
+secured, and, scrambling over a ruined wall, went on my way through
+scarlet and crimson trees towards Kew--it was like walking through an
+avenue of gigantic blood drops--possessed with two ideas: to get more
+food, and to limp, as soon and as far as my strength permitted, out of
+this accursed unearthly region of the pit.
+
+Some way farther, in a grassy place, was a group of mushrooms which
+also I devoured, and then I came upon a brown sheet of flowing shallow
+water, where meadows used to be.  These fragments of nourishment served
+only to whet my hunger.  At first I was surprised at this flood in a
+hot, dry summer, but afterwards I discovered that it was caused by the
+tropical exuberance of the red weed.  Directly this extraordinary
+growth encountered water it straightway became gigantic and of
+unparalleled fecundity.  Its seeds were simply poured down into the
+water of the Wey and Thames, and its swiftly growing and Titanic water
+fronds speedily choked both those rivers.
+
+At Putney, as I afterwards saw, the bridge was almost lost in a
+tangle of this weed, and at Richmond, too, the Thames water poured in
+a broad and shallow stream across the meadows of Hampton and
+Twickenham.  As the water spread the weed followed them, until the
+ruined villas of the Thames valley were for a time lost in this red
+swamp, whose margin I explored, and much of the desolation the
+Martians had caused was concealed.
+
+In the end the red weed succumbed almost as quickly as it had
+spread.  A cankering disease, due, it is believed, to the action of
+certain bacteria, presently seized upon it.  Now by the action of
+natural selection, all terrestrial plants have acquired a resisting
+power against bacterial diseases--they never succumb without a severe
+struggle, but the red weed rotted like a thing already dead.  The
+fronds became bleached, and then shrivelled and brittle.  They broke
+off at the least touch, and the waters that had stimulated their early
+growth carried their last vestiges out to sea.
+
+My first act on coming to this water was, of course, to slake my
+thirst.  I drank a great deal of it and, moved by an impulse, gnawed
+some fronds of red weed; but they were watery, and had a sickly,
+metallic taste.  I found the water was sufficiently shallow for me to
+wade securely, although the red weed impeded my feet a little; but the
+flood evidently got deeper towards the river, and I turned back to
+Mortlake.  I managed to make out the road by means of occasional ruins
+of its villas and fences and lamps, and so presently I got out of this
+spate and made my way to the hill going up towards Roehampton and came
+out on Putney Common.
+
+Here the scenery changed from the strange and unfamiliar to the
+wreckage of the familiar: patches of ground exhibited the devastation
+of a cyclone, and in a few score yards I would come upon perfectly
+undisturbed spaces, houses with their blinds trimly drawn and doors
+closed, as if they had been left for a day by the owners, or as if
+their inhabitants slept within.  The red weed was less abundant; the
+tall trees along the lane were free from the red creeper.  I hunted
+for food among the trees, finding nothing, and I also raided a couple
+of silent houses, but they had already been broken into and ransacked.
+I rested for the remainder of the daylight in a shrubbery, being, in
+my enfeebled condition, too fatigued to push on.
+
+All this time I saw no human beings, and no signs of the Martians.
+I encountered a couple of hungry-looking dogs, but both hurried
+circuitously away from the advances I made them.  Near Roehampton I
+had seen two human skeletons--not bodies, but skeletons, picked
+clean--and in the wood by me I found the crushed and scattered bones
+of several cats and rabbits and the skull of a sheep.  But though I
+gnawed parts of these in my mouth, there was nothing to be got from
+them.
+
+After sunset I struggled on along the road towards Putney, where I
+think the Heat-Ray must have been used for some reason.  And in the
+garden beyond Roehampton I got a quantity of immature potatoes,
+sufficient to stay my hunger.  From this garden one looked down upon
+Putney and the river.  The aspect of the place in the dusk was
+singularly desolate: blackened trees, blackened, desolate ruins, and
+down the hill the sheets of the flooded river, red-tinged with the
+weed.  And over all--silence.  It filled me with indescribable terror
+to think how swiftly that desolating change had come.
+
+For a time I believed that mankind had been swept out of existence,
+and that I stood there alone, the last man left alive.  Hard by the
+top of Putney Hill I came upon another skeleton, with the arms
+dislocated and removed several yards from the rest of the body.  As I
+proceeded I became more and more convinced that the extermination of
+mankind was, save for such stragglers as myself, already accomplished
+in this part of the world.  The Martians, I thought, had gone on and
+left the country desolated, seeking food elsewhere.  Perhaps even now
+they were destroying Berlin or Paris, or it might be they had gone
+northward.
+
+
+
+CHAPTER SEVEN
+
+THE MAN ON PUTNEY HILL
+
+
+I spent that night in the inn that stands at the top of Putney
+Hill, sleeping in a made bed for the first time since my flight to
+Leatherhead.  I will not tell the needless trouble I had breaking into
+that house--afterwards I found the front door was on the latch--nor
+how I ransacked every room for food, until just on the verge of
+despair, in what seemed to me to be a servant's bedroom, I found a
+rat-gnawed crust and two tins of pineapple.  The place had been
+already searched and emptied.  In the bar I afterwards found some
+biscuits and sandwiches that had been overlooked.  The latter I could
+not eat, they were too rotten, but the former not only stayed my
+hunger, but filled my pockets.  I lit no lamps, fearing some Martian
+might come beating that part of London for food in the night.  Before
+I went to bed I had an interval of restlessness, and prowled from
+window to window, peering out for some sign of these monsters.  I
+slept little.  As I lay in bed I found myself thinking consecutively--a
+thing I do not remember to have done since my last argument with the
+curate.  During all the intervening time my mental condition had been
+a hurrying succession of vague emotional states or a sort of stupid
+receptivity.  But in the night my brain, reinforced, I suppose, by the
+food I had eaten, grew clear again, and I thought.
+
+Three things struggled for possession of my mind: the killing of
+the curate, the whereabouts of the Martians, and the possible fate of
+my wife.  The former gave me no sensation of horror or remorse to
+recall; I saw it simply as a thing done, a memory infinitely
+disagreeable but quite without the quality of remorse.  I saw myself
+then as I see myself now, driven step by step towards that hasty blow,
+the creature of a sequence of accidents leading inevitably to that.  I
+felt no condemnation; yet the memory, static, unprogressive, haunted
+me.  In the silence of the night, with that sense of the nearness of
+God that sometimes comes into the stillness and the darkness, I stood
+my trial, my only trial, for that moment of wrath and fear.  I
+retraced every step of our conversation from the moment when I had
+found him crouching beside me, heedless of my thirst, and pointing to
+the fire and smoke that streamed up from the ruins of Weybridge.  We
+had been incapable of co-operation--grim chance had taken no heed of
+that.  Had I foreseen, I should have left him at Halliford.  But I did
+not foresee; and crime is to foresee and do.  And I set this down as I
+have set all this story down, as it was.  There were no witnesses--all
+these things I might have concealed.  But I set it down, and the
+reader must form his judgment as he will.
+
+And when, by an effort, I had set aside that picture of a prostrate
+body, I faced the problem of the Martians and the fate of my wife.  For
+the former I had no data; I could imagine a hundred things, and so,
+unhappily, I could for the latter.  And suddenly that night became
+terrible.  I found myself sitting up in bed, staring at the dark.  I
+found myself praying that the Heat-Ray might have suddenly and
+painlessly struck her out of being.  Since the night of my return from
+Leatherhead I had not prayed.  I had uttered prayers, fetish prayers,
+had prayed as heathens mutter charms when I was in extremity; but now
+I prayed indeed, pleading steadfastly and sanely, face to face with
+the darkness of God.  Strange night!  Strangest in this, that so soon
+as dawn had come, I, who had talked with God, crept out of the house
+like a rat leaving its hiding place--a creature scarcely larger, an
+inferior animal, a thing that for any passing whim of our masters
+might be hunted and killed.  Perhaps they also prayed confidently to
+God.  Surely, if we have learned nothing else, this war has taught us
+pity--pity for those witless souls that suffer our dominion.
+
+The morning was bright and fine, and the eastern sky glowed pink,
+and was fretted with little golden clouds.  In the road that runs from
+the top of Putney Hill to Wimbledon was a number of poor vestiges of
+the panic torrent that must have poured Londonward on the Sunday night
+after the fighting began.  There was a little two-wheeled cart
+inscribed with the name of Thomas Lobb, Greengrocer, New Malden, with
+a smashed wheel and an abandoned tin trunk; there was a straw hat
+trampled into the now hardened mud, and at the top of West Hill a lot
+of blood-stained glass about the overturned water trough.  My
+movements were languid, my plans of the vaguest.  I had an idea of
+going to Leatherhead, though I knew that there I had the poorest
+chance of finding my wife.  Certainly, unless death had overtaken them
+suddenly, my cousins and she would have fled thence; but it seemed to
+me I might find or learn there whither the Surrey people had fled.  I
+knew I wanted to find my wife, that my heart ached for her and the
+world of men, but I had no clear idea how the finding might be done.  I
+was also sharply aware now of my intense loneliness.  From the corner
+I went, under cover of a thicket of trees and bushes, to the edge of
+Wimbledon Common, stretching wide and far.
+
+That dark expanse was lit in patches by yellow gorse and broom;
+there was no red weed to be seen, and as I prowled, hesitating, on the
+verge of the open, the sun rose, flooding it all with light and
+vitality.  I came upon a busy swarm of little frogs in a swampy place
+among the trees.  I stopped to look at them, drawing a lesson from
+their stout resolve to live.  And presently, turning suddenly, with an
+odd feeling of being watched, I beheld something crouching amid a
+clump of bushes.  I stood regarding this.  I made a step towards it,
+and it rose up and became a man armed with a cutlass.  I approached
+him slowly.  He stood silent and motionless, regarding me.
+
+As I drew nearer I perceived he was dressed in clothes as dusty and
+filthy as my own; he looked, indeed, as though he had been dragged
+through a culvert.  Nearer, I distinguished the green slime of ditches
+mixing with the pale drab of dried clay and shiny, coaly patches.  His
+black hair fell over his eyes, and his face was dark and dirty and
+sunken, so that at first I did not recognise him.  There was a red cut
+across the lower part of his face.
+
+"Stop!" he cried, when I was within ten yards of him, and I
+stopped.  His voice was hoarse.  "Where do you come from?" he said.
+
+I thought, surveying him.
+
+"I come from Mortlake," I said.  "I was buried near the pit the
+Martians made about their cylinder.  I have worked my way out and
+escaped."
+
+"There is no food about here," he said.  "This is my country.  All
+this hill down to the river, and back to Clapham, and up to the edge
+of the common.  There is only food for one.  Which way are you going?"
+
+I answered slowly.
+
+"I don't know," I said.  "I have been buried in the ruins of a
+house thirteen or fourteen days.  I don't know what has happened."
+
+He looked at me doubtfully, then started, and looked with a changed
+expression.
+
+"I've no wish to stop about here," said I.  "I think I shall go to
+Leatherhead, for my wife was there."
+
+He shot out a pointing finger.
+
+"It is you," said he; "the man from Woking.  And you weren't killed
+at Weybridge?"
+
+I recognised him at the same moment.
+
+"You are the artilleryman who came into my garden."
+
+"Good luck!" he said.  "We are lucky ones!  Fancy _you_!"  He put out
+a hand, and I took it.  "I crawled up a drain," he said. "But they
+didn't kill everyone.  And after they went away I got off towards
+Walton across the fields.  But---- It's not sixteen days altogether--and
+your hair is grey."  He looked over his shoulder suddenly.  "Only
+a rook," he said.  "One gets to know that birds have shadows these
+days.  This is a bit open.  Let us crawl under those bushes and talk."
+
+"Have you seen any Martians?" I said.  "Since I crawled out----"
+
+"They've gone away across London," he said.  "I guess they've got a
+bigger camp there.  Of a night, all over there, Hampstead way, the sky
+is alive with their lights.  It's like a great city, and in the glare
+you can just see them moving.  By daylight you can't.  But nearer--I
+haven't seen them--" (he counted on his fingers) "five days.  Then I
+saw a couple across Hammersmith way carrying something big.  And the
+night before last"--he stopped and spoke impressively--"it was just a
+matter of lights, but it was something up in the air.  I believe
+they've built a flying-machine, and are learning to fly."
+
+I stopped, on hands and knees, for we had come to the bushes.
+
+"Fly!"
+
+"Yes," he said, "fly."
+
+I went on into a little bower, and sat down.
+
+"It is all over with humanity," I said.  "If they can do that they
+will simply go round the world."
+
+He nodded.
+
+"They will.  But---- It will relieve things over here a bit.  And
+besides----"  He looked at me.  "Aren't you satisfied it _is_ up with
+humanity?  I am.  We're down; we're beat."
+
+I stared.  Strange as it may seem, I had not arrived at this fact--a
+fact perfectly obvious so soon as he spoke.  I had still held a
+vague hope; rather, I had kept a lifelong habit of mind.  He repeated
+his words, "We're beat."  They carried absolute conviction.
+
+"It's all over," he said.  "They've lost _one_--just _one_.  And they've
+made their footing good and crippled the greatest power in the world.
+They've walked over us.  The death of that one at Weybridge was an
+accident.  And these are only pioneers.  They kept on coming.  These
+green stars--I've seen none these five or six days, but I've no doubt
+they're falling somewhere every night.  Nothing's to be done.  We're
+under! We're beat!"
+
+I made him no answer.  I sat staring before me, trying in vain to
+devise some countervailing thought.
+
+"This isn't a war," said the artilleryman.  "It never was a war,
+any more than there's war between man and ants."
+
+Suddenly I recalled the night in the observatory.
+
+"After the tenth shot they fired no more--at least, until the first
+cylinder came."
+
+"How do you know?" said the artilleryman.  I explained.  He thought.
+"Something wrong with the gun," he said.  "But what if there is?
+They'll get it right again.  And even if there's a delay, how can it
+alter the end?  It's just men and ants.  There's the ants builds their
+cities, live their lives, have wars, revolutions, until the men want
+them out of the way, and then they go out of the way.  That's what we
+are now--just ants.  Only----"
+
+"Yes," I said.
+
+"We're eatable ants."
+
+We sat looking at each other.
+
+"And what will they do with us?" I said.
+
+"That's what I've been thinking," he said; "that's what I've been
+thinking.  After Weybridge I went south--thinking.  I saw what was up.
+Most of the people were hard at it squealing and exciting themselves.
+But I'm not so fond of squealing.  I've been in sight of death once or
+twice; I'm not an ornamental soldier, and at the best and worst,
+death--it's just death.  And it's the man that keeps on thinking comes
+through.  I saw everyone tracking away south.  Says I, 'Food won't
+last this way,' and I turned right back.  I went for the Martians like
+a sparrow goes for man.  All round"--he waved a hand to the
+horizon--"they're starving in heaps, bolting, treading on each other.
+. . ."
+
+He saw my face, and halted awkwardly.
+
+"No doubt lots who had money have gone away to France," he said.  He
+seemed to hesitate whether to apologise, met my eyes, and went on:
+"There's food all about here.  Canned things in shops; wines, spirits,
+mineral waters; and the water mains and drains are empty.  Well, I was
+telling you what I was thinking.  'Here's intelligent things,' I said,
+'and it seems they want us for food.  First, they'll smash us up--ships,
+machines, guns, cities, all the order and organisation.  All
+that will go.  If we were the size of ants we might pull through.  But
+we're not.  It's all too bulky to stop.  That's the first certainty.'
+Eh?"
+
+I assented.
+
+"It is; I've thought it out.  Very well, then--next; at present
+we're caught as we're wanted.  A Martian has only to go a few miles to
+get a crowd on the run.  And I saw one, one day, out by Wandsworth,
+picking houses to pieces and routing among the wreckage.  But they
+won't keep on doing that.  So soon as they've settled all our guns and
+ships, and smashed our railways, and done all the things they are
+doing over there, they will begin catching us systematic, picking the
+best and storing us in cages and things.  That's what they will start
+doing in a bit.  Lord!  They haven't begun on us yet.  Don't you see
+that?"
+
+"Not begun!" I exclaimed.
+
+"Not begun.  All that's happened so far is through our not having
+the sense to keep quiet--worrying them with guns and such foolery.  And
+losing our heads, and rushing off in crowds to where there wasn't any
+more safety than where we were.  They don't want to bother us yet.
+They're making their things--making all the things they couldn't bring
+with them, getting things ready for the rest of their people.  Very
+likely that's why the cylinders have stopped for a bit, for fear of
+hitting those who are here.  And instead of our rushing about blind,
+on the howl, or getting dynamite on the chance of busting them up,
+we've got to fix ourselves up according to the new state of affairs.
+That's how I figure it out.  It isn't quite according to what a man
+wants for his species, but it's about what the facts point to.  And
+that's the principle I acted upon.  Cities, nations, civilisation,
+progress--it's all over.  That game's up.  We're beat."
+
+"But if that is so, what is there to live for?"
+
+The artilleryman looked at me for a moment.
+
+"There won't be any more blessed concerts for a million years or
+so; there won't be any Royal Academy of Arts, and no nice little feeds
+at restaurants.  If it's amusement you're after, I reckon the game is
+up.  If you've got any drawing-room manners or a dislike to eating
+peas with a knife or dropping aitches, you'd better chuck 'em away.
+They ain't no further use."
+
+"You mean----"
+
+"I mean that men like me are going on living--for the sake of the
+breed.  I tell you, I'm grim set on living.  And if I'm not mistaken,
+you'll show what insides _you've_ got, too, before long.  We aren't
+going to be exterminated.  And I don't mean to be caught either, and
+tamed and fattened and bred like a thundering ox.  Ugh! Fancy those
+brown creepers!"
+
+"You don't mean to say----"
+
+"I do.  I'm going on, under their feet.  I've got it planned; I've
+thought it out.  We men are beat.  We don't know enough.  We've got to
+learn before we've got a chance.  And we've got to live and keep
+independent while we learn.  See! That's what has to be done."
+
+I stared, astonished, and stirred profoundly by the man's
+resolution.
+
+"Great God!" cried I.  "But you are a man indeed!"  And suddenly I
+gripped his hand.
+
+"Eh!" he said, with his eyes shining.  "I've thought it out, eh?"
+
+"Go on," I said.
+
+"Well, those who mean to escape their catching must get ready.  I'm
+getting ready.  Mind you, it isn't all of us that are made for wild
+beasts; and that's what it's got to be.  That's why I watched you.  I
+had my doubts.  You're slender.  I didn't know that it was you, you
+see, or just how you'd been buried.  All these--the sort of people
+that lived in these houses, and all those damn little clerks that used
+to live down that way--they'd be no good.  They haven't any spirit in
+them--no proud dreams and no proud lusts; and a man who hasn't one or
+the other--Lord!  What is he but funk and precautions?  They just used
+to skedaddle off to work--I've seen hundreds of 'em, bit of breakfast
+in hand, running wild and shining to catch their little season-ticket
+train, for fear they'd get dismissed if they didn't; working at
+businesses they were afraid to take the trouble to understand;
+skedaddling back for fear they wouldn't be in time for dinner; keeping
+indoors after dinner for fear of the back streets, and sleeping with
+the wives they married, not because they wanted them, but because they
+had a bit of money that would make for safety in their one little
+miserable skedaddle through the world.  Lives insured and a bit
+invested for fear of accidents.  And on Sundays--fear of the
+hereafter.  As if hell was built for rabbits!  Well, the Martians will
+just be a godsend to these.  Nice roomy cages, fattening food, careful
+breeding, no worry.  After a week or so chasing about the fields and
+lands on empty stomachs, they'll come and be caught cheerful.  They'll
+be quite glad after a bit.  They'll wonder what people did before
+there were Martians to take care of them.  And the bar loafers, and
+mashers, and singers--I can imagine them.  I can imagine them," he
+said, with a sort of sombre gratification.  "There'll be any amount of
+sentiment and religion loose among them.  There's hundreds of things I
+saw with my eyes that I've only begun to see clearly these last few
+days.  There's lots will take things as they are--fat and stupid; and
+lots will be worried by a sort of feeling that it's all wrong, and
+that they ought to be doing something.  Now whenever things are so
+that a lot of people feel they ought to be doing something, the weak,
+and those who go weak with a lot of complicated thinking, always make
+for a sort of do-nothing religion, very pious and superior, and
+submit to persecution and the will of the Lord.  Very likely you've
+seen the same thing.  It's energy in a gale of funk, and turned clean
+inside out.  These cages will be full of psalms and hymns and piety.
+And those of a less simple sort will work in a bit of--what is
+it?--eroticism."
+
+He paused.
+
+"Very likely these Martians will make pets of some of them; train
+them to do tricks--who knows?--get sentimental over the pet boy who
+grew up and had to be killed.  And some, maybe, they will train to
+hunt us."
+
+"No," I cried, "that's impossible!  No human being----"
+
+"What's the good of going on with such lies?" said the
+artilleryman.  "There's men who'd do it cheerful.  What nonsense to
+pretend there isn't!"
+
+And I succumbed to his conviction.
+
+"If they come after me," he said; "Lord, if they come after me!"
+and subsided into a grim meditation.
+
+I sat contemplating these things.  I could find nothing to bring
+against this man's reasoning.  In the days before the invasion no one
+would have questioned my intellectual superiority to his--I, a
+professed and recognised writer on philosophical themes, and he, a
+common soldier; and yet he had already formulated a situation that I
+had scarcely realised.
+
+"What are you doing?" I said presently.  "What plans have you
+made?"
+
+He hesitated.
+
+"Well, it's like this," he said.  "What have we to do?  We have to
+invent a sort of life where men can live and breed, and be
+sufficiently secure to bring the children up.  Yes--wait a bit, and
+I'll make it clearer what I think ought to be done.  The tame ones
+will go like all tame beasts; in a few generations they'll be big,
+beautiful, rich-blooded, stupid--rubbish! The risk is that we who keep
+wild will go savage--degenerate into a sort of big, savage rat. . . .
+You see, how I mean to live is underground.  I've been thinking about
+the drains.  Of course those who don't know drains think horrible
+things; but under this London are miles and miles--hundreds of
+miles--and a few days rain and London empty will leave them sweet and
+clean. The main drains are big enough and airy enough for anyone.
+Then there's cellars, vaults, stores, from which bolting passages may
+be made to the drains. And the railway tunnels and subways.  Eh?  You
+begin to see?  And we form a band--able-bodied, clean-minded men.
+We're not going to pick up any rubbish that drifts in.  Weaklings
+go out again."
+
+"As you meant me to go?"
+
+"Well--I parleyed, didn't I?"
+
+"We won't quarrel about that.  Go on."
+
+"Those who stop obey orders.  Able-bodied, clean-minded women we
+want also--mothers and teachers.  No lackadaisical ladies--no blasted
+rolling eyes.  We can't have any weak or silly.  Life is real again,
+and the useless and cumbersome and mischievous have to die.  They
+ought to die.  They ought to be willing to die.  It's a sort of
+disloyalty, after all, to live and taint the race.  And they can't be
+happy.  Moreover, dying's none so dreadful; it's the funking makes it
+bad.  And in all those places we shall gather.  Our district will be
+London.  And we may even be able to keep a watch, and run about in the
+open when the Martians keep away.  Play cricket, perhaps.  That's how
+we shall save the race.  Eh?  It's a possible thing?  But saving the
+race is nothing in itself.  As I say, that's only being rats.  It's
+saving our knowledge and adding to it is the thing.  There men like
+you come in.  There's books, there's models.  We must make great safe
+places down deep, and get all the books we can; not novels and poetry
+swipes, but ideas, science books.  That's where men like you come in.
+We must go to the British Museum and pick all those books through.
+Especially we must keep up our science--learn more.  We must watch
+these Martians.  Some of us must go as spies.  When it's all working,
+perhaps I will.  Get caught, I mean.  And the great thing is, we must
+leave the Martians alone.  We mustn't even steal.  If we get in their
+way, we clear out.  We must show them we mean no harm.  Yes, I know.
+But they're intelligent things, and they won't hunt us down if they
+have all they want, and think we're just harmless vermin."
+
+The artilleryman paused and laid a brown hand upon my arm.
+
+"After all, it may not be so much we may have to learn before--Just
+imagine this: four or five of their fighting machines suddenly
+starting off--Heat-Rays right and left, and not a Martian in 'em.  Not
+a Martian in 'em, but men--men who have learned the way how.  It may
+be in my time, even--those men.  Fancy having one of them lovely
+things, with its Heat-Ray wide and free!  Fancy having it in control!
+What would it matter if you smashed to smithereens at the end of the
+run, after a bust like that?  I reckon the Martians'll open their
+beautiful eyes!  Can't you see them, man?  Can't you see them
+hurrying, hurrying--puffing and blowing and hooting to their other
+mechanical affairs?  Something out of gear in every case.  And swish,
+bang, rattle, swish!  Just as they are fumbling over it, _swish_ comes
+the Heat-Ray, and, behold! man has come back to his own."
+
+For a while the imaginative daring of the artilleryman, and the
+tone of assurance and courage he assumed, completely dominated my
+mind.  I believed unhesitatingly both in his forecast of human destiny
+and in the practicability of his astonishing scheme, and the reader
+who thinks me susceptible and foolish must contrast his position,
+reading steadily with all his thoughts about his subject, and mine,
+crouching fearfully in the bushes and listening, distracted by
+apprehension.  We talked in this manner through the early morning
+time, and later crept out of the bushes, and, after scanning the sky
+for Martians, hurried precipitately to the house on Putney Hill where
+he had made his lair.  It was the coal cellar of the place, and when I
+saw the work he had spent a week upon--it was a burrow scarcely ten
+yards long, which he designed to reach to the main drain on Putney
+Hill--I had my first inkling of the gulf between his dreams and his
+powers.  Such a hole I could have dug in a day.  But I believed in him
+sufficiently to work with him all that morning until past midday at
+his digging.  We had a garden barrow and shot the earth we removed
+against the kitchen range.  We refreshed ourselves with a tin of
+mock-turtle soup and wine from the neighbouring pantry.  I found a
+curious relief from the aching strangeness of the world in this steady
+labour. As we worked, I turned his project over in my mind, and
+presently objections and doubts began to arise; but I worked there all
+the morning, so glad was I to find myself with a purpose again.  After
+working an hour I began to speculate on the distance one had to go
+before the cloaca was reached, the chances we had of missing it
+altogether.  My immediate trouble was why we should dig this long
+tunnel, when it was possible to get into the drain at once down one of
+the manholes, and work back to the house.  It seemed to me, too, that
+the house was inconveniently chosen, and required a needless length of
+tunnel.  And just as I was beginning to face these things, the
+artilleryman stopped digging, and looked at me.
+
+"We're working well," he said.  He put down his spade. "Let us
+knock off a bit" he said.  "I think it's time we reconnoitred from the
+roof of the house."
+
+I was for going on, and after a little hesitation he resumed his
+spade; and then suddenly I was struck by a thought.  I stopped, and so
+did he at once.
+
+"Why were you walking about the common," I said, "instead of being
+here?"
+
+"Taking the air," he said.  "I was coming back.  It's safer by
+night."
+
+"But the work?"
+
+"Oh, one can't always work," he said, and in a flash I saw the man
+plain.  He hesitated, holding his spade.  "We ought to reconnoitre
+now," he said, "because if any come near they may hear the spades and
+drop upon us unawares."
+
+I was no longer disposed to object.  We went together to the roof
+and stood on a ladder peeping out of the roof door.  No Martians were
+to be seen, and we ventured out on the tiles, and slipped down under
+shelter of the parapet.
+
+From this position a shrubbery hid the greater portion of Putney,
+but we could see the river below, a bubbly mass of red weed, and the
+low parts of Lambeth flooded and red.  The red creeper swarmed up the
+trees about the old palace, and their branches stretched gaunt and
+dead, and set with shrivelled leaves, from amid its clusters.  It was
+strange how entirely dependent both these things were upon flowing
+water for their propagation.  About us neither had gained a footing;
+laburnums, pink mays, snowballs, and trees of arbor-vitae, rose out of
+laurels and hydrangeas, green and brilliant into the sunlight.  Beyond
+Kensington dense smoke was rising, and that and a blue haze hid the
+northward hills.
+
+The artilleryman began to tell me of the sort of people who still
+remained in London.
+
+"One night last week," he said, "some fools got the electric light
+in order, and there was all Regent Street and the Circus ablaze,
+crowded with painted and ragged drunkards, men and women, dancing and
+shouting till dawn.  A man who was there told me.  And as the day came
+they became aware of a fighting-machine standing near by the Langham
+and looking down at them.  Heaven knows how long he had been there.
+It must have given some of them a nasty turn.  He came down the road
+towards them, and picked up nearly a hundred too drunk or frightened
+to run away."
+
+Grotesque gleam of a time no history will ever fully describe!
+
+From that, in answer to my questions, he came round to his
+grandiose plans again.  He grew enthusiastic.  He talked so eloquently
+of the possibility of capturing a fighting-machine that I more than
+half believed in him again.  But now that I was beginning to
+understand something of his quality, I could divine the stress he laid
+on doing nothing precipitately.  And I noted that now there was no
+question that he personally was to capture and fight the great
+machine.
+
+After a time we went down to the cellar.  Neither of us seemed
+disposed to resume digging, and when he suggested a meal, I was
+nothing loath.  He became suddenly very generous, and when we had
+eaten he went away and returned with some excellent cigars.  We lit
+these, and his optimism glowed.  He was inclined to regard my coming
+as a great occasion.
+
+"There's some champagne in the cellar," he said.
+
+"We can dig better on this Thames-side burgundy," said I.
+
+"No," said he; "I am host today.  Champagne!  Great God! We've a
+heavy enough task before us!  Let us take a rest and gather strength
+while we may.  Look at these blistered hands!"
+
+And pursuant to this idea of a holiday, he insisted upon playing
+cards after we had eaten.  He taught me euchre, and after dividing
+London between us, I taking the northern side and he the southern, we
+played for parish points.  Grotesque and foolish as this will seem to
+the sober reader, it is absolutely true, and what is more remarkable,
+I found the card game and several others we played extremely
+interesting.
+
+Strange mind of man! that, with our species upon the edge of
+extermination or appalling degradation, with no clear prospect before
+us but the chance of a horrible death, we could sit following the
+chance of this painted pasteboard, and playing the "joker" with vivid
+delight.  Afterwards he taught me poker, and I beat him at three tough
+chess games.  When dark came we decided to take the risk, and lit a
+lamp.
+
+After an interminable string of games, we supped, and the
+artilleryman finished the champagne.  We went on smoking the cigars.
+He was no longer the energetic regenerator of his species I had
+encountered in the morning.  He was still optimistic, but it was a
+less kinetic, a more thoughtful optimism.  I remember he wound up with
+my health, proposed in a speech of small variety and considerable
+intermittence.  I took a cigar, and went upstairs to look at the
+lights of which he had spoken that blazed so greenly along the
+Highgate hills.
+
+At first I stared unintelligently across the London valley.  The
+northern hills were shrouded in darkness; the fires near Kensington
+glowed redly, and now and then an orange-red tongue of flame flashed
+up and vanished in the deep blue night.  All the rest of London
+was black.  Then, nearer, I perceived a strange light, a pale,
+violet-purple fluorescent glow, quivering under the night breeze.  For
+a space I could not understand it, and then I knew that it must be
+the red weed from which this faint irradiation proceeded.  With that
+realisation my dormant sense of wonder, my sense of the proportion of
+things, awoke again.  I glanced from that to Mars, red and clear,
+glowing high in the west, and then gazed long and earnestly at the
+darkness of Hampstead and Highgate.
+
+I remained a very long time upon the roof, wondering at the
+grotesque changes of the day.  I recalled my mental states from the
+midnight prayer to the foolish card-playing.  I had a violent
+revulsion of feeling.  I remember I flung away the cigar with a
+certain wasteful symbolism.  My folly came to me with glaring
+exaggeration.  I seemed a traitor to my wife and to my kind; I was
+filled with remorse.  I resolved to leave this strange undisciplined
+dreamer of great things to his drink and gluttony, and to go on into
+London.  There, it seemed to me, I had the best chance of learning
+what the Martians and my fellowmen were doing.  I was still upon the
+roof when the late moon rose.
+
+
+
+CHAPTER EIGHT
+
+DEAD LONDON
+
+
+After I had parted from the artilleryman, I went down the hill, and
+by the High Street across the bridge to Fulham.  The red weed was
+tumultuous at that time, and nearly choked the bridge roadway; but its
+fronds were already whitened in patches by the spreading disease that
+presently removed it so swiftly.
+
+At the corner of the lane that runs to Putney Bridge station I
+found a man lying.  He was as black as a sweep with the black dust,
+alive, but helplessly and speechlessly drunk.  I could get nothing
+from him but curses and furious lunges at my head.  I think I should
+have stayed by him but for the brutal expression of his face.
+
+There was black dust along the roadway from the bridge onwards, and
+it grew thicker in Fulham.  The streets were horribly quiet.  I got
+food--sour, hard, and mouldy, but quite eatable--in a baker's shop
+here.  Some way towards Walham Green the streets became clear of
+powder, and I passed a white terrace of houses on fire; the noise of
+the burning was an absolute relief.  Going on towards Brompton, the
+streets were quiet again.
+
+Here I came once more upon the black powder in the streets and upon
+dead bodies.  I saw altogether about a dozen in the length of the
+Fulham Road.  They had been dead many days, so that I hurried quickly
+past them.  The black powder covered them over, and softened their
+outlines.  One or two had been disturbed by dogs.
+
+Where there was no black powder, it was curiously like a Sunday in
+the City, with the closed shops, the houses locked up and the blinds
+drawn, the desertion, and the stillness.  In some places plunderers
+had been at work, but rarely at other than the provision and wine
+shops.  A jeweller's window had been broken open in one place, but
+apparently the thief had been disturbed, and a number of gold chains
+and a watch lay scattered on the pavement.  I did not trouble to touch
+them.  Farther on was a tattered woman in a heap on a doorstep; the
+hand that hung over her knee was gashed and bled down her rusty brown
+dress, and a smashed magnum of champagne formed a pool across the
+pavement.  She seemed asleep, but she was dead.
+
+The farther I penetrated into London, the profounder grew the
+stillness.  But it was not so much the stillness of death--it was the
+stillness of suspense, of expectation.  At any time the destruction
+that had already singed the northwestern borders of the metropolis,
+and had annihilated Ealing and Kilburn, might strike among these
+houses and leave them smoking ruins.  It was a city condemned and
+derelict. . . .
+
+In South Kensington the streets were clear of dead and of black
+powder.  It was near South Kensington that I first heard the howling.
+It crept almost imperceptibly upon my senses.  It was a sobbing
+alternation of two notes, "Ulla, ulla, ulla, ulla," keeping on
+perpetually.  When I passed streets that ran northward it grew in
+volume, and houses and buildings seemed to deaden and cut it off
+again.  It came in a full tide down Exhibition Road.  I stopped,
+staring towards Kensington Gardens, wondering at this strange, remote
+wailing.  It was as if that mighty desert of houses had found a voice
+for its fear and solitude.
+
+"Ulla, ulla, ulla, ulla," wailed that superhuman note--great waves
+of sound sweeping down the broad, sunlit roadway, between the tall
+buildings on each side.  I turned northwards, marvelling, towards the
+iron gates of Hyde Park.  I had half a mind to break into the Natural
+History Museum and find my way up to the summits of the towers, in
+order to see across the park.  But I decided to keep to the ground,
+where quick hiding was possible, and so went on up the Exhibition
+Road.  All the large mansions on each side of the road were empty and
+still, and my footsteps echoed against the sides of the houses.  At
+the top, near the park gate, I came upon a strange sight--a bus
+overturned, and the skeleton of a horse picked clean.  I puzzled over
+this for a time, and then went on to the bridge over the Serpentine.
+The voice grew stronger and stronger, though I could see nothing above
+the housetops on the north side of the park, save a haze of smoke to
+the northwest.
+
+"Ulla, ulla, ulla, ulla," cried the voice, coming, as it seemed to
+me, from the district about Regent's Park.  The desolating cry worked
+upon my mind.  The mood that had sustained me passed.  The wailing
+took possession of me.  I found I was intensely weary, footsore, and
+now again hungry and thirsty.
+
+It was already past noon.  Why was I wandering alone in this city
+of the dead?  Why was I alone when all London was lying in state, and
+in its black shroud?  I felt intolerably lonely.  My mind ran on old
+friends that I had forgotten for years.  I thought of the poisons in
+the chemists' shops, of the liquors the wine merchants stored; I
+recalled the two sodden creatures of despair, who so far as I knew,
+shared the city with myself. . . .
+
+I came into Oxford Street by the Marble Arch, and here again were
+black powder and several bodies, and an evil, ominous smell from the
+gratings of the cellars of some of the houses.  I grew very thirsty
+after the heat of my long walk.  With infinite trouble I managed to
+break into a public-house and get food and drink.  I was weary after
+eating, and went into the parlour behind the bar, and slept on a black
+horsehair sofa I found there.
+
+I awoke to find that dismal howling still in my ears, "Ulla, ulla,
+ulla, ulla."  It was now dusk, and after I had routed out some
+biscuits and a cheese in the bar--there was a meat safe, but it
+contained nothing but maggots--I wandered on through the silent
+residential squares to Baker Street--Portman Square is the only one I
+can name--and so came out at last upon Regent's Park.  And as I
+emerged from the top of Baker Street, I saw far away over the trees in
+the clearness of the sunset the hood of the Martian giant from which
+this howling proceeded.  I was not terrified.  I came upon him as if
+it were a matter of course.  I watched him for some time, but he did
+not move.  He appeared to be standing and yelling, for no reason that
+I could discover.
+
+I tried to formulate a plan of action.  That perpetual sound of
+"Ulla, ulla, ulla, ulla," confused my mind.  Perhaps I was too tired
+to be very fearful.  Certainly I was more curious to know the reason
+of this monotonous crying than afraid.  I turned back away from the
+park and struck into Park Road, intending to skirt the park, went
+along under the shelter of the terraces, and got a view of this
+stationary, howling Martian from the direction of St. John's Wood.  A
+couple of hundred yards out of Baker Street I heard a yelping chorus,
+and saw, first a dog with a piece of putrescent red meat in his jaws
+coming headlong towards me, and then a pack of starving mongrels in
+pursuit of him.  He made a wide curve to avoid me, as though he feared
+I might prove a fresh competitor.  As the yelping died away down the
+silent road, the wailing sound of "Ulla, ulla, ulla, ulla," reasserted
+itself.
+
+I came upon the wrecked handling-machine halfway to St. John's Wood
+station.  At first I thought a house had fallen across the road.  It
+was only as I clambered among the ruins that I saw, with a start, this
+mechanical Samson lying, with its tentacles bent and smashed and
+twisted, among the ruins it had made.  The forepart was shattered.  It
+seemed as if it had driven blindly straight at the house, and had been
+overwhelmed in its overthrow.  It seemed to me then that this might
+have happened by a handling-machine escaping from the guidance of its
+Martian.  I could not clamber among the ruins to see it, and the
+twilight was now so far advanced that the blood with which its seat
+was smeared, and the gnawed gristle of the Martian that the dogs had
+left, were invisible to me.
+
+Wondering still more at all that I had seen, I pushed on towards
+Primrose Hill.  Far away, through a gap in the trees, I saw a second
+Martian, as motionless as the first, standing in the park towards the
+Zoological Gardens, and silent.  A little beyond the ruins about the
+smashed handling-machine I came upon the red weed again, and found the
+Regent's Canal, a spongy mass of dark-red vegetation.
+
+As I crossed the bridge, the sound of "Ulla, ulla, ulla, ulla,"
+ceased.  It was, as it were, cut off.  The silence came like a
+thunderclap.
+
+The dusky houses about me stood faint and tall and dim; the trees
+towards the park were growing black.  All about me the red weed
+clambered among the ruins, writhing to get above me in the dimness.
+Night, the mother of fear and mystery, was coming upon me.  But while
+that voice sounded the solitude, the desolation, had been endurable;
+by virtue of it London had still seemed alive, and the sense of life
+about me had upheld me.  Then suddenly a change, the passing of
+something--I knew not what--and then a stillness that could be felt.
+Nothing but this gaunt quiet.
+
+London about me gazed at me spectrally.  The windows in the white
+houses were like the eye sockets of skulls.  About me my imagination
+found a thousand noiseless enemies moving.  Terror seized me, a horror
+of my temerity.  In front of me the road became pitchy black as though
+it was tarred, and I saw a contorted shape lying across the pathway.  I
+could not bring myself to go on.  I turned down St. John's Wood Road,
+and ran headlong from this unendurable stillness towards Kilburn.  I
+hid from the night and the silence, until long after midnight, in a
+cabmen's shelter in Harrow Road.  But before the dawn my courage
+returned, and while the stars were still in the sky I turned once more
+towards Regent's Park.  I missed my way among the streets, and
+presently saw down a long avenue, in the half-light of the early dawn,
+the curve of Primrose Hill.  On the summit, towering up to the fading
+stars, was a third Martian, erect and motionless like the others.
+
+An insane resolve possessed me.  I would die and end it.  And I
+would save myself even the trouble of killing myself.  I marched on
+recklessly towards this Titan, and then, as I drew nearer and the
+light grew, I saw that a multitude of black birds was circling and
+clustering about the hood.  At that my heart gave a bound, and I began
+running along the road.
+
+I hurried through the red weed that choked St. Edmund's Terrace (I
+waded breast-high across a torrent of water that was rushing down from
+the waterworks towards the Albert Road), and emerged upon the grass
+before the rising of the sun.  Great mounds had been heaped about the
+crest of the hill, making a huge redoubt of it--it was the final and
+largest place the Martians had made--and from behind these heaps there
+rose a thin smoke against the sky.  Against the sky line an eager dog
+ran and disappeared.  The thought that had flashed into my mind grew
+real, grew credible.  I felt no fear, only a wild, trembling
+exultation, as I ran up the hill towards the motionless monster.  Out
+of the hood hung lank shreds of brown, at which the hungry birds
+pecked and tore.
+
+In another moment I had scrambled up the earthen rampart and stood
+upon its crest, and the interior of the redoubt was below me.  A
+mighty space it was, with gigantic machines here and there within it,
+huge mounds of material and strange shelter places.  And scattered
+about it, some in their overturned war-machines, some in the now rigid
+handling-machines, and a dozen of them stark and silent and laid in a
+row, were the Martians--_dead_!--slain by the putrefactive and disease
+bacteria against which their systems were unprepared; slain as the red
+weed was being slain; slain, after all man's devices had failed, by
+the humblest things that God, in his wisdom, has put upon this earth.
+
+For so it had come about, as indeed I and many men might have
+foreseen had not terror and disaster blinded our minds.  These
+germs of disease have taken toll of humanity since the beginning of
+things--taken toll of our prehuman ancestors since life began here.
+But by virtue of this natural selection of our kind we have developed
+resisting power; to no germs do we succumb without a struggle, and to
+many--those that cause putrefaction in dead matter, for instance--our
+living frames are altogether immune.  But there are no bacteria in
+Mars, and directly these invaders arrived, directly they drank and
+fed, our microscopic allies began to work their overthrow.  Already
+when I watched them they were irrevocably doomed, dying and rotting
+even as they went to and fro.  It was inevitable.  By the toll of a
+billion deaths man has bought his birthright of the earth, and it is
+his against all comers; it would still be his were the Martians ten
+times as mighty as they are.  For neither do men live nor die in vain.
+
+Here and there they were scattered, nearly fifty altogether, in
+that great gulf they had made, overtaken by a death that must have
+seemed to them as incomprehensible as any death could be.  To me also
+at that time this death was incomprehensible.  All I knew was that
+these things that had been alive and so terrible to men were dead.
+For a moment I believed that the destruction of Sennacherib had been
+repeated, that God had repented, that the Angel of Death had slain
+them in the night.
+
+I stood staring into the pit, and my heart lightened gloriously,
+even as the rising sun struck the world to fire about me with his
+rays.  The pit was still in darkness; the mighty engines, so great and
+wonderful in their power and complexity, so unearthly in their
+tortuous forms, rose weird and vague and strange out of the shadows
+towards the light.  A multitude of dogs, I could hear, fought over the
+bodies that lay darkly in the depth of the pit, far below me.  Across
+the pit on its farther lip, flat and vast and strange, lay the great
+flying-machine with which they had been experimenting upon our denser
+atmosphere when decay and death arrested them.  Death had come not a
+day too soon.  At the sound of a cawing overhead I looked up at the
+huge fighting-machine that would fight no more for ever, at the
+tattered red shreds of flesh that dripped down upon the overturned
+seats on the summit of Primrose Hill.
+
+I turned and looked down the slope of the hill to where, enhaloed
+now in birds, stood those other two Martians that I had seen
+overnight, just as death had overtaken them.  The one had died, even
+as it had been crying to its companions; perhaps it was the last to
+die, and its voice had gone on perpetually until the force of its
+machinery was exhausted.  They glittered now, harmless tripod towers
+of shining metal, in the brightness of the rising sun.
+
+All about the pit, and saved as by a miracle from everlasting
+destruction, stretched the great Mother of Cities.  Those who have only
+seen London veiled in her sombre robes of smoke can scarcely imagine
+the naked clearness and beauty of the silent wilderness of houses.
+
+Eastward, over the blackened ruins of the Albert Terrace and the
+splintered spire of the church, the sun blazed dazzling in a clear
+sky, and here and there some facet in the great wilderness of roofs
+caught the light and glared with a white intensity.
+
+Northward were Kilburn and Hampsted, blue and crowded with houses;
+westward the great city was dimmed; and southward, beyond the
+Martians, the green waves of Regent's Park, the Langham Hotel, the
+dome of the Albert Hall, the Imperial Institute, and the giant
+mansions of the Brompton Road came out clear and little in the
+sunrise, the jagged ruins of Westminster rising hazily beyond.  Far
+away and blue were the Surrey hills, and the towers of the Crystal
+Palace glittered like two silver rods.  The dome of St. Paul's was
+dark against the sunrise, and injured, I saw for the first time, by a
+huge gaping cavity on its western side.
+
+And as I looked at this wide expanse of houses and factories and
+churches, silent and abandoned; as I thought of the multitudinous
+hopes and efforts, the innumerable hosts of lives that had gone to
+build this human reef, and of the swift and ruthless destruction that
+had hung over it all; when I realised that the shadow had been rolled
+back, and that men might still live in the streets, and this dear vast
+dead city of mine be once more alive and powerful, I felt a wave of
+emotion that was near akin to tears.
+
+The torment was over.  Even that day the healing would begin.  The
+survivors of the people scattered over the country--leaderless,
+lawless, foodless, like sheep without a shepherd--the thousands who
+had fled by sea, would begin to return; the pulse of life, growing
+stronger and stronger, would beat again in the empty streets and pour
+across the vacant squares.  Whatever destruction was done, the hand of
+the destroyer was stayed.  All the gaunt wrecks, the blackened
+skeletons of houses that stared so dismally at the sunlit grass of the
+hill, would presently be echoing with the hammers of the restorers and
+ringing with the tapping of their trowels.  At the thought I extended
+my hands towards the sky and began thanking God.  In a year, thought
+I--in a year. . .
+
+With overwhelming force came the thought of myself, of my wife, and
+the old life of hope and tender helpfulness that had ceased for ever.
+
+
+
+CHAPTER NINE
+
+WRECKAGE
+
+
+And now comes the strangest thing in my story.  Yet, perhaps, it is
+not altogether strange.  I remember, clearly and coldly and vividly,
+all that I did that day until the time that I stood weeping and
+praising God upon the summit of Primrose Hill.  And then I forget.
+
+Of the next three days I know nothing.  I have learned since that,
+so far from my being the first discoverer of the Martian overthrow,
+several such wanderers as myself had already discovered this on the
+previous night.  One man--the first--had gone to St. Martin's-le-Grand,
+and, while I sheltered in the cabmen's hut, had contrived to
+telegraph to Paris.  Thence the joyful news had flashed all over the
+world; a thousand cities, chilled by ghastly apprehensions, suddenly
+flashed into frantic illuminations; they knew of it in Dublin,
+Edinburgh, Manchester, Birmingham, at the time when I stood upon the
+verge of the pit.  Already men, weeping with joy, as I have heard,
+shouting and staying their work to shake hands and shout, were making
+up trains, even as near as Crewe, to descend upon London.  The church
+bells that had ceased a fortnight since suddenly caught the news,
+until all England was bell-ringing.  Men on cycles, lean-faced,
+unkempt, scorched along every country lane shouting of unhoped
+deliverance, shouting to gaunt, staring figures of despair.  And for
+the food!  Across the Channel, across the Irish Sea, across the
+Atlantic, corn, bread, and meat were tearing to our relief.  All the
+shipping in the world seemed going Londonward in those days.  But of
+all this I have no memory.  I drifted--a demented man.  I found myself
+in a house of kindly people, who had found me on the third day
+wandering, weeping, and raving through the streets of St. John's Wood.
+They have told me since that I was singing some insane doggerel about
+"The Last Man Left Alive! Hurrah!  The Last Man Left Alive!"  Troubled
+as they were with their own affairs, these people, whose name, much as
+I would like to express my gratitude to them, I may not even give
+here, nevertheless cumbered themselves with me, sheltered me, and
+protected me from myself.  Apparently they had learned something of my
+story from me during the days of my lapse.
+
+Very gently, when my mind was assured again, did they break to me
+what they had learned of the fate of Leatherhead.  Two days after I
+was imprisoned it had been destroyed, with every soul in it, by a
+Martian.  He had swept it out of existence, as it seemed, without any
+provocation, as a boy might crush an ant hill, in the mere wantonness
+of power.
+
+I was a lonely man, and they were very kind to me.  I was a lonely
+man and a sad one, and they bore with me.  I remained with them four
+days after my recovery.  All that time I felt a vague, a growing
+craving to look once more on whatever remained of the little life that
+seemed so happy and bright in my past.  It was a mere hopeless desire
+to feast upon my misery.  They dissuaded me.  They did all they could
+to divert me from this morbidity.  But at last I could resist the
+impulse no longer, and, promising faithfully to return to them, and
+parting, as I will confess, from these four-day friends with tears, I
+went out again into the streets that had lately been so dark and
+strange and empty.
+
+Already they were busy with returning people; in places even there
+were shops open, and I saw a drinking fountain running water.
+
+I remember how mockingly bright the day seemed as I went back on my
+melancholy pilgrimage to the little house at Woking, how busy the
+streets and vivid the moving life about me.  So many people were
+abroad everywhere, busied in a thousand activities, that it seemed
+incredible that any great proportion of the population could have been
+slain.  But then I noticed how yellow were the skins of the people I
+met, how shaggy the hair of the men, how large and bright their eyes,
+and that every other man still wore his dirty rags.  Their faces
+seemed all with one of two expressions--a leaping exultation and
+energy or a grim resolution.  Save for the expression of the faces,
+London seemed a city of tramps.  The vestries were indiscriminately
+distributing bread sent us by the French government.  The ribs of the
+few horses showed dismally.  Haggard special constables with white
+badges stood at the corners of every street.  I saw little of the
+mischief wrought by the Martians until I reached Wellington Street,
+and there I saw the red weed clambering over the buttresses of
+Waterloo Bridge.
+
+At the corner of the bridge, too, I saw one of the common contrasts
+of that grotesque time--a sheet of paper flaunting against a thicket
+of the red weed, transfixed by a stick that kept it in place.  It was
+the placard of the first newspaper to resume publication--the _Daily
+Mail_.  I bought a copy for a blackened shilling I found in my pocket.
+Most of it was in blank, but the solitary compositor who did the thing
+had amused himself by making a grotesque scheme of advertisement
+stereo on the back page.  The matter he printed was emotional; the
+news organisation had not as yet found its way back.  I learned
+nothing fresh except that already in one week the examination of the
+Martian mechanisms had yielded astonishing results.  Among other
+things, the article assured me what I did not believe at the time,
+that the "Secret of Flying," was discovered.  At Waterloo I found the
+free trains that were taking people to their homes.  The first rush
+was already over.  There were few people in the train, and I was in no
+mood for casual conversation.  I got a compartment to myself, and sat
+with folded arms, looking greyly at the sunlit devastation that flowed
+past the windows.  And just outside the terminus the train jolted over
+temporary rails, and on either side of the railway the houses were
+blackened ruins.  To Clapham Junction the face of London was grimy
+with powder of the Black Smoke, in spite of two days of thunderstorms
+and rain, and at Clapham Junction the line had been wrecked again;
+there were hundreds of out-of-work clerks and shopmen working side by
+side with the customary navvies, and we were jolted over a hasty
+relaying.
+
+All down the line from there the aspect of the country was gaunt
+and unfamiliar; Wimbledon particularly had suffered.  Walton, by virtue
+of its unburned pine woods, seemed the least hurt of any place along
+the line.  The Wandle, the Mole, every little stream, was a heaped
+mass of red weed, in appearance between butcher's meat and pickled
+cabbage.  The Surrey pine woods were too dry, however, for the festoons
+of the red climber.  Beyond Wimbledon, within sight of the line, in
+certain nursery grounds, were the heaped masses of earth about the
+sixth cylinder.  A number of people were standing about it, and some
+sappers were busy in the midst of it.  Over it flaunted a Union Jack,
+flapping cheerfully in the morning breeze.  The nursery grounds were
+everywhere crimson with the weed, a wide expanse of livid colour cut
+with purple shadows, and very painful to the eye.  One's gaze went
+with infinite relief from the scorched greys and sullen reds of the
+foreground to the blue-green softness of the eastward hills.
+
+The line on the London side of Woking station was still undergoing
+repair, so I descended at Byfleet station and took the road to
+Maybury, past the place where I and the artilleryman had talked to the
+hussars, and on by the spot where the Martian had appeared to me in
+the thunderstorm.  Here, moved by curiosity, I turned aside to find,
+among a tangle of red fronds, the warped and broken dog cart with the
+whitened bones of the horse scattered and gnawed.  For a time I stood
+regarding these vestiges. . . .
+
+Then I returned through the pine wood, neck-high with red weed here
+and there, to find the landlord of the Spotted Dog had already found
+burial, and so came home past the College Arms.  A man standing at an
+open cottage door greeted me by name as I passed.
+
+I looked at my house with a quick flash of hope that faded
+immediately.  The door had been forced; it was unfast and was opening
+slowly as I approached.
+
+It slammed again.  The curtains of my study fluttered out of the
+open window from which I and the artilleryman had watched the dawn.  No
+one had closed it since.  The smashed bushes were just as I had left
+them nearly four weeks ago.  I stumbled into the hall, and the house
+felt empty.  The stair carpet was ruffled and discoloured where I had
+crouched, soaked to the skin from the thunderstorm the night of the
+catastrophe.  Our muddy footsteps I saw still went up the stairs.
+
+I followed them to my study, and found lying on my writing-table
+still, with the selenite paper weight upon it, the sheet of work I had
+left on the afternoon of the opening of the cylinder.  For a space I
+stood reading over my abandoned arguments.  It was a paper on the
+probable development of Moral Ideas with the development of the
+civilising process; and the last sentence was the opening of a
+prophecy: "In about two hundred years," I had written, "we may
+expect----"  The sentence ended abruptly.  I remembered my inability
+to fix my mind that morning, scarcely a month gone by, and how I had
+broken off to get my _Daily Chronicle_ from the newsboy.  I remembered
+how I went down to the garden gate as he came along, and how I had
+listened to his odd story of "Men from Mars."
+
+I came down and went into the dining room.  There were the mutton
+and the bread, both far gone now in decay, and a beer bottle
+overturned, just as I and the artilleryman had left them.  My home was
+desolate.  I perceived the folly of the faint hope I had cherished so
+long.  And then a strange thing occurred.  "It is no use," said a
+voice.  "The house is deserted.  No one has been here these ten days.
+Do not stay here to torment yourself.  No one escaped but you."
+
+I was startled.  Had I spoken my thought aloud?  I turned, and the
+French window was open behind me.  I made a step to it, and stood
+looking out.
+
+And there, amazed and afraid, even as I stood amazed and afraid,
+were my cousin and my wife--my wife white and tearless.  She gave a
+faint cry.
+
+"I came," she said.  "I knew--knew----"
+
+She put her hand to her throat--swayed.  I made a step forward, and
+caught her in my arms.
+
+
+
+CHAPTER TEN
+
+THE EPILOGUE
+
+
+I cannot but regret, now that I am concluding my story, how little
+I am able to contribute to the discussion of the many debatable
+questions which are still unsettled.  In one respect I shall certainly
+provoke criticism.  My particular province is speculative philosophy.
+My knowledge of comparative physiology is confined to a book or two,
+but it seems to me that Carver's suggestions as to the reason of the
+rapid death of the Martians is so probable as to be regarded almost as
+a proven conclusion.  I have assumed that in the body of my narrative.
+
+At any rate, in all the bodies of the Martians that were examined
+after the war, no bacteria except those already known as terrestrial
+species were found.  That they did not bury any of their dead, and the
+reckless slaughter they perpetrated, point also to an entire ignorance
+of the putrefactive process.  But probable as this seems, it is by no
+means a proven conclusion.
+
+Neither is the composition of the Black Smoke known, which the
+Martians used with such deadly effect, and the generator of the
+Heat-Rays remains a puzzle.  The terrible disasters at the Ealing
+and South Kensington laboratories have disinclined analysts for further
+investigations upon the latter.  Spectrum analysis of the black powder
+points unmistakably to the presence of an unknown element with a
+brilliant group of three lines in the green, and it is possible that
+it combines with argon to form a compound which acts at once with
+deadly effect upon some constituent in the blood.  But such unproven
+speculations will scarcely be of interest to the general reader, to
+whom this story is addressed.  None of the brown scum that drifted
+down the Thames after the destruction of Shepperton was examined at
+the time, and now none is forthcoming.
+
+The results of an anatomical examination of the Martians, so far
+as the prowling dogs had left such an examination possible, I have
+already given.  But everyone is familiar with the magnificent and
+almost complete specimen in spirits at the Natural History Museum, and
+the countless drawings that have been made from it; and beyond that
+the interest of their physiology and structure is purely scientific.
+
+A question of graver and universal interest is the possibility of
+another attack from the Martians.  I do not think that nearly enough
+attention is being given to this aspect of the matter.  At present the
+planet Mars is in conjunction, but with every return to opposition I,
+for one, anticipate a renewal of their adventure.  In any case, we
+should be prepared.  It seems to me that it should be possible to
+define the position of the gun from which the shots are discharged, to
+keep a sustained watch upon this part of the planet, and to anticipate
+the arrival of the next attack.
+
+In that case the cylinder might be destroyed with dynamite or
+artillery before it was sufficiently cool for the Martians to emerge,
+or they might be butchered by means of guns so soon as the screw
+opened.  It seems to me that they have lost a vast advantage in the
+failure of their first surprise.  Possibly they see it in the same
+light.
+
+Lessing has advanced excellent reasons for supposing that the
+Martians have actually succeeded in effecting a landing on the planet
+Venus.  Seven months ago now, Venus and Mars were in alignment with
+the sun; that is to say, Mars was in opposition from the point of view
+of an observer on Venus.  Subsequently a peculiar luminous and sinuous
+marking appeared on the unillumined half of the inner planet, and
+almost simultaneously a faint dark mark of a similar sinuous character
+was detected upon a photograph of the Martian disk.  One needs to see
+the drawings of these appearances in order to appreciate fully their
+remarkable resemblance in character.
+
+At any rate, whether we expect another invasion or not, our views
+of the human future must be greatly modified by these events.  We have
+learned now that we cannot regard this planet as being fenced in and a
+secure abiding place for Man; we can never anticipate the unseen good
+or evil that may come upon us suddenly out of space.  It may be that
+in the larger design of the universe this invasion from Mars is not
+without its ultimate benefit for men; it has robbed us of that serene
+confidence in the future which is the most fruitful source of
+decadence, the gifts to human science it has brought are enormous, and
+it has done much to promote the conception of the commonweal of
+mankind.  It may be that across the immensity of space the Martians
+have watched the fate of these pioneers of theirs and learned their
+lesson, and that on the planet Venus they have found a securer
+settlement.  Be that as it may, for many years yet there will
+certainly be no relaxation of the eager scrutiny of the Martian disk,
+and those fiery darts of the sky, the shooting stars, will bring with
+them as they fall an unavoidable apprehension to all the sons of men.
+
+The broadening of men's views that has resulted can scarcely be
+exaggerated.  Before the cylinder fell there was a general persuasion
+that through all the deep of space no life existed beyond the petty
+surface of our minute sphere.  Now we see further.  If the Martians
+can reach Venus, there is no reason to suppose that the thing is
+impossible for men, and when the slow cooling of the sun makes this
+earth uninhabitable, as at last it must do, it may be that the thread
+of life that has begun here will have streamed out and caught our
+sister planet within its toils.
+
+Dim and wonderful is the vision I have conjured up in my mind of
+life spreading slowly from this little seed bed of the solar system
+throughout the inanimate vastness of sidereal space.  But that is a
+remote dream.  It may be, on the other hand, that the destruction of
+the Martians is only a reprieve.  To them, and not to us, perhaps, is
+the future ordained.
+
+I must confess the stress and danger of the time have left an
+abiding sense of doubt and insecurity in my mind.  I sit in my study
+writing by lamplight, and suddenly I see again the healing valley
+below set with writhing flames, and feel the house behind and about me
+empty and desolate.  I go out into the Byfleet Road, and vehicles pass
+me, a butcher boy in a cart, a cabful of visitors, a workman on a
+bicycle, children going to school, and suddenly they become vague and
+unreal, and I hurry again with the artilleryman through the hot,
+brooding silence.  Of a night I see the black powder darkening the
+silent streets, and the contorted bodies shrouded in that layer; they
+rise upon me tattered and dog-bitten.  They gibber and grow fiercer,
+paler, uglier, mad distortions of humanity at last, and I wake, cold
+and wretched, in the darkness of the night.
+
+I go to London and see the busy multitudes in Fleet Street and the
+Strand, and it comes across my mind that they are but the ghosts of
+the past, haunting the streets that I have seen silent and wretched,
+going to and fro, phantasms in a dead city, the mockery of life in a
+galvanised body.  And strange, too, it is to stand on Primrose Hill,
+as I did but a day before writing this last chapter, to see the great
+province of houses, dim and blue through the haze of the smoke and
+mist, vanishing at last into the vague lower sky, to see the people
+walking to and fro among the flower beds on the hill, to see the
+sight-seers about the Martian machine that stands there still, to hear
+the tumult of playing children, and to recall the time when I saw it
+all bright and clear-cut, hard and silent, under the dawn of that last
+great day. . . .
+
+And strangest of all is it to hold my wife's hand again, and to think
+that I have counted her, and that she has counted me, among the dead.
+
+
+
+
+
+
+
+End of the Project Gutenberg EBook of The War of the Worlds, by H. G. Wells
+
+*** END OF THIS PROJECT GUTENBERG EBOOK THE WAR OF THE WORLDS ***
+
+***** This file should be named 36.txt or 36.zip *****
+This and all associated files of various formats will be found in:
+        http://www.gutenberg.net/3/36/
+
+
+
+Updated editions will replace the previous one--the old editions
+will be renamed.
+
+Creating the works from public domain print editions means that no
+one owns a United States copyright in these works, so the Foundation
+(and you!) can copy and distribute it in the United States without
+permission and without paying copyright royalties.  Special rules,
+set forth in the General Terms of Use part of this license, apply to
+copying and distributing Project Gutenberg-tm electronic works to
+protect the PROJECT GUTENBERG-tm concept and trademark.  Project
+Gutenberg is a registered trademark, and may not be used if you
+charge for the eBooks, unless you receive specific permission.  If you
+do not charge anything for copies of this eBook, complying with the
+rules is very easy.  You may use this eBook for nearly any purpose
+such as creation of derivative works, reports, performances and
+research.  They may be modified and printed and given away--you may do
+practically ANYTHING with public domain eBooks.  Redistribution is
+subject to the trademark license, especially commercial
+redistribution.
+
+
+
+*** START: FULL LICENSE ***
+
+THE FULL PROJECT GUTENBERG LICENSE
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg-tm mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase "Project
+Gutenberg"), you agree to comply with all the terms of the Full Project
+Gutenberg-tm License (available with this file or online at
+http://gutenberg.net/license).
+
+
+Section 1.  General Terms of Use and Redistributing Project Gutenberg-tm
+electronic works
+
+1.A.  By reading or using any part of this Project Gutenberg-tm
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement.  If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or destroy
+all copies of Project Gutenberg-tm electronic works in your possession.
+If you paid a fee for obtaining a copy of or access to a Project
+Gutenberg-tm electronic work and you do not agree to be bound by the
+terms of this agreement, you may obtain a refund from the person or
+entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B.  "Project Gutenberg" is a registered trademark.  It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement.  There are a few
+things that you can do with most Project Gutenberg-tm electronic works
+even without complying with the full terms of this agreement.  See
+paragraph 1.C below.  There are a lot of things you can do with Project
+Gutenberg-tm electronic works if you follow the terms of this agreement
+and help preserve free future access to Project Gutenberg-tm electronic
+works.  See paragraph 1.E below.
+
+1.C.  The Project Gutenberg Literary Archive Foundation ("the Foundation"
+or PGLAF), owns a compilation copyright in the collection of Project
+Gutenberg-tm electronic works.  Nearly all the individual works in the
+collection are in the public domain in the United States.  If an
+individual work is in the public domain in the United States and you are
+located in the United States, we do not claim a right to prevent you from
+copying, distributing, performing, displaying or creating derivative
+works based on the work as long as all references to Project Gutenberg
+are removed.  Of course, we hope that you will support the Project
+Gutenberg-tm mission of promoting free access to electronic works by
+freely sharing Project Gutenberg-tm works in compliance with the terms of
+this agreement for keeping the Project Gutenberg-tm name associated with
+the work.  You can easily comply with the terms of this agreement by
+keeping this work in the same format with its attached full Project
+Gutenberg-tm License when you share it without charge with others.
+
+1.D.  The copyright laws of the place where you are located also govern
+what you can do with this work.  Copyright laws in most countries are in
+a constant state of change.  If you are outside the United States, check
+the laws of your country in addition to the terms of this agreement
+before downloading, copying, displaying, performing, distributing or
+creating derivative works based on this work or any other Project
+Gutenberg-tm work.  The Foundation makes no representations concerning
+the copyright status of any work in any country outside the United
+States.
+
+1.E.  Unless you have removed all references to Project Gutenberg:
+
+1.E.1.  The following sentence, with active links to, or other immediate
+access to, the full Project Gutenberg-tm License must appear prominently
+whenever any copy of a Project Gutenberg-tm work (any work on which the
+phrase "Project Gutenberg" appears, or with which the phrase "Project
+Gutenberg" is associated) is accessed, displayed, performed, viewed,
+copied or distributed:
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+1.E.2.  If an individual Project Gutenberg-tm electronic work is derived
+from the public domain (does not contain a notice indicating that it is
+posted with permission of the copyright holder), the work can be copied
+and distributed to anyone in the United States without paying any fees
+or charges.  If you are redistributing or providing access to a work
+with the phrase "Project Gutenberg" associated with or appearing on the
+work, you must comply either with the requirements of paragraphs 1.E.1
+through 1.E.7 or obtain permission for the use of the work and the
+Project Gutenberg-tm trademark as set forth in paragraphs 1.E.8 or
+1.E.9.
+
+1.E.3.  If an individual Project Gutenberg-tm electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any additional
+terms imposed by the copyright holder.  Additional terms will be linked
+to the Project Gutenberg-tm License for all works posted with the
+permission of the copyright holder found at the beginning of this work.
+
+1.E.4.  Do not unlink or detach or remove the full Project Gutenberg-tm
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg-tm.
+
+1.E.5.  Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg-tm License.
+
+1.E.6.  You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including any
+word processing or hypertext form.  However, if you provide access to or
+distribute copies of a Project Gutenberg-tm work in a format other than
+"Plain Vanilla ASCII" or other format used in the official version
+posted on the official Project Gutenberg-tm web site (www.gutenberg.net),
+you must, at no additional cost, fee or expense to the user, provide a
+copy, a means of exporting a copy, or a means of obtaining a copy upon
+request, of the work in its original "Plain Vanilla ASCII" or other
+form.  Any alternate format must include the full Project Gutenberg-tm
+License as specified in paragraph 1.E.1.
+
+1.E.7.  Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg-tm works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8.  You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg-tm electronic works provided
+that
+
+- You pay a royalty fee of 20% of the gross profits you derive from
+     the use of Project Gutenberg-tm works calculated using the method
+     you already use to calculate your applicable taxes.  The fee is
+     owed to the owner of the Project Gutenberg-tm trademark, but he
+     has agreed to donate royalties under this paragraph to the
+     Project Gutenberg Literary Archive Foundation.  Royalty payments
+     must be paid within 60 days following each date on which you
+     prepare (or are legally required to prepare) your periodic tax
+     returns.  Royalty payments should be clearly marked as such and
+     sent to the Project Gutenberg Literary Archive Foundation at the
+     address specified in Section 4, "Information about donations to
+     the Project Gutenberg Literary Archive Foundation."
+
+- You provide a full refund of any money paid by a user who notifies
+     you in writing (or by e-mail) within 30 days of receipt that s/he
+     does not agree to the terms of the full Project Gutenberg-tm
+     License.  You must require such a user to return or
+     destroy all copies of the works possessed in a physical medium
+     and discontinue all use of and all access to other copies of
+     Project Gutenberg-tm works.
+
+- You provide, in accordance with paragraph 1.F.3, a full refund of any
+     money paid for a work or a replacement copy, if a defect in the
+     electronic work is discovered and reported to you within 90 days
+     of receipt of the work.
+
+- You comply with all other terms of this agreement for free
+     distribution of Project Gutenberg-tm works.
+
+1.E.9.  If you wish to charge a fee or distribute a Project Gutenberg-tm
+electronic work or group of works on different terms than are set
+forth in this agreement, you must obtain permission in writing from
+both the Project Gutenberg Literary Archive Foundation and Michael
+Hart, the owner of the Project Gutenberg-tm trademark.  Contact the
+Foundation as set forth in Section 3 below.
+
+1.F.
+
+1.F.1.  Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+public domain works in creating the Project Gutenberg-tm
+collection.  Despite these efforts, Project Gutenberg-tm electronic
+works, and the medium on which they may be stored, may contain
+"Defects," such as, but not limited to, incomplete, inaccurate or
+corrupt data, transcription errors, a copyright or other intellectual
+property infringement, a defective or damaged disk or other medium, a
+computer virus, or computer codes that damage or cannot be read by
+your equipment.
+
+1.F.2.  LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the "Right
+of Replacement or Refund" described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg-tm trademark, and any other party distributing a Project
+Gutenberg-tm electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees.  YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH F3.  YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3.  LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from.  If you
+received the work on a physical medium, you must return the medium with
+your written explanation.  The person or entity that provided you with
+the defective work may elect to provide a replacement copy in lieu of a
+refund.  If you received the work electronically, the person or entity
+providing it to you may choose to give you a second opportunity to
+receive the work electronically in lieu of a refund.  If the second copy
+is also defective, you may demand a refund in writing without further
+opportunities to fix the problem.
+
+1.F.4.  Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you 'AS-IS', WITH NO OTHER
+WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+WARRANTIES OF MERCHANTIBILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5.  Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of damages.
+If any disclaimer or limitation set forth in this agreement violates the
+law of the state applicable to this agreement, the agreement shall be
+interpreted to make the maximum disclaimer or limitation permitted by
+the applicable state law.  The invalidity or unenforceability of any
+provision of this agreement shall not void the remaining provisions.
+
+1.F.6.  INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg-tm electronic works in accordance
+with this agreement, and any volunteers associated with the production,
+promotion and distribution of Project Gutenberg-tm electronic works,
+harmless from all liability, costs and expenses, including legal fees,
+that arise directly or indirectly from any of the following which you do
+or cause to occur: (a) distribution of this or any Project Gutenberg-tm
+work, (b) alteration, modification, or additions or deletions to any
+Project Gutenberg-tm work, and (c) any Defect you cause.
+
+
+Section  2.  Information about the Mission of Project Gutenberg-tm
+
+Project Gutenberg-tm is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of computers
+including obsolete, old, middle-aged and new computers.  It exists
+because of the efforts of hundreds of volunteers and donations from
+people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need, is critical to reaching Project Gutenberg-tm's
+goals and ensuring that the Project Gutenberg-tm collection will
+remain freely available for generations to come.  In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg-tm and future generations.
+To learn more about the Project Gutenberg Literary Archive Foundation
+and how your efforts and donations can help, see Sections 3 and 4
+and the Foundation web page at http://www.pglaf.org.
+
+
+Section 3.  Information about the Project Gutenberg Literary Archive
+Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service.  The Foundation's EIN or federal tax identification
+number is 64-6221541.  Its 501(c)(3) letter is posted at
+http://pglaf.org/fundraising.  Contributions to the Project Gutenberg
+Literary Archive Foundation are tax deductible to the full extent
+permitted by U.S. federal laws and your state's laws.
+
+The Foundation's principal office is located at 4557 Melan Dr. S.
+Fairbanks, AK, 99712., but its volunteers and employees are scattered
+throughout numerous locations.  Its business office is located at
+809 North 1500 West, Salt Lake City, UT 84116, (801) 596-1887, email
+business@pglaf.org.  Email contact links and up to date contact
+information can be found at the Foundation's web site and official
+page at http://pglaf.org
+
+For additional contact information:
+     Dr. Gregory B. Newby
+     Chief Executive and Director
+     gbnewby@pglaf.org
+
+Section 4.  Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg-tm depends upon and cannot survive without wide
+spread public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine readable form accessible by the widest
+array of equipment including outdated equipment.  Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States.  Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements.  We do not solicit donations in locations
+where we have not received written confirmation of compliance.  To
+SEND DONATIONS or determine the status of compliance for any
+particular state visit http://pglaf.org
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States.  U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg Web pages for current donation
+methods and addresses.  Donations are accepted in a number of other
+ways including including checks, online payments and credit card
+donations.  To donate, please visit: http://pglaf.org/donate
+
+
+Section 5.  General Information About Project Gutenberg-tm electronic
+works.
+
+Professor Michael S. Hart is the originator of the Project Gutenberg-tm
+concept of a library of electronic works that could be freely shared
+with anyone.  For thirty years, he produced and distributed Project
+Gutenberg-tm eBooks with only a loose network of volunteer support.
+
+Project Gutenberg-tm eBooks are often created from several printed
+editions, all of which are confirmed as Public Domain in the U.S.
+unless a copyright notice is included.  Thus, we do not necessarily
+keep eBooks in compliance with any particular paper edition.
+
+Most people start at our Web site which has the main PG search facility:
+
+     http://www.gutenberg.net
+
+This Web site includes information about Project Gutenberg-tm,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.


### PR DESCRIPTION
Intellij doesn't like when multiple modules use the same folder as
resource folder - it prevents saving changes in the module settings
dialog.